### PR TITLE
doc(mpdo-rfp): improve blueprint chapter readability

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -373,9 +373,10 @@
     \]
     This is a blocked-basis analog of the uniform BNT-label family in
     \cite[Theorem~4.14(ii)]{Cirac2016MPDO_arXiv}; the remaining uniformity
-    gap is recorded in
-    \path{docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex}.
+    gap is open.
 \end{definition}
+% The uniformity gap is documented in
+% docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex.
 
 \begin{theorem}[Trace of a blocked $\chi$ power]%
     \label{thm:mpdo_blocked_structure_chi_trace_matrix_pow}
@@ -443,9 +444,10 @@
     coefficients. This is the blocked-basis analog of the positive
     diagonal matrices in
     \cite[Theorem~4.14(ii)]{Cirac2016MPDO_arXiv}; the uniform BNT-label gap
-    is recorded in
-    \path{docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex}.
+    remains open.
 \end{definition}
+% The uniformity gap is documented in
+% docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex.
 
 \begin{theorem}[BNT witnesses give blocked $\chi$ witnesses]%
     \label{thm:mpdo_bnt_blocked_basis_to_positive_blocked_chi_trace_power_form}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -1,5 +1,7 @@
 \section{Simple local structure from SAL and ZCL}
 
+\subsection{Markov decomposition and inverse-map sector factorization}
+
 For the simple MPDO case in Appendix~C.2 of \cite{Cirac2016MPDO_arXiv},
 the strong-area-law hypothesis is used locally through the equality case of
 strong subadditivity for a normalized three-site reduced state.
@@ -739,6 +741,8 @@ strong subadditivity for a normalized three-site reduced state.
     $(R_4)_{\beta_3,\alpha_1}\ne0$, and the sector factorization applies.
 \end{proof}
 
+\subsection{Neighboring operators and commuting bond products}
+
 \begin{definition}[Neighboring operators]%
     \label{def:mpdo_sector_eta}
     \lean{MPOTensor.sectorEta}
@@ -769,15 +773,19 @@ strong subadditivity for a normalized three-site reduced state.
     shared virtual bond of two neighboring factorized slices leaves the
     neighboring operator between the outer sector tensors:
     \[
-        \sum_{\gamma}
+        \begin{aligned}
+        &\sum_{\gamma}
         \left[U_B\kappa_{\beta_1,\gamma}U_B^\dagger
-        \right]_{(k,l_1,r_1),(k,l_1',r_1')}
+        \right]_{(k,l_1,r_1),(k,l_1',r_1')} \\
+        &\qquad {}\cdot
         \left[U_B\kappa_{\gamma,\alpha_3}U_B^\dagger
-        \right]_{(h,l_2,r_2),(h,l_2',r_2')}
-        =
+        \right]_{(h,l_2,r_2),(h,l_2',r_2')} \\
+        &\quad =
         \left[(l_k)_{\beta_1}\right]_{l_1,l_1'}
-        \left[\eta_{k,h}\right]_{(r_1,l_2),(r_1',l_2')}
+        \left[\eta_{k,h}\right]_{(r_1,l_2),(r_1',l_2')} \\
+        &\qquad {}\cdot
         \left[(r_h)_{\alpha_3}\right]_{r_2,r_2'}.
+        \end{aligned}
     \]
     This is the single-bond step of the identity assembling
     $\bigotimes_{n}\eta_{k_n,k_{n+1}}$ from the factorized chain in
@@ -1900,6 +1908,8 @@ strong subadditivity for a normalized three-site reduced state.
     realizes every finite-chain operator with normalization scalar $1$.
 \end{proof}
 
+\subsection{Closed-sector contractions and coherent rephasing}
+
 \begin{definition}[Closed sector tensors]%
     \label{def:mpdo_closed_sector_tensors}
     \lean{MPOTensor.closedSectorL}
@@ -2870,9 +2880,10 @@ strong subadditivity for a normalized three-site reduced state.
     This is a scope-restricted result. Recurrence is not a hypothesis of
     Lemma~C.4 in
     \cite[Appendix~C.2, lines~1406--1450]{Cirac2016MPDO_arXiv}; its derivation
-    from the source hypotheses remains open and is recorded in
-    \path{docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex}.
+    from the source hypotheses remains open.
 \end{theorem}
+% The recurrence gap is documented in
+% docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex.
 
 \begin{proof}
     \leanok
@@ -2976,6 +2987,8 @@ strong subadditivity for a normalized three-site reduced state.
     applied to that scalar gives
     $\eta'_{k,h}\otimes\eta'_{h,k}=\eta_{k,h}\otimes\eta_{h,k}$.
 \end{proof}
+
+\subsection{Normalized preparations and controlled partial traces}
 
 \begin{definition}[Trace matrices of explicit $\eta$-data]
     \label{def:mpdo_explicit_eta_trace_matrix}
@@ -3936,20 +3949,16 @@ strong subadditivity for a normalized three-site reduced state.
 
 \begin{figure}[ht]
     \centering
-    \begin{minipage}{0.40\textwidth}
-      \centering
-      $\displaystyle\bigoplus_{k,h}$; one $(k,h)$-fiber is drawn
+    $\displaystyle\bigoplus_{k,h}$; one $(k,h)$-fiber is drawn
 
-      \smallskip
-      \TNMPDOTwoSiteTraceAndShift
-    \end{minipage}\hfill
-    \begin{minipage}{0.57\textwidth}
-      \centering
-      $\displaystyle\bigoplus_{k,h}$; one $(k,h)$-fiber and one $l$-summand are drawn
+    \smallskip
+    \TNMPDOTwoSiteTraceAndShift
 
-      \smallskip
-      \TNMPDOThreeSiteTraceAndShift
-    \end{minipage}
+    \medskip
+    $\displaystyle\bigoplus_{k,h}$; one $(k,h)$-fiber and one $l$-summand are drawn
+
+    \smallskip
+    \TNMPDOThreeSiteTraceAndShift
     \caption{Schematics on a fixed $(k,h)$-summand of the global $\bigoplus_{k,h}$ index
     space. The controlled maps $\mathcal T_0$ and $\mathcal S_0$ discard coherences between
     distinct outer summands and take the displayed trace in each diagonal summand; the shifts
@@ -3960,6 +3969,8 @@ strong subadditivity for a normalized three-site reduced state.
     \cite[Appendix~C.2, lines~1521--1559]{Cirac2016MPDO_arXiv}.}
     \label{fig:mpdo_regrouping_partial_trace_maps}
 \end{figure}
+
+\subsection{Refinement and coarse-graining channels}
 
 % **Local fix (zero-weight quotient):** the source quotient is completed on
 % zero-weight pairs. Documented in
@@ -4941,6 +4952,8 @@ $\widehat{\cal K}$.
     \label{fig:mpdo_sector_pairing}
 \end{figure}
 
+\subsection{Primitivity and rank-one trace matrices}
+
 \begin{definition}[Explicit $\eta$-data from the sector tensors]%
     \label{def:mpdo_explicit_eta_of_sector_tensors}
     \lean{MPOTensor.ExplicitEtaOperators.ofSectorTensors}
@@ -5201,13 +5214,13 @@ $\widehat{\cal K}$.
 
     The proposed implication from primitivity and constant trace powers to a
     rank-one factorization is not a valid general theorem. A
-    concrete $3 \times 3$ counterexample appears in the archive, and the
-    deviation from the source is documented in
-    \path{docs/paper-gaps/cpgsv17_pf_rank_one.tex}. The
-    corrected criterion proved here adds positive semidefiniteness and trace
+    concrete $3 \times 3$ counterexample appears in the archive. The corrected
+    criterion proved here adds positive semidefiniteness and trace
     normalization, which provide the diagonalizability needed to turn the
     trace-power condition into a rank-one factorization.
 \end{definition}
+% The deviation from the source is documented in
+% docs/paper-gaps/cpgsv17_pf_rank_one.tex.
 
 \begin{theorem}[Trace square of a Hermitian matrix]
     \label{thm:matrix_hermitian_trace_square_eigenvalues}

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -181,7 +181,7 @@
 % the outer and neighbouring factors already supplied and draws only the
 % inverse regrouping S_2; it deliberately contains no preparation map.
 \newcommand{\TNMPDOTwoSiteTraceAndShift}{%
-    \begin{tikzpicture}[tn picture, scale=0.60]
+    \begin{tikzpicture}[tn picture, scale=0.72]
         \node[anchor=east] at (-3.72,1.18) {$\mathcal T_0:$};
         \TN@subspinbox{tzeroLk}{(-3.15,1.18)}{l_k}
         \TN@subspinbox{tzeroRk}{(-2.15,1.18)}{r_k}
@@ -227,7 +227,7 @@
 % index space traced by S_0.  The lower row starts with that entire block and
 % applies only the inverse regrouping T_2, not T_1 or a full recovery map.
 \newcommand{\TNMPDOThreeSiteTraceAndShift}{%
-    \begin{tikzpicture}[tn picture, scale=0.56]
+    \begin{tikzpicture}[tn picture, scale=0.67]
         \node[anchor=east] at (-4.70,1.35) {$\mathcal S_0:$};
         \TN@subspinbox{szeroLk}{(-4.10,1.35)}{l_k}
         \TN@subspinbox{szeroRk}{(-3.10,1.35)}{r_k}


### PR DESCRIPTION
## Summary

- divide the long simple-local-structure chapter into six mathematical subsections
- enlarge and stack the controlled partial-trace TikZ diagrams for legibility
- reflow the neighboring-bond identity and keep internal gap-note paths out of reader-facing prose

## Validation

- leanblueprint pdf (521 pages)
- leanblueprint web with the compatible Python 3.9 plasTeX environment
- independent visual and prose review
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and LaTeX layout only; no Lean or runtime behavior changes.
> 
> **Overview**
> **Blueprint readability** for the MPDO RFP chapters: the long simple-local-structure section is split into **six `\subsection` headings** (Markov/sector factorization through primitivity/rank-one trace matrices), and the **controlled partial-trace figure** is **stacked vertically** instead of side-by-side minipages.
> 
> **TikZ** macros `\TNMPDOTwoSiteTraceAndShift` and `\TNMPDOThreeSiteTraceAndShift` use **higher scale** (0.72 / 0.67) for legibility. The **neighboring-bond contraction** identity is **reflowed** with an `aligned` environment.
> 
> **Gap notes**: reader-facing `\path{docs/paper-gaps/...}` links are replaced by short prose (“gap is open” / “remains open”); the archive paths move to **LaTeX comments** in `ch21_mpdo_rfp_bnt_coefficients.tex` and the simple-local-structure chapter (uniform χ, recurrence, rank-one deviation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b4d5f44186932e33a457c73c92cf32f37541746. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->