### PR TITLE
feat(MPS/MPDO): construct the refinement channel

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -390,6 +390,7 @@ import TNLean.MPS.MPDO.NeighboringPreparation
 import TNLean.MPS.MPDO.PhysicalSectorSubspinMaps
 import TNLean.MPS.MPDO.PhysicalSectorRefinementRegroupings
 import TNLean.MPS.MPDO.PhysicalSectorCoarseGraining
+import TNLean.MPS.MPDO.PhysicalSectorOmegaPreparation
 import TNLean.MPS.MPDO.PhysicalSectorClosureTwo
 import TNLean.MPS.MPDO.PhysicalSectorClosureThree
 import TNLean.MPS.MPDO.PhysicalSectorClosureGlobal

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -390,11 +390,11 @@ import TNLean.MPS.MPDO.NeighboringPreparation
 import TNLean.MPS.MPDO.PhysicalSectorSubspinMaps
 import TNLean.MPS.MPDO.PhysicalSectorRefinementRegroupings
 import TNLean.MPS.MPDO.PhysicalSectorCoarseGraining
-import TNLean.MPS.MPDO.PhysicalSectorOmegaPreparation
 import TNLean.MPS.MPDO.PhysicalSectorClosureTwo
 import TNLean.MPS.MPDO.PhysicalSectorClosureThree
 import TNLean.MPS.MPDO.PhysicalSectorClosureGlobal
 import TNLean.MPS.MPDO.PhysicalSectorTraceActions
+import TNLean.MPS.MPDO.PhysicalSectorOmegaPreparation
 import TNLean.MPS.MPDO.PhysicalSectorCoarseGrainingAction
 import TNLean.MPS.MPDO.PhysicalSectorCoarseGrainingIdentity
 import TNLean.MPS.MPDO.SectorPairingTransfer

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -395,6 +395,7 @@ import TNLean.MPS.MPDO.PhysicalSectorClosureThree
 import TNLean.MPS.MPDO.PhysicalSectorClosureGlobal
 import TNLean.MPS.MPDO.PhysicalSectorTraceActions
 import TNLean.MPS.MPDO.PhysicalSectorOmegaPreparation
+import TNLean.MPS.MPDO.PhysicalSectorRefinement
 import TNLean.MPS.MPDO.PhysicalSectorCoarseGrainingAction
 import TNLean.MPS.MPDO.PhysicalSectorCoarseGrainingIdentity
 import TNLean.MPS.MPDO.SectorPairingTransfer

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -388,6 +388,7 @@ import TNLean.MPS.MPDO.SectorFactorization
 import TNLean.MPS.MPDO.PhysicalSectorFactorization
 import TNLean.MPS.MPDO.NeighboringPreparation
 import TNLean.MPS.MPDO.PhysicalSectorSubspinMaps
+import TNLean.MPS.MPDO.PhysicalSectorRefinementRegroupings
 import TNLean.MPS.MPDO.PhysicalSectorCoarseGraining
 import TNLean.MPS.MPDO.PhysicalSectorClosureTwo
 import TNLean.MPS.MPDO.PhysicalSectorClosureThree

--- a/TNLean/MPS/MPDO/PhysicalSectorCoarseGrainingAction.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorCoarseGrainingAction.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.PhysicalSectorCoarseGraining
-import TNLean.MPS.MPDO.PhysicalSectorTraceActions
+import TNLean.MPS.MPDO.PhysicalSectorOmegaPreparation
 
 /-!
 # Action of the physical-sector coarse-graining maps
@@ -34,40 +34,6 @@ open scoped Matrix BigOperators Kronecker
 namespace MPOTensor.PhysicalSectorFactorization
 
 variable {d D : ℕ} {K : MPOTensor d D} {F : PhysicalSectorFactorization K}
-
-/-- The direct sum
-\(\Omega_{k,h}=\bigoplus_l(\eta_{k,l}\otimes\eta_{l,h})\) carried by the
-four middle subspins of a three-site sector.
-
-Source: arXiv:1606.00608, Appendix C.2, lines 1510--1516 and 1547--1555. -/
-noncomputable def threeSiteNeighboringOperator
-    (F : PhysicalSectorFactorization K) (k h : Fin F.sectorCount) :
-    Matrix (ThreeSiteMiddleIndex F k h) (ThreeSiteMiddleIndex F k h) ℂ :=
-  Matrix.blockDiagonal' fun l ↦
-    F.neighboringOperator k l ⊗ₖ F.neighboringOperator l h
-
-/-- The trace of \(\Omega_{k,h}\) is the sum of the products of the two
-neighboring-operator traces.
-
-Source: arXiv:1606.00608, Appendix C.2, lines 1510--1516 and 1547--1555. -/
-theorem trace_threeSiteNeighboringOperator
-    (F : PhysicalSectorFactorization K) (k h : Fin F.sectorCount) :
-    (F.threeSiteNeighboringOperator k h).trace =
-      ∑ l, (F.neighboringOperator k l).trace *
-        (F.neighboringOperator l h).trace := by
-  rw [threeSiteNeighboringOperator, Matrix.trace_blockDiagonal']
-  simp only [Matrix.trace_kronecker]
-
-/-- Under the rank-one trace factorization,
-\(\operatorname{tr}(\Omega_{k,h})=a_kb_h\).
-
-Source: arXiv:1606.00608, Appendix C.2, lines 1547--1555. -/
-theorem NeighboringTraceFactorization.trace_threeSiteNeighboringOperator
-    (H : NeighboringTraceFactorization F) (k h : Fin F.sectorCount) :
-    (F.threeSiteNeighboringOperator k h).trace =
-      ((H.a k * H.b h : ℝ) : ℂ) := by
-  rw [F.trace_threeSiteNeighboringOperator]
-  exact H.sum_threeSite_trace_coefficients k h
 
 /-- On a diagonal outer-sector pair, \(\mathcal S_0\) is the partial trace
 of the corresponding regrouped block.

--- a/TNLean/MPS/MPDO/PhysicalSectorOmegaPreparation.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorOmegaPreparation.lean
@@ -1,0 +1,329 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalSectorSubspinMaps
+import TNLean.MPS.MPDO.PhysicalSectorTraceActions
+
+/-!
+# Preparations of the three-site neighboring operator
+
+For a physical-sector factorization, the four middle subspins between outer
+sectors (k) and (h) carry
+
+\[
+  \Omega_{k,h}=\bigoplus_l(\eta_{k,l}\otimes\eta_{l,h}).
+\]
+
+This file proves positivity and the trace identity
+\(\operatorname{tr}(\Omega_{k,h})=a_kb_h\). On an active sector pair,
+\(\Omega_{k,h}\) is normalized by \((a_kb_h)^{-1}\). On a zero-weight pair,
+the source quotient is undefined; a density matrix is chosen on the same
+subspin space to extend the preparation to a trace-preserving completely
+positive map. These preparations are combined according to the orthogonal
+outer-sector decomposition in the definition of \(\mathcal T_1\).
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, lines 1510--1516 and 1523--1535
+-/
+
+open scoped Matrix BigOperators ComplexOrder Kronecker
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D} {F : PhysicalSectorFactorization K}
+
+/-! ### The direct-sum neighboring operator -/
+
+/-- The operator on the four middle subspins between outer sectors (k) and
+(h):
+\[
+  \Omega_{k,h}=\bigoplus_l(\eta_{k,l}\otimes\eta_{l,h}).
+\]
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1510--1516 and 1527--1535. -/
+noncomputable def threeSiteNeighboringOperator
+    (F : PhysicalSectorFactorization K) (k h : Fin F.sectorCount) :
+    Matrix (ThreeSiteMiddleIndex F k h) (ThreeSiteMiddleIndex F k h) ℂ :=
+  Matrix.blockDiagonal' fun l ↦
+    F.neighboringOperator k l ⊗ₖ F.neighboringOperator l h
+
+/-- The trace of \(\Omega_{k,h}\) is the sum of the products of the two
+neighboring-operator traces.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1510--1516 and 1527--1535. -/
+theorem trace_threeSiteNeighboringOperator
+    (F : PhysicalSectorFactorization K) (k h : Fin F.sectorCount) :
+    (F.threeSiteNeighboringOperator k h).trace =
+      ∑ l, (F.neighboringOperator k l).trace *
+        (F.neighboringOperator l h).trace := by
+  rw [threeSiteNeighboringOperator, Matrix.trace_blockDiagonal']
+  simp only [Matrix.trace_kronecker]
+
+/-- The operator \(\Omega_{k,h}\) is positive semidefinite.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1510--1516 and 1527--1535. -/
+theorem NeighboringTraceFactorization.threeSiteNeighboringOperator_pos
+    (H : NeighboringTraceFactorization F) (k h : Fin F.sectorCount) :
+    (F.threeSiteNeighboringOperator k h).PosSemidef := by
+  apply Matrix.PosSemidef.blockDiagonal'
+  intro l
+  exact (H.neighboringOperator_pos k l).kronecker
+    (H.neighboringOperator_pos l h)
+
+/-- Under the rank-one trace factorization,
+\(\operatorname{tr}(\Omega_{k,h})=a_kb_h\).
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1527--1535. -/
+theorem NeighboringTraceFactorization.trace_threeSiteNeighboringOperator
+    (H : NeighboringTraceFactorization F) (k h : Fin F.sectorCount) :
+    (F.threeSiteNeighboringOperator k h).trace =
+      ((H.a k * H.b h : ℝ) : ℂ) := by
+  rw [F.trace_threeSiteNeighboringOperator]
+  exact H.sum_threeSite_trace_coefficients k h
+
+/-- The sector set is nonempty because \(\sum_l a_lb_l=1\).
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1395--1402. -/
+theorem NeighboringTraceFactorization.sector_nonempty
+    (H : NeighboringTraceFactorization F) : Nonempty (Fin F.sectorCount) := by
+  by_contra hempty
+  haveI : IsEmpty (Fin F.sectorCount) := not_nonempty_iff.mp hempty
+  have hzero : ∑ l : Fin F.sectorCount, H.a l * H.b l = 0 := by simp
+  have hsum := H.sum_mul
+  rw [hzero] at hsum
+  norm_num at hsum
+
+/-- The subspin space carrying \(\Omega_{k,h}\) is nonempty.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1381--1388 and 1527--1535. -/
+theorem NeighboringTraceFactorization.threeSiteMiddleIndex_nonempty
+    (H : NeighboringTraceFactorization F) (k h : Fin F.sectorCount) :
+    Nonempty (ThreeSiteMiddleIndex F k h) := by
+  rcases H.sector_nonempty with ⟨l⟩
+  rcases F.neighborIndex_nonempty k l with ⟨u⟩
+  rcases F.neighborIndex_nonempty l h with ⟨v⟩
+  exact ⟨⟨l, (u, v)⟩⟩
+
+/-- If \(a_kb_h=0\), then \(\Omega_{k,h}=0\).
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1527--1535. -/
+theorem NeighboringTraceFactorization.threeSiteNeighboringOperator_eq_zero_of_mul_eq_zero
+    (H : NeighboringTraceFactorization F) (k h : Fin F.sectorCount)
+    (hzero : H.a k * H.b h = 0) :
+    F.threeSiteNeighboringOperator k h = 0 := by
+  apply (Matrix.PosSemidef.trace_eq_zero_iff
+    (H.threeSiteNeighboringOperator_pos k h)).mp
+  rw [H.trace_threeSiteNeighboringOperator, hzero]
+  norm_num
+
+/-! ### Normalization and completion -/
+
+/-- The normalized operator \((a_kb_h)^{-1}\Omega_{k,h}\). Its trace is one
+when \(a_kb_h\ne0\), which is the domain of the quotient in the source.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1527--1535. -/
+noncomputable def NeighboringTraceFactorization.normalizedThreeSiteNeighboringDensity
+    (H : NeighboringTraceFactorization F) (k h : Fin F.sectorCount) :
+    Matrix (ThreeSiteMiddleIndex F k h) (ThreeSiteMiddleIndex F k h) ℂ :=
+  (((H.a k * H.b h)⁻¹ : ℝ) : ℂ) • F.threeSiteNeighboringOperator k h
+
+/-- The normalized three-site neighboring operator is positive semidefinite.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1527--1535. -/
+theorem NeighboringTraceFactorization.normalizedThreeSiteNeighboringDensity_pos
+    (H : NeighboringTraceFactorization F) (k h : Fin F.sectorCount) :
+    (H.normalizedThreeSiteNeighboringDensity k h).PosSemidef := by
+  apply (H.threeSiteNeighboringOperator_pos k h).smul
+  exact_mod_cast inv_nonneg.mpr (H.weight_nonneg k h)
+
+/-- On an active pair, the normalized three-site neighboring operator has
+trace one.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1527--1535. -/
+theorem NeighboringTraceFactorization.trace_normalizedThreeSiteNeighboringDensity
+    (H : NeighboringTraceFactorization F) (k h : Fin F.sectorCount)
+    (hactive : H.a k * H.b h ≠ 0) :
+    (H.normalizedThreeSiteNeighboringDensity k h).trace = 1 := by
+  simp only [NeighboringTraceFactorization.normalizedThreeSiteNeighboringDensity,
+    Matrix.trace_smul, H.trace_threeSiteNeighboringOperator, smul_eq_mul]
+  norm_cast
+  exact inv_mul_cancel₀ hactive
+
+/-- A density matrix used to extend the preparation on a zero-weight outer
+sector pair, where the quotient in the source formula is undefined.
+
+Source formula: arXiv:1606.00608, Appendix C.2, lines 1527--1535. -/
+noncomputable def NeighboringTraceFactorization.inactiveThreeSiteNeighboringDensity
+    (H : NeighboringTraceFactorization F) (k h : Fin F.sectorCount) :
+    Matrix (ThreeSiteMiddleIndex F k h) (ThreeSiteMiddleIndex F k h) ℂ :=
+  letI := H.threeSiteMiddleIndex_nonempty k h
+  Matrix.faithfulDensity _
+
+/-- The density chosen on a zero-weight pair is positive definite.
+
+This is the zero-weight completion of the source formula at arXiv:1606.00608,
+Appendix C.2, lines 1527--1535. -/
+theorem NeighboringTraceFactorization.inactiveThreeSiteNeighboringDensity_posDef
+    (H : NeighboringTraceFactorization F) (k h : Fin F.sectorCount) :
+    (H.inactiveThreeSiteNeighboringDensity k h).PosDef :=
+  letI := H.threeSiteMiddleIndex_nonempty k h
+  Matrix.faithfulDensity_posDef _
+
+/-- The density chosen on a zero-weight pair has trace one.
+
+This is the zero-weight completion of the source formula at arXiv:1606.00608,
+Appendix C.2, lines 1527--1535. -/
+theorem NeighboringTraceFactorization.inactiveThreeSiteNeighboringDensity_trace
+    (H : NeighboringTraceFactorization F) (k h : Fin F.sectorCount) :
+    (H.inactiveThreeSiteNeighboringDensity k h).trace = 1 :=
+  letI := H.threeSiteMiddleIndex_nonempty k h
+  Matrix.faithfulDensity_trace _
+
+/-- The completed three-site neighboring density is the normalized source
+operator on an active pair and a density matrix on a zero-weight pair.
+
+The second branch extends the source formula to a trace-preserving map where
+the quotient \((a_kb_h)^{-1}\) is undefined.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1527--1535. -/
+noncomputable def NeighboringTraceFactorization.completedThreeSiteNeighboringDensity
+    (H : NeighboringTraceFactorization F) (k h : Fin F.sectorCount) :
+    Matrix (ThreeSiteMiddleIndex F k h) (ThreeSiteMiddleIndex F k h) ℂ :=
+  if H.a k * H.b h ≠ 0 then H.normalizedThreeSiteNeighboringDensity k h
+  else H.inactiveThreeSiteNeighboringDensity k h
+
+/-- Every completed three-site neighboring density is positive semidefinite.
+
+Source formula: arXiv:1606.00608, Appendix C.2, lines 1527--1535. -/
+theorem NeighboringTraceFactorization.completedThreeSiteNeighboringDensity_pos
+    (H : NeighboringTraceFactorization F) (k h : Fin F.sectorCount) :
+    (H.completedThreeSiteNeighboringDensity k h).PosSemidef := by
+  rw [NeighboringTraceFactorization.completedThreeSiteNeighboringDensity]
+  split_ifs
+  · exact H.normalizedThreeSiteNeighboringDensity_pos k h
+  · exact (H.inactiveThreeSiteNeighboringDensity_posDef k h).posSemidef
+
+/-- Every completed three-site neighboring density has trace one.
+
+Source formula: arXiv:1606.00608, Appendix C.2, lines 1527--1535. -/
+theorem NeighboringTraceFactorization.trace_completedThreeSiteNeighboringDensity
+    (H : NeighboringTraceFactorization F) (k h : Fin F.sectorCount) :
+    (H.completedThreeSiteNeighboringDensity k h).trace = 1 := by
+  rw [NeighboringTraceFactorization.completedThreeSiteNeighboringDensity]
+  split_ifs with hactive
+  · exact H.trace_normalizedThreeSiteNeighboringDensity k h hactive
+  · exact H.inactiveThreeSiteNeighboringDensity_trace k h
+
+/-- On an active pair, the completed density is
+\((a_kb_h)^{-1}\Omega_{k,h}\). -/
+theorem NeighboringTraceFactorization.completedThreeSiteNeighboringDensity_eq_normalized
+    (H : NeighboringTraceFactorization F) (k h : Fin F.sectorCount)
+    (hactive : H.a k * H.b h ≠ 0) :
+    H.completedThreeSiteNeighboringDensity k h =
+      H.normalizedThreeSiteNeighboringDensity k h := by
+  simp [NeighboringTraceFactorization.completedThreeSiteNeighboringDensity, hactive]
+
+/-! ### The controlled preparation -/
+
+/-- The sectorwise map which adjoins the completed three-site neighboring
+density.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1527--1535. -/
+noncomputable def NeighboringTraceFactorization.completedThreeSitePreparationMap
+    {α : Type*} [Fintype α] [DecidableEq α]
+    (H : NeighboringTraceFactorization F) (k h : Fin F.sectorCount) :
+    Matrix α α ℂ →ₗ[ℂ]
+      Matrix (α × ThreeSiteMiddleIndex F k h)
+        (α × ThreeSiteMiddleIndex F k h) ℂ :=
+  Matrix.preparationMap (H.completedThreeSiteNeighboringDensity k h)
+
+/-- Adjoining the completed three-site neighboring density is
+trace-preserving and completely positive.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1527--1535. -/
+theorem NeighboringTraceFactorization.completedThreeSitePreparationMap_isKrausCPTP
+    {α : Type*} [Fintype α] [DecidableEq α]
+    (H : NeighboringTraceFactorization F) (k h : Fin F.sectorCount) :
+    IsKrausCPTP (H.completedThreeSitePreparationMap (α := α) k h) := by
+  simpa [NeighboringTraceFactorization.completedThreeSitePreparationMap] using
+    Matrix.preparationMap_isKrausCPTP _
+      (H.completedThreeSiteNeighboringDensity_pos k h)
+      (H.trace_completedThreeSiteNeighboringDensity k h)
+
+/-- On an active pair, the completed preparation adjoins the normalized
+operator \((a_kb_h)^{-1}\Omega_{k,h}\). -/
+theorem NeighboringTraceFactorization.completedThreeSitePreparationMap_eq_normalized
+    {α : Type*} [Fintype α] [DecidableEq α]
+    (H : NeighboringTraceFactorization F) (k h : Fin F.sectorCount)
+    (hactive : H.a k * H.b h ≠ 0) :
+    H.completedThreeSitePreparationMap (α := α) k h =
+      Matrix.preparationMap (H.normalizedThreeSiteNeighboringDensity k h) := by
+  rw [NeighboringTraceFactorization.completedThreeSitePreparationMap,
+    H.completedThreeSiteNeighboringDensity_eq_normalized k h hactive]
+
+section ControlledPreparation
+
+variable {α : Fin F.sectorCount × Fin F.sectorCount → Type*}
+variable [∀ p, Fintype (α p)] [∀ p, DecidableEq (α p)]
+
+/-- The orthogonally controlled preparation of \(\Omega_{k,h}\). It discards
+coherences between distinct pairs of outer sectors and adjoins the completed
+three-site neighboring density in every diagonal pair.
+
+On active pairs this is \(\mathcal T_{k,h}\) from the source; the zero-weight
+branch is its trace-preserving extension.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1523--1535. -/
+noncomputable def NeighboringTraceFactorization.completedThreeSiteControlledMap
+    (H : NeighboringTraceFactorization F) :
+    Matrix (Σ p, α p) (Σ p, α p) ℂ →ₗ[ℂ]
+      Matrix (Σ p, α p × ThreeSiteMiddleIndex F p.1 p.2)
+        (Σ p, α p × ThreeSiteMiddleIndex F p.1 p.2) ℂ :=
+  Matrix.controlledKrausMap
+    (fun p ↦ Fintype.card (ThreeSiteMiddleIndex F p.1 p.2))
+    (fun p j ↦ Matrix.preparationKraus
+      (H.completedThreeSiteNeighboringDensity p.1 p.2)
+      (H.completedThreeSiteNeighboringDensity_pos p.1 p.2)
+      ((Fintype.equivFin (ThreeSiteMiddleIndex F p.1 p.2)).symm j))
+
+/-- On a diagonal outer-sector pair, the controlled map is preparation of
+the completed three-site neighboring density.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1523--1535. -/
+theorem NeighboringTraceFactorization.completedThreeSiteControlledMap_sameBlock_apply
+    (H : NeighboringTraceFactorization F)
+    (X : Matrix (Σ p, α p) (Σ p, α p) ℂ)
+    (p : Fin F.sectorCount × Fin F.sectorCount) (a b : α p)
+    (u v : ThreeSiteMiddleIndex F p.1 p.2) :
+    H.completedThreeSiteControlledMap X ⟨p, (a, u)⟩ ⟨p, (b, v)⟩ =
+      H.completedThreeSitePreparationMap p.1 p.2
+        (X.submatrix (Sigma.mk p) (Sigma.mk p)) (a, u) (b, v) := by
+  classical
+  rw [NeighboringTraceFactorization.completedThreeSiteControlledMap,
+    Matrix.controlledKrausMap_sameBlock_apply,
+    Matrix.rectangularKrausMap_equiv
+      (Fintype.equivFin (ThreeSiteMiddleIndex F p.1 p.2)),
+    Matrix.rectangularKrausMap_preparationKraus_eq]
+  rfl
+
+/-- The orthogonally controlled three-site neighboring preparation is
+trace-preserving and completely positive.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1523--1535. -/
+theorem NeighboringTraceFactorization.completedThreeSiteControlledMap_isKrausCPTP
+    (H : NeighboringTraceFactorization F) :
+    IsKrausCPTP (H.completedThreeSiteControlledMap (α := α)) := by
+  apply Matrix.controlledKrausMap_isKrausCPTP
+  intro p
+  exact Matrix.preparationKraus_resolution
+    (H.completedThreeSiteNeighboringDensity p.1 p.2)
+    (H.completedThreeSiteNeighboringDensity_pos p.1 p.2)
+    (H.trace_completedThreeSiteNeighboringDensity p.1 p.2)
+
+end ControlledPreparation
+
+end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/PhysicalSectorOmegaPreparation.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorOmegaPreparation.lean
@@ -70,7 +70,8 @@ theorem trace_threeSiteNeighboringOperator
 
 /-- The operator \(\Omega_{k,h}\) is positive semidefinite.
 
-Source: arXiv:1606.00608, Appendix C.2, lines 1510--1516 and 1527--1535. -/
+Source: arXiv:1606.00608, Appendix C.2, lines 1389--1392, 1510--1516,
+and 1527--1535. -/
 theorem NeighboringTraceFactorization.threeSiteNeighboringOperator_pos
     (H : NeighboringTraceFactorization F) (k h : Fin F.sectorCount) :
     (F.threeSiteNeighboringOperator k h).PosSemidef := by
@@ -115,7 +116,7 @@ theorem NeighboringTraceFactorization.threeSiteMiddleIndex_nonempty
 
 /-- If \(a_kb_h=0\), then \(\Omega_{k,h}=0\).
 
-Source: arXiv:1606.00608, Appendix C.2, lines 1527--1535. -/
+Source: arXiv:1606.00608, Appendix C.2, lines 1389--1392 and 1527--1535. -/
 theorem NeighboringTraceFactorization.threeSiteNeighboringOperator_eq_zero_of_mul_eq_zero
     (H : NeighboringTraceFactorization F) (k h : Fin F.sectorCount)
     (hzero : H.a k * H.b h = 0) :
@@ -244,6 +245,10 @@ theorem NeighboringTraceFactorization.completedThreeSiteNeighboringDensity_eq_no
 /-- The sectorwise map which adjoins the completed three-site neighboring
 density.
 
+**Local fix (zero-weight quotient):** the inactive branch makes the source map
+total without adding a nonzero-weight hypothesis. Documented in
+`docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex`.
+
 Source: arXiv:1606.00608, Appendix C.2, lines 1527--1535. -/
 noncomputable def NeighboringTraceFactorization.completedThreeSitePreparationMap
     {α : Type*} [Fintype α] [DecidableEq α]
@@ -255,6 +260,10 @@ noncomputable def NeighboringTraceFactorization.completedThreeSitePreparationMap
 
 /-- Adjoining the completed three-site neighboring density is
 trace-preserving and completely positive.
+
+**Local fix (zero-weight quotient):** this theorem includes the completed
+inactive branch documented in
+`docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex`.
 
 Source: arXiv:1606.00608, Appendix C.2, lines 1527--1535. -/
 theorem NeighboringTraceFactorization.completedThreeSitePreparationMap_isKrausCPTP

--- a/TNLean/MPS/MPDO/PhysicalSectorOmegaPreparation.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorOmegaPreparation.lean
@@ -24,6 +24,11 @@ subspin space to extend the preparation to a trace-preserving completely
 positive map. These preparations are combined according to the orthogonal
 outer-sector decomposition in the definition of \(\mathcal T_1\).
 
+**Local fix (zero-weight quotient):** the density chosen on an inactive pair
+makes the source map total without adding a nonzero-weight hypothesis. This is
+documented in
+`docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex`.
+
 ## References
 
 * [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
@@ -156,6 +161,10 @@ theorem NeighboringTraceFactorization.trace_normalizedThreeSiteNeighboringDensit
 /-- A density matrix used to extend the preparation on a zero-weight outer
 sector pair, where the quotient in the source formula is undefined.
 
+**Local fix (zero-weight quotient):** this completion makes the source map
+total without adding a nonzero-weight hypothesis. Documented in
+`docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex`.
+
 Source formula: arXiv:1606.00608, Appendix C.2, lines 1527--1535. -/
 noncomputable def NeighboringTraceFactorization.inactiveThreeSiteNeighboringDensity
     (H : NeighboringTraceFactorization F) (k h : Fin F.sectorCount) :
@@ -188,6 +197,9 @@ operator on an active pair and a density matrix on a zero-weight pair.
 
 The second branch extends the source formula to a trace-preserving map where
 the quotient \((a_kb_h)^{-1}\) is undefined.
+
+**Local fix (zero-weight quotient):** documented in
+`docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex`.
 
 Source: arXiv:1606.00608, Appendix C.2, lines 1527--1535. -/
 noncomputable def NeighboringTraceFactorization.completedThreeSiteNeighboringDensity
@@ -276,6 +288,10 @@ three-site neighboring density in every diagonal pair.
 
 On active pairs this is \(\mathcal T_{k,h}\) from the source; the zero-weight
 branch is its trace-preserving extension.
+
+**Local fix (zero-weight quotient):** the inactive branch makes the source map
+total without adding a nonzero-weight hypothesis. Documented in
+`docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex`.
 
 Source: arXiv:1606.00608, Appendix C.2, lines 1523--1535. -/
 noncomputable def NeighboringTraceFactorization.completedThreeSiteControlledMap

--- a/TNLean/MPS/MPDO/PhysicalSectorRefinement.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorRefinement.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalSectorOmegaPreparation
+import TNLean.MPS.MPDO.PhysicalSectorRefinementRegroupings
+
+/-!
+# The physical-sector refinement channel
+
+This file defines the three stages of the refinement channel
+\(\mathcal T=\mathcal T_2\mathcal T_1\mathcal T_0\) in Proposition C.7.
+The first stage traces the neighboring subspins of two physical sites, the
+second adjoins the normalized three-site neighboring operator on each outer
+sector pair, and the last reindexes the resulting subspins as three physical
+sites.
+
+## Main declarations
+
+* `NeighboringTraceFactorization.t1Map`: the controlled preparation stage.
+* `NeighboringTraceFactorization.tMap`: the refinement channel from two sites
+  to three sites.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, lines 1522--1545
+-/
+
+open scoped Matrix
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D} {F : PhysicalSectorFactorization K}
+
+/-- The map \(\mathcal T_1\) discards coherences between outer-sector pairs
+and adjoins the completed three-site neighboring density on each diagonal
+summand. On an active pair, this density is
+\((a_kb_h)^{-1}\bigoplus_l(\eta_{k,l}\otimes\eta_{l,h})\); the zero-weight
+pairs use the trace-preserving completion.
+
+**Local fix (zero-weight quotient):** the inactive branch makes the source map
+total without adding a nonzero-weight hypothesis. Documented in
+`docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1523--1535. -/
+noncomputable def NeighboringTraceFactorization.t1Map
+    (H : NeighboringTraceFactorization F) :
+    Matrix (BoundarySubspinIndex F) (BoundarySubspinIndex F) ℂ →ₗ[ℂ]
+      Matrix (S0PreparationIndex F) (S0PreparationIndex F) ℂ :=
+  H.completedThreeSiteControlledMap
+    (α := fun kh : Fin F.sectorCount × Fin F.sectorCount ↦
+      BoundaryIndex F kh.1 kh.2)
+
+/-- The map \(\mathcal T_1\) is trace-preserving and completely positive.
+
+**Local fix (zero-weight quotient):** this theorem includes the completed
+inactive branch documented in
+`docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1523--1535. -/
+theorem NeighboringTraceFactorization.t1Map_isKrausCPTP
+    (H : NeighboringTraceFactorization F) : IsKrausCPTP H.t1Map := by
+  exact H.completedThreeSiteControlledMap_isKrausCPTP
+
+/-- The refinement channel
+\(\mathcal T=\mathcal T_2\mathcal T_1\mathcal T_0\) from two physical sites
+to three physical sites.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1522--1545. -/
+noncomputable def NeighboringTraceFactorization.tMap
+    (H : NeighboringTraceFactorization F) :
+    Matrix (SectorSiteIndex F × SectorSiteIndex F)
+        (SectorSiteIndex F × SectorSiteIndex F) ℂ →ₗ[ℂ]
+      Matrix (SectorSiteIndex F × (SectorSiteIndex F × SectorSiteIndex F))
+        (SectorSiteIndex F × (SectorSiteIndex F × SectorSiteIndex F)) ℂ :=
+  F.t2Map ∘ₗ H.t1Map ∘ₗ F.t0Map
+
+/-- The refinement channel \(\mathcal T\) is trace-preserving and completely
+positive.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1522--1545. -/
+theorem NeighboringTraceFactorization.tMap_isKrausCPTP
+    (H : NeighboringTraceFactorization F) : IsKrausCPTP H.tMap := by
+  exact isKrausCPTP_comp
+    (isKrausCPTP_comp F.t0Map_isKrausCPTP H.t1Map_isKrausCPTP)
+    F.t2Map_isKrausCPTP
+
+end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/PhysicalSectorRefinementRegroupings.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorRefinementRegroupings.lean
@@ -1,0 +1,107 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalSectorSubspinMaps
+
+/-!
+# Physical-sector refinement regroupings
+
+This file defines the two regrouping stages of the refinement channel in
+Proposition C.7 directly from a physical-sector factorization.  The first
+stage regroups two sites and traces the neighboring subspins.  The last stage
+reindexes the prepared outer and middle subspins as three physical sites.
+
+Only the decomposition
+\[
+  \mathcal H=\bigoplus_k B_k^L\otimes B_k^R
+\]
+is used.  No quantum-Markov state or neighboring-operator preparation is
+assumed here.
+
+## Main declarations
+
+* `t0RegroupEquiv` and `t0Map`: the two-site regrouping and controlled partial
+  trace.
+* `t2ShiftEquiv` and `t2Map`: the final shift to three physical sites.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, lines 1521--1522 and 1535--1540
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D}
+
+/-- Regroup two physical sites into the two outer subspins and the neighboring
+pair that is traced by \(\mathcal T_0\):
+\[
+  ((l_k,r_k),(l_h,r_h))\longmapsto((l_k,r_h),(r_k,l_h)).
+\]
+This equivalence is the inverse of the shift used by \(\mathcal S_2\).
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1521--1522 and 1555--1559. -/
+def t0RegroupEquiv (F : PhysicalSectorFactorization K) :
+    (SectorSiteIndex F × SectorSiteIndex F) ≃ S2PreparationIndex F :=
+  F.s2ShiftEquiv.symm
+
+/-- The map \(\mathcal T_0\): regroup two sites and, in every orthogonal
+outer-sector pair, trace the neighboring subspins \(R_k\otimes L_h\).
+
+Source: arXiv:1606.00608, Appendix C.2, line 1522. -/
+noncomputable def t0Map (F : PhysicalSectorFactorization K) :
+    Matrix (SectorSiteIndex F × SectorSiteIndex F)
+        (SectorSiteIndex F × SectorSiteIndex F) ℂ →ₗ[ℂ]
+      Matrix (BoundarySubspinIndex F) (BoundarySubspinIndex F) ℂ :=
+  Matrix.controlledPartialTraceRightLM
+      (α := fun kh : Fin F.sectorCount × Fin F.sectorCount ↦
+        BoundaryIndex F kh.1 kh.2)
+      (β := fun kh : Fin F.sectorCount × Fin F.sectorCount ↦
+        NeighborIndex F kh.1 kh.2) ∘ₗ
+    Matrix.equivReindexMap F.t0RegroupEquiv
+
+/-- The map \(\mathcal T_0\) is trace-preserving and completely positive.
+
+Source: arXiv:1606.00608, Appendix C.2, line 1522. -/
+theorem t0Map_isKrausCPTP (F : PhysicalSectorFactorization K) :
+    IsKrausCPTP F.t0Map := by
+  simpa [t0Map] using isKrausCPTP_comp
+    (Matrix.equivReindexMap_isKrausCPTP F.t0RegroupEquiv)
+    Matrix.controlledPartialTraceRightLM_isKrausCPTP
+
+/-- Regroup the prepared outer and middle subspins as three physical sites:
+\[
+ ((l_k,r_h),(l,(r_k,l_l),(r_l,l_h)))
+ \longmapsto ((l_k,r_k),((l_l,r_l),(l_h,r_h))).
+\]
+This is the inverse of the regrouping used by \(\mathcal S_0\).
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1535--1540 and 1547. -/
+def t2ShiftEquiv (F : PhysicalSectorFactorization K) :
+    S0PreparationIndex F ≃
+      (SectorSiteIndex F × (SectorSiteIndex F × SectorSiteIndex F)) :=
+  F.s0RegroupEquiv.symm
+
+/-- The final shift \(\mathcal T_2\), realized by reindexing along the inverse
+three-site regrouping.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1535--1540. -/
+def t2Map (F : PhysicalSectorFactorization K) :
+    Matrix (S0PreparationIndex F) (S0PreparationIndex F) ℂ →ₗ[ℂ]
+      Matrix (SectorSiteIndex F × (SectorSiteIndex F × SectorSiteIndex F))
+        (SectorSiteIndex F × (SectorSiteIndex F × SectorSiteIndex F)) ℂ :=
+  Matrix.equivReindexMap F.t2ShiftEquiv
+
+/-- The shift \(\mathcal T_2\) is trace-preserving and completely positive.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1535--1540. -/
+theorem t2Map_isKrausCPTP (F : PhysicalSectorFactorization K) :
+    IsKrausCPTP F.t2Map :=
+  Matrix.equivReindexMap_isKrausCPTP F.t2ShiftEquiv
+
+end MPOTensor.PhysicalSectorFactorization

--- a/blueprint/src/Packages/tn_diagrams.py
+++ b/blueprint/src/Packages/tn_diagrams.py
@@ -53,6 +53,8 @@ _DIAGRAM_ARGS: dict[str, str] = {
     "TNEtaSectorDecomposition": "",
     "TNMPDOTwoSiteTraceAndShift": "",
     "TNMPDOThreeSiteTraceAndShift": "",
+    "TNMPDORefinementConstruction": "",
+    "TNMPDORefinementDirection": "",
     "TNMPDOTwoSiteClosureFactorization": "",
     "TNMPDOThreeSiteClosureFactorization": "",
     "TNMPDOCyclicEtaContraction": "",

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -2631,6 +2631,27 @@ strong subadditivity for a normalized three-site reduced state.
     applies these preparations on the diagonal summands.
 \end{proof}
 
+\begin{figure}[ht]
+    \centering
+    \TNMPDORefinementConstruction
+
+    \medskip
+    \TNMPDORefinementDirection
+    \caption{Physical-sector construction of the refinement channel
+    $\mathcal T=\mathcal T_2\mathcal T_1\mathcal T_0$. The first stage traces
+    $R_k\otimes L_h$ and retains $a_kb_h$ on $L_k\otimes R_h$. On an active
+    sector pair, the second stage adjoins
+    $\widehat\Omega_{k,h}=(a_kb_h)^{-1}
+      \bigoplus_l(\eta_{k,l}\otimes\eta_{l,h})$, and the final stage orders
+    the factors as
+    $(L_k\otimes R_k)\otimes(L_l\otimes R_l)\otimes(L_h\otimes R_h)$.
+    The lower schematic records the two-site to three-site direction in
+    \cite[Appendix~C.2, lines~1522--1545]{Cirac2016MPDO_arXiv}. The figure
+    records the three constituent maps only; no composite map or closure
+    identity is asserted here.}
+    \label{fig:mpdo_physical_sector_refinement_channel}
+\end{figure}
+
 \begin{definition}[The neighboring-state preparation $\mathcal S_1$]
     \label{def:mpdo_physical_sector_s1_map}
     \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.normalizedNeighboringDensity}
@@ -2704,26 +2725,6 @@ strong subadditivity for a normalized three-site reduced state.
     Each of the three factors is trace-preserving and completely positive,
     and this property is preserved under composition.
 \end{proof}
-
-\begin{figure}[ht]
-    \centering
-    \TNMPDORefinementConstruction
-
-    \medskip
-    \TNMPDORefinementDirection
-    \caption{Physical-sector construction of the refinement channel
-    $\mathcal T=\mathcal T_2\mathcal T_1\mathcal T_0$. The first stage traces
-    $R_k\otimes L_h$ and retains $a_kb_h$ on $L_k\otimes R_h$. On an active
-    sector pair, the second stage adjoins
-    $\widehat\Omega_{k,h}=(a_kb_h)^{-1}
-      \bigoplus_l(\eta_{k,l}\otimes\eta_{l,h})$, and the final stage orders
-    the factors as
-    $(L_k\otimes R_k)\otimes(L_l\otimes R_l)\otimes(L_h\otimes R_h)$.
-    The lower schematic records the two-site to three-site direction of the
-    channel. These are the diagrams in
-    \cite[Appendix~C.2, lines~1522--1545]{Cirac2016MPDO_arXiv}.}
-    \label{fig:mpdo_physical_sector_refinement_channel}
-\end{figure}
 
 \begin{definition}[Two- and three-site sector coordinates]
     \label{def:mpdo_physical_sector_closure_coordinates}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -2248,8 +2248,9 @@ strong subadditivity for a normalized three-site reduced state.
     \lean{MPOTensor.ExplicitEtaOperators.t0RegroupEquiv}
     \lean{MPOTensor.ExplicitEtaOperators.etaShiftEquiv}
     \lean{MPOTensor.ExplicitEtaOperators.s2ShiftEquiv}
+    \lean{MPOTensor.PhysicalSectorFactorization.t0RegroupEquiv}
     \leanok
-    \uses{def:mpdo_eta_structure}
+    \uses{def:mpdo_eta_structure, def:mpdo_physical_sector_factorization}
     In sector-adapted coordinates, regroup two sites by
     \[
       ((l_k,r_k),(l_h,r_h))
@@ -2271,6 +2272,7 @@ strong subadditivity for a normalized three-site reduced state.
 \begin{definition}[The two-site partial-trace map $\mathcal T_0$]
     \label{def:mpdo_t0_map}
     \lean{MPOTensor.ExplicitEtaOperators.t0Map}
+    \lean{MPOTensor.PhysicalSectorFactorization.t0Map}
     \leanok
     \uses{def:mpdo_two_site_subspin_regrouping,
       def:mpdo_controlled_dependent_partial_trace,
@@ -2288,6 +2290,7 @@ strong subadditivity for a normalized three-site reduced state.
 \begin{theorem}[$\mathcal T_0$ is trace-preserving completely positive]
     \label{thm:mpdo_t0_map_cptp}
     \lean{MPOTensor.ExplicitEtaOperators.t0Map_isKrausCPTP}
+    \lean{MPOTensor.PhysicalSectorFactorization.t0Map_isKrausCPTP}
     \leanok
     \uses{def:mpdo_t0_map}
     The map $\mathcal T_0$ is trace-preserving and completely positive.
@@ -2351,9 +2354,11 @@ strong subadditivity for a normalized three-site reduced state.
     \lean{MPOTensor.ExplicitEtaOperators.t2ShiftEquiv}
     \lean{MPOTensor.PhysicalSectorFactorization.ThreeSiteMiddleIndex,
       MPOTensor.PhysicalSectorFactorization.S0PreparationIndex,
-      MPOTensor.PhysicalSectorFactorization.s0RegroupEquiv}
+      MPOTensor.PhysicalSectorFactorization.s0RegroupEquiv,
+      MPOTensor.PhysicalSectorFactorization.t2ShiftEquiv}
     \leanok
-    \uses{def:mpdo_two_site_subspin_regrouping, def:mpdo_eta_omega}
+    \uses{def:mpdo_two_site_subspin_regrouping, def:mpdo_eta_omega,
+      def:mpdo_physical_sector_factorization}
     Regroup three sites by
     \[
       ((l_k,r_k),((l_l,r_l),(l_h,r_h)))
@@ -2430,6 +2435,7 @@ strong subadditivity for a normalized three-site reduced state.
 \begin{definition}[The three-site shift $\mathcal T_2$]
     \label{def:mpdo_t2_map}
     \lean{MPOTensor.ExplicitEtaOperators.t2Map}
+    \lean{MPOTensor.PhysicalSectorFactorization.t2Map}
     \leanok
     \uses{def:mpdo_three_site_subspin_regrouping,
       def:mpdo_equiv_reindex_map}
@@ -2444,6 +2450,7 @@ strong subadditivity for a normalized three-site reduced state.
 \begin{theorem}[$\mathcal T_2$ is trace-preserving completely positive]
     \label{thm:mpdo_t2_map_cptp}
     \lean{MPOTensor.ExplicitEtaOperators.t2Map_isKrausCPTP}
+    \lean{MPOTensor.PhysicalSectorFactorization.t2Map_isKrausCPTP}
     \leanok
     \uses{def:mpdo_t2_map}
     The shift $\mathcal T_2$ is trace-preserving and completely positive.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -2705,6 +2705,26 @@ strong subadditivity for a normalized three-site reduced state.
     and this property is preserved under composition.
 \end{proof}
 
+\begin{figure}[ht]
+    \centering
+    \TNMPDORefinementConstruction
+
+    \medskip
+    \TNMPDORefinementDirection
+    \caption{Physical-sector construction of the refinement channel
+    $\mathcal T=\mathcal T_2\mathcal T_1\mathcal T_0$. The first stage traces
+    $R_k\otimes L_h$ and retains $a_kb_h$ on $L_k\otimes R_h$. On an active
+    sector pair, the second stage adjoins
+    $\widehat\Omega_{k,h}=(a_kb_h)^{-1}
+      \bigoplus_l(\eta_{k,l}\otimes\eta_{l,h})$, and the final stage orders
+    the factors as
+    $(L_k\otimes R_k)\otimes(L_l\otimes R_l)\otimes(L_h\otimes R_h)$.
+    The lower schematic records the two-site to three-site direction of the
+    channel. These are the diagrams in
+    \cite[Appendix~C.2, lines~1522--1545]{Cirac2016MPDO_arXiv}.}
+    \label{fig:mpdo_physical_sector_refinement_channel}
+\end{figure}
+
 \begin{definition}[Two- and three-site sector coordinates]
     \label{def:mpdo_physical_sector_closure_coordinates}
     \lean{MPOTensor.PhysicalSectorFactorization.twoSiteSectorCoordinateEquiv,

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -2575,29 +2575,35 @@ strong subadditivity for a normalized three-site reduced state.
 % **Local fix (zero-weight quotient):** the source quotient is completed on
 % zero-weight pairs. Documented in
 % docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex.
-\begin{definition}[The three-site neighboring-state preparation $\mathcal T_1$]
-    \label{def:mpdo_physical_sector_t1_preparation}
+\begin{theorem}[Positivity and zero-weight neighboring operators]
+    \label{thm:mpdo_physical_sector_three_site_neighboring_operator_properties}
     \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.sector_nonempty,
       MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.threeSiteMiddleIndex_nonempty}
     \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.threeSiteNeighboringOperator_pos,
       MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.threeSiteNeighboringOperator_eq_zero_of_mul_eq_zero}
-    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.normalizedThreeSiteNeighboringDensity,
-      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.normalizedThreeSiteNeighboringDensity_pos,
-      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.trace_normalizedThreeSiteNeighboringDensity}
-    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.inactiveThreeSiteNeighboringDensity,
-      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.inactiveThreeSiteNeighboringDensity_posDef,
-      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.inactiveThreeSiteNeighboringDensity_trace}
-    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedThreeSiteNeighboringDensity,
-      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedThreeSiteNeighboringDensity_pos,
-      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.trace_completedThreeSiteNeighboringDensity,
-      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedThreeSiteNeighboringDensity_eq_normalized}
-    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedThreeSitePreparationMap,
-      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedThreeSitePreparationMap_eq_normalized}
-    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedThreeSiteControlledMap,
-      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedThreeSiteControlledMap_sameBlock_apply}
     \leanok
     \uses{def:mpdo_physical_sector_three_site_neighboring_operator,
-      def:mpdo_neighboring_trace_factorization}
+      def:mpdo_neighboring_trace_factorization,
+      thm:mpdo_physical_sector_three_site_neighboring_operator_trace}
+    The sector set and every middle-subspin space are nonempty. Moreover,
+    $\Omega_{k,h}$ is positive semidefinite, and
+    \[
+      a_kb_h=0 \quad\Longrightarrow\quad \Omega_{k,h}=0.
+    \]
+\end{theorem}
+
+\begin{definition}[The three-site neighboring-state preparation $\mathcal T_1$]
+    \label{def:mpdo_physical_sector_t1_preparation}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.normalizedThreeSiteNeighboringDensity}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.inactiveThreeSiteNeighboringDensity}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedThreeSiteNeighboringDensity}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedThreeSitePreparationMap}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedThreeSiteControlledMap}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.t1Map}
+    \leanok
+    \uses{def:mpdo_physical_sector_three_site_neighboring_operator,
+      def:mpdo_neighboring_trace_factorization,
+      thm:mpdo_physical_sector_three_site_neighboring_operator_properties}
     On a sector pair with $a_kb_h\ne0$, set
     \[
       \widehat\Omega_{k,h}=(a_kb_h)^{-1}\Omega_{k,h}.
@@ -2613,16 +2619,38 @@ strong subadditivity for a normalized three-site reduced state.
     preparation stage $\mathcal T_1$ of
     \cite[Appendix~C.2, lines~1523--1535]{Cirac2016MPDO_arXiv}.
     The zero-weight choice makes the source map total without imposing a
-    nonzero-weight hypothesis and does not affect its action on the two-site
-    closure.
+    nonzero-weight hypothesis.
 \end{definition}
+
+\begin{theorem}[Properties of the three-site neighboring densities]
+    \label{thm:mpdo_physical_sector_t1_density_properties}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.normalizedThreeSiteNeighboringDensity_pos,
+      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.trace_normalizedThreeSiteNeighboringDensity}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.inactiveThreeSiteNeighboringDensity_posDef,
+      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.inactiveThreeSiteNeighboringDensity_trace}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedThreeSiteNeighboringDensity_pos,
+      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.trace_completedThreeSiteNeighboringDensity,
+      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedThreeSiteNeighboringDensity_eq_normalized}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedThreeSitePreparationMap_eq_normalized}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedThreeSiteControlledMap_sameBlock_apply}
+    \leanok
+    \uses{def:mpdo_physical_sector_t1_preparation}
+    The normalized density is positive semidefinite and has trace one on
+    every active pair. The density chosen on an inactive pair is positive
+    definite and has trace one. Hence $\overline\Omega_{k,h}$ is positive
+    semidefinite with trace one for every pair, and agrees with
+    $\widehat\Omega_{k,h}$ on active pairs. The corresponding sectorwise and
+    controlled maps prepare these densities on their diagonal summands.
+\end{theorem}
 
 \begin{theorem}[$\mathcal T_1$ is trace-preserving completely positive]
     \label{thm:mpdo_physical_sector_t1_preparation_cptp}
     \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedThreeSitePreparationMap_isKrausCPTP,
       MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedThreeSiteControlledMap_isKrausCPTP}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.t1Map_isKrausCPTP}
     \leanok
-    \uses{def:mpdo_physical_sector_t1_preparation}
+    \uses{def:mpdo_physical_sector_t1_preparation,
+      thm:mpdo_physical_sector_t1_density_properties}
     The completed sectorwise preparations and their orthogonally controlled
     direct sum are trace-preserving and completely positive.
 \end{theorem}
@@ -2639,6 +2667,8 @@ strong subadditivity for a normalized three-site reduced state.
 
 \begin{definition}[The refinement channel $\mathcal T$]
     \label{def:mpdo_physical_sector_t_map}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.tMap}
+    \leanok
     \uses{def:mpdo_t0_map,
       def:mpdo_physical_sector_t1_preparation,
       def:mpdo_t2_map}
@@ -2654,12 +2684,15 @@ strong subadditivity for a normalized three-site reduced state.
 
 \begin{theorem}[$\mathcal T$ is trace-preserving completely positive]
     \label{thm:mpdo_physical_sector_t_map_cptp}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.tMap_isKrausCPTP}
+    \leanok
     \uses{def:mpdo_physical_sector_t_map}
     The refinement channel $\mathcal T$ is trace-preserving and completely
     positive.
 \end{theorem}
 
 \begin{proof}
+    \leanok
     \uses{thm:mpdo_t0_map_cptp,
       thm:mpdo_physical_sector_t1_preparation_cptp,
       thm:mpdo_t2_map_cptp,
@@ -2675,18 +2708,19 @@ strong subadditivity for a normalized three-site reduced state.
     \medskip
     \TNMPDORefinementDirection
     \caption{Physical-sector construction of the refinement channel
-    $\mathcal T=\mathcal T_2\mathcal T_1\mathcal T_0$. The first stage traces
-    $R_k\otimes L_h$ and retains $a_kb_h$ on $L_k\otimes R_h$. On an active
-    sector pair, the second stage adjoins
+    $\mathcal T=\mathcal T_2\mathcal T_1\mathcal T_0$. On a two-site closure,
+    the first stage traces $R_k\otimes L_h$ and leaves $a_kb_h$ multiplying
+    the operator on $L_k\otimes R_h$. On an active sector pair, the second
+    stage adjoins
     $\widehat\Omega_{k,h}=(a_kb_h)^{-1}
       \bigoplus_l(\eta_{k,l}\otimes\eta_{l,h})$, and the final stage orders
     the factors as
     $(L_k\otimes R_k)\otimes(L_l\otimes R_l)\otimes(L_h\otimes R_h)$.
     The upper and lower rows lie in the sitewise sector coordinates
-    $\mathfrak R_2$ and $\mathfrak R_3$, respectively. The lower schematic is
-    the refinement identity in
+    $\mathfrak R_2$ and $\mathfrak R_3$, respectively. The lower schematic
+    records the intended two-site to three-site action in
     \cite[Appendix~C.2, lines~1510--1516 and~1522--1545]
-      {Cirac2016MPDO_arXiv}.}
+      {Cirac2016MPDO_arXiv}; no refinement closure identity is asserted here.}
     \label{fig:mpdo_physical_sector_refinement_channel}
 \end{figure}
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -2572,6 +2572,65 @@ strong subadditivity for a normalized three-site reduced state.
     \label{fig:mpdo_regrouping_partial_trace_maps}
 \end{figure}
 
+\begin{definition}[The three-site neighboring-state preparation $\mathcal T_1$]
+    \label{def:mpdo_physical_sector_t1_preparation}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.sector_nonempty,
+      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.threeSiteMiddleIndex_nonempty}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.threeSiteNeighboringOperator_pos,
+      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.threeSiteNeighboringOperator_eq_zero_of_mul_eq_zero}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.normalizedThreeSiteNeighboringDensity,
+      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.normalizedThreeSiteNeighboringDensity_pos,
+      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.trace_normalizedThreeSiteNeighboringDensity}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.inactiveThreeSiteNeighboringDensity,
+      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.inactiveThreeSiteNeighboringDensity_posDef,
+      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.inactiveThreeSiteNeighboringDensity_trace}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedThreeSiteNeighboringDensity,
+      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedThreeSiteNeighboringDensity_pos,
+      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.trace_completedThreeSiteNeighboringDensity,
+      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedThreeSiteNeighboringDensity_eq_normalized}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedThreeSitePreparationMap,
+      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedThreeSitePreparationMap_eq_normalized}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedThreeSiteControlledMap,
+      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedThreeSiteControlledMap_sameBlock_apply}
+    \leanok
+    \uses{def:mpdo_physical_sector_three_site_neighboring_operator,
+      def:mpdo_neighboring_trace_factorization}
+    On a sector pair with $a_kb_h\ne0$, set
+    \[
+      \widehat\Omega_{k,h}=(a_kb_h)^{-1}\Omega_{k,h}.
+    \]
+    If $a_kb_h=0$, positivity and vanishing trace imply
+    $\Omega_{k,h}=0$; choose any density operator on that summand and denote
+    the resulting completed density by $\overline\Omega_{k,h}$. The sectorwise
+    preparation is
+    \[
+      X\longmapsto X\otimes\overline\Omega_{k,h}.
+    \]
+    Taking the orthogonal direct sum over the outer sectors $(k,h)$ gives the
+    preparation stage $\mathcal T_1$ of
+    \cite[Appendix~C.2, lines~1523--1535]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{theorem}[$\mathcal T_1$ is trace-preserving completely positive]
+    \label{thm:mpdo_physical_sector_t1_preparation_cptp}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedThreeSitePreparationMap_isKrausCPTP,
+      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedThreeSiteControlledMap_isKrausCPTP}
+    \leanok
+    \uses{def:mpdo_physical_sector_t1_preparation}
+    The completed sectorwise preparations and their orthogonally controlled
+    direct sum are trace-preserving and completely positive.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    On an active pair,
+    $\tr(\widehat\Omega_{k,h})=(a_kb_h)^{-1}a_kb_h=1$; the chosen density on
+    a zero-weight pair also has trace one. Preparation by a positive operator
+    of trace one is trace-preserving and completely positive. The orthogonal
+    control discards coherences between distinct outer-sector pairs and
+    applies these preparations on the diagonal summands.
+\end{proof}
+
 \begin{definition}[The neighboring-state preparation $\mathcal S_1$]
     \label{def:mpdo_physical_sector_s1_map}
     \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.normalizedNeighboringDensity}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -2645,14 +2645,14 @@ strong subadditivity for a normalized three-site reduced state.
 
 \begin{theorem}[$\mathcal T_1$ is trace-preserving completely positive]
     \label{thm:mpdo_physical_sector_t1_preparation_cptp}
-    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedThreeSitePreparationMap_isKrausCPTP,
-      MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedThreeSiteControlledMap_isKrausCPTP}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedThreeSitePreparationMap_isKrausCPTP}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedThreeSiteControlledMap_isKrausCPTP}
     \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.t1Map_isKrausCPTP}
     \leanok
     \uses{def:mpdo_physical_sector_t1_preparation,
       thm:mpdo_physical_sector_t1_density_properties}
-    The completed sectorwise preparations and their orthogonally controlled
-    direct sum are trace-preserving and completely positive.
+    Each completed preparation is trace-preserving and completely positive.
+    The same holds for their orthogonally controlled direct sum.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -2572,6 +2572,9 @@ strong subadditivity for a normalized three-site reduced state.
     \label{fig:mpdo_regrouping_partial_trace_maps}
 \end{figure}
 
+% **Local fix (zero-weight quotient):** the source quotient is completed on
+% zero-weight pairs. Documented in
+% docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex.
 \begin{definition}[The three-site neighboring-state preparation $\mathcal T_1$]
     \label{def:mpdo_physical_sector_t1_preparation}
     \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.sector_nonempty,
@@ -2609,6 +2612,9 @@ strong subadditivity for a normalized three-site reduced state.
     Taking the orthogonal direct sum over the outer sectors $(k,h)$ gives the
     preparation stage $\mathcal T_1$ of
     \cite[Appendix~C.2, lines~1523--1535]{Cirac2016MPDO_arXiv}.
+    The zero-weight choice makes the source map total without imposing a
+    nonzero-weight hypothesis and does not affect its action on the two-site
+    closure.
 \end{definition}
 
 \begin{theorem}[$\mathcal T_1$ is trace-preserving completely positive]
@@ -2631,6 +2637,37 @@ strong subadditivity for a normalized three-site reduced state.
     applies these preparations on the diagonal summands.
 \end{proof}
 
+\begin{definition}[The refinement channel $\mathcal T$]
+    \label{def:mpdo_physical_sector_t_map}
+    \uses{def:mpdo_t0_map,
+      def:mpdo_physical_sector_t1_preparation,
+      def:mpdo_t2_map}
+    Define the channel from two physical sites to three physical sites by
+    \[
+      \mathcal T=\mathcal T_2\mathcal T_1\mathcal T_0.
+    \]
+    Thus $\mathcal T_0$ traces the neighboring subspins, $\mathcal T_1$
+    adjoins the completed three-site neighboring density, and $\mathcal T_2$
+    restores the three complete physical sectors. This is the refinement map
+    in \cite[Appendix~C.2, lines~1522--1545]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{theorem}[$\mathcal T$ is trace-preserving completely positive]
+    \label{thm:mpdo_physical_sector_t_map_cptp}
+    \uses{def:mpdo_physical_sector_t_map}
+    The refinement channel $\mathcal T$ is trace-preserving and completely
+    positive.
+\end{theorem}
+
+\begin{proof}
+    \uses{thm:mpdo_t0_map_cptp,
+      thm:mpdo_physical_sector_t1_preparation_cptp,
+      thm:mpdo_t2_map_cptp,
+      lem:is_kraus_cptp_comp}
+    Each constituent map is trace-preserving and completely positive, and
+    this property is preserved under composition.
+\end{proof}
+
 \begin{figure}[ht]
     \centering
     \TNMPDORefinementConstruction
@@ -2645,10 +2682,11 @@ strong subadditivity for a normalized three-site reduced state.
       \bigoplus_l(\eta_{k,l}\otimes\eta_{l,h})$, and the final stage orders
     the factors as
     $(L_k\otimes R_k)\otimes(L_l\otimes R_l)\otimes(L_h\otimes R_h)$.
-    The lower schematic records the two-site to three-site direction in
-    \cite[Appendix~C.2, lines~1522--1545]{Cirac2016MPDO_arXiv}. The figure
-    records the three constituent maps only; no composite map or closure
-    identity is asserted here.}
+    The upper and lower rows lie in the sitewise sector coordinates
+    $\mathfrak R_2$ and $\mathfrak R_3$, respectively. The lower schematic is
+    the refinement identity in
+    \cite[Appendix~C.2, lines~1510--1516 and~1522--1545]
+      {Cirac2016MPDO_arXiv}.}
     \label{fig:mpdo_physical_sector_refinement_channel}
 \end{figure}
 
@@ -2739,8 +2777,64 @@ strong subadditivity for a normalized three-site reduced state.
     the direct sums over site-sector pairs and triples. Write
     $\mathfrak R_2$ and $\mathfrak R_3$ for the corresponding matrix
     reindexings. Their inverses send every sector block to the corresponding
-    physical matrix entries.
+    physical matrix entries. These reindexings preserve the left-right order
+    within every physical site. They differ from the regrouped coordinates
+    $\mathfrak G_2$ and $\mathfrak G_3$ of
+    Definition~\ref{def:mpdo_global_sector_closure_coordinates}, which place
+    the two outer subspins before the neighboring subspins. If
+    $R_{\Phi_2}$ and $R_{\Phi_3}$ denote the two regrouping maps, then
+    \[
+      \mathfrak G_2=R_{\Phi_2}\mathfrak R_2,
+      \qquad
+      \mathfrak G_3=R_{\Phi_3}\mathfrak R_3.
+    \]
 \end{definition}
+
+\begin{theorem}[Refinement of the two-site closure]
+    \label{thm:mpdo_physical_sector_t_closure_identity}
+    \uses{def:phys_close,
+      def:mpdo_physical_sector_t_map,
+      def:mpdo_physical_sector_closure_coordinates,
+      def:mpdo_neighboring_trace_factorization}
+    Assume the neighboring-operator trace factorization of
+    Definition~\ref{def:mpdo_neighboring_trace_factorization}. For every
+    virtual matrix $X$, in the canonical physical-sector coordinates selected
+    by the isometry $U$, the refinement channel satisfies
+    \[
+      \mathcal T\bigl(\mathfrak R_2({\cal K}_2(X))\bigr)
+      =\mathfrak R_3({\cal K}_3(X)).
+    \]
+    This is the refinement half of Proposition~C.7
+    \cite[Appendix~C.2, lines~1510--1516 and~1522--1545]
+      {Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}
+    \uses{thm:mpdo_global_sector_closure_decomposition,
+      thm:mpdo_sector_closure_partial_traces,
+      def:mpdo_physical_sector_t1_preparation,
+      def:mpdo_physical_sector_closure_coordinates}
+    The regrouping contained in $\mathcal T_0$ changes
+    $\mathfrak R_2$ into $\mathfrak G_2$. On the $(k,h)$ diagonal block, the
+    partial trace then gives
+    \[
+      \mathcal T_0\bigl(\mathfrak R_2({\cal K}_2(X))\bigr)_{k,h}
+      =a_kb_hB_{k,h}(X).
+    \]
+    On an active pair, $\mathcal T_1$ adjoins
+    $(a_kb_h)^{-1}\Omega_{k,h}$, and hence
+    \[
+      \mathcal T_1\mathcal T_0
+        \bigl(\mathfrak R_2({\cal K}_2(X))\bigr)_{k,h}
+      =B_{k,h}(X)\otimes\Omega_{k,h}.
+    \]
+    If $a_kb_h=0$, both sides vanish because
+    $\Omega_{k,h}=0$. After the canonical reassociation of the intermediate
+    sector sum, these are precisely the diagonal blocks of
+    $\mathfrak G_3({\cal K}_3(X))$; all off-diagonal sector blocks vanish.
+    Finally, the inverse regrouping $\mathcal T_2$ changes
+    $\mathfrak G_3$ into $\mathfrak R_3$, which gives the stated equality.
+\end{proof}
 
 \begin{theorem}[Coarse-graining of the three-site closure]
     \label{thm:mpdo_physical_sector_s_closure_identity}

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -282,6 +282,72 @@
     \end{tikzpicture}%
 }
 
+% The three stages of the physical-sector refinement channel in Appendix C.2.
+% The layout follows MPDO_TMatrix.png: a two-site sector row, the boundary row
+% left by T_0, and the three-site factor order obtained after T_1 and T_2.
+\newcommand{\TNMPDORefinementConstruction}{%
+    \begin{tikzpicture}[tn picture, scale=0.85]
+        \node[anchor=east] at (-4.30,2.45) {$\displaystyle\bigoplus_{k,h}$};
+        \TN@subspinbox{trefTopLk}{(-3.72,2.45)}{l_k}
+        \TN@subspinbox{trefTopRk}{(-2.72,2.45)}{r_k}
+        \TN@subspinbox{trefTopLh}{(-1.72,2.45)}{l_h}
+        \TN@subspinbox{trefTopRh}{(-0.72,2.45)}{r_h}
+        \TN@subspinlink{trefTopLk}{trefTopRk}
+        \TN@subspinlink{trefTopRk}{trefTopLh}
+        \TN@subspinlink{trefTopLh}{trefTopRh}
+        \draw[rounded corners=2pt, densely dashed]
+            (-3.25,1.94) rectangle (-1.19,2.96);
+        \node at (-2.22,1.68) {$\tr_{R_k\otimes L_h}$};
+
+        \draw[->, line width=0.55pt] (2.15,2.18) -- (2.15,1.22)
+            node[midway, right] {$\mathcal T_0$};
+        \node[anchor=east] at (-2.08,0.86)
+            {$\displaystyle\bigoplus_{k,h}a_kb_h$};
+        \TN@subspinbox{trefMidLk}{(-1.50,0.86)}{l_k}
+        \TN@subspinbox{trefMidRh}{(-0.50,0.86)}{r_h}
+        \TN@subspinlink{trefMidLk}{trefMidRh}
+
+        \draw[->, line width=0.55pt] (2.15,0.38) -- (2.15,-0.58)
+            node[midway, right] {$\mathcal T_2\mathcal T_1$};
+        \node[anchor=east] at (-4.30,-0.96)
+            {$\displaystyle\bigoplus_{k,h,l}$};
+        \TN@subspinbox{trefBotLk}{(-3.72,-0.96)}{l_k}
+        \TN@subspinbox{trefBotRk}{(-2.72,-0.96)}{r_k}
+        \TN@subspinbox{trefBotLl}{(-1.72,-0.96)}{l_l}
+        \TN@subspinbox{trefBotRl}{(-0.72,-0.96)}{r_l}
+        \TN@subspinbox{trefBotLh}{(0.28,-0.96)}{l_h}
+        \TN@subspinbox{trefBotRh}{(1.28,-0.96)}{r_h}
+        \TN@subspinlink{trefBotLk}{trefBotRk}
+        \TN@subspinlink{trefBotRk}{trefBotLl}
+        \TN@subspinlink{trefBotLl}{trefBotRl}
+        \TN@subspinlink{trefBotRl}{trefBotLh}
+        \TN@subspinlink{trefBotLh}{trefBotRh}
+    \end{tikzpicture}%
+}
+
+% The refinement half of MPDO_TSKKK.png.  This records only the direction and
+% site counts of the channel; the closure identity belongs to its theorem.
+\newcommand{\TNMPDORefinementDirection}{%
+    \begin{tikzpicture}[tn picture, scale=0.85]
+        \TN@subspinbox{trefDirTwoL}{(-2.85,0)}{\mathcal K}
+        \TN@subspinbox{trefDirTwoR}{(-1.75,0)}{\mathcal K}
+        \TN@subspinlink{trefDirTwoL}{trefDirTwoR}
+        \draw[tn leg] (trefDirTwoL.west) -- ++(-0.48,0);
+        \draw[tn leg] (trefDirTwoR.east) -- ++(0.48,0);
+
+        \draw[->, line width=0.65pt, bend left=18]
+            (-0.94,0.28) to node[above] {$\mathcal T$} (0.04,0.28);
+
+        \TN@subspinbox{trefDirThreeL}{(0.85,0)}{\mathcal K}
+        \TN@subspinbox{trefDirThreeM}{(1.95,0)}{\mathcal K}
+        \TN@subspinbox{trefDirThreeR}{(3.05,0)}{\mathcal K}
+        \TN@subspinlink{trefDirThreeL}{trefDirThreeM}
+        \TN@subspinlink{trefDirThreeM}{trefDirThreeR}
+        \draw[tn leg] (trefDirThreeL.west) -- ++(-0.48,0);
+        \draw[tn leg] (trefDirThreeR.east) -- ++(0.48,0);
+    \end{tikzpicture}%
+}
+
 % Fixed-sector factorization of the arbitrary-X two-site physical closure.
 % The left-hand row shows the sector subspins and the outer virtual closure;
 % the right-hand side shows only the proved boundary/neighbor tensor product.

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -287,6 +287,7 @@
 % left by T_0, and the three-site factor order obtained after T_1 and T_2.
 \newcommand{\TNMPDORefinementConstruction}{%
     \begin{tikzpicture}[tn picture, scale=0.85]
+        \node[anchor=east] at (-5.35,2.45) {$\mathfrak R_2:$};
         \node[anchor=east] at (-4.30,2.45) {$\displaystyle\bigoplus_{k,h}$};
         \TN@subspinbox{trefTopLk}{(-3.72,2.45)}{l_k}
         \TN@subspinbox{trefTopRk}{(-2.72,2.45)}{r_k}
@@ -309,6 +310,7 @@
 
         \draw[->, line width=0.55pt] (2.15,0.38) -- (2.15,-0.58)
             node[midway, right] {$\mathcal T_2\mathcal T_1$};
+        \node[anchor=east] at (-5.35,-0.96) {$\mathfrak R_3:$};
         \node[anchor=east] at (-4.30,-0.96)
             {$\displaystyle\bigoplus_{k,h,l}$};
         \TN@subspinbox{trefBotLk}{(-3.72,-0.96)}{l_k}
@@ -334,6 +336,7 @@
         \TN@subspinlink{trefDirTwoL}{trefDirTwoR}
         \draw[tn leg] (trefDirTwoL.west) -- ++(-0.48,0);
         \draw[tn leg] (trefDirTwoR.east) -- ++(0.48,0);
+        \node at (-2.30,-0.92) {$\mathfrak R_2({\cal K}_2(X))$};
 
         \draw[->, line width=0.65pt, bend left=18]
             (-0.94,0.28) to node[above] {$\mathcal T$} (0.04,0.28);
@@ -345,6 +348,7 @@
         \TN@subspinlink{trefDirThreeM}{trefDirThreeR}
         \draw[tn leg] (trefDirThreeL.west) -- ++(-0.48,0);
         \draw[tn leg] (trefDirThreeR.east) -- ++(0.48,0);
+        \node at (1.95,-0.92) {$\mathfrak R_3({\cal K}_3(X))$};
     \end{tikzpicture}%
 }
 

--- a/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
+++ b/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
@@ -7,7 +7,7 @@ name: TNMPSLocal TNMPSWord TNMPV TNBlocking TNMPVOverlap TNTransferMap TNMPOCell
 name: TNMPOLocalPurification TNMPORenormalizationTS TNEtaSectorDecomposition TNMPDOCyclicEtaContraction TNMPDOSectorAdaptedDecomposition
 {{ obj.tn_svg_html }}
 
-name: TNMPDOTwoSiteTraceAndShift TNMPDOThreeSiteTraceAndShift
+name: TNMPDOTwoSiteTraceAndShift TNMPDOThreeSiteTraceAndShift TNMPDORefinementConstruction TNMPDORefinementDirection
 {{ obj.tn_svg_html }}
 
 name: TNMPDOTwoSiteClosureFactorization TNMPDOThreeSiteClosureFactorization

--- a/docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex
@@ -1,0 +1,72 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+
+\input{command}
+
+\title{Zero-Weight Sector Completions in the MPDO Refinement Map}
+\author{}
+\date{2026-07-12}
+
+\begin{document}
+\maketitle
+
+\section{The undefined source quotient}
+
+In the proof of Proposition~C.7,
+\cite[Appendix~C.2, lines~1523--1535]{Cirac2016MPDO_arXiv}, the sectorwise
+refinement map is written as
+\[
+  \mathcal T_{k,h}(X)
+  =\frac{1}{a_kb_h}X\otimes
+    \left[\bigoplus_l(\eta_{k,l}\otimes\eta_{l,h})\right].
+\]
+The hypotheses of Proposition~C.7 require
+\[
+  \eta_{k,h}\succeq0,
+  \qquad
+  \tr(\eta_{k,h})=a_kb_h,
+  \qquad
+  \sum_k a_kb_k=1,
+\]
+but do not state that every product $a_kb_h$ is nonzero. Consequently the
+displayed quotient is not defined on a zero-weight sector pair.
+
+\section{Trace-preserving completion}
+
+Set
+\[
+  \Omega_{k,h}
+  =\bigoplus_l(\eta_{k,l}\otimes\eta_{l,h}).
+\]
+Positivity and the source trace calculation give
+\[
+  \Omega_{k,h}\succeq0,
+  \qquad
+  \tr(\Omega_{k,h})=a_kb_h.
+\]
+Thus $a_kb_h=0$ implies $\Omega_{k,h}=0$. On an active sector pair one
+adjoins the density operator $(a_kb_h)^{-1}\Omega_{k,h}$. On a zero-weight
+pair one may adjoin any density operator on the same subspin space. This
+defines a trace-preserving completely positive map on every sector pair.
+
+The choice on a zero-weight pair does not affect the refinement identity:
+the preceding partial trace $\mathcal T_0$ produces the factor
+$a_kb_hB_{k,h}(X)$, which is already zero on that pair. Equivalently, the
+corresponding block of the three-site closure is
+$B_{k,h}(X)\otimes\Omega_{k,h}=0$.
+
+\section{Verdict}
+
+The inactive-sector density is a local completion of the map omitted from the
+source formula. It adds no hypothesis to Proposition~C.7 and leaves its two-
+site to three-site identity unchanged. Formal declarations implementing this
+completion should carry a \emph{Local fix (zero-weight quotient)} marker and
+cite this file.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
## Summary

- construct the source-minimal refinement regroupings \(\mathcal T_0\) and \(\mathcal T_2\), with trace-preserving complete-positivity proofs;
- construct the specialized three-site neighboring preparation \(\mathcal T_1\), including the total trace-preserving completion on zero-weight sector pairs;
- define the composite refinement channel
  \[
  \mathcal T=\mathcal T_2\mathcal T_1\mathcal T_0
  \]
  and prove that it is trace-preserving and completely positive;
- add paper-faithful TikZ renderings of the refinement construction and the two-site-to-three-site direction;
- state the later closure identity in the blueprint without premature formalization tags.

## Mathematical scope

This is the channel-construction part of #3744. It does not yet claim the identity
\[
\mathcal T(\mathfrak R_2(\mathcal K_2(X)))=\mathfrak R_3(\mathcal K_3(X)).
\]
That calculation requires the stage-action lemmas and the final coordinate argument in follow-up changes.

The construction assumes only the physical-sector factorization and neighboring trace factorization from Appendix C.2; it does not introduce `EtaStructure` or a quantum-Markov-state hypothesis. Global regrouping coordinates \(\mathfrak G_2,\mathfrak G_3\) remain distinct from the site-sector coordinates \(\mathfrak R_2,\mathfrak R_3\).

On a pair with \(a_kb_h=0\), the quotient in the source is undefined. The map is made total by choosing a density on that unused summand. This local repair is documented in `docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex`; it adds no nonzero-weight hypothesis.

## Validation

- focused Lean checks for all new refinement modules;
- full `lake build TNLean` (9,315 jobs);
- proof-integrity and axiom audits of the changed modules;
- blueprint/Lean synchronization and changed-declaration reverse coverage;
- reader-facing prose check;
- `leanblueprint checkdecls`;
- tensor-network diagram registry, usage, and 102 smoke-render checks;
- full 493-page blueprint PDF build and visual inspection of the refinement pages;
- standalone build of the paper-gap note.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New CPTP quantum channels and a documented zero-weight completion affect MPDO formalization correctness, but changes are additive with no auth or runtime surface; the main mathematical closure identity is not yet formalized in Lean.
> 
> **Overview**
> Adds the **Proposition C.7 refinement channel** \(\mathcal T=\mathcal T_2\mathcal T_1\mathcal T_0\) on physical-sector factorizations: new Lean modules for \(\mathcal T_0/\mathcal T_2\) regroupings and partial trace, \(\Omega_{k,h}\) three-site preparation (\(\mathcal T_1\)), and composite **`tMap`** with Kraus CPTP proofs.
> 
> **Refactor:** `threeSiteNeighboringOperator` and trace lemmas move from `PhysicalSectorCoarseGrainingAction` into **`PhysicalSectorOmegaPreparation`**; coarse-graining action now imports that module.
> 
> **Zero-weight pairs:** where the paper’s \((a_kb_h)^{-1}\) quotient is undefined, preparation uses a **faithful density** completion so \(\mathcal T_1\) is total; documented in `docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex` and marked in Lean docstrings.
> 
> **Blueprint/diagrams:** chapter 21 gains formal `\lean{...}` links for \(\mathcal T_0\), \(\mathcal T_1\), \(\mathcal T\), density properties, and TikZ **`TNMPDORefinementConstruction`** / **`TNMPDORefinementDirection`**; a **refinement closure identity** theorem is stated in prose **without** new Lean tags (identity proof deferred).
> 
> Root `TNLean.lean` wires the new imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67310e4ac574f5e885bc83d53e3e1714c6aa6dd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->