### PR TITLE
feat(MPS/MPDO): assemble pairwise bond commutativity

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -414,6 +414,7 @@ import TNLean.MPS.MPDO.PhysicalSectorPositiveBond
 import TNLean.MPS.MPDO.PhysicalSectorBondCommutativity
 import TNLean.MPS.MPDO.PhysicalSectorBondTransport
 import TNLean.MPS.MPDO.PhysicalSectorBondTwoSite
+import TNLean.MPS.MPDO.PhysicalSectorBondPairwise
 import TNLean.MPS.MPDO.PhysicalSectorPhysicalTransport
 import TNLean.MPS.MPDO.SectorPairingTransfer
 import TNLean.MPS.MPDO.SectorEtaContraction

--- a/TNLean/MPS/MPDO/PhysicalSectorBondPairwise.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorBondPairwise.lean
@@ -1,0 +1,72 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalSectorBondTwoSite
+import TNLean.MPS.ParentHamiltonian.Martingale.OverlapReduction
+
+/-!
+# Pairwise commutativity of the physical-sector bond
+
+This file assembles the local commutator calculations for the physical-sector
+bond into pairwise commutativity on every periodic chain of length at least
+two. For chains of length at least three, overlapping two-site windows either coincide or are cyclic
+neighbors; all other pairs have disjoint supports. The crossed two-site chain
+is treated separately.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, Proposition C.8, lines 1571--1593
+-/
+
+open scoped Matrix Kronecker
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D}
+
+/-- Moving one site clockwise is the same cyclic rotation used in the MPO
+formulation. -/
+private theorem cyclicForwardSite_one_eq_finRotate {N : ℕ} (i : Fin N) :
+    MPSTensor.cyclicForwardSite i 1 = finRotate N i := by
+  apply Fin.ext
+  simp [MPSTensor.cyclicForwardSite, finRotate_apply, Fin.add_def]
+
+/-- All translates of the physical bond commute pairwise on every periodic
+chain of length at least two.
+
+This assembles the adjacent, crossed two-site, and disjoint-support
+calculations. It uses no positivity, strong-area-law, zero-correlation-length,
+or injectivity hypothesis beyond the given physical-sector factorization.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8, lines
+1571--1593. -/
+theorem physicalBond_pairwise_comm (F : PhysicalSectorFactorization K)
+    {N : ℕ} (hN : 2 ≤ N) (i j : Fin N) :
+    embedLocalOperator (d := d) 2 N hN i F.physicalBond *
+        embedLocalOperator (d := d) 2 N hN j F.physicalBond =
+      embedLocalOperator (d := d) 2 N hN j F.physicalBond *
+        embedLocalOperator (d := d) 2 N hN i F.physicalBond := by
+  by_cases htwo : N = 2
+  · subst N
+    fin_cases i <;> fin_cases j
+    · rfl
+    · exact F.physicalBond_two_zero_one_comm
+    · exact F.physicalBond_two_zero_one_comm.symm
+    · rfl
+  · have hthree : 3 ≤ N := by omega
+    by_cases hoverlap : MPSTensor.cyclicWindowsOverlap N 2 i j
+    · rcases MPSTensor.cyclicWindowsOverlap_twoSite_cases hoverlap with hji | hji | hij
+      · subst j
+        rfl
+      · subst j
+        rw [cyclicForwardSite_one_eq_finRotate]
+        exact F.physicalBond_adjacent_comm hthree i
+      · subst i
+        rw [cyclicForwardSite_one_eq_finRotate]
+        exact (F.physicalBond_adjacent_comm hthree j).symm
+    · exact F.physicalBond_disjoint_comm hN hoverlap
+
+end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/PhysicalSectorBondTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorBondTransport.lean
@@ -611,10 +611,10 @@ The two-site chain is excluded because its two translated windows have the
 same support with opposite cyclic order, rather than forming the three-site
 configuration used in the source calculation.
 
-**Scope restriction (N ≥ 3):** The two-site crossed-order commutator remains
-open, as documented in
-`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.  Elimination:
-prove the `N = 2` crossed-order commutator separately.
+**Scope restriction (N ≥ 3):** This theorem treats the three-site local
+configuration and its embeddings.  The crossed-order case at `N = 2` is
+supplied separately by `physicalBond_two_zero_one_comm`, as documented in
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
 
 Source: arXiv:1606.00608, Appendix C.2, Proposition C.8, lines 1571--1593. -/
 theorem physicalBond_adjacent_comm (F : PhysicalSectorFactorization K)

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -260,10 +260,11 @@
     crossed two-site case is
     Theorem~\ref{thm:mpdo_physical_two_site_crossed_bonds_comm}. Disjoint
     translates commute by
-    Theorem~\ref{thm:mpdo_periodic_disjoint_physical_bonds_comm}. The local
-    commutator cases are therefore complete; their finite all-pairs assembly
-    and the all-length product identity
-    in~(\ref{eq:mpdo_eta_product_form}) remain open.
+    Theorem~\ref{thm:mpdo_periodic_disjoint_physical_bonds_comm}. These cases
+    are assembled into pairwise commutativity at every length $N\geq2$ in
+    Theorem~\ref{thm:mpdo_periodic_pairwise_physical_bonds_comm}. The
+    all-length product identity in~(\ref{eq:mpdo_eta_product_form}) remains
+    open.
     The doubled-index transfer condition enters only in the subsequent RFP and
     GSNNCH branch conclusions.
 \end{remark}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -1472,6 +1472,45 @@ strong subadditivity for a normalized three-site reduced state.
     locality step.
 \end{proof}
 
+\begin{theorem}[Pairwise commutativity of the physical bonds]
+    \label{thm:mpdo_periodic_pairwise_physical_bonds_comm}
+    \lean{MPOTensor.PhysicalSectorFactorization.physicalBond_pairwise_comm}
+    \leanok
+    \uses{lem:two_site_cyclic_window_overlap_cases,
+      thm:mpdo_periodic_adjacent_physical_bonds_comm,
+      thm:mpdo_physical_two_site_crossed_bonds_comm,
+      thm:mpdo_periodic_disjoint_physical_bonds_comm}
+    Suppose that the physical-sector factorization is given. For every
+    periodic chain of length $N\geq2$ and every pair of sites
+    $i,j\in\mathbb Z/N\mathbb Z$, the corresponding translates of the
+    physical bond commute:
+    \[
+      (B_{\mathrm{physical}})_{i,i+1}
+      (B_{\mathrm{physical}})_{j,j+1}
+      =
+      (B_{\mathrm{physical}})_{j,j+1}
+      (B_{\mathrm{physical}})_{i,i+1}.
+    \]
+    This is the pairwise commutation assertion in
+    \cite[Appendix~C.2, Proposition~C.8, lines~1571--1593]
+      {Cirac2016MPDO_arXiv}, conditional here on the physical-sector
+    factorization constructed in the preceding results.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    For $N=2$, equal translates commute trivially, while the two distinct
+    translates commute by
+    Theorem~\ref{thm:mpdo_physical_two_site_crossed_bonds_comm}. Let $N\geq3$.
+    If the two cyclic supports are disjoint, apply
+    Theorem~\ref{thm:mpdo_periodic_disjoint_physical_bonds_comm}. Otherwise,
+    Lemma~\ref{lem:two_site_cyclic_window_overlap_cases} shows that the two
+    starting sites either coincide or are cyclic neighbors. The coincident
+    case is immediate, and the two neighboring orientations follow from
+    Theorem~\ref{thm:mpdo_periodic_adjacent_physical_bonds_comm} and its
+    symmetric equality.
+\end{proof}
+
 \begin{definition}[Closed sector tensors]%
     \label{def:mpdo_closed_sector_tensors}
     \lean{MPOTensor.closedSectorL}

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -477,17 +477,18 @@ Translates with disjoint cyclic two-site supports commute by locality, without
 any further physical hypothesis.\footnote{The formal declaration is
 \leanid{MPOTensor.PhysicalSectorFactorization.physicalBond_disjoint_comm}.}
 Thus the adjacent, crossed two-site, and disjoint local commutators are all
-formalized.
+formalized.  Their finite case distinction is also assembled into pairwise
+commutativity of all translates on every periodic chain of length $N\geq2$.
+\footnote{The formal declaration is
+\leanid{MPOTensor.PhysicalSectorFactorization.physicalBond_pairwise_comm}.}
 
-Two global steps remain.  First, the local calculations must be assembled
-into pairwise commutativity of all translates on every periodic chain length;
-only the finite case distinction assembling these local cases into the
-all-pairs statement remains.  Second, one must transport the cyclic sector
-identity through the local unitary to prove the finite-chain realization
+The remaining global step is to transport the cyclic sector identity through
+the local unitary and prove the finite-chain realization
 \[
   \sigma^{(N)}(K)=c_N\prod_{n=1}^N B_{n,n+1}
 \]
-for positive scalars $c_N$.  These two steps construct
+for positive scalars $c_N$.  Together with the positive bond already
+constructed, this product identity will construct
 \leanid{MPOTensor.EtaLocalStructureData} from the Appendix C.2 local structure
 of a simple MPDO satisfying SAL.  ZCL is not a hypothesis of this construction.
 
@@ -525,10 +526,10 @@ The primitivity of $T_{k,h}$ also remains open, and cannot be used to
 derive recurrence without circularity.
 
 For the conditional bond construction, adjacent translates commute for every
-chain length $N\geq 2$, including the wraparound and crossed two-site cases.
-Disjoint translates commute at every length for which their two-site cyclic
-supports are disjoint.  The finite all-pairs assembly and the finite-chain
-product realization remain open.
+chain length $N\geq 2$, including the wraparound and crossed two-site cases,
+and disjoint translates commute by locality.  These cases are assembled into
+pairwise commutativity of all translates at every length $N\geq2$.  The
+finite-chain product realization remains open.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

- assemble adjacent, crossed two-site, and disjoint-support commutator calculations into pairwise commutativity of all physical-bond translates
- treat the exceptional two-site periodic chain separately and use the cyclic two-window overlap trichotomy for lengths at least three
- update the MPO/RFP blueprint and paper-gap status so that only the finite-chain product realization remains in this local-structure branch

The theorem is conditional on the given physical-sector factorization and introduces no positivity, SAL, ZCL, injectivity, or recurrence hypothesis. It is the finite all-pairs assembly of the pairwise commutation clause in arXiv:1606.00608, Appendix C.2, Proposition C.8.

## Verification

- `lake build TNLean`
- `cd blueprint && leanblueprint checkdecls`
- `python3 scripts/blueprint_lean_sync.py --ci`
- direct Lean and style checks for the new module
- proof-integrity and whitespace checks

Advances #823.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal Lean assembly of existing local commutativity lemmas plus documentation sync; no runtime, security, or data-path changes.
> 
> **Overview**
> Adds **`physicalBond_pairwise_comm`**, which proves all translates of the physical-sector bond commute on every periodic chain with **N ≥ 2**, given only a physical-sector factorization (no SAL, ZCL, or positivity).
> 
> The proof is a case split: **N = 2** uses the existing crossed two-site commutator; for **N ≥ 3**, overlapping two-site windows are handled via the cyclic overlap trichotomy (coincident, adjacent via `physicalBond_adjacent_comm`, or disjoint via `physicalBond_disjoint_comm`). The module is wired into the root import list; blueprint and paper-gap notes now treat **pairwise commutation as closed** and leave the **finite-chain product realization** as the remaining open step toward η-local structure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a012c8a8fae5c73be430bbef520a68ae3f95b7d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->