### PR TITLE
feat(MPS/MPDO): factor arbitrary physical closures

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -383,6 +383,9 @@ import TNLean.MPS.MPDO.EtaPreparation
 import TNLean.MPS.MPDO.RFPSubspinMaps
 import TNLean.MPS.MPDO.HayashiSectorComparison
 import TNLean.MPS.MPDO.SectorFactorization
+import TNLean.MPS.MPDO.PhysicalSectorFactorization
+import TNLean.MPS.MPDO.PhysicalSectorClosureTwo
+import TNLean.MPS.MPDO.PhysicalSectorClosureThree
 import TNLean.MPS.MPDO.SectorPairingTransfer
 import TNLean.MPS.MPDO.SectorEtaContraction
 import TNLean.MPS.MPDO.SectorEtaOperator

--- a/TNLean/MPS/MPDO/PhysicalSectorClosureThree.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorClosureThree.lean
@@ -67,6 +67,17 @@ def threeSiteRegroupEquiv (F : PhysicalSectorFactorization K)
   left_inv := by rintro ⟨⟨lk, rk⟩, ⟨ll, rl⟩, lh, rh⟩; rfl
   right_inv := by rintro ⟨⟨lk, rh⟩, ⟨rk, ll⟩, rl, lh⟩; rfl
 
+/-- The inverse regrouping reconstructs the three complete sector indices.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl` and `etarl`,
+lines 1435--1450. -/
+@[simp] theorem threeSiteRegroupEquiv_symm_apply
+    (F : PhysicalSectorFactorization K) (k l h : Fin F.sectorCount)
+    (x : BoundaryIndex F k h × (NeighborIndex F k l × NeighborIndex F l h)) :
+    (F.threeSiteRegroupEquiv k l h).symm x =
+      ((x.1.1, x.2.1.1), ((x.2.1.2, x.2.2.1), (x.2.2.2, x.1.2))) :=
+  rfl
+
 /-- The fixed-`(k,l,h)` submatrix of the three-site closure, reindexed into
 the outer boundary factors and the two neighboring pairs.
 
@@ -99,12 +110,10 @@ theorem threeSiteSectorClosure_eq (F : PhysicalSectorFactorization K)
       F.boundaryOperator k h X ⊗ₖ
         (F.neighboringOperator k l ⊗ₖ F.neighboringOperator l h) := by
   ext x y
-  simp only [threeSiteSectorClosure, threeSiteRegroupEquiv, MPOTensor.physClose3,
-    Matrix.trace, Matrix.mul_assoc, Matrix.diag_apply, Matrix.mul_apply,
-    sectorCoordinateTensor_apply, LinearMap.coe_mk, AddHom.coe_mk,
-    Matrix.reindex_apply, Equiv.symm_mk, Equiv.coe_fn_mk, Matrix.submatrix_apply,
-    threeSiteSectorEmbedding, Matrix.of_apply, Equiv.apply_symm_apply,
-    transformedPhysicalSlice_apply_same, Matrix.kroneckerMap_apply,
+  simp only [threeSiteSectorClosure, Matrix.reindex_apply, Matrix.submatrix_apply,
+    threeSiteRegroupEquiv_symm_apply, threeSiteSectorEmbedding, physClose3_apply,
+    sectorCoordinateTensor_apply_same, Matrix.trace, Matrix.mul_assoc,
+    Matrix.diag_apply, Matrix.mul_apply, Matrix.kroneckerMap_apply,
     boundaryOperator_apply, neighboringOperator_apply]
   simp_rw [Finset.mul_sum, Finset.sum_mul]
   have sum_permute (f : Fin D → Fin D → Fin D → Fin D → ℂ) :

--- a/TNLean/MPS/MPDO/PhysicalSectorClosureThree.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorClosureThree.lean
@@ -55,8 +55,9 @@ and the two neighboring pairs:
  \longmapsto ((l_k,r_h),((r_k,l_l),(r_l,l_h))).
 \]
 
-Source: arXiv:1606.00608, Appendix C.2, line 1547 and the accompanying
-diagram. -/
+Source: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl` and `etarl`,
+lines 1435--1450; the order of the three subspins follows the convention at
+lines 1520--1522. -/
 def threeSiteRegroupEquiv (F : PhysicalSectorFactorization K)
     (k l h : Fin F.sectorCount) :
     (SectorIndex F k × (SectorIndex F l × SectorIndex F h)) ≃
@@ -98,8 +99,13 @@ theorem threeSiteSectorClosure_eq (F : PhysicalSectorFactorization K)
       F.boundaryOperator k h X ⊗ₖ
         (F.neighboringOperator k l ⊗ₖ F.neighboringOperator l h) := by
   ext x y
-  simp [threeSiteSectorClosure, threeSiteSectorEmbedding, threeSiteRegroupEquiv,
-    MPOTensor.physClose3, Matrix.trace, Matrix.mul_apply, Matrix.mul_assoc]
+  simp only [threeSiteSectorClosure, threeSiteRegroupEquiv, MPOTensor.physClose3,
+    Matrix.trace, Matrix.mul_assoc, Matrix.diag_apply, Matrix.mul_apply,
+    sectorCoordinateTensor_apply, LinearMap.coe_mk, AddHom.coe_mk,
+    Matrix.reindex_apply, Equiv.symm_mk, Equiv.coe_fn_mk, Matrix.submatrix_apply,
+    threeSiteSectorEmbedding, Matrix.of_apply, Equiv.apply_symm_apply,
+    transformedPhysicalSlice_apply_same, Matrix.kroneckerMap_apply,
+    boundaryOperator_apply, neighboringOperator_apply]
   simp_rw [Finset.mul_sum, Finset.sum_mul]
   have sum_permute (f : Fin D → Fin D → Fin D → Fin D → ℂ) :
       (∑ a, ∑ c, ∑ e, ∑ b, f a c e b) =

--- a/TNLean/MPS/MPDO/PhysicalSectorClosureThree.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorClosureThree.lean
@@ -1,0 +1,124 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalSectorFactorization
+import TNLean.MPS.MPDO.RFPViaTS
+
+/-!
+# Three-site closure in fixed physical sectors
+
+This file evaluates the three-site physical closure of a tensor admitting a
+physical-sector factorization.  After restricting the three physical sites to
+fixed sectors `k`, `l`, and `h`, the physical indices are regrouped into the
+two outer factors and the two neighboring pairs.  The resulting matrix is the
+Kronecker product of the boundary operator with the two neighboring
+operators.
+
+Only the algebraic sector factorization is used.  No positivity,
+normalization, or quantum-channel assertion is made.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, equations `AppUkU=rl` and `etarl`, lines 1381--1450, and the
+  three-site contraction in Proposition C.7, lines 1510--1516
+-/
+
+open scoped Matrix BigOperators Kronecker
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D}
+
+/-- The inclusion of three fixed physical sectors into the right-associated
+three-site physical index space.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl` and `etarl`,
+lines 1381--1450. -/
+noncomputable def threeSiteSectorEmbedding (F : PhysicalSectorFactorization K)
+    (k l h : Fin F.sectorCount) :
+    SectorIndex F k × (SectorIndex F l × SectorIndex F h) →
+      Fin (Fintype.card (Σ q : Fin F.sectorCount, SectorIndex F q)) ×
+        (Fin (Fintype.card (Σ q : Fin F.sectorCount, SectorIndex F q)) ×
+          Fin (Fintype.card (Σ q : Fin F.sectorCount, SectorIndex F q))) :=
+  fun x ↦
+    (F.sectorFinEquiv.symm ⟨k, x.1⟩,
+      (F.sectorFinEquiv.symm ⟨l, x.2.1⟩,
+        F.sectorFinEquiv.symm ⟨h, x.2.2⟩))
+
+/-- Regroup the three fixed physical sectors into the outer boundary factors
+and the two neighboring pairs:
+\[
+ ((l_k,r_k),((l_l,r_l),(l_h,r_h)))
+ \longmapsto ((l_k,r_h),((r_k,l_l),(r_l,l_h))).
+\]
+
+Source: arXiv:1606.00608, Appendix C.2, line 1547 and the accompanying
+diagram. -/
+def threeSiteRegroupEquiv (F : PhysicalSectorFactorization K)
+    (k l h : Fin F.sectorCount) :
+    (SectorIndex F k × (SectorIndex F l × SectorIndex F h)) ≃
+      (BoundaryIndex F k h × (NeighborIndex F k l × NeighborIndex F l h)) where
+  toFun x := ((x.1.1, x.2.2.2), ((x.1.2, x.2.1.1), (x.2.1.2, x.2.2.1)))
+  invFun x := ((x.1.1, x.2.1.1), ((x.2.1.2, x.2.2.1), (x.2.2.2, x.1.2)))
+  left_inv := by rintro ⟨⟨lk, rk⟩, ⟨ll, rl⟩, lh, rh⟩; rfl
+  right_inv := by rintro ⟨⟨lk, rh⟩, ⟨rk, ll⟩, rl, lh⟩; rfl
+
+/-- The fixed-`(k,l,h)` submatrix of the three-site closure, reindexed into
+the outer boundary factors and the two neighboring pairs.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl` and `etarl`,
+lines 1381--1450, and Proposition C.7, lines 1510--1516. -/
+noncomputable def threeSiteSectorClosure (F : PhysicalSectorFactorization K)
+    (k l h : Fin F.sectorCount) (X : Matrix (Fin D) (Fin D) ℂ) :
+    Matrix (BoundaryIndex F k h × (NeighborIndex F k l × NeighborIndex F l h))
+      (BoundaryIndex F k h × (NeighborIndex F k l × NeighborIndex F l h)) ℂ :=
+  Matrix.reindex (threeSiteRegroupEquiv F k l h) (threeSiteRegroupEquiv F k l h)
+    ((MPOTensor.physClose3 F.sectorCoordinateTensor X).submatrix
+      (threeSiteSectorEmbedding F k l h) (threeSiteSectorEmbedding F k l h))
+
+/-- The three-site closure in fixed physical sectors factors into its outer
+boundary contraction and the two neighboring contractions:
+\[
+ K_{3;k,l,h}(X)=B_{k,h}(X)\otimes
+   \bigl(\eta_{k,l}\otimes\eta_{l,h}\bigr).
+\]
+
+This is an identity for an arbitrary virtual matrix `X`.  It asserts neither
+positivity nor normalization of any factor.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl` and `etarl`,
+lines 1381--1450, and the three-site contraction in Proposition C.7, lines
+1510--1516. -/
+theorem threeSiteSectorClosure_eq (F : PhysicalSectorFactorization K)
+    (k l h : Fin F.sectorCount) (X : Matrix (Fin D) (Fin D) ℂ) :
+    F.threeSiteSectorClosure k l h X =
+      F.boundaryOperator k h X ⊗ₖ
+        (F.neighboringOperator k l ⊗ₖ F.neighboringOperator l h) := by
+  ext x y
+  simp [threeSiteSectorClosure, threeSiteSectorEmbedding, threeSiteRegroupEquiv,
+    MPOTensor.physClose3, Matrix.trace, Matrix.mul_apply, Matrix.mul_assoc]
+  simp_rw [Finset.mul_sum, Finset.sum_mul]
+  have sum_permute (f : Fin D → Fin D → Fin D → Fin D → ℂ) :
+      (∑ a, ∑ c, ∑ e, ∑ b, f a c e b) =
+        ∑ e, ∑ a, ∑ b, ∑ c, f a c e b := by
+    calc
+      _ = ∑ a, ∑ e, ∑ c, ∑ b, f a c e b := by
+        congr 1 with a
+        rw [Finset.sum_comm]
+      _ = ∑ e, ∑ a, ∑ c, ∑ b, f a c e b := Finset.sum_comm
+      _ = _ := by
+        congr 1 with e
+        congr 1 with a
+        rw [Finset.sum_comm]
+  rw [sum_permute]
+  congr 1 with e
+  congr 1 with a
+  congr 1 with b
+  rw [Finset.mul_sum]
+  congr 1 with c
+  ring
+
+end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/PhysicalSectorClosureTwo.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorClosureTwo.lean
@@ -1,0 +1,126 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalSectorFactorization
+import TNLean.MPS.MPDO.RFPViaTS
+
+/-!
+# Two-site closures in fixed physical sectors
+
+This file computes the two-site physical closure of a tensor satisfying the
+source-minimal physical-sector factorization from Appendix C.2 of
+arXiv:1606.00608.  After restricting the two physical sites to sectors `k`
+and `h`, the factors are regrouped as
+\[
+  ((L_k,R_k),(L_h,R_h))\longmapsto ((L_k,R_h),(R_k,L_h)).
+\]
+The resulting matrix is the Kronecker product of the outer boundary operator
+with the neighboring operator.  This is only an algebraic contraction
+identity; no positivity, normalization, or renormalization fixed-point claim
+is made.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, equations `AppUkU=rl` and `etarl`, lines 1381--1388 and
+  1441--1450
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D}
+
+/-- Regroup the two fixed-sector physical indices into the two outer factors
+and the two neighboring factors:
+\[
+  ((L_k,R_k),(L_h,R_h))\longmapsto ((L_k,R_h),(R_k,L_h)).
+\]
+
+Source: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl` and `etarl`,
+lines 1381--1388 and 1441--1445. -/
+def twoSiteRegroupEquiv (F : PhysicalSectorFactorization K)
+    (k h : Fin F.sectorCount) :
+    (SectorIndex F k × SectorIndex F h) ≃
+      (BoundaryIndex F k h × NeighborIndex F k h) where
+  toFun x := ((x.1.1, x.2.2), (x.1.2, x.2.1))
+  invFun x := ((x.1.1, x.2.1), (x.2.2, x.1.2))
+  left_inv := by rintro ⟨⟨lk, rk⟩, lh, rh⟩; rfl
+  right_inv := by rintro ⟨⟨lk, rh⟩, rk, lh⟩; rfl
+
+/-- The inverse regrouping reconstructs the two complete sector indices.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl` and `etarl`,
+lines 1381--1388 and 1441--1445. -/
+@[simp] theorem twoSiteRegroupEquiv_symm_apply
+    (F : PhysicalSectorFactorization K) (k h : Fin F.sectorCount)
+    (x : BoundaryIndex F k h × NeighborIndex F k h) :
+    (F.twoSiteRegroupEquiv k h).symm x =
+      ((x.1.1, x.2.1), (x.2.2, x.1.2)) :=
+  rfl
+
+/-- Embed a pair of fixed-sector physical indices into the two-site index
+space of the sector-coordinate tensor.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `AppUkU=rl`, lines
+1381--1388. -/
+noncomputable def twoSiteSectorEmbedding (F : PhysicalSectorFactorization K)
+    (k h : Fin F.sectorCount) :
+    SectorIndex F k × SectorIndex F h →
+      Fin (Fintype.card (Σ l : Fin F.sectorCount, SectorIndex F l)) ×
+        Fin (Fintype.card (Σ l : Fin F.sectorCount, SectorIndex F l)) :=
+  fun x ↦ (F.sectorFinEquiv.symm ⟨k, x.1⟩, F.sectorFinEquiv.symm ⟨h, x.2⟩)
+
+/-- The two-site closure restricted to the physical sectors `k,h` and then
+regrouped as `((L_k,R_k),(L_h,R_h)) ↦ ((L_k,R_h),(R_k,L_h))`.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl` and `etarl`,
+lines 1381--1388 and 1441--1450. -/
+noncomputable def physicalSectorClosureTwo (F : PhysicalSectorFactorization K)
+    (k h : Fin F.sectorCount) (X : Matrix (Fin D) (Fin D) ℂ) :
+    Matrix (BoundaryIndex F k h × NeighborIndex F k h)
+      (BoundaryIndex F k h × NeighborIndex F k h) ℂ :=
+  (physClose2 F.sectorCoordinateTensor X).submatrix
+    (F.twoSiteSectorEmbedding k h ∘ (F.twoSiteRegroupEquiv k h).symm)
+    (F.twoSiteSectorEmbedding k h ∘ (F.twoSiteRegroupEquiv k h).symm)
+
+/-- For arbitrary virtual boundary matrix `X`, the fixed-sector two-site
+closure factors into its outer boundary contraction and its neighboring
+contraction:
+\[
+  \mathcal K_{2;k,h}(X)=B_{k,h}(X)\otimes\eta_{k,h}.
+\]
+
+This theorem uses only the physical-sector factorization.  In particular it
+does not assume positivity or trace preservation and does not assert
+Proposition C.7.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl` and `etarl`,
+lines 1381--1388 and 1441--1450. -/
+theorem physicalSectorClosureTwo_eq_kronecker (F : PhysicalSectorFactorization K)
+    (k h : Fin F.sectorCount) (X : Matrix (Fin D) (Fin D) ℂ) :
+    F.physicalSectorClosureTwo k h X =
+      Matrix.kroneckerMap (· * ·) (F.boundaryOperator k h X)
+        (F.neighboringOperator k h) := by
+  ext x y
+  simp only [physicalSectorClosureTwo, Matrix.submatrix_apply, Function.comp_apply,
+    twoSiteRegroupEquiv_symm_apply, twoSiteSectorEmbedding, physClose2_apply,
+    sectorCoordinateTensor_apply_same, Matrix.trace, Matrix.diag_apply,
+    Matrix.mul_apply, Matrix.kroneckerMap_apply, boundaryOperator_apply,
+    neighboringOperator_apply, Finset.sum_mul, Finset.mul_sum]
+  conv_rhs =>
+    rw [Finset.sum_comm]
+    enter [2, a]
+    rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro a ha
+  apply Finset.sum_congr rfl
+  intro b hb
+  apply Finset.sum_congr rfl
+  intro c hc
+  ring
+
+end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/PhysicalSectorClosureTwo.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorClosureTwo.lean
@@ -28,7 +28,7 @@ is made.
   1441--1450
 -/
 
-open scoped Matrix BigOperators
+open scoped Matrix BigOperators Kronecker
 
 namespace MPOTensor.PhysicalSectorFactorization
 
@@ -79,13 +79,13 @@ regrouped as `((L_k,R_k),(L_h,R_h)) ↦ ((L_k,R_h),(R_k,L_h))`.
 
 Source: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl` and `etarl`,
 lines 1381--1388 and 1441--1450. -/
-noncomputable def physicalSectorClosureTwo (F : PhysicalSectorFactorization K)
+noncomputable def twoSiteSectorClosure (F : PhysicalSectorFactorization K)
     (k h : Fin F.sectorCount) (X : Matrix (Fin D) (Fin D) ℂ) :
     Matrix (BoundaryIndex F k h × NeighborIndex F k h)
       (BoundaryIndex F k h × NeighborIndex F k h) ℂ :=
-  (physClose2 F.sectorCoordinateTensor X).submatrix
-    (F.twoSiteSectorEmbedding k h ∘ (F.twoSiteRegroupEquiv k h).symm)
-    (F.twoSiteSectorEmbedding k h ∘ (F.twoSiteRegroupEquiv k h).symm)
+  Matrix.reindex (twoSiteRegroupEquiv F k h) (twoSiteRegroupEquiv F k h)
+    ((physClose2 F.sectorCoordinateTensor X).submatrix
+      (twoSiteSectorEmbedding F k h) (twoSiteSectorEmbedding F k h))
 
 /-- For arbitrary virtual boundary matrix `X`, the fixed-sector two-site
 closure factors into its outer boundary contraction and its neighboring
@@ -100,13 +100,13 @@ Proposition C.7.
 
 Source: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl` and `etarl`,
 lines 1381--1388 and 1441--1450. -/
-theorem physicalSectorClosureTwo_eq_kronecker (F : PhysicalSectorFactorization K)
+theorem twoSiteSectorClosure_eq (F : PhysicalSectorFactorization K)
     (k h : Fin F.sectorCount) (X : Matrix (Fin D) (Fin D) ℂ) :
-    F.physicalSectorClosureTwo k h X =
-      Matrix.kroneckerMap (· * ·) (F.boundaryOperator k h X)
-        (F.neighboringOperator k h) := by
+    F.twoSiteSectorClosure k h X =
+      F.boundaryOperator k h X ⊗ₖ
+        F.neighboringOperator k h := by
   ext x y
-  simp only [physicalSectorClosureTwo, Matrix.submatrix_apply, Function.comp_apply,
+  simp only [twoSiteSectorClosure, Matrix.reindex_apply, Matrix.submatrix_apply,
     twoSiteRegroupEquiv_symm_apply, twoSiteSectorEmbedding, physClose2_apply,
     sectorCoordinateTensor_apply_same, Matrix.trace, Matrix.diag_apply,
     Matrix.mul_apply, Matrix.kroneckerMap_apply, boundaryOperator_apply,

--- a/TNLean/MPS/MPDO/PhysicalSectorFactorization.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorFactorization.lean
@@ -1,0 +1,277 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.HayashiSectorComparison
+
+/-!
+# Physical-sector factorizations of simple MPO tensors
+
+This file isolates the algebraic content of the physical-sector decomposition
+used in Appendix C.2 of arXiv:1606.00608.  After an isometry on the physical
+space, every physical slice of the MPO tensor is a direct sum of Kronecker
+products
+\[
+  U\,\kappa_{\beta,\alpha}\,U^*=
+    \bigoplus_k (l_k)_\beta\otimes(r_k)_\alpha.
+\]
+The datum below records exactly this factorization.  In particular, it does
+not contain a quantum-Markov decomposition, positivity of the neighboring
+operators, or the trace factorization used later in Proposition C.7.
+
+The two contractions needed in the fixed-point calculation are then intrinsic
+to this datum.  The neighboring operator contracts the common virtual index
+between a right tensor and a left tensor.  The boundary operator contracts an
+arbitrary virtual matrix against the two outer tensors.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, equation `AppUkU=rl`, lines 1381--1388, and equation `etarl`,
+  lines 1441--1445
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- A source-minimal physical-sector factorization of an MPO tensor.
+
+The physical space is decomposed as
+$\bigoplus_k B_k^L\otimes B_k^R$.  The matrices `leftTensor k beta` and
+`rightTensor k alpha` are the factors $(l_k)_\beta$ and $(r_k)_\alpha$ in
+the transformed physical slice.  The only compatibility imposed on these
+data is the displayed direct-sum factorization from the source.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `AppUkU=rl`, lines
+1381--1388; the explicit slice factorization is derived at lines 1435--1448. -/
+structure PhysicalSectorFactorization (K : MPOTensor d D) where
+  /-- Number of physical sectors. -/
+  sectorCount : ℕ
+  /-- Dimension of the left factor in each physical sector. -/
+  leftDim : Fin sectorCount → ℕ
+  /-- Dimension of the right factor in each physical sector. -/
+  rightDim : Fin sectorCount → ℕ
+  /-- Identification of the physical space with the direct sum of its sectors. -/
+  sectorEquiv : Fin d ≃ Σ k : Fin sectorCount, Fin (leftDim k) × Fin (rightDim k)
+  /-- The physical-space isometry in equation `AppUkU=rl`. -/
+  physicalIsometry : Matrix (Fin d) (Fin d) ℂ
+  /-- The physical transformation is an isometry. -/
+  physicalIsometry_isometry : physicalIsometryᴴ * physicalIsometry = 1
+  /-- The left tensor $(l_k)_\beta$ in sector `k`. -/
+  leftTensor : (k : Fin sectorCount) → Fin D →
+    Matrix (Fin (leftDim k)) (Fin (leftDim k)) ℂ
+  /-- The right tensor $(r_k)_\alpha$ in sector `k`. -/
+  rightTensor : (k : Fin sectorCount) → Fin D →
+    Matrix (Fin (rightDim k)) (Fin (rightDim k)) ℂ
+  /-- Every transformed physical slice is the direct sum of its sector factors. -/
+  factorization : ∀ beta alpha : Fin D,
+    Matrix.reindex sectorEquiv sectorEquiv
+        (physicalIsometry * physicalSlice K beta alpha * physicalIsometryᴴ) =
+      Matrix.blockDiagonal' fun k ↦
+        Matrix.kroneckerMap (· * ·) (leftTensor k beta) (rightTensor k alpha)
+
+namespace PhysicalSectorFactorization
+
+variable {K : MPOTensor d D}
+
+/-- The physical index type within sector `k`. -/
+abbrev SectorIndex (F : PhysicalSectorFactorization K)
+    (k : Fin F.sectorCount) :=
+  Fin (F.leftDim k) × Fin (F.rightDim k)
+
+/-- The index space supporting the neighboring operator between sectors `k`
+and `h`. -/
+abbrev NeighborIndex (F : PhysicalSectorFactorization K)
+    (k h : Fin F.sectorCount) :=
+  Fin (F.rightDim k) × Fin (F.leftDim h)
+
+/-- The index space supporting the two outer tensors in sectors `k` and `h`. -/
+abbrev BoundaryIndex (F : PhysicalSectorFactorization K)
+    (k h : Fin F.sectorCount) :=
+  Fin (F.leftDim k) × Fin (F.rightDim h)
+
+/-- A transformed physical slice, expressed in physical-sector coordinates. -/
+def transformedPhysicalSlice (F : PhysicalSectorFactorization K)
+    (beta alpha : Fin D) :
+    Matrix (Σ k : Fin F.sectorCount, SectorIndex F k)
+      (Σ k : Fin F.sectorCount, SectorIndex F k) ℂ :=
+  Matrix.reindex F.sectorEquiv F.sectorEquiv
+    (F.physicalIsometry * physicalSlice K beta alpha * F.physicalIsometryᴴ)
+
+/-- The transformed physical slice is the direct sum of its left-right sector
+factors. -/
+theorem transformedPhysicalSlice_eq (F : PhysicalSectorFactorization K)
+    (beta alpha : Fin D) :
+    F.transformedPhysicalSlice beta alpha =
+      Matrix.blockDiagonal' fun k ↦
+        Matrix.kroneckerMap (· * ·) (F.leftTensor k beta) (F.rightTensor k alpha) :=
+  F.factorization beta alpha
+
+/-- The canonical finite encoding of the dependent sum of physical sectors.
+
+This converts the direct-sum coordinates of equation `AppUkU=rl` into the
+`Fin`-indexed physical space used by an MPO tensor.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `AppUkU=rl`, lines
+1381--1388. -/
+noncomputable def sectorFinEquiv (F : PhysicalSectorFactorization K) :
+    Fin (Fintype.card (Σ k : Fin F.sectorCount, SectorIndex F k)) ≃
+      (Σ k : Fin F.sectorCount, SectorIndex F k) :=
+  (Fintype.equivFin _).symm
+
+/-- The MPO tensor obtained by expressing the physical legs in sector
+coordinates.  Its physical matrix at fixed virtual indices is precisely
+`transformedPhysicalSlice`, with the dependent sector sum encoded by
+`sectorFinEquiv`.
+
+Thus this tensor is the direct `Fin`-indexed form of
+$U\,\mathcal K\,U^*=\bigoplus_k l_k\otimes r_k$ and can be inserted into the
+ordinary physical-closure operations without additional coordinate changes.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `AppUkU=rl`, lines
+1381--1388; the explicit physical-slice form appears at lines 1435--1448. -/
+noncomputable def sectorCoordinateTensor (F : PhysicalSectorFactorization K) :
+    MPOTensor (Fintype.card (Σ k : Fin F.sectorCount, SectorIndex F k)) D :=
+  fun i j ↦ Matrix.of fun beta alpha ↦
+    F.transformedPhysicalSlice beta alpha (F.sectorFinEquiv i) (F.sectorFinEquiv j)
+
+/-- An entry of the sector-coordinate tensor is the corresponding entry of
+the transformed physical slice.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `AppUkU=rl`, lines
+1381--1388. -/
+@[simp] theorem sectorCoordinateTensor_apply (F : PhysicalSectorFactorization K)
+    (i j : Fin (Fintype.card (Σ k : Fin F.sectorCount, SectorIndex F k)))
+    (beta alpha : Fin D) :
+    F.sectorCoordinateTensor i j beta alpha =
+      F.transformedPhysicalSlice beta alpha (F.sectorFinEquiv i) (F.sectorFinEquiv j) :=
+  rfl
+
+/-- Within one physical sector, an entry of the sector-coordinate tensor is
+the product of the corresponding left- and right-tensor entries.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `AppUkU=rl`, lines
+1381--1388; the explicit physical-slice form appears at lines 1435--1448. -/
+@[simp] theorem sectorCoordinateTensor_apply_same
+    (F : PhysicalSectorFactorization K) (k : Fin F.sectorCount)
+    (x y : SectorIndex F k) (beta alpha : Fin D) :
+    F.sectorCoordinateTensor
+        (F.sectorFinEquiv.symm ⟨k, x⟩) (F.sectorFinEquiv.symm ⟨k, y⟩) beta alpha =
+      F.leftTensor k beta x.1 y.1 * F.rightTensor k alpha x.2 y.2 := by
+  rw [sectorCoordinateTensor_apply]
+  simp only [Equiv.apply_symm_apply]
+  rw [F.transformedPhysicalSlice_eq, Matrix.blockDiagonal'_apply_eq]
+  rfl
+
+/-- Entries of the sector-coordinate tensor between distinct physical sectors
+vanish.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `AppUkU=rl`, lines
+1381--1388; the direct-sum form is used at lines 1435--1448. -/
+@[simp] theorem sectorCoordinateTensor_apply_ne
+    (F : PhysicalSectorFactorization K) {k h : Fin F.sectorCount} (hkh : k ≠ h)
+    (x : SectorIndex F k) (y : SectorIndex F h) (beta alpha : Fin D) :
+    F.sectorCoordinateTensor
+        (F.sectorFinEquiv.symm ⟨k, x⟩) (F.sectorFinEquiv.symm ⟨h, y⟩) beta alpha = 0 := by
+  rw [sectorCoordinateTensor_apply]
+  simp only [Equiv.apply_symm_apply]
+  rw [F.transformedPhysicalSlice_eq, Matrix.blockDiagonal'_apply_ne _ _ _ hkh]
+
+/-- An entry within one sector is the product of the corresponding entries of
+the left and right tensors. -/
+@[simp] theorem transformedPhysicalSlice_apply_same
+    (F : PhysicalSectorFactorization K) (beta alpha : Fin D)
+    (k : Fin F.sectorCount) (x y : SectorIndex F k) :
+    F.transformedPhysicalSlice beta alpha ⟨k, x⟩ ⟨k, y⟩ =
+      F.leftTensor k beta x.1 y.1 * F.rightTensor k alpha x.2 y.2 := by
+  rw [F.transformedPhysicalSlice_eq, Matrix.blockDiagonal'_apply_eq]
+  rfl
+
+/-- Entries between distinct physical sectors vanish. -/
+@[simp] theorem transformedPhysicalSlice_apply_ne
+    (F : PhysicalSectorFactorization K) (beta alpha : Fin D)
+    {k h : Fin F.sectorCount} (hkh : k ≠ h)
+    (x : SectorIndex F k) (y : SectorIndex F h) :
+    F.transformedPhysicalSlice beta alpha ⟨k, x⟩ ⟨h, y⟩ = 0 := by
+  rw [F.transformedPhysicalSlice_eq, Matrix.blockDiagonal'_apply_ne _ _ _ hkh]
+
+/-- The neighboring operator $\eta_{k,h}=r_k l_h$, obtained by contracting
+the common virtual index:
+\[
+  (\eta_{k,h})_{(x_R,x_L),(y_R,y_L)}=
+  \sum_a (r_k)_a(x_R,y_R)(l_h)_a(x_L,y_L).
+\]
+
+No positivity or normalization is asserted.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `etarl`, lines 1441--1445. -/
+noncomputable def neighboringOperator (F : PhysicalSectorFactorization K)
+    (k h : Fin F.sectorCount) :
+    Matrix (NeighborIndex F k h) (NeighborIndex F k h) ℂ :=
+  Matrix.of fun x y ↦
+    ∑ a : Fin D,
+      F.rightTensor k a x.1 y.1 * F.leftTensor h a x.2 y.2
+
+/-- Entries of the neighboring operator are virtual-index contractions of the
+right and left sector tensors. -/
+@[simp] theorem neighboringOperator_apply (F : PhysicalSectorFactorization K)
+    (k h : Fin F.sectorCount) (x y : NeighborIndex F k h) :
+    F.neighboringOperator k h x y =
+      ∑ a : Fin D,
+        F.rightTensor k a x.1 y.1 * F.leftTensor h a x.2 y.2 :=
+  rfl
+
+/-- The outer boundary operator associated with a virtual matrix `X`:
+\[
+  B_{k,h}(X)=\sum_{a,b}X_{b,a}\,(l_k)_a\otimes(r_h)_b.
+\]
+
+This is the boundary factor left after contracting the interior virtual
+indices in products of the factorized tensor.  It uses only the factorization
+in equation `AppUkU=rl`.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `AppUkU=rl`, lines
+1381--1388, and the contraction argument at lines 1441--1450. -/
+noncomputable def boundaryOperator (F : PhysicalSectorFactorization K)
+    (k h : Fin F.sectorCount) (X : Matrix (Fin D) (Fin D) ℂ) :
+    Matrix (BoundaryIndex F k h) (BoundaryIndex F k h) ℂ :=
+  Matrix.of fun x y ↦
+    ∑ a : Fin D, ∑ b : Fin D,
+      X b a * F.leftTensor k a x.1 y.1 * F.rightTensor h b x.2 y.2
+
+/-- Entries of the boundary operator are the contraction of `X` against the
+two outer sector tensors. -/
+@[simp] theorem boundaryOperator_apply (F : PhysicalSectorFactorization K)
+    (k h : Fin F.sectorCount) (X : Matrix (Fin D) (Fin D) ℂ)
+    (x y : BoundaryIndex F k h) :
+    F.boundaryOperator k h X x y =
+      ∑ a : Fin D, ∑ b : Fin D,
+        X b a * F.leftTensor k a x.1 y.1 * F.rightTensor h b x.2 y.2 :=
+  rfl
+
+@[simp] theorem boundaryOperator_zero (F : PhysicalSectorFactorization K)
+    (k h : Fin F.sectorCount) :
+    F.boundaryOperator k h 0 = 0 := by
+  ext x y
+  simp
+
+@[simp] theorem boundaryOperator_add (F : PhysicalSectorFactorization K)
+    (k h : Fin F.sectorCount) (X Y : Matrix (Fin D) (Fin D) ℂ) :
+    F.boundaryOperator k h (X + Y) =
+      F.boundaryOperator k h X + F.boundaryOperator k h Y := by
+  ext x y
+  simp [add_mul, Finset.sum_add_distrib]
+
+@[simp] theorem boundaryOperator_smul (F : PhysicalSectorFactorization K)
+    (k h : Fin F.sectorCount) (c : ℂ) (X : Matrix (Fin D) (Fin D) ℂ) :
+    F.boundaryOperator k h (c • X) = c • F.boundaryOperator k h X := by
+  ext x y
+  simp [Finset.mul_sum, mul_assoc]
+
+end PhysicalSectorFactorization
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/RFPViaTS.lean
+++ b/TNLean/MPS/MPDO/RFPViaTS.lean
@@ -179,6 +179,13 @@ theorem physCloseN_two_eq_physClose2 (M : MPOTensor d D) :
 
 /-! ### The three-site physical operator -/
 
+/-- The canonical right-associated identification of three-coordinate
+configurations with triples: separate the first coordinate, then identify the
+remaining two-coordinate configuration with a pair. -/
+def finThreeArrowEquiv (α : Type*) : (Fin 3 → α) ≃ α × (α × α) :=
+  (Fin.consEquiv fun _ : Fin 3 => α).symm.trans
+    (Equiv.prodCongr (Equiv.refl α) (finTwoArrowEquiv α))
+
 /-- The **three-site physical operator** as a linear map in the virtual operator
 $X$. Its physical indices are right-associated as
 $\operatorname{Fin}(d) \times (\operatorname{Fin}(d) \times \operatorname{Fin}(d))$,
@@ -211,6 +218,18 @@ Proposition C.7, lines 1510--1516. -/
     physClose3 M X i j =
       Matrix.trace (M i.1 j.1 * M i.2.1 j.2.1 * M i.2.2 j.2.2 * X) :=
   rfl
+
+/-- Under the canonical right-associated identification of three-site
+configurations with triples of physical indices, the general length-three
+closure is `physClose3`. For $M=\mathcal K$, this identifies the two forms of
+$\mathcal K_3(X)$ in arXiv:1606.00608, Proposition C.7, lines 1510--1516. -/
+theorem physCloseN_three_eq_physClose3 (M : MPOTensor d D) :
+    (Matrix.reindexLinearEquiv ℂ ℂ (finThreeArrowEquiv (Fin d))
+        (finThreeArrowEquiv (Fin d))).toLinearMap ∘ₗ physCloseN M 3 =
+      physClose3 M := by
+  ext X i j
+  simp [Matrix.coe_reindexLinearEquiv, finThreeArrowEquiv,
+    Matrix.mul_assoc]
 
 /-! ### MPDO renormalization fixed point (Definition 4.1) -/
 

--- a/TNLean/MPS/MPDO/RFPViaTS.lean
+++ b/TNLean/MPS/MPDO/RFPViaTS.lean
@@ -40,8 +40,8 @@ the predicate.
   completely positive maps used in Definition 4.1.
 * `MPOTensor.physCloseN`: the length-$N$ physical operator as a linear map in
   the virtual operator $X$.
-* `MPOTensor.physClose1`, `MPOTensor.physClose2`: the one-site and two-site
-  specializations used in Definition 4.1.
+* `MPOTensor.physClose1`, `MPOTensor.physClose2`, `MPOTensor.physClose3`: the
+  one-site, two-site, and three-site specializations.
 * `MPOTensor.IsRFPViaTS`: Definition 4.1, the tp-CP-map renormalization
   fixed point.
 
@@ -176,6 +176,41 @@ theorem physCloseN_two_eq_physClose2 (M : MPOTensor d D) :
       physClose2 M := by
   ext X i j
   simp [Matrix.coe_reindexLinearEquiv, finTwoArrowEquiv_symm_apply]
+
+/-! ### The three-site physical operator -/
+
+/-- The **three-site physical operator** as a linear map in the virtual operator
+$X$. Its physical indices are right-associated as
+$\operatorname{Fin}(d) \times (\operatorname{Fin}(d) \times \operatorname{Fin}(d))$,
+and its coefficients are
+\[
+  M_3(X)_{(i_0,(i_1,i_2)),(j_0,(j_1,j_2))}
+  = \operatorname{tr}(M^{i_0j_0}M^{i_1j_1}M^{i_2j_2}X).
+\]
+
+When $M=\mathcal K$, this is the operator $\mathcal K_3(X)$ of
+arXiv:1606.00608, Proposition C.7, lines 1510--1516. -/
+noncomputable def physClose3 (M : MPOTensor d D) :
+    Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ]
+      Matrix (Fin d × (Fin d × Fin d)) (Fin d × (Fin d × Fin d)) ℂ where
+  toFun X := Matrix.of fun i j =>
+    Matrix.trace (M i.1 j.1 * M i.2.1 j.2.1 * M i.2.2 j.2.2 * X)
+  map_add' X Y := by
+    ext i j
+    simp [Matrix.mul_add, Matrix.trace_add]
+  map_smul' c X := by
+    ext i j
+    simp [Matrix.trace_smul]
+
+/-- Coefficient formula for the right-associated three-site physical closure.
+For $M=\mathcal K$, this is $\mathcal K_3(X)$ in arXiv:1606.00608,
+Proposition C.7, lines 1510--1516. -/
+@[simp] lemma physClose3_apply (M : MPOTensor d D)
+    (X : Matrix (Fin D) (Fin D) ℂ)
+    (i j : Fin d × (Fin d × Fin d)) :
+    physClose3 M X i j =
+      Matrix.trace (M i.1 j.1 * M i.2.1 j.2.1 * M i.2.2 j.2.2 * X) :=
+  rfl
 
 /-! ### MPDO renormalization fixed point (Definition 4.1) -/
 

--- a/blueprint/src/Packages/tn_diagrams.py
+++ b/blueprint/src/Packages/tn_diagrams.py
@@ -53,6 +53,8 @@ _DIAGRAM_ARGS: dict[str, str] = {
     "TNEtaSectorDecomposition": "",
     "TNMPDOTwoSiteTraceAndShift": "",
     "TNMPDOThreeSiteTraceAndShift": "",
+    "TNMPDOTwoSiteClosureFactorization": "",
+    "TNMPDOThreeSiteClosureFactorization": "",
     "TNMPDOCyclicEtaContraction": "",
     "TNMPDOSectorAdaptedDecomposition": "",
     "TNMPDOInverseMapThreeSiteContraction": "",

--- a/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
@@ -386,7 +386,8 @@
 
 \begin{definition}[Physical closure maps]
     \label{def:phys_close}
-    \lean{MPOTensor.physCloseN, MPOTensor.physClose1, MPOTensor.physClose2}
+    \lean{MPOTensor.physCloseN, MPOTensor.physClose1, MPOTensor.physClose2,
+      MPOTensor.physClose3}
     \leanok
     \uses{def:mpo_eval_word}
     For an MPO tensor $M$, a length $N$, and a virtual operator $X$, define the
@@ -431,12 +432,13 @@
 
 \begin{lemma}[Three-site physical closure]
     \label{lem:phys_close_three}
-    \lean{MPOTensor.physCloseN_three_apply}
+    \lean{MPOTensor.physCloseN_three_apply, MPOTensor.physClose3_apply,
+      MPOTensor.physCloseN_three_eq_physClose3}
     \leanok
     \uses{def:phys_close}
     The general three-site physical closure has coefficients
     \[
-        M_3(X)_{(i_0,i_1,i_2),(j_0,j_1,j_2)}
+        M_3(X)_{(i_0,(i_1,i_2)),(j_0,(j_1,j_2))}
         =\tr(M^{i_0j_0} M^{i_1j_1} M^{i_2j_2} X).
     \]
     For $M=\mathcal K$, this is the operator $\mathcal K_3(X)$ in

--- a/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
@@ -432,7 +432,8 @@
 
 \begin{lemma}[Three-site physical closure]
     \label{lem:phys_close_three}
-    \lean{MPOTensor.physCloseN_three_apply, MPOTensor.physClose3_apply,
+    \lean{MPOTensor.finThreeArrowEquiv,
+      MPOTensor.physCloseN_three_apply, MPOTensor.physClose3_apply,
       MPOTensor.physCloseN_three_eq_physClose3}
     \leanok
     \uses{def:phys_close}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -779,7 +779,14 @@ strong subadditivity for a normalized three-site reduced state.
     \label{def:mpdo_physical_sector_factorization}
     \lean{MPOTensor.PhysicalSectorFactorization,
       MPOTensor.PhysicalSectorFactorization.transformedPhysicalSlice,
+      MPOTensor.PhysicalSectorFactorization.transformedPhysicalSlice_eq,
+      MPOTensor.PhysicalSectorFactorization.sectorFinEquiv,
       MPOTensor.PhysicalSectorFactorization.sectorCoordinateTensor}
+    \lean{MPOTensor.PhysicalSectorFactorization.sectorCoordinateTensor_apply,
+      MPOTensor.PhysicalSectorFactorization.sectorCoordinateTensor_apply_same,
+      MPOTensor.PhysicalSectorFactorization.sectorCoordinateTensor_apply_ne}
+    \lean{MPOTensor.PhysicalSectorFactorization.transformedPhysicalSlice_apply_same,
+      MPOTensor.PhysicalSectorFactorization.transformedPhysicalSlice_apply_ne}
     \leanok
     \uses{def:mpo_tensor}
     A physical-sector factorization of an MPO tensor ${\cal K}$ consists of a
@@ -794,8 +801,7 @@ strong subadditivity for a normalized three-site reduced state.
       =\bigoplus_k(l_k)_\beta\otimes(r_k)_\alpha.
     \]
     No positivity, trace factorization, or quantum-Markov decomposition is
-    included in this datum. This isolates equation
-    \texttt{AppUkU=rl} of
+    included in this datum. This is the factorization displayed in
     \cite[Appendix~C.2, lines~1381--1388]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
@@ -818,7 +824,10 @@ strong subadditivity for a normalized three-site reduced state.
 \begin{definition}[Boundary contraction against a virtual matrix]
     \label{def:mpdo_sector_boundary_operator}
     \lean{MPOTensor.PhysicalSectorFactorization.boundaryOperator,
-      MPOTensor.PhysicalSectorFactorization.boundaryOperator_apply}
+      MPOTensor.PhysicalSectorFactorization.boundaryOperator_apply,
+      MPOTensor.PhysicalSectorFactorization.boundaryOperator_zero,
+      MPOTensor.PhysicalSectorFactorization.boundaryOperator_add,
+      MPOTensor.PhysicalSectorFactorization.boundaryOperator_smul}
     \leanok
     \uses{def:mpdo_physical_sector_factorization}
     For an arbitrary virtual matrix $X$, define the outer boundary operator
@@ -827,18 +836,23 @@ strong subadditivity for a normalized three-site reduced state.
       B_{k,h}(X)
       =\sum_{a,b}X_{b,a}\,(l_k)_a\otimes(r_h)_b.
     \]
-    No positivity of $X$ or $B_{k,h}(X)$ is assumed.
+    The map $X\mapsto B_{k,h}(X)$ is complex-linear. No positivity of $X$ or
+    $B_{k,h}(X)$ is assumed.
 \end{definition}
 
 \begin{definition}[Regrouped two-site sector closure]
     \label{def:mpdo_two_site_sector_closure}
     \lean{MPOTensor.PhysicalSectorFactorization.twoSiteRegroupEquiv,
+      MPOTensor.PhysicalSectorFactorization.twoSiteRegroupEquiv_symm_apply,
       MPOTensor.PhysicalSectorFactorization.twoSiteSectorEmbedding,
       MPOTensor.PhysicalSectorFactorization.physicalSectorClosureTwo}
     \leanok
     \uses{def:phys_close, def:mpdo_physical_sector_factorization}
-    Restrict ${\cal K}_2(X)$ to the physical sectors $(k,h)$ and reindex its
-    physical factors by
+    First pass to the physical basis selected by $U$, so that each slice is
+    written in the sector coordinates of
+    Definition~\ref{def:mpdo_physical_sector_factorization}. Form the
+    two-site closure of this sector-coordinate tensor, restrict it to the
+    physical sectors $(k,h)$, and reindex its physical factors by
     \[
       ((L_k,R_k),(L_h,R_h))
       \longmapsto ((L_k,R_h),(R_k,L_h)).
@@ -861,10 +875,21 @@ strong subadditivity for a normalized three-site reduced state.
 \end{theorem}
 \begin{proof}
     \leanok
-    At a regrouped matrix entry, the virtual trace expands as
+    \uses{def:mpdo_two_site_sector_closure,
+      def:mpdo_minimal_neighboring_operator,
+      def:mpdo_sector_boundary_operator,
+      def:phys_close,
+      def:mpdo_physical_sector_factorization}
+    At the regrouped matrix entry indexed by
+    $((\lambda_k,\rho_h),(\rho_k,\lambda_h))$ and
+    $((\lambda'_k,\rho'_h),(\rho'_k,\lambda'_h))$, the virtual trace expands
+    as the scalar
     \[
       \sum_{a,b,c}X_{b,a}
-      (l_k)_a(r_k)_c(l_h)_c(r_h)_b.
+      [(l_k)_a]_{\lambda_k,\lambda'_k}
+      [(r_k)_c]_{\rho_k,\rho'_k}
+      [(l_h)_c]_{\lambda_h,\lambda'_h}
+      [(r_h)_b]_{\rho_h,\rho'_h}.
     \]
     Commuting scalar factors and collecting the sums over $(a,b)$ and $c$
     gives respectively $B_{k,h}(X)$ and $\eta_{k,h}$.
@@ -877,8 +902,9 @@ strong subadditivity for a normalized three-site reduced state.
       MPOTensor.PhysicalSectorFactorization.threeSiteSectorClosure}
     \leanok
     \uses{def:phys_close, def:mpdo_physical_sector_factorization}
-    Restrict ${\cal K}_3(X)$ to the sectors $(k,l,h)$ and reindex its physical
-    factors by
+    First pass to the physical basis selected by $U$ and form the three-site
+    closure of the resulting sector-coordinate tensor. Restrict this closure
+    to the sectors $(k,l,h)$ and reindex its physical factors by
     \[
       ((L_k,R_k),((L_l,R_l),(L_h,R_h)))
       \longmapsto
@@ -903,10 +929,22 @@ strong subadditivity for a normalized three-site reduced state.
 \end{theorem}
 \begin{proof}
     \leanok
-    The matrix entry of the left-hand side is
+    \uses{def:mpdo_three_site_sector_closure,
+      def:mpdo_minimal_neighboring_operator,
+      def:mpdo_sector_boundary_operator,
+      def:phys_close,
+      def:mpdo_physical_sector_factorization}
+    At the regrouped matrix entry indexed by
+    $((\lambda_k,\rho_h),((\rho_k,\lambda_l),(\rho_l,\lambda_h)))$ and its
+    primed counterpart, the left-hand side is the scalar
     \[
       \sum_{a,b,c,e}X_{b,a}
-      (l_k)_a(r_k)_c(l_l)_c(r_l)_e(l_h)_e(r_h)_b.
+      [(l_k)_a]_{\lambda_k,\lambda'_k}
+      [(r_k)_c]_{\rho_k,\rho'_k}
+      [(l_l)_c]_{\lambda_l,\lambda'_l}
+      [(r_l)_e]_{\rho_l,\rho'_l}
+      [(l_h)_e]_{\lambda_h,\lambda'_h}
+      [(r_h)_b]_{\rho_h,\rho'_h}.
     \]
     Reordering the four finite sums separates the $(a,b)$ boundary
     contraction from the neighboring contractions indexed by $c$ and $e$,
@@ -923,10 +961,11 @@ strong subadditivity for a normalized three-site reduced state.
       \centering
       \TNMPDOThreeSiteClosureFactorization
     \end{minipage}
-    \caption{After restriction to fixed sectors, and only after the displayed
-    physical-sector reindexings, the arbitrary-$X$ two- and three-site
-    closures separate into the boundary factor and respectively one or two
-    neighboring contractions. The diagrams do not assert positivity,
+    \caption{First each slice is conjugated by $U$ and expressed in the
+    corresponding sector coordinates. After restriction to fixed sectors and
+    the displayed regroupings, the arbitrary-$X$ two- and three-site closures
+    separate into the boundary factor and respectively one or two neighboring
+    contractions. The diagrams do not assert positivity,
     preparation, recovery, or the full conclusion of Proposition~C.7. They
     follow the contractions in
     \cite[lines~638--655 and Appendix~C.2, lines~1435--1448]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -898,6 +898,7 @@ strong subadditivity for a normalized three-site reduced state.
 \begin{definition}[Regrouped three-site sector closure]
     \label{def:mpdo_three_site_sector_closure}
     \lean{MPOTensor.PhysicalSectorFactorization.threeSiteRegroupEquiv,
+      MPOTensor.PhysicalSectorFactorization.threeSiteRegroupEquiv_symm_apply,
       MPOTensor.PhysicalSectorFactorization.threeSiteSectorEmbedding,
       MPOTensor.PhysicalSectorFactorization.threeSiteSectorClosure}
     \leanok

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -845,7 +845,7 @@ strong subadditivity for a normalized three-site reduced state.
     \lean{MPOTensor.PhysicalSectorFactorization.twoSiteRegroupEquiv,
       MPOTensor.PhysicalSectorFactorization.twoSiteRegroupEquiv_symm_apply,
       MPOTensor.PhysicalSectorFactorization.twoSiteSectorEmbedding,
-      MPOTensor.PhysicalSectorFactorization.physicalSectorClosureTwo}
+      MPOTensor.PhysicalSectorFactorization.twoSiteSectorClosure}
     \leanok
     \uses{def:phys_close, def:mpdo_physical_sector_factorization}
     First pass to the physical basis selected by $U$, so that each slice is
@@ -862,7 +862,7 @@ strong subadditivity for a normalized three-site reduced state.
 
 \begin{theorem}[Two-site closure factorization]
     \label{thm:mpdo_two_site_sector_closure_factorization}
-    \lean{MPOTensor.PhysicalSectorFactorization.physicalSectorClosureTwo_eq_kronecker}
+    \lean{MPOTensor.PhysicalSectorFactorization.twoSiteSectorClosure_eq}
     \leanok
     \uses{def:mpdo_two_site_sector_closure,
       def:mpdo_minimal_neighboring_operator,

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -775,6 +775,165 @@ strong subadditivity for a normalized three-site reduced state.
     by definition of the neighboring operator.
 \end{proof}
 
+\begin{definition}[Source-minimal physical-sector factorization]
+    \label{def:mpdo_physical_sector_factorization}
+    \lean{MPOTensor.PhysicalSectorFactorization,
+      MPOTensor.PhysicalSectorFactorization.transformedPhysicalSlice,
+      MPOTensor.PhysicalSectorFactorization.sectorCoordinateTensor}
+    \leanok
+    \uses{def:mpo_tensor}
+    A physical-sector factorization of an MPO tensor ${\cal K}$ consists of a
+    finite decomposition
+    \[
+      \mathbb C^d\simeq\bigoplus_k(B_k^L\otimes B_k^R),
+    \]
+    an isometry $U$ on the physical space, and matrix families
+    $(l_k)_\beta$ and $(r_k)_\alpha$ such that every physical slice satisfies
+    \[
+      U\kappa_{\beta,\alpha}U^\dagger
+      =\bigoplus_k(l_k)_\beta\otimes(r_k)_\alpha.
+    \]
+    No positivity, trace factorization, or quantum-Markov decomposition is
+    included in this datum. This isolates equation
+    \texttt{AppUkU=rl} of
+    \cite[Appendix~C.2, lines~1381--1388]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{definition}[Algebraic neighboring contraction]
+    \label{def:mpdo_minimal_neighboring_operator}
+    \lean{MPOTensor.PhysicalSectorFactorization.neighboringOperator,
+      MPOTensor.PhysicalSectorFactorization.neighboringOperator_apply}
+    \leanok
+    \uses{def:mpdo_physical_sector_factorization}
+    For sectors $k,h$, contract the common virtual index of the right and
+    left sector tensors:
+    \[
+      \eta_{k,h}
+      =\sum_a(r_k)_a\otimes(l_h)_a.
+    \]
+    This is an operator on $B_k^R\otimes B_h^L$. Positivity is not part of
+    this definition; it is a separate hypothesis in Proposition~C.7.
+\end{definition}
+
+\begin{definition}[Boundary contraction against a virtual matrix]
+    \label{def:mpdo_sector_boundary_operator}
+    \lean{MPOTensor.PhysicalSectorFactorization.boundaryOperator,
+      MPOTensor.PhysicalSectorFactorization.boundaryOperator_apply}
+    \leanok
+    \uses{def:mpdo_physical_sector_factorization}
+    For an arbitrary virtual matrix $X$, define the outer boundary operator
+    on $B_k^L\otimes B_h^R$ by
+    \[
+      B_{k,h}(X)
+      =\sum_{a,b}X_{b,a}\,(l_k)_a\otimes(r_h)_b.
+    \]
+    No positivity of $X$ or $B_{k,h}(X)$ is assumed.
+\end{definition}
+
+\begin{definition}[Regrouped two-site sector closure]
+    \label{def:mpdo_two_site_sector_closure}
+    \lean{MPOTensor.PhysicalSectorFactorization.twoSiteRegroupEquiv,
+      MPOTensor.PhysicalSectorFactorization.twoSiteSectorEmbedding,
+      MPOTensor.PhysicalSectorFactorization.physicalSectorClosureTwo}
+    \leanok
+    \uses{def:phys_close, def:mpdo_physical_sector_factorization}
+    Restrict ${\cal K}_2(X)$ to the physical sectors $(k,h)$ and reindex its
+    physical factors by
+    \[
+      ((L_k,R_k),(L_h,R_h))
+      \longmapsto ((L_k,R_h),(R_k,L_h)).
+    \]
+    Denote the resulting matrix by ${\cal K}_{2;k,h}(X)$.
+\end{definition}
+
+\begin{theorem}[Two-site closure factorization]
+    \label{thm:mpdo_two_site_sector_closure_factorization}
+    \lean{MPOTensor.PhysicalSectorFactorization.physicalSectorClosureTwo_eq_kronecker}
+    \leanok
+    \uses{def:mpdo_two_site_sector_closure,
+      def:mpdo_minimal_neighboring_operator,
+      def:mpdo_sector_boundary_operator}
+    For every virtual matrix $X$ and every sector pair $(k,h)$,
+    \[
+      {\cal K}_{2;k,h}(X)
+      =B_{k,h}(X)\otimes\eta_{k,h}.
+    \]
+\end{theorem}
+\begin{proof}
+    \leanok
+    At a regrouped matrix entry, the virtual trace expands as
+    \[
+      \sum_{a,b,c}X_{b,a}
+      (l_k)_a(r_k)_c(l_h)_c(r_h)_b.
+    \]
+    Commuting scalar factors and collecting the sums over $(a,b)$ and $c$
+    gives respectively $B_{k,h}(X)$ and $\eta_{k,h}$.
+\end{proof}
+
+\begin{definition}[Regrouped three-site sector closure]
+    \label{def:mpdo_three_site_sector_closure}
+    \lean{MPOTensor.PhysicalSectorFactorization.threeSiteRegroupEquiv,
+      MPOTensor.PhysicalSectorFactorization.threeSiteSectorEmbedding,
+      MPOTensor.PhysicalSectorFactorization.threeSiteSectorClosure}
+    \leanok
+    \uses{def:phys_close, def:mpdo_physical_sector_factorization}
+    Restrict ${\cal K}_3(X)$ to the sectors $(k,l,h)$ and reindex its physical
+    factors by
+    \[
+      ((L_k,R_k),((L_l,R_l),(L_h,R_h)))
+      \longmapsto
+      ((L_k,R_h),((R_k,L_l),(R_l,L_h))).
+    \]
+    Denote the resulting matrix by ${\cal K}_{3;k,l,h}(X)$.
+\end{definition}
+
+\begin{theorem}[Three-site closure factorization]
+    \label{thm:mpdo_three_site_sector_closure_factorization}
+    \lean{MPOTensor.PhysicalSectorFactorization.threeSiteSectorClosure_eq}
+    \leanok
+    \uses{def:mpdo_three_site_sector_closure,
+      def:mpdo_minimal_neighboring_operator,
+      def:mpdo_sector_boundary_operator}
+    For every virtual matrix $X$ and fixed sectors $(k,l,h)$,
+    \[
+      {\cal K}_{3;k,l,h}(X)
+      =B_{k,h}(X)\otimes
+        \bigl(\eta_{k,l}\otimes\eta_{l,h}\bigr).
+    \]
+\end{theorem}
+\begin{proof}
+    \leanok
+    The matrix entry of the left-hand side is
+    \[
+      \sum_{a,b,c,e}X_{b,a}
+      (l_k)_a(r_k)_c(l_l)_c(r_l)_e(l_h)_e(r_h)_b.
+    \]
+    Reordering the four finite sums separates the $(a,b)$ boundary
+    contraction from the neighboring contractions indexed by $c$ and $e$,
+    which gives the three factors on the right-hand side.
+\end{proof}
+
+\begin{figure}[ht]
+    \centering
+    \begin{minipage}{0.41\textwidth}
+      \centering
+      \TNMPDOTwoSiteClosureFactorization
+    \end{minipage}\hfill
+    \begin{minipage}{0.56\textwidth}
+      \centering
+      \TNMPDOThreeSiteClosureFactorization
+    \end{minipage}
+    \caption{After restriction to fixed sectors, and only after the displayed
+    physical-sector reindexings, the arbitrary-$X$ two- and three-site
+    closures separate into the boundary factor and respectively one or two
+    neighboring contractions. The diagrams do not assert positivity,
+    preparation, recovery, or the full conclusion of Proposition~C.7. They
+    follow the contractions in
+    \cite[lines~638--655 and Appendix~C.2, lines~1435--1448]
+      {Cirac2016MPDO_arXiv}.}
+    \label{fig:mpdo_sector_closure_factorizations}
+\end{figure}
+
 \begin{definition}[Closed sector tensors]%
     \label{def:mpdo_closed_sector_tensors}
     \lean{MPOTensor.closedSectorL}

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -282,6 +282,69 @@
     \end{tikzpicture}%
 }
 
+% Fixed-sector factorization of the arbitrary-X two-site physical closure.
+% The left-hand row shows the sector subspins and the outer virtual closure;
+% the right-hand side shows only the proved boundary/neighbor tensor product.
+\newcommand{\TNMPDOTwoSiteClosureFactorization}{%
+    \begin{tikzpicture}[tn picture, scale=0.50]
+        \TN@subspinbox{ctwoLk}{(-4.40,0.55)}{l_k}
+        \TN@subspinbox{ctwoRk}{(-3.40,0.55)}{r_k}
+        \TN@subspinbox{ctwoLh}{(-2.40,0.55)}{l_h}
+        \TN@subspinbox{ctwoRh}{(-1.40,0.55)}{r_h}
+        \TN@subspinlink{ctwoLk}{ctwoRk}
+        \TN@subspinlink{ctwoRk}{ctwoLh}
+        \TN@subspinlink{ctwoLh}{ctwoRh}
+        \node[draw, fill=white, inner sep=2pt] (ctwoX) at (-2.90,-0.95) {$X$};
+        \draw[tn leg] (ctwoLk.west)
+          .. controls (-5.05,0.55) and (-5.05,-0.95) .. (ctwoX.west);
+        \draw[tn leg] (ctwoX.east)
+          .. controls (-0.75,-0.95) and (-0.75,0.55) .. (ctwoRh.east);
+        \node at (0.00,0.05) {$=$};
+        \node[draw, rounded corners=2pt, minimum width=2.25cm,
+          minimum height=0.72cm] (ctwoB) at (1.70,0.05) {$B_{k,h}(X)$};
+        \node at (3.20,0.05) {$\otimes$};
+        \node[draw, rounded corners=2pt, minimum width=1.75cm,
+          minimum height=0.72cm] (ctwoEta) at (4.45,0.05) {$\eta_{k,h}$};
+        \node at (1.70,-0.62) {$L_k\otimes R_h$};
+        \node at (4.45,-0.62) {$R_k\otimes L_h$};
+    \end{tikzpicture}%
+}
+
+% Fixed-sector factorization of the arbitrary-X three-site physical closure.
+% No preparation, positivity, or channel identity is represented.
+\newcommand{\TNMPDOThreeSiteClosureFactorization}{%
+    \begin{tikzpicture}[tn picture, scale=0.43]
+        \TN@subspinbox{cthreeLk}{(-5.70,0.62)}{l_k}
+        \TN@subspinbox{cthreeRk}{(-4.70,0.62)}{r_k}
+        \TN@subspinbox{cthreeLl}{(-3.70,0.62)}{l_l}
+        \TN@subspinbox{cthreeRl}{(-2.70,0.62)}{r_l}
+        \TN@subspinbox{cthreeLh}{(-1.70,0.62)}{l_h}
+        \TN@subspinbox{cthreeRh}{(-0.70,0.62)}{r_h}
+        \TN@subspinlink{cthreeLk}{cthreeRk}
+        \TN@subspinlink{cthreeRk}{cthreeLl}
+        \TN@subspinlink{cthreeLl}{cthreeRl}
+        \TN@subspinlink{cthreeRl}{cthreeLh}
+        \TN@subspinlink{cthreeLh}{cthreeRh}
+        \node[draw, fill=white, inner sep=2pt] (cthreeX) at (-3.20,-1.00) {$X$};
+        \draw[tn leg] (cthreeLk.west)
+          .. controls (-6.35,0.62) and (-6.35,-1.00) .. (cthreeX.west);
+        \draw[tn leg] (cthreeX.east)
+          .. controls (-0.05,-1.00) and (-0.05,0.62) .. (cthreeRh.east);
+        \node at (0.45,0.05) {$=$};
+        \node[draw, rounded corners=2pt, minimum width=2.05cm,
+          minimum height=0.72cm] at (1.85,0.05) {$B_{k,h}(X)$};
+        \node at (3.15,0.05) {$\otimes$};
+        \node[draw, rounded corners=2pt, minimum width=1.65cm,
+          minimum height=0.72cm] at (4.20,0.05) {$\eta_{k,l}$};
+        \node at (5.25,0.05) {$\otimes$};
+        \node[draw, rounded corners=2pt, minimum width=1.65cm,
+          minimum height=0.72cm] at (6.30,0.05) {$\eta_{l,h}$};
+        \node at (1.85,-0.65) {$L_k\otimes R_h$};
+        \node at (5.25,-0.65)
+          {$(R_k\otimes L_l)\otimes(R_l\otimes L_h)$};
+    \end{tikzpicture}%
+}
+
 % A closed chain of factorized sector tensors regrouped into neighbouring
 % eta operators.  This mirrors the cyclic contractions in Appendix C.2.
 \newcommand{\TNMPDOCyclicEtaContraction}{%

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -294,7 +294,7 @@
         \TN@subspinlink{ctwoLk}{ctwoRk}
         \TN@subspinlink{ctwoRk}{ctwoLh}
         \TN@subspinlink{ctwoLh}{ctwoRh}
-        \node[draw, fill=white, inner sep=2pt] (ctwoX) at (-2.90,-0.95) {$X$};
+        \TN@opdotbelow{ctwoX}{(-2.90,-0.95)}{X}
         \draw[tn leg] (ctwoLk.west)
           .. controls (-5.05,0.55) and (-5.05,-0.95) .. (ctwoX.west);
         \draw[tn leg] (ctwoX.east)
@@ -325,7 +325,7 @@
         \TN@subspinlink{cthreeLl}{cthreeRl}
         \TN@subspinlink{cthreeRl}{cthreeLh}
         \TN@subspinlink{cthreeLh}{cthreeRh}
-        \node[draw, fill=white, inner sep=2pt] (cthreeX) at (-3.20,-1.00) {$X$};
+        \TN@opdotbelow{cthreeX}{(-3.20,-1.00)}{X}
         \draw[tn leg] (cthreeLk.west)
           .. controls (-6.35,0.62) and (-6.35,-1.00) .. (cthreeX.west);
         \draw[tn leg] (cthreeX.east)

--- a/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
+++ b/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
@@ -10,6 +10,9 @@ name: TNMPOLocalPurification TNMPORenormalizationTS TNEtaSectorDecomposition TNM
 name: TNMPDOTwoSiteTraceAndShift TNMPDOThreeSiteTraceAndShift
 {{ obj.tn_svg_html }}
 
+name: TNMPDOTwoSiteClosureFactorization TNMPDOThreeSiteClosureFactorization
+{{ obj.tn_svg_html }}
+
 name: TNMPDOInverseMapThreeSiteContraction TNMPDONormalizedFourSiteTail TNMPDOLocalOrthogonality
 {{ obj.tn_svg_html }}
 


### PR DESCRIPTION
## Summary\n\n- define the three-site physical closure and identify it with the general length-three closure\n- isolate the source-minimal physical-sector factorization from Appendix C.2\n- prove the fixed-sector two- and three-site closure factorizations for an arbitrary virtual matrix\n- add source-style TikZ diagrams next to the proved blueprint results\n\n## Mathematical scope\n\nThe new factorization datum records only the physical basis change and the direct-sum factorization of each transformed slice. It does not assume a quantum-Markov state, positivity of the neighboring operators, trace factorization, or normalization.\n\nThe proved identities are the algebraic fixed-sector consequences\n[\n  {cal K}_{2;k,h}(X)=B_{k,h}(X)otimeseta_{k,h}\n]\nand\n[\n  {cal K}_{3;k,l,h}(X)\n  =B_{k,h}(X)otimes(eta_{k,l}otimeseta_{l,h}).\n]\nThey do not assert that the factors are positive, define channels, construct preparation or recovery maps, or prove the full conclusion of Proposition C.7.\n\nThis advances #3740, #3743, and #3744; it closes none of them.\n\n## Validation\n\n- ⚠ [1746/2116] Replayed TNLean.MPS.Defs
warning: TNLean/MPS/Defs.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [1751/2116] Replayed TNLean.Algebra.TracePairing
warning: TNLean/Algebra/TracePairing.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [1753/2116] Replayed TNLean.Algebra.BlockPermutation
warning: TNLean/Algebra/BlockPermutation.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [1794/2116] Replayed TNLean.Algebra.SkolemNoether
warning: TNLean/Algebra/SkolemNoether.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [2671/3078] Replayed TNLean.Algebra.GramMatrixLI
warning: TNLean/Algebra/GramMatrixLI.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [2675/3078] Replayed TNLean.Algebra.MatrixAux
warning: TNLean/Algebra/MatrixAux.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [2676/3078] Replayed TNLean.Algebra.HermitianHelpers
warning: TNLean/Algebra/HermitianHelpers.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/Algebra/HermitianHelpers.lean:408:0: automatically included section variable(s) unused in theorem `Matrix.PosSemidef.trace_pos_of_ne_zero`:
  [DecidableEq n]
consider restructuring your `variable` declarations so that the variables are not in scope or explicitly omit them:
  omit [DecidableEq n] in theorem ...

Note: This linter can be disabled with `set_option linter.unusedSectionVars false`
warning: TNLean/Algebra/HermitianHelpers.lean:403:0: `trace_pos_of_ne_zero` does not use the following hypothesis in its type:
  • [DecidableEq n] (#3)

Consider removing this hypothesis and using `classical` in the proof instead. For terms, consider using `open scoped Classical in` at the term level (not the command level).

Note: This linter can be disabled with `set_option linter.unusedDecidableInType false`
⚠ [2677/3078] Replayed TNLean.Algebra.MatrixSpectralDecomp
warning: TNLean/Algebra/MatrixSpectralDecomp.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [2679/3078] Replayed TNLean.Algebra.FinSum
warning: TNLean/Algebra/FinSum.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [2681/3078] Replayed TNLean.Algebra.ScalarPowerSumIdentity
warning: TNLean/Algebra/ScalarPowerSumIdentity.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [2684/3078] Replayed TNLean.Algebra.UnitModulusPowerSum
warning: TNLean/Algebra/UnitModulusPowerSum.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [2688/3078] Replayed TNLean.Algebra.FiniteCycleCoboundary
warning: TNLean/Algebra/FiniteCycleCoboundary.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [2980/3078] Replayed TNLean.Channel.Irreducible.Basic
warning: TNLean/Channel/Irreducible/Basic.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [2981/3078] Replayed TNLean.Algebra.ProjectionTriangularTrace
warning: TNLean/Algebra/ProjectionTriangularTrace.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [2982/3078] Replayed TNLean.MPS.Core.MultiBlock
warning: TNLean/MPS/Core/MultiBlock.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [2983/3078] Replayed TNLean.MPS.Overlap.Basic
warning: TNLean/MPS/Overlap/Basic.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Overlap/Basic.lean:10:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `open scoped BigOperators InnerProductSpace`.

Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Overlap/Basic.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Overlap/Basic.lean:10:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `/-!# MPV overlaps

For an MPS tensor `A`, the Matrix Product Vector (MPV) coefficient at system size `N` and physical
configuration `σ : Fin N → Fin d` is `mpv A σ : ℂ`.

This file organizes the family `σ ↦ mpv A σ` as a vector `mpvState A N` in the Hilbert space
`MPVSpace d N := EuclideanSpace ℂ (Fin N → Fin d)`.

**Orientation convention.** Lean's inner product on complex Hilbert spaces is conjugate-linear in
the first argument, so `⟪mpvState A N, mpvState B N⟫_ℂ` expands to
`∑ σ, mpv B σ * star (mpv A σ)`.

In the physics literature one often uses the bilinear overlap without complex conjugation
on the first factor, `∑ σ, mpv A σ * star (mpv B σ)`. We define this as `mpvOverlap A B N`;
it differs from Lean's inner product by a complex conjugation.
-/
`.

Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [2987/3078] Replayed TNLean.MPS.Structure.LinearExtension
warning: TNLean/MPS/Structure/LinearExtension.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [2988/3078] Replayed TNLean.MPS.FundamentalTheorem.Basic
warning: TNLean/MPS/FundamentalTheorem/Basic.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [2989/3078] Replayed TNLean.MPS.FundamentalTheorem.Multi
warning: TNLean/MPS/FundamentalTheorem/Multi.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/FundamentalTheorem/Multi.lean:7:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `open scoped Matrix BigOperators`.

Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/FundamentalTheorem/Multi.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/FundamentalTheorem/Multi.lean:7:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `namespace MPSTensor`.

Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/FundamentalTheorem/Multi.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/FundamentalTheorem/Multi.lean:7:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `/-!# Gauge equivalence for direct sums of block tensors

The central identity is the direct-sum conjugation formula
`B k i = X k * A k i * (X k)⁻¹` for all `k,i`
implies
`toTensorFromBlocks μ B i = X * toTensorFromBlocks μ A i * X⁻¹`,
where `X` is the block-diagonal matrix with diagonal blocks `X k`.

For each block index `k`, the injective MPV theorem gives an invertible matrix
`X k` satisfying `B k i = X k * A k i * (X k)⁻¹` whenever the block tensors
`A k` and `B k` generate the same MPV family.  The direct-sum formula above then
uses the block-diagonal matrix `⊕_k X k` for
`toTensorFromBlocks μ A = ⊕_k μ_k A_k`.

The block-diagonal `GL` constructors `blockDiagonalGL` and `globalGaugeOfBlocks`
and the direct-sum conjugation identity
`toTensorFromBlocks_eq_globalGaugeOfBlocks_conj` are pure linear-algebra
intermediate constructions and have been moved to `TNLean.MPS.SharedInfra.BlockGauge` so that
canonical-form modules can use them without inverting the layer order.  They
are re-stated here transitively through the import above.
-/
`.

Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [2991/3078] Replayed TNLean.MPS.Structure.InvariantSubspaceDecomp
warning: TNLean/MPS/Structure/InvariantSubspaceDecomp.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Structure/InvariantSubspaceDecomp.lean:78:22: Used `tac1 <;> tac2` where `(tac1; tac2)` would suffice

Note: This linter can be disabled with `set_option linter.unnecessarySeqFocus false`
warning: TNLean/MPS/Structure/InvariantSubspaceDecomp.lean:78:54: Used `tac1 <;> tac2` where `(tac1; tac2)` would suffice

Note: This linter can be disabled with `set_option linter.unnecessarySeqFocus false`
⚠ [2992/3078] Replayed TNLean.MPS.CanonicalForm.Reduction
warning: TNLean/MPS/CanonicalForm/Reduction.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/CanonicalForm/Reduction.lean:7:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `open scoped Matrix BigOperators`.

Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/CanonicalForm/Reduction.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/CanonicalForm/Reduction.lean:7:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `/-!# Iterated invariant-projection splitting: irreducible block decomposition

This module implements the "iterate until all blocks are irreducible" step from
Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, lines 201–219
(the display labelled eq:II_Aiplusk1 is at lines 214–218).
It also corresponds to the invariant-subspace splitting used inside
Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical,
lines 765–833.
The source proof is ordered as follows: lines 765–770 handle spectral-radius
normalization and the full-rank fixed-point gauge; lines 771–783 derive the
invariant support from a singular positive fixed point; lines 785–815 split the
finite-ring trace over that support and its orthogonal complement; lines 816–826
iterate the split and use a non-scalar fixed point to force uniqueness of the
identity fixed point.  This file formalizes only the abstract splitting once an
invariant projection is available; a faithful proof of the full theorem must
also derive that projection from the singular positive fixed-point argument in
lines 771–783 and then compose the dual fixed-point diagonalization in
lines 827–832.

Starting from an arbitrary MPS tensor `A : MPSTensor d D`, we iteratively apply
`MPSTensor.exists_twoBlock_decomp_of_lowerZero_strict` — which produces two blocks each with
*strictly smaller* bond dimension — until every block is irreducible with respect to invariant
orthogonal projections. Strong induction on `D` guarantees termination.

## Main result

* `MPSTensor.exists_irreducible_blockDecomp`: every tensor is `SameMPV₂`-equivalent to a
  block-diagonal tensor `toTensorFromBlocks (μ ≡ 1) blocks` whose blocks are all irreducible.

## What is **not** done here

* Periodicity removal / Perron–Frobenius normalization.
* Gauge normalization (CFII, left-canonical gauge).
* Blocking to remove periodicity.
* The positive weights, unital block orientation, diagonal full-rank dual fixed
  points, uniqueness of the identity fixed point, and total bond-dimension bound
  in Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical,
  lines 742–763.
These are separate steps in the canonical-form construction.

## References

* Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, lines 201–219,
  with eq:II_Aiplusk1 at lines 214–218.
* Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical,
  proof lines 765–833.
-/
`.

Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [2993/3078] Replayed TNLean.Wielandt.SpanGrowth.CumulativeSpan
warning: TNLean/Wielandt/SpanGrowth/CumulativeSpan.lean:2:18: * '. All rights reserved.':
'Copyright (c) YYYY' should be followed by a space


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [2994/3078] Replayed TNLean.Algebra.BurnsideMatrix
warning: TNLean/Algebra/BurnsideMatrix.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [2995/3078] Replayed TNLean.Algebra.IrreducibleTensorAction
warning: TNLean/Algebra/IrreducibleTensorAction.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [3007/3078] Replayed TNLean.Algebra.PerronFrobenius.RankOne
warning: TNLean/Algebra/PerronFrobenius/RankOne.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [3008/3078] Replayed TNLean.Algebra.ProjectiveRepresentation
warning: TNLean/Algebra/ProjectiveRepresentation.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [3009/3078] Replayed TNLean.Algebra.ScalarCommutant
warning: TNLean/Algebra/ScalarCommutant.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [3010/3078] Replayed TNLean.Algebra.CocycleCohomology
warning: TNLean/Algebra/CocycleCohomology.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [3022/3078] Replayed TNLean.Algebra.SpinCover
warning: TNLean/Algebra/SpinCover.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [3024/3078] Replayed TNLean.Algebra.StarSubalgebraSpatial
warning: TNLean/Algebra/StarSubalgebraSpatial.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [3025/3078] Replayed TNLean.Algebra.StarSubalgebraIrreducibleDecomp
warning: TNLean/Algebra/StarSubalgebraIrreducibleDecomp.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [3027/3078] Replayed TNLean.Algebra.StarSubalgebraSchur
warning: TNLean/Algebra/StarSubalgebraSchur.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [3028/3078] Replayed TNLean.Algebra.StarSubalgebraIsotypic
warning: TNLean/Algebra/StarSubalgebraIsotypic.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [3029/3078] Replayed TNLean.Algebra.StarSubalgebraIsotypicDecomp
warning: TNLean/Algebra/StarSubalgebraIsotypicDecomp.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [3030/3078] Replayed TNLean.Algebra.StarSubalgebraIntertwinerIsometry
warning: TNLean/Algebra/StarSubalgebraIntertwinerIsometry.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [3031/3078] Replayed TNLean.Algebra.StarSubalgebraUnitaryIntertwiner
warning: TNLean/Algebra/StarSubalgebraUnitaryIntertwiner.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [3032/3078] Replayed TNLean.Algebra.StarSubalgebraIsotypicFactorization
warning: TNLean/Algebra/StarSubalgebraIsotypicFactorization.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [3033/3078] Replayed TNLean.Algebra.StarSubalgebraBlockDiagonal
warning: TNLean/Algebra/StarSubalgebraBlockDiagonal.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [3040/3078] Replayed TNLean.Algebra.StarSubalgebraSemisimple
warning: TNLean/Algebra/StarSubalgebraSemisimple.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [3041/3078] Replayed TNLean.Algebra.StarSubalgebraSimpleModule
warning: TNLean/Algebra/StarSubalgebraSimpleModule.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [3042/3078] Replayed TNLean.Algebra.StarSubalgebraBlockForm
warning: TNLean/Algebra/StarSubalgebraBlockForm.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [3044/3078] Replayed TNLean.Analysis.ProjectionGeometry
warning: TNLean/Analysis/ProjectionGeometry.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [3045/3078] Replayed TNLean.Analysis.TraceCFC
warning: TNLean/Analysis/TraceCFC.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [3046/3078] Replayed TNLean.Analysis.MatrixSqrt
warning: TNLean/Analysis/MatrixSqrt.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [3047/3078] Replayed TNLean.Analysis.CfcConjugation
warning: TNLean/Analysis/CfcConjugation.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [3048/3078] Replayed TNLean.Analysis.MatrixOrderTopology
warning: TNLean/Analysis/MatrixOrderTopology.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [3129/3455] Replayed TNLean.Analysis.LiebIntegrandConcave
warning: TNLean/Analysis/LiebIntegrandConcave.lean:202:2: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/Analysis/LiebIntegrandConcave.lean:215:4: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/Analysis/LiebIntegrandConcave.lean:219:4: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/Analysis/LiebIntegrandConcave.lean:223:4: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
⚠ [3131/3455] Replayed TNLean.Topology.ConvexProjection
warning: TNLean/Topology/ConvexProjection.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8624/9301] Replayed TNLean.Channel.Basic
warning: TNLean/Channel/Basic.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8625/9301] Replayed TNLean.Channel.PartialTrace
warning: TNLean/Channel/PartialTrace.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8626/9301] Replayed TNLean.Channel.MaximallyEntangled
warning: TNLean/Channel/MaximallyEntangled.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8627/9301] Replayed TNLean.Channel.TensorMap
warning: TNLean/Channel/TensorMap.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8628/9301] Replayed TNLean.Channel.ChoiJamiolkowski
warning: TNLean/Channel/ChoiJamiolkowski.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8631/9301] Replayed TNLean.Channel.ChoiTypeMap
warning: TNLean/Channel/ChoiTypeMap.lean:162:20: `simp [f]` is a flexible tactic modifying `⊢`. Try `simp?` and use the suggested `simp only [...]`. Alternatively, use `suffices` to explicitly state the simplified form.

Note: This linter can be disabled with `set_option linter.flexible false`
info: TNLean/Channel/ChoiTypeMap.lean:162:20: Try this:
  [apply] simp only [Fin.zero_eta, Fin.isValue]
info: TNLean/Channel/ChoiTypeMap.lean:162:33: `positivity` uses `⊢`!
warning: TNLean/Channel/ChoiTypeMap.lean:162:20: `simp [f]` is a flexible tactic modifying `⊢`. Try `simp?` and use the suggested `simp only [...]`. Alternatively, use `suffices` to explicitly state the simplified form.

Note: This linter can be disabled with `set_option linter.flexible false`
info: TNLean/Channel/ChoiTypeMap.lean:162:20: Try this:
  [apply] simp only [Fin.mk_one, Fin.isValue]
info: TNLean/Channel/ChoiTypeMap.lean:162:33: `positivity` uses `⊢`!
warning: TNLean/Channel/ChoiTypeMap.lean:162:20: `simp [f]` is a flexible tactic modifying `⊢`. Try `simp?` and use the suggested `simp only [...]`. Alternatively, use `suffices` to explicitly state the simplified form.

Note: This linter can be disabled with `set_option linter.flexible false`
info: TNLean/Channel/ChoiTypeMap.lean:162:20: Try this:
  [apply] simp only [Fin.reduceFinMk, Fin.isValue]
info: TNLean/Channel/ChoiTypeMap.lean:162:33: `positivity` uses `⊢`!
warning: TNLean/Channel/ChoiTypeMap.lean:188:4: `simp` is a flexible tactic modifying `⊢`. Try `simp?` and use the suggested `simp only [...]`. Alternatively, use `suffices` to explicitly state the simplified form.

Note: This linter can be disabled with `set_option linter.flexible false`
info: TNLean/Channel/ChoiTypeMap.lean:188:4: Try this:
  [apply] simp only [mul_zero, add_zero, div_zero, zero_add, zero_div, ge_iff_le]
info: TNLean/Channel/ChoiTypeMap.lean:193:6: `have h2y : 2 * y ≠ 0 := by positivity` uses `⊢`!
warning: TNLean/Channel/ChoiTypeMap.lean:201:4: `simp` is a flexible tactic modifying `⊢`. Try `simp?` and use the suggested `simp only [...]`. Alternatively, use `suffices` to explicitly state the simplified form.

Note: This linter can be disabled with `set_option linter.flexible false`
info: TNLean/Channel/ChoiTypeMap.lean:201:4: Try this:
  [apply] simp only [mul_zero, zero_add, zero_div, add_zero, div_zero, ge_iff_le]
info: TNLean/Channel/ChoiTypeMap.lean:206:6: `have h2z : 2 * z ≠ 0 := by positivity` uses `⊢`!
warning: TNLean/Channel/ChoiTypeMap.lean:214:4: `simp` is a flexible tactic modifying `⊢`. Try `simp?` and use the suggested `simp only [...]`. Alternatively, use `suffices` to explicitly state the simplified form.

Note: This linter can be disabled with `set_option linter.flexible false`
info: TNLean/Channel/ChoiTypeMap.lean:214:4: Try this:
  [apply] simp only [add_zero, mul_zero, zero_add, zero_div, div_zero, ge_iff_le]
info: TNLean/Channel/ChoiTypeMap.lean:219:6: `have h2x : 2 * x ≠ 0 := by positivity` uses `⊢`!
warning: TNLean/Channel/ChoiTypeMap.lean:336:0: `isPositiveMap_of_forall_vecMulVec_posSemidef` does not use the following hypothesis in its type:
  • [DecidableEq m] (#3)

Consider removing this hypothesis and using `classical` in the proof instead. For terms, consider using `open scoped Classical in` at the term level (not the command level).

Note: This linter can be disabled with `set_option linter.unusedDecidableInType false`
warning: TNLean/Channel/ChoiTypeMap.lean:336:0: `isPositiveMap_of_forall_vecMulVec_posSemidef` does not use the following hypothesis in its type:
  • [Fintype m] (#2)

Consider replacing this hypothesis with the corresponding instance of `Finite` and using `Fintype.ofFinite` in the proof, or removing it entirely.

Note: This linter can be disabled with `set_option linter.unusedFintypeInType false`
⚠ [8632/9301] Replayed TNLean.Channel.DensityRetract
warning: TNLean/Channel/DensityRetract.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8636/9301] Replayed TNLean.Channel.KrausRank
warning: TNLean/Channel/KrausRank.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8637/9301] Replayed TNLean.Channel.KrausRepresentation
warning: TNLean/Channel/KrausRepresentation.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8638/9301] Replayed TNLean.Channel.Stinespring
warning: TNLean/Channel/Stinespring.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8640/9301] Replayed TNLean.Channel.KrausUnitaryFreedom
warning: TNLean/Channel/KrausUnitaryFreedom.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8641/9301] Replayed TNLean.Channel.OrderedCP
warning: TNLean/Channel/OrderedCP.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8642/9301] Replayed TNLean.Channel.CompletelyPositiveBridge
warning: TNLean/Channel/CompletelyPositiveBridge.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8643/9301] Replayed TNLean.Channel.RadonNikodym
warning: TNLean/Channel/RadonNikodym.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8645/9301] Replayed TNLean.MPS.Tactic.Basic
warning: TNLean/MPS/Tactic/Basic.lean:5:7: Files in mathlib cannot import the whole `Mathlib.Tactic` folder. Doing so would cause imports to be unnecessarily slow.

Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Tactic/Basic.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8646/9301] Replayed TNLean.MPS.Core.Transfer
warning: TNLean/MPS/Core/Transfer.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8647/9301] Replayed TNLean.Channel.TransferMatrix
warning: TNLean/Channel/TransferMatrix.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8649/9301] Replayed TNLean.Channel.Semigroup.Basic
warning: TNLean/Channel/Semigroup/Basic.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8650/9301] Replayed TNLean.Channel.Schwarz.Basic
warning: TNLean/Channel/Schwarz/Basic.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8652/9301] Replayed TNLean.Channel.POVM
warning: TNLean/Channel/POVM.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8653/9301] Replayed TNLean.Channel.POVM.Uniqueness
warning: TNLean/Channel/POVM/Uniqueness.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8654/9301] Replayed TNLean.Analysis.Entropy
warning: TNLean/Analysis/Entropy.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8655/9301] Replayed TNLean.Analysis.EntropyDecomposition
warning: TNLean/Analysis/EntropyDecomposition.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/Analysis/EntropyDecomposition.lean:240:100: This line exceeds the 100 character limit, please shorten it!

Note: This linter can be disabled with `set_option linter.style.longLine false`
warning: TNLean/Analysis/EntropyDecomposition.lean:271:100: This line exceeds the 100 character limit, please shorten it!

Note: This linter can be disabled with `set_option linter.style.longLine false`
warning: TNLean/Analysis/EntropyDecomposition.lean:273:100: This line exceeds the 100 character limit, please shorten it!

Note: This linter can be disabled with `set_option linter.style.longLine false`
⚠ [8656/9301] Replayed TNLean.Analysis.HayashiMarkovStructure
warning: TNLean/Analysis/HayashiMarkovStructure.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8657/9301] Replayed TNLean.Analysis.EntropyMarkovReverse
warning: TNLean/Analysis/EntropyMarkovReverse.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/Analysis/EntropyMarkovReverse.lean:522:0: `kronecker_density` does not use the following hypotheses in its type:
  • [DecidableEq m] (#4)
  • [DecidableEq n] (#6)

Consider removing these hypotheses and using `classical` in the proof instead. For terms, consider using `open scoped Classical in` at the term level (not the command level).

Note: This linter can be disabled with `set_option linter.unusedDecidableInType false`
warning: TNLean/Analysis/EntropyMarkovReverse.lean:729:4: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/Analysis/EntropyMarkovReverse.lean:739:6: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/Analysis/EntropyMarkovReverse.lean:776:4: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/Analysis/EntropyMarkovReverse.lean:822:4: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
⚠ [8658/9301] Replayed TNLean.Analysis.KleinInequality
warning: TNLean/Analysis/KleinInequality.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8659/9301] Replayed TNLean.Analysis.MarginalSupport
warning: TNLean/Analysis/MarginalSupport.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/Analysis/MarginalSupport.lean:123:0: `mulVec_submatrix_support` does not use the following hypotheses in its type:
  • [DecidableEq S] (#4)
  • [DecidableEq T] (#6)

Consider removing these hypotheses and using `classical` in the proof instead. For terms, consider using `open scoped Classical in` at the term level (not the command level).

Note: This linter can be disabled with `set_option linter.unusedDecidableInType false`
warning: TNLean/Analysis/MarginalSupport.lean:186:0: automatically included section variable(s) unused in theorem `Matrix.traceLeftA_posSemidef`:
  [Fintype R]
consider restructuring your `variable` declarations so that the variables are not in scope or explicitly omit them:
  omit [Fintype R] in theorem ...

Note: This linter can be disabled with `set_option linter.unusedSectionVars false`
warning: TNLean/Analysis/MarginalSupport.lean:182:0: `traceLeftA_posSemidef` does not use the following hypothesis in its type:
  • [Fintype R] (#3)

Consider replacing this hypothesis with the corresponding instance of `Finite` and using `Fintype.ofFinite` in the proof, or removing it entirely.

Note: This linter can be disabled with `set_option linter.unusedFintypeInType false`
⚠ [8660/9301] Replayed TNLean.Axioms.Entropy
warning: TNLean/Axioms/Entropy.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8661/9301] Replayed TNLean.Entropy.VonNeumann
warning: TNLean/Entropy/VonNeumann.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8664/9301] Replayed TNLean.Axioms.OperatorConvexity
warning: TNLean/Axioms/OperatorConvexity.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8665/9301] Replayed TNLean.Channel.Schwarz.DiagonalJensen
warning: TNLean/Channel/Schwarz/DiagonalJensen.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8666/9301] Replayed TNLean.Analysis.OperatorConvexity
warning: TNLean/Analysis/OperatorConvexity.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8667/9301] Replayed TNLean.Channel.Schwarz.AndoLieb
warning: TNLean/Channel/Schwarz/AndoLieb.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8668/9301] Replayed TNLean.Channel.Schwarz.RelativeEntropyConvexity
warning: TNLean/Channel/Schwarz/RelativeEntropyConvexity.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/Channel/Schwarz/RelativeEntropyConvexity.lean:573:5: Variable name `hρ` is not explicitly referenced.

The binding can be removed (if unused) or named `_` (if used implicitly).

Note: This linter can be disabled with `set_option linter.unusedVariables false`
warning: TNLean/Channel/Schwarz/RelativeEntropyConvexity.lean:603:73: This simp argument is unused:
  smul_eq_mul

Hint: Omit it from the simp argument list.
  simp only [Matrix.smul_apply, Matrix.add_apply, Matrix.one_apply_eq, s̵mul_e̵q̵_̵m̵u̵l̵,̵
  ̵ ̵ ̵ ̵ ̵ ̵ ̵m̵u̵l̵_̵one, Complex.real_smul,
  ̲  ̲ ̲ ̲ ̲ ̲Complex.mul_re, Complex.add_re, Complex.ofReal_re,
  ̵  ̵ ̵ ̵ ̵ ̵Complex.ofReal_im, Complex.add_im, hw]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: TNLean/Channel/Schwarz/RelativeEntropyConvexity.lean:764:5: Variable name `hρ` is not explicitly referenced.

The binding can be removed (if unused) or named `_` (if used implicitly).

Note: This linter can be disabled with `set_option linter.unusedVariables false`
warning: TNLean/Channel/Schwarz/RelativeEntropyConvexity.lean:793:73: This simp argument is unused:
  smul_eq_mul

Hint: Omit it from the simp argument list.
  simp only [Matrix.smul_apply, Matrix.add_apply, Matrix.one_apply_eq, s̵mul_e̵q̵_̵m̵u̵l̵,̵
  ̵ ̵ ̵ ̵ ̵ ̵ ̵m̵u̵l̵_̵one, Complex.real_smul,
  ̲  ̲ ̲ ̲ ̲ ̲Complex.mul_re, Complex.add_re, Complex.ofReal_re,
  ̵  ̵ ̵ ̵ ̵ ̵Complex.ofReal_im, Complex.add_im, hw]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
⚠ [8669/9301] Replayed TNLean.Channel.Schwarz.RelativeEntropyUnitaryInvariance
warning: TNLean/Channel/Schwarz/RelativeEntropyUnitaryInvariance.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8672/9301] Replayed TNLean.Entropy.TripartiteTrace
warning: TNLean/Entropy/TripartiteTrace.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8673/9301] Replayed TNLean.Channel.Schwarz.StrongSubadditivityPosDef
warning: TNLean/Channel/Schwarz/StrongSubadditivityPosDef.lean:265:5: Variable name `hρ` is not explicitly referenced.

The binding can be removed (if unused) or named `_` (if used implicitly).

Note: This linter can be disabled with `set_option linter.unusedVariables false`
warning: TNLean/Channel/Schwarz/StrongSubadditivityPosDef.lean:354:65: This simp argument is unused:
  true_and

Hint: Omit it from the simp argument list.
  simp only [h1, h2, if_true, if_false, and_true, and_false, t̵r̵u̵e̵_̵a̵n̵d̵,̵ ̵false_and, mul_one, mul_zero,
  ̲  ̲ ̲ ̲ ̲ ̲ ̲ ̲zero_mul, add_zero, zero_add]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: TNLean/Channel/Schwarz/StrongSubadditivityPosDef.lean:354:75: This simp argument is unused:
  false_and

Hint: Omit it from the simp argument list.
  simp only [h1, h2, if_true, if_false, and_true, and_false, true_and, f̵a̵l̵s̵e̵_̵a̵n̵d̵,̵mul_one, mul_zero,
  ̲  ̲ ̲ ̲ ̲ ̲ ̲ ̲zero_mul, add_zero, zero_add]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: TNLean/Channel/Schwarz/StrongSubadditivityPosDef.lean:355:47: This simp argument is unused:
  zero_add

Hint: Omit it from the simp argument list.
  simp only [h1, h2, if_true, if_false, and_true, and_false, true_and, false_and, mul_one,
  ̲  ̲ ̲ ̲ ̲ ̲ ̲ ̲mul_zero, zero_mul, a̵d̵d̵_̵z̵e̵r̵o̵,̵ ̵z̵e̵r̵o̵_̵a̵d̵d̵]̵a̲d̲d̲_̲z̲e̲r̲o̲]̲

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: TNLean/Channel/Schwarz/StrongSubadditivityPosDef.lean:573:0: `kron_marginal_support` does not use the following hypothesis in its type:
  • [DecidableEq R] (#4)

Consider removing this hypothesis and using `classical` in the proof instead. For terms, consider using `open scoped Classical in` at the term level (not the command level).

Note: This linter can be disabled with `set_option linter.unusedDecidableInType false`
⚠ [8674/9301] Replayed TNLean.Entropy.StrongSubadditivity
warning: TNLean/Entropy/StrongSubadditivity.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8675/9301] Replayed TNLean.Entropy.MarkovChain
warning: TNLean/Entropy/MarkovChain.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8676/9301] Replayed TNLean.Entropy.MutualInformation
warning: TNLean/Entropy/MutualInformation.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8677/9301] Replayed TNLean.Axioms.LiebSubBoundary
warning: TNLean/Axioms/LiebSubBoundary.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8678/9301] Replayed TNLean.Analysis.RpowConvexity
warning: TNLean/Analysis/RpowConvexity.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8679/9301] Replayed TNLean.Channel.Schwarz.KadisonSchwarz
warning: TNLean/Channel/Schwarz/KadisonSchwarz.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8680/9301] Replayed TNLean.Channel.Schwarz.PositiveMapProperties
warning: TNLean/Channel/Schwarz/PositiveMapProperties.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8681/9301] Replayed TNLean.Channel.Schwarz.Douglas
warning: TNLean/Channel/Schwarz/Douglas.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8682/9301] Replayed TNLean.Channel.Schwarz.OperatorConvexity
warning: TNLean/Channel/Schwarz/OperatorConvexity.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8683/9301] Replayed TNLean.Channel.Schwarz.OperatorMonotone
warning: TNLean/Channel/Schwarz/OperatorMonotone.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8684/9301] Replayed TNLean.Channel.Schwarz.PositiveOnAbelian.Basic
warning: TNLean/Channel/Schwarz/PositiveOnAbelian/Basic.lean:201:100: This line exceeds the 100 character limit, please shorten it!

Note: This linter can be disabled with `set_option linter.style.longLine false`
⚠ [8687/9301] Replayed TNLean.Channel.Schwarz.PositiveOnAbelian
warning: TNLean/Channel/Schwarz/PositiveOnAbelian.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8688/9301] Replayed TNLean.Channel.Schwarz.SchwarzNormal
warning: TNLean/Channel/Schwarz/SchwarzNormal.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8689/9301] Replayed TNLean.Channel.Schwarz.SchwarzSubnormal
warning: TNLean/Channel/Schwarz/SchwarzSubnormal.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/Channel/Schwarz/SchwarzSubnormal.lean:225:19: 'change M.toBlocks₁₁.PosSemidef' tactic does nothing

Note: This linter can be disabled with `set_option linter.unusedTactic false`
warning: TNLean/Channel/Schwarz/SchwarzSubnormal.lean:296:10: try 'simp' instead of 'simpa'

Note: This linter can be disabled with `set_option linter.unnecessarySimpa false`
warning: TNLean/Channel/Schwarz/SchwarzSubnormal.lean:302:10: try 'simp' instead of 'simpa'

Note: This linter can be disabled with `set_option linter.unnecessarySimpa false`
⚠ [8690/9301] Replayed TNLean.Channel.Schwarz.SchwarzNotCP
warning: TNLean/Channel/Schwarz/SchwarzNotCP.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8691/9301] Replayed TNLean.Channel.Schwarz.TwoPositive
warning: TNLean/Channel/Schwarz/TwoPositive.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8702/9301] Replayed TNLean.Channel.Schwarz.MultiplicativeDomain
warning: TNLean/Channel/Schwarz/MultiplicativeDomain.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8703/9301] Replayed TNLean.Channel.Schwarz.MultiplicativeDomainPowers
warning: TNLean/Channel/Schwarz/MultiplicativeDomainPowers.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8704/9301] Replayed TNLean.Channel.Schwarz.MultiplicativeDomainFull
warning: TNLean/Channel/Schwarz/MultiplicativeDomainFull.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8705/9301] Replayed TNLean.Channel.FixedPoint.Algebra
warning: TNLean/Channel/FixedPoint/Algebra.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8706/9301] Replayed TNLean.Channel.FixedPoint.BlockForm
warning: TNLean/Channel/FixedPoint/BlockForm.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8708/9301] Replayed TNLean.Channel.FixedPoint.Cesaro
warning: TNLean/Channel/FixedPoint/Cesaro.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8709/9301] Replayed TNLean.Channel.Primitive
warning: TNLean/Channel/Primitive.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8710/9301] Replayed TNLean.Channel.Peripheral.Spectrum
warning: TNLean/Channel/Peripheral/Spectrum.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8711/9301] Replayed TNLean.Channel.Peripheral.Powers
warning: TNLean/Channel/Peripheral/Powers.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8712/9301] Replayed TNLean.MPS.Core.CPPrimitive
warning: TNLean/MPS/Core/CPPrimitive.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Core/CPPrimitive.lean:10:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `open scoped Matrix ComplexOrder BigOperators`.

Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Core/CPPrimitive.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Core/CPPrimitive.lean:10:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `namespace MPSTensor`.

Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Core/CPPrimitive.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Core/CPPrimitive.lean:10:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `variable {d D : ℕ}`.

Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Core/CPPrimitive.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Core/CPPrimitive.lean:10:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `/-!## MPS injectivity implies irreducibility of the transfer map

The general definitions (`IsOrthogonalProjection`, `IsIrreducibleMap`,
`HasUniqueFixedPoint`) are stated in `TNLean.Channel.Irreducible.Basic`. The
supporting sum-of-squares matrix lemma
`Matrix.eq_zero_of_sum_mul_conjTranspose_eq_zero` is stated in `TNLean.Algebra.MatrixAux`.

This file proves the MPS-specific connection: injectivity of an MPS tensor
implies irreducibility of its transfer map.

Key results:
- `injective_implies_irreducibleCP`: injectivity of an MPS tensor implies
  irreducibility of its transfer map.
-/
`.

Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8713/9301] Replayed TNLean.QPF.PosDef
warning: TNLean/QPF/PosDef.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8715/9301] Replayed TNLean.Channel.Peripheral.PeriodicityRemoval
warning: TNLean/Channel/Peripheral/PeriodicityRemoval.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8716/9301] Replayed TNLean.QPF.Uniqueness
warning: TNLean/QPF/Uniqueness.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8718/9301] Replayed TNLean.Channel.FixedPoint.CornerAlgebra
warning: TNLean/Channel/FixedPoint/CornerAlgebra.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8719/9301] Replayed TNLean.MPS.Irreducible.FixedPointProjection
warning: TNLean/MPS/Irreducible/FixedPointProjection.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8720/9301] Replayed TNLean.Channel.Spectral.Support
warning: TNLean/Channel/Spectral/Support.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8725/9301] Replayed TNLean.Channel.Peripheral.CyclicDecomposition
warning: TNLean/Channel/Peripheral/CyclicDecomposition.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8726/9301] Replayed TNLean.Channel.Peripheral.Conjugation
warning: TNLean/Channel/Peripheral/Conjugation.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8727/9301] Replayed TNLean.MPS.Core.OrthogonalProjectionInvariance
warning: TNLean/MPS/Core/OrthogonalProjectionInvariance.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8728/9301] Replayed TNLean.QPF.Assembly
warning: TNLean/QPF/Assembly.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8729/9301] Replayed TNLean.MPS.Irreducible.FormII
warning: TNLean/MPS/Irreducible/FormII.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Irreducible/FormII.lean:11:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `open scoped Matrix BigOperators ComplexOrder`.

Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Irreducible/FormII.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Irreducible/FormII.lean:11:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `/-!# Irreducible Form II: diagonal positive-definite fixed point

This module connects the irreducible-block decomposition (`CanonicalFormReduction.lean`)
to channel / QPF normalization, following:

* Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, Appendix A
  (CFII definition: TP + full-rank diagonal fixed point), and
* De las Cuevas–Cirac–Schuch–Pérez-García, arXiv:1708.00029, Section 2.1
  (irreducible form II discussion, diagonal fixed point).

## Main results

### Part 1: Equivalence of `IsIrreducibleTensor` and `IsIrreducibleMap (transferMap A)`

* `MPSTensor.invariance_implies_lowerZero`: the invariance condition for a projection
  under a transfer map implies `(1 - P) * A i * P = 0` for all `i`.
* `MPSTensor.lowerZero_implies_invariance`: the converse — the lower-zero condition
  on Kraus operators implies the invariance condition for the transfer map.
* `MPSTensor.isIrreducibleCP_transferMap_of_isIrreducibleTensor`: if the MPS tensor
  has no nontrivial invariant projection, then the transfer map is irreducible as a CP map.
* `MPSTensor.isIrreducibleTensor_of_isIrreducibleMap`: the converse — if the transfer
  map is irreducible as a CP map, then the MPS tensor has no nontrivial invariant projection.

### Part 2: CFII-style diagonal fixed point

* `MPSTensor.exists_unitary_diag_posDef_fixedPoint_of_TP_of_isIrreducibleTensor`:
  for a trace-preserving / left-canonical irreducible MPS tensor, there exists a
  unitary conjugation such that the conjugated tensor is still left-canonical and has a
  diagonal positive-definite fixed point.

## References

* [Cirac et al., arXiv:1606.00608, Section 2.3 and Appendix A][Cirac2017Annals]
* [De las Cuevas et al., arXiv:1708.00029, Section 2.1][DeLasCuevas2017Irreducible]
* [Pérez-García et al., quant-ph/0608197, Theorem 3][PerezGarcia2007]
-/
`.

Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8730/9301] Replayed TNLean.MPS.Core.Blocking
warning: TNLean/MPS/Core/Blocking.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8731/9301] Replayed TNLean.Spectral.MixedTransfer
warning: TNLean/Spectral/MixedTransfer.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8732/9301] Replayed TNLean.MPS.Core.BlockingTransfer
warning: TNLean/MPS/Core/BlockingTransfer.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8733/9301] Replayed TNLean.MPS.Irreducible.Adjoint
warning: TNLean/MPS/Irreducible/Adjoint.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8734/9301] Replayed TNLean.MPS.CanonicalForm.BlockingViaAdjoint
warning: TNLean/MPS/CanonicalForm/BlockingViaAdjoint.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/CanonicalForm/BlockingViaAdjoint.lean:14:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `open scoped Matrix ComplexOrder MatrixOrder BigOperators`.

Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/CanonicalForm/BlockingViaAdjoint.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/CanonicalForm/BlockingViaAdjoint.lean:14:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `namespace MPSTensor`.

Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/CanonicalForm/BlockingViaAdjoint.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/CanonicalForm/BlockingViaAdjoint.lean:14:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `open Matrix Finset Complex`.

Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/CanonicalForm/BlockingViaAdjoint.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/CanonicalForm/BlockingViaAdjoint.lean:14:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `/-!## Auxiliary lemmas: adjoint eigenvalues and primitivity

We need a small connection between the peripheral spectrum of a linear map and that of its adjoint.
For finite-dimensional complex inner product spaces, eigenvalues of `E.adjoint` are complex
conjugates of eigenvalues of `E`.

We then specialize this to `Matrix (Fin D) (Fin D) ℂ` equipped with the Frobenius inner product
(induced by the identity matrix).
-/
`.

Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8735/9301] Replayed TNLean.MPS.Core.BlockingInfrastructure
warning: TNLean/MPS/Core/BlockingInfrastructure.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8737/9301] Replayed TNLean.Channel.FixedPoint.CornerFixedPoints
warning: TNLean/Channel/FixedPoint/CornerFixedPoints.lean:380:6: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/Channel/FixedPoint/CornerFixedPoints.lean:381:6: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/Channel/FixedPoint/CornerFixedPoints.lean:375:6: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/Channel/FixedPoint/CornerFixedPoints.lean:376:6: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/Channel/FixedPoint/CornerFixedPoints.lean:371:6: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/Channel/FixedPoint/CornerFixedPoints.lean:372:6: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/Channel/FixedPoint/CornerFixedPoints.lean:366:6: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/Channel/FixedPoint/CornerFixedPoints.lean:367:6: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/Channel/FixedPoint/CornerFixedPoints.lean:391:6: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/Channel/FixedPoint/CornerFixedPoints.lean:392:6: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/Channel/FixedPoint/CornerFixedPoints.lean:397:6: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/Channel/FixedPoint/CornerFixedPoints.lean:398:6: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
⚠ [8738/9301] Replayed TNLean.Channel.FixedPoint.CornerBlockForm
warning: TNLean/Channel/FixedPoint/CornerBlockForm.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8739/9301] Replayed TNLean.Channel.Irreducible.Growth.OneStep
warning: TNLean/Channel/Irreducible/Growth/OneStep.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8740/9301] Replayed TNLean.Channel.Irreducible.Growth.Preservation
warning: TNLean/Channel/Irreducible/Growth/Preservation.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8741/9301] Replayed TNLean.Channel.Irreducible.Growth.KernelDescent
warning: TNLean/Channel/Irreducible/Growth/KernelDescent.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8742/9301] Replayed TNLean.Channel.Semigroup.GeneratorDefs
warning: TNLean/Channel/Semigroup/GeneratorDefs.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8751/9301] Replayed TNLean.Channel.Semigroup.LindbladForm
warning: TNLean/Channel/Semigroup/LindbladForm.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8755/9301] Replayed TNLean.Channel.Irreducible.Growth.Exponential
warning: TNLean/Channel/Irreducible/Growth/Exponential.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8756/9301] Replayed TNLean.Channel.Irreducible.Growth.OrthogonalTrace
warning: TNLean/Channel/Irreducible/Growth/OrthogonalTrace.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8757/9301] Replayed TNLean.Channel.Irreducible.Growth
warning: TNLean/Channel/Irreducible/Growth.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8758/9301] Replayed TNLean.Channel.PerronFrobenius.Normalization
warning: TNLean/Channel/PerronFrobenius/Normalization.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8759/9301] Replayed TNLean.MPS.Core.TPGauge
warning: TNLean/MPS/Core/TPGauge.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8761/9301] Replayed TNLean.Channel.FixedPoint.WedderburnDecomp
warning: TNLean/Channel/FixedPoint/WedderburnDecomp.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8764/9301] Replayed TNLean.Channel.FixedPoint.WeightedCornerFixedPoints
warning: TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean:414:6: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean:408:6: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean:409:6: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean:404:6: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean:399:6: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean:400:6: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean:425:6: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean:426:6: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean:432:6: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean:433:6: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
⚠ [8767/9301] Replayed TNLean.Spectral.TransferOperatorGap
warning: TNLean/Spectral/TransferOperatorGap.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8768/9301] Replayed TNLean.Channel.Peripheral.GroupStructure
warning: TNLean/Channel/Peripheral/GroupStructure.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8769/9301] Replayed TNLean.Channel.Peripheral.CyclicGroup
warning: TNLean/Channel/Peripheral/CyclicGroup.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8773/9301] Replayed TNLean.Channel.Semigroup.ReducibleQDS
warning: TNLean/Channel/Semigroup/ReducibleQDS.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8774/9301] Replayed TNLean.Channel.Semigroup.RelaxationConditions
warning: TNLean/Channel/Semigroup/RelaxationConditions.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8775/9301] Replayed TNLean.QPF.Primitive
warning: TNLean/QPF/Primitive.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8777/9301] Replayed TNLean.Spectral.MPVOverlapTrace
warning: TNLean/Spectral/MPVOverlapTrace.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/Spectral/MPVOverlapTrace.lean:14:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `namespace MPSTensor`.

Note: This linter can be disabled with `set_option linter.style.header false`
info: TNLean/Spectral/MPVOverlapTrace.lean:15:0: linter.style.header:63:42: error: unexpected token 'ᴴ'; expected ')', ',' or ':'

linter.style.header:123:42: error: unexpected token 'ᴴ'; expected ')', ',' or ':'
warning: TNLean/Spectral/MPVOverlapTrace.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/Spectral/MPVOverlapTrace.lean:15:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `open scoped Matrix BigOperators`.

Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/Spectral/MPVOverlapTrace.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/Spectral/MPVOverlapTrace.lean:15:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `/-!# MPV overlaps as traces of mixed transfer operators

This module proves the key identity (standard in the MPS literature) expressing the overlap
\[
  \sum_{\sigma : \mathrm{Fin}\,N \to \mathrm{Fin}\,d}
    \mathrm{mpv}(A,\sigma)\,\overline{\mathrm{mpv}(B,\sigma)}
\]
as the trace of the $N$-th power of the mixed transfer operator.

The trace-expansion helpers (`linearMap_trace_eq_sum_apply_single`,
`entry_mul_single_mul`) are provided by `TNLean.Spectral.TraceExpansion`.

## Rectangular overlaps for different bond dimensions

`trace_mixedTransferMap₂_pow_eq_mpvOverlap` is the rectangular analogue, where
`A : MPSTensor d D₁` and `B : MPSTensor d D₂` may have different bond dimensions and the
mixed transfer map acts on `Matrix (Fin D₁) (Fin D₂) ℂ`.

The same trace-expansion helpers apply to this rectangular matrix space.
-/
`.

Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8778/9301] Replayed TNLean.Spectral.MPVOverlapDecay
warning: TNLean/Spectral/MPVOverlapDecay.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/Spectral/MPVOverlapDecay.lean:12:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `namespace MPSTensor`.

Note: This linter can be disabled with `set_option linter.style.header false`
info: TNLean/Spectral/MPVOverlapDecay.lean:13:0: linter.style.header:68:33: error: unexpected token 'ᴴ'; expected ')'

linter.style.header:125:33: error: unexpected token 'ᴴ'; expected ')'
warning: TNLean/Spectral/MPVOverlapDecay.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/Spectral/MPVOverlapDecay.lean:13:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `open scoped Matrix BigOperators ComplexOrder NNReal ENNReal
  Matrix.Norms.Operator`.

Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/Spectral/MPVOverlapDecay.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/Spectral/MPVOverlapDecay.lean:13:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `open Matrix Filter`.

Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/Spectral/MPVOverlapDecay.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/Spectral/MPVOverlapDecay.lean:13:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `attribute [local instance] ContinuousLinearMap.toNormedAddCommGroup
  ContinuousLinearMap.toNormedRing ContinuousLinearMap.toSeminormedRing ContinuousLinearMap.toNormedAlgebra`.

Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/Spectral/MPVOverlapDecay.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/Spectral/MPVOverlapDecay.lean:13:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `/-!# MPV overlap decay

This file proves a literature-standard decay statement for the *MPV overlap*
`mpvOverlap A B N` in the **square bond dimension** case
(cf. PerezGarcia2007 Lemma 5; Wolf Theorem 6.6 for the underlying
transfer-operator gap theory).

If `A` and `B` are injective, satisfy the trace-preserving normalization
`∑ i, (A i)ᴴ * A i = 1` and `∑ i, (B i)ᴴ * B i = 1`, and are **not** gauge-phase
equivalent, then the MPV overlaps decay to `0` as `N → ∞`.

## Proof idea (no operator topology)

1. Use `trace_mixedTransferMap_pow_eq_mpvOverlap` to rewrite the overlap as the
   operator trace of `((mixedTransferMap A B)^N)`.
2. Expand `LinearMap.trace` as a finite double sum over matrix units
   `Matrix.single p q 1` using `linearMap_trace_eq_sum_apply_single`.
3. For each fixed `(p,q)`, apply the transfer-operator gap lemma
   `mixedTransfer_pow_tendsto_zero`
   to get `((mixedTransferMap A B)^N) (Matrix.single p q 1) → 0`.
4. Extract the `(p,q)` entry using the continuous linear functional
   `Matrix.entryLinearMap ℂ ℂ p q`.
5. Reassemble the finite sum using `tendsto_finsetSum`.

## Rectangular overlaps for different bond dimensions

`mpvOverlap_tendsto_zero_of_mixedTransferSpectralRadius_lt_one` handles the case where
`A : MPSTensor d D₁` and `B : MPSTensor d D₂` may have different bond dimensions,
*assuming* a spectral-radius gap `spectralRadius < 1` for the rectangular mixed transfer
operator.
-/
`.

Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8779/9301] Replayed TNLean.Spectral.TransferOperatorGapRect
warning: TNLean/Spectral/TransferOperatorGapRect.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8780/9301] Replayed TNLean.Spectral.PrimitiveOverlap
warning: TNLean/Spectral/PrimitiveOverlap.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8781/9301] Replayed TNLean.Spectral.CrossCorrelation
warning: TNLean/Spectral/CrossCorrelation.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8782/9301] Replayed TNLean.Wielandt.SpanGrowth.EigenvectorSpreading
warning: TNLean/Wielandt/SpanGrowth/EigenvectorSpreading.lean:2:18: * '. All rights reserved.':
'Copyright (c) YYYY' should be followed by a space


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8783/9301] Replayed TNLean.Wielandt.Primitivity.Definitions
warning: TNLean/Wielandt/Primitivity/Definitions.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8784/9301] Replayed TNLean.Wielandt.SpanGrowth.VectorToMatrixSpan
warning: TNLean/Wielandt/SpanGrowth/VectorToMatrixSpan.lean:2:18: * '. All rights reserved.':
'Copyright (c) YYYY' should be followed by a space


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8785/9301] Replayed TNLean.Wielandt.Primitivity.EasyDirections
warning: TNLean/Wielandt/Primitivity/EasyDirections.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8786/9301] Replayed TNLean.MPS.Structure.PrimitivityBridge
warning: TNLean/MPS/Structure/PrimitivityBridge.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8787/9301] Replayed TNLean.Wielandt.Primitivity.Normal
warning: TNLean/Wielandt/Primitivity/Normal.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8788/9301] Replayed TNLean.MPS.Overlap.PeripheralToTransferMapGap
warning: TNLean/MPS/Overlap/PeripheralToTransferMapGap.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8791/9301] Replayed TNLean.Spectral.QuantitativeGap
warning: TNLean/Spectral/QuantitativeGap.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8793/9301] Replayed TNLean.MPS.Core.RepeatedWord
warning: TNLean/MPS/Core/RepeatedWord.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8794/9301] Replayed TNLean.MPS.Core.CyclicTrace
warning: TNLean/MPS/Core/CyclicTrace.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8795/9301] Replayed TNLean.MPS.Chain.Defs
warning: TNLean/MPS/Chain/Defs.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8796/9301] Replayed TNLean.MPS.Chain.VirtualInsertion
warning: TNLean/MPS/Chain/VirtualInsertion.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8797/9301] Replayed TNLean.MPS.Chain.TensorEquality
warning: TNLean/MPS/Chain/TensorEquality.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8798/9301] Replayed TNLean.MPS.Chain.AlgebraIsomorphism
warning: TNLean/MPS/Chain/AlgebraIsomorphism.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8799/9301] Replayed TNLean.MPS.Chain.FundamentalTheorem
warning: TNLean/MPS/Chain/FundamentalTheorem.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8800/9301] Replayed TNLean.MPS.Chain.GaugePhase
warning: TNLean/MPS/Chain/GaugePhase.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8801/9301] Replayed TNLean.MPS.Chain.BlockedChainFT
warning: TNLean/MPS/Chain/BlockedChainFT.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8802/9301] Replayed TNLean.MPS.Chain.SameStateBridge
warning: TNLean/MPS/Chain/SameStateBridge.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8803/9301] Replayed TNLean.MPS.Chain.TranslationInvariance
warning: TNLean/MPS/Chain/TranslationInvariance.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8804/9301] Replayed TNLean.MPS.Overlap.CastLemmas
warning: TNLean/MPS/Overlap/CastLemmas.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8805/9301] Replayed TNLean.MPS.Core.Correlations
warning: TNLean/MPS/Core/Correlations.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8806/9301] Replayed TNLean.MPS.ParentHamiltonian.GroundSpace
warning: TNLean/MPS/ParentHamiltonian/GroundSpace.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8807/9301] Replayed TNLean.MPS.ParentHamiltonian.Defs
warning: TNLean/MPS/ParentHamiltonian/Defs.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8808/9301] Replayed TNLean.MPS.ParentHamiltonian.Basic
warning: TNLean/MPS/ParentHamiltonian/Basic.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8809/9301] Replayed TNLean.MPS.ParentHamiltonian.Nonvanishing
warning: TNLean/MPS/ParentHamiltonian/Nonvanishing.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8810/9301] Replayed TNLean.Wielandt.SpanGrowth.NonzeroTraceProduct
warning: TNLean/Wielandt/SpanGrowth/NonzeroTraceProduct.lean:2:18: * '. All rights reserved.':
'Copyright (c) YYYY' should be followed by a space


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8811/9301] Replayed TNLean.Wielandt.FittingDecomposition
warning: TNLean/Wielandt/FittingDecomposition.lean:2:18: * '. All rights reserved.':
'Copyright (c) YYYY' should be followed by a space


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8812/9301] Replayed TNLean.Wielandt.RankOne.Products
warning: TNLean/Wielandt/RankOne/Products.lean:2:18: * '. All rights reserved.':
'Copyright (c) YYYY' should be followed by a space


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8813/9301] Replayed TNLean.Wielandt.SpanGrowth.CumulativeToWordSpan
warning: TNLean/Wielandt/SpanGrowth/CumulativeToWordSpan.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8814/9301] Replayed TNLean.MPS.ParentHamiltonian.IntersectionProperty
warning: TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8815/9301] Replayed TNLean.MPS.ParentHamiltonian.CyclicWindow
warning: TNLean/MPS/ParentHamiltonian/CyclicWindow.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8816/9301] Replayed TNLean.MPS.ParentHamiltonian.LocalSupport
warning: TNLean/MPS/ParentHamiltonian/LocalSupport.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8819/9301] Replayed TNLean.MPS.FundamentalTheorem.FiniteLength
warning: TNLean/MPS/FundamentalTheorem/FiniteLength.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8824/9301] Replayed TNLean.MPS.ParentHamiltonian.WrappingWindow
warning: TNLean/MPS/ParentHamiltonian/WrappingWindow.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8833/9301] Replayed TNLean.MPS.RFP.Defs
warning: TNLean/MPS/RFP/Defs.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8834/9301] Replayed TNLean.MPS.BNT.Basic
warning: TNLean/MPS/BNT/Basic.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8837/9301] Replayed TNLean.MPS.Periodic.Defs
warning: TNLean/MPS/Periodic/Defs.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Periodic/Defs.lean:10:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `open scoped Matrix BigOperators`.

Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Periodic/Defs.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Periodic/Defs.lean:10:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `/-!# Periodic MPS definitions

This file introduces the basic periodic MPS predicates and equivalence relations
used by the periodic form theory (arXiv:1708.00029, Section 2.1).
-/
`.

Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8838/9301] Replayed TNLean.Axioms.Beigi
warning: TNLean/Axioms/Beigi.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8839/9301] Replayed TNLean.MPS.Structure.BlockPermutation
warning: TNLean/MPS/Structure/BlockPermutation.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8840/9301] Replayed TNLean.PiAlgebra.Construction
warning: TNLean/PiAlgebra/Construction.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8841/9301] Replayed TNLean.PiAlgebra.FundamentalTheoremComplete
warning: TNLean/PiAlgebra/FundamentalTheoremComplete.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8842/9301] Replayed TNLean.MPS.ParentHamiltonian.Decorrelation
warning: TNLean/MPS/ParentHamiltonian/Decorrelation.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8848/9301] Replayed TNLean.MPS.Symmetry.Defs
warning: TNLean/MPS/Symmetry/Defs.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8849/9301] Replayed TNLean.MPS.Symmetry.GaugeUniqueness
warning: TNLean/MPS/Symmetry/GaugeUniqueness.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8850/9301] Replayed TNLean.MPS.Symmetry.OnSiteSymmetry
warning: TNLean/MPS/Symmetry/OnSiteSymmetry.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Symmetry/OnSiteSymmetry.lean:3:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `open scoped Matrix`.

Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Symmetry/OnSiteSymmetry.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Symmetry/OnSiteSymmetry.lean:3:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `namespace MPSTensor`.

Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Symmetry/OnSiteSymmetry.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Symmetry/OnSiteSymmetry.lean:3:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `variable {G : Type*} [Group G] {d D : ℕ}`.

Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Symmetry/OnSiteSymmetry.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Symmetry/OnSiteSymmetry.lean:3:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `/-- On-site symmetry data on the physical index:
`u` is a matrix-valued map on the group and `σ` is the physical-index action. -/
structure OnSiteSymmetry (G : Type*) [Group G] (d : ℕ) where
  u : G → Matrix (Fin d) (Fin d) ℂ
  σ : G → Fin d → Fin d`.

Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Symmetry/OnSiteSymmetry.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Symmetry/OnSiteSymmetry.lean:3:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `/-- Tensor twisted by the physical permutation action `σ` at group element `g`.

This is the index-permutation twist `A^{σ_g}` defined by
`(TwistedTensor S A g) i = A (S.σ g i)`. -/
def TwistedTensor (S : OnSiteSymmetry G d) (A : MPSTensor d D) (g : G) : MPSTensor d D := fun i => A (S.σ g i)`.

Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Symmetry/OnSiteSymmetry.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Symmetry/OnSiteSymmetry.lean:3:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `@[simp]
lemma TwistedTensor_apply (S : OnSiteSymmetry G d) (A : MPSTensor d D) (g : G) (i : Fin d) :
    TwistedTensor S A g i = A (S.σ g i) :=
  rfl`.

Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Symmetry/OnSiteSymmetry.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Symmetry/OnSiteSymmetry.lean:3:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `/-- Twisting by the identity is trivial when `σ 1 = id`. -/
@[simp]
lemma TwistedTensor_one (S : OnSiteSymmetry G d) (hσ1 : S.σ 1 = id) (A : MPSTensor d D) : TwistedTensor S A 1 = A :=
  by
  funext i
  simp [TwistedTensor, hσ1]`.

Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Symmetry/OnSiteSymmetry.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Symmetry/OnSiteSymmetry.lean:3:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `/-- Composition law for permutation twists:
if `σ (g * h) = σ g ∘ σ h`, then twisting by `g*h` equals twisting by `g` then `h`. -/
lemma TwistedTensor_mul (S : OnSiteSymmetry G d) (hσmul : ∀ g h : G, S.σ (g * h) = S.σ g ∘ S.σ h) (A : MPSTensor d D)
    (g h : G) : TwistedTensor S A (g * h) = TwistedTensor S (TwistedTensor S A g) h :=
  by
  funext i
  simp [TwistedTensor, hσmul, Function.comp]`.

Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Symmetry/OnSiteSymmetry.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Symmetry/OnSiteSymmetry.lean:3:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `end MPSTensor`.

Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Symmetry/OnSiteSymmetry.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Symmetry/OnSiteSymmetry.lean:3:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before ``.

Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8851/9301] Replayed TNLean.MPS.Symmetry.VirtualRepresentation
warning: TNLean/MPS/Symmetry/VirtualRepresentation.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8852/9301] Replayed TNLean.MPS.Symmetry.CocycleCoboundary
warning: TNLean/MPS/Symmetry/CocycleCoboundary.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8853/9301] Replayed TNLean.MPS.Symmetry.SymmetricMPS
warning: TNLean/MPS/Symmetry/SymmetricMPS.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8856/9301] Replayed TNLean.MPS.MPDO.Defs
warning: TNLean/MPS/MPDO/Defs.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8857/9301] Replayed TNLean.MPS.MPDO.VerticalCF
warning: TNLean/MPS/MPDO/VerticalCF.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8864/9301] Replayed TNLean.MPS.ParentHamiltonian.BlockIntersectionProperty
warning: TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8865/9301] Replayed TNLean.MPS.ParentHamiltonian.PGVWCCDEIdentities
warning: TNLean/MPS/ParentHamiltonian/PGVWCCDEIdentities.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8870/9301] Replayed TNLean.MPS.ParentHamiltonian.CyclicSubmoduleIteration
warning: TNLean/MPS/ParentHamiltonian/CyclicSubmoduleIteration.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8871/9301] Replayed TNLean.MPS.ParentHamiltonian.BlockSumGroundSpace
warning: TNLean/MPS/ParentHamiltonian/BlockSumGroundSpace.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8872/9301] Replayed TNLean.MPS.ParentHamiltonian.BlockDiagonalChainGroundSpace
warning: TNLean/MPS/ParentHamiltonian/BlockDiagonalChainGroundSpace.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8873/9301] Replayed TNLean.Algebra.BlockTriangularTrace
warning: TNLean/Algebra/BlockTriangularTrace.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8875/9301] Replayed TNLean.MPS.FundamentalTheorem.SectorWeightComparison
warning: TNLean/MPS/FundamentalTheorem/SectorWeightComparison.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8876/9301] Replayed TNLean.MPS.FundamentalTheorem.SectorBNT.Basic
warning: TNLean/MPS/FundamentalTheorem/SectorBNT/Basic.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8877/9301] Replayed TNLean.MPS.FundamentalTheorem.SectorBNT.EqualModulus
warning: TNLean/MPS/FundamentalTheorem/SectorBNT/EqualModulus.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8878/9301] Replayed TNLean.MPS.FundamentalTheorem.SectorBNT.Examples
warning: TNLean/MPS/FundamentalTheorem/SectorBNT/Examples.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8879/9301] Replayed TNLean.Wielandt.Primitivity.ToNormal
warning: TNLean/Wielandt/Primitivity/ToNormal.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8880/9301] Replayed TNLean.Wielandt.Primitivity.TracePairing
warning: TNLean/Wielandt/Primitivity/TracePairing.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8881/9301] Replayed TNLean.MPS.Irreducible.ScalarFixedPoint
warning: TNLean/MPS/Irreducible/ScalarFixedPoint.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8886/9301] Replayed TNLean.MPS.CanonicalForm.SectorComparison.CyclicSectorRelation
warning: TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorRelation.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorRelation.lean:7:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `open scoped Matrix BigOperators ComplexOrder MatrixOrder`.

Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorRelation.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorRelation.lean:7:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `/-!# Cyclic-sector relations for blocked tensors

A cyclic decomposition of the adjoint transfer map determines a sector
decomposition for the tensor obtained by blocking over one full period.  The
connection is made by comparing the blocked adjoint transfer map with the
corresponding power of the original adjoint transfer map.

An irreducible quantum channel has cyclic projections as in Wolf Chapter 6, and
periodic MPS blocks have the off-diagonal form and period-blocking behavior of
arXiv:1708.00029.  In the cyclic order used there, the relevant identities are
$$
  \mathcal E_A^*(P_u) = P_{u+1},\qquad
  A^i = \sum_u P_u A^i P_{u+1},\qquad
  C_u = P_u A^{[m]} P_u.
$$
Reversing the cyclic order gives the equivalent convention
$\mathcal E_A^*(P_{u+1}) = P_u$, which is the indexing used by the cyclic
iteration lemmas below.

## References

* [Wolf, *Quantum Channels & Operations*, Chapter 6]
* [De las Cuevas et al., arXiv:1708.00029, periodic-block decomposition]

## Tags

matrix product states, cyclic sectors, peripheral spectrum, blocking
-/
`.

Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8888/9301] Replayed TNLean.MPS.CanonicalForm.CyclicSectors
warning: TNLean/MPS/CanonicalForm/CyclicSectors.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8891/9301] Replayed TNLean.Wielandt.RankOne.Construction
warning: TNLean/Wielandt/RankOne/Construction.lean:2:18: * '. All rights reserved.':
'Copyright (c) YYYY' should be followed by a space


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8892/9301] Replayed TNLean.Wielandt.RankOne.Element
warning: TNLean/Wielandt/RankOne/Element.lean:2:18: * '. All rights reserved.':
'Copyright (c) YYYY' should be followed by a space


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8893/9301] Replayed TNLean.Wielandt.RankOne.Extraction
warning: TNLean/Wielandt/RankOne/Extraction.lean:2:18: * '. All rights reserved.':
'Copyright (c) YYYY' should be followed by a space


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8894/9301] Replayed TNLean.Wielandt.RectangularSpan.Ranges
warning: TNLean/Wielandt/RectangularSpan/Ranges.lean:2:18: * '. All rights reserved.':
'Copyright (c) YYYY' should be followed by a space


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8895/9301] Replayed TNLean.Wielandt.RectangularSpan.Basic
warning: TNLean/Wielandt/RectangularSpan/Basic.lean:2:18: * '. All rights reserved.':
'Copyright (c) YYYY' should be followed by a space


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8896/9301] Replayed TNLean.Wielandt.RankOne.SpanGrowth
warning: TNLean/Wielandt/RankOne/SpanGrowth.lean:2:18: * '. All rights reserved.':
'Copyright (c) YYYY' should be followed by a space


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8897/9301] Replayed TNLean.Wielandt.RectangularSpan.Growth
warning: TNLean/Wielandt/RectangularSpan/Growth.lean:2:18: * '. All rights reserved.':
'Copyright (c) YYYY' should be followed by a space


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8903/9301] Replayed TNLean.Wielandt.RectangularSpan.Universality
warning: TNLean/Wielandt/RectangularSpan/Universality.lean:2:18: * '. All rights reserved.':
'Copyright (c) YYYY' should be followed by a space


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8904/9301] Replayed TNLean.Wielandt.SpanGrowth.InvertibleWordSpan
warning: TNLean/Wielandt/SpanGrowth/InvertibleWordSpan.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8909/9301] Replayed TNLean.MPS.Periodic.SectorIrreducibility
warning: TNLean/MPS/Periodic/SectorIrreducibility.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8913/9301] Replayed TNLean.MPS.Periodic.ZGauge
warning: TNLean/MPS/Periodic/ZGauge.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8914/9301] Replayed TNLean.MPS.Periodic.Applications
warning: TNLean/MPS/Periodic/Applications.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8915/9301] Replayed TNLean.MPS.CanonicalForm.ProjectorClosure
warning: TNLean/MPS/CanonicalForm/ProjectorClosure.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8916/9301] Replayed TNLean.MPS.CanonicalForm.ProjectorClosureDecomposition
warning: TNLean/MPS/CanonicalForm/ProjectorClosureDecomposition.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8917/9301] Replayed TNLean.MPS.CanonicalForm.Definitions
warning: TNLean/MPS/CanonicalForm/Definitions.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8918/9301] Replayed TNLean.MPS.CanonicalForm.NormalCommutant
warning: TNLean/MPS/CanonicalForm/NormalCommutant.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8923/9301] Replayed TNLean.MPS.Periodic.GlobalGauge
warning: TNLean/MPS/Periodic/GlobalGauge.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8924/9301] Replayed TNLean.PiAlgebra.TIReduction
warning: TNLean/PiAlgebra/TIReduction.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8925/9301] Replayed TNLean.PiAlgebra.GlobalSymmetry
warning: TNLean/PiAlgebra/GlobalSymmetry.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8926/9301] Replayed TNLean.MPS.MPDO.AreaLaw
warning: TNLean/MPS/MPDO/AreaLaw.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8927/9301] Replayed TNLean.MPS.MPDO.MutualInfoMonotone
warning: TNLean/MPS/MPDO/MutualInfoMonotone.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8928/9301] Replayed TNLean.MPS.MPDO.PureAreaLaw
warning: TNLean/MPS/MPDO/PureAreaLaw.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8929/9301] Replayed TNLean.MPS.MPDO.PureRFPSAL
warning: TNLean/MPS/MPDO/PureRFPSAL.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8930/9301] Replayed TNLean.MPS.MPDO.InvariantProjection
warning: TNLean/MPS/MPDO/InvariantProjection.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8931/9301] Replayed TNLean.MPS.MPDO.ZCL
warning: TNLean/MPS/MPDO/ZCL.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8932/9301] Replayed TNLean.MPS.MPDO.SectorTrace
warning: TNLean/MPS/MPDO/SectorTrace.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8936/9301] Replayed TNLean.MPS.MPDO.BiCFDerivation
warning: TNLean/MPS/MPDO/BiCFDerivation.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8937/9301] Replayed TNLean.MPS.MPDO.RFP
warning: TNLean/MPS/MPDO/RFP.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8938/9301] Replayed TNLean.MPS.MPDO.KrausCPTP
warning: TNLean/MPS/MPDO/KrausCPTP.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8939/9301] Replayed TNLean.MPS.MPDO.RFPViaTS
warning: TNLean/MPS/MPDO/RFPViaTS.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8940/9301] Replayed TNLean.MPS.MPDO.PRFP
warning: TNLean/MPS/MPDO/PRFP.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8941/9301] Replayed TNLean.MPS.MPDO.LocalPurificationRFP
warning: TNLean/MPS/MPDO/LocalPurificationRFP.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8942/9301] Replayed TNLean.MPS.MPDO.SimpleLocalStructure
warning: TNLean/MPS/MPDO/SimpleLocalStructure.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8943/9301] Replayed TNLean.MPS.MPDO.EtaPreparation
warning: TNLean/MPS/MPDO/EtaPreparation.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8944/9301] Replayed TNLean.MPS.MPDO.RFPSubspinMaps
warning: TNLean/MPS/MPDO/RFPSubspinMaps.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8945/9301] Replayed TNLean.MPS.MPDO.HayashiSectorComparison
warning: TNLean/MPS/MPDO/HayashiSectorComparison.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8946/9301] Replayed TNLean.MPS.MPDO.SectorFactorization
warning: TNLean/MPS/MPDO/SectorFactorization.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8949/9301] Replayed TNLean.MPS.MPDO.SectorPairingTransfer
warning: TNLean/MPS/MPDO/SectorPairingTransfer.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8950/9301] Replayed TNLean.MPS.MPDO.SectorEtaContraction
warning: TNLean/MPS/MPDO/SectorEtaContraction.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8951/9301] Replayed TNLean.MPS.MPDO.SectorEtaOperator
warning: TNLean/MPS/MPDO/SectorEtaOperator.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8952/9301] Replayed TNLean.MPS.RFP.ZeroCorrelationLength
warning: TNLean/MPS/RFP/ZeroCorrelationLength.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8953/9301] Replayed TNLean.MPS.MPDO.PureRecovery
warning: TNLean/MPS/MPDO/PureRecovery.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8954/9301] Replayed TNLean.MPS.MPDO.FusionIsometries
warning: TNLean/MPS/MPDO/FusionIsometries.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8964/9301] Replayed TNLean.MPS.MPDO.CommutingForm
warning: TNLean/MPS/MPDO/CommutingForm.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8965/9301] Replayed TNLean.MPS.MPDO.CommutingFormBridge
warning: TNLean/MPS/MPDO/CommutingFormBridge.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8967/9301] Replayed TNLean.MPS.Examples.ZMod2
warning: TNLean/MPS/Examples/ZMod2.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8968/9301] Replayed TNLean.MPS.Examples.AKLT
warning: TNLean/MPS/Examples/AKLT.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8969/9301] Replayed TNLean.MPS.Examples.AKLTCorrelation
warning: TNLean/MPS/Examples/AKLTCorrelation.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8970/9301] Replayed TNLean.MPS.Examples.AKLTRotation
warning: TNLean/MPS/Examples/AKLTRotation.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8971/9301] Replayed TNLean.MPS.Examples.GHZ
warning: TNLean/MPS/Examples/GHZ.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8972/9301] Replayed TNLean.MPS.Examples.EvenParity
warning: TNLean/MPS/Examples/EvenParity.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8974/9301] Replayed TNLean.MPS.Examples.MajumdarGhosh
warning: TNLean/MPS/Examples/MajumdarGhosh.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8976/9301] Replayed TNLean.MPS.RFP.Decorrelation
warning: TNLean/MPS/RFP/Decorrelation.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8977/9301] Replayed TNLean.Wielandt.RankOne.Manufacture
warning: TNLean/Wielandt/RankOne/Manufacture.lean:2:18: * '. All rights reserved.':
'Copyright (c) YYYY' should be followed by a space


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8978/9301] Replayed TNLean.Wielandt.RankOne.BoundedWord
warning: TNLean/Wielandt/RankOne/BoundedWord.lean:2:18: * '. All rights reserved.':
'Copyright (c) YYYY' should be followed by a space


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8979/9301] Replayed TNLean.Wielandt.RankOne.ExtractionFull
warning: TNLean/Wielandt/RankOne/ExtractionFull.lean:2:18: * '. All rights reserved.':
'Copyright (c) YYYY' should be followed by a space


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8980/9301] Replayed TNLean.Wielandt.Primitivity.ImpliesIrreducible
warning: TNLean/Wielandt/Primitivity/ImpliesIrreducible.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/Wielandt/Primitivity/ImpliesIrreducible.lean:79:4: 'change (1 - P) * (E ^ (n + 1)) (P * X * P) = 0' tactic does nothing

Note: This linter can be disabled with `set_option linter.unusedTactic false`
⚠ [8981/9301] Replayed TNLean.Channel.Peripheral.Cycles
warning: TNLean/Channel/Peripheral/Cycles.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8982/9301] Replayed TNLean.Channel.Peripheral.MultiCycleDecomposition
warning: TNLean/Channel/Peripheral/MultiCycleDecomposition.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8983/9301] Replayed TNLean.Channel.NormalForm
warning: TNLean/Channel/NormalForm.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8985/9301] Replayed TNLean.Channel.LorentzNormalForm
warning: TNLean/Channel/LorentzNormalForm.lean:624:4: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/Channel/LorentzNormalForm.lean:828:8: declaration uses `sorry`
⚠ [8986/9301] Replayed TNLean.Channel.WolfChapter2Index
warning: TNLean/Channel/WolfChapter2Index.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8988/9301] Replayed TNLean.Channel.Semigroup.Perturbation
warning: TNLean/Channel/Semigroup/Perturbation.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8989/9301] Replayed TNLean.Channel.Semigroup.KossakowskiForm
warning: TNLean/Channel/Semigroup/KossakowskiForm.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8990/9301] Replayed TNLean.Channel.Semigroup.LiouvillianKernel
warning: TNLean/Channel/Semigroup/LiouvillianKernel.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/Channel/Semigroup/LiouvillianKernel.lean:109:6: 'change star Complex.I • F.H = (-Complex.I) • F.H' tactic does nothing

Note: This linter can be disabled with `set_option linter.unusedTactic false`
warning: TNLean/Channel/Semigroup/LiouvillianKernel.lean:111:6: 'change star (1 / 2 : ℂ) • S = (1 / 2 : ℂ) • S' tactic does nothing

Note: This linter can be disabled with `set_option linter.unusedTactic false`
⚠ [8992/9301] Replayed TNLean.PEPS.Defs
warning: TNLean/PEPS/Defs.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8993/9301] Replayed TNLean.PEPS.InjectiveRegion
warning: TNLean/PEPS/InjectiveRegion.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8994/9301] Replayed TNLean.PEPS.InjectiveRegionContraction
warning: TNLean/PEPS/InjectiveRegionContraction.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8995/9301] Replayed TNLean.PEPS.FiniteKernelDescent
warning: TNLean/PEPS/FiniteKernelDescent.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8996/9301] Replayed TNLean.PEPS.VirtualInsertion
warning: TNLean/PEPS/VirtualInsertion.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8997/9301] Replayed TNLean.PEPS.SingletonRegion
warning: TNLean/PEPS/SingletonRegion.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [8998/9301] Replayed TNLean.PEPS.Blocking
warning: TNLean/PEPS/Blocking.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9001/9301] Replayed TNLean.PEPS.EdgeMiddlePhysical
warning: TNLean/PEPS/EdgeMiddlePhysical.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9002/9301] Replayed TNLean.PEPS.VertexComplement.Basic
warning: TNLean/PEPS/VertexComplement/Basic.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9003/9301] Replayed TNLean.PEPS.VertexComplement.KernelDescent
warning: TNLean/PEPS/VertexComplement/KernelDescent.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9004/9301] Replayed TNLean.PEPS.RegionBlock.Basic
warning: TNLean/PEPS/RegionBlock/Basic.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9005/9301] Replayed TNLean.PEPS.RegionBlock.KernelDescent
warning: TNLean/PEPS/RegionBlock/KernelDescent.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9006/9301] Replayed TNLean.PEPS.RegionBlock.UnionClosure
warning: TNLean/PEPS/RegionBlock/UnionClosure.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9007/9301] Replayed TNLean.PEPS.NormalEdgeBlockingData
warning: TNLean/PEPS/NormalEdgeBlockingData.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9008/9301] Replayed TNLean.PEPS.NormalBlocking
warning: TNLean/PEPS/NormalBlocking.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9010/9301] Replayed TNLean.PEPS.TwoInjectiveComparison
warning: TNLean/PEPS/TwoInjectiveComparison.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9011/9301] Replayed TNLean.PEPS.NormalEdgeGauge
warning: TNLean/PEPS/NormalEdgeGauge.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9012/9301] Replayed TNLean.PEPS.IdentityInsertion
warning: TNLean/PEPS/IdentityInsertion.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9013/9301] Replayed TNLean.PEPS.InsertionRealization
warning: TNLean/PEPS/InsertionRealization.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9014/9301] Replayed TNLean.PEPS.InsertionCoefficientRealization
warning: TNLean/PEPS/InsertionCoefficientRealization.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9015/9301] Replayed TNLean.PEPS.InsertionAlgebra
warning: TNLean/PEPS/InsertionAlgebra.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9016/9301] Replayed TNLean.PEPS.EdgeGaugeExtraction
warning: TNLean/PEPS/EdgeGaugeExtraction.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9017/9301] Replayed TNLean.PEPS.EdgeGaugeFamily
warning: TNLean/PEPS/EdgeGaugeFamily.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9018/9301] Replayed TNLean.PEPS.LocalGauge
warning: TNLean/PEPS/LocalGauge.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9022/9301] Replayed TNLean.PEPS.RegionBlock.Insertion
warning: TNLean/PEPS/RegionBlock/Insertion.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9023/9301] Replayed TNLean.PEPS.SquareLatticeGraph
warning: TNLean/PEPS/SquareLatticeGraph.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9024/9301] Replayed TNLean.PEPS.TorusLatticeGraph
warning: TNLean/PEPS/TorusLatticeGraph.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/PEPS/TorusLatticeGraph.lean:110:8: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/PEPS/TorusLatticeGraph.lean:115:8: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
⚠ [9025/9301] Replayed TNLean.PEPS.TorusTranslation
warning: TNLean/PEPS/TorusTranslation.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9026/9301] Replayed TNLean.PEPS.IsoTransport
warning: TNLean/PEPS/IsoTransport.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9027/9301] Replayed TNLean.PEPS.RegionTransport
warning: TNLean/PEPS/RegionTransport.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9028/9301] Replayed TNLean.PEPS.RegionBlock.Algebra
warning: TNLean/PEPS/RegionBlock/Algebra.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9029/9301] Replayed TNLean.PEPS.EdgeScalarSolve
warning: TNLean/PEPS/EdgeScalarSolve.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/PEPS/EdgeScalarSolve.lean:228:0: automatically included section variable(s) unused in theorem `TNLean.PEPS.v0Inc_subsingleton`:
  [Fintype V]
  [DecidableRel G.Adj]
consider restructuring your `variable` declarations so that the variables are not in scope or explicitly omit them:
  omit [Fintype V] [DecidableRel G.Adj] in theorem ...

Note: This linter can be disabled with `set_option linter.unusedSectionVars false`
warning: TNLean/PEPS/EdgeScalarSolve.lean:226:0: `v0Inc_subsingleton` does not use the following hypothesis in its type:
  • [DecidableRel G.Adj] (#5)

Consider removing this hypothesis and using `classical` in the proof instead. For terms, consider using `open scoped Classical in` at the term level (not the command level).

Note: This linter can be disabled with `set_option linter.unusedDecidableInType false`
warning: TNLean/PEPS/EdgeScalarSolve.lean:226:0: `v0Inc_subsingleton` does not use the following hypothesis in its type:
  • [Fintype V] (#2)

Consider replacing this hypothesis with the corresponding instance of `Finite` and using `Fintype.ofFinite` in the proof, or removing it entirely.

Note: This linter can be disabled with `set_option linter.unusedFintypeInType false`
⚠ [9030/9301] Replayed TNLean.PEPS.TensorFactorScalar
warning: TNLean/PEPS/TensorFactorScalar.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9031/9301] Replayed TNLean.PEPS.FundamentalTheorem
warning: TNLean/PEPS/FundamentalTheorem.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9032/9301] Replayed TNLean.PEPS.NormalFundamentalTheorem
warning: TNLean/PEPS/NormalFundamentalTheorem.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9033/9301] Replayed TNLean.PEPS.RegionBlock.Recovery
warning: TNLean/PEPS/RegionBlock/Recovery.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9034/9301] Replayed TNLean.PEPS.RegionBlock.Realization
warning: TNLean/PEPS/RegionBlock/Realization.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9035/9301] Replayed TNLean.PEPS.RegionBlock.Recovery2
warning: TNLean/PEPS/RegionBlock/Recovery2.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9036/9301] Replayed TNLean.PEPS.TorusTranslationInvariant
warning: TNLean/PEPS/TorusTranslationInvariant.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9037/9301] Replayed TNLean.PEPS.TorusRectangleRegion
warning: TNLean/PEPS/TorusRectangleRegion.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9038/9301] Replayed TNLean.PEPS.TorusEdgeBlockingRegion
warning: TNLean/PEPS/TorusEdgeBlockingRegion.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9039/9301] Replayed TNLean.PEPS.TorusRowColumnReductionObstruction
warning: TNLean/PEPS/TorusRowColumnReductionObstruction.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9040/9301] Replayed TNLean.PEPS.RegionBlock.GaugeBridge
warning: TNLean/PEPS/RegionBlock/GaugeBridge.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9041/9301] Replayed TNLean.PEPS.NormalEdgeComplementCover
warning: TNLean/PEPS/NormalEdgeComplementCover.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9042/9301] Replayed TNLean.PEPS.NormalEdgeBlockingCoordinate
warning: TNLean/PEPS/NormalEdgeBlockingCoordinate.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9043/9301] Replayed TNLean.PEPS.NormalEdgeBlockingTranslated
warning: TNLean/PEPS/NormalEdgeBlockingTranslated.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9044/9301] Replayed TNLean.PEPS.NormalRectangleTiling
warning: TNLean/PEPS/NormalRectangleTiling.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9045/9301] Replayed TNLean.PEPS.NormalEdgeBlockingInterior
warning: TNLean/PEPS/NormalEdgeBlockingInterior.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9046/9301] Replayed TNLean.PEPS.NormalSquarePEPSBlocking
warning: TNLean/PEPS/NormalSquarePEPSBlocking.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9047/9301] Replayed TNLean.PEPS.NormalEdgeBlockingMargins
warning: TNLean/PEPS/NormalEdgeBlockingMargins.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9048/9301] Replayed TNLean.PEPS.PhysicalToVirtualCounterexample
warning: TNLean/PEPS/PhysicalToVirtualCounterexample.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9049/9301] Replayed TNLean.PEPS.GaugeConsistencyConnectivityCounterexample
warning: TNLean/PEPS/GaugeConsistencyConnectivityCounterexample.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9050/9301] Replayed TNLean.PEPS.FundamentalTheorem.Uniqueness
warning: TNLean/PEPS/FundamentalTheorem/Uniqueness.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9051/9301] Replayed TNLean.PEPS.RegionComplementComparison
warning: TNLean/PEPS/RegionComplementComparison.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9052/9301] Replayed TNLean.PEPS.RegionBlock.InsertSplit
warning: TNLean/PEPS/RegionBlock/InsertSplit.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9053/9301] Replayed TNLean.PEPS.RegionBlock.InsertResidual
warning: TNLean/PEPS/RegionBlock/InsertResidual.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/PEPS/RegionBlock/InsertResidual.lean:535:4: 'beta_reduce' tactic does nothing

Note: This linter can be disabled with `set_option linter.unusedTactic false`
⚠ [9054/9301] Replayed TNLean.PEPS.RegionBlock.ScalarExtraction
warning: TNLean/PEPS/RegionBlock/ScalarExtraction.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9055/9301] Replayed TNLean.PEPS.RegionBlock.GaugeInjectivity
warning: TNLean/PEPS/RegionBlock/GaugeInjectivity.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9056/9301] Replayed TNLean.PEPS.RegionBlock.GaugeInjectivity2
warning: TNLean/PEPS/RegionBlock/GaugeInjectivity2.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9057/9301] Replayed TNLean.PEPS.RegionBlock.ReindexInjectivity
warning: TNLean/PEPS/RegionBlock/ReindexInjectivity.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9058/9301] Replayed TNLean.PEPS.TorusCornerRegion
warning: TNLean/PEPS/TorusCornerRegion.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9059/9301] Replayed TNLean.PEPS.NormalSquareComparisonRegion
warning: TNLean/PEPS/NormalSquareComparisonRegion.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9060/9301] Replayed TNLean.PEPS.NormalPairBlocking
warning: TNLean/PEPS/NormalPairBlocking.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9061/9301] Replayed TNLean.PEPS.CycleArcRegion
warning: TNLean/PEPS/CycleArcRegion.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9062/9301] Replayed TNLean.PEPS.CycleMPSTensor
warning: TNLean/PEPS/CycleMPSTensor.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9063/9301] Replayed TNLean.PEPS.CycleMPSInjectivity
warning: TNLean/PEPS/CycleMPSInjectivity.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9064/9301] Replayed TNLean.PEPS.CycleMPSWordTransport
warning: TNLean/PEPS/CycleMPSWordTransport.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9065/9301] Replayed TNLean.PEPS.CycleMPSChainArc
warning: TNLean/PEPS/CycleMPSChainArc.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/PEPS/CycleMPSChainArc.lean:315:10: 'change ((s + 1 + k.val : ℕ) : Fin n) = g k.succ' tactic does nothing

Note: This linter can be disabled with `set_option linter.unusedTactic false`
⚠ [9066/9301] Replayed TNLean.PEPS.CycleMPSChainOverlapWindow
warning: TNLean/PEPS/CycleMPSChainOverlapWindow.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9067/9301] Replayed TNLean.PEPS.CycleMPSOverlapWindow
warning: TNLean/PEPS/CycleMPSOverlapWindow.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9068/9301] Replayed TNLean.PEPS.CycleMPSOverlapInsertion
warning: TNLean/PEPS/CycleMPSOverlapInsertion.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9069/9301] Replayed TNLean.PEPS.CycleMPSChainOverlapInsertion
warning: TNLean/PEPS/CycleMPSChainOverlapInsertion.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9070/9301] Replayed TNLean.PEPS.CycleMPSChainOverlapCapstone
warning: TNLean/PEPS/CycleMPSChainOverlapCapstone.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9072/9303] Replayed TNLean.PEPS.RegionBlock.Recovery3
warning: TNLean/PEPS/RegionBlock/Recovery3.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9073/9303] Replayed TNLean.PEPS.RegionBlock.Recovery4
warning: TNLean/PEPS/RegionBlock/Recovery4.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9074/9303] Replayed TNLean.PEPS.RegionBlock.Recovery5
warning: TNLean/PEPS/RegionBlock/Recovery5.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9075/9303] Replayed TNLean.PEPS.RegionBlock.Recovery6
warning: TNLean/PEPS/RegionBlock/Recovery6.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9076/9303] Replayed TNLean.PEPS.RegionBlock.Recovery7
warning: TNLean/PEPS/RegionBlock/Recovery7.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9077/9303] Replayed TNLean.PEPS.RegionBlock.Recovery8
warning: TNLean/PEPS/RegionBlock/Recovery8.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9078/9303] Replayed TNLean.PEPS.RegionBlock.Recovery9
warning: TNLean/PEPS/RegionBlock/Recovery9.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9079/9303] Replayed TNLean.PEPS.RegionBlock.Recovery10
warning: TNLean/PEPS/RegionBlock/Recovery10.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9080/9303] Replayed TNLean.PEPS.RegionBlock.Recovery11
warning: TNLean/PEPS/RegionBlock/Recovery11.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9081/9303] Replayed TNLean.PEPS.RegionBlock.BlockRangeCoincidence
warning: TNLean/PEPS/RegionBlock/BlockRangeCoincidence.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9082/9303] Replayed TNLean.PEPS.RegionBlock.ThreeBlockResonate
warning: TNLean/PEPS/RegionBlock/ThreeBlockResonate.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9083/9303] Replayed TNLean.PEPS.RegionBlock.ThreeBlockResonate2
warning: TNLean/PEPS/RegionBlock/ThreeBlockResonate2.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9084/9303] Replayed TNLean.PEPS.RegionBlock.ThreeBlockReconcile
warning: TNLean/PEPS/RegionBlock/ThreeBlockReconcile.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9085/9303] Replayed TNLean.PEPS.RegionBlock.UnionInjectivity
warning: TNLean/PEPS/RegionBlock/UnionInjectivity.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9086/9303] Replayed TNLean.PEPS.RegionBlock.RegionReconcile
warning: TNLean/PEPS/RegionBlock/RegionReconcile.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9087/9303] Replayed TNLean.PEPS.RegionBlock.BlockCoeffTransfer
warning: TNLean/PEPS/RegionBlock/BlockCoeffTransfer.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9088/9303] Replayed TNLean.PEPS.RegionBlock.ThreeBlockTransfer
warning: TNLean/PEPS/RegionBlock/ThreeBlockTransfer.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9089/9303] Replayed TNLean.PEPS.RegionBlock.CoarseThreeSite
warning: TNLean/PEPS/RegionBlock/CoarseThreeSite.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9090/9303] Replayed TNLean.PEPS.RegionBlock.CoarseThreeSite2
warning: TNLean/PEPS/RegionBlock/CoarseThreeSite2.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9091/9303] Replayed TNLean.PEPS.RegionTransportData
warning: TNLean/PEPS/RegionTransportData.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9092/9303] Replayed TNLean.PEPS.RegionBlock.UnionInjectivityGeneral
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneral.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9093/9303] Replayed TNLean.PEPS.RegionBlock.UnionInjectivityGeneralBlue
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneralBlue.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9094/9303] Replayed TNLean.PEPS.RegionBlock.UnionInjectivityGeneral2
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneral2.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9095/9303] Replayed TNLean.PEPS.RegionBlock.UnionInjectivityOverlap
warning: TNLean/PEPS/RegionBlock/UnionInjectivityOverlap.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9096/9303] Replayed TNLean.PEPS.RegionBlock.UnionInjectivityOverlap2
warning: TNLean/PEPS/RegionBlock/UnionInjectivityOverlap2.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9097/9303] Replayed TNLean.PEPS.RegionBlock.UnionInjectivityOverlap3
warning: TNLean/PEPS/RegionBlock/UnionInjectivityOverlap3.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9098/9303] Replayed TNLean.PEPS.RegionBlock.UnionInjectivityOverlap3b
warning: TNLean/PEPS/RegionBlock/UnionInjectivityOverlap3b.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9099/9303] Replayed TNLean.PEPS.RegionBlock.UnionInjectivityOverlap4
warning: TNLean/PEPS/RegionBlock/UnionInjectivityOverlap4.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9100/9303] Replayed TNLean.PEPS.RegionBlock.UnionInjectivityOverlap5
warning: TNLean/PEPS/RegionBlock/UnionInjectivityOverlap5.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9101/9303] Replayed TNLean.PEPS.RegionTransportInsertion
warning: TNLean/PEPS/RegionTransportInsertion.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9102/9303] Replayed TNLean.PEPS.TorusBlockingData
warning: TNLean/PEPS/TorusBlockingData.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9103/9303] Replayed TNLean.PEPS.RegionTransferCovariance
warning: TNLean/PEPS/RegionTransferCovariance.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9104/9303] Replayed TNLean.PEPS.SingletonEdgeBlockingData
warning: TNLean/PEPS/SingletonEdgeBlockingData.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9105/9303] Replayed TNLean.PEPS.TorusEdgeBlockingCrossing
warning: TNLean/PEPS/TorusEdgeBlockingCrossing.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9106/9303] Replayed TNLean.PEPS.TorusWindowRegion
warning: TNLean/PEPS/TorusWindowRegion.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9107/9303] Replayed TNLean.PEPS.TorusWindowComplement
warning: TNLean/PEPS/TorusWindowComplement.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9108/9303] Replayed TNLean.PEPS.TorusWindowSingleCrossingObstruction
warning: TNLean/PEPS/TorusWindowSingleCrossingObstruction.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9109/9303] Replayed TNLean.PEPS.TorusDeformedWindow
warning: TNLean/PEPS/TorusDeformedWindow.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9110/9303] Replayed TNLean.PEPS.TorusWindowChain
warning: TNLean/PEPS/TorusWindowChain.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9111/9303] Replayed TNLean.PEPS.TorusWindowFamily
warning: TNLean/PEPS/TorusWindowFamily.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9112/9303] Replayed TNLean.PEPS.TorusWindowFamilyVertical
warning: TNLean/PEPS/TorusWindowFamilyVertical.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9113/9303] Replayed TNLean.PEPS.TorusWindowChain2
warning: TNLean/PEPS/TorusWindowChain2.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9114/9303] Replayed TNLean.PEPS.TorusWindowChain3
warning: TNLean/PEPS/TorusWindowChain3.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9115/9303] Replayed TNLean.PEPS.TorusWindowChain4
warning: TNLean/PEPS/TorusWindowChain4.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9116/9303] Replayed TNLean.PEPS.TorusWindowChain5
warning: TNLean/PEPS/TorusWindowChain5.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9117/9303] Replayed TNLean.PEPS.TorusWindowChain6
warning: TNLean/PEPS/TorusWindowChain6.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9118/9303] Replayed TNLean.PEPS.TorusWindowExtraction
warning: TNLean/PEPS/TorusWindowExtraction.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9119/9303] Replayed TNLean.PEPS.TorusWindowFamilyCrossing
warning: TNLean/PEPS/TorusWindowFamilyCrossing.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9120/9303] Replayed TNLean.PEPS.TorusWindowPeel
warning: TNLean/PEPS/TorusWindowPeel.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9121/9303] Replayed TNLean.PEPS.TorusWindowPeel2
warning: TNLean/PEPS/TorusWindowPeel2.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9122/9303] Replayed TNLean.PEPS.TorusWindowPeel3
warning: TNLean/PEPS/TorusWindowPeel3.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9123/9303] Replayed TNLean.PEPS.RegionBlock.AbsorbedEquality
warning: TNLean/PEPS/RegionBlock/AbsorbedEquality.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9124/9303] Replayed TNLean.PEPS.TorusWindowPeel4
warning: TNLean/PEPS/TorusWindowPeel4.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9125/9303] Replayed TNLean.PEPS.TorusWindowBondTransport
warning: TNLean/PEPS/TorusWindowBondTransport.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9126/9303] Replayed TNLean.PEPS.TorusWindowBondUniform
warning: TNLean/PEPS/TorusWindowBondUniform.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/PEPS/TorusWindowBondUniform.lean:5:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `open scoped Matrix`.

Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/PEPS/TorusWindowBondUniform.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/PEPS/TorusWindowBondUniform.lean:5:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `/-!# The uniform interior-bond product of the staircase windows under translation invariance

The two-dimensional strengthening of the normal PEPS Fundamental Theorem
(arXiv:1804.04964, the corollary at lines 2297--2318 of `Papers/1804.04964/paper_normal.tex`) is the
strengthening of the *torus* Theorem 3, whose tensors are translation invariant
(`IsTorusTranslationInvariant`).  This file records the consequence of that translation invariance
that the per-consecutive-window bond transport
`horizontalStaircaseConsecutiveWindow_bondTransport_extend_eq`
(`TNLean/PEPS/TorusWindowBondTransport.lean`) needs to glue into a single common-state family: every
staircase window `W_j` has the *same* interior-bond product `regionInteriorBondProd`.

## The mechanism

Each staircase window is an `L × K` cyclic rectangle `torusArcRectangle`, and any two such
rectangles of the same dimensions are translates of one another.  The interior-bond product is the
product of the bond dimensions over the edges interior to the region (the non-boundary edges); a
translation carries the interior edges of one rectangle bijectively onto those of its translate
(`regionInteriorBondProd_map`, the edge action reindexing the product), and a translation-invariant
tensor has equal bond dimensions on an edge and its translate
(`bondDim_translateEdge_of_translationInvariant`).  So the interior-bond product is invariant under
translation (`regionInteriorBondProd_translate_of_translationInvariant`), hence independent of the
rectangle's start vertex (`regionInteriorBondProd_torusArcRectangle_eq`), hence equal for every
window of the staircase (`regionInteriorBondProd_staircaseWindow_eq`).

This is the translation-invariance input that turns the neighbour-dependent rescaling of the
per-step bond transport into a uniform one: the per-step transport scales window `W_j` by
`regionInteriorBondProd W_{j+1}` and `W_{j+1}` by `regionInteriorBondProd W_j`, and under
translation invariance both equal one common constant, so the rescalings agree across the whole
chain and the per-step transports glue into a single common-state family.

## References

* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
  generating the same state*, arXiv:1804.04964, the corollary at lines 2297--2318 of
  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964); the filled-in derivation
  in `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 1.
-/
`.

Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9127/9303] Replayed TNLean.PEPS.NormalEdgeSingleCrossing
warning: TNLean/PEPS/NormalEdgeSingleCrossing.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9128/9303] Replayed TNLean.PEPS.RegionBlock.CoarseThreeSite3
warning: TNLean/PEPS/RegionBlock/CoarseThreeSite3.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9129/9303] Replayed TNLean.PEPS.RegionBlock.CoarseThreeSite4
warning: TNLean/PEPS/RegionBlock/CoarseThreeSite4.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9130/9303] Replayed TNLean.PEPS.RegionBlock.CoarseThreeSite5
warning: TNLean/PEPS/RegionBlock/CoarseThreeSite5.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9131/9303] Replayed TNLean.PEPS.RegionBlock.CoarseThreeSite6
warning: TNLean/PEPS/RegionBlock/CoarseThreeSite6.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9132/9303] Replayed TNLean.PEPS.RegionBlock.CoarseThreeSite7
warning: TNLean/PEPS/RegionBlock/CoarseThreeSite7.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9133/9303] Replayed TNLean.PEPS.RegionBlock.CoarseThreeSite8
warning: TNLean/PEPS/RegionBlock/CoarseThreeSite8.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9134/9303] Replayed TNLean.PEPS.RegionBlock.CoarseThreeSite9
warning: TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9135/9303] Replayed TNLean.PEPS.RegionBlock.CoarseThreeSite10
warning: TNLean/PEPS/RegionBlock/CoarseThreeSite10.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9136/9303] Replayed TNLean.PEPS.RegionBlock.CoarseThreeSite11
warning: TNLean/PEPS/RegionBlock/CoarseThreeSite11.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9137/9303] Replayed TNLean.PEPS.CoherentFrameInstance
warning: TNLean/PEPS/CoherentFrameInstance.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9138/9303] Replayed TNLean.PEPS.CoherentFrameInstance2
warning: TNLean/PEPS/CoherentFrameInstance2.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9139/9303] Replayed TNLean.PEPS.NormalEdgeGaugeFamily
warning: TNLean/PEPS/NormalEdgeGaugeFamily.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9140/9303] Replayed TNLean.PEPS.TorusEdgeGauge
warning: TNLean/PEPS/TorusEdgeGauge.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9141/9303] Replayed TNLean.PEPS.TorusEdgeGaugeCovariance
warning: TNLean/PEPS/TorusEdgeGaugeCovariance.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9142/9303] Replayed TNLean.PEPS.TorusConjCovarianceFamily
warning: TNLean/PEPS/TorusConjCovarianceFamily.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9143/9303] Replayed TNLean.PEPS.TorusWindowWitness
warning: TNLean/PEPS/TorusWindowWitness.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9144/9303] Replayed TNLean.PEPS.TorusWindowMult
warning: TNLean/PEPS/TorusWindowMult.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9145/9303] Replayed TNLean.PEPS.TorusWindowBondLocal
warning: TNLean/PEPS/TorusWindowBondLocal.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9146/9303] Replayed TNLean.PEPS.TorusWindowRealizes
warning: TNLean/PEPS/TorusWindowRealizes.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9147/9303] Replayed TNLean.PEPS.TorusRectangleReferenceData
warning: TNLean/PEPS/TorusRectangleReferenceData.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9148/9303] Replayed TNLean.PEPS.TorusRectangleGauge
warning: TNLean/PEPS/TorusRectangleGauge.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9149/9303] Replayed TNLean.PEPS.TorusReferenceBlockingData
warning: TNLean/PEPS/TorusReferenceBlockingData.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9150/9303] Replayed TNLean.PEPS.TorusWitnessTransport
warning: TNLean/PEPS/TorusWitnessTransport.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9151/9303] Replayed TNLean.PEPS.TorusWitnessTranslate
warning: TNLean/PEPS/TorusWitnessTranslate.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9152/9303] Replayed TNLean.PEPS.TorusWitnessCapstone
warning: TNLean/PEPS/TorusWitnessCapstone.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9153/9303] Replayed TNLean.PEPS.RegionScalarCondition
warning: TNLean/PEPS/RegionScalarCondition.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9154/9303] Replayed TNLean.PEPS.RegionBlock.ProportionalityFromAbsorbed
warning: TNLean/PEPS/RegionBlock/ProportionalityFromAbsorbed.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9155/9303] Replayed TNLean.PEPS.TorusFundamentalTheorem
warning: TNLean/PEPS/TorusFundamentalTheorem.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9156/9303] Replayed TNLean.PEPS.TorusEdgeAbsorbed
warning: TNLean/PEPS/TorusEdgeAbsorbed.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9157/9303] Replayed TNLean.PEPS.TorusAbsorbedCovariance
warning: TNLean/PEPS/TorusAbsorbedCovariance.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9158/9303] Replayed TNLean.PEPS.TorusCovariantAbsorbedFamily
warning: TNLean/PEPS/TorusCovariantAbsorbedFamily.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9159/9303] Replayed TNLean.PEPS.TorusGaugedWeightCovariance
warning: TNLean/PEPS/TorusGaugedWeightCovariance.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9160/9303] Replayed TNLean.PEPS.RegionBlock.UnionInjectivityOverlap6
warning: TNLean/PEPS/RegionBlock/UnionInjectivityOverlap6.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9161/9303] Replayed TNLean.PEPS.NormalSquareInjectivity
warning: TNLean/PEPS/NormalSquareInjectivity.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9162/9303] Replayed TNLean.PEPS.TorusFundamentalTheorem2
warning: TNLean/PEPS/TorusFundamentalTheorem2.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9163/9303] Replayed TNLean.PEPS.TorusGaugeUniqueness
warning: TNLean/PEPS/TorusGaugeUniqueness.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9164/9303] Replayed TNLean.PEPS.RegionBlock.BondLocalFromReconcile
warning: TNLean/PEPS/RegionBlock/BondLocalFromReconcile.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9165/9303] Replayed TNLean.PEPS.RegionBlock.CoarseThreeSiteMul
warning: TNLean/PEPS/RegionBlock/CoarseThreeSiteMul.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9166/9303] Replayed TNLean.PEPS.NormalSquareEdgeCoeff
warning: TNLean/PEPS/NormalSquareEdgeCoeff.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9167/9303] Replayed TNLean.PEPS.NormalSquareInteriorAbsorbedFamily
warning: TNLean/PEPS/NormalSquareInteriorAbsorbedFamily.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9168/9303] Replayed TNLean.PEPS.NormalSquareFundamentalTheorem2
warning: TNLean/PEPS/NormalSquareFundamentalTheorem2.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9169/9303] Replayed TNLean.PEPS.NormalAbsorbedFamily
warning: TNLean/PEPS/NormalAbsorbedFamily.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9170/9303] Replayed TNLean.PEPS.NormalBondDimension
warning: TNLean/PEPS/NormalBondDimension.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9171/9303] Replayed TNLean.PEPS.NormalComparisonScalar
warning: TNLean/PEPS/NormalComparisonScalar.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9172/9303] Replayed TNLean.PEPS.NormalGeneralFundamentalTheorem
warning: TNLean/PEPS/NormalGeneralFundamentalTheorem.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9173/9303] Replayed TNLean.PEPS.CycleBlockingData
warning: TNLean/PEPS/CycleBlockingData.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9174/9303] Replayed TNLean.PEPS.CycleFundamentalTheorem
warning: TNLean/PEPS/CycleFundamentalTheorem.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9175/9303] Replayed TNLean.PEPS.CycleMPSOverlapCapstone
warning: TNLean/PEPS/CycleMPSOverlapCapstone.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9176/9303] Replayed TNLean.PEPS.CycleMPSFundamentalTheorem
warning: TNLean/PEPS/CycleMPSFundamentalTheorem.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9177/9303] Replayed TNLean.PEPS.CycleMPSTranslationInvariant
warning: TNLean/PEPS/CycleMPSTranslationInvariant.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9178/9303] Replayed TNLean.PEPS.CycleMPSConstantDescription
warning: TNLean/PEPS/CycleMPSConstantDescription.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9180/9303] Replayed Gametheory.Scarf
warning: Gametheory/Scarf.lean:1793:18: `Set.mem_diff` has been deprecated: Use `Set.mem_sdiff` instead
warning: Gametheory/Scarf.lean:1797:18: `Set.mem_diff` has been deprecated: Use `Set.mem_sdiff` instead
warning: Gametheory/Scarf.lean:1824:24: `Set.mem_diff` has been deprecated: Use `Set.mem_sdiff` instead
warning: Gametheory/Scarf.lean:1871:24: `Set.mem_diff` has been deprecated: Use `Set.mem_sdiff` instead
warning: Gametheory/Scarf.lean:1919:24: `Set.mem_diff` has been deprecated: Use `Set.mem_sdiff` instead
warning: Gametheory/Scarf.lean:1964:24: `Set.mem_diff` has been deprecated: Use `Set.mem_sdiff` instead
warning: Gametheory/Scarf.lean:1793:18: This simp argument is unused:
  Set.mem_diff

Hint: Omit it from the simp argument list.
  simp [S̵e̵t̵.̵m̵e̵m̵_̵d̵i̵f̵f̵,̵ ̵h_x_in_σ]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: Gametheory/Scarf.lean:1797:18: This simp argument is unused:
  Set.mem_diff

Hint: Omit it from the simp argument list.
  simp [S̵e̵t̵.̵m̵e̵m̵_̵d̵i̵f̵f̵,̵ ̵h_y_in_σ]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: Gametheory/Scarf.lean:1824:24: This simp argument is unused:
  Set.mem_diff

Hint: Omit it from the simp argument list.
  simp [S̵e̵t̵.̵m̵e̵m̵_̵d̵i̵f̵f̵,̵ ̵h_y_in_σ, h_y_ne_a, h_y_eq_b]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: Gametheory/Scarf.lean:1871:24: This simp argument is unused:
  Set.mem_diff

Hint: Omit it from the simp argument list.
  simp [S̵e̵t̵.̵m̵e̵m̵_̵d̵i̵f̵f̵,̵ ̵h_y_in_σ, h_y_eq_a, h_y_ne_b]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: Gametheory/Scarf.lean:1919:24: This simp argument is unused:
  Set.mem_diff

Hint: Omit it from the simp argument list.
  simp [S̵e̵t̵.̵m̵e̵m̵_̵d̵i̵f̵f̵,̵ ̵h_x_in_σ, h_x_ne_a, h_x_eq_b]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: Gametheory/Scarf.lean:1964:24: This simp argument is unused:
  Set.mem_diff

Hint: Omit it from the simp argument list.
  simp [S̵e̵t̵.̵m̵e̵m̵_̵d̵i̵f̵f̵,̵ ̵h_x_in_σ, h_x_eq_a, h_x_ne_b]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
⚠ [9181/9303] Replayed Gametheory.Brouwer
warning: Gametheory/Brouwer.lean:596:18: `PNat.one_le` has been deprecated: use `one_le`
⚠ [9182/9303] Replayed Gametheory.Brouwer_product
warning: Gametheory/Brouwer_product.lean:566:8: `continuous_finset_sum` has been deprecated: Use `continuous_finsetSum` instead
warning: Gametheory/Brouwer_product.lean:574:8: `continuous_finset_sum` has been deprecated: Use `continuous_finsetSum` instead
warning: Gametheory/Brouwer_product.lean:618:10: `continuous_finset_sum` has been deprecated: Use `continuous_finsetSum` instead
⚠ [9183/9303] Replayed TNLean.Topology.BrouwerProduct
warning: TNLean/Topology/BrouwerProduct.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9184/9303] Replayed TNLean.Topology.CompactRetractFixedPoint
warning: TNLean/Topology/CompactRetractFixedPoint.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9185/9303] Replayed TNLean.Axioms.BrouwerFixedPoint
warning: TNLean/Axioms/BrouwerFixedPoint.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9186/9303] Replayed TNLean.Channel.PerronFrobenius.Existence
warning: TNLean/Channel/PerronFrobenius/Existence.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9188/9303] Replayed TNLean.Channel.Irreducible.PerronFrobenius
warning: TNLean/Channel/Irreducible/PerronFrobenius.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9189/9303] Replayed TNLean.Channel.Irreducible.Ergodicity
warning: TNLean/Channel/Irreducible/Ergodicity.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9190/9303] Replayed TNLean.Channel.FixedPoint.StationarySupport
warning: TNLean/Channel/FixedPoint/StationarySupport.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9191/9303] Replayed TNLean.Channel.Irreducible.Similarity
warning: TNLean/Channel/Irreducible/Similarity.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9192/9303] Replayed TNLean.Channel.Irreducible.SpectralRadius
warning: TNLean/Channel/Irreducible/SpectralRadius.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9193/9303] Replayed TNLean.Channel.Irreducible.FromSpectral
warning: TNLean/Channel/Irreducible/FromSpectral.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9196/9303] Replayed TNLean.MPS.FundamentalTheorem.Proportional
warning: TNLean/MPS/FundamentalTheorem/Proportional.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/FundamentalTheorem/Proportional.lean:7:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `open scoped Matrix BigOperators`.

Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/FundamentalTheorem/Proportional.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/FundamentalTheorem/Proportional.lean:7:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `namespace MPSTensor`.

Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/FundamentalTheorem/Proportional.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/FundamentalTheorem/Proportional.lean:7:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `/-!# Proportional single-block Fundamental Theorem (primitive case)

This file contains a lightweight “proportional” variant of the single-block Fundamental Theorem,
aligned with the **primitive/aperiodic** branch of Cirac et al., Rev. Mod. Phys. 93 (2021),
Theorem 4.4 (arXiv:2011.12127).

* If `A` and `B` are related by a gauge transform up to a scalar `ζ` (`GaugePhaseEquiv A B`), then
  their Matrix Product Vectors are proportional for each system size `N`.

* Conversely, if the MPV families are proportional (`ProportionalMPV₂ A B`) and both self-overlaps
  `mpvOverlap A A N` and `mpvOverlap B B N` converge to `1`, then `A` and `B` must be
  gauge-phase equivalent.

The key input for the converse is the overlap decay lemma
`MPSTensor.mpvOverlap_tendsto_zero` from `TNLean.Spectral.MPVOverlapDecay`.
-/
`.

Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9198/9303] Replayed TNLean.MPS.RFP.StructuralForm
warning: TNLean/MPS/RFP/StructuralForm.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9199/9303] Replayed TNLean.MPS.RFP.StructuralFull
warning: TNLean/MPS/RFP/StructuralFull.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/RFP/StructuralFull.lean:938:2: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
⚠ [9200/9303] Replayed TNLean.MPS.RFP.CommutingBridge
warning: TNLean/MPS/RFP/CommutingBridge.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9201/9303] Replayed TNLean.MPS.ParentHamiltonian.Commuting
warning: TNLean/MPS/ParentHamiltonian/Commuting.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9203/9303] Replayed TNLean.MPS.ParentHamiltonian.Martingale
warning: TNLean/MPS/ParentHamiltonian/Martingale.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9205/9303] Replayed TNLean.MPS.Symmetry.StringOrder
warning: TNLean/MPS/Symmetry/StringOrder.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9206/9303] Replayed TNLean.MPS.BNT.Separation
warning: TNLean/MPS/BNT/Separation.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9208/9303] Replayed TNLean.MPS.BNT.Construction
warning: TNLean/MPS/BNT/Construction.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9210/9303] Replayed TNLean.MPS.ParentHamiltonian.BNTBlockIntersection
warning: TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9212/9303] Replayed TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalChain
warning: TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9213/9303] Replayed TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalChainBoundary
warning: TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChainBoundary.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9214/9303] Replayed TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossing
warning: TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9216/9303] Replayed TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalPGVWCComparison
warning: TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9217/9303] Replayed TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalTraceDecomposition
warning: TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9218/9303] Replayed TNLean.MPS.BNT.PermutationRigidityPrimitive
warning: TNLean/MPS/BNT/PermutationRigidityPrimitive.lean:1:1: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9219/9303] Replayed TNLean.MPS.FundamentalTheorem.SectorBNT.Api
warning: TNLean/MPS/FundamentalTheorem/SectorBNT/Api.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9221/9303] Replayed TNLean.MPS.FundamentalTheorem.SectorBNT.StrongMatch
warning: TNLean/MPS/FundamentalTheorem/SectorBNT/StrongMatch.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9222/9303] Replayed TNLean.MPS.CanonicalForm.PhaseCover
warning: TNLean/MPS/CanonicalForm/PhaseCover.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/CanonicalForm/PhaseCover.lean:10:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `open scoped Matrix BigOperators`.

Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/CanonicalForm/PhaseCover.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/CanonicalForm/PhaseCover.lean:10:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `open Filter`.

Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/CanonicalForm/PhaseCover.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/CanonicalForm/PhaseCover.lean:10:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `/-!# MPV phase covers for canonical-form block families

This file contains the MPV phase-equivalence and phase-cover constructions used by the
canonical-form equal-norm comparison and sector-comparison layers.
-/
`.

Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9223/9303] Replayed TNLean.MPS.FundamentalTheorem.SectorBNT.CoeffIdentity
warning: TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9224/9303] Replayed TNLean.MPS.FundamentalTheorem.SectorBNT.WeightEquiv
warning: TNLean/MPS/FundamentalTheorem/SectorBNT/WeightEquiv.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9225/9303] Replayed TNLean.MPS.FundamentalTheorem.SectorBNT.CopyWeightMatching
warning: TNLean/MPS/FundamentalTheorem/SectorBNT/CopyWeightMatching.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9227/9303] Replayed TNLean.MPS.FundamentalTheorem.SectorBNT.ProportionalMatch
warning: TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9228/9303] Replayed TNLean.MPS.FundamentalTheorem.SectorBNT.Fundamental
warning: TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9230/9303] Replayed TNLean.MPS.FundamentalTheorem.SectorBNT.Unitary
warning: TNLean/MPS/FundamentalTheorem/SectorBNT/Unitary.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9231/9303] Replayed TNLean.MPS.FundamentalTheorem.SectorBNT.FundamentalCoord
warning: TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9232/9303] Replayed TNLean.Wielandt.Primitivity.PrimitiveBridge
warning: TNLean/Wielandt/Primitivity/PrimitiveBridge.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9234/9303] Replayed TNLean.MPS.CanonicalForm.Existence
warning: TNLean/MPS/CanonicalForm/Existence.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/CanonicalForm/Existence.lean:12:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `open scoped Matrix BigOperators ComplexOrder MatrixOrder`.

Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/CanonicalForm/Existence.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/CanonicalForm/Existence.lean:12:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `open Filter`.

Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/CanonicalForm/Existence.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/CanonicalForm/Existence.lean:12:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `/-!# Canonical form existence reductions from the source proofs

This file collects the arbitrary-tensor reductions toward the canonical-form construction for
MPS tensors from Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608.

The file contains the following reductions from arXiv:1606.00608 and the
translation-invariant canonical-form theorem of Pérez-García, Verstraete, Wolf,
and Cirac:

* arXiv:1606.00608, lines 201-219: iterated invariant-projection splitting gives an
  irreducible block decomposition.
* arXiv:1606.00608, lines 1058-1077: after canonical form has been obtained,
  the canonical-form-II gauge makes the associated maps trace-preserving and
  gives diagonal full-rank fixed points.
* Pérez-García, Verstraete, Wolf, and Cirac, proof of Theorem Th:TIcanonical,
  lines 765-770 and 827-832: the full-rank fixed-point gauge and the final
  dual fixed-point diagonalization.

We also keep a couple of formulations for already-normalized primitive / injective block families,
but those are **not** obtained from arbitrary input in this file.

Note: the Appendix-A CFII story is genuinely two-step:
first a generally non-unitary TP similarity from the adjoint Perron--Frobenius eigenvector,
then a unitary diagonalization **within** that TP gauge.

The reductions below are composed with finite-family weight normalization to
obtain the arbitrary-input positive-length PGVWC07 canonical form.  After a
positive global rescaling, the conclusion gives positive weights, unital blocks,
diagonal full-rank dual fixed points, scalar transfer-map fixed points, and the
bond-dimension bound.  If every positive-length MPV coefficient vanishes, the
nonzero-block family is empty.  The remaining all-zero direct summand $A_0$
separately records the length-zero dimension identity $D = D_0 + \sum_k D_k$.

The later Fundamental-Theorem reductions--TP gauge, period removal, common
blocking, and normal/BNT predicates--are subsequent consequences of the
canonical-form outputs, not missing conclusions of PGVWC07 Theorem
Th:TIcanonical.

Maintainer note: the blueprint cites
`MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_allow_empty` in
`TNLean.MPS.CanonicalForm.NormalReduction.WeightNormalization`; the zero-tail
dimension identity is recorded by
`MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound`
in `TNLean.MPS.CanonicalForm.NormalReduction.TPGauge`.  The audit boundary is
recorded in `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`.
For Pérez-García, Verstraete, Wolf, and Cirac, the faithful proof order is the
one in `Papers/quant-ph_0608197/MPSarchive.tex`: lines 765–770 for
spectral-radius normalization and the full-rank fixed-point gauge, lines
771–815 for deriving the invariant support from a singular positive fixed point
and then splitting the trace, lines 816–826 for iteration and non-scalar
fixed-point splitting, and lines 827–832 for dual fixed-point diagonalization.

## External input — Quantum Wielandt strong irreducibility ⇒ full Kraus rank

This file imports `TNLean.Wielandt.Primitivity.StronglyIrreducibleToFullRank`,
which supplies the hardest direction of the Quantum Wielandt primitivity equivalence:

> **Proposition 3(c)→(b) of arXiv:0909.5347 / Wolf Theorem 6.7 case (iii).**
> If `E_A` is **strongly irreducible** — the Kraus operators' word products
> eventually span the full matrix algebra `M_D(ℂ)` — then the fixed-point
> space of `E_A` has full Kraus rank: `dim S_1(A) = D` (the Kraus operators
> themselves span `M_D(ℂ)` at word-length `1`).

In MPS notation after blocking: `IsStronglyIrreducible A` (Kraus word products
eventually span `M_D(ℂ)`) implies `IsInjective A` (the single-site
Kraus operators `{A_i}` already span `M_D(ℂ)`).  This is a
step in the canonical-form existence argument: it upgrades the cumulative word
span to single-site injectivity, which then yields block injectivity at every
positive length.

The formal statement:

> `Wielandt.Primitivity.StronglyIrreducibleToFullRank` proves the implication
> `IsStronglyIrreduciblePaper A → krausRank A = D` (equivalently,
> `wordSpan A 1 = ⊤`).  This proves the hardest direction
> in the Sanz–Pérez-García–Wolf–Cirac primitivity equivalence.

## External input — invariant subspace decomposition in the canonical-form proof

The iterated invariant-projection splitting in arXiv:1606.00608, lines
201–219, is formalized in
`TNLean.MPS.Structure.InvariantSubspaceDecomp`.
This external input provides:

> **Pérez-García, Verstraete, Wolf, and Cirac, proof of Theorem
> Th:TIcanonical, lines 765–833.**
> An invariant orthogonal projection `P` on the bond space (satisfying
> `(1-P) A_i P = 0` for all `i`) yields an MPV-equivalent two-block direct-sum
> tensor with strictly smaller block dimensions.

The formal statement:

> `MPSTensor.exists_twoBlock_decomp_of_lowerZero` produces a two-block
> block-diagonal tensor MPV-equivalent to the original, with a strict dimension
> decrease (`exists_twoBlock_decomp_of_lowerZero_strict`).

## External input — Wolf spectral theory: Perron-Frobenius fixed point

The Appendix A PF/TP gauge step uses the Perron-Frobenius theorem for
completely positive maps (Wolf Chapter 6), formalized in
`TNLean.Channel.PerronFrobenius.Existence`:

> An irreducible CP map on `M_D(ℂ)` with spectral radius `1` has a
> positive-definite fixed point `ρ > 0`.  This provides the TP gauge
> transformation `A_i ↦ ρ^{1/2} A_i ρ^{-1/2}` that makes the
> tensor left-canonical.

The complementary transfer-map gap connection to peripheral primitivity is supplied by
`TNLean.MPS.Overlap.PeripheralToTransferMapGap` (Wolf Proposition 6.8).
-/
`.

Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9238/9303] Replayed TNLean.MPS.CanonicalForm.NormalReduction
warning: TNLean/MPS/CanonicalForm/NormalReduction.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9239/9303] Replayed TNLean.MPS.CanonicalForm.BNTGrouping
warning: TNLean/MPS/CanonicalForm/BNTGrouping.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/CanonicalForm/BNTGrouping.lean:8:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `open scoped Matrix BigOperators`.

Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/CanonicalForm/BNTGrouping.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/CanonicalForm/BNTGrouping.lean:8:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `/-!# Granular sector decomposition from a weighted block family

This file provides the **one-sector-per-block** sector decomposition used by
the canonical-form existence reduction.  Each block in the input family
`(μ k, blocks k)` becomes its own sector basis tensor with multiplicity
`copies j = 1` and sector weight `μ j`.

The construction is deliberately a structural form: it does not assert the
basis-of-normal-tensors linear-independence condition `HasBNTSectorData`
from `TNLean.MPS.SharedInfra.SectorDecomposition`, and it is not the
paper's minimal BNT representative construction.

## Main definitions

* `MPSTensor.trivialSectorDecomp` — one-sector-per-block `SectorDecomposition`
  with `copies j = 1` and sector weight `μ j` on each sector.

## Main results

* `MPSTensor.sameMPV₂_trivialSectorDecomp` — the granular sector
  decomposition has `SameMPV₂` with the original weighted block-sum tensor.

## References

- [Cirac--Perez-Garcia--Schuch--Verstraete 2017, Definition 2.6, Proposition 2.7]:
  BNT minimal representative condition.
- [Cirac--Perez-Garcia--Schuch--Verstraete 2021, Section IV.A]: Existence of canonical form.
-/
`.

Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9240/9303] Replayed TNLean.MPS.CanonicalForm.PhaseClassSectorData
warning: TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean:15:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `open scoped Matrix BigOperators`.

Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean:15:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `open Filter`.

Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean:15:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `/-!# Phase-class BNT sector data

This file builds BNT sector decompositions by quotienting a family of primitive
irreducible blocks by MPV phase equivalence.  It proves the representative
overlap data and transports finite-length MPV span identities through the chosen
phase classes.
-/
`.

Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9242/9303] Replayed TNLean.Wielandt.Primitivity.Equivalence
warning: TNLean/Wielandt/Primitivity/Equivalence.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9243/9303] Replayed TNLean.Wielandt.Inequality.EigenvectorSpreading
warning: TNLean/Wielandt/Inequality/EigenvectorSpreading.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9244/9303] Replayed TNLean.Wielandt.Inequality.MatrixSpanSharpBound
warning: TNLean/Wielandt/Inequality/MatrixSpanSharpBound.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9245/9303] Replayed TNLean.Wielandt.Inequality.NonzeroTraceWord
warning: TNLean/Wielandt/Inequality/NonzeroTraceWord.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9246/9303] Replayed TNLean.Wielandt.Inequality.Bounds
warning: TNLean/Wielandt/Inequality/Bounds.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9254/9303] Replayed TNLean.MPS.FundamentalTheorem.SectorBNT.Supplier
warning: TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9261/9303] Replayed TNLean.MPS.Periodic.Overlap.Case3
warning: TNLean/MPS/Periodic/Overlap/Case3.lean:583:14: declaration uses `sorry`
⚠ [9263/9303] Replayed TNLean.MPS.Periodic.Overlap
warning: TNLean/MPS/Periodic/Overlap.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9264/9303] Replayed TNLean.MPS.Periodic.FundamentalTheorem
warning: TNLean/MPS/Periodic/FundamentalTheorem.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Periodic/FundamentalTheorem.lean:12:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `open scoped Matrix BigOperators`.

Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Periodic/FundamentalTheorem.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
warning: TNLean/MPS/Periodic/FundamentalTheorem.lean:12:0: The module doc-string for a file should be the first command after the imports.
Please, add a module doc-string before `/-!# Periodic Fundamental Theorem of MPS (arXiv:1708.00029, Section 3)

This file formalizes the periodic fundamental theorem of arXiv:1708.00029 Section 3 and the
Z-gauge theory used in its equal-case strengthening:

* **Proportional theorem `thm:bd`** (`fundamentalTheorem_periodic_proportional`):
  If two non-repeated block families satisfy the periodic overlap dichotomy, their bases
  of periodic tensors match up to a bijection with per-block `RepeatedBlocks` equivalence.
  (In the paper, proportional MPVs imply the dichotomy; here it is a direct hypothesis.)

* **Supporting lemmas for the equal-case theorem `thm:bdequal`**: The equal-case
  strengthening produces per-block Z-gauge data (diagonal Z with Z^m = 1) from the
  Newton–Girard identity on multiplicity entries.
  The Z-gauge construction is packaged in `zgauge_construction` and
  `perBlock_zgauge_of_power_eq`.

## Periodic overlap dichotomy

The proportional theorem `thm:bd` is stated in two forms:

* `fundamentalTheorem_periodic_proportional` takes a `PeriodicOverlapHypothesis` directly,
  leaving callers free to supply the dichotomy from any source.
* `fundamentalTheorem_periodic_proportional_of_isPeriodic` is a variant that no
  longer takes `PeriodicOverlapHypothesis` as a parameter: the
  `hetRepeatedBlocks_of_nondecaying` field is filled inside
  `PeriodicOverlapHypothesis.ofIsPeriodic` via `periodicOverlapDichotomy`.
  Callers only need to supply per-block `IsPeriodic` data
  plus the existence of non-decaying cross-family overlaps (`exists_nondecaying_A/B`),
  which encode the paper's proportional-MPV assumption.

  **Caveat**: `periodicOverlapDichotomy` is stated and callable, but its proof still
  depends on the remaining Case-3 contraction with \(F_u\), \(\Omega_u\), and the
  phases \(\kappa_v\) from arXiv:1708.00029, Appendix A, lines 1023--1117,
  formalized as `repeatedBlocks_of_blockedSectorGaugePhase` in
  `TNLean.MPS.Periodic.Overlap.Case3`. Subsequent results using the `_of_isPeriodic`
  variant therefore inherit that obligation and should not be treated as unconditional.

The Z-gauge construction (the scalar-entry part of `thm:bdequal`) is fully proved.

## Key references

* arXiv:1708.00029 (De las Cuevas–Cirac–Schuch–Pérez-García, 2017)
* `MPSTensor.ft_sector_bnt_proportional_sector_match_witnesses` — current
  sector-decomposition matching template for the non-periodic theorem
* Z-gauge construction lemmas in `ZGauge.lean`
-/
`.

Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9271/9303] Replayed TNLean.MPS.Periodic.Symmetry
warning: TNLean/MPS/Periodic/Symmetry.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9272/9303] Replayed TNLean.MPS.Periodic.ProjectiveRep
warning: TNLean/MPS/Periodic/ProjectiveRep.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9273/9303] Replayed TNLean.MPS.Periodic.NormalCanonicalPeriodOne
warning: TNLean/MPS/Periodic/NormalCanonicalPeriodOne.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9274/9303] Replayed TNLean.MPS.CanonicalForm.ProjectorClosureSpectral
warning: TNLean/MPS/CanonicalForm/ProjectorClosureSpectral.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9275/9303] Replayed TNLean.MPS.Periodic.SectorUnitary
warning: TNLean/MPS/Periodic/SectorUnitary.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9276/9303] Replayed TNLean.MPS.MPDO.PeriodicExclusion
warning: TNLean/MPS/MPDO/PeriodicExclusion.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9277/9303] Replayed TNLean.MPS.MPDO.StackedLayers
warning: TNLean/MPS/MPDO/StackedLayers.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9278/9303] Replayed TNLean.MPS.Examples.AKLTStringOrder
warning: TNLean/MPS/Examples/AKLTStringOrder.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9279/9303] Replayed TNLean.MPS.Examples.Cluster
warning: TNLean/MPS/Examples/Cluster.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9280/9303] Replayed TNLean.MPS.Examples.ZeroCorrelationExamples
warning: TNLean/MPS/Examples/ZeroCorrelationExamples.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9281/9303] Replayed TNLean.MPS.RFP.AppendixBSupport
warning: TNLean/MPS/RFP/AppendixBSupport.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9282/9303] Replayed TNLean.MPS.RFP.Convergence
warning: TNLean/MPS/RFP/Convergence.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9283/9303] Replayed TNLean.MPS.RFP.Assembly
warning: TNLean/MPS/RFP/Assembly.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9284/9303] Replayed TNLean.MPS.RFP.BNTOrthogonality
warning: TNLean/MPS/RFP/BNTOrthogonality.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9285/9303] Replayed TNLean.MPS.RFP.ResidualIsometry
warning: TNLean/MPS/RFP/ResidualIsometry.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9286/9303] Replayed TNLean.MPS.RFP.PhaseMultiplicityCounterexample
warning: TNLean/MPS/RFP/PhaseMultiplicityCounterexample.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9287/9303] Replayed TNLean.Wielandt.Inequality.MatrixSpanExistence
warning: TNLean/Wielandt/Inequality/MatrixSpanExistence.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9289/9303] Replayed TNLean.Channel.WolfChapter6Index
warning: TNLean/Channel/WolfChapter6Index.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9295/9303] Replayed TNLean.Channel.Semigroup.Primitivity
warning: TNLean/Channel/Semigroup/Primitivity.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
⚠ [9300/9303] Replayed TNLean.Channel.Determinant
warning: TNLean/Channel/Determinant.lean:4:0: * '-/':
Copyright too short!


Note: This linter can be disabled with `set_option linter.style.header false`
✔ [9301/9303] Built TNLean.MPS.MPDO.PhysicalSectorClosureThree (3.3s)
✔ [9302/9303] Built TNLean (4.6s)
Build completed successfully (9303 jobs).\n- \n- focused compilation of both closure modules\n- exact axiom audit of both headline theorems\n- blueprint–Lean synchronization and reverse declaration coverage\n- \n- Rc files read:
  latexmkrc
Latexmk: This is Latexmk, John Collins, 15 June 2025. Version 4.87.
Latexmk: Nothing to do for 'print.tex'.
Latexmk: All targets (/private/tmp/tnlean-physical-closures/blueprint/print/print.pdf) are up-to-date (485 pages, diagrams visually inspected)\n- plasTeX version 3.1\n- reader-facing prose and proof-integrity checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely additive formalization and blueprint sync in the MPDO RFP track; no changes to auth, runtime services, or existing theorem statements beyond new definitions and proofs.
> 
> **Overview**
> Adds **source-minimal physical-sector factorization** for MPO tensors (direct-sum slice structure after a physical isometry only—no Markov/positivity assumptions) and proves that **two- and three-site physical closures** on fixed sectors, for an **arbitrary virtual matrix** `X`, split as Kronecker products of a **boundary operator** `B_{k,h}(X)` with **neighboring contractions** `η_{k,h}` (and `η_{k,l} ⊗ η_{l,h}` in the three-site case).
> 
> **Lean:** new `PhysicalSectorFactorization` with `sectorCoordinateTensor`, `neighboringOperator`, and `boundaryOperator`; `physClose3` plus `finThreeArrowEquiv` and alignment with `physCloseN` at length 3; sector-restricted closure definitions and the factorization theorems `twoSiteSectorClosure_eq` / `threeSiteSectorClosure_eq`. Root imports wire the three new modules.
> 
> **Blueprint:** matching definitions, theorems, and TikZ macros (`TNMPDOTwoSiteClosureFactorization`, `TNMPDOThreeSiteClosureFactorization`) with plasTeX registration; `phys_close` extended to cite `physClose3`.
> 
> Scope is **algebraic contraction identities** only—not positivity, channels, or the full conclusion of Proposition C.7.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edc4b64736fc8d3cf62cb3a3b5919ebf3b219c98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->