### PR TITLE
feat(MPS/MPDO): construct the cyclic projector of a nontrivial periodic vector

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -370,6 +370,7 @@ import TNLean.MPS.MPDO.VerticalCF
 import TNLean.MPS.MPDO.InvariantProjection
 import TNLean.MPS.MPDO.PeriodicExclusion
 import TNLean.MPS.MPDO.StackedLayers
+import TNLean.MPS.MPDO.CyclicProjector
 import TNLean.MPS.MPDO.SectorTrace
 import TNLean.MPS.MPDO.BiCFDerivation
 import TNLean.MPS.MPDO.ZCL

--- a/TNLean/Channel/Irreducible/Basic.lean
+++ b/TNLean/Channel/Irreducible/Basic.lean
@@ -7,6 +7,7 @@ import Mathlib.Data.Matrix.Basis
 import Mathlib.Analysis.Matrix.Order
 import Mathlib.LinearAlgebra.Matrix.PosDef
 import Mathlib.Tactic.NoncommRing
+import TNLean.Algebra.MatrixAux
 
 /-!
 # Irreducible Completely Positive Maps
@@ -62,6 +63,65 @@ theorem isOrthogonalProjection_posSemidef {P : Matrix (Fin D) (Fin D) ℂ}
     (hP : IsOrthogonalProjection P) :
     P.PosSemidef :=
   Matrix.nonneg_iff_posSemidef.mp hP.isStarProjection.nonneg
+
+/-- **Orthogonal projections summing to the identity are mutually
+orthogonal**: `P k * P l = 0` for `k ≠ l`.  Compressing the resolution of the
+identity by `P k` exhibits a vanishing sum of positive semidefinite
+matrices. -/
+theorem orthogonalProjection_mul_eq_zero_of_sum_eq_one {m : ℕ}
+    (P : Fin m → Matrix (Fin D) (Fin D) ℂ)
+    (hproj : ∀ k, IsOrthogonalProjection (P k))
+    (hsum : ∑ k : Fin m, P k = 1) :
+    ∀ {k l : Fin m}, k ≠ l → P k * P l = 0 := by
+  classical
+  -- It suffices to prove `P l * P k = 0` for `k ≠ l` and take adjoints.
+  suffices h : ∀ k l : Fin m, k ≠ l → P l * P k = 0 by
+    intro k l hkl
+    have hconj := congrArg Matrix.conjTranspose (h k l hkl)
+    simpa [Matrix.conjTranspose_mul, (hproj k).1.eq, (hproj l).1.eq] using hconj
+  intro k l hkl
+  -- Pad the family `j ↦ P j * P k` (for `j ≠ k`) by zero at `j = k`.
+  set B : Fin m → Matrix (Fin D) (Fin D) ℂ :=
+    fun j => if j = k then 0 else P j * P k with hB
+  -- `∑ j ≠ k, P k P j P k = P k - P k = 0`, a vanishing sum of PSD matrices.
+  have hexp : ∀ j, (B j)ᴴ * B j = if j = k then 0 else P k * P j * P k := by
+    intro j
+    by_cases hj : j = k
+    · simp [hB, hj]
+    · simp only [hB, hj, if_false]
+      rw [Matrix.conjTranspose_mul, (hproj j).1.eq, (hproj k).1.eq]
+      calc P k * P j * (P j * P k)
+          = P k * (P j * P j) * P k := by simp only [Matrix.mul_assoc]
+        _ = P k * P j * P k := by rw [(hproj j).2, Matrix.mul_assoc]
+  have hzero : ∑ j ∈ Finset.univ.erase k, P k * P j * P k = 0 := by
+    have hfull : ∑ j : Fin m, P k * P j * P k = P k := by
+      calc ∑ j : Fin m, P k * P j * P k
+          = P k * (∑ j : Fin m, P j) * P k := by
+            rw [Finset.mul_sum, Finset.sum_mul]
+        _ = P k := by rw [hsum, Matrix.mul_one, (hproj k).2]
+    have hsplit := Finset.add_sum_erase Finset.univ
+      (fun j => P k * P j * P k) (Finset.mem_univ k)
+    rw [hfull] at hsplit
+    have hkk : P k * P k * P k = P k := by rw [(hproj k).2, (hproj k).2]
+    rw [hkk] at hsplit
+    have hsplit' : P k + ∑ j ∈ Finset.univ.erase k, P k * P j * P k = P k + 0 := by
+      rw [add_zero]; exact hsplit
+    exact add_left_cancel hsplit'
+  -- Extract the `l`-th summand through the sum-of-squares lemma.
+  have hBzero : ∀ j, B j = 0 := by
+    refine Matrix.eq_zero_of_sum_conjTranspose_mul_self_eq_zero B ?_
+    calc ∑ j : Fin m, (B j)ᴴ * B j
+        = ∑ j : Fin m, (if j = k then 0 else P k * P j * P k) :=
+          Finset.sum_congr rfl fun j _ => hexp j
+      _ = ∑ j ∈ Finset.univ.erase k, (if j = k then 0 else P k * P j * P k) :=
+          (Finset.sum_erase Finset.univ (by simp)).symm
+      _ = ∑ j ∈ Finset.univ.erase k, P k * P j * P k :=
+          Finset.sum_congr rfl fun j hj => by
+            rw [if_neg (Finset.mem_erase.mp hj).1]
+      _ = 0 := hzero
+  have hBl := hBzero l
+  rw [hB] at hBl
+  simpa [Ne.symm hkl] using hBl
 
 /-! ### Irreducibility of CP maps -/
 

--- a/TNLean/Channel/Peripheral/CyclicDecomposition.lean
+++ b/TNLean/Channel/Peripheral/CyclicDecomposition.lean
@@ -6,6 +6,7 @@ import TNLean.Channel.Peripheral.CyclicDecomposition.Basic
 import TNLean.Channel.Peripheral.CyclicDecomposition.PeripheralUnitary
 import TNLean.Channel.Peripheral.CyclicDecomposition.CyclicProjections
 import TNLean.Channel.Peripheral.CyclicDecomposition.Decomposition
+import TNLean.Channel.Peripheral.CyclicDecomposition.LetterShift
 import TNLean.Channel.Peripheral.CyclicDecomposition.Primitivity
 
 /-!
@@ -13,7 +14,7 @@ import TNLean.Channel.Peripheral.CyclicDecomposition.Primitivity
 
 This module keeps the historical import path
 `TNLean.Channel.Peripheral.CyclicDecomposition` while the development is split
-across five focused submodules.
+across six focused submodules.
 
 The supporting modules are:
 
@@ -25,6 +26,8 @@ The supporting modules are:
   spectral projections of a finite-order peripheral unitary.
 * `TNLean.Channel.Peripheral.CyclicDecomposition.Decomposition` — the main
   cyclic decomposition theorem for irreducible unital Schwarz maps.
+* `TNLean.Channel.Peripheral.CyclicDecomposition.LetterShift` — the cyclic
+  shift of the Kraus operators across the cyclic projections.
 * `TNLean.Channel.Peripheral.CyclicDecomposition.Primitivity` — corner
   preservation, sector irreducibility, sector primitivity, and the permutation
   variant.
@@ -32,6 +35,7 @@ The supporting modules are:
 ## Main statements
 
 * `exists_cyclic_decomposition_of_irreducible_schwarz`
+* `kraus_mul_cyclicProj`
 * `preserves_corner_pow_of_cyclic_decomp`
 * `isIrreducible_restriction_of_cyclic_decomp`
 * `isPrimitive_restriction_of_cyclic_decomp`

--- a/TNLean/Channel/Peripheral/CyclicDecomposition/LetterShift.lean
+++ b/TNLean/Channel/Peripheral/CyclicDecomposition/LetterShift.lean
@@ -19,13 +19,25 @@ with each projection.
 
 * `one_sub_mul_kraus_mul_eq_zero_of_transferMap_proj` — each Kraus operator
   maps the range of `P'` into the range of `P` when the map sends `P'` to `P`.
-* `orthogonalProjection_mul_eq_zero_of_sum_eq_one` — orthogonal projections
-  summing to the identity are mutually orthogonal.
 * `kraus_mul_cyclicProj` — the letter-level cyclic shift
-  `K v * P (k + 1) = P k * K v`.
+  $K_vP_{k+1}=P_kK_v$.
 * `evalWord_mul_cyclicProj` — the word-level shift
-  `evalWord K w * P k = P (k - w.length) * evalWord K w`.
+  $A^wP_k=P_{k-\ell}A^w$ for words of length $\ell$.
 * `cyclicProj_ne_zero` — no cyclic projection vanishes.
+
+The mutual orthogonality of projections summing to the identity is
+`orthogonalProjection_mul_eq_zero_of_sum_eq_one` in
+`TNLean/Channel/Irreducible/Basic.lean`.
+
+The letter shift here assumes the resolution of the identity
+$\sum_kP_k=1$ and no normalization of the Kraus family; the companion
+statement `offDiag_shift_of_adjoint_cyclic_shift` in
+`TNLean/MPS/CanonicalForm/CyclicSectors/FixedAdjoint.lean` derives the same
+shift for the adjoint orientation from unitality of the family through the
+Kadison--Schwarz equality, without the resolution of the identity.  Neither
+hypothesis set implies the other, so the two statements coexist; both
+instantiate to the cyclic decomposition, where the projections sum to the
+identity and the gauged family is unital.
 
 ## References
 
@@ -77,68 +89,19 @@ theorem one_sub_mul_kraus_mul_eq_zero_of_transferMap_proj
           rw [show ∑ w : Fin r, K w * P' * (K w)ᴴ = P from by
             simpa [transferMap_apply] using hmap]
       _ = 0 := by rw [h1PP, Matrix.zero_mul]
-  -- Trace positivity extracts each summand.
-  intro v
-  have htr_sum : ∑ w : Fin r, (T w * (T w)ᴴ).trace = 0 := by
-    rw [← Matrix.trace_sum, hsum, Matrix.trace_zero]
-  have htr : (T v * (T v)ᴴ).trace = 0 :=
-    (Finset.sum_eq_zero_iff_of_nonneg fun w _ =>
-      (Matrix.posSemidef_self_mul_conjTranspose (T w)).trace_nonneg).mp
-      htr_sum v (Finset.mem_univ v)
-  exact Matrix.trace_mul_conjTranspose_self_eq_zero_iff.mp htr
-
-/-- **Orthogonal projections summing to the identity are mutually
-orthogonal**: `P k * P l = 0` for `k ≠ l`.  Compressing the resolution of the
-identity by `P k` exhibits a vanishing sum of positive semidefinite
-matrices. -/
-theorem orthogonalProjection_mul_eq_zero_of_sum_eq_one
-    (P : Fin m → MatrixAlg n)
-    (hproj : ∀ k, IsOrthogonalProjection (P k))
-    (hsum : ∑ k : Fin m, P k = 1) :
-    ∀ {k l : Fin m}, k ≠ l → P k * P l = 0 := by
-  classical
-  -- It suffices to prove `P l * P k = 0` for `l ≠ k` and take adjoints.
-  suffices h : ∀ k l : Fin m, k ≠ l → P l * P k = 0 by
-    intro k l hkl
-    have := congrArg Matrix.conjTranspose (h k l hkl)
-    simpa [Matrix.conjTranspose_mul, (hproj k).1.eq, (hproj l).1.eq] using this
-  intro k l hkl
-  -- `∑ j ≠ k, P k P j P k = P k - P k = 0`, a vanishing sum of PSD matrices.
-  have hzero : ∑ j ∈ Finset.univ.erase k, P k * P j * P k = 0 := by
-    have hfull : ∑ j : Fin m, P k * P j * P k = P k := by
-      calc ∑ j : Fin m, P k * P j * P k
-          = P k * (∑ j : Fin m, P j) * P k := by
-            rw [Finset.mul_sum, Finset.sum_mul]
-        _ = P k := by rw [hsum, Matrix.mul_one, (hproj k).2]
-    have hsplit := Finset.add_sum_erase Finset.univ
-      (fun j => P k * P j * P k) (Finset.mem_univ k)
-    rw [hfull] at hsplit
-    have hkk : P k * P k * P k = P k := by rw [(hproj k).2, (hproj k).2]
-    rw [hkk] at hsplit
-    have hsplit' : P k + ∑ j ∈ Finset.univ.erase k, P k * P j * P k = P k + 0 := by
-      rw [add_zero]; exact hsplit
-    exact add_left_cancel hsplit'
-  -- Each summand is `(P j P k)ᴴ (P j P k)`, hence PSD with nonnegative trace.
-  have hexp : ∀ j, P k * P j * P k = (P j * P k)ᴴ * (P j * P k) := by
-    intro j
-    rw [Matrix.conjTranspose_mul, (hproj j).1.eq, (hproj k).1.eq]
-    calc P k * P j * P k = P k * (P j * P j) * P k := by rw [(hproj j).2]
-      _ = P k * P j * (P j * P k) := by simp only [Matrix.mul_assoc]
-  have htr_sum : ∑ j ∈ Finset.univ.erase k, ((P j * P k)ᴴ * (P j * P k)).trace = 0 := by
-    rw [← Matrix.trace_sum, ← Finset.sum_congr rfl fun j _ => hexp j, hzero,
-      Matrix.trace_zero]
-  have htr : ((P l * P k)ᴴ * (P l * P k)).trace = 0 :=
-    (Finset.sum_eq_zero_iff_of_nonneg fun j _ =>
-      (Matrix.posSemidef_conjTranspose_mul_self (P j * P k)).trace_nonneg).mp
-      htr_sum l (Finset.mem_erase.mpr ⟨Ne.symm hkl, Finset.mem_univ l⟩)
-  exact Matrix.trace_conjTranspose_mul_self_eq_zero_iff.mp htr
+  exact Matrix.eq_zero_of_sum_mul_conjTranspose_eq_zero T hsum
 
 variable [NeZero m]
 
 /-- **Letter-level cyclic shift** (Wolf Theorem 6.6).  For a cyclic family of
 orthogonal projections summing to the identity and permuted by the transfer
-map, `E(P (k+1)) = P k`, each Kraus operator intertwines consecutive
-projections: `K v * P (k + 1) = P k * K v`. -/
+map, $\mathcal E(P_{k+1})=P_k$, each Kraus operator intertwines consecutive
+projections: $K_vP_{k+1}=P_kK_v$.
+
+For the adjoint orientation under a unitality hypothesis instead of the
+resolution of the identity, see `offDiag_shift_of_adjoint_cyclic_shift` in
+`TNLean/MPS/CanonicalForm/CyclicSectors/FixedAdjoint.lean`; the two
+hypothesis sets are incomparable (see the module docstring). -/
 theorem kraus_mul_cyclicProj
     (K : Fin r → MatrixAlg n) (P : Fin m → MatrixAlg n)
     (hproj : ∀ k, IsOrthogonalProjection (P k))
@@ -177,9 +140,10 @@ theorem kraus_mul_cyclicProj
     (fun h => absurd (Finset.mem_univ k) h)]
   exact hinto k
 
-/-- **Word-level cyclic shift**: a word of length `ℓ` moves each cyclic
-projection back by `ℓ` steps, `evalWord K w * P k = P (k - ℓ) * evalWord K w`.
-In particular a word of length `m` commutes with every cyclic projection. -/
+/-- **Word-level cyclic shift**: a word $A^w=K_{w_1}\cdots K_{w_\ell}$ of
+length $\ell$ moves each cyclic projection back by $\ell$ steps,
+$A^wP_k=P_{k-\ell}A^w$.  In particular a word of length $m$ commutes with
+every cyclic projection. -/
 theorem evalWord_mul_cyclicProj
     (K : Fin r → MatrixAlg n) (P : Fin m → MatrixAlg n)
     (hproj : ∀ k, IsOrthogonalProjection (P k))

--- a/TNLean/Channel/Peripheral/CyclicDecomposition/LetterShift.lean
+++ b/TNLean/Channel/Peripheral/CyclicDecomposition/LetterShift.lean
@@ -1,0 +1,257 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Channel.Peripheral.CyclicDecomposition.Basic
+
+/-!
+# Cyclic shift of the Kraus operators across the cyclic projections
+
+For an irreducible map with nontrivial peripheral spectrum, Wolf Theorem 6.6
+produces orthogonal projections $P_0,\dots,P_{m-1}$ summing to the identity
+and permuted by the map, $\mathcal E(P_{k+1}) = P_k$.  This file derives the
+letter-level consequence: each Kraus operator of $\mathcal E$ intertwines
+consecutive projections, $K_v P_{k+1} = P_k K_v$, so a word of length $\ell$
+shifts every projection by $\ell$ steps and a word of length $m$ commutes
+with each projection.
+
+## Main statements
+
+* `one_sub_mul_kraus_mul_eq_zero_of_transferMap_proj` — each Kraus operator
+  maps the range of `P'` into the range of `P` when the map sends `P'` to `P`.
+* `orthogonalProjection_mul_eq_zero_of_sum_eq_one` — orthogonal projections
+  summing to the identity are mutually orthogonal.
+* `kraus_mul_cyclicProj` — the letter-level cyclic shift
+  `K v * P (k + 1) = P k * K v`.
+* `evalWord_mul_cyclicProj` — the word-level shift
+  `evalWord K w * P k = P (k - w.length) * evalWord K w`.
+* `cyclicProj_ne_zero` — no cyclic projection vanishes.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Theorem 6.6]
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder BigOperators Fin.NatCast
+open Matrix Finset Complex
+
+namespace MPSTensor
+
+variable {r n m : ℕ}
+
+/-- **Kraus operators respect a transfer-mapped projection pair.**  If the
+transfer map of the Kraus family `K` sends the orthogonal projection `P'` to
+the orthogonal projection `P`, then each Kraus operator maps the range of
+`P'` into the range of `P`: `(1 - P) * K v * P' = 0`.
+
+This is the letter-level step in the proof of Wolf Theorem 6.6: compressing
+$\sum_v K_v P' K_v^\dagger = P$ by $1-P$ exhibits a vanishing sum of positive
+semidefinite matrices, so each summand vanishes. -/
+theorem one_sub_mul_kraus_mul_eq_zero_of_transferMap_proj
+    (K : Fin r → MatrixAlg n) {P P' : MatrixAlg n}
+    (hP : IsOrthogonalProjection P) (hP' : IsOrthogonalProjection P')
+    (hmap : transferMap (d := r) (D := n) K P' = P) :
+    ∀ v, (1 - P) * K v * P' = 0 := by
+  classical
+  set T : Fin r → MatrixAlg n := fun w => (1 - P) * K w * P' with hT
+  have h1P : (1 - P)ᴴ = 1 - P := by
+    rw [Matrix.conjTranspose_sub, Matrix.conjTranspose_one, hP.1.eq]
+  -- Each `T w * (T w)ᴴ` is the `w`-th summand of `(1-P) E(P') (1-P)`.
+  have hexp : ∀ w, T w * (T w)ᴴ = (1 - P) * (K w * P' * (K w)ᴴ) * (1 - P) := by
+    intro w
+    calc T w * (T w)ᴴ
+        = (1 - P) * K w * (P' * P'ᴴ) * (K w)ᴴ * (1 - P)ᴴ := by
+          simp only [hT, Matrix.conjTranspose_mul, Matrix.mul_assoc]
+      _ = (1 - P) * (K w * P' * (K w)ᴴ) * (1 - P) := by
+          rw [hP'.1.eq, hP'.2, h1P]
+          simp only [Matrix.mul_assoc]
+  -- The sum of these PSD matrices is `(1-P) P (1-P) = 0`.
+  have hsum : ∑ w : Fin r, T w * (T w)ᴴ = 0 := by
+    have h1PP : (1 - P) * P = 0 := by
+      rw [Matrix.sub_mul, Matrix.one_mul, hP.2, sub_self]
+    calc ∑ w : Fin r, T w * (T w)ᴴ
+        = (1 - P) * (∑ w : Fin r, K w * P' * (K w)ᴴ) * (1 - P) := by
+          rw [Finset.mul_sum, Finset.sum_mul]
+          exact Finset.sum_congr rfl fun w _ => hexp w
+      _ = (1 - P) * P * (1 - P) := by
+          rw [show ∑ w : Fin r, K w * P' * (K w)ᴴ = P from by
+            simpa [transferMap_apply] using hmap]
+      _ = 0 := by rw [h1PP, Matrix.zero_mul]
+  -- Trace positivity extracts each summand.
+  intro v
+  have htr_sum : ∑ w : Fin r, (T w * (T w)ᴴ).trace = 0 := by
+    rw [← Matrix.trace_sum, hsum, Matrix.trace_zero]
+  have htr : (T v * (T v)ᴴ).trace = 0 :=
+    (Finset.sum_eq_zero_iff_of_nonneg fun w _ =>
+      (Matrix.posSemidef_self_mul_conjTranspose (T w)).trace_nonneg).mp
+      htr_sum v (Finset.mem_univ v)
+  exact Matrix.trace_mul_conjTranspose_self_eq_zero_iff.mp htr
+
+/-- **Orthogonal projections summing to the identity are mutually
+orthogonal**: `P k * P l = 0` for `k ≠ l`.  Compressing the resolution of the
+identity by `P k` exhibits a vanishing sum of positive semidefinite
+matrices. -/
+theorem orthogonalProjection_mul_eq_zero_of_sum_eq_one
+    (P : Fin m → MatrixAlg n)
+    (hproj : ∀ k, IsOrthogonalProjection (P k))
+    (hsum : ∑ k : Fin m, P k = 1) :
+    ∀ {k l : Fin m}, k ≠ l → P k * P l = 0 := by
+  classical
+  -- It suffices to prove `P l * P k = 0` for `l ≠ k` and take adjoints.
+  suffices h : ∀ k l : Fin m, k ≠ l → P l * P k = 0 by
+    intro k l hkl
+    have := congrArg Matrix.conjTranspose (h k l hkl)
+    simpa [Matrix.conjTranspose_mul, (hproj k).1.eq, (hproj l).1.eq] using this
+  intro k l hkl
+  -- `∑ j ≠ k, P k P j P k = P k - P k = 0`, a vanishing sum of PSD matrices.
+  have hzero : ∑ j ∈ Finset.univ.erase k, P k * P j * P k = 0 := by
+    have hfull : ∑ j : Fin m, P k * P j * P k = P k := by
+      calc ∑ j : Fin m, P k * P j * P k
+          = P k * (∑ j : Fin m, P j) * P k := by
+            rw [Finset.mul_sum, Finset.sum_mul]
+        _ = P k := by rw [hsum, Matrix.mul_one, (hproj k).2]
+    have hsplit := Finset.add_sum_erase Finset.univ
+      (fun j => P k * P j * P k) (Finset.mem_univ k)
+    rw [hfull] at hsplit
+    have hkk : P k * P k * P k = P k := by rw [(hproj k).2, (hproj k).2]
+    rw [hkk] at hsplit
+    have hsplit' : P k + ∑ j ∈ Finset.univ.erase k, P k * P j * P k = P k + 0 := by
+      rw [add_zero]; exact hsplit
+    exact add_left_cancel hsplit'
+  -- Each summand is `(P j P k)ᴴ (P j P k)`, hence PSD with nonnegative trace.
+  have hexp : ∀ j, P k * P j * P k = (P j * P k)ᴴ * (P j * P k) := by
+    intro j
+    rw [Matrix.conjTranspose_mul, (hproj j).1.eq, (hproj k).1.eq]
+    calc P k * P j * P k = P k * (P j * P j) * P k := by rw [(hproj j).2]
+      _ = P k * P j * (P j * P k) := by simp only [Matrix.mul_assoc]
+  have htr_sum : ∑ j ∈ Finset.univ.erase k, ((P j * P k)ᴴ * (P j * P k)).trace = 0 := by
+    rw [← Matrix.trace_sum, ← Finset.sum_congr rfl fun j _ => hexp j, hzero,
+      Matrix.trace_zero]
+  have htr : ((P l * P k)ᴴ * (P l * P k)).trace = 0 :=
+    (Finset.sum_eq_zero_iff_of_nonneg fun j _ =>
+      (Matrix.posSemidef_conjTranspose_mul_self (P j * P k)).trace_nonneg).mp
+      htr_sum l (Finset.mem_erase.mpr ⟨Ne.symm hkl, Finset.mem_univ l⟩)
+  exact Matrix.trace_conjTranspose_mul_self_eq_zero_iff.mp htr
+
+variable [NeZero m]
+
+/-- **Letter-level cyclic shift** (Wolf Theorem 6.6).  For a cyclic family of
+orthogonal projections summing to the identity and permuted by the transfer
+map, `E(P (k+1)) = P k`, each Kraus operator intertwines consecutive
+projections: `K v * P (k + 1) = P k * K v`. -/
+theorem kraus_mul_cyclicProj
+    (K : Fin r → MatrixAlg n) (P : Fin m → MatrixAlg n)
+    (hproj : ∀ k, IsOrthogonalProjection (P k))
+    (hsum : ∑ k : Fin m, P k = 1)
+    (hcyclic : ∀ k : Fin m, transferMap (d := r) (D := n) K (P (k + 1)) = P k) :
+    ∀ (v : Fin r) (k : Fin m), K v * P (k + 1) = P k * K v := by
+  intro v k
+  -- One-sided containment for every consecutive pair.
+  have hinto : ∀ j : Fin m, K v * P (j + 1) = P j * (K v * P (j + 1)) := by
+    intro j
+    have h := one_sub_mul_kraus_mul_eq_zero_of_transferMap_proj K
+      (hproj j) (hproj (j + 1)) (hcyclic j) v
+    have h' : K v * P (j + 1) - P j * (K v * P (j + 1)) = 0 := by
+      calc K v * P (j + 1) - P j * (K v * P (j + 1))
+          = (1 - P j) * K v * P (j + 1) := by
+            rw [Matrix.sub_mul, Matrix.sub_mul, Matrix.one_mul, Matrix.mul_assoc]
+        _ = 0 := h
+    exact sub_eq_zero.mp h'
+  -- Off-diagonal compressions vanish: `P j * K v * P (l+1) = 0` for `j ≠ l`.
+  have hoff : ∀ j l : Fin m, j ≠ l → P j * (K v * P (l + 1)) = 0 := by
+    intro j l hjl
+    rw [hinto l, ← Matrix.mul_assoc,
+      orthogonalProjection_mul_eq_zero_of_sum_eq_one P hproj hsum hjl,
+      Matrix.zero_mul]
+  -- Expand `P k * K v` through the resolution of the identity.
+  have hone : (∑ l : Fin m, P (l + 1)) = 1 := by
+    rw [← hsum]
+    exact Fintype.sum_equiv (Equiv.addRight (1 : Fin m)) _ _ fun l => rfl
+  have hexpand : P k * K v = ∑ l : Fin m, P k * (K v * P (l + 1)) := by
+    calc P k * K v
+        = (P k * K v) * (∑ l : Fin m, P (l + 1)) := by rw [hone, Matrix.mul_one]
+      _ = ∑ l : Fin m, P k * (K v * P (l + 1)) := by
+          rw [Finset.mul_sum]
+          exact Finset.sum_congr rfl fun l _ => by rw [Matrix.mul_assoc]
+  rw [hexpand, Finset.sum_eq_single k (fun l _ hlk => hoff k l (Ne.symm hlk))
+    (fun h => absurd (Finset.mem_univ k) h)]
+  exact hinto k
+
+/-- **Word-level cyclic shift**: a word of length `ℓ` moves each cyclic
+projection back by `ℓ` steps, `evalWord K w * P k = P (k - ℓ) * evalWord K w`.
+In particular a word of length `m` commutes with every cyclic projection. -/
+theorem evalWord_mul_cyclicProj
+    (K : Fin r → MatrixAlg n) (P : Fin m → MatrixAlg n)
+    (hproj : ∀ k, IsOrthogonalProjection (P k))
+    (hsum : ∑ k : Fin m, P k = 1)
+    (hcyclic : ∀ k : Fin m, transferMap (d := r) (D := n) K (P (k + 1)) = P k) :
+    ∀ (w : List (Fin r)) (k : Fin m),
+      evalWord K w * P k = P (k - (w.length : Fin m)) * evalWord K w := by
+  intro w
+  induction w with
+  | nil =>
+    intro k
+    simp
+  | cons v w ih =>
+    intro k
+    have hstep : K v * P (k - (w.length : Fin m)) =
+        P (k - (w.length : Fin m) - 1) * K v := by
+      have := kraus_mul_cyclicProj K P hproj hsum hcyclic v (k - (w.length : Fin m) - 1)
+      rwa [sub_add_cancel] at this
+    calc evalWord K (v :: w) * P k
+        = K v * (evalWord K w * P k) := by rw [evalWord_cons, Matrix.mul_assoc]
+      _ = K v * (P (k - (w.length : Fin m)) * evalWord K w) := by rw [ih k]
+      _ = (K v * P (k - (w.length : Fin m))) * evalWord K w := by
+          rw [Matrix.mul_assoc]
+      _ = P (k - (w.length : Fin m) - 1) * (K v * evalWord K w) := by
+          rw [hstep, Matrix.mul_assoc]
+      _ = P (k - ((v :: w).length : Fin m)) * evalWord K (v :: w) := by
+          rw [evalWord_cons]
+          congr 2
+          rw [List.length_cons, Nat.cast_add, Nat.cast_one, sub_sub]
+
+/-- **No cyclic projection vanishes.**  If one projection of a cyclic family
+summing to the identity vanished, the cyclic action `E(P (k+1)) = P k` would
+propagate the vanishing to every projection, contradicting the resolution of
+the identity. -/
+theorem cyclicProj_ne_zero [NeZero n]
+    (K : Fin r → MatrixAlg n) (P : Fin m → MatrixAlg n)
+    (hsum : ∑ k : Fin m, P k = 1)
+    (hcyclic : ∀ k : Fin m, transferMap (d := r) (D := n) K (P (k + 1)) = P k) :
+    ∀ k : Fin m, P k ≠ 0 := by
+  by_contra! h
+  obtain ⟨k₀, hk₀⟩ := h
+  -- Vanishing propagates backwards through the cyclic action.
+  have hback : ∀ j : Fin m, P (j + 1) = 0 → P j = 0 := fun j hj => by
+    rw [← hcyclic j, hj, map_zero]
+  -- Every projection vanishes: induct on the backward distance to `k₀`.
+  have hall : ∀ j : Fin m, P j = 0 := by
+    suffices hs : ∀ N : ℕ, N < m → ∀ j : Fin m, (k₀ - j).val = N → P j = 0 by
+      intro j
+      exact hs _ (k₀ - j).isLt j rfl
+    intro N
+    induction N with
+    | zero =>
+      intro _ j hj
+      have hj0 : k₀ - j = 0 := by
+        ext
+        simpa using hj
+      have : k₀ = j := by
+        have := sub_eq_zero.mp hj0
+        exact this
+      subst this
+      exact hk₀
+    | succ N ih =>
+      intro hN j hj
+      apply hback j
+      apply ih (by omega) (j + 1)
+      have h_eq : k₀ - (j + 1) = (k₀ - j) - 1 := by abel
+      rw [h_eq, Fin.val_sub_one_of_ne_zero (by intro h0; simp [h0] at hj)]
+      omega
+  have hzero : (1 : MatrixAlg n) = 0 := by
+    rw [← hsum]
+    exact Finset.sum_eq_zero fun k _ => hall k
+  exact one_ne_zero (α := ℂ) (by
+    simpa using congrFun (congrFun hzero ⟨0, NeZero.pos n⟩) ⟨0, NeZero.pos n⟩)
+
+end MPSTensor

--- a/TNLean/MPS/CanonicalForm/CyclicSectors/FixedAdjoint.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors/FixedAdjoint.lean
@@ -192,7 +192,13 @@ If the orthogonal projections `P` are shifted by the adjoint transfer map,
 `𝓔^*(P_{k+1}) = P_k`, then each Kraus operator carries index `k` to `k+1`:
 `P_{k+1} · A_i = A_i · P_k`.  This is the single-site analogue of the
 fixed-projection commutation `commutes_letters_of_adjoint_fixed_projection`;
-see arXiv:1708.00029, eq:Aoffdiag, in inverse-indexed form. -/
+see arXiv:1708.00029, eq:Aoffdiag, in inverse-indexed form.
+
+The companion statement `kraus_mul_cyclicProj` in
+`TNLean/Channel/Peripheral/CyclicDecomposition/LetterShift.lean` derives the
+same shift for the direct orientation from the resolution of the identity
+$\sum_kP_k=1$ instead of the unitality used here; the two hypothesis sets
+are incomparable, so the two statements coexist. -/
 theorem offDiag_shift_of_adjoint_cyclic_shift [NeZero m]
     (A : MPSTensor d D)
     (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1)

--- a/TNLean/MPS/Irreducible/FixedPointProjection.lean
+++ b/TNLean/MPS/Irreducible/FixedPointProjection.lean
@@ -227,6 +227,107 @@ theorem supportProj_mulVec_eq_zero_of_mulVec_eq_zero
 
 end SupportProjLemmas
 
+/-! ## Range factorization of the support projection
+
+The support projection of a positive semidefinite matrix has the same range
+as the matrix itself.  At the matrix level this is witnessed by a spectral
+pseudo-inverse factor `W` with `supportProj ρ = ρ * W`; combined with
+`supportProj_mul` it lets invariance statements about the range of `ρ` pass
+to the support projection.  These lemmas serve the invariant-subspace steps
+of the canonical-form analysis, where the invariant subspace arrives as the
+range of a rectangular matrix `Y` and the corresponding orthogonal projector
+is the support projection of `Y * Yᴴ`. -/
+
+section SupportProjRange
+
+variable {D : ℕ}
+
+/-- The support projection factors through its matrix: `supportProj ρ = ρ * W`
+for an explicit spectral pseudo-inverse `W`.  This witnesses the range
+inclusion of the support projection in the range of `ρ` at the matrix
+level. -/
+lemma exists_supportProj_eq_mul (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosSemidef) :
+    ∃ W : Matrix (Fin D) (Fin D) ℂ, supportProj (D := D) ρ hρ = ρ * W := by
+  classical
+  let hH : ρ.IsHermitian := hρ.isHermitian
+  set U : Matrix (Fin D) (Fin D) ℂ := ↑hH.eigenvectorUnitary
+  set sgn : Fin D → ℂ := fun i => if 0 < hH.eigenvalues i then 1 else 0
+  set pinv : Fin D → ℂ :=
+    fun i => if 0 < hH.eigenvalues i then (↑(hH.eigenvalues i) : ℂ)⁻¹ else 0
+  refine ⟨U * Matrix.diagonal pinv * Uᴴ, ?_⟩
+  have hUU : Uᴴ * U = 1 := by
+    rw [← Matrix.star_eq_conjTranspose]
+    simp [U]
+  have hρ_spec : ρ = U * Matrix.diagonal (fun j => (↑(hH.eigenvalues j) : ℂ)) * Uᴴ := by
+    simpa [U, Unitary.conjStarAlgAut_apply, Matrix.star_eq_conjTranspose,
+      Function.comp_def] using hH.spectral_theorem
+  have hmul : (fun i => (↑(hH.eigenvalues i) : ℂ) * pinv i) = sgn := by
+    ext i
+    by_cases hi : 0 < hH.eigenvalues i
+    · have hne : (↑(hH.eigenvalues i) : ℂ) ≠ 0 := by
+        exact_mod_cast ne_of_gt hi
+      simp [pinv, sgn, hi, mul_inv_cancel₀ hne]
+    · simp [pinv, sgn, hi]
+  have hP_def : supportProj (D := D) ρ hρ = U * Matrix.diagonal sgn * Uᴴ := by
+    simp [supportProj, U, sgn]
+  have hglue : ∀ A B : Matrix (Fin D) (Fin D) ℂ,
+      (U * A * Uᴴ) * (U * B * Uᴴ) = U * (A * B) * Uᴴ := by
+    intro A B
+    calc (U * A * Uᴴ) * (U * B * Uᴴ)
+        = U * (A * ((Uᴴ * U) * (B * Uᴴ))) := by simp only [Matrix.mul_assoc]
+      _ = U * (A * (B * Uᴴ)) := by rw [hUU, Matrix.one_mul]
+      _ = U * (A * B) * Uᴴ := by simp only [Matrix.mul_assoc]
+  rw [hP_def]
+  conv_rhs => rw [hρ_spec]
+  rw [hglue, Matrix.diagonal_mul_diagonal, hmul]
+
+/-- The support projection of `Y * Yᴴ` fixes `Y`. -/
+lemma supportProj_mul_left_eq_self {k : ℕ} (Y : Matrix (Fin D) (Fin k) ℂ) :
+    supportProj (D := D) (Y * Yᴴ) (Matrix.posSemidef_self_mul_conjTranspose Y) * Y = Y := by
+  set π := supportProj (D := D) (Y * Yᴴ) (Matrix.posSemidef_self_mul_conjTranspose Y) with hπ
+  have hπS : π * (Y * Yᴴ) = Y * Yᴴ :=
+    supportProj_mul (D := D) (ρ := Y * Yᴴ) (Matrix.posSemidef_self_mul_conjTranspose Y)
+  have hπherm : (1 - π)ᴴ = 1 - π := by
+    have hH : πᴴ = π :=
+      (isOrthogonalProjection_supportProj (D := D) (ρ := Y * Yᴴ)
+        (hρ := Matrix.posSemidef_self_mul_conjTranspose Y)).1.eq
+    rw [Matrix.conjTranspose_sub, Matrix.conjTranspose_one, hH]
+  have hzero : ((1 - π) * Y) * ((1 - π) * Y)ᴴ = 0 := by
+    calc ((1 - π) * Y) * ((1 - π) * Y)ᴴ
+        = (1 - π) * (Y * Yᴴ) * (1 - π)ᴴ := by
+          rw [Matrix.conjTranspose_mul]
+          simp only [Matrix.mul_assoc]
+      _ = ((Y * Yᴴ) - π * (Y * Yᴴ)) * (1 - π) := by
+          rw [hπherm, Matrix.sub_mul, Matrix.one_mul]
+      _ = 0 := by rw [hπS, sub_self, Matrix.zero_mul]
+  have h0 : (1 - π) * Y = 0 := Matrix.self_mul_conjTranspose_eq_zero.mp hzero
+  have h0' : Y - π * Y = 0 := by
+    rw [Matrix.sub_mul, Matrix.one_mul] at h0
+    exact h0
+  exact (sub_eq_zero.mp h0').symm
+
+/-- **Invariance transfer to the support projection.**  If a matrix `A` maps
+the range of `Y` into itself through a right factor, `A * Y = Y * G`, then
+the support projection `π` of `Y * Yᴴ` — the orthogonal projector onto the
+range of `Y` — satisfies the one-sided invariance `(1 - π) * A * π = 0`. -/
+lemma one_sub_supportProj_mul_mul_supportProj_eq_zero {k : ℕ}
+    (Y : Matrix (Fin D) (Fin k) ℂ) {A : Matrix (Fin D) (Fin D) ℂ}
+    {G : Matrix (Fin k) (Fin k) ℂ} (hAY : A * Y = Y * G) :
+    (1 - supportProj (D := D) (Y * Yᴴ) (Matrix.posSemidef_self_mul_conjTranspose Y)) * A *
+      supportProj (D := D) (Y * Yᴴ) (Matrix.posSemidef_self_mul_conjTranspose Y) = 0 := by
+  obtain ⟨W, hW⟩ :=
+    exists_supportProj_eq_mul (D := D) (Y * Yᴴ) (Matrix.posSemidef_self_mul_conjTranspose Y)
+  set π := supportProj (D := D) (Y * Yᴴ) (Matrix.posSemidef_self_mul_conjTranspose Y) with hπ
+  have hY : (1 - π) * Y = 0 := by
+    rw [Matrix.sub_mul, Matrix.one_mul, supportProj_mul_left_eq_self (D := D) Y, sub_self]
+  calc (1 - π) * A * π
+      = (1 - π) * A * (Y * Yᴴ * W) := by rw [← hW]
+    _ = (1 - π) * (A * Y) * (Yᴴ * W) := by simp only [Matrix.mul_assoc]
+    _ = ((1 - π) * Y) * (G * (Yᴴ * W)) := by rw [hAY]; simp only [Matrix.mul_assoc]
+    _ = 0 := by rw [hY, Matrix.zero_mul]
+
+end SupportProjRange
+
 
 /-! ## Fixed point ⇒ invariant support projection -/
 

--- a/TNLean/MPS/MPDO/CyclicProjector.lean
+++ b/TNLean/MPS/MPDO/CyclicProjector.lean
@@ -1,0 +1,674 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.MPDO.StackedLayers
+import TNLean.Channel.Peripheral.CyclicDecomposition.Decomposition
+import TNLean.Channel.Peripheral.CyclicDecomposition.LetterShift
+import TNLean.Channel.Peripheral.GroupStructure
+import TNLean.MPS.Core.TPGauge
+import TNLean.MPS.Core.CPPrimitive
+import TNLean.MPS.Irreducible.FixedPointProjection
+import TNLean.MPS.Irreducible.Adjoint
+import TNLean.MPS.Irreducible.FormII
+import TNLean.Channel.FixedPoint.Cesaro
+import TNLean.QPF.PosDef
+
+/-!
+# The cyclic projector of a nontrivial periodic vector
+
+This file constructs, from a nontrivial $p$-periodic vector of the vertically
+viewed tensor of a matrix product operator, the orthogonal projector demanded
+by the periodic-sector step in the proof of Proposition 4.13 of
+arXiv:1606.00608, lines 1888--1893.  A nontrivial $p$-periodic vector is an
+eigenvector of the transfer map of an irreducible corner of the vertically
+viewed tensor with peripheral eigenvalue $e^{2\pi iq/p}\ne 1$
+(arXiv:1606.00608, lines 225--230).  The cyclic decomposition of the
+peripheral spectrum (Wolf 2012, Theorem 6.6, formalized in
+`TNLean/Channel/Peripheral/CyclicDecomposition`) attaches to it a cyclic
+family of orthogonal projections permuted by one application of the transfer
+map; the projector $Q$ is the complement of the orthogonal projection onto
+the subspace carried by one cyclic sector.
+
+Two of the three properties demanded of $Q$ by the cyclic-projector
+hypothesis `PeriodicVectorYieldsCyclicProjector` are proved here
+unconditionally:
+
+* the **word invariance**: $Q$ is one-sided invariant for every full-period
+  word of the vertically viewed tensor, because a full cyclic period returns
+  each sector to itself; and
+* the **single-letter displacement**: $Q\widetilde M\ne Q\widetilde MQ$,
+  because one vertical layer moves each cyclic sector to the next one, and
+  distinct sectors are orthogonal.
+
+The remaining property — the failure of $Q$ to commute with the density
+operator $H^{(N)}$ at every length (arXiv:1606.00608, line 1889) — is where
+the horizontal canonical form enters the source proof: for a tensor in
+canonical form the argument of lines 1874--1887 turns all-length commutation
+into letter-level invariance, which the displacement forbids.  That
+implication is recorded here as the hypothesis
+`NoninvariantProjectorNoncommuting`; granted it, the cyclic-projector
+hypothesis follows (`periodicVectorYieldsCyclicProjector_of_noncommutation`).
+The residual gap is documented in
+`docs/paper-gaps/cpgsv17_periodic_sector_projector.tex`.
+
+## Main results
+
+* `MPSTensor.isIrreducibleTensor_smul_conj`: tensor irreducibility is
+  preserved by rescaled conjugation with an invertible matrix.
+* `MPSTensor.spectralUnitalGauge_schwarz_setup`: the rescaled unital gauge of
+  an irreducible corner satisfies the hypotheses of Wolf Theorem 6.6.
+* `MPOTensor.exists_displaced_invariant_projector_of_periodic_vector`: a
+  nontrivial periodic vector of the vertically viewed tensor supplies an
+  orthogonal projector, invariant for every full-period word and displaced by
+  the single letters.
+* `MPOTensor.NoninvariantProjectorNoncommuting`: the hypothesis that a
+  displaced projector never commutes with the density operator.
+* `MPOTensor.periodicVectorYieldsCyclicProjector_of_noncommutation`: the
+  hypothesis implies `PeriodicVectorYieldsCyclicProjector`.
+* `MPOTensor.hasNoPeriodicVectors_verticalTensor_of_noncommutation`: granted
+  the hypothesis, a matrix product density operator has no nontrivial
+  periodic vectors in the vertical direction.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Proposition 4.13, lines 1888--1893; lines 225--230 for periodic vectors
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Theorem 6.6]
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder BigOperators Fin.NatCast
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-! ### Irreducibility under rescaled conjugation
+
+The unital normalization of an irreducible corner conjugates the letters by
+the square root of the positive transfer eigenvector.  Conjugation by an
+invertible matrix does not preserve orthogonality, so an invariant orthogonal
+projection of the conjugated tensor corresponds to an invariant *subspace* of
+the original tensor; the support projection of the transported subspace
+recovers an invariant orthogonal projection. -/
+
+/-- **Rescaled conjugation preserves tensor irreducibility.**  If `B` admits
+no nontrivial invariant orthogonal projection, neither does
+`c • (X⁻¹ * B v * X)` for an invertible `X` and a nonzero scalar `c`: an
+invariant orthogonal projection `P` of the conjugated tensor transports to
+the invariant subspace of `B` spanned by the columns of `X * P`, whose
+support projection is a nontrivial invariant orthogonal projection of `B`.
+
+This is the normalization step of arXiv:1606.00608, lines 224--225, for the
+corner tensors: the rescaled unital gauge of an irreducible corner is again
+irreducible. -/
+theorem isIrreducibleTensor_smul_conj (B : MPSTensor d D)
+    (hIrr : IsIrreducibleTensor B) {X : Matrix (Fin D) (Fin D) ℂ} (hX : IsUnit X)
+    {c : ℂ} (hc : c ≠ 0) :
+    IsIrreducibleTensor (fun v => c • (X⁻¹ * B v * X)) := by
+  classical
+  intro hHas
+  apply hIrr
+  obtain ⟨P, hPproj, hP0, hP1, hPinv⟩ := hHas
+  have hXdet : IsUnit X.det := (Matrix.isUnit_iff_isUnit_det X).mp hX
+  have hXHdet : IsUnit Xᴴ.det := by
+    rw [Matrix.det_conjTranspose]
+    exact hXdet.star
+  set Y : Matrix (Fin D) (Fin D) ℂ := X * P with hY
+  set π : Matrix (Fin D) (Fin D) ℂ :=
+    supportProj (D := D) (Y * Yᴴ) (Matrix.posSemidef_self_mul_conjTranspose Y) with hπ
+  refine ⟨π, isOrthogonalProjection_supportProj (D := D) (ρ := Y * Yᴴ)
+    (hρ := Matrix.posSemidef_self_mul_conjTranspose Y), ?_, ?_, ?_⟩
+  · -- `π ≠ 0` because `Y ≠ 0`.
+    have hYne : Y ≠ 0 := by
+      intro h0
+      apply hP0
+      calc P = X⁻¹ * (X * P) := (Matrix.nonsing_inv_mul_cancel_left X P hXdet).symm
+        _ = 0 := by rw [← hY, h0, Matrix.mul_zero]
+    have hSne : Y * Yᴴ ≠ 0 := fun h0 =>
+      hYne (Matrix.self_mul_conjTranspose_eq_zero.mp h0)
+    exact supportProj_ne_zero_of_ne_zero (Y * Yᴴ)
+      (Matrix.posSemidef_self_mul_conjTranspose Y) hSne
+  · -- `π ≠ 1`: a nonzero vector in the kernel of `P` transports to the
+    -- kernel of `Y * Yᴴ`, hence of `π`.
+    have h1Pne : (1 : Matrix (Fin D) (Fin D) ℂ) - P ≠ 0 := by
+      intro h0
+      exact hP1 (by rw [sub_eq_zero] at h0; exact h0.symm)
+    obtain ⟨i, j, hij⟩ : ∃ i j, ((1 : Matrix (Fin D) (Fin D) ℂ) - P) i j ≠ 0 := by
+      by_contra hall
+      push Not at hall
+      exact h1Pne (Matrix.ext fun i j => hall i j)
+    set w : Fin D → ℂ := ((1 : Matrix (Fin D) (Fin D) ℂ) - P) *ᵥ Pi.single j 1 with hw
+    have hwne : w ≠ 0 := by
+      intro h0
+      apply hij
+      have := congrFun h0 i
+      simpa [hw, Matrix.mulVec, dotProduct, Pi.single_apply] using this
+    have hP1P : P * ((1 : Matrix (Fin D) (Fin D) ℂ) - P) = 0 := by
+      rw [Matrix.mul_sub, Matrix.mul_one, hPproj.2, sub_self]
+    have hPw : P *ᵥ w = 0 := by
+      rw [hw, Matrix.mulVec_mulVec, hP1P, Matrix.zero_mulVec]
+    set v : Fin D → ℂ := (Xᴴ)⁻¹ *ᵥ w with hv
+    have hXHv : Xᴴ *ᵥ v = w := by
+      rw [hv, Matrix.mulVec_mulVec, Matrix.mul_nonsing_inv Xᴴ hXHdet,
+        Matrix.one_mulVec]
+    have hvne : v ≠ 0 := by
+      intro h0
+      apply hwne
+      rw [← hXHv, h0, Matrix.mulVec_zero]
+    have hYY : Y * Yᴴ = X * (P * Xᴴ) := by
+      rw [hY, Matrix.conjTranspose_mul, hPproj.1.eq]
+      calc X * P * (P * Xᴴ) = X * (P * P * Xᴴ) := by simp only [Matrix.mul_assoc]
+        _ = X * (P * Xᴴ) := by rw [hPproj.2]
+    have hSv : (Y * Yᴴ) *ᵥ v = 0 := by
+      rw [hYY, ← Matrix.mulVec_mulVec, ← Matrix.mulVec_mulVec, hXHv, hPw,
+        Matrix.mulVec_zero]
+    have hπv : π *ᵥ v = 0 :=
+      supportProj_mulVec_eq_zero_of_mulVec_eq_zero (Y * Yᴴ)
+        (Matrix.posSemidef_self_mul_conjTranspose Y) v hSv
+    intro h1
+    apply hvne
+    rw [← Matrix.one_mulVec v, ← h1, hπv]
+  · -- Invariance: `(1 - π) * B v * π = 0` for every letter.
+    intro u
+    have h' : ((1 : Matrix (Fin D) (Fin D) ℂ) - P) * (X⁻¹ * B u * X) * P = 0 := by
+      have hs : c • (((1 : Matrix (Fin D) (Fin D) ℂ) - P) * (X⁻¹ * B u * X) * P) = 0 := by
+        have := hPinv u
+        calc c • (((1 : Matrix (Fin D) (Fin D) ℂ) - P) * (X⁻¹ * B u * X) * P)
+            = (1 - P) * (c • (X⁻¹ * B u * X)) * P := by
+              rw [Matrix.mul_smul, Matrix.smul_mul]
+          _ = 0 := this
+      exact (smul_eq_zero.mp hs).resolve_left hc
+    have hinv' : X⁻¹ * B u * X * P = P * (X⁻¹ * B u * X * P) := by
+      have h'' : X⁻¹ * B u * X * P - P * (X⁻¹ * B u * X * P) = 0 := by
+        have := h'
+        rw [Matrix.sub_mul, Matrix.sub_mul, Matrix.one_mul] at this
+        rw [← this]
+        simp only [Matrix.mul_assoc]
+      exact sub_eq_zero.mp h''
+    have hGB : B u * Y = Y * (X⁻¹ * B u * X * P) := by
+      calc B u * Y = B u * X * P := by rw [hY, Matrix.mul_assoc]
+        _ = X * (X⁻¹ * (B u * X * P)) :=
+            (Matrix.mul_nonsing_inv_cancel_left X _ hXdet).symm
+        _ = X * (X⁻¹ * B u * X * P) := by simp only [Matrix.mul_assoc]
+        _ = X * (P * (X⁻¹ * B u * X * P)) := by rw [← hinv']
+        _ = Y * (X⁻¹ * B u * X * P) := by rw [hY]; simp only [Matrix.mul_assoc]
+    exact one_sub_supportProj_mul_mul_supportProj_eq_zero Y hGB
+
+/-! ### The unital gauge of a corner satisfies the Wolf Theorem 6.6 hypotheses -/
+
+/-- **Unital Schwarz data for an irreducible corner.**  The rescaled unital
+gauge `K = spectralUnitalGauge B r ρ` of an irreducible tensor `B` with a
+positive definite transfer eigenvector `ρ` of positive eigenvalue `r`
+(arXiv:1606.00608, lines 220--225: each corner map is rescaled to spectral
+radius one) is a unital Kraus family, is again an irreducible tensor with an
+irreducible transfer map, and its adjoint map has a positive definite fixed
+point.  These are the hypotheses of the cyclic decomposition of the
+peripheral spectrum, Wolf 2012, Theorem 6.6. -/
+theorem spectralUnitalGauge_schwarz_setup [NeZero D]
+    (B : MPSTensor d D) (hIrr : IsIrreducibleTensor B)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (rad : ℝ) (hρ : ρ.PosDef) (hrad : 0 < rad)
+    (hfix : transferMap (d := d) (D := D) B ρ = (rad : ℂ) • ρ) :
+    KadisonSchwarz.IsUnitalKraus (d := d) (D := D) (spectralUnitalGauge B rad ρ) ∧
+    IsIrreducibleTensor (spectralUnitalGauge B rad ρ) ∧
+    IsIrreducibleMap (transferMap (d := d) (D := D) (spectralUnitalGauge B rad ρ)) ∧
+    ∃ σ : Matrix (Fin D) (Fin D) ℂ, σ.PosDef ∧
+      Kraus.adjointMap (spectralUnitalGauge B rad ρ) σ = σ := by
+  classical
+  have hUnital : KadisonSchwarz.IsUnitalKraus (d := d) (D := D)
+      (spectralUnitalGauge B rad ρ) := by
+    simpa [KadisonSchwarz.IsUnitalKraus] using
+      spectralUnitalGauge_isUnital_of_transferMap_eigenvector B ρ rad hρ hrad hfix
+  have hcne : ((↑((Real.sqrt rad)⁻¹) : ℂ)) ≠ 0 := by
+    have hs : Real.sqrt rad ≠ 0 := ne_of_gt (Real.sqrt_pos.mpr hrad)
+    exact_mod_cast inv_ne_zero hs
+  have hSunit : IsUnit (CFC.sqrt ρ) :=
+    (Matrix.isUnit_iff_isUnit_det _).mpr (isUnit_det_cfc_sqrt_of_posDef ρ hρ)
+  have hIrrK : IsIrreducibleTensor (spectralUnitalGauge B rad ρ) := by
+    have h := isIrreducibleTensor_smul_conj B hIrr hSunit hcne
+    exact h
+  have hIrrMap : IsIrreducibleMap (transferMap (d := d) (D := D)
+      (spectralUnitalGauge B rad ρ)) :=
+    isIrreducibleCP_transferMap_of_isIrreducibleTensor _ hIrrK
+  refine ⟨hUnital, hIrrK, hIrrMap, ?_⟩
+  -- The adjoint of a unital family is trace-preserving; its transfer map is a
+  -- channel and has a positive semidefinite fixed point, which irreducibility
+  -- upgrades to a positive definite one.
+  set K : MPSTensor d D := spectralUnitalGauge B rad ρ with hK
+  have hTPadj : ∑ v : Fin d, ((K v)ᴴ)ᴴ * (K v)ᴴ = 1 := by
+    simpa [Matrix.conjTranspose_conjTranspose] using hUnital
+  have hCh : IsChannel (transferMap (d := d) (D := D) (fun v => (K v)ᴴ)) :=
+    transferMap_isChannel (fun v => (K v)ᴴ) hTPadj
+  obtain ⟨σ, hσ_psd, hσ_ne, hσ_fix⟩ :=
+    hCh.exists_posSemidef_fixedPoint
+      (E := transferMap (d := d) (D := D) (fun v => (K v)ᴴ)) (NeZero.pos D)
+  have hIrrAdj : IsIrreducibleMap (transferMap (d := d) (D := D) (fun v => (K v)ᴴ)) :=
+    isIrreducibleCP_transferMap_conjTranspose_of_isIrreducibleTensor K hIrrK
+  have hσ_pd : σ.PosDef :=
+    posSemidef_fixedPoint_isPosDef_of_irreducible (fun v => (K v)ᴴ) hIrrAdj σ
+      hσ_psd hσ_ne hσ_fix
+  refine ⟨σ, hσ_pd, ?_⟩
+  simpa [Kraus.adjointMap, transferMap_apply, Matrix.conjTranspose_conjTranspose,
+    Matrix.mul_assoc] using hσ_fix
+
+/-- **Eigenvalue transport to the unital gauge.**  An eigenvalue `μ` of the
+transfer map of `B` becomes the eigenvalue `μ / r` of the transfer map of the
+rescaled unital gauge `spectralUnitalGauge B r ρ`: the gauge conjugates the
+transfer map by a congruence and divides it by `r`.  In particular the
+peripheral eigenvalues `exp(2πiq/p)` of arXiv:1606.00608, lines 225--230,
+arise from the transfer eigenvalues of modulus `r`. -/
+theorem hasEigenvalue_transferMap_spectralUnitalGauge
+    (B : MPSTensor d D) (ρ : Matrix (Fin D) (Fin D) ℂ) (rad : ℝ)
+    (hρ : ρ.PosDef) (hrad : 0 < rad) {μ : ℂ}
+    (hμ : Module.End.HasEigenvalue (transferMap (d := d) (D := D) B) μ) :
+    Module.End.HasEigenvalue
+      (transferMap (d := d) (D := D) (spectralUnitalGauge B rad ρ)) (μ / rad) := by
+  classical
+  obtain ⟨X, hX⟩ := hμ.exists_hasEigenvector
+  have hXeq : transferMap (d := d) (D := D) B X = μ • X :=
+    Module.End.mem_eigenspace_iff.mp (Module.End.hasEigenvector_iff.mp hX).1
+  have hXne : X ≠ 0 := (Module.End.hasEigenvector_iff.mp hX).2
+  set S : Matrix (Fin D) (Fin D) ℂ := CFC.sqrt ρ with hS
+  have hSdet : IsUnit S.det := isUnit_det_cfc_sqrt_of_posDef ρ hρ
+  have hSH : Sᴴ = S := conjTranspose_cfc_sqrt ρ
+  have hSinvH : (S⁻¹)ᴴ = S⁻¹ := by rw [Matrix.conjTranspose_nonsing_inv, hSH]
+  set c : ℂ := (↑((Real.sqrt rad)⁻¹) : ℂ) with hc
+  have hcstar : star c = c := by rw [hc, RCLike.star_def, Complex.conj_ofReal]
+  have hcc : c * c = (↑rad : ℂ)⁻¹ := by
+    rw [hc, ← Complex.ofReal_mul, ← sq, inv_pow, Real.sq_sqrt hrad.le,
+      Complex.ofReal_inv]
+  set X' : Matrix (Fin D) (Fin D) ℂ := S⁻¹ * X * S⁻¹ with hX'
+  have hX'ne : X' ≠ 0 := by
+    intro h0
+    apply hXne
+    calc X = S * (S⁻¹ * X) := (Matrix.mul_nonsing_inv_cancel_left S X hSdet).symm
+      _ = S * (S⁻¹ * (X * (S⁻¹ * S))) := by
+          rw [Matrix.nonsing_inv_mul S hSdet, Matrix.mul_one]
+      _ = S * (X' * S) := by rw [hX']; simp only [Matrix.mul_assoc]
+      _ = 0 := by rw [h0, Matrix.zero_mul, Matrix.mul_zero]
+  have hmap : transferMap (d := d) (D := D) (spectralUnitalGauge B rad ρ) X'
+      = (μ / ↑rad) • X' := by
+    have hterm : ∀ v : Fin d,
+        spectralUnitalGauge B rad ρ v * X' * (spectralUnitalGauge B rad ρ v)ᴴ
+          = (c * c) • (S⁻¹ * (B v * X * (B v)ᴴ) * S⁻¹) := by
+      intro v
+      have hKv : spectralUnitalGauge B rad ρ v = c • (S⁻¹ * B v * S) := rfl
+      have hKvH : (spectralUnitalGauge B rad ρ v)ᴴ = c • (S * (B v)ᴴ * S⁻¹) := by
+        rw [hKv, Matrix.conjTranspose_smul, hcstar, Matrix.conjTranspose_mul,
+          Matrix.conjTranspose_mul, hSH, hSinvH, Matrix.mul_assoc]
+      rw [hKvH, hKv, Matrix.smul_mul, Matrix.smul_mul, Matrix.mul_smul, smul_smul]
+      congr 1
+      rw [hX']
+      simp only [Matrix.mul_assoc, Matrix.mul_nonsing_inv_cancel_left _ _ hSdet,
+        Matrix.nonsing_inv_mul_cancel_left _ _ hSdet]
+    rw [transferMap_apply]
+    calc ∑ v : Fin d,
+          spectralUnitalGauge B rad ρ v * X' * (spectralUnitalGauge B rad ρ v)ᴴ
+        = ∑ v : Fin d, (c * c) • (S⁻¹ * (B v * X * (B v)ᴴ) * S⁻¹) :=
+          Finset.sum_congr rfl fun v _ => hterm v
+      _ = (c * c) • (S⁻¹ * (∑ v : Fin d, B v * X * (B v)ᴴ) * S⁻¹) := by
+          rw [← Finset.smul_sum, Finset.mul_sum, Finset.sum_mul]
+      _ = (c * c) • (S⁻¹ * (μ • X) * S⁻¹) := by
+          rw [show ∑ v : Fin d, B v * X * (B v)ᴴ
+              = transferMap (d := d) (D := D) B X from
+            (transferMap_apply (d := d) (D := D) B X).symm, hXeq]
+      _ = (μ / ↑rad) • X' := by
+          rw [Matrix.mul_smul, Matrix.smul_mul, smul_smul, hcc, hX',
+            div_eq_mul_inv, mul_comm]
+  exact hasEigenvalue_of_eigenvector_eq _ _ X' hmap hX'ne
+
+end MPSTensor
+
+namespace MPOTensor
+
+open MPSTensor in
+/-- **The displaced invariant projector of a nontrivial periodic vector**
+(arXiv:1606.00608, lines 1888--1891, from Wolf 2012, Theorem 6.6).
+
+A nontrivial periodic vector of the vertically viewed tensor — an irreducible
+corner `B` reached through the isometry `V`, carrying a positive definite
+transfer eigenvector of eigenvalue `r > 0` together with a transfer
+eigenvalue `μ ≠ r` of modulus `r` — supplies a positive period `p` and an
+orthogonal projector `Q` on the physical space such that
+
+* `Q` is one-sided invariant for every length-`p` word of the vertically
+  viewed tensor, and
+* `Q` is displaced by a single vertical layer:
+  $Q\widetilde M\ne Q\widetilde MQ$.
+
+The projector is the complement of the orthogonal projection onto the
+subspace carried by one cyclic sector of Wolf Theorem 6.6 for the rescaled
+corner transfer map, transported through the isometry and the square root of
+the transfer eigenvector.  A full cyclic period returns the sector to itself,
+giving the word invariance; a single layer moves it to the neighboring
+orthogonal sector, forbidding single-letter invariance. -/
+theorem exists_displaced_invariant_projector_of_periodic_vector
+    {d D : ℕ} (M : MPOTensor d D) {n : ℕ}
+    (V : Matrix (Fin d) (Fin n) ℂ) (B : MPSTensor (D * D) n)
+    (ρ : Matrix (Fin n) (Fin n) ℂ) (rad : ℝ)
+    (hV : Vᴴ * V = 1)
+    (hint : ∀ v : Fin (D * D), verticalTensor M v * V = V * B v)
+    (hirr : MPSTensor.IsIrreducibleTensor B) (hρ : ρ.PosDef) (hrad : 0 < rad)
+    (hfix : MPSTensor.transferMap (d := D * D) (D := n) B ρ = (rad : ℂ) • ρ)
+    (μ : ℂ)
+    (hμ : Module.End.HasEigenvalue (MPSTensor.transferMap (d := D * D) (D := n) B) μ)
+    (hnorm : ‖μ‖ = rad) (hne : μ ≠ (rad : ℂ)) :
+    ∃ (p : ℕ) (Q : Matrix (Fin d) (Fin d) ℂ),
+      p ≠ 0 ∧ Q.IsHermitian ∧ IsIdempotentElem Q ∧
+      (∀ w : List (Fin (D * D)), w.length = p →
+        Q * MPSTensor.evalWord (verticalTensor M) w =
+          Q * MPSTensor.evalWord (verticalTensor M) w * Q) ∧
+      M.ketLeftMul Q ≠ (M.ketLeftMul Q).braRightMul Q := by
+  classical
+  -- The corner space is nonzero: it carries an eigenvector.
+  have hn : n ≠ 0 := by
+    rintro rfl
+    obtain ⟨X, hX⟩ := hμ.exists_hasEigenvector
+    have hXne : X ≠ 0 := (Module.End.hasEigenvector_iff.mp hX).2
+    exact hXne (Matrix.ext fun i _ => i.elim0)
+  haveI : NeZero n := ⟨hn⟩
+  -- The unital gauge of the corner and its Wolf Theorem 6.6 data.
+  set K : MPSTensor (D * D) n := MPSTensor.spectralUnitalGauge B rad ρ with hK
+  obtain ⟨hUnital, hIrrK, hIrrMap, σ, hσ, hσfix⟩ :=
+    MPSTensor.spectralUnitalGauge_schwarz_setup B hirr ρ rad hρ hrad hfix
+  obtain ⟨m, γ, hm_pos, hγprim, hset⟩ :=
+    PeripheralSpectrum.peripheral_eigenvalues_cyclic_structure K hUnital σ hσ hσfix hIrrMap
+  haveI : NeZero m := ⟨hm_pos.ne'⟩
+  -- `μ / r` is a peripheral eigenvalue of the gauged transfer map, and it is
+  -- not `1`, so the peripheral cyclic group has order at least two.
+  have hradC : (rad : ℂ) ≠ 0 := by exact_mod_cast hrad.ne'
+  have hμ'val : Module.End.HasEigenvalue
+      (MPSTensor.transferMap (d := D * D) (D := n) K) (μ / rad) :=
+    MPSTensor.hasEigenvalue_transferMap_spectralUnitalGauge B ρ rad hρ hrad hμ
+  have hμ'norm : ‖μ / (rad : ℂ)‖ = 1 := by
+    rw [norm_div, hnorm, Complex.norm_real, Real.norm_eq_abs, abs_of_pos hrad,
+      div_self hrad.ne']
+  have hμ'ne1 : μ / (rad : ℂ) ≠ 1 := fun h =>
+    hne (by rwa [div_eq_one_iff_eq hradC] at h)
+  have hm2 : 1 < m := by
+    by_contra hm1'
+    have hm1 : m = 1 := le_antisymm (not_lt.mp hm1') hm_pos
+    have hμ'mem : μ / (rad : ℂ) ∈
+        peripheralEigenvalues (MPSTensor.transferMap (d := D * D) (D := n) K) :=
+      ⟨hμ'val, hμ'norm⟩
+    rw [hset] at hμ'mem
+    obtain ⟨k, hk⟩ := hμ'mem
+    apply hμ'ne1
+    rw [hk]
+    subst hm1
+    rw [Fin.eq_zero k]
+    simp
+  -- The cyclic family of Wolf Theorem 6.6 for the gauged corner map.
+  have hperiph : peripheralEigenvalues (MPSTensor.transferMap (d := D * D) (D := n) K) =
+      Set.range (fun j : Fin m => γ ^ (j : ℕ)) := by
+    rw [hset]
+    ext z
+    simp [Set.mem_range, eq_comm]
+  obtain ⟨U, P, _, _, _, hPproj, hPsum, _, hcyclic⟩ :=
+    MPSTensor.exists_cyclic_decomposition_of_irreducible_schwarz
+      (K := K) hUnital σ hσ hσfix hIrrMap hγprim hperiph
+  -- Notation for the square root of the eigenvector and the scaling factor.
+  set S : Matrix (Fin n) (Fin n) ℂ := CFC.sqrt ρ with hS
+  have hSdet : IsUnit S.det := MPSTensor.isUnit_det_cfc_sqrt_of_posDef ρ hρ
+  set c : ℂ := (↑((Real.sqrt rad)⁻¹) : ℂ) with hc
+  have hcne : c ≠ 0 := by
+    have hs : Real.sqrt rad ≠ 0 := ne_of_gt (Real.sqrt_pos.mpr hrad)
+    rw [hc]
+    exact_mod_cast inv_ne_zero hs
+  -- Words of the vertically viewed tensor act on `V * S` through words of the
+  -- gauged corner letters.
+  have hword_int : ∀ w : List (Fin (D * D)),
+      MPSTensor.evalWord (verticalTensor M) w * V = V * MPSTensor.evalWord B w := by
+    intro w
+    induction w with
+    | nil => simp
+    | cons v w ih =>
+      rw [MPSTensor.evalWord_cons, MPSTensor.evalWord_cons, Matrix.mul_assoc, ih,
+        ← Matrix.mul_assoc, hint v, Matrix.mul_assoc]
+  have hletterB : ∀ v : Fin (D * D), B v * S = c⁻¹ • (S * K v) := by
+    intro v
+    have hKv : K v = c • (S⁻¹ * B v * S) := rfl
+    rw [hKv, Matrix.mul_smul, smul_smul, inv_mul_cancel₀ hcne, one_smul,
+      show S * (S⁻¹ * B v * S) = B v * S from by
+        rw [Matrix.mul_assoc S⁻¹, Matrix.mul_nonsing_inv_cancel_left _ _ hSdet]]
+  have hkeyB : ∀ w : List (Fin (D * D)),
+      MPSTensor.evalWord B w * S = (c⁻¹ ^ w.length) • (S * MPSTensor.evalWord K w) := by
+    intro w
+    induction w with
+    | nil => simp
+    | cons v w ih =>
+      rw [MPSTensor.evalWord_cons, MPSTensor.evalWord_cons]
+      calc B v * MPSTensor.evalWord B w * S
+          = B v * (MPSTensor.evalWord B w * S) := by rw [Matrix.mul_assoc]
+        _ = B v * ((c⁻¹ ^ w.length) • (S * MPSTensor.evalWord K w)) := by rw [ih]
+        _ = (c⁻¹ ^ w.length) • (B v * S * MPSTensor.evalWord K w) := by
+            rw [Matrix.mul_smul, Matrix.mul_assoc]
+        _ = (c⁻¹ ^ w.length) • ((c⁻¹ • (S * K v)) * MPSTensor.evalWord K w) := by
+            rw [hletterB v]
+        _ = (c⁻¹ ^ (v :: w).length) • (S * (K v * MPSTensor.evalWord K w)) := by
+            rw [Matrix.smul_mul, smul_smul, List.length_cons, pow_succ,
+              mul_comm (c⁻¹ ^ w.length) c⁻¹, Matrix.mul_assoc]
+  have hkey : ∀ w : List (Fin (D * D)),
+      MPSTensor.evalWord (verticalTensor M) w * (V * S) =
+        (c⁻¹ ^ w.length) • (V * S * MPSTensor.evalWord K w) := by
+    intro w
+    calc MPSTensor.evalWord (verticalTensor M) w * (V * S)
+        = MPSTensor.evalWord (verticalTensor M) w * V * S := by
+          rw [Matrix.mul_assoc]
+      _ = V * MPSTensor.evalWord B w * S := by rw [hword_int w]
+      _ = V * (MPSTensor.evalWord B w * S) := by rw [Matrix.mul_assoc]
+      _ = V * ((c⁻¹ ^ w.length) • (S * MPSTensor.evalWord K w)) := by rw [hkeyB w]
+      _ = (c⁻¹ ^ w.length) • (V * S * MPSTensor.evalWord K w) := by
+          rw [Matrix.mul_smul, Matrix.mul_assoc]
+  -- The projector: complement of the support projection of the transported
+  -- cyclic sector `V S · ran (P 0)`.
+  set Y : Matrix (Fin d) (Fin n) ℂ := V * S * P 0 with hY
+  set π : Matrix (Fin d) (Fin d) ℂ :=
+    MPSTensor.supportProj (Y * Yᴴ) (Matrix.posSemidef_self_mul_conjTranspose Y) with hπ
+  have hπproj : IsOrthogonalProjection π :=
+    MPSTensor.isOrthogonalProjection_supportProj (ρ := Y * Yᴴ)
+      (hρ := Matrix.posSemidef_self_mul_conjTranspose Y)
+  have hQproj : IsOrthogonalProjection (1 - π) := hπproj.one_sub
+  -- Left cancellation of `V * S`.
+  have hVScancel : ∀ {Z Z' : Matrix (Fin n) (Fin n) ℂ},
+      V * S * Z = V * S * Z' → Z = Z' := by
+    intro Z Z' hZZ
+    have h1 : ∀ W : Matrix (Fin n) (Fin n) ℂ, S⁻¹ * (Vᴴ * (V * S * W)) = W := by
+      intro W
+      calc S⁻¹ * (Vᴴ * (V * S * W))
+          = S⁻¹ * ((Vᴴ * V) * (S * W)) := by simp only [Matrix.mul_assoc]
+        _ = S⁻¹ * (S * W) := by rw [hV, Matrix.one_mul]
+        _ = W := Matrix.nonsing_inv_mul_cancel_left S W hSdet
+    calc Z = S⁻¹ * (Vᴴ * (V * S * Z)) := (h1 Z).symm
+      _ = S⁻¹ * (Vᴴ * (V * S * Z')) := by rw [hZZ]
+      _ = Z' := h1 Z'
+  -- The nonzero displaced sector index `0 - 1` in `Fin m`.
+  have h01 : ((0 : Fin m) - 1) ≠ 0 := by
+    intro h
+    have h01' : (0 : Fin m) = 1 := sub_eq_zero.mp h
+    have hv : (0 : ℕ) = 1 % m := by
+      have := congrArg Fin.val h01'
+      simpa [Fin.val_one'] using this
+    rw [Nat.mod_eq_of_lt hm2] at hv
+    exact absurd hv (by omega)
+  refine ⟨m, 1 - π, hm_pos.ne', hQproj.1, hQproj.2, ?_, ?_⟩
+  · -- Word invariance for full-period words: the sector returns to itself.
+    intro w hw
+    have hKw : MPSTensor.evalWord K w * P 0 = P 0 * MPSTensor.evalWord K w := by
+      have := MPSTensor.evalWord_mul_cyclicProj K P hPproj hPsum hcyclic w 0
+      rwa [hw, Fin.natCast_self, sub_zero] at this
+    have hAY : MPSTensor.evalWord (verticalTensor M) w * Y =
+        Y * ((c⁻¹ ^ w.length) • MPSTensor.evalWord K w) := by
+      calc MPSTensor.evalWord (verticalTensor M) w * Y
+          = MPSTensor.evalWord (verticalTensor M) w * (V * S) * P 0 := by
+            rw [hY]; simp only [Matrix.mul_assoc]
+        _ = ((c⁻¹ ^ w.length) • (V * S * MPSTensor.evalWord K w)) * P 0 := by
+            rw [hkey w]
+        _ = (c⁻¹ ^ w.length) • (V * S * (MPSTensor.evalWord K w * P 0)) := by
+            rw [Matrix.smul_mul]; simp only [Matrix.mul_assoc]
+        _ = (c⁻¹ ^ w.length) • (V * S * (P 0 * MPSTensor.evalWord K w)) := by
+            rw [hKw]
+        _ = (c⁻¹ ^ w.length) • (Y * MPSTensor.evalWord K w) := by
+            rw [hY]; simp only [Matrix.mul_assoc]
+        _ = Y * ((c⁻¹ ^ w.length) • MPSTensor.evalWord K w) := by
+            rw [Matrix.mul_smul]
+    have hinv0 : (1 - π) * MPSTensor.evalWord (verticalTensor M) w * π = 0 :=
+      MPSTensor.one_sub_supportProj_mul_mul_supportProj_eq_zero Y hAY
+    calc (1 - π) * MPSTensor.evalWord (verticalTensor M) w
+        = (1 - π) * MPSTensor.evalWord (verticalTensor M) w * 1 := by
+          rw [Matrix.mul_one]
+      _ = (1 - π) * MPSTensor.evalWord (verticalTensor M) w * (π + (1 - π)) := by
+          rw [add_sub_cancel]
+      _ = (1 - π) * MPSTensor.evalWord (verticalTensor M) w * (1 - π) := by
+          rw [Matrix.mul_add, hinv0, zero_add]
+  · -- Single-letter displacement: one layer moves the sector to the
+    -- neighboring orthogonal sector.
+    intro hEq
+    -- Letter-level invariance from the tensor equation.
+    have hletter : ∀ v : Fin (D * D),
+        (1 - π) * verticalTensor M v * π = 0 := by
+      intro v
+      have h1 : verticalTensor (M.ketLeftMul (1 - π)) v =
+          verticalTensor ((M.ketLeftMul (1 - π)).braRightMul (1 - π)) v :=
+        congrFun (congrArg verticalTensor hEq) v
+      rw [verticalTensor_braRightMul, verticalTensor_ketLeftMul] at h1
+      calc (1 - π) * verticalTensor M v * π
+          = (1 - π) * verticalTensor M v * (1 - (1 - π)) := by
+            rw [sub_sub_cancel]
+        _ = (1 - π) * verticalTensor M v -
+            (1 - π) * verticalTensor M v * (1 - π) := by
+            rw [Matrix.mul_sub, Matrix.mul_one]
+        _ = 0 := by rw [← h1, sub_self]
+    -- The displaced sector kills every gauged letter.
+    have hPK : ∀ v : Fin (D * D), P (0 - 1) * K v = 0 := by
+      intro v
+      -- Single-letter action on `Y`.
+      have hKv0 : K v * P 0 = P (0 - 1) * K v := by
+        have := MPSTensor.kraus_mul_cyclicProj K P hPproj hPsum hcyclic v (0 - 1)
+        rwa [sub_add_cancel] at this
+      have hsingle : verticalTensor M v * Y =
+          c⁻¹ • (V * S * (P (0 - 1) * K v)) := by
+        have hkey1 := hkey [v]
+        simp only [List.length_cons, List.length_nil, zero_add, pow_one,
+          MPSTensor.evalWord_cons, MPSTensor.evalWord_nil, Matrix.mul_one] at hkey1
+        calc verticalTensor M v * Y
+            = verticalTensor M v * (V * S) * P 0 := by
+              rw [hY]; simp only [Matrix.mul_assoc]
+          _ = (c⁻¹ • (V * S * K v)) * P 0 := by rw [hkey1]
+          _ = c⁻¹ • (V * S * (K v * P 0)) := by
+              rw [Matrix.smul_mul]; simp only [Matrix.mul_assoc]
+          _ = c⁻¹ • (V * S * (P (0 - 1) * K v)) := by rw [hKv0]
+      -- `π` fixes `Y` and absorbs the letter action.
+      have hπY : π * Y = Y := MPSTensor.supportProj_mul_left_eq_self Y
+      have hfix' : π * (verticalTensor M v * Y) = verticalTensor M v * Y := by
+        have hAπ : verticalTensor M v * π = π * (verticalTensor M v * π) := by
+          have h0 := hletter v
+          have := sub_eq_zero.mp (by
+            calc verticalTensor M v * π - π * (verticalTensor M v * π)
+                = (1 - π) * verticalTensor M v * π := by
+                  rw [Matrix.sub_mul, Matrix.sub_mul, Matrix.one_mul,
+                    Matrix.mul_assoc]
+              _ = 0 := h0)
+          exact this
+        calc π * (verticalTensor M v * Y)
+            = π * (verticalTensor M v * (π * Y)) := by rw [hπY]
+          _ = π * (verticalTensor M v * π) * Y := by simp only [Matrix.mul_assoc]
+          _ = verticalTensor M v * π * Y := by rw [← hAπ]
+          _ = verticalTensor M v * Y := by rw [Matrix.mul_assoc, hπY]
+      -- Express the fixed equation through the support factorization.
+      obtain ⟨W, hW⟩ := MPSTensor.exists_supportProj_eq_mul (Y * Yᴴ)
+        (Matrix.posSemidef_self_mul_conjTranspose Y)
+      have hππ : π = Y * (Yᴴ * W) := by rw [hπ, hW, Matrix.mul_assoc]
+      have hZ : V * S * (P (0 - 1) * K v) =
+          V * S * (P 0 * (Yᴴ * W * (V * S * (P (0 - 1) * K v)))) := by
+        have hs : π * (V * S * (P (0 - 1) * K v)) = V * S * (P (0 - 1) * K v) := by
+          have := hfix'
+          rw [hsingle, Matrix.mul_smul] at this
+          exact smul_right_injective _ (inv_ne_zero hcne) this
+        calc V * S * (P (0 - 1) * K v)
+            = π * (V * S * (P (0 - 1) * K v)) := hs.symm
+          _ = Y * (Yᴴ * W * (V * S * (P (0 - 1) * K v))) := by
+              rw [hππ]; simp only [Matrix.mul_assoc]
+          _ = V * S * (P 0 * (Yᴴ * W * (V * S * (P (0 - 1) * K v)))) := by
+              rw [hY]; simp only [Matrix.mul_assoc]
+      have hcancel := hVScancel hZ
+      have horth : P (0 - 1) * P 0 = 0 :=
+        MPSTensor.orthogonalProjection_mul_eq_zero_of_sum_eq_one P hPproj hPsum h01
+      calc P (0 - 1) * K v
+          = P (0 - 1) * (P (0 - 1) * K v) := by
+            rw [← Matrix.mul_assoc, (hPproj (0 - 1)).2]
+        _ = P (0 - 1) * (P 0 * (Yᴴ * W * (V * S * (P (0 - 1) * K v)))) := by
+            conv_lhs => rw [hcancel]
+        _ = 0 := by rw [← Matrix.mul_assoc, horth, Matrix.zero_mul]
+    -- The cyclic action then annihilates the displaced sector, which is
+    -- impossible: no cyclic projection vanishes.
+    have hmap0 : MPSTensor.transferMap (d := D * D) (D := n) K (P 0) = 0 := by
+      rw [MPSTensor.transferMap_apply]
+      refine Finset.sum_eq_zero fun v _ => ?_
+      have hKv0 : K v * P 0 = P (0 - 1) * K v := by
+        have := MPSTensor.kraus_mul_cyclicProj K P hPproj hPsum hcyclic v (0 - 1)
+        rwa [sub_add_cancel] at this
+      rw [hKv0, hPK v, Matrix.zero_mul]
+    have hP1 : P (0 - 1) = 0 := by
+      have := hcyclic (0 - 1)
+      rwa [sub_add_cancel, hmap0, eq_comm] at this
+    exact MPSTensor.cyclicProj_ne_zero K P hPsum hcyclic (0 - 1) hP1
+
+/-- **Hypothesis** (arXiv:1606.00608, lines 1888--1891, resting on the
+canonical-form input of lines 1874--1887): an orthogonal projector on the
+physical space that is displaced by the vertically viewed tensor —
+$Q\widetilde M\ne Q\widetilde MQ$ — fails to commute with the density
+operator $H^{(N)}$ at every length.
+
+This is the horizontal-canonical-form step of the periodic-sector argument.
+The source assumes the tensor is in canonical form in the horizontal
+direction; the argument of lines 1874--1887 (Lemma L of the appendix,
+formalized blockwise in `TNLean/MPS/MPDO/VerticalCF.lean`) then turns
+all-length commutation of $Q_1$ with $H^{(N)}$ into the letter-level
+invariance $Q\widetilde M=Q\widetilde MQ$; contrapositively, a displaced
+projector cannot commute.  The derivation of this implication from a
+horizontal canonical form of `M` remains open; it is recorded in
+`docs/paper-gaps/cpgsv17_periodic_sector_projector.tex`. -/
+def NoninvariantProjectorNoncommuting {d D : ℕ} (M : MPOTensor d D) : Prop :=
+  ∀ Q : Matrix (Fin d) (Fin d) ℂ, Q.IsHermitian → IsIdempotentElem Q →
+    M.ketLeftMul Q ≠ (M.ketLeftMul Q).braRightMul Q →
+    ∀ N : ℕ, ¬ Commute (firstSiteMatrix Q N) (mpo M (N + 1))
+
+/-- The non-commutation hypothesis discharges the cyclic-projector hypothesis
+of the periodic-sector step: the cyclic decomposition of the peripheral
+spectrum supplies the invariant, displaced projector unconditionally
+(`exists_displaced_invariant_projector_of_periodic_vector`), and the
+displacement upgrades to the all-length non-commutation family through the
+hypothesis.  This reduces the periodic-sector step of the proof of
+Proposition 4.13 of arXiv:1606.00608, lines 1888--1893, to the
+canonical-form implication of lines 1874--1887. -/
+theorem periodicVectorYieldsCyclicProjector_of_noncommutation
+    {d D : ℕ} (M : MPOTensor d D)
+    (hNC : NoninvariantProjectorNoncommuting M) :
+    PeriodicVectorYieldsCyclicProjector M := by
+  intro n V B ρ rad hV hint hirr hρ hrad hfix μ hμ hnorm hne
+  obtain ⟨p, Q, hp, hherm, hidem, hword, hdisp⟩ :=
+    exists_displaced_invariant_projector_of_periodic_vector M V B ρ rad hV hint
+      hirr hρ hrad hfix μ hμ hnorm hne
+  exact ⟨p, Q, hp, hherm, hidem, hword, hNC Q hherm hidem hdisp⟩
+
+/-- The vertically viewed tensor of a matrix product density operator has no
+nontrivial periodic vectors, granted that displaced projectors never commute
+with the density operator.  This is the periodic-sector step in the proof of
+Proposition 4.13 of arXiv:1606.00608, lines 1888--1893, with the projector
+and its word invariance constructed from the cyclic decomposition of the
+peripheral spectrum (Wolf 2012, Theorem 6.6) rather than assumed.
+
+**Scope restriction (conditional on the non-commutation family):** the source
+derives the non-commutation from the horizontal canonical form through the
+argument of lines 1874--1887; here that implication is the explicit
+hypothesis.  Recorded in
+`docs/paper-gaps/cpgsv17_periodic_sector_projector.tex`. -/
+theorem hasNoPeriodicVectors_verticalTensor_of_noncommutation
+    {d D : ℕ} (M : MPOTensor d D) (hM : IsMPDO M)
+    (hNC : NoninvariantProjectorNoncommuting M) :
+    MPSTensor.HasNoPeriodicVectors (verticalTensor M) :=
+  hasNoPeriodicVectors_verticalTensor_of_cyclicProjector M hM
+    (periodicVectorYieldsCyclicProjector_of_noncommutation M hNC)
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/CyclicProjector.lean
+++ b/TNLean/MPS/MPDO/CyclicProjector.lean
@@ -198,13 +198,13 @@ theorem isIrreducibleTensor_smul_conj (B : MPSTensor d D)
 /-! ### The unital gauge of a corner satisfies the Wolf Theorem 6.6 hypotheses -/
 
 /-- **Unital Schwarz data for an irreducible corner.**  The rescaled unital
-gauge `K = spectralUnitalGauge B r ρ` of an irreducible tensor `B` with a
-positive definite transfer eigenvector `ρ` of positive eigenvalue `r`
-(arXiv:1606.00608, lines 220--225: each corner map is rescaled to spectral
-radius one) is a unital Kraus family, is again an irreducible tensor with an
-irreducible transfer map, and its adjoint map has a positive definite fixed
-point.  These are the hypotheses of the cyclic decomposition of the
-peripheral spectrum, Wolf 2012, Theorem 6.6. -/
+gauge $K^v=r^{-1/2}\rho^{-1/2}B^v\rho^{1/2}$ of an irreducible tensor $B$
+with a positive definite transfer eigenvector $\rho$ of positive eigenvalue
+$r$ (arXiv:1606.00608, lines 220--225: each corner map is rescaled to
+spectral radius one) is a unital Kraus family, is again an irreducible
+tensor with an irreducible transfer map, and its adjoint map has a positive
+definite fixed point.  These are the hypotheses of the cyclic decomposition
+of the peripheral spectrum, Wolf 2012, Theorem 6.6. -/
 theorem spectralUnitalGauge_schwarz_setup [NeZero D]
     (B : MPSTensor d D) (hIrr : IsIrreducibleTensor B)
     (ρ : Matrix (Fin D) (Fin D) ℂ) (rad : ℝ) (hρ : ρ.PosDef) (hrad : 0 < rad)
@@ -251,12 +251,13 @@ theorem spectralUnitalGauge_schwarz_setup [NeZero D]
   simpa [Kraus.adjointMap, transferMap_apply, Matrix.conjTranspose_conjTranspose,
     Matrix.mul_assoc] using hσ_fix
 
-/-- **Eigenvalue transport to the unital gauge.**  An eigenvalue `μ` of the
-transfer map of `B` becomes the eigenvalue `μ / r` of the transfer map of the
-rescaled unital gauge `spectralUnitalGauge B r ρ`: the gauge conjugates the
-transfer map by a congruence and divides it by `r`.  In particular the
-peripheral eigenvalues `exp(2πiq/p)` of arXiv:1606.00608, lines 225--230,
-arise from the transfer eigenvalues of modulus `r`. -/
+/-- **Eigenvalue transport to the unital gauge.**  An eigenvalue $\mu$ of
+the transfer map of $B$ becomes the eigenvalue $\mu/r$ of the transfer map
+of the rescaled unital gauge $K^v=r^{-1/2}\rho^{-1/2}B^v\rho^{1/2}$: the
+gauge conjugates the transfer map by a congruence and divides it by $r$.
+In particular the peripheral eigenvalues $e^{2\pi iq/p}$ of
+arXiv:1606.00608, lines 225--230, arise from the transfer eigenvalues of
+modulus $r$. -/
 theorem hasEigenvalue_transferMap_spectralUnitalGauge
     (B : MPSTensor d D) (ρ : Matrix (Fin D) (Fin D) ℂ) (rad : ℝ)
     (hρ : ρ.PosDef) (hrad : 0 < rad) {μ : ℂ}
@@ -593,7 +594,7 @@ theorem exists_displaced_invariant_projector_of_periodic_vector
               rw [hY]; simp only [Matrix.mul_assoc]
       have hcancel := hVScancel hZ
       have horth : P (0 - 1) * P 0 = 0 :=
-        MPSTensor.orthogonalProjection_mul_eq_zero_of_sum_eq_one P hPproj hPsum h01
+        orthogonalProjection_mul_eq_zero_of_sum_eq_one P hPproj hPsum h01
       calc P (0 - 1) * K v
           = P (0 - 1) * (P (0 - 1) * K v) := by
             rw [← Matrix.mul_assoc, (hPproj (0 - 1)).2]

--- a/TNLean/MPS/MPDO/PeriodicExclusion.lean
+++ b/TNLean/MPS/MPDO/PeriodicExclusion.lean
@@ -29,11 +29,13 @@ shows that a matrix product density operator admits no such projector.  The
 implication from a nontrivial $p$-periodic vector to such a projector — which
 the source asserts from the general theory of the peripheral spectrum of
 completely positive maps at lines 1889--1891 — is stated as the hypothesis
-`PeriodicVectorYieldsProjector`; its derivation from the cyclic decomposition
-of the peripheral spectrum (Wolf 2012, Theorem 6.6) applied to the vertical
-transfer map remains open.  Granted that hypothesis,
-`hasNoPeriodicVectors_verticalTensor` concludes that the vertically viewed
-tensor has no nontrivial $p$-periodic vectors.
+`PeriodicVectorYieldsProjector`.  The cyclic decomposition of the peripheral
+spectrum (Wolf 2012, Theorem 6.6) applied to the vertical transfer map
+supplies the projector with its word invariance and single-letter
+displacement (`TNLean/MPS/MPDO/CyclicProjector.lean`); the passage from the
+displacement to the all-length non-commutation family remains open.  Granted
+that hypothesis, `hasNoPeriodicVectors_verticalTensor` concludes that the
+vertically viewed tensor has no nontrivial $p$-periodic vectors.
 
 ## Main definitions
 
@@ -127,7 +129,10 @@ $[H^{(N)}]^p$ by the argument of eq1:proof.IV.12 (lines 1874--1887) applied
 to the stacked tensor.  The stacking and invariance parts of this
 derivation are formalized in `TNLean/MPS/MPDO/StackedLayers.lean`, which
 reduces this hypothesis to `PeriodicVectorYieldsCyclicProjector`; the
-remaining gap is recorded in
+cyclic projections themselves, with their word invariance and single-letter
+displacement, are constructed in `TNLean/MPS/MPDO/CyclicProjector.lean`,
+which reduces further to the non-commutation hypothesis
+`NoninvariantProjectorNoncommuting`.  The remaining gap is recorded in
 `docs/paper-gaps/cpgsv17_periodic_sector_projector.tex`. -/
 def PeriodicVectorYieldsProjector (M : MPOTensor d D) : Prop :=
   ∀ ⦃n : ℕ⦄ (V : Matrix (Fin d) (Fin n) ℂ) (B : MPSTensor (D * D) n)

--- a/TNLean/MPS/MPDO/StackedLayers.lean
+++ b/TNLean/MPS/MPDO/StackedLayers.lean
@@ -26,9 +26,12 @@ Combined with the all-length non-commutation family, this produces a
 periodic-sector projector.  The passage from a nontrivial $p$-periodic vector
 to an invariant, non-commuting projector — which the source draws from the
 cyclic decomposition of the peripheral spectrum (Wolf 2012, Theorem 6.6) —
-remains the hypothesis `PeriodicVectorYieldsCyclicProjector`; granted it, the
+is the hypothesis `PeriodicVectorYieldsCyclicProjector`; granted it, the
 vertically viewed tensor of a matrix product density operator has no
-nontrivial $p$-periodic vectors.
+nontrivial $p$-periodic vectors.  The invariant projector itself, together
+with its single-letter displacement, is constructed from the cyclic
+decomposition in `TNLean/MPS/MPDO/CyclicProjector.lean`, which reduces this
+hypothesis to the non-commutation family alone.
 
 ## Main definitions
 
@@ -340,8 +343,15 @@ nontrivial cyclic displacement under one layer prevents commutation with
 $H^{(N)}$.  Compared with `PeriodicVectorYieldsProjector`, the commutation
 of $Q$ with $[H^{(N)}]^p$ is no longer assumed: it is derived from the word
 invariance through the stacked-layers identity
-(`periodicSectorProjectorOfCyclicData`).  The remaining gap is recorded in
-`docs/paper-gaps/cpgsv17_periodic_sector_projector.tex`. -/
+(`periodicSectorProjectorOfCyclicData`).
+
+The projector, its word invariance, and its single-letter displacement are
+constructed unconditionally in
+`exists_displaced_invariant_projector_of_periodic_vector`
+(`TNLean/MPS/MPDO/CyclicProjector.lean`); this hypothesis follows from the
+non-commutation hypothesis `NoninvariantProjectorNoncommuting` through
+`periodicVectorYieldsCyclicProjector_of_noncommutation`.  The remaining gap
+is recorded in `docs/paper-gaps/cpgsv17_periodic_sector_projector.tex`. -/
 def PeriodicVectorYieldsCyclicProjector (M : MPOTensor d D) : Prop :=
   ∀ ⦃n : ℕ⦄ (V : Matrix (Fin d) (Fin n) ℂ) (B : MPSTensor (D * D) n)
     (ρ : Matrix (Fin n) (Fin n) ℂ) (r : ℝ),

--- a/TNLean/MPS/Periodic/SectorIrreducibility/ProjectionOrtho.lean
+++ b/TNLean/MPS/Periodic/SectorIrreducibility/ProjectionOrtho.lean
@@ -40,61 +40,15 @@ variable {D m : ℕ}
 /-- If a finite family of orthogonal projections sums to the identity, then
 distinct projections are orthogonal: `P i * P j = 0` for `i ≠ j`.
 
-This is a standard fact about orthogonal decompositions of the identity. The
-proof sandwiches the sum between `P i` to isolate the diagonal, then extracts
-each off-diagonal term via positivity (`B B* = 0 → B = 0`). -/
+This is the `Pairwise` packaging of
+`orthogonalProjection_mul_eq_zero_of_sum_eq_one` from
+`TNLean/Channel/Irreducible/Basic.lean`. -/
 theorem pairwise_mul_zero_of_orthogonalProjection_sum_one
     (P : Fin m → MatrixAlg D)
     (hPproj : ∀ k : Fin m, IsOrthogonalProjection (P k))
     (hPsum : ∑ k : Fin m, P k = 1) :
-    Pairwise fun i j : Fin m => P i * P j = 0 := by
-  intro i j hij
-  have hsum_i : ∑ k : Fin m, P i * P k * P i = P i := by
-    calc
-      ∑ k : Fin m, P i * P k * P i
-          = P i * (∑ k : Fin m, P k) * P i := by
-              simp [Finset.mul_sum, Finset.sum_mul, Matrix.mul_assoc]
-      _ = P i * 1 * P i := by rw [hPsum]
-      _ = P i := by simp [(hPproj i).2]
-  have hsum_erase : ∑ k ∈ Finset.univ.erase i, P i * P k * P i = 0 := by
-    rw [← Finset.sum_erase_add Finset.univ (fun k => P i * P k * P i)
-        (Finset.mem_univ i)] at hsum_i
-    have hiii : P i * P i * P i = P i := by
-      simp [(hPproj i).2]
-    rw [hiii] at hsum_i
-    simpa using hsum_i
-  let B : Fin m → MatrixAlg D := fun k => if k = i then 0 else P i * P k
-  have hsum_B : ∑ k : Fin m, B k * (B k)ᴴ = 0 := by
-    classical
-    rw [← Finset.sum_erase_add Finset.univ (fun k => B k * (B k)ᴴ) (Finset.mem_univ i)]
-    have hzero_i : B i * (B i)ᴴ = 0 := by simp [B]
-    rw [hzero_i, add_zero]
-    calc
-      ∑ k ∈ Finset.univ.erase i, B k * (B k)ᴴ
-          = ∑ k ∈ Finset.univ.erase i, P i * P k * P i := by
-              refine Finset.sum_congr rfl ?_
-              intro k hk
-              have hki : k ≠ i := by
-                exact Finset.mem_erase.mp hk |>.1
-              calc
-                B k * (B k)ᴴ = (P i * P k) * ((P i * P k)ᴴ) := by
-                  simp [B, hki]
-                _ = P i * P k * P i := by
-                  calc
-                    (P i * P k) * ((P i * P k)ᴴ)
-                        = P i * (P k * (P k * P i)) := by
-                            simp [Matrix.conjTranspose_mul, Matrix.mul_assoc, (hPproj i).1.eq,
-                              (hPproj k).1.eq]
-                    _ = P i * ((P k * P k) * P i) := by simp [Matrix.mul_assoc]
-                    _ = P i * (P k * P i) := by rw [(hPproj k).2]
-                    _ = P i * P k * P i := by simp [Matrix.mul_assoc]
-      _ = 0 := hsum_erase
-  have hB_zero := Matrix.eq_zero_of_sum_mul_conjTranspose_eq_zero B hsum_B
-  have hPiPj : P i * P j = 0 := by
-    by_cases hji : j = i
-    · exact False.elim (hij hji.symm)
-    · simpa [B, hji] using hB_zero j
-  exact hPiPj
+    Pairwise fun i j : Fin m => P i * P j = 0 := fun _ _ hij =>
+  orthogonalProjection_mul_eq_zero_of_sum_eq_one P hPproj hPsum hij
 
 /-! ### Corner preservation from adjoint fixed projections -/
 

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2889,6 +2889,42 @@ Theorem~\ref{thm:peripheral_cyclic_group}.
     full cyclic projection decomposition realizing the peripheral period.
 \end{theorem}
 
+\begin{lemma}[Cyclic shift of the Kraus operators]
+    \label{lem:kraus_cyclic_shift}
+    \lean{MPSTensor.one_sub_mul_kraus_mul_eq_zero_of_transferMap_proj}
+    \lean{MPSTensor.orthogonalProjection_mul_eq_zero_of_sum_eq_one}
+    \lean{MPSTensor.kraus_mul_cyclicProj}
+    \lean{MPSTensor.evalWord_mul_cyclicProj}
+    \lean{MPSTensor.cyclicProj_ne_zero}
+    \leanok
+    Let $P_0,\dots,P_{m-1}$ be orthogonal projections summing to the
+    identity and cyclically permuted by a Kraus map,
+    $\sum_vK_vP_{k+1}K_v^\dagger=P_k$.  Then the projections are mutually
+    orthogonal, none of them vanishes, and each Kraus operator intertwines
+    consecutive projections,
+    \[
+        K_vP_{k+1}=P_kK_v .
+    \]
+    Consequently a product of $\ell$ Kraus operators moves each projection
+    back by $\ell$ steps; in particular a product of $m$ Kraus operators
+    commutes with every projection.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Compressing $\sum_vK_vP_{k+1}K_v^\dagger=P_k$ by $\Id-P_k$ exhibits a
+    vanishing sum of positive semidefinite matrices, so each summand
+    vanishes: $(\Id-P_k)K_vP_{k+1}=0$.  Mutual orthogonality follows by
+    compressing the resolution of the identity by a fixed $P_k$, another
+    vanishing sum of positive semidefinite matrices.  Expanding
+    $K_vP_{k+1}$ and $P_kK_v$ through the resolution of the identity, the
+    off-diagonal compressions vanish by orthogonality, leaving
+    $K_vP_{k+1}=P_kK_vP_{k+1}=P_kK_v$.  If some projection vanished, the
+    cyclic action would propagate the vanishing around the cycle,
+    contradicting the resolution of the identity.  The word statement is
+    induction on the length.
+\end{proof}
+
 \begin{lemma}[Power maps preserve each cyclic sector]
     \lean{preserves_corner_pow_of_cyclic_decomp}
     \leanok

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2892,7 +2892,7 @@ Theorem~\ref{thm:peripheral_cyclic_group}.
 \begin{lemma}[Cyclic shift of the Kraus operators]
     \label{lem:kraus_cyclic_shift}
     \lean{MPSTensor.one_sub_mul_kraus_mul_eq_zero_of_transferMap_proj}
-    \lean{MPSTensor.orthogonalProjection_mul_eq_zero_of_sum_eq_one}
+    \lean{orthogonalProjection_mul_eq_zero_of_sum_eq_one}
     \lean{MPSTensor.kraus_mul_cyclicProj}
     \lean{MPSTensor.evalWord_mul_cyclicProj}
     \lean{MPSTensor.cyclicProj_ne_zero}

--- a/blueprint/src/chapter/ch09_canonical.tex
+++ b/blueprint/src/chapter/ch09_canonical.tex
@@ -798,6 +798,113 @@ irreducible unital blocks and the algebra-spanning input used later.
     coefficients.
 \end{proof}
 
+\begin{lemma}[Range factorization of the support projection]
+    \label{lem:support_proj_range_factorization}
+    \lean{MPSTensor.exists_supportProj_eq_mul}
+    \lean{MPSTensor.supportProj_mul_left_eq_self}
+    \lean{MPSTensor.one_sub_supportProj_mul_mul_supportProj_eq_zero}
+    \leanok
+    \uses{def:support_proj}
+    The support projection $\pi$ of a positive semidefinite matrix $\rho$
+    factors as $\pi=\rho W$ for a spectral pseudo-inverse $W$, witnessing
+    that the range of $\pi$ is the range of $\rho$.  For a rectangular
+    matrix $Y$, the support projection $\pi$ of $YY^\dagger$ fixes $Y$,
+    $\pi Y=Y$; and whenever $AY=YG$ for some matrix $G$ --- that is, $A$
+    maps the range of $Y$ into itself --- the one-sided invariance
+    $(\Id-\pi)A\pi=0$ holds.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{def:support_proj}
+    In the spectral decomposition
+    $\rho=U\diag(\lambda)U^\dagger$ take
+    $W=U\diag(\lambda^{+})U^\dagger$, where $\lambda^{+}$ inverts the
+    positive eigenvalues and vanishes on the kernel; then
+    $\rho W=U\diag(\mathbf 1_{\lambda>0})U^\dagger=\pi$.  From
+    $\pi(YY^\dagger)=YY^\dagger$ the matrix
+    $((\Id-\pi)Y)((\Id-\pi)Y)^\dagger$ vanishes, hence $\pi Y=Y$.
+    Finally $(\Id-\pi)A\pi=(\Id-\pi)AY(Y^\dagger W)
+    =(\Id-\pi)Y\,G(Y^\dagger W)=0$.
+\end{proof}
+
+\begin{theorem}[Irreducibility under rescaled conjugation]
+    \label{thm:irreducible_tensor_smul_conj}
+    \lean{MPSTensor.isIrreducibleTensor_smul_conj}
+    \leanok
+    \uses{def:irreducible_tensor, def:support_proj,
+        lem:support_proj_range_factorization}
+    Let $B$ be an irreducible tensor, let $X$ be invertible, and let
+    $c\ne 0$.  Then the rescaled conjugated tensor with letters
+    $c\,X^{-1}B^vX$ is irreducible.  In particular the rescaled unital
+    gauge of an irreducible tensor is irreducible; this is the
+    normalization of \cite[lines~224--225]{Cirac2016MPDO_arXiv} applied to
+    an irreducible corner.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:support_proj_range_factorization}
+    An invariant orthogonal projection $P\notin\{0,\Id\}$ of the
+    conjugated tensor makes the columns of $Y=XP$ span a subspace invariant
+    under every letter of $B$: $B^vY=YG_v$ with
+    $G_v=X^{-1}B^vXP$.  The support projection of $YY^\dagger$ is then a
+    nontrivial invariant orthogonal projection of $B$ by
+    Lemma~\ref{lem:support_proj_range_factorization}: it is nonzero
+    because $Y\ne 0$, and it is not the identity because any nonzero
+    vector of the kernel of $P$ transports through $(X^\dagger)^{-1}$ to
+    the kernel of $YY^\dagger$.  This contradicts irreducibility of $B$.
+\end{proof}
+
+\begin{theorem}[Unital Schwarz data for an irreducible corner]
+    \label{thm:spectral_unital_gauge_schwarz_setup}
+    \lean{MPSTensor.spectralUnitalGauge_schwarz_setup}
+    \leanok
+    \uses{def:irreducible_tensor, def:transfer_map,
+        thm:unital_gauge_of_pd_fixed_point, thm:irreducible_tensor_smul_conj}
+    Let $B$ be an irreducible tensor with a positive definite transfer
+    eigenvector, $\E_B(\rho)=r\rho$ with $\rho>0$ and $r>0$.  Then the
+    rescaled unital gauge $K^v=r^{-1/2}\rho^{-1/2}B^v\rho^{1/2}$ is a
+    unital Kraus family, is an irreducible tensor with an irreducible
+    transfer map, and its adjoint map has a positive definite fixed point.
+    These are the hypotheses of the cyclic decomposition of the peripheral
+    spectrum, \cite[Theorem~6.6]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:unital_gauge_of_pd_fixed_point, thm:irreducible_tensor_smul_conj,
+        thm:psd_fp_pd_irred}
+    Unitality is Theorem~\ref{thm:unital_gauge_of_pd_fixed_point};
+    irreducibility is Theorem~\ref{thm:irreducible_tensor_smul_conj}.  The
+    adjoint of a unital family is trace preserving, so its transfer map is
+    a channel and has a positive semidefinite fixed point by the Ces\`aro
+    argument; irreducibility of the adjoint map upgrades the fixed point to
+    a positive definite one.
+\end{proof}
+
+\begin{lemma}[Eigenvalue transport to the unital gauge]
+    \label{lem:eigenvalue_transport_unital_gauge}
+    \lean{MPSTensor.hasEigenvalue_transferMap_spectralUnitalGauge}
+    \leanok
+    \uses{def:transfer_map}
+    In the setting of
+    Theorem~\ref{thm:spectral_unital_gauge_schwarz_setup}, every transfer
+    eigenvalue $\mu$ of $B$ becomes the transfer eigenvalue $\mu/r$ of the
+    rescaled unital gauge: the gauge conjugates the transfer map by the
+    congruence with $\rho^{1/2}$ and divides it by $r$.  In particular the
+    peripheral eigenvalues $e^{2\pi iq/p}$ of
+    \cite[lines~225--230]{Cirac2016MPDO_arXiv} arise from the transfer
+    eigenvalues of modulus $r$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    If $\E_B(Z)=\mu Z$ then
+    $Z'=\rho^{-1/2}Z\rho^{-1/2}$ is nonzero and satisfies
+    $\E_K(Z')=(\mu/r)Z'$ by direct computation.
+\end{proof}
+
 \begin{theorem}[Unitary diagonal positive fixed point in TP gauge]\label{thm:form_II}
     \lean{MPSTensor.exists_unitary_diag_posDef_fixedPoint_of_TP_of_isIrreducibleTensor}
     \leanok

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -583,8 +583,12 @@
     this implication from the general theory of the peripheral spectrum of
     completely positive maps, with $q$ equal to the period $p$ of the
     vector; only the existence of some exponent enters the exclusion
-    argument.  The derivation of the projector from the cyclic decomposition
-    of the peripheral spectrum remains open.
+    argument.  The projector, its word invariance, and its single-letter
+    displacement are constructed from the cyclic decomposition of the
+    peripheral spectrum
+    (Theorem~\ref{thm:mpdo_displaced_invariant_projector}); the passage
+    from the displacement to the all-length non-commutation family remains
+    open.
     % Gap recorded in docs/paper-gaps/cpgsv17_periodic_sector_projector.tex.
 \end{definition}
 
@@ -789,6 +793,112 @@
     Definition~\ref{def:mpdo_periodic_sector_projector_of_cyclic}.  The
     exclusion of periodic vectors is then
     Theorem~\ref{thm:mpdo_vertical_no_periodic_vectors}.
+\end{proof}
+
+\begin{theorem}[The displaced invariant projector of a nontrivial periodic
+    vector]
+    \label{thm:mpdo_displaced_invariant_projector}
+    \lean{MPOTensor.exists_displaced_invariant_projector_of_periodic_vector}
+    \leanok
+    \uses{def:vertical_tensor_mpdo, def:no_periodic_vectors,
+        def:mpdo_vertical_one_site_actions, def:support_proj}
+    Let $M$ be an MPO tensor and let $\widetilde M$ carry a nontrivial
+    $p$-periodic vector, presented as in
+    Definition~\ref{def:no_periodic_vectors}: an irreducible restriction
+    $B$ of $\widetilde M$ to a minimal invariant subspace, reached through
+    an isometry $V$, with a positive definite transfer eigenvector $\rho$
+    of eigenvalue $r>0$ and a transfer eigenvalue $\mu\ne r$ of modulus
+    $r$.  Then there are an exponent $q\ge 1$ and an orthogonal projector
+    $Q$ on the physical space such that $QA_w=QA_wQ$ for every product
+    $A_w$ of $q$ letters of $\widetilde M$, while
+    $Q\widetilde M\ne Q\widetilde MQ$ in the sense of
+    Definition~\ref{def:mpdo_vertical_one_site_actions}.  This realizes
+    the projector that the proof of
+    \cite[Proposition~4.13, lines~1889--1891]{Cirac2016MPDO_arXiv} draws
+    from the general theory of the peripheral spectrum, up to its
+    non-commutation family.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:spectral_unital_gauge_schwarz_setup,
+        lem:eigenvalue_transport_unital_gauge,
+        thm:peripheral_cyclic_structure,
+        thm:cyclic_decomposition_irreducible_schwarz,
+        lem:kraus_cyclic_shift, lem:support_proj_range_factorization}
+    The rescaled unital gauge $K$ of the corner satisfies the hypotheses of
+    the cyclic decomposition of the peripheral spectrum
+    (Theorem~\ref{thm:spectral_unital_gauge_schwarz_setup}), and the
+    eigenvalue $\mu/r\ne 1$ of modulus one
+    (Lemma~\ref{lem:eigenvalue_transport_unital_gauge}) forces the
+    peripheral cyclic group to have order $m\ge 2$.
+    Theorem~\ref{thm:cyclic_decomposition_irreducible_schwarz} produces
+    orthogonal projections $P_0,\dots,P_{m-1}$ summing to the identity
+    with $\E_K(P_{k+1})=P_k$, and the letter-level shift
+    $K_vP_{k+1}=P_kK_v$ holds
+    (Lemma~\ref{lem:kraus_cyclic_shift}).  Set $q=m$ and let $Q$ be the
+    complement of the support projection $\pi$ of
+    $YY^\dagger$ for $Y=V\rho^{1/2}P_0$.  A word $A_w$ of $m$ letters of
+    $\widetilde M$ satisfies $A_wY=YG_w$, where $G_w$ is a scalar multiple
+    of the corresponding word in the letters of $K$, which commutes with
+    $P_0$ by the full-period shift; so the range of $Y$ is invariant and
+    Lemma~\ref{lem:support_proj_range_factorization} gives
+    $QA_w=QA_wQ$.  If a single letter also satisfied the invariance, then
+    $\pi$ would fix $A_vY$, whose columns lie in the sector
+    $V\rho^{1/2}P_{m-1}$ by the cyclic shift; cancelling the injective
+    factor $V\rho^{1/2}$ and using orthogonality of $P_{m-1}$ and $P_0$
+    would force $P_{m-1}K_v=0$ for every letter, hence
+    $P_{m-1}=\E_K(P_0)=0$, contradicting the nonvanishing of the cyclic
+    projections.
+\end{proof}
+
+\begin{definition}[Displaced projectors never commute]
+    \label{def:mpdo_noninvariant_projector_noncommuting}
+    \lean{MPOTensor.NoninvariantProjectorNoncommuting}
+    \leanok
+    \uses{def:mpo_tensor, def:mpo_family, def:mpdo_vertical_one_site_actions}
+    Say that \emph{displaced projectors of $M$ never commute} if every
+    orthogonal projector $Q$ on the physical space with
+    $Q\widetilde M\ne Q\widetilde MQ$ satisfies
+    $Q_1H^{(N)}\ne H^{(N)}Q_1$ at every length.  This is the
+    canonical-form step of the periodic-sector argument: the proof of
+    \cite[Proposition~4.13]{Cirac2016MPDO_arXiv} assumes the tensor is in
+    canonical form in the horizontal direction, and the argument of
+    lines~1874--1887 turns all-length commutation of $Q_1$ with $H^{(N)}$
+    into the letter-level invariance $Q\widetilde M=Q\widetilde MQ$, so a
+    displaced projector cannot commute.  The derivation of this implication
+    from a horizontal canonical form remains open.
+    % Gap recorded in docs/paper-gaps/cpgsv17_periodic_sector_projector.tex.
+\end{definition}
+
+\begin{theorem}[Reduction of the periodic-sector step to the
+    non-commutation family]
+    \label{thm:mpdo_cyclic_projector_of_noncommutation}
+    \lean{MPOTensor.periodicVectorYieldsCyclicProjector_of_noncommutation}
+    \lean{MPOTensor.hasNoPeriodicVectors_verticalTensor_of_noncommutation}
+    \leanok
+    \uses{def:mpdo, def:mpdo_noninvariant_projector_noncommuting,
+        def:mpdo_periodic_vector_yields_cyclic_projector,
+        def:vertical_tensor_mpdo, def:no_periodic_vectors}
+    Let $M$ generate matrix product density operators.  If displaced
+    projectors of $M$ never commute, then periodic vectors of $M$ supply
+    cyclic projectors, and the vertically viewed tensor $\widetilde M$ has
+    no nontrivial $p$-periodic vectors.  This narrows the hypothesis of the
+    periodic-sector step in the proof of
+    \cite[Proposition~4.13, lines~1888--1893]{Cirac2016MPDO_arXiv} to the
+    canonical-form implication of lines~1874--1887: every other ingredient
+    of the step is proved.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_displaced_invariant_projector,
+        thm:mpdo_cyclic_projector_reduction}
+    A nontrivial $p$-periodic vector supplies the invariant, displaced
+    projector of Theorem~\ref{thm:mpdo_displaced_invariant_projector}; the
+    non-commutation hypothesis upgrades the displacement to the all-length
+    non-commutation family, so periodic vectors supply cyclic projectors
+    and Theorem~\ref{thm:mpdo_cyclic_projector_reduction} applies.
 \end{proof}
 
 \begin{theorem}[Positive trace of nonzero positive semidefinite matrices]

--- a/docs/paper-gaps/cpgsv17_periodic_sector_projector.tex
+++ b/docs/paper-gaps/cpgsv17_periodic_sector_projector.tex
@@ -74,6 +74,16 @@ content of the formalized step is the projector exclusion of item~2, and
 the hypothesis of item~3 is the named interface for the missing
 construction.
 
+The construction itself is now formalized up to its final family: from the
+corner data of a nontrivial vertical period, the cyclic decomposition of
+the peripheral spectrum produces an orthogonal projector on the physical
+space that is one-sided invariant for every full-period vertical word and
+fails the single-letter invariance
+(\leanid{MPOTensor.exists\_displaced\_invariant\_projector\_of\_periodic\_vector},
+in \path{TNLean/MPS/MPDO/CyclicProjector.lean}).  What the source
+additionally asserts — and what remains open — is that this single-letter
+displacement forces $QH^{(N)}\ne H^{(N)}Q$ at \emph{every} length.
+
 \section{Elimination plan}
 
 The intended derivation of the hypothesis from the positivity assumption
@@ -112,19 +122,49 @@ $p$-periodic vector supplies an orthogonal projector that is one-sided
 invariant for every length-$p$ vertical word and fails to commute with
 $H^{(N)}$ at every length
 (\leanid{MPOTensor.PeriodicVectorYieldsCyclicProjector},
-\leanid{MPOTensor.periodicVectorYieldsProjector\_of\_cyclic}).  What
-remains open is item~1's output in this form: producing, from a nontrivial
-vertical period, the invariant projector together with the all-length
-non-commutation family.  Once that is proved from global positivity, the
-conditional exclusion becomes the unconditional statement asserted by the
-source, and this note can be retired.
+\leanid{MPOTensor.periodicVectorYieldsProjector\_of\_cyclic}).
+
+Item~1 is now formalized in
+\path{TNLean/MPS/MPDO/CyclicProjector.lean}.  The rescaled unital gauge of
+the corner satisfies the hypotheses of the cyclic decomposition
+(\leanid{MPSTensor.spectralUnitalGauge\_schwarz\_setup}; the gauge
+preserves irreducibility by
+\leanid{MPSTensor.isIrreducibleTensor\_smul\_conj}, through the support
+projection of the transported invariant subspace).  The letter-level shift
+of the cyclic projections, $K_vP_{k+1}=P_kK_v$, is derived in
+\path{TNLean/Channel/Peripheral/CyclicDecomposition/LetterShift.lean}
+(\leanid{MPSTensor.kraus\_mul\_cyclicProj},
+\leanid{MPSTensor.evalWord\_mul\_cyclicProj}).  Transporting one cyclic
+sector through the isometry and the square root of the transfer
+eigenvector and taking the complement of its support projection yields an
+orthogonal projector on the physical space that is one-sided invariant for
+every full-period vertical word and fails single-letter invariance,
+$Q\widetilde M\ne Q\widetilde MQ$
+(\leanid{MPOTensor.exists\_displaced\_invariant\_projector\_of\_periodic\_vector}).
+
+What remains open is the all-length non-commutation family: the source
+asserts $QH^{(N)}\ne H^{(N)}Q$ for every $N$, which does not follow from
+the single-letter displacement alone.  This is where the horizontal
+canonical form enters: the proposition assumes the tensor is in canonical
+form horizontally, and the argument of lines~1874--1887 (Lemma~L of the
+appendix) turns all-length commutation into the letter-level invariance
+that the displacement forbids.  This implication is recorded as the
+hypothesis \leanid{MPOTensor.NoninvariantProjectorNoncommuting}; granted
+it, the cyclic-projector hypothesis follows
+(\leanid{MPOTensor.periodicVectorYieldsCyclicProjector\_of\_noncommutation}).
+Once the implication is proved from a horizontal canonical form, the
+conditional exclusion becomes the statement asserted by the source, and
+this note can be retired.
 
 \paragraph{Verdict.}
-This is an open gap: the projector exclusion (the positivity part of the
-source paragraph) and the stacked-layers reduction of the commutation
-family are formalized unconditionally, while the passage from a nontrivial
-vertical period to the invariant, non-commuting projector remains a stated
-hypothesis.
+This is an open gap, now narrowed to a single implication: the projector
+exclusion (the positivity part of the source paragraph), the
+stacked-layers reduction of the commutation family, and the construction
+of the invariant, displaced projector from the cyclic decomposition of the
+peripheral spectrum are formalized unconditionally.  The remaining stated
+hypothesis is that a projector displaced by the vertically viewed tensor
+cannot commute with $H^{(N)}$ at any length — the canonical-form step of
+lines~1874--1887.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
Partially addresses #3674 (stage 2 of the formalization target: excluding nontrivial vertical periods, arXiv:1606.00608, lines 1888–1893).

## What this does

Constructs, sorry-free, the orthogonal projector that the periodic-sector step of the proof of Proposition 4.13 draws from the general theory of the peripheral spectrum, and reduces the remaining hypothesis of that step to the canonical-form implication of lines 1874–1887.

Building on #3736 (`PeriodicVectorYieldsCyclicProjector`: word invariance after `p` vertical layers plus the all-length non-commutation family), this PR proves the word-invariance half and the single-letter displacement unconditionally:

- **`TNLean/Channel/Peripheral/CyclicDecomposition/LetterShift.lean`** (new): letter-level consequences of the cyclic decomposition (Wolf 2012, Thm 6.6). For orthogonal projections `P 0, …, P (m-1)` summing to `1` with `E(P (k+1)) = P k`: mutual orthogonality (`orthogonalProjection_mul_eq_zero_of_sum_eq_one`), the Kraus-operator shift `K v * P (k+1) = P k * K v` (`kraus_mul_cyclicProj`), the word-level shift `evalWord K w * P k = P (k - w.length) * evalWord K w` (`evalWord_mul_cyclicProj`), and nonvanishing of every cyclic projection (`cyclicProj_ne_zero`).
- **`TNLean/MPS/Irreducible/FixedPointProjection.lean`**: range factorization of the support projection (`exists_supportProj_eq_mul`: `supportProj ρ = ρ * W` for a spectral pseudo-inverse), `supportProj (Y * Yᴴ) * Y = Y` (`supportProj_mul_left_eq_self`), and the invariance transfer `one_sub_supportProj_mul_mul_supportProj_eq_zero` (from `A * Y = Y * G` to `(1 - π) * A * π = 0`).
- **`TNLean/MPS/MPDO/CyclicProjector.lean`** (new):
  - `MPSTensor.isIrreducibleTensor_smul_conj` — tensor irreducibility is preserved by rescaled conjugation with an invertible matrix (via the support projection of the transported invariant subspace);
  - `MPSTensor.spectralUnitalGauge_schwarz_setup` — the rescaled unital gauge of an irreducible corner with a positive definite transfer eigenvector is a unital Kraus family with irreducible transfer map and a positive definite adjoint fixed point (the hypotheses of the cyclic decomposition);
  - `MPSTensor.hasEigenvalue_transferMap_spectralUnitalGauge` — transfer eigenvalues `μ` of the corner become `μ/r` for the gauge;
  - `MPOTensor.exists_displaced_invariant_projector_of_periodic_vector` — **main construction**: a nontrivial periodic vector of the vertically viewed tensor supplies `p ≥ 1` and an orthogonal projector `Q` on the physical space with `Q * A_w = Q * A_w * Q` for every length-`p` vertical word and `M.ketLeftMul Q ≠ (M.ketLeftMul Q).braRightMul Q` (single-letter displacement);
  - `MPOTensor.NoninvariantProjectorNoncommuting` — the narrowed hypothesis: a displaced projector fails to commute with `H^(N)` at every length (the horizontal-canonical-form step of lines 1874–1887);
  - `MPOTensor.periodicVectorYieldsCyclicProjector_of_noncommutation`, `MPOTensor.hasNoPeriodicVectors_verticalTensor_of_noncommutation` — the reduction chain to the periodic-vector exclusion.

## Residual gap

The all-length non-commutation family does not follow from the displacement alone: this is where the source uses the horizontal canonical form (Lemma L, lines 1874–1887). The narrowed hypothesis `NoninvariantProjectorNoncommuting` records exactly that implication. The paper-gap note `docs/paper-gaps/cpgsv17_periodic_sector_projector.tex` is updated with the narrowed verdict and the elimination plan.

## Blueprint

- ch07: `lem:kraus_cyclic_shift` (letter shift, `\leanok`).
- ch09: `lem:support_proj_range_factorization`, `thm:irreducible_tensor_smul_conj`, `thm:spectral_unital_gauge_schwarz_setup`, `lem:eigenvalue_transport_unital_gauge` (all `\leanok`).
- ch20: `thm:mpdo_displaced_invariant_projector`, `def:mpdo_noninvariant_projector_noncommuting`, `thm:mpdo_cyclic_projector_of_noncommutation` (all `\leanok`); prose of `def:mpdo_periodic_vector_yields_projector` updated to the narrowed status. The capstone `thm:vertical_cf_of_horizontal_cf` stays `\notready`.

## Verification

- `lake build` clean; no `sorry`/`axiom`; `#print axioms` on all new declarations: `[propext, Classical.choice, Quot.sound]`.
- `lake exe lint_style` clean on changed files.
- `leanblueprint checkdecls` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new Lean proofs on the MPDO periodic-exclusion path; correctness hinges on formal math rather than runtime behavior. The main residual claim is explicitly a named hypothesis, not silently assumed proved.
> 
> **Overview**
> This PR **formalizes the periodic-sector projector** from Wolf’s cyclic decomposition (arXiv:1606.00608, Prop. 4.13) and **narrows the remaining open step** to a single canonical-form implication.
> 
> **Channel / cyclic infrastructure:** Adds `LetterShift.lean` with Kraus letter- and word-level cyclic shifts (`kraus_mul_cyclicProj`, `evalWord_mul_cyclicProj`, etc.) and centralizes mutual orthogonality of projections summing to `1` in `orthogonalProjection_mul_eq_zero_of_sum_eq_one` (replacing a duplicated proof in `ProjectionOrtho.lean`).
> 
> **Support projection tooling:** Extends `FixedPointProjection.lean` with range factorization and invariance transfer (`exists_supportProj_eq_mul`, `one_sub_supportProj_mul_mul_supportProj_eq_zero`), used when rescaled conjugation preserves tensor irreducibility.
> 
> **MPDO capstone (`CyclicProjector.lean`):** From nontrivial vertical periodic corner data, proves **unconditionally** an orthogonal projector `Q` with **full-period word invariance** and **single-letter displacement** (`exists_displaced_invariant_projector_of_periodic_vector`), via spectral unital gauge + cyclic decomposition. Records the still-missing horizontal step as **`NoninvariantProjectorNoncommuting`** and chains it to `PeriodicVectorYieldsCyclicProjector` / vertical no-periodic-vectors theorems.
> 
> Blueprint (ch07, ch09, ch20) and `docs/paper-gaps/cpgsv17_periodic_sector_projector.tex` are updated to match the narrowed gap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d0abbe34af159addde16bedbc9f8fe84543794d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->