### PR TITLE
doc(blueprint): carry the MPO chapter mathematics in formulas (batch 2)

### DIFF
--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -122,7 +122,7 @@
     finite-length spanning hypothesis is that the tuple-valued evaluations
     span the full product algebra of block matrices,
     \[
-        \spn_{\C}\bigl\{\,w \longmapsto (A_k^w)_k
+        \spn_{\C}\bigl\{\,(A_k^w)_k
             : w \in \{0,\ldots,d{-}1\}^L\,\bigr\}
         = \textstyle\prod_k \MN{D_k}.
     \]

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -13,11 +13,12 @@
     MPS tensor generates the same MPV family as a block-diagonal tensor
     $\bigoplus_k \mu_k A_k$ whose blocks are injective, left-canonical, and
     have nonzero weights $\mu_k$. It also includes a finite-length
-    block-separation condition: there is a length $L$ such that
+    block-separation condition: there is a length $L$ such that, for every
+    tuple $(\Delta_k)_k$ of block matrices,
     \[
-        \sum_k \tr(\Delta_k A_k^w)=0
+        \Bigl(\forall\, w \text{ of length } L,\ \textstyle\sum_k \tr(\Delta_k A_k^w)=0\Bigr)
+        \implies \forall k,\ \Delta_k=0.
     \]
-    for every word $w$ of length $L$ implies $\Delta_k=0$ for every block $k$.
 \end{definition}
 
 \begin{figure}[ht]
@@ -115,45 +116,68 @@
     \lean{MPOTensor.horizontalCFData_of_wordEntryFamily_linearIndependent}
     \lean{MPOTensor.horizontalCFData_of_propBlockInjective}
     \leanok
-    Let $(A_k)$ be a family of block tensors, and fix a length $L$.
-    Write $A_k^w$ for the length-$L$ word evaluation of $A_k$ along a word $w$.
-    The finite-length spanning hypothesis says that the tuple-valued evaluations
+    Let $(A_k)_{k}$ be a finite family of block tensors of physical
+    dimension~$d$, and fix a length $L$; write $A_k^w$ for the length-$L$
+    word evaluation of $A_k$ along a word $w \in \{0,\ldots,d{-}1\}^L$. The
+    finite-length spanning hypothesis is that the tuple-valued evaluations
+    span the full product algebra of block matrices,
     \[
-        w \longmapsto (A_k^w)_k
+        \spn_{\C}\bigl\{\,w \longmapsto (A_k^w)_k
+            : w \in \{0,\ldots,d{-}1\}^L\,\bigr\}
+        = \textstyle\prod_k \MN{D_k}.
     \]
-    span the full product algebra of block matrices.
-    The corresponding finite-length separation property asserts that there
-    exists a length $L$ such that if, for every word $w$ of length~$L$,
+    The corresponding finite-length separation property is that some length
+    $L$ makes the trace pairing against block words nondegenerate: there is
+    a length $L$ such that, for every tuple $(\Delta_k)_k$ of block
+    matrices,
     \[
-        \sum_k \tr(\Delta_k A_k^w) = 0
+        \Bigl(\forall\, w \in \{0,\ldots,d{-}1\}^L,\
+            \textstyle\sum_k \tr(\Delta_k A_k^w) = 0\Bigr)
+        \implies \forall k,\ \Delta_k = 0.
     \]
-    then these pairings vanish on a spanning set for the product algebra, so
-    the induced linear functional on the product algebra is zero; by
-    nondegeneracy of the product trace pairing, every $\Delta_k$ vanishes.
-    In other words, a single finite blocking length already separates the blocks
-    by their word evaluations. Combined with injectivity, left-canonicality, and
-    nonzero block weights, this finite-length separation yields the horizontal
-    canonical-form data of the block-diagonal tensor.
+    Spanning at length~$L$ gives separation at the same length: a trace
+    functional that vanishes on every tuple $(A_k^w)_k$ vanishes on their
+    span, hence on the whole product algebra, so nondegeneracy of the
+    product trace pairing forces every $\Delta_k=0$. Combined with
+    injectivity, left-canonicality, and nonzero block weights, this
+    finite-length separation yields the horizontal canonical-form data of
+    the block-diagonal tensor.
 
-    The entrywise scalar family of block-matrix coefficients encodes the same
-    finite-length data. Linear independence of that scalar family implies the
-    product-algebra spanning statement, hence a block-injective
-    canonical-form witness. The same criterion therefore gives horizontal
-    canonical-form data directly.
-    The duplicate-scalar counterexample shows that this finite-length witness
+    The spanning hypothesis has an equivalent entrywise form. For a block
+    index $k$ and matrix entry $(a,b)$, let
+    \[
+        w \longmapsto (A_k^w)_{a,b}
+    \]
+    be the corresponding scalar word family, indexed jointly by the triple
+    $(k,a,b)$. Linear independence of this scalar family already implies
+    the spanning condition, hence the separation property, and hence the
+    horizontal canonical-form data directly.
+
+    The duplicate-scalar counterexample shows that the separation property
     is strictly stronger than blockwise injectivity, left-canonicality, and
-    nonzero weights alone: two identical scalar blocks satisfy those hypotheses,
-    but the block-injective canonical-form separation condition fails and no
-    blocking length makes the entrywise family linearly independent.
+    nonzero weights alone. Take $d=1$ and two blocks of bond dimension~$1$
+    with $A_0^{0}=A_1^{0}=1$ and weights $\mu_0=1$, $\mu_1=2$: both blocks
+    are injective and left-canonical, $(A_k^0)^\dagger A_k^0=1$, and the
+    weights are nonzero, but at every length $L$ there is a unique word $w$
+    and $A_0^w=A_1^w=1$, so $\Delta_0=1$, $\Delta_1=-1$ satisfies
+    $\sum_k \tr(\Delta_k A_k^w)=0$ while $\Delta\neq0$. Thus the separation
+    property fails, and no length makes the entrywise scalar family linearly
+    independent.
 
-    The block-injectivity proposition in
+    The block-injectivity proposition of
     \cite[lines~340--345]{Cirac2016MPDO_arXiv} gives a concrete sufficient
-    criterion for the spanning condition: after a common blocking length each
-    block is block-injective, and after a further finite blocking length one
-    can form linear combinations of word evaluations which equal the identity
-    on one chosen block and vanish on all others. Concatenating an injective
-    prefix with this finite block-separation data produces the product-algebra
-    spanning condition, hence the horizontal canonical-form data.
+    criterion for the spanning condition: a common length $L$ with every
+    block $L$-block-injective, together with a length $S$ at which, for
+    every $k$, there is a coefficient family $(c_w)_{w \in
+    \{0,\ldots,d{-}1\}^S}$ with
+    \[
+        \sum_w c_w A_k^w = \Id,
+        \qquad
+        \forall\, j\neq k,\ \sum_w c_w A_j^w = 0.
+    \]
+    Concatenating the injective prefix with this finite selector family
+    produces the spanning condition at length $L+S$, hence the separation
+    property and the horizontal canonical-form data.
 \end{remark}
 
 \begin{figure}[ht]
@@ -199,12 +223,22 @@
     \uses{def:block_diagonal_tensor, def:injective, thm:propblockinj_abstract}
     Let $\bigoplus_k \mu_k A_k$ be a block-diagonal tensor whose blocks are
     injective, left-canonical, weighted by nonzero scalars, and jointly
-    block-injective in the sense that for some blocking length~$L$ the tuple of
-    trace pairings against length-$L$ block words is faithful across all blocks
-    simultaneously.
-    If two physical operators induce the same first-site action on every MPV
-    generated by this tensor, then their first-site insertions agree on each
-    block $A_k$.
+    block-injective in the sense that for some blocking length~$L$ the tuple
+    of trace pairings against length-$L$ block words is faithful across all
+    blocks simultaneously.
+    For $Y\in M_d(\C)$, write $(YA_k)^i := \sum_{j=0}^{d-1}Y_{i,j}A_k^j$ for
+    the physical-index insertion of $Y$ into block $A_k$, and for a
+    configuration $\sigma=(i_1,\ldots,i_N)$ write
+    \[
+        \bigl(Y_1V^{(N)}(A)\bigr)_{(i_1,\ldots,i_N)}
+        := \sum_{j=0}^{d-1} Y_{i_1,j}\, V^{(N)}(A)_{(j,i_2,\ldots,i_N)}
+    \]
+    for $Y$ acting on the first physical index of the MPV.
+    If $Y,Z\in M_d(\C)$ satisfy
+    \[
+        Y_1V^{(N)}(A) = Z_1V^{(N)}(A)
+    \]
+    for every $N\ge 1$, then $YA_k=ZA_k$ for every block $k$.
 
     \textbf{Scope restriction (per-block separation).} The source's Lemma~L
     separates blockwise contributions at the level of a minimal basis of
@@ -294,12 +328,20 @@
     \lean{MPOTensor.blockwise_opposite_insert_eq_of_mpv_agree}
     \leanok
     \uses{def:block_diagonal_tensor, thm:propblockinj_abstract}
-    Let $\bigoplus_k\mu_kA_k$ be in block-injective canonical form.  Suppose
-    three first-site contractions represent $PH^{(N)}$, $PH^{(N)}P$, and
-    $H^{(N)}P$, respectively.  If the first and second contractions agree for
-    every $N$, and the first and third contractions agree for every $N$, then
-    the insertions representing $H^{(N)}P$ and $PH^{(N)}P$ agree on each block
-    $A_k$.
+    Let $\bigoplus_k\mu_kA_k$ be in block-injective canonical form and let
+    $Y_L,Y_C,Y_R\in M_d(\C)$, with $Y_1V^{(N)}(A)$ denoting $Y$ acting on the
+    first physical index of the MPV as in
+    Lemma~\ref{lem:blockwise_insert_eq_of_mpv_agree}. If, for every
+    $N\ge 1$,
+    \[
+        (Y_L)_1V^{(N)}(A) = (Y_C)_1V^{(N)}(A),
+        \qquad
+        (Y_L)_1V^{(N)}(A) = (Y_R)_1V^{(N)}(A),
+    \]
+    then $Y_RA_k=Y_CA_k$ for every block $A_k$. This anticipates the
+    concrete instantiation with $Y_L,Y_C,Y_R$ the physical-index insertions
+    of $P$, $PHP$, $HP$ in
+    Theorem~\ref{thm:blockwise_opposite_insert_rotated_mpo}.
 
     \textbf{Scope restriction (per-block separation).} Inherited from
     Lemma~\ref{lem:blockwise_insert_eq_of_mpv_agree}: decompositions with

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -8,9 +8,13 @@
     This structure records the local ingredients of
     \cite[Appendix~C.2]{Cirac2016MPDO_arXiv}: a normalized
     three-site reduced state with equality in strong subadditivity, the
-    resulting local $\eta$-structure, and the rank-one conclusion for the
-    auxiliary primitive matrix $T$, supplied here through the conditional
-    rank-one criterion of Theorem~\ref{thm:sal_zcl_implies_rank_one_t}.
+    resulting local $\eta$-structure, and, supplied here through the
+    conditional rank-one criterion of
+    Theorem~\ref{thm:sal_zcl_implies_rank_one_t}, a rank-one factorization
+    \[
+        T = a b^\top, \qquad a \cdot b = 1,
+    \]
+    for the auxiliary primitive matrix $T$.
 \end{definition}
 
 \begin{theorem}[Local simple-MPDO structure from entropy data and the rank-one criterion]
@@ -24,8 +28,14 @@
         thm:pairing_idempotent_rank_one_t}
     The hypotheses of \cite[Lemmas~C.2, C.4, and~C.5]{Cirac2016MPDO_arXiv}
     determine the local simple-MPDO
-    structure. There are three forms. The conditional form assumes the
-    rank-one implication for $T$. The corrected form assumes instead that
+    structure. There are three forms. The conditional form supplies the
+    Perron--Frobenius hypothesis of
+    Theorem~\ref{thm:sal_zcl_implies_rank_one_t} directly, yielding the
+    rank-one factorization
+    \[
+        T = a b^\top, \qquad a \cdot b = 1.
+    \]
+    The corrected form assumes instead that
     $T\ge 0$ as a matrix, with $\operatorname{tr}(T)=1$ and
     $\operatorname{tr}(T^m)=1$ for every $m>0$, and then applies
     Theorem~\ref{thm:psd_trace_powers_rank_one_t}. The pairing-idempotence
@@ -122,8 +132,11 @@
     \leanok
     \uses{def:phys_close, def:mpdo_four_site_physical_closure}
     Under the canonical right-associated identification of four-site
-    configurations with quadruples of physical indices, the general
-    length-four closure is $K_4(X)$.
+    configurations with quadruples of physical indices,
+    \[
+        K_4(X)_{(i_0,(i_1,(i_2,i_3))),(j_0,(j_1,(j_2,j_3)))}
+          =\tr\!\left(K^{i_0j_0}K^{i_1j_1}K^{i_2j_2}K^{i_3j_3}X\right).
+    \]
 \end{theorem}
 
 \begin{proof}\leanok
@@ -212,13 +225,16 @@
     local $\eta$-structure and a primitive matrix $T$ with
     $\operatorname{tr}(T)=1$, and the doubled-index transfer condition together with
     \cite[Lemma~C.5]{Cirac2016MPDO_arXiv} gives
-    $\operatorname{tr}(T^m)$ independent of $m$ and the conditional rank-one
-    criterion for $T$. Suppose also that the assembled $\eta$-local structure gives
+    $\operatorname{tr}(T^m)$ independent of $m$ and the rank-one factorization
+    \[
+        T = a b^\top, \qquad a \cdot b = 1.
+    \]
+    Suppose also that the assembled $\eta$-local structure gives
     $\sigma^{(N)}(K)=c_N\prod_{n=1}^N B_{n,n+1}$ with $c_N>0$,
     $B_{n,n+1}\ge 0$, and $[B_{i,i+1},B_{j,j+1}]=0$ for all $i,j$.
     Then these hypotheses determine the simple-MPDO blocked-RFP structure for $K$.
-    In the PSD-corrected form, the conditional rank-one criterion is replaced
-    by $T\ge0$, $\operatorname{tr}(T)=1$, and
+    In the PSD-corrected form, the rank-one factorization hypothesis is
+    replaced by $T\ge0$, $\operatorname{tr}(T)=1$, and
     $\operatorname{tr}(T^m)=1$ for all $m>0$.
 \end{theorem}
 
@@ -245,11 +261,14 @@
 \end{theorem}
 
 \begin{proof}\leanok
-    The doubled-index transfer condition is transfer-map idempotence. Applying
-    the converse direction of
-    Theorem~\ref{thm:mpdo_rfp_via_fusion_iff} to that RFP witness yields
-    fusion-isometry data at every positive blocked size; evaluating it at size $2$
-    produces the blocked witness.
+    The doubled-index transfer condition is transfer-map idempotence, and
+    \[
+        \E_K\circ\E_K=\E_K
+        \Longrightarrow \operatorname{RFP}(K)
+        \Longrightarrow \operatorname{FusionWitness}_{2}(K)
+    \]
+    by the converse direction of Theorem~\ref{thm:mpdo_rfp_via_fusion_iff},
+    evaluated at blocked size $2$.
 \end{proof}
 
 \begin{theorem}[Blocked-RFP data give a blocked fusion-isometry witness]
@@ -384,7 +403,10 @@
         thm:simple_mpdo_rfp_chain_of_data}
     Assume the local hypotheses of
     \cite[Lemmas~C.2, C.4, and~C.5]{Cirac2016MPDO_arXiv} and the assembled
-    $\eta$-local product form, with the conditional rank-one criterion for $T$
+    $\eta$-local product form, with the rank-one factorization
+    \[
+        T = a b^\top, \qquad a \cdot b = 1,
+    \]
     and the doubled-index transfer equation
     \[
         \E_K\circ\E_K=\E_K.
@@ -395,8 +417,8 @@
     fusion-isometry witness at size $2$, and satisfies the
     transfer-map fusion formulation of idempotence. The
     PSD-corrected form uses $T\ge0$ together with
-    $\operatorname{tr}(T^m)=1$ for all $m>0$ in place of the conditional
-    matrix rank-one hypothesis.
+    $\operatorname{tr}(T^m)=1$ for all $m>0$ in place of the rank-one
+    factorization hypothesis.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -422,11 +444,21 @@
 \begin{proof}\leanok
     The commuting-form and doubled-index transfer hypotheses give the GSNNCH
     branch via
-    Theorem~\ref{thm:mpdo_is_gsnnch_zcl_iff_has_commuting_form_and_is_zcl}.
-    The blocked witness is Theorem~\ref{thm:structural_implies_rfp_blocked}. The
-    full transfer-map fusion formulation follows by applying the converse direction
-    of Theorem~\ref{thm:mpdo_rfp_via_fusion_iff} to the doubled-index transfer
-    condition, which is transfer-map idempotence.
+    Theorem~\ref{thm:mpdo_is_gsnnch_zcl_iff_has_commuting_form_and_is_zcl}. The
+    doubled-index transfer condition is transfer-map idempotence, and
+    \[
+        \E_K\circ\E_K=\E_K \Longrightarrow
+        \operatorname{RFP}(K) \Longrightarrow
+        \operatorname{RFP}_{\mathrm{fusion}}(K),
+    \]
+    \[
+        \E_K\circ\E_K=\E_K \Longrightarrow
+        \operatorname{RFP}(K) \Longrightarrow
+        \operatorname{FusionWitness}_{2}(K),
+    \]
+    the first by the converse direction of
+    Theorem~\ref{thm:mpdo_rfp_via_fusion_iff}, the second by
+    Theorem~\ref{thm:structural_implies_rfp_blocked}.
 \end{proof}
 
 \begin{remark}[Missing implication for the GSNNCH branch]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -52,9 +52,12 @@
     \lean{MPOTensor.BNTLabelOperatorFamily.HasSameLengthProductForm.eq_sum}
     \leanok
     \uses{def:mpdo_bnt_label_same_length_product_form}
-    Under same-length BNT product form, the product of two length-$L$
-    BNT-label operators is the corresponding finite linear combination of
-    length-$L$ BNT-label operators.
+    Under same-length BNT product form, for every positive length $L$,
+    \[
+        O_L(M_\alpha)O_L(M_\beta)
+        = \sum_\gamma
+        c^{(L)}_{\alpha,\beta,\gamma} O_L(M_\gamma).
+    \]
 \end{theorem}
 \begin{proof}\leanok
     This is exactly the defining equality of same-length product form.
@@ -91,9 +94,12 @@
     \lean{MPOTensor.BNTLabelTraceScalarFamily.HasIdempotentCoefficientForm.eq_sum}
     \leanok
     \uses{def:mpdo_bnt_label_idempotent_coefficient_form}
-    Under BNT idempotent coefficient form, each $m_\gamma$ is the
-    corresponding finite linear combination of products $m_\alpha m_\beta$
-    with the length-one coefficients $c^{(1)}_{\alpha,\beta,\gamma}$.
+    Under BNT idempotent coefficient form, for every BNT label $\gamma$,
+    \[
+        m_\gamma =
+        \sum_{\alpha,\beta}
+        c^{(1)}_{\alpha,\beta,\gamma}m_\alpha m_\beta.
+    \]
 \end{theorem}
 \begin{proof}\leanok
     This is exactly the defining equality of BNT idempotent coefficient form.
@@ -142,8 +148,13 @@
     \lean{MPOTensor.BNTBlockedBasisCoefficientComparison.blocked_coeff_eq}
     \leanok
     \uses{def:mpdo_bnt_blocked_basis_coefficient_comparison}
-    Under a BNT comparison with blocked coefficients, each chosen blocked-basis
-    multiplication coefficient is the corresponding BNT-label coefficient.
+    Under a BNT comparison with blocked coefficients, for every positive
+    blocked length $n$ and indices $i,j,k$,
+    \[
+        c^{(n)}_{i,j,k}
+        =
+        c^{(n)}_{\sigma_n(i),\sigma_n(j),\tau_n(k)}.
+    \]
 \end{theorem}
 \begin{proof}\leanok
     This is exactly the defining equality of the comparison.
@@ -172,8 +183,10 @@
     \uses{def:mpdo_bnt_label_positive_length_chi_trace_power_form,
         thm:mpdo_trace_matrix_pow}
     Under positive-length BNT-label trace-power form, for every $L>0$,
-    $c^{(L)}_{\alpha,\beta,\gamma}$ is the trace of
-    $\chi_{\alpha,\beta,\gamma}^{L}$.
+    \[
+        c^{(L)}_{\alpha,\beta,\gamma}
+        = \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{L}).
+    \]
 \end{theorem}
 \begin{proof}\leanok
     Combine the defining positive-length trace-power identity with the trace
@@ -349,9 +362,15 @@
     \lean{MPOTensor.AlgebraStructureData.BlockedStructureChiFamily}
     \leanok
     \uses{def:mpdo_blocked_structure_coefficients}
-    A dependent diagonal matrix family indexed by the blocked multiplication
-    triples $(n,i,j,k)$, where $i$ and $j$ label basis elements of
-    $\mathcal{A}_n$ and $k$ labels a basis element of $\mathcal{A}_{2n}$.
+    For each blocked multiplication triple $(n,i,j,k)$, where $i$ and $j$
+    label basis elements of $\mathcal{A}_n$ and $k$ labels a basis element of
+    $\mathcal{A}_{2n}$, a size $r_{n,i,j,k} \in \N$ and diagonal entries
+    $\chi_{n,i,j,k,1}, \ldots, \chi_{n,i,j,k,r_{n,i,j,k}} \in \C$, giving the
+    diagonal matrix
+    \[
+        \chi_{n,i,j,k}
+        = \diag\bigl(\chi_{n,i,j,k,1}, \ldots, \chi_{n,i,j,k,r_{n,i,j,k}}\bigr).
+    \]
     This is a blocked-basis analog of the uniform BNT-label family in
     \cite[Theorem~4.14(ii)]{Cirac2016MPDO_arXiv}; the remaining uniformity
     gap is recorded in
@@ -364,8 +383,11 @@
     \leanok
     \uses{def:mpdo_blocked_structure_chi_family}
     For each blocked multiplication triple $(n,i,j,k)$ and every exponent
-    $L$, the trace of the $L$-th power of its diagonal matrix is the sum of the
-    $L$-th powers of the corresponding diagonal entries.
+    $L$,
+    \[
+        \operatorname{tr}(\chi_{n,i,j,k}^{\,L})
+        = \sum_r \chi_{n,i,j,k,r}^{\,L}.
+    \]
 \end{theorem}
 \begin{proof}\leanok
     Diagonal matrices raise to powers entrywise and the trace of a diagonal
@@ -398,9 +420,11 @@
     \uses{def:mpdo_has_blocked_structure_chi_trace_power_form,
         thm:mpdo_blocked_structure_chi_trace_matrix_pow}
     Under trace-power form for the blocked multiplication coefficients,
-    for every positive blocked size $n$, the coefficient $c^{(n)}_{i,j,k}$ is
-    the trace of the $n$-th power of the diagonal matrix attached to
-    $(n,i,j,k)$.
+    for every positive blocked size $n$,
+    \[
+        c^{(n)}_{i,j,k}
+        = \operatorname{tr}(\chi_{n,i,j,k}^{\,n}).
+    \]
 \end{theorem}
 \begin{proof}\leanok
     Combine the defining trace-power identity with the trace formula for
@@ -522,9 +546,10 @@
     length independent. Then every diagonal entry
     $\chi_{\alpha,\beta,\gamma,r}$ lies in $\{0,1\}$, as stated in
     \cite[Section~4.5]{Cirac2016MPDO_arXiv}; by positivity every entry
-    equals one. Consequently, at every positive length the coefficient
-    $c^{(L)}_{\alpha,\beta,\gamma}$ is the size of the diagonal matrix
-    $\chi_{\alpha,\beta,\gamma}$, a natural number.
+    equals one. Consequently, at every positive length,
+    \[
+        c^{(L)}_{\alpha,\beta,\gamma} = r_{\alpha,\beta,\gamma} \in \N.
+    \]
 \end{theorem}
 \begin{proof}\leanok
     For fixed labels, the trace-power form turns length independence into
@@ -545,9 +570,12 @@
     \uses{def:mpdo_bnt_label_length_independent,
         def:mpdo_bnt_label_positive_length_chi_trace_power_form}
     If a BNT-label coefficient system is in trace-power form with respect
-    to a diagonal $\chi$-family all of whose entries equal one, then it is
-    length independent: at every positive length each coefficient equals
-    the size of the corresponding diagonal matrix.
+    to a diagonal $\chi$-family all of whose entries equal one, then for
+    every $L>0$,
+    \[
+        c^{(L)}_{\alpha,\beta,\gamma} = r_{\alpha,\beta,\gamma},
+    \]
+    so the coefficient system is length independent.
 \end{theorem}
 \begin{proof}\leanok
     The power sums of a family of ones do not depend on the exponent.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -3408,10 +3408,15 @@ $\widehat{\cal K}$.
     \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.localizedPhysicalTMap}
     \leanok
     \uses{def:mpdo_physical_t_map}
-    Reassociate three sites as $(12)3$, apply
-    $\widehat{\mathcal T}\otimes\operatorname{id}$, and reassociate the
-    result as $1(2(34))$. This defines the localized refinement channel on
-    right-associated physical coordinates.
+    Reassociating three right-associated sites as $(12)3$, applying
+    $\widehat{\mathcal T}\otimes\operatorname{id}$ to the first two, and
+    reassociating the result back to $1(2(34))$ defines the localized
+    refinement channel
+    \[
+      \widehat{\mathcal T}_{(12)3}:
+      M_{q^3}(\mathbb C)\longrightarrow M_{q^4}(\mathbb C)
+    \]
+    on right-associated physical coordinates.
 \end{definition}
 
 \begin{theorem}[The localized physical refinement is a channel]
@@ -3458,10 +3463,15 @@ $\widehat{\cal K}$.
     \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.localizedPhysicalSMap}
     \leanok
     \uses{def:mpdo_physical_s_map}
-    Reassociate four sites as $(123)4$, apply
-    $\widehat{\mathcal S}\otimes\operatorname{id}$, and reassociate the
-    result as $1(23)$. This defines the localized coarse-graining channel on
-    right-associated physical coordinates.
+    Reassociating four right-associated sites as $(123)4$, applying
+    $\widehat{\mathcal S}\otimes\operatorname{id}$ to the first three, and
+    reassociating the result back to $1(23)$ defines the localized
+    coarse-graining channel
+    \[
+      \widehat{\mathcal S}_{(123)4}:
+      M_{q^4}(\mathbb C)\longrightarrow M_{q^3}(\mathbb C)
+    \]
+    on right-associated physical coordinates.
 \end{definition}
 
 \begin{theorem}[The localized physical coarse-graining is a channel]


### PR DESCRIPTION
## Summary

Second batch of the formula-first blueprint clarity pass, covering the entries deferred from #3774. Each rewritten entry states its hypotheses and conclusion as displayed formulas instead of paraphrasing them in prose. All `\lean`, `\leanok`, `\uses`, and `\label` tags and all Lean identifiers are unchanged; only the surrounding mathematical prose was rewritten.

Entries rewritten, by file:

**`blueprint/src/chapter/ch20_mpdo_canonical_forms.tex`**
- `def:horizontal_cf_mpdo` — block-separation condition as a displayed implication
- `rem:word_tuple_span_top` — spanning/separation hypotheses, entrywise scalar form, and the duplicate-scalar counterexample as explicit formulas
- `lem:blockwise_insert_eq_of_mpv_agree` — first-site insertion notation and hypothesis/conclusion as displayed formulas
- `thm:blockwise_opposite_insert_eq` — three-contraction hypothesis and conclusion as displayed formulas

**`blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex`**
- `thm:mpdo_bnt_label_same_length_product_eq_sum` — product expansion formula
- `thm:mpdo_bnt_label_idempotent_coefficient_eq_sum` — idempotent coefficient formula
- `thm:mpdo_bnt_blocked_basis_coefficient_eq` — coefficient pullback formula
- `thm:mpdo_bnt_label_chi_eq_trace_matrix_pow` — trace-power formula
- `def:mpdo_blocked_structure_chi_family` — diagonal matrix construction as a formula
- `thm:mpdo_blocked_structure_chi_trace_matrix_pow` — trace-power sum formula
- `thm:mpdo_blocked_structure_chi_eq_trace_matrix_pow` — trace-power formula
- `thm:mpdo_bnt_label_length_independent_of_unit_entries` — length-independence conclusion as a formula
- `thm:mpdo_bnt_label_length_independent_natural` — natural-number conclusion as a formula

**`blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex`**
- `def:simple_mpdo_local_structure_data` — rank-one factorization as a displayed formula
- `thm:simple_mpdo_local_structure_data_of_sal_zcl` — rank-one factorization formula in the conditional-form case
- `thm:mpdo_phys_close_four` — four-site closure identity as a displayed formula
- `thm:simple_mpdo_blocked_rfp_data_of_sal_zcl_and_eta_local_structure` — rank-one factorization formula
- `thm:structural_implies_rfp_blocked` (proof) — implication chain as a displayed formula
- `thm:simple_mpdo_rfp_chain_of_sal_zcl_and_eta_local_structure` — rank-one factorization formula
- `thm:simple_mpdo_rfp_chain` (proof) — implication chains as displayed formulas

**`blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex`**
- `def:mpdo_localized_physical_t_map` — localized refinement channel as a displayed formula
- `def:mpdo_localized_physical_s_map` — localized coarse-graining channel as a displayed formula

## Test plan
- [x] `cd blueprint && leanblueprint pdf` builds successfully (507 pages, no LaTeX errors, no undefined references)
- [x] Spot-checked every rewritten entry's rendered page against the intended formula-first prose
- [x] `lake build TNLean` completes successfully (9329/9329 jobs)
- [x] `leanblueprint checkdecls` passes
- [x] `python3 scripts/blueprint_lean_sync.py --update-lean-decls` reports blueprint and Lean in sync (no diff produced)
- [x] `python3 scripts/check_reader_facing_prose.py --diff-base origin/main` reports no violations
- [x] `chktex` on changed files shows only pre-existing style warning classes (no new categories)
- [x] `git diff --check` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to blueprint `.tex` files; no runtime, auth, or Lean proof changes indicated in the diff.
> 
> **Overview**
> **Formula-first clarity** for deferred blueprint entries in the MPO / MPDO chapters: surrounding prose is rewritten so hypotheses and conclusions appear as **displayed equations**, without changing `\lean`, `\leanok`, `\uses`, or labels.
> 
> **`ch20_mpdo_canonical_forms.tex`** sharpens horizontal canonical form and finite block-separation (spanning vs. trace nondegeneracy), adds an explicit duplicate-scalar counterexample and block-selector criterion, and states **first-site MPV insertion** notation and the blockwise lemmas/theorems in formula form.
> 
> **`ch21_mpdo_rfp_bnt_coefficients.tex`** turns BNT product, idempotent, blocked pullback, and χ trace-power statements into explicit sums/traces; the blocked χ family is defined via **diag(χ₁,…,χ_r)**; length-independence conclusions use **c = r ∈ ℕ**.
> 
> **`ch21_mpdo_rfp_blocked_rfp.tex`** and **`ch21_mpdo_rfp_simple_local_structure.tex`** replace paraphrases with **T = abᵀ**, four-site closure **K₄(X)**, RFP implication chains (**𝔼_K∘𝔼_K = 𝔼_K ⇒ …**), and localized refinement/coarse-graining maps **𝒯̂_(12)3**, **Ŝ_(123)4**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73f4d8eaf6ba78658a364b3012513def32283aba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->