### PR TITLE
feat(MPS/MPDO): prove blocked sector RFP

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -407,6 +407,7 @@ import TNLean.MPS.MPDO.PhysicalSectorCoarseGrainingIdentity
 import TNLean.MPS.MPDO.PhysicalSectorRefinementAction
 import TNLean.MPS.MPDO.PhysicalSectorRefinementIdentity
 import TNLean.MPS.MPDO.PhysicalSectorPhysicalMaps
+import TNLean.MPS.MPDO.PhysicalSectorBlockedRFP
 import TNLean.MPS.MPDO.SectorPairingTransfer
 import TNLean.MPS.MPDO.SectorEtaContraction
 import TNLean.MPS.MPDO.SectorEtaOperator

--- a/TNLean/MPS/MPDO/PhysicalSectorBlockedRFP.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorBlockedRFP.lean
@@ -1,0 +1,285 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalSectorPhysicalMaps
+
+/-!
+# Two-site blocked renormalization of the physical-sector tensor
+
+This file composes the physical-coordinate channels of Proposition C.7 twice.
+The resulting channels exchange the two-site and four-site closures of the
+physical-sector tensor. Decoding the physical indices of a two-site block then
+exhibits the two-site blocked physical-sector tensor as a renormalization fixed
+point.
+
+The result concerns the tensor in the physical-sector coordinates selected by
+the isometry in Proposition C.7. Transport through that isometry to the original
+physical tensor is not asserted here.
+
+**Local fix (implication label):** Appendix line 1824 labels the construction
+as direction (iii) implies (v), whereas the theorem statement and the local
+structure used there give direction (iv) implies (v). Documented in
+`docs/paper-gaps/cpgsv17_mpdo_theorem_4_9_implication_label.tex`.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Theorem 4.9, direction (iv) implies (v), source lines 851--893; its channel
+  construction at source lines 1821--1825, where the implication is
+  mislabelled; and Proposition C.7, Appendix C.2, source lines 1510--1563
+-/
+
+open scoped Matrix
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D} {F : PhysicalSectorFactorization K}
+
+/-- The twice-applied physical refinement channel: first refine two physical
+sites to three, then refine the first two of those three sites to obtain four.
+
+This is the map denoted \(\mathcal T^2\) in arXiv:1606.00608, Theorem 4.9,
+direction (iv) implies (v), source lines 851--893, with the channel construction
+at source lines 1821--1825. It is built from the channel of Proposition C.7,
+Appendix C.2, source lines 1510--1545. -/
+noncomputable def NeighboringTraceFactorization.physicalTSquaredMap
+    (H : NeighboringTraceFactorization F) :
+    Matrix (Fin (Fintype.card (SectorSiteIndex F)) ×
+        Fin (Fintype.card (SectorSiteIndex F)))
+      (Fin (Fintype.card (SectorSiteIndex F)) ×
+        Fin (Fintype.card (SectorSiteIndex F))) ℂ →ₗ[ℂ]
+    Matrix (Fin (Fintype.card (SectorSiteIndex F)) ×
+        (Fin (Fintype.card (SectorSiteIndex F)) ×
+          (Fin (Fintype.card (SectorSiteIndex F)) ×
+            Fin (Fintype.card (SectorSiteIndex F)))))
+      (Fin (Fintype.card (SectorSiteIndex F)) ×
+        (Fin (Fintype.card (SectorSiteIndex F)) ×
+          (Fin (Fintype.card (SectorSiteIndex F)) ×
+            Fin (Fintype.card (SectorSiteIndex F))))) ℂ :=
+  H.localizedPhysicalTMap ∘ₗ H.physicalTMap
+
+/-- The twice-applied physical refinement map is trace-preserving and
+completely positive.
+
+Source: arXiv:1606.00608, Theorem 4.9, direction (iv) implies (v), source
+lines 851--893, with the channel construction at source lines 1821--1825; and
+Proposition C.7, Appendix C.2, source lines 1510--1545. -/
+theorem NeighboringTraceFactorization.physicalTSquaredMap_isKrausCPTP
+    (H : NeighboringTraceFactorization F) :
+    IsKrausCPTP H.physicalTSquaredMap := by
+  exact isKrausCPTP_comp H.physicalTMap_isKrausCPTP
+    H.localizedPhysicalTMap_isKrausCPTP
+
+/-- The twice-applied physical refinement sends the two-site closure of the
+physical-sector tensor to its four-site closure.
+
+**Local fix (zero-weight quotient):** this identity uses the completed
+zero-weight preparation branch of the refinement channel. Documented in
+`docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex`.
+
+Source: arXiv:1606.00608, Theorem 4.9, direction (iv) implies (v), source
+lines 851--893, with the channel construction at source lines 1821--1825; and
+Proposition C.7, Appendix C.2, source lines 1510--1545. -/
+theorem NeighboringTraceFactorization.physicalTSquaredMap_twoSiteClosure_eq_fourSiteClosure
+    (H : NeighboringTraceFactorization F) (X : Matrix (Fin D) (Fin D) ℂ) :
+    H.physicalTSquaredMap (physClose2 F.sectorCoordinateTensor X) =
+      physClose4 F.sectorCoordinateTensor X := by
+  rw [NeighboringTraceFactorization.physicalTSquaredMap, LinearMap.comp_apply,
+    H.physicalTMap_twoSiteClosure_eq_threeSiteClosure,
+    H.localizedPhysicalTMap_threeSiteClosure_eq_fourSiteClosure]
+
+/-- The twice-applied physical coarse-graining channel: first coarse-grain the
+first three of four physical sites, then coarse-grain the remaining three sites
+to two.
+
+This is the map denoted \(\mathcal S^2\) in arXiv:1606.00608, Theorem 4.9,
+direction (iv) implies (v), source lines 851--893, with the channel construction
+at source lines 1821--1825. It is built from the channel of Proposition C.7,
+Appendix C.2, source lines 1547--1563. -/
+noncomputable def NeighboringTraceFactorization.physicalSSquaredMap
+    (H : NeighboringTraceFactorization F) :
+    Matrix (Fin (Fintype.card (SectorSiteIndex F)) ×
+        (Fin (Fintype.card (SectorSiteIndex F)) ×
+          (Fin (Fintype.card (SectorSiteIndex F)) ×
+            Fin (Fintype.card (SectorSiteIndex F)))))
+      (Fin (Fintype.card (SectorSiteIndex F)) ×
+        (Fin (Fintype.card (SectorSiteIndex F)) ×
+          (Fin (Fintype.card (SectorSiteIndex F)) ×
+            Fin (Fintype.card (SectorSiteIndex F))))) ℂ →ₗ[ℂ]
+    Matrix (Fin (Fintype.card (SectorSiteIndex F)) ×
+        Fin (Fintype.card (SectorSiteIndex F)))
+      (Fin (Fintype.card (SectorSiteIndex F)) ×
+        Fin (Fintype.card (SectorSiteIndex F))) ℂ :=
+  H.physicalSMap ∘ₗ H.localizedPhysicalSMap
+
+/-- The twice-applied physical coarse-graining map is trace-preserving and
+completely positive.
+
+Source: arXiv:1606.00608, Theorem 4.9, direction (iv) implies (v), source
+lines 851--893, with the channel construction at source lines 1821--1825; and
+Proposition C.7, Appendix C.2, source lines 1547--1563. -/
+theorem NeighboringTraceFactorization.physicalSSquaredMap_isKrausCPTP
+    (H : NeighboringTraceFactorization F) :
+    IsKrausCPTP H.physicalSSquaredMap := by
+  exact isKrausCPTP_comp H.localizedPhysicalSMap_isKrausCPTP
+    H.physicalSMap_isKrausCPTP
+
+/-- The twice-applied physical coarse-graining sends the four-site closure of
+the physical-sector tensor to its two-site closure.
+
+Source: arXiv:1606.00608, Theorem 4.9, direction (iv) implies (v), source
+lines 851--893, with the channel construction at source lines 1821--1825; and
+Proposition C.7, Appendix C.2, source lines 1547--1563. -/
+theorem NeighboringTraceFactorization.physicalSSquaredMap_fourSiteClosure_eq_twoSiteClosure
+    (H : NeighboringTraceFactorization F) (X : Matrix (Fin D) (Fin D) ℂ) :
+    H.physicalSSquaredMap (physClose4 F.sectorCoordinateTensor X) =
+      physClose2 F.sectorCoordinateTensor X := by
+  rw [NeighboringTraceFactorization.physicalSSquaredMap, LinearMap.comp_apply,
+    H.localizedPhysicalSMap_fourSiteClosure_eq_threeSiteClosure,
+    H.physicalSMap_threeSiteClosure_eq_twoSiteClosure]
+
+/-- The refinement channel on two-site blocked physical indices, obtained from
+\(\mathcal T^2\) by the canonical decoding of one and two blocked sites.
+
+Source: arXiv:1606.00608, Theorem 4.9, direction (iv) implies (v), source
+lines 851--893, with the channel construction at source lines 1821--1825. -/
+private noncomputable def NeighboringTraceFactorization.blockedPhysicalTMap
+    (H : NeighboringTraceFactorization F) :
+    Matrix (Fin (Fintype.card (SectorSiteIndex F) *
+        Fintype.card (SectorSiteIndex F)))
+      (Fin (Fintype.card (SectorSiteIndex F) *
+        Fintype.card (SectorSiteIndex F))) ℂ →ₗ[ℂ]
+    Matrix (Fin (Fintype.card (SectorSiteIndex F) *
+          Fintype.card (SectorSiteIndex F)) ×
+        Fin (Fintype.card (SectorSiteIndex F) *
+          Fintype.card (SectorSiteIndex F)))
+      (Fin (Fintype.card (SectorSiteIndex F) *
+          Fintype.card (SectorSiteIndex F)) ×
+        Fin (Fintype.card (SectorSiteIndex F) *
+          Fintype.card (SectorSiteIndex F))) ℂ :=
+  Matrix.equivReindexMap
+      (blockedPairEquiv (Fintype.card (SectorSiteIndex F))).symm ∘ₗ
+    H.physicalTSquaredMap ∘ₗ
+    Matrix.equivReindexMap
+      (blockedIndexEquiv (Fintype.card (SectorSiteIndex F)))
+
+/-- The coarse-graining channel on two-site blocked physical indices, obtained
+from \(\mathcal S^2\) by the canonical decoding of one and two blocked sites.
+
+Source: arXiv:1606.00608, Theorem 4.9, direction (iv) implies (v), source
+lines 851--893, with the channel construction at source lines 1821--1825. -/
+private noncomputable def NeighboringTraceFactorization.blockedPhysicalSMap
+    (H : NeighboringTraceFactorization F) :
+    Matrix (Fin (Fintype.card (SectorSiteIndex F) *
+          Fintype.card (SectorSiteIndex F)) ×
+        Fin (Fintype.card (SectorSiteIndex F) *
+          Fintype.card (SectorSiteIndex F)))
+      (Fin (Fintype.card (SectorSiteIndex F) *
+          Fintype.card (SectorSiteIndex F)) ×
+        Fin (Fintype.card (SectorSiteIndex F) *
+          Fintype.card (SectorSiteIndex F))) ℂ →ₗ[ℂ]
+    Matrix (Fin (Fintype.card (SectorSiteIndex F) *
+        Fintype.card (SectorSiteIndex F)))
+      (Fin (Fintype.card (SectorSiteIndex F) *
+        Fintype.card (SectorSiteIndex F))) ℂ :=
+  Matrix.equivReindexMap
+      (blockedIndexEquiv (Fintype.card (SectorSiteIndex F))).symm ∘ₗ
+    H.physicalSSquaredMap ∘ₗ
+    Matrix.equivReindexMap
+      (blockedPairEquiv (Fintype.card (SectorSiteIndex F)))
+
+/-- The two-site blocked physical-sector tensor is a renormalization fixed
+point. The channels are the maps \(\mathcal S^2\) and \(\mathcal T^2\) of the
+source, transported only through the canonical blocked-index equivalences.
+
+**Local fix (zero-weight quotient):** the refinement identity used here has
+the completed zero-weight preparation branch. Documented in
+`docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex`.
+
+This statement is restricted to the physical-sector tensor; it does not
+transport the channels through the physical isometry to the original tensor.
+
+**Scope restriction (physical coordinates):** the source conclusion concerns
+the original blocked tensor, whereas this theorem concerns its sector-coordinate
+form. Documented in
+`docs/paper-gaps/cpgsv17_mpdo_blocked_rfp_physical_transport.tex`. Elimination:
+transport the two channels through the two- and four-site physical unitaries.
+
+Source: arXiv:1606.00608, Definition 4.1, source lines 645--659; Theorem 4.9,
+direction (iv) implies (v), source lines 851--893, with the channel construction
+at source lines 1821--1825; and Proposition C.7, Appendix C.2, source lines
+1510--1563. -/
+theorem NeighboringTraceFactorization.blockTwo_sectorCoordinateTensor_isRFPViaTS
+    (H : NeighboringTraceFactorization F) :
+    IsRFPViaTS (blockTwo F.sectorCoordinateTensor) := by
+  refine ⟨H.blockedPhysicalSMap, H.blockedPhysicalTMap, ?_, ?_, ?_, ?_⟩
+  · exact isKrausCPTP_comp
+      (isKrausCPTP_comp
+        (Matrix.equivReindexMap_isKrausCPTP
+          (blockedPairEquiv (Fintype.card (SectorSiteIndex F))))
+        H.physicalSSquaredMap_isKrausCPTP)
+      (Matrix.equivReindexMap_isKrausCPTP
+        (blockedIndexEquiv (Fintype.card (SectorSiteIndex F))).symm)
+  · exact isKrausCPTP_comp
+      (isKrausCPTP_comp
+        (Matrix.equivReindexMap_isKrausCPTP
+          (blockedIndexEquiv (Fintype.card (SectorSiteIndex F))))
+        H.physicalTSquaredMap_isKrausCPTP)
+      (Matrix.equivReindexMap_isKrausCPTP
+        (blockedPairEquiv (Fintype.card (SectorSiteIndex F))).symm)
+  · intro X
+    change Matrix.reindex
+        (blockedIndexEquiv (Fintype.card (SectorSiteIndex F))).symm
+        (blockedIndexEquiv (Fintype.card (SectorSiteIndex F))).symm
+        (H.physicalSSquaredMap
+          (Matrix.reindex
+            (blockedPairEquiv (Fintype.card (SectorSiteIndex F)))
+            (blockedPairEquiv (Fintype.card (SectorSiteIndex F)))
+            (physClose2 (blockTwo F.sectorCoordinateTensor) X))) =
+      physClose1 (blockTwo F.sectorCoordinateTensor) X
+    rw [show Matrix.reindex
+        (blockedPairEquiv (Fintype.card (SectorSiteIndex F)))
+        (blockedPairEquiv (Fintype.card (SectorSiteIndex F)))
+        (physClose2 (blockTwo F.sectorCoordinateTensor) X) =
+      physClose4 F.sectorCoordinateTensor X by
+        exact LinearMap.congr_fun
+          (physClose2_blockTwo_eq_physClose4 F.sectorCoordinateTensor) X]
+    rw [H.physicalSSquaredMap_fourSiteClosure_eq_twoSiteClosure]
+    rw [← show Matrix.reindex
+        (blockedIndexEquiv (Fintype.card (SectorSiteIndex F)))
+        (blockedIndexEquiv (Fintype.card (SectorSiteIndex F)))
+        (physClose1 (blockTwo F.sectorCoordinateTensor) X) =
+      physClose2 F.sectorCoordinateTensor X by
+        exact LinearMap.congr_fun
+          (physClose1_blockTwo_eq_physClose2 F.sectorCoordinateTensor) X]
+    simp
+  · intro X
+    change Matrix.reindex
+        (blockedPairEquiv (Fintype.card (SectorSiteIndex F))).symm
+        (blockedPairEquiv (Fintype.card (SectorSiteIndex F))).symm
+        (H.physicalTSquaredMap
+          (Matrix.reindex
+            (blockedIndexEquiv (Fintype.card (SectorSiteIndex F)))
+            (blockedIndexEquiv (Fintype.card (SectorSiteIndex F)))
+            (physClose1 (blockTwo F.sectorCoordinateTensor) X))) =
+      physClose2 (blockTwo F.sectorCoordinateTensor) X
+    rw [show Matrix.reindex
+        (blockedIndexEquiv (Fintype.card (SectorSiteIndex F)))
+        (blockedIndexEquiv (Fintype.card (SectorSiteIndex F)))
+        (physClose1 (blockTwo F.sectorCoordinateTensor) X) =
+      physClose2 F.sectorCoordinateTensor X by
+        exact LinearMap.congr_fun
+          (physClose1_blockTwo_eq_physClose2 F.sectorCoordinateTensor) X]
+    rw [H.physicalTSquaredMap_twoSiteClosure_eq_fourSiteClosure]
+    rw [← show Matrix.reindex
+        (blockedPairEquiv (Fintype.card (SectorSiteIndex F)))
+        (blockedPairEquiv (Fintype.card (SectorSiteIndex F)))
+        (physClose2 (blockTwo F.sectorCoordinateTensor) X) =
+      physClose4 F.sectorCoordinateTensor X by
+        exact LinearMap.congr_fun
+          (physClose2_blockTwo_eq_physClose4 F.sectorCoordinateTensor) X]
+    simp
+
+end MPOTensor.PhysicalSectorFactorization

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -3295,7 +3295,7 @@ strong subadditivity for a normalized three-site reduced state.
 \end{proof}
 
 For the following construction, through
-Theorem~\ref{thm:mpdo_localized_physical_s_closure_identity}, assume the
+Theorem~\ref{thm:mpdo_blocked_sector_coordinate_tensor_is_rfp_via_ts}, assume the
 neighboring-operator trace factorization of
 Definition~\ref{def:mpdo_neighboring_trace_factorization}. Write
 \[
@@ -3498,6 +3498,173 @@ $\widehat{\cal K}$.
     Fixing the last ket and bra indices identifies the four-site closure with
     a three-site closure having the last tensor matrix absorbed into $X$.
     Apply the three-to-two-site coarse-graining identity.
+\end{proof}
+
+% **Local fix (implication label):** Appendix line 1824 says
+% (iii) implies (v), but the theorem statement and the local structure used
+% here give (iv) implies (v). Documented in
+% docs/paper-gaps/cpgsv17_mpdo_theorem_4_9_implication_label.tex.
+\begin{definition}[Two-step physical refinement]
+    \label{def:mpdo_physical_t_squared_map}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.physicalTSquaredMap}
+    \leanok
+    \uses{def:mpdo_physical_t_map,
+      def:mpdo_localized_physical_t_map}
+    Let $\widehat{\cal K}$ be the sector-coordinate tensor selected by the
+    physical isometry of Proposition~C.7. Define
+    \[
+      \widehat{\mathcal T}^2
+      =\widehat{\mathcal T}_{(12)3}\circ\widehat{\mathcal T},
+      \qquad
+      \widehat{\mathcal T}^2:M_{q^2}(\mathbb C)
+        \longrightarrow M_{q^4}(\mathbb C),
+    \]
+    where the second application acts on the first two sites and leaves the
+    third site unchanged. Thus the superscript denotes two successive
+    overlapping applications, as in the proof of
+    \cite[Theorem~4.9, (iv)$\Rightarrow$(v)]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{theorem}[The two-step physical refinement is a channel]
+    \label{thm:mpdo_physical_t_squared_map_cptp}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.physicalTSquaredMap_isKrausCPTP}
+    \leanok
+    \uses{def:mpdo_physical_t_squared_map}
+    The map $\widehat{\mathcal T}^2$ is trace-preserving and completely
+    positive.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_physical_t_map_cptp,
+      thm:mpdo_localized_physical_t_map_cptp}
+    It is the composition of the physical refinement channel and its
+    localization on the first two sites.
+\end{proof}
+
+% **Local fix (zero-weight quotient):** this identity uses the completed
+% zero-weight preparation. Documented in
+% docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex.
+\begin{theorem}[Two-step refinement of the sector-coordinate tensor]
+    \label{thm:mpdo_physical_t_squared_closure_identity}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.physicalTSquaredMap_twoSiteClosure_eq_fourSiteClosure}
+    \leanok
+    \uses{def:mpdo_physical_t_squared_map}
+    For every virtual matrix $X$, the sector-coordinate tensor satisfies
+    \[
+      \widehat{\mathcal T}^2
+        \bigl(\widehat{\cal K}_2(X)\bigr)
+      =\widehat{\cal K}_4(X).
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_physical_t_closure_identity,
+      thm:mpdo_localized_physical_t_closure_identity}
+    The first refinement gives $\widehat{\cal K}_3(X)$; applying the localized
+    refinement to its first two sites gives $\widehat{\cal K}_4(X)$.
+\end{proof}
+
+\begin{definition}[Two-step physical coarse-graining]
+    \label{def:mpdo_physical_s_squared_map}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.physicalSSquaredMap}
+    \leanok
+    \uses{def:mpdo_physical_s_map,
+      def:mpdo_localized_physical_s_map}
+    Define
+    \[
+      \widehat{\mathcal S}^2
+      =\widehat{\mathcal S}\circ\widehat{\mathcal S}_{(123)4},
+      \qquad
+      \widehat{\mathcal S}^2:M_{q^4}(\mathbb C)
+        \longrightarrow M_{q^2}(\mathbb C),
+    \]
+    where the first application acts on the first three sites and leaves the
+    fourth site unchanged. The superscript again denotes successive
+    overlapping applications.
+\end{definition}
+
+\begin{theorem}[The two-step physical coarse-graining is a channel]
+    \label{thm:mpdo_physical_s_squared_map_cptp}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.physicalSSquaredMap_isKrausCPTP}
+    \leanok
+    \uses{def:mpdo_physical_s_squared_map}
+    The map $\widehat{\mathcal S}^2$ is trace-preserving and completely
+    positive.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_physical_s_map_cptp,
+      thm:mpdo_localized_physical_s_map_cptp}
+    It is the composition of the localized coarse-graining channel and the
+    physical coarse-graining channel.
+\end{proof}
+
+\begin{theorem}[Two-step coarse-graining of the sector-coordinate tensor]
+    \label{thm:mpdo_physical_s_squared_closure_identity}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.physicalSSquaredMap_fourSiteClosure_eq_twoSiteClosure}
+    \leanok
+    \uses{def:mpdo_physical_s_squared_map}
+    For every virtual matrix $X$, the sector-coordinate tensor satisfies
+    \[
+      \widehat{\mathcal S}^2
+        \bigl(\widehat{\cal K}_4(X)\bigr)
+      =\widehat{\cal K}_2(X).
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_localized_physical_s_closure_identity,
+      thm:mpdo_physical_s_closure_identity}
+    The localized coarse-graining first gives $\widehat{\cal K}_3(X)$; the
+    second coarse-graining gives $\widehat{\cal K}_2(X)$.
+\end{proof}
+
+\begin{figure}[ht]
+    \centering
+    \TNMPDOBlockedRFPChannels
+    \caption{The superscripts in $\widehat{\mathcal T}^2$ and
+    $\widehat{\mathcal S}^2$ denote successive overlapping applications.
+    The dashed frames identify the two-site and four-site endpoints with one
+    and two sites of the blocked tensor. This is the channel construction in
+    \cite[Appendix~C.2, lines~1821--1825]{Cirac2016MPDO_arXiv}.}
+    \label{fig:mpdo_blocked_rfp_channels}
+\end{figure}
+
+% **Local fix (zero-weight quotient):** this theorem uses the completed
+% zero-weight preparation through the two-step refinement identity. Documented
+% in docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex.
+% **Scope restriction (physical coordinates):** this theorem concerns the
+% sector-coordinate tensor, not yet the original tensor. Documented in
+% docs/paper-gaps/cpgsv17_mpdo_blocked_rfp_physical_transport.tex.
+\begin{theorem}[Blocked sector-coordinate tensor is a renormalization fixed point]
+    \label{thm:mpdo_blocked_sector_coordinate_tensor_is_rfp_via_ts}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.blockTwo_sectorCoordinateTensor_isRFPViaTS}
+    \leanok
+    \uses{def:is_rfp_via_ts, def:mpdo_two_site_blocking}
+    Let $\widehat{\cal K}^{[2]}$ be the tensor obtained by blocking two
+    adjacent sites of the sector-coordinate tensor $\widehat{\cal K}$. Then
+    $\widehat{\cal K}^{[2]}$ is a renormalization fixed point in the sense of
+    Definition~\ref{def:is_rfp_via_ts}. More precisely, after the canonical
+    identifications of one blocked site with two original sites and two
+    blocked sites with four original sites, the required channels are
+    $\widehat{\mathcal S}^2$ and
+    $\widehat{\mathcal T}^2$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_physical_t_squared_map_cptp,
+      thm:mpdo_physical_t_squared_closure_identity,
+      thm:mpdo_physical_s_squared_map_cptp,
+      thm:mpdo_physical_s_squared_closure_identity,
+      thm:mpdo_one_site_closure_two_site_blocking,
+      thm:mpdo_two_site_closure_two_site_blocking}
+    Decode one blocked index as a pair of physical indices and two blocked
+    indices as four physical indices. The one-site and two-site closures of
+    $\widehat{\cal K}^{[2]}$ thereby become respectively
+    $\widehat{\cal K}_2(X)$ and $\widehat{\cal K}_4(X)$. Transporting the two
+    channels through these permutation identifications preserves complete
+    positivity and trace, and the two closure identities give the required
+    equations in Definition~\ref{def:is_rfp_via_ts}.
 \end{proof}
 
 \begin{figure}[ht]

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -352,6 +352,76 @@
     \end{tikzpicture}%
 }
 
+% The overlapping applications of T and S used after two-site blocking in
+% Theorem 4.9.  The endpoint frames identify one and two blocked sites; the
+% intermediate rows retain the original physical-site decomposition.
+\newcommand{\TNMPDOBlockedRFPChannels}{%
+    \begin{tikzpicture}[tn picture, scale=0.72]
+        \foreach \x/\name in {-5.0/btTwoA,-4.0/btTwoB} {
+            \TN@subspinbox{\name}{(\x,1.35)}{\widehat{\cal K}}
+        }
+        \TN@subspinlink{btTwoA}{btTwoB}
+        \draw[rounded corners=2pt, densely dashed]
+            (-5.48,0.87) rectangle (-3.52,1.83);
+        \node at (-4.50,0.54) {one blocked site};
+
+        \foreach \x/\name in {-1.4/btThreeA,-0.4/btThreeB,0.6/btThreeC} {
+            \TN@subspinbox{\name}{(\x,1.35)}{\widehat{\cal K}}
+        }
+        \TN@subspinlink{btThreeA}{btThreeB}
+        \TN@subspinlink{btThreeB}{btThreeC}
+
+        \foreach \x/\name in {3.0/btFourA,4.0/btFourB,5.0/btFourC,6.0/btFourD} {
+            \TN@subspinbox{\name}{(\x,1.35)}{\widehat{\cal K}}
+        }
+        \TN@subspinlink{btFourA}{btFourB}
+        \TN@subspinlink{btFourB}{btFourC}
+        \TN@subspinlink{btFourC}{btFourD}
+        \draw[rounded corners=2pt, densely dashed]
+            (2.52,0.87) rectangle (4.48,1.83);
+        \draw[rounded corners=2pt, densely dashed]
+            (4.52,0.87) rectangle (6.48,1.83);
+        \node at (4.50,0.54) {two blocked sites};
+
+        \draw[->, line width=0.60pt] (-3.22,1.35) -- (-1.88,1.35)
+            node[midway, above] {$\widehat{\mathcal T}$};
+        \draw[->, line width=0.60pt] (1.08,1.35) -- (2.52,1.35)
+            node[midway, above] {$\widehat{\mathcal T}_{(12)3}$};
+        \node at (0.50,2.25)
+            {$\widehat{\mathcal T}^2:\widehat{\cal K}_2(X)
+              \longmapsto\widehat{\cal K}_4(X)$};
+
+        \foreach \x/\name in {3.0/bsFourA,4.0/bsFourB,5.0/bsFourC,6.0/bsFourD} {
+            \TN@subspinbox{\name}{(\x,-1.30)}{\widehat{\cal K}}
+        }
+        \TN@subspinlink{bsFourA}{bsFourB}
+        \TN@subspinlink{bsFourB}{bsFourC}
+        \TN@subspinlink{bsFourC}{bsFourD}
+        \draw[rounded corners=2pt, densely dashed]
+            (2.52,-1.78) rectangle (4.48,-0.82);
+        \draw[rounded corners=2pt, densely dashed]
+            (4.52,-1.78) rectangle (6.48,-0.82);
+        \foreach \x/\name in {-1.4/bsThreeA,-0.4/bsThreeB,0.6/bsThreeC} {
+            \TN@subspinbox{\name}{(\x,-1.30)}{\widehat{\cal K}}
+        }
+        \TN@subspinlink{bsThreeA}{bsThreeB}
+        \TN@subspinlink{bsThreeB}{bsThreeC}
+        \foreach \x/\name in {-5.0/bsTwoA,-4.0/bsTwoB} {
+            \TN@subspinbox{\name}{(\x,-1.30)}{\widehat{\cal K}}
+        }
+        \TN@subspinlink{bsTwoA}{bsTwoB}
+        \draw[rounded corners=2pt, densely dashed]
+            (-5.48,-1.78) rectangle (-3.52,-0.82);
+        \draw[<-, line width=0.60pt] (1.08,-1.30) -- (2.52,-1.30)
+            node[midway, above] {$\widehat{\mathcal S}_{(123)4}$};
+        \draw[<-, line width=0.60pt] (-3.22,-1.30) -- (-1.88,-1.30)
+            node[midway, above] {$\widehat{\mathcal S}$};
+        \node at (0.50,-2.20)
+            {$\widehat{\mathcal S}^2:\widehat{\cal K}_4(X)
+              \longmapsto\widehat{\cal K}_2(X)$};
+    \end{tikzpicture}%
+}
+
 % Fixed-sector factorization of the arbitrary-X two-site physical closure.
 % The left-hand row shows the sector subspins and the outer virtual closure;
 % the right-hand side shows only the proved boundary/neighbor tensor product.

--- a/docs/paper-gaps/cpgsv17_mpdo_blocked_rfp_physical_transport.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_blocked_rfp_physical_transport.tex
@@ -1,0 +1,72 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+
+\input{command}
+
+\title{Physical-Isometry Transport for the Blocked MPDO Fixed Point}
+\author{}
+\date{2026-07-12}
+
+\begin{document}
+\maketitle
+
+\section{Source conclusion and present scope}
+
+The proof of Theorem~4.9, direction (iv)$\Rightarrow$(v), constructs the
+channels $\mathcal T^2$ and $\mathcal S^2$ after applying the physical
+isometry of Proposition~C.7; see
+\cite[Appendix~C.2, lines~1510--1563 and 1821--1825]
+{Cirac2016MPDO_arXiv}.  The theorem itself concerns the original tensor after
+blocking two adjacent sites.
+
+The present formal theorem
+\path{NeighboringTraceFactorization.blockTwo_sectorCoordinateTensor_isRFPViaTS}
+proves the fixed-point identities for
+\[
+  \operatorname{blockTwo}(\widehat{\mathcal K}),
+\]
+where $\widehat{\mathcal K}$ is the tensor in the sector coordinates selected
+by the physical isometry.  Its conclusion is exact in these coordinates, but
+it does not yet transport the two channels back to
+$\operatorname{blockTwo}(\mathcal K)$.  It is therefore a scope-restricted
+intermediate result, not the complete formalization of the source implication.
+
+\section{Required transport}
+
+In the formal sector factorization, the physical isometry is a square matrix
+$U$ satisfying $U^\dagger U=I$.  Finite dimensionality then also gives
+$UU^\dagger=I$.  The remaining argument should first prove the closure
+relations
+\[
+  \widehat{\mathcal K}_n(X)
+  =U^{\otimes n}\mathcal K_n(X)(U^\dagger)^{\otimes n}
+  \qquad (n=2,4),
+\]
+with the tensor indices placed in the right-associated conventions used by the
+channel construction.  Transporting $\widehat{\mathcal T}^2$ and
+$\widehat{\mathcal S}^2$ through these unitary congruences then preserves
+complete positivity and trace.  The two sector-coordinate closure identities
+become the required identities for the original blocked tensor.
+
+\section{Elimination plan}
+
+The next result should formalize the two- and four-site unitary closure
+relations, define the transported channels on the original physical matrix
+spaces, and prove
+\[
+  \operatorname{IsRFPViaTS}
+    \bigl(\operatorname{blockTwo}(\mathcal K)\bigr)
+\]
+under the same neighboring-operator trace-factorization hypothesis.  Once
+that theorem is available, the scope-restriction marker on the
+sector-coordinate theorem can remain as a description of its narrower role,
+while the source-labelled blueprint implication should refer to the transported
+theorem.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/cpgsv17_mpdo_theorem_4_9_implication_label.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_theorem_4_9_implication_label.tex
@@ -1,0 +1,45 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+
+\input{command}
+
+\title{The Implication Label in the Proof of MPDO Theorem 4.9}
+\author{}
+\date{2026-07-12}
+
+\begin{document}
+\maketitle
+
+\section{The inconsistent label}
+
+The statement of Theorem~4.9 in
+\cite[lines~851--893]{Cirac2016MPDO_arXiv} labels the simple local structure as
+condition~(iv) and the renormalization fixed-point property as condition~(v).
+The Appendix construction of the two channels concludes instead with the words
+``(iii)$\Rightarrow$(v)'' at line~1824.  This label is inconsistent with the
+hypothesis used in that construction: Proposition~C.7 supplies precisely the
+neighboring-operator trace factorization belonging to the simple local
+structure in condition~(iv).
+
+Consequently the direct channel argument at lines~1821--1825 establishes
+condition~(iv)$\Rightarrow$(v).  Reading the displayed implication as
+condition~(iii)$\Rightarrow$(v) would detach the construction from the local
+structure established immediately beforehand.
+
+\section{Formal treatment}
+
+The formal development cites the route as
+Theorem~4.9, (iv)$\Rightarrow$(v), while retaining the Appendix line range for
+the explicit channels.  This is a local correction of the implication label;
+it changes neither the hypotheses nor the conclusion of the source theorem.
+A file collecting declarations that use this corrected label should carry a
+file-level \emph{Local fix (implication label)} marker and cite this note; the
+corresponding blueprint block should carry the same marker.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
## Summary

- construct the overlapping two-step physical channels \(\widehat{\mathcal T}^2:K_2\to K_4\) and \(\widehat{\mathcal S}^2:K_4\to K_2\) and prove their channel properties and closure identities
- transport these maps through the canonical blocked-index equivalences to prove `IsRFPViaTS (blockTwo F.sectorCoordinateTensor)`
- add a TikZ diagram modeled on the Appendix C.2 tensor-box construction, showing the overlapping channel actions and blocked endpoints
- document the paper's implication-label typo, the zero-weight completion, and the remaining physical-isometry transport from sector coordinates to the original tensor

## Scope

The fixed-point theorem in this PR is deliberately restricted to the blocked sector-coordinate tensor. It does not claim `IsRFPViaTS K` or even the final source-faithful statement for `blockTwo K`; the latter transport is recorded in `docs/paper-gaps/cpgsv17_mpdo_blocked_rfp_physical_transport.tex`.

## Verification

- `lake build` (9,328 jobs)
- `lake env lean TNLean/MPS/MPDO/PhysicalSectorBlockedRFP.lean`
- `cd blueprint && leanblueprint checkdecls`
- `cd blueprint && leanblueprint pdf` (505 pages, visual inspection of the new figure and entries)
- standalone PDF builds of both new paper-gap notes
- independent Lean, source-faithfulness, and TikZ/blueprint reviews

Part of #3744.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formal proofs and documentation on an existing MPDO track; no auth, runtime, or API surface changes. Remaining gaps are documented rather than hidden.
> 
> **Overview**
> Adds **`PhysicalSectorBlockedRFP.lean`** and wires it into **`TNLean.lean`**, formalizing the overlapping two-step refinement/coarse-graining channels \(\widehat{\mathcal T}^2\) and \(\widehat{\mathcal S}^2\) on the sector-coordinate tensor and proving **`IsRFPViaTS (blockTwo F.sectorCoordinateTensor)`** after reindexing through blocked-index equivalences.
> 
> The **blueprint** chapter gains matching definitions, CPTP/closure theorems, a new TikZ figure (`TNMPDOBlockedRFPChannels`), and a forward reference update to the blocked RFP theorem. **Paper-gap notes** record the Appendix (iii)/(iv) label typo and that the result is still in sector coordinates (physical-isometry transport left open).
> 
> The capstone theorem is explicitly **scope-limited** to sector coordinates; it does not claim the original blocked physical tensor until transport is proved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 580e5fe74aafca9d2cd9e627410d835669885daa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->