### PR TITLE
feat(MPS/MPDO): specialize fixed-final intertwiners

### DIFF
--- a/TNLean/MPS/MPDO/BNTFinalSectorFusion.lean
+++ b/TNLean/MPS/MPDO/BNTFinalSectorFusion.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.BNTLeftTripleFusion
 import TNLean.MPS.MPDO.BNTRightTripleFusion
+import TNLean.Algebra.ScalarCommutant
 
 /-!
 # Final-sector restrictions of triple fusion
@@ -19,6 +20,12 @@ the $F$-move of arXiv:1511.08090, after reindexing the triple bond space by the 
 associator.  No identification of the positive diagonal chi indices with the fusion
 multiplicities of that source is asserted here.  Such a comparison first requires the
 length-independent integer specialization and injectivity of `tensor ε`.
+
+The final result below isolates the part of the comparison that follows from injectivity.  If a
+matrix between the two fixed-final-sector spaces already intertwines the amplified letters of
+`tensor ε`, then it acts trivially on the bond factor, up to a matrix between the two
+multiplicity spaces.  The result does not construct this intertwiner, prove that it is
+invertible, or identify the chi dimensions with fusion multiplicities.
 
 ## References
 
@@ -70,6 +77,38 @@ Source: arXiv:1606.00608, Theorem IV.13(iii), lines 986--999. -/
 abbrev RightFinalIndex (α β γ ε : Λ) : Type u :=
   (δ : Λ) × Fin (Fam.chi.dim β γ δ) × Fin (Fam.chi.dim α δ ε) ×
     Fin (Fam.bondDim ε)
+
+/-- The canonical identification of the left fixed-final-sector index with the product of its
+multiplicity space and the bond space of `tensor ε`.
+
+Source: arXiv:1606.00608, Theorem IV.13(iii), label `Ualphabeta`, and the associativity remark
+immediately following it; arXiv:1511.08090, equation (Fmove), left multiplicity indices
+`(e, μ, ν)`. -/
+def leftFinalIndexEquiv (α β γ ε : Λ) :
+    Fam.LeftFinalIndex α β γ ε ≃
+      Fam.LeftFinalMultiplicity α β γ ε × Fin (Fam.bondDim ε) :=
+  (Equiv.sigmaCongrRight fun δ =>
+    (Equiv.prodAssoc (Fin (Fam.chi.dim α β δ)) (Fin (Fam.chi.dim δ γ ε))
+      (Fin (Fam.bondDim ε))).symm).trans
+    (Equiv.sigmaProdDistrib
+      (fun δ => Fin (Fam.chi.dim α β δ) × Fin (Fam.chi.dim δ γ ε))
+      (Fin (Fam.bondDim ε))).symm
+
+/-- The canonical identification of the right fixed-final-sector index with the product of its
+multiplicity space and the bond space of `tensor ε`.
+
+Source: arXiv:1606.00608, Theorem IV.13(iii), label `Ualphabeta`, and the associativity remark
+immediately following it; arXiv:1511.08090, equation (Fmove), right multiplicity indices
+`(f, λ, σ)`. -/
+def rightFinalIndexEquiv (α β γ ε : Λ) :
+    Fam.RightFinalIndex α β γ ε ≃
+      Fam.RightFinalMultiplicity α β γ ε × Fin (Fam.bondDim ε) :=
+  (Equiv.sigmaCongrRight fun δ =>
+    (Equiv.prodAssoc (Fin (Fam.chi.dim β γ δ)) (Fin (Fam.chi.dim α δ ε))
+      (Fin (Fam.bondDim ε))).symm).trans
+    (Equiv.sigmaProdDistrib
+      (fun δ => Fin (Fam.chi.dim β γ δ) × Fin (Fam.chi.dim α δ ε))
+      (Fin (Fam.bondDim ε))).symm
 
 /-- The row inclusion selecting the block with final label `ε` in the left-associated
 decomposition.
@@ -189,5 +228,49 @@ theorem rightFinalFusion_apply (α β γ ε : Λ) (i k : Fin p) :
   · subst δ'
     simp
   · simp [Matrix.blockDiagonal'_apply_ne _ _ _ hδ]
+
+/-- An intertwiner between the two fixed-final-sector spaces of an injective final tensor is a
+matrix on the multiplicity spaces tensored with the identity on the final bond space.
+
+The matrix `C` is only assumed here.  After the two canonical reindexings, the hypothesis says
+that `C` intertwines the two identity amplifications of every letter of `tensor ε`.  Injectivity
+then forces every rectangular bond-space block of `C` to be scalar.  Thus the bond-space action
+is the identity and all remaining information lies in the rectangular matrix `F` between the
+left and right multiplicity spaces.
+
+This is the injective-sector uniqueness step in the derivation of an $F$-move.  It does not
+construct `C`, prove that either `C` or `F` is invertible, or identify the dimensions of the
+positive diagonal chi matrices with the fusion multiplicities of arXiv:1511.08090.
+
+Source: arXiv:1606.00608, Theorem IV.13(iii), label `Ualphabeta`, and the associativity remark
+immediately following it; arXiv:1511.08090, Section "Fusion tensors", uniqueness paragraph
+preceding equation (zippercondition2), and Section "Associativity and the pentagon equation",
+the injectivity argument following equation (pentagon3). -/
+theorem exists_reindexed_intertwiner_eq_kronecker_one_of_isInjective
+    (α β γ ε : Λ)
+    (hε : MPSTensor.IsInjective (Fam.tensor ε).toMPSTensor)
+    (C : Matrix (Fam.LeftFinalIndex α β γ ε)
+      (Fam.RightFinalIndex α β γ ε) ℂ)
+    (hC : ∀ ij : Fin (p * p),
+      ((1 : Matrix (Fam.LeftFinalMultiplicity α β γ ε)
+          (Fam.LeftFinalMultiplicity α β γ ε) ℂ) ⊗ₖ
+          (Fam.tensor ε).toMPSTensor ij) *
+          C.submatrix (Fam.leftFinalIndexEquiv α β γ ε).symm
+            (Fam.rightFinalIndexEquiv α β γ ε).symm =
+        C.submatrix (Fam.leftFinalIndexEquiv α β γ ε).symm
+            (Fam.rightFinalIndexEquiv α β γ ε).symm *
+          ((1 : Matrix (Fam.RightFinalMultiplicity α β γ ε)
+            (Fam.RightFinalMultiplicity α β γ ε) ℂ) ⊗ₖ
+            (Fam.tensor ε).toMPSTensor ij)) :
+    ∃ F : Matrix (Fam.LeftFinalMultiplicity α β γ ε)
+        (Fam.RightFinalMultiplicity α β γ ε) ℂ,
+      C.submatrix (Fam.leftFinalIndexEquiv α β γ ε).symm
+          (Fam.rightFinalIndexEquiv α β γ ε).symm =
+        F ⊗ₖ (1 : Matrix (Fin (Fam.bondDim ε)) (Fin (Fam.bondDim ε)) ℂ) := by
+  exact Matrix.exists_eq_kronecker_one_of_intertwines_span_eq_top
+    (Fam.tensor ε).toMPSTensor
+    (C.submatrix (Fam.leftFinalIndexEquiv α β γ ε).symm
+      (Fam.rightFinalIndexEquiv α β γ ε).symm)
+    hε.span_eq_top hC
 
 end MPOTensor.BNTFusionIsometryFamily

--- a/TNLean/MPS/MPDO/BNTFinalSectorFusion.lean
+++ b/TNLean/MPS/MPDO/BNTFinalSectorFusion.lean
@@ -81,7 +81,7 @@ abbrev RightFinalIndex (α β γ ε : Λ) : Type u :=
 /-- The canonical identification of the left fixed-final-sector index with the product of its
 multiplicity space and the bond space of `tensor ε`.
 
-Source: arXiv:1606.00608, Theorem IV.13(iii), label `Ualphabeta`, and the associativity remark
+Source: arXiv:1606.00608, Theorem 4.14(iii), label `Ualphabeta`, and the associativity remark
 immediately following it; arXiv:1511.08090, equation (Fmove), left multiplicity indices
 `(e, μ, ν)`. -/
 def leftFinalIndexEquiv (α β γ ε : Λ) :
@@ -97,7 +97,7 @@ def leftFinalIndexEquiv (α β γ ε : Λ) :
 /-- The canonical identification of the right fixed-final-sector index with the product of its
 multiplicity space and the bond space of `tensor ε`.
 
-Source: arXiv:1606.00608, Theorem IV.13(iii), label `Ualphabeta`, and the associativity remark
+Source: arXiv:1606.00608, Theorem 4.14(iii), label `Ualphabeta`, and the associativity remark
 immediately following it; arXiv:1511.08090, equation (Fmove), right multiplicity indices
 `(f, λ, σ)`. -/
 def rightFinalIndexEquiv (α β γ ε : Λ) :
@@ -242,7 +242,7 @@ This is the injective-sector uniqueness step in the derivation of an $F$-move.  
 construct `C`, prove that either `C` or `F` is invertible, or identify the dimensions of the
 positive diagonal chi matrices with the fusion multiplicities of arXiv:1511.08090.
 
-Source: arXiv:1606.00608, Theorem IV.13(iii), label `Ualphabeta`, and the associativity remark
+Source: arXiv:1606.00608, Theorem 4.14(iii), label `Ualphabeta`, and the associativity remark
 immediately following it; arXiv:1511.08090, Section "Fusion tensors", uniqueness paragraph
 preceding equation (zippercondition2), and Section "Associativity and the pentagon equation",
 the injectivity argument following equation (pentagon3). -/

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -423,6 +423,8 @@ the change of basis between the two resulting direct sums.
     \label{def:mpdo_final_sector_multiplicity_spaces}
     \lean{MPOTensor.BNTFusionIsometryFamily.LeftFinalMultiplicity}
     \lean{MPOTensor.BNTFusionIsometryFamily.RightFinalMultiplicity}
+    \lean{MPOTensor.BNTFusionIsometryFamily.leftFinalIndexEquiv}
+    \lean{MPOTensor.BNTFusionIsometryFamily.rightFinalIndexEquiv}
     \leanok
     \uses{def:mpdo_bnt_fusion_isometry_family}
     Fix a final label $\varepsilon$.  The multiplicity spaces of the two
@@ -511,4 +513,40 @@ the change of basis between the two resulting direct sums.
     Restrict Theorem~\ref{thm:mpdo_right_fusion_apply} to the rows and columns
     whose final label is $\varepsilon$.  The outer block-diagonal matrix then
     retains precisely the displayed $\varepsilon$-blocks.
+\end{proof}
+
+\begin{theorem}[Injective fixed-final intertwiners]%
+    \label{thm:mpdo_injective_fixed_final_intertwiner}
+    \lean{MPOTensor.BNTFusionIsometryFamily.%
+        exists_reindexed_intertwiner_eq_kronecker_one_of_isInjective}
+    \leanok
+    \uses{def:mpdo_final_sector_multiplicity_spaces, def:injective}
+    Suppose that $M_\varepsilon$ is injective.  Let $C$ be a matrix from the
+    right fixed-final-sector space to the left fixed-final-sector space.  Under
+    the canonical identifications with
+    $\mathcal H^{\mathrm L}_{\varepsilon}\otimes\C^{D_\varepsilon}$ and
+    $\mathcal H^{\mathrm R}_{\varepsilon}\otimes\C^{D_\varepsilon}$, assume
+    that, for every pair of physical indices $i,j$,
+    \[
+        (1_{\mathcal H^{\mathrm L}_{\varepsilon}}\otimes M_\varepsilon^{ij})C
+        =C(1_{\mathcal H^{\mathrm R}_{\varepsilon}}\otimes
+        M_\varepsilon^{ij}).
+    \]
+    Then there is a rectangular matrix
+    $F:\mathcal H^{\mathrm R}_{\varepsilon}\to
+    \mathcal H^{\mathrm L}_{\varepsilon}$ such that
+    \[
+        C=F\otimes 1_{D_\varepsilon}.
+    \]
+    This conclusion is conditional on the supplied matrix $C$.  It does not
+    assert the existence or invertibility of $C$ or $F$, and it does not
+    identify the dimensions of the positive diagonal matrices $\chi$ with the
+    fusion multiplicities in \cite[eq.~(Fmove)]{Bultinck2017Anyons}.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{lem:amplified_center_scalar}
+    Apply Lemma~\ref{lem:amplified_center_scalar} to the family
+    $\{M_\varepsilon^{ij}\}_{i,j}$.  This family spans the full matrix algebra
+    by injectivity, and the assumed relation is precisely the amplified
+    intertwining identity of that lemma.
 \end{proof}


### PR DESCRIPTION
## Mathematical purpose

This pull request applies the rectangular amplified-commutant lemma from #3795 to the two fixed-final-sector index spaces occurring in the left and right triple-fusion bracketings.

It adds the canonical identifications

`LeftFinalIndex ≃ LeftFinalMultiplicity × Fin (bondDim ε)`

and
`RightFinalIndex ≃ RightFinalMultiplicity × Fin (bondDim ε)`,

then proves the following conditional statement: if the final labelled tensor is injective and a supplied comparison matrix `C` intertwines the two identity amplifications of every tensor letter, its reindexed form equals `F ⊗ 1` for a rectangular multiplicity matrix `F`.

The result does **not** construct `C`, prove that `C` or `F` is invertible, or identify the positive χ dimensions with the fusion multiplicities. The zipper/completeness, final-label separation, χ-specialization, F-move existence, and pentagon steps remain open.

Advances #3776.

## Verification

- `lake env lean TNLean/MPS/MPDO/BNTFinalSectorFusion.lean`
- `lake build TNLean.Algebra.ScalarCommutant TNLean.MPS.MPDO.BNTFinalSectorFusion`
- `lake exe lint_style TNLean/MPS/MPDO/BNTFinalSectorFusion.lean`
- full `lake build`
- blueprint synchronization and `cd blueprint && leanblueprint checkdecls`
- reader-facing prose and proof-integrity scans
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal math only in MPS/MPDO final-sector fusion; no runtime, auth, or data paths. Scope is a thin specialization of an existing algebra lemma plus documentation.
> 
> **Overview**
> Adds **canonical equivalences** `leftFinalIndexEquiv` and `rightFinalIndexEquiv` that split each fixed-final-sector index into **multiplicity × bond** (`Fin (bondDim ε)`), and wires in `TNLean.Algebra.ScalarCommutant`.
> 
> Under **injectivity** of `tensor ε`, a **hypothetical** comparison matrix `C` that intertwines the identity-amplified letters of `tensor ε` (after reindexing) is proved to equal **`F ⊗ 1`** on the bond factor for some rectangular multiplicity matrix `F`. The proof is a direct application of `Matrix.exists_eq_kronecker_one_of_intertwines_span_eq_top`; the change **does not** build `C`, prove invertibility, or identify χ dimensions with fusion multiplicities.
> 
> The **blueprint** chapter links the new equivs and states **Theorem (Injective fixed-final intertwiners)** with a proof via the amplified-center lemma.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8ded082efc7c861c5a0bab1a61bf106658db8b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->