### PR TITLE
feat(MPS/MPDO): prove refinement closure identity

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -396,10 +396,12 @@ import TNLean.MPS.MPDO.PhysicalSectorClosureThree
 import TNLean.MPS.MPDO.PhysicalSectorClosureGlobal
 import TNLean.MPS.MPDO.PhysicalSectorTraceActions
 import TNLean.MPS.MPDO.PhysicalSectorOmegaPreparation
+import TNLean.MPS.MPDO.PhysicalSectorClosureBlocks
 import TNLean.MPS.MPDO.PhysicalSectorRefinement
 import TNLean.MPS.MPDO.PhysicalSectorCoarseGrainingAction
 import TNLean.MPS.MPDO.PhysicalSectorCoarseGrainingIdentity
 import TNLean.MPS.MPDO.PhysicalSectorRefinementAction
+import TNLean.MPS.MPDO.PhysicalSectorRefinementIdentity
 import TNLean.MPS.MPDO.SectorPairingTransfer
 import TNLean.MPS.MPDO.SectorEtaContraction
 import TNLean.MPS.MPDO.SectorEtaOperator

--- a/TNLean/MPS/MPDO/PhysicalSectorClosureBlocks.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorClosureBlocks.lean
@@ -1,0 +1,128 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalSectorClosureCoordinates
+import TNLean.MPS.MPDO.PhysicalSectorOmegaPreparation
+
+/-!
+# Outer-sector blocks of the three-site closure
+
+This file expresses the regrouped three-site physical closure in blocks
+indexed by its two outer sectors. Each diagonal block is the boundary
+operator tensored with the three-site neighboring operator, and every entry
+between distinct outer-sector pairs vanishes.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, lines 1435--1448 and 1510--1516
+-/
+
+open scoped Matrix BigOperators Kronecker
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D}
+
+/-- On an outer-sector pair, the regrouped three-site physical closure is
+the boundary operator tensored with the three-site neighboring operator.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1435--1448 and 1510--1516. -/
+theorem s0Regrouped_threeSiteClosure_block_eq
+    (F : PhysicalSectorFactorization K) (X : Matrix (Fin D) (Fin D) ℂ)
+    (k h : Fin F.sectorCount) :
+    (Matrix.equivReindexMap F.s0RegroupEquiv
+      (Matrix.reindex F.threeSiteSectorCoordinateEquiv
+        F.threeSiteSectorCoordinateEquiv
+        (physClose3 F.sectorCoordinateTensor X))).submatrix
+          (Sigma.mk (k, h)) (Sigma.mk (k, h)) =
+      F.boundaryOperator k h X ⊗ₖ F.threeSiteNeighboringOperator k h := by
+  ext ⟨a, l, u⟩ ⟨b, m, v⟩
+  by_cases hlm : l = m
+  · subst m
+    have hg := congrFun (congrFun (F.threeSiteSectorClosure_eq k l h X)
+      (a, u)) (b, v)
+    simpa [Matrix.equivReindexMap, Matrix.reindex_apply, Matrix.submatrix_apply,
+      s0RegroupEquiv, threeSiteSectorCoordinateEquiv,
+      threeSiteSectorClosure, threeSiteSectorEmbedding,
+      threeSiteNeighboringOperator,
+      Matrix.blockDiagonal'_apply] using hg
+  · have hz : F.sectorCoordinateTensor
+        (F.sectorFinEquiv.symm ⟨l, (u.1.2, u.2.1)⟩)
+        (F.sectorFinEquiv.symm ⟨m, (v.1.2, v.2.1)⟩) = 0 := by
+      ext beta alpha
+      exact sectorCoordinateTensor_apply_ne F hlm _ _ beta alpha
+    change Matrix.trace
+      (F.sectorCoordinateTensor
+          (F.sectorFinEquiv.symm ⟨k, (a.1, u.1.1)⟩)
+          (F.sectorFinEquiv.symm ⟨k, (b.1, v.1.1)⟩) *
+        F.sectorCoordinateTensor
+          (F.sectorFinEquiv.symm ⟨l, (u.1.2, u.2.1)⟩)
+          (F.sectorFinEquiv.symm ⟨m, (v.1.2, v.2.1)⟩) *
+        F.sectorCoordinateTensor
+          (F.sectorFinEquiv.symm ⟨h, (u.2.2, a.2)⟩)
+          (F.sectorFinEquiv.symm ⟨h, (v.2.2, b.2)⟩) * X) =
+      F.boundaryOperator k h X a b *
+        F.threeSiteNeighboringOperator k h ⟨l, u⟩ ⟨m, v⟩
+    rw [hz]
+    simp [threeSiteNeighboringOperator, Matrix.blockDiagonal'_apply, hlm]
+
+/-- Between distinct outer-sector pairs, the regrouped three-site physical
+closure vanishes.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1435--1448. -/
+theorem s0Regrouped_threeSiteClosure_apply_of_outer_ne
+    (F : PhysicalSectorFactorization K) (X : Matrix (Fin D) (Fin D) ℂ)
+    {kh pq : Fin F.sectorCount × Fin F.sectorCount} (hne : kh ≠ pq)
+    (a : BoundaryIndex F kh.1 kh.2)
+    (u : ThreeSiteMiddleIndex F kh.1 kh.2)
+    (b : BoundaryIndex F pq.1 pq.2)
+    (v : ThreeSiteMiddleIndex F pq.1 pq.2) :
+    Matrix.equivReindexMap F.s0RegroupEquiv
+        (Matrix.reindex F.threeSiteSectorCoordinateEquiv
+          F.threeSiteSectorCoordinateEquiv
+          (physClose3 F.sectorCoordinateTensor X))
+        ⟨kh, (a, u)⟩ ⟨pq, (b, v)⟩ = 0 := by
+  rcases u with ⟨l, u⟩
+  rcases v with ⟨m, v⟩
+  have houter : kh.1 ≠ pq.1 ∨ kh.2 ≠ pq.2 := by
+    exact not_and_or.mp (fun h ↦ hne (Prod.ext h.1 h.2))
+  rcases houter with hfirst | hthird
+  · have hz : F.sectorCoordinateTensor
+        (F.sectorFinEquiv.symm ⟨kh.1, (a.1, u.1.1)⟩)
+        (F.sectorFinEquiv.symm ⟨pq.1, (b.1, v.1.1)⟩) = 0 := by
+      ext beta alpha
+      exact sectorCoordinateTensor_apply_ne F hfirst _ _ beta alpha
+    change Matrix.trace
+      (F.sectorCoordinateTensor
+          (F.sectorFinEquiv.symm ⟨kh.1, (a.1, u.1.1)⟩)
+          (F.sectorFinEquiv.symm ⟨pq.1, (b.1, v.1.1)⟩) *
+        F.sectorCoordinateTensor
+          (F.sectorFinEquiv.symm ⟨l, (u.1.2, u.2.1)⟩)
+          (F.sectorFinEquiv.symm ⟨m, (v.1.2, v.2.1)⟩) *
+        F.sectorCoordinateTensor
+          (F.sectorFinEquiv.symm ⟨kh.2, (u.2.2, a.2)⟩)
+          (F.sectorFinEquiv.symm ⟨pq.2, (v.2.2, b.2)⟩) * X) = 0
+    rw [hz]
+    simp
+  · have hz : F.sectorCoordinateTensor
+        (F.sectorFinEquiv.symm ⟨kh.2, (u.2.2, a.2)⟩)
+        (F.sectorFinEquiv.symm ⟨pq.2, (v.2.2, b.2)⟩) = 0 := by
+      ext beta alpha
+      exact sectorCoordinateTensor_apply_ne F hthird _ _ beta alpha
+    change Matrix.trace
+      (F.sectorCoordinateTensor
+          (F.sectorFinEquiv.symm ⟨kh.1, (a.1, u.1.1)⟩)
+          (F.sectorFinEquiv.symm ⟨pq.1, (b.1, v.1.1)⟩) *
+        F.sectorCoordinateTensor
+          (F.sectorFinEquiv.symm ⟨l, (u.1.2, u.2.1)⟩)
+          (F.sectorFinEquiv.symm ⟨m, (v.1.2, v.2.1)⟩) *
+        F.sectorCoordinateTensor
+          (F.sectorFinEquiv.symm ⟨kh.2, (u.2.2, a.2)⟩)
+          (F.sectorFinEquiv.symm ⟨pq.2, (v.2.2, b.2)⟩) * X) = 0
+    rw [hz]
+    simp
+
+end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/PhysicalSectorCoarseGrainingIdentity.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorCoarseGrainingIdentity.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.PhysicalSectorCoarseGrainingAction
-import TNLean.MPS.MPDO.PhysicalSectorClosureCoordinates
+import TNLean.MPS.MPDO.PhysicalSectorClosureBlocks
 
 /-!
 # Coarse-graining identity for physical-sector closures
@@ -26,50 +26,6 @@ open scoped Matrix BigOperators Kronecker
 namespace MPOTensor.PhysicalSectorFactorization
 
 variable {d D : ℕ} {K : MPOTensor d D} {F : PhysicalSectorFactorization K}
-
-/-- On an outer-sector pair, the regrouped three-site physical closure is
-the boundary operator tensored with the direct sum of the two neighboring
-operators.
-
-Source: arXiv:1606.00608, Appendix C.2, lines 1510--1516 and 1547--1555. -/
-theorem s0Regrouped_threeSiteClosure_block_eq
-    (F : PhysicalSectorFactorization K) (X : Matrix (Fin D) (Fin D) ℂ)
-    (k h : Fin F.sectorCount) :
-    (Matrix.equivReindexMap F.s0RegroupEquiv
-      (Matrix.reindex F.threeSiteSectorCoordinateEquiv
-        F.threeSiteSectorCoordinateEquiv
-        (physClose3 F.sectorCoordinateTensor X))).submatrix
-          (Sigma.mk (k, h)) (Sigma.mk (k, h)) =
-      F.boundaryOperator k h X ⊗ₖ F.threeSiteNeighboringOperator k h := by
-  ext ⟨a, l, u⟩ ⟨b, m, v⟩
-  by_cases hlm : l = m
-  · subst m
-    have hg := congrFun (congrFun (F.threeSiteSectorClosure_eq k l h X)
-      (a, u)) (b, v)
-    simpa [Matrix.equivReindexMap, Matrix.reindex_apply, Matrix.submatrix_apply,
-      s0RegroupEquiv, threeSiteSectorCoordinateEquiv,
-      threeSiteSectorClosure, threeSiteSectorEmbedding,
-      threeSiteNeighboringOperator,
-      Matrix.blockDiagonal'_apply] using hg
-  · have hz : F.sectorCoordinateTensor
-        (F.sectorFinEquiv.symm ⟨l, (u.1.2, u.2.1)⟩)
-        (F.sectorFinEquiv.symm ⟨m, (v.1.2, v.2.1)⟩) = 0 := by
-      ext beta alpha
-      exact sectorCoordinateTensor_apply_ne F hlm _ _ beta alpha
-    change Matrix.trace
-      (F.sectorCoordinateTensor
-          (F.sectorFinEquiv.symm ⟨k, (a.1, u.1.1)⟩)
-          (F.sectorFinEquiv.symm ⟨k, (b.1, v.1.1)⟩) *
-        F.sectorCoordinateTensor
-          (F.sectorFinEquiv.symm ⟨l, (u.1.2, u.2.1)⟩)
-          (F.sectorFinEquiv.symm ⟨m, (v.1.2, v.2.1)⟩) *
-        F.sectorCoordinateTensor
-          (F.sectorFinEquiv.symm ⟨h, (u.2.2, a.2)⟩)
-          (F.sectorFinEquiv.symm ⟨h, (v.2.2, b.2)⟩) * X) =
-      F.boundaryOperator k h X a b *
-        F.threeSiteNeighboringOperator k h ⟨l, u⟩ ⟨m, v⟩
-    rw [hz]
-    simp [threeSiteNeighboringOperator, Matrix.blockDiagonal'_apply, hlm]
 
 /-- The preparation stage annihilates entries between distinct pairs of
 outer sectors.

--- a/TNLean/MPS/MPDO/PhysicalSectorRefinementIdentity.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorRefinementIdentity.lean
@@ -1,0 +1,81 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalSectorClosureBlocks
+import TNLean.MPS.MPDO.PhysicalSectorRefinementAction
+
+/-!
+# Refinement identity for physical-sector closures
+
+This file proves the fixed-point calculation for the refinement channel of
+Proposition C.7. The first two stages replace the neighboring factor in each
+outer-sector block of the two-site closure by its three-site counterpart. The
+last stage returns from the prepared coordinates to three physical sites.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, lines 1510--1516 and 1522--1545
+-/
+
+open scoped Matrix BigOperators Kronecker
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D} {F : PhysicalSectorFactorization K}
+
+/-- The refinement channel sends the two-site physical closure to the
+three-site physical closure for every virtual boundary matrix.
+
+**Local fix (zero-weight quotient):** the preparation density is completed on
+zero-weight outer-sector pairs. The factor produced by the first stage and
+the corresponding three-site neighboring operator both vanish there, so the
+completion does not change the identity. Documented in
+`docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex`.
+
+Source: arXiv:1606.00608, Proposition C.7, Appendix C.2, lines 1510--1516 and
+1522--1545. -/
+theorem NeighboringTraceFactorization.tMap_twoSiteClosure_eq_threeSiteClosure
+    (H : NeighboringTraceFactorization F) (X : Matrix (Fin D) (Fin D) ℂ) :
+    H.tMap
+        (Matrix.reindex F.twoSiteSectorCoordinateEquiv
+          F.twoSiteSectorCoordinateEquiv
+          (physClose2 F.sectorCoordinateTensor X)) =
+      Matrix.reindex F.threeSiteSectorCoordinateEquiv
+        F.threeSiteSectorCoordinateEquiv
+        (physClose3 F.sectorCoordinateTensor X) := by
+  let Z₂ := Matrix.reindex F.twoSiteSectorCoordinateEquiv
+    F.twoSiteSectorCoordinateEquiv
+    (physClose2 F.sectorCoordinateTensor X)
+  let Z₃ := Matrix.reindex F.threeSiteSectorCoordinateEquiv
+    F.threeSiteSectorCoordinateEquiv
+    (physClose3 F.sectorCoordinateTensor X)
+  have hprepared :
+      H.t1Map (F.t0Map Z₂) = Matrix.equivReindexMap F.s0RegroupEquiv Z₃ := by
+    ext ⟨kh, a, u⟩ ⟨pq, b, v⟩
+    by_cases hp : kh = pq
+    · subst pq
+      have h₀ := H.t0Map_block_eq_smul Z₂ kh.1 kh.2
+        (F.boundaryOperator kh.1 kh.2 X)
+        (F.t0Regrouped_twoSiteClosure_block_eq X kh.1 kh.2)
+      have h₁ := H.t1Map_block_eq_kronecker (F.t0Map Z₂) kh.1 kh.2
+        (F.boundaryOperator kh.1 kh.2 X) h₀
+      have hl := congrFun (congrFun h₁ (a, u)) (b, v)
+      have hr := congrFun
+        (congrFun (F.s0Regrouped_threeSiteClosure_block_eq X kh.1 kh.2)
+          (a, u)) (b, v)
+      simpa [Z₂, Z₃, Matrix.submatrix_apply] using hl.trans hr.symm
+    · have hl := H.t1Map_apply_of_ne (F.t0Map Z₂) hp a u b v
+      have hr := F.s0Regrouped_threeSiteClosure_apply_of_outer_ne X hp a u b v
+      exact hl.trans hr.symm
+  change F.t2Map (H.t1Map (F.t0Map Z₂)) = Z₃
+  rw [hprepared]
+  change
+    (Matrix.reindexLinearEquiv ℂ ℂ F.s0RegroupEquiv F.s0RegroupEquiv).symm
+        ((Matrix.reindexLinearEquiv ℂ ℂ F.s0RegroupEquiv F.s0RegroupEquiv) Z₃) = Z₃
+  exact
+    (Matrix.reindexLinearEquiv ℂ ℂ F.s0RegroupEquiv F.s0RegroupEquiv).symm_apply_apply Z₃
+
+end MPOTensor.PhysicalSectorFactorization

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -2824,6 +2824,54 @@ strong subadditivity for a normalized three-site reduced state.
     \]
 \end{definition}
 
+\begin{theorem}[Diagonal outer-sector block of the three-site closure]
+    \label{thm:mpdo_regrouped_three_site_closure_block}
+    \lean{MPOTensor.PhysicalSectorFactorization.s0Regrouped_threeSiteClosure_block_eq}
+    \leanok
+    \uses{def:phys_close,
+      def:mpdo_sector_boundary_operator,
+      def:mpdo_physical_sector_three_site_neighboring_operator,
+      def:mpdo_physical_sector_closure_coordinates,
+      def:mpdo_three_site_subspin_regrouping}
+    For every virtual matrix $X$ and outer-sector pair $(k,h)$,
+    \[
+      \left[
+        R_{\Phi_3}\mathfrak R_3({\cal K}_3(X))
+      \right]_{(k,h),(k,h)}
+      =B_{k,h}(X)\otimes\Omega_{k,h}.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_three_site_sector_closure_factorization,
+      def:mpdo_physical_sector_factorization}
+    On the summand labelled by the middle sector $l$, this is the fixed-sector
+    factorization
+    $B_{k,h}(X)\otimes(\eta_{k,l}\otimes\eta_{l,h})$.
+    Taking the direct sum over $l$ gives the stated block.
+\end{proof}
+
+\begin{theorem}[Off-diagonal outer-sector entries of the three-site closure]
+    \label{thm:mpdo_regrouped_three_site_closure_off_diagonal}
+    \lean{MPOTensor.PhysicalSectorFactorization.s0Regrouped_threeSiteClosure_apply_of_outer_ne}
+    \leanok
+    \uses{def:mpdo_physical_sector_factorization,
+      def:mpdo_physical_sector_closure_coordinates,
+      def:mpdo_three_site_subspin_regrouping}
+    Every matrix entry of
+    $R_{\Phi_3}\mathfrak R_3({\cal K}_3(X))$ between distinct outer-sector
+    pairs $(k,h)\ne(p,q)$ vanishes.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:mpdo_physical_sector_factorization}
+    Distinct outer-sector pairs differ either in their first sector or in
+    their third sector. In the corresponding physical slice, the
+    sector-coordinate tensor is block diagonal, so that factor vanishes.
+\end{proof}
+
 \begin{theorem}[Regrouped two-site closure block]
     \label{thm:mpdo_t0_regrouped_two_site_closure_block}
     \lean{MPOTensor.PhysicalSectorFactorization.t0Regrouped_twoSiteClosure_block_eq}
@@ -2973,6 +3021,8 @@ strong subadditivity for a normalized three-site reduced state.
 
 \begin{theorem}[Refinement of the two-site closure]
     \label{thm:mpdo_physical_sector_t_closure_identity}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.tMap_twoSiteClosure_eq_threeSiteClosure}
+    \leanok
     \uses{def:phys_close,
       def:mpdo_physical_sector_t_map,
       def:mpdo_physical_sector_closure_coordinates,
@@ -2991,13 +3041,13 @@ strong subadditivity for a normalized three-site reduced state.
 \end{theorem}
 
 \begin{proof}
+    \leanok
     \uses{thm:mpdo_t0_regrouped_two_site_closure_block,
       thm:mpdo_t0_factorized_block_action,
       thm:mpdo_t1_factorized_block_action,
       thm:mpdo_t1_off_diagonal_action,
-      thm:mpdo_t2_reindexing_action,
-      thm:mpdo_global_sector_closure_decomposition,
-      def:mpdo_physical_sector_closure_coordinates}
+      thm:mpdo_regrouped_three_site_closure_block,
+      thm:mpdo_regrouped_three_site_closure_off_diagonal}
     The regrouping contained in $\mathcal T_0$ changes
     $\mathfrak R_2$ into $\mathfrak G_2$. On the $(k,h)$ diagonal block, the
     partial trace then gives
@@ -3022,7 +3072,6 @@ strong subadditivity for a normalized three-site reduced state.
 
 \begin{theorem}[Coarse-graining of the three-site closure]
     \label{thm:mpdo_physical_sector_s_closure_identity}
-    \lean{MPOTensor.PhysicalSectorFactorization.s0Regrouped_threeSiteClosure_block_eq}
     \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.s0Map_block_eq_smul}
     \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.sMap_threeSiteClosure_eq_twoSiteClosure}
     \leanok
@@ -3042,7 +3091,8 @@ strong subadditivity for a normalized three-site reduced state.
 
 \begin{proof}
     \leanok
-    \uses{thm:mpdo_two_site_sector_closure_factorization,
+    \uses{thm:mpdo_regrouped_three_site_closure_block,
+      thm:mpdo_two_site_sector_closure_factorization,
       thm:mpdo_three_site_sector_closure_factorization,
       thm:mpdo_physical_sector_three_site_neighboring_operator_trace,
       def:mpdo_physical_sector_factorization,


### PR DESCRIPTION
## Summary

- prove the two complementary outer-sector block formulas for the regrouped three-site closure in a neutral closure module
- prove the literal refinement identity
  \[
  \mathcal T\bigl(\mathfrak R_2(\mathcal K_2(X))\bigr)
  =\mathfrak R_3(\mathcal K_3(X))
  \]
  by the source order \(\mathcal T_0\), \(\mathcal T_1\), \(\mathcal T_2\)
- give the block facts and the final identity separate, source-faithful blueprint entries
- preserve the documented zero-weight completion only where the completed \(\mathcal T_1\) preparation is used

This establishes the refinement half of Proposition C.7 in arXiv:1606.00608, Appendix C.2, lines 1510–1516 and 1522–1545. It does not assert the later blocked-RFP bridge.

Part of #3744.

## Verification

- `lake build TNLean`
- focused builds of the shared block module and both closure identity modules
- proof-integrity and axiom audit
- `leanblueprint checkdecls`
- `leanblueprint pdf`
- visual inspection of the affected blueprint pages

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor plus new formal lemmas in the MPDO physical-sector track; no runtime, auth, or API surface changes.
> 
> **Overview**
> **Refinement half of Proposition C.7** is now formalized: `NeighboringTraceFactorization.tMap_twoSiteClosure_eq_threeSiteClosure` in `PhysicalSectorRefinementIdentity.lean` shows the refinement channel maps the two-site physical closure to the three-site one in sector coordinates, via \(\mathcal T_0\), \(\mathcal T_1\), and \(\mathcal T_2\) (with zero-weight preparation completion noted where both sides vanish).
> 
> **Shared block structure** for the regrouped three-site closure moves into `PhysicalSectorClosureBlocks.lean`: diagonal outer-sector blocks are \(B_{k,h}(X)\otimes\Omega_{k,h}\); off-diagonal outer-sector entries vanish. `PhysicalSectorCoarseGrainingIdentity.lean` imports this module instead of duplicating those proofs.
> 
> **Build and blueprint**: `TNLean.lean` adds imports for the block and refinement-identity modules; `ch21_mpdo_rfp_simple_local_structure.tex` gets separate `\leanok` entries for the block theorems and links the refinement theorem to the new Lean name; coarse-graining proof references the extracted block theorems.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb910a7ea9e15d6ec66444ea4a39784ef466672f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->