### PR TITLE
feat(MPS/MPDO): separate triple-fusion final sectors

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -442,6 +442,7 @@ import TNLean.MPS.MPDO.BNTLeftTripleFusion
 import TNLean.MPS.MPDO.BNTRightTripleFusion
 import TNLean.MPS.MPDO.BNTTripleFusionComparison
 import TNLean.MPS.MPDO.BNTFinalSectorFusion
+import TNLean.MPS.MPDO.BNTTripleFusionSeparation
 import TNLean.MPS.MPDO.CommutingForm
 import TNLean.MPS.MPDO.CommutingFormBridge
 import TNLean.MPS.MPDO.BlockedRFPConstruction

--- a/TNLean/MPS/MPDO/BNTTripleFusionSeparation.lean
+++ b/TNLean/MPS/MPDO/BNTTripleFusionSeparation.lean
@@ -1,0 +1,151 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.BNTTripleFusionComparison
+import TNLean.MPS.MPDO.BNTFinalSectorFusion
+import TNLean.MPS.MPDO.BiCFDerivation.Core
+
+/-!
+# Separation of final sectors in the triple-fusion comparison
+
+The full triple-fusion comparison intertwines direct sums over all final labels.
+If a common word polynomial selects one final-label tensor and annihilates all
+the others, its off-diagonal final-label corners vanish.  This is the finite
+word form of the simultaneous inverse used in the fixed-channel extraction in
+arXiv:1511.08090.
+
+The selector hypothesis is stated explicitly.  It is not presently derived
+from the assumptions on `BNTFusionIsometryFamily`.  Consequently the result below is
+a conditional final-sector decomposition; it does not construct an invertible
+fixed-sector comparison, an $F$-matrix, or a pentagon identity.
+
+## References
+
+* [Bultinck--Marien--Williamson--Sahinoglu--Haegeman--Verstraete 2015]
+  arXiv:1511.08090, lines 237--277, especially the simultaneous inverse at
+  line 269; see also lines 427--431 for the blocked direct-sum span input
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  lines 995--1010
+-/
+
+open scoped Matrix BigOperators ComplexOrder Kronecker
+open Matrix
+
+namespace MPOTensor.BNTFusionIsometryFamily
+
+universe u
+
+variable {Λ : Type u} [Fintype Λ] [DecidableEq Λ] {p : ℕ}
+variable (Fam : BNTFusionIsometryFamily Λ p)
+
+/-- A common finite family of word polynomials separates every final-label
+tensor from all the others.  This is the arbitrary-finite-label form of
+`MPSTensor.HasBlockSelectorWords`.
+
+For each `ε`, the same coefficients evaluate to the identity on `tensor ε`
+and to zero on every `tensor ε'` with `ε' ≠ ε`.
+
+Source: arXiv:1511.08090, simultaneous inverse relation
+`B_d^+ B_{d'} = δ_{d,d'} 1` at line 269, after the common blocking described
+at lines 427--431. -/
+def HasFinalLabelSelectorWords (S : ℕ) : Prop :=
+  ∀ ε : Λ, ∃ c : (Fin S → Fin (p * p)) → ℂ,
+    (∑ w : Fin S → Fin (p * p),
+      c w • MPSTensor.evalWord (Fam.tensor ε).toMPSTensor (List.ofFn w)) = 1 ∧
+    ∀ ε' : Λ, ε' ≠ ε →
+      (∑ w : Fin S → Fin (p * p),
+        c w • MPSTensor.evalWord (Fam.tensor ε').toMPSTensor (List.ofFn w)) = 0
+
+private theorem rectangularIntertwiner_eq_zero_of_selectorWords
+    {d D₁ D₂ S : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (C : Matrix (Fin D₁) (Fin D₂) ℂ)
+    (hC : ∀ i : Fin d, A i * C = C * B i)
+    (c : (Fin S → Fin d) → ℂ)
+    (hA : (∑ w : Fin S → Fin d,
+      c w • MPSTensor.evalWord A (List.ofFn w)) = 1)
+    (hB : (∑ w : Fin S → Fin d,
+      c w • MPSTensor.evalWord B (List.ofFn w)) = 0) :
+    C = 0 := by
+  have hWord : ∀ w : List (Fin d),
+      MPSTensor.evalWord A w * C = C * MPSTensor.evalWord B w := by
+    intro w
+    induction w with
+    | nil => simp
+    | cons i w ih =>
+        simp only [MPSTensor.evalWord_cons]
+        calc
+          (A i * MPSTensor.evalWord A w) * C =
+              A i * (MPSTensor.evalWord A w * C) := Matrix.mul_assoc _ _ _
+          _ =
+              A i * (C * MPSTensor.evalWord B w) := by rw [ih]
+          _ = (A i * C) * MPSTensor.evalWord B w := by rw [Matrix.mul_assoc]
+          _ = (C * B i) * MPSTensor.evalWord B w := by rw [hC i]
+          _ = C * (B i * MPSTensor.evalWord B w) := by rw [Matrix.mul_assoc]
+  have hSum :
+      (∑ w : Fin S → Fin d,
+        (c w • MPSTensor.evalWord A (List.ofFn w)) * C) =
+      ∑ w : Fin S → Fin d,
+        C * (c w • MPSTensor.evalWord B (List.ofFn w)) := by
+    refine Finset.sum_congr rfl fun w _ => ?_
+    rw [Matrix.smul_mul, Matrix.mul_smul, hWord]
+  rw [← Matrix.sum_mul, hA, Matrix.one_mul, ← Matrix.mul_sum, hB,
+    Matrix.mul_zero] at hSum
+  exact hSum
+
+/-- **Conditional off-diagonal final-sector vanishing.** Suppose the positive
+trace-power coefficients are independent of the positive chain length and a
+common finite word family separates the final-label tensors.  Then the full
+triple-fusion comparison has no corner from a right final sector `ε'` to a
+distinct left final sector `ε`.
+
+**Scope restriction (simultaneous final-label separation):** the selector
+hypothesis is the finite-word form of the simultaneous inverse at line 269 of
+arXiv:1511.08090.  It is not derived from the current assumptions on
+`BNTFusionIsometryFamily`; this remaining implication is documented in
+`docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`.
+
+This theorem asserts only off-diagonal vanishing.  It does not assert that a
+diagonal corner is invertible, identify such a corner with an $F$-matrix, or
+prove a pentagon identity.
+
+Source: arXiv:1511.08090, equations `zippercondition2` and `Fmove`, lines
+237--277, especially line 269; arXiv:1606.00608, lines 995--1010. -/
+theorem tripleFusionComparison_finalSector_submatrix_eq_zero
+    (c : BNTLabelCoefficientFamily Λ)
+    (hχ : c.HasPositiveLengthChiTracePowerForm Fam.chi)
+    (hLI : c.LengthIndependent) {S : ℕ}
+    (hSel : Fam.HasFinalLabelSelectorWords S)
+    (α β γ ε ε' : Λ) (hε : ε' ≠ ε) :
+    (Fam.tripleFusionComparison α β γ).submatrix
+        (Fam.leftFinalRow α β γ ε) (Fam.rightFinalRow α β γ ε') = 0 := by
+  let C := Fam.tripleFusionComparison α β γ
+  ext x y
+  rcases x with ⟨δL, μL, νL, bL⟩
+  rcases y with ⟨δR, μR, νR, bR⟩
+  let Cblock : Matrix (Fin (Fam.bondDim ε)) (Fin (Fam.bondDim ε')) ℂ :=
+    fun b b' => C (Fam.leftFinalRow α β γ ε ⟨δL, μL, νL, b⟩)
+      (Fam.rightFinalRow α β γ ε' ⟨δR, μR, νR, b'⟩)
+  have hLetter : ∀ ij : Fin (p * p),
+      (Fam.tensor ε).toMPSTensor ij * Cblock =
+        Cblock * (Fam.tensor ε').toMPSTensor ij := by
+    intro ij
+    obtain ⟨⟨i, k⟩, rfl⟩ := finProdFinEquiv.surjective ij
+    have hFull := Fam.tripleFusionComparison_intertwines_of_lengthIndependent
+      c hχ hLI α β γ i k
+    ext b b'
+    have hEntry := congrArg
+      (fun X => X (Fam.leftFinalRow α β γ ε ⟨δL, μL, νL, b⟩)
+        (Fam.rightFinalRow α β γ ε' ⟨δR, μR, νR, b'⟩)) hFull
+    simpa [Cblock, C, Matrix.mul_apply, Matrix.blockDiagonal'_apply,
+      leftFinalRow, rightFinalRow, Fintype.sum_sigma, Fintype.sum_prod_type,
+      Matrix.one_apply, MPOTensor.toMPSTensor]
+      using hEntry
+  obtain ⟨coeff, hSelf, hOther⟩ := hSel ε
+  have hZero := rectangularIntertwiner_eq_zero_of_selectorWords
+    (Fam.tensor ε).toMPSTensor (Fam.tensor ε').toMPSTensor Cblock hLetter
+    coeff hSelf (hOther ε' hε)
+  exact congrArg (fun X => X bL bR) hZero
+
+end MPOTensor.BNTFusionIsometryFamily

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -615,6 +615,60 @@ separate step.
     and apply Theorem~\ref{thm:mpdo_operator_product_associativity}.
 \end{proof}
 
+\begin{definition}[Common word selectors for the final labels]%
+    \label{def:mpdo_final_label_selector_words}
+    \lean{MPOTensor.BNTFusionIsometryFamily.HasFinalLabelSelectorWords}
+    \leanok
+    For some common length $S$, suppose that for each final label
+    $\varepsilon$ there are coefficients $c_\varepsilon(w)$, indexed by the
+    words $w$ of length $S$ in the doubled physical alphabet, such that
+    \[
+        \sum_{|w|=S}c_\varepsilon(w)M_\varepsilon^w=1,
+        \qquad
+        \sum_{|w|=S}c_\varepsilon(w)M_{\varepsilon'}^w=0
+        \quad(\varepsilon'\ne\varepsilon).
+    \]
+    This is the finite-word form of the simultaneous inverse relation
+    $B_d^+B_{d'}=\delta_{d,d'}1$ used in the fixed-channel argument of
+    \cite{Bultinck2017Anyons}.
+\end{definition}
+
+\begin{theorem}[Vanishing between distinct final sectors]%
+    \label{thm:mpdo_triple_fusion_comparison_final_sector_vanishing}
+    \lean{MPOTensor.BNTFusionIsometryFamily.%
+        tripleFusionComparison_finalSector_submatrix_eq_zero}
+    \leanok
+    \uses{def:mpdo_triple_fusion_comparison,
+        def:mpdo_final_label_selector_words}
+    Suppose the positive trace-power coefficients are independent of the
+    positive chain length and common word selectors exist.  If
+    $\varepsilon\ne\varepsilon'$, then the corner of the full comparison from
+    the right final sector $\varepsilon'$ to the left final sector
+    $\varepsilon$ vanishes:
+    \[
+        P^{\mathrm L}_{\varepsilon}
+        C_{\alpha,\beta,\gamma}
+        P^{\mathrm R}_{\varepsilon'}=0.
+    \]
+    The assertion is conditional on the displayed word-selector identities.
+    It neither states that a diagonal corner is invertible nor identifies one
+    with an $F$-matrix, and it does not assert the pentagon identity.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:mpdo_triple_fusion_comparison_intertwines}
+    Fix one left multiplicity index and one right multiplicity index.  Taking
+    the corresponding bond-space corner of the full letterwise identity gives
+    \[
+        M_\varepsilon^{ij}X
+          =X M_{\varepsilon'}^{ij}.
+    \]
+    Induction on the word $w$ gives
+    $M_\varepsilon^w X = X M_{\varepsilon'}^w$.  Multiply these identities by
+    $c_\varepsilon(w)$ and sum over all words of length $S$.  The two selector
+    identities give $X=0$.  Since the multiplicity indices were arbitrary,
+    the whole off-diagonal final-sector corner vanishes.
+\end{proof}
+
 \begin{definition}[Fixed-final multiplicity spaces]%
     \label{def:mpdo_final_sector_multiplicity_spaces}
     \lean{MPOTensor.BNTFusionIsometryFamily.LeftFinalMultiplicity}

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -510,16 +510,28 @@ is oriented from the right-associated sum to the left-associated sum, hence
 oppositely to the printed $F$-matrix convention in equation
 \texttt{Fmove}; it is not identified with that $F$-matrix.
 
-The formalization does not extract a comparison at a fixed final label.  That
-extraction uses the simultaneous inverse relation at line~269 of the
-arXiv:1511.08090 source,
+The simultaneous inverse relation at line~269 of the arXiv:1511.08090 source,
 \[
     B_d^+ B_{d'}=\delta_{d,d'}1,
 \]
-which separates all final-label blocks at once.  No such simultaneous
-final-label separation is presently derived from the BNT hypotheses.  Hence
-the fixed-final $F$-transformation, its invertibility, and the pentagon-like
-equation mentioned at lines~995--999 remain unformalized.
+separates all final-label blocks at once.  Its exact finite-word consequence is
+now an explicit hypothesis in
+\leanid{MPOTensor.BNTFusionIsometryFamily.HasFinalLabelSelectorWords}.  Under
+this hypothesis,
+\leanid{MPOTensor.BNTFusionIsometryFamily.%
+tripleFusionComparison_finalSector_submatrix_eq_zero} proves that the full
+comparison has zero corner between two distinct final labels.  The proof takes
+one rectangular bond-space corner of the letterwise intertwining identity,
+extends it to words, and applies the selector polynomial.
+
+This is a scope-restricted result: no simultaneous final-label selector is
+presently derived from the assumptions on the fusion-isometry family.  That
+missing implication is the remaining source-faithfulness gap at this stage.
+Even after it is supplied, off-diagonal vanishing alone neither proves that the
+diagonal fixed-final corners are invertible nor identifies them with the
+printed $F$-matrices.  The fixed-final $F$-transformation, its invertibility,
+and the pentagon-like equation mentioned at lines~995--999 therefore remain
+unformalized.
 
 To eliminate the source-theorem gap, the formalization should instead:
 \begin{enumerate}


### PR DESCRIPTION
## Summary

This change proves the first source-faithful fixed-final-sector consequence of the full triple-fusion comparison.

- It defines a common finite-word selector hypothesis for the final tensor labels, the direct analogue of the simultaneous inverse \(B_d^+B_{d'}=\delta_{d,d'}I\).
- It proves a generic rectangular cancellation lemma for a letterwise intertwiner under such selectors.
- It applies that lemma to show that every comparison corner between two distinct final labels vanishes.
- It updates the fusion-isometry blueprint and the paper-gap note with the exact conditional scope.

## Faithfulness boundary

The selector is an explicit hypothesis corresponding to arXiv:1511.08090, line 269, after the common blocked direct-sum span assumption at lines 427–431. It is not yet derived from the present `BNTFusionIsometryFamily` fields. The result therefore does not claim diagonal-corner invertibility, identification with the printed \(F\)-matrix, or the pentagon identity.

## Validation

- `lake env lean TNLean/MPS/MPDO/BNTTripleFusionSeparation.lean`
- full `lake build` (9348 jobs)
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `leanblueprint pdf` (517 pages)
- reader-facing prose check
- proof-integrity scan and `git diff --check`
- independent mathematical, source, Lean, blueprint, and identity review by a parallel agent

Advances #3776.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal mathematics and documentation on the MPDO fusion track; no runtime, auth, or data-path changes, and the main result is explicitly conditional on an unproven selector hypothesis.
> 
> **Overview**
> Adds **`BNTTripleFusionSeparation.lean`** and wires it into the public import surface, with matching blueprint and paper-gap prose.
> 
> The new **`HasFinalLabelSelectorWords`** hypothesis encodes the finite-word analogue of the simultaneous inverse \(B_d^+ B_{d'}=\delta_{d,d'}I\) (arXiv:1511.08090): for each final label \(\varepsilon\), one shared word polynomial is 1 on \(M_\varepsilon\) and 0 on every other final tensor. A private lemma shows any rectangular matrix that letterwise intertwines two tensors and is killed by such selectors must be zero.
> 
> Under length-independent positive \(\chi\) coefficients and that selector hypothesis, **`tripleFusionComparison_finalSector_submatrix_eq_zero`** proves every off-diagonal corner of the full triple-fusion comparison matrix vanishes between distinct final sectors—by restricting the existing letterwise intertwining identity to a bond block and applying the selector argument.
> 
> Documentation is explicit that selectors are **not** derived from `BNTFusionIsometryFamily` today; diagonal invertibility, \(F\)-matrix identification, and the pentagon identity are **out of scope**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27f387c424708db020a48f380836613630895ed0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->