### PR TITLE
refactor(MPS): proof simplifications and dead-code removal across MPS, Channel, and Algebra

### DIFF
--- a/TNLean/Algebra/PerronFrobenius/RankOne.lean
+++ b/TNLean/Algebra/PerronFrobenius/RankOne.lean
@@ -113,11 +113,7 @@ theorem hasRankOneFactorization_of_mul_self_eq_self
     (hspan ⟨f (Pi.single j 1), LinearMap.mem_range_self f _⟩)
   have hb' := congrArg (fun x : LinearMap.range f ↦ x.1 i) hb
   have heval : f (Pi.single j 1) i = T i j := by
-    simp only [f, Matrix.toLin'_apply, Matrix.mulVec, dotProduct]
-    rw [Fintype.sum_eq_single j]
-    · simp
-    · intro x hx
-      simp [hx]
+    simp [f, Matrix.toLin'_apply]
   change Classical.choose _ * u.1 i = f (Pi.single j 1) i at hb'
   rw [heval] at hb'
   simpa [b, Matrix.vecMulVec_apply, mul_comm] using hb'.symm
@@ -131,11 +127,7 @@ sector tensors. -/
 theorem tracePowersConstant_of_mul_self_eq_self
     {T : Matrix (Fin n) (Fin n) ℝ} (hTT : T * T = T) :
     TracePowersConstant T := by
-  have hpow : ∀ m : ℕ, T ^ (m + 1) = T := by
-    intro m
-    induction m with
-    | zero => rw [pow_one]
-    | succ p ih => rw [pow_succ, ih, hTT]
+  have hpow : ∀ m : ℕ, T ^ (m + 1) = T := fun m => IsIdempotentElem.pow_succ_eq m hTT
   intro k hk
   obtain ⟨m, rfl⟩ : ∃ m, k = m + 1 := ⟨k - 1, by omega⟩
   rw [hpow]

--- a/TNLean/Channel/Peripheral/CyclicDecomposition/Basic.lean
+++ b/TNLean/Channel/Peripheral/CyclicDecomposition/Basic.lean
@@ -174,9 +174,8 @@ lemma cornerCompressionIsometry_conjTranspose_mul
         cornerCompressionIsometry Umat eST eS = 1 := by
   let I : Matrix (S ⊕ T) S ℂ := cornerCompressionInclusion (S := S) (T := T)
   let E : Matrix (Fin D) (Fin n) ℂ := Matrix.reindexLinearEquiv ℂ ℂ eST.symm eS I
-  have hE_star : Eᴴ = Matrix.reindexLinearEquiv ℂ ℂ eS eST.symm Iᴴ := by
-    ext a b
-    simp [E, I, Matrix.conjTranspose_apply, Matrix.reindex_apply]
+  have hE_star : Eᴴ = Matrix.reindexLinearEquiv ℂ ℂ eS eST.symm Iᴴ :=
+    Matrix.conjTranspose_reindex eST.symm eS I
   rw [cornerCompressionIsometry]
   change (Umat * E)ᴴ * (Umat * E) = 1
   rw [Matrix.conjTranspose_mul]
@@ -235,13 +234,8 @@ lemma cornerCompressionExpand_one
   rw [cornerCompressionExpand_apply]
   have hReindexOne :
       Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm (1 : Matrix (Fin n) (Fin n) ℂ) =
-        (1 : Matrix S S ℂ) := by
-    ext s t
-    by_cases h : s = t
-    · subst t
-      simp [Matrix.reindex_apply]
-    · have hne : eS s ≠ eS t := fun h' => h (eS.injective h')
-      simp [Matrix.reindex_apply, h, hne]
+        (1 : Matrix S S ℂ) :=
+    Matrix.reindexLinearEquiv_one ℂ ℂ eS.symm
   rw [hReindexOne, ← hP0, hPdiag_back, ← hP_decomp]
 
 /-- The ambient expansion is conjugation by the rectangular support isometry. -/
@@ -258,9 +252,8 @@ lemma cornerCompressionExpand_eq_isometry
   let M' : Matrix S S ℂ := Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm M
   have hM_back : Matrix.reindexLinearEquiv ℂ ℂ eS eS M' = M :=
     (Matrix.reindexLinearEquiv ℂ ℂ eS eS).apply_symm_apply M
-  have hE_star : Eᴴ = Matrix.reindexLinearEquiv ℂ ℂ eS eST.symm Iᴴ := by
-    ext a b
-    simp [E, I, Matrix.conjTranspose_apply, Matrix.reindex_apply]
+  have hE_star : Eᴴ = Matrix.reindexLinearEquiv ℂ ℂ eS eST.symm Iᴴ :=
+    Matrix.conjTranspose_reindex eST.symm eS I
   have hE_mid :
       E * M * Eᴴ =
         Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm

--- a/TNLean/MPS/CanonicalForm/CyclicSectors/Compression.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors/Compression.lean
@@ -51,24 +51,12 @@ private lemma evalWord_conj_unitary
     (A : MPSTensor d D) (U : Matrix.unitaryGroup (Fin D) ℂ) :
     ∀ w : List (Fin d),
       evalWord (fun i => (↑U : MatrixAlg D)ᴴ * A i * (↑U : MatrixAlg D)) w =
-        (↑U : MatrixAlg D)ᴴ * evalWord A w * (↑U : MatrixAlg D) := by
-  intro w
-  induction w with
-  | nil =>
-      have hUU : (↑U : MatrixAlg D)ᴴ * (↑U : MatrixAlg D) = 1 := by
-        simpa [Matrix.star_eq_conjTranspose] using Matrix.UnitaryGroup.star_mul_self U
-      simp only [evalWord, hUU, Matrix.mul_one]
-  | cons i w ih =>
-      have hUU : (↑U : MatrixAlg D) * (↑U : MatrixAlg D)ᴴ = 1 := by
-        simpa [Matrix.star_eq_conjTranspose] using Unitary.mul_star_self_of_mem U.prop
-      simp only [evalWord]
-      rw [ih]
-      calc (↑U : MatrixAlg D)ᴴ * A i * (↑U : MatrixAlg D) *
-            ((↑U : MatrixAlg D)ᴴ * evalWord A w * (↑U : MatrixAlg D))
-          = (↑U : MatrixAlg D)ᴴ * A i * ((↑U : MatrixAlg D) * (↑U : MatrixAlg D)ᴴ) *
-              evalWord A w * (↑U : MatrixAlg D) := by noncomm_ring
-        _ = (↑U : MatrixAlg D)ᴴ * (A i * evalWord A w) * (↑U : MatrixAlg D) := by
-              simp only [Matrix.mul_assoc, hUU, Matrix.one_mul]
+        (↑U : MatrixAlg D)ᴴ * evalWord A w * (↑U : MatrixAlg D) :=
+  evalWord_gauge
+    ⟨(↑U : MatrixAlg D)ᴴ, ↑U,
+      by simpa [Matrix.star_eq_conjTranspose] using Matrix.UnitaryGroup.star_mul_self U,
+      by simpa [Matrix.star_eq_conjTranspose] using Unitary.mul_star_self_of_mem U.prop⟩
+    fun _ => rfl
 
 /-- Compress a tensor supported on an orthogonal projection to the corresponding sector bond
 space.  The compressed tensor has the same sector MPVs and inherits the left-canonical equation.
@@ -246,9 +234,8 @@ theorem exists_compressedTensor_of_supported_projection_with_letter_and_isometry
       -- φ(∑ B_i† B_i) = ∑ φ(B_i† * B_i) = ∑ (X_i)† (X_i) = P0
       -- But we also need φ(B_i†) = (X_i)†
       have hφ_ct : ∀ i, rAlg ((B i)ᴴ) = (X i)ᴴ := by
-        intro i; ext a b
-        simp [rAlg, X, Matrix.reindex_apply, Matrix.conjTranspose_apply,
-          Matrix.submatrix_apply, Matrix.reindexAlgEquiv]
+        intro i
+        simp [rAlg, X, Matrix.coe_reindexAlgEquiv]
       -- h : ∑ (X_i)† * X_i = P0
       have h : ∑ i : Fin d, (X i)ᴴ * X i = P0 := by
         have h0 := congrArg rAlg hTPB
@@ -287,10 +274,7 @@ theorem exists_compressedTensor_of_supported_projection_with_letter_and_isometry
       change
         (Matrix.reindex eS eS (B11 i))ᴴ * Matrix.reindex eS eS (B11 i) =
           Matrix.reindex eS eS ((B11 i)ᴴ * B11 i)
-      rw [show (Matrix.reindex eS eS (B11 i))ᴴ = Matrix.reindex eS eS ((B11 i)ᴴ) from by
-        ext a b
-        simp only [Matrix.reindex_apply, Matrix.conjTranspose_apply,
-          Matrix.submatrix_apply]]
+      rw [Matrix.conjTranspose_reindex]
       simp only [Matrix.reindex_apply, Matrix.submatrix_mul_equiv]
     simp_rw [hterm]
     -- ∑ reindex eS eS (f i) = reindex eS eS (∑ f i)

--- a/TNLean/MPS/CanonicalForm/ProjectorClosure.lean
+++ b/TNLean/MPS/CanonicalForm/ProjectorClosure.lean
@@ -66,8 +66,7 @@ theorem commutes_of_hasInvariantProjectorClosure_of_lowerZero
     calc
       A i * P - P * A i * P = (1 - P) * A i * P := by noncomm_ring
       _ = 0 := h
-  have hPcomp : P * (1 - P) = 0 := by
-    rw [mul_sub, mul_one, hP.2, sub_self]
+  have hPcomp : P * (1 - P) = 0 := IsIdempotentElem.mul_one_sub_self hP.2
   have hUpper : P * A i * (1 - P) = 0 := by
     calc
       P * A i * (1 - P) = P * (A i * (1 - P)) := by noncomm_ring

--- a/TNLean/MPS/MPDO/InvariantProjection.lean
+++ b/TNLean/MPS/MPDO/InvariantProjection.lean
@@ -150,12 +150,10 @@ theorem firstSiteMatrix_mul_apply (P : Matrix (Fin d) (Fin d) ℂ) {N : ℕ}
   rw [Matrix.mul_apply, sum_fin_succ_eq_sum_cons]
   refine Finset.sum_congr rfl fun i _ => ?_
   simp only [firstSiteMatrix, Fin.cons_zero, Function.comp_def, Fin.cons_succ]
-  rw [Finset.sum_eq_single (fun n : Fin N => σ (Fin.succ n))]
+  rw [Fintype.sum_eq_single (fun n : Fin N => σ (Fin.succ n))]
   · rw [if_pos rfl, mul_one]
-  · intro ρ _ hρ
+  · intro ρ hρ
     rw [if_neg fun hh => hρ hh.symm, mul_zero, zero_mul]
-  · intro hmem
-    exact (hmem (Finset.mem_univ _)).elim
 
 /-- Right multiplication by the first-spin action, entrywise:
 $(GP_1)_{\sigma\tau}=\sum_jG_{\sigma,(j,\tau')}P_{j\tau_0}$, where
@@ -168,12 +166,10 @@ theorem mul_firstSiteMatrix_apply (P : Matrix (Fin d) (Fin d) ℂ) {N : ℕ}
   rw [Matrix.mul_apply, sum_fin_succ_eq_sum_cons]
   refine Finset.sum_congr rfl fun j _ => ?_
   simp only [firstSiteMatrix, Fin.cons_zero, Function.comp_def, Fin.cons_succ]
-  rw [Finset.sum_eq_single (fun n : Fin N => τ (Fin.succ n))]
+  rw [Fintype.sum_eq_single (fun n : Fin N => τ (Fin.succ n))]
   · rw [if_pos rfl, mul_one]
-  · intro ρ _ hρ
+  · intro ρ hρ
     rw [if_neg hρ, mul_zero, mul_zero]
-  · intro hmem
-    exact (hmem (Finset.mem_univ _)).elim
 
 /-- First-site actions compose site by site:
 $P_1Q_1 = (PQ)_1$ on an $(N+1)$-site chain. -/

--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -243,14 +243,12 @@ theorem ketLeftAction_mpv (M : MPOTensor d D) (P : Matrix (Fin d) (Fin d) ℂ)
   simp only [ketLeftAction, finProdFinEquiv_divNat, finProdFinEquiv_modNat]
   apply Finset.sum_congr rfl
   intro i _
-  rw [Finset.sum_eq_single (ρ 0).modNat]
+  rw [Fintype.sum_eq_single (ρ 0).modNat]
   · simp only [if_true]
     rw [mpv_toMPSTensor_cons_pair]
     rfl
-  · intro j _ hj
+  · intro j hj
     simp only [hj.symm, if_false, zero_mul]
-  · intro hj
-    exact (hj (Finset.mem_univ _)).elim
 
 /-- Coefficient identity identifying the first-site doubled-index bra action
 with the matrix entries of $H^{(N)}P$. -/
@@ -266,16 +264,14 @@ theorem braRightAction_mpv (M : MPOTensor d D) (P : Matrix (Fin d) (Fin d) ℂ)
   rw [Fintype.sum_prod_type]
   simp only [braRightAction, finProdFinEquiv_divNat, finProdFinEquiv_modNat,
     ite_mul]
-  rw [Finset.sum_eq_single (ρ 0).divNat]
+  rw [Fintype.sum_eq_single (ρ 0).divNat]
   · apply Finset.sum_congr rfl
     intro j _
     simp only [if_true]
     rw [mpv_toMPSTensor_cons_pair]
     simp only [Function.comp_apply, mul_comm]
-  · intro i _ hi
+  · intro i hi
     simp only [hi.symm, if_false, zero_mul, Finset.sum_const_zero]
-  · intro hi
-    exact (hi (Finset.mem_univ _)).elim
 
 /-- Coefficient identity identifying the two-sided first-site doubled-index
 action with the matrix entries of $PH^{(N)}P$. -/

--- a/TNLean/MPS/MPDO/ZCL.lean
+++ b/TNLean/MPS/MPDO/ZCL.lean
@@ -116,8 +116,6 @@ theorem IsSourceZCL.normalized_idempotent {M : MPOTensor d D} (h : IsSourceZCL M
   refine ⟨lam, hlam, ?_⟩
   change ((lam : ℂ)⁻¹ • physTraceTransfer M) * ((lam : ℂ)⁻¹ • physTraceTransfer M)
     = (lam : ℂ)⁻¹ • physTraceTransfer M
-  rw [Matrix.smul_mul, Matrix.mul_smul, smul_smul, hidem, smul_smul]
-  congr 1
-  rw [mul_assoc, inv_mul_cancel₀ hlamC, mul_one]
+  rw [smul_mul_smul_comm, hidem, smul_smul, mul_assoc, inv_mul_cancel₀ hlamC, mul_one]
 
 end MPOTensor

--- a/TNLean/MPS/RFP/CommutingBridge.lean
+++ b/TNLean/MPS/RFP/CommutingBridge.lean
@@ -137,12 +137,6 @@ def HasProductPairMPV (A : MPSTensor d D) : Prop :=
   ∃ ψ₂ : NSiteSpace d 2, ∀ N, 0 < N → ∀ σ : Cfg d (2 * N),
     mpv A σ = productPairState ψ₂ N σ
 
-theorem HasProductPairMPV.exists_twoSiteAmplitude {A : MPSTensor d D}
-    (hA : HasProductPairMPV A) :
-    ∃ ψ₂ : NSiteSpace d 2, ∀ N, 0 < N → ∀ σ : Cfg d (2 * N),
-      mpv A σ = productPairState ψ₂ N σ :=
-  hA
-
 /-- Hypotheses asserting that the nearest-neighbor local terms of \(A\) are
 commuting idempotents \(p_i\) on an \(N\)-site chain, with
 \(p_i p_j = p_j p_i\).
@@ -201,17 +195,6 @@ structure ProductPairBridge (A : MPSTensor d D) where
   hmpv : ∀ N, 0 < N → ∀ σ : Cfg d (2 * N),
     mpv A σ = productPairState pairAmplitude N σ
   localProjectors : ∀ N, 2 ≤ N → HasProductPairLocalProjectors A N
-
-theorem ProductPairBridge.mpv_eq_productPairState {A : MPSTensor d D}
-    (hBridge : ProductPairBridge A) :
-    ∀ N, 0 < N → ∀ σ : Cfg d (2 * N),
-      mpv A σ = productPairState hBridge.pairAmplitude N σ :=
-  hBridge.hmpv
-
-theorem ProductPairBridge.hasProductPairMPV {A : MPSTensor d D}
-    (hBridge : ProductPairBridge A) :
-    HasProductPairMPV A :=
-  ⟨hBridge.pairAmplitude, hBridge.hmpv⟩
 
 /-- The conditional physical-pair hypotheses yield the unfolded `IsNNCPH`
 conclusion: all two-site local terms commute on every finite chain of length at


### PR DESCRIPTION
## Summary

Applies a vetted batch of pure refactorings. No mathematical statements, hypotheses, or names of surviving declarations change; every edit is a proof-body simplification or a deletion of unused declarations.

## Applied refactorings

- **TNLean/MPS/RFP/CommutingBridge.lean** — delete three dead pass-through theorems (`HasProductPairMPV.exists_twoSiteAmplitude`, `ProductPairBridge.mpv_eq_productPairState`, `ProductPairBridge.hasProductPairMPV`): each body merely restated a hypothesis or structure field, and no Lean file or blueprint entry references them.
- **TNLean/Channel/Peripheral/CyclicDecomposition/Basic.lean** — replace a 9-line by-hand proof that reindexing preserves the identity matrix with `Matrix.reindexLinearEquiv_one`, and two identical ext proofs that conjugate transposition commutes with reindexing with `Matrix.conjTranspose_reindex`.
- **TNLean/MPS/CanonicalForm/CyclicSectors/Compression.lean** — derive the private unitary word-evaluation conjugation lemma from the existing `evalWord_gauge` instead of re-proving the letter-by-letter induction; replace two more by-hand conjugate-transpose/reindex ext proofs with `Matrix.conjTranspose_reindex` / `Matrix.coe_reindexAlgEquiv`.
- **TNLean/MPS/MPDO/VerticalCF.lean** — use `Fintype.sum_eq_single` in place of `Finset.sum_eq_single`, removing two impossible-membership bullets.
- **TNLean/MPS/MPDO/InvariantProjection.lean** — same `Fintype.sum_eq_single` cleanup in the two first-site matrix entry lemmas.
- **TNLean/Algebra/PerronFrobenius/RankOne.lean** — replace an inner induction on powers of an idempotent with `IsIdempotentElem.pow_succ_eq`, and shrink a matrix-entry evaluation to one `simp` call via the `Matrix.mulVec_single` simp lemma.
- **TNLean/MPS/CanonicalForm/ProjectorClosure.lean** — prove `P * (1 - P) = 0` by `IsIdempotentElem.mul_one_sub_self` instead of a rewrite chain.
- **TNLean/MPS/MPDO/ZCL.lean** — collapse the normalized-idempotence rewrite chain using `smul_mul_smul_comm`, eliminating a `congr` step.

## Verification

- `lake build TNLean` succeeds (no new warnings; the two header-linter warnings are pre-existing in untouched files)
- `rg -n "sorry|axiom"` clean on all changed files
- `lake exe checkdecls blueprint/lean_decls` passes (after regenerating the untracked `lean_decls` as CI does)
- `python3 scripts/blueprint_lean_sync.py --ci` passes
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main` passes
- `lake exe lint_style` passes
- `git diff --check` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-body and deletion-only changes with no API or mathematical statement changes; risk is limited to accidental proof regressions, which the PR description says CI already checks.
> 
> **Overview**
> Proof-only refactor across Algebra, Channel peripheral cyclic decomposition, and several MPS modules: **no theorem statements, hypotheses, or surviving declaration names change.**
> 
> **Dead code:** `CommutingBridge.lean` drops three pass-through lemmas that only restated `HasProductPairMPV` or `ProductPairBridge` fields (`HasProductPairMPV.exists_twoSiteAmplitude`, `ProductPairBridge.mpv_eq_productPairState`, `ProductPairBridge.hasProductPairMPV`).
> 
> **Library lemmas instead of hand proofs:** Corner compression uses `Matrix.reindexLinearEquiv_one` and `Matrix.conjTranspose_reindex` in `CyclicDecomposition/Basic.lean` and `CyclicSectors/Compression.lean`; idempotent matrix steps use `IsIdempotentElem.pow_succ_eq` and `mul_one_sub_self` in `RankOne.lean` and `ProjectorClosure.lean`; ZCL normalization uses `smul_mul_smul_comm` in `ZCL.lean`.
> 
> **Other proof shortening:** `evalWord_conj_unitary` is derived from `evalWord_gauge` in compression; MPDO first-site and vertical CF lemmas switch `Finset.sum_eq_single` to `Fintype.sum_eq_single`, dropping impossible-membership cases; a rank-one matrix entry evaluation is collapsed to a single `simp`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c5de6501edd843bd51f31eb807d108462fdc7a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->