### PR TITLE
feat(MPS/MPDO): length-independent structure coefficients are natural numbers

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -27,6 +27,7 @@ import TNLean.Algebra.MatrixAux
 import TNLean.Algebra.MatrixGramUnitary
 import TNLean.Algebra.FinSum
 import TNLean.Algebra.ScalarPowerSumIdentity
+import TNLean.Algebra.ConstantPowerSums
 import TNLean.Algebra.UnitModulusPowerSum
 import TNLean.Algebra.FiniteCycleCoboundary
 import TNLean.Algebra.PiTensorProductPhase
@@ -375,6 +376,7 @@ import TNLean.MPS.MPDO.FusionIsometries
 import TNLean.MPS.MPDO.AlgebraStructure
 import TNLean.MPS.MPDO.AlgebraFusionCounterexample
 import TNLean.MPS.MPDO.BNTCoefficients
+import TNLean.MPS.MPDO.LengthIndependentCoefficients
 import TNLean.MPS.MPDO.BNTTheoremData
 import TNLean.MPS.MPDO.BNTTheoremWitness
 import TNLean.MPS.MPDO.BNTTheoremWitnessConsequences

--- a/TNLean/Algebra/ConstantPowerSums.lean
+++ b/TNLean/Algebra/ConstantPowerSums.lean
@@ -1,0 +1,123 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Algebra.Order.Archimedean.Basic
+import Mathlib.Algebra.Order.BigOperators.Group.Finset
+import Mathlib.Analysis.Complex.Order
+import Mathlib.Data.Complex.BigOperators
+
+/-!
+# Constant power sums
+
+A finite family of nonnegative real numbers whose power sums
+$\sum_k x_k^L$ take the same value at every positive exponent $L$ has all
+entries equal to $0$ or $1$: an entry exceeding one would make the power sums
+unbounded, and comparing the exponents one and two then forces
+$\sum_k x_k(1 - x_k) = 0$ with nonnegative summands.  The file also provides
+the corresponding statement for families of complex numbers that are
+nonnegative in the complex order.
+
+These are the scalar inputs for the discussion following Theorem IV.13 of
+arXiv:1606.00608 (lines 995--1010): structure coefficients of the form
+$\operatorname{tr}(\chi^L)$ with positive diagonal $\chi$ that do not depend
+on $L$ are natural numbers.  The paper derives this from its power-sum
+uniqueness lemma (lines 1155--1163); the elementary argument here suffices for
+the constant-power-sum specialization.
+
+The nonnegativity hypothesis cannot be dropped: the primitive cube roots of
+unity have power sums invariant under doubling the exponent, yet do not lie in
+$\{0, 1\}$.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Section 4.5, lines 995--1010
+-/
+
+open scoped BigOperators ComplexOrder
+
+variable {ι : Type*} [Fintype ι]
+
+/-- Entries of a nonnegative real family whose power sums do not depend on the
+positive exponent are at most one: an entry exceeding one would make the power
+sums unbounded.
+
+Source: arXiv:1606.00608, line 1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem le_one_of_forall_sum_pow_eq {x : ι → ℝ} (hx : ∀ k, 0 ≤ x k)
+    (hsum : ∀ L : ℕ, 0 < L → ∑ k, x k ^ L = ∑ k, x k) (j : ι) : x j ≤ 1 := by
+  by_contra hgt
+  rw [not_le] at hgt
+  obtain ⟨L, hL⟩ := pow_unbounded_of_one_lt (∑ k, x k) hgt
+  have hsingle : x j ^ (L + 1) ≤ ∑ k, x k ^ (L + 1) :=
+    Finset.single_le_sum (fun k _ => pow_nonneg (hx k) _) (Finset.mem_univ j)
+  have hmono : x j ^ L ≤ x j ^ (L + 1) := pow_le_pow_right₀ hgt.le (Nat.le_succ L)
+  have heq := hsum (L + 1) (Nat.succ_pos L)
+  linarith
+
+/-- **Constant power sums have entries zero or one.** If the power sums
+`∑ k, x k ^ L` of a nonnegative real family do not depend on the positive
+exponent `L`, then every entry equals `0` or `1`.
+
+Comparing the exponents one and two shows that `∑ k, x k * (1 - x k)`
+vanishes, and every summand is nonnegative because no entry exceeds one.
+
+Source: arXiv:1606.00608, line 1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem eq_zero_or_eq_one_of_forall_sum_pow_eq {x : ι → ℝ} (hx : ∀ k, 0 ≤ x k)
+    (hsum : ∀ L : ℕ, 0 < L → ∑ k, x k ^ L = ∑ k, x k) (j : ι) :
+    x j = 0 ∨ x j = 1 := by
+  have hle : ∀ k, x k ≤ 1 := le_one_of_forall_sum_pow_eq hx hsum
+  have hzero : ∑ k, (x k - x k ^ 2) = 0 := by
+    rw [Finset.sum_sub_distrib, hsum 2 two_pos, sub_self]
+  have hterm : ∀ k ∈ Finset.univ, (0 : ℝ) ≤ x k - x k ^ 2 := by
+    intro k _
+    have hsq : x k ^ 2 ≤ x k := by
+      rw [sq]
+      exact mul_le_of_le_one_left (hx k) (hle k)
+    linarith
+  have hj := (Finset.sum_eq_zero_iff_of_nonneg hterm).mp hzero j (Finset.mem_univ j)
+  have hfactor : x j * (1 - x j) = 0 := by ring_nf; linarith
+  rcases mul_eq_zero.mp hfactor with h | h
+  · exact Or.inl h
+  · exact Or.inr (by linarith)
+
+/-- Complex version of the constant-power-sum dichotomy, for families that are
+nonnegative in the complex order (real entries with nonnegative real part).
+Nonnegativity cannot be dropped: the primitive cube roots of unity have power
+sums invariant under doubling the exponent without lying in `{0, 1}`.
+
+Source: arXiv:1606.00608, line 1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem Complex.eq_zero_or_eq_one_of_forall_sum_pow_eq {z : ι → ℂ}
+    (hz : ∀ k, 0 ≤ z k)
+    (hsum : ∀ L : ℕ, 0 < L → ∑ k, z k ^ L = ∑ k, z k) (j : ι) :
+    z j = 0 ∨ z j = 1 := by
+  have hre : ∀ k, z k = ((z k).re : ℂ) := by
+    intro k
+    have him : (z k).im = 0 := by
+      have := (Complex.le_def).mp (hz k)
+      simpa using this.2.symm
+    exact Complex.ext rfl (by simp [him])
+  have hxnonneg : ∀ k, 0 ≤ (z k).re := by
+    intro k
+    have := (Complex.le_def).mp (hz k)
+    simpa using this.1
+  have hsumR : ∀ L : ℕ, 0 < L → ∑ k, (z k).re ^ L = ∑ k, (z k).re := by
+    intro L hL
+    have hcast : ((∑ k, (z k).re ^ L : ℝ) : ℂ) = ((∑ k, (z k).re : ℝ) : ℂ) := by
+      push_cast
+      calc (∑ k, ((z k).re : ℂ) ^ L)
+          = ∑ k, z k ^ L := by
+            refine Finset.sum_congr rfl fun k _ => ?_
+            rw [← hre k]
+        _ = ∑ k, z k := hsum L hL
+        _ = ∑ k, ((z k).re : ℂ) := Finset.sum_congr rfl fun k _ => hre k
+    exact_mod_cast hcast
+  rcases _root_.eq_zero_or_eq_one_of_forall_sum_pow_eq hxnonneg hsumR j with h | h
+  · left
+    rw [hre j, h, Complex.ofReal_zero]
+  · right
+    rw [hre j, h, Complex.ofReal_one]

--- a/TNLean/MPS/MPDO/LengthIndependentCoefficients.lean
+++ b/TNLean/MPS/MPDO/LengthIndependentCoefficients.lean
@@ -1,0 +1,217 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.ConstantPowerSums
+import TNLean.MPS.MPDO.BNTCoefficients
+
+/-!
+# Length-independent BNT-label structure coefficients
+
+After Theorem IV.13, arXiv:1606.00608 singles out the renormalization fixed
+points whose BNT-label structure coefficients
+$c^{(L)}_{\alpha,\beta,\gamma} = \operatorname{tr}(\chi^L_{\alpha,\beta,\gamma})$
+do not depend on the chain length $L$.  For this case the paper observes
+(line 1010) that the diagonal entries of the matrices
+$\chi_{\alpha,\beta,\gamma}$ lie in $\{0, 1\}$, so every structure coefficient
+is a natural number; with the positivity of Theorem IV.13(ii) the entries in
+fact all equal one, and each coefficient is the size of the corresponding
+diagonal matrix.  Starting from the same-length product law and the idempotent
+condition with natural-number coefficients independent of the length,
+Bultinck, Marien, Williamson, Sahinoglu, Haegeman, and Verstraete
+(arXiv:1511.08090) recover the known non-chiral topologically ordered phases;
+the paper leaves open whether renormalization fixed points with
+length-dependent structure coefficients exist (lines 995--997).
+
+This file defines the length-independence predicate on the BNT-label
+coefficient systems of `TNLean.MPS.MPDO.BNTCoefficients` and proves the
+naturality consequences for a positive chi witness, together with the
+converse.  Every statement stays at the BNT-label level: nothing is
+constructed from an MPDO tensor, since the construction of the coefficient
+objects from a tensor is the separate Appendix C.3--C.4 obligation recorded in
+`docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`.
+
+The paper derives the $\{0, 1\}$ membership from the power-sum uniqueness
+lemma of its appendix (lines 1155--1163, formalized in
+`TNLean.Algebra.ScalarPowerSumIdentity`); the proofs here use the elementary
+constant-power-sum dichotomy from `TNLean.Algebra.ConstantPowerSums`, which
+suffices for this specialization.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Section 4.5, lines 995--1010
+* [Bultinck--Marien--Williamson--Sahinoglu--Haegeman--Verstraete 2017]
+  arXiv:1511.08090, Ann. Phys. 378 (2017) 183--233
+-/
+
+open scoped BigOperators ComplexOrder
+
+namespace MPOTensor
+
+namespace DiagonalChiFamily
+
+variable {I : Type*} {χ : DiagonalChiFamily I}
+
+/-- Diagonal entries of a positive chi family whose trace-power coefficients
+do not depend on the positive exponent all equal one.
+
+Source: arXiv:1606.00608, line 1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem entry_eq_one_of_posEntries_of_forall_tracePowerCoeff_eq
+    (hχ : χ.PosEntries) (α β γ : I)
+    (hsum : ∀ L : ℕ, 0 < L →
+      χ.tracePowerCoeff α β γ L = χ.tracePowerCoeff α β γ 1)
+    (k : Fin (χ.dim α β γ)) : χ.entry α β γ k = 1 := by
+  have hsum' : ∀ L : ℕ, 0 < L →
+      ∑ r, χ.entry α β γ r ^ L = ∑ r, χ.entry α β γ r := by
+    intro L hL
+    simpa [tracePowerCoeff] using hsum L hL
+  rcases Complex.eq_zero_or_eq_one_of_forall_sum_pow_eq
+      (fun r => (hχ α β γ r).le) hsum' k with h | h
+  · exact absurd h (ne_of_gt (hχ α β γ k))
+  · exact h
+
+/-- When every diagonal entry of a chi family equals one, the trace-power
+coefficient at any exponent is the size of the diagonal matrix.
+
+Source: arXiv:1606.00608, line 1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem tracePowerCoeff_eq_dim_of_forall_entry_eq_one
+    (hone : ∀ α β γ : I, ∀ k : Fin (χ.dim α β γ), χ.entry α β γ k = 1)
+    (α β γ : I) (L : ℕ) :
+    χ.tracePowerCoeff α β γ L = (χ.dim α β γ : ℂ) := by
+  simp [tracePowerCoeff, hone]
+
+end DiagonalChiFamily
+
+namespace BNTLabelCoefficientFamily
+
+variable {Λ : Type*} (c : BNTLabelCoefficientFamily Λ)
+
+/-- Length independence of the BNT-label structure coefficients: at every
+positive chain length the coefficients agree with the length-one
+coefficients.
+
+This is the special case singled out in the discussion following
+Theorem IV.13, where the structure coefficients
+$c^{(L)}_{\alpha,\beta,\gamma}$ are natural numbers independent of $L$ and
+connect the renormalization fixed points to non-chiral topologically ordered
+phases.  Whether every renormalization fixed point has length-independent
+coefficients is the open question of the source.
+
+Source: arXiv:1606.00608, lines 995--1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+def LengthIndependent : Prop :=
+  ∀ L : ℕ, 0 < L → ∀ α β γ : Λ, c.coeff L α β γ = c.coeff 1 α β γ
+
+variable {c}
+
+/-- Length-independent coefficients agree at any two positive lengths.
+
+Source: arXiv:1606.00608, lines 995--1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem LengthIndependent.coeff_eq (hLI : c.LengthIndependent)
+    {L L' : ℕ} (hL : 0 < L) (hL' : 0 < L') (α β γ : Λ) :
+    c.coeff L α β γ = c.coeff L' α β γ := by
+  rw [hLI L hL α β γ, hLI L' hL' α β γ]
+
+/-- Every diagonal entry of a positive chi witness for a length-independent
+coefficient system equals one.
+
+Source: arXiv:1606.00608, line 1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem HasPositiveLengthChiTracePowerForm.entry_eq_one_of_lengthIndependent
+    {χ : DiagonalChiFamily Λ}
+    (h : c.HasPositiveLengthChiTracePowerForm χ) (hχ : χ.PosEntries)
+    (hLI : c.LengthIndependent) (α β γ : Λ) (k : Fin (χ.dim α β γ)) :
+    χ.entry α β γ k = 1 := by
+  refine DiagonalChiFamily.entry_eq_one_of_posEntries_of_forall_tracePowerCoeff_eq
+    hχ α β γ (fun L hL => ?_) k
+  rw [← h L hL α β γ, ← h 1 one_pos α β γ]
+  exact hLI L hL α β γ
+
+/-- The diagonal entries of a positive chi witness for a length-independent
+coefficient system lie in $\{0, 1\}$, as stated in the source; positivity
+excludes the value zero.
+
+Source: arXiv:1606.00608, line 1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem HasPositiveLengthChiTracePowerForm.entry_eq_zero_or_eq_one_of_lengthIndependent
+    {χ : DiagonalChiFamily Λ}
+    (h : c.HasPositiveLengthChiTracePowerForm χ) (hχ : χ.PosEntries)
+    (hLI : c.LengthIndependent) (α β γ : Λ) (k : Fin (χ.dim α β γ)) :
+    χ.entry α β γ k = 0 ∨ χ.entry α β γ k = 1 :=
+  Or.inr (h.entry_eq_one_of_lengthIndependent hχ hLI α β γ k)
+
+/-- Length-independent coefficients with a positive chi witness equal the
+sizes of the corresponding diagonal matrices at every positive length.
+
+Source: arXiv:1606.00608, line 1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem HasPositiveLengthChiTracePowerForm.coeff_eq_dim_of_lengthIndependent
+    {χ : DiagonalChiFamily Λ}
+    (h : c.HasPositiveLengthChiTracePowerForm χ) (hχ : χ.PosEntries)
+    (hLI : c.LengthIndependent) (L : ℕ) (hL : 0 < L) (α β γ : Λ) :
+    c.coeff L α β γ = (χ.dim α β γ : ℂ) := by
+  rw [h L hL α β γ]
+  exact DiagonalChiFamily.tracePowerCoeff_eq_dim_of_forall_entry_eq_one
+    (h.entry_eq_one_of_lengthIndependent hχ hLI) α β γ L
+
+/-- Length-independent coefficients with a positive chi witness are natural
+numbers.
+
+Source: arXiv:1606.00608, line 1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem HasPositiveLengthChiTracePowerForm.exists_natCast_coeff_of_lengthIndependent
+    {χ : DiagonalChiFamily Λ}
+    (h : c.HasPositiveLengthChiTracePowerForm χ) (hχ : χ.PosEntries)
+    (hLI : c.LengthIndependent) (L : ℕ) (hL : 0 < L) (α β γ : Λ) :
+    ∃ n : ℕ, c.coeff L α β γ = (n : ℂ) :=
+  ⟨χ.dim α β γ, h.coeff_eq_dim_of_lengthIndependent hχ hLI L hL α β γ⟩
+
+/-- Conversely, a coefficient system with a chi witness whose diagonal entries
+all equal one is length independent.
+
+Source: arXiv:1606.00608, lines 995--1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem HasPositiveLengthChiTracePowerForm.lengthIndependent_of_forall_entry_eq_one
+    {χ : DiagonalChiFamily Λ}
+    (h : c.HasPositiveLengthChiTracePowerForm χ)
+    (hone : ∀ α β γ : Λ, ∀ k : Fin (χ.dim α β γ), χ.entry α β γ k = 1) :
+    c.LengthIndependent := by
+  intro L hL α β γ
+  rw [h L hL α β γ, h 1 one_pos α β γ,
+    DiagonalChiFamily.tracePowerCoeff_eq_dim_of_forall_entry_eq_one hone,
+    DiagonalChiFamily.tracePowerCoeff_eq_dim_of_forall_entry_eq_one hone]
+
+end BNTLabelCoefficientFamily
+
+namespace PositiveBNTLabelChiTracePowerForm
+
+variable {Λ : Type*} {c : BNTLabelCoefficientFamily Λ}
+
+/-- Every diagonal entry of a positive BNT-label chi witness equals one when
+the coefficient system is length independent.
+
+Source: arXiv:1606.00608, line 1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem entry_eq_one_of_lengthIndependent (h : PositiveBNTLabelChiTracePowerForm c)
+    (hLI : c.LengthIndependent) (α β γ : Λ) (k : Fin (h.chi.dim α β γ)) :
+    h.chi.entry α β γ k = 1 :=
+  h.tracePower.entry_eq_one_of_lengthIndependent h.posEntries hLI α β γ k
+
+/-- Length-independent coefficients with a positive BNT-label chi witness are
+the sizes of the diagonal matrices, hence natural numbers.
+
+Source: arXiv:1606.00608, line 1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem coeff_eq_dim_of_lengthIndependent (h : PositiveBNTLabelChiTracePowerForm c)
+    (hLI : c.LengthIndependent) (L : ℕ) (hL : 0 < L) (α β γ : Λ) :
+    c.coeff L α β γ = (h.chi.dim α β γ : ℂ) :=
+  h.tracePower.coeff_eq_dim_of_lengthIndependent h.posEntries hLI L hL α β γ
+
+end PositiveBNTLabelChiTracePowerForm
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -458,3 +458,111 @@
     BNT-label trace-power formula.
 \end{proof}
 
+
+\begin{lemma}[Constant power sums have entries zero or one]%
+    \label{lem:constant_power_sum_dichotomy}
+    \lean{le_one_of_forall_sum_pow_eq}
+    \lean{eq_zero_or_eq_one_of_forall_sum_pow_eq}
+    \lean{Complex.eq_zero_or_eq_one_of_forall_sum_pow_eq}
+    \leanok
+    Let $x_1,\dots,x_n$ be nonnegative real numbers whose power sums
+    $\sum_k x_k^L$ take the same value at every exponent $L \ge 1$. Then
+    every $x_k$ equals $0$ or $1$. The same holds for a finite family of
+    complex numbers that are nonnegative in the complex order.
+    Nonnegativity cannot be dropped: the primitive cube roots of unity have
+    power sums invariant under doubling the exponent, yet do not lie in
+    $\{0,1\}$.
+\end{lemma}
+\begin{proof}\leanok
+    If some entry exceeded one, its powers would grow without bound while
+    all other summands stay nonnegative, contradicting constancy of the
+    power sums; hence every entry lies in $[0,1]$. Comparing the exponents
+    one and two gives $\sum_k x_k(1-x_k) = 0$ with nonnegative summands, so
+    each summand vanishes.
+\end{proof}
+
+\begin{definition}[Length-independent coefficients]%
+    \label{def:mpdo_bnt_label_length_independent}
+    \lean{MPOTensor.BNTLabelCoefficientFamily.LengthIndependent}
+    \lean{MPOTensor.BNTLabelCoefficientFamily.LengthIndependent.coeff_eq}
+    \leanok
+    \uses{def:mpdo_bnt_label_coefficient_family}
+    A BNT-label coefficient system $c^{(L)}_{\alpha,\beta,\gamma}$ is
+    \emph{length independent} when
+    $c^{(L)}_{\alpha,\beta,\gamma} = c^{(1)}_{\alpha,\beta,\gamma}$ for
+    every positive chain length $L$ and all labels; equivalently, the
+    coefficients agree at any two positive lengths. This is the case
+    singled out in the discussion following
+    \cite[Theorem~4.14]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{theorem}[Length-independent coefficients are natural numbers]%
+    \label{thm:mpdo_bnt_label_length_independent_natural}
+    \lean{MPOTensor.DiagonalChiFamily.%
+        entry_eq_one_of_posEntries_of_forall_tracePowerCoeff_eq}
+    \lean{MPOTensor.BNTLabelCoefficientFamily.HasPositiveLengthChiTracePowerForm.%
+        entry_eq_one_of_lengthIndependent}
+    \lean{MPOTensor.BNTLabelCoefficientFamily.HasPositiveLengthChiTracePowerForm.%
+        entry_eq_zero_or_eq_one_of_lengthIndependent}
+    \lean{MPOTensor.BNTLabelCoefficientFamily.HasPositiveLengthChiTracePowerForm.%
+        coeff_eq_dim_of_lengthIndependent}
+    \lean{MPOTensor.BNTLabelCoefficientFamily.HasPositiveLengthChiTracePowerForm.%
+        exists_natCast_coeff_of_lengthIndependent}
+    \lean{MPOTensor.PositiveBNTLabelChiTracePowerForm.entry_eq_one_of_lengthIndependent}
+    \lean{MPOTensor.PositiveBNTLabelChiTracePowerForm.coeff_eq_dim_of_lengthIndependent}
+    \leanok
+    \uses{def:mpdo_bnt_label_length_independent,
+        def:mpdo_bnt_label_positive_length_chi_trace_power_form,
+        def:mpdo_positive_bnt_label_chi_trace_power_form,
+        lem:constant_power_sum_dichotomy}
+    Suppose a BNT-label coefficient system is in trace-power form
+    $c^{(L)}_{\alpha,\beta,\gamma}
+        = \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{\,L})$
+    with positive diagonal matrices $\chi_{\alpha,\beta,\gamma}$, and is
+    length independent. Then every diagonal entry
+    $\chi_{\alpha,\beta,\gamma,r}$ lies in $\{0,1\}$, as stated in
+    \cite[Section~4.5]{Cirac2016MPDO_arXiv}; by positivity every entry
+    equals one. Consequently, at every positive length the coefficient
+    $c^{(L)}_{\alpha,\beta,\gamma}$ is the size of the diagonal matrix
+    $\chi_{\alpha,\beta,\gamma}$, a natural number.
+\end{theorem}
+\begin{proof}\leanok
+    For fixed labels, the trace-power form turns length independence into
+    constancy of the power sums of the diagonal entries of
+    $\chi_{\alpha,\beta,\gamma}$, so by
+    Lemma~\ref{lem:constant_power_sum_dichotomy} every entry equals $0$ or
+    $1$, and positivity excludes $0$. The trace of
+    $\chi_{\alpha,\beta,\gamma}^{\,L}$ is then the number of diagonal
+    entries.
+\end{proof}
+
+\begin{theorem}[Unit entries give length independence]%
+    \label{thm:mpdo_bnt_label_length_independent_of_unit_entries}
+    \lean{MPOTensor.DiagonalChiFamily.tracePowerCoeff_eq_dim_of_forall_entry_eq_one}
+    \lean{MPOTensor.BNTLabelCoefficientFamily.HasPositiveLengthChiTracePowerForm.%
+        lengthIndependent_of_forall_entry_eq_one}
+    \leanok
+    \uses{def:mpdo_bnt_label_length_independent,
+        def:mpdo_bnt_label_positive_length_chi_trace_power_form}
+    If a BNT-label coefficient system is in trace-power form with respect
+    to a diagonal $\chi$-family all of whose entries equal one, then it is
+    length independent: at every positive length each coefficient equals
+    the size of the corresponding diagonal matrix.
+\end{theorem}
+\begin{proof}\leanok
+    The power sums of a family of ones do not depend on the exponent.
+\end{proof}
+
+\begin{remark}[Topological order and an open question]%
+    \label{rem:mpdo_bnt_label_length_independent_topological}
+    Starting from the same-length product law and the idempotent condition,
+    in the particular case of natural-number structure coefficients
+    independent of the length, one recovers all known non-chiral
+    topologically ordered phases together with a description of their
+    excitations \cite{Bultinck2017Anyons}. The renormalization fixed-point
+    density operators correspond to the boundary theories of the
+    renormalization fixed-point representatives of those phases, which
+    yields a large family of non-trivial examples. Whether there exist
+    renormalization fixed points whose structure coefficients depend on the
+    length is left open in \cite[Section~4.5]{Cirac2016MPDO_arXiv}.
+\end{remark}

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -220,6 +220,18 @@
   doi          = {10.1016/j.aop.2016.12.030},
 }
 
+@article{Bultinck2017Anyons,
+  title        = {Anyons and matrix product operator algebras},
+  author       = {Bultinck, N. and Mari{\"e}n, M. and Williamson, D. J. and {\c{S}}ahino{\u{g}}lu, M. B. and Haegeman, J. and Verstraete, F.},
+  year         = {2017},
+  month        = mar,
+  journal      = {Ann. Phys.},
+  volume       = {378},
+  pages        = {183--233},
+  issn         = {0003-4916},
+  doi          = {10.1016/j.aop.2017.01.004},
+}
+
 % ---------------------------------------------------------------------------
 % Parent Hamiltonian references (ch14, ch15)
 % ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

After Theorem IV.13, arXiv:1606.00608 (Section 4.5, `Papers/1606.00608/MPDO-22-12-17-2.tex` lines 995–1010) singles out the renormalization fixed points whose BNT-label structure coefficients $c^{(L)}_{\alpha,\beta,\gamma} = \operatorname{tr}(\chi^L_{\alpha,\beta,\gamma})$ do not depend on the chain length $L$: this is the case that connects RFP MPDO to non-chiral topologically ordered phases (Bultinck–Mariën–Williamson–Şahinoğlu–Haegeman–Verstraete, Ann. Phys. 378 (2017) 183–233, arXiv:1511.08090), and the paper leaves open whether renormalization fixed points with length-dependent coefficients exist. Line 1010 states that length independence forces the diagonal entries $\chi_{\alpha,\beta,\gamma,k}$ into $\{0,1\}$, so the coefficients are natural numbers.

This PR formalizes that observation at the hypothesis-carrying BNT-label level of `TNLean.MPS.MPDO.BNTCoefficients` and records the open question in the blueprint.

## New declarations

`TNLean/Algebra/ConstantPowerSums.lean` (new):
- `le_one_of_forall_sum_pow_eq` — nonnegative real families with exponent-independent power sums have entries at most one.
- `eq_zero_or_eq_one_of_forall_sum_pow_eq` — such entries equal `0` or `1` (compare exponents one and two).
- `Complex.eq_zero_or_eq_one_of_forall_sum_pow_eq` — the complex-order version. Nonnegativity is load-bearing: the primitive cube roots of unity have power sums invariant under doubling the exponent.

`TNLean/MPS/MPDO/LengthIndependentCoefficients.lean` (new):
- `MPOTensor.BNTLabelCoefficientFamily.LengthIndependent` — the predicate ($c^{(L)} = c^{(1)}$ for every positive length), with `LengthIndependent.coeff_eq`.
- `MPOTensor.DiagonalChiFamily.entry_eq_one_of_posEntries_of_forall_tracePowerCoeff_eq`, `tracePowerCoeff_eq_dim_of_forall_entry_eq_one`.
- `HasPositiveLengthChiTracePowerForm.entry_eq_one_of_lengthIndependent`, `entry_eq_zero_or_eq_one_of_lengthIndependent` (the source's $\{0,1\}$ form), `coeff_eq_dim_of_lengthIndependent`, `exists_natCast_coeff_of_lengthIndependent` (naturality), `lengthIndependent_of_forall_entry_eq_one` (converse).
- Restatements on the bundled witness `MPOTensor.PositiveBNTLabelChiTracePowerForm`.

The paper derives the $\{0,1\}$ membership from its appendix power-sum lemma (lines 1155–1163, formalized in `TNLean.Algebra.ScalarPowerSumIdentity`); the proofs here use the elementary constant-power-sum dichotomy, which suffices for this specialization. Under the positivity of Theorem IV.13(ii) the membership sharpens to equality with one, and each coefficient is the size of its diagonal matrix.

Consistent with `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex` and the support-algebra counterexample (`TNLean/MPS/MPDO/AlgebraFusionCounterexample.lean`), nothing is constructed from an MPDO tensor: all statements are conditional on the BNT-label witnesses. The Appendix C.3–C.4 construction remains the separate tracked obligation.

## Blueprint

- New entries in `blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex`: `lem:constant_power_sum_dichotomy`, `def:mpdo_bnt_label_length_independent`, `thm:mpdo_bnt_label_length_independent_natural`, `thm:mpdo_bnt_label_length_independent_of_unit_entries`, all `\leanok`.
- `rem:mpdo_bnt_label_length_independent_topological` records the connection to non-chiral topological order and the paper's open question (prose only, no Lean tags).
- `Bultinck2017Anyons` added to `blueprint/src/references.bib`.

## Verification

- `lake build` green (9284 jobs), zero `sorry`/`axiom` in the new files.
- `scripts/blueprint_lean_sync.py --ci` passes (all new `\lean{}` tags resolve), `scripts/check_reader_facing_prose.py --ci` passes, `scripts/blueprint_bibtex.py` passes, latexindent clean, all lines ≤ 100 chars.

Parent trackers: #232, #2380

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib/Lean proofs and blueprint sync on the BNT-label layer; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds formal Lean support for arXiv:1606.00608 Section 4.5: when BNT-label structure coefficients **do not depend on chain length** and come from positive diagonal **χ** witnesses, coefficients are **natural numbers** (matrix dimensions).
> 
> **`TNLean/Algebra/ConstantPowerSums.lean`** introduces an elementary dichotomy: nonnegative (real or complex-order) families with **constant positive-exponent power sums** have entries in `{0, 1}` (with a counterexample if nonnegativity is dropped).
> 
> **`TNLean/MPS/MPDO/LengthIndependentCoefficients.lean`** defines **`LengthIndependent`**, then shows length independence plus a positive trace-power **χ** witness forces diagonal entries to **1**, coefficients to **`dim χ`**, and gives the converse when all entries are **1**. Results are stated on existing **`BNTLabelCoefficientFamily`** / **`PositiveBNTLabelChiTracePowerForm`** hypotheses only (no new MPDO-tensor construction).
> 
> **`TNLean.lean`** exports the new modules. **Blueprint** `ch21_mpdo_rfp_bnt_coefficients.tex` gains matching lemma/definition/theorems and a remark on topological order and the paper’s open question; **`Bultinck2017Anyons`** is added to **`references.bib`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fd62a94c3d08860ebff7133536557b9c8b3ba28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->