### PR TITLE
feat(MPS/MPDO): rephase recurrent sector support positively

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -25,6 +25,7 @@ import TNLean.Algebra.HermitianHelpers
 import TNLean.Algebra.MatrixSpectralDecomp
 import TNLean.Algebra.MatrixAux
 import TNLean.Algebra.KroneckerFactorPositivity
+import TNLean.Algebra.ComplexPhasePositivity
 import TNLean.Algebra.DirectedWalkCoboundary
 import TNLean.Algebra.MatrixGramUnitary
 import TNLean.Algebra.FinSum

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -429,6 +429,7 @@ import TNLean.MPS.MPDO.SectorEtaOperator
 import TNLean.MPS.MPDO.SectorEtaPositivity
 import TNLean.MPS.MPDO.SALPhysicalSectorCyclicPositivity
 import TNLean.MPS.MPDO.SectorRecurrence
+import TNLean.MPS.MPDO.RecurrentSectorRephasing
 import TNLean.MPS.MPDO.FusionIsometries
 import TNLean.MPS.MPDO.OperatorProduct
 import TNLean.MPS.MPDO.AlgebraStructure

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -391,6 +391,7 @@ import TNLean.MPS.MPDO.RFPSubspinMaps
 import TNLean.MPS.MPDO.HayashiSectorComparison
 import TNLean.MPS.MPDO.SectorFactorization
 import TNLean.MPS.MPDO.PhysicalSectorFactorization
+import TNLean.MPS.MPDO.PhysicalSectorRephasing
 import TNLean.MPS.MPDO.InverseMapPhysicalSectorFactorization
 import TNLean.MPS.MPDO.NeighboringPreparation
 import TNLean.MPS.MPDO.PhysicalSectorSubspinMaps

--- a/TNLean/Algebra/ComplexPhasePositivity.lean
+++ b/TNLean/Algebra/ComplexPhasePositivity.lean
@@ -1,0 +1,73 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Analysis.Complex.Circle
+import TNLean.Algebra.KroneckerFactorPositivity
+
+/-!
+# Unit phases of positive matrix rescalings
+
+Every nonzero complex number has a multiplicative unit-modulus part. Replacing
+a scalar that makes a matrix positive semidefinite by this unit phase preserves
+positive semidefiniteness. For a nonzero matrix, the unit phase with this
+property is unique.
+-/
+
+open scoped ComplexOrder
+
+noncomputable section
+
+namespace Complex
+
+/-- The unit-modulus part of a nonzero complex number, as a multiplicative map. -/
+def unitsPhase : Units ℂ →* Circle where
+  toFun z := ⟨(z : ℂ) / ‖(z : ℂ)‖, by
+    change (z : ℂ) / ‖(z : ℂ)‖ ∈ Metric.sphere (0 : ℂ) 1
+    rw [mem_sphere_zero_iff_norm, norm_div, norm_real, Real.norm_eq_abs,
+      abs_norm, div_self]
+    exact norm_ne_zero_iff.mpr (Units.ne_zero z)⟩
+  map_one' := by
+    apply Circle.ext
+    simp
+  map_mul' z w := by
+    apply Circle.ext
+    simp [div_mul_div_comm]
+
+/-- The unit-modulus part of a specified nonzero complex number. -/
+def phase (c : ℂ) (hc : c ≠ 0) : Circle :=
+  unitsPhase (Units.mk0 c hc)
+
+/-- Replacing a nonzero rescaling scalar by its unit-modulus part preserves
+positive semidefiniteness. -/
+theorem phase_smul_posSemidef
+    {n : Type*} [Finite n] {M : Matrix n n ℂ} {c : ℂ} (hc : c ≠ 0)
+    (h : (c • M).PosSemidef) : (((phase c hc : Circle) : ℂ) • M).PosSemidef := by
+  have habs_pos : 0 < ‖c‖ := norm_pos_iff.mpr hc
+  have hscaled : ((‖c‖⁻¹ : ℝ) • (c • M)).PosSemidef :=
+    h.smul (inv_nonneg.mpr habs_pos.le)
+  have hphase : ((phase c hc : Circle) : ℂ) = (‖c‖⁻¹ : ℝ) • c := by
+    simp [phase, unitsPhase, Complex.real_smul, div_eq_mul_inv, mul_comm]
+  rw [hphase, IsScalarTower.smul_assoc]
+  exact hscaled
+
+end Complex
+
+namespace Circle
+
+/-- A nonzero complex matrix admits at most one unit-modulus phase that makes
+it positive semidefinite. -/
+theorem eq_of_smul_posSemidef
+    {n : Type*} [Finite n] {M : Matrix n n ℂ} (hM : M ≠ 0) {u v : Circle}
+    (hu : ((u : ℂ) • M).PosSemidef)
+    (hv : ((v : ℂ) • M).PosSemidef) : u = v := by
+  obtain ⟨t, ht, huv⟩ := Matrix.exists_pos_real_smul_eq_of_smul_posSemidef
+    hM hu hv (Circle.coe_ne_zero u) (Circle.coe_ne_zero v)
+  have ht_one : t = 1 := by
+    have hnorm := congrArg norm huv
+    simpa [norm_mul, abs_of_pos ht] using hnorm.symm
+  apply Circle.ext
+  simpa [ht_one] using huv
+
+end Circle

--- a/TNLean/MPS/MPDO/PhysicalSectorRephasing.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorRephasing.lean
@@ -1,0 +1,76 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Analysis.Complex.Circle
+import TNLean.Algebra.KroneckerFactorPositivity
+import TNLean.MPS.MPDO.PhysicalSectorFactorization
+
+/-!
+# Rephasing a physical-sector factorization
+
+Multiplying the left tensor in sector `k` by a unit complex number `z_k` and
+the right tensor by `z_k⁻¹` leaves the physical-slice factorization
+unchanged. The neighboring operator from sector `k` to sector `h` is then
+multiplied by `z_k⁻¹ z_h`.
+
+This is the sector rephasing used in the positive-choice argument for the
+neighboring operators in Appendix C.2 of arXiv:1606.00608.
+
+## References
+
+- [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, lines 1441--1450
+-/
+
+open scoped Matrix
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D}
+
+/-- Rephase the left and right tensors of each physical sector by reciprocal
+unit complex scalars. The reciprocal scalars preserve every same-sector
+Kronecker factorization.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1441--1450. -/
+noncomputable def rephase (F : PhysicalSectorFactorization K)
+    (z : Fin F.sectorCount → Circle) : PhysicalSectorFactorization K where
+  sectorCount := F.sectorCount
+  leftDim := F.leftDim
+  rightDim := F.rightDim
+  leftDim_pos := F.leftDim_pos
+  rightDim_pos := F.rightDim_pos
+  sectorEquiv := F.sectorEquiv
+  physicalIsometry := F.physicalIsometry
+  physicalIsometry_isometry := F.physicalIsometry_isometry
+  leftTensor := fun k beta ↦ (z k : ℂ) • F.leftTensor k beta
+  rightTensor := fun k alpha ↦ ((z k : ℂ)⁻¹) • F.rightTensor k alpha
+  factorization := by
+    intro beta alpha
+    rw [F.factorization beta alpha]
+    congr 1
+    funext k
+    exact (Matrix.smul_kronecker_smul_inv_eq
+      (F.leftTensor k beta) (F.rightTensor k alpha) (Circle.coe_ne_zero (z k))).symm
+
+/-- Rephasing the sector tensors multiplies the neighboring operator from
+sector `k` to sector `h` by the vertex-phase ratio `z_k⁻¹ z_h`.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1441--1450. -/
+theorem rephase_neighboringOperator (F : PhysicalSectorFactorization K)
+    (z : Fin F.sectorCount → Circle) (k h : Fin F.sectorCount) :
+    (F.rephase z).neighboringOperator k h =
+      ((((z k)⁻¹ * z h : Circle) : ℂ) • F.neighboringOperator k h) := by
+  ext x y
+  simp only [neighboringOperator_apply, Matrix.smul_apply, smul_eq_mul]
+  simp_rw [Finset.mul_sum]
+  apply Finset.sum_congr rfl
+  intro a _
+  change (((z k : ℂ)⁻¹) * F.rightTensor k a x.1 y.1) *
+      ((z h : ℂ) * F.leftTensor h a x.2 y.2) = _
+  simp only [Circle.coe_mul, Circle.coe_inv]
+  ring
+
+end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/RecurrentSectorRephasing.lean
+++ b/TNLean/MPS/MPDO/RecurrentSectorRephasing.lean
@@ -1,0 +1,202 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.ComplexPhasePositivity
+import TNLean.MPS.MPDO.InverseMapPhysicalSectorFactorization
+import TNLean.MPS.MPDO.PhysicalSectorRephasing
+import TNLean.MPS.MPDO.SectorRecurrence
+
+/-!
+# Positive sector rephasing under recurrent support
+
+Suppose every cyclic tensor product of a neighboring-operator family is
+positive semidefinite and every nonzero edge of its support graph lies on a
+directed cycle. Each nonzero edge then has a unique unit phase which makes its
+neighboring operator positive semidefinite. The product of these phases around
+every closed directed walk is one, so the recurrent-walk coboundary theorem
+expresses them as ratios of vertex phases.
+
+Rephasing the left and right sector tensors by these vertex phases produces a
+physical-sector factorization whose individual neighboring operators are all
+positive semidefinite.
+
+The recurrence assumption is not present in Lemma C.4 of arXiv:1606.00608.
+The paper-gap note `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`
+records both this restriction and a counterexample showing that cyclic
+positivity alone is insufficient.
+
+## References
+
+- [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, lines 1441--1450
+-/
+
+open scoped Matrix ComplexOrder BigOperators
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+variable {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+
+private theorem exists_circle_smul_posSemidef_of_sectorEdge
+    (hη : EtaStructure ρ) (eta : etaOperators hη)
+    (hcyc : ∀ {N : ℕ} [NeZero N] (k : Fin N → Fin hη.m),
+      (cyclicEtaTensorProduct hη eta k).PosSemidef)
+    (hrec : IsRecurrentSupport eta) {k h : Fin hη.m}
+    (hkh : IsSectorEdge eta k h) :
+    ∃ u : Circle, (((u : Circle) : ℂ) • eta k h).PosSemidef := by
+  obtain ⟨w⟩ := (sectorReaches_iff_directedWalkReaches eta h k).mp (hrec k h hkh)
+  let q := TNLean.Algebra.DirectedWalk.closedConsVertices (IsSectorEdge eta) hkh w
+  haveI : NeZero (TNLean.Algebra.DirectedWalk.edgeCount (IsSectorEdge eta) w + 1) :=
+    ⟨by omega⟩
+  have hne : ∀ n, eta (q n) (q (n + 1)) ≠ 0 := by
+    intro n
+    exact TNLean.Algebra.DirectedWalk.closedConsVertices_edge
+      (IsSectorEdge eta) hkh w n
+  obtain ⟨c, hc, -, hcpos⟩ :=
+    exists_pi_smul_posSemidef_of_cyclicEtaTensorProduct_posSemidef
+      hη eta q (hcyc q) hne
+  refine ⟨Complex.phase (c 0) (hc 0), ?_⟩
+  have hpos := Complex.phase_smul_posSemidef (hc 0) (hcpos 0)
+  have hqzero : q 0 = k :=
+    TNLean.Algebra.DirectedWalk.closedConsVertices_zero (IsSectorEdge eta) hkh w
+  have hqone : q (0 + 1) = h :=
+    TNLean.Algebra.DirectedWalk.closedConsVertices_zero_add_one
+      (IsSectorEdge eta) hkh w
+  rw [hqzero, hqone] at hpos
+  exact hpos
+
+/-- **Coherent positive vertex rephasing under recurrent support.** If every
+cyclic tensor product of a neighboring-operator family is positive
+semidefinite and every nonzero support edge lies on a directed cycle, then
+there are unit vertex phases whose ratios make every neighboring operator
+positive semidefinite.
+
+**Scope restriction (recurrent nonzero support):** Recurrence is not a
+hypothesis of arXiv:1606.00608, Appendix C.2, Lemma C.4, lines 1406--1450.
+This additional hypothesis and its possible elimination are recorded in
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`. -/
+theorem exists_vertexPhase_smul_posSemidef
+    (hη : EtaStructure ρ) (eta : etaOperators hη)
+    (hcyc : ∀ {N : ℕ} [NeZero N] (k : Fin N → Fin hη.m),
+      (cyclicEtaTensorProduct hη eta k).PosSemidef)
+    (hrec : IsRecurrentSupport eta) :
+    ∃ z : Fin hη.m → Circle, ∀ k h,
+      (((((z k)⁻¹ * z h : Circle) : ℂ) • eta k h).PosSemidef) := by
+  classical
+  have hedge : ∀ {k h : Fin hη.m}, IsSectorEdge eta k h →
+      ∃ u : Circle, ((u : ℂ) • eta k h).PosSemidef := by
+    intro k h hkh
+    exact exists_circle_smul_posSemidef_of_sectorEdge hη eta hcyc hrec hkh
+  let κ : Fin hη.m → Fin hη.m → Circle := fun k h ↦
+    if hkh : IsSectorEdge eta k h then Classical.choose (hedge hkh) else 1
+  have hκpos : ∀ k h, (((κ k h : Circle) : ℂ) • eta k h).PosSemidef := by
+    intro k h
+    by_cases hkh : IsSectorEdge eta k h
+    · rw [show κ k h = Classical.choose (hedge hkh) by simp [κ, hkh]]
+      exact Classical.choose_spec (hedge hkh)
+    · have heta : eta k h = 0 := not_ne_iff.mp hkh
+      simpa [heta] using
+        (Matrix.PosSemidef.zero :
+          (0 : Matrix (Fin (hη.dR k) × Fin (hη.dL h))
+            (Fin (hη.dR k) × Fin (hη.dL h)) ℂ).PosSemidef)
+  have hclosed : ∀ (a : Fin hη.m)
+      (w : TNLean.Algebra.DirectedWalk (IsSectorEdge eta) a a),
+      TNLean.Algebra.DirectedWalk.weight (IsSectorEdge eta) κ w = 1 := by
+    intro a w
+    cases w with
+    | nil => rfl
+    | @cons a b _ hab w =>
+        let q := TNLean.Algebra.DirectedWalk.closedConsVertices
+          (IsSectorEdge eta) hab w
+        haveI : NeZero (TNLean.Algebra.DirectedWalk.edgeCount (IsSectorEdge eta) w + 1) :=
+          ⟨by omega⟩
+        have hne : ∀ n, eta (q n) (q (n + 1)) ≠ 0 := by
+          intro n
+          exact TNLean.Algebra.DirectedWalk.closedConsVertices_edge
+            (IsSectorEdge eta) hab w n
+        obtain ⟨c, hc, hcprod, hcpos⟩ :=
+          exists_pi_smul_posSemidef_of_cyclicEtaTensorProduct_posSemidef
+            hη eta q (hcyc q) hne
+        have hphase : ∀ n, Complex.phase (c n) (hc n) = κ (q n) (q (n + 1)) := by
+          intro n
+          exact Circle.eq_of_smul_posSemidef (hne n)
+            (Complex.phase_smul_posSemidef (hc n) (hcpos n))
+            (hκpos (q n) (q (n + 1)))
+        have hcUnits : ∏ n, Units.mk0 (c n) (hc n) = (1 : Units ℂ) := by
+          apply Units.ext
+          simpa using hcprod
+        have hphaseProd : ∏ n, Complex.phase (c n) (hc n) = (1 : Circle) := by
+          calc
+            ∏ n, Complex.phase (c n) (hc n) =
+                Complex.unitsPhase (∏ n, Units.mk0 (c n) (hc n)) := by
+              exact (map_prod Complex.unitsPhase
+                (fun n ↦ Units.mk0 (c n) (hc n)) Finset.univ).symm
+            _ = Complex.unitsPhase 1 := congrArg Complex.unitsPhase hcUnits
+            _ = 1 := map_one Complex.unitsPhase
+        rw [TNLean.Algebra.DirectedWalk.weight_closedCons_eq_fin_prod]
+        calc
+          ∏ n, κ (q n) (q (n + 1)) = ∏ n, Complex.phase (c n) (hc n) := by
+            apply Finset.prod_congr rfl
+            intro n _
+            exact (hphase n).symm
+          _ = 1 := hphaseProd
+  have hreturn :
+      ∀ {k h : Fin hη.m}, IsSectorEdge eta k h →
+        TNLean.Algebra.DirectedWalk.Reaches (IsSectorEdge eta) h k :=
+    (isRecurrentSupport_iff_directedWalkReturns eta).mp hrec
+  obtain ⟨z, hz⟩ := TNLean.Algebra.DirectedWalk.exists_vertex_of_closedWalk_weight_eq_one
+    (IsSectorEdge eta) κ hreturn hclosed
+  refine ⟨z, fun k h ↦ ?_⟩
+  by_cases hkh : IsSectorEdge eta k h
+  · rw [← hz hkh]
+    exact hκpos k h
+  · have heta : eta k h = 0 := not_ne_iff.mp hkh
+    simpa [heta] using
+      (Matrix.PosSemidef.zero :
+        (0 : Matrix (Fin (hη.dR k) × Fin (hη.dL h))
+          (Fin (hη.dR k) × Fin (hη.dL h)) ℂ).PosSemidef)
+
+/-- **Positive inverse-map sector factorization under recurrent support.**
+The inverse-map sector tensors can be rephased so that all neighboring
+operators are positive semidefinite, provided their nonzero support is
+recurrent.
+
+**Scope restriction (recurrent nonzero support):** Recurrence is not a
+hypothesis of arXiv:1606.00608, Appendix C.2, Lemma C.4, lines 1406--1450.
+This additional hypothesis and its possible elimination are recorded in
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`. -/
+theorem exists_rephased_inverseMapPhysicalSectorFactorization
+    (K : MPOTensor d D) (hK : K.IsInjective)
+    (R : Matrix (Fin D) (Fin D) ℂ)
+    (hρ : IsThreeSiteClosure K R ρ) (hη : EtaStructure ρ)
+    {α₁ β₃ : Fin D} (hm : R β₃ α₁ ≠ 0) (hM : IsMPDO K)
+    (hrec : IsRecurrentSupport (sectorEta K hK hη R α₁ β₃)) :
+    ∃ F : PhysicalSectorFactorization K,
+      ∀ k h, (F.neighboringOperator k h).PosSemidef := by
+  let F := inverseMapPhysicalSectorFactorization K hK R hρ hη α₁ β₃ hm
+  have hcyc : ∀ {N : ℕ} [NeZero N] (k : Fin N → Fin hη.m),
+      (cyclicEtaTensorProduct hη (sectorEta K hK hη R α₁ β₃) k).PosSemidef := by
+    intro N _ k
+    have hpos := cyclicEtaTensorProduct_posSemidef K hη
+      (fun q ↦ sectorTensorL K hK hη R α₁ β₃ q)
+      (fun q ↦ sectorTensorR K hK hη β₃ q)
+      (fun β α ↦ physicalSlice_sector_factorization K hK R ρ hρ hη hm β α)
+      (hM N) k
+    have heta : sectorEta K hK hη R α₁ β₃ =
+        etaOfSectorTensors hη
+          (fun q ↦ sectorTensorL K hK hη R α₁ β₃ q)
+          (fun q ↦ sectorTensorR K hK hη β₃ q) := by
+      funext q p
+      exact sectorEta_eq_etaOfSectorTensors K hK hη R α₁ β₃ q p
+    rw [heta]
+    exact hpos
+  obtain ⟨z, hz⟩ := exists_vertexPhase_smul_posSemidef hη _ hcyc hrec
+  refine ⟨F.rephase z, fun k h ↦ ?_⟩
+  rw [F.rephase_neighboringOperator]
+  rw [inverseMapPhysicalSectorFactorization_neighboringOperator_eq_sectorEta]
+  exact hz k h
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/SectorRecurrence.lean
+++ b/TNLean/MPS/MPDO/SectorRecurrence.lean
@@ -32,10 +32,11 @@ obtained from the `N`-ary Kronecker rescaling
 the cyclic tensor product after reindexing along the horizontal bond fiber.
 
 The recurrence declarations and the phase-uniqueness theorem
-`Matrix.exists_pos_real_smul_eq_of_smul_posSemidef` are preparatory. No proved
-theorem in this module yet derives recurrence from injectivity or combines
-the choices from different cycles into one vertex-indexed rescaling. In
-particular, the fixed-cycle theorem does not use recurrence.
+`Matrix.exists_pos_real_smul_eq_of_smul_posSemidef` prepare the coherent
+rephasing argument in `TNLean.MPS.MPDO.RecurrentSectorRephasing`. That later
+module combines the choices from different cycles under the recurrence
+hypothesis. No proved theorem derives recurrence from injectivity. In
+particular, the fixed-cycle theorem below does not use recurrence.
 
 ## Main declarations
 
@@ -61,10 +62,10 @@ particular, the fixed-cycle theorem does not use recurrence.
 
 ## What remains
 
-Deriving `IsRecurrentSupport` unconditionally from injectivity of `𝒦`, and
-propagating the per-cycle phase choice above into a single vertex-indexed
-rescaling coherent across the whole recurrent component, are recorded as
-open steps in the paper-gap note.
+Deriving `IsRecurrentSupport` unconditionally from injectivity of `𝒦` remains
+open and is recorded in the paper-gap note. Conditional on recurrence,
+`TNLean.MPS.MPDO.RecurrentSectorRephasing` propagates the per-cycle choices
+into a single vertex-indexed rephasing.
 
 ## References
 
@@ -235,10 +236,9 @@ the cycle have a compatible choice of phases: scalars, all nonzero, with
 product `1`, rescaling every consecutive `η_{k_n,k_{n+1}}` to be positive
 semidefinite.
 
-This theorem concerns one fixed cycle; propagating the choice into a single
-vertex-indexed rescaling coherent across a whole recurrent component of the
-sector support graph is recorded as open in
-`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+This theorem concerns one fixed cycle. Conditional on recurrence,
+`MPOTensor.exists_vertexPhase_smul_posSemidef` propagates these choices into
+a single vertex-indexed rephasing over the whole support graph.
 
 This is a supporting lemma for arXiv:1606.00608, Appendix C.2,
 lines 1446--1450, not a separately stated result of the paper. -/

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -823,6 +823,26 @@ strong subadditivity for a normalized three-site reduced state.
     this definition; it is a separate hypothesis in Proposition~C.7.
 \end{definition}
 
+\begin{definition}[Vertex rephasing of the sector tensors]%
+    \label{def:mpdo_physical_sector_rephasing}
+    \lean{MPOTensor.PhysicalSectorFactorization.rephase}
+    \lean{MPOTensor.PhysicalSectorFactorization.rephase_neighboringOperator}
+    \leanok
+    \uses{def:mpdo_physical_sector_factorization,
+      def:mpdo_minimal_neighboring_operator}
+    Let $z_k\in\mathbb C$ satisfy $|z_k|=1$ for every sector. Replacing
+    \[
+        (l_k)_a\longmapsto z_k(l_k)_a,
+        \qquad
+        (r_k)_a\longmapsto z_k^{-1}(r_k)_a
+    \]
+    leaves every physical-slice factorization unchanged and transforms the
+    neighboring operators by
+    \[
+        \eta_{k,h}\longmapsto z_k^{-1}z_h\,\eta_{k,h}.
+    \]
+\end{definition}
+
 \begin{definition}[Inverse-map physical-sector factorization]
     \label{def:mpdo_inverse_map_physical_sector_factorization}
     \lean{MPOTensor.inverseMapPhysicalSectorFactorization}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -2384,11 +2384,18 @@ strong subadditivity for a normalized three-site reduced state.
 
 \begin{theorem}[Uniqueness of the positive rescaling phase]%
     \label{thm:positive_rescaling_phase_unique}
+    \lean{Complex.unitsPhase}
+    \lean{Complex.phase}
+    \lean{Complex.phase_smul_posSemidef}
+    \lean{Circle.eq_of_smul_posSemidef}
     \lean{Matrix.exists_pos_real_smul_eq_of_smul_posSemidef}
     \leanok
     \uses{lem:possemidef_and_neg_possemidef}
     Let $M\ne0$. If $c_1,c_2\ne0$ and both $c_1M$ and $c_2M$ are positive
     semidefinite, then $c_1=t c_2$ for some positive real number $t$.
+    In particular, every nonzero scalar $c$ has a unit-modulus part
+    $u=c/|c|$, positivity of $cM$ implies positivity of $uM$, and there is
+    at most one such unit scalar when $M\ne0$.
 \end{theorem}
 
 \begin{proof}
@@ -2398,6 +2405,9 @@ strong subadditivity for a normalized three-site reduced state.
     $c_2\overline{c_1}=c_1\overline{c_2}$, so $c_1/c_2$ is real. It cannot be
     negative: otherwise $c_1M$ and its negative would both be positive
     semidefinite, forcing $c_1M=0$. Thus the quotient is positive.
+    Multiplication by $|c|^{-1}>0$ replaces $c$ by its unit-modulus part
+    without changing positivity. Two admissible unit scalars differ by a
+    positive real number of modulus one, and are therefore equal.
 \end{proof}
 
 \begin{theorem}[Positive rescaling of a finite Kronecker product]%
@@ -2720,6 +2730,60 @@ strong subadditivity for a normalized three-site reduced state.
     Theorem~\ref{thm:kronecker_factor_positive_rescaling}.
 \end{proof}
 
+\begin{theorem}[Coherent positive rephasing under recurrent support]%
+    \label{thm:mpdo_eta_coherent_positive_choice_recurrent}
+    \lean{MPOTensor.exists_vertexPhase_smul_posSemidef}
+    \lean{MPOTensor.exists_rephased_inverseMapPhysicalSectorFactorization}
+    \leanok
+    \uses{def:mpdo_physical_sector_rephasing,
+        def:mpdo_eta_recurrent_support,
+        lem:mpdo_eta_reachability_equivalence,
+        lem:directed_closed_walk_finite_cycle,
+        thm:positive_rescaling_phase_unique,
+        thm:mpdo_eta_cycle_positive_rescaling,
+        thm:directed_cycle_coboundary}
+    Let $(\eta_{k,h})$ be a neighboring-operator family for which every
+    nonempty cyclic tensor product is positive semidefinite. Suppose, in
+    addition, that every nonzero edge $k\to h$ admits a directed return path
+    from $h$ to $k$. Then there are unit complex numbers $z_k$ such that
+    \[
+        z_k^{-1}z_h\,\eta_{k,h}\geq0
+        \qquad\text{for all }k,h.
+    \]
+    Consequently, if the neighboring operators arise from the inverse-map
+    physical-sector factorization of an injective MPDO and its nonzero
+    support is recurrent, the sector tensors admit a reciprocal rephasing
+    for which all neighboring operators are positive semidefinite.
+
+    This is a scope-restricted result. Recurrence is not a hypothesis of
+    Lemma~C.4 in
+    \cite[Appendix~C.2, lines~1406--1450]{Cirac2016MPDO_arXiv}; its derivation
+    from the source hypotheses remains open and is recorded in
+    \path{docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:mpdo_eta_reachability_equivalence,
+        lem:directed_closed_walk_finite_cycle,
+        thm:positive_rescaling_phase_unique,
+        thm:mpdo_eta_cycle_positive_rescaling,
+        thm:directed_cycle_coboundary,
+        def:mpdo_physical_sector_rephasing}
+    For a nonzero edge, choose a directed return path and close it with the
+    edge. Positive rescaling of the corresponding cyclic tensor product
+    supplies a scalar that makes the edge operator positive; retain only its
+    unit-modulus part. On any closed directed walk, positive rescaling of the
+    associated cyclic tensor product gives phases whose product is one.
+    Uniqueness of the unit phase identifies them edge by edge with the chosen
+    phases. Hence the chosen edge phases have product one around every closed
+    walk. The closed-walk criterion gives
+    $\kappa_{k,h}=z_k^{-1}z_h$ on every nonzero edge. Zero edge operators are
+    already positive semidefinite. Finally, reciprocal rephasing of the left
+    and right sector tensors multiplies each neighboring operator by this
+    phase and preserves the physical-slice factorization.
+\end{proof}
+
 \begin{theorem}[Coherent positive choice of the neighboring operators]%
     \label{thm:mpdo_eta_coherent_positive_choice}
     \notready
@@ -2742,18 +2806,18 @@ strong subadditivity for a normalized three-site reduced state.
         thm:mpdo_eta_cycle_positive_rescaling,
         thm:mpdo_sector_adapted_decomposition,
         thm:positive_rescaling_phase_unique,
-        thm:directed_cycle_coboundary}
+        thm:directed_cycle_coboundary,
+        thm:mpdo_eta_coherent_positive_choice_recurrent}
     The projected chain identity makes every cyclic Kronecker product of the
-    neighboring operators positive semidefinite. The finite-factor rescaling
-    theorem chooses positive phases on any one nonzero cycle. Two obligations
-    remain. First, recurrence of the nonzero inverse-map support must be
-    derived from the actual injective normal-tensor hypotheses, without using
-    the later primitivity conclusion. Second, phase uniqueness and trivial
-    cycle holonomy must be established for a single edge-phase family.
-    Theorem~\ref{thm:directed_cycle_coboundary} then integrates those edge
-    phases to a vertex-indexed rephasing of the tensors $l_k,r_k$. Such a
-    coboundary rephasing preserves every cyclic product, and hence the
-    all-length decomposition. This is the coherent-choice step asserted at
+    neighboring operators positive semidefinite.
+    Theorem~\ref{thm:mpdo_eta_coherent_positive_choice_recurrent} completes
+    the phase-uniqueness, trivial-holonomy, and vertex-rephasing argument once
+    recurrence is known. The remaining obligation is therefore to normalize
+    the tensors in zero-weight Hayashi sectors so that they create no support
+    edges, and to derive recurrence of the resulting inverse-map support from
+    the actual injective normal-tensor hypotheses, without using the later
+    primitivity conclusion. This is the last missing part of the
+    coherent-choice step asserted at
     \cite[Appendix~C.2, lines~1446--1450]{Cirac2016MPDO_arXiv}; it is not a
     consequence of positivity of the cyclic products alone.
 \end{proof}

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -336,6 +336,39 @@ be recorded as scope-restricted.  The later primitivity argument cannot be
 used for this purpose without circularity, since the source defines the
 nonnegative trace matrix only after choosing positive neighboring operators.
 
+For the present formal notion of a Hayashi decomposition, recurrence is false
+even for the concrete inverse-map neighboring operators.  The reason is that
+the structure permits zero sector weights.  Consider the scalar-bond tensor
+on a two-dimensional physical space given by
+\[
+  K^{00}=1,\qquad K^{01}=K^{10}=K^{11}=0.
+\]
+It is injective and generates the rank-one projector onto the constant-zero
+word at every length.  Decompose the middle physical space into its two
+one-dimensional coordinate sectors, with weights $p_0=1$ and $p_1=0$, and
+choose the normalized left and right states in both sectors to be supported
+on the zero coordinate.  For the scalar tail $R=1$, the inverse-map sector
+tensors satisfy
+\[
+  r_0=r_1=1,\qquad l_0=1,\qquad l_1=0,
+  \qquad \eta_{k,h}=p_h.
+\]
+Thus $1\to0$ is a nonzero support edge, whereas no edge enters sector $1$.
+This edge is not recurrent.  Hence no theorem deriving recurrence may
+quantify over an arbitrary decomposition satisfying only $p_k\geq0$.
+
+Zero-weight summands cannot simply be deleted from the present decomposition,
+because its sector equivalence must still cover the whole middle Hilbert
+space.  There is, however, a source-faithful normalization which preserves
+that ambient space.  The left tensor of a zero-weight sector already vanishes
+by definition, so replacing its right tensor by zero leaves the one-site
+factorization unchanged.  Every neighboring operator incident to an inactive
+sector then vanishes, while the active--active operators are unchanged.  On
+the active support, one may seek to prove recurrence from injectivity by
+closing any nonzero two-sector product with a third sector, using
+nondegeneracy of the matrix trace pairing.  Formalizing this inactive-sector
+normalization and the resulting recurrence theorem remains open.
+
 \subsection{Recurrence of the sector support graph: definitions and the
 per-cycle rescaling}
 
@@ -436,7 +469,7 @@ specific argument tied to the inverse-map construction of the sector
 tensors --- rather than through this graph-theoretic argument alone --- is
 the open question left by this note.  No such argument has been identified.
 
-\subsection{An elimination plan for the coherent vertex-rephasing step}
+\subsection{Coherent vertex rephasing under recurrence}
 
 Granting recurrence, propagating the per-cycle phase choice above into a
 single vertex-indexed rescaling requires a coboundary argument, for which
@@ -467,14 +500,25 @@ The proof chooses one representative of each reachability component and
 defines the vertex weight by multiplication along a path from that
 representative; a common return path proves independence of the chosen path.
 
-The MPDO-specific bridge to this theorem remains open.  One must choose a
-single unit-modulus rescaling scalar for every nonzero neighboring operator,
-use the fixed-cycle rescaling and phase-uniqueness theorems to prove that this
-chosen family has product one around every closed nonzero sector walk, and
-translate recurrence expressed by \leanid{MPOTensor.SectorReaches} into the
-explicit finite walks used by the coboundary theorem.  These statements are
-expected consequences of the existing per-cycle results, but they have not
-yet been assembled for the dependent sector bond spaces.
+The MPDO-specific bridge is now formalized under the recurrence hypothesis.
+For every nonzero neighboring operator, a directed return path closes the
+edge into a nonzero cycle.  Positive rescaling of that cyclic tensor product
+therefore supplies a unit phase that makes the edge operator positive
+semidefinite.  Positive rescaling of an arbitrary closed walk, together with
+uniqueness of the unit phase, shows that these chosen edge phases have product
+one around the walk.  The coboundary theorem then gives unit vertex phases
+$z_k$ with edge phase $z_k^{-1}z_h$.  The declarations
+\leanid{MPOTensor.exists_vertexPhase_smul_posSemidef} and
+\leanid{MPOTensor.exists_rephased_inverseMapPhysicalSectorFactorization}
+carry out this argument, including the dependent sector bond spaces and the
+reciprocal rephasing of the physical-sector tensors.
+
+This result is explicitly a scope restriction: recurrence is an additional
+hypothesis not present in Lemma~C.4.  The remaining elimination problem is to
+normalize the tensors in zero-weight Hayashi sectors so that they create no
+support edges, and derive recurrence for the resulting inverse-map neighboring
+operators from the source's injectivity and normality assumptions, without
+appealing to the later primitivity conclusion.
 
 The canonical family
 \leanid{MPOTensor.ExplicitEtaOperators.ofHayashiMarkov} does not supply this
@@ -555,18 +599,16 @@ This note records an open gap for the SAL-to-positive-bond construction of
 \leanid{MPOTensor.EtaLocalStructureData}. The positivity half of the projected
 chain identity is now formalized unconditionally, and the pairwise
 positive-choice construction is formalized under the symmetric-support scope
-restriction described above.  The sector support graph, its recurrence, and the
-per-cycle coherent positive rescaling are now formalized unconditionally
-(recurrence itself is a hypothesis, not yet derived).  Two obligations
-remain open: deriving recurrence from injectivity of $\mathcal K$
+restriction described above.  The sector support graph, the per-cycle
+positive rescaling, and the coherent vertex-rephasing theorem are now
+formalized.  In the last theorem recurrence is a hypothesis, not a conclusion.
+The remaining obligation for the source statement is to deactivate the
+zero-weight Hayashi sectors and then derive recurrence from injectivity of
+$\mathcal K$
 (\S~``Why recurrence is not a direct consequence of the source's own
-argument'' above records why the source's own two-projector argument does
-not by itself supply it), and propagating the per-cycle phase choice into a
-single vertex-indexed rescaling coherent across a whole recurrent component
-(\S~``An elimination plan for the coherent vertex-rephasing step'' above
-records an elimination plan using the uniqueness of the rescaling phase).
-The primitivity of $T_{k,h}$ also remains open, and cannot be used to
-derive recurrence without circularity.
+argument'' above records why the source's two-projector argument does not by
+itself supply it).  The primitivity of $T_{k,h}$ also remains open and cannot
+be used to derive recurrence without circularity.
 
 For the conditional bond construction, all translates commute pairwise at
 every length $N\geq2$.  The finite-chain MPO is the ordered product of those
@@ -575,8 +617,10 @@ coordinates.  If the neighboring operators are positive semidefinite, these
 results provide the positive commuting bond and its exact realization with
 scalar one, and they determine the eta-local structure data. The raw
 physical-sector factorization already follows for an injective tensor
-satisfying SAL. The remaining obligation in this implication is to choose the
-inverse-map neighboring operators coherently positive.
+satisfying SAL. The coherent positive choice follows once recurrence of the
+inverse-map support is known; normalizing the inactive sectors and deriving
+recurrence for the resulting support from the source hypotheses is the
+remaining obligation in this implication.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

This proves the coherent positive rephasing theorem under recurrence of the nonzero neighboring-operator support.

For a neighboring-operator family whose every nonempty cyclic tensor product is positive semidefinite, recurrence provides a closed cycle through each nonzero edge. Positive rescaling on that cycle determines a unit phase for the edge. Uniqueness of the unit phase shows that the product of the chosen phases is one around every closed directed walk. The closed-walk coboundary theorem from #3823 then expresses the edge phases as ratios `z_k⁻¹ z_h` of vertex phases.

Reciprocal rephasing of the left and right physical-sector tensors preserves the one-site factorization and makes every neighboring operator positive semidefinite.

## Main declarations

- `Complex.unitsPhase`, `Complex.phase`, and `Complex.phase_smul_posSemidef`
- `Circle.eq_of_smul_posSemidef`
- `MPOTensor.PhysicalSectorFactorization.rephase`
- `MPOTensor.PhysicalSectorFactorization.rephase_neighboringOperator`
- `MPOTensor.exists_vertexPhase_smul_posSemidef`
- `MPOTensor.exists_rephased_inverseMapPhysicalSectorFactorization`

## Source-faithfulness boundary

The main theorem is explicitly marked:

> **Scope restriction (recurrent nonzero support):**

Recurrence is not a hypothesis of arXiv:1606.00608, Appendix C.2, Lemma C.4. The unrestricted blueprint theorem remains `\notready`.

The paper-gap note now records why recurrence is false for an arbitrary current `EtaStructure`: zero-probability Hayashi sectors may retain a nonzero right tensor and hence transient outgoing support edges. Issue #3825 tracks the source-faithful repair—set the right tensor of every zero-weight sector to zero without changing the one-site factorization, then prove recurrence on the resulting active support.

No primitivity conclusion is used, avoiding the circular route through the trace matrix introduced only after positivity is chosen.

## Verification

- `lake build +TNLean`
- `PATH=/Users/siruilu/Library/Python/3.9/bin:$PATH leanblueprint web`
- `lake exe checkdecls blueprint/lean_decls`
- proof-integrity and 100-character line scans on all new Lean files
- kernel-axiom audit: only `propext`, `Classical.choice`, and `Quot.sound`

Closes #3821.
Part of #3696.
Related to #823 and #3825.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Substantial new formal mathematics on the MPDO positivity track; correctness risk is proof/logic rather than runtime, and the unrestricted paper theorem remains explicitly out of scope pending recurrence from injectivity.
> 
> **Overview**
> Adds **formal Lean** for the MPDO “coherent positive choice” step **conditional on recurrent nonzero support**, wiring per-cycle rescaling into a global vertex rephasing.
> 
> **Algebra:** New `ComplexPhasePositivity` defines unit-modulus phases (`Complex.unitsPhase`, `Complex.phase`), shows replacing a PSD rescaling scalar by its phase preserves PSD, and proves uniqueness of the unit phase (`Circle.eq_of_smul_posSemidef`).
> 
> **Sector geometry:** `PhysicalSectorRephasing` introduces reciprocal unit rephasing of left/right sector tensors (`rephase`) and proves neighboring operators pick up the factor `z_k⁻¹ z_h` (`rephase_neighboringOperator`).
> 
> **Main result:** `RecurrentSectorRephasing` proves that if every cyclic η-tensor product is PSD and every nonzero support edge lies on a directed cycle, there exist vertex phases `z_k` with `z_k⁻¹ z_h η_{k,h}` PSD (`exists_vertexPhase_smul_posSemidef`), and the inverse-map physical-sector factorization can be rephased so **all** neighboring operators are PSD (`exists_rephased_inverseMapPhysicalSectorFactorization`). The argument closes cycles through each edge, uses cyclic positive rescaling + phase uniqueness for trivial holonomy, then applies the directed-walk coboundary theorem.
> 
> **Docs:** `SectorRecurrence` module text now points here for the global rephasing; blueprint gains definitions/theorems for rephasing and the recurrent coherent-choice theorem (full source theorem still `\notready`); the paper-gap note documents why recurrence is an extra hypothesis (zero-weight Hayashi sectors) and that the MPDO coboundary bridge is now formalized under recurrence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00d6b7a197282b48524f98d3b52f186bf8e4030c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->