### PR TITLE
fix(MPS/MPDO): state the vertical canonical form on the vertically viewed tensor

### DIFF
--- a/TNLean/MPS/MPDO/InvariantProjection.lean
+++ b/TNLean/MPS/MPDO/InvariantProjection.lean
@@ -77,6 +77,27 @@ noncomputable def braRightMul (M : MPOTensor d D) (P : Matrix (Fin d) (Fin d) �
     MPOTensor d D :=
   fun i j => ∑ k : Fin d, P k j • M i k
 
+/-- The letters of $P\widetilde M$ are the letters of $\widetilde M$
+multiplied by `P` on the left.  This identifies the one-site action
+`ketLeftMul` with left multiplication on the vertically viewed tensor of
+arXiv:1606.00608, line 943. -/
+theorem verticalTensor_ketLeftMul (M : MPOTensor d D)
+    (P : Matrix (Fin d) (Fin d) ℂ) (v : Fin (D * D)) :
+    verticalTensor (M.ketLeftMul P) v = P * verticalTensor M v := by
+  ext i j
+  simp [verticalTensor, ketLeftMul, Matrix.mul_apply, Matrix.sum_apply]
+
+/-- The letters of $\widetilde M P$ are the letters of $\widetilde M$
+multiplied by `P` on the right.  This identifies the one-site action
+`braRightMul` with right multiplication on the vertically viewed tensor of
+arXiv:1606.00608, line 943. -/
+theorem verticalTensor_braRightMul (M : MPOTensor d D)
+    (P : Matrix (Fin d) (Fin d) ℂ) (v : Fin (D * D)) :
+    verticalTensor (M.braRightMul P) v = verticalTensor M v * P := by
+  ext i j
+  simp [verticalTensor, braRightMul, Matrix.mul_apply, Matrix.sum_apply,
+    mul_comm]
+
 /-- Splitting off the first site of a density-operator entry:
 $H^{(N+1)}_{(i,\sigma),(j,\tau)}
 =\tr(M^{ij}M^{\sigma_0\tau_0}\cdots M^{\sigma_{N-1}\tau_{N-1}})$. -/

--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -601,7 +601,15 @@ decomposition are the ones consumed by the renormalization fixed-point
 characterization at arXiv:1606.00608, line 1956.  Every basis tensor appears
 with at least one copy: each `μ_α` is a positive diagonal matrix of size
 `mult α ≥ 1`, matching arXiv:1606.00608, line 1901, where the sector `(α, 1)`
-exists for every `α`. -/
+exists for every `α`.
+
+The isometry is a unitary change of the physical basis, so both `Uᴴ * U = 1`
+and `U * Uᴴ = 1` are required: the canonical form (arXiv:1606.00608,
+eq. II_CF1, read in the vertical direction) decomposes the physical space
+exactly, and the source discards `U` because "it just changes the physical
+basis on each site" (arXiv:1606.00608, line 959).  With an isometric
+embedding alone, the decomposed space could exceed the physical space, which
+the source's conclusion excludes. -/
 def IsVerticalCF (M : MPOTensor d D) : Prop :=
   ∃ (g : ℕ) (dim : Fin g → ℕ) (mult : Fin g → ℕ)
     (ω : (α : Fin g) → Fin (mult α) → ℂ)
@@ -611,6 +619,7 @@ def IsVerticalCF (M : MPOTensor d D) : Prop :=
     (∀ α, 0 < mult α) ∧
       (∀ α k, (0 : ℂ) < ω α k) ∧
       Uᴴ * U = 1 ∧
+      U * Uᴴ = 1 ∧
       MPSTensor.IsBNT (verticalTensor M) g dim A ∧
       ∀ v : Fin (D * D),
         U * verticalTensor M v * Uᴴ = verticalAssembledTensor dim mult ω A v

--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -598,14 +598,18 @@ $U \widetilde M_{ab} U^\dagger = (\bigoplus_\alpha \mu_\alpha \otimes M_\alpha)_
 The right-hand side keeps the multiplicities `mult α` and the diagonal
 entries `ω α k` explicit; the trace coefficients `m_α = tr μ_α` of this
 decomposition are the ones consumed by the renormalization fixed-point
-characterization at arXiv:1606.00608, line 1956. -/
+characterization at arXiv:1606.00608, line 1956.  Every basis tensor appears
+with at least one copy: each `μ_α` is a positive diagonal matrix of size
+`mult α ≥ 1`, matching arXiv:1606.00608, line 1901, where the sector `(α, 1)`
+exists for every `α`. -/
 def IsVerticalCF (M : MPOTensor d D) : Prop :=
   ∃ (g : ℕ) (dim : Fin g → ℕ) (mult : Fin g → ℕ)
     (ω : (α : Fin g) → Fin (mult α) → ℂ)
     (A : (α : Fin g) → MPSTensor (D * D) (dim α))
     (U : Matrix (Fin (∑ q : Fin (∑ α : Fin g, mult α), verticalCopyDim dim mult q))
       (Fin d) ℂ),
-    (∀ α k, (0 : ℂ) < ω α k) ∧
+    (∀ α, 0 < mult α) ∧
+      (∀ α k, (0 : ℂ) < ω α k) ∧
       Uᴴ * U = 1 ∧
       MPSTensor.IsBNT (verticalTensor M) g dim A ∧
       ∀ v : Fin (D * D),

--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -10,31 +10,45 @@ import TNLean.MPS.SharedInfra.BlockAssembly
 /-!
 # Vertical canonical form for MPO tensors
 
-This file introduces a block-decomposed version of the vertical canonical-form
-structure used in the MPDO analysis of arXiv:1606.00608, Section 4.4.
+This file introduces the vertically viewed tensor of an MPO and the vertical
+canonical-form structure used in the MPDO analysis of arXiv:1606.00608,
+Section 4.4.
 
-Proposition 4.13 of arXiv:1606.00608 writes the tensor, after a local isometry
-on the physical indices, as a direct sum
-`⊕_α μ_α ⊗ M_α`, where the `μ_α` are positive diagonal matrices and the
-`M_α` form a basis of normal tensors (BNT). The current repository formalization
-uses canonical-form and BNT data with scalar block weights. We therefore
-encode the paper's diagonal matrices by **flattening** each diagonal entry of
-`μ_α` into a repeated positive scalar weight attached to the same block `M_α`.
-
-The resulting predicate `IsVerticalCF` should be read as a repository-friendly
-surrogate for the paper's vertical canonical form.
+The vertical direction is obtained by exchanging the notion of physical and
+virtual indices (arXiv:1606.00608, line 943): the vertically viewed tensor has
+its letters indexed by the horizontal bond pair `(a, b)`, and each letter is
+the operator on the physical space with matrix elements
+$(\widetilde M_{ab})_{ij} = M^{ij}_{ab}$. Proposition 4.13 of arXiv:1606.00608
+(eq. UMU-appendix, lines 1863--1870) concludes that, after an isometry `U` on
+the physical space, this tensor is a direct sum
+$U \widetilde M U^\dagger = \bigoplus_\alpha \mu_\alpha \otimes M_\alpha$,
+where the `μ_α` are positive diagonal matrices and the `M_α` form a basis of
+normal tensors (BNT). Since each `μ_α` is diagonal, the summand `μ_α ⊗ M_α`
+equals the direct sum `⊕_k ω_{α,k} M_α` of its diagonal entries, so the
+right-hand side is the block-diagonal tensor over the pairs `(α, k)` in which
+the multiplicities `m_α` and the diagonal entries `ω_{α,k}` stay explicit.
+The predicate `IsVerticalCF` states exactly this conclusion.
 
 ## Main definitions
 
+* `verticalTensor`:
+  the vertically viewed tensor, with letters indexed by the horizontal bond
+  pair and matrices acting on the physical space (arXiv:1606.00608, line 943).
 * `diagonalTensor`:
-  the MPS tensor `i ↦ M i i` extracted from the diagonal MPO entries.
-* `verticalTransferMap`:
-  the transfer map of `diagonalTensor`, i.e. `E_vert(X) = Σ_i M^{ii} X (M^{ii})†`.
+  the MPS tensor `i ↦ M i i` extracted from the diagonal MPO entries; its
+  coefficients are the diagonal entries `⟨σ|ρ^{(N)}(M)|σ⟩` of the generated
+  operator.
+* `diagonalTransferMap`:
+  the transfer map of `diagonalTensor`, i.e. `E_diag(X) = Σ_i M^{ii} X (M^{ii})†`.
 * `HorizontalCFData` / `IsHorizontalCF`:
   lightweight horizontal canonical-form data for an MPO, expressed via the
   doubled-index MPS tensor `M.toMPSTensor`.
 * `IsVerticalCF`:
-  a flattened positive-weight BNT decomposition for `diagonalTensor M`.
+  the vertical canonical form of arXiv:1606.00608, eq. UMU-appendix: an
+  isometry `U` on the physical space with
+  $U \widetilde M_{ab} U^\dagger = (\bigoplus_\alpha \mu_\alpha \otimes M_\alpha)_{ab}$
+  for every bond pair `(a, b)`, with positive diagonal matrices `μ_α` and a
+  BNT `{M_α}` for the vertically viewed tensor.
 * `MPSTensor.diagBlock`:
   the diagonal restriction `B ↦ (i ↦ B (i, i))` of a doubled-index block.
 
@@ -337,9 +351,35 @@ namespace MPOTensor
 
 variable {d D : ℕ}
 
+/-! ### The vertically viewed tensor -/
+
+/-- The **vertically viewed tensor** of an MPO tensor.  The vertical direction
+is obtained by exchanging the notion of physical and virtual indices
+(arXiv:1606.00608, line 943): the letters of the vertical tensor are indexed
+by the horizontal bond pair `(a, b)`, and each letter is the operator on the
+physical space with matrix elements $(\widetilde M_{ab})_{ij} = M^{ij}_{ab}$.
+Concatenating this tensor vertically generates the matrix product vectors of
+the vertical direction, and the vertical canonical form of
+arXiv:1606.00608, Proposition 4.13, is a statement about this tensor. -/
+def verticalTensor (M : MPOTensor d D) : MPSTensor (D * D) d :=
+  fun ab i j => M i j ab.divNat ab.modNat
+
+@[simp] lemma verticalTensor_apply (M : MPOTensor d D) (ab : Fin (D * D))
+    (i j : Fin d) : verticalTensor M ab i j = M i j ab.divNat ab.modNat :=
+  rfl
+
+/-- The vertical letter at an explicitly paired bond index `(a, b)`. -/
+lemma verticalTensor_finProdFinEquiv (M : MPOTensor d D) (a b : Fin D)
+    (i j : Fin d) :
+    verticalTensor M (finProdFinEquiv (a, b)) i j = M i j a b := by
+  simp
+
 /-- The diagonal MPS tensor extracted from an MPO by restricting to equal ket
-and bra indices. This is the tensor whose transfer map is the "vertical"
-transfer map used in the MPDO vertical-canonical-form discussion. -/
+and bra indices.  Its matrix product vectors are the diagonal entries
+`⟨σ|ρ^{(N)}(M)|σ⟩` of the generated operator
+(`mpv_diagonalTensor_eq_mpo_diag`), the positivity input to the vertical
+canonical form.  The tensor generating the vertical direction itself is
+`verticalTensor`. -/
 def diagonalTensor (M : MPOTensor d D) : MPSTensor d D :=
   fun i => M i i
 
@@ -450,9 +490,12 @@ theorem mpo_compress_trace_pos (M : MPOTensor d D) (hM : IsMPDO M) (N : ℕ)
     0 < Matrix.trace (P * mpo M N * P) :=
   Matrix.PosSemidef.trace_pos_of_ne_zero (mpo_compress_posSemidef M hM N P hP) hne
 
-/-- The vertical transfer map of an MPO tensor:
-`E_vert(X) = Σ_i M^{ii} X (M^{ii})†`. -/
-noncomputable def verticalTransferMap (M : MPOTensor d D) :
+/-- The transfer map of the diagonal tensor of an MPO:
+`E_diag(X) = Σ_i M^{ii} X (M^{ii})†`.  It acts on the horizontal bond space;
+the transfer map of the vertically viewed tensor is
+`MPSTensor.transferMap (verticalTensor M)`, which acts on the physical
+space. -/
+noncomputable def diagonalTransferMap (M : MPOTensor d D) :
     Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ :=
   MPSTensor.transferMap (diagonalTensor M)
 
@@ -528,8 +571,11 @@ def verticalCopyWeights {g : ℕ} (mult : Fin g → ℕ)
     let p := finSigmaFinEquiv.symm q
     ω p.1 p.2
 
-/-- The flattened repeated tensor corresponding to the paper's
-`⊕_α μ_α ⊗ M_α` block structure. -/
+/-- The direct-sum tensor `⊕_α μ_α ⊗ M_α` with positive diagonal matrices
+`μ_α = diag (ω α 0, …)`.  Since each `μ_α` is diagonal, the summand
+`μ_α ⊗ M_α` is the further direct sum `⊕_k ω_{α,k} M_α` of its diagonal
+entries; this constructor lists those blocks in exactly that order, so the
+multiplicities `mult α` and the diagonal entries `ω α k` stay explicit. -/
 noncomputable def verticalAssembledTensor {g : ℕ}
     (dim : Fin g → ℕ) (mult : Fin g → ℕ)
     (ω : (α : Fin g) → Fin (mult α) → ℂ)
@@ -539,19 +585,31 @@ noncomputable def verticalAssembledTensor {g : ℕ}
     (μ := verticalCopyWeights mult ω)
     (A := verticalCopyBlocks dim mult A)
 
-/-- A Lean-friendly version of the paper's vertical canonical form:
+/-- **Vertical canonical form** of an MPO tensor (arXiv:1606.00608,
+Proposition 4.13, eq. UMU-appendix, lines 1863--1870; the vertical direction
+is defined at line 943 by exchanging the physical and virtual indices).
 
-there is a basis of normal tensors `A α`, together with positive scalar weights
-obtained by flattening the positive diagonal matrices `μ_α`, such that the
-diagonal MPO tensor `diagonalTensor M` generates the same MPV family as the
-flattened repeated tensor built from those blocks. -/
+There are a basis of normal tensors `{M_α}` for the vertically viewed tensor,
+positive diagonal matrices `μ_α = diag (ω α 0, …)`, and an isometry `U` on the
+physical space such that, letter by letter over the horizontal bond pairs
+`(a, b)`,
+$U \widetilde M_{ab} U^\dagger = (\bigoplus_\alpha \mu_\alpha \otimes M_\alpha)_{ab}$.
+
+The right-hand side keeps the multiplicities `mult α` and the diagonal
+entries `ω α k` explicit; the trace coefficients `m_α = tr μ_α` of this
+decomposition are the ones consumed by the renormalization fixed-point
+characterization at arXiv:1606.00608, line 1956. -/
 def IsVerticalCF (M : MPOTensor d D) : Prop :=
   ∃ (g : ℕ) (dim : Fin g → ℕ) (mult : Fin g → ℕ)
     (ω : (α : Fin g) → Fin (mult α) → ℂ)
-    (A : (α : Fin g) → MPSTensor d (dim α)),
-    (∀ α q, (0 : ℂ) < ω α q) ∧
-      MPSTensor.IsBNT (verticalAssembledTensor dim mult ω A) g dim A ∧
-      MPSTensor.SameMPV₂ (diagonalTensor M) (verticalAssembledTensor dim mult ω A)
+    (A : (α : Fin g) → MPSTensor (D * D) (dim α))
+    (U : Matrix (Fin (∑ q : Fin (∑ α : Fin g, mult α), verticalCopyDim dim mult q))
+      (Fin d) ℂ),
+    (∀ α k, (0 : ℂ) < ω α k) ∧
+      Uᴴ * U = 1 ∧
+      MPSTensor.IsBNT (verticalTensor M) g dim A ∧
+      ∀ v : Fin (D * D),
+        U * verticalTensor M v * Uᴴ = verticalAssembledTensor dim mult ω A v
 
 /-- The matrix product vector of the vertical-assembled tensor, as a sum over the
 flattened `(block, multiplicity)` index `(α, j)`:

--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -16,17 +16,18 @@ Section 4.4.
 
 The vertical direction is obtained by exchanging the notion of physical and
 virtual indices (arXiv:1606.00608, line 943): the vertically viewed tensor has
-its letters indexed by the horizontal bond pair `(a, b)`, and each letter is
+its letters indexed by the horizontal bond pair $(a, b)$, and each letter is
 the operator on the physical space with matrix elements
 $(\widetilde M_{ab})_{ij} = M^{ij}_{ab}$. Proposition 4.13 of arXiv:1606.00608
-(eq. UMU-appendix, lines 1863--1870) concludes that, after an isometry `U` on
+(lines 1863--1870) concludes that, after an isometry $U$ on
 the physical space, this tensor is a direct sum
 $U \widetilde M U^\dagger = \bigoplus_\alpha \mu_\alpha \otimes M_\alpha$,
-where the `μ_α` are positive diagonal matrices and the `M_α` form a basis of
-normal tensors (BNT). Since each `μ_α` is diagonal, the summand `μ_α ⊗ M_α`
-equals the direct sum `⊕_k ω_{α,k} M_α` of its diagonal entries, so the
-right-hand side is the block-diagonal tensor over the pairs `(α, k)` in which
-the multiplicities `m_α` and the diagonal entries `ω_{α,k}` stay explicit.
+where the $\mu_\alpha$ are positive diagonal matrices and the $M_\alpha$ form a basis of
+normal tensors (BNT). Since each $\mu_\alpha$ is diagonal, the summand
+$\mu_\alpha \otimes M_\alpha$
+equals the direct sum $\bigoplus_k \omega_{\alpha,k} M_\alpha$ of its diagonal entries, so the
+right-hand side is the block-diagonal tensor over the pairs $(\alpha, k)$ in which
+the multiplicities $m_\alpha$ and the diagonal entries $\omega_{\alpha,k}$ stay explicit.
 The predicate `IsVerticalCF` states exactly this conclusion.
 
 ## Main definitions
@@ -36,19 +37,20 @@ The predicate `IsVerticalCF` states exactly this conclusion.
   pair and matrices acting on the physical space (arXiv:1606.00608, line 943).
 * `diagonalTensor`:
   the MPS tensor `i ↦ M i i` extracted from the diagonal MPO entries; its
-  coefficients are the diagonal entries `⟨σ|ρ^{(N)}(M)|σ⟩` of the generated
-  operator.
+  coefficients are the diagonal entries $\langle\sigma|\rho^{(N)}(M)|\sigma\rangle$ of the
+  generated operator.
 * `diagonalTransferMap`:
-  the transfer map of `diagonalTensor`, i.e. `E_diag(X) = Σ_i M^{ii} X (M^{ii})†`.
+  the transfer map of `diagonalTensor`, i.e.
+  $E_{\mathrm{diag}}(X) = \sum_i M^{ii} X (M^{ii})^\dagger$.
 * `HorizontalCFData` / `IsHorizontalCF`:
   lightweight horizontal canonical-form data for an MPO, expressed via the
   doubled-index MPS tensor `M.toMPSTensor`.
 * `IsVerticalCF`:
-  the vertical canonical form of arXiv:1606.00608, eq. UMU-appendix: an
-  isometry `U` on the physical space with
+  the vertical canonical form of arXiv:1606.00608, Proposition 4.13: an
+  isometry $U$ on the physical space with
   $U \widetilde M_{ab} U^\dagger = (\bigoplus_\alpha \mu_\alpha \otimes M_\alpha)_{ab}$
-  for every bond pair `(a, b)`, with positive diagonal matrices `μ_α` and a
-  BNT `{M_α}` for the vertically viewed tensor.
+  for every bond pair $(a, b)$, with positive diagonal matrices $\mu_\alpha$ and a
+  BNT $\{M_\alpha\}$ for the vertically viewed tensor.
 * `MPSTensor.diagBlock`:
   the diagonal restriction `B ↦ (i ↦ B (i, i))` of a doubled-index block.
 
@@ -64,8 +66,8 @@ The predicate `IsVerticalCF` states exactly this conclusion.
   under a horizontal canonical form, `diagonalTensor M` shares its MPV family with
   the single-spin block-diagonal assembly of the diagonally-restricted blocks.
 * `mpv_diagonalTensor_eq_mpo_diag` / `mpv_diagonalTensor_nonneg`:
-  the diagonal-tensor MPV equals the density-operator diagonal `⟨σ|ρ^{(N)}(M)|σ⟩`,
-  hence is nonnegative when `M` generates an MPDO.
+  the diagonal-tensor MPV equals the density-operator diagonal
+  $\langle\sigma|\rho^{(N)}(M)|\sigma\rangle$, hence is nonnegative when `M` generates an MPDO.
 * `Matrix.IsHermitian.opposite_corner_eq_zero` / `mpo_opposite_corner_eq_zero`:
   the positivity identity `P H = P H P ⇒ (1 - P) H P = 0` used in the first
   step of Proposition 4.13.
@@ -356,7 +358,7 @@ variable {d D : ℕ}
 /-- The **vertically viewed tensor** of an MPO tensor.  The vertical direction
 is obtained by exchanging the notion of physical and virtual indices
 (arXiv:1606.00608, line 943): the letters of the vertical tensor are indexed
-by the horizontal bond pair `(a, b)`, and each letter is the operator on the
+by the horizontal bond pair $(a, b)$, and each letter is the operator on the
 physical space with matrix elements $(\widetilde M_{ab})_{ij} = M^{ij}_{ab}$.
 Concatenating this tensor vertically generates the matrix product vectors of
 the vertical direction, and the vertical canonical form of
@@ -368,7 +370,7 @@ def verticalTensor (M : MPOTensor d D) : MPSTensor (D * D) d :=
     (i j : Fin d) : verticalTensor M ab i j = M i j ab.divNat ab.modNat :=
   rfl
 
-/-- The vertical letter at an explicitly paired bond index `(a, b)`. -/
+/-- The vertical letter at an explicitly paired bond index $(a, b)$. -/
 lemma verticalTensor_finProdFinEquiv (M : MPOTensor d D) (a b : Fin D)
     (i j : Fin d) :
     verticalTensor M (finProdFinEquiv (a, b)) i j = M i j a b := by
@@ -376,7 +378,7 @@ lemma verticalTensor_finProdFinEquiv (M : MPOTensor d D) (a b : Fin D)
 
 /-- The diagonal MPS tensor extracted from an MPO by restricting to equal ket
 and bra indices.  Its matrix product vectors are the diagonal entries
-`⟨σ|ρ^{(N)}(M)|σ⟩` of the generated operator
+$\langle\sigma|\rho^{(N)}(M)|\sigma\rangle$ of the generated operator
 (`mpv_diagonalTensor_eq_mpo_diag`), the positivity input to the vertical
 canonical form.  The tensor generating the vertical direction itself is
 `verticalTensor`. -/
@@ -491,7 +493,7 @@ theorem mpo_compress_trace_pos (M : MPOTensor d D) (hM : IsMPDO M) (N : ℕ)
   Matrix.PosSemidef.trace_pos_of_ne_zero (mpo_compress_posSemidef M hM N P hP) hne
 
 /-- The transfer map of the diagonal tensor of an MPO:
-`E_diag(X) = Σ_i M^{ii} X (M^{ii})†`.  It acts on the horizontal bond space;
+$E_{\mathrm{diag}}(X) = \sum_i M^{ii} X (M^{ii})^\dagger$.  It acts on the horizontal bond space;
 the transfer map of the vertically viewed tensor is
 `MPSTensor.transferMap (verticalTensor M)`, which acts on the physical
 space. -/
@@ -571,9 +573,10 @@ def verticalCopyWeights {g : ℕ} (mult : Fin g → ℕ)
     let p := finSigmaFinEquiv.symm q
     ω p.1 p.2
 
-/-- The direct-sum tensor `⊕_α μ_α ⊗ M_α` with positive diagonal matrices
-`μ_α = diag (ω α 0, …)`.  Since each `μ_α` is diagonal, the summand
-`μ_α ⊗ M_α` is the further direct sum `⊕_k ω_{α,k} M_α` of its diagonal
+/-- The direct-sum tensor $\bigoplus_\alpha \mu_\alpha \otimes M_\alpha$ with positive diagonal
+matrices $\mu_\alpha = \operatorname{diag}(\omega_{\alpha,0}, \dots)$.  Since each $\mu_\alpha$ is
+diagonal, the summand $\mu_\alpha \otimes M_\alpha$ is the further direct sum
+$\bigoplus_k \omega_{\alpha,k} M_\alpha$ of its diagonal
 entries; this constructor lists those blocks in exactly that order, so the
 multiplicities `mult α` and the diagonal entries `ω α k` stay explicit. -/
 noncomputable def verticalAssembledTensor {g : ℕ}
@@ -586,27 +589,27 @@ noncomputable def verticalAssembledTensor {g : ℕ}
     (A := verticalCopyBlocks dim mult A)
 
 /-- **Vertical canonical form** of an MPO tensor (arXiv:1606.00608,
-Proposition 4.13, eq. UMU-appendix, lines 1863--1870; the vertical direction
+Proposition 4.13, lines 1863--1870; the vertical direction
 is defined at line 943 by exchanging the physical and virtual indices).
 
-There are a basis of normal tensors `{M_α}` for the vertically viewed tensor,
-positive diagonal matrices `μ_α = diag (ω α 0, …)`, and an isometry `U` on the
-physical space such that, letter by letter over the horizontal bond pairs
-`(a, b)`,
+There are a basis of normal tensors $\{M_\alpha\}$ for the vertically viewed tensor,
+positive diagonal matrices $\mu_\alpha = \operatorname{diag}(\omega_{\alpha,0}, \dots)$, and an
+isometry $U$ on the physical space such that, letter by letter over the horizontal bond pairs
+$(a, b)$,
 $U \widetilde M_{ab} U^\dagger = (\bigoplus_\alpha \mu_\alpha \otimes M_\alpha)_{ab}$.
 
 The right-hand side keeps the multiplicities `mult α` and the diagonal
-entries `ω α k` explicit; the trace coefficients `m_α = tr μ_α` of this
+entries `ω α k` explicit; the trace coefficients $m_\alpha = \operatorname{tr}\,\mu_\alpha$ of this
 decomposition are the ones consumed by the renormalization fixed-point
 characterization at arXiv:1606.00608, line 1956.  Every basis tensor appears
-with at least one copy: each `μ_α` is a positive diagonal matrix of size
-`mult α ≥ 1`, matching arXiv:1606.00608, line 1901, where the sector `(α, 1)`
-exists for every `α`.
+with at least one copy: each $\mu_\alpha$ is a positive diagonal matrix of size
+`mult α`, at least one, matching arXiv:1606.00608, line 1901, where the sector
+$(\alpha, 1)$ exists for every $\alpha$.
 
 The isometry is a unitary change of the physical basis, so both `Uᴴ * U = 1`
-and `U * Uᴴ = 1` are required: the canonical form (arXiv:1606.00608,
-eq. II_CF1, read in the vertical direction) decomposes the physical space
-exactly, and the source discards `U` because "it just changes the physical
+and `U * Uᴴ = 1` are required: the canonical-form decomposition of
+arXiv:1606.00608 read in the vertical direction decomposes the physical space
+exactly, and the source discards $U$ because "it just changes the physical
 basis on each site" (arXiv:1606.00608, line 959).  With an isometric
 embedding alone, the decomposed space could exceed the physical space, which
 the source's conclusion excludes. -/

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -20,18 +20,44 @@
     for every word $w$ of length $L$ implies $\Delta_k=0$ for every block $k$.
 \end{definition}
 
+\begin{definition}[Vertically viewed tensor of an MPO]%
+    \label{def:vertical_tensor_mpdo}
+    \lean{MPOTensor.verticalTensor}
+    \leanok
+    \uses{def:mpo_tensor}
+    The \emph{vertical direction} of an MPO tensor exchanges the notion of
+    physical and virtual indices \cite[line~943]{Cirac2016MPDO_arXiv}: the
+    vertically viewed tensor $\widetilde M$ has its letters indexed by the
+    horizontal bond pair $(a,b)$, and each letter is the operator on the
+    physical space with matrix elements
+    \[
+        (\widetilde M_{ab})_{ij} = M^{ij}_{ab}.
+    \]
+    Concatenating $\widetilde M$ vertically generates the matrix product
+    vectors of the vertical direction.
+\end{definition}
+
 \begin{definition}[Vertical canonical form for an MPO]\label{def:vertical_cf_mpdo}
     \lean{MPOTensor.IsVerticalCF}
     \notready
-    \uses{def:mpo_tensor, def:bnt, def:same_mpv2, def:block_diagonal_tensor}
-    An MPO tensor is in \emph{vertical canonical form} if its diagonal MPS
-    tensor $\{M^{ii}\}_{i=0}^{d-1}$ generates the same MPV family as a
-    block-diagonal tensor obtained from a basis of normal tensors by repeating
-    each block according to a multiplicity and weighting each copy by a
-    positive scalar.
-    This is the flattened form of the decomposition
-    $\bigoplus_\alpha \mu_\alpha \otimes M_\alpha$
-    from \cite[Proposition~4.13]{Cirac2016MPDO_arXiv}.
+    \uses{def:mpo_tensor, def:vertical_tensor_mpdo, def:bnt,
+        def:block_diagonal_tensor}
+    An MPO tensor is in \emph{vertical canonical form} if there are a basis of
+    normal tensors $\{M_\alpha\}_\alpha$ for its vertically viewed tensor
+    $\widetilde M$, positive diagonal matrices
+    $\mu_\alpha=\operatorname{diag}(\omega_{\alpha,1},\dots,\omega_{\alpha,m_\alpha})$,
+    and an isometry $U$ on the physical space such that
+    \[
+        U\widetilde MU^\dagger=\bigoplus_\alpha \mu_\alpha\otimes M_\alpha.
+    \]
+    This is the conclusion of
+    \cite[Proposition~4.13, lines~1863--1870]{Cirac2016MPDO_arXiv}.
+    Since each $\mu_\alpha$ is diagonal, the summand
+    $\mu_\alpha\otimes M_\alpha$ is the direct sum
+    $\bigoplus_{k=1}^{m_\alpha}\omega_{\alpha,k}M_\alpha$ of weighted copies
+    of $M_\alpha$, so the right-hand side is a block-diagonal tensor over the
+    pairs $(\alpha,k)$ in which the multiplicities $m_\alpha$ and the diagonal
+    entries $\omega_{\alpha,k}$ stay explicit.
 \end{definition}
 
 \begin{figure}[ht]
@@ -320,10 +346,13 @@
     \lean{MPOTensor.ketLeftMul}
     \lean{MPOTensor.braRightMul}
     \lean{MPOTensor.firstSiteMatrix}
+    \lean{MPOTensor.verticalTensor_ketLeftMul}
+    \lean{MPOTensor.verticalTensor_braRightMul}
     \leanok
-    \uses{def:mpo_tensor}
+    \uses{def:mpo_tensor, def:vertical_tensor_mpdo}
     View the MPO tensor $M$ vertically as the family of physical-space
-    operators $M_{ab}$, indexed by the virtual indices, with matrix elements
+    operators $M_{ab}$ of Definition~\ref{def:vertical_tensor_mpdo}, indexed
+    by the virtual indices, with matrix elements
     $(M_{ab})_{ij}=M^{ij}_{ab}$.  A matrix $P\in M_d(\C)$ then acts on the
     tensor by
     \[
@@ -332,7 +361,9 @@
         (MP)^{ij}=\sum_k P_{kj}\,M^{ik},
     \]
     and on an $(N+1)$-site chain by the first-spin operator
-    $P\otimes\Id^{\otimes N}$.
+    $P\otimes\Id^{\otimes N}$.  On the letters of the vertically viewed
+    tensor these actions are the left and right matrix products,
+    $(PM)_{ab}=PM_{ab}$ and $(MP)_{ab}=M_{ab}P$.
 \end{definition}
 
 \begin{theorem}[One-sided invariance and density-operator commutation]
@@ -903,7 +934,8 @@
 \begin{theorem}[Horizontal canonical form implies vertical canonical form]
     \label{thm:vertical_cf_of_horizontal_cf}
     \notready
-    \uses{def:mpdo, def:horizontal_cf_mpdo, def:vertical_cf_mpdo,
+    \uses{def:mpdo, def:horizontal_cf_mpdo, def:vertical_tensor_mpdo,
+        def:vertical_cf_mpdo,
         thm:mpdo_opposite_corner_zero, thm:blockwise_opposite_insert_eq,
         thm:blockwise_opposite_insert_rotated_mpo,
         thm:mpdo_first_site_invariant_comm,
@@ -918,7 +950,15 @@
         lem:mpv_diagonal_tensor_eq_blocks, lem:mpv_diagonal_tensor_nonneg,
         lem:mpv_vertical_assembled,
         lem:vertical_grouping_equiv}
-    Every MPDO in horizontal canonical form is also in vertical canonical form.
+    A tensor in horizontal canonical form that generates matrix product
+    density operators is also in canonical form in the vertical direction:
+    there are a basis of normal tensors $\{M_\alpha\}_\alpha$ for the
+    vertically viewed tensor $\widetilde M$, positive diagonal matrices
+    $\mu_\alpha$, and an isometry $U$ on the physical space with
+    \[
+        U\widetilde MU^\dagger=\bigoplus_\alpha\mu_\alpha\otimes M_\alpha.
+    \]
+    This is \cite[Proposition~4.13]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 
 \begin{proof}
@@ -943,32 +983,33 @@
     commuting with $[H^{(N)}]^p$ commutes with $H^{(N)}$.  It remains to prove
     that a nontrivial vertical period supplies one orthogonal projector $Q$
     with the two all-length properties stated in source lines 1889--1890.
-    One must then apply the canonical-form theorem in the vertical direction to obtain a
-    new vertical family $(B_k)_{k\in I}$ and weights $\nu_k$.  This family is not obtained by
-    restricting the horizontal blocks to diagonal physical pairs, as
-    Theorem~\ref{thm:diagonal_restriction_not_normal} shows.  Instead it satisfies
+    One must then apply the canonical-form theorem in the vertical direction
+    to the vertically viewed tensor $\widetilde M$, obtaining a decomposition
     \[
-        V^{(N)}\bigl(i\mapsto M^{ii}\bigr)
-        =V^{(N)}\Bigl(\textstyle\bigoplus_{k\in I}\nu_k B_k\Bigr).
+        \widetilde M
+        =\bigoplus_{\alpha,k}\mu_{\alpha,k}X_{\alpha,k}M_\alpha X_{\alpha,k}^{-1}
     \]
-    Group gauge-equivalent vertical sectors by a bijection
-    $e(k)=(\alpha,j)$.  Once the corresponding dimensions, weights, and
-    positive-length matrix product vectors are identified,
-    Lemma~\ref{lem:vertical_grouping_equiv} gives
+    carried by the physical space, with normal tensors $M_\alpha$ whose
+    letters remain indexed by the horizontal bond pairs.  These blocks are not
+    obtained by restricting the horizontal blocks to diagonal physical pairs,
+    as Theorem~\ref{thm:diagonal_restriction_not_normal} shows.  Positivity
+    then gives $\mu_{\alpha,k}>0$:
+    Theorem~\ref{thm:mpdo_sector_compression_trace_pos} supplies the positive
+    traces of the nonzero sector compressions.
+    Theorem~\ref{thm:eq3_of_dressed_adjoint} derives equation eq3,
     \[
-        V^{(N)}\bigl(i\mapsto M^{ii}\bigr)
-        =V^{(N)}\Bigl(
-          \textstyle\bigoplus_\alpha\bigoplus_{j=0}^{m_\alpha-1}
-          \omega_{\alpha j}A_\alpha
-        \Bigr)
+        X_{\alpha,k}^\dagger X_{\alpha,k}
+        =\omega_{\alpha,k}\,X_{\alpha,1}^\dagger X_{\alpha,1},
     \]
-    for every $N$, including $N=0$.  A final use of positivity gives
-    $\omega_{\alpha j}>0$ and makes the similarities between grouped sectors
-    unitary: Theorem~\ref{thm:mpdo_sector_compression_trace_pos} gives the
-    positive traces of the nonzero sector compressions, and
-    Theorem~\ref{thm:eq3_of_dressed_adjoint} derives equation eq3 and the
-    isometric normalization of the sector gauges from the blockwise
-    dressed-adjoint identities of the two displayed diagrams.  Deriving those
+    and the isometric normalization
+    $U_{\alpha,k}=\omega_{\alpha,k}^{-1/2}X_{\alpha,k}$ of the sector gauges
+    from the blockwise dressed-adjoint identities of the two displayed
+    diagrams.  Composing the sector unitaries $U_{\alpha,k}$ yields the
+    isometry $U$ with
+    $U\widetilde MU^\dagger=\bigoplus_\alpha\mu_\alpha\otimes M_\alpha$; each
+    $\mu_\alpha$ is diagonal, so the summands regroup as repeated weighted
+    copies of $M_\alpha$ exactly as in the finite regrouping of
+    Lemma~\ref{lem:vertical_grouping_equiv}.  Deriving the dressed-adjoint
     identities from self-adjointness of the sector compressions via Lemma L
     within the vertical decomposition remains open, as does the construction
     of the vertical canonical decomposition itself.

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -45,7 +45,8 @@
     An MPO tensor is in \emph{vertical canonical form} if there are a basis of
     normal tensors $\{M_\alpha\}_\alpha$ for its vertically viewed tensor
     $\widetilde M$, positive diagonal matrices
-    $\mu_\alpha=\operatorname{diag}(\omega_{\alpha,1},\dots,\omega_{\alpha,m_\alpha})$,
+    $\mu_\alpha=\operatorname{diag}(\omega_{\alpha,1},\dots,\omega_{\alpha,m_\alpha})$
+    with $m_\alpha\geq1$,
     and an isometry $U$ on the physical space such that
     \[
         U\widetilde MU^\dagger=\bigoplus_\alpha \mu_\alpha\otimes M_\alpha.

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -39,7 +39,7 @@
 
 \begin{definition}[Vertical canonical form for an MPO]\label{def:vertical_cf_mpdo}
     \lean{MPOTensor.IsVerticalCF}
-    \notready
+    \leanok
     \uses{def:mpo_tensor, def:vertical_tensor_mpdo, def:bnt,
         def:block_diagonal_tensor}
     An MPO tensor is in \emph{vertical canonical form} if there are a basis of
@@ -53,6 +53,10 @@
     \]
     This is the conclusion of
     \cite[Proposition~4.13, lines~1863--1870]{Cirac2016MPDO_arXiv}.
+    The isometry is a unitary change of the physical basis: the canonical
+    form decomposes the physical space exactly, and the source treats $U$ as
+    a change of the physical basis on each site
+    \cite[line~959]{Cirac2016MPDO_arXiv}.
     Since each $\mu_\alpha$ is diagonal, the summand
     $\mu_\alpha\otimes M_\alpha$ is the direct sum
     $\bigoplus_{k=1}^{m_\alpha}\omega_{\alpha,k}M_\alpha$ of weighted copies
@@ -997,7 +1001,7 @@
     then gives $\mu_{\alpha,k}>0$:
     Theorem~\ref{thm:mpdo_sector_compression_trace_pos} supplies the positive
     traces of the nonzero sector compressions.
-    Theorem~\ref{thm:eq3_of_dressed_adjoint} derives equation eq3,
+    Theorem~\ref{thm:eq3_of_dressed_adjoint} derives the identity
     \[
         X_{\alpha,k}^\dagger X_{\alpha,k}
         =\omega_{\alpha,k}\,X_{\alpha,1}^\dagger X_{\alpha,1},

--- a/docs/paper-gaps/cpgsv17_vertical_tensor_definition.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_tensor_definition.tex
@@ -1,0 +1,114 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{The Vertical Direction in Proposition 4.13 Is the Index-Exchanged Tensor}
+\author{}
+\date{2026-07-11}
+
+\begin{document}
+\maketitle
+
+\section{Source definition of the vertical direction}
+
+Proposition~4.13 (source label \path{Prop:IV.12}) of
+\cite{Cirac2016MPDO_arXiv} is a statement about the tensor viewed in the
+vertical direction.  The source defines that direction explicitly: the tensor
+is considered ``as generating MPV by concatenating it vertically, and thus by
+exchanging the notion of physical and virtual indices''
+(\path{Papers/1606.00608/MPDO-22-12-17-2.tex}, line~943).  The vertically
+viewed tensor $\widetilde M$ therefore has its letters indexed by the
+horizontal bond pair $(a,b)$, each letter being the operator on the physical
+space with matrix elements
+\begin{equation}
+  (\widetilde M_{ab})_{ij}=M^{ij}_{ab}.
+  \label{eq:vertical-letters}
+\end{equation}
+The conclusion of Proposition~4.13 (restated at lines~1863--1870, equation
+\path{UMU-appendix}) is that for a canonical-form tensor generating matrix
+product density operators there is an isometry $U$ on the physical space with
+\begin{equation}
+  U\widetilde MU^\dagger=\bigoplus_\alpha\mu_\alpha\otimes M_\alpha,
+  \label{eq:umu}
+\end{equation}
+where the $\mu_\alpha$ are positive diagonal matrices and $\{M_\alpha\}_\alpha$
+is a basis of normal tensors for $\widetilde M$.  The multiplicity
+coefficients $m_\alpha=\tr(\mu_\alpha)$ of this decomposition are consumed by
+the renormalization fixed-point characterization (Theorem~4.14, line~1956).
+
+\section{The former diagonal-tensor surrogate}
+
+Until this realignment, the formal vertical canonical-form predicate stated
+the conclusion of Proposition~4.13 as a property of the \emph{diagonal} MPS
+tensor $i\mapsto M^{ii}$: the diagonal tensor was required to generate the
+same matrix product vector family as a block-diagonal tensor obtained by
+repeating basis blocks with positive scalar weights.  Both sides of that
+comparison live on the physical alphabet $\{0,\dots,d-1\}$ and have matrices
+acting on the horizontal bond space --- the opposite of
+\eqref{eq:vertical-letters}, where the letters range over bond pairs and the
+matrices act on the physical space.
+
+The surrogate also cannot carry the multiplicity coefficients of
+\eqref{eq:umu}.  Take $d=2$, $D=1$, and $M^{ij}=\delta_{ij}/2$, a matrix
+product density operator in canonical form.  Its vertically viewed tensor is
+the single physical-space letter $\widetilde M_{11}=\tfrac12\Id_2$, whose
+decomposition \eqref{eq:umu} has one block with
+$\mu=\operatorname{diag}(\tfrac12,\tfrac12)$: the multiplicity is $2$ and
+$m=\tr(\mu)=1$.  The diagonal tensor, by contrast, has the scalar family
+$V^{(N)}=2^{-N}$, and a two-weight flattening would require positive reals
+with
+\[
+  \omega_1^N+\omega_2^N=2^{-N}\qquad(N\geq1);
+\]
+the cases $N=1$ and $N=2$ force $\omega_1\omega_2=0$, a contradiction.  The
+surrogate is therefore satisfiable only with multiplicity $1$ for this
+tensor, so the coefficients $m_\alpha$ needed at line~1956 are lost.
+Consequently the diagonal-tensor statement is \emph{not} a corollary of
+Proposition~4.13, and a proof of the surrogate would not formalize the
+proposition.
+
+\section{The realigned formal statement}
+
+The realignment (\ghissue{3712}) introduces the vertically viewed tensor
+\eqref{eq:vertical-letters} as a formal object and restates the vertical
+canonical-form predicate on it: there are a basis of normal tensors
+$\{M_\alpha\}_\alpha$ for $\widetilde M$, positive diagonal matrices
+$\mu_\alpha=\operatorname{diag}(\omega_{\alpha,1},\dots,\omega_{\alpha,m_\alpha})$,
+and an isometry $U$ on the physical space satisfying \eqref{eq:umu} letter by
+letter over the horizontal bond pairs.  Since each $\mu_\alpha$ is diagonal,
+the summand $\mu_\alpha\otimes M_\alpha$ is the direct sum
+$\bigoplus_k\omega_{\alpha,k}M_\alpha$, so the right-hand side of
+\eqref{eq:umu} is a block-diagonal tensor over the pairs $(\alpha,k)$ in
+which both the multiplicities $m_\alpha$ and the diagonal entries
+$\omega_{\alpha,k}$ remain explicit.  The one-site actions used in the
+invariant-projection step are identified with left and right multiplication
+on the letters of $\widetilde M$.
+
+The diagonal-tensor identities remain in the development as auxiliary
+results: the matrix product vectors of $i\mapsto M^{ii}$ are the diagonal
+entries $\langle\sigma|\rho^{(N)}(M)|\sigma\rangle$ of the density operator,
+which is the positivity input to the proof of Proposition~4.13.  They no
+longer state its conclusion.
+
+\section{Relation to the neighboring notes}
+
+\path{cpgsv17_vertical_cf_grouping.tex} records that the positive diagonal
+coefficients in \eqref{eq:umu} arise from the vertical canonical
+decomposition, not from flattening horizontal weights;
+\path{cpgsv17_vertical_diagonal_restriction.tex} records that diagonal
+restriction of horizontal blocks does not preserve normality.  Neither note
+documented the definitional mismatch addressed here: the former predicate
+placed the conclusion of Proposition~4.13 on the wrong tensor.  The
+source-faithful horizontal-to-vertical implication itself remains
+unformalized and is tracked by the blueprint entry for Proposition~4.13 in
+\path{blueprint/src/chapter/ch20_mpdo_canonical_forms.tex}.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/cpgsv17_vertical_tensor_definition.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_tensor_definition.tex
@@ -108,6 +108,18 @@ source-faithful horizontal-to-vertical implication itself remains
 unformalized and is tracked by the blueprint entry for Proposition~4.13 in
 \path{blueprint/src/chapter/ch20_mpdo_canonical_forms.tex}.
 
+\paragraph{Verdict.}
+This is a corrected definitional mismatch.  The former predicate placed the
+conclusion of Proposition~4.13 on the diagonal tensor $i\mapsto M^{ii}$
+rather than on the vertically viewed tensor $\widetilde M$ defined at source
+line~943, and the $d=2$, $D=1$ example shows the diagonal surrogate cannot
+carry the multiplicity coefficients $m_\alpha=\tr(\mu_\alpha)$ of
+\eqref{eq:umu}; a proof of the surrogate would therefore not have formalized
+the proposition.  The realignment restores the source-faithful vertical
+tensor definition and the isometry-form conclusion.  The
+horizontal-to-vertical implication of Proposition~4.13 itself remains an
+open gap.
+
 \bibliographystyle{alpha}
 \bibliography{references}
 

--- a/docs/paper-gaps/cpgsv17_vertical_tensor_definition.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_tensor_definition.tex
@@ -78,9 +78,13 @@ The realignment (\ghissue{3712}) introduces the vertically viewed tensor
 \eqref{eq:vertical-letters} as a formal object and restates the vertical
 canonical-form predicate on it: there are a basis of normal tensors
 $\{M_\alpha\}_\alpha$ for $\widetilde M$, positive diagonal matrices
-$\mu_\alpha=\operatorname{diag}(\omega_{\alpha,1},\dots,\omega_{\alpha,m_\alpha})$,
-and an isometry $U$ on the physical space satisfying \eqref{eq:umu} letter by
-letter over the horizontal bond pairs.  Since each $\mu_\alpha$ is diagonal,
+$\mu_\alpha=\operatorname{diag}(\omega_{\alpha,1},\dots,\omega_{\alpha,m_\alpha})$
+with $m_\alpha\geq1$, and an isometry $U$ on the physical space satisfying
+\eqref{eq:umu} letter by letter over the horizontal bond pairs.  The isometry
+is required to be a unitary change of the physical basis ($U^\dagger U=\Id$
+and $UU^\dagger=\Id$): the canonical form decomposes the physical space
+exactly, and the source discards $U$ because ``it just changes the physical
+basis on each site'' (line~959).  Since each $\mu_\alpha$ is diagonal,
 the summand $\mu_\alpha\otimes M_\alpha$ is the direct sum
 $\bigoplus_k\omega_{\alpha,k}M_\alpha$, so the right-hand side of
 \eqref{eq:umu} is a block-diagonal tensor over the pairs $(\alpha,k)$ in


### PR DESCRIPTION
## Summary

Paper-realignment of the vertical canonical form for MPO tensors (`TNLean/MPS/MPDO/VerticalCF.lean`) against arXiv:1606.00608, Proposition 4.13.

The previous `MPOTensor.IsVerticalCF` stated the proposition's conclusion as a positive-weight block decomposition of the **diagonal tensor's** matrix product vector family. The source defines the vertical direction by *exchanging the notion of physical and virtual indices* (`Papers/1606.00608/MPDO-22-12-17-2.tex`, line 943): the vertical tensor's letters are indexed by the horizontal bond pair $(a,b)$ and its matrices act on the physical space, and the conclusion is the isometry form $U\widetilde MU^\dagger=\bigoplus_\alpha\mu_\alpha\otimes M_\alpha$ with positive diagonal $\mu_\alpha$ and a BNT $\{M_\alpha\}$ (lines 1863–1870, eq. `UMU-appendix`). The diagonal surrogate cannot carry the multiplicity coefficients $m_\alpha=\mathrm{tr}(\mu_\alpha)$ consumed at line 1956 (see the $d=2$, $D=1$, $M^{ij}=\delta_{ij}/2$ obstruction in the paper-gap note), so it is not even a corollary of the source statement.

## Changes

- **New** `MPOTensor.verticalTensor`: the vertically viewed tensor, letters indexed by the bond pair, matrices on the physical space (source line 943), with `verticalTensor_apply` / `verticalTensor_finProdFinEquiv`.
- **Restated** `MPOTensor.IsVerticalCF` on the vertically viewed tensor: a BNT $\{M_\alpha\}$ for $\widetilde M$, positive diagonal entries $\omega_{\alpha,k}$ with explicit multiplicities $m_\alpha$, and an isometry $U$ on the physical space with $U\widetilde M_{ab}U^\dagger=(\bigoplus_\alpha\mu_\alpha\otimes M_\alpha)_{ab}$ for every bond pair, using that a diagonal Kronecker factor is the direct sum of its diagonal entries (the existing exact block assembly).
- **Removed** the diagonal-tensor form of the predicate. It had no consumers (no theorem proved or consumed it), and the multiplicity obstruction shows it is not a consequence of Proposition 4.13, so it is deleted rather than kept under another name. No deprecation alias, per the mathematical-language rename convention (`docs/CONTRIBUTING.md`): the old name encoded the misleading identification of the diagonal family with the vertical direction.
- **Renamed** `MPOTensor.verticalTransferMap` → `MPOTensor.diagonalTransferMap` (it is the transfer map of the diagonal tensor on the horizontal bond space, not the vertical transfer map). No consumers; no deprecation alias for the same reason.
- **New lemmas** `MPOTensor.verticalTensor_ketLeftMul` / `verticalTensor_braRightMul` (`InvariantProjection.lean`): the one-site actions of #3684 are letterwise left/right multiplication on the vertically viewed tensor.
- **Blueprint (ch20)**: new entry `def:vertical_tensor_mpdo` (`\leanok`); `def:vertical_cf_mpdo` restated to the faithful isometry form (stays `\notready`); `thm:vertical_cf_of_horizontal_cf` statement restated to the source's conclusion and its proof sketch reworked to the vertical decomposition $\widetilde M=\bigoplus_{\alpha,k}\mu_{\alpha,k}X_{\alpha,k}M_\alpha X_{\alpha,k}^{-1}$ (stays `\notready`); `def:mpdo_vertical_one_site_actions` now references the vertical tensor definition.
- **Docstrings** that presented the diagonal tensor as the vertical view are re-pointed (`diagonalTensor`, `verticalAssembledTensor`, module docstring).
- **Paper-gap note** `docs/paper-gaps/cpgsv17_vertical_tensor_definition.tex` records the definitional mismatch, the multiplicity obstruction, and the realigned statement; it complements `cpgsv17_vertical_cf_grouping.tex` and `cpgsv17_vertical_diagonal_restriction.tex`, which document the grouping and diagonal-restriction issues only.

## Sorry inventory

None. No `sorry` is introduced: the removed predicate had no consumers, and all retained lemmas (contractions, compressions, trace identities, regrouping) are stated at the tensor level and are unaffected. The horizontal-to-vertical implication itself remains unformalized and `\notready`, tracked by #3674 / #2537.

## Verification

- `lake build` succeeds (no new warnings; changed files contain no `sorry`/`axiom`)
- `leanblueprint checkdecls` passes
- `scripts/blueprint_lean_sync.py --ci` passes
- `scripts/check_reader_facing_prose.py --ci --diff-base origin/main` passes
- `lake exe lint_style` passes
- `scripts/check_forbidden_lean_tokens.py`, `scripts/check_oversized_lean_files.py` pass
- `latexmk` builds the new paper-gap note
- `git diff --check` clean

Closes #3712.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This changes a central formal predicate and blueprint definitions for MPDO canonical forms; impact is limited because the old `IsVerticalCF` had no Lean consumers, but downstream work must target the new statement and the main horizontal→vertical theorem remains unproved.
> 
> **Overview**
> Realigns **vertical canonical form** with arXiv:1606.00608 Proposition 4.13: the conclusion is stated on the **vertically viewed** tensor (bond-index letters, physical-space matrices), not on the diagonal MPS tensor’s MPV family.
> 
> **Lean:** Adds `MPOTensor.verticalTensor` and redefines `IsVerticalCF` as a BNT for `verticalTensor M`, explicit multiplicities and positive diagonal weights, and a **unitary** `U` on physical space with letterwise `U \widetilde M_{ab} U^\dagger` matching the flattened block assembly. Drops the old diagonal-tensor MPV surrogate (no downstream theorems used it). Renames `verticalTransferMap` → `diagonalTransferMap`. Adds `verticalTensor_ketLeftMul` / `verticalTensor_braRightMul` linking one-site actions to matrix multiplication on vertical letters.
> 
> **Docs:** Blueprint gains `def:vertical_tensor_mpdo`, restates vertical CF and the horizontal→vertical theorem sketch; new paper-gap note documents the mismatch and a multiplicity obstruction for the old predicate. Diagonal-tensor lemmas stay as positivity/auxiliary input, not as the proposition’s conclusion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b90d78005289a7bf93bf65f2a4e9650a44ce975. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->