### PR TITLE
feat(MPS/MPDO): establish fixed-sector adjacent bond commutator

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -411,6 +411,7 @@ import TNLean.MPS.MPDO.PhysicalSectorPhysicalMaps
 import TNLean.MPS.MPDO.PhysicalSectorBlockedRFP
 import TNLean.MPS.MPDO.PhysicalSectorCoordinateTransport
 import TNLean.MPS.MPDO.PhysicalSectorPositiveBond
+import TNLean.MPS.MPDO.PhysicalSectorBondCommutativity
 import TNLean.MPS.MPDO.PhysicalSectorPhysicalTransport
 import TNLean.MPS.MPDO.SectorPairingTransfer
 import TNLean.MPS.MPDO.SectorEtaContraction

--- a/TNLean/MPS/MPDO/PhysicalSectorBondCommutativity.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorBondCommutativity.lean
@@ -1,0 +1,162 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalSectorPositiveBond
+import TNLean.MPS.MPDO.CommutingForm
+
+/-!
+# Commutativity of adjacent physical-sector bonds
+
+This file proves the fixed-sector Kronecker-product calculation underlying
+commutativity of two adjacent physical-sector bonds.  For sectors `k, l, h`,
+the first bond acts on the neighboring factor $R_k \otimes L_l$, while the
+second acts on $R_l \otimes L_h$.  It also identifies the two translated
+bonds on three sites with the corresponding left and right tensor-product
+lifts.  Their simultaneous transport through the sector decomposition is a
+subsequent step.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, Proposition C.8, lines 1589--1593
+-/
+
+open scoped Matrix Kronecker
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D}
+
+/-- Lift a two-site matrix to the first two factors of a right-associated
+three-site tensor product.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`), lines
+1589--1593. -/
+noncomputable def leftPairMatrix {n : Type*} [Fintype n] [DecidableEq n]
+    (B : Matrix (n × n) (n × n) ℂ) :
+    Matrix (n × (n × n)) (n × (n × n)) ℂ :=
+  Matrix.reindex (Equiv.prodAssoc n n n) (Equiv.prodAssoc n n n)
+    (B ⊗ₖ (1 : Matrix n n ℂ))
+
+/-- Lift a two-site matrix to the last two factors of a right-associated
+three-site tensor product.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`), lines
+1589--1593. -/
+noncomputable def rightPairMatrix {n : Type*} [Fintype n] [DecidableEq n]
+    (B : Matrix (n × n) (n × n) ℂ) :
+    Matrix (n × (n × n)) (n × (n × n)) ℂ :=
+  (1 : Matrix n n ℂ) ⊗ₖ B
+
+/-- On a three-site chain, embedding a two-site operator at the first site is
+its left tensor-product lift after identifying configurations with triples.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`), lines
+1589--1593. -/
+theorem reindex_embedLocalOperator_zero (F : PhysicalSectorFactorization K) :
+    Matrix.reindex (finThreeArrowEquiv (Fin d)) (finThreeArrowEquiv (Fin d))
+        (embedLocalOperator (d := d) 2 3 (by decide) (0 : Fin 3) F.physicalBond) =
+      leftPairMatrix F.physicalPairBond := by
+  ext σ τ
+  have hAgree :
+      AgreesOutsideWindow (d := d) 2 (by decide) (0 : Fin 3)
+          ((finThreeArrowEquiv (Fin d)).symm σ)
+          ((finThreeArrowEquiv (Fin d)).symm τ) ↔
+        τ.2.2 = σ.2.2 := by
+    constructor
+    · intro ha
+      have h := congrFun ha (2 : Fin 3)
+      simpa [AgreesOutsideWindow, finThreeArrowEquiv,
+        MPSTensor.replaceWindow, MPSTensor.extractWindow] using h
+    · intro ha
+      funext i
+      fin_cases i <;>
+        simp [finThreeArrowEquiv,
+          MPSTensor.replaceWindow, MPSTensor.extractWindow, ha]
+  by_cases h : τ.2.2 = σ.2.2
+  · have ha := hAgree.mpr h
+    simp [Matrix.reindex_apply, embedLocalOperator_apply, ha, leftPairMatrix,
+      physicalBond, MPSTensor.extractWindow, h]
+    simp [finThreeArrowEquiv]
+  · have ha : ¬ AgreesOutsideWindow (d := d) 2 (by decide) (0 : Fin 3)
+        ((finThreeArrowEquiv (Fin d)).symm σ)
+        ((finThreeArrowEquiv (Fin d)).symm τ) := fun ha ↦ h (hAgree.mp ha)
+    simp only [Fin.isValue, Matrix.reindex_apply, Matrix.submatrix_apply,
+      embedLocalOperator_apply]
+    rw [if_neg ha]
+    simp only [leftPairMatrix, Matrix.reindex_apply, Matrix.submatrix_apply,
+      Matrix.kroneckerMap_apply]
+    change 0 = F.physicalPairBond (σ.1, σ.2.1) (τ.1, τ.2.1) *
+      (if σ.2.2 = τ.2.2 then 1 else 0)
+    rw [if_neg (fun hs ↦ h hs.symm), mul_zero]
+
+/-- On a three-site chain, embedding a two-site operator at the second site is
+its right tensor-product lift after identifying configurations with triples.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`), lines
+1589--1593. -/
+theorem reindex_embedLocalOperator_one (F : PhysicalSectorFactorization K) :
+    Matrix.reindex (finThreeArrowEquiv (Fin d)) (finThreeArrowEquiv (Fin d))
+        (embedLocalOperator (d := d) 2 3 (by decide) (1 : Fin 3) F.physicalBond) =
+      rightPairMatrix F.physicalPairBond := by
+  ext σ τ
+  have hAgree :
+      AgreesOutsideWindow (d := d) 2 (by decide) (1 : Fin 3)
+          ((finThreeArrowEquiv (Fin d)).symm σ)
+          ((finThreeArrowEquiv (Fin d)).symm τ) ↔
+        τ.1 = σ.1 := by
+    constructor
+    · intro ha
+      have h := congrFun ha (0 : Fin 3)
+      simpa [finThreeArrowEquiv, MPSTensor.replaceWindow,
+        MPSTensor.extractWindow] using h
+    · intro ha
+      funext i
+      fin_cases i <;>
+        simp [finThreeArrowEquiv, MPSTensor.replaceWindow,
+          MPSTensor.extractWindow, ha]
+  by_cases h : τ.1 = σ.1
+  · have ha := hAgree.mpr h
+    simp only [Fin.isValue, Matrix.reindex_apply, Matrix.submatrix_apply,
+      embedLocalOperator_apply]
+    rw [if_pos ha]
+    change F.physicalPairBond σ.2 τ.2 =
+      (if σ.1 = τ.1 then 1 else 0) * F.physicalPairBond σ.2 τ.2
+    rw [if_pos h.symm, one_mul]
+  · have ha : ¬ AgreesOutsideWindow (d := d) 2 (by decide) (1 : Fin 3)
+        ((finThreeArrowEquiv (Fin d)).symm σ)
+        ((finThreeArrowEquiv (Fin d)).symm τ) := fun ha ↦ h (hAgree.mp ha)
+    simp only [Fin.isValue, Matrix.reindex_apply, Matrix.submatrix_apply,
+      embedLocalOperator_apply]
+    rw [if_neg ha]
+    simp only [rightPairMatrix, Matrix.kroneckerMap_apply]
+    change 0 = (if σ.1 = τ.1 then 1 else 0) * F.physicalPairBond σ.2 τ.2
+    rw [if_neg (fun hs ↦ h hs.symm), zero_mul]
+
+/-- On fixed physical sectors `(k, l, h)`, the two adjacent bonds commute.
+The first neighboring operator acts on $R_k \otimes L_l$ and the second on
+$R_l \otimes L_h$; all other tensor factors carry the identity.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`), lines
+1589--1593. -/
+theorem adjacentSectorBonds_comm (F : PhysicalSectorFactorization K)
+    (k l h : Fin F.sectorCount) :
+    ((1 : Matrix (BoundaryIndex F k h) (BoundaryIndex F k h) ℂ) ⊗ₖ
+        (F.neighboringOperator k l ⊗ₖ
+          (1 : Matrix (NeighborIndex F l h) (NeighborIndex F l h) ℂ))) *
+      ((1 : Matrix (BoundaryIndex F k h) (BoundaryIndex F k h) ℂ) ⊗ₖ
+        ((1 : Matrix (NeighborIndex F k l) (NeighborIndex F k l) ℂ) ⊗ₖ
+          F.neighboringOperator l h)) =
+    ((1 : Matrix (BoundaryIndex F k h) (BoundaryIndex F k h) ℂ) ⊗ₖ
+        ((1 : Matrix (NeighborIndex F k l) (NeighborIndex F k l) ℂ) ⊗ₖ
+          F.neighboringOperator l h)) *
+      ((1 : Matrix (BoundaryIndex F k h) (BoundaryIndex F k h) ℂ) ⊗ₖ
+        (F.neighboringOperator k l ⊗ₖ
+          (1 : Matrix (NeighborIndex F l h) (NeighborIndex F l h) ℂ))) := by
+  rw [← Matrix.mul_kronecker_mul, ← Matrix.mul_kronecker_mul,
+    ← Matrix.mul_kronecker_mul, ← Matrix.mul_kronecker_mul]
+  simp
+
+end MPOTensor.PhysicalSectorFactorization

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -254,6 +254,12 @@
     (\ref{eq:mpdo_eta_bond_assembly}) and~(\ref{eq:mpdo_eta_product_form}) are
     exactly the $\eta$-local product hypothesis; after that,
     Theorem~\ref{thm:mpdo_has_commuting_form_of_eta_local_structure}
-    gives the commuting-form conclusion. The doubled-index transfer condition
-    enters only in the subsequent RFP and GSNNCH branch conclusions.
+    gives the commuting-form conclusion. The fixed-sector commutator in
+    Theorem~\ref{thm:mpdo_fixed_sector_adjacent_bonds_comm} is complete, but
+    its simultaneous transport through the three-site direct-sum coordinates
+    has not yet been proved. Consequently, commutativity of the physical
+    translates, pairwise commutativity on every periodic chain, and the
+    all-length product identity in~(\ref{eq:mpdo_eta_product_form}) remain open.
+    The doubled-index transfer condition enters only in the subsequent RFP and
+    GSNNCH branch conclusions.
 \end{remark}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -1220,6 +1220,78 @@ strong subadditivity for a normalized three-site reduced state.
     two-site configurations preserves positivity.
 \end{proof}
 
+\begin{definition}[Three-site lifts of a two-site operator]
+    \label{def:mpdo_three_site_pair_lifts}
+    \lean{MPOTensor.PhysicalSectorFactorization.leftPairMatrix,
+      MPOTensor.PhysicalSectorFactorization.rightPairMatrix}
+    \leanok
+    Let $B$ be an operator on two copies of a finite-dimensional space $H$.
+    On the right-associated space $H\otimes(H\otimes H)$, define
+    \[
+      B_{01}=\alpha(B\otimes I_H)\alpha^{-1},
+      \qquad
+      B_{12}=I_H\otimes B,
+    \]
+    where $\alpha:(H\otimes H)\otimes H\to H\otimes(H\otimes H)$ is the
+    canonical associator.
+\end{definition}
+
+\begin{theorem}[Three-site translation identities]
+    \label{thm:mpdo_three_site_pair_lifts}
+    \lean{MPOTensor.PhysicalSectorFactorization.reindex_embedLocalOperator_zero,
+      MPOTensor.PhysicalSectorFactorization.reindex_embedLocalOperator_one}
+    \leanok
+    \uses{def:mpdo_physical_two_site_bond,
+      def:mpdo_three_site_pair_lifts}
+    Under the canonical identification of three-site configurations with
+    $H\otimes(H\otimes H)$, the translates of the physical bond beginning at
+    sites $0$ and $1$ are respectively
+    \[
+      (B_{\mathrm{physical}})_{01}=B_{01},
+      \qquad
+      (B_{\mathrm{physical}})_{12}=B_{12}.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    An entry of the first translate vanishes unless the third indices agree;
+    its remaining entry is that of $B_{\mathrm{physical}}$. Similarly, an
+    entry of the second translate vanishes unless the first indices agree.
+    These are precisely the matrix entries of $B_{01}$ and $B_{12}$.
+\end{proof}
+
+\begin{theorem}[Commutativity on a fixed sector triple]
+    \label{thm:mpdo_fixed_sector_adjacent_bonds_comm}
+    \lean{MPOTensor.PhysicalSectorFactorization.adjacentSectorBonds_comm}
+    \leanok
+    \uses{def:mpdo_minimal_neighboring_operator}
+    Fix sectors $(k,l,h)$. On the regrouped sector space, set
+    \begin{align*}
+      C_{01}^{k,l,h}
+        &=I_{B_k^L\otimes B_h^R}\otimes
+          \left(\eta_{k,l}\otimes I_{B_l^R\otimes B_h^L}\right),\\
+      C_{12}^{k,l,h}
+        &=I_{B_k^L\otimes B_h^R}\otimes
+          \left(I_{B_k^R\otimes B_l^L}\otimes\eta_{l,h}\right).
+    \end{align*}
+    Then
+    \[
+      C_{01}^{k,l,h}C_{12}^{k,l,h}
+        =C_{12}^{k,l,h}C_{01}^{k,l,h}.
+    \]
+    This is the fixed-sector calculation in
+    \cite[Appendix~C.2, Proposition~C.8, lines~1589--1593]
+      {Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The operators $\eta_{k,l}$ and $\eta_{l,h}$ act on the distinct factors
+    $B_k^R\otimes B_l^L$ and $B_l^R\otimes B_h^L$, respectively. The claim
+    follows from the mixed-product identity for tensor products.
+\end{proof}
+
 \begin{definition}[Closed sector tensors]%
     \label{def:mpdo_closed_sector_tensors}
     \lean{MPOTensor.closedSectorL}


### PR DESCRIPTION
## Summary

This change isolates the fixed-sector calculation underlying commutativity of neighboring bonds in Proposition C.8 of arXiv:1606.00608.

It adds:

- the left and right three-site tensor-product lifts of a two-site matrix;
- exact reindexing formulas identifying the translated physical bond at sites `0` and `1` with those lifts;
- the fixed-sector identity showing that `I ⊗ (η_{k,l} ⊗ I)` commutes with `I ⊗ (I ⊗ η_{l,h})`;
- corresponding blueprint statements and an updated status remark.

The result uses no positivity, saturation, zero-correlation-length, injectivity, or trace-factorization hypothesis. It is the algebraic calculation at Appendix C.2, Proposition C.8 (`3to4`), lines 1589–1593.

The simultaneous transport through the dependent three-site sector decomposition is not claimed here and remains #3796. Accordingly, the physical three-site commutator, arbitrary-chain pairwise commutativity, and the all-length product identity remain open.

Closes #3794.

## Verification

- `lake env lean TNLean/MPS/MPDO/PhysicalSectorBondCommutativity.lean`
- `lake env lean TNLean.lean`
- `lake build`
- `lake exe lint_style TNLean/MPS/MPDO/PhysicalSectorBondCommutativity.lean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `cd blueprint && leanblueprint checkdecls`
- `cd blueprint && leanblueprint pdf`
- visual inspection of the rendered blueprint pages
- proof-integrity scan for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast`
- independent review of source faithfulness, matrix orientation, imports, and `#print axioms`