### PR TITLE
refactor(MPS): restructure tangled MPO and RFP proofs

### DIFF
--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -445,14 +445,14 @@ end AlgebraStructureData
 /-- One-site peeling of the blocked transfer map, $\mathbb{E}^{n+1} = \mathbb{E}^n \circ
 \mathbb{E}$, used in the spectral fixed-point calculation of arXiv:1606.00608,
 Appendix C.4, lines 2046--2085 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
-theorem blockedTransferMap_succ (M : MPOTensor d D) (n : ℕ) :
+private theorem blockedTransferMap_succ (M : MPOTensor d D) (n : ℕ) :
     blockedTransferMap M (n + 1) = blockedTransferMap M n ∘ₗ transferMap M := by
   simp only [blockedTransferMap_eq_pow, pow_succ, Module.End.mul_eq_comp]
 
 /-- Adjoint form of the one-site peeling: the adjoint of the blocked transfer map at
 size `n + 1` is the adjoint one-site transfer map applied after the adjoint blocked
 transfer map at size `n`. -/
-theorem adjoint_blockedTransferMap_succ_apply (M : MPOTensor d D) (n : ℕ) (X : Mat) :
+private theorem adjoint_blockedTransferMap_succ_apply (M : MPOTensor d D) (n : ℕ) (X : Mat) :
     (blockedTransferMap M (n + 1)).adjoint X =
       (transferMap M).adjoint ((blockedTransferMap M n).adjoint X) := by
   rw [blockedTransferMap_succ, LinearMap.adjoint_comp, LinearMap.comp_apply]

--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -442,6 +442,21 @@ noncomputable def blockedInclusionCoefficients
 
 end AlgebraStructureData
 
+/-- One-site peeling of the blocked transfer map, $\mathbb{E}^{n+1} = \mathbb{E}^n \circ
+\mathbb{E}$, used in the spectral fixed-point calculation of arXiv:1606.00608,
+Appendix C.4, lines 2046--2085 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem blockedTransferMap_succ (M : MPOTensor d D) (n : ℕ) :
+    blockedTransferMap M (n + 1) = blockedTransferMap M n ∘ₗ transferMap M := by
+  simp only [blockedTransferMap_eq_pow, pow_succ, Module.End.mul_eq_comp]
+
+/-- Adjoint form of the one-site peeling: the adjoint of the blocked transfer map at
+size `n + 1` is the adjoint one-site transfer map applied after the adjoint blocked
+transfer map at size `n`. -/
+theorem adjoint_blockedTransferMap_succ_apply (M : MPOTensor d D) (n : ℕ) (X : Mat) :
+    (blockedTransferMap M (n + 1)).adjoint X =
+      (transferMap M).adjoint ((blockedTransferMap M n).adjoint X) := by
+  rw [blockedTransferMap_succ, LinearMap.adjoint_comp, LinearMap.comp_apply]
+
 /-- The algebra-structure RFP predicate forces every adjoint fixed point of the
 blocked transfer map to be an adjoint fixed point of the unblocked transfer
 map.
@@ -475,13 +490,7 @@ theorem adjoint_transferMap_apply_of_isRFP_MPDO_via_algebra
     exact (data.iota n ⟨X, hXn⟩).property
   have hXsucFix : (blockedTransferMap M (n + 1)).adjoint X = X :=
     (hCompat (n + 1) (Nat.succ_pos n) X).1 hXsuc
-  have hPow : blockedTransferMap M (n + 1) =
-      blockedTransferMap M n ∘ₗ transferMap M := by
-    simp only [blockedTransferMap_eq_pow, pow_succ, Module.End.mul_eq_comp]
-  have hAdj : (blockedTransferMap M (n + 1)).adjoint X =
-      (transferMap M).adjoint X := by
-    rw [hPow, LinearMap.adjoint_comp, LinearMap.comp_apply, hX]
-  rw [hAdj] at hXsucFix
+  rw [adjoint_blockedTransferMap_succ_apply, hX] at hXsucFix
   exact hXsucFix
 
 /-- Reverse inclusion for the adjoint fixed-point comparison: any adjoint fixed
@@ -502,10 +511,7 @@ theorem adjoint_blockedTransferMap_apply_of_adjoint_transferMap_apply
   | zero =>
       simp [blockedTransferMap_eq_pow, Module.End.one_eq_id]
   | succ k ih =>
-      have hPow : blockedTransferMap M (k + 1) =
-          blockedTransferMap M k ∘ₗ transferMap M := by
-        simp only [blockedTransferMap_eq_pow, pow_succ, Module.End.mul_eq_comp]
-      rw [hPow, LinearMap.adjoint_comp, LinearMap.comp_apply, ih, hX]
+      rw [adjoint_blockedTransferMap_succ_apply, ih, hX]
 
 /-- Eigenvector version of the blocked adjoint calculation.
 
@@ -525,11 +531,7 @@ theorem adjoint_blockedTransferMap_apply_of_adjoint_transferMap_eigenvector
   | zero =>
       simp [blockedTransferMap_eq_pow, Module.End.one_eq_id]
   | succ k ih =>
-      have hPow : blockedTransferMap M (k + 1) =
-          blockedTransferMap M k ∘ₗ transferMap M := by
-        simp only [blockedTransferMap_eq_pow, pow_succ, Module.End.mul_eq_comp]
-      rw [hPow, LinearMap.adjoint_comp, LinearMap.comp_apply, ih]
-      rw [map_smul, hX, smul_smul, pow_succ]
+      rw [adjoint_blockedTransferMap_succ_apply, ih, map_smul, hX, smul_smul, pow_succ]
 
 /-- The current algebra-structure predicate rules out finite-order adjoint
 eigenvalues different from $1$.

--- a/TNLean/MPS/MPDO/BNTCoefficients.lean
+++ b/TNLean/MPS/MPDO/BNTCoefficients.lean
@@ -627,6 +627,25 @@ theorem pulledBlockedChiFamily_toDiagonal_of_pos
       hχ.chi.comap (cmp.blockedLabel n hn) := by
   simp [pulledBlockedChiFamily, hn]
 
+/-- The pulled-back blocked chi family has positive diagonal entries at every
+blocked length: at positive length the entries come from the positive BNT-label
+witness, and at length zero the family is empty.
+
+Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
+Appendix C.3--C.4, lines 1830--1942 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem pulledBlockedChiFamily_toDiagonal_posEntries
+    (cmp : BNTBlockedBasisCoefficientComparison data c)
+    (hχ : PositiveBNTLabelChiTracePowerForm c) (n : ℕ) :
+    ((cmp.pulledBlockedChiFamily hχ).toDiagonal n).PosEntries := by
+  by_cases hn : 0 < n
+  · simpa only [pulledBlockedChiFamily, dif_pos hn] using
+      hχ.posEntries.comap (cmp.blockedLabel n hn)
+  · simpa only [pulledBlockedChiFamily, dif_neg hn] using
+      DiagonalChiFamily.PosEntries.empty
+        (AlgebraStructureData.BlockedIndex data n ⊕
+          AlgebraStructureData.BlockedIndex data (2 * n))
+
 /-- At positive blocked length, the finite-sum trace-power coefficient of the
 pulled-back blocked chi family is the corresponding BNT-label trace-power
 coefficient.
@@ -723,19 +742,9 @@ def toPositiveBlockedStructureChiTracePowerForm
     (hχ : PositiveBNTLabelChiTracePowerForm c) :
     AlgebraStructureData.PositiveBlockedStructureChiTracePowerForm data where
   chi := cmp.pulledBlockedChiFamily hχ
-  posEntries := by
-    intro n i j k r
-    by_cases hn : 0 < n
-    · have hpos : ((cmp.pulledBlockedChiFamily hχ).toDiagonal n).PosEntries := by
-        simpa only [pulledBlockedChiFamily, dif_pos hn] using
-          hχ.posEntries.comap (cmp.blockedLabel n hn)
-      exact hpos (Sum.inl i) (Sum.inl j) (Sum.inr k) r
-    · have hpos : ((cmp.pulledBlockedChiFamily hχ).toDiagonal n).PosEntries := by
-        simpa only [pulledBlockedChiFamily, dif_neg hn] using
-          DiagonalChiFamily.PosEntries.empty
-            (AlgebraStructureData.BlockedIndex data n ⊕
-              AlgebraStructureData.BlockedIndex data (2 * n))
-      exact hpos (Sum.inl i) (Sum.inl j) (Sum.inr k) r
+  posEntries := fun n i j k r =>
+    cmp.pulledBlockedChiFamily_toDiagonal_posEntries hχ n
+      (Sum.inl i) (Sum.inl j) (Sum.inr k) r
   tracePower := by
     intro n hn i j k
     rw [cmp.blocked_coeff_eq n hn i j k]

--- a/TNLean/MPS/RFP/BNTOrthogonality.lean
+++ b/TNLean/MPS/RFP/BNTOrthogonality.lean
@@ -64,6 +64,52 @@ private lemma submatrix_sum' {ι l m p q : Type*}
   ext a b
   simp only [Matrix.submatrix_apply, Matrix.sum_apply]
 
+/-- Left block-diagonal action on a bond block: the `(j, j')` bond block of
+$(\bigoplus_k L_k)\, X$ is $L_j X_{j,j'}$ (arXiv:1606.00608, line 551 context). -/
+private lemma blockDiagonal'_mul_toBlock
+    (L : (k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ)
+    (X : Matrix ((k : Fin r) × Fin (dim k)) ((k : Fin r) × Fin (dim k)) ℂ)
+    (j j' : Fin r) :
+    (Matrix.blockDiagonal' L * X).submatrix (blockIncl j dim) (blockIncl j' dim) =
+      L j * X.submatrix (blockIncl j dim) (blockIncl j' dim) := by
+  classical
+  ext a a'
+  rw [Matrix.submatrix_apply]
+  change (Matrix.blockDiagonal' L * X) (⟨j, a⟩ :
+      (k : Fin r) × Fin (dim k)) ⟨j', a'⟩ = _
+  rw [Matrix.mul_apply, Fintype.sum_sigma]
+  -- kill the off-diagonal blocks of the left factor
+  rw [Finset.sum_eq_single j
+    (fun k _ hk => Finset.sum_eq_zero fun b _ => by
+      rw [Matrix.blockDiagonal'_apply_ne _ _ _ (Ne.symm hk), zero_mul])
+    (fun h => absurd (Finset.mem_univ j) h)]
+  rw [Matrix.mul_apply]
+  refine Finset.sum_congr rfl fun b _ => ?_
+  rw [Matrix.blockDiagonal'_apply_eq, Matrix.submatrix_apply, blockIncl, blockIncl]
+
+/-- Right block-diagonal action on a bond block: the `(j, j')` bond block of
+$X\, (\bigoplus_k R_k)$ is $X_{j,j'} R_{j'}$ (arXiv:1606.00608, line 551 context). -/
+private lemma mul_blockDiagonal'_toBlock
+    (R : (k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ)
+    (X : Matrix ((k : Fin r) × Fin (dim k)) ((k : Fin r) × Fin (dim k)) ℂ)
+    (j j' : Fin r) :
+    (X * Matrix.blockDiagonal' R).submatrix (blockIncl j dim) (blockIncl j' dim) =
+      X.submatrix (blockIncl j dim) (blockIncl j' dim) * R j' := by
+  classical
+  ext a a'
+  rw [Matrix.submatrix_apply]
+  change (X * Matrix.blockDiagonal' R) (⟨j, a⟩ :
+      (k : Fin r) × Fin (dim k)) ⟨j', a'⟩ = _
+  rw [Matrix.mul_apply, Fintype.sum_sigma]
+  -- kill the off-diagonal blocks of the right factor
+  rw [Finset.sum_eq_single j'
+    (fun k' _ hk' => Finset.sum_eq_zero fun b' _ => by
+      rw [Matrix.blockDiagonal'_apply_ne _ _ _ hk', mul_zero])
+    (fun h => absurd (Finset.mem_univ j') h)]
+  rw [Matrix.mul_apply]
+  refine Finset.sum_congr rfl fun b' _ => ?_
+  rw [Matrix.blockDiagonal'_apply_eq, Matrix.submatrix_apply, blockIncl, blockIncl]
+
 /-- The `(j, j')` bond block of $(\bigoplus_k L_k)\, X\, (\bigoplus_k R_k)$ is
 $L_j X_{j,j'} R_{j'}$. -/
 private lemma blockDiagonal'_mul_mul_toBlock
@@ -73,29 +119,7 @@ private lemma blockDiagonal'_mul_mul_toBlock
     (Matrix.blockDiagonal' L * X * Matrix.blockDiagonal' R).submatrix
         (blockIncl j dim) (blockIncl j' dim) =
       L j * X.submatrix (blockIncl j dim) (blockIncl j' dim) * R j' := by
-  classical
-  ext a a'
-  rw [Matrix.submatrix_apply]
-  change (Matrix.blockDiagonal' L * X * Matrix.blockDiagonal' R) (⟨j, a⟩ :
-      (k : Fin r) × Fin (dim k)) ⟨j', a'⟩ = _
-  rw [Matrix.mul_apply, Fintype.sum_sigma]
-  -- reduce the outer (right block-diagonal) index to `j'`
-  rw [Finset.sum_eq_single j'
-    (fun k' _ hk' => Finset.sum_eq_zero fun b' _ => by
-      rw [Matrix.blockDiagonal'_apply_ne _ _ _ hk', mul_zero])
-    (fun h => absurd (Finset.mem_univ j') h)]
-  rw [Matrix.mul_apply]
-  refine Finset.sum_congr rfl fun b' _ => ?_
-  rw [Matrix.blockDiagonal'_apply_eq]
-  congr 1
-  -- now reduce the inner (left block-diagonal) index to `j`
-  rw [Matrix.mul_apply, Fintype.sum_sigma, Matrix.mul_apply]
-  rw [Finset.sum_eq_single j
-    (fun k _ hk => Finset.sum_eq_zero fun b _ => by
-      rw [Matrix.blockDiagonal'_apply_ne _ _ _ (Ne.symm hk), zero_mul])
-    (fun h => absurd (Finset.mem_univ j) h)]
-  refine Finset.sum_congr rfl fun b _ => ?_
-  rw [Matrix.blockDiagonal'_apply_eq, Matrix.submatrix_apply, blockIncl, blockIncl]
+  rw [mul_blockDiagonal'_toBlock, blockDiagonal'_mul_toBlock]
 
 /-- The `(j, j')` bond block of the block-diagonal transfer sum
 $\sum_i (\bigoplus_k B_k^i)\, X\, (\bigoplus_k B_k^i)^{\dagger}$ is the mixed
@@ -270,19 +294,11 @@ private lemma mixedTransferMap₂_eq_zero_of_isIdempotentElem
         (mixedTransferMap₂ (d := d) (D₁ := D₁) (D₂ := D₂) A B)) : V →L[ℂ] V) < 1
     rw [mixedTransferSpectralRadius₂_eq] at hsr
     simpa only [] using hsr
-  have hpow : Tendsto (fun n => F' ^ n) atTop (nhds 0) :=
-    @pow_tendsto_zero_of_spectralRadius_lt_one (V →L[ℂ] V)
+  have hidem' : IsIdempotentElem F' := hidem.map Φ
+  have hF'0 : F' = 0 :=
+    @IsIdempotentElem.eq_zero_of_spectralRadius_lt_one (V →L[ℂ] V)
       (ContinuousLinearMap.toNormedRing : NormedRing (V →L[ℂ] V)) hComplete
-      (ContinuousLinearMap.toNormedAlgebra : NormedAlgebra ℂ (V →L[ℂ] V)) F' hSpectF
-  have hFpow : ∀ n, F' ^ (n + 1) = F' := by
-    intro n
-    change (Φ (mixedTransferMap₂ A B)) ^ (n + 1) = Φ (mixedTransferMap₂ A B)
-    rw [← map_pow, hidem.pow_succ_eq n]
-  have hshift : Tendsto (fun n => F' ^ (n + 1)) atTop (nhds 0) :=
-    hpow.comp (tendsto_add_atTop_nat 1)
-  have hconst : Tendsto (fun n => F' ^ (n + 1)) atTop (nhds F') := by
-    simp only [hFpow]; exact tendsto_const_nhds
-  have hF'0 : F' = 0 := tendsto_nhds_unique hconst hshift
+      (ContinuousLinearMap.toNormedAlgebra : NormedAlgebra ℂ (V →L[ℂ] V)) F' hidem' hSpectF
   have hF0 : Φ (mixedTransferMap₂ A B) = Φ 0 := by rw [map_zero]; exact hF'0
   exact Φ.injective hF0
 

--- a/TNLean/MPS/RFP/BNTOrthogonality.lean
+++ b/TNLean/MPS/RFP/BNTOrthogonality.lean
@@ -65,7 +65,7 @@ private lemma submatrix_sum' {ι l m p q : Type*}
   simp only [Matrix.submatrix_apply, Matrix.sum_apply]
 
 /-- Left block-diagonal action on a bond block: the `(j, j')` bond block of
-$(\bigoplus_k L_k)\, X$ is $L_j X_{j,j'}$ (arXiv:1606.00608, line 551 context). -/
+$(\bigoplus_k L_k)\, X$ is $L_j X_{j,j'}$ (arXiv:1606.00608, line 551). -/
 private lemma blockDiagonal'_mul_toBlock
     (L : (k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ)
     (X : Matrix ((k : Fin r) × Fin (dim k)) ((k : Fin r) × Fin (dim k)) ℂ)
@@ -88,7 +88,7 @@ private lemma blockDiagonal'_mul_toBlock
   rw [Matrix.blockDiagonal'_apply_eq, Matrix.submatrix_apply, blockIncl, blockIncl]
 
 /-- Right block-diagonal action on a bond block: the `(j, j')` bond block of
-$X\, (\bigoplus_k R_k)$ is $X_{j,j'} R_{j'}$ (arXiv:1606.00608, line 551 context). -/
+$X\, (\bigoplus_k R_k)$ is $X_{j,j'} R_{j'}$ (arXiv:1606.00608, line 551). -/
 private lemma mul_blockDiagonal'_toBlock
     (R : (k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ)
     (X : Matrix ((k : Fin r) × Fin (dim k)) ((k : Fin r) × Fin (dim k)) ℂ)

--- a/TNLean/MPS/RFP/BNTOrthogonality.lean
+++ b/TNLean/MPS/RFP/BNTOrthogonality.lean
@@ -293,7 +293,7 @@ private lemma mixedTransferMap₂_eq_zero_of_isIdempotentElem
       (((Module.End.toContinuousLinearMap V)
         (mixedTransferMap₂ (d := d) (D₁ := D₁) (D₂ := D₂) A B)) : V →L[ℂ] V) < 1
     rw [mixedTransferSpectralRadius₂_eq] at hsr
-    simpa only [] using hsr
+    exact hsr
   have hidem' : IsIdempotentElem F' := hidem.map Φ
   have hF'0 : F' = 0 :=
     @IsIdempotentElem.eq_zero_of_spectralRadius_lt_one (V →L[ℂ] V)

--- a/TNLean/MPS/RFP/ZeroCorrelationLength.lean
+++ b/TNLean/MPS/RFP/ZeroCorrelationLength.lean
@@ -238,6 +238,21 @@ read as the full source definition for a multi-block BNT family. See
 def IsZCL (A : MPSTensor d D) : Prop :=
   IsLocallyOrthogonal A ∧ IsCID A
 
+/-- Correlator independence of distance forces the trace pairings of
+$\mathbb{E}^2(X\rho_R)$ and $\mathbb{E}(X\rho_R)$ against every observable to
+agree: this is the independence-of-separation step at gaps $2$ and $1$
+(arXiv:1606.00608, Definition 3.3 context). -/
+private lemma trace_mul_transferMap_sq_eq_of_isCID
+    (A : MPSTensor d D) (ρR : Matrix (Fin D) (Fin D) ℂ)
+    (hρ_pd : ρR.PosDef) (hρ_fix : transferMap A ρR = ρR) (hCID : IsCID A)
+    (X N : Matrix (Fin D) (Fin D) ℂ) :
+    Matrix.trace (N * transferMap A (transferMap A (X * ρR))) =
+      Matrix.trace (N * transferMap A (X * ρR)) := by
+  have h := hCID ρR hρ_pd hρ_fix X N 2 1 (by omega) (by omega)
+  simp only [connectedCorrelator_def, twoPointExpectation_transfer] at h
+  simp only [pow_succ, pow_zero, one_mul, Module.End.mul_apply] at h
+  exact sub_left_injective h
+
 /-- **Virtual-insertion distance independence implies RFP.**
 
 For a tensor with a positive-definite fixed point, independence of the
@@ -268,29 +283,11 @@ theorem isCID_implies_isRFP
   have hZ : Z = X * (u : Matrix (Fin D) (Fin D) ℂ) := by
     rw [hX, mul_assoc, Units.inv_mul, mul_one]
   rw [hZ]
-  -- By trace nondegeneracy, suffices: E(E(X·ρR)) - E(X·ρR) = 0
-  suffices h_diff : transferMap A (transferMap A (X * (u : Matrix (Fin D) (Fin D) ℂ))) -
-      transferMap A (X * (u : Matrix (Fin D) (Fin D) ℂ)) = 0 from
-    eq_of_sub_eq_zero h_diff
-  apply (Matrix.ext_iff_trace_mul_right
-    (A := transferMap A (transferMap A (X * (u : Matrix (Fin D) (Fin D) ℂ))) -
-      transferMap A (X * (u : Matrix (Fin D) (Fin D) ℂ)))
-    (B := 0)).2
-  intro N
-  -- From IsCID with n=2, m=1: correlator equality gives trace equality
-  have h := hCID ↑u hρ_pd hρ_fix X N 2 1 (by omega) (by omega)
-  simp only [connectedCorrelator_def, twoPointExpectation_transfer] at h
-  simp only [pow_succ, pow_zero, one_mul, Module.End.mul_apply] at h
-  -- h : tr(N * E(E(X*ρR))) - c = tr(N * E(X*ρR)) - c, so extract equality
-  have heq := sub_left_injective h
-  -- Goal: tr((E(E(X*ρR)) - E(X*ρR)) * N) = 0
-  rw [sub_mul, Matrix.trace_sub,
-    Matrix.trace_mul_comm _ N, Matrix.trace_mul_comm _ N]
-  calc
-    Matrix.trace (N * transferMap A (transferMap A (X * (u : Matrix (Fin D) (Fin D) ℂ)))) -
-        Matrix.trace (N * transferMap A (X * (u : Matrix (Fin D) (Fin D) ℂ))) = 0 :=
-      sub_eq_zero.mpr heq
-    _ = Matrix.trace (0 * N) := by simp
+  -- By trace nondegeneracy, suffices: tr(N · E(E(X·ρR))) = tr(N · E(X·ρR)) for all N
+  refine eq_of_sub_eq_zero ((Matrix.ext_iff_trace_mul_right (B := 0)).2 fun N => ?_)
+  rw [sub_mul, Matrix.trace_sub, Matrix.trace_mul_comm _ N, Matrix.trace_mul_comm _ N,
+    Matrix.zero_mul, Matrix.trace_zero]
+  exact sub_eq_zero.mpr (trace_mul_transferMap_sq_eq_of_isCID A ↑u hρ_pd hρ_fix hCID X N)
 
 /-- Single-block ZCL is equivalent to transfer-map idempotence (i.e. `IsRFP`).
 

--- a/TNLean/MPS/RFP/ZeroCorrelationLength.lean
+++ b/TNLean/MPS/RFP/ZeroCorrelationLength.lean
@@ -241,7 +241,7 @@ def IsZCL (A : MPSTensor d D) : Prop :=
 /-- Correlator independence of distance forces the trace pairings of
 $\mathbb{E}^2(X\rho_R)$ and $\mathbb{E}(X\rho_R)$ against every observable to
 agree: this is the independence-of-separation step at gaps $2$ and $1$
-(arXiv:1606.00608, Definition 3.3 context). -/
+(arXiv:1606.00608, Definition 3.3). -/
 private lemma trace_mul_transferMap_sq_eq_of_isCID
     (A : MPSTensor d D) (ρR : Matrix (Fin D) (Fin D) ℂ)
     (hρ_pd : ρR.PosDef) (hρ_fix : transferMap A ρR = ρR) (hCID : IsCID A)

--- a/TNLean/Spectral/TransferOperatorGap.lean
+++ b/TNLean/Spectral/TransferOperatorGap.lean
@@ -526,6 +526,21 @@ theorem pow_tendsto_zero_of_spectralRadius_lt_one
     rw [← coe_nnnorm, ← NNReal.coe_pow]; exact_mod_cast hn.le
   · exact tendsto_pow_atTop_nhds_zero_of_lt_one r.coe_nonneg (by exact_mod_cast hr_lt_one)
 
+/-- **An idempotent with spectral radius below one is zero.** In a complex Banach
+algebra, the powers of such an element converge to `0` while every positive power
+equals the element itself. -/
+theorem IsIdempotentElem.eq_zero_of_spectralRadius_lt_one
+    {A : Type*} [NormedRing A] [CompleteSpace A] [NormedAlgebra ℂ A]
+    {a : A} (ha : IsIdempotentElem a) (h : spectralRadius ℂ a < 1) :
+    a = 0 := by
+  have hpow := pow_tendsto_zero_of_spectralRadius_lt_one a h
+  have hshift : Filter.Tendsto (fun n => a ^ (n + 1)) Filter.atTop (nhds 0) :=
+    hpow.comp (Filter.tendsto_add_atTop_nat 1)
+  have hconst : Filter.Tendsto (fun n => a ^ (n + 1)) Filter.atTop (nhds a) := by
+    simp only [ha.pow_succ_eq]
+    exact tendsto_const_nhds
+  exact tendsto_nhds_unique hconst hshift
+
 /-! ### Application to mixed transfer convergence -/
 
 /-- **Mixed transfer iterates decay for distinct blocks**: `F_{AB}^n(X) → 0`. -/

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -428,6 +428,8 @@
     \lean{MPOTensor.BNTBlockedBasisCoefficientComparison.blockedLabel}
     \lean{MPOTensor.BNTBlockedBasisCoefficientComparison.pulledBlockedChiFamily}
     \lean{MPOTensor.BNTBlockedBasisCoefficientComparison.pulledBlockedChiFamily_toDiagonal_of_pos}
+    \lean{MPOTensor.BNTBlockedBasisCoefficientComparison.%
+        pulledBlockedChiFamily_toDiagonal_posEntries}
     \lean{MPOTensor.BNTBlockedBasisCoefficientComparison.pulledBlockedChi_tracePowerCoeff_of_pos}
     \lean{MPOTensor.BNTBlockedBasisCoefficientComparison.pulledBlockedChi_dim_of_pos}
     \lean{MPOTensor.BNTBlockedBasisCoefficientComparison.pulledBlockedChi_trace_matrix_pow_of_pos}


### PR DESCRIPTION
Restructures five tangled proofs in the MPO and RFP layers by extracting reusable lemmas. No statement, name, or hypothesis of any existing declaration changed; all blueprint `\lean{}` tags remain valid.

## Restructurings

1. **`MPOTensor.adjoint_transferMap_apply_of_isRFP_MPDO_via_algebra`** (`TNLean/MPS/MPDO/AlgebraStructure.lean`)
   - Extracted: `MPOTensor.blockedTransferMap_succ` (one-site peeling `E^{n+1} = E^n ∘ E`) and `MPOTensor.adjoint_blockedTransferMap_succ_apply` (its adjoint form).
   - Three hosts repeated the same `pow_succ`/`adjoint_comp` unfolding: `adjoint_transferMap_apply_of_isRFP_MPDO_via_algebra` (17 → 10 lines), `adjoint_blockedTransferMap_apply_of_adjoint_transferMap_apply` (succ branch 5 → 1 lines), `adjoint_blockedTransferMap_apply_of_adjoint_transferMap_eigenvector` (succ branch 6 → 1 lines).

2. **`MPSTensor.isCID_implies_isRFP`** (`TNLean/MPS/RFP/ZeroCorrelationLength.lean`)
   - Extracted: private `trace_mul_transferMap_sq_eq_of_isCID` (the connected-correlator independence-of-separation step at gaps 2 and 1).
   - Host proof 32 → 15 tactic lines; the three verbatim copies of the `E(E(X·ρ)) − E(X·ρ)` expression and the trailing `trace (0 * N)` calc step are gone.

3. **`MPSTensor.blockDiagonal'_mul_mul_toBlock`** (`TNLean/MPS/RFP/BNTOrthogonality.lean`)
   - Extracted: private `blockDiagonal'_mul_toBlock` and `mul_blockDiagonal'_toBlock` (left/right block-diagonal action on a bond block).
   - The host's 23-line interleaved double-sum reduction becomes a 1-line rewrite chain.

4. **`MPSTensor.mixedTransferMap₂_eq_zero_of_isIdempotentElem`** (`TNLean/MPS/RFP/BNTOrthogonality.lean` + `TNLean/Spectral/TransferOperatorGap.lean`)
   - Extracted: `MPSTensor.IsIdempotentElem.eq_zero_of_spectralRadius_lt_one` in `TransferOperatorGap.lean`, directly after `pow_tendsto_zero_of_spectralRadius_lt_one` with the same hypothesis set (an idempotent element of a complex Banach algebra with spectral radius below one is zero).
   - Host proof 31 → 24 lines; the power-convergence/uniqueness-of-limits argument no longer runs inline.

5. **`MPOTensor.BNTBlockedBasisCoefficientComparison.toPositiveBlockedStructureChiTracePowerForm`** (`TNLean/MPS/MPDO/BNTCoefficients.lean`)
   - Extracted: `pulledBlockedChiFamily_toDiagonal_posEntries` (positivity of the pulled-back blocked chi family, arXiv:1606.00608, Theorem IV.13(ii)).
   - The `posEntries` field collapses from a 14-line case-split tactic block to a 3-line term.

## Verification

- `lake build`: success (full build)
- `rg -n "sorry|axiom"` on all changed files: none
- `lake exe checkdecls blueprint/lean_decls`: pass
- `python3 scripts/blueprint_lean_sync.py --root . --ci`: pass
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`: pass
- `lake exe lint_style`: pass
- `git diff --check`: clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactors and one new exported spectral lemma; no API or behavioral changes to existing declarations.
> 
> **Overview**
> This PR **refactors** five proof sites by pulling repeated steps into shared lemmas. **No theorem statements, names, or hypotheses change**; blueprint `\lean{}` links stay valid.
> 
> **MPDO algebra / blocked transfer:** Adds private `blockedTransferMap_succ` and `adjoint_blockedTransferMap_succ_apply` for one-site peeling of blocked transfer maps and their adjoints. `adjoint_transferMap_apply_of_isRFP_MPDO_via_algebra` and two induction lemmas on blocked adjoint maps/eigenvectors now call these instead of inlining `pow_succ` / `adjoint_comp`.
> 
> **BNT coefficients:** New `pulledBlockedChiFamily_toDiagonal_posEntries` proves positivity of the pulled-back blocked χ family; `toPositiveBlockedStructureChiTracePowerForm.posEntries` delegates to it. Blueprint theorem `thm:mpdo_bnt_blocked_basis_to_positive_blocked_chi_trace_power_form` gains a `\lean{}` tag for the new lemma.
> 
> **RFP / BNT orthogonality:** Splits `blockDiagonal'_mul_mul_toBlock` into left/right block-diagonal lemmas, then composes them. **Spectral:** `IsIdempotentElem.eq_zero_of_spectralRadius_lt_one` lives in `TransferOperatorGap.lean` next to power convergence; `mixedTransferMap₂_eq_zero_of_isIdempotentElem` uses it instead of an inline limit argument.
> 
> **Zero correlation length:** Private `trace_mul_transferMap_sq_eq_of_isCID` isolates the CID trace step at gaps 2 vs 1; `isCID_implies_isRFP` is shorter and uses trace nondegeneracy via `ext_iff_trace_mul_right`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c087fdbe8be040c5bf4b2e77ccc3885642c58a99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->