### PR TITLE
feat(MPS/MPDO): add CPTP equivalence reindexing

### DIFF
--- a/TNLean/MPS/MPDO/KrausCPTP.lean
+++ b/TNLean/MPS/MPDO/KrausCPTP.lean
@@ -5,6 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.MPDO.Defs
 import TNLean.Analysis.MatrixSqrt
 import TNLean.Channel.PartialTrace
+import Mathlib.Data.Matrix.PEquiv
+import Mathlib.LinearAlgebra.Matrix.Reindex
 
 /-!
 # Trace-preserving completely positive maps in Kraus form
@@ -20,8 +22,12 @@ dimensions.
 * `IsKrausCPTP`: a trace-preserving completely positive map in rectangular
   Kraus form.
 * `isKrausCPTP_id`: the identity map is trace-preserving completely positive.
+* `isKrausCPTP_of_singleKraus`: conjugation by an isometry is trace-preserving
+  completely positive.
 * `isKrausCPTP_comp`: composition preserves the trace-preserving completely
   positive property.
+* `Matrix.equivReindexMap_isKrausCPTP`: reindexing by an equivalence is
+  trace-preserving completely positive.
 * `Matrix.controlledKrausMap_isKrausCPTP`: orthogonal control of sectorwise
   Kraus families is trace-preserving completely positive.
 * `Matrix.partialTraceRightLM_isKrausCPTP`: tracing a right tensor factor is a
@@ -51,6 +57,19 @@ theorem isKrausCPTP_id {α : Type*} [Fintype α] [DecidableEq α] :
   · intro X
     simp
   · simp
+
+/-- A map given by conjugation with a single isometry is trace-preserving
+completely positive. The local basis isometry in arXiv:1606.00608,
+Appendix C.2, lines 1439 and 1520, has this form. -/
+theorem isKrausCPTP_of_singleKraus {α β : Type*} [Fintype α] [DecidableEq α]
+    [Fintype β] [DecidableEq β]
+    {S : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ} (V : Matrix β α ℂ)
+    (hform : ∀ X, S X = V * X * Vᴴ) (hV : Vᴴ * V = 1) :
+    IsKrausCPTP S := by
+  refine ⟨1, fun _ => V, ?_, ?_⟩
+  · intro X
+    simpa only [Fin.sum_univ_one] using hform X
+  · simpa only [Fin.sum_univ_one] using hV
 
 /-- Composition of trace-preserving completely positive maps is again
 trace-preserving completely positive. If `T` has Kraus operators `Bⱼ` and `S`
@@ -86,6 +105,50 @@ theorem isKrausCPTP_comp {α β γ : Type*} [Fintype α] [DecidableEq α] [Finty
     rw [step, hA_tp, Matrix.one_mul]
 
 namespace Matrix
+
+/-! ### Equivalence reindexing -/
+
+/-- Reindex both matrix coordinates along an equivalence of index sets.
+This is the basis relabeling used to regroup tensor factors and shift
+subspins in arXiv:1606.00608, Appendix C.2, lines 1521--1522, 1535--1540,
+1547, and 1555--1559. -/
+def equivReindexMap {α β : Type*} (e : α ≃ β) :
+    Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ :=
+  (Matrix.reindexLinearEquiv ℂ ℂ e e).toLinearMap
+
+/-- Reindexing both matrix coordinates along an equivalence is
+trace-preserving completely positive. This provides the general basis
+relabeling operation required by the regroupings and subspin shifts in
+arXiv:1606.00608, Appendix C.2, lines 1521--1522, 1535--1540, 1547, and
+1555--1559. -/
+theorem equivReindexMap_isKrausCPTP {α β : Type*} [Fintype α] [DecidableEq α]
+    [Fintype β] [DecidableEq β] (e : α ≃ β) :
+    IsKrausCPTP (equivReindexMap e) := by
+  let P : Matrix β α ℂ := e.symm.toPEquiv.toMatrix
+  apply isKrausCPTP_of_singleKraus P
+  · intro X
+    ext b c
+    simp [equivReindexMap, Matrix.coe_reindexLinearEquiv,
+      Matrix.reindex_apply, P, Matrix.mul_apply, PEquiv.toMatrix_apply]
+  · ext a b
+    by_cases hab : a = b
+    · subst b
+      rw [Matrix.one_apply_eq, Matrix.mul_apply]
+      rw [Finset.sum_eq_single (e a)]
+      · simp [P, Matrix.conjTranspose_apply, PEquiv.toMatrix_apply]
+      · intro b _ hba
+        have hne : e.symm b ≠ a := by
+          intro h
+          apply hba
+          simpa using congrArg e h
+        simp [P, Matrix.conjTranspose_apply, PEquiv.toMatrix_apply, hne]
+      · simp
+    · rw [Matrix.one_apply_ne hab, Matrix.mul_apply]
+      apply Finset.sum_eq_zero
+      intro x _
+      by_cases hxa : e.symm x = a
+      · simpa [P, Matrix.conjTranspose_apply, PEquiv.toMatrix_apply, hxa] using hab
+      · simp [P, Matrix.conjTranspose_apply, PEquiv.toMatrix_apply, hxa]
 
 /-! ### Orthogonally controlled direct sums -/
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
@@ -38,6 +38,64 @@
     $A_0^\dagger A_0 = I$.
 \end{proof}
 
+\begin{theorem}[Conjugation by an isometry is trace-preserving completely positive]
+    \label{thm:mpdo_single_kraus_isometry_cptp}
+    \lean{isKrausCPTP_of_singleKraus}
+    \leanok
+    \uses{def:is_kraus_cptp}
+    Let $H$ and $K$ be finite-dimensional complex vector spaces, and let
+    $V:H\to K$ satisfy $V^\dagger V=I_H$. Then the map
+    \[
+        \Phi_V:\operatorname{End}_{\C}(H)\longrightarrow
+          \operatorname{End}_{\C}(K),
+        \qquad \Phi_V(X)=VXV^\dagger,
+    \]
+    is trace-preserving and completely positive. This is the general
+    one-isometry form of the local basis change used in
+    \cite[Appendix~C.2, lines~1439 and~1520]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+\begin{proof}
+    \leanok
+    Take the sole Kraus operator to be $V$. Its resolution of the identity is
+    precisely $V^\dagger V=I_H$.
+\end{proof}
+
+\begin{definition}[Matrix reindexing along an equivalence]
+    \label{def:mpdo_equiv_reindex_map}
+    \lean{Matrix.equivReindexMap}
+    \leanok
+    Let $e:I\simeq J$ be an equivalence of index sets. The associated
+    matrix reindexing is the linear map
+    $R_e:\C^{I\times I}\to\C^{J\times J}$ determined by
+    \[
+        \bigl[R_e(X)\bigr]_{j,j'}=X_{e^{-1}(j),e^{-1}(j')}.
+    \]
+\end{definition}
+
+\begin{theorem}[Equivalence reindexing is trace-preserving completely positive]
+    \label{thm:mpdo_equiv_reindex_cptp}
+    \lean{Matrix.equivReindexMap_isKrausCPTP}
+    \leanok
+    \uses{def:mpdo_equiv_reindex_map, thm:mpdo_single_kraus_isometry_cptp}
+    For every equivalence $e:I\simeq J$ between finite index sets, the
+    reindexing map $R_e$ is trace-preserving and completely positive.
+\end{theorem}
+\begin{proof}
+    \leanok
+    Let $P_e:\C^I\to\C^J$ be the permutation matrix of $e$. Then
+    \[
+        R_e(X)=P_eXP_e^\dagger,
+        \qquad P_e^\dagger P_e=I_{\C^I}.
+    \]
+    The claim follows from the preceding isometry lemma.
+\end{proof}
+
+% Concrete equivalences remain to be supplied for the regroupings preceding
+% T_0 and S_0 (Appendix C.2, lines 1521--1522 and 1547) and for the shifts T_2
+% and S_2 (lines 1535--1540 and 1555--1559). The result above provides the
+% trace-preserving completely positive reindexing once those equivalences are
+% defined; it does not itself define the paper-specific maps.
+
 \begin{lemma}[Composition of trace-preserving completely positive maps]
     \label{lem:is_kraus_cptp_comp}
     \lean{isKrausCPTP_comp}


### PR DESCRIPTION
This PR adds the one-Kraus isometry criterion and matrix reindexing along an equivalence, together with a proof that equivalence reindexing is trace-preserving and completely positive.

The blueprint states the finite-dimensional hypotheses explicitly, distinguishes arbitrary-index reindexing from its finite-dimensional CPTP theorem, and records the precise role of this construction in Appendix C.2 of arXiv:1606.00608.

This advances #3741. The concrete equivalences for the paper-specific regrouping and shift maps remain to be defined, so this PR does not close the issue.

Validation:
- lake env lean TNLean/MPS/MPDO/KrausCPTP.lean
- lake build TNLean (9299 jobs)
- leanblueprint checkdecls
- independent exact-head audit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formal proofs in the MPDO Kraus CPTP library with no runtime or security impact; remaining work is defining concrete equivalences elsewhere.
> 
> **Overview**
> Adds a reusable **one-Kraus isometry** criterion (`isKrausCPTP_of_singleKraus`) and shows that **matrix reindexing along an equivalence** (`Matrix.equivReindexMap`) is trace-preserving completely positive by realizing it as conjugation with the permutation matrix from `e.symm.toPEquiv`.
> 
> The blueprint chapter documents the isometry theorem, the reindexing definition, and the CPTP reindexing theorem, and notes that **paper-specific equivalences** for Appendix C.2 regroupings/shifts are still to be supplied—this PR only provides the generic CPTP relabeling tool.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e867aacef850c06ff8f324ba35ba60be5f465105. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->