### PR TITLE
feat(MPS/MPDO): prove the coarse-graining identity

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -389,6 +389,7 @@ import TNLean.MPS.MPDO.PhysicalSectorFactorization
 import TNLean.MPS.MPDO.NeighboringPreparation
 import TNLean.MPS.MPDO.PhysicalSectorSubspinMaps
 import TNLean.MPS.MPDO.PhysicalSectorCoarseGraining
+import TNLean.MPS.MPDO.PhysicalSectorCoarseGrainingAction
 import TNLean.MPS.MPDO.PhysicalSectorClosureTwo
 import TNLean.MPS.MPDO.PhysicalSectorClosureThree
 import TNLean.MPS.MPDO.PhysicalSectorClosureGlobal

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -391,6 +391,7 @@ import TNLean.MPS.MPDO.PhysicalSectorSubspinMaps
 import TNLean.MPS.MPDO.PhysicalSectorCoarseGraining
 import TNLean.MPS.MPDO.PhysicalSectorClosureTwo
 import TNLean.MPS.MPDO.PhysicalSectorClosureThree
+import TNLean.MPS.MPDO.PhysicalSectorClosureGlobal
 import TNLean.MPS.MPDO.PhysicalSectorTraceActions
 import TNLean.MPS.MPDO.SectorPairingTransfer
 import TNLean.MPS.MPDO.SectorEtaContraction

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -389,12 +389,12 @@ import TNLean.MPS.MPDO.PhysicalSectorFactorization
 import TNLean.MPS.MPDO.NeighboringPreparation
 import TNLean.MPS.MPDO.PhysicalSectorSubspinMaps
 import TNLean.MPS.MPDO.PhysicalSectorCoarseGraining
-import TNLean.MPS.MPDO.PhysicalSectorCoarseGrainingAction
-import TNLean.MPS.MPDO.PhysicalSectorCoarseGrainingIdentity
 import TNLean.MPS.MPDO.PhysicalSectorClosureTwo
 import TNLean.MPS.MPDO.PhysicalSectorClosureThree
 import TNLean.MPS.MPDO.PhysicalSectorClosureGlobal
 import TNLean.MPS.MPDO.PhysicalSectorTraceActions
+import TNLean.MPS.MPDO.PhysicalSectorCoarseGrainingAction
+import TNLean.MPS.MPDO.PhysicalSectorCoarseGrainingIdentity
 import TNLean.MPS.MPDO.SectorPairingTransfer
 import TNLean.MPS.MPDO.SectorEtaContraction
 import TNLean.MPS.MPDO.SectorEtaOperator

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -390,6 +390,7 @@ import TNLean.MPS.MPDO.NeighboringPreparation
 import TNLean.MPS.MPDO.PhysicalSectorSubspinMaps
 import TNLean.MPS.MPDO.PhysicalSectorCoarseGraining
 import TNLean.MPS.MPDO.PhysicalSectorCoarseGrainingAction
+import TNLean.MPS.MPDO.PhysicalSectorCoarseGrainingIdentity
 import TNLean.MPS.MPDO.PhysicalSectorClosureTwo
 import TNLean.MPS.MPDO.PhysicalSectorClosureThree
 import TNLean.MPS.MPDO.PhysicalSectorClosureGlobal

--- a/TNLean/MPS/MPDO/PhysicalSectorClosureGlobal.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorClosureGlobal.lean
@@ -1,0 +1,221 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalSectorClosureTwo
+import TNLean.MPS.MPDO.PhysicalSectorClosureThree
+
+/-!
+# Global physical-sector closure decompositions
+
+This file combines the fixed-sector closure identities of Appendix C.2 of
+arXiv:1606.00608 into direct-sum decompositions of the complete two- and
+three-site physical closures.  The physical indices are first written as
+sector tuples, and the factors within each tuple are then regrouped into the
+outer boundary factor and the neighboring factors.
+
+The diagonal blocks are the fixed-sector Kronecker products.  Every block
+between distinct sector tuples vanishes.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, equations `AppUkU=rl` and `etarl`, lines 1381--1450, and
+  Proposition C.7, lines 1510--1563
+-/
+
+open scoped Matrix BigOperators Kronecker
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D}
+
+private def sigmaPairEquiv {I J : Type*} {A : I → Type*} {B : J → Type*} :
+    (Sigma A × Sigma B) ≃ Σ ij : I × J, A ij.1 × B ij.2 where
+  toFun x := ⟨(x.1.1, x.2.1), (x.1.2, x.2.2)⟩
+  invFun x := (⟨x.1.1, x.2.1⟩, ⟨x.1.2, x.2.2⟩)
+  left_inv := by rintro ⟨⟨i, x⟩, j, y⟩; rfl
+  right_inv := by rintro ⟨⟨i, j⟩, x, y⟩; rfl
+
+private def sigmaTripleEquiv {I J L : Type*} {A : I → Type*} {B : J → Type*}
+    {C : L → Type*} :
+    (Sigma A × (Sigma B × Sigma C)) ≃
+      Σ ijl : I × (J × L), A ijl.1 × (B ijl.2.1 × C ijl.2.2) where
+  toFun x := ⟨(x.1.1, (x.2.1.1, x.2.2.1)), (x.1.2, (x.2.1.2, x.2.2.2))⟩
+  invFun x := (⟨x.1.1, x.2.1⟩, (⟨x.1.2.1, x.2.2.1⟩, ⟨x.1.2.2, x.2.2.2⟩))
+  left_inv := by rintro ⟨⟨i, x⟩, ⟨j, y⟩, l, z⟩; rfl
+  right_inv := by rintro ⟨⟨i, j, l⟩, x, y, z⟩; rfl
+
+/-- The complete two-site physical space, indexed by a sector pair and
+regrouped into its outer and neighboring factors.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl` and `etarl`,
+lines 1381--1450. -/
+noncomputable def twoSiteGlobalRegroupEquiv (F : PhysicalSectorFactorization K) :
+    (Fin (Fintype.card (Σ k : Fin F.sectorCount, SectorIndex F k)) ×
+      Fin (Fintype.card (Σ k : Fin F.sectorCount, SectorIndex F k))) ≃
+      Σ kh : Fin F.sectorCount × Fin F.sectorCount,
+        BoundaryIndex F kh.1 kh.2 × NeighborIndex F kh.1 kh.2 :=
+  ((Equiv.prodCongr F.sectorFinEquiv F.sectorFinEquiv).trans sigmaPairEquiv).trans
+    (Equiv.sigmaCongrRight fun kh ↦ F.twoSiteRegroupEquiv kh.1 kh.2)
+
+@[simp] theorem twoSiteGlobalRegroupEquiv_symm_apply
+    (F : PhysicalSectorFactorization K) (k h : Fin F.sectorCount)
+    (x : BoundaryIndex F k h × NeighborIndex F k h) :
+    F.twoSiteGlobalRegroupEquiv.symm ⟨(k, h), x⟩ =
+      F.twoSiteSectorEmbedding k h ((F.twoSiteRegroupEquiv k h).symm x) :=
+  rfl
+
+/-- The complete three-site physical space, indexed by a sector triple and
+regrouped into its outer and two neighboring factors.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl` and `etarl`,
+lines 1381--1450; the order of factors is that of Proposition C.7,
+lines 1510--1522. -/
+noncomputable def threeSiteGlobalRegroupEquiv (F : PhysicalSectorFactorization K) :
+    (Fin (Fintype.card (Σ k : Fin F.sectorCount, SectorIndex F k)) ×
+      (Fin (Fintype.card (Σ k : Fin F.sectorCount, SectorIndex F k)) ×
+        Fin (Fintype.card (Σ k : Fin F.sectorCount, SectorIndex F k)))) ≃
+      Σ klh : Fin F.sectorCount × (Fin F.sectorCount × Fin F.sectorCount),
+        BoundaryIndex F klh.1 klh.2.2 ×
+          (NeighborIndex F klh.1 klh.2.1 × NeighborIndex F klh.2.1 klh.2.2) :=
+  ((Equiv.prodCongr F.sectorFinEquiv
+      (Equiv.prodCongr F.sectorFinEquiv F.sectorFinEquiv)).trans sigmaTripleEquiv).trans
+    (Equiv.sigmaCongrRight fun klh ↦
+      F.threeSiteRegroupEquiv klh.1 klh.2.1 klh.2.2)
+
+@[simp] theorem threeSiteGlobalRegroupEquiv_symm_apply
+    (F : PhysicalSectorFactorization K) (k l h : Fin F.sectorCount)
+    (x : BoundaryIndex F k h ×
+      (NeighborIndex F k l × NeighborIndex F l h)) :
+    F.threeSiteGlobalRegroupEquiv.symm ⟨(k, (l, h)), x⟩ =
+      F.threeSiteSectorEmbedding k l h ((F.threeSiteRegroupEquiv k l h).symm x) :=
+  rfl
+
+/-- After global regrouping, the complete two-site closure is the direct sum
+over sector pairs of the outer boundary operator tensored with the neighboring
+operator.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl` and `etarl`,
+lines 1381--1450, and the two-site operator in Proposition C.7,
+lines 1510--1516. -/
+theorem twoSiteGlobalClosure_eq (F : PhysicalSectorFactorization K)
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    Matrix.reindex F.twoSiteGlobalRegroupEquiv F.twoSiteGlobalRegroupEquiv
+        (physClose2 F.sectorCoordinateTensor X) =
+      Matrix.blockDiagonal' fun kh : Fin F.sectorCount × Fin F.sectorCount ↦
+        F.boundaryOperator kh.1 kh.2 X ⊗ₖ F.neighboringOperator kh.1 kh.2 := by
+  ext ⟨kh, x⟩ ⟨pq, y⟩
+  by_cases hp : kh = pq
+  · subst pq
+    rw [Matrix.blockDiagonal'_apply_eq]
+    change physClose2 F.sectorCoordinateTensor X
+      (F.twoSiteGlobalRegroupEquiv.symm ⟨kh, x⟩)
+      (F.twoSiteGlobalRegroupEquiv.symm ⟨kh, y⟩) = _
+    rw [twoSiteGlobalRegroupEquiv_symm_apply,
+      twoSiteGlobalRegroupEquiv_symm_apply]
+    have h := congrFun (congrFun (F.twoSiteSectorClosure_eq kh.1 kh.2 X) x) y
+    simpa only [Matrix.reindex_apply, Matrix.submatrix_apply,
+      twoSiteSectorClosure] using h
+  · rw [Matrix.blockDiagonal'_apply_ne _ _ _ hp]
+    have hne : kh.1 ≠ pq.1 ∨ kh.2 ≠ pq.2 := by
+      exact not_and_or.mp (fun h ↦ hp (Prod.ext h.1 h.2))
+    change physClose2 F.sectorCoordinateTensor X
+      (F.twoSiteGlobalRegroupEquiv.symm ⟨kh, x⟩)
+      (F.twoSiteGlobalRegroupEquiv.symm ⟨pq, y⟩) = 0
+    rw [twoSiteGlobalRegroupEquiv_symm_apply,
+      twoSiteGlobalRegroupEquiv_symm_apply]
+    simp only [twoSiteSectorEmbedding, physClose2_apply]
+    rcases hne with hne | hne
+    · have hz : F.sectorCoordinateTensor
+          (F.sectorFinEquiv.symm
+            ⟨kh.1, ((F.twoSiteRegroupEquiv kh.1 kh.2).symm x).1⟩)
+          (F.sectorFinEquiv.symm
+            ⟨pq.1, ((F.twoSiteRegroupEquiv pq.1 pq.2).symm y).1⟩) = 0 := by
+        ext beta alpha
+        exact sectorCoordinateTensor_apply_ne F hne _ _ beta alpha
+      rw [hz]
+      simp
+    · have hz : F.sectorCoordinateTensor
+          (F.sectorFinEquiv.symm
+            ⟨kh.2, ((F.twoSiteRegroupEquiv kh.1 kh.2).symm x).2⟩)
+          (F.sectorFinEquiv.symm
+            ⟨pq.2, ((F.twoSiteRegroupEquiv pq.1 pq.2).symm y).2⟩) = 0 := by
+        ext beta alpha
+        exact sectorCoordinateTensor_apply_ne F hne _ _ beta alpha
+      rw [hz]
+      simp
+
+/-- After global regrouping, the complete three-site closure is the direct
+sum over sector triples of the outer boundary operator tensored with the two
+neighboring operators.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl` and `etarl`,
+lines 1381--1450, and the three-site operator in Proposition C.7,
+lines 1510--1516. -/
+theorem threeSiteGlobalClosure_eq (F : PhysicalSectorFactorization K)
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    Matrix.reindex F.threeSiteGlobalRegroupEquiv F.threeSiteGlobalRegroupEquiv
+        (physClose3 F.sectorCoordinateTensor X) =
+      Matrix.blockDiagonal' fun
+          klh : Fin F.sectorCount × (Fin F.sectorCount × Fin F.sectorCount) ↦
+        F.boundaryOperator klh.1 klh.2.2 X ⊗ₖ
+          (F.neighboringOperator klh.1 klh.2.1 ⊗ₖ
+            F.neighboringOperator klh.2.1 klh.2.2) := by
+  ext ⟨klh, x⟩ ⟨pqr, y⟩
+  by_cases hp : klh = pqr
+  · subst pqr
+    rw [Matrix.blockDiagonal'_apply_eq]
+    change physClose3 F.sectorCoordinateTensor X
+      (F.threeSiteGlobalRegroupEquiv.symm ⟨klh, x⟩)
+      (F.threeSiteGlobalRegroupEquiv.symm ⟨klh, y⟩) = _
+    rw [threeSiteGlobalRegroupEquiv_symm_apply,
+      threeSiteGlobalRegroupEquiv_symm_apply]
+    have h := congrFun
+      (congrFun (F.threeSiteSectorClosure_eq klh.1 klh.2.1 klh.2.2 X) x) y
+    simpa only [Matrix.reindex_apply, Matrix.submatrix_apply,
+      threeSiteSectorClosure] using h
+  · rw [Matrix.blockDiagonal'_apply_ne _ _ _ hp]
+    have hne : klh.1 ≠ pqr.1 ∨ klh.2.1 ≠ pqr.2.1 ∨ klh.2.2 ≠ pqr.2.2 := by
+      by_contra h
+      simp only [not_or, not_not] at h
+      exact hp (Prod.ext h.1 (Prod.ext h.2.1 h.2.2))
+    change physClose3 F.sectorCoordinateTensor X
+      (F.threeSiteGlobalRegroupEquiv.symm ⟨klh, x⟩)
+      (F.threeSiteGlobalRegroupEquiv.symm ⟨pqr, y⟩) = 0
+    rw [threeSiteGlobalRegroupEquiv_symm_apply,
+      threeSiteGlobalRegroupEquiv_symm_apply]
+    simp only [threeSiteSectorEmbedding, physClose3_apply]
+    rcases hne with hne | hne | hne
+    · have hz : F.sectorCoordinateTensor
+          (F.sectorFinEquiv.symm
+            ⟨klh.1, ((F.threeSiteRegroupEquiv klh.1 klh.2.1 klh.2.2).symm x).1⟩)
+          (F.sectorFinEquiv.symm
+            ⟨pqr.1, ((F.threeSiteRegroupEquiv pqr.1 pqr.2.1 pqr.2.2).symm y).1⟩) = 0 := by
+        ext beta alpha
+        exact sectorCoordinateTensor_apply_ne F hne _ _ beta alpha
+      rw [hz]
+      simp
+    · have hz : F.sectorCoordinateTensor
+          (F.sectorFinEquiv.symm
+            ⟨klh.2.1, ((F.threeSiteRegroupEquiv klh.1 klh.2.1 klh.2.2).symm x).2.1⟩)
+          (F.sectorFinEquiv.symm
+            ⟨pqr.2.1, ((F.threeSiteRegroupEquiv pqr.1 pqr.2.1 pqr.2.2).symm y).2.1⟩) =
+            0 := by
+        ext beta alpha
+        exact sectorCoordinateTensor_apply_ne F hne _ _ beta alpha
+      rw [hz]
+      simp
+    · have hz : F.sectorCoordinateTensor
+          (F.sectorFinEquiv.symm
+            ⟨klh.2.2, ((F.threeSiteRegroupEquiv klh.1 klh.2.1 klh.2.2).symm x).2.2⟩)
+          (F.sectorFinEquiv.symm
+            ⟨pqr.2.2, ((F.threeSiteRegroupEquiv pqr.1 pqr.2.1 pqr.2.2).symm y).2.2⟩) =
+            0 := by
+        ext beta alpha
+        exact sectorCoordinateTensor_apply_ne F hne _ _ beta alpha
+      rw [hz]
+      simp
+
+end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/PhysicalSectorClosureGlobal.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorClosureGlobal.lean
@@ -21,8 +21,7 @@ between distinct sector tuples vanishes.
 ## References
 
 * [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
-  Appendix C.2, equations `AppUkU=rl` and `etarl`, lines 1381--1450, and
-  Proposition C.7, lines 1510--1563
+  Appendix C.2, lines 1381--1450, and Proposition C.7, lines 1510--1563
 -/
 
 open scoped Matrix BigOperators Kronecker
@@ -50,8 +49,7 @@ private def sigmaTripleEquiv {I J L : Type*} {A : I → Type*} {B : J → Type*}
 /-- The complete two-site physical space, indexed by a sector pair and
 regrouped into its outer and neighboring factors.
 
-Source: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl` and `etarl`,
-lines 1381--1450. -/
+Source: arXiv:1606.00608, Appendix C.2, lines 1381--1450. -/
 noncomputable def twoSiteGlobalRegroupEquiv (F : PhysicalSectorFactorization K) :
     (Fin (Fintype.card (Σ k : Fin F.sectorCount, SectorIndex F k)) ×
       Fin (Fintype.card (Σ k : Fin F.sectorCount, SectorIndex F k))) ≃
@@ -60,6 +58,10 @@ noncomputable def twoSiteGlobalRegroupEquiv (F : PhysicalSectorFactorization K) 
   ((Equiv.prodCongr F.sectorFinEquiv F.sectorFinEquiv).trans sigmaPairEquiv).trans
     (Equiv.sigmaCongrRight fun kh ↦ F.twoSiteRegroupEquiv kh.1 kh.2)
 
+/-- The inverse global two-site regrouping is the fixed-sector embedding
+after the inverse regrouping of the four subspins.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1381--1450. -/
 @[simp] theorem twoSiteGlobalRegroupEquiv_symm_apply
     (F : PhysicalSectorFactorization K) (k h : Fin F.sectorCount)
     (x : BoundaryIndex F k h × NeighborIndex F k h) :
@@ -70,9 +72,8 @@ noncomputable def twoSiteGlobalRegroupEquiv (F : PhysicalSectorFactorization K) 
 /-- The complete three-site physical space, indexed by a sector triple and
 regrouped into its outer and two neighboring factors.
 
-Source: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl` and `etarl`,
-lines 1381--1450; the order of factors is that of Proposition C.7,
-lines 1510--1522. -/
+Source: arXiv:1606.00608, Appendix C.2, lines 1381--1450; the order of factors
+is that of Proposition C.7, lines 1510--1522. -/
 noncomputable def threeSiteGlobalRegroupEquiv (F : PhysicalSectorFactorization K) :
     (Fin (Fintype.card (Σ k : Fin F.sectorCount, SectorIndex F k)) ×
       (Fin (Fintype.card (Σ k : Fin F.sectorCount, SectorIndex F k)) ×
@@ -85,6 +86,10 @@ noncomputable def threeSiteGlobalRegroupEquiv (F : PhysicalSectorFactorization K
     (Equiv.sigmaCongrRight fun klh ↦
       F.threeSiteRegroupEquiv klh.1 klh.2.1 klh.2.2)
 
+/-- The inverse global three-site regrouping is the fixed-sector embedding
+after the inverse regrouping of the six subspins.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1381--1450. -/
 @[simp] theorem threeSiteGlobalRegroupEquiv_symm_apply
     (F : PhysicalSectorFactorization K) (k l h : Fin F.sectorCount)
     (x : BoundaryIndex F k h ×
@@ -97,9 +102,8 @@ noncomputable def threeSiteGlobalRegroupEquiv (F : PhysicalSectorFactorization K
 over sector pairs of the outer boundary operator tensored with the neighboring
 operator.
 
-Source: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl` and `etarl`,
-lines 1381--1450, and the two-site operator in Proposition C.7,
-lines 1510--1516. -/
+Source: arXiv:1606.00608, Appendix C.2, lines 1381--1450, and the two-site
+operator in Proposition C.7, lines 1510--1516. -/
 theorem twoSiteGlobalClosure_eq (F : PhysicalSectorFactorization K)
     (X : Matrix (Fin D) (Fin D) ℂ) :
     Matrix.reindex F.twoSiteGlobalRegroupEquiv F.twoSiteGlobalRegroupEquiv
@@ -151,9 +155,8 @@ theorem twoSiteGlobalClosure_eq (F : PhysicalSectorFactorization K)
 sum over sector triples of the outer boundary operator tensored with the two
 neighboring operators.
 
-Source: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl` and `etarl`,
-lines 1381--1450, and the three-site operator in Proposition C.7,
-lines 1510--1516. -/
+Source: arXiv:1606.00608, Appendix C.2, lines 1381--1450, and the three-site
+operator in Proposition C.7, lines 1510--1516. -/
 theorem threeSiteGlobalClosure_eq (F : PhysicalSectorFactorization K)
     (X : Matrix (Fin D) (Fin D) ℂ) :
     Matrix.reindex F.threeSiteGlobalRegroupEquiv F.threeSiteGlobalRegroupEquiv

--- a/TNLean/MPS/MPDO/PhysicalSectorCoarseGrainingAction.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorCoarseGrainingAction.lean
@@ -1,0 +1,176 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalSectorCoarseGraining
+import TNLean.MPS.MPDO.PhysicalSectorTraceActions
+
+/-!
+# Action of the physical-sector coarse-graining maps
+
+This file computes the diagonal-sector action of the three maps in the
+coarse-graining channel of Proposition C.7.  The four middle subspins of a
+three-site sector carry
+
+\[
+  \Omega_{k,h}=\bigoplus_l(\eta_{k,l}\otimes\eta_{l,h}).
+\]
+
+The first map traces this matrix and gives the coefficient \(a_kb_h\).  The
+second map adjoins the normalized neighboring operator.  The coefficient
+cancels the normalization on active sectors; on zero-weight sectors both
+sides vanish.  The third map only relabels the remaining subspins as two
+complete physical sites.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, lines 1547--1563
+-/
+
+open scoped Matrix BigOperators Kronecker
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D} {F : PhysicalSectorFactorization K}
+
+/-- The direct sum
+\(\Omega_{k,h}=\bigoplus_l(\eta_{k,l}\otimes\eta_{l,h})\) carried by the
+four middle subspins of a three-site sector.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1510--1516 and 1547--1555. -/
+noncomputable def threeSiteNeighboringOperator
+    (F : PhysicalSectorFactorization K) (k h : Fin F.sectorCount) :
+    Matrix (ThreeSiteMiddleIndex F k h) (ThreeSiteMiddleIndex F k h) ℂ :=
+  Matrix.blockDiagonal' fun l ↦
+    F.neighboringOperator k l ⊗ₖ F.neighboringOperator l h
+
+/-- The trace of \(\Omega_{k,h}\) is the sum of the products of the two
+neighboring-operator traces.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1510--1516 and 1547--1555. -/
+theorem trace_threeSiteNeighboringOperator
+    (F : PhysicalSectorFactorization K) (k h : Fin F.sectorCount) :
+    (F.threeSiteNeighboringOperator k h).trace =
+      ∑ l, (F.neighboringOperator k l).trace *
+        (F.neighboringOperator l h).trace := by
+  rw [threeSiteNeighboringOperator, Matrix.trace_blockDiagonal']
+  simp only [Matrix.trace_kronecker]
+
+/-- Under the rank-one trace factorization,
+\(\operatorname{tr}(\Omega_{k,h})=a_kb_h\).
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1547--1555. -/
+theorem NeighboringTraceFactorization.trace_threeSiteNeighboringOperator
+    (H : NeighboringTraceFactorization F) (k h : Fin F.sectorCount) :
+    (F.threeSiteNeighboringOperator k h).trace =
+      ((H.a k * H.b h : ℝ) : ℂ) := by
+  rw [F.trace_threeSiteNeighboringOperator]
+  exact H.sum_threeSite_trace_coefficients k h
+
+/-- On a diagonal outer-sector pair, \(\mathcal S_0\) is the partial trace
+of the corresponding regrouped block.
+
+Source: arXiv:1606.00608, Appendix C.2, line 1547. -/
+theorem s0Map_sameBlock_apply (F : PhysicalSectorFactorization K)
+    (X : Matrix (SectorSiteIndex F × (SectorSiteIndex F × SectorSiteIndex F))
+      (SectorSiteIndex F × (SectorSiteIndex F × SectorSiteIndex F)) ℂ)
+    (k h : Fin F.sectorCount) (a b : BoundaryIndex F k h) :
+    F.s0Map X ⟨(k, h), a⟩ ⟨(k, h), b⟩ =
+      Matrix.partialTraceRight
+        ((Matrix.equivReindexMap F.s0RegroupEquiv X).submatrix
+          (fun p ↦ Sigma.mk (k, h) p) (fun p ↦ Sigma.mk (k, h) p)) a b := by
+  rw [s0Map, LinearMap.comp_apply,
+    Matrix.controlledPartialTraceRightLM_sameBlock_apply]
+
+/-- If a regrouped diagonal block is
+\(B\otimes\Omega_{k,h}\), then \(\mathcal S_0\) maps it to
+\((a_kb_h)B\).
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1547--1555. -/
+theorem NeighboringTraceFactorization.s0Map_block_eq_smul
+    (H : NeighboringTraceFactorization F)
+    (X : Matrix (SectorSiteIndex F × (SectorSiteIndex F × SectorSiteIndex F))
+      (SectorSiteIndex F × (SectorSiteIndex F × SectorSiteIndex F)) ℂ)
+    (k h : Fin F.sectorCount) (B : Matrix (BoundaryIndex F k h)
+      (BoundaryIndex F k h) ℂ)
+    (hblock :
+      (Matrix.equivReindexMap F.s0RegroupEquiv X).submatrix
+        (fun p ↦ Sigma.mk (k, h) p) (fun p ↦ Sigma.mk (k, h) p) =
+          B ⊗ₖ F.threeSiteNeighboringOperator k h) :
+    (F.s0Map X).submatrix (Sigma.mk (k, h)) (Sigma.mk (k, h)) =
+      ((H.a k * H.b h : ℝ) : ℂ) • B := by
+  ext a b
+  rw [Matrix.submatrix_apply, F.s0Map_sameBlock_apply, hblock,
+    Matrix.partialTraceRight_kronecker,
+    H.trace_threeSiteNeighboringOperator, Matrix.smul_apply]
+
+/-- Multiplying a boundary matrix by \(a_kb_h\) and then adjoining the
+completed normalized neighboring density gives exactly
+\(B\otimes\eta_{k,h}\).  This includes zero-weight sectors.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1548--1555. -/
+theorem NeighboringTraceFactorization.completedNeighboringPreparationMap_smul
+    (H : NeighboringTraceFactorization F) (k h : Fin F.sectorCount)
+    (B : Matrix (BoundaryIndex F k h) (BoundaryIndex F k h) ℂ) :
+    H.completedNeighboringPreparationMap F.neighborIndex_nonempty k h
+        (((H.a k * H.b h : ℝ) : ℂ) • B) =
+      B ⊗ₖ F.neighboringOperator k h := by
+  classical
+  by_cases hactive : H.a k * H.b h ≠ 0
+  · rw [H.completedNeighboringPreparationMap_eq_normalized
+      F.neighborIndex_nonempty k h hactive]
+    ext p q
+    change Matrix.kroneckerMap (· * ·)
+        (((H.a k * H.b h : ℝ) : ℂ) • B)
+        ((((H.a k * H.b h)⁻¹ : ℝ) : ℂ) • F.neighboringOperator k h) p q = _
+    simp only [Matrix.kroneckerMap_apply, Matrix.smul_apply, smul_eq_mul]
+    have hcancel :
+        ((H.a k * H.b h : ℝ) : ℂ) * (((H.a k * H.b h)⁻¹ : ℝ) : ℂ) = 1 := by
+      exact_mod_cast mul_inv_cancel₀ hactive
+    calc
+      _ = (((H.a k * H.b h : ℝ) : ℂ) *
+            (((H.a k * H.b h)⁻¹ : ℝ) : ℂ)) *
+          (B p.1 q.1 * F.neighboringOperator k h p.2 q.2) := by ring
+      _ = _ := by rw [hcancel, one_mul]
+  · have hzero : H.a k * H.b h = 0 := not_ne_iff.mp hactive
+    rw [hzero]
+    simp [H.neighboringOperator_eq_zero_of_mul_eq_zero k h hzero]
+
+/-- If a diagonal input block is \((a_kb_h)B\), then \(\mathcal S_1\)
+maps it to \(B\otimes\eta_{k,h}\).
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1548--1555. -/
+theorem NeighboringTraceFactorization.s1Map_block_eq_kronecker
+    (H : NeighboringTraceFactorization F)
+    (X : Matrix (BoundarySubspinIndex F) (BoundarySubspinIndex F) ℂ)
+    (k h : Fin F.sectorCount)
+    (B : Matrix (BoundaryIndex F k h) (BoundaryIndex F k h) ℂ)
+    (hblock : X.submatrix (Sigma.mk (k, h)) (Sigma.mk (k, h)) =
+      ((H.a k * H.b h : ℝ) : ℂ) • B) :
+    (H.s1Map X).submatrix
+        (fun p ↦ Sigma.mk (k, h) p) (fun p ↦ Sigma.mk (k, h) p) =
+      B ⊗ₖ F.neighboringOperator k h := by
+  ext p q
+  rcases p with ⟨a, u⟩
+  rcases q with ⟨b, v⟩
+  rw [Matrix.submatrix_apply, NeighboringTraceFactorization.s1Map,
+    H.completedNeighboringControlledMap_sameBlock_apply]
+  change H.completedNeighboringPreparationMap F.neighborIndex_nonempty k h
+      (X.submatrix (fun x ↦ Sigma.mk (k, h) x) (fun x ↦ Sigma.mk (k, h) x))
+        (a, u) (b, v) = _
+  rw [hblock, H.completedNeighboringPreparationMap_smul]
+
+/-- The map \(\mathcal S_2\) sends the regrouped matrix
+\(B\otimes\eta_{k,h}\) to the corresponding two-site diagonal sector by
+relabeling its indices.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1555--1559. -/
+theorem s2Map_apply (F : PhysicalSectorFactorization K)
+    (X : Matrix (S2PreparationIndex F) (S2PreparationIndex F) ℂ)
+    (p q : SectorSiteIndex F × SectorSiteIndex F) :
+    F.s2Map X p q = X (F.s2ShiftEquiv.symm p) (F.s2ShiftEquiv.symm q) := by
+  rfl
+
+end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/PhysicalSectorCoarseGrainingIdentity.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorCoarseGrainingIdentity.lean
@@ -1,0 +1,194 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalSectorClosureGlobal
+import TNLean.MPS.MPDO.PhysicalSectorCoarseGrainingAction
+
+/-!
+# Coarse-graining identity for physical-sector closures
+
+This file proves the fixed-point calculation for the coarse-graining channel
+of Proposition C.7.  Both physical closures are first expressed in the sector
+coordinates of the factorized tensor.  The three stages of the channel then
+trace the four middle subspins, prepare the neighboring operator, and regroup
+the remaining factors into two physical sites.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, lines 1547--1563
+-/
+
+open scoped Matrix BigOperators Kronecker
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D} {F : PhysicalSectorFactorization K}
+
+/-- Express two physical sites in the direct sum of physical sectors.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1381--1388 and 1555--1559. -/
+noncomputable def twoSiteSectorCoordinateEquiv (F : PhysicalSectorFactorization K) :
+    (Fin (Fintype.card (SectorSiteIndex F)) ×
+      Fin (Fintype.card (SectorSiteIndex F))) ≃
+      SectorSiteIndex F × SectorSiteIndex F :=
+  Equiv.prodCongr F.sectorFinEquiv F.sectorFinEquiv
+
+/-- Express three physical sites in the direct sum of physical sectors.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1381--1388 and 1547--1559. -/
+noncomputable def threeSiteSectorCoordinateEquiv (F : PhysicalSectorFactorization K) :
+    (Fin (Fintype.card (SectorSiteIndex F)) ×
+      (Fin (Fintype.card (SectorSiteIndex F)) ×
+        Fin (Fintype.card (SectorSiteIndex F)))) ≃
+      SectorSiteIndex F × (SectorSiteIndex F × SectorSiteIndex F) :=
+  Equiv.prodCongr F.sectorFinEquiv
+    (Equiv.prodCongr F.sectorFinEquiv F.sectorFinEquiv)
+
+@[simp] theorem twoSiteSectorCoordinateEquiv_symm_apply
+    (F : PhysicalSectorFactorization K) (k h : Fin F.sectorCount)
+    (x : SectorIndex F k) (y : SectorIndex F h) :
+    F.twoSiteSectorCoordinateEquiv.symm (⟨k, x⟩, ⟨h, y⟩) =
+      (F.sectorFinEquiv.symm ⟨k, x⟩, F.sectorFinEquiv.symm ⟨h, y⟩) :=
+  rfl
+
+@[simp] theorem threeSiteSectorCoordinateEquiv_symm_apply
+    (F : PhysicalSectorFactorization K) (k l h : Fin F.sectorCount)
+    (x : SectorIndex F k) (y : SectorIndex F l) (z : SectorIndex F h) :
+    F.threeSiteSectorCoordinateEquiv.symm (⟨k, x⟩, (⟨l, y⟩, ⟨h, z⟩)) =
+      (F.sectorFinEquiv.symm ⟨k, x⟩,
+        (F.sectorFinEquiv.symm ⟨l, y⟩, F.sectorFinEquiv.symm ⟨h, z⟩)) :=
+  rfl
+
+/-- On an outer-sector pair, the regrouped three-site physical closure is
+the boundary operator tensored with the direct sum of the two neighboring
+operators.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1510--1516 and 1547--1555. -/
+theorem s0Regrouped_threeSiteClosure_block_eq
+    (F : PhysicalSectorFactorization K) (X : Matrix (Fin D) (Fin D) ℂ)
+    (k h : Fin F.sectorCount) :
+    (Matrix.equivReindexMap F.s0RegroupEquiv
+      (Matrix.reindex F.threeSiteSectorCoordinateEquiv
+        F.threeSiteSectorCoordinateEquiv
+        (physClose3 F.sectorCoordinateTensor X))).submatrix
+          (Sigma.mk (k, h)) (Sigma.mk (k, h)) =
+      F.boundaryOperator k h X ⊗ₖ F.threeSiteNeighboringOperator k h := by
+  ext ⟨a, l, u⟩ ⟨b, m, v⟩
+  by_cases hlm : l = m
+  · subst m
+    have hg := congrFun (congrFun (F.threeSiteSectorClosure_eq k l h X)
+      (a, u)) (b, v)
+    simpa [Matrix.equivReindexMap, Matrix.reindex_apply, Matrix.submatrix_apply,
+      s0RegroupEquiv, threeSiteSectorCoordinateEquiv,
+      threeSiteSectorClosure, threeSiteSectorEmbedding,
+      threeSiteNeighboringOperator,
+      Matrix.blockDiagonal'_apply] using hg
+  · have hz : F.sectorCoordinateTensor
+        (F.sectorFinEquiv.symm ⟨l, (u.1.2, u.2.1)⟩)
+        (F.sectorFinEquiv.symm ⟨m, (v.1.2, v.2.1)⟩) = 0 := by
+      ext beta alpha
+      exact sectorCoordinateTensor_apply_ne F hlm _ _ beta alpha
+    change Matrix.trace
+      (F.sectorCoordinateTensor
+          (F.sectorFinEquiv.symm ⟨k, (a.1, u.1.1)⟩)
+          (F.sectorFinEquiv.symm ⟨k, (b.1, v.1.1)⟩) *
+        F.sectorCoordinateTensor
+          (F.sectorFinEquiv.symm ⟨l, (u.1.2, u.2.1)⟩)
+          (F.sectorFinEquiv.symm ⟨m, (v.1.2, v.2.1)⟩) *
+        F.sectorCoordinateTensor
+          (F.sectorFinEquiv.symm ⟨h, (u.2.2, a.2)⟩)
+          (F.sectorFinEquiv.symm ⟨h, (v.2.2, b.2)⟩) * X) =
+      F.boundaryOperator k h X a b *
+        F.threeSiteNeighboringOperator k h ⟨l, u⟩ ⟨m, v⟩
+    rw [hz]
+    simp [threeSiteNeighboringOperator, Matrix.blockDiagonal'_apply, hlm]
+
+/-- The preparation stage annihilates entries between distinct pairs of
+outer sectors.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1548--1555. -/
+theorem NeighboringTraceFactorization.s1Map_apply_of_ne
+    (H : NeighboringTraceFactorization F)
+    (Y : Matrix (BoundarySubspinIndex F) (BoundarySubspinIndex F) ℂ)
+    {kh pq : Fin F.sectorCount × Fin F.sectorCount} (hne : kh ≠ pq)
+    (a : BoundaryIndex F kh.1 kh.2) (u : NeighborIndex F kh.1 kh.2)
+    (b : BoundaryIndex F pq.1 pq.2) (v : NeighborIndex F pq.1 pq.2) :
+    H.s1Map Y ⟨kh, (a, u)⟩ ⟨pq, (b, v)⟩ = 0 := by
+  classical
+  rw [NeighboringTraceFactorization.s1Map,
+    NeighboringTraceFactorization.completedNeighboringControlledMap,
+    Matrix.controlledKrausMap_apply_of_ne _ _ Y hne]
+
+/-- The coarse-graining channel sends the three-site physical closure to the
+two-site physical closure for every virtual boundary matrix.
+
+Source: arXiv:1606.00608, Proposition C.7, lines 1547--1563. -/
+theorem NeighboringTraceFactorization.sMap_threeSiteClosure_eq_twoSiteClosure
+    (H : NeighboringTraceFactorization F) (X : Matrix (Fin D) (Fin D) ℂ) :
+    H.sMap
+        (Matrix.reindex F.threeSiteSectorCoordinateEquiv
+          F.threeSiteSectorCoordinateEquiv
+          (physClose3 F.sectorCoordinateTensor X)) =
+      Matrix.reindex F.twoSiteSectorCoordinateEquiv F.twoSiteSectorCoordinateEquiv
+        (physClose2 F.sectorCoordinateTensor X) := by
+  ext ⟨⟨k, x⟩, h, y⟩ ⟨⟨p, z⟩, q, w⟩
+  let Z := Matrix.reindex F.threeSiteSectorCoordinateEquiv
+    F.threeSiteSectorCoordinateEquiv
+    (physClose3 F.sectorCoordinateTensor X)
+  by_cases hkp : k = p
+  · subst p
+    by_cases hhq : h = q
+    · subst q
+      have h0 := H.s0Map_block_eq_smul Z k h (F.boundaryOperator k h X)
+        (F.s0Regrouped_threeSiteClosure_block_eq X k h)
+      have h1 := H.s1Map_block_eq_kronecker (F.s0Map Z) k h
+        (F.boundaryOperator k h X) h0
+      have hs := congrFun (congrFun h1
+        ((x.1, y.2), (x.2, y.1))) ((z.1, w.2), (z.2, w.1))
+      have h2 := congrFun (congrFun (F.twoSiteSectorClosure_eq k h X)
+        ((x.1, y.2), (x.2, y.1))) ((z.1, w.2), (z.2, w.1))
+      simpa [Z, NeighboringTraceFactorization.sMap, LinearMap.comp_apply,
+        s2Map_apply, Matrix.reindex_apply, Matrix.submatrix_apply,
+        twoSiteSectorCoordinateEquiv, twoSiteSectorClosure,
+        twoSiteSectorEmbedding, twoSiteRegroupEquiv,
+        s2ShiftEquiv] using hs.trans h2.symm
+    · have hpair : (k, h) ≠ (k, q) := fun hp ↦ hhq (Prod.mk.inj hp).2
+      have hs := H.s1Map_apply_of_ne (F.s0Map Z) hpair
+        (x.1, y.2) (x.2, y.1) (z.1, w.2) (z.2, w.1)
+      have hlhs : H.sMap Z (⟨k, x⟩, ⟨h, y⟩) (⟨k, z⟩, ⟨q, w⟩) = 0 := by
+        simpa [NeighboringTraceFactorization.sMap, LinearMap.comp_apply,
+          s2Map_apply, s2ShiftEquiv] using hs
+      rw [hlhs]
+      have hz : F.sectorCoordinateTensor
+          (F.sectorFinEquiv.symm ⟨h, y⟩)
+          (F.sectorFinEquiv.symm ⟨q, w⟩) = 0 := by
+        ext beta alpha
+        exact sectorCoordinateTensor_apply_ne F hhq y w beta alpha
+      change 0 = physClose2 F.sectorCoordinateTensor X
+        (F.sectorFinEquiv.symm ⟨k, x⟩, F.sectorFinEquiv.symm ⟨h, y⟩)
+        (F.sectorFinEquiv.symm ⟨k, z⟩, F.sectorFinEquiv.symm ⟨q, w⟩)
+      rw [physClose2_apply]
+      rw [hz]
+      simp
+  · have hpair : (k, h) ≠ (p, q) := fun hp ↦ hkp (Prod.mk.inj hp).1
+    have hs := H.s1Map_apply_of_ne (F.s0Map Z) hpair
+      (x.1, y.2) (x.2, y.1) (z.1, w.2) (z.2, w.1)
+    have hlhs : H.sMap Z (⟨k, x⟩, ⟨h, y⟩) (⟨p, z⟩, ⟨q, w⟩) = 0 := by
+      simpa [NeighboringTraceFactorization.sMap, LinearMap.comp_apply,
+        s2Map_apply, s2ShiftEquiv] using hs
+    rw [hlhs]
+    have hz : F.sectorCoordinateTensor
+        (F.sectorFinEquiv.symm ⟨k, x⟩)
+        (F.sectorFinEquiv.symm ⟨p, z⟩) = 0 := by
+      ext beta alpha
+      exact sectorCoordinateTensor_apply_ne F hkp x z beta alpha
+    change 0 = physClose2 F.sectorCoordinateTensor X
+      (F.sectorFinEquiv.symm ⟨k, x⟩, F.sectorFinEquiv.symm ⟨h, y⟩)
+      (F.sectorFinEquiv.symm ⟨p, z⟩, F.sectorFinEquiv.symm ⟨q, w⟩)
+    rw [physClose2_apply, hz]
+    simp
+
+end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/PhysicalSectorCoarseGrainingIdentity.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorCoarseGrainingIdentity.lean
@@ -3,7 +3,6 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.MPDO.PhysicalSectorClosureGlobal
 import TNLean.MPS.MPDO.PhysicalSectorCoarseGrainingAction
 
 /-!

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -1112,10 +1112,10 @@ strong subadditivity for a normalized three-site reduced state.
       thm:mpdo_three_site_sector_closure_factorization,
       def:mpdo_physical_sector_factorization}
     On a diagonal sector tuple these are the fixed-sector factorizations.
-    A sector-coordinate slice satisfies
+    When $\sigma$ and $\sigma'$ belong to distinct sectors, a
+    sector-coordinate slice satisfies
     \[
-      \widetilde K_{\sigma,\sigma'}=0
-      \qquad\text{when $\sigma$ and $\sigma'$ belong to distinct sectors.}
+      \widetilde K_{\sigma,\sigma'}=0.
     \]
     Consequently, if $(k,h)\ne(p,q)$ or
     $(k,l,h)\ne(p,m,q)$, respectively, then
@@ -2673,12 +2673,13 @@ strong subadditivity for a normalized three-site reduced state.
     \]
     If $a_kb_h=0$, positivity and zero trace give $\eta_{k,h}=0$, so both
     sides of this identity vanish. Finally, $\mathcal S_2$ regroups the four
-    factors into two physical sites. For distinct sector pairs,
+    factors into two physical sites. For distinct sector pairs
+    $(k,h)\ne(p,q)$,
     \[
-      (\mathcal S_1Y)_{(k,h),(p,q)}=0
-      \qquad\text{when $(k,h)\ne(p,q)$},
+      (\mathcal S_1Y)_{(k,h),(p,q)}=0,
+      \qquad
+      [\mathfrak R_2({\cal K}_2(X))]_{(k,h),(p,q)}=0.
     \]
-    and the two-site closure has the same off-diagonal zero blocks.
 \end{proof}
 
 \begin{figure}[ht]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -1089,7 +1089,8 @@ strong subadditivity for a normalized three-site reduced state.
       MPOTensor.PhysicalSectorFactorization.threeSiteGlobalClosure_eq}
     \leanok
     \uses{thm:mpdo_two_site_sector_closure_factorization,
-      thm:mpdo_three_site_sector_closure_factorization}
+      thm:mpdo_three_site_sector_closure_factorization,
+      def:mpdo_physical_sector_factorization}
     After the canonical regrouping of all physical-sector indices, the full
     closures are
     \[
@@ -1108,10 +1109,21 @@ strong subadditivity for a normalized three-site reduced state.
 \begin{proof}
     \leanok
     \uses{thm:mpdo_two_site_sector_closure_factorization,
-      thm:mpdo_three_site_sector_closure_factorization}
+      thm:mpdo_three_site_sector_closure_factorization,
+      def:mpdo_physical_sector_factorization}
     On a diagonal sector tuple these are the fixed-sector factorizations.
-    If two tuples differ, at least one physical slice lies between distinct
-    sectors and hence vanishes.
+    A sector-coordinate slice satisfies
+    \[
+      \widetilde K_{\sigma,\sigma'}=0
+      \qquad\text{when $\sigma$ and $\sigma'$ belong to distinct sectors.}
+    \]
+    Consequently, if $(k,h)\ne(p,q)$ or
+    $(k,l,h)\ne(p,m,q)$, respectively, then
+    \[
+      [{\cal K}_2(X)]_{(k,h),(p,q)}=0,
+      \qquad
+      [{\cal K}_3(X)]_{(k,l,h),(p,m,q)}=0.
+    \]
 \end{proof}
 
 \begin{definition}[Closed sector tensors]%
@@ -2624,7 +2636,9 @@ strong subadditivity for a normalized three-site reduced state.
     The two- and three-site physical spaces are identified with their
     canonical direct sums over sector pairs and triples. The inverse
     equivalences send a diagonal sector block to the corresponding embedded
-    physical matrix and send off-diagonal sector blocks to zero.
+    physical matrix and send off-diagonal sector blocks to zero. Write
+    $\mathfrak R_2$ and $\mathfrak R_3$ for the resulting reindexings of
+    two- and three-site matrices.
 \end{definition}
 
 \begin{theorem}[Coarse-graining of the three-site closure]
@@ -2635,12 +2649,13 @@ strong subadditivity for a normalized three-site reduced state.
     \leanok
     \uses{def:phys_close, def:mpdo_physical_sector_s_map,
       def:mpdo_physical_sector_closure_coordinates}
-    For every virtual matrix $X$, the coarse-graining channel satisfies
+    For every virtual matrix $X$, in the canonical physical-sector
+    coordinates selected by the isometry $U$, the coarse-graining channel
+    satisfies
     \[
-      \mathcal S\bigl({\cal K}_3(X)\bigr)={\cal K}_2(X).
+      \mathcal S\bigl(\mathfrak R_3({\cal K}_3(X))\bigr)
+      =\mathfrak R_2({\cal K}_2(X)).
     \]
-    The equality is written in the canonical physical-sector coordinates
-    selected by the isometry $U$.
 \end{theorem}
 
 \begin{proof}
@@ -2648,14 +2663,22 @@ strong subadditivity for a normalized three-site reduced state.
     \uses{thm:mpdo_two_site_sector_closure_factorization,
       thm:mpdo_three_site_sector_closure_factorization,
       thm:mpdo_physical_sector_three_site_neighboring_operator_trace,
+      def:mpdo_physical_sector_factorization,
       def:mpdo_physical_sector_s1_map}
     On the $(k,h)$ diagonal block, $\mathcal S_0$ traces
-    $\Omega_{k,h}$ and gives $a_kb_hB_{k,h}(X)$. The map $\mathcal S_1$
-    adjoins $\eta_{k,h}/(a_kb_h)$ on an active pair, so the scalar cancels;
-    both sides vanish on a zero-weight pair. Finally, $\mathcal S_2$ regroups
-    the four factors into two physical sites. Entries between distinct sector
-    pairs vanish under both the controlled preparation and the two-site
-    direct-sum decomposition.
+    $\Omega_{k,h}$ and gives $a_kb_hB_{k,h}(X)$. On an active sector pair,
+    \[
+      \mathcal S_1\bigl((a_kb_h)B_{k,h}(X)\bigr)
+      =B_{k,h}(X)\otimes\eta_{k,h}.
+    \]
+    If $a_kb_h=0$, positivity and zero trace give $\eta_{k,h}=0$, so both
+    sides of this identity vanish. Finally, $\mathcal S_2$ regroups the four
+    factors into two physical sites. For distinct sector pairs,
+    \[
+      (\mathcal S_1Y)_{(k,h),(p,q)}=0
+      \qquad\text{when $(k,h)\ne(p,q)$},
+    \]
+    and the two-site closure has the same off-diagonal zero blocks.
 \end{proof}
 
 \begin{figure}[ht]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -1002,6 +1002,9 @@ strong subadditivity for a normalized three-site reduced state.
     \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.partialTraceRight_twoSiteSectorClosure}
     \lean{MPOTensor.PhysicalSectorFactorization.partialTraceRight_threeSiteSectorClosure}
     \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.sum_threeSite_trace_coefficients}
+    \lean{MPOTensor.PhysicalSectorFactorization.threeSiteNeighboringOperator,
+      MPOTensor.PhysicalSectorFactorization.trace_threeSiteNeighboringOperator,
+      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.trace_threeSiteNeighboringOperator}
     \leanok
     \uses{thm:mpdo_two_site_sector_closure_factorization,
       thm:mpdo_three_site_sector_closure_factorization,
@@ -1032,6 +1035,41 @@ strong subadditivity for a normalized three-site reduced state.
       =a_k\left(\sum_l a_lb_l\right)b_h
       =a_kb_h.
     \]
+\end{proof}
+
+\begin{theorem}[Global direct-sum form of the sector closures]
+    \label{thm:mpdo_global_sector_closure_decomposition}
+    \lean{MPOTensor.PhysicalSectorFactorization.twoSiteGlobalRegroupEquiv,
+      MPOTensor.PhysicalSectorFactorization.twoSiteGlobalRegroupEquiv_symm_apply,
+      MPOTensor.PhysicalSectorFactorization.threeSiteGlobalRegroupEquiv,
+      MPOTensor.PhysicalSectorFactorization.threeSiteGlobalRegroupEquiv_symm_apply}
+    \lean{MPOTensor.PhysicalSectorFactorization.twoSiteGlobalClosure_eq,
+      MPOTensor.PhysicalSectorFactorization.threeSiteGlobalClosure_eq}
+    \leanok
+    \uses{thm:mpdo_two_site_sector_closure_factorization,
+      thm:mpdo_three_site_sector_closure_factorization}
+    After the canonical regrouping of all physical-sector indices, the full
+    closures are
+    \[
+      {\cal K}_2(X)
+      =\bigoplus_{k,h}B_{k,h}(X)\otimes\eta_{k,h}
+    \]
+    and
+    \[
+      {\cal K}_3(X)
+      =\bigoplus_{k,l,h}B_{k,h}(X)\otimes
+        \bigl(\eta_{k,l}\otimes\eta_{l,h}\bigr).
+    \]
+    Every matrix entry between distinct sector tuples vanishes.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_two_site_sector_closure_factorization,
+      thm:mpdo_three_site_sector_closure_factorization}
+    On a diagonal sector tuple these are the fixed-sector factorizations.
+    If two tuples differ, at least one physical slice lies between distinct
+    sectors and hence vanishes.
 \end{proof}
 
 \begin{definition}[Closed sector tensors]%
@@ -2206,7 +2244,8 @@ strong subadditivity for a normalized three-site reduced state.
     \label{def:mpdo_s2_map}
     \lean{MPOTensor.ExplicitEtaOperators.s2Map}
     \lean{MPOTensor.PhysicalSectorFactorization.s2ShiftEquiv,
-      MPOTensor.PhysicalSectorFactorization.s2Map}
+      MPOTensor.PhysicalSectorFactorization.s2Map,
+      MPOTensor.PhysicalSectorFactorization.s2Map_apply}
     \leanok
     \uses{def:mpdo_two_site_subspin_regrouping,
       def:mpdo_equiv_reindex_map}
@@ -2269,7 +2308,8 @@ strong subadditivity for a normalized three-site reduced state.
 \begin{definition}[The three-site partial-trace map $\mathcal S_0$]
     \label{def:mpdo_s0_map}
     \lean{MPOTensor.ExplicitEtaOperators.s0Map}
-    \lean{MPOTensor.PhysicalSectorFactorization.s0Map}
+    \lean{MPOTensor.PhysicalSectorFactorization.s0Map,
+      MPOTensor.PhysicalSectorFactorization.s0Map_sameBlock_apply}
     \leanok
     \uses{def:mpdo_three_site_subspin_regrouping,
       def:mpdo_controlled_dependent_partial_trace,
@@ -2474,7 +2514,10 @@ strong subadditivity for a normalized three-site reduced state.
       MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedNeighboringPreparationMap_eq_normalized}
     \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedNeighboringControlledMap}
     \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedNeighboringControlledMap_sameBlock_apply}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedNeighboringPreparationMap_smul}
     \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.s1Map}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.s1Map_block_eq_kronecker,
+      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.s1Map_apply_of_ne}
     \leanok
     \uses{def:mpdo_neighboring_trace_factorization}
     On a sector pair with $a_kb_h\ne0$, let
@@ -2498,6 +2541,10 @@ strong subadditivity for a normalized three-site reduced state.
 \begin{definition}[The coarse-graining channel $\mathcal S$]
     \label{def:mpdo_physical_sector_s_map}
     \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.sMap}
+    \lean{MPOTensor.PhysicalSectorFactorization.twoSiteSectorCoordinateEquiv,
+      MPOTensor.PhysicalSectorFactorization.twoSiteSectorCoordinateEquiv_symm_apply,
+      MPOTensor.PhysicalSectorFactorization.threeSiteSectorCoordinateEquiv,
+      MPOTensor.PhysicalSectorFactorization.threeSiteSectorCoordinateEquiv_symm_apply}
     \leanok
     \uses{def:mpdo_s0_map, def:mpdo_physical_sector_s1_map,
       def:mpdo_s2_map}
@@ -2525,6 +2572,37 @@ strong subadditivity for a normalized three-site reduced state.
     \uses{lem:is_kraus_cptp_comp}
     Each of the three factors is trace-preserving and completely positive,
     and this property is preserved under composition.
+\end{proof}
+
+\begin{theorem}[Coarse-graining of the three-site closure]
+    \label{thm:mpdo_physical_sector_s_closure_identity}
+    \lean{MPOTensor.PhysicalSectorFactorization.s0Regrouped_threeSiteClosure_block_eq}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.s0Map_block_eq_smul}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.sMap_threeSiteClosure_eq_twoSiteClosure}
+    \leanok
+    \uses{thm:mpdo_global_sector_closure_decomposition,
+      thm:mpdo_sector_closure_partial_traces,
+      def:mpdo_physical_sector_s_map}
+    For every virtual matrix $X$, the coarse-graining channel satisfies
+    \[
+      \mathcal S\bigl({\cal K}_3(X)\bigr)={\cal K}_2(X).
+    \]
+    The equality is written in the canonical physical-sector coordinates
+    selected by the isometry $U$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_global_sector_closure_decomposition,
+      thm:mpdo_sector_closure_partial_traces,
+      def:mpdo_physical_sector_s1_map}
+    On the $(k,h)$ diagonal block, $\mathcal S_0$ traces
+    $\Omega_{k,h}$ and gives $a_kb_hB_{k,h}(X)$. The map $\mathcal S_1$
+    adjoins $\eta_{k,h}/(a_kb_h)$ on an active pair, so the scalar cancels;
+    both sides vanish on a zero-weight pair. Finally, $\mathcal S_2$ regroups
+    the four factors into two physical sites. Entries between distinct sector
+    pairs vanish under both the controlled preparation and the two-site
+    direct-sum decomposition.
 \end{proof}
 
 \begin{figure}[ht]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -954,6 +954,21 @@ strong subadditivity for a normalized three-site reduced state.
     which gives the three factors on the right-hand side.
 \end{proof}
 
+\begin{definition}[Three-site neighboring operator]
+    \label{def:mpdo_physical_sector_three_site_neighboring_operator}
+    \lean{MPOTensor.PhysicalSectorFactorization.threeSiteNeighboringOperator}
+    \leanok
+    \uses{def:mpdo_minimal_neighboring_operator}
+    For every outer-sector pair $(k,h)$, define
+    \[
+      \Omega_{k,h}=\bigoplus_l
+        \bigl(\eta_{k,l}\otimes\eta_{l,h}\bigr).
+    \]
+    This is the direct sum of the two neighboring contractions appearing in
+    the three-site closure factorization
+    \cite[Appendix~C.2, lines~1510--1516]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
 \begin{figure}[ht]
     \centering
     \begin{minipage}{0.41\textwidth}
@@ -996,15 +1011,42 @@ strong subadditivity for a normalized three-site reduced state.
     \cite[Appendix~C.2, lines~1389--1403]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
+\begin{theorem}[Trace of the three-site neighboring operator]
+    \label{thm:mpdo_physical_sector_three_site_neighboring_operator_trace}
+    \lean{MPOTensor.PhysicalSectorFactorization.trace_threeSiteNeighboringOperator,
+      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.trace_threeSiteNeighboringOperator}
+    \leanok
+    \uses{def:mpdo_physical_sector_three_site_neighboring_operator,
+      def:mpdo_neighboring_trace_factorization}
+    For every outer-sector pair $(k,h)$,
+    \[
+      \tr(\Omega_{k,h})
+      =\sum_l\tr(\eta_{k,l})\tr(\eta_{l,h})
+      =a_kb_h.
+    \]
+    This is the normalization used in the coarse-graining channel of
+    \cite[Appendix~C.2]{Cirac2016MPDO_arXiv}, lines~1547--1555.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:mpdo_neighboring_trace_factorization}
+    The trace of a direct sum is the sum of the traces of its blocks, and the
+    trace of a tensor product is the product of the traces. Hence
+    \[
+      \tr(\Omega_{k,h})
+      =\sum_l(a_kb_l)(a_lb_h)
+      =a_kb_h\sum_l a_lb_l
+      =a_kb_h.
+    \]
+\end{proof}
+
 \begin{theorem}[Partial traces of the sector closures]
     \label{thm:mpdo_sector_closure_partial_traces}
     \lean{MPOTensor.PhysicalSectorFactorization.partialTraceRight_twoSiteSectorClosure}
     \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.partialTraceRight_twoSiteSectorClosure}
     \lean{MPOTensor.PhysicalSectorFactorization.partialTraceRight_threeSiteSectorClosure}
     \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.sum_threeSite_trace_coefficients}
-    \lean{MPOTensor.PhysicalSectorFactorization.threeSiteNeighboringOperator,
-      MPOTensor.PhysicalSectorFactorization.trace_threeSiteNeighboringOperator,
-      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.trace_threeSiteNeighboringOperator}
     \leanok
     \uses{thm:mpdo_two_site_sector_closure_factorization,
       thm:mpdo_three_site_sector_closure_factorization,
@@ -2541,10 +2583,6 @@ strong subadditivity for a normalized three-site reduced state.
 \begin{definition}[The coarse-graining channel $\mathcal S$]
     \label{def:mpdo_physical_sector_s_map}
     \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.sMap}
-    \lean{MPOTensor.PhysicalSectorFactorization.twoSiteSectorCoordinateEquiv,
-      MPOTensor.PhysicalSectorFactorization.twoSiteSectorCoordinateEquiv_symm_apply,
-      MPOTensor.PhysicalSectorFactorization.threeSiteSectorCoordinateEquiv,
-      MPOTensor.PhysicalSectorFactorization.threeSiteSectorCoordinateEquiv_symm_apply}
     \leanok
     \uses{def:mpdo_s0_map, def:mpdo_physical_sector_s1_map,
       def:mpdo_s2_map}
@@ -2574,15 +2612,29 @@ strong subadditivity for a normalized three-site reduced state.
     and this property is preserved under composition.
 \end{proof}
 
+\begin{definition}[Two- and three-site sector coordinates]
+    \label{def:mpdo_physical_sector_closure_coordinates}
+    \lean{MPOTensor.PhysicalSectorFactorization.twoSiteSectorCoordinateEquiv,
+      MPOTensor.PhysicalSectorFactorization.twoSiteSectorCoordinateEquiv_symm_apply,
+      MPOTensor.PhysicalSectorFactorization.threeSiteSectorCoordinateEquiv,
+      MPOTensor.PhysicalSectorFactorization.threeSiteSectorCoordinateEquiv_symm_apply}
+    \leanok
+    \uses{def:mpdo_two_site_sector_closure,
+      def:mpdo_three_site_sector_closure}
+    The two- and three-site physical spaces are identified with their
+    canonical direct sums over sector pairs and triples. The inverse
+    equivalences send a diagonal sector block to the corresponding embedded
+    physical matrix and send off-diagonal sector blocks to zero.
+\end{definition}
+
 \begin{theorem}[Coarse-graining of the three-site closure]
     \label{thm:mpdo_physical_sector_s_closure_identity}
     \lean{MPOTensor.PhysicalSectorFactorization.s0Regrouped_threeSiteClosure_block_eq}
     \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.s0Map_block_eq_smul}
     \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.sMap_threeSiteClosure_eq_twoSiteClosure}
     \leanok
-    \uses{thm:mpdo_global_sector_closure_decomposition,
-      thm:mpdo_sector_closure_partial_traces,
-      def:mpdo_physical_sector_s_map}
+    \uses{def:phys_close, def:mpdo_physical_sector_s_map,
+      def:mpdo_physical_sector_closure_coordinates}
     For every virtual matrix $X$, the coarse-graining channel satisfies
     \[
       \mathcal S\bigl({\cal K}_3(X)\bigr)={\cal K}_2(X).
@@ -2593,8 +2645,9 @@ strong subadditivity for a normalized three-site reduced state.
 
 \begin{proof}
     \leanok
-    \uses{thm:mpdo_global_sector_closure_decomposition,
-      thm:mpdo_sector_closure_partial_traces,
+    \uses{thm:mpdo_two_site_sector_closure_factorization,
+      thm:mpdo_three_site_sector_closure_factorization,
+      thm:mpdo_physical_sector_three_site_neighboring_operator_trace,
       def:mpdo_physical_sector_s1_map}
     On the $(k,h)$ diagonal block, $\mathcal S_0$ traces
     $\Omega_{k,h}$ and gives $a_kb_hB_{k,h}(X)$. The map $\mathcal S_1$

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -1018,7 +1018,9 @@ strong subadditivity for a normalized three-site reduced state.
     \leanok
     \uses{def:mpdo_physical_sector_three_site_neighboring_operator,
       def:mpdo_neighboring_trace_factorization}
-    For every outer-sector pair $(k,h)$,
+    Assume the neighboring-operator trace factorization of
+    Definition~\ref{def:mpdo_neighboring_trace_factorization}. Then, for every
+    outer-sector pair $(k,h)$,
     \[
       \tr(\Omega_{k,h})
       =\sum_l\tr(\eta_{k,l})\tr(\eta_{l,h})
@@ -2649,9 +2651,8 @@ strong subadditivity for a normalized three-site reduced state.
     The coordinate equivalences used by the coarse-graining channel expose
     the direct sums over site-sector pairs and triples. Write
     $\mathfrak R_2$ and $\mathfrak R_3$ for the corresponding matrix
-    reindexings. Their inverses send a diagonal sector block to the
-    corresponding embedded physical matrix and send off-diagonal sector
-    blocks to zero.
+    reindexings. Their inverses send every sector block to the corresponding
+    physical matrix entries.
 \end{definition}
 
 \begin{theorem}[Coarse-graining of the three-site closure]
@@ -2661,8 +2662,11 @@ strong subadditivity for a normalized three-site reduced state.
     \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.sMap_threeSiteClosure_eq_twoSiteClosure}
     \leanok
     \uses{def:phys_close, def:mpdo_physical_sector_s_map,
-      def:mpdo_physical_sector_closure_coordinates}
-    For every virtual matrix $X$, in the canonical physical-sector
+      def:mpdo_physical_sector_closure_coordinates,
+      def:mpdo_neighboring_trace_factorization}
+    Assume the neighboring-operator trace factorization of
+    Definition~\ref{def:mpdo_neighboring_trace_factorization}. For every
+    virtual matrix $X$, in the canonical physical-sector
     coordinates selected by the isometry $U$, the coarse-graining channel
     satisfies
     \[

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -1079,27 +1079,39 @@ strong subadditivity for a normalized three-site reduced state.
     \]
 \end{proof}
 
-\begin{theorem}[Global direct-sum form of the sector closures]
-    \label{thm:mpdo_global_sector_closure_decomposition}
+\begin{definition}[Global two- and three-site sector coordinates]
+    \label{def:mpdo_global_sector_closure_coordinates}
     \lean{MPOTensor.PhysicalSectorFactorization.twoSiteGlobalRegroupEquiv,
       MPOTensor.PhysicalSectorFactorization.twoSiteGlobalRegroupEquiv_symm_apply,
       MPOTensor.PhysicalSectorFactorization.threeSiteGlobalRegroupEquiv,
       MPOTensor.PhysicalSectorFactorization.threeSiteGlobalRegroupEquiv_symm_apply}
+    \leanok
+    \uses{def:mpdo_two_site_sector_closure,
+      def:mpdo_three_site_sector_closure}
+    The two- and three-site physical spaces are reindexed by their canonical
+    direct sums over sector pairs and triples, with each summand further
+    regrouped into its boundary and neighboring factors. Write
+    $\mathfrak G_2$ and $\mathfrak G_3$ for these reindexings of matrices.
+\end{definition}
+
+\begin{theorem}[Global direct-sum form of the sector closures]
+    \label{thm:mpdo_global_sector_closure_decomposition}
     \lean{MPOTensor.PhysicalSectorFactorization.twoSiteGlobalClosure_eq,
       MPOTensor.PhysicalSectorFactorization.threeSiteGlobalClosure_eq}
     \leanok
     \uses{thm:mpdo_two_site_sector_closure_factorization,
       thm:mpdo_three_site_sector_closure_factorization,
-      def:mpdo_physical_sector_factorization}
+      def:mpdo_physical_sector_factorization,
+      def:mpdo_global_sector_closure_coordinates}
     After the canonical regrouping of all physical-sector indices, the full
     closures are
     \[
-      {\cal K}_2(X)
+      \mathfrak G_2({\cal K}_2(X))
       =\bigoplus_{k,h}B_{k,h}(X)\otimes\eta_{k,h}
     \]
     and
     \[
-      {\cal K}_3(X)
+      \mathfrak G_3({\cal K}_3(X))
       =\bigoplus_{k,l,h}B_{k,h}(X)\otimes
         \bigl(\eta_{k,l}\otimes\eta_{l,h}\bigr).
     \]
@@ -1110,19 +1122,20 @@ strong subadditivity for a normalized three-site reduced state.
     \leanok
     \uses{thm:mpdo_two_site_sector_closure_factorization,
       thm:mpdo_three_site_sector_closure_factorization,
-      def:mpdo_physical_sector_factorization}
+      def:mpdo_physical_sector_factorization,
+      def:mpdo_global_sector_closure_coordinates}
     On a diagonal sector tuple these are the fixed-sector factorizations.
-    When $\sigma$ and $\sigma'$ belong to distinct sectors, a
-    sector-coordinate slice satisfies
+    For distinct sector labels $k\ne p$, the block structure of the
+    sector-coordinate tensor gives
     \[
-      \widetilde K_{\sigma,\sigma'}=0.
+      [U\kappa_{\beta,\alpha}U^\dagger]_{k,p}=0.
     \]
     Consequently, if $(k,h)\ne(p,q)$ or
     $(k,l,h)\ne(p,m,q)$, respectively, then
     \[
-      [{\cal K}_2(X)]_{(k,h),(p,q)}=0,
+      [\mathfrak G_2({\cal K}_2(X))]_{(k,h),(p,q)}=0,
       \qquad
-      [{\cal K}_3(X)]_{(k,l,h),(p,m,q)}=0.
+      [\mathfrak G_3({\cal K}_3(X))]_{(k,l,h),(p,m,q)}=0.
     \]
 \end{proof}
 
@@ -2633,12 +2646,12 @@ strong subadditivity for a normalized three-site reduced state.
     \leanok
     \uses{def:mpdo_two_site_sector_closure,
       def:mpdo_three_site_sector_closure}
-    The two- and three-site physical spaces are identified with their
-    canonical direct sums over sector pairs and triples. The inverse
-    equivalences send a diagonal sector block to the corresponding embedded
-    physical matrix and send off-diagonal sector blocks to zero. Write
-    $\mathfrak R_2$ and $\mathfrak R_3$ for the resulting reindexings of
-    two- and three-site matrices.
+    The coordinate equivalences used by the coarse-graining channel expose
+    the direct sums over site-sector pairs and triples. Write
+    $\mathfrak R_2$ and $\mathfrak R_3$ for the corresponding matrix
+    reindexings. Their inverses send a diagonal sector block to the
+    corresponding embedded physical matrix and send off-diagonal sector
+    blocks to zero.
 \end{definition}
 
 \begin{theorem}[Coarse-graining of the three-site closure]
@@ -2664,6 +2677,7 @@ strong subadditivity for a normalized three-site reduced state.
       thm:mpdo_three_site_sector_closure_factorization,
       thm:mpdo_physical_sector_three_site_neighboring_operator_trace,
       def:mpdo_physical_sector_factorization,
+      def:mpdo_physical_sector_closure_coordinates,
       def:mpdo_physical_sector_s1_map}
     On the $(k,h)$ diagonal block, $\mathcal S_0$ traces
     $\Omega_{k,h}$ and gives $a_kb_hB_{k,h}(X)$. On an active sector pair,


### PR DESCRIPTION
## Mathematical content

This pull request completes the coarse-graining half of Proposition C.7. For every virtual matrix \(X\), it proves
\[
\mathcal S\bigl(\mathcal K_3(X)\bigr)=\mathcal K_2(X)
\]
in the canonical physical-sector coordinates selected by the source isometry.

The proof uses exactly the hypotheses introduced with the source-minimal physical-sector factorization:

- positivity of every neighboring operator \(\eta_{k,h}\);
- \(\operatorname{tr}(\eta_{k,h})=a_kb_h\);
- \(\sum_k a_kb_k=1\).

No Hayashi quantum-Markov witness, primitivity, or strict positivity is added.

The new results establish:

- canonical global two- and three-site sector regroupings;
- the direct-sum decompositions
  \[
  \mathcal K_2(X)=\bigoplus_{k,h}B_{k,h}(X)\otimes\eta_{k,h},
  \qquad
  \mathcal K_3(X)=\bigoplus_{k,l,h}B_{k,h}(X)\otimes
    (\eta_{k,l}\otimes\eta_{l,h});
  \]
- vanishing of entries between distinct sector tuples;
- the exact diagonal-block actions of \(\mathcal S_0\) and \(\mathcal S_1\), including zero-weight sectors;
- vanishing of off-diagonal output blocks under the controlled preparation;
- the literal Proposition C.7 coarse-graining identity for arbitrary \(X\).

## Blueprint

The MPO/RFP chapter now states the global direct-sum closure formulas and the coarse-graining identity, with links to every new declaration. The source-style TikZ diagrams for the three-site trace and two-site regrouping remain adjacent to the channel construction.

## Verification

- `lake build TNLean`
- focused build of `PhysicalSectorCoarseGrainingIdentity`
- `leanblueprint checkdecls`
- `leanblueprint pdf`
- `leanblueprint web`
- blueprint forward and reverse declaration synchronization
- reader-facing prose check
- proof-integrity and 100-column scans
- kernel axiom audit of the headline identity and its principal ingredients (only `propext`, `Classical.choice`, and `Quot.sound`)

Closes #3743
Parent: #3740

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal mathematics and blueprint wiring on the existing MPDO physical-sector track; no runtime, auth, or data-path changes.
> 
> **Overview**
> Formalizes the **coarse-graining half of Proposition C.7** (arXiv:1606.00608): in physical-sector coordinates, the channel \(\mathcal S=\mathcal S_2\circ\mathcal S_1\circ\mathcal S_0\) maps the three-site closure to the two-site closure for every virtual matrix \(X\), using only the neighboring trace factorization hypotheses already in the library.
> 
> **`PhysicalSectorClosureGlobal`** introduces global two-/three-site regrouping equivalences and proves **`twoSiteGlobalClosure_eq`** / **`threeSiteGlobalClosure_eq`**: after regrouping, \(\mathcal K_2\) and \(\mathcal K_3\) are block-diagonal direct sums of boundary ⊗ neighboring (Kronecker) factors, with **zero off-diagonal blocks** between distinct sector tuples.
> 
> **`PhysicalSectorCoarseGrainingAction`** defines **`threeSiteNeighboringOperator`** \(\Omega_{k,h}=\bigoplus_l(\eta_{k,l}\otimes\eta_{l,h})\), shows \(\mathrm{tr}(\Omega_{k,h})=a_kb_h\), and gives the **exact diagonal actions** of \(\mathcal S_0\), \(\mathcal S_1\), and \(\mathcal S_2\) on regrouped blocks (including **zero-weight** sectors).
> 
> **`PhysicalSectorCoarseGrainingIdentity`** proves the capstone **`NeighboringTraceFactorization.sMap_threeSiteClosure_eq_twoSiteClosure`**, with off-diagonal cases handled via **`s1Map_apply_of_ne`** and sector-coordinate vanishing.
> 
> The MPO/RFP blueprint chapter gains matching definitions/theorems and **`lean`** links; **`TNLean.lean`** imports the three new modules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88ec8b78d22fc018c601f528ca2fb7f59aa479ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->