### PR TITLE
feat(MPS/MPDO): prove active trace-matrix primitivity

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -420,7 +420,6 @@ import TNLean.MPS.MPDO.PhysicalSectorCoordinateTransport
 import TNLean.MPS.MPDO.PhysicalSectorVirtualSpanning
 import TNLean.MPS.MPDO.PhysicalSectorTraceMatrix
 import TNLean.MPS.MPDO.InverseMapActiveSectorRecurrence
-import TNLean.MPS.MPDO.PhysicalSectorTraceMatrix
 import TNLean.MPS.MPDO.InverseMapActiveSectorPrimitivity
 import TNLean.MPS.MPDO.PhysicalSectorPositiveBond
 import TNLean.MPS.MPDO.PhysicalSectorBondCommutativity

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -36,6 +36,7 @@ import TNLean.Algebra.FiniteCycleCoboundary
 import TNLean.Algebra.PiTensorProductPhase
 import TNLean.Algebra.BurnsideMatrix
 import TNLean.Algebra.IrreducibleTensorAction
+import TNLean.Algebra.PerronFrobenius.PrimitiveAperiodic
 import TNLean.Algebra.PerronFrobenius.RankOne
 import TNLean.Algebra.ProjectiveRepresentation
 import TNLean.Algebra.ScalarCommutant
@@ -419,6 +420,8 @@ import TNLean.MPS.MPDO.PhysicalSectorCoordinateTransport
 import TNLean.MPS.MPDO.PhysicalSectorVirtualSpanning
 import TNLean.MPS.MPDO.PhysicalSectorTraceMatrix
 import TNLean.MPS.MPDO.InverseMapActiveSectorRecurrence
+import TNLean.MPS.MPDO.PhysicalSectorTraceMatrix
+import TNLean.MPS.MPDO.InverseMapActiveSectorPrimitivity
 import TNLean.MPS.MPDO.PhysicalSectorPositiveBond
 import TNLean.MPS.MPDO.PhysicalSectorBondCommutativity
 import TNLean.MPS.MPDO.PhysicalSectorBondTransport

--- a/TNLean/Algebra/PerronFrobenius/PrimitiveAperiodic.lean
+++ b/TNLean/Algebra/PerronFrobenius/PrimitiveAperiodic.lean
@@ -1,0 +1,94 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Data.Real.Basic
+import Mathlib.LinearAlgebra.Matrix.Irreducible.Defs
+
+/-!
+# Primitivity from returns of lengths two and three
+
+An irreducible nonnegative finite matrix is primitive if every vertex of its
+positive support has closed walks of lengths two and three. The proof chooses
+one positive path between each ordered pair, bounds their lengths uniformly,
+and pads every path to a common length using the two coprime return lengths.
+
+This is the elementary matrix step used for the active sector trace matrix in
+arXiv:1606.00608, Appendix C.2, Lemma C.4 (`propSN`), lines 1451--1471.
+-/
+
+namespace Matrix
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+private theorem exists_two_mul_add_three_mul (N : ℕ) (hN : 2 ≤ N) :
+    ∃ a b : ℕ, N = 2 * a + 3 * b := by
+  rcases Nat.even_or_odd N with ⟨a, ha⟩ | ⟨a, ha⟩
+  · exact ⟨a, 0, by omega⟩
+  · exact ⟨a - 1, 1, by omega⟩
+
+private theorem pow_add_apply_pos_of_pos {T : Matrix n n ℝ}
+    (hT : ∀ i j, 0 ≤ T i j) {a b : ℕ} {i j k : n}
+    (ha : 0 < (T ^ a) i k) (hb : 0 < (T ^ b) k j) :
+    0 < (T ^ (a + b)) i j := by
+  rw [pow_add, Matrix.mul_apply]
+  exact (Finset.sum_pos_iff_of_nonneg (fun l _ ↦
+    mul_nonneg (Matrix.pow_apply_nonneg hT a i l)
+      (Matrix.pow_apply_nonneg hT b l j))).2
+    ⟨k, Finset.mem_univ k, mul_pos ha hb⟩
+
+private theorem diagonal_two_mul_add_three_mul_pos {T : Matrix n n ℝ}
+    (hT : ∀ i j, 0 ≤ T i j)
+    (h2 : ∀ i, 0 < (T ^ 2) i i) (h3 : ∀ i, 0 < (T ^ 3) i i)
+    (a b : ℕ) (i : n) :
+    0 < (T ^ (2 * a + 3 * b)) i i := by
+  have htwo : ∀ c : ℕ, 0 < (T ^ (2 * c)) i i := by
+    intro c
+    induction c with
+    | zero => simp
+    | succ c hc =>
+        rw [Nat.mul_succ]
+        exact pow_add_apply_pos_of_pos hT hc (h2 i)
+  have hthree : ∀ c : ℕ, 0 < (T ^ (3 * c)) i i := by
+    intro c
+    induction c with
+    | zero => simp
+    | succ c hc =>
+        rw [Nat.mul_succ]
+        exact pow_add_apply_pos_of_pos hT hc (h3 i)
+  exact pow_add_apply_pos_of_pos hT (htwo a) (hthree b)
+
+/-- An irreducible nonnegative finite matrix with positive length-two and
+length-three returns at every index is primitive. -/
+theorem IsIrreducible.isPrimitive_of_pow_two_diagonal_pos_of_pow_three_diagonal_pos
+    {T : Matrix n n ℝ} (hT : IsIrreducible T)
+    (h2 : ∀ i, 0 < (T ^ 2) i i) (h3 : ∀ i, 0 < (T ^ 3) i i) :
+    IsPrimitive T := by
+  classical
+  have hexists : ∀ i j : n, ∃ m : ℕ, 0 < m ∧ 0 < (T ^ m) i j :=
+    (isIrreducible_iff_exists_pow_pos hT.nonneg).1 hT
+  let m : n × n → ℕ := fun q ↦ Classical.choose (hexists q.1 q.2)
+  have hmpos : ∀ i j : n, 0 < (T ^ m (i, j)) i j := fun i j ↦
+    (Classical.choose_spec (hexists i j)).2
+  let L : ℕ := ∑ q : n × n, m q
+  refine ⟨hT.nonneg, 2 * L + 2, by omega, fun i j ↦ ?_⟩
+  have hmL : m (i, j) ≤ L := by
+    exact Finset.single_le_sum (fun q _ ↦ Nat.zero_le (m q))
+      (Finset.mem_univ (i, j))
+  let r := 2 * L + 2 - m (i, j)
+  have hmr : m (i, j) + r = 2 * L + 2 := by
+    dsimp [r]
+    exact Nat.add_sub_of_le (by omega)
+  have hr : 2 ≤ r := by
+    dsimp [r]
+    omega
+  obtain ⟨a, b, hab⟩ := exists_two_mul_add_three_mul r hr
+  have hreturn : 0 < (T ^ r) j j := by
+    rw [hab]
+    exact diagonal_two_mul_add_three_mul_pos hT.nonneg h2 h3 a b j
+  have hpositive : 0 < (T ^ (m (i, j) + r)) i j :=
+    pow_add_apply_pos_of_pos hT.nonneg (hmpos i j) hreturn
+  rwa [hmr] at hpositive
+
+end Matrix

--- a/TNLean/Algebra/PerronFrobenius/PrimitiveAperiodic.lean
+++ b/TNLean/Algebra/PerronFrobenius/PrimitiveAperiodic.lean
@@ -14,8 +14,9 @@ positive support has closed walks of lengths two and three. The proof chooses
 one positive path between each ordered pair, bounds their lengths uniformly,
 and pads every path to a common length using the two coprime return lengths.
 
-This is the elementary matrix step used for the active sector trace matrix in
-arXiv:1606.00608, Appendix C.2, Lemma C.4 (`propSN`), lines 1451--1471.
+This is an auxiliary finite-matrix lemma. For the active sector trace matrix,
+it implements the marked local replacement of the source's removal of periodic
+components by blocking; it is not an argument stated in the source.
 -/
 
 namespace Matrix

--- a/TNLean/MPS/MPDO/InverseMapActiveSectorPrimitivity.lean
+++ b/TNLean/MPS/MPDO/InverseMapActiveSectorPrimitivity.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.InverseMapActiveSectorRecurrence
+import TNLean.MPS.MPDO.PhysicalSectorRephasing
 import TNLean.MPS.MPDO.PhysicalSectorTraceMatrix
 
 /-!

--- a/TNLean/MPS/MPDO/InverseMapActiveSectorPrimitivity.lean
+++ b/TNLean/MPS/MPDO/InverseMapActiveSectorPrimitivity.lean
@@ -1,0 +1,185 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.InverseMapActiveSectorRecurrence
+import TNLean.MPS.MPDO.PhysicalSectorTraceMatrix
+
+/-!
+# Primitivity of the active inverse-map sector trace matrix
+
+The coherently rephased inverse-map physical-sector factorization has a
+primitive trace matrix on the positive-weight Hayashi sectors. Zero-weight
+sectors remain in the physical direct sum; they are omitted only from the
+auxiliary trace matrix because the source-faithful reparameterization makes
+all incident neighboring operators vanish.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma C.4 (`propSN`), lines
+1406--1471.
+-/
+
+open scoped Matrix ComplexOrder BigOperators
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+  {rho : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+
+/-- A zero-weight sector has zero virtual matrices in the source-faithful
+zero-weight reparameterization.
+
+**Local fix (inactive sectors):** see
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `formK` and `etarl`, lines
+1434--1445. -/
+theorem zeroWeightReparameterized_sectorVirtualMatrix_eq_zero
+    (K : MPOTensor d D) (hK : K.IsInjective)
+    (R : Matrix (Fin D) (Fin D) ℂ) (hρ : IsThreeSiteClosure K R rho)
+    (hη : EtaStructure rho) (alpha beta : Fin D) (hm : R beta alpha ≠ 0)
+    (k : Fin hη.m) (hk : hη.p k = 0)
+    (x y : (zeroWeightReparameterizedInverseMapPhysicalSectorFactorization
+      K hK R hρ hη alpha beta hm).SectorIndex k) :
+    (zeroWeightReparameterizedInverseMapPhysicalSectorFactorization
+      K hK R hρ hη alpha beta hm).sectorVirtualMatrix k x y = 0 := by
+  ext gamma delta
+  simp [PhysicalSectorFactorization.sectorVirtualMatrix,
+    zeroWeightReparameterizedInverseMapPhysicalSectorFactorization,
+    hk, Matrix.zero_apply]
+  right
+  rfl
+
+/-- The source inverse-map factorization admits a coherent rephasing whose
+active trace matrix is primitive.
+
+**Local fix (inactive sectors):** the physical factorization retains every
+zero-weight sector. Primitivity concerns only the subtype on which the Hayashi
+weight is nonzero. See
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma C.4 (`propSN`), lines
+1406--1471. -/
+theorem exists_rephased_inverseMap_activeSectorTraceMatrix_isPrimitive
+    (K : MPOTensor d D) (hK : K.IsInjective)
+    (R : Matrix (Fin D) (Fin D) ℂ) (hρ : IsThreeSiteClosure K R rho)
+    (hη : EtaStructure rho) (alpha beta : Fin D) (hm : R beta alpha ≠ 0)
+    (hM : IsMPDO K) :
+    let F := zeroWeightReparameterizedInverseMapPhysicalSectorFactorization
+      K hK R hρ hη alpha beta hm
+    ∃ z : Fin F.sectorCount → Circle,
+      (∀ k h, ((F.rephase z).neighboringOperator k h).PosSemidef) ∧
+        Matrix.IsPrimitive ((F.rephase z).activeSectorTraceMatrix hη.p) := by
+  let F := zeroWeightReparameterizedInverseMapPhysicalSectorFactorization
+    K hK R hρ hη alpha beta hm
+  change ∃ z : Fin F.sectorCount → Circle,
+    (∀ k h, ((F.rephase z).neighboringOperator k h).PosSemidef) ∧
+      Matrix.IsPrimitive ((F.rephase z).activeSectorTraceMatrix hη.p)
+  let eta : etaOperators hη := fun k h ↦ F.neighboringOperator k h
+  have hcyc : ∀ {N : ℕ} [NeZero N] (q : Fin N → Fin hη.m),
+      (cyclicEtaTensorProduct hη eta q).PosSemidef := by
+    intro N _ q
+    exact cyclicEtaTensorProduct_posSemidef K hη F.leftTensor F.rightTensor
+      F.factorization (hM N) q
+  have hrec : IsRecurrentSupport eta :=
+    zeroWeightReparameterizedInverseMapPhysicalSectorFactorization_isRecurrentSupport
+      K hK R hρ hη alpha beta hm
+  obtain ⟨z, hz⟩ := exists_vertexPhase_smul_posSemidef hη eta hcyc hrec
+  have hpos : ∀ k h, ((F.rephase z).neighboringOperator k h).PosSemidef := by
+    intro k h
+    rw [F.rephase_neighboringOperator]
+    exact hz k h
+  refine ⟨z, hpos, ?_⟩
+  have hspanAll :
+      Submodule.span ℂ (Set.range F.sectorVirtualMatrixFamily) = ⊤ :=
+    F.sectorVirtualMatrixFamily_span_eq_top hK
+  have hinactive : ∀ k, hη.p k = 0 →
+      ∀ x y : F.SectorIndex k, F.sectorVirtualMatrix k x y = 0 := by
+    intro k hk x y
+    exact zeroWeightReparameterized_sectorVirtualMatrix_eq_zero
+      K hK R hρ hη alpha beta hm k hk x y
+  have hspanF : Submodule.span ℂ
+      (Set.range (F.activeSectorOneSiteMatrixFamily hη.p)) = ⊤ :=
+    F.activeSectorOneSiteMatrixFamily_span_eq_top hη.p hspanAll hinactive
+  have hfamily :
+      (F.rephase z).activeSectorOneSiteMatrixFamily hη.p =
+        F.activeSectorOneSiteMatrixFamily hη.p := by
+    funext q
+    simpa [PhysicalSectorFactorization.activeSectorOneSiteMatrixFamily] using
+      F.rephase_sectorVirtualMatrix z q.1.1 q.2.1 q.2.2
+  have hspan : Submodule.span ℂ
+      (Set.range ((F.rephase z).activeSectorOneSiteMatrixFamily hη.p)) = ⊤ := by
+    rw [hfamily]
+    exact hspanF
+  have hnonzero : ∀ k : (F.rephase z).ActiveSector hη.p,
+      ∃ x y : (F.rephase z).SectorIndex k,
+        (F.rephase z).sectorVirtualMatrix k x y ≠ 0 := by
+    intro k
+    obtain ⟨x, y, hxy⟩ := exists_active_sectorVirtualMatrix_ne_zero
+      K hK R hρ hη alpha beta hm k.1 k.property
+    exact ⟨x, y, by simpa using hxy⟩
+  have hedgeNonzero : ∀ {k h}, F.neighboringOperator k h ≠ 0 →
+      (∃ x y : F.SectorIndex k, F.sectorVirtualMatrix k x y ≠ 0) ∧
+        ∃ x y : F.SectorIndex h, F.sectorVirtualMatrix h x y ≠ 0 := by
+    intro k h hkh
+    obtain ⟨hk, hh⟩ :=
+      probability_ne_zero_of_reparameterized_neighboringOperator_ne_zero
+        K hK R hρ hη alpha beta hm hkh
+    exact ⟨exists_active_sectorVirtualMatrix_ne_zero
+      K hK R hρ hη alpha beta hm k hk,
+      exists_active_sectorVirtualMatrix_ne_zero
+        K hK R hρ hη alpha beta hm h hh⟩
+  have htriangle : ∀ {k h : (F.rephase z).ActiveSector hη.p},
+      (F.rephase z).neighboringOperator k h ≠ 0 →
+        ∃ j : (F.rephase z).ActiveSector hη.p,
+          (F.rephase z).neighboringOperator h j ≠ 0 ∧
+            (F.rephase z).neighboringOperator j k ≠ 0 := by
+    intro k h hkh
+    have hkhF : F.neighboringOperator k.1 h.1 ≠ 0 :=
+      (F.rephase_neighboringOperator_ne_zero_iff z k.1 h.1).1 hkh
+    obtain ⟨j, hhj, hjk⟩ :=
+      F.exists_two_edge_return_of_neighboringOperator_ne_zero
+        hspanAll hedgeNonzero hkhF
+    have hj : hη.p j ≠ 0 :=
+      (probability_ne_zero_of_reparameterized_neighboringOperator_ne_zero
+        K hK R hρ hη alpha beta hm hhj).2
+    exact ⟨⟨j, hj⟩,
+      (F.rephase_neighboringOperator_ne_zero_iff z h.1 j).2 hhj,
+      (F.rephase_neighboringOperator_ne_zero_iff z j k.1).2 hjk⟩
+  exact (F.rephase z).activeSectorTraceMatrix_isPrimitive
+    hη.p hpos hspan hnonzero htriangle
+
+/-- Every injective MPO tensor satisfying the strong area law admits a
+positive physical-sector factorization whose active trace matrix is primitive.
+
+The accompanying weights are nonnegative and sum to one. Zero-weight sectors
+remain in the physical factorization and are omitted only from the auxiliary
+trace matrix.
+
+**Local fix (inactive sectors):** see
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma C.4 (`propSN`), lines
+1406--1471. -/
+theorem exists_positive_physicalSectorFactorization_activeSectorTraceMatrix_isPrimitive_of_isSAL
+    (K : MPOTensor d D) (hK : K.IsInjective) (hSAL : IsSAL K) :
+    ∃ (F : PhysicalSectorFactorization K) (p : Fin F.sectorCount → ℝ),
+      (∀ k, 0 ≤ p k) ∧
+        (∑ k, p k) = 1 ∧
+          (∀ k h, (F.neighboringOperator k h).PosSemidef) ∧
+            Matrix.IsPrimitive (F.activeSectorTraceMatrix p) := by
+  obtain ⟨hη⟩ := exists_etaStructure_reducedBlockState_of_isSAL K hSAL
+  obtain ⟨beta, alpha, hm⟩ :=
+    exists_normalizedFourSiteTail_entry_ne_zero
+      K ((Classical.choose_spec hSAL).1 4)
+  let F₀ := zeroWeightReparameterizedInverseMapPhysicalSectorFactorization
+    K hK (normalizedFourSiteTail K)
+      (isThreeSiteClosure_reducedBlockState K) hη alpha beta hm
+  obtain ⟨z, hpos, hprim⟩ :=
+    exists_rephased_inverseMap_activeSectorTraceMatrix_isPrimitive
+      K hK (normalizedFourSiteTail K)
+        (isThreeSiteClosure_reducedBlockState K) hη alpha beta hm
+          (Classical.choose hSAL)
+  exact ⟨F₀.rephase z, hη.p, hη.hp_nonneg, hη.hp_sum, hpos, hprim⟩
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/InverseMapActiveSectorPrimitivity.lean
+++ b/TNLean/MPS/MPDO/InverseMapActiveSectorPrimitivity.lean
@@ -44,11 +44,14 @@ theorem zeroWeightReparameterized_sectorVirtualMatrix_eq_zero
     (zeroWeightReparameterizedInverseMapPhysicalSectorFactorization
       K hK R hρ hη alpha beta hm).sectorVirtualMatrix k x y = 0 := by
   ext gamma delta
-  simp [PhysicalSectorFactorization.sectorVirtualMatrix,
-    zeroWeightReparameterizedInverseMapPhysicalSectorFactorization,
-    hk, Matrix.zero_apply]
-  right
-  rfl
+  rw [PhysicalSectorFactorization.sectorVirtualMatrix]
+  have hleft :
+      (zeroWeightReparameterizedInverseMapPhysicalSectorFactorization
+        K hK R hρ hη alpha beta hm).leftTensor k gamma = 0 := by
+    change sectorTensorL K hK hη R alpha beta k gamma = 0
+    exact sectorTensorL_eq_zero_of_weight_eq_zero
+      K hK hη R alpha beta k gamma hk
+  rw [hleft, Matrix.zero_apply, zero_mul, Matrix.zero_apply]
 
 /-- The source inverse-map factorization admits a coherent rephasing whose
 active trace matrix is primitive.
@@ -105,8 +108,7 @@ theorem exists_rephased_inverseMap_activeSectorTraceMatrix_isPrimitive
       (F.rephase z).activeSectorOneSiteMatrixFamily hη.p =
         F.activeSectorOneSiteMatrixFamily hη.p := by
     funext q
-    simpa [PhysicalSectorFactorization.activeSectorOneSiteMatrixFamily] using
-      F.rephase_sectorVirtualMatrix z q.1.1 q.2.1 q.2.2
+    simp [PhysicalSectorFactorization.activeSectorOneSiteMatrixFamily]
   have hspan : Submodule.span ℂ
       (Set.range ((F.rephase z).activeSectorOneSiteMatrixFamily hη.p)) = ⊤ := by
     rw [hfamily]

--- a/TNLean/MPS/MPDO/InverseMapActiveSectorPrimitivity.lean
+++ b/TNLean/MPS/MPDO/InverseMapActiveSectorPrimitivity.lean
@@ -61,6 +61,10 @@ zero-weight sector. Primitivity concerns only the subtype on which the Hayashi
 weight is nonzero. See
 `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
 
+**Local fix (periodicity):** the proof uses closed walks of lengths two and
+three in place of the source's blocking of periodic components. See the same
+paper-gap note.
+
 Source: arXiv:1606.00608, Appendix C.2, Lemma C.4 (`propSN`), lines
 1406--1471. -/
 theorem exists_rephased_inverseMap_activeSectorTraceMatrix_isPrimitive
@@ -160,6 +164,10 @@ trace matrix.
 
 **Local fix (inactive sectors):** see
 `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+
+**Local fix (periodicity):** the proof uses closed walks of lengths two and
+three in place of the source's blocking of periodic components. See the same
+paper-gap note.
 
 Source: arXiv:1606.00608, Appendix C.2, Lemma C.4 (`propSN`), lines
 1406--1471. -/

--- a/TNLean/MPS/MPDO/InverseMapActiveSectorPrimitivity.lean
+++ b/TNLean/MPS/MPDO/InverseMapActiveSectorPrimitivity.lean
@@ -82,20 +82,8 @@ theorem exists_rephased_inverseMap_activeSectorTraceMatrix_isPrimitive
   change ∃ z : Fin F.sectorCount → Circle,
     (∀ k h, ((F.rephase z).neighboringOperator k h).PosSemidef) ∧
       Matrix.IsPrimitive ((F.rephase z).activeSectorTraceMatrix hη.p)
-  let eta : etaOperators hη := fun k h ↦ F.neighboringOperator k h
-  have hcyc : ∀ {N : ℕ} [NeZero N] (q : Fin N → Fin hη.m),
-      (cyclicEtaTensorProduct hη eta q).PosSemidef := by
-    intro N _ q
-    exact cyclicEtaTensorProduct_posSemidef K hη F.leftTensor F.rightTensor
-      F.factorization (hM N) q
-  have hrec : IsRecurrentSupport eta :=
-    zeroWeightReparameterizedInverseMapPhysicalSectorFactorization_isRecurrentSupport
-      K hK R hρ hη alpha beta hm
-  obtain ⟨z, hz⟩ := exists_vertexPhase_smul_posSemidef hη eta hcyc hrec
-  have hpos : ∀ k h, ((F.rephase z).neighboringOperator k h).PosSemidef := by
-    intro k h
-    rw [F.rephase_neighboringOperator]
-    exact hz k h
+  obtain ⟨z, hpos⟩ := exists_rephase_zeroWeightInverseMap_posSemidef
+    K hK R hρ hη alpha beta hm hM
   refine ⟨z, hpos, ?_⟩
   have hspanAll :
       Submodule.span ℂ (Set.range F.sectorVirtualMatrixFamily) = ⊤ :=

--- a/TNLean/MPS/MPDO/InverseMapActiveSectorRecurrence.lean
+++ b/TNLean/MPS/MPDO/InverseMapActiveSectorRecurrence.lean
@@ -219,6 +219,44 @@ theorem zeroWeightReparameterizedInverseMapPhysicalSectorFactorization_isRecurre
     exists_active_sectorVirtualMatrix_ne_zero
       K hK R hρ hη alpha beta hm b hb⟩
 
+/-- The zero-weight reparameterized inverse-map factorization admits a
+reciprocal sector rephasing with positive semidefinite neighboring operators.
+
+This exposes the coherent rephasing witness used both for the positive
+factorization and for the active trace-matrix primitivity theorem.
+
+**Local fix (inactive sectors):** see
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma C.4 (`propSN`), lines
+1406--1450. -/
+theorem exists_rephase_zeroWeightInverseMap_posSemidef
+    {rho : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    (K : MPOTensor d D) (hK : K.IsInjective)
+    (R : Matrix (Fin D) (Fin D) ℂ) (hρ : IsThreeSiteClosure K R rho)
+    (hη : EtaStructure rho) (alpha beta : Fin D) (hm : R beta alpha ≠ 0)
+    (hM : IsMPDO K) :
+    let F := zeroWeightReparameterizedInverseMapPhysicalSectorFactorization
+      K hK R hρ hη alpha beta hm
+    ∃ z : Fin F.sectorCount → Circle,
+      ∀ k h, ((F.rephase z).neighboringOperator k h).PosSemidef := by
+  let F := zeroWeightReparameterizedInverseMapPhysicalSectorFactorization
+    K hK R hρ hη alpha beta hm
+  let eta : etaOperators hη := fun k h ↦ F.neighboringOperator k h
+  have hcyc : ∀ {N : ℕ} [NeZero N] (q : Fin N → Fin hη.m),
+      (cyclicEtaTensorProduct hη eta q).PosSemidef := by
+    intro N _ q
+    exact cyclicEtaTensorProduct_posSemidef K hη F.leftTensor F.rightTensor
+      F.factorization (hM N) q
+  have hrec : IsRecurrentSupport eta :=
+    zeroWeightReparameterizedInverseMapPhysicalSectorFactorization_isRecurrentSupport
+      K hK R hρ hη alpha beta hm
+  obtain ⟨z, hz⟩ :=
+    exists_vertexPhase_smul_posSemidef hη eta hcyc hrec
+  refine ⟨z, fun k h ↦ ?_⟩
+  rw [F.rephase_neighboringOperator]
+  exact hz k h
+
 /-- The inverse-map construction admits a physical-sector factorization whose
 neighboring operators are all positive semidefinite, with no recurrence
 hypothesis.
@@ -242,20 +280,9 @@ theorem exists_positive_inverseMapPhysicalSectorFactorization
       ∀ k h, (F.neighboringOperator k h).PosSemidef := by
   let F := zeroWeightReparameterizedInverseMapPhysicalSectorFactorization
     K hK R hρ hη alpha beta hm
-  let eta : etaOperators hη := fun k h ↦ F.neighboringOperator k h
-  have hcyc : ∀ {N : ℕ} [NeZero N] (q : Fin N → Fin hη.m),
-      (cyclicEtaTensorProduct hη eta q).PosSemidef := by
-    intro N _ q
-    exact cyclicEtaTensorProduct_posSemidef K hη F.leftTensor F.rightTensor
-      F.factorization (hM N) q
-  have hrec : IsRecurrentSupport eta :=
-    zeroWeightReparameterizedInverseMapPhysicalSectorFactorization_isRecurrentSupport
-      K hK R hρ hη alpha beta hm
-  obtain ⟨z, hz⟩ :=
-    exists_vertexPhase_smul_posSemidef hη eta hcyc hrec
-  refine ⟨F.rephase z, fun k h ↦ ?_⟩
-  rw [F.rephase_neighboringOperator]
-  exact hz k h
+  obtain ⟨z, hpos⟩ := exists_rephase_zeroWeightInverseMap_posSemidef
+    K hK R hρ hη alpha beta hm hM
+  exact ⟨F.rephase z, hpos⟩
 
 /-- Every injective MPO tensor satisfying the strong area law admits a
 physical-sector factorization with positive semidefinite neighboring

--- a/TNLean/MPS/MPDO/PhysicalSectorRephasing.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorRephasing.lean
@@ -6,6 +6,7 @@ Authors: TNLean contributors
 import Mathlib.Analysis.Complex.Circle
 import TNLean.Algebra.KroneckerFactorPositivity
 import TNLean.MPS.MPDO.PhysicalSectorChainDecomposition
+import TNLean.MPS.MPDO.PhysicalSectorSupportRecurrence
 
 /-!
 # Rephasing a physical-sector factorization
@@ -72,6 +73,30 @@ theorem rephase_neighboringOperator (F : PhysicalSectorFactorization K)
       ((z h : ℂ) * F.leftTensor h a x.2 y.2) = _
   simp only [Circle.coe_mul, Circle.coe_inv]
   ring
+
+/-- Reciprocal sector rephasing leaves each sector virtual matrix unchanged.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1434--1450. -/
+@[simp] theorem rephase_sectorVirtualMatrix (F : PhysicalSectorFactorization K)
+    (z : Fin F.sectorCount → Circle) (k : Fin F.sectorCount)
+    (x y : F.SectorIndex k) :
+    (F.rephase z).sectorVirtualMatrix k x y =
+      F.sectorVirtualMatrix k x y := by
+  ext beta alpha
+  simp only [sectorVirtualMatrix, rephase, Matrix.smul_apply, smul_eq_mul]
+  field_simp [Circle.coe_ne_zero]
+
+/-- Reciprocal sector rephasing preserves the nonzero neighboring support.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1441--1450. -/
+theorem rephase_neighboringOperator_ne_zero_iff
+    (F : PhysicalSectorFactorization K) (z : Fin F.sectorCount → Circle)
+    (k h : Fin F.sectorCount) :
+    (F.rephase z).neighboringOperator k h ≠ 0 ↔
+      F.neighboringOperator k h ≠ 0 := by
+  rw [F.rephase_neighboringOperator]
+  exact smul_ne_zero_iff_right
+    (mul_ne_zero (Circle.coe_ne_zero ((z k)⁻¹)) (Circle.coe_ne_zero (z h)))
 
 /-- Reciprocal sector rephasing leaves every complete cyclic product of
 neighboring operators unchanged.

--- a/TNLean/MPS/MPDO/PhysicalSectorTraceMatrix.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorTraceMatrix.lean
@@ -5,7 +5,9 @@ Authors: TNLean contributors
 -/
 import Mathlib.LinearAlgebra.Matrix.Irreducible.Defs
 import TNLean.Algebra.HermitianHelpers
+import TNLean.Algebra.PerronFrobenius.PrimitiveAperiodic
 import TNLean.MPS.MPDO.PhysicalSectorDirectedCut
+import TNLean.MPS.MPDO.PhysicalSectorRephasing
 import TNLean.MPS.MPDO.PhysicalSectorVirtualSpanning
 
 /-!
@@ -58,6 +60,26 @@ lines 1383--1387 and 1434--1439. -/
     F.oneSiteSectorMatrix k x y = F.sectorVirtualMatrix k x y := by
   ext beta alpha
   simp [oneSiteSectorMatrix, sectorVirtualMatrix]
+
+/-- Reciprocal sector rephasing leaves each sector virtual matrix unchanged. -/
+@[simp] theorem rephase_sectorVirtualMatrix (F : PhysicalSectorFactorization K)
+    (z : Fin F.sectorCount → Circle) (k : Fin F.sectorCount)
+    (x y : F.SectorIndex k) :
+    (F.rephase z).sectorVirtualMatrix k x y =
+      F.sectorVirtualMatrix k x y := by
+  ext beta alpha
+  simp only [sectorVirtualMatrix, rephase, Matrix.smul_apply, smul_eq_mul]
+  field_simp [Circle.coe_ne_zero]
+
+/-- Reciprocal sector rephasing preserves the nonzero neighboring support. -/
+theorem rephase_neighboringOperator_ne_zero_iff
+    (F : PhysicalSectorFactorization K) (z : Fin F.sectorCount → Circle)
+    (k h : Fin F.sectorCount) :
+    (F.rephase z).neighboringOperator k h ≠ 0 ↔
+      F.neighboringOperator k h ≠ 0 := by
+  rw [F.rephase_neighboringOperator]
+  exact smul_ne_zero_iff_right
+    (mul_ne_zero (Circle.coe_ne_zero ((z k)⁻¹)) (Circle.coe_ne_zero (z h)))
 
 /-- The ambient sector indices represented by a set of nonzero-weight
 sectors. -/
@@ -411,5 +433,79 @@ theorem activeSectorTraceMatrix_isIrreducible
         F.exists_active_neighboringOperator_ne_zero p hspan hnonzero k
       exact hconnected.isSStronglyConnected_of_hom
         (PLift.up ((F.activeSectorTraceMatrix_pos_iff p hpos k h).2 hkh))
+
+/-- If every active nonzero edge closes through a third active sector, then
+every diagonal entry of the cube of the active trace matrix is positive.
+
+**Local fix (periodicity):** this length-three return is an auxiliary
+substitute for the source's blocking of periodic components and is combined
+with the length-two return above. See
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma C.4 (`propSN`), lines
+1452--1470. -/
+theorem activeSectorTraceMatrix_pow_three_diag_pos
+    (F : PhysicalSectorFactorization K) (p : Fin F.sectorCount → ℝ)
+    (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
+    (hspan : Submodule.span ℂ
+      (Set.range (F.activeSectorOneSiteMatrixFamily p)) = ⊤)
+    (hnonzero : ∀ k : F.ActiveSector p,
+      ∃ x y : F.SectorIndex k, F.sectorVirtualMatrix k x y ≠ 0)
+    (htriangle : ∀ {k h : F.ActiveSector p},
+      F.neighboringOperator k h ≠ 0 →
+        ∃ j : F.ActiveSector p,
+          F.neighboringOperator h j ≠ 0 ∧
+            F.neighboringOperator j k ≠ 0)
+    (k : F.ActiveSector p) :
+    0 < ((F.activeSectorTraceMatrix p) ^ 3) k k := by
+  obtain ⟨h, hkh⟩ :=
+    F.exists_active_neighboringOperator_ne_zero p hspan hnonzero k
+  obtain ⟨j, hhj, hjk⟩ := htriangle hkh
+  let T := F.activeSectorTraceMatrix p
+  have hnonneg : ∀ a b, 0 ≤ T a b :=
+    F.activeSectorTraceMatrix_nonneg p hpos
+  have hpow2 : 0 < (T ^ 2) k j := by
+    rw [pow_two, Matrix.mul_apply]
+    apply Finset.sum_pos'
+    · intro l _
+      exact mul_nonneg (hnonneg k l) (hnonneg l j)
+    · exact ⟨h, Finset.mem_univ h, mul_pos
+        ((F.activeSectorTraceMatrix_pos_iff p hpos k h).2 hkh)
+        ((F.activeSectorTraceMatrix_pos_iff p hpos h j).2 hhj)⟩
+  rw [show T ^ 3 = T ^ 2 * T by rw [pow_succ], Matrix.mul_apply]
+  apply Finset.sum_pos'
+  · intro l _
+    exact mul_nonneg (Matrix.pow_apply_nonneg hnonneg 2 k l) (hnonneg l k)
+  · exact ⟨j, Finset.mem_univ j, mul_pos hpow2
+      ((F.activeSectorTraceMatrix_pos_iff p hpos j k).2 hjk)⟩
+
+/-- Active-sector spanning, sector nonvanishing, positive neighboring
+operators, and triangle closure imply primitivity of the active trace matrix.
+
+**Local fix (periodicity):** the common positive power is obtained from
+closed walks of lengths two and three in place of the source's blocking
+argument. See
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma C.4 (`propSN`), lines
+1451--1471. -/
+theorem activeSectorTraceMatrix_isPrimitive
+    (F : PhysicalSectorFactorization K) (p : Fin F.sectorCount → ℝ)
+    (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
+    (hspan : Submodule.span ℂ
+      (Set.range (F.activeSectorOneSiteMatrixFamily p)) = ⊤)
+    (hnonzero : ∀ k : F.ActiveSector p,
+      ∃ x y : F.SectorIndex k, F.sectorVirtualMatrix k x y ≠ 0)
+    (htriangle : ∀ {k h : F.ActiveSector p},
+      F.neighboringOperator k h ≠ 0 →
+        ∃ j : F.ActiveSector p,
+          F.neighboringOperator h j ≠ 0 ∧
+            F.neighboringOperator j k ≠ 0) :
+    Matrix.IsPrimitive (F.activeSectorTraceMatrix p) :=
+  (F.activeSectorTraceMatrix_isIrreducible p hpos hspan hnonzero)
+    |>.isPrimitive_of_pow_two_diagonal_pos_of_pow_three_diagonal_pos
+      (F.activeSectorTraceMatrix_pow_two_diag_pos p hpos hspan hnonzero)
+      (F.activeSectorTraceMatrix_pow_three_diag_pos
+        p hpos hspan hnonzero htriangle)
 
 end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/PhysicalSectorTraceMatrix.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorTraceMatrix.lean
@@ -7,7 +7,6 @@ import Mathlib.LinearAlgebra.Matrix.Irreducible.Defs
 import TNLean.Algebra.HermitianHelpers
 import TNLean.Algebra.PerronFrobenius.PrimitiveAperiodic
 import TNLean.MPS.MPDO.PhysicalSectorDirectedCut
-import TNLean.MPS.MPDO.PhysicalSectorRephasing
 import TNLean.MPS.MPDO.PhysicalSectorVirtualSpanning
 
 /-!

--- a/TNLean/MPS/MPDO/PhysicalSectorTraceMatrix.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorTraceMatrix.lean
@@ -61,26 +61,6 @@ lines 1383--1387 and 1434--1439. -/
   ext beta alpha
   simp [oneSiteSectorMatrix, sectorVirtualMatrix]
 
-/-- Reciprocal sector rephasing leaves each sector virtual matrix unchanged. -/
-@[simp] theorem rephase_sectorVirtualMatrix (F : PhysicalSectorFactorization K)
-    (z : Fin F.sectorCount → Circle) (k : Fin F.sectorCount)
-    (x y : F.SectorIndex k) :
-    (F.rephase z).sectorVirtualMatrix k x y =
-      F.sectorVirtualMatrix k x y := by
-  ext beta alpha
-  simp only [sectorVirtualMatrix, rephase, Matrix.smul_apply, smul_eq_mul]
-  field_simp [Circle.coe_ne_zero]
-
-/-- Reciprocal sector rephasing preserves the nonzero neighboring support. -/
-theorem rephase_neighboringOperator_ne_zero_iff
-    (F : PhysicalSectorFactorization K) (z : Fin F.sectorCount → Circle)
-    (k h : Fin F.sectorCount) :
-    (F.rephase z).neighboringOperator k h ≠ 0 ↔
-      F.neighboringOperator k h ≠ 0 := by
-  rw [F.rephase_neighboringOperator]
-  exact smul_ne_zero_iff_right
-    (mul_ne_zero (Circle.coe_ne_zero ((z k)⁻¹)) (Circle.coe_ne_zero (z h)))
-
 /-- The ambient sector indices represented by a set of nonzero-weight
 sectors. -/
 def activeSectorSet (F : PhysicalSectorFactorization K)

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -1215,7 +1215,7 @@ separate step.
     \centering
     \TNMPDOFixedFinalComparisonUnitary
     \caption{The fixed-final comparison in the graphical order of
-        \cite[equation~(pentagon3) and lines~269--277]
+        \cite[lines~269--277]
         {Bultinck2017Anyons}.  At a positive common length, the simultaneous
         word selector is the finite-word counterpart of the inverse
         $B_d^+$ in the source: it retains the chosen final label and

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -1215,7 +1215,7 @@ separate step.
     \centering
     \TNMPDOFixedFinalComparisonUnitary
     \caption{The fixed-final comparison in the graphical order of
-        \cite[lines~269--277]
+        \cite[equation~(pentagon3) and lines~269--277]
         {Bultinck2017Anyons}.  At a positive common length, the simultaneous
         word selector is the finite-word counterpart of the inverse
         $B_d^+$ in the source: it retains the chosen final label and

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -5244,6 +5244,29 @@ $\widehat{\cal K}$.
     \label{fig:mpdo_local_orthogonality}
 \end{figure}
 
+\begin{theorem}[Primitivity from returns of lengths two and three]%
+    \label{thm:matrix_primitive_of_two_three_returns}
+    \lean{Matrix.IsIrreducible.%
+      isPrimitive_of_pow_two_diagonal_pos_of_pow_three_diagonal_pos}
+    \leanok
+    Let $T$ be a nonnegative irreducible matrix on a finite index set. If
+    \[
+        (T^2)_{k,k}>0
+        \qquad\text{and}\qquad
+        (T^3)_{k,k}>0
+    \]
+    for every index $k$, then $T$ is primitive.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Choose a positive path between every ordered pair of indices, and let $L$
+    be the sum of the chosen path lengths. Every chosen length is at most $L$.
+    For a chosen path of length $m$, write the difference $2L+2-m$ as
+    $2a+3b$ with $a,b\geq0$. Appending these returns at the terminal index
+    gives a positive path of common length $2L+2$ between every ordered pair.
+\end{proof}
+
 \begin{definition}[Nonzero-weight sector trace matrix]%
     \label{def:mpdo_active_sector_trace_matrix}
     \lean{MPOTensor.PhysicalSectorFactorization.ActiveSector,
@@ -5252,6 +5275,9 @@ $\widehat{\cal K}$.
       MPOTensor.PhysicalSectorFactorization.activeSectorSet,
       MPOTensor.PhysicalSectorFactorization.activeSectorOneSiteSpace}
     \lean{MPOTensor.PhysicalSectorFactorization.activeSectorTraceMatrix}
+    \lean{MPOTensor.PhysicalSectorFactorization.rephase_sectorVirtualMatrix}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+      rephase_neighboringOperator_ne_zero_iff}
     \leanok
     \uses{def:mpdo_one_site_sector_matrix_space,
       def:mpdo_minimal_neighboring_operator}
@@ -5383,9 +5409,41 @@ $\widehat{\cal K}$.
     nonzero such matrix.  Then the nonnegative matrix $T^*$ is irreducible.
 \end{theorem}
 
+% **Local fix (periodicity):** the source blocks to remove periodic
+% components.  The following length-three return and common-power argument
+% replace that step.  See
+% docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex.
+\begin{theorem}[Three-step returns and a common positive power]%
+    \label{thm:mpdo_active_sector_three_step_return_and_primitivity}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+      activeSectorTraceMatrix_pow_three_diag_pos}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+      activeSectorTraceMatrix_isPrimitive}
+    \leanok
+    \uses{thm:matrix_primitive_of_two_three_returns,
+      thm:mpdo_active_sector_two_step_return,
+      thm:mpdo_active_trace_matrix_irreducible,
+      thm:mpdo_sector_support_triangle_closure}
+    If every nonzero edge closes through a third active sector, then
+    $(T^{*3})_{k,k}>0$ for every $k\in I_*$. Consequently, under the
+    hypotheses of the irreducibility theorem, $T^*$ is primitive.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Triangle closure supplies a positive closed walk of length three through
+    each active sector. Combine these walks with the length-two returns and
+    apply Theorem~\ref{thm:matrix_primitive_of_two_three_returns}.
+\end{proof}
+
 \begin{theorem}[Primitivity of the active sector trace matrix]%
     \label{thm:mpdo_sector_trace_matrix_primitive}
-    \notready
+    \lean{MPOTensor.zeroWeightReparameterized_sectorVirtualMatrix_eq_zero}
+    \lean{MPOTensor.%
+      exists_rephased_inverseMap_activeSectorTraceMatrix_isPrimitive}
+    \lean{MPOTensor.%
+      exists_positive_physicalSectorFactorization_activeSectorTraceMatrix_isPrimitive_of_isSAL}
+    \leanok
     \uses{def:mpdo, def:injective, def:is_sal,
         def:mpdo_explicit_eta_of_sector_tensors,
         thm:mpdo_eta_coherent_positive_choice,
@@ -5421,7 +5479,9 @@ $\widehat{\cal K}$.
         thm:mpdo_active_neighboring_support_strongly_connected,
         thm:mpdo_active_sector_two_step_return,
         thm:mpdo_active_trace_matrix_irreducible,
-        thm:mpdo_active_trace_matrix_positive_entries}
+        thm:mpdo_active_trace_matrix_positive_entries,
+        thm:mpdo_active_sector_three_step_return_and_primitivity}
+    \leanok
     First use the zero-weight reparameterization to make every zero-weight
     sector isolated. Injectivity makes the nonzero-weight one-site matrices
     span $\MN{D}$, and every such sector contains a nonzero matrix. Hence

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -909,8 +909,6 @@ strong subadditivity for a normalized three-site reduced state.
 \begin{definition}[Vertex rephasing of the sector tensors]%
     \label{def:mpdo_physical_sector_rephasing}
     \lean{MPOTensor.PhysicalSectorFactorization.rephase}
-    \lean{MPOTensor.PhysicalSectorFactorization.rephase_neighboringOperator}
-    \lean{MPOTensor.PhysicalSectorFactorization.rephase_cyclicNeighboringProduct}
     \leanok
     \uses{def:mpdo_physical_sector_factorization,
       def:mpdo_minimal_neighboring_operator}
@@ -920,13 +918,28 @@ strong subadditivity for a normalized three-site reduced state.
         \qquad
         (r_k)_a\longmapsto z_k^{-1}(r_k)_a
     \]
-    leaves every physical-slice factorization unchanged and transforms the
-    neighboring operators by
+    leaves every physical-slice factorization unchanged.
+\end{definition}
+
+\begin{theorem}[Rephasing identities for the sector data]%
+    \label{thm:mpdo_physical_sector_rephasing_invariance}
+    \lean{MPOTensor.PhysicalSectorFactorization.rephase_neighboringOperator}
+    \lean{MPOTensor.PhysicalSectorFactorization.rephase_cyclicNeighboringProduct}
+    \lean{MPOTensor.PhysicalSectorFactorization.rephase_sectorVirtualMatrix}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+      rephase_neighboringOperator_ne_zero_iff}
+    \leanok
+    \uses{def:mpdo_physical_sector_rephasing,
+      def:mpdo_minimal_neighboring_operator}
+    Vertex rephasing transforms the neighboring operators by
     \[
         \eta_{k,h}\longmapsto z_k^{-1}z_h\,\eta_{k,h}.
     \]
-    Every complete cyclic product of neighboring operators is unchanged.
-\end{definition}
+    It leaves every sector virtual matrix unchanged, preserves the nonzero
+    neighboring support, and leaves every complete cyclic product of
+    neighboring operators unchanged. These are the rephasing identities used
+    in \cite[Appendix~C.2, lines~1434--1450]{Cirac2016MPDO_arXiv}.
+\end{theorem}
 
 \begin{definition}[Vanishing right tensors on inactive sectors]
     \label{def:mpdo_physical_sector_inactive_right_zero}
@@ -2672,16 +2685,27 @@ strong subadditivity for a normalized three-site reduced state.
     can reach $k$ whenever $k\to h$ is an edge.
 \end{definition}
 
+\begin{definition}[Sector-coordinate virtual matrix families]%
+    \label{def:mpdo_sector_virtual_matrix_families}
+    \lean{MPOTensor.PhysicalSectorFactorization.sectorCoordinateMatrixFamily}
+    \lean{MPOTensor.PhysicalSectorFactorization.sectorVirtualMatrix}
+    \lean{MPOTensor.PhysicalSectorFactorization.sectorVirtualMatrixFamily}
+    \leanok
+    \uses{def:mpdo_physical_sector_factorization}
+    In sector coordinates, let $A_{k;x,y}$ be the virtual matrix obtained
+    from the $(x,y)$ entry within sector $k$. The sector-coordinate family
+    contains all transformed physical matrices, while the virtual-matrix
+    family consists of all matrices $A_{k;x,y}$.
+\end{definition}
+
 \begin{theorem}[Sector spanning from injectivity]%
     \label{thm:mpdo_sector_virtual_matrix_spanning}
     \lean{MPOTensor.PhysicalSectorFactorization.changePhysicalBasis_inverse_apply_eq_sum}
-    \lean{MPOTensor.PhysicalSectorFactorization.sectorCoordinateMatrixFamily}
     \lean{MPOTensor.PhysicalSectorFactorization.sectorCoordinateMatrixFamily_span_eq_top}
     \lean{MPOTensor.PhysicalSectorFactorization.sectorCoordinateTensor_mem_span_sectorVirtualMatrixFamily}
-    \lean{MPOTensor.PhysicalSectorFactorization.sectorVirtualMatrixFamily}
     \lean{MPOTensor.PhysicalSectorFactorization.sectorVirtualMatrixFamily_span_eq_top}
     \leanok
-    \uses{def:mpdo_physical_sector_factorization}
+    \uses{def:mpdo_sector_virtual_matrix_families}
     Let ${\cal K}$ be injective and let
     \[
       U\kappa_{\beta,\alpha}U^\dagger
@@ -2704,14 +2728,13 @@ strong subadditivity for a normalized three-site reduced state.
 
 \begin{theorem}[Triangle closure from sector spanning]%
     \label{thm:mpdo_sector_support_triangle_closure}
-    \lean{MPOTensor.PhysicalSectorFactorization.sectorVirtualMatrix}
     \lean{MPOTensor.PhysicalSectorFactorization.sectorVirtualMatrix_mul_apply}
     \lean{MPOTensor.PhysicalSectorFactorization.%
       sectorVirtualMatrix_mul_eq_zero_of_neighboringOperator_eq_zero}
     \lean{MPOTensor.PhysicalSectorFactorization.exists_two_edge_return_of_neighboringOperator_ne_zero}
     \lean{MPOTensor.PhysicalSectorFactorization.neighboringOperator_reaches_of_ne_zero}
     \leanok
-    \uses{def:mpdo_physical_sector_factorization,
+    \uses{def:mpdo_sector_virtual_matrix_families,
         def:mpdo_minimal_neighboring_operator,
         thm:trace_nondeg}
     For a physical-sector factorization, let $A_{k;x,y}\in\MN{D}$ be the
@@ -5279,9 +5302,6 @@ $\widehat{\cal K}$.
       MPOTensor.PhysicalSectorFactorization.activeSectorSet,
       MPOTensor.PhysicalSectorFactorization.activeSectorOneSiteSpace}
     \lean{MPOTensor.PhysicalSectorFactorization.activeSectorTraceMatrix}
-    \lean{MPOTensor.PhysicalSectorFactorization.rephase_sectorVirtualMatrix}
-    \lean{MPOTensor.PhysicalSectorFactorization.%
-      rephase_neighboringOperator_ne_zero_iff}
     \leanok
     \uses{def:mpdo_one_site_sector_matrix_space,
       def:mpdo_minimal_neighboring_operator}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -1025,6 +1025,7 @@ strong subadditivity for a normalized three-site reduced state.
 \begin{theorem}[Neighboring operators after zero-weight reparameterization]
     \label{thm:mpdo_zero_weight_reparameterized_neighboring_operator}
     \lean{MPOTensor.zeroWeightReparameterizedInverseMapPhysicalSectorFactorization_neighboringOperator}
+    \lean{MPOTensor.probability_ne_zero_of_reparameterized_neighboringOperator_ne_zero}
     \leanok
     \uses{def:mpdo_zero_weight_reparameterized_inverse_map_factorization,
       thm:mpdo_inverse_map_factorization_neighboring_operator}
@@ -2677,6 +2678,7 @@ strong subadditivity for a normalized three-site reduced state.
     \lean{MPOTensor.PhysicalSectorFactorization.sectorCoordinateMatrixFamily}
     \lean{MPOTensor.PhysicalSectorFactorization.sectorCoordinateMatrixFamily_span_eq_top}
     \lean{MPOTensor.PhysicalSectorFactorization.sectorCoordinateTensor_mem_span_sectorVirtualMatrixFamily}
+    \lean{MPOTensor.PhysicalSectorFactorization.sectorVirtualMatrixFamily}
     \lean{MPOTensor.PhysicalSectorFactorization.sectorVirtualMatrixFamily_span_eq_top}
     \leanok
     \uses{def:mpdo_physical_sector_factorization}
@@ -2704,6 +2706,8 @@ strong subadditivity for a normalized three-site reduced state.
     \label{thm:mpdo_sector_support_triangle_closure}
     \lean{MPOTensor.PhysicalSectorFactorization.sectorVirtualMatrix}
     \lean{MPOTensor.PhysicalSectorFactorization.sectorVirtualMatrix_mul_apply}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+      sectorVirtualMatrix_mul_eq_zero_of_neighboringOperator_eq_zero}
     \lean{MPOTensor.PhysicalSectorFactorization.exists_two_edge_return_of_neighboringOperator_ne_zero}
     \lean{MPOTensor.PhysicalSectorFactorization.neighboringOperator_reaches_of_ne_zero}
     \leanok

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -5492,12 +5492,6 @@ $\widehat{\cal K}$.
     is primitive. Zero-weight summands remain in the physical direct sum but
     are not indices of $T^*$.
 
-    \emph{Local fix (inactive sectors):} on the full ambient sector set, each
-    zero-weight summand gives a zero row and column, so the trace matrix cannot
-    be primitive. The primitive matrix is therefore restricted to the
-    effective positive-weight sectors, without removing the zero-weight
-    summands from the physical direct sum. This is recorded in
-    \path{docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex}.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -5491,6 +5491,13 @@ $\widehat{\cal K}$.
     \]
     is primitive. Zero-weight summands remain in the physical direct sum but
     are not indices of $T^*$.
+
+    \emph{Local fix (inactive sectors):} on the full ambient sector set, each
+    zero-weight summand gives a zero row and column, so the trace matrix cannot
+    be primitive. The primitive matrix is therefore restricted to the
+    effective positive-weight sectors, without removing the zero-weight
+    summands from the physical direct sum. This is recorded in
+    \path{docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex}.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -3122,7 +3122,7 @@ strong subadditivity for a normalized three-site reduced state.
     Let ${\cal K}$ be an injective MPO tensor satisfying SAL. Then it admits
     a physical-sector factorization for which every neighboring operator
     \[
-        \eta_{k,h}=r_k l_h
+        \eta_{k,h}=\sum_a (r_k)_a\otimes(l_h)_a
     \]
     is positive semidefinite. Zero-weight Hayashi sectors remain in the
     physical direct sum, but their right tensors may be set to zero without
@@ -5449,9 +5449,12 @@ $\widehat{\cal K}$.
       thm:mpdo_active_sector_two_step_return,
       thm:mpdo_active_trace_matrix_irreducible,
       thm:mpdo_sector_support_triangle_closure}
-    If every nonzero edge closes through a third active sector, then
-    $(T^{*3})_{k,k}>0$ for every $k\in I_*$. Consequently, under the
-    hypotheses of the irreducibility theorem, $T^*$ is primitive.
+    Suppose that the neighboring operators are positive semidefinite, the
+    active one-site matrices span $\MN{D}$, each active sector contains a
+    nonzero such matrix, and every nonzero edge closes through a third active
+    sector. Then $(T^{*3})_{k,k}>0$ for every $k\in I_*$. Together with the
+    length-two returns and irreducibility, this implies that $T^*$ is
+    primitive.
 \end{theorem}
 
 \begin{proof}
@@ -5461,6 +5464,9 @@ $\widehat{\cal K}$.
     apply Theorem~\ref{thm:matrix_primitive_of_two_three_returns}.
 \end{proof}
 
+% The effective-sector restriction, including the zero rows and columns on
+% the full ambient sector set, is documented in
+% docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex.
 \begin{theorem}[Primitivity of the active sector trace matrix]%
     \label{thm:mpdo_sector_trace_matrix_primitive}
     \lean{MPOTensor.zeroWeightReparameterized_sectorVirtualMatrix_eq_zero}
@@ -5470,6 +5476,7 @@ $\widehat{\cal K}$.
       exists_positive_physicalSectorFactorization_activeSectorTraceMatrix_isPrimitive_of_isSAL}
     \leanok
     \uses{def:mpdo, def:injective, def:is_sal,
+        def:mpdo_active_sector_trace_matrix,
         def:mpdo_explicit_eta_of_sector_tensors,
         thm:mpdo_eta_coherent_positive_choice,
         thm:mpdo_sector_eta_data_trace_matrix}
@@ -5477,21 +5484,13 @@ $\widehat{\cal K}$.
     satisfies SAL, and choose the positive neighboring operators of
     Theorem~\ref{thm:mpdo_eta_coherent_positive_choice}. Restrict the sector
     index to the positive-weight summands of the Hayashi decomposition. Then
-    the nonnegative
-    matrix
+    positive semidefiniteness makes every neighboring trace real and
+    nonnegative, and the matrix
     \[
-        T_{k,h}=\tr(\eta_{k,h})
+        T^*_{k,h}=\operatorname{Re}\tr(\eta_{k,h})
     \]
-    is primitive.
-
-    \emph{Local fix (inactive sectors):} the physical direct sum retains
-    zero-weight summands, but the normalized factorization makes every
-    neighboring operator incident to such a summand zero. Hence the trace
-    matrix on the full ambient sector set has a zero row and column and cannot
-    be primitive. The primitive matrix asserted by the source is the
-    restriction to its effective, positive-weight sector set. This is recorded
-    in
-    \path{docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex}.
+    is primitive. Zero-weight summands remain in the physical direct sum but
+    are not indices of $T^*$.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -3108,6 +3108,7 @@ strong subadditivity for a normalized three-site reduced state.
     \lean{MPOTensor.conjugated_middle_threeSiteClosure}
     \lean{MPOTensor.exists_active_sectorVirtualMatrix_ne_zero}
     \lean{MPOTensor.zeroWeightReparameterizedInverseMapPhysicalSectorFactorization_isRecurrentSupport}
+    \lean{MPOTensor.exists_rephase_zeroWeightInverseMap_posSemidef}
     \lean{MPOTensor.exists_positive_inverseMapPhysicalSectorFactorization}
     \lean{MPOTensor.exists_positive_physicalSectorFactorization_of_isSAL}
     \leanok

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -262,13 +262,12 @@ statements are
 \path{MPOTensor.PhysicalSectorFactorization.mpo_submatrix_sector_eq_cyclicNeighboringProduct}
 and
 \path{MPOTensor.PhysicalSectorFactorization.mpo_reindex_sectorChainEquiv_eq_blockDiagonal}.}
-The positive choice of the individual $\eta_{k,h}$ is now obtained for the
-inverse-map factorization by isolating zero-weight sectors, deriving recurrence
-from injectivity, and applying coherent vertex rephasing.  Positivity of a
-complete cyclic product alone would not suffice: the recurrence and
-injectivity argument is essential.  What remains in Lemma \texttt{propSN} is
-the local-orthogonality argument establishing primitivity of the sector trace
-matrix on the positive-weight sector set.
+The positive choice of the individual $\eta_{k,h}$ and primitivity of the
+active sector trace matrix are now obtained from this factorization.
+Positivity of a complete cyclic product alone would not supply coherent
+positive representatives for all neighboring pairs: recurrence, injective
+spanning, and the directed-cut argument control the choices simultaneously
+across the sector graph.
 
 The positivity half of the projected chain identity is now formalized: for
 an MPDO, the chain of the physically conjugated tensor is a congruence of
@@ -508,10 +507,15 @@ blocking step.  The length-two result and positivity of the corresponding
 diagonal entry of $T^2$ are formalized by
 \leanid{MPOTensor.PhysicalSectorFactorization.exists_active_two_cycle} and
 \leanid{MPOTensor.PhysicalSectorFactorization.activeSectorTraceMatrix_pow_two_diag_pos}.
-The remaining theorem must combine strong connectivity with the length-two
-and length-three returns to exhibit one common exponent $N$ for which every
-entry of $T^N$ is positive.  Until that common exponent is proved, primitivity
-remains open.
+The length-three return is
+\leanid{MPOTensor.PhysicalSectorFactorization.activeSectorTraceMatrix_pow_three_diag_pos}.
+The elementary theorem
+\leanid{Matrix.IsIrreducible.isPrimitive_of_pow_two_diagonal_pos_of_pow_three_diagonal_pos}
+combines irreducibility with these two coprime returns to exhibit one common
+exponent $N$ for which every entry of $T^N$ is positive. Thus
+\leanid{MPOTensor.PhysicalSectorFactorization.activeSectorTraceMatrix_isPrimitive}
+completes the active-sector primitivity argument. This replacement of the
+source's blocking step is a local fix, not an additional hypothesis.
 
 \subsection{Coherent vertex rephasing under recurrence}
 
@@ -633,13 +637,13 @@ after this commuting product form has been obtained, in the later step that
 derives the GSNNCH--ZCL and RFP conclusions.  Accordingly, adding ZCL to a
 conditional theorem would not be relevant to the coherent positive choice.
 
-The coherent positive choice in Lemma \texttt{propSN} is now complete.  The
-remaining trace-matrix primitivity statement is tracked by
-\href{https://github.com/LionSR/TNLean/issues/3696}{issue \#3696}.  The positive
-commuting bond, its exact all-length product realization, and the resulting
-eta-local structure of Proposition \texttt{3to4} are already available from a
-coherently positive physical-sector factorization.  Their composition with
-the new SAL theorem is
+The coherent positive choice and the active-sector trace-matrix primitivity in
+Lemma \texttt{propSN} are now complete.  The latter is
+\leanid{MPOTensor.exists_positive_physicalSectorFactorization_activeSectorTraceMatrix_isPrimitive_of_isSAL}.
+The positive commuting bond, its exact all-length product realization, and
+the resulting eta-local structure of Proposition \texttt{3to4} are available
+from a coherently positive physical-sector factorization.  Their composition
+with the SAL theorem is
 \leanid{MPOTensor.nonempty_etaLocalStructureData_of_isSAL}, so the
 $\eta$-local conclusion of Proposition~C.8 is now formalized from its source
 hypotheses.
@@ -659,18 +663,17 @@ equivalence, and hence the full Hilbert space, unchanged.
 
 \section{Classification}
 
-This note now records a closed coherent-positive-choice gap and the remaining
-downstream obligations in the SAL-to-positive-bond construction of
+This note now records a closed coherent-positive-choice and primitivity gap in
+the SAL-to-positive-bond construction of
 \leanid{MPOTensor.EtaLocalStructureData}. Zero-weight sectors are
 reparameterized without changing the physical decomposition, recurrence is
 derived from injectivity, and the inverse-map sector tensors are coherently
 rephased so that every neighboring operator is positive semidefinite. The
 earlier scope-restricted recurrence theorem remains useful as the general
 graph-theoretic component, but recurrence is a conclusion for the
-reparameterized inverse-map factorization.  The primitivity of the trace
-matrix restricted to positive-weight sectors remains open; it is no longer
-needed for recurrence and must be proved separately.  The unrestricted
-ambient trace matrix is not primitive when a zero-weight sector is present.
+reparameterized inverse-map factorization.  The trace matrix restricted to
+positive-weight sectors is primitive.  The unrestricted ambient trace matrix
+is not primitive when a zero-weight sector is present.
 
 For the conditional bond construction, all translates commute pairwise at
 every length $N\geq2$.  The finite-chain MPO is the ordered product of those
@@ -681,9 +684,11 @@ scalar one, and they determine the eta-local structure data. The raw
 physical-sector factorization already follows for an injective tensor
 satisfying SAL, and the coherent positive choice is now obtained by
 normalizing the inactive sectors and deriving recurrence from injectivity.
-The remaining work in this part of the paper is the later active-sector
-trace-matrix primitivity step; it is logically separate from the
-commuting-bond construction.
+The active-sector trace-matrix primitivity step is also complete.  The
+projector form of the local-orthogonality contraction remains a separate
+source presentation, but it is no longer an obstruction to Lemma
+\texttt{propSN} because the directed-cut product identity is proved directly
+for the sector virtual matrix spaces.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

- define the trace matrix on the nonzero-weight sector subtype while retaining every physical summand;
- prove strong connectivity from injective spanning and the source one-sided directed-cut obstruction;
- obtain closed support walks of lengths two and three and deduce primitivity from a common positive power;
- apply the argument to the coherently rephased inverse-map factorization under exactly injectivity and SAL;
- mark the active-sector primitivity theorem and its proof complete in the blueprint and close the corresponding paper-gap account;
- link the three recurrence helper declarations identified by the blueprint synchronization audit after PR #3830 merged.

## Mathematical scope

The full physical-sector decomposition is unchanged. Zero-weight summands remain present, but the auxiliary trace matrix is restricted to the effective sector set. This is the local clarification recorded in `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`, not an additional hypothesis.

The source-labelled capstone assumes only `K.IsInjective` and `IsSAL K`. It adds no recurrence, normality, ZCL, symmetric-support, or strict-positive-weight assumption.

Source: arXiv:1606.00608, Appendix C.2, Lemma C.4 (`propSN`), lines 1406–1471.

## Validation

- full `lake build`;
- direct root elaboration;
- proof-integrity and prose checks;
- blueprint-to-Lean declaration synchronization and `checkdecls`;
- blueprint web rendering.

Closes #3696.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a core formalization step on the SAL→η-local track with nontrivial graph/matrix arguments and documented deviations from the source blocking proof; impact is mathematical correctness of downstream MPDO results, not runtime or security.
> 
> **Overview**
> Completes Lemma C.4 (`propSN`) by proving **primitivity of the active-sector trace matrix** for injective MPO tensors with **SAL**, while keeping the full physical-sector decomposition (zero-weight summands stay; only the auxiliary `activeSectorTraceMatrix` is restricted).
> 
> Adds a finite-matrix lemma that **irreducibility plus positive diagonal entries of `T²` and `T³`** yields **`IsPrimitive`**, as a documented substitute for the paper’s periodic blocking step. On the physical-sector side, new results show **`(T*)³` diagonal positivity** from triangle closure and wire **`activeSectorTraceMatrix_isPrimitive`** through that lemma.
> 
> A new module assembles the **inverse-map** pipeline: zero-weight sectors have vanishing virtual matrices, coherent rephasing preserves spanning and support, triangle closure lifts to active sectors, then the SAL capstone **`exists_positive_physicalSectorFactorization_activeSectorTraceMatrix_isPrimitive_of_isSAL`** is exported. **`exists_rephase_zeroWeightInverseMap_posSemidef`** is factored out of the positive factorization proof for reuse.
> 
> Blueprint chapter 21 and the paper-gap note are updated to mark primitivity **complete** and link the new Lean declarations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 109ba57a65549880c7d972f7705b86e22112b95b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->