### PR TITLE
feat(MPS/MPDO): identify conditional fixed-final corners

### DIFF
--- a/TNLean/MPS/MPDO/BNTTripleFusionSeparation.lean
+++ b/TNLean/MPS/MPDO/BNTTripleFusionSeparation.lean
@@ -19,7 +19,8 @@ arXiv:1511.08090.
 The selector hypothesis is stated explicitly.  It is not presently derived
 from the assumptions on `BNTFusionIsometryFamily`.  Consequently the result below is
 a conditional final-sector decomposition; it does not construct an invertible
-fixed-sector comparison, an $F$-matrix, or a pentagon identity.
+fixed-sector comparison, identify its multiplicity factor with the source
+$F$-matrix, or prove a pentagon identity.
 
 ## References
 
@@ -39,6 +40,20 @@ universe u
 
 variable {Λ : Type u} [Fintype Λ] [DecidableEq Λ] {p : ℕ}
 variable (Fam : BNTFusionIsometryFamily Λ p)
+
+@[simp] private theorem leftFinalIndexEquiv_symm_apply
+    (α β γ ε δ : Λ) (μ : Fin (Fam.chi.dim α β δ))
+    (ν : Fin (Fam.chi.dim δ γ ε)) (b : Fin (Fam.bondDim ε)) :
+    (Fam.leftFinalIndexEquiv α β γ ε).symm (⟨⟨δ, μ, ν⟩, b⟩) =
+      ⟨δ, μ, ν, b⟩ := by
+  rfl
+
+@[simp] private theorem rightFinalIndexEquiv_symm_apply
+    (α β γ ε δ : Λ) (μ : Fin (Fam.chi.dim β γ δ))
+    (ν : Fin (Fam.chi.dim α δ ε)) (b : Fin (Fam.bondDim ε)) :
+    (Fam.rightFinalIndexEquiv α β γ ε).symm (⟨⟨δ, μ, ν⟩, b⟩) =
+      ⟨δ, μ, ν, b⟩ := by
+  rfl
 
 /-- A common finite family of word polynomials separates every final-label
 tensor from all the others.  This is the arbitrary-finite-label form of
@@ -147,5 +162,80 @@ theorem tripleFusionComparison_finalSector_submatrix_eq_zero
     (Fam.tensor ε).toMPSTensor (Fam.tensor ε').toMPSTensor Cblock hLetter
     coeff hSelf (hOther ε' hε)
   exact congrArg (fun X => X bL bR) hZero
+
+/-- **Conditional fixed-final Kronecker form.** Suppose the positive
+trace-power coefficients are independent of the positive chain length, common
+finite word selectors separate the final-label tensors, and the selected final
+tensor is injective at the present blocking. Then the diagonal fixed-final corner of the full
+triple-fusion comparison has the form \(F_\varepsilon \otimes 1\), while every
+corner from a distinct right final sector into the selected left sector
+vanishes.
+
+**Scope restriction (injectivity and simultaneous final-label separation):**
+neither injectivity at the present blocking nor the selector hypothesis is derived
+from the current assumptions on `BNTFusionIsometryFamily`. The missing
+implications are documented in
+`docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`.
+
+The matrix `F` is rectangular in general. This theorem does not assert that it
+or the diagonal comparison corner is invertible, identify it with the printed
+$F$-matrix, or prove a pentagon identity.
+
+Source: arXiv:1511.08090, equations `Fmove` and `zippercondition2`, lines
+237--277, especially the simultaneous inverse at line 269, the injectivity
+argument following equation `pentagon3`, and the tensor-product conclusion at
+line 277; arXiv:1606.00608, lines 995--1010. -/
+theorem exists_tripleFusionComparison_finalSector_eq_kronecker_one_of_separation
+    (c : BNTLabelCoefficientFamily Λ)
+    (hχ : c.HasPositiveLengthChiTracePowerForm Fam.chi)
+    (hLI : c.LengthIndependent) {S : ℕ}
+    (hSel : Fam.HasFinalLabelSelectorWords S)
+    (α β γ ε : Λ)
+    (hε : MPSTensor.IsInjective (Fam.tensor ε).toMPSTensor) :
+    ∃ F : Matrix (Fam.LeftFinalMultiplicity α β γ ε)
+        (Fam.RightFinalMultiplicity α β γ ε) ℂ,
+      ((Fam.tripleFusionComparison α β γ).submatrix
+          (Fam.leftFinalRow α β γ ε) (Fam.rightFinalRow α β γ ε)).submatrix
+            (Fam.leftFinalIndexEquiv α β γ ε).symm
+            (Fam.rightFinalIndexEquiv α β γ ε).symm =
+          F ⊗ₖ (1 : Matrix (Fin (Fam.bondDim ε)) (Fin (Fam.bondDim ε)) ℂ) ∧
+        ∀ ε' : Λ, ε' ≠ ε →
+          (Fam.tripleFusionComparison α β γ).submatrix
+            (Fam.leftFinalRow α β γ ε) (Fam.rightFinalRow α β γ ε') = 0 := by
+  let C := (Fam.tripleFusionComparison α β γ).submatrix
+    (Fam.leftFinalRow α β γ ε) (Fam.rightFinalRow α β γ ε)
+  have hC : ∀ ij : Fin (p * p),
+      ((1 : Matrix (Fam.LeftFinalMultiplicity α β γ ε)
+          (Fam.LeftFinalMultiplicity α β γ ε) ℂ) ⊗ₖ
+          (Fam.tensor ε).toMPSTensor ij) *
+          C.submatrix (Fam.leftFinalIndexEquiv α β γ ε).symm
+            (Fam.rightFinalIndexEquiv α β γ ε).symm =
+        C.submatrix (Fam.leftFinalIndexEquiv α β γ ε).symm
+            (Fam.rightFinalIndexEquiv α β γ ε).symm *
+          ((1 : Matrix (Fam.RightFinalMultiplicity α β γ ε)
+            (Fam.RightFinalMultiplicity α β γ ε) ℂ) ⊗ₖ
+            (Fam.tensor ε).toMPSTensor ij) := by
+    intro ij
+    obtain ⟨⟨i, k⟩, rfl⟩ := finProdFinEquiv.surjective ij
+    have hFull := Fam.tripleFusionComparison_intertwines_of_lengthIndependent
+      c hχ hLI α β γ i k
+    ext ⟨⟨δL, μL, νL⟩, bL⟩ ⟨⟨δR, μR, νR⟩, bR⟩
+    simp [C, Matrix.mul_apply, MPOTensor.toMPSTensor,
+      leftFinalIndexEquiv_symm_apply, rightFinalIndexEquiv_symm_apply,
+      Fintype.sum_prod_type, Matrix.one_apply]
+    have hEntry := congrArg
+      (fun X => X (Fam.leftFinalRow α β γ ε ⟨δL, μL, νL, bL⟩)
+        (Fam.rightFinalRow α β γ ε ⟨δR, μR, νR, bR⟩)) hFull
+    simpa [Matrix.mul_apply, Matrix.blockDiagonal'_apply,
+      leftFinalRow, rightFinalRow, Fintype.sum_sigma,
+      Fintype.sum_prod_type, Matrix.one_apply] using hEntry
+  obtain ⟨F, hF⟩ :=
+    Fam.exists_reindexed_intertwiner_eq_kronecker_one_of_isInjective
+      α β γ ε hε C hC
+  refine ⟨F, ?_, ?_⟩
+  · exact hF
+  · intro ε' hε'
+    exact Fam.tripleFusionComparison_finalSector_submatrix_eq_zero
+      c hχ hLI hSel α β γ ε ε' hε'
 
 end MPOTensor.BNTFusionIsometryFamily

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -462,9 +462,11 @@ separate step.
         $\varepsilon$, in the diagrammatic language of
         \cite[eq.~(Fmove)]{Bultinck2017Anyons}.  The solid fusion trees are
         the left- and right-bracketed maps constructed below.  The dashed
-        bridge denotes the fixed-final change of multiplicity basis.  The
-        results below compare the full direct sums, but do not yet extract
-        this fixed-final map or prove its invertibility.}
+        line denotes the invertible fixed-final change of multiplicity basis
+        in the source.  The conditional result below extracts a rectangular
+        multiplicity factor acting trivially on the final bond space, but does
+        not identify that factor with the dashed source transformation or
+        prove its invertibility.}
     \label{fig:mpdo_fixed_final_fusion_bracketings}
 \end{figure}
 
@@ -827,4 +829,64 @@ separate step.
     $\{M_\varepsilon^{ij}\}_{i,j}$.  This family spans the full matrix algebra
     by injectivity, and the assumed relation is precisely the amplified
     intertwining identity of that lemma.
+\end{proof}
+
+\begin{theorem}[Conditional fixed-final Kronecker form and separation]%
+    \label{thm:mpdo_triple_fusion_comparison_final_sector_kronecker}
+    \lean{MPOTensor.BNTFusionIsometryFamily.%
+        exists_tripleFusionComparison_finalSector_eq_kronecker_one_of_separation}
+    \leanok
+    \uses{def:mpdo_triple_fusion_comparison,
+        def:mpdo_final_label_selector_words,
+        def:mpdo_final_sector_multiplicity_spaces}
+    Suppose the positive trace-power coefficients are independent of the
+    positive chain length and common word selectors separate the final labels.
+    Fix labels $\alpha,\beta,\gamma,\varepsilon$, and suppose that
+    $M_\varepsilon$ is injective at the present blocking.  Write
+    \[
+        C^{\varepsilon,\varepsilon'}_{\alpha,\beta,\gamma}
+          =P^{\mathrm L}_{\varepsilon}
+            C_{\alpha,\beta,\gamma}
+            P^{\mathrm R}_{\varepsilon'}
+    \]
+    for the corner from the right final sector $\varepsilon'$ to the left
+    final sector $\varepsilon$.  There is a rectangular matrix
+    \[
+        F_\varepsilon:\mathcal H^{\mathrm R}_{\varepsilon}
+          \longrightarrow \mathcal H^{\mathrm L}_{\varepsilon}
+    \]
+    such that, after the canonical index identifications,
+    \[
+        C^{\varepsilon,\varepsilon}_{\alpha,\beta,\gamma}
+          =F_\varepsilon\otimes 1_{D_\varepsilon}.
+    \]
+    For every $\varepsilon'\ne\varepsilon$,
+    \[
+        C^{\varepsilon,\varepsilon'}_{\alpha,\beta,\gamma}=0.
+    \]
+    The selector identities and injectivity at the present blocking are
+    additional hypotheses here.  The theorem neither asserts that
+    $F_\varepsilon$ is square or invertible nor identifies it with the
+    $F$-matrix of \cite[eq.~(Fmove)]{Bultinck2017Anyons}; no pentagon identity
+    is asserted.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:mpdo_triple_fusion_comparison_intertwines,
+        thm:mpdo_triple_fusion_comparison_final_sector_vanishing,
+        thm:mpdo_injective_fixed_final_intertwiner}
+    Taking the $\varepsilon$--$\varepsilon$ corner of the full comparison
+    identity gives, for every pair $i,j$,
+    \[
+        (1_{\mathcal H^{\mathrm L}_\varepsilon}\otimes
+          M_\varepsilon^{ij})C^{\varepsilon,\varepsilon}
+          =C^{\varepsilon,\varepsilon}
+            (1_{\mathcal H^{\mathrm R}_\varepsilon}\otimes
+              M_\varepsilon^{ij}).
+    \]
+    Injectivity and the amplified commutant result give
+    $C^{\varepsilon,\varepsilon}=F_\varepsilon\otimes1_{D_\varepsilon}$.
+    The common word selectors give
+    $C^{\varepsilon,\varepsilon'}=0$ whenever
+    $\varepsilon'\ne\varepsilon$ by
+    Theorem~\ref{thm:mpdo_triple_fusion_comparison_final_sector_vanishing}.
 \end{proof}

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -524,14 +524,31 @@ comparison has zero corner between two distinct final labels.  The proof takes
 one rectangular bond-space corner of the letterwise intertwining identity,
 extends it to words, and applies the selector polynomial.
 
-This is a scope-restricted result: no simultaneous final-label selector is
-presently derived from the assumptions on the fusion-isometry family.  That
-missing implication is the remaining source-faithfulness gap at this stage.
-Even after it is supplied, off-diagonal vanishing alone neither proves that the
-diagonal fixed-final corners are invertible nor identifies them with the
-printed $F$-matrices.  The fixed-final $F$-transformation, its invertibility,
-and the pentagon-like equation mentioned at lines~995--999 therefore remain
-unformalized.
+Under the additional assumption that the selected final tensor is injective
+at the present blocking,
+\leanid{MPOTensor.BNTFusionIsometryFamily.%
+exists_tripleFusionComparison_finalSector_eq_kronecker_one_of_separation}
+combines this separation with the amplified-commutant argument.  For every
+selected final label $\varepsilon$, it produces a rectangular multiplicity
+matrix $F_\varepsilon$ for which the reindexed diagonal corner is
+\[
+    C^{\varepsilon,\varepsilon}_{\alpha,\beta,\gamma}
+      =F_\varepsilon\otimes 1_{D_\varepsilon},
+\]
+and retains the vanishing of
+$C^{\varepsilon,\varepsilon'}_{\alpha,\beta,\gamma}$ when
+$\varepsilon'\ne\varepsilon$.  This is the bond-factor conclusion appearing
+at line~277 of the arXiv:1511.08090 source, but the comparison used here is
+oriented oppositely to the printed convention.
+
+This remains a scope-restricted result.  Neither the simultaneous final-label
+selectors nor one-letter injectivity of every final tensor at the present
+blocking is derived from the assumptions on the fusion-isometry family.  The
+matrix $F_\varepsilon$ may be rectangular, and the theorem proves neither its
+invertibility nor invertibility of the diagonal corner.  It is therefore not
+identified with the printed $F$-matrix.  The invertible fixed-final
+$F$-transformation and the pentagon-like equation mentioned at lines~995--999
+remain unformalized.
 
 To eliminate the source-theorem gap, the formalization should instead:
 \begin{enumerate}


### PR DESCRIPTION
## Summary

This change identifies the diagonal fixed-final corner of the triple-fusion comparison under the exact conditional hypotheses currently available.

- It restricts the full intertwining identity to a chosen final label and reindexes the bond coordinate explicitly as multiplicity \(\times\) final bond.
- Under one-site injectivity of the selected final tensor, the existing amplified-commutant theorem gives
  \[
    C^{\varepsilon,\varepsilon}=F_\varepsilon\otimes I.
  \]
- Under the common final-label selector hypothesis, every corner \(C^{\varepsilon,\varepsilon'}\) with \(\varepsilon'\ne\varepsilon\) vanishes.
- The blueprint and paper-gap note now record this precise intermediate conclusion and its orientation.

## Faithfulness boundary

Both present-blocking injectivity and simultaneous final-label selectors remain explicit hypotheses; neither is derived from the current `BNTFusionIsometryFamily` fields. The resulting multiplicity matrix is rectangular in general and is oriented with the repository comparison from the right-associated sum to the left-associated sum, opposite to the printed convention. The theorem does not claim nonvanishing, squareness, uniqueness, invertibility, identification with the paper's printed \(F\)-matrix, or the pentagon identity.

The source correspondence is arXiv:1511.08090, lines 237–277, especially the simultaneous inverse at line 269 and the \(F\otimes I\) conclusion at line 277, together with arXiv:1606.00608, lines 995–1010.

## Validation

- direct Lean check of `BNTTripleFusionSeparation.lean`
- full `lake build TNLean`
- blueprint synchronization and changed-declaration coverage
- `lake exe checkdecls blueprint/lean_decls`
- `leanblueprint pdf` (518 pages), with visual inspection of the affected pages
- reader-facing prose and ChkTeX checks
- proof-integrity and axiom audits
- `git diff --check`
- independent mathematical, index-orientation, source, blueprint, and identity review by a parallel agent

Advances #3776.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive formal proofs and documentation with explicit conditional boundaries; no runtime, auth, or data-path impact. Residual risk is mathematical misstatement of scope, which the PR repeatedly guards in Lean docstrings and gap notes.
> 
> **Overview**
> Under explicit hypotheses—length-independent trace-power coefficients, **final-label selector words**, and **injectivity** of the selected final tensor at the present blocking—this PR proves the reindexed \(\varepsilon\)–\(\varepsilon\) corner of `tripleFusionComparison` equals **`F ⊗ₖ 1`** on the final bond, and reuses the existing separation theorem for **zero off-diagonal corners** \(\varepsilon' \ne \varepsilon\).
> 
> The Lean proof restricts the full intertwining identity to the fixed-final submatrix, adds small `@[simp]` lemmas for final index equivalences, and applies `exists_reindexed_intertwiner_eq_kronecker_one_of_isInjective`. **Blueprint** Ch.21 gains theorem `thm:mpdo_triple_fusion_comparison_final_sector_kronecker` and a tightened figure caption; **`docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`** records this as the line-277 bond-factor step while stressing selectors/injectivity are **not derived** from `BNTFusionIsometryFamily`, \(F_\varepsilon\) may be **rectangular**, and invertibility / printed \(F\)-matrix / pentagon remain **out of scope**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea5e92ea7b93ee42eec8a753342d26b3d6e10b4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->