### PR TITLE
doc(blueprint): add MPO fusion diagrams

### DIFF
--- a/blueprint/src/Packages/tn_diagrams.py
+++ b/blueprint/src/Packages/tn_diagrams.py
@@ -77,6 +77,8 @@ _DIAGRAM_ARGS: dict[str, str] = {
     "TNBNTDecomposition": "",
     "TNMPDOZCLIdempotence": "",
     "TNMPDOFixedFinalFusionBracketings": "",
+    "TNMPDOBNTFusionIdentity": "",
+    "TNMPDOFusionTracePower": "",
     "TNRFPKrausIsometry": "",
     "TNRFPKrausIsometryReverse": "",
     "TNRFPIsometryCanonicalForm": "",

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -264,6 +264,20 @@ them.
     Definition~\ref{def:mpdo_bnt_label_idempotent_coefficient_form}.
 \end{definition}
 
+\begin{figure}[ht]
+    \centering
+    \TNMPDOBNTFusionIdentity
+    \caption{The local fusion isometry: the two vertically concatenated basis
+        tensors are conjugated by $U_{\alpha,\beta}$ into the weighted direct
+        sum $\bigoplus_\gamma\chi_{\alpha,\beta,\gamma}\otimes M_\gamma$.
+        This is precisely the tensor identity in
+        \cite[Theorem~4.14(iii), equation~(89), lines~986--991]
+        {Cirac2016MPDO_arXiv}; its graphical arrangement follows the physical
+        isometry and direct-sum picture of
+        \cite[Proposition~4.13, lines~943--959]{Cirac2016MPDO_arXiv}.}
+    \label{fig:mpdo_bnt_fusion_identity}
+\end{figure}
+
 \begin{theorem}[Weighted zipper identities]%
     \label{thm:mpdo_bnt_weighted_zipper}
     \lean{MPOTensor.BNTFusionIsometryFamily.fusionIsometry_mul_mulTensor}
@@ -370,6 +384,20 @@ them.
     $c^{(L)}_{\alpha,\beta,\gamma}
         = \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{L})$.
 \end{definition}
+
+\begin{figure}[ht]
+    \centering
+    \TNMPDOFusionTracePower
+    \caption{Closing an $L$-site chain of the local fusion identity. On the
+        left, the bra legs of the $M_\alpha$ operator are contracted with the
+        ket legs of the $M_\beta$ operator. On the right, the multiplicity loop
+        and the $M_\gamma$ loop are disjoint; the former contributes
+        $\operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{L})$. Thus the diagram is
+        the trace-power product law of
+        \cite[Theorem~4.14(ii)--(iii), equations~(87) and~(89),
+        lines~962--991]{Cirac2016MPDO_arXiv}.}
+    \label{fig:mpdo_fusion_trace_power}
+\end{figure}
 
 \begin{theorem}[Fusion isometries give the same-length product law]%
     \label{thm:mpdo_fusion_same_length_product}

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -1186,6 +1186,112 @@
     \end{tikzpicture}%
 }
 
+% Local BNT fusion identity from CPSV16, eq. (Ualphabeta).  The left-hand
+% isometry combines the two incoming bond factors, while its adjoint separates
+% the outgoing factors.  The right-hand side records the weighted final-sector
+% direct sum without introducing an F-move.
+\newcommand{\TNMPDOBNTFusionIdentity}{%
+    \begin{tikzpicture}[tn picture, scale=0.92]
+        \node[draw, rounded corners, fill=blue!8, inner sep=2pt,
+            minimum height=1.16cm] (bfiU) at (-2.20,0) {$U_{\alpha,\beta}$};
+        \TN@tensordot{bfiA}{(-0.95,0.42)}
+        \TN@tensordot{bfiB}{(-0.95,-0.42)}
+        \node[draw, rounded corners, fill=blue!8, inner sep=2pt,
+            minimum height=1.16cm] (bfiUd) at (0.30,0)
+            {$U_{\alpha,\beta}^{\dagger}$};
+        \draw[tn leg] (bfiU.north east) -- (bfiA.west);
+        \draw[tn leg] (bfiU.south east) -- (bfiB.west);
+        \draw[tn leg] (bfiA.east) -- (bfiUd.north west);
+        \draw[tn leg] (bfiB.east) -- (bfiUd.south west);
+        \draw[tn leg] (bfiU.west) -- ++(-0.48,0);
+        \draw[tn leg] (bfiUd.east) -- ++(0.48,0);
+        \draw[tn phys leg] (bfiA.south) -- (bfiB.north);
+        \TN@upleg{bfiA}{0.42}
+        \TN@downleg{bfiB}{0.42}
+        \node at (-0.68,0.68) {$M_\alpha$};
+        \node at (-0.68,-0.68) {$M_\beta$};
+        \node at (-1.17,1.06) {$i$};
+        \node at (-1.17,-1.06) {$j$};
+
+        \node at (1.42,0) {$=$};
+        \node at (2.32,0) {$\displaystyle\bigoplus_\gamma$};
+        \node[draw, fill=white, minimum width=1.08cm, minimum height=0.48cm,
+            inner sep=1pt] (bfiChi) at (3.65,0.55)
+            {$\chi_{\alpha,\beta,\gamma}$};
+        \TN@tensordot{bfiG}{(3.65,-0.36)}
+        \TN@leftleg{bfiChi}{0.48}
+        \TN@rightleg{bfiChi}{0.48}
+        \TN@leftleg{bfiG}{0.48}
+        \TN@rightleg{bfiG}{0.48}
+        \TN@upleg{bfiG}{0.42}
+        \TN@downleg{bfiG}{0.42}
+        \node at (3.94,-0.36) {$M_\gamma$};
+        \node at (3.46,0.20) {$i$};
+        \node at (3.46,-0.92) {$j$};
+    \end{tikzpicture}%
+}
+
+% Closing an L-site chain of the local BNT fusion identity.  On the right the
+% multiplicity loop and the M_gamma loop are disjoint, so their traces factor.
+\newcommand{\TNMPDOFusionTracePower}{%
+    \begin{tikzpicture}[tn picture, scale=0.82]
+        \foreach \x/\s in {0/L,1.10/M,3.20/R} {
+            \TN@tensordot{ftpA\s}{(\x,0.52)}
+            \TN@tensordot{ftpB\s}{(\x,-0.52)}
+            \draw[tn phys leg] (ftpA\s.south) -- (ftpB\s.north);
+        }
+        \draw[tn leg] (ftpAL.east) -- (ftpAM.west);
+        \draw[tn leg] (ftpAM.east) -- ++(0.52,0);
+        \draw[tn leg] ($(ftpAR.west)+(-0.52,0)$) -- (ftpAR.west);
+        \draw[tn leg] (ftpBL.east) -- (ftpBM.west);
+        \draw[tn leg] (ftpBM.east) -- ++(0.52,0);
+        \draw[tn leg] ($(ftpBR.west)+(-0.52,0)$) -- (ftpBR.west);
+        \node at (2.15,0.52) {$\cdots$};
+        \node at (2.15,-0.52) {$\cdots$};
+        \draw[tn leg] (ftpAL.west) -- ++(-0.40,0) -- ++(0,0.86)
+            -- ($(ftpAR.east)+(0.40,0.86)$) -- ($(ftpAR.east)+(0.40,0)$)
+            -- (ftpAR.east);
+        \draw[tn leg] (ftpBL.west) -- ++(-0.40,0) -- ++(0,-0.86)
+            -- ($(ftpBR.east)+(0.40,-0.86)$) -- ($(ftpBR.east)+(0.40,0)$)
+            -- (ftpBR.east);
+        \foreach \s in {L,M,R} {
+            \TN@upleg{ftpA\s}{0.34}
+            \TN@downleg{ftpB\s}{0.34}
+        }
+        \node[anchor=east] at (-0.60,0.52) {$M_\alpha$};
+        \node[anchor=east] at (-0.60,-0.52) {$M_\beta$};
+        \node at (4.20,0) {$=$};
+        \node at (4.82,0) {$\displaystyle\sum_\gamma$};
+
+        \foreach \x/\s in {5.65/L,6.75/M,8.85/R} {
+            \TN@opdot{ftpC\s}{(\x,0.52)}
+            \TN@tensordot{ftpG\s}{(\x,-0.52)}
+        }
+        \draw[tn leg] (ftpCL.east) -- (ftpCM.west);
+        \draw[tn leg] (ftpCM.east) -- ++(0.52,0);
+        \draw[tn leg] ($(ftpCR.west)+(-0.52,0)$) -- (ftpCR.west);
+        \draw[tn leg] (ftpGL.east) -- (ftpGM.west);
+        \draw[tn leg] (ftpGM.east) -- ++(0.52,0);
+        \draw[tn leg] ($(ftpGR.west)+(-0.52,0)$) -- (ftpGR.west);
+        \node at (7.80,0.52) {$\cdots$};
+        \node at (7.80,-0.52) {$\cdots$};
+        \draw[tn leg] (ftpCL.west) -- ++(-0.40,0) -- ++(0,0.86)
+            -- ($(ftpCR.east)+(0.40,0.86)$) -- ($(ftpCR.east)+(0.40,0)$)
+            -- (ftpCR.east);
+        \draw[tn leg] (ftpGL.west) -- ++(-0.40,0) -- ++(0,-0.86)
+            -- ($(ftpGR.east)+(0.40,-0.86)$) -- ($(ftpGR.east)+(0.40,0)$)
+            -- (ftpGR.east);
+        \foreach \s in {L,M,R} {
+            \TN@upleg{ftpG\s}{0.34}
+            \TN@downleg{ftpG\s}{0.34}
+        }
+        \node[anchor=east] at (5.05,0.52) {$\chi_{\alpha,\beta,\gamma}$};
+        \node[anchor=east] at (5.05,-0.52) {$M_\gamma$};
+        \node at (2.15,-1.80) {$L\text{ sites}$};
+        \node at (7.80,-1.80) {$L\text{ sites}$};
+    \end{tikzpicture}%
+}
+
 % Fusion isometry of the renormalization fixed-point characterization: two
 % contracted copies of the tensor equal one copy with the isometry merging
 % the summed index into the physical pair.

--- a/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
+++ b/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
@@ -28,6 +28,9 @@ name: TNMPDOInverseContraction TNMPDOSectorPairing TNMPDOSectorZCLIdentity
 name: TNMPSInverseContraction TNBNTDecomposition TNMPDOZCLIdempotence TNMPDOFixedFinalFusionBracketings
 {{ obj.tn_svg_html }}
 
+name: TNMPDOBNTFusionIdentity TNMPDOFusionTracePower
+{{ obj.tn_svg_html }}
+
 name: TNRFPKrausIsometry TNRFPKrausIsometryReverse TNRFPIsometryCanonicalForm
 {{ obj.tn_svg_html }}
 


### PR DESCRIPTION
## Summary

This change adds two source-faithful TikZ figures to the MPO/RFP fusion-isometry chapter.

- The first depicts the local identity
  \(U_{\alpha,\beta}(M_\alpha M_\beta)U_{\alpha,\beta}^\dagger = \bigoplus_\gamma \chi_{\alpha,\beta,\gamma}\otimes M_\gamma\), following the paper's physical-isometry/direct-sum PNG.
- The second closes an \(L\)-site chain and separates the multiplicity and \(M_\gamma\) loops, making the coefficient \(\operatorname{tr}(\chi_{\alpha,\beta,\gamma}^L)\) visible.
- Both macros are registered in the web renderer and its template.

The figures correspond to arXiv:1606.00608, Theorem 4.14(ii)–(iii), equations (87) and (89), lines 962–991. They do not depict the still-open fixed-final \(F\)-move as established.

## Validation

- `leanblueprint pdf` (518 pages)
- visual inspection of rendered pages 434–436 at 150/180 dpi
- `leanblueprint web`, with both SVGs present
- tensor-network registry check and two-macro smoke render
- PEPS macro-usage check
- `chktex` on the modified chapter
- reader-facing prose check
- `git diff --check`
- independent source-semantic, renderer, and visual review by a parallel agent

Advances #3776.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and diagram macros only; no Lean or runtime logic changes.
> 
> **Overview**
> Adds **two TikZ tensor-network figures** to the MPO/RFP fusion-isometry chapter, aligned with Cirac et al. Theorem 4.14(ii)–(iii).
> 
> `\TNMPDOBNTFusionIdentity` shows the local identity \(U_{\alpha,\beta}(M_\alpha M_\beta)U_{\alpha,\beta}^\dagger = \bigoplus_\gamma \chi_{\alpha,\beta,\gamma}\otimes M_\gamma\), placed after the fusion-isometry family definition. `\TNMPDOFusionTracePower` closes an \(L\)-site chain so the \(\chi\) multiplicity trace \(\operatorname{tr}(\chi_{\alpha,\beta,\gamma}^L)\) is visible on the right, before the same-length product law theorem.
> 
> Both macros are registered in `tn_diagrams.py` and the plasTeX web template so PDF and web blueprints render the same SVGs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit feef2b963b48590269afe24ad2ef0eab7f6177a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->