### PR TITLE
feat(MPS/MPDO): identify the closed-sector pairing transfer

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -378,6 +378,7 @@ import TNLean.MPS.MPDO.LocalPurificationRFP
 import TNLean.MPS.MPDO.SimpleLocalStructure
 import TNLean.MPS.MPDO.HayashiSectorComparison
 import TNLean.MPS.MPDO.SectorFactorization
+import TNLean.MPS.MPDO.SectorPairingTransfer
 import TNLean.MPS.MPDO.SectorEtaContraction
 import TNLean.MPS.MPDO.SectorEtaOperator
 import TNLean.MPS.MPDO.FusionIsometries

--- a/TNLean/MPS/MPDO/SectorFactorization.lean
+++ b/TNLean/MPS/MPDO/SectorFactorization.lean
@@ -414,11 +414,13 @@ The source obtains the positivity from the projected chain identity
 \]
 
 at lines 1446--1450, and asserts that the $\eta$'s *can be chosen* positive
-semidefinite; the choice is a rescaling of the sector tensors. That
-all-length identity is not yet formalized, so positive semidefiniteness of
-the representative fixed by `MPOTensor.sectorTensorL` and
-`MPOTensor.sectorTensorR` enters here as a hypothesis; the surrounding gap is
-recorded in `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+semidefinite; the choice is a rescaling of the sector tensors. The all-length
+sector identity is formalized in `MPOTensor.mpo_reindex_sectorChainEquiv`, but
+it does not by itself provide a coherent positive choice of representatives.
+Positive semidefiniteness of the representatives fixed by
+`MPOTensor.sectorTensorL` and `MPOTensor.sectorTensorR` therefore enters here
+as a hypothesis; the remaining choice problem is recorded in
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
 
 Source: arXiv:1606.00608, Appendix C.2, lines 1441--1455. -/
 noncomputable def ExplicitEtaOperators.ofSectorTensors

--- a/TNLean/MPS/MPDO/SectorFactorization.lean
+++ b/TNLean/MPS/MPDO/SectorFactorization.lean
@@ -415,9 +415,9 @@ The source obtains the positivity from the projected chain identity
 
 at lines 1446--1450, and asserts that the $\eta$'s *can be chosen* positive
 semidefinite; the choice is a rescaling of the sector tensors. The all-length
-sector identity is formalized in
-`MPOTensor.mpo_reindex_sectorChainEquiv_eq_blockDiagonal_cyclicEta`, but it
-does not by itself provide a coherent positive choice of representatives.
+sector identity (arXiv:1606.00608, Appendix C.2, lines 1446--1450) is now
+formalized, but it does not by itself provide a coherent positive choice of
+representatives.
 Positive semidefiniteness of the representatives fixed by
 `MPOTensor.sectorTensorL` and `MPOTensor.sectorTensorR` therefore enters here
 as a hypothesis; the remaining choice problem is recorded in

--- a/TNLean/MPS/MPDO/SectorFactorization.lean
+++ b/TNLean/MPS/MPDO/SectorFactorization.lean
@@ -415,8 +415,9 @@ The source obtains the positivity from the projected chain identity
 
 at lines 1446--1450, and asserts that the $\eta$'s *can be chosen* positive
 semidefinite; the choice is a rescaling of the sector tensors. The all-length
-sector identity is formalized in `MPOTensor.mpo_reindex_sectorChainEquiv`, but
-it does not by itself provide a coherent positive choice of representatives.
+sector identity is formalized in
+`MPOTensor.mpo_reindex_sectorChainEquiv_eq_blockDiagonal_cyclicEta`, but it
+does not by itself provide a coherent positive choice of representatives.
 Positive semidefiniteness of the representatives fixed by
 `MPOTensor.sectorTensorL` and `MPOTensor.sectorTensorR` therefore enters here
 as a hypothesis; the remaining choice problem is recorded in

--- a/TNLean/MPS/MPDO/SectorPairingTransfer.lean
+++ b/TNLean/MPS/MPDO/SectorPairingTransfer.lean
@@ -15,7 +15,7 @@ zero-correlation-length condition gives the corresponding pairing operator
 idempotence, up to the positive scalar allowed before canonical
 normalization.
 
-## Main results
+## Main declarations
 
 * `physTraceTransfer_eq_sum_closedSector`: a sector factorization expresses
   the physical-trace transfer as a sum of outer products of closed tensors.
@@ -35,7 +35,7 @@ normalization.
   Appendix C.2, lines 1473--1493
 -/
 
-open scoped Matrix ComplexOrder BigOperators
+open scoped Matrix BigOperators
 
 namespace MPOTensor
 

--- a/TNLean/MPS/MPDO/SectorPairingTransfer.lean
+++ b/TNLean/MPS/MPDO/SectorPairingTransfer.lean
@@ -25,6 +25,9 @@ normalization.
   gives quasi-idempotence of the closed-sector pairing operator.
 * `closedSector_operator_normalized_idempotent`: after the source
   normalization, the pairing operator is idempotent.
+* `closedSector_operator_idempotent_of_physTraceTransfer_sq`: for a
+  canonically normalized representative, the raw pairing operator is
+  idempotent.
 
 ## References
 
@@ -141,5 +144,26 @@ theorem closedSector_operator_normalized_idempotent
   dsimp only
   rw [← concrete_physTraceTransfer_eq_sum_closedSector K hK hη R hρ α₁ β₃ hm]
   exact hidem
+
+/-- For a canonically normalized representative whose physical-trace transfer
+is literally idempotent, the raw closed-sector pairing operator satisfies
+\[
+  \left(\sum_k |l_k)(r_k|\right)^2=\sum_k |l_k)(r_k|.
+\]
+This is the displayed zero-correlation-length identity used in
+arXiv:1606.00608, Appendix C.2, lines 1489--1493. -/
+theorem closedSector_operator_idempotent_of_physTraceTransfer_sq
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    (K : MPOTensor d D) (hK : K.IsInjective) (hη : EtaStructure ρ)
+    (R : Matrix (Fin D) (Fin D) ℂ) (hρ : IsThreeSiteClosure K R ρ)
+    (α₁ β₃ : Fin D) (hm : R β₃ α₁ ≠ 0)
+    (hZCL : physTraceTransfer K * physTraceTransfer K = physTraceTransfer K) :
+    let S := ∑ q, Matrix.vecMulVec
+      (closedSectorL K hK hη R α₁ β₃ q)
+      (closedSectorR K hK hη β₃ q)
+    S * S = S := by
+  dsimp only
+  rw [← concrete_physTraceTransfer_eq_sum_closedSector K hK hη R hρ α₁ β₃ hm]
+  exact hZCL
 
 end MPOTensor

--- a/TNLean/MPS/MPDO/SectorPairingTransfer.lean
+++ b/TNLean/MPS/MPDO/SectorPairingTransfer.lean
@@ -9,7 +9,7 @@ import TNLean.MPS.Core.MultiBlock
 # Closed sector tensors and the physical-trace transfer
 
 This file identifies the closed-sector pairing operator of
-arXiv:1606.00608, Appendix C.2, equations `lkrk` and `Tkn`, with the
+arXiv:1606.00608, Appendix C.2, equations lkrk and Tkn, with the
 physical-trace transfer of the original tensor.  Consequently the source
 zero-correlation-length condition gives the corresponding pairing operator
 idempotence, up to the positive scalar allowed before canonical
@@ -150,14 +150,14 @@ is literally idempotent, the raw closed-sector pairing operator satisfies
 This is the displayed zero-correlation-length identity used in
 arXiv:1606.00608, Appendix C.2, lines 1489--1493. -/
 theorem closedSector_operator_idempotent_of_physTraceTransfer_sq
-    (hZCL : physTraceTransfer K * physTraceTransfer K = physTraceTransfer K) :
+    (hT_sq : physTraceTransfer K * physTraceTransfer K = physTraceTransfer K) :
     let S := ∑ q, Matrix.vecMulVec
       (closedSectorL K hK hη R α₁ β₃ q)
       (closedSectorR K hK hη β₃ q)
     S * S = S := by
   dsimp only
   rw [← concrete_physTraceTransfer_eq_sum_closedSector K hK hη R hρ α₁ β₃ hm]
-  exact hZCL
+  exact hT_sq
 
 end InverseMapSectorTensors
 

--- a/TNLean/MPS/MPDO/SectorPairingTransfer.lean
+++ b/TNLean/MPS/MPDO/SectorPairingTransfer.lean
@@ -1,0 +1,145 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.MPDO.SectorFactorization
+import TNLean.MPS.Core.MultiBlock
+
+/-!
+# Closed sector tensors and the physical-trace transfer
+
+This file identifies the closed-sector pairing operator of
+arXiv:1606.00608, Appendix C.2, equations `lkrk` and `Tkn`, with the
+physical-trace transfer of the original tensor.  Consequently the source
+zero-correlation-length condition gives the corresponding pairing operator
+idempotence, up to the positive scalar allowed before canonical
+normalization.
+
+## Main results
+
+* `physTraceTransfer_eq_sum_closedSector`: a sector factorization expresses
+  the physical-trace transfer as a sum of outer products of closed tensors.
+* `concrete_physTraceTransfer_eq_sum_closedSector`: the identity for the
+  inverse-map sector tensors constructed from an injective simple tensor.
+* `closedSector_operator_quasi_idempotent`: source zero correlation length
+  gives quasi-idempotence of the closed-sector pairing operator.
+* `closedSector_operator_normalized_idempotent`: after the source
+  normalization, the pairing operator is idempotent.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, lines 1473--1493
+-/
+
+open scoped Matrix ComplexOrder BigOperators
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- A sector factorization expresses the physical-trace transfer as the sum
+of the outer products of the closed left and right sector tensors:
+\[
+  \mathcal T_{\cal K}=\sum_k |l_k)(r_k|.
+\]
+
+This is the operator on the left-hand side of the zero-correlation-length
+identity in arXiv:1606.00608, Appendix C.2, lines 1489--1493. -/
+theorem physTraceTransfer_eq_sum_closedSector
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    (K : MPOTensor d D) (hη : EtaStructure ρ)
+    (l : (q : Fin hη.m) → Fin D →
+      Matrix (Fin (hη.dL q)) (Fin (hη.dL q)) ℂ)
+    (r : (q : Fin hη.m) → Fin D →
+      Matrix (Fin (hη.dR q)) (Fin (hη.dR q)) ℂ)
+    (hfactor : ∀ β α,
+      Matrix.reindex hη.decompB hη.decompB
+          ((hη.U_B : Matrix (Fin d) (Fin d) ℂ) * physicalSlice K β α *
+            (hη.U_B : Matrix (Fin d) (Fin d) ℂ)ᴴ)
+        = Matrix.blockDiagonal' fun q ↦
+            Matrix.kroneckerMap (· * ·) (l q β) (r q α)) :
+    physTraceTransfer K =
+      ∑ q, Matrix.vecMulVec (fun β ↦ (l q β).trace) (fun α ↦ (r q α).trace) := by
+  classical
+  ext β α
+  simp only [physTraceTransfer, Matrix.sum_apply]
+  change Matrix.trace (physicalSlice K β α) = _
+  rw [← Matrix.trace_reindex hη.decompB]
+  rw [show Matrix.trace (Matrix.reindex hη.decompB hη.decompB (physicalSlice K β α)) =
+      Matrix.trace (Matrix.reindex hη.decompB hη.decompB
+        ((hη.U_B : Matrix (Fin d) (Fin d) ℂ) * physicalSlice K β α *
+          (hη.U_B : Matrix (Fin d) (Fin d) ℂ)ᴴ)) by
+    rw [Matrix.trace_reindex, Matrix.trace_reindex, Matrix.trace_mul_cycle,
+      ← Matrix.star_eq_conjTranspose, Unitary.coe_star_mul_self, Matrix.one_mul]]
+  rw [hfactor, Matrix.trace_blockDiagonal']
+  simp only [Matrix.trace_kronecker, Matrix.vecMulVec_apply]
+
+/-- For the inverse-map sector tensors of an injective simple tensor,
+\[
+  \mathcal T_{\cal K}=\sum_k |l_k)(r_k|.
+\]
+This supplies the concrete closed-tensor operator used immediately before
+Lemma C.5 in arXiv:1606.00608, Appendix C.2, lines 1473--1493. -/
+theorem concrete_physTraceTransfer_eq_sum_closedSector
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    (K : MPOTensor d D) (hK : K.IsInjective) (hη : EtaStructure ρ)
+    (R : Matrix (Fin D) (Fin D) ℂ) (hρ : IsThreeSiteClosure K R ρ)
+    (α₁ β₃ : Fin D) (hm : R β₃ α₁ ≠ 0) :
+    physTraceTransfer K =
+      ∑ q, Matrix.vecMulVec
+        (closedSectorL K hK hη R α₁ β₃ q)
+        (closedSectorR K hK hη β₃ q) := by
+  apply physTraceTransfer_eq_sum_closedSector K hη
+      (sectorTensorL K hK hη R α₁ β₃)
+      (sectorTensorR K hK hη β₃)
+  exact physicalSlice_sector_factorization K hK R ρ hρ hη hm
+
+/-- Source zero correlation length makes the concrete closed-sector pairing
+operator quasi-idempotent:
+\[
+  S^2=\lambda S,\qquad \lambda>0,
+  \qquad S=\sum_k |l_k)(r_k|.
+\]
+The scalar is present because `IsSourceZCL` is invariant under rescaling;
+the paper uses the canonically normalized representative in the display at
+arXiv:1606.00608, Appendix C.2, lines 1489--1493. -/
+theorem closedSector_operator_quasi_idempotent
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    (K : MPOTensor d D) (hK : K.IsInjective) (hη : EtaStructure ρ)
+    (R : Matrix (Fin D) (Fin D) ℂ) (hρ : IsThreeSiteClosure K R ρ)
+    (α₁ β₃ : Fin D) (hm : R β₃ α₁ ≠ 0)
+    (hZCL : IsSourceZCL K) :
+    ∃ lam : ℝ, 0 < lam ∧
+      let S := ∑ q, Matrix.vecMulVec
+        (closedSectorL K hK hη R α₁ β₃ q)
+        (closedSectorR K hK hη β₃ q)
+      S * S = (lam : ℂ) • S := by
+  obtain ⟨_, lam, hlam, hmul⟩ := hZCL
+  refine ⟨lam, hlam, ?_⟩
+  dsimp only
+  rw [← concrete_physTraceTransfer_eq_sum_closedSector K hK hη R hρ α₁ β₃ hm]
+  exact hmul
+
+/-- After the positive source normalization, the concrete closed-sector
+pairing operator is idempotent.  This is the normalized form of the displayed
+zero-correlation-length identity in arXiv:1606.00608, Appendix C.2,
+lines 1489--1493. -/
+theorem closedSector_operator_normalized_idempotent
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    (K : MPOTensor d D) (hK : K.IsInjective) (hη : EtaStructure ρ)
+    (R : Matrix (Fin D) (Fin D) ℂ) (hρ : IsThreeSiteClosure K R ρ)
+    (α₁ β₃ : Fin D) (hm : R β₃ α₁ ≠ 0)
+    (hZCL : IsSourceZCL K) :
+    ∃ lam : ℝ, 0 < lam ∧
+      let S := ∑ q, Matrix.vecMulVec
+        (closedSectorL K hK hη R α₁ β₃ q)
+        (closedSectorR K hK hη β₃ q)
+      IsIdempotentElem ((lam : ℂ)⁻¹ • S) := by
+  obtain ⟨lam, hlam, hidem⟩ := hZCL.normalized_idempotent
+  refine ⟨lam, hlam, ?_⟩
+  dsimp only
+  rw [← concrete_physTraceTransfer_eq_sum_closedSector K hK hη R hρ α₁ β₃ hm]
+  exact hidem
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/SectorPairingTransfer.lean
+++ b/TNLean/MPS/MPDO/SectorPairingTransfer.lean
@@ -41,6 +41,20 @@ namespace MPOTensor
 
 variable {d D : ℕ}
 
+/-- The pairing operator obtained by closing the physical legs of the left and
+right tensors in each sector:
+\[
+  S=\sum_k |l_k)(r_k|.
+\]
+This is the operator displayed in arXiv:1606.00608, Appendix C.2,
+lines 1473--1493. -/
+noncomputable def closedSectorPairingOperator
+    {m : ℕ} {dL dR : Fin m → ℕ}
+    (l : (q : Fin m) → Fin D → Matrix (Fin (dL q)) (Fin (dL q)) ℂ)
+    (r : (q : Fin m) → Fin D → Matrix (Fin (dR q)) (Fin (dR q)) ℂ) :
+    Matrix (Fin D) (Fin D) ℂ :=
+  ∑ q, Matrix.vecMulVec (fun β ↦ (l q β).trace) (fun α ↦ (r q α).trace)
+
 /-- A sector factorization expresses the physical-trace transfer as the sum
 of the outer products of the closed left and right sector tensors:
 \[
@@ -50,33 +64,33 @@ of the outer products of the closed left and right sector tensors:
 This is the operator on the left-hand side of the zero-correlation-length
 identity in arXiv:1606.00608, Appendix C.2, lines 1489--1493. -/
 theorem physTraceTransfer_eq_sum_closedSector
-    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
-    (K : MPOTensor d D) (hη : EtaStructure ρ)
-    (l : (q : Fin hη.m) → Fin D →
-      Matrix (Fin (hη.dL q)) (Fin (hη.dL q)) ℂ)
-    (r : (q : Fin hη.m) → Fin D →
-      Matrix (Fin (hη.dR q)) (Fin (hη.dR q)) ℂ)
+    {m : ℕ} {dL dR : Fin m → ℕ}
+    (K : MPOTensor d D)
+    (decompB : Fin d ≃ Σ q : Fin m, Fin (dL q) × Fin (dR q))
+    (U_B : Matrix.unitaryGroup (Fin d) ℂ)
+    (l : (q : Fin m) → Fin D → Matrix (Fin (dL q)) (Fin (dL q)) ℂ)
+    (r : (q : Fin m) → Fin D → Matrix (Fin (dR q)) (Fin (dR q)) ℂ)
     (hfactor : ∀ β α,
-      Matrix.reindex hη.decompB hη.decompB
-          ((hη.U_B : Matrix (Fin d) (Fin d) ℂ) * physicalSlice K β α *
-            (hη.U_B : Matrix (Fin d) (Fin d) ℂ)ᴴ)
+      Matrix.reindex decompB decompB
+          ((U_B : Matrix (Fin d) (Fin d) ℂ) * physicalSlice K β α *
+            (U_B : Matrix (Fin d) (Fin d) ℂ)ᴴ)
         = Matrix.blockDiagonal' fun q ↦
             Matrix.kroneckerMap (· * ·) (l q β) (r q α)) :
-    physTraceTransfer K =
-      ∑ q, Matrix.vecMulVec (fun β ↦ (l q β).trace) (fun α ↦ (r q α).trace) := by
+    physTraceTransfer K = closedSectorPairingOperator l r := by
   classical
   ext β α
   simp only [physTraceTransfer, Matrix.sum_apply]
   change Matrix.trace (physicalSlice K β α) = _
-  rw [← Matrix.trace_reindex hη.decompB]
-  rw [show Matrix.trace (Matrix.reindex hη.decompB hη.decompB (physicalSlice K β α)) =
-      Matrix.trace (Matrix.reindex hη.decompB hη.decompB
-        ((hη.U_B : Matrix (Fin d) (Fin d) ℂ) * physicalSlice K β α *
-          (hη.U_B : Matrix (Fin d) (Fin d) ℂ)ᴴ)) by
+  rw [← Matrix.trace_reindex decompB]
+  rw [show Matrix.trace (Matrix.reindex decompB decompB (physicalSlice K β α)) =
+      Matrix.trace (Matrix.reindex decompB decompB
+        ((U_B : Matrix (Fin d) (Fin d) ℂ) * physicalSlice K β α *
+          (U_B : Matrix (Fin d) (Fin d) ℂ)ᴴ)) by
     rw [Matrix.trace_reindex, Matrix.trace_reindex, Matrix.trace_mul_cycle,
       ← Matrix.star_eq_conjTranspose, Unitary.coe_star_mul_self, Matrix.one_mul]]
   rw [hfactor, Matrix.trace_blockDiagonal']
-  simp only [Matrix.trace_kronecker, Matrix.vecMulVec_apply]
+  simp only [closedSectorPairingOperator, Matrix.sum_apply, Matrix.trace_kronecker,
+    Matrix.vecMulVec_apply]
 
 section InverseMapSectorTensors
 
@@ -94,11 +108,10 @@ include hρ hm
 This supplies the concrete closed-tensor operator used immediately before
 Lemma C.5 in arXiv:1606.00608, Appendix C.2, lines 1473--1493. -/
 theorem concrete_physTraceTransfer_eq_sum_closedSector
-    : physTraceTransfer K =
-      ∑ q, Matrix.vecMulVec
-        (closedSectorL K hK hη R α₁ β₃ q)
-        (closedSectorR K hK hη β₃ q) := by
-  apply physTraceTransfer_eq_sum_closedSector K hη
+    : physTraceTransfer K = closedSectorPairingOperator
+        (sectorTensorL K hK hη R α₁ β₃)
+        (sectorTensorR K hK hη β₃) := by
+  apply physTraceTransfer_eq_sum_closedSector K hη.decompB hη.U_B
       (sectorTensorL K hK hη R α₁ β₃)
       (sectorTensorR K hK hη β₃)
   exact physicalSlice_sector_factorization K hK R ρ hρ hη hm
@@ -109,15 +122,16 @@ operator quasi-idempotent:
   S^2=\lambda S,\qquad \lambda>0,
   \qquad S=\sum_k |l_k)(r_k|.
 \]
-The scalar is present because `IsSourceZCL` is invariant under rescaling;
+The scalar is present because the source zero-correlation-length condition is
+scale-invariant;
 the paper uses the canonically normalized representative in the display at
 arXiv:1606.00608, Appendix C.2, lines 1489--1493. -/
 theorem closedSector_operator_quasi_idempotent
     (hZCL : IsSourceZCL K) :
     ∃ lam : ℝ, 0 < lam ∧
-      let S := ∑ q, Matrix.vecMulVec
-        (closedSectorL K hK hη R α₁ β₃ q)
-        (closedSectorR K hK hη β₃ q)
+      let S := closedSectorPairingOperator
+        (sectorTensorL K hK hη R α₁ β₃)
+        (sectorTensorR K hK hη β₃)
       S * S = (lam : ℂ) • S := by
   obtain ⟨_, lam, hlam, hmul⟩ := hZCL
   refine ⟨lam, hlam, ?_⟩
@@ -132,9 +146,9 @@ lines 1489--1493. -/
 theorem closedSector_operator_normalized_idempotent
     (hZCL : IsSourceZCL K) :
     ∃ lam : ℝ, 0 < lam ∧
-      let S := ∑ q, Matrix.vecMulVec
-        (closedSectorL K hK hη R α₁ β₃ q)
-        (closedSectorR K hK hη β₃ q)
+      let S := closedSectorPairingOperator
+        (sectorTensorL K hK hη R α₁ β₃)
+        (sectorTensorR K hK hη β₃)
       IsIdempotentElem ((lam : ℂ)⁻¹ • S) := by
   obtain ⟨lam, hlam, hidem⟩ := hZCL.normalized_idempotent
   refine ⟨lam, hlam, ?_⟩
@@ -151,9 +165,9 @@ This is the displayed zero-correlation-length identity used in
 arXiv:1606.00608, Appendix C.2, lines 1489--1493. -/
 theorem closedSector_operator_idempotent_of_physTraceTransfer_sq
     (hT_sq : physTraceTransfer K * physTraceTransfer K = physTraceTransfer K) :
-    let S := ∑ q, Matrix.vecMulVec
-      (closedSectorL K hK hη R α₁ β₃ q)
-      (closedSectorR K hK hη β₃ q)
+    let S := closedSectorPairingOperator
+      (sectorTensorL K hK hη R α₁ β₃)
+      (sectorTensorR K hK hη β₃)
     S * S = S := by
   dsimp only
   rw [← concrete_physTraceTransfer_eq_sum_closedSector K hK hη R hρ α₁ β₃ hm]

--- a/TNLean/MPS/MPDO/SectorPairingTransfer.lean
+++ b/TNLean/MPS/MPDO/SectorPairingTransfer.lean
@@ -78,6 +78,15 @@ theorem physTraceTransfer_eq_sum_closedSector
   rw [hfactor, Matrix.trace_blockDiagonal']
   simp only [Matrix.trace_kronecker, Matrix.vecMulVec_apply]
 
+section InverseMapSectorTensors
+
+variable {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+variable (K : MPOTensor d D) (hK : K.IsInjective) (hη : EtaStructure ρ)
+variable (R : Matrix (Fin D) (Fin D) ℂ) (hρ : IsThreeSiteClosure K R ρ)
+variable (α₁ β₃ : Fin D) (hm : R β₃ α₁ ≠ 0)
+
+include hρ hm
+
 /-- For the inverse-map sector tensors of an injective simple tensor,
 \[
   \mathcal T_{\cal K}=\sum_k |l_k)(r_k|.
@@ -85,11 +94,7 @@ theorem physTraceTransfer_eq_sum_closedSector
 This supplies the concrete closed-tensor operator used immediately before
 Lemma C.5 in arXiv:1606.00608, Appendix C.2, lines 1473--1493. -/
 theorem concrete_physTraceTransfer_eq_sum_closedSector
-    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
-    (K : MPOTensor d D) (hK : K.IsInjective) (hη : EtaStructure ρ)
-    (R : Matrix (Fin D) (Fin D) ℂ) (hρ : IsThreeSiteClosure K R ρ)
-    (α₁ β₃ : Fin D) (hm : R β₃ α₁ ≠ 0) :
-    physTraceTransfer K =
+    : physTraceTransfer K =
       ∑ q, Matrix.vecMulVec
         (closedSectorL K hK hη R α₁ β₃ q)
         (closedSectorR K hK hη β₃ q) := by
@@ -108,10 +113,6 @@ The scalar is present because `IsSourceZCL` is invariant under rescaling;
 the paper uses the canonically normalized representative in the display at
 arXiv:1606.00608, Appendix C.2, lines 1489--1493. -/
 theorem closedSector_operator_quasi_idempotent
-    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
-    (K : MPOTensor d D) (hK : K.IsInjective) (hη : EtaStructure ρ)
-    (R : Matrix (Fin D) (Fin D) ℂ) (hρ : IsThreeSiteClosure K R ρ)
-    (α₁ β₃ : Fin D) (hm : R β₃ α₁ ≠ 0)
     (hZCL : IsSourceZCL K) :
     ∃ lam : ℝ, 0 < lam ∧
       let S := ∑ q, Matrix.vecMulVec
@@ -129,10 +130,6 @@ pairing operator is idempotent.  This is the normalized form of the displayed
 zero-correlation-length identity in arXiv:1606.00608, Appendix C.2,
 lines 1489--1493. -/
 theorem closedSector_operator_normalized_idempotent
-    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
-    (K : MPOTensor d D) (hK : K.IsInjective) (hη : EtaStructure ρ)
-    (R : Matrix (Fin D) (Fin D) ℂ) (hρ : IsThreeSiteClosure K R ρ)
-    (α₁ β₃ : Fin D) (hm : R β₃ α₁ ≠ 0)
     (hZCL : IsSourceZCL K) :
     ∃ lam : ℝ, 0 < lam ∧
       let S := ∑ q, Matrix.vecMulVec
@@ -153,10 +150,6 @@ is literally idempotent, the raw closed-sector pairing operator satisfies
 This is the displayed zero-correlation-length identity used in
 arXiv:1606.00608, Appendix C.2, lines 1489--1493. -/
 theorem closedSector_operator_idempotent_of_physTraceTransfer_sq
-    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
-    (K : MPOTensor d D) (hK : K.IsInjective) (hη : EtaStructure ρ)
-    (R : Matrix (Fin D) (Fin D) ℂ) (hρ : IsThreeSiteClosure K R ρ)
-    (α₁ β₃ : Fin D) (hm : R β₃ α₁ ≠ 0)
     (hZCL : physTraceTransfer K * physTraceTransfer K = physTraceTransfer K) :
     let S := ∑ q, Matrix.vecMulVec
       (closedSectorL K hK hη R α₁ β₃ q)
@@ -165,5 +158,7 @@ theorem closedSector_operator_idempotent_of_physTraceTransfer_sq
   dsimp only
   rw [← concrete_physTraceTransfer_eq_sum_closedSector K hK hη R hρ α₁ β₃ hm]
   exact hZCL
+
+end InverseMapSectorTensors
 
 end MPOTensor

--- a/TNLean/MPS/MPDO/SectorPairingTransfer.lean
+++ b/TNLean/MPS/MPDO/SectorPairingTransfer.lean
@@ -9,7 +9,7 @@ import TNLean.MPS.Core.MultiBlock
 # Closed sector tensors and the physical-trace transfer
 
 This file identifies the closed-sector pairing operator of
-arXiv:1606.00608, Appendix C.2, equations lkrk and Tkn, with the
+arXiv:1606.00608, Appendix C.2, lines 1473--1493, with the
 physical-trace transfer of the original tensor.  Consequently the source
 zero-correlation-length condition gives the corresponding pairing operator
 idempotence, up to the positive scalar allowed before canonical

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -827,12 +827,15 @@ strong subadditivity for a normalized three-site reduced state.
     \leanok
     \uses{def:mpo_physical_trace_transfer,
         def:mpdo_closed_sector_tensors, thm:mpdo_sector_factorization}
-    For the sector tensors obtained from the injective inverse-map
-    construction, the physical-trace transfer is the closed-sector pairing
-    operator:
+    More generally, any sector factorization
+    $U_B\kappa_{\beta,\alpha}U_B^\dagger
+    =\bigoplus_k(l_k)_\beta\otimes(r_k)_\alpha$ gives the closed-sector
+    pairing operator
     \[
         \mathcal T_{\cal K}=\sum_k |l_k)(r_k|.
     \]
+    In particular, this holds for the sector tensors obtained from the
+    injective inverse-map construction.
     This identifies the transfer matrix of
     Definition~\ref{def:mpo_physical_trace_transfer} with the operator on the
     left-hand side of the zero-correlation-length identity in

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -857,6 +857,7 @@ strong subadditivity for a normalized three-site reduced state.
     \label{thm:mpdo_closed_sector_pairing_normalized_idempotent}
     \lean{MPOTensor.closedSector_operator_quasi_idempotent}
     \lean{MPOTensor.closedSector_operator_normalized_idempotent}
+    \lean{MPOTensor.closedSector_operator_idempotent_of_physTraceTransfer_sq}
     \leanok
     \uses{def:mpo_source_zcl,
         thm:mpdo_closed_sector_physical_trace_transfer,
@@ -871,8 +872,9 @@ strong subadditivity for a normalized three-site reduced state.
         \qquad
         (\lambda^{-1}S)^2=\lambda^{-1}S.
     \]
-    The paper works with the canonically normalized representative
-    $\lambda=1$ in the display preceding
+    If ${\cal K}$ is the canonically normalized representative satisfying
+    $\mathcal T_{\cal K}^2=\mathcal T_{\cal K}$, then the raw pairing
+    operator itself satisfies $S^2=S$.  This is the display preceding
     \cite[Appendix~C.2, Lemma~C.5]{Cirac2016MPDO_arXiv}; the first identity
     records the rescaling-invariant form of the same zero-correlation-length
     condition.
@@ -887,7 +889,8 @@ strong subadditivity for a normalized three-site reduced state.
     Theorem~\ref{thm:mpdo_closed_sector_physical_trace_transfer} into the
     defining relation
     $\mathcal T_{\cal K}^2=\lambda\mathcal T_{\cal K}$, and then apply
-    Lemma~\ref{lem:mpo_source_zcl_normalized_idempotent}.
+    Lemma~\ref{lem:mpo_source_zcl_normalized_idempotent}.  Under literal
+    idempotence, the same substitution gives $S^2=S$ directly.
 \end{proof}
 
 \begin{definition}[Explicit neighboring $\eta$-operator data]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -823,7 +823,6 @@ strong subadditivity for a normalized three-site reduced state.
 \begin{theorem}[Closed-sector form of the physical-trace transfer]
     \label{thm:mpdo_closed_sector_physical_trace_transfer}
     \lean{MPOTensor.physTraceTransfer_eq_sum_closedSector}
-    \lean{MPOTensor.concrete_physTraceTransfer_eq_sum_closedSector}
     \leanok
     \uses{def:mpo_physical_trace_transfer,
         def:mpdo_closed_sector_tensors, thm:mpdo_sector_factorization}
@@ -834,8 +833,6 @@ strong subadditivity for a normalized three-site reduced state.
     \[
         \mathcal T_{\cal K}=\sum_k |l_k)(r_k|.
     \]
-    In particular, this holds for the sector tensors obtained from the
-    injective inverse-map construction.
     This identifies the transfer matrix of
     Definition~\ref{def:mpo_physical_trace_transfer} with the operator on the
     left-hand side of the zero-correlation-length identity in
@@ -846,14 +843,43 @@ strong subadditivity for a normalized three-site reduced state.
     \leanok
     \uses{thm:mpdo_sector_factorization}
     Trace the sector factorization over the physical index.  Unitary
-    invariance of the trace removes the Hayashi basis change, while the trace
-    of the block diagonal is the sum of the block traces.  In each sector,
+    invariance gives
+    \[
+        \tr\bigl(U_B\kappa_{\beta,\alpha}U_B^\dagger\bigr)
+        =\tr(\kappa_{\beta,\alpha}).
+    \]
+    The trace of the block diagonal is the sum of the block traces.  In each
+    sector,
     \[
         \tr\bigl((l_k)_\beta\otimes(r_k)_\alpha\bigr)
         =\tr[(l_k)_\beta]\,\tr[(r_k)_\alpha]
         =\bigl[|l_k)(r_k|\bigr]_{\beta,\alpha}.
     \]
     Summing over $k$ gives the asserted operator identity.
+\end{proof}
+
+\begin{corollary}[Physical-trace transfer from the inverse-map sectors]
+    \label{cor:mpdo_concrete_closed_sector_physical_trace_transfer}
+    \lean{MPOTensor.concrete_physTraceTransfer_eq_sum_closedSector}
+    \leanok
+    \uses{def:mpdo_injective_inverse_layer, def:mpdo_eta_structure,
+        thm:mpdo_closed_sector_physical_trace_transfer}
+    Let ${\cal K}$ be injective.  Let $R$ and $\rho$ give a three-site
+    closure of ${\cal K}$, choose a Hayashi decomposition of $\rho$, and fix
+    virtual indices $\alpha_1,\beta_3$ such that
+    $R_{\beta_3,\alpha_1}\ne0$.  For the corresponding closed sector tensors,
+    \[
+        \mathcal T_{\cal K}=\sum_k |l_k)(r_k|.
+    \]
+\end{corollary}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_sector_factorization,
+        thm:mpdo_closed_sector_physical_trace_transfer}
+    The inverse-map sector tensors satisfy the sector factorization of
+    Theorem~\ref{thm:mpdo_sector_factorization}.  Apply
+    Theorem~\ref{thm:mpdo_closed_sector_physical_trace_transfer}.
 \end{proof}
 
 \begin{theorem}[Normalized closed-sector pairing operator]
@@ -864,7 +890,7 @@ strong subadditivity for a normalized three-site reduced state.
     \leanok
     \uses{def:mpo_source_zcl,
         def:mpdo_injective_inverse_layer, def:mpdo_eta_structure,
-        thm:mpdo_closed_sector_physical_trace_transfer,
+        cor:mpdo_concrete_closed_sector_physical_trace_transfer,
         lem:mpo_source_zcl_normalized_idempotent}
     Let ${\cal K}$ be injective.  Let $R$ and $\rho$ give a three-site
     closure of ${\cal K}$, choose a Hayashi decomposition of $\rho$, and fix
@@ -895,7 +921,8 @@ strong subadditivity for a normalized three-site reduced state.
         lem:mpo_source_zcl_normalized_idempotent}
     Substitute
     $S=\mathcal T_{\cal K}$ from
-    Theorem~\ref{thm:mpdo_closed_sector_physical_trace_transfer} into the
+    Corollary~\ref{cor:mpdo_concrete_closed_sector_physical_trace_transfer}
+    into the
     defining relation
     $\mathcal T_{\cal K}^2=\lambda\mathcal T_{\cal K}$, and then apply
     Lemma~\ref{lem:mpo_source_zcl_normalized_idempotent}.  Under literal

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -839,8 +839,7 @@ strong subadditivity for a normalized three-site reduced state.
     \lean{MPOTensor.physTraceTransfer_eq_sum_closedSector}
     \leanok
     \uses{def:mpo_physical_trace_transfer,
-        def:mpdo_closed_sector_pairing_operator,
-        thm:mpdo_sector_factorization}
+        def:mpdo_closed_sector_pairing_operator}
     More generally, any sector factorization
     $U_B\kappa_{\beta,\alpha}U_B^\dagger
     =\bigoplus_k(l_k)_\beta\otimes(r_k)_\alpha$ gives the closed-sector
@@ -1271,10 +1270,10 @@ strong subadditivity for a normalized three-site reduced state.
     and the sector tensors can be chosen so that each factor is positive
     semidefinite \cite[Appendix~C.2, lines~1446--1450]{Cirac2016MPDO_arXiv}.
     The all-length sector identity is
-    Theorem~\ref{thm:mpdo_sector_adapted_decomposition}.  Its positivity does
-    not, by itself, choose a coherent phase for every individual
-    $\eta_{k,h}$, so positivity remains a hypothesis on the chosen
-    representatives here.
+    Theorem~\ref{thm:mpdo_sector_adapted_decomposition}.  That algebraic
+    identity does not by itself choose coherent positive representatives for
+    all neighboring pairs, so positive semidefiniteness remains a hypothesis
+    on the chosen representatives here.
 \end{definition}
 
 \begin{theorem}[Trace matrix of the sector-tensor $\eta$-data]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -863,9 +863,15 @@ strong subadditivity for a normalized three-site reduced state.
     \lean{MPOTensor.closedSector_operator_idempotent_of_physTraceTransfer_sq}
     \leanok
     \uses{def:mpo_source_zcl,
+        def:mpdo_injective_inverse_layer, def:mpdo_eta_structure,
         thm:mpdo_closed_sector_physical_trace_transfer,
         lem:mpo_source_zcl_normalized_idempotent}
-    Suppose ${\cal K}$ has source zero correlation length and set
+    Let ${\cal K}$ be injective.  Let $R$ and $\rho$ give a three-site
+    closure of ${\cal K}$, choose a Hayashi decomposition of $\rho$, and fix
+    virtual indices $\alpha_1,\beta_3$ such that
+    $R_{\beta_3,\alpha_1}\ne0$.  Form the corresponding closed sector
+    tensors $|l_k)$ and $(r_k|$.  If ${\cal K}$ has source zero correlation
+    length, set
     \[
         S:=\sum_k |l_k)(r_k|.
     \]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -794,6 +794,20 @@ strong subadditivity for a normalized three-site reduced state.
     in Figure~\ref{fig:mpdo_sector_pairing}.
 \end{definition}
 
+\begin{definition}[Closed-sector pairing operator]
+    \label{def:mpdo_closed_sector_pairing_operator}
+    \lean{MPOTensor.closedSectorPairingOperator}
+    \leanok
+    \uses{def:mpdo_closed_sector_tensors}
+    For sector tensors $(l_k)_\beta$ and $(r_k)_\alpha$, close their physical
+    legs and set
+    \[
+        S:=\sum_k |l_k)(r_k|.
+    \]
+    This is the pairing operator displayed in
+    \cite[Appendix~C.2, lines~1473--1493]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
 \begin{theorem}[Sector trace pairing]
     \label{thm:mpdo_sector_trace_pairing}
     \lean{MPOTensor.trace_sectorEta}
@@ -825,7 +839,8 @@ strong subadditivity for a normalized three-site reduced state.
     \lean{MPOTensor.physTraceTransfer_eq_sum_closedSector}
     \leanok
     \uses{def:mpo_physical_trace_transfer,
-        def:mpdo_closed_sector_tensors, thm:mpdo_sector_factorization}
+        def:mpdo_closed_sector_pairing_operator,
+        thm:mpdo_sector_factorization}
     More generally, any sector factorization
     $U_B\kappa_{\beta,\alpha}U_B^\dagger
     =\bigoplus_k(l_k)_\beta\otimes(r_k)_\alpha$ gives the closed-sector

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -841,7 +841,6 @@ strong subadditivity for a normalized three-site reduced state.
 
 \begin{proof}
     \leanok
-    \uses{thm:mpdo_sector_factorization}
     Trace the sector factorization over the physical index.  Unitary
     invariance gives
     \[
@@ -917,7 +916,7 @@ strong subadditivity for a normalized three-site reduced state.
 
 \begin{proof}
     \leanok
-    \uses{thm:mpdo_closed_sector_physical_trace_transfer,
+    \uses{cor:mpdo_concrete_closed_sector_physical_trace_transfer,
         lem:mpo_source_zcl_normalized_idempotent}
     Substitute
     $S=\mathcal T_{\cal K}$ from

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -820,6 +820,76 @@ strong subadditivity for a normalized three-site reduced state.
     \]
 \end{proof}
 
+\begin{theorem}[Closed-sector form of the physical-trace transfer]
+    \label{thm:mpdo_closed_sector_physical_trace_transfer}
+    \lean{MPOTensor.physTraceTransfer_eq_sum_closedSector}
+    \lean{MPOTensor.concrete_physTraceTransfer_eq_sum_closedSector}
+    \leanok
+    \uses{def:mpo_physical_trace_transfer,
+        def:mpdo_closed_sector_tensors, thm:mpdo_sector_factorization}
+    For the sector tensors obtained from the injective inverse-map
+    construction, the physical-trace transfer is the closed-sector pairing
+    operator:
+    \[
+        \mathcal T_{\cal K}=\sum_k |l_k)(r_k|.
+    \]
+    This identifies the transfer matrix of
+    Definition~\ref{def:mpo_physical_trace_transfer} with the operator on the
+    left-hand side of the zero-correlation-length identity in
+    \cite[Appendix~C.2, lines~1489--1493]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_sector_factorization}
+    Trace the sector factorization over the physical index.  Unitary
+    invariance of the trace removes the Hayashi basis change, while the trace
+    of the block diagonal is the sum of the block traces.  In each sector,
+    \[
+        \tr\bigl((l_k)_\beta\otimes(r_k)_\alpha\bigr)
+        =\tr[(l_k)_\beta]\,\tr[(r_k)_\alpha]
+        =\bigl[|l_k)(r_k|\bigr]_{\beta,\alpha}.
+    \]
+    Summing over $k$ gives the asserted operator identity.
+\end{proof}
+
+\begin{theorem}[Normalized closed-sector pairing operator]
+    \label{thm:mpdo_closed_sector_pairing_normalized_idempotent}
+    \lean{MPOTensor.closedSector_operator_quasi_idempotent}
+    \lean{MPOTensor.closedSector_operator_normalized_idempotent}
+    \leanok
+    \uses{def:mpo_source_zcl,
+        thm:mpdo_closed_sector_physical_trace_transfer,
+        lem:mpo_source_zcl_normalized_idempotent}
+    Suppose ${\cal K}$ has source zero correlation length and set
+    \[
+        S:=\sum_k |l_k)(r_k|.
+    \]
+    Then there is a real number $\lambda>0$ such that
+    \[
+        S^2=\lambda S,
+        \qquad
+        (\lambda^{-1}S)^2=\lambda^{-1}S.
+    \]
+    The paper works with the canonically normalized representative
+    $\lambda=1$ in the display preceding
+    \cite[Appendix~C.2, Lemma~C.5]{Cirac2016MPDO_arXiv}; the first identity
+    records the rescaling-invariant form of the same zero-correlation-length
+    condition.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_closed_sector_physical_trace_transfer,
+        lem:mpo_source_zcl_normalized_idempotent}
+    Substitute
+    $S=\mathcal T_{\cal K}$ from
+    Theorem~\ref{thm:mpdo_closed_sector_physical_trace_transfer} into the
+    defining relation
+    $\mathcal T_{\cal K}^2=\lambda\mathcal T_{\cal K}$, and then apply
+    Lemma~\ref{lem:mpo_source_zcl_normalized_idempotent}.
+\end{proof}
+
 \begin{definition}[Explicit neighboring $\eta$-operator data]
     \label{def:mpdo_explicit_eta_operators}
     \lean{MPOTensor.etaOperators}
@@ -1147,8 +1217,11 @@ strong subadditivity for a normalized three-site reduced state.
     \]
     and the sector tensors can be chosen so that each factor is positive
     semidefinite \cite[Appendix~C.2, lines~1446--1450]{Cirac2016MPDO_arXiv}.
-    That all-length identity is a remaining step of Lemma~C.4, so positivity
-    enters here as a hypothesis on the chosen representatives.
+    The all-length sector identity is
+    Theorem~\ref{thm:mpdo_sector_adapted_decomposition}.  Its positivity does
+    not, by itself, choose a coherent phase for every individual
+    $\eta_{k,h}$, so positivity remains a hypothesis on the chosen
+    representatives here.
 \end{definition}
 
 \begin{theorem}[Trace matrix of the sector-tensor $\eta$-data]

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -211,9 +211,11 @@ declarations are \leanid{MPOTensor.sectorEta},
 \leanid{MPOTensor.ExplicitEtaOperators.ofSectorTensors}.}  The source derives
 positivity of the $\eta_{k,h}$ from the all-length projected chain identity at
 lines 1446--1450, choosing the sector tensors so that each factor is positive
-semidefinite; until that identity is available, positive semidefiniteness of
-the chosen representatives enters the construction of the explicit
-$\eta$-data as a hypothesis.
+semidefinite.  That all-length algebraic identity is now formalized, but it
+does not by itself choose coherent positive representatives for all
+neighboring pairs.  Positive semidefiniteness of the chosen representatives
+therefore still enters the construction of the explicit $\eta$-data as a
+hypothesis.
 
 The Hayashi decomposition of the concrete closure state is now formalized for
 the four-site chain.  Independent bijections on the three tensor factors

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -217,7 +217,7 @@ neighboring pairs.  Positive semidefiniteness of the chosen representatives
 therefore still enters the construction of the explicit $\eta$-data as a
 hypothesis.
 
-The earlier summary figure path{MPDO_etahk=RhLk.png} at source line 1391
+The earlier summary figure \path{MPDO_etahk=RhLk.png} at source line 1391
 draws $r_h$ next to $l_k$ while naming the operator $\eta_{k,h}$.  The later
 definition 	exttt{etarl}, the identity $T_{k,h}=(r_k|l_h)$, and the products
 $\eta_{k,l}\otimes\eta_{l,h}$ in Proposition 	exttt{3to5} consistently fix

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -217,6 +217,13 @@ neighboring pairs.  Positive semidefiniteness of the chosen representatives
 therefore still enters the construction of the explicit $\eta$-data as a
 hypothesis.
 
+The earlier summary figure path{MPDO_etahk=RhLk.png} at source line 1391
+draws $r_h$ next to $l_k$ while naming the operator $\eta_{k,h}$.  The later
+definition 	exttt{etarl}, the identity $T_{k,h}=(r_k|l_h)$, and the products
+$\eta_{k,l}\otimes\eta_{l,h}$ in Proposition 	exttt{3to5} consistently fix
+the intended convention as $\eta_{k,h}=r_k l_h$.  The formalization follows
+this later consistent convention; the earlier figure is an index-swap typo.
+
 The Hayashi decomposition of the concrete closure state is now formalized for
 the four-site chain.  Independent bijections on the three tensor factors
 preserve equality in strong subadditivity: each marginal is carried to the

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -219,8 +219,8 @@ hypothesis.
 
 The earlier summary figure \path{MPDO_etahk=RhLk.png} at source line 1391
 draws $r_h$ next to $l_k$ while naming the operator $\eta_{k,h}$.  The later
-definition 	exttt{etarl}, the identity $T_{k,h}=(r_k|l_h)$, and the products
-$\eta_{k,l}\otimes\eta_{l,h}$ in Proposition 	exttt{3to5} consistently fix
+definition \texttt{etarl}, the identity $T_{k,h}=(r_k|l_h)$, and the products
+$\eta_{k,l}\otimes\eta_{l,h}$ in Proposition \texttt{3to5} consistently fix
 the intended convention as $\eta_{k,h}=r_k l_h$.  The formalization follows
 this later consistent convention; the earlier figure is an index-swap typo.
 


### PR DESCRIPTION
This PR identifies the closed-sector pairing operator of arXiv:1606.00608, Appendix C.2, with the physical-trace transfer of the injective simple tensor: `𝒯_K = ∑ₖ |lₖ)(rₖ|`.

It derives the rescaling-invariant source zero-correlation-length relation `S² = λS`, idempotence of the normalized operator `λ⁻¹S`, and the exact raw identity `S² = S` for the canonically normalized representative with literally idempotent physical-trace transfer. This supplies the concrete operator identity used by Lemma C.5 without imposing positivity, linear independence, or a real structure on the individual closed tensors.

The blueprint states both the rescaling-invariant and canonical forms. Stale prose is also corrected to record that the all-length sector decomposition is complete while the coherent positive choice of the individual `η_{k,h}` remains open.

This advances #3593. The remaining rank-one step requires a complex pairing interface together with source-derived independence or an equivalent exclusion of the zero-eigenvalue nilpotent part.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization and documentation in the MPDO sector/ZCL track; no auth, runtime, or API surface changes.
> 
> **Overview**
> Adds **`TNLean/MPS/MPDO/SectorPairingTransfer.lean`** and wires it into the public import surface. The new module defines **`closedSectorPairingOperator`** and proves **`physTraceTransfer`** equals \(\sum_k |l_k)(r_k|\) from a sector factorization, with a concrete instance for inverse-map sector tensors. **Source zero correlation length** is then transported to quasi-idempotence \(S^2 = \lambda S\), normalized idempotence, and raw \(S^2 = S\) when **`physTraceTransfer`** is literally idempotent.
> 
> The blueprint chapter gains matching definitions and theorems (closed-sector pairing operator, physical-trace transfer identity, ZCL consequences). **Docs and comments** are updated to say the all-length sector decomposition is formalized while **coherent positive \(\eta_{k,h}\) representatives** remain a hypothesis; the paper-gap note clarifies the \(\eta_{k,h} = r_k l_h\) convention vs. an earlier figure typo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15e5704fb6d156336cb5e5a12d501beb1f0ac8f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->