### PR TITLE
feat(MPS/MPDO): the positivity choice for the neighboring operators

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -24,6 +24,7 @@ import TNLean.Algebra.GramMatrixLI
 import TNLean.Algebra.HermitianHelpers
 import TNLean.Algebra.MatrixSpectralDecomp
 import TNLean.Algebra.MatrixAux
+import TNLean.Algebra.KroneckerFactorPositivity
 import TNLean.Algebra.MatrixGramUnitary
 import TNLean.Algebra.FinSum
 import TNLean.Algebra.ScalarPowerSumIdentity
@@ -383,6 +384,7 @@ import TNLean.MPS.MPDO.SectorFactorization
 import TNLean.MPS.MPDO.SectorPairingTransfer
 import TNLean.MPS.MPDO.SectorEtaContraction
 import TNLean.MPS.MPDO.SectorEtaOperator
+import TNLean.MPS.MPDO.SectorEtaPositivity
 import TNLean.MPS.MPDO.FusionIsometries
 import TNLean.MPS.MPDO.OperatorProduct
 import TNLean.MPS.MPDO.AlgebraStructure

--- a/TNLean/Algebra/KroneckerFactorPositivity.lean
+++ b/TNLean/Algebra/KroneckerFactorPositivity.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
 -/
 import Mathlib.Analysis.Complex.Basic
 import Mathlib.Analysis.Complex.Order

--- a/TNLean/Algebra/KroneckerFactorPositivity.lean
+++ b/TNLean/Algebra/KroneckerFactorPositivity.lean
@@ -34,6 +34,9 @@ a complex matrix is determined by its quadratic form.
 - `Matrix.exists_smul_posSemidef_of_kronecker_posSemidef`: the positive
   rescaling of the two factors of a nonzero positive semidefinite Kronecker
   product.
+- `Matrix.smul_kronecker_smul_inv_eq`: a reciprocal pair of scalars leaves a
+  Kronecker product unchanged; this is what makes the rescaling of the
+  previous result represent the same product.
 -/
 
 open scoped Matrix ComplexOrder Kronecker
@@ -122,16 +125,29 @@ theorem star_dotProduct_kronecker_mulVec_prod
   refine Finset.sum_congr rfl fun i' _ => Finset.sum_congr rfl fun j' _ => ?_
   ring
 
+/-- A reciprocal pair of scalars leaves a Kronecker product unchanged: for
+any nonzero `c`, `(c • A) ⊗ (c⁻¹ • B) = A ⊗ B`.  This holds for arbitrary
+matrix shapes and needs no positivity hypothesis; it is the algebraic fact
+that makes the rescaling in
+`Matrix.exists_smul_posSemidef_of_kronecker_posSemidef` represent the same
+product as the original factors. -/
+theorem smul_kronecker_smul_inv_eq {l p q r : Type*}
+    (A : Matrix l p ℂ) (B : Matrix q r ℂ) {c : ℂ} (hc : c ≠ 0) :
+    (c • A) ⊗ₖ (c⁻¹ • B) = A ⊗ₖ B := by
+  rw [smul_kronecker, kronecker_smul, smul_smul, mul_inv_cancel₀ hc, one_smul]
+
 /-- **Positive rescaling of Kronecker factors.** If a Kronecker product of
 two nonzero complex matrices is positive semidefinite, then there is a
 nonzero scalar `c` such that `c • A` and `c⁻¹ • B` are both positive
-semidefinite.  Since `(c • A) ⊗ (c⁻¹ • B) = A ⊗ B`, the rescaled factors
-represent the same product. -/
+semidefinite.  By `Matrix.smul_kronecker_smul_inv_eq`,
+`(c • A) ⊗ (c⁻¹ • B) = A ⊗ B`, so the rescaled factors represent the same
+product. -/
 theorem exists_smul_posSemidef_of_kronecker_posSemidef
     {m n : Type*} [Finite m] [Finite n]
     {A : Matrix m m ℂ} {B : Matrix n n ℂ}
     (hAB : (A ⊗ₖ B).PosSemidef) (hA : A ≠ 0) (hB : B ≠ 0) :
-    ∃ c : ℂ, c ≠ 0 ∧ (c • A).PosSemidef ∧ (c⁻¹ • B).PosSemidef := by
+    ∃ c : ℂ, c ≠ 0 ∧ (c • A).PosSemidef ∧ (c⁻¹ • B).PosSemidef ∧
+      (c • A) ⊗ₖ (c⁻¹ • B) = A ⊗ₖ B := by
   have := Fintype.ofFinite m
   have := Fintype.ofFinite n
   obtain ⟨v₀, ha⟩ := exists_star_dotProduct_mulVec_ne_zero hA
@@ -141,7 +157,7 @@ theorem exists_smul_posSemidef_of_kronecker_posSemidef
     intro x y
     rw [← star_dotProduct_kronecker_mulVec_prod]
     exact hAB.dotProduct_mulVec_nonneg _
-  refine ⟨star w₀ ⬝ᵥ B *ᵥ w₀, hc, ?_, ?_⟩
+  refine ⟨star w₀ ⬝ᵥ B *ᵥ w₀, hc, ?_, ?_, ?_⟩
   · refine posSemidef_of_forall_star_dotProduct_mulVec_nonneg fun x => ?_
     have hx : star x ⬝ᵥ ((star w₀ ⬝ᵥ B *ᵥ w₀) • A) *ᵥ x =
         (star x ⬝ᵥ A *ᵥ x) * (star w₀ ⬝ᵥ B *ᵥ w₀) := by
@@ -158,5 +174,6 @@ theorem exists_smul_posSemidef_of_kronecker_posSemidef
     have hpos : 0 < (star v₀ ⬝ᵥ A *ᵥ v₀) * (star w₀ ⬝ᵥ B *ᵥ w₀) :=
       lt_of_le_of_ne (hq v₀ w₀) (Ne.symm (mul_ne_zero ha hc))
     exact mul_nonneg (hq v₀ y) (le_of_lt (RCLike.inv_pos.mpr hpos))
+  · exact smul_kronecker_smul_inv_eq A B hc
 
 end Matrix

--- a/TNLean/Algebra/KroneckerFactorPositivity.lean
+++ b/TNLean/Algebra/KroneckerFactorPositivity.lean
@@ -1,0 +1,161 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Analysis.Complex.Basic
+import Mathlib.Analysis.Complex.Order
+import Mathlib.Analysis.RCLike.Basic
+import Mathlib.LinearAlgebra.Matrix.Kronecker
+import Mathlib.LinearAlgebra.Matrix.PosDef
+
+/-!
+# Positive rescaling of the factors of a positive Kronecker product
+
+A Kronecker product `A ⊗ B` determines its factors only up to a reciprocal
+pair of scalars.  This file shows that over `ℂ` the scalar ambiguity can be
+used in one direction: if `A ⊗ B` is positive semidefinite and both factors
+are nonzero, then there is a nonzero scalar `c` with `c • A` and `c⁻¹ • B`
+positive semidefinite.
+
+The proof evaluates the quadratic form of `A ⊗ B` on product vectors, which
+factors it into the two quadratic forms, and uses the polarization identity:
+a complex matrix is determined by its quadratic form.
+
+## Main results
+
+- `Matrix.eq_zero_of_forall_star_dotProduct_mulVec_eq_zero`: a complex matrix
+  whose quadratic form vanishes identically is zero.
+- `Matrix.posSemidef_of_forall_star_dotProduct_mulVec_nonneg`: a complex
+  matrix with nonnegative quadratic form is positive semidefinite; over `ℂ`
+  the Hermitian property is automatic.
+- `Matrix.star_dotProduct_kronecker_mulVec_prod`: on a product vector the
+  quadratic form of a Kronecker product factors.
+- `Matrix.exists_smul_posSemidef_of_kronecker_posSemidef`: the positive
+  rescaling of the two factors of a nonzero positive semidefinite Kronecker
+  product.
+-/
+
+open scoped Matrix ComplexOrder Kronecker
+
+namespace Matrix
+
+variable {m n : Type*} [Fintype m] [Fintype n]
+
+/-- **Polarization.** A complex matrix whose quadratic form
+`x ↦ star x ⬝ᵥ M *ᵥ x` vanishes identically is the zero matrix. -/
+theorem eq_zero_of_forall_star_dotProduct_mulVec_eq_zero
+    {M : Matrix n n ℂ} (h : ∀ x : n → ℂ, star x ⬝ᵥ M *ᵥ x = 0) : M = 0 := by
+  classical
+  have hsum : ∀ x y : n → ℂ,
+      star x ⬝ᵥ M *ᵥ y + star y ⬝ᵥ M *ᵥ x = 0 := by
+    intro x y
+    have hxy := h (x + y)
+    rw [star_add, add_dotProduct, mulVec_add, dotProduct_add,
+      dotProduct_add] at hxy
+    linear_combination hxy - h x - h y
+  have hpair : ∀ x y : n → ℂ, star x ⬝ᵥ M *ᵥ y = 0 := by
+    intro x y
+    have hI := hsum x (Complex.I • y)
+    rw [star_smul, smul_dotProduct, mulVec_smul, dotProduct_smul,
+      Complex.star_def, Complex.conj_I, smul_eq_mul, smul_eq_mul] at hI
+    have hbase := hsum x y
+    have h2 : (2 * Complex.I) * (star x ⬝ᵥ M *ᵥ y) = 0 := by
+      linear_combination hI + Complex.I * hbase
+    exact (mul_eq_zero.mp h2).resolve_left
+      (mul_ne_zero two_ne_zero Complex.I_ne_zero)
+  ext i j
+  have hij := hpair (Pi.single i 1) (Pi.single j 1)
+  have hstar : star (Pi.single i (1 : ℂ)) = (Pi.single i 1 : n → ℂ) := by
+    ext a
+    by_cases hai : a = i <;> simp [hai]
+  rw [hstar, mulVec_single_one, single_dotProduct] at hij
+  simpa using hij
+
+/-- A nonzero complex matrix has a nonzero quadratic-form value. -/
+theorem exists_star_dotProduct_mulVec_ne_zero
+    {M : Matrix n n ℂ} (hM : M ≠ 0) :
+    ∃ x : n → ℂ, star x ⬝ᵥ M *ᵥ x ≠ 0 := by
+  by_contra hc
+  refine hM (eq_zero_of_forall_star_dotProduct_mulVec_eq_zero fun x => ?_)
+  by_contra hx
+  exact hc ⟨x, hx⟩
+
+/-- A complex matrix with nonnegative quadratic form is positive
+semidefinite.  Over `ℂ` a real-valued quadratic form already forces the
+Hermitian property, so no symmetry hypothesis is needed. -/
+theorem posSemidef_of_forall_star_dotProduct_mulVec_nonneg
+    {M : Matrix n n ℂ} (h : ∀ x : n → ℂ, 0 ≤ star x ⬝ᵥ M *ᵥ x) :
+    M.PosSemidef := by
+  classical
+  have hreal : ∀ x : n → ℂ,
+      star (star x ⬝ᵥ M *ᵥ x) = star x ⬝ᵥ M *ᵥ x := by
+    intro x
+    rw [Complex.star_def, Complex.conj_eq_iff_im]
+    exact ((Complex.nonneg_iff.mp (h x)).2).symm
+  have hherm : M.IsHermitian := by
+    have hzero : ∀ x : n → ℂ, star x ⬝ᵥ (M - Mᴴ) *ᵥ x = 0 := by
+      intro x
+      have hMH : star x ⬝ᵥ Mᴴ *ᵥ x = star (star x ⬝ᵥ M *ᵥ x) := by
+        rw [star_dotProduct, star_mulVec, conjTranspose_conjTranspose,
+          ← dotProduct_mulVec]
+      rw [sub_mulVec, dotProduct_sub, hMH, hreal x, sub_self]
+    have hsub := eq_zero_of_forall_star_dotProduct_mulVec_eq_zero hzero
+    exact (sub_eq_zero.mp hsub).symm
+  exact Matrix.PosSemidef.of_dotProduct_mulVec_nonneg hherm h
+
+/-- On a product vector, the quadratic form of a Kronecker product is the
+product of the quadratic forms of the two factors. -/
+theorem star_dotProduct_kronecker_mulVec_prod
+    (A : Matrix m m ℂ) (B : Matrix n n ℂ) (x : m → ℂ) (y : n → ℂ) :
+    star (fun p : m × n => x p.1 * y p.2) ⬝ᵥ
+        (A ⊗ₖ B) *ᵥ (fun p : m × n => x p.1 * y p.2) =
+      (star x ⬝ᵥ A *ᵥ x) * (star y ⬝ᵥ B *ᵥ y) := by
+  classical
+  simp only [dotProduct, mulVec, kroneckerMap_apply, Pi.star_apply, star_mul,
+    Fintype.sum_prod_type]
+  rw [Finset.sum_mul_sum]
+  refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
+  rw [mul_mul_mul_comm, Finset.sum_mul_sum,
+    mul_comm (star (y j)) (star (x i))]
+  congr 1
+  refine Finset.sum_congr rfl fun i' _ => Finset.sum_congr rfl fun j' _ => ?_
+  ring
+
+/-- **Positive rescaling of Kronecker factors.** If a Kronecker product of
+two nonzero complex matrices is positive semidefinite, then there is a
+nonzero scalar `c` such that `c • A` and `c⁻¹ • B` are both positive
+semidefinite.  Since `(c • A) ⊗ (c⁻¹ • B) = A ⊗ B`, the rescaled factors
+represent the same product. -/
+theorem exists_smul_posSemidef_of_kronecker_posSemidef
+    {m n : Type*} [Finite m] [Finite n]
+    {A : Matrix m m ℂ} {B : Matrix n n ℂ}
+    (hAB : (A ⊗ₖ B).PosSemidef) (hA : A ≠ 0) (hB : B ≠ 0) :
+    ∃ c : ℂ, c ≠ 0 ∧ (c • A).PosSemidef ∧ (c⁻¹ • B).PosSemidef := by
+  have := Fintype.ofFinite m
+  have := Fintype.ofFinite n
+  obtain ⟨v₀, ha⟩ := exists_star_dotProduct_mulVec_ne_zero hA
+  obtain ⟨w₀, hc⟩ := exists_star_dotProduct_mulVec_ne_zero hB
+  have hq : ∀ (x : m → ℂ) (y : n → ℂ),
+      0 ≤ (star x ⬝ᵥ A *ᵥ x) * (star y ⬝ᵥ B *ᵥ y) := by
+    intro x y
+    rw [← star_dotProduct_kronecker_mulVec_prod]
+    exact hAB.dotProduct_mulVec_nonneg _
+  refine ⟨star w₀ ⬝ᵥ B *ᵥ w₀, hc, ?_, ?_⟩
+  · refine posSemidef_of_forall_star_dotProduct_mulVec_nonneg fun x => ?_
+    have hx : star x ⬝ᵥ ((star w₀ ⬝ᵥ B *ᵥ w₀) • A) *ᵥ x =
+        (star x ⬝ᵥ A *ᵥ x) * (star w₀ ⬝ᵥ B *ᵥ w₀) := by
+      rw [smul_mulVec, dotProduct_smul, smul_eq_mul, mul_comm]
+    rw [hx]
+    exact hq x w₀
+  · refine posSemidef_of_forall_star_dotProduct_mulVec_nonneg fun y => ?_
+    have hy : star y ⬝ᵥ ((star w₀ ⬝ᵥ B *ᵥ w₀)⁻¹ • B) *ᵥ y =
+        ((star v₀ ⬝ᵥ A *ᵥ v₀) * (star y ⬝ᵥ B *ᵥ y)) *
+          ((star v₀ ⬝ᵥ A *ᵥ v₀) * (star w₀ ⬝ᵥ B *ᵥ w₀))⁻¹ := by
+      rw [smul_mulVec, dotProduct_smul, smul_eq_mul, mul_inv]
+      field_simp
+    rw [hy]
+    have hpos : 0 < (star v₀ ⬝ᵥ A *ᵥ v₀) * (star w₀ ⬝ᵥ B *ᵥ w₀) :=
+      lt_of_le_of_ne (hq v₀ w₀) (Ne.symm (mul_ne_zero ha hc))
+    exact mul_nonneg (hq v₀ y) (le_of_lt (RCLike.inv_pos.mpr hpos))
+
+end Matrix

--- a/TNLean/MPS/MPDO/SectorEtaPositivity.lean
+++ b/TNLean/MPS/MPDO/SectorEtaPositivity.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
 -/
 import TNLean.Algebra.KroneckerFactorPositivity
 import TNLean.MPS.MPDO.SectorEtaOperator

--- a/TNLean/MPS/MPDO/SectorEtaPositivity.lean
+++ b/TNLean/MPS/MPDO/SectorEtaPositivity.lean
@@ -1,0 +1,377 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Algebra.KroneckerFactorPositivity
+import TNLean.MPS.MPDO.SectorEtaOperator
+
+/-!
+# Positivity of the neighboring operators of a simple MPDO
+
+For an MPDO every finite-chain operator is positive semidefinite.  In the
+sector-adapted coordinates of the Hayashi decomposition each diagonal sector
+block of the basis-conjugated chain is a compression of a positive operator,
+and by the sector-adapted decomposition it is the cyclic tensor product of
+the neighboring operators:
+\[
+  0 \le \bigl[Q_{k_1}\otimes\cdots\otimes Q_{k_N}\bigr]\,\tilde\sigma\,
+  \bigl[Q_{k_1}\otimes\cdots\otimes Q_{k_N}\bigr]
+  = \bigotimes_{n=1}^{N}\eta_{k_n,k_{n+1}} .
+\]
+The chain of length one gives $\eta_{k,k}\ge 0$.  The chain of length two
+gives $\eta_{k,h}\otimes\eta_{h,k}\ge 0$, and rescaling the two factors of a
+nonzero positive semidefinite Kronecker product yields a scalar $c\ne 0$ with
+$c\,\eta_{k,h}\ge 0$ and $c^{-1}\eta_{h,k}\ge 0$.
+
+Choosing one such scalar for every pair of sectors produces a positive
+semidefinite family of neighboring operators which agrees with the raw family
+on the diagonal and differs from it by reciprocal scalars within each pair.
+This realizes the positivity choice at lines 1446--1450 of the source from
+the chains of length at most two.  The choice made here requires the nonzero
+neighboring operators to appear in symmetric pairs; the coherence of a single
+choice across longer cycles is the remaining gap recorded in
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+
+## References
+
+- [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, lines 1434--1455
+-/
+
+open scoped Matrix ComplexOrder BigOperators
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+variable {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+
+/-! ### The conjugated chain is a congruence of the original chain -/
+
+/-- The closed-chain matrix entry as a cyclic sum over bond configurations. -/
+private theorem mpo_apply_eq_sum_cyclic (M : MPOTensor d D) {N : ℕ}
+    [NeZero N] (σ τ : Fin N → Fin d) :
+    mpo M N σ τ =
+      ∑ g : Fin N → Fin D, ∏ n : Fin N, M (σ n) (τ n) (g n) (g (n + 1)) := by
+  have h := MPSTensor.trace_evalWord_eq_sum_cyclic
+    (fun n : Fin N => M (σ n) (τ n)) id
+  rw [MPSTensor.evalWord_ofFn_eq_prod] at h
+  rw [mpo_apply, mpoMatrixEntry, MPOTensor.evalWord_ofFn]
+  simpa only [id_eq] using h
+
+/-- Expansion of one basis-conjugated local entry over the physical indices. -/
+private theorem conjugatePhysical_entry_expand (K : MPOTensor d D)
+    (U : Matrix (Fin d) (Fin d) ℂ) (a b : Fin d) (β α : Fin D) :
+    conjugatePhysical K U a b β α =
+      ∑ p : Fin d × Fin d, U a p.1 * K p.1 p.2 β α * star (U b p.2) := by
+  simp only [conjugatePhysical, Matrix.mul_apply, Matrix.conjTranspose_apply,
+    physicalSlice, Fintype.sum_prod_type, Finset.sum_mul]
+  rw [Finset.sum_comm]
+
+/-- **The conjugated chain is a congruence.** The operator family of the
+physically conjugated tensor is the congruence of the original family by the
+sitewise product matrix of `U`:
+\[
+  \rho^{(N)}(\widetilde{\mathcal K})
+  = U^{\otimes N}\,\rho^{(N)}({\mathcal K})\,\bigl(U^{\otimes N}\bigr)^\dagger.
+\]
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1434--1448 (the basis change
+defining $\tilde\sigma$). -/
+theorem mpo_conjugatePhysical_eq (K : MPOTensor d D)
+    (U : Matrix (Fin d) (Fin d) ℂ) {N : ℕ} [NeZero N] :
+    mpo (conjugatePhysical K U) N =
+      Matrix.of (fun σ σ' : Fin N → Fin d => ∏ n, U (σ n) (σ' n)) *
+        mpo K N *
+        (Matrix.of (fun σ σ' : Fin N → Fin d => ∏ n, U (σ n) (σ' n)))ᴴ := by
+  ext σ τ
+  rw [mpo_apply_eq_sum_cyclic]
+  have hexp : ∀ g : Fin N → Fin D,
+      (∏ n : Fin N, conjugatePhysical K U (σ n) (τ n) (g n) (g (n + 1))) =
+      ∑ P : Fin N → Fin d × Fin d, ∏ n : Fin N,
+        (U (σ n) (P n).1 * K (P n).1 (P n).2 (g n) (g (n + 1)) *
+          star (U (τ n) (P n).2)) := by
+    intro g
+    simp_rw [conjugatePhysical_entry_expand]
+    rw [Finset.prod_univ_sum
+      (fun _ : Fin N => (Finset.univ : Finset (Fin d × Fin d)))
+      (fun n p => U (σ n) p.1 * K p.1 p.2 (g n) (g (n + 1)) *
+        star (U (τ n) p.2))]
+    simp only [Fintype.piFinset_univ]
+  simp_rw [hexp]
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.of_apply]
+  simp_rw [mpo_apply_eq_sum_cyclic K, star_prod, Finset.mul_sum,
+    Finset.sum_mul]
+  simp_rw [← Finset.prod_mul_distrib]
+  rw [Finset.sum_comm_cycle]
+  refine Finset.sum_congr rfl fun g _ => ?_
+  rw [Finset.sum_comm]
+  exact Eq.trans
+    (Fintype.sum_equiv
+      (Equiv.arrowProdEquivProdArrow (Fin N) (fun _ => Fin d)
+        (fun _ => Fin d))
+      _ (fun pr : (Fin N → Fin d) × (Fin N → Fin d) => ∏ n : Fin N,
+        U (σ n) (pr.1 n) * K (pr.1 n) (pr.2 n) (g n) (g (n + 1)) *
+          star (U (τ n) (pr.2 n)))
+      fun P => rfl)
+    (Fintype.sum_prod_type
+      (f := fun pr : (Fin N → Fin d) × (Fin N → Fin d) => ∏ n : Fin N,
+        U (σ n) (pr.1 n) * K (pr.1 n) (pr.2 n) (g n) (g (n + 1)) *
+          star (U (τ n) (pr.2 n))))
+
+/-- The chain operators of the physically conjugated tensor inherit positive
+semidefiniteness from the chain operators of the original tensor. -/
+theorem mpo_conjugatePhysical_posSemidef (K : MPOTensor d D)
+    (U : Matrix (Fin d) (Fin d) ℂ) {N : ℕ} [NeZero N]
+    (hN : (mpo K N).PosSemidef) :
+    (mpo (conjugatePhysical K U) N).PosSemidef := by
+  rw [mpo_conjugatePhysical_eq]
+  exact hN.mul_mul_conjTranspose_same _
+
+/-! ### Positivity of the cyclic sector blocks -/
+
+/-- **Positivity of the projected chain blocks.** For an MPDO with a sector
+factorization of its physical slices, every cyclic tensor product of the
+neighboring operators is positive semidefinite: it is a diagonal sector block
+of the positive basis-conjugated chain,
+\[
+  0 \le \bigl[Q_{k_1}\otimes\cdots\otimes Q_{k_N}\bigr]\,\tilde\sigma\,
+  \bigl[Q_{k_1}\otimes\cdots\otimes Q_{k_N}\bigr]
+  = \bigotimes_{n=1}^{N}\eta_{k_n,k_{n+1}} .
+\]
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1446--1450. -/
+theorem cyclicEtaTensorProduct_posSemidef
+    (K : MPOTensor d D) (hη : EtaStructure ρ)
+    (l : (q : Fin hη.m) → Fin D →
+      Matrix (Fin (hη.dL q)) (Fin (hη.dL q)) ℂ)
+    (r : (q : Fin hη.m) → Fin D →
+      Matrix (Fin (hη.dR q)) (Fin (hη.dR q)) ℂ)
+    (hfactor : ∀ β α,
+      Matrix.reindex hη.decompB hη.decompB
+          ((hη.U_B : Matrix (Fin d) (Fin d) ℂ) * physicalSlice K β α *
+            (hη.U_B : Matrix (Fin d) (Fin d) ℂ)ᴴ)
+        = Matrix.blockDiagonal' fun q =>
+            Matrix.kroneckerMap (· * ·) (l q β) (r q α))
+    {N : ℕ} [NeZero N] (hN : (mpo K N).PosSemidef)
+    (k : Fin N → Fin hη.m) :
+    (cyclicEtaTensorProduct hη (etaOfSectorTensors hη l r) k).PosSemidef := by
+  rw [← mpo_submatrix_sector_eq_cyclicEtaTensorProduct K hη l r hfactor k]
+  exact (mpo_conjugatePhysical_posSemidef K hη.U_B hN).submatrix _
+
+/-- **The diagonal neighboring operators are positive semidefinite.** The
+chain of length one projected to the sector `q` is the neighboring operator
+`η_{q,q}` up to the exchange of its two factors.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1446--1450. -/
+theorem etaOfSectorTensors_self_posSemidef
+    (K : MPOTensor d D) (hη : EtaStructure ρ)
+    (l : (q : Fin hη.m) → Fin D →
+      Matrix (Fin (hη.dL q)) (Fin (hη.dL q)) ℂ)
+    (r : (q : Fin hη.m) → Fin D →
+      Matrix (Fin (hη.dR q)) (Fin (hη.dR q)) ℂ)
+    (hfactor : ∀ β α,
+      Matrix.reindex hη.decompB hη.decompB
+          ((hη.U_B : Matrix (Fin d) (Fin d) ℂ) * physicalSlice K β α *
+            (hη.U_B : Matrix (Fin d) (Fin d) ℂ)ᴴ)
+        = Matrix.blockDiagonal' fun q =>
+            Matrix.kroneckerMap (· * ·) (l q β) (r q α))
+    (h1 : (mpo K 1).PosSemidef) (q : Fin hη.m) :
+    (etaOfSectorTensors hη l r q q).PosSemidef := by
+  have hcyc := cyclicEtaTensorProduct_posSemidef K hη l r hfactor h1
+    (fun _ : Fin 1 => q)
+  have heq : (cyclicEtaTensorProduct hη (etaOfSectorTensors hη l r)
+        (fun _ : Fin 1 => q)).submatrix
+        (fun x : Fin (hη.dR q) × Fin (hη.dL q) =>
+          (fun _ : Fin 1 => (x.2, x.1)))
+        (fun x : Fin (hη.dR q) × Fin (hη.dL q) =>
+          (fun _ : Fin 1 => (x.2, x.1))) =
+      etaOfSectorTensors hη l r q q := by
+    ext x y
+    simp only [Matrix.submatrix_apply, cyclicEtaTensorProduct]
+    rw [Fin.prod_univ_one]
+  rw [← heq]
+  exact hcyc.submatrix _
+
+/-- **Positivity of the mixed neighboring pairs.** The chain of length two
+projected to the sectors `(q, p)` is the Kronecker product
+`η_{q,p} ⊗ η_{p,q}`, so this product is positive semidefinite.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1446--1450. -/
+theorem etaOfSectorTensors_kronecker_posSemidef
+    (K : MPOTensor d D) (hη : EtaStructure ρ)
+    (l : (q : Fin hη.m) → Fin D →
+      Matrix (Fin (hη.dL q)) (Fin (hη.dL q)) ℂ)
+    (r : (q : Fin hη.m) → Fin D →
+      Matrix (Fin (hη.dR q)) (Fin (hη.dR q)) ℂ)
+    (hfactor : ∀ β α,
+      Matrix.reindex hη.decompB hη.decompB
+          ((hη.U_B : Matrix (Fin d) (Fin d) ℂ) * physicalSlice K β α *
+            (hη.U_B : Matrix (Fin d) (Fin d) ℂ)ᴴ)
+        = Matrix.blockDiagonal' fun q =>
+            Matrix.kroneckerMap (· * ·) (l q β) (r q α))
+    (h2 : (mpo K 2).PosSemidef) (q p : Fin hη.m) :
+    (Matrix.kroneckerMap (· * ·) (etaOfSectorTensors hη l r q p)
+      (etaOfSectorTensors hη l r p q)).PosSemidef := by
+  have hcyc := cyclicEtaTensorProduct_posSemidef K hη l r hfactor h2 ![q, p]
+  have heq : (cyclicEtaTensorProduct hη (etaOfSectorTensors hη l r)
+        ![q, p]).submatrix
+        (fun z : (Fin (hη.dR q) × Fin (hη.dL p)) ×
+            (Fin (hη.dR p) × Fin (hη.dL q)) =>
+          Fin.cons (z.2.2, z.1.1) (Fin.cons (z.1.2, z.2.1) finZeroElim))
+        (fun z : (Fin (hη.dR q) × Fin (hη.dL p)) ×
+            (Fin (hη.dR p) × Fin (hη.dL q)) =>
+          Fin.cons (z.2.2, z.1.1) (Fin.cons (z.1.2, z.2.1) finZeroElim)) =
+      Matrix.kroneckerMap (· * ·) (etaOfSectorTensors hη l r q p)
+        (etaOfSectorTensors hη l r p q) := by
+    ext z w
+    simp only [Matrix.submatrix_apply, cyclicEtaTensorProduct,
+      Matrix.kroneckerMap_apply]
+    rw [Fin.prod_univ_two]
+    rfl
+  rw [← heq]
+  exact hcyc.submatrix _
+
+/-! ### The neighboring operators of the sector tensors -/
+
+/-- The neighboring operators built from the sector tensors are the explicit
+contraction family of those tensors. -/
+theorem sectorEta_eq_etaOfSectorTensors
+    (K : MPOTensor d D) (hK : K.IsInjective) (hη : EtaStructure ρ)
+    (R : Matrix (Fin D) (Fin D) ℂ) (α₁ β₃ : Fin D) (k h : Fin hη.m) :
+    sectorEta K hK hη R α₁ β₃ k h =
+      etaOfSectorTensors hη (fun q => sectorTensorL K hK hη R α₁ β₃ q)
+        (fun q => sectorTensorR K hK hη β₃ q) k h := by
+  ext x y
+  simp [sectorEta, etaOfSectorTensors, Matrix.sum_apply]
+
+/-- **The diagonal neighboring operators are positive semidefinite.** For an
+MPDO, the chain of length one projected to the sector `k` realizes
+`η_{k,k}` as a compression of a positive operator:
+$0 \le [Q_k]\,\tilde\sigma^{(1)}\,[Q_k] = \eta_{k,k}$.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1446--1450. -/
+theorem sectorEta_self_posSemidef
+    (K : MPOTensor d D) (hK : K.IsInjective)
+    (R : Matrix (Fin D) (Fin D) ℂ)
+    (hρ : IsThreeSiteClosure K R ρ) (hη : EtaStructure ρ)
+    {α₁ β₃ : Fin D} (hm : R β₃ α₁ ≠ 0) (hM : IsMPDO K) (k : Fin hη.m) :
+    (sectorEta K hK hη R α₁ β₃ k k).PosSemidef := by
+  rw [sectorEta_eq_etaOfSectorTensors]
+  exact etaOfSectorTensors_self_posSemidef K hη _ _
+    (fun β α => physicalSlice_sector_factorization K hK R ρ hρ hη hm β α)
+    (hM 1) k
+
+/-- **Positivity of the mixed neighboring pairs.** For an MPDO, the chain of
+length two projected to the sectors `(k, h)` realizes
+`η_{k,h} ⊗ η_{h,k}` as a compression of a positive operator:
+$0 \le [Q_k \otimes Q_h]\,\tilde\sigma^{(2)}\,[Q_k \otimes Q_h]
+= \eta_{k,h} \otimes \eta_{h,k}$.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1446--1450. -/
+theorem sectorEta_kronecker_posSemidef
+    (K : MPOTensor d D) (hK : K.IsInjective)
+    (R : Matrix (Fin D) (Fin D) ℂ)
+    (hρ : IsThreeSiteClosure K R ρ) (hη : EtaStructure ρ)
+    {α₁ β₃ : Fin D} (hm : R β₃ α₁ ≠ 0) (hM : IsMPDO K) (k h : Fin hη.m) :
+    (Matrix.kroneckerMap (· * ·) (sectorEta K hK hη R α₁ β₃ k h)
+      (sectorEta K hK hη R α₁ β₃ h k)).PosSemidef := by
+  rw [sectorEta_eq_etaOfSectorTensors K hK hη R α₁ β₃ k h,
+    sectorEta_eq_etaOfSectorTensors K hK hη R α₁ β₃ h k]
+  exact etaOfSectorTensors_kronecker_posSemidef K hη _ _
+    (fun β α => physicalSlice_sector_factorization K hK R ρ hρ hη hm β α)
+    (hM 2) k h
+
+/-- **The pairwise positivity choice.** If the neighboring operators of a
+pair of sectors are both nonzero, positivity of `η_{k,h} ⊗ η_{h,k}` yields a
+scalar `c ≠ 0` with `c • η_{k,h}` and `c⁻¹ • η_{h,k}` positive semidefinite.
+The rescaled pair represents the same Kronecker product, so the choice
+absorbs the scalar into the sector tensors as in the source.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1446--1450. -/
+theorem exists_smul_posSemidef_sectorEta
+    (K : MPOTensor d D) (hK : K.IsInjective)
+    (R : Matrix (Fin D) (Fin D) ℂ)
+    (hρ : IsThreeSiteClosure K R ρ) (hη : EtaStructure ρ)
+    {α₁ β₃ : Fin D} (hm : R β₃ α₁ ≠ 0) (hM : IsMPDO K) (k h : Fin hη.m)
+    (hkh : sectorEta K hK hη R α₁ β₃ k h ≠ 0)
+    (hhk : sectorEta K hK hη R α₁ β₃ h k ≠ 0) :
+    ∃ c : ℂ, c ≠ 0 ∧ (c • sectorEta K hK hη R α₁ β₃ k h).PosSemidef ∧
+      (c⁻¹ • sectorEta K hK hη R α₁ β₃ h k).PosSemidef :=
+  Matrix.exists_smul_posSemidef_of_kronecker_posSemidef
+    (sectorEta_kronecker_posSemidef K hK R hρ hη hm hM k h) hkh hhk
+
+/-- **The positivity choice for the neighboring operators.** Assume the MPDO
+positivity of the chain operators and that the nonzero neighboring operators
+occur in symmetric pairs.  Then there is an explicit positive semidefinite
+`η`-family which agrees with the raw neighboring operators on the diagonal
+and differs from them by a reciprocal pair of scalars within every pair of
+sectors.  In particular each two-site block
+`η_{k,h} ⊗ η_{h,k}` of the sector-adapted decomposition is unchanged.
+
+This is the choice asserted at lines 1446--1450 of the source ("the η's can
+be chosen positive semidefinite"), realized from the chains of length at
+most two.
+
+**Scope restriction (symmetric support):** the hypothesis `hsym` that
+`η_{k,h} = 0` forces `η_{h,k} = 0` is not stated in the source.  Without it,
+a nonzero neighboring operator whose reverse pair vanishes is constrained
+only by cycles through at least three sectors, and a coherent choice for the
+whole family need not exist; a four-sector scalar obstruction and the
+sufficient recurrence hypothesis are recorded in
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1446--1455. -/
+theorem exists_explicitEtaOperators_sectorEta
+    (K : MPOTensor d D) (hK : K.IsInjective)
+    (R : Matrix (Fin D) (Fin D) ℂ)
+    (hρ : IsThreeSiteClosure K R ρ) (hη : EtaStructure ρ)
+    {α₁ β₃ : Fin D} (hm : R β₃ α₁ ≠ 0) (hM : IsMPDO K)
+    (hsym : ∀ k h, sectorEta K hK hη R α₁ β₃ k h = 0 →
+      sectorEta K hK hη R α₁ β₃ h k = 0) :
+    ∃ data : ExplicitEtaOperators hη,
+      (∀ k, data.eta k k = sectorEta K hK hη R α₁ β₃ k k) ∧
+      ∀ k h, ∃ c : ℂ, c ≠ 0 ∧
+        data.eta k h = c • sectorEta K hK hη R α₁ β₃ k h ∧
+        data.eta h k = c⁻¹ • sectorEta K hK hη R α₁ β₃ h k := by
+  classical
+  have hpair : ∀ k h, ∃ c : ℂ, c ≠ 0 ∧
+      (c • sectorEta K hK hη R α₁ β₃ k h).PosSemidef ∧
+      (c⁻¹ • sectorEta K hK hη R α₁ β₃ h k).PosSemidef := by
+    intro k h
+    by_cases h0 : sectorEta K hK hη R α₁ β₃ k h = 0
+    · refine ⟨1, one_ne_zero, ?_, ?_⟩
+      · rw [h0, smul_zero]
+        exact Matrix.PosSemidef.zero
+      · rw [hsym k h h0, smul_zero]
+        exact Matrix.PosSemidef.zero
+    · exact exists_smul_posSemidef_sectorEta K hK R hρ hη hm hM k h h0
+        fun hz => h0 (hsym h k hz)
+  refine ⟨⟨fun k h =>
+      (if k = h then 1 else if k ≤ h then (hpair k h).choose
+        else ((hpair h k).choose)⁻¹) • sectorEta K hK hη R α₁ β₃ k h,
+      ?_⟩, ?_, ?_⟩
+  · intro k h
+    by_cases hkh : k = h
+    · subst hkh
+      simpa using sectorEta_self_posSemidef K hK R hρ hη hm hM k
+    · by_cases hle : k ≤ h
+      · simpa [hkh, hle] using (hpair k h).choose_spec.2.1
+      · simpa [hkh, hle] using (hpair h k).choose_spec.2.2
+  · intro k
+    simp
+  · intro k h
+    by_cases hkh : k = h
+    · subst hkh
+      exact ⟨1, one_ne_zero, by simp, by simp⟩
+    · by_cases hle : k ≤ h
+      · have hgt : ¬h ≤ k := fun hle' => hkh (le_antisymm hle hle')
+        exact ⟨(hpair k h).choose, (hpair k h).choose_spec.1,
+          by simp [hkh, hle], by simp [Ne.symm hkh, hgt]⟩
+      · have hlt : h ≤ k := le_of_not_ge hle
+        refine ⟨((hpair h k).choose)⁻¹,
+          inv_ne_zero (hpair h k).choose_spec.1,
+          by simp [hkh, hle], ?_⟩
+        rw [inv_inv]
+        simp [Ne.symm hkh, hlt]
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/SectorEtaPositivity.lean
+++ b/TNLean/MPS/MPDO/SectorEtaPositivity.lean
@@ -234,8 +234,12 @@ theorem etaOfSectorTensors_kronecker_posSemidef
 
 /-! ### The neighboring operators of the sector tensors -/
 
-/-- The neighboring operators built from the sector tensors are the explicit
-contraction family of those tensors. -/
+/-- The `sectorEta` operator computed from the concrete sector-tensor
+representatives `sectorTensorL` and `sectorTensorR` equals the generic
+`etaOfSectorTensors` family applied to the same tensors.  This bridge lemma
+transfers the abstract positivity results proved above for
+`etaOfSectorTensors` to the concrete `sectorEta` operators used in the rest
+of the development. -/
 theorem sectorEta_eq_etaOfSectorTensors
     (K : MPOTensor d D) (hK : K.IsInjective) (hη : EtaStructure ρ)
     (R : Matrix (Fin D) (Fin D) ℂ) (α₁ β₃ : Fin D) (k h : Fin hη.m) :
@@ -284,9 +288,9 @@ theorem sectorEta_kronecker_posSemidef
 
 /-- **The pairwise positivity choice.** If the neighboring operators of a
 pair of sectors are both nonzero, positivity of `η_{k,h} ⊗ η_{h,k}` yields a
-scalar `c ≠ 0` with `c • η_{k,h}` and `c⁻¹ • η_{h,k}` positive semidefinite.
-The rescaled pair represents the same Kronecker product, so the choice
-absorbs the scalar into the sector tensors as in the source.
+scalar `c ≠ 0` with `c • η_{k,h}` and `c⁻¹ • η_{h,k}` positive semidefinite
+and with the rescaled pair representing the same Kronecker product, so the
+choice absorbs the scalar into the sector tensors as in the source.
 
 Source: arXiv:1606.00608, Appendix C.2, lines 1446--1450. -/
 theorem exists_smul_posSemidef_sectorEta
@@ -297,7 +301,11 @@ theorem exists_smul_posSemidef_sectorEta
     (hkh : sectorEta K hK hη R α₁ β₃ k h ≠ 0)
     (hhk : sectorEta K hK hη R α₁ β₃ h k ≠ 0) :
     ∃ c : ℂ, c ≠ 0 ∧ (c • sectorEta K hK hη R α₁ β₃ k h).PosSemidef ∧
-      (c⁻¹ • sectorEta K hK hη R α₁ β₃ h k).PosSemidef :=
+      (c⁻¹ • sectorEta K hK hη R α₁ β₃ h k).PosSemidef ∧
+      Matrix.kroneckerMap (· * ·) (c • sectorEta K hK hη R α₁ β₃ k h)
+          (c⁻¹ • sectorEta K hK hη R α₁ β₃ h k) =
+        Matrix.kroneckerMap (· * ·) (sectorEta K hK hη R α₁ β₃ k h)
+          (sectorEta K hK hη R α₁ β₃ h k) :=
   Matrix.exists_smul_posSemidef_of_kronecker_posSemidef
     (sectorEta_kronecker_posSemidef K hK R hρ hη hm hM k h) hkh hhk
 
@@ -331,9 +339,12 @@ theorem exists_explicitEtaOperators_sectorEta
       sectorEta K hK hη R α₁ β₃ h k = 0) :
     ∃ data : ExplicitEtaOperators hη,
       (∀ k, data.eta k k = sectorEta K hK hη R α₁ β₃ k k) ∧
-      ∀ k h, ∃ c : ℂ, c ≠ 0 ∧
+      (∀ k h, ∃ c : ℂ, c ≠ 0 ∧
         data.eta k h = c • sectorEta K hK hη R α₁ β₃ k h ∧
-        data.eta h k = c⁻¹ • sectorEta K hK hη R α₁ β₃ h k := by
+        data.eta h k = c⁻¹ • sectorEta K hK hη R α₁ β₃ h k) ∧
+      ∀ k h, Matrix.kroneckerMap (· * ·) (data.eta k h) (data.eta h k) =
+        Matrix.kroneckerMap (· * ·) (sectorEta K hK hη R α₁ β₃ k h)
+          (sectorEta K hK hη R α₁ β₃ h k) := by
   classical
   have hpair : ∀ k h, ∃ c : ℂ, c ≠ 0 ∧
       (c • sectorEta K hK hη R α₁ β₃ k h).PosSemidef ∧
@@ -345,12 +356,38 @@ theorem exists_explicitEtaOperators_sectorEta
         exact Matrix.PosSemidef.zero
       · rw [hsym k h h0, smul_zero]
         exact Matrix.PosSemidef.zero
-    · exact exists_smul_posSemidef_sectorEta K hK R hρ hη hm hM k h h0
-        fun hz => h0 (hsym h k hz)
+    · obtain ⟨c, hc, hpos1, hpos2, -⟩ :=
+        exists_smul_posSemidef_sectorEta K hK R hρ hη hm hM k h h0
+          fun hz => h0 (hsym h k hz)
+      exact ⟨c, hc, hpos1, hpos2⟩
+  -- The scalar assigned to the ordered pair `(k, h)`, together with its
+  -- defining equalities against both `sectorEta k h` and `sectorEta h k`.
+  -- Proved once and reused for the pairwise-scalar and block-preservation
+  -- conjuncts below, so both refer to the same witness `c`.
+  have hexists : ∀ k h, ∃ c : ℂ, c ≠ 0 ∧
+      (if k = h then 1 else if k ≤ h then (hpair k h).choose
+        else ((hpair h k).choose)⁻¹) • sectorEta K hK hη R α₁ β₃ k h =
+        c • sectorEta K hK hη R α₁ β₃ k h ∧
+      (if h = k then 1 else if h ≤ k then (hpair h k).choose
+        else ((hpair k h).choose)⁻¹) • sectorEta K hK hη R α₁ β₃ h k =
+        c⁻¹ • sectorEta K hK hη R α₁ β₃ h k := by
+    intro k h
+    by_cases hkh : k = h
+    · subst hkh
+      exact ⟨1, one_ne_zero, by simp, by simp⟩
+    · by_cases hle : k ≤ h
+      · have hgt : ¬h ≤ k := fun hle' => hkh (le_antisymm hle hle')
+        exact ⟨(hpair k h).choose, (hpair k h).choose_spec.1,
+          by simp [hkh, hle], by simp [Ne.symm hkh, hgt]⟩
+      · have hlt : h ≤ k := le_of_not_ge hle
+        refine ⟨((hpair h k).choose)⁻¹, inv_ne_zero (hpair h k).choose_spec.1,
+          by simp [hkh, hle], ?_⟩
+        rw [inv_inv]
+        simp [Ne.symm hkh, hlt]
   refine ⟨⟨fun k h =>
       (if k = h then 1 else if k ≤ h then (hpair k h).choose
         else ((hpair h k).choose)⁻¹) • sectorEta K hK hη R α₁ β₃ k h,
-      ?_⟩, ?_, ?_⟩
+      ?_⟩, ?_, hexists, ?_⟩
   · intro k h
     by_cases hkh : k = h
     · subst hkh
@@ -361,18 +398,9 @@ theorem exists_explicitEtaOperators_sectorEta
   · intro k
     simp
   · intro k h
-    by_cases hkh : k = h
-    · subst hkh
-      exact ⟨1, one_ne_zero, by simp, by simp⟩
-    · by_cases hle : k ≤ h
-      · have hgt : ¬h ≤ k := fun hle' => hkh (le_antisymm hle hle')
-        exact ⟨(hpair k h).choose, (hpair k h).choose_spec.1,
-          by simp [hkh, hle], by simp [Ne.symm hkh, hgt]⟩
-      · have hlt : h ≤ k := le_of_not_ge hle
-        refine ⟨((hpair h k).choose)⁻¹,
-          inv_ne_zero (hpair h k).choose_spec.1,
-          by simp [hkh, hle], ?_⟩
-        rw [inv_inv]
-        simp [Ne.symm hkh, hlt]
+    obtain ⟨c, hc, heq1, heq2⟩ := hexists k h
+    dsimp only
+    rw [heq1, heq2]
+    exact Matrix.smul_kronecker_smul_inv_eq _ _ hc
 
 end MPOTensor

--- a/TNLean/MPS/MPDO/SectorFactorization.lean
+++ b/TNLean/MPS/MPDO/SectorFactorization.lean
@@ -422,6 +422,11 @@ Positive semidefiniteness of the representatives fixed by
 `MPOTensor.sectorTensorL` and `MPOTensor.sectorTensorR` therefore enters here
 as a hypothesis; the remaining choice problem is recorded in
 `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+For an MPDO the diagonal operators are positive semidefinite
+(`MPOTensor.sectorEta_self_posSemidef`), each pair `η_{k,h} ⊗ η_{h,k}` is
+positive semidefinite (`MPOTensor.sectorEta_kronecker_posSemidef`), and a
+rescaled positive family exists once the nonzero neighboring operators occur
+in symmetric pairs (`MPOTensor.exists_explicitEtaOperators_sectorEta`).
 
 Source: arXiv:1606.00608, Appendix C.2, lines 1441--1455. -/
 noncomputable def ExplicitEtaOperators.ofSectorTensors

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -1223,19 +1223,20 @@ strong subadditivity for a normalized three-site reduced state.
     every summand in the closed trace is zero.
 \end{proof}
 
-\begin{lemma}[Positive rescaling of Kronecker factors]%
-    \label{lem:kronecker_factor_positive_rescaling}
+\begin{theorem}[Positive rescaling of Kronecker factors]%
+    \label{thm:kronecker_factor_positive_rescaling}
     \lean{Matrix.exists_smul_posSemidef_of_kronecker_posSemidef}
     \lean{Matrix.eq_zero_of_forall_star_dotProduct_mulVec_eq_zero}
     \lean{Matrix.posSemidef_of_forall_star_dotProduct_mulVec_nonneg}
     \lean{Matrix.star_dotProduct_kronecker_mulVec_prod}
+    \lean{Matrix.smul_kronecker_smul_inv_eq}
     \leanok
     Let $A$ and $B$ be nonzero complex square matrices whose Kronecker
     product $A\otimes B$ is positive semidefinite. Then there is a scalar
     $c\ne0$ with $cA\ge0$ and $c^{-1}B\ge0$. Since
     $(cA)\otimes(c^{-1}B)=A\otimes B$, the rescaled factors represent the
     same product.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}
     \leanok
@@ -1334,26 +1335,29 @@ strong subadditivity for a normalized three-site reduced state.
     \leanok
     \uses{def:mpdo, def:mpdo_sector_eta,
         thm:mpdo_cyclic_eta_posSemidef,
-        lem:kronecker_factor_positive_rescaling}
+        thm:kronecker_factor_positive_rescaling}
     Let ${\cal K}$ be an injective MPDO with the chosen Hayashi
     decomposition and a nonzero tail entry. Then for all sectors $k,h$:
     \begin{enumerate}
         \item $\eta_{k,k}\ge0$;
         \item $\eta_{k,h}\otimes\eta_{h,k}\ge0$;
         \item if $\eta_{k,h}\ne0$ and $\eta_{h,k}\ne0$, there is a scalar
-            $c\ne0$ with $c\,\eta_{k,h}\ge0$ and $c^{-1}\eta_{h,k}\ge0$.
+            $c\ne0$ with $c\,\eta_{k,h}\ge0$, $c^{-1}\eta_{h,k}\ge0$, and
+            $(c\,\eta_{k,h})\otimes(c^{-1}\eta_{h,k})=\eta_{k,h}\otimes
+            \eta_{h,k}$.
     \end{enumerate}
 \end{theorem}
 
 \begin{proof}
     \leanok
     \uses{thm:mpdo_cyclic_eta_posSemidef,
-        lem:kronecker_factor_positive_rescaling}
+        thm:kronecker_factor_positive_rescaling}
     The chain of length one projected to the sector $k$ is $\eta_{k,k}$ up
     to the exchange of its two tensor factors, and the chain of length two
     projected to $(k,h)$ is $\eta_{k,h}\otimes\eta_{h,k}$, both positive by
-    Theorem~\ref{thm:mpdo_cyclic_eta_posSemidef}. The third item is
-    Lemma~\ref{lem:kronecker_factor_positive_rescaling}.
+    Theorem~\ref{thm:mpdo_cyclic_eta_posSemidef}. The third item, including
+    the Kronecker-product-preserving equality, is
+    Theorem~\ref{thm:kronecker_factor_positive_rescaling}.
 \end{proof}
 
 \begin{theorem}[Positivity choice with symmetric support]%
@@ -1383,7 +1387,8 @@ strong subadditivity for a normalized three-site reduced state.
 
 \begin{proof}
     \leanok
-    \uses{thm:mpdo_sector_eta_pair_posSemidef}
+    \uses{thm:mpdo_sector_eta_pair_posSemidef,
+        thm:kronecker_factor_positive_rescaling}
     The diagonal operators are positive by
     Theorem~\ref{thm:mpdo_sector_eta_pair_posSemidef}, and their scalar is
     taken to be one. For a pair of distinct sectors, either both
@@ -1391,7 +1396,10 @@ strong subadditivity for a normalized three-site reduced state.
     nonzero by symmetric support and
     Theorem~\ref{thm:mpdo_sector_eta_pair_posSemidef} supplies the
     reciprocal pair of scalars. Choosing the scalar once per unordered
-    pair makes the two assignments reciprocal.
+    pair makes the two assignments reciprocal, and the block-preserving
+    equality of Theorem~\ref{thm:kronecker_factor_positive_rescaling}
+    applied to that scalar gives
+    $\eta'_{k,h}\otimes\eta'_{h,k}=\eta_{k,h}\otimes\eta_{h,k}$.
 \end{proof}
 
 \begin{definition}[Trace matrices of explicit $\eta$-data]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -1272,10 +1272,22 @@ strong subadditivity for a normalized three-site reduced state.
 
 \begin{proof}
     \leanok
-    Expand the closed trace of each side as a cyclic sum over bond
-    configurations, and each conjugated local entry over its two physical
-    indices. Distributing the site product over these sums matches the two
-    sides term by term. Positivity is preserved by any congruence.
+    Expand the closed trace over bond configurations $g$ (with
+    $g_{N+1}=g_1$), and each conjugated local entry over its two physical
+    indices:
+    \[
+        \bigl[\rho^{(N)}(\widetilde{\cal K})\bigr]_{\sigma,\tau}
+        =\sum_{g}\prod_{n=1}^{N}
+            \widetilde\kappa_{g_n,g_{n+1}}^{\,\sigma_n\tau_n}
+        =\sum_{g}\prod_{n=1}^{N}\sum_{p_n,q_n}
+            U_{\sigma_n p_n}\,
+            \kappa_{g_n,g_{n+1}}^{\,p_n q_n}\,
+            \overline{U_{\tau_n q_n}} .
+    \]
+    Distributing the site product over the physical sums factors the two
+    $U$-products out of the bond sum, which leaves the matrix entry of
+    $U^{\otimes N}\rho^{(N)}({\cal K})\bigl(U^{\otimes N}\bigr)^\dagger$.
+    Positivity is preserved by any congruence.
 \end{proof}
 
 \begin{theorem}[Positivity of the projected chain blocks]%
@@ -1301,8 +1313,9 @@ strong subadditivity for a normalized three-site reduced state.
     \leanok
     \uses{thm:mpdo_fixed_sector_cyclic_eta,
         thm:mpdo_conjugated_chain_congruence}
-    The cyclic tensor product $\Omega_k$ is a diagonal sector block of the
-    basis-conjugated chain by
+    The cyclic tensor product $\Omega_k$ of
+    Definition~\ref{def:mpdo_cyclic_eta_tensor_product} is a diagonal
+    sector block of the basis-conjugated chain by
     Theorem~\ref{thm:mpdo_fixed_sector_cyclic_eta}. The conjugated chain is
     positive semidefinite by
     Theorem~\ref{thm:mpdo_conjugated_chain_congruence} and the MPDO
@@ -1318,7 +1331,6 @@ strong subadditivity for a normalized three-site reduced state.
     \lean{MPOTensor.exists_smul_posSemidef_sectorEta}
     \lean{MPOTensor.etaOfSectorTensors_self_posSemidef}
     \lean{MPOTensor.etaOfSectorTensors_kronecker_posSemidef}
-    \lean{MPOTensor.sectorEta_eq_etaOfSectorTensors}
     \leanok
     \uses{def:mpdo, def:mpdo_sector_eta,
         thm:mpdo_cyclic_eta_posSemidef,

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -1240,10 +1240,9 @@ strong subadditivity for a normalized three-site reduced state.
 \begin{proof}
     \leanok
     On a product vector $x\otimes y$ the quadratic form of $A\otimes B$
-    factors, so
+    factors, so for all vectors $x$ and $y$,
     \[
-        \bigl(x^\dagger A\,x\bigr)\bigl(y^\dagger B\,y\bigr)\ge0
-        \quad\text{for all } x,y.
+        \bigl(x^\dagger A\,x\bigr)\bigl(y^\dagger B\,y\bigr)\ge0 .
     \]
     By polarization a complex matrix is determined by its quadratic form;
     since $A$ and $B$ are nonzero there are vectors with

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -1223,6 +1223,166 @@ strong subadditivity for a normalized three-site reduced state.
     every summand in the closed trace is zero.
 \end{proof}
 
+\begin{lemma}[Positive rescaling of Kronecker factors]%
+    \label{lem:kronecker_factor_positive_rescaling}
+    \lean{Matrix.exists_smul_posSemidef_of_kronecker_posSemidef}
+    \lean{Matrix.eq_zero_of_forall_star_dotProduct_mulVec_eq_zero}
+    \lean{Matrix.posSemidef_of_forall_star_dotProduct_mulVec_nonneg}
+    \lean{Matrix.star_dotProduct_kronecker_mulVec_prod}
+    \leanok
+    Let $A$ and $B$ be nonzero complex square matrices whose Kronecker
+    product $A\otimes B$ is positive semidefinite. Then there is a scalar
+    $c\ne0$ with $cA\ge0$ and $c^{-1}B\ge0$. Since
+    $(cA)\otimes(c^{-1}B)=A\otimes B$, the rescaled factors represent the
+    same product.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    On a product vector $x\otimes y$ the quadratic form of $A\otimes B$
+    factors, so
+    \[
+        \bigl(x^\dagger A\,x\bigr)\bigl(y^\dagger B\,y\bigr)\ge0
+        \quad\text{for all } x,y.
+    \]
+    By polarization a complex matrix is determined by its quadratic form;
+    since $A$ and $B$ are nonzero there are vectors with
+    $a=v_0^\dagger A\,v_0\ne0$ and $c=w_0^\dagger B\,w_0\ne0$. Every value
+    $x^\dagger(cA)\,x=(x^\dagger A\,x)\,c$ is nonnegative, and over the
+    complex numbers a nonnegative quadratic form already forces the matrix
+    to be Hermitian, hence positive semidefinite. For the second factor,
+    $ac>0$ and $a\,(y^\dagger B\,y)\ge0$ give
+    $c^{-1}(y^\dagger B\,y)=\bigl(a\,(y^\dagger B\,y)\bigr)(ac)^{-1}\ge0$.
+\end{proof}
+
+\begin{theorem}[The conjugated chain is a congruence]%
+    \label{thm:mpdo_conjugated_chain_congruence}
+    \lean{MPOTensor.mpo_conjugatePhysical_eq}
+    \lean{MPOTensor.mpo_conjugatePhysical_posSemidef}
+    \leanok
+    \uses{def:mpdo_conjugate_physical}
+    For every matrix $U$ on the physical space and every $N\ge1$,
+    \[
+        \rho^{(N)}(\widetilde{\cal K})
+        = U^{\otimes N}\,\rho^{(N)}({\cal K})\,
+          \bigl(U^{\otimes N}\bigr)^\dagger .
+    \]
+    In particular $\rho^{(N)}(\widetilde{\cal K})\ge0$ whenever
+    $\rho^{(N)}({\cal K})\ge0$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Expand the closed trace of each side as a cyclic sum over bond
+    configurations, and each conjugated local entry over its two physical
+    indices. Distributing the site product over these sums matches the two
+    sides term by term. Positivity is preserved by any congruence.
+\end{proof}
+
+\begin{theorem}[Positivity of the projected chain blocks]%
+    \label{thm:mpdo_cyclic_eta_posSemidef}
+    \lean{MPOTensor.cyclicEtaTensorProduct_posSemidef}
+    \leanok
+    \uses{def:mpdo, def:mpdo_cyclic_eta_tensor_product,
+        thm:mpdo_fixed_sector_cyclic_eta,
+        thm:mpdo_conjugated_chain_congruence}
+    Let ${\cal K}$ be an MPDO whose transformed physical slices satisfy the
+    sector factorization hypothesis. Then for every $N\ge1$ and every
+    cyclic sector assignment $k_1,\ldots,k_N$ (with $k_{N+1}=k_1$),
+    \[
+        0\le\bigl[Q_{k_1}\otimes\cdots\otimes Q_{k_N}\bigr]\,\tilde\sigma\,
+        \bigl[Q_{k_1}\otimes\cdots\otimes Q_{k_N}\bigr]
+        =\bigotimes_{n=1}^{N}\eta_{k_n,k_{n+1}} .
+    \]
+    This is the positivity half of the display at
+    \cite[Appendix~C.2, lines~1446--1450]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_fixed_sector_cyclic_eta,
+        thm:mpdo_conjugated_chain_congruence}
+    The cyclic tensor product $\Omega_k$ is a diagonal sector block of the
+    basis-conjugated chain by
+    Theorem~\ref{thm:mpdo_fixed_sector_cyclic_eta}. The conjugated chain is
+    positive semidefinite by
+    Theorem~\ref{thm:mpdo_conjugated_chain_congruence} and the MPDO
+    property, and a principal submatrix of a positive semidefinite matrix
+    is positive semidefinite.
+\end{proof}
+
+\begin{theorem}[Positivity of the diagonal and paired neighboring
+    operators]%
+    \label{thm:mpdo_sector_eta_pair_posSemidef}
+    \lean{MPOTensor.sectorEta_self_posSemidef}
+    \lean{MPOTensor.sectorEta_kronecker_posSemidef}
+    \lean{MPOTensor.exists_smul_posSemidef_sectorEta}
+    \lean{MPOTensor.etaOfSectorTensors_self_posSemidef}
+    \lean{MPOTensor.etaOfSectorTensors_kronecker_posSemidef}
+    \lean{MPOTensor.sectorEta_eq_etaOfSectorTensors}
+    \leanok
+    \uses{def:mpdo, def:mpdo_sector_eta,
+        thm:mpdo_cyclic_eta_posSemidef,
+        lem:kronecker_factor_positive_rescaling}
+    Let ${\cal K}$ be an injective MPDO with the chosen Hayashi
+    decomposition and a nonzero tail entry. Then for all sectors $k,h$:
+    \begin{enumerate}
+        \item $\eta_{k,k}\ge0$;
+        \item $\eta_{k,h}\otimes\eta_{h,k}\ge0$;
+        \item if $\eta_{k,h}\ne0$ and $\eta_{h,k}\ne0$, there is a scalar
+            $c\ne0$ with $c\,\eta_{k,h}\ge0$ and $c^{-1}\eta_{h,k}\ge0$.
+    \end{enumerate}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_cyclic_eta_posSemidef,
+        lem:kronecker_factor_positive_rescaling}
+    The chain of length one projected to the sector $k$ is $\eta_{k,k}$ up
+    to the exchange of its two tensor factors, and the chain of length two
+    projected to $(k,h)$ is $\eta_{k,h}\otimes\eta_{h,k}$, both positive by
+    Theorem~\ref{thm:mpdo_cyclic_eta_posSemidef}. The third item is
+    Lemma~\ref{lem:kronecker_factor_positive_rescaling}.
+\end{proof}
+
+\begin{theorem}[Positivity choice with symmetric support]%
+    \label{thm:mpdo_eta_positivity_choice_symmetric}
+    \lean{MPOTensor.exists_explicitEtaOperators_sectorEta}
+    \leanok
+    \uses{def:mpdo_explicit_eta_operators,
+        thm:mpdo_sector_eta_pair_posSemidef}
+    In the setting of Theorem~\ref{thm:mpdo_sector_eta_pair_posSemidef},
+    assume in addition that the nonzero neighboring operators occur in
+    symmetric pairs: $\eta_{k,h}=0$ forces $\eta_{h,k}=0$. Then there is a
+    positive semidefinite family $\eta'_{k,h}$ with $\eta'_{k,k}=\eta_{k,k}$
+    and, for every pair of sectors, scalars $c_{k,h}\ne0$ with
+    $\eta'_{k,h}=c_{k,h}\,\eta_{k,h}$ and
+    $\eta'_{h,k}=c_{k,h}^{-1}\,\eta_{h,k}$. In particular every two-site
+    block $\eta'_{k,h}\otimes\eta'_{h,k}=\eta_{k,h}\otimes\eta_{h,k}$ of
+    the sector-adapted decomposition is unchanged.
+
+    The source asserts at
+    \cite[Appendix~C.2, lines~1446--1450]{Cirac2016MPDO_arXiv} that the
+    $\eta$'s can be chosen positive semidefinite, without the
+    symmetric-support hypothesis. That hypothesis excludes a scalar
+    obstruction: a nonzero neighboring operator whose reverse pair
+    vanishes is constrained only by cycles through at least three
+    sectors, and a coherent choice for the whole family can then fail.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_sector_eta_pair_posSemidef}
+    The diagonal operators are positive by
+    Theorem~\ref{thm:mpdo_sector_eta_pair_posSemidef}, and their scalar is
+    taken to be one. For a pair of distinct sectors, either both
+    neighboring operators vanish and any nonzero scalar works, or both are
+    nonzero by symmetric support and
+    Theorem~\ref{thm:mpdo_sector_eta_pair_posSemidef} supplies the
+    reciprocal pair of scalars. Choosing the scalar once per unordered
+    pair makes the two assignments reciprocal.
+\end{proof}
+
 \begin{definition}[Trace matrices of explicit $\eta$-data]
     \label{def:mpdo_explicit_eta_trace_matrix}
     \lean{MPOTensor.ExplicitEtaOperators.traceMatrix}
@@ -1274,6 +1434,10 @@ strong subadditivity for a normalized three-site reduced state.
     identity does not by itself choose coherent positive representatives for
     all neighboring pairs, so positive semidefiniteness remains a hypothesis
     on the chosen representatives here.
+    Theorem~\ref{thm:mpdo_sector_eta_pair_posSemidef} provides the diagonal
+    and paired positivity, and
+    Theorem~\ref{thm:mpdo_eta_positivity_choice_symmetric} a rescaled
+    positive family under symmetric support.
 \end{definition}
 
 \begin{theorem}[Trace matrix of the sector-tensor $\eta$-data]

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -368,7 +368,11 @@ presented as the full formalization of Proposition~C.8.
 This note records an open gap for the SAL-to-bond construction of
 \leanid{MPOTensor.EtaLocalStructureData}. The two conditional declarations
 above are scope restrictions: they begin after the nearest-neighbor bonds have
-already been constructed.
+already been constructed. The positivity half of the projected chain identity
+is now formalized unconditionally, and the pairwise positive-choice
+construction is formalized under the symmetric-support scope restriction
+described above; the coherent choice across the whole sector graph and the
+primitivity of $T_{k,h}$ remain open.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -257,6 +257,43 @@ itself supply coherent positive representatives for all neighboring pairs;
 the missing argument must control these choices simultaneously across the
 sector graph.
 
+The positivity half of the projected chain identity is now formalized: for
+an MPDO, the chain of the physically conjugated tensor is a congruence of
+the original chain, so every cyclic tensor product of neighboring operators
+is a diagonal sector block of a positive operator,
+\[
+  0\le\bigl[Q_{k_1}\otimes\cdots\otimes Q_{k_N}\bigr]\,\tilde\sigma\,
+  \bigl[Q_{k_1}\otimes\cdots\otimes Q_{k_N}\bigr]
+  =\bigotimes_{n=1}^{N}\eta_{k_n,k_{n+1}} .
+\]
+The length-one and length-two specializations give $\eta_{k,k}\ge0$ and
+$\eta_{k,h}\otimes\eta_{h,k}\ge0$ unconditionally.  A rescaling lemma for
+the factors of a nonzero positive semidefinite Kronecker product then
+yields, for every pair with $\eta_{k,h}\ne0$ and $\eta_{h,k}\ne0$, a scalar
+$c\ne0$ with $c\,\eta_{k,h}\ge0$ and $c^{-1}\eta_{h,k}\ge0$.  Under the
+additional hypothesis of \emph{symmetric support} ($\eta_{k,h}=0$ forces
+$\eta_{h,k}=0$), choosing one scalar per unordered pair produces a positive
+semidefinite family which agrees with the raw family on the diagonal and
+preserves every two-site block
+$\eta_{k,h}\otimes\eta_{h,k}$.\footnote{The formal declarations are
+\path{Matrix.exists_smul_posSemidef_of_kronecker_posSemidef},
+\path{MPOTensor.mpo_conjugatePhysical_eq},
+\path{MPOTensor.cyclicEtaTensorProduct_posSemidef},
+\path{MPOTensor.sectorEta_self_posSemidef},
+\path{MPOTensor.sectorEta_kronecker_posSemidef},
+\path{MPOTensor.exists_smul_posSemidef_sectorEta}, and
+\path{MPOTensor.exists_explicitEtaOperators_sectorEta}.}
+
+Two aspects of the source's positive choice remain open.  First, the
+symmetric-support hypothesis is not stated in the source; it is neither
+implied by nor implies the recurrence hypothesis below, and either must be
+derived from injectivity or recorded as a scope restriction.  Second, the
+pairwise choice preserves the chain blocks of length at most two, whereas
+the source's choice rescales the sector tensors themselves and therefore
+preserves the blocks of every length simultaneously; the coherent choice
+across the whole sector graph is exactly the vertex-rephasing problem
+described next.
+
 The obstruction is already present when every neighboring bond space is
 one-dimensional.  Take four sectors $0,1,2,3$ and set
 \[


### PR DESCRIPTION
Partially addresses #3696.

Formalizes the positivity half of the projected chain identity of arXiv:1606.00608, Appendix C.2, lines 1446–1450, and the resulting choice of positive neighboring operators from the chains of length at most two.

## New module `TNLean/Algebra/KroneckerFactorPositivity.lean`

- `Matrix.eq_zero_of_forall_star_dotProduct_mulVec_eq_zero` — polarization over `ℂ`: a matrix whose quadratic form vanishes identically is zero;
- `Matrix.posSemidef_of_forall_star_dotProduct_mulVec_nonneg` — over `ℂ` a nonnegative quadratic form forces positive semidefiniteness (the Hermitian property is automatic);
- `Matrix.star_dotProduct_kronecker_mulVec_prod` — on a product vector the quadratic form of a Kronecker product factors;
- `Matrix.exists_smul_posSemidef_of_kronecker_posSemidef` — **positive rescaling of Kronecker factors**: if $A \otimes B \ge 0$ with $A, B \ne 0$, there is $c \ne 0$ with $cA \ge 0$ and $c^{-1}B \ge 0$; the rescaled pair represents the same product.

## New module `TNLean/MPS/MPDO/SectorEtaPositivity.lean`

- `MPOTensor.mpo_conjugatePhysical_eq` / `mpo_conjugatePhysical_posSemidef` — the chain of the physically conjugated tensor is the congruence $\rho^{(N)}(\widetilde{\mathcal K}) = U^{\otimes N}\rho^{(N)}(\mathcal K)(U^{\otimes N})^\dagger$, hence positive for an MPDO;
- `MPOTensor.cyclicEtaTensorProduct_posSemidef` — for an MPDO with the sector factorization, every cyclic tensor product of neighboring operators is positive semidefinite: $0 \le [Q_{k_1}\otimes\cdots\otimes Q_{k_N}]\,\tilde\sigma\,[Q_{k_1}\otimes\cdots\otimes Q_{k_N}] = \bigotimes_n \eta_{k_n,k_{n+1}}$ (the positivity half of lines 1446–1450);
- `MPOTensor.sectorEta_self_posSemidef` / `sectorEta_kronecker_posSemidef` — the length-one and length-two specializations: $\eta_{k,k} \ge 0$ and $\eta_{k,h}\otimes\eta_{h,k} \ge 0$ unconditionally;
- `MPOTensor.exists_smul_posSemidef_sectorEta` — the pairwise positivity choice for pairs with both neighboring operators nonzero;
- `MPOTensor.exists_explicitEtaOperators_sectorEta` — **the positivity choice**: under symmetric support of the nonzero neighboring operators, a positive semidefinite `ExplicitEtaOperators` family exists which agrees with the raw family on the diagonal and differs by reciprocal scalars within each pair, so every two-site block $\eta_{k,h}\otimes\eta_{h,k}$ is unchanged.

## Scope restriction

The symmetric-support hypothesis (`η_{k,h} = 0` forces `η_{h,k} = 0`) is not stated in the source. The paper-gap note `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex` already records a four-sector scalar obstruction showing that cyclic positivity alone does not yield a coherent choice; this PR extends the note with the new results, the symmetric-support restriction, and the remaining coherence question (the pairwise choice preserves the chain blocks of length at most two, while the source's rescaling of the sector tensors preserves all lengths simultaneously).

## Blueprint

Five new entries in `ch21_mpdo_rfp_simple_local_structure.tex` (`lem:kronecker_factor_positive_rescaling`, `thm:mpdo_conjugated_chain_congruence`, `thm:mpdo_cyclic_eta_posSemidef`, `thm:mpdo_sector_eta_pair_posSemidef`, `thm:mpdo_eta_positivity_choice_symmetric`), all with `\lean{}` and `\leanok`; the entry for `ExplicitEtaOperators.ofSectorTensors` now points to the new positivity results.

## Verification

- `lake build` succeeds; no `sorry`/`axiom` in the changed files;
- `#print axioms` on all fifteen new declarations: `[propext, Classical.choice, Quot.sound]`;
- `lake exe lint_style` clean; `leanblueprint checkdecls` passes.

## Remaining (tracked in #3696)

1. The coherent positive choice across the sector graph (vertex rephasing under recurrence of the nonzero support, or its derivation from injectivity);
2. primitivity of $T_{k,h} = \operatorname{tr}(\eta_{k,h})$ (lines 1468–1471).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New Mathlib-only proofs and documentation; no changes to auth, runtime, or critical infrastructure. Remaining gaps are explicitly scoped in paper-gap notes.
> 
> **Overview**
> Formalizes the **positivity half** of the projected chain identity (arXiv:1606.00608, Appendix C.2, ~1446–1450) and the resulting **choice of positive neighboring operators** from chains of length at most two.
> 
> **`TNLean/Algebra/KroneckerFactorPositivity.lean`** adds complex-matrix tools: polarization, nonnegative quadratic form ⇒ PSD, Kronecker quadratic forms on product vectors, and **`exists_smul_posSemidef_of_kronecker_posSemidef`** (nonzero factors of a PSD `A ⊗ B` admit reciprocal scalings `c • A`, `c⁻¹ • B` with the same product).
> 
> **`TNLean/MPS/MPDO/SectorEtaPositivity.lean`** shows the physically conjugated MPO chain is a **congruence** of the original (hence PSD for MPDOs), derives **PSD cyclic η products** and the **N=1 / N=2** cases (`η_{k,k}`, `η_{k,h} ⊗ η_{h,k}`), and builds **`exists_explicitEtaOperators_sectorEta`**—a PSD `ExplicitEtaOperators` family agreeing on the diagonal and differing by reciprocal scalars per pair—under **symmetric support** (`η_{k,h} = 0` ⇒ `η_{h,k} = 0`). Coherent choice across longer cycles is still documented as open.
> 
> Root imports, **`SectorFactorization`** doc cross-refs, **five blueprint theorems** in `ch21_mpdo_rfp_simple_local_structure.tex`, and **`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`** are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 929bb60aa85c45740d0f4458358407c753db79cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->