### PR TITLE
feat(MPS/MPDO): define subspin regrouping maps

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -380,6 +380,7 @@ import TNLean.MPS.MPDO.PRFP
 import TNLean.MPS.MPDO.LocalPurificationRFP
 import TNLean.MPS.MPDO.SimpleLocalStructure
 import TNLean.MPS.MPDO.EtaPreparation
+import TNLean.MPS.MPDO.RFPSubspinMaps
 import TNLean.MPS.MPDO.HayashiSectorComparison
 import TNLean.MPS.MPDO.SectorFactorization
 import TNLean.MPS.MPDO.SectorPairingTransfer

--- a/TNLean/MPS/MPDO/KrausCPTP.lean
+++ b/TNLean/MPS/MPDO/KrausCPTP.lean
@@ -32,6 +32,8 @@ dimensions.
   Kraus families is trace-preserving completely positive.
 * `Matrix.partialTraceRightLM_isKrausCPTP`: tracing a right tensor factor is a
   trace-preserving completely positive map.
+* `Matrix.controlledPartialTraceRightLM_isKrausCPTP`: tracing dependent right
+  factors sector by sector is trace-preserving completely positive.
 * `Matrix.preparationMap_isKrausCPTP`: adjoining a density matrix is a
   trace-preserving completely positive map.
 * `Matrix.preparationKraus`: the explicit Kraus family for state preparation.
@@ -397,6 +399,52 @@ lemma partialTraceRightLM_isKrausCPTP
             apply hpq
             exact Prod.ext h.1 (h.2.1.symm.trans h.2.2)
           simp [partialTraceRightKraus_conjTranspose_mul_apply, hnot]
+
+private noncomputable def chosenKrausRank
+    {α β : Type*} [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]
+    {S : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ} (hS : IsKrausCPTP S) : ℕ :=
+  hS.choose
+
+private noncomputable def chosenKraus
+    {α β : Type*} [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]
+    {S : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ} (hS : IsKrausCPTP S) :
+    Fin (chosenKrausRank hS) → Matrix β α ℂ :=
+  hS.choose_spec.choose
+
+private theorem chosenKraus_resolution
+    {α β : Type*} [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]
+    {S : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ} (hS : IsKrausCPTP S) :
+    ∑ i, (chosenKraus hS i)ᴴ * chosenKraus hS i = (1 : Matrix α α ℂ) :=
+  hS.choose_spec.choose_spec.2
+
+/-- Partial trace on each summand of a dependent orthogonal direct sum. The
+map discards coherences between distinct summands and traces the right factor
+within every diagonal summand. -/
+noncomputable def controlledPartialTraceRightLM
+    {ι : Type*} [Fintype ι] [DecidableEq ι]
+    {α β : ι → Type*}
+    [∀ i, Fintype (α i)] [∀ i, DecidableEq (α i)]
+    [∀ i, Fintype (β i)] [∀ i, DecidableEq (β i)] :
+    Matrix (Σ i, α i × β i) (Σ i, α i × β i) ℂ →ₗ[ℂ]
+      Matrix (Σ i, α i) (Σ i, α i) ℂ :=
+  controlledKrausMap
+    (fun i => chosenKrausRank
+      (partialTraceRightLM_isKrausCPTP (α := α i) (β := β i)))
+    (fun i => chosenKraus
+      (partialTraceRightLM_isKrausCPTP (α := α i) (β := β i)))
+
+/-- The controlled dependent partial trace is trace-preserving and completely
+positive. -/
+theorem controlledPartialTraceRightLM_isKrausCPTP
+    {ι : Type*} [Fintype ι] [DecidableEq ι]
+    {α β : ι → Type*}
+    [∀ i, Fintype (α i)] [∀ i, DecidableEq (α i)]
+    [∀ i, Fintype (β i)] [∀ i, DecidableEq (β i)] :
+    IsKrausCPTP (controlledPartialTraceRightLM (α := α) (β := β)) := by
+  apply controlledKrausMap_isKrausCPTP
+  intro i
+  exact chosenKraus_resolution
+    (partialTraceRightLM_isKrausCPTP (α := α i) (β := β i))
 
 /-- The state-preparation map $X\mapsto X\otimes\rho$.  This is the
 elementary operation used to adjoin the positive neighboring operators in

--- a/TNLean/MPS/MPDO/RFPSubspinMaps.lean
+++ b/TNLean/MPS/MPDO/RFPSubspinMaps.lean
@@ -1,0 +1,381 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.MPDO.EtaPreparation
+
+/-!
+# Subspin regrouping and shifts for the MPDO fixed-point maps
+
+This file gives the concrete dependent equivalences underlying the partial
+traces $\mathcal T_0$, $\mathcal S_0$ and the shifts $\mathcal T_2$,
+$\mathcal S_2$ in arXiv:1606.00608, Appendix C.2, lines 1521--1522,
+1535--1540, 1547, and 1555--1559.
+
+The retained outer subspins in sectors $k,h$ have index
+$B_k^L\times B_h^R$. The complementary factors are precisely the index space
+of $\eta_{k,h}$ for two sites and of one summand of $\Omega_{k,h}$ for three
+sites. No equality between the left and right sector dimensions is required:
+the equivalences only reorder existing factors.
+
+## Main declarations
+
+* `t0RegroupEquiv` and `s2ShiftEquiv`: the mutually inverse two-site
+  regrouping and shift.
+* `s0RegroupEquiv` and `t2ShiftEquiv`: the mutually inverse three-site
+  regrouping and shift.
+* `t0Map` and `s0Map`: the regroupings followed by their dependent controlled
+  partial traces.
+* `t2Map` and `s2Map`: the two global shift channels.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+namespace MPOTensor.ExplicitEtaOperators
+
+variable {dA dB dC : ℕ}
+variable {rhoABC : Matrix (Fin dA × Fin dB × Fin dC)
+  (Fin dA × Fin dB × Fin dC) ℂ}
+variable {hη : EtaStructure rhoABC}
+
+/-- The physical left-right index within one Hayashi sector. -/
+abbrev PhysicalSectorIndex (hη : EtaStructure rhoABC) (k : Fin hη.m) :=
+  Fin (hη.dL k) × Fin (hη.dR k)
+
+/-- The two outer subspins retained after tracing between sectors $k$ and
+$h$. -/
+abbrev OuterSubspinIndex (hη : EtaStructure rhoABC) (k h : Fin hη.m) :=
+  Fin (hη.dL k) × Fin (hη.dR h)
+
+/-- The neighboring subspins carrying $\eta_{k,h}$. -/
+abbrev NeighborSubspinIndex (hη : EtaStructure rhoABC) (k h : Fin hη.m) :=
+  Fin (hη.dR k) × Fin (hη.dL h)
+
+/-- Regroup two sector indices into the outer subspins and the neighboring
+subspins to be traced:
+
+$$
+((l_k,r_k),(l_h,r_h))\longmapsto((l_k,r_h),(r_k,l_h)).
+$$
+
+This is the factor regrouping preceding $\mathcal T_0$ in
+arXiv:1606.00608, Appendix C.2, lines 1521--1522. -/
+def twoSiteTraceRegroupEquiv (hη : EtaStructure rhoABC) (k h : Fin hη.m) :
+    (PhysicalSectorIndex hη k × PhysicalSectorIndex hη h) ≃
+      (OuterSubspinIndex hη k h × NeighborSubspinIndex hη k h) where
+  toFun x := ((x.1.1, x.2.2), (x.1.2, x.2.1))
+  invFun x := ((x.1.1, x.2.1), (x.2.2, x.1.2))
+  left_inv := by rintro ⟨⟨lk, rk⟩, lh, rh⟩; rfl
+  right_inv := by rintro ⟨⟨lk, rh⟩, rk, lh⟩; rfl
+
+/-- Regroup three sector indices into the outer subspins and the four middle
+subspins to be traced:
+
+$$
+((l_k,r_k),((l_l,r_l),(l_h,r_h)))
+\longmapsto ((l_k,r_h),((r_k,l_l),(r_l,l_h))).
+$$
+
+This is the factor regrouping preceding $\mathcal S_0$ in
+arXiv:1606.00608, Appendix C.2, line 1547, and in the corresponding source
+diagram. The repeated ``$2l$'' in the prose at line 1547 is read as ``$3l$'';
+see `docs/paper-gaps/cpgsv17_mpdo_s0_trace_subspin_typo.tex`. -/
+def threeSiteTraceRegroupEquiv (hη : EtaStructure rhoABC) (k l h : Fin hη.m) :
+    (PhysicalSectorIndex hη k ×
+        (PhysicalSectorIndex hη l × PhysicalSectorIndex hη h)) ≃
+      (OuterSubspinIndex hη k h ×
+        (NeighborSubspinIndex hη k l × NeighborSubspinIndex hη l h)) where
+  toFun x := ((x.1.1, x.2.2.2), ((x.1.2, x.2.1.1), (x.2.1.2, x.2.2.1)))
+  invFun x := ((x.1.1, x.2.1.1), ((x.2.1.2, x.2.2.1), (x.2.2.2, x.1.2)))
+  left_inv := by rintro ⟨⟨lk, rk⟩, ⟨ll, rl⟩, lh, rh⟩; rfl
+  right_inv := by rintro ⟨⟨lk, rh⟩, ⟨rk, ll⟩, rl, lh⟩; rfl
+
+/-- The two-site shift which turns an outer pair together with
+$\eta_{k,h}$ into two complete physical sectors:
+
+$$
+((l_k,r_h),(r_k,l_h))\longmapsto((l_k,r_k),(l_h,r_h)).
+$$
+
+This is $\mathcal S_2$ in arXiv:1606.00608, Appendix C.2,
+lines 1555--1559. -/
+def etaShiftEquiv (hη : EtaStructure rhoABC) (k h : Fin hη.m) :
+    (OuterSubspinIndex hη k h × NeighborSubspinIndex hη k h) ≃
+      (PhysicalSectorIndex hη k × PhysicalSectorIndex hη h) :=
+  (twoSiteTraceRegroupEquiv hη k h).symm
+
+/-- The three-site shift which turns an outer pair together with one summand
+of $\Omega_{k,h}$ into three complete physical sectors:
+
+$$
+((l_k,r_h),((r_k,l_l),(r_l,l_h)))
+\longmapsto ((l_k,r_k),((l_l,r_l),(l_h,r_h))).
+$$
+
+This is $\mathcal T_2$ in arXiv:1606.00608, Appendix C.2,
+lines 1535--1540. -/
+def omegaShiftEquiv (hη : EtaStructure rhoABC) (k h : Fin hη.m) :
+    (OuterSubspinIndex hη k h × OmegaIndex (hη := hη) k h) ≃
+      (Σ l : Fin hη.m,
+        PhysicalSectorIndex hη k ×
+          (PhysicalSectorIndex hη l × PhysicalSectorIndex hη h)) where
+  toFun x := ⟨x.2.1,
+    ((x.1.1, x.2.2.1.1), ((x.2.2.1.2, x.2.2.2.1), (x.2.2.2.2, x.1.2)))⟩
+  invFun x := ((x.2.1.1, x.2.2.2.2),
+    ⟨x.1, ((x.2.1.2, x.2.2.1.1), (x.2.2.1.2, x.2.2.2.1))⟩)
+  left_inv := by rintro ⟨⟨lk, rh⟩, l, ⟨rk, ll⟩, rl, lh⟩; rfl
+  right_inv := by rintro ⟨l, ⟨⟨lk, rk⟩, ⟨ll, rl⟩, lh, rh⟩⟩; rfl
+
+/-! ## Global dependent-sum equivalences -/
+
+/-- The full one-site direct sum of physical sector indices. -/
+abbrev SectorSiteIndex (hη : EtaStructure rhoABC) :=
+  Σ k : Fin hη.m, PhysicalSectorIndex hη k
+
+/-- The full direct sum of retained outer-subspin indices. -/
+abbrev BoundarySubspinIndex (hη : EtaStructure rhoABC) :=
+  Σ kh : Fin hη.m × Fin hη.m, OuterSubspinIndex hη kh.1 kh.2
+
+/-- The full direct sum obtained after the two-site regrouping for
+$\mathcal T_0$, equivalently the input index of the $\mathcal S_2$ shift. -/
+abbrev EtaPreparationIndex (hη : EtaStructure rhoABC) :=
+  Σ kh : Fin hη.m × Fin hη.m,
+    OuterSubspinIndex hη kh.1 kh.2 × NeighborSubspinIndex hη kh.1 kh.2
+
+/-- The full direct sum obtained after the three-site regrouping for
+$\mathcal S_0$, equivalently the input index of the $\mathcal T_2$ shift. -/
+abbrev OmegaPreparationIndex (hη : EtaStructure rhoABC) :=
+  Σ kh : Fin hη.m × Fin hη.m,
+    OuterSubspinIndex hη kh.1 kh.2 × OmegaIndex (hη := hη) kh.1 kh.2
+
+/-- The global two-site regrouping into retained and traced subspins. It is
+the dependent direct-sum form of `twoSiteTraceRegroupEquiv`.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1521--1522 and 1555--1559. -/
+def t0RegroupEquiv (hη : EtaStructure rhoABC) :
+    (SectorSiteIndex hη × SectorSiteIndex hη) ≃ EtaPreparationIndex hη where
+  toFun x := ⟨(x.1.1, x.2.1), ((x.1.2.1, x.2.2.2), (x.1.2.2, x.2.2.1))⟩
+  invFun x := (⟨x.1.1, (x.2.1.1, x.2.2.1)⟩,
+    ⟨x.1.2, (x.2.2.2, x.2.1.2)⟩)
+  left_inv := by rintro ⟨⟨k, lk, rk⟩, h, lh, rh⟩; rfl
+  right_inv := by rintro ⟨⟨k, h⟩, ⟨lk, rh⟩, rk, lh⟩; rfl
+
+/-- The global two-site shift $\mathcal S_2$ is the inverse of the regrouping
+used by $\mathcal T_0$.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1555--1559. -/
+def s2ShiftEquiv (hη : EtaStructure rhoABC) :
+    EtaPreparationIndex hη ≃ (SectorSiteIndex hη × SectorSiteIndex hη) :=
+  (t0RegroupEquiv hη).symm
+
+/-- The global three-site regrouping into retained and traced subspins. It is
+the dependent direct-sum form of `threeSiteTraceRegroupEquiv`.
+
+**Local fix (repeated subspin):** the final $2l$ in the source sentence is
+read as $3l$, as forced by the source diagram. Documented in
+`docs/paper-gaps/cpgsv17_mpdo_s0_trace_subspin_typo.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, line 1547. -/
+def s0RegroupEquiv (hη : EtaStructure rhoABC) :
+    (SectorSiteIndex hη × (SectorSiteIndex hη × SectorSiteIndex hη)) ≃
+      OmegaPreparationIndex hη where
+  toFun x := ⟨(x.1.1, x.2.2.1), ((x.1.2.1, x.2.2.2.2),
+    ⟨x.2.1.1, ((x.1.2.2, x.2.1.2.1), (x.2.1.2.2, x.2.2.2.1))⟩)⟩
+  invFun x := (⟨x.1.1, (x.2.1.1, x.2.2.2.1.1)⟩,
+    (⟨x.2.2.1, (x.2.2.2.1.2, x.2.2.2.2.1)⟩,
+      ⟨x.1.2, (x.2.2.2.2.2, x.2.1.2)⟩))
+  left_inv := by rintro ⟨⟨k, lk, rk⟩, ⟨l, ll, rl⟩, h, lh, rh⟩; rfl
+  right_inv := by rintro ⟨⟨k, h⟩, ⟨lk, rh⟩, l, ⟨rk, ll⟩, rl, lh⟩; rfl
+
+/-- The global three-site shift $\mathcal T_2$ is the inverse of the
+regrouping used by $\mathcal S_0$.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1535--1540. -/
+def t2ShiftEquiv (hη : EtaStructure rhoABC) :
+    OmegaPreparationIndex hη ≃
+      (SectorSiteIndex hη × (SectorSiteIndex hη × SectorSiteIndex hη)) :=
+  (s0RegroupEquiv hη).symm
+
+/-! ## The four channels -/
+
+/-- The global map $\mathcal T_0$: regroup two sites into the retained outer
+subspins and the neighboring inner subspins, then trace the inner factors in
+each orthogonal sector pair.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1521--1522. -/
+noncomputable def t0Map (hη : EtaStructure rhoABC) :
+    Matrix (SectorSiteIndex hη × SectorSiteIndex hη)
+        (SectorSiteIndex hη × SectorSiteIndex hη) ℂ →ₗ[ℂ]
+      Matrix (BoundarySubspinIndex hη) (BoundarySubspinIndex hη) ℂ :=
+  Matrix.controlledPartialTraceRightLM
+      (α := fun kh : Fin hη.m × Fin hη.m => OuterSubspinIndex hη kh.1 kh.2)
+      (β := fun kh : Fin hη.m × Fin hη.m => NeighborSubspinIndex hη kh.1 kh.2) ∘ₗ
+    Matrix.equivReindexMap (t0RegroupEquiv hη)
+
+/-- The global map $\mathcal T_0$ is trace-preserving and completely
+positive.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1521--1522. -/
+theorem t0Map_isKrausCPTP (hη : EtaStructure rhoABC) :
+    IsKrausCPTP (t0Map hη) := by
+  simpa [t0Map] using isKrausCPTP_comp
+    (Matrix.equivReindexMap_isKrausCPTP (t0RegroupEquiv hη))
+    Matrix.controlledPartialTraceRightLM_isKrausCPTP
+
+/-- The global map $\mathcal S_0$: regroup three sites into the retained outer
+subspins and the two neighboring inner pairs, then trace the inner factors in
+each orthogonal outer-sector pair.
+
+**Local fix (repeated subspin):** the final $2l$ in the source sentence is
+read as $3l$, as forced by the source diagram. Documented in
+`docs/paper-gaps/cpgsv17_mpdo_s0_trace_subspin_typo.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, line 1547. -/
+noncomputable def s0Map (hη : EtaStructure rhoABC) :
+    Matrix (SectorSiteIndex hη × (SectorSiteIndex hη × SectorSiteIndex hη))
+        (SectorSiteIndex hη × (SectorSiteIndex hη × SectorSiteIndex hη)) ℂ →ₗ[ℂ]
+      Matrix (BoundarySubspinIndex hη) (BoundarySubspinIndex hη) ℂ :=
+  Matrix.controlledPartialTraceRightLM
+      (α := fun kh : Fin hη.m × Fin hη.m => OuterSubspinIndex hη kh.1 kh.2)
+      (β := fun kh : Fin hη.m × Fin hη.m => OmegaIndex (hη := hη) kh.1 kh.2) ∘ₗ
+    Matrix.equivReindexMap (s0RegroupEquiv hη)
+
+/-- The global map $\mathcal S_0$ is trace-preserving and completely
+positive.
+
+Source: arXiv:1606.00608, Appendix C.2, line 1547. -/
+theorem s0Map_isKrausCPTP (hη : EtaStructure rhoABC) :
+    IsKrausCPTP (s0Map hη) := by
+  simpa [s0Map] using isKrausCPTP_comp
+    (Matrix.equivReindexMap_isKrausCPTP (s0RegroupEquiv hη))
+    Matrix.controlledPartialTraceRightLM_isKrausCPTP
+
+/-- The global shift $\mathcal S_2$, realized by reindexing along the inverse
+of the two-site regrouping.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1555--1559. -/
+def s2Map (hη : EtaStructure rhoABC) :
+    Matrix (EtaPreparationIndex hη) (EtaPreparationIndex hη) ℂ →ₗ[ℂ]
+      Matrix (SectorSiteIndex hη × SectorSiteIndex hη)
+        (SectorSiteIndex hη × SectorSiteIndex hη) ℂ :=
+  Matrix.equivReindexMap (s2ShiftEquiv hη)
+
+/-- The global shift $\mathcal S_2$ is trace-preserving and completely
+positive.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1555--1559. -/
+theorem s2Map_isKrausCPTP (hη : EtaStructure rhoABC) :
+    IsKrausCPTP (s2Map hη) :=
+  Matrix.equivReindexMap_isKrausCPTP (s2ShiftEquiv hη)
+
+/-- The global shift $\mathcal T_2$, realized by reindexing along the inverse
+of the three-site regrouping.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1535--1540. -/
+def t2Map (hη : EtaStructure rhoABC) :
+    Matrix (OmegaPreparationIndex hη) (OmegaPreparationIndex hη) ℂ →ₗ[ℂ]
+      Matrix (SectorSiteIndex hη × (SectorSiteIndex hη × SectorSiteIndex hη))
+        (SectorSiteIndex hη × (SectorSiteIndex hη × SectorSiteIndex hη)) ℂ :=
+  Matrix.equivReindexMap (t2ShiftEquiv hη)
+
+/-- The global shift $\mathcal T_2$ is trace-preserving and completely
+positive.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1535--1540. -/
+theorem t2Map_isKrausCPTP (hη : EtaStructure rhoABC) :
+    IsKrausCPTP (t2Map hη) :=
+  Matrix.equivReindexMap_isKrausCPTP (t2ShiftEquiv hη)
+
+/-! ### Fiberwise forms -/
+
+/-- The sectorwise map $\mathcal T_0$: regroup two physical sectors, then
+trace the neighboring subspins $B_k^R\otimes B_h^L$.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1521--1522. -/
+noncomputable def t0SectorMap (hη : EtaStructure rhoABC) (k h : Fin hη.m) :
+    Matrix (PhysicalSectorIndex hη k × PhysicalSectorIndex hη h)
+        (PhysicalSectorIndex hη k × PhysicalSectorIndex hη h) ℂ →ₗ[ℂ]
+      Matrix (OuterSubspinIndex hη k h) (OuterSubspinIndex hη k h) ℂ :=
+  Matrix.partialTraceRightLM ∘ₗ Matrix.equivReindexMap (twoSiteTraceRegroupEquiv hη k h)
+
+/-- The sectorwise map $\mathcal T_0$ is trace-preserving and completely
+positive.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1521--1522. -/
+theorem t0SectorMap_isKrausCPTP (hη : EtaStructure rhoABC) (k h : Fin hη.m) :
+    IsKrausCPTP (t0SectorMap hη k h) :=
+  isKrausCPTP_comp
+    (Matrix.equivReindexMap_isKrausCPTP (twoSiteTraceRegroupEquiv hη k h))
+    Matrix.partialTraceRightLM_isKrausCPTP
+
+/-- The sectorwise map $\mathcal S_0$: regroup three physical sectors, then
+trace the four middle subspins.
+
+**Local fix (repeated subspin):** the source prose lists $2l$ twice. The
+diagram and the required outer factors show that the last traced subspin is
+$3l$. Documented in
+`docs/paper-gaps/cpgsv17_mpdo_s0_trace_subspin_typo.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, line 1547. -/
+noncomputable def s0SectorMap (hη : EtaStructure rhoABC) (k l h : Fin hη.m) :
+    Matrix (PhysicalSectorIndex hη k ×
+        (PhysicalSectorIndex hη l × PhysicalSectorIndex hη h))
+        (PhysicalSectorIndex hη k ×
+          (PhysicalSectorIndex hη l × PhysicalSectorIndex hη h)) ℂ →ₗ[ℂ]
+      Matrix (OuterSubspinIndex hη k h) (OuterSubspinIndex hη k h) ℂ :=
+  Matrix.partialTraceRightLM ∘ₗ
+    Matrix.equivReindexMap (threeSiteTraceRegroupEquiv hη k l h)
+
+/-- The sectorwise map $\mathcal S_0$ is trace-preserving and completely
+positive.
+
+Source: arXiv:1606.00608, Appendix C.2, line 1547. -/
+theorem s0SectorMap_isKrausCPTP (hη : EtaStructure rhoABC) (k l h : Fin hη.m) :
+    IsKrausCPTP (s0SectorMap hη k l h) :=
+  isKrausCPTP_comp
+    (Matrix.equivReindexMap_isKrausCPTP (threeSiteTraceRegroupEquiv hη k l h))
+    Matrix.partialTraceRightLM_isKrausCPTP
+
+/-- The sectorwise shift $\mathcal S_2$, realized as matrix reindexing along
+`etaShiftEquiv`.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1555--1559. -/
+def s2SectorMap (hη : EtaStructure rhoABC) (k h : Fin hη.m) :
+    Matrix (OuterSubspinIndex hη k h × NeighborSubspinIndex hη k h)
+        (OuterSubspinIndex hη k h × NeighborSubspinIndex hη k h) ℂ →ₗ[ℂ]
+      Matrix (PhysicalSectorIndex hη k × PhysicalSectorIndex hη h)
+        (PhysicalSectorIndex hη k × PhysicalSectorIndex hη h) ℂ :=
+  Matrix.equivReindexMap (etaShiftEquiv hη k h)
+
+/-- The sectorwise shift $\mathcal S_2$ is trace-preserving and completely
+positive.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1555--1559. -/
+theorem s2SectorMap_isKrausCPTP (hη : EtaStructure rhoABC) (k h : Fin hη.m) :
+    IsKrausCPTP (s2SectorMap hη k h) :=
+  Matrix.equivReindexMap_isKrausCPTP (etaShiftEquiv hη k h)
+
+/-- The sectorwise shift $\mathcal T_2$, realized as matrix reindexing along
+`omegaShiftEquiv`.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1535--1540. -/
+def t2SectorMap (hη : EtaStructure rhoABC) (k h : Fin hη.m) :
+    Matrix (OuterSubspinIndex hη k h × OmegaIndex (hη := hη) k h)
+        (OuterSubspinIndex hη k h × OmegaIndex (hη := hη) k h) ℂ →ₗ[ℂ]
+      Matrix (Σ l : Fin hη.m,
+          PhysicalSectorIndex hη k ×
+            (PhysicalSectorIndex hη l × PhysicalSectorIndex hη h))
+        (Σ l : Fin hη.m,
+          PhysicalSectorIndex hη k ×
+            (PhysicalSectorIndex hη l × PhysicalSectorIndex hη h)) ℂ :=
+  Matrix.equivReindexMap (omegaShiftEquiv hη k h)
+
+/-- The sectorwise shift $\mathcal T_2$ is trace-preserving and completely
+positive.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1535--1540. -/
+theorem t2SectorMap_isKrausCPTP (hη : EtaStructure rhoABC) (k h : Fin hη.m) :
+    IsKrausCPTP (t2SectorMap hη k h) :=
+  Matrix.equivReindexMap_isKrausCPTP (omegaShiftEquiv hη k h)
+
+end MPOTensor.ExplicitEtaOperators

--- a/blueprint/src/Packages/tn_diagrams.py
+++ b/blueprint/src/Packages/tn_diagrams.py
@@ -51,6 +51,8 @@ _DIAGRAM_ARGS: dict[str, str] = {
     "TNMPOLocalPurification": "",
     "TNMPORenormalizationTS": "",
     "TNEtaSectorDecomposition": "",
+    "TNMPDOTwoSiteTraceAndShift": "",
+    "TNMPDOThreeSiteTraceAndShift": "",
     "TNMPDOCyclicEtaContraction": "",
     "TNMPDOSectorAdaptedDecomposition": "",
     "TNMPDOInverseMapThreeSiteContraction": "",

--- a/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
@@ -90,11 +90,8 @@
     The claim follows from the preceding isometry lemma.
 \end{proof}
 
-% Concrete equivalences remain to be supplied for the regroupings preceding
-% T_0 and S_0 (Appendix C.2, lines 1521--1522 and 1547) and for the shifts T_2
-% and S_2 (lines 1535--1540 and 1555--1559). The result above provides the
-% trace-preserving completely positive reindexing once those equivalences are
-% defined; it does not itself define the paper-specific maps.
+% The concrete dependent-sum equivalences for T_0, S_0, T_2, and S_2 are
+% stated in ch21_mpdo_rfp_simple_local_structure.tex after the eta preparations.
 
 \begin{lemma}[Composition of trace-preserving completely positive maps]
     \label{lem:is_kraus_cptp_comp}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -48,7 +48,6 @@ strong subadditivity for a normalized three-site reduced state.
     \]
     which is the stated equality for the regions $A,B,C$.
 \end{proof}
-
 \begin{theorem}[SAL implies local $\eta$-structure]
     \label{thm:sal_implies_eta_structure}
     \lean{MPOTensor.sal_implies_eta_structure}
@@ -1745,6 +1744,369 @@ strong subadditivity for a normalized three-site reduced state.
     maps, shift maps, and the required closure identities are separate parts
     of that statement.
 \end{remark}
+
+\begin{definition}[Controlled dependent partial trace]
+    \label{def:mpdo_controlled_dependent_partial_trace}
+    \lean{Matrix.controlledPartialTraceRightLM}
+    \leanok
+    \uses{def:mpdo_controlled_kraus_map, def:mpdo_right_partial_trace_map}
+    Let
+    \[
+        H=\bigoplus_{i\in I}(A_i\otimes B_i),
+        \qquad K=\bigoplus_{i\in I}A_i.
+    \]
+    The controlled dependent partial trace discards the off-diagonal blocks
+    between distinct $i$ and applies $\tr_{B_i}$ to the $i$th diagonal block.
+\end{definition}
+
+\begin{theorem}[The controlled dependent partial trace is trace-preserving
+    completely positive]
+    \label{thm:mpdo_controlled_dependent_partial_trace_cptp}
+    \lean{Matrix.controlledPartialTraceRightLM_isKrausCPTP}
+    \leanok
+    \uses{def:mpdo_controlled_dependent_partial_trace}
+    The controlled dependent partial trace is trace-preserving and completely
+    positive.
+\end{theorem}
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_controlled_kraus_map_cptp,
+      lem:mpdo_right_partial_trace_cptp}
+    Choose Kraus operators $(V_{i,a})_a$ for $\tr_{B_i}$ and extend each
+    $V_{i,a}$ by zero outside the $i$th summand. Their controlled family
+    satisfies
+    \[
+      \sum_{i,a}\widetilde V_{i,a}^{\dagger}\widetilde V_{i,a}
+      =\bigoplus_i\left(\sum_aV_{i,a}^{\dagger}V_{i,a}\right)
+      =\bigoplus_i I_{A_i\otimes B_i}
+      =I_H.
+    \]
+    Its Kraus form gives complete positivity, and the displayed resolution of
+    the identity gives trace preservation.
+\end{proof}
+
+\begin{definition}[Two-site subspin regrouping]
+    \label{def:mpdo_two_site_subspin_regrouping}
+    \lean{MPOTensor.ExplicitEtaOperators.PhysicalSectorIndex}
+    \lean{MPOTensor.ExplicitEtaOperators.OuterSubspinIndex}
+    \lean{MPOTensor.ExplicitEtaOperators.NeighborSubspinIndex}
+    \lean{MPOTensor.ExplicitEtaOperators.SectorSiteIndex}
+    \lean{MPOTensor.ExplicitEtaOperators.BoundarySubspinIndex}
+    \lean{MPOTensor.ExplicitEtaOperators.EtaPreparationIndex}
+    \lean{MPOTensor.ExplicitEtaOperators.twoSiteTraceRegroupEquiv}
+    \lean{MPOTensor.ExplicitEtaOperators.t0RegroupEquiv}
+    \lean{MPOTensor.ExplicitEtaOperators.etaShiftEquiv}
+    \lean{MPOTensor.ExplicitEtaOperators.s2ShiftEquiv}
+    \leanok
+    \uses{def:mpdo_eta_structure}
+    In sector-adapted coordinates, regroup two sites by
+    \[
+      ((l_k,r_k),(l_h,r_h))
+      \longmapsto ((l_k,r_h),(r_k,l_h)).
+    \]
+    Globally this gives the dependent-sum equivalence
+    \[
+      \left(\bigoplus_k L_k\otimes R_k\right)^{\!\otimes2}
+      \simeq
+      \bigoplus_{k,h}(L_k\otimes R_h)\otimes(R_k\otimes L_h).
+    \]
+    The forward equivalence prepares the neighboring factors
+    $R_k\otimes L_h$ for the partial trace in $\mathcal T_0$; its inverse is
+    the shift $\mathcal S_2$. These are the reorderings in
+    \cite[Appendix~C.2, lines~1521--1522 and~1555--1559]
+      {Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{definition}[The two-site partial-trace map $\mathcal T_0$]
+    \label{def:mpdo_t0_map}
+    \lean{MPOTensor.ExplicitEtaOperators.t0Map}
+    \leanok
+    \uses{def:mpdo_two_site_subspin_regrouping,
+      def:mpdo_controlled_dependent_partial_trace,
+      def:mpdo_equiv_reindex_map}
+    Define $\mathcal T_0$ by the two-site regrouping followed, in each pair
+    $(k,h)$, by the partial trace over $R_k\otimes L_h$. Its output is indexed
+    by the retained outer factors $L_k\otimes R_h$. Thus, writing $R_{\Phi_2}$
+    for the regrouping reindexing,
+    \[
+      \mathcal T_0
+      =\operatorname{CTr}_{(R_k\otimes L_h)_{k,h}}\circ R_{\Phi_2}.
+    \]
+\end{definition}
+
+\begin{theorem}[$\mathcal T_0$ is trace-preserving completely positive]
+    \label{thm:mpdo_t0_map_cptp}
+    \lean{MPOTensor.ExplicitEtaOperators.t0Map_isKrausCPTP}
+    \leanok
+    \uses{def:mpdo_t0_map}
+    The map $\mathcal T_0$ is trace-preserving and completely positive.
+\end{theorem}
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_equiv_reindex_cptp,
+      thm:mpdo_controlled_dependent_partial_trace_cptp,
+      lem:is_kraus_cptp_comp}
+    If $R_{\Phi_2}$ denotes reindexing along the two-site equivalence and
+    $\operatorname{CTr}$ the controlled dependent partial trace, then
+    \[
+      \mathcal T_0
+      =\operatorname{CTr}_{(R_k\otimes L_h)_{k,h}}\circ R_{\Phi_2}.
+    \]
+    The first factor is trace-preserving completely positive by
+    Theorem~\ref{thm:mpdo_controlled_dependent_partial_trace_cptp}, and the
+    second by Theorem~\ref{thm:mpdo_equiv_reindex_cptp}. Their composition is
+    therefore trace-preserving and completely positive.
+\end{proof}
+
+\begin{definition}[The two-site shift $\mathcal S_2$]
+    \label{def:mpdo_s2_map}
+    \lean{MPOTensor.ExplicitEtaOperators.s2Map}
+    \leanok
+    \uses{def:mpdo_two_site_subspin_regrouping,
+      def:mpdo_equiv_reindex_map}
+    The map $\mathcal S_2$ is matrix reindexing along the inverse two-site
+    equivalence. Thus
+    \[
+      ((l_k,r_h),(r_k,l_h))
+      \longmapsto ((l_k,r_k),(l_h,r_h)).
+    \]
+\end{definition}
+
+\begin{theorem}[$\mathcal S_2$ is trace-preserving completely positive]
+    \label{thm:mpdo_s2_map_cptp}
+    \lean{MPOTensor.ExplicitEtaOperators.s2Map_isKrausCPTP}
+    \leanok
+    \uses{def:mpdo_s2_map}
+    The shift $\mathcal S_2$ is trace-preserving and completely positive.
+\end{theorem}
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_equiv_reindex_cptp}
+    If $\Phi_2$ is the two-site regrouping, then
+    $\mathcal S_2=R_{\Phi_2^{-1}}$. It is therefore trace-preserving and
+    completely positive by Theorem~\ref{thm:mpdo_equiv_reindex_cptp}.
+\end{proof}
+
+\begin{definition}[Three-site subspin regrouping]
+    \label{def:mpdo_three_site_subspin_regrouping}
+    \lean{MPOTensor.ExplicitEtaOperators.OmegaPreparationIndex}
+    \lean{MPOTensor.ExplicitEtaOperators.threeSiteTraceRegroupEquiv}
+    \lean{MPOTensor.ExplicitEtaOperators.s0RegroupEquiv}
+    \lean{MPOTensor.ExplicitEtaOperators.omegaShiftEquiv}
+    \lean{MPOTensor.ExplicitEtaOperators.t2ShiftEquiv}
+    \leanok
+    \uses{def:mpdo_two_site_subspin_regrouping, def:mpdo_eta_omega}
+    Regroup three sites by
+    \[
+      ((l_k,r_k),((l_l,r_l),(l_h,r_h)))
+      \longmapsto
+      ((l_k,r_h),((r_k,l_l),(r_l,l_h))).
+    \]
+    Equivalently,
+    \[
+      \left(\bigoplus_k L_k\otimes R_k\right)^{\!\otimes3}
+      \simeq
+      \bigoplus_{k,h}(L_k\otimes R_h)\otimes
+        \left[\bigoplus_l
+          (R_k\otimes L_l)\otimes(R_l\otimes L_h)\right].
+    \]
+    The forward equivalence prepares the four middle subspins for
+    $\mathcal S_0$; its inverse is the shift $\mathcal T_2$ in
+    \cite[Appendix~C.2, lines~1535--1540 and~1547]
+      {Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{definition}[The three-site partial-trace map $\mathcal S_0$]
+    \label{def:mpdo_s0_map}
+    \lean{MPOTensor.ExplicitEtaOperators.s0Map}
+    \leanok
+    \uses{def:mpdo_three_site_subspin_regrouping,
+      def:mpdo_controlled_dependent_partial_trace,
+      def:mpdo_equiv_reindex_map}
+    Define $\mathcal S_0$ by the three-site regrouping followed, for every
+    outer pair $(k,h)$, by the partial trace over
+    \[
+      \bigoplus_l(R_k\otimes L_l)\otimes(R_l\otimes L_h).
+    \]
+    Thus, writing $R_{\Phi_3}$ for the regrouping reindexing,
+    \[
+      \mathcal S_0
+      =\operatorname{CTr}_{\left(
+          \bigoplus_l(R_k\otimes L_l)\otimes(R_l\otimes L_h)
+        \right)_{k,h}}\circ R_{\Phi_3}.
+    \]
+\end{definition}
+% The source prose at line 1547 repeats 2l; the diagram forces the final
+% traced factor to be 3l. The correction is documented in
+% docs/paper-gaps/cpgsv17_mpdo_s0_trace_subspin_typo.tex.
+
+\begin{theorem}[$\mathcal S_0$ is trace-preserving completely positive]
+    \label{thm:mpdo_s0_map_cptp}
+    \lean{MPOTensor.ExplicitEtaOperators.s0Map_isKrausCPTP}
+    \leanok
+    \uses{def:mpdo_s0_map}
+    The map $\mathcal S_0$ is trace-preserving and completely positive.
+\end{theorem}
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_equiv_reindex_cptp,
+      thm:mpdo_controlled_dependent_partial_trace_cptp,
+      lem:is_kraus_cptp_comp}
+    If $R_{\Phi_3}$ denotes reindexing along the three-site equivalence, then
+    \[
+      \mathcal S_0
+      =\operatorname{CTr}_{\left(
+          \bigoplus_l(R_k\otimes L_l)\otimes(R_l\otimes L_h)
+        \right)_{k,h}}\circ R_{\Phi_3}.
+    \]
+    The controlled trace and equivalence reindexing are trace-preserving and
+    completely positive by
+    Theorems~\ref{thm:mpdo_controlled_dependent_partial_trace_cptp}
+    and~\ref{thm:mpdo_equiv_reindex_cptp}, respectively. Their composition
+    has the same property.
+\end{proof}
+
+\begin{definition}[The three-site shift $\mathcal T_2$]
+    \label{def:mpdo_t2_map}
+    \lean{MPOTensor.ExplicitEtaOperators.t2Map}
+    \leanok
+    \uses{def:mpdo_three_site_subspin_regrouping,
+      def:mpdo_equiv_reindex_map}
+    The map $\mathcal T_2$ is matrix reindexing along the inverse three-site
+    equivalence. On each summand it sends
+    \[
+      ((l_k,r_h),((r_k,l_l),(r_l,l_h)))
+      \longmapsto ((l_k,r_k),((l_l,r_l),(l_h,r_h))).
+    \]
+\end{definition}
+
+\begin{theorem}[$\mathcal T_2$ is trace-preserving completely positive]
+    \label{thm:mpdo_t2_map_cptp}
+    \lean{MPOTensor.ExplicitEtaOperators.t2Map_isKrausCPTP}
+    \leanok
+    \uses{def:mpdo_t2_map}
+    The shift $\mathcal T_2$ is trace-preserving and completely positive.
+\end{theorem}
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_equiv_reindex_cptp}
+    If $\Phi_3$ is the three-site regrouping, then
+    $\mathcal T_2=R_{\Phi_3^{-1}}$. It is therefore trace-preserving and
+    completely positive by Theorem~\ref{thm:mpdo_equiv_reindex_cptp}.
+\end{proof}
+
+\begin{definition}[Fiberwise partial-trace maps]
+    \label{def:mpdo_fiberwise_partial_trace_maps}
+    \lean{MPOTensor.ExplicitEtaOperators.t0SectorMap}
+    \lean{MPOTensor.ExplicitEtaOperators.s0SectorMap}
+    \leanok
+    \uses{def:mpdo_two_site_subspin_regrouping,
+      def:mpdo_three_site_subspin_regrouping,
+      def:mpdo_right_partial_trace_map,
+      def:mpdo_equiv_reindex_map}
+    For fixed sectors $(k,h)$, define the fiberwise form of $\mathcal T_0$ by
+    regrouping two sites and tracing $R_k\otimes L_h$. For fixed
+    $(k,l,h)$, define the fiberwise form of $\mathcal S_0$ by regrouping three
+    sites and tracing
+    $(R_k\otimes L_l)\otimes(R_l\otimes L_h)$.
+\end{definition}
+
+\begin{theorem}[The fiberwise partial traces are trace-preserving completely
+    positive]
+    \label{thm:mpdo_fiberwise_partial_trace_maps_cptp}
+    \lean{MPOTensor.ExplicitEtaOperators.t0SectorMap_isKrausCPTP}
+    \lean{MPOTensor.ExplicitEtaOperators.s0SectorMap_isKrausCPTP}
+    \leanok
+    \uses{def:mpdo_fiberwise_partial_trace_maps}
+    Every fiberwise form of $\mathcal T_0$ and $\mathcal S_0$ is
+    trace-preserving and completely positive.
+\end{theorem}
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_equiv_reindex_cptp,
+      lem:mpdo_right_partial_trace_cptp,
+      lem:is_kraus_cptp_comp}
+    The fiberwise forms factor as
+    \[
+      \mathcal T_0^{(k,h)}
+      =\tr_{R_k\otimes L_h}\circ R_{\phi_{k,h}},
+      \qquad
+      \mathcal S_0^{(k,l,h)}
+      =\tr_{(R_k\otimes L_l)\otimes(R_l\otimes L_h)}
+        \circ R_{\phi_{k,l,h}},
+    \]
+    where $\phi_{k,h}$ is the two-site equivalence of
+    Definition~\ref{def:mpdo_two_site_subspin_regrouping} on the $(k,h)$
+    sector, $\phi_{k,l,h}$ is the three-site equivalence of
+    Definition~\ref{def:mpdo_three_site_subspin_regrouping} on the $(k,l,h)$
+    sector, and $R_\phi$ denotes equivalence reindexing. Both factors in each
+    composition are trace-preserving and completely positive, so the
+    composition is as well.
+\end{proof}
+
+\begin{definition}[Fiberwise shifts]
+    \label{def:mpdo_fiberwise_shifts}
+    \lean{MPOTensor.ExplicitEtaOperators.s2SectorMap}
+    \lean{MPOTensor.ExplicitEtaOperators.t2SectorMap}
+    \leanok
+    \uses{def:mpdo_two_site_subspin_regrouping,
+      def:mpdo_three_site_subspin_regrouping,
+      def:mpdo_equiv_reindex_map}
+    On fixed sector pairs, define $\mathcal S_2$ and $\mathcal T_2$ by the
+    same inverse regroupings as the corresponding global shifts.
+\end{definition}
+
+\begin{samepage}
+\begin{theorem}[The fiberwise shifts are trace-preserving completely positive]
+    \label{thm:mpdo_fiberwise_shifts_cptp}
+    \lean{MPOTensor.ExplicitEtaOperators.s2SectorMap_isKrausCPTP}
+    \lean{MPOTensor.ExplicitEtaOperators.t2SectorMap_isKrausCPTP}
+    \leanok
+    \uses{def:mpdo_fiberwise_shifts}
+    Every fiberwise shift is trace-preserving and completely positive.
+\end{theorem}
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_equiv_reindex_cptp}
+    The shifts $\mathcal S_2^{(k,h)}$ and $\mathcal T_2^{(k,h)}$ are
+    reindexings along the inverse two-site and three-site equivalences of
+    Definitions~\ref{def:mpdo_two_site_subspin_regrouping}
+    and~\ref{def:mpdo_three_site_subspin_regrouping}, respectively. They are
+    therefore trace-preserving and completely positive by
+    Theorem~\ref{thm:mpdo_equiv_reindex_cptp}.
+\end{proof}
+\end{samepage}
+
+\begin{figure}[ht]
+    \centering
+    \begin{minipage}{0.40\textwidth}
+      \centering
+      $\displaystyle\bigoplus_{k,h}$; one $(k,h)$-fiber is drawn
+
+      \smallskip
+      \TNMPDOTwoSiteTraceAndShift
+    \end{minipage}\hfill
+    \begin{minipage}{0.57\textwidth}
+      \centering
+      $\displaystyle\bigoplus_{k,h}$; one $(k,h)$-fiber and one $l$-summand are drawn
+
+      \smallskip
+      \TNMPDOThreeSiteTraceAndShift
+    \end{minipage}
+    \caption{Schematics on a fixed $(k,h)$-summand of the global $\bigoplus_{k,h}$ index
+    space. The controlled maps $\mathcal T_0$ and $\mathcal S_0$ discard coherences between
+    distinct outer summands and take the displayed trace in each diagonal summand; the shifts
+    $\mathcal S_2$ and $\mathcal T_2$ are global reindexings. The $l$-labelled boxes depict one
+    summand, but $\mathcal S_0$ traces the entire
+    $\bigoplus_l[(R_k\otimes L_l)\otimes(R_l\otimes L_h)]$. Both shifts begin with all displayed
+    factors supplied; no preparation or recovery identity is shown
+    \cite[Appendix~C.2, lines~1521--1559]{Cirac2016MPDO_arXiv}.}
+    \label{fig:mpdo_regrouping_partial_trace_maps}
+\end{figure}
+
+% The orthogonal direct sum of the active maps and a trace-preserving
+% completion on the unused zero-weight input summands remain part of the
+% construction of the full maps T_1 and S_1.
 
 \begin{figure}[ht]
     \centering

--- a/blueprint/src/macros/tn_core.tex
+++ b/blueprint/src/macros/tn_core.tex
@@ -84,6 +84,21 @@
     \node at ($(#1.south)+(0,-#2)$) {$#3$};%
 }
 
+% A labeled Hayashi subspin factor.  The short vertical stroke follows the
+% source diagrams in Appendix C.2; horizontal strokes are added separately so
+% that a public diagram can display either a physical site or a regrouped
+% tensor product without changing the glyph.
+\newcommand{\TN@subspinbox}[3]{%
+    \node[draw, fill=white, minimum width=0.72cm, minimum height=0.52cm,
+        inner sep=1pt] (#1) at #2 {$#3$};%
+    \draw[tn leg] (#1.north) -- ++(0,0.26);%
+    \draw[tn leg] (#1.south) -- ++(0,-0.26);%
+}
+
+\newcommand{\TN@subspinlink}[2]{%
+    \draw[tn leg] (#1.east) -- (#2.west);%
+}
+
 % ---------- Layout commands ----------
 
 \newcommand{\TN@openMPSword}[4]{%

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -176,6 +176,112 @@
     \end{tikzpicture}%
 }
 
+% The two proved two-site operations from Appendix C.2.  The upper row is the
+% regrouping followed by T_0's partial trace.  The lower row begins with both
+% the outer and neighbouring factors already supplied and draws only the
+% inverse regrouping S_2; it deliberately contains no preparation map.
+\newcommand{\TNMPDOTwoSiteTraceAndShift}{%
+    \begin{tikzpicture}[tn picture, scale=0.60]
+        \node[anchor=east] at (-3.72,1.18) {$\mathcal T_0:$};
+        \TN@subspinbox{tzeroLk}{(-3.15,1.18)}{l_k}
+        \TN@subspinbox{tzeroRk}{(-2.15,1.18)}{r_k}
+        \TN@subspinbox{tzeroLh}{(-1.15,1.18)}{l_h}
+        \TN@subspinbox{tzeroRh}{(-0.15,1.18)}{r_h}
+        \TN@subspinlink{tzeroLk}{tzeroRk}
+        \TN@subspinlink{tzeroRk}{tzeroLh}
+        \TN@subspinlink{tzeroLh}{tzeroRh}
+        \draw[rounded corners=2pt, densely dashed]
+            (-2.62,0.68) rectangle (-0.68,1.68);
+        \node at (-1.65,0.44) {$\tr_{R_k\otimes L_h}$};
+        \draw[->, line width=0.55pt] (0.52,1.18) -- (1.32,1.18);
+        \TN@subspinbox{tzeroOutL}{(1.88,1.18)}{l_k}
+        \TN@subspinbox{tzeroOutR}{(2.88,1.18)}{r_h}
+        \TN@subspinlink{tzeroOutL}{tzeroOutR}
+
+        \node[anchor=east] at (-3.72,-1.18) {$\mathcal S_2:$};
+        \draw[rounded corners=2pt] (-3.42,-1.72) rectangle (-1.38,-0.64);
+        \TN@subspinbox{sTwoLk}{(-2.90,-1.18)}{l_k}
+        \TN@subspinbox{sTwoRh}{(-1.90,-1.18)}{r_h}
+        \TN@subspinlink{sTwoLk}{sTwoRh}
+        \node at (-1.00,-1.18) {$\otimes$};
+        \draw[rounded corners=2pt] (-0.60,-1.72) rectangle (1.44,-0.64);
+        \TN@subspinbox{sTwoRk}{(-0.08,-1.18)}{r_k}
+        \TN@subspinbox{sTwoLh}{(0.92,-1.18)}{l_h}
+        \TN@subspinlink{sTwoRk}{sTwoLh}
+        \draw[->, line width=0.55pt] (1.72,-1.18) -- (2.52,-1.18);
+        \begin{scope}[xshift=5.98cm]
+            \TN@subspinbox{sTwoOutLk}{(-3.15,-1.18)}{l_k}
+            \TN@subspinbox{sTwoOutRk}{(-2.15,-1.18)}{r_k}
+            \TN@subspinbox{sTwoOutLh}{(-1.15,-1.18)}{l_h}
+            \TN@subspinbox{sTwoOutRh}{(-0.15,-1.18)}{r_h}
+            \TN@subspinlink{sTwoOutLk}{sTwoOutRk}
+            \TN@subspinlink{sTwoOutRk}{sTwoOutLh}
+            \TN@subspinlink{sTwoOutLh}{sTwoOutRh}
+        \end{scope}
+        \node at (-1.99,-2.03) {outer factors};
+        \node at (0.42,-2.03) {neighbouring factors};
+    \end{tikzpicture}%
+}
+
+% The three-site analogues.  The dashed middle block is exactly the Omega
+% index space traced by S_0.  The lower row starts with that entire block and
+% applies only the inverse regrouping T_2, not T_1 or a full recovery map.
+\newcommand{\TNMPDOThreeSiteTraceAndShift}{%
+    \begin{tikzpicture}[tn picture, scale=0.56]
+        \node[anchor=east] at (-4.70,1.35) {$\mathcal S_0:$};
+        \TN@subspinbox{szeroLk}{(-4.10,1.35)}{l_k}
+        \TN@subspinbox{szeroRk}{(-3.10,1.35)}{r_k}
+        \TN@subspinbox{szeroLl}{(-2.10,1.35)}{l_l}
+        \TN@subspinbox{szeroRl}{(-1.10,1.35)}{r_l}
+        \TN@subspinbox{szeroLh}{(-0.10,1.35)}{l_h}
+        \TN@subspinbox{szeroRh}{(0.90,1.35)}{r_h}
+        \TN@subspinlink{szeroLk}{szeroRk}
+        \TN@subspinlink{szeroRk}{szeroLl}
+        \TN@subspinlink{szeroLl}{szeroRl}
+        \TN@subspinlink{szeroRl}{szeroLh}
+        \TN@subspinlink{szeroLh}{szeroRh}
+        \draw[rounded corners=2pt, densely dashed]
+            (-3.57,0.84) rectangle (0.37,1.86);
+        \node at (-1.60,0.50)
+            {$\tr_{\bigoplus_l[(R_k\otimes L_l)\otimes(R_l\otimes L_h)]}$};
+        \draw[->, line width=0.55pt] (1.58,1.35) -- (2.38,1.35);
+        \TN@subspinbox{szeroOutL}{(2.94,1.35)}{l_k}
+        \TN@subspinbox{szeroOutR}{(3.94,1.35)}{r_h}
+        \TN@subspinlink{szeroOutL}{szeroOutR}
+
+        \node[anchor=east] at (-4.70,-1.35) {$\mathcal T_2:$};
+        \draw[rounded corners=2pt] (-4.37,-1.90) rectangle (-2.33,-0.80);
+        \TN@subspinbox{tTwoLk}{(-3.85,-1.35)}{l_k}
+        \TN@subspinbox{tTwoRh}{(-2.85,-1.35)}{r_h}
+        \TN@subspinlink{tTwoLk}{tTwoRh}
+        \node at (-1.96,-1.35) {$\otimes$};
+        \draw[rounded corners=2pt] (-1.55,-1.90) rectangle (2.42,-0.80);
+        \TN@subspinbox{tTwoRk}{(-1.03,-1.35)}{r_k}
+        \TN@subspinbox{tTwoLl}{(-0.03,-1.35)}{l_l}
+        \TN@subspinbox{tTwoRl}{(0.97,-1.35)}{r_l}
+        \TN@subspinbox{tTwoLh}{(1.97,-1.35)}{l_h}
+        \TN@subspinlink{tTwoRk}{tTwoLl}
+        \TN@subspinlink{tTwoLl}{tTwoRl}
+        \TN@subspinlink{tTwoRl}{tTwoLh}
+        \draw[->, line width=0.55pt] (2.68,-1.35) -- (3.48,-1.35);
+        \begin{scope}[xshift=7.90cm]
+            \TN@subspinbox{tTwoOutLk}{(-4.10,-1.35)}{l_k}
+            \TN@subspinbox{tTwoOutRk}{(-3.10,-1.35)}{r_k}
+            \TN@subspinbox{tTwoOutLl}{(-2.10,-1.35)}{l_l}
+            \TN@subspinbox{tTwoOutRl}{(-1.10,-1.35)}{r_l}
+            \TN@subspinbox{tTwoOutLh}{(-0.10,-1.35)}{l_h}
+            \TN@subspinbox{tTwoOutRh}{(0.90,-1.35)}{r_h}
+            \TN@subspinlink{tTwoOutLk}{tTwoOutRk}
+            \TN@subspinlink{tTwoOutRk}{tTwoOutLl}
+            \TN@subspinlink{tTwoOutLl}{tTwoOutRl}
+            \TN@subspinlink{tTwoOutRl}{tTwoOutLh}
+            \TN@subspinlink{tTwoOutLh}{tTwoOutRh}
+        \end{scope}
+        \node at (-3.35,-2.24) {outer factors};
+        \node at (0.44,-2.24) {$\Omega_{k,h}=\bigoplus_l(\cdots)$};
+    \end{tikzpicture}%
+}
+
 % A closed chain of factorized sector tensors regrouped into neighbouring
 % eta operators.  This mirrors the cyclic contractions in Appendix C.2.
 \newcommand{\TNMPDOCyclicEtaContraction}{%

--- a/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
+++ b/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
@@ -7,6 +7,9 @@ name: TNMPSLocal TNMPSWord TNMPV TNBlocking TNMPVOverlap TNTransferMap TNMPOCell
 name: TNMPOLocalPurification TNMPORenormalizationTS TNEtaSectorDecomposition TNMPDOCyclicEtaContraction TNMPDOSectorAdaptedDecomposition
 {{ obj.tn_svg_html }}
 
+name: TNMPDOTwoSiteTraceAndShift TNMPDOThreeSiteTraceAndShift
+{{ obj.tn_svg_html }}
+
 name: TNMPDOInverseMapThreeSiteContraction TNMPDONormalizedFourSiteTail TNMPDOLocalOrthogonality
 {{ obj.tn_svg_html }}
 

--- a/docs/paper-gaps/cpgsv17_mpdo_s0_trace_subspin_typo.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_s0_trace_subspin_typo.tex
@@ -1,0 +1,63 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+
+\input{command}
+
+\title{The Final Traced Subspin in the Definition of $\mathcal S_0$}
+\author{}
+\date{2026-07-12}
+
+\begin{document}
+\maketitle
+
+\section{The source sentence}
+
+In the proof of Proposition~C.7, Appendix~C.2 of
+\cite{Cirac2016MPDO_arXiv}, the map $\mathcal S_0$ reduces three physical
+sites to the two outer subspins.  The prose at line~1547 of
+\path{Papers/1606.00608/MPDO-22-12-17-2.tex} says that it traces the subspins
+$1r,2l,2r,2l$.  The factor $2l$ therefore appears twice, while no subspin of
+the third site is listed.
+
+\section{Correction forced by the diagram}
+
+The diagram \path{Papers/1606.00608/MPDO_TMatrix2.png} shows three consecutive
+sector factors
+\[
+  (L_k\otimes R_k)\otimes(L_l\otimes R_l)\otimes(L_h\otimes R_h)
+\]
+before $\mathcal S_0$, and retains only $L_k\otimes R_h$.  Hence the traced
+space is
+\[
+  (R_k\otimes L_l)\otimes(R_l\otimes L_h),
+\]
+corresponding to subspins $1r,2l,2r,3l$.  The displayed formula for
+$\mathcal S_2$ at lines~1557--1559 confirms the same two retained outer
+factors.  Thus the final occurrence of $2l$ in line~1547 is a typographical
+error for $3l$.
+
+The formal regrouping uses the corrected equivalence
+\[
+  ((l_k,r_k),((l_l,r_l),(l_h,r_h)))
+  \longmapsto ((l_k,r_h),((r_k,l_l),(r_l,l_h))).
+\]
+The corresponding formal declarations are recorded in
+\doclink{TNLean/MPS/MPDO/RFPSubspinMaps}.\footnote{In particular,
+\leanid{MPOTensor.ExplicitEtaOperators.s0RegroupEquiv},
+\leanid{MPOTensor.ExplicitEtaOperators.s0Map}, and
+\leanid{MPOTensor.ExplicitEtaOperators.s0SectorMap}.}
+This correction changes no hypothesis and is local to the ordering of tensor
+factors.
+
+\section{Verdict}
+
+This is a local correction of a repeated subspin label in the source prose.
+It does not alter the statement or hypotheses of Proposition~C.7.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
This PR formalizes the regrouping, partial-trace, and shift stages used in Appendix C.2 of Cirac--Pérez-García--Schuch--Verstraete.

The new development:

- defines a controlled dependent partial trace and proves that it is trace-preserving and completely positive;
- gives explicit two-site and three-site subspin equivalences in a uniform right-associated convention;
- defines the global maps $\mathcal T_0$, $\mathcal S_0$, $\mathcal T_2$, and $\mathcal S_2$, together with their fiberwise forms;
- proves that all four maps are trace-preserving and completely positive;
- records the repeated-$2l$ typo in the source description of $\mathcal S_0$ and uses the $3l$ factor forced by the source diagram; and
- adds a source-faithful TikZ reconstruction of the two regrouping, trace, and shift diagrams.

The blueprint states the exact scope: this PR does not define the preparation stages $\mathcal T_1$ and $\mathcal S_1$, and it does not claim either recovery identity from Proposition C.7. The source correction is documented in `docs/paper-gaps/cpgsv17_mpdo_s0_trace_subspin_typo.tex`.

Validation:

- `lake env lean TNLean/MPS/MPDO/RFPSubspinMaps.lean`
- `lake build TNLean` (9,300 jobs)
- `leanblueprint checkdecls`
- `leanblueprint web`
- `leanblueprint pdf` (481 pages)
- reader-facing prose, line-length, proof-integrity, and diff checks
- visual inspection of the rendered regrouping figure

Closes #3741. Advances #3740, #3743, and #3744.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formalization and blueprint documentation on the MPDO RFP track; no changes to auth, runtime, or existing API behavior beyond new exports and proofs.
> 
> **Overview**
> Formalizes Appendix C.2 **regrouping, sectorwise partial trace, and shift** channels that were previously only sketched in the blueprint.
> 
> **Lean:** Adds `Matrix.controlledPartialTraceRightLM` and its Kraus CPTP proof in `KrausCPTP.lean`, plus new module `RFPSubspinMaps.lean` with dependent-sum equivalences and global/fiberwise maps **𝒯₀**, **𝒮₀**, **𝒯₂**, **𝒮₂**, each with `IsKrausCPTP` proofs. Registers the module in `TNLean.lean`. **𝒮₀** uses a documented read of repeated **2l** as **3l** in the source prose.
> 
> **Blueprint:** Large addition in `ch21_mpdo_rfp_simple_local_structure.tex` (definitions, CPTP theorems, figure); `ch21_mpdo_rfp_pure_state_recovery.tex` now points readers to that chapter for the concrete equivalences. New TikZ macros `TNMPDOTwoSiteTraceAndShift` / `TNMPDOThreeSiteTraceAndShift`, subspin drawing helpers, and plasTeX diagram registration.
> 
> **Docs:** `docs/paper-gaps/cpgsv17_mpdo_s0_trace_subspin_typo.tex` records the **𝒮₀** subspin-label correction. Scope explicitly excludes **𝒯₁**/**𝒮₁** and Proposition C.7 recovery identities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b35dd742383af949e67fe8e9e7ea8a0cd64b0e47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->