### PR TITLE
feat(Algebra): integrate recurrent edge phases

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -25,6 +25,7 @@ import TNLean.Algebra.HermitianHelpers
 import TNLean.Algebra.MatrixSpectralDecomp
 import TNLean.Algebra.MatrixAux
 import TNLean.Algebra.KroneckerFactorPositivity
+import TNLean.Algebra.DirectedCycleCoboundary
 import TNLean.Algebra.MatrixGramUnitary
 import TNLean.Algebra.FinSum
 import TNLean.Algebra.ScalarPowerSumIdentity

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -25,7 +25,7 @@ import TNLean.Algebra.HermitianHelpers
 import TNLean.Algebra.MatrixSpectralDecomp
 import TNLean.Algebra.MatrixAux
 import TNLean.Algebra.KroneckerFactorPositivity
-import TNLean.Algebra.DirectedCycleCoboundary
+import TNLean.Algebra.DirectedWalkCoboundary
 import TNLean.Algebra.MatrixGramUnitary
 import TNLean.Algebra.FinSum
 import TNLean.Algebra.ScalarPowerSumIdentity

--- a/TNLean/Algebra/DirectedCycleCoboundary.lean
+++ b/TNLean/Algebra/DirectedCycleCoboundary.lean
@@ -1,0 +1,163 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Algebra.Group.Defs
+import Mathlib.Data.Quot
+
+/-!
+# Multiplicative coboundaries on recurrent directed graphs
+
+An edge weight on a directed graph is a vertex coboundary when it is the ratio
+of vertex weights at the endpoints of every edge. This file proves that trivial
+weight around every closed directed walk is sufficient when every directed edge
+admits a directed return walk.
+
+The proof chooses one vertex in each reachability component and defines the
+vertex weight by multiplication along a walk from that vertex. Trivial closed
+walk weights make this choice independent of the walk.
+-/
+
+namespace TNLean.Algebra
+
+variable {V G : Type*} (r : V → V → Prop)
+
+/-- A finite directed walk, including the walk of length zero. -/
+inductive DirectedWalk : V → V → Type _
+  | nil (a : V) : DirectedWalk a a
+  | cons {a b c : V} (hab : r a b) (w : DirectedWalk b c) : DirectedWalk a c
+
+namespace DirectedWalk
+
+/-- Concatenation of directed walks. -/
+def append {a b c : V} : DirectedWalk r a b → DirectedWalk r b c → DirectedWalk r a c
+  | .nil _, q => q
+  | .cons hab p, q => .cons hab (p.append q)
+
+@[simp]
+theorem nil_append {a b : V} (w : DirectedWalk r a b) : append r (nil a) w = w := rfl
+
+@[simp]
+theorem append_nil {a b : V} (w : DirectedWalk r a b) : append r w (nil b) = w := by
+  induction w with
+  | nil => rfl
+  | cons hab w ih => simp [append, ih]
+
+@[simp]
+theorem append_assoc {a b c d : V} (u : DirectedWalk r a b) (v : DirectedWalk r b c)
+    (w : DirectedWalk r c d) :
+    append r (append r u v) w = append r u (append r v w) := by
+  induction u with
+  | nil => rfl
+  | cons hab u ih => simp [append, ih]
+
+/-- The product of an edge-weight family along a directed walk. -/
+def weight (r : V → V → Prop) [Group G] (κ : V → V → G)
+    {a b : V} : DirectedWalk r a b → G
+  | .nil _ => 1
+  | @DirectedWalk.cons _ _ a b _ hab w => κ a b * weight r κ w
+
+@[simp]
+theorem weight_nil [Group G] (κ : V → V → G) (a : V) :
+    weight r κ (nil a) = 1 := rfl
+
+@[simp]
+theorem weight_cons [Group G] (κ : V → V → G) {a b c : V} (hab : r a b)
+    (w : DirectedWalk r b c) :
+    weight r κ (cons hab w) = κ a b * weight r κ w := rfl
+
+@[simp]
+theorem weight_append [Group G] (κ : V → V → G) {a b c : V}
+    (u : DirectedWalk r a b) (v : DirectedWalk r b c) :
+    weight r κ (append r u v) = weight r κ u * weight r κ v := by
+  induction u with
+  | nil => simp
+  | cons hab u ih => simp [append, ih, mul_assoc]
+
+private theorem weight_transport_start [Group G] (κ : V → V → G)
+    {a a' b : V} (h : a = a') (w : DirectedWalk r a b) :
+    weight r κ (h ▸ w) = weight r κ w := by
+  cases h
+  rfl
+
+/-- Reachability by a finite directed walk. -/
+def Reaches (a b : V) : Prop := Nonempty (DirectedWalk r a b)
+
+theorem reaches_refl (a : V) : Reaches r a a := ⟨nil a⟩
+
+theorem reaches_of_edge {a b : V} (hab : r a b) : Reaches r a b :=
+  ⟨cons hab (nil b)⟩
+
+theorem Reaches.trans {a b c : V} : Reaches r a b → Reaches r b c → Reaches r a c := by
+  rintro ⟨u⟩ ⟨v⟩
+  exact ⟨append r u v⟩
+
+/-- If every edge admits a return walk, every walk admits a return walk. -/
+theorem reaches_reverse_of_edge_returns
+    (hreturn : ∀ {a b : V}, r a b → Reaches r b a) {a b : V}
+    (w : DirectedWalk r a b) : Reaches r b a := by
+  induction w with
+  | nil a => exact reaches_refl r a
+  | @cons a b c hab w ih => exact Reaches.trans r ih (hreturn hab)
+
+/-- Reachability is an equivalence relation when every edge admits a return
+walk. -/
+def reachabilitySetoid (hreturn : ∀ {a b : V}, r a b → Reaches r b a) : Setoid V where
+  r := Reaches r
+  iseqv := {
+    refl := reaches_refl r
+    symm := by
+      rintro a b ⟨w⟩
+      exact reaches_reverse_of_edge_returns r hreturn w
+    trans := fun {_ _ _} hab hbc => Reaches.trans r hab hbc
+  }
+
+private theorem weight_eq_of_same_endpoints [Group G] (κ : V → V → G)
+    (hreturn : ∀ {a b : V}, r a b → Reaches r b a)
+    (hclosed : ∀ (a : V) (w : DirectedWalk r a a), weight r κ w = 1)
+    {a b : V} (u v : DirectedWalk r a b) : weight r κ u = weight r κ v := by
+  obtain ⟨q⟩ := reaches_reverse_of_edge_returns r hreturn u
+  have hu := hclosed a (append r u q)
+  have hv := hclosed a (append r v q)
+  simp only [weight_append] at hu hv
+  exact mul_right_cancel (hu.trans hv.symm)
+
+/-- **Closed-walk criterion for a multiplicative coboundary.** Suppose every
+directed edge admits a directed return walk. If the product of the edge weights
+around every closed directed walk is one, then there are vertex weights whose
+ratio across each directed edge is the prescribed edge weight. -/
+theorem exists_vertex_of_closedWalk_weight_eq_one [Group G]
+    (κ : V → V → G)
+    (hreturn : ∀ {a b : V}, r a b → Reaches r b a)
+    (hclosed : ∀ (a : V) (w : DirectedWalk r a a), weight r κ w = 1) :
+    ∃ z : V → G, ∀ {a b : V}, r a b → κ a b = (z a)⁻¹ * z b := by
+  classical
+  let s := reachabilitySetoid r hreturn
+  let root : V → V := fun a => (⟦a⟧ : Quotient s).out
+  have hroot_reaches : ∀ a : V, Reaches r (root a) a := by
+    intro a
+    exact Quotient.mk_out a
+  let path : (a : V) → DirectedWalk r (root a) a :=
+    fun a => Classical.choice (hroot_reaches a)
+  let z : V → G := fun a => weight r κ (path a)
+  refine ⟨z, ?_⟩
+  intro a b hab
+  have hquot : (⟦a⟧ : Quotient s) = ⟦b⟧ :=
+    Quotient.sound (reaches_of_edge r hab)
+  have hroot : root a = root b := congrArg Quotient.out hquot
+  let edgeWalk : DirectedWalk r a b := cons hab (nil b)
+  let candidate : DirectedWalk r (root b) b := hroot ▸ append r (path a) edgeWalk
+  have hweight := weight_eq_of_same_endpoints r κ hreturn hclosed (path b) candidate
+  have hcandidate : weight r κ candidate = z a * κ a b := by
+    rw [show candidate = hroot ▸ append r (path a) edgeWalk from rfl,
+      weight_transport_start]
+    simp [edgeWalk, z]
+  rw [hcandidate] at hweight
+  have hz : z b = z a * κ a b := hweight
+  rw [hz]
+  simp
+
+end DirectedWalk
+
+end TNLean.Algebra

--- a/TNLean/Algebra/DirectedWalkCoboundary.lean
+++ b/TNLean/Algebra/DirectedWalkCoboundary.lean
@@ -17,6 +17,21 @@ admits a directed return walk.
 The proof chooses one vertex in each reachability component and defines the
 vertex weight by multiplication along a walk from that vertex. Trivial closed
 walk weights make this choice independent of the walk.
+
+## Implementation notes
+
+The local `DirectedWalk` is a type-valued walk over an ordinary proposition-
+valued relation. This connects directly to relations such as
+`MPOTensor.IsSectorEdge` and allows a walk to be eliminated into its weight in
+an arbitrary monoid. In contrast, `Relation.ReflTransGen` is proposition-valued
+and therefore cannot in general be eliminated into such data, while
+`Quiver.Path` would first require replacing the proposition-valued relation by
+a quiver of edge types.
+
+`TNLean.Algebra.FiniteCycleCoboundary` treats the complementary special case of
+one finite cycle. A future MPDO specialization should prove the correspondence
+between `Relation.ReflTransGen` (hence `MPOTensor.SectorReaches`) and
+`DirectedWalk`, then apply the closed-walk theorem below to the sector phases.
 -/
 
 namespace TNLean.Algebra
@@ -53,29 +68,29 @@ theorem append_assoc {a b c d : V} (u : DirectedWalk r a b) (v : DirectedWalk r 
   | cons hab u ih => simp [append, ih]
 
 /-- The product of an edge-weight family along a directed walk. -/
-def weight (r : V → V → Prop) [Group G] (κ : V → V → G)
+def weight (r : V → V → Prop) [Monoid G] (κ : V → V → G)
     {a b : V} : DirectedWalk r a b → G
   | .nil _ => 1
   | @DirectedWalk.cons _ _ a b _ hab w => κ a b * weight r κ w
 
 @[simp]
-theorem weight_nil [Group G] (κ : V → V → G) (a : V) :
+theorem weight_nil [Monoid G] (κ : V → V → G) (a : V) :
     weight r κ (nil a) = 1 := rfl
 
 @[simp]
-theorem weight_cons [Group G] (κ : V → V → G) {a b c : V} (hab : r a b)
+theorem weight_cons [Monoid G] (κ : V → V → G) {a b c : V} (hab : r a b)
     (w : DirectedWalk r b c) :
     weight r κ (cons hab w) = κ a b * weight r κ w := rfl
 
 @[simp]
-theorem weight_append [Group G] (κ : V → V → G) {a b c : V}
+theorem weight_append [Monoid G] (κ : V → V → G) {a b c : V}
     (u : DirectedWalk r a b) (v : DirectedWalk r b c) :
     weight r κ (append r u v) = weight r κ u * weight r κ v := by
   induction u with
   | nil => simp
   | cons hab u ih => simp [append, ih, mul_assoc]
 
-private theorem weight_transport_start [Group G] (κ : V → V → G)
+private theorem weight_transport_start [Monoid G] (κ : V → V → G)
     {a a' b : V} (h : a = a') (w : DirectedWalk r a b) :
     weight r κ (h ▸ w) = weight r κ w := by
   cases h

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -1723,6 +1723,37 @@ strong subadditivity for a normalized three-site reduced state.
     can reach $k$ whenever $k\to h$ is an edge.
 \end{definition}
 
+\begin{theorem}[Closed-walk criterion for vertex phases]%
+    \label{thm:directed_cycle_coboundary}
+    \lean{TNLean.Algebra.DirectedWalk.exists_vertex_of_closedWalk_weight_eq_one}
+    \leanok
+    Let $E$ be a directed relation on a set $V$, and suppose that every edge
+    $a\to b$ admits a directed return walk from $b$ to $a$. Let $G$ be a
+    group and assign a weight $\kappa_{a,b}\in G$ to each ordered
+    pair of vertices. If the product of the edge weights along every closed
+    directed walk is one, then there are vertex weights $z_a\in G$ such that
+
+    \[
+        \kappa_{a,b}=z_a^{-1}z_b
+    \]
+    whenever $a\to b$ is an edge. This is the graph-theoretic coboundary step
+    needed to make the phase choices in
+    \cite[Appendix~C.2, lines~1446--1450]{Cirac2016MPDO_arXiv} coherent across
+    a recurrent support component.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Reachability is an equivalence relation because every edge has a return
+    walk. Choose one vertex in each reachability class and, for every vertex
+    $a$, choose a walk from the class representative to $a$. Define $z_a$ as
+    the product of the edge weights along this walk. If two such walks have
+    the same endpoints, append a common return walk; the two resulting closed
+    walks have weight one, so the original walk weights agree. Comparing the
+    chosen walk to $b$ with the chosen walk to $a$ followed by the edge
+    $a\to b$ gives $z_b=z_a\kappa_{a,b}$.
+\end{proof}
+
 \begin{definition}[Horizontal bond fiber of a sector cycle]%
     \label{def:mpdo_eta_cycle_fiber}
     \lean{MPOTensor.CycleFiber}
@@ -1951,17 +1982,19 @@ strong subadditivity for a normalized three-site reduced state.
         thm:mpdo_cyclic_eta_posSemidef,
         thm:mpdo_eta_cycle_positive_rescaling,
         thm:mpdo_sector_adapted_decomposition,
-        thm:positive_rescaling_phase_unique}
+        thm:positive_rescaling_phase_unique,
+        thm:directed_cycle_coboundary}
     The projected chain identity makes every cyclic Kronecker product of the
     neighboring operators positive semidefinite. The finite-factor rescaling
     theorem chooses positive phases on any one nonzero cycle. Two obligations
     remain. First, recurrence of the nonzero inverse-map support must be
     derived from the actual injective normal-tensor hypotheses, without using
     the later primitivity conclusion. Second, phase uniqueness and trivial
-    cycle holonomy must be used to integrate the edge phases to a single
-    vertex-indexed rephasing of the tensors $l_k,r_k$. Such a coboundary
-    rephasing preserves every cyclic product, and hence the all-length
-    decomposition. This is the coherent-choice step asserted at
+    cycle holonomy must be established for a single edge-phase family.
+    Theorem~\ref{thm:directed_cycle_coboundary} then integrates those edge
+    phases to a vertex-indexed rephasing of the tensors $l_k,r_k$. Such a
+    coboundary rephasing preserves every cyclic product, and hence the
+    all-length decomposition. This is the coherent-choice step asserted at
     \cite[Appendix~C.2, lines~1446--1450]{Cirac2016MPDO_arXiv}; it is not a
     consequence of positivity of the cyclic products alone.
 \end{proof}

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -427,12 +427,25 @@ component and defining its vertex phase by accumulating the per-edge
 scalars along any nonzero directed path from the base sector is then
 independent of the path chosen, because any two paths between the same
 pair of sectors close into a nonzero cycle (using recurrence to supply the
-return path) whose holonomy is trivial.  What remains is the bookkeeping to
-carry this argument out in Lean: converting \leanid{MPOTensor.SectorReaches}
-membership into an explicit finite path of sectors, defining the
-vertex phase by a choice of path via that path witness, and verifying the
-choice does not depend on which cycle produced the per-edge scalar via the
-uniqueness lemma above.  No formal declaration exists yet for this step.
+return path) whose holonomy is trivial.
+
+The graph-theoretic coboundary step is now formalized: for a recurrent
+directed relation, any group-valued edge assignment with trivial
+product around every closed directed walk is a vertex coboundary.
+\footnote{The formal declaration is
+\path{TNLean.Algebra.DirectedWalk.exists_vertex_of_closedWalk_weight_eq_one}.}
+The proof chooses one representative of each reachability component and
+defines the vertex weight by multiplication along a path from that
+representative; a common return path proves independence of the chosen path.
+
+The MPDO-specific bridge to this theorem remains open.  One must choose a
+single unit-modulus rescaling scalar for every nonzero neighboring operator,
+use the fixed-cycle rescaling and phase-uniqueness theorems to prove that this
+chosen family has product one around every closed nonzero sector walk, and
+translate recurrence expressed by \leanid{MPOTensor.SectorReaches} into the
+explicit finite walks used by the coboundary theorem.  These statements are
+expected consequences of the existing per-cycle results, but they have not
+yet been assembled for the dependent sector bond spaces.
 
 The canonical family
 \leanid{MPOTensor.ExplicitEtaOperators.ofHayashiMarkov} does not supply this


### PR DESCRIPTION
This PR proves the graph-theoretic coboundary step needed for coherent sector phases.

The new `DirectedWalk` API provides finite directed walks, concatenation, multiplicative weights, and reachability. Its main theorem states that if every directed edge admits a return walk and every closed directed walk has weight one, then a group-valued edge assignment is a vertex coboundary:

`κ(a,b) = z(a)⁻¹ z(b)` on every edge.

The theorem is valid for an arbitrary group; no commutativity, finiteness, or global connectedness assumption is used. The proof chooses one representative in each reachability class and integrates edge weights along representative-to-vertex paths. A common return path proves path independence by right cancellation.

The Chapter 22 blueprint and the MPDO paper-gap note record this as a proved preparatory step for #3696. They also state exactly what remains: choose one unit-modulus positive-semidefinite rescaling scalar for each nonzero neighboring operator, prove closed-walk holonomy using fixed-cycle rescaling and phase uniqueness, and separately derive recurrence from the concrete injective setting. This PR does not claim Lemma C.4.

This advances #3696.

Validation:

- focused Lean compilation and `lake exe lint_style`;
- full `TNLean:leanArts` build (9,334 jobs);
- proof-integrity and `git diff --check` scans;
- axiom audit: only `propext`, `Classical.choice`, and `Quot.sound`;
- reader-facing prose and blueprint synchronization checks;
- `leanblueprint checkdecls`;
- exact-head blueprint PDF build (512 pages) and visual inspection of printed page 452;
- standalone paper-gap note compilation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New standalone algebra with doc/blueprint sync only; no runtime or security-sensitive paths, and MPDO Lemma application is explicitly deferred.
> 
> **Overview**
> Adds **`TNLean.Algebra.DirectedWalkCoboundary`**, a small graph API (`DirectedWalk`, concatenation, multiplicative **`weight`**, reachability) and proves that on a directed relation where every edge has a return walk, **trivial product around all closed walks** forces edge weights to be a **vertex coboundary** `κ a b = (z a)⁻¹ * z b` in an arbitrary **group** `G`.
> 
> The module is exported from **`TNLean.lean`**. The Chapter 21 blueprint gains **`thm:directed_cycle_coboundary`** (lean-linked), and the η positivity proof now cites that theorem for integrating edge phases instead of leaving the coboundary step informal. The MPDO paper-gap note marks this graph step as **proved** while stating the **MPDO-specific bridge** (sector walks, unit-modulus rescaling, holonomy) is still open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c33dbed9cf15c5e52f29d438ba09ae2a1a263ff6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->