### PR TITLE
feat(MPS/MPDO): prove disjoint bond commutativity

### DIFF
--- a/TNLean/MPS/MPDO/CommutingForm.lean
+++ b/TNLean/MPS/MPDO/CommutingForm.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.MPDO.RFP
 import TNLean.MPS.ParentHamiltonian.Defs
+import TNLean.MPS.ParentHamiltonian.CyclicWindow
 
 /-!
 # Commuting-form and GSNNCH data for simple MPDOs
@@ -237,6 +238,130 @@ theorem embedLocalOperator_mul (L N : ℕ) (hLN : L ≤ N) (i : Fin N)
     reindex_embedLocalOperator_windowComplement,
     ← Matrix.mul_kronecker_mul]
   simp
+
+/-- The action of a cyclically embedded local operator is the sum over
+replacements of the configuration inside its window. -/
+private theorem embedLocalOperator_mulVec_apply (L N : ℕ) (hLN : L ≤ N) (i : Fin N)
+    (B : Matrix (Fin L → Fin d) (Fin L → Fin d) ℂ)
+    (v : (Fin N → Fin d) → ℂ) (σ : Fin N → Fin d) :
+    (embedLocalOperator (d := d) L N hLN i B).mulVec v σ =
+      ∑ τ : Fin L → Fin d,
+        B (MPSTensor.extractWindow L i σ) τ *
+          v (MPSTensor.replaceWindow L hLN i σ τ) := by
+  let e := windowComplementEquiv (d := d) L N hLN i
+  rw [Matrix.mulVec, dotProduct]
+  calc
+    (∑ τ : Fin N → Fin d,
+        embedLocalOperator (d := d) L N hLN i B σ τ * v τ) =
+        ∑ x : (Fin L → Fin d) × (Fin (N - L) → Fin d),
+          embedLocalOperator (d := d) L N hLN i B σ (e.symm x) * v (e.symm x) :=
+      Fintype.sum_equiv e _ _ fun x ↦ by rw [e.symm_apply_apply]
+    _ = _ := by
+      rw [Fintype.sum_prod_type]
+      apply Finset.sum_congr rfl
+      intro τ _
+      have heσ : e σ =
+          (MPSTensor.extractWindow L i σ, (e σ).2) := by
+        exact Prod.ext rfl rfl
+      have hreplace :
+          e.symm (τ, (e σ).2) = MPSTensor.replaceWindow L hLN i σ τ := by
+        apply e.injective
+        rw [e.apply_symm_apply, windowComplementEquiv_replaceWindow]
+      have hentry (u : Fin (N - L) → Fin d) :
+          embedLocalOperator (d := d) L N hLN i B σ (e.symm (τ, u)) =
+            B (MPSTensor.extractWindow L i σ) τ *
+              (if (e σ).2 = u then 1 else 0) := by
+        have h := congrFun (congrFun
+          (reindex_embedLocalOperator_windowComplement (d := d) L N hLN i B)
+          (e σ)) (τ, u)
+        simp only [Matrix.reindex_apply, Matrix.submatrix_apply, Matrix.kroneckerMap_apply,
+          Matrix.one_apply] at h
+        rw [e.symm_apply_apply] at h
+        rw [show (e σ).1 = MPSTensor.extractWindow L i σ from rfl] at h
+        exact h
+      simp_rw [hentry]
+      rw [Finset.sum_eq_single (e σ).2]
+      · simp [hreplace]
+      · intro u _ hu
+        rw [if_neg (Ne.symm hu), mul_zero, zero_mul]
+      · simp
+
+private theorem cyclicWindowsDisjoint_of_not_overlap {N L : ℕ} (hLN : L ≤ N)
+    {i j : Fin N} (hij : ¬ MPSTensor.cyclicWindowsOverlap N L i j) :
+    ∀ k : Fin N,
+      ((k.val + N - i.val) % N < L) →
+        ((k.val + N - j.val) % N < L) → False := by
+  intro k hki hkj
+  apply hij
+  refine ⟨k, ?_, ?_⟩
+  · exact (MPSTensor.mem_cyclicWindowSupport_iff hLN i k).mpr hki
+  · exact (MPSTensor.mem_cyclicWindowSupport_iff hLN j k).mpr hkj
+
+private theorem extractWindow_replaceWindow_of_not_cyclicWindowsOverlap
+    {N L : ℕ} (hLN : L ≤ N) {i j : Fin N}
+    (hij : ¬ MPSTensor.cyclicWindowsOverlap N L i j)
+    (σ : Fin N → Fin d) (τ : Fin L → Fin d) :
+    MPSTensor.extractWindow L i (MPSTensor.replaceWindow L hLN j σ τ) =
+      MPSTensor.extractWindow L i σ := by
+  funext r
+  unfold MPSTensor.extractWindow MPSTensor.replaceWindow
+  have hi : (((i.val + r.val) % N + N - i.val) % N) < L := by
+    rw [MPSTensor.offset_mod_eq i.isLt (Nat.lt_of_lt_of_le r.isLt hLN)]
+    exact r.isLt
+  have hnotj : ¬ (((i.val + r.val) % N + N - j.val) % N < L) := by
+    intro hj
+    exact cyclicWindowsDisjoint_of_not_overlap hLN hij
+      ⟨(i.val + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩ hi hj
+  rw [dif_neg hnotj]
+
+private theorem replaceWindow_commute_of_not_cyclicWindowsOverlap
+    {N L : ℕ} (hLN : L ≤ N) {i j : Fin N}
+    (hij : ¬ MPSTensor.cyclicWindowsOverlap N L i j)
+    (σ : Fin N → Fin d) (α β : Fin L → Fin d) :
+    MPSTensor.replaceWindow L hLN j (MPSTensor.replaceWindow L hLN i σ α) β =
+      MPSTensor.replaceWindow L hLN i (MPSTensor.replaceWindow L hLN j σ β) α := by
+  funext k
+  have hdisjoint := cyclicWindowsDisjoint_of_not_overlap hLN hij
+  by_cases hi : ((k.val + N - i.val) % N < L)
+  · have hnotj : ¬ ((k.val + N - j.val) % N < L) := fun hj => hdisjoint k hi hj
+    simp [MPSTensor.replaceWindow, hi, hnotj]
+  · by_cases hj : ((k.val + N - j.val) % N < L)
+    · simp [MPSTensor.replaceWindow, hi, hj]
+    · simp [MPSTensor.replaceWindow, hi, hj]
+
+/-- Operators embedded into disjoint cyclic windows commute.
+
+The hypothesis is precisely that the two cyclic supports have no common site.
+No positivity, idempotency, or relation between the two local matrices is
+required.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8, lines
+1571--1593. -/
+theorem embedLocalOperator_commute_of_not_cyclicWindowsOverlap
+    (L N : ℕ) (hLN : L ≤ N) {i j : Fin N}
+    (hij : ¬ MPSTensor.cyclicWindowsOverlap N L i j)
+    (B C : Matrix (Fin L → Fin d) (Fin L → Fin d) ℂ) :
+    embedLocalOperator (d := d) L N hLN i B *
+        embedLocalOperator (d := d) L N hLN j C =
+      embedLocalOperator (d := d) L N hLN j C *
+        embedLocalOperator (d := d) L N hLN i B := by
+  apply Matrix.mulVec_injective
+  funext v σ
+  rw [← Matrix.mulVec_mulVec, ← Matrix.mulVec_mulVec]
+  rw [embedLocalOperator_mulVec_apply, embedLocalOperator_mulVec_apply]
+  simp_rw [embedLocalOperator_mulVec_apply]
+  simp_rw [extractWindow_replaceWindow_of_not_cyclicWindowsOverlap
+    (d := d) hLN hij]
+  simp_rw [extractWindow_replaceWindow_of_not_cyclicWindowsOverlap
+    (d := d) hLN (fun h ↦ hij ((MPSTensor.cyclicWindowsOverlap_comm N L j i).mp h))]
+  simp_rw [Finset.mul_sum]
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro β _
+  apply Finset.sum_congr rfl
+  intro α _
+  rw [replaceWindow_commute_of_not_cyclicWindowsOverlap (d := d) hLN hij]
+  ring
 
 /-- Chain-level commuting-form data for the simple-MPDO theorem.
 

--- a/TNLean/MPS/MPDO/PhysicalSectorBondTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorBondTransport.lean
@@ -639,4 +639,23 @@ theorem physicalBond_adjacent_comm (F : PhysicalSectorFactorization K)
     _ = _ := by
       rw [embedLocalOperator_two_zero_nested, embedLocalOperator_two_one_nested]
 
+/-- Translates of the physical bond with disjoint cyclic supports commute.
+
+This is the locality part of the pairwise commutation assertion in the source.
+It requires no property of the sector factorization beyond the existence of its
+two-site physical bond.  The adjacent, overlapping case is the separate content
+of `physicalBond_adjacent_comm`.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8, lines
+1571--1593. -/
+theorem physicalBond_disjoint_comm (F : PhysicalSectorFactorization K)
+    {N : ℕ} (hN : 2 ≤ N) {i j : Fin N}
+    (hij : ¬ MPSTensor.cyclicWindowsOverlap N 2 i j) :
+    embedLocalOperator (d := d) 2 N hN i F.physicalBond *
+        embedLocalOperator (d := d) 2 N hN j F.physicalBond =
+      embedLocalOperator (d := d) 2 N hN j F.physicalBond *
+        embedLocalOperator (d := d) 2 N hN i F.physicalBond :=
+  embedLocalOperator_commute_of_not_cyclicWindowsOverlap 2 N hN hij
+    F.physicalBond F.physicalBond
+
 end MPOTensor.PhysicalSectorFactorization

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -258,9 +258,12 @@
     periodic chain of length at least three by
     Theorem~\ref{thm:mpdo_periodic_adjacent_physical_bonds_comm}, and the
     crossed two-site case is
-    Theorem~\ref{thm:mpdo_physical_two_site_crossed_bonds_comm}. The remaining
-    nonadjacent cases needed for full pairwise commutativity and the all-length
-    product identity in~(\ref{eq:mpdo_eta_product_form}) remain open.
+    Theorem~\ref{thm:mpdo_physical_two_site_crossed_bonds_comm}. Disjoint
+    translates commute by
+    Theorem~\ref{thm:mpdo_periodic_disjoint_physical_bonds_comm}. The local
+    commutator cases are therefore complete; their finite all-pairs assembly
+    and the all-length product identity
+    in~(\ref{eq:mpdo_eta_product_form}) remain open.
     The doubled-index transfer condition enters only in the subsequent RFP and
     GSNNCH branch conclusions.
 \end{remark}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -1354,6 +1354,27 @@ strong subadditivity for a normalized three-site reduced state.
     $E_i^L(B)=B\otimes I$, so the assertion is the mixed-product identity.
 \end{proof}
 
+\begin{theorem}[Commutativity on disjoint cyclic windows]
+    \label{thm:mpdo_disjoint_cyclic_local_embeddings_comm}
+    \lean{MPOTensor.embedLocalOperator_commute_of_not_cyclicWindowsOverlap}
+    \leanok
+    \uses{lem:cyclic_window_support_offsets,
+      lem:cyclic_windows_overlap_symmetry}
+    Let $L\leq N$, and let $W_i^L$ and $W_j^L$ be disjoint cyclic windows in
+    an $N$-site periodic chain. For arbitrary operators $B$ and $C$ on $L$ sites,
+    \[
+      E_i^L(B)E_j^L(C)=E_j^L(C)E_i^L(B).
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    Apply both sides to a chain amplitude. The first order of application is
+    a double sum over replacements on $W_i^L$ and $W_j^L$. Since the windows
+    are disjoint, each replacement leaves the other restricted configuration
+    unchanged, and the two replacements commute. Interchanging the two finite
+    sums gives the reverse order.
+\end{proof}
+
 \begin{theorem}[Adjacent physical bonds on periodic chains]
     \label{thm:mpdo_periodic_adjacent_physical_bonds_comm}
     \lean{MPOTensor.PhysicalSectorFactorization.physicalBond_adjacent_comm}
@@ -1421,6 +1442,34 @@ strong subadditivity for a normalized three-site reduced state.
     the factors $R_h$ and $L_k$.  These operators act on complementary
     factors and commute.  Taking the direct sum over $(k,h)$ and conjugating
     by the two-fold physical coordinate unitary proves the claim.
+\end{proof}
+
+\begin{theorem}[Disjoint physical bonds on periodic chains]
+    \label{thm:mpdo_periodic_disjoint_physical_bonds_comm}
+    \lean{MPOTensor.PhysicalSectorFactorization.physicalBond_disjoint_comm}
+    \leanok
+    \uses{def:mpdo_physical_two_site_bond,
+      thm:mpdo_disjoint_cyclic_local_embeddings_comm}
+    Let $N\geq 2$, and suppose that the cyclic bonds beginning at $i$ and $j$
+    have disjoint two-site supports. Then their physical bond operators
+    commute:
+    \[
+      (B_{\mathrm{physical}})_{i,i+1}
+      (B_{\mathrm{physical}})_{j,j+1}
+      =
+      (B_{\mathrm{physical}})_{j,j+1}
+      (B_{\mathrm{physical}})_{i,i+1}.
+    \]
+    This is the locality part of the pairwise commutation assertion in
+    \cite[Appendix~C.2, Proposition~C.8, lines~1571--1593]
+      {Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    This is Theorem~\ref{thm:mpdo_disjoint_cyclic_local_embeddings_comm}
+    applied to the same physical bond operator in both windows. No positivity
+    or additional property of the sector factorization is needed for this
+    locality step.
 \end{proof}
 
 \begin{definition}[Closed sector tensors]%

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -473,12 +473,17 @@ are
 \leanid{MPOTensor.PhysicalSectorFactorization.physicalBond_adjacent_comm} and
 \leanid{MPOTensor.PhysicalSectorFactorization.physicalBond_two_zero_one_comm}.}
 
+Translates with disjoint cyclic two-site supports commute by locality, without
+any further physical hypothesis.\footnote{The formal declaration is
+\leanid{MPOTensor.PhysicalSectorFactorization.physicalBond_disjoint_comm}.}
+Thus the adjacent, crossed two-site, and disjoint local commutators are all
+formalized.
+
 Two global steps remain.  First, the local calculations must be assembled
 into pairwise commutativity of all translates on every periodic chain length;
-the remaining case is commutativity of nonadjacent, disjoint translates by
-locality, followed by the finite case distinction assembling the pairwise
-statement.  Second, one must transport the cyclic sector identity through the
-local unitary to prove the finite-chain realization
+only the finite case distinction assembling these local cases into the
+all-pairs statement remains.  Second, one must transport the cyclic sector
+identity through the local unitary to prove the finite-chain realization
 \[
   \sigma^{(N)}(K)=c_N\prod_{n=1}^N B_{n,n+1}
 \]
@@ -521,8 +526,9 @@ derive recurrence without circularity.
 
 For the conditional bond construction, adjacent translates commute for every
 chain length $N\geq 2$, including the wraparound and crossed two-site cases.
-The remaining nonadjacent cases required for full pairwise commutativity and
-the finite-chain product realization remain open.
+Disjoint translates commute at every length for which their two-site cyclic
+supports are disjoint.  The finite all-pairs assembly and the finite-chain
+product realization remain open.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

- prove that arbitrary operators embedded in disjoint cyclic windows commute
- specialize the locality theorem to the physical two-site bond arising from a sector factorization
- update the MPO/RFP blueprint and paper-gap record: adjacent, crossed two-site, and disjoint local commutator cases are complete

No positivity or additional property of the sector factorization is used in the disjoint-support argument. The finite all-pairs assembly and the finite-chain product realization remain separate obligations.

## Verification

- `lake build TNLean`
- `cd blueprint && leanblueprint checkdecls`
- `python3 scripts/blueprint_lean_sync.py --ci`
- direct Lean checks for both changed modules
- style and whitespace checks

Advances #823.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style formal proofs and blueprint/paper-gap narrative updates; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds a **general locality theorem**: two arbitrary `L`-site operators embedded on a periodic chain via `embedLocalOperator` **commute when their cyclic windows do not overlap** (`¬ cyclicWindowsOverlap`), with no positivity or sector hypotheses. The proof is via `mulVec` expansion (`embedLocalOperator_mulVec_apply`) and lemmas that disjoint windows leave each other's `extractWindow` / `replaceWindow` data unchanged.
> 
> **Specialization:** `PhysicalSectorFactorization.physicalBond_disjoint_comm` applies the same result to translated copies of the two-site physical bond when supports are disjoint.
> 
> **Documentation:** Blueprint gains theorems for disjoint cyclic embeddings and periodic disjoint physical bonds; commuting-form / paper-gap text now records that **adjacent, crossed two-site, and disjoint** local commutator cases are formalized, while **finite all-pairs assembly** and the **all-length product identity** remain open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a22cf8a736f6b32afafab38f9f4c053361703f76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->