### PR TITLE
feat(MPS/MPDO): control Kraus maps by sectors

### DIFF
--- a/TNLean/MPS/MPDO/KrausCPTP.lean
+++ b/TNLean/MPS/MPDO/KrausCPTP.lean
@@ -89,7 +89,15 @@ namespace Matrix
 
 /-! ### Orthogonally controlled direct sums -/
 
-/-- The Kraus map associated to a finite family of rectangular operators. -/
+/-- For a finite family of rectangular matrices $A_i$ with row set $\beta$
+and finite column set $\alpha$, the associated Kraus map is
+
+$$
+\Phi_A(X)=\sum_i A_i X A_i^\dagger.
+$$
+
+It maps square matrices indexed by $\alpha$ to square matrices indexed by
+$\beta$. -/
 noncomputable def rectangularKrausMap
     {κ α β : Type*} [Fintype κ] [Fintype α]
     (A : κ → Matrix β α ℂ) :
@@ -149,7 +157,7 @@ private lemma singleBlock_conjTranspose_mul
 /-- Sectorwise resolutions of the identity make the orthogonally controlled
 Kraus map trace-preserving and completely positive.
 
-This is the trace-preserving sector assembly for $\mathcal T_1$ and
+This is the trace-preserving sector construction for $\mathcal T_1$ and
 $\mathcal S_1$ in arXiv:1606.00608, Appendix C.2, lines 1523--1535 and
 1548--1555. -/
 theorem controlledKrausMap_isKrausCPTP (r : ι → ℕ)

--- a/TNLean/MPS/MPDO/KrausCPTP.lean
+++ b/TNLean/MPS/MPDO/KrausCPTP.lean
@@ -22,6 +22,8 @@ dimensions.
 * `isKrausCPTP_id`: the identity map is trace-preserving completely positive.
 * `isKrausCPTP_comp`: composition preserves the trace-preserving completely
   positive property.
+* `Matrix.controlledKrausMap_isKrausCPTP`: orthogonal control of sectorwise
+  Kraus families is trace-preserving completely positive.
 * `Matrix.partialTraceRightLM_isKrausCPTP`: tracing a right tensor factor is a
   trace-preserving completely positive map.
 * `Matrix.preparationMap_isKrausCPTP`: adjoining a density matrix is a
@@ -84,6 +86,122 @@ theorem isKrausCPTP_comp {α β γ : Type*} [Fintype α] [DecidableEq α] [Finty
     rw [step, hA_tp, Matrix.one_mul]
 
 namespace Matrix
+
+/-! ### Orthogonally controlled direct sums -/
+
+/-- The Kraus map associated to a finite family of rectangular operators. -/
+noncomputable def rectangularKrausMap
+    {κ α β : Type*} [Fintype κ] [Fintype α]
+    (A : κ → Matrix β α ℂ) :
+    Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ where
+  toFun X := ∑ i, A i * X * (A i)ᴴ
+  map_add' X Y := by
+    simp_rw [Matrix.mul_add, Matrix.add_mul]
+    exact Finset.sum_add_distrib
+  map_smul' c X := by
+    simp only [RingHom.id_apply]
+    rw [Finset.smul_sum]
+    apply Finset.sum_congr rfl
+    intro i _
+    rw [Matrix.mul_smul, Matrix.smul_mul]
+
+section ControlledDirectSum
+
+variable {ι : Type*} [Fintype ι] [DecidableEq ι]
+variable {α β : ι → Type*}
+variable [∀ i, Fintype (α i)] [∀ i, DecidableEq (α i)]
+variable [∀ i, Fintype (β i)] [∀ i, DecidableEq (β i)]
+
+/-- A rectangular matrix supported on one matching pair of orthogonal
+summands. -/
+private noncomputable def singleBlock (i : ι) (A : Matrix (β i) (α i) ℂ) :
+    Matrix (Σ j, β j) (Σ j, α j) ℂ :=
+  Matrix.blockDiagonal' (Pi.single i A)
+
+/-- The Kraus map controlled by an orthogonal direct-sum decomposition. Each
+Kraus operator acts on one input summand and has range in the corresponding
+output summand, so the map discards coherences between distinct summands.
+
+This is the sector-control operation in arXiv:1606.00608, Appendix C.2,
+lines 1523--1529 and 1548--1553. -/
+noncomputable def controlledKrausMap (r : ι → ℕ)
+    (A : (i : ι) → Fin (r i) → Matrix (β i) (α i) ℂ) :
+    Matrix (Σ i, α i) (Σ i, α i) ℂ →ₗ[ℂ]
+      Matrix (Σ i, β i) (Σ i, β i) ℂ :=
+  rectangularKrausMap fun p : Σ i, Fin (r i) ↦
+    singleBlock p.1 (A p.1 p.2)
+
+omit [∀ i, Fintype (α i)] [∀ i, DecidableEq (α i)]
+    [∀ i, DecidableEq (β i)] in
+private lemma singleBlock_conjTranspose_mul
+    (i : ι) (A : Matrix (β i) (α i) ℂ) :
+    (singleBlock i A)ᴴ * singleBlock i A =
+      Matrix.blockDiagonal' (Pi.single i (Aᴴ * A)) := by
+  rw [singleBlock, Matrix.blockDiagonal'_conjTranspose,
+    ← Matrix.blockDiagonal'_mul]
+  congr 1
+  funext j
+  by_cases hji : j = i
+  · subst j
+    simp
+  · simp [hji]
+
+/-- Sectorwise resolutions of the identity make the orthogonally controlled
+Kraus map trace-preserving and completely positive.
+
+This is the trace-preserving sector assembly for $\mathcal T_1$ and
+$\mathcal S_1$ in arXiv:1606.00608, Appendix C.2, lines 1523--1535 and
+1548--1555. -/
+theorem controlledKrausMap_isKrausCPTP (r : ι → ℕ)
+    (A : (i : ι) → Fin (r i) → Matrix (β i) (α i) ℂ)
+    (htp : ∀ i, ∑ j, (A i j)ᴴ * A i j = (1 : Matrix (α i) (α i) ℂ)) :
+    IsKrausCPTP (controlledKrausMap r A) := by
+  let e := Fintype.equivFin (Σ i, Fin (r i))
+  refine ⟨Fintype.card (Σ i, Fin (r i)),
+    fun j ↦ singleBlock (e.symm j).1 (A (e.symm j).1 (e.symm j).2), ?_, ?_⟩
+  · intro X
+    change (∑ p : Σ i, Fin (r i), singleBlock p.1 (A p.1 p.2) * X *
+      (singleBlock p.1 (A p.1 p.2))ᴴ) = _
+    rw [← e.symm.sum_comp]
+  · change (∑ j : Fin (Fintype.card (Σ i, Fin (r i))),
+        (singleBlock (e.symm j).1 (A (e.symm j).1 (e.symm j).2))ᴴ *
+          singleBlock (e.symm j).1 (A (e.symm j).1 (e.symm j).2)) = 1
+    have hsum :
+        (∑ p : Σ i, Fin (r i),
+          (singleBlock p.1 (A p.1 p.2))ᴴ * singleBlock p.1 (A p.1 p.2)) = 1 := by
+      rw [Fintype.sum_sigma]
+      simp_rw [singleBlock_conjTranspose_mul]
+      have hinner (i : ι) :
+          (∑ j, Matrix.blockDiagonal' (Pi.single i ((A i j)ᴴ * A i j))) =
+            Matrix.blockDiagonal' (Pi.single i (∑ j, (A i j)ᴴ * A i j)) := by
+        change (∑ j, (Matrix.blockDiagonal'AddMonoidHom α α ℂ)
+          (Pi.single i ((A i j)ᴴ * A i j))) =
+            (Matrix.blockDiagonal'AddMonoidHom α α ℂ)
+              (Pi.single i (∑ j, (A i j)ᴴ * A i j))
+        rw [← map_sum (Matrix.blockDiagonal'AddMonoidHom α α ℂ)]
+        congr 1
+        funext k
+        by_cases hki : k = i
+        · subst k
+          simp
+        · simp [hki]
+      simp_rw [hinner, htp]
+      change (∑ i, (Matrix.blockDiagonal'AddMonoidHom α α ℂ)
+        (Pi.single i (1 : Matrix (α i) (α i) ℂ))) = 1
+      rw [← map_sum (Matrix.blockDiagonal'AddMonoidHom α α ℂ)]
+      have hfamily :
+          (∑ i, Pi.single i (1 : Matrix (α i) (α i) ℂ)) =
+            (1 : ∀ i, Matrix (α i) (α i) ℂ) := by
+        funext i
+        simpa only [Finset.sum_apply, Pi.one_apply] using
+          Fintype.sum_pi_single i fun j ↦ (1 : Matrix (α j) (α j) ℂ)
+      rw [hfamily]
+      change Matrix.blockDiagonal' (1 : ∀ i, Matrix (α i) (α i) ℂ) = 1
+      exact Matrix.blockDiagonal'_one
+    exact (Equiv.sum_comp e.symm fun p : Σ i, Fin (r i) ↦
+      (singleBlock p.1 (A p.1 p.2))ᴴ * singleBlock p.1 (A p.1 p.2)).trans hsum
+
+end ControlledDirectSum
 
 private def partialTraceRightKraus
     {α β : Type*} [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
@@ -65,9 +65,9 @@
     \label{def:mpdo_rectangular_kraus_map}
     \lean{Matrix.rectangularKrausMap}
     \leanok
-    Let $H$ be finite-dimensional, let $K$ have a chosen basis, and let
-    $(A_a:H\to K)_a$ be a finite family of operators. Its rectangular Kraus
-    map is
+    Let $I$ be a finite index set, let $J$ be an arbitrary index set, and let
+    $(A_a\in\mathbb C^{J\times I})_a$ be a finite family of matrices. Its
+    rectangular Kraus map is
     \[
         \Phi_A(X)=\sum_a A_aXA_a^{\dagger}.
     \]
@@ -98,11 +98,12 @@
     \lean{Matrix.controlledKrausMap_isKrausCPTP}
     \leanok
     \uses{def:mpdo_controlled_kraus_map, def:is_kraus_cptp}
-    Suppose that every sectorwise Kraus family resolves the identity:
+    Suppose that for every $k$ the sectorwise Kraus family resolves the
+    identity:
     \[
-        \sum_a A_{k,a}^{\dagger}A_{k,a}=I_{H_k}
+        \sum_a A_{k,a}^{\dagger}A_{k,a}=I_{H_k}.
     \]
-    for each $k$. Then the orthogonally controlled map $\mathcal C$ is
+    Then the orthogonally controlled map $\mathcal C$ is
     trace-preserving and completely positive.
 \end{theorem}
 \begin{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
@@ -66,7 +66,7 @@
     \lean{Matrix.rectangularKrausMap}
     \leanok
     Let $I$ be a finite index set, let $J$ be an arbitrary index set, and let
-    $(A_a\in\mathbb C^{J\times I})_a$ be a finite family of matrices. Its
+    $(A_a\in\C^{J\times I})_a$ be a finite family of matrices. Its
     rectangular Kraus map is
     \[
         \Phi_A(X)=\sum_a A_aXA_a^{\dagger}.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
@@ -61,6 +61,62 @@
     \]
 \end{proof}
 
+\begin{definition}[Rectangular Kraus map]
+    \label{def:mpdo_rectangular_kraus_map}
+    \lean{Matrix.rectangularKrausMap}
+    \leanok
+    Let $H$ be finite-dimensional, let $K$ have a chosen basis, and let
+    $(A_a:H\to K)_a$ be a finite family of operators. Its rectangular Kraus
+    map is
+    \[
+        \Phi_A(X)=\sum_a A_aXA_a^{\dagger}.
+    \]
+\end{definition}
+
+\begin{definition}[Orthogonally controlled Kraus map]
+    \label{def:mpdo_controlled_kraus_map}
+    \lean{Matrix.controlledKrausMap}
+    \leanok
+    \uses{def:mpdo_rectangular_kraus_map}
+    Let $H=\bigoplus_k H_k$ and $K=\bigoplus_k K_k$. For each $k$, let
+    $(A_{k,a}:H_k\to K_k)_a$ be a finite family of operators, and let
+    $\widetilde A_{k,a}:H\to K$ agree with $A_{k,a}$ on $H_k$ and vanish on
+    every other summand. The orthogonally controlled Kraus map is
+    \[
+        \mathcal C(X)
+        =\sum_{k,a}\widetilde A_{k,a}X\widetilde A_{k,a}^{\dagger}.
+    \]
+    In particular, $\mathcal C$ discards the off-diagonal blocks between
+    distinct summands. This is the sector control in the definitions of
+    $\mathcal T_1$ and $\mathcal S_1$ in
+    \cite[Appendix~C.2, lines~1523--1535 and~1548--1555]
+      {Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{theorem}[Orthogonal control preserves trace-preserving complete positivity]
+    \label{thm:mpdo_controlled_kraus_map_cptp}
+    \lean{Matrix.controlledKrausMap_isKrausCPTP}
+    \leanok
+    \uses{def:mpdo_controlled_kraus_map, def:is_kraus_cptp}
+    Suppose that every sectorwise Kraus family resolves the identity:
+    \[
+        \sum_a A_{k,a}^{\dagger}A_{k,a}=I_{H_k}
+    \]
+    for each $k$. Then the orthogonally controlled map $\mathcal C$ is
+    trace-preserving and completely positive.
+\end{theorem}
+\begin{proof}
+    \leanok
+    Each embedded operator has support in one summand, and therefore
+    \[
+        \sum_{k,a}\widetilde A_{k,a}^{\dagger}\widetilde A_{k,a}
+        =\bigoplus_k\left(\sum_a A_{k,a}^{\dagger}A_{k,a}\right)
+        =\bigoplus_k I_{H_k}=I_H.
+    \]
+    The displayed Kraus form gives complete positivity, while this identity
+    gives trace preservation.
+\end{proof}
+
 \begin{definition}[Right partial trace]
     \label{def:mpdo_right_partial_trace_map}
     \lean{Matrix.partialTraceRightLM}


### PR DESCRIPTION
This PR adds the generic orthogonal direct-sum channel constructor needed for the sector-controlled maps in Proposition C.7.

It defines rectangular Kraus maps, embeds each sectorwise rectangular Kraus operator into its matching dependent direct-sum block, and proves that sectorwise resolutions of the identity assemble to a global `IsKrausCPTP` witness. The proof includes the finite reindexing required by the existing `Fin n` Kraus interface. Separate blueprint entries distinguish the general rectangular map from its controlled specialization and cite arXiv:1606.00608, Appendix C.2, lines 1523–1535 and 1548–1555.

This advances, but does not close, #3741. Equivalence reindexing and the paper-specific tensor-factor permutations remain separate constructors. It also provides the controlled direct-sum infrastructure required for the remaining global completion in #3742.

Validation:
- full lake build (9299 jobs) after rebasing on current main
- focused KrausCPTP build
- leanblueprint web
- leanblueprint checkdecls
- proof-integrity, line-length, prose, and diff checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formalized quantum-channel infrastructure with no changes to auth, I/O, or existing partial-trace/preparation proofs; risk is mainly proof correctness in new Lean lemmas.
> 
> **Overview**
> Adds **rectangular** and **orthogonally controlled** Kraus channel constructors in `KrausCPTP.lean`, plus blueprint definitions/theorems tied to Cirac et al. Appendix C.2 sector control for \(\mathcal T_1\) and \(\mathcal S_1\).
> 
> `Matrix.rectangularKrausMap` is the generic \(\sum_a A_a X A_a^\dagger\) linear map between matrix algebras of possibly different index types. `Matrix.controlledKrausMap` builds the sector-controlled channel by embedding each sector’s Kraus operator as a block on matching \(\Sigma_i\) summands (via `singleBlock` / `blockDiagonal'`), so cross-sector coherences are not propagated. **`controlledKrausMap_isKrausCPTP`** shows that per-sector \(\sum_j A_{ij}^\dagger A_{ij} = I\) implies global `IsKrausCPTP`, including reindexing Kraus operators to the existing `Fin n` witness interface.
> 
> Chapter 21 blueprint now records the rectangular map, the controlled specialization, and the CPTP preservation theorem with lean links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bae93f6fc07eea3dd6804fb068039208799a8775. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->