### PR TITLE
doc(blueprint): add unweighted zipper diagram

### DIFF
--- a/blueprint/src/Packages/tn_diagrams.py
+++ b/blueprint/src/Packages/tn_diagrams.py
@@ -78,6 +78,7 @@ _DIAGRAM_ARGS: dict[str, str] = {
     "TNMPDOZCLIdempotence": "",
     "TNMPDOFixedFinalFusionBracketings": "",
     "TNMPDOBNTFusionIdentity": "",
+    "TNMPDOUnweightedZipperReconstruction": "",
     "TNMPDOFusionTracePower": "",
     "TNRFPKrausIsometry": "",
     "TNRFPKrausIsometryReverse": "",

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -369,6 +369,25 @@ them.
     letter and apply the fusion identity between the two inserted factors.
 \end{proof}
 
+\begin{figure}[ht]
+    \centering
+    \TNMPDOUnweightedZipperReconstruction
+    \caption{The two unweighted zipper directions and their local
+        reconstruction consequence. Here
+        $H=H_{\alpha,\beta}^{ij}$ and the physical indices are carried by the
+        vertical legs. The final row uses only
+        $U_{\alpha,\beta}^\dagger U_{\alpha,\beta}=1$ to recover the product
+        letter. It does not assert
+        $U_{\alpha,\beta}U_{\alpha,\beta}^\dagger=1$, surjectivity of the
+        fusion map, total-fusion completeness, or invertibility of a
+        fixed-final comparison. The layout follows the zipper figures of
+        \cite[Section~3, Equations~(19)--(21)]{Bultinck2017Anyons}; in the
+        MPDO specialization these identities arise from the length-independent
+        fusion data discussed in
+        \cite[lines~995--1008]{Cirac2016MPDO_arXiv}.}
+    \label{fig:mpdo_unweighted_zipper_reconstruction}
+\end{figure}
+
 \begin{definition}[Operator family of a fusion-isometry family]%
     \label{def:mpdo_bnt_fusion_operator_family}
     \lean{MPOTensor.BNTFusionIsometryFamily.toOperatorFamily}

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -1231,6 +1231,109 @@
     \end{tikzpicture}%
 }
 
+% The two unweighted zipper directions and the resulting reconstruction of a
+% product letter.  This follows the graphical arrangement of the zipper
+% figures in Bultinck et al., arXiv:1511.08090, while using the notation of
+% the present MPDO fusion family.  The final row uses U^\dagger U = 1 only;
+% it deliberately does not depict U U^\dagger = 1.
+\newcommand{\TNMPDOUnweightedZipperReconstruction}{%
+    \begin{tikzpicture}[tn picture, scale=0.95]
+        % U (M_alpha M_beta) = H U.
+        \node[anchor=east] at (-4.72,2.35)
+            {$U(M_\alpha M_\beta)=HU$};
+        \node[draw, rounded corners, fill=blue!8, inner sep=2pt,
+            minimum height=1.10cm] (uzTopL) at (-3.78,2.35) {$U$};
+        \TN@tensordot{uzTopA}{(-2.48,2.72)}
+        \TN@tensordot{uzTopB}{(-2.48,1.98)}
+        \draw[tn leg] (uzTopL.west) -- ++(-0.42,0);
+        \draw[tn leg] (uzTopL.north east) -- (uzTopA.west);
+        \draw[tn leg] (uzTopL.south east) -- (uzTopB.west);
+        \TN@rightleg{uzTopA}{0.42}
+        \TN@rightleg{uzTopB}{0.42}
+        \draw[tn phys leg] (uzTopA.south) -- (uzTopB.north);
+        \TN@upleg{uzTopA}{0.34}
+        \TN@downleg{uzTopB}{0.34}
+        \node at (-2.18,2.72) {$M_\alpha$};
+        \node at (-2.18,1.98) {$M_\beta$};
+        \node at (-1.42,2.35) {$=$};
+        \node[draw, fill=white, minimum width=0.72cm,
+            minimum height=0.52cm, inner sep=1pt]
+            (uzTopH) at (-0.52,2.35) {$H$};
+        \node[draw, rounded corners, fill=blue!8, inner sep=2pt,
+            minimum height=1.10cm] (uzTopR) at (0.80,2.35) {$U$};
+        \draw[tn leg] (uzTopH.west) -- ++(-0.42,0);
+        \draw[tn leg] (uzTopH.east) -- (uzTopR.west);
+        \draw[tn leg] (uzTopR.north east) -- ++(0.56,0);
+        \draw[tn leg] (uzTopR.south east) -- ++(0.56,0);
+        \TN@upleg{uzTopH}{0.34}
+        \TN@downleg{uzTopH}{0.34}
+
+        % (M_alpha M_beta) U^dagger = U^dagger H.
+        \node[anchor=east] at (-4.72,0)
+            {$(M_\alpha M_\beta)U^\dagger=U^\dagger H$};
+        \TN@tensordot{uzBotA}{(-3.78,0.37)}
+        \TN@tensordot{uzBotB}{(-3.78,-0.37)}
+        \TN@leftleg{uzBotA}{0.42}
+        \TN@leftleg{uzBotB}{0.42}
+        \draw[tn phys leg] (uzBotA.south) -- (uzBotB.north);
+        \TN@upleg{uzBotA}{0.34}
+        \TN@downleg{uzBotB}{0.34}
+        \node at (-3.48,0.37) {$M_\alpha$};
+        \node at (-3.48,-0.37) {$M_\beta$};
+        \node[draw, rounded corners, fill=blue!8, inner sep=2pt,
+            minimum height=1.10cm] (uzBotL) at (-2.48,0) {$U^\dagger$};
+        \draw[tn leg] (uzBotA.east) -- (uzBotL.north west);
+        \draw[tn leg] (uzBotB.east) -- (uzBotL.south west);
+        \draw[tn leg] (uzBotL.east) -- ++(0.42,0);
+        \node at (-1.42,0) {$=$};
+        \node[draw, rounded corners, fill=blue!8, inner sep=2pt,
+            minimum height=1.10cm] (uzBotR) at (-0.52,0) {$U^\dagger$};
+        \node[draw, fill=white, minimum width=0.72cm,
+            minimum height=0.52cm, inner sep=1pt]
+            (uzBotH) at (0.80,0) {$H$};
+        \draw[tn leg] (uzBotR.north west) -- ++(-0.56,0);
+        \draw[tn leg] (uzBotR.south west) -- ++(-0.56,0);
+        \draw[tn leg] (uzBotR.east) -- (uzBotH.west);
+        \draw[tn leg] (uzBotH.east) -- ++(0.42,0);
+        \TN@upleg{uzBotH}{0.34}
+        \TN@downleg{uzBotH}{0.34}
+
+        % Local reconstruction M_alpha M_beta = U^dagger H U.
+        \node[anchor=east] at (-4.72,-2.42)
+            {$M_\alpha M_\beta=U^\dagger H U$};
+        \TN@tensordot{uzRecA}{(-3.78,-2.05)}
+        \TN@tensordot{uzRecB}{(-3.78,-2.79)}
+        \TN@leftleg{uzRecA}{0.42}
+        \TN@leftleg{uzRecB}{0.42}
+        \TN@rightleg{uzRecA}{0.42}
+        \TN@rightleg{uzRecB}{0.42}
+        \draw[tn phys leg] (uzRecA.south) -- (uzRecB.north);
+        \TN@upleg{uzRecA}{0.34}
+        \TN@downleg{uzRecB}{0.34}
+        \node at (-3.48,-2.05) {$M_\alpha$};
+        \node at (-3.48,-2.79) {$M_\beta$};
+        \node at (-2.68,-2.42) {$=$};
+        \node[draw, rounded corners, fill=blue!8, inner sep=2pt,
+            minimum height=1.10cm] (uzRecUd) at (-1.72,-2.42)
+            {$U^\dagger$};
+        \node[draw, fill=white, minimum width=0.72cm,
+            minimum height=0.52cm, inner sep=1pt]
+            (uzRecH) at (-0.40,-2.42) {$H$};
+        \node[draw, rounded corners, fill=blue!8, inner sep=2pt,
+            minimum height=1.10cm] (uzRecU) at (0.92,-2.42) {$U$};
+        \draw[tn leg] (uzRecUd.north west) -- ++(-0.52,0);
+        \draw[tn leg] (uzRecUd.south west) -- ++(-0.52,0);
+        \draw[tn leg] (uzRecUd.east) -- (uzRecH.west);
+        \draw[tn leg] (uzRecH.east) -- (uzRecU.west);
+        \draw[tn leg] (uzRecU.north east) -- ++(0.52,0);
+        \draw[tn leg] (uzRecU.south east) -- ++(0.52,0);
+        \TN@upleg{uzRecH}{0.34}
+        \TN@downleg{uzRecH}{0.34}
+        \node[anchor=west] at (-1.72,-3.48)
+            {local reconstruction; not total-fusion completeness};
+    \end{tikzpicture}%
+}
+
 % Closing an L-site chain of the local BNT fusion identity.  On the right the
 % multiplicity loop and the M_gamma loop are disjoint, so their traces factor.
 \newcommand{\TNMPDOFusionTracePower}{%

--- a/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
+++ b/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
@@ -28,7 +28,7 @@ name: TNMPDOInverseContraction TNMPDOSectorPairing TNMPDOSectorZCLIdentity
 name: TNMPSInverseContraction TNBNTDecomposition TNMPDOZCLIdempotence TNMPDOFixedFinalFusionBracketings
 {{ obj.tn_svg_html }}
 
-name: TNMPDOBNTFusionIdentity TNMPDOFusionTracePower
+name: TNMPDOBNTFusionIdentity TNMPDOUnweightedZipperReconstruction TNMPDOFusionTracePower
 {{ obj.tn_svg_html }}
 
 name: TNRFPKrausIsometry TNRFPKrausIsometryReverse TNRFPIsometryCanonicalForm


### PR DESCRIPTION
## Summary

- add a native TikZ rendering of the two unweighted zipper identities
- depict the resulting local reconstruction identity separately
- state explicitly that these identities do not by themselves imply total-fusion completeness, surjectivity, or invertibility

The diagram follows arXiv:1511.08090, equations (19)–(21) and the `zipper` figures, in the length-independent setting used at arXiv:1606.00608, lines 995–1008. It advances the visual account of #3776 without strengthening any theorem.

## Validation

- `leanblueprint pdf` (522 pages before rebase; figure on PDF page 436, printed page 435)
- visual inspection: clean, aligned, legible, and unclipped
- tensor-network diagram registry synchronization
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and diagram plumbing only; no Lean proofs or behavioral code changes.
> 
> **Overview**
> Adds a **native TikZ figure** for the length-independent **unweighted zipper** identities in the MPDO fusion-isometry chapter, placed after Theorem on length-independent zipper/completeness.
> 
> The new `\TNMPDOUnweightedZipperReconstruction` macro shows **both zipper directions** (`U(M_\alpha M_\beta)=HU` and `(M_\alpha M_\beta)U^\dagger=U^\dagger H`) and the **local reconstruction** `M_\alpha M_\beta=U^\dagger H U`, with caption text stressing that only `U^\dagger U=1` is used and that **total-fusion completeness, surjectivity, and invertibility are not claimed**.
> 
> **Registry sync** for PDF/web: `tn_diagrams.py` and `TensorNetworkDiagrams.jinja2s` register the macro so the web blueprint can render the same SVG from TikZ.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fcabc0b0cef834113e5a786fa95ae5c81c0417c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->