### PR TITLE
fix(blueprint): separate the vertical multiplicity symbol from the trace coefficient

### DIFF
--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -28,8 +28,9 @@ $\mu_\alpha \otimes M_\alpha$
 equals the direct sum $\bigoplus_k \omega_{\alpha,k} M_\alpha$ of its diagonal entries, so the
 right-hand side is the block-diagonal tensor over the pairs $(\alpha, k)$ in which
 the multiplicities $r_\alpha$ and the diagonal entries $\omega_{\alpha,k}$ stay explicit;
-the coefficients $m_\alpha = \operatorname{tr}(\mu_\alpha)$ used downstream are recovered
-from them.  The predicate `IsVerticalCF` states exactly this conclusion.
+the coefficients $m_\alpha = \operatorname{tr}(\mu_\alpha)$ appearing in the
+renormalization fixed-point characterization are recovered from them.
+The predicate `IsVerticalCF` states exactly this conclusion.
 
 ## Main definitions
 

--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -27,8 +27,9 @@ normal tensors (BNT). Since each $\mu_\alpha$ is diagonal, the summand
 $\mu_\alpha \otimes M_\alpha$
 equals the direct sum $\bigoplus_k \omega_{\alpha,k} M_\alpha$ of its diagonal entries, so the
 right-hand side is the block-diagonal tensor over the pairs $(\alpha, k)$ in which
-the multiplicities $m_\alpha$ and the diagonal entries $\omega_{\alpha,k}$ stay explicit.
-The predicate `IsVerticalCF` states exactly this conclusion.
+the multiplicities $r_\alpha$ and the diagonal entries $\omega_{\alpha,k}$ stay explicit;
+the coefficients $m_\alpha = \operatorname{tr}(\mu_\alpha)$ used downstream are recovered
+from them.  The predicate `IsVerticalCF` states exactly this conclusion.
 
 ## Main definitions
 

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -23,6 +23,7 @@
 \begin{definition}[Vertically viewed tensor of an MPO]%
     \label{def:vertical_tensor_mpdo}
     \lean{MPOTensor.verticalTensor}
+    \lean{MPOTensor.verticalTensor_finProdFinEquiv}
     \leanok
     \uses{def:mpo_tensor}
     The \emph{vertical direction} of an MPO tensor exchanges the notion of
@@ -45,8 +46,8 @@
     An MPO tensor is in \emph{vertical canonical form} if there are a basis of
     normal tensors $\{M_\alpha\}_\alpha$ for its vertically viewed tensor
     $\widetilde M$, positive diagonal matrices
-    $\mu_\alpha=\operatorname{diag}(\omega_{\alpha,1},\dots,\omega_{\alpha,m_\alpha})$
-    with $m_\alpha\geq1$,
+    $\mu_\alpha=\operatorname{diag}(\omega_{\alpha,1},\dots,\omega_{\alpha,r_\alpha})$
+    with $r_\alpha\geq1$,
     and an isometry $U$ on the physical space such that
     \[
         U\widetilde MU^\dagger=\bigoplus_\alpha \mu_\alpha\otimes M_\alpha.
@@ -59,10 +60,12 @@
     \cite[line~959]{Cirac2016MPDO_arXiv}.
     Since each $\mu_\alpha$ is diagonal, the summand
     $\mu_\alpha\otimes M_\alpha$ is the direct sum
-    $\bigoplus_{k=1}^{m_\alpha}\omega_{\alpha,k}M_\alpha$ of weighted copies
+    $\bigoplus_{k=1}^{r_\alpha}\omega_{\alpha,k}M_\alpha$ of weighted copies
     of $M_\alpha$, so the right-hand side is a block-diagonal tensor over the
-    pairs $(\alpha,k)$ in which the multiplicities $m_\alpha$ and the diagonal
-    entries $\omega_{\alpha,k}$ stay explicit.
+    pairs $(\alpha,k)$ in which the multiplicities $r_\alpha$ and the diagonal
+    entries $\omega_{\alpha,k}$ stay explicit; the coefficients
+    $m_\alpha=\tr(\mu_\alpha)=\sum_k\omega_{\alpha,k}$ consumed by the
+    renormalization fixed-point characterization are recovered from them.
 \end{definition}
 
 \begin{figure}[ht]

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -64,8 +64,9 @@
     of $M_\alpha$, so the right-hand side is a block-diagonal tensor over the
     pairs $(\alpha,k)$ in which the multiplicities $r_\alpha$ and the diagonal
     entries $\omega_{\alpha,k}$ stay explicit; the coefficients
-    $m_\alpha=\tr(\mu_\alpha)=\sum_k\omega_{\alpha,k}$ consumed by the
-    renormalization fixed-point characterization are recovered from them.
+    $m_\alpha=\tr(\mu_\alpha)=\sum_{k=0}^{r_\alpha-1}\omega_{\alpha,k}$
+    appearing in the renormalization fixed-point characterization are
+    recovered from them.
 \end{definition}
 
 \begin{figure}[ht]

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -46,7 +46,7 @@
     An MPO tensor is in \emph{vertical canonical form} if there are a basis of
     normal tensors $\{M_\alpha\}_\alpha$ for its vertically viewed tensor
     $\widetilde M$, positive diagonal matrices
-    $\mu_\alpha=\operatorname{diag}(\omega_{\alpha,1},\dots,\omega_{\alpha,r_\alpha})$
+    $\mu_\alpha=\operatorname{diag}(\omega_{\alpha,0},\dots,\omega_{\alpha,r_\alpha-1})$
     with $r_\alpha\geq1$,
     and an isometry $U$ on the physical space such that
     \[
@@ -60,7 +60,7 @@
     \cite[line~959]{Cirac2016MPDO_arXiv}.
     Since each $\mu_\alpha$ is diagonal, the summand
     $\mu_\alpha\otimes M_\alpha$ is the direct sum
-    $\bigoplus_{k=1}^{r_\alpha}\omega_{\alpha,k}M_\alpha$ of weighted copies
+    $\bigoplus_{k=0}^{r_\alpha-1}\omega_{\alpha,k}M_\alpha$ of weighted copies
     of $M_\alpha$, so the right-hand side is a block-diagonal tensor over the
     pairs $(\alpha,k)$ in which the multiplicities $r_\alpha$ and the diagonal
     entries $\omega_{\alpha,k}$ stay explicit; the coefficients

--- a/docs/paper-gaps/cpgsv17_vertical_tensor_definition.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_tensor_definition.tex
@@ -78,7 +78,7 @@ The realignment (\ghissue{3712}) introduces the vertically viewed tensor
 \eqref{eq:vertical-letters} as a formal object and restates the vertical
 canonical-form predicate on it: there are a basis of normal tensors
 $\{M_\alpha\}_\alpha$ for $\widetilde M$, positive diagonal matrices
-$\mu_\alpha=\operatorname{diag}(\omega_{\alpha,1},\dots,\omega_{\alpha,r_\alpha})$
+$\mu_\alpha=\operatorname{diag}(\omega_{\alpha,0},\dots,\omega_{\alpha,r_\alpha-1})$
 with $r_\alpha\geq1$, and an isometry $U$ on the physical space satisfying
 \eqref{eq:umu} letter by letter over the horizontal bond pairs.  The isometry
 is required to be a unitary change of the physical basis ($U^\dagger U=\Id$
@@ -86,11 +86,12 @@ and $UU^\dagger=\Id$): the canonical form decomposes the physical space
 exactly, and the source discards $U$ because ``it just changes the physical
 basis on each site'' (line~959).  Since each $\mu_\alpha$ is diagonal,
 the summand $\mu_\alpha\otimes M_\alpha$ is the direct sum
-$\bigoplus_k\omega_{\alpha,k}M_\alpha$, so the right-hand side of
+$\bigoplus_{k=0}^{r_\alpha-1}\omega_{\alpha,k}M_\alpha$, so the right-hand side of
 \eqref{eq:umu} is a block-diagonal tensor over the pairs $(\alpha,k)$ in
 which both the multiplicities $r_\alpha$ and the diagonal entries
 $\omega_{\alpha,k}$ remain explicit; the coefficients
-$m_\alpha=\tr(\mu_\alpha)=\sum_k\omega_{\alpha,k}$ are recovered from them.  The one-site actions used in the
+$m_\alpha=\tr(\mu_\alpha)=\sum_{k=0}^{r_\alpha-1}\omega_{\alpha,k}$ are
+recovered from them.  The one-site actions used in the
 invariant-projection step are identified with left and right multiplication
 on the letters of $\widetilde M$.
 

--- a/docs/paper-gaps/cpgsv17_vertical_tensor_definition.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_tensor_definition.tex
@@ -78,8 +78,8 @@ The realignment (\ghissue{3712}) introduces the vertically viewed tensor
 \eqref{eq:vertical-letters} as a formal object and restates the vertical
 canonical-form predicate on it: there are a basis of normal tensors
 $\{M_\alpha\}_\alpha$ for $\widetilde M$, positive diagonal matrices
-$\mu_\alpha=\operatorname{diag}(\omega_{\alpha,1},\dots,\omega_{\alpha,m_\alpha})$
-with $m_\alpha\geq1$, and an isometry $U$ on the physical space satisfying
+$\mu_\alpha=\operatorname{diag}(\omega_{\alpha,1},\dots,\omega_{\alpha,r_\alpha})$
+with $r_\alpha\geq1$, and an isometry $U$ on the physical space satisfying
 \eqref{eq:umu} letter by letter over the horizontal bond pairs.  The isometry
 is required to be a unitary change of the physical basis ($U^\dagger U=\Id$
 and $UU^\dagger=\Id$): the canonical form decomposes the physical space
@@ -88,8 +88,9 @@ basis on each site'' (line~959).  Since each $\mu_\alpha$ is diagonal,
 the summand $\mu_\alpha\otimes M_\alpha$ is the direct sum
 $\bigoplus_k\omega_{\alpha,k}M_\alpha$, so the right-hand side of
 \eqref{eq:umu} is a block-diagonal tensor over the pairs $(\alpha,k)$ in
-which both the multiplicities $m_\alpha$ and the diagonal entries
-$\omega_{\alpha,k}$ remain explicit.  The one-site actions used in the
+which both the multiplicities $r_\alpha$ and the diagonal entries
+$\omega_{\alpha,k}$ remain explicit; the coefficients
+$m_\alpha=\tr(\mu_\alpha)=\sum_k\omega_{\alpha,k}$ are recovered from them.  The one-site actions used in the
 invariant-projection step are identified with left and right multiplication
 on the letters of $\widetilde M$.
 


### PR DESCRIPTION
## Summary

Follow-up to #3719. Three review threads were filed on that PR in the minutes after it merged; the two accepted fixes were pushed to its branch but missed the merge. This PR carries exactly those two commits (same SHAs as cited in the #3719 thread replies).

**`53ac69497` — separate the multiplicity symbol from the trace coefficient.** The source reserves $m_\alpha$ for $\operatorname{tr}(\mu_\alpha)$ (arXiv:1606.00608, line 1956), but the blueprint definition `def:vertical_cf_mpdo`, the module docstring, and the paper-gap note used the same symbol for the *size* of $\mu_\alpha$; for non-unit weights such as $\operatorname{diag}(1/2,1/2)$ the two differ (size $2$, coefficient $1$), so a `\leanok` definition entry was identifying the wrong quantity with the coefficient consumed by the renormalization fixed-point characterization. The size is now $r_\alpha$, and $m_\alpha=\operatorname{tr}(\mu_\alpha)=\sum_k\omega_{\alpha,k}$ is stated as recovered from the explicit multiplicities and diagonal entries. Also anchors the pair-level letter formula of the vertically viewed tensor (`MPOTensor.verticalTensor_finProdFinEquiv`) in its blueprint definition entry, addressing the unused-lemma thread.

**`0e1e8cee1` — zero-based weight indices.** The vertical canonical-form definition's weight index now runs $0,\dots,r_\alpha-1$ in both displays, matching the zero-based index convention of the blueprint and the formal statement's index range.

## Verification

- `lake build` succeeds (docstring-only Lean change; no `sorry`/`axiom`)
- `leanblueprint checkdecls`, `blueprint_lean_sync.py --ci`, prose checker, `lake exe lint_style` all pass
- `latexmk` builds the touched paper-gap note
- `git diff --check` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring and LaTeX/blueprint prose only; no formal definitions or proof logic changed.
> 
> **Overview**
> Aligns vertical canonical-form **notation** with arXiv:1606.00608: **$r_\alpha$** is the size of $\mu_\alpha$ (explicit diagonal weights $\omega_{\alpha,k}$), while **$m_\alpha=\operatorname{tr}(\mu_\alpha)=\sum_k\omega_{\alpha,k}$** is stated as the coefficient used later in renormalization—not the same as $r_\alpha$ when weights are not all $1$ (e.g. $\operatorname{diag}(1/2,1/2)$).
> 
> Weight indices in the direct-sum display are **zero-based** ($k=0,\dots,r_\alpha-1$) to match the formal development. The blueprint **vertically viewed tensor** definition now also `\lean`-links **`MPOTensor.verticalTensor_finProdFinEquiv`** for the paired bond-index letter formula.
> 
> Updates are prose-only in the Lean module docstring, blueprint `def:vertical_cf_mpdo`, and the paper-gap note; no change to `IsVerticalCF` or other formal statements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41907f842494d66d6bf9274dc8e009ec7edad578. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->