### PR TITLE
feat(Channel): block form of the corner-restricted fixed points

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -167,6 +167,7 @@ import TNLean.Channel.FixedPoint.BlockForm
 import TNLean.Channel.FixedPoint.ChoiEffros
 import TNLean.Channel.FixedPoint.Cesaro
 import TNLean.Channel.FixedPoint.CornerAlgebra
+import TNLean.Channel.FixedPoint.CornerBlockForm
 import TNLean.Channel.FixedPoint.CornerFixedPoints
 import TNLean.Channel.FixedPoint.StationarySupport
 import TNLean.Channel.FixedPoint.WedderburnDecomp

--- a/TNLean/Channel/FixedPoint/CornerBlockForm.lean
+++ b/TNLean/Channel/FixedPoint/CornerBlockForm.lean
@@ -17,11 +17,15 @@ $$\{Y \in Q M_D(\mathbb{C}) Q \mid Q T^{*}(Y) Q = Y\}
   \;=\; W \Bigl(\bigoplus_{k} \mathbf{1}_{m_k} \otimes M_{d_k}(\mathbb{C})\Bigr)
   W^{\dagger},$$
 where $W$ is an isometry onto the support sector ($W^{\dagger} W = \mathbf{1}$,
-$W W^{\dagger} = Q$) and $\sum_k d_k m_k \le D$. Embedded in the ambient matrix algebra
-this is the block representation of Equation (1.39) of *Quantum Channels & Operations*
-(Wolf 2012) *with* the zero block carried by the complement of the support sector — the
-general form invoked by Theorem 6.14 of the same reference, without a full-rank
-hypothesis on the fixed point. The Kronecker factors are written in the order
+$W W^{\dagger} = Q$) and $\sum_k d_k m_k \le D$. This is the block form of the
+corner-restricted fixed-point star-algebra of Corollary 6.6 of *Quantum Channels &
+Operations* (Wolf 2012), the support-sector ingredient of the zero-block representation
+invoked by Theorem 6.14 of the same reference. A corner-restricted fixed point extended
+by zero on the complement of the support sector need not be a fixed point of the ambient
+Heisenberg-picture map (the identity matrix is always an ambient fixed point of the
+adjoint of a trace-preserving map, and it is not supported on the sector), so the
+identification of the ambient fixed-point space with a zero-block form is not asserted
+here. The Kronecker factors are written in the order
 identity-times-matrix, as in the block form of the fixed-point algebra of a map with a
 positive definite fixed point.
 
@@ -52,11 +56,14 @@ $$Y \;=\; W \Bigl(\bigoplus_{k} \mathbf{1}_{m_k} \otimes B_k\Bigr) W^{\dagger}$$
 for some matrices $B_k \in M_{d_k}(\mathbb{C})$: the corner-restricted fixed-point
 star-algebra of Corollary 6.6 of *Quantum Channels & Operations* (Wolf 2012) is carried by
 the isometry onto the block algebra, up to reordering the two Kronecker factors of each
-block. Embedded in $M_D(\mathbb{C})$, the right-hand side is the block representation of
-Equation (1.39) of *Quantum Channels & Operations* (Wolf 2012) with the zero block on the
-complement of the support sector, so this is the $\sum_k d_k m_k \le D$ form of the block
-structure invoked by Theorem 6.14 of the same reference, without a full-rank hypothesis on
-the fixed point. As in the corner star-algebra of Corollary 6.6, the map is a Kraus map,
+block. The right-hand side is the support-sector block representation of
+Equation (1.39) of *Quantum Channels & Operations* (Wolf 2012) in the
+$\sum_k d_k m_k \le D$ form, without a full-rank hypothesis on the fixed point. The
+equivalence characterizes the corner-restricted set only: a corner-restricted fixed
+point extended by zero on the complement need not satisfy the ambient fixed-point
+equation, so this does not by itself identify the ambient fixed-point space of the
+adjoint map with a zero-block form. As in the corner star-algebra of Corollary 6.6, the
+map is a Kraus map,
 the completely positive case of the Schwarz hypothesis of the reference. The
 density-weighted form of Theorem 6.14 for the Schrödinger-picture fixed points is not
 asserted here.

--- a/TNLean/Channel/FixedPoint/CornerBlockForm.lean
+++ b/TNLean/Channel/FixedPoint/CornerBlockForm.lean
@@ -17,7 +17,8 @@ $$\{Y \in Q M_D(\mathbb{C}) Q \mid Q T^{*}(Y) Q = Y\}
   \;=\; W \Bigl(\bigoplus_{k} \mathbf{1}_{m_k} \otimes M_{d_k}(\mathbb{C})\Bigr)
   W^{\dagger},$$
 where $W$ is an isometry onto the support sector ($W^{\dagger} W = \mathbf{1}$,
-$W W^{\dagger} = Q$) and $\sum_k d_k m_k \le D$. This is the block form of the
+$W W^{\dagger} = Q$) and $\sum_k d_k m_k = r$ for the support-sector dimension
+$r \le D$. This is the block form of the
 corner-restricted fixed-point star-algebra of Corollary 6.6 of *Quantum Channels &
 Operations* (Wolf 2012), the support-sector ingredient of the zero-block representation
 invoked by Theorem 6.14 of the same reference. A corner-restricted fixed point extended

--- a/TNLean/Channel/FixedPoint/CornerBlockForm.lean
+++ b/TNLean/Channel/FixedPoint/CornerBlockForm.lean
@@ -1,0 +1,240 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Channel.FixedPoint.CornerFixedPoints
+import TNLean.Channel.FixedPoint.BlockForm
+
+/-!
+# Block form of the corner-restricted fixed points of a Kraus map
+
+This file combines the corner-restricted fixed-point star-algebra of Corollary 6.6 of
+*Quantum Channels & Operations* (Wolf 2012) with the block representation of Equation (1.39)
+of the same reference. For a trace-preserving Kraus map whose Schrödinger picture has a
+positive semidefinite fixed point $\rho$ with support projection $Q$, the corner-restricted
+fixed-point set carries the block structure
+$$\{Y \in Q M_D(\mathbb{C}) Q \mid Q T^{*}(Y) Q = Y\}
+  \;=\; W \Bigl(\bigoplus_{k} \mathbf{1}_{m_k} \otimes M_{d_k}(\mathbb{C})\Bigr)
+  W^{\dagger},$$
+where $W$ is an isometry onto the support sector ($W^{\dagger} W = \mathbf{1}$,
+$W W^{\dagger} = Q$) and $\sum_k d_k m_k \le D$. Embedded in the ambient matrix algebra
+this is the block representation of Equation (1.39) of *Quantum Channels & Operations*
+(Wolf 2012) *with* the zero block carried by the complement of the support sector — the
+general form invoked by Theorem 6.14 of the same reference, without a full-rank
+hypothesis on the fixed point. The Kronecker factors are written in the order
+identity-times-matrix, as in the block form of the fixed-point algebra of a map with a
+positive definite fixed point.
+
+## Main result
+
+* `Kraus.cornerFixedPoints_blockDiagonal_iff` -- a corner element is a corner-restricted
+  fixed point exactly when it is carried by the support isometry from a block-diagonal
+  matrix with blocks $\mathbf{1}_{m_k} \otimes B_k$.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder BigOperators Kronecker
+open Matrix Finset Complex
+
+namespace Kraus
+
+variable {d D : ℕ}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+/-- **Block form of the corner-restricted fixed points.** Let $T$ be a trace-preserving
+Kraus map on $M_D(\mathbb{C})$, let $\rho$ be a positive semidefinite fixed point of $T$,
+and let $Q$ be the support projection of $\rho$. Then there are a sector dimension
+$r \le D$, a number $n$ of blocks, positive dimensions $d_k$ and multiplicities $m_k$ with
+$\sum_k d_k m_k = r$, and an isometry $W$ onto the support sector, with
+$W^{\dagger} W = \mathbf{1}_r$ and $W W^{\dagger} = Q$, such that a matrix $Y$ satisfies
+$Q Y Q = Y$ and $Q T^{*}(Y) Q = Y$ exactly when
+$$Y \;=\; W \Bigl(\bigoplus_{k} \mathbf{1}_{m_k} \otimes B_k\Bigr) W^{\dagger}$$
+for some matrices $B_k \in M_{d_k}(\mathbb{C})$: the corner-restricted fixed-point
+star-algebra of Corollary 6.6 of *Quantum Channels & Operations* (Wolf 2012) is carried by
+the isometry onto the block algebra, up to reordering the two Kronecker factors of each
+block. Embedded in $M_D(\mathbb{C})$, the right-hand side is the block representation of
+Equation (1.39) of *Quantum Channels & Operations* (Wolf 2012) with the zero block on the
+complement of the support sector, so this is the $\sum_k d_k m_k \le D$ form of the block
+structure invoked by Theorem 6.14 of the same reference, without a full-rank hypothesis on
+the fixed point. As in the corner star-algebra of Corollary 6.6, the map is a Kraus map,
+the completely positive case of the Schwarz hypothesis of the reference. The
+density-weighted form of Theorem 6.14 for the Schrödinger-picture fixed points is not
+asserted here.
+
+The compressed family on the support sector is trace-preserving with a positive definite
+fixed point, so the block form of the fixed-point algebra applies there; the compression
+isometry transports the equivalence to the corner. -/
+theorem cornerFixedPoints_blockDiagonal_iff
+    (K : Fin d → Mat) (h_tp : IsTP K) {ρ : Mat} (hρ_psd : ρ.PosSemidef)
+    (hρ_fix : map K ρ = ρ) :
+    ∃ (r n : ℕ) (dims mult : Fin n → ℕ)
+      (e : ((k : Fin n) × (Fin (mult k) × Fin (dims k))) ≃ Fin r)
+      (W : Matrix (Fin D) (Fin r) ℂ),
+      r ≤ D ∧ Wᴴ * W = 1 ∧ W * Wᴴ = stationaryProj hρ_psd ∧
+        (∀ k, 0 < dims k) ∧ (∀ k, 0 < mult k) ∧
+        ∀ Y : Mat,
+          (stationaryProj hρ_psd * Y * stationaryProj hρ_psd = Y ∧
+            stationaryProj hρ_psd * adjointMap K Y * stationaryProj hρ_psd = Y) ↔
+          ∃ B : ∀ k, Matrix (Fin (dims k)) (Fin (dims k)) ℂ,
+            Y = W * Matrix.reindex e e
+              (Matrix.blockDiagonal' fun k =>
+                (1 : Matrix (Fin (mult k)) (Fin (mult k)) ℂ) ⊗ₖ B k) * Wᴴ := by
+  classical
+  set Q : Mat := stationaryProj hρ_psd with hQdef
+  have hQproj : IsOrthogonalProjection Q := isOrthogonalProjection_stationaryProj hρ_psd
+  have hInv : ∀ i : Fin d, (1 - Q) * K i * Q = 0 :=
+    stationaryProj_lowerZero K hρ_psd hρ_fix
+  have hQρ : Q * ρ = ρ := MPSTensor.supportProj_mul (D := D) (ρ := ρ) hρ_psd
+  have hρQ : ρ * Q = ρ := MPSTensor.mul_supportProj (D := D) (ρ := ρ) hρ_psd
+  have hQρQ : Q * ρ * Q = ρ := by rw [hQρ, hρQ]
+  set A : Fin d → Mat := cornerCompressionKraus K Q with hAdef
+  have hAsupp : ∀ i : Fin d, Q * A i * Q = A i :=
+    cornerCompressionKraus_supported K hQproj
+  have hAtp : ∑ i : Fin d, (A i)ᴴ * A i = Q :=
+    cornerCompressionKraus_isTP K h_tp hQproj hInv
+  -- Compress the corner family to the support sector along the isometry `V`.
+  obtain ⟨r, C, φ, V, -, hCtp, -, hIntertw, -, -, hLetter, hVtV, hVVt, hφV⟩ :=
+    MPSTensor.exists_compressedTensor_of_supported_projection_with_letter_and_isometry
+      A Q hQproj hAsupp hAtp
+  have hCtp' : IsTP C := hCtp
+  have hCi : ∀ i : Fin d, C i = Vᴴ * A i * V := by
+    intro i
+    have h : V * C i * Vᴴ = A i := by simpa [hφV] using hLetter i
+    calc
+      C i = (Vᴴ * V) * C i * (Vᴴ * V) := by rw [hVtV]; simp
+      _ = Vᴴ * (V * C i * Vᴴ) * V := by simp [Matrix.mul_assoc]
+      _ = Vᴴ * A i * V := by rw [h]
+  -- The compressed Schrödinger map has the positive definite fixed point `σ`.
+  set σ : Matrix (Fin r) (Fin r) ℂ := Vᴴ * ρ * V with hσdef
+  have hσpd : σ.PosDef := by
+    have := Matrix.PosSemidef.compression_on_support_posDef (D := D) (ρ := ρ) hρ_psd
+      (k := r) (V := Vᴴ) (by simpa [Matrix.conjTranspose_conjTranspose] using hVtV)
+      (by simpa [hQdef, stationaryProj, Matrix.conjTranspose_conjTranspose] using hVVt)
+    simpa [hσdef, Matrix.conjTranspose_conjTranspose] using this
+  have hσfix : map C σ = σ := by
+    have hmapA : map A ρ = ρ := by
+      have heq : map A ρ = Q * map K ρ * Q := by
+        rw [hAdef]; exact map_cornerCompressionKraus_eq K hQproj (Z := ρ) hQρQ
+      rw [heq, hρ_fix, hQρQ]
+    have hterm : ∀ i : Fin d,
+        C i * σ * (C i)ᴴ = Vᴴ * (A i * ρ * (A i)ᴴ) * V := by
+      intro i
+      have hCiH : (C i)ᴴ = Vᴴ * (A i)ᴴ * V := by
+        rw [hCi i]
+        simp [Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose, Matrix.mul_assoc]
+      rw [hCiH, hCi i, hσdef]
+      calc
+        Vᴴ * A i * V * (Vᴴ * ρ * V) * (Vᴴ * (A i)ᴴ * V)
+            = Vᴴ * (A i * (V * Vᴴ) * ρ * (V * Vᴴ) * (A i)ᴴ) * V := by
+              simp [Matrix.mul_assoc]
+        _ = Vᴴ * (A i * Q * ρ * Q * (A i)ᴴ) * V := by rw [hVVt]
+        _ = Vᴴ * (A i * (Q * ρ * Q) * (A i)ᴴ) * V := by simp [Matrix.mul_assoc]
+        _ = Vᴴ * (A i * ρ * (A i)ᴴ) * V := by rw [hQρQ]
+    calc
+      map C σ = ∑ i : Fin d, C i * σ * (C i)ᴴ := by rw [map_apply]
+      _ = ∑ i : Fin d, Vᴴ * (A i * ρ * (A i)ᴴ) * V :=
+          Finset.sum_congr rfl (fun i _ => hterm i)
+      _ = Vᴴ * (∑ i : Fin d, A i * ρ * (A i)ᴴ) * V := by
+          rw [Matrix.mul_sum, Matrix.sum_mul]
+      _ = Vᴴ * map A ρ * V := by rw [map_apply]
+      _ = σ := by rw [hmapA, hσdef]
+  -- The corner fixed-point condition corresponds to the compressed one along `φ`.
+  have hcorr : ∀ X : Matrix (Fin r) (Fin r) ℂ,
+      Q * adjointMap K (φ X).1 * Q = (φ X).1 ↔ adjointMap C X = X := by
+    intro X
+    have hφmem : Q * (φ X).1 * Q = (φ X).1 := (φ X).2
+    have hintertw' : (φ (adjointMap C X)).1 = Q * adjointMap K (φ X).1 * Q := by
+      have h1 : (φ (MPSTensor.transferMap (d := d) (D := r) (fun i => (C i)ᴴ) X)).1 =
+          MPSTensor.transferMap (d := d) (D := D) (fun i => (A i)ᴴ) ((φ X).1) := hIntertw X
+      have h2 : MPSTensor.transferMap (d := d) (D := D) (fun i => (A i)ᴴ) ((φ X).1) =
+          adjointMap A (φ X).1 := by simp [adjointMap, MPSTensor.transferMap_apply]
+      have h3 : adjointMap A (φ X).1 = Q * adjointMap K (φ X).1 * Q := by
+        rw [hAdef]; exact adjointMap_cornerCompressionKraus_eq K hQproj hφmem
+      have h4 : MPSTensor.transferMap (d := d) (D := r) (fun i => (C i)ᴴ) X =
+          adjointMap C X := by simp [adjointMap, MPSTensor.transferMap_apply]
+      rw [h4] at h1
+      rw [h1, h2, h3]
+    constructor
+    · intro hfix
+      have hval : (φ (adjointMap C X)).1 = (φ X).1 := by rw [hintertw', hfix]
+      exact φ.injective (Subtype.ext hval)
+    · intro hfix
+      rw [← hintertw', hfix]
+  -- The block form of the compressed fixed-point algebra.
+  obtain ⟨n, dims, mult, e, U, hUmem, hdims, hmult, hUiff⟩ :=
+    adjointFixedPoints_blockDiagonal_iff (D := r) C hCtp' hσpd hσfix
+  have hU1 : star U * U = 1 := Matrix.mem_unitaryGroup_iff'.mp hUmem
+  have hU2 : U * star U = 1 := Matrix.mem_unitaryGroup_iff.mp hUmem
+  -- The support isometry composed with the block unitary.
+  set W : Matrix (Fin D) (Fin r) ℂ := V * U with hWdef
+  have hWH : Wᴴ = star U * Vᴴ := by
+    rw [hWdef, Matrix.conjTranspose_mul, Matrix.star_eq_conjTranspose]
+  have hWtW : Wᴴ * W = 1 := by
+    rw [hWH, hWdef]
+    calc star U * Vᴴ * (V * U) = star U * (Vᴴ * V) * U := by simp [Matrix.mul_assoc]
+      _ = star U * U := by rw [hVtV]; simp
+      _ = 1 := hU1
+  have hWWt : W * Wᴴ = Q := by
+    rw [hWH, hWdef]
+    calc V * U * (star U * Vᴴ) = V * (U * star U) * Vᴴ := by simp [Matrix.mul_assoc]
+      _ = V * Vᴴ := by rw [hU2]; simp
+      _ = Q := hVVt
+  -- The sector dimension is bounded by the ambient dimension.
+  have hrD : r ≤ D := by
+    have hinj : Function.Injective (Matrix.mulVecLin V) := by
+      intro x y hxy
+      have hxy' : V.mulVec x = V.mulVec y := hxy
+      have h1 : (Vᴴ * V).mulVec x = (Vᴴ * V).mulVec y := by
+        rw [← Matrix.mulVec_mulVec, ← Matrix.mulVec_mulVec]
+        exact congrArg _ hxy'
+      simpa [hVtV] using h1
+    simpa using LinearMap.finrank_le_finrank_of_injective hinj
+  refine ⟨r, n, dims, mult, e, W, hrD, hWtW, hWWt, hdims, hmult, fun Y => ?_⟩
+  constructor
+  · rintro ⟨hYmem, hYfix⟩
+    -- Pull `Y` back to the sector, apply the block form there, and push forward.
+    set X : Matrix (Fin r) (Fin r) ℂ := φ.symm ⟨Y, hYmem⟩ with hXdef
+    have hφX : (φ X).1 = Y := by rw [hXdef, LinearEquiv.apply_symm_apply]
+    have hXfix : adjointMap C X = X := (hcorr X).mp (by rw [hφX]; exact hYfix)
+    obtain ⟨B, hB⟩ := (hUiff X).mp hXfix
+    refine ⟨B, ?_⟩
+    have hXeq : X = U * Matrix.reindex e e
+        (Matrix.blockDiagonal' fun k =>
+          (1 : Matrix (Fin (mult k)) (Fin (mult k)) ℂ) ⊗ₖ B k) * star U := by
+      calc X = (U * star U) * X * (U * star U) := by rw [hU2]; simp
+        _ = U * (star U * X * U) * star U := by simp [Matrix.mul_assoc]
+        _ = _ := by rw [hB]
+    calc Y = V * X * Vᴴ := by rw [← hφX, hφV]
+      _ = W * Matrix.reindex e e
+            (Matrix.blockDiagonal' fun k =>
+              (1 : Matrix (Fin (mult k)) (Fin (mult k)) ℂ) ⊗ₖ B k) * Wᴴ := by
+          rw [hXeq, hWdef, hWH]
+          simp [Matrix.mul_assoc]
+  · rintro ⟨B, hYeq⟩
+    -- The block-diagonal matrix on the sector is a compressed fixed point.
+    set X : Matrix (Fin r) (Fin r) ℂ := U * Matrix.reindex e e
+        (Matrix.blockDiagonal' fun k =>
+          (1 : Matrix (Fin (mult k)) (Fin (mult k)) ℂ) ⊗ₖ B k) * star U with hXdef
+    have hXBd : star U * X * U = Matrix.reindex e e
+        (Matrix.blockDiagonal' fun k =>
+          (1 : Matrix (Fin (mult k)) (Fin (mult k)) ℂ) ⊗ₖ B k) := by
+      calc star U * (U * Matrix.reindex e e
+            (Matrix.blockDiagonal' fun k =>
+              (1 : Matrix (Fin (mult k)) (Fin (mult k)) ℂ) ⊗ₖ B k) * star U) * U
+          = (star U * U) * Matrix.reindex e e
+              (Matrix.blockDiagonal' fun k =>
+                (1 : Matrix (Fin (mult k)) (Fin (mult k)) ℂ) ⊗ₖ B k) * (star U * U) := by
+            simp [Matrix.mul_assoc]
+        _ = _ := by rw [hU1]; simp
+    have hXfix : adjointMap C X = X := (hUiff X).mpr ⟨B, hXBd⟩
+    have hYX : Y = V * X * Vᴴ := by
+      rw [hYeq, hXdef, hWdef, hWH]
+      simp [Matrix.mul_assoc]
+    have hYmem : Q * Y * Q = Y := by
+      rw [hYX, ← hφV X]
+      exact (φ X).2
+    refine ⟨hYmem, ?_⟩
+    have hfix := (hcorr X).mpr hXfix
+    rwa [hφV X, ← hYX] at hfix
+
+end Kraus

--- a/TNLean/Channel/FixedPoint/CornerFixedPoints.lean
+++ b/TNLean/Channel/FixedPoint/CornerFixedPoints.lean
@@ -33,6 +33,11 @@ the compression isomorphism `φ : M_n(ℂ) ≃ Q M_D(ℂ) Q`.
 * `Kraus.cornerFixedPointsStarSubalgebra`: Wolf Corollary 6.6 — the
   corner-restricted fixed points form a `StarSubalgebra` of the corner algebra.
 
+The block representation of this corner algebra, in the sense of Equation (1.39) of
+*Quantum Channels & Operations* (Wolf 2012) with the zero block on the complement of the
+support sector, is `Kraus.cornerFixedPoints_blockDiagonal_iff` in
+`TNLean.Channel.FixedPoint.CornerBlockForm`.
+
 ## References
 
 * [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Corollary 6.6, Section 6.4]

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -291,9 +291,9 @@ positive semidefinite fixed point):
 
 * `Kraus.cornerFixedPoints_blockDiagonal_iff` — the corner-restricted
   fixed-point set is carried by an isometry `W` (`W† W = 1`, `W W† = Q`) onto
-  `⊕_k 1_{m_k} ⊗ M_{d_k}` with `∑_k d_k m_k ≤ D`; embedded in `M_D(ℂ)` this is
-  the block representation with the zero block on the complement of the
-  support sector.
+  `⊕_k 1_{m_k} ⊗ M_{d_k}` with `∑_k d_k m_k = r` for the support-sector
+  dimension `r ≤ D`; embedded in `M_D(ℂ)` this is the block representation
+  with the zero block on the complement of the support sector.
 
 What is still missing for the full Wolf statement is the density-block
 refinement with matrices `ρ_k` for the Schrödinger-picture fixed points.

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -8,6 +8,8 @@ import TNLean.Channel.FixedPoint.ConditionalExpectation
 import TNLean.Channel.FixedPoint.StationarySupport
 import TNLean.Channel.FixedPoint.CornerFixedPoints
 import TNLean.Channel.FixedPoint.WedderburnDecomp
+import TNLean.Channel.FixedPoint.BlockForm
+import TNLean.Channel.FixedPoint.CornerBlockForm
 import TNLean.Channel.FixedPoint.Corollaries
 import TNLean.Channel.Irreducible.Ergodicity
 import TNLean.Channel.Irreducible.Basic
@@ -286,16 +288,19 @@ point of the pre-dual, no zero block):
 * `Kraus.fixedPoints_blockDiagonal_iff` — the companion for the fixed points
   of a unital Kraus map.
 
-In `TNLean.Channel.FixedPoint.CornerBlockForm` (zero-block general case, any
+In `TNLean.Channel.FixedPoint.CornerBlockForm` (corner-restricted case, any
 positive semidefinite fixed point):
 
 * `Kraus.cornerFixedPoints_blockDiagonal_iff` — the corner-restricted
   fixed-point set is carried by an isometry `W` (`W† W = 1`, `W W† = Q`) onto
   `⊕_k 1_{m_k} ⊗ M_{d_k}` with `∑_k d_k m_k = r` for the support-sector
   dimension `r ≤ D`; embedded in `M_D(ℂ)` this is the block representation
-  with the zero block on the complement of the support sector.
+  in the `∑_k d_k m_k ≤ D` form. The equivalence characterizes the
+  corner-restricted set only; extending by zero on the complement does not
+  produce ambient fixed points in general.
 
-What is still missing for the full Wolf statement is the density-block
+What is still missing for the full Wolf statement is the identification of
+the ambient fixed-point space with the zero-block form and the density-block
 refinement with matrices `ρ_k` for the Schrödinger-picture fixed points.
 
 ### Wolf Corollary 6.7 (faithful fixed-point conjugation) — FORMALIZED

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -278,9 +278,25 @@ In `TNLean.Channel.FixedPoint.WedderburnDecomp`:
 * `Kraus.adjointFixedPoints_wedderburnDecomp` — existence of this
   decomposition data for the adjoint-fixed-point algebra.
 
-What is still missing for the full Wolf statement is the concrete unitary
-realization `Fix(T*) = U (0 ⊕ ⊕_k M_{d_k} ⊗ 1_{m_k}) U†` and the density-block
-refinement with matrices `ρ_k`.
+In `TNLean.Channel.FixedPoint.BlockForm` (unital case, positive definite fixed
+point of the pre-dual, no zero block):
+
+* `Kraus.adjointFixedPoints_blockDiagonal_iff` — the unitary realization
+  `Fix(T*) = U (⊕_k 1_{m_k} ⊗ M_{d_k}) U†` with `∑_k d_k m_k = D`.
+* `Kraus.fixedPoints_blockDiagonal_iff` — the companion for the fixed points
+  of a unital Kraus map.
+
+In `TNLean.Channel.FixedPoint.CornerBlockForm` (zero-block general case, any
+positive semidefinite fixed point):
+
+* `Kraus.cornerFixedPoints_blockDiagonal_iff` — the corner-restricted
+  fixed-point set is carried by an isometry `W` (`W† W = 1`, `W W† = Q`) onto
+  `⊕_k 1_{m_k} ⊗ M_{d_k}` with `∑_k d_k m_k ≤ D`; embedded in `M_D(ℂ)` this is
+  the block representation with the zero block on the complement of the
+  support sector.
+
+What is still missing for the full Wolf statement is the density-block
+refinement with matrices `ρ_k` for the Schrödinger-picture fixed points.
 
 ### Wolf Corollary 6.7 (faithful fixed-point conjugation) — FORMALIZED
 
@@ -291,6 +307,10 @@ In `TNLean.Channel.FixedPoint.Corollaries`:
   then `ρ^{-1/2} Fix(T) ρ^{-1/2}` is a `StarSubalgebra`.
 * `Kraus.mem_weightedFixedPointsStarSubalgebra_iff` — membership is
   equivalent to saying that `ρ^{1/2} X ρ^{1/2}` is fixed by the original map.
+
+The formalized case takes `ρ` positive definite. Wolf's statement takes any
+maximum-rank fixed-point density matrix, with the inverse square root taken on
+the support of `ρ`; the singular case is not formalized.
 
 ### Wolf Theorem 6.15 (Conditional expectation onto fixed-point algebra) — PARTIALLY FORMALIZED
 

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -303,7 +303,7 @@ What is still missing for the full Wolf statement is the identification of
 the ambient fixed-point space with the zero-block form and the density-block
 refinement with matrices `ρ_k` for the Schrödinger-picture fixed points.
 
-### Wolf Corollary 6.7 (faithful fixed-point conjugation) — FORMALIZED
+### Wolf Corollary 6.7 (faithful fixed-point conjugation) — PARTIALLY FORMALIZED
 
 In `TNLean.Channel.FixedPoint.Corollaries`:
 

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2274,12 +2274,15 @@ $\bigoplus_k \Id_{m_k} \otimes \MN{d_k}$.
     supplies the unitary and the equivalence.
 \end{proof}
 
-Without a full-rank hypothesis on the fixed point, the block representation acquires a
-zero block on the complement of the support sector. The corner-restricted fixed-point
-$*$-algebra of Theorem~\ref{thm:cornerFixedPointsStarSubalgebra} carries the block
+Without a full-rank hypothesis on the fixed point, the corner-restricted fixed-point
+$*$-algebra of Theorem~\ref{thm:cornerFixedPointsStarSubalgebra} still carries the block
 structure through the compression onto the support sector; this is the
-$\sum_k d_k m_k \le D$ form of the block representation in Equation~(1.39)
-of~\cite{Wolf2012Quantum} invoked by~\cite[Theorem~6.14]{Wolf2012Quantum}.
+$\sum_k d_k m_k \le D$ support-sector form of the block representation in
+Equation~(1.39) of~\cite{Wolf2012Quantum} invoked
+by~\cite[Theorem~6.14]{Wolf2012Quantum}. A corner-restricted fixed point extended by
+zero on the complement of the support sector need not be a fixed point of the ambient
+map, so the corner block form does not by itself give the ambient fixed-point space a
+zero-block representation.
 
 \begin{theorem}[Block form of the corner-restricted fixed points]%
     \label{thm:cornerFixedPoints_block_form}
@@ -2305,9 +2308,9 @@ of~\cite{Wolf2012Quantum} invoked by~\cite[Theorem~6.14]{Wolf2012Quantum}.
         \{Y \in Q\,\MN{D}\,Q \mid Q\,E^*(Y)\,Q = Y\} \;=\;
         W \Bigl(\bigoplus_{k=0}^{n-1} \Id_{m_k} \otimes \MN{d_k}\Bigr) W^{\dagger}.
     \]
-    Embedded in $\MN{D}$, the right-hand side is the block representation in
-    Equation~(1.39) of~\cite{Wolf2012Quantum} with the zero block carried by the
-    complement of the support sector.
+    The right-hand side is the support-sector block representation in
+    Equation~(1.39) of~\cite{Wolf2012Quantum}; the equivalence characterizes the
+    corner-restricted set, not the ambient fixed-point space.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2278,7 +2278,7 @@ Without a full-rank hypothesis on the fixed point, the block representation acqu
 zero block on the complement of the support sector. The corner-restricted fixed-point
 $*$-algebra of Theorem~\ref{thm:cornerFixedPointsStarSubalgebra} carries the block
 structure through the compression onto the support sector; this is the
-$\sum_k d_k m_k \le D$ form of the block representation in Eq.~(1.39)
+$\sum_k d_k m_k \le D$ form of the block representation in Equation~(1.39)
 of~\cite{Wolf2012Quantum} invoked by~\cite[Theorem~6.14]{Wolf2012Quantum}.
 
 \begin{theorem}[Block form of the corner-restricted fixed points]%

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2286,7 +2286,9 @@ of~\cite{Wolf2012Quantum} invoked by~\cite[Theorem~6.14]{Wolf2012Quantum}.
     \lean{Kraus.cornerFixedPoints_blockDiagonal_iff}
     \leanok
     \uses{def:support_proj, def:kraus_map_channels}
-    Let $E$ be a trace-preserving Kraus map on $\MN{D}$, let $\rho \succeq 0$ satisfy
+    Let $E(X) = \sum_i K_i X K_i^{\dagger}$ be a trace-preserving Kraus map on $\MN{D}$,
+    with Heisenberg-picture adjoint $E^*(Y) = \sum_i K_i^{\dagger} Y K_i$, let
+    $\rho \succeq 0$ satisfy
     $E(\rho) = \rho$, and let $Q$ be the support projection of $\rho$. There are a sector
     dimension $r \le D$, a number $n$ of blocks, positive dimensions $d_0, \ldots,
     d_{n-1}$ and multiplicities $m_0, \ldots, m_{n-1}$ with $\sum_k d_k m_k = r$,
@@ -2303,9 +2305,9 @@ of~\cite{Wolf2012Quantum} invoked by~\cite[Theorem~6.14]{Wolf2012Quantum}.
         \{Y \in Q\,\MN{D}\,Q \mid Q\,E^*(Y)\,Q = Y\} \;=\;
         W \Bigl(\bigoplus_{k=0}^{n-1} \Id_{m_k} \otimes \MN{d_k}\Bigr) W^{\dagger}.
     \]
-    Embedded in $\MN{D}$, the right-hand side is the block representation in Eq.~(1.39)
-    of~\cite{Wolf2012Quantum} with the zero block carried by the complement of the
-    support sector.
+    Embedded in $\MN{D}$, the right-hand side is the block representation in
+    Equation~(1.39) of~\cite{Wolf2012Quantum} with the zero block carried by the
+    complement of the support sector.
 \end{theorem}
 
 \begin{proof}
@@ -2325,9 +2327,17 @@ of~\cite{Wolf2012Quantum} invoked by~\cite[Theorem~6.14]{Wolf2012Quantum}.
     (Theorem~\ref{thm:adjointFixedPoints_block_form}) yields a unitary
     $U \in \MN{r}$, dimensions $d_k$ and multiplicities $m_k$ with
     $\sum_k d_k m_k = r$, and the equivalence between the fixed-point equation on the
-    sector and the block-diagonal conjugation identity. The compression isomorphism
-    intertwines the corner-restricted fixed-point condition with the fixed-point
-    equation of the compressed map, so, with $W := V U$, which satisfies
+    sector and the block-diagonal conjugation identity. Writing
+    $\Phi(X) := V X V^{\dagger}$ for the compression isomorphism onto the corner and
+    $C^*$ for the Heisenberg-picture adjoint of the compressed family, the
+    corner-restricted fixed-point condition corresponds to the fixed-point equation of
+    the compressed map,
+    \[
+        Q\,E^*\!\bigl(\Phi(X)\bigr)\,Q \;=\; \Phi(X)
+        \quad\Longleftrightarrow\quad
+        C^*(X) \;=\; X,
+    \]
+    so, with $W := V U$, which satisfies
     $W^{\dagger} W = \Id_r$ and $W W^{\dagger} = Q$, a corner element $Y$ is a
     corner-restricted fixed point exactly when $Y = W (\bigoplus_k \Id_{m_k} \otimes
     B_k) W^{\dagger}$ for some blocks $B_k$. Finally $r \le D$ because the isometry $V$

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2274,6 +2274,66 @@ $\bigoplus_k \Id_{m_k} \otimes \MN{d_k}$.
     supplies the unitary and the equivalence.
 \end{proof}
 
+Without a full-rank hypothesis on the fixed point, the block representation acquires a
+zero block on the complement of the support sector. The corner-restricted fixed-point
+$*$-algebra of Theorem~\ref{thm:cornerFixedPointsStarSubalgebra} carries the block
+structure through the compression onto the support sector; this is the
+$\sum_k d_k m_k \le D$ form of the block representation in Eq.~(1.39)
+of~\cite{Wolf2012Quantum} invoked by~\cite[Theorem~6.14]{Wolf2012Quantum}.
+
+\begin{theorem}[Block form of the corner-restricted fixed points]%
+    \label{thm:cornerFixedPoints_block_form}
+    \lean{Kraus.cornerFixedPoints_blockDiagonal_iff}
+    \leanok
+    \uses{def:support_proj, def:kraus_map_channels}
+    Let $E$ be a trace-preserving Kraus map on $\MN{D}$, let $\rho \succeq 0$ satisfy
+    $E(\rho) = \rho$, and let $Q$ be the support projection of $\rho$. There are a sector
+    dimension $r \le D$, a number $n$ of blocks, positive dimensions $d_0, \ldots,
+    d_{n-1}$ and multiplicities $m_0, \ldots, m_{n-1}$ with $\sum_k d_k m_k = r$,
+    realized by an explicit identification of the index sets, and an isometry
+    $W : \C^{r} \to \C^{D}$ with $W^{\dagger} W = \Id_{r}$ and $W W^{\dagger} = Q$, such
+    that a matrix $Y \in \MN{D}$ satisfies $Q\,Y\,Q = Y$ and $Q\,E^*(Y)\,Q = Y$ exactly
+    when
+    \[
+        Y \;=\; W \Bigl(\bigoplus_{k=0}^{n-1} \Id_{m_k} \otimes B_k\Bigr) W^{\dagger}
+    \]
+    for some matrices $B_k \in \MN{d_k}$; that is, up to reordering the two tensor
+    factors of each block,
+    \[
+        \{Y \in Q\,\MN{D}\,Q \mid Q\,E^*(Y)\,Q = Y\} \;=\;
+        W \Bigl(\bigoplus_{k=0}^{n-1} \Id_{m_k} \otimes \MN{d_k}\Bigr) W^{\dagger}.
+    \]
+    Embedded in $\MN{D}$, the right-hand side is the block representation in Eq.~(1.39)
+    of~\cite{Wolf2012Quantum} with the zero block carried by the complement of the
+    support sector.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:support_proj_fixed, thm:supported_corner_compression_isometry,
+        thm:compression_on_support_posDef, thm:adjointFixedPoints_block_form}
+    Since $\rho$ is a fixed point of $E$, the support projection satisfies
+    $(\Id - Q) K_i Q = 0$ (Theorem~\ref{thm:support_proj_fixed}), so the compressed
+    family $Q K_i Q$ is supported on the corner and trace-preserving there. Compress it
+    to the support sector along the isometry $V : \C^{r} \to \C^{D}$ of
+    Theorem~\ref{thm:supported_corner_compression_isometry}, which satisfies
+    $V^{\dagger} V = \Id_{r}$ and $V V^{\dagger} = Q$: the compressed
+    family $C$ is trace-preserving on $\C^{r}$, and the compression
+    $\sigma = V^{\dagger} \rho V$ of $\rho$ is a positive definite fixed point of the
+    compressed Schr\"odinger map (Theorem~\ref{thm:compression_on_support_posDef}). The
+    block form of the Heisenberg-picture fixed points of $C$
+    (Theorem~\ref{thm:adjointFixedPoints_block_form}) yields a unitary
+    $U \in \MN{r}$, dimensions $d_k$ and multiplicities $m_k$ with
+    $\sum_k d_k m_k = r$, and the equivalence between the fixed-point equation on the
+    sector and the block-diagonal conjugation identity. The compression isomorphism
+    intertwines the corner-restricted fixed-point condition with the fixed-point
+    equation of the compressed map, so, with $W := V U$, which satisfies
+    $W^{\dagger} W = \Id_r$ and $W W^{\dagger} = Q$, a corner element $Y$ is a
+    corner-restricted fixed point exactly when $Y = W (\bigoplus_k \Id_{m_k} \otimes
+    B_k) W^{\dagger}$ for some blocks $B_k$. Finally $r \le D$ because the isometry $V$
+    embeds $\C^{r}$ into $\C^{D}$.
+\end{proof}
+
 \begin{theorem}[Weighted fixed points form a $*$-subalgebra]%
     \label{thm:weightedFixedPointsStarSubalgebra}
     \lean{Kraus.weightedFixedPointsStarSubalgebra}


### PR DESCRIPTION
## Summary

Survey outcome first, since it reframes the remaining work on LionSR/QICLean#39: the star-algebra statements of both target corollaries are **already formalized on main**:

- Corollary 6.6 of *Quantum Channels & Operations* (Wolf 2012): `Kraus.cornerFixedPointsStarSubalgebra` (`TNLean/Channel/FixedPoint/CornerFixedPoints.lean`, blueprint `thm:cornerFixedPointsStarSubalgebra`) — stated for **any** positive semidefinite fixed point $\rho$ of the Schrödinger map with $Q$ its support projection, which subsumes Wolf's maximum-rank instance (weaker hypotheses, same conclusion).
- Corollary 6.7 of the same reference: `Kraus.weightedFixedPointsStarSubalgebra` (`TNLean/Channel/FixedPoint/Corollaries.lean`, blueprint `thm:weightedFixedPointsStarSubalgebra`) — the **positive definite** case. Wolf's statement takes any *maximum-rank* fixed-point density matrix with the inverse square root on its support; the singular case is not formalized (see the remaining-work list below).

**What this PR adds** — the genuinely open item from the issue thread: the *zero-block general case* of the block representation invoked by Theorem 6.14 of *Quantum Channels & Operations* (Wolf 2012), i.e. the block structure of the Corollary 6.6 corner algebra without any full-rank hypothesis.

New file `TNLean/Channel/FixedPoint/CornerBlockForm.lean` (sorry/axiom-free):

- `Kraus.cornerFixedPoints_blockDiagonal_iff` — for a trace-preserving Kraus family $K$ and a positive semidefinite fixed point $\rho$ of the Schrödinger map, with $Q$ the support projection of $\rho$: there are a sector dimension $r \le D$, block data $(d_k, m_k)_{k<n}$ (positive, $\sum_k d_k m_k = r$ via an explicit index identification) and an isometry $W$ with $W^\dagger W = \mathbf 1_r$, $W W^\dagger = Q$, such that
  $$Q Y Q = Y \ \wedge\ Q\,T^*(Y)\,Q = Y \iff Y = W\Bigl(\bigoplus_k \mathbf 1_{m_k} \otimes B_k\Bigr)W^\dagger \text{ for some } B_k,$$
  i.e. $\{Y \in Q M_D Q \mid Q T^*(Y) Q = Y\} = W(\bigoplus_k \mathbf 1_{m_k} \otimes M_{d_k}(\mathbb C))W^\dagger$. Embedded in $M_D(\mathbb C)$ the right-hand side is the block representation of Equation (1.39) of *Quantum Channels & Operations* (Wolf 2012) **with** the zero block on the complement of the support sector — the $\sum_k d_k m_k \le D$ form, without a full-rank hypothesis.

Proof route: compress the corner family $Q K_i Q$ to the support sector along the compression isometry (`MPSTensor.exists_compressedTensor_of_supported_projection_with_letter_and_isometry`); the compressed family is trace-preserving with the positive definite fixed point $V^\dagger \rho V$, so `Kraus.adjointFixedPoints_blockDiagonal_iff` (#3723) applies on the sector; the compression equivalence transports the fixed-point condition, and $W := V U$ composes the support isometry with the block unitary.

**Exact hypotheses and scope.** Kraus (completely positive) maps — the completely positive case of the Schwarz hypothesis of the reference, the scope convention already recorded in the tagged Theorem 6.12 entries — and an arbitrary positive semidefinite fixed point of the Schrödinger picture. No full-rank assumption. The Kronecker factors are in the identity-times-matrix order fixed by LionSR/TNLean#3717; Wolf writes matrix-times-identity.

**Remaining for LionSR/QICLean#39** (recorded in `TNLean/Channel/WolfChapter6Index.lean`, which this PR brings up to date):
- Corollary 6.7 of *Quantum Channels & Operations* (Wolf 2012) in its stated generality: a *maximum-rank* (possibly singular) fixed-point density matrix with $\rho^{-1/2}$ taken on the support. Missing ingredients: a positive-semidefinite inverse square root on the support, and the maximal-support property of fixed points (every fixed point is supported in the support of a maximum-rank fixed point — the propositions recorded as open in `TNLean/Channel/FixedPoint/StationarySupport.lean`). Elimination plan: derive the singular case from the full-rank `Kraus.weightedFixedPointsStarSubalgebra` on the support sector via the same compression used here, once the maximal-support proposition is available.
- The density-weighted form $\bigoplus_k M_{d_k} \otimes \rho_k$ of Theorem 6.14 for the Schrödinger-picture fixed points (Equation (1.40) of the reference).

Partially addresses LionSR/QICLean#39.

## Blueprint

One new entry in `blueprint/src/chapter/ch07_spectral.tex`, placed after the unital block-form entries, with a full prose proof and wired `\uses`:

- `thm:cornerFixedPoints_block_form` — statement uses the support-projection and Kraus-map definitions; proof uses `thm:support_proj_fixed`, `thm:supported_corner_compression_isometry`, `thm:compression_on_support_posDef`, and `thm:adjointFixedPoints_block_form`, matching the Lean proof's dependencies.

## Validation

- `lake build TNLean` — success, no new warnings
- `rg -n "sorry|axiom"` on the new and touched Lean files — clean
- `lake exe checkdecls blueprint/lean_decls` — pass (after `--update-lean-decls`)
- `python3 scripts/blueprint_lean_sync.py --ci` — in sync
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main --ci` — no violations
- `lake exe lint_style`, `git diff --check` — clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style formalization in fixed-point theory; no runtime, auth, or data-path changes. Scope is explicitly corner-restricted (not ambient fixed-point space).
> 
> **Overview**
> Adds **`Kraus.cornerFixedPoints_blockDiagonal_iff`** in `TNLean/Channel/FixedPoint/CornerBlockForm.lean`: for a trace-preserving Kraus map and any **positive semidefinite** Schrödinger fixed point \(\rho\) with support projection \(Q\), corner elements \(Y\) with \(QYQ=Y\) and \(Q\,T^*(Y)\,Q=Y\) are exactly those of the form \(W(\bigoplus_k \mathbf{1}_{m_k}\otimes B_k)W^\dagger\) for an isometry \(W\) onto the support sector (\(r\le D\), \(\sum_k d_k m_k=r\)). The proof compresses \(QK_iQ\) to the sector, applies the existing **`adjointFixedPoints_blockDiagonal_iff`**, and pulls back via the compression isomorphism.
> 
> Wires the module into **`TNLean.lean`**, points **`CornerFixedPoints`** at the new theorem, and refreshes **`WolfChapter6Index`** (block-form coverage vs. still-open ambient zero-block and density-weighted Theorem 6.14). Blueprint gains **`thm:cornerFixedPoints_block_form`** in `ch07_spectral.tex` with a proof sketch aligned to the Lean route.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 476d3f66b12804f2514f5f253425afe011d25f52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->