### PR TITLE
feat(MPS/MPDO): normalize eta preparations

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -378,6 +378,7 @@ import TNLean.MPS.MPDO.RFPViaTS
 import TNLean.MPS.MPDO.PRFP
 import TNLean.MPS.MPDO.LocalPurificationRFP
 import TNLean.MPS.MPDO.SimpleLocalStructure
+import TNLean.MPS.MPDO.EtaPreparation
 import TNLean.MPS.MPDO.HayashiSectorComparison
 import TNLean.MPS.MPDO.SectorFactorization
 import TNLean.MPS.MPDO.SectorPairingTransfer

--- a/TNLean/Analysis/MatrixSqrt.lean
+++ b/TNLean/Analysis/MatrixSqrt.lean
@@ -19,6 +19,8 @@ operator theory development.
   root of a positive-semidefinite matrix is Hermitian.
 * `Matrix.PosSemidef.cfc_sqrt_mul_self`: the square of that square root is the
   original matrix.
+* `Matrix.PosSemidef.blockDiagonal'`: a finite dependent block diagonal of
+  positive-semidefinite matrices is positive semidefinite.
 -/
 
 open scoped Matrix ComplexOrder
@@ -55,5 +57,28 @@ theorem PosSemidef.cfc_sqrt_mul_self {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef)
     simp only [Function.comp_apply, id_eq]
     exact congrArg (RCLike.ofReal) (Real.mul_self_sqrt (hρ.eigenvalues_nonneg i))
   rw [hcongr, hρ.isHermitian.cfc_id]
+
+/-- A finite dependent block diagonal of positive-semidefinite matrices is
+positive semidefinite. -/
+theorem PosSemidef.blockDiagonal'
+    {p : Type*} [Finite p] [DecidableEq p]
+    {m : p → Type*} [∀ i, Finite (m i)]
+    (A : ∀ i, Matrix (m i) (m i) ℂ) (hA : ∀ i, (A i).PosSemidef) :
+    (Matrix.blockDiagonal' A).PosSemidef := by
+  classical
+  letI := Fintype.ofFinite p
+  letI (i : p) := Fintype.ofFinite (m i)
+  let B : ∀ i, Matrix (m i) (m i) ℂ :=
+    fun i ↦ (hA i).isHermitian.cfc Real.sqrt
+  have hBherm (i) : (B i).IsHermitian := (hA i).cfc_sqrt_isHermitian
+  have hBB (i) : B i * B i = A i := (hA i).cfc_sqrt_mul_self
+  have hEq : Matrix.blockDiagonal' A =
+      (Matrix.blockDiagonal' B)ᴴ * Matrix.blockDiagonal' B := by
+    rw [Matrix.blockDiagonal'_conjTranspose, ← Matrix.blockDiagonal'_mul]
+    congr 1
+    funext i
+    rw [show (B i)ᴴ = B i from hBherm i, hBB]
+  rw [hEq]
+  exact Matrix.posSemidef_conjTranspose_mul_self _
 
 end Matrix

--- a/TNLean/MPS/MPDO/EtaPreparation.lean
+++ b/TNLean/MPS/MPDO/EtaPreparation.lean
@@ -60,33 +60,12 @@ noncomputable def omega (data : ExplicitEtaOperators hη) (k h : Fin hη.m) :
   Matrix.blockDiagonal' fun l ↦
     Matrix.kroneckerMap (· * ·) (data.eta k l) (data.eta l h)
 
-private theorem posSemidef_blockDiagonal'
-    {p : Type*} [Finite p] [DecidableEq p]
-    {n : p → Type*} [∀ i, Finite (n i)]
-    (A : ∀ i, Matrix (n i) (n i) ℂ) (hA : ∀ i, (A i).PosSemidef) :
-    (Matrix.blockDiagonal' A).PosSemidef := by
-  classical
-  letI := Fintype.ofFinite p
-  letI (i : p) := Fintype.ofFinite (n i)
-  let B : ∀ i, Matrix (n i) (n i) ℂ :=
-    fun i ↦ (hA i).isHermitian.cfc Real.sqrt
-  have hBherm (i) : (B i).IsHermitian := (hA i).cfc_sqrt_isHermitian
-  have hBB (i) : B i * B i = A i := (hA i).cfc_sqrt_mul_self
-  have hEq : Matrix.blockDiagonal' A =
-      (Matrix.blockDiagonal' B)ᴴ * Matrix.blockDiagonal' B := by
-    rw [Matrix.blockDiagonal'_conjTranspose, ← Matrix.blockDiagonal'_mul]
-    congr 1
-    funext i
-    rw [show (B i)ᴴ = B i from hBherm i, hBB]
-  rw [hEq]
-  exact Matrix.posSemidef_conjTranspose_mul_self _
-
 /-- Each $\Omega_{k,h}$ is positive semidefinite.
 
 Source: arXiv:1606.00608, Appendix C.2, lines 1527--1535. -/
 theorem omega_pos (data : ExplicitEtaOperators hη) (k h : Fin hη.m) :
     (data.omega k h).PosSemidef := by
-  apply posSemidef_blockDiagonal'
+  apply Matrix.PosSemidef.blockDiagonal'
   intro l
   exact (data.eta_pos k l).kronecker (data.eta_pos l h)
 
@@ -189,7 +168,7 @@ theorem trace_normalizedEta (data : ExplicitEtaOperators hη)
   rcases mul_ne_zero_iff.mp hactive with ⟨ha, hb⟩
   have haC : (factor.a k : ℂ) ≠ 0 := by exact_mod_cast ha
   have hbC : (factor.b h : ℂ) ≠ 0 := by exact_mod_cast hb
-  simp [normalizedEta, Matrix.trace_smul, factor.trace_eta]
+  simp only [normalizedEta, Matrix.trace_smul, factor.trace_eta]
   field_simp
 
 /-- The normalized direct-sum operator is positive semidefinite. On a zero
@@ -213,7 +192,7 @@ theorem trace_normalizedOmega (data : ExplicitEtaOperators hη)
   rcases mul_ne_zero_iff.mp hactive with ⟨ha, hb⟩
   have haC : (factor.a k : ℂ) ≠ 0 := by exact_mod_cast ha
   have hbC : (factor.b h : ℂ) ≠ 0 := by exact_mod_cast hb
-  simp [normalizedOmega, Matrix.trace_smul,
+  simp only [normalizedOmega, Matrix.trace_smul,
     data.trace_omega_eq_mul factor k h]
   field_simp
 

--- a/TNLean/MPS/MPDO/EtaPreparation.lean
+++ b/TNLean/MPS/MPDO/EtaPreparation.lean
@@ -1,0 +1,246 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.MPDO.KrausCPTP
+import TNLean.MPS.MPDO.SimpleLocalStructure
+
+/-!
+# Normalized neighboring-operator preparations
+
+This file defines the direct-sum operator
+
+$$
+\Omega_{k,h}=\bigoplus_l(\eta_{k,l}\otimes\eta_{l,h})
+$$
+
+from arXiv:1606.00608, Appendix C.2, lines 1527--1535. It proves positivity,
+computes its trace from the rank-one trace factorization
+$\operatorname{tr}(\eta_{k,h})=a_kb_h$, and treats the pairs with
+$a_kb_h=0$ without assuming that all sector weights are nonzero.
+
+The results construct the individual normalized preparations on active sector
+pairs. The orthogonal direct sum of these maps, including a trace-preserving
+completion on unused zero-weight input summands, is a separate construction.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+namespace MPOTensor.ExplicitEtaOperators
+
+variable {dA dB dC : ℕ}
+variable {rhoABC : Matrix (Fin dA × Fin dB × Fin dC)
+  (Fin dA × Fin dB × Fin dC) ℂ}
+variable {hη : EtaStructure rhoABC}
+
+/-- The rank-one trace factorization of the neighboring operators:
+$\operatorname{tr}(\eta_{k,h})=a_kb_h$ and $\sum_l a_lb_l=1$.
+
+These are equations Apptralktrrk and AppPsiPhi in arXiv:1606.00608,
+Appendix C.2, lines 1395--1402. -/
+structure RankOneTraceFactorization (data : ExplicitEtaOperators hη) where
+  a : Fin hη.m → ℝ
+  b : Fin hη.m → ℝ
+  trace_eta : ∀ k h, (data.eta k h).trace = ((a k * b h : ℝ) : ℂ)
+  sum_mul : ∑ l, a l * b l = 1
+
+/-- The index space of
+$\Omega_{k,h}=\bigoplus_l(\eta_{k,l}\otimes\eta_{l,h})$.
+The outer sigma coordinate records the intermediate sector $l$. -/
+abbrev OmegaIndex (k h : Fin hη.m) :=
+  Σ l : Fin hη.m,
+    (Fin (hη.dR k) × Fin (hη.dL l)) ×
+      (Fin (hη.dR l) × Fin (hη.dL h))
+
+/-- The direct sum
+$\Omega_{k,h}=\bigoplus_l(\eta_{k,l}\otimes\eta_{l,h})$ used by
+$\mathcal T_1$ in arXiv:1606.00608, Appendix C.2, lines 1527--1535. -/
+noncomputable def omega (data : ExplicitEtaOperators hη) (k h : Fin hη.m) :
+    Matrix (OmegaIndex k h) (OmegaIndex k h) ℂ :=
+  Matrix.blockDiagonal' fun l ↦
+    Matrix.kroneckerMap (· * ·) (data.eta k l) (data.eta l h)
+
+private theorem posSemidef_blockDiagonal'
+    {p : Type*} [Finite p] [DecidableEq p]
+    {n : p → Type*} [∀ i, Finite (n i)]
+    (A : ∀ i, Matrix (n i) (n i) ℂ) (hA : ∀ i, (A i).PosSemidef) :
+    (Matrix.blockDiagonal' A).PosSemidef := by
+  classical
+  letI := Fintype.ofFinite p
+  letI (i : p) := Fintype.ofFinite (n i)
+  let B : ∀ i, Matrix (n i) (n i) ℂ :=
+    fun i ↦ (hA i).isHermitian.cfc Real.sqrt
+  have hBherm (i) : (B i).IsHermitian := (hA i).cfc_sqrt_isHermitian
+  have hBB (i) : B i * B i = A i := (hA i).cfc_sqrt_mul_self
+  have hEq : Matrix.blockDiagonal' A =
+      (Matrix.blockDiagonal' B)ᴴ * Matrix.blockDiagonal' B := by
+    rw [Matrix.blockDiagonal'_conjTranspose, ← Matrix.blockDiagonal'_mul]
+    congr 1
+    funext i
+    rw [show (B i)ᴴ = B i from hBherm i, hBB]
+  rw [hEq]
+  exact Matrix.posSemidef_conjTranspose_mul_self _
+
+/-- Each $\Omega_{k,h}$ is positive semidefinite.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1527--1535. -/
+theorem omega_pos (data : ExplicitEtaOperators hη) (k h : Fin hη.m) :
+    (data.omega k h).PosSemidef := by
+  apply posSemidef_blockDiagonal'
+  intro l
+  exact (data.eta_pos k l).kronecker (data.eta_pos l h)
+
+/-- The trace of $\Omega_{k,h}$ is the sum of the products of the two
+neighboring-operator traces:
+
+$$
+\operatorname{tr}(\Omega_{k,h})
+=\sum_l\operatorname{tr}(\eta_{k,l})\operatorname{tr}(\eta_{l,h}).
+$$
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1527--1535. -/
+theorem trace_omega (data : ExplicitEtaOperators hη) (k h : Fin hη.m) :
+    (data.omega k h).trace =
+      ∑ l, (data.eta k l).trace * (data.eta l h).trace := by
+  rw [omega, Matrix.trace_blockDiagonal']
+  simp only [Matrix.trace_kronecker]
+
+/-- Under the source rank-one trace factorization,
+$\operatorname{tr}(\Omega_{k,h})=a_kb_h$.
+
+Source: arXiv:1606.00608, Appendix C.2, equations Apptralktrrk and
+AppPsiPhi at lines 1395--1402, and lines 1531--1535. -/
+theorem trace_omega_eq_mul (data : ExplicitEtaOperators hη)
+    (factor : RankOneTraceFactorization data) (k h : Fin hη.m) :
+    (data.omega k h).trace = ((factor.a k * factor.b h : ℝ) : ℂ) := by
+  rw [data.trace_omega]
+  simp_rw [factor.trace_eta]
+  norm_cast
+  calc
+    ∑ l, factor.a k * factor.b l * (factor.a l * factor.b h) =
+        factor.a k * (∑ l, factor.a l * factor.b l) * factor.b h := by
+      rw [Finset.mul_sum, Finset.sum_mul]
+      apply Finset.sum_congr rfl
+      intro l _
+      ring
+    _ = factor.a k * factor.b h := by rw [factor.sum_mul]; ring
+
+/-- Every sector weight $a_kb_h$ is nonnegative, as it is the trace of the
+positive semidefinite operator $\eta_{k,h}$. -/
+theorem mul_nonneg (data : ExplicitEtaOperators hη)
+    (factor : RankOneTraceFactorization data) (k h : Fin hη.m) :
+    0 ≤ factor.a k * factor.b h := by
+  have htrace := (data.eta_pos k h).trace_nonneg
+  rw [factor.trace_eta] at htrace
+  exact_mod_cast htrace
+
+/-- If $a_kb_h=0$, then the corresponding positive operator
+$\eta_{k,h}$ vanishes. -/
+theorem eta_eq_zero_of_mul_eq_zero (data : ExplicitEtaOperators hη)
+    (factor : RankOneTraceFactorization data) (k h : Fin hη.m)
+    (hzero : factor.a k * factor.b h = 0) :
+    data.eta k h = 0 := by
+  apply (Matrix.PosSemidef.trace_eq_zero_iff (data.eta_pos k h)).mp
+  rw [factor.trace_eta, hzero]
+  norm_num
+
+/-- If $a_kb_h=0$, then the corresponding positive direct-sum operator
+$\Omega_{k,h}$ vanishes. -/
+theorem omega_eq_zero_of_mul_eq_zero (data : ExplicitEtaOperators hη)
+    (factor : RankOneTraceFactorization data) (k h : Fin hη.m)
+    (hzero : factor.a k * factor.b h = 0) :
+    data.omega k h = 0 := by
+  apply (Matrix.PosSemidef.trace_eq_zero_iff (data.omega_pos k h)).mp
+  rw [data.trace_omega_eq_mul factor k h, hzero]
+  norm_num
+
+/-- The normalized neighboring operator on an active pair $a_kb_h\ne0$.
+The definition is also meaningful on a zero pair, but it is used only with an
+active-pair hypothesis. -/
+noncomputable def normalizedEta (data : ExplicitEtaOperators hη)
+    (factor : RankOneTraceFactorization data) (k h : Fin hη.m) :=
+  (((factor.a k * factor.b h)⁻¹ : ℝ) : ℂ) • data.eta k h
+
+/-- The normalized direct-sum operator on an active pair $a_kb_h\ne0$.
+The definition is also meaningful on a zero pair, but it is used only with an
+active-pair hypothesis. -/
+noncomputable def normalizedOmega (data : ExplicitEtaOperators hη)
+    (factor : RankOneTraceFactorization data) (k h : Fin hη.m) :=
+  (((factor.a k * factor.b h)⁻¹ : ℝ) : ℂ) • data.omega k h
+
+/-- The normalized neighboring operator is positive semidefinite. On a zero
+pair it is the zero operator; the trace-one statement below is restricted to
+active pairs.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1551--1555. -/
+theorem normalizedEta_pos (data : ExplicitEtaOperators hη)
+    (factor : RankOneTraceFactorization data) (k h : Fin hη.m) :
+    (data.normalizedEta factor k h).PosSemidef := by
+  apply (data.eta_pos k h).smul
+  exact_mod_cast inv_nonneg.mpr (data.mul_nonneg factor k h)
+
+/-- On an active pair, the normalized neighboring operator has trace one.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1551--1555. -/
+theorem trace_normalizedEta (data : ExplicitEtaOperators hη)
+    (factor : RankOneTraceFactorization data) (k h : Fin hη.m)
+    (hactive : factor.a k * factor.b h ≠ 0) :
+    (data.normalizedEta factor k h).trace = 1 := by
+  rcases mul_ne_zero_iff.mp hactive with ⟨ha, hb⟩
+  have haC : (factor.a k : ℂ) ≠ 0 := by exact_mod_cast ha
+  have hbC : (factor.b h : ℂ) ≠ 0 := by exact_mod_cast hb
+  simp [normalizedEta, Matrix.trace_smul, factor.trace_eta]
+  field_simp
+
+/-- The normalized direct-sum operator is positive semidefinite. On a zero
+pair it is the zero operator; the trace-one statement below is restricted to
+active pairs.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1527--1535. -/
+theorem normalizedOmega_pos (data : ExplicitEtaOperators hη)
+    (factor : RankOneTraceFactorization data) (k h : Fin hη.m) :
+    (data.normalizedOmega factor k h).PosSemidef := by
+  apply (data.omega_pos k h).smul
+  exact_mod_cast inv_nonneg.mpr (data.mul_nonneg factor k h)
+
+/-- On an active pair, the normalized direct-sum operator has trace one.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1527--1535. -/
+theorem trace_normalizedOmega (data : ExplicitEtaOperators hη)
+    (factor : RankOneTraceFactorization data) (k h : Fin hη.m)
+    (hactive : factor.a k * factor.b h ≠ 0) :
+    (data.normalizedOmega factor k h).trace = 1 := by
+  rcases mul_ne_zero_iff.mp hactive with ⟨ha, hb⟩
+  have haC : (factor.a k : ℂ) ≠ 0 := by exact_mod_cast ha
+  have hbC : (factor.b h : ℂ) ≠ 0 := by exact_mod_cast hb
+  simp [normalizedOmega, Matrix.trace_smul,
+    data.trace_omega_eq_mul factor k h]
+  field_simp
+
+/-- On an active pair, adjoining the normalized neighboring operator is a
+trace-preserving completely positive map. This is the individual
+$\mathcal S_{k,h}$ preparation from arXiv:1606.00608, Appendix C.2,
+lines 1551--1555. -/
+theorem normalizedEta_preparationMap_isKrausCPTP
+    {α : Type*} [Fintype α] [DecidableEq α]
+    (data : ExplicitEtaOperators hη) (factor : RankOneTraceFactorization data)
+    (k h : Fin hη.m) (hactive : factor.a k * factor.b h ≠ 0) :
+    IsKrausCPTP (Matrix.preparationMap (α := α)
+      (data.normalizedEta factor k h)) := by
+  exact Matrix.preparationMap_isKrausCPTP _
+    (data.normalizedEta_pos factor k h) (data.trace_normalizedEta factor k h hactive)
+
+/-- On an active pair, adjoining the normalized direct-sum operator is a
+trace-preserving completely positive map. This is the individual
+$\mathcal T_{k,h}$ preparation from arXiv:1606.00608, Appendix C.2,
+lines 1527--1535. -/
+theorem normalizedOmega_preparationMap_isKrausCPTP
+    {α : Type*} [Fintype α] [DecidableEq α]
+    (data : ExplicitEtaOperators hη) (factor : RankOneTraceFactorization data)
+    (k h : Fin hη.m) (hactive : factor.a k * factor.b h ≠ 0) :
+    IsKrausCPTP (Matrix.preparationMap (α := α)
+      (data.normalizedOmega factor k h)) := by
+  exact Matrix.preparationMap_isKrausCPTP _
+    (data.normalizedOmega_pos factor k h) (data.trace_normalizedOmega factor k h hactive)
+
+end MPOTensor.ExplicitEtaOperators

--- a/TNLean/MPS/MPDO/EtaPreparation.lean
+++ b/TNLean/MPS/MPDO/EtaPreparation.lean
@@ -165,12 +165,9 @@ theorem trace_normalizedEta (data : ExplicitEtaOperators hη)
     (factor : RankOneTraceFactorization data) (k h : Fin hη.m)
     (hactive : factor.a k * factor.b h ≠ 0) :
     (data.normalizedEta factor k h).trace = 1 := by
-  rcases mul_ne_zero_iff.mp hactive with ⟨ha, hb⟩
-  have haC : (factor.a k : ℂ) ≠ 0 := by exact_mod_cast ha
-  have hbC : (factor.b h : ℂ) ≠ 0 := by exact_mod_cast hb
   simp only [normalizedEta, Matrix.trace_smul, factor.trace_eta, smul_eq_mul]
   norm_cast
-  field_simp
+  exact inv_mul_cancel₀ hactive
 
 /-- The normalized direct-sum operator is positive semidefinite. On a zero
 pair it is the zero operator; the trace-one statement below is restricted to
@@ -190,13 +187,10 @@ theorem trace_normalizedOmega (data : ExplicitEtaOperators hη)
     (factor : RankOneTraceFactorization data) (k h : Fin hη.m)
     (hactive : factor.a k * factor.b h ≠ 0) :
     (data.normalizedOmega factor k h).trace = 1 := by
-  rcases mul_ne_zero_iff.mp hactive with ⟨ha, hb⟩
-  have haC : (factor.a k : ℂ) ≠ 0 := by exact_mod_cast ha
-  have hbC : (factor.b h : ℂ) ≠ 0 := by exact_mod_cast hb
   simp only [normalizedOmega, Matrix.trace_smul,
     data.trace_omega_eq_mul factor k h, smul_eq_mul]
   norm_cast
-  field_simp
+  exact inv_mul_cancel₀ hactive
 
 /-- On an active pair, adjoining the normalized neighboring operator is a
 trace-preserving completely positive map. This is the individual

--- a/TNLean/MPS/MPDO/EtaPreparation.lean
+++ b/TNLean/MPS/MPDO/EtaPreparation.lean
@@ -106,7 +106,7 @@ theorem trace_omega_eq_mul (data : ExplicitEtaOperators hη)
 
 /-- Every sector weight $a_kb_h$ is nonnegative, as it is the trace of the
 positive semidefinite operator $\eta_{k,h}$. -/
-theorem mul_nonneg (data : ExplicitEtaOperators hη)
+theorem weight_nonneg (data : ExplicitEtaOperators hη)
     (factor : RankOneTraceFactorization data) (k h : Fin hη.m) :
     0 ≤ factor.a k * factor.b h := by
   have htrace := (data.eta_pos k h).trace_nonneg
@@ -156,7 +156,7 @@ theorem normalizedEta_pos (data : ExplicitEtaOperators hη)
     (factor : RankOneTraceFactorization data) (k h : Fin hη.m) :
     (data.normalizedEta factor k h).PosSemidef := by
   apply (data.eta_pos k h).smul
-  exact_mod_cast inv_nonneg.mpr (data.mul_nonneg factor k h)
+  exact_mod_cast inv_nonneg.mpr (data.weight_nonneg factor k h)
 
 /-- On an active pair, the normalized neighboring operator has trace one.
 
@@ -181,7 +181,7 @@ theorem normalizedOmega_pos (data : ExplicitEtaOperators hη)
     (factor : RankOneTraceFactorization data) (k h : Fin hη.m) :
     (data.normalizedOmega factor k h).PosSemidef := by
   apply (data.omega_pos k h).smul
-  exact_mod_cast inv_nonneg.mpr (data.mul_nonneg factor k h)
+  exact_mod_cast inv_nonneg.mpr (data.weight_nonneg factor k h)
 
 /-- On an active pair, the normalized direct-sum operator has trace one.
 
@@ -207,8 +207,8 @@ theorem normalizedEta_preparationMap_isKrausCPTP
     (data : ExplicitEtaOperators hη) (factor : RankOneTraceFactorization data)
     (k h : Fin hη.m) (hactive : factor.a k * factor.b h ≠ 0) :
     IsKrausCPTP (Matrix.preparationMap (α := α)
-      (data.normalizedEta factor k h)) := by
-  exact Matrix.preparationMap_isKrausCPTP _
+      (data.normalizedEta factor k h)) :=
+  Matrix.preparationMap_isKrausCPTP _
     (data.normalizedEta_pos factor k h) (data.trace_normalizedEta factor k h hactive)
 
 /-- On an active pair, adjoining the normalized direct-sum operator is a
@@ -220,8 +220,8 @@ theorem normalizedOmega_preparationMap_isKrausCPTP
     (data : ExplicitEtaOperators hη) (factor : RankOneTraceFactorization data)
     (k h : Fin hη.m) (hactive : factor.a k * factor.b h ≠ 0) :
     IsKrausCPTP (Matrix.preparationMap (α := α)
-      (data.normalizedOmega factor k h)) := by
-  exact Matrix.preparationMap_isKrausCPTP _
+      (data.normalizedOmega factor k h)) :=
+  Matrix.preparationMap_isKrausCPTP _
     (data.normalizedOmega_pos factor k h) (data.trace_normalizedOmega factor k h hactive)
 
 end MPOTensor.ExplicitEtaOperators

--- a/TNLean/MPS/MPDO/EtaPreparation.lean
+++ b/TNLean/MPS/MPDO/EtaPreparation.lean
@@ -168,7 +168,8 @@ theorem trace_normalizedEta (data : ExplicitEtaOperators hη)
   rcases mul_ne_zero_iff.mp hactive with ⟨ha, hb⟩
   have haC : (factor.a k : ℂ) ≠ 0 := by exact_mod_cast ha
   have hbC : (factor.b h : ℂ) ≠ 0 := by exact_mod_cast hb
-  simp only [normalizedEta, Matrix.trace_smul, factor.trace_eta]
+  simp only [normalizedEta, Matrix.trace_smul, factor.trace_eta, smul_eq_mul]
+  norm_cast
   field_simp
 
 /-- The normalized direct-sum operator is positive semidefinite. On a zero
@@ -193,7 +194,8 @@ theorem trace_normalizedOmega (data : ExplicitEtaOperators hη)
   have haC : (factor.a k : ℂ) ≠ 0 := by exact_mod_cast ha
   have hbC : (factor.b h : ℂ) ≠ 0 := by exact_mod_cast hb
   simp only [normalizedOmega, Matrix.trace_smul,
-    data.trace_omega_eq_mul factor k h]
+    data.trace_omega_eq_mul factor k h, smul_eq_mul]
+  norm_cast
   field_simp
 
 /-- On an active pair, adjoining the normalized neighboring operator is a

--- a/TNLean/MPS/MPDO/EtaPreparation.lean
+++ b/TNLean/MPS/MPDO/EtaPreparation.lean
@@ -36,8 +36,7 @@ variable {hη : EtaStructure rhoABC}
 /-- The rank-one trace factorization of the neighboring operators:
 $\operatorname{tr}(\eta_{k,h})=a_kb_h$ and $\sum_l a_lb_l=1$.
 
-These are equations Apptralktrrk and AppPsiPhi in arXiv:1606.00608,
-Appendix C.2, lines 1395--1402. -/
+Source: arXiv:1606.00608, Appendix C.2, lines 1395--1402. -/
 structure RankOneTraceFactorization (data : ExplicitEtaOperators hη) where
   a : Fin hη.m → ℝ
   b : Fin hη.m → ℝ
@@ -53,8 +52,9 @@ abbrev OmegaIndex (k h : Fin hη.m) :=
       (Fin (hη.dR l) × Fin (hη.dL h))
 
 /-- The direct sum
-$\Omega_{k,h}=\bigoplus_l(\eta_{k,l}\otimes\eta_{l,h})$ used by
-$\mathcal T_1$ in arXiv:1606.00608, Appendix C.2, lines 1527--1535. -/
+$\Omega_{k,h}=\bigoplus_l(\eta_{k,l}\otimes\eta_{l,h})$, adjoined by the
+preparation map $\mathcal T_{k,h}$ in arXiv:1606.00608, Appendix C.2,
+lines 1527--1535. -/
 noncomputable def omega (data : ExplicitEtaOperators hη) (k h : Fin hη.m) :
     Matrix (OmegaIndex k h) (OmegaIndex k h) ℂ :=
   Matrix.blockDiagonal' fun l ↦
@@ -87,8 +87,7 @@ theorem trace_omega (data : ExplicitEtaOperators hη) (k h : Fin hη.m) :
 /-- Under the source rank-one trace factorization,
 $\operatorname{tr}(\Omega_{k,h})=a_kb_h$.
 
-Source: arXiv:1606.00608, Appendix C.2, equations Apptralktrrk and
-AppPsiPhi at lines 1395--1402, and lines 1531--1535. -/
+Source: arXiv:1606.00608, Appendix C.2, lines 1395--1402 and 1531--1535. -/
 theorem trace_omega_eq_mul (data : ExplicitEtaOperators hη)
     (factor : RankOneTraceFactorization data) (k h : Fin hη.m) :
     (data.omega k h).trace = ((factor.a k * factor.b h : ℝ) : ℂ) := by

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -1270,12 +1270,27 @@ strong subadditivity for a normalized three-site reduced state.
     \cite[Appendix~C.2, lines~1527--1535]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
+\begin{theorem}[Positivity of finite dependent block diagonals]
+    \label{thm:matrix_pos_semidef_block_diagonal}
+    \lean{Matrix.PosSemidef.blockDiagonal'}
+    \leanok
+    Let $(A_i)_{i\in I}$ be a finite family of positive semidefinite matrices,
+    where the size of $A_i$ may depend on $i$. Then the block-diagonal matrix
+    $\bigoplus_{i\in I}A_i$ is positive semidefinite.
+\end{theorem}
+\begin{proof}
+    \leanok
+    Write each $A_i=B_i^*B_i$ using its positive square root. The dependent
+    block diagonal then satisfies
+    $\bigoplus_i A_i=(\bigoplus_i B_i)^*(\bigoplus_i B_i)$.
+\end{proof}
+
 \begin{theorem}[Positivity of the direct-sum neighboring operator]
     \label{thm:mpdo_eta_omega_pos}
-    \lean{Matrix.PosSemidef.blockDiagonal'}
     \lean{MPOTensor.ExplicitEtaOperators.omega_pos}
     \leanok
-    \uses{def:mpdo_eta_omega, def:mpdo_explicit_eta_operators}
+    \uses{def:mpdo_eta_omega, def:mpdo_explicit_eta_operators,
+      thm:matrix_pos_semidef_block_diagonal}
     Every operator $\Omega_{k,h}$ is positive semidefinite.
 \end{theorem}
 \begin{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -1329,8 +1329,13 @@ strong subadditivity for a normalized three-site reduced state.
 \end{theorem}
 \begin{proof}
     \leanok
-    The trace of a finite direct sum is the sum of the block traces, and
-    $\tr(A\otimes B)=\tr(A)\tr(B)$. Substitute
+    The direct-sum and Kronecker trace identities give
+    \[
+        \tr(\Omega_{k,h})
+        =\sum_l\tr\bigl(\eta_{k,l}\otimes\eta_{l,h}\bigr)
+        =\sum_l\tr(\eta_{k,l})\tr(\eta_{l,h}).
+    \]
+    Substitute
     $\tr(\eta_{k,h})=a_kb_h$ and $\sum_l a_lb_l=1$.
 \end{proof}
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -1329,7 +1329,7 @@ strong subadditivity for a normalized three-site reduced state.
 
 \begin{theorem}[Vanishing of zero-weight neighboring operators]
     \label{thm:mpdo_eta_zero_weight}
-    \lean{MPOTensor.ExplicitEtaOperators.mul_nonneg}
+    \lean{MPOTensor.ExplicitEtaOperators.weight_nonneg}
     \lean{MPOTensor.ExplicitEtaOperators.eta_eq_zero_of_mul_eq_zero}
     \lean{MPOTensor.ExplicitEtaOperators.omega_eq_zero_of_mul_eq_zero}
     \leanok

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -1249,7 +1249,7 @@ strong subadditivity for a normalized three-site reduced state.
         \qquad
         \sum_l a_lb_l=1.
     \]
-    These are equations \textup{(Apptralktrrk)} and \textup{(AppPsiPhi)} in
+    These identities occur in
     \cite[Appendix~C.2, lines~1395--1402]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
@@ -1359,7 +1359,8 @@ strong subadditivity for a normalized three-site reduced state.
     \lean{MPOTensor.ExplicitEtaOperators.normalizedOmega_preparationMap_isKrausCPTP}
     \leanok
     \uses{def:mpdo_normalized_eta_omega, thm:mpdo_eta_omega_pos,
-      thm:mpdo_eta_omega_trace, lem:mpdo_state_preparation_cptp}
+      thm:mpdo_eta_omega_trace, thm:mpdo_eta_zero_weight,
+      lem:mpdo_state_preparation_cptp}
     If $a_kb_h\ne0$, then $\widehat\eta_{k,h}$ and
     $\widehat\Omega_{k,h}$ are positive semidefinite and have trace one.
     Consequently the maps

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -1272,6 +1272,7 @@ strong subadditivity for a normalized three-site reduced state.
 
 \begin{theorem}[Positivity of the direct-sum neighboring operator]
     \label{thm:mpdo_eta_omega_pos}
+    \lean{Matrix.PosSemidef.blockDiagonal'}
     \lean{MPOTensor.ExplicitEtaOperators.omega_pos}
     \leanok
     \uses{def:mpdo_eta_omega, def:mpdo_explicit_eta_operators}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -1365,20 +1365,35 @@ strong subadditivity for a normalized three-site reduced state.
     $a_kb_h\ne0$.
 \end{definition}
 
+\begin{theorem}[Positivity of normalized neighboring operators]
+    \label{thm:mpdo_normalized_eta_omega_pos}
+    \lean{MPOTensor.ExplicitEtaOperators.normalizedEta_pos}
+    \lean{MPOTensor.ExplicitEtaOperators.normalizedOmega_pos}
+    \leanok
+    \uses{def:mpdo_normalized_eta_omega, thm:mpdo_eta_omega_pos,
+      thm:mpdo_eta_zero_weight}
+    For every pair $(k,h)$, the operators $\widehat\eta_{k,h}$ and
+    $\widehat\Omega_{k,h}$ are positive semidefinite.
+\end{theorem}
+\begin{proof}
+    \leanok
+    The weight $a_kb_h$ is nonnegative, hence so is its inverse. Scaling the
+    positive semidefinite operators $\eta_{k,h}$ and $\Omega_{k,h}$ by this
+    inverse preserves positive semidefiniteness.
+\end{proof}
+
 \begin{theorem}[Normalized active preparations]
     \label{thm:mpdo_normalized_eta_omega_preparation}
-    \lean{MPOTensor.ExplicitEtaOperators.normalizedEta_pos}
     \lean{MPOTensor.ExplicitEtaOperators.trace_normalizedEta}
-    \lean{MPOTensor.ExplicitEtaOperators.normalizedOmega_pos}
     \lean{MPOTensor.ExplicitEtaOperators.trace_normalizedOmega}
     \lean{MPOTensor.ExplicitEtaOperators.normalizedEta_preparationMap_isKrausCPTP}
     \lean{MPOTensor.ExplicitEtaOperators.normalizedOmega_preparationMap_isKrausCPTP}
     \leanok
-    \uses{def:mpdo_normalized_eta_omega, thm:mpdo_eta_omega_pos,
-      thm:mpdo_eta_omega_trace, thm:mpdo_eta_zero_weight,
+    \uses{def:mpdo_normalized_eta_omega,
+      thm:mpdo_normalized_eta_omega_pos, thm:mpdo_eta_omega_trace,
       lem:mpdo_state_preparation_cptp}
     If $a_kb_h\ne0$, then $\widehat\eta_{k,h}$ and
-    $\widehat\Omega_{k,h}$ are positive semidefinite and have trace one.
+    $\widehat\Omega_{k,h}$ have trace one.
     Consequently the maps
     \[
         X\longmapsto X\otimes\widehat\eta_{k,h},
@@ -1392,8 +1407,7 @@ strong subadditivity for a normalized three-site reduced state.
 \end{theorem}
 \begin{proof}
     \leanok
-    Since $a_kb_h>0$ on an active pair, division preserves positivity. The
-    trace identities give
+    The trace identities give
     $\tr(\widehat\eta_{k,h})=\tr(\widehat\Omega_{k,h})=1$.
     Apply Lemma~\ref{lem:mpdo_state_preparation_cptp} to each operator.
 \end{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -1344,9 +1344,18 @@ strong subadditivity for a normalized three-site reduced state.
 \end{theorem}
 \begin{proof}
     \leanok
-    The trace of a positive semidefinite operator is nonnegative, and a
-    positive semidefinite operator with zero trace is zero. Apply this first to
-    $\eta_{k,h}$ and then to $\Omega_{k,h}$.
+    Since $\eta_{k,h}\succeq 0$, its trace is nonnegative, and hence
+    $a_kb_h=\tr(\eta_{k,h})\geq 0$. If $a_kb_h=0$, then
+    \[
+        \eta_{k,h}\succeq 0,
+        \qquad
+        \tr(\eta_{k,h})=a_kb_h=0
+        \quad\Longrightarrow\quad
+        \eta_{k,h}=0.
+    \]
+    The same implication gives $\Omega_{k,h}=0$ because
+    $\Omega_{k,h}\succeq 0$ and
+    $\tr(\Omega_{k,h})=a_kb_h=0$.
 \end{proof}
 
 \begin{definition}[Normalized active neighboring operators]
@@ -1377,9 +1386,17 @@ strong subadditivity for a normalized three-site reduced state.
 \end{theorem}
 \begin{proof}
     \leanok
-    The weight $a_kb_h$ is nonnegative, hence so is its inverse. Scaling the
-    positive semidefinite operators $\eta_{k,h}$ and $\Omega_{k,h}$ by this
-    inverse preserves positive semidefiniteness.
+    By Theorem~\ref{thm:mpdo_eta_zero_weight}, $a_kb_h\geq 0$, and hence
+    $(a_kb_h)^{-1}\geq 0$. Therefore
+    \[
+        \eta_{k,h}\succeq 0,
+        \qquad
+        (a_kb_h)^{-1}\geq 0
+        \quad\Longrightarrow\quad
+        \widehat\eta_{k,h}
+        =(a_kb_h)^{-1}\eta_{k,h}\succeq 0,
+    \]
+    and the identical argument applies to $\widehat\Omega_{k,h}$.
 \end{proof}
 
 \begin{theorem}[Normalized active preparations]
@@ -1407,8 +1424,15 @@ strong subadditivity for a normalized three-site reduced state.
 \end{theorem}
 \begin{proof}
     \leanok
-    The trace identities give
-    $\tr(\widehat\eta_{k,h})=\tr(\widehat\Omega_{k,h})=1$.
+    On an active pair,
+    \[
+        \tr(\widehat\eta_{k,h})
+        =(a_kb_h)^{-1}\tr(\eta_{k,h})
+        =(a_kb_h)^{-1}a_kb_h
+        =1.
+    \]
+    Likewise, $\tr(\widehat\Omega_{k,h})=1$ follows from
+    $\tr(\Omega_{k,h})=a_kb_h$.
     Apply Lemma~\ref{lem:mpdo_state_preparation_cptp} to each operator.
 \end{proof}
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -1295,9 +1295,16 @@ strong subadditivity for a normalized three-site reduced state.
 \end{theorem}
 \begin{proof}
     \leanok
-    Each tensor product $\eta_{k,l}\otimes\eta_{l,h}$ is positive
-    semidefinite, and a finite orthogonal direct sum of positive semidefinite
-    operators is positive semidefinite.
+    For every $l$, positivity is preserved by the Kronecker product:
+    \[
+        \eta_{k,l}\succeq 0,
+        \qquad
+        \eta_{l,h}\succeq 0
+        \quad\Longrightarrow\quad
+        \eta_{k,l}\otimes\eta_{l,h}\succeq 0.
+    \]
+    Apply Theorem~\ref{thm:matrix_pos_semidef_block_diagonal} to the family
+    $(\eta_{k,l}\otimes\eta_{l,h})_l$.
 \end{proof}
 
 \begin{theorem}[Trace of the direct-sum neighboring operator]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -1237,6 +1237,154 @@ strong subadditivity for a normalized three-site reduced state.
     in the rank-one step.
 \end{definition}
 
+\begin{definition}[Rank-one factorization of neighboring-operator traces]
+    \label{def:mpdo_eta_rank_one_trace_factorization}
+    \lean{MPOTensor.ExplicitEtaOperators.RankOneTraceFactorization}
+    \leanok
+    \uses{def:mpdo_explicit_eta_operators}
+    Let $(\eta_{k,h})$ be a positive neighboring-operator family. A rank-one
+    trace factorization consists of real families $(a_k)$ and $(b_h)$ such that
+    \[
+        \tr(\eta_{k,h})=a_kb_h,
+        \qquad
+        \sum_l a_lb_l=1.
+    \]
+    These are equations \textup{(Apptralktrrk)} and \textup{(AppPsiPhi)} in
+    \cite[Appendix~C.2, lines~1395--1402]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{definition}[Direct-sum neighboring operator]
+    \label{def:mpdo_eta_omega}
+    \lean{MPOTensor.ExplicitEtaOperators.OmegaIndex}
+    \lean{MPOTensor.ExplicitEtaOperators.omega}
+    \leanok
+    \uses{def:mpdo_explicit_eta_operators}
+    For sectors $k,h$, define the positive-operator candidate
+    \[
+        \Omega_{k,h}
+        =\bigoplus_l\bigl(\eta_{k,l}\otimes\eta_{l,h}\bigr).
+    \]
+    The summand indexed by $l$ acts on
+    $(B_k^R\otimes B_l^L)\otimes(B_l^R\otimes B_h^L)$.
+    This is the operator adjoined by $\mathcal T_{k,h}$ in
+    \cite[Appendix~C.2, lines~1527--1535]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{theorem}[Positivity of the direct-sum neighboring operator]
+    \label{thm:mpdo_eta_omega_pos}
+    \lean{MPOTensor.ExplicitEtaOperators.omega_pos}
+    \leanok
+    \uses{def:mpdo_eta_omega, def:mpdo_explicit_eta_operators}
+    Every operator $\Omega_{k,h}$ is positive semidefinite.
+\end{theorem}
+\begin{proof}
+    \leanok
+    Each tensor product $\eta_{k,l}\otimes\eta_{l,h}$ is positive
+    semidefinite, and a finite orthogonal direct sum of positive semidefinite
+    operators is positive semidefinite.
+\end{proof}
+
+\begin{theorem}[Trace of the direct-sum neighboring operator]
+    \label{thm:mpdo_eta_omega_trace}
+    \lean{MPOTensor.ExplicitEtaOperators.trace_omega}
+    \lean{MPOTensor.ExplicitEtaOperators.trace_omega_eq_mul}
+    \leanok
+    \uses{def:mpdo_eta_omega, def:mpdo_eta_rank_one_trace_factorization}
+    The trace is
+    \[
+        \tr(\Omega_{k,h})
+        =\sum_l\tr(\eta_{k,l})\tr(\eta_{l,h}).
+    \]
+    Under the rank-one trace factorization, this becomes
+    \[
+        \tr(\Omega_{k,h})
+        =a_kb_h\sum_l a_lb_l
+        =a_kb_h.
+    \]
+    This is the trace calculation in
+    \cite[Appendix~C.2, lines~1531--1535]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+\begin{proof}
+    \leanok
+    The trace of a finite direct sum is the sum of the block traces, and
+    $\tr(A\otimes B)=\tr(A)\tr(B)$. Substitute
+    $\tr(\eta_{k,h})=a_kb_h$ and $\sum_l a_lb_l=1$.
+\end{proof}
+
+\begin{theorem}[Vanishing of zero-weight neighboring operators]
+    \label{thm:mpdo_eta_zero_weight}
+    \lean{MPOTensor.ExplicitEtaOperators.mul_nonneg}
+    \lean{MPOTensor.ExplicitEtaOperators.eta_eq_zero_of_mul_eq_zero}
+    \lean{MPOTensor.ExplicitEtaOperators.omega_eq_zero_of_mul_eq_zero}
+    \leanok
+    \uses{thm:mpdo_eta_omega_pos, thm:mpdo_eta_omega_trace,
+      def:mpdo_eta_rank_one_trace_factorization}
+    Every product $a_kb_h$ is nonnegative. If $a_kb_h=0$, then
+    \[
+        \eta_{k,h}=0,
+        \qquad
+        \Omega_{k,h}=0.
+    \]
+\end{theorem}
+\begin{proof}
+    \leanok
+    The trace of a positive semidefinite operator is nonnegative, and a
+    positive semidefinite operator with zero trace is zero. Apply this first to
+    $\eta_{k,h}$ and then to $\Omega_{k,h}$.
+\end{proof}
+
+\begin{definition}[Normalized active neighboring operators]
+    \label{def:mpdo_normalized_eta_omega}
+    \lean{MPOTensor.ExplicitEtaOperators.normalizedEta}
+    \lean{MPOTensor.ExplicitEtaOperators.normalizedOmega}
+    \leanok
+    \uses{def:mpdo_eta_omega, def:mpdo_eta_rank_one_trace_factorization}
+    With the convention $0^{-1}=0$, define for every pair $(k,h)$
+    \[
+        \widehat\eta_{k,h}=(a_kb_h)^{-1}\eta_{k,h},
+        \qquad
+        \widehat\Omega_{k,h}=(a_kb_h)^{-1}\Omega_{k,h}.
+    \]
+    These operators are normalized when the pair is active, namely when
+    $a_kb_h\ne0$.
+\end{definition}
+
+\begin{theorem}[Normalized active preparations]
+    \label{thm:mpdo_normalized_eta_omega_preparation}
+    \lean{MPOTensor.ExplicitEtaOperators.normalizedEta_pos}
+    \lean{MPOTensor.ExplicitEtaOperators.trace_normalizedEta}
+    \lean{MPOTensor.ExplicitEtaOperators.normalizedOmega_pos}
+    \lean{MPOTensor.ExplicitEtaOperators.trace_normalizedOmega}
+    \lean{MPOTensor.ExplicitEtaOperators.normalizedEta_preparationMap_isKrausCPTP}
+    \lean{MPOTensor.ExplicitEtaOperators.normalizedOmega_preparationMap_isKrausCPTP}
+    \leanok
+    \uses{def:mpdo_normalized_eta_omega, thm:mpdo_eta_omega_pos,
+      thm:mpdo_eta_omega_trace, lem:mpdo_state_preparation_cptp}
+    If $a_kb_h\ne0$, then $\widehat\eta_{k,h}$ and
+    $\widehat\Omega_{k,h}$ are positive semidefinite and have trace one.
+    Consequently the maps
+    \[
+        X\longmapsto X\otimes\widehat\eta_{k,h},
+        \qquad
+        X\longmapsto X\otimes\widehat\Omega_{k,h}
+    \]
+    are trace-preserving and completely positive. These are the individual
+    preparations $\mathcal S_{k,h}$ and $\mathcal T_{k,h}$ in
+    \cite[Appendix~C.2, lines~1527--1535 and~1551--1555]
+      {Cirac2016MPDO_arXiv}.
+\end{theorem}
+\begin{proof}
+    \leanok
+    Since $a_kb_h>0$ on an active pair, division preserves positivity. The
+    trace identities give
+    $\tr(\widehat\eta_{k,h})=\tr(\widehat\Omega_{k,h})=1$.
+    Apply Lemma~\ref{lem:mpdo_state_preparation_cptp} to each operator.
+\end{proof}
+
+% The orthogonal direct sum of the active maps and a trace-preserving
+% completion on the unused zero-weight input summands remain part of the
+% construction of the full maps T_1 and S_1.
+
 \begin{figure}[ht]
     \centering
     \TNMPDOSectorPairing


### PR DESCRIPTION
This PR formalizes the active-sector preparation operators used in Appendix C.2 of arXiv:1606.00608.

It introduces the rank-one trace factorization of the neighboring operators, constructs the dependent block sum Ω_{k,h}, proves positivity and the trace identity tr(Ω_{k,h}) = a_k b_h, treats zero-weight sectors, and obtains normalized CPTP preparation maps on every active sector. The corresponding Chapter 21 blueprint statements cite equations Apptralktrrk and AppPsiPhi and the preparation-map passages at lines 1527–1535 and 1551–1555.

This advances, but does not close, #3742. The remaining obligation is the global orthogonal direct sum of the active maps together with a trace-preserving completion on unused zero-weight input summands. No nonzero or dimension hypothesis absent from the source is introduced here.

Validation:
- full lake build TNLean after rebasing on main
- lake env lean TNLean/MPS/MPDO/EtaPreparation.lean
- leanblueprint web
- leanblueprint checkdecls
- leanblueprint pdf
- proof-integrity and diff checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formalization and documentation on the MPDO track; no changes to auth, runtime, or existing proof obligations beyond new imports and matrix theory lemmas.
> 
> **Overview**
> Adds **Appendix C.2** preparation machinery for explicit neighboring **η**-operators: rank-one trace weights **tr(η_{k,h}) = a_k b_h**, the direct sum **Ω_{k,h} = ⊕_l (η_{k,l} ⊗ η_{l,h})**, and trace-normalized **η̂** / **Ω̂** on active pairs **a_k b_h ≠ 0**.
> 
> New Lean module `TNLean/MPS/MPDO/EtaPreparation.lean` proves PSD of **Ω**, **tr(Ω) = a_k b_h**, vanishing when **a_k b_h = 0**, and that **X ↦ X ⊗ η̂** and **X ↦ X ⊗ Ω̂** are Kraus CPTP via existing `preparationMap_isKrausCPTP`. Supporting lemma **`Matrix.PosSemidef.blockDiagonal'`** is added in `MatrixSqrt.lean` for dependent block diagonals of PSD matrices. The module is wired into the root import list.
> 
> Chapter 21 blueprint gains matching definitions and theorems (with `\leanok` links); a comment notes the **global** orthogonal direct sum of active maps plus trace-preserving completion on zero-weight summands is still out of scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66512b226ea5ebfce747bd09150278175f5c75ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->