### PR TITLE
doc(blueprint): diagram adjacent sector bonds

### DIFF
--- a/blueprint/src/Packages/tn_diagrams.py
+++ b/blueprint/src/Packages/tn_diagrams.py
@@ -59,6 +59,7 @@ _DIAGRAM_ARGS: dict[str, str] = {
     "TNMPDOPhysicalIsometryTransport": "",
     "TNMPDOTwoSiteClosureFactorization": "",
     "TNMPDOThreeSiteClosureFactorization": "",
+    "TNMPDOFixedSectorAdjacentCommutativity": "",
     "TNMPDOCyclicEtaContraction": "",
     "TNMPDOSectorAdaptedDecomposition": "",
     "TNMPDOInverseMapThreeSiteContraction": "",

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -1285,6 +1285,18 @@ strong subadditivity for a normalized three-site reduced state.
       {Cirac2016MPDO_arXiv}.
 \end{theorem}
 
+\begin{figure}[ht]
+    \centering
+    \TNMPDOFixedSectorAdjacentCommutativity
+    \caption{On the sector triple $(k,l,h)$, the operator
+    $\eta_{k,l}$ acts only on $B_k^R\otimes B_l^L$, whereas $\eta_{l,h}$ acts
+    only on $B_l^R\otimes B_h^L$. The outer factors $B_k^L$ and $B_h^R$ are
+    unchanged.
+    Thus exchanging the vertical order of the two operators leaves the
+    contraction unchanged, which is the displayed fixed-sector commutativity.}
+    \label{fig:mpdo_fixed_sector_adjacent_bonds_comm}
+\end{figure}
+
 \begin{proof}
     \leanok
     The operators $\eta_{k,l}$ and $\eta_{l,h}$ act on the distinct factors

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -553,6 +553,51 @@
     \end{tikzpicture}%
 }
 
+% Adjacent-bond commutativity on one fixed sector triple.  The six vertical
+% lines are the factors L_k, R_k, L_l, R_l, L_h, R_h.  Reading from bottom to
+% top, the two panels differ only by the order of the operators on the disjoint
+% pairs R_k \otimes L_l and R_l \otimes L_h.
+\newcommand{\TNMPDOFixedSectorAdjacentCommutativity}{%
+    \begin{tikzpicture}[tn picture, scale=0.78]
+        \foreach \x in {-5.25,-4.45,-3.65,-2.85,-2.05,-1.25,
+                        1.25,2.05,2.85,3.65,4.45,5.25} {
+            \draw[tn leg] (\x,-1.12) -- (\x,1.12);
+        }
+
+        \node[draw, fill=white, rounded corners=2pt, minimum width=1.38cm,
+            minimum height=0.48cm, inner sep=1pt]
+            at (-4.05,0.38) {$\eta_{k,l}$};
+        \node[draw, fill=white, rounded corners=2pt, minimum width=1.38cm,
+            minimum height=0.48cm, inner sep=1pt]
+            at (-2.45,-0.38) {$\eta_{l,h}$};
+
+        \node[draw, fill=white, rounded corners=2pt, minimum width=1.38cm,
+            minimum height=0.48cm, inner sep=1pt]
+            at (2.45,-0.38) {$\eta_{k,l}$};
+        \node[draw, fill=white, rounded corners=2pt, minimum width=1.38cm,
+            minimum height=0.48cm, inner sep=1pt]
+            at (4.05,0.38) {$\eta_{l,h}$};
+
+        \node at (-3.25,1.57) {$C_{01}^{k,l,h}C_{12}^{k,l,h}$};
+        \node at (3.25,1.57) {$C_{12}^{k,l,h}C_{01}^{k,l,h}$};
+        \node at (0,0) {$=$};
+
+        \foreach \x/\lab in {
+            -5.25/{B_k^L},-4.45/{B_k^R},-3.65/{B_l^L},-2.85/{B_l^R},
+            -2.05/{B_h^L},-1.25/{B_h^R},
+             1.25/{B_k^L}, 2.05/{B_k^R}, 2.85/{B_l^L}, 3.65/{B_l^R},
+             4.45/{B_h^L}, 5.25/{B_h^R}} {
+            \node at (\x,-1.42) {$\lab$};
+        }
+        \foreach \a/\b/\lab in {
+            -5.58/-4.12/0,-3.98/-2.52/1,-2.38/-0.92/2,
+             0.92/2.38/0, 2.52/3.98/1, 4.12/5.58/2} {
+            \draw[tn leg] (\a,-1.72) -- (\a,-1.84) -- (\b,-1.84) -- (\b,-1.72);
+            \node at ({(\a+\b)/2},-2.05) {site $\lab$};
+        }
+    \end{tikzpicture}%
+}
+
 % A closed chain of factorized sector tensors regrouped into neighbouring
 % eta operators.  This mirrors the cyclic contractions in Appendix C.2.
 \newcommand{\TNMPDOCyclicEtaContraction}{%

--- a/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
+++ b/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
@@ -10,7 +10,7 @@ name: TNMPOLocalPurification TNMPORenormalizationTS TNEtaSectorDecomposition TNM
 name: TNMPDOTwoSiteTraceAndShift TNMPDOThreeSiteTraceAndShift TNMPDORefinementConstruction TNMPDORefinementDirection TNMPDOBlockedRFPChannels TNMPDOPhysicalIsometryTransport
 {{ obj.tn_svg_html }}
 
-name: TNMPDOTwoSiteClosureFactorization TNMPDOThreeSiteClosureFactorization
+name: TNMPDOTwoSiteClosureFactorization TNMPDOThreeSiteClosureFactorization TNMPDOFixedSectorAdjacentCommutativity
 {{ obj.tn_svg_html }}
 
 name: TNMPDOInverseMapThreeSiteContraction TNMPDONormalizedFourSiteTail TNMPDOLocalOrthogonality


### PR DESCRIPTION
## Summary

- add a TikZ diagram for fixed-sector adjacent-bond commutativity
- show the two neighboring operators acting on disjoint tensor-factor pairs of the middle three-site sector decomposition
- register the diagram in both PDF and web rendering paths

The figure illustrates the already-proved commutativity theorem and adds no new mathematical assertion. Its layout follows the split-site and neighboring-operator imagery of arXiv:1606.00608, Appendix C.2.

## Verification

- full `leanblueprint pdf` build (513 pages)
- visual inspection of rendered page 450
- tensor-diagram registration check (106 macros)
- independent SVG smoke render
- blueprint synchronization and prose checks
- `git diff --check`

Advances #823.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and diagram plumbing only; no Lean or proof logic changes.
> 
> **Overview**
> Adds a **TikZ figure** for fixed-sector adjacent-bond commutativity next to the existing theorem in the MPDO chapter, showing that \(\eta_{k,l}\) and \(\eta_{l,h}\) act on disjoint tensor factors so swapping their order does not change the contraction.
> 
> Introduces `\TNMPDOFixedSectorAdjacentCommutativity` in `tn_print.tex` and wires it through **`tn_diagrams.py`** and the plasTeX **`TensorNetworkDiagrams.jinja2s`** template so the same macro renders in PDF and as cached SVG on the web blueprint. No new mathematical claims beyond illustrating the proved commutativity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e9a91405f2a32b80e61a232a0749728346e4cec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->