### PR TITLE
feat(MPS/MPDO): prove state preparation is CPTP

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -55,6 +55,7 @@ import TNLean.Algebra.StarSubalgebraUnitaryIntertwiner
 import TNLean.Analysis.ProjectionGeometry
 -- Layer 0b: Trace of the Hermitian functional calculus (Mathlib-only matrix lemma)
 import TNLean.Analysis.TraceCFC
+import TNLean.Analysis.MatrixSqrt
 import TNLean.Analysis.CfcConjugation
 import TNLean.Analysis.MatrixOrderTopology
 import TNLean.Analysis.CfcLogAdditive

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -53,7 +53,7 @@ import TNLean.Algebra.StarSubalgebraUnitaryIntertwiner
 
 -- Layer 0b: General analysis
 import TNLean.Analysis.ProjectionGeometry
--- Layer 0b: Trace of the Hermitian functional calculus (Mathlib-only matrix lemma)
+-- Layer 0b: Hermitian functional calculus for finite-dimensional matrices
 import TNLean.Analysis.TraceCFC
 import TNLean.Analysis.MatrixSqrt
 import TNLean.Analysis.CfcConjugation

--- a/TNLean/Analysis/MarginalSupport.lean
+++ b/TNLean/Analysis/MarginalSupport.lean
@@ -2,8 +2,7 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Mathlib.Analysis.Matrix.PosDef
-import Mathlib.Analysis.SpecialFunctions.Sqrt
+import TNLean.Analysis.MatrixSqrt
 import TNLean.Analysis.Entropy
 import TNLean.Analysis.TraceCFC
 
@@ -69,45 +68,6 @@ open scoped Matrix ComplexOrder Kronecker
 open Matrix Finset
 
 namespace Matrix
-
-/-! ## Positive semidefinite square root via the Hermitian functional calculus -/
-
-section Sqrt
-
-variable {n : Type*} [Fintype n] [DecidableEq n]
-
-/-- The Hermitian functional calculus square root $\sqrt\rho$, realized by
-`Real.sqrt` through the Hermitian functional calculus, of a positive semidefinite
-matrix is Hermitian. -/
-theorem PosSemidef.cfc_sqrt_isHermitian {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) :
-    (hρ.isHermitian.cfc Real.sqrt).IsHermitian := by
-  rw [hρ.isHermitian.cfc_form Real.sqrt, Matrix.star_eq_conjTranspose]
-  have hD : (Matrix.diagonal
-      (fun i => ((Real.sqrt (hρ.isHermitian.eigenvalues i) : ℝ) : ℂ))).IsHermitian := by
-    apply Matrix.IsHermitian.ext
-    intro i j
-    by_cases hij : i = j
-    · subst hij; simp
-    · simp [Matrix.diagonal_apply_ne _ hij, Matrix.diagonal_apply_ne _ (Ne.symm hij)]
-  exact Matrix.isHermitian_mul_mul_conjTranspose _ hD
-
-/-- The square of the Hermitian functional calculus square root recovers a
-positive semidefinite matrix: $\sqrt\rho \, \sqrt\rho = \rho$. The pointwise
-identity $\sqrt\lambda \, \sqrt\lambda = \lambda$ holds because every eigenvalue
-$\lambda$ of $\rho$ is nonnegative. -/
-theorem PosSemidef.cfc_sqrt_mul_self {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) :
-    hρ.isHermitian.cfc Real.sqrt * hρ.isHermitian.cfc Real.sqrt = ρ := by
-  rw [← hρ.isHermitian.cfc_mul]
-  have hcongr : hρ.isHermitian.cfc (fun x => Real.sqrt x * Real.sqrt x)
-      = hρ.isHermitian.cfc id := by
-    rw [Matrix.IsHermitian.cfc, Matrix.IsHermitian.cfc]
-    congr 2
-    funext i
-    simp only [Function.comp_apply, id_eq]
-    exact congrArg (RCLike.ofReal) (Real.mul_self_sqrt (hρ.eigenvalues_nonneg i))
-  rw [hcongr, hρ.isHermitian.cfc_id]
-
-end Sqrt
 
 /-! ## Core lemma: a projection with zero expectation annihilates a state -/
 

--- a/TNLean/Analysis/MatrixSqrt.lean
+++ b/TNLean/Analysis/MatrixSqrt.lean
@@ -1,0 +1,59 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Analysis.TraceCFC
+import Mathlib.Analysis.Matrix.PosDef
+import Mathlib.Analysis.SpecialFunctions.Sqrt
+
+/-!
+# Positive-semidefinite matrix square roots
+
+This file records the two elementary Hermitian functional-calculus facts about
+the positive-semidefinite square root used throughout the finite-dimensional
+operator theory development.
+
+## Main results
+
+* `Matrix.PosSemidef.cfc_sqrt_isHermitian`: the functional-calculus square
+  root of a positive-semidefinite matrix is Hermitian.
+* `Matrix.PosSemidef.cfc_sqrt_mul_self`: the square of that square root is the
+  original matrix.
+-/
+
+open scoped Matrix ComplexOrder
+
+namespace Matrix
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- The Hermitian functional-calculus square root of a positive-semidefinite
+matrix is Hermitian. -/
+theorem PosSemidef.cfc_sqrt_isHermitian {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) :
+    (hρ.isHermitian.cfc Real.sqrt).IsHermitian := by
+  rw [hρ.isHermitian.cfc_form Real.sqrt, Matrix.star_eq_conjTranspose]
+  have hD : (Matrix.diagonal
+      (fun i => ((Real.sqrt (hρ.isHermitian.eigenvalues i) : ℝ) : ℂ))).IsHermitian := by
+    apply Matrix.IsHermitian.ext
+    intro i j
+    by_cases hij : i = j
+    · subst hij
+      simp
+    · simp [Matrix.diagonal_apply_ne _ hij, Matrix.diagonal_apply_ne _ (Ne.symm hij)]
+  exact Matrix.isHermitian_mul_mul_conjTranspose _ hD
+
+/-- The square of the Hermitian functional-calculus square root recovers the
+positive-semidefinite matrix. -/
+theorem PosSemidef.cfc_sqrt_mul_self {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) :
+    hρ.isHermitian.cfc Real.sqrt * hρ.isHermitian.cfc Real.sqrt = ρ := by
+  rw [← hρ.isHermitian.cfc_mul]
+  have hcongr : hρ.isHermitian.cfc (fun x => Real.sqrt x * Real.sqrt x)
+      = hρ.isHermitian.cfc id := by
+    rw [Matrix.IsHermitian.cfc, Matrix.IsHermitian.cfc]
+    congr 2
+    funext i
+    simp only [Function.comp_apply, id_eq]
+    exact congrArg (RCLike.ofReal) (Real.mul_self_sqrt (hρ.eigenvalues_nonneg i))
+  rw [hcongr, hρ.isHermitian.cfc_id]
+
+end Matrix

--- a/TNLean/MPS/MPDO/KrausCPTP.lean
+++ b/TNLean/MPS/MPDO/KrausCPTP.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.MPDO.Defs
+import TNLean.Analysis.MatrixSqrt
 
 /-!
 # Trace-preserving completely positive maps in Kraus form
@@ -20,9 +21,11 @@ dimensions.
 * `isKrausCPTP_id`: the identity map is trace-preserving completely positive.
 * `isKrausCPTP_comp`: composition preserves the trace-preserving completely
   positive property.
+* `Matrix.preparationMap_isKrausCPTP`: adjoining a density matrix is a
+  trace-preserving completely positive map.
 -/
 
-open scoped Matrix BigOperators
+open scoped Matrix BigOperators ComplexOrder
 
 /-- A **trace-preserving completely positive map** in Kraus form
 `S(X) = ∑ᵢ Aᵢ X Aᵢ†` with `∑ᵢ Aᵢ† Aᵢ = I`; rectangular Kraus operators
@@ -76,3 +79,118 @@ theorem isKrausCPTP_comp {α β γ : Type*} [Fintype α] [DecidableEq α] [Finty
         = (B j)ᴴ * ((∑ i : Fin r, (A i)ᴴ * A i) * B j) := by
       simp only [Matrix.sum_mul, Matrix.mul_sum, Matrix.mul_assoc]
     rw [step, hA_tp, Matrix.one_mul]
+
+namespace Matrix
+
+/-- The state-preparation map $X\mapsto X\otimes\rho$.  This is the
+elementary operation used to adjoin the positive neighboring operators in
+the maps $\mathcal T_1$ and $\mathcal S_1$ of arXiv:1606.00608,
+Appendix C.2, lines 1527--1533 and 1551--1555. -/
+noncomputable def preparationMap {α β : Type*} [Fintype α] [DecidableEq α]
+    [Fintype β] [DecidableEq β] (ρ : Matrix β β ℂ) :
+    Matrix α α ℂ →ₗ[ℂ] Matrix (α × β) (α × β) ℂ where
+  toFun X := Matrix.kroneckerMap (· * ·) X ρ
+  map_add' X Y := Matrix.add_kronecker X Y ρ
+  map_smul' c X := Matrix.smul_kronecker c X ρ
+
+private noncomputable def preparationKraus
+    {α β : Type*} [Fintype α] [DecidableEq α]
+    [Fintype β] [DecidableEq β] (ρ : Matrix β β ℂ) (hρ : ρ.PosSemidef) (j : β) :
+    Matrix (α × β) α ℂ :=
+  let R := hρ.isHermitian.cfc Real.sqrt
+  Matrix.of fun p a => if p.1 = a then R p.2 j else 0
+
+private theorem preparationKraus_mul_apply {α β : Type*} [Fintype α] [DecidableEq α]
+    [Fintype β] [DecidableEq β] (ρ : Matrix β β ℂ) (hρ : ρ.PosSemidef)
+    (j : β) (X : Matrix α α ℂ) (p : α × β) (b : α) :
+    (preparationKraus (α := α) ρ hρ j * X) p b =
+      (hρ.isHermitian.cfc Real.sqrt) p.2 j * X p.1 b := by
+  rw [Matrix.mul_apply]
+  rw [Finset.sum_eq_single p.1]
+  · simp [preparationKraus]
+  · intro a _ ha
+    simp [preparationKraus, Ne.symm ha]
+  · intro hmem
+    simp at hmem
+
+private theorem preparationKraus_mul_conjTranspose_apply
+    {α β : Type*} [Fintype α] [DecidableEq α]
+    [Fintype β] [DecidableEq β] (ρ : Matrix β β ℂ) (hρ : ρ.PosSemidef)
+    (j : β) (X : Matrix α α ℂ) (p q : α × β) :
+    (preparationKraus (α := α) ρ hρ j * X * (preparationKraus (α := α) ρ hρ j)ᴴ) p q =
+      X p.1 q.1 * ((hρ.isHermitian.cfc Real.sqrt) p.2 j *
+        star ((hρ.isHermitian.cfc Real.sqrt) q.2 j)) := by
+  rw [Matrix.mul_apply]
+  rw [Finset.sum_eq_single q.1]
+  · rw [preparationKraus_mul_apply]
+    simp [preparationKraus, Matrix.conjTranspose_apply]
+    ring
+  · intro b _ hb
+    rw [preparationKraus_mul_apply]
+    simp [preparationKraus, Matrix.conjTranspose_apply, Ne.symm hb]
+  · intro hmem
+    simp at hmem
+
+private theorem preparationKraus_conjTranspose_mul_apply
+    {α β : Type*} [Fintype α] [DecidableEq α]
+    [Fintype β] [DecidableEq β] (ρ : Matrix β β ℂ) (hρ : ρ.PosSemidef)
+    (j : β) (a b : α) :
+    ((preparationKraus (α := α) ρ hρ j)ᴴ * preparationKraus (α := α) ρ hρ j) a b =
+      if a = b then ∑ t : β, star ((hρ.isHermitian.cfc Real.sqrt) t j) *
+        (hρ.isHermitian.cfc Real.sqrt) t j else 0 := by
+  rw [Matrix.mul_apply, Fintype.sum_prod_type]
+  by_cases hab : a = b
+  · subst b
+    simp [preparationKraus, Matrix.conjTranspose_apply]
+  · simp [preparationKraus, Matrix.conjTranspose_apply, hab, Ne.symm hab]
+
+/-- Adjoining a positive-semidefinite matrix of trace one is a
+trace-preserving completely positive map.  Its Kraus operators are obtained
+from the columns of $\sqrt\rho$.
+
+This is the state-preparation step used in the construction of
+$\mathcal T_1$ and $\mathcal S_1$ in arXiv:1606.00608, Appendix C.2,
+lines 1527--1533 and 1551--1555. -/
+theorem preparationMap_isKrausCPTP
+    {α β : Type*} [Fintype α] [DecidableEq α]
+    [Fintype β] [DecidableEq β] (ρ : Matrix β β ℂ) (hρ : ρ.PosSemidef)
+    (hρtr : ρ.trace = 1) : IsKrausCPTP (Matrix.preparationMap (α := α) ρ) := by
+  classical
+  let R := hρ.isHermitian.cfc Real.sqrt
+  have hRherm : R.IsHermitian := hρ.cfc_sqrt_isHermitian
+  have hRR : R * R = ρ := hρ.cfc_sqrt_mul_self
+  refine ⟨Fintype.card β,
+    fun j => preparationKraus ρ hρ ((Fintype.equivFin β).symm j), ?_, ?_⟩
+  · intro X
+    ext p q
+    change X p.1 q.1 * ρ p.2 q.2 = _
+    have hRRentry : ρ p.2 q.2 = (R * R) p.2 q.2 :=
+      congrArg (fun M : Matrix β β ℂ => M p.2 q.2) hRR.symm
+    rw [hRRentry, Matrix.mul_apply, Finset.mul_sum, Matrix.sum_apply]
+    rw [← Equiv.sum_comp (Fintype.equivFin β).symm]
+    refine Finset.sum_congr rfl fun j _ => ?_
+    rw [preparationKraus_mul_conjTranspose_apply]
+    rw [hRherm.apply]
+  · ext a b
+    have hsum : ∑ j : β, ∑ t : β, star (R t j) * R t j = 1 := by
+      calc
+        ∑ j : β, ∑ t : β, star (R t j) * R t j = (R * R).trace := by
+          simp_rw [hRherm.apply]
+          rfl
+        _ = ρ.trace := congrArg Matrix.trace hRR
+        _ = 1 := hρtr
+    by_cases hab : a = b
+    · subst b
+      rw [Matrix.one_apply_eq, Matrix.sum_apply]
+      simp_rw [preparationKraus_conjTranspose_mul_apply, if_pos]
+      change (∑ x : Fin (Fintype.card β),
+        ∑ t : β, star (R t ((Fintype.equivFin β).symm x)) *
+          R t ((Fintype.equivFin β).symm x)) = 1
+      exact (Equiv.sum_comp (Fintype.equivFin β).symm
+        (fun j : β => ∑ t : β, star (R t j) * R t j)).trans hsum
+    · rw [Matrix.one_apply_ne hab, Matrix.sum_apply]
+      apply Finset.sum_eq_zero
+      intro j _
+      rw [preparationKraus_conjTranspose_mul_apply, if_neg hab]
+
+end Matrix

--- a/TNLean/MPS/MPDO/KrausCPTP.lean
+++ b/TNLean/MPS/MPDO/KrausCPTP.lean
@@ -86,7 +86,7 @@ namespace Matrix
 elementary operation used to adjoin the positive neighboring operators in
 the maps $\mathcal T_1$ and $\mathcal S_1$ of arXiv:1606.00608,
 Appendix C.2, lines 1527--1533 and 1551--1555. -/
-noncomputable def preparationMap {α β : Type*} [Fintype α] [DecidableEq α]
+def preparationMap {α β : Type*} [Fintype α] [DecidableEq α]
     [Fintype β] [DecidableEq β] (ρ : Matrix β β ℂ) :
     Matrix α α ℂ →ₗ[ℂ] Matrix (α × β) (α × β) ℂ where
   toFun X := Matrix.kroneckerMap (· * ·) X ρ
@@ -151,7 +151,7 @@ from the columns of $\sqrt\rho$.
 This is the state-preparation step used in the construction of
 $\mathcal T_1$ and $\mathcal S_1$ in arXiv:1606.00608, Appendix C.2,
 lines 1527--1533 and 1551--1555. -/
-theorem preparationMap_isKrausCPTP
+lemma preparationMap_isKrausCPTP
     {α β : Type*} [Fintype α] [DecidableEq α]
     [Fintype β] [DecidableEq β] (ρ : Matrix β β ℂ) (hρ : ρ.PosSemidef)
     (hρtr : ρ.trace = 1) : IsKrausCPTP (Matrix.preparationMap (α := α) ρ) := by

--- a/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
@@ -65,7 +65,6 @@
     \label{def:mpdo_state_preparation_map}
     \lean{Matrix.preparationMap}
     \leanok
-    \uses{def:is_kraus_cptp}
     Let $\rho$ be a matrix on a finite-dimensional space $B$.  The
     state-preparation map from matrices on $A$ to matrices on $A\otimes B$ is
     \[

--- a/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
@@ -61,6 +61,46 @@
     \]
 \end{proof}
 
+\begin{definition}[State-preparation map]
+    \label{def:mpdo_state_preparation_map}
+    \lean{Matrix.preparationMap}
+    \leanok
+    \uses{def:is_kraus_cptp}
+    Let $\rho$ be a matrix on a finite-dimensional space $B$.  The
+    state-preparation map from matrices on $A$ to matrices on $A\otimes B$ is
+    \[
+        \mathcal P_\rho(X)=X\otimes\rho.
+    \]
+    This is the elementary preparation operation used in the maps
+    $\mathcal T_1$ and $\mathcal S_1$ of
+    \cite[Appendix~C.2, lines~1527--1533 and~1551--1555]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{lemma}[State preparation is trace-preserving completely positive]
+    \label{lem:mpdo_state_preparation_cptp}
+    \lean{Matrix.preparationMap_isKrausCPTP}
+    \leanok
+    \uses{def:mpdo_state_preparation_map, def:is_kraus_cptp}
+    If $\rho\geq0$ and $\tr(\rho)=1$, then
+    $\mathcal P_\rho:X\mapsto X\otimes\rho$ is trace-preserving completely
+    positive.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Let $R=\sqrt\rho$.  For an orthonormal basis $(e_j)_j$ of $B$, define
+    rectangular Kraus operators
+    \[
+        A_j(e_a)=e_a\otimes Re_j.
+    \]
+    Then
+    \[
+        \sum_j A_jXA_j^\dagger=X\otimes RR=X\otimes\rho,
+        \qquad
+        \sum_j A_j^\dagger A_j=\tr(RR)I_A=I_A.
+    \]
+\end{proof}
+
 \begin{definition}[One- and two-site physical closure maps]
     \label{def:phys_close}
     \lean{MPOTensor.physClose1, MPOTensor.physClose2}


### PR DESCRIPTION
This PR advances #3741 by formalizing the state-preparation operation used in the Appendix C.2 constructions of (\mathcal T_1) and (\mathcal S_1).

It introduces the linear map
[
X \longmapsto X \otimes \rho
]
and proves, under exactly (\rho\geq 0) and (\operatorname{tr}(\rho)=1), that it is trace-preserving and completely positive by an explicit rectangular Kraus family formed from the columns of (\sqrt\rho).

The two reusable functional-calculus square-root lemmas are moved from `MarginalSupport` into a small `Analysis.MatrixSqrt` module. Their statements and proofs are unchanged. The blueprint records the preparation map and its CPTP proof with the source lines from arXiv:1606.00608, Appendix C.2.

This is a partial step toward #3741. Partial traces, permutations, and controlled direct sums remain for subsequent focused PRs. The three Proposition C.7 tensor-network diagrams are intentionally deferred until the composite maps they depict are proved.

Checks performed:
- `lake build TNLean` (9292 jobs)
- `lake exe checkdecls blueprint/lean_decls`
- blueprint/Lean synchronization (15/15 declarations in the chapter)
- `git diff --check`
- no new `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New Kraus/CPTP formalization in the MPDO channel layer is mathematically sensitive but scoped; the MatrixSqrt extraction is a no-op refactor with unchanged proofs.
> 
> **Overview**
> Adds **`Matrix.preparationMap`** (\(X \mapsto X \otimes \rho\)) and proves **`preparationMap_isKrausCPTP`**: for \(\rho \geq 0\) and \(\mathrm{tr}(\rho)=1\), adjoining \(\rho\) is trace-preserving and completely positive via rectangular Kraus operators built from columns of \(\sqrt\rho\). This is the preparation step for \(\mathcal T_1\) and \(\mathcal S_1\) in arXiv:1606.00608 Appendix C.2.
> 
> **Refactor:** the Hermitian functional-calculus square-root lemmas (`cfc_sqrt_isHermitian`, `cfc_sqrt_mul_self`) move from `MarginalSupport` into new **`TNLean.Analysis.MatrixSqrt`** (statements unchanged); `MarginalSupport` and `KrausCPTP` import that module. Root **`TNLean.lean`** exports `MatrixSqrt`.
> 
> **Blueprint:** records the preparation map definition and CPTP lemma with Lean links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbda039277ddd077d211da2fb4bdd2f27bb1de82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->