### PR TITLE
fix(blueprint): register blocked RFP diagram

### DIFF
--- a/blueprint/src/Packages/tn_diagrams.py
+++ b/blueprint/src/Packages/tn_diagrams.py
@@ -55,6 +55,7 @@ _DIAGRAM_ARGS: dict[str, str] = {
     "TNMPDOThreeSiteTraceAndShift": "",
     "TNMPDORefinementConstruction": "",
     "TNMPDORefinementDirection": "",
+    "TNMPDOBlockedRFPChannels": "",
     "TNMPDOTwoSiteClosureFactorization": "",
     "TNMPDOThreeSiteClosureFactorization": "",
     "TNMPDOCyclicEtaContraction": "",

--- a/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
+++ b/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
@@ -7,7 +7,7 @@ name: TNMPSLocal TNMPSWord TNMPV TNBlocking TNMPVOverlap TNTransferMap TNMPOCell
 name: TNMPOLocalPurification TNMPORenormalizationTS TNEtaSectorDecomposition TNMPDOCyclicEtaContraction TNMPDOSectorAdaptedDecomposition
 {{ obj.tn_svg_html }}
 
-name: TNMPDOTwoSiteTraceAndShift TNMPDOThreeSiteTraceAndShift TNMPDORefinementConstruction TNMPDORefinementDirection
+name: TNMPDOTwoSiteTraceAndShift TNMPDOThreeSiteTraceAndShift TNMPDORefinementConstruction TNMPDORefinementDirection TNMPDOBlockedRFPChannels
 {{ obj.tn_svg_html }}
 
 name: TNMPDOTwoSiteClosureFactorization TNMPDOThreeSiteClosureFactorization


### PR DESCRIPTION
## Summary

- register `TNMPDOBlockedRFPChannels` with the tensor-network diagram renderer
- expose the macro through the web blueprint template

## Verification

- `cd blueprint/src && PYTHONPATH=Packages python3 Packages/tn_diagrams.py --check --check-peps-usage --smoke-render`

This repairs the post-merge diagram-registration failure from #3778.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/blueprint wiring only; no runtime logic, auth, or data paths change beyond diagram registration.
> 
> **Overview**
> Registers **`TNMPDOBlockedRFPChannels`** with the web blueprint’s tensor-network diagram pipeline so it matches the existing TikZ macro in `tn_print.tex` and its use in the MPDO chapter.
> 
> The macro is added to **`_DIAGRAM_ARGS`** in `tn_diagrams.py` (zero-argument arity) and to the **`TensorNetworkDiagrams.jinja2s`** template with the other refinement/trace MPDO diagrams, restoring parity for `--check` / template-coverage validation and enabling cached SVG rendering for that figure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b0d2a4a4ee13f09b22d1b1e738ce1307b86b66a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->