### PR TITLE
feat(MPS/MPDO): prove exact physical bond product

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -416,6 +416,8 @@ import TNLean.MPS.MPDO.PhysicalSectorBondTransport
 import TNLean.MPS.MPDO.PhysicalSectorBondTwoSite
 import TNLean.MPS.MPDO.PhysicalSectorBondPairwise
 import TNLean.MPS.MPDO.PhysicalSectorChainDecomposition
+import TNLean.MPS.MPDO.PhysicalSectorProductRealization
+import TNLean.MPS.MPDO.PhysicalSectorProductTransport
 import TNLean.MPS.MPDO.PhysicalSectorPhysicalTransport
 import TNLean.MPS.MPDO.SectorPairingTransfer
 import TNLean.MPS.MPDO.SectorEtaContraction

--- a/TNLean/MPS/MPDO/CommutingForm.lean
+++ b/TNLean/MPS/MPDO/CommutingForm.lean
@@ -99,7 +99,7 @@ theorem agreesOutsideWindow_iff (L : ℕ) {N : ℕ} (hLN : L ≤ N)
 
 /-- Decompose a periodic configuration into a cyclic window and its cyclic
 complement. -/
-private def windowComplementEquiv (L N : ℕ) (hLN : L ≤ N) (i : Fin N) :
+def windowComplementEquiv (L N : ℕ) (hLN : L ≤ N) (i : Fin N) :
     (Fin N → Fin d) ≃ ((Fin L → Fin d) × (Fin (N - L) → Fin d)) where
   toFun σ :=
     (MPSTensor.extractWindow L i σ,
@@ -183,7 +183,7 @@ private def windowComplementEquiv (L N : ℕ) (hLN : L ≤ N) (i : Fin N) :
 
 /-- In cyclic-window coordinates, a local operator is the tensor product of
 the window operator with the identity on the complement. -/
-private theorem reindex_embedLocalOperator_windowComplement
+theorem reindex_embedLocalOperator_windowComplement
     (L N : ℕ) (hLN : L ≤ N) (i : Fin N)
     (B : Matrix (Fin L → Fin d) (Fin L → Fin d) ℂ) :
     Matrix.reindex (windowComplementEquiv (d := d) L N hLN i)

--- a/TNLean/MPS/MPDO/PhysicalSectorBondTwoSite.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorBondTwoSite.lean
@@ -26,8 +26,12 @@ namespace MPOTensor.PhysicalSectorFactorization
 
 variable {d D : ℕ} {K : MPOTensor d D}
 
-/-- Exchange the two factors of a matrix indexed by ordered pairs. -/
-private noncomputable def swapPairMatrix {n : Type*}
+/-- Exchange the two factors of a matrix indexed by ordered pairs.
+
+This is the opposite cyclic ordering of the two sites at chain length two.
+Appendix C.2, Proposition C.8 of arXiv:1606.00608 does not discuss this
+finite-size ordering separately. -/
+noncomputable def swapPairMatrix {n : Type*}
     (B : Matrix (n × n) (n × n) ℂ) : Matrix (n × n) (n × n) ℂ :=
   Matrix.reindex (Equiv.prodComm n n) (Equiv.prodComm n n) B
 
@@ -43,7 +47,7 @@ private theorem reindex_prodComm_kronecker_self
 
 /-- Exchanging both physical sites commutes with a change of coordinates
 which is the tensor square of one single-site coordinate matrix. -/
-private theorem swapPairMatrix_sandwich_kronecker_self
+theorem swapPairMatrix_sandwich_kronecker_self
     {m n : Type*} [Fintype m] [Fintype n]
     (A : Matrix m n ℂ) (B : Matrix (m × m) (m × m) ℂ) :
     swapPairMatrix (sandwichMap (A ⊗ₖ A)ᴴ B) =
@@ -80,8 +84,11 @@ the outer and neighboring pairs in the regrouped coordinates. -/
   rfl
 
 /-- The crossed bond on a fixed `(k,h)` sector block.  It acts on the outer
-factor $L_k \otimes R_h$, leaving the neighboring factor fixed. -/
-private noncomputable def crossedSectorBond (F : PhysicalSectorFactorization K)
+factor $L_k \otimes R_h$, leaving the neighboring factor fixed.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8.  The source does not
+separately state the crossed finite-size case. -/
+noncomputable def crossedSectorBond (F : PhysicalSectorFactorization K)
     (k h : Fin F.sectorCount) :
     Matrix (BoundaryIndex F k h × NeighborIndex F k h)
       (BoundaryIndex F k h × NeighborIndex F k h) ℂ :=
@@ -102,8 +109,11 @@ private theorem fixedSectorBond_crossed_comm
   simp
 
 /-- Regrouping the swapped sector-coordinate bond gives the dependent direct
-sum of the crossed fixed-sector bonds. -/
-private theorem reindex_swapPairMatrix_sectorCoordinateBond
+sum of the crossed fixed-sector bonds.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8.  The source does not
+separately state the crossed finite-size case. -/
+theorem reindex_swapPairMatrix_sectorCoordinateBond
     (F : PhysicalSectorFactorization K) :
     Matrix.reindex F.twoSiteGlobalRegroupEquiv F.twoSiteGlobalRegroupEquiv
         (swapPairMatrix F.sectorCoordinateBond) =
@@ -214,7 +224,7 @@ the original pair matrix after identifying configurations with ordered pairs.
 
 Source: arXiv:1606.00608, Appendix C.2, Proposition C.8.  The source does not
 separately state the crossed finite-size case. -/
-private theorem reindex_embedLocalOperator_two_zero
+theorem reindex_embedLocalOperator_two_zero
     (F : PhysicalSectorFactorization K) :
     Matrix.reindex (finTwoArrowEquiv (Fin d)) (finTwoArrowEquiv (Fin d))
         (embedLocalOperator (d := d) 2 2 (by decide) (0 : Fin 2) F.physicalBond) =
@@ -236,7 +246,7 @@ the pair matrix with its two tensor factors exchanged.
 
 Source: arXiv:1606.00608, Appendix C.2, Proposition C.8.  The source does not
 separately state the crossed finite-size case. -/
-private theorem reindex_embedLocalOperator_two_one
+theorem reindex_embedLocalOperator_two_one
     (F : PhysicalSectorFactorization K) :
     Matrix.reindex (finTwoArrowEquiv (Fin d)) (finTwoArrowEquiv (Fin d))
         (embedLocalOperator (d := d) 2 2 (by decide) (1 : Fin 2) F.physicalBond) =

--- a/TNLean/MPS/MPDO/PhysicalSectorProductRealization.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorProductRealization.lean
@@ -1,0 +1,792 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalSectorChainDecomposition
+import TNLean.MPS.MPDO.PhysicalSectorBondCommutativity
+
+/-!
+# Product realization from physical-sector coordinates
+
+This file proves the all-length cyclic contraction underlying the product
+form of a matrix product density operator with a physical-sector
+factorization.  No positivity, normalization, area-law, or zero-correlation
+hypothesis is imposed.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, Proposition C.8, lines 1581--1593
+-/
+
+open scoped Matrix BigOperators Kronecker
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D}
+
+/-- The pointwise finite encoding of the transformed physical chain. -/
+private noncomputable def physicalConfigEquiv
+    (F : PhysicalSectorFactorization K) (N : ℕ) :
+    (Fin N → Fin d) ≃ (Fin N → Fin (Fintype.card (SectorSiteIndex F))) :=
+  Equiv.arrowCongr (Equiv.refl (Fin N)) F.physicalFinEquiv
+
+/-- The finite sector-coordinate chain is the transformed physical chain,
+followed by the sector decomposition already used in the all-length chain
+decomposition. -/
+private noncomputable def sectorCoordinateChainEquiv
+    (F : PhysicalSectorFactorization K) (N : ℕ) :
+    (Fin N → Fin (Fintype.card (SectorSiteIndex F))) ≃ SectorChainIndex F N :=
+  (F.physicalConfigEquiv N).symm.trans (F.sectorChainEquiv N)
+
+/-- Encoding the transformed one-site physical indices by `Fin` commutes with
+forming the periodic MPO. -/
+private theorem mpo_sectorCoordinateTensor_eq_reindex_conjugatePhysical
+    (F : PhysicalSectorFactorization K) (N : ℕ) :
+    mpo F.sectorCoordinateTensor N =
+      Matrix.reindex (F.physicalConfigEquiv N) (F.physicalConfigEquiv N)
+        (mpo (conjugatePhysical K F.physicalIsometry) N) := by
+  ext s t
+  simp only [Matrix.reindex_apply, Matrix.submatrix_apply, mpo_apply,
+    mpoMatrixEntry, MPOTensor.evalWord_ofFn]
+  congr 1
+
+/-- In finite sector coordinates, the full MPO is the direct sum from the
+all-length physical-sector chain decomposition.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `sigmaNK2`, lines
+1581--1588. -/
+private theorem reindex_mpo_sectorCoordinateTensor_eq_blockDiagonal
+    (F : PhysicalSectorFactorization K) {N : ℕ} [NeZero N] :
+    Matrix.reindex (F.sectorCoordinateChainEquiv N)
+        (F.sectorCoordinateChainEquiv N) (mpo F.sectorCoordinateTensor N) =
+      Matrix.blockDiagonal' fun k ↦ F.cyclicNeighboringProduct k := by
+  ext s t
+  have h := congrFun (congrFun
+    (F.mpo_reindex_sectorChainEquiv_eq_blockDiagonal (N := N)) s) t
+  rw [F.mpo_sectorCoordinateTensor_eq_reindex_conjugatePhysical N]
+  simpa [sectorCoordinateChainEquiv, Matrix.reindex_apply] using h
+
+private def piProdEquiv
+    {ι : Type*} {A B : ι → Type*} :
+    ((i : ι) → A i × B i) ≃ ((i : ι) → A i) × ((i : ι) → B i) where
+  toFun x := (fun i ↦ (x i).1, fun i ↦ (x i).2)
+  invFun x i := (x.1 i, x.2 i)
+  left_inv _ := rfl
+  right_inv _ := rfl
+
+/-- Regroup a fixed sector configuration from site factors
+`(L_n,R_n)` to cyclic edge factors `(R_n,L_(n+1))`.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `sigmaNK2`, lines
+1586--1589. -/
+private def cyclicEdgeEquiv (F : PhysicalSectorFactorization K) {N : ℕ} [NeZero N]
+    (k : Fin N → Fin F.sectorCount) :
+    ((n : Fin N) → SectorIndex F (k n)) ≃
+      ((n : Fin N) → NeighborIndex F (k n) (k (n + 1))) :=
+  piProdEquiv.trans <|
+    (Equiv.prodComm _ _).trans <|
+      (Equiv.prodCongr (Equiv.refl _)
+        (Equiv.piCongrLeft
+          (fun n : Fin N ↦ Fin (F.leftDim (k n))) (finRotate N)).symm).trans <|
+        piProdEquiv.symm |>.trans <|
+          Equiv.piCongrRight fun n ↦
+            Equiv.prodCongr (Equiv.refl _)
+              (finCongr (congrArg F.leftDim
+                (congrArg k (finRotate_apply n))))
+
+@[simp] private theorem cyclicEdgeEquiv_apply
+    (F : PhysicalSectorFactorization K) {N : ℕ} [NeZero N]
+    (k : Fin N → Fin F.sectorCount)
+    (x : (n : Fin N) → SectorIndex F (k n)) (n : Fin N) :
+    F.cyclicEdgeEquiv k x n = ((x n).2, (x (n + 1)).1) := by
+  apply Prod.ext
+  · rfl
+  · apply Fin.ext
+    change ((x (finRotate N n)).1 : ℕ) = ((x (n + 1)).1 : ℕ)
+    rw [finRotate_apply]
+
+@[simp] private theorem cyclicEdgeEquiv_symm_edge
+    (F : PhysicalSectorFactorization K) {N : ℕ} [NeZero N]
+    (k : Fin N → Fin F.sectorCount)
+    (x : (n : Fin N) → NeighborIndex F (k n) (k (n + 1)))
+    (n : Fin N) :
+    (((F.cyclicEdgeEquiv k).symm x n).2,
+        ((F.cyclicEdgeEquiv k).symm x (n + 1)).1) = x n := by
+  have h := congrFun ((F.cyclicEdgeEquiv k).apply_symm_apply x) n
+  simpa only [cyclicEdgeEquiv_apply] using h
+
+/-- Under cyclic edge coordinates, a fixed-sector neighboring product is
+the ordinary tensor-product matrix whose entries are products over edges.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `sigmaNK2`, lines
+1586--1589. -/
+private theorem reindex_cyclicNeighboringProduct_cyclicEdgeEquiv
+    (F : PhysicalSectorFactorization K) {N : ℕ} [NeZero N]
+    (k : Fin N → Fin F.sectorCount) :
+    Matrix.reindex (F.cyclicEdgeEquiv k) (F.cyclicEdgeEquiv k)
+        (F.cyclicNeighboringProduct k) =
+      fun x y ↦ ∏ n : Fin N,
+        F.neighboringOperator (k n) (k (n + 1)) (x n) (y n) := by
+  ext x y
+  simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
+    cyclicNeighboringProduct]
+  apply Finset.prod_congr rfl
+  intro n _
+  have hx := congrFun ((F.cyclicEdgeEquiv k).apply_symm_apply x) n
+  have hy := congrFun ((F.cyclicEdgeEquiv k).apply_symm_apply y) n
+  simpa only [cyclicEdgeEquiv_apply] using
+    congrArg₂ (F.neighboringOperator (k n) (k (n + 1))) hx hy
+
+/-- The complete sector-coordinate chain, regrouped as a direct sum over
+sector configurations with one neighboring factor on every cyclic edge.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `sigmaNK2`, lines
+1581--1589. -/
+private noncomputable def sectorEdgeChainEquiv
+    (F : PhysicalSectorFactorization K) (N : ℕ) [NeZero N] :
+    (Fin N → Fin (Fintype.card (SectorSiteIndex F))) ≃
+      Σ k : Fin N → Fin F.sectorCount,
+        (n : Fin N) → NeighborIndex F (k n) (k (n + 1)) :=
+  (F.sectorCoordinateChainEquiv N).trans <|
+    Equiv.sigmaCongrRight fun k ↦ F.cyclicEdgeEquiv k
+
+@[simp] private theorem sectorEdgeChainEquiv_symm_apply
+    (F : PhysicalSectorFactorization K) (N : ℕ) [NeZero N]
+    (k : Fin N → Fin F.sectorCount)
+    (x : (n : Fin N) → NeighborIndex F (k n) (k (n + 1)))
+    (n : Fin N) :
+    (F.sectorEdgeChainEquiv N).symm ⟨k, x⟩ n =
+      F.sectorFinEquiv.symm
+        ⟨k n, (F.cyclicEdgeEquiv k).symm x n⟩ := by
+  simp [sectorEdgeChainEquiv, sectorCoordinateChainEquiv,
+    physicalConfigEquiv, physicalFinEquiv, sectorChainEquiv]
+  rfl
+
+/-- Under complete cyclic-edge coordinates, the sector-coordinate MPO is
+block diagonal and each fixed-sector block is the product of its edge
+matrix entries.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `sigmaNK2`, lines
+1581--1589. -/
+private theorem reindex_mpo_sectorCoordinateTensor_sectorEdgeChainEquiv
+    (F : PhysicalSectorFactorization K) {N : ℕ} [NeZero N] :
+    Matrix.reindex (F.sectorEdgeChainEquiv N) (F.sectorEdgeChainEquiv N)
+        (mpo F.sectorCoordinateTensor N) =
+      Matrix.blockDiagonal' fun k ↦
+        fun x y ↦ ∏ n : Fin N,
+          F.neighboringOperator (k n) (k (n + 1)) (x n) (y n) := by
+  change Matrix.reindex
+      ((F.sectorCoordinateChainEquiv N).trans
+        (Equiv.sigmaCongrRight fun k ↦ F.cyclicEdgeEquiv k))
+      ((F.sectorCoordinateChainEquiv N).trans
+        (Equiv.sigmaCongrRight fun k ↦ F.cyclicEdgeEquiv k)) _ = _
+  ext ⟨k, x⟩ ⟨h, y⟩
+  have hfull := congrFun (congrFun
+    F.reindex_mpo_sectorCoordinateTensor_eq_blockDiagonal
+      ⟨k, (F.cyclicEdgeEquiv k).symm x⟩)
+      ⟨h, (F.cyclicEdgeEquiv h).symm y⟩
+  change _ = Matrix.blockDiagonal' (fun q ↦ F.cyclicNeighboringProduct q)
+    ⟨k, (F.cyclicEdgeEquiv k).symm x⟩
+    ⟨h, (F.cyclicEdgeEquiv h).symm y⟩ at hfull
+  change Matrix.reindex (F.sectorCoordinateChainEquiv N)
+      (F.sectorCoordinateChainEquiv N) (mpo F.sectorCoordinateTensor N)
+        ⟨k, (F.cyclicEdgeEquiv k).symm x⟩
+        ⟨h, (F.cyclicEdgeEquiv h).symm y⟩ = _
+  rw [hfull]
+  by_cases hkh : k = h
+  · subst h
+    rw [Matrix.blockDiagonal'_apply_eq, Matrix.blockDiagonal'_apply_eq]
+    exact congrFun (congrFun
+      (F.reindex_cyclicNeighboringProduct_cyclicEdgeEquiv k) x) y
+  · rw [Matrix.blockDiagonal'_apply_ne _ _ _ hkh,
+      Matrix.blockDiagonal'_apply_ne _ _ _ hkh]
+
+/-- The product on a chosen set of cyclic edges in a fixed sector
+configuration.  Edges outside the set carry the identity matrix.
+
+This is the scalar-entry form of a partial tensor product. -/
+private noncomputable def edgePartialProduct
+    (F : PhysicalSectorFactorization K) {N : ℕ} [NeZero N]
+    (k : Fin N → Fin F.sectorCount) (s : Finset (Fin N)) :
+    Matrix ((n : Fin N) → NeighborIndex F (k n) (k (n + 1)))
+      ((n : Fin N) → NeighborIndex F (k n) (k (n + 1))) ℂ :=
+  fun x y ↦ ∏ n : Fin N,
+    if n ∈ s then
+      F.neighboringOperator (k n) (k (n + 1)) (x n) (y n)
+    else if x n = y n then 1 else 0
+
+@[simp] private theorem edgePartialProduct_empty
+    (F : PhysicalSectorFactorization K) {N : ℕ} [NeZero N]
+    (k : Fin N → Fin F.sectorCount) :
+    F.edgePartialProduct k ∅ = 1 := by
+  ext x y
+  simp only [edgePartialProduct, Finset.notMem_empty, ↓reduceIte,
+    Matrix.one_apply]
+  by_cases hxy : x = y
+  · subst y
+    simp
+  · obtain ⟨n, hn⟩ := Function.ne_iff.mp hxy
+    rw [Finset.prod_eq_zero (Finset.mem_univ n)]
+    · simp [hxy]
+    · simp [hn]
+
+@[simp] private theorem edgePartialProduct_univ
+    (F : PhysicalSectorFactorization K) {N : ℕ} [NeZero N]
+    (k : Fin N → Fin F.sectorCount) :
+    F.edgePartialProduct k Finset.univ =
+      fun x y ↦ ∏ n : Fin N,
+        F.neighboringOperator (k n) (k (n + 1)) (x n) (y n) := by
+  ext x y
+  simp [edgePartialProduct]
+
+/-- Multiplying by a new single-edge factor adjoins that edge to the partial
+tensor product. -/
+private theorem edgePartialProduct_mul_singleton
+    (F : PhysicalSectorFactorization K) {N : ℕ} [NeZero N]
+    (k : Fin N → Fin F.sectorCount) (s : Finset (Fin N))
+    (i : Fin N) (hi : i ∉ s) :
+    F.edgePartialProduct k s * F.edgePartialProduct k {i} =
+      F.edgePartialProduct k (insert i s) := by
+  classical
+  ext x y
+  simp only [Matrix.mul_apply, edgePartialProduct]
+  simp_rw [← Finset.prod_mul_distrib]
+  rw [← Fintype.piFinset_univ]
+  rw [← Finset.prod_univ_sum
+    (fun n : Fin N ↦
+      (Finset.univ : Finset (NeighborIndex F (k n) (k (n + 1)))))
+    (fun n z ↦
+      (if n ∈ s then
+        F.neighboringOperator (k n) (k (n + 1)) (x n) z
+      else if x n = z then 1 else 0) *
+      (if n ∈ ({i} : Finset (Fin N)) then
+        F.neighboringOperator (k n) (k (n + 1)) z (y n)
+      else if z = y n then 1 else 0))]
+  apply Finset.prod_congr rfl
+  intro n _
+  by_cases hni : n = i
+  · subst n
+    simp [hi]
+  · by_cases hns : n ∈ s
+    · simp [hni, hns]
+    · by_cases hxy : x n = y n
+      · simp [hni, hns, hxy]
+      · simp [hni, hns, hxy]
+
+/-- Multiplying a partial tensor product on the left by a new single-edge
+factor adjoins that edge. -/
+private theorem edgePartialProduct_singleton_mul
+    (F : PhysicalSectorFactorization K) {N : ℕ} [NeZero N]
+    (k : Fin N → Fin F.sectorCount) (s : Finset (Fin N))
+    (i : Fin N) (hi : i ∉ s) :
+    F.edgePartialProduct k {i} * F.edgePartialProduct k s =
+      F.edgePartialProduct k (insert i s) := by
+  classical
+  ext x y
+  simp only [Matrix.mul_apply, edgePartialProduct]
+  simp_rw [← Finset.prod_mul_distrib]
+  rw [← Fintype.piFinset_univ]
+  rw [← Finset.prod_univ_sum
+    (fun n : Fin N ↦
+      (Finset.univ : Finset (NeighborIndex F (k n) (k (n + 1)))))
+    (fun n z ↦
+      (if n ∈ ({i} : Finset (Fin N)) then
+        F.neighboringOperator (k n) (k (n + 1)) (x n) z
+      else if x n = z then 1 else 0) *
+      (if n ∈ s then
+        F.neighboringOperator (k n) (k (n + 1)) z (y n)
+      else if z = y n then 1 else 0))]
+  apply Finset.prod_congr rfl
+  intro n _
+  by_cases hni : n = i
+  · subst n
+    simp [hi]
+  · by_cases hns : n ∈ s
+    · simp [hni, hns]
+    · by_cases hxy : x n = y n
+      · simp [hni, hns, hxy]
+      · simp [hni, hns, hxy]
+
+/-- The ordered product of the single-edge matrices indexed by a list
+without repetitions is the partial tensor product over the entries of that
+list. -/
+private theorem prod_edgePartialProduct_singletons
+    (F : PhysicalSectorFactorization K) {N : ℕ} [NeZero N]
+    (k : Fin N → Fin F.sectorCount) (l : List (Fin N)) (hl : l.Nodup) :
+    (l.map fun i ↦ F.edgePartialProduct k {i}).prod =
+      F.edgePartialProduct k l.toFinset := by
+  induction l with
+  | nil => simp
+  | cons i l ih =>
+      rw [List.nodup_cons] at hl
+      simp only [List.map_cons, List.prod_cons, List.toFinset_cons]
+      rw [ih hl.2]
+      exact F.edgePartialProduct_singleton_mul k l.toFinset i (by
+        simpa only [List.mem_toFinset] using hl.1)
+
+/-- The ordered product over all cyclic edges is the complete product of
+neighboring-operator entries. -/
+private theorem prod_edgePartialProduct_singletons_univ
+    (F : PhysicalSectorFactorization K) {N : ℕ} [NeZero N]
+    (k : Fin N → Fin F.sectorCount) :
+    (List.ofFn fun i : Fin N ↦ F.edgePartialProduct k {i}).prod =
+      fun x y ↦ ∏ n : Fin N,
+        F.neighboringOperator (k n) (k (n + 1)) (x n) (y n) := by
+  have hlist : List.ofFn (fun i : Fin N ↦ F.edgePartialProduct k {i}) =
+      (List.ofFn id).map fun i ↦ F.edgePartialProduct k {i} := by
+    simp
+  rw [hlist]
+  rw [F.prod_edgePartialProduct_singletons k (List.ofFn id)
+    (List.nodup_ofFn.mpr Function.injective_id)]
+  have hfin : (List.ofFn id : List (Fin N)).toFinset = Finset.univ := by
+    ext i
+    simp only [List.mem_toFinset, Finset.mem_univ, iff_true]
+    exact List.mem_ofFn.mpr ⟨i, rfl⟩
+  rw [hfin]
+  exact F.edgePartialProduct_univ k
+
+/-- The sector-coordinate bond indexed by two-site configurations. -/
+noncomputable def sectorBond (F : PhysicalSectorFactorization K) :
+    Matrix
+      (Fin 2 → Fin (Fintype.card (SectorSiteIndex F)))
+      (Fin 2 → Fin (Fintype.card (SectorSiteIndex F))) ℂ :=
+  Matrix.reindex
+    (finTwoArrowEquiv (Fin (Fintype.card (SectorSiteIndex F)))).symm
+    (finTwoArrowEquiv (Fin (Fintype.card (SectorSiteIndex F)))).symm
+    F.sectorCoordinateBond
+
+@[simp] private theorem twoSiteGlobalRegroupEquiv_twoSiteSectorEmbedding
+    (F : PhysicalSectorFactorization K) (k h : Fin F.sectorCount)
+    (x : SectorIndex F k × SectorIndex F h) :
+    F.twoSiteGlobalRegroupEquiv (F.twoSiteSectorEmbedding k h x) =
+      ⟨(k, h), F.twoSiteRegroupEquiv k h x⟩ := by
+  apply F.twoSiteGlobalRegroupEquiv.symm.injective
+  rw [Equiv.symm_apply_apply, twoSiteGlobalRegroupEquiv_symm_apply]
+  rfl
+
+private theorem add_one_ne_self_of_three_le {N : ℕ} [NeZero N]
+    (hN : 3 ≤ N) (i : Fin N) :
+    i + 1 ≠ i := by
+  have h1 : ((1 : Fin N) : ℕ) = 1 := by
+    change 1 % N = 1
+    rw [Nat.mod_eq_of_lt (by omega)]
+  intro h
+  have hval := congrArg Fin.val h
+  rw [Fin.val_add_eq_ite, h1] at hval
+  have := i.isLt
+  split_ifs at hval <;> omega
+
+private theorem mem_cyclicWindowSupport_two {N : ℕ} (i q : Fin N) :
+    q ∈ MPSTensor.cyclicWindowSupport N 2 i ↔
+      q = i ∨ q = MPSTensor.cyclicForwardSite i 1 := by
+  rw [MPSTensor.cyclicWindowSupport]
+  simp only [Finset.mem_image, Finset.mem_range]
+  constructor
+  · rintro ⟨r, hr, rfl⟩
+    interval_cases r
+    · simp
+    · simp
+  · rintro (rfl | rfl)
+    · exact ⟨0, by simp, by simp⟩
+    · exact ⟨1, by simp, rfl⟩
+
+/-- Within a fixed pair of sectors, the sector bond carries the neighboring
+operator and the two outer factors contribute Kronecker deltas. -/
+private theorem sectorBond_fixedSector_apply
+    (F : PhysicalSectorFactorization K) (k h : Fin F.sectorCount)
+    (x x' : SectorIndex F k) (y y' : SectorIndex F h) :
+    F.sectorBond
+        ![F.sectorFinEquiv.symm ⟨k, x⟩, F.sectorFinEquiv.symm ⟨h, y⟩]
+        ![F.sectorFinEquiv.symm ⟨k, x'⟩, F.sectorFinEquiv.symm ⟨h, y'⟩] =
+      (if x.1 = x'.1 then 1 else 0) *
+        (if y.2 = y'.2 then 1 else 0) *
+          F.neighboringOperator k h (x.2, y.1) (x'.2, y'.1) := by
+  simp only [sectorBond, Matrix.reindex_apply, Matrix.submatrix_apply,
+    finTwoArrowEquiv]
+  change F.sectorCoordinateBond
+      (F.twoSiteSectorEmbedding k h (x, y))
+      (F.twoSiteSectorEmbedding k h (x', y')) = _
+  simp only [sectorCoordinateBond, Matrix.reindex_apply,
+    Matrix.submatrix_apply, Equiv.symm_symm,
+    twoSiteGlobalRegroupEquiv_twoSiteSectorEmbedding]
+  change Matrix.blockDiagonal' (fun kh :
+      Fin F.sectorCount × Fin F.sectorCount ↦
+        (1 : Matrix (BoundaryIndex F kh.1 kh.2)
+          (BoundaryIndex F kh.1 kh.2) ℂ) ⊗ₖ
+            F.neighboringOperator kh.1 kh.2)
+      ⟨(k, h), ((x.1, y.2), (x.2, y.1))⟩
+      ⟨(k, h), ((x'.1, y'.2), (x'.2, y'.1))⟩ = _
+  rw [Matrix.blockDiagonal'_apply_eq]
+  simp only [Matrix.kroneckerMap_apply, Matrix.one_apply,
+    Prod.ext_iff, neighboringOperator_apply]
+  by_cases hx : x.1 = x'.1 <;> by_cases hy : y.2 = y'.2 <;>
+    simp [hx, hy]
+
+/-- In complete cyclic-edge coordinates, a translated two-site sector bond
+is block diagonal in the sector configuration and acts only on the
+corresponding edge.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8, lines
+1586--1593. -/
+private theorem reindex_embedLocalOperator_sectorBond
+    (F : PhysicalSectorFactorization K) {N : ℕ} [NeZero N]
+    (hN : 3 ≤ N) (i : Fin N) :
+    Matrix.reindex (F.sectorEdgeChainEquiv N) (F.sectorEdgeChainEquiv N)
+        (embedLocalOperator
+          (d := Fintype.card (SectorSiteIndex F)) 2 N (by omega) i F.sectorBond) =
+      Matrix.blockDiagonal' fun k ↦ F.edgePartialProduct k {i} := by
+  classical
+  ext ⟨k, x⟩ ⟨h, y⟩
+  simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
+    embedLocalOperator_apply]
+  by_cases hkh : k = h
+  · subst h
+    rw [Matrix.blockDiagonal'_apply_eq]
+    let sx := (F.cyclicEdgeEquiv k).symm x
+    let sy := (F.cyclicEdgeEquiv k).symm y
+    have hxchain : (F.sectorEdgeChainEquiv N).symm ⟨k, x⟩ =
+        fun n ↦ F.sectorFinEquiv.symm ⟨k n, sx n⟩ := by
+      funext n
+      exact F.sectorEdgeChainEquiv_symm_apply N k x n
+    have hychain : (F.sectorEdgeChainEquiv N).symm ⟨k, y⟩ =
+        fun n ↦ F.sectorFinEquiv.symm ⟨k n, sy n⟩ := by
+      funext n
+      exact F.sectorEdgeChainEquiv_symm_apply N k y n
+    rw [hxchain, hychain]
+    simp only [sectorBond, sectorCoordinateBond, Matrix.reindex_apply,
+      Equiv.symm_symm, MPSTensor.extractWindow, finTwoArrowEquiv_apply,
+      Equiv.toFun_as_coe, piFinTwoEquiv_apply, Fin.isValue,
+      Matrix.submatrix_apply, Fin.coe_ofNat_eq_mod, Nat.zero_mod,
+      Nat.add_zero, Nat.reduceMod, edgePartialProduct,
+      Finset.mem_singleton, neighboringOperator_apply]
+    have hi0 : (⟨i.val % N, Nat.mod_lt _ (Fin.pos i)⟩ : Fin N) = i := by
+      ext
+      exact Nat.mod_eq_of_lt i.isLt
+    have hi1 : (⟨(i.val + 1) % N, Nat.mod_lt _ (Fin.pos i)⟩ : Fin N) =
+        i + 1 := by
+      ext
+      simp [Fin.add_def]
+    rw [hi0, hi1]
+    have hregx : F.twoSiteGlobalRegroupEquiv
+        (F.sectorFinEquiv.symm ⟨k i, sx i⟩,
+          F.sectorFinEquiv.symm ⟨k (i + 1), sx (i + 1)⟩) =
+        ⟨(k i, k (i + 1)), F.twoSiteRegroupEquiv (k i) (k (i + 1))
+          (sx i, sx (i + 1))⟩ := by
+      change F.twoSiteGlobalRegroupEquiv
+          (F.twoSiteSectorEmbedding (k i) (k (i + 1))
+            (sx i, sx (i + 1))) = _
+      exact F.twoSiteGlobalRegroupEquiv_twoSiteSectorEmbedding _ _ _
+    have hregy : F.twoSiteGlobalRegroupEquiv
+        (F.sectorFinEquiv.symm ⟨k i, sy i⟩,
+          F.sectorFinEquiv.symm ⟨k (i + 1), sy (i + 1)⟩) =
+        ⟨(k i, k (i + 1)), F.twoSiteRegroupEquiv (k i) (k (i + 1))
+          (sy i, sy (i + 1))⟩ := by
+      change F.twoSiteGlobalRegroupEquiv
+          (F.twoSiteSectorEmbedding (k i) (k (i + 1))
+            (sy i, sy (i + 1))) = _
+      exact F.twoSiteGlobalRegroupEquiv_twoSiteSectorEmbedding _ _ _
+    rw [hregx, hregy, Matrix.blockDiagonal'_apply_eq]
+    simp only [Matrix.kroneckerMap_apply, Matrix.one_apply]
+    change (if AgreesOutsideWindow 2 (by omega) i
+          (fun n ↦ F.sectorFinEquiv.symm ⟨k n, sx n⟩)
+          (fun n ↦ F.sectorFinEquiv.symm ⟨k n, sy n⟩) then
+        (if ((sx i).1, (sx (i + 1)).2) =
+            ((sy i).1, (sy (i + 1)).2) then 1 else 0) *
+          F.neighboringOperator (k i) (k (i + 1))
+            ((sx i).2, (sx (i + 1)).1) ((sy i).2, (sy (i + 1)).1)
+      else 0) = _
+    have hxedge : ∀ n : Fin N,
+        x n = ((sx n).2, (sx (n + 1)).1) := by
+      intro n
+      simpa only [sx, cyclicEdgeEquiv_apply] using
+        (congrFun ((F.cyclicEdgeEquiv k).apply_symm_apply x) n).symm
+    have hyedge : ∀ n : Fin N,
+        y n = ((sy n).2, (sy (n + 1)).1) := by
+      intro n
+      simpa only [sy, cyclicEdgeEquiv_apply] using
+        (congrFun ((F.cyclicEdgeEquiv k).apply_symm_apply y) n).symm
+    have hj : MPSTensor.cyclicForwardSite i 1 = i + 1 := by
+      ext
+      simp [MPSTensor.cyclicForwardSite, Fin.add_def]
+    have hij : i + 1 ≠ i := by
+      exact add_one_ne_self_of_three_le hN i
+    have hcondition :
+        (AgreesOutsideWindow 2 (by omega) i
+            (fun n ↦ F.sectorFinEquiv.symm ⟨k n, sx n⟩)
+            (fun n ↦ F.sectorFinEquiv.symm ⟨k n, sy n⟩) ∧
+          ((sx i).1, (sx (i + 1)).2) =
+            ((sy i).1, (sy (i + 1)).2)) ↔
+          ∀ n : Fin N, n ≠ i → x n = y n := by
+      constructor
+      · rintro ⟨ha, hb⟩ n hni
+        rw [hxedge, hyedge]
+        apply Prod.ext
+        · by_cases hnj : n = i + 1
+          · subst n
+            exact congrArg (fun z : Fin (F.leftDim (k i)) ×
+              Fin (F.rightDim (k (i + 1))) ↦ z.2) hb
+          · have hs := (agreesOutsideWindow_iff 2 (by omega) i _ _).mp ha
+              n (by
+                rw [← MPSTensor.mem_cyclicWindowSupport_iff (by omega),
+                  mem_cyclicWindowSupport_two, hj]
+                simp [hni, hnj])
+            have hs' := congrArg F.sectorFinEquiv hs
+            simp only [Equiv.apply_symm_apply, Sigma.mk.injEq,
+              true_and] at hs'
+            exact congrArg Prod.snd (eq_of_heq hs').symm
+        · by_cases hn1i : n + 1 = i
+          · rw [hn1i]
+            exact congrArg (fun z : Fin (F.leftDim (k i)) ×
+              Fin (F.rightDim (k (i + 1))) ↦ z.1) hb
+          · have hn1j : n + 1 ≠ i + 1 := by
+              intro hn
+              exact hni (add_right_cancel hn)
+            have hs := (agreesOutsideWindow_iff 2 (by omega) i _ _).mp ha
+              (n + 1) (by
+                rw [← MPSTensor.mem_cyclicWindowSupport_iff (by omega),
+                  mem_cyclicWindowSupport_two, hj]
+                simp [hn1i, hn1j])
+            have hs' := congrArg F.sectorFinEquiv hs
+            simp only [Equiv.apply_symm_apply, Sigma.mk.injEq,
+              true_and] at hs'
+            exact congrArg Prod.fst (eq_of_heq hs').symm
+      · intro he
+        constructor
+        · rw [agreesOutsideWindow_iff]
+          intro q hq
+          have hqi : q ≠ i := by
+            intro h
+            subst q
+            exact hq (by simp)
+          have hqj : q ≠ i + 1 := by
+            intro h
+            subst q
+            apply hq
+            rw [← MPSTensor.mem_cyclicWindowSupport_iff (by omega),
+              mem_cyclicWindowSupport_two, hj]
+            simp
+          congr 1
+          refine Sigma.ext rfl (heq_of_eq ?_)
+          apply Prod.ext
+          · let p : Fin N := q - 1
+            have hpnext : p + 1 = q := by simp [p]
+            have hpne : p ≠ i := by
+              intro hp
+              have : q = i + 1 := by rw [← hpnext, hp]
+              exact hqj this
+            have hpedge := congrArg Prod.snd (he p hpne).symm
+            rw [hxedge p, hyedge p, hpnext] at hpedge
+            exact hpedge
+          · have hqedge := congrArg Prod.fst (he q hqi).symm
+            rw [hxedge q, hyedge q] at hqedge
+            exact hqedge
+        · apply Prod.ext
+          · let p : Fin N := i - 1
+            have hpnext : p + 1 = i := by simp [p]
+            have hpne : p ≠ i := by
+              intro hp
+              have hpnext' := hpnext
+              rw [hp] at hpnext'
+              exact hij hpnext'
+            have hpedge := he p hpne
+            rw [hxedge p, hyedge p, hpnext] at hpedge
+            exact congrArg (fun z : NeighborIndex F (k p) (k i) ↦ z.2) hpedge
+          · have hedge := congrArg Prod.fst (he (i + 1) hij)
+            rw [hxedge (i + 1), hyedge (i + 1)] at hedge
+            exact hedge
+    by_cases he : ∀ n : Fin N, n ≠ i → x n = y n
+    · obtain ⟨ha, hb⟩ := hcondition.mpr he
+      rw [if_pos ha, if_pos hb, one_mul]
+      rw [Finset.prod_eq_single i]
+      · rw [if_pos rfl]
+        rw [hxedge i, hyedge i]
+        rfl
+      · intro n _ hni
+        rw [if_neg hni, if_pos (he n hni)]
+      · simp
+    · have hnot : ¬ (AgreesOutsideWindow 2 (by omega) i
+            (fun n ↦ F.sectorFinEquiv.symm ⟨k n, sx n⟩)
+            (fun n ↦ F.sectorFinEquiv.symm ⟨k n, sy n⟩) ∧
+          ((sx i).1, (sx (i + 1)).2) =
+            ((sy i).1, (sy (i + 1)).2)) := by
+        exact fun hc ↦ he (hcondition.mp hc)
+      push Not at he
+      obtain ⟨n, hni, hnxy⟩ := he
+      have hprod : (∏ q : Fin N,
+          if q = i then
+            ∑ a, F.rightTensor (k q) a (x q).1 (y q).1 *
+              F.leftTensor (k (q + 1)) a (x q).2 (y q).2
+          else if x q = y q then 1 else 0) = 0 := by
+        apply Finset.prod_eq_zero (Finset.mem_univ n)
+        simp [hni, hnxy]
+      rw [hprod]
+      by_cases ha : AgreesOutsideWindow 2 (by omega) i
+          (fun n ↦ F.sectorFinEquiv.symm ⟨k n, sx n⟩)
+          (fun n ↦ F.sectorFinEquiv.symm ⟨k n, sy n⟩)
+      · rw [if_pos ha]
+        have hb : ((sx i).1, (sx (i + 1)).2) ≠
+            ((sy i).1, (sy (i + 1)).2) := fun hb ↦ hnot ⟨ha, hb⟩
+        rw [if_neg hb, zero_mul]
+      · rw [if_neg ha]
+  · rw [Matrix.blockDiagonal'_apply_ne _ _ _ hkh]
+    let sx := (F.cyclicEdgeEquiv k).symm x
+    let ty := (F.cyclicEdgeEquiv h).symm y
+    have hxchain : (F.sectorEdgeChainEquiv N).symm ⟨k, x⟩ =
+        fun n ↦ F.sectorFinEquiv.symm ⟨k n, sx n⟩ := by
+      funext n
+      exact F.sectorEdgeChainEquiv_symm_apply N k x n
+    have hychain : (F.sectorEdgeChainEquiv N).symm ⟨h, y⟩ =
+        fun n ↦ F.sectorFinEquiv.symm ⟨h n, ty n⟩ := by
+      funext n
+      exact F.sectorEdgeChainEquiv_symm_apply N h y n
+    rw [hxchain, hychain]
+    simp only [sectorBond, sectorCoordinateBond, Matrix.reindex_apply,
+      Equiv.symm_symm, MPSTensor.extractWindow, finTwoArrowEquiv_apply,
+      Equiv.toFun_as_coe, piFinTwoEquiv_apply, Fin.isValue,
+      Matrix.submatrix_apply, Fin.coe_ofNat_eq_mod, Nat.zero_mod,
+      Nat.add_zero, Nat.reduceMod]
+    have hi0 : (⟨i.val % N, Nat.mod_lt _ (Fin.pos i)⟩ : Fin N) = i := by
+      ext
+      exact Nat.mod_eq_of_lt i.isLt
+    have hi1 : (⟨(i.val + 1) % N, Nat.mod_lt _ (Fin.pos i)⟩ : Fin N) =
+        i + 1 := by
+      ext
+      simp [Fin.add_def]
+    rw [hi0, hi1]
+    have hregx : F.twoSiteGlobalRegroupEquiv
+        (F.sectorFinEquiv.symm ⟨k i, sx i⟩,
+          F.sectorFinEquiv.symm ⟨k (i + 1), sx (i + 1)⟩) =
+        ⟨(k i, k (i + 1)), F.twoSiteRegroupEquiv (k i) (k (i + 1))
+          (sx i, sx (i + 1))⟩ := by
+      change F.twoSiteGlobalRegroupEquiv
+          (F.twoSiteSectorEmbedding (k i) (k (i + 1))
+            (sx i, sx (i + 1))) = _
+      exact F.twoSiteGlobalRegroupEquiv_twoSiteSectorEmbedding _ _ _
+    have hregy : F.twoSiteGlobalRegroupEquiv
+        (F.sectorFinEquiv.symm ⟨h i, ty i⟩,
+          F.sectorFinEquiv.symm ⟨h (i + 1), ty (i + 1)⟩) =
+        ⟨(h i, h (i + 1)), F.twoSiteRegroupEquiv (h i) (h (i + 1))
+          (ty i, ty (i + 1))⟩ := by
+      change F.twoSiteGlobalRegroupEquiv
+          (F.twoSiteSectorEmbedding (h i) (h (i + 1))
+            (ty i, ty (i + 1))) = _
+      exact F.twoSiteGlobalRegroupEquiv_twoSiteSectorEmbedding _ _ _
+    rw [hregx, hregy]
+    by_cases ha : AgreesOutsideWindow 2 (by omega) i
+        (fun n ↦ F.sectorFinEquiv.symm ⟨k n, sx n⟩)
+        (fun n ↦ F.sectorFinEquiv.symm ⟨h n, ty n⟩)
+    · rw [if_pos ha]
+      have hpairs : (k i, k (i + 1)) ≠ (h i, h (i + 1)) := by
+        intro hp
+        apply hkh
+        funext q
+        by_cases hq : ((q.val + N - i.val) % N < 2)
+        · rw [← MPSTensor.mem_cyclicWindowSupport_iff (by omega),
+            mem_cyclicWindowSupport_two] at hq
+          rcases hq with rfl | hq
+          · exact congrArg Prod.fst hp
+          · have hj : MPSTensor.cyclicForwardSite i 1 = i + 1 := by
+              ext
+              simp [MPSTensor.cyclicForwardSite, Fin.add_def]
+            rw [hj] at hq
+            subst q
+            exact congrArg Prod.snd hp
+        · have hs := (agreesOutsideWindow_iff 2 (by omega) i _ _).mp ha q hq
+          have hs' := congrArg F.sectorFinEquiv hs
+          simpa only [Equiv.apply_symm_apply] using
+            (congrArg Sigma.fst hs').symm
+      rw [Matrix.blockDiagonal'_apply_ne _ _ _ hpairs]
+    · rw [if_neg ha]
+
+private theorem reindex_list_prod
+    {α β : Type*} [Fintype α] [DecidableEq α]
+    [Fintype β] [DecidableEq β] (e : α ≃ β)
+    (l : List (Matrix α α ℂ)) :
+    Matrix.reindex e e l.prod =
+      (l.map fun A ↦ Matrix.reindex e e A).prod := by
+  induction l with
+  | nil =>
+      ext x y
+      simp [Matrix.reindex_apply, Matrix.one_apply]
+  | cons A l ih =>
+      simp only [List.prod_cons, List.map_cons]
+      change Matrix.reindexLinearEquiv ℂ ℂ e e (A * l.prod) = _
+      rw [← Matrix.reindexLinearEquiv_mul ℂ ℂ e e e]
+      simp only [Matrix.coe_reindexLinearEquiv, ih]
+
+private theorem blockDiagonal'_list_prod
+    {ι : Type*} [Fintype ι] [DecidableEq ι]
+    {α : ι → Type*} [∀ i, Fintype (α i)] [∀ i, DecidableEq (α i)]
+    (l : List ((i : ι) → Matrix (α i) (α i) ℂ)) :
+    (l.map Matrix.blockDiagonal').prod =
+      Matrix.blockDiagonal' fun i ↦ (l.map fun A ↦ A i).prod := by
+  induction l with
+  | nil =>
+      ext ⟨i, x⟩ ⟨j, y⟩
+      by_cases hij : i = j
+      · subst j
+        simp [Matrix.one_apply, Matrix.blockDiagonal'_apply]
+      · simp [Matrix.blockDiagonal'_apply_ne _ _ _ hij, hij]
+  | cons A l ih =>
+      simp only [List.map_cons, List.prod_cons]
+      rw [ih, ← Matrix.blockDiagonal'_mul]
+
+/-- For every length at least three, the sector-coordinate MPO is exactly
+the ordered product of the translated sector bonds. -/
+theorem mpo_sectorCoordinateTensor_eq_product_sectorBond
+    (F : PhysicalSectorFactorization K) {N : ℕ} [NeZero N]
+    (hN : 3 ≤ N) :
+    mpo F.sectorCoordinateTensor N =
+      (List.ofFn fun i : Fin N ↦
+        embedLocalOperator
+          (d := Fintype.card (SectorSiteIndex F)) 2 N (by omega) i
+            F.sectorBond).prod := by
+  apply (Matrix.reindex (F.sectorEdgeChainEquiv N)
+    (F.sectorEdgeChainEquiv N)).injective
+  rw [F.reindex_mpo_sectorCoordinateTensor_sectorEdgeChainEquiv]
+  rw [reindex_list_prod]
+  rw [show (List.ofFn fun i : Fin N ↦
+      embedLocalOperator
+        (d := Fintype.card (SectorSiteIndex F)) 2 N (by omega) i
+          F.sectorBond).map
+        (fun A ↦ Matrix.reindex (F.sectorEdgeChainEquiv N)
+          (F.sectorEdgeChainEquiv N) A) =
+      List.ofFn (fun i : Fin N ↦
+        Matrix.reindex (F.sectorEdgeChainEquiv N) (F.sectorEdgeChainEquiv N)
+          (embedLocalOperator
+            (d := Fintype.card (SectorSiteIndex F)) 2 N (by omega) i
+              F.sectorBond)) by
+    simp
+    rfl]
+  have hmap :
+      (List.ofFn fun i : Fin N ↦
+        Matrix.reindex (F.sectorEdgeChainEquiv N) (F.sectorEdgeChainEquiv N)
+          (embedLocalOperator
+            (d := Fintype.card (SectorSiteIndex F)) 2 N (by omega) i
+              F.sectorBond)) =
+      List.ofFn (fun i : Fin N ↦
+        Matrix.blockDiagonal' fun k ↦ F.edgePartialProduct k {i}) := by
+    exact congrArg List.ofFn (funext fun i ↦
+      F.reindex_embedLocalOperator_sectorBond hN i)
+  rw [hmap]
+  rw [show List.ofFn (fun i : Fin N ↦
+      Matrix.blockDiagonal' fun k ↦ F.edgePartialProduct k {i}) =
+      (List.ofFn fun i : Fin N ↦
+        fun k ↦ F.edgePartialProduct k {i}).map Matrix.blockDiagonal' by
+    simp
+    rfl]
+  rw [blockDiagonal'_list_prod]
+  congr
+  funext k
+  symm
+  have hl : (List.ofFn fun i : Fin N ↦
+      fun q ↦ F.edgePartialProduct q {i}).map (fun A ↦ A k) =
+      List.ofFn (fun i : Fin N ↦ F.edgePartialProduct k {i}) := by
+    simp
+    rfl
+  rw [hl]
+  exact F.prod_edgePartialProduct_singletons_univ k
+
+end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/PhysicalSectorProductTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorProductTransport.lean
@@ -1,0 +1,659 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalSectorProductRealization
+import TNLean.MPS.MPDO.PhysicalSectorBondTwoSite
+
+/-!
+# Physical transport of the sector product realization
+
+This file transports the cyclic neighboring-operator product from physical-sector
+coordinates to the original physical coordinates.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, Proposition C.8, lines 1581--1593
+-/
+
+open scoped Matrix BigOperators Kronecker
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D}
+
+/-- The sitewise product of the one-site physical coordinate matrix on a
+chain of length `N`.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1581--1583. -/
+private noncomputable def physicalCoordinateMatrixN
+    (F : PhysicalSectorFactorization K) (N : ℕ) :
+    Matrix (Fin N → Fin (Fintype.card (SectorSiteIndex F)))
+      (Fin N → Fin d) ℂ :=
+  fun s t ↦ ∏ n : Fin N, F.physicalCoordinateMatrix (s n) (t n)
+
+/-- The sitewise physical coordinate matrix is an isometry. -/
+private theorem physicalCoordinateMatrixN_isometry
+    (F : PhysicalSectorFactorization K) (N : ℕ) :
+    (F.physicalCoordinateMatrixN N)ᴴ * F.physicalCoordinateMatrixN N = 1 := by
+  classical
+  ext x y
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply,
+    physicalCoordinateMatrixN]
+  simp_rw [star_prod, ← Finset.prod_mul_distrib]
+  rw [← Fintype.piFinset_univ]
+  rw [← Finset.prod_univ_sum
+    (fun _ : Fin N ↦
+      (Finset.univ : Finset (Fin (Fintype.card (SectorSiteIndex F)))))
+    (fun n a ↦ star (F.physicalCoordinateMatrix a (x n)) *
+      F.physicalCoordinateMatrix a (y n))]
+  have hentry : ∀ n : Fin N,
+      (∑ a : Fin (Fintype.card (SectorSiteIndex F)),
+        star (F.physicalCoordinateMatrix a (x n)) *
+        F.physicalCoordinateMatrix a (y n)) =
+      if x n = y n then 1 else 0 := by
+    intro n
+    simpa only [Matrix.mul_apply, Matrix.conjTranspose_apply,
+      Matrix.one_apply] using
+      congrFun (congrFun F.physicalCoordinateMatrix_isometry (x n)) (y n)
+  simp_rw [hentry]
+  by_cases hxy : x = y
+  · subst y
+    simp
+  · obtain ⟨n, hn⟩ := Function.ne_iff.mp hxy
+    rw [Finset.prod_eq_zero (Finset.mem_univ n)]
+    · simp [hxy]
+    · simp [hn]
+
+/-- The sitewise physical coordinate matrix is a coisometry. -/
+private theorem physicalCoordinateMatrixN_coisometry
+    (F : PhysicalSectorFactorization K) (N : ℕ) :
+    F.physicalCoordinateMatrixN N * (F.physicalCoordinateMatrixN N)ᴴ = 1 := by
+  classical
+  ext x y
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply,
+    physicalCoordinateMatrixN]
+  simp_rw [star_prod, ← Finset.prod_mul_distrib]
+  rw [← Fintype.piFinset_univ]
+  rw [← Finset.prod_univ_sum
+    (fun _ : Fin N ↦ (Finset.univ : Finset (Fin d)))
+    (fun n a ↦ F.physicalCoordinateMatrix (x n) a *
+      star (F.physicalCoordinateMatrix (y n) a))]
+  have hentry : ∀ n : Fin N,
+      (∑ a, F.physicalCoordinateMatrix (x n) a *
+        star (F.physicalCoordinateMatrix (y n) a)) =
+      if x n = y n then 1 else 0 := by
+    intro n
+    simpa only [Matrix.mul_apply, Matrix.conjTranspose_apply,
+      Matrix.one_apply] using
+      congrFun (congrFun F.physicalCoordinateMatrix_coisometry (x n)) (y n)
+  simp_rw [hentry]
+  by_cases hxy : x = y
+  · subst y
+    simp
+  · obtain ⟨n, hn⟩ := Function.ne_iff.mp hxy
+    rw [Finset.prod_eq_zero (Finset.mem_univ n)]
+    · simp [hxy]
+    · simp [hn]
+
+private theorem list_prod_sum_ofFn {a n : Type*} [Fintype a]
+    [Fintype n] [DecidableEq n] {N : ℕ}
+    (f : (i : Fin N) → a → Matrix n n ℂ) :
+    (List.ofFn fun i : Fin N ↦ ∑ x : a, f i x).prod =
+      ∑ x : Fin N → a, (List.ofFn fun i : Fin N ↦ f i (x i)).prod := by
+  classical
+  induction N with
+  | zero => simp
+  | succ N ih =>
+      rw [List.ofFn_succ, List.prod_cons]
+      simp only [ih]
+      rw [Finset.sum_mul]
+      simp_rw [Finset.mul_sum]
+      have h := Fintype.sum_equiv
+        (Fin.consEquiv fun _ : Fin (N + 1) ↦ a)
+        (fun p : a × (Fin N → a) ↦
+          f 0 p.1 * (List.ofFn fun i : Fin N ↦ f i.succ (p.2 i)).prod)
+        (fun x : Fin (N + 1) → a ↦
+          (List.ofFn fun i : Fin (N + 1) ↦ f i (x i)).prod)
+        (fun p ↦ by simp [List.ofFn_succ])
+      rw [Fintype.sum_prod_type] at h
+      exact h
+
+private theorem list_prod_smul_ofFn {n : Type*} [Fintype n]
+    [DecidableEq n] {N : ℕ} (c : Fin N → ℂ)
+    (A : Fin N → Matrix n n ℂ) :
+    (List.ofFn fun i : Fin N ↦ c i • A i).prod =
+      (∏ i : Fin N, c i) • (List.ofFn A).prod := by
+  induction N with
+  | zero => simp
+  | succ N ih =>
+      simp only [List.ofFn_succ, List.prod_cons, ih, Fin.prod_univ_succ,
+        Matrix.smul_mul, Matrix.mul_smul, smul_smul]
+      rw [mul_comm (c 0)]
+
+private def braKetFunctionsEquiv {i a b : Type*} :
+    ((i → b) × (i → a)) ≃ (i → a × b) where
+  toFun x j := (x.2 j, x.1 j)
+  invFun x := (fun j ↦ (x j).2, fun j ↦ (x j).1)
+  left_inv _ := rfl
+  right_inv _ := rfl
+
+private theorem evalWord_changePhysicalBasis_ofFn {e : ℕ}
+    (V : Matrix (Fin e) (Fin d) ℂ) (M : MPOTensor d D) {N : ℕ}
+    (s t : Fin N → Fin e) :
+    MPOTensor.evalWord (changePhysicalBasis V M) (List.ofFn s) (List.ofFn t) =
+      ∑ x : Fin N → Fin d × Fin d,
+        (∏ i : Fin N, V (s i) (x i).1 * star (V (t i) (x i).2)) •
+          MPOTensor.evalWord M
+            (List.ofFn fun i : Fin N ↦ (x i).1)
+            (List.ofFn fun i : Fin N ↦ (x i).2) := by
+  rw [MPOTensor.evalWord_ofFn]
+  simp_rw [changePhysicalBasis_apply_eq_sum]
+  rw [list_prod_sum_ofFn]
+  apply Finset.sum_congr rfl
+  intro x _
+  rw [list_prod_smul_ofFn, MPOTensor.evalWord_ofFn]
+
+/-- The length-`N` MPO transforms by the sitewise physical coordinate
+matrix.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1581--1583. -/
+private theorem physicalCoordinateMatrixN_mpo
+    (F : PhysicalSectorFactorization K) (N : ℕ) :
+    sandwichMap (F.physicalCoordinateMatrixN N) (mpo K N) =
+      mpo F.sectorCoordinateTensor N := by
+  rw [F.sectorCoordinateTensor_eq_changePhysicalBasis]
+  ext s t
+  simp only [sandwichMap_apply, Matrix.mul_apply, Matrix.conjTranspose_apply,
+    physicalCoordinateMatrixN, mpo_apply, mpoMatrixEntry,
+    evalWord_changePhysicalBasis_ofFn, Matrix.trace_sum, Matrix.trace_smul,
+    smul_eq_mul, star_prod]
+  have hexpand :
+      (∑ q : Fin N → Fin d,
+        (∑ p : Fin N → Fin d,
+          (∏ i : Fin N, F.physicalCoordinateMatrix (s i) (p i)) *
+            Matrix.trace (MPOTensor.evalWord K (List.ofFn p) (List.ofFn q))) *
+          (∏ i : Fin N, star (F.physicalCoordinateMatrix (t i) (q i)))) =
+        ∑ q : Fin N → Fin d, ∑ p : Fin N → Fin d,
+          ((∏ i : Fin N, F.physicalCoordinateMatrix (s i) (p i)) *
+            Matrix.trace (MPOTensor.evalWord K (List.ofFn p) (List.ofFn q))) *
+          (∏ i : Fin N, star (F.physicalCoordinateMatrix (t i) (q i))) := by
+    apply Finset.sum_congr rfl
+    intro q _
+    simpa only using Finset.sum_mul Finset.univ
+      (fun p : Fin N → Fin d ↦
+        (∏ i : Fin N, F.physicalCoordinateMatrix (s i) (p i)) *
+          Matrix.trace (MPOTensor.evalWord K (List.ofFn p) (List.ofFn q)))
+      (∏ i : Fin N, star (F.physicalCoordinateMatrix (t i) (q i)))
+  rw [hexpand]
+  have h := Fintype.sum_equiv
+    (braKetFunctionsEquiv (i := Fin N) (a := Fin d) (b := Fin d))
+    (fun p : (Fin N → Fin d) × (Fin N → Fin d) ↦
+      (∏ i : Fin N, F.physicalCoordinateMatrix (s i) (p.2 i)) *
+        Matrix.trace (MPOTensor.evalWord K (List.ofFn p.2) (List.ofFn p.1)) *
+        (∏ i : Fin N, star (F.physicalCoordinateMatrix (t i) (p.1 i))))
+    (fun x : Fin N → Fin d × Fin d ↦
+      (∏ i : Fin N,
+        F.physicalCoordinateMatrix (s i) (x i).1 *
+          star (F.physicalCoordinateMatrix (t i) (x i).2)) *
+        Matrix.trace (MPOTensor.evalWord K
+          (List.ofFn fun i : Fin N ↦ (x i).1)
+          (List.ofFn fun i : Fin N ↦ (x i).2)))
+    (fun p ↦ by
+      dsimp
+      change
+        (∏ i : Fin N, F.physicalCoordinateMatrix (s i) (p.2 i)) *
+              Matrix.trace (MPOTensor.evalWord K
+                (List.ofFn p.2) (List.ofFn p.1)) *
+            (∏ i : Fin N,
+              star (F.physicalCoordinateMatrix (t i) (p.1 i))) =
+          (∏ i : Fin N,
+            F.physicalCoordinateMatrix (s i) (p.2 i) *
+              star (F.physicalCoordinateMatrix (t i) (p.1 i))) *
+            Matrix.trace (MPOTensor.evalWord K
+              (List.ofFn p.2) (List.ofFn p.1))
+      have hprod :
+          (∏ i : Fin N,
+            F.physicalCoordinateMatrix (s i) (p.2 i) *
+              star (F.physicalCoordinateMatrix (t i) (p.1 i))) =
+            (∏ i : Fin N, F.physicalCoordinateMatrix (s i) (p.2 i)) *
+              (∏ i : Fin N,
+                star (F.physicalCoordinateMatrix (t i) (p.1 i))) := by
+        exact Finset.prod_mul_distrib
+      rw [hprod]
+      ring)
+  rw [Fintype.sum_prod_type] at h
+  exact h
+
+private def cyclicShiftEquiv (N : ℕ) (i : Fin N) : Fin N ≃ Fin N where
+  toFun k := ⟨(i.val + k.val) % N, Nat.mod_lt _ (Fin.pos i)⟩
+  invFun k := ⟨(k.val + N - i.val) % N, Nat.mod_lt _ (Fin.pos i)⟩
+  left_inv k := by
+    apply Fin.ext
+    exact MPSTensor.offset_mod_eq i.isLt k.isLt
+  right_inv k := by
+    apply Fin.ext
+    change (i.val + ((k.val + N - i.val) % N)) % N = k.val
+    let offset := (k.val + N - i.val) % N
+    have hsite : (i.val + offset) % N = k.val := by
+      rcases lt_or_ge k.val i.val with hki | hik
+      · have hmod : offset = k.val + N - i.val := by
+          simp only [offset]
+          rw [Nat.mod_eq_of_lt (by omega)]
+        rw [hmod, show i.val + (k.val + N - i.val) = k.val + N by omega,
+          Nat.add_mod_right, Nat.mod_eq_of_lt k.isLt]
+      · have hmod : offset = k.val - i.val := by
+          simp only [offset]
+          have heq : k.val + N - i.val = N + (k.val - i.val) := by omega
+          rw [heq, Nat.add_mod_left,
+            Nat.mod_eq_of_lt (lt_of_le_of_lt (Nat.sub_le _ _) k.isLt)]
+        rw [hmod, Nat.add_sub_of_le hik, Nat.mod_eq_of_lt k.isLt]
+    exact hsite
+
+private def cyclicWindowIndexEquiv (L N : ℕ) (hLN : L ≤ N) (i : Fin N) :
+    Fin L ⊕ Fin (N - L) ≃ Fin N :=
+  finSumFinEquiv |>.trans (finCongr (Nat.add_sub_of_le hLN)) |>.trans
+    (cyclicShiftEquiv N i)
+
+@[simp] private theorem cyclicWindowIndexEquiv_inl
+    (L N : ℕ) (hLN : L ≤ N) (i : Fin N) (r : Fin L) :
+    cyclicWindowIndexEquiv L N hLN i (Sum.inl r) =
+      ⟨(i.val + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩ := rfl
+
+@[simp] private theorem cyclicWindowIndexEquiv_inr
+    (L N : ℕ) (hLN : L ≤ N) (i : Fin N) (r : Fin (N - L)) :
+    cyclicWindowIndexEquiv L N hLN i (Sum.inr r) =
+      ⟨(i.val + L + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩ := by
+  apply Fin.ext
+  change (i.val + (L + r.val)) % N = (i.val + L + r.val) % N
+  congr 1
+  omega
+
+private theorem prod_cyclicWindow_complement
+    (L N : ℕ) (hLN : L ≤ N) (i : Fin N) (f : Fin N → ℂ) :
+    (∏ n : Fin N, f n) =
+      (∏ r : Fin L, f ⟨(i.val + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩) *
+        (∏ r : Fin (N - L),
+          f ⟨(i.val + L + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩) := by
+  rw [Fintype.prod_equiv (cyclicWindowIndexEquiv L N hLN i).symm
+    f (fun x ↦ f (cyclicWindowIndexEquiv L N hLN i x))
+    (fun n ↦ by simp)]
+  rw [Fintype.prod_sum_type]
+  simp only [cyclicWindowIndexEquiv_inl, cyclicWindowIndexEquiv_inr]
+
+private theorem reindex_physicalCoordinateMatrixN_windowComplement
+    (F : PhysicalSectorFactorization K) {N : ℕ} (hN : 2 ≤ N) (i : Fin N) :
+    Matrix.reindex
+        (windowComplementEquiv
+          (d := Fintype.card (SectorSiteIndex F)) 2 N hN i)
+        (windowComplementEquiv (d := d) 2 N hN i)
+        (F.physicalCoordinateMatrixN N) =
+      F.physicalCoordinateMatrixN 2 ⊗ₖ F.physicalCoordinateMatrixN (N - 2) := by
+  ext ⟨x, u⟩ ⟨y, v⟩
+  let es := windowComplementEquiv
+    (d := Fintype.card (SectorSiteIndex F)) 2 N hN i
+  let ep := windowComplementEquiv (d := d) 2 N hN i
+  let s := es.symm (x, u)
+  let t := ep.symm (y, v)
+  have hes : es s = (x, u) := es.apply_symm_apply (x, u)
+  have het : ep t = (y, v) := ep.apply_symm_apply (y, v)
+  have hx : MPSTensor.extractWindow 2 i s = x := congrArg Prod.fst hes
+  have hy : MPSTensor.extractWindow 2 i t = y := congrArg Prod.fst het
+  have hu : (fun r ↦ s ⟨(i.val + 2 + r.val) % N,
+      Nat.mod_lt _ (Fin.pos i)⟩) = u := congrArg Prod.snd hes
+  have hv : (fun r ↦ t ⟨(i.val + 2 + r.val) % N,
+      Nat.mod_lt _ (Fin.pos i)⟩) = v := congrArg Prod.snd het
+  change (∏ n : Fin N, F.physicalCoordinateMatrix (s n) (t n)) = _
+  rw [prod_cyclicWindow_complement 2 N hN i]
+  simp only [MPSTensor.extractWindow] at hx hy
+  simp only [physicalCoordinateMatrixN, Matrix.kroneckerMap_apply]
+  apply congrArg₂ (fun a b : ℂ ↦ a * b)
+  · apply Finset.prod_congr rfl
+    intro r _
+    rw [congrFun hx r, congrFun hy r]
+  · apply Finset.prod_congr rfl
+    intro r _
+    rw [congrFun hu r, congrFun hv r]
+
+private theorem physicalCoordinateMatrixN_two
+    (F : PhysicalSectorFactorization K) :
+    F.physicalCoordinateMatrixN 2 =
+      Matrix.reindex
+        (finTwoArrowEquiv
+          (Fin (Fintype.card (SectorSiteIndex F)))).symm
+        (finTwoArrowEquiv (Fin d)).symm F.physicalCoordinateMatrixTwo := by
+  ext s t
+  simp [physicalCoordinateMatrixN, physicalCoordinateMatrixTwo,
+    Matrix.reindex_apply, Matrix.kroneckerMap_apply, finTwoArrowEquiv]
+
+private theorem sandwichMap_physicalCoordinateMatrixN_two_physicalBond
+    (F : PhysicalSectorFactorization K) :
+    sandwichMap (F.physicalCoordinateMatrixN 2) F.physicalBond =
+      F.sectorBond := by
+  apply (Matrix.reindex
+    (finTwoArrowEquiv (Fin (Fintype.card (SectorSiteIndex F))))
+    (finTwoArrowEquiv (Fin (Fintype.card (SectorSiteIndex F))))).injective
+  simp only [sandwichMap_apply]
+  change Matrix.reindexLinearEquiv ℂ ℂ
+      (finTwoArrowEquiv (Fin (Fintype.card (SectorSiteIndex F))))
+      (finTwoArrowEquiv (Fin (Fintype.card (SectorSiteIndex F))))
+      (F.physicalCoordinateMatrixN 2 * F.physicalBond *
+        (F.physicalCoordinateMatrixN 2)ᴴ) = _
+  rw [← Matrix.reindexLinearEquiv_mul ℂ ℂ
+      (finTwoArrowEquiv (Fin (Fintype.card (SectorSiteIndex F))))
+      (finTwoArrowEquiv (Fin d))
+      (finTwoArrowEquiv (Fin (Fintype.card (SectorSiteIndex F)))),
+    ← Matrix.reindexLinearEquiv_mul ℂ ℂ
+      (finTwoArrowEquiv (Fin (Fintype.card (SectorSiteIndex F))))
+      (finTwoArrowEquiv (Fin d))
+      (finTwoArrowEquiv (Fin d))]
+  simp only [Matrix.coe_reindexLinearEquiv]
+  have hV : Matrix.reindex
+      (finTwoArrowEquiv (Fin (Fintype.card (SectorSiteIndex F))))
+      (finTwoArrowEquiv (Fin d)) (F.physicalCoordinateMatrixN 2) =
+      F.physicalCoordinateMatrixTwo := by
+    ext x y
+    simp [physicalCoordinateMatrixN_two, Matrix.reindex_apply]
+  have hB : Matrix.reindex (finTwoArrowEquiv (Fin d))
+      (finTwoArrowEquiv (Fin d)) F.physicalBond = F.physicalPairBond := by
+    ext x y
+    simp [physicalBond, Matrix.reindex_apply]
+  have hVH : Matrix.reindex (finTwoArrowEquiv (Fin d))
+      (finTwoArrowEquiv (Fin (Fintype.card (SectorSiteIndex F))))
+      (F.physicalCoordinateMatrixN 2)ᴴ = F.physicalCoordinateMatrixTwoᴴ := by
+    simpa only [Matrix.conjTranspose_reindex] using
+      congrArg Matrix.conjTranspose hV
+  have hSector : Matrix.reindex
+      (finTwoArrowEquiv (Fin (Fintype.card (SectorSiteIndex F))))
+      (finTwoArrowEquiv (Fin (Fintype.card (SectorSiteIndex F)))) F.sectorBond =
+      F.sectorCoordinateBond := by
+    ext x y
+    simp [sectorBond, Matrix.reindex_apply]
+  rw [hV, hB, hVH, hSector]
+  simp only [physicalPairBond, sandwichMap_apply,
+    Matrix.conjTranspose_conjTranspose, Matrix.mul_assoc]
+  rw [← Matrix.mul_assoc F.physicalCoordinateMatrixTwo
+    F.physicalCoordinateMatrixTwoᴴ,
+    F.physicalCoordinateMatrixTwo_coisometry, Matrix.one_mul]
+  exact Matrix.mul_one _
+
+/-- A translated physical bond is carried to the corresponding
+sector-coordinate bond by the sitewise physical coordinate matrix.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8, lines
+1581--1593. -/
+private theorem physicalCoordinateMatrixN_embedLocalOperator_physicalBond
+    (F : PhysicalSectorFactorization K) {N : ℕ} (hN : 2 ≤ N) (i : Fin N) :
+    sandwichMap (F.physicalCoordinateMatrixN N)
+        (embedLocalOperator (d := d) 2 N hN i F.physicalBond) =
+      embedLocalOperator
+        (d := Fintype.card (SectorSiteIndex F)) 2 N hN i F.sectorBond := by
+  let es := windowComplementEquiv
+    (d := Fintype.card (SectorSiteIndex F)) 2 N hN i
+  let ep := windowComplementEquiv (d := d) 2 N hN i
+  apply (Matrix.reindex es es).injective
+  simp only [sandwichMap_apply]
+  change Matrix.reindexLinearEquiv ℂ ℂ es es
+      (F.physicalCoordinateMatrixN N *
+        embedLocalOperator (d := d) 2 N hN i F.physicalBond *
+          (F.physicalCoordinateMatrixN N)ᴴ) = _
+  rw [← Matrix.reindexLinearEquiv_mul ℂ ℂ es ep es,
+    ← Matrix.reindexLinearEquiv_mul ℂ ℂ es ep ep]
+  simp only [Matrix.coe_reindexLinearEquiv]
+  rw [F.reindex_physicalCoordinateMatrixN_windowComplement hN i,
+    reindex_embedLocalOperator_windowComplement]
+  have hVH : Matrix.reindex ep es (F.physicalCoordinateMatrixN N)ᴴ =
+      (F.physicalCoordinateMatrixN 2)ᴴ ⊗ₖ
+        (F.physicalCoordinateMatrixN (N - 2))ᴴ := by
+    simpa only [Matrix.conjTranspose_reindex,
+      Matrix.conjTranspose_kronecker] using congrArg Matrix.conjTranspose
+        (F.reindex_physicalCoordinateMatrixN_windowComplement hN i)
+  rw [hVH, reindex_embedLocalOperator_windowComplement]
+  rw [← Matrix.mul_kronecker_mul, ← Matrix.mul_kronecker_mul]
+  simp only [Matrix.mul_one]
+  rw [← sandwichMap_apply,
+    F.sandwichMap_physicalCoordinateMatrixN_two_physicalBond,
+    F.physicalCoordinateMatrixN_coisometry]
+
+private theorem sandwichMap_list_prod
+    {a b : Type*} [Fintype a] [DecidableEq a]
+    [Fintype b] [DecidableEq b] (V : Matrix a b ℂ)
+    (hiso : Vᴴ * V = 1) (hcoiso : V * Vᴴ = 1)
+    (l : List (Matrix b b ℂ)) :
+    sandwichMap V l.prod = (l.map (sandwichMap V)).prod := by
+  induction l with
+  | nil =>
+      simp only [List.prod_nil, List.map_nil, sandwichMap_apply]
+      simpa only [Matrix.mul_one] using hcoiso
+  | cons A l ih =>
+      simp only [List.prod_cons, List.map_cons, sandwichMap_apply]
+      rw [← ih]
+      simp only [sandwichMap_apply, Matrix.mul_assoc]
+      rw [← Matrix.mul_assoc Vᴴ V, hiso, Matrix.one_mul]
+
+private theorem physicalCoordinateMatrixN_product_physicalBond
+    (F : PhysicalSectorFactorization K) {N : ℕ} (hN : 2 ≤ N) :
+    sandwichMap (F.physicalCoordinateMatrixN N)
+        (List.ofFn fun i : Fin N ↦
+          embedLocalOperator (d := d) 2 N hN i F.physicalBond).prod =
+      (List.ofFn fun i : Fin N ↦
+        embedLocalOperator
+          (d := Fintype.card (SectorSiteIndex F)) 2 N hN i F.sectorBond).prod := by
+  rw [sandwichMap_list_prod _ (F.physicalCoordinateMatrixN_isometry N)
+    (F.physicalCoordinateMatrixN_coisometry N)]
+  congr 1
+  rw [List.map_ofFn]
+  apply congrArg List.ofFn
+  funext i
+  exact F.physicalCoordinateMatrixN_embedLocalOperator_physicalBond hN i
+
+/-- For every length at least three, the MPO in the original physical
+coordinates is the ordered product of the translated physical-sector bonds.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8, lines
+1581--1593.
+
+**Scope restriction (given physical-sector factorization):** The source
+derives this factorization and positivity of the neighboring operators from
+SAL. That upstream construction remains documented in
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`. -/
+private theorem mpo_eq_product_physicalBond_of_three_le
+    (F : PhysicalSectorFactorization K) {N : ℕ} [NeZero N] (hN : 3 ≤ N) :
+    mpo K N =
+      (List.ofFn fun i : Fin N ↦
+        embedLocalOperator (d := d) 2 N (by omega) i F.physicalBond).prod := by
+  let V := F.physicalCoordinateMatrixN N
+  have htransport : sandwichMap V (mpo K N) =
+      sandwichMap V
+        (List.ofFn fun i : Fin N ↦
+          embedLocalOperator (d := d) 2 N (by omega) i F.physicalBond).prod := by
+    rw [F.physicalCoordinateMatrixN_mpo,
+      F.mpo_sectorCoordinateTensor_eq_product_sectorBond hN,
+      F.physicalCoordinateMatrixN_product_physicalBond (by omega)]
+  have hiso : Vᴴ * V = 1 := F.physicalCoordinateMatrixN_isometry N
+  calc
+    mpo K N = sandwichMap Vᴴ (sandwichMap V (mpo K N)) := by
+      simp only [sandwichMap_apply, Matrix.conjTranspose_conjTranspose,
+        Matrix.mul_assoc]
+      rw [hiso, Matrix.mul_one, ← Matrix.mul_assoc, hiso, Matrix.one_mul]
+    _ = sandwichMap Vᴴ (sandwichMap V
+        (List.ofFn fun i : Fin N ↦
+          embedLocalOperator (d := d) 2 N (by omega) i F.physicalBond).prod) := by
+      rw [htransport]
+    _ = (List.ofFn fun i : Fin N ↦
+        embedLocalOperator (d := d) 2 N (by omega) i F.physicalBond).prod := by
+      simp only [sandwichMap_apply, Matrix.conjTranspose_conjTranspose,
+        Matrix.mul_assoc]
+      rw [hiso, Matrix.mul_one, ← Matrix.mul_assoc, hiso, Matrix.one_mul]
+
+private theorem boundaryOperator_one_kronecker_neighboring_eq_mul_crossedSectorBond
+    (F : PhysicalSectorFactorization K) (k h : Fin F.sectorCount) :
+    F.boundaryOperator k h 1 ⊗ₖ F.neighboringOperator k h =
+      ((1 : Matrix (BoundaryIndex F k h) (BoundaryIndex F k h) ℂ) ⊗ₖ
+        F.neighboringOperator k h) * F.crossedSectorBond k h := by
+  rw [crossedSectorBond, ← Matrix.mul_kronecker_mul]
+  simp only [Matrix.one_mul, Matrix.mul_one]
+  congr 1
+  ext x y
+  simp [boundaryOperator_apply, neighboringOperator_apply,
+    Matrix.reindex_apply, Matrix.one_apply, mul_comm]
+
+/-- The two-site sector-coordinate MPO is the product of the ordinary bond
+and its oppositely oriented cyclic translate.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8, lines
+1581--1593. -/
+private theorem physClose2_sectorCoordinateTensor_one_eq_bond_mul_crossed
+    (F : PhysicalSectorFactorization K) :
+    physClose2 F.sectorCoordinateTensor 1 =
+      F.sectorCoordinateBond * swapPairMatrix F.sectorCoordinateBond := by
+  apply (Matrix.reindex F.twoSiteGlobalRegroupEquiv
+    F.twoSiteGlobalRegroupEquiv).injective
+  change Matrix.reindexLinearEquiv ℂ ℂ F.twoSiteGlobalRegroupEquiv
+      F.twoSiteGlobalRegroupEquiv (physClose2 F.sectorCoordinateTensor 1) =
+    Matrix.reindexLinearEquiv ℂ ℂ F.twoSiteGlobalRegroupEquiv
+      F.twoSiteGlobalRegroupEquiv (_ * _)
+  rw [← Matrix.reindexLinearEquiv_mul ℂ ℂ
+      F.twoSiteGlobalRegroupEquiv F.twoSiteGlobalRegroupEquiv
+      F.twoSiteGlobalRegroupEquiv]
+  change Matrix.reindex F.twoSiteGlobalRegroupEquiv
+      F.twoSiteGlobalRegroupEquiv (physClose2 F.sectorCoordinateTensor 1) =
+    Matrix.reindex F.twoSiteGlobalRegroupEquiv F.twoSiteGlobalRegroupEquiv
+        F.sectorCoordinateBond *
+      Matrix.reindex F.twoSiteGlobalRegroupEquiv F.twoSiteGlobalRegroupEquiv
+        (swapPairMatrix F.sectorCoordinateBond)
+  rw [F.twoSiteGlobalClosure_eq,
+    F.reindex_swapPairMatrix_sectorCoordinateBond]
+  have horiginal :
+      Matrix.reindex F.twoSiteGlobalRegroupEquiv F.twoSiteGlobalRegroupEquiv
+          F.sectorCoordinateBond =
+        Matrix.blockDiagonal' fun kh :
+            Fin F.sectorCount × Fin F.sectorCount ↦
+          (1 : Matrix (BoundaryIndex F kh.1 kh.2)
+            (BoundaryIndex F kh.1 kh.2) ℂ) ⊗ₖ
+              F.neighboringOperator kh.1 kh.2 := by
+    ext x y
+    simp [sectorCoordinateBond, Matrix.reindex_apply]
+  rw [horiginal, ← Matrix.blockDiagonal'_mul]
+  congr 1
+  funext kh
+  exact F.boundaryOperator_one_kronecker_neighboring_eq_mul_crossedSectorBond
+    kh.1 kh.2
+
+/-- At length two, the original-coordinate closure is the product of the
+physical pair bond and its oppositely oriented translate.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8, lines
+1581--1593. -/
+private theorem physClose2_one_eq_physicalPairBond_mul_crossed
+    (F : PhysicalSectorFactorization K) :
+    physClose2 K 1 =
+      F.physicalPairBond * swapPairMatrix F.physicalPairBond := by
+  rw [← F.physicalCoordinateMatrixTwo_conjTranspose_physClose2 1]
+  rw [F.physClose2_sectorCoordinateTensor_one_eq_bond_mul_crossed]
+  have hswap : swapPairMatrix F.physicalPairBond =
+      sandwichMap F.physicalCoordinateMatrixTwoᴴ
+        (swapPairMatrix F.sectorCoordinateBond) := by
+    simpa only [physicalPairBond, physicalCoordinateMatrixTwo] using
+      swapPairMatrix_sandwich_kronecker_self
+        F.physicalCoordinateMatrix F.sectorCoordinateBond
+  rw [hswap]
+  simp only [physicalPairBond, sandwichMap_apply,
+    Matrix.conjTranspose_conjTranspose, Matrix.mul_assoc]
+  rw [← Matrix.mul_assoc F.physicalCoordinateMatrixTwo
+    F.physicalCoordinateMatrixTwoᴴ]
+  rw [F.physicalCoordinateMatrixTwo_coisometry]
+  simp only [Matrix.one_mul]
+
+/-- Reindexing the length-two MPO by ordered pairs gives the two-site closure
+with identity virtual boundary. -/
+private theorem reindex_mpo_two_eq_physClose2_one (K : MPOTensor d D) :
+    Matrix.reindex (finTwoArrowEquiv (Fin d)) (finTwoArrowEquiv (Fin d))
+        (mpo K 2) =
+      physClose2 K 1 := by
+  ext i j
+  simp [Matrix.reindex_apply, mpo_apply, mpoMatrixEntry,
+    MPOTensor.evalWord, finTwoArrowEquiv, physClose2_apply]
+
+/-- On a two-site periodic chain, the MPO is exactly the product of the two
+oriented translates of the physical-sector bond.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8, lines
+1581--1593. -/
+private theorem mpo_two_eq_product_physicalBond
+    (F : PhysicalSectorFactorization K) :
+    mpo K 2 =
+      (List.ofFn fun i : Fin 2 ↦
+        embedLocalOperator (d := d) 2 2 (by decide) i F.physicalBond).prod := by
+  have hprod :
+      (List.ofFn fun i : Fin 2 ↦
+        embedLocalOperator (d := d) 2 2 (by decide) i F.physicalBond).prod =
+      embedLocalOperator (d := d) 2 2 (by decide)
+          (0 : Fin 2) F.physicalBond *
+        embedLocalOperator (d := d) 2 2 (by decide)
+          (1 : Fin 2) F.physicalBond := by
+    simp [List.ofFn_succ]
+  rw [hprod]
+  apply (Matrix.reindex (finTwoArrowEquiv (Fin d))
+    (finTwoArrowEquiv (Fin d))).injective
+  change Matrix.reindexLinearEquiv ℂ ℂ (finTwoArrowEquiv (Fin d))
+      (finTwoArrowEquiv (Fin d)) (mpo K 2) =
+    Matrix.reindexLinearEquiv ℂ ℂ (finTwoArrowEquiv (Fin d))
+      (finTwoArrowEquiv (Fin d))
+        (embedLocalOperator (d := d) 2 2 (by decide)
+            (0 : Fin 2) F.physicalBond *
+          embedLocalOperator (d := d) 2 2 (by decide)
+            (1 : Fin 2) F.physicalBond)
+  rw [← Matrix.reindexLinearEquiv_mul ℂ ℂ
+      (finTwoArrowEquiv (Fin d)) (finTwoArrowEquiv (Fin d))
+      (finTwoArrowEquiv (Fin d))]
+  simpa only [Matrix.coe_reindexLinearEquiv,
+    reindex_mpo_two_eq_physClose2_one,
+    F.reindex_embedLocalOperator_two_zero,
+    F.reindex_embedLocalOperator_two_one] using
+      F.physClose2_one_eq_physicalPairBond_mul_crossed
+
+/-- At every length at least two, the MPO is exactly the ordered product of
+the translated physical-sector bonds.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8, lines
+1581--1593.
+
+**Scope restriction (given physical-sector factorization):** The source
+derives this factorization and positivity of the neighboring operators from
+SAL. That upstream construction remains documented in
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`. -/
+theorem mpo_eq_product_physicalBond
+    (F : PhysicalSectorFactorization K) {N : ℕ} (hN : 2 ≤ N) :
+    mpo K N =
+      (List.ofFn fun i : Fin N ↦
+        embedLocalOperator (d := d) 2 N hN i F.physicalBond).prod := by
+  by_cases htwo : N = 2
+  · subst N
+    exact F.mpo_two_eq_product_physicalBond
+  · letI : NeZero N := ⟨by omega⟩
+    exact F.mpo_eq_product_physicalBond_of_three_le (by omega)
+
+/-- The positive scalar in the physical-sector product realization may be
+chosen to be exactly one.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8, lines
+1581--1593.
+
+**Scope restriction (given physical-sector factorization):** The source
+derives this factorization and positivity of the neighboring operators from
+SAL. That upstream construction remains documented in
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`. -/
+theorem exists_positive_scalar_mpo_eq_product_physicalBond
+    (F : PhysicalSectorFactorization K) {N : ℕ} (hN : 2 ≤ N) :
+    ∃ c : ℝ, 0 < c ∧
+      mpo K N = (c : ℂ) •
+        (List.ofFn fun i : Fin N ↦
+          embedLocalOperator (d := d) 2 N hN i F.physicalBond).prod := by
+  refine ⟨1, by norm_num, ?_⟩
+  rw [F.mpo_eq_product_physicalBond hN]
+  norm_num
+
+end MPOTensor.PhysicalSectorFactorization

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -262,9 +262,12 @@
     translates commute by
     Theorem~\ref{thm:mpdo_periodic_disjoint_physical_bonds_comm}. These cases
     are assembled into pairwise commutativity at every length $N\geq2$ in
-    Theorem~\ref{thm:mpdo_periodic_pairwise_physical_bonds_comm}. The
-    all-length product identity in~(\ref{eq:mpdo_eta_product_form}) remains
-    open.
+    Theorem~\ref{thm:mpdo_periodic_pairwise_physical_bonds_comm}. Given the
+    physical-sector factorization, the all-length product identity is
+    Theorem~\ref{thm:mpdo_exact_physical_sector_bond_product}. The remaining
+    entropy-side problem is to construct a coherently positive physical-sector
+    factorization from SAL and assemble these conditional results into the
+    eta-local structure.
     The doubled-index transfer condition enters only in the subsequent RFP and
     GSNNCH branch conclusions.
 \end{remark}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -1588,6 +1588,60 @@ strong subadditivity for a normalized three-site reduced state.
     symmetric equality.
 \end{proof}
 
+\begin{theorem}[Exact product of physical-sector bonds]
+    \label{thm:mpdo_exact_physical_sector_bond_product}
+    \lean{MPOTensor.PhysicalSectorFactorization.mpo_eq_product_physicalBond}
+    \leanok
+    \uses{def:mpdo_physical_sector_factorization,
+      def:mpdo_physical_two_site_bond,
+      thm:mpdo_physical_sector_chain_decomposition}
+    Suppose that $K$ is equipped with a physical-sector factorization $F$.
+    Let $B_i$ denote the cyclic translate beginning at site $i$ of the
+    physical two-site bond determined by $F$. For every $N\geq2$, the
+    $N$-site periodic operator is
+    \[
+      \rho_N=B_0B_1\cdots B_{N-1}.
+    \]
+    No positivity, zero-correlation-length, injectivity, or normalization
+    hypothesis is required. This is the product identity in
+    \cite[Appendix~C.2, Proposition~C.8, lines~1581--1593]
+      {Cirac2016MPDO_arXiv}, conditional here on the given physical-sector
+    factorization.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    For a fixed cyclic sector sequence, contraction of the virtual index
+    between the right tensor at site $i$ and the left tensor at site $i+1$
+    produces $\eta_{k_i,k_{i+1}}$. Taking the virtual trace therefore gives
+    the cyclic product of these neighboring operators. The
+    translated sector bonds give the same ordered product. Conjugating by the
+    tensor power of the one-site coordinate unitary gives the stated physical
+    identity. For $N=2$, the second translate has the opposite cyclic order;
+    the two factors are the ordinary and crossed bonds.
+\end{proof}
+
+\begin{theorem}[Unit scalar in the physical-sector product]
+    \label{thm:mpdo_physical_sector_bond_product_unit_scalar}
+    \lean{MPOTensor.PhysicalSectorFactorization.exists_positive_scalar_mpo_eq_product_physicalBond}
+    \leanok
+    \uses{thm:mpdo_exact_physical_sector_bond_product}
+    Under the physical-sector factorization $F$ of the preceding theorem,
+    for every $N\geq2$ there is a real number $c>0$ such that
+    \[
+      \rho_N=c\,B_0B_1\cdots B_{N-1}.
+    \]
+    Here the bonds are the canonical bonds determined by $F$, and one may
+    take $c=1$. No positivity hypothesis on the neighboring operators
+    $\eta_{k,h}$ is required.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Take $c=1$ in
+    Theorem~\ref{thm:mpdo_exact_physical_sector_bond_product}.
+\end{proof}
+
 \begin{theorem}[Positive translation-invariant bond datum]
     \label{thm:mpdo_positive_translation_invariant_bond_data}
     \lean{MPOTensor.PhysicalSectorFactorization.translationInvariantBondData}

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -487,15 +487,21 @@ commutativity of all translates on every periodic chain of length $N\geq2$.
 \footnote{The formal declaration is
 \leanid{MPOTensor.PhysicalSectorFactorization.physicalBond_pairwise_comm}.}
 
-The remaining global step is to transport the cyclic sector identity through
-the local unitary and prove the finite-chain realization
+The cyclic sector identity is now identified with the ordered bond product
+and transported through the local unitary, giving the exact finite-chain
+realization
 \[
   \sigma^{(N)}(K)=c_N\prod_{n=1}^N B_{n,n+1}
 \]
-for positive scalars $c_N$.  Together with the positive bond already
-constructed, this product identity will construct
-\leanid{MPOTensor.EtaLocalStructureData} from the Appendix C.2 local structure
-of a simple MPDO satisfying SAL.  ZCL is not a hypothesis of this construction.
+with $c_N=1$ for the canonical bond determined by the physical-sector
+factorization.\footnote{The formal declaration is
+\leanid{MPOTensor.PhysicalSectorFactorization.mpo_eq_product_physicalBond}.}
+Together with positivity of the neighboring operators, this supplies the
+mathematical data needed to construct
+\leanid{MPOTensor.EtaLocalStructureData}.  The remaining steps are to package
+these conditional results and, upstream, to construct a coherently positive
+physical-sector factorization from SAL. ZCL is not a hypothesis of this
+construction.
 
 The source Proposition \texttt{3to4} assumes SAL, not ZCL.  ZCL enters only
 after this commuting product form has been obtained, in the later step that
@@ -530,14 +536,14 @@ records an elimination plan using the uniqueness of the rescaling phase).
 The primitivity of $T_{k,h}$ also remains open, and cannot be used to
 derive recurrence without circularity.
 
-For the conditional bond construction, adjacent translates commute for every
-chain length $N\geq 2$, including the wraparound and crossed two-site cases,
-and disjoint translates commute by locality.  These cases are assembled into
-pairwise commutativity of all translates at every length $N\geq2$.  The
-finite-chain MPO is now expressed directly as the cyclic neighboring product
-in the coordinates of the physical-sector factorization.  Identifying this
-matrix with the ordered product of the translated two-site bonds, and then
-transporting that product to the original physical coordinates, remain open.
+For the conditional bond construction, all translates commute pairwise at
+every length $N\geq2$.  The finite-chain MPO is the ordered product of those
+bonds, first in cyclic sector coordinates and then in the original physical
+coordinates.  If the neighboring operators are positive semidefinite, these
+results provide the positive commuting bond and its exact realization with
+scalar one. Packaging them as eta-local structure data, and deriving the
+required coherently positive physical-sector factorization from SAL, remain
+open.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Mathematical statement

For a given physical-sector factorization of an MPO tensor and every periodic length `N ≥ 2`, this pull request proves the exact ordered product formula

```text
mpo K N = ∏ i, embed_i(F.physicalBond).
```

It also records the equivalent positive-scalar formulation with scalar exactly `1`.

## Proof architecture

- Reuse the all-length sector-chain decomposition from #3814; no duplicate cyclic-product algebra remains.
- Regroup each fixed sector from site factors `(L_n,R_n)` to cyclic edge factors `(R_n,L_{n+1})`.
- Identify the ordered product of embedded sector bonds with the same block diagonal cyclic neighboring product.
- Transport the ordered product through the sitewise physical coordinate isometry.
- Treat `N = 2` separately: the two translates are the ordinary and crossed bonds, with the correct opposite cyclic ordering.

No commutativity is used to reorder the product.

## Scope and faithfulness

The statement assumes the physical-sector factorization as an intermediate datum. It uses no positivity, SAL, ZCL, injectivity, normalization, recurrence, or primitivity hypothesis. The source derives the required coherently positive factorization upstream; that remaining gap is recorded in `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`. For the repository’s raw unnormalized MPO and canonical bond, the realization scalar is exactly `1`.

Source: arXiv:1606.00608, Appendix C.2, Proposition C.8, lines 1581–1593.

## API and verification

All encoded-coordinate, edge-regrouping, and physical-transport intermediates are private except the cross-file sector-bond capstone. Public results are the exact product theorem and scalar-one corollary.

- full `lake build TNLean`
- `leanblueprint checkdecls`
- blueprint declaration synchronization (chapter 21: 383/383)
- direct Lean/style checks for both new modules
- proof-integrity, prose, size, conflict, and whitespace checks
- independent audits of N=2 orientation, N≥3 ordering, coordinate transport, hypotheses, and axiom dependencies

Closes #3803. Advances #823.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Large formal proof additions in MPS/MPDO with no runtime or auth paths; main risk is proof maintenance and API surface from newly public lemmas.
> 
> **Overview**
> **Proves** that given a physical-sector factorization, the periodic MPO equals the ordered product of translated two-site `physicalBond` operators for every chain length **N ≥ 2**, with **no reordering via commutativity** and **no** SAL, positivity, or ZCL hypotheses on the theorem itself.
> 
> Adds **`PhysicalSectorProductRealization`** (sector coordinates: cyclic edge regrouping, edge partial products, `mpo_sectorCoordinateTensor_eq_product_sectorBond` for **N ≥ 3**) and **`PhysicalSectorProductTransport`** (sitewise physical coordinate isometry; public **`mpo_eq_product_physicalBond`** and **`exists_positive_scalar_mpo_eq_product_physicalBond`** with **c = 1**). **N = 2** is handled separately via ordinary vs **crossed** (`swapPairMatrix`) bond orientation.
> 
> Promotes **`windowComplementEquiv`**, **`reindex_embedLocalOperator_windowComplement`**, and several two-site lemmas from `private` to public for cross-module reuse. Blueprint chapter 21 and the SAL/ZCL gap doc now treat the all-length product identity as proved **conditionally**; upstream SAL → coherently positive factorization remains open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit daca2a2bf9847899ed62c5ce886da784cf403c1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->