### PR TITLE
feat(MPS/MPDO): prove weighted zipper identities

### DIFF
--- a/TNLean/MPS/MPDO/BNTFusionIsometries.lean
+++ b/TNLean/MPS/MPDO/BNTFusionIsometries.lean
@@ -26,6 +26,19 @@ idempotent identity for the trace scalars of the vertical decomposition; that
 condition is recorded separately by the idempotent coefficient predicate of
 `TNLean.MPS.MPDO.BNTCoefficients`.
 
+The fusion identity and $U_{\alpha,\beta}^\dagger U_{\alpha,\beta}=1$ also give the two
+chi-weighted zipper equations
+\[
+  U_{\alpha,\beta}(M_\alpha M_\beta)^{ij}=G_{\alpha,\beta}^{ij}U_{\alpha,\beta},
+  \qquad
+  (M_\alpha M_\beta)^{ij}U_{\alpha,\beta}^\dagger
+    =U_{\alpha,\beta}^\dagger G_{\alpha,\beta}^{ij},
+\]
+where $G_{\alpha,\beta}^{ij}=\bigoplus_\gamma
+\chi_{\alpha,\beta,\gamma}\otimes M_\gamma^{ij}$.  These are weighted analogues of the zipper
+condition of arXiv:1511.08090; the unweighted condition requires a separate specialization of
+the chi matrices.
+
 From the fusion identity the same-length product law of statement (ii)
 follows for the concrete operator family: for every positive chain length,
 \[
@@ -120,6 +133,73 @@ namespace BNTFusionIsometryFamily
 
 variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {p : ℕ}
 variable (Fam : BNTFusionIsometryFamily Λ p)
+
+/-- **The fusion map carries a product letter to its weighted direct sum.**
+
+For every pair of labels and physical indices,
+\[
+  U_{\alpha,\beta}(M_\alpha M_\beta)^{ij}
+    = \left(\bigoplus_\gamma
+        \chi_{\alpha,\beta,\gamma}\otimes M_\gamma^{ij}\right)U_{\alpha,\beta}.
+\]
+This is the first direction of the chi-weighted zipper identity.  It follows from the fusion
+identity by multiplying on the right by the isometry and using
+$U_{\alpha,\beta}^\dagger U_{\alpha,\beta}=1$.
+
+The corresponding equation in arXiv:1511.08090 has identity weights on the multiplicity
+spaces.  No identification of the positive diagonal chi indices with those fusion
+multiplicities is asserted here.
+
+Source: arXiv:1606.00608, Theorem 4.14(iii), equation `Ualphabeta`; arXiv:1511.08090,
+Section ``Fusion tensors'', equations `inversegaugeone` and `zippercondition2`. -/
+theorem fusionIsometry_mul_mulTensor (α β : Λ) (i j : Fin p) :
+    Fam.fusionIsometry α β * mulTensor (Fam.tensor α) (Fam.tensor β) i j =
+      (Matrix.blockDiagonal' fun γ =>
+        Fam.chi.matrix α β γ ⊗ₖ Fam.tensor γ i j) * Fam.fusionIsometry α β := by
+  calc
+    Fam.fusionIsometry α β * mulTensor (Fam.tensor α) (Fam.tensor β) i j =
+        (Fam.fusionIsometry α β * mulTensor (Fam.tensor α) (Fam.tensor β) i j *
+          (Fam.fusionIsometry α β)ᴴ) * Fam.fusionIsometry α β := by
+      rw [Matrix.mul_assoc, Fam.isometry, Matrix.mul_one]
+    _ = (Matrix.blockDiagonal' fun γ =>
+        Fam.chi.matrix α β γ ⊗ₖ Fam.tensor γ i j) * Fam.fusionIsometry α β := by
+      rw [Fam.fusion]
+
+/-- **A product letter carries the adjoint fusion map to its weighted direct sum.**
+
+For every pair of labels and physical indices,
+\[
+  (M_\alpha M_\beta)^{ij}U_{\alpha,\beta}^\dagger
+    = U_{\alpha,\beta}^\dagger
+      \left(\bigoplus_\gamma
+        \chi_{\alpha,\beta,\gamma}\otimes M_\gamma^{ij}\right).
+\]
+This is the second direction of the chi-weighted zipper identity.  It follows from the fusion
+identity by multiplying on the left by the adjoint isometry and using
+$U_{\alpha,\beta}^\dagger U_{\alpha,\beta}=1$.
+
+The corresponding equation in arXiv:1511.08090 has identity weights on the multiplicity
+spaces.  The length-independent integer specialization removes the chi weights.  It does not
+by itself construct an $F$-move: zipper completeness and final-label separation remain
+necessary.
+
+Source: arXiv:1606.00608, Theorem 4.14(iii), equation `Ualphabeta`; arXiv:1511.08090,
+Section ``Fusion tensors'', equations `inversegaugeone` and `zippercondition2`. -/
+theorem mulTensor_mul_fusionIsometry_conjTranspose (α β : Λ) (i j : Fin p) :
+    mulTensor (Fam.tensor α) (Fam.tensor β) i j * (Fam.fusionIsometry α β)ᴴ =
+      (Fam.fusionIsometry α β)ᴴ *
+        Matrix.blockDiagonal' fun γ =>
+          Fam.chi.matrix α β γ ⊗ₖ Fam.tensor γ i j := by
+  calc
+    mulTensor (Fam.tensor α) (Fam.tensor β) i j * (Fam.fusionIsometry α β)ᴴ =
+        (Fam.fusionIsometry α β)ᴴ *
+          (Fam.fusionIsometry α β * mulTensor (Fam.tensor α) (Fam.tensor β) i j *
+            (Fam.fusionIsometry α β)ᴴ) := by
+      rw [← Matrix.mul_assoc, ← Matrix.mul_assoc, Fam.isometry, Matrix.one_mul]
+    _ = (Fam.fusionIsometry α β)ᴴ *
+        Matrix.blockDiagonal' fun γ =>
+          Fam.chi.matrix α β γ ⊗ₖ Fam.tensor γ i j := by
+      rw [Fam.fusion]
 
 /-- **The same-length product law with trace-power coefficients**: for every
 positive chain length, the product of two labelled operators expands over the

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -222,6 +222,43 @@ them.
     Definition~\ref{def:mpdo_bnt_label_idempotent_coefficient_form}.
 \end{definition}
 
+\begin{theorem}[Weighted zipper identities]%
+    \label{thm:mpdo_bnt_weighted_zipper}
+    \lean{MPOTensor.BNTFusionIsometryFamily.fusionIsometry_mul_mulTensor}
+    \lean{MPOTensor.BNTFusionIsometryFamily.%
+        mulTensor_mul_fusionIsometry_conjTranspose}
+    \leanok
+    \uses{def:mpdo_bnt_fusion_isometry_family}
+    For every pair of labels and physical indices, write
+    \[
+        G_{\alpha,\beta}^{ij}
+        = \bigoplus_\gamma \chi_{\alpha,\beta,\gamma}
+            \otimes M_\gamma^{ij}.
+    \]
+    The fusion isometry satisfies the two chi-weighted zipper identities
+    \[
+        U_{\alpha,\beta}(M_\alpha M_\beta)^{ij}
+          = G_{\alpha,\beta}^{ij}U_{\alpha,\beta},
+        \qquad
+        (M_\alpha M_\beta)^{ij}U_{\alpha,\beta}^\dagger
+          = U_{\alpha,\beta}^\dagger G_{\alpha,\beta}^{ij}.
+    \]
+    The corresponding identities in
+    \cite[Equation~(21)]{Bultinck2017Anyons} have identity matrices on
+    the multiplicity spaces in place of the positive diagonal matrices
+    $\chi$.  Their unweighted form requires the length-independent integer
+    specialization and is not a consequence of the present hypotheses. Even
+    after that specialization, zipper completeness and final-label separation
+    are still needed to construct an invertible $F$-move.
+\end{theorem}
+\begin{proof}\leanok
+    Multiply the fusion identity
+    $U_{\alpha,\beta}(M_\alpha M_\beta)^{ij}U_{\alpha,\beta}^\dagger
+      =G_{\alpha,\beta}^{ij}$ on the right by $U_{\alpha,\beta}$ and on the
+    left by $U_{\alpha,\beta}^\dagger$, respectively, and use
+    $U_{\alpha,\beta}^\dagger U_{\alpha,\beta}=1$.
+\end{proof}
+
 \begin{definition}[Operator family of a fusion-isometry family]%
     \label{def:mpdo_bnt_fusion_operator_family}
     \lean{MPOTensor.BNTFusionIsometryFamily.toOperatorFamily}


### PR DESCRIPTION
## Mathematical purpose

This pull request records the two χ-weighted zipper identities that follow directly from the BNT fusion identity and the isometry relation `U†U = 1`:

`U (Mα Mβ)^{ij} = G^{ij}_{αβ} U`

and
`(Mα Mβ)^{ij} U† = U† G^{ij}_{αβ}`,

where `G^{ij}_{αβ} = ⊕γ χαβγ ⊗ Mγ^{ij}`.

These are the weighted analogues of the zipper equation in arXiv:1511.08090. The pull request keeps the positive diagonal χ factors explicit. The length-independent integer specialization is needed to remove those weights, but it does not by itself construct an invertible F-move: zipper completeness and final-label separation remain necessary.

Fixed-final row restrictions are not asserted here, because the restricted maps are not themselves isometries; those identities should descend from the full left/right triple-fusion zipper relations in a later step.

Advances #3776.

## Verification

- `lake env lean TNLean/MPS/MPDO/BNTFusionIsometries.lean`
- `lake build TNLean.MPS.MPDO.BNTFusionIsometries`
- full `lake build`
- `lake exe lint_style TNLean/MPS/MPDO/BNTFusionIsometries.lean`
- blueprint synchronization and `cd blueprint && leanblueprint checkdecls`
- reader-facing prose and proof-integrity scans
- `git diff --check`
- independent audit of both multiplication orientations and source scope

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds formal lemmas and documentation only; no runtime behavior, APIs, or security-sensitive logic—changes are localized to MPDO fusion-isometry theory.
> 
> **Overview**
> Derives the two **χ-weighted zipper identities** for `BNTFusionIsometryFamily` from the existing fusion conjugation identity and `U†U = 1`, keeping the positive diagonal χ blocks explicit in `G^{ij}_{αβ}`.
> 
> Adds Lean theorems `fusionIsometry_mul_mulTensor` and `mulTensor_mul_fusionIsometry_conjTranspose` (short `calc` proofs via `Matrix.mul_assoc` and the isometry field), expands the module doc to state the equations and their relation to arXiv:1511.08090, and syncs blueprint **Theorem** `thm:mpdo_bnt_weighted_zipper` with the same statement and proof sketch. The prose notes that unweighted Bultinck-style zippers and an invertible **F**-move still need further specialization and completeness hypotheses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fbfb6cf745f8ba7c4754758071f87bec650d870. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->