### PR TITLE
feat(MPS/MPDO): transport adjacent bond commutator

### DIFF
--- a/TNLean/MPS/MPDO/PhysicalSectorBondCommutativity.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorBondCommutativity.lean
@@ -507,10 +507,10 @@ Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`), lines
 1589--1593. -/
 theorem physicalBond_adjacent_comm_three
     (F : PhysicalSectorFactorization K) :
-    embedLocalOperator (d := d) 2 3 (by omega) (0 : Fin 3) F.physicalBond *
-        embedLocalOperator (d := d) 2 3 (by omega) (1 : Fin 3) F.physicalBond =
-      embedLocalOperator (d := d) 2 3 (by omega) (1 : Fin 3) F.physicalBond *
-        embedLocalOperator (d := d) 2 3 (by omega) (0 : Fin 3) F.physicalBond := by
+    embedLocalOperator (d := d) 2 3 (by decide) (0 : Fin 3) F.physicalBond *
+        embedLocalOperator (d := d) 2 3 (by decide) (1 : Fin 3) F.physicalBond =
+      embedLocalOperator (d := d) 2 3 (by decide) (1 : Fin 3) F.physicalBond *
+        embedLocalOperator (d := d) 2 3 (by decide) (0 : Fin 3) F.physicalBond := by
   apply (Matrix.reindex (finThreeArrowEquiv (Fin d))
     (finThreeArrowEquiv (Fin d))).injective
   change Matrix.reindexLinearEquiv ℂ ℂ (finThreeArrowEquiv (Fin d))
@@ -526,7 +526,7 @@ theorem physicalBond_adjacent_comm_three
   have hzero :
       Matrix.reindexLinearEquiv ℂ ℂ (finThreeArrowEquiv (Fin d))
           (finThreeArrowEquiv (Fin d))
-            (embedLocalOperator (d := d) 2 3 (by omega) (0 : Fin 3)
+            (embedLocalOperator (d := d) 2 3 (by decide) (0 : Fin 3)
               F.physicalBond) =
         leftPairMatrix F.physicalPairBond := by
     simpa only [Matrix.coe_reindexLinearEquiv] using
@@ -534,7 +534,7 @@ theorem physicalBond_adjacent_comm_three
   have hone :
       Matrix.reindexLinearEquiv ℂ ℂ (finThreeArrowEquiv (Fin d))
           (finThreeArrowEquiv (Fin d))
-            (embedLocalOperator (d := d) 2 3 (by omega) (1 : Fin 3)
+            (embedLocalOperator (d := d) 2 3 (by decide) (1 : Fin 3)
               F.physicalBond) =
         rightPairMatrix F.physicalPairBond := by
     simpa only [Matrix.coe_reindexLinearEquiv] using

--- a/TNLean/MPS/MPDO/PhysicalSectorBondCommutativity.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorBondCommutativity.lean
@@ -14,8 +14,21 @@ commutativity of two adjacent physical-sector bonds.  For sectors `k, l, h`,
 the first bond acts on the neighboring factor $R_k \otimes L_l$, while the
 second acts on $R_l \otimes L_h$.  It also identifies the two translated
 bonds on three sites with the corresponding left and right tensor-product
-lifts.  Their simultaneous transport through the sector decomposition is a
-subsequent step.
+lifts.  The two lifts are regrouped simultaneously over sector triples,
+transported back to physical coordinates, and shown to commute on three
+sites.
+
+## Main results
+
+* `reindex_leftPairMatrix_sectorCoordinateBond` and
+  `reindex_rightPairMatrix_sectorCoordinateBond` identify the two regrouped
+  sector-coordinate lifts.
+* `sectorCoordinateBond_adjacent_comm_three` assembles the fixed-sector
+  commutators over all sector triples.
+* `leftPairMatrix_physicalPairBond` and `rightPairMatrix_physicalPairBond`
+  give the exact three-site coordinate congruences.
+* `physicalBond_adjacent_comm_three` proves commutativity of the two adjacent
+  physical bonds on a three-site chain.
 
 ## References
 
@@ -135,6 +148,240 @@ theorem reindex_embedLocalOperator_one (F : PhysicalSectorFactorization K) :
     change 0 = (if σ.1 = τ.1 then 1 else 0) * F.physicalPairBond σ.2 τ.2
     rw [if_neg (fun hs ↦ h hs.symm), zero_mul]
 
+/-- After three-site regrouping, the first translated sector-coordinate bond
+is block diagonal. On the sector triple `(k, l, h)` it is the identity on the
+outer boundary, followed by `ηₖₗ` and the identity on the second neighboring
+factor.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`), lines
+1589--1593. -/
+theorem reindex_leftPairMatrix_sectorCoordinateBond
+    (F : PhysicalSectorFactorization K) :
+    Matrix.reindex F.threeSiteGlobalRegroupEquiv F.threeSiteGlobalRegroupEquiv
+        (leftPairMatrix F.sectorCoordinateBond) =
+      Matrix.blockDiagonal' fun
+          klh : Fin F.sectorCount × (Fin F.sectorCount × Fin F.sectorCount) ↦
+        (1 : Matrix (BoundaryIndex F klh.1 klh.2.2)
+          (BoundaryIndex F klh.1 klh.2.2) ℂ) ⊗ₖ
+            (F.neighboringOperator klh.1 klh.2.1 ⊗ₖ
+              (1 : Matrix (NeighborIndex F klh.2.1 klh.2.2)
+                (NeighborIndex F klh.2.1 klh.2.2) ℂ)) := by
+  ext ⟨klh, x⟩ ⟨pqr, y⟩
+  rcases klh with ⟨k, l, h⟩
+  rcases pqr with ⟨p, q, r⟩
+  by_cases hp : (k, (l, h)) = (p, (q, r))
+  · cases hp
+    rw [Matrix.blockDiagonal'_apply_eq]
+    simp only [Matrix.reindex_apply, Matrix.submatrix_apply, leftPairMatrix,
+      Matrix.kroneckerMap_apply, Equiv.prodAssoc_symm_apply]
+    simp only [sectorCoordinateBond, Matrix.reindex_apply,
+      Matrix.submatrix_apply, Equiv.symm_symm]
+    rw [twoSiteGlobalRegroupEquiv_threeSiteGlobalRegroupEquiv_symm_left,
+      twoSiteGlobalRegroupEquiv_threeSiteGlobalRegroupEquiv_symm_left]
+    rw [Matrix.blockDiagonal'_apply_eq]
+    rw [threeSiteGlobalRegroupEquiv_symm_last,
+      threeSiteGlobalRegroupEquiv_symm_last]
+    by_cases ha : x.1.1 = y.1.1
+    <;> by_cases hb : x.1.2 = y.1.2
+    <;> by_cases hc : x.2.2.1 = y.2.2.1
+    <;> by_cases hd : x.2.2.2 = y.2.2.2
+    <;> simp [Matrix.one_apply, Prod.ext_iff,
+      ha, hb, hc, hd]
+  · rw [Matrix.blockDiagonal'_apply_ne _ _ _ hp]
+    simp only [Matrix.reindex_apply, Matrix.submatrix_apply, leftPairMatrix,
+      Matrix.kroneckerMap_apply, Equiv.prodAssoc_symm_apply]
+    simp only [sectorCoordinateBond, Matrix.reindex_apply,
+      Matrix.submatrix_apply, Equiv.symm_symm]
+    rw [twoSiteGlobalRegroupEquiv_threeSiteGlobalRegroupEquiv_symm_left,
+      twoSiteGlobalRegroupEquiv_threeSiteGlobalRegroupEquiv_symm_left]
+    by_cases hpairs : (k, l) = (p, q)
+    · cases hpairs
+      have hhr : h ≠ r := by
+        intro hhr
+        cases hhr
+        exact hp rfl
+      rw [Matrix.blockDiagonal'_apply_eq]
+      rw [threeSiteGlobalRegroupEquiv_symm_last,
+        threeSiteGlobalRegroupEquiv_symm_last]
+      simp [Matrix.one_apply, hhr]
+    · rw [Matrix.blockDiagonal'_apply_ne _ _ _ hpairs, zero_mul]
+
+/-- After three-site regrouping, the second translated sector-coordinate bond
+is block diagonal. On the sector triple `(k, l, h)` it is the identity on the
+outer boundary and on the first neighboring factor, followed by `ηₗₕ`.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`), lines
+1589--1593. -/
+theorem reindex_rightPairMatrix_sectorCoordinateBond
+    (F : PhysicalSectorFactorization K) :
+    Matrix.reindex F.threeSiteGlobalRegroupEquiv F.threeSiteGlobalRegroupEquiv
+        (rightPairMatrix F.sectorCoordinateBond) =
+      Matrix.blockDiagonal' fun
+          klh : Fin F.sectorCount × (Fin F.sectorCount × Fin F.sectorCount) ↦
+        (1 : Matrix (BoundaryIndex F klh.1 klh.2.2)
+          (BoundaryIndex F klh.1 klh.2.2) ℂ) ⊗ₖ
+            ((1 : Matrix (NeighborIndex F klh.1 klh.2.1)
+              (NeighborIndex F klh.1 klh.2.1) ℂ) ⊗ₖ
+                F.neighboringOperator klh.2.1 klh.2.2) := by
+  ext ⟨klh, x⟩ ⟨pqr, y⟩
+  rcases klh with ⟨k, l, h⟩
+  rcases pqr with ⟨p, q, r⟩
+  by_cases hp : (k, (l, h)) = (p, (q, r))
+  · cases hp
+    rw [Matrix.blockDiagonal'_apply_eq]
+    simp only [Matrix.reindex_apply, Matrix.submatrix_apply, rightPairMatrix,
+      Matrix.kroneckerMap_apply]
+    simp only [sectorCoordinateBond, Matrix.reindex_apply,
+      Matrix.submatrix_apply, Equiv.symm_symm]
+    rw [twoSiteGlobalRegroupEquiv_threeSiteGlobalRegroupEquiv_symm_right,
+      twoSiteGlobalRegroupEquiv_threeSiteGlobalRegroupEquiv_symm_right]
+    rw [Matrix.blockDiagonal'_apply_eq]
+    rw [threeSiteGlobalRegroupEquiv_symm_first,
+      threeSiteGlobalRegroupEquiv_symm_first]
+    by_cases ha : x.1.1 = y.1.1
+    <;> by_cases hb : x.1.2 = y.1.2
+    <;> by_cases hc : x.2.1.1 = y.2.1.1
+    <;> by_cases hd : x.2.1.2 = y.2.1.2
+    <;> simp [Matrix.one_apply, Prod.ext_iff, ha, hb, hc, hd]
+  · rw [Matrix.blockDiagonal'_apply_ne _ _ _ hp]
+    simp only [Matrix.reindex_apply, Matrix.submatrix_apply, rightPairMatrix,
+      Matrix.kroneckerMap_apply]
+    simp only [sectorCoordinateBond, Matrix.reindex_apply,
+      Matrix.submatrix_apply, Equiv.symm_symm]
+    rw [twoSiteGlobalRegroupEquiv_threeSiteGlobalRegroupEquiv_symm_right,
+      twoSiteGlobalRegroupEquiv_threeSiteGlobalRegroupEquiv_symm_right]
+    by_cases hpairs : (l, h) = (q, r)
+    · cases hpairs
+      have hkp : k ≠ p := by
+        intro hkp
+        cases hkp
+        exact hp rfl
+      rw [Matrix.blockDiagonal'_apply_eq]
+      rw [threeSiteGlobalRegroupEquiv_symm_first,
+        threeSiteGlobalRegroupEquiv_symm_first]
+      simp [Matrix.one_apply, hkp]
+    · rw [Matrix.blockDiagonal'_apply_ne _ _ _ hpairs, mul_zero]
+
+/-- The right three-site lift of the physical bond is the transport of the
+right lift of the sector-coordinate bond by the three-site coordinate
+matrix.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`), lines
+1589--1593. -/
+theorem rightPairMatrix_physicalPairBond
+    (F : PhysicalSectorFactorization K) :
+    rightPairMatrix F.physicalPairBond =
+      sandwichMap F.physicalCoordinateMatrixThreeᴴ
+        (rightPairMatrix F.sectorCoordinateBond) := by
+  simp only [rightPairMatrix, physicalPairBond, sandwichMap_apply]
+  rw [← F.physicalCoordinateMatrix_isometry]
+  simp only [physicalCoordinateMatrixThree,
+    Matrix.conjTranspose_kronecker, Matrix.conjTranspose_conjTranspose]
+  calc
+    _ = (F.physicalCoordinateMatrixᴴ ⊗ₖ
+          (F.physicalCoordinateMatrixTwoᴴ * F.sectorCoordinateBond)) *
+        (F.physicalCoordinateMatrix ⊗ₖ F.physicalCoordinateMatrixTwo) :=
+      Matrix.mul_kronecker_mul _ _ _ _
+    _ = ((F.physicalCoordinateMatrixᴴ *
+          (1 : Matrix (Fin (Fintype.card (SectorSiteIndex F)))
+            (Fin (Fintype.card (SectorSiteIndex F))) ℂ)) ⊗ₖ
+          (F.physicalCoordinateMatrixTwoᴴ * F.sectorCoordinateBond)) *
+        (F.physicalCoordinateMatrix ⊗ₖ F.physicalCoordinateMatrixTwo) := by
+      simp
+    _ = ((F.physicalCoordinateMatrixᴴ ⊗ₖ
+          F.physicalCoordinateMatrixTwoᴴ) *
+            ((1 : Matrix (Fin (Fintype.card (SectorSiteIndex F)))
+              (Fin (Fintype.card (SectorSiteIndex F))) ℂ) ⊗ₖ
+                F.sectorCoordinateBond)) *
+        (F.physicalCoordinateMatrix ⊗ₖ F.physicalCoordinateMatrixTwo) := by
+      rw [Matrix.mul_kronecker_mul]
+    _ = _ := rfl
+
+/-- The left three-site lift of the physical bond is the transport of the
+left lift of the sector-coordinate bond by the three-site coordinate matrix.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`), lines
+1589--1593. -/
+theorem leftPairMatrix_physicalPairBond
+    (F : PhysicalSectorFactorization K) :
+    leftPairMatrix F.physicalPairBond =
+      sandwichMap F.physicalCoordinateMatrixThreeᴴ
+        (leftPairMatrix F.sectorCoordinateBond) := by
+  simp only [leftPairMatrix, physicalPairBond, sandwichMap_apply]
+  rw [← F.physicalCoordinateMatrix_isometry]
+  simp only [physicalCoordinateMatrixTwo, physicalCoordinateMatrixThree,
+    Matrix.conjTranspose_kronecker, Matrix.conjTranspose_conjTranspose]
+  rw [Matrix.mul_kronecker_mul]
+  have hfactor :
+      (((F.physicalCoordinateMatrixᴴ ⊗ₖ F.physicalCoordinateMatrixᴴ) *
+          F.sectorCoordinateBond) ⊗ₖ F.physicalCoordinateMatrixᴴ) =
+        (((F.physicalCoordinateMatrixᴴ ⊗ₖ F.physicalCoordinateMatrixᴴ) ⊗ₖ
+          F.physicalCoordinateMatrixᴴ) *
+            (F.sectorCoordinateBond ⊗ₖ
+              (1 : Matrix (Fin (Fintype.card (SectorSiteIndex F)))
+                (Fin (Fintype.card (SectorSiteIndex F))) ℂ))) := by
+    calc
+      _ = (((F.physicalCoordinateMatrixᴴ ⊗ₖ F.physicalCoordinateMatrixᴴ) *
+            F.sectorCoordinateBond) ⊗ₖ
+          (F.physicalCoordinateMatrixᴴ *
+            (1 : Matrix (Fin (Fintype.card (SectorSiteIndex F)))
+              (Fin (Fintype.card (SectorSiteIndex F))) ℂ))) := by
+        simp
+      _ = _ := Matrix.mul_kronecker_mul _ _ _ _
+  rw [hfactor]
+  let eP := Equiv.prodAssoc (Fin d) (Fin d) (Fin d)
+  let eS := Equiv.prodAssoc
+    (Fin (Fintype.card (SectorSiteIndex F)))
+    (Fin (Fintype.card (SectorSiteIndex F)))
+    (Fin (Fintype.card (SectorSiteIndex F)))
+  have hreindex_outer
+      (A : Matrix ((Fin d × Fin d) × Fin d)
+        ((Fin (Fintype.card (SectorSiteIndex F)) ×
+          Fin (Fintype.card (SectorSiteIndex F))) ×
+            Fin (Fintype.card (SectorSiteIndex F))) ℂ)
+      (B : Matrix ((Fin (Fintype.card (SectorSiteIndex F)) ×
+          Fin (Fintype.card (SectorSiteIndex F))) ×
+            Fin (Fintype.card (SectorSiteIndex F)))
+        ((Fin d × Fin d) × Fin d) ℂ) :
+      Matrix.reindex eP eP (A * B) =
+        Matrix.reindex eP eS A * Matrix.reindex eS eP B := by
+    simpa only [Matrix.coe_reindexLinearEquiv] using
+      (Matrix.reindexLinearEquiv_mul ℂ ℂ eP eS eP A B).symm
+  have hreindex_inner
+      (A : Matrix ((Fin d × Fin d) × Fin d)
+        ((Fin (Fintype.card (SectorSiteIndex F)) ×
+          Fin (Fintype.card (SectorSiteIndex F))) ×
+            Fin (Fintype.card (SectorSiteIndex F))) ℂ)
+      (B : Matrix ((Fin (Fintype.card (SectorSiteIndex F)) ×
+          Fin (Fintype.card (SectorSiteIndex F))) ×
+            Fin (Fintype.card (SectorSiteIndex F)))
+        ((Fin (Fintype.card (SectorSiteIndex F)) ×
+          Fin (Fintype.card (SectorSiteIndex F))) ×
+            Fin (Fintype.card (SectorSiteIndex F))) ℂ) :
+      Matrix.reindex eP eS (A * B) =
+        Matrix.reindex eP eS A * Matrix.reindex eS eS B := by
+    simpa only [Matrix.coe_reindexLinearEquiv] using
+      (Matrix.reindexLinearEquiv_mul ℂ ℂ eP eS eS A B).symm
+  simp only [eP, eS] at hreindex_outer hreindex_inner
+  calc
+    _ = Matrix.reindex (Equiv.prodAssoc (Fin d) (Fin d) (Fin d))
+          (Equiv.prodAssoc
+            (Fin (Fintype.card (SectorSiteIndex F)))
+            (Fin (Fintype.card (SectorSiteIndex F)))
+            (Fin (Fintype.card (SectorSiteIndex F))))
+            ((F.physicalCoordinateMatrixᴴ ⊗ₖ F.physicalCoordinateMatrixᴴ) ⊗ₖ
+              F.physicalCoordinateMatrixᴴ) *
+        Matrix.reindex (Equiv.prodAssoc _ _ _) (Equiv.prodAssoc _ _ _)
+          (F.sectorCoordinateBond ⊗ₖ
+            (1 : Matrix (Fin (Fintype.card (SectorSiteIndex F)))
+              (Fin (Fintype.card (SectorSiteIndex F))) ℂ)) *
+        Matrix.reindex (Equiv.prodAssoc _ _ _) (Equiv.prodAssoc _ _ _)
+          ((F.physicalCoordinateMatrix ⊗ₖ F.physicalCoordinateMatrix) ⊗ₖ
+            F.physicalCoordinateMatrix) := by
+      rw [hreindex_outer, hreindex_inner]
+    _ = _ := by
+      rw [Matrix.kronecker_assoc, Matrix.kronecker_assoc]
+
 /-- On fixed physical sectors `(k, l, h)`, the two adjacent bonds commute.
 The first neighboring operator acts on $R_k \otimes L_l$ and the second on
 $R_l \otimes L_h$; all other tensor factors carry the identity.
@@ -158,5 +405,140 @@ theorem adjacentSectorBonds_comm (F : PhysicalSectorFactorization K)
   rw [← Matrix.mul_kronecker_mul, ← Matrix.mul_kronecker_mul,
     ← Matrix.mul_kronecker_mul, ← Matrix.mul_kronecker_mul]
   simp
+
+/-- The two adjacent lifts of the sector-coordinate bond commute on three
+sites. This assembles the fixed-sector calculation over the direct sum of
+sector triples.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`), lines
+1589--1593. -/
+theorem sectorCoordinateBond_adjacent_comm_three
+    (F : PhysicalSectorFactorization K) :
+    leftPairMatrix F.sectorCoordinateBond *
+        rightPairMatrix F.sectorCoordinateBond =
+      rightPairMatrix F.sectorCoordinateBond *
+        leftPairMatrix F.sectorCoordinateBond := by
+  apply (Matrix.reindex F.threeSiteGlobalRegroupEquiv
+    F.threeSiteGlobalRegroupEquiv).injective
+  change Matrix.reindexLinearEquiv ℂ ℂ F.threeSiteGlobalRegroupEquiv
+      F.threeSiteGlobalRegroupEquiv
+        (leftPairMatrix F.sectorCoordinateBond *
+          rightPairMatrix F.sectorCoordinateBond) =
+    Matrix.reindexLinearEquiv ℂ ℂ F.threeSiteGlobalRegroupEquiv
+      F.threeSiteGlobalRegroupEquiv
+        (rightPairMatrix F.sectorCoordinateBond *
+          leftPairMatrix F.sectorCoordinateBond)
+  rw [← Matrix.reindexLinearEquiv_mul ℂ ℂ
+      F.threeSiteGlobalRegroupEquiv F.threeSiteGlobalRegroupEquiv
+      F.threeSiteGlobalRegroupEquiv,
+    ← Matrix.reindexLinearEquiv_mul ℂ ℂ
+      F.threeSiteGlobalRegroupEquiv F.threeSiteGlobalRegroupEquiv
+      F.threeSiteGlobalRegroupEquiv]
+  change Matrix.reindex F.threeSiteGlobalRegroupEquiv
+      F.threeSiteGlobalRegroupEquiv (leftPairMatrix F.sectorCoordinateBond) *
+        Matrix.reindex F.threeSiteGlobalRegroupEquiv
+          F.threeSiteGlobalRegroupEquiv
+            (rightPairMatrix F.sectorCoordinateBond) =
+    Matrix.reindex F.threeSiteGlobalRegroupEquiv
+        F.threeSiteGlobalRegroupEquiv
+          (rightPairMatrix F.sectorCoordinateBond) *
+      Matrix.reindex F.threeSiteGlobalRegroupEquiv
+        F.threeSiteGlobalRegroupEquiv (leftPairMatrix F.sectorCoordinateBond)
+  rw [
+    F.reindex_leftPairMatrix_sectorCoordinateBond,
+    F.reindex_rightPairMatrix_sectorCoordinateBond,
+    ← Matrix.blockDiagonal'_mul, ← Matrix.blockDiagonal'_mul]
+  congr 1
+  funext klh
+  exact F.adjacentSectorBonds_comm klh.1 klh.2.1 klh.2.2
+
+/-- The first and second lifts of the physical pair bond commute on three
+sites.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`), lines
+1589--1593. -/
+theorem physicalPairBond_adjacent_comm_three
+    (F : PhysicalSectorFactorization K) :
+    leftPairMatrix F.physicalPairBond * rightPairMatrix F.physicalPairBond =
+      rightPairMatrix F.physicalPairBond * leftPairMatrix F.physicalPairBond := by
+  rw [F.leftPairMatrix_physicalPairBond,
+    F.rightPairMatrix_physicalPairBond]
+  simp only [sandwichMap_apply, Matrix.conjTranspose_conjTranspose]
+  calc
+    _ = F.physicalCoordinateMatrixThreeᴴ *
+        leftPairMatrix F.sectorCoordinateBond *
+          (F.physicalCoordinateMatrixThree *
+            F.physicalCoordinateMatrixThreeᴴ) *
+              rightPairMatrix F.sectorCoordinateBond *
+                F.physicalCoordinateMatrixThree := by
+      simp only [Matrix.mul_assoc]
+    _ = F.physicalCoordinateMatrixThreeᴴ *
+        (leftPairMatrix F.sectorCoordinateBond *
+          rightPairMatrix F.sectorCoordinateBond) *
+            F.physicalCoordinateMatrixThree := by
+      rw [F.physicalCoordinateMatrixThree_coisometry]
+      simp only [Matrix.mul_one, Matrix.mul_assoc]
+    _ = F.physicalCoordinateMatrixThreeᴴ *
+        (rightPairMatrix F.sectorCoordinateBond *
+          leftPairMatrix F.sectorCoordinateBond) *
+            F.physicalCoordinateMatrixThree := by
+      rw [F.sectorCoordinateBond_adjacent_comm_three]
+    _ = F.physicalCoordinateMatrixThreeᴴ *
+        rightPairMatrix F.sectorCoordinateBond *
+          (F.physicalCoordinateMatrixThree *
+            F.physicalCoordinateMatrixThreeᴴ) *
+              leftPairMatrix F.sectorCoordinateBond *
+                F.physicalCoordinateMatrixThree := by
+      rw [F.physicalCoordinateMatrixThree_coisometry]
+      simp [Matrix.mul_assoc]
+    _ = _ := by simp only [Matrix.mul_assoc]
+
+/-- The physical bond translated to the first and second positions of a
+three-site chain commutes:
+\[
+  B_{01}B_{12}=B_{12}B_{01}.
+\]
+
+This is the three-site assertion only. Commutativity of all translates on an
+arbitrary periodic chain, including the crossed two-site ordering, remains a
+separate result.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`), lines
+1589--1593. -/
+theorem physicalBond_adjacent_comm_three
+    (F : PhysicalSectorFactorization K) :
+    embedLocalOperator (d := d) 2 3 (by omega) (0 : Fin 3) F.physicalBond *
+        embedLocalOperator (d := d) 2 3 (by omega) (1 : Fin 3) F.physicalBond =
+      embedLocalOperator (d := d) 2 3 (by omega) (1 : Fin 3) F.physicalBond *
+        embedLocalOperator (d := d) 2 3 (by omega) (0 : Fin 3) F.physicalBond := by
+  apply (Matrix.reindex (finThreeArrowEquiv (Fin d))
+    (finThreeArrowEquiv (Fin d))).injective
+  change Matrix.reindexLinearEquiv ℂ ℂ (finThreeArrowEquiv (Fin d))
+      (finThreeArrowEquiv (Fin d)) (_ * _) =
+    Matrix.reindexLinearEquiv ℂ ℂ (finThreeArrowEquiv (Fin d))
+      (finThreeArrowEquiv (Fin d)) (_ * _)
+  rw [← Matrix.reindexLinearEquiv_mul ℂ ℂ
+      (finThreeArrowEquiv (Fin d)) (finThreeArrowEquiv (Fin d))
+      (finThreeArrowEquiv (Fin d)),
+    ← Matrix.reindexLinearEquiv_mul ℂ ℂ
+      (finThreeArrowEquiv (Fin d)) (finThreeArrowEquiv (Fin d))
+      (finThreeArrowEquiv (Fin d))]
+  have hzero :
+      Matrix.reindexLinearEquiv ℂ ℂ (finThreeArrowEquiv (Fin d))
+          (finThreeArrowEquiv (Fin d))
+            (embedLocalOperator (d := d) 2 3 (by omega) (0 : Fin 3)
+              F.physicalBond) =
+        leftPairMatrix F.physicalPairBond := by
+    simpa only [Matrix.coe_reindexLinearEquiv] using
+      F.reindex_embedLocalOperator_zero
+  have hone :
+      Matrix.reindexLinearEquiv ℂ ℂ (finThreeArrowEquiv (Fin d))
+          (finThreeArrowEquiv (Fin d))
+            (embedLocalOperator (d := d) 2 3 (by omega) (1 : Fin 3)
+              F.physicalBond) =
+        rightPairMatrix F.physicalPairBond := by
+    simpa only [Matrix.coe_reindexLinearEquiv] using
+      F.reindex_embedLocalOperator_one
+  rw [hzero, hone, F.physicalPairBond_adjacent_comm_three]
 
 end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/PhysicalSectorClosureGlobal.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorClosureGlobal.lean
@@ -69,6 +69,18 @@ Source: arXiv:1606.00608, Appendix C.2, lines 1381--1450. -/
       F.twoSiteSectorEmbedding k h ((F.twoSiteRegroupEquiv k h).symm x) :=
   rfl
 
+/-- The forward global two-site regrouping sends a fixed-sector embedding to
+the corresponding sector-pair summand and the regrouped four-subspin index.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1381--1450. -/
+@[simp] theorem twoSiteGlobalRegroupEquiv_apply
+    (F : PhysicalSectorFactorization K) (k h : Fin F.sectorCount)
+    (x : SectorIndex F k × SectorIndex F h) :
+    F.twoSiteGlobalRegroupEquiv (F.twoSiteSectorEmbedding k h x) =
+      ⟨(k, h), F.twoSiteRegroupEquiv k h x⟩ := by
+  apply F.twoSiteGlobalRegroupEquiv.symm.injective
+  simp
+
 /-- The complete three-site physical space, indexed by a sector triple and
 regrouped into its outer and two neighboring factors.
 
@@ -96,6 +108,76 @@ Source: arXiv:1606.00608, Appendix C.2, lines 1381--1450. -/
       (NeighborIndex F k l × NeighborIndex F l h)) :
     F.threeSiteGlobalRegroupEquiv.symm ⟨(k, (l, h)), x⟩ =
       F.threeSiteSectorEmbedding k l h ((F.threeSiteRegroupEquiv k l h).symm x) :=
+  rfl
+
+/-- The first two sites of an inversely regrouped sector triple regroup to
+the pair `(k, l)`, with outer index `(L_k,R_l)` and neighboring index
+`(R_k,L_l)`.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`), lines
+1589--1593. -/
+@[simp] theorem twoSiteGlobalRegroupEquiv_threeSiteGlobalRegroupEquiv_symm_left
+    (F : PhysicalSectorFactorization K) (k l h : Fin F.sectorCount)
+    (x : BoundaryIndex F k h ×
+      (NeighborIndex F k l × NeighborIndex F l h)) :
+    F.twoSiteGlobalRegroupEquiv
+        ((F.threeSiteGlobalRegroupEquiv.symm ⟨(k, (l, h)), x⟩).1,
+          (F.threeSiteGlobalRegroupEquiv.symm ⟨(k, (l, h)), x⟩).2.1) =
+      ⟨(k, l), ((x.1.1, x.2.2.1), x.2.1)⟩ := by
+  rw [threeSiteGlobalRegroupEquiv_symm_apply]
+  change F.twoSiteGlobalRegroupEquiv
+      (F.twoSiteSectorEmbedding k l
+        ((x.1.1, x.2.1.1), (x.2.1.2, x.2.2.1))) = _
+  rw [twoSiteGlobalRegroupEquiv_apply]
+  rfl
+
+/-- The last two sites of an inversely regrouped sector triple regroup to
+the pair `(l, h)`, with outer index `(L_l,R_h)` and neighboring index
+`(R_l,L_h)`.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`), lines
+1589--1593. -/
+@[simp] theorem twoSiteGlobalRegroupEquiv_threeSiteGlobalRegroupEquiv_symm_right
+    (F : PhysicalSectorFactorization K) (k l h : Fin F.sectorCount)
+    (x : BoundaryIndex F k h ×
+      (NeighborIndex F k l × NeighborIndex F l h)) :
+    F.twoSiteGlobalRegroupEquiv
+        ((F.threeSiteGlobalRegroupEquiv.symm ⟨(k, (l, h)), x⟩).2.1,
+          (F.threeSiteGlobalRegroupEquiv.symm ⟨(k, (l, h)), x⟩).2.2) =
+      ⟨(l, h), ((x.2.1.2, x.1.2), x.2.2)⟩ := by
+  rw [threeSiteGlobalRegroupEquiv_symm_apply]
+  change F.twoSiteGlobalRegroupEquiv
+      (F.twoSiteSectorEmbedding l h
+        ((x.2.1.2, x.2.2.1), (x.2.2.2, x.1.2))) = _
+  rw [twoSiteGlobalRegroupEquiv_apply]
+  rfl
+
+/-- The first site of an inversely regrouped sector triple is the finite
+encoding of `(L_k,R_k)`.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`), lines
+1589--1593. -/
+@[simp] theorem threeSiteGlobalRegroupEquiv_symm_first
+    (F : PhysicalSectorFactorization K) (k l h : Fin F.sectorCount)
+    (x : BoundaryIndex F k h ×
+      (NeighborIndex F k l × NeighborIndex F l h)) :
+    (F.threeSiteGlobalRegroupEquiv.symm ⟨(k, (l, h)), x⟩).1 =
+      F.sectorFinEquiv.symm ⟨k, (x.1.1, x.2.1.1)⟩ := by
+  rw [threeSiteGlobalRegroupEquiv_symm_apply]
+  rfl
+
+/-- The last site of an inversely regrouped sector triple is the finite
+encoding of `(L_h,R_h)`.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`), lines
+1589--1593. -/
+@[simp] theorem threeSiteGlobalRegroupEquiv_symm_last
+    (F : PhysicalSectorFactorization K) (k l h : Fin F.sectorCount)
+    (x : BoundaryIndex F k h ×
+      (NeighborIndex F k l × NeighborIndex F l h)) :
+    (F.threeSiteGlobalRegroupEquiv.symm ⟨(k, (l, h)), x⟩).2.2 =
+      F.sectorFinEquiv.symm ⟨h, (x.2.2.2, x.1.2)⟩ := by
+  rw [threeSiteGlobalRegroupEquiv_symm_apply]
   rfl
 
 /-- After global regrouping, the complete two-site closure is the direct sum

--- a/TNLean/MPS/MPDO/PhysicalSectorCoordinateTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorCoordinateTransport.lean
@@ -96,6 +96,20 @@ noncomputable def physicalCoordinateMatrixTwo
   Matrix.kroneckerMap (· * ·)
     F.physicalCoordinateMatrix F.physicalCoordinateMatrix
 
+/-- The right-associated three-site product of the physical coordinate matrix.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`), lines
+1589--1593. -/
+noncomputable def physicalCoordinateMatrixThree
+    (F : PhysicalSectorFactorization K) :
+    Matrix
+      (Fin (Fintype.card (SectorSiteIndex F)) ×
+        (Fin (Fintype.card (SectorSiteIndex F)) ×
+          Fin (Fintype.card (SectorSiteIndex F))))
+      (Fin d × (Fin d × Fin d)) ℂ :=
+  Matrix.kroneckerMap (· * ·) F.physicalCoordinateMatrix
+    F.physicalCoordinateMatrixTwo
+
 /-- The right-associated four-site product of the physical coordinate matrix. -/
 noncomputable def physicalCoordinateMatrixFour
     (F : PhysicalSectorFactorization K) :
@@ -122,6 +136,30 @@ theorem physicalCoordinateMatrixTwo_coisometry
     F.physicalCoordinateMatrixTwo * F.physicalCoordinateMatrixTwoᴴ = 1 := by
   rw [physicalCoordinateMatrixTwo, Matrix.conjTranspose_kronecker,
     ← Matrix.mul_kronecker_mul, F.physicalCoordinateMatrix_coisometry]
+  exact Matrix.one_kronecker_one
+
+/-- The three-site physical coordinate matrix is an isometry.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`), lines
+1589--1593. -/
+theorem physicalCoordinateMatrixThree_isometry
+    (F : PhysicalSectorFactorization K) :
+    F.physicalCoordinateMatrixThreeᴴ * F.physicalCoordinateMatrixThree = 1 := by
+  simp only [physicalCoordinateMatrixThree, Matrix.conjTranspose_kronecker,
+    ← Matrix.mul_kronecker_mul, F.physicalCoordinateMatrix_isometry,
+    F.physicalCoordinateMatrixTwo_isometry]
+  exact Matrix.one_kronecker_one
+
+/-- The three-site physical coordinate matrix is a coisometry.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`), lines
+1589--1593. -/
+theorem physicalCoordinateMatrixThree_coisometry
+    (F : PhysicalSectorFactorization K) :
+    F.physicalCoordinateMatrixThree * F.physicalCoordinateMatrixThreeᴴ = 1 := by
+  simp only [physicalCoordinateMatrixThree, Matrix.conjTranspose_kronecker,
+    ← Matrix.mul_kronecker_mul, F.physicalCoordinateMatrix_coisometry,
+    F.physicalCoordinateMatrixTwo_coisometry]
   exact Matrix.one_kronecker_one
 
 theorem physicalCoordinateMatrixFour_isometry

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -254,12 +254,12 @@
     (\ref{eq:mpdo_eta_bond_assembly}) and~(\ref{eq:mpdo_eta_product_form}) are
     exactly the $\eta$-local product hypothesis; after that,
     Theorem~\ref{thm:mpdo_has_commuting_form_of_eta_local_structure}
-    gives the commuting-form conclusion. The fixed-sector commutator in
-    Theorem~\ref{thm:mpdo_fixed_sector_adjacent_bonds_comm} is complete, but
-    its simultaneous transport through the three-site direct-sum coordinates
-    has not yet been proved. Consequently, commutativity of the physical
-    translates, pairwise commutativity on every periodic chain, and the
-    all-length product identity in~(\ref{eq:mpdo_eta_product_form}) remain open.
+    gives the commuting-form conclusion. The fixed-sector commutator and its
+    transport to two adjacent physical bonds on three sites are complete in
+    Theorem~\ref{thm:mpdo_physical_adjacent_bonds_comm_three}. Pairwise
+    commutativity on every periodic chain, including the crossed ordering on
+    two sites, and the all-length product identity
+    in~(\ref{eq:mpdo_eta_product_form}) remain open.
     The doubled-index transfer condition enters only in the subsequent RFP and
     GSNNCH branch conclusions.
 \end{remark}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -1292,6 +1292,101 @@ strong subadditivity for a normalized three-site reduced state.
     follows from the mixed-product identity for tensor products.
 \end{proof}
 
+\begin{theorem}[Three-site sector-coordinate commutator]
+    \label{thm:mpdo_sector_coordinate_adjacent_bonds_comm}
+    \lean{MPOTensor.PhysicalSectorFactorization.reindex_leftPairMatrix_sectorCoordinateBond,
+      MPOTensor.PhysicalSectorFactorization.reindex_rightPairMatrix_sectorCoordinateBond,
+      MPOTensor.PhysicalSectorFactorization.sectorCoordinateBond_adjacent_comm_three}
+    \leanok
+    \uses{def:mpdo_physical_sector_two_site_bond,
+      def:mpdo_three_site_pair_lifts,
+      thm:mpdo_fixed_sector_adjacent_bonds_comm}
+    Let $C_{01}$ and $C_{12}$ be the first and second three-site lifts of
+    $B_{\mathrm{sector}}$. Under the three-site sector regrouping, they are
+    respectively
+    \[
+      \bigoplus_{k,l,h}C_{01}^{k,l,h},
+      \qquad
+      \bigoplus_{k,l,h}C_{12}^{k,l,h}.
+    \]
+    Consequently,
+    \[
+      C_{01}C_{12}=C_{12}C_{01}.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The first lift acts by $\eta_{k,l}$ on the first neighboring factor and
+    the second lift acts by $\eta_{l,h}$ on the second neighboring factor.
+    Thus the two regrouped matrices are block diagonal over $(k,l,h)$.
+    Apply
+    Theorem~\ref{thm:mpdo_fixed_sector_adjacent_bonds_comm} in every block.
+\end{proof}
+
+\begin{definition}[Three-site physical coordinate isometry]
+    \label{def:mpdo_three_site_physical_coordinate_isometry}
+    \lean{MPOTensor.PhysicalSectorFactorization.physicalCoordinateMatrixThree,
+      MPOTensor.PhysicalSectorFactorization.physicalCoordinateMatrixThree_isometry,
+      MPOTensor.PhysicalSectorFactorization.physicalCoordinateMatrixThree_coisometry}
+    \leanok
+    Let $V$ be the one-site change from physical to sector coordinates and
+    set
+    \[
+      V_3=V\otimes(V\otimes V).
+    \]
+    Then $V_3^\dagger V_3=I$ and $V_3V_3^\dagger=I$.
+\end{definition}
+
+\begin{theorem}[Transport of the adjacent three-site bonds]
+    \label{thm:mpdo_three_site_adjacent_bond_transport}
+    \lean{MPOTensor.PhysicalSectorFactorization.leftPairMatrix_physicalPairBond,
+      MPOTensor.PhysicalSectorFactorization.rightPairMatrix_physicalPairBond}
+    \leanok
+    \uses{def:mpdo_physical_two_site_bond,
+      def:mpdo_three_site_pair_lifts,
+      def:mpdo_three_site_physical_coordinate_isometry}
+    The two physical lifts are the congruences
+    \[
+      (B_{\mathrm{physical}})_{01}=V_3^\dagger C_{01}V_3,
+      \qquad
+      (B_{\mathrm{physical}})_{12}=V_3^\dagger C_{12}V_3.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Expand $B_{\mathrm{physical}}=V_2^\dagger
+    B_{\mathrm{sector}}V_2$. For the right lift, the mixed-product identity
+    gives the displayed congruence directly. For the left lift, first apply
+    the associator from $(H\otimes H)\otimes H$ to
+    $H\otimes(H\otimes H)$ and then use the same identity.
+\end{proof}
+
+\begin{theorem}[Adjacent physical bonds commute on three sites]
+    \label{thm:mpdo_physical_adjacent_bonds_comm_three}
+    \lean{MPOTensor.PhysicalSectorFactorization.physicalPairBond_adjacent_comm_three,
+      MPOTensor.PhysicalSectorFactorization.physicalBond_adjacent_comm_three}
+    \leanok
+    \uses{thm:mpdo_three_site_pair_lifts,
+      thm:mpdo_sector_coordinate_adjacent_bonds_comm,
+      thm:mpdo_three_site_adjacent_bond_transport}
+    On a three-site chain,
+    \[
+      (B_{\mathrm{physical}})_{01}(B_{\mathrm{physical}})_{12}
+      =(B_{\mathrm{physical}})_{12}(B_{\mathrm{physical}})_{01}.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Insert $V_3V_3^\dagger=I$ between the two congruences in
+    Theorem~\ref{thm:mpdo_three_site_adjacent_bond_transport}, and use
+    Theorem~\ref{thm:mpdo_sector_coordinate_adjacent_bonds_comm}. The
+    translation identities then give the assertion for three-site
+    configuration indices.
+\end{proof}
+
 \begin{definition}[Closed sector tensors]%
     \label{def:mpdo_closed_sector_tensors}
     \lean{MPOTensor.closedSectorL}


### PR DESCRIPTION
## Summary

This change completes the three-site physical commutator in arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`), lines 1589–1593:

`B₀₁ B₁₂ = B₁₂ B₀₁`.

It adds:

- the right-associated three-site physical coordinate matrix and its isometry/coisometry identities;
- explicit forward and inverse-compatible two-/three-site sector regrouping identities;
- left and right block-diagonal formulas for the lifted sector-coordinate bond;
- assembly of fixed-sector commutativity over all sector triples;
- exact left and right transport identities through the three-site physical coordinate matrix;
- commutativity of the physical pair lifts;
- the final theorem `physicalBond_adjacent_comm_three` for `embedLocalOperator` at sites `0` and `1` on three sites;
- synchronized blueprint statements and an updated remaining-scope remark.

No positivity, saturation of the area law, zero correlation length, injectivity, or normalization hypothesis is used. On sector `(k,l,h)`, the two operators act on the distinct factors `R_k ⊗ L_l` and `R_l ⊗ L_h` exactly as in the source.

The pull request does not claim pairwise commutativity on every periodic chain. The disjoint-window reduction, the crossed two-site ordering, and the all-length product realization remain later steps under parent #823.

Closes #3796.

## Verification

- direct Lean checks of all three edited modules;
- targeted module build (3665 jobs);
- `lake build` after rebasing onto current `main` (9337 jobs; only pre-existing warnings);
- root `lake env lean TNLean.lean`;
- `cd blueprint && leanblueprint checkdecls` after rebasing;
- blueprint declaration synchronization and reverse coverage;
- reader-facing prose, proof-integrity, line-length, file-size, and `git diff --check` checks;
- two independent reviews, including a focused audit of dependent sigma indices, off-diagonal delta cases, associator direction, and `#print axioms`.

## Faithfulness

The blueprint marks only the three-site sector-coordinate commutator, its unitary transport, and the resulting three-site physical commutator. It explicitly leaves arbitrary periodic-chain commutativity—including the special crossed ordering at length two—and the all-length product formula open.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large formal proof surface (~400+ lines) with intricate index/regrouping logic; incorrect lemmas could break downstream MPDO commuting-form work, but changes are localized to pure Lean math with no runtime or auth impact.
> 
> **Overview**
> Completes **Proposition C.8 (`3to4`)** for three sites: adjacent embedded physical bonds at sites 0 and 1 commute (`B₀₁ B₁₂ = B₁₂ B₀₁`).
> 
> The proof chains **fixed-sector** `adjacentSectorBonds_comm` through **three-site sector regrouping** (new block-diagonal formulas for left/right sector-coordinate lifts), **assembly** over all sector triples (`sectorCoordinateBond_adjacent_comm_three`), **unitary transport** via new `physicalCoordinateMatrixThree` and left/right pair congruences, then **`physicalBond_adjacent_comm_three`** via `embedLocalOperator` reindexing.
> 
> Supporting additions: `physicalCoordinateMatrixThree` with isometry/coisometry lemmas; forward/inverse **two- and three-site regrouping** simp lemmas in `PhysicalSectorClosureGlobal`; blueprint theorems and an updated remark that **periodic-chain** commutativity and the all-length product identity remain open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec241b1b714a34a7fc4218fedcf18d5857e3ff53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->