### PR TITLE
feat(MPS/MPDO): derive recurrence after zero-weight reparameterization

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -392,6 +392,7 @@ import TNLean.MPS.MPDO.RFPSubspinMaps
 import TNLean.MPS.MPDO.HayashiSectorComparison
 import TNLean.MPS.MPDO.SectorFactorization
 import TNLean.MPS.MPDO.PhysicalSectorFactorization
+import TNLean.MPS.MPDO.PhysicalSectorSupportRecurrence
 import TNLean.MPS.MPDO.PhysicalSectorRephasing
 import TNLean.MPS.MPDO.InverseMapPhysicalSectorFactorization
 import TNLean.MPS.MPDO.PhysicalSectorPruning

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -416,6 +416,8 @@ import TNLean.MPS.MPDO.PhysicalSectorRefinementIdentity
 import TNLean.MPS.MPDO.PhysicalSectorPhysicalMaps
 import TNLean.MPS.MPDO.PhysicalSectorBlockedRFP
 import TNLean.MPS.MPDO.PhysicalSectorCoordinateTransport
+import TNLean.MPS.MPDO.PhysicalSectorVirtualSpanning
+import TNLean.MPS.MPDO.InverseMapActiveSectorRecurrence
 import TNLean.MPS.MPDO.PhysicalSectorPositiveBond
 import TNLean.MPS.MPDO.PhysicalSectorBondCommutativity
 import TNLean.MPS.MPDO.PhysicalSectorBondTransport

--- a/TNLean/MPS/MPDO/InverseMapActiveSectorRecurrence.lean
+++ b/TNLean/MPS/MPDO/InverseMapActiveSectorRecurrence.lean
@@ -1,0 +1,285 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalSectorPruning
+import TNLean.MPS.MPDO.PhysicalSectorVirtualSpanning
+import TNLean.MPS.MPDO.SectorEtaOperator
+import TNLean.MPS.MPDO.SectorRecurrence
+import TNLean.MPS.MPDO.RecurrentSectorRephasing
+
+/-!
+# Recurrence after deactivating zero-weight sectors
+
+For the inverse-map physical-sector factorization, every positive-weight
+Hayashi sector contains a nonzero virtual matrix. Otherwise the corresponding
+middle-site block of the three-site closure would vanish, contrary to its
+expression as a nonzero weight times two trace-one density matrices.
+
+After zero-weight sectors are deactivated, every endpoint of a nonzero
+neighboring operator has positive weight. Injectivity supplies spanning by the
+sector virtual matrices, so the triangle-closing argument proves recurrence of
+the neighboring support. The recurrent-support rephasing theorem then gives a
+physical-sector factorization with positive semidefinite neighboring
+operators, without an additional recurrence hypothesis.
+
+## References
+
+- [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, Lemma C.4 (`propSN`), lines 1406--1450
+- `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`
+-/
+
+open scoped Matrix ComplexOrder BigOperators
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- Conjugating the middle physical index of a three-site closure is the same
+as replacing the middle MPO matrix by its conjugated physical matrix.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1421--1438. -/
+theorem conjugated_middle_threeSiteClosure
+    {rho : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    (K : MPOTensor d D) (R : Matrix (Fin D) (Fin D) ℂ)
+    (hρ : IsThreeSiteClosure K R rho)
+    (U : Matrix (Fin d) (Fin d) ℂ)
+    (i₁ j₁ i₃ j₃ b b' : Fin d) :
+    (∑ i₂ : Fin d, ∑ j₂ : Fin d,
+      U b i₂ * rho (i₁, i₂, i₃) (j₁, j₂, j₃) * star (U b' j₂)) =
+      Matrix.trace
+        (K i₁ j₁ * conjugatePhysical K U b b' * K i₃ j₃ * R) := by
+  have hmiddle : conjugatePhysical K U b b' =
+      ∑ i₂ : Fin d, ∑ j₂ : Fin d,
+        (U b i₂ * star (U b' j₂)) • K i₂ j₂ := by
+    have h := PhysicalSectorFactorization.changePhysicalBasis_apply_eq_sum U K b b'
+    rw [Fintype.sum_prod_type] at h
+    exact h
+  rw [hmiddle]
+  simp only [Matrix.mul_sum, Matrix.mul_smul, Matrix.sum_mul,
+    Matrix.smul_mul, Matrix.trace_sum, Matrix.trace_smul, smul_eq_mul]
+  apply Finset.sum_congr rfl
+  intro i₂ _
+  apply Finset.sum_congr rfl
+  intro j₂ _
+  rw [hρ i₁ i₂ i₃ j₁ j₂ j₃]
+  ring
+
+private theorem exists_diagonal_ne_zero_of_trace_eq_one
+    {n : Type*} [Fintype n] (A : Matrix n n ℂ)
+    (htrace : A.trace = 1) : ∃ i, A i i ≠ 0 := by
+  classical
+  by_contra hall
+  push Not at hall
+  have hz : A.trace = 0 := by
+    simp [Matrix.trace, hall]
+  exact one_ne_zero (htrace.symm.trans hz)
+
+/-- Both endpoints of a nonzero neighboring operator in the zero-weight
+reparameterized inverse-map factorization have positive Hayashi weight.
+
+The source weight is nonzero because its right tensor was set to zero when
+inactive. The target weight is nonzero because a zero target weight already
+makes the original neighboring operator vanish.
+
+**Local fix (inactive sectors):** see
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `etarl`, lines 1441--1445. -/
+theorem probability_ne_zero_of_reparameterized_neighboringOperator_ne_zero
+    {rho : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    (K : MPOTensor d D) (hK : K.IsInjective)
+    (R : Matrix (Fin D) (Fin D) ℂ) (hρ : IsThreeSiteClosure K R rho)
+    (hη : EtaStructure rho) (alpha beta : Fin D) (hm : R beta alpha ≠ 0)
+    {k h : Fin hη.m}
+    (hkh : (zeroWeightReparameterizedInverseMapPhysicalSectorFactorization
+      K hK R hρ hη alpha beta hm).neighboringOperator k h ≠ 0) :
+    hη.p k ≠ 0 ∧ hη.p h ≠ 0 := by
+  constructor
+  · intro hk
+    rw [zeroWeightReparameterizedInverseMapPhysicalSectorFactorization_neighboringOperator,
+      if_neg (not_ne_of_eq hk)] at hkh
+    exact hkh rfl
+  · intro hh
+    rw [zeroWeightReparameterizedInverseMapPhysicalSectorFactorization_neighboringOperator,
+      sectorEta_eq_zero_of_target_weight_eq_zero K hK hη R alpha beta k h hh] at hkh
+    split at hkh <;> exact hkh rfl
+
+/-- Every positive-weight Hayashi sector contains a nonzero virtual matrix in
+the deactivated inverse-map factorization.
+
+The two trace-one sector density matrices have nonzero diagonal entries. If
+all virtual matrices in the sector vanished, the corresponding conjugated
+middle-site MPO matrix would be zero. The closure identity would then make the
+associated diagonal entry of the three-site state vanish, contradicting the
+Hayashi block decomposition and the nonzero sector weight.
+
+**Local fix (inactive sectors):** the ambient physical decomposition is
+unchanged; only right tensors in zero-weight sectors are set to zero. This
+correction is recorded in
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `formK` and `etarl`, lines
+1434--1445. -/
+theorem exists_active_sectorVirtualMatrix_ne_zero
+    {rho : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    (K : MPOTensor d D) (hK : K.IsInjective)
+    (R : Matrix (Fin D) (Fin D) ℂ) (hρ : IsThreeSiteClosure K R rho)
+    (hη : EtaStructure rho) (alpha beta : Fin D) (hm : R beta alpha ≠ 0)
+    (k : Fin hη.m) (hk : hη.p k ≠ 0) :
+    ∃ x y :
+        (zeroWeightReparameterizedInverseMapPhysicalSectorFactorization
+          K hK R hρ hη alpha beta hm).SectorIndex k,
+      (zeroWeightReparameterizedInverseMapPhysicalSectorFactorization
+        K hK R hρ hη alpha beta hm).sectorVirtualMatrix k x y ≠ 0 := by
+  classical
+  let F := zeroWeightReparameterizedInverseMapPhysicalSectorFactorization
+    K hK R hρ hη alpha beta hm
+  by_contra hall
+  push Not at hall
+  obtain ⟨⟨i₁, l⟩, hleft⟩ :=
+    exists_diagonal_ne_zero_of_trace_eq_one
+      (hη.ρ_left k) (hη.hρ_left_dm k).2
+  obtain ⟨⟨r, i₃⟩, hright⟩ :=
+    exists_diagonal_ne_zero_of_trace_eq_one
+      (hη.ρ_right k) (hη.hρ_right_dm k).2
+  let x : F.SectorIndex k := (l, r)
+  let b : Fin d := hη.decompB.symm ⟨k, (l, r)⟩
+  have hmid : conjugatePhysical K hη.U_B b b = 0 := by
+    ext gamma delta
+    have hslice := F.transformedPhysicalSlice_apply_same gamma delta k x x
+    have hzero := congrFun (congrFun (hall x x) gamma) delta
+    change
+      Matrix.reindex hη.decompB hη.decompB
+        ((hη.U_B : Matrix (Fin d) (Fin d) ℂ) *
+          physicalSlice K gamma delta *
+            (hη.U_B : Matrix (Fin d) (Fin d) ℂ)ᴴ)
+          ⟨k, (l, r)⟩ ⟨k, (l, r)⟩ = _ at hslice
+    rw [Matrix.reindex_apply, Matrix.submatrix_apply] at hslice
+    change (((hη.U_B : Matrix (Fin d) (Fin d) ℂ) *
+      physicalSlice K gamma delta *
+        (hη.U_B : Matrix (Fin d) (Fin d) ℂ)ᴴ) b b) = _ at hslice
+    change conjugatePhysical K hη.U_B b b gamma delta = 0
+    exact hslice.trans hzero
+  have hs := congrFun (congrFun hη.h_state
+    (i₁, (⟨k, (l, r)⟩, i₃))) (i₁, (⟨k, (l, r)⟩, i₃))
+  rw [Matrix.reindex_apply, Matrix.submatrix_apply] at hs
+  have hindex : (HayashiMarkov.abcEquiv hη.decompB).symm
+      (i₁, (⟨k, (l, r)⟩, i₃)) = (i₁, b, i₃) := by
+    simp [HayashiMarkov.abcEquiv, b]
+  rw [hindex, HayashiMarkov.liftB_conj_apply,
+    HayashiMarkov.blockState_apply] at hs
+  have hs' :
+      (∑ i₂ : Fin d, ∑ j₂ : Fin d,
+        (hη.U_B : Matrix (Fin d) (Fin d) ℂ) b i₂ *
+          rho (i₁, i₂, i₃) (i₁, j₂, i₃) *
+            star ((hη.U_B : Matrix (Fin d) (Fin d) ℂ) b j₂)) =
+        (hη.p k : ℂ) * hη.ρ_left k (i₁, l) (i₁, l) *
+          hη.ρ_right k (r, i₃) (r, i₃) := by
+    simpa using hs
+  have hclosure := conjugated_middle_threeSiteClosure
+    K R hρ hη.U_B i₁ i₁ i₃ i₃ b b
+  rw [hclosure, hmid] at hs'
+  simp only [Matrix.mul_zero, Matrix.zero_mul, Matrix.trace_zero] at hs'
+  exact mul_ne_zero (mul_ne_zero (Complex.ofReal_ne_zero.mpr hk) hleft) hright hs'.symm
+
+/-- The nonzero neighboring support of the deactivated inverse-map
+factorization is recurrent.
+
+Indeed, every nonzero edge has positive-weight endpoints, hence each endpoint
+contains a nonzero virtual matrix. Injectivity gives spanning by all sector
+virtual matrices, and every edge therefore closes through a third sector.
+
+**Local fix (inactive sectors):** see
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma C.4 (`propSN`), lines
+1406--1450. -/
+theorem zeroWeightReparameterizedInverseMapPhysicalSectorFactorization_isRecurrentSupport
+    {rho : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    (K : MPOTensor d D) (hK : K.IsInjective)
+    (R : Matrix (Fin D) (Fin D) ℂ) (hρ : IsThreeSiteClosure K R rho)
+    (hη : EtaStructure rho) (alpha beta : Fin D) (hm : R beta alpha ≠ 0) :
+    IsRecurrentSupport (fun k h ↦
+      (zeroWeightReparameterizedInverseMapPhysicalSectorFactorization
+        K hK R hρ hη alpha beta hm).neighboringOperator k h) := by
+  let F := zeroWeightReparameterizedInverseMapPhysicalSectorFactorization
+    K hK R hρ hη alpha beta hm
+  intro k h hkh
+  apply F.neighboringOperator_reaches_of_ne_zero
+    (F.sectorVirtualMatrixFamily_span_eq_top hK) _ hkh
+  intro a b hab
+  obtain ⟨ha, hb⟩ :=
+    probability_ne_zero_of_reparameterized_neighboringOperator_ne_zero
+      K hK R hρ hη alpha beta hm hab
+  exact ⟨exists_active_sectorVirtualMatrix_ne_zero
+    K hK R hρ hη alpha beta hm a ha,
+    exists_active_sectorVirtualMatrix_ne_zero
+      K hK R hρ hη alpha beta hm b hb⟩
+
+/-- The inverse-map construction admits a physical-sector factorization whose
+neighboring operators are all positive semidefinite, with no recurrence
+hypothesis.
+
+Zero-weight sectors are first deactivated without changing the physical
+factorization. Their support is recurrent by the preceding theorem. Positivity
+of all cyclic sector products then yields a coherent vertex rephasing.
+
+**Local fix (inactive sectors):** see
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma C.4 (`propSN`), lines
+1406--1450. -/
+theorem exists_positive_inverseMapPhysicalSectorFactorization
+    {rho : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    (K : MPOTensor d D) (hK : K.IsInjective)
+    (R : Matrix (Fin D) (Fin D) ℂ) (hρ : IsThreeSiteClosure K R rho)
+    (hη : EtaStructure rho) (alpha beta : Fin D) (hm : R beta alpha ≠ 0)
+    (hM : IsMPDO K) :
+    ∃ F : PhysicalSectorFactorization K,
+      ∀ k h, (F.neighboringOperator k h).PosSemidef := by
+  let F := zeroWeightReparameterizedInverseMapPhysicalSectorFactorization
+    K hK R hρ hη alpha beta hm
+  let eta : etaOperators hη := fun k h ↦ F.neighboringOperator k h
+  have hcyc : ∀ {N : ℕ} [NeZero N] (q : Fin N → Fin hη.m),
+      (cyclicEtaTensorProduct hη eta q).PosSemidef := by
+    intro N _ q
+    exact cyclicEtaTensorProduct_posSemidef K hη F.leftTensor F.rightTensor
+      F.factorization (hM N) q
+  have hrec : IsRecurrentSupport eta :=
+    zeroWeightReparameterizedInverseMapPhysicalSectorFactorization_isRecurrentSupport
+      K hK R hρ hη alpha beta hm
+  obtain ⟨z, hz⟩ :=
+    exists_vertexPhase_smul_posSemidef hη eta hcyc hrec
+  refine ⟨F.rephase z, fun k h ↦ ?_⟩
+  rw [F.rephase_neighboringOperator]
+  exact hz k h
+
+/-- Every injective MPO tensor satisfying the strong area law admits a
+physical-sector factorization with positive semidefinite neighboring
+operators.
+
+This is the positive local structure asserted in Lemma C.4. Zero-weight
+Hayashi sectors remain present in the physical decomposition, but their unused
+right tensors are set to zero before the coherent rephasing.
+
+**Local fix (inactive sectors):** see
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma C.4 (`propSN`), lines
+1406--1450. -/
+theorem exists_positive_physicalSectorFactorization_of_isSAL
+    (K : MPOTensor d D) (hK : K.IsInjective) (hSAL : IsSAL K) :
+    ∃ F : PhysicalSectorFactorization K,
+      ∀ k h, (F.neighboringOperator k h).PosSemidef := by
+  obtain ⟨hη⟩ := exists_etaStructure_reducedBlockState_of_isSAL K hSAL
+  obtain ⟨beta, alpha, hm⟩ :=
+    exists_normalizedFourSiteTail_entry_ne_zero
+      K ((Classical.choose_spec hSAL).1 4)
+  exact exists_positive_inverseMapPhysicalSectorFactorization K hK
+    (normalizedFourSiteTail K) (isThreeSiteClosure_reducedBlockState K)
+    hη alpha beta hm (Classical.choose hSAL)
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/InverseMapActiveSectorRecurrence.lean
+++ b/TNLean/MPS/MPDO/InverseMapActiveSectorRecurrence.lean
@@ -282,4 +282,15 @@ theorem exists_positive_physicalSectorFactorization_of_isSAL
     (normalizedFourSiteTail K) (isThreeSiteClosure_reducedBlockState K)
     hη alpha beta hm (Classical.choose hSAL)
 
+/-- Every injective MPO tensor satisfying the strong area law has the
+positive commuting nearest-neighbor product structure of Proposition C.8.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`), lines
+1571--1593. -/
+theorem nonempty_etaLocalStructureData_of_isSAL
+    (K : MPOTensor d D) (hK : K.IsInjective) (hSAL : IsSAL K) :
+    Nonempty (EtaLocalStructureData K) := by
+  obtain ⟨F, hF⟩ := exists_positive_physicalSectorFactorization_of_isSAL K hK hSAL
+  exact ⟨F.etaLocalStructureData hF⟩
+
 end MPOTensor

--- a/TNLean/MPS/MPDO/InverseMapActiveSectorRecurrence.lean
+++ b/TNLean/MPS/MPDO/InverseMapActiveSectorRecurrence.lean
@@ -10,14 +10,14 @@ import TNLean.MPS.MPDO.SectorRecurrence
 import TNLean.MPS.MPDO.RecurrentSectorRephasing
 
 /-!
-# Recurrence after deactivating zero-weight sectors
+# Recurrence after reparameterizing zero-weight sectors
 
 For the inverse-map physical-sector factorization, every positive-weight
 Hayashi sector contains a nonzero virtual matrix. Otherwise the corresponding
 middle-site block of the three-site closure would vanish, contrary to its
 expression as a nonzero weight times two trace-one density matrices.
 
-After zero-weight sectors are deactivated, every endpoint of a nonzero
+After zero-weight sectors are reparameterized, every endpoint of a nonzero
 neighboring operator has positive weight. Injectivity supplies spanning by the
 sector virtual matrices, so the triangle-closing argument proves recurrence of
 the neighboring support. The recurrent-support rephasing theorem then gives a
@@ -100,7 +100,7 @@ theorem probability_ne_zero_of_reparameterized_neighboringOperator_ne_zero
   constructor
   · intro hk
     rw [zeroWeightReparameterizedInverseMapPhysicalSectorFactorization_neighboringOperator,
-      if_neg (not_ne_of_eq hk)] at hkh
+      if_neg (fun hne ↦ hne hk)] at hkh
     exact hkh rfl
   · intro hh
     rw [zeroWeightReparameterizedInverseMapPhysicalSectorFactorization_neighboringOperator,

--- a/TNLean/MPS/MPDO/PhysicalSectorEtaLocalStructure.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorEtaLocalStructure.lean
@@ -37,11 +37,8 @@ The normalization scalar at every chain length is one.
 Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`), lines
 1571--1593.
 
-**Scope restriction (given coherently positive physical-sector
-factorization):** The source derives the factorization and the simultaneous
-positive choice of its neighboring contractions from SAL. That upstream step
-remains documented in
-`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`. -/
+The source-faithful existence theorem from SAL is
+`MPOTensor.nonempty_etaLocalStructureData_of_isSAL`. -/
 noncomputable def etaLocalStructureData
     (F : PhysicalSectorFactorization K)
     (hη : ∀ k h, (F.neighboringOperator k h).PosSemidef) :

--- a/TNLean/MPS/MPDO/PhysicalSectorSupportRecurrence.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorSupportRecurrence.lean
@@ -1,0 +1,199 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.TracePairing
+import TNLean.MPS.MPDO.PhysicalSectorFactorization
+
+/-!
+# Recurrence from physical-sector spanning
+
+For a physical-sector factorization, every matrix entry within one sector
+determines a matrix on the virtual space. Multiplying entries from two
+consecutive sectors exposes the neighboring operator between them.
+
+If these virtual matrices span the full matrix algebra and both endpoints of
+each nonzero neighboring edge contain a nonzero virtual matrix, then every
+such edge `k → h` admits a two-edge return `h → j → k`. The proof uses
+nondegeneracy and cyclicity of the matrix trace.
+
+## Main declarations
+
+- `sectorVirtualMatrix`: the virtual matrix associated with one matrix entry
+  inside a physical sector.
+- `sectorVirtualMatrix_mul_apply`: the product of two sector virtual matrices
+  contains the corresponding neighboring-operator entry as its middle factor.
+- `exists_two_edge_return_of_neighboringOperator_ne_zero`: every nonzero
+  neighboring edge closes to a directed triangle under the spanning and
+  nonvanishing hypotheses.
+- `neighboringOperator_reaches_of_ne_zero`: the corresponding reachability
+  statement for the nonzero neighboring relation.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D}
+
+/-- The virtual matrix obtained from a matrix entry within physical sector
+`k`. Its `(beta, alpha)` entry is the product of the corresponding left and
+right sector-tensor entries. -/
+def sectorVirtualMatrix (F : PhysicalSectorFactorization K)
+    (k : Fin F.sectorCount) (x y : F.SectorIndex k) :
+    Matrix (Fin D) (Fin D) ℂ :=
+  fun beta alpha ↦
+    F.leftTensor k beta x.1 y.1 * F.rightTensor k alpha x.2 y.2
+
+/-- Multiplying virtual matrices from sectors `k` and `h` exposes the
+neighboring operator from `k` to `h` as the middle factor. -/
+theorem sectorVirtualMatrix_mul_apply (F : PhysicalSectorFactorization K)
+    (k h : Fin F.sectorCount) (x y : F.SectorIndex k)
+    (u v : F.SectorIndex h) (beta gamma : Fin D) :
+    (F.sectorVirtualMatrix k x y * F.sectorVirtualMatrix h u v) beta gamma =
+      F.leftTensor k beta x.1 y.1 *
+        F.neighboringOperator k h (x.2, u.1) (y.2, v.1) *
+          F.rightTensor h gamma u.2 v.2 := by
+  simp only [Matrix.mul_apply, sectorVirtualMatrix, neighboringOperator_apply]
+  rw [Finset.mul_sum, Finset.sum_mul]
+  apply Finset.sum_congr rfl
+  intro a _
+  ring
+
+/-- If the neighboring operator from `k` to `h` vanishes, then every product
+of a sector-`k` virtual matrix with a sector-`h` virtual matrix vanishes. -/
+theorem sectorVirtualMatrix_mul_eq_zero_of_neighboringOperator_eq_zero
+    (F : PhysicalSectorFactorization K) (k h : Fin F.sectorCount)
+    (hzero : F.neighboringOperator k h = 0)
+    (x y : F.SectorIndex k) (u v : F.SectorIndex h) :
+    F.sectorVirtualMatrix k x y * F.sectorVirtualMatrix h u v = 0 := by
+  ext beta gamma
+  rw [F.sectorVirtualMatrix_mul_apply k h x y u v beta gamma, hzero]
+  simp
+
+/-- The finite index type of all matrix entries within all physical sectors. -/
+abbrev SectorEntryIndex (F : PhysicalSectorFactorization K) :=
+  Σ k : Fin F.sectorCount, F.SectorIndex k × F.SectorIndex k
+
+/-- The family of virtual matrices indexed by all entries within all physical
+sectors. -/
+def sectorVirtualMatrixFamily (F : PhysicalSectorFactorization K)
+    (q : SectorEntryIndex F) : Matrix (Fin D) (Fin D) ℂ :=
+  F.sectorVirtualMatrix q.1 q.2.1 q.2.2
+
+/-- Suppose the sector virtual matrices span the full virtual matrix algebra
+and both endpoint sectors of every nonzero neighboring edge contain a nonzero
+virtual matrix. Then every nonzero edge `k → h` has a two-edge return
+`h → j → k`.
+
+Indeed, a nonzero neighboring entry gives sector matrices `A` and `B` with
+`A * B ≠ 0`. Nondegeneracy of the trace pairing and the spanning hypothesis
+give a sector matrix `C` with `trace (A * B * C) ≠ 0`. Cyclicity of the trace
+then forces both `B * C` and `C * A` to be nonzero. -/
+theorem exists_two_edge_return_of_neighboringOperator_ne_zero
+    (F : PhysicalSectorFactorization K)
+    (hspan : Submodule.span ℂ (Set.range F.sectorVirtualMatrixFamily) = ⊤)
+    (hnonzero : ∀ {k h}, F.neighboringOperator k h ≠ 0 →
+      (∃ x y : F.SectorIndex k, F.sectorVirtualMatrix k x y ≠ 0) ∧
+        ∃ x y : F.SectorIndex h, F.sectorVirtualMatrix h x y ≠ 0)
+    {k h : Fin F.sectorCount} (hkh : F.neighboringOperator k h ≠ 0) :
+    ∃ j : Fin F.sectorCount,
+      F.neighboringOperator h j ≠ 0 ∧ F.neighboringOperator j k ≠ 0 := by
+  classical
+  obtain ⟨ex, ey, heta⟩ : ∃ ex ey, F.neighboringOperator k h ex ey ≠ 0 := by
+    by_contra hall
+    push Not at hall
+    apply hkh
+    ext x y
+    exact hall x y
+  obtain ⟨⟨kx, ky, hkxy⟩, ⟨hx, hy, hhxy⟩⟩ := hnonzero hkh
+  obtain ⟨beta, alpha, hkentry⟩ :
+      ∃ beta alpha, F.sectorVirtualMatrix k kx ky beta alpha ≠ 0 := by
+    by_contra hall
+    push Not at hall
+    apply hkxy
+    ext beta alpha
+    exact hall beta alpha
+  have hkleft : F.leftTensor k beta kx.1 ky.1 ≠ 0 :=
+    left_ne_zero_of_mul hkentry
+  obtain ⟨delta, gamma, hhentry⟩ :
+      ∃ delta gamma, F.sectorVirtualMatrix h hx hy delta gamma ≠ 0 := by
+    by_contra hall
+    push Not at hall
+    apply hhxy
+    ext delta gamma
+    exact hall delta gamma
+  have hhright : F.rightTensor h gamma hx.2 hy.2 ≠ 0 :=
+    right_ne_zero_of_mul hhentry
+  let x : F.SectorIndex k := (kx.1, ex.1)
+  let y : F.SectorIndex k := (ky.1, ey.1)
+  let u : F.SectorIndex h := (ex.2, hx.2)
+  let v : F.SectorIndex h := (ey.2, hy.2)
+  let A := F.sectorVirtualMatrix k x y
+  let B := F.sectorVirtualMatrix h u v
+  have hAB : A * B ≠ 0 := by
+    intro hz
+    have hzentry := congrFun (congrFun hz beta) gamma
+    rw [Matrix.zero_apply,
+      F.sectorVirtualMatrix_mul_apply k h x y u v beta gamma] at hzentry
+    exact mul_ne_zero (mul_ne_zero hkleft heta) hhright hzentry
+  obtain ⟨Y, htraceY⟩ : ∃ Y : Matrix (Fin D) (Fin D) ℂ,
+      Matrix.trace (A * B * Y) ≠ 0 := by
+    by_contra hall
+    push Not at hall
+    exact hAB ((Matrix.trace_mul_right_eq_zero_iff (A * B)).mp hall)
+  have hYmem : Y ∈ Submodule.span ℂ (Set.range F.sectorVirtualMatrixFamily) := by
+    rw [hspan]
+    exact Submodule.mem_top
+  obtain ⟨c, hc⟩ :=
+    (Submodule.mem_span_range_iff_exists_fun ℂ).mp hYmem
+  have hsum : Matrix.trace
+      (A * B * ∑ q, c q • F.sectorVirtualMatrixFamily q) ≠ 0 := by
+    rw [hc]
+    exact htraceY
+  simp only [Matrix.mul_sum, Matrix.mul_smul, Matrix.trace_sum,
+    Matrix.trace_smul] at hsum
+  obtain ⟨q, hq⟩ : ∃ q : SectorEntryIndex F,
+      c q * Matrix.trace (A * B * F.sectorVirtualMatrixFamily q) ≠ 0 := by
+    by_contra hall
+    push Not at hall
+    exact hsum (Finset.sum_eq_zero fun q _ ↦ hall q)
+  have htraceC : Matrix.trace
+      (A * B * F.sectorVirtualMatrixFamily q) ≠ 0 :=
+    right_ne_zero_of_mul hq
+  let C := F.sectorVirtualMatrixFamily q
+  have hBC : B * C ≠ 0 := by
+    intro hz
+    apply htraceC
+    rw [← Matrix.trace_mul_cycle B C A, hz, Matrix.zero_mul,
+      Matrix.trace_zero]
+  have hCA : C * A ≠ 0 := by
+    intro hz
+    apply htraceC
+    rw [Matrix.trace_mul_cycle A B C, hz, Matrix.zero_mul,
+      Matrix.trace_zero]
+  refine ⟨q.1, ?_, ?_⟩
+  · intro hz
+    exact hBC (F.sectorVirtualMatrix_mul_eq_zero_of_neighboringOperator_eq_zero
+      h q.1 hz u v q.2.1 q.2.2)
+  · intro hz
+    exact hCA (F.sectorVirtualMatrix_mul_eq_zero_of_neighboringOperator_eq_zero
+      q.1 k hz q.2.1 q.2.2 x y)
+
+/-- Under the spanning and endpoint-nonvanishing hypotheses, the terminal
+sector of every nonzero neighboring edge reaches its initial sector through
+nonzero neighboring edges. The return path supplied here has length two. -/
+theorem neighboringOperator_reaches_of_ne_zero
+    (F : PhysicalSectorFactorization K)
+    (hspan : Submodule.span ℂ (Set.range F.sectorVirtualMatrixFamily) = ⊤)
+    (hnonzero : ∀ {k h}, F.neighboringOperator k h ≠ 0 →
+      (∃ x y : F.SectorIndex k, F.sectorVirtualMatrix k x y ≠ 0) ∧
+        ∃ x y : F.SectorIndex h, F.sectorVirtualMatrix h x y ≠ 0)
+    {k h : Fin F.sectorCount} (hkh : F.neighboringOperator k h ≠ 0) :
+    Relation.ReflTransGen (fun a b ↦ F.neighboringOperator a b ≠ 0) h k := by
+  obtain ⟨j, hhj, hjk⟩ :=
+    F.exists_two_edge_return_of_neighboringOperator_ne_zero hspan hnonzero hkh
+  exact Relation.ReflTransGen.head hhj (Relation.ReflTransGen.single hjk)
+
+end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/PhysicalSectorVirtualSpanning.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorVirtualSpanning.lean
@@ -1,0 +1,168 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalSectorCoordinateTransport
+import TNLean.MPS.MPDO.PhysicalSectorSupportRecurrence
+
+/-!
+# Spanning by physical-sector virtual matrices
+
+An isometric change of physical coordinates preserves the span of the virtual
+matrices of an MPO tensor. For a physical-sector factorization, the entries in
+the new coordinates are either zero or the virtual matrices obtained from one
+sector. Consequently, injectivity of the original tensor implies that all
+sector virtual matrices span the full virtual matrix algebra.
+
+## References
+
+- [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, equations `AppUkU=rl` and `formK`, lines 1383--1387 and
+  1434--1439
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d e D : ℕ}
+
+/-- An isometric change of physical coordinates can be inverted entrywise by
+the adjoint change of coordinates. -/
+theorem changePhysicalBasis_inverse_apply_eq_sum
+    (V : Matrix (Fin e) (Fin d) ℂ) (M : MPOTensor d D)
+    (hV : Vᴴ * V = 1) (i j : Fin d) :
+    M i j = ∑ x : Fin e, ∑ y : Fin e,
+      (star (V x i) * V y j) • changePhysicalBasis V M x y := by
+  ext beta alpha
+  have hmatrix :
+      Vᴴ * (V * physicalSlice M beta alpha * Vᴴ) * V =
+        physicalSlice M beta alpha := by
+    calc
+      Vᴴ * (V * physicalSlice M beta alpha * Vᴴ) * V =
+          (Vᴴ * V) * physicalSlice M beta alpha * (Vᴴ * V) := by
+            simp only [Matrix.mul_assoc]
+      _ = physicalSlice M beta alpha := by rw [hV]; simp
+  have hentry := congrFun (congrFun hmatrix i) j
+  change physicalSlice M beta alpha i j =
+    (∑ x : Fin e, ∑ y : Fin e,
+      (star (V x i) * V y j) • changePhysicalBasis V M x y) beta alpha
+  rw [← hentry]
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, physicalSlice,
+    Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul, changePhysicalBasis]
+  simp_rw [Finset.mul_sum, Finset.sum_mul]
+  simp_rw [Finset.mul_sum, Finset.sum_mul]
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro x _
+  apply Finset.sum_congr rfl
+  intro y _
+  apply Finset.sum_congr rfl
+  intro q _
+  apply Finset.sum_congr rfl
+  intro p _
+  ring
+
+variable {K : MPOTensor d D}
+
+/-- The family of virtual matrices obtained from all pairs of physical
+indices in sector coordinates. -/
+noncomputable def sectorCoordinateMatrixFamily (F : PhysicalSectorFactorization K)
+    (q : Fin (Fintype.card (Σ k : Fin F.sectorCount, F.SectorIndex k)) ×
+      Fin (Fintype.card (Σ k : Fin F.sectorCount, F.SectorIndex k))) :
+    Matrix (Fin D) (Fin D) ℂ :=
+  F.sectorCoordinateTensor q.1 q.2
+
+/-- If the original MPO tensor is injective, its matrices in sector
+coordinates still span the full virtual matrix algebra. -/
+theorem sectorCoordinateMatrixFamily_span_eq_top
+    (F : PhysicalSectorFactorization K) (hK : K.IsInjective) :
+    Submodule.span ℂ (Set.range F.sectorCoordinateMatrixFamily) = ⊤ := by
+  classical
+  let S := Submodule.span ℂ (Set.range F.sectorCoordinateMatrixFamily)
+  have hKmem (i j : Fin d) : K i j ∈ S := by
+    have hrepr := changePhysicalBasis_inverse_apply_eq_sum
+      F.physicalCoordinateMatrix K F.physicalCoordinateMatrix_isometry i j
+    rw [← F.sectorCoordinateTensor_eq_changePhysicalBasis] at hrepr
+    rw [hrepr]
+    apply Submodule.sum_mem
+    intro x _
+    apply Submodule.sum_mem
+    intro y _
+    apply Submodule.smul_mem
+    exact Submodule.subset_span (Set.mem_range_self (x, y))
+  rw [Submodule.eq_top_iff']
+  intro Y
+  have hY : Y ∈ Submodule.span ℂ (Set.range K.toMPSTensor) := by
+    rw [hK]
+    exact Submodule.mem_top
+  induction hY using Submodule.span_induction with
+  | mem X hX =>
+      obtain ⟨p, rfl⟩ := hX
+      simpa [MPOTensor.toMPSTensor] using hKmem p.divNat p.modNat
+  | zero => exact Submodule.zero_mem S
+  | add X Y _ _ hX hY => exact Submodule.add_mem S hX hY
+  | smul c X _ hX => exact Submodule.smul_mem S c hX
+
+/-- Every physical matrix entry in sector coordinates belongs to the span of
+the within-sector virtual matrices. Off-diagonal sector entries vanish. -/
+theorem sectorCoordinateTensor_mem_span_sectorVirtualMatrixFamily
+    (F : PhysicalSectorFactorization K)
+    (i j : Fin (Fintype.card (Σ k : Fin F.sectorCount, F.SectorIndex k))) :
+    F.sectorCoordinateTensor i j ∈
+      Submodule.span ℂ (Set.range F.sectorVirtualMatrixFamily) := by
+  classical
+  generalize hi : F.sectorFinEquiv i = si
+  generalize hj : F.sectorFinEquiv j = sj
+  obtain ⟨k, x⟩ := si
+  obtain ⟨h, y⟩ := sj
+  have hi' : i = F.sectorFinEquiv.symm ⟨k, x⟩ := by
+    apply F.sectorFinEquiv.injective
+    rw [Equiv.apply_symm_apply, hi]
+  have hj' : j = F.sectorFinEquiv.symm ⟨h, y⟩ := by
+    apply F.sectorFinEquiv.injective
+    rw [Equiv.apply_symm_apply, hj]
+  subst i
+  subst j
+  by_cases hkh : k = h
+  · subst h
+    have heq : F.sectorCoordinateTensor
+        (F.sectorFinEquiv.symm ⟨k, x⟩) (F.sectorFinEquiv.symm ⟨k, y⟩) =
+        F.sectorVirtualMatrix k x y := by
+      ext beta alpha
+      simp [sectorVirtualMatrix]
+    rw [heq]
+    apply Submodule.subset_span
+    exact ⟨⟨k, (x, y)⟩, rfl⟩
+  · have heq : F.sectorCoordinateTensor
+        (F.sectorFinEquiv.symm ⟨k, x⟩) (F.sectorFinEquiv.symm ⟨h, y⟩) = 0 := by
+      ext beta alpha
+      simpa using F.sectorCoordinateTensor_apply_ne hkh x y beta alpha
+    rw [heq]
+    exact Submodule.zero_mem _
+
+/-- The virtual matrices obtained from all entries within all physical sectors
+span the full virtual matrix algebra whenever the original MPO tensor is
+injective.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl` and `formK`,
+lines 1383--1387 and 1434--1439. -/
+theorem sectorVirtualMatrixFamily_span_eq_top
+    (F : PhysicalSectorFactorization K) (hK : K.IsInjective) :
+    Submodule.span ℂ (Set.range F.sectorVirtualMatrixFamily) = ⊤ := by
+  rw [Submodule.eq_top_iff']
+  intro Y
+  have hY : Y ∈ Submodule.span ℂ (Set.range F.sectorCoordinateMatrixFamily) := by
+    rw [F.sectorCoordinateMatrixFamily_span_eq_top hK]
+    exact Submodule.mem_top
+  induction hY using Submodule.span_induction with
+  | mem X hX =>
+      obtain ⟨q, rfl⟩ := hX
+      exact F.sectorCoordinateTensor_mem_span_sectorVirtualMatrixFamily q.1 q.2
+  | zero => exact Submodule.zero_mem _
+  | add X Y _ _ hX hY => exact Submodule.add_mem _ hX hY
+  | smul c X _ hX => exact Submodule.smul_mem _ c hX
+
+end MPOTensor.PhysicalSectorFactorization
+

--- a/TNLean/MPS/MPDO/PhysicalSectorVirtualSpanning.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorVirtualSpanning.lean
@@ -165,4 +165,3 @@ theorem sectorVirtualMatrixFamily_span_eq_top
   | smul c X _ hX => exact Submodule.smul_mem _ c hX
 
 end MPOTensor.PhysicalSectorFactorization
-

--- a/TNLean/MPS/MPDO/SectorRecurrence.lean
+++ b/TNLean/MPS/MPDO/SectorRecurrence.lean
@@ -35,8 +35,11 @@ The recurrence declarations and the phase-uniqueness theorem
 `Matrix.exists_pos_real_smul_eq_of_smul_posSemidef` prepare the coherent
 rephasing argument in `TNLean.MPS.MPDO.RecurrentSectorRephasing`. That later
 module combines the choices from different cycles under the recurrence
-hypothesis. No proved theorem derives recurrence from injectivity. In
-particular, the fixed-cycle theorem below does not use recurrence.
+hypothesis. For the inverse-map physical-sector factorization, recurrence after
+zero-weight reparameterization is derived from injectivity in
+`TNLean.MPS.MPDO.InverseMapActiveSectorRecurrence`. The fixed-cycle theorem
+below applies to a general neighboring-operator family and does not use
+recurrence.
 
 ## Main declarations
 
@@ -60,12 +63,14 @@ particular, the fixed-cycle theorem below does not use recurrence.
 - `MPOTensor.exists_pi_smul_posSemidef_of_sectorEta_cycle`: the preceding
   fixed-cycle result for the concrete inverse-map neighboring operators.
 
-## What remains
+## Scope
 
-Deriving `IsRecurrentSupport` unconditionally from injectivity of `𝒦` remains
-open and is recorded in the paper-gap note. Conditional on recurrence,
-`TNLean.MPS.MPDO.RecurrentSectorRephasing` propagates the per-cycle choices
-into a single vertex-indexed rephasing.
+For a general neighboring-operator family, recurrence remains a hypothesis.
+Conditional on it, `TNLean.MPS.MPDO.RecurrentSectorRephasing` propagates the
+per-cycle choices into a single vertex-indexed rephasing. The concrete
+inverse-map family arising from an injective tensor satisfies recurrence after
+zero-weight reparameterization, as proved in
+`TNLean.MPS.MPDO.InverseMapActiveSectorRecurrence`.
 
 ## References
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -2656,6 +2656,35 @@ strong subadditivity for a normalized three-site reduced state.
     can reach $k$ whenever $k\to h$ is an edge.
 \end{definition}
 
+\begin{theorem}[Sector spanning from injectivity]%
+    \label{thm:mpdo_sector_virtual_matrix_spanning}
+    \lean{MPOTensor.PhysicalSectorFactorization.changePhysicalBasis_inverse_apply_eq_sum}
+    \lean{MPOTensor.PhysicalSectorFactorization.sectorCoordinateMatrixFamily}
+    \lean{MPOTensor.PhysicalSectorFactorization.sectorCoordinateMatrixFamily_span_eq_top}
+    \lean{MPOTensor.PhysicalSectorFactorization.sectorCoordinateTensor_mem_span_sectorVirtualMatrixFamily}
+    \lean{MPOTensor.PhysicalSectorFactorization.sectorVirtualMatrixFamily_span_eq_top}
+    \leanok
+    \uses{def:mpdo_physical_sector_factorization}
+    Let ${\cal K}$ be injective and let
+    \[
+      U\kappa_{\beta,\alpha}U^\dagger
+      =\bigoplus_k(l_k)_\beta\otimes(r_k)_\alpha
+    \]
+    be a physical-sector factorization. Then the virtual matrices
+    $A_{k;x,y}$ obtained from all within-sector physical entries span the full
+    virtual matrix algebra $\MN{D}$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Since $U$ is unitary, every original physical matrix of ${\cal K}$ is a
+    linear combination of the matrices in the transformed physical
+    coordinates. The off-diagonal sector entries in those coordinates vanish,
+    while each diagonal sector entry is one of the matrices $A_{k;x,y}$.
+    Injectivity says that the original physical matrices span $\MN{D}$, and
+    the conclusion follows.
+\end{proof}
+
 \begin{theorem}[Triangle closure from sector spanning]%
     \label{thm:mpdo_sector_support_triangle_closure}
     \lean{MPOTensor.PhysicalSectorFactorization.sectorVirtualMatrix}
@@ -3000,8 +3029,10 @@ strong subadditivity for a normalized three-site reduced state.
 
     This is a scope-restricted result. Recurrence is not a hypothesis of
     Lemma~C.4 in
-    \cite[Appendix~C.2, lines~1406--1450]{Cirac2016MPDO_arXiv}; its derivation
-    from the source hypotheses remains open.
+    \cite[Appendix~C.2, lines~1406--1450]{Cirac2016MPDO_arXiv}. Its derivation
+    for the normalized inverse-map factorization is treated in
+    Theorem~\ref{thm:mpdo_eta_coherent_positive_choice} and recorded in
+    \path{docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex}.
 \end{theorem}
 % The recurrence gap is documented in
 % docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex.
@@ -3032,39 +3063,54 @@ strong subadditivity for a normalized three-site reduced state.
 
 \begin{theorem}[Coherent positive choice of the neighboring operators]%
     \label{thm:mpdo_eta_coherent_positive_choice}
-    \notready
-    \uses{def:mpdo, def:injective, def:normal, def:is_sal,
-        def:mpdo_sector_eta, thm:mpdo_exists_sector_factorization}
-    Let ${\cal K}$ be an injective normal tensor that generates MPDOs and
-    satisfies SAL. The sector tensors in the factorization of
-    Theorem~\ref{thm:mpdo_exists_sector_factorization} can be chosen so
-    that every neighboring operator
+    \lean{MPOTensor.conjugated_middle_threeSiteClosure}
+    \lean{MPOTensor.exists_active_sectorVirtualMatrix_ne_zero}
+    \lean{MPOTensor.zeroWeightReparameterizedInverseMapPhysicalSectorFactorization_isRecurrentSupport}
+    \lean{MPOTensor.exists_positive_inverseMapPhysicalSectorFactorization}
+    \lean{MPOTensor.exists_positive_physicalSectorFactorization_of_isSAL}
+    \leanok
+    \uses{def:mpdo, def:injective, def:is_sal,
+        def:mpdo_sector_eta,
+        def:mpdo_zero_weight_reparameterized_inverse_map_factorization,
+        thm:mpdo_zero_weight_reparameterized_neighboring_operator,
+        thm:mpdo_sector_virtual_matrix_spanning,
+        thm:mpdo_sector_support_triangle_closure,
+        thm:mpdo_eta_coherent_positive_choice_recurrent}
+    Let ${\cal K}$ be an injective MPO tensor satisfying SAL. Then it admits
+    a physical-sector factorization for which every neighboring operator
     \[
         \eta_{k,h}=r_k l_h
     \]
-    is positive semidefinite, while the all-length cyclic sector
-    decomposition remains unchanged.
+    is positive semidefinite. Zero-weight Hayashi sectors remain in the
+    physical direct sum, but their right tensors may be set to zero without
+    changing the physical slices.
 \end{theorem}
 
 \begin{proof}
+    \leanok
     \uses{def:mpdo_eta_recurrent_support,
         thm:mpdo_cyclic_eta_posSemidef,
         thm:mpdo_eta_cycle_positive_rescaling,
-        thm:mpdo_sector_adapted_decomposition,
+        def:mpdo_zero_weight_reparameterized_inverse_map_factorization,
+        thm:mpdo_zero_weight_reparameterized_neighboring_operator,
+        thm:mpdo_sector_virtual_matrix_spanning,
+        thm:mpdo_sector_support_triangle_closure,
         thm:positive_rescaling_phase_unique,
         thm:directed_cycle_coboundary,
         thm:mpdo_eta_coherent_positive_choice_recurrent}
-    The projected chain identity makes every cyclic Kronecker product of the
-    neighboring operators positive semidefinite.
-    Theorem~\ref{thm:mpdo_eta_coherent_positive_choice_recurrent} completes
-    the phase-uniqueness, trivial-holonomy, and vertex-rephasing argument once
-    recurrence is known. The remaining obligation is therefore to remove
-    zero-weight Hayashi summands and derive recurrence of the resulting
-    nonzero inverse-map support from the actual injective normal-tensor
-    hypotheses, without using the later primitivity conclusion. This is the
-    last missing part of the coherent-choice step asserted at
-    \cite[Appendix~C.2, lines~1446--1450]{Cirac2016MPDO_arXiv}; it is not a
-    consequence of positivity of the cyclic products alone.
+    First set the right tensor to zero in every zero-weight sector. The left
+    tensor already vanishes there, so this does not alter the factorization
+    and removes every support edge incident to such a sector. Every remaining
+    endpoint has positive weight. If all virtual matrices in a positive-weight
+    sector vanished, then the corresponding middle-site block of the
+    three-site closure would vanish; this contradicts its Hayashi expression
+    as a nonzero weight times two trace-one sector states. Thus every endpoint
+    of a nonzero edge contains a nonzero virtual matrix. Injectivity supplies
+    spanning by all sector virtual matrices, and triangle closure gives
+    recurrence. The projected chain identity makes every cyclic Kronecker
+    product positive semidefinite. Apply
+    Theorem~\ref{thm:mpdo_eta_coherent_positive_choice_recurrent} to obtain the
+    coherent vertex rephasing.
 \end{proof}
 
 \begin{theorem}[Positivity choice with symmetric support]%

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -3045,7 +3045,7 @@ strong subadditivity for a normalized three-site reduced state.
     This is a scope-restricted result. Recurrence is not a hypothesis of
     Lemma~C.4 in
     \cite[Appendix~C.2, lines~1406--1450]{Cirac2016MPDO_arXiv}. Its derivation
-    for the normalized inverse-map factorization is treated in
+    for the zero-weight reparameterized inverse-map factorization is treated in
     Theorem~\ref{thm:mpdo_eta_coherent_positive_choice} and recorded in
     \path{docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex}.
 \end{theorem}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -2656,6 +2656,42 @@ strong subadditivity for a normalized three-site reduced state.
     can reach $k$ whenever $k\to h$ is an edge.
 \end{definition}
 
+\begin{theorem}[Triangle closure from sector spanning]%
+    \label{thm:mpdo_sector_support_triangle_closure}
+    \lean{MPOTensor.PhysicalSectorFactorization.sectorVirtualMatrix}
+    \lean{MPOTensor.PhysicalSectorFactorization.sectorVirtualMatrix_mul_apply}
+    \lean{MPOTensor.PhysicalSectorFactorization.exists_two_edge_return_of_neighboringOperator_ne_zero}
+    \lean{MPOTensor.PhysicalSectorFactorization.neighboringOperator_reaches_of_ne_zero}
+    \leanok
+    \uses{def:mpdo_physical_sector_factorization,
+        def:mpdo_minimal_neighboring_operator,
+        thm:trace_nondeg}
+    For a physical-sector factorization, let $A_{k;x,y}\in\MN{D}$ be the
+    virtual matrix obtained from the physical matrix entry $(x,y)$ within
+    sector $k$. Suppose that all such matrices span $\MN{D}$ and that both
+    endpoint sectors of every nonzero neighboring operator contain a nonzero
+    matrix of this form. Then every nonzero $\eta_{k,h}$ admits a two-edge
+    return: there is a sector $j$ for which
+    \[
+        \eta_{h,j}\ne0,
+        \qquad
+        \eta_{j,k}\ne0.
+    \]
+    In particular, the nonzero neighboring support is recurrent.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:trace_nondeg}
+    A nonzero entry of $\eta_{k,h}$, together with nonzero sector matrices at
+    $k$ and $h$, gives matrices $A$ from sector $k$ and $B$ from sector $h$
+    with $AB\ne0$. By nondegeneracy of the trace pairing, choose $Y$ with
+    $\tr(ABY)\ne0$. Expanding $Y$ in the spanning family, some sector matrix
+    $C$ from a sector $j$ satisfies $\tr(ABC)\ne0$. Cyclicity of the trace
+    gives $BC\ne0$ and $CA\ne0$. The sector multiplication identity then
+    forces $\eta_{h,j}\ne0$ and $\eta_{j,k}\ne0$.
+\end{proof}
+
 \begin{lemma}[Equivalent forms of sector reachability]%
     \label{lem:mpdo_eta_reachability_equivalence}
     \lean{TNLean.Algebra.DirectedWalk.reaches_iff_reflTransGen}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -2634,13 +2634,8 @@ strong subadditivity for a normalized three-site reduced state.
     \lean{Matrix.submodule_sup_ne_top_of_mul_eq_zero}
     \leanok
     Let $\mathcal A_1,\mathcal A_2\subseteq\MN{D}$ be nonzero linear
-    subspaces. If
-    \[
-        XY=0
-        \qquad
-        (X\in\mathcal A_1,\;Y\in\mathcal A_2),
-    \]
-    then
+    subspaces. If $XY=0$ for every $X\in\mathcal A_1$ and
+    $Y\in\mathcal A_2$, then
     \[
         \mathcal A_1+\mathcal A_2\ne\MN{D}.
     \]
@@ -5249,48 +5244,68 @@ $\widehat{\cal K}$.
     \label{fig:mpdo_local_orthogonality}
 \end{figure}
 
-\begin{theorem}[Primitivity of the concrete sector trace matrix]%
+\begin{theorem}[Primitivity of the active sector trace matrix]%
     \label{thm:mpdo_sector_trace_matrix_primitive}
     \notready
-    \uses{def:mpdo, def:injective, def:normal, def:is_sal,
+    \uses{def:mpdo, def:injective, def:is_sal,
         def:mpdo_explicit_eta_of_sector_tensors,
         thm:mpdo_eta_coherent_positive_choice,
-        lem:mpdo_local_orthogonality_contraction,
         thm:mpdo_sector_eta_data_trace_matrix}
-    Let ${\cal K}$ be an injective normal tensor that generates MPDOs and
+    Let ${\cal K}$ be an injective tensor that generates MPDOs and
     satisfies SAL, and choose the positive neighboring operators of
-    Theorem~\ref{thm:mpdo_eta_coherent_positive_choice}. Then the nonnegative
+    Theorem~\ref{thm:mpdo_eta_coherent_positive_choice}. Restrict the sector
+    index to the positive-weight summands of the Hayashi decomposition. Then
+    the nonnegative
     matrix
     \[
         T_{k,h}=\tr(\eta_{k,h})
     \]
     is primitive.
+
+    \emph{Local fix (inactive sectors):} the physical direct sum retains
+    zero-weight summands, but the normalized factorization makes every
+    neighboring operator incident to such a summand zero. Hence the trace
+    matrix on the full ambient sector set has a zero row and column and cannot
+    be primitive. The primitive matrix asserted by the source is the
+    restriction to its effective, positive-weight sector set. This is recorded
+    in
+    \path{docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex}.
 \end{theorem}
 
 \begin{proof}
     \uses{def:mpdo_eta_recurrent_support,
         def:mpdo_zero_weight_reparameterized_inverse_map_factorization,
         thm:mpdo_zero_weight_reparameterized_neighboring_operator,
+        thm:mpdo_sector_virtual_matrix_spanning,
+        thm:mpdo_sector_support_triangle_closure,
         lem:mpdo_local_orthogonality_contraction,
         thm:mpdo_directed_cut_one_site_spaces,
         lem:matrix_one_sided_product_obstruction}
     First use the zero-weight reparameterization to make every zero-weight
-    sector isolated. Suppose that the retained support is not strongly
-    connected. The sectors reachable from a fixed retained sector then contain
-    a nonempty proper forward-closed set $S$; write $C$ for its complement.
-    There are no neighboring edges from $S$ to $C$.
+    sector isolated. The spanning theorem and the trace-pairing argument close
+    every nonzero edge through a third sector, so the active support is
+    recurrent.
+
+    Suppose that the active support is not strongly connected. The sectors
+    reachable from a fixed active sector then form a nonempty proper
+    forward-closed set $S$; write $C$ for its complement. There are no
+    neighboring edges from $S$ to $C$.
 
     Let ${\cal A}_S$ and ${\cal A}_C$ be the one-site matrix spaces belonging
-    to the two classes. The directed-cut theorem gives
-    ${\cal A}_S{\cal A}_C=0$. The source argument still requires two bridges:
-    both spaces are nonzero, and injectivity in the physical sector coordinates
-    gives ${\cal A}_S+{\cal A}_C=\MN{D}$. Once these are established,
+    to the two classes. Positive sector weights make both spaces nonzero.
+    Injectivity in physical sector coordinates gives
+    ${\cal A}_S+{\cal A}_C=\MN{D}$, while the directed-cut theorem gives
+    ${\cal A}_S{\cal A}_C=0$. Hence
     Lemma~\ref{lem:matrix_one_sided_product_obstruction} gives the desired
     contradiction. No vanishing in the reverse order is needed. This is the
     directed-cut argument at
-    \cite[Appendix~C.2, lines~1452--1470]{Cirac2016MPDO_arXiv}; formalizing the
-    two bridges, and then the passage from the resulting recurrent positive
-    support to primitivity of $T$, remains open.
+    \cite[Appendix~C.2, lines~1452--1470]{Cirac2016MPDO_arXiv}.
+
+    Finally, nondegeneracy and cyclicity of the trace pairing give a closed
+    support walk of length two through every active sector. Triangle closure
+    gives one of length three. Strong connectivity together with these two
+    coprime return lengths yields a common length at which every entry of the
+    active trace-matrix power is positive. Thus $T$ is primitive.
 \end{proof}
 
 \begin{theorem}[Positivity of bipartite partial traces]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -1959,6 +1959,26 @@ strong subadditivity for a normalized three-site reduced state.
     realizes every finite-chain operator with normalization scalar $1$.
 \end{proof}
 
+\begin{corollary}[$\eta$-local structure from SAL]%
+    \label{cor:mpdo_eta_local_structure_of_is_sal}
+    \lean{MPOTensor.nonempty_etaLocalStructureData_of_isSAL}
+    \leanok
+    \uses{thm:mpdo_eta_local_structure_of_positive_physical_sector_factorization,
+      thm:mpdo_eta_coherent_positive_choice}
+    Every injective MPO tensor satisfying SAL admits an $\eta$-local
+    structure.  Thus there is a single positive two-site bond whose cyclic
+    translates commute pairwise and whose ordered product is the finite-chain
+    density operator at every length $N\geq2$, with normalization scalar one.
+    This is the conclusion of Proposition~C.8.
+\end{corollary}
+
+\begin{proof}
+    \leanok
+    Theorem~\ref{thm:mpdo_eta_coherent_positive_choice} supplies the positive
+    physical-sector factorization. Apply
+    Theorem~\ref{thm:mpdo_eta_local_structure_of_positive_physical_sector_factorization}.
+\end{proof}
+
 \subsection{Closed-sector contractions and coherent rephasing}
 
 \begin{definition}[Closed sector tensors]%

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -614,9 +614,11 @@ remaining trace-matrix primitivity statement is tracked by
 \href{https://github.com/LionSR/TNLean/issues/3696}{issue \#3696}.  The positive
 commuting bond, its exact all-length product realization, and the resulting
 eta-local structure of Proposition \texttt{3to4} are already available from a
-coherently positive physical-sector factorization; their direct composition
-with the new SAL theorem remains to be recorded before Proposition~C.8 is
-presented as unconditionally formalized from its source hypotheses.
+coherently positive physical-sector factorization.  Their composition with
+the new SAL theorem is
+\leanid{MPOTensor.nonempty_etaLocalStructureData_of_isSAL}, so the
+$\eta$-local conclusion of Proposition~C.8 is now formalized from its source
+hypotheses.
 
 \section{Classification}
 
@@ -640,9 +642,9 @@ scalar one, and they determine the eta-local structure data. The raw
 physical-sector factorization already follows for an injective tensor
 satisfying SAL, and the coherent positive choice is now obtained by
 normalizing the inactive sectors and deriving recurrence from injectivity.
-The remaining work is to compose this factorization with the already
-formalized positive commuting-bond construction and to discharge the later
-trace-matrix primitivity step.
+The remaining work in this part of the paper is the later trace-matrix
+primitivity step; it is logically separate from the commuting-bond
+construction.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -262,12 +262,13 @@ statements are
 \path{MPOTensor.PhysicalSectorFactorization.mpo_submatrix_sector_eq_cyclicNeighboringProduct}
 and
 \path{MPOTensor.PhysicalSectorFactorization.mpo_reindex_sectorChainEquiv_eq_blockDiagonal}.}
-What remains in Lemma \texttt{propSN} is the positive choice of the individual
-$\eta_{k,h}$ and the local-orthogonality argument establishing primitivity of
-the sector trace matrix.  Positivity of a complete cyclic product does not by
-itself supply coherent positive representatives for all neighboring pairs;
-the missing argument must control these choices simultaneously across the
-sector graph.
+The positive choice of the individual $\eta_{k,h}$ is now obtained for the
+inverse-map factorization by isolating zero-weight sectors, deriving recurrence
+from injectivity, and applying coherent vertex rephasing.  Positivity of a
+complete cyclic product alone would not suffice: the recurrence and
+injectivity argument is essential.  What remains in Lemma \texttt{propSN} is
+the local-orthogonality argument establishing primitivity of the sector trace
+matrix on the positive-weight sector set.
 
 The positivity half of the projected chain identity is now formalized: for
 an MPDO, the chain of the physically conjugated tensor is a congruence of

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -296,15 +296,13 @@ $\eta_{k,h}\otimes\eta_{h,k}$.\footnote{The formal declarations are
 \path{MPOTensor.exists_smul_posSemidef_sectorEta}, and
 \path{MPOTensor.exists_explicitEtaOperators_sectorEta}.}
 
-Two aspects of the source's positive choice remain open.  First, the
-symmetric-support hypothesis is not stated in the source; it is neither
-implied by nor implies the recurrence hypothesis below, and either must be
-derived from injectivity or recorded as a scope restriction.  Second, the
-pairwise choice preserves the chain blocks of length at most two, whereas
-the source's choice rescales the sector tensors themselves and therefore
-preserves the blocks of every length simultaneously; the coherent choice
-across the whole sector graph is exactly the vertex-rephasing problem
-described next.
+The pairwise construction has two limitations.  Its symmetric-support
+hypothesis is not stated in the source, and it preserves only the chain blocks
+of length at most two.  The source instead rescales the sector tensors and
+therefore preserves every length simultaneously.  These limitations are
+overcome below by deactivating zero-weight sectors, proving recurrence of the
+remaining support, and applying a vertex rephasing across the whole sector
+graph.
 
 The obstruction is already present when every neighboring bond space is
 one-dimensional.  Take four sectors $0,1,2,3$ and set
@@ -325,16 +323,15 @@ $z_1=z_0$, $z_2=z_0$, and $z_3=z_1$, respectively.  The transformed edge
 $2\to3$ then still has phase $i$.  Hence no coherent choice of sector phases
 makes all four nonzero neighboring operators positive.
 
-A sufficient additional hypothesis is recurrence of the nonzero support:
+A sufficient condition for the graph-theoretic rephasing step is recurrence
+of the nonzero support:
 every nonzero directed edge lies on a nonzero directed cycle.  Under this
 hypothesis, positivity of all cyclic tensor products would first show that
 each edge is a phase times a positive operator, then force trivial phase
 around every cycle, and finally permit a coherent choice of vertex phases.
-The source does not state this recurrence hypothesis.  It must therefore be
-derived independently from injectivity, or the positive-choice theorem must
-be recorded as scope-restricted.  The later primitivity argument cannot be
-used for this purpose without circularity, since the source defines the
-nonnegative trace matrix only after choosing positive neighboring operators.
+The source does not state recurrence as a hypothesis.  It is derived below
+from injectivity after zero-weight sectors are deactivated.  This derivation
+does not use the later primitivity argument, and hence avoids circularity.
 
 For the present formal notion of a Hayashi decomposition, recurrence is false
 even for the concrete inverse-map neighboring operators.  The reason is that
@@ -382,8 +379,16 @@ trace pairing.\footnote{The formal declarations are
 \leanid{MPOTensor.PhysicalSectorFactorization.exists_two_edge_return_of_neighboringOperator_ne_zero},
 and
 \leanid{MPOTensor.PhysicalSectorFactorization.neighboringOperator_reaches_of_ne_zero}.}
-The remaining concrete obligations are to derive the spanning and
-sector-nonvanishing hypotheses from the injective inverse-map construction.
+Injectivity now supplies the spanning hypothesis for every physical-sector
+factorization.\footnote{This is
+\leanid{MPOTensor.PhysicalSectorFactorization.sectorVirtualMatrixFamily_span_eq_top}.}
+Positive-weight endpoint nonvanishing is now proved directly from the
+three-site closure and the Hayashi state decomposition.\footnote{The formal
+declaration is
+\leanid{MPOTensor.exists_active_sectorVirtualMatrix_ne_zero}.}
+Consequently the zero-weight reparameterized inverse-map support is recurrent,
+by injective spanning and triangle closure.\footnote{This is
+\leanid{MPOTensor.zeroWeightReparameterizedInverseMapPhysicalSectorFactorization_isRecurrentSupport}.}
 
 \subsection{Recurrence of the sector support graph: definitions and the
 per-cycle rescaling}
@@ -464,23 +469,25 @@ have all products vanish in one order.
 The zero-weight reparameterization is now formalized: it retains every
 physical summand, sets the right sector tensor to zero when its Hayashi weight
 vanishes, and thereby isolates every zero-weight sector without changing the
-physical slices.  On the retained positive-weight support, let $S$ be a
-nonempty proper forward-closed set and let $C$ be its complement.  The absence
-of edges from $S$ to $C$ now gives
-$\mathcal A_S\mathcal A_C=0$ by
-\leanid{MPOTensor.PhysicalSectorFactorization.oneSiteSectorSpace_mul_eq_zero}.
-Injectivity should give
-$\mathcal A_S+\mathcal A_C=M_D(\mathbb C)$, while nontriviality of the two
-parts should make both spaces nonzero.  The formalized obstruction would
-then give a contradiction.  No absence of edges from $C$ to $S$ is needed.
+physical slices.  The concrete inverse-map construction gives a short proof
+of recurrence.  Positive-weight sectors contain nonzero virtual matrices,
+injectivity makes the full sector family span $M_D(\mathbb C)$, and the
+trace-pairing argument closes every nonzero edge through a third sector.
+Thus recurrence is a conclusion, not an additional hypothesis.
 
-The remaining statements needed for this application are separate from the
-matrix-algebra lemma: physical unitary reparameterization must be shown to
-preserve the injective one-site span, positive-weight sectors must contribute
-nonzero one-site matrix spaces.  The abstract four-sector phase example
-remains a counterexample to cyclic positivity alone, but it need not satisfy
-these inverse-map and injectivity consequences.  Thus no recurrence theorem
-is asserted here.
+For the stronger one-component assertion used in trace-matrix primitivity,
+let $S$ be a nonempty proper forward-closed set of positive-weight sectors and
+let $C$ be its complement.  The source argument obtains
+$\mathcal A_S\mathcal A_C=0$ from the absence of edges from $S$ to $C$; this
+directed-cut implication is formalized by
+\leanid{MPOTensor.PhysicalSectorFactorization.oneSiteSectorSpace_mul_eq_zero}.
+The spanning and positive-weight nontriviality results above supply the two
+remaining inputs for the one-sided product obstruction.  Their assembly into
+the one-component conclusion, followed by the passage from one-component
+positive support to primitivity of the active trace matrix, remains open.  No
+absence of edges from $C$ to $S$ is needed.  The abstract four-sector phase
+example remains a counterexample to cyclic positivity alone, but it does not
+satisfy the additional inverse-map and injectivity consequences used here.
 
 \subsection{Coherent vertex rephasing under recurrence}
 
@@ -513,7 +520,7 @@ The proof chooses one representative of each reachability component and
 defines the vertex weight by multiplication along a path from that
 representative; a common return path proves independence of the chosen path.
 
-The MPDO-specific bridge is now formalized under the recurrence hypothesis.
+The general MPDO-specific bridge is formalized under a recurrence hypothesis.
 For every nonzero neighboring operator, a directed return path closes the
 edge into a nonzero cycle.  Positive rescaling of that cyclic tensor product
 therefore supplies a unit phase that makes the edge operator positive
@@ -531,11 +538,14 @@ Composing the positive rephased factorization with the conditional bond
 construction gives
 \leanid{MPOTensor.nonempty_etaLocalStructureData_of_recurrentSupport}.
 
-This result is explicitly a scope restriction: recurrence is an additional
-hypothesis not present in Lemma~C.4.  The zero-weight reparameterization is
-now formalized.  The remaining elimination problem is to derive recurrence
-for its neighboring operators from injectivity by the directed-cut argument
-above, without appealing to the later primitivity conclusion.
+This general result is explicitly scope-restricted: recurrence is an
+additional hypothesis not present in Lemma~C.4. For the concrete inverse-map
+factorization, that restriction is now eliminated. The declarations
+\leanid{MPOTensor.zeroWeightReparameterizedInverseMapPhysicalSectorFactorization_isRecurrentSupport},
+\leanid{MPOTensor.exists_positive_inverseMapPhysicalSectorFactorization}, and
+\leanid{MPOTensor.exists_positive_physicalSectorFactorization_of_isSAL}
+retain and reparameterize the zero-weight sectors, derive recurrence from the
+source hypotheses, and produce the coherently positive factorization.
 
 The canonical family
 \leanid{MPOTensor.ExplicitEtaOperators.ofHayashiMarkov} does not supply this
@@ -591,40 +601,35 @@ mathematical data needed to construct
 \leanid{MPOTensor.EtaLocalStructureData}.  The conditional construction is
 \leanid{MPOTensor.PhysicalSectorFactorization.etaLocalStructureData}; its
 normalization scalar is one. The raw inverse-map physical-sector factorization
-is now constructed for an injective tensor satisfying SAL. The remaining
-upstream step is to choose its
-neighboring contractions coherently positive. ZCL is not a hypothesis of this
-construction.
+and its coherently positive normalization are now constructed for an injective
+tensor satisfying SAL.  ZCL is not a hypothesis of this construction.
 
 The source Proposition \texttt{3to4} assumes SAL, not ZCL.  ZCL enters only
 after this commuting product form has been obtained, in the later step that
 derives the GSNNCH--ZCL and RFP conclusions.  Accordingly, adding ZCL to a
-conditional theorem would not repair the missing coherent positive choice.
+conditional theorem would not be relevant to the coherent positive choice.
 
-The positive-choice and primitivity statements that remain in Lemma
-\texttt{propSN} are tracked by
-\href{https://github.com/LionSR/TNLean/issues/3696}{issue \#3696}. Conditional
-on the coherently positive physical-sector factorization produced there, the
-positive commuting bond, its exact all-length product realization, and the
-resulting eta-local structure of Proposition \texttt{3to4} are formalized.
-Until the SAL implication is complete, Proposition~C.8 must not be presented
-as unconditionally formalized from its source hypotheses.
+The coherent positive choice in Lemma \texttt{propSN} is now complete.  The
+remaining trace-matrix primitivity statement is tracked by
+\href{https://github.com/LionSR/TNLean/issues/3696}{issue \#3696}.  The positive
+commuting bond, its exact all-length product realization, and the resulting
+eta-local structure of Proposition \texttt{3to4} are already available from a
+coherently positive physical-sector factorization; their direct composition
+with the new SAL theorem remains to be recorded before Proposition~C.8 is
+presented as unconditionally formalized from its source hypotheses.
 
 \section{Classification}
 
-This note records an open gap for the SAL-to-positive-bond construction of
-\leanid{MPOTensor.EtaLocalStructureData}. The positivity half of the projected
-chain identity is now formalized unconditionally, and the pairwise
-positive-choice construction is formalized under the symmetric-support scope
-restriction described above.  The sector support graph, the per-cycle
-positive rescaling, and the coherent vertex-rephasing theorem are now
-formalized.  In the last theorem recurrence is a hypothesis, not a conclusion.
-The zero-weight reparameterization is formalized, but recurrence remains a
-hypothesis.  The remaining obligation for the source statement is to prove
-that positive-weight sectors contribute nonzero one-site matrix spaces and
-then formalize the directed-cut injectivity contradiction above.  The
-primitivity of $T_{k,h}$ also remains open and cannot be used to derive
-recurrence without circularity.
+This note now records a closed coherent-positive-choice gap and the remaining
+downstream obligations in the SAL-to-positive-bond construction of
+\leanid{MPOTensor.EtaLocalStructureData}. Zero-weight sectors are
+reparameterized without changing the physical decomposition, recurrence is
+derived from injectivity, and the inverse-map sector tensors are coherently
+rephased so that every neighboring operator is positive semidefinite. The
+earlier scope-restricted recurrence theorem remains useful as the general
+graph-theoretic component, but recurrence is a conclusion for the normalized
+inverse-map factorization. The primitivity of the trace matrix $T$ remains
+open; it is no longer needed for recurrence and must be proved separately.
 
 For the conditional bond construction, all translates commute pairwise at
 every length $N\geq2$.  The finite-chain MPO is the ordered product of those
@@ -633,10 +638,11 @@ coordinates.  If the neighboring operators are positive semidefinite, these
 results provide the positive commuting bond and its exact realization with
 scalar one, and they determine the eta-local structure data. The raw
 physical-sector factorization already follows for an injective tensor
-satisfying SAL. The coherent positive choice follows once recurrence of the
-inverse-map support is known; constructing a strictly positive-weight Hayashi
-decomposition and deriving recurrence for it from the source hypotheses is the
-remaining obligation in this implication.
+satisfying SAL, and the coherent positive choice is now obtained by
+normalizing the inactive sectors and deriving recurrence from injectivity.
+The remaining work is to compose this factorization with the already
+formalized positive commuting-bond construction and to discharge the later
+trace-matrix primitivity step.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -300,7 +300,7 @@ The pairwise construction has two limitations.  Its symmetric-support
 hypothesis is not stated in the source, and it preserves only the chain blocks
 of length at most two.  The source instead rescales the sector tensors and
 therefore preserves every length simultaneously.  These limitations are
-overcome below by deactivating zero-weight sectors, proving recurrence of the
+overcome below by reparameterizing zero-weight sectors, proving recurrence of the
 remaining support, and applying a vertex rephasing across the whole sector
 graph.
 
@@ -330,7 +330,7 @@ hypothesis, positivity of all cyclic tensor products would first show that
 each edge is a phase times a positive operator, then force trivial phase
 around every cycle, and finally permit a coherent choice of vertex phases.
 The source does not state recurrence as a hypothesis.  It is derived below
-from injectivity after zero-weight sectors are deactivated.  This derivation
+from injectivity after zero-weight sectors are reparameterized.  This derivation
 does not use the later primitivity argument, and hence avoids circularity.
 
 For the present formal notion of a Hayashi decomposition, recurrence is false
@@ -555,9 +555,9 @@ construction the trace matrix
 \[
   T_{k,h}=\tr(\eta_{k,h})
 \]
-is a generally nonconstant primitive nonnegative matrix.  Thus the two
-families cannot be identified without an additional theorem; in general they
-are not equal.
+is a generally nonconstant nonnegative matrix whose positive-weight
+restriction is asserted to be primitive.  Thus the two families cannot be
+identified without an additional theorem; in general they are not equal.
 
 The translation-invariant bond $B_{n,n+1}$ is now defined in the original
 physical coordinates and proved positive.  Adjacent translates commute on
@@ -623,7 +623,7 @@ hypotheses.
 There is a necessary distinction between the physical sector decomposition
 and the effective index set of the trace matrix.  The former must retain every
 summand of the middle Hilbert space, including a summand with $p_k=0$.  After
-the inactive-sector normalization above, however,
+the zero-weight reparameterization above, however,
 $\eta_{k,h}=\eta_{h,k}=0$ for every $h$ whenever $p_k=0$.  Thus the trace
 matrix on the full ambient sector set has a zero row and a zero column and is
 not primitive.  The primitive matrix in Lemma \texttt{propSN} must therefore

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -620,6 +620,18 @@ the new SAL theorem is
 $\eta$-local conclusion of Proposition~C.8 is now formalized from its source
 hypotheses.
 
+There is a necessary distinction between the physical sector decomposition
+and the effective index set of the trace matrix.  The former must retain every
+summand of the middle Hilbert space, including a summand with $p_k=0$.  After
+the inactive-sector normalization above, however,
+$\eta_{k,h}=\eta_{h,k}=0$ for every $h$ whenever $p_k=0$.  Thus the trace
+matrix on the full ambient sector set has a zero row and a zero column and is
+not primitive.  The primitive matrix in Lemma \texttt{propSN} must therefore
+be read on the effective sector set $\{k:p_k>0\}$, as is customary when zero
+probability terms in a direct-sum state decomposition are omitted.  The Lean
+statement will restrict the trace matrix to this subtype while leaving the
+physical sector equivalence, and hence the full Hilbert space, unchanged.
+
 \section{Classification}
 
 This note now records a closed coherent-positive-choice gap and the remaining
@@ -629,9 +641,11 @@ reparameterized without changing the physical decomposition, recurrence is
 derived from injectivity, and the inverse-map sector tensors are coherently
 rephased so that every neighboring operator is positive semidefinite. The
 earlier scope-restricted recurrence theorem remains useful as the general
-graph-theoretic component, but recurrence is a conclusion for the normalized
-inverse-map factorization. The primitivity of the trace matrix $T$ remains
-open; it is no longer needed for recurrence and must be proved separately.
+graph-theoretic component, but recurrence is a conclusion for the
+reparameterized inverse-map factorization.  The primitivity of the trace
+matrix restricted to positive-weight sectors remains open; it is no longer
+needed for recurrence and must be proved separately.  The unrestricted
+ambient trace matrix is not primitive when a zero-weight sector is present.
 
 For the conditional bond construction, all translates commute pairwise at
 every length $N\geq2$.  The finite-chain MPO is the ordered product of those
@@ -642,9 +656,9 @@ scalar one, and they determine the eta-local structure data. The raw
 physical-sector factorization already follows for an injective tensor
 satisfying SAL, and the coherent positive choice is now obtained by
 normalizing the inactive sectors and deriving recurrence from injectivity.
-The remaining work in this part of the paper is the later trace-matrix
-primitivity step; it is logically separate from the commuting-bond
-construction.
+The remaining work in this part of the paper is the later active-sector
+trace-matrix primitivity step; it is logically separate from the
+commuting-bond construction.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -370,8 +370,20 @@ formula are now formalized by
 \leanid{MPOTensor.zeroWeightReparameterizedInverseMapPhysicalSectorFactorization},
 and
 \leanid{MPOTensor.zeroWeightReparameterizedInverseMapPhysicalSectorFactorization_neighboringOperator}.
-The remaining problem is the injectivity argument establishing recurrence on
-the nonzero-weight support.
+Every neighboring operator incident to an inactive sector therefore
+vanishes, while active--active operators are unchanged.  On the active
+support, recurrence follows from an algebraic triangle-closing argument once
+the virtual matrices furnished by all sector entries span the full matrix
+algebra and every active sector furnishes a nonzero matrix.  This argument is
+now formalized: a nonzero edge $k\to h$ can be closed through one further
+sector $j$, giving $h\to j\to k$, by nondegeneracy and cyclicity of the matrix
+trace pairing.\footnote{The formal declarations are
+\leanid{MPOTensor.PhysicalSectorFactorization.sectorVirtualMatrix},
+\leanid{MPOTensor.PhysicalSectorFactorization.exists_two_edge_return_of_neighboringOperator_ne_zero},
+and
+\leanid{MPOTensor.PhysicalSectorFactorization.neighboringOperator_reaches_of_ne_zero}.}
+The remaining concrete obligations are to derive the spanning and
+sector-nonvanishing hypotheses from the injective inverse-map construction.
 
 \subsection{Recurrence of the sector support graph: definitions and the
 per-cycle rescaling}


### PR DESCRIPTION
## Summary

This change removes the recurrent-support hypothesis from the coherent positive-choice step for the concrete inverse-map physical-sector factorization.

- It proves an algebraic triangle-closing theorem: injective spanning and nonzero endpoint sectors close every nonzero neighboring edge through a third sector.
- It uses the zero-weight reparameterization merged in #3832, which retains the full Hayashi physical decomposition while setting the unused right tensor to zero in zero-weight sectors.
- It proves that the virtual matrices of any physical-sector factorization of an injective MPO span the full virtual matrix algebra.
- It proves that every positive-weight Hayashi sector contains a nonzero virtual matrix, using the three-site closure identity and the two trace-one sector states.
- It derives recurrence of the reparameterized inverse-map support, applies the existing recurrent-support rephasing theorem, and obtains a positive physical-sector factorization for every injective MPO tensor satisfying SAL.
- It composes this factorization with the existing commuting-bond construction, proving that every injective MPO tensor satisfying SAL has the eta-local structure of Proposition C.8.
- It updates the blueprint and paper-gap note so the unconditional coherent-positive-choice entry is complete, while retaining the general recurrence-conditional theorem as a scope-restricted auxiliary result.

## Mathematical point

An arbitrary Hayashi decomposition may contain zero-weight sectors. These sectors cannot be deleted, because the sector equivalence covers the entire middle physical Hilbert space. The source-faithful correction from #3832 leaves the physical direct sum unchanged and sets the right tensor to zero wherever the weight is zero; the left tensor already vanishes there.

For a remaining nonzero edge, both endpoint weights are nonzero. If all virtual matrices in one such sector vanished, then the corresponding conjugated middle-site MPO matrix would vanish. The three-site closure would therefore have a zero diagonal block there, contradicting its Hayashi expression as a nonzero weight times nonzero diagonal entries of two trace-one density matrices. Injectivity supplies spanning, and nondegeneracy of the trace pairing closes the edge through a third sector.

This proves recurrence from the source hypotheses without using the later trace-matrix primitivity conclusion.

## Faithfulness

The final theorem has exactly the relevant source assumptions: injectivity and SAL; `IsSAL` already includes the MPDO property. No recurrence, symmetric-support, strict-positive-weight, normality, or ZCL hypothesis is added. Zero-weight sectors remain in the ambient physical decomposition.

The lighter `Local fix (inactive sectors)` markers cite `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`, which records the zero-weight counterexample and the ambient-space-preserving correction.

The full ambient trace matrix is not called primitive: if a zero-weight sector is present, its row and column vanish. The remaining source statement is primitivity after restriction to the positive-weight sector subtype, tracked in #3696.

## Validation

- direct Lean elaboration of the three new proof modules and the eta-local capstone at the rebased head
- `leanblueprint web` at the rebased head
- full `lake build TNLean` passed before the rebase; post-rebase full-build attempts were interrupted by concurrent worktrees deleting shared `.lake` products, while every changed Lean module passed independently
- proof-integrity and 100-character line checks
- `git diff --check`
- kernel axiom audit: standard logical axioms; the SAL corollary also has the existing sanctioned entropy input `hayashi_ssa_equality_characterization_forward`

Closes #3825 and #823. Advances #3696.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new formal proofs in core MPDO/SAL theory; incorrect lemmas would undermine downstream RFP/η-local claims, but changes are additive with no runtime or security surface.
> 
> **Overview**
> This PR **closes the coherent positive-choice gap** for injective MPO tensors with SAL by proving recurrence of the inverse-map neighboring support **without** assuming it up front.
> 
> It adds **generic infrastructure**: sector virtual matrices, a trace-pairing **triangle-closure** lemma (every nonzero edge admits a two-edge return when virtual matrices span and endpoints are nonzero), and **injectivity ⇒ spanning** of those virtual matrices in sector coordinates.
> 
> It adds **inverse-map-specific proofs** after zero-weight reparameterization: nonzero edges have positive Hayashi weights, positive-weight sectors contain a nonzero virtual matrix (via three-site closure + Hayashi decomposition), hence **recurrent support**; existing **vertex rephasing** then yields all neighboring operators positive semidefinite. Capstone theorems **`exists_positive_physicalSectorFactorization_of_isSAL`** and **`nonempty_etaLocalStructureData_of_isSAL`** wire this into Proposition C.8’s η-local structure.
> 
> **Docs/blueprint** mark the coherent positive-choice theorem as proved, add spanning/triangle-closure entries, a SAL corollary, and revise the paper-gap note so recurrence is a **conclusion** for the reparameterized inverse-map family (trace-matrix primitivity on active sectors remains open).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93a1e1767ef0623ecf81fa9734b357f4bf0b2d1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->