### PR TITLE
doc(blueprint): carry the MPO chapter mathematics in formulas

### DIFF
--- a/blueprint/src/chapter/ch20_mpdo_foundations.tex
+++ b/blueprint/src/chapter/ch20_mpdo_foundations.tex
@@ -40,7 +40,8 @@
     \[
         M^{u,v} := M^{i_1 j_1} M^{i_2 j_2} \cdots M^{i_N j_N} \in \MN{D}.
     \]
-    The empty pair of words evaluates to $\Id_D$, and word pairs of different
+    The empty pair of words evaluates to the identity,
+    $M^{\varnothing,\varnothing} = \Id_D$, and word pairs of different
     lengths evaluate to $0$.
 \end{definition}
 
@@ -176,7 +177,8 @@ legs cyclically and taking the resulting trace.
     \[
         (M^\dagger)^{ij} = (M^{ji})^\dagger.
     \]
-    A tensor equals its adjoint tensor precisely when it is Hermitian.
+    A tensor equals its adjoint tensor, $M^\dagger = M$, precisely when it
+    is Hermitian.
 \end{definition}
 
 \begin{theorem}[Reflection identity for the adjoint tensor]
@@ -202,14 +204,23 @@ legs cyclically and taking the resulting trace.
 
 \begin{proof}
     \leanok
-    Word evaluation of the adjoint tensor conjugate-transposes the evaluation
-    of the reversed words with ket and bra exchanged, since the conjugate
-    transpose of a product reverses the factors.  Taking traces gives the
-    entrywise identity.  For an MPDO the density operators are Hermitian, so
-    the complex conjugate of the $(\tau\circ\mathrm{rev},
-    \sigma\circ\mathrm{rev})$ entry is the $(\sigma\circ\mathrm{rev},
-    \tau\circ\mathrm{rev})$ entry; positive semidefiniteness is preserved
-    under the simultaneous relabeling of rows and columns by the reflection.
+    At the level of word evaluations, the conjugate transpose of a product
+    reverses the factors, so
+    \[
+        (M^\dagger)^{\sigma,\tau}
+        = \bigl(M^{\tau\circ\mathrm{rev},\,\sigma\circ\mathrm{rev}}\bigr)^\dagger.
+    \]
+    Taking traces gives the entrywise identity
+    \[
+        \rho^{(N)}(M^\dagger)_{\sigma\tau}
+        = \tr\!\bigl((M^{\tau\circ\mathrm{rev},\,\sigma\circ\mathrm{rev}})^\dagger\bigr)
+        = \overline{\rho^{(N)}(M)_{\tau\circ\mathrm{rev},\,\sigma\circ\mathrm{rev}}}.
+    \]
+    For an MPDO, $\rho^{(N)}(M)$ is Hermitian, so
+    $\overline{\rho^{(N)}(M)_{\tau\circ\mathrm{rev},\,\sigma\circ\mathrm{rev}}}
+    = \rho^{(N)}(M)_{\sigma\circ\mathrm{rev},\,\tau\circ\mathrm{rev}}$;
+    positive semidefiniteness is preserved under the simultaneous relabeling
+    of rows and columns by the reflection.
 \end{proof}
 
 \section{Transfer maps}
@@ -230,15 +241,24 @@ legs cyclically and taking the resulting trace.
     \leanok
     \uses{def:mpo_to_mps, def:mpo_transfer_map, def:transfer_map}
     The transfer map of an MPO tensor agrees with the transfer map of its
-    doubled-index MPS view.
+    doubled-index MPS view:
+    \[
+        \E_M = \E_{M^{\mathrm{MPS}}}.
+    \]
 \end{lemma}
 
 \begin{proof}
     \leanok
     \uses{def:mpo_to_mps, def:mpo_transfer_map, def:transfer_map}
     After identifying the single physical index of the doubled tensor with a
-    pair $(i,j)$, the single sum defining the MPS transfer map is exactly the
-    double sum defining $\E_M$.
+    pair $(i,j)$, for every $X \in \MN{D}$,
+    \[
+        \E_{M^{\mathrm{MPS}}}(X)
+        = \sum_{(i,j)} M^{\mathrm{MPS}}_{(i,j)}\, X\,
+          \bigl(M^{\mathrm{MPS}}_{(i,j)}\bigr)^\dagger
+        = \sum_{i,j=0}^{d-1} M^{ij} X (M^{ij})^\dagger
+        = \E_M(X).
+    \]
 \end{proof}
 
 \begin{theorem}[Positivity of the MPO transfer map]\label{thm:mpo_transfer_pos}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_algebra_tower.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_algebra_tower.tex
@@ -11,10 +11,11 @@
     A family of support $*$-algebras $\{\mathcal{A}_n\}_{n \ge 0}$, one at
     every blocking size, equipped with blocking maps
     $m_n : \mathcal{A}_n \otimes \mathcal{A}_n \to \mathcal{A}_{2n}$ and
-    inclusion maps $\iota_n : \mathcal{A}_n \to \mathcal{A}_{n+1}$ such that,
-    after viewing all elements inside the ambient bond-space matrix algebra,
-    $m_n$ is ordinary matrix multiplication and $\iota_n$ is the ambient
-    inclusion.
+    inclusion maps $\iota_n : \mathcal{A}_n \to \mathcal{A}_{n+1}$ realized,
+    inside the ambient bond-space matrix algebra, by
+    \[
+        m_n(x,y) = xy, \qquad \iota_n(x) = x.
+    \]
 \end{definition}
 
 \begin{definition}[Algebra-structure RFP predicate]%
@@ -23,10 +24,13 @@
     \leanok
     \uses{def:mpdo_algebra_structure_data, def:mpo_tensor}
     An MPO tensor $M$ satisfies the \emph{algebra-structure formulation} used
-    here when there exist algebra-structure data whose support algebra at every
-    positive blocking size coincides with the fixed-point algebra of the adjoint
-    blocked transfer map. This is a nontrivial algebraic condition, but it is still
-    weaker than the full coefficient formulation of
+    here when there exist algebra-structure data such that, for every
+    positive blocking size $n$,
+    \[
+        \mathcal{A}_n = \operatorname{Fix}(E_n^{\dagger}),
+    \]
+    where $E_n$ is the blocked transfer map. This is a nontrivial algebraic
+    condition, but it is still weaker than the full coefficient formulation of
     \cite[Theorem~4.14(ii)]{Cirac2016MPDO_arXiv}; that formulation also
     includes the coefficient family $c_{\alpha,\beta,\gamma}^{(L)}$.
 \end{definition}
@@ -37,16 +41,21 @@
     \leanok
     \uses{def:is_rfp_mpdo, def:mpdo_rfp_via_algebra}
     Assume the doubled tensor is trace-preserving and the transfer map admits a
-    positive-definite fixed point. If the transfer map is idempotent, then there
-    exists a stationary family of support algebras, all equal to the fixed-point
-    algebra of the adjoint transfer map, with multiplication given by matrix
-    multiplication and inclusions given by the identity.
+    positive-definite fixed point. If $E_1^2 = E_1$, then there is a stationary
+    family of support algebras
+    \[
+        \mathcal{A}_n = \operatorname{Fix}(E_1^{\dagger}),
+    \]
+    with multiplication $m_n(x,y) = xy$ and inclusion $\iota_n(x) = x$.
 \end{theorem}
 \begin{proof}\leanok
     Under the trace-preserving normalization and the faithful fixed point, Wolf's
-    fixed-point-algebra theorem gives a $*$-subalgebra of adjoint fixed points.
-    Idempotence identifies every positive blocked transfer map with the original
-    one, so the same fixed-point algebra works at every blocking size.
+    fixed-point-algebra theorem gives the $*$-subalgebra
+    $\operatorname{Fix}(E_1^{\dagger}) \subseteq \MN{D}$. Since $E_1$ is
+    idempotent, $E_n = E_1^n = E_1$ for every $n \ge 1$, so
+    $\operatorname{Fix}(E_n^{\dagger}) = \operatorname{Fix}(E_1^{\dagger})$ at every
+    positive blocking size, giving the stationary tower
+    $\mathcal{A}_n = \operatorname{Fix}(E_1^{\dagger})$.
 \end{proof}
 
 \begin{figure}[ht]
@@ -84,16 +93,18 @@
     \leanok
     \uses{def:mpdo_rfp_via_algebra}
     Assume the doubled tensor is trace-preserving and the transfer map admits a
-    positive-definite fixed point. If, for every positive blocked size $n$, the
-    adjoint fixed-point space of the blocked transfer map agrees with the
-    adjoint fixed-point space of the original transfer map, then the
-    algebra-structure formulation holds.
+    positive-definite fixed point. If, for every positive blocked size $n$,
+    \[
+        \operatorname{Fix}(E_n^{\dagger}) = \operatorname{Fix}(E_1^{\dagger}),
+    \]
+    then the algebra-structure formulation holds.
 \end{theorem}
 \begin{proof}\leanok
-    Use the adjoint fixed-point algebra of the original transfer map as a constant
-    support-algebra tower. The stabilization hypothesis identifies that same
-    algebra with the adjoint fixed-point space of every positive blocked transfer
-    map, so the stationary family satisfies the definition.
+    Take the constant tower $\mathcal{A}_n := \operatorname{Fix}(E_1^{\dagger})$ for
+    every $n$. The stabilization hypothesis
+    $\operatorname{Fix}(E_n^{\dagger}) = \operatorname{Fix}(E_1^{\dagger})$ then gives
+    $\mathcal{A}_n = \operatorname{Fix}(E_n^{\dagger})$ at every positive blocking
+    size $n$, which is compatibility with $M$.
 \end{proof}
 
 This does not give the full converse direction of
@@ -109,9 +120,13 @@ family, and the corresponding multiplication / inclusion coefficient arrays.
     \lean{MPOTensor.AlgebraStructureData.toBlockedCoefficients}
     \leanok
     \uses{def:mpdo_algebra_structure_data}
-    For each blocked size $n$, once a basis of $\mathcal{A}_n$ is chosen,
-    every element of $\mathcal{A}_n$ is identified with a finite coefficient
-    family on that basis.
+    For each blocked size $n$, fix a basis $\{b_i\}_{i \in I_n}$ of
+    $\mathcal{A}_n$ over a finite index set $I_n$. The \emph{blocked
+    coefficients} of $x \in \mathcal{A}_n$ are the coordinates
+    $(x_i)_{i \in I_n} \in \C^{I_n}$ with
+    \[
+        x = \sum_{i \in I_n} x_i\, b_i.
+    \]
 \end{definition}
 
 \begin{theorem}[Reconstruction from blocked coefficients]%
@@ -132,9 +147,12 @@ family, and the corresponding multiplication / inclusion coefficient arrays.
     \lean{MPOTensor.AlgebraStructureData.blockedStructureCoefficients}
     \leanok
     \uses{def:mpdo_blocked_coefficients}
-    The blocking multiplication map $m_n$ determines a coefficient family for
-    the product of any two chosen basis elements of $\mathcal{A}_n$, now viewed
-    in the basis of $\mathcal{A}_{2n}$.
+    For $i,j \in I_n$, the \emph{blocked multiplication coefficients} are the
+    blocked coefficients $(c^{(n)}_{i,j,k})_{k \in I_{2n}}$ of
+    $m_n(b_i,b_j) \in \mathcal{A}_{2n}$:
+    \[
+        m_n(b_i,b_j) = \sum_{k \in I_{2n}} c^{(n)}_{i,j,k}\, b_k.
+    \]
 \end{definition}
 
 \begin{theorem}[Blocked multiplication reconstructs from its coefficients]%
@@ -142,9 +160,10 @@ family, and the corresponding multiplication / inclusion coefficient arrays.
     \lean{MPOTensor.AlgebraStructureData.coe_mul_eq_sum_blockedStructureCoefficients}
     \leanok
     \uses{def:mpdo_blocked_structure_coefficients}
-    In the ambient bond-space matrix algebra, the product of two chosen basis
-    elements of $\mathcal{A}_n$ is the sum of the basis elements of
-    $\mathcal{A}_{2n}$ weighted by these extracted coefficients.
+    In the ambient bond-space matrix algebra,
+    \[
+        b_i\, b_j = \sum_{k \in I_{2n}} c^{(n)}_{i,j,k}\, b_k.
+    \]
 \end{theorem}
 \begin{proof}\leanok
     Apply the reconstruction formula of
@@ -157,9 +176,12 @@ family, and the corresponding multiplication / inclusion coefficient arrays.
     \lean{MPOTensor.AlgebraStructureData.blockedInclusionCoefficients}
     \leanok
     \uses{def:mpdo_blocked_coefficients}
-    The inclusion map $\iota_n$ determines a coefficient family for the image
-    of any chosen basis element of $\mathcal{A}_n$, now viewed in the basis of
-    $\mathcal{A}_{n+1}$.
+    For $i \in I_n$, the \emph{blocked inclusion coefficients} are the
+    blocked coefficients $(d_{ij})_{j \in I_{n+1}}$ of
+    $\iota_n(b_i) \in \mathcal{A}_{n+1}$:
+    \[
+        \iota_n(b_i) = \sum_{j \in I_{n+1}} d_{ij}\, b_j.
+    \]
 \end{definition}
 
 \begin{theorem}[Blocked inclusion reconstructs from its coefficients]%
@@ -167,9 +189,11 @@ family, and the corresponding multiplication / inclusion coefficient arrays.
     \lean{MPOTensor.AlgebraStructureData.reconstructFromBlockedInclusionCoefficients}
     \leanok
     \uses{def:mpdo_blocked_inclusion_coefficients}
-    Reconstructing the inclusion coefficient family of a chosen basis element
-    $b_i$ of $\mathcal{A}_n$ recovers its image $\iota_n(b_i)$ in
-    $\mathcal{A}_{n+1}$.
+    Reconstructing the inclusion coefficients recovers the image of $b_i$
+    under $\iota_n$:
+    \[
+        \sum_{j \in I_{n+1}} d_{ij}\, b_j = \iota_n(b_i).
+    \]
 \end{theorem}
 \begin{proof}\leanok
     \uses{def:mpdo_blocked_coefficients}
@@ -184,10 +208,13 @@ family, and the corresponding multiplication / inclusion coefficient arrays.
     \lean{MPOTensor.AlgebraStructureData.reconstructFromBlockedCoefficients_of_fixedPoint}
     \leanok
     \uses{def:mpdo_rfp_via_algebra, def:mpdo_blocked_coefficients}
-    If the algebra tower is compatible with an MPO tensor $M$, then every adjoint
-    blocked fixed point of the blocked transfer map $E_n$ belongs to
-    $\mathcal{A}_n$ and is recovered exactly from its extracted coefficient
-    family.
+    If the algebra tower is compatible with an MPO tensor $M$ and
+    $E_n^\dagger X = X$ for a positive blocking size $n$, then $X \in
+    \mathcal{A}_n$ and, writing $(X_i)_{i \in I_n}$ for its blocked
+    coefficients,
+    \[
+        X = \sum_{i \in I_n} X_i\, b_i.
+    \]
 \end{theorem}
 \begin{proof}\leanok
     Compatibility identifies $\mathcal{A}_n$ with the adjoint fixed-point algebra of
@@ -200,10 +227,11 @@ family, and the corresponding multiplication / inclusion coefficient arrays.
     \lean{MPOTensor.adjoint_transferMap_apply_of_isRFP_MPDO_via_algebra}
     \leanok
     \uses{def:mpdo_rfp_via_algebra}
-    If an MPO tensor satisfies the algebra-structure formulation, then every
-    adjoint fixed point of the blocked transfer map $E_n$ at a positive
-    blocking size $n$ is already an adjoint fixed point of the unblocked
-    transfer map $E_1$.
+    If an MPO tensor satisfies the algebra-structure formulation, then for
+    every positive blocking size $n$ and every $X$,
+    \[
+        E_n^{\dagger} X = X \implies E_1^{\dagger} X = X.
+    \]
 \end{theorem}
 \begin{proof}\leanok
     Compatibility at size $n$ places $X$ in $\mathcal{A}_n$. The inclusion map
@@ -219,8 +247,10 @@ family, and the corresponding multiplication / inclusion coefficient arrays.
     \label{lem:mpdo_adjoint_fix_reverse}
     \lean{MPOTensor.adjoint_blockedTransferMap_apply_of_adjoint_transferMap_apply}
     \leanok
-    Every adjoint fixed point of the unblocked transfer map $E_1$ is an
-    adjoint fixed point of every blocked transfer map $E_n$.
+    For every $n$,
+    \[
+        E_1^{\dagger} X = X \implies E_n^{\dagger} X = X.
+    \]
 \end{lemma}
 \begin{proof}\leanok
     Induction on $n$ using $E_{n+1} = E_n \circ E_1$ and
@@ -271,8 +301,10 @@ family, and the corresponding multiplication / inclusion coefficient arrays.
     \uses{def:mpdo_rfp_via_algebra, thm:mpdo_adjoint_fix_descent,
         lem:mpdo_adjoint_fix_reverse}
     If an MPO tensor satisfies the algebra-structure formulation, then for
-    every positive blocking size $n$ the adjoint fixed points of $E_n$ are
-    exactly the adjoint fixed points of $E_1$.
+    every positive blocking size $n$,
+    \[
+        \operatorname{Fix}(E_n^{\dagger}) = \operatorname{Fix}(E_1^{\dagger}).
+    \]
 \end{theorem}
 \begin{proof}\leanok
     Combine Theorem~\ref{thm:mpdo_adjoint_fix_descent} with
@@ -286,13 +318,13 @@ family, and the corresponding multiplication / inclusion coefficient arrays.
     \uses{def:mpdo_rfp_via_algebra,
         thm:mpdo_adjoint_fix_equality_from_algebra}
     Under the trace-preserving normalization and a positive-definite fixed
-    point, any algebra-structure witness forces the stationary adjoint
-    fixed-point tower itself to be compatible with the MPO tensor.
+    point, if $M$ satisfies the algebra-structure formulation, then the
+    stationary tower $\mathcal{A}_n = \operatorname{Fix}(E_1^\dagger)$ is
+    itself compatible with $M$: for every positive blocking size $n$,
+    \[
+        \operatorname{Fix}(E_1^\dagger) = \operatorname{Fix}(E_n^\dagger).
+    \]
 \end{theorem}
-\begin{proof}\leanok
-    Apply the adjoint fixed-point equality obtained from the algebra-structure
-    predicate to the stationary tower constructed from the faithful fixed point.
-\end{proof}
 
 \begin{theorem}[The support-algebra condition does not imply fusion]%
     \label{thm:mpdo_algebra_not_imply_fusion}
@@ -433,9 +465,18 @@ the elementary trace-power identity for diagonal matrices.
     \label{def:mpdo_diagonal_chi_family}
     \lean{MPOTensor.DiagonalChiFamily}
     \leanok
-    A family of diagonal complex matrices $\chi_{\alpha,\beta,\gamma}$ indexed
-    by ordered triples drawn from a common index type, each of a specified
-    size. This is the matrix $\chi_{\alpha,\beta,\gamma}$ of
+    A family of diagonal complex matrices, indexed by ordered triples
+    $(\alpha,\beta,\gamma)$ drawn from a common index type, consisting of a
+    size $r_{\alpha,\beta,\gamma} \in \N$ and diagonal entries
+    $\chi_{\alpha,\beta,\gamma,1}, \ldots,
+    \chi_{\alpha,\beta,\gamma,r_{\alpha,\beta,\gamma}} \in \C$ for each
+    triple, giving the diagonal matrix
+    \[
+        \chi_{\alpha,\beta,\gamma}
+        = \diag\bigl(\chi_{\alpha,\beta,\gamma,1}, \ldots,
+        \chi_{\alpha,\beta,\gamma,r_{\alpha,\beta,\gamma}}\bigr).
+    \]
+    This is the matrix $\chi_{\alpha,\beta,\gamma}$ of
     \cite[Theorem~4.14(ii)]{Cirac2016MPDO_arXiv}.
 \end{definition}
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
@@ -5,10 +5,17 @@
     \leanok
     \uses{def:mpo_tensor, def:von_neumann_entropy}
     For a fixed system size $N$, a block length $L\le N$, and an MPO tensor $M$
-    such that $\rho^{(N)}(M)$ is positive semidefinite, the \emph{$L$-block entropy}
-    $S_L^{(N)}(M)$ is the von Neumann entropy of the reduced state of the first
-    $L$ of $N$ spins of the normalized state
-    $\sigma^{(N)}(M) = \rho^{(N)}(M) / \tr[\rho^{(N)}(M)]$.
+    such that $\rho^{(N)}(M)$ is positive semidefinite, let
+    \[
+        \sigma^{(N)}(M) = \frac{\rho^{(N)}(M)}{\tr[\rho^{(N)}(M)]},
+        \qquad
+        \rho_L^{(N)}(M) = \tr_{N\setminus L}\!\bigl[\sigma^{(N)}(M)\bigr]
+    \]
+    denote the normalized state and the reduced state of the first $L$ of $N$
+    spins. The \emph{$L$-block entropy} is
+    \[
+        S_L^{(N)}(M) = S\bigl(\rho_L^{(N)}(M)\bigr).
+    \]
 \end{definition}
 
 \begin{definition}[Mutual information of an MPDO]\label{def:mutual_info_chain}
@@ -70,18 +77,23 @@
     \]
 \end{theorem}
 \begin{proof}\leanok
-    Reindexing a matrix does not change its von Neumann entropy.  The first
-    equality follows immediately.  Tracing out $C$ leaves the first $a+b$
-    sites.  Tracing out $A$ and $C$ leaves the middle $b$ sites, while tracing
-    out $A$ leaves the final $b+c$ sites.  Translation invariance gives
+    Write $\rho^{(k)}$ for the first-$k$-site reduced state, with $\cong$
+    denoting equality up to a permutation of basis indices. Reindexing a
+    matrix does not change its von Neumann entropy, giving the first equality
+    $S(ABC)=S_{a+b+c}$ immediately. Tracing out $C$ leaves the first $a+b$
+    sites,
+    \[
+        \operatorname{tr}_C(\rho_{ABC})\cong\rho^{(a+b)},
+    \]
+    so $S(AB)=S_{a+b}$. Tracing out $A$ and $C$ leaves the middle $b$ sites,
+    while tracing out $A$ leaves the final $b+c$ sites; translation invariance
+    gives
     \[
         \operatorname{tr}_{A,C}(\rho_{ABC})\cong\rho^{(b)},
         \qquad
-        \operatorname{tr}_{A}(\rho_{ABC})\cong\rho^{(b+c)},
+        \operatorname{tr}_{A}(\rho_{ABC})\cong\rho^{(b+c)}.
     \]
-    where $\rho^{(k)}$ is the first-$k$-site reduced state and $\cong$ denotes
-    equality up to a permutation of basis indices.  Hence $S(B)=S_b$ and
-    $S(BC)=S_{b+c}$.
+    Hence $S(B)=S_b$ and $S(BC)=S_{b+c}$.
 \end{proof}
 
 \begin{proposition}[Monotonicity of the mutual information]
@@ -209,13 +221,18 @@
     \lean{MPSTensor.pureBlockEntropy, MPSTensor.IsSAL}
     \leanok
     \uses{def:mps_tensor, def:von_neumann_entropy}
-    For an MPS tensor $A$, a system size $N$, and a block length $L\le N$,
-    the $L$-block entropy $S_L^{(N)}(A)$ is the von Neumann entropy of the
-    reduced state of the first $L$ spins of
+    For an MPS tensor $A$, a system size $N$, and a block length $L\le N$, let
     \[
         \sigma^{(N)}(A)
         =
-        \frac{\ketbra{V^{(N)}(A)}{V^{(N)}(A)}}{\|V^{(N)}(A)\|^2}.
+        \frac{\ketbra{V^{(N)}(A)}{V^{(N)}(A)}}{\|V^{(N)}(A)\|^2},
+        \qquad
+        \rho_L^{(N)}(A) = \tr_{N\setminus L}\!\bigl[\sigma^{(N)}(A)\bigr]
+    \]
+    denote the normalized state and the reduced state of the first $L$ spins.
+    The $L$-block entropy is
+    \[
+        S_L^{(N)}(A) = S\bigl(\rho_L^{(N)}(A)\bigr).
     \]
     The tensor saturates the area law if
     $S_L^{(N)}(A) = S_{L+1}^{(N)}(A)$ for all
@@ -252,10 +269,15 @@
     theory apply to pure-state block entropies.
 \end{lemma}
 \begin{proof}\leanok
-    The word product of doubled-tensor entries is the Kronecker product of the
-    bra word product and the conjugated ket word product. Thus its trace is
+    The word evaluation of the doubled tensor is the Kronecker product of the
+    word evaluation of $A$ and its conjugate,
     \[
-        \overline{V^{(N)}(A)(\tau)}\,V^{(N)}(A)(\sigma),
+        M^{\sigma,\tau} = A^\sigma \otimes \overline{A^\tau},
+    \]
+    so its trace factors as
+    $\tr(M^{\sigma,\tau}) = \tr(A^\sigma)\,\overline{\tr(A^\tau)}$, i.e.\
+    \[
+        \overline{V^{(N)}(A)_\tau}\,V^{(N)}(A)_\sigma,
     \]
     the corresponding matrix element of
     $\ketbra{V^{(N)}(A)}{V^{(N)}(A)}$.
@@ -322,9 +344,10 @@
     $W$ is the matrix of amplitudes $\langle u\,w\,|\,V^{(N)}(A)\rangle$ with $u$ the
     first $L$ spins and $w$ the remaining $N-L$. By cyclic invariance of the
     amplitudes, the reduced state of the complement is $\propto \overline{W^\dagger W}$.
-    Since $W W^\dagger$ and $W^\dagger W$ share the same nonzero spectrum, and
-    complex conjugation preserves the (real) eigenvalues of a Hermitian matrix, the
-    two reduced states have equal von Neumann entropy.
+    Cyclic invariance of the entropy, $S(WW^\dagger) = S(W^\dagger W)$, together with
+    invariance of the entropy under entrywise conjugation of a Hermitian matrix,
+    $S(\overline{W^\dagger W}) = S(W^\dagger W)$, gives
+    $S_L^{(N)}(A) = S_{N-L}^{(N)}(A)$.
 \end{proof}
 
 \begin{proposition}[Pure-state area-law monotonicity]\label{prop:pure_area_monotone}
@@ -411,10 +434,10 @@
     \]
 \end{lemma}
 \begin{proof}\leanok
-    The RFP hypothesis says that the transfer map is idempotent. Hence
-    $\mathbb{E}_A^{\,k}=\mathbb{E}_A$ for every $k\ge 1$. Applying
-    Lemma~\ref{lem:schmidt_gram_transfer_power} to the left and right Gram
-    entries gives the two displayed identities.
+    By definition, a renormalization fixed point satisfies
+    $\mathbb{E}_A^{\,2}=\mathbb{E}_A$, so $\mathbb{E}_A^{\,k}=\mathbb{E}_A$ for
+    every $k\ge 1$. Applying Lemma~\ref{lem:schmidt_gram_transfer_power} to the
+    left and right Gram entries gives the two displayed identities.
 \end{proof}
 
 \begin{lemma}[Pure block entropy as a bond-environment charpoly sum]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
@@ -83,11 +83,25 @@
     \uses{def:mpdo_bnt_label_theorem_data,
         thm:mpdo_bnt_blocked_basis_coefficient_eq,
         thm:mpdo_bnt_label_theorem_data_coeff_eq_trace_pow}
-    BNT-label theorem data give the comparison between the blocked-basis
+    BNT-label theorem data give, for every positive blocked length $n$ and
+    blocked-basis indices $i,j,k$, the comparison between the blocked-basis
     coefficients and the BNT-label coefficients through the source and target
-    label maps. Since the positive-length coefficients agree with the
-    canonical coefficient family determined by the same $\chi$-matrices, the
-    comparison can also be written with those canonical coefficients.
+    label maps $\sigma_n,\tau_n$,
+    \[
+        c^{(n)}_{i,j,k}
+        =
+        c^{(n)}_{\sigma_n(i),\sigma_n(j),\tau_n(k)}.
+    \]
+    Since the positive-length coefficients agree with the canonical
+    coefficient family determined by the same $\chi$-matrices, the
+    comparison can also be written as
+    \[
+        c^{(n)}_{i,j,k}
+        =
+        \operatorname{tr}\bigl(
+        \chi_{\sigma_n(i),\sigma_n(j),\tau_n(k)}^{\,n}
+        \bigr).
+    \]
 \end{theorem}
 \begin{proof}\leanok
     This is the blocked-basis coefficient comparison carried by the theorem
@@ -119,8 +133,11 @@
     \leanok
     \uses{def:mpdo_bnt_label_theorem_data,
         def:mpdo_positive_bnt_label_chi_trace_power_form}
-    BNT-label theorem data give positivity of every diagonal entry of
-    $\chi_{\alpha,\beta,\gamma}$.
+    BNT-label theorem data give, for all labels $\alpha,\beta,\gamma$ and
+    every diagonal-entry index $r$,
+    \[
+        0 < \chi_{\alpha,\beta,\gamma,r}.
+    \]
 \end{theorem}
 \begin{proof}\leanok
     This is the positivity condition carried by the positive BNT-label
@@ -133,9 +150,14 @@
     \leanok
     \uses{def:mpdo_bnt_label_theorem_data,
         thm:mpdo_bnt_label_same_length_product_eq_sum_chi_trace_pow}
-    BNT-label theorem data give the same-length product expansion with
-    coefficients written as traces of powers of the length-independent
-    $\chi_{\alpha,\beta,\gamma}$-matrices.
+    For every positive length $L$, BNT-label theorem data give the
+    same-length product expansion with coefficients written as traces of
+    powers of the length-independent $\chi_{\alpha,\beta,\gamma}$-matrices,
+    \[
+        O_L(M_\alpha)O_L(M_\beta)
+        = \sum_\gamma
+        \operatorname{tr}\bigl(\chi_{\alpha,\beta,\gamma}^{\,L}\bigr) O_L(M_\gamma).
+    \]
 \end{theorem}
 \begin{proof}\leanok
     Apply the chi-trace product law to the product identity and the positive
@@ -148,9 +170,13 @@
     \leanok
     \uses{def:mpdo_bnt_label_theorem_data,
         thm:mpdo_bnt_label_idempotent_eq_sum_chi_trace}
-    BNT-label theorem data give the idempotent scalar identity with the
-    length-one coefficients written as traces of the corresponding
-    $\chi$-matrices.
+    BNT-label theorem data give
+    \[
+        m_\gamma =
+        \sum_{\alpha,\beta}
+        \operatorname{tr}(\chi_{\alpha,\beta,\gamma})
+        m_\alpha m_\beta.
+    \]
 \end{theorem}
 \begin{proof}\leanok
     Apply the chi-trace idempotent law to the idempotent condition and the
@@ -166,7 +192,14 @@
     BNT-label theorem data give the blocked-basis coefficient trace-power
     formula obtained by pulling the BNT-label
     $\chi_{\alpha,\beta,\gamma}$-matrices back along the blocked-basis
-    comparison maps.
+    comparison maps: for every positive blocked length $n$,
+    \[
+        c^{(n)}_{i,j,k}
+        =
+        \operatorname{tr}\bigl(
+        \chi_{\sigma_n(i),\sigma_n(j),\tau_n(k)}^{\,n}
+        \bigr).
+    \]
 \end{theorem}
 \begin{proof}\leanok
     Apply the blocked-basis coefficient trace-power theorem to the comparison
@@ -185,7 +218,15 @@
         thm:mpdo_bnt_blocked_basis_to_positive_blocked_chi_trace_power_form}
     BNT-label theorem data give a positive blocked-basis $\chi$ trace-power
     witness by pulling the length-independent BNT-label $\chi$-family back
-    along the blocked-basis comparison maps.
+    along the blocked-basis comparison maps: writing $\chi_{n,i,j,k}$ for the
+    resulting blocked-basis diagonal matrix at a positive blocked length $n$,
+    \[
+        \chi_{n,i,j,k}
+        =
+        \chi_{\sigma_n(i),\sigma_n(j),\tau_n(k)}.
+    \]
+    The size, diagonal entries, and traces of powers of $\chi_{n,i,j,k}$
+    therefore agree with those of $\chi_{\sigma_n(i),\sigma_n(j),\tau_n(k)}$.
 \end{theorem}
 \begin{proof}\leanok
     Apply the BNT-to-blocked witness construction to the comparison and the
@@ -199,7 +240,13 @@
     \uses{def:mpdo_bnt_label_theorem_data,
         thm:mpdo_bnt_label_theorem_data_to_positive_blocked_chi_trace_power_form}
     The pulled-back blocked-basis $\chi$-family obtained from BNT-label
-    theorem data satisfies the blocked trace-power predicate.
+    theorem data satisfies, for every positive blocked length $n$, the
+    blocked trace-power identity
+    \[
+        c^{(n)}_{i,j,k}
+        =
+        \sum_r \chi_{n,i,j,k,r}^{\,n}.
+    \]
 \end{theorem}
 \begin{proof}\leanok
     This is the trace-power part of the positive blocked-basis
@@ -213,7 +260,11 @@
     \uses{def:mpdo_bnt_label_theorem_data,
         thm:mpdo_bnt_label_theorem_data_to_positive_blocked_chi_trace_power_form}
     The pulled-back blocked-basis $\chi$-family obtained from BNT-label
-    theorem data has positive diagonal entries.
+    theorem data has positive diagonal entries: for every blocked length $n$,
+    indices $i,j,k$, and entry index $r$,
+    \[
+        0 < \chi_{n,i,j,k,r}.
+    \]
 \end{theorem}
 \begin{proof}\leanok
     This is the positivity part of the positive blocked-basis
@@ -227,7 +278,11 @@
     \uses{def:mpdo_bnt_label_theorem_data,
         thm:mpdo_bnt_label_theorem_data_to_positive_blocked_chi_trace_power_form}
     The pulled-back blocked-basis $\chi$-entries obtained from BNT-label
-    theorem data are positive.
+    theorem data are positive: for every blocked length $n$,
+    indices $i,j,k$, and entry index $r$,
+    \[
+        0 < \chi_{n,i,j,k,r}.
+    \]
 \end{theorem}
 \begin{proof}\leanok
     This is the positivity part of the positive blocked-basis
@@ -243,7 +298,12 @@
         thm:mpdo_positive_blocked_structure_chi_eq_trace_matrix_pow}
     The positive-length blocked-basis coefficients are traces of powers of the
     pulled-back blocked-basis $\chi$-matrices obtained from BNT-label
-    theorem data.
+    theorem data: for every positive blocked length $n$,
+    \[
+        c^{(n)}_{i,j,k}
+        =
+        \operatorname{tr}\bigl(\chi_{n,i,j,k}^{\,n}\bigr).
+    \]
 \end{theorem}
 \begin{proof}\leanok
     Apply the trace-power identity of the positive blocked-basis

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_witnesses.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_witnesses.tex
@@ -51,19 +51,31 @@
     \leanok
     \uses{def:mpdo_bnt_label_theorem_witness}
     A proposition-level BNT-label theorem witness contains the source-side
-    same-length product law, the idempotent scalar law, the positive-length
-    trace-power law, and positivity of the diagonal
-    $\chi_{\alpha,\beta,\gamma}$-entries. After unpacking the witness, the
-    same-length product and idempotent equations can first be written with the
-    BNT-label coefficients $c^{(L)}_{\alpha,\beta,\gamma}$, and then with
-    the coefficients expressed as
-    $\operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{\,L})$ and
-    $\operatorname{tr}(\chi_{\alpha,\beta,\gamma})$, respectively. At
-    every positive length, the BNT-label coefficient family also agrees with
-    the canonical coefficient family determined by these $\chi$-matrices.
-    Consequently, the product and idempotent predicates may be stated directly
-    using that canonical coefficient family, and the same displayed source
-    equations hold with those canonical coefficients.
+    same-length product law, which holds for every positive length $L$, and
+    the idempotent scalar law,
+    \[
+        O_L(M_\alpha)O_L(M_\beta)
+        = \sum_\gamma c^{(L)}_{\alpha,\beta,\gamma} O_L(M_\gamma),
+        \qquad
+        m_\gamma = \sum_{\alpha,\beta} c^{(1)}_{\alpha,\beta,\gamma}m_\alpha m_\beta.
+    \]
+    A witness also carries the positive-length trace-power law
+    $c^{(L)}_{\alpha,\beta,\gamma}
+        = \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{\,L})$
+    and positivity of the diagonal $\chi_{\alpha,\beta,\gamma}$-entries.
+    Substituting the trace-power law into the two equations above rewrites
+    them with the coefficients as $\chi$-traces,
+    \[
+        O_L(M_\alpha)O_L(M_\beta)
+        = \sum_\gamma \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{\,L}) O_L(M_\gamma),
+        \qquad
+        m_\gamma
+        = \sum_{\alpha,\beta} \operatorname{tr}(\chi_{\alpha,\beta,\gamma}) m_\alpha m_\beta.
+    \]
+    At every positive length the BNT-label coefficient family also agrees
+    with the canonical coefficient family determined by these
+    $\chi$-matrices, so both pairs of equations above hold equally with
+    that canonical family in place of $c^{(L)}_{\alpha,\beta,\gamma}$.
 \end{theorem}
 \begin{proof}\leanok
     Unpack the existential witness and apply the corresponding witness-level
@@ -145,12 +157,17 @@
     \leanok
     \uses{def:mpdo_bnt_label_theorem_witness,
         thm:mpdo_bnt_label_theorem_data_blocked_coeff_eq}
-    An existential BNT-label theorem witness gives the comparison between the
-    blocked-basis coefficients and the BNT-label coefficients through the
-    source and target label maps. The same comparison is also available with
-    the canonical coefficient family determined by the witness's
-    $\chi$-matrices. The proposition-level nonempty form of the witness
-    gives the same comparisons after choosing a witness.
+    An existential BNT-label theorem witness gives
+    \[
+        c^{(n)}_{i,j,k} = c^{(n)}_{\sigma_n(i),\sigma_n(j),\tau_n(k)}
+    \]
+    between the chosen blocked-basis coefficients and the witness's
+    BNT-label coefficients $c^{(n)}_{\alpha,\beta,\gamma}$, through the
+    source and target label maps $\sigma_n,\tau_n$ carried by the witness.
+    The same comparison holds with the canonical coefficient family
+    determined by the witness's $\chi$-matrices in place of
+    $c^{(n)}_{\alpha,\beta,\gamma}$. The proposition-level nonempty form of
+    the witness gives the same comparisons after choosing a witness.
 \end{theorem}
 \begin{proof}\leanok
     Apply the corresponding theorem-data comparison carried by the witness.
@@ -198,9 +215,15 @@
     \leanok
     \uses{def:mpdo_bnt_label_theorem_witness,
         thm:mpdo_bnt_label_theorem_data_blocked_coeff_eq_trace_pow}
-    An existential BNT-label theorem witness gives the blocked-basis
-    coefficient trace-power formula obtained by pulling the BNT-label
-    $\chi$-matrices back along the blocked-basis comparison maps.
+    For every positive blocked length $n$, an existential BNT-label theorem
+    witness gives the blocked-basis coefficient trace-power formula
+    \[
+        c^{(n)}_{i,j,k}
+        = \operatorname{tr}\bigl(\chi_{\sigma_n(i),\sigma_n(j),\tau_n(k)}^{\,n}\bigr),
+    \]
+    obtained by pulling the BNT-label $\chi_{\alpha,\beta,\gamma}$-matrices
+    back along the source and target label maps $\sigma_n,\tau_n$ carried by
+    the witness.
 \end{theorem}
 \begin{proof}\leanok
     Apply the corresponding theorem-data identity carried by the witness.
@@ -221,12 +244,18 @@
     \uses{def:mpdo_bnt_label_theorem_witness,
         thm:mpdo_bnt_label_theorem_data_to_positive_blocked_chi_trace_power_form}
     An existential BNT-label theorem witness gives a positive blocked-basis
-    $\chi$ trace-power witness for the chosen algebra-structure data. The
-    blocked-basis $\chi$-family is the pullback of the BNT-label
-    $\chi$-family along the source and target comparison maps. The
-    proposition-level nonempty form of the witness gives the corresponding
-    existential blocked-basis trace-power family, both in coefficient form and
-    in matrix-trace form.
+    $\chi$ trace-power witness for the chosen algebra-structure data: a
+    blocked $\chi$-family with positive diagonal entries such that, for
+    every positive blocked length $n$,
+    \[
+        c^{(n)}_{i,j,k} = \operatorname{tr}\bigl(\chi_{n,i,j,k}^{\,n}\bigr).
+    \]
+    The blocked-basis $\chi$-family is the pullback of the BNT-label
+    $\chi$-family along the source and target comparison maps
+    $\sigma_n,\tau_n$. The proposition-level nonempty form of the witness
+    gives the same existential blocked-basis family, stated either through
+    this trace-power predicate or through the coefficient equation it
+    unfolds to.
 \end{theorem}
 \begin{proof}\leanok
     Apply the corresponding theorem-data consequence carried by the witness.
@@ -281,9 +310,12 @@
     \uses{def:mpdo_bnt_label_theorem_witness,
         thm:mpdo_bnt_label_theorem_witness_to_positive_blocked_chi_trace_power_form,
         thm:mpdo_positive_blocked_structure_chi_eq_trace_matrix_pow}
-    The positive-length blocked-basis coefficients are traces of powers of the
-    pulled-back blocked-basis $\chi$-matrices obtained from an existential
-    BNT-label theorem witness.
+    For every positive blocked length $n$, the blocked-basis coefficients
+    obtained from an existential BNT-label theorem witness are traces of
+    powers of the pulled-back blocked-basis $\chi$-matrices,
+    \[
+        c^{(n)}_{i,j,k} = \operatorname{tr}\bigl(\chi_{n,i,j,k}^{\,n}\bigr).
+    \]
 \end{theorem}
 \begin{proof}\leanok
     Apply the trace-power identity of the positive blocked-basis

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -6,8 +6,11 @@
     \leanok
     \uses{def:mpo_tensor}
     For a fixed chain length $N \ge 2$, this consists of a positive
-    semidefinite two-site operator $B$ such that its translated copies on the
-    periodic chain commute pairwise.
+    semidefinite two-site operator $B\ge0$ whose translated copies commute
+    pairwise on the periodic $N$-site chain:
+    \[
+        [B_{i,i+1},B_{j,j+1}]=0.
+    \]
 \end{definition}
 
 \begin{definition}[Commuting form]
@@ -15,9 +18,13 @@
     \lean{MPOTensor.HasCommutingForm}
     \leanok
     \uses{def:mpdo_commuting_form_data, def:mpo_tensor}
-    An MPO tensor has the commuting-form property if for every $N \ge 2$ its
-    $N$-site operator is a positive scalar multiple of the product of the
-    translated copies of some commuting two-site operator $B$.
+    An MPO tensor $M$ has the commuting-form property if for every $N \ge 2$
+    there is a two-site operator $B$ as in
+    Definition~\ref{def:mpdo_commuting_form_data} and a constant $c>0$ such
+    that
+    \[
+        \rho^{(N)}(M)=c\prod_{i=0}^{N-1}B_{i,i+1}.
+    \]
 \end{definition}
 
 \begin{definition}[GSNNCH]
@@ -25,10 +32,14 @@
     \lean{MPOTensor.IsGSNNCH}
     \leanok
     \uses{def:mpdo_has_commuting_form}
-    An MPO tensor is a Gibbs state of a nearest-neighbor commuting Hamiltonian
-    if every finite-chain operator admits the equivalent positive-operator
-    presentation $\rho^{(N)} = c \prod_i B_{i,i+1}$ with $c > 0$ and
-    commuting nearest-neighbor factors. The projector-limit convention in
+    An MPO tensor $M$ is a Gibbs state of a nearest-neighbor commuting
+    Hamiltonian if for every $N\ge2$ its finite-chain operator admits the
+    equivalent positive-operator presentation
+    \[
+        \rho^{(N)}(M)=c\prod_{i=0}^{N-1}B_{i,i+1},
+        \qquad c>0,\qquad B\ge0,\qquad [B_{i,i+1},B_{j,j+1}]=0.
+    \]
+    The projector-limit convention in
     \cite{Cirac2016MPDO_arXiv}
     identifies this with the exponential Gibbs form.
 \end{definition}
@@ -43,8 +54,11 @@
 \end{theorem}
 
 \begin{proof}\leanok
-    A positive normalization constant converts commuting-form data into a GSNNCH
-    witness, and every GSNNCH witness remembers its underlying commuting-form data.
+    Both directions unfold to the same identity
+    $\rho^{(N)}(M)=c\prod_{i=0}^{N-1}B_{i,i+1}$ with $c>0$: a commuting-form
+    witness for $M$ at length $N$ together with its constant $c$ is exactly a
+    GSNNCH witness for $M$ at length $N$ with that same constant, and
+    conversely.
 \end{proof}
 
 \begin{definition}[GSNNCH with doubled-index transfer idempotence]
@@ -83,9 +97,12 @@
     \lean{MPOTensor.TranslationInvariantBondData}
     \leanok
     \uses{def:mpdo_commuting_form_data}
-    This records a single positive two-site bond together with its translated
-    copies on every finite periodic chain, requiring those translated copies to
-    commute pairwise.
+    This records a single positive semidefinite two-site bond $B\ge0$ whose
+    translated copies commute pairwise on the periodic $N$-site chain at
+    every chain length $N\ge2$:
+    \[
+        [B_{i,i+1},B_{j,j+1}]=0.
+    \]
 \end{definition}
 
 \begin{definition}[$\eta$-local commuting-form data]
@@ -93,10 +110,13 @@
     \lean{MPOTensor.EtaLocalStructureData}
     \leanok
     \uses{def:mpdo_translation_invariant_bond_data, def:mpdo_has_commuting_form}
-    This defines the eta-local form of \cite[Appendix~C.2]{Cirac2016MPDO_arXiv}: the
-    translation-invariant positive two-site bond data together with the
-    requirement that the corresponding product realizes the MPO at every finite
-    length.
+    This defines the eta-local form of \cite[Appendix~C.2]{Cirac2016MPDO_arXiv}:
+    a two-site bond $B$ as in
+    Definition~\ref{def:mpdo_translation_invariant_bond_data} together with,
+    for every chain length $N\ge2$, a constant $c>0$ such that
+    \[
+        \rho^{(N)}(M)=c\prod_{i=0}^{N-1}B_{i,i+1}.
+    \]
 \end{definition}
 
 \begin{definition}[Finite-chain bond form]
@@ -133,10 +153,17 @@
     \lean{MPOTensor.EtaLocalStructureData.positive_commuting_product_form}
     \leanok
     \uses{def:mpdo_eta_local_structure_data, def:mpdo_has_commuting_form}
-    The $\eta$-local structure itself determines a commuting-form witness for every
-    chain length $N \ge 2$. In particular, the translated nearest-neighbor
-    bonds commute and the MPDO at length $N$ is a positive scalar multiple of
-    their product. This is the commuting-form half of
+    The $\eta$-local structure itself determines a commuting-form witness for
+    every chain length $N \ge 2$: writing $B$ for its bond, the translated
+    copies commute,
+    \[
+        [B_{i,i+1},B_{j,j+1}]=0,
+    \]
+    and there exists $c>0$ with
+    \[
+        \rho^{(N)}(M)=c\prod_{i=0}^{N-1}B_{i,i+1}.
+    \]
+    This is the commuting-form half of
     \cite[Proposition~C.8]{Cirac2016MPDO_arXiv}, taking the $\eta$-local data as
     given; deriving that data from the saturation of the area law is the
     deferred step recorded in Remark~\ref{rem:simple_mpdo_rfp_chain_gap}.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_foundations.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_foundations.tex
@@ -198,7 +198,7 @@
     \[
         \rho^{(N)}(M)=\rho^{(N)}_p(A).
     \]
-    Equivalently,
+    Equivalently, for every positive length $N$,
     \[
         \rho^{(N)}(M)
         =
@@ -206,7 +206,6 @@
         \bigl(
             |\Psi^{(N)}(A)\rangle\langle\Psi^{(N)}(A)|
         \bigr),
-        \qquad N>0,
     \]
     as in \cite[line~751]{Cirac2016MPDO_arXiv}.
 \end{definition}
@@ -217,11 +216,8 @@
     \leanok
     \uses{def:mpdo_ancillary_trace_map, def:is_kraus_cptp}
     The spin reduction obtained by tracing the ancillary index is
-    trace-preserving and completely positive when
-    \[
-        \operatorname{tr}_a
-        \quad\text{is a tpCPM}.
-    \]
+    trace-preserving completely positive: the ancillary trace map
+    $\operatorname{tr}_a$ satisfies Definition~\ref{def:is_kraus_cptp}.
     This is the structure described immediately after Definition~4.4 in
     \cite[lines~761--764]{Cirac2016MPDO_arXiv}.
 \end{definition}
@@ -264,15 +260,14 @@
     \uses{def:mpdo_purification_rfp_witness}
     An MPO tensor is a purification renormalization fixed point if it has a
     purification RFP witness. Equivalently, it admits a purifying tensor $A$
-    satisfying
+    such that, for every positive length $N$,
     \[
         \rho^{(N)}(M)
         =
         \operatorname{tr}_a
         \bigl(
             |\Psi^{(N)}(A)\rangle\langle\Psi^{(N)}(A)|
-        \bigr)
-        \quad\text{for all }N>0,
+        \bigr),
     \]
     and $\widehat A$ is a pure-state renormalization fixed point. This is
     Definition~4.4 of \cite[lines~756--764]{Cirac2016MPDO_arXiv}.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
@@ -148,6 +148,7 @@
 \begin{definition}[Orthogonally controlled Kraus map]
     \label{def:mpdo_controlled_kraus_map}
     \lean{Matrix.controlledKrausMap}
+    \lean{Matrix.controlledKrausMap_apply_of_ne}
     \leanok
     \uses{def:mpdo_rectangular_kraus_map}
     Let $H=\bigoplus_k H_k$ and $K=\bigoplus_k K_k$. For each $k$, let
@@ -158,9 +159,8 @@
         \mathcal C(X)
         =\sum_{k,a}\widetilde A_{k,a}X\widetilde A_{k,a}^{\dagger}.
     \]
-    In particular, $\mathcal C$ discards the off-diagonal blocks between
-    distinct summands. This is the sector control in the definitions of
-    $\mathcal T_1$ and $\mathcal S_1$ in
+    In particular, $\mathcal C(X)_{kl}=0$ for $k\ne l$. This is the sector
+    control in the definitions of $\mathcal T_1$ and $\mathcal S_1$ in
     \cite[Appendix~C.2, lines~1523--1535 and~1548--1555]
       {Cirac2016MPDO_arXiv}.
 \end{definition}
@@ -555,7 +555,8 @@
     \[
         \E_{A^{\mathrm{MPO}}}\circ\E_{A^{\mathrm{MPO}}}
         = \E_{A^{\mathrm{MPO}}}
-        \iff A \text{ is RFP}.
+        \iff
+        \E_A\circ\E_A=\E_A.
     \]
 \end{theorem}
 


### PR DESCRIPTION
## Summary

Formula-first clarity pass on the MPO/MPDO chapters (`ch20_mpdo_foundations.tex`, `ch21_mpdo_rfp_*.tex`), bringing them to the same standard already applied to chapters 1-12: word-only descriptions of mathematical content are rewritten as explicit displayed formulas. All `\lean`, `\leanok`, `\uses` tags and labels are unchanged, except that `Matrix.controlledKrausMap_apply_of_ne` is added to the existing `\lean` list of `def:mpdo_controlled_kraus_map` (the definition's prose already described that vanishing property; the formula now states it and the tag now cites the Lean lemma that proves it).

## Entries rewritten

`ch20_mpdo_foundations.tex`:
- `def:mpo_eval_word` — the empty-word base case is now the formula `M^{∅,∅} = Id_D`.
- `def:mpo_adjoint_tensor` — adjoint-equals-Hermitian criterion now states `M^† = M`.
- `thm:mpo_adjoint_reflection` — proof now carries the word-evaluation and entrywise-trace identities as displayed formulas.
- `lem:mpo_transfer_eq_mps` — statement and proof now display the transfer-map identification `E_M = E_{M^MPS}` and its sum expansion.

`ch21_mpdo_rfp_algebra_tower.tex`:
- `def:mpdo_algebra_structure_data` — blocking/inclusion maps stated as `m_n(x,y) = xy`, `ι_n(x) = x`.
- `def:mpdo_rfp_via_algebra` — algebra-structure formulation stated as `A_n = Fix(E_n^†)`.
- `thm:mpdo_rfp_via_algebra_from_rfp` (statement + proof) — idempotence hypothesis and stationary tower conclusion as formulas.
- `thm:mpdo_algebra_from_stabilized_adjoint_fixedpoints` (statement + proof) — stabilization hypothesis and constant-tower construction as formulas.
- `def:mpdo_blocked_coefficients`, `def:mpdo_blocked_structure_coefficients`, `thm:mpdo_mul_coefficients_reconstruct`, `def:mpdo_blocked_inclusion_coefficients`, `thm:mpdo_inclusion_coefficients_reconstruct` — basis-coefficient definitions and reconstruction identities as formulas.
- `thm:mpdo_fixedpoint_coefficients_reconstruct`, `thm:mpdo_adjoint_fix_descent`, `lem:mpdo_adjoint_fix_reverse`, `thm:mpdo_adjoint_fix_equality_from_algebra` (+ proof), `thm:mpdo_stationary_tower_from_algebra` — fixed-point descent/reverse-inclusion/equality chain as displayed implications.
- `def:mpdo_diagonal_chi_family` — the diagonal χ family spelled out with explicit size and entries.

`ch21_mpdo_rfp_area_law.tex`:
- `def:block_entropy`, `def:pure_sal` — normalized state, reduced state, and block entropy given as formulas.
- `lem:schmidt_symmetry` (proof) — cyclic-invariance and conjugation-invariance steps as named formulas.
- `thm:mpdo_tripartite_block_entropy_identifications` (proof) — the four tripartite-entropy identifications derived via displayed partial traces.
- `lem:mpo_doubled` (proof) — the Kronecker-product word evaluation `M^{σ,τ} = A^σ ⊗ conj(A^τ)` made explicit.
- `lem:rfp_schmidt_gram_collapse` (proof) — RFP idempotence spelled out as `E_A² = E_A`.

`ch21_mpdo_rfp_bnt_theorem_data.tex` (10 entries) and `ch21_mpdo_rfp_bnt_witnesses.tex` (5 entries) — every "gives the comparison/law/witness" sentence replaced by the corresponding displayed coefficient/trace-power/positivity formula, matching the pattern already used elsewhere in the same file for the un-rewritten entries.

`ch21_mpdo_rfp_commuting_form_gsnnch.tex`:
- `def:mpdo_commuting_form_data`, `def:mpdo_has_commuting_form`, `def:mpdo_is_gsnnch`, `thm:mpdo_is_gsnnch_iff_has_commuting_form` (proof), `def:mpdo_translation_invariant_bond_data`, `def:mpdo_eta_local_structure_data`, `thm:mpdo_eta_local_structure_has_commuting_form` — the commuting-bond product form `ρ^(N)(M) = c·∏B_{i,i+1}` with `[B_{i,i+1},B_{j,j+1}]=0` made explicit throughout instead of described in prose.

`ch21_mpdo_rfp_foundations.tex`:
- `def:mpdo_global_purification_equation`, `def:mpdo_has_trace_preserving_spin_reduction`, `def:mpdo_is_prfp` — purification and trace-preservation conditions as formulas/definition references.

`ch21_mpdo_rfp_pure_state_recovery.tex`:
- `def:mpdo_controlled_kraus_map` — off-diagonal vanishing now the formula `C(X)_{kl}=0` for `k≠l`.
- `thm:to_mpo_rfp_iff_rfp` — the RFP-recovery equivalence now displays both idempotence conditions side by side.

## Verification

- `cd blueprint && leanblueprint pdf` — compiles cleanly (499 pages); spot-checked the changed pages via `pdftoppm` (ch20 word-evaluation/adjoint page, ch21 algebra-tower page, ch21 BNT-theorem-data page, ch21 area-law page) — formulas render correctly, no new overfull-hbox or missing-reference warnings.
- `lake exe cache get` + `lake build TNLean` — 9322/9322 jobs, green (only pre-existing repo-wide `Copyright too short` style lints, unrelated to this PR; no `.lean` files were touched).
- `python3 scripts/blueprint_lean_sync.py --update-lean-decls` then `leanblueprint checkdecls` — passes.
- `python3 scripts/blueprint_lean_sync.py --ci` — in sync (3768/3772, unchanged from before this PR; all 8 touched chapter files at 100%).
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main` — no newly added violations.
- `chktex -q` on all 8 changed files — all warnings land on pre-existing (untouched) lines; no chktex warnings on any newly added line.
- `git diff --check` — clean.
- All added/changed lines ≤ 100 chars.

Not merging per instructions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX edits with unchanged mathematical labels and Lean linkage; no runtime, auth, or application code paths are affected.
> 
> **Overview**
> Formula-first clarity pass on the MPO/MPDO blueprint chapters (`ch20_mpdo_foundations`, `ch21_mpdo_rfp_*`), matching the style already used in earlier chapters: prose-only statements are rewritten as **explicit displayed equations** while `\lean` / `\leanok` / `\uses` tags and labels stay the same.
> 
> **Foundations and transfer maps** (`ch20`): empty-word evaluation, Hermitian/adjoint criteria, the adjoint-reflection proof, and MPO–MPS transfer-map identification now state the identities in formulas (e.g. \(\mathcal{E}_M = \mathcal{E}_{M^{\mathrm{MPS}}}\)).
> 
> **Algebra tower & RFP** (`ch21_mpdo_rfp_algebra_tower`): blocking/inclusion as \(m_n(x,y)=xy\), \(\iota_n(x)=x\); algebra-structure and fixed-point conditions as \(\mathcal{A}_n = \mathrm{Fix}(E_n^\dagger)\); blocked coefficient definitions and descent/equality lemmas as displayed implications and equalities; diagonal \(\chi\) family spelled out with sizes and entries.
> 
> **Area law, BNT data/witnesses, GSNNCH, purification** (other `ch21` files): block entropy and normalized/reduced states; tripartite-entropy and doubled-tensor proofs; BNT “gives …” theorems now show coefficient comparisons and \(\chi\)-trace laws explicitly; commuting/GSNNCH and \(\eta\)-local data use \(\rho^{(N)}(M)=c\prod B_{i,i+1}\) with commutators; purification/trace-preservation and pure-state RFP equivalence stated as formulas.
> 
> **Lean sync**: `\lean{Matrix.controlledKrausMap_apply_of_ne}` is added on `def:mpdo_controlled_kraus_map` alongside the new off-diagonal formula \(\mathcal{C}(X)_{kl}=0\) for \(k\ne l\). No `.lean` sources are modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11febd9b70cad33fce2c8afe5d184d698d0f98c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->