### PR TITLE
feat(MPS/MPDO): lift adjacent bond commutativity

### DIFF
--- a/TNLean/MPS/MPDO/CommutingForm.lean
+++ b/TNLean/MPS/MPDO/CommutingForm.lean
@@ -37,7 +37,7 @@ commuting-form witness and proves the GSNNCH equivalence built from that data.
   Section 4.4 and Appendix C.2
 -/
 
-open scoped Matrix BigOperators ComplexOrder
+open scoped Matrix Kronecker BigOperators ComplexOrder
 open Matrix Finset
 
 namespace MPOTensor
@@ -75,6 +75,168 @@ noncomputable def embedLocalOperator (L N : ℕ) (hLN : L ≤ N) (i : Fin N)
         B (MPSTensor.extractWindow L i σ) (MPSTensor.extractWindow L i τ)
       else 0 :=
   rfl
+
+/-- Two configurations agree outside a cyclic window exactly when their values
+coincide at every site outside that window. -/
+theorem agreesOutsideWindow_iff (L : ℕ) {N : ℕ} (hLN : L ≤ N)
+    (i : Fin N) (σ τ : Fin N → Fin d) :
+    AgreesOutsideWindow (d := d) L hLN i σ τ ↔
+      ∀ k : Fin N, ¬ ((k.val + N - i.val) % N < L) → τ k = σ k := by
+  constructor
+  · intro h k hk
+    have hk' := congrFun h k
+    simpa [AgreesOutsideWindow, MPSTensor.replaceWindow, hk] using hk'
+  · intro h
+    rw [AgreesOutsideWindow]
+    funext k
+    unfold MPSTensor.replaceWindow
+    by_cases hk : (k.val + N - i.val) % N < L
+    · rw [dif_pos hk]
+      have hself := congrFun (MPSTensor.replaceWindow_extractWindow L hLN i σ) k
+      simpa [MPSTensor.replaceWindow, hk] using hself
+    · simp [hk, h k hk]
+
+/-- Decompose a periodic configuration into a cyclic window and its cyclic
+complement. -/
+private def windowComplementEquiv (L N : ℕ) (hLN : L ≤ N) (i : Fin N) :
+    (Fin N → Fin d) ≃ ((Fin L → Fin d) × (Fin (N - L) → Fin d)) where
+  toFun σ :=
+    (MPSTensor.extractWindow L i σ,
+      fun r ↦ σ ⟨(i.val + L + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩)
+  invFun x := fun k ↦
+    let offset := (k.val + N - i.val) % N
+    if h : offset < L then x.1 ⟨offset, h⟩
+    else x.2 ⟨offset - L, by
+      have hoffN : offset < N := Nat.mod_lt _ (Fin.pos i)
+      omega⟩
+  left_inv σ := by
+    funext k
+    simp only
+    let offset := (k.val + N - i.val) % N
+    have hoffN : offset < N := Nat.mod_lt _ (Fin.pos i)
+    have hsite : (i.val + offset) % N = k.val := by
+      rcases lt_or_ge k.val i.val with hki | hik
+      · have hmod : offset = k.val + N - i.val := by
+          simp only [offset]
+          rw [Nat.mod_eq_of_lt (by omega)]
+        rw [hmod, show i.val + (k.val + N - i.val) = k.val + N by omega,
+          Nat.add_mod_right, Nat.mod_eq_of_lt k.isLt]
+      · have hmod : offset = k.val - i.val := by
+          simp only [offset]
+          have heq : k.val + N - i.val = N + (k.val - i.val) := by omega
+          rw [heq, Nat.add_mod_left,
+            Nat.mod_eq_of_lt (lt_of_le_of_lt (Nat.sub_le _ _) k.isLt)]
+        rw [hmod, Nat.add_sub_of_le hik, Nat.mod_eq_of_lt k.isLt]
+    by_cases hoff : offset < L
+    · rw [dif_pos hoff]
+      exact congrArg σ (Fin.ext hsite)
+    · rw [dif_neg hoff]
+      apply congrArg σ
+      apply Fin.ext
+      change (i.val + L + (offset - L)) % N = k.val
+      calc
+        _ = (i.val + offset) % N := by congr 1; omega
+        _ = k.val := hsite
+  right_inv x := by
+    apply Prod.ext
+    · funext r
+      simp only [MPSTensor.extractWindow]
+      have hoff : (((i.val + r.val) % N + N - i.val) % N) = r.val :=
+        MPSTensor.offset_mod_eq i.isLt (Nat.lt_of_lt_of_le r.isLt hLN)
+      rw [dif_pos (hoff.symm ▸ r.isLt)]
+      exact congrArg x.1 (Fin.ext hoff)
+    · funext r
+      simp only
+      have hrN : L + r.val < N := by omega
+      have hoff :
+          (((i.val + L + r.val) % N + N - i.val) % N) = L + r.val := by
+        simpa [Nat.add_assoc] using MPSTensor.offset_mod_eq i.isLt hrN
+      have hnot :
+          ¬ (((i.val + L + r.val) % N + N - i.val) % N) < L := by
+        omega
+      rw [dif_neg hnot]
+      apply congrArg x.2
+      apply Fin.ext
+      change (((i.val + L + r.val) % N + N - i.val) % N) - L = r.val
+      omega
+
+@[simp] private theorem windowComplementEquiv_replaceWindow
+    (L N : ℕ) (hLN : L ≤ N) (i : Fin N)
+    (σ : Fin N → Fin d) (τ : Fin L → Fin d) :
+    windowComplementEquiv (d := d) L N hLN i
+        (MPSTensor.replaceWindow L hLN i σ τ) =
+      (τ, (windowComplementEquiv (d := d) L N hLN i σ).2) := by
+  apply Prod.ext
+  · exact MPSTensor.extractWindow_replaceWindow L hLN i σ τ
+  · funext r
+    simp only [windowComplementEquiv, Equiv.coe_fn_mk]
+    unfold MPSTensor.replaceWindow
+    have hrN : L + r.val < N := by omega
+    have hoff :
+        (((i.val + L + r.val) % N + N - i.val) % N) = L + r.val := by
+      simpa [Nat.add_assoc] using MPSTensor.offset_mod_eq i.isLt hrN
+    have hnot :
+        ¬ (((i.val + L + r.val) % N + N - i.val) % N) < L := by
+      omega
+    rw [dif_neg hnot]
+
+/-- In cyclic-window coordinates, a local operator is the tensor product of
+the window operator with the identity on the complement. -/
+private theorem reindex_embedLocalOperator_windowComplement
+    (L N : ℕ) (hLN : L ≤ N) (i : Fin N)
+    (B : Matrix (Fin L → Fin d) (Fin L → Fin d) ℂ) :
+    Matrix.reindex (windowComplementEquiv (d := d) L N hLN i)
+        (windowComplementEquiv (d := d) L N hLN i)
+        (embedLocalOperator (d := d) L N hLN i B) =
+      B ⊗ₖ (1 : Matrix (Fin (N - L) → Fin d) (Fin (N - L) → Fin d) ℂ) := by
+  let e := windowComplementEquiv (d := d) L N hLN i
+  ext ⟨x, u⟩ ⟨y, v⟩
+  let σ := e.symm (x, u)
+  let τ := e.symm (y, v)
+  have heσ : e σ = (x, u) := e.apply_symm_apply (x, u)
+  have heτ : e τ = (y, v) := e.apply_symm_apply (y, v)
+  have hx : MPSTensor.extractWindow L i σ = x := congrArg Prod.fst heσ
+  have hy : MPSTensor.extractWindow L i τ = y := congrArg Prod.fst heτ
+  have hAgree : AgreesOutsideWindow (d := d) L hLN i σ τ ↔ v = u := by
+    constructor
+    · intro h
+      have heq := congrArg e h
+      have hsnd := congrArg Prod.snd heq
+      simpa [e, σ, τ] using hsnd
+    · intro h
+      apply e.injective
+      rw [windowComplementEquiv_replaceWindow, heσ, heτ, h, hx]
+  by_cases h : v = u
+  · change (if AgreesOutsideWindow (d := d) L hLN i σ τ then
+        B (MPSTensor.extractWindow L i σ) (MPSTensor.extractWindow L i τ) else 0) =
+      B x y * (if u = v then 1 else 0)
+    rw [if_pos (hAgree.mpr h), hx, hy, if_pos h.symm, mul_one]
+  · change (if AgreesOutsideWindow (d := d) L hLN i σ τ then
+        B (MPSTensor.extractWindow L i σ) (MPSTensor.extractWindow L i τ) else 0) =
+      B x y * (if u = v then 1 else 0)
+    rw [if_neg (hAgree.not.mpr h), if_neg (Ne.symm h), mul_zero]
+
+/-- Embedding two operators into the same cyclic window preserves their
+product. -/
+theorem embedLocalOperator_mul (L N : ℕ) (hLN : L ≤ N) (i : Fin N)
+    (B C : Matrix (Fin L → Fin d) (Fin L → Fin d) ℂ) :
+    embedLocalOperator (d := d) L N hLN i (B * C) =
+      embedLocalOperator (d := d) L N hLN i B *
+        embedLocalOperator (d := d) L N hLN i C := by
+  let e := windowComplementEquiv (d := d) L N hLN i
+  apply (Matrix.reindex e e).injective
+  change (Matrix.reindexLinearEquiv ℂ ℂ e e)
+      (embedLocalOperator (d := d) L N hLN i (B * C)) =
+    (Matrix.reindexLinearEquiv ℂ ℂ e e)
+      (embedLocalOperator (d := d) L N hLN i B *
+        embedLocalOperator (d := d) L N hLN i C)
+  rw [← Matrix.reindexLinearEquiv_mul ℂ ℂ e e e,
+    Matrix.coe_reindexLinearEquiv,
+    reindex_embedLocalOperator_windowComplement,
+    reindex_embedLocalOperator_windowComplement,
+    reindex_embedLocalOperator_windowComplement,
+    ← Matrix.mul_kronecker_mul]
+  simp
 
 /-- Chain-level commuting-form data for the simple-MPDO theorem.
 

--- a/TNLean/MPS/MPDO/PhysicalSectorBondTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorBondTransport.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.PhysicalSectorBondCommutativity
+import TNLean.MPS.ParentHamiltonian.CyclicWindow
 
 /-!
 # Transport of adjacent physical-sector bonds
@@ -23,6 +24,196 @@ open scoped Matrix Kronecker
 namespace MPOTensor.PhysicalSectorFactorization
 
 variable {d D : ℕ} {K : MPOTensor d D}
+
+private theorem extractWindow_two_eq_zero_of_three {N : ℕ}
+    (i : Fin N) (σ : Fin N → Fin d) :
+    MPSTensor.extractWindow 2 i σ =
+      MPSTensor.extractWindow 2 (0 : Fin 3) (MPSTensor.extractWindow 3 i σ) := by
+  funext r
+  fin_cases r <;> simp [MPSTensor.extractWindow, Nat.mod_eq_of_lt i.isLt]
+
+private theorem extractWindow_two_finRotate_eq_one_of_three {N : ℕ}
+    (i : Fin N) (σ : Fin N → Fin d) :
+    MPSTensor.extractWindow 2 (finRotate N i) σ =
+      MPSTensor.extractWindow 2 (1 : Fin 3) (MPSTensor.extractWindow 3 i σ) := by
+  have hrot : (finRotate N i).val = (i.val + 1) % N := by
+    simp [finRotate_apply, Fin.add_def]
+  funext r
+  apply congrArg σ
+  apply Fin.ext
+  fin_cases r
+  · simp [Fin.add_def]
+  · simp only [Fin.val_one, hrot]
+    rw [Nat.mod_add_mod]
+
+private theorem agreesOutsideWindow_two_zero_three_iff
+    (σ τ : Fin 3 → Fin d) :
+    AgreesOutsideWindow (d := d) 2 (by decide) (0 : Fin 3) σ τ ↔
+      τ 2 = σ 2 := by
+  rw [agreesOutsideWindow_iff]
+  constructor
+  · intro h
+    exact h 2 (by decide)
+  · intro h k hk
+    fin_cases k
+    · simp at hk
+    · simp at hk
+    · exact h
+
+private theorem agreesOutsideWindow_two_one_three_iff
+    (σ τ : Fin 3 → Fin d) :
+    AgreesOutsideWindow (d := d) 2 (by decide) (1 : Fin 3) σ τ ↔
+      τ 0 = σ 0 := by
+  rw [agreesOutsideWindow_iff]
+  constructor
+  · intro h
+    exact h 0 (by decide)
+  · intro h k hk
+    fin_cases k
+    · exact h
+    · simp at hk
+    · simp at hk
+
+private theorem offset_from_finRotate {N : ℕ} (hN : 2 ≤ N) (i k : Fin N) :
+    (k.val + N - (finRotate N i).val) % N =
+      if (k.val + N - i.val) % N = 0 then N - 1
+      else (k.val + N - i.val) % N - 1 := by
+  let r := (k.val + N - i.val) % N
+  have hrN : r < N := Nat.mod_lt _ (by omega)
+  have hrot : (finRotate N i).val = (i.val + 1) % N := by
+    simp [finRotate_apply, Fin.add_def]
+  by_cases hr : r = 0
+  · have hk : k = i := by
+      have hk' := MPSTensor.eq_cyclic_site_of_offset_eq (Fin.pos i) hr
+      simpa [Nat.mod_eq_of_lt i.isLt] using hk'
+    subst k
+    rw [if_pos hr]
+    by_cases hi : i.val + 1 < N
+    · rw [hrot, Nat.mod_eq_of_lt hi]
+      have heq : i.val + N - (i.val + 1) = N - 1 := by omega
+      rw [heq, Nat.mod_eq_of_lt (by omega)]
+    · have hiN : i.val + 1 = N := by omega
+      rw [hrot, hiN, Nat.mod_self]
+      simp only [Nat.sub_zero, Nat.add_mod_right, Nat.mod_eq_of_lt i.isLt]
+      omega
+  · rw [if_neg hr]
+    change (k.val + N - (finRotate N i).val) % N = r - 1
+    have hk : k = ⟨((finRotate N i).val + (r - 1)) % N,
+        Nat.mod_lt _ (by omega)⟩ := by
+      have hk' := MPSTensor.eq_cyclic_site_of_offset_eq (Fin.pos i)
+        (i := i) (k := k) (r := r) rfl
+      apply Fin.ext
+      change k.val = ((finRotate N i).val + (r - 1)) % N
+      calc
+        k.val = (i.val + r) % N := congrArg Fin.val hk'
+        _ = (i.val + 1 + (r - 1)) % N := by congr 1; omega
+        _ = ((i.val + 1) % N + (r - 1)) % N := by rw [Nat.mod_add_mod]
+        _ = ((finRotate N i).val + (r - 1)) % N := by rw [hrot]
+    rw [hk, MPSTensor.offset_mod_eq (finRotate N i).isLt (by omega : r - 1 < N)]
+
+private theorem embedLocalOperator_two_zero_nested {N : ℕ} (hN : 3 ≤ N)
+    (i : Fin N) (B : Matrix (Fin 2 → Fin d) (Fin 2 → Fin d) ℂ) :
+    embedLocalOperator (d := d) 3 N (by omega) i
+        (embedLocalOperator (d := d) 2 3 (by decide) (0 : Fin 3) B) =
+      embedLocalOperator (d := d) 2 N (by omega) i B := by
+  ext σ τ
+  have hAgree :
+      (AgreesOutsideWindow (d := d) 3 (by omega) i σ τ ∧
+        AgreesOutsideWindow (d := d) 2 (by decide) (0 : Fin 3)
+          (MPSTensor.extractWindow 3 i σ) (MPSTensor.extractWindow 3 i τ)) ↔
+        AgreesOutsideWindow (d := d) 2 (by omega) i σ τ := by
+    rw [agreesOutsideWindow_two_zero_three_iff]
+    constructor
+    · rintro ⟨h3, h2⟩
+      rw [agreesOutsideWindow_iff] at h3 ⊢
+      intro k hk2
+      by_cases hk3 : (k.val + N - i.val) % N < 3
+      · have hoff : (k.val + N - i.val) % N = 2 := by omega
+        have hk := MPSTensor.eq_cyclic_site_of_offset_eq (Fin.pos i) hoff
+        subst k
+        simpa [MPSTensor.extractWindow, Nat.mod_eq_of_lt (by omega : 2 < N)] using h2
+      · exact h3 k hk3
+    · intro h2
+      rw [agreesOutsideWindow_iff] at h2
+      constructor
+      · rw [agreesOutsideWindow_iff]
+        intro k hk3
+        exact h2 k (by omega)
+      · apply h2
+        change ¬ (((i.val + 2) % N + N - i.val) % N < 2)
+        rw [MPSTensor.offset_mod_eq i.isLt (by omega : 2 < N)]
+        omega
+  simp only [embedLocalOperator_apply]
+  rw [extractWindow_two_eq_zero_of_three i σ,
+    extractWindow_two_eq_zero_of_three i τ]
+  by_cases h3 : AgreesOutsideWindow (d := d) 3 (by omega) i σ τ
+  · rw [if_pos h3]
+    by_cases h2 : AgreesOutsideWindow (d := d) 2 (by decide) (0 : Fin 3)
+        (MPSTensor.extractWindow 3 i σ) (MPSTensor.extractWindow 3 i τ)
+    · rw [if_pos h2, if_pos (hAgree.mp ⟨h3, h2⟩)]
+    · rw [if_neg h2, if_neg (fun h ↦ h2 (hAgree.mpr h).2)]
+  · rw [if_neg h3, if_neg (fun h ↦ h3 (hAgree.mpr h).1)]
+
+private theorem embedLocalOperator_two_one_nested {N : ℕ} (hN : 3 ≤ N)
+    (i : Fin N) (B : Matrix (Fin 2 → Fin d) (Fin 2 → Fin d) ℂ) :
+    embedLocalOperator (d := d) 3 N (by omega) i
+        (embedLocalOperator (d := d) 2 3 (by decide) (1 : Fin 3) B) =
+      embedLocalOperator (d := d) 2 N (by omega) (finRotate N i) B := by
+  ext σ τ
+  have hAgree :
+      (AgreesOutsideWindow (d := d) 3 (by omega) i σ τ ∧
+        AgreesOutsideWindow (d := d) 2 (by decide) (1 : Fin 3)
+          (MPSTensor.extractWindow 3 i σ) (MPSTensor.extractWindow 3 i τ)) ↔
+        AgreesOutsideWindow (d := d) 2 (by omega) (finRotate N i) σ τ := by
+    rw [agreesOutsideWindow_two_one_three_iff]
+    constructor
+    · rintro ⟨h3, hlocal⟩
+      rw [agreesOutsideWindow_iff] at h3 ⊢
+      intro k hk
+      let r := (k.val + N - i.val) % N
+      have hoff := offset_from_finRotate (by omega : 2 ≤ N) i k
+      by_cases hr : r = 0
+      · have hki := MPSTensor.eq_cyclic_site_of_offset_eq (Fin.pos i)
+          (i := i) (k := k) (r := r) rfl
+        have hki' : k = i := by simpa [hr, Nat.mod_eq_of_lt i.isLt] using hki
+        have hiEq : τ i = σ i := by
+          simpa [MPSTensor.extractWindow, Nat.mod_eq_of_lt i.isLt] using hlocal
+        simpa [hki'] using hiEq
+      · apply h3 k
+        change ¬ r < 3
+        change ¬ ((k.val + N - (finRotate N i).val) % N < 2) at hk
+        rw [hoff, if_neg hr] at hk
+        omega
+    · intro h2
+      rw [agreesOutsideWindow_iff] at h2
+      constructor
+      · rw [agreesOutsideWindow_iff]
+        intro k hk3
+        apply h2 k
+        let r := (k.val + N - i.val) % N
+        have hoff := offset_from_finRotate (by omega : 2 ≤ N) i k
+        have hr : r ≠ 0 := by
+          change ¬ r < 3 at hk3
+          omega
+        rw [hoff, if_neg hr]
+        change ¬ r < 3 at hk3
+        omega
+      · have hi := h2 i
+        have hoff := offset_from_finRotate (by omega : 2 ≤ N) i i
+        have hzero : (i.val + N - i.val) % N = 0 := by
+          rw [show i.val + N - i.val = N by omega, Nat.mod_self]
+        specialize hi (by rw [hoff, if_pos hzero]; omega)
+        simpa [MPSTensor.extractWindow, Nat.mod_eq_of_lt i.isLt] using hi
+  simp only [embedLocalOperator_apply]
+  rw [extractWindow_two_finRotate_eq_one_of_three i σ,
+    extractWindow_two_finRotate_eq_one_of_three i τ]
+  by_cases h3 : AgreesOutsideWindow (d := d) 3 (by omega) i σ τ
+  · rw [if_pos h3]
+    by_cases h2 : AgreesOutsideWindow (d := d) 2 (by decide) (1 : Fin 3)
+        (MPSTensor.extractWindow 3 i σ) (MPSTensor.extractWindow 3 i τ)
+    · rw [if_pos h2, if_pos (hAgree.mp ⟨h3, h2⟩)]
+    · rw [if_neg h2, if_neg (fun h ↦ h2 (hAgree.mpr h).2)]
+  · rw [if_neg h3, if_neg (fun h ↦ h3 (hAgree.mpr h).1)]
 
 /-- The first two sites extracted from the inverse three-site regrouping have
 the expected two-site outer and neighboring coordinates.
@@ -412,5 +603,40 @@ theorem physicalBond_zero_one_comm (F : PhysicalSectorFactorization K) :
       (finThreeArrowEquiv (Fin d)) (finThreeArrowEquiv (Fin d)),
     Matrix.coe_reindexLinearEquiv, F.reindex_embedLocalOperator_zero,
     F.reindex_embedLocalOperator_one, F.physicalPairBonds_comm]
+
+/-- Adjacent translates of the physical bond commute on every periodic chain
+of length at least three, including the pair crossing the periodic boundary.
+
+The two-site chain is excluded because its two translated windows have the
+same support with opposite cyclic order, rather than forming the three-site
+configuration used in the source calculation.
+
+**Scope restriction (N ≥ 3):** The two-site crossed-order commutator remains
+open, as documented in
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.  Elimination:
+prove the `N = 2` crossed-order commutator separately.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8, lines 1571--1593. -/
+theorem physicalBond_adjacent_comm (F : PhysicalSectorFactorization K)
+    {N : ℕ} (hN : 3 ≤ N) (i : Fin N) :
+    embedLocalOperator (d := d) 2 N (by omega) i F.physicalBond *
+        embedLocalOperator (d := d) 2 N (by omega) (finRotate N i) F.physicalBond =
+      embedLocalOperator (d := d) 2 N (by omega) (finRotate N i) F.physicalBond *
+        embedLocalOperator (d := d) 2 N (by omega) i F.physicalBond := by
+  let P := embedLocalOperator (d := d) 2 3 (by decide) (0 : Fin 3) F.physicalBond
+  let Q := embedLocalOperator (d := d) 2 3 (by decide) (1 : Fin 3) F.physicalBond
+  calc
+    _ = embedLocalOperator (d := d) 3 N (by omega) i P *
+        embedLocalOperator (d := d) 3 N (by omega) i Q := by
+      rw [embedLocalOperator_two_zero_nested, embedLocalOperator_two_one_nested]
+    _ = embedLocalOperator (d := d) 3 N (by omega) i (P * Q) := by
+      rw [embedLocalOperator_mul]
+    _ = embedLocalOperator (d := d) 3 N (by omega) i (Q * P) := by
+      rw [F.physicalBond_zero_one_comm]
+    _ = embedLocalOperator (d := d) 3 N (by omega) i Q *
+        embedLocalOperator (d := d) 3 N (by omega) i P := by
+      rw [embedLocalOperator_mul]
+    _ = _ := by
+      rw [embedLocalOperator_two_zero_nested, embedLocalOperator_two_one_nested]
 
 end MPOTensor.PhysicalSectorFactorization

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -254,9 +254,10 @@
     (\ref{eq:mpdo_eta_bond_assembly}) and~(\ref{eq:mpdo_eta_product_form}) are
     exactly the $\eta$-local product hypothesis; after that,
     Theorem~\ref{thm:mpdo_has_commuting_form_of_eta_local_structure}
-    gives the commuting-form conclusion. The adjacent physical commutator is
-    Theorem~\ref{thm:mpdo_physical_adjacent_bonds_comm}. Its extension to
-    pairwise commutativity on every periodic chain and the all-length product
+    gives the commuting-form conclusion. Adjacent translates commute on every
+    periodic chain of length at least three by
+    Theorem~\ref{thm:mpdo_periodic_adjacent_physical_bonds_comm}. Pairwise
+    commutativity, the exceptional two-site chain, and the all-length product
     identity in~(\ref{eq:mpdo_eta_product_form}) remain open.
     The doubled-index transfer condition enters only in the subsequent RFP and
     GSNNCH branch conclusions.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -1321,6 +1321,69 @@ strong subadditivity for a normalized three-site reduced state.
     commutator.
 \end{proof}
 
+\begin{theorem}[Agreement outside a cyclic window]
+    \label{thm:mpdo_agreement_outside_cyclic_window}
+    \lean{MPOTensor.agreesOutsideWindow_iff}
+    \leanok
+    Let $W_i^L=\{i,i+1,\ldots,i+L-1\}$ be a cyclic window of length
+    $L\leq N$. Two configurations agree outside $W_i^L$ precisely when their
+    values agree at every site not contained in $W_i^L$.
+\end{theorem}
+
+\begin{proof}\leanok
+    Replacing the entries in $W_i^L$ does not affect any complementary site.
+    Conversely, if the two configurations agree on the complement, replacing
+    the window of the first by the window of the second reconstructs the
+    second configuration.
+\end{proof}
+
+\begin{theorem}[Multiplicativity of cyclic local embeddings]
+    \label{thm:mpdo_cyclic_local_embedding_mul}
+    \lean{MPOTensor.embedLocalOperator_mul}
+    \leanok
+    Let $E_i^L$ embed an operator on $L$ consecutive sites into an
+    $N$-site periodic chain at the cyclic window beginning at $i$. Then
+    \[
+        E_i^L(BC)=E_i^L(B)E_i^L(C).
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    Identify a periodic configuration with its restriction to $W_i^L$ and
+    its restriction to the cyclic complement. In these coordinates,
+    $E_i^L(B)=B\otimes I$, so the assertion is the mixed-product identity.
+\end{proof}
+
+\begin{theorem}[Adjacent physical bonds on periodic chains]
+    \label{thm:mpdo_periodic_adjacent_physical_bonds_comm}
+    \lean{MPOTensor.PhysicalSectorFactorization.physicalBond_adjacent_comm}
+    \leanok
+    \uses{thm:mpdo_cyclic_local_embedding_mul,
+      thm:mpdo_physical_adjacent_bonds_comm}
+    Let $N\geq 3$. For every site $i\in\mathbb Z/N\mathbb Z$, including
+    $i=N-1$, the adjacent translates of the physical bond commute:
+    \[
+      (B_{\mathrm{physical}})_{i,i+1}
+      (B_{\mathrm{physical}})_{i+1,i+2}
+      =
+      (B_{\mathrm{physical}})_{i+1,i+2}
+      (B_{\mathrm{physical}})_{i,i+1}.
+    \]
+    This is the periodic-chain form of the adjacent-bond calculation in
+    \cite[Appendix~C.2, Proposition~C.8, lines~1571--1593]
+      {Cirac2016MPDO_arXiv}. The case $N=2$ is excluded because its two
+    translated bonds have the same support with opposite cyclic order.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Enclose the two bonds in the cyclic three-site window beginning at $i$.
+    In these coordinates they are the bonds beginning at sites $0$ and $1$,
+    respectively. Embedding an operator into a fixed cyclic window preserves
+    products, so the assertion follows from
+    Theorem~\ref{thm:mpdo_physical_adjacent_bonds_comm}.
+\end{proof}
+
 \begin{definition}[Closed sector tensors]%
     \label{def:mpdo_closed_sector_tensors}
     \lean{MPOTensor.closedSectorL}

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -454,11 +454,13 @@ is a generally nonconstant primitive nonnegative matrix.  Thus the two
 families cannot be identified without an additional theorem; in general they
 are not equal.
 
-Beyond the neighboring operators, two further steps
-remain.  First, the translation-invariant bond $B_{n,n+1}$ above must be
-defined in the original physical coordinates and proved positive, with
-commuting translates.  Second, one must transport the cyclic sector identity
-through the local unitary to prove the finite-chain realization
+The translation-invariant bond $B_{n,n+1}$ is now defined in the original
+physical coordinates and proved positive.  Adjacent translates commute on
+every periodic chain of length at least three, including the pair crossing
+the periodic boundary.  The two-site crossed-order commutator and the
+nonadjacent cases needed for full pairwise commutativity remain open.
+One must also transport the cyclic sector identity through the local unitary
+to prove the finite-chain realization
 \[
   \sigma^{(N)}(K)=c_N\prod_{n=1}^N B_{n,n+1}
 \]
@@ -498,6 +500,11 @@ single vertex-indexed rescaling coherent across a whole recurrent component
 records an elimination plan using the uniqueness of the rescaling phase).
 The primitivity of $T_{k,h}$ also remains open, and cannot be used to
 derive recurrence without circularity.
+
+For the conditional bond construction, adjacent translates commute for every
+chain length $N\geq 3$, including the wraparound pair.  The $N=2$
+crossed-order commutator, the remaining nonadjacent cases required for full
+pairwise commutativity, and the finite-chain product realization remain open.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Mathematical purpose

This pull request lifts the three-site adjacent physical-bond commutator from #3804 to every translated three-site window on a periodic chain of length `N ≥ 3`. The theorem uses `finRotate N i`, so the case `i = N-1` includes the wraparound pair `(N-1,0)` and `(0,1)`.

The proof first establishes generic cyclic local-operator infrastructure:

- a pointwise characterization of agreement outside a cyclic window;
- multiplicativity of embedding into a fixed cyclic window.

It then identifies the bonds at `i` and `i+1` with local positions `0` and `1` inside the translated three-site window and applies `physicalBond_zero_one_comm`.

**Scope restriction (`N ≥ 3`).** The two-site chain is excluded because its two translated windows have the same support with opposite cyclic order. Its crossed-order commutator remains a separate calculation. Nonadjacent pairwise commutativity and the all-length product realization also remain open. The existing paper-gap note is updated accordingly.

Advances #823.

## Verification

- direct Lean checks for `CommutingForm.lean` and `PhysicalSectorBondTransport.lean`
- targeted and full `lake build`
- `lake exe lint_style` on both changed Lean modules
- blueprint synchronization and `cd blueprint && leanblueprint checkdecls`
- reader-facing prose and proof-integrity scans
- `git diff --check`
- independent audit of cyclic offsets, nesting orientations, and the `N-1 → 0` wraparound case

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new formal proofs in cyclic indexing and nested embeddings; incorrect window or `finRotate` reasoning could silently break the lift from the three-site case, though scope is confined to MPDO transport and commuting-form infrastructure.
> 
> **Overview**
> Adds **cyclic local-operator infrastructure** in `CommutingForm.lean`: `agreesOutsideWindow_iff`, a window/complement reindexing, and **`embedLocalOperator_mul`** (embedding respects products via a Kronecker-with-identity picture).
> 
> In **`PhysicalSectorBondTransport.lean`**, proves **`physicalBond_adjacent_comm`**: for `N ≥ 3` and every site `i` (including wraparound via `finRotate`), adjacent translates of `physicalBond` commute. The proof nests two-site bonds in a three-site cyclic window, uses the new multiplicativity lemma, and applies the existing **`physicalBond_zero_one_comm`**. Supporting lemmas cover three-site nesting, `finRotate` offsets, and agreement outside windows on `Fin 3`.
> 
> **Blueprint** (`ch21_mpdo_rfp_simple_local_structure.tex`, `ch21_mpdo_rfp_commuting_form_gsnnch.tex`) and **`docs/paper-gaps/...`** are updated to record the new theorem and that **`N = 2`**, full pairwise commutativity, and the finite-chain product identity remain open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c7490d64e672f5ed887a9c5ceba17c298e15f77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->