### PR TITLE
refactor(MPS/MPDO): narrow product realization imports

### DIFF
--- a/TNLean/MPS/MPDO/PhysicalSectorProductRealization.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorProductRealization.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.PhysicalSectorChainDecomposition
-import TNLean.MPS.MPDO.PhysicalSectorBondCommutativity
+import TNLean.MPS.MPDO.PhysicalSectorPositiveBond
+import TNLean.MPS.MPDO.CommutingForm
 
 /-!
 # Product realization from physical-sector coordinates


### PR DESCRIPTION
## Summary

This follow-up narrows the imports of the exact physical-bond product proof.
It replaces the umbrella adjacent-bond commutativity import by the two modules
that provide precisely the required data: the physical bond and the cyclic
local-operator embedding.

This makes explicit at the module boundary that the ordered product identity
does not rely on commutativity. No declaration or proof changes.

Follow-up to #3813.

## Verification

- `lake env lean TNLean/MPS/MPDO/PhysicalSectorProductRealization.lean`
- `lake env lean TNLean/MPS/MPDO/PhysicalSectorProductTransport.lean`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only import lines changed; behavior and proofs are unchanged.
> 
> **Overview**
> **Import-only refactor** for `PhysicalSectorProductRealization.lean`: it no longer pulls in `PhysicalSectorBondCommutativity` and instead imports `PhysicalSectorPositiveBond` and `CommutingForm` directly.
> 
> That matches what the file actually needs (physical-sector bond data and `embedLocalOperator` from the commuting-form layer) and makes the module boundary explicit—the ordered product realization proof does **not** depend on adjacent-bond commutativity. **No lemmas, proofs, or declarations were changed.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 127675e77a2dfa0807400989dfb11e3325f28075. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->