### PR TITLE
feat(MPS/MPDO): unconditional constant trace powers for the sector pairing

### DIFF
--- a/TNLean/Algebra/PerronFrobenius/RankOne.lean
+++ b/TNLean/Algebra/PerronFrobenius/RankOne.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.Analysis.Matrix.PosDef
 import Mathlib.LinearAlgebra.Dual.Defs
+import Mathlib.LinearAlgebra.Finsupp.LinearCombination
 import Mathlib.LinearAlgebra.LinearIndependent.Defs
 import Mathlib.LinearAlgebra.Matrix.Irreducible.Defs
 import Mathlib.LinearAlgebra.Projection
@@ -50,6 +51,17 @@ powers in the proof of Lemma C.5 from idempotence, and
 `Matrix.IsPrimitive.exists_row_pos` / `Matrix.IsPrimitive.exists_col_pos` show
 that a primitive matrix has a positive entry in every row and in every column,
 which makes the paired sector tensors nonzero.
+
+Without any independence hypothesis, `Matrix.pow_two_eq_pow_three_of_pairing_idempotent`
+derives `T^2 = T^3` directly from the pairing idempotence, by composing the
+identity `M^2 = M` with the coefficient map and the functional map on both
+sides. `Matrix.trace_eq_trace_sq_of_pairing_idempotent` then derives
+`trace T = trace (T^2)` by restricting the pairing operator to the
+finite-dimensional span of the tensors `l k` and using cyclicity of the trace
+of a composition there. Combined with `Matrix.pow_eq_pow_two_of_pow_two_eq_pow_three`
+(a purely algebraic fact: `T^2 = T^3` forces `T^N = T^2` for every `N ≥ 2`),
+`Matrix.tracePowersConstant_of_pairing_idempotent` gives the unconditional
+constant trace powers `Matrix.TracePowersConstant T`.
 -/
 
 open scoped BigOperators Matrix ComplexOrder
@@ -297,6 +309,166 @@ theorem hasRankOneFactorization_of_pairing_idempotent
     HasRankOneFactorization T :=
   hasRankOneFactorization_of_mul_self_eq_self
     (mul_self_eq_self_of_pairing_idempotent hT hl hM) hTrace
+
+/-! ### Unconditional constant trace powers of the sector pairing
+
+The identity `M^2 = M` alone, without any independence hypothesis on the
+tensors `l k` or the functionals `r k`, already gives `T^2 = T^3`: writing
+`T = R ∘ L` for the coefficient map `L` and the functional map `R`, the
+displayed identity `L R = (L R)^2` gives `R (L R) L = R (L R)^2 L`, and
+associativity turns the two sides into `T^2` and `T^3`. Since `T^2 = T^3`
+forces `T^N = T^2` for every `N ≥ 2`, only `trace T = trace (T^2)` remains
+to recover the constant trace powers of Lemma C.5 (lines 1494--1497)
+unconditionally. This last identity follows by restricting the pairing
+operator to the finite-dimensional span `W` of the tensors `l k`: on `W`
+the pairing operator is an idempotent endomorphism of a finite free module,
+and cyclicity of the trace of a composition between `W` and the coefficient
+space identifies `trace T` with the trace of the restricted operator and
+`trace (T^2)` with the trace of its square, which coincide by idempotence. -/
+
+/-- **Unconditional `T^2 = T^3` from the pairing idempotence.**
+
+For the sector trace matrix `T k h = r k (l h)` of arXiv:1606.00608,
+Appendix C.2, satisfying the zero-correlation-length identity
+(lines 1490--1493) in the form `M^2 = M`, the matrix identity `T^2 = T^3`
+holds without any independence hypothesis on `l` or `r`. Multiplying
+`M^2 = M` on the left by the functional map and on the right by the
+coefficient map turns the two sides directly into `T^2` and `T^3`.
+
+Source: arXiv:1606.00608, lines 1494--1497. This is the pairing computation
+of `docs/paper-gaps/cpgsv17_pf_rank_one.tex`, §3 ("What the operator-valued
+ZCL identity implies"). -/
+theorem pow_two_eq_pow_three_of_pairing_idempotent
+    {V : Type*} [AddCommGroup V] [Module ℝ V]
+    {l : Fin n → V} {r : Fin n → Module.Dual ℝ V} {T : Matrix (Fin n) (Fin n) ℝ}
+    (hT : ∀ k h, T k h = r k (l h))
+    (hM : ∀ v : V, ∑ k, r k (∑ j, r j v • l j) • l k = ∑ k, r k v • l k) :
+    T ^ 2 = T ^ 3 := by
+  classical
+  have hexpand : ∀ (v : V) (k : Fin n), r k (∑ j, r j v • l j) = ∑ j, T k j * r j v := by
+    intro v k
+    rw [map_sum]
+    exact Finset.sum_congr rfl fun j _ => by rw [map_smul, smul_eq_mul, hT k j]; ring
+  have hcube : T * T = T * T * T := by
+    ext k h
+    rw [mul_assoc]
+    simp only [Matrix.mul_apply]
+    have key := congrArg (r k) (hM (l h))
+    rw [hexpand (l h) k, hexpand (∑ j, r j (l h) • l j) k] at key
+    have hinner : ∀ k' : Fin n, r k' (∑ j, r j (l h) • l j) = ∑ j, T k' j * r j (l h) :=
+      fun k' => hexpand (l h) k'
+    simp_rw [hinner] at key
+    simpa only [← hT] using key.symm
+  have e2 : T ^ 2 = T * T := by rw [pow_succ, pow_one]
+  have e3 : T ^ 3 = T * T * T := by rw [pow_succ, pow_succ, pow_one]
+  rw [e2, e3]; exact hcube
+
+/-- **Unconditional `trace T = trace (T^2)` from the pairing idempotence.**
+
+For the sector trace matrix `T k h = r k (l h)` of arXiv:1606.00608,
+Appendix C.2, satisfying the zero-correlation-length identity in the form
+`M^2 = M`, the trace identity `trace T = trace (T^2)` holds without any
+independence hypothesis. Restricting `M` to the finite-dimensional span `W`
+of the tensors `l k` gives an idempotent endomorphism of a finite free
+module; cyclicity of the trace of a composition between `W` and the
+coefficient space `Fin n → ℝ` identifies `trace T` with the trace of the
+restriction and `trace (T^2)` with the trace of its square, which coincide
+since the restriction is idempotent.
+
+Source: arXiv:1606.00608, lines 1494--1497. This is the "finite-dimensional
+carrier" step of `docs/paper-gaps/cpgsv17_pf_rank_one.tex`, §3. -/
+theorem trace_eq_trace_sq_of_pairing_idempotent
+    {V : Type*} [AddCommGroup V] [Module ℝ V]
+    {l : Fin n → V} {r : Fin n → Module.Dual ℝ V} {T : Matrix (Fin n) (Fin n) ℝ}
+    (hT : ∀ k h, T k h = r k (l h))
+    (hM : ∀ v : V, ∑ k, r k (∑ j, r j v • l j) • l k = ∑ k, r k v • l k) :
+    Matrix.trace T = Matrix.trace (T * T) := by
+  classical
+  set W : Submodule ℝ V := Submodule.span ℝ (Set.range l) with hW
+  haveI hWfin : Module.Finite ℝ W := Module.Finite.span_of_finite ℝ (Set.finite_range l)
+  set Lfull : (Fin n → ℝ) →ₗ[ℝ] V := Fintype.linearCombination ℝ l with hLfull
+  have hLmem : ∀ x, Lfull x ∈ W := by
+    intro x
+    rw [hW, ← Fintype.range_linearCombination]
+    exact LinearMap.mem_range_self Lfull x
+  set L : (Fin n → ℝ) →ₗ[ℝ] W := LinearMap.codRestrict W Lfull hLmem with hL
+  set Rfull : V →ₗ[ℝ] (Fin n → ℝ) := LinearMap.pi r with hRfull
+  set Rres : W →ₗ[ℝ] (Fin n → ℝ) := Rfull ∘ₗ W.subtype with hRres
+  set MW : W →ₗ[ℝ] W := L ∘ₗ Rres with hMW
+  have hRresval : ∀ (u : W) (k : Fin n), Rres u k = r k (u : V) := by
+    intro u k
+    simp only [hRres, hRfull, LinearMap.comp_apply, LinearMap.pi_apply,
+      Submodule.subtype_apply]
+  have hMWval : ∀ u : W, (MW u : V) = ∑ k, r k (u : V) • l k := by
+    intro u
+    simp only [hMW, LinearMap.comp_apply, hL, LinearMap.codRestrict_apply, hLfull,
+      Fintype.linearCombination_apply, hRresval]
+  have hTL : Matrix.toLin' T = Rres ∘ₗ L := by
+    apply LinearMap.ext
+    intro x
+    funext k
+    have hLxval : (L x : V) = ∑ j, x j • l j := by
+      simp only [hL, LinearMap.codRestrict_apply, hLfull, Fintype.linearCombination_apply]
+    simp only [Matrix.toLin'_apply, Matrix.mulVec, dotProduct, LinearMap.comp_apply,
+      hRresval, hLxval, map_sum]
+    refine Finset.sum_congr rfl fun j _ => ?_
+    rw [map_smul, smul_eq_mul, hT k j, mul_comm]
+  have hMWidem : MW ∘ₗ MW = MW := by
+    ext w
+    simp only [LinearMap.comp_apply]
+    show (MW (MW w) : V) = (MW w : V)
+    rw [hMWval (MW w), hMWval w]
+    exact hM (w : V)
+  have step1 : Matrix.trace T = LinearMap.trace ℝ W MW := by
+    rw [← Matrix.trace_toLin'_eq, hTL, hMW]
+    exact LinearMap.trace_comp_comm' L Rres
+  have step2 : Matrix.trace (T * T) = LinearMap.trace ℝ W (MW ∘ₗ MW) := by
+    rw [← Matrix.trace_toLin'_eq, Matrix.toLin'_mul, hTL]
+    have hreassoc : (Rres ∘ₗ L) ∘ₗ (Rres ∘ₗ L) = Rres ∘ₗ (MW ∘ₗ L) := by
+      ext x
+      simp only [LinearMap.comp_apply, hMW]
+    rw [hreassoc]
+    exact LinearMap.trace_comp_comm' (MW ∘ₗ L) Rres
+  rw [step1, step2, hMWidem]
+
+/-- If `T^2 = T^3`, then every power `T^N` for `N ≥ 2` agrees with `T^2`. -/
+theorem pow_eq_pow_two_of_pow_two_eq_pow_three
+    {T : Matrix (Fin n) (Fin n) ℝ} (h : T ^ 2 = T ^ 3) :
+    ∀ N, 2 ≤ N → T ^ N = T ^ 2 := by
+  have hmul : T * T = T * T * T := by
+    have e2 : T ^ 2 = T * T := by rw [pow_succ, pow_one]
+    have e3 : T ^ 3 = T * T * T := by rw [pow_succ, pow_succ, pow_one]
+    rw [e2, e3] at h; exact h
+  intro N hN
+  induction N, hN using Nat.le_induction with
+  | base => rfl
+  | succ m _ ih =>
+    rw [pow_succ, ih]
+    calc T ^ 2 * T = T * T * T := by rw [pow_two]
+      _ = T * T := hmul.symm
+      _ = T ^ 2 := (pow_two T).symm
+
+/-- **Unconditional constant trace powers for the sector pairing.**
+
+For the sector trace matrix `T k h = r k (l h)` of arXiv:1606.00608,
+Appendix C.2, satisfying the zero-correlation-length identity, every positive
+power of `T` has the same trace as `T`, without any independence hypothesis
+on the tensors `l` or the functionals `r`.
+
+Source: arXiv:1606.00608, lines 1494--1497. -/
+theorem tracePowersConstant_of_pairing_idempotent
+    {V : Type*} [AddCommGroup V] [Module ℝ V]
+    {l : Fin n → V} {r : Fin n → Module.Dual ℝ V} {T : Matrix (Fin n) (Fin n) ℝ}
+    (hT : ∀ k h, T k h = r k (l h))
+    (hM : ∀ v : V, ∑ k, r k (∑ j, r j v • l j) • l k = ∑ k, r k v • l k) :
+    TracePowersConstant T := by
+  have hsq3 := pow_two_eq_pow_three_of_pairing_idempotent hT hM
+  have htr := trace_eq_trace_sq_of_pairing_idempotent hT hM
+  intro k hk
+  rcases Nat.lt_or_ge k 2 with hk2 | hk2
+  · interval_cases k
+    rw [pow_one]
+  · rw [pow_eq_pow_two_of_pow_two_eq_pow_three hsq3 k hk2, pow_two, ← htr]
 
 /-- A finite family of nonnegative real numbers with sum and sum of squares both
 one has exactly one nonzero entry, and that entry is one. -/

--- a/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
+++ b/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
@@ -182,9 +182,10 @@ def ofSALZCLOfPosSemidef
 /-- Construct the local simple-MPDO structure from the Lemma C.2 and C.4
 hypotheses and the pairing-idempotence Lemma C.5 rank-one criterion: the
 sector tensors of arXiv:1606.00608, Appendix C.2, satisfy the displayed
-zero-correlation-length identity (lines 1490--1493), and their linear
-independence turns it into idempotence of the sector trace matrix, from which
-the constant trace powers and the rank-one factorization follow.
+zero-correlation-length identity (lines 1490--1493), giving the constant
+trace powers of the sector trace matrix unconditionally; linear independence
+of the closed sector tensors additionally turns the identity into idempotence
+of that matrix, from which the rank-one factorization follows.
 
 Source: arXiv:1606.00608, Appendix C.2, Lemmas C.4 and C.5, lines 1406--1499.
 
@@ -215,7 +216,7 @@ def ofSALZCLOfPairingIdempotent
   T := T
   hPrimitive := hPrimitive
   hTrace := hTrace
-  hTraceConst := data.tracePowersConstant hl
+  hTraceConst := data.tracePowersConstant
   rankOne :=
     sal_zcl_implies_rank_one_T_of_pairing_idempotent T data hl hTrace
 

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -78,6 +78,10 @@ arXiv:1606.00608 (Cirac–Pérez-García–Schuch–Verstraete).
   trace matrix from the zero-correlation-length identity, and linear
   independence of the sector tensors from primitivity and an independent
   family of subspaces containing each sector tensor.
+- `MPOTensor.SectorPairingData.pairing_sq_eq_pairing_cube` /
+  `MPOTensor.SectorPairingData.tracePowersConstant`: the unconditional matrix
+  identity $T^2=T^3$ and the resulting constant trace powers of $T$, with no
+  independence hypothesis on the sector tensors.
 - `MPOTensor.sal_zcl_implies_rank_one_T_of_pairing_idempotent` /
   `MPOTensor.sal_zcl_implies_rank_one_T_of_sector_supports`: the rank-one
   factorization at lines 1484--1499, derived from the zero-correlation-length
@@ -837,16 +841,26 @@ theorem mul_self_eq_self (data : SectorPairingData T V)
   Matrix.mul_self_eq_self_of_pairing_idempotent data.pairing hl
     data.pairing_operator_idempotent
 
-/-- The traces of all positive powers of the sector trace matrix agree with
-its trace: $\operatorname{tr}(T^N)=\operatorname{tr}(T)$ for $N\geq 1$, as at
-arXiv:1606.00608, lines 1494--1497, recovered from idempotence.
+/-- **Unconditional `T^2=T^3`** for sector tensors satisfying the
+zero-correlation-length identity, with no independence hypothesis on the
+closed sector tensors $|l_k)$ or the functionals $(r_k|$: pairing the
+identity with $(r_j|$ and $|l_i)$ gives this matrix identity directly.
 
-**Scope restriction (linear independence):** inherited from
-`SectorPairingData.mul_self_eq_self`; documented in
-`docs/paper-gaps/cpgsv17_pf_rank_one.tex`. -/
-theorem tracePowersConstant (data : SectorPairingData T V)
-    (hl : LinearIndependent ℝ data.l) : Matrix.TracePowersConstant T :=
-  Matrix.tracePowersConstant_of_mul_self_eq_self (data.mul_self_eq_self hl)
+Source: arXiv:1606.00608, lines 1494--1497. This is the pairing computation
+of `docs/paper-gaps/cpgsv17_pf_rank_one.tex`, §3 ("What the operator-valued
+ZCL identity implies"). -/
+theorem pairing_sq_eq_pairing_cube (data : SectorPairingData T V) : T ^ 2 = T ^ 3 :=
+  Matrix.pow_two_eq_pow_three_of_pairing_idempotent data.pairing data.pairing_operator_idempotent
+
+/-- **Unconditional constant trace powers of the sector trace matrix.** The
+traces of all positive powers of the sector trace matrix agree with its
+trace: $\operatorname{tr}(T^N)=\operatorname{tr}(T)$ for $N\geq 1$, with no
+independence hypothesis on the closed sector tensors $|l_k)$ or the
+functionals $(r_k|$.
+
+Source: arXiv:1606.00608, lines 1494--1497. -/
+theorem tracePowersConstant (data : SectorPairingData T V) : Matrix.TracePowersConstant T :=
+  Matrix.tracePowersConstant_of_pairing_idempotent data.pairing data.pairing_operator_idempotent
 
 /-- Primitivity of the sector trace matrix makes every closed sector tensor
 $|l_k)$ nonzero: some entry of column $k$ of $T$ is positive, and that entry

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -3518,6 +3518,40 @@ strong subadditivity for a normalized three-site reduced state.
     \label{fig:mpdo_sector_zcl_identity}
 \end{figure}
 
+\begin{theorem}[Unconditional constant trace powers of the pairing matrix]
+    \label{thm:matrix_pairing_sq_eq_cube}
+    \lean{Matrix.pow_two_eq_pow_three_of_pairing_idempotent}
+    \lean{Matrix.trace_eq_trace_sq_of_pairing_idempotent}
+    \lean{Matrix.pow_eq_pow_two_of_pow_two_eq_pow_three}
+    \lean{Matrix.tracePowersConstant_of_pairing_idempotent}
+    \leanok
+    \uses{def:matrix_trace_rankone_predicates}
+    In the setting of Theorem~\ref{thm:matrix_pairing_idempotent}, without
+    assuming linear independence of $l_1,\dots,l_n$ or of $r_1,\dots,r_n$,
+    \[
+        T^2 = T^3,
+    \]
+    so $T^N = T^2$ for every $N \geq 2$, and for every positive integer $N$,
+    \[
+        \operatorname{tr}(T^N) = \operatorname{tr}(T).
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:matrix_pairing_idempotent}
+    Multiplying the identity $M^2 = M$ on the left by the functional map and
+    on the right by the coefficient map turns the two sides directly into
+    $T^2$ and $T^3$, with no independence hypothesis; induction then gives
+    $T^N = T^2$ for every $N \geq 2$. For the trace identity, restrict the
+    operator $M$ to the finite-dimensional span of $l_1,\dots,l_n$: there it
+    is an idempotent endomorphism of a finite free module, and cyclicity of
+    the trace of a composition between that span and the coefficient space
+    identifies $\operatorname{tr}(T)$ with the trace of the restriction and
+    $\operatorname{tr}(T^2)$ with the trace of its square, which agree since
+    the restriction is idempotent.
+\end{proof}
+
 % Scope restriction (linear independence): the source Lemma C.5 neither
 % assumes nor derives linear independence of the sector tensors. Its proof
 % instead uses primitivity of the trace matrix, obtained from the injectivity
@@ -3634,23 +3668,17 @@ strong subadditivity for a normalized three-site reduced state.
     \label{thm:mpdo_sector_pairing_idempotent}
     \lean{MPOTensor.SectorPairingData.pairing_operator_idempotent}
     \lean{MPOTensor.SectorPairingData.mul_self_eq_self}
-    \lean{MPOTensor.SectorPairingData.tracePowersConstant}
     \leanok
     \uses{def:mpdo_sector_pairing_data}
     For sector tensors paired into $T$ as in
     Definition~\ref{def:mpdo_sector_pairing_data}, the operator
     $M = \sum_k |l_k)(r_k|$ satisfies $M^2 = M$. If in addition the vectors
-    $|l_0), \dots, |l_{n-1})$ are linearly independent, then $T^2 = T$, and for
-    every positive integer $N$,
-    \[
-        \operatorname{tr}(T^N) = \operatorname{tr}(T).
-    \]
+    $|l_0), \dots, |l_{n-1})$ are linearly independent, then $T^2 = T$.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    \uses{thm:matrix_pairing_idempotent,
-        thm:matrix_idempotent_trace_powers_constant}
+    \uses{thm:matrix_pairing_idempotent}
     Substituting $T_{k,h} = (r_k|l_h)$ into the right-hand side of the
     zero-correlation-length identity gives, for every $v \in V$,
     \[
@@ -3660,9 +3688,34 @@ strong subadditivity for a normalized three-site reduced state.
         = M^2 v,
     \]
     so $M^2 = M$. Linear independence of the $|l_k)$ then
-    gives $T^2 = T$ by Theorem~\ref{thm:matrix_pairing_idempotent}, and
-    idempotence gives the constant trace powers by
-    Theorem~\ref{thm:matrix_idempotent_trace_powers_constant}.
+    gives $T^2 = T$ by Theorem~\ref{thm:matrix_pairing_idempotent}.
+\end{proof}
+
+\begin{theorem}[Unconditional constant trace powers of the sector trace matrix]
+    \label{thm:mpdo_sector_pairing_trace_powers}
+    \lean{MPOTensor.SectorPairingData.pairing_sq_eq_pairing_cube}
+    \lean{MPOTensor.SectorPairingData.tracePowersConstant}
+    \leanok
+    \uses{def:mpdo_sector_pairing_data}
+    For sector tensors paired into $T$ as in
+    Definition~\ref{def:mpdo_sector_pairing_data}, without any independence
+    hypothesis on the closed sector tensors or the functionals,
+    \[
+        T^2 = T^3,
+    \]
+    and for every positive integer $N$,
+    \[
+        \operatorname{tr}(T^N) = \operatorname{tr}(T).
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_sector_pairing_idempotent, thm:matrix_pairing_sq_eq_cube}
+    The operator identity $M^2 = M$ established in the proof of
+    Theorem~\ref{thm:mpdo_sector_pairing_idempotent} gives $T^2 = T^3$ and
+    the constant trace powers by Theorem~\ref{thm:matrix_pairing_sq_eq_cube},
+    with no independence hypothesis.
 \end{proof}
 
 % Scope restriction (independent subspaces): the independent subspace family in the
@@ -3719,10 +3772,12 @@ strong subadditivity for a normalized three-site reduced state.
 \begin{proof}
     \leanok
     \uses{thm:mpdo_sector_pairing_idempotent,
+        thm:mpdo_sector_pairing_trace_powers,
         thm:mpdo_sector_tensors_independent,
         thm:matrix_idempotent_trace_one_rank_one}
-    Theorem~\ref{thm:mpdo_sector_pairing_idempotent} gives $T^2 = T$ and the
-    constant trace powers. The idempotent trace-one criterion of
+    Theorem~\ref{thm:mpdo_sector_pairing_idempotent} gives $T^2 = T$, and
+    Theorem~\ref{thm:mpdo_sector_pairing_trace_powers} gives the constant
+    trace powers unconditionally. The idempotent trace-one criterion of
     Theorem~\ref{thm:matrix_idempotent_trace_one_rank_one} yields the
     factorization $T = a b^\top$, and taking traces gives
     $\sum_k a_k b_k = \operatorname{tr}(T) = 1$. When the independence is not

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -3526,8 +3526,12 @@ strong subadditivity for a normalized three-site reduced state.
     \lean{Matrix.tracePowersConstant_of_pairing_idempotent}
     \leanok
     \uses{def:matrix_trace_rankone_predicates}
-    In the setting of Theorem~\ref{thm:matrix_pairing_idempotent}, without
-    assuming linear independence of $l_1,\dots,l_n$ or of $r_1,\dots,r_n$,
+    Let $V$ be a real vector space, let $l_1,\dots,l_n \in V$, let
+    $r_1,\dots,r_n$ be real linear functionals on $V$, and let
+    $T_{k,h}=(r_k|l_h)$ be the pairing matrix, as in
+    Theorem~\ref{thm:matrix_pairing_idempotent}. Assuming only the identity
+    $M^2 = M$ for the operator $M = \sum_k |l_k)(r_k|$, without assuming
+    linear independence of $l_1,\dots,l_n$ or of $r_1,\dots,r_n$,
     \[
         T^2 = T^3,
     \]

--- a/docs/paper-gaps/cpgsv17_pf_rank_one.tex
+++ b/docs/paper-gaps/cpgsv17_pf_rank_one.tex
@@ -186,31 +186,53 @@ the two displayed identities of the source,
   \sum_k |l_k)(r_k| = \sum_{k,h} T_{k,h}|l_k)(r_h|,
 \]
 from lines 1478--1493 of Appendix C.2.  These equations make the pairing
-operator $M=\sum_k|l_k)(r_k|$ idempotent.  If the vectors $(l_k)_k$ are
-linearly independent, then the coefficient map $L$ is injective and
+operator $M=\sum_k|l_k)(r_k|$ idempotent, without any independence
+hypothesis on $(l_k)_k$ or $(r_k)_k$.  Pairing the idempotence with the
+functional map $R$ on the left and the coefficient map $L$ on the right, as
+in Section~3, gives $T^2=T^3$ unconditionally; restricting the pairing
+operator to the finite-dimensional span of $(l_k)_k$ then identifies
+$\operatorname{tr}(T)$ with $\operatorname{tr}(T^2)$, so every positive
+power of $T$ has the same trace as $T$.  This recovers the trace identity
+displayed at lines 1494--1497 of Appendix C.2 unconditionally, at the matrix
+product density operator side.
+\footnote{\sloppy The formal declarations are
+{\scriptsize\leanid{MPOTensor.SectorPairingData.pairing_sq_eq_pairing_cube}}
+and
+{\scriptsize\leanid{MPOTensor.SectorPairingData.tracePowersConstant}} in
+\doclink{TNLean/MPS/MPDO/SimpleLocalStructure}, resting on the general matrix
+statements
+{\scriptsize\leanid{Matrix.pow_two_eq_pow_three_of_pairing_idempotent}},
+{\scriptsize\leanid{Matrix.trace_eq_trace_sq_of_pairing_idempotent}},
+{\scriptsize\leanid{Matrix.pow_eq_pow_two_of_pow_two_eq_pow_three}}, and
+{\scriptsize\leanid{Matrix.tracePowersConstant_of_pairing_idempotent}} in
+\doclink{TNLean/Algebra/PerronFrobenius/RankOne}, added for \ghissue{3714}.}
+
+If in addition the vectors $(l_k)_k$ are linearly independent, then the
+coefficient map $L$ is injective and
 \[
   L T^2=M^2L=ML=LT,
 \]
-so $T^2=T$.  Hence all positive powers of $T$ have the same trace; trace one
-then gives the rank-one factorization.  Primitivity separately makes each
-$|l_k)$ nonzero, so an independent family of subspaces carrying the vectors
-is sufficient to derive their linear independence.
+so $T^2=T$, the strictly stronger idempotence used for the rank-one
+factorization below.  Trace one and idempotence together then give the
+factorization directly.  Primitivity separately makes each $|l_k)$ nonzero,
+so an independent family of subspaces carrying the vectors is sufficient to
+derive their linear independence.
 \footnote{\sloppy The formal declarations are
 {\scriptsize\leanid{MPOTensor.SectorPairingData.pairing_operator_idempotent}},
 {\scriptsize\leanid{MPOTensor.SectorPairingData.mul_self_eq_self}},
-{\scriptsize\leanid{MPOTensor.SectorPairingData.tracePowersConstant}},
 {\scriptsize\leanid{MPOTensor.SectorPairingData.l_ne_zero}},
 {\scriptsize\leanid{MPOTensor.SectorPairingData.linearIndependent_l}},
 {\scriptsize\leanid{MPOTensor.sal_zcl_implies_rank_one_T_of_pairing_idempotent}}, and
 {\scriptsize\leanid{MPOTensor.sal_zcl_implies_rank_one_T_of_sector_supports}} in
 \doclink{TNLean/MPS/MPDO/SimpleLocalStructure}.}
 
-Three obligations remain before the conditional hypotheses disappear.
-First, the inverse-map factorization at lines 1407--1482 must construct the
-families $(l_k)_k$ and $(r_k)_k$ from an injective simple tensor and prove the
-pairing $T_{k,h}=(r_k|l_h)$.  Second, zero correlation length must be used to
-derive the operator identity at lines 1490--1493 for those concrete families;
-the present structure records this identity as data.  Third, linear
+Two obligations remain before the conditional hypotheses of the rank-one
+factorization disappear; the constant trace powers above no longer depend on
+either.  First, the inverse-map factorization at lines 1407--1482 must
+construct the families $(l_k)_k$ and $(r_k)_k$ from an injective simple
+tensor and prove the pairing $T_{k,h}=(r_k|l_h)$ together with the operator
+identity at lines 1490--1493 for those concrete families; the present
+structure records the pairing and the identity as data.  Second, linear
 independence of the closed tensors must be proved.  The direct sum in the
 source's sector splitting at lines 1436--1448 concerns the physical indices;
 after those indices are contracted, the closed tensors live in a common bond


### PR DESCRIPTION
## Summary

Derives the constant trace powers of the sector trace matrix `T` directly from the zero-correlation-length identity, with no linear-independence hypothesis, matching the source derivation at arXiv:1606.00608 (`Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 1494–1497), and following the pairing computation in `docs/paper-gaps/cpgsv17_pf_rank_one.tex`, §3 ("What the operator-valued ZCL identity implies").

## Mathematical route

Pairing the idempotence of the pairing operator `M = ∑ₖ |lₖ)(rₖ|` with the functional map on the left and the coefficient map on the right gives the matrix identity `T² = T³` unconditionally — no independence needed, since this only uses associativity of the composition, not injectivity of either map. Restricting the pairing operator to the finite-dimensional span of the sector tensors and using cyclicity of the trace of a composition (between that span and the coefficient space) gives `trace T = trace (T²)`. Induction from `T² = T³` gives `T^N = T²` for every `N ≥ 2`. Together these give the unconditional `Matrix.TracePowersConstant T`.

## Declarations

`TNLean/Algebra/PerronFrobenius/RankOne.lean` (general matrix statements):
- `Matrix.pow_two_eq_pow_three_of_pairing_idempotent`
- `Matrix.trace_eq_trace_sq_of_pairing_idempotent`
- `Matrix.pow_eq_pow_two_of_pow_two_eq_pow_three`
- `Matrix.tracePowersConstant_of_pairing_idempotent`

`TNLean/MPS/MPDO/SimpleLocalStructure.lean` (MPDO-side wrappers):
- `MPOTensor.SectorPairingData.pairing_sq_eq_pairing_cube` (new)
- `MPOTensor.SectorPairingData.tracePowersConstant` (now unconditional — the `hl : LinearIndependent ℝ data.l` hypothesis is dropped, and the `**Scope restriction (linear independence):**` marker is removed from this declaration)

`MPOTensor.SectorPairingData.mul_self_eq_self` is **unchanged**: it keeps its `hl` hypothesis and its scope-restriction marker. Idempotence `T² = T` is strictly stronger than `T² = T³`, and the source proof of Lemma C.5 does not derive it without independence either — this is documented in `docs/paper-gaps/cpgsv17_pf_rank_one.tex`, §3.1/§3.2 (unchanged by this PR).

## Downstream consumer

The single downstream call site, `SimpleMPDOLocalStructureData.ofSALZCLOfPairingIdempotent` in `TNLean/MPS/MPDO/BlockedRFPConstruction.lean`, drops the now-unnecessary `hl` argument at `hTraceConst := data.tracePowersConstant`. Its `hl` parameter remains in the `def`'s signature, since it is still needed for the `rankOne` field (the rank-one factorization is untouched by this PR).

## Blueprint

`ch21_mpdo_rfp_simple_local_structure.tex`:
- New general entry `thm:matrix_pairing_sq_eq_cube` (unconditional `T² = T³` and constant trace powers at the matrix level), `\leanok`.
- New MPDO-side entry `thm:mpdo_sector_pairing_trace_powers` (unconditional at the `SectorPairingData` level), `\leanok`.
- `thm:mpdo_sector_pairing_idempotent` is narrowed to state only the independence-conditional `T² = T` (the `\lean{...tracePowersConstant}` tag and the trace-power conclusion are removed from this entry, since that conclusion no longer needs the independence hypothesis this theorem carries).
- `thm:pairing_idempotent_rank_one_t`'s proof is updated to cite the new unconditional entry for the trace-power step instead of the (now narrower) idempotence entry.

## Paper-gap note

`docs/paper-gaps/cpgsv17_pf_rank_one.tex`, §3.2 records the unconditional derivation (with declaration references) ahead of the still-conditional `T² = T` paragraph, and narrows the "obligations remaining" list to the two that are specific to the rank-one factorization (the trace-power obligation is resolved).

## Verification

- `lake build` (targeted + full, 9319/9319 jobs) — green, no new warnings beyond pre-existing repo-wide `Copyright too short` style lints.
- `rg "sorry|axiom"` on touched Lean files — clean.
- `python3 scripts/blueprint_lean_sync.py --ci --diff-base origin/main` — in sync (3752/3756, unchanged from before this PR).
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci` — clean.
- All changed lines ≤ 100 chars.

### Deviation: `latexindent`

Ran `latexindent -w -s -l blueprint/latexindent.yaml` on both changed `.tex` files as instructed; it proposed reformatting ~1600 and ~200 lines respectively of pre-existing, unrelated content (the baseline files are not `latexindent`-clean under the current config/version — this predates this PR). Applying that would have violated "prefer minimal diffs" and risked colliding with concurrent PRs touching the same files. Instead, the added text was hand-formatted to match the immediately surrounding (pre-existing) indentation style, and `latexindent` was verified via a scratch copy to make no changes at all within the newly added blocks specifically.

Parent trackers: #232, #2380.

Closes #3714.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal math and documentation only; no auth, runtime, or API surface changes. Rank-one and independence paths are unchanged.
> 
> **Overview**
> Derives **constant trace powers** of the sector trace matrix `T` from the zero-correlation-length pairing identity **without** requiring linear independence of the sector tensors—matching arXiv:1606.00608 Appendix C.2 (lines 1494–1497).
> 
> **Lean:** New general matrix lemmas in `RankOne.lean` (`pow_two_eq_pow_three_of_pairing_idempotent`, `trace_eq_trace_sq_of_pairing_idempotent`, `pow_eq_pow_two_of_pow_two_eq_pow_three`, `tracePowersConstant_of_pairing_idempotent`). `SectorPairingData.tracePowersConstant` and `pairing_sq_eq_pairing_cube` wrap these; the `hl` hypothesis is removed from trace powers only. `ofSALZCLOfPairingIdempotent` now uses `data.tracePowersConstant` with no `hl` for `hTraceConst`; rank-one still needs independence via `mul_self_eq_self`.
> 
> **Docs:** Blueprint adds `thm:matrix_pairing_sq_eq_cube` and `thm:mpdo_sector_pairing_trace_powers`, narrows the idempotence theorem to conditional `T² = T`, and updates `cpgsv17_pf_rank_one.tex` so the trace-power obligation is closed while rank-one gaps remain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d479bffb0ca4f67f41ec03f2978ba164c8b882e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->