### PR TITLE
feat(MPS/MPDO): iterated fusion of a triple product tensor

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -421,6 +421,7 @@ import TNLean.MPS.MPDO.BNTTheoremWitness
 import TNLean.MPS.MPDO.BNTTheoremWitnessConsequences
 import TNLean.MPS.MPDO.BNTFusionIsometries
 import TNLean.MPS.MPDO.BNTAssociativity
+import TNLean.MPS.MPDO.BNTTripleFusion
 import TNLean.MPS.MPDO.CommutingForm
 import TNLean.MPS.MPDO.CommutingFormBridge
 import TNLean.MPS.MPDO.BlockedRFPConstruction

--- a/TNLean/MPS/MPDO/BNTTripleFusion.lean
+++ b/TNLean/MPS/MPDO/BNTTripleFusion.lean
@@ -1,0 +1,367 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.BNTFusionIsometries
+
+/-!
+# Iterated fusion of a triple product tensor
+
+Statement (iii) of Theorem IV.13 of arXiv:1606.00608 (label Ualphabeta, lines 986--993 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`) gives, for every pair of labels, an isometry conjugating
+the product tensor of the corresponding pair of labelled tensors onto a chi-weighted direct sum.
+The remark following the theorem (lines 995--999) observes that associativity of the product in
+(eq:algebra) constrains the chi coefficients and, through (Ualphabeta), gives an equation relating
+the fusion isometries for the two ways of bracketing a triple product; the source attributes the
+construction and the classification of solutions of that equation to
+[Bultinck--Marien--Williamson--Sahinoglu--Haegeman--Verstraete 2015] (arXiv:1511.08090).
+arXiv:1606.00608 itself does not spell out that equation.
+
+This file stays within Cirac--Perez-Garcia--Schuch--Verstraete's own objects (the tensors, the
+chi matrices, and the fusion isometries of `BNTFusionIsometryFamily`) and records one concrete
+consequence of applying the fusion identity twice: fusing the first two factors of a triple
+product tensor with `fusionIsometry α β`, then fusing the result with the third factor label by
+label with `fusionIsometry δ γ`, conjugates the triple product tensor onto a tensor that is
+block-diagonal in two nested labels, with block `(δ, ε)` equal to the Kronecker product of the
+two chi matrices `χ_{α,β,δ}` and `χ_{δ,γ,ε}` with the tensor of label `ε`. This is the
+tensor-level refinement, for one bracketing of the triple product, of the associativity remark;
+it is infrastructure toward the equation of lines 997--999 relating the two bracketings, not that
+equation itself. The comparison with the other bracketing of the triple product is left to a
+follow-up.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608, Theorem IV.13(iii), lines
+  986--999 of `Papers/1606.00608/MPDO-22-12-17-2.tex`
+-/
+
+open scoped Matrix BigOperators ComplexOrder Kronecker
+open Matrix
+
+namespace MPOTensor
+
+/-- Conjugating a block-diagonal matrix by another block-diagonal matrix acts block by block.
+
+Source: bookkeeping lemma, not paper-specific. -/
+private theorem blockDiagonal'_conj {ι : Type*} [Fintype ι] [DecidableEq ι]
+    {m' n' : ι → Type*} [∀ i, Fintype (n' i)]
+    (F : ∀ i, Matrix (m' i) (n' i) ℂ) (G : ∀ i, Matrix (n' i) (n' i) ℂ) :
+    Matrix.blockDiagonal' F * Matrix.blockDiagonal' G * (Matrix.blockDiagonal' F)ᴴ =
+      Matrix.blockDiagonal' fun i => F i * G i * (F i)ᴴ := by
+  rw [Matrix.blockDiagonal'_conjTranspose, ← Matrix.blockDiagonal'_mul,
+    ← Matrix.blockDiagonal'_mul]
+
+/-- A sum, over the physical index `j`, of Kronecker products with a fixed left spectator factor
+`X` reassociates against `finProdFinEquiv` and `Equiv.prodAssoc` to exhibit the sum as `X` tensored
+with the corresponding letter of the product tensor `mulTensor Y Z`. The reindexing equivalence
+`E` is supplied together with a proof that it is this specific composite, so that a caller's own
+named equivalence (defeq to the composite) can be substituted and the conclusion matches the
+caller's goal on the nose.
+
+Source: bookkeeping lemma for the second fusion stage of arXiv:1606.00608, Theorem IV.13(iii),
+lines 986--993. -/
+private theorem kronecker_sum_mulTensor {p a bd1 bd2 : ℕ} (X : Matrix (Fin a) (Fin a) ℂ)
+    (Y : MPOTensor p bd1) (Z : MPOTensor p bd2) (i k : Fin p)
+    (E : Fin a × Fin (bd1 * bd2) ≃ (Fin a × Fin bd1) × Fin bd2)
+    (hE : E = (Equiv.prodCongr (Equiv.refl (Fin a)) finProdFinEquiv.symm).trans
+        (Equiv.prodAssoc (Fin a) (Fin bd1) (Fin bd2)).symm) :
+    (∑ j : Fin p, (X ⊗ₖ Y i j) ⊗ₖ Z j k) =
+      (X ⊗ₖ mulTensor Y Z i k).submatrix E.symm E.symm := by
+  subst hE
+  rw [mulTensor_apply]
+  ext ⟨⟨x1, x2⟩, x3⟩ ⟨⟨y1, y2⟩, y3⟩
+  simp only [Matrix.submatrix_apply, Equiv.symm_trans_apply, Equiv.prodCongr_symm,
+    Equiv.symm_symm, Equiv.prodCongr_apply, Prod.map_apply, Equiv.refl_symm, Equiv.coe_refl,
+    id_eq, Equiv.prodAssoc_apply, Matrix.sum_apply, Matrix.kronecker_apply,
+    Equiv.symm_apply_apply]
+  rw [Finset.mul_sum]
+  refine Finset.sum_congr rfl fun j _ => ?_
+  ring
+
+/-- Reindexing only the row space of a conjugating matrix by an equivalence commutes with the
+conjugation: applying the reindexed matrix is the same as applying the original matrix and then
+reindexing the result on both sides.
+
+Source: bookkeeping lemma, not paper-specific. -/
+private theorem submatrix_left_conj {l m u : Type*} [Fintype l] (A : Matrix m l ℂ)
+    (r : u ≃ m) (X : Matrix l l ℂ) :
+    (A.submatrix r id) * X * (A.submatrix r id)ᴴ = (A * X * Aᴴ).submatrix r r := by
+  have step1 : A.submatrix r id * X = (A * X).submatrix r id :=
+    (Matrix.submatrix_mul A X r id id Function.bijective_id).symm
+  have step2 : (A * X).submatrix r id * (A.submatrix r id)ᴴ =
+      (A * X * Aᴴ).submatrix r r := by
+    rw [Matrix.conjTranspose_submatrix]
+    exact (Matrix.submatrix_mul (A * X) Aᴴ r id r Function.bijective_id).symm
+  rw [step1, step2]
+
+namespace BNTFusionIsometryFamily
+
+variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {p : ℕ}
+variable (Fam : BNTFusionIsometryFamily Λ p)
+
+/-- The reindexing equivalence identifying the bond space of the fusion isometry of `α, β`
+tensored with a spectator label `γ` with the flattened sigma type of `leftFusionIsometry`'s first
+stage. This is the plain distributivity of a sigma type over a product, chosen so that composing
+it with its own inverse cancels on the nose in `blockPiece_apply` and `pairBond_sum_blockDiagonal`.
+
+Source: bookkeeping for arXiv:1606.00608, Theorem IV.13(iii), lines 986--993. -/
+private def pairBondEquiv (α β γ : Λ) :
+    ((δ : Λ) × (Fin (Fam.chi.dim α β δ) × Fin (Fam.bondDim δ))) × Fin (Fam.bondDim γ) ≃
+      (δ : Λ) × (Fin (Fam.chi.dim α β δ) × Fin (Fam.bondDim δ)) × Fin (Fam.bondDim γ) :=
+  Equiv.sigmaProdDistrib (fun δ => Fin (Fam.chi.dim α β δ) × Fin (Fam.bondDim δ))
+    (Fin (Fam.bondDim γ))
+
+/-- The reindexing equivalence identifying the multiplicity factor `Fin (chi.dim α β δ)` tensored
+with the bond space `bondDim δ * bondDim γ` of the fusion isometry of `δ, γ` with the per-block
+product type of `pairBondEquiv`'s target, associated as
+`(Fin (chi.dim α β δ) × Fin (bondDim δ)) × Fin (bondDim γ)`.
+
+Source: bookkeeping for arXiv:1606.00608, Theorem IV.13(iii), lines 986--993. -/
+private def tripleMultEquiv (α β δ γ : Λ) :
+    Fin (Fam.chi.dim α β δ) × Fin (Fam.bondDim δ * Fam.bondDim γ) ≃
+      (Fin (Fam.chi.dim α β δ) × Fin (Fam.bondDim δ)) × Fin (Fam.bondDim γ) :=
+  (Equiv.prodCongr (Equiv.refl (Fin (Fam.chi.dim α β δ))) finProdFinEquiv.symm).trans
+    (Equiv.prodAssoc (Fin (Fam.chi.dim α β δ)) (Fin (Fam.bondDim δ))
+      (Fin (Fam.bondDim γ))).symm
+
+/-- The reindexing equivalence flattening the two-level sigma type produced by fusing `α, β` and
+then `δ, γ` down to a single pair of labels `δ, ε` with their multiplicity indices.
+
+Source: bookkeeping for arXiv:1606.00608, Theorem IV.13(iii), lines 986--993. -/
+private def tripleFlattenEquiv (α β γ : Λ) :
+    (δ : Λ) × Fin (Fam.chi.dim α β δ) × (ε : Λ) × Fin (Fam.chi.dim δ γ ε) ×
+        Fin (Fam.bondDim ε) ≃
+      (δ : Λ) × (ε : Λ) × Fin (Fam.chi.dim α β δ) × Fin (Fam.chi.dim δ γ ε) ×
+        Fin (Fam.bondDim ε) :=
+  Equiv.sigmaCongrRight fun δ =>
+    (Equiv.prodComm (Fin (Fam.chi.dim α β δ))
+        ((ε : Λ) × Fin (Fam.chi.dim δ γ ε) × Fin (Fam.bondDim ε))).trans
+      ((Equiv.sigmaProdDistrib (fun ε => Fin (Fam.chi.dim δ γ ε) × Fin (Fam.bondDim ε))
+          (Fin (Fam.chi.dim α β δ))).trans
+        (Equiv.sigmaCongrRight fun ε =>
+          Equiv.prodComm (Fin (Fam.chi.dim δ γ ε) × Fin (Fam.bondDim ε))
+            (Fin (Fam.chi.dim α β δ))))
+
+/-- The first stage of the left iterated fusion isometry: `fusionIsometry α β` tensored with the
+identity on the bond space of `γ`, reindexed against `γ`'s bond space by `pairBondEquiv` and
+against `Fin (bondDim α * bondDim β * bondDim γ)` by `finProdFinEquiv`, exactly as `mulTensor`
+itself reindexes bond spaces.
+
+Source: arXiv:1606.00608, Theorem IV.13(iii), lines 986--993. -/
+private noncomputable def fuseFirstTwoStep (α β γ : Λ) :
+    Matrix ((δ : Λ) × (Fin (Fam.chi.dim α β δ) × Fin (Fam.bondDim δ)) ×
+        Fin (Fam.bondDim γ))
+      (Fin (Fam.bondDim α * Fam.bondDim β * Fam.bondDim γ)) ℂ :=
+  (Fam.fusionIsometry α β ⊗ₖ
+      (1 : Matrix (Fin (Fam.bondDim γ)) (Fin (Fam.bondDim γ)) ℂ)).submatrix
+    (Fam.pairBondEquiv α β γ).symm finProdFinEquiv.symm
+
+private theorem fuseFirstTwoStep_isometry (α β γ : Λ) :
+    (Fam.fuseFirstTwoStep α β γ)ᴴ * Fam.fuseFirstTwoStep α β γ = 1 := by
+  unfold fuseFirstTwoStep
+  rw [Matrix.conjTranspose_submatrix,
+    Matrix.submatrix_mul_equiv _ _ _ (Fam.pairBondEquiv α β γ).symm _,
+    Matrix.conjTranspose_kronecker, ← Matrix.mul_kronecker_mul, Fam.isometry,
+    Matrix.conjTranspose_one, Matrix.one_mul, Matrix.one_kronecker_one,
+    Matrix.submatrix_one_equiv]
+
+private theorem fuseFirstTwoStep_apply (α β γ : Λ) (i k : Fin p) :
+    Fam.fuseFirstTwoStep α β γ *
+        (mulTensor (mulTensor (Fam.tensor α) (Fam.tensor β)) (Fam.tensor γ)) i k *
+        (Fam.fuseFirstTwoStep α β γ)ᴴ =
+      (∑ j : Fin p,
+          (Matrix.blockDiagonal' fun δ => Fam.chi.matrix α β δ ⊗ₖ Fam.tensor δ i j) ⊗ₖ
+            Fam.tensor γ j k).submatrix (Fam.pairBondEquiv α β γ).symm
+        (Fam.pairBondEquiv α β γ).symm := by
+  unfold fuseFirstTwoStep
+  rw [mulTensor_apply, Matrix.conjTranspose_submatrix,
+    Matrix.submatrix_mul_equiv _ _ _ finProdFinEquiv.symm _,
+    Matrix.submatrix_mul_equiv _ _ _ finProdFinEquiv.symm _]
+  congr 1
+  rw [Matrix.mul_sum, Matrix.sum_mul]
+  refine Finset.sum_congr rfl fun j _ => ?_
+  rw [Matrix.conjTranspose_kronecker, ← Matrix.mul_kronecker_mul, ← Matrix.mul_kronecker_mul,
+    Matrix.one_mul, Matrix.conjTranspose_one, Matrix.mul_one, Fam.fusion]
+
+/-- The second stage of the left iterated fusion isometry, block `δ`: the identity on the
+multiplicity factor `Fin (chi.dim α β δ)` tensored with `fusionIsometry δ γ`, reindexed by
+`tripleMultEquiv` against the block-`δ` fiber of `pairBondEquiv`'s target.
+
+Source: arXiv:1606.00608, Theorem IV.13(iii), lines 986--993. -/
+private noncomputable def blockPiece (α β γ δ : Λ) :
+    Matrix (Fin (Fam.chi.dim α β δ) × (ε : Λ) × Fin (Fam.chi.dim δ γ ε) ×
+        Fin (Fam.bondDim ε))
+      ((Fin (Fam.chi.dim α β δ) × Fin (Fam.bondDim δ)) × Fin (Fam.bondDim γ)) ℂ :=
+  ((1 : Matrix (Fin (Fam.chi.dim α β δ)) (Fin (Fam.chi.dim α β δ)) ℂ) ⊗ₖ
+      Fam.fusionIsometry δ γ).submatrix (Equiv.refl _) (Fam.tripleMultEquiv α β δ γ).symm
+
+private theorem blockPiece_isometry (α β γ δ : Λ) :
+    (Fam.blockPiece α β γ δ)ᴴ * Fam.blockPiece α β γ δ = 1 := by
+  unfold blockPiece
+  rw [Matrix.conjTranspose_submatrix, Matrix.submatrix_mul_equiv _ _ _ (Equiv.refl _) _,
+    Matrix.conjTranspose_kronecker, ← Matrix.mul_kronecker_mul, Fam.isometry,
+    Matrix.conjTranspose_one, Matrix.one_mul, Matrix.one_kronecker_one,
+    Matrix.submatrix_one_equiv]
+
+/-- Conjugating a fixed `δ`-block of the fused pair, summed against the third factor's physical
+index, by `blockPiece` reduces to the fusion identity of `fusionIsometry δ γ` applied to the
+letter `mulTensor (tensor δ) (tensor γ) i k`, with `chi.matrix α β δ` carried through as a
+spectator factor.
+
+Source: arXiv:1606.00608, Theorem IV.13(iii), lines 986--993. -/
+private theorem blockPiece_apply (α β γ δ : Λ) (i k : Fin p) :
+    Fam.blockPiece α β γ δ *
+        (∑ j : Fin p, (Fam.chi.matrix α β δ ⊗ₖ Fam.tensor δ i j) ⊗ₖ
+            Fam.tensor γ j k) *
+        (Fam.blockPiece α β γ δ)ᴴ =
+      Fam.chi.matrix α β δ ⊗ₖ
+        Matrix.blockDiagonal' fun ε => Fam.chi.matrix δ γ ε ⊗ₖ Fam.tensor ε i k := by
+  rw [kronecker_sum_mulTensor _ _ _ _ _ (Fam.tripleMultEquiv α β δ γ) rfl]
+  unfold blockPiece
+  rw [Matrix.conjTranspose_submatrix,
+    Matrix.submatrix_mul_equiv _ _ _ (Fam.tripleMultEquiv α β δ γ).symm _,
+    Matrix.submatrix_mul_equiv _ _ _ (Fam.tripleMultEquiv α β δ γ).symm _,
+    Equiv.coe_refl, Matrix.submatrix_id_id, Matrix.conjTranspose_kronecker,
+    ← Matrix.mul_kronecker_mul, ← Matrix.mul_kronecker_mul, Matrix.one_mul,
+    Matrix.conjTranspose_one, Matrix.mul_one, Fam.fusion]
+
+/-- Flattening the two-level block-diagonal structure produced by fusing `α, β` and then `δ, γ`
+via `tripleFlattenEquiv`: the nested block-diagonal matrix reindexes to the single block-diagonal
+matrix over the pair `(δ, ε)`.
+
+Source: bookkeeping lemma for arXiv:1606.00608, Theorem IV.13(iii), lines 986--993. -/
+private theorem tripleFlatten_blockDiagonal' (α β γ : Λ)
+    (X : ∀ δ, Matrix (Fin (Fam.chi.dim α β δ)) (Fin (Fam.chi.dim α β δ)) ℂ)
+    (Y : ∀ δ ε, Matrix (Fin (Fam.chi.dim δ γ ε)) (Fin (Fam.chi.dim δ γ ε)) ℂ)
+    (T : ∀ ε, Matrix (Fin (Fam.bondDim ε)) (Fin (Fam.bondDim ε)) ℂ) :
+    (Matrix.blockDiagonal' fun δ =>
+        X δ ⊗ₖ Matrix.blockDiagonal' fun ε => Y δ ε ⊗ₖ T ε).submatrix
+        (Fam.tripleFlattenEquiv α β γ).symm (Fam.tripleFlattenEquiv α β γ).symm =
+      Matrix.blockDiagonal' fun δ =>
+        Matrix.blockDiagonal' fun ε => X δ ⊗ₖ (Y δ ε ⊗ₖ T ε) := by
+  ext ⟨δ, ε, m1, m2, b⟩ ⟨δ', ε', m1', m2', b'⟩
+  simp only [Matrix.submatrix_apply, tripleFlattenEquiv, Equiv.symm_trans_apply,
+    Equiv.sigmaCongrRight_symm, Equiv.sigmaCongrRight_apply, Equiv.prodComm_symm,
+    Equiv.prodComm_apply, Equiv.sigmaProdDistrib_symm_apply]
+  by_cases hδ : δ = δ'
+  · subst hδ
+    by_cases hε : ε = ε'
+    · subst hε; simp
+    · simp [Matrix.blockDiagonal'_apply_eq, Matrix.blockDiagonal'_apply_ne _ _ _ hε]
+  · simp [Matrix.blockDiagonal'_apply_ne _ _ _ hδ]
+
+/-- The sum, over the physical index `j`, of the block-diagonal chi-weighted letters produced by
+`fuseFirstTwoStep_apply` reindexes, via `pairBondEquiv`, to the block-diagonal matrix whose block
+`δ` is the corresponding sum carried entirely inside the block.
+
+Source: bookkeeping lemma for arXiv:1606.00608, Theorem IV.13(iii), lines 986--993. -/
+private theorem pairBond_sum_blockDiagonal (α β γ : Λ) (i k : Fin p) :
+    (∑ j : Fin p,
+        (Matrix.blockDiagonal' fun δ => Fam.chi.matrix α β δ ⊗ₖ Fam.tensor δ i j) ⊗ₖ
+          Fam.tensor γ j k).submatrix (Fam.pairBondEquiv α β γ).symm
+        (Fam.pairBondEquiv α β γ).symm =
+      Matrix.blockDiagonal' fun δ =>
+        ∑ j : Fin p, (Fam.chi.matrix α β δ ⊗ₖ Fam.tensor δ i j) ⊗ₖ
+          Fam.tensor γ j k := by
+  ext ⟨δ, m1, m2, b⟩ ⟨δ', m1', m2', b'⟩
+  simp only [Matrix.submatrix_apply, pairBondEquiv, Equiv.sigmaProdDistrib_symm_apply,
+    Matrix.sum_apply, Matrix.kronecker_apply, Matrix.blockDiagonal'_apply]
+  by_cases hδ : δ = δ'
+  · subst hδ; simp
+  · simp [hδ]
+
+private theorem blockDiagonal'_blockPiece_isometry (α β γ : Λ) :
+    (Matrix.blockDiagonal' (Fam.blockPiece α β γ))ᴴ *
+        Matrix.blockDiagonal' (Fam.blockPiece α β γ) = 1 := by
+  rw [Matrix.blockDiagonal'_conjTranspose, ← Matrix.blockDiagonal'_mul]
+  simp_rw [Fam.blockPiece_isometry]
+  exact Matrix.blockDiagonal'_one
+
+/-- **The left iterated fusion isometry** of a triple of labels: apply `fusionIsometry α β` to
+fuse the first two factors, then apply `fusionIsometry δ γ` for each intermediate label `δ` to
+fuse the result with the third factor. Concretely, this composes `fuseFirstTwoStep` (the fusion
+isometry of `α, β` tensored with the identity on `γ`'s bond space, reindexed against
+`Fin (bondDim α * bondDim β * bondDim γ)`) with the block-diagonal family of
+`fusionIsometry δ γ` maps, and flattens the resulting two-level sigma type of intermediate and
+final labels via `tripleFlattenEquiv`.
+
+Source: arXiv:1606.00608, Theorem IV.13(iii), lines 986--993, and the associativity remark, lines
+995--999, of `Papers/1606.00608/MPDO-22-12-17-2.tex`. This is the tensor-level object underlying
+one bracketing of the equation of lines 997--999 relating the two ways of fusing a triple
+product; the source attributes the construction and the classification of solutions of that
+equation to arXiv:1511.08090, not to arXiv:1606.00608 itself. -/
+noncomputable def leftFusionIsometry (α β γ : Λ) :
+    Matrix ((δ : Λ) × (ε : Λ) × Fin (Fam.chi.dim α β δ) × Fin (Fam.chi.dim δ γ ε) ×
+        Fin (Fam.bondDim ε))
+      (Fin (Fam.bondDim α * Fam.bondDim β * Fam.bondDim γ)) ℂ :=
+  (Matrix.blockDiagonal' (Fam.blockPiece α β γ) * Fam.fuseFirstTwoStep α β γ).submatrix
+    (Fam.tripleFlattenEquiv α β γ).symm id
+
+/-- **`leftFusionIsometry` is an isometry**: the composite of the two fusion-isometry stages is
+again an isometry.
+
+Source: arXiv:1606.00608, Theorem IV.13(iii), lines 986--993. -/
+theorem leftFusionIsometry_isometry (α β γ : Λ) :
+    (Fam.leftFusionIsometry α β γ)ᴴ * Fam.leftFusionIsometry α β γ = 1 := by
+  unfold leftFusionIsometry
+  rw [Matrix.conjTranspose_submatrix,
+    Matrix.submatrix_mul_equiv _ _ _ (Fam.tripleFlattenEquiv α β γ).symm _,
+    Matrix.submatrix_id_id, Matrix.conjTranspose_mul]
+  have hreassoc : (Fam.fuseFirstTwoStep α β γ)ᴴ *
+      (Matrix.blockDiagonal' (Fam.blockPiece α β γ))ᴴ *
+      (Matrix.blockDiagonal' (Fam.blockPiece α β γ) * Fam.fuseFirstTwoStep α β γ) =
+      (Fam.fuseFirstTwoStep α β γ)ᴴ *
+      ((Matrix.blockDiagonal' (Fam.blockPiece α β γ))ᴴ *
+        Matrix.blockDiagonal' (Fam.blockPiece α β γ)) * Fam.fuseFirstTwoStep α β γ := by
+    simp only [Matrix.mul_assoc]
+  rw [hreassoc, Fam.blockDiagonal'_blockPiece_isometry, Matrix.mul_one,
+    Fam.fuseFirstTwoStep_isometry]
+
+/-- **`leftFusionIsometry` conjugates the triple product tensor onto a doubly block-diagonal
+tensor**: applying `leftFusionIsometry α β γ` to a letter of the triple product tensor
+`mulTensor (mulTensor (tensor α) (tensor β)) (tensor γ)` gives the tensor block-diagonal in the
+intermediate label `δ` and the final label `ε`, with block `(δ, ε)` equal to the chi matrices
+`χ_{α,β,δ}` and `χ_{δ,γ,ε}` tensored with the letter of the tensor of label `ε`.
+
+This is the tensor-level refinement, for the left bracketing `(M_α M_β) M_γ` of the triple
+product, of the associativity remark following Theorem IV.13(iii) (lines 995--999): the source
+observes that associativity of the product constrains the chi coefficients and, via the isometry
+statement (Ualphabeta), gives an equation relating the fusion isometries of the two bracketings
+of a triple product, attributing the construction of that equation to arXiv:1511.08090. This
+theorem stays within the source's own objects and records one concrete conjugation identity that
+such an equation would relate to the corresponding identity for the right bracketing
+`M_α (M_β M_γ)`; that comparison is left to a follow-up.
+
+The block content is stated as `χ_{α,β,δ} ⊗ (χ_{δ,γ,ε} ⊗ tensor_ε^{ij})`, right-associated in
+the Kronecker product, rather than the left-associated
+`(χ_{α,β,δ} ⊗ χ_{δ,γ,ε}) ⊗ tensor_ε^{ij}`: a harmless reassociation of the same three factors in
+the same order, forced by the natural bond splitting of `mulTensor`.
+
+Source: arXiv:1606.00608, Theorem IV.13(iii), lines 986--993, and the associativity remark, lines
+995--999, of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem leftFusion_apply (α β γ : Λ) (i k : Fin p) :
+    Fam.leftFusionIsometry α β γ *
+        (mulTensor (mulTensor (Fam.tensor α) (Fam.tensor β)) (Fam.tensor γ)) i k *
+        (Fam.leftFusionIsometry α β γ)ᴴ =
+      Matrix.blockDiagonal' fun δ => Matrix.blockDiagonal' fun ε =>
+        Fam.chi.matrix α β δ ⊗ₖ (Fam.chi.matrix δ γ ε ⊗ₖ Fam.tensor ε i k) := by
+  unfold leftFusionIsometry
+  rw [submatrix_left_conj]
+  have hreassoc :
+      Matrix.blockDiagonal' (Fam.blockPiece α β γ) * Fam.fuseFirstTwoStep α β γ *
+          (mulTensor (mulTensor (Fam.tensor α) (Fam.tensor β)) (Fam.tensor γ)) i k *
+          (Matrix.blockDiagonal' (Fam.blockPiece α β γ) * Fam.fuseFirstTwoStep α β γ)ᴴ =
+        Matrix.blockDiagonal' (Fam.blockPiece α β γ) *
+          (Fam.fuseFirstTwoStep α β γ *
+              (mulTensor (mulTensor (Fam.tensor α) (Fam.tensor β)) (Fam.tensor γ)) i k *
+              (Fam.fuseFirstTwoStep α β γ)ᴴ) *
+          (Matrix.blockDiagonal' (Fam.blockPiece α β γ))ᴴ := by
+    rw [Matrix.conjTranspose_mul]
+    simp only [Matrix.mul_assoc]
+  rw [hreassoc, Fam.fuseFirstTwoStep_apply, Fam.pairBond_sum_blockDiagonal, blockDiagonal'_conj]
+  simp_rw [Fam.blockPiece_apply]
+  rw [tripleFlatten_blockDiagonal']
+
+end BNTFusionIsometryFamily
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -281,3 +281,68 @@ them.
     taking the trace block by block and factor by factor yields the
     coefficients $\operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{L})$.
 \end{proof}
+
+The associativity of the algebra product of \cite[eq:algebra]{Cirac2016MPDO_arXiv}
+constrains the diagonal matrices $\chi_{\alpha,\beta,\gamma}$ and, through the
+isometry statement, induces a compatibility equation between the fusion
+isometries of the two ways of bracketing a triple product,
+$(M_\alpha M_\beta) M_\gamma$ and $M_\alpha (M_\beta M_\gamma)$
+\cite[lines~995--999]{Cirac2016MPDO_arXiv}. The source attributes the
+construction of that equation, and the classification of its solutions, to
+\cite{Bultinck2017Anyons}. The next definition and theorems record the
+tensor-level content of one bracketing, $(M_\alpha M_\beta) M_\gamma$: fusing
+the first two tensors and then fusing the result with the third.
+
+\begin{definition}[Iterated fusion isometry of a triple product, left
+        bracketing]%
+    \label{def:mpdo_left_fusion_isometry}
+    \lean{MPOTensor.BNTFusionIsometryFamily.leftFusionIsometry}
+    \leanok
+    \uses{def:mpdo_bnt_fusion_isometry_family}
+    For labels $\alpha, \beta, \gamma$, the \emph{left iterated fusion
+        isometry} $U^{\mathrm L}_{\alpha,\beta,\gamma}$ is obtained by applying
+    $U_{\alpha,\beta}$ (tensored with the identity on the bond space of
+    $M_\gamma$) to fuse the first two tensors, then applying $U_{\delta,\gamma}$,
+    for each label $\delta$ appearing in the resulting direct sum, to fuse
+    the outcome with the third tensor. Its domain is indexed by pairs of
+    labels $(\delta, \varepsilon)$ together with the multiplicity indices of
+    $\chi_{\alpha,\beta,\delta}$ and $\chi_{\delta,\gamma,\varepsilon}$.
+\end{definition}
+
+\begin{theorem}[The left iterated fusion isometry is an isometry]%
+    \label{thm:mpdo_left_fusion_isometry_isometry}
+    \lean{MPOTensor.BNTFusionIsometryFamily.leftFusionIsometry_isometry}
+    \leanok
+    \uses{def:mpdo_left_fusion_isometry}
+    $(U^{\mathrm L}_{\alpha,\beta,\gamma})^\dagger
+        U^{\mathrm L}_{\alpha,\beta,\gamma} = 1$.
+\end{theorem}
+\begin{proof}\leanok
+    The composite of two isometries is an isometry.
+\end{proof}
+
+\begin{theorem}[The left iterated fusion isometry conjugates a triple product
+        onto a doubly weighted direct sum]%
+    \label{thm:mpdo_left_fusion_apply}
+    \lean{MPOTensor.BNTFusionIsometryFamily.leftFusion_apply}
+    \leanok
+    \uses{def:mpdo_left_fusion_isometry, def:mpdo_operator_product}
+    Site by site,
+    \[
+        U^{\mathrm L}_{\alpha,\beta,\gamma}\,
+        \bigl((M_\alpha M_\beta) M_\gamma\bigr)^{i j}\,
+        (U^{\mathrm L}_{\alpha,\beta,\gamma})^\dagger
+        = \bigoplus_{\delta} \bigoplus_{\varepsilon}
+        \chi_{\alpha,\beta,\delta}
+        \otimes \bigl(\chi_{\delta,\gamma,\varepsilon} \otimes
+        M_\varepsilon^{i j}\bigr).
+    \]
+\end{theorem}
+\begin{proof}\leanok
+    Apply the fusion identity for $U_{\alpha,\beta}$ to the first two
+    tensors, summed against the physical index contracting with the third
+    tensor; regrouping the resulting sum block by block over $\delta$
+    exhibits it as $\chi_{\alpha,\beta,\delta}$ tensored with a letter of the
+    product tensor $M_\delta M_\gamma$, to which the fusion identity for
+    $U_{\delta,\gamma}$ applies.
+\end{proof}


### PR DESCRIPTION
## Calibration

arXiv:1606.00608, Theorem IV.13(iii) (label Ualphabeta, lines 986-993 of
`Papers/1606.00608/MPDO-22-12-17-2.tex`) gives an isometry `U_{alpha,beta}`
conjugating the product tensor of a pair of labelled tensors onto a
chi-weighted direct sum. The remark following the theorem (lines 995-999)
observes that associativity of the algebra product constrains the chi
coefficients and, via the isometry statement, gives an equation relating the
fusion isometries of the two ways of bracketing a triple product. The source
attributes the construction of that equation, and the classification of its
solutions, to Bultinck-Marien-Williamson-Sahinoglu-Haegeman-Verstraete 2015
(arXiv:1511.08090) -- arXiv:1606.00608 itself does not spell out that
equation.

This PR is **not** a formalization of that equation. It formalizes the more
modest, directly-grounded next step: the tensor-level content of applying
the fusion identity **twice**, for **one** bracketing of a triple product
`(M_alpha M_beta) M_gamma`. It stays entirely within Cirac-Perez-Garcia-
Schuch-Verstraete's own objects (`chi`, `fusionIsometry`, `tensor`,
`mulTensor`); no new structure, category, or notion of "F-symbol" is
introduced.

## What is proved (full scope, no fallback needed)

New file `TNLean/MPS/MPDO/BNTTripleFusion.lean`, additive only:

- `MPOTensor.BNTFusionIsometryFamily.leftFusionIsometry alpha beta gamma`:
  the left iterated fusion isometry -- apply `fusionIsometry alpha beta` to
  fuse the first two factors, then apply `fusionIsometry delta gamma`, for
  each intermediate label `delta`, to fuse the result with the third factor.
- `leftFusionIsometry_isometry`: it is an isometry
  (`U^dagger U = 1`).
- `leftFusion_apply`: it conjugates the triple product tensor
  `mulTensor (mulTensor (tensor alpha) (tensor beta)) (tensor gamma)` onto
  the doubly block-diagonal tensor indexed by `(delta, epsilon)` with block
  `chi_{alpha,beta,delta} (x) (chi_{delta,gamma,epsilon} (x) tensor_epsilon^{ij})`
  -- right-associated in the Kronecker product (a harmless reassociation of
  the same three factors in the same order, forced by `mulTensor`'s own bond
  splitting; documented in the theorem's docstring).

All three private/general-purpose helper lemmas (reindexing bookkeeping,
block-diagonal/Kronecker distributivity, associativity reshuffling) are
proved with no `sorry` and no new axioms. `lake build` (full project,
9327 jobs) is green.

## What was deferred

Per the task instructions, defining a "right fusion" composite (fusing
`beta, gamma` first, then `alpha`) or any comparison/intertwiner between the
two bracketings is explicitly **not** attempted here -- that comparison is
exactly the content of the equation at lines 997-999 and belongs to a
follow-up. `#3764` ("Mathlib inventory for Hopf algebras, the pentagon
equation, and fusion categories") already scopes that broader program; this
PR supplies the "bounded" step 1 that scout identified (double-fusion
composites on one bracketing) but does not close it, and is not a fix for
that issue.

## Verification

- `lake build TNLean.MPS.MPDO.BNTTripleFusion` and full `lake build`: green,
  zero `sorry`/`axiom`.
- `leanblueprint pdf`, `leanblueprint web`, `leanblueprint checkdecls`: pass.
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main --ci`:
  clean.
- `python3 scripts/blueprint_lean_sync.py --diff-base origin/main --ci`
  reports pre-existing sync noise from the PEPS chapter
  (`\input{chapter/ch24_peps_ft}` is commented out in
  `blueprint/src/content.tex`, so its `\lean{}` tags never reach the
  generated `lean_decls`). Verified this is unconditional on my diff: the
  same script run against a clean `origin/main` (my changes stashed out)
  reports the same class of issue. Not touched by this PR.
- `latexindent -w -s -l blueprint/latexindent.yaml` applied to the changed
  `.tex` file; no `.bak`/`indent.log` files committed.
- All lines <= 100 characters; copyright header matches
  `OperatorProduct.lean`.

Advances the discussion following Theorem IV.13(iii), lines 995-999.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Mathlib formalization and blueprint sync only; no changes to auth, runtime, or existing fusion APIs beyond new exports.
> 
> **Overview**
> Adds **`TNLean/MPS/MPDO/BNTTripleFusion.lean`** on top of `BNTFusionIsometryFamily`, formalizing the **left bracketing** \((M_\alpha M_\beta) M_\gamma\) from Cirac et al. (arXiv:1606.00608): **`leftFusionIsometry`** (fuse \(\alpha,\beta\) then \(\delta,\gamma\) per intermediate \(\delta\)), **`leftFusionIsometry_isometry`**, and **`leftFusion_apply`** (triple product letters conjugate to a doubly block-diagonal \(\chi\)–tensor form). Private lemmas handle Kronecker/block-diagonal reindexing; the **right bracketing / pentagon-style compatibility** is explicitly out of scope.
> 
> **`TNLean.lean`** imports the new module. **Blueprint** `ch21_mpdo_rfp_fusion_isometries.tex` adds definition **`def:mpdo_left_fusion_isometry`** and linked theorems with `\lean{}` tags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d98b74324a654563bf32bc9e68c4976a1aac8cf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->