### PR TITLE
feat(MPS/MPDO): prune zero-weight sector edges

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -394,6 +394,7 @@ import TNLean.MPS.MPDO.SectorFactorization
 import TNLean.MPS.MPDO.PhysicalSectorFactorization
 import TNLean.MPS.MPDO.PhysicalSectorRephasing
 import TNLean.MPS.MPDO.InverseMapPhysicalSectorFactorization
+import TNLean.MPS.MPDO.PhysicalSectorPruning
 import TNLean.MPS.MPDO.NeighboringPreparation
 import TNLean.MPS.MPDO.PhysicalSectorSubspinMaps
 import TNLean.MPS.MPDO.PhysicalSectorClosureCoordinates

--- a/TNLean/MPS/MPDO/PhysicalSectorPruning.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorPruning.lean
@@ -1,0 +1,195 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.InverseMapPhysicalSectorFactorization
+
+/-!
+# Zero-weight physical-sector reparameterization
+
+If the left tensor of a physical sector vanishes, its right tensor may be replaced by zero
+without changing the physical-slice factorization. The neighboring operators whose source is
+that sector then vanish, while those with an active source are unchanged.
+
+For the inverse-map factorization, every sector of zero Hayashi weight has vanishing left tensor.
+The construction therefore removes the outgoing neighboring contractions of zero-weight sectors
+while retaining every physical direct summand.
+
+## References
+
+- [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, equations `formK` and `etarl`, lines 1434--1445
+- `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D}
+
+/-- Replace the right tensor of every inactive sector by zero.
+
+The physical direct sum, its factor spaces, and its physical isometry are retained. The hypothesis
+that the left tensor already vanishes on every inactive sector makes the same-sector product
+unchanged.
+
+This is the zero-weight reparameterization permitted by the factorization in arXiv:1606.00608,
+Appendix C.2, equations `formK` and `etarl`, lines 1434--1445. Its role in removing spurious
+outgoing edges from zero-weight Hayashi sectors is recorded in
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`. -/
+noncomputable def zeroRightTensorOnInactive (F : PhysicalSectorFactorization K)
+    (active : Fin F.sectorCount → Prop) [DecidablePred active]
+    (hleft : ∀ k, ¬ active k → ∀ beta, F.leftTensor k beta = 0) :
+    PhysicalSectorFactorization K where
+  sectorCount := F.sectorCount
+  leftDim := F.leftDim
+  rightDim := F.rightDim
+  leftDim_pos := F.leftDim_pos
+  rightDim_pos := F.rightDim_pos
+  sectorEquiv := F.sectorEquiv
+  physicalIsometry := F.physicalIsometry
+  physicalIsometry_isometry := F.physicalIsometry_isometry
+  leftTensor := F.leftTensor
+  rightTensor := fun k alpha ↦ if active k then F.rightTensor k alpha else 0
+  factorization := by
+    classical
+    intro beta alpha
+    rw [F.factorization beta alpha]
+    congr 1
+    funext k
+    by_cases hk : active k
+    · change Matrix.kroneckerMap (· * ·) (F.leftTensor k beta) (F.rightTensor k alpha) =
+        Matrix.kroneckerMap (· * ·) (F.leftTensor k beta)
+          (if active k then F.rightTensor k alpha else 0)
+      simp [hk]
+    · change Matrix.kroneckerMap (· * ·) (F.leftTensor k beta) (F.rightTensor k alpha) =
+        Matrix.kroneckerMap (· * ·) (F.leftTensor k beta)
+          (if active k then F.rightTensor k alpha else 0)
+      simp [hk, hleft k hk beta]
+
+@[simp] private theorem zeroRightTensorOnInactive_leftTensor
+    (F : PhysicalSectorFactorization K) (active : Fin F.sectorCount → Prop)
+    [DecidablePred active]
+    (hleft : ∀ k, ¬ active k → ∀ beta, F.leftTensor k beta = 0)
+    (k : Fin F.sectorCount) (beta : Fin D) :
+    (F.zeroRightTensorOnInactive active hleft).leftTensor k beta =
+      F.leftTensor k beta := rfl
+
+@[simp] private theorem zeroRightTensorOnInactive_rightTensor
+    (F : PhysicalSectorFactorization K) (active : Fin F.sectorCount → Prop)
+    [DecidablePred active]
+    (hleft : ∀ k, ¬ active k → ∀ beta, F.leftTensor k beta = 0)
+    (k : Fin F.sectorCount) (alpha : Fin D) :
+    (F.zeroRightTensorOnInactive active hleft).rightTensor k alpha =
+      if active k then F.rightTensor k alpha else 0 := rfl
+
+/-- The neighboring operator is unchanged on an active source sector and vanishes on an inactive
+source sector after the right tensor is replaced by zero.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `etarl`, lines 1441--1445. The
+zero-weight application is recorded in
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`. -/
+theorem zeroRightTensorOnInactive_neighboringOperator
+    (F : PhysicalSectorFactorization K) (active : Fin F.sectorCount → Prop)
+    [DecidablePred active]
+    (hleft : ∀ k, ¬ active k → ∀ beta, F.leftTensor k beta = 0)
+    (k h : Fin F.sectorCount) :
+    (F.zeroRightTensorOnInactive active hleft).neighboringOperator k h =
+      if active k then F.neighboringOperator k h else 0 := by
+  classical
+  by_cases hk : active k
+  · rw [if_pos hk]
+    ext x y
+    simp [neighboringOperator_apply, hk]
+  · rw [if_neg hk]
+    apply Matrix.ext
+    intro x y
+    rw [neighboringOperator_apply]
+    simp only [zeroRightTensorOnInactive_leftTensor,
+      zeroRightTensorOnInactive_rightTensor, if_neg hk]
+    change (∑ _alpha : Fin D, 0 * F.leftTensor h _alpha x.2 y.2) = 0
+    simp
+
+end MPOTensor.PhysicalSectorFactorization
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+variable {rho : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+
+/-- A zero Hayashi weight makes the corresponding inverse-map left tensor vanish.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `Qketc` and `formK`, lines 1415--1439;
+the factor $p_k$ is attached to the left tensor in the chosen factorization. The zero-weight
+boundary is recorded in `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`. -/
+@[simp] theorem sectorTensorL_eq_zero_of_weight_eq_zero
+    (K : MPOTensor d D) (hK : K.IsInjective) (hη : EtaStructure rho)
+    (R : Matrix (Fin D) (Fin D) ℂ) (α₁ β₃ : Fin D) (k : Fin hη.m) (beta : Fin D)
+    (hk : hη.p k = 0) :
+    sectorTensorL K hK hη R α₁ β₃ k beta = 0 := by
+  ext x y
+  simp [sectorTensorL, hk]
+
+/-- A zero Hayashi weight makes every inverse-map neighboring operator entering that sector
+vanish.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `etarl`, lines 1441--1445. The zero-weight
+boundary is recorded in `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`. -/
+theorem sectorEta_eq_zero_of_target_weight_eq_zero
+    (K : MPOTensor d D) (hK : K.IsInjective) (hη : EtaStructure rho)
+    (R : Matrix (Fin D) (Fin D) ℂ) (α₁ β₃ : Fin D) (k h : Fin hη.m)
+    (hh : hη.p h = 0) :
+    sectorEta K hK hη R α₁ β₃ k h = 0 := by
+  ext x y
+  simp [sectorEta, Matrix.sum_apply,
+    sectorTensorL_eq_zero_of_weight_eq_zero K hK hη R α₁ β₃ h _ hh]
+
+/-- The inverse-map physical-sector factorization with every zero-weight source right tensor set
+to zero.
+
+All physical sectors and factor spaces are retained. Since the left tensor of a zero-weight sector
+already vanishes, this changes neither the physical-slice factorization nor any sector of nonzero
+weight. It removes the outgoing neighboring contractions which arise solely from the unused right
+tensor of a zero-weight sector.
+
+**Local fix (zero-weight sectors):** The Hayashi structure used here permits summands of weight
+zero. Retaining their physical spaces while setting their unused right tensors to zero is recorded
+in `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `formK` and `etarl`, lines 1434--1445. -/
+noncomputable def zeroWeightReparameterizedInverseMapPhysicalSectorFactorization
+    (K : MPOTensor d D) (hK : K.IsInjective)
+    (R : Matrix (Fin D) (Fin D) ℂ) (hρ : IsThreeSiteClosure K R rho)
+    (hη : EtaStructure rho) (α₁ β₃ : Fin D) (hm : R β₃ α₁ ≠ 0) :
+    PhysicalSectorFactorization K := by
+  classical
+  let F := inverseMapPhysicalSectorFactorization K hK R hρ hη α₁ β₃ hm
+  exact F.zeroRightTensorOnInactive
+    (fun k ↦ hη.p k ≠ 0)
+    (fun k hk beta ↦ sectorTensorL_eq_zero_of_weight_eq_zero
+      K hK hη R α₁ β₃ k beta (not_ne_iff.mp hk))
+
+/-- The neighboring operator after the zero-weight reparameterization agrees with the original
+inverse-map operator on a nonzero-weight source and vanishes on a zero-weight source.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `etarl`, lines 1441--1445. The need to
+remove outgoing edges of zero-weight sectors is recorded in
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`. -/
+theorem zeroWeightReparameterizedInverseMapPhysicalSectorFactorization_neighboringOperator
+    (K : MPOTensor d D) (hK : K.IsInjective)
+    (R : Matrix (Fin D) (Fin D) ℂ) (hρ : IsThreeSiteClosure K R rho)
+    (hη : EtaStructure rho) (α₁ β₃ : Fin D) (hm : R β₃ α₁ ≠ 0)
+    (k h : Fin hη.m) :
+    (zeroWeightReparameterizedInverseMapPhysicalSectorFactorization
+      K hK R hρ hη α₁ β₃ hm).neighboringOperator k h =
+      if hη.p k ≠ 0 then sectorEta K hK hη R α₁ β₃ k h else 0 := by
+  classical
+  unfold zeroWeightReparameterizedInverseMapPhysicalSectorFactorization
+  rw [PhysicalSectorFactorization.zeroRightTensorOnInactive_neighboringOperator]
+  split
+  · rw [inverseMapPhysicalSectorFactorization_neighboringOperator_eq_sectorEta]
+  · rfl
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -644,6 +644,30 @@ strong subadditivity for a normalized three-site reduced state.
     displayed in \cite[Appendix~C.2, lines~1435--1448]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
+\begin{lemma}[Zero-weight left sector tensor]
+    \label{lem:mpdo_sector_tensor_left_zero_of_weight_zero}
+    \lean{MPOTensor.sectorTensorL_eq_zero_of_weight_eq_zero}
+    \lean{MPOTensor.sectorEta_eq_zero_of_target_weight_eq_zero}
+    \leanok
+    \uses{def:mpdo_sector_tensors}
+    If $p_k=0$, then
+    \[
+        (l_k)_\beta=0
+    \]
+    for every virtual index $\beta$. Consequently,
+    \[
+        \eta_{h,k}=0
+    \]
+    for every sector $h$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The scalar weight $p_k$ is a factor of every matrix entry of
+    $(l_k)_\beta$. Each neighboring operator entering sector $k$ contains
+    $(l_k)_\beta$ as its target factor.
+\end{proof}
+
 \begin{theorem}[Sector factorization of an injective simple tensor]
     \label{thm:mpdo_sector_factorization}
     \lean{MPOTensor.physicalSlice_sector_factorization}
@@ -845,6 +869,40 @@ strong subadditivity for a normalized three-site reduced state.
     Every complete cyclic product of neighboring operators is unchanged.
 \end{definition}
 
+\begin{definition}[Vanishing right tensors on inactive sectors]
+    \label{def:mpdo_physical_sector_inactive_right_zero}
+    \lean{MPOTensor.PhysicalSectorFactorization.zeroRightTensorOnInactive}
+    \lean{MPOTensor.PhysicalSectorFactorization.zeroRightTensorOnInactive_neighboringOperator}
+    \leanok
+    \uses{def:mpdo_physical_sector_factorization,
+      def:mpdo_minimal_neighboring_operator}
+    Let $S$ be a set of active sectors in a physical-sector factorization,
+    and suppose that $(l_k)_\beta=0$ for every $k\notin S$ and every $\beta$.
+    Retain every physical summand and define
+    \[
+        \widehat l_k=l_k,
+        \qquad
+        \widehat r_k=
+        \begin{cases}
+          r_k,&k\in S,\\
+          0,&k\notin S.
+        \end{cases}
+    \]
+    Then $\widehat l_k\otimes\widehat r_k=l_k\otimes r_k$ for every $k$,
+    so the physical-slice factorization is unchanged. The neighboring
+    operators become
+    \[
+        \widehat\eta_{k,h}=
+        \begin{cases}
+          \eta_{k,h},&k\in S,\\
+          0,&k\notin S.
+        \end{cases}
+    \]
+    This is the reparameterization freedom in the factorization and
+    neighboring contraction of
+    \cite[Appendix~C.2, lines~1434--1445]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
 \begin{definition}[Inverse-map physical-sector factorization]
     \label{def:mpdo_inverse_map_physical_sector_factorization}
     \lean{MPOTensor.inverseMapPhysicalSectorFactorization}
@@ -881,6 +939,55 @@ strong subadditivity for a normalized three-site reduced state.
     This is equation \texttt{etarl} in
     \cite[Appendix~C.2, lines~1441--1445]{Cirac2016MPDO_arXiv}.
 \end{theorem}
+
+\begin{definition}[Zero-weight inverse-map reparameterization]
+    \label{def:mpdo_zero_weight_reparameterized_inverse_map_factorization}
+    \lean{MPOTensor.zeroWeightReparameterizedInverseMapPhysicalSectorFactorization}
+    \leanok
+    \uses{def:mpdo_inverse_map_physical_sector_factorization,
+      def:mpdo_physical_sector_inactive_right_zero,
+      lem:mpdo_sector_tensor_left_zero_of_weight_zero}
+    In the inverse-map factorization, retain every physical sector and its
+    factor spaces, and set
+    \[
+        \widehat l_k=l_k,
+        \qquad
+        \widehat r_k=
+        \begin{cases}
+          r_k,&p_k\ne0,\\
+          0,&p_k=0.
+        \end{cases}
+    \]
+    The physical-slice factorization is unchanged. This treats the
+    zero-weight freedom left by the Hayashi decomposition used in
+    \cite[Appendix~C.2, lines~1415--1445]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{theorem}[Neighboring operators after zero-weight reparameterization]
+    \label{thm:mpdo_zero_weight_reparameterized_neighboring_operator}
+    \lean{MPOTensor.zeroWeightReparameterizedInverseMapPhysicalSectorFactorization_neighboringOperator}
+    \leanok
+    \uses{def:mpdo_zero_weight_reparameterized_inverse_map_factorization,
+      thm:mpdo_inverse_map_factorization_neighboring_operator}
+    The neighboring operators of the reparameterized factorization are
+    \[
+        \widehat\eta_{k,h}=
+        \begin{cases}
+          \eta_{k,h},&p_k\ne0,\\
+          0,&p_k=0.
+        \end{cases}
+    \]
+    Thus a zero-weight sector has no outgoing support edge. Since
+    $p_h=0$ also gives $l_h=0$, it has no incoming support edge either.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The neighboring contraction uses $r_k$ at its source and $l_h$ at its
+    target. The first assertion follows from the definition of
+    $\widehat r_k$, and the last assertion follows from
+    Lemma~\ref{lem:mpdo_sector_tensor_left_zero_of_weight_zero}.
+\end{proof}
 
 \begin{corollary}[SAL gives a raw physical-sector factorization]
     \label{cor:mpdo_sal_raw_physical_sector_factorization}

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -357,14 +357,21 @@ Thus $1\to0$ is a nonzero support edge, whereas no edge enters sector $1$.
 This edge is not recurrent.  Hence no theorem deriving recurrence may
 quantify over an arbitrary decomposition satisfying only $p_k\geq0$.
 
-The source-faithful repair is to remove zero-weight summands before forming
-the inverse-map sector tensors.  This does not strengthen the mathematical
-hypotheses: such summands make no contribution to the Markov decomposition.
-After pruning, every retained weight is strictly positive.  One may then seek
-to prove recurrence from injectivity by closing any nonzero two-sector product
-with a third sector, using nondegeneracy of the matrix trace pairing.  The
-formal construction of this positive-weight decomposition and the resulting
-recurrence theorem remain open.
+The source-faithful repair retains the full physical direct sum, since a
+zero-weight summand can have nonzero left and right factor dimensions.  In the
+chosen inverse-map factorization, $p_k=0$ already implies $l_k=0$.  Replacing
+$r_k$ by zero on precisely those sectors therefore leaves every product
+$l_k\otimes r_k$ unchanged and kills the spurious outgoing edges of the
+zero-weight sectors.  Incoming edges were already zero because their target
+left tensor vanishes.  This reparameterization and its neighboring-operator
+formula are now formalized by
+\leanid{MPOTensor.PhysicalSectorFactorization.zeroRightTensorOnInactive},
+\leanid{MPOTensor.sectorTensorL_eq_zero_of_weight_eq_zero},
+\leanid{MPOTensor.zeroWeightReparameterizedInverseMapPhysicalSectorFactorization},
+and
+\leanid{MPOTensor.zeroWeightReparameterizedInverseMapPhysicalSectorFactorization_neighboringOperator}.
+The remaining problem is the injectivity argument establishing recurrence on
+the nonzero-weight support.
 
 \subsection{Recurrence of the sector support graph: definitions and the
 per-cycle rescaling}
@@ -431,40 +438,36 @@ theorem concerns one fixed cycle: it does not by itself assert that the
 choices made on two different cycles agree on a shared edge, which is the
 remaining content of the coherent vertex-rephasing step.
 
-\subsection{Why recurrence is not a direct consequence of the source's own
-argument}
+\subsection{Directed-cut recurrence after zero-weight reparameterization}
 
-The source's proof that $T$ has a single primitive component (quoted above)
-uses two orthogonal projectors $P_{1,2}$ satisfying three vanishing
-conditions and derives a contradiction with injectivity from the resulting
-matrix-algebra decomposition $\mathcal A=\mathcal A_1+\mathcal A_2$,
-$\mathcal A_1\mathcal A_2=0$.  Read literally as a graph statement, this
-argument requires a partition of the sector index set into two nonempty
-blocks with \emph{no} edges between them in \emph{either} direction: this is
-exactly what the paper's ``$T^n=\bigoplus_x T^{(x)}$'' display asserts.
+The source's local-orthogonality contradiction uses the decomposition
+$\mathcal A=\mathcal A_1+\mathcal A_2$ together with the one-sided product
+vanishing $\mathcal A_1\mathcal A_2=0$.  It does not require
+$\mathcal A_2\mathcal A_1=0$.  Thus the argument applies to a directed cut,
+not only to a block-diagonal partition.
 
-For a general nonnegative matrix, however, such an exactly block-diagonal
-power exists only when the support graph, restricted to the transitive
-closure the paper is decomposing, already has no edges leaving one block for
-another --- i.e., only when the graph decomposes into strongly connected
-components with no cross edges at all.  A vertex with a self-loop and one
-outgoing edge to a different component (a \emph{transient} sector in the
-usual Markov-chain sense) can still leave a unique sink component
-unreachable from it in the reverse direction; no exact power of $T$
-eliminates that one-directional edge.  The two-projector argument, run on
-the split \{sink component\}/\{everything else\}, only forces vanishing in
-the direction from the sink into the rest, not the reverse: exactly the
-direction of the surviving edge in the four-sector counterexample above
-(there, $1\to3$ and $2\to3$ survive with $3$ the unique sink, while
-$0,1,2$ are transient).  Consequently, the source's own two-projector
-argument --- formalized as stated --- yields at most \emph{uniqueness of the
-final (recurrent) component} of the sector graph, which is a strictly
-weaker statement than recurrence of every nonzero edge, and does not rule
-out the four-sector counterexample's transient edges.  Whether recurrence
-itself follows from injectivity of $\mathcal K$ through some other, more
-specific argument tied to the inverse-map construction of the sector
-tensors --- rather than through this graph-theoretic argument alone --- is
-the open question left by this note.  No such argument has been identified.
+Indeed, let $S$ be a nonempty forward-closed set of sectors and let $C$ be
+its complement.  The direct-sum physical factorization gives the two
+single-site cross-sector vanishings.  The absence of edges from $S$ to $C$
+gives $\eta_{s,c}=0$ for $s\in S$ and $c\in C$, hence
+\[
+  \mathcal A_S\mathcal A_C=0.
+\]
+If the one-site matrices belonging to both sides are nonzero, injectivity
+and the physical direct sum give
+$\mathcal A_S+\mathcal A_C=M_D(\mathbb C)$, contradicting this product
+vanishing exactly as in Appendix~C.2, lines 1463--1470.  Taking $S$ to be
+the vertices reachable from a fixed positive-weight sector would therefore
+show that the positive-weight support is strongly connected, and hence
+recurrent.
+
+The missing formal statements are now precise: a positive Hayashi weight
+must imply that the corresponding same-sector one-site matrix space is
+nonzero, physical unitary reparameterization must preserve the injective
+span, and the preceding one-sided-cut contradiction must be expressed for a
+physical-sector factorization.  The abstract four-sector phase example is
+still a counterexample to cyclic positivity alone, but it does not satisfy
+these additional inverse-map and injectivity conclusions.
 
 \subsection{Coherent vertex rephasing under recurrence}
 
@@ -516,10 +519,10 @@ construction gives
 \leanid{MPOTensor.nonempty_etaLocalStructureData_of_recurrentSupport}.
 
 This result is explicitly a scope restriction: recurrence is an additional
-hypothesis not present in Lemma~C.4.  The remaining elimination problem is to
-prune zero-weight Hayashi summands and derive recurrence for the resulting
-inverse-map neighboring operators from the source's injectivity and normality
-assumptions, without appealing to the later primitivity conclusion.
+hypothesis not present in Lemma~C.4.  The zero-weight reparameterization is
+now formalized.  The remaining elimination problem is to derive recurrence
+for its neighboring operators from injectivity by the directed-cut argument
+above, without appealing to the later primitivity conclusion.
 
 The canonical family
 \leanid{MPOTensor.ExplicitEtaOperators.ofHayashiMarkov} does not supply this
@@ -603,12 +606,12 @@ positive-choice construction is formalized under the symmetric-support scope
 restriction described above.  The sector support graph, the per-cycle
 positive rescaling, and the coherent vertex-rephasing theorem are now
 formalized.  In the last theorem recurrence is a hypothesis, not a conclusion.
-The remaining obligation for the source statement is to prune zero-weight
-Hayashi summands and then derive recurrence from injectivity of $\mathcal K$
-(\S~``Why recurrence is not a direct consequence of the source's own
-argument'' above records why the source's two-projector argument does not by
-itself supply it).  The primitivity of $T_{k,h}$ also remains open and cannot
-be used to derive recurrence without circularity.
+The zero-weight reparameterization is formalized, but recurrence remains a
+hypothesis.  The remaining obligation for the source statement is to prove
+that positive-weight sectors contribute nonzero one-site matrix spaces and
+then formalize the directed-cut injectivity contradiction above.  The
+primitivity of $T_{k,h}$ also remains open and cannot be used to derive
+recurrence without circularity.
 
 For the conditional bond construction, all translates commute pairwise at
 every length $N\geq2$.  The finite-chain MPO is the ordered product of those


### PR DESCRIPTION
## Summary

This change removes the spurious neighboring edges produced by zero-weight Hayashi sectors without deleting any physical summand.

- It defines a generic reparameterization of a physical-sector factorization that replaces the right tensor of an inactive sector by zero when its left tensor already vanishes.
- It proves that the physical-slice factorization is unchanged, every active-source neighboring operator is unchanged, and every inactive-source neighboring operator vanishes.
- It proves that a zero Hayashi weight makes the inverse-map left tensor vanish and specializes the construction to the inverse-map factorization.
- It records both directions of the zero-weight boundary: a zero-weight target already kills the incoming raw neighboring operator, while pruning kills the outgoing one.
- It updates the MPO/RFP blueprint and paper-gap note with the corrected one-sided directed-cut route from Appendix C.2.

## Faithfulness boundary

The construction retains the same sector index, factor dimensions, physical direct sum, and physical isometry; it does not delete zero-weight physical subspaces. It proves only the reparameterization and neighboring-operator formulas. Strong connectivity, recurrence, coherent positivity, and primitivity remain separate obligations.

The source correspondence is arXiv:1606.00608, equations `formK` and `etarl`, lines 1434–1445. The revised gap discussion records that the later injectivity contradiction at lines 1465–1470 uses a one-sided vanishing product, not a two-sided cut.

## Validation

- direct Lean check of `PhysicalSectorPruning.lean`
- full `lake build TNLean`
- blueprint synchronization, changed-declaration coverage, and `checkdecls`
- `leanblueprint pdf` (519 pages), with visual inspection of the affected pages
- reader-facing prose and proof-integrity checks
- `git diff --check`
- independent mathematical, index-orientation, source, blueprint, and identity review by a parallel agent

Advances #3696 and #823.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Lean proofs and documentation on the MPDO physical-sector track; no changes to auth, runtime, or existing factorization APIs beyond new declarations.
> 
> **Overview**
> Adds **`PhysicalSectorPruning.lean`** and wires it into the public import surface. The new Lean work formalizes a **zero-weight physical-sector reparameterization**: when a sector’s left tensor is already zero, zeroing its right tensor leaves the physical-slice factorization unchanged while **killing outgoing neighboring edges** from that source sector.
> 
> The generic construction is **`zeroRightTensorOnInactive`**, with lemmas that active-source **`neighboringOperator`** values are unchanged and inactive-source ones vanish. For the inverse-map factorization it proves **`p_k = 0` ⇒ left tensor and incoming `sectorEta` vanish**, defines **`zeroWeightReparameterizedInverseMapPhysicalSectorFactorization`** (active sectors = nonzero Hayashi weight), and shows neighboring operators match **`sectorEta`** on positive-weight sources and are zero otherwise.
> 
> **Blueprint** (`ch21_mpdo_rfp_simple_local_structure.tex`) gains matching definitions and the zero-weight neighboring-operator theorem. The **paper-gap note** shifts from “prune zero-weight summands” to **retain the full physical direct sum** and use this reparameterization, and reframes recurrence toward a **one-sided directed-cut** injectivity argument rather than the source’s two-projector block split.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e81b2d575715691207c0a46446807b69917c1dc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->