### PR TITLE
doc(paper-gaps): repoint the power-sum note at the current comparison endpoint

### DIFF
--- a/docs/paper-gaps/power_sum_alternative_route.tex
+++ b/docs/paper-gaps/power_sum_alternative_route.tex
@@ -59,7 +59,11 @@ sequences which vanishes eventually vanishes at every exponent, so the equality
 holds for all positive $N$. The formal proof then applies the
 unequal-cardinality finite-range power-sum theorem.\footnote{\path{Matrix.sum_pow_eq_implies_card_eq_and_multiset_eq_of_le_max_card}.}
 The endpoint used by the BNT comparison is the corresponding sector-weight
-comparison lemma.\footnote{\path{MPSTensor.SectorWeightData.copies_eq_and_weight_multiset_eq_of_eventually_coeff_eq}.}
+comparison lemma.\footnote{\path{MPSTensor.matched_sector_weight_multiset_eq} in
+    \path{TNLean/MPS/FundamentalTheorem/SectorBNT/WeightEquiv.lean}, which composes
+    the extension to all positive exponents
+    (\path{MPSTensor.SectorWeightData.power_sums_eq_of_eventually_eq_hetero}) with
+    the unequal-cardinality power-sum theorem.}
 
 The conclusion is
 \[


### PR DESCRIPTION
## Summary

`docs/paper-gaps/power_sum_alternative_route.tex` cited
`MPSTensor.SectorWeightData.copies_eq_and_weight_multiset_eq_of_eventually_coeff_eq` as the endpoint used by the BNT comparison, but that declaration no longer exists in the Lean tree (zero hits under `TNLean/`).

The current endpoint is `MPSTensor.matched_sector_weight_multiset_eq` (`TNLean/MPS/FundamentalTheorem/SectorBNT/WeightEquiv.lean`), which composes the extension from eventual to all positive exponents (`MPSTensor.SectorWeightData.power_sums_eq_of_eventually_eq_hetero`, `TNLean/MPS/FundamentalTheorem/SectorWeightComparison.lean`) with the unequal-cardinality power-sum theorem. The footnote now cites it in file-plus-declaration form, following the citation refresh of #3721.

Doc-only change; no Lean code touched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX footnote change; no Lean or runtime code is modified.
> 
> **Overview**
> Updates the footnote in **`docs/paper-gaps/power_sum_alternative_route.tex`** so the “source-facing formal route” cites the Lean theorem that actually exists today.
> 
> The old reference to **`MPSTensor.SectorWeightData.copies_eq_and_weight_multiset_eq_of_eventually_coeff_eq`** is replaced with **`MPSTensor.matched_sector_weight_multiset_eq`** in **`TNLean/MPS/FundamentalTheorem/SectorBNT/WeightEquiv.lean`**, with a short note that it composes **`power_sums_eq_of_eventually_eq_hetero`** with the unequal-cardinality power-sum theorem. Citation style matches the file-plus-declaration pattern from #3721.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8201b26ca1e9ddb6d6e591312ae5966a04a35850. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->