### PR TITLE
feat(Algebra): spatial factorization of isotypic components as matrix-times-identity blocks

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -42,6 +42,7 @@ import TNLean.Algebra.StarSubalgebraIntertwinerIsometry
 import TNLean.Algebra.StarSubalgebraIrreducibleDecomp
 import TNLean.Algebra.StarSubalgebraIsotypic
 import TNLean.Algebra.StarSubalgebraIsotypicDecomp
+import TNLean.Algebra.StarSubalgebraIsotypicFactorization
 import TNLean.Algebra.StarSubalgebraSchur
 import TNLean.Algebra.StarSubalgebraSemisimple
 import TNLean.Algebra.StarSubalgebraSimpleModule

--- a/TNLean/Algebra/StarSubalgebraIsotypicDecomp.lean
+++ b/TNLean/Algebra/StarSubalgebraIsotypicDecomp.lean
@@ -27,7 +27,8 @@ family, the components span the whole space.
   orthogonal.
 * `StarSubalgebra.exists_orthogonal_isotypic_decomposition` -- the whole representation space
   is the supremum of a finite, pairwise orthogonal family of isotypic components, each of
-  which is the supremum of a finite, nonempty same-type class of irreducible pieces.
+  which is the supremum of a finite, nonempty same-type class of pairwise orthogonal
+  irreducible pieces.
 -/
 
 namespace StarSubalgebra
@@ -52,19 +53,19 @@ theorem isOrtho_sSup_of_not_sameIsotype
 
 /-- The whole representation space of a finite-dimensional star-subalgebra of complex matrices
 is the supremum of a finite, pairwise orthogonal family of isotypic components. Each component
-is the supremum of a finite, nonempty same-type class of irreducible pieces. The orthogonal
-decomposition into irreducible pieces supplies the family; the same-type relation groups it
-into classes; and pieces of different type are orthogonal, so distinct components are
-orthogonal. See
+is the supremum of a finite, nonempty same-type class of pairwise orthogonal irreducible
+pieces. The orthogonal decomposition into irreducible pieces supplies the family; the
+same-type relation groups it into classes, which inherit the pairwise orthogonality; and
+pieces of different type are orthogonal, so distinct components are orthogonal. See
 *Quantum Channels & Operations* (Wolf 2012), Chapter 6, towards Theorem 6.14. -/
 theorem exists_orthogonal_isotypic_decomposition :
     ∃ C : Set (Submodule ℂ (EuclideanSpace ℂ n)), C.Finite ∧
       C.Pairwise (· ⟂ ·) ∧ sSup C = ⊤ ∧
       ∀ c ∈ C, ∃ Dc : Set (Submodule ℂ (EuclideanSpace ℂ n)),
         Dc.Nonempty ∧ Dc.Finite ∧ (∀ p ∈ Dc, S.IsIrreducibleSubspace p) ∧ c = sSup Dc ∧
-          Dc.Pairwise fun p q => S.SameIsotype p q := by
+          Dc.Pairwise (· ⟂ ·) ∧ Dc.Pairwise fun p q => S.SameIsotype p q := by
   classical
-  obtain ⟨D, hDfin, hDirr, -, hDsup⟩ := S.exists_orthogonal_irreducible_decomposition
+  obtain ⟨D, hDfin, hDirr, hDpair, hDsup⟩ := S.exists_orthogonal_irreducible_decomposition
   -- The same-type class of a piece `p`, taken within the family `D`.
   set cls : Submodule ℂ (EuclideanSpace ℂ n) → Set (Submodule ℂ (EuclideanSpace ℂ n)) :=
     fun p => {q ∈ D | S.SameIsotype p q} with hcls
@@ -109,9 +110,11 @@ theorem exists_orthogonal_isotypic_decomposition :
       exact sSup_le fun q hq => le_sSup hq.1
     · -- Each piece sits inside the supremum of its own class, hence inside that component.
       exact le_trans (le_sSup (hcls_self p hp)) (le_sSup ⟨p, hp, rfl⟩)
-  · -- Each component carries its class as the requested witness.
+  · -- Each component carries its class as the requested witness; the class inherits the
+    -- pairwise orthogonality of the family.
     rintro c ⟨p, hp, rfl⟩
-    exact ⟨cls p, ⟨p, hcls_self p hp⟩, hcls_fin p, hcls_irr p, rfl, hcls_same p hp⟩
+    exact ⟨cls p, ⟨p, hcls_self p hp⟩, hcls_fin p, hcls_irr p, rfl,
+      hDpair.mono (Set.sep_subset _ _), hcls_same p hp⟩
 
 end StarSubalgebra
 

--- a/TNLean/Algebra/StarSubalgebraIsotypicFactorization.lean
+++ b/TNLean/Algebra/StarSubalgebraIsotypicFactorization.lean
@@ -48,13 +48,13 @@ variable (S : StarSubalgebra ℂ (Matrix n n ℂ))
 nonempty family of pairwise orthogonal subspaces of $\mathbb{C}^{D}$, irreducible under a
 star-subalgebra $S$ of complex matrices and pairwise of the same type. Write $m$ for the number
 of pieces; all pieces share one dimension $d$. Then the span of the family has an orthonormal
-basis $(f_{i,j})_{i \le m,\, j \le d}$ such that for every $A \in S$ there is a matrix
-$B \in M_{d}(\mathbb{C})$ with
-$$A\,f_{i,j} \;=\; \sum_{j'} B_{j'j}\, f_{i,j'} \qquad (i \le m,\ j \le d) :$$
+basis $(f_{i,j})_{0 \le i < m,\, 0 \le j < d}$ such that for every $A \in S$ there is a matrix
+$B \in M_{d}(\mathbb{C})$ with, for all $i < m$ and $j < d$,
+$$A\,f_{i,j} \;=\; \sum_{j'} B_{j'j}\, f_{i,j'} :$$
 in the adapted basis the member $A$ acts on the component as $\mathbf{1}_{m} \otimes B$, one
 matrix on the irreducible index, identically across the multiplicity index.
 
-An orthonormal basis $e_1, \ldots, e_d$ of one piece spreads to the others through the
+An orthonormal basis $e_0, \ldots, e_{d-1}$ of one piece spreads to the others through the
 inner-product-preserving intertwiners of
 `StarSubalgebra.exists_isometry_intertwiner_of_sameIsotype`; the intertwining identity makes
 the matrix of $A$ the same on every copy. See *Quantum Channels & Operations* (Wolf 2012),
@@ -162,7 +162,7 @@ theorem exists_adapted_orthonormal_family_of_sameIsotype
 /-- **Spatial tensor factorization of the isotypic components.** For a star-subalgebra $S$ of
 complex matrices, $\mathbb{C}^{D}$ is the supremum of a finite family of pairwise orthogonal
 isotypic components, and each component carries an orthonormal basis $(f_{i,j})$, indexed by a
-multiplicity index $i \le m$ and an irreducible index $j \le d$, on which every $A \in S$ acts
+multiplicity index $i < m$ and an irreducible index $j < d$, on which every $A \in S$ acts
 by
 $$A\,f_{i,j} = \sum_{j'} B_{j'j}\, f_{i,j'}$$
 for a matrix $B \in M_{d}(\mathbb{C})$ depending only on $A$ and the component. In the adapted

--- a/TNLean/Algebra/StarSubalgebraIsotypicFactorization.lean
+++ b/TNLean/Algebra/StarSubalgebraIsotypicFactorization.lean
@@ -1,0 +1,186 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Algebra.StarSubalgebraIsotypicDecomp
+import TNLean.Algebra.StarSubalgebraUnitaryIntertwiner
+
+/-!
+# Tensor factorization of the isotypic components of a star-subalgebra
+
+Continuing the structure theory of *Quantum Channels & Operations* (Wolf 2012), Chapter 6,
+towards Theorem 6.14, this file factors each isotypic component spatially. An isotypic
+component is spanned by finitely many pairwise orthogonal irreducible pieces of one type; the
+pieces are unitarily identified copies of a single irreducible piece, so an orthonormal basis
+of one copy spreads to an adapted orthonormal basis of the whole component, indexed by a
+multiplicity index and an irreducible index. In this basis every member of the subalgebra acts
+by one matrix on the irreducible index, identically across the multiplicity index. This is the
+matrix-times-identity block structure of Theorem 6.14: on the component of multiplicity $m$
+over an irreducible piece of dimension $d$, the subalgebra acts by matrices of the form
+$\mathbf{1}_{m} \otimes B$ with $B$ a $d \times d$ matrix.
+
+## Main results
+
+* `StarSubalgebra.exists_adapted_orthonormal_family_of_sameIsotype` -- a finite nonempty family
+  of pairwise orthogonal irreducible pieces of one type has an adapted orthonormal basis of its
+  span, on which every member of the subalgebra acts by a matrix on the irreducible index,
+  identically across the multiplicity index.
+* `StarSubalgebra.exists_isotypic_tensor_factorization` -- the whole representation space is
+  the supremum of a finite, pairwise orthogonal family of isotypic components, each carrying
+  such an adapted orthonormal basis.
+
+## Remaining step towards Wolf Thm 6.14
+
+The adapted bases realize the action of the subalgebra on each isotypic component as
+matrix-times-identity blocks. The remaining step is the global change of basis: concatenating
+the adapted bases of the components into a single unitary matrix that conjugates the subalgebra
+to the block-diagonal form asserted by the theorem.
+-/
+
+open scoped InnerProductSpace
+
+namespace StarSubalgebra
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+variable (S : StarSubalgebra ℂ (Matrix n n ℂ))
+
+/-- **Adapted orthonormal basis of an isotypic component.** Let $\mathcal{D}$ be a finite,
+nonempty family of pairwise orthogonal subspaces of $\mathbb{C}^{D}$, irreducible under a
+star-subalgebra $S$ of complex matrices and pairwise of the same type. Write $m$ for the number
+of pieces; all pieces share one dimension $d$. Then the span of the family has an orthonormal
+basis $(f_{i,j})_{i \le m,\, j \le d}$ such that for every $A \in S$ there is a matrix
+$B \in M_{d}(\mathbb{C})$ with
+$$A\,f_{i,j} \;=\; \sum_{j'} B_{j'j}\, f_{i,j'} \qquad (i \le m,\ j \le d) :$$
+in the adapted basis the member $A$ acts on the component as $\mathbf{1}_{m} \otimes B$, one
+matrix on the irreducible index, identically across the multiplicity index.
+
+An orthonormal basis $e_1, \ldots, e_d$ of one piece spreads to the others through the
+inner-product-preserving intertwiners of
+`StarSubalgebra.exists_isometry_intertwiner_of_sameIsotype`; the intertwining identity makes
+the matrix of $A$ the same on every copy. See *Quantum Channels & Operations* (Wolf 2012),
+Chapter 6, towards Theorem 6.14. -/
+theorem exists_adapted_orthonormal_family_of_sameIsotype
+    {Dc : Set (Submodule ℂ (EuclideanSpace ℂ n))} (hne : Dc.Nonempty) (hfin : Dc.Finite)
+    (hirr : ∀ p ∈ Dc, S.IsIrreducibleSubspace p) (hortho : Dc.Pairwise (· ⟂ ·))
+    (hsame : Dc.Pairwise fun p q => S.SameIsotype p q) :
+    ∃ (d m : ℕ) (f : Fin m × Fin d → EuclideanSpace ℂ n),
+      m = Dc.ncard ∧ (∀ p ∈ Dc, Module.finrank ℂ p = d) ∧
+      Orthonormal ℂ f ∧ Submodule.span ℂ (Set.range f) = sSup Dc ∧
+      ∀ A ∈ S, ∃ B : Matrix (Fin d) (Fin d) ℂ, ∀ (i : Fin m) (j : Fin d),
+        Matrix.toEuclideanLin A (f (i, j)) = ∑ j', B j' j • f (i, j') := by
+  classical
+  obtain ⟨p₀, hp₀⟩ := hne
+  have hp₀irr : S.IsIrreducibleSubspace p₀ := hirr p₀ hp₀
+  haveI : Fintype ↥Dc := hfin.fintype
+  -- An orthonormal basis of the base piece and an enumeration of the family.
+  set e : OrthonormalBasis (Fin (Module.finrank ℂ p₀)) ℂ ↥p₀ := stdOrthonormalBasis ℂ ↥p₀
+  set σ : Fin (Fintype.card ↥Dc) ≃ ↥Dc := (Fintype.equivFin ↥Dc).symm
+  -- Every piece receives an inner-product-preserving intertwiner from the base piece.
+  have key : ∀ q : ↥Dc, ∃ u : Module.End ℂ (EuclideanSpace ℂ n),
+      S.IsIntertwiner p₀ q.1 u ∧ Submodule.map u p₀ = q.1 ∧
+        ∀ x ∈ p₀, ∀ y ∈ p₀, ⟪u x, u y⟫_ℂ = ⟪x, y⟫_ℂ := by
+    rintro ⟨q, hq⟩
+    rcases eq_or_ne p₀ q with rfl | hpq
+    · exact S.exists_isometry_intertwiner_of_sameIsotype hp₀irr hp₀irr (S.sameIsotype_refl hp₀irr)
+    · exact S.exists_isometry_intertwiner_of_sameIsotype hp₀irr (hirr q hq) (hsame hp₀ hq hpq)
+  choose u hu_int hu_map hu_inner using key
+  -- The adapted family: the basis of the base piece, spread to each copy.
+  set f : Fin (Fintype.card ↥Dc) × Fin (Module.finrank ℂ p₀) → EuclideanSpace ℂ n :=
+    fun ij => u (σ ij.1) (e ij.2 : EuclideanSpace ℂ n)
+  have hmem : ∀ i j, f (i, j) ∈ (σ i : Submodule ℂ (EuclideanSpace ℂ n)) := fun i j =>
+    hu_map (σ i) ▸ Submodule.mem_map_of_mem (e j).2
+  -- Orthonormality: within a copy by the isometry, across copies by orthogonality.
+  have hf_on : Orthonormal ℂ f := by
+    rw [orthonormal_iff_ite]
+    rintro ⟨i, j⟩ ⟨i', j'⟩
+    rcases eq_or_ne i i' with rfl | hii
+    · have h1 : ⟪f (i, j), f (i, j')⟫_ℂ =
+          ⟪(e j : EuclideanSpace ℂ n), (e j' : EuclideanSpace ℂ n)⟫_ℂ :=
+        hu_inner (σ i) _ (e j).2 _ (e j').2
+      rw [h1, ← Submodule.coe_inner, orthonormal_iff_ite.mp e.orthonormal j j']
+      simp [Prod.ext_iff]
+    · have hqq : (σ i : Submodule ℂ (EuclideanSpace ℂ n)) ≠ ↑(σ i') := fun h =>
+        hii (σ.injective (Subtype.ext h))
+      rw [(hortho (σ i).2 (σ i').2 hqq).inner_eq (hmem i j) (hmem i' j')]
+      simp [Prod.ext_iff, hii]
+  -- The base basis spans the base piece, so each spread copy spans its piece.
+  have hspan₀ : Submodule.span ℂ (Set.range fun j => (e j : EuclideanSpace ℂ n)) = p₀ := by
+    have h1 := congrArg (Submodule.map p₀.subtype) e.toBasis.span_eq
+    rwa [Submodule.map_span, Submodule.map_top, Submodule.range_subtype, ← Set.range_comp] at h1
+  have hspan_copy : ∀ i, Submodule.span ℂ (Set.range fun j => f (i, j)) =
+      (σ i : Submodule ℂ (EuclideanSpace ℂ n)) := by
+    intro i
+    have h1 := congrArg (Submodule.map (u (σ i))) hspan₀
+    rw [Submodule.map_span, ← Set.range_comp, hu_map (σ i)] at h1
+    exact h1
+  refine ⟨Module.finrank ℂ p₀, Fintype.card ↥Dc, f, ?_, ?_, hf_on, ?_, ?_⟩
+  · -- The number of copies is the number of pieces of the family.
+    rw [← Nat.card_coe_set_eq, Nat.card_eq_fintype_card]
+  · -- Every piece has the dimension of the base piece: it is spanned by an orthonormal family
+    -- of that many vectors.
+    intro q hq
+    have hsub : Orthonormal ℂ fun j => f (σ.symm ⟨q, hq⟩, j) :=
+      hf_on.comp (fun j => (σ.symm ⟨q, hq⟩, j)) fun a b hab => (Prod.ext_iff.mp hab).2
+    have hcopy := hspan_copy (σ.symm ⟨q, hq⟩)
+    rw [Equiv.apply_symm_apply] at hcopy
+    have h2 := finrank_span_eq_card hsub.linearIndependent
+    rw [hcopy] at h2
+    simpa using h2
+  · -- The copies together span the whole component.
+    refine le_antisymm ?_ (sSup_le fun q hq => ?_)
+    · rw [Submodule.span_le]
+      rintro x ⟨⟨i, j⟩, rfl⟩
+      exact le_sSup (σ i).2 (hmem i j)
+    · have hcopy := hspan_copy (σ.symm ⟨q, hq⟩)
+      rw [Equiv.apply_symm_apply] at hcopy
+      exact hcopy.symm.le.trans
+        (Submodule.span_mono (Set.range_comp_subset_range (fun j => (σ.symm ⟨q, hq⟩, j)) f))
+  · -- The action: one matrix on the irreducible index, identically across the copies.
+    intro A hA
+    refine ⟨Matrix.of fun j' j => ⟪(e j' : EuclideanSpace ℂ n),
+      Matrix.toEuclideanLin A (e j : EuclideanSpace ℂ n)⟫_ℂ, fun i j => ?_⟩
+    have hAe : Matrix.toEuclideanLin A (e j : EuclideanSpace ℂ n) ∈ p₀ :=
+      (Module.End.mem_invtSubmodule_iff_forall_mem_of_mem
+        (f := Matrix.toEuclideanLin A)).mp (hp₀irr.1 A hA) _ (e j).2
+    have hcomm := (hu_int (σ i)).2 A hA (e j : EuclideanSpace ℂ n) (e j).2
+    -- Expand the image of the base basis vector in the base basis and spread by the
+    -- intertwiner.
+    have happ := congrArg ((u (σ i)).comp p₀.subtype)
+      (e.sum_repr' (⟨Matrix.toEuclideanLin A (e j : EuclideanSpace ℂ n), hAe⟩ : ↥p₀))
+    rw [map_sum] at happ
+    simp only [LinearMap.comp_apply, Submodule.subtype_apply, map_smul] at happ
+    calc Matrix.toEuclideanLin A (f (i, j))
+        = u (σ i) (Matrix.toEuclideanLin A (e j : EuclideanSpace ℂ n)) := hcomm.symm
+      _ = ∑ j', ⟪e j', (⟨Matrix.toEuclideanLin A (e j : EuclideanSpace ℂ n), hAe⟩ : ↥p₀)⟫_ℂ •
+            u (σ i) (e j' : EuclideanSpace ℂ n) := happ.symm
+      _ = ∑ j', Matrix.of (fun j' j => ⟪(e j' : EuclideanSpace ℂ n),
+            Matrix.toEuclideanLin A (e j : EuclideanSpace ℂ n)⟫_ℂ) j' j • f (i, j') := by
+          refine Finset.sum_congr rfl fun j' _ => ?_
+          rw [Submodule.coe_inner]
+          rfl
+
+/-- **Spatial tensor factorization of the isotypic components.** For a star-subalgebra $S$ of
+complex matrices, $\mathbb{C}^{D}$ is the supremum of a finite family of pairwise orthogonal
+isotypic components, and each component carries an orthonormal basis $(f_{i,j})$, indexed by a
+multiplicity index $i \le m$ and an irreducible index $j \le d$, on which every $A \in S$ acts
+by
+$$A\,f_{i,j} = \sum_{j'} B_{j'j}\, f_{i,j'}$$
+for a matrix $B \in M_{d}(\mathbb{C})$ depending only on $A$ and the component. In the adapted
+basis the action
+of $S$ on each component is by matrices of the form $\mathbf{1}_{m} \otimes B$; these are the
+matrix-times-identity blocks of *Quantum Channels & Operations* (Wolf 2012), Theorem 6.14. -/
+theorem exists_isotypic_tensor_factorization :
+    ∃ C : Set (Submodule ℂ (EuclideanSpace ℂ n)), C.Finite ∧
+      C.Pairwise (· ⟂ ·) ∧ sSup C = ⊤ ∧
+      ∀ c ∈ C, ∃ (d m : ℕ) (f : Fin m × Fin d → EuclideanSpace ℂ n),
+        Orthonormal ℂ f ∧ Submodule.span ℂ (Set.range f) = c ∧
+        ∀ A ∈ S, ∃ B : Matrix (Fin d) (Fin d) ℂ, ∀ (i : Fin m) (j : Fin d),
+          Matrix.toEuclideanLin A (f (i, j)) = ∑ j', B j' j • f (i, j') := by
+  obtain ⟨C, hCfin, hCpair, hCsup, hC⟩ := S.exists_orthogonal_isotypic_decomposition
+  refine ⟨C, hCfin, hCpair, hCsup, fun c hc => ?_⟩
+  obtain ⟨Dc, hne, hfin, hirr, rfl, hortho, hsame⟩ := hC c hc
+  obtain ⟨d, m, f, -, -, hon, hspan, hact⟩ :=
+    S.exists_adapted_orthonormal_family_of_sameIsotype hne hfin hirr hortho hsame
+  exact ⟨d, m, f, hon, hspan, hact⟩
+
+end StarSubalgebra

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -1729,11 +1729,10 @@ $\MN{d_k} \otimes \Id_{m_k}$ of~\cite[Theorem~6.14]{Wolf2012Quantum}.
     of pairwise orthogonal subspaces of $\C^{D}$, irreducible under $S$ and pairwise of the
     same type. Write $m$ for the number of pieces of $\mathcal{D}$; all pieces share one
     dimension $d$. Then the component $C = \bigvee_{W \in \mathcal{D}} W$ has an orthonormal
-    basis $(f_{i,j})_{i \le m,\, j \le d}$ such that for every $A \in S$ there is a matrix
-    $B \in \MN{d}$ with
+    basis $(f_{i,j})_{0 \le i < m,\, 0 \le j < d}$ such that for every $A \in S$ there is a
+    matrix $B \in \MN{d}$ with, for all $i < m$ and $j < d$,
     \[
-        A\,f_{i,j} \;=\; \sum_{j'=1}^{d} B_{j'j}\, f_{i,j'}
-        \qquad (i \le m,\ j \le d).
+        A\,f_{i,j} \;=\; \sum_{j'=0}^{d-1} B_{j'j}\, f_{i,j'}.
     \]
     In the adapted basis the member $A$ acts on $C$ by the matrix $B$ on the irreducible
     index, identically across the multiplicity index; after reordering the indices this is the
@@ -1743,17 +1742,17 @@ $\MN{d_k} \otimes \Id_{m_k}$ of~\cite[Theorem~6.14]{Wolf2012Quantum}.
 \begin{proof}
     \leanok
     \uses{lem:starSubalgebra_sameIsotype_isometry, lem:starSubalgebra_sameIsotype_refl}
-    Fix a piece $W_1 \in \mathcal{D}$, of dimension $d$, with an orthonormal basis
-    $e_1, \ldots, e_d$, and enumerate $\mathcal{D} = \{W'_1, \ldots, W'_m\}$. Every piece of
-    $\mathcal{D}$ is of the same type as $W_1$, by hypothesis for the other pieces and by
-    reflexivity (Lemma~\ref{lem:starSubalgebra_sameIsotype_refl}) for $W_1$ itself, so
+    Fix a piece $W \in \mathcal{D}$, of dimension $d$, with an orthonormal basis
+    $e_0, \ldots, e_{d-1}$, and enumerate $\mathcal{D} = \{W'_0, \ldots, W'_{m-1}\}$. Every
+    piece of $\mathcal{D}$ is of the same type as $W$, by hypothesis for the other pieces and
+    by reflexivity (Lemma~\ref{lem:starSubalgebra_sameIsotype_refl}) for $W$ itself, so
     Lemma~\ref{lem:starSubalgebra_sameIsotype_isometry} provides intertwiners $u_i$ mapping
-    $W_1$ onto $W'_i$ and preserving the inner product on $W_1$. Set $f_{i,j} = u_i(e_j)$.
-    Within one copy the vectors $f_{i,1}, \ldots, f_{i,d}$ are orthonormal because $u_i$
+    $W$ onto $W'_i$ and preserving the inner product on $W$. Set $f_{i,j} = u_i(e_j)$.
+    Within one copy the vectors $f_{i,0}, \ldots, f_{i,d-1}$ are orthonormal because $u_i$
     preserves inner products; across copies they are orthogonal because distinct pieces of
-    $\mathcal{D}$ are. Since $u_i$ maps $W_1$ onto $W'_i$, the vectors of the $i$-th copy span
+    $\mathcal{D}$ are. Since $u_i$ maps $W$ onto $W'_i$, the vectors of the $i$-th copy span
     $W'_i$; in particular each $W'_i$ has dimension $d$, and all the vectors together span $C$.
-    For $A \in S$ the piece $W_1$ is invariant, so $A e_j = \sum_{j'} B_{j'j}\, e_{j'}$ with
+    For $A \in S$ the piece $W$ is invariant, so $A e_j = \sum_{j'} B_{j'j}\, e_{j'}$ with
     $B_{j'j} = \langle e_{j'}, A e_j \rangle$, and the intertwining identity gives
     \[
         A f_{i,j} = A\,u_i(e_j) = u_i(A e_j)
@@ -1770,10 +1769,10 @@ $\MN{d_k} \otimes \Id_{m_k}$ of~\cite[Theorem~6.14]{Wolf2012Quantum}.
         thm:starSubalgebra_adapted_orthonormal_basis}
     Let $S$ be a $*$-subalgebra of $\MN{D}$. Then $\C^{D}$ is the supremum of a finite family
     of pairwise orthogonal isotypic components, and each component carries an orthonormal
-    basis $(f_{i,j})$, indexed by a multiplicity index $i \le m$ and an irreducible index
-    $j \le d$, such that every $A \in S$ acts by
+    basis $(f_{i,j})$, indexed by a multiplicity index $i < m$ and an irreducible index
+    $j < d$, such that every $A \in S$ acts by
     \[
-        A\,f_{i,j} = \sum_{j'=1}^{d} B_{j'j}\, f_{i,j'}
+        A\,f_{i,j} = \sum_{j'=0}^{d-1} B_{j'j}\, f_{i,j'}
     \]
     for a matrix $B \in \MN{d}$ depending only on $A$ and the component. In the adapted bases
     the action of $S$ on each component is by matrix-times-identity blocks, the form

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -1675,8 +1675,8 @@ $\C^{D}$.
         lem:starSubalgebra_sameIsotype_trans}
     Let $S$ be a $*$-subalgebra of $\MN{D}$. Then $\C^{D}$ is the supremum of a finite family
     $\mathcal{C}$ of pairwise orthogonal subspaces, the isotypic components, and each component
-    $C \in \mathcal{C}$ is the supremum of a finite, nonempty class $\mathcal{D}_C$ of subspaces
-    irreducible under $S$ that are pairwise of the same type:
+    $C \in \mathcal{C}$ is the supremum of a finite, nonempty class $\mathcal{D}_C$ of pairwise
+    orthogonal subspaces irreducible under $S$ that are pairwise of the same type:
     \[
         C = \bigvee_{W \in \mathcal{D}_C} W.
     \]
@@ -1695,8 +1695,9 @@ $\C^{D}$.
     of pieces of $\mathcal{D}$ of the same type as $W$, and let $C_W$ be its supremum. Each piece
     lies in its own class by reflexivity
     (Lemma~\ref{lem:starSubalgebra_sameIsotype_refl}), so each class is nonempty, the classes
-    cover $\mathcal{D}$, and the components span $\C^{D}$. Two pieces of one class are of the same type with each other through
-    the representative, by symmetry and transitivity
+    cover $\mathcal{D}$, and the components span $\C^{D}$. Each class is contained in
+    $\mathcal{D}$, so its pieces are pairwise orthogonal. Two pieces of one class are of the
+    same type with each other through the representative, by symmetry and transitivity
     (Lemmas~\ref{lem:starSubalgebra_sameIsotype_symm}
     and~\ref{lem:starSubalgebra_sameIsotype_trans}). If two representatives are of the same type,
     transitivity makes their classes equal, hence their components equal; so two distinct
@@ -1710,6 +1711,85 @@ $\C^{D}$.
     hence $W \sim W'$, contradicting that $W$ and $W'$ are not of the same type. So no piece of
     $\mathcal{D}_W$ is of the same type as any piece of $\mathcal{D}_{W'}$, and the components are
     orthogonal (Lemma~\ref{lem:starSubalgebra_isOrtho_sSup_not_sameIsotype}).
+\end{proof}
+
+The pieces of one class are unitarily identified copies of a single irreducible piece. An
+orthonormal basis of one piece therefore spreads, through the inner-product-preserving
+intertwiners, to an adapted orthonormal basis of the whole component, and in this basis every
+member of $S$ acts by one matrix on the irreducible index, identically across the multiplicity
+index. This is the tensor factorization of the isotypic components behind the block form
+$\MN{d_k} \otimes \Id_{m_k}$ of~\cite[Theorem~6.14]{Wolf2012Quantum}.
+
+\begin{theorem}[Adapted orthonormal basis of an isotypic component]%
+    \label{thm:starSubalgebra_adapted_orthonormal_basis}
+    \lean{StarSubalgebra.exists_adapted_orthonormal_family_of_sameIsotype}
+    \leanok
+    \uses{def:starSubalgebra_irreducibleSubspace, def:starSubalgebra_sameIsotype}
+    Let $S$ be a $*$-subalgebra of $\MN{D}$ and let $\mathcal{D}$ be a finite, nonempty family
+    of pairwise orthogonal subspaces of $\C^{D}$, irreducible under $S$ and pairwise of the
+    same type. Write $m$ for the number of pieces of $\mathcal{D}$; all pieces share one
+    dimension $d$. Then the component $C = \bigvee_{W \in \mathcal{D}} W$ has an orthonormal
+    basis $(f_{i,j})_{i \le m,\, j \le d}$ such that for every $A \in S$ there is a matrix
+    $B \in \MN{d}$ with
+    \[
+        A\,f_{i,j} \;=\; \sum_{j'=1}^{d} B_{j'j}\, f_{i,j'}
+        \qquad (i \le m,\ j \le d).
+    \]
+    In the adapted basis the member $A$ acts on $C$ by the matrix $B$ on the irreducible
+    index, identically across the multiplicity index; after reordering the indices this is the
+    block $\MN{d} \otimes \Id_{m}$ of~\cite[Theorem~6.14]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:starSubalgebra_sameIsotype_isometry, lem:starSubalgebra_sameIsotype_refl}
+    Fix a piece $W_1 \in \mathcal{D}$, of dimension $d$, with an orthonormal basis
+    $e_1, \ldots, e_d$, and enumerate $\mathcal{D} = \{W'_1, \ldots, W'_m\}$. Every piece of
+    $\mathcal{D}$ is of the same type as $W_1$, by hypothesis for the other pieces and by
+    reflexivity (Lemma~\ref{lem:starSubalgebra_sameIsotype_refl}) for $W_1$ itself, so
+    Lemma~\ref{lem:starSubalgebra_sameIsotype_isometry} provides intertwiners $u_i$ mapping
+    $W_1$ onto $W'_i$ and preserving the inner product on $W_1$. Set $f_{i,j} = u_i(e_j)$.
+    Within one copy the vectors $f_{i,1}, \ldots, f_{i,d}$ are orthonormal because $u_i$
+    preserves inner products; across copies they are orthogonal because distinct pieces of
+    $\mathcal{D}$ are. Since $u_i$ maps $W_1$ onto $W'_i$, the vectors of the $i$-th copy span
+    $W'_i$; in particular each $W'_i$ has dimension $d$, and all the vectors together span $C$.
+    For $A \in S$ the piece $W_1$ is invariant, so $A e_j = \sum_{j'} B_{j'j}\, e_{j'}$ with
+    $B_{j'j} = \langle e_{j'}, A e_j \rangle$, and the intertwining identity gives
+    \[
+        A f_{i,j} = A\,u_i(e_j) = u_i(A e_j)
+        = \sum_{j'} B_{j'j}\, u_i(e_{j'}) = \sum_{j'} B_{j'j}\, f_{i,j'},
+    \]
+    the same matrix $B$ for every copy $i$.
+\end{proof}
+
+\begin{theorem}[Spatial tensor factorization of the isotypic components]%
+    \label{thm:starSubalgebra_isotypic_tensor_factorization}
+    \lean{StarSubalgebra.exists_isotypic_tensor_factorization}
+    \leanok
+    \uses{thm:starSubalgebra_orthogonal_isotypic_decomposition,
+        thm:starSubalgebra_adapted_orthonormal_basis}
+    Let $S$ be a $*$-subalgebra of $\MN{D}$. Then $\C^{D}$ is the supremum of a finite family
+    of pairwise orthogonal isotypic components, and each component carries an orthonormal
+    basis $(f_{i,j})$, indexed by a multiplicity index $i \le m$ and an irreducible index
+    $j \le d$, such that every $A \in S$ acts by
+    \[
+        A\,f_{i,j} = \sum_{j'=1}^{d} B_{j'j}\, f_{i,j'}
+    \]
+    for a matrix $B \in \MN{d}$ depending only on $A$ and the component. In the adapted bases
+    the action of $S$ on each component is by matrix-times-identity blocks, the form
+    $\MN{d_k} \otimes \Id_{m_k}$ of~\cite[Theorem~6.14]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:starSubalgebra_orthogonal_isotypic_decomposition,
+        thm:starSubalgebra_adapted_orthonormal_basis}
+    The isotypic-component decomposition
+    (Theorem~\ref{thm:starSubalgebra_orthogonal_isotypic_decomposition}) writes $\C^{D}$ as
+    the supremum of finitely many pairwise orthogonal components, each the supremum of a
+    finite, nonempty class of pairwise orthogonal irreducible pieces of one type. Applying
+    Theorem~\ref{thm:starSubalgebra_adapted_orthonormal_basis} to each class equips each
+    component with its adapted orthonormal basis.
 \end{proof}
 
 \begin{theorem}[Fixed-point algebra is semisimple]%


### PR DESCRIPTION
Partially addresses LionSR/QICLean#189 (step (c) of the route laid out there): the per-component spatial factorization. The remaining step (d), the single global unitary, is left to a follow-up (see the issue comment).

## Mathematical content

For a star-subalgebra $S$ of $M_D(\mathbb{C})$, each isotypic component is the span of finitely many pairwise orthogonal irreducible pieces of one type. An orthonormal basis $e_1,\ldots,e_d$ of one piece spreads to every other piece through the inner-product-preserving intertwiners of `StarSubalgebra.exists_isometry_intertwiner_of_sameIsotype` (#3591). The resulting family $f_{i,j} = u_i(e_j)$ is an adapted orthonormal basis of the component: orthonormal within a copy because $u_i$ preserves inner products, orthogonal across copies because distinct pieces are, and spanning because $u_i$ maps the base piece onto the $i$-th piece. The intertwining identity gives, for every $A \in S$,
$$A\,f_{i,j} = A\,u_i(e_j) = u_i(A\,e_j) = \sum_{j'} B_{j'j}\, f_{i,j'}, \qquad B_{j'j} = \langle e_{j'}, A\,e_j\rangle,$$
the same matrix $B$ on every copy: in the adapted basis, $A$ acts on the component as $\mathbf{1}_m \otimes B$, the matrix-times-identity block of Wolf Thm 6.14.

## New declarations (`TNLean/Algebra/StarSubalgebraIsotypicFactorization.lean`)

- `StarSubalgebra.exists_adapted_orthonormal_family_of_sameIsotype` — a finite, nonempty, pairwise orthogonal, pairwise same-type family of irreducible pieces has an adapted orthonormal family indexed by `Fin m × Fin d` spanning its supremum, with `m` the number of pieces, `d` the common dimension of the pieces, and every `A ∈ S` acting by a matrix `B : Matrix (Fin d) (Fin d) ℂ` on the second index, identically in the first.
- `StarSubalgebra.exists_isotypic_tensor_factorization` — composition with the isotypic-component decomposition (#3582): $\mathbb{C}^D$ is the supremum of finitely many pairwise orthogonal isotypic components, each carrying such an adapted basis.

## Strengthening

`StarSubalgebra.exists_orthogonal_isotypic_decomposition` now also exposes that each same-type class is pairwise orthogonal. Its proof already had this on hand (the classes are subsets of the pairwise orthogonal irreducible family); the conjunct is what the per-component factorization consumes. The blueprint entry is updated accordingly.

## Blueprint

Two new entries in `blueprint/src/chapter/ch07_spectral.tex`, placed after the isotypic-component decomposition: `thm:starSubalgebra_adapted_orthonormal_basis` and `thm:starSubalgebra_isotypic_tensor_factorization`, both with `\lean{}`/`\leanok` and full proofs in prose.

## Verification

- `lake build TNLean`: success (9279 jobs), no new warnings (the header-linter notes on the `StarSubalgebra*` family predate this PR).
- No `sorry`/`axiom` in touched files.
- `lake exe checkdecls blueprint/lean_decls`: pass.
- `python3 scripts/blueprint_lean_sync.py --ci`: blueprint and Lean in sync.
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main --ci`: no violations.
- `lake exe lint_style`, `git diff --check`: clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal mathematics in star-subalgebra representation theory; no auth, I/O, or runtime behavior changes—only new proofs and a stronger decomposition statement consumed by the factorization layer.
> 
> **Overview**
> Adds **per-isotypic-component spatial factorization** toward Wolf Thm. 6.14: on each finite same-type class of pairwise orthogonal irreducible pieces, the span admits an adapted orthonormal basis indexed by multiplicity × irreducible dimension, and every `A ∈ S` acts as the **same** matrix on the irreducible index on every copy (the **1_m ⊗ B** block picture).
> 
> New Lean module `StarSubalgebraIsotypicFactorization.lean` with `exists_adapted_orthonormal_family_of_sameIsotype` and `exists_isotypic_tensor_factorization` (latter built from the isotypic decomposition plus the adapted basis). **`exists_orthogonal_isotypic_decomposition`** is strengthened so each same-type witness class is also **pairwise orthogonal** (pulled from the irreducible family via `hDpair`). Root import and blueprint (`ch07_spectral.tex`) updated with matching theorem entries and prose; global unitary block-diagonal conjugation is explicitly left for a follow-up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e28b12582843a56d5af14a2fad76c91ee34da17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->