### PR TITLE
feat(MPS/MPDO): expose controlled channel actions

### DIFF
--- a/TNLean/Channel/PartialTrace.lean
+++ b/TNLean/Channel/PartialTrace.lean
@@ -31,6 +31,8 @@ Proposition 2.1) and for reduced states on contiguous tensor factors.
 * `Matrix.traceRight_apply`: elementwise formula for `tr_B`
 * `Matrix.trace_partialTraceRight`: the full trace is preserved by the general
   right partial trace
+* `Matrix.partialTraceRight_kronecker`: the right partial trace of a Kronecker
+  product
 * `Matrix.trace_eq_trace_traceLeft`: `tr(X) = tr(tr_A(X))`
 * `Matrix.traceLeft_kronecker`: `tr_A(A ⊗ B) = tr(A) • B`
 * `Matrix.traceRight_kronecker`: `tr_B(A ⊗ B) = A • tr(B)`
@@ -97,6 +99,15 @@ theorem trace_partialTraceRight [Fintype α] (X : Matrix (α × β) (α × β) �
     (partialTraceRight X).trace = X.trace := by
   simp only [Matrix.trace, Matrix.diag, partialTraceRight_apply]
   rw [Fintype.sum_prod_type]
+
+/-- The partial trace over the right factor of a Kronecker product is the
+retained matrix multiplied by the trace of the discarded matrix. -/
+theorem partialTraceRight_kronecker (A : Matrix α α ℂ) (B : Matrix β β ℂ) :
+    partialTraceRight (kroneckerMap (· * ·) A B) = B.trace • A := by
+  ext i j
+  simp only [partialTraceRight_apply, kroneckerMap_apply, Matrix.smul_apply, Matrix.trace,
+    Matrix.diag, smul_eq_mul, ← Finset.mul_sum]
+  ring
 
 /-- The partial trace over the second factor is additive. -/
 theorem partialTraceRight_add (X Y : Matrix (α × β) (α × β) ℂ) :

--- a/TNLean/MPS/MPDO/EtaPreparation.lean
+++ b/TNLean/MPS/MPDO/EtaPreparation.lean
@@ -475,6 +475,24 @@ noncomputable def completedEtaControlledMap
       (data.completedEta_pos factor p.1 p.2)
       ((Fintype.equivFin (EtaIndex (hη := hη) p.1 p.2)).symm j))
 
+/-- On each diagonal sector pair, the completed neighboring-state control is
+the preparation map for the completed neighboring density.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1548--1555. -/
+theorem completedEtaControlledMap_sameBlock_apply
+    (data : ExplicitEtaOperators hη) (factor : RankOneTraceFactorization data)
+    (X : Matrix (Σ p, α p) (Σ p, α p) ℂ) (p : Fin hη.m × Fin hη.m)
+    (a b : α p) (u v : EtaIndex (hη := hη) p.1 p.2) :
+    data.completedEtaControlledMap factor X ⟨p, (a, u)⟩ ⟨p, (b, v)⟩ =
+      data.completedEtaPreparationMap factor p.1 p.2
+        (X.submatrix (Sigma.mk p) (Sigma.mk p)) (a, u) (b, v) := by
+  classical
+  rw [completedEtaControlledMap, Matrix.controlledKrausMap_sameBlock_apply,
+    Matrix.rectangularKrausMap_equiv
+      (Fintype.equivFin (EtaIndex (hη := hη) p.1 p.2)),
+    Matrix.rectangularKrausMap_preparationKraus_eq]
+  rfl
+
 /-- The global orthogonally controlled neighboring-state preparation is
 trace-preserving and completely positive.
 
@@ -507,6 +525,24 @@ noncomputable def completedOmegaControlledMap
     (fun p j => Matrix.preparationKraus (data.completedOmega factor p.1 p.2)
       (data.completedOmega_pos factor p.1 p.2)
       ((Fintype.equivFin (OmegaIndex (hη := hη) p.1 p.2)).symm j))
+
+/-- On each diagonal sector pair, the completed direct-sum control is the
+preparation map for the completed direct-sum density.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1523--1535. -/
+theorem completedOmegaControlledMap_sameBlock_apply
+    (data : ExplicitEtaOperators hη) (factor : RankOneTraceFactorization data)
+    (X : Matrix (Σ p, α p) (Σ p, α p) ℂ) (p : Fin hη.m × Fin hη.m)
+    (a b : α p) (u v : OmegaIndex (hη := hη) p.1 p.2) :
+    data.completedOmegaControlledMap factor X ⟨p, (a, u)⟩ ⟨p, (b, v)⟩ =
+      data.completedOmegaPreparationMap factor p.1 p.2
+        (X.submatrix (Sigma.mk p) (Sigma.mk p)) (a, u) (b, v) := by
+  classical
+  rw [completedOmegaControlledMap, Matrix.controlledKrausMap_sameBlock_apply,
+    Matrix.rectangularKrausMap_equiv
+      (Fintype.equivFin (OmegaIndex (hη := hη) p.1 p.2)),
+    Matrix.rectangularKrausMap_preparationKraus_eq]
+  rfl
 
 /-- The global orthogonally controlled direct-sum preparation is
 trace-preserving and completely positive.

--- a/TNLean/MPS/MPDO/KrausCPTP.lean
+++ b/TNLean/MPS/MPDO/KrausCPTP.lean
@@ -28,15 +28,23 @@ dimensions.
   positive property.
 * `Matrix.equivReindexMap_isKrausCPTP`: reindexing by an equivalence is
   trace-preserving completely positive.
+* `Matrix.controlledKrausMap_sameBlock_apply`: the action on each diagonal
+  summand of an orthogonally controlled Kraus map.
+* `Matrix.controlledKrausMap_apply_of_ne`: the vanishing of its off-diagonal
+  output blocks.
 * `Matrix.controlledKrausMap_isKrausCPTP`: orthogonal control of sectorwise
   Kraus families is trace-preserving completely positive.
 * `Matrix.partialTraceRightLM_isKrausCPTP`: tracing a right tensor factor is a
   trace-preserving completely positive map.
 * `Matrix.controlledPartialTraceRightLM_isKrausCPTP`: tracing dependent right
   factors sector by sector is trace-preserving completely positive.
+* `Matrix.controlledPartialTraceRightLM_sameBlock_apply`: the partial trace on
+  each diagonal summand.
 * `Matrix.preparationMap_isKrausCPTP`: adjoining a density matrix is a
   trace-preserving completely positive map.
 * `Matrix.preparationKraus`: the explicit Kraus family for state preparation.
+* `Matrix.rectangularKrausMap_preparationKraus_eq`: the Kraus action of state
+  preparation.
 -/
 
 open scoped Matrix BigOperators ComplexOrder
@@ -179,6 +187,16 @@ noncomputable def rectangularKrausMap
     intro i _
     rw [Matrix.mul_smul, Matrix.smul_mul]
 
+/-- Relabeling a finite Kraus family along an equivalence does not change its
+rectangular Kraus map. -/
+theorem rectangularKrausMap_equiv
+    {κ κ' α β : Type*} [Fintype κ] [Fintype κ'] [Fintype α]
+    (e : κ ≃ κ') (A : κ → Matrix β α ℂ) :
+    rectangularKrausMap (fun j : κ' => A (e.symm j)) = rectangularKrausMap A := by
+  apply LinearMap.ext
+  intro X
+  exact Equiv.sum_comp e.symm (fun i : κ => A i * X * (A i)ᴴ)
+
 section ControlledDirectSum
 
 variable {ι : Type*} [Fintype ι] [DecidableEq ι]
@@ -204,6 +222,89 @@ noncomputable def controlledKrausMap (r : ι → ℕ)
       Matrix (Σ i, β i) (Σ i, β i) ℂ :=
   rectangularKrausMap fun p : Σ i, Fin (r i) ↦
     singleBlock p.1 (A p.1 p.2)
+
+omit [∀ i, DecidableEq (α i)] [∀ i, Fintype (β i)] [∀ i, DecidableEq (β i)] in
+private lemma singleBlock_mul_conjTranspose_sameBlock_apply
+    (i : ι) (A : Matrix (β i) (α i) ℂ)
+    (X : Matrix (Σ i, α i) (Σ i, α i) ℂ) (b c : β i) :
+    (singleBlock i A * X * (singleBlock i A)ᴴ) ⟨i, b⟩ ⟨i, c⟩ =
+      (A * X.submatrix (Sigma.mk i) (Sigma.mk i) * Aᴴ) b c := by
+  classical
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, Fintype.sum_sigma]
+  rw [Finset.sum_eq_single i]
+  · simp [singleBlock, Matrix.blockDiagonal'_apply, Matrix.submatrix_apply]
+  · intro j _ hji
+    simp [singleBlock, Matrix.blockDiagonal'_apply, Ne.symm hji]
+  · simp
+
+omit [∀ i, DecidableEq (α i)] [∀ i, Fintype (β i)] [∀ i, DecidableEq (β i)] in
+private lemma singleBlock_mul_conjTranspose_apply_of_left_ne
+    (j : ι) (A : Matrix (β j) (α j) ℂ)
+    (X : Matrix (Σ i, α i) (Σ i, α i) ℂ) {i : ι} (hij : i ≠ j)
+    (b : β i) (q : Σ i, β i) :
+    (singleBlock j A * X * (singleBlock j A)ᴴ) ⟨i, b⟩ q = 0 := by
+  classical
+  simp [singleBlock, Matrix.mul_apply, Matrix.blockDiagonal'_apply, hij]
+
+omit [∀ i, DecidableEq (α i)] [∀ i, Fintype (β i)] [∀ i, DecidableEq (β i)] in
+private lemma singleBlock_mul_conjTranspose_apply_of_right_ne
+    (i : ι) (A : Matrix (β i) (α i) ℂ)
+    (X : Matrix (Σ i, α i) (Σ i, α i) ℂ) {j : ι} (hji : j ≠ i)
+    (p : Σ i, β i) (c : β j) :
+    (singleBlock i A * X * (singleBlock i A)ᴴ) p ⟨j, c⟩ = 0 := by
+  classical
+  rw [Matrix.mul_apply]
+  apply Finset.sum_eq_zero
+  rintro ⟨k, d⟩ _
+  by_cases hjk : j = k
+  · subst k
+    rw [Matrix.conjTranspose_apply, singleBlock, Matrix.blockDiagonal'_apply_eq]
+    simp [hji]
+  · rw [Matrix.conjTranspose_apply, singleBlock,
+      Matrix.blockDiagonal'_apply_ne _ c d hjk]
+    simp
+
+omit [∀ i, DecidableEq (α i)] [∀ i, Fintype (β i)] [∀ i, DecidableEq (β i)] in
+/-- On a diagonal summand, an orthogonally controlled Kraus map is the
+rectangular Kraus map of the corresponding family of operators. -/
+theorem controlledKrausMap_sameBlock_apply (r : ι → ℕ)
+    (A : (i : ι) → Fin (r i) → Matrix (β i) (α i) ℂ)
+    (X : Matrix (Σ i, α i) (Σ i, α i) ℂ) (i : ι) (b c : β i) :
+    controlledKrausMap r A X ⟨i, b⟩ ⟨i, c⟩ =
+      rectangularKrausMap (A i) (X.submatrix (Sigma.mk i) (Sigma.mk i)) b c := by
+  classical
+  change (∑ p : Σ i, Fin (r i), singleBlock p.1 (A p.1 p.2) * X *
+      (singleBlock p.1 (A p.1 p.2))ᴴ) ⟨i, b⟩ ⟨i, c⟩ =
+    (∑ j, A i j * X.submatrix (Sigma.mk i) (Sigma.mk i) * (A i j)ᴴ) b c
+  rw [Fintype.sum_sigma, Matrix.sum_apply]
+  rw [Finset.sum_eq_single i]
+  · simp_rw [Matrix.sum_apply, singleBlock_mul_conjTranspose_sameBlock_apply]
+  · intro j _ hji
+    simp_rw [Matrix.sum_apply,
+      singleBlock_mul_conjTranspose_apply_of_left_ne j (A j _) X (Ne.symm hji)]
+    exact Finset.sum_const_zero
+  · simp
+
+omit [∀ i, DecidableEq (α i)] [∀ i, Fintype (β i)] [∀ i, DecidableEq (β i)] in
+/-- An orthogonally controlled Kraus map annihilates every matrix entry
+between two distinct output summands. -/
+theorem controlledKrausMap_apply_of_ne (r : ι → ℕ)
+    (A : (i : ι) → Fin (r i) → Matrix (β i) (α i) ℂ)
+    (X : Matrix (Σ i, α i) (Σ i, α i) ℂ) {i j : ι} (hij : i ≠ j)
+    (b : β i) (c : β j) :
+    controlledKrausMap r A X ⟨i, b⟩ ⟨j, c⟩ = 0 := by
+  classical
+  change (∑ p : Σ i, Fin (r i), singleBlock p.1 (A p.1 p.2) * X *
+      (singleBlock p.1 (A p.1 p.2))ᴴ) ⟨i, b⟩ ⟨j, c⟩ = 0
+  rw [Matrix.sum_apply]
+  apply Finset.sum_eq_zero
+  rintro ⟨k, a⟩ _
+  by_cases hik : i = k
+  · have hjk : j ≠ k := by
+      intro hjk
+      exact hij (hik.trans hjk.symm)
+    exact singleBlock_mul_conjTranspose_apply_of_right_ne k (A k a) X hjk ⟨i, b⟩ c
+  · exact singleBlock_mul_conjTranspose_apply_of_left_ne k (A k a) X hik b ⟨j, c⟩
 
 omit [∀ i, Fintype (α i)] [∀ i, DecidableEq (α i)]
     [∀ i, DecidableEq (β i)] in
@@ -411,6 +512,14 @@ private noncomputable def chosenKraus
     Fin (chosenKrausRank hS) → Matrix β α ℂ :=
   hS.choose_spec.choose
 
+private theorem rectangularKrausMap_chosenKraus_eq
+    {α β : Type*} [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]
+    {S : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ} (hS : IsKrausCPTP S) :
+    rectangularKrausMap (chosenKraus hS) = S := by
+  apply LinearMap.ext
+  intro X
+  exact (hS.choose_spec.choose_spec.1 X).symm
+
 private theorem chosenKraus_resolution
     {α β : Type*} [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]
     {S : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ} (hS : IsKrausCPTP S) :
@@ -432,6 +541,24 @@ noncomputable def controlledPartialTraceRightLM
       (partialTraceRightLM_isKrausCPTP (α := α i) (β := β i)))
     (fun i => chosenKraus
       (partialTraceRightLM_isKrausCPTP (α := α i) (β := β i)))
+
+/-- On each diagonal summand, the controlled dependent partial trace is the
+ordinary partial trace over the corresponding right factor. -/
+theorem controlledPartialTraceRightLM_sameBlock_apply
+    {ι : Type*} [Fintype ι] [DecidableEq ι]
+    {α β : ι → Type*}
+    [∀ i, Fintype (α i)] [∀ i, DecidableEq (α i)]
+    [∀ i, Fintype (β i)] [∀ i, DecidableEq (β i)]
+    (X : Matrix (Σ i, α i × β i) (Σ i, α i × β i) ℂ)
+    (i : ι) (a b : α i) :
+    controlledPartialTraceRightLM X ⟨i, a⟩ ⟨i, b⟩ =
+      partialTraceRight
+        (X.submatrix (fun p : α i × β i => Sigma.mk i p)
+          (fun p : α i × β i => Sigma.mk i p)) a b := by
+  classical
+  rw [controlledPartialTraceRightLM, controlledKrausMap_sameBlock_apply,
+    rectangularKrausMap_chosenKraus_eq]
+  rfl
 
 /-- The controlled dependent partial trace is trace-preserving and completely
 positive. -/
@@ -511,6 +638,29 @@ private theorem preparationKraus_conjTranspose_mul_apply
   · subst b
     simp [preparationKraus, Matrix.conjTranspose_apply]
   · simp [preparationKraus, Matrix.conjTranspose_apply, hab, Ne.symm hab]
+
+/-- Summing the rectangular Kraus action of the square-root columns of a
+positive-semidefinite matrix gives the corresponding state-preparation map. -/
+theorem rectangularKrausMap_preparationKraus_eq
+    {α β : Type*} [Fintype α] [DecidableEq α]
+    [Fintype β] [DecidableEq β] (ρ : Matrix β β ℂ) (hρ : ρ.PosSemidef) :
+    rectangularKrausMap (fun j : β => preparationKraus (α := α) ρ hρ j) =
+      preparationMap ρ := by
+  classical
+  let R := hρ.isHermitian.cfc Real.sqrt
+  have hRherm : R.IsHermitian := hρ.cfc_sqrt_isHermitian
+  have hRR : R * R = ρ := hρ.cfc_sqrt_mul_self
+  apply LinearMap.ext
+  intro X
+  ext p q
+  change (∑ j : β, preparationKraus (α := α) ρ hρ j * X *
+      (preparationKraus (α := α) ρ hρ j)ᴴ) p q = X p.1 q.1 * ρ p.2 q.2
+  rw [Matrix.sum_apply]
+  have hRRentry : ρ p.2 q.2 = (R * R) p.2 q.2 :=
+    congrArg (fun M : Matrix β β ℂ => M p.2 q.2) hRR.symm
+  rw [hRRentry, Matrix.mul_apply, Finset.mul_sum]
+  refine Finset.sum_congr rfl fun j _ => ?_
+  rw [preparationKraus_mul_conjTranspose_apply, hRherm.apply]
 
 /-- The explicit preparation Kraus family resolves the identity,
 $\sum_j A_j^\dagger A_j=I$, when the prepared matrix has trace one. -/

--- a/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
@@ -128,6 +128,23 @@
     \]
 \end{definition}
 
+\begin{theorem}[Relabeling a rectangular Kraus family]
+    \label{thm:mpdo_rectangular_kraus_map_equiv}
+    \lean{Matrix.rectangularKrausMap_equiv}
+    \leanok
+    \uses{def:mpdo_rectangular_kraus_map}
+    If $e:I\simeq I'$ and $A'_b=A_{e^{-1}(b)}$, then
+    $\Phi_{A'}=\Phi_A$.
+\end{theorem}
+\begin{proof}
+    \leanok
+    Reindexing the finite sum gives
+    \[
+        \sum_{b\in I'}A_{e^{-1}(b)}X A_{e^{-1}(b)}^\dagger
+        =\sum_{a\in I}A_aXA_a^\dagger.
+    \]
+\end{proof}
+
 \begin{definition}[Orthogonally controlled Kraus map]
     \label{def:mpdo_controlled_kraus_map}
     \lean{Matrix.controlledKrausMap}
@@ -147,6 +164,50 @@
     \cite[Appendix~C.2, lines~1523--1535 and~1548--1555]
       {Cirac2016MPDO_arXiv}.
 \end{definition}
+
+\begin{theorem}[Diagonal blocks of an orthogonally controlled map]
+    \label{thm:mpdo_controlled_kraus_map_same_block}
+    \lean{Matrix.controlledKrausMap_sameBlock_apply}
+    \leanok
+    \uses{def:mpdo_controlled_kraus_map,
+      def:mpdo_rectangular_kraus_map}
+    Let $X_{kk}:H_k\to H_k$ denote the $k$th diagonal block of $X$. Then
+    \[
+        \mathcal C(X)_{kk}
+        =\sum_a A_{k,a}X_{kk}A_{k,a}^\dagger
+        =\Phi_{A_k}(X_{kk}).
+    \]
+\end{theorem}
+\begin{proof}
+    \leanok
+    If $j\ne k$, then every zero-extended Kraus operator satisfies
+    \[
+      [\widetilde A_{j,a}X\widetilde A_{j,a}^\dagger]
+        _{(k,b),(k,c)}=0.
+    \]
+    Hence only the $j=k$ terms survive, and
+    \[
+      [\mathcal C(X)]_{kk}
+      =\sum_a A_{k,a}X_{kk}A_{k,a}^\dagger.
+    \]
+\end{proof}
+
+\begin{theorem}[Off-diagonal blocks of an orthogonally controlled map]
+    \label{thm:mpdo_controlled_kraus_map_off_block}
+    \lean{Matrix.controlledKrausMap_apply_of_ne}
+    \leanok
+    \uses{def:mpdo_controlled_kraus_map}
+    If $k\ne l$, then $\mathcal C(X)_{kl}=0$.
+\end{theorem}
+\begin{proof}
+    \leanok
+    For every $(j,a)$ and $k\ne l$, the zero-extended operator satisfies
+    \[
+      [\widetilde A_{j,a}X\widetilde A_{j,a}^\dagger]
+        _{(k,b),(l,c)}=0.
+    \]
+    Therefore $[\mathcal C(X)]_{kl}=\sum_{j,a}0=0$.
+\end{proof}
 
 \begin{theorem}[Orthogonal control preserves trace-preserving complete positivity]
     \label{thm:mpdo_controlled_kraus_map_cptp}
@@ -189,6 +250,25 @@
     $\mathcal T_0$ and $\mathcal S_0$ in
     \cite[Appendix~C.2, lines~1521--1522 and~1547]{Cirac2016MPDO_arXiv}.
 \end{definition}
+
+\begin{theorem}[Right partial trace of a Kronecker product]
+    \label{thm:mpdo_right_partial_trace_kronecker}
+    \lean{Matrix.partialTraceRight_kronecker}
+    \leanok
+    \uses{def:mpdo_right_partial_trace_map}
+    For square matrices $X$ on $A$ and $Y$ on $B$,
+    \[
+        \tr_B(X\otimes Y)=\tr(Y)X.
+    \]
+\end{theorem}
+\begin{proof}
+    \leanok
+    For all $i,j$,
+    \[
+      [\tr_B(X\otimes Y)]_{ij}
+      =\sum_t X_{ij}Y_{tt}=\tr(Y)X_{ij}.
+    \]
+\end{proof}
 
 \begin{lemma}[The right partial trace is trace-preserving completely positive]
     \label{lem:mpdo_right_partial_trace_cptp}
@@ -238,6 +318,28 @@
         A_j(e_a)=e_a\otimes Re_j.
     \]
 \end{definition}
+
+\begin{theorem}[Kraus action of state preparation]
+    \label{thm:mpdo_state_preparation_kraus_action}
+    \lean{Matrix.rectangularKrausMap_preparationKraus_eq}
+    \leanok
+    \uses{def:mpdo_rectangular_kraus_map,
+      def:mpdo_state_preparation_map,
+      def:mpdo_state_preparation_kraus}
+    If $\rho\succeq0$ and $A_j(e_a)=e_a\otimes\sqrt\rho\,e_j$, then
+    \[
+        \sum_j A_jXA_j^\dagger=X\otimes\rho.
+    \]
+\end{theorem}
+\begin{proof}
+    \leanok
+    Put $R=\sqrt\rho$. Since $R$ is Hermitian and $R^2=\rho$, the
+    $((a,s),(b,t))$ entry of the left-hand side is
+    \[
+        X_{ab}\sum_jR_{sj}\overline{R_{tj}}
+        =X_{ab}(R^2)_{st}=X_{ab}\rho_{st}.
+    \]
+\end{proof}
 
 \begin{theorem}[Preparation Kraus operators resolve the identity]
     \label{thm:mpdo_state_preparation_kraus_resolution}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -1665,6 +1665,37 @@ strong subadditivity for a normalized three-site reduced state.
     \cite[Appendix~C.2, lines~1548--1555]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
+\begin{theorem}[Diagonal-sector action of the completed neighboring preparation]
+    \label{thm:mpdo_completed_eta_controlled_map_same_block}
+    \lean{MPOTensor.ExplicitEtaOperators.completedEtaControlledMap_sameBlock_apply}
+    \leanok
+    \uses{def:mpdo_completed_eta_controlled_map,
+      def:mpdo_completed_eta_preparation}
+    If $X_{k,h}$ is the $(k,h)$ diagonal block of $X$, then
+    \[
+      [\overline{\mathcal S}_1(X)]_{k,h}
+      =\overline{\mathcal S}_{k,h}(X_{k,h})
+      =X_{k,h}\otimes\overline\eta_{k,h}.
+    \]
+\end{theorem}
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_controlled_kraus_map_same_block,
+      thm:mpdo_rectangular_kraus_map_equiv,
+      thm:mpdo_state_preparation_kraus_action}
+    The diagonal-block formula and invariance under Kraus-index relabeling give
+    \[
+      [\overline{\mathcal S}_1(X)]_{k,h}
+      =\Phi_{\widetilde A_{k,h}}(X_{k,h})
+      =\Phi_{A_{k,h}}(X_{k,h}).
+    \]
+    The preparation Kraus identity then gives
+    \[
+      \Phi_{A_{k,h}}(X_{k,h})
+      =X_{k,h}\otimes\overline\eta_{k,h}.
+    \]
+\end{proof}
+
 \begin{theorem}[The globally controlled neighboring-state preparation is
     trace-preserving completely positive]
     \label{thm:mpdo_completed_eta_controlled_map_cptp}
@@ -1706,6 +1737,37 @@ strong subadditivity for a normalized three-site reduced state.
     and, on active sectors, is the sector-control formula for $\mathcal T_1$
     in \cite[Appendix~C.2, lines~1523--1535]{Cirac2016MPDO_arXiv}.
 \end{definition}
+
+\begin{theorem}[Diagonal-sector action of the completed direct-sum preparation]
+    \label{thm:mpdo_completed_omega_controlled_map_same_block}
+    \lean{MPOTensor.ExplicitEtaOperators.completedOmegaControlledMap_sameBlock_apply}
+    \leanok
+    \uses{def:mpdo_completed_omega_controlled_map,
+      def:mpdo_completed_omega_preparation}
+    If $X_{k,h}$ is the $(k,h)$ diagonal block of $X$, then
+    \[
+      [\overline{\mathcal T}_1(X)]_{k,h}
+      =\overline{\mathcal T}_{k,h}(X_{k,h})
+      =X_{k,h}\otimes\overline\Omega_{k,h}.
+    \]
+\end{theorem}
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_controlled_kraus_map_same_block,
+      thm:mpdo_rectangular_kraus_map_equiv,
+      thm:mpdo_state_preparation_kraus_action}
+    The diagonal-block formula and invariance under Kraus-index relabeling give
+    \[
+      [\overline{\mathcal T}_1(X)]_{k,h}
+      =\Phi_{\widetilde B_{k,h}}(X_{k,h})
+      =\Phi_{B_{k,h}}(X_{k,h}).
+    \]
+    The preparation Kraus identity then gives
+    \[
+      \Phi_{B_{k,h}}(X_{k,h})
+      =X_{k,h}\otimes\overline\Omega_{k,h}.
+    \]
+\end{proof}
 
 \begin{theorem}[The globally controlled direct-sum preparation is
     trace-preserving completely positive]
@@ -1758,6 +1820,29 @@ strong subadditivity for a normalized three-site reduced state.
     The controlled dependent partial trace discards the off-diagonal blocks
     between distinct $i$ and applies $\tr_{B_i}$ to the $i$th diagonal block.
 \end{definition}
+
+\begin{theorem}[Diagonal blocks of the controlled dependent partial trace]
+    \label{thm:mpdo_controlled_dependent_partial_trace_same_block}
+    \lean{Matrix.controlledPartialTraceRightLM_sameBlock_apply}
+    \leanok
+    \uses{def:mpdo_controlled_dependent_partial_trace,
+      def:mpdo_right_partial_trace_map}
+    If $X_{ii}$ denotes the $i$th diagonal block of $X$, then
+    \[
+        [\mathcal C_{\mathrm{tr}}(X)]_{ii}=\tr_{B_i}(X_{ii}).
+    \]
+\end{theorem}
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_controlled_kraus_map_same_block}
+    If $(K_{i,j})_j$ is the Kraus family chosen for $\tr_{B_i}$, then the
+    diagonal-block formula gives
+    \[
+      [\mathcal C_{\mathrm{tr}}(X)]_{ii}
+      =\sum_j K_{i,j}X_{ii}K_{i,j}^\dagger
+      =\tr_{B_i}(X_{ii}).
+    \]
+\end{proof}
 
 \begin{theorem}[The controlled dependent partial trace is trace-preserving
     completely positive]


### PR DESCRIPTION
## Summary

This change proves the matrix-entry action of the orthogonally controlled Kraus maps used in the completed neighboring-state and direct-sum preparations. It also supplies the partial-trace and preparation identities needed for the next source-faithful construction of the maps S and T in Proposition C.7.

## Mathematical scope

- prove that a controlled Kraus map acts sectorwise on diagonal blocks and annihilates off-diagonal output blocks;
- identify the controlled dependent partial trace on every diagonal sector;
- prove invariance of rectangular Kraus sums under finite relabeling;
- prove the Kronecker-product formula for the right partial trace;
- identify the explicit preparation Kraus family with X mapped to X tensor rho;
- derive the exact diagonal-sector actions of the completed eta and Omega preparations.

The final two results concern the explicitly completed, overbarred maps. They do not assert Proposition C.7 and do not yet prove either physical-closure identity K3 to K2 or K2 to K3.

This advances #3740, #3743, and #3744.

## Source alignment

The completed neighboring preparation follows arXiv:1606.00608, Appendix C.2, lines 1548–1555. The completed direct-sum preparation follows lines 1523–1535. No additional positivity hypothesis is introduced.

## Validation

- lake build TNLean: 9,300 jobs passed
- focused Lean checks for all three changed modules passed
- leanblueprint checkdecls passed
- blueprint web and PDF generation passed
- affected PDF pages were visually inspected
- reader-facing prose and diff checks passed
- no new sorry or axiom was introduced

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formal proofs and blueprint text only; no runtime, auth, or API behavior changes. Risk is limited to mathematical correctness of the new lemmas, which are localized to MPDO channel algebra.
> 
> **Overview**
> Adds **matrix-entry** lemmas for orthogonally controlled Kraus maps, preparation, and partial trace, then wires them into the completed η/Ω MPDO preparations and the blueprint.
> 
> **KrausCPTP:** `controlledKrausMap_sameBlock_apply` and `controlledKrausMap_apply_of_ne` show sectorwise diagonal action and zero off-diagonal output blocks; `rectangularKrausMap_equiv` and `rectangularKrausMap_preparationKraus_eq` identify preparation Kraus sums with `X ↦ X ⊗ ρ`; `controlledPartialTraceRightLM_sameBlock_apply` reduces the controlled partial trace to ordinary `partialTraceRight` on each summand.
> 
> **PartialTrace:** `partialTraceRight_kronecker` gives `tr_B(A ⊗ B) = tr(B) • A`.
> 
> **EtaPreparation:** `completedEtaControlledMap_sameBlock_apply` and `completedOmegaControlledMap_sameBlock_apply` express each global controlled preparation on a diagonal sector as the corresponding sector preparation map (via the new Kraus lemmas).
> 
> Blueprint chapters document the same identities and cite them in proofs of the completed `𝒮₁` / `𝒯₁` diagonal-sector actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d93a09cb877784852642992aee5086d1e9078eb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->