### PR TITLE
feat(MPS/MPDO): define length-indexed physical closures

### DIFF
--- a/TNLean/MPS/MPDO/RFPViaTS.lean
+++ b/TNLean/MPS/MPDO/RFPViaTS.lean
@@ -10,7 +10,7 @@ import TNLean.MPS.MPDO.KrausCPTP
 This file states the source-faithful renormalization-fixed-point notion for
 matrix product density operators, following
 arXiv:1606.00608 (Cirac–Pérez-García–Schuch–Verstraete), Definition 4.1
-(paper label `RFPMixedTS`, line 657, figures `MPDO_XM`, `MPDO_XMM`,
+(paper label `RFPMixedTS`, line 657, figures MPDO_XM, MPDO_XMM,
 `MPDO_TandS`).
 
 In the paper, a tensor `M` in canonical form generating MPDOs is a renormalization
@@ -25,9 +25,9 @@ ring:
 for all virtual operators `X`. Here, with the physical legs left open,
 
 * `(M₁ X) i j = tr(M^{ij} X)` is the one-site physical operator (figure
-  `MPDO_XM`), and
+  MPDO_XM), and
 * `(M₂ X) (i₁,i₂) (j₁,j₂) = tr(M^{i₁j₁} M^{i₂j₂} X)` is the two-site physical
-  operator (figure `MPDO_XMM`).
+  operator (figure MPDO_XMM).
 
 Following the codebase convention (as for `MPOTensor.IsRFP` and `MPOTensor.IsZCL`),
 `IsRFPViaTS` is stated on a bare `MPOTensor`; the source's standing hypotheses
@@ -92,15 +92,15 @@ noncomputable def physCloseN (M : MPOTensor d D) (N : ℕ) :
   rfl
 
 /-- The length-one physical closure has the source coefficient formula from
-arXiv:1606.00608, Definition 4.1, line 657 and figure `MPDO_XM`. -/
-@[simp] lemma physCloseN_one_apply (M : MPOTensor d D)
+arXiv:1606.00608, Definition 4.1, line 657 and figure MPDO_XM. -/
+lemma physCloseN_one_apply (M : MPOTensor d D)
     (X : Matrix (Fin D) (Fin D) ℂ) (σ τ : Fin 1 → Fin d) :
     physCloseN M 1 X σ τ = Matrix.trace (M (σ 0) (τ 0) * X) := by
   simp [physCloseN, List.ofFn_succ, evalWord_cons]
 
 /-- The length-two physical closure has the source coefficient formula from
-arXiv:1606.00608, Definition 4.1, line 657 and figure `MPDO_XMM`. -/
-@[simp] lemma physCloseN_two_apply (M : MPOTensor d D)
+arXiv:1606.00608, Definition 4.1, line 657 and figure MPDO_XMM. -/
+lemma physCloseN_two_apply (M : MPOTensor d D)
     (X : Matrix (Fin D) (Fin D) ℂ) (σ τ : Fin 2 → Fin d) :
     physCloseN M 2 X σ τ =
       Matrix.trace (M (σ 0) (τ 0) * M (σ 1) (τ 1) * X) := by
@@ -109,7 +109,7 @@ arXiv:1606.00608, Definition 4.1, line 657 and figure `MPDO_XMM`. -/
 /-- The general length-three physical closure has the coefficient formula for
 $M_3(X)$. When $M=\mathcal K$, it is the operator $\mathcal K_3(X)$ in
 arXiv:1606.00608, Proposition C.7, lines 1510--1516. -/
-@[simp] lemma physCloseN_three_apply (M : MPOTensor d D)
+lemma physCloseN_three_apply (M : MPOTensor d D)
     (X : Matrix (Fin D) (Fin D) ℂ) (σ τ : Fin 3 → Fin d) :
     physCloseN M 3 X σ τ =
       Matrix.trace
@@ -120,7 +120,7 @@ arXiv:1606.00608, Proposition C.7, lines 1510--1516. -/
 
 /-- The **one-site physical operator** as a linear map in the virtual operator
 `X`: contract `X : D × D` into a single copy of the tensor with the physical legs
-open, giving `(physClose1 M X) i j = tr(M^{ij} X)` (figure `MPDO_XM` of
+open, giving `(physClose1 M X) i j = tr(M^{ij} X)` (figure MPDO_XM of
 arXiv:1606.00608). -/
 noncomputable def physClose1 (M : MPOTensor d D) :
     Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ where
@@ -137,7 +137,7 @@ noncomputable def physClose1 (M : MPOTensor d D) :
 
 /-- Under the canonical equivalence between one-site configurations and
 physical indices, the length-one closure is `physClose1`. This is the one-site
-operator in arXiv:1606.00608, Definition 4.1, line 657 and figure `MPDO_XM`. -/
+operator in arXiv:1606.00608, Definition 4.1, line 657 and figure MPDO_XM. -/
 theorem physCloseN_one_eq_physClose1 (M : MPOTensor d D) :
     (Matrix.reindexLinearEquiv ℂ ℂ (Equiv.funUnique (Fin 1) (Fin d))
         (Equiv.funUnique (Fin 1) (Fin d))).toLinearMap ∘ₗ physCloseN M 1 =
@@ -150,7 +150,7 @@ theorem physCloseN_one_eq_physClose1 (M : MPOTensor d D) :
 /-- The **two-site physical operator** as a linear map in the virtual operator
 `X`: contract `X : D × D` into two copies of the tensor with all four physical
 legs open, giving `(physClose2 M X) (i₁,i₂) (j₁,j₂) = tr(M^{i₁j₁} M^{i₂j₂} X)`
-(figure `MPDO_XMM` of arXiv:1606.00608). -/
+(figure MPDO_XMM of arXiv:1606.00608). -/
 noncomputable def physClose2 (M : MPOTensor d D) :
     Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ where
   toFun X := Matrix.of fun i j => Matrix.trace (M i.1 j.1 * M i.2 j.2 * X)

--- a/TNLean/MPS/MPDO/RFPViaTS.lean
+++ b/TNLean/MPS/MPDO/RFPViaTS.lean
@@ -10,8 +10,8 @@ import TNLean.MPS.MPDO.KrausCPTP
 This file states the source-faithful renormalization-fixed-point notion for
 matrix product density operators, following
 arXiv:1606.00608 (Cirac–Pérez-García–Schuch–Verstraete), Definition 4.1
-(paper label `RFPMixedTS`, line 657, figures MPDO_XM, MPDO_XMM,
-`MPDO_TandS`).
+(paper label RFPMixedTS, line 657, figures MPDO_XM, MPDO_XMM,
+MPDO_TandS).
 
 In the paper, a tensor `M` in canonical form generating MPDOs is a renormalization
 fixed point when there exist two trace-preserving completely positive maps `T` and
@@ -19,8 +19,8 @@ fixed point when there exist two trace-preserving completely positive maps `T` a
 operators obtained by contracting an arbitrary virtual operator into the tensor
 ring:
 
-* `S[M₂(X)] = M₁(X)`  (paper label `eq:Smap`);
-* `T[M₁(X)] = M₂(X)`  (paper label `eq:Tmap`),
+* `S[M₂(X)] = M₁(X)`  (paper label eq:Smap);
+* `T[M₁(X)] = M₂(X)`  (paper label eq:Tmap),
 
 for all virtual operators `X`. Here, with the physical legs left open,
 
@@ -180,12 +180,12 @@ theorem physCloseN_two_eq_physClose2 (M : MPOTensor d D) :
 /-! ### MPDO renormalization fixed point (Definition 4.1) -/
 
 /-- `IsRFPViaTS M` is the source's MPDO **renormalization fixed point** of
-arXiv:1606.00608 Definition 4.1 (paper label `RFPMixedTS`, line 657): there exist
+arXiv:1606.00608 Definition 4.1 (paper label RFPMixedTS, line 657): there exist
 two trace-preserving completely positive maps `S` and `T` on the physical indices
 intertwining the one-site and two-site physical operators, namely
 
-* `S[M₂(X)] = M₁(X)` for all `X`  (paper label `eq:Smap`), and
-* `T[M₁(X)] = M₂(X)` for all `X`  (paper label `eq:Tmap`).
+* `S[M₂(X)] = M₁(X)` for all `X`  (paper label eq:Smap), and
+* `T[M₁(X)] = M₂(X)` for all `X`  (paper label eq:Tmap).
 
 This is the source's tp-CP-map renormalization fixed point. It is *distinct* from
 `MPOTensor.IsRFP`, the transfer-map idempotence (zero-correlation-length)

--- a/TNLean/MPS/MPDO/RFPViaTS.lean
+++ b/TNLean/MPS/MPDO/RFPViaTS.lean
@@ -38,8 +38,10 @@ the predicate.
 
 * `IsKrausCPTP`: the rectangular Kraus-form predicate for trace-preserving
   completely positive maps used in Definition 4.1.
+* `MPOTensor.physCloseN`: the length-$N$ physical operator as a linear map in
+  the virtual operator $X$.
 * `MPOTensor.physClose1`, `MPOTensor.physClose2`: the one-site and two-site
-  physical operators as linear maps in the virtual operator `X`.
+  specializations used in Definition 4.1.
 * `MPOTensor.IsRFPViaTS`: Definition 4.1, the tp-CP-map renormalization
   fixed point.
 
@@ -54,6 +56,65 @@ open scoped Matrix BigOperators
 namespace MPOTensor
 
 variable {d D : ℕ}
+
+/-! ### Physical operators of arbitrary length -/
+
+/-- The length-$N$ physical operator obtained by contracting an arbitrary
+virtual operator $X$ into a chain of $N$ copies of an MPO tensor while leaving
+the physical legs open:
+
+For configurations $\sigma$ and $\tau$, its coefficient is
+$\operatorname{tr}(M^{\sigma_0\tau_0}\cdots
+M^{\sigma_{N-1}\tau_{N-1}}X)$.
+
+The displayed order chooses the cut of the cyclic virtual contraction just
+before the first site, so that $X$ follows the last site. For $N=1,2$, this is
+the physical closure constructed in arXiv:1606.00608, lines 638--654 and used
+in Definition 4.1, line 657. When $M=\mathcal K$, the cases $N=2,3$ are the
+operators $\mathcal K_2(X)$ and $\mathcal K_3(X)$ in Proposition C.7,
+lines 1510--1516. -/
+noncomputable def physCloseN (M : MPOTensor d D) (N : ℕ) :
+    Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ]
+      Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ where
+  toFun X := Matrix.of fun σ τ =>
+    Matrix.trace (evalWord M (List.ofFn σ) (List.ofFn τ) * X)
+  map_add' X Y := by
+    ext σ τ
+    simp [Matrix.mul_add, Matrix.trace_add]
+  map_smul' c X := by
+    ext σ τ
+    simp [Matrix.trace_smul]
+
+@[simp] lemma physCloseN_apply (M : MPOTensor d D) (N : ℕ)
+    (X : Matrix (Fin D) (Fin D) ℂ) (σ τ : Fin N → Fin d) :
+    physCloseN M N X σ τ =
+      Matrix.trace (evalWord M (List.ofFn σ) (List.ofFn τ) * X) :=
+  rfl
+
+/-- The length-one physical closure has the source coefficient formula from
+arXiv:1606.00608, Definition 4.1, line 657 and figure `MPDO_XM`. -/
+@[simp] lemma physCloseN_one_apply (M : MPOTensor d D)
+    (X : Matrix (Fin D) (Fin D) ℂ) (σ τ : Fin 1 → Fin d) :
+    physCloseN M 1 X σ τ = Matrix.trace (M (σ 0) (τ 0) * X) := by
+  simp [physCloseN, List.ofFn_succ, evalWord_cons]
+
+/-- The length-two physical closure has the source coefficient formula from
+arXiv:1606.00608, Definition 4.1, line 657 and figure `MPDO_XMM`. -/
+@[simp] lemma physCloseN_two_apply (M : MPOTensor d D)
+    (X : Matrix (Fin D) (Fin D) ℂ) (σ τ : Fin 2 → Fin d) :
+    physCloseN M 2 X σ τ =
+      Matrix.trace (M (σ 0) (τ 0) * M (σ 1) (τ 1) * X) := by
+  simp [physCloseN, List.ofFn_succ, evalWord_cons, Matrix.mul_assoc]
+
+/-- The general length-three physical closure has the coefficient formula for
+$M_3(X)$. When $M=\mathcal K$, it is the operator $\mathcal K_3(X)$ in
+arXiv:1606.00608, Proposition C.7, lines 1510--1516. -/
+@[simp] lemma physCloseN_three_apply (M : MPOTensor d D)
+    (X : Matrix (Fin D) (Fin D) ℂ) (σ τ : Fin 3 → Fin d) :
+    physCloseN M 3 X σ τ =
+      Matrix.trace
+        (M (σ 0) (τ 0) * M (σ 1) (τ 1) * M (σ 2) (τ 2) * X) := by
+  simp [physCloseN, List.ofFn_succ, evalWord_cons, Matrix.mul_assoc]
 
 /-! ### The one-site physical operator -/
 
@@ -74,6 +135,16 @@ noncomputable def physClose1 (M : MPOTensor d D) :
 @[simp] lemma physClose1_apply (M : MPOTensor d D) (X : Matrix (Fin D) (Fin D) ℂ)
     (i j : Fin d) : physClose1 M X i j = Matrix.trace (M i j * X) := rfl
 
+/-- Under the canonical equivalence between one-site configurations and
+physical indices, the length-one closure is `physClose1`. This is the one-site
+operator in arXiv:1606.00608, Definition 4.1, line 657 and figure `MPDO_XM`. -/
+theorem physCloseN_one_eq_physClose1 (M : MPOTensor d D) :
+    (Matrix.reindexLinearEquiv ℂ ℂ (Equiv.funUnique (Fin 1) (Fin d))
+        (Equiv.funUnique (Fin 1) (Fin d))).toLinearMap ∘ₗ physCloseN M 1 =
+      physClose1 M := by
+  ext X i j
+  simp [Matrix.coe_reindexLinearEquiv]
+
 /-! ### The two-site physical operator -/
 
 /-- The **two-site physical operator** as a linear map in the virtual operator
@@ -93,6 +164,18 @@ noncomputable def physClose2 (M : MPOTensor d D) :
 @[simp] lemma physClose2_apply (M : MPOTensor d D) (X : Matrix (Fin D) (Fin D) ℂ)
     (i j : Fin d × Fin d) :
     physClose2 M X i j = Matrix.trace (M i.1 j.1 * M i.2 j.2 * X) := rfl
+
+/-- Under the canonical equivalence between two-site configurations and pairs
+of physical indices, the length-two closure is `physClose2`. This is the
+two-site operator constructed in arXiv:1606.00608, lines 638--654 and used in
+Definition 4.1, line 657. When $M=\mathcal K$, it is $\mathcal K_2(X)$ in
+Proposition C.7, lines 1510--1516. -/
+theorem physCloseN_two_eq_physClose2 (M : MPOTensor d D) :
+    (Matrix.reindexLinearEquiv ℂ ℂ (finTwoArrowEquiv (Fin d))
+        (finTwoArrowEquiv (Fin d))).toLinearMap ∘ₗ physCloseN M 2 =
+      physClose2 M := by
+  ext X i j
+  simp [Matrix.coe_reindexLinearEquiv, finTwoArrowEquiv_symm_apply]
 
 /-! ### MPDO renormalization fixed point (Definition 4.1) -/
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
@@ -141,17 +141,69 @@
     \]
 \end{proof}
 
-\begin{definition}[One- and two-site physical closure maps]
+\begin{definition}[Physical closure maps]
     \label{def:phys_close}
-    \lean{MPOTensor.physClose1, MPOTensor.physClose2}
+    \lean{MPOTensor.physCloseN, MPOTensor.physClose1, MPOTensor.physClose2}
     \leanok
-    \uses{def:mpo_tensor}
-    For an MPO tensor $M$, the one- and two-site physical operators obtained by
-    closing one or two tensors with a virtual operator $X$ are
-    $M_1(X)_{ij} = \tr(M^{ij} X)$ and
-    $M_2(X)_{(i_1 i_2)(j_1 j_2)} = \tr(M^{i_1 j_1} M^{i_2 j_2} X)$, both linear
-    in $X$.
+    \uses{def:mpo_eval_word}
+    For an MPO tensor $M$, a length $N$, and a virtual operator $X$, define the
+    physical operator $M_N(X)$ by
+    \[
+        M_N(X)_{\boldsymbol i,\boldsymbol j}
+        =
+        \tr\!\left(
+          M^{i_0j_0} M^{i_1j_1}\cdots M^{i_{N-1}j_{N-1}} X
+        \right).
+    \]
+    This is linear in $X$. The displayed order chooses the cut of the cyclic
+    virtual contraction immediately before the first site, so that $X$ follows
+    the last site. The one- and two-site operators are constructed in
+    \cite[lines~638--654 and Definition~4.1]{Cirac2016MPDO_arXiv}. When
+    $M=\mathcal K$, write these operators as $\mathcal K_N(X)$; the cases
+    $N=2,3$ occur in
+    \cite[Proposition~C.7, lines~1510--1516]{Cirac2016MPDO_arXiv}.
 \end{definition}
+
+\begin{theorem}[One- and two-site physical closures]
+    \label{thm:phys_close_one_two}
+    \lean{MPOTensor.physCloseN_one_eq_physClose1,
+      MPOTensor.physCloseN_two_eq_physClose2}
+    \leanok
+    \uses{def:phys_close}
+    Under the canonical identifications of one-site configurations with
+    physical indices and two-site configurations with pairs of physical
+    indices,
+    \[
+        M_1(X)_{i,j}=\tr(M^{ij} X),
+        \qquad
+        M_2(X)_{(i_0,i_1),(j_0,j_1)}
+        =\tr(M^{i_0j_0} M^{i_1j_1} X).
+    \]
+\end{theorem}
+\begin{proof}
+    \leanok
+    Under these identifications, the length-one and length-two word
+    evaluations are $M^{ij}$ and $M^{i_0j_0}M^{i_1j_1}$, respectively.
+\end{proof}
+
+\begin{lemma}[Three-site physical closure]
+    \label{lem:phys_close_three}
+    \lean{MPOTensor.physCloseN_three_apply}
+    \leanok
+    \uses{def:phys_close}
+    The general three-site physical closure has coefficients
+    \[
+        M_3(X)_{(i_0,i_1,i_2),(j_0,j_1,j_2)}
+        =\tr(M^{i_0j_0} M^{i_1j_1} M^{i_2j_2} X).
+    \]
+    For $M=\mathcal K$, this is the operator $\mathcal K_3(X)$ in
+    \cite[Proposition~C.7, lines~1510--1516]{Cirac2016MPDO_arXiv}.
+\end{lemma}
+\begin{proof}
+    \leanok
+    The length-three word evaluation is
+    $M^{i_0j_0}M^{i_1j_1}M^{i_2j_2}$.
+\end{proof}
 
 \begin{definition}[Renormalization fixed point via trace-preserving maps]
     \label{def:is_rfp_via_ts}


### PR DESCRIPTION
This PR defines the length-indexed physical closure of an MPO tensor and closes #3746.

For an MPO tensor $M$, a length $N$, and a virtual operator $X$, `MPOTensor.physCloseN` has coefficients
\[
M_N(X)_{\boldsymbol i,\boldsymbol j}
=\operatorname{tr}\!\left(M^{i_0j_0}\cdots M^{i_{N-1}j_{N-1}}X\right).
\]
The development proves the general pointwise formula, identifies the $N=1$ and $N=2$ linear maps with the existing `physClose1` and `physClose2` under the canonical configuration-space equivalences, and records the explicit $N=3$ formula required by Proposition C.7.

The notation $M_N(X)$ is used for an arbitrary tensor; $\mathcal K_N(X)$ is reserved for the specialization $M=\mathcal K$ in arXiv:1606.00608, Proposition C.7. The blueprint also explains that the source draws $X$ before the first tensor, whereas the displayed formula uses the equivalent cyclic cut after the final tensor.

No coarse-graining or refinement map is asserted here. Those constructions remain in #3743 and #3744 and will use these well-typed $\mathcal K_2(X)$ and $\mathcal K_3(X)$ operators.

Verification:

```bash
lake build TNLean
cd blueprint
leanblueprint checkdecls
leanblueprint pdf
```

All commands pass; the PDF contains 468 pages.

Closes #3746.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API and blueprint sync with no changes to `IsRFPViaTS` or transfer-map predicates; risk is limited to correctness of the new `physCloseN`/`evalWord` wiring.
> 
> **Overview**
> Introduces **`MPOTensor.physCloseN`**, a ℂ-linear map from virtual $X$ to length-$N$ physical operators with coefficients $\mathrm{tr}(M^{\sigma_0\tau_0}\cdots M^{\sigma_{N-1}\tau_{N-1}} X)$, using **`evalWord`** and documenting the cyclic virtual cut ( $X$ after the last site).
> 
> The PR adds pointwise lemmas for **$N=1,2,3$** and theorems **`physCloseN_one_eq_physClose1`** / **`physCloseN_two_eq_physClose2`** (via configuration-space reindexing), so Definition 4.1’s existing **`physClose1`**, **`physClose2`**, and **`IsRFPViaTS`** stay unchanged in meaning. Blueprint **ch21** is updated to define general $M_N(X)$, link $\mathcal K_2,\mathcal K_3$ to Proposition C.7, and add the one/two/three-site closure results.
> 
> Doc-only tweaks in **`RFPViaTS.lean`** drop backticks around paper labels in module comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73b76d3297e043699a3fb4a248b82a582a82f7f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->