### PR TITLE
refactor(MPS): deduplicate spectral-splitting, reindexing, and eigenvalue-shift proofs

### DIFF
--- a/TNLean/Algebra/HermitianHelpers.lean
+++ b/TNLean/Algebra/HermitianHelpers.lean
@@ -306,38 +306,11 @@ theorem smul_one_sub_hermitian_spectral
       (↑hM.eigenvectorUnitary : Matrix n n ℂ) *
       Matrix.diagonal (fun j => (↑(c - hM.eigenvalues j) : ℂ)) *
       (↑hM.eigenvectorUnitary : Matrix n n ℂ)ᴴ := by
-  set U : Matrix n n ℂ := ↑hM.eigenvectorUnitary
-  have hUU : U * Uᴴ = 1 := by
-    simpa [U, Matrix.star_eq_conjTranspose] using
-      (Unitary.mul_star_self_of_mem hM.eigenvectorUnitary.prop)
-  have h_cI : (↑c : ℂ) • (1 : Matrix n n ℂ) =
-      U * ((↑c : ℂ) • 1) * Uᴴ := by
-    calc
-      (↑c : ℂ) • (1 : Matrix n n ℂ) = (↑c : ℂ) • (U * Uᴴ) := by
-        rw [hUU]
-      _ = U * ((↑c : ℂ) • 1) * Uᴴ := by
-          rw [Matrix.mul_smul, Matrix.mul_one, smul_mul_assoc]
-  have hspec :
-      M = U * Matrix.diagonal (fun j => (↑(hM.eigenvalues j) : ℂ)) * Uᴴ := by
-    simpa [U, Unitary.conjStarAlgAut_apply, Matrix.star_eq_conjTranspose,
-      Function.comp_def] using hM.spectral_theorem
-  calc
-    (↑c : ℂ) • (1 : Matrix n n ℂ) - M
-        = U * ((↑c : ℂ) • 1) * Uᴴ -
-            U * Matrix.diagonal (fun j => (↑(hM.eigenvalues j) : ℂ)) * Uᴴ := by
-              conv_lhs =>
-                rw [hspec]
-                rw [h_cI]
-    _ = U * ((↑c : ℂ) • 1 -
-          Matrix.diagonal (fun j => (↑(hM.eigenvalues j) : ℂ))) * Uᴴ := by
-          noncomm_ring
-    _ = U * Matrix.diagonal (fun j => ↑(c - hM.eigenvalues j)) * Uᴴ := by
-          congr 1
-          congr 1
-          rw [Matrix.smul_one_eq_diagonal, Matrix.diagonal_sub]
-          congr 1
-          ext i
-          simp [Complex.ofReal_sub]
+  rw [← neg_sub M ((↑c : ℂ) • 1), hermitian_sub_scalar_spectral hM c, ← Matrix.neg_mul,
+    ← Matrix.mul_neg, Matrix.diagonal_neg]
+  congr 2
+  ext j
+  simp [Complex.ofReal_sub, neg_sub]
 
 /-- A Hermitian matrix is bounded above by its largest eigenvalue times the
 identity. -/

--- a/TNLean/Channel/Peripheral/CyclicDecomposition/Basic.lean
+++ b/TNLean/Channel/Peripheral/CyclicDecomposition/Basic.lean
@@ -24,6 +24,8 @@ decomposition of periodic irreducible channels.
 * `cornerRestriction` — restriction of a linear map to an invariant corner.
 * `cornerCompressionLinearEquiv` — the shared linear equivalence between a matrix
   algebra and a projection corner.
+* `ProjectionSpectralSplit` — the spectral splitting of an orthogonal projection
+  into its eigenvalue-`1` and eigenvalue-`0` sectors.
 * `cornerRank` — the matrix size of a projection corner.
 
 ## Main statements
@@ -254,12 +256,8 @@ lemma cornerCompressionExpand_eq_isometry
   let I : Matrix (S ⊕ T) S ℂ := cornerCompressionInclusion (S := S) (T := T)
   let E : Matrix (Fin D) (Fin n) ℂ := Matrix.reindexLinearEquiv ℂ ℂ eST.symm eS I
   let M' : Matrix S S ℂ := Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm M
-  have hM_back : Matrix.reindexLinearEquiv ℂ ℂ eS eS M' = M := by
-    change Matrix.reindexLinearEquiv ℂ ℂ eS eS
-      (Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm M) = M
-    rw [Matrix.reindexLinearEquiv_comp_apply, Equiv.symm_trans_self,
-      Matrix.reindexLinearEquiv_refl_refl]
-    rfl
+  have hM_back : Matrix.reindexLinearEquiv ℂ ℂ eS eS M' = M :=
+    (Matrix.reindexLinearEquiv ℂ ℂ eS eS).apply_symm_apply M
   have hE_star : Eᴴ = Matrix.reindexLinearEquiv ℂ ℂ eS eST.symm Iᴴ := by
     ext a b
     simp [E, I, Matrix.conjTranspose_apply, Matrix.reindex_apply]
@@ -508,12 +506,8 @@ lemma cornerCompressionInvFun_expand
           = (Umatᴴ * Umat) * Y_D * (Umatᴴ * Umat) := by simp [Matrix.mul_assoc]
       _ = Y_D := by rw [hU'U]; simp
   have hreindex_Y :
-      Matrix.reindexLinearEquiv ℂ ℂ eST eST Y_D = Y_ST := by
-    change Matrix.reindexLinearEquiv ℂ ℂ eST eST
-        (Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm Y_ST) = Y_ST
-    rw [Matrix.reindexLinearEquiv_comp_apply, Equiv.symm_trans_self,
-      Matrix.reindexLinearEquiv_refl_refl]
-    rfl
+      Matrix.reindexLinearEquiv ℂ ℂ eST eST Y_D = Y_ST :=
+    (Matrix.reindexLinearEquiv ℂ ℂ eST eST).apply_symm_apply Y_ST
   simp only [cornerCompressionInvFun]
   rw [cornerCompressionExpand_apply Umat eST eS M]
   rw [show Umatᴴ * (Umat *
@@ -524,11 +518,7 @@ lemma cornerCompressionInvFun_expand
       Y_ST.toBlocks₁₁ = Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm M := by
     simp [Y_ST, Matrix.toBlocks_fromBlocks₁₁]
   rw [htoBlocks]
-  change Matrix.reindexLinearEquiv ℂ ℂ eS eS
-    (Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm M) = M
-  rw [Matrix.reindexLinearEquiv_comp_apply, Equiv.symm_trans_self,
-    Matrix.reindexLinearEquiv_refl_refl]
-  rfl
+  exact (Matrix.reindexLinearEquiv ℂ ℂ eS eS).apply_symm_apply M
 
 lemma cornerCompressionExpand_invFun
     {D n : ℕ} (P Pdiag Umat : MatrixAlg D)
@@ -582,20 +572,14 @@ lemma cornerCompressionExpand_invFun
   rw [cornerCompressionExpand_apply Umat eST eS]
   have hround :
       Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm
-        (Matrix.reindexLinearEquiv ℂ ℂ eS eS Y_ST.toBlocks₁₁) = Y_ST.toBlocks₁₁ := by
-    rw [Matrix.reindexLinearEquiv_comp_apply, Equiv.self_trans_symm,
-      Matrix.reindexLinearEquiv_refl_refl]
-    rfl
+        (Matrix.reindexLinearEquiv ℂ ℂ eS eS Y_ST.toBlocks₁₁) = Y_ST.toBlocks₁₁ :=
+    (Matrix.reindexLinearEquiv ℂ ℂ eS eS).symm_apply_apply Y_ST.toBlocks₁₁
   rw [hround]
   rw [show Matrix.fromBlocks Y_ST.toBlocks₁₁ (0 : Matrix S T ℂ)
         (0 : Matrix T S ℂ) (0 : Matrix T T ℂ) = Y_ST from hY_ST_block.symm]
   have hround₂ :
-      Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm Y_ST = Y := by
-    change Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm
-      (Matrix.reindexLinearEquiv ℂ ℂ eST eST Y) = Y
-    rw [Matrix.reindexLinearEquiv_comp_apply, Equiv.self_trans_symm,
-      Matrix.reindexLinearEquiv_refl_refl]
-    rfl
+      Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm Y_ST = Y :=
+    (Matrix.reindexLinearEquiv ℂ ℂ eST eST).symm_apply_apply Y
   rw [hround₂]
   change Umat * (Umatᴴ * X.1 * Umat) * Umatᴴ = X.1
   calc
@@ -636,22 +620,59 @@ noncomputable def cornerCompressionLinearEquiv
       exact cornerCompressionExpand_invFun (P := P) (Pdiag := Pdiag) Umat eST eS P0
         hP0 hPdiag_UPU hPdiag_std hU'U hUU X }
 
-/-- **Compression isometry for a projection (existence form).**
+/-- Spectral splitting data for an orthogonal projection `P : M_D(ℂ)`.
 
-Given an orthogonal projection `P : M_D(ℂ)` of rank `n = trace P`, there is a linear
-isomorphism between `M_n(ℂ)` and the corner submodule `P · M_D(ℂ) · P`, constructed
-from the eigendecomposition of `P` via `Matrix.IsHermitian.eigenvectorUnitary`,
-`Matrix.reindexLinearEquiv`, and `Matrix.fromBlocks`.
+`Umat` is a diagonalizing unitary for `P`, the index types `S` and `T`
+enumerate the eigenvalue-`1` and eigenvalue-`0` eigenvectors, `eST` splits the
+ambient index set accordingly, and `eS` counts the support coordinates.  In
+the split basis the projection becomes the standard corner block
+`fromBlocks 1 0 0 0`, and the support size `n` recovers the trace of `P`.
+This bundle is shared by the corner-compression construction below and by the
+sector-compression theorem in `MPS/CanonicalForm/CyclicSectors`. -/
+structure ProjectionSpectralSplit {D : ℕ} (P : MatrixAlg D) where
+  /-- Unitary diagonalizing the projection. -/
+  Umat : MatrixAlg D
+  /-- Index type of the eigenvalue-`1` eigenvectors. -/
+  S : Type
+  /-- Index type of the eigenvalue-`0` eigenvectors. -/
+  T : Type
+  [instFintypeS : Fintype S]
+  [instFintypeT : Fintype T]
+  [instDecidableEqS : DecidableEq S]
+  [instDecidableEqT : DecidableEq T]
+  /-- Number of support coordinates. -/
+  n : ℕ
+  /-- The support size counts the eigenvalue-`1` eigenvectors. -/
+  hn : n = Fintype.card S
+  /-- Splitting of the ambient index set into the two eigenvalue sectors. -/
+  eST : Fin D ≃ S ⊕ T
+  /-- Enumeration of the support coordinates. -/
+  eS : S ≃ Fin n
+  /-- The diagonalizing matrix is unitary (`Umat * Umatᴴ = 1`). -/
+  hUU : Umat * Umatᴴ = 1
+  /-- The diagonalizing matrix is unitary (`Umatᴴ * Umat = 1`). -/
+  hU'U : Umatᴴ * Umat = 1
+  /-- In the split basis the diagonalized projection is the standard corner. -/
+  hPdiag_std : Matrix.reindexLinearEquiv ℂ ℂ eST eST (Umatᴴ * P * Umat) =
+    Matrix.fromBlocks (1 : Matrix S S ℂ) 0 0 (0 : Matrix T T ℂ)
+  /-- The projection is recovered from its diagonalization. -/
+  hP_decomp : P = Umat * (Umatᴴ * P * Umat) * Umatᴴ
+  /-- Reindexing the standard corner back returns the diagonalized projection. -/
+  hPdiag_back : Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm
+      (Matrix.fromBlocks (1 : Matrix S S ℂ) 0 0 (0 : Matrix T T ℂ)) =
+    Umatᴴ * P * Umat
+  /-- The support size recovers the trace of the projection. -/
+  htrace : (n : ℂ) = Matrix.trace P
+  /-- Conjugation by the diagonalizing unitary preserves traces. -/
+  trace_conj : ∀ M : MatrixAlg D, Matrix.trace (Umatᴴ * M * Umat) = Matrix.trace M
 
-This is the projector analog of the isometry `φ` already constructed inside
-`exists_compressedTensor_of_supported_projection` in `MPS/CanonicalForm/CyclicSectors`.
-The public interface is exposed through the `noncomputable def`s `cornerRank` and
-`cornerSubmoduleMatrixLinearEquiv` together with the companion lemma
-`cornerRank_eq_trace`. -/
-private lemma exists_cornerSubmodule_matrixLinearEquiv_aux {D : ℕ}
+/-- The spectral splitting of an orthogonal projection, obtained from the
+eigendecomposition `Matrix.IsHermitian.eigenvectorUnitary`: the eigenvalues of
+an idempotent Hermitian matrix are `0` or `1`, and splitting the eigenvector
+basis by eigenvalue puts the projection in standard corner form. -/
+noncomputable def ProjectionSpectralSplit.ofOrthogonalProjection {D : ℕ}
     (P : MatrixAlg D) (hP : IsOrthogonalProjection P) :
-    ∃ (n : ℕ) (_ : Matrix (Fin n) (Fin n) ℂ ≃ₗ[ℂ] cornerSubmodule P),
-      (n : ℂ) = Matrix.trace P := by
+    ProjectionSpectralSplit P := by
   classical
   -- Spectral diagonalization of `P`.
   have hHerm : P.IsHermitian := hP.1
@@ -686,13 +707,7 @@ private lemma exists_cornerSubmodule_matrixLinearEquiv_aux {D : ℕ}
     have hfun : (fun k => f k * f k) = f := by
       apply Matrix.diagonal_injective
       simpa [Matrix.diagonal_mul_diagonal] using hDiag_idem
-    have hfj : f j * f j = f j := congrFun hfun j
-    have hfj' : f j * (f j - 1) = 0 := by
-      calc f j * (f j - 1) = f j * f j - f j := by ring
-        _ = 0 := by simpa using sub_eq_zero.mpr hfj
-    rcases mul_eq_zero.mp hfj' with h0 | h1
-    · exact Or.inl h0
-    · exact Or.inr (sub_eq_zero.mp h1)
+    exact IsIdempotentElem.iff_eq_zero_or_one.mp (congrFun hfun j)
   let p : Fin D → Prop := fun j => f j = 1
   haveI : DecidablePred p := fun _ => inferInstance
   let S := { j : Fin D // p j }
@@ -716,7 +731,6 @@ private lemma exists_cornerSubmodule_matrixLinearEquiv_aux {D : ℕ}
     rw [hfsum, ← Finset.sum_filter, Finset.sum_const, nsmul_eq_mul, mul_one]
     have : n = (Finset.univ.filter p).card := Fintype.card_subtype p
     exact_mod_cast this
-  refine ⟨n, ?_, htrace⟩
   -- `P0` in the `S ⊕ T` basis is the identity-plus-zero block.
   let P0 : Matrix (S ⊕ T) (S ⊕ T) ℂ :=
     Matrix.fromBlocks (1 : Matrix S S ℂ) 0 0 (0 : Matrix T T ℂ)
@@ -763,16 +777,46 @@ private lemma exists_cornerSubmodule_matrixLinearEquiv_aux {D : ℕ}
       _ = Umat * (Umatᴴ * P * Umat) * Umatᴴ := by simp [Matrix.mul_assoc]
   have hPdiag_back :
       Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm P0 = Pdiag := by
-    have h := congrArg
-      (Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm) hPdiag_std
-    have hid := (Matrix.reindexLinearEquiv_comp_apply (R := ℂ) (A := ℂ)
-      eST eST eST.symm eST.symm Pdiag)
-    rw [Equiv.self_trans_symm, Matrix.reindexLinearEquiv_refl_refl,
-      LinearEquiv.refl_apply] at hid
-    exact h.symm.trans hid
-  -- Construct the compression as a `LinearEquiv` using the shared
-  -- `cornerCompressionLinearEquiv` builder.
-  exact cornerCompressionLinearEquiv (P := P) (Pdiag := Pdiag) Umat eST eS P0
+    rw [← hPdiag_std]
+    exact (Matrix.reindexLinearEquiv ℂ ℂ eST eST).symm_apply_apply Pdiag
+  exact
+    { Umat := Umat
+      S := S
+      T := T
+      n := n
+      hn := rfl
+      eST := eST
+      eS := eS
+      hUU := hUU
+      hU'U := hU'U
+      hPdiag_std := hPdiag_std
+      hP_decomp := hP_decomp
+      hPdiag_back := hPdiag_back
+      htrace := htrace
+      trace_conj := trace_conj }
+
+/-- **Compression isometry for a projection (existence form).**
+
+Given an orthogonal projection `P : M_D(ℂ)` of rank `n = trace P`, there is a linear
+isomorphism between `M_n(ℂ)` and the corner submodule `P · M_D(ℂ) · P`, constructed
+from the eigendecomposition of `P` via `Matrix.IsHermitian.eigenvectorUnitary`,
+`Matrix.reindexLinearEquiv`, and `Matrix.fromBlocks`.
+
+This is the projector analog of the isometry `φ` already constructed inside
+`exists_compressedTensor_of_supported_projection` in `MPS/CanonicalForm/CyclicSectors`.
+The public interface is exposed through the `noncomputable def`s `cornerRank` and
+`cornerSubmoduleMatrixLinearEquiv` together with the companion lemma
+`cornerRank_eq_trace`. -/
+private lemma exists_cornerSubmodule_matrixLinearEquiv_aux {D : ℕ}
+    (P : MatrixAlg D) (hP : IsOrthogonalProjection P) :
+    ∃ (n : ℕ) (_ : Matrix (Fin n) (Fin n) ℂ ≃ₗ[ℂ] cornerSubmodule P),
+      (n : ℂ) = Matrix.trace P := by
+  obtain ⟨Umat, S, T, n, -, eST, eS, hUU, hU'U, hPdiag_std,
+    hP_decomp, hPdiag_back, htrace, -⟩ :=
+    ProjectionSpectralSplit.ofOrthogonalProjection P hP
+  refine ⟨n, ?_, htrace⟩
+  exact cornerCompressionLinearEquiv (P := P) (Pdiag := Umatᴴ * P * Umat) Umat eST eS
+    (Matrix.fromBlocks (1 : Matrix S S ℂ) 0 0 (0 : Matrix T T ℂ))
     rfl hP_decomp rfl hPdiag_std hPdiag_back hU'U hUU
 
 /-- The rank of an orthogonal projection `P : M_D(ℂ)`, defined so that

--- a/TNLean/Channel/Peripheral/CyclicDecomposition/PeripheralUnitary.lean
+++ b/TNLean/Channel/Peripheral/CyclicDecomposition/PeripheralUnitary.lean
@@ -42,22 +42,8 @@ private theorem hermitian_fixed_eq_scalar_of_irreducible_unital
   classical
   haveI : Nonempty (Fin D) := ⟨⟨0, NeZero.pos D⟩⟩
   set c0 : ℝ := minEigenvalue hH
-  set U : MatrixAlg D := (↑hH.eigenvectorUnitary : MatrixAlg D)
-  have hU_unit : IsUnit U := by
-    rw [Matrix.isUnit_iff_isUnit_det]
-    simpa [U] using Matrix.UnitaryGroup.det_isUnit hH.eigenvectorUnitary
-  have hshift_eq :
-      H - (c0 : ℂ) • 1 =
-        U * Matrix.diagonal (fun i : Fin D => (↑(hH.eigenvalues i - c0) : ℂ)) * Uᴴ := by
-    simpa [U] using hermitian_sub_scalar_spectral hH c0
-  have hshift_psd : (H - (c0 : ℂ) • 1).PosSemidef := by
-    rw [hshift_eq]
-    have hdiag_psd :
-        (Matrix.diagonal (fun i : Fin D => (↑(hH.eigenvalues i - c0) : ℂ))).PosSemidef := by
-      rw [Matrix.posSemidef_diagonal_iff]
-      intro i
-      exact_mod_cast sub_nonneg.mpr (minEigenvalue_le hH i)
-    exact (Matrix.IsUnit.posSemidef_star_right_conjugate_iff hU_unit).2 hdiag_psd
+  have hshift_psd : (H - (c0 : ℂ) • 1).PosSemidef :=
+    sub_minEigenvalue_smul_one_posSemidef hH
   have hone_fix : transferMap (d := r) (D := D) K (1 : MatrixAlg D) = 1 := by
     simpa [MPSTensor.transferMap_apply, KadisonSchwarz.krausMap,
       KadisonSchwarz.IsUnitalKraus] using hUnital

--- a/TNLean/MPS/CanonicalForm/CyclicSectors/Compression.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors/Compression.lean
@@ -103,50 +103,16 @@ theorem exists_compressedTensor_of_supported_projection_with_letter_and_isometry
       V * Vᴴ = P ∧
       (∀ X : Matrix (Fin n) (Fin n) ℂ, (φ X).1 = V * X * Vᴴ) := by
   classical
-  -- Spectral diagonalization of P
-  let hHerm : P.IsHermitian := hP.1
-  let U := hHerm.eigenvectorUnitary
-  let Umat : MatrixAlg D := (U : MatrixAlg D)
-  have hUU : Umat * Umatᴴ = 1 :=
-    by simpa [Matrix.star_eq_conjTranspose] using Unitary.mul_star_self_of_mem U.prop
-  have hU'U : Umatᴴ * Umat = 1 :=
-    by simpa [Matrix.star_eq_conjTranspose] using Matrix.UnitaryGroup.star_mul_self U
-  -- Trace invariance under unitary conjugation
-  have trace_conj (M : MatrixAlg D) : Matrix.trace (Umatᴴ * M * Umat) = Matrix.trace M := by
-    rw [Matrix.mul_assoc, Matrix.trace_mul_comm Umatᴴ (M * Umat),
-      Matrix.mul_assoc, hUU, Matrix.mul_one]
+  -- Spectral splitting of `P` via the shared bundle.
+  obtain ⟨Umat, S, T, n, -, eST, eS, hUU, hU'U, hPdiag_std_lin, hP_decomp,
+    hPdiag_back, htrace, trace_conj⟩ :=
+    ProjectionSpectralSplit.ofOrthogonalProjection P hP
   let Pdiag : MatrixAlg D := Umatᴴ * P * Umat
-  let f : Fin D → ℂ := fun j => (↑(hHerm.eigenvalues j) : ℂ)
-  have hPdiag_eq : Pdiag = Matrix.diagonal f := by
-    have h := hHerm.conjStarAlgAut_star_eigenvectorUnitary
-    change (star (↑hHerm.eigenvectorUnitary : MatrixAlg D) * P *
-        (↑hHerm.eigenvectorUnitary : MatrixAlg D)) = Matrix.diagonal f
-    simpa [f, Function.comp_def, Unitary.conjStarAlgAut_star_apply] using h
-  have hPdiag_idem : Pdiag * Pdiag = Pdiag := by
-    change Umatᴴ * P * Umat * (Umatᴴ * P * Umat) = Umatᴴ * P * Umat
-    calc
-      Umatᴴ * P * Umat * (Umatᴴ * P * Umat)
-          = Umatᴴ * (P * (Umat * Umatᴴ) * P) * Umat := by
-              simp only [Matrix.mul_assoc]
-      _ = Umatᴴ * (P * P) * Umat := by rw [hUU, Matrix.mul_one]
-      _ = Umatᴴ * P * Umat := by rw [hP.2]
-  have hf01 : ∀ j : Fin D, f j = 0 ∨ f j = 1 := by
-    intro j
-    have hDiag_idem : Matrix.diagonal f * Matrix.diagonal f = Matrix.diagonal f := by
-      simpa [hPdiag_eq] using hPdiag_idem
-    have hfun : (fun k => f k * f k) = f := by
-      apply Matrix.diagonal_injective
-      simpa [Matrix.diagonal_mul_diagonal] using hDiag_idem
-    exact IsIdempotentElem.iff_eq_zero_or_one.mp (congrFun hfun j)
-  -- Index splitting
-  let p : Fin D → Prop := fun j => f j = 1
-  haveI : DecidablePred p := fun _ => inferInstance
-  let S := { j : Fin D // p j }
-  let T := { j : Fin D // ¬ p j }
-  let n := Fintype.card S
-  have hfT : ∀ t : T, f t.1 = 0 := fun t => (hf01 t.1).resolve_right t.2
-  let eST : Fin D ≃ (S ⊕ T) := (Equiv.sumCompl p).symm
-  let eS : S ≃ Fin n := Fintype.equivFin S
+  -- The diagonalizing matrix as a unitary-group element.
+  have hUmem : Umat ∈ Matrix.unitaryGroup (Fin D) ℂ :=
+    ⟨by simpa [Matrix.star_eq_conjTranspose] using hU'U,
+      by simpa [Matrix.star_eq_conjTranspose] using hUU⟩
+  let U : Matrix.unitaryGroup (Fin D) ℂ := ⟨Umat, hUmem⟩
   -- Conjugated tensor
   let B : MPSTensor d D := fun i => Umatᴴ * A i * Umat
   -- Algebra isomorphism for reindexing (renamed to avoid clashing with the
@@ -156,32 +122,7 @@ theorem exists_compressedTensor_of_supported_projection_with_letter_and_isometry
   let P0 : Matrix (S ⊕ T) (S ⊕ T) ℂ :=
     Matrix.fromBlocks (1 : Matrix S S ℂ) 0 0 (0 : Matrix T T ℂ)
   -- Pdiag in S⊕T basis
-  have hPdiag_std : rAlg Pdiag = P0 := by
-    change Matrix.reindex eST eST Pdiag = P0
-    rw [hPdiag_eq, show Matrix.reindex eST eST (Matrix.diagonal f) =
-        Matrix.diagonal (f ∘ eST.symm) from by simp [Matrix.reindex_apply]]
-    ext x y
-    cases x with
-    | inl s =>
-        cases y with
-        | inl s' =>
-            by_cases h : s = s'
-            · subst h
-              have hs : (Equiv.sumCompl p) (Sum.inl s) = s.1 := rfl
-              simpa [P0, p, eST, hs] using s.2
-            · simp [P0, Matrix.fromBlocks_apply₁₁, h]
-        | inr t =>
-            simp [P0, Matrix.fromBlocks_apply₁₂]
-    | inr t =>
-        cases y with
-        | inl s =>
-            simp [P0, Matrix.fromBlocks_apply₂₁]
-        | inr t' =>
-            by_cases h : t = t'
-            · subst h
-              have ht : (Equiv.sumCompl p) (Sum.inr t) = t.1 := rfl
-              simpa [P0, p, eST, ht] using hfT t
-            · simp [P0, Matrix.fromBlocks_apply₂₂, h]
+  have hPdiag_std : rAlg Pdiag = P0 := hPdiag_std_lin
   -- B_i is Pdiag-supported
   have hBsupp : ∀ i : Fin d, Pdiag * B i * Pdiag = B i := by
     intro i
@@ -228,42 +169,9 @@ theorem exists_compressedTensor_of_supported_projection_with_letter_and_isometry
     rw [h12, h21, h22]
   -- Compressed tensor
   let C : MPSTensor d n := fun i => Matrix.reindex eS eS (B11 i)
-  -- `P = Umat * Pdiag * Umatᴴ`.
-  have hP_decomp : P = Umat * Pdiag * Umatᴴ := by
-    change P = Umat * (Umatᴴ * P * Umat) * Umatᴴ
-    calc
-      P = (Umat * Umatᴴ) * P * (Umat * Umatᴴ) := by rw [hUU]; simp
-      _ = Umat * (Umatᴴ * P * Umat) * Umatᴴ := by simp [Matrix.mul_assoc]
-  -- `reindexLinearEquiv eST.symm eST.symm P0 = Pdiag`.
-  have hPdiag_back :
-      Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm P0 = Pdiag := by
-    have hstd : Matrix.reindexLinearEquiv ℂ ℂ eST eST Pdiag = P0 := hPdiag_std
-    have h := congrArg
-      (Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm) hstd
-    have hid := Matrix.reindexLinearEquiv_comp_apply (R := ℂ) (A := ℂ)
-      eST eST eST.symm eST.symm Pdiag
-    rw [Equiv.self_trans_symm, Matrix.reindexLinearEquiv_refl_refl,
-      LinearEquiv.refl_apply] at hid
-    exact h.symm.trans hid
   let expand : Matrix (Fin n) (Fin n) ℂ →ₗ[ℂ] MatrixAlg D :=
     cornerCompressionExpand Umat eST eS
   have hP0_def : P0 = Matrix.fromBlocks (1 : Matrix S S ℂ) 0 0 (0 : Matrix T T ℂ) := rfl
-  have htrace : (n : ℂ) = Matrix.trace P := by
-    have : Matrix.trace P = Matrix.trace Pdiag := by
-      change Matrix.trace P = Matrix.trace (Umatᴴ * P * Umat)
-      rw [trace_conj]
-    rw [this, hPdiag_eq, Matrix.trace_diagonal]
-    have hfsum : ∑ j : Fin D, f j = ∑ j : Fin D, if p j then (1 : ℂ) else 0 := by
-      congr 1
-      ext j
-      show f j = if p j then 1 else 0
-      by_cases hp : p j
-      · simp [hp, show f j = 1 from hp]
-      · simp [hp, show f j = 0 from (hf01 j).resolve_right hp]
-    rw [hfsum, ← Finset.sum_filter, Finset.sum_const, nsmul_eq_mul, mul_one]
-    congr 1
-    change n = (Finset.univ.filter p).card
-    exact Fintype.card_subtype p
   have hexpand_def : ∀ M : Matrix (Fin n) (Fin n) ℂ,
       expand M = Umat *
         Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm
@@ -272,7 +180,6 @@ theorem exists_compressedTensor_of_supported_projection_with_letter_and_isometry
     intro M
     exact cornerCompressionExpand_apply Umat eST eS M
   have hPdiag_UPU : Pdiag = Umatᴴ * P * Umat := rfl
-  have hPdiag_std_lin : Matrix.reindexLinearEquiv ℂ ℂ eST eST Pdiag = P0 := hPdiag_std
   let cornerEmbed : Matrix (Fin n) (Fin n) ℂ ≃ₗ[ℂ] cornerSubmodule P :=
     cornerCompressionLinearEquiv (P := P) (Pdiag := Pdiag) Umat eST eS P0 hP0_def
       hP_decomp hPdiag_UPU hPdiag_std_lin hPdiag_back hU'U hUU
@@ -292,6 +199,19 @@ theorem exists_compressedTensor_of_supported_projection_with_letter_and_isometry
     intro X
     change expand X = V * X * Vᴴ
     simpa [V] using cornerCompressionExpand_eq_isometry Umat eST eS X
+  -- `A i = Umat * B i * Umatᴴ`.
+  have hA_i : ∀ i, A i = Umat * B i * Umatᴴ := by
+    intro i
+    change A i = Umat * (Umatᴴ * A i * Umat) * Umatᴴ
+    calc
+      A i = (Umat * Umatᴴ) * A i * (Umat * Umatᴴ) := by rw [hUU]; simp
+      _ = Umat * (Umatᴴ * A i * Umat) * Umatᴴ := by simp [Matrix.mul_assoc]
+  -- `reindex eS.symm eS.symm (C i) = B11 i`.
+  have hExM_C : ∀ i, Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm (C i) = B11 i :=
+    fun i => (Matrix.reindexLinearEquiv ℂ ℂ eS eS).symm_apply_apply (B11 i)
+  -- `reindex eST.symm eST.symm (X i) = B i`.
+  have hExST_X : ∀ i, Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm (X i) = B i :=
+    fun i => (Matrix.reindexLinearEquiv ℂ ℂ eST eST).symm_apply_apply (B i)
   refine ⟨n, C, cornerEmbed, V, ?_, ?_, ?_, ?_, ?_, ?_, ?_, hV_iso, hV_range,
     hEmbed_eq_V⟩
   -- (1) Trace identity: n = tr P
@@ -518,28 +438,10 @@ theorem exists_compressedTensor_of_supported_projection_with_letter_and_isometry
     set G : MatrixAlg D := Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm F
     -- `expand Z = Umat * G * Umatᴴ`.
     have hexpand_Z : expand Z = Umat * G * Umatᴴ := hexpand_def Z
-    -- `A i = Umat * B i * Umatᴴ` and `(A i)ᴴ = Umat * (B i)ᴴ * Umatᴴ`.
-    have hA_i : A i = Umat * B i * Umatᴴ := by
-      change A i = Umat * (Umatᴴ * A i * Umat) * Umatᴴ
-      calc
-        A i = (Umat * Umatᴴ) * A i * (Umat * Umatᴴ) := by rw [hUU]; simp
-        _ = Umat * (Umatᴴ * A i * Umat) * Umatᴴ := by simp [Matrix.mul_assoc]
+    -- `(A i)ᴴ = Umat * (B i)ᴴ * Umatᴴ`.
     have hA_i_ct : (A i)ᴴ = Umat * (B i)ᴴ * Umatᴴ := by
-      rw [hA_i, Matrix.conjTranspose_mul, Matrix.conjTranspose_mul,
+      rw [hA_i i, Matrix.conjTranspose_mul, Matrix.conjTranspose_mul,
         Matrix.conjTranspose_conjTranspose, Matrix.mul_assoc]
-    -- `reindex eS.symm eS.symm (C i) = B11 i`.
-    have hExM_C : Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm (C i) = B11 i := by
-      change Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm
-        (Matrix.reindexLinearEquiv ℂ ℂ eS eS (B11 i)) = B11 i
-      rw [Matrix.reindexLinearEquiv_comp_apply, Equiv.self_trans_symm,
-        Matrix.reindexLinearEquiv_refl_refl]
-      rfl
-    -- `reindex eST.symm eST.symm (X i) = B i`.
-    have hExST_X : Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm (X i) = B i := by
-      have hXi_eq : X i = Matrix.reindexLinearEquiv ℂ ℂ eST eST (B i) := rfl
-      rw [hXi_eq, Matrix.reindexLinearEquiv_comp_apply, Equiv.self_trans_symm,
-        Matrix.reindexLinearEquiv_refl_refl]
-      rfl
     -- Reduction: reindex eS.symm eS.symm ((C i)ᴴ * Z * C i) = (B11 i)ᴴ * M' * B11 i.
     have hExM_letter :
         Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm ((C i)ᴴ * Z * C i) =
@@ -551,8 +453,8 @@ theorem exists_compressedTensor_of_supported_projection_with_letter_and_isometry
       have hCt_reindex :
           Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm ((C i)ᴴ) = (B11 i)ᴴ := by
         change Matrix.reindex eS.symm eS.symm ((C i)ᴴ) = (B11 i)ᴴ
-        simpa [Matrix.conjTranspose_reindex] using congrArg (fun M => Mᴴ) hExM_C
-      rw [hCt_reindex, hExM_C]
+        simpa [Matrix.conjTranspose_reindex] using congrArg (fun M => Mᴴ) (hExM_C i)
+      rw [hCt_reindex, hExM_C i]
     -- Block identity: fromBlocks ((B11 i)ᴴ * M' * B11 i) 0 0 0 = (X i)ᴴ * F * X i.
     have hF_letter :
         Matrix.fromBlocks ((B11 i)ᴴ * M' * B11 i) (0 : Matrix S T ℂ)
@@ -579,12 +481,12 @@ theorem exists_compressedTensor_of_supported_projection_with_letter_and_isometry
       have hXct_reindex :
           Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm ((X i)ᴴ) = (B i)ᴴ := by
         change Matrix.reindex eST.symm eST.symm ((X i)ᴴ) = (B i)ᴴ
-        simpa [Matrix.conjTranspose_reindex] using congrArg (fun M => Mᴴ) hExST_X
-      rw [hXct_reindex, hExST_X]
+        simpa [Matrix.conjTranspose_reindex] using congrArg (fun M => Mᴴ) (hExST_X i)
+      rw [hXct_reindex, hExST_X i]
     -- Compute RHS = Umat * ((B i)ᴴ * G * B i) * Umatᴴ.
     have hRHS :
         (A i)ᴴ * expand Z * A i = Umat * ((B i)ᴴ * G * B i) * Umatᴴ := by
-      rw [hexpand_Z, hA_i_ct, hA_i]
+      rw [hexpand_Z, hA_i_ct, hA_i i]
       calc
         (Umat * (B i)ᴴ * Umatᴴ) * (Umat * G * Umatᴴ) * (Umat * B i * Umatᴴ)
             = Umat * (B i)ᴴ * (Umatᴴ * Umat) * G * (Umatᴴ * Umat) * B i * Umatᴴ := by
@@ -603,34 +505,18 @@ theorem exists_compressedTensor_of_supported_projection_with_letter_and_isometry
   -- (7) Letter expansion: φ(C_i) is the original supported ambient letter.
   · intro i
     change expand (C i) = A i
-    have hExM_C : Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm (C i) = B11 i := by
-      change Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm
-        (Matrix.reindexLinearEquiv ℂ ℂ eS eS (B11 i)) = B11 i
-      rw [Matrix.reindexLinearEquiv_comp_apply, Equiv.self_trans_symm,
-        Matrix.reindexLinearEquiv_refl_refl]
-      rfl
-    have hExST_X : Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm (X i) = B i := by
-      have hXi_eq : X i = Matrix.reindexLinearEquiv ℂ ℂ eST eST (B i) := rfl
-      rw [hXi_eq, Matrix.reindexLinearEquiv_comp_apply, Equiv.self_trans_symm,
-        Matrix.reindexLinearEquiv_refl_refl]
-      rfl
     have hBlockBack :
         Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm
             (Matrix.fromBlocks
               (Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm (C i))
               (0 : Matrix S T ℂ) (0 : Matrix T S ℂ) (0 : Matrix T T ℂ)) =
           B i := by
-      rw [hExM_C, ← hX_block i]
-      exact hExST_X
-    have hA_i : A i = Umat * B i * Umatᴴ := by
-      change A i = Umat * (Umatᴴ * A i * Umat) * Umatᴴ
-      calc
-        A i = (Umat * Umatᴴ) * A i * (Umat * Umatᴴ) := by rw [hUU]; simp
-        _ = Umat * (Umatᴴ * A i * Umat) * Umatᴴ := by simp [Matrix.mul_assoc]
+      rw [hExM_C i, ← hX_block i]
+      exact hExST_X i
     calc
       expand (C i) = Umat * B i * Umatᴴ := by
         rw [hexpand_def, hBlockBack]
-      _ = A i := hA_i.symm
+      _ = A i := (hA_i i).symm
 
 /-- Compress a tensor supported on an orthogonal projection to the corresponding sector bond
 space.  The compressed tensor has the same sector MPVs and inherits the left-canonical equation.

--- a/TNLean/MPS/Core/BlockingInfrastructure.lean
+++ b/TNLean/MPS/Core/BlockingInfrastructure.lean
@@ -461,25 +461,6 @@ theorem wordOfBlock_cast_length (d : ℕ) {L₁ L₂ : ℕ} (h : L₁ = L₂)
   subst h
   rfl
 
-/-- Reindex the physical alphabet of a tensor by a map of physical indices. -/
-noncomputable def reindexPhysical {d₁ d₂ D : ℕ} (f : Fin d₁ → Fin d₂)
-    (A : MPSTensor d₂ D) : MPSTensor d₁ D :=
-  fun i => A (f i)
-
-/-- Word evaluation after physical reindexing is word evaluation on the mapped word. -/
-theorem evalWord_reindexPhysical {d₁ d₂ D : ℕ} (f : Fin d₁ → Fin d₂)
-    (A : MPSTensor d₂ D) (w : List (Fin d₁)) :
-    evalWord (reindexPhysical f A) w = evalWord A (w.map f) := by
-  induction w with
-  | nil => simp
-  | cons i w ih => simp [evalWord, reindexPhysical, ih]
-
-/-- MPVs after physical reindexing are MPVs on the reindexed configuration. -/
-theorem mpv_reindexPhysical {d₁ d₂ D : ℕ} (f : Fin d₁ → Fin d₂)
-    (A : MPSTensor d₂ D) {N : ℕ} (σ : Fin N → Fin d₁) :
-    mpv (reindexPhysical f A) σ = mpv A (fun n => f (σ n)) := by
-  simp [mpv, coeff, evalWord_reindexPhysical, List.map_ofFn, Function.comp_def]
-
 /-- Iterated physical blocking agrees with direct blocking after the canonical
 index relabeling from iterated blocks to flattened blocks. -/
 @[mps_block_words]

--- a/TNLean/MPS/Defs.lean
+++ b/TNLean/MPS/Defs.lean
@@ -81,6 +81,25 @@ dimension. -/
     mpv A σ = (D : ℂ) := by
   simp [mpv, coeff]
 
+/-- Reindex the physical alphabet of a tensor by a map of physical indices. -/
+noncomputable def reindexPhysical {d₁ d₂ D : ℕ} (f : Fin d₁ → Fin d₂)
+    (A : MPSTensor d₂ D) : MPSTensor d₁ D :=
+  fun i => A (f i)
+
+/-- Word evaluation after physical reindexing is word evaluation on the mapped word. -/
+theorem evalWord_reindexPhysical {d₁ d₂ D : ℕ} (f : Fin d₁ → Fin d₂)
+    (A : MPSTensor d₂ D) (w : List (Fin d₁)) :
+    evalWord (reindexPhysical f A) w = evalWord A (w.map f) := by
+  induction w with
+  | nil => simp
+  | cons i w ih => simp [evalWord, reindexPhysical, ih]
+
+/-- MPVs after physical reindexing are MPVs on the reindexed configuration. -/
+theorem mpv_reindexPhysical {d₁ d₂ D : ℕ} (f : Fin d₁ → Fin d₂)
+    (A : MPSTensor d₂ D) {N : ℕ} (σ : Fin N → Fin d₁) :
+    mpv (reindexPhysical f A) σ = mpv A (fun n => f (σ n)) := by
+  simp [mpv, coeff, evalWord_reindexPhysical, List.map_ofFn, Function.comp_def]
+
 /-- Gauge equivalence: `A` and `B` are related by simultaneous similarity
 `B i = X * A i * X⁻¹` for some `X ∈ GL(D,ℂ)`. -/
 def GaugeEquiv (A B : MPSTensor d D) : Prop :=

--- a/TNLean/MPS/Defs.lean
+++ b/TNLean/MPS/Defs.lean
@@ -100,6 +100,17 @@ theorem mpv_reindexPhysical {d₁ d₂ D : ℕ} (f : Fin d₁ → Fin d₂)
     mpv (reindexPhysical f A) σ = mpv A (fun n => f (σ n)) := by
   simp [mpv, coeff, evalWord_reindexPhysical, List.map_ofFn, Function.comp_def]
 
+@[deprecated evalWord_reindexPhysical (since := "2026-07-10")]
+lemma evalWord_map {d' : ℕ} (B : MPSTensor d' D) (g : Fin d → Fin d') (l : List (Fin d)) :
+    evalWord B (l.map g) = evalWord (fun i => B (g i)) l :=
+  (evalWord_reindexPhysical g B l).symm
+
+@[deprecated mpv_reindexPhysical (since := "2026-07-10")]
+lemma mpv_comp_reindex {d' : ℕ} (B : MPSTensor d' D) (g : Fin d → Fin d')
+    {N : ℕ} (σ : Fin N → Fin d) :
+    mpv (fun i => B (g i)) σ = mpv B (fun k => g (σ k)) :=
+  mpv_reindexPhysical g B σ
+
 /-- Gauge equivalence: `A` and `B` are related by simultaneous similarity
 `B i = X * A i * X⁻¹` for some `X ∈ GL(D,ℂ)`. -/
 def GaugeEquiv (A B : MPSTensor d D) : Prop :=

--- a/TNLean/MPS/Irreducible/FixedPointProjection.lean
+++ b/TNLean/MPS/Irreducible/FixedPointProjection.lean
@@ -457,23 +457,6 @@ section NonScalarFixedPoint
 
 variable {d D : ℕ}
 
-private lemma max_shift_posSemidef [Nonempty (Fin D)]
-    {X : Matrix (Fin D) (Fin D) ℂ} (hX : X.IsHermitian) :
-    ((↑(maxEigenvalue hX) : ℂ) • (1 : Matrix (Fin D) (Fin D) ℂ) - X).PosSemidef := by
-  classical
-  set U : Matrix (Fin D) (Fin D) ℂ := ↑hX.eigenvectorUnitary
-  have hU_unit : IsUnit U := by
-    rw [Matrix.isUnit_iff_isUnit_det]
-    simpa [U] using Matrix.UnitaryGroup.det_isUnit hX.eigenvectorUnitary
-  rw [smul_one_sub_hermitian_spectral hX (maxEigenvalue hX)]
-  rw [show Uᴴ = star U by simp [Matrix.star_eq_conjTranspose]]
-  exact (Matrix.IsUnit.posSemidef_star_right_conjugate_iff hU_unit).mpr
-    (Matrix.posSemidef_diagonal_iff.mpr (fun i => by
-      rw [RCLike.nonneg_iff]
-      constructor
-      · exact_mod_cast sub_nonneg.mpr (le_maxEigenvalue hX i)
-      · simp [Complex.ofReal_im]))
-
 private lemma max_shift_not_posDef [Nonempty (Fin D)]
     {X : Matrix (Fin D) (Fin D) ℂ} (hX : X.IsHermitian) :
     ¬ ((↑(maxEigenvalue hX) : ℂ) • (1 : Matrix (Fin D) (Fin D) ℂ) - X).PosDef := by
@@ -519,7 +502,7 @@ theorem exists_singular_posSemidef_fixedPoint_of_unital_nonScalar_fixedPoint
   let c : ℝ := maxEigenvalue hX_herm
   let ρ : Matrix (Fin D) (Fin D) ℂ := (↑c : ℂ) • 1 - X
   have hρ_psd : ρ.PosSemidef := by
-    simpa [ρ, c] using max_shift_posSemidef (D := D) hX_herm
+    simpa [ρ, c] using maxEigenvalue_smul_one_sub_posSemidef hX_herm
   have hρ_not_pd : ¬ ρ.PosDef := by
     simpa [ρ, c] using max_shift_not_posDef (D := D) hX_herm
   have hρ_fix : transferMap (d := d) (D := D) A ρ = ρ := by

--- a/TNLean/MPS/MPDO/Defs.lean
+++ b/TNLean/MPS/MPDO/Defs.lean
@@ -58,6 +58,20 @@ we keep both indices explicit following the notation of
 arXiv:1606.00608, Section 4. -/
 abbrev MPOTensor (d D : ℕ) := Fin d → Fin d → Matrix (Fin D) (Fin D) ℂ
 
+namespace MPSTensor
+
+/-- The first factor of a product index encoded by `finProdFinEquiv`. -/
+@[simp] theorem finProdFinEquiv_divNat {m n : ℕ} (i : Fin m) (j : Fin n) :
+    (finProdFinEquiv (i, j) : Fin (m * n)).divNat = i :=
+  congrArg Prod.fst (finProdFinEquiv.symm_apply_apply (i, j))
+
+/-- The second factor of a product index encoded by `finProdFinEquiv`. -/
+@[simp] theorem finProdFinEquiv_modNat {m n : ℕ} (i : Fin m) (j : Fin n) :
+    (finProdFinEquiv (i, j) : Fin (m * n)).modNat = j :=
+  congrArg Prod.snd (finProdFinEquiv.symm_apply_apply (i, j))
+
+end MPSTensor
+
 namespace MPOTensor
 
 variable {d D : ℕ}

--- a/TNLean/MPS/MPDO/LocalPurificationRFP.lean
+++ b/TNLean/MPS/MPDO/LocalPurificationRFP.lean
@@ -385,13 +385,8 @@ returns the corresponding matrix of the family. -/
 private theorem purificationTensor_finProdFinEquiv {dK D' : ℕ}
     (A : Fin d → Fin dK → Matrix (Fin D') (Fin D') ℂ) (i : Fin d) (k : Fin dK) :
     purificationTensor A (finProdFinEquiv (i, k)) = A i k := by
-  have h : ((finProdFinEquiv (i, k) : Fin (d * dK)).divNat,
-      (finProdFinEquiv (i, k) : Fin (d * dK)).modNat) = (i, k) :=
-    finProdFinEquiv.symm_apply_apply (i, k)
-  have hd : (finProdFinEquiv (i, k) : Fin (d * dK)).divNat = i := congrArg Prod.fst h
-  have hm : (finProdFinEquiv (i, k) : Fin (d * dK)).modNat = k := congrArg Prod.snd h
   change A (finProdFinEquiv (i, k)).divNat (finProdFinEquiv (i, k)).modNat = A i k
-  rw [hd, hm]
+  rw [MPSTensor.finProdFinEquiv_divNat, MPSTensor.finProdFinEquiv_modNat]
 
 /-- The matrix product vector coefficient of the purifying tensor along a joined
 spin-ancilla configuration is the trace of the ordered product of the

--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -173,14 +173,6 @@ noncomputable def ketLeftBraRightAction (P : Matrix (Fin d) (Fin d) ℂ) :
     Matrix (Fin (d * d)) (Fin (d * d)) ℂ :=
   fun p q => P p.divNat q.divNat * P q.modNat p.modNat
 
-@[simp] private theorem finProdFinEquiv_divNat (i j : Fin d) :
-    (finProdFinEquiv (i, j) : Fin (d * d)).divNat = i := by
-  exact congrArg Prod.fst (finProdFinEquiv.symm_apply_apply (i, j))
-
-@[simp] private theorem finProdFinEquiv_modNat (i j : Fin d) :
-    (finProdFinEquiv (i, j) : Fin (d * d)).modNat = j := by
-  exact congrArg Prod.snd (finProdFinEquiv.symm_apply_apply (i, j))
-
 /-- Reading the doubled physical index as a ket--bra pair recovers the
 corresponding matrix entry of the horizontal MPO contraction. -/
 theorem mpv_toMPSTensor_pairConfig (M : MPOTensor d D) {N : ℕ}
@@ -317,20 +309,6 @@ theorem firstSiteActionAgree_ketLeft_braRight
   rw [ketLeftAction_mpv, braRightAction_mpv]
   exact hComm N ρ
 
-/-- Evaluating a reindexed word: `evalWord B (l.map g) = evalWord (B ∘ g) l`. -/
-lemma evalWord_map {d' : ℕ} (B : MPSTensor d' D) (g : Fin d → Fin d') (l : List (Fin d)) :
-    evalWord B (l.map g) = evalWord (fun i => B (g i)) l := by
-  induction l with
-  | nil => rfl
-  | cons a t ih => simp only [List.map_cons, evalWord_cons, ih]
-
-/-- Reindexing the physical legs of an MPV: composing the tensor with `g : Fin d → Fin d'`
-on the inside equals composing the configuration with `g` on the outside. -/
-lemma mpv_comp_reindex {d' : ℕ} (B : MPSTensor d' D) (g : Fin d → Fin d')
-    {N : ℕ} (σ : Fin N → Fin d) :
-    mpv (fun i => B (g i)) σ = mpv B (fun k => g (σ k)) := by
-  simp only [mpv, coeff, List.ofFn_comp' σ g, evalWord_map]
-
 /-- The diagonal restriction of a doubled-index block: `diagBlock B i = B (i, i)`. -/
 def diagBlock {dim : ℕ} (B : MPSTensor (d * d) dim) : MPSTensor d dim :=
   fun i => B (finProdFinEquiv (i, i))
@@ -346,7 +324,7 @@ theorem mpv_toTensorFromBlocks_diag {r : ℕ} {dim : Fin r → ℕ}
   rw [mpv_toTensorFromBlocks_eq_sum, mpv_toTensorFromBlocks_eq_sum]
   refine Finset.sum_congr rfl fun k _ => ?_
   congr 1
-  exact (mpv_comp_reindex (A k) (fun i => finProdFinEquiv (i, i)) σ).symm
+  exact (mpv_reindexPhysical (fun i => finProdFinEquiv (i, i)) (A k) σ).symm
 
 end MPSTensor
 
@@ -368,13 +346,8 @@ def diagonalTensor (M : MPOTensor d D) : MPSTensor d D :=
 `(i, i)`: `diagonalTensor M i = M.toMPSTensor (finProdFinEquiv (i, i))`. -/
 theorem diagonalTensor_apply_eq (M : MPOTensor d D) (i : Fin d) :
     diagonalTensor M i = M.toMPSTensor (finProdFinEquiv (i, i)) := by
-  have h : ((finProdFinEquiv (i, i) : Fin (d * d)).divNat,
-      (finProdFinEquiv (i, i) : Fin (d * d)).modNat) = (i, i) :=
-    finProdFinEquiv.symm_apply_apply (i, i)
-  have hd : (finProdFinEquiv (i, i) : Fin (d * d)).divNat = i := congrArg Prod.fst h
-  have hm : (finProdFinEquiv (i, i) : Fin (d * d)).modNat = i := congrArg Prod.snd h
-  simp only [diagonalTensor_apply, toMPSTensor]
-  rw [hd, hm]
+  simp only [diagonalTensor_apply, toMPSTensor, MPSTensor.finProdFinEquiv_divNat,
+    MPSTensor.finProdFinEquiv_modNat]
 
 /-- **Matrix product vector of the diagonal tensor.** The MPV of the diagonal tensor at
 a configuration `σ` equals the MPV of the doubled-index tensor at the diagonal-paired
@@ -384,9 +357,10 @@ diagonal configurations seen by `diagonalTensor M`, the first step of Propositio
 theorem mpv_diagonalTensor (M : MPOTensor d D) {N : ℕ} (σ : Fin N → Fin d) :
     MPSTensor.mpv (diagonalTensor M) σ
       = MPSTensor.mpv M.toMPSTensor (fun k => finProdFinEquiv (σ k, σ k)) := by
-  have htensor : diagonalTensor M = fun i => M.toMPSTensor (finProdFinEquiv (i, i)) :=
+  have htensor : diagonalTensor M =
+      MPSTensor.reindexPhysical (fun i => finProdFinEquiv (i, i)) M.toMPSTensor :=
     funext (diagonalTensor_apply_eq M)
-  rw [htensor, MPSTensor.mpv_comp_reindex M.toMPSTensor (fun i => finProdFinEquiv (i, i))]
+  rw [htensor, MPSTensor.mpv_reindexPhysical (fun i => finProdFinEquiv (i, i)) M.toMPSTensor]
 
 /-- Under a horizontal canonical-form decomposition of `M.toMPSTensor`, the diagonal
 tensor of `M` generates the same MPV family as the block-diagonal assembly, on the

--- a/TNLean/MPS/RFP/StructuralFull.lean
+++ b/TNLean/MPS/RFP/StructuralFull.lean
@@ -543,98 +543,6 @@ private theorem unit_pair_of_scaled_sqrtCard [NeZero D] (U₀ : MPSTensor d D)
           · simp [hpq, hD_ne]
           · simp [hpq]
 
-/-- **Unit pair-index form of Lemma B.1.**  This is the same structural
-decomposition as the isometry theorem above
-(Theorem~\ref{thm:rfp_nt_structural_full}), rewritten in the source convention
-for the pair-index isometry equation
-\[
-  \sum_i \overline{(U^i)_{\alpha,\beta}}\,(U^i)_{\alpha',\beta'}
-  =
-  \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
-\]
-
-The theorem is only a normalization comparison: the diagonal factor is rescaled by
-\(D^{-1/2}\), and the residual tensor by \(D^{1/2}\).
-
-**Scope restriction (source isometry):** Corollary III.cor3 and the joint
-isometry equation in arXiv:1606.00608, lines 550--554, also include the source
-trace condition \(\operatorname{tr}\Lambda=1\) and cross-block
-\(\delta_{j,j'}\) orthogonality.  Those conclusions are not proved here; this
-theorem only compares the scalar normalization for a single block.  This
-restriction is recorded in `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`.
-Elimination: prove a whole-family isometry form with trace-normalized diagonal
-weights and orthogonality between distinct blocks. -/
-theorem rfp_nt_structural_full_unit_pair (A : MPSTensor d D) [NeZero D]
-    (hNT : IsNormal A) (hRFP : IsRFP A)
-    (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
-    ∃ (X : Matrix (Fin D) (Fin D) ℂ) (Λ : Fin D → ℝ)
-      (U : MPSTensor d D),
-      X.det ≠ 0 ∧
-      (∀ k, 0 < Λ k) ∧
-      (∀ p q : Fin D × Fin D,
-        ∑ i : Fin d, star (U i p.1 p.2) * U i q.1 q.2 =
-          if p = q then 1 else 0) ∧
-      (∀ i, A i = X * Matrix.diagonal (fun k => (Λ k : ℂ)) * U i * X⁻¹) := by
-  classical
-  obtain ⟨X, Λ₀, U₀, hX_det, hΛ₀_pos, _, hU₀_pair, hA_eq⟩ :=
-    rfp_nt_structural_full A hNT hRFP hLeft
-  let sR : ℝ := Real.sqrt (D : ℝ)
-  let s : ℂ := (sR : ℂ)
-  let Λ : Fin D → ℝ := fun k => Λ₀ k / sR
-  let U : MPSTensor d D := fun i => s • U₀ i
-  have hDpos_nat : 0 < D := Nat.pos_of_ne_zero (NeZero.ne D)
-  have hDpos : 0 < (D : ℝ) := by
-    exact_mod_cast hDpos_nat
-  have hsR_ne : sR ≠ 0 := by
-    exact Real.sqrt_ne_zero'.2 hDpos
-  have hsR_pos : 0 < sR := by
-    exact Real.sqrt_pos.2 hDpos
-  have hs_ne : s ≠ 0 := by
-    simpa [s] using Complex.ofReal_ne_zero.mpr hsR_ne
-  have hdiag :
-      Matrix.diagonal (fun k => (Λ k : ℂ)) =
-        s⁻¹ • Matrix.diagonal (fun k => (Λ₀ k : ℂ)) := by
-    ext a b
-    by_cases hab : a = b
-    · subst hab
-      calc
-        Matrix.diagonal (fun k => (Λ k : ℂ)) a a = ((Λ₀ a / sR : ℝ) : ℂ) := by
-            simp [Λ, Matrix.diagonal]
-        _ = s⁻¹ * (Λ₀ a : ℂ) := by
-            rw [Complex.ofReal_div]
-            simp [s, div_eq_mul_inv, mul_comm]
-        _ = (s⁻¹ • Matrix.diagonal (fun k => (Λ₀ k : ℂ))) a a := by
-            simp [Matrix.diagonal]
-    · simp [Matrix.diagonal, hab]
-  refine ⟨X, Λ, U, hX_det, ?_, ?_, ?_⟩
-  · intro k
-    exact div_pos (hΛ₀_pos k) hsR_pos
-  · intro p q
-    exact unit_pair_of_scaled_sqrtCard U₀ hU₀_pair p q
-  · intro i
-    rw [hA_eq i]
-    let L : Matrix (Fin D) (Fin D) ℂ := Matrix.diagonal (fun k => (Λ k : ℂ))
-    have hdiag' : Matrix.diagonal (fun k => (Λ₀ k : ℂ)) = s • L := by
-      calc
-        Matrix.diagonal (fun k => (Λ₀ k : ℂ)) =
-            (s * s⁻¹) • Matrix.diagonal (fun k => (Λ₀ k : ℂ)) := by
-            simp [hs_ne]
-        _ = s • (s⁻¹ • Matrix.diagonal (fun k => (Λ₀ k : ℂ))) := by
-            simp [smul_smul]
-        _ = s • L := by
-            rw [← hdiag]
-    have hmove : (s • L) * U₀ i = L * (s • U₀ i) := by
-      rw [Matrix.smul_mul, Matrix.mul_smul]
-    calc
-      X * Matrix.diagonal (fun k => (Λ₀ k : ℂ)) * U₀ i * X⁻¹
-          = X * (s • L) * U₀ i * X⁻¹ := by
-              rw [hdiag']
-      _ = X * L * (s • U₀ i) * X⁻¹ := by
-          rw [Matrix.mul_assoc X (s • L) (U₀ i), hmove,
-            ← Matrix.mul_assoc X L (s • U₀ i)]
-      _ = X * Matrix.diagonal (fun k => (Λ k : ℂ)) * U i * X⁻¹ := by
-          simp [L, U]
-
 /-- **Isometry canonical form for a single normal-tensor block**
 (arXiv:1606.00608, Lemma charact-NT-pure-RFP, lines 1271--1301, and the
 single-block case j = j' of the structural characterization Theorem
@@ -782,6 +690,43 @@ theorem isIsometryCanonicalForm_of_rfp_nt (A : MPSTensor d D) [NeZero D]
               ← Matrix.mul_assoc X L (s • U₀ i)]
       _ = X * Matrix.diagonal (fun k => (Real.sqrt (Λ k) : ℂ)) * U i * X⁻¹ := by
             simp [L, U]
+
+/-- **Unit pair-index form of Lemma B.1.**  This is the same structural
+decomposition as the isometry theorem above
+(Theorem~\ref{thm:rfp_nt_structural_full}), rewritten in the source convention
+for the pair-index isometry equation
+\[
+  \sum_i \overline{(U^i)_{\alpha,\beta}}\,(U^i)_{\alpha',\beta'}
+  =
+  \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
+\]
+
+The theorem is only a normalization comparison: the diagonal factor is rescaled by
+\(D^{-1/2}\), and the residual tensor by \(D^{1/2}\).
+
+**Scope restriction (source isometry):** Corollary III.cor3 and the joint
+isometry equation in arXiv:1606.00608, lines 550--554, also include the source
+trace condition \(\operatorname{tr}\Lambda=1\) and cross-block
+\(\delta_{j,j'}\) orthogonality.  Those conclusions are not proved here; this
+theorem only compares the scalar normalization for a single block.  This
+restriction is recorded in `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`.
+Elimination: prove a whole-family isometry form with trace-normalized diagonal
+weights and orthogonality between distinct blocks. -/
+theorem rfp_nt_structural_full_unit_pair (A : MPSTensor d D) [NeZero D]
+    (hNT : IsNormal A) (hRFP : IsRFP A)
+    (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
+    ∃ (X : Matrix (Fin D) (Fin D) ℂ) (Λ : Fin D → ℝ)
+      (U : MPSTensor d D),
+      X.det ≠ 0 ∧
+      (∀ k, 0 < Λ k) ∧
+      (∀ p q : Fin D × Fin D,
+        ∑ i : Fin d, star (U i p.1 p.2) * U i q.1 q.2 =
+          if p = q then 1 else 0) ∧
+      (∀ i, A i = X * Matrix.diagonal (fun k => (Λ k : ℂ)) * U i * X⁻¹) := by
+  obtain ⟨X, Λ, U, hX_det, hΛ_pos, _, hU_pair, hA_eq⟩ :=
+    isIsometryCanonicalForm_of_rfp_nt A hNT hRFP hLeft
+  exact ⟨X, fun k => Real.sqrt (Λ k), U, hX_det,
+    fun k => Real.sqrt_pos.2 (hΛ_pos k), hU_pair, hA_eq⟩
 
 /-- **Per-block trace-normalized isometry canonical form.** Each block of a
 multi-block tensor that is a normal, left-canonical renormalization fixed point

--- a/TNLean/QPF/Uniqueness.lean
+++ b/TNLean/QPF/Uniqueness.lean
@@ -208,14 +208,8 @@ lemma exists_critical_scalar [Nonempty (Fin D)]
   have h_shift := hermitian_sub_scalar_spectral hH_herm c₀
   have hct : ∀ f, V * Matrix.diagonal f * Vᴴ = V * Matrix.diagonal f * star V :=
     fun _ => by simp [Matrix.star_eq_conjTranspose]
-  have hHc_psd : (H - (↑c₀ : ℂ) • 1).PosSemidef := by
-    rw [h_shift, hct]
-    exact (Matrix.IsUnit.posSemidef_star_right_conjugate_iff hV_unit).mpr
-      (Matrix.posSemidef_diagonal_iff.mpr (fun i => by
-        rw [RCLike.nonneg_iff]
-        constructor
-        · exact_mod_cast sub_nonneg.mpr (minEigenvalue_le hH_herm i)
-        · simp [Complex.ofReal_im]))
+  have hHc_psd : (H - (↑c₀ : ℂ) • 1).PosSemidef :=
+    sub_minEigenvalue_smul_one_posSemidef hH_herm
   have hHc_not_pd : ¬(H - (↑c₀ : ℂ) • 1).PosDef := by
     rw [h_shift, hct]; intro h_pd
     have h_pd' := (Matrix.IsUnit.posDef_star_right_conjugate_iff hV_unit).mp h_pd

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -609,23 +609,12 @@ and rates for the single-tensor transfer map $\E_A$.
     the trace-normalization $\tr(\Lambda)=1$.
 \end{theorem}
 \begin{proof}\leanok
-    \uses{thm:rfp_nt_structural_full}
-    Apply Theorem~\ref{thm:rfp_nt_structural_full}, then set
-    $\widetilde U^i=\sqrt D\,U^i$ and
-    $\widetilde\Lambda=D^{-1/2}\Lambda$.  Since
-    $\widetilde\Lambda\widetilde U^i=\Lambda U^i$, the decomposition
-    $A^i=X\widetilde\Lambda\widetilde U^iX^{-1}$ still holds.  The
-    pair-index contraction becomes
-    \[
-        \sum_i
-        \overline{(\widetilde U^i)_{\alpha,\beta}}\,
-        (\widetilde U^i)_{\alpha',\beta'}
-        =
-        D\cdot D^{-1}
-        \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}
-        =
-        \delta_{\alpha,\alpha'}\delta_{\beta,\beta'} .
-    \]
+    \uses{thm:isometry_canonical_form_of_rfp_nt}
+    Apply Theorem~\ref{thm:isometry_canonical_form_of_rfp_nt}, which gives
+    $A^i = X\sqrt{\Lambda}\,U^i X^{-1}$ with $U$ already a unit pair-index
+    isometry.  Set $\widetilde\Lambda_\alpha = \sqrt{\Lambda_\alpha}$, so that
+    $A^i = X\widetilde\Lambda\,U^i X^{-1}$ with $\widetilde\Lambda$ diagonal
+    positive; the decomposition and the pair-index condition are immediate.
 \end{proof}
 
 \begin{theorem}[Per-block isometry canonical form]%


### PR DESCRIPTION
Pure-refactoring sweep across the RFP, cyclic-decomposition, and MPDO layers. No mathematical statements changed: every public theorem keeps its name, signature, hypotheses, and docstring; all changes are proof bodies, shared-helper extraction, or verbatim moves of declarations to lower layers.

## Applied refactorings

1. **`MPS/RFP/StructuralFull.lean`** — `rfp_nt_structural_full_unit_pair` is now a direct corollary of `isIsometryCanonicalForm_of_rfp_nt` (moved below it), replacing a 58-line rescaling proof that re-derived what the isometry canonical form already provides.
2. **`Channel/Peripheral/CyclicDecomposition/Basic.lean` + `MPS/CanonicalForm/CyclicSectors/Compression.lean`** — the spectral-splitting preamble of the corner-compression lemma was duplicated near-verbatim (~150 lines) inside the sector-compression theorem; both now consume a shared `ProjectionSpectralSplit` bundle built by one constructor from `IsOrthogonalProjection`.
3. **`Algebra/HermitianHelpers.lean`** — `smul_one_sub_hermitian_spectral` is derived from its exact mirror `hermitian_sub_scalar_spectral` instead of repeating the spectral-theorem calc skeleton.
4. **`MPS/MPDO/VerticalCF.lean` + `MPS/Defs.lean` + `MPS/Core/BlockingInfrastructure.lean`** — `reindexPhysical` and its `evalWord`/`mpv` lemmas moved verbatim to `MPS/Defs`; the VerticalCF duplicates (`evalWord_map`, `mpv_comp_reindex`, no external uses) are deleted in favor of the shared lemmas.
5. **`Channel/Peripheral/CyclicDecomposition/Basic.lean` + `Compression.lean`** — 3-step reindex round-trip blocks replaced by one-line `LinearEquiv.apply_symm_apply` / `symm_apply_apply` terms (definitionally valid since `Matrix.symm_reindexLinearEquiv` is `rfl`).
6. **`MPS/Irreducible/FixedPointProjection.lean`** — deleted private `max_shift_posSemidef`, a verbatim restatement of `maxEigenvalue_smul_one_sub_posSemidef` from `Algebra/HermitianHelpers`.
7. **`QPF/Uniqueness.lean`** — an 8-line positive-semidefiniteness block replaced by the library lemma `sub_minEigenvalue_smul_one_posSemidef`.
8. **`Channel/Peripheral/CyclicDecomposition/PeripheralUnitary.lean`** — same replacement in `hermitian_fixed_eq_scalar_of_irreducible_unital`, deleting the now-unused local unitary and its spectral identity.
9. **`MPS/MPDO/Defs.lean` + `VerticalCF.lean` + `LocalPurificationRFP.lean`** — the private square `finProdFinEquiv` `divNat`/`modNat` simp pair generalized to rectangular products, moved to `MPS/MPDO/Defs`, and reused at the diagonal-tensor and purification call sites.
10. **`Compression.lean`** — the letter-expansion bullet re-proved three facts (`A i = Umat * B i * Umatᴴ` and two reindex identities) already proved in the intertwining bullet; one quantified copy of each is hoisted above the bullets.

## Skipped

None — all ten vetted refactorings applied.

## Verification

- `lake build TNLean` — success (9278 jobs)
- `rg -n "sorry|axiom"` on all changed files — clean
- `lake exe checkdecls blueprint/lean_decls` — pass
- `python3 scripts/blueprint_lean_sync.py --ci` — in sync
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main` — no violations
- `lake exe lint_style` — pass
- `git diff --check` — clean

The only blueprint-tagged declaration touched is `MPSTensor.rfp_nt_structural_full_unit_pair` (ch14), which keeps its exact statement and docstring.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactoring only: theorem statements unchanged and verification (build, lint, blueprint sync) is reported clean. Residual risk is limited to accidental proof regressions in long compression proofs, not API or runtime behavior.
> 
> **Overview**
> This PR is a **proof and library-layout refactor** across MPS, cyclic decomposition, Hermitian algebra, and MPDO layers. **No public theorem names, hypotheses, or mathematical claims are changed**; work is deduplication, helper extraction, and shorter proof bodies.
> 
> **Spectral splitting for projection corners:** A new `ProjectionSpectralSplit` structure and `ofOrthogonalProjection` constructor in cyclic-decomposition `Basic` replace ~150 lines of duplicated eigendecomposition preamble in sector compression (`Compression.lean`) and feed `exists_cornerSubmodule_matrixLinearEquiv_aux`.
> 
> **Hermitian eigenvalue shifts:** `smul_one_sub_hermitian_spectral` is derived from `hermitian_sub_scalar_spectral` instead of repeating the spectral calc. Call sites in fixed-point projection, QPF uniqueness, and peripheral unitary drop local PSD proofs in favor of `sub_minEigenvalue_smul_one_posSemidef` / `maxEigenvalue_smul_one_sub_posSemidef`.
> 
> **Physical reindexing:** `reindexPhysical` with `evalWord_reindexPhysical` / `mpv_reindexPhysical` move to `MPS/Defs`; MPDO vertical CF and blocking infrastructure drop duplicate lemmas (old names kept as deprecated aliases).
> 
> **Corner compression / reindex round-trips:** Multi-step `reindexLinearEquiv` comp proofs become one-line `apply_symm_apply` / `symm_apply_apply` uses.
> 
> **RFP structural full:** `rfp_nt_structural_full_unit_pair` is repositioned as a short corollary of `isIsometryCanonicalForm_of_rfp_nt` (replacing a long rescaling proof); blueprint ch14 proof text now cites the isometry canonical form theorem.
> 
> **MPDO product indices:** Shared `finProdFinEquiv_divNat` / `modNat` simp lemmas live in `MPDO/Defs` for purification and vertical CF.
> 
> **Risk:** Low—large diff but mechanical; CI/build and blueprint sync reported passing; only proof implementations and doc/prose wiring change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6ecf13ff4fc531b7a9bd7dc1e950834355d2f6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->