### PR TITLE
feat(MPS/MPDO): package eta-local structure

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -418,6 +418,7 @@ import TNLean.MPS.MPDO.PhysicalSectorBondPairwise
 import TNLean.MPS.MPDO.PhysicalSectorChainDecomposition
 import TNLean.MPS.MPDO.PhysicalSectorProductRealization
 import TNLean.MPS.MPDO.PhysicalSectorProductTransport
+import TNLean.MPS.MPDO.PhysicalSectorEtaLocalStructure
 import TNLean.MPS.MPDO.PhysicalSectorPhysicalTransport
 import TNLean.MPS.MPDO.SectorPairingTransfer
 import TNLean.MPS.MPDO.SectorEtaContraction

--- a/TNLean/MPS/MPDO/CommutingFormBridge.lean
+++ b/TNLean/MPS/MPDO/CommutingFormBridge.lean
@@ -29,16 +29,14 @@ tensor `K` a sector factorization satisfying, for every `N`,
   \widetilde\sigma^{(N)}(K)
     = \bigoplus_{k_1,\ldots,k_N}\bigotimes_{n=1}^N \eta_{k_n,k_{n+1}}.
 \]
-The later Proposition 3to4 step assembles those source
-operators into a single translation-invariant positive two-site bond whose
-translated copies commute.
+Conditional on a physical-sector factorization with positive neighboring
+operators, Proposition 3to4 is completed by
+`PhysicalSectorFactorization.etaLocalStructureData`.
 
-*Proof-state note.* The strongest unconditional conclusion currently available
-starts from `EtaLocalStructureData M`.  To reach it from SAL, one must first
-establish the inverse-map sector factorization of Lemma propSN and then
-construct the neighboring operators carried by `EtaLocalStructureData M`.
-The theorem `hasCommutingForm_of_etaLocalStructure` then gives the global
-commuting-form conclusion.
+*Proof-state note.* To reach `EtaLocalStructureData M` from SAL, it remains to
+establish the inverse-map sector factorization of Lemma propSN with a coherent
+positive choice of all neighboring operators. The conditional bond,
+commutativity, product realization, and eta-local structure are complete.
 
 ## Main declarations
 

--- a/TNLean/MPS/MPDO/PhysicalSectorEtaLocalStructure.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorEtaLocalStructure.lean
@@ -1,0 +1,59 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.CommutingFormBridge
+import TNLean.MPS.MPDO.PhysicalSectorProductTransport
+
+/-!
+# Eta-local structure from a positive physical-sector factorization
+
+A physical-sector factorization with positive neighboring contractions
+determines the positive translation-invariant bond of Proposition C.8. The
+exact finite-chain product identity realizes every periodic MPO with scalar
+one, and hence gives `MPOTensor.EtaLocalStructureData`.
+
+## Main declaration
+
+* `PhysicalSectorFactorization.etaLocalStructureData`
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, Proposition C.8, lines 1571--1593
+-/
+
+open scoped ComplexOrder
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D}
+
+/-- A physical-sector factorization whose neighboring contractions are
+positive semidefinite determines the eta-local commuting product structure.
+The normalization scalar at every chain length is one.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`), lines
+1571--1593.
+
+**Scope restriction (given coherently positive physical-sector
+factorization):** The source derives the factorization and the simultaneous
+positive choice of its neighboring contractions from SAL. That upstream step
+remains documented in
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`. -/
+noncomputable def etaLocalStructureData
+    (F : PhysicalSectorFactorization K)
+    (hη : ∀ k h, (F.neighboringOperator k h).PosSemidef) :
+    EtaLocalStructureData K where
+  bondData := F.translationInvariantBondData hη
+  realizes_mpo := by
+    intro N hN
+    refine ⟨1, by norm_num, ?_⟩
+    norm_num
+    change mpo K N =
+      (List.ofFn fun i : Fin N ↦
+        embedLocalOperator (d := d) 2 N hN i F.physicalBond).prod
+    exact F.mpo_eq_product_physicalBond hN
+
+end MPOTensor.PhysicalSectorFactorization

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -233,11 +233,10 @@
 \end{proof}
 
 \begin{remark}[Entropy-side construction]
-    The remaining entropy-side step is the construction of a single
-    $\eta$-local product form from $\mathrm{SAL}(K)$. The local $\eta_{k,h}$
-    are already supplied by
-    Definition~\ref{def:mpdo_eta_of_hayashi_markov}. What remains is the
-    tensor-coordinate assembly
+    The remaining entropy-side step is to derive from $\mathrm{SAL}(K)$ a
+    physical-sector factorization whose neighboring operators
+    $\eta_{k,h}$ are simultaneously positive semidefinite. Given such a
+    factorization, the two-site bond is
     \begin{equation}\label{eq:mpdo_eta_bond_assembly}
         B=\sum_{k,h}
         \operatorname{Id}_{H_L^{(k)}}\otimes
@@ -251,10 +250,11 @@
         \qquad c_N>0,\qquad
         [B_{i,i+1},B_{j,j+1}]=0.
     \end{equation}
-    (\ref{eq:mpdo_eta_bond_assembly}) and~(\ref{eq:mpdo_eta_product_form}) are
-    exactly the $\eta$-local product hypothesis; after that,
-    Theorem~\ref{thm:mpdo_has_commuting_form_of_eta_local_structure}
-    gives the commuting-form conclusion. Adjacent translates commute on every
+    Theorem~\ref{thm:mpdo_eta_local_structure_of_positive_physical_sector_factorization}
+    constructs the $\eta$-local structure and proves
+    (\ref{eq:mpdo_eta_bond_assembly})--(\ref{eq:mpdo_eta_product_form}) with
+    $c_N=1$. Theorem~\ref{thm:mpdo_has_commuting_form_of_eta_local_structure}
+    then gives the commuting-form conclusion. Adjacent translates commute on every
     periodic chain of length at least three by
     Theorem~\ref{thm:mpdo_periodic_adjacent_physical_bonds_comm}, and the
     crossed two-site case is
@@ -265,9 +265,8 @@
     Theorem~\ref{thm:mpdo_periodic_pairwise_physical_bonds_comm}. Given the
     physical-sector factorization, the all-length product identity is
     Theorem~\ref{thm:mpdo_exact_physical_sector_bond_product}. The remaining
-    entropy-side problem is to construct a coherently positive physical-sector
-    factorization from SAL and assemble these conditional results into the
-    eta-local structure.
+    entropy-side problem is precisely the construction of a coherently
+    positive physical-sector factorization from SAL.
     The doubled-index transfer condition enters only in the subsequent RFP and
     GSNNCH branch conclusions.
 \end{remark}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -1663,6 +1663,33 @@ strong subadditivity for a normalized three-site reduced state.
     is Theorem~\ref{thm:mpdo_periodic_pairwise_physical_bonds_comm}.
 \end{proof}
 
+\begin{theorem}[$\eta$-local structure from a positive physical-sector factorization]
+    \label{thm:mpdo_eta_local_structure_of_positive_physical_sector_factorization}
+    \lean{MPOTensor.PhysicalSectorFactorization.etaLocalStructureData}
+    \leanok
+    \uses{thm:mpdo_exact_physical_sector_bond_product,
+      thm:mpdo_positive_translation_invariant_bond_data,
+      def:mpdo_eta_local_structure_data}
+    Suppose that a physical-sector factorization of $K$ is given and that
+    every neighboring operator $\eta_{k,h}$ is positive semidefinite. Then
+    the physical two-site bond determines an $\eta$-local structure for $K$.
+    Its translated copies commute pairwise, and for every $N\geq2$,
+    \[
+      \rho_N=B_0B_1\cdots B_{N-1}.
+    \]
+    Thus the positive normalization scalar may be chosen to be $1$. This is
+    Proposition~C.8 conditional on the coherently positive physical-sector
+    factorization that the source derives from SAL.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Theorem~\ref{thm:mpdo_positive_translation_invariant_bond_data} gives the
+    positive translation-invariant bond and its pairwise commuting
+    translates. Theorem~\ref{thm:mpdo_exact_physical_sector_bond_product}
+    realizes every finite-chain operator with normalization scalar $1$.
+\end{proof}
+
 \begin{definition}[Closed sector tensors]%
     \label{def:mpdo_closed_sector_tensors}
     \lean{MPOTensor.closedSectorL}

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -498,10 +498,11 @@ factorization.\footnote{The formal declaration is
 \leanid{MPOTensor.PhysicalSectorFactorization.mpo_eq_product_physicalBond}.}
 Together with positivity of the neighboring operators, this supplies the
 mathematical data needed to construct
-\leanid{MPOTensor.EtaLocalStructureData}.  The remaining steps are to package
-these conditional results and, upstream, to construct a coherently positive
-physical-sector factorization from SAL. ZCL is not a hypothesis of this
-construction.
+\leanid{MPOTensor.EtaLocalStructureData}.  The conditional construction is
+\leanid{MPOTensor.PhysicalSectorFactorization.etaLocalStructureData}; its
+normalization scalar is one. The remaining step is upstream: construct a
+coherently positive physical-sector factorization from SAL. ZCL is not a
+hypothesis of this construction.
 
 The source Proposition \texttt{3to4} assumes SAL, not ZCL.  ZCL enters only
 after this commuting product form has been obtained, in the later step that
@@ -511,11 +512,12 @@ factorization.
 
 The positive-choice and primitivity statements that remain in Lemma
 \texttt{propSN} are tracked by
-\href{https://github.com/LionSR/TNLean/issues/3696}{issue \#3696}.  Once those
-operators have been constructed, the positive commuting bond and product form
-of Proposition \texttt{3to4} are tracked separately by
-\href{https://github.com/LionSR/TNLean/issues/823}{issue \#823}. Until both
-constructions exist, Proposition~C.8 must not be presented as fully formalized.
+\href{https://github.com/LionSR/TNLean/issues/3696}{issue \#3696}. Conditional
+on the coherently positive physical-sector factorization produced there, the
+positive commuting bond, its exact all-length product realization, and the
+resulting eta-local structure of Proposition \texttt{3to4} are formalized.
+Until the SAL implication is complete, Proposition~C.8 must not be presented
+as unconditionally formalized from its source hypotheses.
 
 \section{Classification}
 
@@ -541,9 +543,9 @@ every length $N\geq2$.  The finite-chain MPO is the ordered product of those
 bonds, first in cyclic sector coordinates and then in the original physical
 coordinates.  If the neighboring operators are positive semidefinite, these
 results provide the positive commuting bond and its exact realization with
-scalar one. Packaging them as eta-local structure data, and deriving the
-required coherently positive physical-sector factorization from SAL, remain
-open.
+scalar one, and they determine the eta-local structure data. The only
+remaining obligation in this implication is to derive the required
+coherently positive physical-sector factorization from SAL.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Mathematical purpose

This pull request completes the conditional Appendix C.2 local-structure packaging. Given a `PhysicalSectorFactorization K` whose neighboring operators `η_{k,h}` are all positive semidefinite, it constructs `EtaLocalStructureData K`.

The constructor combines:

- the positive translation-invariant physical bond datum;
- pairwise commutativity at every periodic length `N ≥ 2`;
- the exact all-length product identity from #3813;
- realization scalar exactly `1`.

## Scope and faithfulness

This is Proposition C.8 conditional on the coherently positive physical-sector factorization. It does not claim that SAL has already produced that factorization. The remaining upstream obligation is precisely SAL → coherently positive physical-sector factorization, recorded in `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`. No ZCL, injectivity, recurrence, primitivity, trace, or extra normalization hypothesis is added.

Source: arXiv:1606.00608, Appendix C.2, Proposition C.8, lines 1571–1593.

## Verification

- direct Lean and targeted module build
- style, prose, proof-integrity, size, and whitespace checks
- blueprint declaration synchronization
- independent mathematical and source-faithfulness review

Advances #823.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, documentation-heavy Lean addition that composes existing lemmas; no auth, runtime, or behavioral API changes.
> 
> **Overview**
> Adds **`PhysicalSectorFactorization.etaLocalStructureData`**, which builds `EtaLocalStructureData K` when a physical-sector factorization is given and every neighboring operator `η_{k,h}` is positive semidefinite. The constructor reuses the existing translation-invariant bond, pairwise commutativity, and exact product identity, with **normalization scalar 1** at every chain length.
> 
> **`CommutingFormBridge`** and the blueprint/paper-gap notes are updated to state that Appendix C.2 Proposition C.8 (**3to4**) is now formalized **conditionally** on that factorization; the only remaining entropy-side step is **SAL → coherently positive physical-sector factorization** (issue #3696), not further bond/product packaging (issue #823 advanced).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 487ece023aca65882940ea6a8a2d454cb5a88024. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->