### PR TITLE
feat(MPS/MPDO): prove fixed-final multiplicity squareness

### DIFF
--- a/TNLean/MPS/MPDO/BNTFinalSectorFusion.lean
+++ b/TNLean/MPS/MPDO/BNTFinalSectorFusion.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.BNTLeftTripleFusion
 import TNLean.MPS.MPDO.BNTRightTripleFusion
+import TNLean.MPS.MPDO.BNTAssociativity
 import TNLean.Algebra.ScalarCommutant
 
 /-!
@@ -21,11 +22,16 @@ associator.  No identification of the positive diagonal chi indices with the fus
 multiplicities of that source is asserted here.  Such a comparison first requires the
 length-independent integer specialization and injectivity of `tensor ε`.
 
+Associativity gives one further conclusion in the length-independent case: eventual linear
+independence identifies the cardinalities of the two fixed-final multiplicity spaces.  Thus a
+matrix between them has square shape.  This numerical conclusion does not provide the
+completeness of the two fusion decompositions required for invertibility.
+
 The final result below isolates the part of the comparison that follows from injectivity.  If a
 matrix between the two fixed-final-sector spaces already intertwines the amplified letters of
 `tensor ε`, then it acts trivially on the bond factor, up to a matrix between the two
-multiplicity spaces.  The result does not construct this intertwiner, prove that it is
-invertible, or identify the chi dimensions with fusion multiplicities.
+multiplicity spaces.  The result does not construct this intertwiner or prove that it is
+invertible.
 
 ## References
 
@@ -63,6 +69,58 @@ asserted.
 Source: arXiv:1606.00608, Theorem IV.13(iii), lines 986--999. -/
 abbrev RightFinalMultiplicity (α β γ ε : Λ) : Type u :=
   (δ : Λ) × Fin (Fam.chi.dim β γ δ) × Fin (Fam.chi.dim α δ ε)
+
+/-- The left- and right-associated multiplicity spaces at a fixed final label
+have the same dimension when the positive trace-power coefficients are length
+independent and the labelled operators are eventually linearly independent.
+
+Indeed, eventual linear independence permits coefficient comparison in the
+associativity identity, while length independence identifies each coefficient
+with the corresponding fusion multiplicity.  The resulting equality is
+\[
+  \sum_\delta r_{\alpha,\beta}^{\delta}r_{\delta,\gamma}^{\varepsilon}
+    = \sum_\delta
+      r_{\beta,\gamma}^{\delta}r_{\alpha,\delta}^{\varepsilon}.
+\]
+
+This proves only that a fixed-final multiplicity matrix has square shape.  It
+does not supply completeness of either fusion decomposition and does not prove
+that the fixed-final comparison is invertible.
+
+**Scope restriction (BNT input):** Eventual linear independence is an explicit
+hypothesis because a fusion-isometry family does not itself include the defining
+independence property of a basis of normal tensors.  This distinction is recorded
+in `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`.
+
+Source: arXiv:1606.00608, lines 995--1010; arXiv:1511.08090,
+`AnyonsPEPS.tex`, lines 237--252, especially the multiplicity associativity
+identity at lines 238--241. -/
+theorem card_leftFinalMultiplicity_eq_card_rightFinalMultiplicity_of_lengthIndependent
+    (c : BNTLabelCoefficientFamily Λ)
+    (hχ : c.HasPositiveLengthChiTracePowerForm Fam.chi)
+    (hLI : c.LengthIndependent)
+    (hlin : Fam.toOperatorFamily.EventuallyLinearIndependent)
+    (α β γ ε : Λ) :
+    Fintype.card (Fam.LeftFinalMultiplicity α β γ ε) =
+      Fintype.card (Fam.RightFinalMultiplicity α β γ ε) := by
+  have hprod : Fam.toOperatorFamily.HasSameLengthProductForm c := by
+    intro L hL α' β'
+    rw [Fam.toOperatorFamily_hasSameLengthProductForm L hL α' β']
+    apply Finset.sum_congr rfl
+    intro γ' _
+    rw [BNTLabelCoefficientFamily.ofChi_coeff, ← hχ L hL α' β' γ']
+  obtain ⟨N, hN⟩ := hlin
+  let L := N + 1
+  have hL : 0 < L := by
+    simp [L]
+  have hassoc := hprod.coeff_assoc_of_linearIndependentAt hL
+    (hN L (by simp [L])) α β γ ε
+  simp_rw [hχ.coeff_eq_dim_of_lengthIndependent Fam.posEntries hLI L hL] at hassoc
+  have hnat :
+      ∑ δ, Fam.chi.dim α β δ * Fam.chi.dim δ γ ε =
+        ∑ δ, Fam.chi.dim β γ δ * Fam.chi.dim α δ ε := by
+    exact_mod_cast hassoc
+  simpa only [Fintype.card_sigma, Fintype.card_prod, Fintype.card_fin] using hnat
 
 /-- The left-associated fixed-final-sector index, including the bond index of `tensor ε`.
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -785,6 +785,43 @@ separate step.
     $\mathcal H^{\mathrm R}_{\varepsilon}\otimes\C^{D_\varepsilon}$.
 \end{definition}
 
+\begin{theorem}[Equality of fixed-final multiplicity dimensions]%
+    \label{thm:mpdo_final_sector_multiplicity_card_eq}
+    \lean{MPOTensor.BNTFusionIsometryFamily.%
+        card_leftFinalMultiplicity_eq_card_rightFinalMultiplicity_of_lengthIndependent}
+    \leanok
+    \uses{def:mpdo_final_sector_multiplicity_spaces,
+        def:mpdo_bnt_label_linear_independent,
+        def:mpdo_bnt_label_length_independent}
+    Suppose that the positive trace-power coefficients are independent of
+    the positive chain length and that the labelled operators are eventually
+    linearly independent.  Then, for each final label $\varepsilon$,
+    \[
+        \dim\mathcal H^{\mathrm L}_{\varepsilon}
+          = \sum_{\delta}
+              \dim\chi_{\alpha,\beta,\delta}\,
+              \dim\chi_{\delta,\gamma,\varepsilon}
+          = \sum_{\delta}
+              \dim\chi_{\beta,\gamma,\delta}\,
+              \dim\chi_{\alpha,\delta,\varepsilon}
+          = \dim\mathcal H^{\mathrm R}_{\varepsilon}.
+    \]
+    Consequently a matrix between the two fixed-final multiplicity spaces
+    is square.  This is the numerical associativity statement of
+    \cite[lines~237--241]{Bultinck2017Anyons}; it does not assert completeness
+    of the fusion maps or invertibility of the fixed-final comparison.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:mpdo_bnt_label_coeff_associativity,
+        thm:mpdo_bnt_label_length_independent_natural}
+    Choose a positive length beyond the linear-independence threshold.
+    Associativity of the same-length product law gives equality of the two
+    sums of products of structure coefficients.  Length independence and
+    positivity identify every coefficient with the size of its corresponding
+    diagonal $\chi$-matrix.  The two sums are precisely the cardinalities of
+    the displayed dependent sums.
+\end{proof}
+
 \begin{definition}[Triple-fusion maps with fixed final label]%
     \label{def:mpdo_final_sector_fusion_maps}
     \lean{MPOTensor.BNTFusionIsometryFamily.leftFinalFusionMap}

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -565,11 +565,31 @@ oriented oppositely to the printed convention.
 This remains a scope-restricted result.  Neither the simultaneous final-label
 selectors nor one-letter injectivity of every final tensor at the present
 blocking is derived from the assumptions on the fusion-isometry family.  The
-matrix $F_\varepsilon$ may be rectangular, and the theorem proves neither its
-invertibility nor invertibility of the diagonal corner.  It is therefore not
-identified with the printed $F$-matrix.  The invertible fixed-final
-$F$-transformation and the pentagon-like equation mentioned at lines~995--999
-remain unformalized.
+factorization theorem alone permits a rectangular matrix $F_\varepsilon$.
+
+There is now a separate numerical squareness result.  Under length
+independence and eventual linear independence,
+\leanid{MPOTensor.BNTFusionIsometryFamily.%
+card_leftFinalMultiplicity_eq_card_rightFinalMultiplicity_of_lengthIndependent}
+specializes the coefficient associativity relation to
+\[
+  \sum_\delta r_{\alpha,\beta}^{\delta}
+      r_{\delta,\gamma}^{\varepsilon}
+    = \sum_\delta r_{\beta,\gamma}^{\delta}
+      r_{\alpha,\delta}^{\varepsilon}.
+\]
+This is exactly the equality of fixed-final multiplicity dimensions at
+lines~238--241 of the arXiv:1511.08090 source.  It proves that the matrix
+$F_\varepsilon$ has square shape when both the factorization theorem and the
+additional eventual-independence hypothesis apply.  It does not prove that
+$F_\varepsilon$, or the corresponding diagonal corner, is invertible.
+Lines~181--191 of that source explain the remaining obstruction: without the
+zipper completeness relation, the fusion tensors may cover only a proper
+support subspace and may leave nonzero upper-triangular blocks.  The existing
+isometry relation supplies a left inverse but not this missing range
+completeness.  Consequently the formalized square-shape result is not yet the
+printed invertible $F$-matrix.  The invertible fixed-final transformation and
+the pentagon-like equation mentioned at lines~995--999 remain unformalized.
 
 To eliminate the source-theorem gap, the formalization should instead:
 \begin{enumerate}


### PR DESCRIPTION
## Summary

- prove equality of the left and right fixed-final multiplicity cardinalities
- derive the equality from coefficient associativity at a positive linearly independent length
- synchronize the blueprint and paper-gap note while keeping completeness and invertibility explicitly open

This formalizes the dimension equality in arXiv:1511.08090, lines 238–241. It proves that the fixed-final comparison is square under the stated scope restrictions; it does not assert surjectivity, invertibility, or a pentagon identity. Advances #3776.

## Validation

- full lake build
- lake env lean TNLean/MPS/MPDO/BNTFinalSectorFusion.lean
- leanblueprint checkdecls
- blueprint declaration synchronization
- leanblueprint web
- leanblueprint pdf (521 pages) with visual inspection
- independent mathematical and source-faithfulness review
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formal theorem and documentation only; no changes to authentication, runtime behavior, or existing proof obligations beyond the new import and theorem.
> 
> **Overview**
> Adds **`card_leftFinalMultiplicity_eq_card_rightFinalMultiplicity_of_lengthIndependent`**, showing left- and right-bracket **fixed-final multiplicity** spaces have equal cardinality when trace-power coefficients are **length-independent** and BNT operators are **eventually linearly independent**. The proof chains fusion **same-length product form**, **coefficient associativity** at a length past the independence threshold, and identification of coefficients with **χ dimensions**, then rewrites the resulting sum equality via **Fintype** cardinalities.
> 
> **Blueprint** gains the matching theorem (numerical associativity at fixed final label ε; square comparison matrix, not invertibility). **Paper-gap** text is updated to separate this **square-shape** result from the prior Kronecker factorization and to keep **completeness / invertible F-matrix** explicitly open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cae17e4ddb663abfddf4ab5affad14bdd6d2c02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->