### PR TITLE
feat(MPS/MPDO): identify normalized four-site tail

### DIFF
--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.MPDO.Defs
+import TNLean.MPS.MPDO.ZCL
 import TNLean.Entropy.MarkovChain
 import TNLean.MPS.MPDO.MutualInfoMonotone
 import TNLean.MPS.Chain.VirtualInsertion
@@ -23,6 +24,12 @@ arXiv:1606.00608 (Cirac–Pérez-García–Schuch–Verstraete).
   doubled-index MPS tensor.
 - `MPOTensor.inverseTensor` / `MPOTensor.inverseTensor_spec`: the concrete
   inverse tensor `K⁻¹` and its matrix-unit contraction identity.
+- `MPOTensor.normalizedFourSiteTail` /
+  `MPOTensor.reducedBlockState_four_three_apply`: the normalized one-site
+  virtual tail closing the three-site marginal of the four-site MPO.
+- `MPOTensor.normalizedFourSiteTail_ne_zero` /
+  `MPOTensor.exists_normalizedFourSiteTail_entry_ne_zero`: nonvanishing of the
+  tail and selection of a nonzero virtual entry.
 - `MPOTensor.inverseMapThreeSiteContraction` /
   `MPOTensor.inverseMapThreeSiteContraction_eq`: the double inverse-map
   contraction at lines 1415--1438 of Appendix C.2 in arXiv:1606.00608.
@@ -187,6 +194,122 @@ theorem inverseTensor_spec (K : MPOTensor d D) (hK : K.IsInjective)
         = Matrix.single α β (1 : ℂ)
   exact MPSTensor.decompositionMap_sum (A := K.toMPSTensor) hK
     (Matrix.single α β (1 : ℂ))
+
+/-- The virtual matrix obtained by tracing the fourth physical site of the
+normalized four-site MPO:
+
+\[
+  R_4 = \operatorname{tr}(\rho^{(4)}(K))^{-1}
+    \sum_i K^{i,i}.
+\]
+
+The scalar is the normalization of the full four-site state. This matrix is
+the one-site specialization of the virtual tail shown in the three-site
+marginal formula `sigma3bka` and later denoted by $m$ at lines 1430--1433.
+
+Source: arXiv:1606.00608, lines 792--793 and Appendix C.2, equation
+`sigma3bka`, lines 1343--1348. The later inverse-map contraction at lines
+1415--1438 uses this tail but is not part of the definition. -/
+noncomputable def normalizedFourSiteTail (K : MPOTensor d D) :
+    Matrix (Fin D) (Fin D) ℂ :=
+  (Matrix.trace (mpo K 4))⁻¹ • physTraceTransfer K
+
+/-- The normalized three-site marginal of the four-site MPO is the product of
+the first three local tensors closed against `normalizedFourSiteTail`:
+
+\[
+  \bigl(\sigma^{(4)}_3(K)\bigr)_{u,v}
+    = \operatorname{tr}\!\left(K^{u_1,v_1}K^{u_2,v_2}K^{u_3,v_3}R_4\right).
+\]
+
+This is the four-site instance of equation `sigma3bka`. It supplies the
+normalized tail occurring in the inverse-map calculation at lines 1415--1438;
+it does not make the subsequent comparison with the Hayashi decomposition.
+
+Source: arXiv:1606.00608, lines 792--793 and Appendix C.2, equation
+`sigma3bka`, lines 1343--1348; compare lines 1415--1438. -/
+theorem reducedBlockState_four_three_apply
+    (K : MPOTensor d D) (u v : Fin 3 → Fin d) :
+    K.reducedBlockState 4 3 (by omega) u v =
+      Matrix.trace
+        (K.evalWord (List.ofFn u) (List.ofFn v) * normalizedFourSiteTail K) := by
+  rw [reducedBlockState_eq_sum]
+  rw [normalizedMPO, normalizedFourSiteTail, physTraceTransfer]
+  simp only [Matrix.smul_apply, mpo_apply, mpoMatrixEntry]
+  have hwords (a : Fin 3 → Fin d) (x : Fin 1 → Fin d) :
+      List.ofFn (Fin.append a x ∘ Fin.cast (show 4 = 3 + 1 by omega)) =
+        List.ofFn a ++ List.ofFn x := by
+    rw [← List.ofFn_fin_append]
+    congr 1
+  simp_rw [hwords]
+  have heval (x : Fin 1 → Fin d) :
+      K.evalWord (List.ofFn u ++ List.ofFn x) (List.ofFn v ++ List.ofFn x) =
+        K.evalWord (List.ofFn u) (List.ofFn v) *
+          K.evalWord (List.ofFn x) (List.ofFn x) := by
+    exact evalWord_append K _ _ _ _ (by simp)
+  simp_rw [heval]
+  let z : Fin 1 := 0
+  have hone (x : Fin 1 → Fin d) :
+      K.evalWord (List.ofFn x) (List.ofFn x) = K (x z) (x z) := by
+    simp
+    congr 3
+  simp_rw [hone]
+  rw [← Equiv.sum_comp (Equiv.funUnique (Fin 1) (Fin d)).symm
+    (fun x : Fin 1 → Fin d ↦
+      (K.mpo 4).trace⁻¹ •
+        Matrix.trace
+          (K.evalWord (List.ofFn u) (List.ofFn v) * K (x z) (x z)))]
+  simp only [Equiv.funUnique_symm_apply, uniqueElim_const]
+  simp_rw [← Matrix.trace_smul]
+  rw [← Matrix.trace_sum]
+  congr 1
+  rw [← Finset.smul_sum]
+  rw [← Finset.mul_sum]
+  rw [Matrix.mul_smul]
+
+/-- The normalized one-site tail is nonzero whenever the four-site MPO has
+nonzero trace. Equivalently, the normalized three-site marginal cannot be
+closed against the zero virtual matrix.
+
+This is the four-site instance of the observation that the matrix $m$ in
+Appendix C.2 has a nonzero entry; the source uses such an entry in the next
+sector-factorization step.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1431--1434, with the
+normalization convention at lines 792--793. -/
+theorem normalizedFourSiteTail_ne_zero
+    (K : MPOTensor d D) (htrace : (mpo K 4).trace ≠ 0) :
+    normalizedFourSiteTail K ≠ 0 := by
+  intro htail
+  have hred : K.reducedBlockState 4 3 (by omega) = 0 := by
+    ext u v
+    rw [reducedBlockState_four_three_apply, htail]
+    simp
+  have hunit := reducedBlockState_trace K 4 3 (by omega) htrace
+  rw [hred] at hunit
+  simp at hunit
+
+/-- A nonzero four-site trace supplies virtual indices at which the normalized
+one-site tail does not vanish:
+
+\[
+  \exists\,\beta,\alpha,\qquad (R_4)_{\beta,\alpha}\ne 0.
+\]
+
+These are precisely the indices selected before equation `formK`; no SAL or
+injectivity hypothesis is needed for this selection once the four-site state
+has nonzero trace.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1431--1437. -/
+theorem exists_normalizedFourSiteTail_entry_ne_zero
+    (K : MPOTensor d D) (htrace : (mpo K 4).trace ≠ 0) :
+    ∃ β α : Fin D, normalizedFourSiteTail K β α ≠ 0 := by
+  classical
+  by_contra h
+  push Not at h
+  apply normalizedFourSiteTail_ne_zero K htrace
+  ext β α
+  exact h β α
 
 /-- The contraction obtained by applying the inverse tensor to the first and
 third sites of a three-site MPO word.

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -204,12 +204,12 @@ normalized four-site MPO:
 \]
 
 The scalar is the normalization of the full four-site state. This matrix is
-the one-site specialization of the virtual tail shown in the three-site
-marginal formula `sigma3bka` and later denoted by $m$ at lines 1430--1433.
+the one-site specialization of the virtual tail in the three-site marginal
+formula at lines 1343--1348, later denoted by $m$ at lines 1430--1433.
 
-Source: arXiv:1606.00608, lines 792--793 and Appendix C.2, equation
-`sigma3bka`, lines 1343--1348. The later inverse-map contraction at lines
-1415--1438 uses this tail but is not part of the definition. -/
+Source: arXiv:1606.00608, lines 792--793 and Appendix C.2, lines 1343--1348.
+The later inverse-map contraction at lines 1415--1438 uses this tail but is not
+part of the definition. -/
 noncomputable def normalizedFourSiteTail (K : MPOTensor d D) :
     Matrix (Fin D) (Fin D) ℂ :=
   (Matrix.trace (mpo K 4))⁻¹ • physTraceTransfer K
@@ -222,12 +222,13 @@ the first three local tensors closed against `normalizedFourSiteTail`:
     = \operatorname{tr}\!\left(K^{u_1,v_1}K^{u_2,v_2}K^{u_3,v_3}R_4\right).
 \]
 
-This is the four-site instance of equation `sigma3bka`. It supplies the
-normalized tail occurring in the inverse-map calculation at lines 1415--1438;
-it does not make the subsequent comparison with the Hayashi decomposition.
+This is the four-site instance of the three-site marginal formula at lines
+1343--1348. It supplies the normalized tail occurring in the inverse-map
+calculation at lines 1415--1438; it does not make the subsequent comparison
+with the Hayashi decomposition.
 
-Source: arXiv:1606.00608, lines 792--793 and Appendix C.2, equation
-`sigma3bka`, lines 1343--1348; compare lines 1415--1438. -/
+Source: arXiv:1606.00608, lines 792--793 and Appendix C.2, lines 1343--1348;
+compare lines 1415--1438. -/
 theorem reducedBlockState_four_three_apply
     (K : MPOTensor d D) (u v : Fin 3 → Fin d) :
     K.reducedBlockState 4 3 (by omega) u v =
@@ -251,8 +252,7 @@ theorem reducedBlockState_four_three_apply
   let z : Fin 1 := 0
   have hone (x : Fin 1 → Fin d) :
       K.evalWord (List.ofFn x) (List.ofFn x) = K (x z) (x z) := by
-    simp
-    congr 3
+    simp [z]
   simp_rw [hone]
   rw [← Equiv.sum_comp (Equiv.funUnique (Fin 1) (Fin d)).symm
     (fun x : Fin 1 → Fin d ↦
@@ -296,15 +296,14 @@ one-site tail does not vanish:
   \exists\,\beta,\alpha,\qquad (R_4)_{\beta,\alpha}\ne 0.
 \]
 
-These are precisely the indices selected before equation `formK`; no SAL or
-injectivity hypothesis is needed for this selection once the four-site state
-has nonzero trace.
+These are precisely the indices selected at line 1434 before the sector
+factorization at lines 1435--1437; no SAL or injectivity hypothesis is needed
+for this selection once the four-site state has nonzero trace.
 
 Source: arXiv:1606.00608, Appendix C.2, lines 1431--1437. -/
 theorem exists_normalizedFourSiteTail_entry_ne_zero
     (K : MPOTensor d D) (htrace : (mpo K 4).trace ≠ 0) :
     ∃ β α : Fin D, normalizedFourSiteTail K β α ≠ 0 := by
-  classical
   by_contra h
   push Not at h
   apply normalizedFourSiteTail_ne_zero K htrace

--- a/blueprint/src/Packages/tn_diagrams.py
+++ b/blueprint/src/Packages/tn_diagrams.py
@@ -58,6 +58,7 @@ _DIAGRAM_ARGS: dict[str, str] = {
     "TNMPDOInverseContraction": "",
     "TNMPDOSectorPairing": "",
     "TNMPDOSectorZCLIdentity": "",
+    "TNMPDONormalizedFourSiteTail": "",
     "TNGaugeConjugation": "left physical right",
     "TNPhysicalRealization": "virtual physical",
     "TNLinearTwist": "twist label",

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -184,8 +184,7 @@ strong subadditivity for a normalized three-site reduced state.
     \label{thm:mpdo_normalized_four_site_tail_ne_zero}
     \lean{MPOTensor.normalizedFourSiteTail_ne_zero}
     \leanok
-    \uses{def:mpdo_normalized_four_site_tail,
-        thm:mpdo_reduced_four_three_tail}
+    \uses{def:mpdo_normalized_four_site_tail}
     If $Z_4=\tr[\rho^{(4)}({\cal K})]\ne0$, then $R_4\ne0$.
 \end{theorem}
 
@@ -193,9 +192,15 @@ strong subadditivity for a normalized three-site reduced state.
     \leanok
     \uses{thm:mpdo_reduced_four_three_tail}
     If $R_4=0$, then the tail formula makes every entry of
-    $\sigma_3^{(4)}({\cal K})$ vanish. Its trace would therefore be zero. On the
-    other hand, $Z_4\ne0$ makes the normalized four-site operator, and hence its
-    three-site marginal, have trace one. This is a contradiction.
+    $\sigma_3^{(4)}({\cal K})$ vanish, so
+    \[
+        \tr[\sigma_3^{(4)}({\cal K})]=0.
+    \]
+    On the other hand, $Z_4\ne0$ implies
+    \[
+        \tr[\sigma_3^{(4)}({\cal K})]=1,
+    \]
+    a contradiction.
 \end{proof}
 
 \begin{theorem}[A nonzero entry of the normalized fourth-site tail]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -109,6 +109,115 @@ strong subadditivity for a normalized three-site reduced state.
     \label{fig:mpdo_inverse_contraction}
 \end{figure}
 
+\begin{definition}[Normalized fourth-site virtual tail]
+    \label{def:mpdo_normalized_four_site_tail}
+    \lean{MPOTensor.normalizedFourSiteTail}
+    \leanok
+    \uses{def:mpo_family, def:mpo_physical_trace_transfer}
+    Let ${\cal K}$ be an MPO tensor and set
+    $Z_4=\tr[\rho^{(4)}({\cal K})]$. Its normalized fourth-site virtual tail is
+    \[
+        R_4:=Z_4^{-1}\mathcal T_{\cal K}
+        =\tr[\rho^{(4)}({\cal K})]^{-1}
+          \sum_{i_4=0}^{d-1}{\cal K}^{i_4i_4}.
+    \]
+    Thus the contraction of the fourth ket and bra indices is incorporated into
+    the virtual closing matrix. This is the $N=4$ specialization of the
+    normalization convention and three-site marginal in
+    \cite[lines~792--793 and 1343--1348]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{theorem}[Three-site marginal closed by the normalized fourth-site tail]
+    \label{thm:mpdo_reduced_four_three_tail}
+    \lean{MPOTensor.reducedBlockState_four_three_apply}
+    \leanok
+    \uses{def:mpdo_normalized_four_site_tail, def:mpo_eval_word}
+    Let $u=(i_1,i_2,i_3)$ and $v=(j_1,j_2,j_3)$ be physical words of length
+    three. The corresponding entry of the first-three-site marginal of the
+    normalized four-site periodic operator is
+    \[
+        \sigma_3^{(4)}({\cal K})_{u,v}
+        =\tr\!\left({\cal K}^{u,v}R_4\right)
+        =\tr\!\left(
+          {\cal K}^{i_1j_1}{\cal K}^{i_2j_2}{\cal K}^{i_3j_3}R_4
+        \right).
+    \]
+\end{theorem}
+
+\begin{figure}[ht]
+    \centering
+    \TNMPDONormalizedFourSiteTail
+    \caption{Tracing the fourth site of the normalized four-site periodic MPO
+    leaves the physical legs of sites $1,2,3$ open and replaces the fourth site
+    by the virtual closing operator
+    $R_4=\tr[\rho^{(4)}({\cal K})]^{-1}
+    \sum_{i_4}{\cal K}^{i_4 i_4}$; compare the normalization convention and
+    three-site marginal in
+    \cite[lines~792--793 and 1343--1348]{Cirac2016MPDO_arXiv}.}
+    \label{fig:mpdo_normalized_four_site_tail}
+\end{figure}
+
+\begin{proof}
+    \leanok
+    \uses{def:mpdo_normalized_four_site_tail,
+        lem:mpo_eval_word_append}
+    Expanding the partial trace over the fourth site and factoring each
+    length-four word at its last letter gives
+    \[
+        \sigma_3^{(4)}({\cal K})_{u,v}
+        =Z_4^{-1}\sum_{i_4=0}^{d-1}
+          \tr\!\left({\cal K}^{u,v}{\cal K}^{i_4i_4}\right).
+    \]
+    Linearity of the trace now yields
+    \[
+        Z_4^{-1}\sum_{i_4=0}^{d-1}
+          \tr\!\left({\cal K}^{u,v}{\cal K}^{i_4i_4}\right)
+        =\tr\!\left(
+          {\cal K}^{u,v}
+          \left(Z_4^{-1}\sum_{i_4=0}^{d-1}{\cal K}^{i_4i_4}\right)
+        \right)
+        =\tr\!\left({\cal K}^{u,v}R_4\right).
+    \]
+\end{proof}
+
+\begin{theorem}[Non-vanishing of the normalized fourth-site tail]
+    \label{thm:mpdo_normalized_four_site_tail_ne_zero}
+    \lean{MPOTensor.normalizedFourSiteTail_ne_zero}
+    \leanok
+    \uses{def:mpdo_normalized_four_site_tail,
+        thm:mpdo_reduced_four_three_tail}
+    If $Z_4=\tr[\rho^{(4)}({\cal K})]\ne0$, then $R_4\ne0$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_reduced_four_three_tail}
+    If $R_4=0$, then the tail formula makes every entry of
+    $\sigma_3^{(4)}({\cal K})$ vanish. Its trace would therefore be zero. On the
+    other hand, $Z_4\ne0$ makes the normalized four-site operator, and hence its
+    three-site marginal, have trace one. This is a contradiction.
+\end{proof}
+
+\begin{theorem}[A nonzero entry of the normalized fourth-site tail]
+    \label{thm:mpdo_normalized_four_site_tail_entry_ne_zero}
+    \lean{MPOTensor.exists_normalizedFourSiteTail_entry_ne_zero}
+    \leanok
+    \uses{def:mpdo_normalized_four_site_tail}
+    If $Z_4\ne0$, there exist virtual indices $\beta$ and $\alpha$ such that
+    \[
+        (R_4)_{\beta,\alpha}\ne0.
+    \]
+    These are the indices selected before the sector factorization in
+    \cite[Appendix~C.2, lines~1431--1437]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_normalized_four_site_tail_ne_zero}
+    If every matrix entry of $R_4$ vanished, then $R_4$ would be the zero
+    matrix, contrary to the preceding theorem.
+\end{proof}
+
 \begin{definition}[Three-site inverse-map contraction]
     \label{def:mpdo_inverse_map_three_site_contraction}
     \lean{MPOTensor.inverseMapThreeSiteContraction}

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -488,9 +488,9 @@
         \node[draw, rounded corners, fill=blue!8, inner sep=2pt]
             (tnFourSiteTail) at (0,-1.42) {$R_4$};
         \draw[tn leg] (tnTailOne.west) -- ++(-0.48,0)
-            |- (tnFourSiteTail.west);
+            |- ($(tnFourSiteTail.east)+(0,-0.40)$) -- (tnFourSiteTail.east);
         \draw[tn leg] (tnTailThree.east) -- ++(0.48,0)
-            |- (tnFourSiteTail.east);
+            |- ($(tnFourSiteTail.west)+(0,0.38)$) -- (tnFourSiteTail.west);
 
     \end{tikzpicture}%
 }

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -457,6 +457,44 @@
     \end{tikzpicture}%
 }
 
+% The normalized three-site marginal of a four-site periodic MPO.  The first
+% three sites retain their two physical legs, while tracing the fourth site is
+% absorbed into the virtual closing operator R_4.
+\newcommand{\TNMPDONormalizedFourSiteTail}{%
+    \begin{tikzpicture}[tn picture]
+        \node at (-3.72,0) {$\sigma_3^{(4)}({\cal K})$};
+        \node at (-2.76,0) {$=$};
+
+        \TN@tensordot{tnTailOne}{(-1.48,0)}
+        \TN@tensordot{tnTailTwo}{(0,0)}
+        \TN@tensordot{tnTailThree}{(1.48,0)}
+        \draw[tn leg] (tnTailOne.east) -- (tnTailTwo.west);
+        \draw[tn leg] (tnTailTwo.east) -- (tnTailThree.west);
+
+        \foreach \n in {tnTailOne,tnTailTwo,tnTailThree} {
+            \TN@upleg{\n}{0.48}
+            \TN@downleg{\n}{0.48}
+        }
+        \TN@uplabel{tnTailOne}{0.72}{i_1}
+        \TN@uplabel{tnTailTwo}{0.72}{i_2}
+        \TN@uplabel{tnTailThree}{0.72}{i_3}
+        \TN@downlabel{tnTailOne}{0.72}{j_1}
+        \TN@downlabel{tnTailTwo}{0.72}{j_2}
+        \TN@downlabel{tnTailThree}{0.72}{j_3}
+        \node[anchor=east] at (-1.62,0.25) {${\cal K}$};
+        \node[anchor=east] at (-0.14,0.25) {${\cal K}$};
+        \node[anchor=east] at (1.34,0.25) {${\cal K}$};
+
+        \node[draw, rounded corners, fill=blue!8, inner sep=2pt]
+            (tnFourSiteTail) at (0,-1.42) {$R_4$};
+        \draw[tn leg] (tnTailOne.west) -- ++(-0.48,0)
+            |- (tnFourSiteTail.west);
+        \draw[tn leg] (tnTailThree.east) -- ++(0.48,0)
+            |- (tnFourSiteTail.east);
+
+    \end{tikzpicture}%
+}
+
 \newcommand{\TNGaugeConjugation}[3]{%
     \begin{tikzpicture}[tn picture]
         \TN@opdotabove{tnXl}{(-1.10,0)}{#1}

--- a/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
+++ b/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
@@ -7,7 +7,7 @@ name: TNMPSLocal TNMPSWord TNMPV TNBlocking TNMPVOverlap TNTransferMap TNMPOCell
 name: TNMPOLocalPurification TNMPORenormalizationTS TNEtaSectorDecomposition
 {{ obj.tn_svg_html }}
 
-name: TNMPDOInverseMapThreeSiteContraction
+name: TNMPDOInverseMapThreeSiteContraction TNMPDONormalizedFourSiteTail
 {{ obj.tn_svg_html }}
 
 name: TNMPDOHorizontalOperator TNMPDOFirstSiteContractions TNMPDOVerticalDirectSum

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -24,7 +24,7 @@ form
   \sigma^{(N)}({\cal K})\propto \prod_{n=1}^N B_{n,n+1},
 \]
 where $B_{n,n+1}\geq 0$ and the translated two-site operators commute
-\cite[Appendix~C.2, Proposition~C.6]{Cirac2016MPDO_arXiv}. In the local
+\cite[Appendix~C.2, Proposition~C.8]{Cirac2016MPDO_arXiv}. In the local
 source file this is Proposition \texttt{3to4},
 \path{Papers/1606.00608/MPDO-22-12-17-2.tex:1571--1593}.
 
@@ -77,13 +77,13 @@ and the GSNNCH--ZCL consequences.  After ZCL is assumed, ZCL itself gives the
 size-$2$ fusion witness and the transfer-map fusion formulation of the MPDO
 RFP condition.
 
-The two scope-restricted declarations are assembly
+The two scope-restricted declarations are conditional construction
 statements.\footnote{These declarations are
 \leanid{MPOTensor.SimpleMPDOBlockedRFPData.ofSALZCLAndEtaLocalStructure} and
 \leanid{MPOTensor.simple_mpdo_rfp_chain_of_sal_zcl_and_etaLocalStructure}.}
 They assume the eta-local structure instead of deriving it from the SAL local
 coordinates. They also carry the ZCL hypothesis needed for the subsequent RFP
-consequences. Thus they formalize the final assembly step after the
+consequences. Thus they formalize the final deduction after the
 $B_{n,n+1}$ have been constructed, not the source theorem that constructs those
 bonds from SAL.
 
@@ -104,7 +104,28 @@ the resulting neighboring operators $\eta_{k,h}$ satisfy
 for every chain length.  No current declaration states this tensor
 factorization or its all-length contraction identity.
 
-The double inverse-map contraction preceding this factorization is now
+For the four-site chain, the virtual contraction of the traced fourth site is
+now identified before applying the inverse tensor.  Writing
+\[
+  R_4=
+  \tr\!\left[\rho^{(4)}({\cal K})\right]^{-1}
+  \sum_i {\cal K}^{i,i},
+\]
+the normalized three-site marginal satisfies
+\[
+  \sigma_3^{(4)}({\cal K})_{u,v}
+  =\tr\!\left({\cal K}^{u,v}R_4\right).
+\]
+If the four-site trace is nonzero, then $R_4\ne0$, and hence some entry
+$(R_4)_{\beta,\alpha}$ is nonzero.  Thus the boundary matrix and the nonzero
+entry selected before equation \texttt{formK} are available without adding
+SAL or injectivity as separate hypotheses.\footnote{The formal declarations
+are \leanid{MPOTensor.normalizedFourSiteTail},
+\leanid{MPOTensor.reducedBlockState_four_three_apply},
+\leanid{MPOTensor.normalizedFourSiteTail_ne_zero}, and
+\leanid{MPOTensor.exists_normalizedFourSiteTail_entry_ne_zero}.}
+
+The double inverse-map contraction preceding the sector factorization is also
 formalized.  If $R$ denotes the virtual contraction of the remaining sites,
 then
 \[
@@ -175,21 +196,25 @@ of a simple MPDO satisfying SAL.  ZCL is not a hypothesis of this construction.
 
 The source Proposition \texttt{3to4} assumes SAL, not ZCL.  ZCL enters only
 after this commuting product form has been obtained, in the later step that
-derives the GSNNCH--ZCL and RFP conclusions.  Accordingly, adding ZCL to an
-assembly theorem would not repair the missing inverse-map sector
+derives the GSNNCH--ZCL and RFP conclusions.  Accordingly, adding ZCL to a
+conditional theorem would not repair the missing inverse-map sector
 factorization.
 
-This is tracked by
-\href{https://github.com/LionSR/TNLean/issues/823}{issue \#823}. Until that
-construction exists, the scope-restricted assembly statements must not be
-presented as the full formalization of Proposition~C.6.
+The inverse-map comparison, sector factorization, all-length identity, and
+primitivity statement of Lemma \texttt{propSN} are tracked by
+\href{https://github.com/LionSR/TNLean/issues/3696}{issue \#3696}.  Once those
+operators have been constructed, the positive commuting bond and product form
+of Proposition \texttt{3to4} are tracked separately by
+\href{https://github.com/LionSR/TNLean/issues/823}{issue \#823}. Until both
+constructions exist, the scope-restricted conditional statements must not be
+presented as the full formalization of Proposition~C.8.
 
 \section{Classification}
 
 This note records an open gap for the SAL-to-bond construction of
-\leanid{MPOTensor.EtaLocalStructureData}. The two assembly declarations above
-are scope restrictions: they formalize only the post-assembly step after the
-nearest-neighbor bonds have already been constructed.
+\leanid{MPOTensor.EtaLocalStructureData}. The two conditional declarations
+above are scope restrictions: they begin after the nearest-neighbor bonds have
+already been constructed.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

This pull request identifies the normalized virtual tail left by tracing the fourth site of a four-site periodic MPO. It:

- defines \(R_4 = \operatorname{tr}(\rho^{(4)}(K))^{-1}\sum_i K^{ii}\);
- proves the entrywise formula \((\sigma_3^{(4)}(K))_{u,v}=\operatorname{tr}(K^{u,v}R_4)\);
- proves \(R_4\ne 0\), and hence that \(R_4\) has a nonzero matrix entry, assuming only that the four-site trace is nonzero;
- adds source-faithful blueprint statements and a native TikZ tensor-network diagram modelled on the contraction shown in the original paper; and
- updates the paper-gap note to separate this completed four-site input from the remaining inverse-map sector factorization and commuting-product construction.

The source correspondence is the normalization convention at arXiv:1606.00608, lines 792–793, the three-site marginal at lines 1343–1348, and the later choice of a nonzero tail entry at lines 1431–1437.

This pull request does not claim the subsequent Hayashi comparison, sector factorization, all-length identity, or primitivity argument. Those remain tracked in #3696; the commuting product construction remains tracked in #823.

## Validation

- Full Lean build: 9,278 jobs completed successfully.
- leanblueprint declaration synchronization: the simple MPDO local-structure subchapter is 55/55.
- leanblueprint checkdecls.
- Full blueprint PDF: 438 pages, with the affected MPO/RFP pages visually inspected.
- Full blueprint web build, including the registered SVG.
- Tensor-network registration and smoke rendering: 74 diagrams.
- Reader-facing prose, whitespace, line-length, proof-integrity, and changed-declaration coverage checks.

Progresses #3696

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formalization, blueprint, and documentation with no changes to authentication, security, or existing proof obligations beyond new lemmas.
> 
> **Overview**
> Formalizes the **normalized fourth-site virtual tail** \(R_4\) for a four-site periodic MPO and ties it to Appendix C.2 of arXiv:1606.00608.
> 
> In Lean (`SimpleLocalStructure.lean`), the PR adds `MPOTensor.normalizedFourSiteTail`, proves the three-site marginal closes as \((\sigma_3^{(4)}(K))_{u,v}=\operatorname{tr}(K^{u,v}R_4)\) via `reducedBlockState_four_three_apply`, and shows \(R_4\neq 0\) and some matrix entry is nonzero when the four-site trace is nonzero—without SAL or injectivity.
> 
> The blueprint chapter documents the definition and theorems, registers `\TNMPDONormalizedFourSiteTail` for PDF/web SVG rendering, and the paper-gap note records this as done while sector factorization and the commuting product remain in **#3696** and **#823**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58a4ddfd4d3b59a80bce61e883323d5368976625. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->