### PR TITLE
feat(MPS/MPDO): localize physical sector channels

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -406,6 +406,7 @@ import TNLean.MPS.MPDO.PhysicalSectorCoarseGrainingAction
 import TNLean.MPS.MPDO.PhysicalSectorCoarseGrainingIdentity
 import TNLean.MPS.MPDO.PhysicalSectorRefinementAction
 import TNLean.MPS.MPDO.PhysicalSectorRefinementIdentity
+import TNLean.MPS.MPDO.PhysicalSectorPhysicalMaps
 import TNLean.MPS.MPDO.SectorPairingTransfer
 import TNLean.MPS.MPDO.SectorEtaContraction
 import TNLean.MPS.MPDO.SectorEtaOperator

--- a/TNLean/MPS/MPDO/PhysicalSectorPhysicalMaps.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorPhysicalMaps.lean
@@ -1,0 +1,329 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.LocalizedKrausCPTP
+import TNLean.MPS.MPDO.PhysicalBlocking
+import TNLean.MPS.MPDO.PhysicalSectorCoarseGrainingIdentity
+import TNLean.MPS.MPDO.PhysicalSectorRefinementIdentity
+
+/-!
+# Physical-coordinate refinement and coarse-graining channels
+
+This file transports the sector-coordinate channels of Proposition C.7 to
+the ordinary, right-associated physical coordinates of the sector tensor.
+It also localizes the transported channels on the first tensor factors while
+leaving the last physical site unchanged.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, lines 1510--1516 and 1522--1563
+-/
+
+open scoped Matrix
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D} {F : PhysicalSectorFactorization K}
+
+/-- The refinement channel in the ordinary right-associated physical
+coordinates of the sector tensor.
+
+Source: arXiv:1606.00608, Proposition C.7, Appendix C.2, lines 1510--1516 and
+1522--1545. -/
+noncomputable def NeighboringTraceFactorization.physicalTMap
+    (H : NeighboringTraceFactorization F) :
+    Matrix (Fin (Fintype.card (SectorSiteIndex F)) ×
+        Fin (Fintype.card (SectorSiteIndex F)))
+      (Fin (Fintype.card (SectorSiteIndex F)) ×
+        Fin (Fintype.card (SectorSiteIndex F))) ℂ →ₗ[ℂ]
+    Matrix (Fin (Fintype.card (SectorSiteIndex F)) ×
+        (Fin (Fintype.card (SectorSiteIndex F)) ×
+          Fin (Fintype.card (SectorSiteIndex F))))
+      (Fin (Fintype.card (SectorSiteIndex F)) ×
+        (Fin (Fintype.card (SectorSiteIndex F)) ×
+          Fin (Fintype.card (SectorSiteIndex F)))) ℂ :=
+  Matrix.equivReindexMap F.threeSiteSectorCoordinateEquiv.symm ∘ₗ
+    H.tMap ∘ₗ Matrix.equivReindexMap F.twoSiteSectorCoordinateEquiv
+
+/-- The physical-coordinate refinement channel is trace-preserving and
+completely positive.
+
+Source: arXiv:1606.00608, Proposition C.7, Appendix C.2, lines 1522--1545. -/
+theorem NeighboringTraceFactorization.physicalTMap_isKrausCPTP
+    (H : NeighboringTraceFactorization F) : IsKrausCPTP H.physicalTMap := by
+  exact isKrausCPTP_comp
+    (isKrausCPTP_comp
+      (Matrix.equivReindexMap_isKrausCPTP F.twoSiteSectorCoordinateEquiv)
+      H.tMap_isKrausCPTP)
+    (Matrix.equivReindexMap_isKrausCPTP F.threeSiteSectorCoordinateEquiv.symm)
+
+/-- The physical-coordinate refinement channel sends the two-site closure of
+the sector tensor to its three-site closure.
+
+**Local fix (zero-weight quotient):** this identity inherits the completed
+zero-weight preparation branch of the sector-coordinate refinement channel.
+Documented in
+`docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex`.
+
+Source: arXiv:1606.00608, Proposition C.7, Appendix C.2, lines 1510--1516 and
+1522--1545. -/
+theorem NeighboringTraceFactorization.physicalTMap_twoSiteClosure_eq_threeSiteClosure
+    (H : NeighboringTraceFactorization F) (X : Matrix (Fin D) (Fin D) ℂ) :
+    H.physicalTMap (physClose2 F.sectorCoordinateTensor X) =
+      physClose3 F.sectorCoordinateTensor X := by
+  change
+    Matrix.reindex F.threeSiteSectorCoordinateEquiv.symm
+        F.threeSiteSectorCoordinateEquiv.symm
+        (H.tMap
+          (Matrix.reindex F.twoSiteSectorCoordinateEquiv
+            F.twoSiteSectorCoordinateEquiv
+            (physClose2 F.sectorCoordinateTensor X))) =
+      physClose3 F.sectorCoordinateTensor X
+  rw [H.tMap_twoSiteClosure_eq_threeSiteClosure]
+  exact (Matrix.reindexLinearEquiv ℂ ℂ F.threeSiteSectorCoordinateEquiv
+    F.threeSiteSectorCoordinateEquiv).symm_apply_apply
+      (physClose3 F.sectorCoordinateTensor X)
+
+/-- The coarse-graining channel in the ordinary right-associated physical
+coordinates of the sector tensor.
+
+Source: arXiv:1606.00608, Proposition C.7, Appendix C.2, lines 1547--1563. -/
+noncomputable def NeighboringTraceFactorization.physicalSMap
+    (H : NeighboringTraceFactorization F) :
+    Matrix (Fin (Fintype.card (SectorSiteIndex F)) ×
+        (Fin (Fintype.card (SectorSiteIndex F)) ×
+          Fin (Fintype.card (SectorSiteIndex F))))
+      (Fin (Fintype.card (SectorSiteIndex F)) ×
+        (Fin (Fintype.card (SectorSiteIndex F)) ×
+          Fin (Fintype.card (SectorSiteIndex F)))) ℂ →ₗ[ℂ]
+    Matrix (Fin (Fintype.card (SectorSiteIndex F)) ×
+        Fin (Fintype.card (SectorSiteIndex F)))
+      (Fin (Fintype.card (SectorSiteIndex F)) ×
+        Fin (Fintype.card (SectorSiteIndex F))) ℂ :=
+  Matrix.equivReindexMap F.twoSiteSectorCoordinateEquiv.symm ∘ₗ
+    H.sMap ∘ₗ Matrix.equivReindexMap F.threeSiteSectorCoordinateEquiv
+
+/-- The physical-coordinate coarse-graining channel is trace-preserving and
+completely positive.
+
+Source: arXiv:1606.00608, Proposition C.7, Appendix C.2, lines 1547--1563. -/
+theorem NeighboringTraceFactorization.physicalSMap_isKrausCPTP
+    (H : NeighboringTraceFactorization F) : IsKrausCPTP H.physicalSMap := by
+  exact isKrausCPTP_comp
+    (isKrausCPTP_comp
+      (Matrix.equivReindexMap_isKrausCPTP F.threeSiteSectorCoordinateEquiv)
+      H.sMap_isKrausCPTP)
+    (Matrix.equivReindexMap_isKrausCPTP F.twoSiteSectorCoordinateEquiv.symm)
+
+/-- The physical-coordinate coarse-graining channel sends the three-site
+closure of the sector tensor to its two-site closure.
+
+Source: arXiv:1606.00608, Proposition C.7, Appendix C.2, lines 1547--1563. -/
+theorem NeighboringTraceFactorization.physicalSMap_threeSiteClosure_eq_twoSiteClosure
+    (H : NeighboringTraceFactorization F) (X : Matrix (Fin D) (Fin D) ℂ) :
+    H.physicalSMap (physClose3 F.sectorCoordinateTensor X) =
+      physClose2 F.sectorCoordinateTensor X := by
+  change
+    Matrix.reindex F.twoSiteSectorCoordinateEquiv.symm
+        F.twoSiteSectorCoordinateEquiv.symm
+        (H.sMap
+          (Matrix.reindex F.threeSiteSectorCoordinateEquiv
+            F.threeSiteSectorCoordinateEquiv
+            (physClose3 F.sectorCoordinateTensor X))) =
+      physClose2 F.sectorCoordinateTensor X
+  rw [H.sMap_threeSiteClosure_eq_twoSiteClosure]
+  exact (Matrix.reindexLinearEquiv ℂ ℂ F.twoSiteSectorCoordinateEquiv
+    F.twoSiteSectorCoordinateEquiv).symm_apply_apply
+      (physClose2 F.sectorCoordinateTensor X)
+
+/-! ### Localization on the first physical sites -/
+
+/-- Reassociate three right-associated sites so that the first two form the
+first tensor factor and the last site is unchanged. -/
+def threeSiteFirstTwoEquiv (α : Type*) : α × (α × α) ≃ (α × α) × α where
+  toFun x := ((x.1, x.2.1), x.2.2)
+  invFun x := (x.1.1, (x.1.2, x.2))
+  left_inv _ := rfl
+  right_inv _ := rfl
+
+/-- Reassociate four right-associated sites so that the first three form the
+first tensor factor and the last site is unchanged. -/
+def fourSiteFirstThreeEquiv (α : Type*) :
+    α × (α × (α × α)) ≃ (α × (α × α)) × α where
+  toFun x := ((x.1, (x.2.1, x.2.2.1)), x.2.2.2)
+  invFun x := (x.1.1, (x.1.2.1, (x.1.2.2, x.2)))
+  left_inv _ := rfl
+  right_inv _ := rfl
+
+/-- The refinement channel acting on the first two sites of a right-associated
+three-site matrix, with the last physical site unchanged.
+
+Source: arXiv:1606.00608, Proposition C.7, Appendix C.2, lines 1510--1516 and
+1522--1545; Theorem 4.9, lines 851--856. -/
+noncomputable def NeighboringTraceFactorization.localizedPhysicalTMap
+    (H : NeighboringTraceFactorization F) :
+    Matrix (Fin (Fintype.card (SectorSiteIndex F)) ×
+        (Fin (Fintype.card (SectorSiteIndex F)) ×
+          Fin (Fintype.card (SectorSiteIndex F))))
+      (Fin (Fintype.card (SectorSiteIndex F)) ×
+        (Fin (Fintype.card (SectorSiteIndex F)) ×
+          Fin (Fintype.card (SectorSiteIndex F)))) ℂ →ₗ[ℂ]
+    Matrix (Fin (Fintype.card (SectorSiteIndex F)) ×
+        (Fin (Fintype.card (SectorSiteIndex F)) ×
+          (Fin (Fintype.card (SectorSiteIndex F)) ×
+            Fin (Fintype.card (SectorSiteIndex F)))))
+      (Fin (Fintype.card (SectorSiteIndex F)) ×
+        (Fin (Fintype.card (SectorSiteIndex F)) ×
+          (Fin (Fintype.card (SectorSiteIndex F)) ×
+            Fin (Fintype.card (SectorSiteIndex F))))) ℂ :=
+  Matrix.equivReindexMap
+      (fourSiteFirstThreeEquiv
+        (Fin (Fintype.card (SectorSiteIndex F)))).symm ∘ₗ
+    Matrix.tensorMapIdLM
+      (δ := Fin (Fintype.card (SectorSiteIndex F))) H.physicalTMap ∘ₗ
+    Matrix.equivReindexMap
+      (threeSiteFirstTwoEquiv (Fin (Fintype.card (SectorSiteIndex F))))
+
+/-- The localized physical-coordinate refinement channel is trace-preserving
+and completely positive.
+
+Source: arXiv:1606.00608, Proposition C.7, Appendix C.2, lines 1510--1516 and
+1522--1545; Theorem 4.9, lines 851--856. -/
+theorem NeighboringTraceFactorization.localizedPhysicalTMap_isKrausCPTP
+    (H : NeighboringTraceFactorization F) :
+    IsKrausCPTP H.localizedPhysicalTMap := by
+  exact isKrausCPTP_comp
+    (isKrausCPTP_comp
+      (Matrix.equivReindexMap_isKrausCPTP
+        (threeSiteFirstTwoEquiv (Fin (Fintype.card (SectorSiteIndex F)))))
+      (Matrix.tensorMapIdLM_isKrausCPTP H.physicalTMap_isKrausCPTP))
+    (Matrix.equivReindexMap_isKrausCPTP
+      (fourSiteFirstThreeEquiv
+        (Fin (Fintype.card (SectorSiteIndex F)))).symm)
+
+/-- Applying the refinement channel to the first two sites of a three-site
+closure produces the four-site closure, while the last physical site is left
+unchanged.
+
+**Local fix (zero-weight quotient):** this action inherits the completed
+zero-weight preparation branch of the refinement channel. Documented in
+`docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex`.
+
+Source: arXiv:1606.00608, Proposition C.7, Appendix C.2, lines 1510--1516 and
+1522--1545; Theorem 4.9, lines 851--856. -/
+theorem NeighboringTraceFactorization.localizedPhysicalTMap_threeSiteClosure_eq_fourSiteClosure
+    (H : NeighboringTraceFactorization F) (X : Matrix (Fin D) (Fin D) ℂ) :
+    H.localizedPhysicalTMap (physClose3 F.sectorCoordinateTensor X) =
+      physClose4 F.sectorCoordinateTensor X := by
+  ext ⟨i₁, i₂, i₃, i₄⟩ ⟨j₁, j₂, j₃, j₄⟩
+  change H.physicalTMap
+      (Matrix.bipartiteSlice
+        (Matrix.reindex (threeSiteFirstTwoEquiv
+          (Fin (Fintype.card (SectorSiteIndex F))))
+          (threeSiteFirstTwoEquiv
+            (Fin (Fintype.card (SectorSiteIndex F))))
+          (physClose3 F.sectorCoordinateTensor X)) i₄ j₄)
+      (i₁, (i₂, i₃)) (j₁, (j₂, j₃)) =
+    physClose4 F.sectorCoordinateTensor X
+      (i₁, (i₂, (i₃, i₄))) (j₁, (j₂, (j₃, j₄)))
+  rw [show Matrix.bipartiteSlice
+      (Matrix.reindex (threeSiteFirstTwoEquiv
+        (Fin (Fintype.card (SectorSiteIndex F))))
+        (threeSiteFirstTwoEquiv
+          (Fin (Fintype.card (SectorSiteIndex F))))
+        (physClose3 F.sectorCoordinateTensor X))
+      i₄ j₄ =
+      physClose2 F.sectorCoordinateTensor
+        (F.sectorCoordinateTensor i₄ j₄ * X) by
+      ext a b
+      simp [Matrix.bipartiteSlice, threeSiteFirstTwoEquiv,
+        Matrix.reindex_apply, Matrix.mul_assoc]]
+  rw [H.physicalTMap_twoSiteClosure_eq_threeSiteClosure]
+  simp [physClose3_apply, physClose4_apply, Matrix.mul_assoc]
+
+/-- The coarse-graining channel acting on the first three sites of a
+right-associated four-site matrix, with the last physical site unchanged.
+
+Source: arXiv:1606.00608, Proposition C.7, Appendix C.2, lines 1510--1516 and
+1547--1563; Theorem 4.9, lines 851--856. -/
+noncomputable def NeighboringTraceFactorization.localizedPhysicalSMap
+    (H : NeighboringTraceFactorization F) :
+    Matrix (Fin (Fintype.card (SectorSiteIndex F)) ×
+        (Fin (Fintype.card (SectorSiteIndex F)) ×
+          (Fin (Fintype.card (SectorSiteIndex F)) ×
+            Fin (Fintype.card (SectorSiteIndex F)))))
+      (Fin (Fintype.card (SectorSiteIndex F)) ×
+        (Fin (Fintype.card (SectorSiteIndex F)) ×
+          (Fin (Fintype.card (SectorSiteIndex F)) ×
+            Fin (Fintype.card (SectorSiteIndex F))))) ℂ →ₗ[ℂ]
+    Matrix (Fin (Fintype.card (SectorSiteIndex F)) ×
+        (Fin (Fintype.card (SectorSiteIndex F)) ×
+          Fin (Fintype.card (SectorSiteIndex F))))
+      (Fin (Fintype.card (SectorSiteIndex F)) ×
+        (Fin (Fintype.card (SectorSiteIndex F)) ×
+          Fin (Fintype.card (SectorSiteIndex F)))) ℂ :=
+  Matrix.equivReindexMap
+      (threeSiteFirstTwoEquiv
+        (Fin (Fintype.card (SectorSiteIndex F)))).symm ∘ₗ
+    Matrix.tensorMapIdLM
+      (δ := Fin (Fintype.card (SectorSiteIndex F))) H.physicalSMap ∘ₗ
+    Matrix.equivReindexMap
+      (fourSiteFirstThreeEquiv (Fin (Fintype.card (SectorSiteIndex F))))
+
+/-- The localized physical-coordinate coarse-graining channel is
+trace-preserving and completely positive.
+
+Source: arXiv:1606.00608, Proposition C.7, Appendix C.2, lines 1510--1516 and
+1547--1563; Theorem 4.9, lines 851--856. -/
+theorem NeighboringTraceFactorization.localizedPhysicalSMap_isKrausCPTP
+    (H : NeighboringTraceFactorization F) :
+    IsKrausCPTP H.localizedPhysicalSMap := by
+  exact isKrausCPTP_comp
+    (isKrausCPTP_comp
+      (Matrix.equivReindexMap_isKrausCPTP
+        (fourSiteFirstThreeEquiv (Fin (Fintype.card (SectorSiteIndex F)))))
+      (Matrix.tensorMapIdLM_isKrausCPTP H.physicalSMap_isKrausCPTP))
+    (Matrix.equivReindexMap_isKrausCPTP
+      (threeSiteFirstTwoEquiv
+        (Fin (Fintype.card (SectorSiteIndex F)))).symm)
+
+/-- Applying the coarse-graining channel to the first three sites of a
+four-site closure recovers the three-site closure, while the last physical
+site is left unchanged.
+
+Source: arXiv:1606.00608, Proposition C.7, Appendix C.2, lines 1510--1516 and
+1547--1563; Theorem 4.9, lines 851--856. -/
+theorem NeighboringTraceFactorization.localizedPhysicalSMap_fourSiteClosure_eq_threeSiteClosure
+    (H : NeighboringTraceFactorization F) (X : Matrix (Fin D) (Fin D) ℂ) :
+    H.localizedPhysicalSMap (physClose4 F.sectorCoordinateTensor X) =
+      physClose3 F.sectorCoordinateTensor X := by
+  ext ⟨i₁, i₂, i₃⟩ ⟨j₁, j₂, j₃⟩
+  change H.physicalSMap
+      (Matrix.bipartiteSlice
+        (Matrix.reindex (fourSiteFirstThreeEquiv
+          (Fin (Fintype.card (SectorSiteIndex F))))
+          (fourSiteFirstThreeEquiv
+            (Fin (Fintype.card (SectorSiteIndex F))))
+          (physClose4 F.sectorCoordinateTensor X)) i₃ j₃)
+      (i₁, i₂) (j₁, j₂) =
+    physClose3 F.sectorCoordinateTensor X
+      (i₁, (i₂, i₃)) (j₁, (j₂, j₃))
+  rw [show Matrix.bipartiteSlice
+      (Matrix.reindex (fourSiteFirstThreeEquiv
+        (Fin (Fintype.card (SectorSiteIndex F))))
+        (fourSiteFirstThreeEquiv
+          (Fin (Fintype.card (SectorSiteIndex F))))
+        (physClose4 F.sectorCoordinateTensor X))
+      i₃ j₃ =
+      physClose3 F.sectorCoordinateTensor
+        (F.sectorCoordinateTensor i₃ j₃ * X) by
+      ext a b
+      simp [Matrix.bipartiteSlice, fourSiteFirstThreeEquiv,
+        Matrix.reindex_apply, physClose4_apply, Matrix.mul_assoc]]
+  rw [H.physicalSMap_threeSiteClosure_eq_twoSiteClosure]
+  simp [physClose2_apply, physClose3_apply, Matrix.mul_assoc]
+
+end MPOTensor.PhysicalSectorFactorization

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -3294,6 +3294,212 @@ strong subadditivity for a normalized three-site reduced state.
     \]
 \end{proof}
 
+For the following construction, through
+Theorem~\ref{thm:mpdo_localized_physical_s_closure_identity}, assume the
+neighboring-operator trace factorization of
+Definition~\ref{def:mpdo_neighboring_trace_factorization}. Write
+\[
+  q=\dim\!\left(\bigoplus_k L_k\otimes R_k\right)
+\]
+for the physical dimension of the sector-coordinate tensor
+$\widehat{\cal K}$.
+
+\begin{definition}[Refinement in ordinary physical coordinates]
+    \label{def:mpdo_physical_t_map}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.physicalTMap}
+    \leanok
+    \uses{def:mpdo_physical_sector_t_map,
+      def:mpdo_physical_sector_closure_coordinates}
+    Transporting $\mathcal T$ through the canonical two-site and three-site
+    coordinate identifications gives a channel
+    \[
+      \widehat{\mathcal T}:M_{q^2}(\mathbb C)\longrightarrow
+        M_{q^3}(\mathbb C),
+    \]
+    where all multiple physical indices are associated to the right.
+\end{definition}
+
+\begin{theorem}[The physical refinement map is a channel]
+    \label{thm:mpdo_physical_t_map_cptp}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.physicalTMap_isKrausCPTP}
+    \leanok
+    \uses{def:mpdo_physical_t_map}
+    The map $\widehat{\mathcal T}$ is trace-preserving and completely
+    positive.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_physical_sector_t_map_cptp}
+    The coordinate identifications are unitary permutation channels.
+    Composing them with a trace-preserving completely positive map preserves
+    both properties.
+\end{proof}
+
+% **Local fix (zero-weight quotient):** this identity uses the completed
+% zero-weight preparation. Documented in
+% docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex.
+\begin{theorem}[Refinement identity in ordinary physical coordinates]
+    \label{thm:mpdo_physical_t_closure_identity}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.physicalTMap_twoSiteClosure_eq_threeSiteClosure}
+    \leanok
+    \uses{def:mpdo_physical_t_map}
+    For every virtual matrix $X$,
+    \[
+      \widehat{\mathcal T}\bigl(\widehat{\cal K}_2(X)\bigr)
+      =\widehat{\cal K}_3(X).
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_physical_sector_t_closure_identity}
+    Transport the sector-coordinate identity through the inverse three-site
+    coordinate identification.
+\end{proof}
+
+\begin{definition}[Physical coarse-graining]
+    \label{def:mpdo_physical_s_map}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.physicalSMap}
+    \leanok
+    \uses{def:mpdo_physical_sector_s_map,
+      def:mpdo_physical_sector_closure_coordinates}
+    Transporting $\mathcal S$ through the canonical three-site and two-site
+    coordinate identifications gives a channel
+    \[
+      \widehat{\mathcal S}:M_{q^3}(\mathbb C)\longrightarrow
+        M_{q^2}(\mathbb C).
+    \]
+\end{definition}
+
+\begin{theorem}[The physical coarse-graining map is a channel]
+    \label{thm:mpdo_physical_s_map_cptp}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.physicalSMap_isKrausCPTP}
+    \leanok
+    \uses{def:mpdo_physical_s_map}
+    The map $\widehat{\mathcal S}$ is trace-preserving and completely
+    positive.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_physical_sector_s_map_cptp}
+    This follows by composition with the two coordinate-permutation
+    channels.
+\end{proof}
+
+\begin{theorem}[Coarse-graining identity in ordinary physical coordinates]
+    \label{thm:mpdo_physical_s_closure_identity}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.physicalSMap_threeSiteClosure_eq_twoSiteClosure}
+    \leanok
+    \uses{def:mpdo_physical_s_map}
+    For every virtual matrix $X$,
+    \[
+      \widehat{\mathcal S}\bigl(\widehat{\cal K}_3(X)\bigr)
+      =\widehat{\cal K}_2(X).
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_physical_sector_s_closure_identity}
+    Transport the sector-coordinate identity through the inverse two-site
+    coordinate identification.
+\end{proof}
+
+\begin{definition}[Localized physical refinement]
+    \label{def:mpdo_localized_physical_t_map}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.localizedPhysicalTMap}
+    \leanok
+    \uses{def:mpdo_physical_t_map}
+    Reassociate three sites as $(12)3$, apply
+    $\widehat{\mathcal T}\otimes\operatorname{id}$, and reassociate the
+    result as $1(2(34))$. This defines the localized refinement channel on
+    right-associated physical coordinates.
+\end{definition}
+
+\begin{theorem}[The localized physical refinement is a channel]
+    \label{thm:mpdo_localized_physical_t_map_cptp}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.localizedPhysicalTMap_isKrausCPTP}
+    \leanok
+    \uses{def:mpdo_localized_physical_t_map}
+    The localized refinement map is trace-preserving and completely
+    positive.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_physical_t_map_cptp}
+    Tensoring a channel with the identity preserves complete positivity and
+    trace, as do the two associativity permutations.
+\end{proof}
+
+% **Local fix (zero-weight quotient):** this identity uses the completed
+% zero-weight preparation. Documented in
+% docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex.
+\begin{theorem}[Localized refinement of physical closures]
+    \label{thm:mpdo_localized_physical_t_closure_identity}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.localizedPhysicalTMap_threeSiteClosure_eq_fourSiteClosure}
+    \leanok
+    \uses{def:mpdo_localized_physical_t_map}
+    For every virtual matrix $X$,
+    \[
+      (\widehat{\mathcal T}\otimes\operatorname{id})
+        \bigl(\widehat{\cal K}_3(X)\bigr)
+      =\widehat{\cal K}_4(X),
+    \]
+    with the displayed map understood in right-associated coordinates.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_physical_t_closure_identity}
+    Fixing the last ket and bra indices turns the three-site closure into a
+    two-site closure with the last tensor matrix absorbed into $X$. Apply the
+    two-to-three-site refinement identity to this virtual matrix.
+\end{proof}
+
+\begin{definition}[Localized physical coarse-graining]
+    \label{def:mpdo_localized_physical_s_map}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.localizedPhysicalSMap}
+    \leanok
+    \uses{def:mpdo_physical_s_map}
+    Reassociate four sites as $(123)4$, apply
+    $\widehat{\mathcal S}\otimes\operatorname{id}$, and reassociate the
+    result as $1(23)$. This defines the localized coarse-graining channel on
+    right-associated physical coordinates.
+\end{definition}
+
+\begin{theorem}[The localized physical coarse-graining is a channel]
+    \label{thm:mpdo_localized_physical_s_map_cptp}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.localizedPhysicalSMap_isKrausCPTP}
+    \leanok
+    \uses{def:mpdo_localized_physical_s_map}
+    The localized coarse-graining map is trace-preserving and completely
+    positive.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_physical_s_map_cptp}
+    Tensor the physical coarse-graining channel with the identity and compose
+    with the two associativity permutations.
+\end{proof}
+
+\begin{theorem}[Localized coarse-graining of physical closures]
+    \label{thm:mpdo_localized_physical_s_closure_identity}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.localizedPhysicalSMap_fourSiteClosure_eq_threeSiteClosure}
+    \leanok
+    \uses{def:mpdo_localized_physical_s_map}
+    For every virtual matrix $X$,
+    \[
+      (\widehat{\mathcal S}\otimes\operatorname{id})
+        \bigl(\widehat{\cal K}_4(X)\bigr)
+      =\widehat{\cal K}_3(X),
+    \]
+    in right-associated coordinates.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_physical_s_closure_identity}
+    Fixing the last ket and bra indices identifies the four-site closure with
+    a three-site closure having the last tensor matrix absorbed into $X$.
+    Apply the three-to-two-site coarse-graining identity.
+\end{proof}
+
 \begin{figure}[ht]
     \centering
     \TNMPDOSectorPairing


### PR DESCRIPTION
## Summary

- transport the sector-coordinate refinement and coarse-graining channels to ordinary right-associated physical coordinates
- prove their trace-preserving complete positivity and exact action on two-, three-, and four-site closures
- formalize the localized actions corresponding to the paper notation \(\widehat{\mathcal T}\otimes\operatorname{id}\) and \(\widehat{\mathcal S}\otimes\operatorname{id}\)
- extend the MPO/RFP blueprint with source-faithful statements, proof dependencies, and the documented zero-weight local fix

## Verification

- `lake env lean TNLean/MPS/MPDO/PhysicalSectorPhysicalMaps.lean`
- `cd blueprint && leanblueprint checkdecls`
- `cd blueprint && leanblueprint pdf`
- proof-integrity scan of the new Lean module
- independent Lean, source-faithfulness, and blueprint reviews

Part of #3744.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formalization and documentation on the MPDO track; no runtime or auth changes, with proofs composed from existing sector-coordinate results.
> 
> **Overview**
> Adds **`PhysicalSectorPhysicalMaps.lean`** and wires it into **`TNLean.lean`**, formalizing Proposition C.7 channels in ordinary right-associated physical coordinates and their localized variants.
> 
> **Physical transport:** `physicalTMap` / `physicalSMap` reindex the existing sector-coordinate `tMap` / `sMap` through two- and three-site coordinate equivalences. Proofs show Kraus CPTP (composition with reindex channels) and closure identities (2→3 and 3→2), with refinement closure identities noting the documented zero-weight preparation local fix.
> 
> **Localization:** `localizedPhysicalTMap` and `localizedPhysicalSMap` implement \(\widehat{\mathcal T}\otimes\mathrm{id}\) and \(\widehat{\mathcal S}\otimes\mathrm{id}\) via associativity equivalences and `tensorMapIdLM`, with matching CPTP and closure lemmas (3→4 and 4→3).
> 
> **Blueprint:** `ch21_mpdo_rfp_simple_local_structure.tex` gains matching definitions, CPTP theorems, closure identities, and `\lean{}` links for the new declarations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bad36aed65023b0976e97c49125893868ce7204. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->