### PR TITLE
feat(MPS/MPDO): resolve periodic-sector step for injective MPDO tensors

### DIFF
--- a/TNLean/MPS/MPDO/CyclicProjector.lean
+++ b/TNLean/MPS/MPDO/CyclicProjector.lean
@@ -672,4 +672,55 @@ theorem hasNoPeriodicVectors_verticalTensor_of_noncommutation
   hasNoPeriodicVectors_verticalTensor_of_cyclicProjector M hM
     (periodicVectorYieldsCyclicProjector_of_noncommutation M hNC)
 
+/-- **The periodic-sector step for a single-letter injective matrix product
+density operator, unconditionally.**
+
+If `M`'s doubled-index tensor is (single-letter) injective, the vertically
+viewed tensor has no nontrivial periodic vectors, with no further hypothesis.
+This bypasses `NoninvariantProjectorNoncommuting` entirely: rather than
+requiring the displaced-projector-noncommutation family at *every* chain
+length, the contradiction only ever needs the commutation family at chain
+length `2`, where `ketLeftMul_eq_braRightMul_of_commute_of_isInjective`
+(`TNLean/MPS/MPDO/InvariantProjection.lean`) applies directly to `M`'s own
+letters through injectivity's trace-pairing nondegeneracy — no horizontal
+canonical-form decomposition or `SameMPV₂` transport is needed.
+
+The word invariance of the constructed cyclic projector transfers to the
+stacked tensor (`stackedTensor_ketLeftMul_invariant`), giving commutation with
+$[H^{(2)}]^p$ unconditionally through the invariant-projection step applied to
+the stack (`firstSiteMatrix_mul_mpo_comm`); positive semidefiniteness of the
+density operators then removes the power (`mpo_commute_of_commute_pow`), and
+injectivity turns the resulting commutation with $H^{(2)}$ into the
+letter-level invariance that the displacement forbids.
+
+**Scope restriction (single-letter injective tensors):** the source's
+Proposition 4.13 allows `M` to be reducible, decomposed horizontally into
+several gauge-inequivalent canonical-form blocks with weights; this theorem
+covers the sub-case where `M`'s own tensor is already (single-letter)
+injective. Discharging `NoninvariantProjectorNoncommuting` for a general
+horizontal canonical form remains open, and is documented in
+`docs/paper-gaps/cpgsv17_periodic_sector_projector.tex` together with the
+reason the general route resists this proof strategy: at chain length `1`
+(the only length at which a general, block-injective argument working
+through `SameMPV₂` could plausibly reach `M`'s own letters), the single
+trailing letter is the identity, giving only one trace-level equation per
+matrix-entry pair — far short of what nondegeneracy of the trace pairing
+needs to separate a whole matrix. -/
+theorem hasNoPeriodicVectors_verticalTensor_of_isInjective
+    {d D : ℕ} (M : MPOTensor d D) (hM : IsMPDO M)
+    (hInj : MPSTensor.IsInjective M.toMPSTensor) :
+    MPSTensor.HasNoPeriodicVectors (verticalTensor M) := by
+  intro n V B ρ r hV hint hirr hρ hr hfix μ hμ hnorm
+  by_contra hne
+  obtain ⟨p, Q, hp, hQherm, hQidem, hword, hdisp⟩ :=
+    exists_displaced_invariant_projector_of_periodic_vector M V B ρ r hV hint
+      hirr hρ hr hfix μ hμ hnorm hne
+  apply hdisp
+  have hCommPow : Commute (firstSiteMatrix Q 1) (mpo M 2 ^ p) := by
+    have h := firstSiteMatrix_mul_mpo_comm (stackedTensor M p) (hM.stackedTensor p) hQherm
+      (stackedTensor_ketLeftMul_invariant M hword) 1
+    rwa [mpo_stackedTensor] at h
+  exact ketLeftMul_eq_braRightMul_of_commute_of_isInjective M hInj hQidem
+    (mpo_commute_of_commute_pow M hM 2 hp hCommPow)
+
 end MPOTensor

--- a/TNLean/MPS/MPDO/InvariantProjection.lean
+++ b/TNLean/MPS/MPDO/InvariantProjection.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.MPDO.VerticalCF
+import TNLean.Algebra.TracePairing
 
 /-!
 # One-sided invariant matrices for matrix product density operators
@@ -304,6 +305,82 @@ theorem blockwise_braRight_eq_ketLeftBraRight_of_invariant
     rw [mul_firstSiteMatrix_apply, firstSiteMatrix_mul_apply] at h2
     simp only [Fin.cons_zero, Function.comp_def, Fin.cons_succ] at h2
     exact h2
+
+/-- **Commutation at a two-site chain forces letter-level invariance, for a
+single-letter injective tensor.**
+
+If `M`'s doubled-index tensor `M.toMPSTensor` is (single-letter) injective —
+its `d * d` many matrices `M i j` already span the full `D × D` matrix
+algebra — then commutation of the first-site action of a Hermitian idempotent
+`Q` with the two-site density operator `mpo M 2` alone forces the
+letter-level invariance `M.ketLeftMul Q = (M.ketLeftMul Q).braRightMul Q`.
+
+This is a single-instantiation converse of the invariant-projection step
+(arXiv:1606.00608, lines 1874--1887): idempotence of `Q` upgrades the full
+commutation `Q_1 H = H Q_1` to the one-sided reduction `Q_1 H = Q_1 H Q_1`
+(the reverse of `firstSiteMatrix_mul_mpo_of_ketLeftMul_invariant`'s
+conclusion); unfolding *that* identity against every trailing letter `M c c'`
+gives `d * d` many trace identities pairing `(M.ketLeftMul Q) a b` against
+`((M.ketLeftMul Q).braRightMul Q) a b`, for every physical index pair `a, b`,
+over every letter of `M.toMPSTensor`. Injectivity's spanning property and
+nondegeneracy of the trace pairing (`MPSTensor.traceMulRightPi_ker_eq_bot`)
+then force the two matrices to agree.
+
+Unlike the block-injective route of `VerticalCF.lean`'s Lemma L (which needs a
+horizontal canonical-form decomposition and the commutation family at *every*
+length, transported through `SameMPV₂` back to `M`'s own letters — an
+unresolved transport step recorded in
+`docs/paper-gaps/cpgsv17_periodic_sector_projector.tex`), this theorem needs
+only the commutation hypothesis at chain length `2`, applies to `M`'s own
+tensor directly, and does not extend to chain length `1` (`mpo M 1`): there
+the single trailing letter is the identity matrix, giving only a trace-level
+identity, not enough to separate the opposite-corner difference. -/
+theorem ketLeftMul_eq_braRightMul_of_commute_of_isInjective
+    (M : MPOTensor d D) (hInj : MPSTensor.IsInjective M.toMPSTensor)
+    {Q : Matrix (Fin d) (Fin d) ℂ} (hQidem : IsIdempotentElem Q)
+    (hComm : Commute (firstSiteMatrix Q 1) (mpo M 2)) :
+    M.ketLeftMul Q = (M.ketLeftMul Q).braRightMul Q := by
+  classical
+  have hQ1idem : firstSiteMatrix Q 1 * firstSiteMatrix Q 1 = firstSiteMatrix Q 1 := by
+    rw [firstSiteMatrix_mul_firstSiteMatrix, hQidem]
+  have hOneSided : firstSiteMatrix Q 1 * mpo M 2 =
+      firstSiteMatrix Q 1 * mpo M 2 * firstSiteMatrix Q 1 := by
+    calc firstSiteMatrix Q 1 * mpo M 2
+        = firstSiteMatrix Q 1 * firstSiteMatrix Q 1 * mpo M 2 := by rw [hQ1idem]
+      _ = firstSiteMatrix Q 1 * (firstSiteMatrix Q 1 * mpo M 2) := by rw [Matrix.mul_assoc]
+      _ = firstSiteMatrix Q 1 * (mpo M 2 * firstSiteMatrix Q 1) := by rw [hComm.eq]
+      _ = firstSiteMatrix Q 1 * mpo M 2 * firstSiteMatrix Q 1 := by rw [Matrix.mul_assoc]
+  funext a b
+  show (M.ketLeftMul Q) a b = ((M.ketLeftMul Q).braRightMul Q) a b
+  refine sub_eq_zero.mp
+    ((LinearMap.ker_eq_bot'.1 (MPSTensor.traceMulRightPi_ker_eq_bot hInj))
+      ((M.ketLeftMul Q) a b - ((M.ketLeftMul Q).braRightMul Q) a b) ?_)
+  funext p
+  rw [MPSTensor.traceMulRightPi_apply, Pi.zero_apply]
+  change Matrix.trace
+    (((M.ketLeftMul Q) a b - ((M.ketLeftMul Q).braRightMul Q) a b) * M p.divNat p.modNat) = 0
+  set c := p.divNat
+  set c' := p.modNat
+  have h2 := Matrix.ext_iff.mpr hOneSided
+      (Fin.cons a (fun _ : Fin 1 => c)) (Fin.cons b (fun _ : Fin 1 => c'))
+  rw [mul_firstSiteMatrix_apply] at h2
+  simp only [firstSiteMatrix_mul_apply] at h2
+  simp only [Fin.cons_zero, Function.comp_def, Fin.cons_succ] at h2
+  simp only [mpo_cons_cons, List.ofFn_succ, List.ofFn_zero, evalWord_cons,
+    evalWord_nil, mul_one] at h2
+  rw [Matrix.sub_mul, Matrix.trace_sub, sub_eq_zero]
+  calc Matrix.trace ((M.ketLeftMul Q) a b * M c c')
+      = ∑ i : Fin d, Q a i * Matrix.trace (M i b * M c c') :=
+        (sum_mul_trace_eq_trace_sum_smul (fun i => Q a i) (fun i => M i b) (M c c')).symm
+    _ = ∑ j : Fin d, (∑ i : Fin d, Q a i * Matrix.trace (M i j * M c c')) * Q j b := h2
+    _ = ∑ j : Fin d, Q j b * ∑ i : Fin d, Q a i * Matrix.trace (M i j * M c c') :=
+        Finset.sum_congr rfl fun j _ => mul_comm _ _
+    _ = ∑ j : Fin d, Q j b * Matrix.trace ((M.ketLeftMul Q) a j * M c c') := by
+        refine Finset.sum_congr rfl fun j _ => ?_
+        congr 1
+        exact sum_mul_trace_eq_trace_sum_smul (fun i => Q a i) (fun i => M i j) (M c c')
+    _ = Matrix.trace (((M.ketLeftMul Q).braRightMul Q) a b * M c c') :=
+        sum_mul_trace_eq_trace_sum_smul (fun j => Q j b) (fun j => (M.ketLeftMul Q) a j) (M c c')
 
 /-- For an MPDO, any matrix commuting with a nonzero power of the $N$-site
 density operator commutes with the density operator itself.

--- a/TNLean/MPS/MPDO/InvariantProjection.lean
+++ b/TNLean/MPS/MPDO/InvariantProjection.lean
@@ -311,9 +311,12 @@ single-letter injective tensor.**
 
 If `M`'s doubled-index tensor `M.toMPSTensor` is (single-letter) injective —
 its `d * d` many matrices `M i j` already span the full `D × D` matrix
-algebra — then commutation of the first-site action of a Hermitian idempotent
-`Q` with the two-site density operator `mpo M 2` alone forces the
-letter-level invariance `M.ketLeftMul Q = (M.ketLeftMul Q).braRightMul Q`.
+algebra — then commutation of the first-site action of an idempotent `Q`
+with the two-site density operator `mpo M 2` alone forces the letter-level
+invariance `M.ketLeftMul Q = (M.ketLeftMul Q).braRightMul Q`.  Hermiticity of
+`Q` is not needed: only idempotence and the commutation itself enter the
+argument (in the application to orthogonal projectors, `Q` happens to be
+Hermitian, but that is not used here).
 
 This is a single-instantiation converse of the invariant-projection step
 (arXiv:1606.00608, lines 1874--1887): idempotence of `Q` upgrades the full

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -967,6 +967,58 @@
     and Theorem~\ref{thm:mpdo_cyclic_projector_reduction} applies.
 \end{proof}
 
+\begin{theorem}[Commutation at chain length two forces letter invariance, for
+    an injective tensor]
+    \label{thm:mpdo_commute_of_isInjective}
+    \lean{MPOTensor.ketLeftMul_eq_braRightMul_of_commute_of_isInjective}
+    \leanok
+    \uses{def:injective, def:mpdo_vertical_one_site_actions, def:mpo_family}
+    Let $M$ be an MPO tensor whose doubled-index tensor is injective, and
+    let $Q$ be a Hermitian idempotent on the physical space.  If
+    $Q_1H^{(2)}=H^{(2)}Q_1$, then $Q\widetilde M=Q\widetilde MQ$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Idempotence of $Q$ upgrades the commutation to the one-sided reduction
+    $Q_1H^{(2)}=Q_1H^{(2)}Q_1$.  Unfolding this identity against every
+    trailing letter of $M$ gives, for every pair of physical indices $a,b$,
+    a trace identity pairing $(Q\widetilde M)_{ab}$ against
+    $(Q\widetilde MQ)_{ab}$ over every letter of the doubled-index tensor.
+    Injectivity's spanning property and nondegeneracy of the trace pairing
+    force the two matrices to agree.
+\end{proof}
+
+\begin{theorem}[No periodic vectors for an injective matrix product density
+    operator]
+    \label{thm:mpdo_vertical_no_periodic_vectors_injective}
+    \lean{MPOTensor.hasNoPeriodicVectors_verticalTensor_of_isInjective}
+    \leanok
+    \uses{def:mpdo, def:injective, def:vertical_tensor_mpdo,
+        def:no_periodic_vectors, thm:mpdo_displaced_invariant_projector,
+        thm:mpdo_commute_of_isInjective}
+    Let $M$ generate matrix product density operators and let $M$'s
+    doubled-index tensor be injective.  Then the vertically viewed tensor
+    $\widetilde M$ has no nontrivial periodic vectors, unconditionally.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    A nontrivial periodic vector supplies the invariant, displaced projector
+    $Q$ of Theorem~\ref{thm:mpdo_displaced_invariant_projector}.  Its word
+    invariance transfers to the stacked tensor, giving commutation with
+    $[H^{(2)}]^p$ unconditionally through the invariant-projection step
+    applied to the stack; positive semidefiniteness of the density operators
+    removes the power, and Theorem~\ref{thm:mpdo_commute_of_isInjective}
+    turns the resulting commutation with $H^{(2)}$ into the letter-level
+    invariance that the displacement forbids.
+
+    This covers the sub-case where $M$'s own tensor is already injective; a
+    general horizontal canonical form (several gauge-inequivalent blocks
+    with weights) remains open, documented in
+    \path{docs/paper-gaps/cpgsv17_periodic_sector_projector.tex}.
+\end{proof}
+
 \begin{theorem}[Positive trace of nonzero positive semidefinite matrices]
     \label{thm:psd_trace_pos}
     \lean{Matrix.PosSemidef.trace_pos_of_ne_zero}

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -974,8 +974,8 @@
     \leanok
     \uses{def:injective, def:mpdo_vertical_one_site_actions, def:mpo_family}
     Let $M$ be an MPO tensor whose doubled-index tensor is injective, and
-    let $Q$ be a Hermitian idempotent on the physical space.  If
-    $Q_1H^{(2)}=H^{(2)}Q_1$, then $Q\widetilde M=Q\widetilde MQ$.
+    let $Q$ be an idempotent on the physical space (Hermiticity is not
+    needed).  If $Q_1H^{(2)}=H^{(2)}Q_1$, then $Q\widetilde M=Q\widetilde MQ$.
 \end{theorem}
 
 \begin{proof}

--- a/docs/paper-gaps/cpgsv17_periodic_sector_projector.tex
+++ b/docs/paper-gaps/cpgsv17_periodic_sector_projector.tex
@@ -156,15 +156,142 @@ Once the implication is proved from a horizontal canonical form, the
 conditional exclusion becomes the statement asserted by the source, and
 this note can be retired.
 
-\paragraph{Verdict.}
-This is an open gap, now narrowed to a single implication: the projector
-exclusion (the positivity part of the source paragraph), the
-stacked-layers reduction of the commutation family, and the construction
-of the invariant, displaced projector from the cyclic decomposition of the
-peripheral spectrum are formalized unconditionally.  The remaining stated
-hypothesis is that a projector displaced by the vertically viewed tensor
-cannot commute with $H^{(N)}$ at any length — the canonical-form step of
-lines~1874--1887.
+\section{The injective special case is now resolved}
+
+The implication \leanid{MPOTensor.NoninvariantProjectorNoncommuting} is
+discharged unconditionally when $M$'s own doubled-index tensor is
+(single-letter) injective, i.e.\ its $d^2$ matrices $M^{ij}$ already span
+the full $D\times D$ matrix algebra (\leanid{MPSTensor.IsInjective}).  The
+route does not go through the block-injective (biCF) machinery of
+\path{TNLean/MPS/MPDO/VerticalCF.lean} at all.
+
+\leanid{MPOTensor.ketLeftMul_eq_braRightMul_of_commute_of_isInjective}
+(\path{TNLean/MPS/MPDO/InvariantProjection.lean}) proves: if $Q$ is
+Hermitian idempotent and $Q_1H^{(2)}=H^{(2)}Q_1$ (commutation at the
+\emph{two-site} chain alone), then $Q\widetilde M=Q\widetilde MQ$.
+Idempotence of $Q$ upgrades the hypothesis to the one-sided reduction
+$Q_1H^{(2)}=Q_1H^{(2)}Q_1$ — the reverse of the invariant-projection step
+of lines~1874--1887 — and unfolding that identity against every trailing
+letter $M^{cc'}$ produces, for every pair of physical indices $a,b$, a
+trace identity pairing $(Q\widetilde M)_{ab}$ against
+$(Q\widetilde MQ)_{ab}$ over every letter of $M$'s doubled-index tensor.
+Injectivity's spanning property, together with nondegeneracy of the trace
+pairing on the full matrix algebra
+(\leanid{MPSTensor.traceMulRightPi_ker_eq_bot}), forces the two matrices
+to agree entrywise.  No horizontal canonical-form decomposition,
+block-injectivity, or \leanid{SameMPV₂} transport enters this argument: it
+works directly with $M$'s own letters.
+
+Combined with the stacked-layers reduction
+(\leanid{MPOTensor.stackedTensor_ketLeftMul_invariant},
+\leanid{MPOTensor.firstSiteMatrix_mul_mpo_comm}) and the positive
+semidefinite power-commutation theorem
+(\leanid{MPOTensor.mpo_commute_of_commute_pow}), this closes the
+periodic-sector step unconditionally for injective tensors:
+\leanid{MPOTensor.hasNoPeriodicVectors_verticalTensor_of_isInjective}
+proves that an MPDO tensor with an injective doubled-index tensor has no
+nontrivial periodic vectors in the vertical direction, with no further
+hypothesis.  The contradiction only ever needs the commutation family at
+chain length~$2$; it never constructs, and does not need, an inhabitant of
+\leanid{MPOTensor.NoninvariantProjectorNoncommuting}.
+
+\section{Why the general (reducible) case resists the same route}
+
+\leanid{MPOTensor.NoninvariantProjectorNoncommuting} quantifies over
+\emph{every} chain length $N$ (starting at $N=0$), and the natural
+discharge route — the block-injective Lemma~L of
+\path{TNLean/MPS/MPDO/VerticalCF.lean}, applied to a general horizontal
+canonical-form decomposition of $M$ into several (possibly
+gauge-inequivalent) normal blocks with weights — meets two independent
+obstructions that the injective special case above sidesteps.
+
+\begin{enumerate}
+    \item \textbf{Chain length one supplies no data.}  At $N=1$ (chain
+      length one, the shortest length at which an argument of this shape
+      could plausibly reach $M$'s own letters), the trailing word is
+      empty: the only relevant ``letter'' of the commutation identity is
+      the identity matrix, and unfolding $Q_1H^{(1)}=H^{(1)}Q_1$ gives
+      only one trace-level equation per matrix-entry pair,
+      $\tr\bigl((Q\widetilde M)_{ab}-(Q\widetilde MQ)_{ab}\bigr)=0$.
+      This is far short of what nondegeneracy of the trace pairing needs
+      to conclude $(Q\widetilde M)_{ab}=(Q\widetilde MQ)_{ab}$ as
+      matrices — it forces only the trace of the difference to vanish,
+      not the difference itself, unless $D=1$.  This is why the
+      injective route above uses chain length \emph{two}, not one or
+      zero: at chain length two, the trailing word ranges over the $d^2$
+      many letters $M^{cc'}$ themselves, which is enough data once those
+      letters span the full matrix algebra.  For a general (not
+      necessarily injective) $M$, no comparable argument is available at
+      $N=0$: the periodic-sector-projector contradiction that consumes
+      \leanid{MPOTensor.NoninvariantProjectorNoncommuting}
+      (\leanid{MPOTensor.isEmpty_periodicSectorProjector}) happens to use
+      only the $N=0$ instance, but the field's type still forces a proof
+      of \leanid{NoninvariantProjectorNoncommuting} to supply the $\forall
+      N$ statement to type-check as a
+      \leanid{PeriodicSectorProjector} — \emph{unless} the contradiction
+      is derived directly, bypassing that structure, exactly as
+      \leanid{MPOTensor.hasNoPeriodicVectors_verticalTensor_of_isInjective}
+      does above, by choosing chain length two instead of the length that
+      the structure's field type superficially suggests.
+    \item \textbf{The horizontal canonical-form surrogate is MPV-level,
+      not literal.}  \leanid{HorizontalCFData} and \leanid{IsHorizontalCF}
+      express ``$M$ is in horizontal canonical form'' through
+      \leanid{SameMPV₂}: $M$'s doubled-index tensor generates the
+      \emph{same matrix product vectors} as an assembled block-diagonal
+      tensor, not that $M$'s own letters \emph{literally equal} a
+      gauge-conjugated direct sum of normal blocks.  The source's own
+      canonical-form decomposition,
+      $\bigoplus_{j,q}\mu_{j,q}X_{j,q}A_jX_{j,q}^{-1}$
+      (\cite[eq:II\_ABasicTensors]{Cirac2016MPDO_arXiv}), is literal: it
+      exhibits $M$ itself, after a change of basis on the bond space, as
+      that direct sum.  The block-injective Lemma~L
+      (\leanid{blockwise_insert_eq_of_mpv_agree}) concludes letter
+      equality \emph{for the canonical-form blocks $A_k$}, which live in
+      their own (separately injective) bond space — not for $M$'s own
+      letters.  Transporting that block-level conclusion back to $M$'s
+      own bond space needs either $M$'s own injectivity (the special case
+      resolved above, where the transport is vacuous because $M$ already
+      is the sole block) or a literal, gauge-explicit multi-block
+      decomposition of $M$, which
+      \leanid{HorizontalCFData}/\leanid{IsHorizontalCF} does not carry
+      and which is not otherwise formalized in the repository for
+      reducible MPDO tensors.  Constructing that literal decomposition is
+      a separate, substantial undertaking, adjacent to but distinct from
+      the multiplicity-free restriction of \leanid{biCF} tracked at
+      \#3713 (\path{docs/paper-gaps/cpgsv17_bicf_block_separation.tex}),
+      not a corollary of the biCF machinery already in place.
+\end{enumerate}
+
+Both obstructions are independent of the exponent $p$ or the specific
+displaced-projector construction of
+\leanid{MPOTensor.exists_displaced_invariant_projector_of_periodic_vector}:
+they are structural facts about what finite-length trace data can
+determine, and about what \leanid{IsHorizontalCF}'s current formalization
+asserts.  Discharging \leanid{MPOTensor.NoninvariantProjectorNoncommuting}
+for a general (reducible, multi-block) horizontal canonical form therefore
+remains open, and is not a routine extension of the injective argument to
+a larger blocking length.
+
+\paragraph{Verdict (updated).}
+The periodic-sector step of Proposition~4.13 is now closed unconditionally
+for MPDO tensors whose doubled-index tensor is (single-letter) injective
+(\leanid{MPOTensor.hasNoPeriodicVectors_verticalTensor_of_isInjective}).
+For the general reducible case, the gap is unchanged in substance from the
+previous verdict — the projector exclusion, the stacked-layers reduction,
+and the displaced-projector construction remain unconditional, and the
+remaining stated hypothesis is
+\leanid{MPOTensor.NoninvariantProjectorNoncommuting} — but is now
+understood more precisely: it is not a routine extension of the
+block-injective Lemma~L already in
+\path{TNLean/MPS/MPDO/VerticalCF.lean}, because that machinery concludes
+letter equality for the canonical-form blocks, not for $M$'s own (possibly
+non-injective) bond space, and the transport between the two needs either
+$M$'s own injectivity or a literal, gauge-explicit multi-block
+decomposition that is not currently formalized.  The capstone
+\leanid{thm:vertical_cf_of_horizontal_cf} does not consume the injective
+special case: it still needs the independent vertical canonical-form
+construction (stage~3 of \ghissue{3674}), which is unaffected by either
+resolution recorded in this note.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpgsv17_periodic_sector_projector.tex
+++ b/docs/paper-gaps/cpgsv17_periodic_sector_projector.tex
@@ -158,12 +158,14 @@ this note can be retired.
 
 \section{The injective special case is now resolved}
 
-The implication \leanid{MPOTensor.NoninvariantProjectorNoncommuting} is
-discharged unconditionally when $M$'s own doubled-index tensor is
+The periodic-exclusion goal that
+\leanid{MPOTensor.NoninvariantProjectorNoncommuting} was introduced to
+supply is reached unconditionally when $M$'s own doubled-index tensor is
 (single-letter) injective, i.e.\ its $d^2$ matrices $M^{ij}$ already span
-the full $D\times D$ matrix algebra (\leanid{MPSTensor.IsInjective}).  The
-route does not go through the block-injective (biCF) machinery of
-\path{TNLean/MPS/MPDO/VerticalCF.lean} at all.
+the full $D\times D$ matrix algebra (\leanid{MPSTensor.IsInjective}) --- by
+a route that bypasses that hypothesis rather than discharging it (see
+below).  The route does not go through the block-injective (biCF) machinery
+of \path{TNLean/MPS/MPDO/VerticalCF.lean} at all.
 
 \leanid{MPOTensor.ketLeftMul_eq_braRightMul_of_commute_of_isInjective}
 (\path{TNLean/MPS/MPDO/InvariantProjection.lean}) proves: if $Q$ is

--- a/docs/paper-gaps/cpgsv17_periodic_sector_projector.tex
+++ b/docs/paper-gaps/cpgsv17_periodic_sector_projector.tex
@@ -167,8 +167,9 @@ route does not go through the block-injective (biCF) machinery of
 
 \leanid{MPOTensor.ketLeftMul_eq_braRightMul_of_commute_of_isInjective}
 (\path{TNLean/MPS/MPDO/InvariantProjection.lean}) proves: if $Q$ is
-Hermitian idempotent and $Q_1H^{(2)}=H^{(2)}Q_1$ (commutation at the
-\emph{two-site} chain alone), then $Q\widetilde M=Q\widetilde MQ$.
+idempotent (Hermiticity is not needed) and $Q_1H^{(2)}=H^{(2)}Q_1$
+(commutation at the \emph{two-site} chain alone), then
+$Q\widetilde M=Q\widetilde MQ$.
 Idempotence of $Q$ upgrades the hypothesis to the one-sided reduction
 $Q_1H^{(2)}=Q_1H^{(2)}Q_1$ — the reverse of the invariant-projection step
 of lines~1874--1887 — and unfolding that identity against every trailing


### PR DESCRIPTION
Partially addresses #3674.

## Summary

- Proves `MPOTensor.ketLeftMul_eq_braRightMul_of_commute_of_isInjective` (`TNLean/MPS/MPDO/InvariantProjection.lean`): for a matrix product operator whose doubled-index tensor is (single-letter) injective, commutation of a Hermitian idempotent `Q` with the two-site density operator alone forces the letter-level invariance `Q M̃ = Q M̃ Q`. Idempotence upgrades the commutation to a one-sided reduction, and nondegeneracy of the trace pairing on the full matrix algebra (`MPSTensor.traceMulRightPi_ker_eq_bot`) closes the argument — no horizontal canonical-form decomposition or the block-injective Lemma L machinery of `VerticalCF.lean` is needed.
- Combined with the stacked-layers reduction and the positive-semidefinite power-commutation theorem, this closes the periodic-sector step of Proposition 4.13 (arXiv:1606.00608, lines 1888–1893) unconditionally for injective tensors: `MPOTensor.hasNoPeriodicVectors_verticalTensor_of_isInjective` (`TNLean/MPS/MPDO/CyclicProjector.lean`) bypasses `NoninvariantProjectorNoncommuting` entirely, since the contradiction only ever needs the commutation family at chain length two.
- Updates `docs/paper-gaps/cpgsv17_periodic_sector_projector.tex` with the resolution and a precise account of why the general (reducible, multi-block horizontal canonical form) case resists the same route: chain length one supplies only trace-level data (insufficient to separate a whole matrix unless `D = 1`), and `HorizontalCFData`/`IsHorizontalCF` is an MPV-level (`SameMPV₂`) surrogate for the source's literal, gauge-explicit canonical-form decomposition, so block-level Lemma L conclusions do not transport back to `M`'s own letters without either `M`'s own injectivity or a literal multi-block decomposition that is not currently formalized.
- Adds the two theorems to blueprint ch20 as `\leanok` entries. `thm:vertical_cf_of_horizontal_cf` is unaffected and stays `\notready`: it does not consume either theorem, and separately needs the vertical canonical-form construction (stage 3 of #3674, still open).

## Remaining obligations for #3674

- `NoninvariantProjectorNoncommuting` for a general (reducible) horizontal canonical form remains open (documented obstruction, not merely unattempted).
- Stage 3: construct the independent vertical canonical-form family and prove weight positivity (arXiv:1606.00608, lines 1895–1921).

## Test plan

- [x] `lake build` — full repository build succeeds (9329/9329 jobs)
- [x] `rg -n "sorry|axiom"` on changed files — clean
- [x] `#print axioms` on both new theorems — only `propext`, `Classical.choice`, `Quot.sound`
- [x] `lake exe lint_style` on changed files — clean
- [x] `cd blueprint && leanblueprint checkdecls` — clean (both `\lean{}` tags resolve)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style formal proofs and documentation; no runtime, auth, or data-path changes. Residual risk is mathematical scope (injective subcase only), not deployment.
> 
> **Overview**
> **Closes the Proposition 4.13 periodic-sector step for injective MPDO tensors** without assuming `NoninvariantProjectorNoncommuting`.
> 
> Adds `ketLeftMul_eq_braRightMul_of_commute_of_isInjective` in `InvariantProjection.lean` (new `TracePairing` import): for an injective doubled-index tensor, idempotent `Q` commuting with the **two-site** density operator forces letter-level invariance `Q M̃ = Q M̃ Q`, via one-sided commutation and `traceMulRightPi_ker_eq_bot`. Adds `hasNoPeriodicVectors_verticalTensor_of_isInjective` in `CyclicProjector.lean`, wiring the existing displaced periodic-vector projector through stacked layers, power commutation, and that lemma.
> 
> Blueprint ch20 gains two `\leanok` theorems; `docs/paper-gaps/cpgsv17_periodic_sector_projector.tex` records the injective resolution and why the reducible horizontal-CF route (length-one trace data, `SameMPV₂` vs literal blocks) stays open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8236e38ad90cc02ddbb78144cf23753a5ca6978. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->