### PR TITLE
feat(MPS/MPDO): encode recurrent sector walks as finite cycles

### DIFF
--- a/TNLean/Algebra/DirectedWalkCoboundary.lean
+++ b/TNLean/Algebra/DirectedWalkCoboundary.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import Mathlib.Algebra.BigOperators.Fin
 import Mathlib.Algebra.Group.Defs
 import Mathlib.Data.Quot
 
@@ -32,9 +33,15 @@ a quiver of edge types.
 one finite cycle. Reachability by a directed walk is equivalent to the
 reflexive transitive closure of the edge relation; this permits direct use with
 relations defined through `Relation.ReflTransGen`.
+
+A nonempty closed walk also determines a finite cyclic family of vertices.
+Every consecutive pair is an edge, including the final return to the initial
+vertex, and the cyclic product of the edge weights equals the walk weight.
 -/
 
 namespace TNLean.Algebra
+
+open scoped BigOperators
 
 variable {V G : Type*} (r : V → V → Prop)
 
@@ -89,6 +96,193 @@ theorem weight_append [Monoid G] (κ : V → V → G) {a b c : V}
   induction u with
   | nil => simp
   | cons hab u ih => simp [append, ih, mul_assoc]
+
+/-- The number of edges in a directed walk. -/
+@[reducible] def edgeCount {a b : V} : DirectedWalk r a b → ℕ
+  | .nil _ => 0
+  | .cons _ w => edgeCount w + 1
+
+@[simp] theorem edgeCount_nil (a : V) : edgeCount r (.nil a) = 0 := rfl
+
+@[simp] theorem edgeCount_cons {a b c : V} (hab : r a b) (w : DirectedWalk r b c) :
+    edgeCount r (.cons hab w) = edgeCount r w + 1 := rfl
+
+/-- The vertex at a position of a directed walk, including both endpoints. -/
+def vertexAt {a b : V} (w : DirectedWalk r a b) :
+    Fin (edgeCount r w + 1) → V :=
+  match w with
+  | .nil a => fun _ => a
+  | .cons (a := a) _ w => Fin.cases a (fun i => vertexAt w i)
+
+@[simp] theorem vertexAt_nil (a : V) (i : Fin 1) :
+    vertexAt r (.nil a) i = a := rfl
+
+@[simp] theorem vertexAt_cons_zero {a b c : V} (hab : r a b)
+    (w : DirectedWalk r b c) :
+    vertexAt r (.cons hab w) 0 = a := rfl
+
+@[simp] theorem vertexAt_cons_succ {a b c : V} (hab : r a b)
+    (w : DirectedWalk r b c) (i : Fin (edgeCount r w + 1)) :
+    vertexAt r (.cons hab w) i.succ = vertexAt r w i := rfl
+
+@[simp] theorem vertexAt_zero {a b : V} (w : DirectedWalk r a b) :
+    vertexAt r w 0 = a := by
+  cases w <;> rfl
+
+@[simp] theorem vertexAt_last {a b : V} (w : DirectedWalk r a b) :
+    vertexAt r w (Fin.last (edgeCount r w)) = b := by
+  induction w with
+  | nil => rfl
+  | @cons a b c hab w ih =>
+      change Fin.cases a (fun i => vertexAt r w i)
+        (Fin.last (edgeCount r w + 1)) = c
+      rw [show Fin.last (edgeCount r w + 1) = (Fin.last (edgeCount r w)).succ by
+        ext
+        simp]
+      exact ih
+
+/-- Consecutive positions in a directed walk are related by an edge. -/
+theorem vertexAt_edge {a b : V} (w : DirectedWalk r a b)
+    (i : Fin (edgeCount r w)) :
+    r (vertexAt r w i.castSucc) (vertexAt r w i.succ) := by
+  induction w with
+  | nil => exact Fin.elim0 i
+  | @cons a b c hab w ih =>
+      refine Fin.cases ?_ (fun j => ?_) i
+      · change r a (Fin.cases a (fun i => vertexAt r w i) 1)
+        have hone : (1 : Fin (edgeCount r w + 2)) =
+            (0 : Fin (edgeCount r w + 1)).succ := by
+          ext
+          simp
+        rw [hone]
+        rw [Fin.cases_succ, vertexAt_zero]
+        exact hab
+      · change r
+          (Fin.cases a (fun i => vertexAt r w i) j.succ.castSucc)
+          (Fin.cases a (fun i => vertexAt r w i) j.succ.succ)
+        simp only [Fin.cases_succ]
+        exact ih j
+
+/-- A nonempty closed walk, written as its cyclic list of source vertices. -/
+def closedConsVertices {a b : V} (hab : r a b) (w : DirectedWalk r b a) :
+    Fin (edgeCount r w + 1) → V :=
+  fun i => vertexAt r (.cons hab w) i.castSucc
+
+@[simp] theorem closedConsVertices_zero {a b : V} (hab : r a b)
+    (w : DirectedWalk r b a) :
+    closedConsVertices r hab w 0 = a := rfl
+
+private theorem castSucc_add_one_eq_succ_of_ne_last {N : ℕ}
+    (i : Fin (N + 1)) (hi : i ≠ Fin.last N) :
+    (i + 1).castSucc = i.succ := by
+  apply Fin.ext
+  have hi' : i.val < N := by
+    have hine : i.val ≠ N := by
+      intro heq
+      apply hi
+      ext
+      exact heq
+    omega
+  have hone : (1 : Fin (N + 1)).val = 1 := by
+    rw [Fin.val_one']
+    exact Nat.mod_eq_of_lt (by omega)
+  calc
+    ↑(i + 1).castSucc = ↑(i + 1) := Fin.val_castSucc _
+    _ = (i.val + (1 : Fin (N + 1)).val) % (N + 1) := Fin.val_add _ _
+    _ = (i.val + 1) % (N + 1) := by rw [hone]
+    _ = i.val + 1 := Nat.mod_eq_of_lt (by omega)
+    _ = ↑i.succ := (Fin.val_succ i).symm
+
+private theorem castSucc_add_one_eq_zero_of_eq_last {N : ℕ}
+    (i : Fin (N + 1)) (hi : i = Fin.last N) :
+    (i + 1).castSucc = (0 : Fin (N + 2)) := by
+  subst i
+  apply Fin.ext
+  calc
+    ↑(Fin.last N + 1).castSucc = ↑(Fin.last N + 1) := Fin.val_castSucc _
+    _ = ((Fin.last N).val + (1 : Fin (N + 1)).val) % (N + 1) :=
+      Fin.val_add _ _
+    _ = 0 := by
+      cases N <;> simp [Nat.mod_self]
+    _ = ↑(0 : Fin (N + 2)) := rfl
+
+/-- The vertex following the initial vertex is the target of the distinguished
+first edge. -/
+@[simp] theorem closedConsVertices_zero_add_one {a b : V} (hab : r a b)
+    (w : DirectedWalk r b a) :
+    closedConsVertices r hab w (0 + 1) = b := by
+  cases w with
+  | nil =>
+      rw [show (0 + 1 : Fin 1) = 0 from Subsingleton.elim _ _,
+        closedConsVertices_zero]
+  | @cons b c a hbc w =>
+      unfold closedConsVertices
+      rw [castSucc_add_one_eq_succ_of_ne_last]
+      · simp only [vertexAt_cons_succ, vertexAt_zero]
+      · intro h
+        have := congrArg Fin.val h
+        simp at this
+
+/-- Consecutive cyclic vertices of a nonempty closed walk are related by an edge. -/
+theorem closedConsVertices_edge {a b : V} (hab : r a b)
+    (w : DirectedWalk r b a) (i : Fin (edgeCount r w + 1)) :
+    r (closedConsVertices r hab w i)
+      (closedConsVertices r hab w (i + 1)) := by
+  by_cases hi : i = Fin.last (edgeCount r w)
+  · have hedge := vertexAt_edge r (.cons hab w) i
+    change r (vertexAt r (.cons hab w) i.castSucc)
+      (vertexAt r (.cons hab w) (i + 1).castSucc)
+    rw [castSucc_add_one_eq_zero_of_eq_last i hi, vertexAt_zero]
+    have hisucc : i.succ = Fin.last (edgeCount r w + 1) := by
+      subst i
+      ext
+      simp
+    rw [hisucc, vertexAt_last] at hedge
+    exact hedge
+  · have hedge := vertexAt_edge r (.cons hab w) i
+    change r (vertexAt r (.cons hab w) i.castSucc)
+      (vertexAt r (.cons hab w) (i + 1).castSucc)
+    rw [castSucc_add_one_eq_succ_of_ne_last i hi]
+    exact hedge
+
+/-- The weight of a walk is the product of the weights of its linearly ordered edges. -/
+theorem weight_eq_fin_prod_vertexAt [CommMonoid G] (κ : V → V → G)
+    {a b : V} (w : DirectedWalk r a b) :
+    weight r κ w = ∏ i : Fin (edgeCount r w),
+      κ (vertexAt r w i.castSucc) (vertexAt r w i.succ) := by
+  induction w with
+  | nil => simp [edgeCount]
+  | @cons a b c hab w ih =>
+      rw [weight_cons]
+      change κ a b * weight r κ w = ∏ i : Fin (edgeCount r w + 1),
+        κ (vertexAt r (.cons hab w) i.castSucc)
+          (vertexAt r (.cons hab w) i.succ)
+      rw [Fin.prod_univ_succ]
+      rw [ih]
+      congr 1
+      change κ a b = κ a (vertexAt r w 0)
+      rw [vertexAt_zero]
+
+/-- The weight of a nonempty closed walk is the cyclic product of the weights
+of its consecutive edges. -/
+theorem weight_closedCons_eq_fin_prod [CommMonoid G] (κ : V → V → G)
+    {a b : V} (hab : r a b) (w : DirectedWalk r b a) :
+    weight r κ (.cons hab w) = ∏ i : Fin (edgeCount r w + 1),
+      κ (closedConsVertices r hab w i)
+        (closedConsVertices r hab w (i + 1)) := by
+  rw [weight_eq_fin_prod_vertexAt]
+  apply Finset.prod_congr rfl
+  intro i _
+  congr 1
+  unfold closedConsVertices
+  by_cases hi : i = Fin.last (edgeCount r w)
+  · rw [castSucc_add_one_eq_zero_of_eq_last i hi, vertexAt_zero]
+    have hisucc : i.succ = Fin.last (edgeCount r w + 1) := by
+      subst i
+      ext
+      simp
+    rw [hisucc, vertexAt_last]
+  · rw [castSucc_add_one_eq_succ_of_ne_last i hi]
 
 private theorem weight_transport_start [Monoid G] (κ : V → V → G)
     {a a' b : V} (h : a = a') (w : DirectedWalk r a b) :

--- a/TNLean/Algebra/DirectedWalkCoboundary.lean
+++ b/TNLean/Algebra/DirectedWalkCoboundary.lean
@@ -29,9 +29,9 @@ and therefore cannot in general be eliminated into such data, while
 a quiver of edge types.
 
 `TNLean.Algebra.FiniteCycleCoboundary` treats the complementary special case of
-one finite cycle. A future MPDO specialization should prove the correspondence
-between `Relation.ReflTransGen` (hence `MPOTensor.SectorReaches`) and
-`DirectedWalk`, then apply the closed-walk theorem below to the sector phases.
+one finite cycle. Reachability by a directed walk is equivalent to the
+reflexive transitive closure of the edge relation; this permits direct use with
+relations defined through `Relation.ReflTransGen`.
 -/
 
 namespace TNLean.Algebra
@@ -107,6 +107,22 @@ theorem reaches_of_edge {a b : V} (hab : r a b) : Reaches r a b :=
 theorem Reaches.trans {a b c : V} : Reaches r a b → Reaches r b c → Reaches r a c := by
   rintro ⟨u⟩ ⟨v⟩
   exact ⟨append r u v⟩
+
+/-- Reachability by a directed walk is equivalent to membership in the
+reflexive transitive closure of the edge relation. -/
+theorem reaches_iff_reflTransGen {a b : V} :
+    Reaches r a b ↔ Relation.ReflTransGen r a b := by
+  constructor
+  · rintro ⟨w⟩
+    induction w with
+    | nil => exact .refl
+    | cons hab w ih => exact ih.head hab
+  · intro h
+    induction h with
+    | refl => exact ⟨nil _⟩
+    | tail hab hbc ih =>
+      obtain ⟨w⟩ := ih
+      exact ⟨append r w (cons hbc (nil _))⟩
 
 /-- If every edge admits a return walk, every walk admits a return walk. -/
 theorem reaches_reverse_of_edge_returns

--- a/TNLean/MPS/MPDO/SectorRecurrence.lean
+++ b/TNLean/MPS/MPDO/SectorRecurrence.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.DirectedWalkCoboundary
 import TNLean.Algebra.KroneckerFactorPositivity
 import TNLean.MPS.MPDO.SectorEtaPositivity
 
@@ -110,6 +111,33 @@ This is an auxiliary condition from
 additional hypothesis stated in arXiv:1606.00608. -/
 def IsRecurrentSupport {hη : EtaStructure ρ} (eta : etaOperators hη) : Prop :=
   ∀ k h : Fin hη.m, IsSectorEdge eta k h → SectorReaches eta h k
+
+/-- Reachability in the nonzero sector support is equivalently witnessed by a
+finite directed walk of nonzero neighboring operators.
+
+Source: `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`,
+the elimination plan for coherent sector rephasing. -/
+theorem sectorReaches_iff_directedWalkReaches {hη : EtaStructure ρ}
+    (eta : etaOperators hη) (k h : Fin hη.m) :
+    SectorReaches eta k h ↔
+      TNLean.Algebra.DirectedWalk.Reaches (IsSectorEdge eta) k h := by
+  exact (TNLean.Algebra.DirectedWalk.reaches_iff_reflTransGen _).symm
+
+/-- Recurrence of the nonzero sector support is exactly the return-walk
+hypothesis for its directed edge relation.
+
+Source: `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`,
+the elimination plan for coherent sector rephasing. -/
+theorem isRecurrentSupport_iff_directedWalkReturns {hη : EtaStructure ρ}
+    (eta : etaOperators hη) :
+    IsRecurrentSupport eta ↔
+      ∀ {k h : Fin hη.m}, IsSectorEdge eta k h →
+        TNLean.Algebra.DirectedWalk.Reaches (IsSectorEdge eta) h k := by
+  constructor
+  · intro hrec k h hkh
+    exact (sectorReaches_iff_directedWalkReaches eta h k).mp (hrec k h hkh)
+  · intro hrec k h hkh
+    exact (sectorReaches_iff_directedWalkReaches eta h k).mpr (hrec hkh)
 
 /-! ### The horizontal bond fiber around a cyclic sector assignment -/
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -2422,6 +2422,25 @@ strong subadditivity for a normalized three-site reduced state.
     can reach $k$ whenever $k\to h$ is an edge.
 \end{definition}
 
+\begin{lemma}[Equivalent forms of sector reachability]%
+    \label{lem:mpdo_eta_reachability_equivalence}
+    \lean{TNLean.Algebra.DirectedWalk.reaches_iff_reflTransGen}
+    \lean{MPOTensor.sectorReaches_iff_directedWalkReaches}
+    \lean{MPOTensor.isRecurrentSupport_iff_directedWalkReturns}
+    \leanok
+    A vertex $h$ is reachable from $k$ in the nonzero sector support if and
+    only if there is a finite directed walk from $k$ to $h$. Consequently,
+    the support is recurrent if and only if every directed edge admits a
+    directed return walk.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    A walk gives an element of the reflexive transitive closure by induction
+    on its edges. Conversely, append the final edge at each induction step in
+    the reflexive transitive closure.
+\end{proof}
+
 \begin{theorem}[Closed-walk criterion for vertex phases]%
     \label{thm:directed_cycle_coboundary}
     \lean{TNLean.Algebra.DirectedWalk.exists_vertex_of_closedWalk_weight_eq_one}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -2441,6 +2441,27 @@ strong subadditivity for a normalized three-site reduced state.
     the reflexive transitive closure.
 \end{proof}
 
+\begin{lemma}[Finite cyclic form of a closed directed walk]%
+    \label{lem:directed_closed_walk_finite_cycle}
+    \lean{TNLean.Algebra.DirectedWalk.closedConsVertices}
+    \lean{TNLean.Algebra.DirectedWalk.closedConsVertices_edge}
+    \lean{TNLean.Algebra.DirectedWalk.weight_closedCons_eq_fin_prod}
+    \leanok
+    Every nonempty closed directed walk of length $N$ determines a cyclic
+    family of vertices $v_0,\ldots,v_{N-1}$. Each $v_n\to v_{n+1}$ is an
+    edge, where $v_N=v_0$, and for any edge weights in a commutative monoid,
+    \[
+        \operatorname{wt}(w)=\prod_{n=0}^{N-1}\kappa_{v_n,v_{n+1}}.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Enumerate the sources of the successive edges. The last edge ends at the
+    initial vertex because the walk is closed. The product identity follows
+    by induction on the number of edges.
+\end{proof}
+
 \begin{theorem}[Closed-walk criterion for vertex phases]%
     \label{thm:directed_cycle_coboundary}
     \lean{TNLean.Algebra.DirectedWalk.exists_vertex_of_closedWalk_weight_eq_one}

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -358,6 +358,15 @@ theorem.\footnote{The formal declarations are
 \leanid{MPOTensor.sectorReaches_iff_directedWalkReaches}, and
 \leanid{MPOTensor.isRecurrentSupport_iff_directedWalkReturns}.}
 
+Every nonempty closed directed walk is also represented by a finite cyclic
+family of its source vertices.  Consecutive vertices are connected by the
+corresponding edge, including the final return to the initial vertex, and the
+cyclic product of edge weights equals the walk weight.\footnote{The formal
+declarations are
+\leanid{TNLean.Algebra.DirectedWalk.closedConsVertices},
+\leanid{TNLean.Algebra.DirectedWalk.closedConsVertices_edge}, and
+\leanid{TNLean.Algebra.DirectedWalk.weight_closedCons_eq_fin_prod}.}
+
 The finite-factor rescaling used implicitly by the four-sector
 counterexample is now a general lemma about complex matrices, independent of
 the MPDO setting.  If a finite Kronecker product $A_0\otimes\cdots\otimes

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -350,6 +350,14 @@ on the trace matrix $T$: this matches the phase-mismatch mechanism of the
 four-sector counterexample above, which is already visible at the level of
 the individual neighboring operators.
 
+Reachability defined by reflexive transitive closure is equivalent to the
+existence of a finite directed walk.  Consequently, recurrence of the sector
+support is exactly the return-walk hypothesis in the closed-walk coboundary
+theorem.\footnote{The formal declarations are
+\leanid{TNLean.Algebra.DirectedWalk.reaches_iff_reflTransGen},
+\leanid{MPOTensor.sectorReaches_iff_directedWalkReaches}, and
+\leanid{MPOTensor.isRecurrentSupport_iff_directedWalkReturns}.}
+
 The finite-factor rescaling used implicitly by the four-sector
 counterexample is now a general lemma about complex matrices, independent of
 the MPDO setting.  If a finite Kronecker product $A_0\otimes\cdots\otimes


### PR DESCRIPTION
## Summary

- identify reachability by reflexive transitive closure with reachability by a finite directed walk
- show that recurrence of the nonzero sector support is exactly the return-walk hypothesis of the closed-walk coboundary theorem
- represent every nonempty closed walk by a finite cyclic family of source vertices, preserving every edge and the exact product of edge weights
- record these results in the MPDO blueprint and the paper-gap analysis

## Mathematical role

For a nonempty closed walk (w) with cyclic vertices (v_0,\ldots,v_{N-1}), the new finite representation satisfies

\[
  v_n\to v_{n+1},
  \qquad
  \operatorname{wt}(w)=\prod_{n=0}^{N-1}\kappa_{v_n,v_{n+1}},
  \qquad v_N=v_0.
\]

This permits positivity of a cyclic neighboring product to be applied to an arbitrary closed walk in the sector support. It is the finite-indexing step needed before phase uniqueness can prove trivial holonomy and the recurrent-walk coboundary theorem can produce vertex phases.

## Scope and faithfulness

This pull request proves only the graph-theoretic and finite-cycle preliminaries for #3821. It does not derive recurrence from injectivity, make an individual neighboring operator positive semidefinite, or claim the unrestricted statement of arXiv:1606.00608, Appendix C.2, Lemma C.4. The paper-gap note continues to record recurrence as an extra hypothesis absent from the source.

References: #3821 and #3696.

## Verification

- `lake build` — 9,346 jobs
- targeted builds of `TNLean.Algebra.DirectedWalkCoboundary` and `TNLean.MPS.MPDO.SectorRecurrence`
- `leanblueprint web`
- `leanblueprint checkdecls`
- proof-integrity and diff checks
- axiom audit: only standard logical axioms (`propext`, `Classical.choice`, `Quot.sound`) where required

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style algebra and MPDO glue lemmas; no auth, runtime, or data-path changes.
> 
> **Overview**
> Adds **graph-theoretic infrastructure** on `DirectedWalk`: `edgeCount`, `vertexAt`, cyclic `closedConsVertices`, proofs that consecutive cyclic vertices are edges and that walk weight equals a `Fin`-indexed (cyclic) edge product. Proves **`reaches_iff_reflTransGen`**, linking walk reachability to `Relation.ReflTransGen`.
> 
> In **MPDO sector recurrence**, wires `SectorReaches` and `IsRecurrentSupport` to that API via `sectorReaches_iff_directedWalkReaches` and `isRecurrentSupport_iff_directedWalkReturns`, so recurrence matches the return-walk hypothesis of the closed-walk coboundary theorem.
> 
> **Blueprint** and the **paper-gap note** document reachability equivalence and the finite cyclic form of nonempty closed walks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2f53e2f2fb943dfb365548913c4a6df0112299c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->