### PR TITLE
feat(MPS/MPDO): construct the coarse-graining channel

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -388,6 +388,7 @@ import TNLean.MPS.MPDO.SectorFactorization
 import TNLean.MPS.MPDO.PhysicalSectorFactorization
 import TNLean.MPS.MPDO.PhysicalSectorClosureTwo
 import TNLean.MPS.MPDO.PhysicalSectorClosureThree
+import TNLean.MPS.MPDO.PhysicalSectorTraceActions
 import TNLean.MPS.MPDO.SectorPairingTransfer
 import TNLean.MPS.MPDO.SectorEtaContraction
 import TNLean.MPS.MPDO.SectorEtaOperator

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -386,6 +386,7 @@ import TNLean.MPS.MPDO.RFPSubspinMaps
 import TNLean.MPS.MPDO.HayashiSectorComparison
 import TNLean.MPS.MPDO.SectorFactorization
 import TNLean.MPS.MPDO.PhysicalSectorFactorization
+import TNLean.MPS.MPDO.PhysicalSectorSubspinMaps
 import TNLean.MPS.MPDO.PhysicalSectorClosureTwo
 import TNLean.MPS.MPDO.PhysicalSectorClosureThree
 import TNLean.MPS.MPDO.PhysicalSectorTraceActions

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -386,6 +386,7 @@ import TNLean.MPS.MPDO.RFPSubspinMaps
 import TNLean.MPS.MPDO.HayashiSectorComparison
 import TNLean.MPS.MPDO.SectorFactorization
 import TNLean.MPS.MPDO.PhysicalSectorFactorization
+import TNLean.MPS.MPDO.NeighboringPreparation
 import TNLean.MPS.MPDO.PhysicalSectorSubspinMaps
 import TNLean.MPS.MPDO.PhysicalSectorClosureTwo
 import TNLean.MPS.MPDO.PhysicalSectorClosureThree

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -388,6 +388,7 @@ import TNLean.MPS.MPDO.SectorFactorization
 import TNLean.MPS.MPDO.PhysicalSectorFactorization
 import TNLean.MPS.MPDO.NeighboringPreparation
 import TNLean.MPS.MPDO.PhysicalSectorSubspinMaps
+import TNLean.MPS.MPDO.PhysicalSectorCoarseGraining
 import TNLean.MPS.MPDO.PhysicalSectorClosureTwo
 import TNLean.MPS.MPDO.PhysicalSectorClosureThree
 import TNLean.MPS.MPDO.PhysicalSectorTraceActions

--- a/TNLean/MPS/MPDO/NeighboringPreparation.lean
+++ b/TNLean/MPS/MPDO/NeighboringPreparation.lean
@@ -1,0 +1,309 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalSectorFactorization
+import TNLean.MPS.MPDO.KrausCPTP
+import TNLean.Algebra.MatrixAux
+
+/-!
+# Preparations of neighboring physical sectors
+
+This file records the positivity and rank-one trace factorization of the
+neighboring operators associated with a physical-sector factorization.  These
+are precisely the additional hypotheses in Proposition C.7 of
+arXiv:1606.00608.
+
+For every active pair of sectors, the neighboring operator is normalized to a
+density matrix.  On zero-weight pairs it is completed by a uniform density
+matrix, provided the corresponding factor space is nonempty.  The resulting
+family defines the orthogonally controlled preparation occurring in
+$\mathcal S_1$.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, equations `Appetakhetc`, `Apptralktrrk`, `AppPsiPhi`, and
+  Proposition `3to5`, lines 1389--1403 and 1548--1555
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D}
+
+/-- Positivity and rank-one trace factorization of the neighboring operators
+of a physical-sector factorization:
+\[
+  \eta_{k,h}\geq 0,\qquad
+  \operatorname{tr}(\eta_{k,h})=a_kb_h,\qquad
+  \sum_k a_kb_k=1.
+\]
+
+Together with `PhysicalSectorFactorization`, these are exactly the hypotheses
+used in Proposition C.7.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `Appetakhetc`,
+`Apptralktrrk`, and `AppPsiPhi`, lines 1389--1403. -/
+structure NeighboringTraceFactorization (F : PhysicalSectorFactorization K) where
+  /-- Every neighboring operator $\eta_{k,h}$ is positive semidefinite. -/
+  neighboringOperator_pos : ∀ k h, (F.neighboringOperator k h).PosSemidef
+  /-- The left factors in the rank-one trace matrix. -/
+  a : Fin F.sectorCount → ℝ
+  /-- The right factors in the rank-one trace matrix. -/
+  b : Fin F.sectorCount → ℝ
+  /-- The trace matrix has entries $\operatorname{tr}(\eta_{k,h})=a_kb_h$. -/
+  trace_neighboringOperator : ∀ k h,
+    (F.neighboringOperator k h).trace = ((a k * b h : ℝ) : ℂ)
+  /-- The diagonal products satisfy $\sum_k a_kb_k=1$. -/
+  sum_mul : ∑ k, a k * b k = 1
+
+namespace NeighboringTraceFactorization
+
+variable {F : PhysicalSectorFactorization K}
+
+/-- Every sector-pair weight $a_kb_h$ is nonnegative. -/
+theorem weight_nonneg (H : NeighboringTraceFactorization F)
+    (k h : Fin F.sectorCount) :
+    0 ≤ H.a k * H.b h := by
+  have htrace := (H.neighboringOperator_pos k h).trace_nonneg
+  rw [H.trace_neighboringOperator] at htrace
+  exact_mod_cast htrace
+
+/-- A zero-weight neighboring operator vanishes. -/
+theorem neighboringOperator_eq_zero_of_mul_eq_zero
+    (H : NeighboringTraceFactorization F) (k h : Fin F.sectorCount)
+    (hzero : H.a k * H.b h = 0) :
+    F.neighboringOperator k h = 0 := by
+  apply (Matrix.PosSemidef.trace_eq_zero_iff
+    (H.neighboringOperator_pos k h)).mp
+  rw [H.trace_neighboringOperator, hzero]
+  norm_num
+
+/-- An active neighboring operator acts on a nonempty factor space. -/
+theorem neighborIndex_nonempty_of_mul_ne_zero
+    (H : NeighboringTraceFactorization F) (k h : Fin F.sectorCount)
+    (hactive : H.a k * H.b h ≠ 0) :
+    Nonempty (NeighborIndex F k h) := by
+  by_contra hempty
+  haveI : IsEmpty (NeighborIndex F k h) := not_nonempty_iff.mp hempty
+  have htrace : (F.neighboringOperator k h).trace = 0 := by
+    simp [Matrix.trace]
+  rw [H.trace_neighboringOperator] at htrace
+  apply hactive
+  exact_mod_cast htrace
+
+/-- The normalized neighboring density on a sector pair.  On a zero-weight
+pair this expression is the zero matrix; its trace is one on active pairs.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1551--1555. -/
+noncomputable def normalizedNeighboringDensity
+    (H : NeighboringTraceFactorization F) (k h : Fin F.sectorCount) :
+    Matrix (NeighborIndex F k h) (NeighborIndex F k h) ℂ :=
+  (((H.a k * H.b h)⁻¹ : ℝ) : ℂ) • F.neighboringOperator k h
+
+/-- The normalized neighboring density is positive semidefinite. -/
+theorem normalizedNeighboringDensity_pos
+    (H : NeighboringTraceFactorization F) (k h : Fin F.sectorCount) :
+    (H.normalizedNeighboringDensity k h).PosSemidef := by
+  apply (H.neighboringOperator_pos k h).smul
+  exact_mod_cast inv_nonneg.mpr (H.weight_nonneg k h)
+
+/-- On an active sector pair, the normalized neighboring density has trace
+one. -/
+theorem trace_normalizedNeighboringDensity
+    (H : NeighboringTraceFactorization F) (k h : Fin F.sectorCount)
+    (hactive : H.a k * H.b h ≠ 0) :
+    (H.normalizedNeighboringDensity k h).trace = 1 := by
+  simp only [normalizedNeighboringDensity, Matrix.trace_smul,
+    H.trace_neighboringOperator, smul_eq_mul]
+  norm_cast
+  exact inv_mul_cancel₀ hactive
+
+/-- On an active sector pair, adjoining the normalized neighboring density is
+trace-preserving and completely positive.  This is the individual
+$\mathcal S_{k,h}$ preparation from arXiv:1606.00608, Appendix C.2,
+lines 1551--1555. -/
+theorem normalizedNeighboringPreparationMap_isKrausCPTP
+    {α : Type*} [Fintype α] [DecidableEq α]
+    (H : NeighboringTraceFactorization F) (k h : Fin F.sectorCount)
+    (hactive : H.a k * H.b h ≠ 0) :
+    IsKrausCPTP (Matrix.preparationMap (α := α)
+      (H.normalizedNeighboringDensity k h)) :=
+  Matrix.preparationMap_isKrausCPTP _
+    (H.normalizedNeighboringDensity_pos k h)
+    (H.trace_normalizedNeighboringDensity k h hactive)
+
+/-- A uniform density matrix used to complete a zero-weight neighboring
+sector. -/
+noncomputable def inactiveNeighboringDensity
+    (k h : Fin F.sectorCount) [Nonempty (NeighborIndex F k h)] :
+    Matrix (NeighborIndex F k h) (NeighborIndex F k h) ℂ :=
+  Matrix.faithfulDensity _
+
+/-- The inactive neighboring density is positive definite. -/
+theorem inactiveNeighboringDensity_posDef
+    (k h : Fin F.sectorCount) [Nonempty (NeighborIndex F k h)] :
+    (inactiveNeighboringDensity (F := F) k h).PosDef :=
+  Matrix.faithfulDensity_posDef _
+
+/-- The inactive neighboring density has trace one. -/
+theorem inactiveNeighboringDensity_trace
+    (k h : Fin F.sectorCount) [Nonempty (NeighborIndex F k h)] :
+    (inactiveNeighboringDensity (F := F) k h).trace = 1 :=
+  Matrix.faithfulDensity_trace _
+
+/-- The neighboring density equals the normalized source operator on an
+active pair and a uniform density on a zero-weight pair.
+
+On active pairs this is the state adjoined by $\mathcal S_{k,h}$ in
+arXiv:1606.00608, Appendix C.2, lines 1551--1555.  The inactive branch is a
+trace-preserving extension where the source quotient is undefined. -/
+noncomputable def completedNeighboringDensity
+    (H : NeighboringTraceFactorization F)
+    (hindex : ∀ k h, Nonempty (NeighborIndex F k h))
+    (k h : Fin F.sectorCount) :
+    Matrix (NeighborIndex F k h) (NeighborIndex F k h) ℂ :=
+  if H.a k * H.b h ≠ 0 then H.normalizedNeighboringDensity k h
+  else
+    letI := hindex k h
+    inactiveNeighboringDensity k h
+
+/-- Every completed neighboring density is positive semidefinite. -/
+theorem completedNeighboringDensity_pos
+    (H : NeighboringTraceFactorization F)
+    (hindex : ∀ k h, Nonempty (NeighborIndex F k h))
+    (k h : Fin F.sectorCount) :
+    (H.completedNeighboringDensity hindex k h).PosSemidef := by
+  rw [completedNeighboringDensity]
+  split_ifs
+  · exact H.normalizedNeighboringDensity_pos k h
+  · letI := hindex k h
+    exact (inactiveNeighboringDensity_posDef (F := F) k h).posSemidef
+
+/-- Every completed neighboring density has trace one. -/
+theorem trace_completedNeighboringDensity
+    (H : NeighboringTraceFactorization F)
+    (hindex : ∀ k h, Nonempty (NeighborIndex F k h))
+    (k h : Fin F.sectorCount) :
+    (H.completedNeighboringDensity hindex k h).trace = 1 := by
+  rw [completedNeighboringDensity]
+  split_ifs with hactive
+  · exact H.trace_normalizedNeighboringDensity k h hactive
+  · letI := hindex k h
+    exact inactiveNeighboringDensity_trace (F := F) k h
+
+/-- On an active pair, the completed density is the normalized neighboring
+operator from Proposition C.7. -/
+theorem completedNeighboringDensity_eq_normalized
+    (H : NeighboringTraceFactorization F)
+    (hindex : ∀ k h, Nonempty (NeighborIndex F k h))
+    (k h : Fin F.sectorCount) (hactive : H.a k * H.b h ≠ 0) :
+    H.completedNeighboringDensity hindex k h =
+      H.normalizedNeighboringDensity k h := by
+  simp [completedNeighboringDensity, hactive]
+
+/-- The sectorwise map which adjoins the completed neighboring density. -/
+noncomputable def completedNeighboringPreparationMap
+    {α : Type*} [Fintype α] [DecidableEq α]
+    (H : NeighboringTraceFactorization F)
+    (hindex : ∀ k h, Nonempty (NeighborIndex F k h))
+    (k h : Fin F.sectorCount) :
+    Matrix α α ℂ →ₗ[ℂ]
+      Matrix (α × NeighborIndex F k h) (α × NeighborIndex F k h) ℂ :=
+  Matrix.preparationMap (H.completedNeighboringDensity hindex k h)
+
+/-- Adjoining a completed neighboring density is trace-preserving and
+completely positive.  On active pairs this is $\mathcal S_{k,h}$ from
+arXiv:1606.00608, Appendix C.2, lines 1551--1555. -/
+theorem completedNeighboringPreparationMap_isKrausCPTP
+    {α : Type*} [Fintype α] [DecidableEq α]
+    (H : NeighboringTraceFactorization F)
+    (hindex : ∀ k h, Nonempty (NeighborIndex F k h))
+    (k h : Fin F.sectorCount) :
+    IsKrausCPTP (H.completedNeighboringPreparationMap hindex (α := α) k h) := by
+  simpa [completedNeighboringPreparationMap] using
+    Matrix.preparationMap_isKrausCPTP _
+      (H.completedNeighboringDensity_pos hindex k h)
+      (H.trace_completedNeighboringDensity hindex k h)
+
+/-- On an active pair, the completed preparation is the source preparation. -/
+theorem completedNeighboringPreparationMap_eq_normalized
+    {α : Type*} [Fintype α] [DecidableEq α]
+    (H : NeighboringTraceFactorization F)
+    (hindex : ∀ k h, Nonempty (NeighborIndex F k h))
+    (k h : Fin F.sectorCount) (hactive : H.a k * H.b h ≠ 0) :
+    H.completedNeighboringPreparationMap hindex (α := α) k h =
+      Matrix.preparationMap (H.normalizedNeighboringDensity k h) := by
+  rw [completedNeighboringPreparationMap,
+    H.completedNeighboringDensity_eq_normalized hindex k h hactive]
+
+/-! ## Orthogonally controlled neighboring preparations -/
+
+section ControlledPreparation
+
+variable {α : Fin F.sectorCount × Fin F.sectorCount → Type*}
+variable [∀ p, Fintype (α p)] [∀ p, DecidableEq (α p)]
+
+/-- The orthogonally controlled neighboring-state preparation.  It discards
+coherences between sector pairs and adjoins the completed neighboring density
+inside each diagonal sector.
+
+On active pairs its sector maps are the $\mathcal S_{k,h}$ preparations in
+arXiv:1606.00608, Appendix C.2, lines 1548--1555. -/
+noncomputable def completedNeighboringControlledMap
+    (H : NeighboringTraceFactorization F)
+    (hindex : ∀ k h, Nonempty (NeighborIndex F k h)) :
+    Matrix (Σ p, α p) (Σ p, α p) ℂ →ₗ[ℂ]
+      Matrix (Σ p, α p × NeighborIndex F p.1 p.2)
+        (Σ p, α p × NeighborIndex F p.1 p.2) ℂ :=
+  Matrix.controlledKrausMap
+    (fun p => Fintype.card (NeighborIndex F p.1 p.2))
+    (fun p j => Matrix.preparationKraus
+      (H.completedNeighboringDensity hindex p.1 p.2)
+      (H.completedNeighboringDensity_pos hindex p.1 p.2)
+      ((Fintype.equivFin (NeighborIndex F p.1 p.2)).symm j))
+
+/-- On a diagonal sector pair, the controlled map is preparation of the
+completed neighboring density.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1548--1555. -/
+theorem completedNeighboringControlledMap_sameBlock_apply
+    (H : NeighboringTraceFactorization F)
+    (hindex : ∀ k h, Nonempty (NeighborIndex F k h))
+    (X : Matrix (Σ p, α p) (Σ p, α p) ℂ)
+    (p : Fin F.sectorCount × Fin F.sectorCount) (a b : α p)
+    (u v : NeighborIndex F p.1 p.2) :
+    H.completedNeighboringControlledMap hindex X ⟨p, (a, u)⟩ ⟨p, (b, v)⟩ =
+      H.completedNeighboringPreparationMap hindex p.1 p.2
+        (X.submatrix (Sigma.mk p) (Sigma.mk p)) (a, u) (b, v) := by
+  classical
+  rw [completedNeighboringControlledMap, Matrix.controlledKrausMap_sameBlock_apply,
+    Matrix.rectangularKrausMap_equiv
+      (Fintype.equivFin (NeighborIndex F p.1 p.2)),
+    Matrix.rectangularKrausMap_preparationKraus_eq]
+  rfl
+
+/-- The orthogonally controlled neighboring-state preparation is
+trace-preserving and completely positive.
+
+This is the sector-control part of $\mathcal S_1$ in arXiv:1606.00608,
+Appendix C.2, lines 1548--1555. -/
+theorem completedNeighboringControlledMap_isKrausCPTP
+    (H : NeighboringTraceFactorization F)
+    (hindex : ∀ k h, Nonempty (NeighborIndex F k h)) :
+    IsKrausCPTP (H.completedNeighboringControlledMap hindex (α := α)) := by
+  apply Matrix.controlledKrausMap_isKrausCPTP
+  intro p
+  exact Matrix.preparationKraus_resolution
+    (H.completedNeighboringDensity hindex p.1 p.2)
+    (H.completedNeighboringDensity_pos hindex p.1 p.2)
+    (H.trace_completedNeighboringDensity hindex p.1 p.2)
+
+end ControlledPreparation
+
+end NeighboringTraceFactorization
+
+end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/NeighboringPreparation.lean
+++ b/TNLean/MPS/MPDO/NeighboringPreparation.lean
@@ -24,8 +24,7 @@ $\mathcal S_1$.
 ## References
 
 * [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
-  Appendix C.2, equations `Appetakhetc`, `Apptralktrrk`, `AppPsiPhi`, and
-  Proposition `3to5`, lines 1389--1403 and 1548--1555
+  Appendix C.2, lines 1389--1403 and 1548--1555
 -/
 
 open scoped Matrix BigOperators ComplexOrder
@@ -45,8 +44,7 @@ of a physical-sector factorization:
 Together with `PhysicalSectorFactorization`, these are exactly the hypotheses
 used in Proposition C.7.
 
-Source: arXiv:1606.00608, Appendix C.2, equations `Appetakhetc`,
-`Apptralktrrk`, and `AppPsiPhi`, lines 1389--1403. -/
+Source: arXiv:1606.00608, Appendix C.2, lines 1389--1403. -/
 structure NeighboringTraceFactorization (F : PhysicalSectorFactorization K) where
   /-- Every neighboring operator $\eta_{k,h}$ is positive semidefinite. -/
   neighboringOperator_pos : ∀ k h, (F.neighboringOperator k h).PosSemidef

--- a/TNLean/MPS/MPDO/PhysicalSectorCoarseGraining.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorCoarseGraining.lean
@@ -1,0 +1,73 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.NeighboringPreparation
+import TNLean.MPS.MPDO.PhysicalSectorSubspinMaps
+
+/-!
+# The physical-sector coarse-graining channel
+
+This file defines the three stages of the coarse-graining channel
+\(\mathcal S=\mathcal S_2\mathcal S_1\mathcal S_0\) in Proposition C.7.
+The hypotheses are precisely the physical-sector factorization, positivity of
+the neighboring operators, and their rank-one trace factorization.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, lines 1547--1563
+-/
+
+open scoped Matrix
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D} {F : PhysicalSectorFactorization K}
+
+/-- The map \(\mathcal S_1\) discards coherences between outer-sector pairs
+and adjoins the normalized neighboring density in each diagonal pair.  On a
+zero-weight pair it uses an arbitrary density matrix; the neighboring operator
+then vanishes, so this choice does not affect the fixed-point identity.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1548--1555. -/
+noncomputable def NeighboringTraceFactorization.s1Map
+    (H : NeighboringTraceFactorization F) :
+    Matrix (BoundarySubspinIndex F) (BoundarySubspinIndex F) ℂ →ₗ[ℂ]
+      Matrix (S2PreparationIndex F) (S2PreparationIndex F) ℂ :=
+  H.completedNeighboringControlledMap F.neighborIndex_nonempty
+    (α := fun kh : Fin F.sectorCount × Fin F.sectorCount ↦
+      BoundaryIndex F kh.1 kh.2)
+
+/-- The map \(\mathcal S_1\) is trace-preserving and completely positive.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1548--1555. -/
+theorem NeighboringTraceFactorization.s1Map_isKrausCPTP
+    (H : NeighboringTraceFactorization F) : IsKrausCPTP H.s1Map := by
+  exact H.completedNeighboringControlledMap_isKrausCPTP F.neighborIndex_nonempty
+
+/-- The coarse-graining channel
+\(\mathcal S=\mathcal S_2\mathcal S_1\mathcal S_0\) from three physical sites
+to two physical sites.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1547--1563. -/
+noncomputable def NeighboringTraceFactorization.sMap
+    (H : NeighboringTraceFactorization F) :
+    Matrix (SectorSiteIndex F × (SectorSiteIndex F × SectorSiteIndex F))
+        (SectorSiteIndex F × (SectorSiteIndex F × SectorSiteIndex F)) ℂ →ₗ[ℂ]
+      Matrix (SectorSiteIndex F × SectorSiteIndex F)
+        (SectorSiteIndex F × SectorSiteIndex F) ℂ :=
+  F.s2Map ∘ₗ H.s1Map ∘ₗ F.s0Map
+
+/-- The coarse-graining channel \(\mathcal S\) is trace-preserving and
+completely positive.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1547--1563. -/
+theorem NeighboringTraceFactorization.sMap_isKrausCPTP
+    (H : NeighboringTraceFactorization F) : IsKrausCPTP H.sMap := by
+  exact isKrausCPTP_comp
+    (isKrausCPTP_comp F.s0Map_isKrausCPTP H.s1Map_isKrausCPTP)
+    F.s2Map_isKrausCPTP
+
+end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/PhysicalSectorFactorization.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorFactorization.lean
@@ -56,10 +56,10 @@ structure PhysicalSectorFactorization (K : MPOTensor d D) where
   /-- Dimension of the right factor in each physical sector. -/
   rightDim : Fin sectorCount → ℕ
   /-- Every left sector factor is nonzero, as the direct sum ranges over the
-  nonzero sector summands in equation `AppUkU=rl`, lines 1381--1388. -/
+  nonzero sector summands in arXiv:1606.00608, Appendix C.2, lines 1381--1388. -/
   leftDim_pos : ∀ k, 0 < leftDim k
   /-- Every right sector factor is nonzero, as the direct sum ranges over the
-  nonzero sector summands in equation `AppUkU=rl`, lines 1381--1388. -/
+  nonzero sector summands in arXiv:1606.00608, Appendix C.2, lines 1381--1388. -/
   rightDim_pos : ∀ k, 0 < rightDim k
   /-- Identification of the physical space with the direct sum of its sectors. -/
   sectorEquiv : Fin d ≃ Σ k : Fin sectorCount, Fin (leftDim k) × Fin (rightDim k)

--- a/TNLean/MPS/MPDO/PhysicalSectorFactorization.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorFactorization.lean
@@ -55,6 +55,12 @@ structure PhysicalSectorFactorization (K : MPOTensor d D) where
   leftDim : Fin sectorCount → ℕ
   /-- Dimension of the right factor in each physical sector. -/
   rightDim : Fin sectorCount → ℕ
+  /-- Every left sector factor is nonzero, as the direct sum ranges over the
+  nonzero sector summands in equation `AppUkU=rl`, lines 1381--1388. -/
+  leftDim_pos : ∀ k, 0 < leftDim k
+  /-- Every right sector factor is nonzero, as the direct sum ranges over the
+  nonzero sector summands in equation `AppUkU=rl`, lines 1381--1388. -/
+  rightDim_pos : ∀ k, 0 < rightDim k
   /-- Identification of the physical space with the direct sum of its sectors. -/
   sectorEquiv : Fin d ≃ Σ k : Fin sectorCount, Fin (leftDim k) × Fin (rightDim k)
   /-- The physical-space isometry in equation `AppUkU=rl`. -/
@@ -88,6 +94,12 @@ and `h`. -/
 abbrev NeighborIndex (F : PhysicalSectorFactorization K)
     (k h : Fin F.sectorCount) :=
   Fin (F.rightDim k) × Fin (F.leftDim h)
+
+/-- Every neighboring-subspin index space is nonempty because the sector
+summands have nonzero left and right factors. -/
+theorem neighborIndex_nonempty (F : PhysicalSectorFactorization K)
+    (k h : Fin F.sectorCount) : Nonempty (NeighborIndex F k h) :=
+  ⟨(⟨0, F.rightDim_pos k⟩, ⟨0, F.leftDim_pos h⟩)⟩
 
 /-- The index space supporting the two outer tensors in sectors `k` and `h`. -/
 abbrev BoundaryIndex (F : PhysicalSectorFactorization K)

--- a/TNLean/MPS/MPDO/PhysicalSectorSubspinMaps.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorSubspinMaps.lean
@@ -1,0 +1,158 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.KrausCPTP
+import TNLean.MPS.MPDO.PhysicalSectorFactorization
+
+/-!
+# Physical-sector subspin maps
+
+This file defines the regrouping and partial trace $\mathcal S_0$, together
+with the shift $\mathcal S_2$, directly from a physical-sector factorization
+of a simple MPO tensor.  The construction uses only the decomposition
+
+\[
+  \mathcal H=\bigoplus_k B_k^L\otimes B_k^R.
+\]
+
+In particular, it does not require a quantum-Markov decomposition of a
+tripartite state.
+
+## Main declarations
+
+* `s0RegroupEquiv`: the three-site regrouping into the two outer subspins and
+  the four middle subspins.
+* `s0Map`: the regrouping followed by the partial trace over the four middle
+  subspins.
+* `s2ShiftEquiv` and `s2Map`: the two-site shift from the regrouped factors
+  back to two physical sites.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, lines 1547 and 1555--1559
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D}
+
+/-- The direct sum of the one-site physical-sector indices. -/
+abbrev SectorSiteIndex (F : PhysicalSectorFactorization K) :=
+  Σ k : Fin F.sectorCount, SectorIndex F k
+
+/-- The direct sum of the two outer subspins retained between sectors $k$
+and $h$. -/
+abbrev BoundarySubspinIndex (F : PhysicalSectorFactorization K) :=
+  Σ kh : Fin F.sectorCount × Fin F.sectorCount, BoundaryIndex F kh.1 kh.2
+
+/-- The four middle subspins traced by $\mathcal S_0$, with the intermediate
+sector retained as a direct-sum label. -/
+abbrev ThreeSiteMiddleIndex (F : PhysicalSectorFactorization K)
+    (k h : Fin F.sectorCount) :=
+  Σ l : Fin F.sectorCount, NeighborIndex F k l × NeighborIndex F l h
+
+/-- The direct sum obtained by regrouping three physical sites into the two
+outer subspins and the four middle subspins. -/
+abbrev S0PreparationIndex (F : PhysicalSectorFactorization K) :=
+  Σ kh : Fin F.sectorCount × Fin F.sectorCount,
+    BoundaryIndex F kh.1 kh.2 × ThreeSiteMiddleIndex F kh.1 kh.2
+
+/-- The direct sum on which $\mathcal S_2$ acts: two outer subspins together
+with the neighboring pair between them. -/
+abbrev S2PreparationIndex (F : PhysicalSectorFactorization K) :=
+  Σ kh : Fin F.sectorCount × Fin F.sectorCount,
+    BoundaryIndex F kh.1 kh.2 × NeighborIndex F kh.1 kh.2
+
+/-- Regroup three physical-sector indices as
+
+$$
+((l_k,r_k),((l_l,r_l),(l_h,r_h)))
+\longmapsto ((l_k,r_h),(l,(r_k,l_l),(r_l,l_h))).
+$$
+
+The first factor consists of the two outer subspins.  The second factor
+consists of the four middle subspins that $\mathcal S_0$ traces.
+
+**Local fix (repeated subspin):** the final $2l$ in the source sentence is
+read as $3l$, as forced by the source diagram. Documented in
+`docs/paper-gaps/cpgsv17_mpdo_s0_trace_subspin_typo.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, line 1547. -/
+def s0RegroupEquiv (F : PhysicalSectorFactorization K) :
+    (SectorSiteIndex F × (SectorSiteIndex F × SectorSiteIndex F)) ≃
+      S0PreparationIndex F where
+  toFun x := ⟨(x.1.1, x.2.2.1), ((x.1.2.1, x.2.2.2.2),
+    ⟨x.2.1.1, ((x.1.2.2, x.2.1.2.1), (x.2.1.2.2, x.2.2.2.1))⟩)⟩
+  invFun x := (⟨x.1.1, (x.2.1.1, x.2.2.2.1.1)⟩,
+    (⟨x.2.2.1, (x.2.2.2.1.2, x.2.2.2.2.1)⟩,
+      ⟨x.1.2, (x.2.2.2.2.2, x.2.1.2)⟩))
+  left_inv := by rintro ⟨⟨k, lk, rk⟩, ⟨l, ll, rl⟩, h, lh, rh⟩; rfl
+  right_inv := by rintro ⟨⟨k, h⟩, ⟨lk, rh⟩, l, ⟨rk, ll⟩, rl, lh⟩; rfl
+
+/-- The map $\mathcal S_0$: regroup three sites, then trace the four middle
+subspins in every orthogonal pair of outer sectors.
+
+**Local fix (repeated subspin):** the final $2l$ in the source sentence is
+read as $3l$, as forced by the source diagram. Documented in
+`docs/paper-gaps/cpgsv17_mpdo_s0_trace_subspin_typo.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, line 1547. -/
+noncomputable def s0Map (F : PhysicalSectorFactorization K) :
+    Matrix (SectorSiteIndex F × (SectorSiteIndex F × SectorSiteIndex F))
+        (SectorSiteIndex F × (SectorSiteIndex F × SectorSiteIndex F)) ℂ →ₗ[ℂ]
+      Matrix (BoundarySubspinIndex F) (BoundarySubspinIndex F) ℂ :=
+  Matrix.controlledPartialTraceRightLM
+      (α := fun kh : Fin F.sectorCount × Fin F.sectorCount =>
+        BoundaryIndex F kh.1 kh.2)
+      (β := fun kh : Fin F.sectorCount × Fin F.sectorCount =>
+        ThreeSiteMiddleIndex F kh.1 kh.2) ∘ₗ
+    Matrix.equivReindexMap (s0RegroupEquiv F)
+
+/-- The map $\mathcal S_0$ is trace-preserving and completely positive.
+
+Source: arXiv:1606.00608, Appendix C.2, line 1547. -/
+theorem s0Map_isKrausCPTP (F : PhysicalSectorFactorization K) :
+    IsKrausCPTP (s0Map F) := by
+  simpa [s0Map] using isKrausCPTP_comp
+    (Matrix.equivReindexMap_isKrausCPTP (s0RegroupEquiv F))
+    Matrix.controlledPartialTraceRightLM_isKrausCPTP
+
+/-- The shift $\mathcal S_2$ regroups an outer pair and its neighboring
+subspins into two complete physical sectors:
+
+$$
+((l_k,r_h),(r_k,l_h))\longmapsto((l_k,r_k),(l_h,r_h)).
+$$
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1555--1559. -/
+def s2ShiftEquiv (F : PhysicalSectorFactorization K) :
+    S2PreparationIndex F ≃ (SectorSiteIndex F × SectorSiteIndex F) where
+  toFun x := (⟨x.1.1, (x.2.1.1, x.2.2.1)⟩,
+    ⟨x.1.2, (x.2.2.2, x.2.1.2)⟩)
+  invFun x := ⟨(x.1.1, x.2.1), ((x.1.2.1, x.2.2.2), (x.1.2.2, x.2.2.1))⟩
+  left_inv := by rintro ⟨⟨k, h⟩, ⟨lk, rh⟩, rk, lh⟩; rfl
+  right_inv := by rintro ⟨⟨k, lk, rk⟩, h, lh, rh⟩; rfl
+
+/-- The global shift $\mathcal S_2$, realized by reindexing matrices along
+`s2ShiftEquiv`.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1555--1559. -/
+def s2Map (F : PhysicalSectorFactorization K) :
+    Matrix (S2PreparationIndex F) (S2PreparationIndex F) ℂ →ₗ[ℂ]
+      Matrix (SectorSiteIndex F × SectorSiteIndex F)
+        (SectorSiteIndex F × SectorSiteIndex F) ℂ :=
+  Matrix.equivReindexMap (s2ShiftEquiv F)
+
+/-- The shift $\mathcal S_2$ is trace-preserving and completely positive.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1555--1559. -/
+theorem s2Map_isKrausCPTP (F : PhysicalSectorFactorization K) :
+    IsKrausCPTP (s2Map F) :=
+  Matrix.equivReindexMap_isKrausCPTP (s2ShiftEquiv F)
+
+end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/PhysicalSectorTraceActions.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorTraceActions.lean
@@ -3,7 +3,9 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.MPS.MPDO.NeighboringPreparation
 import TNLean.MPS.MPDO.PhysicalSectorClosureTwo
+import TNLean.MPS.MPDO.PhysicalSectorClosureThree
 
 /-!
 # Partial traces of physical-sector closures
@@ -43,5 +45,50 @@ theorem partialTraceRight_twoSiteSectorClosure
     Matrix.partialTraceRight (F.twoSiteSectorClosure k h X) =
       (F.neighboringOperator k h).trace • F.boundaryOperator k h X := by
   rw [F.twoSiteSectorClosure_eq, Matrix.partialTraceRight_kronecker]
+
+/-- Under the rank-one trace factorization, the two-site partial trace has
+coefficient \(a_kb_h\).
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1518--1522. -/
+theorem NeighboringTraceFactorization.partialTraceRight_twoSiteSectorClosure
+    {F : PhysicalSectorFactorization K} (H : NeighboringTraceFactorization F)
+    (k h : Fin F.sectorCount) (X : Matrix (Fin D) (Fin D) ℂ) :
+    Matrix.partialTraceRight (F.twoSiteSectorClosure k h X) =
+      ((H.a k * H.b h : ℝ) : ℂ) • F.boundaryOperator k h X := by
+  rw [F.partialTraceRight_twoSiteSectorClosure, H.trace_neighboringOperator]
+
+/-- Tracing the four middle factors of a fixed-sector three-site closure
+leaves the boundary operator multiplied by the traces of the two neighboring
+operators.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1547--1555. -/
+theorem partialTraceRight_threeSiteSectorClosure
+    (F : PhysicalSectorFactorization K) (k l h : Fin F.sectorCount)
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    Matrix.partialTraceRight (F.threeSiteSectorClosure k l h X) =
+      ((F.neighboringOperator k l).trace *
+          (F.neighboringOperator l h).trace) • F.boundaryOperator k h X := by
+  rw [F.threeSiteSectorClosure_eq, Matrix.partialTraceRight_kronecker,
+    Matrix.trace_kronecker]
+
+/-- Summing the three-site partial-trace coefficients over the intermediate
+sector gives \(a_kb_h\).
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1547--1555. -/
+theorem NeighboringTraceFactorization.sum_threeSite_trace_coefficients
+    {F : PhysicalSectorFactorization K} (H : NeighboringTraceFactorization F)
+    (k h : Fin F.sectorCount) :
+    ∑ l, (F.neighboringOperator k l).trace *
+        (F.neighboringOperator l h).trace = ((H.a k * H.b h : ℝ) : ℂ) := by
+  simp_rw [H.trace_neighboringOperator]
+  norm_cast
+  calc
+    ∑ l, H.a k * H.b l * (H.a l * H.b h) =
+        H.a k * (∑ l, H.a l * H.b l) * H.b h := by
+      rw [Finset.mul_sum, Finset.sum_mul]
+      apply Finset.sum_congr rfl
+      intro l _
+      ring
+    _ = H.a k * H.b h := by rw [H.sum_mul]; ring
 
 end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/PhysicalSectorTraceActions.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorTraceActions.lean
@@ -1,0 +1,47 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalSectorClosureTwo
+
+/-!
+# Partial traces of physical-sector closures
+
+This file computes the partial trace of the two-site physical closure in fixed
+sectors.  Once the physical indices have been regrouped into their two outer
+factors and the neighboring pair, tracing the neighboring pair multiplies the
+boundary operator by the trace of the neighboring operator.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, lines 1518--1522
+-/
+
+open scoped Matrix Kronecker
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D}
+
+/-- Tracing the neighboring factors of a fixed-sector two-site closure leaves
+the boundary operator multiplied by the trace of the neighboring operator:
+\[
+  \operatorname{tr}_{B_k^R\otimes B_h^L}
+    \bigl(\mathcal K_{2;k,h}(X)\bigr)
+  =\operatorname{tr}(\eta_{k,h})B_{k,h}(X).
+\]
+
+This is the first partial-trace calculation in the construction of
+$\mathcal T$ in Proposition C.7.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1518--1522. -/
+theorem partialTraceRight_twoSiteSectorClosure
+    (F : PhysicalSectorFactorization K) (k h : Fin F.sectorCount)
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    Matrix.partialTraceRight (F.twoSiteSectorClosure k h X) =
+      (F.neighboringOperator k h).trace • F.boundaryOperator k h X := by
+  rw [F.twoSiteSectorClosure_eq, Matrix.partialTraceRight_kronecker]
+
+end MPOTensor.PhysicalSectorFactorization

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -781,7 +781,8 @@ strong subadditivity for a normalized three-site reduced state.
       MPOTensor.PhysicalSectorFactorization.transformedPhysicalSlice,
       MPOTensor.PhysicalSectorFactorization.transformedPhysicalSlice_eq,
       MPOTensor.PhysicalSectorFactorization.sectorFinEquiv,
-      MPOTensor.PhysicalSectorFactorization.sectorCoordinateTensor}
+      MPOTensor.PhysicalSectorFactorization.sectorCoordinateTensor,
+      MPOTensor.PhysicalSectorFactorization.neighborIndex_nonempty}
     \lean{MPOTensor.PhysicalSectorFactorization.sectorCoordinateTensor_apply,
       MPOTensor.PhysicalSectorFactorization.sectorCoordinateTensor_apply_same,
       MPOTensor.PhysicalSectorFactorization.sectorCoordinateTensor_apply_ne}
@@ -794,6 +795,7 @@ strong subadditivity for a normalized three-site reduced state.
     \[
       \mathbb C^d\simeq\bigoplus_k(B_k^L\otimes B_k^R),
     \]
+    whose left and right factors are nonzero,
     an isometry $U$ on the physical space, and matrix families
     $(l_k)_\beta$ and $(r_k)_\alpha$ such that every physical slice satisfies
     \[
@@ -973,6 +975,64 @@ strong subadditivity for a normalized three-site reduced state.
       {Cirac2016MPDO_arXiv}.}
     \label{fig:mpdo_sector_closure_factorizations}
 \end{figure}
+
+\begin{definition}[Neighboring-operator trace factorization]
+    \label{def:mpdo_neighboring_trace_factorization}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.weight_nonneg,
+      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.neighboringOperator_eq_zero_of_mul_eq_zero,
+      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.neighborIndex_nonempty_of_mul_ne_zero}
+    \leanok
+    \uses{def:mpdo_minimal_neighboring_operator}
+    Suppose that every neighboring operator is positive semidefinite and that
+    there are real numbers $a_k,b_h$ such that
+    \[
+      \tr(\eta_{k,h})=a_kb_h,
+      \qquad
+      \sum_k a_kb_k=1.
+    \]
+    These are precisely the remaining hypotheses used in the construction of
+    Proposition~C.7 after the physical-sector factorization has been fixed
+    \cite[Appendix~C.2, lines~1389--1403]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{theorem}[Partial traces of the sector closures]
+    \label{thm:mpdo_sector_closure_partial_traces}
+    \lean{MPOTensor.PhysicalSectorFactorization.partialTraceRight_twoSiteSectorClosure}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.partialTraceRight_twoSiteSectorClosure}
+    \lean{MPOTensor.PhysicalSectorFactorization.partialTraceRight_threeSiteSectorClosure}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.sum_threeSite_trace_coefficients}
+    \leanok
+    \uses{thm:mpdo_two_site_sector_closure_factorization,
+      thm:mpdo_three_site_sector_closure_factorization,
+      def:mpdo_neighboring_trace_factorization}
+    For every virtual matrix $X$,
+    \[
+      \tr_{R_k\otimes L_h}\!\left({\cal K}_{2;k,h}(X)\right)
+      =\tr(\eta_{k,h})B_{k,h}(X)
+      =a_kb_h B_{k,h}(X).
+    \]
+    Similarly,
+    \[
+      \tr_{(R_k\otimes L_l)\otimes(R_l\otimes L_h)}
+        \!\left({\cal K}_{3;k,l,h}(X)\right)
+      =\tr(\eta_{k,l})\tr(\eta_{l,h})B_{k,h}(X),
+    \]
+    and summing the scalar coefficient over $l$ gives $a_kb_h$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_two_site_sector_closure_factorization,
+      thm:mpdo_three_site_sector_closure_factorization}
+    The partial trace of $A\otimes B$ is $\tr(B)A$. The two-site identity
+    follows immediately. For three sites, the coefficient is
+    \[
+      \sum_l (a_kb_l)(a_lb_h)
+      =a_k\left(\sum_l a_lb_l\right)b_h
+      =a_kb_h.
+    \]
+\end{proof}
 
 \begin{definition}[Closed sector tensors]%
     \label{def:mpdo_closed_sector_tensors}
@@ -2145,6 +2205,8 @@ strong subadditivity for a normalized three-site reduced state.
 \begin{definition}[The two-site shift $\mathcal S_2$]
     \label{def:mpdo_s2_map}
     \lean{MPOTensor.ExplicitEtaOperators.s2Map}
+    \lean{MPOTensor.PhysicalSectorFactorization.s2ShiftEquiv,
+      MPOTensor.PhysicalSectorFactorization.s2Map}
     \leanok
     \uses{def:mpdo_two_site_subspin_regrouping,
       def:mpdo_equiv_reindex_map}
@@ -2159,6 +2221,7 @@ strong subadditivity for a normalized three-site reduced state.
 \begin{theorem}[$\mathcal S_2$ is trace-preserving completely positive]
     \label{thm:mpdo_s2_map_cptp}
     \lean{MPOTensor.ExplicitEtaOperators.s2Map_isKrausCPTP}
+    \lean{MPOTensor.PhysicalSectorFactorization.s2Map_isKrausCPTP}
     \leanok
     \uses{def:mpdo_s2_map}
     The shift $\mathcal S_2$ is trace-preserving and completely positive.
@@ -2178,6 +2241,9 @@ strong subadditivity for a normalized three-site reduced state.
     \lean{MPOTensor.ExplicitEtaOperators.s0RegroupEquiv}
     \lean{MPOTensor.ExplicitEtaOperators.omegaShiftEquiv}
     \lean{MPOTensor.ExplicitEtaOperators.t2ShiftEquiv}
+    \lean{MPOTensor.PhysicalSectorFactorization.ThreeSiteMiddleIndex,
+      MPOTensor.PhysicalSectorFactorization.S0PreparationIndex,
+      MPOTensor.PhysicalSectorFactorization.s0RegroupEquiv}
     \leanok
     \uses{def:mpdo_two_site_subspin_regrouping, def:mpdo_eta_omega}
     Regroup three sites by
@@ -2203,6 +2269,7 @@ strong subadditivity for a normalized three-site reduced state.
 \begin{definition}[The three-site partial-trace map $\mathcal S_0$]
     \label{def:mpdo_s0_map}
     \lean{MPOTensor.ExplicitEtaOperators.s0Map}
+    \lean{MPOTensor.PhysicalSectorFactorization.s0Map}
     \leanok
     \uses{def:mpdo_three_site_subspin_regrouping,
       def:mpdo_controlled_dependent_partial_trace,
@@ -2227,6 +2294,7 @@ strong subadditivity for a normalized three-site reduced state.
 \begin{theorem}[$\mathcal S_0$ is trace-preserving completely positive]
     \label{thm:mpdo_s0_map_cptp}
     \lean{MPOTensor.ExplicitEtaOperators.s0Map_isKrausCPTP}
+    \lean{MPOTensor.PhysicalSectorFactorization.s0Map_isKrausCPTP}
     \leanok
     \uses{def:mpdo_s0_map}
     The map $\mathcal S_0$ is trace-preserving and completely positive.
@@ -2388,9 +2456,76 @@ strong subadditivity for a normalized three-site reduced state.
     \label{fig:mpdo_regrouping_partial_trace_maps}
 \end{figure}
 
-% The orthogonal direct sum of the active maps and a trace-preserving
-% completion on the unused zero-weight input summands remain part of the
-% construction of the full maps T_1 and S_1.
+\begin{definition}[The neighboring-state preparation $\mathcal S_1$]
+    \label{def:mpdo_physical_sector_s1_map}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.normalizedNeighboringDensity}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.normalizedNeighboringDensity_pos,
+      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.trace_normalizedNeighboringDensity,
+      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.normalizedNeighboringPreparationMap_isKrausCPTP}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.inactiveNeighboringDensity,
+      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.inactiveNeighboringDensity_posDef,
+      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.inactiveNeighboringDensity_trace}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedNeighboringDensity}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedNeighboringDensity_pos,
+      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.trace_completedNeighboringDensity,
+      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedNeighboringDensity_eq_normalized}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedNeighboringPreparationMap,
+      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedNeighboringPreparationMap_isKrausCPTP,
+      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedNeighboringPreparationMap_eq_normalized}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedNeighboringControlledMap}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedNeighboringControlledMap_sameBlock_apply}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.s1Map}
+    \leanok
+    \uses{def:mpdo_neighboring_trace_factorization}
+    On a sector pair with $a_kb_h\ne0$, let
+    \[
+      \mathcal S_{k,h}(X)=X\otimes\frac{\eta_{k,h}}{a_kb_h}.
+    \]
+    If $a_kb_h=0$, positivity and vanishing trace imply
+    $\eta_{k,h}=0$; choose any density operator on that unused summand.
+    Taking the orthogonal direct sum over $(k,h)$ defines $\mathcal S_1$.
+\end{definition}
+
+\begin{theorem}[$\mathcal S_1$ is trace-preserving completely positive]
+    \label{thm:mpdo_physical_sector_s1_map_cptp}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedNeighboringControlledMap_isKrausCPTP}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.s1Map_isKrausCPTP}
+    \leanok
+    \uses{def:mpdo_physical_sector_s1_map}
+    The map $\mathcal S_1$ is trace-preserving and completely positive.
+\end{theorem}
+
+\begin{definition}[The coarse-graining channel $\mathcal S$]
+    \label{def:mpdo_physical_sector_s_map}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.sMap}
+    \leanok
+    \uses{def:mpdo_s0_map, def:mpdo_physical_sector_s1_map,
+      def:mpdo_s2_map}
+    Define the channel from three physical sites to two physical sites by
+    \[
+      \mathcal S=\mathcal S_2\mathcal S_1\mathcal S_0.
+    \]
+    This is the coarse-graining map in Proposition~C.7
+    \cite[Appendix~C.2, lines~1547--1563]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{theorem}[$\mathcal S$ is trace-preserving completely positive]
+    \label{thm:mpdo_physical_sector_s_map_cptp}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.sMap_isKrausCPTP}
+    \leanok
+    \uses{thm:mpdo_s0_map_cptp,
+      thm:mpdo_physical_sector_s1_map_cptp,
+      thm:mpdo_s2_map_cptp,
+      lem:is_kraus_cptp_comp}
+    The channel $\mathcal S$ is trace-preserving and completely positive.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:is_kraus_cptp_comp}
+    Each of the three factors is trace-preserving and completely positive,
+    and this property is preserved under composition.
+\end{proof}
 
 \begin{figure}[ht]
     \centering


### PR DESCRIPTION
## Mathematical content

This pull request constructs the coarse-graining channel
\[
\mathcal S=\mathcal S_2\mathcal S_1\mathcal S_0
\]
from Proposition C.7 of arXiv:1606.00608, Appendix C.2, lines 1547--1563.

The construction is formulated directly from the physical-sector factorization. It assumes only:

- nonzero left and right sector factors;
- positivity of every neighboring operator \(\eta_{k,h}\);
- \(\operatorname{tr}(\eta_{k,h})=a_kb_h\);
- \(\sum_k a_kb_k=1\).

It does not use the stronger Hayashi quantum-Markov structure.

The new results provide:

- the exact two- and three-site partial-trace calculations;
- normalized neighboring densities on active sector pairs and arbitrary density completions on zero-weight pairs;
- the controlled preparation \(\mathcal S_1\);
- physical-sector versions of \(\mathcal S_0\) and \(\mathcal S_2\);
- the composed channel \(\mathcal S\), with a proof that it is trace-preserving and completely positive.

The local correction at source line 1547, where the final traced subspin is \(3l\) rather than the repeated \(2l\), remains documented in `docs/paper-gaps/cpgsv17_mpdo_s0_trace_subspin_typo.tex`.

The literal identity \(\mathcal S(\mathcal K_3(X))=\mathcal K_2(X)\) still requires the full direct-sum closure evaluation and is therefore not claimed here. This pull request advances, but does not close, #3743.

## Blueprint

The MPO/RFP chapter now records the source-minimal trace hypotheses, sector partial traces, \(\mathcal S_1\), the composed channel, and its channel theorem. The existing TikZ diagrams reproduce the coarse-graining contractions and subspin regroupings from the paper figures.

## Verification

- `lake build TNLean`
- focused builds for the new MPO/RFP modules
- `leanblueprint checkdecls`
- `leanblueprint pdf`
- `leanblueprint web`
- blueprint forward and reverse declaration synchronization
- reader-facing prose check
- proof-integrity scan
- kernel axiom audit of the headline results (only `propext`, `Classical.choice`, and `Quot.sound`)

Advances #3743
Parent: #3740

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal mathematics (new Lean modules and blueprint links); no runtime, auth, or data-path changes. Downstream callers must satisfy the new `leftDim_pos` / `rightDim_pos` fields on `PhysicalSectorFactorization`.
> 
> **Overview**
> Formalizes Proposition C.7’s coarse-graining channel \(\mathcal S=\mathcal S_2\mathcal S_1\mathcal S_0\) from a **physical-sector factorization** plus neighboring-operator positivity and rank-one trace data \(\mathrm{tr}(\eta_{k,h})=a_kb_h\), \(\sum_k a_kb_k=1\)—without Hayashi quantum-Markov structure.
> 
> **`PhysicalSectorFactorization`** now requires **nonzero** left/right sector dimensions and supplies **`neighborIndex_nonempty`**. New Lean modules define **`s0Map` / `s2Map`** (subspin regrouping and partial trace), **`NeighboringTraceFactorization`** with completed/normalized neighboring densities and orthogonally controlled **`s1Map`**, composition **`sMap`**, and **partial-trace lemmas** on two-/three-site sector closures (including \(\sum_l\) collapsing to \(a_kb_h\)). Each stage is proved **`IsKrausCPTP`**.
> 
> The MPO/RFP blueprint chapter gains matching definitions and theorems (trace hypotheses, \(\mathcal S_1\), \(\mathcal S\), CPTP). The full identity \(\mathcal S(\mathcal K_3(X))=\mathcal K_2(X)\) is still out of scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07546c242b179a2401a8aa5f13a7f077adc299e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->