### PR TITLE
feat(Algebra): prove finite power-sum nonvanishing

### DIFF
--- a/TNLean/Algebra/ScalarPowerSumIdentity.lean
+++ b/TNLean/Algebra/ScalarPowerSumIdentity.lean
@@ -237,6 +237,33 @@ theorem sum_pow_eq_implies_card_eq_and_multiset_eq_of_le_max_card
   intro k hk hkcard
   exact h k hk (by simpa using hkcard)
 
+/-- A nonempty finite family of nonzero complex numbers has a nonvanishing
+power sum at some positive exponent no larger than its cardinality.
+
+This is the specialization of the Appendix power-sum lemma used in Lemma L of
+arXiv:1606.00608, lines 1851--1858. -/
+theorem exists_sum_pow_ne_zero_of_pos_card
+    (m : ℕ) (a : Fin m → ℂ) (hm : 0 < m) (ha : ∀ i, a i ≠ 0) :
+    ∃ N : ℕ, 0 < N ∧ N ≤ m ∧ ∑ i : Fin m, a i ^ N ≠ 0 := by
+  classical
+  by_contra h
+  have hzero : ∀ N : ℕ, 0 < N → N ≤ m → ∑ i : Fin m, a i ^ N = 0 := by
+    intro N hN hNm
+    by_contra hne
+    exact h ⟨N, hN, hNm, hne⟩
+  let b : Fin 0 → ℂ := fun i ↦ Fin.elim0 i
+  have hb : ∀ i, b i ≠ 0 := fun i ↦ Fin.elim0 i
+  have hp : ∀ N : ℕ, 0 < N → N ≤ max m 0 →
+      ∑ i : Fin m, a i ^ N = ∑ i : Fin 0, b i ^ N := by
+    intro N hN hNmax
+    have hNm : N ≤ m := by simpa using hNmax
+    rw [hzero N hN hNm]
+    simp
+  have hcard :=
+    (sum_pow_eq_implies_card_eq_and_multiset_eq_of_le_max_card
+      m 0 a b ha hb hp).1
+  exact (Nat.ne_of_gt hm) hcard
+
 
 private lemma list_pow_sum_eq_ofFn (f : Fin m → ℂ) (l : List ℂ)
     (h_ofFn : List.ofFn f = l) (k : ℕ) :

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -490,6 +490,32 @@ multiset with multiplicity.
     $N=0$ gives $x_a=x_b$.
 \end{proof}
 
+\begin{corollary}[A nonzero finite family has a nonvanishing power sum]
+    \label{cor:nonvanishing_finite_power_sum}
+    \lean{Matrix.exists_sum_pow_ne_zero_of_pos_card}
+    \leanok
+    \uses{thm:bounded_power_sum_multiset}
+    Let $m\geq 1$ and let $\lambda_0,\ldots,\lambda_{m-1}\in\C$ be nonzero.
+    Then there is an exponent $N$ with $1\leq N\leq m$ such that
+    \[
+        \sum_{q=0}^{m-1}\lambda_q^N\neq 0.
+    \]
+    This is the consequence of the Appendix power-sum lemma used in the proof
+    of Lemma~L
+    \cite[Appendix~C.3, lines~1851--1858]{Cirac2016MPDO_arXiv}; the finite-range
+    comparison is
+    \cite[Appendix~A, lines~1155--1163]{Cirac2016MPDO_arXiv}.
+\end{corollary}
+
+\begin{proof}
+    \leanok
+    \uses{thm:bounded_power_sum_multiset}
+    Suppose that every power sum with $1\leq N\leq m$ vanishes. Comparing
+    $\lambda_0,\ldots,\lambda_{m-1}$ with the empty family in
+    Theorem~\ref{thm:bounded_power_sum_multiset} gives $m=0$, contradicting
+    $m\geq 1$.
+\end{proof}
+
 \begin{theorem}[Equal power sums imply equal multisets]\label{thm:power_sum_multiset}
     \lean{Matrix.sum_pow_eq_implies_multiset_eq}
     \leanok


### PR DESCRIPTION
This PR proves the finite power-sum nonvanishing consequence used in the source proof of grouped Lemma L.

For a nonempty family of nonzero complex numbers indexed by `Fin m`, the new theorem produces an exponent `N` with `1 ≤ N ≤ m` whose power sum is nonzero. The proof does not introduce a new Vandermonde argument: it compares the family with `Fin 0` and applies the existing bounded power-sum multiset recovery theorem. If every positive power sum through `m` vanished, that theorem would force `m = 0`.

A matching source-cited blueprint corollary is added in Chapter 10. This is an atomic precursor for the representative-grouped Lemma L work in #3713; it does not claim that grouped Lemma L or Proposition 4.13 is complete.

This advances #3713.

Validation:

- focused Lean compilation;
- full `lake build` (9,332 jobs, followed by a successful incremental build after rebasing);
- `lake exe lint_style`;
- hazard, oversized-file, and `git diff --check` scans;
- reader-facing prose and blueprint synchronization checks;
- `leanblueprint checkdecls`;
- clean three-pass blueprint PDF build (511 pages) and visual inspection of printed page 140.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive theorem and documentation in algebra/blueprint only; no changes to auth, runtime, or existing theorem statements.
> 
> **Overview**
> Adds **`Matrix.exists_sum_pow_ne_zero_of_pos_card`**: for `m > 0` and nonzero `a : Fin m → ℂ`, some exponent `N` with `1 ≤ N ≤ m` has a **nonzero** power sum `∑ᵢ aᵢ^N`. The proof is by contradiction—if all such sums vanished, the family is compared to the empty `Fin 0` family via the existing **`sum_pow_eq_implies_card_eq_and_multiset_eq_of_le_max_card`** theorem, which would force `m = 0`.
> 
> Chapter 10 blueprint gains a matching **corollary** (Lemma L / Cirac2016 appendix citation) with `\lean{Matrix.exists_sum_pow_ne_zero_of_pos_card}`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95dfd13770cb9c850815d51352b5b14a23f57117. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->