### PR TITLE
feat(MPS/MPDO): add directed sector cut annihilation

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -395,6 +395,7 @@ import TNLean.MPS.MPDO.PhysicalSectorFactorization
 import TNLean.MPS.MPDO.PhysicalSectorRephasing
 import TNLean.MPS.MPDO.InverseMapPhysicalSectorFactorization
 import TNLean.MPS.MPDO.PhysicalSectorPruning
+import TNLean.MPS.MPDO.PhysicalSectorDirectedCut
 import TNLean.MPS.MPDO.NeighboringPreparation
 import TNLean.MPS.MPDO.PhysicalSectorSubspinMaps
 import TNLean.MPS.MPDO.PhysicalSectorClosureCoordinates

--- a/TNLean/MPS/MPDO/PhysicalSectorDirectedCut.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorDirectedCut.lean
@@ -1,0 +1,128 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalSectorFactorization
+
+/-!
+# Matrix spaces separated by a directed sector cut
+
+For a physical-sector factorization, the matrices belonging to a set of
+sectors are the span of the corresponding one-site MPO matrices.  If every
+neighboring operator from one set of sectors to another vanishes, then every
+matrix in the first span annihilates every matrix in the second span on the
+left.
+
+Only this one-sided conclusion is used in the local-orthogonality argument of
+the source.  No vanishing in the reverse order and no recurrence of the sector
+graph are asserted here.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, equation `P1KP2` and lines 1463--1470
+-/
+
+open scoped Matrix
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D}
+
+/-- The virtual matrix of the sector-coordinate tensor obtained from one
+matrix entry inside a fixed physical sector.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1463--1467, where these are the
+generators of the spaces denoted by $\mathcal A_1$ and $\mathcal A_2$. -/
+noncomputable def oneSiteSectorMatrix (F : PhysicalSectorFactorization K)
+    (k : Fin F.sectorCount) (x y : SectorIndex F k) :
+    Matrix (Fin D) (Fin D) ℂ :=
+  F.sectorCoordinateTensor
+    (F.sectorFinEquiv.symm ⟨k, x⟩) (F.sectorFinEquiv.symm ⟨k, y⟩)
+
+/-- A vanishing neighboring operator makes the corresponding one-site sector
+matrices vanish in the directed product order.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `P1KP2` and lines 1463--1470.
+The source uses precisely the product $\mathcal A_1\mathcal A_2=0$. -/
+theorem oneSiteSectorMatrix_mul_eq_zero_of_neighboringOperator_eq_zero
+    (F : PhysicalSectorFactorization K) (k h : Fin F.sectorCount)
+    (hkh : F.neighboringOperator k h = 0)
+    (x y : SectorIndex F k) (u v : SectorIndex F h) :
+    F.oneSiteSectorMatrix k x y * F.oneSiteSectorMatrix h u v = 0 := by
+  ext beta alpha
+  simp only [Matrix.mul_apply, oneSiteSectorMatrix,
+    sectorCoordinateTensor_apply_same, Matrix.zero_apply]
+  have heta :
+      (∑ gamma : Fin D,
+        F.rightTensor k gamma x.2 y.2 * F.leftTensor h gamma u.1 v.1) = 0 := by
+    have hentry := congrArg
+      (fun M ↦ M (x.2, u.1) (y.2, v.1)) hkh
+    simpa only [neighboringOperator_apply, Matrix.zero_apply] using hentry
+  calc
+    ∑ gamma : Fin D,
+        F.leftTensor k beta x.1 y.1 * F.rightTensor k gamma x.2 y.2 *
+          (F.leftTensor h gamma u.1 v.1 * F.rightTensor h alpha u.2 v.2) =
+      F.leftTensor k beta x.1 y.1 *
+        (∑ gamma : Fin D,
+          F.rightTensor k gamma x.2 y.2 * F.leftTensor h gamma u.1 v.1) *
+        F.rightTensor h alpha u.2 v.2 := by
+          rw [Finset.mul_sum, Finset.sum_mul]
+          apply Finset.sum_congr rfl
+          intro gamma _
+          ring
+    _ = 0 := by rw [heta]; simp
+
+/-- The span of the one-site virtual matrices whose physical entries belong
+to sectors in `S`.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1463--1467, where the two
+instances associated with complementary physical projections are denoted by
+$\mathcal A_1$ and $\mathcal A_2$. -/
+noncomputable def oneSiteSectorSpace (F : PhysicalSectorFactorization K)
+    (S : Set (Fin F.sectorCount)) : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ) :=
+  Submodule.span ℂ {A | ∃ k ∈ S, ∃ x y, A = F.oneSiteSectorMatrix k x y}
+
+/-- If there are no neighboring operators directed from `S` to `C`, then
+every matrix belonging to the one-site sector space of `S` annihilates every
+matrix belonging to the one-site sector space of `C` on the left.
+
+This is the source-faithful directed-cut conclusion
+$\mathcal A_S\mathcal A_C=0$.  It neither assumes nor concludes the reverse
+product vanishing.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `P1KP2` and lines 1463--1470.
+-/
+theorem oneSiteSectorSpace_mul_eq_zero
+    (F : PhysicalSectorFactorization K) (S C : Set (Fin F.sectorCount))
+    (hcut : ∀ k ∈ S, ∀ h ∈ C, F.neighboringOperator k h = 0)
+    {A B : Matrix (Fin D) (Fin D) ℂ}
+    (hA : A ∈ F.oneSiteSectorSpace S) (hB : B ∈ F.oneSiteSectorSpace C) :
+    A * B = 0 := by
+  refine Submodule.span_induction₂
+    (s := {M | ∃ k ∈ S, ∃ x y, M = F.oneSiteSectorMatrix k x y})
+    (t := {M | ∃ h ∈ C, ∃ u v, M = F.oneSiteSectorMatrix h u v})
+    (p := fun A B _ _ ↦ A * B = 0)
+    ?_ ?_ ?_ ?_ ?_ ?_ ?_
+    (by simpa only [oneSiteSectorSpace] using hA)
+    (by simpa only [oneSiteSectorSpace] using hB)
+  · intro A B hAmem hBmem
+    rcases hAmem with ⟨k, hkS, x, y, rfl⟩
+    rcases hBmem with ⟨h, hhC, u, v, rfl⟩
+    exact F.oneSiteSectorMatrix_mul_eq_zero_of_neighboringOperator_eq_zero
+      k h (hcut k hkS h hhC) x y u v
+  · intro B _
+    simp
+  · intro A _
+    simp
+  · intro A₁ A₂ B _ _ _ h₁ h₂
+    rw [Matrix.add_mul, h₁, h₂, add_zero]
+  · intro A B₁ B₂ _ _ _ h₁ h₂
+    rw [Matrix.mul_add, h₁, h₂, add_zero]
+  · intro r A B _ _ hAB
+    rw [smul_mul_assoc, hAB, smul_zero]
+  · intro r A B _ _ hAB
+    rw [mul_smul_comm, hAB, smul_zero]
+
+end MPOTensor.PhysicalSectorFactorization

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -855,6 +855,57 @@ strong subadditivity for a normalized three-site reduced state.
     this definition; it is a separate hypothesis in Proposition~C.7.
 \end{definition}
 
+\begin{definition}[One-site matrix spaces of sector sets]%
+    \label{def:mpdo_one_site_sector_matrix_space}
+    \lean{MPOTensor.PhysicalSectorFactorization.oneSiteSectorMatrix,
+      MPOTensor.PhysicalSectorFactorization.oneSiteSectorSpace}
+    \leanok
+    \uses{def:mpdo_physical_sector_factorization}
+    For a sector $k$ and physical matrix indices $x,y$ in its summand, let
+    $A_{k;x,y}\in\MN{D}$ be the corresponding entry of the
+    sector-coordinate tensor. For a set $S$ of sectors, define
+    \[
+        {\cal A}_S=\spn\{A_{k;x,y}:k\in S\}.
+    \]
+    These are the matrix spaces associated with the physical projections in
+    \cite[Appendix~C.2, lines~1463--1467]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{theorem}[Directed-cut annihilation of one-site matrix spaces]%
+    \label{thm:mpdo_directed_cut_one_site_spaces}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+      oneSiteSectorMatrix_mul_eq_zero_of_neighboringOperator_eq_zero}
+    \lean{MPOTensor.PhysicalSectorFactorization.oneSiteSectorSpace_mul_eq_zero}
+    \leanok
+    \uses{def:mpdo_minimal_neighboring_operator,
+      def:mpdo_one_site_sector_matrix_space}
+    Let $S$ and $C$ be sets of sectors. If
+    \[
+        \eta_{k,h}=0\qquad(k\in S,\ h\in C),
+    \]
+    then
+    \[
+        XY=0\qquad(X\in{\cal A}_S,\ Y\in{\cal A}_C).
+    \]
+    No conclusion in the reverse product order is asserted. This is the
+    directed local-orthogonality implication used in
+    \cite[Appendix~C.2, lines~1463--1470]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Expand two generating matrices in sector coordinates. Their product has
+    entries
+    \[
+      \sum_{\gamma}
+        (l_k)_\beta (r_k)_\gamma
+        (l_h)_\gamma (r_h)_\alpha.
+    \]
+    The middle contraction is a matrix entry of $\eta_{k,h}$ and therefore
+    vanishes. Bilinearity extends the conclusion from the generators to the
+    two linear spans.
+\end{proof}
+
 \begin{definition}[Vertex rephasing of the sector tensors]%
     \label{def:mpdo_physical_sector_rephasing}
     \lean{MPOTensor.PhysicalSectorFactorization.rephase}
@@ -5119,6 +5170,7 @@ $\widehat{\cal K}$.
         def:mpdo_zero_weight_reparameterized_inverse_map_factorization,
         thm:mpdo_zero_weight_reparameterized_neighboring_operator,
         lem:mpdo_local_orthogonality_contraction,
+        thm:mpdo_directed_cut_one_site_spaces,
         lem:matrix_one_sided_product_obstruction}
     First use the zero-weight reparameterization to make every zero-weight
     sector isolated. Suppose that the retained support is not strongly
@@ -5127,15 +5179,15 @@ $\widehat{\cal K}$.
     There are no neighboring edges from $S$ to $C$.
 
     Let ${\cal A}_S$ and ${\cal A}_C$ be the one-site matrix spaces belonging
-    to the two classes. The source argument requires three remaining bridges:
-    both spaces are nonzero, injectivity in the physical sector coordinates
-    gives ${\cal A}_S+{\cal A}_C=\MN{D}$, and the local contraction across the
-    directed cut gives ${\cal A}_S{\cal A}_C=0$. Once these are established,
+    to the two classes. The directed-cut theorem gives
+    ${\cal A}_S{\cal A}_C=0$. The source argument still requires two bridges:
+    both spaces are nonzero, and injectivity in the physical sector coordinates
+    gives ${\cal A}_S+{\cal A}_C=\MN{D}$. Once these are established,
     Lemma~\ref{lem:matrix_one_sided_product_obstruction} gives the desired
     contradiction. No vanishing in the reverse order is needed. This is the
     directed-cut argument at
     \cite[Appendix~C.2, lines~1452--1470]{Cirac2016MPDO_arXiv}; formalizing the
-    three bridges, and then the passage from the resulting recurrent positive
+    two bridges, and then the passage from the resulting recurrent positive
     support to primitivity of $T$, remains open.
 \end{proof}
 

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -454,8 +454,10 @@ physical summand, sets the right sector tensor to zero when its Hayashi weight
 vanishes, and thereby isolates every zero-weight sector without changing the
 physical slices.  On the retained positive-weight support, let $S$ be a
 nonempty proper forward-closed set and let $C$ be its complement.  The absence
-of edges from $S$ to $C$ should give
-$\mathcal A_S\mathcal A_C=0$.  Injectivity should give
+of edges from $S$ to $C$ now gives
+$\mathcal A_S\mathcal A_C=0$ by
+\leanid{MPOTensor.PhysicalSectorFactorization.oneSiteSectorSpace_mul_eq_zero}.
+Injectivity should give
 $\mathcal A_S+\mathcal A_C=M_D(\mathbb C)$, while nontriviality of the two
 parts should make both spaces nonzero.  The formalized obstruction would
 then give a contradiction.  No absence of edges from $C$ to $S$ is needed.
@@ -463,11 +465,10 @@ then give a contradiction.  No absence of edges from $C$ to $S$ is needed.
 The remaining statements needed for this application are separate from the
 matrix-algebra lemma: physical unitary reparameterization must be shown to
 preserve the injective one-site span, positive-weight sectors must contribute
-nonzero one-site matrix spaces, and vanishing neighboring operators across a
-directed cut must be transported to the corresponding product of those
-spaces.  The abstract four-sector phase example remains a counterexample to
-cyclic positivity alone, but it need not satisfy these inverse-map and
-injectivity consequences.  Thus no recurrence theorem is asserted here.
+nonzero one-site matrix spaces.  The abstract four-sector phase example
+remains a counterexample to cyclic positivity alone, but it need not satisfy
+these inverse-map and injectivity consequences.  Thus no recurrence theorem
+is asserted here.
 
 \subsection{Coherent vertex rephasing under recurrence}
 


### PR DESCRIPTION
## Summary

- define the one-site virtual matrix spaces belonging to arbitrary sector sets
- prove at the generator level that a vanishing neighboring operator forces the corresponding directed product to vanish
- extend the conclusion by bilinearity to the full sector matrix spaces
- update the blueprint and paper-gap analysis so only the nontriviality and injective-spanning bridges remain in the directed-cut route

This formalizes the one-sided implication used in arXiv:1606.00608, Appendix C.2, lines 1463–1470. It makes no reverse-product or recurrence claim. Advances #3696.

## Validation

- full lake build TNLean (9353 jobs)
- lake env lean TNLean/MPS/MPDO/PhysicalSectorDirectedCut.lean
- regenerated blueprint declaration synchronization
- lake exe checkdecls blueprint/lean_decls
- leanblueprint pdf (522 pages)
- focused visual inspection of the rendered theorem and proof
- independent mathematical and source-faithfulness review
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization and documentation on the MPDO physical-sector track; no runtime or security-sensitive code paths.
> 
> **Overview**
> **Formalizes the one-sided directed-cut step** from Cirac–Perez-Garcia–Schuch–Verstraete Appendix C.2: when all neighboring operators vanish from sector set `S` to `C`, matrices in the one-site sector spans multiply to zero as `𝒜_S 𝒜_C = 0` (no reverse-order claim).
> 
> Adds `PhysicalSectorDirectedCut.lean` with `oneSiteSectorMatrix`, `oneSiteSectorSpace`, a generator-level vanishing lemma from zero `neighboringOperator`, and span extension via `Submodule.span_induction₂`. Registers the module in `TNLean.lean`.
> 
> Blueprint chapter 21 gains matching definitions/theorems and proof sketch; the recurrence proof outline now cites this theorem and lists only **nontriviality** and **injective spanning** as remaining bridges. The paper-gap note marks transport across the cut as closed and drops it from the open list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f94725996e01b9abf221eedd456950d3dd99c16e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->