### PR TITLE
doc(paper-gaps): repoint citations at the split counterexample module

### DIFF
--- a/docs/paper-gaps/cpgsv17_bicf_block_separation.tex
+++ b/docs/paper-gaps/cpgsv17_bicf_block_separation.tex
@@ -90,8 +90,8 @@ horizontal canonical-form trace-separation conclusion.\footnote{The criteria are
     named \texttt{WordTupleSpanTop}, \texttt{wordEntryFamily}, and
     \texttt{PropBlockInjective}. The trace-separation assumption is
     \texttt{HorizontalCFData.biCF}. The constructors from these hypotheses to
-    horizontal canonical-form data are in
-    \path{TNLean/MPS/MPDO/BiCFDerivation.lean}. Relevant implications include
+    horizontal canonical-form data are in the modules under
+    \path{TNLean/MPS/MPDO/BiCFDerivation/}. Relevant implications include
     \texttt{hasBiCF\_of\_wordTupleSpanTop},
     \texttt{hasBiCF\_of\_wordEntryFamily\_linearIndependent},
     \texttt{hasBiCF\_of\_propBlockInjective}, and corresponding
@@ -116,8 +116,8 @@ $\mathbb C\oplus\mathbb C$, not the whole product algebra. Equivalently,
 choosing $\Delta_1=1$ and $\Delta_2=-1$ makes the trace pairing vanish on every
 word while the tuple $(\Delta_1,\Delta_2)$ is nonzero.
 
-This example is formalized in
-\path{TNLean/MPS/MPDO/BiCFDerivation.lean}, lines 1363--1463, and is recorded in
+This example is formalized as \texttt{duplicateScalarBlocks} and its lemmas in
+\path{TNLean/MPS/MPDO/BiCFDerivation/Counterexample.lean}, and is recorded in
 \path{docs/counterexamples.md}, lines 29--35. It shows that the additional
 finite-length witness in the formal hypotheses is genuinely stronger than the
 other horizontal canonical-form assumptions. It does not refute

--- a/docs/paper-gaps/cpgsv17_pf_rank_one.tex
+++ b/docs/paper-gaps/cpgsv17_pf_rank_one.tex
@@ -228,7 +228,7 @@ $N$, then $T$ has an outer-product factorization $T=a b^{\top}$.
 \footnote{The formal statements are
 \texttt{Matrix.PosSemidef.trace\_powers\_constant\_implies\_rank\_one} and
 \texttt{Matrix.primitive\_trace\_powers\_constant\_implies\_rank\_one\_of\_posSemidef}
-in \path{TNLean/Algebra/PerronFrobenius/RankOne.lean:181--240}.}
+in \path{TNLean/Algebra/PerronFrobenius/RankOne.lean}.}
 Primitivity is not needed for this corrected matrix theorem once positive
 semidefiniteness and trace normalization are assumed.
 


### PR DESCRIPTION
## Summary

Two paper-gap notes carried citations that predate the July module split:

- `docs/paper-gaps/cpgsv17_bicf_block_separation.tex` cited `TNLean/MPS/MPDO/BiCFDerivation.lean` (now an import shim) for the duplicate-scalar-blocks counterexample and the canonical-form-data constructors; it now cites `BiCFDerivation/Counterexample.lean` by declaration name and the `BiCFDerivation/` modules respectively.
- `docs/paper-gaps/cpgsv17_pf_rank_one.tex` cited `RankOne.lean:181--240` for the positive-semidefinite rank-one theorems, which shifted when the pairing-idempotence section was inserted; the footnote already names both declarations, so the line range is dropped in favor of the stable file-plus-declaration citation.

Both fixes cite declarations rather than line ranges so the pointers do not rot with future insertions. All underlying mathematical verdicts of the notes are unchanged.

The vertical-canonical-form note inventories (items 3 of the tracking issue) are deferred until the open sector-trace pull request lands, so the refresh can record the final state in one pass.

## Validation

- `latexmk` compiles `cpgsv17_bicf_block_separation.tex` (the rank-one note is not standalone-compilable before or after the change; the edit is text inside `\path{}`)
- `git diff --check` clean

Partially addresses #3715

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only citation fixes in LaTeX notes; no code or formal proof changes.
> 
> **Overview**
> Updates **paper-gap** footnotes so Lean pointers match the post-split layout and stay stable without line ranges.
> 
> In **`cpgsv17_bicf_block_separation.tex`**, BiCF derivation constructors are cited under **`TNLean/MPS/MPDO/BiCFDerivation/`** instead of the monolithic **`BiCFDerivation.lean`** shim. The duplicate-scalar-blocks counterexample now points at **`BiCFDerivation/Counterexample.lean`** with declaration **`duplicateScalarBlocks`**.
> 
> In **`cpgsv17_pf_rank_one.tex`**, the positive-semidefinite rank-one footnote drops **`RankOne.lean:181--240`** and cites **`RankOne.lean`** by file plus the named theorems already in the text.
> 
> No mathematical claims in either note are changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b93bdd147159ad4e068adbbf5ad595b5d77369dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->