### PR TITLE
feat(MPS/MPDO): connect closed-sector trace matrix to ZCL

### DIFF
--- a/TNLean/Algebra/PerronFrobenius/RankOne.lean
+++ b/TNLean/Algebra/PerronFrobenius/RankOne.lean
@@ -310,6 +310,24 @@ and cyclicity of the trace of a composition between `W` and the coefficient
 space identifies `trace T` with the trace of the restricted operator and
 `trace (T^2)` with the trace of its square, which coincide by idempotence. -/
 
+/-- If the rectangular product `L * Q` is idempotent, then the product in the
+opposite order satisfies
+\[
+  (QL)^2=(QL)^3.
+\]
+This is the rectangular associativity calculation used in
+arXiv:1606.00608, Appendix C.2, lines 1490--1497. -/
+theorem pow_two_eq_pow_three_of_rectangular_idempotent
+    {a b : Type*} [Fintype a] [Fintype b] [DecidableEq b]
+    {R : Type*} [Semiring R] (L : Matrix a b R) (Q : Matrix b a R)
+    (h : IsIdempotentElem (L * Q)) :
+    (Q * L) ^ 2 = (Q * L) ^ 3 := by
+  classical
+  rw [show (Q * L) ^ 2 = Q * (L * Q) * L by simp [pow_two, Matrix.mul_assoc]]
+  rw [show (Q * L) ^ 3 = Q * ((L * Q) * (L * Q)) * L by
+    simp [pow_succ, Matrix.mul_assoc]]
+  rw [h.eq]
+
 /-- **Unconditional `T^2 = T^3` from the pairing idempotence.**
 
 For the sector trace matrix `T k h = r k (l h)` of arXiv:1606.00608,

--- a/TNLean/MPS/MPDO/SectorPairingTransfer.lean
+++ b/TNLean/MPS/MPDO/SectorPairingTransfer.lean
@@ -21,6 +21,8 @@ normalization.
   the physical-trace transfer as a sum of outer products of closed tensors.
 * `concrete_physTraceTransfer_eq_sum_closedSector`: the identity for the
   inverse-map sector tensors constructed from an injective simple tensor.
+* `closedSectorTraceMatrix`: the matrix of pairings between the concrete
+  closed right and left sector tensors.
 * `closedSector_operator_quasi_idempotent`: source zero correlation length
   gives quasi-idempotence of the closed-sector pairing operator.
 * `closedSector_operator_normalized_idempotent`: after the source
@@ -40,6 +42,24 @@ open scoped Matrix BigOperators
 namespace MPOTensor
 
 variable {d D : ℕ}
+
+/-- If the rectangular product `L * R` is idempotent, then the product in the
+opposite order satisfies
+\[
+  (RL)^2=(RL)^3.
+\]
+This is the rectangular associativity calculation used in
+arXiv:1606.00608, Appendix C.2, lines 1490--1497. -/
+theorem _root_.Matrix.pow_two_eq_pow_three_of_rectangular_idempotent
+    {a b : Type*} [Fintype a] [Fintype b] [DecidableEq b]
+    {R : Type*} [Semiring R] (L : Matrix a b R) (Q : Matrix b a R)
+    (h : IsIdempotentElem (L * Q)) :
+    (Q * L) ^ 2 = (Q * L) ^ 3 := by
+  classical
+  rw [show (Q * L) ^ 2 = Q * (L * Q) * L by simp [pow_two, Matrix.mul_assoc]]
+  rw [show (Q * L) ^ 3 = Q * ((L * Q) * (L * Q)) * L by
+    simp [pow_succ, Matrix.mul_assoc]]
+  rw [h.eq]
 
 /-- The pairing operator obtained by closing the physical legs of the left and
 right tensors in each sector:
@@ -99,6 +119,30 @@ variable (K : MPOTensor d D) (hK : K.IsInjective) (hη : EtaStructure ρ)
 variable (R : Matrix (Fin D) (Fin D) ℂ) (hρ : IsThreeSiteClosure K R ρ)
 variable (α₁ β₃ : Fin D) (hm : R β₃ α₁ ≠ 0)
 
+/-- **The concrete closed-sector trace matrix.** Its entries pair the closed
+right sector tensor with the closed left sector tensor:
+\[
+  T_{k,h}=(r_k\mid l_h).
+\]
+
+Source: arXiv:1606.00608, Appendix C.2, equation `Tkn`, lines 1478--1481. -/
+noncomputable def closedSectorTraceMatrix : Matrix (Fin hη.m) (Fin hη.m) ℂ :=
+  fun k h ↦ closedSectorR K hK hη β₃ k ⬝ᵥ
+    closedSectorL K hK hη R α₁ β₃ h
+
+/-- The entries of the concrete closed-sector trace matrix are the traces of
+the neighboring operators:
+\[
+  T_{k,h}=\operatorname{tr}(\eta_{k,h}).
+\]
+
+Source: arXiv:1606.00608, Appendix C.2, equations `etarl` and `Tkn`,
+lines 1446--1455 and 1478--1481. -/
+theorem closedSectorTraceMatrix_apply (k h : Fin hη.m) :
+    closedSectorTraceMatrix K hK hη R α₁ β₃ k h =
+      (sectorEta K hK hη R α₁ β₃ k h).trace := by
+  rw [closedSectorTraceMatrix, trace_sectorEta]
+
 include hρ hm
 
 /-- For the inverse-map sector tensors of an injective simple tensor,
@@ -155,6 +199,46 @@ theorem closedSector_operator_normalized_idempotent
   dsimp only
   rw [← concrete_physTraceTransfer_eq_sum_closedSector K hK hη R hρ α₁ β₃ hm]
   exact hidem
+
+/-- Source zero correlation length implies that the normalized concrete
+closed-sector trace matrix satisfies
+\[
+  \widehat T^2=\widehat T^3,
+  \qquad \widehat T=\lambda^{-1}T,
+  \qquad \lambda>0.
+\]
+This follows by writing the normalized closed-sector pairing operator as
+`L * Q` and the normalized trace matrix as `Q * L`.  The conclusion does not
+assert that the trace matrix is idempotent or has rank one.
+
+Derived from the zero-correlation-length identity in the proof of
+arXiv:1606.00608, Appendix C.2, Lemma `SALZCL`, lines 1490--1497. -/
+theorem closedSectorTraceMatrix_normalized_pow_two_eq_pow_three
+    (hZCL : IsSourceZCL K) :
+    ∃ lam : ℝ, 0 < lam ∧
+      let T := closedSectorTraceMatrix K hK hη R α₁ β₃
+      (((lam : ℂ)⁻¹ • T) ^ 2 = ((lam : ℂ)⁻¹ • T) ^ 3) := by
+  obtain ⟨lam, hlam, hidem⟩ :=
+    closedSector_operator_normalized_idempotent K hK hη R hρ α₁ β₃ hm hZCL
+  let L : Matrix (Fin D) (Fin hη.m) ℂ :=
+    fun β h ↦ closedSectorL K hK hη R α₁ β₃ h β
+  let Q : Matrix (Fin hη.m) (Fin D) ℂ :=
+    fun k α ↦ closedSectorR K hK hη β₃ k α
+  have hS : closedSectorPairingOperator
+      (sectorTensorL K hK hη R α₁ β₃) (sectorTensorR K hK hη β₃) = L * Q := by
+    ext β α
+    simp [closedSectorPairingOperator, L, Q, Matrix.mul_apply, Matrix.sum_apply,
+      Matrix.vecMulVec_apply, closedSectorL, closedSectorR]
+  have hT : closedSectorTraceMatrix K hK hη R α₁ β₃ = Q * L := by
+    ext k h
+    simp [closedSectorTraceMatrix, Q, L, Matrix.mul_apply, dotProduct]
+  refine ⟨lam, hlam, ?_⟩
+  dsimp only
+  have hrect : IsIdempotentElem (((lam : ℂ)⁻¹ • L) * Q) := by
+    simpa only [Matrix.smul_mul, ← hS] using hidem
+  have hpow := Matrix.pow_two_eq_pow_three_of_rectangular_idempotent
+    ((lam : ℂ)⁻¹ • L) Q hrect
+  simpa only [Matrix.mul_smul, ← hT] using hpow
 
 /-- For a canonically normalized representative whose physical-trace transfer
 is literally idempotent, the raw closed-sector pairing operator satisfies

--- a/TNLean/MPS/MPDO/SectorPairingTransfer.lean
+++ b/TNLean/MPS/MPDO/SectorPairingTransfer.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.MPDO.SectorFactorization
 import TNLean.MPS.Core.MultiBlock
+import TNLean.Algebra.PerronFrobenius.RankOne
 
 /-!
 # Closed sector tensors and the physical-trace transfer
@@ -42,24 +43,6 @@ open scoped Matrix BigOperators
 namespace MPOTensor
 
 variable {d D : ℕ}
-
-/-- If the rectangular product `L * R` is idempotent, then the product in the
-opposite order satisfies
-\[
-  (RL)^2=(RL)^3.
-\]
-This is the rectangular associativity calculation used in
-arXiv:1606.00608, Appendix C.2, lines 1490--1497. -/
-theorem _root_.Matrix.pow_two_eq_pow_three_of_rectangular_idempotent
-    {a b : Type*} [Fintype a] [Fintype b] [DecidableEq b]
-    {R : Type*} [Semiring R] (L : Matrix a b R) (Q : Matrix b a R)
-    (h : IsIdempotentElem (L * Q)) :
-    (Q * L) ^ 2 = (Q * L) ^ 3 := by
-  classical
-  rw [show (Q * L) ^ 2 = Q * (L * Q) * L by simp [pow_two, Matrix.mul_assoc]]
-  rw [show (Q * L) ^ 3 = Q * ((L * Q) * (L * Q)) * L by
-    simp [pow_succ, Matrix.mul_assoc]]
-  rw [h.eq]
 
 /-- The pairing operator obtained by closing the physical legs of the left and
 right tensors in each sector:

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -1278,6 +1278,24 @@ strong subadditivity for a normalized three-site reduced state.
     \]
 \end{proof}
 
+\begin{definition}[Concrete closed-sector trace matrix]
+    \label{def:mpdo_concrete_closed_sector_trace_matrix}
+    \lean{MPOTensor.closedSectorTraceMatrix}
+    \lean{MPOTensor.closedSectorTraceMatrix_apply}
+    \leanok
+    \uses{def:mpdo_closed_sector_tensors, thm:mpdo_sector_trace_pairing}
+    For the inverse-map sector tensors, define the complex matrix
+    \[
+        T_{k,h}:=(r_k|l_h).
+    \]
+    Equivalently,
+    \[
+        T_{k,h}=\tr(\eta_{k,h}).
+    \]
+    This is the trace matrix in
+    \cite[Appendix~C.2, lines~1478--1481]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
 \begin{theorem}[Closed-sector form of the physical-trace transfer]
     \label{thm:mpdo_closed_sector_physical_trace_transfer}
     \lean{MPOTensor.physTraceTransfer_eq_sum_closedSector}
@@ -1384,6 +1402,41 @@ strong subadditivity for a normalized three-site reduced state.
     $\mathcal T_{\cal K}^2=\lambda\mathcal T_{\cal K}$, and then apply
     Lemma~\ref{lem:mpo_source_zcl_normalized_idempotent}.  Under literal
     idempotence, the same substitution gives $S^2=S$ directly.
+\end{proof}
+
+\begin{theorem}[Normalized closed-sector trace relation]
+    \label{thm:mpdo_closed_sector_trace_normalized_pow_relation}
+    \lean{MPOTensor.closedSectorTraceMatrix_normalized_pow_two_eq_pow_three}
+    \leanok
+    \uses{def:mpdo_concrete_closed_sector_trace_matrix,
+        thm:mpdo_closed_sector_pairing_normalized_idempotent}
+    Under the hypotheses of
+    Theorem~\ref{thm:mpdo_closed_sector_pairing_normalized_idempotent},
+    suppose that ${\cal K}$ has source zero correlation length.  There is a
+    real number $\lambda>0$ such that, for
+    \[
+        \widehat T:=\lambda^{-1}T,
+    \]
+    one has
+    \[
+        \widehat T^2=\widehat T^3.
+    \]
+    No idempotence or rank-one conclusion for $\widehat T$ is asserted.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_closed_sector_pairing_normalized_idempotent}
+    Let $L$ be the matrix whose $h$th column is $|l_h)$, and let $Q$ be the
+    matrix whose $k$th row is $(r_k|$.  Then $S=LQ$ and $T=QL$.  Place the
+    normalization scalar on $L$.  Since $\lambda^{-1}LQ$ is idempotent,
+    associativity gives
+    \[
+      (Q\lambda^{-1}L)^2
+        =Q(\lambda^{-1}LQ)\lambda^{-1}L
+        =Q(\lambda^{-1}LQ)^2\lambda^{-1}L
+        =(Q\lambda^{-1}L)^3.
+    \]
 \end{proof}
 
 \begin{definition}[Explicit neighboring $\eta$-operator data]

--- a/docs/paper-gaps/cpgsv17_pf_rank_one.tex
+++ b/docs/paper-gaps/cpgsv17_pf_rank_one.tex
@@ -226,19 +226,35 @@ derive their linear independence.
 {\scriptsize\leanid{MPOTensor.sal_zcl_implies_rank_one_T_of_sector_supports}} in
 \doclink{TNLean/MPS/MPDO/SimpleLocalStructure}.}
 
-Two obligations remain before the conditional hypotheses of the rank-one
-factorization disappear; the constant trace powers above no longer depend on
-either.  First, the inverse-map factorization at lines 1407--1482 must
-construct the families $(l_k)_k$ and $(r_k)_k$ from an injective simple
-tensor and prove the pairing $T_{k,h}=(r_k|l_h)$ together with the operator
-identity at lines 1490--1493 for those concrete families; the present
-structure records the pairing and the identity as data.  Second, linear
-independence of the closed tensors must be proved.  The direct sum in the
-source's sector splitting at lines 1436--1448 concerns the physical indices;
-after those indices are contracted, the closed tensors live in a common bond
-space.  Their membership in corresponding members of an independent family of
-subspaces --- or their independence by another argument --- therefore does not
-follow from the displayed equations alone.
+The inverse-map construction has now been connected to this argument without
+introducing additional hypotheses.  The closed tensors $(l_k)_k$ and
+$(r_k)_k$ are constructed from an injective simple tensor, the complex matrix
+is defined by
+\[
+  T_{k,h}=(r_k|l_h)=\operatorname{tr}(\eta_{k,h}),
+\]
+and its pairing operator is identified with the physical-trace transfer.
+Source zero correlation length therefore supplies a number $\lambda>0$ for
+which the normalized pairing operator is idempotent.  The rectangular
+factorization $S=L R$ and $T=R L$ then proves
+\[
+  (\lambda^{-1}T)^2=(\lambda^{-1}T)^3.
+\]
+This is formalized as
+{\scriptsize\leanid{MPOTensor.closedSectorTraceMatrix_apply}} and
+{\scriptsize\leanid{MPOTensor.closedSectorTraceMatrix_normalized_pow_two_eq_pow_three}}
+in \doclink{TNLean/MPS/MPDO/SectorPairingTransfer}.
+
+This conclusion is the scale-invariant consequence of the displayed operator
+equation; it does not imply that the normalized trace matrix is
+idempotent or has rank one.  The remaining pairing route would have to prove
+linear independence of one of the two closed tensor families, or supply a
+different argument excluding the generalized zero-eigenspace.  The direct sum
+in the source's sector splitting at lines 1436--1448 concerns the physical
+indices; after those indices are contracted, the closed tensors live in a
+common bond space.  Their membership in corresponding members of an
+independent family of subspaces --- or their independence by another argument
+--- therefore does not follow from the displayed equations alone.
 
 \section{A positive-semidefinite route}
 
@@ -340,10 +356,10 @@ false primitive trace-power implication has been removed.
 
 For the unconditional matrix product density operator argument, it therefore
 suffices either to prove the required positive-semidefinite structure of the
-trace matrix, or to construct the source sector pairing and derive the needed
-linear independence at the matrix product density operator call site.  The
-source proof has a genuine unsupported intermediate assertion, while the
-intended matrix product density operator theorem itself has not been
+trace matrix, or to derive the needed linear independence (or an equivalent
+exclusion of the generalized zero-eigenspace) for the concrete source sector
+pairing.  The source proof has a genuine unsupported intermediate assertion,
+while the intended matrix product density operator theorem itself has not been
 disproved.
 
 \bibliographystyle{alpha}


### PR DESCRIPTION
## Summary

This change connects the concrete inverse-map sector tensors to the trace-matrix calculation in Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, Appendix C.2, Lemma C.5.

It defines
\[
T_{k,h}=(r_k\mid l_h),
\]
proves entrywise that `T_{k,h} = tr(η_{k,h})`, and derives the source-faithful normalized relation
\[
\widehat T^2=\widehat T^3,
\qquad
\widehat T=\lambda^{-1}T,
\qquad \lambda>0,
\]
from source zero correlation length.

Closes #3791.

## Mathematical argument

Let `L` have columns `|l_h)` and let `Q` have rows `(r_k|`. The normalized closed-sector pairing operator is
\[
\lambda^{-1}LQ,
\]
which is idempotent by the existing concrete ZCL theorem. The normalized trace matrix is
\[
Q(\lambda^{-1}L)=\lambda^{-1}T.
\]
For rectangular matrices, idempotence of `LQ` gives
\[
(QL)^2=Q(LQ)L=Q(LQ)^2L=(QL)^3.
\]
The new matrix helper formalizes precisely this associativity calculation.

## Source-faithfulness boundary

The square–cube relation is derived from the zero-correlation-length operator identity in the proof of `SALZCL`, lines 1490–1497. The paper does not state this relation as a separate theorem.

This change does not assert rank one, `T^2=T`, positive semidefiniteness, or linear independence of the closed sector tensors. The paper-gap note now records that the normalized square–cube relation is the scale-invariant consequence presently justified by the concrete operator identity. Excluding the generalized zero-eigenspace remains issue #3593.

## Verification

- `lake env lean TNLean/MPS/MPDO/SectorPairingTransfer.lean`
- `lake build`
- `cd blueprint && leanblueprint checkdecls && leanblueprint pdf`
- visual inspection of the affected trace-matrix pages
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --diff-base origin/main --ci`
- `chktex` on the blueprint sources
- `git diff --check`
- independent review of the rectangular algebra, scalar placement, and source claim
- no `sorry`, `axiom`, kernel bypass, or stronger rank-one/idempotence hypothesis

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization and documentation in MPDO/Perron–Frobenius algebra; no auth, runtime, or API surface changes, and theorems explicitly avoid stronger rank-one claims.
> 
> **Overview**
> Connects the **inverse-map closed-sector tensors** to Cirac et al. Appendix C.2 trace-matrix algebra: defines **`closedSectorTraceMatrix`** with entries \(T_{k,h}=(r_k\mid l_h)\), proves **`closedSectorTraceMatrix_apply`** (\(T_{k,h}=\mathrm{tr}(\eta_{k,h})\)), and from source ZCL derives **`closedSectorTraceMatrix_normalized_pow_two_eq_pow_three`** (\(\widehat T^2=\widehat T^3\) for \(\widehat T=\lambda^{-1}T\), \(\lambda>0\)) via rectangular factors \(S=LQ\), \(T=QL\) and normalized idempotence of \(\lambda^{-1}LQ\).
> 
> Adds reusable **`Matrix.pow_two_eq_pow_three_of_rectangular_idempotent`** in `RankOne.lean` (idempotent \(LQ\) implies \((QL)^2=(QL)^3\)) and wires it through a new import on `SectorPairingTransfer`.
> 
> Blueprint gains matching definitions/theorems; **`cpgsv17_pf_rank_one.tex`** records that this square–cube relation is the scale-invariant consequence currently justified—**not** idempotence or rank one—and that linear independence / generalized zero-eigenspace exclusion remains open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b342ffc6a9da7fe74e0ba22ca5fe295a5bcf6d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->