### PR TITLE
feat(Channel): a fixed point of maximal support (Wolf Section 6.4; unrestricted Cor 6.7 conjugation)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -171,6 +171,7 @@ import TNLean.Channel.FixedPoint.Cesaro
 import TNLean.Channel.FixedPoint.CornerAlgebra
 import TNLean.Channel.FixedPoint.CornerBlockForm
 import TNLean.Channel.FixedPoint.CornerFixedPoints
+import TNLean.Channel.FixedPoint.MaximalSupport
 import TNLean.Channel.FixedPoint.StationarySupport
 import TNLean.Channel.FixedPoint.WedderburnDecomp
 import TNLean.Channel.FixedPoint.WeightedCornerFixedPoints

--- a/TNLean/Channel/FixedPoint/MaximalSupport.lean
+++ b/TNLean/Channel/FixedPoint/MaximalSupport.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.FixedPoint.WeightedCornerFixedPoints
+import TNLean.MPS.Core.CPPrimitive
 import TNLean.Channel.FixedPoint.Cesaro
 
 /-!
@@ -16,9 +17,8 @@ property of fixed points stated in Section 6.4 of *Quantum Channels & Operations
 the fixed-point space to the identity; the construction here instead sums the positive
 parts of a basis of the fixed-point space, so that every fixed point is a linear
 combination of positive fixed points dominated by $\rho_0$, and domination transfers the
-support:
-$$0 \preceq P \preceq \rho \;\Longrightarrow\; Q\,P = P = P\,Q,$$
-for $Q$ the support projection of $\rho$.
+support: for $Q$ the support projection of $\rho$,
+$$0 \preceq P \preceq \rho \;\Longrightarrow\; Q\,P = P = P\,Q.$$
 
 Instantiating the weighted corner fixed points at $\rho_0$ removes the corner-support
 restriction: conjugation by $\sqrt{\rho_0}$ maps the weighted corner star-algebra
@@ -109,23 +109,12 @@ theorem stationaryProj_absorb_of_le {ρ P : Mat} (hρ_psd : ρ.PosSemidef)
   have h := congrArg Matrix.conjTranspose hQP
   rwa [Matrix.conjTranspose_mul, hQherm, hP_psd.isHermitian.eq] at h
 
-/-- The transfer map of a trace-preserving Kraus family is a quantum channel: it is
-completely positive by its Kraus form and trace-preserving because
-$\sum_i K_i^\dagger K_i = \mathbf 1$. -/
+/-- The transfer map of a trace-preserving Kraus family is a quantum channel; the
+trace-preservation hypothesis is the normalization of the channel form of the transfer
+map (`MPSTensor.transferMap_isChannel`). -/
 theorem isChannel_transferMap (K : Fin d → Mat) (h_tp : IsTP K) :
-    IsChannel (MPSTensor.transferMap (d := d) (D := D) K) := by
-  constructor
-  · exact ⟨d, K, fun X => by simp [MPSTensor.transferMap_apply]⟩
-  · intro X
-    calc Matrix.trace (MPSTensor.transferMap (d := d) (D := D) K X)
-        = ∑ i : Fin d, Matrix.trace (K i * X * (K i)ᴴ) := by
-          rw [MPSTensor.transferMap_apply, Matrix.trace_sum]
-      _ = ∑ i : Fin d, Matrix.trace ((K i)ᴴ * K i * X) := by
-          refine Finset.sum_congr rfl fun i _ => ?_
-          rw [Matrix.trace_mul_cycle]
-      _ = Matrix.trace ((∑ i : Fin d, (K i)ᴴ * K i) * X) := by
-          rw [Matrix.sum_mul, Matrix.trace_sum]
-      _ = Matrix.trace X := by rw [h_tp, Matrix.one_mul]
+    IsChannel (MPSTensor.transferMap (d := d) (D := D) K) :=
+  MPSTensor.transferMap_isChannel K h_tp
 
 /-- **A fixed point of maximal support.** For a trace-preserving Kraus map $T$ there is a
 positive semidefinite fixed point $\rho_0$ whose support carries every fixed point:
@@ -290,9 +279,8 @@ that every fixed point $X$ of $T$ arises as $X = \sqrt{\rho_0}\, Y \sqrt{\rho_0}
 corner-supported $Y$ with $\sqrt{\rho_0}\, Y \sqrt{\rho_0}$ fixed by $T$: conjugation by
 $\sqrt{\rho_0}$ maps the carrier of the weighted corner star-subalgebra
 (`Kraus.weightedCornerFixedPointsStarSubalgebra`) onto the full fixed-point set, so that
-set realizes
-$$\rho_0^{-1/2}\,\{X \mid T(X) = X\}\,\rho_0^{-1/2},$$
-with the inverse square root taken on the support of $\rho_0$. This is the conjugated
+set realizes, with the inverse square root taken on the support of $\rho_0$,
+$$\rho_0^{-1/2}\,\{X \mid T(X) = X\}\,\rho_0^{-1/2}.$$ This is the conjugated
 fixed-point set of Corollary 6.7 of *Quantum Channels & Operations* (Wolf 2012), at a
 fixed point of maximal support; after normalization $\rho_0$ is a fixed-point density
 matrix of maximum rank, as in the corollary. -/

--- a/TNLean/Channel/FixedPoint/MaximalSupport.lean
+++ b/TNLean/Channel/FixedPoint/MaximalSupport.lean
@@ -56,13 +56,12 @@ hence $(\mathbf 1 - Q)\sqrt{P} = 0$ and $(\mathbf 1 - Q)P = 0$. -/
 theorem stationaryProj_absorb_of_le {ρ P : Mat} (hρ_psd : ρ.PosSemidef)
     (hP_psd : P.PosSemidef) (hle : P ≤ ρ) :
     stationaryProj hρ_psd * P = P ∧ P * stationaryProj hρ_psd = P := by
-  set Q : Mat := stationaryProj hρ_psd with hQdef
+  set Q : Mat := stationaryProj hρ_psd
   have hQproj : IsOrthogonalProjection Q := isOrthogonalProjection_stationaryProj hρ_psd
   have hQherm : Qᴴ = Q := hQproj.1.eq
   have h1Q : (1 - Q)ᴴ = 1 - Q := by
     rw [Matrix.conjTranspose_sub, Matrix.conjTranspose_one, hQherm]
   have hQρ : Q * ρ = ρ := MPSTensor.supportProj_mul (D := D) (ρ := ρ) hρ_psd
-  have hρQ : ρ * Q = ρ := MPSTensor.mul_supportProj (D := D) (ρ := ρ) hρ_psd
   -- The corner of `ρ` on the complement of the support vanishes.
   have hρ0 : (1 - Q) * ρ * (1 - Q) = 0 := by
     have h : (1 - Q) * ρ = 0 := by
@@ -164,14 +163,14 @@ theorem exists_maximalSupport_fixedPoint (K : Fin d → Mat) (h_tp : IsTP K) :
   have hSmem : ∀ X : Mat, X ∈ S ↔ map K X = X := by
     intro X
     rw [hSdef, Module.End.mem_eigenspace_iff, one_smul, hEK]
-  set m : ℕ := Module.finrank ℂ ↥S with hmdef
-  set b : Module.Basis (Fin m) ℂ ↥S := Module.finBasis ℂ ↥S with hbdef
+  set m : ℕ := Module.finrank ℂ ↥S
+  set b : Module.Basis (Fin m) ℂ ↥S := Module.finBasis ℂ ↥S
   -- The Hermitian and anti-Hermitian components of the basis vectors are fixed.
   have hbfix : ∀ j : Fin m, map K ((b j : Mat)) = (b j : Mat) := fun j => (hSmem _).mp (b j).2
   have hbHfix : ∀ j : Fin m, map K ((b j : Mat))ᴴ = ((b j : Mat))ᴴ := fun j =>
     conjTranspose_mem_fixedPoints (K := K) (hbfix j)
-  set H₁ : Fin m → Mat := fun j => (b j : Mat) + (b j : Mat)ᴴ with hH₁def
-  set H₂ : Fin m → Mat := fun j => Complex.I • ((b j : Mat) - (b j : Mat)ᴴ) with hH₂def
+  set H₁ : Fin m → Mat := fun j => (b j : Mat) + (b j : Mat)ᴴ
+  set H₂ : Fin m → Mat := fun j => Complex.I • ((b j : Mat) - (b j : Mat)ᴴ)
   have hH₁herm : ∀ j, (H₁ j).IsHermitian := by
     intro j
     show ((b j : Mat) + (b j : Mat)ᴴ)ᴴ = (b j : Mat) + (b j : Mat)ᴴ
@@ -207,7 +206,7 @@ theorem exists_maximalSupport_fixedPoint (K : Fin d → Mat) (h_tp : IsTP K) :
   choose P₁p P₁m hP₁p hP₁m hH₁eq hf₁p hf₁m using fun j => hpos (H₁ j) (hH₁herm j) (hH₁fix j)
   choose P₂p P₂m hP₂p hP₂m hH₂eq hf₂p hf₂m using fun j => hpos (H₂ j) (hH₂herm j) (hH₂fix j)
   -- The maximal fixed point: the sum of all the positive parts.
-  set g : Fin m → Mat := fun j => P₁p j + P₁m j + P₂p j + P₂m j with hgdef
+  set g : Fin m → Mat := fun j => P₁p j + P₁m j + P₂p j + P₂m j
   have hg_nonneg : ∀ j, (0 : Mat) ≤ g j := by
     intro j
     show (0 : Mat) ≤ P₁p j + P₁m j + P₂p j + P₂m j
@@ -223,7 +222,7 @@ theorem exists_maximalSupport_fixedPoint (K : Fin d → Mat) (h_tp : IsTP K) :
     rw [E.map_add, E.map_add, E.map_add, hEK, hEK, hEK, hEK,
       hf₁p j, hf₁m j, hf₂p j, hf₂m j]
   refine ⟨ρ₀, hρ₀psd, hρ₀fix, ?_⟩
-  set Q₀ : Mat := stationaryProj hρ₀psd with hQ₀def
+  set Q₀ : Mat := stationaryProj hρ₀psd
   -- Every positive part is dominated by the sum, so the support projection absorbs it.
   have hg_le : ∀ j, g j ≤ ρ₀ := fun j =>
     Finset.single_le_sum (fun i _ => hg_nonneg i) (Finset.mem_univ j)

--- a/TNLean/Channel/FixedPoint/MaximalSupport.lean
+++ b/TNLean/Channel/FixedPoint/MaximalSupport.lean
@@ -280,8 +280,7 @@ $\sqrt{\rho_0}$ maps the carrier of the weighted corner star-subalgebra
 set realizes, with the inverse square root taken on the support of $\rho_0$,
 $$\rho_0^{-1/2}\,\{X \mid T(X) = X\}\,\rho_0^{-1/2}.$$ This is the conjugated
 fixed-point set of Corollary 6.7 of *Quantum Channels & Operations* (Wolf 2012), at a
-fixed point of maximal support; after normalization $\rho_0$ is a fixed-point density
-matrix of maximum rank, as in the corollary. -/
+fixed point of maximal support. -/
 theorem exists_maximalSupport_weightedCorner_sqrt_eq (K : Fin d → Mat) (h_tp : IsTP K) :
     ∃ (ρ₀ : Mat) (hρ₀ : ρ₀.PosSemidef), map K ρ₀ = ρ₀ ∧
       ∀ X : Mat, map K X = X →

--- a/TNLean/Channel/FixedPoint/MaximalSupport.lean
+++ b/TNLean/Channel/FixedPoint/MaximalSupport.lean
@@ -21,8 +21,8 @@ $$0 \preceq P \preceq \rho \;\Longrightarrow\; Q\,P = P = P\,Q,$$
 for $Q$ the support projection of $\rho$.
 
 Instantiating the weighted corner fixed points at $\rho_0$ removes the corner-support
-restriction: conjugation by $\sqrt{\rho_0}$ maps the corner star-algebra of
-`Kraus.weightedCornerFixedPointsStarSubalgebra` onto the full fixed-point set of $T$,
+restriction: conjugation by $\sqrt{\rho_0}$ maps the weighted corner star-algebra
+(`Kraus.weightedCornerFixedPointsStarSubalgebra`) onto the full fixed-point set of $T$,
 which is the set $\rho_0^{-1/2}\,\{X \mid T(X) = X\}\,\rho_0^{-1/2}$ of Corollary 6.7 of
 *Quantum Channels & Operations* (Wolf 2012), with the inverse square root taken on the
 support of $\rho_0$.

--- a/TNLean/Channel/FixedPoint/MaximalSupport.lean
+++ b/TNLean/Channel/FixedPoint/MaximalSupport.lean
@@ -125,9 +125,7 @@ image of the identity under the projection onto the fixed-point space, while her
 $\rho_0$ is the sum of the positive parts of the Hermitian and anti-Hermitian components
 of a basis of the fixed-point space. Every fixed point is then a linear combination of
 positive semidefinite fixed points dominated by $\rho_0$ in the Loewner order, and
-domination transfers the support (`Kraus.stationaryProj_absorb_of_le`). In particular
-$\rho_0$ has maximal rank among the positive semidefinite fixed points, and after
-normalization it is a fixed-point density matrix of maximum rank. -/
+domination transfers the support (`Kraus.stationaryProj_absorb_of_le`). -/
 theorem exists_maximalSupport_fixedPoint (K : Fin d → Mat) (h_tp : IsTP K) :
     ∃ (ρ₀ : Mat) (hρ₀ : ρ₀.PosSemidef), map K ρ₀ = ρ₀ ∧
       ∀ X : Mat, map K X = X →

--- a/TNLean/Channel/FixedPoint/MaximalSupport.lean
+++ b/TNLean/Channel/FixedPoint/MaximalSupport.lean
@@ -289,8 +289,8 @@ theorem exists_maximalSupport_fixedPoint (K : Fin d → Mat) (h_tp : IsTP K) :
 trace-preserving Kraus map $T$ there is a positive semidefinite fixed point $\rho_0$ such
 that every fixed point $X$ of $T$ arises as $X = \sqrt{\rho_0}\, Y \sqrt{\rho_0}$ for a
 corner-supported $Y$ with $\sqrt{\rho_0}\, Y \sqrt{\rho_0}$ fixed by $T$: conjugation by
-$\sqrt{\rho_0}$ maps the carrier of the star-subalgebra
-`Kraus.weightedCornerFixedPointsStarSubalgebra` onto the full fixed-point set, so that
+$\sqrt{\rho_0}$ maps the carrier of the weighted corner star-subalgebra
+(`Kraus.weightedCornerFixedPointsStarSubalgebra`) onto the full fixed-point set, so that
 set realizes
 $$\rho_0^{-1/2}\,\{X \mid T(X) = X\}\,\rho_0^{-1/2},$$
 with the inverse square root taken on the support of $\rho_0$. This is the conjugated

--- a/TNLean/Channel/FixedPoint/MaximalSupport.lean
+++ b/TNLean/Channel/FixedPoint/MaximalSupport.lean
@@ -1,0 +1,310 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Channel.FixedPoint.WeightedCornerFixedPoints
+import TNLean.Channel.FixedPoint.Cesaro
+
+/-!
+# A fixed point of maximal support
+
+For a trace-preserving Kraus map $T$ there is a positive semidefinite fixed point
+$\rho_0$ whose support carries every fixed point: $Q_0 X Q_0 = X$ for every fixed point
+$X$ of $T$, where $Q_0$ is the support projection of $\rho_0$. This is the maximal-support
+property of fixed points stated in Section 6.4 of *Quantum Channels & Operations*
+(Wolf 2012), there in terms of the fixed point obtained by applying the projection onto
+the fixed-point space to the identity; the construction here instead sums the positive
+parts of a basis of the fixed-point space, so that every fixed point is a linear
+combination of positive fixed points dominated by $\rho_0$, and domination transfers the
+support:
+$$0 \preceq P \preceq \rho \;\Longrightarrow\; Q\,P = P = P\,Q,$$
+for $Q$ the support projection of $\rho$.
+
+Instantiating the weighted corner fixed points at $\rho_0$ removes the corner-support
+restriction: conjugation by $\sqrt{\rho_0}$ maps the corner star-algebra of
+`Kraus.weightedCornerFixedPointsStarSubalgebra` onto the full fixed-point set of $T$,
+which is the set $\rho_0^{-1/2}\,\{X \mid T(X) = X\}\,\rho_0^{-1/2}$ of Corollary 6.7 of
+*Quantum Channels & Operations* (Wolf 2012), with the inverse square root taken on the
+support of $\rho_0$.
+
+## Main results
+
+* `Kraus.stationaryProj_absorb_of_le` -- Loewner domination transfers the support: for
+  positive semidefinite $P \preceq \rho$, the support projection of $\rho$ absorbs $P$.
+* `Kraus.exists_maximalSupport_fixedPoint` -- a positive semidefinite fixed point whose
+  support carries every fixed point.
+* `Kraus.exists_maximalSupport_weightedCorner_sqrt_eq` -- at such a fixed point,
+  conjugation by the square root maps the weighted corner carrier onto the full
+  fixed-point set.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder BigOperators
+open Matrix Finset Complex
+
+namespace Kraus
+
+variable {d D : ℕ}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+/-- **Loewner domination transfers the support.** For positive semidefinite matrices
+$P \preceq \rho$, the support projection $Q$ of $\rho$ absorbs $P$:
+$Q P = P$ and $P Q = P$. From $(\mathbf 1 - Q)\rho = 0$ and
+$0 \preceq (\mathbf 1 - Q) P (\mathbf 1 - Q) \preceq (\mathbf 1 - Q) \rho (\mathbf 1 - Q)
+= 0$ one gets $(\mathbf 1 - Q)\sqrt{P}\,\bigl((\mathbf 1 - Q)\sqrt{P}\bigr)^{\dagger} = 0$,
+hence $(\mathbf 1 - Q)\sqrt{P} = 0$ and $(\mathbf 1 - Q)P = 0$. -/
+theorem stationaryProj_absorb_of_le {ρ P : Mat} (hρ_psd : ρ.PosSemidef)
+    (hP_psd : P.PosSemidef) (hle : P ≤ ρ) :
+    stationaryProj hρ_psd * P = P ∧ P * stationaryProj hρ_psd = P := by
+  set Q : Mat := stationaryProj hρ_psd with hQdef
+  have hQproj : IsOrthogonalProjection Q := isOrthogonalProjection_stationaryProj hρ_psd
+  have hQherm : Qᴴ = Q := hQproj.1.eq
+  have h1Q : (1 - Q)ᴴ = 1 - Q := by
+    rw [Matrix.conjTranspose_sub, Matrix.conjTranspose_one, hQherm]
+  have hQρ : Q * ρ = ρ := MPSTensor.supportProj_mul (D := D) (ρ := ρ) hρ_psd
+  have hρQ : ρ * Q = ρ := MPSTensor.mul_supportProj (D := D) (ρ := ρ) hρ_psd
+  -- The corner of `ρ` on the complement of the support vanishes.
+  have hρ0 : (1 - Q) * ρ * (1 - Q) = 0 := by
+    have h : (1 - Q) * ρ = 0 := by
+      rw [Matrix.sub_mul, Matrix.one_mul, hQρ, sub_self]
+    rw [h, Matrix.zero_mul]
+  -- Hence so does the corner of the dominated `P`.
+  have hP0 : (1 - Q) * P * (1 - Q) = 0 := by
+    have hupper : (1 - Q) * P * (1 - Q) ≤ 0 := by
+      have hconj : (1 - Q) * P * (1 - Q) ≤ (1 - Q) * ρ * (1 - Q) := by
+        rw [← sub_nonneg] at hle ⊢
+        have hpsd : ((1 - Q)ᴴ * (ρ - P) * (1 - Q)).PosSemidef :=
+          (hle.posSemidef).conjTranspose_mul_mul_same (1 - Q)
+        rw [h1Q] at hpsd
+        have heq : (1 - Q) * ρ * (1 - Q) - (1 - Q) * P * (1 - Q) =
+            (1 - Q) * (ρ - P) * (1 - Q) := by
+          rw [mul_sub (1 - Q) ρ P, sub_mul ((1 - Q) * ρ) ((1 - Q) * P) (1 - Q)]
+        rw [heq]
+        exact hpsd.nonneg
+      calc (1 - Q) * P * (1 - Q) ≤ (1 - Q) * ρ * (1 - Q) := hconj
+        _ = 0 := hρ0
+    have hlower : (0 : Mat) ≤ (1 - Q) * P * (1 - Q) := by
+      have : ((1 - Q)ᴴ * P * (1 - Q)).PosSemidef :=
+        hP_psd.conjTranspose_mul_mul_same (1 - Q)
+      rw [h1Q] at this
+      exact this.nonneg
+    exact le_antisymm hupper hlower
+  -- Vanishing corner of a positive semidefinite matrix forces the whole row to vanish.
+  have hS_herm : (CFC.sqrt P)ᴴ = CFC.sqrt P := MPSTensor.conjTranspose_cfc_sqrt (D := D) P
+  have hSS : CFC.sqrt P * CFC.sqrt P = P := CFC.sqrt_mul_sqrt_self P hP_psd.nonneg
+  have hM0 : ((1 - Q) * CFC.sqrt P) * ((1 - Q) * CFC.sqrt P)ᴴ = 0 := by
+    rw [Matrix.conjTranspose_mul, hS_herm, h1Q]
+    calc (1 - Q) * CFC.sqrt P * (CFC.sqrt P * (1 - Q))
+        = (1 - Q) * (CFC.sqrt P * CFC.sqrt P) * (1 - Q) := by simp [Matrix.mul_assoc]
+      _ = (1 - Q) * P * (1 - Q) := by rw [hSS]
+      _ = 0 := hP0
+  have hMsqrt : (1 - Q) * CFC.sqrt P = 0 := Matrix.self_mul_conjTranspose_eq_zero.mp hM0
+  have hQP : Q * P = P := by
+    have h : (1 - Q) * P = 0 := by
+      calc (1 - Q) * P = ((1 - Q) * CFC.sqrt P) * CFC.sqrt P := by
+            rw [Matrix.mul_assoc, hSS]
+        _ = 0 := by rw [hMsqrt, Matrix.zero_mul]
+    rw [Matrix.sub_mul, Matrix.one_mul] at h
+    exact (sub_eq_zero.mp h).symm
+  refine ⟨hQP, ?_⟩
+  have h := congrArg Matrix.conjTranspose hQP
+  rwa [Matrix.conjTranspose_mul, hQherm, hP_psd.isHermitian.eq] at h
+
+/-- The transfer map of a trace-preserving Kraus family is a quantum channel: it is
+completely positive by its Kraus form and trace-preserving because
+$\sum_i K_i^\dagger K_i = \mathbf 1$. -/
+theorem isChannel_transferMap (K : Fin d → Mat) (h_tp : IsTP K) :
+    IsChannel (MPSTensor.transferMap (d := d) (D := D) K) := by
+  constructor
+  · exact ⟨d, K, fun X => by simp [MPSTensor.transferMap_apply]⟩
+  · intro X
+    calc Matrix.trace (MPSTensor.transferMap (d := d) (D := D) K X)
+        = ∑ i : Fin d, Matrix.trace (K i * X * (K i)ᴴ) := by
+          rw [MPSTensor.transferMap_apply, Matrix.trace_sum]
+      _ = ∑ i : Fin d, Matrix.trace ((K i)ᴴ * K i * X) := by
+          refine Finset.sum_congr rfl fun i _ => ?_
+          rw [Matrix.trace_mul_cycle]
+      _ = Matrix.trace ((∑ i : Fin d, (K i)ᴴ * K i) * X) := by
+          rw [Matrix.sum_mul, Matrix.trace_sum]
+      _ = Matrix.trace X := by rw [h_tp, Matrix.one_mul]
+
+/-- **A fixed point of maximal support.** For a trace-preserving Kraus map $T$ there is a
+positive semidefinite fixed point $\rho_0$ whose support carries every fixed point:
+$Q_0 X Q_0 = X$ for every $X$ with $T(X) = X$, where $Q_0$ is the support projection of
+$\rho_0$. This is the maximal-support property of fixed points stated in Section 6.4 of
+*Quantum Channels & Operations* (Wolf 2012); the reference exhibits the witness as the
+image of the identity under the projection onto the fixed-point space, while here
+$\rho_0$ is the sum of the positive parts of the Hermitian and anti-Hermitian components
+of a basis of the fixed-point space. Every fixed point is then a linear combination of
+positive semidefinite fixed points dominated by $\rho_0$ in the Loewner order, and
+domination transfers the support (`Kraus.stationaryProj_absorb_of_le`). In particular
+$\rho_0$ has maximal rank among the positive semidefinite fixed points, and after
+normalization it is a fixed-point density matrix of maximum rank. -/
+theorem exists_maximalSupport_fixedPoint (K : Fin d → Mat) (h_tp : IsTP K) :
+    ∃ (ρ₀ : Mat) (hρ₀ : ρ₀.PosSemidef), map K ρ₀ = ρ₀ ∧
+      ∀ X : Mat, map K X = X →
+        stationaryProj hρ₀ * X * stationaryProj hρ₀ = X := by
+  classical
+  set E : Mat →ₗ[ℂ] Mat := MPSTensor.transferMap (d := d) (D := D) K with hEdef
+  have hEK : ∀ X : Mat, E X = map K X := by
+    intro X
+    simp [hEdef, MPSTensor.transferMap_apply, map]
+  have hE : IsChannel E := isChannel_transferMap K h_tp
+  -- Positive parts of a Hermitian fixed point are fixed (Proposition 6.8 of the source).
+  have hpos : ∀ H : Mat, H.IsHermitian → map K H = H →
+      ∃ P₁ P₂ : Mat, P₁.PosSemidef ∧ P₂.PosSemidef ∧ H = P₁ - P₂ ∧
+        map K P₁ = P₁ ∧ map K P₂ = P₂ := by
+    intro H hH hHfix
+    obtain ⟨P₁, P₂, h₁, h₂, hdiff, hf₁, hf₂⟩ :=
+      IsChannel.posSemidef_parts_of_hermitian_fixedPoint E hE hH
+        (by rw [hEK]; exact hHfix)
+    exact ⟨P₁, P₂, h₁, h₂, hdiff, by rw [← hEK]; exact hf₁, by rw [← hEK]; exact hf₂⟩
+  -- A basis of the fixed-point space, the eigenspace of the transfer map at one.
+  set S : Submodule ℂ Mat := Module.End.eigenspace E 1 with hSdef
+  have hSmem : ∀ X : Mat, X ∈ S ↔ map K X = X := by
+    intro X
+    rw [hSdef, Module.End.mem_eigenspace_iff, one_smul, hEK]
+  set m : ℕ := Module.finrank ℂ ↥S with hmdef
+  set b : Module.Basis (Fin m) ℂ ↥S := Module.finBasis ℂ ↥S with hbdef
+  -- The Hermitian and anti-Hermitian components of the basis vectors are fixed.
+  have hbfix : ∀ j : Fin m, map K ((b j : Mat)) = (b j : Mat) := fun j => (hSmem _).mp (b j).2
+  have hbHfix : ∀ j : Fin m, map K ((b j : Mat))ᴴ = ((b j : Mat))ᴴ := fun j =>
+    conjTranspose_mem_fixedPoints (K := K) (hbfix j)
+  set H₁ : Fin m → Mat := fun j => (b j : Mat) + (b j : Mat)ᴴ with hH₁def
+  set H₂ : Fin m → Mat := fun j => Complex.I • ((b j : Mat) - (b j : Mat)ᴴ) with hH₂def
+  have hH₁herm : ∀ j, (H₁ j).IsHermitian := by
+    intro j
+    show ((b j : Mat) + (b j : Mat)ᴴ)ᴴ = (b j : Mat) + (b j : Mat)ᴴ
+    rw [Matrix.conjTranspose_add, Matrix.conjTranspose_conjTranspose]
+    exact add_comm _ _
+  have hH₂herm : ∀ j, (H₂ j).IsHermitian := by
+    intro j
+    show (Complex.I • ((b j : Mat) - (b j : Mat)ᴴ))ᴴ =
+      Complex.I • ((b j : Mat) - (b j : Mat)ᴴ)
+    rw [Matrix.conjTranspose_smul, Matrix.conjTranspose_sub,
+      Matrix.conjTranspose_conjTranspose]
+    rw [show star Complex.I = -Complex.I by simp]
+    rw [neg_smul, ← smul_neg, neg_sub]
+  have hH₁fix : ∀ j, map K (H₁ j) = H₁ j := by
+    intro j
+    show map K ((b j : Mat) + (b j : Mat)ᴴ) = (b j : Mat) + (b j : Mat)ᴴ
+    rw [← hEK, E.map_add, hEK, hEK, hbfix j, hbHfix j]
+  have hH₂fix : ∀ j, map K (H₂ j) = H₂ j := by
+    intro j
+    show map K (Complex.I • ((b j : Mat) - (b j : Mat)ᴴ)) =
+      Complex.I • ((b j : Mat) - (b j : Mat)ᴴ)
+    rw [← hEK, E.map_smul, E.map_sub, hEK, hEK, hbfix j, hbHfix j]
+  -- Each basis vector is a combination of its Hermitian and anti-Hermitian components.
+  have hXj : ∀ j, (b j : Mat) = (2⁻¹ : ℂ) • H₁ j - ((2⁻¹ : ℂ) * Complex.I) • H₂ j := by
+    intro j
+    show (b j : Mat) = (2⁻¹ : ℂ) • ((b j : Mat) + (b j : Mat)ᴴ) -
+      ((2⁻¹ : ℂ) * Complex.I) • (Complex.I • ((b j : Mat) - (b j : Mat)ᴴ))
+    rw [smul_smul,
+      show ((2⁻¹ : ℂ) * Complex.I) * Complex.I = -(2⁻¹ : ℂ) by
+        rw [mul_assoc, Complex.I_mul_I]; ring]
+    module
+  -- Positive parts of the components, all of them fixed points.
+  choose P₁p P₁m hP₁p hP₁m hH₁eq hf₁p hf₁m using fun j => hpos (H₁ j) (hH₁herm j) (hH₁fix j)
+  choose P₂p P₂m hP₂p hP₂m hH₂eq hf₂p hf₂m using fun j => hpos (H₂ j) (hH₂herm j) (hH₂fix j)
+  -- The maximal fixed point: the sum of all the positive parts.
+  set g : Fin m → Mat := fun j => P₁p j + P₁m j + P₂p j + P₂m j with hgdef
+  have hg_nonneg : ∀ j, (0 : Mat) ≤ g j := by
+    intro j
+    show (0 : Mat) ≤ P₁p j + P₁m j + P₂p j + P₂m j
+    exact add_nonneg (add_nonneg (add_nonneg (hP₁p j).nonneg (hP₁m j).nonneg)
+      (hP₂p j).nonneg) (hP₂m j).nonneg
+  set ρ₀ : Mat := ∑ j : Fin m, g j with hρ₀def
+  have hρ₀psd : ρ₀.PosSemidef :=
+    (Finset.sum_nonneg fun j _ => hg_nonneg j).posSemidef
+  have hρ₀fix : map K ρ₀ = ρ₀ := by
+    rw [hρ₀def, ← hEK, _root_.map_sum]
+    refine Finset.sum_congr rfl fun j _ => ?_
+    show E (P₁p j + P₁m j + P₂p j + P₂m j) = g j
+    rw [E.map_add, E.map_add, E.map_add, hEK, hEK, hEK, hEK,
+      hf₁p j, hf₁m j, hf₂p j, hf₂m j]
+  refine ⟨ρ₀, hρ₀psd, hρ₀fix, ?_⟩
+  set Q₀ : Mat := stationaryProj hρ₀psd with hQ₀def
+  -- Every positive part is dominated by the sum, so the support projection absorbs it.
+  have hg_le : ∀ j, g j ≤ ρ₀ := fun j =>
+    Finset.single_le_sum (fun i _ => hg_nonneg i) (Finset.mem_univ j)
+  have habsorb : ∀ (P : Mat), P.PosSemidef → P ≤ ρ₀ → Q₀ * P * Q₀ = P := by
+    intro P hP hle
+    obtain ⟨hQP, hPQ⟩ := stationaryProj_absorb_of_le hρ₀psd hP hle
+    rw [Matrix.mul_assoc, hPQ, hQP]
+  have hle₁p : ∀ j, P₁p j ≤ ρ₀ := by
+    intro j
+    refine le_trans (show P₁p j ≤ g j from ?_) (hg_le j)
+    calc P₁p j ≤ P₁p j + P₁m j := le_add_of_nonneg_right (hP₁m j).nonneg
+      _ ≤ P₁p j + P₁m j + P₂p j := le_add_of_nonneg_right (hP₂p j).nonneg
+      _ ≤ P₁p j + P₁m j + P₂p j + P₂m j := le_add_of_nonneg_right (hP₂m j).nonneg
+  have hle₁m : ∀ j, P₁m j ≤ ρ₀ := by
+    intro j
+    refine le_trans (show P₁m j ≤ g j from ?_) (hg_le j)
+    calc P₁m j ≤ P₁p j + P₁m j := le_add_of_nonneg_left (hP₁p j).nonneg
+      _ ≤ P₁p j + P₁m j + P₂p j := le_add_of_nonneg_right (hP₂p j).nonneg
+      _ ≤ P₁p j + P₁m j + P₂p j + P₂m j := le_add_of_nonneg_right (hP₂m j).nonneg
+  have hle₂p : ∀ j, P₂p j ≤ ρ₀ := by
+    intro j
+    refine le_trans (show P₂p j ≤ g j from ?_) (hg_le j)
+    calc P₂p j ≤ P₁p j + P₁m j + P₂p j := le_add_of_nonneg_left
+          (add_nonneg (hP₁p j).nonneg (hP₁m j).nonneg)
+      _ ≤ P₁p j + P₁m j + P₂p j + P₂m j := le_add_of_nonneg_right (hP₂m j).nonneg
+  have hle₂m : ∀ j, P₂m j ≤ ρ₀ := by
+    intro j
+    refine le_trans (show P₂m j ≤ g j from ?_) (hg_le j)
+    exact le_add_of_nonneg_left (add_nonneg (add_nonneg (hP₁p j).nonneg (hP₁m j).nonneg)
+      (hP₂p j).nonneg)
+  -- The support projection absorbs the components, hence the basis vectors.
+  have habsorbH₁ : ∀ j, Q₀ * H₁ j * Q₀ = H₁ j := by
+    intro j
+    rw [hH₁eq j, Matrix.mul_sub, Matrix.sub_mul,
+      habsorb _ (hP₁p j) (hle₁p j), habsorb _ (hP₁m j) (hle₁m j)]
+  have habsorbH₂ : ∀ j, Q₀ * H₂ j * Q₀ = H₂ j := by
+    intro j
+    rw [hH₂eq j, Matrix.mul_sub, Matrix.sub_mul,
+      habsorb _ (hP₂p j) (hle₂p j), habsorb _ (hP₂m j) (hle₂m j)]
+  have hQb : ∀ j, Q₀ * (b j : Mat) * Q₀ = (b j : Mat) := by
+    intro j
+    conv_lhs => rw [hXj j]
+    rw [Matrix.mul_sub, Matrix.sub_mul, Matrix.mul_smul, Matrix.smul_mul,
+      Matrix.mul_smul, Matrix.smul_mul, habsorbH₁ j, habsorbH₂ j, ← hXj j]
+  -- Every fixed point is a combination of the basis vectors, all carried by the support.
+  intro X hX
+  have hXS : X ∈ S := (hSmem X).mpr hX
+  have hrepr : ∑ j : Fin m, b.repr ⟨X, hXS⟩ j • (b j : Mat) = X := by
+    have h := congrArg (Subtype.val) (b.sum_repr ⟨X, hXS⟩)
+    simp only [AddSubmonoidClass.coe_finsetSum, SetLike.val_smul] at h
+    exact h
+  calc Q₀ * X * Q₀
+      = ∑ j : Fin m, b.repr ⟨X, hXS⟩ j • (Q₀ * (b j : Mat) * Q₀) := by
+        conv_lhs => rw [← hrepr]
+        rw [Matrix.mul_sum, Matrix.sum_mul]
+        exact Finset.sum_congr rfl fun j _ => by
+          rw [Matrix.mul_smul, Matrix.smul_mul]
+    _ = ∑ j : Fin m, b.repr ⟨X, hXS⟩ j • (b j : Mat) := by
+        exact Finset.sum_congr rfl fun j _ => by rw [hQb j]
+    _ = X := hrepr
+
+/-- **Conjugation by the square root at a fixed point of maximal support.** For a
+trace-preserving Kraus map $T$ there is a positive semidefinite fixed point $\rho_0$ such
+that every fixed point $X$ of $T$ arises as $X = \sqrt{\rho_0}\, Y \sqrt{\rho_0}$ for a
+corner-supported $Y$ with $\sqrt{\rho_0}\, Y \sqrt{\rho_0}$ fixed by $T$: conjugation by
+$\sqrt{\rho_0}$ maps the carrier of the star-subalgebra
+`Kraus.weightedCornerFixedPointsStarSubalgebra` onto the full fixed-point set, so that
+set realizes
+$$\rho_0^{-1/2}\,\{X \mid T(X) = X\}\,\rho_0^{-1/2},$$
+with the inverse square root taken on the support of $\rho_0$. This is the conjugated
+fixed-point set of Corollary 6.7 of *Quantum Channels & Operations* (Wolf 2012), at a
+fixed point of maximal support; after normalization $\rho_0$ is a fixed-point density
+matrix of maximum rank, as in the corollary. -/
+theorem exists_maximalSupport_weightedCorner_sqrt_eq (K : Fin d → Mat) (h_tp : IsTP K) :
+    ∃ (ρ₀ : Mat) (hρ₀ : ρ₀.PosSemidef), map K ρ₀ = ρ₀ ∧
+      ∀ X : Mat, map K X = X →
+        ∃ Y : Mat, stationaryProj hρ₀ * Y * stationaryProj hρ₀ = Y ∧
+          map K (CFC.sqrt ρ₀ * Y * CFC.sqrt ρ₀) = CFC.sqrt ρ₀ * Y * CFC.sqrt ρ₀ ∧
+          CFC.sqrt ρ₀ * Y * CFC.sqrt ρ₀ = X := by
+  obtain ⟨ρ₀, hρ₀, hfix, hmax⟩ := exists_maximalSupport_fixedPoint K h_tp
+  exact ⟨ρ₀, hρ₀, hfix, fun X hX =>
+    exists_weightedCorner_sqrt_eq_of_fixedPoint K h_tp hρ₀ hfix hX (hmax X hX)⟩
+
+end Kraus

--- a/TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean
+++ b/TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean
@@ -20,16 +20,16 @@ elements $Y$ with $\sqrt{\rho}\, Y \sqrt{\rho}$ fixed by $T$; conjugation by
 $\sqrt{\rho}$ maps this carrier bijectively onto the fixed points of $T$ supported on the
 support of $\rho$, which realizes the displayed set without naming the pseudo-inverse.
 
-**Scope restriction (corner-supported fixed points):** Corollary 6.7 of
-*Quantum Channels & Operations* (Wolf 2012) takes $\rho$ to be a *maximum-rank* fixed-point
-density matrix and conjugates the full fixed-point set of $T$. For a maximum-rank fixed
-point every fixed point of $T$ is supported on the support of $\rho$, so the corner
-restriction is vacuous; that maximal-support property (the proposition on maximal support
-of fixed points in Section 6.4 of the reference) remains to be established here, and the
-present statements restrict to the fixed points supported on the support of $\rho$
-instead. Documented in `docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex`.
-Elimination: establish the maximal-support proposition and instantiate these statements
-at a maximum-rank fixed point.
+Corollary 6.7 of *Quantum Channels & Operations* (Wolf 2012) takes $\rho$ to be a
+*maximum-rank* fixed-point density matrix and conjugates the full fixed-point set of $T$.
+For a fixed point of maximal support the corner restriction $Q X Q = X$ is vacuous: the
+maximal-support property is `Kraus.exists_maximalSupport_fixedPoint` in
+`TNLean.Channel.FixedPoint.MaximalSupport`, and its combination with the results below,
+removing the corner restriction, is `Kraus.exists_maximalSupport_weightedCorner_sqrt_eq`
+there. The statements below take an arbitrary positive semidefinite fixed point, so for a
+non-maximal choice of $\rho$ they conjugate the fixed points supported on the support of
+$\rho$. The resolution of the former restriction is recorded in
+`docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex`.
 
 The proofs compress to the support sector, where the compressed fixed point is positive
 definite and the positive definite case applies, and transport the structure back along
@@ -363,11 +363,12 @@ the support of $\rho$ (`Kraus.exists_weightedCorner_sqrt_eq_of_fixedPoint`), so 
 realizes the set $\rho^{-1/2}\{X \mid T(X) = X,\ Q X Q = X\}\rho^{-1/2}$ of the
 corollary, with the inverse square root taken on the support of $\rho$.
 
-**Scope restriction (corner-supported fixed points):** the corollary in the reference
-takes a maximum-rank fixed point, for which every fixed point of $T$ is supported on the
-support of $\rho$ and the corner restriction disappears; that maximal-support property
-remains to be established here. Documented in
-`docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex`. -/
+The corollary in the reference takes a maximum-rank fixed point, for which every fixed
+point of $T$ is supported on the support of $\rho$ and the corner restriction disappears:
+a fixed point of maximal support is `Kraus.exists_maximalSupport_fixedPoint`, and the
+combination removing the corner restriction is
+`Kraus.exists_maximalSupport_weightedCorner_sqrt_eq`, both in
+`TNLean.Channel.FixedPoint.MaximalSupport`. -/
 noncomputable def weightedCornerFixedPointsStarSubalgebra
     (K : Fin d → Mat) (h_tp : IsTP K) {ρ : Mat} (hρ_psd : ρ.PosSemidef)
     (hρ_fix : map K ρ = ρ) :
@@ -463,12 +464,11 @@ the carrier with the set $\rho^{-1/2}\{X \mid T(X) = X,\ Q X Q = X\}\rho^{-1/2}$
 Corollary 6.7 of *Quantum Channels & Operations* (Wolf 2012), with the inverse square
 root taken on the support of $\rho$.
 
-**Scope restriction (corner support):** the source's corollary takes a maximum-rank
-fixed point, for which the support condition on $X$ is automatic by the maximal-support
-property; that property has not yet been established here, so the statement carries the
-support
-hypothesis explicitly. Documented in
-`docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex`. -/
+The source's corollary takes a maximum-rank fixed point, for which the support condition
+on $X$ is automatic by the maximal-support property
+(`Kraus.exists_maximalSupport_fixedPoint` in `TNLean.Channel.FixedPoint.MaximalSupport`);
+at such a fixed point the combination without the support hypothesis is
+`Kraus.exists_maximalSupport_weightedCorner_sqrt_eq`. -/
 theorem exists_weightedCorner_sqrt_eq_of_fixedPoint
     (K : Fin d → Mat) (h_tp : IsTP K) {ρ : Mat} (hρ_psd : ρ.PosSemidef)
     (hρ_fix : map K ρ = ρ) {X : Mat} (hX_fix : map K X = X)

--- a/TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean
+++ b/TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean
@@ -26,8 +26,7 @@ For a fixed point of maximal support the corner restriction $Q X Q = X$ is vacuo
 is a positive semidefinite fixed point whose support projection absorbs every fixed point
 (`Kraus.exists_maximalSupport_fixedPoint` in `TNLean.Channel.FixedPoint.MaximalSupport`),
 and at such a fixed point the conjugation below reaches the full fixed-point set
-(`Kraus.exists_maximalSupport_weightedCorner_sqrt_eq`)
-there. The statements below take an arbitrary positive semidefinite fixed point, so for a
+(`Kraus.exists_maximalSupport_weightedCorner_sqrt_eq`). The statements below take an arbitrary positive semidefinite fixed point, so for a
 non-maximal choice of $\rho$ they conjugate the fixed points supported on the support of
 $\rho$. The resolution of the former restriction is recorded in
 `docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex`.

--- a/TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean
+++ b/TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean
@@ -22,10 +22,11 @@ support of $\rho$, which realizes the displayed set without naming the pseudo-in
 
 Corollary 6.7 of *Quantum Channels & Operations* (Wolf 2012) takes $\rho$ to be a
 *maximum-rank* fixed-point density matrix and conjugates the full fixed-point set of $T$.
-For a fixed point of maximal support the corner restriction $Q X Q = X$ is vacuous: the
-maximal-support property is `Kraus.exists_maximalSupport_fixedPoint` in
-`TNLean.Channel.FixedPoint.MaximalSupport`, and its combination with the results below,
-removing the corner restriction, is `Kraus.exists_maximalSupport_weightedCorner_sqrt_eq`
+For a fixed point of maximal support the corner restriction $Q X Q = X$ is vacuous: there
+is a positive semidefinite fixed point whose support projection absorbs every fixed point
+(`Kraus.exists_maximalSupport_fixedPoint` in `TNLean.Channel.FixedPoint.MaximalSupport`),
+and at such a fixed point the conjugation below reaches the full fixed-point set
+(`Kraus.exists_maximalSupport_weightedCorner_sqrt_eq`)
 there. The statements below take an arbitrary positive semidefinite fixed point, so for a
 non-maximal choice of $\rho$ they conjugate the fixed points supported on the support of
 $\rho$. The resolution of the former restriction is recorded in
@@ -365,9 +366,10 @@ corollary, with the inverse square root taken on the support of $\rho$.
 
 The corollary in the reference takes a maximum-rank fixed point, for which every fixed
 point of $T$ is supported on the support of $\rho$ and the corner restriction disappears:
-a fixed point of maximal support is `Kraus.exists_maximalSupport_fixedPoint`, and the
-combination removing the corner restriction is
-`Kraus.exists_maximalSupport_weightedCorner_sqrt_eq`, both in
+a positive semidefinite fixed point whose support projection absorbs every fixed point
+exists (`Kraus.exists_maximalSupport_fixedPoint`), and at such a fixed point the
+conjugation reaches the full fixed-point set
+(`Kraus.exists_maximalSupport_weightedCorner_sqrt_eq`), both in
 `TNLean.Channel.FixedPoint.MaximalSupport`. -/
 noncomputable def weightedCornerFixedPointsStarSubalgebra
     (K : Fin d → Mat) (h_tp : IsTP K) {ρ : Mat} (hρ_psd : ρ.PosSemidef)
@@ -467,8 +469,8 @@ root taken on the support of $\rho$.
 The source's corollary takes a maximum-rank fixed point, for which the support condition
 on $X$ is automatic by the maximal-support property
 (`Kraus.exists_maximalSupport_fixedPoint` in `TNLean.Channel.FixedPoint.MaximalSupport`);
-at such a fixed point the combination without the support hypothesis is
-`Kraus.exists_maximalSupport_weightedCorner_sqrt_eq`. -/
+at such a fixed point the conjugation reaches the full fixed-point set without the
+support hypothesis (`Kraus.exists_maximalSupport_weightedCorner_sqrt_eq`). -/
 theorem exists_weightedCorner_sqrt_eq_of_fixedPoint
     (K : Fin d → Mat) (h_tp : IsTP K) {ρ : Mat} (hρ_psd : ρ.PosSemidef)
     (hρ_fix : map K ρ = ρ) {X : Mat} (hX_fix : map K X = X)

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -12,6 +12,7 @@ import TNLean.Channel.FixedPoint.BlockForm
 import TNLean.Channel.FixedPoint.CornerBlockForm
 import TNLean.Channel.FixedPoint.Corollaries
 import TNLean.Channel.FixedPoint.WeightedCornerFixedPoints
+import TNLean.Channel.FixedPoint.MaximalSupport
 import TNLean.Channel.Irreducible.Ergodicity
 import TNLean.Channel.Irreducible.Basic
 import TNLean.Channel.Irreducible.Growth

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -329,11 +329,12 @@ points):
 In `TNLean.Channel.FixedPoint.MaximalSupport` (the maximal-support property
 and the removal of the corner restriction):
 
-* `Kraus.stationaryProj_absorb_of_le` — for PSD `P ≤ ρ` the support
-  projection of `ρ` absorbs `P`.
-* `Kraus.exists_maximalSupport_fixedPoint` — a PSD fixed point `ρ₀` whose
+* `Kraus.stationaryProj_absorb_of_le` — for positive semidefinite $P \preceq \rho$
+  the support projection of $\rho$ absorbs $P$.
+* `Kraus.exists_maximalSupport_fixedPoint` — a positive semidefinite fixed point
+  $\rho_0$ whose
   support projection $Q_0$ satisfies $Q_0 X Q_0 = X$ for every fixed point $X$.
-* `Kraus.exists_maximalSupport_weightedCorner_sqrt_eq` — at `ρ₀`, conjugation
+* `Kraus.exists_maximalSupport_weightedCorner_sqrt_eq` — at $\rho_0$, conjugation
   by $\sqrt{\rho_0}$ maps the corner carrier onto the full fixed-point set,
   realizing $\rho_0^{-1/2}\,\{X \mid T(X) = X\}\,\rho_0^{-1/2}$ without a support
   restriction.

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -332,10 +332,11 @@ and the removal of the corner restriction):
 * `Kraus.stationaryProj_absorb_of_le` — for PSD `P ≤ ρ` the support
   projection of `ρ` absorbs `P`.
 * `Kraus.exists_maximalSupport_fixedPoint` — a PSD fixed point `ρ₀` whose
-  support projection `Q₀` satisfies `Q₀ X Q₀ = X` for every fixed point `X`.
+  support projection $Q_0$ satisfies $Q_0 X Q_0 = X$ for every fixed point $X$.
 * `Kraus.exists_maximalSupport_weightedCorner_sqrt_eq` — at `ρ₀`, conjugation
-  by `√ρ₀` maps the corner carrier onto the full fixed-point set, realizing
-  `ρ₀^{-1/2} {X | T(X) = X} ρ₀^{-1/2}` without a support restriction.
+  by $\sqrt{\rho_0}$ maps the corner carrier onto the full fixed-point set,
+  realizing $\rho_0^{-1/2}\,\{X \mid T(X) = X\}\,\rho_0^{-1/2}$ without a support
+  restriction.
 
 Wolf's statement quantifies over an arbitrary maximum-rank fixed-point
 density matrix; the formalized statements produce one fixed point of maximal

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -339,7 +339,7 @@ and the removal of the corner restriction):
 
 Wolf's statement quantifies over an arbitrary maximum-rank fixed-point
 density matrix; the formalized statements produce one fixed point of maximal
-support (a maximum-rank fixed point after normalization) and realize the
+support and realize the
 conjugated set there. Transferring the statement to every maximum-rank fixed
 point (by identifying the supports of any two of them) is not formalized
 (see `docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex`).

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -325,12 +325,23 @@ points):
 * `Kraus.exists_weightedCorner_sqrt_eq_of_fixedPoint` — conjugation by `√ρ`
   maps the carrier onto the corner-supported fixed points.
 
-Wolf's statement takes a maximum-rank fixed-point density matrix and
-conjugates the full fixed-point set; for such `ρ` every fixed point is
-supported on the support of `ρ`, so the corner restriction disappears. That
-maximal-support property remains to be established here (see
-`docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex`); it is the
-remaining step for the statement in its stated generality.
+In `TNLean.Channel.FixedPoint.MaximalSupport` (the maximal-support property
+and the removal of the corner restriction):
+
+* `Kraus.stationaryProj_absorb_of_le` — for PSD `P ≤ ρ` the support
+  projection of `ρ` absorbs `P`.
+* `Kraus.exists_maximalSupport_fixedPoint` — a PSD fixed point `ρ₀` whose
+  support projection `Q₀` satisfies `Q₀ X Q₀ = X` for every fixed point `X`.
+* `Kraus.exists_maximalSupport_weightedCorner_sqrt_eq` — at `ρ₀`, conjugation
+  by `√ρ₀` maps the corner carrier onto the full fixed-point set, realizing
+  `ρ₀^{-1/2} {X | T(X) = X} ρ₀^{-1/2}` without a support restriction.
+
+Wolf's statement quantifies over an arbitrary maximum-rank fixed-point
+density matrix; the formalized statements produce one fixed point of maximal
+support (a maximum-rank fixed point after normalization) and realize the
+conjugated set there. Transferring the statement to every maximum-rank fixed
+point (by identifying the supports of any two of them) is not formalized
+(see `docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex`).
 
 ### Wolf Theorem 6.15 (Conditional expectation onto fixed-point algebra) — PARTIALLY FORMALIZED
 

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2607,13 +2607,19 @@ transfers the support.
     support projection $Q_0$ of $\rho_0$ absorbs each of them
     (Lemma~\ref{lem:stationaryProj_absorb_of_le}):
     \[
-        Q_0\, P^{\pm}_{k,j}\, Q_0 = P^{\pm}_{k,j},
-        \qquad
-        \text{hence}
-        \qquad
-        Q_0\, X_j\, Q_0 = X_j
+        Q_0\, P^{\pm}_{k,j}\, Q_0 = P^{\pm}_{k,j}.
     \]
-    by linearity through the two displayed decompositions. A fixed point $X$ of $T$ is a
+    Substituting into the two displayed decompositions gives
+    \[
+        Q_0\, H_{k,j}\, Q_0
+        \;=\; Q_0\,\bigl(P^{+}_{k,j} - P^{-}_{k,j}\bigr)\,Q_0
+        \;=\; H_{k,j},
+        \qquad
+        Q_0\, X_j\, Q_0
+        \;=\; \tfrac{1}{2}\,Q_0 H_{1,j} Q_0 - \tfrac{i}{2}\,Q_0 H_{2,j} Q_0
+        \;=\; X_j.
+    \]
+    A fixed point $X$ of $T$ is a
     linear combination of the basis $X_1, \ldots, X_m$, so $Q_0\, X\, Q_0 = X$.
 \end{proof}
 

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2379,10 +2379,13 @@ zero-block representation.
 For a singular fixed point the conjugation is taken with the inverse square root on the
 support of $\rho$, and the conjugated set lives in the corner algebra of the support
 projection. The corollary in~\cite{Wolf2012Quantum} takes a maximum-rank fixed point, for
-which every fixed point of $T$ is supported on the support of $\rho$; the following
-statements restrict to the fixed points supported on the support of $\rho$.
-% Maintainer note: the maximal-support property (which makes the restriction vacuous at
-% a maximum-rank fixed point) is not yet formalized; see
+which every fixed point of $T$ is supported on the support of $\rho$; the following two
+statements take an arbitrary positive semidefinite fixed point and restrict to the fixed
+points supported on the support of $\rho$. Theorem~\ref{thm:maximalSupport_fixedPoint}
+below supplies a fixed point whose support carries every fixed point, and at such a fixed
+point the restriction disappears
+(Theorem~\ref{thm:maximalSupport_weightedCorner}).
+% Maintainer note: the restriction history is recorded in
 % docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex.
 
 \begin{theorem}[Weighted corner fixed points form a $*$-subalgebra]%
@@ -2495,6 +2498,137 @@ the support of $\rho$.
     $\sqrt{\rho}\, Y \sqrt{\rho} = Q X Q = X$, both sides being corner-supported. In
     particular $\sqrt{\rho}\, Y \sqrt{\rho}$ is fixed by $T$.
 \end{proof}
+
+The support hypothesis on the fixed points is discharged by exhibiting a fixed point
+whose support carries every fixed point. The first ingredient is that Loewner domination
+transfers the support.
+
+\begin{lemma}[Loewner domination transfers the support]%
+    \label{lem:stationaryProj_absorb_of_le}
+    \lean{Kraus.stationaryProj_absorb_of_le}
+    \leanok
+    \uses{def:support_proj}
+    Let $\rho, P \succeq 0$ with $P \preceq \rho$, and let $Q$ be the support projection
+    of $\rho$. Then
+    \[
+        Q\,P = P \qquad \text{and} \qquad P\,Q = P.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{def:support_proj}
+    The support projection absorbs $\rho$, so $(\Id - Q)\rho = 0$ and
+    \[
+        0 \;\preceq\; (\Id - Q)\,P\,(\Id - Q)
+        \;\preceq\; (\Id - Q)\,\rho\,(\Id - Q) \;=\; 0,
+    \]
+    the middle inequality because conjugation by $\Id - Q$ preserves the Loewner order.
+    Hence
+    \[
+        \bigl((\Id - Q)\sqrt{P}\bigr)\bigl((\Id - Q)\sqrt{P}\bigr)^{\dagger}
+        \;=\; (\Id - Q)\,P\,(\Id - Q) \;=\; 0,
+    \]
+    so $(\Id - Q)\sqrt{P} = 0$, and
+    \[
+        (\Id - Q)\,P \;=\; \bigl((\Id - Q)\sqrt{P}\bigr)\sqrt{P} \;=\; 0,
+    \]
+    that is $Q P = P$; taking conjugate transposes gives $P Q = P$ since $P$ and $Q$ are
+    Hermitian.
+\end{proof}
+
+\begin{theorem}[A fixed point of maximal support]%
+    \label{thm:maximalSupport_fixedPoint}
+    \lean{Kraus.exists_maximalSupport_fixedPoint}
+    \leanok
+    \uses{def:tp_kraus, def:support_proj}
+    Let $T(X) = \sum_i K_i X K_i^\dagger$ be trace-preserving. There is a positive
+    semidefinite fixed point $\rho_0$ of $T$ such that, with $Q_0$ the support projection
+    of $\rho_0$, every fixed point $X$ of $T$ satisfies
+    \[
+        Q_0\, X\, Q_0 = X.
+    \]
+    This is the maximal-support property of fixed points in Section~6.4
+    of~\cite{Wolf2012Quantum}; there the witness is the image of the identity under the
+    projection onto the fixed-point space, while here it is a sum of positive fixed
+    points. In particular $\rho_0$, normalized to unit trace, is a fixed-point density
+    matrix of maximum rank.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:hermitian_fixedpoint_parts, lem:stationaryProj_absorb_of_le}
+    Let $X_1, \ldots, X_m$ be a basis of the fixed-point space of $T$. Each $X_j$ splits
+    into fixed Hermitian components: with
+    \[
+        H_{1,j} = X_j + X_j^{\dagger},
+        \qquad
+        H_{2,j} = i\,\bigl(X_j - X_j^{\dagger}\bigr),
+    \]
+    both are Hermitian fixed points (the conjugate transpose of a fixed point is fixed),
+    and
+    \[
+        X_j \;=\; \tfrac{1}{2}\,H_{1,j} - \tfrac{i}{2}\,H_{2,j}.
+    \]
+    By the decomposition of Hermitian fixed points into positive parts
+    (Theorem~\ref{thm:hermitian_fixedpoint_parts}) there are positive semidefinite fixed
+    points with
+    \[
+        H_{1,j} = P^{+}_{1,j} - P^{-}_{1,j},
+        \qquad
+        H_{2,j} = P^{+}_{2,j} - P^{-}_{2,j}.
+    \]
+    Set
+    \[
+        \rho_0 \;=\; \sum_{j=1}^{m}
+            \bigl(P^{+}_{1,j} + P^{-}_{1,j} + P^{+}_{2,j} + P^{-}_{2,j}\bigr),
+    \]
+    a positive semidefinite fixed point. Every summand is dominated by $\rho_0$ in the
+    Loewner order, because the remaining summands are positive semidefinite, so the
+    support projection $Q_0$ of $\rho_0$ absorbs each of them
+    (Lemma~\ref{lem:stationaryProj_absorb_of_le}):
+    \[
+        Q_0\, P^{\pm}_{k,j}\, Q_0 = P^{\pm}_{k,j},
+        \qquad
+        \text{hence}
+        \qquad
+        Q_0\, X_j\, Q_0 = X_j
+    \]
+    by linearity through the two displayed decompositions. A fixed point $X$ of $T$ is a
+    linear combination of the basis $X_1, \ldots, X_m$, so $Q_0\, X\, Q_0 = X$.
+\end{proof}
+
+\begin{theorem}[Conjugation by the square root at a fixed point of maximal support]%
+    \label{thm:maximalSupport_weightedCorner}
+    \lean{Kraus.exists_maximalSupport_weightedCorner_sqrt_eq}
+    \leanok
+    \uses{def:tp_kraus, def:support_proj}
+    Let $T(X) = \sum_i K_i X K_i^\dagger$ be trace-preserving. There is a positive
+    semidefinite fixed point $\rho_0$ of $T$ such that every fixed point $X$ of $T$
+    arises as
+    \[
+        X \;=\; \sqrt{\rho_0}\, Y \sqrt{\rho_0}
+    \]
+    for a corner-supported $Y$ with $\sqrt{\rho_0}\, Y \sqrt{\rho_0}$ fixed by $T$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:maximalSupport_fixedPoint, thm:weightedCorner_sqrt_surjective}
+    Take the fixed point $\rho_0$ of Theorem~\ref{thm:maximalSupport_fixedPoint}. Every
+    fixed point $X$ of $T$ satisfies $Q_0\, X\, Q_0 = X$ for the support projection
+    $Q_0$ of $\rho_0$, so Theorem~\ref{thm:weightedCorner_sqrt_surjective} applies to
+    $X$ and produces the corner-supported $Y$.
+\end{proof}
+
+At the fixed point $\rho_0$, the carrier of the $*$-subalgebra of
+Theorem~\ref{thm:weightedCornerFixedPointsStarSubalgebra} therefore realizes
+\[
+    \rho_0^{-1/2}\,\{X \in \MN{D} \mid T(X) = X\}\,\rho_0^{-1/2},
+\]
+with the inverse square root taken on the support of $\rho_0$: the conjugated
+fixed-point set of Corollary~6.7 of~\cite{Wolf2012Quantum} at a fixed point of maximal
+support, without a support restriction on the fixed points.
 
 \section{Further irreducibility and primitivity equivalences}
 

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2573,7 +2573,7 @@ transfers the support.
     \leanok
     \uses{lem:isChannel_transferMap, thm:hermitian_fixedpoint_parts,
         lem:stationaryProj_absorb_of_le}
-    Let $X_1, \ldots, X_m$ be a basis of the fixed-point space of $T$. Each $X_j$ splits
+    Let $X_0, \ldots, X_{m-1}$ be a basis of the fixed-point space of $T$. Each $X_j$ splits
     into fixed Hermitian components: with
     \[
         H_{1,j} = X_j + X_j^{\dagger},
@@ -2595,7 +2595,7 @@ transfers the support.
     \]
     Set
     \[
-        \rho_0 \;=\; \sum_{j=1}^{m}
+        \rho_0 \;=\; \sum_{j=0}^{m-1}
             \bigl(P^{+}_{1,j} + P^{-}_{1,j} + P^{+}_{2,j} + P^{-}_{2,j}\bigr),
     \]
     a positive semidefinite fixed point. Every summand is dominated by $\rho_0$ in the
@@ -2616,7 +2616,7 @@ transfers the support.
         \;=\; X_j.
     \]
     A fixed point $X$ of $T$ is a
-    linear combination of the basis $X_1, \ldots, X_m$, so $Q_0\, X\, Q_0 = X$.
+    linear combination of the basis $X_0, \ldots, X_{m-1}$, so $Q_0\, X\, Q_0 = X$.
 \end{proof}
 
 \begin{theorem}[Conjugation by the square root at a fixed point of maximal support]%
@@ -2642,12 +2642,13 @@ transfers the support.
     $X$ and produces the corner-supported $Y$.
 \end{proof}
 
-At the fixed point $\rho_0$, the carrier of the $*$-subalgebra of
+At the fixed point $\rho_0$, with the inverse square root taken on the support of
+$\rho_0$, the carrier of the $*$-subalgebra of
 Theorem~\ref{thm:weightedCornerFixedPointsStarSubalgebra} therefore realizes
 \[
-    \rho_0^{-1/2}\,\{X \in \MN{D} \mid T(X) = X\}\,\rho_0^{-1/2},
+    \rho_0^{-1/2}\,\{X \in \MN{D} \mid T(X) = X\}\,\rho_0^{-1/2}:
 \]
-with the inverse square root taken on the support of $\rho_0$: the conjugated
+the conjugated
 fixed-point set of Corollary~6.7 of~\cite{Wolf2012Quantum} at a fixed point of maximal
 support, without a support restriction on the fixed points.
 

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2503,6 +2503,24 @@ The support hypothesis on the fixed points is discharged by exhibiting a fixed p
 whose support carries every fixed point. The first ingredient is that Loewner domination
 transfers the support.
 
+\begin{lemma}[The transfer map of a trace-preserving family is a channel]%
+    \label{lem:isChannel_transferMap}
+    \lean{Kraus.isChannel_transferMap}
+    \leanok
+    \uses{def:channel, def:tp_kraus}
+    Let $K_1, \ldots, K_d$ be a trace-preserving Kraus family. The map
+    $E(X) = \sum_i K_i X K_i^{\dagger}$ is a quantum channel.
+\end{lemma}
+\begin{proof}\leanok
+    The map is completely positive because it is in Kraus form, and it preserves the
+    trace because
+    \[
+        \tr\Bigl(\sum_i K_i X K_i^{\dagger}\Bigr)
+        \;=\; \tr\Bigl(\Bigl(\sum_i K_i^{\dagger} K_i\Bigr) X\Bigr)
+        \;=\; \tr(X).
+    \]
+\end{proof}
+
 \begin{lemma}[Loewner domination transfers the support]%
     \label{lem:stationaryProj_absorb_of_le}
     \lean{Kraus.stationaryProj_absorb_of_le}
@@ -2557,7 +2575,8 @@ transfers the support.
 
 \begin{proof}
     \leanok
-    \uses{thm:hermitian_fixedpoint_parts, lem:stationaryProj_absorb_of_le}
+    \uses{lem:isChannel_transferMap, thm:hermitian_fixedpoint_parts,
+        lem:stationaryProj_absorb_of_le}
     Let $X_1, \ldots, X_m$ be a basis of the fixed-point space of $T$. Each $X_j$ splits
     into fixed Hermitian components: with
     \[

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2529,7 +2529,7 @@ transfers the support.
     Let $\rho, P \succeq 0$ with $P \preceq \rho$, and let $Q$ be the support projection
     of $\rho$. Then
     \[
-        Q\,P = P \qquad \text{and} \qquad P\,Q = P.
+        Q\,P = P, \qquad P\,Q = P.
     \]
 \end{lemma}
 

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2566,8 +2566,7 @@ transfers the support.
     This is the maximal-support property of fixed points in Section~6.4
     of~\cite{Wolf2012Quantum}; there the witness is the image of the identity under the
     projection onto the fixed-point space, while here it is a sum of positive fixed
-    points. In particular $\rho_0$, normalized to unit trace, is a fixed-point density
-    matrix of maximum rank.
+    points.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2507,7 +2507,7 @@ transfers the support.
     \label{lem:isChannel_transferMap}
     \lean{Kraus.isChannel_transferMap}
     \leanok
-    \uses{def:channel, def:tp_kraus, thm:transfer_channel}
+    \uses{def:channel, def:tp_kraus}
     Let $K_0, \ldots, K_{d-1}$ be a trace-preserving Kraus family. The map
     $E(X) = \sum_i K_i X K_i^{\dagger}$ is a quantum channel.
 \end{lemma}

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2507,18 +2507,15 @@ transfers the support.
     \label{lem:isChannel_transferMap}
     \lean{Kraus.isChannel_transferMap}
     \leanok
-    \uses{def:channel, def:tp_kraus}
+    \uses{def:channel, def:tp_kraus, thm:transfer_channel}
     Let $K_0, \ldots, K_{d-1}$ be a trace-preserving Kraus family. The map
     $E(X) = \sum_i K_i X K_i^{\dagger}$ is a quantum channel.
 \end{lemma}
 \begin{proof}\leanok
-    The map is completely positive because it is in Kraus form, and it preserves the
-    trace because
-    \[
-        \tr\Bigl(\sum_i K_i X K_i^{\dagger}\Bigr)
-        \;=\; \tr\Bigl(\Bigl(\sum_i K_i^{\dagger} K_i\Bigr) X\Bigr)
-        \;=\; \tr(X).
-    \]
+    \uses{thm:transfer_channel}
+    The trace-preservation hypothesis is the normalization
+    $\sum_i K_i^{\dagger} K_i = \mathbf 1$ of the channel form of the transfer map
+    (Theorem~\ref{thm:transfer_channel}).
 \end{proof}
 
 \begin{lemma}[Loewner domination transfers the support]%

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2508,7 +2508,7 @@ transfers the support.
     \lean{Kraus.isChannel_transferMap}
     \leanok
     \uses{def:channel, def:tp_kraus}
-    Let $K_1, \ldots, K_d$ be a trace-preserving Kraus family. The map
+    Let $K_0, \ldots, K_{d-1}$ be a trace-preserving Kraus family. The map
     $E(X) = \sum_i K_i X K_i^{\dagger}$ is a quantum channel.
 \end{lemma}
 \begin{proof}\leanok

--- a/docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex
+++ b/docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex
@@ -29,59 +29,60 @@ The corollary rests on the maximal-support property of fixed points stated earli
 Section~6.4 of the reference: every fixed point of $T$ has support and range within the
 support of the maximum-rank fixed point, so conjugation by $\rho^{-1/2}$ loses nothing.
 
-\section{The formal statements}
+\section{The formalization}
 
-The formalization (\leanid{Kraus.weightedCornerFixedPointsStarSubalgebra} and
+Two layers are established, both for a Kraus map (the completely positive case of the
+Schwarz hypothesis, as in the other results of this section).
+
+For an \emph{arbitrary} positive semidefinite fixed point $\rho$ with support
+projection $Q$ (\leanid{Kraus.weightedCornerFixedPointsStarSubalgebra} and
 \leanid{Kraus.exists\_weightedCorner\_sqrt\_eq\_of\_fixedPoint} in
-\leanid{TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean}) takes a Kraus map (the
-completely positive case of the Schwarz hypothesis, as in the other formalized results of
-this section) and an \emph{arbitrary} positive semidefinite fixed point $\rho$ with
-support projection $Q$, and proves that
+\leanid{TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean}), the set
 \[
     \rho^{-1/2}\,\{X \mid T(X) = X,\ Q X Q = X\}\,\rho^{-1/2}
 \]
-is a $*$-subalgebra of the corner algebra $Q M_D(\mathbb{C}) Q$: the conjugated set is
-restricted to the fixed points \emph{supported on the support of $\rho$}. The positive
-definite case without the support restriction is
+is a $*$-subalgebra of the corner algebra $Q M_D(\mathbb{C}) Q$; for a non-maximal
+$\rho$ the conjugated set is restricted to the fixed points supported on the support
+of $\rho$. The positive definite case without any support restriction is
 \leanid{Kraus.weightedFixedPointsStarSubalgebra}.
 
-\section{The gap (as originally recorded)}
+At a fixed point of maximal support the restriction disappears
+(\leanid{Kraus.exists\_maximalSupport\_weightedCorner\_sqrt\_eq} in
+\leanid{TNLean/Channel/FixedPoint/MaximalSupport.lean}): there is a positive
+semidefinite fixed point $\rho_0$ at which the conjugated set is
+\[
+    \rho_0^{-1/2}\,\{X \mid T(X) = X\}\,\rho_0^{-1/2},
+\]
+the set of the corollary, with the inverse square root taken on the support of
+$\rho_0$.
 
-For a maximum-rank fixed point the corner restriction $Q X Q = X$ is vacuous, by the
-maximal-support property of fixed points. At the time this note was written that
-property was open: the maximal-support and support-minimality propositions of
-Section~6.4 of the reference were recorded as open in
-\leanid{TNLean/Channel/FixedPoint/StationarySupport.lean}, and the formal statement
-restricted to corner-supported fixed points was a proper restriction of the corollary.
+\section{The maximal-support property}
 
-\section{Elimination plan (as executed)}
+The removal of the restriction rests on the maximal-support property
+(\leanid{Kraus.exists\_maximalSupport\_fixedPoint}): there is a positive semidefinite
+fixed point $\rho_0$ whose support projection $Q_0$ satisfies $Q_0 X Q_0 = X$ for every
+fixed point $X$. The witness is the sum of the positive parts of the Hermitian and
+anti-Hermitian components of a basis $X_0, \ldots, X_{m-1}$ of the fixed-point space
+(the reference instead takes the image of the identity under the projection onto the
+fixed-point space). Writing
+$H_{1,j} = X_j + X_j^{\dagger}$ and $H_{2,j} = i(X_j - X_j^{\dagger})$ for the fixed
+Hermitian components and $H_{k,j} = P^{+}_{k,j} - P^{-}_{k,j}$ for their positive parts
+(\leanid{IsChannel.posSemidef\_parts\_of\_hermitian\_fixedPoint}), the witness
+\begin{align*}
+    \rho_0 &= \sum_{j=0}^{m-1}
+        \bigl(P^{+}_{1,j} + P^{-}_{1,j} + P^{+}_{2,j} + P^{-}_{2,j}\bigr)
+\end{align*}
+dominates every summand in the Loewner order, domination transfers the support
+(\leanid{Kraus.stationaryProj\_absorb\_of\_le}, from
+$0 \preceq (\mathbf 1-Q_0)P(\mathbf 1-Q_0) \preceq (\mathbf 1-Q_0)\rho_0(\mathbf 1-Q_0) = 0$),
+and linearity extends the absorption from the parts to every fixed point.
 
-Establish the maximal-support property: every fixed point of a trace-preserving Kraus
-map has support and range within the support of a maximal-support fixed point. The proof
-decomposes a fixed point into four positive fixed parts (the decomposition is
-\leanid{IsChannel.posSemidef\_parts\_of\_hermitian\_fixedPoint}) and
-bounds the support of each positive fixed part by the maximal one. With that property,
-instantiating the corner-restricted statements at such a fixed point removes the
-restriction $Q X Q = X$.
+\section{Verdict}
 
-\section{Resolution}
-
-This note is now a record of the resolved restriction. The maximal-support property is
-\leanid{Kraus.exists\_maximalSupport\_fixedPoint} in
-\leanid{TNLean/Channel/FixedPoint/MaximalSupport.lean}: a positive semidefinite fixed
-point $\rho_0$ whose support projection $Q_0$ satisfies $Q_0 X Q_0 = X$ for every fixed
-point $X$. The witness is constructed as the sum of the positive parts of the Hermitian
-and anti-Hermitian components of a basis of the fixed-point space (rather than through
-the projection onto the fixed-point space, as in the reference); every fixed point is a
-linear combination of positive fixed points dominated by $\rho_0$ in the Loewner order,
-and domination transfers the support
-(\leanid{Kraus.stationaryProj\_absorb\_of\_le}). Instantiating the corner-restricted
-statements at $\rho_0$ removes the restriction $Q X Q = X$
-(\leanid{Kraus.exists\_maximalSupport\_weightedCorner\_sqrt\_eq}), so the conjugated set
-$\rho_0^{-1/2}\,\{X \mid T(X) = X\}\,\rho_0^{-1/2}$ of the corollary is realized at a
-fixed point of maximal support. What is not asserted is the corollary's quantification
-over an \emph{arbitrary} maximum-rank fixed-point density matrix: identifying the
-supports of any two maximum-rank fixed points (so that the statement transfers from the
-constructed witness to every maximum-rank fixed point) is not formalized.
+The corner-support restriction is eliminated at the constructed fixed point of maximal
+support. The residual gap against the source is the corollary's quantification over an
+\emph{arbitrary} maximum-rank fixed-point density matrix: identifying the supports of
+any two maximum-rank fixed points, so that the statement transfers from the constructed
+witness to every maximum-rank fixed point, is not established here.
 
 \end{document}

--- a/docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex
+++ b/docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex
@@ -45,25 +45,24 @@ restricted to the fixed points \emph{supported on the support of $\rho$}. The po
 definite case without the support restriction is
 \leanid{Kraus.weightedFixedPointsStarSubalgebra}.
 
-\section{The gap}
+\section{The gap (as originally recorded)}
 
 For a maximum-rank fixed point the corner restriction $Q X Q = X$ is vacuous, by the
-maximal-support property of fixed points. That property is not formalized: the
-maximal-support and support-minimality propositions of Section~6.4 of the reference are
-recorded as open in \leanid{TNLean/Channel/FixedPoint/StationarySupport.lean}. Until it
-is available, the formal statement restricted to corner-supported fixed points is a
-proper restriction of the corollary, and neither formal version covers the corollary in
-its stated generality.
+maximal-support property of fixed points. At the time this note was written that
+property was open: the maximal-support and support-minimality propositions of
+Section~6.4 of the reference were recorded as open in
+\leanid{TNLean/Channel/FixedPoint/StationarySupport.lean}, and the formal statement
+restricted to corner-supported fixed points was a proper restriction of the corollary.
 
-\section{Elimination plan}
+\section{Elimination plan (as executed)}
 
-Formalize the maximal-support property: every fixed point of a trace-preserving Kraus
-map has support and range within the support of a maximum-rank fixed point. The proof in
-the reference decomposes a fixed point into four positive fixed parts (the decomposition
-is formalized as \leanid{IsChannel.posSemidef\_parts\_of\_hermitian\_fixedPoint}) and
+Establish the maximal-support property: every fixed point of a trace-preserving Kraus
+map has support and range within the support of a maximal-support fixed point. The proof
+decomposes a fixed point into four positive fixed parts (the decomposition is
+\leanid{IsChannel.posSemidef\_parts\_of\_hermitian\_fixedPoint}) and
 bounds the support of each positive fixed part by the maximal one. With that property,
-instantiating the corner-restricted statements at a maximum-rank fixed point removes the
-restriction $Q X Q = X$ and yields Corollary 6.7 of the reference verbatim.
+instantiating the corner-restricted statements at such a fixed point removes the
+restriction $Q X Q = X$.
 
 \section{Resolution}
 

--- a/docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex
+++ b/docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex
@@ -65,4 +65,24 @@ bounds the support of each positive fixed part by the maximal one. With that pro
 instantiating the corner-restricted statements at a maximum-rank fixed point removes the
 restriction $Q X Q = X$ and yields Corollary 6.7 of the reference verbatim.
 
+\section{Resolution}
+
+This note is now a record of the resolved restriction. The maximal-support property is
+\leanid{Kraus.exists\_maximalSupport\_fixedPoint} in
+\leanid{TNLean/Channel/FixedPoint/MaximalSupport.lean}: a positive semidefinite fixed
+point $\rho_0$ whose support projection $Q_0$ satisfies $Q_0 X Q_0 = X$ for every fixed
+point $X$. The witness is constructed as the sum of the positive parts of the Hermitian
+and anti-Hermitian components of a basis of the fixed-point space (rather than through
+the projection onto the fixed-point space, as in the reference); every fixed point is a
+linear combination of positive fixed points dominated by $\rho_0$ in the Loewner order,
+and domination transfers the support
+(\leanid{Kraus.stationaryProj\_absorb\_of\_le}). Instantiating the corner-restricted
+statements at $\rho_0$ removes the restriction $Q X Q = X$
+(\leanid{Kraus.exists\_maximalSupport\_weightedCorner\_sqrt\_eq}), so the conjugated set
+$\rho_0^{-1/2}\,\{X \mid T(X) = X\}\,\rho_0^{-1/2}$ of the corollary is realized at a
+fixed point of maximal support. What is not asserted is the corollary's quantification
+over an \emph{arbitrary} maximum-rank fixed-point density matrix: identifying the
+supports of any two maximum-rank fixed points (so that the statement transfers from the
+constructed witness to every maximum-rank fixed point) is not formalized.
+
 \end{document}


### PR DESCRIPTION
## Summary

The elimination step named in LionSR/TNLean#3739: the maximal-support property of fixed points from Section 6.4 of *Quantum Channels & Operations* (Wolf 2012), and its consumption discharging the corner-support hypothesis of the singular-case weighted corner fixed points.

New file `TNLean/Channel/FixedPoint/MaximalSupport.lean` (sorry/axiom-free):

- `Kraus.stationaryProj_absorb_of_le` — **Loewner domination transfers the support**: for positive semidefinite $P \preceq \rho$ with $Q$ the support projection of $\rho$, $Q P = P$ and $P Q = P$. Proof: $0 \preceq (\mathbf 1-Q)P(\mathbf 1-Q) \preceq (\mathbf 1-Q)\rho(\mathbf 1-Q) = 0$, hence $((\mathbf 1-Q)\sqrt P)((\mathbf 1-Q)\sqrt P)^\dagger = 0$ and $(\mathbf 1-Q)P = 0$.
- `Kraus.isChannel_transferMap` — a trace-preserving Kraus family defines a quantum channel (the bridge needed to reuse the positive-parts decomposition `IsChannel.posSemidef_parts_of_hermitian_fixedPoint`).
- `Kraus.exists_maximalSupport_fixedPoint` — **a fixed point of maximal support**: for trace-preserving $K$ there is a positive semidefinite fixed point $\rho_0$ with $Q_0 X Q_0 = X$ for **every** fixed point $X$ ($Q_0$ the support projection of $\rho_0$).
- `Kraus.exists_maximalSupport_weightedCorner_sqrt_eq` — at $\rho_0$, conjugation by $\sqrt{\rho_0}$ maps the carrier of `Kraus.weightedCornerFixedPointsStarSubalgebra` **onto the full fixed-point set**: the set $\rho_0^{-1/2}\{X \mid T(X)=X\}\rho_0^{-1/2}$ of Corollary 6.7 of the reference, with the inverse square root on the support, without any support restriction on the fixed points.

**Route** (differs from the reference's, which uses the projection onto the fixed-point space and Douglas' theorem — neither is needed): take a basis $X_1,\dots,X_m$ of the fixed-point space (the eigenspace of the transfer map at one); split each into fixed Hermitian components $H_{1,j} = X_j + X_j^\dagger$ and $H_{2,j} = i(X_j - X_j^\dagger)$ with $X_j = \tfrac12 H_{1,j} - \tfrac i2 H_{2,j}$; decompose each component into positive fixed parts (the decomposition of Hermitian fixed points, already established); set $\rho_0 :=$ the sum of all $4m$ positive parts. Each part is Loewner-dominated by $\rho_0$, so $Q_0$ absorbs it, and every fixed point is a linear combination of the parts.

**Scope-restriction markers eliminated per the marker rules:** the `**Scope restriction (corner …)**` markers on the module doc, `weightedCornerFixedPointsStarSubalgebra`, and `exists_weightedCorner_sqrt_eq_of_fixedPoint` are replaced by references to the unrestricted statements; the paper-gap note `docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex` gains a Resolution section (kept per the repo convention for resolved notes).

**Exact remaining delta vs the source's Corollary 6.7, stated in the gap note and index:** the corollary quantifies over an *arbitrary* maximum-rank fixed-point density matrix; the formalized statements construct **one** fixed point of maximal support (a maximum-rank fixed point after normalization) and realize the conjugated set there. Transferring to every maximum-rank fixed point — identifying the supports of any two maximum-rank fixed points — is not formalized.

**What remains for LionSR/QICLean#39:** the transfer just described, and the density-weighted form $\bigoplus_k M_{d_k} \otimes \rho_k$ of Theorem 6.14 for the Schrödinger-picture fixed points (Equation (1.40) of the reference). Both recorded in the updated `TNLean/Channel/WolfChapter6Index.lean`.

Partially addresses LionSR/QICLean#39.

## Blueprint

Three new entries in `blueprint/src/chapter/ch07_spectral.tex`, after the weighted corner entries, with full displayed-equation proofs and `\uses` matching the Lean proofs:

- `lem:stationaryProj_absorb_of_le` (Loewner domination transfers the support),
- `thm:maximalSupport_fixedPoint` (uses `thm:hermitian_fixedpoint_parts` and the domination lemma),
- `thm:maximalSupport_weightedCorner` (uses the maximal-support theorem and `thm:weightedCorner_sqrt_surjective`).

The preamble before the weighted corner entries now points forward to the maximal-support theorem instead of recording the restriction as open, and a closing paragraph states the realized conjugated set at $\rho_0$.

## Validation

- `lake build TNLean` — success, no new warnings
- `rg -n "sorry|axiom"` on the new and touched Lean files — clean
- `lake exe checkdecls blueprint/lean_decls` — pass (after `--update-lean-decls`)
- `python3 scripts/blueprint_lean_sync.py --ci` — in sync
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main --ci` — no violations
- `lake exe lint_style`, `git diff --check` — clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal mathematics and documentation in the Channel fixed-point layer; no runtime, auth, or data-path changes. Residual proof obligation vs. Wolf is explicitly scoped to arbitrary maximum-rank fixed points.
> 
> **Overview**
> Adds **`TNLean/Channel/FixedPoint/MaximalSupport.lean`** with sorry-free Lean for Wolf Section 6.4’s maximal-support property and its use on singular weighted corner fixed points.
> 
> **New results:** `Kraus.stationaryProj_absorb_of_le` (Loewner domination $P \preceq \rho$ forces the support projection of $\rho$ to absorb $P$); `Kraus.isChannel_transferMap` (bridge to `IsChannel.posSemidef_parts_of_hermitian_fixedPoint`); `Kraus.exists_maximalSupport_fixedPoint` (a PSD fixed point $\rho_0$ with $Q_0 X Q_0 = X$ for every fixed point $X$, built from positive parts of a fixed-point basis); `Kraus.exists_maximalSupport_weightedCorner_sqrt_eq` (at $\rho_0$, $\sqrt{\rho_0}$ conjugation hits the **full** fixed-point set, i.e. $\rho_0^{-1/2}\mathcal{F}_T\rho_0^{-1/2}$ without corner support on $X$).
> 
> **Docs/index:** `WeightedCornerFixedPoints` and **`WolfChapter6Index`** drop “scope restriction open” wording and point at the new theorems; **`TNLean.lean`** and the chapter index import **`MaximalSupport`**. **`blueprint/src/chapter/ch07_spectral.tex`** adds lemmas/theorems with `\lean` links and proofs. **`docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex`** is reframed: corner restriction removed at the constructed witness; remaining delta is quantification over an arbitrary maximum-rank fixed point (support identification not formalized).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a1f34806d724d3b1a66a68597d3cf4d78760c83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->