### PR TITLE
feat(MPS/MPDO): add length-independent zipper identities

### DIFF
--- a/TNLean/MPS/MPDO/BNTFusionIsometries.lean
+++ b/TNLean/MPS/MPDO/BNTFusionIsometries.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.MPDO.BNTCoefficients
+import TNLean.MPS.MPDO.LengthIndependentCoefficients
 import TNLean.MPS.MPDO.OperatorProduct
 
 /-!
@@ -37,7 +37,7 @@ chi-weighted zipper equations
 where $G_{\alpha,\beta}^{ij}=\bigoplus_\gamma
 \chi_{\alpha,\beta,\gamma}\otimes M_\gamma^{ij}$.  These are weighted analogues of the zipper
 condition of arXiv:1511.08090; the unweighted condition requires a separate specialization of
-the chi matrices.
+the chi matrices, proved below under length independence of the trace-power coefficients.
 
 From the fusion identity the same-length product law of statement (ii)
 follows for the concrete operator family: for every positive chain length,
@@ -134,6 +134,19 @@ namespace BNTFusionIsometryFamily
 variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {p : ℕ}
 variable (Fam : BNTFusionIsometryFamily Λ p)
 
+/-- Length independence makes every chi matrix in a fusion-isometry family
+the identity on its multiplicity space.
+
+Source: arXiv:1606.00608, line 1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem chi_matrix_eq_one_of_lengthIndependent
+    (c : BNTLabelCoefficientFamily Λ)
+    (hχ : c.HasPositiveLengthChiTracePowerForm Fam.chi)
+    (hLI : c.LengthIndependent) (α β γ : Λ) :
+    Fam.chi.matrix α β γ = 1 :=
+  DiagonalChiFamily.matrix_eq_one_of_forall_entry_eq_one
+    (hχ.entry_eq_one_of_lengthIndependent Fam.posEntries hLI) α β γ
+
 /-- **The fusion map carries a product letter to its weighted direct sum.**
 
 For every pair of labels and physical indices,
@@ -180,8 +193,8 @@ $U_{\alpha,\beta}^\dagger U_{\alpha,\beta}=1$.
 
 The corresponding equation in arXiv:1511.08090 has identity weights on the multiplicity
 spaces.  The length-independent integer specialization removes the chi weights.  It does not
-by itself construct an $F$-move: zipper completeness and final-label separation remain
-necessary.
+by itself construct an $F$-move: a comparison of the two triple-fusion orders and final-label
+separation remain necessary.
 
 Source: arXiv:1606.00608, Theorem 4.14(iii), equation `Ualphabeta`; arXiv:1511.08090,
 Section ``Fusion tensors'', equations `inversegaugeone` and `zippercondition2`. -/
@@ -200,6 +213,100 @@ theorem mulTensor_mul_fusionIsometry_conjTranspose (α β : Λ) (i j : Fin p) :
         Matrix.blockDiagonal' fun γ =>
           Fam.chi.matrix α β γ ⊗ₖ Fam.tensor γ i j := by
       rw [Fam.fusion]
+
+/-- **The length-independent left zipper identity.**
+
+If the trace-power coefficients of a fusion-isometry family are length
+independent, then every chi matrix is the identity and
+\[
+  U_{\alpha,\beta}(M_\alpha M_\beta)^{ij}
+    = \left(\bigoplus_\gamma 1_{r_{\alpha,\beta,\gamma}}
+        \otimes M_\gamma^{ij}\right)U_{\alpha,\beta}.
+\]
+
+Source: arXiv:1606.00608, lines 995--1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`; arXiv:1511.08090,
+`AnyonsPEPS.tex`, Section `Fusion tensors`, equation `zippercondition2`. -/
+theorem fusionIsometry_mul_mulTensor_of_lengthIndependent
+    (c : BNTLabelCoefficientFamily Λ)
+    (hχ : c.HasPositiveLengthChiTracePowerForm Fam.chi)
+    (hLI : c.LengthIndependent) (α β : Λ) (i j : Fin p) :
+    Fam.fusionIsometry α β * mulTensor (Fam.tensor α) (Fam.tensor β) i j =
+      (Matrix.blockDiagonal' fun γ =>
+        (1 : Matrix (Fin (Fam.chi.dim α β γ))
+          (Fin (Fam.chi.dim α β γ)) ℂ) ⊗ₖ Fam.tensor γ i j) *
+        Fam.fusionIsometry α β := by
+  rw [Fam.fusionIsometry_mul_mulTensor]
+  simp_rw [Fam.chi_matrix_eq_one_of_lengthIndependent c hχ hLI]
+
+/-- **The length-independent right zipper identity.**
+
+If the trace-power coefficients of a fusion-isometry family are length
+independent, then
+\[
+  (M_\alpha M_\beta)^{ij}U_{\alpha,\beta}^\dagger
+    = U_{\alpha,\beta}^\dagger
+      \left(\bigoplus_\gamma 1_{r_{\alpha,\beta,\gamma}}
+        \otimes M_\gamma^{ij}\right).
+\]
+
+Source: arXiv:1606.00608, lines 995--1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`; arXiv:1511.08090,
+`AnyonsPEPS.tex`, Section `Fusion tensors`, equation `zippercondition2`. -/
+theorem mulTensor_mul_fusionIsometry_conjTranspose_of_lengthIndependent
+    (c : BNTLabelCoefficientFamily Λ)
+    (hχ : c.HasPositiveLengthChiTracePowerForm Fam.chi)
+    (hLI : c.LengthIndependent) (α β : Λ) (i j : Fin p) :
+    mulTensor (Fam.tensor α) (Fam.tensor β) i j * (Fam.fusionIsometry α β)ᴴ =
+      (Fam.fusionIsometry α β)ᴴ *
+        Matrix.blockDiagonal' fun γ =>
+          (1 : Matrix (Fin (Fam.chi.dim α β γ))
+            (Fin (Fam.chi.dim α β γ)) ℂ) ⊗ₖ Fam.tensor γ i j := by
+  rw [Fam.mulTensor_mul_fusionIsometry_conjTranspose]
+  simp_rw [Fam.chi_matrix_eq_one_of_lengthIndependent c hχ hLI]
+
+/-- **Length-independent zipper completeness.**
+
+Under length independence, conjugating the direct sum with the adjoint fusion
+isometry recovers the product letter:
+\[
+  (M_\alpha M_\beta)^{ij}
+    = U_{\alpha,\beta}^\dagger
+      \left(\bigoplus_\gamma 1_{r_{\alpha,\beta,\gamma}}
+        \otimes M_\gamma^{ij}\right)U_{\alpha,\beta}.
+\]
+
+Source: arXiv:1606.00608, lines 995--1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`; arXiv:1511.08090,
+`AnyonsPEPS.tex`, Section `Fusion tensors`, equations `blocks` and
+`inversegaugeone`. -/
+theorem mulTensor_eq_conjTranspose_mul_unweightedDirectSum_mul_of_lengthIndependent
+    (c : BNTLabelCoefficientFamily Λ)
+    (hχ : c.HasPositiveLengthChiTracePowerForm Fam.chi)
+    (hLI : c.LengthIndependent) (α β : Λ) (i j : Fin p) :
+    mulTensor (Fam.tensor α) (Fam.tensor β) i j =
+      (Fam.fusionIsometry α β)ᴴ *
+        (Matrix.blockDiagonal' fun γ =>
+          (1 : Matrix (Fin (Fam.chi.dim α β γ))
+            (Fin (Fam.chi.dim α β γ)) ℂ) ⊗ₖ Fam.tensor γ i j) *
+        Fam.fusionIsometry α β := by
+  calc
+    mulTensor (Fam.tensor α) (Fam.tensor β) i j =
+        ((Fam.fusionIsometry α β)ᴴ * Fam.fusionIsometry α β) *
+          mulTensor (Fam.tensor α) (Fam.tensor β) i j *
+          ((Fam.fusionIsometry α β)ᴴ * Fam.fusionIsometry α β) := by
+      rw [Fam.isometry, Matrix.one_mul, Matrix.mul_one]
+    _ = (Fam.fusionIsometry α β)ᴴ *
+        (Fam.fusionIsometry α β * mulTensor (Fam.tensor α) (Fam.tensor β) i j *
+          (Fam.fusionIsometry α β)ᴴ) * Fam.fusionIsometry α β := by
+      simp only [Matrix.mul_assoc]
+    _ = (Fam.fusionIsometry α β)ᴴ *
+        (Matrix.blockDiagonal' fun γ =>
+          (1 : Matrix (Fin (Fam.chi.dim α β γ))
+            (Fin (Fam.chi.dim α β γ)) ℂ) ⊗ₖ Fam.tensor γ i j) *
+        Fam.fusionIsometry α β := by
+      rw [Fam.fusion]
+      simp_rw [Fam.chi_matrix_eq_one_of_lengthIndependent c hχ hLI]
 
 /-- **The same-length product law with trace-power coefficients**: for every
 positive chain length, the product of two labelled operators expands over the

--- a/TNLean/MPS/MPDO/LengthIndependentCoefficients.lean
+++ b/TNLean/MPS/MPDO/LengthIndependentCoefficients.lean
@@ -73,6 +73,21 @@ theorem entry_eq_one_of_posEntries_of_forall_tracePowerCoeff_eq
   · exact absurd h (ne_of_gt (hχ α β γ k))
   · exact h
 
+/-- A diagonal chi matrix all of whose diagonal entries equal one is the
+identity matrix.
+
+Source: arXiv:1606.00608, line 1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem matrix_eq_one_of_forall_entry_eq_one
+    (hone : ∀ α β γ : I, ∀ k : Fin (χ.dim α β γ), χ.entry α β γ k = 1)
+    (α β γ : I) :
+    χ.matrix α β γ = 1 := by
+  ext i j
+  by_cases hij : i = j
+  · subst j
+    simp [DiagonalChiFamily.matrix, hone]
+  · simp [DiagonalChiFamily.matrix, hij]
+
 /-- When every diagonal entry of a chi family equals one, the trace-power
 coefficient at any exponent is the size of the diagonal matrix.
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -524,6 +524,7 @@
     \label{thm:mpdo_bnt_label_length_independent_natural}
     \lean{MPOTensor.DiagonalChiFamily.%
         entry_eq_one_of_posEntries_of_forall_tracePowerCoeff_eq}
+    \lean{MPOTensor.DiagonalChiFamily.matrix_eq_one_of_forall_entry_eq_one}
     \lean{MPOTensor.BNTLabelCoefficientFamily.HasPositiveLengthChiTracePowerForm.%
         entry_eq_one_of_lengthIndependent}
     \lean{MPOTensor.BNTLabelCoefficientFamily.HasPositiveLengthChiTracePowerForm.%

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -248,8 +248,9 @@ them.
     the multiplicity spaces in place of the positive diagonal matrices
     $\chi$.  Their unweighted form requires the length-independent integer
     specialization and is not a consequence of the present hypotheses. Even
-    after that specialization, zipper completeness and final-label separation
-    are still needed to construct an invertible $F$-move.
+    after that specialization, comparison of the two triple-fusion orders and
+    final-label separation are still needed to construct an invertible
+    $F$-move.
 \end{theorem}
 \begin{proof}\leanok
     Multiply the fusion identity
@@ -257,6 +258,59 @@ them.
       =G_{\alpha,\beta}^{ij}$ on the right by $U_{\alpha,\beta}$ and on the
     left by $U_{\alpha,\beta}^\dagger$, respectively, and use
     $U_{\alpha,\beta}^\dagger U_{\alpha,\beta}=1$.
+\end{proof}
+
+\begin{theorem}[Length-independent zipper identities and completeness]%
+    \label{thm:mpdo_bnt_length_independent_zipper}
+    \lean{MPOTensor.BNTFusionIsometryFamily.%
+        chi_matrix_eq_one_of_lengthIndependent}
+    \lean{MPOTensor.BNTFusionIsometryFamily.%
+        fusionIsometry_mul_mulTensor_of_lengthIndependent}
+    \lean{MPOTensor.BNTFusionIsometryFamily.%
+        mulTensor_mul_fusionIsometry_conjTranspose_of_lengthIndependent}
+    \lean{MPOTensor.BNTFusionIsometryFamily.%
+        mulTensor_eq_conjTranspose_mul_unweightedDirectSum_mul_of_lengthIndependent}
+    \leanok
+    \uses{def:mpdo_bnt_fusion_isometry_family,
+        def:mpdo_bnt_label_length_independent,
+        thm:mpdo_bnt_label_length_independent_natural,
+        thm:mpdo_bnt_weighted_zipper}
+    Suppose the structure coefficients have positive trace-power form and are
+    independent of the positive chain length. Then
+    $\chi_{\alpha,\beta,\gamma}=1_{r_{\alpha,\beta,\gamma}}$ for every triple
+    of labels. If
+    \[
+        H_{\alpha,\beta}^{ij}
+          = \bigoplus_\gamma 1_{r_{\alpha,\beta,\gamma}}
+              \otimes M_\gamma^{ij},
+    \]
+    the fusion isometries satisfy
+    \[
+        U_{\alpha,\beta}(M_\alpha M_\beta)^{ij}
+          = H_{\alpha,\beta}^{ij}U_{\alpha,\beta},
+        \qquad
+        (M_\alpha M_\beta)^{ij}U_{\alpha,\beta}^\dagger
+          = U_{\alpha,\beta}^\dagger H_{\alpha,\beta}^{ij},
+    \]
+    and
+    \[
+        (M_\alpha M_\beta)^{ij}
+          = U_{\alpha,\beta}^\dagger H_{\alpha,\beta}^{ij}
+              U_{\alpha,\beta}.
+    \]
+    These are the identity-weight specialization of the zipper and
+    completeness equations in
+    \cite[Section~3, Equations~(19)--(21)]{Bultinck2017Anyons}, obtained from
+    the length-independent case described after
+    \cite[Theorem~4.14]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+\begin{proof}\leanok
+    Length independence makes every positive diagonal entry of
+    $\chi_{\alpha,\beta,\gamma}$ equal to one. Substitute the resulting
+    identity matrices into
+    Theorem~\ref{thm:mpdo_bnt_weighted_zipper}. For completeness, insert
+    $U_{\alpha,\beta}^\dagger U_{\alpha,\beta}=1$ on both sides of the product
+    letter and apply the fusion identity between the two inserted factors.
 \end{proof}
 
 \begin{definition}[Operator family of a fusion-isometry family]%

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -469,6 +469,43 @@ their positive trace-power representation, and the length-one idempotent
 identity are the hypothesis of the converse, not consequences of the mere
 existence of stabilized adjoint fixed-point algebras.
 
+\section{Length-independent zipper specialization}
+
+For a fusion-isometry family already satisfying Theorem~4.14(iii), suppose
+that its positive trace-power coefficients are independent of the positive
+chain length.  The observation at line~1010 then gives
+\[
+    \chi_{\alpha,\beta,\gamma}
+      = 1_{r_{\alpha,\beta,\gamma}}.
+\]
+Substitution in the weighted fusion identity gives both zipper equations and
+the completeness equation
+\[
+    (M_\alpha M_\beta)^{ij}
+      = U_{\alpha,\beta}^\dagger
+          \left(\bigoplus_\gamma
+            1_{r_{\alpha,\beta,\gamma}}\otimes M_\gamma^{ij}\right)
+        U_{\alpha,\beta}.
+\]
+These statements are formalized by
+\leanid{MPOTensor.BNTFusionIsometryFamily.%
+fusionIsometry_mul_mulTensor_of_lengthIndependent},
+\leanid{MPOTensor.BNTFusionIsometryFamily.%
+mulTensor_mul_fusionIsometry_conjTranspose_of_lengthIndependent}, and
+\leanid{MPOTensor.BNTFusionIsometryFamily.%
+mulTensor_eq_conjTranspose_mul_unweightedDirectSum_mul_of_lengthIndependent}.
+They are the identity-weight specialization of the equations labelled
+\texttt{zippercondition2} and \texttt{inversegaugeone} in the ``Fusion
+tensors'' section of the arXiv:1511.08090 source file
+\texttt{AnyonsPEPS.tex}.
+
+This result has an explicit scope restriction: it assumes the special
+length-independent coefficient system discussed at lines~995--1010, rather
+than proving that every renormalization fixed point has such coefficients.
+It also neither constructs the comparison of the two triple-fusion orders nor
+proves its invertibility.  Thus the associativity constraint and the
+pentagon-like equation mentioned at lines~995--999 remain unformalized.
+
 To eliminate the source-theorem gap, the formalization should instead:
 \begin{enumerate}
     \item define a separate, source-faithful predicate for


### PR DESCRIPTION
## Summary

- prove that length-independent positive trace-power coefficients make every fusion multiplicity matrix equal to the identity
- specialize the weighted fusion relations to the two unweighted zipper equations
- derive the associated completeness identity
- synchronize the MPO/RFP blueprint and record the remaining fixed-final comparison gap

## Mathematical scope

The results retain the positive trace-power and length-independence hypotheses used after Theorem 4.14 of arXiv:1606.00608. They do not assert existence or invertibility of the fixed-final-sector comparison map, associativity, or the pentagon equation. This advances #3776 without closing it.

## Verification

- `lake build TNLean.MPS.MPDO.BNTFusionIsometries`
- full `lake build`
- `leanblueprint checkdecls`
- `git diff --check`
- proof-integrity token scan

All checks pass; only pre-existing warnings remain.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive formal proofs and documentation under explicit hypotheses; no auth, I/O, or production runtime paths. Remaining mathematical gaps (F-move, pentagon) are documented rather than claimed closed.
> 
> **Overview**
> Under **positive trace-power form** and **length independence**, the PR shows every fusion multiplicity matrix `χ_{α,β,γ}` is the **identity** and specializes the existing chi-weighted fusion/zipper relations to the **unweighted** left/right zipper equations plus a **completeness** identity recovering the product letter from `U† (⨁ 1 ⊗ M) U`.
> 
> Lean adds `DiagonalChiFamily.matrix_eq_one_of_forall_entry_eq_one`, `BNTFusionIsometryFamily.chi_matrix_eq_one_of_lengthIndependent`, and three specialization theorems built by rewriting the weighted zipper lemmas. `BNTFusionIsometries` now imports `LengthIndependentCoefficients` instead of `BNTCoefficients`.
> 
> Blueprint (`ch21_mpdo_rfp_fusion_isometries`, `ch21_mpdo_rfp_bnt_coefficients`) and `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex` are updated with lean links and explicit scope: this assumes the length-independent coefficient case from the paper, not that every RFP has it, and **does not** construct or invert the fixed-final triple-fusion comparison / F-move.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78c27c1eaa46eeaba8457fdc47aaf01e22a39a50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->