### PR TITLE
fix(MPS/MPDO): record rectangular trace obstruction

### DIFF
--- a/TNLean/Algebra/PerronFrobenius/RankOne.lean
+++ b/TNLean/Algebra/PerronFrobenius/RankOne.lean
@@ -62,6 +62,11 @@ of a composition there. Combined with `Matrix.pow_eq_pow_two_of_pow_two_eq_pow_t
 (a purely algebraic fact: `T^2 = T^3` forces `T^N = T^2` for every `N ≥ 2`),
 `Matrix.tracePowersConstant_of_pairing_idempotent` gives the unconditional
 constant trace powers `Matrix.TracePowersConstant T`.
+
+More generally, `Matrix.trace_pow_eq_trace_of_rectangular_idempotent` proves
+the trace-power identity directly for any rectangular factorization `T = QL`
+whose opposite product `LQ` is idempotent. This is the matrix calculation at
+Appendix C.2, lines 1490--1497.
 -/
 
 open scoped BigOperators Matrix ComplexOrder
@@ -327,6 +332,41 @@ theorem pow_two_eq_pow_three_of_rectangular_idempotent
   rw [show (Q * L) ^ 3 = Q * ((L * Q) * (L * Q)) * L by
     simp [pow_succ, Matrix.mul_assoc]]
   rw [h.eq]
+
+/-- If the rectangular product `L * Q` is idempotent, then all positive powers
+of the product in the opposite order have the same trace:
+\[
+  \operatorname{tr}((QL)^N)=\operatorname{tr}(QL), \qquad N\geq 1.
+\]
+This is the valid trace-power conclusion in arXiv:1606.00608,
+Appendix C.2, lines 1490--1497. -/
+theorem trace_pow_eq_trace_of_rectangular_idempotent
+    {a b : Type*} [Fintype a] [Fintype b] [DecidableEq b]
+    {R : Type*} [CommSemiring R] (L : Matrix a b R) (Q : Matrix b a R)
+    (h : IsIdempotentElem (L * Q)) :
+    ∀ N : ℕ, 0 < N → Matrix.trace ((Q * L) ^ N) = Matrix.trace (Q * L) := by
+  classical
+  have htrace2 : Matrix.trace ((Q * L) ^ 2) = Matrix.trace (Q * L) := by
+    calc
+      Matrix.trace ((Q * L) ^ 2) = Matrix.trace ((Q * L * Q) * L) := by
+        simp [pow_two, Matrix.mul_assoc]
+      _ = Matrix.trace (L * (Q * L * Q)) := Matrix.trace_mul_comm _ _
+      _ = Matrix.trace ((L * Q) * (L * Q)) := by simp [Matrix.mul_assoc]
+      _ = Matrix.trace (L * Q) := by rw [h.eq]
+      _ = Matrix.trace (Q * L) := Matrix.trace_mul_comm _ _
+  have hsq3 := pow_two_eq_pow_three_of_rectangular_idempotent L Q h
+  have hpowers : ∀ N : ℕ, 2 ≤ N → (Q * L) ^ N = (Q * L) ^ 2 := by
+    intro N hN
+    induction N, hN using Nat.le_induction with
+    | base => rfl
+    | succ m _ ih =>
+      rw [pow_succ, ih]
+      exact hsq3.symm
+  intro N hN
+  rcases Nat.lt_or_ge N 2 with hN2 | hN2
+  · interval_cases N
+    rw [pow_one]
+  · rw [hpowers N hN2, htrace2]
 
 /-- **Unconditional `T^2 = T^3` from the pairing idempotence.**
 

--- a/TNLean/Archive/PerronFrobeniusRankOneCounterexample.lean
+++ b/TNLean/Archive/PerronFrobeniusRankOneCounterexample.lean
@@ -28,6 +28,8 @@ nonnegative primitive matrix `T` with
   `Mathlib.Matrix.IsPrimitive`;
 * `trace (T ^ k) = trace T = 1` for every `k ≥ 1`;
 * `T` of rank two — no rank-one factorization `T = vecMulVec a b` exists.
+* explicit rectangular factors `pairingL` and `pairingR` such that
+  `T = pairingR * pairingL` and `pairingL * pairingR` is idempotent.
 
 Concretely, `T = P + (1/6) · N` where `P = (1/3) · J` is the Perron projector
 (`J` the `3 × 3` all-ones matrix) and `N = x · yᵀ` with `x = (1, -1, 0)`,
@@ -53,6 +55,8 @@ This file is deliberately excluded from the root `TNLean.lean` import list.
 
 * `counterexample`: the explicit witness to the failure of the stated
   implication.
+* `counterexample_with_rectangular_pairing`: the same witness satisfies the
+  full rectangular pairing identity used at source lines 1490--1497.
 -/
 
 namespace TNLean.Archive.PerronFrobeniusRankOneCounterexample
@@ -66,6 +70,42 @@ noncomputable def T : Matrix (Fin 3) (Fin 3) ℝ :=
 /-- The rank-one Perron projector for `T`, equal to `T ^ k` for every `k ≥ 2`. -/
 noncomputable def P : Matrix (Fin 3) (Fin 3) ℝ :=
   !![1/3, 1/3, 1/3; 1/3, 1/3, 1/3; 1/3, 1/3, 1/3]
+
+/-- The coefficient-side factor in the rectangular pairing realization of
+`T`. Together with `pairingR`, it realizes the operator identity used in
+arXiv:1606.00608, Appendix C.2, lines 1490--1497. -/
+noncomputable def pairingL : Matrix (Fin 2) (Fin 3) ℝ :=
+  !![1/3, 1/3, 1/3; 1/6, 1/6, -1/3]
+
+/-- The functional-side factor in the rectangular pairing realization of
+`T` from arXiv:1606.00608, Appendix C.2, lines 1490--1497. -/
+noncomputable def pairingR : Matrix (Fin 3) (Fin 2) ℝ :=
+  !![1, 1; 1, -1; 1, 0]
+
+/-- The idempotent product in the bond space for the rectangular pairing
+realization of arXiv:1606.00608, Appendix C.2, lines 1490--1493. -/
+noncomputable def pairingIdempotent : Matrix (Fin 2) (Fin 2) ℝ :=
+  !![1, 0; 0, 0]
+
+lemma pairingR_mul_pairingL : pairingR * pairingL = T := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [pairingR, pairingL, T, Matrix.mul_apply, Fin.sum_univ_two] <;> ring
+
+lemma pairingL_mul_pairingR : pairingL * pairingR = pairingIdempotent := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [pairingL, pairingR, pairingIdempotent, Matrix.mul_apply,
+      Fin.sum_univ_three] <;> ring
+
+/-- The product in the opposite order is idempotent, exactly as in the
+operator identity of arXiv:1606.00608, Appendix C.2, lines 1490--1493. -/
+theorem pairingL_mul_pairingR_isIdempotent :
+    IsIdempotentElem (pairingL * pairingR) := by
+  rw [pairingL_mul_pairingR]
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [pairingIdempotent, Matrix.mul_apply, Fin.sum_univ_two]
 
 lemma T_sq : T * T = P := by
   ext i j
@@ -169,5 +209,21 @@ theorem counterexample_with_zcl_operator_consequence :
       T ^ 2 = T ^ 3 ∧
       ¬ ∃ a b : Fin 3 → ℝ, T = Matrix.vecMulVec a b :=
   ⟨T_isPrimitive, trace_T, T_tracePowersConstant, T_sq_eq_cube, T_not_rankOne⟩
+
+/-- The primitive trace-normalized counterexample satisfies the full
+rectangular pairing identity used in arXiv:1606.00608, Appendix C.2, lines
+1490--1497: `T = pairingR * pairingL`, while the product in the opposite order
+is idempotent. Nevertheless `T` is not an outer product. Thus the rectangular
+identity proves the trace-power display at lines 1494--1497, but does not prove
+the rank-one assertion at lines 1498--1499. -/
+theorem counterexample_with_rectangular_pairing :
+    Matrix.IsPrimitive T ∧
+      Matrix.trace T = 1 ∧
+      (∀ k : ℕ, 0 < k → Matrix.trace (T ^ k) = Matrix.trace T) ∧
+      T = pairingR * pairingL ∧
+      IsIdempotentElem (pairingL * pairingR) ∧
+      ¬ ∃ a b : Fin 3 → ℝ, T = Matrix.vecMulVec a b :=
+  ⟨T_isPrimitive, trace_T, T_tracePowersConstant, pairingR_mul_pairingL.symm,
+    pairingL_mul_pairingR_isIdempotent, T_not_rankOne⟩
 
 end TNLean.Archive.PerronFrobeniusRankOneCounterexample

--- a/TNLean/MPS/MPDO/SectorPairingTransfer.lean
+++ b/TNLean/MPS/MPDO/SectorPairingTransfer.lean
@@ -28,6 +28,10 @@ normalization.
   gives quasi-idempotence of the closed-sector pairing operator.
 * `closedSector_operator_normalized_idempotent`: after the source
   normalization, the pairing operator is idempotent.
+* `closedSectorTraceMatrix_normalized_trace_pow_eq_trace`: source zero
+  correlation length gives the positive-power trace identity of Lemma C.5.
+* `closedSectorTraceMatrix_normalized_relations`: the square--cube and
+  trace-power identities hold for one common source normalization.
 * `closedSector_operator_idempotent_of_physTraceTransfer_sq`: for a
   canonically normalized representative, the raw pairing operator is
   idempotent.
@@ -183,24 +187,26 @@ theorem closedSector_operator_normalized_idempotent
   rw [← concrete_physTraceTransfer_eq_sum_closedSector K hK hη R hρ α₁ β₃ hm]
   exact hidem
 
-/-- Source zero correlation length implies that the normalized concrete
-closed-sector trace matrix satisfies
+/-- Source zero correlation length supplies one positive normalization for
+which the normalized concrete closed-sector trace matrix satisfies both
 \[
-  \widehat T^2=\widehat T^3,
-  \qquad \widehat T=\lambda^{-1}T,
-  \qquad \lambda>0.
+  \widehat T^2=\widehat T^3
 \]
-This follows by writing the normalized closed-sector pairing operator as
-`L * Q` and the normalized trace matrix as `Q * L`.  The conclusion does not
-assert that the trace matrix is idempotent or has rank one.
-
-Derived from the zero-correlation-length identity in the proof of
-arXiv:1606.00608, Appendix C.2, Lemma `SALZCL`, lines 1490--1497. -/
-theorem closedSectorTraceMatrix_normalized_pow_two_eq_pow_three
+and, for every positive integer `N`,
+\[
+  \operatorname{tr}(\widehat T^N)=\operatorname{tr}(\widehat T).
+\]
+These are the source-faithful consequences of the rectangular pairing identity
+in arXiv:1606.00608, Appendix C.2, Lemma `SALZCL`, lines 1490--1497. They do
+not assert that the trace matrix is idempotent or has rank one. -/
+theorem closedSectorTraceMatrix_normalized_relations
     (hZCL : IsSourceZCL K) :
     ∃ lam : ℝ, 0 < lam ∧
       let T := closedSectorTraceMatrix K hK hη R α₁ β₃
-      (((lam : ℂ)⁻¹ • T) ^ 2 = ((lam : ℂ)⁻¹ • T) ^ 3) := by
+      (((lam : ℂ)⁻¹ • T) ^ 2 = ((lam : ℂ)⁻¹ • T) ^ 3) ∧
+        ∀ N : ℕ, 0 < N →
+          Matrix.trace (((lam : ℂ)⁻¹ • T) ^ N) =
+            Matrix.trace ((lam : ℂ)⁻¹ • T) := by
   obtain ⟨lam, hlam, hidem⟩ :=
     closedSector_operator_normalized_idempotent K hK hη R hρ α₁ β₃ hm hZCL
   let L : Matrix (Fin D) (Fin hη.m) ℂ :=
@@ -219,9 +225,55 @@ theorem closedSectorTraceMatrix_normalized_pow_two_eq_pow_three
   dsimp only
   have hrect : IsIdempotentElem (((lam : ℂ)⁻¹ • L) * Q) := by
     simpa only [Matrix.smul_mul, ← hS] using hidem
-  have hpow := Matrix.pow_two_eq_pow_three_of_rectangular_idempotent
-    ((lam : ℂ)⁻¹ • L) Q hrect
-  simpa only [Matrix.mul_smul, ← hT] using hpow
+  constructor
+  · have hpow := Matrix.pow_two_eq_pow_three_of_rectangular_idempotent
+      ((lam : ℂ)⁻¹ • L) Q hrect
+    simpa only [Matrix.mul_smul, ← hT] using hpow
+  · have htrace := Matrix.trace_pow_eq_trace_of_rectangular_idempotent
+      ((lam : ℂ)⁻¹ • L) Q hrect
+    simpa only [Matrix.mul_smul, ← hT] using htrace
+
+/-- Source zero correlation length implies that the normalized concrete
+closed-sector trace matrix satisfies
+\[
+  \widehat T^2=\widehat T^3,
+  \qquad \widehat T=\lambda^{-1}T,
+  \qquad \lambda>0.
+\]
+This follows by writing the normalized closed-sector pairing operator as
+`L * Q` and the normalized trace matrix as `Q * L`.  The conclusion does not
+assert that the trace matrix is idempotent or has rank one.
+
+Derived from the zero-correlation-length identity in the proof of
+arXiv:1606.00608, Appendix C.2, Lemma `SALZCL`, lines 1490--1497. -/
+theorem closedSectorTraceMatrix_normalized_pow_two_eq_pow_three
+    (hZCL : IsSourceZCL K) :
+    ∃ lam : ℝ, 0 < lam ∧
+      let T := closedSectorTraceMatrix K hK hη R α₁ β₃
+      (((lam : ℂ)⁻¹ • T) ^ 2 = ((lam : ℂ)⁻¹ • T) ^ 3) := by
+  obtain ⟨lam, hlam, hpow, _⟩ :=
+    closedSectorTraceMatrix_normalized_relations K hK hη R hρ α₁ β₃ hm hZCL
+  exact ⟨lam, hlam, hpow⟩
+
+/-- Source zero correlation length implies the positive-power trace identity
+for the normalized concrete closed-sector trace matrix:
+\[
+  \operatorname{tr}(\widehat T^N)=\operatorname{tr}(\widehat T),
+  \qquad \widehat T=\lambda^{-1}T,\quad N\geq 1.
+\]
+The conclusion is the valid display in arXiv:1606.00608, Appendix C.2,
+Lemma `SALZCL`, lines 1490--1497. It does not assert that the trace matrix is
+idempotent or has rank one. -/
+theorem closedSectorTraceMatrix_normalized_trace_pow_eq_trace
+    (hZCL : IsSourceZCL K) :
+    ∃ lam : ℝ, 0 < lam ∧
+      let T := closedSectorTraceMatrix K hK hη R α₁ β₃
+      ∀ N : ℕ, 0 < N →
+        Matrix.trace (((lam : ℂ)⁻¹ • T) ^ N) =
+          Matrix.trace ((lam : ℂ)⁻¹ • T) := by
+  obtain ⟨lam, hlam, _, htrace⟩ :=
+    closedSectorTraceMatrix_normalized_relations K hK hη R hρ α₁ β₃ hm hZCL
+  exact ⟨lam, hlam, htrace⟩
 
 /-- For a canonically normalized representative whose physical-trace transfer
 is literally idempotent, the raw closed-sector pairing operator satisfies

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -1476,9 +1476,9 @@ strong subadditivity for a normalized three-site reduced state.
     idempotence, the same substitution gives $S^2=S$ directly.
 \end{proof}
 
-\begin{theorem}[Normalized closed-sector trace relation]
+\begin{theorem}[Normalized closed-sector trace relations]
     \label{thm:mpdo_closed_sector_trace_normalized_pow_relation}
-    \lean{MPOTensor.closedSectorTraceMatrix_normalized_pow_two_eq_pow_three}
+    \lean{MPOTensor.closedSectorTraceMatrix_normalized_relations}
     \leanok
     \uses{def:mpdo_concrete_closed_sector_trace_matrix,
         thm:mpdo_closed_sector_pairing_normalized_idempotent}
@@ -1493,6 +1493,12 @@ strong subadditivity for a normalized three-site reduced state.
     \[
         \widehat T^2=\widehat T^3.
     \]
+    For every positive integer $N$, one also has
+    \[
+        \tr(\widehat T^N)=\tr(\widehat T).
+    \]
+    This is the valid trace-power display in
+    \cite[Appendix~C.2, lines~1490--1497]{Cirac2016MPDO_arXiv}.
     No idempotence or rank-one conclusion for $\widehat T$ is asserted.
 \end{theorem}
 
@@ -1509,6 +1515,16 @@ strong subadditivity for a normalized three-site reduced state.
         =Q(\lambda^{-1}LQ)^2\lambda^{-1}L
         =(Q\lambda^{-1}L)^3.
     \]
+    Cyclicity of trace and the idempotence of $\lambda^{-1}LQ$ give
+    \[
+      \tr(Q\lambda^{-1}L)
+        =\tr(\lambda^{-1}LQ)
+        =\tr\bigl((\lambda^{-1}LQ)^2\bigr)
+        =\tr\bigl((Q\lambda^{-1}L)^2\bigr).
+    \]
+    The preceding square--cube identity then gives
+    $\widehat T^N=\widehat T^2$ for every $N\geq2$, proving the stated trace
+    identity.
 \end{proof}
 
 \begin{definition}[Explicit neighboring $\eta$-operator data]

--- a/docs/counterexamples.md
+++ b/docs/counterexamples.md
@@ -9,12 +9,14 @@ mathematical obstruction.
 ### Primitive constant trace powers need not be rank one
 
 - Location: `TNLean/Archive/PerronFrobeniusRankOneCounterexample.lean`
-- Main declaration: `TNLean.Archive.PerronFrobeniusRankOneCounterexample.counterexample`
+- Main declaration:
+  `TNLean.Archive.PerronFrobeniusRankOneCounterexample.counterexample_with_rectangular_pairing`
 - Statement refuted: a primitive nonnegative matrix whose positive powers have
   constant trace must have rank one.
-- Relevance: this blocks the standalone rank-one step used in the
-  simple-MPDO Appendix C.2 track of arXiv:1606.00608 unless extra structure is
-  added, such as positivity or diagonalizability hypotheses.
+- Relevance: explicit rectangular factors satisfy $T=RL$ with $LR$
+  idempotent, so even the full pairing identity of Appendix C.2 yields the
+  constant traces but not rank one. An additional condition excluding the
+  generalized zero-eigenspace is required.
 
 ### BiCF does not follow from the other horizontal canonical-form fields
 

--- a/docs/paper-gaps/cpgsv17_pf_rank_one.tex
+++ b/docs/paper-gaps/cpgsv17_pf_rank_one.tex
@@ -98,9 +98,9 @@ matrix implication
 \]
 is false for finite entrywise non-negative real matrices.
 \footnote{The formal counterexample is
-\path{TNLean/Archive/PerronFrobeniusRankOneCounterexample.lean}, especially the
-matrix definition at lines 63--65 and the theorem \texttt{counterexample} at
-lines 150--154. It is also summarized in
+\path{TNLean/Archive/PerronFrobeniusRankOneCounterexample.lean}, especially
+\texttt{counterexample} and
+\texttt{counterexample\_with\_rectangular\_pairing}. It is also summarized in
 \path{docs/counterexamples.md:19--27}.}
 
 This example has the form $T=P+\frac16 xy^{\top}$, where
@@ -108,6 +108,37 @@ $x=(1,-1,0)^{\top}$ and $y=(1,1,-2)^{\top}$. The perturbation satisfies
 $(xy^{\top})^2=0$ and is annihilated by $P$ on both sides. It therefore
 leaves all traces of positive powers unchanged from the Perron projector while
 raising the rank of $T$.
+
+The same matrix has a genuinely rectangular realization of the pairing in
+lines 1490--1497 of Appendix C.2.  Set
+\[
+  L=
+  \begin{pmatrix}
+    \tfrac13&\tfrac13&\tfrac13\\
+    \tfrac16&\tfrac16&-\tfrac13
+  \end{pmatrix},
+  \qquad
+  R=
+  \begin{pmatrix}
+    1&1\\
+    1&-1\\
+    1&0
+  \end{pmatrix}.
+\]
+Direct multiplication gives
+\[
+  RL=T,
+  \qquad
+  LR=
+  \begin{pmatrix}1&0\\0&0\end{pmatrix},
+  \qquad
+  (LR)^2=LR.
+\]
+Thus the counterexample satisfies not only the scalar trace identities but
+also the full rectangular idempotence underlying the displayed
+zero-correlation-length equation at source lines 1490--1493.  Nevertheless
+$T$ is not an outer product, so this equation does not justify the rank-one
+assertion at lines 1498--1499.
 
 \section{What the operator-valued ZCL identity implies}
 
@@ -123,10 +154,27 @@ by $R$ and on the right by $L$ gives only
 \[
   T^2=T^3,
 \]
-not $T=T^2$.  The counterexample above already satisfies this weaker identity:
-$T^2=T^3=P$.  Thus retaining the displayed operator equation, without a
-further property of the inverse-map families $l_k$ and $r_k$, does not remove
-the nilpotent part of $T$.
+not $T=T^2$.  The rectangular matrices displayed above satisfy the full
+hypothesis $T=RL$ and $(LR)^2=LR$, while $T^2=T^3=P$.  Thus retaining the
+displayed operator equation, without a further property of the inverse-map
+families $l_k$ and $r_k$, does not remove the nilpotent part of $T$.
+
+There is nevertheless a direct rectangular proof of the trace-power display
+at source lines 1494--1497.  Cyclicity of trace gives
+\[
+  \tr(T)=\tr(RL)
+  =\tr(LR)
+  =\tr((LR)^2)
+  =\tr(T^2).
+\]
+Together with $T^2=T^3$, this implies $T^N=T^2$ for every $N\geq2$, and hence
+\[
+  \tr(T^N)=\tr(T)
+\]
+for every positive integer $N$.
+\footnote{\sloppy Formal declaration:
+{\scriptsize\leanid{Matrix.trace_pow_eq_trace_of_rectangular_idempotent}} in
+\doclink{TNLean/Algebra/PerronFrobenius/RankOne}.}
 
 The exact sufficient conclusion is transparent.  If the inverse-map
 construction were shown to give $T^2=T$, then $T$ itself would be idempotent.
@@ -238,12 +286,17 @@ Source zero correlation length therefore supplies a number $\lambda>0$ for
 which the normalized pairing operator is idempotent.  The rectangular
 factorization $S=L R$ and $T=R L$ then proves
 \[
-  (\lambda^{-1}T)^2=(\lambda^{-1}T)^3.
+  (\lambda^{-1}T)^2=(\lambda^{-1}T)^3,
+  \qquad
+  \tr((\lambda^{-1}T)^N)
+    =\tr(\lambda^{-1}T)
 \]
-This is formalized as
-{\scriptsize\leanid{MPOTensor.closedSectorTraceMatrix_apply}} and
-{\scriptsize\leanid{MPOTensor.closedSectorTraceMatrix_normalized_pow_two_eq_pow_three}}
-in \doclink{TNLean/MPS/MPDO/SectorPairingTransfer}.
+for every positive integer $N$.
+\footnote{\sloppy Formal declarations:
+{\scriptsize\leanid{MPOTensor.closedSectorTraceMatrix_apply}},
+and
+{\scriptsize\leanid{MPOTensor.closedSectorTraceMatrix_normalized_relations}}
+in \doclink{TNLean/MPS/MPDO/SectorPairingTransfer}.}
 
 This conclusion is the scale-invariant consequence of the displayed operator
 equation; it does not imply that the normalized trace matrix is


### PR DESCRIPTION
## Summary

This change formalizes the valid part of the trace argument in arXiv:1606.00608, Appendix C.2, Lemma C.5 (`SALZCL`), lines 1490–1497, and sharpens the documented obstruction to the subsequent rank-one inference.

It adds:

- a general rectangular theorem: if `L * Q` is idempotent, then `tr((Q * L)^N) = tr(Q * L)` for every positive `N`;
- one combined concrete theorem showing that a single positive normalization scalar gives both `T̂² = T̂³` and constant positive-power traces for `closedSectorTraceMatrix`;
- preserved individual square–cube and trace-power APIs as projections of that combined theorem;
- explicit real matrices `L : 2×3` and `R : 3×2` for the archived primitive counterexample, with `T = R L` and `L R = diag(1,0)` idempotent;
- a capstone showing that primitivity, trace normalization, constant traces, and the full rectangular pairing identity still do not imply that `T` is an outer product;
- synchronized blueprint, paper-gap, and counterexample documentation.

The pull request does **not** claim the rank-one conclusion at source lines 1498–1499. The remaining missing assertion is the exclusion of the square-zero generalized zero-eigenspace for the actual inverse-map tensors.

Closes #3798.

## Verification

- targeted Lean checks for all three changed Lean modules;
- `lake build` after rebasing onto current `main` (9337 jobs; only pre-existing warnings);
- proof-integrity and line-length checks;
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`;
- `cd blueprint && leanblueprint checkdecls` after rebasing;
- blueprint PDF generation;
- standalone compilation of `docs/paper-gaps/cpgsv17_pf_rank_one.tex` with no overfull or error diagnostics;
- independent source-faithfulness, axiom, and blueprint exact-match review.

## Faithfulness

The blueprint cites `closedSectorTraceMatrix_normalized_relations`, which obtains both conclusions from one normalized pairing idempotent and therefore uses one common scalar `λ`. The unsupported idempotence and rank-one assertions remain unmarked and are documented as a genuine source gap in `docs/paper-gaps/cpgsv17_pf_rank_one.tex`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal math and documentation only; no runtime, auth, or data paths. Refactors existing MPDO APIs without changing claimed rank-one conclusions.
> 
> **Overview**
> Formalizes the **valid** trace-power step of Appendix C.2 (lines 1490–1497) and documents that it still does not justify rank one.
> 
> Adds **`Matrix.trace_pow_eq_trace_of_rectangular_idempotent`**: when `L * Q` is idempotent, every positive power of `Q * L` has the same trace. **`MPOTensor.closedSectorTraceMatrix_normalized_relations`** bundles `λ̂⁻¹T`’s square–cube identity and constant positive-power traces under one normalization scalar; older square–cube and trace APIs are thin wrappers.
> 
> The archived **3×3 primitive counterexample** now includes explicit **`pairingL` / `pairingR`** with `T = pairingR * pairingL` and idempotent `pairingL * pairingR`, plus **`counterexample_with_rectangular_pairing`** showing that full rectangular ZCL still fails to imply an outer product. Blueprint, `docs/counterexamples.md`, and `docs/paper-gaps/cpgsv17_pf_rank_one.tex` are aligned; rank-one at source lines 1498–1499 remains explicitly unsupported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ad61154748292a744553d67eef6cd0cbb6d65e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->