### PR TITLE
feat(MPS/MPDO): derive cyclic sector positivity from SAL

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -425,6 +425,7 @@ import TNLean.MPS.MPDO.SectorPairingTransfer
 import TNLean.MPS.MPDO.SectorEtaContraction
 import TNLean.MPS.MPDO.SectorEtaOperator
 import TNLean.MPS.MPDO.SectorEtaPositivity
+import TNLean.MPS.MPDO.SALPhysicalSectorCyclicPositivity
 import TNLean.MPS.MPDO.SectorRecurrence
 import TNLean.MPS.MPDO.FusionIsometries
 import TNLean.MPS.MPDO.OperatorProduct

--- a/TNLean/MPS/MPDO/SALPhysicalSectorCyclicPositivity.lean
+++ b/TNLean/MPS/MPDO/SALPhysicalSectorCyclicPositivity.lean
@@ -1,0 +1,62 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.InverseMapPhysicalSectorFactorization
+import TNLean.MPS.MPDO.PhysicalSectorChainDecomposition
+import TNLean.MPS.MPDO.SectorEtaPositivity
+
+/-!
+# Positive cyclic sector products from the strong area law
+
+This file combines the raw physical-sector factorization obtained from an
+injective tensor satisfying the strong area law with positivity of the
+finite-chain operators. Every complete cyclic product of neighboring
+contractions is positive semidefinite because it is a diagonal sector
+compression of a physically conjugated finite-chain operator.
+
+No positivity of an individual neighboring contraction is asserted.
+
+## Main declaration
+
+- `MPOTensor.exists_physicalSectorFactorization_with_cyclicNeighboringProduct_posSemidef_of_isSAL`:
+  existence of a physical-sector factorization whose complete nonempty cyclic
+  neighboring products are positive semidefinite.
+
+## References
+
+- [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, Lemma C.4, lines 1406--1450
+-/
+
+open scoped Matrix ComplexOrder BigOperators
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- An injective MPO tensor satisfying SAL admits a physical-sector
+factorization for which every complete nonempty cyclic product of neighboring
+operators is positive semidefinite.
+
+The product is a diagonal sector compression of the physically conjugated
+finite-chain MPO. This does not give a single coherent positive choice for
+the individual neighboring operators.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma C.4 (`propSN`), lines
+1406--1450. -/
+theorem
+    exists_physicalSectorFactorization_with_cyclicNeighboringProduct_posSemidef_of_isSAL
+    (K : MPOTensor d D) (hK : K.IsInjective) (hSAL : IsSAL K) :
+    ∃ F : PhysicalSectorFactorization K,
+      ∀ {N : ℕ} [NeZero N] (k : Fin N → Fin F.sectorCount),
+        (F.cyclicNeighboringProduct k).PosSemidef := by
+  obtain ⟨F⟩ := nonempty_physicalSectorFactorization_of_isSAL K hK hSAL
+  refine ⟨F, ?_⟩
+  intro N _ k
+  rw [← F.mpo_submatrix_sector_eq_cyclicNeighboringProduct k]
+  exact (mpo_conjugatePhysical_posSemidef K F.physicalIsometry
+    (Classical.choose hSAL N)).submatrix _
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -939,6 +939,33 @@ strong subadditivity for a normalized three-site reduced state.
     vanishes. Thus all off-diagonal sector blocks vanish.
 \end{proof}
 
+\begin{corollary}[SAL gives positive cyclic sector products]
+    \label{cor:mpdo_sal_positive_cyclic_sector_products}
+    \lean{MPOTensor.exists_physicalSectorFactorization_with_cyclicNeighboringProduct_posSemidef_of_isSAL}
+    \leanok
+    \uses{cor:mpdo_sal_raw_physical_sector_factorization,
+      thm:mpdo_physical_sector_chain_decomposition}
+    Every injective MPO tensor satisfying SAL admits a physical-sector
+    factorization such that, for every $N\geq1$ and every cyclic sector
+    configuration $k=(k_0,\ldots,k_{N-1})$,
+    \[
+      \bigotimes_{n=0}^{N-1}\eta_{k_n,k_{n+1}}\geq0,
+      \qquad k_N=k_0.
+    \]
+    This is the projected-chain inequality in
+    \cite[Appendix~C.2, Lemma~C.4, lines~1446--1450]{Cirac2016MPDO_arXiv}.
+    It does not assert positivity of the individual neighboring operators.
+\end{corollary}
+
+\begin{proof}
+    \leanok
+    \uses{cor:mpdo_sal_raw_physical_sector_factorization,
+      thm:mpdo_physical_sector_chain_decomposition}
+    Choose the raw physical-sector factorization supplied by SAL. Each cyclic
+    neighboring product is a diagonal sector compression of the physically
+    conjugated $N$-site MPO and is therefore positive semidefinite.
+\end{proof}
+
 \begin{definition}[Boundary contraction against a virtual matrix]
     \label{def:mpdo_sector_boundary_operator}
     \lean{MPOTensor.PhysicalSectorFactorization.boundaryOperator,

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -244,10 +244,14 @@ factors are derived from the trace-one Hayashi density matrices, rather than
 assumed.  For an injective tensor satisfying SAL, the four-site Hayashi
 decomposition and a nonzero entry of the normalized tail therefore produce
 this raw factorization without ZCL or positivity hypotheses.
+For one such factorization, every complete nonempty cyclic neighboring
+product is positive semidefinite as a diagonal sector compression of the
+corresponding finite-chain operator.
 \footnote{The formal declarations are
 \path{MPOTensor.inverseMapPhysicalSectorFactorization},
 \path{MPOTensor.inverseMapPhysicalSectorFactorization_neighboringOperator_eq_sectorEta},
 \path{MPOTensor.nonempty_physicalSectorFactorization_of_isSAL},
+\path{MPOTensor.exists_physicalSectorFactorization_with_cyclicNeighboringProduct_posSemidef_of_isSAL},
 \path{MPOTensor.etaOfSectorTensors},
 \path{MPOTensor.sum_cyclic_sectorTensor_eq_prod_etaOfSectorTensors},
 \path{MPOTensor.trace_sector_word_eq_prod_etaOfSectorTensors},


### PR DESCRIPTION
## Summary

- build on the inverse-map physical-sector factorization of #3820
- prove that every complete nonempty cyclic neighboring product is positive semidefinite
- record the result as a separate MPO/RFP blueprint corollary and update the paper-gap status

## Mathematical scope

This is the projected-chain inequality in Appendix C.2, Lemma C.4, lines 1446–1450 of arXiv:1606.00608. Each cyclic product is a diagonal sector compression of the physically conjugated finite-chain MPO. The result does not assert a coherent positive choice of each individual neighboring operator, recurrence of the sector graph, or primitivity of the trace matrix. Those gaps remain explicit.

This branch is intentionally based on #3820 and contains no duplicate raw constructor. It advances #3696 without closing it.

## Verification

- targeted module build
- direct theorem import and `#check`
- root-source compilation
- `git diff --check` and 100-column check
- exact proof-integrity token scan

All targeted checks pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, compositional formalization on existing MPDO lemmas with documentation-only TeX updates; no runtime, security, or data-path changes.
> 
> **Overview**
> Adds a Lean capstone **`exists_physicalSectorFactorization_with_cyclicNeighboringProduct_posSemidef_of_isSAL`**: for injective MPO tensors satisfying the strong area law, some physical-sector factorization makes every complete cyclic neighboring product positive semidefinite. The proof reuses the SAL raw factorization, identifies each cyclic product with a sector submatrix of a physically conjugated finite-chain MPO, and pulls positivity from SAL’s chain operators.
> 
> The result is wired into the root import surface, recorded as blueprint corollary `cor:mpdo_sal_positive_cyclic_sector_products` (Appendix C.2, Lemma C.4 projected-chain inequality), and noted in the CPGSV17 paper-gap status. It does **not** claim positivity of individual neighboring operators or close the broader SAL/ZCL track.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3503c9899d9c02c56efac3299a9898cac4b8dc86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->