### PR TITLE
feat(MPS/MPDO): prove triple-fusion support identities

### DIFF
--- a/TNLean/MPS/MPDO/BNTTripleFusionComparison.lean
+++ b/TNLean/MPS/MPDO/BNTTripleFusionComparison.lean
@@ -85,6 +85,84 @@ noncomputable def tripleFusionComparison (α β γ : Λ) :
     mulTensorAssocMatrix (Fam.bondDim α) (Fam.bondDim β) (Fam.bondDim γ) *
       (Fam.rightFusionIsometry α β γ)ᴴ
 
+private theorem mulTensorAssocMatrix_mul_conjTranspose (D₁ D₂ D₃ : ℕ) :
+    mulTensorAssocMatrix D₁ D₂ D₃ * (mulTensorAssocMatrix D₁ D₂ D₃)ᴴ = 1 := by
+  ext x y
+  simp [mulTensorAssocMatrix, Matrix.mul_apply, Matrix.conjTranspose_apply,
+    PEquiv.toMatrix_apply, Matrix.one_apply]
+
+private theorem conjTranspose_mul_mulTensorAssocMatrix (D₁ D₂ D₃ : ℕ) :
+    (mulTensorAssocMatrix D₁ D₂ D₃)ᴴ * mulTensorAssocMatrix D₁ D₂ D₃ = 1 := by
+  classical
+  ext x y
+  rw [Matrix.mul_apply, Matrix.one_apply]
+  rw [Finset.sum_eq_single ((mulTensorAssocEquiv D₁ D₂ D₃).symm x)]
+  · simp [mulTensorAssocMatrix, Matrix.conjTranspose_apply, PEquiv.toMatrix_apply]
+  · intro z _ hz
+    have hf : mulTensorAssocEquiv D₁ D₂ D₃ z ≠ x := by
+      intro h
+      apply hz
+      exact (mulTensorAssocEquiv D₁ D₂ D₃).injective
+        (h.trans ((mulTensorAssocEquiv D₁ D₂ D₃).apply_symm_apply x).symm)
+    simp [mulTensorAssocMatrix, Matrix.conjTranspose_apply, PEquiv.toMatrix_apply, hf]
+  · simp
+
+/-- The product of the full triple-fusion comparison with its adjoint is the
+range projection of the left iterated fusion isometry:
+\[
+  C_{\alpha,\beta,\gamma}C_{\alpha,\beta,\gamma}^\dagger
+    = U^{\mathrm L}_{\alpha,\beta,\gamma}
+      (U^{\mathrm L}_{\alpha,\beta,\gamma})^\dagger.
+\]
+
+The right iterated fusion map is an isometry and the bond reassociation is a
+permutation, so both factors cancel between the two copies of the comparison.
+The remaining projection is not asserted to be the identity. Such an assertion
+requires completeness of the fusion decomposition, which is the additional
+hypothesis in the invertible total fusion-matrix argument of the source.
+
+Source: arXiv:1511.08090, source lines 181--191 and 237--252. -/
+theorem tripleFusionComparison_mul_conjTranspose (α β γ : Λ) :
+    Fam.tripleFusionComparison α β γ * (Fam.tripleFusionComparison α β γ)ᴴ =
+      Fam.leftFusionIsometry α β γ * (Fam.leftFusionIsometry α β γ)ᴴ := by
+  unfold tripleFusionComparison
+  rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_mul,
+    Matrix.conjTranspose_conjTranspose]
+  simp only [Matrix.mul_assoc]
+  rw [← Matrix.mul_assoc (Fam.rightFusionIsometry α β γ)ᴴ,
+    Fam.rightFusionIsometry_isometry, Matrix.one_mul]
+  rw [← Matrix.mul_assoc (mulTensorAssocMatrix (Fam.bondDim α)
+      (Fam.bondDim β) (Fam.bondDim γ)),
+    mulTensorAssocMatrix_mul_conjTranspose, Matrix.one_mul]
+
+/-- The product of the adjoint of the full triple-fusion comparison with the
+comparison is the range projection of the right iterated fusion isometry:
+\[
+  C_{\alpha,\beta,\gamma}^\dagger C_{\alpha,\beta,\gamma}
+    = U^{\mathrm R}_{\alpha,\beta,\gamma}
+      (U^{\mathrm R}_{\alpha,\beta,\gamma})^\dagger.
+\]
+
+The left iterated fusion map is an isometry and the bond reassociation is a
+permutation, so both factors cancel between the two copies of the comparison.
+The remaining projection is not asserted to be the identity. Such an assertion
+requires completeness of the fusion decomposition, which is the additional
+hypothesis in the invertible total fusion-matrix argument of the source.
+
+Source: arXiv:1511.08090, source lines 181--191 and 237--252. -/
+theorem conjTranspose_mul_tripleFusionComparison (α β γ : Λ) :
+    (Fam.tripleFusionComparison α β γ)ᴴ * Fam.tripleFusionComparison α β γ =
+      Fam.rightFusionIsometry α β γ * (Fam.rightFusionIsometry α β γ)ᴴ := by
+  unfold tripleFusionComparison
+  rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_mul,
+    Matrix.conjTranspose_conjTranspose]
+  simp only [Matrix.mul_assoc]
+  rw [← Matrix.mul_assoc (Fam.leftFusionIsometry α β γ)ᴴ,
+    Fam.leftFusionIsometry_isometry, Matrix.one_mul]
+  rw [← Matrix.mul_assoc
+      (mulTensorAssocMatrix (Fam.bondDim α) (Fam.bondDim β) (Fam.bondDim γ))ᴴ,
+    conjTranspose_mul_mulTensorAssocMatrix, Matrix.one_mul]
+
 /-- **The full triple-fusion comparison intertwines the unweighted direct
 sums.** Suppose the positive trace-power coefficients are independent of the
 positive chain length. For every letter, if

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -607,6 +607,61 @@ separate step.
     \cite{Bultinck2017Anyons}.
 \end{definition}
 
+\begin{theorem}[Left range projection of the full triple-fusion comparison]%
+    \label{thm:mpdo_triple_fusion_comparison_left_range}
+    \lean{MPOTensor.BNTFusionIsometryFamily.%
+        tripleFusionComparison_mul_conjTranspose}
+    \leanok
+    \uses{def:mpdo_triple_fusion_comparison}
+    The product of the full comparison with its adjoint is the range
+    projection of the left iterated fusion isometry:
+    \[
+        C_{\alpha,\beta,\gamma}C_{\alpha,\beta,\gamma}^{\dagger}
+          =U^{\mathrm L}_{\alpha,\beta,\gamma}
+            (U^{\mathrm L}_{\alpha,\beta,\gamma})^{\dagger}.
+    \]
+    The right side is not asserted to be the identity.  Surjectivity of the
+    left iterated fusion map requires completeness of the fusion
+    decomposition, corresponding to the invertible total fusion matrix in
+    \cite[lines~181--191]{Bultinck2017Anyons}.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:mpdo_right_fusion_isometry_isometry,
+        def:mpdo_operator_product_associator}
+    Substitute
+    $C=U^{\mathrm L}A(U^{\mathrm R})^{\dagger}$.
+    The isometry identity $(U^{\mathrm R})^{\dagger}U^{\mathrm R}=1$
+    and the two-sided inverse identities for the permutation matrix $A$
+    leave $U^{\mathrm L}(U^{\mathrm L})^{\dagger}$.
+\end{proof}
+
+\begin{theorem}[Right range projection of the full triple-fusion comparison]%
+    \label{thm:mpdo_triple_fusion_comparison_right_range}
+    \lean{MPOTensor.BNTFusionIsometryFamily.%
+        conjTranspose_mul_tripleFusionComparison}
+    \leanok
+    \uses{def:mpdo_triple_fusion_comparison}
+    The product in the opposite order is the range projection of the right
+    iterated fusion isometry:
+    \[
+        C_{\alpha,\beta,\gamma}^{\dagger}C_{\alpha,\beta,\gamma}
+          =U^{\mathrm R}_{\alpha,\beta,\gamma}
+            (U^{\mathrm R}_{\alpha,\beta,\gamma})^{\dagger}.
+    \]
+    The right side is not asserted to be the identity.  Surjectivity of the
+    right iterated fusion map likewise requires completeness of the fusion
+    decomposition.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:mpdo_left_fusion_isometry_isometry,
+        def:mpdo_operator_product_associator}
+    Substitute
+    $C=U^{\mathrm L}A(U^{\mathrm R})^{\dagger}$.
+    The isometry identity $(U^{\mathrm L})^{\dagger}U^{\mathrm L}=1$
+    and the two-sided inverse identities for $A$ leave
+    $U^{\mathrm R}(U^{\mathrm R})^{\dagger}$.
+\end{proof}
+
 \begin{theorem}[The full triple-fusion comparison intertwines the unweighted
         direct sums]%
     \label{thm:mpdo_triple_fusion_comparison_intertwines}

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -510,6 +510,27 @@ is oriented from the right-associated sum to the left-associated sum, hence
 oppositely to the printed $F$-matrix convention in equation
 \texttt{Fmove}; it is not identified with that $F$-matrix.
 
+The two products of the full comparison with its adjoint are now identified
+exactly:
+\[
+    CC^\dagger=U^{\mathrm L}(U^{\mathrm L})^\dagger,
+    \qquad
+    C^\dagger C=U^{\mathrm R}(U^{\mathrm R})^\dagger.
+\]
+These are the range projections of the two iterated fusion isometries.  They
+are formalized by
+\leanid{MPOTensor.BNTFusionIsometryFamily.%
+tripleFusionComparison_mul_conjTranspose} and
+\leanid{MPOTensor.BNTFusionIsometryFamily.%
+conjTranspose_mul_tripleFusionComparison}.  The present fusion assumptions
+give $(U^{\mathrm L})^\dagger U^{\mathrm L}=1$ and
+$(U^{\mathrm R})^\dagger U^{\mathrm R}=1$, but do not identify either range
+projection with the identity.  Thus the full comparison is a partial
+isometry between these ranges.  The invertible total fusion matrix of
+arXiv:1511.08090, lines~187--191, supplies the missing completeness in the
+source argument; no corresponding surjectivity assertion is presently part
+of the fusion-isometry family.
+
 The simultaneous inverse relation at line~269 of the arXiv:1511.08090 source,
 \[
     B_d^+ B_{d'}=\delta_{d,d'}1,


### PR DESCRIPTION
## Summary

- prove that the full triple-fusion comparison times its adjoint is the left fusion-range projection
- prove the adjoint-order identity for the right fusion-range projection
- record in the blueprint and paper-gap note that these are partial-isometry identities, not completeness or invertibility statements

These statements isolate the exact unconditional content available before the source total-fusion completeness argument. Advances #3776.

## Validation

- full lake build
- lake env lean TNLean/MPS/MPDO/BNTTripleFusionComparison.lean
- leanblueprint checkdecls
- blueprint declaration synchronization
- leanblueprint pdf (521 pages)
- independent mathematical and source-faithfulness review
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal mathematics and documentation in an existing MPDO module; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds Lean proofs that the full triple-fusion comparison \(C = U^{\mathrm L} A (U^{\mathrm R})^\dagger\) satisfies **\(C C^\dagger = U^{\mathrm L}(U^{\mathrm L})^\dagger\)** and **\(C^\dagger C = U^{\mathrm R}(U^{\mathrm R})^\dagger\)**, by canceling the bond reassociation permutation \(A\) and the opposite-bracketing isometry in each product.
> 
> Supporting lemmas show `mulTensorAssocMatrix` is unitary in both multiplication orders. Docstrings and blueprint theorems (`tripleFusionComparison_mul_conjTranspose`, `conjTranspose_mul_tripleFusionComparison`) state explicitly that these are **range projections**, not identity or full invertibility; completeness would need the source total-fusion hypothesis.
> 
> The CPGSV17 paper-gap note is updated to record that \(C\) is a **partial isometry** on the iterated-fusion ranges under present fusion-isometry assumptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57e9c8a8b028892e8d3a7e64d80c312050aeb7cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->