### PR TITLE
doc(blueprint): record cyclic positivity congruence

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -944,6 +944,7 @@ strong subadditivity for a normalized three-site reduced state.
     \lean{MPOTensor.exists_physicalSectorFactorization_with_cyclicNeighboringProduct_posSemidef_of_isSAL}
     \leanok
     \uses{cor:mpdo_sal_raw_physical_sector_factorization,
+      thm:mpdo_conjugated_chain_congruence,
       thm:mpdo_physical_sector_chain_decomposition}
     Every injective MPO tensor satisfying SAL admits a physical-sector
     factorization such that, for every $N\geq1$ and every cyclic sector
@@ -960,10 +961,12 @@ strong subadditivity for a normalized three-site reduced state.
 \begin{proof}
     \leanok
     \uses{cor:mpdo_sal_raw_physical_sector_factorization,
+      thm:mpdo_conjugated_chain_congruence,
       thm:mpdo_physical_sector_chain_decomposition}
-    Choose the raw physical-sector factorization supplied by SAL. Each cyclic
-    neighboring product is a diagonal sector compression of the physically
-    conjugated $N$-site MPO and is therefore positive semidefinite.
+    Choose the raw physical-sector factorization supplied by SAL. The physical
+    basis change sends the positive $N$-site MPO to a positive congruence.
+    Each cyclic neighboring product is a diagonal sector compression of this
+    congruence and is therefore positive semidefinite.
 \end{proof}
 
 \begin{definition}[Boundary contraction against a virtual matrix]


### PR DESCRIPTION
## Summary

- add the physical-congruence theorem to the explicit dependency list of the SAL cyclic-sector positivity corollary
- make the proof text state the congruence step before diagonal compression

## Scope

This is a blueprint-only dependency clarification following #3819. It does not change a Lean declaration or mathematical hypothesis.

## Verification

- target label exists in the same chapter
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only dependency and proof wording in a single blueprint corollary; no code or formal proof changes.
> 
> **Overview**
> Blueprint-only update to **Corollary** (SAL gives positive cyclic sector products): it now lists **`thm:mpdo_conjugated_chain_congruence`** in the explicit `\uses` dependencies (statement and proof), alongside the raw SAL factorization and physical-sector chain decomposition.
> 
> The proof text is rewritten so positivity is argued via the **physical basis change** producing a **positive congruence** of the $N$-site MPO, then noting each cyclic neighboring product is a **diagonal sector compression** of that congruence—replacing the shorter wording that jumped straight from compression to PSD.
> 
> No Lean declarations or mathematical hypotheses change; this aligns the written proof with the congruence theorem already used elsewhere in the chapter (e.g. projected chain block positivity).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1565ce99bce6474f4596ec96308ff205a153ce8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->