### PR TITLE
feat(MPS/MPDO): prove fixed-final fusion unitarity

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -451,6 +451,7 @@ import TNLean.MPS.MPDO.BNTRightTripleFusion
 import TNLean.MPS.MPDO.BNTTripleFusionComparison
 import TNLean.MPS.MPDO.BNTFinalSectorFusion
 import TNLean.MPS.MPDO.BNTTripleFusionSeparation
+import TNLean.MPS.MPDO.BNTFixedFinalUnitarity
 import TNLean.MPS.MPDO.CommutingForm
 import TNLean.MPS.MPDO.CommutingFormBridge
 import TNLean.MPS.MPDO.BlockedRFPConstruction

--- a/TNLean/MPS/MPDO/BNTFixedFinalUnitarity.lean
+++ b/TNLean/MPS/MPDO/BNTFixedFinalUnitarity.lean
@@ -1,0 +1,382 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.BNTTripleFusionSeparation
+
+/-!
+# Unitarity of fixed-final triple-fusion comparisons
+
+Under the positive trace-power and length-independence hypotheses,
+positive-length final-label selectors make the full triple-fusion comparison
+unitary and separate its distinct final-label sectors. Reordering the full
+direct sums by their final label therefore makes every diagonal sector corner
+unitary. If the selected final tensor is injective, the amplified commutant
+argument writes this corner as \(F_\varepsilon \otimes 1\). Positivity of the
+bond dimension then permits cancellation of the identity factor, proving both
+unitarity identities for \(F_\varepsilon\).
+
+These conclusions remain conditional on simultaneous final-label selectors
+and injectivity at the present blocking. The comparison used here has the
+opposite orientation from the matrix printed in equation (Fmove) of
+arXiv:1511.08090. No pentagon identity is asserted.
+
+## References
+
+* [Bultinck--Marien--Williamson--Sahinoglu--Haegeman--Verstraete 2015]
+  arXiv:1511.08090, lines 247--280
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  lines 995--1010
+-/
+
+open scoped Matrix BigOperators ComplexOrder Kronecker
+open Matrix
+
+namespace Matrix
+
+universe u
+
+/-- A diagonal corner of a right-unitary matrix over dependent direct sums is
+right-unitary when all off-diagonal corners in the same row vanish.
+
+Source: direct-sum matrix bookkeeping for the fixed-output-channel argument in
+arXiv:1511.08090, lines 247--277. -/
+theorem sigmaDiagonal_mul_conjTranspose_eq_one
+    {ι : Type u} [Fintype ι] [DecidableEq ι]
+    {L R : ι → Type*} [∀ i, DecidableEq (L i)] [∀ i, Fintype (R i)]
+    (C : Matrix ((i : ι) × L i) ((i : ι) × R i) ℂ)
+    (hunit : C * Cᴴ = 1)
+    (hoff : ∀ i j, j ≠ i →
+      C.submatrix (fun x : L i => ⟨i, x⟩) (fun y : R j => ⟨j, y⟩) = 0)
+    (i : ι) :
+    C.submatrix (fun x : L i => ⟨i, x⟩) (fun y : R i => ⟨i, y⟩) *
+        (C.submatrix (fun x : L i => ⟨i, x⟩) (fun y : R i => ⟨i, y⟩))ᴴ = 1 := by
+  ext x y
+  have hentry := congrArg (fun M => M ⟨i, x⟩ ⟨i, y⟩) hunit
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.one_apply,
+    Matrix.submatrix_apply, Fintype.sum_sigma] at hentry ⊢
+  rw [Finset.sum_eq_single i] at hentry
+  · by_cases hxy : x = y
+    · subst y
+      simpa using hentry
+    · have hsigma : Sigma.mk i x ≠ Sigma.mk i y := by
+        intro h
+        cases h
+        exact hxy rfl
+      simp only [hxy, hsigma, ↓reduceIte] at hentry ⊢
+      exact hentry
+  · intro j _ hji
+    apply Finset.sum_eq_zero
+    intro z _
+    have hz := congrArg (fun M => M x z) (hoff i j hji)
+    simp only [Matrix.submatrix_apply, Matrix.zero_apply] at hz
+    simp [hz]
+  · simp
+
+/-- A diagonal corner of a left-unitary matrix over dependent direct sums is
+left-unitary when all off-diagonal corners in the same column vanish.
+
+Source: direct-sum matrix bookkeeping for the fixed-output-channel argument in
+arXiv:1511.08090, lines 247--277. -/
+theorem sigmaDiagonal_conjTranspose_mul_eq_one
+    {ι : Type u} [Fintype ι] [DecidableEq ι]
+    {L R : ι → Type*} [∀ i, Fintype (L i)] [∀ i, DecidableEq (R i)]
+    (C : Matrix ((i : ι) × L i) ((i : ι) × R i) ℂ)
+    (hunit : Cᴴ * C = 1)
+    (hoff : ∀ i j, j ≠ i →
+      C.submatrix (fun x : L j => ⟨j, x⟩) (fun y : R i => ⟨i, y⟩) = 0)
+    (i : ι) :
+    (C.submatrix (fun x : L i => ⟨i, x⟩) (fun y : R i => ⟨i, y⟩))ᴴ *
+        C.submatrix (fun x : L i => ⟨i, x⟩) (fun y : R i => ⟨i, y⟩) = 1 := by
+  ext x y
+  have hentry := congrArg (fun M => M ⟨i, x⟩ ⟨i, y⟩) hunit
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.one_apply,
+    Matrix.submatrix_apply, Fintype.sum_sigma] at hentry ⊢
+  rw [Finset.sum_eq_single i] at hentry
+  · by_cases hxy : x = y
+    · subst y
+      simpa using hentry
+    · have hsigma : Sigma.mk i x ≠ Sigma.mk i y := by
+        intro h
+        cases h
+        exact hxy rfl
+      simp only [hxy, hsigma, ↓reduceIte] at hentry ⊢
+      exact hentry
+  · intro j _ hji
+    apply Finset.sum_eq_zero
+    intro z _
+    have hz := congrArg (fun M => M z x) (hoff i j hji)
+    simp only [Matrix.submatrix_apply, Matrix.zero_apply] at hz
+    simp [hz]
+  · simp
+
+private theorem mul_conjTranspose_eq_one_of_kronecker_one
+    {m n : Type*} [DecidableEq m] [Fintype n]
+    {D : ℕ} (hD : 0 < D)
+    (F : Matrix m n ℂ)
+    (hF : (F ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ)) *
+      (F ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ))ᴴ = 1) :
+    F * Fᴴ = 1 := by
+  let b : Fin D := ⟨0, hD⟩
+  ext i j
+  have hentry := congrArg (fun M => M (i, b) (j, b)) hF
+  simpa [Matrix.conjTranspose_kronecker, ← Matrix.mul_kronecker_mul,
+    Matrix.one_apply, b] using hentry
+
+private theorem conjTranspose_mul_eq_one_of_kronecker_one
+    {m n : Type*} [Fintype m] [DecidableEq n]
+    {D : ℕ} (hD : 0 < D)
+    (F : Matrix m n ℂ)
+    (hF : (F ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ))ᴴ *
+      (F ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ)) = 1) :
+    Fᴴ * F = 1 := by
+  let b : Fin D := ⟨0, hD⟩
+  ext i j
+  have hentry := congrArg (fun M => M (i, b) (j, b)) hF
+  simpa [Matrix.conjTranspose_kronecker, ← Matrix.mul_kronecker_mul,
+    Matrix.one_apply, b] using hentry
+
+end Matrix
+
+namespace MPOTensor.BNTFusionIsometryFamily
+
+universe u
+
+variable {Λ : Type u} [Fintype Λ] [DecidableEq Λ] {p : ℕ}
+variable (Fam : BNTFusionIsometryFamily Λ p)
+
+/-- The canonical reordering which places the final label before the left
+fixed-final index.
+
+Source: index bookkeeping for arXiv:1511.08090, equation (Fmove), whose fixed
+output label is denoted by d. -/
+def leftTripleFinalEquiv (α β γ : Λ) :
+    Fam.LeftTripleFusionIndex α β γ ≃
+      (ε : Λ) × Fam.LeftFinalIndex α β γ ε where
+  toFun
+    | ⟨δ, ε, μ, ν, b⟩ => ⟨ε, δ, μ, ν, b⟩
+  invFun
+    | ⟨ε, δ, μ, ν, b⟩ => ⟨δ, ε, μ, ν, b⟩
+  left_inv x := by rcases x with ⟨δ, ε, μ, ν, b⟩; rfl
+  right_inv x := by rcases x with ⟨ε, δ, μ, ν, b⟩; rfl
+
+/-- The canonical reordering which places the final label before the right
+fixed-final index.
+
+Source: index bookkeeping for arXiv:1511.08090, equation (Fmove), whose fixed
+output label is denoted by d. -/
+def rightTripleFinalEquiv (α β γ : Λ) :
+    Fam.RightTripleFusionIndex α β γ ≃
+      (ε : Λ) × Fam.RightFinalIndex α β γ ε where
+  toFun
+    | ⟨δ, ε, μ, ν, b⟩ => ⟨ε, δ, μ, ν, b⟩
+  invFun
+    | ⟨ε, δ, μ, ν, b⟩ => ⟨δ, ε, μ, ν, b⟩
+  left_inv x := by rcases x with ⟨δ, ε, μ, ν, b⟩; rfl
+  right_inv x := by rcases x with ⟨ε, δ, μ, ν, b⟩; rfl
+
+@[simp] private theorem leftTripleFinalEquiv_symm_sigmaMk
+    (α β γ ε : Λ) (x : Fam.LeftFinalIndex α β γ ε) :
+    (Fam.leftTripleFinalEquiv α β γ).symm ⟨ε, x⟩ =
+      Fam.leftFinalRow α β γ ε x := by
+  rcases x with ⟨δ, μ, ν, b⟩
+  rfl
+
+@[simp] private theorem rightTripleFinalEquiv_symm_sigmaMk
+    (α β γ ε : Λ) (x : Fam.RightFinalIndex α β γ ε) :
+    (Fam.rightTripleFinalEquiv α β γ).symm ⟨ε, x⟩ =
+      Fam.rightFinalRow α β γ ε x := by
+  rcases x with ⟨δ, μ, ν, b⟩
+  rfl
+
+/-- **A fixed-final comparison corner has a right adjoint inverse.**
+
+Suppose that common words of one positive length separate the final-label
+tensors and that the positive trace-power coefficients are independent of the
+positive chain length. Then each diagonal final-sector corner of the full
+triple-fusion comparison satisfies \(C_\varepsilon C_\varepsilon^\dagger=1\).
+
+**Scope restriction (simultaneous final-label separation):** the selector
+hypothesis is not derived from the fusion-isometry family; see
+docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex.
+
+Source: arXiv:1511.08090, lines 247--277, especially the simultaneous inverse
+at line 269; arXiv:1606.00608, lines 995--1010. -/
+theorem tripleFusionComparison_finalSector_mul_conjTranspose_eq_one
+    (c : BNTLabelCoefficientFamily Λ)
+    (hχ : c.HasPositiveLengthChiTracePowerForm Fam.chi)
+    (hLI : c.LengthIndependent) {S : ℕ} (hS : 0 < S)
+    (hSel : Fam.HasFinalLabelSelectorWords S)
+    (α β γ ε : Λ) :
+    (Fam.tripleFusionComparison α β γ).submatrix
+          (Fam.leftFinalRow α β γ ε) (Fam.rightFinalRow α β γ ε) *
+        ((Fam.tripleFusionComparison α β γ).submatrix
+          (Fam.leftFinalRow α β γ ε) (Fam.rightFinalRow α β γ ε))ᴴ = 1 := by
+  let C := Fam.tripleFusionComparison α β γ
+  let C' := C.submatrix (Fam.leftTripleFinalEquiv α β γ).symm
+    (Fam.rightTripleFinalEquiv α β γ).symm
+  have hleft (i : Λ) :
+      (Fam.leftTripleFinalEquiv α β γ).symm ∘
+          (fun x : Fam.LeftFinalIndex α β γ i => ⟨i, x⟩) =
+        Fam.leftFinalRow α β γ i := by
+    funext x
+    simp
+  have hright (i : Λ) :
+      (Fam.rightTripleFinalEquiv α β γ).symm ∘
+          (fun x : Fam.RightFinalIndex α β γ i => ⟨i, x⟩) =
+        Fam.rightFinalRow α β γ i := by
+    funext x
+    simp
+  have hunit : C' * C'ᴴ = 1 := by
+    unfold C'
+    rw [Matrix.conjTranspose_submatrix,
+      Matrix.submatrix_mul_equiv _ _ _ (Fam.rightTripleFinalEquiv α β γ).symm _,
+      Fam.tripleFusionComparison_mul_conjTranspose_eq_one_of_lengthIndependent_of_selectorWords
+        c hχ hLI hS hSel, Matrix.submatrix_one_equiv]
+  have hoff : ∀ i j, j ≠ i →
+      C'.submatrix
+        (fun x : Fam.LeftFinalIndex α β γ i => ⟨i, x⟩)
+        (fun y : Fam.RightFinalIndex α β γ j => ⟨j, y⟩) = 0 := by
+    intro i j hji
+    simpa only [C', Matrix.submatrix_submatrix, hleft, hright] using
+      Fam.tripleFusionComparison_finalSector_submatrix_eq_zero
+        c hχ hLI hSel α β γ i j hji
+  have hdiag := Matrix.sigmaDiagonal_mul_conjTranspose_eq_one C' hunit hoff ε
+  simp only [C', Matrix.submatrix_submatrix, hleft, hright] at hdiag
+  exact hdiag
+
+/-- **A fixed-final comparison corner also has a left adjoint inverse.**
+
+Under the same positive-length selector and length-independence hypotheses,
+every diagonal corner satisfies
+\(C_\varepsilon^\dagger C_\varepsilon=1\).
+
+Together the two identities make the fixed-final bond-space comparison
+unitary. No identification with the orientation of the printed \(F\)-matrix,
+and no pentagon identity, is asserted.
+
+**Scope restriction (simultaneous final-label separation):** the selector
+hypothesis is not derived from the fusion-isometry family; see
+docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex.
+
+Source: arXiv:1511.08090, lines 247--277, especially the simultaneous inverse
+at line 269; arXiv:1606.00608, lines 995--1010. -/
+theorem conjTranspose_mul_tripleFusionComparison_finalSector_eq_one
+    (c : BNTLabelCoefficientFamily Λ)
+    (hχ : c.HasPositiveLengthChiTracePowerForm Fam.chi)
+    (hLI : c.LengthIndependent) {S : ℕ} (hS : 0 < S)
+    (hSel : Fam.HasFinalLabelSelectorWords S)
+    (α β γ ε : Λ) :
+    ((Fam.tripleFusionComparison α β γ).submatrix
+          (Fam.leftFinalRow α β γ ε) (Fam.rightFinalRow α β γ ε))ᴴ *
+        (Fam.tripleFusionComparison α β γ).submatrix
+          (Fam.leftFinalRow α β γ ε) (Fam.rightFinalRow α β γ ε) = 1 := by
+  let C := Fam.tripleFusionComparison α β γ
+  let C' := C.submatrix (Fam.leftTripleFinalEquiv α β γ).symm
+    (Fam.rightTripleFinalEquiv α β γ).symm
+  have hleft (i : Λ) :
+      (Fam.leftTripleFinalEquiv α β γ).symm ∘
+          (fun x : Fam.LeftFinalIndex α β γ i => ⟨i, x⟩) =
+        Fam.leftFinalRow α β γ i := by
+    funext x
+    simp
+  have hright (i : Λ) :
+      (Fam.rightTripleFinalEquiv α β γ).symm ∘
+          (fun x : Fam.RightFinalIndex α β γ i => ⟨i, x⟩) =
+        Fam.rightFinalRow α β γ i := by
+    funext x
+    simp
+  have hunit : C'ᴴ * C' = 1 := by
+    unfold C'
+    rw [Matrix.conjTranspose_submatrix,
+      Matrix.submatrix_mul_equiv _ _ _ (Fam.leftTripleFinalEquiv α β γ).symm _,
+      Fam.conjTranspose_mul_tripleFusionComparison_eq_one_of_lengthIndependent_of_selectorWords
+        c hχ hLI hS hSel, Matrix.submatrix_one_equiv]
+  have hoff : ∀ i j, j ≠ i →
+      C'.submatrix
+        (fun x : Fam.LeftFinalIndex α β γ j => ⟨j, x⟩)
+        (fun y : Fam.RightFinalIndex α β γ i => ⟨i, y⟩) = 0 := by
+    intro i j hji
+    simpa only [C', Matrix.submatrix_submatrix, hleft, hright] using
+      Fam.tripleFusionComparison_finalSector_submatrix_eq_zero
+        c hχ hLI hSel α β γ j i hji.symm
+  have hdiag := Matrix.sigmaDiagonal_conjTranspose_mul_eq_one C' hunit hoff ε
+  simp only [C', Matrix.submatrix_submatrix, hleft, hright] at hdiag
+  exact hdiag
+
+/-- **Conditional unitarity of the fixed-final multiplicity matrix.**
+
+Suppose the positive trace-power coefficients are independent of the positive
+chain length, common words of one positive length separate the final-label
+tensors, the selected final tensor is injective at the present blocking, and
+its bond dimension is positive. Then the diagonal final-sector corner is
+\(F_\varepsilon\otimes 1_{D_\varepsilon}\), where
+\[
+  F_\varepsilon F_\varepsilon^\dagger=1,
+  \qquad
+  F_\varepsilon^\dagger F_\varepsilon=1.
+\]
+Thus the multiplicity matrix is two-sided unitary, and in particular
+invertible. The positive bond-dimension assumption is necessary for cancelling
+the identity Kronecker factor; injectivity alone is vacuous on a zero-dimensional
+bond space.
+
+**Scope restriction (injectivity and simultaneous final-label separation):**
+neither injectivity at the present blocking nor the selector hypothesis is
+derived from the fusion-isometry family. This is documented in
+docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex.
+
+The comparison used here has the opposite orientation from the matrix printed
+in equation (Fmove) of arXiv:1511.08090. No convention-identification or
+pentagon identity is asserted.
+
+Source: arXiv:1511.08090, equation (Fmove) and lines 247--280, especially the
+simultaneous inverse at line 269 and the tensor-factor conclusion at line 277;
+arXiv:1606.00608, lines 995--1010. -/
+theorem exists_tripleFusionComparison_finalSector_eq_kronecker_one_and_unitary
+    (c : BNTLabelCoefficientFamily Λ)
+    (hχ : c.HasPositiveLengthChiTracePowerForm Fam.chi)
+    (hLI : c.LengthIndependent) {S : ℕ} (hS : 0 < S)
+    (hSel : Fam.HasFinalLabelSelectorWords S)
+    (α β γ ε : Λ)
+    (hε : MPSTensor.IsInjective (Fam.tensor ε).toMPSTensor)
+    (hD : 0 < Fam.bondDim ε) :
+    ∃ F : Matrix (Fam.LeftFinalMultiplicity α β γ ε)
+        (Fam.RightFinalMultiplicity α β γ ε) ℂ,
+      ((Fam.tripleFusionComparison α β γ).submatrix
+          (Fam.leftFinalRow α β γ ε) (Fam.rightFinalRow α β γ ε)).submatrix
+            (Fam.leftFinalIndexEquiv α β γ ε).symm
+            (Fam.rightFinalIndexEquiv α β γ ε).symm =
+          F ⊗ₖ (1 : Matrix (Fin (Fam.bondDim ε)) (Fin (Fam.bondDim ε)) ℂ) ∧
+        F * Fᴴ = 1 ∧ Fᴴ * F = 1 := by
+  obtain ⟨F, hF, -⟩ :=
+    Fam.exists_tripleFusionComparison_finalSector_eq_kronecker_one_of_separation
+      c hχ hLI hSel α β γ ε hε
+  let C := (Fam.tripleFusionComparison α β γ).submatrix
+    (Fam.leftFinalRow α β γ ε) (Fam.rightFinalRow α β γ ε)
+  have hCC : C * Cᴴ = 1 :=
+    Fam.tripleFusionComparison_finalSector_mul_conjTranspose_eq_one
+      c hχ hLI hS hSel α β γ ε
+  have hCdagC : Cᴴ * C = 1 :=
+    Fam.conjTranspose_mul_tripleFusionComparison_finalSector_eq_one
+      c hχ hLI hS hSel α β γ ε
+  have hFFdag :
+      (F ⊗ₖ (1 : Matrix (Fin (Fam.bondDim ε)) (Fin (Fam.bondDim ε)) ℂ)) *
+          (F ⊗ₖ (1 : Matrix (Fin (Fam.bondDim ε)) (Fin (Fam.bondDim ε)) ℂ))ᴴ = 1 := by
+    rw [← hF, Matrix.conjTranspose_submatrix,
+      Matrix.submatrix_mul_equiv _ _ _
+        (Fam.rightFinalIndexEquiv α β γ ε).symm _,
+      hCC, Matrix.submatrix_one_equiv]
+  have hFdagF :
+      (F ⊗ₖ (1 : Matrix (Fin (Fam.bondDim ε)) (Fin (Fam.bondDim ε)) ℂ))ᴴ *
+          (F ⊗ₖ (1 : Matrix (Fin (Fam.bondDim ε)) (Fin (Fam.bondDim ε)) ℂ)) = 1 := by
+    rw [← hF, Matrix.conjTranspose_submatrix,
+      Matrix.submatrix_mul_equiv _ _ _
+        (Fam.leftFinalIndexEquiv α β γ ε).symm _,
+      hCdagC, Matrix.submatrix_one_equiv]
+  exact ⟨F, hF,
+    Matrix.mul_conjTranspose_eq_one_of_kronecker_one hD F hFFdag,
+    Matrix.conjTranspose_mul_eq_one_of_kronecker_one hD F hFdagF⟩
+
+end MPOTensor.BNTFusionIsometryFamily

--- a/TNLean/MPS/MPDO/BNTTripleFusionSeparation.lean
+++ b/TNLean/MPS/MPDO/BNTTripleFusionSeparation.lean
@@ -21,10 +21,10 @@ arXiv:1511.08090.
 The selector hypothesis is stated explicitly.  It is not presently derived
 from the assumptions on `BNTFusionIsometryFamily`. At a positive selector
 length it also makes both iterated fusion maps surjective, and hence makes the
-full comparison invertible with adjoint inverse. The fixed-final results remain
-conditional: they do not construct an invertible fixed-sector comparison,
-identify its multiplicity factor with the source $F$-matrix, or prove a
-pentagon identity.
+full comparison invertible with adjoint inverse. Its diagonal final-sector
+corners can then be studied separately. The fixed-final conclusions remain
+conditional on the selector and injectivity hypotheses and require a separate
+argument.
 
 ## References
 
@@ -395,7 +395,8 @@ positive-length final-label separation.**
 This is the opposite product of
 `tripleFusionComparison_mul_conjTranspose_eq_one_of_lengthIndependent_of_selectorWords`.
 It proves two-sided invertibility only on the full direct sums; extracting an invertible
-fixed-final multiplicity matrix remains a separate step.
+fixed-final multiplicity matrix also requires off-diagonal separation,
+injectivity of the selected tensor, and positive bond dimension.
 
 Source: arXiv:1606.00608, lines 995--1010; arXiv:1511.08090, lines 181--191,
 247--252, and 269. -/

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -896,6 +896,8 @@ separate step.
     \lean{MPOTensor.BNTFusionIsometryFamily.RightFinalMultiplicity}
     \lean{MPOTensor.BNTFusionIsometryFamily.leftFinalIndexEquiv}
     \lean{MPOTensor.BNTFusionIsometryFamily.rightFinalIndexEquiv}
+    \lean{MPOTensor.BNTFusionIsometryFamily.leftTripleFinalEquiv}
+    \lean{MPOTensor.BNTFusionIsometryFamily.rightTripleFinalEquiv}
     \leanok
     \uses{def:mpdo_bnt_fusion_isometry_family}
     Fix a final label $\varepsilon$.  The multiplicity spaces of the two
@@ -1117,4 +1119,95 @@ separate step.
     $C^{\varepsilon,\varepsilon'}=0$ whenever
     $\varepsilon'\ne\varepsilon$ by
     Theorem~\ref{thm:mpdo_triple_fusion_comparison_final_sector_vanishing}.
+\end{proof}
+
+\begin{theorem}[Unitarity of each fixed-final comparison corner]%
+    \label{thm:mpdo_triple_fusion_comparison_final_sector_unitary}
+    \lean{MPOTensor.BNTFusionIsometryFamily.%
+        tripleFusionComparison_finalSector_mul_conjTranspose_eq_one}
+    \lean{MPOTensor.BNTFusionIsometryFamily.%
+        conjTranspose_mul_tripleFusionComparison_finalSector_eq_one}
+    \leanok
+    \uses{def:mpdo_final_label_selector_words,
+        def:mpdo_final_sector_multiplicity_spaces,
+        def:mpdo_triple_fusion_comparison}
+    Suppose the positive trace-power coefficients are independent of the
+    positive chain length and common selectors exist at a positive length.
+    For every final label $\varepsilon$, write
+
+    \[
+        C_\varepsilon
+          =P^{\mathrm L}_{\varepsilon}
+            C_{\alpha,\beta,\gamma}
+            P^{\mathrm R}_{\varepsilon}.
+    \]
+    Then
+    \[
+        C_\varepsilon C_\varepsilon^\dagger=1,
+        \qquad
+        C_\varepsilon^\dagger C_\varepsilon=1.
+    \]
+    The conclusion is conditional on the simultaneous selector identities.
+    It is the fixed-output-channel invertibility consequence of the
+    simultaneous inverse used in \cite[lines~247--277]{Bultinck2017Anyons}.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:mpdo_triple_fusion_comparison_right_inverse,
+        thm:mpdo_triple_fusion_comparison_left_inverse,
+        thm:mpdo_triple_fusion_comparison_final_sector_vanishing}
+    Order each full direct sum first by its final label.  In the product
+    $CC^\dagger$, the $\varepsilon$-diagonal corner is
+    \[
+        \sum_{\varepsilon'}
+          C^{\varepsilon,\varepsilon'}
+          (C^{\varepsilon,\varepsilon'})^\dagger.
+    \]
+    Every term with $\varepsilon'\ne\varepsilon$ vanishes, while
+    $CC^\dagger=1$.  Hence
+    $C_\varepsilon C_\varepsilon^\dagger=1$.  Taking instead the
+    $\varepsilon$-diagonal corner of $C^\dagger C=1$ gives the second identity.
+\end{proof}
+\begin{theorem}[Unitarity of the fixed-final multiplicity matrix]%
+    \label{thm:mpdo_triple_fusion_multiplicity_unitary}
+    \lean{MPOTensor.BNTFusionIsometryFamily.%
+        exists_tripleFusionComparison_finalSector_eq_kronecker_one_and_unitary}
+    \leanok
+    \uses{def:mpdo_final_label_selector_words,
+        def:mpdo_final_sector_multiplicity_spaces,
+        def:mpdo_triple_fusion_comparison}
+    Assume the hypotheses of
+    Theorem~\ref{thm:mpdo_triple_fusion_comparison_final_sector_unitary}.
+    Suppose in addition that $M_\varepsilon$ is injective at the present
+    blocking and that $D_\varepsilon>0$.  There is a matrix
+    \[
+        F_\varepsilon:\mathcal H^{\mathrm R}_{\varepsilon}
+          \longrightarrow \mathcal H^{\mathrm L}_{\varepsilon}
+    \]
+    such that
+    \[
+        C_\varepsilon=F_\varepsilon\otimes1_{D_\varepsilon},
+        \qquad
+        F_\varepsilon F_\varepsilon^\dagger=1,
+        \qquad
+        F_\varepsilon^\dagger F_\varepsilon=1.
+    \]
+    Thus $F_\varepsilon$ is invertible.  Its orientation is opposite to the
+    convention in equation (Fmove) of \cite{Bultinck2017Anyons}; no pentagon
+    identity is asserted.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:mpdo_triple_fusion_comparison_final_sector_kronecker,
+        thm:mpdo_triple_fusion_comparison_final_sector_unitary}
+    Injectivity gives
+    $C_\varepsilon=F_\varepsilon\otimes1_{D_\varepsilon}$.
+    Substitute this expression into the two identities for $C_\varepsilon$:
+    \[
+        (F_\varepsilon F_\varepsilon^\dagger)
+          \otimes1_{D_\varepsilon}=1,
+        \qquad
+        (F_\varepsilon^\dagger F_\varepsilon)
+          \otimes1_{D_\varepsilon}=1.
+    \]
+    Since $D_\varepsilon>0$, evaluation at any bond basis vector cancels the
+    identity factor and gives the two asserted identities.
 \end{proof}

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -614,17 +614,26 @@ Under the positive-length selector hypothesis above, the range-completeness
 obstruction from lines~181--191 has now been removed.  The two-sided unitarity
 of the full comparison, together with the vanishing of its off-diagonal
 final-label corners, implies mathematically that every fixed-final bond-space
-corner is two-sided unitary.  This consequence has not yet been packaged as a
-separate Lean theorem.  Combining it with the factorization
-$C^{\varepsilon,\varepsilon}=F_\varepsilon\otimes 1_{D_\varepsilon}$ should
-give the two unitary identities for $F_\varepsilon$ by cancelling the identity
-factor.  That cancellation requires either the explicit assumption
-$0<D_\varepsilon$ or a separate treatment of the zero-dimensional case,
-since injectivity is vacuous when $D_\varepsilon=0$.  Thus the remaining steps
-are to formalize the fixed-final corner identities, extract the
-invertibility---indeed unitarity---of $F_\varepsilon$ with this dimensional
-qualification, identify the orientation convention with the printed
-$F$-matrix, and prove the pentagon-like equation mentioned at lines~995--999.
+corner is two-sided unitary.  The two identities are now formalized by
+\leanid{MPOTensor.BNTFusionIsometryFamily.%
+tripleFusionComparison_finalSector_mul_conjTranspose_eq_one} and
+\leanid{MPOTensor.BNTFusionIsometryFamily.%
+conjTranspose_mul_tripleFusionComparison_finalSector_eq_one}.
+
+Combining these corner identities with
+$C^{\varepsilon,\varepsilon}=F_\varepsilon\otimes 1_{D_\varepsilon}$ gives
+the two unitary identities for $F_\varepsilon$ by cancelling the identity
+factor.  This is formalized by
+\leanid{MPOTensor.BNTFusionIsometryFamily.%
+exists_tripleFusionComparison_finalSector_eq_kronecker_one_and_unitary}
+under the explicit assumption $0<D_\varepsilon$.  The dimensional
+qualification is necessary because injectivity is vacuous when
+$D_\varepsilon=0$.  Thus the fixed-final invertibility obstruction has been
+removed under the simultaneous-selector, present-blocking injectivity, and
+positive-bond-dimension hypotheses.  The remaining steps are to derive those
+hypotheses from the source assumptions, identify the orientation convention
+with the printed $F$-matrix, and prove the pentagon-like equation mentioned at
+lines~995--999.
 
 To eliminate the source-theorem gap, the formalization should instead:
 \begin{enumerate}


### PR DESCRIPTION
## Summary

- decomposes the full triple-fusion comparison by final label and proves both unitary identities for every diagonal final-sector corner
- combines selector completeness, off-diagonal final-sector separation, and the amplified-commutant factorization to obtain
  \[
    C_\varepsilon=F_\varepsilon\otimes 1_{D_\varepsilon},\qquad
    F_\varepsilon F_\varepsilon^\dagger=1,\qquad
    F_\varepsilon^\dagger F_\varepsilon=1
  \]
- isolates the argument in a focused `BNTFixedFinalUnitarity` module and records it in the MPO/RFP blueprint
- updates the paper-gap note to leave only convention identification and the later pentagon coherence theorem

## Mathematical scope

The result assumes the positive trace-power and length-independence hypotheses, simultaneous final-label selectors at a positive word length, injectivity of the selected final tensor at the present blocking, and `0 < D_ε`. The final inequality is needed to cancel the identity Kronecker factor; injectivity is vacuous on a zero-dimensional bond space.

No eventual-linear-independence hypothesis is used. Full comparison unitarity and final-label separation already give both rectangular corner identities, so squareness follows from the two-sided inverse rather than from a separate dimension count.

The comparison has the opposite orientation from equation (Fmove) in the cited source. This pull request proves the fixed-final invertible transformation but does not identify conventions and does not assert the pentagon equation.

Source: arXiv:1511.08090, lines 181--191, 237--280, especially the simultaneous inverse at line 269 and multiplicity-only factor at line 277; arXiv:1606.00608, lines 995--1010.

## Verification

- full `lake build TNLean` (9,357 jobs), with new-module warnings removed
- direct Lean elaboration of the new module
- blueprint synchronization and `checkdecls`
- blueprint web generation
- blueprint PDF generation (526 pages)
- visual inspection of the fixed-final theorem page
- independent mathematical and proof-integrity review
- line-size, whitespace, and identity checks

Closes #3776.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib/Lean proof and documentation additions on the MPDO BNT track; no runtime, auth, or API surface changes, with scope clearly marked conditional on unstated selector/injectivity hypotheses.
> 
> **Overview**
> Adds **`BNTFixedFinalUnitarity`**, wired into the root import list, to close the fixed-final step after full triple-fusion invertibility and final-label separation.
> 
> Under length independence and positive-length **final-label selector words**, index reorderings (`leftTripleFinalEquiv` / `rightTripleFinalEquiv`) plus generic sigma-diagonal matrix lemmas show each diagonal corner \(C_\varepsilon\) satisfies **\(C_\varepsilon C_\varepsilon^\dagger = 1\)** and **\(C_\varepsilon^\dagger C_\varepsilon = 1\)**, using off-diagonal vanishing from the separation module.
> 
> Combining that with the existing Kronecker factorization **\(C_\varepsilon = F_\varepsilon \otimes 1_{D_\varepsilon}\)** (injectivity) and **\(0 < D_\varepsilon\)** yields **two-sided unitarity of \(F_\varepsilon\)** via Kronecker-with-identity cancellation. Selector, injectivity, and positive bond dimension stay explicit hypotheses; orientation vs. printed (Fmove) and the pentagon identity are **not** claimed.
> 
> The MPDO fusion-isometries blueprint gains matching theorems and `\lean` links; **`BNTTripleFusionSeparation`** and **`cpgsv17_blocked_chi_uniformity.tex`** are updated to point at the new Lean names and note that only convention matching and pentagon coherence remain open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a478a027e0a3734884583b167459805ad76fb4a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->