### PR TITLE
feat(MPS/MPDO): construct positive two-site sector bond

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -410,6 +410,7 @@ import TNLean.MPS.MPDO.PhysicalSectorRefinementIdentity
 import TNLean.MPS.MPDO.PhysicalSectorPhysicalMaps
 import TNLean.MPS.MPDO.PhysicalSectorBlockedRFP
 import TNLean.MPS.MPDO.PhysicalSectorCoordinateTransport
+import TNLean.MPS.MPDO.PhysicalSectorPositiveBond
 import TNLean.MPS.MPDO.PhysicalSectorPhysicalTransport
 import TNLean.MPS.MPDO.SectorPairingTransfer
 import TNLean.MPS.MPDO.SectorEtaContraction

--- a/TNLean/MPS/MPDO/PhysicalSectorPositiveBond.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorPositiveBond.lean
@@ -1,0 +1,121 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Analysis.MatrixSqrt
+import TNLean.MPS.MPDO.PhysicalSectorClosureGlobal
+import TNLean.MPS.MPDO.PhysicalSectorCoordinateTransport
+
+/-!
+# Positive two-site bond from physical sectors
+
+This file constructs the two-site bond associated with a physical-sector
+factorization.  In regrouped sector coordinates, its block on sectors
+`(k, h)` is the identity on the two outer factors tensored with the
+neighboring operator `η_{k,h}`.  The bond is then transported to the original
+two-site physical space and reindexed by two-site configurations.
+
+The positivity proofs use only positivity of the neighboring operators.
+
+## Main definitions
+
+* `PhysicalSectorFactorization.sectorCoordinateBond`: the bond in the
+  two-site sector coordinates.
+* `PhysicalSectorFactorization.physicalPairBond`: the same bond on the
+  original pair of physical indices.
+* `PhysicalSectorFactorization.physicalBond`: the bond indexed by two-site
+  physical configurations.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, Proposition C.8, lines 1581--1593
+-/
+
+open scoped Matrix ComplexOrder Kronecker
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D}
+
+/-- The two-site bond in sector coordinates.  On the summand labeled by
+`(k, h)`, it is the identity on the outer space
+$B_k^L \otimes B_h^R$ tensored with the neighboring operator
+$\eta_{k,h}$ on $B_k^R \otimes B_h^L$.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`), lines
+1581--1593. -/
+noncomputable def sectorCoordinateBond (F : PhysicalSectorFactorization K) :
+    Matrix
+      (Fin (Fintype.card (SectorSiteIndex F)) ×
+        Fin (Fintype.card (SectorSiteIndex F)))
+      (Fin (Fintype.card (SectorSiteIndex F)) ×
+        Fin (Fintype.card (SectorSiteIndex F))) ℂ :=
+  Matrix.reindex F.twoSiteGlobalRegroupEquiv.symm
+    F.twoSiteGlobalRegroupEquiv.symm
+    (Matrix.blockDiagonal' fun kh : Fin F.sectorCount × Fin F.sectorCount ↦
+      (1 : Matrix (BoundaryIndex F kh.1 kh.2)
+        (BoundaryIndex F kh.1 kh.2) ℂ) ⊗ₖ F.neighboringOperator kh.1 kh.2)
+
+/-- The sector-coordinate bond is positive semidefinite whenever each
+neighboring operator is positive semidefinite.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1446--1450 and Proposition C.8
+(`3to4`), lines 1581--1593. -/
+theorem sectorCoordinateBond_pos (F : PhysicalSectorFactorization K)
+    (hη : ∀ k h, (F.neighboringOperator k h).PosSemidef) :
+    F.sectorCoordinateBond.PosSemidef := by
+  have hblock :
+      (Matrix.blockDiagonal' fun kh : Fin F.sectorCount × Fin F.sectorCount ↦
+        (1 : Matrix (BoundaryIndex F kh.1 kh.2)
+          (BoundaryIndex F kh.1 kh.2) ℂ) ⊗ₖ
+            F.neighboringOperator kh.1 kh.2).PosSemidef := by
+    apply Matrix.PosSemidef.blockDiagonal'
+    intro kh
+    exact Matrix.PosSemidef.kronecker Matrix.PosSemidef.one (hη kh.1 kh.2)
+  simpa only [sectorCoordinateBond, Matrix.reindex_apply,
+    Equiv.symm_symm] using hblock.submatrix F.twoSiteGlobalRegroupEquiv
+
+/-- The two-site bond transported from sector coordinates to the original
+pair of physical indices.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`), lines
+1581--1593. -/
+noncomputable def physicalPairBond (F : PhysicalSectorFactorization K) :
+    Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ :=
+  sandwichMap F.physicalCoordinateMatrixTwoᴴ F.sectorCoordinateBond
+
+/-- The transported bond on the original pair of physical indices is positive
+semidefinite whenever each neighboring operator is positive semidefinite.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1446--1450 and Proposition C.8
+(`3to4`), lines 1581--1593. -/
+theorem physicalPairBond_pos (F : PhysicalSectorFactorization K)
+    (hη : ∀ k h, (F.neighboringOperator k h).PosSemidef) :
+    F.physicalPairBond.PosSemidef := by
+  exact (F.sectorCoordinateBond_pos hη).mul_mul_conjTranspose_same
+    F.physicalCoordinateMatrixTwoᴴ
+
+/-- The transported two-site bond, indexed by configurations
+`Fin 2 → Fin d`.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`), lines
+1581--1593. -/
+noncomputable def physicalBond (F : PhysicalSectorFactorization K) :
+    Matrix (Fin 2 → Fin d) (Fin 2 → Fin d) ℂ :=
+  Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+    (finTwoArrowEquiv (Fin d)).symm F.physicalPairBond
+
+/-- The transported bond on two-site physical configurations is positive
+semidefinite whenever each neighboring operator is positive semidefinite.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1446--1450 and Proposition C.8
+(`3to4`), lines 1581--1593. -/
+theorem physicalBond_pos (F : PhysicalSectorFactorization K)
+    (hη : ∀ k h, (F.neighboringOperator k h).PosSemidef) :
+    F.physicalBond.PosSemidef := by
+  simpa only [physicalBond, Matrix.reindex_apply, Equiv.symm_symm] using
+    (F.physicalPairBond_pos hη).submatrix (finTwoArrowEquiv (Fin d))
+
+end MPOTensor.PhysicalSectorFactorization

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -1141,6 +1141,85 @@ strong subadditivity for a normalized three-site reduced state.
     \]
 \end{proof}
 
+\begin{definition}[Two-site sector bond]
+    \label{def:mpdo_physical_sector_two_site_bond}
+    \lean{MPOTensor.PhysicalSectorFactorization.sectorCoordinateBond}
+    \leanok
+    \uses{def:mpdo_minimal_neighboring_operator,
+      def:mpdo_global_sector_closure_coordinates}
+    In the two-site sector coordinates, define
+    \[
+      B_{\mathrm{sec}}
+      =\bigoplus_{k,h}
+        \left(I_{B_k^L\otimes B_h^R}\otimes\eta_{k,h}\right).
+    \]
+    Thus the outer factors carry the identity, while the neighboring factors
+    carry the operator $\eta_{k,h}$. This is the local bond in
+    \cite[Appendix~C.2, Proposition~C.8, lines~1581--1593]
+      {Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{theorem}[Positivity of the two-site sector bond]
+    \label{thm:mpdo_physical_sector_two_site_bond_pos}
+    \lean{MPOTensor.PhysicalSectorFactorization.sectorCoordinateBond_pos}
+    \leanok
+    \uses{def:mpdo_physical_sector_two_site_bond,
+      thm:matrix_pos_semidef_block_diagonal}
+    Suppose that $\eta_{k,h}$ is positive semidefinite for every pair of
+    sectors. Then $B_{\mathrm{sec}}$ is positive semidefinite. The positivity
+    premise is the conclusion at
+    \cite[Appendix~C.2, lines~1446--1450]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:matrix_pos_semidef_block_diagonal}
+    Each summand
+    $I_{B_k^L\otimes B_h^R}\otimes\eta_{k,h}$ is positive semidefinite.
+    Positivity is preserved by finite block diagonals and by the reindexing
+    from the regrouped direct sum to the two-site sector coordinates.
+\end{proof}
+
+\begin{definition}[Two-site bond in physical coordinates]
+    \label{def:mpdo_physical_two_site_bond}
+    \lean{MPOTensor.PhysicalSectorFactorization.physicalPairBond,
+      MPOTensor.PhysicalSectorFactorization.physicalBond}
+    \leanok
+    \uses{def:mpdo_physical_sector_two_site_bond,
+      def:mpdo_physical_sector_factorization}
+    Let $V_2$ be the two-site tensor product of the project's coordinate map,
+    so that $V_2XV_2^\dagger$ expresses a physical operator $X$ in sector
+    coordinates. Thus $V_2=U_{\mathrm{paper}}^\dagger$ in the convention of
+    \cite[Appendix~C.2, lines~1581--1583]{Cirac2016MPDO_arXiv}. Define
+    \[
+      B_{\mathrm{phys}}=V_2^\dagger B_{\mathrm{sec}}V_2,
+    \]
+    and identify pairs of physical indices with functions
+    $\{0,1\}\to\{0,\ldots,d-1\}$. This is the physical two-site bond in
+    \cite[Appendix~C.2, Proposition~C.8, lines~1581--1593]
+      {Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{theorem}[Positivity of the physical two-site bond]
+    \label{thm:mpdo_physical_two_site_bond_pos}
+    \lean{MPOTensor.PhysicalSectorFactorization.physicalPairBond_pos,
+      MPOTensor.PhysicalSectorFactorization.physicalBond_pos}
+    \leanok
+    \uses{def:mpdo_physical_two_site_bond,
+      thm:mpdo_physical_sector_two_site_bond_pos}
+    Suppose that $\eta_{k,h}$ is positive semidefinite for every pair of
+    sectors. Then $B_{\mathrm{phys}}$ is positive semidefinite, both with
+    pair indices and with two-site configuration indices.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_physical_sector_two_site_bond_pos}
+    Apply positivity of $B_{\mathrm{sec}}$ to the congruence
+    $U_2^\dagger B_{\mathrm{sec}}U_2$. Reindexing the resulting matrix by
+    two-site configurations preserves positivity.
+\end{proof}
+
 \begin{definition}[Closed sector tensors]%
     \label{def:mpdo_closed_sector_tensors}
     \lean{MPOTensor.closedSectorL}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -1149,7 +1149,7 @@ strong subadditivity for a normalized three-site reduced state.
       def:mpdo_global_sector_closure_coordinates}
     In the two-site sector coordinates, define
     \[
-      B_{\mathrm{sec}}
+      B_{\mathrm{sector}}
       =\bigoplus_{k,h}
         \left(I_{B_k^L\otimes B_h^R}\otimes\eta_{k,h}\right).
     \]
@@ -1166,7 +1166,7 @@ strong subadditivity for a normalized three-site reduced state.
     \uses{def:mpdo_physical_sector_two_site_bond,
       thm:matrix_pos_semidef_block_diagonal}
     Suppose that $\eta_{k,h}$ is positive semidefinite for every pair of
-    sectors. Then $B_{\mathrm{sec}}$ is positive semidefinite. The positivity
+    sectors. Then $B_{\mathrm{sector}}$ is positive semidefinite. The positivity
     premise is the conclusion at
     \cite[Appendix~C.2, lines~1446--1450]{Cirac2016MPDO_arXiv}.
 \end{theorem}
@@ -1192,7 +1192,7 @@ strong subadditivity for a normalized three-site reduced state.
     coordinates. Thus $V_2=U_{\mathrm{paper}}^\dagger$ in the convention of
     \cite[Appendix~C.2, lines~1581--1583]{Cirac2016MPDO_arXiv}. Define
     \[
-      B_{\mathrm{phys}}=V_2^\dagger B_{\mathrm{sec}}V_2,
+      B_{\mathrm{physical}}=V_2^\dagger B_{\mathrm{sector}}V_2,
     \]
     and identify pairs of physical indices with functions
     $\{0,1\}\to\{0,\ldots,d-1\}$. This is the physical two-site bond in
@@ -1208,15 +1208,15 @@ strong subadditivity for a normalized three-site reduced state.
     \uses{def:mpdo_physical_two_site_bond,
       thm:mpdo_physical_sector_two_site_bond_pos}
     Suppose that $\eta_{k,h}$ is positive semidefinite for every pair of
-    sectors. Then $B_{\mathrm{phys}}$ is positive semidefinite, both with
+    sectors. Then $B_{\mathrm{physical}}$ is positive semidefinite, both with
     pair indices and with two-site configuration indices.
 \end{theorem}
 
 \begin{proof}
     \leanok
     \uses{thm:mpdo_physical_sector_two_site_bond_pos}
-    Apply positivity of $B_{\mathrm{sec}}$ to the congruence
-    $U_2^\dagger B_{\mathrm{sec}}U_2$. Reindexing the resulting matrix by
+    Apply positivity of $B_{\mathrm{sector}}$ to the congruence
+    $V_2^\dagger B_{\mathrm{sector}}V_2$. Reindexing the resulting matrix by
     two-site configurations preserves positivity.
 \end{proof}
 


### PR DESCRIPTION
## Summary

This change constructs the local two-site bond appearing in Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, Appendix C.2, Proposition C.8.

For a `PhysicalSectorFactorization`, it defines the sector-coordinate matrix
\[
B_{\mathrm{sec}}=
\bigoplus_{k,h}\left(I_{B_k^L\otimes B_h^R}\otimes\eta_{k,h}\right)
\]
and proves it positive semidefinite when every neighboring operator `η_{k,h}` is positive semidefinite. It then transports this bond to the original two-site physical coordinates and reindexes it by two-site configurations, preserving positivity at both steps.

Closes #3790.

## Source alignment

The construction follows Proposition C.8 (`3to4`), lines 1581–1593; the neighboring-operator positivity premise is the conclusion at lines 1446–1450.

The only substantive hypothesis is
`∀ k h, (F.neighboringOperator k h).PosSemidef`.
The proof does not use `NeighboringTraceFactorization`, zero correlation length, or rank-one trace data. Thus it formalizes the local positive-bond step of Proposition C.8 without importing hypotheses from Lemma C.5.

Under the project's convention, `physicalCoordinateMatrixTwo = V_2` sends physical coordinates to sector coordinates. Hence inverse transport is
\[
B_{\mathrm{phys}}=V_2^\dagger B_{\mathrm{sec}}V_2.
\]
The blueprint states explicitly that this `V_2` corresponds to the adjoint of the coordinate matrix used in the paper's displayed convention.

This pull request does not claim translated commutativity, the all-length product formula, or construction of `EtaLocalStructureData`; those remain in #823.

## Verification

- `lake env lean TNLean/MPS/MPDO/PhysicalSectorPositiveBond.lean`
- `lake build TNLean.MPS.MPDO.PhysicalSectorPositiveBond`
- `lake build`
- `cd blueprint && leanblueprint checkdecls`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --diff-base origin/main --ci`
- `git diff --check`
- independent review of the block order, positivity proof, and coordinate orientation
- no `sorry`, `axiom`, kernel bypass, `NeighboringTraceFactorization`, ZCL, or rank-one dependency

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formalization and documentation on the MPDO physical-sector track; no runtime, security, or axiom bypass.
> 
> **Overview**
> Adds **`PhysicalSectorPositiveBond.lean`**, formalizing the local two-site bond from Cirac et al. Appendix C.2 (Proposition C.8): **`sectorCoordinateBond`** as a block-diagonal direct sum of \(I \otimes \eta_{k,h}\) in regrouped sector coordinates, then **`physicalPairBond`** / **`physicalBond`** via `sandwichMap` with `physicalCoordinateMatrixTwoᴴ` and reindexing to `Fin 2 → Fin d`.
> 
> Positivity is proved at each stage from **`∀ k h, (F.neighboringOperator k h).PosSemidef`** only (block-diagonal + Kronecker with identity, congruence under the coordinate map, submatrix reindexing)—no trace-factorization or ZCL hypotheses.
> 
> Chapter 21 blueprint gains matching definitions/theorems/proofs with `\lean` links; the module is wired into the root **`TNLean.lean`** import list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58fba8001083284ba8008f8a89722c99fd1d2bc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->