### PR TITLE
feat(MPS/MPDO): complete controlled eta preparations

### DIFF
--- a/TNLean/Algebra/MatrixAux.lean
+++ b/TNLean/Algebra/MatrixAux.lean
@@ -38,12 +38,50 @@ Extracted from various files for reusability.
 - `Matrix.eq_zero_of_sum_conjTranspose_mul_self_eq_zero`: the conjugate-transpose
   variant
 - `Matrix.PosSemidef.mulVec_eq_zero_left/right`: kernel containment for PSD matrix sums
+- `Matrix.faithfulDensity`: the faithful uniform density matrix on a nonempty
+  finite index space
+- `Matrix.nonempty_of_trace_eq_one`: an index space carrying a trace-one matrix
+  is nonempty
 - `Continuous.matrix_kronecker`: joint continuity of the Kronecker product in both factors
 -/
 
 open scoped Matrix BigOperators ComplexOrder Kronecker Matrix.Norms.Frobenius
 
 namespace Matrix
+
+/-! ## Uniform density matrices -/
+
+/-- The faithful uniform density matrix on a nonempty finite index space. -/
+noncomputable def faithfulDensity (α : Type*) [Fintype α] [DecidableEq α]
+    [Nonempty α] : Matrix α α ℂ :=
+  ((Fintype.card α : ℂ)⁻¹) • 1
+
+/-- The uniform density matrix on a nonempty finite index space is positive
+definite. -/
+theorem faithfulDensity_posDef (α : Type*) [Fintype α] [DecidableEq α]
+    [Nonempty α] : (faithfulDensity α).PosDef := by
+  apply Matrix.PosDef.smul Matrix.PosDef.one
+  rw [inv_pos]
+  exact_mod_cast Fintype.card_pos
+
+/-- The uniform density matrix on a nonempty finite index space has trace
+one. -/
+theorem faithfulDensity_trace (α : Type*) [Fintype α] [DecidableEq α]
+    [Nonempty α] : (faithfulDensity α).trace = 1 := by
+  rw [faithfulDensity, Matrix.trace_smul, Matrix.trace_one, smul_eq_mul]
+  exact inv_mul_cancel₀ (by exact_mod_cast Fintype.card_ne_zero)
+
+/-- A finite index space carrying a matrix of trace one is nonempty. -/
+theorem nonempty_of_trace_eq_one {α : Type*} [Fintype α]
+    (ρ : Matrix α α ℂ) (hρ : ρ.trace = 1) : Nonempty α := by
+  classical
+  by_contra h
+  haveI : IsEmpty α := not_nonempty_iff.mp h
+  have hzero : ρ.trace = 0 := by
+    rw [Matrix.trace]
+    simp
+  rw [hzero] at hρ
+  norm_num at hρ
 
 section RankOneQuadratic
 

--- a/TNLean/MPS/MPDO/EtaPreparation.lean
+++ b/TNLean/MPS/MPDO/EtaPreparation.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.MPDO.KrausCPTP
 import TNLean.MPS.MPDO.SimpleLocalStructure
+import TNLean.Algebra.MatrixAux
 
 /-!
 # Normalized neighboring-operator preparations
@@ -20,8 +21,8 @@ $\operatorname{tr}(\eta_{k,h})=a_kb_h$, and treats the pairs with
 $a_kb_h=0$ without assuming that all sector weights are nonzero.
 
 The results construct the individual normalized preparations on active sector
-pairs. The orthogonal direct sum of these maps, including a trace-preserving
-completion on unused zero-weight input summands, is a separate construction.
+pairs, complete the zero-weight pairs with faithful density matrices, and
+assemble the completed families into global orthogonally controlled maps.
 -/
 
 open scoped Matrix BigOperators ComplexOrder
@@ -43,6 +44,9 @@ structure RankOneTraceFactorization (data : ExplicitEtaOperators hη) where
   trace_eta : ∀ k h, (data.eta k h).trace = ((a k * b h : ℝ) : ℂ)
   sum_mul : ∑ l, a l * b l = 1
 
+/-- The index space of the neighboring operator $\eta_{k,h}$. -/
+abbrev EtaIndex (k h : Fin hη.m) := Fin (hη.dR k) × Fin (hη.dL h)
+
 /-- The index space of
 $\Omega_{k,h}=\bigoplus_l(\eta_{k,l}\otimes\eta_{l,h})$.
 The outer sigma coordinate records the intermediate sector $l$. -/
@@ -50,6 +54,52 @@ abbrev OmegaIndex (k h : Fin hη.m) :=
   Σ l : Fin hη.m,
     (Fin (hη.dR k) × Fin (hη.dL l)) ×
       (Fin (hη.dR l) × Fin (hη.dL h))
+
+/-- Every right Hayashi factor is nonempty. This follows from the trace-one
+right density matrix, without a separate dimension hypothesis. -/
+theorem dR_nonempty (hη : EtaStructure rhoABC) (k : Fin hη.m) :
+    Nonempty (Fin (hη.dR k)) := by
+  have hp : Nonempty (Fin (hη.dR k) × Fin dC) :=
+    Matrix.nonempty_of_trace_eq_one (hη.ρ_right k) (hη.hρ_right_dm k).2
+  exact hp.map Prod.fst
+
+/-- Every left Hayashi factor is nonempty. This follows from the trace-one
+left density matrix, without a separate dimension hypothesis. -/
+theorem dL_nonempty (hη : EtaStructure rhoABC) (k : Fin hη.m) :
+    Nonempty (Fin (hη.dL k)) := by
+  have hp : Nonempty (Fin dA × Fin (hη.dL k)) :=
+    Matrix.nonempty_of_trace_eq_one (hη.ρ_left k) (hη.hρ_left_dm k).2
+  exact hp.map Prod.snd
+
+/-- The Hayashi sector set is nonempty because its probabilities sum to one. -/
+theorem sector_nonempty (hη : EtaStructure rhoABC) : Nonempty (Fin hη.m) := by
+  classical
+  by_contra h
+  haveI : IsEmpty (Fin hη.m) := not_nonempty_iff.mp h
+  have hzero : ∑ k : Fin hη.m, hη.p k = 0 := by simp
+  have hsum := hη.hp_sum
+  rw [hzero] at hsum
+  norm_num at hsum
+
+/-- The neighboring-operator space is nonempty for every sector pair. -/
+theorem etaIndex_nonempty (hη : EtaStructure rhoABC) (k h : Fin hη.m) :
+    Nonempty (EtaIndex (hη := hη) k h) := by
+  letI := dR_nonempty hη k
+  letI := dL_nonempty hη h
+  infer_instance
+
+/-- The direct-sum neighboring-operator space is nonempty for every sector
+pair. -/
+theorem omegaIndex_nonempty (hη : EtaStructure rhoABC) (k h : Fin hη.m) :
+    Nonempty (OmegaIndex (hη := hη) k h) := by
+  rcases sector_nonempty hη with ⟨l⟩
+  letI := dR_nonempty hη k
+  letI := dL_nonempty hη l
+  letI := dR_nonempty hη l
+  letI := dL_nonempty hη h
+  exact (inferInstance : Nonempty
+    ((Fin (hη.dR k) × Fin (hη.dL l)) ×
+      (Fin (hη.dR l) × Fin (hη.dL h)))).map (Sigma.mk l)
 
 /-- The direct sum
 $\Omega_{k,h}=\bigoplus_l(\eta_{k,l}\otimes\eta_{l,h})$, adjoined by the
@@ -216,5 +266,262 @@ theorem normalizedOmega_preparationMap_isKrausCPTP
       (data.normalizedOmega factor k h)) :=
   Matrix.preparationMap_isKrausCPTP _
     (data.normalizedOmega_pos factor k h) (data.trace_normalizedOmega factor k h hactive)
+
+/-! ## Completion on inactive sector pairs -/
+
+/-- The faithful uniform density matrix used to complete a zero-weight
+neighboring sector. The nonemptiness of its space follows from the trace-one
+Hayashi density matrices. -/
+noncomputable def inactiveEtaDensity (hη : EtaStructure rhoABC) (k h : Fin hη.m) :
+    Matrix (EtaIndex (hη := hη) k h) (EtaIndex (hη := hη) k h) ℂ :=
+  letI := etaIndex_nonempty hη k h
+  Matrix.faithfulDensity _
+
+/-- The inactive neighboring-sector density is positive definite. -/
+theorem inactiveEtaDensity_posDef (hη : EtaStructure rhoABC) (k h : Fin hη.m) :
+    (inactiveEtaDensity hη k h).PosDef :=
+  letI := etaIndex_nonempty hη k h
+  Matrix.faithfulDensity_posDef _
+
+/-- The inactive neighboring-sector density has trace one. -/
+theorem inactiveEtaDensity_trace (hη : EtaStructure rhoABC) (k h : Fin hη.m) :
+    (inactiveEtaDensity hη k h).trace = 1 :=
+  letI := etaIndex_nonempty hη k h
+  Matrix.faithfulDensity_trace _
+
+/-- The faithful uniform density matrix used to complete a zero-weight
+direct-sum neighboring sector. The nonemptiness of its space follows from the
+trace-one Hayashi density matrices and probabilities. -/
+noncomputable def inactiveOmegaDensity (hη : EtaStructure rhoABC) (k h : Fin hη.m) :
+    Matrix (OmegaIndex (hη := hη) k h) (OmegaIndex (hη := hη) k h) ℂ :=
+  letI := omegaIndex_nonempty hη k h
+  Matrix.faithfulDensity _
+
+/-- The inactive direct-sum neighboring-sector density is positive definite. -/
+theorem inactiveOmegaDensity_posDef (hη : EtaStructure rhoABC) (k h : Fin hη.m) :
+    (inactiveOmegaDensity hη k h).PosDef :=
+  letI := omegaIndex_nonempty hη k h
+  Matrix.faithfulDensity_posDef _
+
+/-- The inactive direct-sum neighboring-sector density has trace one. -/
+theorem inactiveOmegaDensity_trace (hη : EtaStructure rhoABC) (k h : Fin hη.m) :
+    (inactiveOmegaDensity hη k h).trace = 1 :=
+  letI := omegaIndex_nonempty hη k h
+  Matrix.faithfulDensity_trace _
+
+/-- The completed neighboring density equals the normalized source operator
+on an active pair and the faithful uniform density on a zero-weight pair.
+
+On active pairs this is the state adjoined by $\mathcal S_{k,h}$ in
+arXiv:1606.00608, Appendix C.2, lines 1551--1555. The inactive branch is a
+trace-preserving extension where the source quotient is undefined. -/
+noncomputable def completedEta (data : ExplicitEtaOperators hη)
+    (factor : RankOneTraceFactorization data) (k h : Fin hη.m) :
+    Matrix (EtaIndex (hη := hη) k h) (EtaIndex (hη := hη) k h) ℂ :=
+  if factor.a k * factor.b h ≠ 0 then data.normalizedEta factor k h
+  else inactiveEtaDensity hη k h
+
+/-- The completed direct-sum density equals the normalized source operator on
+an active pair and the faithful uniform density on a zero-weight pair.
+
+On active pairs this is the state adjoined by $\mathcal T_{k,h}$ in
+arXiv:1606.00608, Appendix C.2, lines 1527--1535. The inactive branch is a
+trace-preserving extension where the source quotient is undefined. -/
+noncomputable def completedOmega (data : ExplicitEtaOperators hη)
+    (factor : RankOneTraceFactorization data) (k h : Fin hη.m) :
+    Matrix (OmegaIndex (hη := hη) k h) (OmegaIndex (hη := hη) k h) ℂ :=
+  if factor.a k * factor.b h ≠ 0 then data.normalizedOmega factor k h
+  else inactiveOmegaDensity hη k h
+
+/-- The completed neighboring density is positive semidefinite on every
+sector pair. -/
+theorem completedEta_pos (data : ExplicitEtaOperators hη)
+    (factor : RankOneTraceFactorization data) (k h : Fin hη.m) :
+    (data.completedEta factor k h).PosSemidef := by
+  rw [completedEta]
+  split_ifs
+  · exact data.normalizedEta_pos factor k h
+  · exact (inactiveEtaDensity_posDef hη k h).posSemidef
+
+/-- The completed neighboring density has trace one on every sector pair. -/
+theorem trace_completedEta (data : ExplicitEtaOperators hη)
+    (factor : RankOneTraceFactorization data) (k h : Fin hη.m) :
+    (data.completedEta factor k h).trace = 1 := by
+  rw [completedEta]
+  split_ifs with hactive
+  · exact data.trace_normalizedEta factor k h hactive
+  · exact inactiveEtaDensity_trace hη k h
+
+/-- The completed direct-sum density is positive semidefinite on every sector
+pair. -/
+theorem completedOmega_pos (data : ExplicitEtaOperators hη)
+    (factor : RankOneTraceFactorization data) (k h : Fin hη.m) :
+    (data.completedOmega factor k h).PosSemidef := by
+  rw [completedOmega]
+  split_ifs
+  · exact data.normalizedOmega_pos factor k h
+  · exact (inactiveOmegaDensity_posDef hη k h).posSemidef
+
+/-- The completed direct-sum density has trace one on every sector pair. -/
+theorem trace_completedOmega (data : ExplicitEtaOperators hη)
+    (factor : RankOneTraceFactorization data) (k h : Fin hη.m) :
+    (data.completedOmega factor k h).trace = 1 := by
+  rw [completedOmega]
+  split_ifs with hactive
+  · exact data.trace_normalizedOmega factor k h hactive
+  · exact inactiveOmegaDensity_trace hη k h
+
+/-- On an active pair, the completed neighboring density is the normalized
+neighboring operator from the source formula. -/
+theorem completedEta_eq_normalizedEta (data : ExplicitEtaOperators hη)
+    (factor : RankOneTraceFactorization data) (k h : Fin hη.m)
+    (hactive : factor.a k * factor.b h ≠ 0) :
+    data.completedEta factor k h = data.normalizedEta factor k h := by
+  simp [completedEta, hactive]
+
+/-- On an active pair, the completed direct-sum density is the normalized
+direct-sum operator from the source formula. -/
+theorem completedOmega_eq_normalizedOmega (data : ExplicitEtaOperators hη)
+    (factor : RankOneTraceFactorization data) (k h : Fin hη.m)
+    (hactive : factor.a k * factor.b h ≠ 0) :
+    data.completedOmega factor k h = data.normalizedOmega factor k h := by
+  simp [completedOmega, hactive]
+
+/-- The sectorwise preparation which adjoins the completed neighboring
+density. -/
+noncomputable def completedEtaPreparationMap
+    {α : Type*} [Fintype α] [DecidableEq α]
+    (data : ExplicitEtaOperators hη) (factor : RankOneTraceFactorization data)
+    (k h : Fin hη.m) :
+    Matrix α α ℂ →ₗ[ℂ]
+      Matrix (α × EtaIndex (hη := hη) k h) (α × EtaIndex (hη := hη) k h) ℂ :=
+  Matrix.preparationMap (data.completedEta factor k h)
+
+/-- The sectorwise preparation which adjoins the completed direct-sum
+density. -/
+noncomputable def completedOmegaPreparationMap
+    {α : Type*} [Fintype α] [DecidableEq α]
+    (data : ExplicitEtaOperators hη) (factor : RankOneTraceFactorization data)
+    (k h : Fin hη.m) :
+    Matrix α α ℂ →ₗ[ℂ]
+      Matrix (α × OmegaIndex (hη := hη) k h) (α × OmegaIndex (hη := hη) k h) ℂ :=
+  Matrix.preparationMap (data.completedOmega factor k h)
+
+/-- Adjoining the completed neighboring density is trace-preserving and
+completely positive on every sector pair. It agrees with $\mathcal S_{k,h}$
+of arXiv:1606.00608, Appendix C.2, lines 1551--1555, on active pairs. -/
+theorem completedEta_preparationMap_isKrausCPTP
+    {α : Type*} [Fintype α] [DecidableEq α]
+    (data : ExplicitEtaOperators hη) (factor : RankOneTraceFactorization data)
+    (k h : Fin hη.m) :
+    IsKrausCPTP (data.completedEtaPreparationMap factor (α := α) k h) := by
+  simpa [completedEtaPreparationMap] using Matrix.preparationMap_isKrausCPTP _
+    (data.completedEta_pos factor k h) (data.trace_completedEta factor k h)
+
+/-- Adjoining the completed direct-sum density is trace-preserving and
+completely positive on every sector pair. It agrees with $\mathcal T_{k,h}$
+of arXiv:1606.00608, Appendix C.2, lines 1527--1535, on active pairs. -/
+theorem completedOmega_preparationMap_isKrausCPTP
+    {α : Type*} [Fintype α] [DecidableEq α]
+    (data : ExplicitEtaOperators hη) (factor : RankOneTraceFactorization data)
+    (k h : Fin hη.m) :
+    IsKrausCPTP (data.completedOmegaPreparationMap factor (α := α) k h) := by
+  simpa [completedOmegaPreparationMap] using Matrix.preparationMap_isKrausCPTP _
+    (data.completedOmega_pos factor k h) (data.trace_completedOmega factor k h)
+
+/-- On an active pair, the completed neighboring preparation is the source
+preparation. -/
+theorem completedEtaPreparationMap_eq_normalized
+    {α : Type*} [Fintype α] [DecidableEq α]
+    (data : ExplicitEtaOperators hη) (factor : RankOneTraceFactorization data)
+    (k h : Fin hη.m) (hactive : factor.a k * factor.b h ≠ 0) :
+    data.completedEtaPreparationMap factor (α := α) k h =
+      Matrix.preparationMap (data.normalizedEta factor k h) := by
+  rw [completedEtaPreparationMap, data.completedEta_eq_normalizedEta factor k h hactive]
+
+/-- On an active pair, the completed direct-sum preparation is the source
+preparation. -/
+theorem completedOmegaPreparationMap_eq_normalized
+    {α : Type*} [Fintype α] [DecidableEq α]
+    (data : ExplicitEtaOperators hη) (factor : RankOneTraceFactorization data)
+    (k h : Fin hη.m) (hactive : factor.a k * factor.b h ≠ 0) :
+    data.completedOmegaPreparationMap factor (α := α) k h =
+      Matrix.preparationMap (data.normalizedOmega factor k h) := by
+  rw [completedOmegaPreparationMap, data.completedOmega_eq_normalizedOmega factor k h hactive]
+
+/-! ## Global orthogonally controlled preparations -/
+
+section GlobalCompletion
+
+variable {α : Fin hη.m × Fin hη.m → Type*}
+variable [∀ p, Fintype (α p)] [∀ p, DecidableEq (α p)]
+
+/-- The global orthogonally controlled neighboring-state preparation. It
+discards coherences between sector pairs and adjoins the completed neighboring
+density inside each diagonal sector.
+
+On active pairs its sector maps are the $\mathcal S_{k,h}$ preparations in
+arXiv:1606.00608, Appendix C.2, lines 1548--1555. The inactive sectors give a
+trace-preserving extension and are not identified with the undefined source
+quotient. -/
+noncomputable def completedEtaControlledMap
+    (data : ExplicitEtaOperators hη) (factor : RankOneTraceFactorization data) :
+    Matrix (Σ p, α p) (Σ p, α p) ℂ →ₗ[ℂ]
+      Matrix (Σ p, α p × EtaIndex (hη := hη) p.1 p.2)
+        (Σ p, α p × EtaIndex (hη := hη) p.1 p.2) ℂ :=
+  Matrix.controlledKrausMap
+    (fun p => Fintype.card (EtaIndex (hη := hη) p.1 p.2))
+    (fun p j => Matrix.preparationKraus (data.completedEta factor p.1 p.2)
+      (data.completedEta_pos factor p.1 p.2)
+      ((Fintype.equivFin (EtaIndex (hη := hη) p.1 p.2)).symm j))
+
+/-- The global orthogonally controlled neighboring-state preparation is
+trace-preserving and completely positive.
+
+This is the completed sector-control part of $\mathcal S_1$ in
+arXiv:1606.00608, Appendix C.2, lines 1548--1555. It does not include the
+regrouping and shift maps surrounding $\mathcal S_1$ in the full construction. -/
+theorem completedEtaControlledMap_isKrausCPTP
+    (data : ExplicitEtaOperators hη) (factor : RankOneTraceFactorization data) :
+    IsKrausCPTP (data.completedEtaControlledMap factor (α := α)) := by
+  apply Matrix.controlledKrausMap_isKrausCPTP
+  intro p
+  exact Matrix.preparationKraus_resolution (data.completedEta factor p.1 p.2)
+    (data.completedEta_pos factor p.1 p.2) (data.trace_completedEta factor p.1 p.2)
+
+/-- The global orthogonally controlled direct-sum preparation. It discards
+coherences between sector pairs and adjoins the completed direct-sum density
+inside each diagonal sector.
+
+On active pairs its sector maps are the $\mathcal T_{k,h}$ preparations in
+arXiv:1606.00608, Appendix C.2, lines 1523--1535. The inactive sectors give a
+trace-preserving extension and are not identified with the undefined source
+quotient. -/
+noncomputable def completedOmegaControlledMap
+    (data : ExplicitEtaOperators hη) (factor : RankOneTraceFactorization data) :
+    Matrix (Σ p, α p) (Σ p, α p) ℂ →ₗ[ℂ]
+      Matrix (Σ p, α p × OmegaIndex (hη := hη) p.1 p.2)
+        (Σ p, α p × OmegaIndex (hη := hη) p.1 p.2) ℂ :=
+  Matrix.controlledKrausMap
+    (fun p => Fintype.card (OmegaIndex (hη := hη) p.1 p.2))
+    (fun p j => Matrix.preparationKraus (data.completedOmega factor p.1 p.2)
+      (data.completedOmega_pos factor p.1 p.2)
+      ((Fintype.equivFin (OmegaIndex (hη := hη) p.1 p.2)).symm j))
+
+/-- The global orthogonally controlled direct-sum preparation is
+trace-preserving and completely positive.
+
+This is the completed sector-control part of $\mathcal T_1$ in
+arXiv:1606.00608, Appendix C.2, lines 1523--1535. It does not include the
+regrouping and shift maps surrounding $\mathcal T_1$ in the full construction. -/
+theorem completedOmegaControlledMap_isKrausCPTP
+    (data : ExplicitEtaOperators hη) (factor : RankOneTraceFactorization data) :
+    IsKrausCPTP (data.completedOmegaControlledMap factor (α := α)) := by
+  apply Matrix.controlledKrausMap_isKrausCPTP
+  intro p
+  exact Matrix.preparationKraus_resolution (data.completedOmega factor p.1 p.2)
+    (data.completedOmega_pos factor p.1 p.2) (data.trace_completedOmega factor p.1 p.2)
+
+end GlobalCompletion
 
 end MPOTensor.ExplicitEtaOperators

--- a/TNLean/MPS/MPDO/KrausCPTP.lean
+++ b/TNLean/MPS/MPDO/KrausCPTP.lean
@@ -34,6 +34,7 @@ dimensions.
   trace-preserving completely positive map.
 * `Matrix.preparationMap_isKrausCPTP`: adjoining a density matrix is a
   trace-preserving completely positive map.
+* `Matrix.preparationKraus`: the explicit Kraus family for state preparation.
 -/
 
 open scoped Matrix BigOperators ComplexOrder
@@ -408,7 +409,11 @@ def preparationMap {α β : Type*} [Fintype α] [DecidableEq α]
   map_add' X Y := Matrix.add_kronecker X Y ρ
   map_smul' c X := Matrix.smul_kronecker c X ρ
 
-private noncomputable def preparationKraus
+/-- The Kraus operator obtained from one column of the positive square root of
+the density matrix in a state-preparation map. These are the explicit
+operators underlying the preparations in arXiv:1606.00608, Appendix C.2,
+lines 1527--1533 and 1551--1555. -/
+noncomputable def preparationKraus
     {α β : Type*} [Fintype α] [DecidableEq α]
     [Fintype β] [DecidableEq β] (ρ : Matrix β β ℂ) (hρ : ρ.PosSemidef) (j : β) :
     Matrix (α × β) α ℂ :=
@@ -459,6 +464,41 @@ private theorem preparationKraus_conjTranspose_mul_apply
     simp [preparationKraus, Matrix.conjTranspose_apply]
   · simp [preparationKraus, Matrix.conjTranspose_apply, hab, Ne.symm hab]
 
+/-- The explicit preparation Kraus family resolves the identity,
+$\sum_j A_j^\dagger A_j=I$, when the prepared matrix has trace one. -/
+theorem preparationKraus_resolution
+    {α β : Type*} [Fintype α] [DecidableEq α]
+    [Fintype β] [DecidableEq β] (ρ : Matrix β β ℂ) (hρ : ρ.PosSemidef)
+    (hρtr : ρ.trace = 1) :
+    ∑ j : Fin (Fintype.card β),
+      (preparationKraus (α := α) ρ hρ ((Fintype.equivFin β).symm j))ᴴ *
+        preparationKraus (α := α) ρ hρ ((Fintype.equivFin β).symm j) = 1 := by
+  classical
+  let R := hρ.isHermitian.cfc Real.sqrt
+  have hRherm : R.IsHermitian := hρ.cfc_sqrt_isHermitian
+  have hRR : R * R = ρ := hρ.cfc_sqrt_mul_self
+  ext a b
+  have hsum : ∑ j : β, ∑ t : β, star (R t j) * R t j = 1 := by
+    calc
+      ∑ j : β, ∑ t : β, star (R t j) * R t j = (R * R).trace := by
+        simp_rw [hRherm.apply]
+        rfl
+      _ = ρ.trace := congrArg Matrix.trace hRR
+      _ = 1 := hρtr
+  by_cases hab : a = b
+  · subst b
+    rw [Matrix.one_apply_eq, Matrix.sum_apply]
+    simp_rw [preparationKraus_conjTranspose_mul_apply, if_pos]
+    change (∑ x : Fin (Fintype.card β),
+      ∑ t : β, star (R t ((Fintype.equivFin β).symm x)) *
+        R t ((Fintype.equivFin β).symm x)) = 1
+    exact (Equiv.sum_comp (Fintype.equivFin β).symm
+      (fun j : β => ∑ t : β, star (R t j) * R t j)).trans hsum
+  · rw [Matrix.one_apply_ne hab, Matrix.sum_apply]
+    apply Finset.sum_eq_zero
+    intro j _
+    rw [preparationKraus_conjTranspose_mul_apply, if_neg hab]
+
 /-- Adjoining a positive-semidefinite matrix of trace one is a
 trace-preserving completely positive map.  Its Kraus operators are obtained
 from the columns of $\sqrt\rho$.
@@ -486,26 +526,6 @@ lemma preparationMap_isKrausCPTP
     refine Finset.sum_congr rfl fun j _ => ?_
     rw [preparationKraus_mul_conjTranspose_apply]
     rw [hRherm.apply]
-  · ext a b
-    have hsum : ∑ j : β, ∑ t : β, star (R t j) * R t j = 1 := by
-      calc
-        ∑ j : β, ∑ t : β, star (R t j) * R t j = (R * R).trace := by
-          simp_rw [hRherm.apply]
-          rfl
-        _ = ρ.trace := congrArg Matrix.trace hRR
-        _ = 1 := hρtr
-    by_cases hab : a = b
-    · subst b
-      rw [Matrix.one_apply_eq, Matrix.sum_apply]
-      simp_rw [preparationKraus_conjTranspose_mul_apply, if_pos]
-      change (∑ x : Fin (Fintype.card β),
-        ∑ t : β, star (R t ((Fintype.equivFin β).symm x)) *
-          R t ((Fintype.equivFin β).symm x)) = 1
-      exact (Equiv.sum_comp (Fintype.equivFin β).symm
-        (fun j : β => ∑ t : β, star (R t j) * R t j)).trans hsum
-    · rw [Matrix.one_apply_ne hab, Matrix.sum_apply]
-      apply Finset.sum_eq_zero
-      intro j _
-      rw [preparationKraus_conjTranspose_mul_apply, if_neg hab]
+  · exact preparationKraus_resolution ρ hρ hρtr
 
 end Matrix

--- a/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
@@ -231,11 +231,44 @@
     \cite[Appendix~C.2, lines~1527--1533 and~1551--1555]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
+\begin{definition}[Preparation Kraus operators]
+    \label{def:mpdo_state_preparation_kraus}
+    \lean{Matrix.preparationKraus}
+    \leanok
+    Let $R=\sqrt\rho$. For an orthonormal basis $(e_j)_j$ of $B$, define
+    rectangular operators $A_j:A\to A\otimes B$ by
+    \[
+        A_j(e_a)=e_a\otimes Re_j.
+    \]
+\end{definition}
+
+\begin{theorem}[Preparation Kraus operators resolve the identity]
+    \label{thm:mpdo_state_preparation_kraus_resolution}
+    \lean{Matrix.preparationKraus_resolution}
+    \leanok
+    \uses{def:mpdo_state_preparation_kraus}
+    If $\rho\geq0$ and $\tr(\rho)=1$, then
+    \[
+        \sum_j A_j^\dagger A_j=I_A.
+    \]
+\end{theorem}
+\begin{proof}
+    \leanok
+    Since $R$ is Hermitian and $R^2=\rho$, the diagonal entries of the sum are
+    \[
+        \sum_{j,t}\overline{R_{tj}}R_{tj}
+        =\tr(R^2)=\tr(\rho)=1,
+    \]
+    while its off-diagonal entries vanish.
+\end{proof}
+
 \begin{lemma}[State preparation is trace-preserving completely positive]
     \label{lem:mpdo_state_preparation_cptp}
     \lean{Matrix.preparationMap_isKrausCPTP}
     \leanok
-    \uses{def:mpdo_state_preparation_map, def:is_kraus_cptp}
+    \uses{def:mpdo_state_preparation_map, def:is_kraus_cptp,
+      def:mpdo_state_preparation_kraus,
+      thm:mpdo_state_preparation_kraus_resolution}
     If $\rho\geq0$ and $\tr(\rho)=1$, then
     $\mathcal P_\rho:X\mapsto X\otimes\rho$ is trace-preserving completely
     positive.
@@ -243,17 +276,13 @@
 
 \begin{proof}
     \leanok
-    Let $R=\sqrt\rho$.  For an orthonormal basis $(e_j)_j$ of $B$, define
-    rectangular Kraus operators
-    \[
-        A_j(e_a)=e_a\otimes Re_j.
-    \]
-    Then
+    The operators from Definition~\ref{def:mpdo_state_preparation_kraus}
+    satisfy
     \[
         \sum_j A_jXA_j^\dagger=X\otimes RR=X\otimes\rho,
-        \qquad
-        \sum_j A_j^\dagger A_j=\tr(RR)I_A=I_A.
     \]
+    and Theorem~\ref{thm:mpdo_state_preparation_kraus_resolution} gives their
+    resolution of the identity.
 \end{proof}
 
 \begin{definition}[Physical closure maps]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -1448,9 +1448,303 @@ strong subadditivity for a normalized three-site reduced state.
     Apply Lemma~\ref{lem:mpdo_state_preparation_cptp} to each operator.
 \end{proof}
 
-% The orthogonal direct sum of the active maps and a trace-preserving
-% completion on the unused zero-weight input summands remain part of the
-% construction of the full maps T_1 and S_1.
+\begin{lemma}[Trace-one matrices have nonempty index spaces]
+    \label{lem:mpdo_trace_one_nonempty}
+    \lean{Matrix.nonempty_of_trace_eq_one}
+    \leanok
+    If a matrix indexed by a finite type has trace one, then its index type
+    is nonempty.
+\end{lemma}
+\begin{proof}
+    \leanok
+    A matrix on an empty index space has trace zero, contrary to the
+    hypothesis.
+\end{proof}
+
+\begin{theorem}[Nonemptiness of the Hayashi auxiliary spaces]
+    \label{thm:mpdo_hayashi_auxiliary_nonempty}
+    \lean{MPOTensor.ExplicitEtaOperators.dR_nonempty}
+    \lean{MPOTensor.ExplicitEtaOperators.dL_nonempty}
+    \lean{MPOTensor.ExplicitEtaOperators.sector_nonempty}
+    \lean{MPOTensor.ExplicitEtaOperators.etaIndex_nonempty}
+    \lean{MPOTensor.ExplicitEtaOperators.omegaIndex_nonempty}
+    \leanok
+    \uses{def:mpdo_eta_structure, def:mpdo_eta_omega,
+      lem:mpdo_trace_one_nonempty}
+    Every left and right factor in a Hayashi sector is nonzero-dimensional,
+    and the set of sectors is nonempty. Consequently the spaces carrying
+    $\eta_{k,h}$ and $\Omega_{k,h}$ are nonzero-dimensional for all $k,h$.
+\end{theorem}
+\begin{proof}
+    \leanok
+    A matrix on an empty index space has trace zero. Hence
+    \[
+      \tr(\rho_k^R)=1
+      \Longrightarrow \dim(B_k^R\otimes C)>0
+      \Longrightarrow \dim B_k^R>0,
+    \]
+    and the same argument applied to $\rho_k^L$ gives
+    $d_k^L>0$. Moreover,
+    \[
+      \sum_k p_k=1\Longrightarrow m>0.
+    \]
+    Choosing one intermediate sector $l$ now supplies an element of every
+    direct-sum space carrying $\Omega_{k,h}$.
+\end{proof}
+
+\begin{definition}[Faithful uniform density matrix]
+    \label{def:mpdo_faithful_uniform_density}
+    \lean{Matrix.faithfulDensity}
+    \leanok
+    On a nonzero finite-dimensional space $H$, define
+    \[
+        \tau_H=\frac{1}{\dim H}I_H.
+    \]
+\end{definition}
+
+\begin{theorem}[The uniform density matrix is faithful and normalized]
+    \label{thm:mpdo_faithful_uniform_density}
+    \lean{Matrix.faithfulDensity_posDef}
+    \lean{Matrix.faithfulDensity_trace}
+    \leanok
+    \uses{def:mpdo_faithful_uniform_density}
+    The matrix $\tau_H$ is positive definite and has trace one.
+\end{theorem}
+\begin{proof}
+    \leanok
+    Since $\dim H>0$, the scalar $(\dim H)^{-1}$ is positive. Thus
+    $\tau_H$ is positive definite, and
+    $\tr(\tau_H)=(\dim H)^{-1}\dim H=1$.
+\end{proof}
+
+\begin{definition}[Completed neighboring-state preparation]
+    \label{def:mpdo_completed_eta_preparation}
+    \lean{MPOTensor.ExplicitEtaOperators.inactiveEtaDensity}
+    \lean{MPOTensor.ExplicitEtaOperators.completedEta}
+    \lean{MPOTensor.ExplicitEtaOperators.completedEtaPreparationMap}
+    \leanok
+    \uses{def:mpdo_normalized_eta_omega,
+      thm:mpdo_hayashi_auxiliary_nonempty,
+      def:mpdo_faithful_uniform_density}
+    For every sector pair define
+    \[
+        \overline\eta_{k,h}=
+        \begin{cases}
+          \widehat\eta_{k,h},&a_kb_h\ne0,\\
+          \tau_{B_k^R\otimes B_h^L},&a_kb_h=0,
+        \end{cases}
+        \qquad
+        \overline{\mathcal S}_{k,h}(X)
+        =X\otimes\overline\eta_{k,h}.
+    \]
+    On an active pair this is precisely the preparation
+    $\mathcal S_{k,h}$ of
+    \cite[Appendix~C.2, lines~1551--1555]{Cirac2016MPDO_arXiv}; the second
+    branch gives a normalized extension on a pair where the displayed source
+    quotient is undefined.
+\end{definition}
+
+\begin{theorem}[Completed neighboring-state preparations are trace-preserving
+    completely positive]
+    \label{thm:mpdo_completed_eta_preparation_cptp}
+    \lean{MPOTensor.ExplicitEtaOperators.completedEta_pos}
+    \lean{MPOTensor.ExplicitEtaOperators.trace_completedEta}
+    \lean{MPOTensor.ExplicitEtaOperators.completedEta_eq_normalizedEta}
+    \lean{MPOTensor.ExplicitEtaOperators.completedEta_preparationMap_isKrausCPTP}
+    \lean{MPOTensor.ExplicitEtaOperators.completedEtaPreparationMap_eq_normalized}
+    \leanok
+    \uses{def:mpdo_completed_eta_preparation,
+      thm:mpdo_normalized_eta_omega_preparation,
+      thm:mpdo_faithful_uniform_density, lem:mpdo_state_preparation_cptp}
+    For every pair $(k,h)$, the operator $\overline\eta_{k,h}$ is positive
+    semidefinite with trace one. Hence $\overline{\mathcal S}_{k,h}$ is
+    trace-preserving and completely positive. If $a_kb_h\ne0$, then both the
+    density matrix and the preparation equal their normalized active forms.
+\end{theorem}
+\begin{proof}
+    \leanok
+    The two branches give
+    \[
+      a_kb_h\ne0\Longrightarrow
+      \overline\eta_{k,h}=\widehat\eta_{k,h}\succeq0,
+      \quad \tr(\overline\eta_{k,h})=1,
+    \]
+    and
+    \[
+      a_kb_h=0\Longrightarrow
+      \overline\eta_{k,h}=\tau_{B_k^R\otimes B_h^L}\succ0,
+      \quad \tr(\overline\eta_{k,h})=1.
+    \]
+    The state-preparation result applies in either case.
+\end{proof}
+
+\begin{definition}[Completed direct-sum preparation]
+    \label{def:mpdo_completed_omega_preparation}
+    \lean{MPOTensor.ExplicitEtaOperators.inactiveOmegaDensity}
+    \lean{MPOTensor.ExplicitEtaOperators.completedOmega}
+    \lean{MPOTensor.ExplicitEtaOperators.completedOmegaPreparationMap}
+    \leanok
+    \uses{def:mpdo_normalized_eta_omega,
+      thm:mpdo_hayashi_auxiliary_nonempty,
+      def:mpdo_faithful_uniform_density}
+    For every sector pair define
+    \[
+        \mathcal H_{k,h}^{\Omega}
+        =\bigoplus_l
+          (B_k^R\otimes B_l^L)\otimes(B_l^R\otimes B_h^L),
+        \qquad
+        \overline\Omega_{k,h}=
+        \begin{cases}
+          \widehat\Omega_{k,h},&a_kb_h\ne0,\\
+          \tau_{\mathcal H_{k,h}^{\Omega}},&a_kb_h=0,
+        \end{cases}
+        \qquad
+        \overline{\mathcal T}_{k,h}(X)
+        =X\otimes\overline\Omega_{k,h},
+    \]
+    where the second density acts on the full direct-sum index space of
+    $\Omega_{k,h}$. On an active pair this is precisely the preparation
+    $\mathcal T_{k,h}$ of
+    \cite[Appendix~C.2, lines~1527--1535]{Cirac2016MPDO_arXiv}; the inactive
+    branch is a normalized extension.
+\end{definition}
+
+\begin{theorem}[Completed direct-sum preparations are trace-preserving
+    completely positive]
+    \label{thm:mpdo_completed_omega_preparation_cptp}
+    \lean{MPOTensor.ExplicitEtaOperators.completedOmega_pos}
+    \lean{MPOTensor.ExplicitEtaOperators.trace_completedOmega}
+    \lean{MPOTensor.ExplicitEtaOperators.completedOmega_eq_normalizedOmega}
+    \lean{MPOTensor.ExplicitEtaOperators.completedOmega_preparationMap_isKrausCPTP}
+    \lean{MPOTensor.ExplicitEtaOperators.completedOmegaPreparationMap_eq_normalized}
+    \leanok
+    \uses{def:mpdo_completed_omega_preparation,
+      thm:mpdo_normalized_eta_omega_preparation,
+      thm:mpdo_faithful_uniform_density, lem:mpdo_state_preparation_cptp}
+    For every pair $(k,h)$, the operator $\overline\Omega_{k,h}$ is positive
+    semidefinite with trace one. Hence $\overline{\mathcal T}_{k,h}$ is
+    trace-preserving and completely positive. On every active pair it equals
+    the normalized active preparation.
+\end{theorem}
+\begin{proof}
+    \leanok
+    On the active branch,
+    \[
+      a_kb_h\ne0\Longrightarrow
+      \overline\Omega_{k,h}=\widehat\Omega_{k,h}\succeq0,
+      \quad \tr(\overline\Omega_{k,h})=1,
+    \]
+    while on the inactive branch,
+    \[
+      a_kb_h=0\Longrightarrow
+      \overline\Omega_{k,h}=\tau_{\mathcal H_{k,h}^{\Omega}}\succ0,
+      \quad \tr(\overline\Omega_{k,h})=1.
+    \]
+    The state-preparation result therefore applies to
+    $\overline{\mathcal T}_{k,h}$.
+\end{proof}
+
+\begin{definition}[Globally controlled neighboring-state preparation]
+    \label{def:mpdo_completed_eta_controlled_map}
+    \lean{MPOTensor.ExplicitEtaOperators.completedEtaControlledMap}
+    \leanok
+    \uses{def:mpdo_completed_eta_preparation,
+      def:mpdo_state_preparation_kraus,
+      def:mpdo_controlled_kraus_map}
+    Let $H=\bigoplus_{k,h}H_{k,h}$. Orthogonally controlling the completed
+    preparations over the sector pairs gives a map
+    \[
+        \overline{\mathcal S}_1(X)
+        =\sum_{k,h,a}\widetilde A_{k,h,a}X
+          \widetilde A_{k,h,a}^{\dagger},
+    \]
+    where $(A_{k,h,a})_a$ is a Kraus family for
+    $\overline{\mathcal S}_{k,h}$ and the tilde denotes its extension by zero
+    outside $H_{k,h}$. Thus the map discards inter-sector coherences and
+    applies the completed preparation in each diagonal sector. On active
+    sectors this is the sector-control formula for $\mathcal S_1$ in
+    \cite[Appendix~C.2, lines~1548--1555]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{theorem}[The globally controlled neighboring-state preparation is
+    trace-preserving completely positive]
+    \label{thm:mpdo_completed_eta_controlled_map_cptp}
+    \lean{MPOTensor.ExplicitEtaOperators.completedEtaControlledMap_isKrausCPTP}
+    \leanok
+    \uses{def:mpdo_completed_eta_controlled_map,
+      thm:mpdo_completed_eta_preparation_cptp,
+      thm:mpdo_state_preparation_kraus_resolution,
+      thm:mpdo_controlled_kraus_map_cptp}
+    The map $\overline{\mathcal S}_1$ is trace-preserving and completely
+    positive.
+\end{theorem}
+\begin{proof}
+    \leanok
+    If $(A_{k,h,a})_a$ is the sectorwise Kraus family, then
+    \[
+      \sum_{k,h,a}\widetilde A_{k,h,a}^{\dagger}\widetilde A_{k,h,a}
+      =\bigoplus_{k,h}\left(\sum_a A_{k,h,a}^{\dagger}A_{k,h,a}\right)
+      =\bigoplus_{k,h}I_{H_{k,h}}=I_H.
+    \]
+    Thus the controlled Kraus family is trace-preserving.
+\end{proof}
+
+\begin{definition}[Globally controlled direct-sum preparation]
+    \label{def:mpdo_completed_omega_controlled_map}
+    \lean{MPOTensor.ExplicitEtaOperators.completedOmegaControlledMap}
+    \leanok
+    \uses{def:mpdo_completed_omega_preparation,
+      def:mpdo_state_preparation_kraus,
+      def:mpdo_controlled_kraus_map}
+    Orthogonally controlling the completed direct-sum preparations gives
+    \[
+        \overline{\mathcal T}_1(X)
+        =\sum_{k,h,a}\widetilde B_{k,h,a}X
+          \widetilde B_{k,h,a}^{\dagger},
+    \]
+    where $(B_{k,h,a})_a$ is a Kraus family for
+    $\overline{\mathcal T}_{k,h}$. This map discards inter-sector coherences
+    and, on active sectors, is the sector-control formula for $\mathcal T_1$
+    in \cite[Appendix~C.2, lines~1523--1535]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{theorem}[The globally controlled direct-sum preparation is
+    trace-preserving completely positive]
+    \label{thm:mpdo_completed_omega_controlled_map_cptp}
+    \lean{MPOTensor.ExplicitEtaOperators.completedOmegaControlledMap_isKrausCPTP}
+    \leanok
+    \uses{def:mpdo_completed_omega_controlled_map,
+      thm:mpdo_completed_omega_preparation_cptp,
+      thm:mpdo_state_preparation_kraus_resolution,
+      thm:mpdo_controlled_kraus_map_cptp}
+    The map $\overline{\mathcal T}_1$ is trace-preserving and completely
+    positive.
+\end{theorem}
+\begin{proof}
+    \leanok
+    For the sectorwise Kraus family $(B_{k,h,a})_a$,
+    \[
+      \sum_{k,h,a}\widetilde B_{k,h,a}^{\dagger}\widetilde B_{k,h,a}
+      =\bigoplus_{k,h}\left(\sum_a B_{k,h,a}^{\dagger}B_{k,h,a}\right)
+      =\bigoplus_{k,h}I_{H_{k,h}}=I_H.
+    \]
+    The orthogonal-control theorem now gives the claim.
+\end{proof}
+
+\begin{remark}[Scope of the completed preparation]
+    The conclusions above begin with the rank-one trace factorization
+    $\tr(\eta_{k,h})=a_kb_h$ and $\sum_l a_lb_l=1$. Deriving this
+    factorization for the inverse-map neighboring operators from the strong
+    area law and zero correlation length is the Perron--Frobenius step of
+    \cite[Appendix~C.2, lines~1404--1410 and~1484--1498]
+      {Cirac2016MPDO_arXiv}.
+    The completed maps therefore give the global controlled preparation once
+    that factorization is supplied; they do not by themselves prove the full
+    two-map statement
+    \cite[Appendix~C.2, lines~1510--1517]{Cirac2016MPDO_arXiv}. The regrouping
+    maps, shift maps, and the required closure identities are separate parts
+    of that statement.
+\end{remark}
 
 \begin{figure}[ht]
     \centering


### PR DESCRIPTION
This PR completes the zero-weight neighboring-state preparations and their global orthogonally controlled CPTP maps.

It derives nonemptiness of every Hayashi auxiliary index space from the existing trace-one density matrices and sector probabilities, uses faithful uniform density matrices only on inactive pairs, proves equality with the source preparations on active pairs, and combines the sectorwise maps using the controlled Kraus construction.

The blueprint gives separate exact entries for the completed eta and Omega preparations and their global controlled maps. It explicitly records the remaining boundary: RankOneTraceFactorization is an input here, and the Perron–Frobenius derivation plus the surrounding regrouping, shift, and closure identities are not claimed by this PR.

Closes #3742.

Validation:
- lake env lean TNLean/MPS/MPDO/EtaPreparation.lean
- lake build TNLean (9299 jobs)
- leanblueprint checkdecls
- leanblueprint pdf (478 pages)
- reader-facing prose and diff checks
- independent exact-head source and blueprint audit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Substantial new formalization on quantum channels and sector completion logic; correctness hinges on the active/inactive split and Kraus resolution, but changes are localized to MPDO prep and matrix auxiliaries rather than core auth or runtime paths.
> 
> **Overview**
> **Completes** the MPDO eta preparation layer for sector pairs where the rank-one weight \(a_k b_h = 0\): instead of leaving those maps undefined, inactive pairs use **`Matrix.faithfulDensity`** (uniform \(\tau_H = I/\dim H\)), with nonemptiness of Hayashi index spaces derived from existing trace-one marginals via **`Matrix.nonempty_of_trace_eq_one`**.
> 
> **Adds** `completedEta` / `completedOmega` (active branch = normalized operators; inactive = uniform density), sectorwise preparation maps, and **`completedEtaControlledMap`** / **`completedOmegaControlledMap`** built from **`Matrix.controlledKrausMap`** and explicit **`Matrix.preparationKraus`** families. CPTP on all pairs is proved from trace-one PSD completions.
> 
> **Refactors** state preparation in **`KrausCPTP`**: public **`preparationKraus`** and **`preparationKraus_resolution`** (\(\sum_j A_j^\dagger A_j = I\)), which **`preparationMap_isKrausCPTP`** and the controlled maps now call directly.
> 
> Blueprint chapters gain matching definitions/theorems and a remark that **rank-one trace factorization remains an input**; Perron–Frobenius derivation and regrouping/shift/closure for full \(\mathcal T_1\) / \(\mathcal S_1\) are out of scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a49858f15fb3930f533a9e323e647e3a4dc54b23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->