### PR TITLE
feat(Channel): the support of a maximum-rank fixed point carries every fixed point (Cor 6.7 transfer)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -171,6 +171,7 @@ import TNLean.Channel.FixedPoint.Cesaro
 import TNLean.Channel.FixedPoint.CornerAlgebra
 import TNLean.Channel.FixedPoint.CornerBlockForm
 import TNLean.Channel.FixedPoint.CornerFixedPoints
+import TNLean.Channel.FixedPoint.MaximalRank
 import TNLean.Channel.FixedPoint.MaximalSupport
 import TNLean.Channel.FixedPoint.StationarySupport
 import TNLean.Channel.FixedPoint.WedderburnDecomp

--- a/TNLean/Channel/FixedPoint/MaximalRank.lean
+++ b/TNLean/Channel/FixedPoint/MaximalRank.lean
@@ -1,0 +1,282 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Channel.FixedPoint.MaximalSupport
+
+/-!
+# The support of a maximum-rank fixed point carries every fixed point
+
+Corollary 6.7 of *Quantum Channels & Operations* (Wolf 2012) quantifies over an arbitrary
+maximum-rank fixed-point density matrix. The results here transfer the maximal-support
+property from the constructed witness of
+`Kraus.exists_maximalSupport_fixedPoint` to every fixed point of maximum rank: if $\rho$
+is a positive semidefinite fixed point of the trace-preserving Kraus map $T$ whose rank
+bounds the rank of every fixed-point density matrix, then the support projection $Q$ of
+$\rho$ satisfies $Q X Q = X$ for every fixed point $X$ of $T$. Consequently conjugation by
+$\sqrt{\rho}$ maps the weighted corner carrier of
+`Kraus.weightedCornerFixedPointsStarSubalgebra` onto the full fixed-point set at every
+such $\rho$, which realizes the conjugated set
+$\rho^{-1/2}\,\{X \mid T(X) = X\}\,\rho^{-1/2}$ of the corollary, with the inverse square
+root taken on the support of $\rho$.
+
+The comparison with the constructed witness $\rho_0$ goes through the rank: the support
+projection of a positive semidefinite matrix has the same rank as the matrix, and its
+trace is that rank. From $Q_0 \rho Q_0 = \rho$ the rank of $\rho$ is at most that of
+$\rho_0$; maximality applied to the normalization of $\rho_0$ gives the reverse
+inequality; and two orthogonal projections $P \preceq Q_0$ (in the sense $Q_0 P = P$)
+with equal traces are equal, so the support projections coincide.
+
+## Main results
+
+* `Kraus.rank_stationaryProj` -- the support projection of a positive semidefinite matrix
+  has the rank of the matrix.
+* `Kraus.trace_stationaryProj` -- the trace of the support projection is the rank.
+* `Kraus.maximalSupport_of_maximalRank` -- the support of a fixed point of maximum rank
+  carries every fixed point.
+* `Kraus.exists_weightedCorner_sqrt_eq_of_maximalRank` -- at every fixed point of maximum
+  rank, conjugation by the square root maps the weighted corner carrier onto the full
+  fixed-point set.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder BigOperators
+open Matrix Finset Complex
+
+namespace Kraus
+
+variable {d D : ℕ}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+/-- **The support projection has the rank of the matrix.** For positive semidefinite
+$\rho$ with spectral decomposition $\rho = U\,\mathrm{diag}(\lambda)\,U^{\dagger}$, the
+support projection is $U\,\mathrm{diag}(\mathbf 1_{\lambda > 0})\,U^{\dagger}$, and both
+ranks count the indices with $\lambda_i \neq 0$, which for nonnegative eigenvalues are
+the indices with $\lambda_i > 0$. -/
+theorem rank_stationaryProj {ρ : Mat} (hρ_psd : ρ.PosSemidef) :
+    (stationaryProj hρ_psd).rank = ρ.rank := by
+  classical
+  set hH : ρ.IsHermitian := hρ_psd.isHermitian with hHdef
+  set U : Mat := (hH.eigenvectorUnitary : Mat) with hUdef
+  set sgn : Fin D → ℂ := fun i => if 0 < hH.eigenvalues i then 1 else 0 with hsgndef
+  have hUU : Uᴴ * U = 1 := by
+    rw [← Matrix.star_eq_conjTranspose]
+    simp [hUdef]
+  have hdet : Uᴴ.det * U.det = 1 := by
+    rw [← Matrix.det_mul, hUU, Matrix.det_one]
+  have hUH_unit : IsUnit Uᴴ.det :=
+    isUnit_iff_ne_zero.mpr (left_ne_zero_of_mul_eq_one hdet)
+  have hU_unit : IsUnit U.det :=
+    isUnit_iff_ne_zero.mpr (right_ne_zero_of_mul_eq_one hdet)
+  have hconj_rank : ∀ w : Fin D → ℂ,
+      (U * Matrix.diagonal w * Uᴴ).rank = (Matrix.diagonal w).rank := by
+    intro w
+    rw [Matrix.rank_mul_eq_left_of_isUnit_det Uᴴ (U * Matrix.diagonal w) hUH_unit,
+      Matrix.rank_mul_eq_right_of_isUnit_det U (Matrix.diagonal w) hU_unit]
+  have hP_def : stationaryProj hρ_psd = U * Matrix.diagonal sgn * Uᴴ := by
+    simp [stationaryProj, MPSTensor.supportProj, hUdef, hsgndef]
+  have hρ_spec : ρ = U * Matrix.diagonal (fun j => (hH.eigenvalues j : ℂ)) * Uᴴ := by
+    simpa [hUdef, Unitary.conjStarAlgAut_apply, Matrix.star_eq_conjTranspose,
+      Function.comp_def] using hH.spectral_theorem
+  rw [hP_def, hconj_rank, Matrix.rank_diagonal]
+  conv_rhs => rw [hρ_spec]
+  rw [hconj_rank, Matrix.rank_diagonal]
+  refine Fintype.card_congr (Equiv.subtypeEquivRight fun i => ?_)
+  have hnn : 0 ≤ hH.eigenvalues i := (hH.posSemidef_iff_eigenvalues_nonneg.mp hρ_psd) i
+  by_cases h : 0 < hH.eigenvalues i
+  · simp [hsgndef, h, Complex.ofReal_ne_zero.mpr (ne_of_gt h)]
+  · have h0 : hH.eigenvalues i = 0 := le_antisymm (not_lt.mp h) hnn
+    simp [hsgndef, h0]
+
+/-- **The trace of the support projection is the rank.** In the spectral decomposition
+the support projection is $U\,\mathrm{diag}(\mathbf 1_{\lambda > 0})\,U^{\dagger}$, whose
+trace counts the positive eigenvalues, and for a positive semidefinite matrix that count
+is the rank. -/
+theorem trace_stationaryProj {ρ : Mat} (hρ_psd : ρ.PosSemidef) :
+    (stationaryProj hρ_psd).trace = (ρ.rank : ℂ) := by
+  classical
+  set hH : ρ.IsHermitian := hρ_psd.isHermitian with hHdef
+  set U : Mat := (hH.eigenvectorUnitary : Mat) with hUdef
+  set sgn : Fin D → ℂ := fun i => if 0 < hH.eigenvalues i then 1 else 0 with hsgndef
+  have hUU : Uᴴ * U = 1 := by
+    rw [← Matrix.star_eq_conjTranspose]
+    simp [hUdef]
+  have hdet : Uᴴ.det * U.det = 1 := by
+    rw [← Matrix.det_mul, hUU, Matrix.det_one]
+  have hUH_unit : IsUnit Uᴴ.det :=
+    isUnit_iff_ne_zero.mpr (left_ne_zero_of_mul_eq_one hdet)
+  have hU_unit : IsUnit U.det :=
+    isUnit_iff_ne_zero.mpr (right_ne_zero_of_mul_eq_one hdet)
+  have hP_def : stationaryProj hρ_psd = U * Matrix.diagonal sgn * Uᴴ := by
+    simp [stationaryProj, MPSTensor.supportProj, hUdef, hsgndef]
+  have hρ_spec : ρ = U * Matrix.diagonal (fun j => (hH.eigenvalues j : ℂ)) * Uᴴ := by
+    simpa [hUdef, Unitary.conjStarAlgAut_apply, Matrix.star_eq_conjTranspose,
+      Function.comp_def] using hH.spectral_theorem
+  have hrank : ρ.rank = Fintype.card {i // (hH.eigenvalues i : ℂ) ≠ 0} := by
+    conv_lhs => rw [hρ_spec]
+    rw [Matrix.rank_mul_eq_left_of_isUnit_det Uᴴ
+        (U * Matrix.diagonal fun j => (hH.eigenvalues j : ℂ)) hUH_unit,
+      Matrix.rank_mul_eq_right_of_isUnit_det U
+        (Matrix.diagonal fun j => (hH.eigenvalues j : ℂ)) hU_unit, Matrix.rank_diagonal]
+  rw [hP_def, Matrix.trace_mul_comm, ← Matrix.mul_assoc, hUU, Matrix.one_mul,
+    Matrix.trace_diagonal, hrank, Fintype.card_subtype, hsgndef]
+  rw [Finset.sum_boole]
+  congr 2
+  refine Finset.filter_congr fun i _ => ?_
+  have hnn : 0 ≤ hH.eigenvalues i := (hH.posSemidef_iff_eigenvalues_nonneg.mp hρ_psd) i
+  by_cases h : 0 < hH.eigenvalues i
+  · simp [h, Complex.ofReal_ne_zero.mpr (ne_of_gt h)]
+  · have h0 : hH.eigenvalues i = 0 := le_antisymm (not_lt.mp h) hnn
+    simp [h0]
+
+/-- **The support of a fixed point of maximum rank carries every fixed point.** Let $T$
+be a trace-preserving Kraus map and let $\rho$ be a positive semidefinite fixed point of
+$T$ whose rank bounds the rank of every fixed-point density matrix (every positive
+semidefinite fixed point of unit trace). Then the support projection $Q$ of $\rho$
+satisfies $Q X Q = X$ for every fixed point $X$ of $T$. In Corollary 6.7 of
+*Quantum Channels & Operations* (Wolf 2012) the maximum-rank fixed point is a density
+matrix; unit trace of $\rho$ itself is not needed for the conclusion and is not assumed
+here. The support projection of $\rho$ is compared with that of the constructed maximal
+witness through the rank: the two support projections have equal traces and one absorbs
+the other, so they coincide. -/
+theorem maximalSupport_of_maximalRank
+    (K : Fin d → Mat) (h_tp : IsTP K) {ρ : Mat} (hρ_psd : ρ.PosSemidef)
+    (hρ_fix : map K ρ = ρ)
+    (hρ_max : ∀ σ : Mat, σ.PosSemidef → σ.trace = 1 → map K σ = σ → σ.rank ≤ ρ.rank) :
+    ∀ X : Mat, map K X = X →
+      stationaryProj hρ_psd * X * stationaryProj hρ_psd = X := by
+  classical
+  obtain ⟨ρ₀, hρ₀_psd, hρ₀_fix, hmax⟩ := exists_maximalSupport_fixedPoint K h_tp
+  set Q₀ : Mat := stationaryProj hρ₀_psd with hQ₀def
+  set P : Mat := stationaryProj hρ_psd with hPdef
+  have hQ₀herm : Q₀ᴴ = Q₀ := (isOrthogonalProjection_stationaryProj hρ₀_psd).1.eq
+  have hPherm : Pᴴ = P := (isOrthogonalProjection_stationaryProj hρ_psd).1.eq
+  have hQ₀idem : Q₀ * Q₀ = Q₀ := (isOrthogonalProjection_stationaryProj hρ₀_psd).2
+  have hPidem : P * P = P := (isOrthogonalProjection_stationaryProj hρ_psd).2
+  rcases eq_or_ne ρ₀ 0 with hρ₀0 | hρ₀ne
+  · -- Degenerate case: every fixed point vanishes, and the claim is trivial.
+    have hQ₀0 : Q₀ = 0 := by
+      refine Matrix.ext_of_mulVec_single fun j => ?_
+      rw [hQ₀def, Matrix.zero_mulVec]
+      exact MPSTensor.supportProj_mulVec_eq_zero_of_mulVec_eq_zero
+        (ρ := ρ₀) (hρ := hρ₀_psd) _ (by rw [hρ₀0, Matrix.zero_mulVec])
+    intro X hX
+    have hX0 : X = 0 := by
+      have h := hmax X hX
+      rw [hQ₀0] at h
+      simpa using h.symm
+    rw [hX0, Matrix.mul_zero, Matrix.zero_mul]
+  · -- The trace of the nonzero maximal witness is a nonzero nonnegative real number.
+    have hc_nonneg : (0 : ℂ) ≤ ρ₀.trace := hρ₀_psd.trace_nonneg
+    have hc_ne : ρ₀.trace ≠ 0 := by
+      intro h0
+      have hS_herm : (CFC.sqrt ρ₀)ᴴ = CFC.sqrt ρ₀ :=
+        MPSTensor.conjTranspose_cfc_sqrt (D := D) ρ₀
+      have hSS : CFC.sqrt ρ₀ * CFC.sqrt ρ₀ = ρ₀ :=
+        CFC.sqrt_mul_sqrt_self ρ₀ hρ₀_psd.nonneg
+      have htr : ((CFC.sqrt ρ₀)ᴴ * CFC.sqrt ρ₀).trace = 0 := by
+        rw [hS_herm, hSS]
+        exact h0
+      have hsq0 : CFC.sqrt ρ₀ = 0 :=
+        Matrix.trace_conjTranspose_mul_self_eq_zero_iff.mp htr
+      exact hρ₀ne (by rw [← hSS, hsq0, Matrix.mul_zero])
+    have him : ρ₀.trace.im = 0 := ((Complex.nonneg_iff.mp hc_nonneg).2).symm
+    have hre_nonneg : 0 ≤ ρ₀.trace.re := (Complex.nonneg_iff.mp hc_nonneg).1
+    have hre_ne : ρ₀.trace.re ≠ 0 := by
+      intro h
+      exact hc_ne (Complex.ext h him)
+    have htr_eq : ρ₀.trace = ((ρ₀.trace.re : ℝ) : ℂ) := by
+      exact Complex.ext rfl (by simp [him])
+    set c : ℝ := (ρ₀.trace.re)⁻¹ with hcdef
+    have hc_re_nonneg : 0 ≤ c := inv_nonneg.mpr hre_nonneg
+    have hc_re_ne : c ≠ 0 := inv_ne_zero hre_ne
+    -- The normalization of the maximal witness is a fixed-point density matrix.
+    set σ : Mat := ((c : ℝ) : ℂ) • ρ₀ with hσdef
+    have hσ_psd : σ.PosSemidef := by
+      have h := hρ₀_psd.conjTranspose_mul_mul_same
+        (((Real.sqrt c : ℝ) : ℂ) • (1 : Mat))
+      have heq : (((Real.sqrt c : ℝ) : ℂ) • (1 : Mat))ᴴ * ρ₀ *
+          (((Real.sqrt c : ℝ) : ℂ) • (1 : Mat)) = σ := by
+        rw [hσdef, Matrix.conjTranspose_smul, Matrix.conjTranspose_one,
+          Matrix.smul_mul, Matrix.one_mul, Matrix.mul_smul, Matrix.mul_one, smul_smul]
+        congr 1
+        rw [show star (((Real.sqrt c : ℝ) : ℂ)) = ((Real.sqrt c : ℝ) : ℂ) by simp]
+        rw [← Complex.ofReal_mul, Real.mul_self_sqrt hc_re_nonneg]
+      rw [← heq]
+      exact h
+    have hσ_tr : σ.trace = 1 := by
+      rw [hσdef, Matrix.trace_smul, htr_eq, smul_eq_mul, ← Complex.ofReal_mul,
+        inv_mul_cancel₀ hre_ne, Complex.ofReal_one]
+    have hσ_fix : map K σ = σ := by
+      rw [hσdef, map_smul, hρ₀_fix]
+    have hσ_rank : σ.rank = ρ₀.rank := by
+      rw [hσdef, Matrix.smul_eq_diagonal_mul]
+      refine Matrix.rank_mul_eq_right_of_isUnit_det _ _ ?_
+      rw [Matrix.det_diagonal, Finset.prod_const]
+      exact (isUnit_iff_ne_zero.mpr (Complex.ofReal_ne_zero.mpr hc_re_ne)).pow _
+    -- The two ranks agree.
+    have h1 : ρ₀.rank ≤ ρ.rank := hσ_rank ▸ hρ_max σ hσ_psd hσ_tr hσ_fix
+    have hQ₀ρQ₀ : Q₀ * ρ * Q₀ = ρ := hmax ρ hρ_fix
+    have h2 : ρ.rank ≤ ρ₀.rank := by
+      calc ρ.rank = (Q₀ * ρ * Q₀).rank := by rw [hQ₀ρQ₀]
+        _ ≤ (Q₀ * ρ).rank := Matrix.rank_mul_le_left _ _
+        _ ≤ Q₀.rank := Matrix.rank_mul_le_left _ _
+        _ = ρ₀.rank := rank_stationaryProj hρ₀_psd
+    have hrank_eq : ρ.rank = ρ₀.rank := le_antisymm h2 h1
+    -- The support of `ρ` is contained in the support of the maximal witness.
+    have hρQ₀ : ρ * Q₀ = ρ := by
+      conv_lhs => rw [← hQ₀ρQ₀]
+      rw [Matrix.mul_assoc, Matrix.mul_assoc, hQ₀idem, ← Matrix.mul_assoc]
+      exact hQ₀ρQ₀
+    have hPQ₀ : P * Q₀ = P := by
+      have hsub : P * (1 - Q₀) = 0 := by
+        refine Matrix.ext_of_mulVec_single fun j => ?_
+        rw [Matrix.zero_mulVec, ← Matrix.mulVec_mulVec]
+        refine MPSTensor.supportProj_mulVec_eq_zero_of_mulVec_eq_zero
+          (ρ := ρ) (hρ := hρ_psd) _ ?_
+        rw [Matrix.mulVec_mulVec,
+          show ρ * (1 - Q₀) = 0 by rw [Matrix.mul_sub, Matrix.mul_one, hρQ₀, sub_self],
+          Matrix.zero_mulVec]
+      rw [Matrix.mul_sub, Matrix.mul_one] at hsub
+      exact (sub_eq_zero.mp hsub).symm
+    have hQ₀P : Q₀ * P = P := by
+      have h := congrArg Matrix.conjTranspose hPQ₀
+      rwa [Matrix.conjTranspose_mul, hQ₀herm, hPherm] at h
+    -- Two projections with equal traces, one absorbing the other, coincide.
+    have hR : (Q₀ - P) * (Q₀ - P) = Q₀ - P := by
+      rw [mul_sub (Q₀ - P) Q₀ P, sub_mul Q₀ P Q₀, sub_mul Q₀ P P,
+        hQ₀idem, hPQ₀, hQ₀P, hPidem]
+      abel
+    have hRH : (Q₀ - P)ᴴ = Q₀ - P := by
+      rw [Matrix.conjTranspose_sub, hQ₀herm, hPherm]
+    have hRtr : ((Q₀ - P)ᴴ * (Q₀ - P)).trace = 0 := by
+      rw [hRH, hR, Matrix.trace_sub, hQ₀def, hPdef, trace_stationaryProj hρ₀_psd,
+        trace_stationaryProj hρ_psd, hrank_eq, sub_self]
+    have hPeq : P = Q₀ := by
+      have h := Matrix.trace_conjTranspose_mul_self_eq_zero_iff.mp hRtr
+      exact (sub_eq_zero.mp h).symm
+    intro X hX
+    rw [hPeq]
+    exact hmax X hX
+
+/-- **Conjugation by the square root at every fixed point of maximum rank.** Let $T$ be a
+trace-preserving Kraus map and let $\rho$ be a positive semidefinite fixed point of $T$
+whose rank bounds the rank of every fixed-point density matrix. Then every fixed point
+$X$ of $T$ arises as $X = \sqrt{\rho}\, Y \sqrt{\rho}$ for a corner-supported $Y$ with
+$\sqrt{\rho}\, Y \sqrt{\rho}$ fixed by $T$: conjugation by $\sqrt{\rho}$ maps the carrier
+of `Kraus.weightedCornerFixedPointsStarSubalgebra` onto the full fixed-point set, which
+realizes the set $\rho^{-1/2}\,\{X \mid T(X) = X\}\,\rho^{-1/2}$ of Corollary 6.7 of
+*Quantum Channels & Operations* (Wolf 2012) at every fixed point of maximum rank, with
+the inverse square root taken on the support of $\rho$. -/
+theorem exists_weightedCorner_sqrt_eq_of_maximalRank
+    (K : Fin d → Mat) (h_tp : IsTP K) {ρ : Mat} (hρ_psd : ρ.PosSemidef)
+    (hρ_fix : map K ρ = ρ)
+    (hρ_max : ∀ σ : Mat, σ.PosSemidef → σ.trace = 1 → map K σ = σ → σ.rank ≤ ρ.rank)
+    {X : Mat} (hX_fix : map K X = X) :
+    ∃ Y : Mat, stationaryProj hρ_psd * Y * stationaryProj hρ_psd = Y ∧
+      map K (CFC.sqrt ρ * Y * CFC.sqrt ρ) = CFC.sqrt ρ * Y * CFC.sqrt ρ ∧
+      CFC.sqrt ρ * Y * CFC.sqrt ρ = X :=
+  exists_weightedCorner_sqrt_eq_of_fixedPoint K h_tp hρ_psd hρ_fix hX_fix
+    (maximalSupport_of_maximalRank K h_tp hρ_psd hρ_fix hρ_max X hX_fix)
+
+end Kraus

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -305,7 +305,7 @@ What is still missing for the full Wolf statement is the identification of
 the ambient fixed-point space with the zero-block form and the density-block
 refinement with matrices `ρ_k` for the Schrödinger-picture fixed points.
 
-### Wolf Corollary 6.7 (faithful fixed-point conjugation) — PARTIALLY FORMALIZED
+### Wolf Corollary 6.7 (faithful fixed-point conjugation) — FORMALIZED
 
 In `TNLean.Channel.FixedPoint.Corollaries`:
 
@@ -339,11 +339,25 @@ and the removal of the corner restriction):
   realizing $\rho_0^{-1/2}\,\{X \mid T(X) = X\}\,\rho_0^{-1/2}$ without a support
   restriction.
 
-Wolf's statement quantifies over an arbitrary maximum-rank fixed-point
-density matrix; the formalized statements produce one fixed point of maximal
-support and realize the
-conjugated set there. Transferring the statement to every maximum-rank fixed
-point (by identifying the supports of any two of them) is not formalized
+In `TNLean.Channel.FixedPoint.MaximalRank` (the transfer to every fixed point
+of maximum rank):
+
+* `Kraus.rank_stationaryProj`, `Kraus.trace_stationaryProj` — the support
+  projection of a positive semidefinite matrix has the rank of the matrix,
+  and its trace is that rank.
+* `Kraus.maximalSupport_of_maximalRank` — if the rank of a positive
+  semidefinite fixed point $\rho$ bounds the rank of every fixed-point
+  density matrix, its support projection $Q$ satisfies $Q X Q = X$ for every
+  fixed point $X$.
+* `Kraus.exists_weightedCorner_sqrt_eq_of_maximalRank` — at every such
+  $\rho$, conjugation by $\sqrt{\rho}$ maps the corner carrier onto the full
+  fixed-point set, realizing $\rho^{-1/2}\,\{X \mid T(X) = X\}\,\rho^{-1/2}$
+  with the inverse square root taken on the support of $\rho$.
+
+The scope is the Kraus (completely positive) case of the source's Schwarz
+hypothesis, as recorded for the other results of this section; the source's
+maximum-rank fixed-point density matrix satisfies the rank hypothesis, with
+unit trace of $\rho$ itself not needed for the conclusion
 (see `docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex`).
 
 ### Wolf Theorem 6.15 (Conditional expectation onto fixed-point algebra) — PARTIALLY FORMALIZED

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -306,7 +306,7 @@ What is still missing for the full Wolf statement is the identification of
 the ambient fixed-point space with the zero-block form and the density-block
 refinement with matrices `ρ_k` for the Schrödinger-picture fixed points.
 
-### Wolf Corollary 6.7 (faithful fixed-point conjugation) — FORMALIZED
+### Wolf Corollary 6.7 (faithful fixed-point conjugation) — FORMALIZED (Kraus case)
 
 In `TNLean.Channel.FixedPoint.Corollaries`:
 

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -13,6 +13,7 @@ import TNLean.Channel.FixedPoint.CornerBlockForm
 import TNLean.Channel.FixedPoint.Corollaries
 import TNLean.Channel.FixedPoint.WeightedCornerFixedPoints
 import TNLean.Channel.FixedPoint.MaximalSupport
+import TNLean.Channel.FixedPoint.MaximalRank
 import TNLean.Channel.Irreducible.Ergodicity
 import TNLean.Channel.Irreducible.Basic
 import TNLean.Channel.Irreducible.Growth

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2717,9 +2717,10 @@ point of maximum rank goes through the rank of the support projection.
     \[
         Q\, X\, Q = X
     \]
-    for every fixed point $X$ of $T$. The maximum-rank fixed point of Corollary~6.7
-    of~\cite{Wolf2012Quantum} is a density matrix; unit trace of $\rho$ itself is not
-    needed for the conclusion and is not assumed.
+    for every fixed point $X$ of $T$.
+    % Maintainer note: the maximum-rank fixed point of Corollary 6.7 of Wolf (2012) is a
+    % density matrix; unit trace of the fixed point itself is not needed for the
+    % conclusion and is not assumed here.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2699,8 +2699,8 @@ point of maximum rank goes through the rank of the support projection.
         \;=\; \#\{i \mid \lambda_i > 0\}
         \;=\; \operatorname{rank} \rho,
     \]
-    the last equality by the count of nonzero eigenvalues in
-    Lemma~\ref{lem:rank_stationaryProj}.
+    the last equality because the rank of a positive semidefinite matrix is the number
+    of its positive eigenvalues.
 \end{proof}
 
 \begin{theorem}[The support of a fixed point of maximum rank carries every fixed
@@ -2742,9 +2742,14 @@ point of maximum rank goes through the rank of the support projection.
         \;=\; \operatorname{rank} \rho_0,
     \]
     the last equality by Lemma~\ref{lem:rank_stationaryProj}; hence the ranks agree.
-    From $\rho\,Q_0 = \rho$ and the kernel inclusion of the support projection,
-    $P (\Id - Q_0) = 0$, that is $P Q_0 = P$, and taking conjugate transposes also
-    $Q_0 P = P$. The difference $R = Q_0 - P$ is then Hermitian and idempotent,
+    From $\rho\,Q_0 = \rho$ one has $\rho\,(\Id - Q_0) = 0$, so the range of
+    $\Id - Q_0$ lies in the kernel of $\rho$; the support projection $P$ of $\rho$
+    vanishes on that kernel, so
+    \[
+        P\,(\Id - Q_0) = 0,
+        \qquad P\,Q_0 = P,
+    \]
+    and taking conjugate transposes also $Q_0 P = P$. The difference $R = Q_0 - P$ is then Hermitian and idempotent,
     \[
         R^2 \;=\; Q_0 - P - P + P \;=\; R,
     \]

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2652,6 +2652,141 @@ the conjugated
 fixed-point set of Corollary~6.7 of~\cite{Wolf2012Quantum} at a fixed point of maximal
 support, without a support restriction on the fixed points.
 
+The corollary in~\cite{Wolf2012Quantum} quantifies over an arbitrary maximum-rank
+fixed-point density matrix. The transfer from the constructed witness to every fixed
+point of maximum rank goes through the rank of the support projection.
+
+\begin{lemma}[The support projection has the rank of the matrix]%
+    \label{lem:rank_stationaryProj}
+    \lean{Kraus.rank_stationaryProj}
+    \leanok
+    \uses{def:support_proj}
+    For $\rho \succeq 0$ on $\C^{D}$, the support projection of $\rho$ has the rank of
+    $\rho$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{def:support_proj}
+    In the spectral decomposition $\rho = U\,\mathrm{diag}(\lambda)\,U^{\dagger}$ the
+    support projection is $U\,\mathrm{diag}(\mathbf 1_{\lambda > 0})\,U^{\dagger}$.
+    Multiplication by the invertible $U$ and $U^{\dagger}$ preserves the rank, and
+    \[
+        \operatorname{rank}\,\mathrm{diag}(\mathbf 1_{\lambda > 0})
+        \;=\; \#\{i \mid \lambda_i > 0\}
+        \;=\; \#\{i \mid \lambda_i \neq 0\}
+        \;=\; \operatorname{rank}\,\mathrm{diag}(\lambda),
+    \]
+    the middle equality because the eigenvalues of $\rho \succeq 0$ are nonnegative.
+\end{proof}
+
+\begin{lemma}[The trace of the support projection is the rank]%
+    \label{lem:trace_stationaryProj}
+    \lean{Kraus.trace_stationaryProj}
+    \leanok
+    \uses{def:support_proj}
+    For $\rho \succeq 0$ on $\C^{D}$, the trace of the support projection of $\rho$ is
+    the rank of $\rho$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{def:support_proj}
+    With $\rho = U\,\mathrm{diag}(\lambda)\,U^{\dagger}$ as above,
+    \[
+        \tr\bigl(U\,\mathrm{diag}(\mathbf 1_{\lambda > 0})\,U^{\dagger}\bigr)
+        \;=\; \tr\,\mathrm{diag}(\mathbf 1_{\lambda > 0})
+        \;=\; \#\{i \mid \lambda_i > 0\}
+        \;=\; \operatorname{rank} \rho,
+    \]
+    the last equality by the count of nonzero eigenvalues in
+    Lemma~\ref{lem:rank_stationaryProj}.
+\end{proof}
+
+\begin{theorem}[The support of a fixed point of maximum rank carries every fixed
+    point]%
+    \label{thm:maximalSupport_of_maximalRank}
+    \lean{Kraus.maximalSupport_of_maximalRank}
+    \leanok
+    \uses{def:tp_kraus, def:support_proj}
+    Let $T(X) = \sum_i K_i X K_i^\dagger$ be trace-preserving and let $\rho \succeq 0$
+    be a fixed point of $T$ whose rank bounds the rank of every fixed-point density
+    matrix: $\operatorname{rank} \sigma \le \operatorname{rank} \rho$ for every
+    $\sigma \succeq 0$ with $\tr \sigma = 1$ and $T(\sigma) = \sigma$. Then the support
+    projection $Q$ of $\rho$ satisfies
+    \[
+        Q\, X\, Q = X
+    \]
+    for every fixed point $X$ of $T$. The maximum-rank fixed point of Corollary~6.7
+    of~\cite{Wolf2012Quantum} is a density matrix; unit trace of $\rho$ itself is not
+    needed for the conclusion and is not assumed.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:maximalSupport_fixedPoint, lem:rank_stationaryProj,
+        lem:trace_stationaryProj}
+    Let $\rho_0$ be the fixed point of maximal support of
+    Theorem~\ref{thm:maximalSupport_fixedPoint}, with support projection $Q_0$, and let
+    $P$ be the support projection of $\rho$. If $\rho_0 = 0$, then every fixed point
+    vanishes, because $Q_0 = 0$ annihilates it, and the claim is trivial; so let
+    $\rho_0 \neq 0$. Its trace is then a nonzero nonnegative real number, and
+    $\sigma = (\tr \rho_0)^{-1} \rho_0$ is a fixed-point density matrix with
+    $\operatorname{rank} \sigma = \operatorname{rank} \rho_0$, so the rank hypothesis
+    gives $\operatorname{rank} \rho_0 \le \operatorname{rank} \rho$. Conversely
+    $Q_0 \rho Q_0 = \rho$, so
+    \[
+        \operatorname{rank} \rho
+        \;=\; \operatorname{rank}\bigl(Q_0\,\rho\,Q_0\bigr)
+        \;\le\; \operatorname{rank} Q_0
+        \;=\; \operatorname{rank} \rho_0,
+    \]
+    the last equality by Lemma~\ref{lem:rank_stationaryProj}; hence the ranks agree.
+    From $\rho\,Q_0 = \rho$ and the kernel inclusion of the support projection,
+    $P (\Id - Q_0) = 0$, that is $P Q_0 = P$, and taking conjugate transposes also
+    $Q_0 P = P$. The difference $R = Q_0 - P$ is then Hermitian and idempotent,
+    \[
+        R^2 \;=\; Q_0 - P - P + P \;=\; R,
+    \]
+    and its trace vanishes by Lemma~\ref{lem:trace_stationaryProj} and the equality of
+    the ranks, so
+    \[
+        \tr\bigl(R^{\dagger} R\bigr) \;=\; \tr R \;=\; 0,
+    \]
+    hence $R = 0$ and $P = Q_0$. The claim now follows from the maximal-support property
+    of $\rho_0$.
+\end{proof}
+
+\begin{theorem}[Conjugation by the square root at every fixed point of maximum rank]%
+    \label{thm:weightedCorner_sqrt_eq_of_maximalRank}
+    \lean{Kraus.exists_weightedCorner_sqrt_eq_of_maximalRank}
+    \leanok
+    \uses{def:tp_kraus, def:support_proj}
+    Let $T(X) = \sum_i K_i X K_i^\dagger$ be trace-preserving and let $\rho \succeq 0$
+    be a fixed point of $T$ whose rank bounds the rank of every fixed-point density
+    matrix. Then every fixed point $X$ of $T$ arises as
+    \[
+        X \;=\; \sqrt{\rho}\, Y \sqrt{\rho}
+    \]
+    for a corner-supported $Y$ with $\sqrt{\rho}\, Y \sqrt{\rho}$ fixed by $T$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:maximalSupport_of_maximalRank, thm:weightedCorner_sqrt_surjective}
+    By Theorem~\ref{thm:maximalSupport_of_maximalRank} every fixed point $X$ of $T$
+    satisfies $Q\, X\, Q = X$ for the support projection $Q$ of $\rho$, so
+    Theorem~\ref{thm:weightedCorner_sqrt_surjective} applies to $X$ and produces the
+    corner-supported $Y$.
+\end{proof}
+
+At every fixed point $\rho$ of maximum rank, with the inverse square root taken on the
+support of $\rho$, the carrier of the $*$-subalgebra of
+Theorem~\ref{thm:weightedCornerFixedPointsStarSubalgebra} therefore realizes the
+conjugated fixed-point set
+$\rho^{-1/2}\,\{X \in \MN{D} \mid T(X) = X\}\,\rho^{-1/2}$ of Corollary~6.7
+of~\cite{Wolf2012Quantum}.
+
 \section{Further irreducibility and primitivity equivalences}
 
 This section collects several criteria and equivalences from~\cite[Theorems~6.2, 6.7, 6.8]{Wolf2012Quantum} that are

--- a/docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex
+++ b/docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex
@@ -79,10 +79,22 @@ and linearity extends the absorption from the parts to every fixed point.
 
 \section{Verdict}
 
-The corner-support restriction is eliminated at the constructed fixed point of maximal
-support. The residual gap against the source is the corollary's quantification over an
-\emph{arbitrary} maximum-rank fixed-point density matrix: identifying the supports of
-any two maximum-rank fixed points, so that the statement transfers from the constructed
-witness to every maximum-rank fixed point, is not established here.
+The restriction is eliminated. The maximal-support property holds at the constructed
+witness (\leanid{Kraus.exists\_maximalSupport\_fixedPoint}), and the transfer to every
+maximum-rank fixed point is
+\leanid{Kraus.maximalSupport\_of\_maximalRank} in
+\leanid{TNLean/Channel/FixedPoint/MaximalRank.lean}: for any positive semidefinite fixed
+point $\rho$ whose rank bounds the rank of every fixed-point density matrix, the support
+projection of $\rho$ carries every fixed point, because the support projection of a
+positive semidefinite matrix has the rank of the matrix and its trace is that rank, so
+the two support projections have equal traces, one absorbs the other, and they coincide.
+The conjugated set $\rho^{-1/2}\,\{X \mid T(X) = X\}\,\rho^{-1/2}$ of the corollary is
+realized at every such $\rho$
+(\leanid{Kraus.exists\_weightedCorner\_sqrt\_eq\_of\_maximalRank}), with the inverse
+square root taken on the support of $\rho$. Unit trace of $\rho$ itself is not needed for
+the conclusion and is not assumed; the maximality hypothesis quantifies over fixed-point
+density matrices, as in the source. The remaining scope convention is the Kraus
+(completely positive) case of the source's Schwarz hypothesis, shared by the other
+formalized results of the section.
 
 \end{document}


### PR DESCRIPTION
## Summary

The remaining quantifier gap on Corollary 6.7 of *Quantum Channels & Operations* (Wolf 2012), recorded in the paper-gap note's Verdict after LionSR/TNLean#3755: the source quantifies over an **arbitrary** maximum-rank fixed-point density matrix, while the formalized statements realized the conjugated set only at the constructed maximal-support witness. This PR closes that gap.

New file `TNLean/Channel/FixedPoint/MaximalRank.lean` (sorry/axiom-free):

- `Kraus.rank_stationaryProj` — the support projection of a positive semidefinite matrix has the rank of the matrix.
- `Kraus.trace_stationaryProj` — the trace of the support projection is the rank (as a complex natural number cast). Both via the spectral decomposition $\rho = U\,\mathrm{diag}(\lambda)\,U^\dagger$: multiplication by the invertible $U, U^\dagger$ preserves the rank, and for $\rho \succeq 0$ the indices with $\lambda_i \neq 0$ are those with $\lambda_i > 0$.
- `Kraus.maximalSupport_of_maximalRank` — **the transfer**: for a trace-preserving Kraus family $K$ and a positive semidefinite fixed point $\rho$ with
  $$\forall\, \sigma \succeq 0,\ \operatorname{tr}\sigma = 1,\ T(\sigma) = \sigma \implies \operatorname{rank}\sigma \le \operatorname{rank}\rho$$
  (the **exact predicate used for maximum rank**, quantified over fixed-point density matrices as in the source), the support projection $Q$ of $\rho$ satisfies $Q X Q = X$ for every fixed point $X$.
- `Kraus.exists_weightedCorner_sqrt_eq_of_maximalRank` — at every such $\rho$, conjugation by $\sqrt{\rho}$ maps the carrier of `Kraus.weightedCornerFixedPointsStarSubalgebra` onto the full fixed-point set: the conjugated set $\rho^{-1/2}\{X \mid T(X)=X\}\rho^{-1/2}$ of the corollary, with the inverse square root on the support, at **every** fixed point of maximum rank.

**Route** (the candidate route from the task, validated): with $\rho_0$ the constructed witness and $Q_0$ its support projection, $Q_0 \rho Q_0 = \rho$ gives $\operatorname{rank}\rho \le \operatorname{rank}Q_0 = \operatorname{rank}\rho_0$; maximality applied to the normalization $(\operatorname{tr}\rho_0)^{-1}\rho_0$ (a fixed-point density matrix of the same rank; the degenerate case $\rho_0 = 0$ makes every fixed point vanish) gives the reverse inequality; the kernel inclusion of the support projection gives $P Q_0 = P = Q_0 P$ for $P$ the support projection of $\rho$; and $R = Q_0 - P$ is a Hermitian idempotent with $\operatorname{tr}(R^\dagger R) = \operatorname{tr}R = 0$, so $P = Q_0$.

**Scope, stated precisely:** unit trace of $\rho$ itself is not needed for the conclusion and is not assumed (a weaker hypothesis than the source's; the source's maximum-rank density matrix satisfies it). The remaining scope convention is the Kraus (completely positive) case of the source's Schwarz hypothesis, shared by all formalized results of this section — per the standing convention, not counted as a residue. The chapter index entry for Corollary 6.7 is upgraded to FORMALIZED with the scope sentence; the paper-gap note's Verdict now records the settled state in present tense.

**What remains for LionSR/QICLean#39:** the density-weighted form $\bigoplus_k M_{d_k} \otimes \rho_k$ of Theorem 6.14 for the Schrödinger-picture fixed points (Equation (1.40) of the reference).

Partially addresses LionSR/QICLean#39.

## Blueprint

Four new entries in `blueprint/src/chapter/ch07_spectral.tex`, after the maximal-support entries, with displayed-equation proofs and `\uses` matching the Lean proofs:

- `lem:rank_stationaryProj`, `lem:trace_stationaryProj` (spectral count of positive eigenvalues),
- `thm:maximalSupport_of_maximalRank` (uses `thm:maximalSupport_fixedPoint` and the two lemmas),
- `thm:weightedCorner_sqrt_eq_of_maximalRank` (uses the transfer and `thm:weightedCorner_sqrt_surjective`),

plus a closing paragraph stating the realized conjugated set at every fixed point of maximum rank.

## Validation

- `lake build TNLean` — success, no new warnings
- `rg -n "sorry|axiom"` on the new and touched Lean files — clean
- `lake exe checkdecls blueprint/lean_decls` — pass (after `--update-lean-decls`)
- `python3 scripts/blueprint_lean_sync.py --ci` — in sync
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main --ci` — no violations
- `lake exe lint_style`, `git diff --check` — clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style channel fixed-point theory with no runtime or auth paths; changes are additive proofs and documentation sync.
> 
> **Overview**
> Closes the **quantifier gap** on Wolf Corollary 6.7: formalization previously realized faithful conjugation only at a constructed maximal-support witness; this PR extends that to **any** positive semidefinite fixed point \(\rho\) whose rank dominates every fixed-point density matrix.
> 
> **New Lean** (`TNLean/Channel/FixedPoint/MaximalRank.lean`): spectral lemmas `Kraus.rank_stationaryProj` and `Kraus.trace_stationaryProj`; main transfer `Kraus.maximalSupport_of_maximalRank` (support projection of \(\rho\) carries every fixed point, via rank equality with the witness and projection absorption); corollary `Kraus.exists_weightedCorner_sqrt_eq_of_maximalRank` (delegates to existing weighted-corner surjectivity once maximal support holds). Module is wired into `TNLean.lean` and `WolfChapter6Index`.
> 
> **Docs**: Wolf Ch.6 index marks Cor 6.7 **FORMALIZED (Kraus case)**; blueprint `ch07_spectral.tex` adds matching lemmas/theorems; paper-gap note verdict updated to **restriction eliminated**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a664a0b5b5fc1b7670a342b05c358db3869b862. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->