### PR TITLE
feat(Channel): weighted corner fixed points for a singular fixed point (Cor 6.7, singular case)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -171,6 +171,7 @@ import TNLean.Channel.FixedPoint.CornerBlockForm
 import TNLean.Channel.FixedPoint.CornerFixedPoints
 import TNLean.Channel.FixedPoint.StationarySupport
 import TNLean.Channel.FixedPoint.WedderburnDecomp
+import TNLean.Channel.FixedPoint.WeightedCornerFixedPoints
 import TNLean.Channel.FixedPoint.Corollaries
 import TNLean.Channel.Spectral.Support
 import TNLean.Channel.Irreducible.Ergodicity

--- a/TNLean/Channel/FixedPoint/Corollaries.lean
+++ b/TNLean/Channel/FixedPoint/Corollaries.lean
@@ -22,9 +22,15 @@ $\rho^{-1/2} \Fix(T) \rho^{-1/2}$ is a `StarSubalgebra` of `M_D(\mathbb{C})`.
 ## Main declarations
 
 * `Kraus.rightCanonicalGauge`: the Kraus family `ρ^{-1/2} K_i ρ^{1/2}`.
-* `Kraus.weightedFixedPointsStarSubalgebra`: Wolf Corollary 6.7.
+* `Kraus.weightedFixedPointsStarSubalgebra`: Wolf Corollary 6.7, in the positive
+  definite case.
 * `Kraus.mem_weightedFixedPointsStarSubalgebra_iff`: membership is equivalent
   to saying that `ρ^{1/2} X ρ^{1/2}` is fixed by the original map.
+
+The singular case, with the inverse square root taken on the support of a positive
+semidefinite fixed point and the conjugated set restricted to the corner-supported fixed
+points, is `Kraus.weightedCornerFixedPointsStarSubalgebra` in
+`TNLean.Channel.FixedPoint.WeightedCornerFixedPoints`.
 
 ## References
 

--- a/TNLean/Channel/FixedPoint/Corollaries.lean
+++ b/TNLean/Channel/FixedPoint/Corollaries.lean
@@ -22,7 +22,8 @@ $\rho^{-1/2} \Fix(T) \rho^{-1/2}$ is a `StarSubalgebra` of `M_D(\mathbb{C})`.
 ## Main declarations
 
 * `Kraus.rightCanonicalGauge`: the Kraus family `ρ^{-1/2} K_i ρ^{1/2}`.
-* `Kraus.weightedFixedPointsStarSubalgebra`: Wolf Corollary 6.7, in the positive
+* `Kraus.weightedFixedPointsStarSubalgebra`: Corollary 6.7 of *Quantum Channels &
+  Operations* (Wolf 2012), in the positive
   definite case.
 * `Kraus.mem_weightedFixedPointsStarSubalgebra_iff`: membership is equivalent
   to saying that `ρ^{1/2} X ρ^{1/2}` is fixed by the original map.

--- a/TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean
+++ b/TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean
@@ -460,7 +460,13 @@ weighted corner fixed-point star-algebra. Together with
 `Kraus.mem_weightedCornerFixedPointsStarSubalgebra` this identifies the carrier of the
 star-algebra with the set $\rho^{-1/2}\{X \mid T(X) = X,\ Q X Q = X\}\rho^{-1/2}$ of
 Corollary 6.7 of *Quantum Channels & Operations* (Wolf 2012), with the inverse square
-root taken on the support of $\rho$. -/
+root taken on the support of $\rho$.
+
+**Scope restriction (corner support):** the source's corollary takes a maximum-rank
+fixed point, for which the support condition on $X$ is automatic by the maximal-support
+property; that property is not yet available here, so the statement carries the support
+hypothesis explicitly. Documented in
+`docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex`. -/
 theorem exists_weightedCorner_sqrt_eq_of_fixedPoint
     (K : Fin d → Mat) (h_tp : IsTP K) {ρ : Mat} (hρ_psd : ρ.PosSemidef)
     (hρ_fix : map K ρ = ρ) {X : Mat} (hX_fix : map K X = X)

--- a/TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean
+++ b/TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean
@@ -465,7 +465,8 @@ root taken on the support of $\rho$.
 
 **Scope restriction (corner support):** the source's corollary takes a maximum-rank
 fixed point, for which the support condition on $X$ is automatic by the maximal-support
-property; that property is not yet available here, so the statement carries the support
+property; that property has not yet been established here, so the statement carries the
+support
 hypothesis explicitly. Documented in
 `docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex`. -/
 theorem exists_weightedCorner_sqrt_eq_of_fixedPoint

--- a/TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean
+++ b/TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean
@@ -1,0 +1,510 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Channel.FixedPoint.CornerFixedPoints
+import TNLean.Channel.FixedPoint.Corollaries
+
+/-!
+# Weighted corner fixed points of a Kraus map with a singular fixed point
+
+This file extends Corollary 6.7 of *Quantum Channels & Operations* (Wolf 2012) beyond the
+positive definite case formalized in `TNLean.Channel.FixedPoint.Corollaries`. Let $T$ be a
+trace-preserving Kraus map, let $\rho$ be a positive semidefinite fixed point of $T$ —
+possibly singular — and let $Q$ be the support projection of $\rho$. The set
+$$\rho^{-1/2}\,\{X \mid T(X) = X,\ Q X Q = X\}\,\rho^{-1/2},$$
+with the inverse square root taken on the support of $\rho$, is a star-subalgebra of the
+corner algebra $Q M_D(\mathbb{C}) Q$. Concretely, the carrier consists of the corner
+elements $Y$ with $\sqrt{\rho}\, Y \sqrt{\rho}$ fixed by $T$; conjugation by
+$\sqrt{\rho}$ maps this carrier bijectively onto the fixed points of $T$ supported on the
+support of $\rho$, which realizes the displayed set without naming the pseudo-inverse.
+
+**Scope restriction (corner-supported fixed points):** Corollary 6.7 of
+*Quantum Channels & Operations* (Wolf 2012) takes $\rho$ to be a *maximum-rank* fixed-point
+density matrix and conjugates the full fixed-point set of $T$. For a maximum-rank fixed
+point every fixed point of $T$ is supported on the support of $\rho$, so the corner
+restriction is vacuous; that maximal-support property (the proposition on maximal support
+of fixed points in Section 6.4 of the reference) is not yet formalized, and the present
+statements restrict to the fixed points supported on the support of $\rho$ instead.
+Documented in `docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex`. Elimination:
+formalize the maximal-support proposition and instantiate these statements at a
+maximum-rank fixed point.
+
+The proofs compress to the support sector, where the compressed fixed point is positive
+definite and the positive definite case applies, and transport the structure back along
+the compression isometry. The square root compresses along the isometry:
+$\sqrt{V^{\dagger} \rho V} = V^{\dagger} \sqrt{\rho}\, V$.
+
+## Main declarations
+
+* `Kraus.weightedCornerFixedPointsStarSubalgebra` -- the weighted corner fixed points form
+  a star-subalgebra of the corner algebra.
+* `Kraus.mem_weightedCornerFixedPointsStarSubalgebra` -- membership is exactly the
+  condition that $\sqrt{\rho}\, Y \sqrt{\rho}$ is fixed by the map.
+* `Kraus.exists_weightedCorner_sqrt_eq_of_fixedPoint` -- every fixed point supported on
+  the support of $\rho$ is $\sqrt{\rho}\, Y \sqrt{\rho}$ for a corner element $Y$ of the
+  carrier: conjugation by $\sqrt{\rho}$ is onto the corner-supported fixed points.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder BigOperators
+open Matrix Finset Complex
+
+namespace Kraus
+
+variable {d D : ℕ}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+/-! ## The square root of a positive semidefinite matrix and its support -/
+
+/-- The support projection absorbs the square root from the left:
+$Q \sqrt{\rho} = \sqrt{\rho}$. -/
+private theorem stationaryProj_mul_cfc_sqrt {ρ : Mat} (hρ_psd : ρ.PosSemidef) :
+    stationaryProj hρ_psd * CFC.sqrt ρ = CFC.sqrt ρ := by
+  set Q : Mat := stationaryProj hρ_psd with hQdef
+  set S : Mat := CFC.sqrt ρ with hSdef
+  have hQproj : IsOrthogonalProjection Q := isOrthogonalProjection_stationaryProj hρ_psd
+  have hQherm : Qᴴ = Q := hQproj.1.eq
+  have hS_herm : Sᴴ = S := MPSTensor.conjTranspose_cfc_sqrt (D := D) ρ
+  have hSS : S * S = ρ := CFC.sqrt_mul_sqrt_self ρ hρ_psd.nonneg
+  have hQρ : Q * ρ = ρ := MPSTensor.supportProj_mul (D := D) (ρ := ρ) hρ_psd
+  -- `(1 - Q) S` has vanishing square, hence vanishes.
+  have h0 : ((1 - Q) * S) * ((1 - Q) * S)ᴴ = 0 := by
+    have h1 : (1 - Q)ᴴ = 1 - Q := by
+      rw [Matrix.conjTranspose_sub, Matrix.conjTranspose_one, hQherm]
+    have h2 : ((1 - Q) * S) * ((1 - Q) * S)ᴴ = (1 - Q) * ρ * (1 - Q) := by
+      rw [Matrix.conjTranspose_mul, hS_herm, h1, ← hSS]
+      simp [Matrix.mul_assoc]
+    have h3 : (1 - Q) * ρ = 0 := by
+      rw [Matrix.sub_mul, Matrix.one_mul, hQρ, sub_self]
+    rw [h2, h3, Matrix.zero_mul]
+  have h4 : (1 - Q) * S = 0 := Matrix.self_mul_conjTranspose_eq_zero.mp h0
+  rw [Matrix.sub_mul, Matrix.one_mul] at h4
+  exact (sub_eq_zero.mp h4).symm
+
+/-- The support projection absorbs the square root from the right:
+$\sqrt{\rho}\, Q = \sqrt{\rho}$. -/
+private theorem cfc_sqrt_mul_stationaryProj {ρ : Mat} (hρ_psd : ρ.PosSemidef) :
+    CFC.sqrt ρ * stationaryProj hρ_psd = CFC.sqrt ρ := by
+  have hQherm : (stationaryProj hρ_psd)ᴴ = stationaryProj hρ_psd :=
+    (isOrthogonalProjection_stationaryProj hρ_psd).1.eq
+  have hS_herm : (CFC.sqrt ρ)ᴴ = CFC.sqrt ρ := MPSTensor.conjTranspose_cfc_sqrt (D := D) ρ
+  have h := congrArg Matrix.conjTranspose (stationaryProj_mul_cfc_sqrt hρ_psd)
+  rwa [Matrix.conjTranspose_mul, hQherm, hS_herm] at h
+
+/-- Conjugation by $\sqrt{\rho}$ lands in the corner: the matrix
+$\sqrt{\rho}\, Y \sqrt{\rho}$ is supported on the support of $\rho$. -/
+private theorem sqrt_conj_supported {ρ : Mat} (hρ_psd : ρ.PosSemidef) (Y : Mat) :
+    stationaryProj hρ_psd * (CFC.sqrt ρ * Y * CFC.sqrt ρ) * stationaryProj hρ_psd =
+      CFC.sqrt ρ * Y * CFC.sqrt ρ := by
+  calc stationaryProj hρ_psd * (CFC.sqrt ρ * Y * CFC.sqrt ρ) * stationaryProj hρ_psd
+      = (stationaryProj hρ_psd * CFC.sqrt ρ) * Y *
+          (CFC.sqrt ρ * stationaryProj hρ_psd) := by simp [Matrix.mul_assoc]
+    _ = CFC.sqrt ρ * Y * CFC.sqrt ρ := by
+        rw [stationaryProj_mul_cfc_sqrt hρ_psd, cfc_sqrt_mul_stationaryProj hρ_psd]
+
+/-- The square root compresses along an isometry onto the support:
+$\sqrt{V^{\dagger} \rho V} = V^{\dagger} \sqrt{\rho}\, V$ for $V$ with
+$V^{\dagger} V = \mathbf{1}$ and $V V^{\dagger} = Q$ the support projection of $\rho$. -/
+private theorem cfc_sqrt_compression {ρ : Mat} (hρ_psd : ρ.PosSemidef)
+    {r : ℕ} {V : Matrix (Fin D) (Fin r) ℂ}
+    (hVVt : V * Vᴴ = stationaryProj hρ_psd) :
+    CFC.sqrt (Vᴴ * ρ * V) = Vᴴ * CFC.sqrt ρ * V := by
+  have hb : (0 : Matrix (Fin r) (Fin r) ℂ) ≤ Vᴴ * CFC.sqrt ρ * V :=
+    (((CFC.sqrt_nonneg ρ).posSemidef).conjTranspose_mul_mul_same V).nonneg
+  refine CFC.sqrt_unique ?_ hb
+  calc (Vᴴ * CFC.sqrt ρ * V) * (Vᴴ * CFC.sqrt ρ * V)
+      = Vᴴ * (CFC.sqrt ρ * (V * Vᴴ) * CFC.sqrt ρ) * V := by simp [Matrix.mul_assoc]
+    _ = Vᴴ * (CFC.sqrt ρ * stationaryProj hρ_psd * CFC.sqrt ρ) * V := by rw [hVVt]
+    _ = Vᴴ * (CFC.sqrt ρ * CFC.sqrt ρ) * V := by
+        rw [cfc_sqrt_mul_stationaryProj hρ_psd]
+    _ = Vᴴ * ρ * V := by rw [CFC.sqrt_mul_sqrt_self ρ hρ_psd.nonneg]
+
+/-! ## Compression of the weighted fixed-point condition to the support sector -/
+
+/-- Compression onto the support sector, packaged for the weighted corner statements: a
+trace-preserving compressed family with a positive definite fixed point, the compression
+identity for the square root, the transport identity for conjugation by the square root,
+and the correspondence between the ambient and compressed fixed-point equations for
+corner-supported matrices. -/
+private theorem exists_weighted_compression
+    (K : Fin d → Mat) (h_tp : IsTP K) {ρ : Mat} (hρ_psd : ρ.PosSemidef)
+    (hρ_fix : map K ρ = ρ) :
+    ∃ (r : ℕ) (C : Fin d → Matrix (Fin r) (Fin r) ℂ) (V : Matrix (Fin D) (Fin r) ℂ)
+      (σ : Matrix (Fin r) (Fin r) ℂ),
+      IsTP C ∧ σ.PosDef ∧ map C σ = σ ∧ Vᴴ * V = 1 ∧
+        V * Vᴴ = stationaryProj hρ_psd ∧
+        CFC.sqrt σ = Vᴴ * CFC.sqrt ρ * V ∧
+        (∀ Y : Mat, stationaryProj hρ_psd * Y * stationaryProj hρ_psd = Y →
+          CFC.sqrt σ * (Vᴴ * Y * V) * CFC.sqrt σ =
+            Vᴴ * (CFC.sqrt ρ * Y * CFC.sqrt ρ) * V) ∧
+        ∀ W : Mat, stationaryProj hρ_psd * W * stationaryProj hρ_psd = W →
+          (map K W = W ↔ map C (Vᴴ * W * V) = Vᴴ * W * V) := by
+  classical
+  set Q : Mat := stationaryProj hρ_psd with hQdef
+  have hQproj : IsOrthogonalProjection Q := isOrthogonalProjection_stationaryProj hρ_psd
+  have hQidem : Q * Q = Q := hQproj.2
+  have hQherm : Qᴴ = Q := hQproj.1.eq
+  have hInv : ∀ i : Fin d, (1 - Q) * K i * Q = 0 :=
+    stationaryProj_lowerZero K hρ_psd hρ_fix
+  have hQρ : Q * ρ = ρ := MPSTensor.supportProj_mul (D := D) (ρ := ρ) hρ_psd
+  have hρQ : ρ * Q = ρ := MPSTensor.mul_supportProj (D := D) (ρ := ρ) hρ_psd
+  have hQρQ : Q * ρ * Q = ρ := by rw [hQρ, hρQ]
+  set A : Fin d → Mat := cornerCompressionKraus K Q with hAdef
+  have hAsupp : ∀ i : Fin d, Q * A i * Q = A i :=
+    cornerCompressionKraus_supported K hQproj
+  have hAtp : ∑ i : Fin d, (A i)ᴴ * A i = Q :=
+    cornerCompressionKraus_isTP K h_tp hQproj hInv
+  obtain ⟨r, C, φ, V, -, hCtp, -, -, -, -, hLetter, hVtV, hVVt, hφV⟩ :=
+    MPSTensor.exists_compressedTensor_of_supported_projection_with_letter_and_isometry
+      A Q hQproj hAsupp hAtp
+  have hCtp' : IsTP C := hCtp
+  have hCi : ∀ i : Fin d, C i = Vᴴ * A i * V := by
+    intro i
+    have h : V * C i * Vᴴ = A i := by simpa [hφV] using hLetter i
+    calc
+      C i = (Vᴴ * V) * C i * (Vᴴ * V) := by rw [hVtV]; simp
+      _ = Vᴴ * (V * C i * Vᴴ) * V := by simp [Matrix.mul_assoc]
+      _ = Vᴴ * A i * V := by rw [h]
+  set σ : Matrix (Fin r) (Fin r) ℂ := Vᴴ * ρ * V with hσdef
+  have hσpd : σ.PosDef := by
+    have := Matrix.PosSemidef.compression_on_support_posDef (D := D) (ρ := ρ) hρ_psd
+      (k := r) (V := Vᴴ) (by simpa [Matrix.conjTranspose_conjTranspose] using hVtV)
+      (by simpa [hQdef, stationaryProj, Matrix.conjTranspose_conjTranspose] using hVVt)
+    simpa [hσdef, Matrix.conjTranspose_conjTranspose] using this
+  have hσfix : map C σ = σ := by
+    have hmapA : map A ρ = ρ := by
+      have heq : map A ρ = Q * map K ρ * Q := by
+        rw [hAdef]; exact map_cornerCompressionKraus_eq K hQproj (Z := ρ) hQρQ
+      rw [heq, hρ_fix, hQρQ]
+    have hterm : ∀ i : Fin d,
+        C i * σ * (C i)ᴴ = Vᴴ * (A i * ρ * (A i)ᴴ) * V := by
+      intro i
+      have hCiH : (C i)ᴴ = Vᴴ * (A i)ᴴ * V := by
+        rw [hCi i]
+        simp [Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose, Matrix.mul_assoc]
+      rw [hCiH, hCi i, hσdef]
+      calc
+        Vᴴ * A i * V * (Vᴴ * ρ * V) * (Vᴴ * (A i)ᴴ * V)
+            = Vᴴ * (A i * (V * Vᴴ) * ρ * (V * Vᴴ) * (A i)ᴴ) * V := by
+              simp [Matrix.mul_assoc]
+        _ = Vᴴ * (A i * Q * ρ * Q * (A i)ᴴ) * V := by rw [hVVt]
+        _ = Vᴴ * (A i * (Q * ρ * Q) * (A i)ᴴ) * V := by simp [Matrix.mul_assoc]
+        _ = Vᴴ * (A i * ρ * (A i)ᴴ) * V := by rw [hQρQ]
+    calc
+      map C σ = ∑ i : Fin d, C i * σ * (C i)ᴴ := by rw [map_apply]
+      _ = ∑ i : Fin d, Vᴴ * (A i * ρ * (A i)ᴴ) * V :=
+          Finset.sum_congr rfl (fun i _ => hterm i)
+      _ = Vᴴ * (∑ i : Fin d, A i * ρ * (A i)ᴴ) * V := by
+          rw [Matrix.mul_sum, Matrix.sum_mul]
+      _ = Vᴴ * map A ρ * V := by rw [map_apply]
+      _ = σ := by rw [hmapA, hσdef]
+  -- The square root compresses along the isometry.
+  have hs : CFC.sqrt σ = Vᴴ * CFC.sqrt ρ * V := by
+    rw [hσdef]
+    exact cfc_sqrt_compression hρ_psd hVVt
+  -- The transport identity for conjugation by the square root.
+  have htrans : ∀ Y : Mat, Q * Y * Q = Y →
+      CFC.sqrt σ * (Vᴴ * Y * V) * CFC.sqrt σ =
+        Vᴴ * (CFC.sqrt ρ * Y * CFC.sqrt ρ) * V := by
+    intro Y hY
+    rw [hs]
+    calc (Vᴴ * CFC.sqrt ρ * V) * (Vᴴ * Y * V) * (Vᴴ * CFC.sqrt ρ * V)
+        = Vᴴ * (CFC.sqrt ρ * ((V * Vᴴ) * Y * (V * Vᴴ)) * CFC.sqrt ρ) * V := by
+          simp [Matrix.mul_assoc]
+      _ = Vᴴ * (CFC.sqrt ρ * (Q * Y * Q) * CFC.sqrt ρ) * V := by rw [hVVt]
+      _ = Vᴴ * (CFC.sqrt ρ * Y * CFC.sqrt ρ) * V := by rw [hY]
+  -- The corner-supported ambient fixed-point equation corresponds to the compressed one.
+  have hQV : Q * V = V := by
+    calc Q * V = (V * Vᴴ) * V := by rw [hVVt]
+      _ = V * (Vᴴ * V) := by rw [Matrix.mul_assoc]
+      _ = V := by rw [hVtV, Matrix.mul_one]
+  have hVQ : Vᴴ * Q = Vᴴ := by
+    calc Vᴴ * Q = Vᴴ * (V * Vᴴ) := by rw [hVVt]
+      _ = (Vᴴ * V) * Vᴴ := by rw [← Matrix.mul_assoc]
+      _ = Vᴴ := by rw [hVtV, Matrix.one_mul]
+  have hKQ : ∀ i : Fin d, K i * Q = Q * K i * Q := by
+    intro i
+    have h := hInv i
+    rw [Matrix.sub_mul, Matrix.sub_mul, Matrix.one_mul, sub_eq_zero] at h
+    exact h
+  have hQKH : ∀ i : Fin d, Q * (K i)ᴴ = Q * (K i)ᴴ * Q := by
+    intro i
+    have h := congrArg Matrix.conjTranspose (hKQ i)
+    simpa [Matrix.conjTranspose_mul, hQherm, Matrix.mul_assoc] using h
+  have hmapK_corner : ∀ W : Mat, Q * W * Q = W → Q * map K W * Q = map K W := by
+    intro W hW
+    have hterm : ∀ i : Fin d,
+        K i * W * (K i)ᴴ = Q * (K i * W * (K i)ᴴ) * Q := by
+      intro i
+      conv_lhs => rw [← hW]
+      calc K i * (Q * W * Q) * (K i)ᴴ
+          = (K i * Q) * W * (Q * (K i)ᴴ) := by simp [Matrix.mul_assoc]
+        _ = (Q * K i * Q) * W * (Q * (K i)ᴴ * Q) := by
+            conv_lhs => rw [hKQ i, hQKH i]
+        _ = Q * (K i * (Q * W * Q) * (K i)ᴴ) * Q := by simp [Matrix.mul_assoc]
+        _ = Q * (K i * W * (K i)ᴴ) * Q := by rw [hW]
+    calc Q * map K W * Q
+        = Q * (∑ i : Fin d, K i * W * (K i)ᴴ) * Q := by rw [map_apply]
+      _ = ∑ i : Fin d, Q * (K i * W * (K i)ᴴ) * Q := by
+          rw [Matrix.mul_sum, Matrix.sum_mul]
+      _ = ∑ i : Fin d, K i * W * (K i)ᴴ :=
+          Finset.sum_congr rfl fun i _ => (hterm i).symm
+      _ = map K W := by rw [map_apply]
+  have hmapC : ∀ Z : Matrix (Fin r) (Fin r) ℂ,
+      map C Z = Vᴴ * map A (V * Z * Vᴴ) * V := by
+    intro Z
+    calc map C Z = ∑ i : Fin d, C i * Z * (C i)ᴴ := by rw [map_apply]
+      _ = ∑ i : Fin d, Vᴴ * (A i * (V * Z * Vᴴ) * (A i)ᴴ) * V := by
+          refine Finset.sum_congr rfl fun i _ => ?_
+          have hCiH : (C i)ᴴ = Vᴴ * (A i)ᴴ * V := by
+            rw [hCi i]
+            simp [Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose,
+              Matrix.mul_assoc]
+          rw [hCiH, hCi i]
+          simp [Matrix.mul_assoc]
+      _ = Vᴴ * (∑ i : Fin d, A i * (V * Z * Vᴴ) * (A i)ᴴ) * V := by
+          rw [Matrix.mul_sum, Matrix.sum_mul]
+      _ = Vᴴ * map A (V * Z * Vᴴ) * V := by rw [map_apply]
+  have hcorrS : ∀ W : Mat, Q * W * Q = W →
+      (map K W = W ↔ map C (Vᴴ * W * V) = Vᴴ * W * V) := by
+    intro W hW
+    have hVWV : V * (Vᴴ * W * V) * Vᴴ = W := by
+      calc V * (Vᴴ * W * V) * Vᴴ = (V * Vᴴ) * W * (V * Vᴴ) := by simp [Matrix.mul_assoc]
+        _ = Q * W * Q := by rw [hVVt]
+        _ = W := hW
+    have hmapCW : map C (Vᴴ * W * V) = Vᴴ * map K W * V := by
+      rw [hmapC, hVWV, hAdef, map_cornerCompressionKraus_eq K hQproj hW]
+      calc Vᴴ * (Q * map K W * Q) * V
+          = (Vᴴ * Q) * map K W * (Q * V) := by simp [Matrix.mul_assoc]
+        _ = Vᴴ * map K W * V := by rw [hVQ, hQV]
+    constructor
+    · intro h
+      rw [hmapCW, h]
+    · intro h
+      have h2 : Q * map K W * Q = W := by
+        calc Q * map K W * Q
+            = (V * Vᴴ) * map K W * (V * Vᴴ) := by rw [hVVt]
+          _ = V * (Vᴴ * map K W * V) * Vᴴ := by simp [Matrix.mul_assoc]
+          _ = V * (Vᴴ * W * V) * Vᴴ := by rw [← hmapCW, h]
+          _ = W := hVWV
+      rw [← hmapK_corner W hW]
+      exact h2
+  exact ⟨r, C, V, σ, hCtp', hσpd, hσfix, hVtV, hVVt, hs, htrans, hcorrS⟩
+
+/-! ## The weighted corner fixed-point star-algebra -/
+
+/-- Multiplication closure of the weighted corner fixed points: if $Y_1$ and $Y_2$ are
+supported on the support of $\rho$ and $\sqrt{\rho}\, Y_j \sqrt{\rho}$ is fixed by the
+map, then the same holds for $Y_1 Y_2$. Proved by compressing to the support sector, where
+the fixed point is positive definite and the weighted fixed points form a star-subalgebra
+in the sense of the positive definite case of Corollary 6.7 of
+*Quantum Channels & Operations* (Wolf 2012). -/
+theorem weightedCornerFixed_mul
+    (K : Fin d → Mat) (h_tp : IsTP K) {ρ : Mat} (hρ_psd : ρ.PosSemidef)
+    (hρ_fix : map K ρ = ρ) {Y₁ Y₂ : Mat}
+    (hY₁mem : stationaryProj hρ_psd * Y₁ * stationaryProj hρ_psd = Y₁)
+    (hY₂mem : stationaryProj hρ_psd * Y₂ * stationaryProj hρ_psd = Y₂)
+    (hY₁ : map K (CFC.sqrt ρ * Y₁ * CFC.sqrt ρ) = CFC.sqrt ρ * Y₁ * CFC.sqrt ρ)
+    (hY₂ : map K (CFC.sqrt ρ * Y₂ * CFC.sqrt ρ) = CFC.sqrt ρ * Y₂ * CFC.sqrt ρ) :
+    map K (CFC.sqrt ρ * (Y₁ * Y₂) * CFC.sqrt ρ) =
+      CFC.sqrt ρ * (Y₁ * Y₂) * CFC.sqrt ρ := by
+  classical
+  obtain ⟨r, C, V, σ, hCtp, hσpd, hσfix, hVtV, hVVt, hs, htrans, hcorrS⟩ :=
+    exists_weighted_compression K h_tp hρ_psd hρ_fix
+  set Q : Mat := stationaryProj hρ_psd with hQdef
+  have hQidem : Q * Q = Q := (isOrthogonalProjection_stationaryProj hρ_psd).2
+  -- One-sided corner absorptions for the two factors.
+  have hQY₁ : Q * Y₁ = Y₁ := by
+    conv_lhs => rw [← hY₁mem]
+    rw [← Matrix.mul_assoc, ← Matrix.mul_assoc, hQidem]
+    exact hY₁mem
+  have hY₂Q : Y₂ * Q = Y₂ := by
+    conv_lhs => rw [← hY₂mem]
+    rw [Matrix.mul_assoc, hQidem]
+    exact hY₂mem
+  have hY₁Q : Y₁ * Q = Y₁ := by
+    conv_lhs => rw [← hY₁mem]
+    rw [Matrix.mul_assoc, hQidem]
+    exact hY₁mem
+  have hprodmem : Q * (Y₁ * Y₂) * Q = Y₁ * Y₂ := by
+    calc Q * (Y₁ * Y₂) * Q = (Q * Y₁) * (Y₂ * Q) := by simp [Matrix.mul_assoc]
+      _ = Y₁ * Y₂ := by rw [hQY₁, hY₂Q]
+  -- Sector membership of the compressed factors in the weighted algebra.
+  have hmem : ∀ Y : Mat, Q * Y * Q = Y →
+      map K (CFC.sqrt ρ * Y * CFC.sqrt ρ) = CFC.sqrt ρ * Y * CFC.sqrt ρ →
+      Vᴴ * Y * V ∈ weightedFixedPointsStarSubalgebra (K := C) hCtp hσpd hσfix := by
+    intro Y hYmem hYfix
+    rw [mem_weightedFixedPointsStarSubalgebra_iff, htrans Y hYmem]
+    exact (hcorrS _ (sqrt_conj_supported hρ_psd Y)).mp hYfix
+  have hZmul :=
+    (weightedFixedPointsStarSubalgebra (K := C) hCtp hσpd hσfix).mul_mem
+      (hmem Y₁ hY₁mem hY₁) (hmem Y₂ hY₂mem hY₂)
+  have hZZ : (Vᴴ * Y₁ * V) * (Vᴴ * Y₂ * V) = Vᴴ * (Y₁ * Y₂) * V := by
+    calc (Vᴴ * Y₁ * V) * (Vᴴ * Y₂ * V)
+        = Vᴴ * (Y₁ * (V * Vᴴ) * Y₂) * V := by simp [Matrix.mul_assoc]
+      _ = Vᴴ * (Y₁ * Q * Y₂) * V := by rw [hVVt]
+      _ = Vᴴ * (Y₁ * Y₂) * V := by rw [hY₁Q]
+  rw [hZZ] at hZmul
+  have hfix :=
+    (mem_weightedFixedPointsStarSubalgebra_iff (K := C) hCtp hσpd hσfix _).mp hZmul
+  rw [htrans (Y₁ * Y₂) hprodmem] at hfix
+  exact (hcorrS _ (sqrt_conj_supported hρ_psd (Y₁ * Y₂))).mpr hfix
+
+/-- **The weighted corner fixed points form a star-algebra** (Corollary 6.7 of
+*Quantum Channels & Operations* (Wolf 2012), restricted to corner-supported fixed
+points). Let $T(X) = \sum_i K_i X K_i^\dagger$ be trace-preserving, let $\rho \succeq 0$
+satisfy $T(\rho) = \rho$, and let $Q$ be the support projection of $\rho$. The corner
+elements $Y$ (with $Q Y Q = Y$) such that $\sqrt{\rho}\, Y \sqrt{\rho}$ is fixed by $T$
+form a star-subalgebra of the corner algebra $Q M_D(\mathbb{C}) Q$. Under conjugation by
+$\sqrt{\rho}$ this carrier corresponds exactly to the fixed points of $T$ supported on
+the support of $\rho$ (`Kraus.exists_weightedCorner_sqrt_eq_of_fixedPoint`), so it
+realizes the set $\rho^{-1/2}\{X \mid T(X) = X,\ Q X Q = X\}\rho^{-1/2}$ of the
+corollary, with the inverse square root taken on the support of $\rho$.
+
+**Scope restriction (corner-supported fixed points):** the corollary in the reference
+takes a maximum-rank fixed point, for which every fixed point of $T$ is supported on the
+support of $\rho$ and the corner restriction disappears; that maximal-support property is
+not yet formalized. Documented in
+`docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex`. -/
+noncomputable def weightedCornerFixedPointsStarSubalgebra
+    (K : Fin d → Mat) (h_tp : IsTP K) {ρ : Mat} (hρ_psd : ρ.PosSemidef)
+    (hρ_fix : map K ρ = ρ) :
+    letI hQ : IsIdempotentElem (stationaryProj hρ_psd) :=
+      (isOrthogonalProjection_stationaryProj hρ_psd).2
+    letI : Star hQ.Corner := MatrixCorner.cornerStar hQ
+      (isOrthogonalProjection_stationaryProj hρ_psd).1.eq
+    letI : StarRing hQ.Corner := MatrixCorner.cornerStarRing hQ
+      (isOrthogonalProjection_stationaryProj hρ_psd).1.eq
+    letI : StarModule ℂ hQ.Corner := MatrixCorner.cornerStarModuleComplex hQ
+      (isOrthogonalProjection_stationaryProj hρ_psd).1.eq
+    StarSubalgebra ℂ hQ.Corner :=
+  letI hQ : IsIdempotentElem (stationaryProj hρ_psd) :=
+    (isOrthogonalProjection_stationaryProj hρ_psd).2
+  letI : Star hQ.Corner := MatrixCorner.cornerStar hQ
+    (isOrthogonalProjection_stationaryProj hρ_psd).1.eq
+  letI : StarRing hQ.Corner := MatrixCorner.cornerStarRing hQ
+    (isOrthogonalProjection_stationaryProj hρ_psd).1.eq
+  letI : StarModule ℂ hQ.Corner := MatrixCorner.cornerStarModuleComplex hQ
+    (isOrthogonalProjection_stationaryProj hρ_psd).1.eq
+  let Q : Mat := stationaryProj hρ_psd
+  have hS_herm : (CFC.sqrt ρ)ᴴ = CFC.sqrt ρ := MPSTensor.conjTranspose_cfc_sqrt (D := D) ρ
+  have hSρS : CFC.sqrt ρ * Q * CFC.sqrt ρ = ρ := by
+    rw [show CFC.sqrt ρ * Q * CFC.sqrt ρ = (CFC.sqrt ρ * Q) * CFC.sqrt ρ from rfl,
+      cfc_sqrt_mul_stationaryProj hρ_psd, CFC.sqrt_mul_sqrt_self ρ hρ_psd.nonneg]
+  { carrier := {Y : hQ.Corner |
+      map K (CFC.sqrt ρ * Y.1 * CFC.sqrt ρ) = CFC.sqrt ρ * Y.1 * CFC.sqrt ρ}
+    zero_mem' := by
+      show map K (CFC.sqrt ρ * (0 : hQ.Corner).1 * CFC.sqrt ρ) = _
+      show map K (CFC.sqrt ρ * (0 : Mat) * CFC.sqrt ρ) = CFC.sqrt ρ * (0 : Mat) * CFC.sqrt ρ
+      simp [map]
+    add_mem' := by
+      intro X Y hX hY
+      show map K (CFC.sqrt ρ * (X.1 + Y.1) * CFC.sqrt ρ) =
+        CFC.sqrt ρ * (X.1 + Y.1) * CFC.sqrt ρ
+      rw [Matrix.mul_add, Matrix.add_mul, map_add, hX, hY]
+    one_mem' := by
+      show map K (CFC.sqrt ρ * (1 : hQ.Corner).1 * CFC.sqrt ρ) = _
+      show map K (CFC.sqrt ρ * Q * CFC.sqrt ρ) = CFC.sqrt ρ * Q * CFC.sqrt ρ
+      rw [hSρS]
+      exact hρ_fix
+    mul_mem' := by
+      intro X Y hX hY
+      show map K (CFC.sqrt ρ * (X.1 * Y.1) * CFC.sqrt ρ) =
+        CFC.sqrt ρ * (X.1 * Y.1) * CFC.sqrt ρ
+      have hXmem : Q * X.1 * Q = X.1 := by
+        obtain ⟨hL, hR⟩ := (Subsemigroup.mem_corner_iff hQ).mp X.2
+        rw [Matrix.mul_assoc, hR, hL]
+      have hYmem : Q * Y.1 * Q = Y.1 := by
+        obtain ⟨hL, hR⟩ := (Subsemigroup.mem_corner_iff hQ).mp Y.2
+        rw [Matrix.mul_assoc, hR, hL]
+      exact weightedCornerFixed_mul K h_tp hρ_psd hρ_fix hXmem hYmem hX hY
+    algebraMap_mem' := by
+      intro c
+      show map K (CFC.sqrt ρ * (algebraMap ℂ hQ.Corner c).1 * CFC.sqrt ρ) = _
+      show map K (CFC.sqrt ρ * (c • Q) * CFC.sqrt ρ) = CFC.sqrt ρ * (c • Q) * CFC.sqrt ρ
+      have hsmul : CFC.sqrt ρ * (c • Q) * CFC.sqrt ρ = c • ρ := by
+        rw [Matrix.mul_smul, Matrix.smul_mul, hSρS]
+      rw [hsmul, map_smul, hρ_fix]
+    star_mem' := by
+      intro X hX
+      show map K (CFC.sqrt ρ * (star X).1 * CFC.sqrt ρ) = _
+      show map K (CFC.sqrt ρ * X.1ᴴ * CFC.sqrt ρ) = CFC.sqrt ρ * X.1ᴴ * CFC.sqrt ρ
+      have hconj : CFC.sqrt ρ * X.1ᴴ * CFC.sqrt ρ = (CFC.sqrt ρ * X.1 * CFC.sqrt ρ)ᴴ := by
+        rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_mul, hS_herm, Matrix.mul_assoc]
+      rw [hconj]
+      exact conjTranspose_mem_fixedPoints (K := K) hX }
+
+/-- Membership in the weighted corner fixed-point star-algebra: a corner element $Y$ lies
+in it exactly when $\sqrt{\rho}\, Y \sqrt{\rho}$ is fixed by the map. -/
+@[simp] theorem mem_weightedCornerFixedPointsStarSubalgebra
+    (K : Fin d → Mat) (h_tp : IsTP K) {ρ : Mat} (hρ_psd : ρ.PosSemidef)
+    (hρ_fix : map K ρ = ρ)
+    (hQ : IsIdempotentElem (stationaryProj hρ_psd) :=
+      (isOrthogonalProjection_stationaryProj hρ_psd).2)
+    (Y : hQ.Corner) :
+    letI : Star hQ.Corner := MatrixCorner.cornerStar hQ
+      (isOrthogonalProjection_stationaryProj hρ_psd).1.eq
+    letI : StarRing hQ.Corner := MatrixCorner.cornerStarRing hQ
+      (isOrthogonalProjection_stationaryProj hρ_psd).1.eq
+    letI : StarModule ℂ hQ.Corner := MatrixCorner.cornerStarModuleComplex hQ
+      (isOrthogonalProjection_stationaryProj hρ_psd).1.eq
+    Y ∈ weightedCornerFixedPointsStarSubalgebra K h_tp hρ_psd hρ_fix ↔
+      map K (CFC.sqrt ρ * Y.1 * CFC.sqrt ρ) = CFC.sqrt ρ * Y.1 * CFC.sqrt ρ :=
+  Iff.rfl
+
+/-- **Conjugation by the square root is onto the corner-supported fixed points.** Every
+fixed point $X$ of the map that is supported on the support of $\rho$ arises as
+$X = \sqrt{\rho}\, Y \sqrt{\rho}$ for a corner-supported $Y$ whose class lies in the
+weighted corner fixed-point star-algebra. Together with
+`Kraus.mem_weightedCornerFixedPointsStarSubalgebra` this identifies the carrier of the
+star-algebra with the set $\rho^{-1/2}\{X \mid T(X) = X,\ Q X Q = X\}\rho^{-1/2}$ of
+Corollary 6.7 of *Quantum Channels & Operations* (Wolf 2012), with the inverse square
+root taken on the support of $\rho$. -/
+theorem exists_weightedCorner_sqrt_eq_of_fixedPoint
+    (K : Fin d → Mat) (h_tp : IsTP K) {ρ : Mat} (hρ_psd : ρ.PosSemidef)
+    (hρ_fix : map K ρ = ρ) {X : Mat} (hX_fix : map K X = X)
+    (hX_supp : stationaryProj hρ_psd * X * stationaryProj hρ_psd = X) :
+    ∃ Y : Mat, stationaryProj hρ_psd * Y * stationaryProj hρ_psd = Y ∧
+      map K (CFC.sqrt ρ * Y * CFC.sqrt ρ) = CFC.sqrt ρ * Y * CFC.sqrt ρ ∧
+      CFC.sqrt ρ * Y * CFC.sqrt ρ = X := by
+  classical
+  obtain ⟨r, C, V, σ, hCtp, hσpd, hσfix, hVtV, hVVt, hs, htrans, hcorrS⟩ :=
+    exists_weighted_compression K h_tp hρ_psd hρ_fix
+  set Q : Mat := stationaryProj hρ_psd with hQdef
+  set s : Matrix (Fin r) (Fin r) ℂ := CFC.sqrt σ with hsdef
+  have hs_det : IsUnit s.det := MPSTensor.isUnit_det_cfc_sqrt_of_posDef (D := r) σ hσpd
+  have hs_inv_mul : s⁻¹ * s = 1 := Matrix.nonsing_inv_mul s hs_det
+  have hs_mul_inv : s * s⁻¹ = 1 := Matrix.mul_nonsing_inv s hs_det
+  -- The candidate corner element, built on the support sector.
+  set Z : Matrix (Fin r) (Fin r) ℂ := s⁻¹ * (Vᴴ * X * V) * s⁻¹ with hZdef
+  set Y : Mat := V * Z * Vᴴ with hYdef
+  have hYmem : Q * Y * Q = Y := by
+    calc Q * (V * Z * Vᴴ) * Q = (Q * V) * Z * (Vᴴ * Q) := by simp [Matrix.mul_assoc]
+      _ = ((V * Vᴴ) * V) * Z * (Vᴴ * (V * Vᴴ)) := by rw [hVVt]
+      _ = (V * (Vᴴ * V)) * Z * ((Vᴴ * V) * Vᴴ) := by simp [Matrix.mul_assoc]
+      _ = V * Z * Vᴴ := by rw [hVtV]; simp
+  have hVYV : Vᴴ * Y * V = Z := by
+    calc Vᴴ * (V * Z * Vᴴ) * V = (Vᴴ * V) * Z * (Vᴴ * V) := by simp [Matrix.mul_assoc]
+      _ = Z := by rw [hVtV]; simp
+  have hsZs : s * Z * s = Vᴴ * X * V := by
+    calc s * (s⁻¹ * (Vᴴ * X * V) * s⁻¹) * s
+        = (s * s⁻¹) * (Vᴴ * X * V) * (s⁻¹ * s) := by simp [Matrix.mul_assoc]
+      _ = Vᴴ * X * V := by rw [hs_mul_inv, hs_inv_mul]; simp
+  -- The conjugate of `Y` by the square root recovers `X`.
+  have hsqrtY : CFC.sqrt ρ * Y * CFC.sqrt ρ = X := by
+    have h1 : Vᴴ * (CFC.sqrt ρ * Y * CFC.sqrt ρ) * V = Vᴴ * X * V := by
+      rw [← htrans Y hYmem, hVYV]
+      exact hsZs
+    calc CFC.sqrt ρ * Y * CFC.sqrt ρ
+        = Q * (CFC.sqrt ρ * Y * CFC.sqrt ρ) * Q := (sqrt_conj_supported hρ_psd Y).symm
+      _ = (V * Vᴴ) * (CFC.sqrt ρ * Y * CFC.sqrt ρ) * (V * Vᴴ) := by rw [hVVt]
+      _ = V * (Vᴴ * (CFC.sqrt ρ * Y * CFC.sqrt ρ) * V) * Vᴴ := by
+          simp [Matrix.mul_assoc]
+      _ = V * (Vᴴ * X * V) * Vᴴ := by rw [h1]
+      _ = (V * Vᴴ) * X * (V * Vᴴ) := by simp [Matrix.mul_assoc]
+      _ = Q * X * Q := by rw [hVVt]
+      _ = X := hX_supp
+  exact ⟨Y, hYmem, by rw [hsqrtY]; exact hX_fix, hsqrtY⟩
+
+end Kraus

--- a/TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean
+++ b/TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean
@@ -60,7 +60,7 @@ local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
 
 /-- The support projection absorbs the square root from the left:
 $Q \sqrt{\rho} = \sqrt{\rho}$. -/
-private theorem stationaryProj_mul_cfc_sqrt {ρ : Mat} (hρ_psd : ρ.PosSemidef) :
+theorem stationaryProj_mul_cfc_sqrt {ρ : Mat} (hρ_psd : ρ.PosSemidef) :
     stationaryProj hρ_psd * CFC.sqrt ρ = CFC.sqrt ρ := by
   set Q : Mat := stationaryProj hρ_psd with hQdef
   set S : Mat := CFC.sqrt ρ with hSdef
@@ -85,7 +85,7 @@ private theorem stationaryProj_mul_cfc_sqrt {ρ : Mat} (hρ_psd : ρ.PosSemidef)
 
 /-- The support projection absorbs the square root from the right:
 $\sqrt{\rho}\, Q = \sqrt{\rho}$. -/
-private theorem cfc_sqrt_mul_stationaryProj {ρ : Mat} (hρ_psd : ρ.PosSemidef) :
+theorem cfc_sqrt_mul_stationaryProj {ρ : Mat} (hρ_psd : ρ.PosSemidef) :
     CFC.sqrt ρ * stationaryProj hρ_psd = CFC.sqrt ρ := by
   have hQherm : (stationaryProj hρ_psd)ᴴ = stationaryProj hρ_psd :=
     (isOrthogonalProjection_stationaryProj hρ_psd).1.eq
@@ -95,7 +95,7 @@ private theorem cfc_sqrt_mul_stationaryProj {ρ : Mat} (hρ_psd : ρ.PosSemidef)
 
 /-- Conjugation by $\sqrt{\rho}$ lands in the corner: the matrix
 $\sqrt{\rho}\, Y \sqrt{\rho}$ is supported on the support of $\rho$. -/
-private theorem sqrt_conj_supported {ρ : Mat} (hρ_psd : ρ.PosSemidef) (Y : Mat) :
+theorem sqrt_conj_supported {ρ : Mat} (hρ_psd : ρ.PosSemidef) (Y : Mat) :
     stationaryProj hρ_psd * (CFC.sqrt ρ * Y * CFC.sqrt ρ) * stationaryProj hρ_psd =
       CFC.sqrt ρ * Y * CFC.sqrt ρ := by
   calc stationaryProj hρ_psd * (CFC.sqrt ρ * Y * CFC.sqrt ρ) * stationaryProj hρ_psd
@@ -107,7 +107,7 @@ private theorem sqrt_conj_supported {ρ : Mat} (hρ_psd : ρ.PosSemidef) (Y : Ma
 /-- The square root compresses along an isometry onto the support:
 $\sqrt{V^{\dagger} \rho V} = V^{\dagger} \sqrt{\rho}\, V$ for $V$ with
 $V^{\dagger} V = \mathbf{1}$ and $V V^{\dagger} = Q$ the support projection of $\rho$. -/
-private theorem cfc_sqrt_compression {ρ : Mat} (hρ_psd : ρ.PosSemidef)
+theorem cfc_sqrt_compression {ρ : Mat} (hρ_psd : ρ.PosSemidef)
     {r : ℕ} {V : Matrix (Fin D) (Fin r) ℂ}
     (hVVt : V * Vᴴ = stationaryProj hρ_psd) :
     CFC.sqrt (Vᴴ * ρ * V) = Vᴴ * CFC.sqrt ρ * V := by
@@ -123,7 +123,7 @@ private theorem cfc_sqrt_compression {ρ : Mat} (hρ_psd : ρ.PosSemidef)
 
 /-! ## Compression of the weighted fixed-point condition to the support sector -/
 
-/-- Compression onto the support sector, packaged for the weighted corner statements: a
+/-- Compression onto the support sector for the weighted corner statements: a
 trace-preserving compressed family with a positive definite fixed point, the compression
 identity for the square root, the transport identity for conjugation by the square root,
 and the correspondence between the ambient and compressed fixed-point equations for

--- a/TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean
+++ b/TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean
@@ -8,8 +8,9 @@ import TNLean.Channel.FixedPoint.Corollaries
 /-!
 # Weighted corner fixed points of a Kraus map with a singular fixed point
 
-This file extends Corollary 6.7 of *Quantum Channels & Operations* (Wolf 2012) beyond the
-positive definite case formalized in `TNLean.Channel.FixedPoint.Corollaries`. Let $T$ be a
+The following results extend Corollary 6.7 of *Quantum Channels & Operations* (Wolf 2012)
+beyond the positive definite case formalized in `TNLean.Channel.FixedPoint.Corollaries`.
+Let $T$ be a
 trace-preserving Kraus map, let $\rho$ be a positive semidefinite fixed point of $T$ —
 possibly singular — and let $Q$ be the support projection of $\rho$. The set
 $$\rho^{-1/2}\,\{X \mid T(X) = X,\ Q X Q = X\}\,\rho^{-1/2},$$

--- a/TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean
+++ b/TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean
@@ -9,7 +9,7 @@ import TNLean.Channel.FixedPoint.Corollaries
 # Weighted corner fixed points of a Kraus map with a singular fixed point
 
 The following results extend Corollary 6.7 of *Quantum Channels & Operations* (Wolf 2012)
-beyond the positive definite case formalized in `TNLean.Channel.FixedPoint.Corollaries`.
+beyond the positive definite case of `TNLean.Channel.FixedPoint.Corollaries`.
 Let $T$ be a
 trace-preserving Kraus map, let $\rho$ be a positive semidefinite fixed point of $T$ —
 possibly singular — and let $Q$ be the support projection of $\rho$. The set
@@ -25,11 +25,11 @@ support of $\rho$, which realizes the displayed set without naming the pseudo-in
 density matrix and conjugates the full fixed-point set of $T$. For a maximum-rank fixed
 point every fixed point of $T$ is supported on the support of $\rho$, so the corner
 restriction is vacuous; that maximal-support property (the proposition on maximal support
-of fixed points in Section 6.4 of the reference) is not yet formalized, and the present
-statements restrict to the fixed points supported on the support of $\rho$ instead.
-Documented in `docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex`. Elimination:
-formalize the maximal-support proposition and instantiate these statements at a
-maximum-rank fixed point.
+of fixed points in Section 6.4 of the reference) remains to be established here, and the
+present statements restrict to the fixed points supported on the support of $\rho$
+instead. Documented in `docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex`.
+Elimination: establish the maximal-support proposition and instantiate these statements
+at a maximum-rank fixed point.
 
 The proofs compress to the support sector, where the compressed fixed point is positive
 definite and the positive definite case applies, and transport the structure back along
@@ -365,8 +365,8 @@ corollary, with the inverse square root taken on the support of $\rho$.
 
 **Scope restriction (corner-supported fixed points):** the corollary in the reference
 takes a maximum-rank fixed point, for which every fixed point of $T$ is supported on the
-support of $\rho$ and the corner restriction disappears; that maximal-support property is
-not yet formalized. Documented in
+support of $\rho$ and the corner restriction disappears; that maximal-support property
+remains to be established here. Documented in
 `docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex`. -/
 noncomputable def weightedCornerFixedPointsStarSubalgebra
     (K : Fin d → Mat) (h_tp : IsTP K) {ρ : Mat} (hρ_psd : ρ.PosSemidef)

--- a/TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean
+++ b/TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean
@@ -457,9 +457,9 @@ in it exactly when $\sqrt{\rho}\, Y \sqrt{\rho}$ is fixed by the map. -/
 /-- **Conjugation by the square root is onto the corner-supported fixed points.** Every
 fixed point $X$ of the map that is supported on the support of $\rho$ arises as
 $X = \sqrt{\rho}\, Y \sqrt{\rho}$ for a corner-supported $Y$ whose class lies in the
-weighted corner fixed-point star-algebra. Together with
-`Kraus.mem_weightedCornerFixedPointsStarSubalgebra` this identifies the carrier of the
-star-algebra with the set $\rho^{-1/2}\{X \mid T(X) = X,\ Q X Q = X\}\rho^{-1/2}$ of
+weighted corner fixed-point star-algebra. Together with the membership description of
+the star-algebra (`Kraus.mem_weightedCornerFixedPointsStarSubalgebra`) this identifies
+the carrier with the set $\rho^{-1/2}\{X \mid T(X) = X,\ Q X Q = X\}\rho^{-1/2}$ of
 Corollary 6.7 of *Quantum Channels & Operations* (Wolf 2012), with the inverse square
 root taken on the support of $\rho$.
 

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -313,9 +313,23 @@ In `TNLean.Channel.FixedPoint.Corollaries`:
 * `Kraus.mem_weightedFixedPointsStarSubalgebra_iff` — membership is
   equivalent to saying that `ρ^{1/2} X ρ^{1/2}` is fixed by the original map.
 
-The formalized case takes `ρ` positive definite. Wolf's statement takes any
-maximum-rank fixed-point density matrix, with the inverse square root taken on
-the support of `ρ`; the singular case is not formalized.
+In `TNLean.Channel.FixedPoint.WeightedCornerFixedPoints` (singular case, any
+positive semidefinite fixed point, restricted to corner-supported fixed
+points):
+
+* `Kraus.weightedCornerFixedPointsStarSubalgebra` — the corner elements `Y`
+  with `√ρ Y √ρ` fixed by the map form a `StarSubalgebra` of the corner
+  algebra `Q M_D(ℂ) Q`, realizing `ρ^{-1/2} {X | T(X) = X, Q X Q = X} ρ^{-1/2}`
+  with the inverse square root taken on the support of `ρ`.
+* `Kraus.exists_weightedCorner_sqrt_eq_of_fixedPoint` — conjugation by `√ρ`
+  maps the carrier onto the corner-supported fixed points.
+
+Wolf's statement takes a maximum-rank fixed-point density matrix and
+conjugates the full fixed-point set; for such `ρ` every fixed point is
+supported on the support of `ρ`, so the corner restriction disappears. That
+maximal-support property is not yet formalized (see
+`docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex`), which is the
+remaining step for the statement in its stated generality.
 
 ### Wolf Theorem 6.15 (Conditional expectation onto fixed-point algebra) — PARTIALLY FORMALIZED
 

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -11,6 +11,7 @@ import TNLean.Channel.FixedPoint.WedderburnDecomp
 import TNLean.Channel.FixedPoint.BlockForm
 import TNLean.Channel.FixedPoint.CornerBlockForm
 import TNLean.Channel.FixedPoint.Corollaries
+import TNLean.Channel.FixedPoint.WeightedCornerFixedPoints
 import TNLean.Channel.Irreducible.Ergodicity
 import TNLean.Channel.Irreducible.Basic
 import TNLean.Channel.Irreducible.Growth

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -319,7 +319,7 @@ positive semidefinite fixed point, restricted to corner-supported fixed
 points):
 
 * `Kraus.weightedCornerFixedPointsStarSubalgebra` — the corner elements `Y`
-  with `√ρ Y √ρ` fixed by the map form a `StarSubalgebra` of the corner
+  with `√ρ Y √ρ` fixed by the map form a star-subalgebra of the corner
   algebra `Q M_D(ℂ) Q`, realizing `ρ^{-1/2} {X | T(X) = X, Q X Q = X} ρ^{-1/2}`
   with the inverse square root taken on the support of `ρ`.
 * `Kraus.exists_weightedCorner_sqrt_eq_of_fixedPoint` — conjugation by `√ρ`
@@ -328,8 +328,8 @@ points):
 Wolf's statement takes a maximum-rank fixed-point density matrix and
 conjugates the full fixed-point set; for such `ρ` every fixed point is
 supported on the support of `ρ`, so the corner restriction disappears. That
-maximal-support property is not yet formalized (see
-`docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex`), which is the
+maximal-support property remains to be established here (see
+`docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex`); it is the
 remaining step for the statement in its stated generality.
 
 ### Wolf Theorem 6.15 (Conditional expectation onto fixed-point algebra) — PARTIALLY FORMALIZED

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2443,8 +2443,15 @@ the fixed points supported on the support of $\rho$.
     corner-supported. The set therefore corresponds, element by element, to the weighted
     fixed points of the compressed family with respect to the positive definite fixed
     point $\sigma$, which form a $*$-subalgebra by
-    Theorem~\ref{thm:weightedFixedPointsStarSubalgebra}; closure under multiplication
-    transports back through the correspondence.
+    Theorem~\ref{thm:weightedFixedPointsStarSubalgebra}. Closure under multiplication
+    transports back through the correspondence: for corner-supported $Y_1, Y_2$ in the
+    set,
+    \[
+        V^{\dagger}\,(Y_1 Y_2)\,V \;=\; (V^{\dagger} Y_1 V)(V^{\dagger} Y_2 V),
+    \]
+    since $V V^{\dagger} = Q$ absorbs into the corner-supported factors, so the product
+    of two members corresponds to the product of their compressed images, which lies in
+    the compressed $*$-subalgebra.
 \end{proof}
 
 \begin{lemma}[Conjugation by the square root is onto the corner-supported fixed

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2379,10 +2379,11 @@ zero-block representation.
 For a singular fixed point the conjugation is taken with the inverse square root on the
 support of $\rho$, and the conjugated set lives in the corner algebra of the support
 projection. The corollary in~\cite{Wolf2012Quantum} takes a maximum-rank fixed point, for
-which every fixed point of $T$ is supported on the support of $\rho$; that
-maximal-support property remains to be established here, and the following statements
-restrict to
-the fixed points supported on the support of $\rho$.
+which every fixed point of $T$ is supported on the support of $\rho$; the following
+statements restrict to the fixed points supported on the support of $\rho$.
+% Maintainer note: the maximal-support property (which makes the restriction vacuous at
+% a maximum-rank fixed point) is not yet formalized; see
+% docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex.
 
 \begin{theorem}[Weighted corner fixed points form a $*$-subalgebra]%
     \label{thm:weightedCornerFixedPointsStarSubalgebra}
@@ -2392,18 +2393,15 @@ the fixed points supported on the support of $\rho$.
     Let $T(X) = \sum_i K_i X K_i^\dagger$ be trace-preserving, let $\rho \succeq 0$
     satisfy $T(\rho) = \rho$, and let $Q$ be the support projection of $\rho$. The corner
     elements $Y \in Q\,\MN{D}\,Q$ such that $\sqrt{\rho}\, Y \sqrt{\rho}$ is a fixed
-    point of $T$ form a $*$-subalgebra of the corner algebra $Q\,\MN{D}\,Q$; under
-    conjugation by $\sqrt{\rho}$ its carrier corresponds exactly to the fixed points of
-    $T$ supported on the support of $\rho$
-    (Lemma~\ref{lem:weightedCorner_sqrt_surjective}), so it realizes
+    point of $T$ form a $*$-subalgebra of the corner algebra $Q\,\MN{D}\,Q$. Combined
+    with the conjugation correspondence of
+    Lemma~\ref{lem:weightedCorner_sqrt_surjective}, the carrier realizes
     \[
         \rho^{-1/2}\,\{X \in \MN{D} \mid T(X) = X,\ Q X Q = X\}\,\rho^{-1/2},
     \]
-    with the inverse square root taken on the support of $\rho$. This is the singular
+    with the inverse square root taken on the support of $\rho$: the singular
     case of Corollary~6.7 of~\cite{Wolf2012Quantum}, restricted to the fixed points
-    supported on the support of $\rho$; for the maximum-rank fixed point of the
-    corollary the restriction is vacuous, by the maximal-support property of fixed
-    points, which remains to be established here.
+    supported on the support of $\rho$.
 \end{theorem}
 
 \begin{proof}
@@ -2460,7 +2458,7 @@ the fixed points supported on the support of $\rho$.
     images, which lies in the compressed $*$-subalgebra.
 \end{proof}
 
-\begin{lemma}[Conjugation by the square root is onto the corner-supported fixed
+\begin{theorem}[Conjugation by the square root is onto the corner-supported fixed
     points]%
     \label{lem:weightedCorner_sqrt_surjective}
     \lean{Kraus.exists_weightedCorner_sqrt_eq_of_fixedPoint}
@@ -2469,7 +2467,7 @@ the fixed points supported on the support of $\rho$.
     In the setting of Theorem~\ref{thm:weightedCornerFixedPointsStarSubalgebra}, every
     fixed point $X$ of $T$ with $Q X Q = X$ arises as $X = \sqrt{\rho}\, Y \sqrt{\rho}$
     for a corner-supported $Y$ with $\sqrt{\rho}\, Y \sqrt{\rho}$ fixed by $T$.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}
     \leanok

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2437,10 +2437,14 @@ the fixed points supported on the support of $\rho$.
         \sqrt{\sigma}\,(V^{\dagger} Y V)\,\sqrt{\sigma}
         \;=\; V^{\dagger}\,(\sqrt{\rho}\, Y \sqrt{\rho})\,V,
     \]
-    and the fixed-point equations correspond: for corner-supported $W$ one has
-    $T(W) = W$ exactly when the compressed map fixes $V^{\dagger} W V$, because the
-    compressed map computes $V^{\dagger}\,Q\,T(W)\,Q\,V$ and $T(W)$ is again
-    corner-supported. The set therefore corresponds, element by element, to the weighted
+    and the fixed-point equations correspond: for corner-supported $W$ the compressed
+    map evaluates to
+    \[
+        C\bigl(V^{\dagger} W V\bigr) \;=\; V^{\dagger}\,Q\,T(W)\,Q\,V
+        \;=\; V^{\dagger}\,T(W)\,V,
+    \]
+    since $T(W)$ is again corner-supported, so $T(W) = W$ exactly when the compressed
+    map fixes $V^{\dagger} W V$. The set therefore corresponds, element by element, to the weighted
     fixed points of the compressed family with respect to the positive definite fixed
     point $\sigma$, which form a $*$-subalgebra by
     Theorem~\ref{thm:weightedFixedPointsStarSubalgebra}. Closure under multiplication

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2393,15 +2393,7 @@ statements restrict to the fixed points supported on the support of $\rho$.
     Let $T(X) = \sum_i K_i X K_i^\dagger$ be trace-preserving, let $\rho \succeq 0$
     satisfy $T(\rho) = \rho$, and let $Q$ be the support projection of $\rho$. The corner
     elements $Y \in Q\,\MN{D}\,Q$ such that $\sqrt{\rho}\, Y \sqrt{\rho}$ is a fixed
-    point of $T$ form a $*$-subalgebra of the corner algebra $Q\,\MN{D}\,Q$. Combined
-    with the conjugation correspondence of
-    Lemma~\ref{lem:weightedCorner_sqrt_surjective}, the carrier realizes
-    \[
-        \rho^{-1/2}\,\{X \in \MN{D} \mid T(X) = X,\ Q X Q = X\}\,\rho^{-1/2},
-    \]
-    with the inverse square root taken on the support of $\rho$: the singular
-    case of Corollary~6.7 of~\cite{Wolf2012Quantum}, restricted to the fixed points
-    supported on the support of $\rho$.
+    point of $T$ form a $*$-subalgebra of the corner algebra $Q\,\MN{D}\,Q$.
 \end{theorem}
 
 \begin{proof}
@@ -2458,9 +2450,19 @@ statements restrict to the fixed points supported on the support of $\rho$.
     images, which lies in the compressed $*$-subalgebra.
 \end{proof}
 
+Combined with the conjugation correspondence of
+Theorem~\ref{thm:weightedCorner_sqrt_surjective}, the carrier of this $*$-subalgebra
+realizes
+\[
+    \rho^{-1/2}\,\{X \in \MN{D} \mid T(X) = X,\ Q X Q = X\}\,\rho^{-1/2},
+\]
+with the inverse square root taken on the support of $\rho$: the singular case of
+Corollary~6.7 of~\cite{Wolf2012Quantum}, restricted to the fixed points supported on
+the support of $\rho$.
+
 \begin{theorem}[Conjugation by the square root is onto the corner-supported fixed
     points]%
-    \label{lem:weightedCorner_sqrt_surjective}
+    \label{thm:weightedCorner_sqrt_surjective}
     \lean{Kraus.exists_weightedCorner_sqrt_eq_of_fixedPoint}
     \leanok
     \uses{def:tp_kraus, def:support_proj}

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2376,6 +2376,105 @@ zero-block representation.
     $\rho^{-1/2} F_T \rho^{-1/2}$.
 \end{proof}
 
+For a singular fixed point the conjugation is taken with the inverse square root on the
+support of $\rho$, and the conjugated set lives in the corner algebra of the support
+projection. The corollary in~\cite{Wolf2012Quantum} takes a maximum-rank fixed point, for
+which every fixed point of $T$ is supported on the support of $\rho$; that
+maximal-support property is not yet formalized, and the following statements restrict to
+the fixed points supported on the support of $\rho$.
+
+\begin{theorem}[Weighted corner fixed points form a $*$-subalgebra]%
+    \label{thm:weightedCornerFixedPointsStarSubalgebra}
+    \lean{Kraus.weightedCornerFixedPointsStarSubalgebra}
+    \leanok
+    \uses{def:tp_kraus, def:support_proj, rem:corner_algebra_star_instances}
+    Let $T(X) = \sum_i K_i X K_i^\dagger$ be trace-preserving, let $\rho \succeq 0$
+    satisfy $T(\rho) = \rho$, and let $Q$ be the support projection of $\rho$. The corner
+    elements $Y \in Q\,\MN{D}\,Q$ such that $\sqrt{\rho}\, Y \sqrt{\rho}$ is a fixed
+    point of $T$ form a $*$-subalgebra of the corner algebra $Q\,\MN{D}\,Q$; under
+    conjugation by $\sqrt{\rho}$ its carrier corresponds exactly to the fixed points of
+    $T$ supported on the support of $\rho$
+    (Lemma~\ref{lem:weightedCorner_sqrt_surjective}), so it realizes
+    \[
+        \rho^{-1/2}\,\{X \in \MN{D} \mid T(X) = X,\ Q X Q = X\}\,\rho^{-1/2},
+    \]
+    with the inverse square root taken on the support of $\rho$. This is the singular
+    case of Corollary~6.7 of~\cite{Wolf2012Quantum}, restricted to the fixed points
+    supported on the support of $\rho$; for the maximum-rank fixed point of the
+    corollary the restriction is vacuous, by the maximal-support property of fixed
+    points, which is not yet formalized.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:weightedFixedPointsStarSubalgebra,
+        thm:supported_corner_compression_isometry, thm:compression_on_support_posDef,
+        thm:support_proj_fixed}
+    Closure under addition, scalars, and conjugation is linearity together with the
+    stability of fixed points under conjugate transposition; the corner unit $Q$ belongs
+    to the set because $\sqrt{\rho}\, Q \sqrt{\rho} = \rho$ is a fixed point, the support
+    projection absorbing the square root: $Q \sqrt{\rho} = \sqrt{\rho} = \sqrt{\rho}\,Q$,
+    since $(\Id - Q)\sqrt{\rho}\,\bigl((\Id - Q)\sqrt{\rho}\bigr)^{\dagger} =
+    (\Id - Q)\rho(\Id - Q) = 0$.
+
+    For closure under multiplication, compress to the support sector: since $\rho$ is a
+    fixed point of $T$, the support projection satisfies $(\Id - Q) K_i Q = 0$
+    (Theorem~\ref{thm:support_proj_fixed}), the compressed family $Q K_i Q$ is
+    trace-preserving on the corner, and the compression along the isometry
+    $V : \C^{r} \to \C^{D}$ of Theorem~\ref{thm:supported_corner_compression_isometry},
+    with $V^{\dagger} V = \Id_r$ and $V V^{\dagger} = Q$, produces a trace-preserving
+    family $C$ on $\C^{r}$ whose Schr\"odinger map has the positive definite fixed point
+    $\sigma = V^{\dagger} \rho V$ (Theorem~\ref{thm:compression_on_support_posDef}). The
+    square root compresses along the isometry,
+    \[
+        \sqrt{\sigma} \;=\; V^{\dagger} \sqrt{\rho}\, V,
+    \]
+    by uniqueness of the positive square root, since
+    $(V^{\dagger}\sqrt{\rho}V)(V^{\dagger}\sqrt{\rho}V)
+    = V^{\dagger}\sqrt{\rho}\,Q\sqrt{\rho}V = \sigma$. Hence for corner-supported $Y$,
+    \[
+        \sqrt{\sigma}\,(V^{\dagger} Y V)\,\sqrt{\sigma}
+        \;=\; V^{\dagger}\,(\sqrt{\rho}\, Y \sqrt{\rho})\,V,
+    \]
+    and the fixed-point equations correspond: for corner-supported $W$ one has
+    $T(W) = W$ exactly when the compressed map fixes $V^{\dagger} W V$, because the
+    compressed map computes $V^{\dagger}\,Q\,T(W)\,Q\,V$ and $T(W)$ is again
+    corner-supported. The set therefore corresponds, element by element, to the weighted
+    fixed points of the compressed family with respect to the positive definite fixed
+    point $\sigma$, which form a $*$-subalgebra by
+    Theorem~\ref{thm:weightedFixedPointsStarSubalgebra}; closure under multiplication
+    transports back through the correspondence.
+\end{proof}
+
+\begin{lemma}[Conjugation by the square root is onto the corner-supported fixed
+    points]%
+    \label{lem:weightedCorner_sqrt_surjective}
+    \lean{Kraus.exists_weightedCorner_sqrt_eq_of_fixedPoint}
+    \leanok
+    \uses{def:tp_kraus, def:support_proj}
+    In the setting of Theorem~\ref{thm:weightedCornerFixedPointsStarSubalgebra}, every
+    fixed point $X$ of $T$ with $Q X Q = X$ arises as $X = \sqrt{\rho}\, Y \sqrt{\rho}$
+    for a corner-supported $Y$ with $\sqrt{\rho}\, Y \sqrt{\rho}$ fixed by $T$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{thm:supported_corner_compression_isometry, thm:compression_on_support_posDef,
+        thm:support_proj_fixed}
+    Compress to the support sector as in the proof of
+    Theorem~\ref{thm:weightedCornerFixedPointsStarSubalgebra} and set
+    \[
+        Y \;=\; V\,\bigl(\sqrt{\sigma}^{-1}\,(V^{\dagger} X V)\,
+            \sqrt{\sigma}^{-1}\bigr)\,V^{\dagger},
+    \]
+    where $\sigma = V^{\dagger} \rho V$ is positive definite, so $\sqrt{\sigma}$ is
+    invertible. Then $Y$ is corner-supported, and the compression identity
+    $\sqrt{\sigma} = V^{\dagger}\sqrt{\rho}\,V$ gives
+    $V^{\dagger}(\sqrt{\rho}\,Y\sqrt{\rho})V = V^{\dagger} X V$, hence
+    $\sqrt{\rho}\, Y \sqrt{\rho} = Q X Q = X$, both sides being corner-supported. In
+    particular $\sqrt{\rho}\, Y \sqrt{\rho}$ is fixed by $T$.
+\end{proof}
+
 \section{Further irreducibility and primitivity equivalences}
 
 This section collects several criteria and equivalences from~\cite[Theorems~6.2, 6.7, 6.8]{Wolf2012Quantum} that are

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2448,14 +2448,16 @@ the fixed points supported on the support of $\rho$.
     fixed points of the compressed family with respect to the positive definite fixed
     point $\sigma$, which form a $*$-subalgebra by
     Theorem~\ref{thm:weightedFixedPointsStarSubalgebra}. Closure under multiplication
-    transports back through the correspondence: for corner-supported $Y_1, Y_2$ in the
-    set,
+    transports back through the correspondence: a corner-supported $Y_j$ satisfies
+    $Y_j Q = Y_j$ (right-multiply $Q Y_j Q = Y_j$ by $Q$ and use $Q^2 = Q$), so
     \[
-        V^{\dagger}\,(Y_1 Y_2)\,V \;=\; (V^{\dagger} Y_1 V)(V^{\dagger} Y_2 V),
+        (V^{\dagger} Y_1 V)(V^{\dagger} Y_2 V)
+        \;=\; V^{\dagger}\, Y_1 (V V^{\dagger})\, Y_2\, V
+        \;=\; V^{\dagger}\, (Y_1 Q)\, Y_2\, V
+        \;=\; V^{\dagger}\,(Y_1 Y_2)\,V,
     \]
-    since $V V^{\dagger} = Q$ absorbs into the corner-supported factors, so the product
-    of two members corresponds to the product of their compressed images, which lies in
-    the compressed $*$-subalgebra.
+    and the product of two members corresponds to the product of their compressed
+    images, which lies in the compressed $*$-subalgebra.
 \end{proof}
 
 \begin{lemma}[Conjugation by the square root is onto the corner-supported fixed
@@ -2480,9 +2482,16 @@ the fixed points supported on the support of $\rho$.
             \sqrt{\sigma}^{-1}\bigr)\,V^{\dagger},
     \]
     where $\sigma = V^{\dagger} \rho V$ is positive definite, so $\sqrt{\sigma}$ is
-    invertible. Then $Y$ is corner-supported, and the compression identity
-    $\sqrt{\sigma} = V^{\dagger}\sqrt{\rho}\,V$ gives
-    $V^{\dagger}(\sqrt{\rho}\,Y\sqrt{\rho})V = V^{\dagger} X V$, hence
+    invertible. Then $Y$ is corner-supported, and, writing
+    $Z = \sqrt{\sigma}^{-1}(V^{\dagger} X V)\sqrt{\sigma}^{-1}$ for the compressed
+    middle factor, the transport identity displayed above gives
+    \[
+        V^{\dagger}\bigl(\sqrt{\rho}\,Y\sqrt{\rho}\bigr)V
+        \;=\; \sqrt{\sigma}\,\bigl(V^{\dagger} Y V\bigr)\,\sqrt{\sigma}
+        \;=\; \sqrt{\sigma}\,Z\,\sqrt{\sigma}
+        \;=\; V^{\dagger} X V,
+    \]
+    hence
     $\sqrt{\rho}\, Y \sqrt{\rho} = Q X Q = X$, both sides being corner-supported. In
     particular $\sqrt{\rho}\, Y \sqrt{\rho}$ is fixed by $T$.
 \end{proof}

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2380,7 +2380,8 @@ For a singular fixed point the conjugation is taken with the inverse square root
 support of $\rho$, and the conjugated set lives in the corner algebra of the support
 projection. The corollary in~\cite{Wolf2012Quantum} takes a maximum-rank fixed point, for
 which every fixed point of $T$ is supported on the support of $\rho$; that
-maximal-support property is not yet formalized, and the following statements restrict to
+maximal-support property remains to be established here, and the following statements
+restrict to
 the fixed points supported on the support of $\rho$.
 
 \begin{theorem}[Weighted corner fixed points form a $*$-subalgebra]%
@@ -2402,7 +2403,7 @@ the fixed points supported on the support of $\rho$.
     case of Corollary~6.7 of~\cite{Wolf2012Quantum}, restricted to the fixed points
     supported on the support of $\rho$; for the maximum-rank fixed point of the
     corollary the restriction is vacuous, by the maximal-support property of fixed
-    points, which is not yet formalized.
+    points, which remains to be established here.
 \end{theorem}
 
 \begin{proof}

--- a/docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex
+++ b/docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex
@@ -1,0 +1,68 @@
+\documentclass[11pt]{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
+
+\input{command}
+
+\title{Corner-Support Restriction in the Weighted Fixed-Point Star-Algebra}
+\author{}
+\date{\today}
+
+\begin{document}
+\maketitle
+
+\section{The assertion}
+
+Corollary 6.7 of \emph{Quantum Channels \& Operations} (Wolf 2012) states: for a
+trace-preserving, positive, linear map $T$ on $M_d(\mathbb{C})$ whose adjoint satisfies
+the Schwarz inequality, and for any density matrix $\rho$ which is a \emph{maximum-rank}
+fixed point of $T$, the set
+\[
+    \rho^{-1/2}\,\mathcal{F}_T\,\rho^{-1/2},
+    \qquad \mathcal{F}_T = \{X \mid T(X) = X\},
+\]
+is a $*$-algebra, with the inverse square root taken on the support of $\rho$.
+
+The corollary rests on the maximal-support property of fixed points stated earlier in
+Section~6.4 of the reference: every fixed point of $T$ has support and range within the
+support of the maximum-rank fixed point, so conjugation by $\rho^{-1/2}$ loses nothing.
+
+\section{The formal statements}
+
+The formalization (\leanid{Kraus.weightedCornerFixedPointsStarSubalgebra} and
+\leanid{Kraus.exists\_weightedCorner\_sqrt\_eq\_of\_fixedPoint} in
+\leanid{TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean}) takes a Kraus map (the
+completely positive case of the Schwarz hypothesis, as in the other formalized results of
+this section) and an \emph{arbitrary} positive semidefinite fixed point $\rho$ with
+support projection $Q$, and proves that
+\[
+    \rho^{-1/2}\,\{X \mid T(X) = X,\ Q X Q = X\}\,\rho^{-1/2}
+\]
+is a $*$-subalgebra of the corner algebra $Q M_D(\mathbb{C}) Q$: the conjugated set is
+restricted to the fixed points \emph{supported on the support of $\rho$}. The positive
+definite case without the support restriction is
+\leanid{Kraus.weightedFixedPointsStarSubalgebra}.
+
+\section{The gap}
+
+For a maximum-rank fixed point the corner restriction $Q X Q = X$ is vacuous, by the
+maximal-support property of fixed points. That property is not formalized: the
+maximal-support and support-minimality propositions of Section~6.4 of the reference are
+recorded as open in \leanid{TNLean/Channel/FixedPoint/StationarySupport.lean}. Until it
+is available, the formal statement restricted to corner-supported fixed points is a
+proper restriction of the corollary, and neither formal version covers the corollary in
+its stated generality.
+
+\section{Elimination plan}
+
+Formalize the maximal-support property: every fixed point of a trace-preserving Kraus
+map has support and range within the support of a maximum-rank fixed point. The proof in
+the reference decomposes a fixed point into four positive fixed parts (the decomposition
+is formalized as \leanid{IsChannel.posSemidef\_parts\_of\_hermitian\_fixedPoint}) and
+bounds the support of each positive fixed part by the maximal one. With that property,
+instantiating the corner-restricted statements at a maximum-rank fixed point removes the
+restriction $Q X Q = X$ and yields Corollary 6.7 of the reference verbatim.
+
+\end{document}


### PR DESCRIPTION
## Summary

The singular case of Corollary 6.7 of *Quantum Channels & Operations* (Wolf 2012), with a precisely stated scope restriction. The formalized `Kraus.weightedFixedPointsStarSubalgebra` covers the corollary only for a positive definite fixed point; the source takes any *maximum-rank* fixed-point density matrix — possibly singular — with the inverse square root taken on its support. This PR delivers the singular case for an **arbitrary positive semidefinite fixed point**, restricted to the fixed points supported on the support of $\rho$.

New file `TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean` (sorry/axiom-free):

- `Kraus.weightedCornerFixedPointsStarSubalgebra` — for a trace-preserving Kraus family $K$, a positive semidefinite fixed point $\rho$ of the Schrödinger map, and $Q$ the support projection of $\rho$: the corner elements $Y \in Q M_D(\mathbb{C}) Q$ with $\sqrt{\rho}\,Y\sqrt{\rho}$ fixed by the map form a `StarSubalgebra` of the corner algebra (unit $Q$).
- `Kraus.mem_weightedCornerFixedPointsStarSubalgebra` — membership is exactly the fixed-point condition on $\sqrt{\rho}\,Y\sqrt{\rho}$.
- `Kraus.exists_weightedCorner_sqrt_eq_of_fixedPoint` — conjugation by $\sqrt{\rho}$ maps the carrier **onto** the corner-supported fixed points. Together with the membership characterization this identifies the carrier with
  $$\rho^{-1/2}\,\{X \mid T(X) = X,\ Q X Q = X\}\,\rho^{-1/2},$$
  the set of the corollary with the inverse square root taken on the support of $\rho$ — realized without a standalone pseudo-inverse: on the support sector the compressed fixed point $\sigma = V^\dagger \rho V$ is positive definite and $\sqrt{\sigma}^{-1}$ is an ordinary inverse.
- `Kraus.weightedCornerFixed_mul` — the multiplication-closure step, the load-bearing part of the star-algebra structure.

Proof route: the square root compresses along the support isometry, $\sqrt{V^\dagger \rho V} = V^\dagger \sqrt{\rho}\, V$, by uniqueness of the positive square root (`CFC.sqrt_unique`) together with the support projection absorbing the square root ($Q\sqrt{\rho} = \sqrt{\rho}$, from $(\mathbf 1-Q)\sqrt{\rho}\,((\mathbf 1-Q)\sqrt{\rho})^\dagger = (\mathbf 1-Q)\rho(\mathbf 1-Q) = 0$). The Schrödinger fixed-point equations for corner-supported matrices correspond across the compression, and the positive definite case (`Kraus.weightedFixedPointsStarSubalgebra`) applies on the sector.

**Exact hypotheses and scope.** Kraus (completely positive) maps — the completely positive case of the Schwarz hypothesis of the reference, the established scope convention — and an arbitrary positive semidefinite fixed point (no maximum-rank or full-rank assumption). **Scope restriction, stated in the theorem docstrings and blueprint:** the conjugated set is restricted to the fixed points supported on the support of $\rho$. For the maximum-rank fixed point of the source's corollary this restriction is vacuous by the maximal-support property of fixed points (Section 6.4 of the reference), which is not yet formalized — the propositions on maximal support / support minimality are recorded as open in `TNLean/Channel/FixedPoint/StationarySupport.lean`. Per the faithfulness rule, the restriction is documented in a new paper-gap note `docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex`, with the elimination plan: formalize the maximal-support property (its main ingredient, the decomposition of a Hermitian fixed point into positive fixed parts, is already formalized as `IsChannel.posSemidef_parts_of_hermitian_fixedPoint`), then instantiate the corner-restricted statements at a maximum-rank fixed point.

**What remains for LionSR/QICLean#39** (also updated in `TNLean/Channel/WolfChapter6Index.lean`): the maximal-support property (removing the corner restriction and giving the source's Corollary 6.7 verbatim), and the density-weighted form of Theorem 6.14 for the Schrödinger-picture fixed points (Equation (1.40) of the reference).

Partially addresses LionSR/QICLean#39.

## Blueprint

Two new entries in `blueprint/src/chapter/ch07_spectral.tex`, placed after the positive definite weighted fixed-point entry, with full prose proofs and `\uses` matching the Lean proofs' dependencies:

- `thm:weightedCornerFixedPointsStarSubalgebra` — statement includes the corner-support restriction and its relation to the source's corollary; proof uses `thm:weightedFixedPointsStarSubalgebra`, `thm:supported_corner_compression_isometry`, `thm:compression_on_support_posDef`, `thm:support_proj_fixed`.
- `lem:weightedCorner_sqrt_surjective` — conjugation by the square root is onto the corner-supported fixed points.

## Validation

- `lake build TNLean` — success, no new warnings
- `rg -n "sorry|axiom"` on the new and touched Lean files — clean
- `lake exe checkdecls blueprint/lean_decls` — pass (after `--update-lean-decls`)
- `python3 scripts/blueprint_lean_sync.py --ci` — in sync
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main --ci` — no violations
- `lake exe lint_style`, `git diff --check` — clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new sorry-free fixed-point theory on critical channel infrastructure; the stated Wolf corollary is intentionally narrower until maximal-support is formalized, so reviewers should check the scope restriction and compression correspondence.
> 
> **Overview**
> Extends Wolf Corollary 6.7 beyond the existing **positive definite** `Kraus.weightedFixedPointsStarSubalgebra` to **positive semidefinite** fixed points $\rho$, with an explicit **corner-support** hypothesis ($Q X Q = X$ for the support projection $Q$ of $\rho$).
> 
> A new Lean module `TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean` proves that corner elements $Y$ with $\sqrt{\rho}\,Y\sqrt{\rho}$ fixed by the Kraus map form a `StarSubalgebra` of $Q M_D(\mathbb{C}) Q$ (`weightedCornerFixedPointsStarSubalgebra`), gives membership (`mem_weightedCornerFixedPointsStarSubalgebra`), and shows surjectivity onto corner-supported fixed points (`exists_weightedCorner_sqrt_eq_of_fixedPoint`). The main proof compresses to the support sector (positive definite $\sigma$) and reuses the PD weighted algebra; supporting lemmas cover $Q\sqrt{\rho}=\sqrt{\rho}$ and square-root compression along the support isometry.
> 
> **Documentation:** `Corollaries.lean`, `WolfChapter6Index.lean`, and root imports are updated; blueprint `ch07_spectral.tex` adds matching theorems and proofs; `docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex` records that Wolf’s maximum-rank / full fixed-point set version still needs the maximal-support proposition from Section 6.4.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93a12732fee42147d0332860bd777767145a831f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->