### PR TITLE
doc(MPS/MPDO): illustrate fixed-final fusion unitarity

### DIFF
--- a/blueprint/src/Packages/tn_diagrams.py
+++ b/blueprint/src/Packages/tn_diagrams.py
@@ -77,6 +77,7 @@ _DIAGRAM_ARGS: dict[str, str] = {
     "TNBNTDecomposition": "",
     "TNMPDOZCLIdempotence": "",
     "TNMPDOFixedFinalFusionBracketings": "",
+    "TNMPDOFixedFinalComparisonUnitary": "",
     "TNMPDOBNTFusionIdentity": "",
     "TNMPDOUnweightedZipperReconstruction": "",
     "TNMPDOFusionTracePower": "",

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -482,10 +482,9 @@ separate step.
         \cite[eq.~(Fmove)]{Bultinck2017Anyons}.  The solid fusion trees are
         the left- and right-bracketed maps constructed below.  The dashed
         line denotes the invertible fixed-final change of multiplicity basis
-        in the source.  The conditional result below extracts a rectangular
-        multiplicity factor acting trivially on the final bond space, but does
-        not identify that factor with the dashed source transformation or
-        prove its invertibility.}
+        in the source.  The results below first extract its action on the
+        multiplicity space and then prove its two-sided unitarity under the
+        simultaneous-selector and positive-bond-dimension hypotheses.}
     \label{fig:mpdo_fixed_final_fusion_bracketings}
 \end{figure}
 
@@ -1211,3 +1210,22 @@ separate step.
     Since $D_\varepsilon>0$, evaluation at any bond basis vector cancels the
     identity factor and gives the two asserted identities.
 \end{proof}
+
+\begin{figure}[ht]
+    \centering
+    \TNMPDOFixedFinalComparisonUnitary
+    \caption{The fixed-final comparison in the graphical order of
+        \cite[equation~(pentagon3) and lines~269--277]
+        {Bultinck2017Anyons}.  At a positive common length, the simultaneous
+        word selector is the finite-word counterpart of the inverse
+        $B_d^+$ in the source: it retains the chosen final label and
+        annihilates every other one.  Thus the comparison has no
+        off-diagonal final-label corners.  On the surviving corner,
+        injectivity gives
+        $C_\varepsilon=F_\varepsilon\otimes1_{D_\varepsilon}$; two-sided
+        unitarity of $C_\varepsilon$ and $D_\varepsilon>0$ give two-sided
+        unitarity of $F_\varepsilon$.  This is the associativity mechanism
+        described in \cite[lines~995--1010]{Cirac2016MPDO_arXiv}.  No
+        pentagon coherence identity is asserted here.}
+    \label{fig:mpdo_fixed_final_comparison_unitary}
+\end{figure}

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -1186,6 +1186,99 @@
     \end{tikzpicture}%
 }
 
+% The fixed-final comparison argument in three graphical steps.  A
+% positive-length simultaneous word selector isolates one final label, the
+% resulting comparison is block diagonal in that label, and injectivity
+% identifies each diagonal corner with F tensored with the identity on the
+% final bond space.  The last line records two-sided unitarity, but deliberately
+% contains no four-fold reassociation or pentagon claim.
+\newcommand{\TNMPDOFixedFinalComparisonUnitary}{%
+    \begin{tikzpicture}[tn picture, scale=0.86]
+        % Positive-length simultaneous selector.
+        \node[anchor=east] at (-4.62,2.82) {\textup{selector}};
+        \node[anchor=east] at (-4.62,2.42) {$S>0$};
+        \foreach \x/\s in {-3.90/L,-2.86/M,-0.66/R} {
+            \TN@tensordot{ffSel\s}{(\x,2.62)}
+            \TN@upleg{ffSel\s}{0.31}
+            \TN@downleg{ffSel\s}{0.31}
+        }
+        \draw[tn leg] (ffSelL.east) -- (ffSelM.west);
+        \draw[tn leg] (ffSelM.east) -- ++(0.49,0);
+        \draw[tn leg] ($(ffSelR.west)+(-0.49,0)$) -- (ffSelR.west);
+        \TN@leftleg{ffSelL}{0.34}
+        \TN@rightleg{ffSelR}{0.34}
+        \node at (-1.76,2.62) {$\cdots$};
+        \node at (-2.28,2.14) {$M_{\varepsilon'}^{w}$};
+        \draw[densely dashed, rounded corners]
+            (-4.33,2.03) rectangle (-0.23,3.17);
+        \node[fill=white, inner sep=1pt] at (-2.28,3.17)
+            {$\displaystyle\sum_{|w|=S}c_{\varepsilon}(w)\,(\,\cdot\,)^{w}$};
+        \draw[->, tn leg] (0.12,2.62) -- (1.05,2.62);
+        \node[anchor=west] at (1.18,2.62)
+            {$\displaystyle
+              \begin{cases}
+                1_{D_\varepsilon},&\varepsilon'=\varepsilon,\\[-1pt]
+                0,&\varepsilon'\ne\varepsilon.
+              \end{cases}$};
+
+        % Off-diagonal corners of the comparison vanish.  The two small trees
+        % retain the bracketing convention of the source F-move figures.
+        \node[anchor=east] at (-4.62,0.48) {\textup{sector cut}};
+        \node (ffLa) at (-3.92,-0.20) {$\alpha$};
+        \node (ffLb) at (-3.32,-0.20) {$\beta$};
+        \node (ffLc) at (-2.72,-0.20) {$\gamma$};
+        \node[draw, rounded corners, fill=blue!8, inner sep=1.2pt]
+            (ffLab) at (-3.62,0.35) {$U_{\alpha,\beta}$};
+        \node[draw, rounded corners, fill=blue!8, inner sep=1.2pt]
+            (ffLroot) at (-3.17,0.94) {$U^{\mathrm L}$};
+        \draw[tn leg] (ffLa.north) -- (ffLab.south west);
+        \draw[tn leg] (ffLb.north) -- (ffLab.south east);
+        \draw[tn leg] (ffLab.north) -- (ffLroot.south west);
+        \draw[tn leg] (ffLc.north) -- (ffLroot.south east);
+        \node[above=1pt] at (ffLroot.north) {$\varepsilon$};
+
+        \node (ffRa) at (2.48,-0.20) {$\alpha$};
+        \node (ffRb) at (3.08,-0.20) {$\beta$};
+        \node (ffRc) at (3.68,-0.20) {$\gamma$};
+        \node[draw, rounded corners, fill=blue!8, inner sep=1.2pt]
+            (ffRbc) at (3.38,0.35) {$U_{\beta,\gamma}$};
+        \node[draw, rounded corners, fill=blue!8, inner sep=1.2pt]
+            (ffRroot) at (2.93,0.94) {$U^{\mathrm R}$};
+        \draw[tn leg] (ffRb.north) -- (ffRbc.south west);
+        \draw[tn leg] (ffRc.north) -- (ffRbc.south east);
+        \draw[tn leg] (ffRa.north) -- (ffRroot.south west);
+        \draw[tn leg] (ffRbc.north) -- (ffRroot.south east);
+        \node[above=1pt] at (ffRroot.north) {$\varepsilon'$};
+        \draw[<-, tn leg] (ffLroot.east) -- node[above]
+            {$C^{\varepsilon,\varepsilon'}_{\alpha,\beta,\gamma}$}
+            (ffRroot.west);
+        \node[anchor=west] at (4.18,0.94)
+            {$=0\quad(\varepsilon\ne\varepsilon')$};
+
+        % The surviving corner splits into the multiplicity F-matrix and the
+        % identity on the final MPO bond space.
+        \node[anchor=east] at (-4.62,-1.76) {\textup{diagonal corner}};
+        \node[anchor=east] at (-3.43,-1.48)
+            {$\mathcal H^{\mathrm L}_{\varepsilon}$};
+        \node[anchor=east] at (-3.43,-2.08) {$\C^{D_\varepsilon}$};
+        \node[anchor=west] at (3.43,-1.48)
+            {$\mathcal H^{\mathrm R}_{\varepsilon}$};
+        \node[anchor=west] at (3.43,-2.08) {$\C^{D_\varepsilon}$};
+        \node[draw, rounded corners, fill=blue!8, inner sep=2pt]
+            (ffF) at (0,-1.48) {$F_\varepsilon$};
+        \draw[<-, tn leg] (-3.36,-1.48) -- (ffF.west);
+        \draw[<-, tn leg] (ffF.east) -- (3.36,-1.48);
+        \draw[<-, tn leg] (-3.36,-2.08) -- node[below]
+            {$1_{D_\varepsilon}$} (3.36,-2.08);
+        \node at (0,-2.62)
+            {$C_\varepsilon=F_\varepsilon\otimes1_{D_\varepsilon},\qquad
+              D_\varepsilon>0$};
+        \node at (0,-3.15)
+            {$F_\varepsilon F_\varepsilon^\dagger=1,\qquad
+              F_\varepsilon^\dagger F_\varepsilon=1$};
+    \end{tikzpicture}%
+}
+
 % Local BNT fusion identity from CPSV16, eq. (Ualphabeta).  The left-hand
 % isometry combines the two incoming bond factors, while its adjoint separates
 % the outgoing factors.  The right-hand side records the weighted final-sector

--- a/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
+++ b/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
@@ -28,7 +28,7 @@ name: TNMPDOInverseContraction TNMPDOSectorPairing TNMPDOSectorZCLIdentity
 name: TNMPSInverseContraction TNBNTDecomposition TNMPDOZCLIdempotence TNMPDOFixedFinalFusionBracketings
 {{ obj.tn_svg_html }}
 
-name: TNMPDOBNTFusionIdentity TNMPDOUnweightedZipperReconstruction TNMPDOFusionTracePower
+name: TNMPDOBNTFusionIdentity TNMPDOUnweightedZipperReconstruction TNMPDOFusionTracePower TNMPDOFixedFinalComparisonUnitary
 {{ obj.tn_svg_html }}
 
 name: TNRFPKrausIsometry TNRFPKrausIsometryReverse TNRFPIsometryCanonicalForm


### PR DESCRIPTION
## Summary

- add a native TikZ figure for the fixed-final comparison proved in #3843;
- display the positive-length simultaneous selector, the vanishing off-diagonal final-sector corner, and the surviving factorization (C_\varepsilon=F_\varepsilon\otimes 1_{D_\varepsilon});
- record the two-sided unitarity of (F_\varepsilon) under (D_\varepsilon>0).

## Source and scope

The graphical order follows arXiv:1511.08090, equation `pentagon3` and lines 269–277, together with the associativity discussion in arXiv:1606.00608, lines 995–1010. The figure contains only the triple-fusion comparison proved here. It explicitly makes no claim about the later fourfold pentagon coherence relation.

## Validation

- tensor-network diagram registry: 110 registrations;
- blueprint–Lean synchronization;
- blueprint web rendering;
- blueprint PDF: 527 pages;
- visual inspection of printed page 442.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (TikZ, LaTeX, diagram registration); no runtime or proof logic is modified.
> 
> **Overview**
> Adds blueprint documentation for the **fixed-final triple-fusion comparison** and why the multiplicity **F-matrix** is unitary under the existing selector and injectivity hypotheses.
> 
> A new TikZ macro `\TNMPDOFixedFinalComparisonUnitary` walks through three steps: a positive-length simultaneous word selector isolates one final label, off-diagonal final-sector corners of the comparison vanish, and on the diagonal corner injectivity gives **C_ε = F_ε ⊗ 1_{D_ε}** with two-sided unitarity of **F_ε** when **D_ε > 0**. The figure is wired into the diagram registry (`tn_diagrams.py`), plasTeX SVG templates, and a new figure in `ch21_mpdo_rfp_fusion_isometries.tex` after the unitarity theorems.
> 
> The caption on the earlier bracketings figure is tightened so it states that the dashed line’s multiplicity action is extracted and proved two-sided unitary under the simultaneous-selector hypotheses, rather than only a conditional rectangular factor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 330e63874edeade46c63d31b35d14925f408a8e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->