### PR TITLE
feat(MPS/MPDO): prove refinement channel actions

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -398,6 +398,7 @@ import TNLean.MPS.MPDO.PhysicalSectorOmegaPreparation
 import TNLean.MPS.MPDO.PhysicalSectorRefinement
 import TNLean.MPS.MPDO.PhysicalSectorCoarseGrainingAction
 import TNLean.MPS.MPDO.PhysicalSectorCoarseGrainingIdentity
+import TNLean.MPS.MPDO.PhysicalSectorRefinementAction
 import TNLean.MPS.MPDO.SectorPairingTransfer
 import TNLean.MPS.MPDO.SectorEtaContraction
 import TNLean.MPS.MPDO.SectorEtaOperator

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -388,6 +388,7 @@ import TNLean.MPS.MPDO.SectorFactorization
 import TNLean.MPS.MPDO.PhysicalSectorFactorization
 import TNLean.MPS.MPDO.NeighboringPreparation
 import TNLean.MPS.MPDO.PhysicalSectorSubspinMaps
+import TNLean.MPS.MPDO.PhysicalSectorClosureCoordinates
 import TNLean.MPS.MPDO.PhysicalSectorRefinementRegroupings
 import TNLean.MPS.MPDO.PhysicalSectorCoarseGraining
 import TNLean.MPS.MPDO.PhysicalSectorClosureTwo

--- a/TNLean/MPS/MPDO/PhysicalSectorClosureCoordinates.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorClosureCoordinates.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalSectorSubspinMaps
+
+/-!
+# Physical-sector coordinates for two- and three-site closures
+
+This file identifies the physical indices of two and three sites with the
+corresponding direct sums of physical sectors. These coordinates are shared
+by the refinement and coarse-graining identities of Proposition C.7.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, lines 1381--1388 and 1510--1563
+-/
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D}
+
+/-- Express two physical sites in the direct sum of physical sectors.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1381--1388 and 1555--1559. -/
+noncomputable def twoSiteSectorCoordinateEquiv (F : PhysicalSectorFactorization K) :
+    (Fin (Fintype.card (SectorSiteIndex F)) ×
+      Fin (Fintype.card (SectorSiteIndex F))) ≃
+      SectorSiteIndex F × SectorSiteIndex F :=
+  Equiv.prodCongr F.sectorFinEquiv F.sectorFinEquiv
+
+/-- Express three physical sites in the direct sum of physical sectors.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1381--1388 and 1547--1559. -/
+noncomputable def threeSiteSectorCoordinateEquiv (F : PhysicalSectorFactorization K) :
+    (Fin (Fintype.card (SectorSiteIndex F)) ×
+      (Fin (Fintype.card (SectorSiteIndex F)) ×
+        Fin (Fintype.card (SectorSiteIndex F)))) ≃
+      SectorSiteIndex F × (SectorSiteIndex F × SectorSiteIndex F) :=
+  Equiv.prodCongr F.sectorFinEquiv
+    (Equiv.prodCongr F.sectorFinEquiv F.sectorFinEquiv)
+
+@[simp] theorem twoSiteSectorCoordinateEquiv_symm_apply
+    (F : PhysicalSectorFactorization K) (k h : Fin F.sectorCount)
+    (x : SectorIndex F k) (y : SectorIndex F h) :
+    F.twoSiteSectorCoordinateEquiv.symm (⟨k, x⟩, ⟨h, y⟩) =
+      (F.sectorFinEquiv.symm ⟨k, x⟩, F.sectorFinEquiv.symm ⟨h, y⟩) :=
+  rfl
+
+@[simp] theorem threeSiteSectorCoordinateEquiv_symm_apply
+    (F : PhysicalSectorFactorization K) (k l h : Fin F.sectorCount)
+    (x : SectorIndex F k) (y : SectorIndex F l) (z : SectorIndex F h) :
+    F.threeSiteSectorCoordinateEquiv.symm (⟨k, x⟩, (⟨l, y⟩, ⟨h, z⟩)) =
+      (F.sectorFinEquiv.symm ⟨k, x⟩,
+        (F.sectorFinEquiv.symm ⟨l, y⟩, F.sectorFinEquiv.symm ⟨h, z⟩)) :=
+  rfl
+
+end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/PhysicalSectorCoarseGrainingIdentity.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorCoarseGrainingIdentity.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.PhysicalSectorCoarseGrainingAction
+import TNLean.MPS.MPDO.PhysicalSectorClosureCoordinates
 
 /-!
 # Coarse-graining identity for physical-sector closures
@@ -25,41 +26,6 @@ open scoped Matrix BigOperators Kronecker
 namespace MPOTensor.PhysicalSectorFactorization
 
 variable {d D : ℕ} {K : MPOTensor d D} {F : PhysicalSectorFactorization K}
-
-/-- Express two physical sites in the direct sum of physical sectors.
-
-Source: arXiv:1606.00608, Appendix C.2, lines 1381--1388 and 1555--1559. -/
-noncomputable def twoSiteSectorCoordinateEquiv (F : PhysicalSectorFactorization K) :
-    (Fin (Fintype.card (SectorSiteIndex F)) ×
-      Fin (Fintype.card (SectorSiteIndex F))) ≃
-      SectorSiteIndex F × SectorSiteIndex F :=
-  Equiv.prodCongr F.sectorFinEquiv F.sectorFinEquiv
-
-/-- Express three physical sites in the direct sum of physical sectors.
-
-Source: arXiv:1606.00608, Appendix C.2, lines 1381--1388 and 1547--1559. -/
-noncomputable def threeSiteSectorCoordinateEquiv (F : PhysicalSectorFactorization K) :
-    (Fin (Fintype.card (SectorSiteIndex F)) ×
-      (Fin (Fintype.card (SectorSiteIndex F)) ×
-        Fin (Fintype.card (SectorSiteIndex F)))) ≃
-      SectorSiteIndex F × (SectorSiteIndex F × SectorSiteIndex F) :=
-  Equiv.prodCongr F.sectorFinEquiv
-    (Equiv.prodCongr F.sectorFinEquiv F.sectorFinEquiv)
-
-@[simp] theorem twoSiteSectorCoordinateEquiv_symm_apply
-    (F : PhysicalSectorFactorization K) (k h : Fin F.sectorCount)
-    (x : SectorIndex F k) (y : SectorIndex F h) :
-    F.twoSiteSectorCoordinateEquiv.symm (⟨k, x⟩, ⟨h, y⟩) =
-      (F.sectorFinEquiv.symm ⟨k, x⟩, F.sectorFinEquiv.symm ⟨h, y⟩) :=
-  rfl
-
-@[simp] theorem threeSiteSectorCoordinateEquiv_symm_apply
-    (F : PhysicalSectorFactorization K) (k l h : Fin F.sectorCount)
-    (x : SectorIndex F k) (y : SectorIndex F l) (z : SectorIndex F h) :
-    F.threeSiteSectorCoordinateEquiv.symm (⟨k, x⟩, (⟨l, y⟩, ⟨h, z⟩)) =
-      (F.sectorFinEquiv.symm ⟨k, x⟩,
-        (F.sectorFinEquiv.symm ⟨l, y⟩, F.sectorFinEquiv.symm ⟨h, z⟩)) :=
-  rfl
 
 /-- On an outer-sector pair, the regrouped three-site physical closure is
 the boundary operator tensored with the direct sum of the two neighboring

--- a/TNLean/MPS/MPDO/PhysicalSectorRefinementAction.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorRefinementAction.lean
@@ -1,0 +1,210 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalSectorCoarseGrainingIdentity
+import TNLean.MPS.MPDO.PhysicalSectorRefinement
+
+/-!
+# Action of the physical-sector refinement maps
+
+This file computes the sector-block action of the three maps in the
+refinement channel of Proposition C.7. The two-site closure first regroups as
+a boundary operator tensored with a neighboring operator. The first map
+traces the neighboring factor, the second adjoins the completed normalized
+three-site neighboring operator, and the third reindexes the resulting
+subspins as three physical sites.
+
+Only the action of the three constituent maps is proved here. The equality
+between the refined two-site closure and the three-site closure is a separate
+statement.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, lines 1522--1545
+-/
+
+open scoped Matrix BigOperators Kronecker
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D} {F : PhysicalSectorFactorization K}
+
+/-- On an outer-sector pair, the regrouped two-site physical closure is the
+boundary operator tensored with the neighboring operator.
+
+**Local fix (zero-weight quotient):** this factorization precedes the
+preparation and remains valid on zero-weight pairs. The completion used later
+is documented in
+`docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1441--1450 and 1521--1524. -/
+theorem t0Regrouped_twoSiteClosure_block_eq
+    (F : PhysicalSectorFactorization K) (X : Matrix (Fin D) (Fin D) ℂ)
+    (k h : Fin F.sectorCount) :
+    (Matrix.equivReindexMap F.t0RegroupEquiv
+      (Matrix.reindex F.twoSiteSectorCoordinateEquiv
+        F.twoSiteSectorCoordinateEquiv
+        (physClose2 F.sectorCoordinateTensor X))).submatrix
+          (Sigma.mk (k, h)) (Sigma.mk (k, h)) =
+      F.boundaryOperator k h X ⊗ₖ F.neighboringOperator k h := by
+  ext ⟨a, u⟩ ⟨b, v⟩
+  have hg := congrFun (congrFun (F.twoSiteSectorClosure_eq k h X)
+    (a, u)) (b, v)
+  simpa [Matrix.equivReindexMap, Matrix.reindex_apply, Matrix.submatrix_apply,
+    t0RegroupEquiv, twoSiteSectorCoordinateEquiv, twoSiteSectorClosure,
+    twoSiteSectorEmbedding, twoSiteRegroupEquiv, s2ShiftEquiv] using hg
+
+/-- On a diagonal outer-sector pair, \(\mathcal T_0\) is the partial trace
+of the corresponding regrouped two-site block.
+
+**Local fix (zero-weight quotient):** this partial trace is defined on every
+sector pair and is independent of the later completion. The completion is
+documented in
+`docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1521--1524. -/
+theorem t0Map_sameBlock_apply (F : PhysicalSectorFactorization K)
+    (X : Matrix (SectorSiteIndex F × SectorSiteIndex F)
+      (SectorSiteIndex F × SectorSiteIndex F) ℂ)
+    (k h : Fin F.sectorCount) (a b : BoundaryIndex F k h) :
+    F.t0Map X ⟨(k, h), a⟩ ⟨(k, h), b⟩ =
+      Matrix.partialTraceRight
+        ((Matrix.equivReindexMap F.t0RegroupEquiv X).submatrix
+          (fun p ↦ Sigma.mk (k, h) p) (fun p ↦ Sigma.mk (k, h) p)) a b := by
+  rw [t0Map, LinearMap.comp_apply,
+    Matrix.controlledPartialTraceRightLM_sameBlock_apply]
+
+/-- If a regrouped diagonal block is
+\(B\otimes\eta_{k,h}\), then \(\mathcal T_0\) maps it to
+\((a_kb_h)B\).
+
+**Local fix (zero-weight quotient):** the coefficient vanishes on inactive
+sector pairs, so the subsequent completed preparation receives the zero
+matrix. Documented in
+`docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1521--1535. -/
+theorem NeighboringTraceFactorization.t0Map_block_eq_smul
+    (H : NeighboringTraceFactorization F)
+    (X : Matrix (SectorSiteIndex F × SectorSiteIndex F)
+      (SectorSiteIndex F × SectorSiteIndex F) ℂ)
+    (k h : Fin F.sectorCount) (B : Matrix (BoundaryIndex F k h)
+      (BoundaryIndex F k h) ℂ)
+    (hblock :
+      (Matrix.equivReindexMap F.t0RegroupEquiv X).submatrix
+        (fun p ↦ Sigma.mk (k, h) p) (fun p ↦ Sigma.mk (k, h) p) =
+          B ⊗ₖ F.neighboringOperator k h) :
+    (F.t0Map X).submatrix (Sigma.mk (k, h)) (Sigma.mk (k, h)) =
+      ((H.a k * H.b h : ℝ) : ℂ) • B := by
+  ext a b
+  rw [Matrix.submatrix_apply, F.t0Map_sameBlock_apply, hblock,
+    Matrix.partialTraceRight_kronecker,
+    H.trace_neighboringOperator, Matrix.smul_apply]
+
+/-- Multiplying a boundary matrix by \(a_kb_h\) and then adjoining the
+completed normalized three-site neighboring density gives exactly
+\(B\otimes\Omega_{k,h}\), including on zero-weight sector pairs.
+
+**Local fix (zero-weight quotient):** the inactive branch is harmless because
+both the input coefficient and \(\Omega_{k,h}\) vanish. Documented in
+`docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1523--1535. -/
+theorem NeighboringTraceFactorization.completedThreeSitePreparationMap_smul
+    (H : NeighboringTraceFactorization F) (k h : Fin F.sectorCount)
+    (B : Matrix (BoundaryIndex F k h) (BoundaryIndex F k h) ℂ) :
+    H.completedThreeSitePreparationMap k h
+        (((H.a k * H.b h : ℝ) : ℂ) • B) =
+      B ⊗ₖ F.threeSiteNeighboringOperator k h := by
+  classical
+  by_cases hactive : H.a k * H.b h ≠ 0
+  · rw [H.completedThreeSitePreparationMap_eq_normalized k h hactive]
+    ext p q
+    change Matrix.kroneckerMap (· * ·)
+        (((H.a k * H.b h : ℝ) : ℂ) • B)
+        ((((H.a k * H.b h)⁻¹ : ℝ) : ℂ) •
+          F.threeSiteNeighboringOperator k h) p q = _
+    simp only [Matrix.kroneckerMap_apply, Matrix.smul_apply, smul_eq_mul]
+    have hcancel :
+        ((H.a k * H.b h : ℝ) : ℂ) *
+          (((H.a k * H.b h)⁻¹ : ℝ) : ℂ) = 1 := by
+      exact_mod_cast mul_inv_cancel₀ hactive
+    calc
+      _ = (((H.a k * H.b h : ℝ) : ℂ) *
+            (((H.a k * H.b h)⁻¹ : ℝ) : ℂ)) *
+          (B p.1 q.1 * F.threeSiteNeighboringOperator k h p.2 q.2) := by ring
+      _ = _ := by rw [hcancel, one_mul]
+  · have hzero : H.a k * H.b h = 0 := not_ne_iff.mp hactive
+    rw [hzero]
+    simp [H.threeSiteNeighboringOperator_eq_zero_of_mul_eq_zero k h hzero]
+
+/-- If a diagonal input block is \((a_kb_h)B\), then \(\mathcal T_1\)
+maps it to \(B\otimes\Omega_{k,h}\).
+
+**Local fix (zero-weight quotient):** on an inactive pair the input block and
+the target neighboring operator both vanish, independently of the chosen
+density. Documented in
+`docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1523--1535. -/
+theorem NeighboringTraceFactorization.t1Map_block_eq_kronecker
+    (H : NeighboringTraceFactorization F)
+    (X : Matrix (BoundarySubspinIndex F) (BoundarySubspinIndex F) ℂ)
+    (k h : Fin F.sectorCount)
+    (B : Matrix (BoundaryIndex F k h) (BoundaryIndex F k h) ℂ)
+    (hblock : X.submatrix (Sigma.mk (k, h)) (Sigma.mk (k, h)) =
+      ((H.a k * H.b h : ℝ) : ℂ) • B) :
+    (H.t1Map X).submatrix
+        (fun p ↦ Sigma.mk (k, h) p) (fun p ↦ Sigma.mk (k, h) p) =
+      B ⊗ₖ F.threeSiteNeighboringOperator k h := by
+  ext p q
+  rcases p with ⟨a, u⟩
+  rcases q with ⟨b, v⟩
+  rw [Matrix.submatrix_apply, NeighboringTraceFactorization.t1Map,
+    H.completedThreeSiteControlledMap_sameBlock_apply]
+  change H.completedThreeSitePreparationMap k h
+      (X.submatrix (fun x ↦ Sigma.mk (k, h) x)
+        (fun x ↦ Sigma.mk (k, h) x)) (a, u) (b, v) = _
+  rw [hblock, H.completedThreeSitePreparationMap_smul]
+
+/-- The preparation stage annihilates entries between distinct pairs of
+outer sectors.
+
+**Local fix (zero-weight quotient):** this vanishing follows from orthogonal
+sector control and is independent of the density chosen on inactive pairs.
+The completion is documented in
+`docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1523--1535. -/
+theorem NeighboringTraceFactorization.t1Map_apply_of_ne
+    (H : NeighboringTraceFactorization F)
+    (Y : Matrix (BoundarySubspinIndex F) (BoundarySubspinIndex F) ℂ)
+    {kh pq : Fin F.sectorCount × Fin F.sectorCount} (hne : kh ≠ pq)
+    (a : BoundaryIndex F kh.1 kh.2)
+    (u : ThreeSiteMiddleIndex F kh.1 kh.2)
+    (b : BoundaryIndex F pq.1 pq.2)
+    (v : ThreeSiteMiddleIndex F pq.1 pq.2) :
+    H.t1Map Y ⟨kh, (a, u)⟩ ⟨pq, (b, v)⟩ = 0 := by
+  classical
+  rw [NeighboringTraceFactorization.t1Map,
+    NeighboringTraceFactorization.completedThreeSiteControlledMap,
+    Matrix.controlledKrausMap_apply_of_ne _ _ Y hne]
+
+/-- The map \(\mathcal T_2\) sends the prepared matrix to the corresponding
+three-site sector matrix by relabeling its indices.
+
+**Local fix (zero-weight quotient):** this reindexing is independent of the
+inactive-sector density. The preceding completion is documented in
+`docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1535--1545. -/
+theorem t2Map_apply (F : PhysicalSectorFactorization K)
+    (X : Matrix (S0PreparationIndex F) (S0PreparationIndex F) ℂ)
+    (p q : SectorSiteIndex F × (SectorSiteIndex F × SectorSiteIndex F)) :
+    F.t2Map X p q = X (F.t2ShiftEquiv.symm p) (F.t2ShiftEquiv.symm q) := by
+  rfl
+
+end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/PhysicalSectorRefinementAction.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorRefinementAction.lean
@@ -3,7 +3,8 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.MPDO.PhysicalSectorCoarseGrainingIdentity
+import TNLean.MPS.MPDO.PhysicalSectorClosureCoordinates
+import TNLean.MPS.MPDO.PhysicalSectorClosureTwo
 import TNLean.MPS.MPDO.PhysicalSectorRefinement
 
 /-!
@@ -35,11 +36,6 @@ variable {d D : ℕ} {K : MPOTensor d D} {F : PhysicalSectorFactorization K}
 /-- On an outer-sector pair, the regrouped two-site physical closure is the
 boundary operator tensored with the neighboring operator.
 
-**Local fix (zero-weight quotient):** this factorization precedes the
-preparation and remains valid on zero-weight pairs. The completion used later
-is documented in
-`docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex`.
-
 Source: arXiv:1606.00608, Appendix C.2, lines 1441--1450 and 1521--1524. -/
 theorem t0Regrouped_twoSiteClosure_block_eq
     (F : PhysicalSectorFactorization K) (X : Matrix (Fin D) (Fin D) ℂ)
@@ -60,11 +56,6 @@ theorem t0Regrouped_twoSiteClosure_block_eq
 /-- On a diagonal outer-sector pair, \(\mathcal T_0\) is the partial trace
 of the corresponding regrouped two-site block.
 
-**Local fix (zero-weight quotient):** this partial trace is defined on every
-sector pair and is independent of the later completion. The completion is
-documented in
-`docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex`.
-
 Source: arXiv:1606.00608, Appendix C.2, lines 1521--1524. -/
 theorem t0Map_sameBlock_apply (F : PhysicalSectorFactorization K)
     (X : Matrix (SectorSiteIndex F × SectorSiteIndex F)
@@ -80,11 +71,6 @@ theorem t0Map_sameBlock_apply (F : PhysicalSectorFactorization K)
 /-- If a regrouped diagonal block is
 \(B\otimes\eta_{k,h}\), then \(\mathcal T_0\) maps it to
 \((a_kb_h)B\).
-
-**Local fix (zero-weight quotient):** the coefficient vanishes on inactive
-sector pairs, so the subsequent completed preparation receives the zero
-matrix. Documented in
-`docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex`.
 
 Source: arXiv:1606.00608, Appendix C.2, lines 1521--1535. -/
 theorem NeighboringTraceFactorization.t0Map_block_eq_smul
@@ -173,11 +159,6 @@ theorem NeighboringTraceFactorization.t1Map_block_eq_kronecker
 /-- The preparation stage annihilates entries between distinct pairs of
 outer sectors.
 
-**Local fix (zero-weight quotient):** this vanishing follows from orthogonal
-sector control and is independent of the density chosen on inactive pairs.
-The completion is documented in
-`docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex`.
-
 Source: arXiv:1606.00608, Appendix C.2, lines 1523--1535. -/
 theorem NeighboringTraceFactorization.t1Map_apply_of_ne
     (H : NeighboringTraceFactorization F)
@@ -195,10 +176,6 @@ theorem NeighboringTraceFactorization.t1Map_apply_of_ne
 
 /-- The map \(\mathcal T_2\) sends the prepared matrix to the corresponding
 three-site sector matrix by relabeling its indices.
-
-**Local fix (zero-weight quotient):** this reindexing is independent of the
-inactive-sector density. The preceding completion is documented in
-`docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex`.
 
 Source: arXiv:1606.00608, Appendix C.2, lines 1535--1545. -/
 theorem t2Map_apply (F : PhysicalSectorFactorization K)

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -2824,6 +2824,153 @@ strong subadditivity for a normalized three-site reduced state.
     \]
 \end{definition}
 
+\begin{theorem}[Regrouped two-site closure block]
+    \label{thm:mpdo_t0_regrouped_two_site_closure_block}
+    \lean{MPOTensor.PhysicalSectorFactorization.t0Regrouped_twoSiteClosure_block_eq}
+    \leanok
+    \uses{thm:mpdo_two_site_sector_closure_factorization,
+      def:mpdo_physical_sector_closure_coordinates,
+      def:mpdo_two_site_subspin_regrouping}
+    For every virtual matrix $X$ and outer-sector pair $(k,h)$,
+    \[
+      \left[
+        R_{\Phi_2}\mathfrak R_2({\cal K}_2(X))
+      \right]_{(k,h),(k,h)}
+      =B_{k,h}(X)\otimes\eta_{k,h}.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_two_site_sector_closure_factorization}
+    This is the fixed-sector two-site factorization after identifying the
+    sitewise sector coordinates with the regrouped boundary and neighboring
+    coordinates.
+\end{proof}
+
+\begin{theorem}[Diagonal-block action of $\mathcal T_0$]
+    \label{thm:mpdo_t0_same_block_action}
+    \lean{MPOTensor.PhysicalSectorFactorization.t0Map_sameBlock_apply}
+    \leanok
+    \uses{def:mpdo_t0_map,
+      def:mpdo_two_site_subspin_regrouping}
+    For every two-site matrix $Y$, outer-sector pair $(k,h)$, and boundary
+    indices $a,b$,
+    \[
+      [\mathcal T_0(Y)]_{(k,h,a),(k,h,b)}
+      =\left[
+        \tr_{R_k\otimes L_h}
+          \left([R_{\Phi_2}Y]_{(k,h),(k,h)}\right)
+       \right]_{a,b}.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The controlled partial trace acts on a diagonal outer-sector block by
+    the ordinary partial trace over its neighboring factor.
+\end{proof}
+
+\begin{theorem}[Partial trace of a factorized two-site block]
+    \label{thm:mpdo_t0_factorized_block_action}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.t0Map_block_eq_smul}
+    \leanok
+    \uses{thm:mpdo_t0_same_block_action,
+      def:mpdo_neighboring_trace_factorization}
+    If the $(k,h)$ diagonal block of $R_{\Phi_2}Y$ is
+    $B\otimes\eta_{k,h}$, then
+    \[
+      [\mathcal T_0(Y)]_{(k,h),(k,h)}=a_kb_hB.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_t0_same_block_action,
+      def:mpdo_neighboring_trace_factorization}
+    The partial trace of $B\otimes\eta_{k,h}$ is
+    $\tr(\eta_{k,h})B=a_kb_hB$.
+\end{proof}
+
+% **Local fix (zero-weight quotient):** the next three entries use the
+% completion documented in
+% docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex.
+\begin{theorem}[Preparation of a scaled boundary block]
+    \label{thm:mpdo_t1_scaled_block_preparation}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.completedThreeSitePreparationMap_smul}
+    \leanok
+    \uses{def:mpdo_physical_sector_t1_preparation,
+      thm:mpdo_physical_sector_t1_density_properties}
+    For every outer-sector pair $(k,h)$ and boundary matrix $B$, the completed
+    sectorwise preparation satisfies
+    \[
+      \overline{\mathcal T}_{k,h}(a_kb_hB)
+      =B\otimes\Omega_{k,h}.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_physical_sector_t1_density_properties,
+      thm:mpdo_physical_sector_three_site_neighboring_operator_trace}
+    If $a_kb_h\ne0$, the scalar cancels the normalization in
+    $\widehat\Omega_{k,h}=(a_kb_h)^{-1}\Omega_{k,h}$. If $a_kb_h=0$, both
+    sides vanish because $\Omega_{k,h}=0$.
+\end{proof}
+
+\begin{theorem}[Diagonal-block action of $\mathcal T_1$]
+    \label{thm:mpdo_t1_factorized_block_action}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.t1Map_block_eq_kronecker}
+    \leanok
+    \uses{def:mpdo_physical_sector_t1_preparation,
+      thm:mpdo_t1_scaled_block_preparation}
+    If the $(k,h)$ diagonal block of a boundary matrix $Y$ is $a_kb_hB$, then
+    \[
+      [\mathcal T_1(Y)]_{(k,h),(k,h)}
+      =B\otimes\Omega_{k,h}.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_t1_scaled_block_preparation}
+    On a diagonal outer-sector block, the controlled map is the completed
+    sectorwise preparation, to which the preceding theorem applies.
+\end{proof}
+
+\begin{theorem}[Off-diagonal action of $\mathcal T_1$]
+    \label{thm:mpdo_t1_off_diagonal_action}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.t1Map_apply_of_ne}
+    \leanok
+    \uses{def:mpdo_physical_sector_t1_preparation}
+    The map $\mathcal T_1$ annihilates every matrix entry between distinct
+    outer-sector pairs.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    This is the orthogonal control in the definition of $\mathcal T_1$.
+\end{proof}
+
+\begin{theorem}[Reindexing action of $\mathcal T_2$]
+    \label{thm:mpdo_t2_reindexing_action}
+    \lean{MPOTensor.PhysicalSectorFactorization.t2Map_apply}
+    \leanok
+    \uses{def:mpdo_t2_map}
+    Let $\Phi_3$ be the three-site regrouping. For every prepared matrix $Y$
+    and three-site indices $p,q$,
+    \[
+      [\mathcal T_2(Y)]_{p,q}
+      =Y_{\Phi_3(p),\Phi_3(q)}.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    This is matrix reindexing along the inverse regrouping
+    $\Phi_3^{-1}$.
+\end{proof}
+
 \begin{theorem}[Refinement of the two-site closure]
     \label{thm:mpdo_physical_sector_t_closure_identity}
     \uses{def:phys_close,
@@ -2844,9 +2991,12 @@ strong subadditivity for a normalized three-site reduced state.
 \end{theorem}
 
 \begin{proof}
-    \uses{thm:mpdo_global_sector_closure_decomposition,
-      thm:mpdo_sector_closure_partial_traces,
-      def:mpdo_physical_sector_t1_preparation,
+    \uses{thm:mpdo_t0_regrouped_two_site_closure_block,
+      thm:mpdo_t0_factorized_block_action,
+      thm:mpdo_t1_factorized_block_action,
+      thm:mpdo_t1_off_diagonal_action,
+      thm:mpdo_t2_reindexing_action,
+      thm:mpdo_global_sector_closure_decomposition,
       def:mpdo_physical_sector_closure_coordinates}
     The regrouping contained in $\mathcal T_0$ changes
     $\mathfrak R_2$ into $\mathfrak G_2$. On the $(k,h)$ diagonal block, the


### PR DESCRIPTION
## Summary

- prove the regrouped two-site closure block formula used by \(\mathcal T_0\);
- prove the diagonal action of \(\mathcal T_0\) and its coefficient \(a_kb_h\);
- prove scalar cancellation for the completed \(\Omega_{k,h}\) preparation, including zero-weight pairs;
- prove the diagonal and off-diagonal actions of \(\mathcal T_1\), and the reindexing action of \(\mathcal T_2\);
- move the shared two- and three-site sector coordinates into a neutral module imported by both the refinement and coarse-graining directions.

## Mathematical scope

This is the action-lemma part of #3744. The public identity
\[
\mathcal T(\mathfrak R_2(\mathcal K_2(X)))=\mathfrak R_3(\mathcal K_3(X))
\]
remains untagged in the blueprint and is not claimed by this PR. The proved lemmas supply precisely its diagonal scalar cancellation, zero-weight vanishing, off-diagonal vanishing, and final reindexing steps.

No nonzero-weight assumption, `EtaStructure`, or quantum-Markov-state hypothesis is added. The local completion is invoked only in the \(\mathcal T_1\) preparation lemmas and is cited through `docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex`.

## Validation

- focused build of the coordinate, coarse-graining identity, and refinement action modules;
- full `lake build TNLean` (9,317 jobs);
- proof-integrity scan and axiom audit of all seven new declarations;
- blueprint/Lean synchronization and changed-declaration reverse coverage;
- reader-facing prose check;
- `leanblueprint checkdecls`;
- full 494-page blueprint PDF build and visual inspection of printed pages 456–458.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive formalization in the MPDO physical-sector track with shared coordinate extraction; no runtime, auth, or data paths, and the main refinement identity remains explicitly unproved in this PR.
> 
> **Overview**
> Adds the **action-lemma layer** for Proposition C.7’s refinement channel \(\mathcal T=\mathcal T_2\mathcal T_1\mathcal T_0\): diagonal and off-diagonal block behavior of \(\mathcal T_0\), \(\mathcal T_1\), and \(\mathcal T_2\), without yet proving the full refinement closure identity (that theorem stays untagged in the blueprint).
> 
> **Refactoring:** two- and three-site sector coordinate equivalences move from `PhysicalSectorCoarseGrainingIdentity` into **`PhysicalSectorClosureCoordinates`**, shared by refinement and coarse-graining.
> 
> **New Lean module** `PhysicalSectorRefinementAction` proves seven declarations, including regrouped two-site closure \(B_{k,h}\otimes\eta_{k,h}\), \(\mathcal T_0\) giving \(a_kb_h B\) on factorized blocks, \(\mathcal T_1\) preparation with **scalar cancellation** and **zero-weight** vanishing (citing the local completion note), off-diagonal \(\mathcal T_1\) annihilation, and \(\mathcal T_2\) as reindexing.
> 
> The blueprint chapter gains matching `\leanok` theorems and the refinement-closure proof sketch now cites these lemmas instead of only global decomposition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e558d5f3ccdf2ca78f9b4ae5eb838eb075092408. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->