### PR TITLE
feat(Algebra): full block form of a star-subalgebra via the double commutant

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -39,6 +39,7 @@ import TNLean.Algebra.CocycleCohomology
 import TNLean.Algebra.SpinCover
 import TNLean.Algebra.MatrixRankClosed
 import TNLean.Algebra.StarSubalgebraBlockDiagonal
+import TNLean.Algebra.StarSubalgebraBlockForm
 import TNLean.Algebra.StarSubalgebraIntertwinerIsometry
 import TNLean.Algebra.StarSubalgebraIrreducibleDecomp
 import TNLean.Algebra.StarSubalgebraIsotypic

--- a/TNLean/Algebra/StarSubalgebraBlockDiagonal.lean
+++ b/TNLean/Algebra/StarSubalgebraBlockDiagonal.lean
@@ -27,6 +27,10 @@ block that Theorem 6.14 reserves for the complement of the support.
   indexed by a component index $k$, a multiplicity index $i < m_k$, and an irreducible index
   $j < d_k$, on which every member of the subalgebra acts by one matrix on the irreducible
   index, identically across the multiplicity index, within each component.
+* `StarSubalgebra.exists_unitary_conj_blockDiagonal_of_orthonormalBasis` -- the change of
+  basis to an orthonormal basis indexed this way is unitary, and it carries every matrix
+  acting on the basis by one block per component to the block-diagonal matrix with blocks
+  $\mathbf{1}_{m_k} \otimes B_k$.
 * `StarSubalgebra.exists_unitary_conj_blockDiagonal` -- a unitary $U$ such that for every
   $A$ in the subalgebra, $U^{\dagger} A U$ is block diagonal with blocks
   $\mathbf{1}_{m_k} \otimes B_k$.
@@ -160,34 +164,33 @@ theorem exists_adapted_orthonormalBasis :
     rw [hb k (i, j), hB (σ k) i j]
     exact Finset.sum_congr rfl fun j' _ => by rw [hb k (i, j')]
 
-/-- **Global unitary block-diagonal form.** For a star-subalgebra $S$ of complex matrices
-there are a number $K$ of isotypic components, positive dimensions $d_k$ and multiplicities
-$m_k$ with $\sum_k d_k m_k = D$, and a unitary $U \in M_{D}(\mathbb{C})$ such that every
-$A \in S$ satisfies
-$$U^{\dagger} A U \;=\; \bigoplus_{k} \mathbf{1}_{m_k} \otimes B_k$$
-for matrices $B_k \in M_{d_k}(\mathbb{C})$ depending on $A$. The columns of $U$ are the
-adapted orthonormal basis of `StarSubalgebra.exists_adapted_orthonormalBasis`; the index
-identification realizing $\sum_k d_k m_k = D$ is part of the statement. Up to reordering the
-two tensor factors this is the block representation of *Quantum Channels & Operations*
-(Wolf 2012), Theorem 6.14, in the unital case: a star-subalgebra contains the identity, so
-there is no zero block. Only the containment direction is stated: every member of $S$ is
-carried by $U$ into the block algebra. The equality, including the reverse inclusion, is
-`StarSubalgebra.exists_unitary_conj_blockDiagonal_iff`. -/
-theorem exists_unitary_conj_blockDiagonal :
-    ∃ (K : ℕ) (d m : Fin K → ℕ) (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ n)
-      (U : Matrix n n ℂ), U ∈ Matrix.unitaryGroup n ℂ ∧ (∀ k, 0 < d k) ∧ (∀ k, 0 < m k) ∧
-        ∀ A ∈ S, ∃ B : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ,
+/-- **Unitary change of basis to block-diagonal form.** Let $(f_{k,i,j})_{k,i,j}$ be an
+orthonormal basis of $\mathbb{C}^{D}$ indexed by a component index $k < K$, a multiplicity
+index $i < m_k$, and an irreducible index $j < d_k$. There are an identification of the index
+set with $\{0, \ldots, D-1\}$, realizing $\sum_k d_k m_k = D$, and a unitary
+$U \in M_{D}(\mathbb{C})$, whose columns are the basis vectors, such that every matrix $A$
+acting on the basis by
+$$A\,f_{k,i,j} \;=\; \sum_{j'} (B_k)_{j'j}\, f_{k,i,j'}$$
+satisfies $U^{\dagger} A U = \bigoplus_{k} \mathbf{1}_{m_k} \otimes B_k$. The matrix
+$U^{\dagger} A U = U^{-1} A U$ is the matrix of the operator $x \mapsto Ax$ in the basis
+$(f_{k,i,j})$, whose entries the action property and orthonormality make
+$\delta_{k'k}\,\delta_{i'i}\,(B_k)_{j'j}$. This is the change-of-basis computation behind the
+block representation of *Quantum Channels & Operations* (Wolf 2012), Theorem 6.14. -/
+theorem exists_unitary_conj_blockDiagonal_of_orthonormalBasis {K : ℕ} {d m : Fin K → ℕ}
+    (b : OrthonormalBasis ((k : Fin K) × (Fin (m k) × Fin (d k))) ℂ (EuclideanSpace ℂ n)) :
+    ∃ (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ n) (U : Matrix n n ℂ),
+      U ∈ Matrix.unitaryGroup n ℂ ∧
+        ∀ (A : Matrix n n ℂ) (B : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ),
+          (∀ (k : Fin K) (i : Fin (m k)) (j : Fin (d k)),
+            Matrix.toEuclideanLin A (b ⟨k, (i, j)⟩) = ∑ j', B k j' j • b ⟨k, (i, j')⟩) →
           star U * A * U = Matrix.reindex e e
             (Matrix.blockDiagonal' fun k => (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ B k) := by
   classical
-  obtain ⟨K, d, m, b, hd, hm, -, -, hact⟩ := S.exists_adapted_orthonormalBasis
   set s : OrthonormalBasis n ℂ (EuclideanSpace ℂ n) := EuclideanSpace.basisFun n ℂ with hs
   set e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ n := b.toBasis.indexEquiv s.toBasis with he
   set b' : OrthonormalBasis n ℂ (EuclideanSpace ℂ n) := b.reindex e with hb'
-  refine ⟨K, d, m, e, s.toBasis.toMatrix ⇑b'.toBasis,
-    s.toMatrix_orthonormalBasis_mem_unitary b', hd, hm, fun A hA => ?_⟩
-  obtain ⟨B, hB⟩ := hact A hA
-  refine ⟨B, ?_⟩
+  refine ⟨e, s.toBasis.toMatrix ⇑b'.toBasis,
+    s.toMatrix_orthonormalBasis_mem_unitary b', fun A B hB => ?_⟩
   -- The conjugate transpose of the change-of-basis matrix is the reverse change of basis.
   have hstar : star (s.toBasis.toMatrix ⇑b'.toBasis) = b'.toBasis.toMatrix ⇑s.toBasis := by
     have h1 : star (s.toBasis.toMatrix ⇑b'.toBasis) * s.toBasis.toMatrix ⇑b'.toBasis = 1 :=
@@ -239,5 +242,32 @@ theorem exists_unitary_conj_blockDiagonal :
     _ = Matrix.reindex e e
           (Matrix.blockDiagonal' fun k => (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ B k) := by
         rw [hreindex, hmatrix]
+
+/-- **Global unitary block-diagonal form.** For a star-subalgebra $S$ of complex matrices
+there are a number $K$ of isotypic components, positive dimensions $d_k$ and multiplicities
+$m_k$ with $\sum_k d_k m_k = D$, and a unitary $U \in M_{D}(\mathbb{C})$ such that every
+$A \in S$ satisfies
+$$U^{\dagger} A U \;=\; \bigoplus_{k} \mathbf{1}_{m_k} \otimes B_k$$
+for matrices $B_k \in M_{d_k}(\mathbb{C})$ depending on $A$. The columns of $U$ are the
+adapted orthonormal basis of `StarSubalgebra.exists_adapted_orthonormalBasis`, through the
+change of basis of `StarSubalgebra.exists_unitary_conj_blockDiagonal_of_orthonormalBasis`;
+the index identification realizing $\sum_k d_k m_k = D$ is part of the statement. Up to
+reordering the two tensor factors this is the block representation of
+*Quantum Channels & Operations* (Wolf 2012), Theorem 6.14, in the unital case: a
+star-subalgebra contains the identity, so there is no zero block. Only the containment
+direction is stated: every member of $S$ is carried by $U$ into the block algebra. The
+equality, including the reverse inclusion, is
+`StarSubalgebra.exists_unitary_conj_blockDiagonal_iff`. -/
+theorem exists_unitary_conj_blockDiagonal :
+    ∃ (K : ℕ) (d m : Fin K → ℕ) (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ n)
+      (U : Matrix n n ℂ), U ∈ Matrix.unitaryGroup n ℂ ∧ (∀ k, 0 < d k) ∧ (∀ k, 0 < m k) ∧
+        ∀ A ∈ S, ∃ B : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ,
+          star U * A * U = Matrix.reindex e e
+            (Matrix.blockDiagonal' fun k => (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ B k) := by
+  obtain ⟨K, d, m, b, hd, hm, -, -, hact⟩ := S.exists_adapted_orthonormalBasis
+  obtain ⟨e, U, hUmem, hconj⟩ := exists_unitary_conj_blockDiagonal_of_orthonormalBasis b
+  refine ⟨K, d, m, e, U, hUmem, hd, hm, fun A hA => ?_⟩
+  obtain ⟨B, hB⟩ := hact A hA
+  exact ⟨B, hconj A B hB⟩
 
 end StarSubalgebra

--- a/TNLean/Algebra/StarSubalgebraBlockDiagonal.lean
+++ b/TNLean/Algebra/StarSubalgebraBlockDiagonal.lean
@@ -27,7 +27,7 @@ block that Theorem 6.14 reserves for the complement of the support.
   indexed by a component index $k$, a multiplicity index $i < m_k$, and an irreducible index
   $j < d_k$, on which every member of the subalgebra acts by one matrix on the irreducible
   index, identically across the multiplicity index, within each component.
-* `StarSubalgebra.exists_unitary_conj_blockDiagonal_of_orthonormalBasis` -- the change of
+* `OrthonormalBasis.exists_unitary_conj_blockDiagonal` -- the change of
   basis to an orthonormal basis indexed this way is unitary, and it carries every matrix
   acting on the basis by one block per component to the block-diagonal matrix with blocks
   $\mathbf{1}_{m_k} \otimes B_k$.
@@ -43,6 +43,91 @@ directions into the equality of Theorem 6.14.
 -/
 
 open scoped InnerProductSpace Kronecker
+
+namespace OrthonormalBasis
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- **Unitary change of basis to block-diagonal form.** Let $(f_{k,i,j})_{k,i,j}$ be an
+orthonormal basis of $\mathbb{C}^{D}$ indexed by a component index $k < K$, a multiplicity
+index $i < m_k$, and an irreducible index $j < d_k$. There are an identification of the index
+set with $\{0, \ldots, D-1\}$, realizing $\sum_k d_k m_k = D$, and a unitary
+$U \in M_{D}(\mathbb{C})$, whose columns are the basis vectors, such that every matrix $A$
+acting on the basis by
+$$A\,f_{k,i,j} \;=\; \sum_{j'} (B_k)_{j'j}\, f_{k,i,j'}$$
+satisfies $U^{\dagger} A U = \bigoplus_{k} \mathbf{1}_{m_k} \otimes B_k$. The matrix
+$U^{\dagger} A U = U^{-1} A U$ is the matrix of the operator $x \mapsto Ax$ in the basis
+$(f_{k,i,j})$, whose entries the action property and orthonormality make
+$\delta_{k'k}\,\delta_{i'i}\,(B_k)_{j'j}$. This is the change-of-basis computation behind the
+block representation of *Quantum Channels & Operations* (Wolf 2012), Theorem 6.14. -/
+theorem exists_unitary_conj_blockDiagonal {K : ℕ} {d m : Fin K → ℕ}
+    (b : OrthonormalBasis ((k : Fin K) × (Fin (m k) × Fin (d k))) ℂ (EuclideanSpace ℂ n)) :
+    ∃ (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ n) (U : Matrix n n ℂ),
+      U ∈ Matrix.unitaryGroup n ℂ ∧
+        ∀ (A : Matrix n n ℂ) (B : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ),
+          (∀ (k : Fin K) (i : Fin (m k)) (j : Fin (d k)),
+            Matrix.toEuclideanLin A (b ⟨k, (i, j)⟩) = ∑ j', B k j' j • b ⟨k, (i, j')⟩) →
+          star U * A * U = Matrix.reindex e e
+            (Matrix.blockDiagonal' fun k => (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ B k) := by
+  classical
+  set s : OrthonormalBasis n ℂ (EuclideanSpace ℂ n) := EuclideanSpace.basisFun n ℂ with hs
+  set e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ n := b.toBasis.indexEquiv s.toBasis with he
+  set b' : OrthonormalBasis n ℂ (EuclideanSpace ℂ n) := b.reindex e with hb'
+  refine ⟨e, s.toBasis.toMatrix ⇑b'.toBasis,
+    s.toMatrix_orthonormalBasis_mem_unitary b', fun A B hB => ?_⟩
+  -- The conjugate transpose of the change-of-basis matrix is the reverse change of basis.
+  have hstar : star (s.toBasis.toMatrix ⇑b'.toBasis) = b'.toBasis.toMatrix ⇑s.toBasis := by
+    have h1 : star (s.toBasis.toMatrix ⇑b'.toBasis) * s.toBasis.toMatrix ⇑b'.toBasis = 1 :=
+      Matrix.mem_unitaryGroup_iff'.mp (s.toMatrix_orthonormalBasis_mem_unitary b')
+    have h2 : s.toBasis.toMatrix ⇑b'.toBasis * b'.toBasis.toMatrix ⇑s.toBasis = 1 :=
+      Module.Basis.toMatrix_mul_toMatrix_flip _ _
+    calc star (s.toBasis.toMatrix ⇑b'.toBasis)
+        = star (s.toBasis.toMatrix ⇑b'.toBasis) *
+            (s.toBasis.toMatrix ⇑b'.toBasis * b'.toBasis.toMatrix ⇑s.toBasis) := by
+          rw [h2, mul_one]
+      _ = star (s.toBasis.toMatrix ⇑b'.toBasis) * s.toBasis.toMatrix ⇑b'.toBasis *
+            b'.toBasis.toMatrix ⇑s.toBasis := by rw [mul_assoc]
+      _ = b'.toBasis.toMatrix ⇑s.toBasis := by rw [h1, one_mul]
+  -- A matrix is the matrix of its Euclidean operator in the standard orthonormal basis.
+  have hA' : LinearMap.toMatrix s.toBasis s.toBasis (Matrix.toEuclideanLin A) = A := by
+    rw [hs, Matrix.toEuclideanLin_eq_toLin_orthonormal, LinearMap.toMatrix_toLin]
+  -- Conjugation by the change-of-basis matrix computes the matrix in the adapted basis.
+  have hchange : b'.toBasis.toMatrix ⇑s.toBasis * A * s.toBasis.toMatrix ⇑b'.toBasis =
+      LinearMap.toMatrix b'.toBasis b'.toBasis (Matrix.toEuclideanLin A) := by
+    conv_lhs => rw [← hA']
+    exact basis_toMatrix_mul_linearMap_toMatrix_mul_basis_toMatrix
+      b'.toBasis s.toBasis b'.toBasis s.toBasis (Matrix.toEuclideanLin A)
+  -- In the adapted basis the matrix of the operator is the block-diagonal Kronecker form.
+  have hmatrix : LinearMap.toMatrix b.toBasis b.toBasis (Matrix.toEuclideanLin A) =
+      Matrix.blockDiagonal' fun k => (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ B k := by
+    ext ⟨k', i', j'⟩ ⟨k, i, j⟩
+    rw [LinearMap.toMatrix_apply, OrthonormalBasis.coe_toBasis,
+      OrthonormalBasis.coe_toBasis_repr_apply, OrthonormalBasis.repr_apply_apply, hB k i j,
+      inner_sum]
+    simp only [inner_smul_right, orthonormal_iff_ite.mp b.orthonormal]
+    rcases eq_or_ne k' k with rfl | hkk
+    · rw [Matrix.blockDiagonal'_apply_eq]
+      simp only [Matrix.kroneckerMap_apply, Matrix.one_apply, Sigma.mk.inj_iff, heq_eq_eq,
+        Prod.mk.injEq, true_and]
+      rcases eq_or_ne i' i with rfl | hii
+      · simp [Finset.sum_ite_eq]
+      · simp [hii]
+    · rw [Matrix.blockDiagonal'_apply_ne _ _ _ hkk]
+      simp [hkk]
+  -- Reindexing the basis reindexes the matrix of the operator.
+  have hreindex : LinearMap.toMatrix b'.toBasis b'.toBasis (Matrix.toEuclideanLin A) =
+      Matrix.reindex e e (LinearMap.toMatrix b.toBasis b.toBasis (Matrix.toEuclideanLin A)) := by
+    ext x y
+    simp [hb', Matrix.reindex_apply, LinearMap.toMatrix_apply,
+      OrthonormalBasis.coe_toBasis_repr_apply, OrthonormalBasis.coe_toBasis]
+  calc star (s.toBasis.toMatrix ⇑b'.toBasis) * A * s.toBasis.toMatrix ⇑b'.toBasis
+      = b'.toBasis.toMatrix ⇑s.toBasis * A * s.toBasis.toMatrix ⇑b'.toBasis := by rw [hstar]
+    _ = LinearMap.toMatrix b'.toBasis b'.toBasis (Matrix.toEuclideanLin A) := hchange
+    _ = Matrix.reindex e e
+          (Matrix.blockDiagonal' fun k => (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ B k) := by
+        rw [hreindex, hmatrix]
+
+end OrthonormalBasis
 
 namespace StarSubalgebra
 
@@ -164,85 +249,6 @@ theorem exists_adapted_orthonormalBasis :
     rw [hb k (i, j), hB (σ k) i j]
     exact Finset.sum_congr rfl fun j' _ => by rw [hb k (i, j')]
 
-/-- **Unitary change of basis to block-diagonal form.** Let $(f_{k,i,j})_{k,i,j}$ be an
-orthonormal basis of $\mathbb{C}^{D}$ indexed by a component index $k < K$, a multiplicity
-index $i < m_k$, and an irreducible index $j < d_k$. There are an identification of the index
-set with $\{0, \ldots, D-1\}$, realizing $\sum_k d_k m_k = D$, and a unitary
-$U \in M_{D}(\mathbb{C})$, whose columns are the basis vectors, such that every matrix $A$
-acting on the basis by
-$$A\,f_{k,i,j} \;=\; \sum_{j'} (B_k)_{j'j}\, f_{k,i,j'}$$
-satisfies $U^{\dagger} A U = \bigoplus_{k} \mathbf{1}_{m_k} \otimes B_k$. The matrix
-$U^{\dagger} A U = U^{-1} A U$ is the matrix of the operator $x \mapsto Ax$ in the basis
-$(f_{k,i,j})$, whose entries the action property and orthonormality make
-$\delta_{k'k}\,\delta_{i'i}\,(B_k)_{j'j}$. This is the change-of-basis computation behind the
-block representation of *Quantum Channels & Operations* (Wolf 2012), Theorem 6.14. -/
-theorem exists_unitary_conj_blockDiagonal_of_orthonormalBasis {K : ℕ} {d m : Fin K → ℕ}
-    (b : OrthonormalBasis ((k : Fin K) × (Fin (m k) × Fin (d k))) ℂ (EuclideanSpace ℂ n)) :
-    ∃ (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ n) (U : Matrix n n ℂ),
-      U ∈ Matrix.unitaryGroup n ℂ ∧
-        ∀ (A : Matrix n n ℂ) (B : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ),
-          (∀ (k : Fin K) (i : Fin (m k)) (j : Fin (d k)),
-            Matrix.toEuclideanLin A (b ⟨k, (i, j)⟩) = ∑ j', B k j' j • b ⟨k, (i, j')⟩) →
-          star U * A * U = Matrix.reindex e e
-            (Matrix.blockDiagonal' fun k => (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ B k) := by
-  classical
-  set s : OrthonormalBasis n ℂ (EuclideanSpace ℂ n) := EuclideanSpace.basisFun n ℂ with hs
-  set e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ n := b.toBasis.indexEquiv s.toBasis with he
-  set b' : OrthonormalBasis n ℂ (EuclideanSpace ℂ n) := b.reindex e with hb'
-  refine ⟨e, s.toBasis.toMatrix ⇑b'.toBasis,
-    s.toMatrix_orthonormalBasis_mem_unitary b', fun A B hB => ?_⟩
-  -- The conjugate transpose of the change-of-basis matrix is the reverse change of basis.
-  have hstar : star (s.toBasis.toMatrix ⇑b'.toBasis) = b'.toBasis.toMatrix ⇑s.toBasis := by
-    have h1 : star (s.toBasis.toMatrix ⇑b'.toBasis) * s.toBasis.toMatrix ⇑b'.toBasis = 1 :=
-      Matrix.mem_unitaryGroup_iff'.mp (s.toMatrix_orthonormalBasis_mem_unitary b')
-    have h2 : s.toBasis.toMatrix ⇑b'.toBasis * b'.toBasis.toMatrix ⇑s.toBasis = 1 :=
-      Module.Basis.toMatrix_mul_toMatrix_flip _ _
-    calc star (s.toBasis.toMatrix ⇑b'.toBasis)
-        = star (s.toBasis.toMatrix ⇑b'.toBasis) *
-            (s.toBasis.toMatrix ⇑b'.toBasis * b'.toBasis.toMatrix ⇑s.toBasis) := by
-          rw [h2, mul_one]
-      _ = star (s.toBasis.toMatrix ⇑b'.toBasis) * s.toBasis.toMatrix ⇑b'.toBasis *
-            b'.toBasis.toMatrix ⇑s.toBasis := by rw [mul_assoc]
-      _ = b'.toBasis.toMatrix ⇑s.toBasis := by rw [h1, one_mul]
-  -- A matrix is the matrix of its Euclidean operator in the standard orthonormal basis.
-  have hA' : LinearMap.toMatrix s.toBasis s.toBasis (Matrix.toEuclideanLin A) = A := by
-    rw [hs, Matrix.toEuclideanLin_eq_toLin_orthonormal, LinearMap.toMatrix_toLin]
-  -- Conjugation by the change-of-basis matrix computes the matrix in the adapted basis.
-  have hchange : b'.toBasis.toMatrix ⇑s.toBasis * A * s.toBasis.toMatrix ⇑b'.toBasis =
-      LinearMap.toMatrix b'.toBasis b'.toBasis (Matrix.toEuclideanLin A) := by
-    conv_lhs => rw [← hA']
-    exact basis_toMatrix_mul_linearMap_toMatrix_mul_basis_toMatrix
-      b'.toBasis s.toBasis b'.toBasis s.toBasis (Matrix.toEuclideanLin A)
-  -- In the adapted basis the matrix of the operator is the block-diagonal Kronecker form.
-  have hmatrix : LinearMap.toMatrix b.toBasis b.toBasis (Matrix.toEuclideanLin A) =
-      Matrix.blockDiagonal' fun k => (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ B k := by
-    ext ⟨k', i', j'⟩ ⟨k, i, j⟩
-    rw [LinearMap.toMatrix_apply, OrthonormalBasis.coe_toBasis,
-      OrthonormalBasis.coe_toBasis_repr_apply, OrthonormalBasis.repr_apply_apply, hB k i j,
-      inner_sum]
-    simp only [inner_smul_right, orthonormal_iff_ite.mp b.orthonormal]
-    rcases eq_or_ne k' k with rfl | hkk
-    · rw [Matrix.blockDiagonal'_apply_eq]
-      simp only [Matrix.kroneckerMap_apply, Matrix.one_apply, Sigma.mk.inj_iff, heq_eq_eq,
-        Prod.mk.injEq, true_and]
-      rcases eq_or_ne i' i with rfl | hii
-      · simp [Finset.sum_ite_eq]
-      · simp [hii]
-    · rw [Matrix.blockDiagonal'_apply_ne _ _ _ hkk]
-      simp [hkk]
-  -- Reindexing the basis reindexes the matrix of the operator.
-  have hreindex : LinearMap.toMatrix b'.toBasis b'.toBasis (Matrix.toEuclideanLin A) =
-      Matrix.reindex e e (LinearMap.toMatrix b.toBasis b.toBasis (Matrix.toEuclideanLin A)) := by
-    ext x y
-    simp [hb', Matrix.reindex_apply, LinearMap.toMatrix_apply,
-      OrthonormalBasis.coe_toBasis_repr_apply, OrthonormalBasis.coe_toBasis]
-  calc star (s.toBasis.toMatrix ⇑b'.toBasis) * A * s.toBasis.toMatrix ⇑b'.toBasis
-      = b'.toBasis.toMatrix ⇑s.toBasis * A * s.toBasis.toMatrix ⇑b'.toBasis := by rw [hstar]
-    _ = LinearMap.toMatrix b'.toBasis b'.toBasis (Matrix.toEuclideanLin A) := hchange
-    _ = Matrix.reindex e e
-          (Matrix.blockDiagonal' fun k => (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ B k) := by
-        rw [hreindex, hmatrix]
-
 /-- **Global unitary block-diagonal form.** For a star-subalgebra $S$ of complex matrices
 there are a number $K$ of isotypic components, positive dimensions $d_k$ and multiplicities
 $m_k$ with $\sum_k d_k m_k = D$, and a unitary $U \in M_{D}(\mathbb{C})$ such that every
@@ -250,7 +256,7 @@ $A \in S$ satisfies
 $$U^{\dagger} A U \;=\; \bigoplus_{k} \mathbf{1}_{m_k} \otimes B_k$$
 for matrices $B_k \in M_{d_k}(\mathbb{C})$ depending on $A$. The columns of $U$ are the
 adapted orthonormal basis of `StarSubalgebra.exists_adapted_orthonormalBasis`, through the
-change of basis of `StarSubalgebra.exists_unitary_conj_blockDiagonal_of_orthonormalBasis`;
+change of basis of `OrthonormalBasis.exists_unitary_conj_blockDiagonal`;
 the index identification realizing $\sum_k d_k m_k = D$ is part of the statement. Up to
 reordering the two tensor factors this is the block representation of
 *Quantum Channels & Operations* (Wolf 2012), Theorem 6.14, in the unital case: a
@@ -265,7 +271,7 @@ theorem exists_unitary_conj_blockDiagonal :
           star U * A * U = Matrix.reindex e e
             (Matrix.blockDiagonal' fun k => (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ B k) := by
   obtain ⟨K, d, m, b, hd, hm, -, -, hact⟩ := S.exists_adapted_orthonormalBasis
-  obtain ⟨e, U, hUmem, hconj⟩ := exists_unitary_conj_blockDiagonal_of_orthonormalBasis b
+  obtain ⟨e, U, hUmem, hconj⟩ := b.exists_unitary_conj_blockDiagonal
   refine ⟨K, d, m, e, U, hUmem, hd, hm, fun A hA => ?_⟩
   obtain ⟨B, hB⟩ := hact A hA
   exact ⟨B, hconj A B hB⟩

--- a/TNLean/Algebra/StarSubalgebraBlockDiagonal.lean
+++ b/TNLean/Algebra/StarSubalgebraBlockDiagonal.lean
@@ -31,11 +31,11 @@ block that Theorem 6.14 reserves for the complement of the support.
   $A$ in the subalgebra, $U^{\dagger} A U$ is block diagonal with blocks
   $\mathbf{1}_{m_k} \otimes B_k$.
 
-## Remaining step towards Wolf Thm 6.14
-
-Both results state the containment direction only: every member of the subalgebra takes the
-block-diagonal form in the adapted coordinates. The converse of Theorem 6.14, that every
-choice of blocks $(B_k)_k$ arises from a member of the subalgebra, is not asserted here.
+Both results state the containment direction: every member of the subalgebra takes the
+block-diagonal form in the adapted coordinates. The reverse inclusion, that every choice of
+blocks $(B_k)_k$ arises from a member of the subalgebra, is proved by a double-commutant
+argument in `TNLean.Algebra.StarSubalgebraBlockForm`, whose statement combines both
+directions into the equality of Theorem 6.14.
 -/
 
 open scoped InnerProductSpace Kronecker
@@ -51,41 +51,55 @@ $d_0, \ldots, d_{K-1}$ and multiplicities $m_0, \ldots, m_{K-1}$, and an orthono
 $(f_{k,i,j})_{k < K,\, i < m_k,\, j < d_k}$ of $\mathbb{C}^{D}$ such that for every $A \in S$
 there are matrices $B_k \in M_{d_k}(\mathbb{C})$ with, for all $k$, $i < m_k$, and $j < d_k$,
 $$A\,f_{k,i,j} \;=\; \sum_{j'} (B_k)_{j'j}\, f_{k,i,j'} :$$
-the member $A$ acts on the $k$-th component as $\mathbf{1}_{m_k} \otimes B_k$. The basis is
+the member $A$ acts on the $k$-th component as $\mathbf{1}_{m_k} \otimes B_k$. Each row
+$(f_{k,i,j})_{j < d_k}$ of the basis spans a subspace irreducible under $S$, and rows drawn
+from distinct components span subspaces that are never of the same type. The basis is
 the concatenation of the adapted orthonormal bases of the pairwise orthogonal isotypic
 components, combining `StarSubalgebra.exists_orthogonal_isotypic_decomposition` with
 `StarSubalgebra.exists_adapted_orthonormal_family_of_sameIsotype` on each component. This is the
 adapted-basis form of the block decomposition behind *Quantum Channels & Operations*
 (Wolf 2012), Theorem 6.14, in the unital case (no zero block). Only the containment direction
-is stated: every member of $S$ takes this form. -/
+is stated here; the reverse inclusion is `StarSubalgebra.exists_unitary_conj_blockDiagonal_iff`
+in `TNLean.Algebra.StarSubalgebraBlockForm`. -/
 theorem exists_adapted_orthonormalBasis :
     ∃ (K : ℕ) (d m : Fin K → ℕ)
       (b : OrthonormalBasis ((k : Fin K) × (Fin (m k) × Fin (d k))) ℂ (EuclideanSpace ℂ n)),
       (∀ k, 0 < d k) ∧ (∀ k, 0 < m k) ∧
+        (∀ (k : Fin K) (i : Fin (m k)),
+          S.IsIrreducibleSubspace (Submodule.span ℂ (Set.range fun j => b ⟨k, (i, j)⟩))) ∧
+        (∀ k k' : Fin K, k ≠ k' → ∀ (i : Fin (m k)) (i' : Fin (m k')),
+          ¬ S.SameIsotype (Submodule.span ℂ (Set.range fun j => b ⟨k, (i, j)⟩))
+            (Submodule.span ℂ (Set.range fun j => b ⟨k', (i', j)⟩))) ∧
         ∀ A ∈ S, ∃ B : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ,
           ∀ (k : Fin K) (i : Fin (m k)) (j : Fin (d k)),
             Matrix.toEuclideanLin A (b ⟨k, (i, j)⟩) = ∑ j', B k j' j • b ⟨k, (i, j')⟩ := by
   classical
-  obtain ⟨C, hCfin, hCpair, hCsup, hC⟩ := S.exists_orthogonal_isotypic_decomposition
+  obtain ⟨C, hCfin, hCpair, hCsup, hC, hCcross⟩ := S.exists_orthogonal_isotypic_decomposition
   haveI : Fintype ↥C := hCfin.fintype
-  -- Each component carries an adapted orthonormal family with positive dimensions.
+  -- Each component carries an adapted orthonormal family with positive dimensions whose rows
+  -- span irreducible subspaces contained in the component.
   have key : ∀ c ∈ C, ∃ (d m : ℕ) (f : Fin m × Fin d → EuclideanSpace ℂ n),
-      0 < d ∧ 0 < m ∧ Orthonormal ℂ f ∧ Submodule.span ℂ (Set.range f) = c ∧
+      0 < d ∧ 0 < m ∧
+        (∀ i : Fin m,
+          S.IsIrreducibleSubspace (Submodule.span ℂ (Set.range fun j => f (i, j))) ∧
+            Submodule.span ℂ (Set.range fun j => f (i, j)) ≤ c) ∧
+        Orthonormal ℂ f ∧ Submodule.span ℂ (Set.range f) = c ∧
         ∀ A ∈ S, ∃ B : Matrix (Fin d) (Fin d) ℂ, ∀ i j,
           Matrix.toEuclideanLin A (f (i, j)) = ∑ j', B j' j • f (i, j') := by
     intro c hc
     obtain ⟨Dc, hne, hfin, hirr, rfl, hortho, hsame⟩ := hC c hc
-    obtain ⟨d, m, f, hmcard, hdim, hon, hspan, hact⟩ :=
+    obtain ⟨d, m, f, hmcard, hdim, hrowmem, hon, hspan, hact⟩ :=
       S.exists_adapted_orthonormal_family_of_sameIsotype hne hfin hirr hortho hsame
     obtain ⟨p₀, hp₀⟩ := hne
-    refine ⟨d, m, f, ?_, ?_, hon, hspan, hact⟩
+    refine ⟨d, m, f, ?_, ?_,
+      fun i => ⟨hirr _ (hrowmem i), le_sSup (hrowmem i)⟩, hon, hspan, hact⟩
     · -- The common dimension is positive because an irreducible piece is nonzero.
       rw [← hdim p₀ hp₀]
       exact Module.finrank_pos_iff.mpr (Submodule.nontrivial_iff_ne_bot.mpr (hirr p₀ hp₀).2.1)
     · -- The multiplicity is positive because the same-type class is nonempty.
       rw [hmcard]
       exact (Set.ncard_pos hfin).mpr ⟨p₀, hp₀⟩
-  choose d m f hd hm hon hspan hact using fun c : ↥C => key c.1 c.2
+  choose d m f hd hm hrow hon hspan hact using fun c : ↥C => key c.1 c.2
   -- The concatenated family over the sigma type of all components.
   have hmem : ∀ (c : ↥C) (p : Fin (m c) × Fin (d c)),
       f c p ∈ (c : Submodule ℂ (EuclideanSpace ℂ n)) := fun c p =>
@@ -109,10 +123,6 @@ theorem exists_adapted_orthonormalBasis :
     exact ⟨⟨⟨c, hc⟩, p⟩, rfl⟩
   -- Enumerate the components and transport the basis to the enumerated index type.
   set σ : Fin (Fintype.card ↥C) ≃ ↥C := (Fintype.equivFin ↥C).symm with hσ
-  refine ⟨Fintype.card ↥C, fun k => d (σ k), fun k => m (σ k),
-    (OrthonormalBasis.mk hFon hFspan).reindex
-      (Equiv.sigmaCongrLeft (β := fun c : ↥C => Fin (m c) × Fin (d c)) σ).symm,
-    fun k => hd (σ k), fun k => hm (σ k), ?_⟩
   have hb : ∀ (k : Fin (Fintype.card ↥C)) (p : Fin (m (σ k)) × Fin (d (σ k))),
       (OrthonormalBasis.mk hFon hFspan).reindex
         (Equiv.sigmaCongrLeft (β := fun c : ↥C => Fin (m c) × Fin (d c)) σ).symm ⟨k, p⟩ =
@@ -122,11 +132,33 @@ theorem exists_adapted_orthonormalBasis :
       show (Equiv.sigmaCongrLeft (β := fun c : ↥C => Fin (m c) × Fin (d c)) σ) ⟨k, p⟩ =
         ⟨σ k, p⟩ from rfl,
       OrthonormalBasis.coe_mk]
-  intro A hA
-  choose B hB using fun c : ↥C => hact c A hA
-  refine ⟨fun k => B (σ k), fun k i j => ?_⟩
-  rw [hb k (i, j), hB (σ k) i j]
-  exact Finset.sum_congr rfl fun j' _ => by rw [hb k (i, j')]
+  -- The row spans of the transported basis are the row spans of the adapted families.
+  have hspanrow : ∀ (k : Fin (Fintype.card ↥C)) (i : Fin (m (σ k))),
+      Submodule.span ℂ (Set.range fun j =>
+        (OrthonormalBasis.mk hFon hFspan).reindex
+          (Equiv.sigmaCongrLeft (β := fun c : ↥C => Fin (m c) × Fin (d c)) σ).symm ⟨k, (i, j)⟩)
+        = Submodule.span ℂ (Set.range fun j => f (σ k) (i, j)) := fun k i =>
+    congrArg (fun F => Submodule.span ℂ (Set.range F)) (funext fun j => hb k (i, j))
+  refine ⟨Fintype.card ↥C, fun k => d (σ k), fun k => m (σ k),
+    (OrthonormalBasis.mk hFon hFspan).reindex
+      (Equiv.sigmaCongrLeft (β := fun c : ↥C => Fin (m c) × Fin (d c)) σ).symm,
+    fun k => hd (σ k), fun k => hm (σ k), ?_, ?_, ?_⟩
+  · -- Each row of the basis spans an irreducible subspace.
+    intro k i
+    rw [hspanrow k i]
+    exact (hrow (σ k) i).1
+  · -- Rows in distinct components span subspaces of different types.
+    intro k k' hkk i i'
+    rw [hspanrow k i, hspanrow k' i']
+    exact hCcross (σ k).1 (σ k).2 (σ k').1 (σ k').2
+      (fun h => hkk (σ.injective (Subtype.ext h))) _ (hrow (σ k) i).1 (hrow (σ k) i).2
+      _ (hrow (σ k') i').1 (hrow (σ k') i').2
+  · -- The action of the subalgebra in the transported basis.
+    intro A hA
+    choose B hB using fun c : ↥C => hact c A hA
+    refine ⟨fun k => B (σ k), fun k i j => ?_⟩
+    rw [hb k (i, j), hB (σ k) i j]
+    exact Finset.sum_congr rfl fun j' _ => by rw [hb k (i, j')]
 
 /-- **Global unitary block-diagonal form.** For a star-subalgebra $S$ of complex matrices
 there are a number $K$ of isotypic components, positive dimensions $d_k$ and multiplicities
@@ -139,8 +171,8 @@ identification realizing $\sum_k d_k m_k = D$ is part of the statement. Up to re
 two tensor factors this is the block representation of *Quantum Channels & Operations*
 (Wolf 2012), Theorem 6.14, in the unital case: a star-subalgebra contains the identity, so
 there is no zero block. Only the containment direction is stated: every member of $S$ is
-carried by $U$ into the block algebra; that every choice of blocks is attained is not
-asserted here. -/
+carried by $U$ into the block algebra. The equality, including the reverse inclusion, is
+`StarSubalgebra.exists_unitary_conj_blockDiagonal_iff`. -/
 theorem exists_unitary_conj_blockDiagonal :
     ∃ (K : ℕ) (d m : Fin K → ℕ) (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ n)
       (U : Matrix n n ℂ), U ∈ Matrix.unitaryGroup n ℂ ∧ (∀ k, 0 < d k) ∧ (∀ k, 0 < m k) ∧
@@ -148,7 +180,7 @@ theorem exists_unitary_conj_blockDiagonal :
           star U * A * U = Matrix.reindex e e
             (Matrix.blockDiagonal' fun k => (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ B k) := by
   classical
-  obtain ⟨K, d, m, b, hd, hm, hact⟩ := S.exists_adapted_orthonormalBasis
+  obtain ⟨K, d, m, b, hd, hm, -, -, hact⟩ := S.exists_adapted_orthonormalBasis
   set s : OrthonormalBasis n ℂ (EuclideanSpace ℂ n) := EuclideanSpace.basisFun n ℂ with hs
   set e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ n := b.toBasis.indexEquiv s.toBasis with he
   set b' : OrthonormalBasis n ℂ (EuclideanSpace ℂ n) := b.reindex e with hb'

--- a/TNLean/Algebra/StarSubalgebraBlockForm.lean
+++ b/TNLean/Algebra/StarSubalgebraBlockForm.lean
@@ -275,7 +275,7 @@ This is the block representation of a finite-dimensional star-algebra of
 unital case: a star-subalgebra contains the identity, so there is no zero block. The
 containment of $S$ in the block algebra is the adapted-basis representation of
 `StarSubalgebra.exists_adapted_orthonormalBasis`, conjugated by the unitary change of basis
-of `StarSubalgebra.exists_unitary_conj_blockDiagonal_of_orthonormalBasis`; the reverse
+of `OrthonormalBasis.exists_unitary_conj_blockDiagonal`; the reverse
 inclusion holds because a matrix that is block diagonal in the adapted basis commutes with
 the commutant of $S$ (`StarSubalgebra.exists_commutant_coeff`) and therefore belongs to $S$
 by the double-commutant criterion (`StarSubalgebra.mem_of_forall_comm`). -/
@@ -290,7 +290,7 @@ theorem exists_unitary_conj_blockDiagonal_iff :
   classical
   obtain ⟨K, d, m, b, hd, hm, hirr, hcross, hact⟩ := S.exists_adapted_orthonormalBasis
   -- The unitary change of basis carrying blockwise actions to block-diagonal matrices.
-  obtain ⟨e, U, hUmem, hconj⟩ := exists_unitary_conj_blockDiagonal_of_orthonormalBasis b
+  obtain ⟨e, U, hUmem, hconj⟩ := b.exists_unitary_conj_blockDiagonal
   refine ⟨K, d, m, e, U, hUmem, hd, hm, fun A => ⟨fun hA => ?_, fun h => ?_⟩⟩
   · -- Containment: the adapted action of a member gives the block-diagonal form.
     obtain ⟨B, hB⟩ := hact A hA

--- a/TNLean/Algebra/StarSubalgebraBlockForm.lean
+++ b/TNLean/Algebra/StarSubalgebraBlockForm.lean
@@ -1,0 +1,400 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Algebra.StarSubalgebraBlockDiagonal
+import TNLean.Algebra.StarSubalgebraSimpleModule
+import Mathlib.RingTheory.SimpleModule.Basic
+
+/-!
+# The full block form of a star-subalgebra of complex matrices
+
+This file completes the block representation of a star-subalgebra $S$ of complex matrices
+asserted by *Quantum Channels & Operations* (Wolf 2012), Eq. (1.39), and invoked there by
+Theorem 6.14: there is a unitary $U$ with
+$$S \;=\; U \Bigl(\bigoplus_{k} \mathbf{1}_{m_k} \otimes M_{d_k}(\mathbb{C})\Bigr) U^{\dagger},$$
+the unital case (no zero block), with the two Kronecker factors of each block written in the
+order identity-times-matrix. The containment of $S$ in the conjugated block algebra is the
+adapted-basis representation of `TNLean.Algebra.StarSubalgebraBlockDiagonal`; this file adds
+the reverse inclusion: every choice of blocks $(B_k)_k$ is attained by a member of $S$.
+
+The reverse inclusion is the finite-dimensional double-commutant argument. Every operator that
+commutes with the commutant of $S$ already lies in $S$; this is the Jacobson density theorem
+applied to $\mathbb{C}^{D}$ as a semisimple module over $S$. The commutant is computed in the
+adapted orthonormal basis: an operator commuting with $S$ acts on each isotypic component by a
+matrix on the multiplicity index, identically across the irreducible index — the block
+$C_k \otimes \mathbf{1}_{d_k}$ opposite to the blocks of $S$. Every matrix that is
+block-diagonal with blocks $\mathbf{1}_{m_k} \otimes B_k$ in the adapted basis commutes with
+all such operators, hence lies in $S$.
+
+## Main results
+
+* `StarSubalgebra.mem_of_forall_comm` -- membership through the double commutant: a matrix
+  whose operator commutes with every endomorphism commuting with the subalgebra is a member
+  of the subalgebra.
+* `StarSubalgebra.exists_unitary_conj_blockDiagonal_iff` -- the full block form: a unitary
+  $U$ such that membership in $S$ is equivalent to $U^{\dagger} A U$ being block diagonal
+  with blocks $\mathbf{1}_{m_k} \otimes B_k$.
+-/
+
+open scoped InnerProductSpace Kronecker
+
+namespace StarSubalgebra
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+variable (S : StarSubalgebra ℂ (Matrix n n ℂ))
+
+/-- **Membership through the double commutant.** A matrix whose operator commutes with every
+endomorphism of $\mathbb{C}^{D}$ that commutes with a star-subalgebra $S$ of complex matrices
+is a member of $S$. This is the finite-dimensional case of the bicommutant characterization of
+von Neumann algebras recalled in *Quantum Channels & Operations* (Wolf 2012), Chapter 1, used
+there for the block representation Eq. (1.39) behind Theorem 6.14. The proof is the Jacobson
+density theorem for $\mathbb{C}^{D}$ as a semisimple module over $S$: an endomorphism linear
+over the commutant agrees with the action of a member of $S$ on any finite set of vectors, in
+particular on a basis. -/
+theorem mem_of_forall_comm {T : Matrix n n ℂ}
+    (hT : ∀ g : Module.End ℂ (EuclideanSpace ℂ n),
+      (∀ A ∈ S, ∀ x, g (Matrix.toEuclideanLin A x) = Matrix.toEuclideanLin A (g x)) →
+      ∀ x, g (Matrix.toEuclideanLin T x) = Matrix.toEuclideanLin T (g x)) :
+    T ∈ S := by
+  classical
+  -- The operator of `T` commutes with every endomorphism over the subalgebra.
+  have hcomm : ∀ (g : Module.End ↥S (EuclideanSpace ℂ n)) (v : EuclideanSpace ℂ n),
+      Matrix.toEuclideanLin T (g v) = g (Matrix.toEuclideanLin T v) := by
+    intro g v
+    have hg : ∀ A ∈ S, ∀ x : EuclideanSpace ℂ n,
+        (LinearMap.restrictScalars ℂ g) (Matrix.toEuclideanLin A x) =
+          Matrix.toEuclideanLin A ((LinearMap.restrictScalars ℂ g) x) := by
+      intro A hA x
+      have h1 := map_smul g (⟨A, hA⟩ : ↥S) x
+      simpa only [LinearMap.restrictScalars_apply, S.euclideanSpace_smul_def] using h1
+    simpa only [LinearMap.restrictScalars_apply] using
+      (hT (LinearMap.restrictScalars ℂ g) hg v).symm
+  -- Package the operator as an endomorphism over the commutant and apply Jacobson density.
+  haveI : IsSemisimpleModule ↥S (EuclideanSpace ℂ n) := S.isSemisimpleModule_euclideanSpace
+  let f : Module.End (Module.End ↥S (EuclideanSpace ℂ n)) (EuclideanSpace ℂ n) :=
+    { toFun := Matrix.toEuclideanLin T
+      map_add' := map_add _
+      map_smul' := fun g v => by
+        simpa only [Module.End.smul_def, RingHom.id_apply] using hcomm g v }
+  obtain ⟨r, hr⟩ := jacobson_density (R := ↥S) (M := EuclideanSpace ℂ n) f
+    (Finset.image (EuclideanSpace.basisFun n ℂ) Finset.univ)
+  -- The member `r` acts as `T` on the standard basis, hence everywhere.
+  have heq : Matrix.toEuclideanLin T = Matrix.toEuclideanLin (r : Matrix n n ℂ) := by
+    refine (EuclideanSpace.basisFun n ℂ).toBasis.ext fun i => ?_
+    have hi := hr (EuclideanSpace.basisFun n ℂ i)
+      (Finset.mem_image_of_mem _ (Finset.mem_univ i))
+    simpa only [OrthonormalBasis.coe_toBasis, LinearMap.coe_mk, AddHom.coe_mk,
+      S.euclideanSpace_smul_def, f] using hi
+  have hTr : T = (r : Matrix n n ℂ) := Matrix.toEuclideanLin.injective heq
+  exact hTr ▸ r.2
+
+section RowTransport
+
+variable {K : ℕ} {d m : Fin K → ℕ}
+variable (b : OrthonormalBasis ((k : Fin K) × (Fin (m k) × Fin (d k))) ℂ (EuclideanSpace ℂ n))
+
+/-- Auxiliary operator between two rows of the adapted orthonormal basis: it reads off the
+coefficients of a vector along the row $(k, i')$ and rebuilds them along the row $(k, i)$,
+$$v \;\longmapsto\; \sum_{j} \langle f_{k,i',j}, v\rangle\, f_{k,i,j}.$$
+Composites of these operators with an element of the commutant realize the intertwiners used
+to compute the commutant of the subalgebra in the adapted basis, towards the block
+representation Eq. (1.39) of *Quantum Channels & Operations* (Wolf 2012). -/
+private noncomputable def rowTransport (k : Fin K) (i' i : Fin (m k)) :
+    Module.End ℂ (EuclideanSpace ℂ n) where
+  toFun v := ∑ j : Fin (d k), ⟪b ⟨k, (i', j)⟩, v⟫_ℂ • b ⟨k, (i, j)⟩
+  map_add' x y := by
+    simp only [inner_add_right, add_smul, Finset.sum_add_distrib]
+  map_smul' c v := by
+    simp only [inner_smul_right, RingHom.id_apply, mul_smul, Finset.smul_sum]
+
+omit [DecidableEq n] in
+private theorem rowTransport_apply (k : Fin K) (i' i : Fin (m k)) (v : EuclideanSpace ℂ n) :
+    rowTransport b k i' i v = ∑ j : Fin (d k), ⟪b ⟨k, (i', j)⟩, v⟫_ℂ • b ⟨k, (i, j)⟩ :=
+  rfl
+
+omit [DecidableEq n] in
+/-- The row transport lands in the span of the target row. -/
+private theorem rowTransport_apply_mem (k : Fin K) (i' i : Fin (m k))
+    (v : EuclideanSpace ℂ n) :
+    rowTransport b k i' i v ∈ Submodule.span ℂ (Set.range fun j => b ⟨k, (i, j)⟩) :=
+  rowTransport_apply b k i' i v ▸ Submodule.sum_mem _ fun j _ =>
+    Submodule.smul_mem _ _ (Submodule.subset_span ⟨j, rfl⟩)
+
+omit [DecidableEq n] in
+/-- On a basis vector of the same component, the row transport matches the source row to the
+target row and annihilates the other rows. -/
+private theorem rowTransport_apply_basis (k : Fin K) (i' i : Fin (m k))
+    (i₀ : Fin (m k)) (j₀ : Fin (d k)) :
+    rowTransport b k i' i (b ⟨k, (i₀, j₀)⟩) =
+      if i₀ = i' then b ⟨k, (i, j₀)⟩ else 0 := by
+  classical
+  have horth := orthonormal_iff_ite.mp b.orthonormal
+  rw [rowTransport_apply]
+  rcases eq_or_ne i₀ i' with rfl | hi
+  · simp [horth]
+  · simp [horth, hi, Ne.symm hi]
+
+omit [DecidableEq n] in
+/-- On a basis vector of a different component, the row transport vanishes. -/
+private theorem rowTransport_apply_basis_ne (k : Fin K) (i' i : Fin (m k)) {k₀ : Fin K}
+    (hk : k₀ ≠ k) (i₀ : Fin (m k₀)) (j₀ : Fin (d k₀)) :
+    rowTransport b k i' i (b ⟨k₀, (i₀, j₀)⟩) = 0 := by
+  classical
+  have horth := orthonormal_iff_ite.mp b.orthonormal
+  rw [rowTransport_apply]
+  simp [horth, Ne.symm hk]
+
+/-- The row transport commutes with every matrix whose action on the adapted basis is by one
+block per component, identically across the multiplicity index. -/
+private theorem rowTransport_comm (k : Fin K) (i' i : Fin (m k)) {A : Matrix n n ℂ}
+    {B : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ}
+    (hB : ∀ (k : Fin K) (i : Fin (m k)) (j : Fin (d k)),
+      Matrix.toEuclideanLin A (b ⟨k, (i, j)⟩) = ∑ j', B k j' j • b ⟨k, (i, j')⟩)
+    (v : EuclideanSpace ℂ n) :
+    rowTransport b k i' i (Matrix.toEuclideanLin A v) =
+      Matrix.toEuclideanLin A (rowTransport b k i' i v) := by
+  have hext : rowTransport b k i' i ∘ₗ Matrix.toEuclideanLin A =
+      Matrix.toEuclideanLin A ∘ₗ rowTransport b k i' i := by
+    refine b.toBasis.ext fun l => ?_
+    obtain ⟨k₀, i₀, j₀⟩ := l
+    simp only [LinearMap.comp_apply, OrthonormalBasis.coe_toBasis]
+    rcases eq_or_ne k₀ k with rfl | hk
+    · rw [hB, map_sum]
+      simp only [map_smul, rowTransport_apply_basis]
+      rcases eq_or_ne i₀ i' with rfl | hi
+      · simp [hB]
+      · simp [hi]
+    · rw [hB, map_sum]
+      simp only [map_smul, rowTransport_apply_basis_ne b k i' i hk, smul_zero,
+        Finset.sum_const_zero, map_zero]
+  exact LinearMap.congr_fun hext v
+
+variable {b}
+
+/-- **The commutant in the adapted basis.** Let $(f_{k,i,j})$ be the adapted orthonormal
+basis of `StarSubalgebra.exists_adapted_orthonormalBasis`: the rows span irreducible
+subspaces, rows of distinct components are of different types, and the subalgebra acts by
+one block per component. Then every endomorphism $g$ commuting with the subalgebra acts by
+$$g\,f_{k,i,j} \;=\; \sum_{i'} \gamma^{(k)}_{i'i}\, f_{k,i',j}$$
+for coefficients $\gamma^{(k)}$ depending only on the component and the multiplicity
+indices: in the adapted basis the commutant consists of the block-diagonal matrices with
+blocks $C_k \otimes \mathbf{1}_{d_k}$, as recalled after Eq. (1.39) of *Quantum Channels &
+Operations* (Wolf 2012). Composites of `g` with the row transports are intertwiners between
+the rows, so Schur's lemma makes them scalar within a component and zero across components. -/
+private theorem exists_commutant_coeff
+    (hirr : ∀ (k : Fin K) (i : Fin (m k)),
+      S.IsIrreducibleSubspace (Submodule.span ℂ (Set.range fun j => b ⟨k, (i, j)⟩)))
+    (hcross : ∀ k k' : Fin K, k ≠ k' → ∀ (i : Fin (m k)) (i' : Fin (m k')),
+      ¬ S.SameIsotype (Submodule.span ℂ (Set.range fun j => b ⟨k, (i, j)⟩))
+        (Submodule.span ℂ (Set.range fun j => b ⟨k', (i', j)⟩)))
+    (hact : ∀ A ∈ S, ∃ B : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ,
+      ∀ (k : Fin K) (i : Fin (m k)) (j : Fin (d k)),
+        Matrix.toEuclideanLin A (b ⟨k, (i, j)⟩) = ∑ j', B k j' j • b ⟨k, (i, j')⟩)
+    {g : Module.End ℂ (EuclideanSpace ℂ n)}
+    (hg : ∀ A ∈ S, ∀ x, g (Matrix.toEuclideanLin A x) = Matrix.toEuclideanLin A (g x)) :
+    ∃ γ : (k : Fin K) → Fin (m k) → Fin (m k) → ℂ,
+      ∀ (k : Fin K) (i : Fin (m k)) (j : Fin (d k)),
+        g (b ⟨k, (i, j)⟩) = ∑ i', γ k i' i • b ⟨k, (i', j)⟩ := by
+  classical
+  have horth := orthonormal_iff_ite.mp b.orthonormal
+  -- The composite of a row transport with `g` commutes with the subalgebra.
+  have hcomp : ∀ (k : Fin K) (i' i : Fin (m k)), ∀ A ∈ S, ∀ x,
+      (rowTransport b k i' i ∘ₗ g) (Matrix.toEuclideanLin A x) =
+        Matrix.toEuclideanLin A ((rowTransport b k i' i ∘ₗ g) x) := by
+    intro k i' i A hA x
+    obtain ⟨B, hB⟩ := hact A hA
+    rw [LinearMap.comp_apply, LinearMap.comp_apply, hg A hA x,
+      rowTransport_comm b k i' i hB]
+  -- Within one component the matrix of `g` between two rows is scalar, by Schur's lemma.
+  have hwithin : ∀ (k : Fin K) (i i' : Fin (m k)), ∃ c : ℂ,
+      ∀ (j : Fin (d k)) (j' : Fin (d k)),
+        ⟪b ⟨k, (i', j')⟩, g (b ⟨k, (i, j)⟩)⟫_ℂ = if j' = j then c else 0 := by
+    intro k i i'
+    have hinv : Submodule.span ℂ (Set.range fun j => b ⟨k, (i, j)⟩) ∈
+        Module.End.invtSubmodule (rowTransport b k i' i ∘ₗ g) :=
+      (Module.End.mem_invtSubmodule_iff_forall_mem_of_mem
+        (f := rowTransport b k i' i ∘ₗ g)).mpr fun x _ =>
+          rowTransport_apply_mem b k i' i (g x)
+    obtain ⟨c, hc⟩ := S.exists_eq_smul_of_commute_of_irreducible (hirr k i) hinv
+      fun A hA x _ => hcomp k i' i A hA x
+    refine ⟨c, fun j j' => ?_⟩
+    have hx := hc (b ⟨k, (i, j)⟩) (Submodule.subset_span ⟨j, rfl⟩)
+    rw [LinearMap.comp_apply, rowTransport_apply] at hx
+    have hcoeff := congrArg (fun v => ⟪b ⟨k, (i, j')⟩, v⟫_ℂ) hx
+    simpa only [inner_sum, inner_smul_right, horth, Sigma.mk.inj_iff, heq_eq_eq,
+      Prod.mk.injEq, true_and, mul_ite, mul_one, mul_zero, Finset.sum_ite_eq,
+      Finset.mem_univ, if_true] using hcoeff
+  -- Across components the matrix of `g` vanishes: a nonzero entry would produce a nonzero
+  -- intertwiner between rows of different types.
+  have hacross : ∀ (k k' : Fin K), k ≠ k' → ∀ (i : Fin (m k)) (i' : Fin (m k'))
+      (j : Fin (d k)) (j' : Fin (d k')),
+      ⟪b ⟨k', (i', j')⟩, g (b ⟨k, (i, j)⟩)⟫_ℂ = 0 := by
+    intro k k' hkk i i' j j'
+    by_contra hne
+    refine hcross k k' hkk i i' ⟨rowTransport b k' i' i' ∘ₗ g, ⟨?_, ?_⟩, ?_⟩
+    · exact Submodule.map_le_iff_le_comap.mpr fun x _ =>
+        rowTransport_apply_mem b k' i' i' (g x)
+    · exact fun A hA x _ => hcomp k' i' i' A hA x
+    · intro hzero
+      have h0 := hzero (b ⟨k, (i, j)⟩) (Submodule.subset_span ⟨j, rfl⟩)
+      rw [LinearMap.comp_apply, rowTransport_apply] at h0
+      have hcoeff := congrArg (fun v => ⟪b ⟨k', (i', j')⟩, v⟫_ℂ) h0
+      simp only [inner_sum, inner_smul_right, horth, Sigma.mk.inj_iff, heq_eq_eq,
+        Prod.mk.injEq, true_and, mul_ite, mul_one, mul_zero, Finset.sum_ite_eq,
+        Finset.mem_univ, if_true, inner_zero_right] at hcoeff
+      exact hne hcoeff
+  -- Expand `g` on the basis and collect the coefficients.
+  choose γ hγ using hwithin
+  refine ⟨fun k i' i => γ k i i', fun k i j => ?_⟩
+  have houter : ∀ k' ∈ (Finset.univ : Finset (Fin K)), k' ≠ k →
+      (∑ i' : Fin (m k'), ∑ j' : Fin (d k'),
+        ⟪b ⟨k', (i', j')⟩, g (b ⟨k, (i, j)⟩)⟫_ℂ • b ⟨k', (i', j')⟩) = 0 := by
+    intro k' _ hk'
+    simp [hacross k k' (Ne.symm hk')]
+  conv_lhs => rw [← b.sum_repr' (g (b ⟨k, (i, j)⟩))]
+  rw [← Finset.univ_sigma_univ, Finset.sum_sigma]
+  simp only [Fintype.sum_prod_type]
+  rw [Finset.sum_eq_single_of_mem k (Finset.mem_univ k) houter]
+  refine Finset.sum_congr rfl fun i' _ => ?_
+  simp only [hγ, ite_smul, zero_smul, Finset.sum_ite_eq', Finset.mem_univ, if_true]
+
+end RowTransport
+
+/-- **The full block form (Wolf Eq. (1.39) / Thm 6.14).** For a star-subalgebra $S$ of
+complex matrices there are a number $K$ of isotypic components, positive dimensions $d_k$
+and multiplicities $m_k$ with $\sum_k d_k m_k = D$, and a unitary $U \in M_{D}(\mathbb{C})$
+such that a matrix $A$ belongs to $S$ exactly when
+$$U^{\dagger} A U \;=\; \bigoplus_{k} \mathbf{1}_{m_k} \otimes B_k$$
+for some matrices $B_k \in M_{d_k}(\mathbb{C})$: up to reordering the two tensor factors of
+each block,
+$$S \;=\; U \Bigl(\bigoplus_{k} \mathbf{1}_{m_k} \otimes M_{d_k}(\mathbb{C})\Bigr)
+U^{\dagger}.$$
+This is the block representation of a finite-dimensional star-algebra of
+*Quantum Channels & Operations* (Wolf 2012), Eq. (1.39), invoked by Theorem 6.14, in the
+unital case: a star-subalgebra contains the identity, so there is no zero block. The
+containment of $S$ in the block algebra is the adapted-basis representation of
+`StarSubalgebra.exists_adapted_orthonormalBasis`; the reverse inclusion holds because a
+matrix that is block diagonal in the adapted basis commutes with the commutant of $S$
+(`StarSubalgebra.exists_commutant_coeff`) and therefore belongs to $S$ by the
+double-commutant criterion (`StarSubalgebra.mem_of_forall_comm`). -/
+theorem exists_unitary_conj_blockDiagonal_iff :
+    ∃ (K : ℕ) (d m : Fin K → ℕ) (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ n)
+      (U : Matrix n n ℂ), U ∈ Matrix.unitaryGroup n ℂ ∧ (∀ k, 0 < d k) ∧ (∀ k, 0 < m k) ∧
+        ∀ A : Matrix n n ℂ,
+          A ∈ S ↔ ∃ B : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ,
+            star U * A * U = Matrix.reindex e e
+              (Matrix.blockDiagonal' fun k =>
+                (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ B k) := by
+  classical
+  obtain ⟨K, d, m, b, hd, hm, hirr, hcross, hact⟩ := S.exists_adapted_orthonormalBasis
+  set s : OrthonormalBasis n ℂ (EuclideanSpace ℂ n) := EuclideanSpace.basisFun n ℂ with hs
+  set e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ n := b.toBasis.indexEquiv s.toBasis with he
+  set b' : OrthonormalBasis n ℂ (EuclideanSpace ℂ n) := b.reindex e with hb'
+  set U : Matrix n n ℂ := s.toBasis.toMatrix ⇑b'.toBasis with hU
+  have hUmem : U ∈ Matrix.unitaryGroup n ℂ := s.toMatrix_orthonormalBasis_mem_unitary b'
+  -- The conjugate transpose of the change-of-basis matrix is the reverse change of basis.
+  have hstar : star U = b'.toBasis.toMatrix ⇑s.toBasis := by
+    have h1 : star U * U = 1 := Matrix.mem_unitaryGroup_iff'.mp hUmem
+    have h2 : U * b'.toBasis.toMatrix ⇑s.toBasis = 1 :=
+      Module.Basis.toMatrix_mul_toMatrix_flip _ _
+    calc star U = star U * (U * b'.toBasis.toMatrix ⇑s.toBasis) := by rw [h2, mul_one]
+      _ = star U * U * b'.toBasis.toMatrix ⇑s.toBasis := by rw [mul_assoc]
+      _ = b'.toBasis.toMatrix ⇑s.toBasis := by rw [h1, one_mul]
+  -- The conjugation identity for any matrix with the adapted block action.
+  have hconj : ∀ (A : Matrix n n ℂ) (B : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ),
+      (∀ (k : Fin K) (i : Fin (m k)) (j : Fin (d k)),
+        Matrix.toEuclideanLin A (b ⟨k, (i, j)⟩) = ∑ j', B k j' j • b ⟨k, (i, j')⟩) →
+      star U * A * U = Matrix.reindex e e
+        (Matrix.blockDiagonal' fun k =>
+          (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ B k) := by
+    intro A B hB
+    -- A matrix is the matrix of its Euclidean operator in the standard orthonormal basis.
+    have hA' : LinearMap.toMatrix s.toBasis s.toBasis (Matrix.toEuclideanLin A) = A := by
+      rw [hs, Matrix.toEuclideanLin_eq_toLin_orthonormal, LinearMap.toMatrix_toLin]
+    -- Conjugation by the change-of-basis matrix computes the matrix in the adapted basis.
+    have hchange : b'.toBasis.toMatrix ⇑s.toBasis * A * s.toBasis.toMatrix ⇑b'.toBasis =
+        LinearMap.toMatrix b'.toBasis b'.toBasis (Matrix.toEuclideanLin A) := by
+      conv_lhs => rw [← hA']
+      exact basis_toMatrix_mul_linearMap_toMatrix_mul_basis_toMatrix
+        b'.toBasis s.toBasis b'.toBasis s.toBasis (Matrix.toEuclideanLin A)
+    -- In the adapted basis the matrix of the operator is the block-diagonal Kronecker form.
+    have hmatrix : LinearMap.toMatrix b.toBasis b.toBasis (Matrix.toEuclideanLin A) =
+        Matrix.blockDiagonal' fun k => (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ B k := by
+      ext ⟨k', i', j'⟩ ⟨k, i, j⟩
+      rw [LinearMap.toMatrix_apply, OrthonormalBasis.coe_toBasis,
+        OrthonormalBasis.coe_toBasis_repr_apply, OrthonormalBasis.repr_apply_apply, hB k i j,
+        inner_sum]
+      simp only [inner_smul_right, orthonormal_iff_ite.mp b.orthonormal]
+      rcases eq_or_ne k' k with rfl | hkk
+      · rw [Matrix.blockDiagonal'_apply_eq]
+        simp only [Matrix.kroneckerMap_apply, Matrix.one_apply, Sigma.mk.inj_iff, heq_eq_eq,
+          Prod.mk.injEq, true_and]
+        rcases eq_or_ne i' i with rfl | hii
+        · simp [Finset.sum_ite_eq]
+        · simp [hii]
+      · rw [Matrix.blockDiagonal'_apply_ne _ _ _ hkk]
+        simp [hkk]
+    -- Reindexing the basis reindexes the matrix of the operator.
+    have hreindex : LinearMap.toMatrix b'.toBasis b'.toBasis (Matrix.toEuclideanLin A) =
+        Matrix.reindex e e
+          (LinearMap.toMatrix b.toBasis b.toBasis (Matrix.toEuclideanLin A)) := by
+      ext x y
+      simp [hb', Matrix.reindex_apply, LinearMap.toMatrix_apply,
+        OrthonormalBasis.coe_toBasis_repr_apply, OrthonormalBasis.coe_toBasis]
+    calc star U * A * U
+        = b'.toBasis.toMatrix ⇑s.toBasis * A * s.toBasis.toMatrix ⇑b'.toBasis := by
+          rw [hstar, hU]
+      _ = LinearMap.toMatrix b'.toBasis b'.toBasis (Matrix.toEuclideanLin A) := hchange
+      _ = Matrix.reindex e e
+            (Matrix.blockDiagonal' fun k =>
+              (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ B k) := by
+          rw [hreindex, hmatrix]
+  refine ⟨K, d, m, e, U, hUmem, hd, hm, fun A => ⟨fun hA => ?_, fun h => ?_⟩⟩
+  · -- Containment: the adapted action of a member gives the block-diagonal form.
+    obtain ⟨B, hB⟩ := hact A hA
+    exact ⟨B, hconj A B hB⟩
+  · -- Reverse inclusion: a block-diagonal matrix in the adapted basis is a member.
+    obtain ⟨B, hAB⟩ := h
+    -- The candidate member acting by the blocks `B` on the adapted basis.
+    set t : Module.End ℂ (EuclideanSpace ℂ n) :=
+      b.toBasis.constr ℂ
+        (fun l : (k : Fin K) × (Fin (m k) × Fin (d k)) =>
+          ∑ j', B l.1 j' l.2.2 • b ⟨l.1, (l.2.1, j')⟩) with ht
+    set T : Matrix n n ℂ := Matrix.toEuclideanLin.symm t with hT
+    have hTact : ∀ (k : Fin K) (i : Fin (m k)) (j : Fin (d k)),
+        Matrix.toEuclideanLin T (b ⟨k, (i, j)⟩) = ∑ j', B k j' j • b ⟨k, (i, j')⟩ := by
+      intro k i j
+      rw [hT, LinearEquiv.apply_symm_apply, ht]
+      have hcb := b.toBasis.constr_basis ℂ
+        (fun l : (k : Fin K) × (Fin (m k) × Fin (d k)) =>
+          ∑ j', B l.1 j' l.2.2 • b ⟨l.1, (l.2.1, j')⟩) ⟨k, (i, j)⟩
+      simpa only [OrthonormalBasis.coe_toBasis] using hcb
+    -- `T` commutes with the commutant of `S`, hence lies in `S`.
+    have hTmem : T ∈ S := by
+      refine S.mem_of_forall_comm fun g hg => ?_
+      obtain ⟨γ, hγ⟩ := exists_commutant_coeff S hirr hcross hact hg
+      have hgt : g ∘ₗ Matrix.toEuclideanLin T = Matrix.toEuclideanLin T ∘ₗ g := by
+        refine b.toBasis.ext fun l => ?_
+        obtain ⟨k, i, j⟩ := l
+        simp only [LinearMap.comp_apply, OrthonormalBasis.coe_toBasis]
+        rw [hTact, hγ, map_sum, map_sum]
+        simp only [map_smul, hγ, hTact, Finset.smul_sum]
+        rw [Finset.sum_comm]
+        exact Finset.sum_congr rfl fun i' _ =>
+          Finset.sum_congr rfl fun j' _ => smul_comm _ _ _
+      exact fun x => LinearMap.congr_fun hgt x
+    -- The block-diagonal forms of `A` and of the member `T` agree, so `A = T`.
+    have hTconj := hconj T B hTact
+    have hU1 : U * star U = 1 := Matrix.mem_unitaryGroup_iff.mp hUmem
+    have hcancel : ∀ X : Matrix n n ℂ, U * (star U * X * U) * star U = X := by
+      intro X
+      rw [← mul_assoc U (star U * X) U, ← mul_assoc U (star U) X, hU1, one_mul,
+        mul_assoc, hU1, mul_one]
+    have hAT : A = T := by
+      have h1 : U * (star U * A * U) * star U = U * (star U * T * U) * star U := by
+        rw [hAB, hTconj]
+      rwa [hcancel A, hcancel T] at h1
+    exact hAT ▸ hTmem
+
+end StarSubalgebra

--- a/TNLean/Algebra/StarSubalgebraBlockForm.lean
+++ b/TNLean/Algebra/StarSubalgebraBlockForm.lean
@@ -274,10 +274,11 @@ This is the block representation of a finite-dimensional star-algebra of
 *Quantum Channels & Operations* (Wolf 2012), Eq. (1.39), invoked by Theorem 6.14, in the
 unital case: a star-subalgebra contains the identity, so there is no zero block. The
 containment of $S$ in the block algebra is the adapted-basis representation of
-`StarSubalgebra.exists_adapted_orthonormalBasis`; the reverse inclusion holds because a
-matrix that is block diagonal in the adapted basis commutes with the commutant of $S$
-(`StarSubalgebra.exists_commutant_coeff`) and therefore belongs to $S$ by the
-double-commutant criterion (`StarSubalgebra.mem_of_forall_comm`). -/
+`StarSubalgebra.exists_adapted_orthonormalBasis`, conjugated by the unitary change of basis
+of `StarSubalgebra.exists_unitary_conj_blockDiagonal_of_orthonormalBasis`; the reverse
+inclusion holds because a matrix that is block diagonal in the adapted basis commutes with
+the commutant of $S$ (`StarSubalgebra.exists_commutant_coeff`) and therefore belongs to $S$
+by the double-commutant criterion (`StarSubalgebra.mem_of_forall_comm`). -/
 theorem exists_unitary_conj_blockDiagonal_iff :
     ∃ (K : ℕ) (d m : Fin K → ℕ) (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ n)
       (U : Matrix n n ℂ), U ∈ Matrix.unitaryGroup n ℂ ∧ (∀ k, 0 < d k) ∧ (∀ k, 0 < m k) ∧
@@ -288,68 +289,8 @@ theorem exists_unitary_conj_blockDiagonal_iff :
                 (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ B k) := by
   classical
   obtain ⟨K, d, m, b, hd, hm, hirr, hcross, hact⟩ := S.exists_adapted_orthonormalBasis
-  set s : OrthonormalBasis n ℂ (EuclideanSpace ℂ n) := EuclideanSpace.basisFun n ℂ with hs
-  set e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ n := b.toBasis.indexEquiv s.toBasis with he
-  set b' : OrthonormalBasis n ℂ (EuclideanSpace ℂ n) := b.reindex e with hb'
-  set U : Matrix n n ℂ := s.toBasis.toMatrix ⇑b'.toBasis with hU
-  have hUmem : U ∈ Matrix.unitaryGroup n ℂ := s.toMatrix_orthonormalBasis_mem_unitary b'
-  -- The conjugate transpose of the change-of-basis matrix is the reverse change of basis.
-  have hstar : star U = b'.toBasis.toMatrix ⇑s.toBasis := by
-    have h1 : star U * U = 1 := Matrix.mem_unitaryGroup_iff'.mp hUmem
-    have h2 : U * b'.toBasis.toMatrix ⇑s.toBasis = 1 :=
-      Module.Basis.toMatrix_mul_toMatrix_flip _ _
-    calc star U = star U * (U * b'.toBasis.toMatrix ⇑s.toBasis) := by rw [h2, mul_one]
-      _ = star U * U * b'.toBasis.toMatrix ⇑s.toBasis := by rw [mul_assoc]
-      _ = b'.toBasis.toMatrix ⇑s.toBasis := by rw [h1, one_mul]
-  -- The conjugation identity for any matrix with the adapted block action.
-  have hconj : ∀ (A : Matrix n n ℂ) (B : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ),
-      (∀ (k : Fin K) (i : Fin (m k)) (j : Fin (d k)),
-        Matrix.toEuclideanLin A (b ⟨k, (i, j)⟩) = ∑ j', B k j' j • b ⟨k, (i, j')⟩) →
-      star U * A * U = Matrix.reindex e e
-        (Matrix.blockDiagonal' fun k =>
-          (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ B k) := by
-    intro A B hB
-    -- A matrix is the matrix of its Euclidean operator in the standard orthonormal basis.
-    have hA' : LinearMap.toMatrix s.toBasis s.toBasis (Matrix.toEuclideanLin A) = A := by
-      rw [hs, Matrix.toEuclideanLin_eq_toLin_orthonormal, LinearMap.toMatrix_toLin]
-    -- Conjugation by the change-of-basis matrix computes the matrix in the adapted basis.
-    have hchange : b'.toBasis.toMatrix ⇑s.toBasis * A * s.toBasis.toMatrix ⇑b'.toBasis =
-        LinearMap.toMatrix b'.toBasis b'.toBasis (Matrix.toEuclideanLin A) := by
-      conv_lhs => rw [← hA']
-      exact basis_toMatrix_mul_linearMap_toMatrix_mul_basis_toMatrix
-        b'.toBasis s.toBasis b'.toBasis s.toBasis (Matrix.toEuclideanLin A)
-    -- In the adapted basis the matrix of the operator is the block-diagonal Kronecker form.
-    have hmatrix : LinearMap.toMatrix b.toBasis b.toBasis (Matrix.toEuclideanLin A) =
-        Matrix.blockDiagonal' fun k => (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ B k := by
-      ext ⟨k', i', j'⟩ ⟨k, i, j⟩
-      rw [LinearMap.toMatrix_apply, OrthonormalBasis.coe_toBasis,
-        OrthonormalBasis.coe_toBasis_repr_apply, OrthonormalBasis.repr_apply_apply, hB k i j,
-        inner_sum]
-      simp only [inner_smul_right, orthonormal_iff_ite.mp b.orthonormal]
-      rcases eq_or_ne k' k with rfl | hkk
-      · rw [Matrix.blockDiagonal'_apply_eq]
-        simp only [Matrix.kroneckerMap_apply, Matrix.one_apply, Sigma.mk.inj_iff, heq_eq_eq,
-          Prod.mk.injEq, true_and]
-        rcases eq_or_ne i' i with rfl | hii
-        · simp [Finset.sum_ite_eq]
-        · simp [hii]
-      · rw [Matrix.blockDiagonal'_apply_ne _ _ _ hkk]
-        simp [hkk]
-    -- Reindexing the basis reindexes the matrix of the operator.
-    have hreindex : LinearMap.toMatrix b'.toBasis b'.toBasis (Matrix.toEuclideanLin A) =
-        Matrix.reindex e e
-          (LinearMap.toMatrix b.toBasis b.toBasis (Matrix.toEuclideanLin A)) := by
-      ext x y
-      simp [hb', Matrix.reindex_apply, LinearMap.toMatrix_apply,
-        OrthonormalBasis.coe_toBasis_repr_apply, OrthonormalBasis.coe_toBasis]
-    calc star U * A * U
-        = b'.toBasis.toMatrix ⇑s.toBasis * A * s.toBasis.toMatrix ⇑b'.toBasis := by
-          rw [hstar, hU]
-      _ = LinearMap.toMatrix b'.toBasis b'.toBasis (Matrix.toEuclideanLin A) := hchange
-      _ = Matrix.reindex e e
-            (Matrix.blockDiagonal' fun k =>
-              (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ B k) := by
-          rw [hreindex, hmatrix]
+  -- The unitary change of basis carrying blockwise actions to block-diagonal matrices.
+  obtain ⟨e, U, hUmem, hconj⟩ := exists_unitary_conj_blockDiagonal_of_orthonormalBasis b
   refine ⟨K, d, m, e, U, hUmem, hd, hm, fun A => ⟨fun hA => ?_, fun h => ?_⟩⟩
   · -- Containment: the adapted action of a member gives the block-diagonal form.
     obtain ⟨B, hB⟩ := hact A hA

--- a/TNLean/Algebra/StarSubalgebraIsotypicDecomp.lean
+++ b/TNLean/Algebra/StarSubalgebraIsotypicDecomp.lean
@@ -25,10 +25,13 @@ family, the components span the whole space.
 * `StarSubalgebra.isOrtho_sSup_of_not_sameIsotype` -- if no piece of one same-type class is of
   the same type as any piece of another class, then the suprema of the two classes are
   orthogonal.
+* `StarSubalgebra.exists_sameIsotype_of_le_sSup` -- an irreducible subspace contained in the
+  supremum of a family of irreducible pieces has the same type as one of the pieces.
 * `StarSubalgebra.exists_orthogonal_isotypic_decomposition` -- the whole representation space
   is the supremum of a finite, pairwise orthogonal family of isotypic components, each of
   which is the supremum of a finite, nonempty same-type class of pairwise orthogonal
-  irreducible pieces.
+  irreducible pieces; irreducible subspaces contained in distinct components are never of the
+  same type.
 -/
 
 namespace StarSubalgebra
@@ -51,19 +54,39 @@ theorem isOrtho_sSup_of_not_sameIsotype
   intro q hq
   exact S.isOrtho_of_not_sameIsotype (h₁ p hp) (h₂ q hq) (h p hp q hq)
 
+/-- An irreducible subspace contained in the supremum of a family of irreducible pieces has
+the same type as one of the pieces. Were it of a different type than every piece, it would be
+orthogonal to every piece, hence to their supremum, hence to itself, forcing it to vanish.
+See *Quantum Channels & Operations* (Wolf 2012), Chapter 6, towards Theorem 6.14. -/
+theorem exists_sameIsotype_of_le_sSup {D : Set (Submodule ℂ (EuclideanSpace ℂ n))}
+    (hD : ∀ q ∈ D, S.IsIrreducibleSubspace q) {p : Submodule ℂ (EuclideanSpace ℂ n)}
+    (hp : S.IsIrreducibleSubspace p) (hle : p ≤ sSup D) :
+    ∃ q ∈ D, S.SameIsotype p q := by
+  by_contra hnone
+  push Not at hnone
+  have hortho : p ⟂ sSup D := Submodule.isOrtho_sSup_right.mpr fun q hq =>
+    S.isOrtho_of_not_sameIsotype hp (hD q hq) (hnone q hq)
+  exact hp.2.1 (Submodule.isOrtho_self.mp (hortho.mono_right hle))
+
 /-- The whole representation space of a finite-dimensional star-subalgebra of complex matrices
 is the supremum of a finite, pairwise orthogonal family of isotypic components. Each component
 is the supremum of a finite, nonempty same-type class of pairwise orthogonal irreducible
-pieces. The orthogonal decomposition into irreducible pieces supplies the family; the
-same-type relation groups it into classes, which inherit the pairwise orthogonality; and
-pieces of different type are orthogonal, so distinct components are orthogonal. See
-*Quantum Channels & Operations* (Wolf 2012), Chapter 6, towards Theorem 6.14. -/
+pieces, and irreducible subspaces contained in distinct components are never of the same type.
+The orthogonal decomposition into irreducible pieces supplies the family; the same-type
+relation groups it into classes, which inherit the pairwise orthogonality; and pieces of
+different type are orthogonal, so distinct components are orthogonal. An irreducible subspace
+of a component has the same type as the pieces of its class, so two such subspaces in distinct
+components cannot have the same type. See *Quantum Channels & Operations* (Wolf 2012),
+Chapter 6, towards Theorem 6.14. -/
 theorem exists_orthogonal_isotypic_decomposition :
     ∃ C : Set (Submodule ℂ (EuclideanSpace ℂ n)), C.Finite ∧
       C.Pairwise (· ⟂ ·) ∧ sSup C = ⊤ ∧
-      ∀ c ∈ C, ∃ Dc : Set (Submodule ℂ (EuclideanSpace ℂ n)),
+      (∀ c ∈ C, ∃ Dc : Set (Submodule ℂ (EuclideanSpace ℂ n)),
         Dc.Nonempty ∧ Dc.Finite ∧ (∀ p ∈ Dc, S.IsIrreducibleSubspace p) ∧ c = sSup Dc ∧
-          Dc.Pairwise (· ⟂ ·) ∧ Dc.Pairwise fun p q => S.SameIsotype p q := by
+          Dc.Pairwise (· ⟂ ·) ∧ Dc.Pairwise fun p q => S.SameIsotype p q) ∧
+      ∀ c ∈ C, ∀ c' ∈ C, c ≠ c' →
+        ∀ p, S.IsIrreducibleSubspace p → p ≤ c →
+          ∀ q, S.IsIrreducibleSubspace q → q ≤ c' → ¬ S.SameIsotype p q := by
   classical
   obtain ⟨D, hDfin, hDirr, hDpair, hDsup⟩ := S.exists_orthogonal_irreducible_decomposition
   -- The same-type class of a piece `p`, taken within the family `D`.
@@ -90,7 +113,7 @@ theorem exists_orthogonal_isotypic_decomposition :
         (S.sameIsotype_symm (hDirr p hp) (hDirr p' hp') hsame) hpq
     · exact S.sameIsotype_trans (hDirr p hp) (hDirr p' hp') (hDirr q hqD) hsame hp'q
   -- The isotypic components are the suprema of the classes.
-  refine ⟨(fun p => sSup (cls p)) '' D, hDfin.image _, ?_, ?_, ?_⟩
+  refine ⟨(fun p => sSup (cls p)) '' D, hDfin.image _, ?_, ?_, ?_, ?_⟩
   · -- Distinct components come from representatives of different type, so they are orthogonal.
     rintro _ ⟨p, hp, rfl⟩ _ ⟨p', hp', rfl⟩ hne
     have hnot : ¬ S.SameIsotype p p' :=
@@ -115,6 +138,23 @@ theorem exists_orthogonal_isotypic_decomposition :
     rintro c ⟨p, hp, rfl⟩
     exact ⟨cls p, ⟨p, hcls_self p hp⟩, hcls_fin p, hcls_irr p, rfl,
       hDpair.mono (Set.sep_subset _ _), hcls_same p hp⟩
+  · -- Irreducible subspaces of distinct components are of different types: each has the type
+    -- of its component's representative, and distinct components have representatives of
+    -- different types.
+    rintro _ ⟨p, hp, rfl⟩ _ ⟨p', hp', rfl⟩ hne w hw hwle w' hw' hw'le hsame
+    have hnot : ¬ S.SameIsotype p p' :=
+      fun hsame' => hne (congrArg sSup (hcls_eq p hp p' hp' hsame'))
+    obtain ⟨a, ha, hwa⟩ := S.exists_sameIsotype_of_le_sSup (hcls_irr p) hw hwle
+    obtain ⟨a', ha', hw'a'⟩ := S.exists_sameIsotype_of_le_sSup (hcls_irr p') hw' hw'le
+    -- Chain the types: `p ~ a ~ w ~ w' ~ a' ~ p'`.
+    have hpw : S.SameIsotype p w :=
+      S.sameIsotype_trans (hDirr p hp) (hcls_irr p a ha) hw ha.2
+        (S.sameIsotype_symm hw (hcls_irr p a ha) hwa)
+    have hw'p' : S.SameIsotype w' p' :=
+      S.sameIsotype_trans hw' (hcls_irr p' a' ha') (hDirr p' hp') hw'a'
+        (S.sameIsotype_symm (hDirr p' hp') (hcls_irr p' a' ha') ha'.2)
+    have hpw' : S.SameIsotype p w' := S.sameIsotype_trans (hDirr p hp) hw hw' hpw hsame
+    exact hnot (S.sameIsotype_trans (hDirr p hp) hw' (hDirr p' hp') hpw' hw'p')
 
 end StarSubalgebra
 

--- a/TNLean/Algebra/StarSubalgebraIsotypicFactorization.lean
+++ b/TNLean/Algebra/StarSubalgebraIsotypicFactorization.lean
@@ -29,14 +29,12 @@ $\mathbf{1}_{m} \otimes B$ with $B$ a $d \times d$ matrix.
   the supremum of a finite, pairwise orthogonal family of isotypic components, each carrying
   such an adapted orthonormal basis.
 
-## Remaining step towards Wolf Thm 6.14
-
 The adapted bases realize the action of the subalgebra on each isotypic component as
 matrix-times-identity blocks. The global change of basis, which concatenates the adapted bases
 of the components into a single unitary matrix conjugating every member of the subalgebra to
 the block-diagonal form, is carried out in `TNLean.Algebra.StarSubalgebraBlockDiagonal`. The
-converse direction of the theorem, that every choice of blocks is attained by a member of the
-subalgebra, remains open.
+reverse inclusion, that every choice of blocks is attained by a member of the subalgebra, is
+proved in `TNLean.Algebra.StarSubalgebraBlockForm`.
 -/
 
 open scoped InnerProductSpace
@@ -54,7 +52,8 @@ basis $(f_{i,j})_{0 \le i < m,\, 0 \le j < d}$ such that for every $A \in S$ the
 $B \in M_{d}(\mathbb{C})$ with, for all $i < m$ and $j < d$,
 $$A\,f_{i,j} \;=\; \sum_{j'} B_{j'j}\, f_{i,j'} :$$
 in the adapted basis the member $A$ acts on the component as $\mathbf{1}_{m} \otimes B$, one
-matrix on the irreducible index, identically across the multiplicity index.
+matrix on the irreducible index, identically across the multiplicity index. The vectors
+$(f_{i,j})_{j < d}$ of the $i$-th copy span one of the pieces of $\mathcal{D}$.
 
 An orthonormal basis $e_0, \ldots, e_{d-1}$ of one piece spreads to the others through the
 inner-product-preserving intertwiners of
@@ -67,6 +66,7 @@ theorem exists_adapted_orthonormal_family_of_sameIsotype
     (hsame : Dc.Pairwise fun p q => S.SameIsotype p q) :
     ∃ (d m : ℕ) (f : Fin m × Fin d → EuclideanSpace ℂ n),
       m = Dc.ncard ∧ (∀ p ∈ Dc, Module.finrank ℂ p = d) ∧
+      (∀ i : Fin m, Submodule.span ℂ (Set.range fun j => f (i, j)) ∈ Dc) ∧
       Orthonormal ℂ f ∧ Submodule.span ℂ (Set.range f) = sSup Dc ∧
       ∀ A ∈ S, ∃ B : Matrix (Fin d) (Fin d) ℂ, ∀ (i : Fin m) (j : Fin d),
         Matrix.toEuclideanLin A (f (i, j)) = ∑ j', B j' j • f (i, j') := by
@@ -115,7 +115,7 @@ theorem exists_adapted_orthonormal_family_of_sameIsotype
     have h1 := congrArg (Submodule.map (u (σ i))) hspan₀
     rw [Submodule.map_span, ← Set.range_comp, hu_map (σ i)] at h1
     exact h1
-  refine ⟨Module.finrank ℂ p₀, Fintype.card ↥Dc, f, ?_, ?_, hf_on, ?_, ?_⟩
+  refine ⟨Module.finrank ℂ p₀, Fintype.card ↥Dc, f, ?_, ?_, ?_, hf_on, ?_, ?_⟩
   · -- The number of copies is the number of pieces of the family.
     rw [← Nat.card_coe_set_eq, Nat.card_eq_fintype_card]
   · -- Every piece has the dimension of the base piece: it is spanned by an orthonormal family
@@ -128,6 +128,10 @@ theorem exists_adapted_orthonormal_family_of_sameIsotype
     have h2 := finrank_span_eq_card hsub.linearIndependent
     rw [hcopy] at h2
     simpa using h2
+  · -- Each copy spans its piece, which is a member of the family.
+    intro i
+    rw [hspan_copy i]
+    exact (σ i).2
   · -- The copies together span the whole component.
     refine le_antisymm ?_ (sSup_le fun q hq => ?_)
     · rw [Submodule.span_le]
@@ -178,10 +182,10 @@ theorem exists_isotypic_tensor_factorization :
         Orthonormal ℂ f ∧ Submodule.span ℂ (Set.range f) = c ∧
         ∀ A ∈ S, ∃ B : Matrix (Fin d) (Fin d) ℂ, ∀ (i : Fin m) (j : Fin d),
           Matrix.toEuclideanLin A (f (i, j)) = ∑ j', B j' j • f (i, j') := by
-  obtain ⟨C, hCfin, hCpair, hCsup, hC⟩ := S.exists_orthogonal_isotypic_decomposition
+  obtain ⟨C, hCfin, hCpair, hCsup, hC, -⟩ := S.exists_orthogonal_isotypic_decomposition
   refine ⟨C, hCfin, hCpair, hCsup, fun c hc => ?_⟩
   obtain ⟨Dc, hne, hfin, hirr, rfl, hortho, hsame⟩ := hC c hc
-  obtain ⟨d, m, f, -, -, hon, hspan, hact⟩ :=
+  obtain ⟨d, m, f, -, -, -, hon, hspan, hact⟩ :=
     S.exists_adapted_orthonormal_family_of_sameIsotype hne hfin hirr hortho hsame
   exact ⟨d, m, f, hon, hspan, hact⟩
 

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -1916,6 +1916,46 @@ by~\cite[Theorem~6.14]{Wolf2012Quantum}, without the zero block.
     row spans of distinct components.
 \end{proof}
 
+The change of basis to an orthonormal basis indexed by such triples is implemented by a
+unitary matrix, and it carries every matrix acting blockwise on the basis to a
+block-diagonal matrix.
+
+\begin{lemma}[Unitary change of basis to block-diagonal form]%
+    \label{lem:starSubalgebra_unitary_change_of_basis_block}
+    \lean{StarSubalgebra.exists_unitary_conj_blockDiagonal_of_orthonormalBasis}
+    \leanok
+    Let $(f_{k,i,j})_{k < K,\, i < m_k,\, j < d_k}$ be an orthonormal basis of $\C^{D}$.
+    There are an identification of the index set of triples $(k, i, j)$ with
+    $\{0, \ldots, D-1\}$, realizing $\sum_k d_k m_k = D$, and a unitary $U \in \MN{D}$,
+    whose columns are the basis vectors, such that every matrix $A \in \MN{D}$ acting on
+    the basis by
+    \[
+        A\,f_{k,i,j} \;=\; \sum_{j'=0}^{d_k-1} (B_k)_{j'j}\, f_{k,i,j'}
+    \]
+    for matrices $B_k \in \MN{d_k}$ satisfies
+    \[
+        U^{\dagger} A\, U \;=\; \bigoplus_{k=0}^{K-1} \Id_{m_k} \otimes B_k.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Let $U$ be the change-of-basis matrix from the standard orthonormal basis of $\C^{D}$
+    to $(f_{k,i,j})$, so the columns of $U$ are the basis vectors; a change of basis
+    between orthonormal bases is unitary. Both bases have $D$ elements, which identifies
+    the index set of triples $(k, i, j)$ with $\{0, \ldots, D-1\}$ and gives
+    $\sum_k d_k m_k = D$. For $A$ acting as displayed, the matrix
+    $U^{\dagger} A\, U = U^{-1} A\, U$ is the matrix of the operator $x \mapsto Ax$ in the
+    basis $(f_{k,i,j})$, with entries
+    \[
+        \langle f_{k',i',j'},\, A f_{k,i,j} \rangle
+        \;=\; \sum_{j''} (B_k)_{j''j} \langle f_{k',i',j'},\, f_{k,i,j''} \rangle
+        \;=\; \delta_{k'k}\, \delta_{i'i}\, (B_k)_{j'j}
+    \]
+    by the action property and orthonormality. This is the block-diagonal matrix with
+    blocks $\Id_{m_k} \otimes B_k$.
+\end{proof}
+
 \begin{theorem}[Global unitary block-diagonal form]%
     \label{thm:starSubalgebra_unitary_block_diagonal}
     \lean{StarSubalgebra.exists_unitary_conj_blockDiagonal}
@@ -1937,22 +1977,14 @@ by~\cite[Theorem~6.14]{Wolf2012Quantum}, without the zero block.
 
 \begin{proof}
     \leanok
-    \uses{thm:starSubalgebra_global_adapted_orthonormal_basis}
+    \uses{thm:starSubalgebra_global_adapted_orthonormal_basis,
+        lem:starSubalgebra_unitary_change_of_basis_block}
     Let $(f_{k,i,j})$ be the adapted orthonormal basis of
     Theorem~\ref{thm:starSubalgebra_global_adapted_orthonormal_basis} and let $U$ be the
-    change-of-basis matrix from the standard orthonormal basis of $\C^{D}$ to
-    $(f_{k,i,j})$, so the columns of $U$ are the adapted basis vectors; a change of basis
-    between orthonormal bases is unitary. Both bases have $D$ elements, which identifies
-    the index set of triples $(k, i, j)$ with $\{0, \ldots, D-1\}$ and gives
-    $\sum_k d_k m_k = D$. For $A \in S$ the matrix $U^{\dagger} A\, U = U^{-1} A\, U$ is
-    the matrix of the operator $x \mapsto Ax$ in the adapted basis, with entries
-    \[
-        \langle f_{k',i',j'},\, A f_{k,i,j} \rangle
-        \;=\; \sum_{j''} (B_k)_{j''j} \langle f_{k',i',j'},\, f_{k,i,j''} \rangle
-        \;=\; \delta_{k'k}\, \delta_{i'i}\, (B_k)_{j'j}
-    \]
-    by the adapted action and orthonormality. This is the block-diagonal matrix with
-    blocks $\Id_{m_k} \otimes B_k$.
+    unitary supplied by Lemma~\ref{lem:starSubalgebra_unitary_change_of_basis_block} for
+    this basis. Every $A \in S$ acts on the basis by matrices $B_k$ on the irreducible
+    index, identically across the multiplicity index, so the lemma gives
+    $U^{\dagger} A\, U = \bigoplus_k \Id_{m_k} \otimes B_k$.
 \end{proof}
 
 The reverse inclusion of the block representation rests on the double-commutant
@@ -2011,15 +2043,15 @@ $\bigoplus_k \Id_{m_k} \otimes \MN{d_k}$.
 \begin{proof}
     \leanok
     \uses{thm:starSubalgebra_global_adapted_orthonormal_basis,
-        thm:starSubalgebra_unitary_block_diagonal, lem:starSubalgebra_double_commutant,
+        lem:starSubalgebra_unitary_change_of_basis_block,
+        lem:starSubalgebra_double_commutant,
         lem:starSubalgebra_scalar_commutant_irreducible, def:starSubalgebra_intertwiner,
         def:starSubalgebra_sameIsotype}
     Let $(f_{k,i,j})$ be the adapted orthonormal basis of
     Theorem~\ref{thm:starSubalgebra_global_adapted_orthonormal_basis}, write $W_{k,i}$ for
-    the span of the row $(f_{k,i,j})_{j < d_k}$, and let $U$ be the change-of-basis matrix
-    from the standard basis to $(f_{k,i,j})$, as in
-    Theorem~\ref{thm:starSubalgebra_unitary_block_diagonal}. The computation there shows
-    that any matrix $A$ whose action on the adapted basis is
+    the span of the row $(f_{k,i,j})_{j < d_k}$, and let $U$ be the unitary supplied by
+    Lemma~\ref{lem:starSubalgebra_unitary_change_of_basis_block} for this basis: any
+    matrix $A$ whose action on the adapted basis is
     $A f_{k,i,j} = \sum_{j'} (B_k)_{j'j}\, f_{k,i,j'}$ satisfies the displayed conjugation
     identity; in particular every member of $S$ does, which is the containment direction.
 
@@ -2044,12 +2076,15 @@ $\bigoplus_k \Id_{m_k} \otimes \MN{d_k}$.
         \langle f_{k,i',j'},\, g\, f_{k,i,j}\rangle
         \;=\; \gamma^{(k)}_{i'i}\, \delta_{j'j}.
     \]
-    Across components the matrix of $g$ vanishes: with $\tau$ built from the rows
-    $(k', i')$ of another component, the composite $\tau \circ g$ carries $W_{k,i}$ into
-    $W_{k',i'}$ and commutes with $S$ on $W_{k,i}$, so a nonzero entry
-    $\langle f_{k',i',j'},\, g\, f_{k,i,j}\rangle$ would make it an intertwiner that does
-    not vanish on $W_{k,i}$, giving $W_{k,i}$ and $W_{k',i'}$ the same type and
-    contradicting Theorem~\ref{thm:starSubalgebra_global_adapted_orthonormal_basis}.
+    Across components the matrix of $g$ vanishes: for $k' \neq k$,
+    \[
+        \langle f_{k',i',j'},\, g\, f_{k,i,j}\rangle \;=\; 0:
+    \]
+    with $\tau$ built from the rows $(k', i')$ of another component, the composite
+    $\tau \circ g$ carries $W_{k,i}$ into $W_{k',i'}$ and commutes with $S$ on $W_{k,i}$,
+    so a nonzero such entry would make it an intertwiner that does not vanish on
+    $W_{k,i}$, giving $W_{k,i}$ and $W_{k',i'}$ the same type and contradicting
+    Theorem~\ref{thm:starSubalgebra_global_adapted_orthonormal_basis}.
     Expanding $g f_{k,i,j}$ in the adapted basis therefore gives
     \[
         g\, f_{k,i,j} \;=\; \sum_{i'} \gamma^{(k)}_{i'i}\, f_{k,i',j} :

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -1699,12 +1699,36 @@ $\C^{D}$.
     supremum of $\mathcal{D}_2$.
 \end{proof}
 
+An irreducible subspace of the supremum of a same-type class need not be one of its pieces,
+but its type is determined by the class.
+
+\begin{lemma}[Irreducible subspaces of a supremum inherit a type]%
+    \label{lem:starSubalgebra_sameIsotype_of_le_sSup}
+    \lean{StarSubalgebra.exists_sameIsotype_of_le_sSup}
+    \leanok
+    \uses{def:starSubalgebra_irreducibleSubspace, def:starSubalgebra_sameIsotype}
+    Let $S$ be a $*$-subalgebra of $\MN{D}$, let $\mathcal{D}$ be a family of subspaces
+    irreducible under $S$, and let $W$ be a subspace irreducible under $S$ with
+    $W \le \bigvee_{W' \in \mathcal{D}} W'$. Then $W$ is of the same type as some piece of
+    $\mathcal{D}$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:starSubalgebra_isOrtho_not_sameIsotype}
+    Suppose $W$ is of a different type than every piece of $\mathcal{D}$. Pieces of different
+    type are orthogonal (Lemma~\ref{lem:starSubalgebra_isOrtho_not_sameIsotype}), so $W$ is
+    orthogonal to every piece of $\mathcal{D}$, hence to their supremum, hence to itself. An
+    irreducible subspace is nonzero, a contradiction.
+\end{proof}
+
 \begin{theorem}[Isotypic-component decomposition]%
     \label{thm:starSubalgebra_orthogonal_isotypic_decomposition}
     \lean{StarSubalgebra.exists_orthogonal_isotypic_decomposition}
     \leanok
     \uses{thm:starSubalgebra_orthogonal_irreducible_decomposition,
         lem:starSubalgebra_isOrtho_sSup_not_sameIsotype,
+        lem:starSubalgebra_sameIsotype_of_le_sSup,
         lem:starSubalgebra_sameIsotype_refl, lem:starSubalgebra_sameIsotype_symm,
         lem:starSubalgebra_sameIsotype_trans}
     Let $S$ be a $*$-subalgebra of $\MN{D}$. Then $\C^{D}$ is the supremum of a finite family
@@ -1714,12 +1738,15 @@ $\C^{D}$.
     \[
         C = \bigvee_{W \in \mathcal{D}_C} W.
     \]
+    Moreover, for distinct components $C \neq C'$, no subspace irreducible under $S$ contained
+    in $C$ is of the same type as any subspace irreducible under $S$ contained in $C'$.
 \end{theorem}
 
 \begin{proof}
     \leanok
     \uses{thm:starSubalgebra_orthogonal_irreducible_decomposition,
         lem:starSubalgebra_isOrtho_sSup_not_sameIsotype,
+        lem:starSubalgebra_sameIsotype_of_le_sSup,
         lem:starSubalgebra_sameIsotype_refl, lem:starSubalgebra_sameIsotype_symm,
         lem:starSubalgebra_sameIsotype_trans}
     The orthogonal irreducible decomposition
@@ -1745,6 +1772,15 @@ $\C^{D}$.
     hence $W \sim W'$, contradicting that $W$ and $W'$ are not of the same type. So no piece of
     $\mathcal{D}_W$ is of the same type as any piece of $\mathcal{D}_{W'}$, and the components are
     orthogonal (Lemma~\ref{lem:starSubalgebra_isOrtho_sSup_not_sameIsotype}).
+
+    Finally, let $V \le C_W$ and $V' \le C_{W'}$ be irreducible under $S$ with
+    $C_W \neq C_{W'}$. By Lemma~\ref{lem:starSubalgebra_sameIsotype_of_le_sSup} there are
+    pieces $a \in \mathcal{D}_W$ and $b \in \mathcal{D}_{W'}$ with $V \sim a$ and $V' \sim b$.
+    Were $V \sim V'$, symmetry and transitivity would give
+    \[
+        W \sim a \sim V \sim V' \sim b \sim W',
+    \]
+    contradicting again that $W$ and $W'$ are not of the same type.
 \end{proof}
 
 The pieces of one class are unitarily identified copies of a single irreducible piece. An
@@ -1770,7 +1806,8 @@ $\MN{d_k} \otimes \Id_{m_k}$ of~\cite[Theorem~6.14]{Wolf2012Quantum}.
     \]
     In the adapted basis the member $A$ acts on $C$ by the matrix $B$ on the irreducible
     index, identically across the multiplicity index; after reordering the indices this is the
-    block $\MN{d} \otimes \Id_{m}$ of~\cite[Theorem~6.14]{Wolf2012Quantum}.
+    block $\MN{d} \otimes \Id_{m}$ of~\cite[Theorem~6.14]{Wolf2012Quantum}. The vectors
+    $(f_{i,j})_{0 \le j < d}$ of the $i$-th copy span one of the pieces of $\mathcal{D}$.
 \end{theorem}
 
 \begin{proof}
@@ -1837,6 +1874,7 @@ by~\cite[Theorem~6.14]{Wolf2012Quantum}, without the zero block.
     \label{thm:starSubalgebra_global_adapted_orthonormal_basis}
     \lean{StarSubalgebra.exists_adapted_orthonormalBasis}
     \leanok
+    \uses{def:starSubalgebra_irreducibleSubspace, def:starSubalgebra_sameIsotype}
     Let $S$ be a $*$-subalgebra of $\MN{D}$. There are $K \in \N$, positive dimensions
     $d_0, \ldots, d_{K-1}$ and multiplicities $m_0, \ldots, m_{K-1}$, and an orthonormal
     basis $(f_{k,i,j})_{k < K,\, i < m_k,\, j < d_k}$ of $\C^{D}$ such that for every
@@ -1846,10 +1884,11 @@ by~\cite[Theorem~6.14]{Wolf2012Quantum}, without the zero block.
         A\,f_{k,i,j} \;=\; \sum_{j'=0}^{d_k-1} (B_k)_{j'j}\, f_{k,i,j'}.
     \]
     In this basis the member $A$ acts on the $k$-th component as
-    $\Id_{m_k} \otimes B_k$. Only the containment direction is asserted: every member of
-    $S$ takes this form. The converse of~\cite[Theorem~6.14]{Wolf2012Quantum}, that every
-    choice of blocks $(B_k)_k$ is attained by a member of $S$, is not part of this
-    statement.
+    $\Id_{m_k} \otimes B_k$. Each row $(f_{k,i,j})_{0 \le j < d_k}$ spans a subspace
+    irreducible under $S$, and rows drawn from distinct components span subspaces that are
+    never of the same type. Only the containment direction is asserted: every member of
+    $S$ takes this form. The equality with the block algebra, including the reverse
+    inclusion, is Theorem~\ref{thm:starSubalgebra_unitary_block_diagonal_iff}.
 \end{theorem}
 
 \begin{proof}
@@ -1869,7 +1908,12 @@ by~\cite[Theorem~6.14]{Wolf2012Quantum}, without the zero block.
     distinct components are orthogonal because the components are. The concatenated family
     spans $\C^{D}$ because each component is spanned by its family and the components have
     supremum $\C^{D}$; a spanning orthonormal family is an orthonormal basis. The action
-    property holds componentwise by the adapted families.
+    property holds componentwise by the adapted families. Each row of the concatenated
+    family spans one of the irreducible pieces of its component's class
+    (Theorem~\ref{thm:starSubalgebra_adapted_orthonormal_basis}), and irreducible subspaces
+    of distinct components are never of the same type
+    (Theorem~\ref{thm:starSubalgebra_orthogonal_isotypic_decomposition}), so neither are the
+    row spans of distinct components.
 \end{proof}
 
 \begin{theorem}[Global unitary block-diagonal form]%
@@ -1886,9 +1930,9 @@ by~\cite[Theorem~6.14]{Wolf2012Quantum}, without the zero block.
     for matrices $B_k \in \MN{d_k}$ depending on $A$. Up to reordering the two tensor
     factors of each block this is the containment direction of the unital case of the
     block representation of~\cite[Theorem~6.14]{Wolf2012Quantum}: $S$ is carried by $U$
-    into the block algebra $\bigoplus_k \Id_{m_k} \otimes \MN{d_k}$. The converse, that
-    every choice of blocks $(B_k)_k$ is attained by a member of $S$, is not part of this
-    statement.
+    into the block algebra $\bigoplus_k \Id_{m_k} \otimes \MN{d_k}$. The equality,
+    including the reverse inclusion, is
+    Theorem~\ref{thm:starSubalgebra_unitary_block_diagonal_iff}.
 \end{theorem}
 
 \begin{proof}
@@ -1909,6 +1953,117 @@ by~\cite[Theorem~6.14]{Wolf2012Quantum}, without the zero block.
     \]
     by the adapted action and orthonormality. This is the block-diagonal matrix with
     blocks $\Id_{m_k} \otimes B_k$.
+\end{proof}
+
+The reverse inclusion of the block representation rests on the double-commutant
+characterization: in finite dimensions a $*$-subalgebra contains every matrix that commutes
+with its commutant. The proof is the Jacobson density theorem for $\C^{D}$ as a semisimple
+module over the subalgebra.
+
+\begin{lemma}[Membership through the double commutant]%
+    \label{lem:starSubalgebra_double_commutant}
+    \lean{StarSubalgebra.mem_of_forall_comm}
+    \leanok
+    Let $S$ be a $*$-subalgebra of $\MN{D}$ and let $T \in \MN{D}$. If $T$ commutes with
+    every linear operator on $\C^{D}$ that commutes with all members of $S$, then
+    $T \in S$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:starSubalgebra_isSemisimpleModule}
+    The space $\C^{D}$ is a semisimple module over $S$
+    (Lemma~\ref{lem:starSubalgebra_isSemisimpleModule}), and the linear operators commuting
+    with all members of $S$ are exactly the endomorphisms of this module. The hypothesis
+    therefore makes $T$ linear over the endomorphism ring of the module. By the Jacobson
+    density theorem, for every finite set of vectors there is a member of $S$ acting on
+    them as $T$ does. Applied to a basis of $\C^{D}$, this produces a member of $S$ whose
+    action agrees with $T$ on a basis, hence equals $T$.
+\end{proof}
+
+Combining the containment direction with the double-commutant criterion yields the full
+block representation of a finite-dimensional $*$-subalgebra, the unital case of
+Eq.~(1.39) of~\cite{Wolf2012Quantum} invoked by~\cite[Theorem~6.14]{Wolf2012Quantum}: up
+to a unitary change of basis, $S$ equals the block algebra
+$\bigoplus_k \Id_{m_k} \otimes \MN{d_k}$.
+
+\begin{theorem}[Full block form of a $*$-subalgebra]%
+    \label{thm:starSubalgebra_unitary_block_diagonal_iff}
+    \lean{StarSubalgebra.exists_unitary_conj_blockDiagonal_iff}
+    \leanok
+    Let $S$ be a $*$-subalgebra of $\MN{D}$. There are $K \in \N$, positive dimensions
+    $d_0, \ldots, d_{K-1}$ and multiplicities $m_0, \ldots, m_{K-1}$ with
+    $\sum_{k} d_k m_k = D$, realized by an explicit identification of the index sets, and
+    a unitary $U \in \MN{D}$ such that a matrix $A \in \MN{D}$ belongs to $S$ exactly when
+    \[
+        U^{\dagger} A\, U \;=\; \bigoplus_{k=0}^{K-1} \Id_{m_k} \otimes B_k
+    \]
+    for some matrices $B_k \in \MN{d_k}$; that is, up to reordering the two tensor factors
+    of each block,
+    \[
+        S \;=\; U \Bigl(\bigoplus_{k=0}^{K-1} \Id_{m_k} \otimes \MN{d_k}\Bigr) U^{\dagger}.
+    \]
+    This is the block representation of a finite-dimensional $*$-algebra in Eq.~(1.39)
+    of~\cite{Wolf2012Quantum}, invoked by~\cite[Theorem~6.14]{Wolf2012Quantum}, in the
+    unital case: a $*$-subalgebra contains the identity matrix, so there is no zero block.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:starSubalgebra_global_adapted_orthonormal_basis,
+        thm:starSubalgebra_unitary_block_diagonal, lem:starSubalgebra_double_commutant,
+        lem:starSubalgebra_scalar_commutant_irreducible, def:starSubalgebra_intertwiner,
+        def:starSubalgebra_sameIsotype}
+    Let $(f_{k,i,j})$ be the adapted orthonormal basis of
+    Theorem~\ref{thm:starSubalgebra_global_adapted_orthonormal_basis}, write $W_{k,i}$ for
+    the span of the row $(f_{k,i,j})_{j < d_k}$, and let $U$ be the change-of-basis matrix
+    from the standard basis to $(f_{k,i,j})$, as in
+    Theorem~\ref{thm:starSubalgebra_unitary_block_diagonal}. The computation there shows
+    that any matrix $A$ whose action on the adapted basis is
+    $A f_{k,i,j} = \sum_{j'} (B_k)_{j'j}\, f_{k,i,j'}$ satisfies the displayed conjugation
+    identity; in particular every member of $S$ does, which is the containment direction.
+
+    For the reverse inclusion, fix blocks $(B_k)_k$ and let $T$ be the matrix acting on
+    the adapted basis by $T f_{k,i,j} = \sum_{j'} (B_k)_{j'j}\, f_{k,i,j'}$. By
+    Lemma~\ref{lem:starSubalgebra_double_commutant} it suffices to show that $T$ commutes
+    with every operator $g$ that commutes with all members of $S$; we compute the matrix
+    of such a $g$ in the adapted basis. For a component index $k$ and multiplicity indices
+    $i, i'$, consider the operator
+    \[
+        \tau \colon v \;\longmapsto\; \sum_{j} \langle f_{k,i',j}, v\rangle\, f_{k,i,j},
+    \]
+    which reads off the coefficients of a vector along the row $(k, i')$ and rebuilds them
+    along the row $(k, i)$. Because every member of $S$ acts on the rows $(k, i')$ and
+    $(k, i)$ by the same matrix, $\tau$ commutes with all members of $S$, and so does
+    $\tau \circ g$. The composite maps $\C^{D}$ into $W_{k,i}$, and $W_{k,i}$ is
+    irreducible, so by Schur's lemma
+    (Lemma~\ref{lem:starSubalgebra_scalar_commutant_irreducible}) there is
+    $\gamma^{(k)}_{i'i} \in \C$ with $\tau(g\,x) = \gamma^{(k)}_{i'i}\, x$ for all
+    $x \in W_{k,i}$. Evaluating at $x = f_{k,i,j}$ and comparing coefficients gives
+    \[
+        \langle f_{k,i',j'},\, g\, f_{k,i,j}\rangle
+        \;=\; \gamma^{(k)}_{i'i}\, \delta_{j'j}.
+    \]
+    Across components the matrix of $g$ vanishes: with $\tau$ built from the rows
+    $(k', i')$ of another component, the composite $\tau \circ g$ carries $W_{k,i}$ into
+    $W_{k',i'}$ and commutes with $S$ on $W_{k,i}$, so a nonzero entry
+    $\langle f_{k',i',j'},\, g\, f_{k,i,j}\rangle$ would make it an intertwiner that does
+    not vanish on $W_{k,i}$, giving $W_{k,i}$ and $W_{k',i'}$ the same type and
+    contradicting Theorem~\ref{thm:starSubalgebra_global_adapted_orthonormal_basis}.
+    Expanding $g f_{k,i,j}$ in the adapted basis therefore gives
+    \[
+        g\, f_{k,i,j} \;=\; \sum_{i'} \gamma^{(k)}_{i'i}\, f_{k,i',j} :
+    \]
+    in the adapted basis $g$ is block diagonal with blocks $C_k \otimes \Id_{d_k}$,
+    opposite to the blocks of $S$. Since $T$ acts by one matrix $B_k$ on the irreducible
+    index of every row and $g$ acts by one coefficient family $\gamma^{(k)}$ on the
+    multiplicity index of every column, the two actions commute on every basis vector, so
+    $T g = g T$. By Lemma~\ref{lem:starSubalgebra_double_commutant}, $T \in S$.
+
+    Finally, if a matrix $A$ satisfies
+    $U^{\dagger} A\, U = \bigoplus_k \Id_{m_k} \otimes B_k$, then
+    $U^{\dagger} A\, U = U^{\dagger} T\, U$ for the member $T \in S$ built from the blocks
+    $(B_k)_k$, so $A = T \in S$.
 \end{proof}
 
 \begin{theorem}[Fixed-point algebra is semisimple]%

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -1922,7 +1922,7 @@ block-diagonal matrix.
 
 \begin{lemma}[Unitary change of basis to block-diagonal form]%
     \label{lem:starSubalgebra_unitary_change_of_basis_block}
-    \lean{StarSubalgebra.exists_unitary_conj_blockDiagonal_of_orthonormalBasis}
+    \lean{OrthonormalBasis.exists_unitary_conj_blockDiagonal}
     \leanok
     Let $(f_{k,i,j})_{k < K,\, i < m_k,\, j < d_k}$ be an orthonormal basis of $\C^{D}$.
     There are an identification of the index set of triples $(k, i, j)$ with


### PR DESCRIPTION
## Summary

Item 3 of step (d) of the route on LionSR/QICLean#189: the reverse inclusion of the block representation of a star-subalgebra (Wolf, *Quantum Channels & Operations*, Eq. (1.39), invoked by Thm 6.14). Together with the containment direction of LionSR/TNLean#3717 this gives the equality
$$S \;=\; U \Bigl(\bigoplus_{k} \mathbf{1}_{m_k} \otimes M_{d_k}(\mathbb{C})\Bigr) U^{\dagger},$$
the unital case (no zero block), up to the Kronecker-factor order fixed in LionSR/TNLean#3717.

New file `TNLean/Algebra/StarSubalgebraBlockForm.lean` (sorry/axiom-free):

- `StarSubalgebra.mem_of_forall_comm` — membership through the double commutant: a matrix whose operator commutes with every endomorphism of $\mathbb{C}^D$ commuting with $S$ lies in $S$. Proof: Mathlib's Jacobson density theorem (`jacobson_density`) applied to $\mathbb{C}^D$ as a semisimple module over $S$ (semisimplicity from LionSR/TNLean#3561's chain), evaluated on the standard basis.
- `StarSubalgebra.exists_unitary_conj_blockDiagonal_iff` — the full block form: a unitary $U$, positive dimensions $d_k$ and multiplicities $m_k$ with $\sum_k d_k m_k = D$, such that $A \in S$ **iff** $U^\dagger A U = \bigoplus_k \mathbf{1}_{m_k} \otimes B_k$ for some blocks $B_k$. In particular $A \mapsto (B_k(A))_k$ is onto $\prod_k M_{d_k}(\mathbb{C})$, the converse asked by the issue.

Route that closed: the double-commutant argument (candidate route 2 of the issue thread, in its commutant form rather than per-factor Burnside + factor separation). The commutant of $S$ is computed in the adapted basis: for an operator $g$ commuting with $S$, the composite of $g$ with the row-transport operators $v \mapsto \sum_j \langle f_{k,i',j}, v\rangle f_{k,i,j}$ commutes with $S$, so Schur's lemma (#3574) makes it scalar within a component, and a nonzero cross-component entry would be a nonzero intertwiner between rows of different types — impossible. Hence $g$ is block diagonal with blocks $C_k \otimes \mathbf{1}_{d_k}$, every block-diagonal matrix $\bigoplus_k \mathbf{1}_{m_k} \otimes B_k$ (in the adapted basis) commutes with all such $g$, and the double-commutant criterion places it in $S$.

Supporting statement strengthenings (all proofs already had the facts on hand):

- `StarSubalgebra.exists_orthogonal_isotypic_decomposition` now also asserts that irreducible subspaces contained in distinct isotypic components are never of the same type, via the new lemma `StarSubalgebra.exists_sameIsotype_of_le_sSup` (an irreducible subspace of a supremum of irreducible pieces has the same type as one of the pieces).
- `StarSubalgebra.exists_adapted_orthonormal_family_of_sameIsotype` now exposes that each row of the adapted family spans a member of the same-type class.
- `StarSubalgebra.exists_adapted_orthonormalBasis` now exposes that each row of the global adapted basis spans an irreducible subspace and that rows of distinct components span subspaces of different types — the two invariants consumed by the commutant computation.

The containment-only statements of LionSR/TNLean#3717 are kept unchanged (their docstrings now point to the equality).

Closes LionSR/QICLean#189.

## Blueprint

Three new entries in `blueprint/src/chapter/ch07_spectral.tex`, with full prose proofs and wired `\uses`:

- `lem:starSubalgebra_sameIsotype_of_le_sSup` (irreducible subspaces of a supremum inherit a type),
- `lem:starSubalgebra_double_commutant` (membership through the double commutant, via Jacobson density),
- `thm:starSubalgebra_unitary_block_diagonal_iff` (full block form of a $*$-subalgebra, Wolf Eq. (1.39) / Thm 6.14, unital case).

The entries for the isotypic decomposition, the per-component adapted basis, and the global adapted basis are updated to state the newly exposed clauses; the containment-only entries now point to the equality instead of recording the converse as open.

## Validation

- `lake build TNLean` — success, no new warnings
- `rg -n "sorry|axiom"` on the new and touched Lean files — clean
- `lake exe checkdecls blueprint/lean_decls` — pass (after `--update-lean-decls`)
- `python3 scripts/blueprint_lean_sync.py --ci` — in sync
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main --ci` — no violations
- `lake exe lint_style`, `git diff --check` — clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large, proof-heavy formalization of core representation theory; correctness depends on the new commutant and density arguments, but changes are localized to Lean algebra and blueprint text rather than runtime systems.
> 
> **Overview**
> Completes the **bidirectional** unitary block representation of a finite-dimensional `*`-subalgebra (Wolf Eq. 1.39 / Thm 6.14): membership is **iff** conjugation by some unitary yields block-diagonal matrices with blocks `𝟙_{m_k} ⊗ B_k`.
> 
> Adds **`TNLean/Algebra/StarSubalgebraBlockForm.lean`** with `StarSubalgebra.mem_of_forall_comm` (Jacobson density / double commutant) and `StarSubalgebra.exists_unitary_conj_blockDiagonal_iff`. The reverse inclusion builds block-diagonal candidates in the adapted basis, characterizes the commutant via **row-transport** operators and Schur’s lemma, then identifies `A` with a constructed member of `S`.
> 
> **Refactors** `StarSubalgebraBlockDiagonal`: unitary conjugation is **`OrthonormalBasis.exists_unitary_conj_blockDiagonal`**; containment theorems delegate to it. **`exists_adapted_orthonormalBasis`** is strengthened so each basis row spans an irreducible piece and rows in different components have **different isotype**.
> 
> **Supporting lemmas**: `exists_sameIsotype_of_le_sSup` and a stronger `exists_orthogonal_isotypic_decomposition`; per-component adapted families now record that each row spans a class piece. Root import and **`ch07_spectral.tex`** blueprint entries updated; containment-only docs point at the new iff theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69cb539b44fd42e227b8fe45f0c10d65bf98bed0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->