### PR TITLE
feat(Channel): unitary block form of the fixed-point algebra (Wolf Thm 6.14, unital case)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -163,6 +163,7 @@ import TNLean.Channel.Schwarz.MultiplicativeDomain
 import TNLean.Channel.Schwarz.MultiplicativeDomainPowers
 import TNLean.Channel.Schwarz.MultiplicativeDomainFull
 import TNLean.Channel.FixedPoint.Algebra
+import TNLean.Channel.FixedPoint.BlockForm
 import TNLean.Channel.FixedPoint.ChoiEffros
 import TNLean.Channel.FixedPoint.Cesaro
 import TNLean.Channel.FixedPoint.CornerAlgebra

--- a/TNLean/Channel/FixedPoint/BlockForm.lean
+++ b/TNLean/Channel/FixedPoint/BlockForm.lean
@@ -21,7 +21,8 @@ the block representation of Equation (1.39) of *Quantum Channels & Operations*
 (Wolf 2012),
 written with the Kronecker factors in the
 order identity-times-matrix. The positive definite fixed point removes the zero block:
-this is the unital case of the block form invoked by Theorem 6.14 there. The general case of
+this is the unital case of the block form invoked by Theorem 6.14 of the same reference.
+The general case of
 Theorem 6.14, where the Schrödinger-picture fixed-point space carries a zero block and
 each
 summand is weighted by a density operator $\rho_k$, is not asserted here.

--- a/TNLean/Channel/FixedPoint/BlockForm.lean
+++ b/TNLean/Channel/FixedPoint/BlockForm.lean
@@ -17,11 +17,13 @@ Channels & Operations*, Wolf 2012), so there is a unitary $U$ with
 $$\{X \mid T^{*}(X) = X\}
   \;=\; U \Bigl(\bigoplus_{k} \mathbf{1}_{m_k} \otimes M_{d_k}(\mathbb{C})\Bigr)
   U^{\dagger},$$
-the block representation of Eq. (1.39) of *Quantum Channels & Operations* (Wolf 2012),
+the block representation of Equation (1.39) of *Quantum Channels & Operations*
+(Wolf 2012),
 written with the Kronecker factors in the
 order identity-times-matrix. The positive definite fixed point removes the zero block:
 this is the unital case of the block form invoked by Theorem 6.14 there. The general case of
-Thm 6.14, where the Schrödinger-picture fixed-point space carries a zero block and each
+Theorem 6.14, where the Schrödinger-picture fixed-point space carries a zero block and
+each
 summand is weighted by a density operator $\rho_k$, is not asserted here.
 
 ## Main results
@@ -56,11 +58,11 @@ $$\{X \mid T^{*}(X) = X\}
 The fixed points of the unital map $T^{*}$ form a star-subalgebra because $T$ has a
 positive definite fixed point (Theorem 6.12 of *Quantum Channels & Operations*, Wolf 2012,
 in the Kraus case of the Schwarz hypothesis), and every star-subalgebra takes the block
-form of Eq. (1.39) there; the
+form of Equation (1.39) there; the
 positive definiteness of $\rho$ removes the zero block, so this is the unital case of the
 block representation invoked by Theorem 6.14 of *Quantum Channels & Operations*
 (Wolf 2012).
-The density-weighted form of Thm 6.14 for the Schrödinger-picture fixed points is not
+The density-weighted form of Theorem 6.14 for the Schrödinger-picture fixed points is not
 asserted here. -/
 theorem adjointFixedPoints_blockDiagonal_iff
     (K : Fin d → Mat) (h_tp : IsTP K) {ρ : Mat}
@@ -91,7 +93,8 @@ for some matrices $B_k \in M_{d_k}(\mathbb{C})$. This is
 exchanged: the fixed points of the unital map $E$ form a star-subalgebra (Theorem 6.12
 of *Quantum Channels & Operations*, Wolf 2012, in the Kraus case of the Schwarz
 hypothesis), and the positive definite fixed point of the
-adjoint removes the zero block from the block representation of Eq. (1.39) there, the
+adjoint removes the zero block from the block representation of Equation (1.39) there,
+the
 unital case invoked by Theorem 6.14 of *Quantum Channels & Operations* (Wolf 2012). -/
 theorem fixedPoints_blockDiagonal_iff
     (K : Fin d → Mat) (h_unital : IsUnital K) {ρ : Mat}

--- a/TNLean/Channel/FixedPoint/BlockForm.lean
+++ b/TNLean/Channel/FixedPoint/BlockForm.lean
@@ -1,0 +1,110 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Channel.FixedPoint.WedderburnDecomp
+import TNLean.Algebra.StarSubalgebraBlockForm
+
+/-!
+# Unitary block form of the fixed-point algebra of a Kraus map
+
+This file instantiates the full block form of a star-subalgebra of complex matrices
+(`StarSubalgebra.exists_unitary_conj_blockDiagonal_iff`) with the fixed-point algebras of
+*Quantum Channels & Operations* (Wolf 2012), Chapter 6. For a trace-preserving Kraus map
+whose Schrödinger picture has a positive definite fixed point, the set of fixed points of
+the Heisenberg-picture map is a unital star-subalgebra (Wolf Thm 6.12), so there is a
+unitary $U$ with
+$$\{X \mid T^{*}(X) = X\}
+  \;=\; U \Bigl(\bigoplus_{k} \mathbf{1}_{m_k} \otimes M_{d_k}(\mathbb{C})\Bigr)
+  U^{\dagger},$$
+the block representation of Wolf Eq. (1.39), written with the Kronecker factors in the
+order identity-times-matrix. The positive definite fixed point removes the zero block:
+this is the unital case of the block form invoked by Wolf Thm 6.14. The general case of
+Thm 6.14, where the Schrödinger-picture fixed-point space carries a zero block and each
+summand is weighted by a density operator $\rho_k$, is not asserted here.
+
+## Main results
+
+* `Kraus.adjointFixedPoints_blockDiagonal_iff` -- for a trace-preserving Kraus map with a
+  positive definite Schrödinger-picture fixed point, a matrix is a fixed point of the
+  Heisenberg-picture map exactly when a fixed unitary conjugates it to block-diagonal
+  form with blocks $\mathbf{1}_{m_k} \otimes B_k$.
+* `Kraus.fixedPoints_blockDiagonal_iff` -- the same statement for the fixed points of a
+  unital Kraus map whose adjoint has a positive definite fixed point.
+-/
+
+open scoped Matrix ComplexOrder Kronecker
+
+namespace Kraus
+
+variable {d D : ℕ}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+/-- **Unitary block form of the Heisenberg-picture fixed points.** Let $T$ be a
+trace-preserving Kraus map on $M_{D}(\mathbb{C})$ with a positive definite fixed point
+$\rho$. Then there are $K \in \mathbb{N}$, positive dimensions $d_k$ and multiplicities
+$m_k$ with $\sum_k d_k m_k = D$, and a unitary $U$ such that a matrix $X$ satisfies
+$T^{*}(X) = X$ exactly when
+$$U^{\dagger} X U \;=\; \bigoplus_{k} \mathbf{1}_{m_k} \otimes B_k$$
+for some matrices $B_k \in M_{d_k}(\mathbb{C})$: up to reordering the two Kronecker
+factors of each block,
+$$\{X \mid T^{*}(X) = X\}
+  \;=\; U \Bigl(\bigoplus_{k} \mathbf{1}_{m_k} \otimes M_{d_k}(\mathbb{C})\Bigr)
+  U^{\dagger}.$$
+The fixed points of the unital map $T^{*}$ form a star-subalgebra because $T$ has a
+positive definite fixed point (Wolf Thm 6.12, in the Kraus case of the Schwarz
+hypothesis), and every star-subalgebra takes the block form of Wolf Eq. (1.39); the
+positive definiteness of $\rho$ removes the zero block, so this is the unital case of the
+block representation invoked by *Quantum Channels & Operations* (Wolf 2012), Thm 6.14.
+The density-weighted form of Thm 6.14 for the Schrödinger-picture fixed points is not
+asserted here. -/
+theorem adjointFixedPoints_blockDiagonal_iff
+    (K : Fin d → Mat) (h_tp : IsTP K) {ρ : Mat}
+    (hρ : ρ.PosDef) (hρ_fix : map K ρ = ρ) :
+    ∃ (n : ℕ) (dims mult : Fin n → ℕ)
+      (e : ((k : Fin n) × (Fin (mult k) × Fin (dims k))) ≃ Fin D) (U : Mat),
+      U ∈ Matrix.unitaryGroup (Fin D) ℂ ∧ (∀ k, 0 < dims k) ∧ (∀ k, 0 < mult k) ∧
+        ∀ X : Mat, adjointMap K X = X ↔
+          ∃ B : ∀ k, Matrix (Fin (dims k)) (Fin (dims k)) ℂ,
+            star U * X * U = Matrix.reindex e e
+              (Matrix.blockDiagonal' fun k =>
+                (1 : Matrix (Fin (mult k)) (Fin (mult k)) ℂ) ⊗ₖ B k) := by
+  obtain ⟨n, dims, mult, e, U, hU, hdims, hmult, hiff⟩ :=
+    (adjointFixedPointsStarSubalgebra (d := d) (D := D) K h_tp hρ
+      hρ_fix).exists_unitary_conj_blockDiagonal_iff
+  refine ⟨n, dims, mult, e, U, hU, hdims, hmult, fun X => Iff.trans ?_ (hiff X)⟩
+  exact ((mem_adjointFixedPointsStarSubalgebra K h_tp hρ hρ_fix X).trans
+    (mem_adjointFixedPoints K X)).symm
+
+/-- **Unitary block form of the fixed points of a unital Kraus map.** Let $E$ be a unital
+Kraus map on $M_{D}(\mathbb{C})$ whose adjoint has a positive definite fixed point $\rho$.
+Then there are $K \in \mathbb{N}$, positive dimensions $d_k$ and multiplicities $m_k$ with
+$\sum_k d_k m_k = D$, and a unitary $U$ such that a matrix $X$ satisfies $E(X) = X$
+exactly when
+$$U^{\dagger} X U \;=\; \bigoplus_{k} \mathbf{1}_{m_k} \otimes B_k$$
+for some matrices $B_k \in M_{d_k}(\mathbb{C})$. This is
+`Kraus.adjointFixedPoints_blockDiagonal_iff` with the roles of the map and its adjoint
+exchanged: the fixed points of the unital map $E$ form a star-subalgebra (Wolf Thm 6.12,
+in the Kraus case of the Schwarz hypothesis), and the positive definite fixed point of the
+adjoint removes the zero block from the block representation of Wolf Eq. (1.39), the
+unital case invoked by *Quantum Channels & Operations* (Wolf 2012), Thm 6.14. -/
+theorem fixedPoints_blockDiagonal_iff
+    (K : Fin d → Mat) (h_unital : IsUnital K) {ρ : Mat}
+    (hρ : ρ.PosDef) (hρ_fix : adjointMap K ρ = ρ) :
+    ∃ (n : ℕ) (dims mult : Fin n → ℕ)
+      (e : ((k : Fin n) × (Fin (mult k) × Fin (dims k))) ≃ Fin D) (U : Mat),
+      U ∈ Matrix.unitaryGroup (Fin D) ℂ ∧ (∀ k, 0 < dims k) ∧ (∀ k, 0 < mult k) ∧
+        ∀ X : Mat, map K X = X ↔
+          ∃ B : ∀ k, Matrix (Fin (dims k)) (Fin (dims k)) ℂ,
+            star U * X * U = Matrix.reindex e e
+              (Matrix.blockDiagonal' fun k =>
+                (1 : Matrix (Fin (mult k)) (Fin (mult k)) ℂ) ⊗ₖ B k) := by
+  obtain ⟨n, dims, mult, e, U, hU, hdims, hmult, hiff⟩ :=
+    (fixedPointsStarSubalgebra (d := d) (D := D) K h_unital hρ
+      hρ_fix).exists_unitary_conj_blockDiagonal_iff
+  refine ⟨n, dims, mult, e, U, hU, hdims, hmult, fun X => Iff.trans ?_ (hiff X)⟩
+  exact ((mem_fixedPointsStarSubalgebra K h_unital hρ hρ_fix X).trans
+    (mem_fixedPoints K X)).symm
+
+end Kraus

--- a/TNLean/Channel/FixedPoint/BlockForm.lean
+++ b/TNLean/Channel/FixedPoint/BlockForm.lean
@@ -2,7 +2,7 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TNLean.Channel.FixedPoint.WedderburnDecomp
+import TNLean.Channel.FixedPoint.Algebra
 import TNLean.Algebra.StarSubalgebraBlockForm
 
 /-!
@@ -12,14 +12,15 @@ This file instantiates the full block form of a star-subalgebra of complex matri
 (`StarSubalgebra.exists_unitary_conj_blockDiagonal_iff`) with the fixed-point algebras of
 *Quantum Channels & Operations* (Wolf 2012), Chapter 6. For a trace-preserving Kraus map
 whose Schrödinger picture has a positive definite fixed point, the set of fixed points of
-the Heisenberg-picture map is a unital star-subalgebra (Wolf Thm 6.12), so there is a
-unitary $U$ with
+the Heisenberg-picture map is a unital star-subalgebra (Theorem 6.12 of *Quantum
+Channels & Operations*, Wolf 2012), so there is a unitary $U$ with
 $$\{X \mid T^{*}(X) = X\}
   \;=\; U \Bigl(\bigoplus_{k} \mathbf{1}_{m_k} \otimes M_{d_k}(\mathbb{C})\Bigr)
   U^{\dagger},$$
-the block representation of Wolf Eq. (1.39), written with the Kronecker factors in the
+the block representation of Eq. (1.39) of *Quantum Channels & Operations* (Wolf 2012),
+written with the Kronecker factors in the
 order identity-times-matrix. The positive definite fixed point removes the zero block:
-this is the unital case of the block form invoked by Wolf Thm 6.14. The general case of
+this is the unital case of the block form invoked by Theorem 6.14 there. The general case of
 Thm 6.14, where the Schrödinger-picture fixed-point space carries a zero block and each
 summand is weighted by a density operator $\rho_k$, is not asserted here.
 
@@ -43,7 +44,7 @@ local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
 
 /-- **Unitary block form of the Heisenberg-picture fixed points.** Let $T$ be a
 trace-preserving Kraus map on $M_{D}(\mathbb{C})$ with a positive definite fixed point
-$\rho$. Then there are $K \in \mathbb{N}$, positive dimensions $d_k$ and multiplicities
+$\rho$. Then there are $n \in \mathbb{N}$, positive dimensions $d_k$ and multiplicities
 $m_k$ with $\sum_k d_k m_k = D$, and a unitary $U$ such that a matrix $X$ satisfies
 $T^{*}(X) = X$ exactly when
 $$U^{\dagger} X U \;=\; \bigoplus_{k} \mathbf{1}_{m_k} \otimes B_k$$
@@ -53,10 +54,12 @@ $$\{X \mid T^{*}(X) = X\}
   \;=\; U \Bigl(\bigoplus_{k} \mathbf{1}_{m_k} \otimes M_{d_k}(\mathbb{C})\Bigr)
   U^{\dagger}.$$
 The fixed points of the unital map $T^{*}$ form a star-subalgebra because $T$ has a
-positive definite fixed point (Wolf Thm 6.12, in the Kraus case of the Schwarz
-hypothesis), and every star-subalgebra takes the block form of Wolf Eq. (1.39); the
+positive definite fixed point (Theorem 6.12 of *Quantum Channels & Operations*, Wolf 2012,
+in the Kraus case of the Schwarz hypothesis), and every star-subalgebra takes the block
+form of Eq. (1.39) there; the
 positive definiteness of $\rho$ removes the zero block, so this is the unital case of the
-block representation invoked by *Quantum Channels & Operations* (Wolf 2012), Thm 6.14.
+block representation invoked by Theorem 6.14 of *Quantum Channels & Operations*
+(Wolf 2012).
 The density-weighted form of Thm 6.14 for the Schrödinger-picture fixed points is not
 asserted here. -/
 theorem adjointFixedPoints_blockDiagonal_iff
@@ -79,16 +82,17 @@ theorem adjointFixedPoints_blockDiagonal_iff
 
 /-- **Unitary block form of the fixed points of a unital Kraus map.** Let $E$ be a unital
 Kraus map on $M_{D}(\mathbb{C})$ whose adjoint has a positive definite fixed point $\rho$.
-Then there are $K \in \mathbb{N}$, positive dimensions $d_k$ and multiplicities $m_k$ with
+Then there are $n \in \mathbb{N}$, positive dimensions $d_k$ and multiplicities $m_k$ with
 $\sum_k d_k m_k = D$, and a unitary $U$ such that a matrix $X$ satisfies $E(X) = X$
 exactly when
 $$U^{\dagger} X U \;=\; \bigoplus_{k} \mathbf{1}_{m_k} \otimes B_k$$
 for some matrices $B_k \in M_{d_k}(\mathbb{C})$. This is
 `Kraus.adjointFixedPoints_blockDiagonal_iff` with the roles of the map and its adjoint
-exchanged: the fixed points of the unital map $E$ form a star-subalgebra (Wolf Thm 6.12,
-in the Kraus case of the Schwarz hypothesis), and the positive definite fixed point of the
-adjoint removes the zero block from the block representation of Wolf Eq. (1.39), the
-unital case invoked by *Quantum Channels & Operations* (Wolf 2012), Thm 6.14. -/
+exchanged: the fixed points of the unital map $E$ form a star-subalgebra (Theorem 6.12
+of *Quantum Channels & Operations*, Wolf 2012, in the Kraus case of the Schwarz
+hypothesis), and the positive definite fixed point of the
+adjoint removes the zero block from the block representation of Eq. (1.39) there, the
+unital case invoked by Theorem 6.14 of *Quantum Channels & Operations* (Wolf 2012). -/
 theorem fixedPoints_blockDiagonal_iff
     (K : Fin d → Mat) (h_unital : IsUnital K) {ρ : Mat}
     (hρ : ρ.PosDef) (hρ_fix : adjointMap K ρ = ρ) :

--- a/TNLean/Channel/FixedPoint/WedderburnDecomp.lean
+++ b/TNLean/Channel/FixedPoint/WedderburnDecomp.lean
@@ -182,7 +182,8 @@ adjoint-fixed-point algebra.
 The unitary block-diagonal refinement, exhibiting each summand as an identity on a
 multiplicity space tensored with a full matrix algebra, is
 `Kraus.fixedPoints_blockDiagonal_iff` in `TNLean.Channel.FixedPoint.BlockForm`; the
-density-weighted form of Theorem 6.14 there is not formalized. -/
+density-weighted form of Theorem 6.14 of *Quantum Channels & Operations* (Wolf 2012)
+is not formalized. -/
 theorem fixedPointsStarSubalgebra_exists_algEquiv_pi_matrix
     (K : Fin d → Mat) (h_unital : IsUnital K)
     {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : adjointMap K ρ = ρ) :

--- a/TNLean/Channel/FixedPoint/WedderburnDecomp.lean
+++ b/TNLean/Channel/FixedPoint/WedderburnDecomp.lean
@@ -46,9 +46,10 @@ The proof chain is:
    Wedderburn--Artin decomposition — available in Mathlib via
    `IsSemisimpleRing.exists_algEquiv_pi_matrix_of_isAlgClosed`.
 
-The concrete unitary block-diagonal embedding and the conditional expectation
-form with density operators ρ_k (Wolf Equations 1.39–1.40) require additional
-representation-theoretic results and are deferred to future work.
+The concrete unitary block-diagonal embedding (Wolf Equation 1.39) is carried out in
+`TNLean.Channel.FixedPoint.BlockForm`, which conjugates the fixed-point algebra to the
+block algebra by a unitary. The conditional expectation form with density operators ρ_k
+(Wolf Equation 1.40) remains future work.
 
 ## References
 
@@ -176,10 +177,10 @@ Schrödinger-picture map `map K`. It is the companion of
 `fixedPointAlgebra_wedderburnArtin`, which decomposes the Heisenberg-picture
 adjoint-fixed-point algebra.
 
-The remaining step toward the full Wolf Thm 6.14 is the unitary block-diagonal
-refinement that exhibits each summand as a full matrix algebra tensored with an
-identity on a multiplicity space, weighted by a density operator; that
-refinement is not formalized here. -/
+The unitary block-diagonal refinement, exhibiting each summand as an identity on a
+multiplicity space tensored with a full matrix algebra, is
+`Kraus.fixedPoints_blockDiagonal_iff` in `TNLean.Channel.FixedPoint.BlockForm`; the
+density-weighted form of Wolf Thm 6.14 is not formalized there. -/
 theorem fixedPointsStarSubalgebra_exists_algEquiv_pi_matrix
     (K : Fin d → Mat) (h_unital : IsUnital K)
     {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : adjointMap K ρ = ρ) :
@@ -232,16 +233,10 @@ structure IsWedderburnBlockDecomp
   algEquiv : ↥S ≃ₐ[ℂ] Π i : Fin numBlocks,
     Matrix (Fin (blockDim i)) (Fin (blockDim i)) ℂ
 
--- TODO: The full structure should additionally include:
--- * A unitary `U : Mat` witnessing the conjugation
--- * A proof that `S.carrier` equals the image of the block-diagonal embedding
---   under conjugation by `U`
--- * Compatibility with the star structure
---
--- This requires:
--- (1) Central projection decomposition of a semisimple algebra
--- (2) Spectral theorem on the center to extract orthogonal projections
--- (3) Construction of the unitary intertwiner U
+-- The unitary conjugation this structure leaves out is available separately:
+-- `StarSubalgebra.exists_unitary_conj_blockDiagonal_iff` identifies every star-subalgebra
+-- of `M_D(ℂ)` with a conjugated block algebra, and
+-- `TNLean.Channel.FixedPoint.BlockForm` instantiates it with the fixed-point algebras.
 
 -- TODO: This theorem is a general fact about arbitrary `StarSubalgebra ℂ Mat`,
 -- not specific to quantum channels or fixed-point algebras. It should
@@ -361,10 +356,9 @@ theorem starSubalgebra_hasWedderburnBlockDecomp
 The adjoint-fixed-point `*`-subalgebra `Fix(T*) = {X | T*(X) = X}` admits a
 Wedderburn block decomposition.
 
-Combined with `fixedPointAlgebra_wedderburnArtin`, this gives:
-`Fix(T*) ≅ ⊕_k M_{d_k}(ℂ)` (abstract) and `Fix(T*) = U(⊕_k M_{d_k} ⊗ 1_{m_k})U†`
-(concrete).
--/
+This records the product decomposition, multiplicities, and dimension bound; the unitary
+conjugation identity itself is `Kraus.adjointFixedPoints_blockDiagonal_iff` in
+`TNLean.Channel.FixedPoint.BlockForm`. -/
 theorem adjointFixedPoints_wedderburnDecomp
     (K : Fin d → Mat) (h_tp : IsTP K) {ρ : Mat}
     (hρ : ρ.PosDef) (hρ_fix : map K ρ = ρ) :

--- a/TNLean/Channel/FixedPoint/WedderburnDecomp.lean
+++ b/TNLean/Channel/FixedPoint/WedderburnDecomp.lean
@@ -46,10 +46,11 @@ The proof chain is:
    Wedderburn--Artin decomposition — available in Mathlib via
    `IsSemisimpleRing.exists_algEquiv_pi_matrix_of_isAlgClosed`.
 
-The concrete unitary block-diagonal embedding (Wolf Equation 1.39) is carried out in
+The concrete unitary block-diagonal embedding (Equation (1.39) of *Quantum Channels &
+Operations*, Wolf 2012) is carried out in
 `TNLean.Channel.FixedPoint.BlockForm`, which conjugates the fixed-point algebra to the
 block algebra by a unitary. The conditional expectation form with density operators ρ_k
-(Wolf Equation 1.40) remains future work.
+(Equation (1.40) of *Quantum Channels & Operations*, Wolf 2012) remains future work.
 
 ## References
 
@@ -171,7 +172,8 @@ The fixed-point `*`-subalgebra of a unital Schwarz map whose adjoint map has a
 positive definite fixed point decomposes, as a ℂ-algebra, into a finite product
 of full complex matrix algebras with positive block sizes.
 
-This is the structure-of-the-algebra content of Wolf Ch. 6, Thm 6.14, applied
+This is the structure-of-the-algebra content of Theorem 6.14 of *Quantum Channels &
+Operations* (Wolf 2012), applied
 to the fixed-point `*`-subalgebra `fixedPointsStarSubalgebra` of the
 Schrödinger-picture map `map K`. It is the companion of
 `fixedPointAlgebra_wedderburnArtin`, which decomposes the Heisenberg-picture
@@ -180,7 +182,7 @@ adjoint-fixed-point algebra.
 The unitary block-diagonal refinement, exhibiting each summand as an identity on a
 multiplicity space tensored with a full matrix algebra, is
 `Kraus.fixedPoints_blockDiagonal_iff` in `TNLean.Channel.FixedPoint.BlockForm`; the
-density-weighted form of Wolf Thm 6.14 is not formalized there. -/
+density-weighted form of Theorem 6.14 there is not formalized. -/
 theorem fixedPointsStarSubalgebra_exists_algEquiv_pi_matrix
     (K : Fin d → Mat) (h_unital : IsUnital K)
     {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : adjointMap K ρ = ρ) :

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2229,7 +2229,7 @@ $\bigoplus_k \Id_{m_k} \otimes \MN{d_k}$.
         U \Bigl(\bigoplus_{k=0}^{n-1} \Id_{m_k} \otimes \MN{d_k}\Bigr) U^{\dagger}.
     \]
     The positive definite fixed point removes the zero block: this is the unital case
-    of the block representation in Eq.~(1.39) of~\cite{Wolf2012Quantum}, invoked
+    of the block representation in Equation~(1.39) of~\cite{Wolf2012Quantum}, invoked
     by~\cite[Theorem~6.14]{Wolf2012Quantum}. The general form
     of~\cite[Theorem~6.14]{Wolf2012Quantum}, with a zero block and density weights
     $\rho_k$ on the Schr\"odinger-picture fixed points, is not asserted here.

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2214,19 +2214,19 @@ $\bigoplus_k \Id_{m_k} \otimes \MN{d_k}$.
     \leanok
     \uses{def:adjoint_fixed_points, def:kraus_map_channels}
     Let $E$ be a trace-preserving Kraus map on $\MN{D}$ with a positive definite fixed
-    point $\rho > 0$, $E(\rho) = \rho$. There are $K \in \N$, positive dimensions
-    $d_0, \ldots, d_{K-1}$ and multiplicities $m_0, \ldots, m_{K-1}$ with
+    point $\rho > 0$, $E(\rho) = \rho$. There are $n \in \N$, positive dimensions
+    $d_0, \ldots, d_{n-1}$ and multiplicities $m_0, \ldots, m_{n-1}$ with
     $\sum_k d_k m_k = D$, realized by an explicit identification of the index sets, and
     a unitary $U \in \MN{D}$ such that a matrix $X \in \MN{D}$ satisfies $E^*(X) = X$
     exactly when
     \[
-        U^{\dagger} X\, U \;=\; \bigoplus_{k=0}^{K-1} \Id_{m_k} \otimes B_k
+        U^{\dagger} X\, U \;=\; \bigoplus_{k=0}^{n-1} \Id_{m_k} \otimes B_k
     \]
     for some matrices $B_k \in \MN{d_k}$; that is, up to reordering the two tensor
     factors of each block,
     \[
         \mathrm{Fix}(E^*) \;=\;
-        U \Bigl(\bigoplus_{k=0}^{K-1} \Id_{m_k} \otimes \MN{d_k}\Bigr) U^{\dagger}.
+        U \Bigl(\bigoplus_{k=0}^{n-1} \Id_{m_k} \otimes \MN{d_k}\Bigr) U^{\dagger}.
     \]
     The positive definite fixed point removes the zero block: this is the unital case
     of the block representation in Eq.~(1.39) of~\cite{Wolf2012Quantum}, invoked
@@ -2253,11 +2253,11 @@ $\bigoplus_k \Id_{m_k} \otimes \MN{d_k}$.
     \leanok
     \uses{def:kraus_fixed_points, def:kraus_map_channels}
     Let $E$ be a unital Kraus map on $\MN{D}$ whose adjoint map $E^*$ has a positive
-    definite fixed point $\rho > 0$. There are $K \in \N$, positive dimensions $d_k$
+    definite fixed point $\rho > 0$. There are $n \in \N$, positive dimensions $d_k$
     and multiplicities $m_k$ with $\sum_k d_k m_k = D$, and a unitary $U \in \MN{D}$
     such that a matrix $X \in \MN{D}$ satisfies $E(X) = X$ exactly when
     \[
-        U^{\dagger} X\, U \;=\; \bigoplus_{k=0}^{K-1} \Id_{m_k} \otimes B_k
+        U^{\dagger} X\, U \;=\; \bigoplus_{k=0}^{n-1} \Id_{m_k} \otimes B_k
     \]
     for some matrices $B_k \in \MN{d_k}$. This is
     Theorem~\ref{thm:adjointFixedPoints_block_form} with the roles of the map and its

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2204,8 +2204,75 @@ $\bigoplus_k \Id_{m_k} \otimes \MN{d_k}$.
     \]
     together with the density-block form $\MN{d_k} \otimes \rho_k$.
     The theorem above gives the product decomposition, multiplicities, and
-    dimension bound needed from this block form.
+    dimension bound from this block form; the unitary conjugation identity itself, in
+    the unital case, is Theorem~\ref{thm:adjointFixedPoints_block_form} below.
 \end{remark}
+
+\begin{theorem}[Unitary block form of the Heisenberg-picture fixed points]%
+    \label{thm:adjointFixedPoints_block_form}
+    \lean{Kraus.adjointFixedPoints_blockDiagonal_iff}
+    \leanok
+    \uses{def:adjoint_fixed_points, def:kraus_map_channels}
+    Let $E$ be a trace-preserving Kraus map on $\MN{D}$ with a positive definite fixed
+    point $\rho > 0$, $E(\rho) = \rho$. There are $K \in \N$, positive dimensions
+    $d_0, \ldots, d_{K-1}$ and multiplicities $m_0, \ldots, m_{K-1}$ with
+    $\sum_k d_k m_k = D$, realized by an explicit identification of the index sets, and
+    a unitary $U \in \MN{D}$ such that a matrix $X \in \MN{D}$ satisfies $E^*(X) = X$
+    exactly when
+    \[
+        U^{\dagger} X\, U \;=\; \bigoplus_{k=0}^{K-1} \Id_{m_k} \otimes B_k
+    \]
+    for some matrices $B_k \in \MN{d_k}$; that is, up to reordering the two tensor
+    factors of each block,
+    \[
+        \mathrm{Fix}(E^*) \;=\;
+        U \Bigl(\bigoplus_{k=0}^{K-1} \Id_{m_k} \otimes \MN{d_k}\Bigr) U^{\dagger}.
+    \]
+    The positive definite fixed point removes the zero block: this is the unital case
+    of the block representation in Eq.~(1.39) of~\cite{Wolf2012Quantum}, invoked
+    by~\cite[Theorem~6.14]{Wolf2012Quantum}. The general form
+    of~\cite[Theorem~6.14]{Wolf2012Quantum}, with a zero block and density weights
+    $\rho_k$ on the Schr\"odinger-picture fixed points, is not asserted here.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:adjointFixedPointsStarSubalgebra,
+        thm:starSubalgebra_unitary_block_diagonal_iff}
+    The fixed points of $E^*$ form a $*$-subalgebra of $\MN{D}$ because $E$ is
+    trace-preserving with a positive definite fixed point
+    (Theorem~\ref{thm:adjointFixedPointsStarSubalgebra}). The full block form of a
+    $*$-subalgebra (Theorem~\ref{thm:starSubalgebra_unitary_block_diagonal_iff})
+    supplies the unitary $U$, the dimensions and multiplicities, and the equivalence
+    between membership and the block-diagonal conjugation identity.
+\end{proof}
+
+\begin{theorem}[Unitary block form of the fixed points of a unital Kraus map]%
+    \label{thm:fixedPoints_block_form}
+    \lean{Kraus.fixedPoints_blockDiagonal_iff}
+    \leanok
+    \uses{def:kraus_fixed_points, def:kraus_map_channels}
+    Let $E$ be a unital Kraus map on $\MN{D}$ whose adjoint map $E^*$ has a positive
+    definite fixed point $\rho > 0$. There are $K \in \N$, positive dimensions $d_k$
+    and multiplicities $m_k$ with $\sum_k d_k m_k = D$, and a unitary $U \in \MN{D}$
+    such that a matrix $X \in \MN{D}$ satisfies $E(X) = X$ exactly when
+    \[
+        U^{\dagger} X\, U \;=\; \bigoplus_{k=0}^{K-1} \Id_{m_k} \otimes B_k
+    \]
+    for some matrices $B_k \in \MN{d_k}$. This is
+    Theorem~\ref{thm:adjointFixedPoints_block_form} with the roles of the map and its
+    adjoint exchanged.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:fixedPointsStarSubalgebra,
+        thm:starSubalgebra_unitary_block_diagonal_iff}
+    The fixed points of the unital map $E$ form a $*$-subalgebra of $\MN{D}$
+    (Theorem~\ref{thm:fixedPointsStarSubalgebra}), and the full block form of a
+    $*$-subalgebra (Theorem~\ref{thm:starSubalgebra_unitary_block_diagonal_iff})
+    supplies the unitary and the equivalence.
+\end{proof}
 
 \begin{theorem}[Weighted fixed points form a $*$-subalgebra]%
     \label{thm:weightedFixedPointsStarSubalgebra}


### PR DESCRIPTION
## Summary

The channel-side instantiation that remained on LionSR/QICLean#186 after the reusable algebra layer landed (#3717, LionSR/TNLean#3720): the unitary spatial form of the fixed-point algebra of a Kraus map.

New file `TNLean/Channel/FixedPoint/BlockForm.lean` (sorry/axiom-free):

- `Kraus.adjointFixedPoints_blockDiagonal_iff` — for a trace-preserving Kraus family $K$ with a positive definite fixed point $\rho$ of the Schrödinger-picture map ($E(\rho)=\rho$, $\rho > 0$), there are $n$, positive dimensions $d_k$ and multiplicities $m_k$ with $\sum_k d_k m_k = D$, and a unitary $U$ such that
  $$E^*(X) = X \iff U^\dagger X U = \bigoplus_k \mathbf{1}_{m_k} \otimes B_k \text{ for some } B_k,$$
  i.e. $\mathrm{Fix}(E^*) = U\bigl(\bigoplus_k \mathbf{1}_{m_k} \otimes M_{d_k}(\mathbb{C})\bigr)U^\dagger$ (Kronecker factors in the identity-times-matrix order fixed by LionSR/TNLean#3717; Wolf writes $M_{d_k} \otimes \mathbf{1}_{m_k}$).
- `Kraus.fixedPoints_blockDiagonal_iff` — the companion for the fixed points of a unital Kraus map whose adjoint has a positive definite fixed point.

Both are direct instantiations of `StarSubalgebra.exists_unitary_conj_blockDiagonal_iff` (#3720) with `Kraus.adjointFixedPointsStarSubalgebra` resp. `Kraus.fixedPointsStarSubalgebra`, membership unfolded to the fixed-point equation.

**Exact hypotheses and scope.** The hypotheses are those under which the fixed-point sets are star-subalgebras in this development (`TNLean/Channel/FixedPoint/Algebra.lean`, Wolf Thm 6.12): a Kraus (hence completely positive) map — the "(e.g., a completely positive map)" case of Wolf's Schwarz-inequality hypothesis, the restriction already recorded in the existing blueprint entries — together with a positive definite fixed point of the pre-dual. The positive definite fixed point removes the zero block, so the theorems deliver the **unital case** of the block representation Eq. (1.39) invoked by Wolf Thm 6.14, with $\sum_k d_k m_k = D$. Not asserted (and stated as such in docstrings and blueprint): the general form of Thm 6.14 without a full-rank fixed point (zero block, $\sum_k d_k m_k \le D$, via the corner reduction of Wolf Lem 6.4/6.5) and the density-weighted form $\bigoplus_k M_{d_k} \otimes \rho_k$ for the Schrödinger-picture fixed points of a trace-preserving map.

Also updated: the deferred-work notes in `TNLean/Channel/FixedPoint/WedderburnDecomp.lean` (module doc, the `IsWedderburnBlockDecomp` comment block, and the docstrings of `fixedPointsStarSubalgebra_exists_algEquiv_pi_matrix` and `adjointFixedPoints_wedderburnDecomp`, the last of which claimed the concrete form as available when it was not) now point to the formalized conjugation instead of describing it as future work.

Closes LionSR/QICLean#186 (the reusable unitary block form and its fixed-point-algebra instantiation, in the positive-definite-fixed-point case in which the fixed-point algebra is formalized; the zero-block and density-weighted generalizations of Wolf Thm 6.14 are recorded as open in the blueprint entry).

## Blueprint

Two new entries in `blueprint/src/chapter/ch07_spectral.tex`, placed after the Wedderburn-decomposition entries for the fixed-point algebra, with full prose proofs and wired `\uses`:

- `thm:adjointFixedPoints_block_form` (uses `thm:adjointFixedPointsStarSubalgebra` and `thm:starSubalgebra_unitary_block_diagonal_iff`),
- `thm:fixedPoints_block_form` (uses `thm:fixedPointsStarSubalgebra` and `thm:starSubalgebra_unitary_block_diagonal_iff`).

The remark on the block form of the fixed-point algebra now points to the conjugation identity instead of describing only the abstract decomposition.

## Validation

- `lake build TNLean` — success, no new warnings
- `rg -n "sorry|axiom"` on the new and touched Lean files — clean
- `lake exe checkdecls blueprint/lean_decls` — pass (after `--update-lean-decls`)
- `python3 scripts/blueprint_lean_sync.py --ci` — in sync
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main --ci` — no violations
- `lake exe lint_style`, `git diff --check` — clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization glue on top of existing algebra and fixed-point infrastructure; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **`TNLean/Channel/FixedPoint/BlockForm.lean`** and wires it into the public import surface. The new theorems **`Kraus.adjointFixedPoints_blockDiagonal_iff`** and **`Kraus.fixedPoints_blockDiagonal_iff`** state that, under a positive definite fixed point (Schrödinger picture for the adjoint case, adjoint picture for the unital case), fixed points are exactly those matrices unitarily conjugate to block-diagonal form with blocks **1_{m_k} ⊗ B_k**. Proofs are instantiations of **`StarSubalgebra.exists_unitary_conj_blockDiagonal_iff`** on the existing fixed-point star-subalgebras, with membership unfolded via the algebra lemmas.
> 
> **`WedderburnDecomp.lean`** no longer treats the unitary block embedding as deferred: module text, **`IsWedderburnBlockDecomp`** comments, and theorem docstrings now cite **`BlockForm`** for the conjugation identity; density-weighted / zero-block generalizations of Wolf 6.14 remain explicitly out of scope.
> 
> The blueprint gains **`thm:adjointFixedPoints_block_form`** and **`thm:fixedPoints_block_form`** in **`ch07_spectral.tex`**, plus an updated remark linking the abstract Wedderburn data to the new conjugation theorems.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e572a73a2987779f2043774180fa649bde55c811. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->