### PR TITLE
feat(MPS/MPDO): decompose physical sector chains

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -415,6 +415,7 @@ import TNLean.MPS.MPDO.PhysicalSectorBondCommutativity
 import TNLean.MPS.MPDO.PhysicalSectorBondTransport
 import TNLean.MPS.MPDO.PhysicalSectorBondTwoSite
 import TNLean.MPS.MPDO.PhysicalSectorBondPairwise
+import TNLean.MPS.MPDO.PhysicalSectorChainDecomposition
 import TNLean.MPS.MPDO.PhysicalSectorPhysicalTransport
 import TNLean.MPS.MPDO.SectorPairingTransfer
 import TNLean.MPS.MPDO.SectorEtaContraction

--- a/TNLean/MPS/MPDO/PhysicalSectorChainDecomposition.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorChainDecomposition.lean
@@ -1,0 +1,261 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalSectorFactorization
+import TNLean.MPS.MPDO.SectorEtaOperator
+
+/-!
+# Finite-chain decomposition from a physical-sector factorization
+
+A physical-sector factorization identifies each physical site with a direct
+sum of left--right tensor factors. Applying this identification at every site
+separates a periodic chain into sectors. Within a fixed cyclic sector, the MPO
+is the product of the neighboring contractions. Matrix entries between
+distinct sector configurations vanish.
+
+No positivity, saturation of the area law, zero correlation length, or
+injectivity hypothesis is used here.
+
+## Main definitions
+
+* `PhysicalSectorFactorization.SectorChainFiber`
+* `PhysicalSectorFactorization.SectorChainIndex`
+* `PhysicalSectorFactorization.sectorChainEquiv`
+* `PhysicalSectorFactorization.cyclicNeighboringProduct`
+
+## Main statements
+
+* `PhysicalSectorFactorization.mpo_submatrix_sector_eq_cyclicNeighboringProduct`
+* `PhysicalSectorFactorization.mpo_reindex_sectorChainEquiv_eq_blockDiagonal`
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, lines 1435--1450
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D N : ℕ} {K : MPOTensor d D}
+
+attribute [local instance] Classical.decEq Classical.propDecidable
+
+/-- The physical indices within a fixed sector configuration of a finite
+chain. At site `n`, the fiber is the product of the left and right factors in
+sector `k n`.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1435--1450. -/
+abbrev SectorChainFiber (F : PhysicalSectorFactorization K)
+    (k : Fin N → Fin F.sectorCount) :=
+  (n : Fin N) → SectorIndex F (k n)
+
+/-- A finite-chain physical index written as a sector configuration together
+with an index in the corresponding left--right fiber.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1435--1450. -/
+abbrev SectorChainIndex (F : PhysicalSectorFactorization K) (N : ℕ) :=
+  Σ k : Fin N → Fin F.sectorCount, SectorChainFiber F k
+
+private def piSigmaEquiv
+    {ι : Type*} {α : ι → Type*} {β : (i : ι) → α i → Type*} :
+    ((i : ι) → Σ a, β i a) ≃
+      Σ a : (i : ι) → α i, (i : ι) → β i (a i) where
+  toFun x := ⟨fun i ↦ (x i).1, fun i ↦ (x i).2⟩
+  invFun x i := ⟨x.1 i, x.2 i⟩
+  left_inv x := by
+    funext i
+    exact Sigma.eta (x i)
+  right_inv x := by
+    obtain ⟨a, b⟩ := x
+    rfl
+
+/-- Applying the one-site sector decomposition at every site identifies the
+physical chain with the direct sum of its sector fibers.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1435--1450. -/
+def sectorChainEquiv (F : PhysicalSectorFactorization K) (N : ℕ) :
+    (Fin N → Fin d) ≃ SectorChainIndex F N :=
+  (Equiv.piCongrRight fun _ : Fin N ↦ F.sectorEquiv).trans piSigmaEquiv
+
+/-- The cyclic product of neighboring contractions in one sector fiber. Its
+factor at site `n` acts on the right factor of sector `k n` and the left
+factor of sector `k (n + 1)`.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1441--1450. -/
+noncomputable def cyclicNeighboringProduct (F : PhysicalSectorFactorization K)
+    [NeZero N] (k : Fin N → Fin F.sectorCount) :
+    Matrix (SectorChainFiber F k) (SectorChainFiber F k) ℂ :=
+  fun x y ↦ ∏ n : Fin N,
+    F.neighboringOperator (k n) (k (n + 1))
+      ((x n).2, (x (n + 1)).1) ((y n).2, (y (n + 1)).1)
+
+private theorem cyclic_contraction
+    (F : PhysicalSectorFactorization K) [NeZero N]
+    (k : Fin N → Fin F.sectorCount)
+    (iL jL : (n : Fin N) → Fin (F.leftDim (k n)))
+    (iR jR : (n : Fin N) → Fin (F.rightDim (k n))) :
+    (∑ g : Fin N → Fin D, ∏ n : Fin N,
+        F.leftTensor (k n) (g n) (iL n) (jL n) *
+          F.rightTensor (k n) (g (n + 1)) (iR n) (jR n)) =
+      ∏ n : Fin N,
+        F.neighboringOperator (k n) (k (n + 1))
+          (iR n, iL (n + 1)) (jR n, jL (n + 1)) := by
+  simp_rw [neighboringOperator_apply]
+  rw [Finset.prod_univ_sum
+    (fun _ : Fin N ↦ (Finset.univ : Finset (Fin D)))
+    (fun n a ↦
+      F.rightTensor (k n) a (iR n) (jR n) *
+        F.leftTensor (k (n + 1)) a (iL (n + 1)) (jL (n + 1)))]
+  simp only [Fintype.piFinset_univ]
+  refine Fintype.sum_equiv (rotateConfig N D) _ _ fun g ↦ ?_
+  simp only [rotateConfig_apply, Function.comp_apply, finRotate_apply]
+  let qL : Fin N → ℂ :=
+    fun n ↦ F.leftTensor (k n) (g n) (iL n) (jL n)
+  let qR : Fin N → ℂ :=
+    fun n ↦ F.rightTensor (k n) (g (n + 1)) (iR n) (jR n)
+  let qLs : Fin N → ℂ :=
+    fun n ↦ F.leftTensor (k (n + 1)) (g (n + 1))
+      (iL (n + 1)) (jL (n + 1))
+  change (∏ n, qL n * qR n) = ∏ n, qR n * qLs n
+  calc
+    (∏ n, qL n * qR n) = (∏ n, qL n) * ∏ n, qR n := by
+      simpa using (Finset.prod_mul_distrib
+        (s := (Finset.univ : Finset (Fin N))) (f := qL) (g := qR))
+    _ = (∏ n, qR n) * ∏ n, qL n := mul_comm _ _
+    _ = (∏ n, qR n) * ∏ n, qLs n := by
+      congr 1
+      change (∏ n, qL n) = ∏ n, qL (n + 1)
+      simpa only [finRotate_apply] using
+        (Equiv.prod_comp (finRotate N) qL).symm
+    _ = ∏ n, qR n * qLs n := by
+      simpa using (Finset.prod_mul_distrib
+        (s := (Finset.univ : Finset (Fin N))) (f := qR) (g := qLs)).symm
+
+private theorem conjugatePhysical_apply_same
+    (F : PhysicalSectorFactorization K) (k : Fin F.sectorCount)
+    (x y : SectorIndex F k) (beta alpha : Fin D) :
+    conjugatePhysical K F.physicalIsometry
+        (F.sectorEquiv.symm ⟨k, x⟩) (F.sectorEquiv.symm ⟨k, y⟩) beta alpha =
+      F.leftTensor k beta x.1 y.1 * F.rightTensor k alpha x.2 y.2 := by
+  have h := congrFun (congrFun (F.factorization beta alpha) ⟨k, x⟩) ⟨k, y⟩
+  simpa [conjugatePhysical, physicalSlice, Matrix.reindex_apply,
+    Matrix.blockDiagonal'_apply_eq, Matrix.kroneckerMap_apply] using h
+
+private theorem conjugatePhysical_apply_ne
+    (F : PhysicalSectorFactorization K) {k h : Fin F.sectorCount}
+    (hkh : k ≠ h) (x : SectorIndex F k) (y : SectorIndex F h)
+    (beta alpha : Fin D) :
+    conjugatePhysical K F.physicalIsometry
+        (F.sectorEquiv.symm ⟨k, x⟩) (F.sectorEquiv.symm ⟨h, y⟩) beta alpha = 0 := by
+  have hentry := congrFun (congrFun (F.factorization beta alpha) ⟨k, x⟩) ⟨h, y⟩
+  simpa [conjugatePhysical, physicalSlice, Matrix.reindex_apply,
+    Matrix.blockDiagonal'_apply_ne _ _ _ hkh] using hentry
+
+/-- In a fixed sector configuration, the physically transformed finite-chain
+MPO is the cyclic product of the neighboring contractions.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1441--1450. -/
+theorem mpo_submatrix_sector_eq_cyclicNeighboringProduct
+    (F : PhysicalSectorFactorization K) [NeZero N]
+    (k : Fin N → Fin F.sectorCount) :
+    Matrix.submatrix (mpo (conjugatePhysical K F.physicalIsometry) N)
+        (fun x n ↦ F.sectorEquiv.symm ⟨k n, x n⟩)
+        (fun x n ↦ F.sectorEquiv.symm ⟨k n, x n⟩) =
+      F.cyclicNeighboringProduct k := by
+  ext x y
+  simp only [Matrix.submatrix_apply, mpo_apply, mpoMatrixEntry,
+    MPOTensor.evalWord_ofFn, cyclicNeighboringProduct]
+  have hlocal : ∀ n : Fin N,
+      conjugatePhysical K F.physicalIsometry
+          (F.sectorEquiv.symm ⟨k n, x n⟩)
+          (F.sectorEquiv.symm ⟨k n, y n⟩) =
+        Matrix.of fun beta alpha ↦
+          F.leftTensor (k n) beta (x n).1 (y n).1 *
+            F.rightTensor (k n) alpha (x n).2 (y n).2 := by
+    intro n
+    ext beta alpha
+    exact F.conjugatePhysical_apply_same (k n) (x n) (y n) beta alpha
+  have htrace :
+      Matrix.trace (MPSTensor.evalWord
+          (fun n : Fin N ↦ Matrix.of fun beta alpha ↦
+            F.leftTensor (k n) beta (x n).1 (y n).1 *
+              F.rightTensor (k n) alpha (x n).2 (y n).2)
+          (List.ofFn id)) =
+        ∏ n : Fin N,
+          F.neighboringOperator (k n) (k (n + 1))
+            ((x n).2, (x (n + 1)).1) ((y n).2, (y (n + 1)).1) := by
+    rw [MPSTensor.trace_evalWord_eq_sum_cyclic]
+    simpa only [Matrix.of_apply, id_eq] using
+      F.cyclic_contraction k (fun n ↦ (x n).1) (fun n ↦ (y n).1)
+        (fun n ↦ (x n).2) (fun n ↦ (y n).2)
+  rw [MPSTensor.evalWord_ofFn_eq_prod] at htrace
+  simpa only [hlocal, Function.id_def] using htrace
+
+private theorem mpo_entry_eq_zero_of_sector_ne
+    (F : PhysicalSectorFactorization K) [NeZero N]
+    (k h : Fin N → Fin F.sectorCount) (hne : k ≠ h)
+    (x : SectorChainFiber F k) (y : SectorChainFiber F h) :
+    mpo (conjugatePhysical K F.physicalIsometry) N
+        (fun n ↦ F.sectorEquiv.symm ⟨k n, x n⟩)
+        (fun n ↦ F.sectorEquiv.symm ⟨h n, y n⟩) = 0 := by
+  obtain ⟨n, hn⟩ := Function.ne_iff.mp hne
+  simp only [mpo_apply, mpoMatrixEntry, MPOTensor.evalWord_ofFn]
+  have hzero : Matrix.trace (MPSTensor.evalWord
+      (fun i : Fin N ↦
+        conjugatePhysical K F.physicalIsometry
+          (F.sectorEquiv.symm ⟨k i, x i⟩)
+          (F.sectorEquiv.symm ⟨h i, y i⟩))
+      (List.ofFn id)) = 0 := by
+    rw [MPSTensor.trace_evalWord_eq_sum_cyclic]
+    apply Finset.sum_eq_zero
+    intro g _
+    apply Finset.prod_eq_zero (Finset.mem_univ n)
+    exact F.conjugatePhysical_apply_ne hn (x n) (y n) (g n) (g (n + 1))
+  rw [MPSTensor.evalWord_ofFn_eq_prod] at hzero
+  simpa only [id_eq] using hzero
+
+/-- In the chain basis determined by a physical-sector factorization, the
+physically transformed MPO is the direct sum of the cyclic products of the
+neighboring contractions.
+
+No positivity of the neighboring contractions is assumed.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1435--1450. -/
+theorem mpo_reindex_sectorChainEquiv_eq_blockDiagonal
+    (F : PhysicalSectorFactorization K) [NeZero N] :
+    Matrix.reindex (F.sectorChainEquiv N) (F.sectorChainEquiv N)
+        (mpo (conjugatePhysical K F.physicalIsometry) N) =
+      Matrix.blockDiagonal' fun k ↦ F.cyclicNeighboringProduct k := by
+  ext s t
+  obtain ⟨k, x⟩ := s
+  obtain ⟨h, y⟩ := t
+  have hx :
+      (F.sectorChainEquiv N).symm ⟨k, x⟩ =
+        fun n ↦ F.sectorEquiv.symm ⟨k n, x n⟩ := by
+    funext n
+    rfl
+  have hy :
+      (F.sectorChainEquiv N).symm ⟨h, y⟩ =
+        fun n ↦ F.sectorEquiv.symm ⟨h n, y n⟩ := by
+    funext n
+    rfl
+  by_cases hkh : k = h
+  · subst h
+    rw [Matrix.blockDiagonal'_apply_eq]
+    change mpo (conjugatePhysical K F.physicalIsometry) N
+        ((F.sectorChainEquiv N).symm ⟨k, x⟩)
+        ((F.sectorChainEquiv N).symm ⟨k, y⟩) = _
+    rw [hx, hy]
+    exact congrFun (congrFun (F.mpo_submatrix_sector_eq_cyclicNeighboringProduct k) x) y
+  · rw [Matrix.blockDiagonal'_apply_ne _ _ _ hkh]
+    change mpo (conjugatePhysical K F.physicalIsometry) N
+        ((F.sectorChainEquiv N).symm ⟨k, x⟩)
+        ((F.sectorChainEquiv N).symm ⟨h, y⟩) = 0
+    rw [hx, hy]
+    exact F.mpo_entry_eq_zero_of_sector_ne k h hkh x y
+
+end MPOTensor.PhysicalSectorFactorization

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -823,6 +823,71 @@ strong subadditivity for a normalized three-site reduced state.
     this definition; it is a separate hypothesis in Proposition~C.7.
 \end{definition}
 
+\begin{definition}[Finite-chain coordinates of a physical-sector factorization]
+    \label{def:mpdo_physical_sector_chain_coordinates}
+    \lean{MPOTensor.PhysicalSectorFactorization.SectorChainFiber,
+      MPOTensor.PhysicalSectorFactorization.SectorChainIndex,
+      MPOTensor.PhysicalSectorFactorization.sectorChainEquiv,
+      MPOTensor.PhysicalSectorFactorization.cyclicNeighboringProduct}
+    \leanok
+    \uses{def:mpdo_physical_sector_factorization,
+      def:mpdo_minimal_neighboring_operator}
+    Let $N\geq1$. For a cyclic sector configuration
+    $k=(k_0,\ldots,k_{N-1})$, write
+    \[
+      I_k=\prod_{n=0}^{N-1}(B_{k_n}^L\times B_{k_n}^R).
+    \]
+    Applying the one-site sector decomposition at every site gives a
+    bijection
+    \[
+      \Phi_N:\{0,\ldots,d-1\}^N
+        \longrightarrow\coprod_{k_0,\ldots,k_{N-1}}I_k.
+    \]
+    On $I_k$, define the cyclic neighboring product by
+    \[
+      \Omega_k(x,y)=\prod_{n=0}^{N-1}
+        \eta_{k_n,k_{n+1}}
+        \bigl((x_n^R,x_{n+1}^L),(y_n^R,y_{n+1}^L)\bigr),
+    \]
+    where site labels are read modulo $N$.
+\end{definition}
+
+\begin{theorem}[Finite-chain decomposition of a physical-sector factorization]
+    \label{thm:mpdo_physical_sector_chain_decomposition}
+    \lean{MPOTensor.PhysicalSectorFactorization.mpo_submatrix_sector_eq_cyclicNeighboringProduct,
+      MPOTensor.PhysicalSectorFactorization.mpo_reindex_sectorChainEquiv_eq_blockDiagonal}
+    \leanok
+    \uses{def:mpdo_physical_sector_chain_coordinates}
+    Suppose that the physical-sector factorization is given. For every
+    $N\geq1$, the physically transformed MPO is block diagonal in the cyclic
+    sector configurations, and
+    \[
+      \operatorname{reindex}_{\Phi_N}
+        \bigl(M_N(\widetilde{\cal K})\bigr)
+      =\bigoplus_{k_0,\ldots,k_{N-1}}\Omega_k.
+    \]
+    This is the all-length algebraic decomposition in
+    \cite[Appendix~C.2, lines~1435--1450]{Cirac2016MPDO_arXiv}, conditional
+    here on the displayed physical-sector factorization. It does not assert
+    positivity of the individual neighboring operators.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Fix a sector configuration $k$ and entries $x,y\in I_k$. Expanding the
+    closed horizontal contraction gives
+    \[
+      \sum_g\prod_n
+        (l_{k_n})_{g_n}(x_n^L,y_n^L)
+        (r_{k_n})_{g_{n+1}}(x_n^R,y_n^R).
+    \]
+    Cyclically shifting the summation variables and collecting the factors
+    with the same horizontal index turns this expression into
+    $\Omega_k(x,y)$. If the row and column sector configurations differ,
+    one transformed physical slice lies between distinct direct summands and
+    vanishes. Thus all off-diagonal sector blocks vanish.
+\end{proof}
+
 \begin{definition}[Boundary contraction against a virtual matrix]
     \label{def:mpdo_sector_boundary_operator}
     \lean{MPOTensor.PhysicalSectorFactorization.boundaryOperator,

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -244,7 +244,12 @@ formalized.
 \path{MPOTensor.sum_cyclic_sectorTensor_eq_prod_etaOfSectorTensors},
 \path{MPOTensor.trace_sector_word_eq_prod_etaOfSectorTensors},
 \path{MPOTensor.mpo_submatrix_sector_eq_cyclicEtaTensorProduct}, and
-\path{MPOTensor.mpo_reindex_sectorChainEquiv_eq_blockDiagonal_cyclicEta}.}
+\path{MPOTensor.mpo_reindex_sectorChainEquiv_eq_blockDiagonal_cyclicEta}.
+For the source-minimal physical-sector factorization, the corresponding direct
+statements are
+\path{MPOTensor.PhysicalSectorFactorization.mpo_submatrix_sector_eq_cyclicNeighboringProduct}
+and
+\path{MPOTensor.PhysicalSectorFactorization.mpo_reindex_sectorChainEquiv_eq_blockDiagonal}.}
 What remains in Lemma \texttt{propSN} is the positive choice of the individual
 $\eta_{k,h}$ and the local-orthogonality argument establishing primitivity of
 the sector trace matrix.  Positivity of a complete cyclic product does not by
@@ -529,7 +534,10 @@ For the conditional bond construction, adjacent translates commute for every
 chain length $N\geq 2$, including the wraparound and crossed two-site cases,
 and disjoint translates commute by locality.  These cases are assembled into
 pairwise commutativity of all translates at every length $N\geq2$.  The
-finite-chain product realization remains open.
+finite-chain MPO is now expressed directly as the cyclic neighboring product
+in the coordinates of the physical-sector factorization.  Identifying this
+matrix with the ordered product of the translated two-site bonds, and then
+transporting that product to the original physical coordinates, remain open.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Mathematical purpose

This pull request proves the all-length sector-coordinate decomposition needed for the remaining Appendix C.2 product realization.

Given a `PhysicalSectorFactorization K`, it defines the finite-chain sector coordinates and the cyclic neighboring product

```text
Ω_k(x,y) = ∏ n, η_{k_n,k_{n+1}}((x_n^R,x_{n+1}^L),(y_n^R,y_{n+1}^L)).
```

It then proves that the physically transformed finite MPO, reindexed by those chain coordinates, is exactly the block diagonal direct sum of the `Ω_k`. Off-diagonal sector blocks vanish.

## Scope and faithfulness

The theorem is conditional on the displayed physical-sector factorization. It uses no positivity, SAL, ZCL, injectivity, normalization, recurrence, or primitivity hypothesis. It does not yet identify this block diagonal matrix with the ordered product of translated physical bonds; that cyclic edge regrouping and physical-coordinate product transport remain the next steps.

Source: arXiv:1606.00608, Appendix C.2, lines 1435–1450.

## Verification

- direct Lean and module-target checks
- full `lake build TNLean` (serial rerun after eliminating concurrent Lake processes)
- `leanblueprint checkdecls`
- blueprint declaration synchronization (chapter 21: 381/381)
- style, prose, proof-integrity, and whitespace checks

Advances #823.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New Mathlib proofs and documentation only; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **`PhysicalSectorChainDecomposition.lean`**, which formalizes the all-length finite-chain sector decomposition for a **`PhysicalSectorFactorization`**: chain coordinates (`SectorChainFiber`, `SectorChainIndex`, `sectorChainEquiv`), the cyclic neighboring product **Ω_k**, and proofs that the physically conjugated MPO is **block diagonal** in those coordinates with diagonal blocks **Ω_k** and zero off-diagonal sector entries. The argument is purely algebraic (factorization + cyclic contraction regrouping); no positivity, SAL, or injectivity is assumed.
> 
> Wires the module into **`TNLean.lean`**, adds matching blueprint material in **chapter 21** (definitions + theorem with `\leanok`), and updates the **CPGSV17 paper-gaps** note to cite the new Lean names and to mark the finite-chain MPO-as-cyclic-neighboring-product step as done, while bond-product identification and transport back to original physical coordinates stay open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d400e362858d7c4bd3efba342f79b3306b9e0440. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->