### PR TITLE
feat(MPS/MPDO): prove crossed two-site bond commutativity

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -413,6 +413,7 @@ import TNLean.MPS.MPDO.PhysicalSectorCoordinateTransport
 import TNLean.MPS.MPDO.PhysicalSectorPositiveBond
 import TNLean.MPS.MPDO.PhysicalSectorBondCommutativity
 import TNLean.MPS.MPDO.PhysicalSectorBondTransport
+import TNLean.MPS.MPDO.PhysicalSectorBondTwoSite
 import TNLean.MPS.MPDO.PhysicalSectorPhysicalTransport
 import TNLean.MPS.MPDO.SectorPairingTransfer
 import TNLean.MPS.MPDO.SectorEtaContraction

--- a/TNLean/MPS/MPDO/PhysicalSectorBondTwoSite.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorBondTwoSite.lean
@@ -1,0 +1,291 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalSectorBondTransport
+
+/-!
+# The crossed two-site translates of the physical-sector bond
+
+On a periodic chain of length two, the translates of a two-site bond beginning
+at sites `0` and `1` read the sites in the opposite cyclic orders `(0, 1)` and
+`(1, 0)`.  This file isolates that finite-size case.  In fixed sector
+coordinates `(k, h)`, the first translate acts on
+$R_k \otimes L_h$, whereas the crossed translate acts on the complementary
+factor $R_h \otimes L_k$.  Hence the two translates commute.
+
+Appendix C.2, Proposition C.8 of arXiv:1606.00608 proves commutativity of the
+translated bonds.  The source does not discuss this crossed two-site ordering
+separately.
+-/
+
+open scoped Matrix Kronecker
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D}
+
+/-- Exchange the two factors of a matrix indexed by ordered pairs. -/
+private noncomputable def swapPairMatrix {n : Type*}
+    (B : Matrix (n × n) (n × n) ℂ) : Matrix (n × n) (n × n) ℂ :=
+  Matrix.reindex (Equiv.prodComm n n) (Equiv.prodComm n n) B
+
+/-- The tensor square of a matrix is unchanged when both its row pair and
+column pair are exchanged. -/
+private theorem reindex_prodComm_kronecker_self
+    {m n : Type*}
+    (A : Matrix m n ℂ) :
+    Matrix.reindex (Equiv.prodComm m m) (Equiv.prodComm n n) (A ⊗ₖ A) =
+      A ⊗ₖ A := by
+  ext ⟨i, j⟩ ⟨p, q⟩
+  simp [Matrix.reindex_apply, Matrix.kroneckerMap_apply, mul_comm]
+
+/-- Exchanging both physical sites commutes with a change of coordinates
+which is the tensor square of one single-site coordinate matrix. -/
+private theorem swapPairMatrix_sandwich_kronecker_self
+    {m n : Type*} [Fintype m] [Fintype n]
+    (A : Matrix m n ℂ) (B : Matrix (m × m) (m × m) ℂ) :
+    swapPairMatrix (sandwichMap (A ⊗ₖ A)ᴴ B) =
+      sandwichMap (A ⊗ₖ A)ᴴ (swapPairMatrix B) := by
+  let em := Equiv.prodComm m m
+  let en := Equiv.prodComm n n
+  have hA : Matrix.reindex em en (A ⊗ₖ A) = A ⊗ₖ A :=
+    reindex_prodComm_kronecker_self A
+  have hAH : Matrix.reindex en em (A ⊗ₖ A)ᴴ = (A ⊗ₖ A)ᴴ := by
+    ext x y
+    have h := congrArg star (congrFun (congrFun hA y) x)
+    simpa [Matrix.reindex_apply, star_mul', mul_comm] using h
+  simp only [swapPairMatrix, sandwichMap_apply,
+    Matrix.conjTranspose_conjTranspose]
+  change (Matrix.reindexLinearEquiv ℂ ℂ en en)
+      ((A ⊗ₖ A)ᴴ * B * (A ⊗ₖ A)) =
+    (A ⊗ₖ A)ᴴ * Matrix.reindex em em B * (A ⊗ₖ A)
+  rw [← Matrix.reindexLinearEquiv_mul ℂ ℂ en em en,
+    ← Matrix.reindexLinearEquiv_mul ℂ ℂ en em em,
+    Matrix.coe_reindexLinearEquiv, Matrix.coe_reindexLinearEquiv,
+    Matrix.coe_reindexLinearEquiv, hA, hAH]
+
+/-- Swapping the two sector sites exchanges their sector labels and exchanges
+the outer and neighboring pairs in the regrouped coordinates. -/
+@[simp] private theorem twoSiteGlobalRegroupEquiv_swap_symm
+    (F : PhysicalSectorFactorization K)
+    (k h : Fin F.sectorCount)
+    (x : BoundaryIndex F k h × NeighborIndex F k h) :
+    F.twoSiteGlobalRegroupEquiv
+        (F.twoSiteGlobalRegroupEquiv.symm ⟨(k, h), x⟩).swap =
+      ⟨(h, k), (x.2.swap, x.1.swap)⟩ := by
+  apply F.twoSiteGlobalRegroupEquiv.symm.injective
+  rw [Equiv.symm_apply_apply, twoSiteGlobalRegroupEquiv_symm_apply]
+  rfl
+
+/-- The crossed bond on a fixed `(k,h)` sector block.  It acts on the outer
+factor $L_k \otimes R_h$, leaving the neighboring factor fixed. -/
+private noncomputable def crossedSectorBond (F : PhysicalSectorFactorization K)
+    (k h : Fin F.sectorCount) :
+    Matrix (BoundaryIndex F k h × NeighborIndex F k h)
+      (BoundaryIndex F k h × NeighborIndex F k h) ℂ :=
+  Matrix.reindex (Equiv.prodComm _ _) (Equiv.prodComm _ _)
+      (F.neighboringOperator h k) ⊗ₖ
+    (1 : Matrix (NeighborIndex F k h) (NeighborIndex F k h) ℂ)
+
+/-- On a fixed sector pair, the ordinary and crossed two-site bonds act on
+complementary tensor factors and hence commute. -/
+private theorem fixedSectorBond_crossed_comm
+    (F : PhysicalSectorFactorization K) (k h : Fin F.sectorCount) :
+    ((1 : Matrix (BoundaryIndex F k h) (BoundaryIndex F k h) ℂ) ⊗ₖ
+        F.neighboringOperator k h) * F.crossedSectorBond k h =
+      F.crossedSectorBond k h *
+        ((1 : Matrix (BoundaryIndex F k h) (BoundaryIndex F k h) ℂ) ⊗ₖ
+          F.neighboringOperator k h) := by
+  simp only [crossedSectorBond, ← Matrix.mul_kronecker_mul]
+  simp
+
+/-- Regrouping the swapped sector-coordinate bond gives the dependent direct
+sum of the crossed fixed-sector bonds. -/
+private theorem reindex_swapPairMatrix_sectorCoordinateBond
+    (F : PhysicalSectorFactorization K) :
+    Matrix.reindex F.twoSiteGlobalRegroupEquiv F.twoSiteGlobalRegroupEquiv
+        (swapPairMatrix F.sectorCoordinateBond) =
+      Matrix.blockDiagonal' fun kh :
+          Fin F.sectorCount × Fin F.sectorCount ↦
+        F.crossedSectorBond kh.1 kh.2 := by
+  ext ⟨kh, x⟩ ⟨pq, y⟩
+  rcases kh with ⟨k, h⟩
+  rcases pq with ⟨p, q⟩
+  simp only [Matrix.reindex_apply, Matrix.submatrix_apply, swapPairMatrix,
+    sectorCoordinateBond, Equiv.symm_symm]
+  change Matrix.blockDiagonal' (fun kh :
+      Fin F.sectorCount × Fin F.sectorCount =>
+      (1 : Matrix (BoundaryIndex F kh.1 kh.2)
+        (BoundaryIndex F kh.1 kh.2) ℂ) ⊗ₖ F.neighboringOperator kh.1 kh.2)
+        (F.twoSiteGlobalRegroupEquiv
+          (F.twoSiteGlobalRegroupEquiv.symm ⟨(k, h), x⟩).swap)
+        (F.twoSiteGlobalRegroupEquiv
+          (F.twoSiteGlobalRegroupEquiv.symm ⟨(p, q), y⟩).swap) = _
+  rw [twoSiteGlobalRegroupEquiv_swap_symm,
+    twoSiteGlobalRegroupEquiv_swap_symm]
+  by_cases hk : k = p
+  · subst p
+    by_cases hh : h = q
+    · subst q
+      simp [crossedSectorBond, Matrix.one_apply, Prod.ext_iff, mul_comm]
+      by_cases hx : x.2.1 = y.2.1 <;>
+        by_cases hy : x.2.2 = y.2.2 <;> simp_all
+    · simp [Matrix.blockDiagonal'_apply, hh, crossedSectorBond]
+  · simp [Matrix.blockDiagonal'_apply, hk, crossedSectorBond]
+
+/-- Regrouping the ordinary sector-coordinate bond recovers its defining
+fixed-sector blocks. -/
+private theorem reindex_sectorCoordinateBond
+    (F : PhysicalSectorFactorization K) :
+    Matrix.reindex F.twoSiteGlobalRegroupEquiv F.twoSiteGlobalRegroupEquiv
+        F.sectorCoordinateBond =
+      Matrix.blockDiagonal' fun kh :
+          Fin F.sectorCount × Fin F.sectorCount ↦
+        (1 : Matrix (BoundaryIndex F kh.1 kh.2)
+          (BoundaryIndex F kh.1 kh.2) ℂ) ⊗ₖ
+            F.neighboringOperator kh.1 kh.2 := by
+  simp [sectorCoordinateBond]
+
+/-- The sector-coordinate bond commutes with the bond obtained by exchanging
+the two sites. -/
+private theorem sectorCoordinateBond_swap_comm
+    (F : PhysicalSectorFactorization K) :
+    F.sectorCoordinateBond * swapPairMatrix F.sectorCoordinateBond =
+      swapPairMatrix F.sectorCoordinateBond * F.sectorCoordinateBond := by
+  apply (Matrix.reindex F.twoSiteGlobalRegroupEquiv
+    F.twoSiteGlobalRegroupEquiv).injective
+  change (Matrix.reindexLinearEquiv ℂ ℂ F.twoSiteGlobalRegroupEquiv
+      F.twoSiteGlobalRegroupEquiv) (_ * _) =
+    (Matrix.reindexLinearEquiv ℂ ℂ F.twoSiteGlobalRegroupEquiv
+      F.twoSiteGlobalRegroupEquiv) (_ * _)
+  rw [← Matrix.reindexLinearEquiv_mul ℂ ℂ F.twoSiteGlobalRegroupEquiv
+      F.twoSiteGlobalRegroupEquiv F.twoSiteGlobalRegroupEquiv,
+    ← Matrix.reindexLinearEquiv_mul ℂ ℂ F.twoSiteGlobalRegroupEquiv
+      F.twoSiteGlobalRegroupEquiv F.twoSiteGlobalRegroupEquiv,
+    Matrix.coe_reindexLinearEquiv, F.reindex_sectorCoordinateBond,
+    F.reindex_swapPairMatrix_sectorCoordinateBond,
+    ← Matrix.blockDiagonal'_mul, ← Matrix.blockDiagonal'_mul]
+  congr
+  funext kh
+  exact F.fixedSectorBond_crossed_comm kh.1 kh.2
+
+/-- The physical pair bond commutes with the same bond in the opposite site
+order. -/
+private theorem physicalPairBond_swap_comm
+    (F : PhysicalSectorFactorization K) :
+    F.physicalPairBond * swapPairMatrix F.physicalPairBond =
+      swapPairMatrix F.physicalPairBond * F.physicalPairBond := by
+  have hswap :
+      swapPairMatrix
+          (sandwichMap F.physicalCoordinateMatrixTwoᴴ F.sectorCoordinateBond) =
+        sandwichMap F.physicalCoordinateMatrixTwoᴴ
+          (swapPairMatrix F.sectorCoordinateBond) := by
+    simpa only [physicalCoordinateMatrixTwo] using
+      swapPairMatrix_sandwich_kronecker_self
+        F.physicalCoordinateMatrix F.sectorCoordinateBond
+  rw [physicalPairBond, hswap]
+  simp only [sandwichMap_apply, Matrix.conjTranspose_conjTranspose]
+  calc
+    _ = F.physicalCoordinateMatrixTwoᴴ * F.sectorCoordinateBond *
+        (F.physicalCoordinateMatrixTwo * F.physicalCoordinateMatrixTwoᴴ) *
+        swapPairMatrix F.sectorCoordinateBond *
+        F.physicalCoordinateMatrixTwo := by simp only [Matrix.mul_assoc]
+    _ = F.physicalCoordinateMatrixTwoᴴ *
+        (F.sectorCoordinateBond * swapPairMatrix F.sectorCoordinateBond) *
+        F.physicalCoordinateMatrixTwo := by
+      rw [F.physicalCoordinateMatrixTwo_coisometry]
+      simp [Matrix.mul_assoc]
+    _ = F.physicalCoordinateMatrixTwoᴴ *
+        (swapPairMatrix F.sectorCoordinateBond * F.sectorCoordinateBond) *
+        F.physicalCoordinateMatrixTwo := by
+      rw [F.sectorCoordinateBond_swap_comm]
+    _ = F.physicalCoordinateMatrixTwoᴴ *
+        swapPairMatrix F.sectorCoordinateBond *
+        (F.physicalCoordinateMatrixTwo * F.physicalCoordinateMatrixTwoᴴ) *
+        F.sectorCoordinateBond * F.physicalCoordinateMatrixTwo := by
+      rw [F.physicalCoordinateMatrixTwo_coisometry]
+      simp [Matrix.mul_assoc]
+    _ = _ := by simp only [Matrix.mul_assoc]
+
+/-- On the two-site periodic chain, the translate beginning at site zero is
+the original pair matrix after identifying configurations with ordered pairs.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8.  The source does not
+separately state the crossed finite-size case. -/
+private theorem reindex_embedLocalOperator_two_zero
+    (F : PhysicalSectorFactorization K) :
+    Matrix.reindex (finTwoArrowEquiv (Fin d)) (finTwoArrowEquiv (Fin d))
+        (embedLocalOperator (d := d) 2 2 (by decide) (0 : Fin 2) F.physicalBond) =
+      F.physicalPairBond := by
+  ext σ τ
+  have hAgree : AgreesOutsideWindow (d := d) 2 (by decide) (0 : Fin 2)
+      ((finTwoArrowEquiv (Fin d)).symm σ)
+      ((finTwoArrowEquiv (Fin d)).symm τ) := by
+    funext i
+    fin_cases i <;>
+      simp [MPSTensor.replaceWindow, MPSTensor.extractWindow, finTwoArrowEquiv]
+  simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
+    embedLocalOperator_apply]
+  rw [if_pos hAgree]
+  simp [physicalBond, MPSTensor.extractWindow, finTwoArrowEquiv]
+
+/-- On the two-site periodic chain, the translate beginning at site one is
+the pair matrix with its two tensor factors exchanged.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8.  The source does not
+separately state the crossed finite-size case. -/
+private theorem reindex_embedLocalOperator_two_one
+    (F : PhysicalSectorFactorization K) :
+    Matrix.reindex (finTwoArrowEquiv (Fin d)) (finTwoArrowEquiv (Fin d))
+        (embedLocalOperator (d := d) 2 2 (by decide) (1 : Fin 2) F.physicalBond) =
+      swapPairMatrix F.physicalPairBond := by
+  ext σ τ
+  have hAgree : AgreesOutsideWindow (d := d) 2 (by decide) (1 : Fin 2)
+      ((finTwoArrowEquiv (Fin d)).symm σ)
+      ((finTwoArrowEquiv (Fin d)).symm τ) := by
+    funext i
+    fin_cases i <;>
+      simp [MPSTensor.replaceWindow, MPSTensor.extractWindow, finTwoArrowEquiv]
+  simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
+    embedLocalOperator_apply]
+  rw [if_pos hAgree]
+  simp [swapPairMatrix, physicalBond, MPSTensor.extractWindow,
+    finTwoArrowEquiv]
+  rfl
+
+/-- The two oppositely ordered translates of the physical bond commute on the
+periodic chain of length two.
+
+In sector coordinates `(k,h)`, the translate beginning at site zero acts on
+$R_k \otimes L_h$, while the translate beginning at site one acts on
+$R_h \otimes L_k$.  No positivity, strong-area-law, zero-correlation-length,
+or injectivity hypothesis is used.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8.  The source proves
+commutativity of translated bonds but does not discuss this crossed two-site
+ordering separately.
+
+**Local finite-size clarification:** The opposite cyclic ordering at length
+two is recorded in
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`. -/
+theorem physicalBond_two_zero_one_comm (F : PhysicalSectorFactorization K) :
+    embedLocalOperator (d := d) 2 2 (by decide) (0 : Fin 2) F.physicalBond *
+        embedLocalOperator (d := d) 2 2 (by decide) (1 : Fin 2) F.physicalBond =
+      embedLocalOperator (d := d) 2 2 (by decide) (1 : Fin 2) F.physicalBond *
+        embedLocalOperator (d := d) 2 2 (by decide) (0 : Fin 2) F.physicalBond := by
+  apply (Matrix.reindex (finTwoArrowEquiv (Fin d))
+    (finTwoArrowEquiv (Fin d))).injective
+  change (Matrix.reindexLinearEquiv ℂ ℂ (finTwoArrowEquiv (Fin d))
+      (finTwoArrowEquiv (Fin d))) (_ * _) =
+    (Matrix.reindexLinearEquiv ℂ ℂ (finTwoArrowEquiv (Fin d))
+      (finTwoArrowEquiv (Fin d))) (_ * _)
+  rw [← Matrix.reindexLinearEquiv_mul ℂ ℂ (finTwoArrowEquiv (Fin d))
+      (finTwoArrowEquiv (Fin d)) (finTwoArrowEquiv (Fin d)),
+    ← Matrix.reindexLinearEquiv_mul ℂ ℂ (finTwoArrowEquiv (Fin d))
+      (finTwoArrowEquiv (Fin d)) (finTwoArrowEquiv (Fin d)),
+    Matrix.coe_reindexLinearEquiv, F.reindex_embedLocalOperator_two_zero,
+    F.reindex_embedLocalOperator_two_one, F.physicalPairBond_swap_comm]
+
+end MPOTensor.PhysicalSectorFactorization

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -256,9 +256,11 @@
     Theorem~\ref{thm:mpdo_has_commuting_form_of_eta_local_structure}
     gives the commuting-form conclusion. Adjacent translates commute on every
     periodic chain of length at least three by
-    Theorem~\ref{thm:mpdo_periodic_adjacent_physical_bonds_comm}. Pairwise
-    commutativity, the exceptional two-site chain, and the all-length product
-    identity in~(\ref{eq:mpdo_eta_product_form}) remain open.
+    Theorem~\ref{thm:mpdo_periodic_adjacent_physical_bonds_comm}, and the
+    crossed two-site case is
+    Theorem~\ref{thm:mpdo_physical_two_site_crossed_bonds_comm}. The remaining
+    nonadjacent cases needed for full pairwise commutativity and the all-length
+    product identity in~(\ref{eq:mpdo_eta_product_form}) remain open.
     The doubled-index transfer condition enters only in the subsequent RFP and
     GSNNCH branch conclusions.
 \end{remark}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -1371,8 +1371,9 @@ strong subadditivity for a normalized three-site reduced state.
     \]
     This is the periodic-chain form of the adjacent-bond calculation in
     \cite[Appendix~C.2, Proposition~C.8, lines~1571--1593]
-      {Cirac2016MPDO_arXiv}. The case $N=2$ is excluded because its two
-    translated bonds have the same support with opposite cyclic order.
+      {Cirac2016MPDO_arXiv}. The case $N=2$ is treated separately below,
+    because its two translated bonds have the same support with opposite
+    cyclic order.
 \end{theorem}
 
 \begin{proof}
@@ -1382,6 +1383,44 @@ strong subadditivity for a normalized three-site reduced state.
     respectively. Embedding an operator into a fixed cyclic window preserves
     products, so the assertion follows from
     Theorem~\ref{thm:mpdo_physical_adjacent_bonds_comm}.
+\end{proof}
+
+\begin{theorem}[Commutativity of the crossed two-site translates]
+    \label{thm:mpdo_physical_two_site_crossed_bonds_comm}
+    \lean{MPOTensor.PhysicalSectorFactorization.physicalBond_two_zero_one_comm}
+    \leanok
+    \uses{def:mpdo_global_sector_closure_coordinates,
+      def:mpdo_physical_sector_two_site_bond,
+      def:mpdo_physical_two_site_bond}
+    On the periodic chain of length two, the translates beginning at sites
+    zero and one read the physical sites in the opposite cyclic orders
+    $(0,1)$ and $(1,0)$.  Nevertheless they commute:
+    \[
+      B_{01}B_{10}=B_{10}B_{01}.
+    \]
+    This is the length-two instance of the translated-bond commutativity in
+    \cite[Appendix~C.2, Proposition~C.8]{Cirac2016MPDO_arXiv}.  The source
+    does not discuss the crossed finite-size ordering separately.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Fix sectors $(k,h)$ and regroup the two physical sites as
+    \[
+      (L_k\otimes R_h)\otimes(R_k\otimes L_h).
+    \]
+    The translate in the order $(0,1)$ is
+    \[
+      I_{L_k\otimes R_h}\otimes\eta_{k,h},
+    \]
+    while the translate in the order $(1,0)$ is
+    \[
+      \eta_{h,k}^{\mathrm{op}}\otimes I_{R_k\otimes L_h},
+    \]
+    where $\eta_{h,k}^{\mathrm{op}}$ denotes the same matrix after exchanging
+    the factors $R_h$ and $L_k$.  These operators act on complementary
+    factors and commute.  Taking the direct sum over $(k,h)$ and conjugating
+    by the two-fold physical coordinate unitary proves the claim.
 \end{proof}
 
 \begin{definition}[Closed sector tensors]%

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -457,10 +457,28 @@ are not equal.
 The translation-invariant bond $B_{n,n+1}$ is now defined in the original
 physical coordinates and proved positive.  Adjacent translates commute on
 every periodic chain of length at least three, including the pair crossing
-the periodic boundary.  The two-site crossed-order commutator and the
-nonadjacent cases needed for full pairwise commutativity remain open.
-One must also transport the cyclic sector identity through the local unitary
-to prove the finite-chain realization
+the periodic boundary.  The exceptional chain of length two is also covered:
+the translates beginning at sites zero and one read the sites in the opposite
+cyclic orders.  On the $(k,h)$ sector block they act,
+respectively, as
+\[
+  I_{L_k\otimes R_h}\otimes\eta_{k,h},
+  \qquad
+  \eta_{h,k}^{\mathrm{op}}\otimes I_{R_k\otimes L_h},
+\]
+and therefore commute on complementary tensor factors.  Proposition~C.8 does
+not discuss this crossed finite-size ordering separately, although it is an
+instance of its translated-bond conclusion.\footnote{The formal declarations
+are
+\leanid{MPOTensor.PhysicalSectorFactorization.physicalBond_adjacent_comm} and
+\leanid{MPOTensor.PhysicalSectorFactorization.physicalBond_two_zero_one_comm}.}
+
+Two global steps remain.  First, the local calculations must be assembled
+into pairwise commutativity of all translates on every periodic chain length;
+the remaining case is commutativity of nonadjacent, disjoint translates by
+locality, followed by the finite case distinction assembling the pairwise
+statement.  Second, one must transport the cyclic sector identity through the
+local unitary to prove the finite-chain realization
 \[
   \sigma^{(N)}(K)=c_N\prod_{n=1}^N B_{n,n+1}
 \]
@@ -502,9 +520,9 @@ The primitivity of $T_{k,h}$ also remains open, and cannot be used to
 derive recurrence without circularity.
 
 For the conditional bond construction, adjacent translates commute for every
-chain length $N\geq 3$, including the wraparound pair.  The $N=2$
-crossed-order commutator, the remaining nonadjacent cases required for full
-pairwise commutativity, and the finite-chain product realization remain open.
+chain length $N\geq 2$, including the wraparound and crossed two-site cases.
+The remaining nonadjacent cases required for full pairwise commutativity and
+the finite-chain product realization remain open.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Mathematical purpose

This pull request proves the exceptional two-site periodic case left open by #3807. On a chain of length two, the translates beginning at sites `0` and `1` read the same two physical sites in opposite cyclic orders.

After regrouping the `(k,h)` sector, the ordinary and crossed translates act as

`I_{L_k ⊗ R_h} ⊗ η_{k,h}`

and
`η_{h,k}^{op} ⊗ I_{R_k ⊗ L_h}`,

respectively. They commute because they act on complementary tensor factors. The proof assembles these sector blocks and transports the equality through the common two-site physical coordinate unitary.

The resulting theorem `physicalBond_two_zero_one_comm` assumes only the physical-sector factorization; it adds no positivity, SAL, ZCL, injectivity, trace, support, or recurrence hypothesis. Proposition C.8 does not discuss this crossed finite-size ordering separately, so the blueprint and gap note state that source-status point explicitly.

Together with #3807, adjacent translates now commute for every periodic chain length `N ≥ 2`. Nonadjacent/disjoint translate commutativity, final pairwise assembly, and finite-chain product realization remain open.

Advances #823.

## Verification

- direct Lean check of `PhysicalSectorBondTwoSite.lean` and `TNLean.lean`
- targeted and full `lake build`
- `lake exe lint_style TNLean/MPS/MPDO/PhysicalSectorBondTwoSite.lean`
- blueprint synchronization, web/PDF builds, and `leanblueprint checkdecls`
- visual inspection of the rendered blueprint theorem
- reader-facing prose and proof-integrity scans
- public API audit: only `physicalBond_two_zero_one_comm` is public in the new file
- `git diff --check`
- independent audit of site-swap, direct-sum, and physical-coordinate orientations

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a self-contained formal proof and documentation updates; no changes to runtime behavior or security-sensitive paths.
> 
> **Overview**
> Closes the **length-two periodic** gap left by adjacent-bond commutativity (`N ≥ 3`): on a 2-site ring, translates at sites `0` and `1` use opposite cyclic orderings but still commute.
> 
> A new Lean module proves **`physicalBond_two_zero_one_comm`** from **`PhysicalSectorFactorization` only** (no SAL/ZCL/positivity). The argument regroups sector blocks so the ordinary and crossed translates act on complementary factors (`I ⊗ η` vs swapped `η^{op} ⊗ I`), commutes there, and transports through the two-site physical coordinate unitary. The module is added to the root **`TNLean`** import list.
> 
> **Blueprint** and **`docs/paper-gaps/...eta_local_structure.tex`** now record this theorem and state that adjacent + crossed cases cover **`N ≥ 2`**, while **nonadjacent** pairwise commutativity and the **finite-chain product realization** remain open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 759c8a68764db5d0c471366db214e53805ea96ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->