### PR TITLE
feat(MPS/MPDO): compare triple fusion parenthesizations

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -440,6 +440,7 @@ import TNLean.MPS.MPDO.BNTFusionIsometries
 import TNLean.MPS.MPDO.BNTAssociativity
 import TNLean.MPS.MPDO.BNTLeftTripleFusion
 import TNLean.MPS.MPDO.BNTRightTripleFusion
+import TNLean.MPS.MPDO.BNTTripleFusionComparison
 import TNLean.MPS.MPDO.BNTFinalSectorFusion
 import TNLean.MPS.MPDO.CommutingForm
 import TNLean.MPS.MPDO.CommutingFormBridge

--- a/TNLean/MPS/MPDO/BNTTripleFusionComparison.lean
+++ b/TNLean/MPS/MPDO/BNTTripleFusionComparison.lean
@@ -1,0 +1,159 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.BNTLeftTripleFusion
+import TNLean.MPS.MPDO.BNTRightTripleFusion
+
+/-!
+# Comparison of the two triple-fusion parenthesizations
+
+The two iterated fusion isometries identify the left- and right-associated
+triple product tensors with doubly indexed direct sums. The canonical
+reassociation matrix \(A_{\alpha,\beta,\gamma}\) between their bond spaces gives
+the full comparison
+
+\[
+  C_{\alpha,\beta,\gamma}
+    = U^{\mathrm L}_{\alpha,\beta,\gamma}
+      A_{\alpha,\beta,\gamma}
+      (U^{\mathrm R}_{\alpha,\beta,\gamma})^\dagger.
+\]
+
+When the trace-power coefficients are independent of the positive chain
+length, every positive diagonal matrix \(\chi_{\alpha,\beta,\gamma}\) is an
+identity matrix. The comparison then intertwines the two unweighted doubly
+indexed direct sums, letter by letter.
+
+This is the full isometry comparison underlying the fixed-final
+\(F\)-transformation in the associativity argument of arXiv:1511.08090. No
+restriction to a fixed final label, invertibility assertion,
+\(F\)-transformation, or pentagon identity is made here. The fixed-label
+extraction in that source additionally uses a simultaneous left inverse
+separating the single-block tensors.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  lines 995--1010
+* [Bultinck--Marien--Williamson--Sahinoglu--Haegeman--Verstraete 2015]
+  arXiv:1511.08090, Section ``Associativity and the pentagon equation'',
+  lines 237--277 of the source
+-/
+
+open scoped Matrix BigOperators ComplexOrder Kronecker
+open Matrix
+
+namespace MPOTensor.BNTFusionIsometryFamily
+
+universe u
+
+variable {Λ : Type u} [Fintype Λ] [DecidableEq Λ] {p : ℕ}
+variable (Fam : BNTFusionIsometryFamily Λ p)
+
+/-- The row index of the left-associated triple-fusion direct sum.
+
+Source: arXiv:1606.00608, lines 995--1010; arXiv:1511.08090, equation
+`Fmove`, left indices \((e,d,\mu,\nu)\). -/
+abbrev LeftTripleFusionIndex (α β γ : Λ) : Type u :=
+  (δ : Λ) × (ε : Λ) × Fin (Fam.chi.dim α β δ) × Fin (Fam.chi.dim δ γ ε) ×
+    Fin (Fam.bondDim ε)
+
+/-- The row index of the right-associated triple-fusion direct sum.
+
+Source: arXiv:1606.00608, lines 995--1010; arXiv:1511.08090, equation
+`Fmove`, right indices \((f,d,\lambda,\sigma)\). -/
+abbrev RightTripleFusionIndex (α β γ : Λ) : Type u :=
+  (δ : Λ) × (ε : Λ) × Fin (Fam.chi.dim β γ δ) × Fin (Fam.chi.dim α δ ε) ×
+    Fin (Fam.bondDim ε)
+
+/-- The full comparison between the left- and right-associated triple-fusion
+direct sums,
+\(C=U^{\mathrm L}A(U^{\mathrm R})^\dagger\), where \(A\) is the canonical
+reassociation of the three bond spaces.
+
+This matrix compares the full ranges of the two iterated fusion isometries. It
+is not a fixed-final-label \(F\)-transformation, and no invertibility is asserted.
+
+Source: arXiv:1606.00608, lines 995--1010; arXiv:1511.08090, Section
+``Associativity and the pentagon equation'', lines 237--277 of the source. -/
+noncomputable def tripleFusionComparison (α β γ : Λ) :
+    Matrix (Fam.LeftTripleFusionIndex α β γ)
+      (Fam.RightTripleFusionIndex α β γ) ℂ :=
+  Fam.leftFusionIsometry α β γ *
+    mulTensorAssocMatrix (Fam.bondDim α) (Fam.bondDim β) (Fam.bondDim γ) *
+      (Fam.rightFusionIsometry α β γ)ᴴ
+
+/-- **The full triple-fusion comparison intertwines the unweighted direct
+sums.** Suppose the positive trace-power coefficients are independent of the
+positive chain length. For every letter, if
+
+\[
+  D^{\mathrm L}_{ik}
+    = \bigoplus_{\delta,\varepsilon}
+        1_{r_{\alpha\beta}^{\delta}}\otimes
+        \bigl(1_{r_{\delta\gamma}^{\varepsilon}}
+          \otimes M_\varepsilon^{ik}\bigr)
+\]
+
+and \(D^{\mathrm R}_{ik}\) is the analogous direct sum for the right
+parenthesization, then
+\[
+  D^{\mathrm L}_{ik} C_{\alpha,\beta,\gamma}
+    = C_{\alpha,\beta,\gamma} D^{\mathrm R}_{ik}.
+\]
+
+The result concerns the full direct sums. It neither selects a final label nor
+asserts that the comparison is invertible.
+
+Source: arXiv:1606.00608, lines 995--1010; arXiv:1511.08090, equations
+`zippercondition2` and `Fmove`, and lines 237--277 of the source. -/
+theorem tripleFusionComparison_intertwines_of_lengthIndependent
+    (c : BNTLabelCoefficientFamily Λ)
+    (hχ : c.HasPositiveLengthChiTracePowerForm Fam.chi)
+    (hLI : c.LengthIndependent) (α β γ : Λ) (i k : Fin p) :
+    (Matrix.blockDiagonal' fun δ => Matrix.blockDiagonal' fun ε =>
+      (1 : Matrix (Fin (Fam.chi.dim α β δ)) (Fin (Fam.chi.dim α β δ)) ℂ) ⊗ₖ
+        ((1 : Matrix (Fin (Fam.chi.dim δ γ ε))
+          (Fin (Fam.chi.dim δ γ ε)) ℂ) ⊗ₖ Fam.tensor ε i k)) *
+        Fam.tripleFusionComparison α β γ =
+      Fam.tripleFusionComparison α β γ *
+        (Matrix.blockDiagonal' fun δ => Matrix.blockDiagonal' fun ε =>
+          (1 : Matrix (Fin (Fam.chi.dim β γ δ))
+            (Fin (Fam.chi.dim β γ δ)) ℂ) ⊗ₖ
+            ((1 : Matrix (Fin (Fam.chi.dim α δ ε))
+              (Fin (Fam.chi.dim α δ ε)) ℂ) ⊗ₖ Fam.tensor ε i k)) := by
+  have hLeft :
+      Fam.leftFusionIsometry α β γ *
+          (mulTensor (mulTensor (Fam.tensor α) (Fam.tensor β)) (Fam.tensor γ)) i k *
+          (Fam.leftFusionIsometry α β γ)ᴴ =
+        Matrix.blockDiagonal' fun δ => Matrix.blockDiagonal' fun ε =>
+          (1 : Matrix (Fin (Fam.chi.dim α β δ))
+            (Fin (Fam.chi.dim α β δ)) ℂ) ⊗ₖ
+            ((1 : Matrix (Fin (Fam.chi.dim δ γ ε))
+              (Fin (Fam.chi.dim δ γ ε)) ℂ) ⊗ₖ Fam.tensor ε i k) := by
+    rw [Fam.leftFusion_apply]
+    simp_rw [Fam.chi_matrix_eq_one_of_lengthIndependent c hχ hLI]
+  have hRight :
+      Fam.rightFusionIsometry α β γ *
+          (mulTensor (Fam.tensor α) (mulTensor (Fam.tensor β) (Fam.tensor γ))) i k *
+          (Fam.rightFusionIsometry α β γ)ᴴ =
+        Matrix.blockDiagonal' fun δ => Matrix.blockDiagonal' fun ε =>
+          (1 : Matrix (Fin (Fam.chi.dim β γ δ))
+            (Fin (Fam.chi.dim β γ δ)) ℂ) ⊗ₖ
+            ((1 : Matrix (Fin (Fam.chi.dim α δ ε))
+              (Fin (Fam.chi.dim α δ ε)) ℂ) ⊗ₖ Fam.tensor ε i k) := by
+    rw [Fam.rightFusion_apply]
+    simp_rw [Fam.chi_matrix_eq_one_of_lengthIndependent c hχ hLI]
+  unfold tripleFusionComparison
+  rw [← hLeft, ← hRight]
+  simp only [Matrix.mul_assoc]
+  simp only [← Matrix.mul_assoc, Fam.leftFusionIsometry_isometry,
+    Fam.rightFusionIsometry_isometry, Matrix.one_mul]
+  simpa only [Matrix.mul_assoc] using congrArg
+    (fun X => Fam.leftFusionIsometry α β γ * X *
+      (Fam.rightFusionIsometry α β γ)ᴴ)
+    (mulTensor_mul_assocMatrix (Fam.tensor α) (Fam.tensor β) (Fam.tensor γ) i k)
+
+end MPOTensor.BNTFusionIsometryFamily

--- a/TNLean/MPS/MPDO/OperatorProduct.lean
+++ b/TNLean/MPS/MPDO/OperatorProduct.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import Mathlib.Data.Matrix.PEquiv
 import TNLean.Channel.PartialTrace
 import TNLean.MPS.MPDO.Defs
 
@@ -39,7 +40,7 @@ open Matrix
 
 namespace MPOTensor
 
-variable {d D D₁ D₂ : ℕ}
+variable {d D D₁ D₂ D₃ : ℕ}
 
 /-! ### The product tensor -/
 
@@ -63,6 +64,72 @@ noncomputable def mulTensor (M : MPOTensor d D₁) (N : MPOTensor d D₂) :
     (i k : Fin d) :
     mulTensor M N i k = (∑ j : Fin d, (M i j) ⊗ₖ (N j k)).submatrix
       finProdFinEquiv.symm finProdFinEquiv.symm := rfl
+
+/-- The canonical reassociation equivalence of three bond spaces,
+\(((\mathbb C^{D_1}\otimes\mathbb C^{D_2})\otimes\mathbb C^{D_3})\) with
+\(\mathbb C^{D_1}\otimes(\mathbb C^{D_2}\otimes\mathbb C^{D_3})\).
+
+Source: arXiv:1606.00608, lines 995--999; arXiv:1511.08090, Section
+``Associativity and the pentagon equation'', lines 237--251 of the source. -/
+def mulTensorAssocEquiv (D₁ D₂ D₃ : ℕ) :
+    Fin (D₁ * D₂ * D₃) ≃ Fin (D₁ * (D₂ * D₃)) :=
+  finProdFinEquiv.symm |>.trans
+    ((Equiv.prodCongr finProdFinEquiv.symm (Equiv.refl (Fin D₃))).trans
+      ((Equiv.prodAssoc (Fin D₁) (Fin D₂) (Fin D₃)).trans
+        ((Equiv.prodCongr (Equiv.refl (Fin D₁)) finProdFinEquiv).trans
+          finProdFinEquiv)))
+
+/-- The permutation matrix of `mulTensorAssocEquiv`, with rows indexed by the
+left-associated bond space and columns by the right-associated bond space.
+
+Source: arXiv:1606.00608, lines 995--999; arXiv:1511.08090, Section
+``Associativity and the pentagon equation'', lines 237--251 of the source. -/
+noncomputable def mulTensorAssocMatrix (D₁ D₂ D₃ : ℕ) :
+    Matrix (Fin (D₁ * D₂ * D₃)) (Fin (D₁ * (D₂ * D₃))) ℂ :=
+  (mulTensorAssocEquiv D₁ D₂ D₃).toPEquiv.toMatrix
+
+/-- **Associativity of the MPO tensor product.** A right-associated product
+letter, reindexed by the canonical bond reassociation on both indices, is the
+corresponding left-associated product letter.
+
+Source: arXiv:1606.00608, lines 995--999; arXiv:1511.08090, Section
+``Associativity and the pentagon equation'', lines 237--251 of the source. -/
+theorem mulTensor_assoc (M : MPOTensor d D₁) (N : MPOTensor d D₂)
+    (P : MPOTensor d D₃) (i l : Fin d) :
+    mulTensor (mulTensor M N) P i l =
+      (mulTensor M (mulTensor N P) i l).submatrix
+        (mulTensorAssocEquiv D₁ D₂ D₃) (mulTensorAssocEquiv D₁ D₂ D₃) := by
+  rw [mulTensor_apply, mulTensor_apply]
+  ext x y
+  rcases finProdFinEquiv.surjective x with ⟨⟨x₁₂, x₃⟩, rfl⟩
+  rcases finProdFinEquiv.surjective x₁₂ with ⟨⟨x₁, x₂⟩, rfl⟩
+  rcases finProdFinEquiv.surjective y with ⟨⟨y₁₂, y₃⟩, rfl⟩
+  rcases finProdFinEquiv.surjective y₁₂ with ⟨⟨y₁, y₂⟩, rfl⟩
+  simp only [Matrix.submatrix_apply, Matrix.sum_apply, mulTensor_apply,
+    mulTensorAssocEquiv, Equiv.trans_apply, Equiv.prodCongr_apply, Prod.map_apply,
+    Equiv.refl_apply, Equiv.prodAssoc_apply]
+  simp only [Equiv.symm_apply_apply, kroneckerMap_apply, submatrix_apply,
+    Equiv.coe_refl, Prod.map_apply, id_eq]
+  simp only [Matrix.sum_apply, Matrix.kronecker_apply]
+  simp_rw [Finset.sum_mul, Finset.mul_sum]
+  rw [Finset.sum_comm]
+  refine Finset.sum_congr rfl fun x _ => ?_
+  simp only [mul_assoc]
+
+/-- The product-tensor associator intertwines the letters belonging to the two
+parenthesizations of a triple product.
+
+Source: arXiv:1606.00608, lines 995--999; arXiv:1511.08090, Section
+``Associativity and the pentagon equation'', lines 237--251 of the source. -/
+theorem mulTensor_mul_assocMatrix (M : MPOTensor d D₁) (N : MPOTensor d D₂)
+    (P : MPOTensor d D₃) (i l : Fin d) :
+    mulTensor (mulTensor M N) P i l * mulTensorAssocMatrix D₁ D₂ D₃ =
+      mulTensorAssocMatrix D₁ D₂ D₃ *
+        mulTensor M (mulTensor N P) i l := by
+  rw [mulTensor_assoc, mulTensorAssocMatrix, PEquiv.mul_toMatrix_toPEquiv,
+    PEquiv.toMatrix_toPEquiv_mul]
+  ext x y
+  simp
 
 /-- Word evaluation of the product tensor is a sum over the contracted middle
 configurations of Kronecker products of word evaluations.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -129,6 +129,48 @@ them.
     \cite[Theorem~4.14(iii)]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
+\begin{definition}[Canonical reassociation of three bond spaces]%
+    \label{def:mpdo_operator_product_associator}
+    \lean{MPOTensor.mulTensorAssocEquiv}
+    \lean{MPOTensor.mulTensorAssocMatrix}
+    \leanok
+    \uses{def:mpdo_operator_product}
+    For three bond spaces, let
+    \[
+        A_{D_1,D_2,D_3}:
+        \C^{D_1}\otimes(\C^{D_2}\otimes\C^{D_3})
+        \longrightarrow
+        (\C^{D_1}\otimes\C^{D_2})\otimes\C^{D_3}
+    \]
+    be the coordinate pullback induced by canonical reassociation, defined on
+    elementary tensors by
+    $A_{D_1,D_2,D_3}(x_1\otimes(x_2\otimes x_3))
+    =(x_1\otimes x_2)\otimes x_3$.
+\end{definition}
+
+\begin{theorem}[Associativity of the product tensor]%
+    \label{thm:mpdo_operator_product_associativity}
+    \lean{MPOTensor.mulTensor_assoc}
+    \lean{MPOTensor.mulTensor_mul_assocMatrix}
+    \leanok
+    \uses{def:mpdo_operator_product,
+        def:mpdo_operator_product_associator}
+    The letters of the two parenthesizations of a triple product are related
+    by the canonical bond reassociation.  Equivalently, for every pair of
+    physical indices $i,k$,
+    \[
+        \bigl((M\mathbin{\cdot}N)\mathbin{\cdot}P\bigr)^{ik}
+          A_{D_1,D_2,D_3}
+        =A_{D_1,D_2,D_3}
+          \bigl(M\mathbin{\cdot}(N\mathbin{\cdot}P)\bigr)^{ik}.
+    \]
+\end{theorem}
+\begin{proof}\leanok
+    Expand both product tensors.  Reassociation preserves every elementary
+    tensor factor, while exchanging the order of the two finite sums gives
+    the same contraction over the two intermediate physical indices.
+\end{proof}
+
 \begin{lemma}[Word evaluation of the product tensor]%
     \label{lem:mpdo_operator_product_eval_word}
     \lean{MPOTensor.evalWord_mulTensor}
@@ -380,9 +422,10 @@ isometries of the two ways of bracketing a triple product,
 $(M_\alpha M_\beta) M_\gamma$ and $M_\alpha (M_\beta M_\gamma)$
 \cite[lines~995--999]{Cirac2016MPDO_arXiv}. The source attributes the
 construction of that equation, and the classification of its solutions, to
-\cite{Bultinck2017Anyons}. The next definitions and theorems record the
-tensor-level content of the two bracketings separately. They do not yet assert
-the change of basis between the two resulting direct sums.
+\cite{Bultinck2017Anyons}. The next definitions and theorems first record the
+tensor-level content of the two bracketings and then compare the resulting
+full direct sums.  Restriction of that comparison to a fixed final label is a
+separate step.
 
 \begin{figure}[ht]
     \centering
@@ -391,8 +434,9 @@ the change of basis between the two resulting direct sums.
         $\varepsilon$, in the diagrammatic language of
         \cite[eq.~(Fmove)]{Bultinck2017Anyons}.  The solid fusion trees are
         the left- and right-bracketed maps constructed below.  The dashed
-        bridge denotes the remaining change of multiplicity basis; it is not
-        asserted by the present results.}
+        bridge denotes the fixed-final change of multiplicity basis.  The
+        results below compare the full direct sums, but do not yet extract
+        this fixed-final map or prove its invertibility.}
     \label{fig:mpdo_fixed_final_fusion_bracketings}
 \end{figure}
 
@@ -508,6 +552,67 @@ the change of basis between the two resulting direct sums.
     \]
     The fusion identity for $U_{\alpha,\delta}$ then gives the stated direct
     sum over $\varepsilon$.
+\end{proof}
+
+\begin{definition}[Full comparison of the two triple-fusion orders]%
+    \label{def:mpdo_triple_fusion_comparison}
+    \lean{MPOTensor.BNTFusionIsometryFamily.tripleFusionComparison}
+    \leanok
+    \uses{def:mpdo_left_fusion_isometry,
+        def:mpdo_right_fusion_isometry,
+        def:mpdo_operator_product_associator}
+    The canonical comparison from the right-associated full direct sum to the
+    left-associated full direct sum is
+    \[
+        C_{\alpha,\beta,\gamma}
+          =U^{\mathrm L}_{\alpha,\beta,\gamma}
+            A_{D_\alpha,D_\beta,D_\gamma}
+            (U^{\mathrm R}_{\alpha,\beta,\gamma})^\dagger.
+    \]
+    Both intermediate labels and the final label remain in the direct sums.
+    This definition does not select a fixed final label and makes no
+    invertibility assertion.  Its orientation is from the right-associated
+    sum to the left-associated sum; consequently it is adjoint-oriented with
+    respect to the $F$-matrix convention in equation (Fmove) of
+    \cite{Bultinck2017Anyons}.
+\end{definition}
+
+\begin{theorem}[The full triple-fusion comparison intertwines the unweighted
+        direct sums]%
+    \label{thm:mpdo_triple_fusion_comparison_intertwines}
+    \lean{MPOTensor.BNTFusionIsometryFamily.%
+        tripleFusionComparison_intertwines_of_lengthIndependent}
+    \leanok
+    \uses{def:mpdo_triple_fusion_comparison,
+        thm:mpdo_operator_product_associativity,
+        thm:mpdo_left_fusion_apply,
+        thm:mpdo_right_fusion_apply,
+        thm:mpdo_bnt_length_independent_zipper}
+    Suppose the positive trace-power coefficients are independent of the
+    positive chain length.  For every pair of physical indices $i,k$, let
+    \[
+        D^{\mathrm L}_{ik}
+          =\bigoplus_{\delta,\varepsilon}
+            1_{r_{\alpha,\beta}^{\delta}}\otimes
+            \bigl(1_{r_{\delta,\gamma}^{\varepsilon}}
+              \otimes M_\varepsilon^{ik}\bigr)
+    \]
+    and define $D^{\mathrm R}_{ik}$ by the right-associated multiplicities
+    $r_{\beta,\gamma}^{\delta}$ and
+    $r_{\alpha,\delta}^{\varepsilon}$.  Then
+    \[
+        D^{\mathrm L}_{ik}C_{\alpha,\beta,\gamma}
+          =C_{\alpha,\beta,\gamma}D^{\mathrm R}_{ik}.
+    \]
+    This is an identity on the full direct sums.  It neither extracts a
+    fixed-final $F$-transformation nor proves invertibility or the pentagon
+    identity.
+\end{theorem}
+\begin{proof}\leanok
+    Length independence makes every positive diagonal factor equal to the
+    identity.  Substitute the left and right triple-fusion identities into
+    the definition of $C_{\alpha,\beta,\gamma}$, cancel the two isometries,
+    and apply Theorem~\ref{thm:mpdo_operator_product_associativity}.
 \end{proof}
 
 \begin{definition}[Fixed-final multiplicity spaces]%

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -502,9 +502,24 @@ tensors'' section of the arXiv:1511.08090 source file
 This result has an explicit scope restriction: it assumes the special
 length-independent coefficient system discussed at lines~995--1010, rather
 than proving that every renormalization fixed point has such coefficients.
-It also neither constructs the comparison of the two triple-fusion orders nor
-proves its invertibility.  Thus the associativity constraint and the
-pentagon-like equation mentioned at lines~995--999 remain unformalized.
+For this specialization, the canonical bond reassociation and the two
+iterated fusion isometries now define the comparison of the full left- and
+right-associated direct sums.  The formalized letterwise identity states
+that this comparison intertwines the two unweighted direct sums.  The matrix
+is oriented from the right-associated sum to the left-associated sum, hence
+oppositely to the printed $F$-matrix convention in equation
+\texttt{Fmove}; it is not identified with that $F$-matrix.
+
+The formalization does not extract a comparison at a fixed final label.  That
+extraction uses the simultaneous inverse relation at line~269 of the
+arXiv:1511.08090 source,
+\[
+    B_d^+ B_{d'}=\delta_{d,d'}1,
+\]
+which separates all final-label blocks at once.  No such simultaneous
+final-label separation is presently derived from the BNT hypotheses.  Hence
+the fixed-final $F$-transformation, its invertibility, and the pentagon-like
+equation mentioned at lines~995--999 remain unformalized.
 
 To eliminate the source-theorem gap, the formalization should instead:
 \begin{enumerate}


### PR DESCRIPTION
## Summary

This change compares the two parenthesizations of triple MPO fusion before extracting a fixed final sector.

- It defines the canonical reassociation of the three bond factors and proves associativity of the product tensor under that reassociation.
- It defines the full left/right triple-fusion comparison matrix and proves that it intertwines the two full direct-sum block tensors when length independence makes every \(\chi\)-matrix the identity.
- It updates the MPO/RFP blueprint and the paper-gap record with the precise source scope and matrix orientation.

The result deliberately does not claim the fixed-final invertible multiplicity transformation printed as the paper's \(F\)-move. That extraction still requires simultaneous separation of the final BNT label; invertibility and the pentagon identity therefore remain open.

## Source correspondence

The reassociation calculation follows arXiv:1606.00608, lines 995–1010, together with the associativity construction in arXiv:1511.08090, lines 237–277. The formal comparison maps the right-associated full sum to the left-associated full sum, so its orientation is adjoint to the printed convention for \(F\); this is stated explicitly in the blueprint and gap note.

## Validation

- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `leanblueprint pdf`
- `git diff --check`
- independent mathematical, Lean, blueprint, and source-faithfulness reviews by two parallel agents

Advances #3776.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formalization in MPS/MPDO with documentation alignment; no changes to auth, runtime, or critical infrastructure.
> 
> **Overview**
> **Adds canonical bond reassociation and triple-fusion comparison** for MPO/BNT fusion before any fixed-final-sector extraction.
> 
> `OperatorProduct.lean` introduces `mulTensorAssocEquiv` / `mulTensorAssocMatrix` and proves `mulTensor_assoc` plus `mulTensor_mul_assocMatrix`, so left- and right-parenthesized triple product letters agree up to the associator matrix.
> 
> New module `BNTTripleFusionComparison.lean` defines `tripleFusionComparison` as \(C = U^L A (U^R)^\dagger\) and proves `tripleFusionComparison_intertwines_of_lengthIndependent`: when \(\chi\) factors are identities, the comparison intertwines the full unweighted block-diagonal direct sums letterwise (via existing left/right fusion apply lemmas and the new associator theorem).
> 
> The MPDO fusion blueprint chapter and `cpgsv17_blocked_chi_uniformity.tex` are updated to document this scope: full-sum comparison only, matrix orientation opposite to the printed **Fmove** convention, and **no** fixed-final \(F\)-transformation, invertibility, or pentagon identity yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a31a0c781d5c51b91022ac02e52f7be4c96c947b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->