### PR TITLE
doc(paper-gaps): refresh the vertical canonical-form note inventories

### DIFF
--- a/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
@@ -9,7 +9,7 @@
 
 \title{Vertical Canonical-Form Grouping in Proposition 4.13}
 \author{}
-\date{2026-07-09}
+\date{2026-07-11}
 
 \begin{document}
 \maketitle
@@ -27,7 +27,12 @@ in the vertical direction.  After a physical isometry, the tensor has the form
   \label{eq:source-vertical-form}
 \end{equation}
 where each $\mu_\alpha$ is positive and diagonal and the tensors
-$M_\alpha$ form a basis of normal tensors.
+$M_\alpha$ form a basis of normal tensors.  Here $\widetilde M$ is the tensor
+viewed in the vertical direction, with letters indexed by the horizontal bond
+pair and matrices acting on the physical space; the formal vertical
+canonical-form statement is placed on exactly this tensor, in the isometry
+form \eqref{eq:source-vertical-form}, as recorded in
+\path{cpgsv17_vertical_tensor_definition.tex}.
 
 The proof has a definite order.  It first uses positivity of the generated
 operators and Lemma~L to exclude one-sided transitions and nontrivial periodic
@@ -55,9 +60,11 @@ The relevant local source passage is
 
 Suppose an indexed family of blocks $(B_k)_{k\in I}$ has already been grouped
 into copies of representative blocks $(A_\alpha)_{\alpha\in J}$.  Write
-$m_\alpha$ for the number of copies and let
+$r_\alpha$ for the number of copies, the size of the diagonal matrix
+$\mu_\alpha$; the trace coefficient $m_\alpha=\tr\mu_\alpha$ is a distinct
+quantity (see \path{cpgsv17_vertical_tensor_definition.tex}).  Let
 \begin{equation}
-  e:I\simeq\{(\alpha,j):\alpha\in J, 0\leq j<m_\alpha\}
+  e:I\simeq\{(\alpha,j):\alpha\in J, 0\leq j<r_\alpha\}
   \label{eq:grouping-equivalence}
 \end{equation}
 be the grouping bijection.  If
@@ -75,7 +82,7 @@ then finite-sum reindexing gives
   V^{(N)}\!\left(\bigoplus_{k\in I}\nu_k B_k\right)
   =
   V^{(N)}\!\left(
-    \bigoplus_{\alpha\in J}\bigoplus_{j=0}^{m_\alpha-1}
+    \bigoplus_{\alpha\in J}\bigoplus_{j=0}^{r_\alpha-1}
     \omega_{\alpha,j}A_\alpha
   \right)
   \label{eq:regrouped-mpv}
@@ -126,15 +133,41 @@ one-sided invariant-matrix calculation from source lines~1874--1887 is also
 formalized.  For the periodic-sector argument, positivity now gives the final
 implication from commutation with $[H^{(N)}]^p$ to commutation with
 $H^{(N)}$.  It remains to derive the orthogonal projector with the required
-all-length properties from a nontrivial vertical period.  The subsequent
-source-level gap is to construct the vertical canonical decomposition, its BNT
-grouping, the positive weights, and the unitary gauges from horizontal
-canonical form and MPDO positivity, as done in source lines~1895--1921.  This
-is the mathematical content shared with the normality and grouping problem
-tracked by \ghissue{2537}; it cannot be supplied by a finite-sum identity
-alone.  The original formulation of \ghissue{2536}, interpreted as a direct
-conversion of the horizontal scalar weights and diagonal restrictions, is
-therefore not a consequence of Proposition~4.13.
+all-length properties from a nontrivial vertical period.
+
+Two further steps of source lines~1895--1921 now have conditional
+formalizations.  For the positive weights: granted an orthogonal sector
+projector $P_{\alpha,k}$ whose insertion into the single-site vertical loop
+selects the sector contribution $\mu_{\alpha,k}E_\alpha$, with
+$E_\alpha=\sum_u M_\alpha^{uu}$ the closed loop of the basis tensor
+(\path{MPOTensor.SectorProjectorData}), the trace of the compressed density
+operator is identified as $\mu_{\alpha,k}d_\alpha$, and positivity of the
+nonzero compressions (\path{MPOTensor.mpo_compress_trace_pos}) yields
+$d_\alpha>0$ and $\mu_{\alpha,k}>0$ under the normalization
+$\mu_{\alpha,1}>0$ (\path{MPOTensor.sector_weight_pos} in
+\path{TNLean/MPS/MPDO/SectorTrace.lean}).  For the unitary gauges: granted
+the dressed-adjoint identities of the two displayed diagrams at source
+lines~1909--1919, transported blockwise by Lemma~L, the scalar commutant of
+the normal tensor $M_\alpha$
+(\path{MPSTensor.IsNormal.eq_smul_one_of_commute}) makes each Gram matrix
+$X_{\alpha,k}^\dagger X_{\alpha,k}$ a positive multiple of the identity, in
+the normalization $X_{\alpha,1}=\Id$, and
+$\omega_{\alpha,k}^{-1/2}X_{\alpha,k}$ unitary
+(\path{MPSTensor.IsNormal.smul_mem_unitaryGroup_of_dressed_adjoint} in
+\path{TNLean/MPS/CanonicalForm/NormalCommutant.lean}).
+
+The remaining source-level gap is the construction of the vertical canonical
+decomposition itself, with its grouping into a basis of normal tensors, from
+horizontal canonical form and MPDO positivity, as done in source
+lines~1895--1921: the construction must produce the sector projectors
+together with their loop identities and a nonvanishing compression, derive
+the dressed-adjoint identities from self-adjointness of the sector
+compressions, and supply the periodic-sector exclusion above.  This is the
+mathematical content shared with the normality and grouping problem tracked
+by \ghissue{2537}; it cannot be supplied by a finite-sum identity alone.  The
+original formulation of \ghissue{2536}, interpreted as a direct conversion of
+the horizontal scalar weights and diagonal restrictions, is therefore not a
+consequence of Proposition~4.13.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
@@ -9,7 +9,7 @@
 
 \title{Diagonal Restriction and the Vertical Canonical Form in Proposition 4.13}
 \author{}
-\date{2026-07-09}
+\date{2026-07-11}
 
 \begin{document}
 \maketitle
@@ -93,6 +93,13 @@ three stages visible in the source:
     \item obtain the vertical canonical-form blocks independently, and prove the
       positivity and unitary normalization of their multiplicity coefficients.
 \end{enumerate}
+The target statement is now in place: the vertical canonical form is stated
+on the vertically viewed tensor, whose letters are indexed by the horizontal
+bond pair and whose matrices act on the physical space, in the isometry form
+of the source; an earlier statement on the diagonal tensor $i\mapsto M^{ii}$
+has been removed.  The definitional realignment is recorded in
+\path{cpgsv17_vertical_tensor_definition.tex}.
+
 The already formalized equality of matrix product vectors after diagonal
 restriction remains useful as an auxiliary identity.  It cannot supply the
 normal blocks of the vertical canonical form.  In particular, Newton--Girard
@@ -140,8 +147,27 @@ formalized:
 \]
 The remaining step is to derive, from a nontrivial vertical period, one
 orthogonal projector $Q$ having the two all-length properties in source
-lines~1889--1890.  The independent vertical canonical-form construction and
-the positivity and unitary normalization of its coefficients also remain open.
+lines~1889--1890.
+
+The third stage now has conditional formalizations of its two closing
+arguments.  Granted orthogonal sector projectors whose insertion into the
+single-site vertical loop selects the sector contribution, the trace of the
+density operator compressed by the projector of sector $(\alpha,k)$ is
+identified as the sector weight $\mu_{\alpha,k}$ times a sector trace
+$d_\alpha$, and positivity of the nonzero compressions forces $d_\alpha>0$
+and $\mu_{\alpha,k}>0$ under the normalization $\mu_{\alpha,1}>0$
+(\path{TNLean/MPS/MPDO/SectorTrace.lean}).  Granted the dressed-adjoint
+identities of the two displayed diagrams at lines~1909--1919, transported
+blockwise by Lemma~L, the Gram matrix of each sector gauge $X_{\alpha,k}$ is
+a positive multiple $\omega_{\alpha,k}$ of the identity, in the normalization
+$X_{\alpha,1}=\Id$, and the normalized gauge
+$\omega_{\alpha,k}^{-1/2}X_{\alpha,k}$ is unitary, because a normal tensor
+has scalar commutant
+(\path{TNLean/MPS/CanonicalForm/NormalCommutant.lean}).  What remains open is
+the independent vertical canonical-form construction itself, which must
+supply the sector projectors with their loop identities and a nonvanishing
+compression, together with the derivation of the dressed-adjoint identities
+from self-adjointness of the sector compressions.
 
 \paragraph{Verdict.}
 This is an open gap: the source-faithful horizontal-to-vertical implication of


### PR DESCRIPTION
## Summary

Refreshes the two vertical canonical-form paper-gap notes (dated 2026-07-09) whose "current formalization" inventories predated the recent merges of the sector-trace positivity chain, the dressed-adjoint/eq3 lemmas, and the vertical-tensor definitional realignment. Both notes' overall verdicts are unchanged.

`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`:
- Identifies the vertically viewed tensor behind eq. (1) and cross-references the new note `cpgsv17_vertical_tensor_definition.tex`, which records that the formal vertical canonical-form statement now lives on that tensor in the isometry form.
- Renames the copy count in the finite-sum statement from `m_alpha` to `r_alpha`, matching the separated multiplicity symbols (`r_alpha` = size of `mu_alpha`, `m_alpha` = tr `mu_alpha`).
- Splits the closing inventory paragraph: the positive-weights step (conditional on `MPOTensor.SectorProjectorData`; `mpo_compress_trace_pos`, `sector_weight_pos` in `TNLean/MPS/MPDO/SectorTrace.lean`) and the unitary-gauge step (conditional on the dressed-adjoint identities; `MPSTensor.IsNormal.eq_smul_one_of_commute`, `smul_mem_unitaryGroup_of_dressed_adjoint` in `TNLean/MPS/CanonicalForm/NormalCommutant.lean`) are now recorded as conditional formalizations, and the remaining open gap is restated as the construction of the vertical canonical decomposition itself (sector projectors with loop identities and a nonvanishing compression, the dressed-adjoint derivation, the periodic-sector exclusion), matching the open-step list in the blueprint proof sketch of `thm:vertical_cf_of_horizontal_cf`.

`docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex`:
- Records that the corrected formal target is now in place: the vertical canonical form is stated on the vertically viewed tensor in the isometry form, the diagonal-tensor statement having been removed; cross-references `cpgsv17_vertical_tensor_definition.tex`.
- Replaces the "positivity and unitary normalization ... also remain open" sentence with the conditional-formalization inventory for the third stage (sector-trace positivity chain in `TNLean/MPS/MPDO/SectorTrace.lean`; Gram rigidity and isometric normalization in `TNLean/MPS/CanonicalForm/NormalCommutant.lean`) and the precise remaining opens.
- The verdict paragraph is unchanged: the source-faithful horizontal-to-vertical implication remains unformalized, and the diagonal-restriction route remains a false strengthening.

Both date stamps updated to 2026-07-11.

## Validation

- `latexmk -pdf -interaction=nonstopmode -output-directory=/tmp/lmcheck <note>.tex` (with `TEXINPUTS=.:` so the local `command.tex` is used): both notes compile cleanly before and after the edit.
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main --ci`: no violations.
- `git diff --check`: clean.

Closes #3715

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX edits to paper-gap notes; no runtime or proof code changes.
> 
> **Overview**
> Updates the two **vertical canonical-form** paper-gap notes (dates **2026-07-11**) so their formalization inventories match recent Lean work; **verdicts are unchanged** (the horizontal-to-vertical implication remains open).
> 
> In **`cpgsv17_vertical_cf_grouping.tex`**, the note now pins the vertical canonical-form target to the **vertically viewed tensor** in isometry form and cross-references **`cpgsv17_vertical_tensor_definition.tex`**. The finite-sum copy count is renamed **`m_α` → `r_α`**, separating **`r_α`** (size of **`μ_α`**) from **`m_α = tr μ_α`**. The closing gap inventory is split: **positive sector weights** and **unitary gauge normalization** are recorded as **conditional** formalizations (with pointers to **`SectorTrace.lean`** and **`NormalCommutant.lean`**), while the **remaining open step** is restated as building the **vertical canonical decomposition** (sector projectors, loop identities, dressed-adjoint derivation, periodic-sector exclusion).
> 
> **`cpgsv17_vertical_diagonal_restriction.tex`** records that the **corrected formal target** is in place on the vertical tensor (diagonal-tensor statement removed) and mirrors the same **third-stage** conditional inventory and **remaining construction** gap instead of treating positivity/unitary normalization as wholly open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c440946d0a237214b0507dc24ad80ba85487a141. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->