### PR TITLE
feat(Channel): prove Choi-type positivity at n = d - 2

### DIFF
--- a/TNLean/Channel/ChoiTypeMap.lean
+++ b/TNLean/Channel/ChoiTypeMap.lean
@@ -23,10 +23,13 @@ where `D` projects a matrix to its diagonal part.
 
 The main theorem in this file is the exact action on rank-one projectors.  This
 is the algebraic reduction needed for the positivity proof of Wolf Example 3.1.
-For the first case \(d=3,n=1\), this file proves positivity.  The general
-positivity theorem still requires a genuine cyclic reciprocal inequality for
-the diagonal weights; it does not follow merely from equality of the total
-numerator and denominator weights.  Indecomposability is not proved here.
+This file proves positivity for the case \(d=3,n=1\) and, more generally, for
+the top of Wolf's range, \(n=d-2\) with \(d\ge3\); the scalar input for the
+latter is a reciprocal inequality valid for an arbitrary permutation.  The
+remaining range \(1\le n\le d-3\) still requires the general cyclic reciprocal
+inequality for the diagonal weights; it does not follow merely from equality of
+the total numerator and denominator weights.  Indecomposability is not proved
+here.
 
 ## References
 
@@ -348,5 +351,259 @@ theorem choiTypeMap_isPositiveMap_three_one :
     convert choiTypeMap_vecMulVec_posSemidef_three_one v using 2
     ext p q
     simp [v, Matrix.vecMulVec_apply]
+
+/-! ## The top of Wolf's range: `n = d - 2`
+
+For `n = d - 2` the backward window `x_{i-1}, …, x_{i-n}` misses exactly the
+entries at `i` and `i + 1`, so the Choi diagonal weight collapses to
+\(a_i = T + x_i - x_{i+1}\) with \(T = \sum_j x_j\).  The cyclic reciprocal
+estimate for this case follows from a reciprocal inequality that holds for an
+arbitrary permutation in place of the cyclic shift.  This case of Wolf's
+positivity assertion is classical: it is due to Ando (*Positivity of certain
+maps*, seminar notes, 1985), as recorded by Yamagami
+[*Cyclic inequalities*, Proc. Amer. Math. Soc. 118 (1993), 521–527], who
+proved the estimate for the whole range \(1\le n\le d-1\). -/
+
+/-- Elementary summand bound for the permutation reciprocal inequality: if
+`a + b ≤ T`, then \(a/(T+a-b) \le (aT - a(a-b) + (a-b)^2/2)/T^2\), because the
+difference of the two sides is \((a-b)^2 (T-a-b) / 2\) up to the positive
+denominators.  Zero denominators are read by the convention `x / 0 = 0`. -/
+private theorem perm_reciprocal_term_le {T a b : ℝ} (ha : 0 ≤ a)
+    (hT : 0 < T) (hpair : a + b ≤ T) :
+    a / (T + a - b) ≤ (a * T - a * (a - b) + (a - b) ^ 2 / 2) / T ^ 2 := by
+  rcases eq_or_lt_of_le (show (0 : ℝ) ≤ T + a - b by linarith) with h0 | hpos
+  · have ha0 : a = 0 := by linarith
+    subst ha0
+    rw [zero_div]
+    have hnum : (0 : ℝ) * T - 0 * (0 - b) + (0 - b) ^ 2 / 2 = b ^ 2 / 2 := by ring
+    rw [hnum]
+    positivity
+  · rw [div_le_div_iff₀ hpos (by positivity)]
+    nlinarith [mul_nonneg (sq_nonneg (a - b)) (sub_nonneg.2 hpair)]
+
+/-- **The permutation reciprocal inequality.**  For nonnegative reals `x` with
+total mass \(T=\sum_j x_j\) and any permutation \(\sigma\),
+\[
+  \sum_i \frac{x_i}{T + x_i - x_{\sigma(i)}} \le 1 ,
+\]
+with zero-denominator summands read as `0`.  Each summand is bounded by
+\((x_iT - x_i\delta_i + \delta_i^2/2)/T^2\) with \(\delta_i=x_i-x_{\sigma(i)}\),
+and the bounds sum to `1` exactly because
+\(\sum_i x_i\delta_i = \tfrac12\sum_i \delta_i^2\) for a permutation.
+
+Applied with \(\sigma\) the cyclic shift on `ZMod d`, this is the case
+`n = d - 2` of the cyclic reciprocal estimate behind Wolf Chapter 3,
+Example 3.1, equation (3.20); that case is classical (Ando 1985; see Yamagami,
+Proc. Amer. Math. Soc. 118 (1993), 521–527). -/
+theorem perm_reciprocal_sum_le_one {ι : Type*} [Fintype ι] (σ : Equiv.Perm ι)
+    (x : ι → ℝ) (hx : ∀ i, 0 ≤ x i) :
+    ∑ i, x i / ((∑ j, x j) + x i - x (σ i)) ≤ 1 := by
+  classical
+  set T : ℝ := ∑ j, x j with hTdef
+  rcases eq_or_lt_of_le (Finset.sum_nonneg fun j _ => hx j : (0 : ℝ) ≤ T)
+    with hT | hTpos
+  · have hx0 : ∀ i ∈ Finset.univ, x i = 0 :=
+      (Finset.sum_eq_zero_iff_of_nonneg fun j _ => hx j).1 hT.symm
+    have hzero : ∀ i ∈ Finset.univ,
+        x i / (T + x i - x (σ i)) = 0 := fun i hi => by
+      rw [hx0 i hi, zero_div]
+    rw [Finset.sum_congr rfl hzero, Finset.sum_const_zero]
+    exact zero_le_one
+  · have key : ∀ i ∈ Finset.univ, x i / (T + x i - x (σ i)) ≤
+        (x i * T - x i * (x i - x (σ i)) + (x i - x (σ i)) ^ 2 / 2) / T ^ 2 := by
+      intro i _
+      by_cases hfix : σ i = i
+      · rw [hfix]
+        have hT' : T + x i - x i = T := by ring
+        have hnum : x i * T - x i * (x i - x i) + (x i - x i) ^ 2 / 2
+            = T * x i := by ring
+        rw [hT', hnum, pow_two, mul_div_mul_left _ _ (ne_of_gt hTpos)]
+      · have hpair : x i + x (σ i) ≤ T := by
+          have hsum := Finset.sum_le_sum_of_subset_of_nonneg
+            (Finset.subset_univ ({i, σ i} : Finset ι)) fun j _ _ => hx j
+          rwa [Finset.sum_pair (Ne.symm hfix)] at hsum
+        exact perm_reciprocal_term_le (hx i) hTpos hpair
+    have hsq : ∑ i, x (σ i) ^ 2 = ∑ i, x i ^ 2 :=
+      Equiv.sum_comp σ fun j => x j ^ 2
+    have hkey : ∑ i, (x i - x (σ i)) ^ 2 =
+        2 * ∑ i, x i * (x i - x (σ i)) := by
+      have hcross : ∑ i, ((x i - x (σ i)) ^ 2 - 2 * (x i * (x i - x (σ i))))
+          = ∑ i, (x (σ i) ^ 2 - x i ^ 2) :=
+        Finset.sum_congr rfl fun i _ => by ring
+      rw [Finset.sum_sub_distrib, ← Finset.mul_sum] at hcross
+      rw [Finset.sum_sub_distrib, hsq, sub_self] at hcross
+      linarith [hcross]
+    have htotal : ∑ i,
+        (x i * T - x i * (x i - x (σ i)) + (x i - x (σ i)) ^ 2 / 2) / T ^ 2
+          = 1 := by
+      rw [← Finset.sum_div]
+      have hnum : ∑ i,
+          (x i * T - x i * (x i - x (σ i)) + (x i - x (σ i)) ^ 2 / 2)
+            = T ^ 2 := by
+        rw [Finset.sum_add_distrib, Finset.sum_sub_distrib, ← Finset.sum_mul,
+          ← Finset.sum_div, ← hTdef, hkey]
+        ring
+      rw [hnum, div_self (by positivity)]
+    calc ∑ i, x i / (T + x i - x (σ i))
+        ≤ ∑ i, (x i * T - x i * (x i - x (σ i)) + (x i - x (σ i)) ^ 2 / 2)
+            / T ^ 2 := Finset.sum_le_sum key
+      _ = 1 := htotal
+
+/-- For `3 ≤ d`, the backward shifts by `1, …, d - 2` from `i` run over every
+index of `ZMod d` except `i` itself and `i + 1`. -/
+theorem sum_shift_window_eq_sub_pair (hd : 3 ≤ d) (x : ZMod d → ℝ)
+    (i : ZMod d) :
+    ∑ k : Fin (d - 2), x (i - ((k.1 + 1 : ℕ) : ZMod d)) =
+      (∑ j, x j) - (x i + x (i + 1)) := by
+  classical
+  have hne : i ≠ i + 1 := by
+    intro h
+    have h1 : (0 : ZMod d) = 1 := by
+      have := congrArg (fun t => t - i) h
+      simpa using this
+    rw [eq_comm, ZMod.one_eq_zero_iff] at h1
+    omega
+  have hmain : ∑ k : Fin (d - 2), x (i - ((k.1 + 1 : ℕ) : ZMod d)) =
+      ∑ c ∈ Finset.univ \ ({i, i + 1} : Finset (ZMod d)), x c := by
+    refine Finset.sum_bij' (fun k _ => i - ((k.1 + 1 : ℕ) : ZMod d))
+      (fun c hc => ⟨(i - c).val - 1, ?_⟩) ?_ ?_ ?_ ?_ ?_
+    · -- the inverse lands in `Fin (d - 2)`
+      rw [Finset.mem_sdiff, Finset.mem_insert, Finset.mem_singleton] at hc
+      obtain ⟨-, hc2⟩ := hc
+      have hci : c ≠ i := fun h => hc2 (Or.inl h)
+      have hci1 : c ≠ i + 1 := fun h => hc2 (Or.inr h)
+      have hval_ne_zero : (i - c).val ≠ 0 := by
+        intro h0
+        have hic : i - c = 0 := (ZMod.val_eq_zero _).1 h0
+        exact hci (sub_eq_zero.1 hic).symm
+      have hval_lt : (i - c).val < d := ZMod.val_lt _
+      have hval_ne_top : (i - c).val ≠ d - 1 := by
+        intro hval
+        have hcast : ((i - c).val : ZMod d) = i - c :=
+          ZMod.natCast_rightInverse (i - c)
+        rw [hval] at hcast
+        have hd1 : ((d - 1 : ℕ) : ZMod d) = -1 := by
+          have h1d : 1 ≤ d := by omega
+          push_cast [Nat.cast_sub h1d]
+          simp
+        rw [hd1] at hcast
+        exact hci1 (by linear_combination hcast)
+      omega
+    · -- forward map lands in the complement of the pair
+      intro k _
+      rw [Finset.mem_sdiff, Finset.mem_insert, Finset.mem_singleton]
+      have hk : k.1 + 1 < d := by omega
+      refine ⟨Finset.mem_univ _, ?_⟩
+      rintro (h | h)
+      · have hzero : ((k.1 + 1 : ℕ) : ZMod d) = 0 := by
+          have := congrArg (fun t => i - t) h
+          simpa using this
+        rw [ZMod.natCast_eq_zero_iff] at hzero
+        have := Nat.le_of_dvd (by omega) hzero
+        omega
+      · have hzero : ((k.1 + 2 : ℕ) : ZMod d) = 0 := by
+          have hstep : ((k.1 + 1 : ℕ) : ZMod d) = -1 := by
+            linear_combination -h
+          push_cast at hstep ⊢
+          linear_combination hstep
+        rw [ZMod.natCast_eq_zero_iff] at hzero
+        have := Nat.le_of_dvd (by omega) hzero
+        omega
+    · -- the inverse lands in `Fin (d - 2)` membership (trivial)
+      intro c _
+      exact Finset.mem_univ _
+    · -- left inverse
+      intro k _
+      have hk : k.1 + 1 < d := by omega
+      apply Fin.ext
+      simp only [sub_sub_cancel]
+      rw [ZMod.val_cast_of_lt hk]
+      omega
+    · -- right inverse
+      intro c hc
+      rw [Finset.mem_sdiff, Finset.mem_insert, Finset.mem_singleton] at hc
+      obtain ⟨-, hc2⟩ := hc
+      have hci : c ≠ i := fun h => hc2 (Or.inl h)
+      have hval_ne_zero : (i - c).val ≠ 0 := by
+        intro h0
+        have hic : i - c = 0 := (ZMod.val_eq_zero _).1 h0
+        exact hci (sub_eq_zero.1 hic).symm
+      simp only [Nat.sub_add_cancel (Nat.one_le_iff_ne_zero.2 hval_ne_zero)]
+      rw [ZMod.natCast_rightInverse (i - c), sub_sub_cancel]
+    · -- summand values agree
+      intro k _
+      rfl
+  rw [hmain, Finset.sum_sdiff_eq_sub (Finset.subset_univ _),
+    Finset.sum_pair hne]
+
+/-- **Wolf Chapter 3, Example 3.1, equation (3.20), case `n = d - 2`.**  The
+Choi rank-one diagonal weight collapses to
+\(a_i = T + |v_i|^2 - |v_{i+1}|^2\) with \(T=\sum_j |v_j|^2\). -/
+theorem choiTypeRankOneWeight_sub_two (hd : 3 ≤ d) (v : ZMod d → ℂ)
+    (i : ZMod d) :
+    choiTypeRankOneWeight d (d - 2) v i =
+      (∑ j, ‖v j‖ ^ 2) + ‖v i‖ ^ 2 - ‖v (i + 1)‖ ^ 2 := by
+  have hcast : ((d - 2 : ℕ) : ℝ) = (d : ℝ) - 2 := by
+    have h2 : 2 ≤ d := by omega
+    push_cast [Nat.cast_sub h2]
+    ring
+  have hshift := sum_shift_window_eq_sub_pair hd (fun j => ‖v j‖ ^ 2) i
+  simp only [choiTypeRankOneWeight, hcast]
+  rw [hshift]
+  ring
+
+/-- Rank-one positivity at the top of Wolf's range: for `3 ≤ d` and
+`n = d - 2`, the image \(T_C(|v\rangle\langle v|)\) is positive semidefinite
+(Wolf Chapter 3, Example 3.1, equation (3.20)).  The scalar input is the
+permutation reciprocal inequality applied to the cyclic shift. -/
+theorem choiTypeMap_vecMulVec_posSemidef_sub_two (hd : 3 ≤ d)
+    (v : ZMod d → ℂ) :
+    (choiTypeMap d (d - 2) (vecMulVec v (star v))).PosSemidef := by
+  refine choiTypeMap_vecMulVec_posSemidef_of_weight_sum_le_one
+    (d - 2) v le_rfl ?_
+  have hperm := perm_reciprocal_sum_le_one (Equiv.addRight (1 : ZMod d))
+    (fun j => ‖v j‖ ^ 2) fun j => sq_nonneg _
+  simp only [Equiv.coe_addRight] at hperm
+  calc ∑ i, ‖v i‖ ^ 2 / choiTypeRankOneWeight d (d - 2) v i
+      = ∑ i, ‖v i‖ ^ 2 /
+          ((∑ j, ‖v j‖ ^ 2) + ‖v i‖ ^ 2 - ‖v (i + 1)‖ ^ 2) :=
+        Finset.sum_congr rfl fun i _ => by
+          rw [choiTypeRankOneWeight_sub_two hd]
+    _ ≤ 1 := hperm
+
+/-- A linear map on matrices is positive once its values on all rank-one
+projectors are positive semidefinite: a positive semidefinite matrix is the
+sum of the rank-one projectors of its spectral decomposition. -/
+theorem isPositiveMap_of_forall_vecMulVec_posSemidef
+    {m : Type*} [Fintype m] [DecidableEq m]
+    (Φ : Matrix m m ℂ →ₗ[ℂ] Matrix m m ℂ)
+    (h : ∀ w : m → ℂ, (Φ (vecMulVec w (star w))).PosSemidef) :
+    IsPositiveMap Φ := by
+  intro X hX
+  rw [hX.eq_sum_vecMulVec_nonzero_eigs]
+  rw [map_sum]
+  exact Matrix.posSemidef_sum Finset.univ fun i _ => by
+    let w : m → ℂ := fun p =>
+      ((Real.sqrt (hX.1.eigenvalues i.1) : ℂ)) *
+        hX.1.eigenvectorUnitary p i.1
+    convert h w using 2
+    ext p q
+    simp [w, Matrix.vecMulVec_apply]
+
+/-- **Wolf Chapter 3, Example 3.1, equation (3.20), case `n = d - 2`.**  The
+Choi-type map at the top of Wolf's range is positive: for `3 ≤ d`, the map
+\(T_C\) with `n = d - 2` sends every positive semidefinite matrix to a
+positive semidefinite matrix.
+
+**Scope restriction:** See
+`docs/paper-gaps/wolf_ex3_1_choi_positivity_subcase_scope.tex`.  This proves
+the case `n = d - 2` of the positivity assertion for every `d ≥ 3`, subsuming
+the earlier \(d=3,n=1\) case.  The remaining range \(1\le n\le d-3\) is still
+open; its classical proof is the variational argument of Yamagami
+[Proc. Amer. Math. Soc. 118 (1993), 521–527]. -/
+theorem choiTypeMap_isPositiveMap_sub_two (hd : 3 ≤ d) :
+    IsPositiveMap (choiTypeMap d (d - 2)) :=
+  isPositiveMap_of_forall_vecMulVec_posSemidef _ fun w =>
+    choiTypeMap_vecMulVec_posSemidef_sub_two hd w
 
 end Matrix

--- a/TNLean/Channel/ChoiTypeMap.lean
+++ b/TNLean/Channel/ChoiTypeMap.lean
@@ -333,6 +333,25 @@ theorem choiTypeMap_vecMulVec_posSemidef_three_one_of_forall_ne_zero
     (choiTypeMap 3 1 (vecMulVec v (star v))).PosSemidef :=
   choiTypeMap_vecMulVec_posSemidef_three_one v
 
+/-- A linear map on matrices is positive once its values on all rank-one
+projectors are positive semidefinite: a positive semidefinite matrix is the
+sum of the rank-one projectors of its spectral decomposition. -/
+theorem isPositiveMap_of_forall_vecMulVec_posSemidef
+    {m : Type*} [Fintype m] [DecidableEq m]
+    (Φ : Matrix m m ℂ →ₗ[ℂ] Matrix m m ℂ)
+    (h : ∀ w : m → ℂ, (Φ (vecMulVec w (star w))).PosSemidef) :
+    IsPositiveMap Φ := by
+  intro X hX
+  rw [hX.eq_sum_vecMulVec_nonzero_eigs]
+  rw [map_sum]
+  exact Matrix.posSemidef_sum Finset.univ fun i _ => by
+    let w : m → ℂ := fun p =>
+      ((Real.sqrt (hX.1.eigenvalues i.1) : ℂ)) *
+        hX.1.eigenvectorUnitary p i.1
+    convert h w using 2
+    ext p q
+    simp [w, Matrix.vecMulVec_apply]
+
 /-- Positivity of the first Choi map.
 
 **Scope restriction:** See
@@ -340,17 +359,9 @@ theorem choiTypeMap_vecMulVec_posSemidef_three_one_of_forall_ne_zero
 only the \(d=3,n=1\) case of Wolf Chapter 3, Example 3.1, equation (3.20).
 The general range \(1\le n\le d-2\) remains separate. -/
 theorem choiTypeMap_isPositiveMap_three_one :
-    IsPositiveMap (choiTypeMap 3 1) := by
-  intro X hX
-  rw [hX.eq_sum_vecMulVec_nonzero_eigs]
-  rw [map_sum]
-  exact Matrix.posSemidef_sum Finset.univ fun i _ => by
-    let v : ZMod 3 → ℂ := fun p =>
-      ((Real.sqrt (hX.1.eigenvalues i.1) : ℂ)) *
-        hX.1.eigenvectorUnitary p i.1
-    convert choiTypeMap_vecMulVec_posSemidef_three_one v using 2
-    ext p q
-    simp [v, Matrix.vecMulVec_apply]
+    IsPositiveMap (choiTypeMap 3 1) :=
+  isPositiveMap_of_forall_vecMulVec_posSemidef _
+    choiTypeMap_vecMulVec_posSemidef_three_one
 
 /-! ## The top of Wolf's range: `n = d - 2`
 
@@ -570,25 +581,6 @@ theorem choiTypeMap_vecMulVec_posSemidef_sub_two (hd : 3 ≤ d)
         Finset.sum_congr rfl fun i _ => by
           rw [choiTypeRankOneWeight_sub_two hd]
     _ ≤ 1 := hperm
-
-/-- A linear map on matrices is positive once its values on all rank-one
-projectors are positive semidefinite: a positive semidefinite matrix is the
-sum of the rank-one projectors of its spectral decomposition. -/
-theorem isPositiveMap_of_forall_vecMulVec_posSemidef
-    {m : Type*} [Fintype m] [DecidableEq m]
-    (Φ : Matrix m m ℂ →ₗ[ℂ] Matrix m m ℂ)
-    (h : ∀ w : m → ℂ, (Φ (vecMulVec w (star w))).PosSemidef) :
-    IsPositiveMap Φ := by
-  intro X hX
-  rw [hX.eq_sum_vecMulVec_nonzero_eigs]
-  rw [map_sum]
-  exact Matrix.posSemidef_sum Finset.univ fun i _ => by
-    let w : m → ℂ := fun p =>
-      ((Real.sqrt (hX.1.eigenvalues i.1) : ℂ)) *
-        hX.1.eigenvectorUnitary p i.1
-    convert h w using 2
-    ext p q
-    simp [w, Matrix.vecMulVec_apply]
 
 /-- **Wolf Chapter 3, Example 3.1, equation (3.20), case `n = d - 2`.**  The
 Choi-type map at the top of Wolf's range is positive: for `3 ≤ d`, the map

--- a/blueprint/src/chapter/ch25_positive_not_cp.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp.tex
@@ -303,8 +303,9 @@ open.  The missing general positivity step is a cyclic reciprocal estimate for
 the weights in the rank-one reduction; it does not follow merely from equality
 of the total numerator and denominator weights.  The general estimate is
 classical: the case $n=d-2$ is due to Ando, the case $n=1$ to Tanahashi and
-Tomiyama, and the whole range to Yamagami~\cite{Yamagami1993Cyclic}, whose
-proof is a variational argument on the boundary of a projective simplex.
+Tomiyama~\cite{TanahashiTomiyama1988Indecomposable}, and the whole range to
+Yamagami~\cite{Yamagami1993Cyclic}, whose proof is a variational argument on
+the boundary of a projective simplex.
 
 \begin{definition}[Choi-type map]
     \label{def:choi_type_map}
@@ -486,32 +487,45 @@ proof is a variational argument on the boundary of a projective simplex.
     Lemma~\ref{lem:choi_type_rankone_positive_from_weight_bound}.
 \end{proof}
 
+\begin{lemma}[Positivity from rank-one positivity]
+    \label{lem:positive_map_from_rankone}
+    \lean{Matrix.isPositiveMap_of_forall_vecMulVec_posSemidef}
+    \leanok
+    A linear map on matrices that sends every rank-one projector
+    $\ket{w}\bra{w}$ to a positive semidefinite matrix sends every positive
+    semidefinite matrix to a positive semidefinite matrix.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Let $\Phi$ be the map and let $X\ge0$.  Scaling the eigenvectors of $X$ by
+    the square roots of its nonnegative eigenvalues produces vectors
+    $w_\alpha$ with
+    \[
+        X=\sum_\alpha \ket{w_\alpha}\bra{w_\alpha}.
+    \]
+    Linearity gives
+    \[
+        \Phi(X)=\sum_\alpha \Phi(\ket{w_\alpha}\bra{w_\alpha}),
+    \]
+    each summand is positive semidefinite by hypothesis, and a sum of
+    positive semidefinite matrices is positive semidefinite.
+\end{proof}
+
 \begin{theorem}[The first Choi map is positive]
     \label{thm:choi_type_first_positive_subcase}
     \lean{Matrix.choiTypeMap_isPositiveMap_three_one}
     \leanok
-    \uses{def:choi_type_map, lem:choi_type_first_cyclic_reciprocal_subcase}
+    \uses{def:choi_type_map, lem:choi_type_first_cyclic_reciprocal_subcase,
+        lem:positive_map_from_rankone}
     For $d=3$ and $n=1$, the Choi-type map $T_C$ sends every positive
     semidefinite matrix to a positive semidefinite matrix.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    Let $X\ge0$.  By the spectral decomposition, there are vectors $w_\alpha$
-    such that
-    \[
-        X=\sum_\alpha \ket{w_\alpha}\bra{w_\alpha},
-    \]
-    where each summand is rank-one and positive semidefinite.  Linearity gives
-    \[
-        T_C(X)=\sum_\alpha T_C(\ket{w_\alpha}\bra{w_\alpha}).
-    \]
-    The preceding lemma gives
-    \[
-        T_C(\ket{w_\alpha}\bra{w_\alpha})\ge0
-    \]
-    for every $\alpha$.  Hence the displayed sum is positive semidefinite, so
-    $T_C(X)\ge0$.
+    Combine Lemma~\ref{lem:choi_type_first_cyclic_reciprocal_subcase} with
+    Lemma~\ref{lem:positive_map_from_rankone}.
 \end{proof}
 
 \begin{lemma}[Permutation reciprocal inequality]
@@ -593,22 +607,6 @@ proof is a variational argument on the boundary of a projective simplex.
     to the cyclic shift $\sigma(i)=i+1$, bounds this sum by $1$, and
     Lemma~\ref{lem:choi_type_rankone_positive_from_weight_bound} turns the
     bound into rank-one positivity.
-\end{proof}
-
-\begin{lemma}[Positivity from rank-one positivity]
-    \label{lem:positive_map_from_rankone}
-    \lean{Matrix.isPositiveMap_of_forall_vecMulVec_posSemidef}
-    \leanok
-    A linear map on matrices that sends every rank-one projector
-    $\ket{w}\bra{w}$ to a positive semidefinite matrix sends every positive
-    semidefinite matrix to a positive semidefinite matrix.
-\end{lemma}
-
-\begin{proof}
-    \leanok
-    A positive semidefinite matrix is the sum of the rank-one projectors of
-    its spectral decomposition, and positive semidefiniteness is preserved
-    under sums.
 \end{proof}
 
 \begin{theorem}[Choi-type maps at the top of the range are positive]

--- a/blueprint/src/chapter/ch25_positive_not_cp.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp.tex
@@ -294,11 +294,17 @@ $D(X)$ and cyclic shifts $U_{k0}$:
     T_C(X)=(d-n)D(X)-X+\sum_{k=1}^nD(U_{k0}XU_{k0}^{\dagger}).
 \]
 The formal statements below record the map and the rank-one reduction used in
-the standard positivity argument.  The first case $d=3$, $n=1$ is positive.
-The positivity and indecomposability assertions for the full range
-$1\le n\le d-2$ remain open.  The missing general positivity step is a cyclic
-reciprocal estimate for the weights in the rank-one reduction; it does not
-follow merely from equality of the total numerator and denominator weights.
+the standard positivity argument.  Positivity is proved for the case $d=3$,
+$n=1$ and, for every $d\ge3$, at the top of the range, $n=d-2$; the scalar
+input for the latter is a reciprocal inequality valid for an arbitrary
+permutation in place of the cyclic shift.  The positivity assertion for the
+remaining range $1\le n\le d-3$ and the indecomposability assertion remain
+open.  The missing general positivity step is a cyclic reciprocal estimate for
+the weights in the rank-one reduction; it does not follow merely from equality
+of the total numerator and denominator weights.  The general estimate is
+classical: the case $n=d-2$ is due to Ando, the case $n=1$ to Tanahashi and
+Tomiyama, and the whole range to Yamagami~\cite{Yamagami1993Cyclic}, whose
+proof is a variational argument on the boundary of a projective simplex.
 
 \begin{definition}[Choi-type map]
     \label{def:choi_type_map}
@@ -506,6 +512,121 @@ follow merely from equality of the total numerator and denominator weights.
     \]
     for every $\alpha$.  Hence the displayed sum is positive semidefinite, so
     $T_C(X)\ge0$.
+\end{proof}
+
+\begin{lemma}[Permutation reciprocal inequality]
+    \label{lem:choi_type_perm_reciprocal}
+    \lean{Matrix.perm_reciprocal_sum_le_one}
+    \leanok
+    Let $x_i\ge0$ be indexed by a finite set, let $T=\sum_j x_j$, and let
+    $\sigma$ be a permutation of the index set.  Then, with zero-denominator
+    summands read as $0$,
+    \[
+        \sum_i \frac{x_i}{T+x_i-x_{\sigma(i)}}\le 1 .
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    If $T=0$, every summand vanishes.  Otherwise write
+    $\delta_i=x_i-x_{\sigma(i)}$.  Each summand obeys
+    \[
+        \frac{x_i}{T+\delta_i}
+        \le\frac{x_iT-x_i\delta_i+\delta_i^2/2}{T^2}:
+    \]
+    for $\sigma(i)=i$ both sides equal $x_i/T$, and for $\sigma(i)\ne i$ the
+    difference of the two sides is
+    \[
+        \frac{\delta_i^2\,\bigl(T-x_i-x_{\sigma(i)}\bigr)}{2\,T^2\,(T+\delta_i)}
+        \ge0,
+    \]
+    by the pair bound $x_i+x_{\sigma(i)}\le T$ and $T+\delta_i\ge 2x_i\ge0$; a
+    vanishing denominator forces $x_i=0$ and leaves a nonnegative right-hand
+    side.  Because $\sigma$ permutes the entries,
+    $\sum_i x_{\sigma(i)}^2=\sum_i x_i^2$, which gives the identity
+    $\sum_i x_i\delta_i=\tfrac12\sum_i\delta_i^2$.  Summing the term bounds
+    therefore yields
+    \[
+        \sum_i\frac{x_i}{T+\delta_i}
+        \le\frac{T\cdot T-\sum_ix_i\delta_i+\tfrac12\sum_i\delta_i^2}{T^2}
+        =1 .
+    \]
+\end{proof}
+
+\begin{lemma}[The Choi weight at the top of the range]
+    \label{lem:choi_type_weight_top}
+    \lean{Matrix.sum_shift_window_eq_sub_pair,
+        Matrix.choiTypeRankOneWeight_sub_two}
+    \leanok
+    \uses{def:choi_type_rankone_weight}
+    Let $d\ge3$ and $n=d-2$.  With $x_i=|v_i|^2$ and $T=\sum_j x_j$, the Choi
+    rank-one diagonal weight equals
+    \[
+        a_i=(d-n)x_i+\sum_{k=1}^{n}x_{i-k}=T+x_i-x_{i+1} .
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    For $n=d-2$ the backward shifts $i-1,\dots,i-(d-2)$ run over every index
+    of $\mathbb Z/d\mathbb Z$ except $i$ and $i+1$, so the shifted sum equals
+    $T-x_i-x_{i+1}$ and $a_i=2x_i+T-x_i-x_{i+1}$.
+\end{proof}
+
+\begin{lemma}[Rank-one positivity at the top of the range]
+    \label{lem:choi_type_rankone_positive_top}
+    \lean{Matrix.choiTypeMap_vecMulVec_posSemidef_sub_two}
+    \leanok
+    \uses{lem:choi_type_rankone_positive_from_weight_bound,
+        lem:choi_type_weight_top, lem:choi_type_perm_reciprocal}
+    For $d\ge3$ and $n=d-2$, every vector $v$ satisfies
+    $T_C(\ket{v}\bra{v})\ge0$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    By Lemma~\ref{lem:choi_type_weight_top}, the reciprocal weight sum is
+    \[
+        \sum_i\frac{x_i}{T+x_i-x_{i+1}}
+    \]
+    with $x_i=|v_i|^2$.  Lemma~\ref{lem:choi_type_perm_reciprocal}, applied
+    to the cyclic shift $\sigma(i)=i+1$, bounds this sum by $1$, and
+    Lemma~\ref{lem:choi_type_rankone_positive_from_weight_bound} turns the
+    bound into rank-one positivity.
+\end{proof}
+
+\begin{lemma}[Positivity from rank-one positivity]
+    \label{lem:positive_map_from_rankone}
+    \lean{Matrix.isPositiveMap_of_forall_vecMulVec_posSemidef}
+    \leanok
+    A linear map on matrices that sends every rank-one projector
+    $\ket{w}\bra{w}$ to a positive semidefinite matrix sends every positive
+    semidefinite matrix to a positive semidefinite matrix.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    A positive semidefinite matrix is the sum of the rank-one projectors of
+    its spectral decomposition, and positive semidefiniteness is preserved
+    under sums.
+\end{proof}
+
+\begin{theorem}[Choi-type maps at the top of the range are positive]
+    \label{thm:choi_type_positive_top}
+    \lean{Matrix.choiTypeMap_isPositiveMap_sub_two}
+    \leanok
+    \uses{def:choi_type_map, lem:choi_type_rankone_positive_top,
+        lem:positive_map_from_rankone}
+    For every $d\ge3$ and $n=d-2$, the Choi-type map $T_C$ sends every
+    positive semidefinite matrix to a positive semidefinite matrix.  This is
+    the case $n=d-2$ of the positivity assertion of Wolf's Example~3.1 and
+    subsumes the case $d=3$, $n=1$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Combine Lemma~\ref{lem:choi_type_rankone_positive_top} with
+    Lemma~\ref{lem:positive_map_from_rankone}.
 \end{proof}
 
 \section{Decomposable positive maps}

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -60,6 +60,17 @@
   doi          = {10.1090/S0002-9939-1993-1128732-7},
 }
 
+@article{TanahashiTomiyama1988Indecomposable,
+  author       = {Tanahashi, Kotaro and Tomiyama, Jun},
+  title        = {Indecomposable Positive Maps in Matrix Algebras},
+  journal      = {Canadian Mathematical Bulletin},
+  volume       = {31},
+  number       = {3},
+  pages        = {308--317},
+  year         = {1988},
+  doi          = {10.4153/CMB-1988-044-4},
+}
+
 @book{Bhatia1997Matrix,
   author       = {Bhatia, Rajendra},
   title        = {Matrix Analysis},

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -49,6 +49,16 @@
                   archival PDF at \url{https://mediatum.ub.tum.de/doc/1099654/1099654.pdf}},
 }
 
+@article{Yamagami1993Cyclic,
+  author       = {Yamagami, Shigeru},
+  title        = {Cyclic Inequalities},
+  journal      = {Proceedings of the American Mathematical Society},
+  volume       = {118},
+  number       = {2},
+  pages        = {521--527},
+  year         = {1993},
+  doi          = {10.1090/S0002-9939-1993-1128732-7},
+}
 
 @book{Bhatia1997Matrix,
   author       = {Bhatia, Rajendra},

--- a/docs/paper-gaps/references.bib
+++ b/docs/paper-gaps/references.bib
@@ -114,6 +114,28 @@
   url          = {https://mediatum.ub.tum.de/doc/1099654/1099654.pdf},
 }
 
+@article{Yamagami1993Cyclic,
+  author       = {Yamagami, Shigeru},
+  title        = {Cyclic Inequalities},
+  journal      = {Proceedings of the American Mathematical Society},
+  volume       = {118},
+  number       = {2},
+  pages        = {521--527},
+  year         = {1993},
+  doi          = {10.1090/S0002-9939-1993-1128732-7},
+}
+
+@article{TanahashiTomiyama1988Indecomposable,
+  author       = {Tanahashi, Kotaro and Tomiyama, Jun},
+  title        = {Indecomposable Positive Maps in Matrix Algebras},
+  journal      = {Canadian Mathematical Bulletin},
+  volume       = {31},
+  number       = {3},
+  pages        = {308--317},
+  year         = {1988},
+  doi          = {10.4153/CMB-1988-044-4},
+}
+
 @article{PerezGarcia2007MPSReps,
   author       = {P\'erez-Garc\'ia, David and Verstraete, Frank and Wolf, Michael M. and Cirac, J. Ignacio},
   title        = {Matrix Product State Representations},

--- a/docs/paper-gaps/references.bib
+++ b/docs/paper-gaps/references.bib
@@ -136,6 +136,16 @@
   doi          = {10.4153/CMB-1988-044-4},
 }
 
+@article{Osaka1991Indecomposable,
+  author       = {Osaka, Hiroyuki},
+  title        = {Indecomposable Positive Maps in Low Dimensional Matrix
+                  Algebras},
+  journal      = {Linear Algebra and its Applications},
+  volume       = {153},
+  pages        = {73--83},
+  year         = {1991},
+}
+
 @article{PerezGarcia2007MPSReps,
   author       = {P\'erez-Garc\'ia, David and Verstraete, Frank and Wolf, Michael M. and Cirac, J. Ignacio},
   title        = {Matrix Product State Representations},

--- a/docs/paper-gaps/wolf_ex3_1_choi_positivity_subcase_scope.tex
+++ b/docs/paper-gaps/wolf_ex3_1_choi_positivity_subcase_scope.tex
@@ -7,9 +7,9 @@
 
 \input{command}
 
-\title{Scope of the First Choi-Type Positivity Subcase (Wolf Example~3.1)}
+\title{Scope of the Choi-Type Positivity Subcases (Wolf Example~3.1)}
 \author{}
-\date{2026-07-02}
+\date{2026-07-02, revised 2026-07-10}
 
 \begin{document}
 \maketitle
@@ -31,8 +31,10 @@ The source states that \(T_C\) is positive and indecomposable for every
 
 \section{Restricted statement now proved}
 
-The present development proves only the first subcase.  For \(d=3\), \(n=1\),
-and an arbitrary vector \(v=(v_0,v_1,v_2)\), it proves
+The present development proves two slices of the positivity assertion.
+
+First, for \(d=3\), \(n=1\), and an arbitrary vector \(v=(v_0,v_1,v_2)\), it
+proves
 \begin{align}
   T_C(|v\rangle\langle v|)\ge 0.
 \end{align}
@@ -52,6 +54,30 @@ rank-one positive semidefinite summands, the development then proves that this
 first Choi map is positive on all positive semidefinite inputs.\footnote{Formal
 declaration: \leanid{Matrix.choiTypeMap\_isPositiveMap\_three\_one}.}
 
+Second, at the top of the source's range, \(n=d-2\), the development proves
+positivity of \(T_C\) on all positive semidefinite inputs for every dimension
+\(d\ge3\); this family subsumes the \(d=3,n=1\)
+case.\footnote{Formal declarations:
+\leanid{Matrix.perm\_reciprocal\_sum\_le\_one},
+\leanid{Matrix.choiTypeMap\_vecMulVec\_posSemidef\_sub\_two}, and
+\leanid{Matrix.choiTypeMap\_isPositiveMap\_sub\_two} in
+\doclink{TNLean/Channel/ChoiTypeMap}.}  For \(n=d-2\) the backward window
+\(x_{i-1},\dots,x_{i-n}\) misses exactly the entries at \(i\) and \(i+1\), so
+with \(T=\sum_j x_j\) the diagonal weight collapses to
+\(a_i=T+x_i-x_{i+1}\), and the cyclic reciprocal estimate becomes an instance
+of a reciprocal inequality valid for an arbitrary permutation \(\sigma\):
+\begin{align}
+  \sum_i \frac{x_i}{T+x_i-x_{\sigma(i)}}\le 1,
+  \qquad x_i\ge 0 .
+\end{align}
+Each summand is at most \((x_iT-x_i\delta_i+\delta_i^2/2)/T^2\) with
+\(\delta_i=x_i-x_{\sigma(i)}\), by the pair bound
+\(x_i+x_{\sigma(i)}\le T\), and the bounds sum to \(1\) exactly because
+\(\sum_i x_i\delta_i=\tfrac12\sum_i\delta_i^2\) for a permutation.  This case
+of the cyclic estimate is classical: it is due to Ando (\emph{Positivity of
+certain maps}, seminar notes, 1985), as recorded in the introduction of
+\cite{Yamagami1993Cyclic}.
+
 \section{Missing hypotheses and elimination plan}
 
 This is a scope restriction, not the source theorem.  The full positivity
@@ -59,21 +85,37 @@ statement still requires the nonnegative cyclic reciprocal estimate
 \begin{align}
   \sum_{i\in\mathbb Z/d\mathbb Z}
   \frac{x_i}{(d-n)x_i+\sum_{k=1}^{n}x_{i-k}}\le 1
-  \qquad (x_i\ge0,\;1\le n\le d-2),
+  \qquad (x_i\ge0,\;1\le n\le d-3),
 \end{align}
-with the usual zero-term convention.  Once this estimate is available, it
-should be applied to \(x_i=|v_i|^2\) to obtain the rank-one statement for the
-full parameter range.  The same positive-semidefinite decomposition used in
-the \(d=3,n=1\) case will then extend the rank-one result to positivity of
-\(T_C\) on all positive semidefinite matrices.  This is tracked by
-\ghissue{3622}.  The indecomposability assertion of the same source paragraph
-is separate and is tracked by \ghissue{3623}.
+with the usual zero-term convention; the case \(n=d-2\) is done, as is
+\(n=d-1\), which lies outside the source's range.  Once this estimate is
+available, it should be applied to \(x_i=|v_i|^2\) to obtain the rank-one
+statement for the full parameter range; the spectral decomposition
+step\footnote{\leanid{Matrix.isPositiveMap\_of\_forall\_vecMulVec\_posSemidef}.}
+already extends any such rank-one statement to positivity of \(T_C\) on all
+positive semidefinite matrices.
+
+The remaining estimate is genuinely harder than the proved cases.  The case
+\(n=1\) is due to Tanahashi and
+Tomiyama~\cite{TanahashiTomiyama1988Indecomposable}, and the full range
+\(1\le n\le d-1\) to Yamagami~\cite{Yamagami1993Cyclic}, whose proof is
+variational: it combines Nowosad's uniqueness theorem for critical points of
+\(x\mapsto\sum_i x_i/(Sx)_i\) on the positive cone, a spectral condition on
+the Hessian at the constant vector (checked through the eigenvalues of the
+cyclic matrix \(S\)), and an analysis of the boundary of the projective
+simplex with a combinatorial count of vanishing summands.  No term-by-term
+convexity or AM--GM bound with coefficients independent of \(x\) can settle
+the middle range, so a formalization must either follow the variational route
+or find a new proof.  This is tracked by \ghissue{3622}.  The
+indecomposability assertion of the same source paragraph is separate and is
+tracked by \ghissue{3623}.
 
 \section{Classification}
 
-\emph{Scope restriction.}  The current theorem is mathematically correct as a
-\(3\times3\) positive-map subcase, but it should not be cited as the formalization
-of Wolf's full Choi-type positivity theorem.
+\emph{Scope restriction.}  The current theorems are mathematically correct as
+the \(d=3,n=1\) and \(n=d-2\) positive-map cases, but they should not be cited
+as the formalization of Wolf's full Choi-type positivity theorem, whose range
+is \(1\le n\le d-2\).
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/wolf_ex3_1_choi_positivity_subcase_scope.tex
+++ b/docs/paper-gaps/wolf_ex3_1_choi_positivity_subcase_scope.tex
@@ -103,12 +103,41 @@ variational: it combines Nowosad's uniqueness theorem for critical points of
 \(x\mapsto\sum_i x_i/(Sx)_i\) on the positive cone, a spectral condition on
 the Hessian at the constant vector (checked through the eigenvalues of the
 cyclic matrix \(S\)), and an analysis of the boundary of the projective
-simplex with a combinatorial count of vanishing summands.  No term-by-term
-convexity or AM--GM bound with coefficients independent of \(x\) can settle
-the middle range, so a formalization must either follow the variational route
-or find a new proof.  This is tracked by \ghissue{3622}.  The
-indecomposability assertion of the same source paragraph is separate and is
-tracked by \ghissue{3623}.
+simplex with a combinatorial count of vanishing summands.
+
+Two verifiable computations locate the obstruction to elementary summand
+bounds in the remaining range.  First, the estimate is tight in two distinct
+regimes: at the constant vector, where every summand equals \(1/d\), and
+along the geometric configurations \(x_i=t^i\) (\(i=0,\dots,d-1\)) as
+\(t\to\infty\), where each of the \(d-n\) summands whose backward window
+avoids the wrap-around tends to \(1/(d-n)\) and the remaining summands
+vanish, so the sum again approaches \(1\).  A usable summand bound must be
+exact in both regimes.  Second, the argument proving \(n=d-2\) does not
+extend.  With \(m=d-n\) and
+\(\delta_i=\sum_{k=1}^{m-1}(x_i-x_{i+k})\), the weight is \(a_i=T+\delta_i\)
+for every \(n\), and the estimate is equivalent (for \(T>0\) and positive
+weights \(a_i\)) to \(\sum_i x_i\delta_i^2/a_i\le\sum_i x_i\delta_i\).  The proved case reaches
+this through the two intermediate steps
+\begin{align}
+  \sum_i \frac{x_i\delta_i^2}{a_i}\le\frac1m\sum_i\delta_i^2
+  \qquad\text{and}\qquad
+  \frac1m\sum_i\delta_i^2
+  \le\frac12\sum_{k=1}^{m-1}\sum_i\bigl(x_i-x_{i+k}\bigr)^2
+  =\sum_i x_i\delta_i .
+\end{align}
+The first step, from \(a_i\ge m x_i\), holds for every \(m\); the second, in
+Fourier form
+\(\bigl|\sum_{k=1}^{m-1}(1-\zeta^k)\bigr|^2
+\le\tfrac m2\sum_{k=1}^{m-1}|1-\zeta^k|^2\) over \(d\)-th roots of unity
+\(\zeta\), holds with equality for \(m=2\) but fails for \(m=3\) at
+\(\zeta=e^{i\pi/3}\), where the two sides are \(7\) and \(6\).  This failure
+is consistent with the historical record: the case \((d,n)=(5,2)\) required a
+separate argument~\cite{Osaka1991Indecomposable}, and the full range was
+settled only by Yamagami's variational proof.  A formalization of the
+remaining range must therefore either follow the variational route or find a
+new proof.  This is tracked by \ghissue{3622}.  The indecomposability
+assertion of the same source paragraph is separate and is tracked by
+\ghissue{3623}.
 
 \section{Classification}
 


### PR DESCRIPTION
Partially addresses LionSR/QICLean#19.

## Mathematical statement

For `n = d - 2` and every `d >= 3` — the top of the range `1 <= n <= d - 2` in Wolf Ch. 3, Ex. 3.1, eq. (3.20) — the Choi-type map `T_C` is a positive map: `Matrix.choiTypeMap_isPositiveMap_sub_two : 3 ≤ d → IsPositiveMap (choiTypeMap d (d - 2))`. This subsumes the earlier `d = 3, n = 1` subcase.

## Proof route

For `n = d - 2` the backward window `x_{i-1}, …, x_{i-n}` misses exactly the entries at `i` and `i+1`, so the Choi diagonal weight collapses to `a_i = T + x_i - x_{i+1}` with `T = Σ_j x_j` (`Matrix.sum_shift_window_eq_sub_pair`, `Matrix.choiTypeRankOneWeight_sub_two`). The cyclic reciprocal estimate for this case is an instance of a **permutation reciprocal inequality** (`Matrix.perm_reciprocal_sum_le_one`): for any permutation σ and nonnegative `x`,

    Σ_i x_i / (T + x_i - x_{σ(i)}) ≤ 1 .

Each summand is bounded by `(x_i T - x_i δ_i + δ_i²/2)/T²` with `δ_i = x_i - x_{σ(i)}`, using the pair bound `x_i + x_{σ(i)} ≤ T`; the bounds sum to 1 exactly because `Σ_i x_i δ_i = ½ Σ_i δ_i²` for a permutation. The rank-one statement then lifts to all positive semidefinite inputs by spectral decomposition (`Matrix.isPositiveMap_of_forall_vecMulVec_posSemidef`, a reusable lift).

This case of the cyclic estimate is classical: it is due to Ando (*Positivity of certain maps*, seminar notes, 1985), as recorded in the introduction of Yamagami, *Cyclic inequalities*, Proc. Amer. Math. Soc. 118 (1993), 521–527, which proves the estimate for the whole range `1 ≤ n ≤ d - 1` by a variational argument.

## Scope

The remaining range `1 ≤ n ≤ d - 3` (first open case: `d = 4, n = 1`) stays open. The paper-gap note `docs/paper-gaps/wolf_ex3_1_choi_positivity_subcase_scope.tex` is updated: it records the two proved slices, narrows the missing estimate to `1 ≤ n ≤ d - 3`, and documents why no term-by-term AM–GM with `x`-independent coefficients can settle the middle range, together with the structure of Yamagami's variational proof (Nowosad's critical-point uniqueness theorem, Hessian spectral condition for cyclic matrices, projective boundary analysis).

## Blueprint

Five new ch25 entries, all `\leanok`: `lem:choi_type_perm_reciprocal`, `lem:choi_type_weight_top`, `lem:choi_type_rankone_positive_top`, `lem:positive_map_from_rankone`, `thm:choi_type_positive_top`; section prose updated; `Yamagami1993Cyclic` added to the bibliographies.

## Verification

- `lake build TNLean` exit 0; no `sorry`/`axiom` in the changed file
- `lake exe checkdecls blueprint/lean_decls` exit 0
- `scripts/blueprint_lean_sync.py --ci`: ch25 73/73 in sync
- `scripts/check_reader_facing_prose.py --diff-base origin/main --ci` clean
- `lake exe lint_style` exit 0
- `leanblueprint pdf` exit 0; paper-gap note builds with `latexmk`
- `git diff --check` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new Lean proofs in channel positivity (hundreds of lines); errors would be mathematical incorrectness rather than runtime/security issues, but the scope is nontrivial formal analysis.
> 
> **Overview**
> **Proves positivity** of Wolf’s Choi-type map `T_C` for every `d ≥ 3` at the top parameter range **`n = d - 2`**, including the earlier **`d = 3, n = 1`** case as a special case.
> 
> In **`TNLean/Channel/ChoiTypeMap.lean`**, the PR adds a **reusable lemma** `isPositiveMap_of_forall_vecMulVec_posSemidef` (spectral decomposition lifts rank-one PSD inputs to full `IsPositiveMap`) and refactors the existing `d=3,n=1` theorem to use it. For **`n = d - 2`**, it formalizes the collapsed diagonal weight **`a_i = T + x_i - x_{i+1}`** (`sum_shift_window_eq_sub_pair`, `choiTypeRankOneWeight_sub_two`), proves the **permutation reciprocal inequality** `perm_reciprocal_sum_le_one` (cyclic shift gives the needed weight bound), and concludes **`choiTypeMap_isPositiveMap_sub_two`**.
> 
> **Blueprint** `ch25_positive_not_cp.tex` gains matching lemmas/theorems (perm reciprocal, top-range weight, rank-one and full positivity) and updates section prose; **bibliographies** add Yamagami (and related) citations. The **paper-gap scope note** is revised to record both proved slices, narrow the open range to **`1 ≤ n ≤ d - 3`**, and document why elementary summand bounds do not extend to the middle range.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8061539e5ccdf6c4ef978b0c3443f7128e9855b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

