### PR TITLE
feat(MPS/MPDO): package inverse-map sector factorization

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -391,6 +391,7 @@ import TNLean.MPS.MPDO.RFPSubspinMaps
 import TNLean.MPS.MPDO.HayashiSectorComparison
 import TNLean.MPS.MPDO.SectorFactorization
 import TNLean.MPS.MPDO.PhysicalSectorFactorization
+import TNLean.MPS.MPDO.InverseMapPhysicalSectorFactorization
 import TNLean.MPS.MPDO.NeighboringPreparation
 import TNLean.MPS.MPDO.PhysicalSectorSubspinMaps
 import TNLean.MPS.MPDO.PhysicalSectorClosureCoordinates

--- a/TNLean/MPS/MPDO/InverseMapPhysicalSectorFactorization.lean
+++ b/TNLean/MPS/MPDO/InverseMapPhysicalSectorFactorization.lean
@@ -1,0 +1,116 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalSectorFactorization
+import TNLean.MPS.MPDO.SectorFactorization
+
+/-!
+# Physical-sector factorization from the inverse-map tensors
+
+This file combines the sector tensors obtained from the Hayashi decomposition
+of a three-site closure as a `PhysicalSectorFactorization`.  The construction
+records only the direct-sum factorization and its neighboring contractions;
+it does not assert positivity of those contractions.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, equation `AppUkU=rl`, lines 1383--1387; Lemma C.4 (`propSN`),
+  lines 1406--1411; equation `formK`, lines 1434--1439; and equation `etarl`,
+  lines 1441--1445
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- The physical-sector factorization determined by a Hayashi decomposition
+and a nonzero entry of the virtual tail.
+
+The nonzero dimensions of the left and right factors follow from the
+trace-one left and right sector density matrices; they are not additional
+hypotheses.  No positivity of the neighboring contractions is asserted.
+
+**Local fix (tail index):** the selected tail entry is
+$R_{\beta_3,\alpha_1}$, as dictated by the inverse-map contraction.  The
+correction is recorded in
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `AppUkU=rl`, lines
+1383--1387; Lemma C.4 (`propSN`), lines 1406--1411; and equation `formK`,
+lines 1434--1439. -/
+noncomputable def inverseMapPhysicalSectorFactorization
+    {rho : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    (K : MPOTensor d D) (hK : K.IsInjective)
+    (R : Matrix (Fin D) (Fin D) ℂ) (hρ : IsThreeSiteClosure K R rho)
+    (hη : EtaStructure rho) (α₁ β₃ : Fin D) (hm : R β₃ α₁ ≠ 0) :
+    PhysicalSectorFactorization K where
+  sectorCount := hη.m
+  leftDim := hη.dL
+  rightDim := hη.dR
+  leftDim_pos := fun k ↦ Fin.pos_iff_nonempty.mpr <| by
+    have hp : Nonempty (Fin d × Fin (hη.dL k)) :=
+      Matrix.nonempty_of_trace_eq_one (hη.ρ_left k) (hη.hρ_left_dm k).2
+    exact hp.map Prod.snd
+  rightDim_pos := fun k ↦ Fin.pos_iff_nonempty.mpr <| by
+    have hp : Nonempty (Fin (hη.dR k) × Fin d) :=
+      Matrix.nonempty_of_trace_eq_one (hη.ρ_right k) (hη.hρ_right_dm k).2
+    exact hp.map Prod.fst
+  sectorEquiv := hη.decompB
+  physicalIsometry := hη.U_B
+  physicalIsometry_isometry := by
+    simpa only [Matrix.star_eq_conjTranspose] using
+      (Matrix.mem_unitaryGroup_iff').mp hη.U_B.2
+  leftTensor := fun k beta ↦ sectorTensorL K hK hη R α₁ β₃ k beta
+  rightTensor := fun k alpha ↦ sectorTensorR K hK hη β₃ k alpha
+  factorization := physicalSlice_sector_factorization K hK R rho hρ hη hm
+
+/-- The neighboring contraction of the resulting physical-sector
+factorization is the inverse-map operator `sectorEta`.
+
+No positivity or normalization is part of this identification.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `etarl`, lines 1441--1445. -/
+theorem inverseMapPhysicalSectorFactorization_neighboringOperator_eq_sectorEta
+    {rho : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    (K : MPOTensor d D) (hK : K.IsInjective)
+    (R : Matrix (Fin D) (Fin D) ℂ) (hρ : IsThreeSiteClosure K R rho)
+    (hη : EtaStructure rho) (α₁ β₃ : Fin D) (hm : R β₃ α₁ ≠ 0)
+    (k h : Fin hη.m) :
+    (inverseMapPhysicalSectorFactorization K hK R hρ hη α₁ β₃ hm).neighboringOperator k h =
+      sectorEta K hK hη R α₁ β₃ k h := by
+  ext ⟨xR, xL⟩ ⟨yR, yL⟩
+  change (∑ gamma : Fin D,
+      sectorTensorR K hK hη β₃ k gamma xR yR *
+        sectorTensorL K hK hη R α₁ β₃ h gamma xL yL) = _
+  rw [sectorEta, Matrix.sum_apply]
+  simp only [Matrix.kroneckerMap_apply]
+
+/-- An injective MPO tensor satisfying SAL admits the raw physical-sector
+factorization obtained from the four-site Hayashi decomposition.
+
+This conclusion contains no positivity, recurrence, ZCL, primitivity, or
+normality assertion.  Those are subsequent steps in the proof of the positive
+factorization used in Proposition C.8.
+
+**Scope restriction (raw sector factorization):** this is the algebraic
+factorization step of Lemma C.4, not the coherent positivity conclusion used
+later in Proposition C.8.  The remaining steps are recorded in
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma C.4 (`propSN`), lines
+1406--1411, and equations `formK` and `etarl`, lines 1434--1445. -/
+theorem nonempty_physicalSectorFactorization_of_isSAL
+    (K : MPOTensor d D) (hK : K.IsInjective) (hSAL : IsSAL K) :
+    Nonempty (PhysicalSectorFactorization K) := by
+  obtain ⟨hη⟩ := exists_etaStructure_reducedBlockState_of_isSAL K hSAL
+  obtain ⟨β₃, α₁, hm⟩ :=
+    exists_normalizedFourSiteTail_entry_ne_zero K ((Classical.choose_spec hSAL).1 4)
+  exact ⟨inverseMapPhysicalSectorFactorization K hK (normalizedFourSiteTail K)
+    (isThreeSiteClosure_reducedBlockState K) hη α₁ β₃ hm⟩
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -823,6 +823,57 @@ strong subadditivity for a normalized three-site reduced state.
     this definition; it is a separate hypothesis in Proposition~C.7.
 \end{definition}
 
+\begin{definition}[Inverse-map physical-sector factorization]
+    \label{def:mpdo_inverse_map_physical_sector_factorization}
+    \lean{MPOTensor.inverseMapPhysicalSectorFactorization}
+    \leanok
+    \uses{thm:mpdo_sector_factorization,
+      def:mpdo_physical_sector_factorization,
+      lem:mpdo_trace_one_nonempty}
+    Let ${\cal K}$ be injective, let $\rho$ be its three-site closure against
+    a virtual tail $R$, and choose a Hayashi decomposition of $\rho$. Fix
+    outer indices such that $R_{\beta_3,\alpha_1}\ne0$. The inverse-map
+    tensors $l_k,r_k$, together with the Hayashi physical decomposition and
+    unitary, determine a physical-sector factorization of ${\cal K}$.
+
+    The left and right factor spaces are nonzero because the corresponding
+    Hayashi density matrices have trace one; their nonzero dimensions are
+    conclusions rather than hypotheses. No positivity of the neighboring
+    operators is asserted. This gives the factorization in
+    \cite[Appendix~C.2, equations \texttt{AppUkU=rl} and \texttt{formK},
+    lines~1383--1387 and~1434--1439]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{theorem}[Identification of the neighboring operators]
+    \label{thm:mpdo_inverse_map_factorization_neighboring_operator}
+    \lean{MPOTensor.inverseMapPhysicalSectorFactorization_neighboringOperator_eq_sectorEta}
+    \leanok
+    \uses{def:mpdo_inverse_map_physical_sector_factorization,
+      def:mpdo_sector_eta,
+      def:mpdo_minimal_neighboring_operator}
+    For all sectors $k,h$, the neighboring contraction of the resulting
+    physical-sector factorization is the inverse-map operator
+    \[
+      \eta_{k,h}=\sum_\gamma (r_k)_\gamma\otimes(l_h)_\gamma.
+    \]
+    This is equation \texttt{etarl} in
+    \cite[Appendix~C.2, lines~1441--1445]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{corollary}[SAL gives a raw physical-sector factorization]
+    \label{cor:mpdo_sal_raw_physical_sector_factorization}
+    \lean{MPOTensor.nonempty_physicalSectorFactorization_of_isSAL}
+    \leanok
+    \uses{thm:mpdo_four_site_sal_eta_structure,
+      thm:mpdo_normalized_four_site_tail_entry_ne_zero,
+      def:mpdo_inverse_map_physical_sector_factorization}
+    Every injective MPO tensor satisfying SAL admits a physical-sector
+    factorization. This is only the raw algebraic factorization from Lemma C.4
+    and equations \texttt{formK} and \texttt{etarl}; coherent positivity of
+    the neighboring operators, recurrence, and primitivity are not part of
+    this conclusion.
+\end{corollary}
+
 \begin{definition}[Finite-chain coordinates of a physical-sector factorization]
     \label{def:mpdo_physical_sector_chain_coordinates}
     \lean{MPOTensor.PhysicalSectorFactorization.SectorChainFiber,

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -39,9 +39,12 @@ unless they are cited by one of the current blueprint chapters above.
 For MPDO renormalization fixed points:
 
 - `cpgsv17_mpdo_sal_zcl_eta_local_structure.tex` records the missing
-  inverse-map sector factorization in Appendix C.2. The double end-site
-  inverse contraction is proved, while its comparison with the conjugated
-  Hayashi decomposition and the resulting tensors $l_k,r_k$ remain open.
+  coherent positive choice for the inverse-map neighboring operators in
+  Appendix C.2. The comparison with the conjugated Hayashi decomposition,
+  the tensors $l_k,r_k$, the resulting physical-sector factorization,
+  and the exact finite-chain bond product are formalized. Deriving recurrence
+  from injectivity and choosing positive representatives coherently across
+  the sector graph remain open.
 - `cpsv16_purification_rfp_definition.tex` records why the former
   local-purification PRFP predicate was removed: it required a generic
   pure-state RFP witness, but did not enforce the source's positive-length

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -238,8 +238,16 @@ the source statement simultaneously for arbitrary chain length.
 \leanid{MPOTensor.exists_etaStructure_reducedBlockState_of_isSAL}.}
 
 The neighboring operators and their all-length algebraic identity are now
-formalized.
+formalized.  The inverse-map tensors also determine a source-minimal
+physical-sector factorization.  The nonzero dimensions of its left and right
+factors are derived from the trace-one Hayashi density matrices, rather than
+assumed.  For an injective tensor satisfying SAL, the four-site Hayashi
+decomposition and a nonzero entry of the normalized tail therefore produce
+this raw factorization without ZCL or positivity hypotheses.
 \footnote{The formal declarations are
+\path{MPOTensor.inverseMapPhysicalSectorFactorization},
+\path{MPOTensor.inverseMapPhysicalSectorFactorization_neighboringOperator_eq_sectorEta},
+\path{MPOTensor.nonempty_physicalSectorFactorization_of_isSAL},
 \path{MPOTensor.etaOfSectorTensors},
 \path{MPOTensor.sum_cyclic_sectorTensor_eq_prod_etaOfSectorTensors},
 \path{MPOTensor.trace_sector_word_eq_prod_etaOfSectorTensors},
@@ -500,15 +508,16 @@ Together with positivity of the neighboring operators, this supplies the
 mathematical data needed to construct
 \leanid{MPOTensor.EtaLocalStructureData}.  The conditional construction is
 \leanid{MPOTensor.PhysicalSectorFactorization.etaLocalStructureData}; its
-normalization scalar is one. The remaining step is upstream: construct a
-coherently positive physical-sector factorization from SAL. ZCL is not a
-hypothesis of this construction.
+normalization scalar is one. The raw inverse-map physical-sector factorization
+is now constructed for an injective tensor satisfying SAL. The remaining
+upstream step is to choose its
+neighboring contractions coherently positive. ZCL is not a hypothesis of this
+construction.
 
 The source Proposition \texttt{3to4} assumes SAL, not ZCL.  ZCL enters only
 after this commuting product form has been obtained, in the later step that
 derives the GSNNCH--ZCL and RFP conclusions.  Accordingly, adding ZCL to a
-conditional theorem would not repair the missing inverse-map sector
-factorization.
+conditional theorem would not repair the missing coherent positive choice.
 
 The positive-choice and primitivity statements that remain in Lemma
 \texttt{propSN} are tracked by
@@ -521,7 +530,7 @@ as unconditionally formalized from its source hypotheses.
 
 \section{Classification}
 
-This note records an open gap for the SAL-to-bond construction of
+This note records an open gap for the SAL-to-positive-bond construction of
 \leanid{MPOTensor.EtaLocalStructureData}. The positivity half of the projected
 chain identity is now formalized unconditionally, and the pairwise
 positive-choice construction is formalized under the symmetric-support scope
@@ -543,9 +552,10 @@ every length $N\geq2$.  The finite-chain MPO is the ordered product of those
 bonds, first in cyclic sector coordinates and then in the original physical
 coordinates.  If the neighboring operators are positive semidefinite, these
 results provide the positive commuting bond and its exact realization with
-scalar one, and they determine the eta-local structure data. The only
-remaining obligation in this implication is to derive the required
-coherently positive physical-sector factorization from SAL.
+scalar one, and they determine the eta-local structure data. The raw
+physical-sector factorization already follows for an injective tensor
+satisfying SAL. The remaining obligation in this implication is to choose the
+inverse-map neighboring operators coherently positive.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Mathematical statement

This pull request constructs the raw physical-sector factorization determined
by the inverse-map tensors in Appendix C.2. Given an injective MPO tensor, a
three-site closure, a Hayashi decomposition, and a nonzero virtual-tail entry,
the existing tensors \(l_k,r_k\) determine a `PhysicalSectorFactorization`.

The nonzero left and right factor dimensions are proved from the trace-one
Hayashi density matrices; they are not added as hypotheses. The resulting
neighboring contraction is identified exactly with the existing inverse-map
operator

\[
  \eta_{k,h}=\sum_\gamma (r_k)_\gamma\otimes(l_h)_\gamma.
\]

An injective tensor satisfying SAL therefore admits this raw factorization,
using the established four-site Hayashi witness and normalized-tail
nonvanishing theorem.

No positivity, recurrence, ZCL, primitivity, normality, or extra normalization
hypothesis is introduced. Coherent positivity remains the upstream gap before
the conditional eta-local theorem can be applied.

Closes #3817.
Advances #3696 and #823.

## Source

- arXiv:1606.00608, Appendix C.2, equation `AppUkU=rl`, lines 1383–1387
- Lemma C.4 (`propSN`), lines 1406–1411
- equation `formK`, lines 1434–1439
- equation `etarl`, lines 1441–1445

## Verification

- targeted compilation of `InverseMapPhysicalSectorFactorization.lean`
- `lake build TNLean` — 9345 jobs
- blueprint synchronization — chapter 21 at 387/387
- `leanblueprint checkdecls`
- blueprint PDF generation
- proof-integrity, line-length, diff, and axiom audits
- independent review of hypotheses, tail-index orientation, factor dimensions,
  constructor fields, neighboring-operator orientation, and gap status

The constructor and neighboring-operator identity use only standard logical
axioms. The SAL corollary additionally uses the existing sanctioned Hayashi
characterization axiom `hayashi_ssa_equality_characterization_forward`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization and documentation on the MPDO proof track; no runtime, auth, or data-path changes, with scope limited to algebraic factorization without new positivity claims.
> 
> **Overview**
> Adds **`InverseMapPhysicalSectorFactorization.lean`**, wiring existing inverse-map sector tensors (`sectorTensorL` / `sectorTensorR`) and `physicalSlice_sector_factorization` into a **`PhysicalSectorFactorization`** constructor with left/right factor dimensions derived from trace-one Hayashi density matrices (not assumed). A theorem equates its **neighboring contractions** with **`sectorEta`**, and **`nonempty_physicalSectorFactorization_of_isSAL`** builds this raw factorization for injective **SAL** tensors via the four-site Hayashi witness and a nonzero normalized tail entry—explicitly **without** ZCL, recurrence, or coherent positivity.
> 
> The module is exported from **`TNLean.lean`**. **Blueprint chapter 21** gains matching definitions/theorems/corollary, and **paper-gap** docs are revised to treat the inverse-map factorization as formalized while the remaining open step is a **coherently positive** choice of neighboring operators.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8b88502dad69a46d46281e2c5d0170b1b83744d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->