### PR TITLE
feat(Algebra): prove rectangular amplified commutant

### DIFF
--- a/TNLean/Algebra/ScalarCommutant.lean
+++ b/TNLean/Algebra/ScalarCommutant.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.Data.Matrix.Basis
 import Mathlib.Data.Matrix.Block
+import Mathlib.LinearAlgebra.Matrix.Kronecker
 
 /-!
 # Scalar commutant lemma: center of M_n(R) = R·1
@@ -16,9 +17,11 @@ of the full matrix algebra over a commutative ring is trivial.
 
 * `Matrix.isScalar_of_commute_span_eq_top`: if `Z` commutes with a spanning set,
   then `Z = scalar n c` for some `c`.
+* `Matrix.exists_eq_kronecker_one_of_intertwines_span_eq_top`: an intertwiner
+  between two multiplicity amplifications has the form `F ⊗ 1`.
 -/
 
-open scoped Matrix
+open scoped Matrix Kronecker
 
 namespace Matrix
 
@@ -52,6 +55,44 @@ theorem isScalar_of_commute_span_eq_top
   rw [center_eq_scalar_image] at hcenter
   obtain ⟨c, _, rfl⟩ := hcenter
   exact ⟨c, rfl⟩
+
+/-- An intertwiner between two multiplicity amplifications of a spanning
+family of square matrices acts trivially on the matrix factor.
+
+Thus, if the matrices `A i` span the full matrix algebra and `C` intertwines
+`1 ⊗ A i` on two possibly different multiplicity spaces, then
+`C = F ⊗ 1` for a rectangular multiplicity matrix `F`.
+
+This is the amplified commutant step used in arXiv:1511.08090,
+Section ``Fusion tensors'', in the uniqueness paragraph preceding equation
+`zippercondition2`, and Section ``Associativity and the pentagon equation'',
+in the injectivity argument following equation `pentagon3`. -/
+theorem exists_eq_kronecker_one_of_intertwines_span_eq_top
+    {m₁ m₂ d ι : Type*}
+    [Fintype m₁] [Fintype m₂] [Fintype d]
+    [DecidableEq m₁] [DecidableEq m₂] [DecidableEq d]
+    (A : ι → Matrix d d R)
+    (C : Matrix (m₁ × d) (m₂ × d) R)
+    (hA : Submodule.span R (Set.range A) = ⊤)
+    (hC : ∀ i,
+      ((1 : Matrix m₁ m₁ R) ⊗ₖ A i) * C =
+        C * ((1 : Matrix m₂ m₂ R) ⊗ₖ A i)) :
+    ∃ F : Matrix m₁ m₂ R, C = F ⊗ₖ (1 : Matrix d d R) := by
+  classical
+  let Z : m₁ → m₂ → Matrix d d R := fun a b x y => C (a, x) (b, y)
+  have hZ (a : m₁) (b : m₂) (i : ι) : Z a b * A i = A i * Z a b := by
+    ext x y
+    have h := congrFun (congrFun (hC i) (a, x)) (b, y)
+    simpa [Z, Matrix.mul_apply, Matrix.one_apply, Fintype.sum_prod_type] using h.symm
+  have hscalar (a : m₁) (b : m₂) : ∃ c : R, Z a b = Matrix.scalar d c := by
+    apply Matrix.isScalar_of_commute_span_eq_top (Z a b) hA
+    rintro M ⟨i, rfl⟩
+    exact hZ a b i
+  let F : Matrix m₁ m₂ R := fun a b => Classical.choose (hscalar a b)
+  refine ⟨F, ?_⟩
+  ext ⟨a, x⟩ ⟨b, y⟩
+  have h := congrFun (congrFun (Classical.choose_spec (hscalar a b)) x) y
+  simpa [Z, F, Matrix.scalar_apply, Matrix.diagonal_apply, Matrix.one_apply] using h
 
 /-! ## Block-diagonal commutants -/
 

--- a/TNLean/Algebra/ScalarCommutant.lean
+++ b/TNLean/Algebra/ScalarCommutant.lean
@@ -67,7 +67,7 @@ This is the amplified commutant step used in arXiv:1511.08090,
 Section ``Fusion tensors'', in the uniqueness paragraph preceding equation
 `zippercondition2`, and Section ``Associativity and the pentagon equation'',
 in the injectivity argument following equation `pentagon3`. -/
-theorem exists_eq_kronecker_one_of_intertwines_span_eq_top
+lemma exists_eq_kronecker_one_of_intertwines_span_eq_top
     {m₁ m₂ d ι : Type*}
     [Fintype m₁] [Fintype m₂] [Fintype d]
     [DecidableEq m₁] [DecidableEq m₂] [DecidableEq d]

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -89,6 +89,37 @@ boundary conditions (PBC).
     vanish and all diagonal entries are equal.
 \end{proof}
 
+\begin{lemma}[Rectangular amplified commutant]
+    \label{lem:amplified_center_scalar}
+    \lean{Matrix.exists_eq_kronecker_one_of_intertwines_span_eq_top}
+    \leanok
+    \uses{lem:center_scalar}
+    Let $(A_i)_{i\in I}$ span $\MN{D}$, and let
+
+    \[
+        C:\C^{m_2}\otimes\C^D\longrightarrow
+          \C^{m_1}\otimes\C^D
+    \]
+
+    satisfy
+    \[
+        (\Id_{m_1}\otimes A_i)C
+          =C(\Id_{m_2}\otimes A_i)
+        \qquad (i\in I).
+    \]
+    Then there is a matrix $F:\C^{m_2}\to\C^{m_1}$ such that
+    \[
+        C=F\otimes\Id_D.
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    Each $(a,b)$ multiplicity block of $C$ commutes with every $A_i$.
+    Since the $A_i$ span the full matrix algebra,
+    Lemma~\ref{lem:center_scalar} makes this block a scalar multiple of the
+    identity.  These scalars are the entries of $F$.
+\end{proof}
+
 \begin{definition}[Matrix product vector]\label{def:mpv}
     \lean{MPSTensor.mpv}
     \leanok


### PR DESCRIPTION
## Mathematical purpose

The fusion-tensor uniqueness argument requires the following finite-dimensional algebraic step: an intertwiner between two multiplicity amplifications of a family spanning the full matrix algebra acts as the identity on the matrix factor.

This pull request proves that rectangular amplified-commutant lemma over a commutative semiring and records it in the blueprint. It is the generic algebraic input for the fixed-final-sector analysis in the MPO associativity argument.

The result does **not** assert the existence or invertibility of an MPO F-move. Those require the source zipper identities, the positive multiplicity weights, and the injective blocked sector, and remain separate steps.

Advances #3776.

## Verification

- `lake env lean TNLean/Algebra/ScalarCommutant.lean`
- `lake exe lint_style TNLean/Algebra/ScalarCommutant.lean`
- `lake build`
- `cd blueprint && leanblueprint checkdecls`
- `cd blueprint && leanblueprint pdf`
- visual inspection of the rendered blueprint page
- proof-integrity scan of the changed Lean file

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Self-contained commutative-semiring algebra extending an existing file; no runtime, auth, or data-path changes—main risk is Mathlib/Kronecker proof correctness, already covered by the PR’s Lean build checks.
> 
> **Overview**
> Adds **`Matrix.exists_eq_kronecker_one_of_intertwines_span_eq_top`**: if a family `(A_i)` spans `M_d(R)` and a map `C` on amplified spaces satisfies `(1 ⊗ A_i) C = C (1 ⊗ A_i)` for all `i`, then **`C = F ⊗ 1`** for some rectangular multiplicity matrix `F`. The proof slices `C` into `(a,b)` blocks, shows each block commutes with every `A_i` via the intertwining identities, and applies the existing scalar-commutant theorem **`isScalar_of_commute_span_eq_top`**.
> 
> Lean changes also pull in **Kronecker** matrix support and document the lemma as the amplified-commutant step for fusion-tensor / pentagon arguments. The **MPS blueprint** (`ch02_mps`) records the same statement as Lemma “Rectangular amplified commutant” with `\leanok` wiring to the new declaration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92aba776b81bd8b775fea7b5e82c298130020aaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->