### PR TITLE
feat(MPS/MPDO): derive eq3 commutation from the dressed-adjoint identities

### DIFF
--- a/TNLean/MPS/CanonicalForm/NormalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/NormalCommutant.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.Algebra.ScalarCommutant
 import TNLean.Algebra.MatrixGramUnitary
 import TNLean.MPS.Defs
+import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
 import Mathlib.LinearAlgebra.Matrix.PosDef
 
 /-!
@@ -22,9 +23,15 @@ $X_{\alpha,k}^\dagger X_{\alpha,k} = \omega_{\alpha,k}
 X_{\alpha,1}^\dagger X_{\alpha,1}$, in the normalization $X_{\alpha,1} = \Id$,
 together with the isometric normalization
 $U_{\alpha,k} = \omega_{\alpha,k}^{-1/2} X_{\alpha,k}$ of lines 1906--1908.
-The derivation of the commutation hypothesis from self-adjointness of the
-sector compressions (the two displayed diagrams of lines 1909--1919) is a
-separate step.
+The commutation hypothesis arises from the two displayed diagrams of lines
+1909--1919: the first diagram, transported blockwise by Lemma L, says that the
+sector-dressed tensor equals its adjoint dressing,
+$X A^i X^{-1} = (X^{-1})^\dagger (A^i)^\dagger X^\dagger$; the second diagram
+is its Gram-conjugation form, and in the normalization $X_{\alpha,1} = \Id$ it
+becomes the commutation of $X^\dagger X$ with every matrix of the tensor.
+The passage from the first diagram to the second and onward to eq3 is proved
+below; deriving the first diagram's blockwise identity from self-adjointness
+of the sector compressions within the vertical decomposition remains open.
 
 ## Main results
 
@@ -35,6 +42,15 @@ separate step.
   tensor, then $X^\dagger X = \omega\,\Id$ with $\omega > 0$.
 * `MPSTensor.IsNormal.smul_mem_unitaryGroup_of_commute`:
   under the same hypotheses, $\omega^{-1/2}X$ is unitary.
+* `Matrix.gram_conj_eq_conjTranspose_of_dressed_adjoint` /
+  `Matrix.gram_conj_eq_gram_conj_of_dressed_adjoint` /
+  `Matrix.commute_gram_of_dressed_adjoint_of_conjTranspose_eq`:
+  the passage from the first displayed diagram to the second, and to the
+  commutation of the Gram matrix with a self-adjoint letter.
+* `MPSTensor.IsNormal.conjTranspose_mul_self_eq_smul_one_of_dressed_adjoint` /
+  `MPSTensor.IsNormal.smul_mem_unitaryGroup_of_dressed_adjoint`:
+  eq3 and its isometric normalization derived end to end from the
+  dressed-adjoint identities.
 
 ## References
 
@@ -43,6 +59,66 @@ separate step.
 -/
 
 open scoped Matrix ComplexOrder
+
+namespace Matrix
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- **From the first displayed diagram to the second** (arXiv:1606.00608,
+proof of Proposition 4.13, lines 1909--1919): if a letter dressed by an
+invertible gauge equals its adjoint dressing,
+$XBX^{-1} = (X^{-1})^\dagger B^\dagger X^\dagger$, then conjugation by the
+Gram matrix $X^\dagger X$ carries the letter to its adjoint. -/
+theorem gram_conj_eq_conjTranspose_of_dressed_adjoint
+    {X B : Matrix n n ℂ} (hX : IsUnit X.det)
+    (hdress : X * B * X⁻¹ = X⁻¹ᴴ * Bᴴ * Xᴴ) :
+    Xᴴ * X * B * (Xᴴ * X)⁻¹ = Bᴴ := by
+  have hXH : IsUnit (Xᴴ).det := by
+    rw [Matrix.det_conjTranspose]
+    exact hX.star
+  have h1 : Xᴴ * (X * B * X⁻¹) * X⁻¹ᴴ = Xᴴ * X * B * (Xᴴ * X)⁻¹ := by
+    rw [Matrix.mul_inv_rev, Matrix.conjTranspose_nonsing_inv]
+    simp only [Matrix.mul_assoc]
+  have h2 : Xᴴ * (X⁻¹ᴴ * Bᴴ * Xᴴ) * X⁻¹ᴴ = Bᴴ := by
+    rw [Matrix.conjTranspose_nonsing_inv, ← Matrix.mul_assoc, ← Matrix.mul_assoc,
+      Matrix.mul_nonsing_inv _ hXH, Matrix.one_mul, Matrix.mul_assoc,
+      Matrix.mul_nonsing_inv _ hXH, Matrix.mul_one]
+  rw [← h1, hdress, h2]
+
+/-- **The second displayed diagram** (arXiv:1606.00608, proof of Proposition
+4.13, lines 1914--1919): two gauges whose dressings both equal the adjoint
+dressing have equal Gram conjugations,
+$X^\dagger X\,B\,(X^\dagger X)^{-1} = Y^\dagger Y\,B\,(Y^\dagger Y)^{-1}$. -/
+theorem gram_conj_eq_gram_conj_of_dressed_adjoint
+    {X Y B : Matrix n n ℂ} (hX : IsUnit X.det) (hY : IsUnit Y.det)
+    (hdX : X * B * X⁻¹ = X⁻¹ᴴ * Bᴴ * Xᴴ)
+    (hdY : Y * B * Y⁻¹ = Y⁻¹ᴴ * Bᴴ * Yᴴ) :
+    Xᴴ * X * B * (Xᴴ * X)⁻¹ = Yᴴ * Y * B * (Yᴴ * Y)⁻¹ := by
+  rw [gram_conj_eq_conjTranspose_of_dressed_adjoint hX hdX,
+    gram_conj_eq_conjTranspose_of_dressed_adjoint hY hdY]
+
+/-- **The second diagram in the normalization $X_{\alpha,1} = \Id$**
+(arXiv:1606.00608, proof of Proposition 4.13, lines 1909--1919): for a
+self-adjoint letter, the dressed-adjoint identity makes the Gram matrix
+$X^\dagger X$ commute with the letter.  Self-adjointness of the letter is the
+first diagram for the sector $k = 1$ with $X_{\alpha,1} = \Id$. -/
+theorem commute_gram_of_dressed_adjoint_of_conjTranspose_eq
+    {X B : Matrix n n ℂ} (hX : IsUnit X.det)
+    (hdress : X * B * X⁻¹ = X⁻¹ᴴ * Bᴴ * Xᴴ) (hB : Bᴴ = B) :
+    Xᴴ * X * B = B * (Xᴴ * X) := by
+  have hG : IsUnit (Xᴴ * X).det := by
+    rw [Matrix.det_mul, Matrix.det_conjTranspose]
+    exact hX.star.mul hX
+  have h := gram_conj_eq_conjTranspose_of_dressed_adjoint hX hdress
+  rw [hB] at h
+  calc
+    Xᴴ * X * B = Xᴴ * X * B * ((Xᴴ * X)⁻¹ * (Xᴴ * X)) := by
+      rw [Matrix.nonsing_inv_mul _ hG, Matrix.mul_one]
+    _ = Xᴴ * X * B * (Xᴴ * X)⁻¹ * (Xᴴ * X) := by
+      simp only [Matrix.mul_assoc]
+    _ = B * (Xᴴ * X) := by rw [h]
+
+end Matrix
 
 namespace MPSTensor
 
@@ -117,5 +193,35 @@ theorem IsNormal.smul_mem_unitaryGroup_of_commute
   obtain ⟨ω, hω, hXX⟩ := hA.conjTranspose_mul_self_eq_smul_one_of_commute hX hcomm
   exact ⟨ω, hω,
     Matrix.smul_mem_unitaryGroup_of_conjTranspose_mul_self_eq_smul_one hω hXX⟩
+
+/-- **Equation eq3:proof.IV.12 from the dressed-adjoint identities.**  If the
+gauge-dressed letters of a normal tensor equal their adjoint dressings (the
+first displayed diagram of arXiv:1606.00608, proof of Proposition 4.13, lines
+1909--1913, transported blockwise by Lemma L) and the letters are self-adjoint
+(the same identity for the sector $k = 1$ in the normalization
+$X_{\alpha,1} = \Id$), then $X^\dagger X = \omega\,\Id$ for a necessarily
+positive constant $\omega$. -/
+theorem IsNormal.conjTranspose_mul_self_eq_smul_one_of_dressed_adjoint
+    {A : MPSTensor d D} (hA : IsNormal A)
+    {X : Matrix (Fin D) (Fin D) ℂ} (hX : IsUnit X.det) (hX0 : X ≠ 0)
+    (hdress : ∀ i, X * A i * X⁻¹ = X⁻¹ᴴ * (A i)ᴴ * Xᴴ)
+    (hsa : ∀ i, (A i)ᴴ = A i) :
+    ∃ ω : ℝ, 0 < ω ∧ Xᴴ * X = (ω : ℂ) • 1 :=
+  hA.conjTranspose_mul_self_eq_smul_one_of_commute hX0 fun i =>
+    Matrix.commute_gram_of_dressed_adjoint_of_conjTranspose_eq hX (hdress i) (hsa i)
+
+/-- **The isometric normalization from the dressed-adjoint identities**
+(arXiv:1606.00608, proof of Proposition 4.13, lines 1906--1908 and
+1909--1919): under the hypotheses of the preceding theorem,
+$\omega^{-1/2}X$ is unitary. -/
+theorem IsNormal.smul_mem_unitaryGroup_of_dressed_adjoint
+    {A : MPSTensor d D} (hA : IsNormal A)
+    {X : Matrix (Fin D) (Fin D) ℂ} (hX : IsUnit X.det) (hX0 : X ≠ 0)
+    (hdress : ∀ i, X * A i * X⁻¹ = X⁻¹ᴴ * (A i)ᴴ * Xᴴ)
+    (hsa : ∀ i, (A i)ᴴ = A i) :
+    ∃ ω : ℝ, 0 < ω ∧
+      ((Real.sqrt ω : ℂ))⁻¹ • X ∈ Matrix.unitaryGroup (Fin D) ℂ :=
+  hA.smul_mem_unitaryGroup_of_commute hX0 fun i =>
+    Matrix.commute_gram_of_dressed_adjoint_of_conjTranspose_eq hX (hdress i) (hsa i)
 
 end MPSTensor

--- a/TNLean/MPS/MPDO/Defs.lean
+++ b/TNLean/MPS/MPDO/Defs.lean
@@ -33,6 +33,8 @@ Verstraete):
 * `MPOTensor.transferMap`: the MPO transfer map
   `E_M(X) = ∑_{i,j} M^{ij} X (M^{ij})†`.
 * `MPOTensor.IsHermitian`: local hermiticity predicate on the tensor.
+* `MPOTensor.adjointTensor`: the adjoint tensor `(M†)^{ij} = (M^{ji})†`, which
+  generates the adjoint operator family up to spatial reflection.
 * `MPOTensor.IsMPDO`: global positivity predicate.
 * `MPOTensor.IsLPDO`: local purification predicate.
 * `MPOTensor.IsRFP`: renormalization fixed-point predicate.
@@ -173,6 +175,83 @@ noncomputable def mpo (M : MPOTensor d D) (N : ℕ) :
 def IsHermitian (M : MPOTensor d D) : Prop :=
   ∀ i j : Fin d, M i j = (M j i)ᴴ
 
+/-! ### The adjoint tensor -/
+
+/-- The **adjoint tensor** $M^\dagger$: exchange the ket and bra physical
+indices and take the conjugate transpose of each virtual matrix,
+$(M^\dagger)^{ij} = (M^{ji})^\dagger$.  Site by site this is the dagger of
+the generated operator family; the $\dagger$-marked tensors in the first
+displayed diagram of the proof of Proposition 4.13 of arXiv:1606.00608,
+lines 1909--1913, are of this form. -/
+def adjointTensor (M : MPOTensor d D) : MPOTensor d D :=
+  fun i j => (M j i)ᴴ
+
+@[simp] lemma adjointTensor_apply (M : MPOTensor d D) (i j : Fin d) :
+    adjointTensor M i j = (M j i)ᴴ := rfl
+
+/-- A tensor equals its adjoint tensor precisely when it is Hermitian. -/
+lemma adjointTensor_eq_iff_isHermitian (M : MPOTensor d D) :
+    adjointTensor M = M ↔ IsHermitian M := by
+  constructor
+  · intro h i j
+    exact (congrFun (congrFun h i) j).symm
+  · intro h
+    funext i j
+    exact (h i j).symm
+
+/-- Word evaluation of the adjoint tensor: for equal-length words it is the
+conjugate transpose of the original word evaluation on the reversed words
+with ket and bra exchanged. -/
+theorem evalWord_adjointTensor (M : MPOTensor d D) :
+    ∀ σs τs : List (Fin d), σs.length = τs.length →
+      evalWord (adjointTensor M) σs τs = (evalWord M τs.reverse σs.reverse)ᴴ := by
+  intro σs
+  induction σs with
+  | nil =>
+      intro τs h
+      rw [List.length_nil, eq_comm, List.length_eq_zero_iff] at h
+      subst h
+      simp only [List.reverse_nil, evalWord_nil, Matrix.conjTranspose_one]
+  | cons i is ih =>
+      intro τs h
+      cases τs with
+      | nil => simp at h
+      | cons j js =>
+          have hlen : is.length = js.length := by simpa using h
+          simp only [evalWord_cons, adjointTensor_apply, List.reverse_cons]
+          rw [ih js hlen,
+            evalWord_append M js.reverse is.reverse [j] [i]
+              (by simp only [List.length_reverse]; exact hlen.symm),
+            evalWord_cons, evalWord_nil, Matrix.mul_one, Matrix.conjTranspose_mul]
+
+/-- Reading a configuration through the index reversal `Fin.rev` reverses the
+associated word. -/
+private theorem ofFn_comp_rev {α : Type*} {N : ℕ} (σ : Fin N → α) :
+    List.ofFn (fun k => σ (Fin.rev k)) = (List.ofFn σ).reverse := by
+  apply List.ext_getElem
+  · simp
+  · intro k h1 h2
+    simp only [List.length_ofFn] at h1
+    rw [List.getElem_ofFn, List.getElem_reverse, List.getElem_ofFn]
+    congr 1
+    ext
+    simp only [Fin.val_rev, List.length_ofFn]
+    omega
+
+/-- The adjoint tensor generates the adjoint operator family up to spatial
+reflection: entrywise,
+$H^{(N)}(M^\dagger)_{\sigma\tau}
+= \overline{H^{(N)}(M)_{\tau\circ\mathrm{rev},\,\sigma\circ\mathrm{rev}}}$,
+where $\mathrm{rev}$ reverses the site order.  This identifies the
+$\dagger$-marked chain in the first displayed diagram of the proof of
+Proposition 4.13 of arXiv:1606.00608, lines 1909--1913. -/
+theorem mpo_adjointTensor (M : MPOTensor d D) {N : ℕ} (σ τ : Fin N → Fin d) :
+    mpo (adjointTensor M) N σ τ =
+      star (mpo M N (fun k => τ (Fin.rev k)) (fun k => σ (Fin.rev k))) := by
+  simp only [mpo_apply, mpoMatrixEntry]
+  rw [evalWord_adjointTensor M _ _ (by simp), ← Matrix.trace_conjTranspose,
+    ofFn_comp_rev, ofFn_comp_rev]
+
 /-! ### Transfer map -/
 
 /-- The **MPO transfer map** associated to an MPO tensor `M`:
@@ -211,6 +290,28 @@ it generates positive semidefinite operators for all system sizes:
 See arXiv:1606.00608, Section 4. -/
 def IsMPDO (M : MPOTensor d D) : Prop :=
   ∀ N : ℕ, (mpo M N).PosSemidef
+
+/-- For an MPDO, Hermiticity of the density operators removes the conjugation:
+the adjoint tensor generates the spatially reflected density operators. -/
+theorem IsMPDO.mpo_adjointTensor_eq {M : MPOTensor d D} (hM : IsMPDO M)
+    {N : ℕ} (σ τ : Fin N → Fin d) :
+    mpo (adjointTensor M) N σ τ =
+      mpo M N (fun k => σ (Fin.rev k)) (fun k => τ (Fin.rev k)) := by
+  rw [mpo_adjointTensor]
+  exact (hM N).isHermitian.apply _ _
+
+/-- The adjoint tensor of an MPDO is again an MPDO: its density operators are
+spatial reflections of positive semidefinite operators. -/
+theorem IsMPDO.adjointTensor {M : MPOTensor d D} (hM : IsMPDO M) :
+    IsMPDO (MPOTensor.adjointTensor M) := by
+  intro N
+  have href : mpo (MPOTensor.adjointTensor M) N =
+      (mpo M N).submatrix (fun σ k => σ (Fin.rev k)) (fun τ k => τ (Fin.rev k)) := by
+    ext σ τ
+    rw [hM.mpo_adjointTensor_eq]
+    rfl
+  rw [href]
+  exact (hM N).submatrix _
 
 /-! ### LPDO: local purification -/
 

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -501,6 +501,66 @@
     Gram matrix the identity.
 \end{proof}
 
+\begin{theorem}[Gram conjugation from the adjoint dressing]
+    \label{thm:gram_conj_of_dressed_adjoint}
+    \lean{Matrix.gram_conj_eq_conjTranspose_of_dressed_adjoint}
+    \lean{Matrix.gram_conj_eq_gram_conj_of_dressed_adjoint}
+    \lean{Matrix.commute_gram_of_dressed_adjoint_of_conjTranspose_eq}
+    \leanok
+    Let $X$ be invertible and let $B$ satisfy the dressed-adjoint identity
+    \[
+        XBX^{-1} = (X^{-1})^\dagger B^\dagger X^\dagger.
+    \]
+    Then conjugation by the Gram matrix carries $B$ to its adjoint,
+    \[
+        (X^\dagger X)\,B\,(X^\dagger X)^{-1} = B^\dagger,
+    \]
+    so any two gauges satisfying the identity have equal Gram conjugations,
+    and if moreover $B^\dagger = B$ then $X^\dagger X$ commutes with $B$.
+    Applied to the letters of a vertical sector, the first display is the
+    blockwise form of the first diagram in the proof of
+    \cite[Proposition~4.13]{Cirac2016MPDO_arXiv}, the second is the second
+    diagram, and the commutation is its form in the normalization
+    $X_{\alpha,1}=\Id$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Multiply the dressed-adjoint identity by $X^\dagger$ on the left and by
+    $(X^{-1})^\dagger$ on the right.  The left side becomes
+    $(X^\dagger X)B(X^\dagger X)^{-1}$ and the right side collapses to
+    $B^\dagger$.  If $B^\dagger = B$, multiplying the resulting identity by
+    $X^\dagger X$ on the right gives the commutation.
+\end{proof}
+
+\begin{theorem}[Equation eq3 from the dressed-adjoint identities]
+    \label{thm:eq3_of_dressed_adjoint}
+    \lean{MPSTensor.IsNormal.conjTranspose_mul_self_eq_smul_one_of_dressed_adjoint}
+    \lean{MPSTensor.IsNormal.smul_mem_unitaryGroup_of_dressed_adjoint}
+    \leanok
+    \uses{def:normal, thm:gram_conj_of_dressed_adjoint,
+        thm:normal_tensor_gram_rigidity}
+    Let $M_\alpha$ be a normal tensor with self-adjoint letters and let
+    $X \ne 0$ be invertible with
+    $XM_\alpha^iX^{-1} = (X^{-1})^\dagger (M_\alpha^i)^\dagger X^\dagger$
+    for every letter.  Then $X^\dagger X = \omega\,\Id$ for a necessarily
+    positive constant $\omega$, and $\omega^{-1/2}X$ is unitary.  The
+    hypotheses are the blockwise identities produced by Lemma L from the
+    first diagram in the proof of
+    \cite[Proposition~4.13]{Cirac2016MPDO_arXiv}, for the sectors $k$ and
+    $1$ in the normalization $X_{\alpha,1}=\Id$; the conclusion is
+    equation eq3 with its isometric normalization.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:gram_conj_of_dressed_adjoint, thm:normal_tensor_gram_rigidity}
+    By Theorem~\ref{thm:gram_conj_of_dressed_adjoint} the Gram matrix
+    $X^\dagger X$ commutes with every letter of $M_\alpha$.
+    Theorem~\ref{thm:normal_tensor_gram_rigidity} then makes it a positive
+    multiple of the identity and normalizes $X$ to a unitary.
+\end{proof}
+
 \begin{lemma}[Matrix product vector of the diagonal tensor]
     \label{lem:mpv_diagonal_tensor}
     \lean{MPOTensor.mpv_diagonalTensor}
@@ -851,6 +911,9 @@
         thm:psd_commute_of_commute_pow,
         thm:mpdo_sector_compression_trace_pos,
         thm:normal_tensor_gram_rigidity,
+        thm:mpo_adjoint_reflection,
+        thm:gram_conj_of_dressed_adjoint,
+        thm:eq3_of_dressed_adjoint,
         lem:mpv_diagonal_tensor,
         lem:mpv_diagonal_tensor_eq_blocks, lem:mpv_diagonal_tensor_nonneg,
         lem:mpv_vertical_assembled,
@@ -867,6 +930,9 @@
         thm:psd_commute_of_commute_pow,
         thm:mpdo_sector_compression_trace_pos,
         thm:normal_tensor_gram_rigidity,
+        thm:mpo_adjoint_reflection,
+        thm:gram_conj_of_dressed_adjoint,
+        thm:eq3_of_dressed_adjoint,
         lem:mpv_diagonal_tensor,
         lem:vertical_grouping_equiv}
     Theorem~\ref{thm:blockwise_one_sub_mp_zero} shows
@@ -900,10 +966,10 @@
     $\omega_{\alpha j}>0$ and makes the similarities between grouped sectors
     unitary: Theorem~\ref{thm:mpdo_sector_compression_trace_pos} gives the
     positive traces of the nonzero sector compressions, and
-    Theorem~\ref{thm:normal_tensor_gram_rigidity} turns the Gram matrices of
-    the sector gauges into positive multiples of the identity, whose
-    normalizations are the required unitaries.  Deriving the commutation
-    hypothesis of the rigidity theorem from self-adjointness of the sector
-    compressions remains open, as does the construction of the vertical
-    canonical decomposition itself.
+    Theorem~\ref{thm:eq3_of_dressed_adjoint} derives equation eq3 and the
+    isometric normalization of the sector gauges from the blockwise
+    dressed-adjoint identities of the two displayed diagrams.  Deriving those
+    identities from self-adjointness of the sector compressions via Lemma L
+    within the vertical decomposition remains open, as does the construction
+    of the vertical canonical decomposition itself.
 \end{proof}

--- a/blueprint/src/chapter/ch20_mpdo_foundations.tex
+++ b/blueprint/src/chapter/ch20_mpdo_foundations.tex
@@ -165,6 +165,53 @@ legs cyclically and taking the resulting trace.
     \]
 \end{definition}
 
+\begin{definition}[Adjoint MPO tensor]\label{def:mpo_adjoint_tensor}
+    \lean{MPOTensor.adjointTensor}
+    \lean{MPOTensor.adjointTensor_eq_iff_isHermitian}
+    \leanok
+    \uses{def:mpo_tensor, def:mpo_hermitian}
+    The \emph{adjoint tensor} $M^\dagger$ of an MPO tensor $M$ exchanges the
+    ket and bra physical indices and conjugate-transposes each virtual
+    matrix:
+    \[
+        (M^\dagger)^{ij} = (M^{ji})^\dagger.
+    \]
+    A tensor equals its adjoint tensor precisely when it is Hermitian.
+\end{definition}
+
+\begin{theorem}[Reflection identity for the adjoint tensor]
+    \label{thm:mpo_adjoint_reflection}
+    \lean{MPOTensor.evalWord_adjointTensor}
+    \lean{MPOTensor.mpo_adjointTensor}
+    \lean{MPOTensor.IsMPDO.mpo_adjointTensor_eq}
+    \lean{MPOTensor.IsMPDO.adjointTensor}
+    \leanok
+    \uses{def:mpo_adjoint_tensor, def:mpo_family, def:mpdo}
+    The adjoint tensor generates the adjoint operator family up to spatial
+    reflection: entrywise,
+    \[
+        \rho^{(N)}(M^\dagger)_{\sigma\tau}
+        = \overline{\rho^{(N)}(M)_{\tau\circ\mathrm{rev},\,
+          \sigma\circ\mathrm{rev}}},
+    \]
+    where $\mathrm{rev}$ reverses the site order.  For an MPDO the
+    conjugation disappears, $\rho^{(N)}(M^\dagger)_{\sigma\tau}
+    = \rho^{(N)}(M)_{\sigma\circ\mathrm{rev},\,\tau\circ\mathrm{rev}}$,
+    and the adjoint tensor is again an MPDO.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Word evaluation of the adjoint tensor conjugate-transposes the evaluation
+    of the reversed words with ket and bra exchanged, since the conjugate
+    transpose of a product reverses the factors.  Taking traces gives the
+    entrywise identity.  For an MPDO the density operators are Hermitian, so
+    the complex conjugate of the $(\tau\circ\mathrm{rev},
+    \sigma\circ\mathrm{rev})$ entry is the $(\sigma\circ\mathrm{rev},
+    \tau\circ\mathrm{rev})$ entry; positive semidefiniteness is preserved
+    under the simultaneous relabeling of rows and columns by the reflection.
+\end{proof}
+
 \section{Transfer maps}
 
 \begin{definition}[MPO transfer map]\label{def:mpo_transfer_map}


### PR DESCRIPTION
Partially addresses #3674.

Formalizes the algebraic content of the two displayed diagrams in the proof of Proposition 4.13 (arXiv:1606.00608, `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 1909–1919), so that equation eq3:proof.IV.12 now chains end to end from the diagram identities into the Gram-rigidity theorem merged in #3703.

## The adjoint tensor (first diagram's dagger-marked chain, lines 1909–1913)

New in `TNLean/MPS/MPDO/Defs.lean`:

- `MPOTensor.adjointTensor` — $(M^\dagger)^{ij} = (M^{ji})^\dagger$, with `adjointTensor_eq_iff_isHermitian`.
- `MPOTensor.evalWord_adjointTensor` — word evaluation of $M^\dagger$ is the conjugate transpose of the evaluation of the reversed words with ket and bra exchanged.
- `MPOTensor.mpo_adjointTensor` — entrywise, $\rho^{(N)}(M^\dagger)_{\sigma\tau} = \overline{\rho^{(N)}(M)_{\tau\circ\mathrm{rev},\,\sigma\circ\mathrm{rev}}}$ (spatial reflection).
- `MPOTensor.IsMPDO.mpo_adjointTensor_eq`, `MPOTensor.IsMPDO.adjointTensor` — for an MPDO the conjugation disappears, and the adjoint tensor is again an MPDO.

## Dressed-adjoint algebra (first diagram to second diagram, lines 1909–1919)

New in `TNLean/MPS/CanonicalForm/NormalCommutant.lean`:

- `Matrix.gram_conj_eq_conjTranspose_of_dressed_adjoint` — from $XBX^{-1} = (X^{-1})^\dagger B^\dagger X^\dagger$ (the blockwise form of the first diagram) derive $(X^\dagger X)B(X^\dagger X)^{-1} = B^\dagger$.
- `Matrix.gram_conj_eq_gram_conj_of_dressed_adjoint` — the second diagram: two such gauges have equal Gram conjugations.
- `Matrix.commute_gram_of_dressed_adjoint_of_conjTranspose_eq` — for self-adjoint $B$ (the sector $k=1$ identity in the normalization $X_{\alpha,1}=\mathrm{Id}$), $X^\dagger X$ commutes with $B$ — exactly the commutation hypothesis of the merged rigidity theorem.

## End-to-end eq3

- `MPSTensor.IsNormal.conjTranspose_mul_self_eq_smul_one_of_dressed_adjoint` and `MPSTensor.IsNormal.smul_mem_unitaryGroup_of_dressed_adjoint` — for a normal tensor with self-adjoint letters and a nonzero invertible gauge satisfying the dressed-adjoint identities, $X^\dagger X = \omega\,\mathrm{Id}$ with $\omega > 0$, and $\omega^{-1/2}X$ is unitary.

## Blueprint

`def:mpo_adjoint_tensor` and `thm:mpo_adjoint_reflection` in the foundations chapter; `thm:gram_conj_of_dressed_adjoint` and `thm:eq3_of_dressed_adjoint` in the canonical-forms chapter, all `\leanok`. The capstone `thm:vertical_cf_of_horizontal_cf` gains the new entries in its `\uses` and stays `\notready`.

## Remaining for #3674

- Derive the blockwise dressed-adjoint identities themselves from self-adjointness of the sector compressions via Lemma L within the vertical decomposition (this needs the sector-embedding data of the decomposition).
- Construct the vertical canonical decomposition $\bigoplus_{\alpha,k}\mu_{\alpha,k}X_{\alpha,k}M_\alpha X_{\alpha,k}^{-1}$ and its BNT grouping.
- The trace identity $\tr(P_{\alpha,k}H^{(N)}P_{\alpha,k}) = \mu_{\alpha,k}d_\alpha$ and the final assembly $U\tilde MU^\dagger = \bigoplus_\alpha\mu_\alpha\otimes M_\alpha$.

## Verification

- `lake build TNLean` succeeds (9279 jobs); no `sorry`/`axiom` in changed files.
- `lake exe checkdecls blueprint/lean_decls` passes.
- `python3 scripts/blueprint_lean_sync.py --ci` passes.
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main` passes.
- `lake exe lint_style` passes; `git diff --check` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Lean and blueprint formalization with no runtime or security surface; remaining proof gaps are explicitly documented.
> 
> **Overview**
> Formalizes the algebra behind the two displayed diagrams in Proposition 4.13 (arXiv:1606.00608): **eq3** and unitary gauge normalization now follow from dressed-adjoint hypotheses instead of assuming Gram–letter commutation outright.
> 
> **MPO adjoint tensor** (`MPOTensor.adjointTensor`): swaps ket/bra and conjugate-transposes virtual matrices; proves word/MPO reflection identities and that MPDO is preserved under adjunction.
> 
> **Dressed-adjoint → Gram** (`NormalCommutant.lean`): new `Matrix.gram_conj_*` and `commute_gram_of_dressed_adjoint_*` lemmas link the first diagram identity to Gram conjugation and, for self-adjoint letters, to `X†X` commuting with each tensor letter.
> 
> **End-to-end eq3**: `IsNormal.conjTranspose_mul_self_eq_smul_one_of_dressed_adjoint` and `smul_mem_unitaryGroup_of_dressed_adjoint` compose those lemmas with the existing normal-tensor Gram rigidity.
> 
> Blueprint adds `def:mpo_adjoint_tensor`, `thm:mpo_adjoint_reflection`, `thm:gram_conj_of_dressed_adjoint`, and `thm:eq3_of_dressed_adjoint`; the vertical CF capstone proof text now cites eq3 from dressed-adjoint data while still marking derivation of those identities from sector compressions as open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a9b04704950855e43db2ef87ef13ec6301550a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->