### PR TITLE
feat(MPS/MPDO): add two-site physical blocking

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -378,6 +378,7 @@ import TNLean.MPS.MPDO.ZCL
 import TNLean.MPS.MPDO.RFP
 import TNLean.MPS.MPDO.KrausCPTP
 import TNLean.MPS.MPDO.RFPViaTS
+import TNLean.MPS.MPDO.PhysicalBlocking
 import TNLean.MPS.MPDO.PRFP
 import TNLean.MPS.MPDO.LocalPurificationRFP
 import TNLean.MPS.MPDO.SimpleLocalStructure

--- a/TNLean/MPS/MPDO/PhysicalBlocking.lean
+++ b/TNLean/MPS/MPDO/PhysicalBlocking.lean
@@ -1,0 +1,132 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.RFPViaTS
+
+/-!
+# Two-site physical blocking of MPO tensors
+
+This file defines the tensor obtained by blocking two adjacent physical sites
+of an MPO tensor and identifies its one-site and two-site physical closures
+with the two-site and four-site closures of the original tensor.
+
+## Main definitions
+
+* `MPOTensor.blockTwo`: the tensor obtained by blocking two adjacent sites.
+* `MPOTensor.physClose4`: the right-associated four-site physical closure.
+* `MPOTensor.physClose1_blockTwo_eq_physClose2`: one blocked site is two original sites.
+* `MPOTensor.physClose2_blockTwo_eq_physClose4`: two blocked sites are four original sites.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Theorem 4.9, lines 851--856
+-/
+
+open scoped Matrix
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-! ### Two-site blocking -/
+
+/-- The MPO tensor obtained by blocking two adjacent physical sites. The two
+ket indices, and separately the two bra indices, are encoded through the
+standard equivalence `Fin d × Fin d ≃ Fin (d * d)`. This is the blocking used
+in arXiv:1606.00608, Theorem 4.9, lines 851--856. -/
+noncomputable def blockTwo (M : MPOTensor d D) : MPOTensor (d * d) D :=
+  fun i j =>
+    M (finProdFinEquiv.symm i).1 (finProdFinEquiv.symm j).1 *
+      M (finProdFinEquiv.symm i).2 (finProdFinEquiv.symm j).2
+
+@[simp] lemma blockTwo_apply (M : MPOTensor d D) (i j : Fin (d * d)) :
+    blockTwo M i j =
+      M (finProdFinEquiv.symm i).1 (finProdFinEquiv.symm j).1 *
+        M (finProdFinEquiv.symm i).2 (finProdFinEquiv.symm j).2 :=
+  rfl
+
+/-! ### The four-site physical closure -/
+
+/-- The canonical right-associated identification of four-coordinate
+configurations with quadruples. -/
+def finFourArrowEquiv (α : Type*) : (Fin 4 → α) ≃ α × (α × (α × α)) :=
+  (Fin.consEquiv fun _ : Fin 4 => α).symm.trans
+    (Equiv.prodCongr (Equiv.refl α) (finThreeArrowEquiv α))
+
+/-- The four-site physical closure, with the physical indices associated as
+`Fin d × (Fin d × (Fin d × Fin d))`. Its coefficient is the virtual trace of
+four consecutive tensor matrices followed by the inserted virtual operator.
+This is the four-site instance of the open physical contraction used in
+arXiv:1606.00608, Definition 4.1, lines 638--657. -/
+noncomputable def physClose4 (M : MPOTensor d D) :
+    Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ]
+      Matrix (Fin d × (Fin d × (Fin d × Fin d)))
+        (Fin d × (Fin d × (Fin d × Fin d))) ℂ where
+  toFun X := Matrix.of fun i j =>
+    Matrix.trace
+      (M i.1 j.1 * M i.2.1 j.2.1 * M i.2.2.1 j.2.2.1 *
+        M i.2.2.2 j.2.2.2 * X)
+  map_add' X Y := by
+    ext i j
+    simp [Matrix.mul_add, Matrix.trace_add]
+  map_smul' c X := by
+    ext i j
+    simp [Matrix.trace_smul]
+
+@[simp] lemma physClose4_apply (M : MPOTensor d D)
+    (X : Matrix (Fin D) (Fin D) ℂ)
+    (i j : Fin d × (Fin d × (Fin d × Fin d))) :
+    physClose4 M X i j =
+      Matrix.trace
+        (M i.1 j.1 * M i.2.1 j.2.1 * M i.2.2.1 j.2.2.1 *
+          M i.2.2.2 j.2.2.2 * X) :=
+  rfl
+
+/-- Under the canonical right-associated identification of four-site
+configurations with quadruples of physical indices, the general length-four
+closure is `physClose4`. -/
+theorem physCloseN_four_eq_physClose4 (M : MPOTensor d D) :
+    (Matrix.reindexLinearEquiv ℂ ℂ (finFourArrowEquiv (Fin d))
+        (finFourArrowEquiv (Fin d))).toLinearMap ∘ₗ physCloseN M 4 =
+      physClose4 M := by
+  ext X i j
+  simp [Matrix.coe_reindexLinearEquiv, finFourArrowEquiv, finThreeArrowEquiv,
+    Matrix.mul_assoc]
+
+/-! ### Blocking identities -/
+
+/-- Decode one blocked physical index into its two constituent indices. -/
+def blockedIndexEquiv (d : ℕ) : Fin (d * d) ≃ Fin d × Fin d :=
+  finProdFinEquiv.symm
+
+/-- Decode a pair of blocked physical indices into four right-associated
+original physical indices. -/
+def blockedPairEquiv (d : ℕ) :
+    Fin (d * d) × Fin (d * d) ≃ Fin d × (Fin d × (Fin d × Fin d)) :=
+  (Equiv.prodCongr (blockedIndexEquiv d) (blockedIndexEquiv d)).trans
+    (Equiv.prodAssoc (Fin d) (Fin d) (Fin d × Fin d))
+
+/-- After decoding the blocked physical index, the one-site closure of the
+two-site blocked tensor is the two-site closure of the original tensor. -/
+theorem physClose1_blockTwo_eq_physClose2 (M : MPOTensor d D) :
+    (Matrix.reindexLinearEquiv ℂ ℂ (blockedIndexEquiv d)
+        (blockedIndexEquiv d)).toLinearMap ∘ₗ physClose1 (blockTwo M) =
+      physClose2 M := by
+  ext X i j
+  simp [Matrix.coe_reindexLinearEquiv, blockedIndexEquiv, blockTwo]
+
+/-- After decoding both blocked physical indices, the two-site closure of the
+two-site blocked tensor is the right-associated four-site closure of the
+original tensor. -/
+theorem physClose2_blockTwo_eq_physClose4 (M : MPOTensor d D) :
+    (Matrix.reindexLinearEquiv ℂ ℂ (blockedPairEquiv d) (blockedPairEquiv d)).toLinearMap ∘ₗ
+        physClose2 (blockTwo M) =
+      physClose4 M := by
+  ext X i j
+  simp [Matrix.coe_reindexLinearEquiv, blockedPairEquiv, blockedIndexEquiv,
+    blockTwo, Matrix.mul_assoc]
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -89,6 +89,79 @@
     \label{fig:mpdo_two_site_blocking}
 \end{figure}
 
+\begin{definition}[Two-site blocking of an MPO tensor]
+    \label{def:mpdo_two_site_blocking}
+    \lean{MPOTensor.blockTwo}
+    \leanok
+    For an MPO tensor $K$, its two-site blocking $K^{[2]}$ has physical
+    indices $(i_0,i_1)$ and $(j_0,j_1)$ and matrices
+    \[
+        \bigl(K^{[2]}\bigr)^{(i_0,i_1),(j_0,j_1)}
+          =K^{i_0j_0}K^{i_1j_1}.
+    \]
+    This is the blocking used in
+    \cite[Theorem~4.9, lines~851--856]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{definition}[Four-site physical closure]
+    \label{def:mpdo_four_site_physical_closure}
+    \lean{MPOTensor.finFourArrowEquiv, MPOTensor.physClose4}
+    \leanok
+    For a virtual matrix $X$, the four-site physical closure of $K$ is the
+    operator $K_4(X)$ whose matrix coefficients are
+    \[
+        K_4(X)_{(i_0,(i_1,(i_2,i_3))),(j_0,(j_1,(j_2,j_3)))}
+          =\tr\!\left(
+            K^{i_0j_0}K^{i_1j_1}K^{i_2j_2}K^{i_3j_3}X\right).
+    \]
+\end{definition}
+
+\begin{theorem}[General and right-associated four-site closures]
+    \label{thm:mpdo_phys_close_four}
+    \lean{MPOTensor.physCloseN_four_eq_physClose4}
+    \leanok
+    \uses{def:phys_close, def:mpdo_four_site_physical_closure}
+    Under the canonical right-associated identification of four-site
+    configurations with quadruples of physical indices, the general
+    length-four closure is $K_4(X)$.
+\end{theorem}
+
+\begin{proof}\leanok
+    Expand the general four-site closure in the right-associated coordinates.
+\end{proof}
+
+\begin{theorem}[One-site closure of the two-site blocking]
+    \label{thm:mpdo_one_site_closure_two_site_blocking}
+    \lean{MPOTensor.physClose1_blockTwo_eq_physClose2}
+    \leanok
+    \uses{def:phys_close, def:mpdo_two_site_blocking}
+    After identifying one blocked physical index with two original indices,
+    \[
+        \bigl(K^{[2]}\bigr)_1(X)=K_2(X).
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    Expand one blocked tensor matrix and decode its two physical indices.
+\end{proof}
+
+\begin{theorem}[Two-site closure of the two-site blocking]
+    \label{thm:mpdo_two_site_closure_two_site_blocking}
+    \lean{MPOTensor.physClose2_blockTwo_eq_physClose4}
+    \leanok
+    \uses{def:phys_close, def:mpdo_two_site_blocking,
+      def:mpdo_four_site_physical_closure}
+    After identifying two blocked physical indices with four original
+    indices, one has
+    \[
+        \bigl(K^{[2]}\bigr)_2(X)=K_4(X).
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    Expand the two blocked tensor matrices and reassociate their product.
+\end{proof}
+
 \begin{theorem}[Blocked-RFP structure from local data and commuting form]
     \label{thm:simple_mpdo_blocked_rfp_data_of_sal_zcl_and_commuting_form}
     \lean{MPOTensor.SimpleMPDOBlockedRFPData.ofSALZCLAndCommutingForm}


### PR DESCRIPTION
## Summary

- define the two-site blocking \(K^{[2]}\) with the physical-index order used in Theorem 4.9
- define the right-associated four-site physical closure \(K_4(X)\)
- prove the exact reindexing identities
  \[
  (K^{[2]})_1(X)=K_2(X),\qquad
  (K^{[2]})_2(X)=K_4(X)
  \]
- add separate blueprint entries with precise declaration ownership and dependencies

These identities provide the closure transport required for the later localized \(\mathcal T^2,\mathcal S^2\) construction. This PR does not yet assert `IsRFPViaTS`; in particular it does not assert `IsRFPViaTS K`.

Part of #3744.

## Verification

- focused Lean checks
- `lake build TNLean`
- proof-integrity and axiom audit
- `leanblueprint checkdecls`
- `leanblueprint pdf`
- visual inspection of the affected blueprint page

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style definitions and `simp`-based proofs on existing `physClose*` API; no auth, runtime, or behavioral changes beyond the library surface and blueprint.
> 
> **Overview**
> Adds **two-site physical blocking** for MPO tensors: `MPOTensor.blockTwo` pairs adjacent sites via `Fin (d * d)`, and `physClose4` is the right-associated four-site physical closure, linked to `physCloseN` at length 4.
> 
> Proves the **closure transport** identities (after index decoding): one-site closure of the blocked tensor equals `physClose2`, and two-site closure equals `physClose4`. These are the reindexing lemmas needed before a later localized \(\mathcal T^2,\mathcal S^2\) / blocked-RFP step; **`IsRFPViaTS` is not asserted here**.
> 
> Wires the module into the root import list and extends **chapter 21 blueprint** (`ch21_mpdo_rfp_blocked_rfp.tex`) with matching definitions, theorems, and `\lean` links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6c9081641fd745059b27755ce16a31d23608419. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->