### PR TITLE
feat(MPS/MPDO): transport blocked RFP to physical tensor

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -408,6 +408,8 @@ import TNLean.MPS.MPDO.PhysicalSectorRefinementAction
 import TNLean.MPS.MPDO.PhysicalSectorRefinementIdentity
 import TNLean.MPS.MPDO.PhysicalSectorPhysicalMaps
 import TNLean.MPS.MPDO.PhysicalSectorBlockedRFP
+import TNLean.MPS.MPDO.PhysicalSectorCoordinateTransport
+import TNLean.MPS.MPDO.PhysicalSectorPhysicalTransport
 import TNLean.MPS.MPDO.SectorPairingTransfer
 import TNLean.MPS.MPDO.SectorEtaContraction
 import TNLean.MPS.MPDO.SectorEtaOperator

--- a/TNLean/MPS/MPDO/KrausCPTP.lean
+++ b/TNLean/MPS/MPDO/KrausCPTP.lean
@@ -24,6 +24,10 @@ dimensions.
 * `isKrausCPTP_id`: the identity map is trace-preserving completely positive.
 * `isKrausCPTP_of_singleKraus`: conjugation by an isometry is trace-preserving
   completely positive.
+* `sandwichMap`: the linear map given by conjugation with one rectangular
+  matrix.
+* `sandwichMap_isKrausCPTP`: an isometric sandwich map is trace-preserving
+  completely positive.
 * `isKrausCPTP_comp`: composition preserves the trace-preserving completely
   positive property.
 * `Matrix.equivReindexMap_isKrausCPTP`: reindexing by an equivalence is
@@ -81,6 +85,26 @@ theorem isKrausCPTP_of_singleKraus {α β : Type*} [Fintype α] [DecidableEq α]
   · intro X
     simpa only [Fin.sum_univ_one] using hform X
   · simpa only [Fin.sum_univ_one] using hV
+
+/-- The single-Kraus sandwich by a rectangular matrix. -/
+noncomputable def sandwichMap {α β : Type*} [Fintype α] [Fintype β]
+    (V : Matrix β α ℂ) : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ where
+  toFun X := V * X * Vᴴ
+  map_add' X Y := by simp [Matrix.mul_add, Matrix.add_mul]
+  map_smul' c X := by simp [Matrix.mul_smul, Matrix.smul_mul]
+
+@[simp] theorem sandwichMap_apply {α β : Type*} [Fintype α] [Fintype β]
+    (V : Matrix β α ℂ) (X : Matrix α α ℂ) :
+    sandwichMap V X = V * X * Vᴴ :=
+  rfl
+
+/-- The sandwich map associated with an isometry is trace-preserving and
+completely positive. -/
+theorem sandwichMap_isKrausCPTP {α β : Type*}
+    [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]
+    (V : Matrix β α ℂ) (hV : Vᴴ * V = 1) :
+    IsKrausCPTP (sandwichMap V) :=
+  isKrausCPTP_of_singleKraus V (fun _ ↦ rfl) hV
 
 /-- Composition of trace-preserving completely positive maps is again
 trace-preserving completely positive. If `T` has Kraus operators `Bⱼ` and `S`

--- a/TNLean/MPS/MPDO/PhysicalSectorCoordinateTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorCoordinateTransport.lean
@@ -1,0 +1,296 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalSectorBlockedRFP
+
+/-!
+# Physical-coordinate transport of sector closures
+
+This file identifies the two-site and four-site closures in the physical
+sector coordinates of Proposition C.7 with unitary congruences of the
+corresponding closures in the original physical coordinates.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Theorem 4.9, direction (iv) implies (v), and Appendix C.2, lines 1510--1563
+  and 1821--1825
+-/
+
+open scoped Matrix Kronecker
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D} {F : PhysicalSectorFactorization K}
+
+/-- The equivalence between the original physical indices and the finite
+encoding of the sector-coordinate indices. -/
+noncomputable def physicalFinEquiv
+    (F : PhysicalSectorFactorization K) :
+    Fin d ≃ Fin (Fintype.card (SectorSiteIndex F)) :=
+  F.sectorEquiv.trans F.sectorFinEquiv.symm
+
+/-- The physical isometry with its output index written in the finite
+sector-coordinate encoding. -/
+noncomputable def physicalCoordinateMatrix
+    (F : PhysicalSectorFactorization K) :
+    Matrix (Fin (Fintype.card (SectorSiteIndex F))) (Fin d) ℂ :=
+  Matrix.reindex F.physicalFinEquiv (Equiv.refl (Fin d)) F.physicalIsometry
+
+theorem physicalIsometry_mul_conjTranspose
+    (F : PhysicalSectorFactorization K) :
+    F.physicalIsometry * F.physicalIsometryᴴ = 1 := by
+  have hmem : F.physicalIsometry ∈ Matrix.unitaryGroup (Fin d) ℂ := by
+    rw [Matrix.mem_unitaryGroup_iff', Matrix.star_eq_conjTranspose]
+    exact F.physicalIsometry_isometry
+  simpa only [Matrix.star_eq_conjTranspose] using
+    (Matrix.mem_unitaryGroup_iff.mp hmem)
+
+theorem physicalCoordinateMatrix_isometry
+    (F : PhysicalSectorFactorization K) :
+    F.physicalCoordinateMatrixᴴ * F.physicalCoordinateMatrix = 1 := by
+  ext i j
+  simp only [physicalCoordinateMatrix, Matrix.mul_apply,
+    Matrix.conjTranspose_apply, Matrix.reindex_apply, Matrix.submatrix_apply,
+    Equiv.refl_symm, Equiv.refl_apply]
+  rw [← F.physicalFinEquiv.sum_comp (fun x ↦
+    star (F.physicalIsometry (F.physicalFinEquiv.symm x) i) *
+      F.physicalIsometry (F.physicalFinEquiv.symm x) j)]
+  simpa only [Equiv.symm_apply_apply, Matrix.mul_apply,
+    Matrix.conjTranspose_apply] using
+    congrFun (congrFun F.physicalIsometry_isometry i) j
+
+theorem physicalCoordinateMatrix_coisometry
+    (F : PhysicalSectorFactorization K) :
+    F.physicalCoordinateMatrix * F.physicalCoordinateMatrixᴴ = 1 := by
+  ext i j
+  simpa only [physicalCoordinateMatrix, Matrix.mul_apply,
+    Matrix.conjTranspose_apply, Matrix.reindex_apply, Matrix.submatrix_apply,
+    Equiv.refl_symm, Equiv.refl_apply, Matrix.one_apply,
+    Equiv.apply_eq_iff_eq] using
+    congrFun (congrFun F.physicalIsometry_mul_conjTranspose
+      (F.physicalFinEquiv.symm i)) (F.physicalFinEquiv.symm j)
+
+/-- Change the physical coordinates of an MPO tensor by a rectangular matrix. -/
+noncomputable def changePhysicalBasis {e : ℕ}
+    (V : Matrix (Fin e) (Fin d) ℂ) (M : MPOTensor d D) : MPOTensor e D :=
+  fun i j beta alpha ↦ (V * physicalSlice M beta alpha * Vᴴ) i j
+
+theorem sectorCoordinateTensor_eq_changePhysicalBasis
+    (F : PhysicalSectorFactorization K) :
+    F.sectorCoordinateTensor = changePhysicalBasis F.physicalCoordinateMatrix K := by
+  ext i j beta alpha
+  simp [sectorCoordinateTensor_apply, transformedPhysicalSlice,
+    changePhysicalBasis, physicalCoordinateMatrix, physicalFinEquiv,
+    Matrix.reindex_apply, Matrix.mul_apply, Matrix.conjTranspose_apply]
+
+/-- The two-site product of the physical coordinate matrix. -/
+noncomputable def physicalCoordinateMatrixTwo
+    (F : PhysicalSectorFactorization K) :
+    Matrix
+      (Fin (Fintype.card (SectorSiteIndex F)) ×
+        Fin (Fintype.card (SectorSiteIndex F)))
+      (Fin d × Fin d) ℂ :=
+  Matrix.kroneckerMap (· * ·)
+    F.physicalCoordinateMatrix F.physicalCoordinateMatrix
+
+/-- The right-associated four-site product of the physical coordinate matrix. -/
+noncomputable def physicalCoordinateMatrixFour
+    (F : PhysicalSectorFactorization K) :
+    Matrix
+      (Fin (Fintype.card (SectorSiteIndex F)) ×
+        (Fin (Fintype.card (SectorSiteIndex F)) ×
+          (Fin (Fintype.card (SectorSiteIndex F)) ×
+            Fin (Fintype.card (SectorSiteIndex F)))))
+      (Fin d × (Fin d × (Fin d × Fin d))) ℂ :=
+  Matrix.kroneckerMap (· * ·) F.physicalCoordinateMatrix
+    (Matrix.kroneckerMap (· * ·) F.physicalCoordinateMatrix
+      (Matrix.kroneckerMap (· * ·)
+        F.physicalCoordinateMatrix F.physicalCoordinateMatrix))
+
+theorem physicalCoordinateMatrixTwo_isometry
+    (F : PhysicalSectorFactorization K) :
+    F.physicalCoordinateMatrixTwoᴴ * F.physicalCoordinateMatrixTwo = 1 := by
+  rw [physicalCoordinateMatrixTwo, Matrix.conjTranspose_kronecker,
+    ← Matrix.mul_kronecker_mul, F.physicalCoordinateMatrix_isometry]
+  exact Matrix.one_kronecker_one
+
+theorem physicalCoordinateMatrixTwo_coisometry
+    (F : PhysicalSectorFactorization K) :
+    F.physicalCoordinateMatrixTwo * F.physicalCoordinateMatrixTwoᴴ = 1 := by
+  rw [physicalCoordinateMatrixTwo, Matrix.conjTranspose_kronecker,
+    ← Matrix.mul_kronecker_mul, F.physicalCoordinateMatrix_coisometry]
+  exact Matrix.one_kronecker_one
+
+theorem physicalCoordinateMatrixFour_isometry
+    (F : PhysicalSectorFactorization K) :
+    F.physicalCoordinateMatrixFourᴴ * F.physicalCoordinateMatrixFour = 1 := by
+  simp only [physicalCoordinateMatrixFour, Matrix.conjTranspose_kronecker,
+    ← Matrix.mul_kronecker_mul, F.physicalCoordinateMatrix_isometry]
+  repeat' rw [Matrix.one_kronecker_one]
+
+theorem physicalCoordinateMatrixFour_coisometry
+    (F : PhysicalSectorFactorization K) :
+    F.physicalCoordinateMatrixFour * F.physicalCoordinateMatrixFourᴴ = 1 := by
+  simp only [physicalCoordinateMatrixFour, Matrix.conjTranspose_kronecker,
+    ← Matrix.mul_kronecker_mul, F.physicalCoordinateMatrix_coisometry]
+  repeat' rw [Matrix.one_kronecker_one]
+
+/-- The single-Kraus sandwich by a rectangular matrix. -/
+noncomputable def sandwichMap {a b : Type*} [Fintype a] [Fintype b]
+    (V : Matrix b a ℂ) : Matrix a a ℂ →ₗ[ℂ] Matrix b b ℂ where
+  toFun X := V * X * Vᴴ
+  map_add' X Y := by simp [Matrix.mul_add, Matrix.add_mul]
+  map_smul' c X := by simp [Matrix.mul_smul, Matrix.smul_mul]
+
+@[simp] theorem sandwichMap_apply {a b : Type*} [Fintype a] [Fintype b]
+    (V : Matrix b a ℂ) (X : Matrix a a ℂ) :
+    sandwichMap V X = V * X * Vᴴ :=
+  rfl
+
+theorem changePhysicalBasis_apply_eq_sum {e : ℕ}
+    (V : Matrix (Fin e) (Fin d) ℂ) (M : MPOTensor d D)
+    (i j : Fin e) :
+    changePhysicalBasis V M i j =
+      ∑ p : Fin d × Fin d,
+        (V i p.1 * star (V j p.2)) • M p.1 p.2 := by
+  ext beta alpha
+  simp only [changePhysicalBasis, Matrix.mul_apply,
+    Matrix.conjTranspose_apply, Matrix.smul_apply, smul_eq_mul,
+    Matrix.sum_apply, Fintype.sum_prod_type, physicalSlice]
+  simp_rw [Finset.sum_mul]
+  rw [Finset.sum_comm]
+  refine Finset.sum_congr rfl fun x _ ↦ ?_
+  refine Finset.sum_congr rfl fun y _ ↦ ?_
+  ring
+
+/-- The two-site closure transforms by the two-site physical coordinate
+matrix. -/
+theorem physicalCoordinateMatrixTwo_physClose2
+    (F : PhysicalSectorFactorization K) (X : Matrix (Fin D) (Fin D) ℂ) :
+    sandwichMap F.physicalCoordinateMatrixTwo (physClose2 K X) =
+      physClose2 F.sectorCoordinateTensor X := by
+  rw [F.sectorCoordinateTensor_eq_changePhysicalBasis]
+  ext ⟨i₁, i₂⟩ ⟨j₁, j₂⟩
+  simp only [physClose2_apply]
+  simp_rw [changePhysicalBasis_apply_eq_sum]
+  simp only [sandwichMap_apply, Matrix.mul_apply, Matrix.conjTranspose_apply,
+    physicalCoordinateMatrixTwo, Matrix.kroneckerMap_apply, physClose2_apply,
+    Matrix.sum_mul, Matrix.mul_sum, Matrix.smul_mul, Matrix.mul_smul,
+    Matrix.trace_sum, Matrix.trace_smul, smul_eq_mul, star_mul']
+  simp_rw [Finset.mul_sum, Finset.sum_mul]
+  let e : ((Fin d × Fin d) × (Fin d × Fin d)) ≃
+      ((Fin d × Fin d) × (Fin d × Fin d)) := {
+    toFun := fun p : ((Fin d × Fin d) × (Fin d × Fin d)) ↦
+      ((p.2.2, p.1.2), (p.2.1, p.1.1))
+    invFun := fun p : ((Fin d × Fin d) × (Fin d × Fin d)) ↦
+      ((p.2.2, p.1.2), (p.2.1, p.1.1))
+    left_inv _ := rfl
+    right_inv _ := rfl }
+  have h := Fintype.sum_equiv e
+      (fun p ↦
+        F.physicalCoordinateMatrix i₁ p.2.1 *
+          F.physicalCoordinateMatrix i₂ p.2.2 *
+          Matrix.trace (K p.2.1 p.1.1 * K p.2.2 p.1.2 * X) *
+          (star (F.physicalCoordinateMatrix j₁ p.1.1) *
+            star (F.physicalCoordinateMatrix j₂ p.1.2)))
+      (fun p ↦
+        F.physicalCoordinateMatrix i₂ p.1.1 *
+          star (F.physicalCoordinateMatrix j₂ p.1.2) *
+          (F.physicalCoordinateMatrix i₁ p.2.1 *
+            star (F.physicalCoordinateMatrix j₁ p.2.2) *
+            Matrix.trace (K p.2.1 p.2.2 * K p.1.1 p.1.2 * X)))
+      (fun _ ↦ by dsimp [e]; ring)
+  rw [Fintype.sum_prod_type] at h
+  conv at h =>
+    rhs
+    rw [Fintype.sum_prod_type]
+  exact h
+
+/-- The four-site closure transforms by the four-site physical coordinate
+matrix. -/
+theorem physicalCoordinateMatrixFour_physClose4
+    (F : PhysicalSectorFactorization K) (X : Matrix (Fin D) (Fin D) ℂ) :
+    sandwichMap F.physicalCoordinateMatrixFour (physClose4 K X) =
+      physClose4 F.sectorCoordinateTensor X := by
+  rw [F.sectorCoordinateTensor_eq_changePhysicalBasis]
+  ext ⟨i₁, i₂, i₃, i₄⟩ ⟨j₁, j₂, j₃, j₄⟩
+  simp only [physClose4_apply]
+  simp_rw [changePhysicalBasis_apply_eq_sum]
+  simp only [sandwichMap_apply, Matrix.mul_apply, Matrix.conjTranspose_apply,
+    physicalCoordinateMatrixFour, Matrix.kroneckerMap_apply, physClose4_apply,
+    Matrix.sum_mul, Matrix.mul_sum, Matrix.smul_mul, Matrix.mul_smul,
+    Matrix.trace_sum, Matrix.trace_smul, smul_eq_mul, star_mul']
+  simp_rw [Finset.mul_sum, Finset.sum_mul]
+  let e :
+      ((Fin d × (Fin d × (Fin d × Fin d))) ×
+        (Fin d × (Fin d × (Fin d × Fin d)))) ≃
+      ((((Fin d × Fin d) × (Fin d × Fin d)) × (Fin d × Fin d)) ×
+        (Fin d × Fin d)) := {
+    toFun := fun p ↦
+      ((((p.2.2.2.2, p.1.2.2.2), (p.2.2.2.1, p.1.2.2.1)),
+        (p.2.2.1, p.1.2.1)), (p.2.1, p.1.1))
+    invFun := fun p ↦
+      ((p.2.2, (p.1.2.2, (p.1.1.2.2, p.1.1.1.2))),
+        (p.2.1, (p.1.2.1, (p.1.1.2.1, p.1.1.1.1))))
+    left_inv _ := rfl
+    right_inv _ := rfl }
+  have h := Fintype.sum_equiv e
+      (fun p ↦
+        F.physicalCoordinateMatrix i₁ p.2.1 *
+          (F.physicalCoordinateMatrix i₂ p.2.2.1 *
+            (F.physicalCoordinateMatrix i₃ p.2.2.2.1 *
+              F.physicalCoordinateMatrix i₄ p.2.2.2.2)) *
+          Matrix.trace
+            (K p.2.1 p.1.1 * K p.2.2.1 p.1.2.1 *
+              K p.2.2.2.1 p.1.2.2.1 * K p.2.2.2.2 p.1.2.2.2 * X) *
+          (star (F.physicalCoordinateMatrix j₁ p.1.1) *
+            (star (F.physicalCoordinateMatrix j₂ p.1.2.1) *
+              (star (F.physicalCoordinateMatrix j₃ p.1.2.2.1) *
+                star (F.physicalCoordinateMatrix j₄ p.1.2.2.2)))))
+      (fun p ↦
+        F.physicalCoordinateMatrix i₄ p.1.1.1.1 *
+          star (F.physicalCoordinateMatrix j₄ p.1.1.1.2) *
+          (F.physicalCoordinateMatrix i₃ p.1.1.2.1 *
+            star (F.physicalCoordinateMatrix j₃ p.1.1.2.2) *
+            (F.physicalCoordinateMatrix i₂ p.1.2.1 *
+              star (F.physicalCoordinateMatrix j₂ p.1.2.2) *
+              (F.physicalCoordinateMatrix i₁ p.2.1 *
+                star (F.physicalCoordinateMatrix j₁ p.2.2) *
+                Matrix.trace
+                  (K p.2.1 p.2.2 * K p.1.2.1 p.1.2.2 *
+                    K p.1.1.2.1 p.1.1.2.2 * K p.1.1.1.1 p.1.1.1.2 * X)))))
+      (fun _ ↦ by dsimp [e]; ring)
+  rw [Fintype.sum_prod_type] at h
+  conv at h =>
+    rhs
+    rw [Fintype.sum_prod_type]
+    rw [Fintype.sum_prod_type]
+    rw [Fintype.sum_prod_type]
+  exact h
+
+theorem physicalCoordinateMatrixTwo_conjTranspose_physClose2
+    (F : PhysicalSectorFactorization K) (X : Matrix (Fin D) (Fin D) ℂ) :
+    sandwichMap F.physicalCoordinateMatrixTwoᴴ
+        (physClose2 F.sectorCoordinateTensor X) =
+      physClose2 K X := by
+  rw [← F.physicalCoordinateMatrixTwo_physClose2]
+  simp only [sandwichMap_apply, Matrix.conjTranspose_conjTranspose]
+  simp only [← Matrix.mul_assoc, F.physicalCoordinateMatrixTwo_isometry,
+    Matrix.one_mul]
+  rw [Matrix.mul_assoc, F.physicalCoordinateMatrixTwo_isometry, Matrix.mul_one]
+
+theorem physicalCoordinateMatrixFour_conjTranspose_physClose4
+    (F : PhysicalSectorFactorization K) (X : Matrix (Fin D) (Fin D) ℂ) :
+    sandwichMap F.physicalCoordinateMatrixFourᴴ
+        (physClose4 F.sectorCoordinateTensor X) =
+      physClose4 K X := by
+  rw [← F.physicalCoordinateMatrixFour_physClose4]
+  simp only [sandwichMap_apply, Matrix.conjTranspose_conjTranspose]
+  simp only [← Matrix.mul_assoc, F.physicalCoordinateMatrixFour_isometry,
+    Matrix.one_mul]
+  rw [Matrix.mul_assoc, F.physicalCoordinateMatrixFour_isometry, Matrix.mul_one]
+
+end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/PhysicalSectorCoordinateTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorCoordinateTransport.lean
@@ -138,18 +138,6 @@ theorem physicalCoordinateMatrixFour_coisometry
     ← Matrix.mul_kronecker_mul, F.physicalCoordinateMatrix_coisometry]
   repeat' rw [Matrix.one_kronecker_one]
 
-/-- The single-Kraus sandwich by a rectangular matrix. -/
-noncomputable def sandwichMap {a b : Type*} [Fintype a] [Fintype b]
-    (V : Matrix b a ℂ) : Matrix a a ℂ →ₗ[ℂ] Matrix b b ℂ where
-  toFun X := V * X * Vᴴ
-  map_add' X Y := by simp [Matrix.mul_add, Matrix.add_mul]
-  map_smul' c X := by simp [Matrix.mul_smul, Matrix.smul_mul]
-
-@[simp] theorem sandwichMap_apply {a b : Type*} [Fintype a] [Fintype b]
-    (V : Matrix b a ℂ) (X : Matrix a a ℂ) :
-    sandwichMap V X = V * X * Vᴴ :=
-  rfl
-
 theorem changePhysicalBasis_apply_eq_sum {e : ℕ}
     (V : Matrix (Fin e) (Fin d) ℂ) (M : MPOTensor d D)
     (i j : Fin e) :

--- a/TNLean/MPS/MPDO/PhysicalSectorPhysicalTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorPhysicalTransport.lean
@@ -1,0 +1,270 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalSectorCoordinateTransport
+
+/-!
+# Transport of the blocked physical-sector fixed point
+
+This file transports the two-site blocked fixed-point channels from the
+sector coordinates of Proposition C.7 back to the original physical tensor.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Theorem 4.9, direction (iv) implies (v), and Appendix C.2, lines 1510--1563
+  and 1821--1825
+-/
+
+open scoped Matrix
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D} {F : PhysicalSectorFactorization K}
+
+private noncomputable def physicalBlockOneMap
+    (F : PhysicalSectorFactorization K) :
+    Matrix (Fin (d * d)) (Fin (d * d)) ℂ →ₗ[ℂ]
+      Matrix (Fin (Fintype.card (SectorSiteIndex F) *
+        Fintype.card (SectorSiteIndex F)))
+        (Fin (Fintype.card (SectorSiteIndex F) *
+          Fintype.card (SectorSiteIndex F))) ℂ :=
+  Matrix.equivReindexMap
+      (blockedIndexEquiv (Fintype.card (SectorSiteIndex F))).symm ∘ₗ
+    sandwichMap F.physicalCoordinateMatrixTwo ∘ₗ
+    Matrix.equivReindexMap (blockedIndexEquiv d)
+
+private noncomputable def physicalBlockOneInverseMap
+    (F : PhysicalSectorFactorization K) :
+    Matrix (Fin (Fintype.card (SectorSiteIndex F) *
+        Fintype.card (SectorSiteIndex F)))
+      (Fin (Fintype.card (SectorSiteIndex F) *
+        Fintype.card (SectorSiteIndex F))) ℂ →ₗ[ℂ]
+      Matrix (Fin (d * d)) (Fin (d * d)) ℂ :=
+  Matrix.equivReindexMap (blockedIndexEquiv d).symm ∘ₗ
+    sandwichMap F.physicalCoordinateMatrixTwoᴴ ∘ₗ
+    Matrix.equivReindexMap
+      (blockedIndexEquiv (Fintype.card (SectorSiteIndex F)))
+
+private noncomputable def physicalBlockTwoMap
+    (F : PhysicalSectorFactorization K) :
+    Matrix (Fin (d * d) × Fin (d * d)) (Fin (d * d) × Fin (d * d)) ℂ →ₗ[ℂ]
+      Matrix
+        (Fin (Fintype.card (SectorSiteIndex F) *
+            Fintype.card (SectorSiteIndex F)) ×
+          Fin (Fintype.card (SectorSiteIndex F) *
+            Fintype.card (SectorSiteIndex F)))
+        (Fin (Fintype.card (SectorSiteIndex F) *
+            Fintype.card (SectorSiteIndex F)) ×
+          Fin (Fintype.card (SectorSiteIndex F) *
+            Fintype.card (SectorSiteIndex F))) ℂ :=
+  Matrix.equivReindexMap
+      (blockedPairEquiv (Fintype.card (SectorSiteIndex F))).symm ∘ₗ
+    sandwichMap F.physicalCoordinateMatrixFour ∘ₗ
+    Matrix.equivReindexMap (blockedPairEquiv d)
+
+private noncomputable def physicalBlockTwoInverseMap
+    (F : PhysicalSectorFactorization K) :
+    Matrix
+        (Fin (Fintype.card (SectorSiteIndex F) *
+            Fintype.card (SectorSiteIndex F)) ×
+          Fin (Fintype.card (SectorSiteIndex F) *
+            Fintype.card (SectorSiteIndex F)))
+        (Fin (Fintype.card (SectorSiteIndex F) *
+            Fintype.card (SectorSiteIndex F)) ×
+          Fin (Fintype.card (SectorSiteIndex F) *
+            Fintype.card (SectorSiteIndex F))) ℂ →ₗ[ℂ]
+      Matrix (Fin (d * d) × Fin (d * d)) (Fin (d * d) × Fin (d * d)) ℂ :=
+  Matrix.equivReindexMap (blockedPairEquiv d).symm ∘ₗ
+    sandwichMap F.physicalCoordinateMatrixFourᴴ ∘ₗ
+    Matrix.equivReindexMap
+      (blockedPairEquiv (Fintype.card (SectorSiteIndex F)))
+
+private theorem sandwichMap_isKrausCPTP {a b : Type*}
+    [Fintype a] [DecidableEq a] [Fintype b] [DecidableEq b]
+    (V : Matrix b a ℂ) (hV : Vᴴ * V = 1) :
+    IsKrausCPTP (sandwichMap V) :=
+  isKrausCPTP_of_singleKraus V (fun _ ↦ rfl) hV
+
+private theorem physicalBlockOneMap_isKrausCPTP
+    (F : PhysicalSectorFactorization K) :
+    IsKrausCPTP (physicalBlockOneMap F) := by
+  exact isKrausCPTP_comp
+    (isKrausCPTP_comp
+      (Matrix.equivReindexMap_isKrausCPTP (blockedIndexEquiv d))
+      (sandwichMap_isKrausCPTP F.physicalCoordinateMatrixTwo
+        F.physicalCoordinateMatrixTwo_isometry))
+    (Matrix.equivReindexMap_isKrausCPTP
+      (blockedIndexEquiv (Fintype.card (SectorSiteIndex F))).symm)
+
+private theorem physicalBlockOneInverseMap_isKrausCPTP
+    (F : PhysicalSectorFactorization K) :
+    IsKrausCPTP (physicalBlockOneInverseMap F) := by
+  exact isKrausCPTP_comp
+    (isKrausCPTP_comp
+      (Matrix.equivReindexMap_isKrausCPTP
+        (blockedIndexEquiv (Fintype.card (SectorSiteIndex F))))
+      (sandwichMap_isKrausCPTP F.physicalCoordinateMatrixTwoᴴ (by
+        simpa using F.physicalCoordinateMatrixTwo_coisometry)))
+    (Matrix.equivReindexMap_isKrausCPTP (blockedIndexEquiv d).symm)
+
+private theorem physicalBlockTwoMap_isKrausCPTP
+    (F : PhysicalSectorFactorization K) :
+    IsKrausCPTP (physicalBlockTwoMap F) := by
+  exact isKrausCPTP_comp
+    (isKrausCPTP_comp
+      (Matrix.equivReindexMap_isKrausCPTP (blockedPairEquiv d))
+      (sandwichMap_isKrausCPTP F.physicalCoordinateMatrixFour
+        F.physicalCoordinateMatrixFour_isometry))
+    (Matrix.equivReindexMap_isKrausCPTP
+      (blockedPairEquiv (Fintype.card (SectorSiteIndex F))).symm)
+
+private theorem physicalBlockTwoInverseMap_isKrausCPTP
+    (F : PhysicalSectorFactorization K) :
+    IsKrausCPTP (physicalBlockTwoInverseMap F) := by
+  exact isKrausCPTP_comp
+    (isKrausCPTP_comp
+      (Matrix.equivReindexMap_isKrausCPTP
+        (blockedPairEquiv (Fintype.card (SectorSiteIndex F))))
+      (sandwichMap_isKrausCPTP F.physicalCoordinateMatrixFourᴴ (by
+        simpa using F.physicalCoordinateMatrixFour_coisometry)))
+    (Matrix.equivReindexMap_isKrausCPTP (blockedPairEquiv d).symm)
+
+private theorem physicalBlockOneMap_closure
+    (F : PhysicalSectorFactorization K) (X : Matrix (Fin D) (Fin D) ℂ) :
+    physicalBlockOneMap F (physClose1 (blockTwo K) X) =
+      physClose1 (blockTwo F.sectorCoordinateTensor) X := by
+  change Matrix.reindex
+      (blockedIndexEquiv (Fintype.card (SectorSiteIndex F))).symm
+      (blockedIndexEquiv (Fintype.card (SectorSiteIndex F))).symm
+      (sandwichMap F.physicalCoordinateMatrixTwo
+        (Matrix.reindex (blockedIndexEquiv d) (blockedIndexEquiv d)
+          (physClose1 (blockTwo K) X))) = _
+  rw [show Matrix.reindex (blockedIndexEquiv d) (blockedIndexEquiv d)
+      (physClose1 (blockTwo K) X) = physClose2 K X by
+    exact LinearMap.congr_fun (physClose1_blockTwo_eq_physClose2 K) X]
+  rw [F.physicalCoordinateMatrixTwo_physClose2]
+  rw [← show Matrix.reindex
+      (blockedIndexEquiv (Fintype.card (SectorSiteIndex F)))
+      (blockedIndexEquiv (Fintype.card (SectorSiteIndex F)))
+      (physClose1 (blockTwo F.sectorCoordinateTensor) X) =
+        physClose2 F.sectorCoordinateTensor X by
+    exact LinearMap.congr_fun
+      (physClose1_blockTwo_eq_physClose2 F.sectorCoordinateTensor) X]
+  simp
+
+private theorem physicalBlockOneInverseMap_closure
+    (F : PhysicalSectorFactorization K) (X : Matrix (Fin D) (Fin D) ℂ) :
+    physicalBlockOneInverseMap F
+        (physClose1 (blockTwo F.sectorCoordinateTensor) X) =
+      physClose1 (blockTwo K) X := by
+  change Matrix.reindex (blockedIndexEquiv d).symm (blockedIndexEquiv d).symm
+      (sandwichMap F.physicalCoordinateMatrixTwoᴴ
+        (Matrix.reindex
+          (blockedIndexEquiv (Fintype.card (SectorSiteIndex F)))
+          (blockedIndexEquiv (Fintype.card (SectorSiteIndex F)))
+          (physClose1 (blockTwo F.sectorCoordinateTensor) X))) = _
+  rw [show Matrix.reindex
+      (blockedIndexEquiv (Fintype.card (SectorSiteIndex F)))
+      (blockedIndexEquiv (Fintype.card (SectorSiteIndex F)))
+      (physClose1 (blockTwo F.sectorCoordinateTensor) X) =
+        physClose2 F.sectorCoordinateTensor X by
+    exact LinearMap.congr_fun
+      (physClose1_blockTwo_eq_physClose2 F.sectorCoordinateTensor) X]
+  rw [F.physicalCoordinateMatrixTwo_conjTranspose_physClose2]
+  rw [← show Matrix.reindex (blockedIndexEquiv d) (blockedIndexEquiv d)
+      (physClose1 (blockTwo K) X) = physClose2 K X by
+    exact LinearMap.congr_fun (physClose1_blockTwo_eq_physClose2 K) X]
+  simp
+
+private theorem physicalBlockTwoMap_closure
+    (F : PhysicalSectorFactorization K) (X : Matrix (Fin D) (Fin D) ℂ) :
+    physicalBlockTwoMap F (physClose2 (blockTwo K) X) =
+      physClose2 (blockTwo F.sectorCoordinateTensor) X := by
+  change Matrix.reindex
+      (blockedPairEquiv (Fintype.card (SectorSiteIndex F))).symm
+      (blockedPairEquiv (Fintype.card (SectorSiteIndex F))).symm
+      (sandwichMap F.physicalCoordinateMatrixFour
+        (Matrix.reindex (blockedPairEquiv d) (blockedPairEquiv d)
+          (physClose2 (blockTwo K) X))) = _
+  rw [show Matrix.reindex (blockedPairEquiv d) (blockedPairEquiv d)
+      (physClose2 (blockTwo K) X) = physClose4 K X by
+    exact LinearMap.congr_fun (physClose2_blockTwo_eq_physClose4 K) X]
+  rw [F.physicalCoordinateMatrixFour_physClose4]
+  rw [← show Matrix.reindex
+      (blockedPairEquiv (Fintype.card (SectorSiteIndex F)))
+      (blockedPairEquiv (Fintype.card (SectorSiteIndex F)))
+      (physClose2 (blockTwo F.sectorCoordinateTensor) X) =
+        physClose4 F.sectorCoordinateTensor X by
+    exact LinearMap.congr_fun
+      (physClose2_blockTwo_eq_physClose4 F.sectorCoordinateTensor) X]
+  simp
+
+private theorem physicalBlockTwoInverseMap_closure
+    (F : PhysicalSectorFactorization K) (X : Matrix (Fin D) (Fin D) ℂ) :
+    physicalBlockTwoInverseMap F
+        (physClose2 (blockTwo F.sectorCoordinateTensor) X) =
+      physClose2 (blockTwo K) X := by
+  change Matrix.reindex (blockedPairEquiv d).symm (blockedPairEquiv d).symm
+      (sandwichMap F.physicalCoordinateMatrixFourᴴ
+        (Matrix.reindex
+          (blockedPairEquiv (Fintype.card (SectorSiteIndex F)))
+          (blockedPairEquiv (Fintype.card (SectorSiteIndex F)))
+          (physClose2 (blockTwo F.sectorCoordinateTensor) X))) = _
+  rw [show Matrix.reindex
+      (blockedPairEquiv (Fintype.card (SectorSiteIndex F)))
+      (blockedPairEquiv (Fintype.card (SectorSiteIndex F)))
+      (physClose2 (blockTwo F.sectorCoordinateTensor) X) =
+        physClose4 F.sectorCoordinateTensor X by
+    exact LinearMap.congr_fun
+      (physClose2_blockTwo_eq_physClose4 F.sectorCoordinateTensor) X]
+  rw [F.physicalCoordinateMatrixFour_conjTranspose_physClose4]
+  rw [← show Matrix.reindex (blockedPairEquiv d) (blockedPairEquiv d)
+      (physClose2 (blockTwo K) X) = physClose4 K X by
+    exact LinearMap.congr_fun (physClose2_blockTwo_eq_physClose4 K) X]
+  simp
+
+/-- The original two-site blocked tensor is a renormalization fixed point.
+The channels are transported from the sector-coordinate channels through the
+physical isometry of Proposition C.7.
+
+**Local fix (zero-weight quotient):** the refinement channel uses the completed
+zero-weight preparation branch. Documented in
+`docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex`.
+
+**Local fix (implication label):** Appendix line 1824 labels this construction
+as direction (iii) implies (v), while the theorem statement and the local
+structure used here give direction (iv) implies (v). Documented in
+`docs/paper-gaps/cpgsv17_mpdo_theorem_4_9_implication_label.tex`.
+
+Source: arXiv:1606.00608, Definition 4.1, lines 645--659; Theorem 4.9,
+direction (iv) implies (v), lines 851--893; and Appendix C.2, lines 1510--1563
+and 1821--1825. -/
+theorem NeighboringTraceFactorization.blockTwo_isRFPViaTS
+    (H : NeighboringTraceFactorization F) : IsRFPViaTS (blockTwo K) := by
+  rcases H.blockTwo_sectorCoordinateTensor_isRFPViaTS with
+    ⟨sectorS, sectorT, hSectorS, hSectorT, hSectorSClose, hSectorTClose⟩
+  let rawS := F.physicalBlockOneInverseMap ∘ₗ sectorS ∘ₗ F.physicalBlockTwoMap
+  let rawT := F.physicalBlockTwoInverseMap ∘ₗ sectorT ∘ₗ F.physicalBlockOneMap
+  refine ⟨rawS, rawT, ?_, ?_, ?_, ?_⟩
+  · exact isKrausCPTP_comp
+      (isKrausCPTP_comp F.physicalBlockTwoMap_isKrausCPTP hSectorS)
+      F.physicalBlockOneInverseMap_isKrausCPTP
+  · exact isKrausCPTP_comp
+      (isKrausCPTP_comp F.physicalBlockOneMap_isKrausCPTP hSectorT)
+      F.physicalBlockTwoInverseMap_isKrausCPTP
+  · intro X
+    change F.physicalBlockOneInverseMap
+      (sectorS (F.physicalBlockTwoMap (physClose2 (blockTwo K) X))) = _
+    rw [F.physicalBlockTwoMap_closure, hSectorSClose,
+      F.physicalBlockOneInverseMap_closure]
+  · intro X
+    change F.physicalBlockTwoInverseMap
+      (sectorT (F.physicalBlockOneMap (physClose1 (blockTwo K) X))) = _
+    rw [F.physicalBlockOneMap_closure, hSectorTClose,
+      F.physicalBlockTwoInverseMap_closure]
+
+
+end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/PhysicalSectorPhysicalTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorPhysicalTransport.lean
@@ -82,12 +82,6 @@ private noncomputable def physicalBlockTwoInverseMap
     Matrix.equivReindexMap
       (blockedPairEquiv (Fintype.card (SectorSiteIndex F)))
 
-private theorem sandwichMap_isKrausCPTP {a b : Type*}
-    [Fintype a] [DecidableEq a] [Fintype b] [DecidableEq b]
-    (V : Matrix b a ℂ) (hV : Vᴴ * V = 1) :
-    IsKrausCPTP (sandwichMap V) :=
-  isKrausCPTP_of_singleKraus V (fun _ ↦ rfl) hV
-
 private theorem physicalBlockOneMap_isKrausCPTP
     (F : PhysicalSectorFactorization K) :
     IsKrausCPTP (physicalBlockOneMap F) := by

--- a/blueprint/src/Packages/tn_diagrams.py
+++ b/blueprint/src/Packages/tn_diagrams.py
@@ -56,6 +56,7 @@ _DIAGRAM_ARGS: dict[str, str] = {
     "TNMPDORefinementConstruction": "",
     "TNMPDORefinementDirection": "",
     "TNMPDOBlockedRFPChannels": "",
+    "TNMPDOPhysicalIsometryTransport": "",
     "TNMPDOTwoSiteClosureFactorization": "",
     "TNMPDOThreeSiteClosureFactorization": "",
     "TNMPDOCyclicEtaContraction": "",

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -3295,7 +3295,7 @@ strong subadditivity for a normalized three-site reduced state.
 \end{proof}
 
 For the following construction, through
-Theorem~\ref{thm:mpdo_blocked_sector_coordinate_tensor_is_rfp_via_ts}, assume the
+Theorem~\ref{thm:mpdo_blocked_original_tensor_is_rfp_via_ts}, assume the
 neighboring-operator trace factorization of
 Definition~\ref{def:mpdo_neighboring_trace_factorization}. Write
 \[
@@ -3629,7 +3629,7 @@ $\widehat{\cal K}$.
     second coarse-graining gives $\widehat{\cal K}_2(X)$.
 \end{proof}
 
-\begin{figure}[ht]
+\begin{figure}[!b]
     \centering
     \TNMPDOBlockedRFPChannels
     \caption{The superscripts in $\widehat{\mathcal T}^2$ and
@@ -3676,6 +3676,49 @@ $\widehat{\cal K}$.
     positivity and trace, and the two closure identities give the required
     equations in Definition~\ref{def:is_rfp_via_ts}.
 \end{proof}
+
+% **Local fix (zero-weight quotient):** this theorem uses the completed
+% zero-weight preparation through the two-step refinement identity. Documented
+% in docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex.
+% **Local fix (implication label):** Appendix line 1824 says
+% (iii) implies (v), but the theorem statement and the local structure used
+% here give (iv) implies (v). Documented in
+% docs/paper-gaps/cpgsv17_mpdo_theorem_4_9_implication_label.tex.
+\begin{theorem}[Two-site blocking of the original tensor is a renormalization fixed point]
+    \label{thm:mpdo_blocked_original_tensor_is_rfp_via_ts}
+    \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.blockTwo_isRFPViaTS}
+    \leanok
+    \uses{def:is_rfp_via_ts, def:mpdo_two_site_blocking}
+    Let ${\cal K}^{[2]}$ be the tensor obtained by blocking two adjacent sites
+    of the original tensor ${\cal K}$. Then ${\cal K}^{[2]}$ is a
+    renormalization fixed point in the sense of
+    Definition~\ref{def:is_rfp_via_ts}. This is
+    \cite[Theorem~4.9, (iv)$\Rightarrow$(v)]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_blocked_sector_coordinate_tensor_is_rfp_via_ts}
+    Transport the refinement and coarse-graining channels for
+    $\widehat{\cal K}^{[2]}$ through the two-site and four-site tensor powers
+    of the physical isometry, as in
+    Figure~\ref{fig:mpdo_physical_isometry_transport}. These unitary
+    congruences preserve complete positivity and trace, while the
+    corresponding closure identities carry the two fixed-point equations back
+    to ${\cal K}^{[2]}$.
+\end{proof}
+
+\begin{figure}[htbp]
+    \centering
+    \TNMPDOPhysicalIsometryTransport
+    \caption{Physical-isometry transport of the blocked channels. The
+    downward arrows conjugate the ket and bra indices by $U^{\otimes n}$ and
+    $(U^\dagger)^{\otimes n}$; the upward arrows give the inverse
+    conjugations. Hence the lower sector-coordinate channels induce the upper
+    ordinary-coordinate channels. This combines Proposition~C.7 with
+    \cite[Appendix~C.2, lines~1510--1563 and 1821--1825]
+    {Cirac2016MPDO_arXiv}.}
+    \label{fig:mpdo_physical_isometry_transport}
+\end{figure}
 
 \begin{figure}[ht]
     \centering

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -422,6 +422,74 @@
     \end{tikzpicture}%
 }
 
+% Transport of the two-step channels from the sector coordinates selected by
+% the physical isometry back to the original physical coordinates. The
+% horizontal arrows follow MPDO_TSKKK.png; the vertical conjugations follow
+% the U and U^dagger convention of MPDO_K=sum_k_LkRk.png.
+\newcommand{\TNMPDOPhysicalIsometryTransport}{%
+    \begin{tikzpicture}[tn picture, scale=0.64]
+        \foreach \x/\name in {-5.0/ptRawTwoA,-4.0/ptRawTwoB} {
+            \TN@subspinbox{\name}{(\x,1.45)}{\cal K}
+        }
+        \TN@subspinlink{ptRawTwoA}{ptRawTwoB}
+        \draw[rounded corners=2pt, densely dashed]
+            (-5.48,0.97) rectangle (-3.52,1.93);
+        \node at (-4.50,2.27) {${\cal K}_2(X)$};
+
+        \foreach \x/\name in {3.0/ptRawFourA,4.0/ptRawFourB,
+                5.0/ptRawFourC,6.0/ptRawFourD} {
+            \TN@subspinbox{\name}{(\x,1.45)}{\cal K}
+        }
+        \TN@subspinlink{ptRawFourA}{ptRawFourB}
+        \TN@subspinlink{ptRawFourB}{ptRawFourC}
+        \TN@subspinlink{ptRawFourC}{ptRawFourD}
+        \draw[rounded corners=2pt, densely dashed]
+            (2.52,0.97) rectangle (4.48,1.93);
+        \draw[rounded corners=2pt, densely dashed]
+            (4.52,0.97) rectangle (6.48,1.93);
+        \node at (4.50,2.27) {${\cal K}_4(X)$};
+
+        \foreach \x/\name in {-5.0/ptHatTwoA,-4.0/ptHatTwoB} {
+            \TN@subspinbox{\name}{(\x,-1.45)}{\widehat{\cal K}}
+        }
+        \TN@subspinlink{ptHatTwoA}{ptHatTwoB}
+        \draw[rounded corners=2pt, densely dashed]
+            (-5.48,-1.93) rectangle (-3.52,-0.97);
+        \node at (-4.50,-2.27) {$\widehat{\cal K}_2(X)$};
+
+        \foreach \x/\name in {3.0/ptHatFourA,4.0/ptHatFourB,
+                5.0/ptHatFourC,6.0/ptHatFourD} {
+            \TN@subspinbox{\name}{(\x,-1.45)}{\widehat{\cal K}}
+        }
+        \TN@subspinlink{ptHatFourA}{ptHatFourB}
+        \TN@subspinlink{ptHatFourB}{ptHatFourC}
+        \TN@subspinlink{ptHatFourC}{ptHatFourD}
+        \draw[rounded corners=2pt, densely dashed]
+            (2.52,-1.93) rectangle (4.48,-0.97);
+        \draw[rounded corners=2pt, densely dashed]
+            (4.52,-1.93) rectangle (6.48,-0.97);
+        \node at (4.50,-2.27) {$\widehat{\cal K}_4(X)$};
+
+        \draw[->, line width=0.60pt, bend left=13]
+            (-3.22,1.62) to node[above] {$\mathcal T_{\cal K}^2$} (2.22,1.62);
+        \draw[->, line width=0.60pt, bend left=13]
+            (2.22,1.28) to node[below] {$\mathcal S_{\cal K}^2$} (-3.22,1.28);
+        \draw[->, line width=0.60pt, bend left=13]
+            (-3.22,-1.28) to node[above] {$\widehat{\mathcal T}^2$} (2.22,-1.28);
+        \draw[->, line width=0.60pt, bend left=13]
+            (2.22,-1.62) to node[below] {$\widehat{\mathcal S}^2$} (-3.22,-1.62);
+
+        \draw[->, line width=0.55pt] (-4.64,0.68) -- (-4.64,-0.68)
+            node[midway, left] {$U^{\otimes 2}$};
+        \draw[->, line width=0.55pt] (-4.36,-0.68) -- (-4.36,0.68)
+            node[midway, right] {$(U^\dagger)^{\otimes 2}$};
+        \draw[->, line width=0.55pt] (4.36,0.68) -- (4.36,-0.68)
+            node[midway, left] {$U^{\otimes 4}$};
+        \draw[->, line width=0.55pt] (4.64,-0.68) -- (4.64,0.68)
+            node[midway, right] {$(U^\dagger)^{\otimes 4}$};
+    \end{tikzpicture}%
+}
+
 % Fixed-sector factorization of the arbitrary-X two-site physical closure.
 % The left-hand row shows the sector subspins and the outer virtual closure;
 % the right-hand side shows only the proved boundary/neighbor tensor product.

--- a/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
+++ b/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
@@ -7,7 +7,7 @@ name: TNMPSLocal TNMPSWord TNMPV TNBlocking TNMPVOverlap TNTransferMap TNMPOCell
 name: TNMPOLocalPurification TNMPORenormalizationTS TNEtaSectorDecomposition TNMPDOCyclicEtaContraction TNMPDOSectorAdaptedDecomposition
 {{ obj.tn_svg_html }}
 
-name: TNMPDOTwoSiteTraceAndShift TNMPDOThreeSiteTraceAndShift TNMPDORefinementConstruction TNMPDORefinementDirection TNMPDOBlockedRFPChannels
+name: TNMPDOTwoSiteTraceAndShift TNMPDOThreeSiteTraceAndShift TNMPDORefinementConstruction TNMPDORefinementDirection TNMPDOBlockedRFPChannels TNMPDOPhysicalIsometryTransport
 {{ obj.tn_svg_html }}
 
 name: TNMPDOTwoSiteClosureFactorization TNMPDOThreeSiteClosureFactorization

--- a/docs/paper-gaps/cpgsv17_mpdo_blocked_rfp_physical_transport.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_blocked_rfp_physical_transport.tex
@@ -22,7 +22,7 @@ isometry of Proposition~C.7; see
 {Cirac2016MPDO_arXiv}.  The theorem itself concerns the original tensor after
 blocking two adjacent sites.
 
-The present formal theorem
+The sector-coordinate theorem
 \path{NeighboringTraceFactorization.blockTwo_sectorCoordinateTensor_isRFPViaTS}
 proves the fixed-point identities for
 \[
@@ -34,11 +34,11 @@ it does not yet transport the two channels back to
 $\operatorname{blockTwo}(\mathcal K)$.  It is therefore a scope-restricted
 intermediate result, not the complete formalization of the source implication.
 
-\section{Required transport}
+\section{Transport theorem}
 
 In the formal sector factorization, the physical isometry is a square matrix
 $U$ satisfying $U^\dagger U=I$.  Finite dimensionality then also gives
-$UU^\dagger=I$.  The remaining argument should first prove the closure
+$UU^\dagger=I$.  The transport theorem proves the closure
 relations
 \[
   \widehat{\mathcal K}_n(X)
@@ -51,20 +51,20 @@ $\widehat{\mathcal S}^2$ through these unitary congruences then preserves
 complete positivity and trace.  The two sector-coordinate closure identities
 become the required identities for the original blocked tensor.
 
-\section{Elimination plan}
+\section{Discharge}
 
-The next result should formalize the two- and four-site unitary closure
-relations, define the transported channels on the original physical matrix
-spaces, and prove
+The theorem
+\path{NeighboringTraceFactorization.blockTwo_isRFPViaTS} formalizes the
+two- and four-site unitary closure relations, transports the two channels to
+the original physical matrix spaces, and proves
 \[
   \operatorname{IsRFPViaTS}
     \bigl(\operatorname{blockTwo}(\mathcal K)\bigr)
 \]
-under the same neighboring-operator trace-factorization hypothesis.  Once
-that theorem is available, the scope-restriction marker on the
-sector-coordinate theorem can remain as a description of its narrower role,
-while the source-labelled blueprint implication should refer to the transported
-theorem.
+under the same neighboring-operator trace-factorization hypothesis.  This
+discharges the transport gap.  The scope-restriction marker on the
+sector-coordinate theorem remains as a description of that theorem's narrower
+role, while the source conclusion is represented by the transported theorem.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

- prove the two- and four-site open-boundary closure congruences under the physical unitary of Proposition C.7
- construct forward and inverse trace-preserving completely positive coordinate transports on one and two blocked sites
- prove the source-faithful conclusion `NeighboringTraceFactorization.blockTwo_isRFPViaTS : IsRFPViaTS (blockTwo K)` with no additional hypotheses
- add a commuting TikZ diagram for the physical-isometry transport and a separate exact blueprint theorem for the original blocked tensor
- mark the physical-transport paper gap discharged while retaining the narrower sector-coordinate theorem and its scope marker
- register both blocked-RFP diagrams for PDF and web rendering

## Faithfulness

The conclusion concerns the two-site blocking of the original tensor, as in Theorem 4.9 `(iv) ⇒ (v)`. It does not assert `IsRFPViaTS K`. The inherited zero-weight completion and the Appendix implication-label correction remain explicitly documented.

## Verification

- clean `lake build` (9,330 jobs before the latest documentation-only rebase; 9,331 jobs on the combined branch)
- `lake env lean TNLean/MPS/MPDO/PhysicalSectorPhysicalTransport.lean`
- proof-integrity and `#print axioms` audit
- generated `blueprint/lean_decls`, `lake exe checkdecls blueprint/lean_decls`, and blueprint–Lean sync
- `leanblueprint pdf` (508 pages; visual inspection of printed pp.466–467)
- tensor-network registration, PEPS-usage, and 104/104 SVG smoke renders
- independent Lean, source-faithfulness, and blueprint/TikZ reviews

Closes the physical-isometry transport gap recorded in `docs/paper-gaps/cpgsv17_mpdo_blocked_rfp_physical_transport.tex`.

Part of #3744.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new formal proofs in core MPDO RFP infrastructure; mathematical risk is moderate (unitary transport of CPTP maps) but scope is proof-only with no runtime or auth impact.
> 
> **Overview**
> Closes the **physical-isometry transport** step for Theorem 4.9 **(iv) ⇒ (v)**: two-site blocking of the **original** MPO tensor is now shown to be a renormalization fixed point via trace–shift channels, not only in sector coordinates.
> 
> **Lean:** Introduces `sandwichMap` / `sandwichMap_isKrausCPTP` in `KrausCPTP.lean`. New `PhysicalSectorCoordinateTransport` proves the 2- and 4-site open-boundary closures in sector coordinates are unitary congruences of the original closures under the Proposition C.7 physical isometry (`U^{⊗2}`, `U^{⊗4}`). `PhysicalSectorPhysicalTransport` builds forward/inverse blocked CPTP transports and proves `NeighboringTraceFactorization.blockTwo_isRFPViaTS` by composing the existing sector-coordinate RFP channels with those maps.
> 
> **Docs / blueprint:** Adds theorem `thm:mpdo_blocked_original_tensor_is_rfp_via_ts`, TikZ macro `TNMPDOPhysicalIsometryTransport`, and updates the paper-gap note to mark transport **discharged** (sector-coordinate theorem kept as the narrower intermediate).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3dc7e244737396c6b47faa15c009eb7d5d56aed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->