### PR TITLE
feat(MPS/MPDO): define fourfold fusion coordinate routes

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -453,6 +453,7 @@ import TNLean.MPS.MPDO.BNTLeftTripleFusion
 import TNLean.MPS.MPDO.BNTRightTripleFusion
 import TNLean.MPS.MPDO.BNTTripleFusionComparison
 import TNLean.MPS.MPDO.BNTFinalSectorFusion
+import TNLean.MPS.MPDO.BNTFourfoldFusionIndices
 import TNLean.MPS.MPDO.BNTTripleFusionSeparation
 import TNLean.MPS.MPDO.BNTFixedFinalUnitarity
 import TNLean.MPS.MPDO.CommutingForm

--- a/TNLean/MPS/MPDO/BNTFourfoldFusionIndices.lean
+++ b/TNLean/MPS/MPDO/BNTFourfoldFusionIndices.lean
@@ -6,25 +6,29 @@ Authors: TNLean contributors
 import TNLean.MPS.MPDO.BNTFinalSectorFusion
 
 /-!
-# Multiplicity spaces for fourfold fusion
+# Weighted coordinate spaces for fourfold fusion
 
-The five parenthesizations of four labels give five finite multiplicity spaces at a fixed final
-label. This file records those spaces and the canonical coordinate reassociations used along the
-three-edge and two-edge routes between the fully left- and fully right-associated products.
+The five parenthesizations of four labels give five finite weighted coordinate spaces at a fixed
+final label. Their `Fin` factors come from the positive-diagonal matrices `Fam.chi`; they are
+analogues of the categorical fusion-multiplicity indices in arXiv:1511.08090, not an
+identification with them. This file records those spaces and the canonical coordinate
+reassociations used along the three-edge and two-edge route patterns between the fully left- and
+fully right-associated products.
 
 For each edge, the source and target spaces are identified with a dependent sum in which one
-factor is a triple-fusion multiplicity space and the remaining multiplicity index is unchanged.
-These identifications do not identify the source and target multiplicity spaces: that change of
-basis belongs to the fusion comparison. The associated matrices below only permute coordinates
-within each fixed parenthesization.
+factor is a weighted triple-fusion coordinate space and the remaining weighted index is
+unchanged. These identifications do not identify the source and target coordinate spaces: that
+change of basis belongs to the fusion comparison. The associated matrices below only permute
+coordinates within each fixed parenthesization.
 
 The same five parenthesizations also give five bond-coordinate types. Their edge equivalences are
 ordinary reassociations of finite Cartesian products. The two composites between the extreme
 parenthesizations are proved equal, together with the corresponding equality of coordinate-
 permutation matrices.
 
-No comparison matrix between different parenthesizations is defined here, and no pentagon
-identity is asserted.
+References below to factors in the printed pentagon record only the pattern of labels and
+indices. No comparison matrix between different parenthesizations is defined here, no equality
+with the source's categorical multiplicities is asserted, and no pentagon identity is asserted.
 
 ## References
 
@@ -41,63 +45,74 @@ universe u
 variable {Λ : Type u} [Fintype Λ] [DecidableEq Λ] {p : ℕ}
 variable (Fam : BNTFusionIsometryFamily Λ p)
 
-/-! ### The five parenthesizations -/
+/-! ### The five weighted coordinate spaces -/
 
-/-- The multiplicity space for the parenthesization ((((\alpha\beta)\gamma)\delta)\)
+/-- The weighted coordinate space for the parenthesization ((((\alpha\beta)\gamma)\delta)\)
 with final label \(\varepsilon\).
 
-Its elements are tuples \((f,g,\mu,\nu,\rho)\), with multiplicity indices for the successive
-fusions \(\alpha\beta\to f\), \(f\gamma\to g\), and \(g\delta\to\varepsilon\).
+Its tuples \((f,g,\mu,\nu,\rho)\) follow the index pattern for the successive fusions
+\(\alpha\beta\to f\), \(f\gamma\to g\), and \(g\delta\to\varepsilon\). The `Fin` factors are
+positive-diagonal weighted analogues; no equality with the categorical fusion multiplicities is
+asserted.
 
-Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299. -/
+Source: arXiv:1606.00608, Theorem IV.13(iii), lines 986--999; index pattern from
+arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299. -/
 abbrev FourfoldLeftAssocMultiplicity (α β γ δ ε : Λ) : Type u :=
   (f : Λ) × (g : Λ) × Fin (Fam.chi.dim α β f) × Fin (Fam.chi.dim f γ g) ×
     Fin (Fam.chi.dim g δ ε)
 
-/-- The multiplicity space for the parenthesization \(((\alpha(\beta\gamma))\delta)\)
+/-- The weighted coordinate space for the parenthesization \(((\alpha(\beta\gamma))\delta)\)
 with final label \(\varepsilon\).
 
-Its elements are tuples \((h,g,\sigma,\lambda,\rho)\), with multiplicity indices for the
-successive fusions \(\beta\gamma\to h\), \(\alpha h\to g\), and
-\(g\delta\to\varepsilon\).
+Its tuples \((h,g,\sigma,\lambda,\rho)\) follow the index pattern for the successive fusions
+\(\beta\gamma\to h\), \(\alpha h\to g\), and \(g\delta\to\varepsilon\). The `Fin` factors are
+positive-diagonal weighted analogues; no equality with the categorical fusion multiplicities is
+asserted.
 
-Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299. -/
+Source: arXiv:1606.00608, Theorem IV.13(iii), lines 986--999; index pattern from
+arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299. -/
 abbrev FourfoldLeftInnerMultiplicity (α β γ δ ε : Λ) : Type u :=
   (h : Λ) × (g : Λ) × Fin (Fam.chi.dim β γ h) × Fin (Fam.chi.dim α h g) ×
     Fin (Fam.chi.dim g δ ε)
 
-/-- The multiplicity space for the parenthesization \(\alpha((\beta\gamma)\delta)\)
+/-- The weighted coordinate space for the parenthesization \(\alpha((\beta\gamma)\delta)\)
 with final label \(\varepsilon\).
 
-Its elements are tuples \((h,i,\sigma,\omega,\kappa)\), with multiplicity indices for the
-successive fusions \(\beta\gamma\to h\), \(h\delta\to i\), and
-\(\alpha i\to\varepsilon\).
+Its tuples \((h,i,\sigma,\omega,\kappa)\) follow the index pattern for the successive fusions
+\(\beta\gamma\to h\), \(h\delta\to i\), and \(\alpha i\to\varepsilon\). The `Fin` factors are
+positive-diagonal weighted analogues; no equality with the categorical fusion multiplicities is
+asserted.
 
-Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299. -/
+Source: arXiv:1606.00608, Theorem IV.13(iii), lines 986--999; index pattern from
+arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299. -/
 abbrev FourfoldMiddleMultiplicity (α β γ δ ε : Λ) : Type u :=
   (h : Λ) × (i : Λ) × Fin (Fam.chi.dim β γ h) × Fin (Fam.chi.dim h δ i) ×
     Fin (Fam.chi.dim α i ε)
 
-/-- The multiplicity space for the parenthesization \(\alpha(\beta(\gamma\delta))\)
+/-- The weighted coordinate space for the parenthesization \(\alpha(\beta(\gamma\delta))\)
 with final label \(\varepsilon\).
 
-Its elements are tuples \((j,i,\gamma',\delta',\kappa)\), with multiplicity indices for the
-successive fusions \(\gamma\delta\to j\), \(\beta j\to i\), and
-\(\alpha i\to\varepsilon\).
+Its tuples \((j,i,\gamma',\delta',\kappa)\) follow the index pattern for the successive fusions
+\(\gamma\delta\to j\), \(\beta j\to i\), and \(\alpha i\to\varepsilon\). The `Fin` factors are
+positive-diagonal weighted analogues; no equality with the categorical fusion multiplicities is
+asserted.
 
-Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299. -/
+Source: arXiv:1606.00608, Theorem IV.13(iii), lines 986--999; index pattern from
+arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299. -/
 abbrev FourfoldRightAssocMultiplicity (α β γ δ ε : Λ) : Type u :=
   (j : Λ) × (i : Λ) × Fin (Fam.chi.dim γ δ j) × Fin (Fam.chi.dim β j i) ×
     Fin (Fam.chi.dim α i ε)
 
-/-- The multiplicity space for the parenthesization \((\alpha\beta)(\gamma\delta)\)
+/-- The weighted coordinate space for the parenthesization \((\alpha\beta)(\gamma\delta)\)
 with final label \(\varepsilon\).
 
-Its elements are tuples \((f,j,\mu,\gamma',\sigma)\), with multiplicity indices for the
-successive fusions \(\alpha\beta\to f\), \(\gamma\delta\to j\), and
-\(fj\to\varepsilon\).
+Its tuples \((f,j,\mu,\gamma',\sigma)\) follow the index pattern for the successive fusions
+\(\alpha\beta\to f\), \(\gamma\delta\to j\), and \(fj\to\varepsilon\). The `Fin` factors are
+positive-diagonal weighted analogues; no equality with the categorical fusion multiplicities is
+asserted.
 
-Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299. -/
+Source: arXiv:1606.00608, Theorem IV.13(iii), lines 986--999; index pattern from
+arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299. -/
 abbrev FourfoldPairMultiplicity (α β γ δ ε : Λ) : Type u :=
   (f : Λ) × (j : Λ) × Fin (Fam.chi.dim α β f) × Fin (Fam.chi.dim γ δ j) ×
     Fin (Fam.chi.dim f j ε)
@@ -105,10 +120,11 @@ abbrev FourfoldPairMultiplicity (α β γ δ ε : Λ) : Type u :=
 /-! ### The three-edge route -/
 
 /-- Reassociate the coordinates of \((((\alpha\beta)\gamma)\delta)\) so that the first
-triple-fusion multiplicity and the unchanged last multiplicity are explicit.
+weighted triple-fusion coordinate space and the unchanged last weighted index are explicit.
 
 Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299,
-the first factor on the left-hand side of equation `pentagoneq`. -/
+following only the route pattern of the first factor on the left-hand side of equation
+`pentagoneq`. -/
 def leftPathFirstSourceEquiv (α β γ δ ε : Λ) :
     Fam.FourfoldLeftAssocMultiplicity α β γ δ ε ≃
       (g : Λ) × Fam.LeftFinalMultiplicity α β γ g × Fin (Fam.chi.dim g δ ε) where
@@ -120,10 +136,11 @@ def leftPathFirstSourceEquiv (α β γ δ ε : Λ) :
   right_inv x := by rcases x with ⟨g, ⟨f, μ, ν⟩, ρ⟩; rfl
 
 /-- Reassociate the coordinates of \(((\alpha(\beta\gamma))\delta)\) so that the first
-triple-fusion multiplicity and the unchanged last multiplicity are explicit.
+weighted triple-fusion coordinate space and the unchanged last weighted index are explicit.
 
 Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299,
-the first factor on the left-hand side of equation `pentagoneq`. -/
+following only the route pattern of the first factor on the left-hand side of equation
+`pentagoneq`. -/
 def leftPathFirstTargetEquiv (α β γ δ ε : Λ) :
     Fam.FourfoldLeftInnerMultiplicity α β γ δ ε ≃
       (g : Λ) × Fam.RightFinalMultiplicity α β γ g × Fin (Fam.chi.dim g δ ε) where
@@ -135,10 +152,11 @@ def leftPathFirstTargetEquiv (α β γ δ ε : Λ) :
   right_inv x := by rcases x with ⟨g, ⟨h, σ, l⟩, ρ⟩; rfl
 
 /-- Reassociate the coordinates of \(((\alpha(\beta\gamma))\delta)\) so that fusion of
-\(\alpha,h,\delta\) is isolated, with the \(\beta\gamma\to h\) multiplicity unchanged.
+\(\alpha,h,\delta\) is isolated, with the weighted \(\beta\gamma\to h\) index unchanged.
 
 Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299,
-the second factor on the left-hand side of equation `pentagoneq`. -/
+following only the route pattern of the second factor on the left-hand side of equation
+`pentagoneq`. -/
 def leftPathSecondSourceEquiv (α β γ δ ε : Λ) :
     Fam.FourfoldLeftInnerMultiplicity α β γ δ ε ≃
       (h : Λ) × Fin (Fam.chi.dim β γ h) × Fam.LeftFinalMultiplicity α h δ ε where
@@ -150,10 +168,11 @@ def leftPathSecondSourceEquiv (α β γ δ ε : Λ) :
   right_inv x := by rcases x with ⟨h, σ, ⟨g, l, ρ⟩⟩; rfl
 
 /-- Reassociate the coordinates of \(\alpha((\beta\gamma)\delta)\) so that fusion of
-\(\alpha,h,\delta\) is isolated, with the \(\beta\gamma\to h\) multiplicity unchanged.
+\(\alpha,h,\delta\) is isolated, with the weighted \(\beta\gamma\to h\) index unchanged.
 
 Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299,
-the second factor on the left-hand side of equation `pentagoneq`. -/
+following only the route pattern of the second factor on the left-hand side of equation
+`pentagoneq`. -/
 def leftPathSecondTargetEquiv (α β γ δ ε : Λ) :
     Fam.FourfoldMiddleMultiplicity α β γ δ ε ≃
       (h : Λ) × Fin (Fam.chi.dim β γ h) × Fam.RightFinalMultiplicity α h δ ε where
@@ -165,11 +184,12 @@ def leftPathSecondTargetEquiv (α β γ δ ε : Λ) :
   right_inv x := by rcases x with ⟨h, σ, ⟨i, ω, κ⟩⟩; rfl
 
 /-- Reassociate the coordinates of \(\alpha((\beta\gamma)\delta)\) so that fusion of
-\(\beta,\gamma,\delta\) is isolated, with the \(\alpha i\to\varepsilon\) multiplicity
+\(\beta,\gamma,\delta\) is isolated, with the weighted \(\alpha i\to\varepsilon\) index
 unchanged.
 
 Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299,
-the third factor on the left-hand side of equation `pentagoneq`. -/
+following only the route pattern of the third factor on the left-hand side of equation
+`pentagoneq`. -/
 def leftPathThirdSourceEquiv (α β γ δ ε : Λ) :
     Fam.FourfoldMiddleMultiplicity α β γ δ ε ≃
       (i : Λ) × Fam.LeftFinalMultiplicity β γ δ i × Fin (Fam.chi.dim α i ε) where
@@ -181,11 +201,12 @@ def leftPathThirdSourceEquiv (α β γ δ ε : Λ) :
   right_inv x := by rcases x with ⟨i, ⟨h, σ, ω⟩, κ⟩; rfl
 
 /-- Reassociate the coordinates of \(\alpha(\beta(\gamma\delta))\) so that fusion of
-\(\beta,\gamma,\delta\) is isolated, with the \(\alpha i\to\varepsilon\) multiplicity
+\(\beta,\gamma,\delta\) is isolated, with the weighted \(\alpha i\to\varepsilon\) index
 unchanged.
 
 Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299,
-the third factor on the left-hand side of equation `pentagoneq`. -/
+following only the route pattern of the third factor on the left-hand side of equation
+`pentagoneq`. -/
 def leftPathThirdTargetEquiv (α β γ δ ε : Λ) :
     Fam.FourfoldRightAssocMultiplicity α β γ δ ε ≃
       (i : Λ) × Fam.RightFinalMultiplicity β γ δ i × Fin (Fam.chi.dim α i ε) where
@@ -199,10 +220,11 @@ def leftPathThirdTargetEquiv (α β γ δ ε : Λ) :
 /-! ### The two-edge route -/
 
 /-- Reassociate the coordinates of \((((\alpha\beta)\gamma)\delta)\) so that fusion of
-\(f,\gamma,\delta\) is isolated, with the \(\alpha\beta\to f\) multiplicity unchanged.
+\(f,\gamma,\delta\) is isolated, with the weighted \(\alpha\beta\to f\) index unchanged.
 
 Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299,
-the first factor on the right-hand side of equation `pentagoneq`. -/
+following only the route pattern of the first factor on the right-hand side of equation
+`pentagoneq`. -/
 def rightPathFirstSourceEquiv (α β γ δ ε : Λ) :
     Fam.FourfoldLeftAssocMultiplicity α β γ δ ε ≃
       (f : Λ) × Fin (Fam.chi.dim α β f) × Fam.LeftFinalMultiplicity f γ δ ε where
@@ -214,10 +236,11 @@ def rightPathFirstSourceEquiv (α β γ δ ε : Λ) :
   right_inv x := by rcases x with ⟨f, μ, ⟨g, ν, ρ⟩⟩; rfl
 
 /-- Reassociate the coordinates of \((\alpha\beta)(\gamma\delta)\) so that fusion of
-\(f,\gamma,\delta\) is isolated, with the \(\alpha\beta\to f\) multiplicity unchanged.
+\(f,\gamma,\delta\) is isolated, with the weighted \(\alpha\beta\to f\) index unchanged.
 
 Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299,
-the first factor on the right-hand side of equation `pentagoneq`. -/
+following only the route pattern of the first factor on the right-hand side of equation
+`pentagoneq`. -/
 def rightPathFirstTargetEquiv (α β γ δ ε : Λ) :
     Fam.FourfoldPairMultiplicity α β γ δ ε ≃
       (f : Λ) × Fin (Fam.chi.dim α β f) × Fam.RightFinalMultiplicity f γ δ ε where
@@ -229,10 +252,11 @@ def rightPathFirstTargetEquiv (α β γ δ ε : Λ) :
   right_inv x := by rcases x with ⟨f, μ, ⟨j, γ', σ⟩⟩; rfl
 
 /-- Reassociate the coordinates of \((\alpha\beta)(\gamma\delta)\) so that fusion of
-\(\alpha,\beta,j\) is isolated, with the \(\gamma\delta\to j\) multiplicity unchanged.
+\(\alpha,\beta,j\) is isolated, with the weighted \(\gamma\delta\to j\) index unchanged.
 
 Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299,
-the second factor on the right-hand side of equation `pentagoneq`. -/
+following only the route pattern of the second factor on the right-hand side of equation
+`pentagoneq`. -/
 def rightPathSecondSourceEquiv (α β γ δ ε : Λ) :
     Fam.FourfoldPairMultiplicity α β γ δ ε ≃
       (j : Λ) × Fam.LeftFinalMultiplicity α β j ε × Fin (Fam.chi.dim γ δ j) where
@@ -244,10 +268,11 @@ def rightPathSecondSourceEquiv (α β γ δ ε : Λ) :
   right_inv x := by rcases x with ⟨j, ⟨f, μ, σ⟩, γ'⟩; rfl
 
 /-- Reassociate the coordinates of \(\alpha(\beta(\gamma\delta))\) so that fusion of
-\(\alpha,\beta,j\) is isolated, with the \(\gamma\delta\to j\) multiplicity unchanged.
+\(\alpha,\beta,j\) is isolated, with the weighted \(\gamma\delta\to j\) index unchanged.
 
 Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299,
-the second factor on the right-hand side of equation `pentagoneq`. -/
+following only the route pattern of the second factor on the right-hand side of equation
+`pentagoneq`. -/
 def rightPathSecondTargetEquiv (α β γ δ ε : Λ) :
     Fam.FourfoldRightAssocMultiplicity α β γ δ ε ≃
       (j : Λ) × Fam.RightFinalMultiplicity α β j ε × Fin (Fam.chi.dim γ δ j) where

--- a/TNLean/MPS/MPDO/BNTFourfoldFusionIndices.lean
+++ b/TNLean/MPS/MPDO/BNTFourfoldFusionIndices.lean
@@ -1,0 +1,510 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.BNTFinalSectorFusion
+
+/-!
+# Multiplicity spaces for fourfold fusion
+
+The five parenthesizations of four labels give five finite multiplicity spaces at a fixed final
+label. This file records those spaces and the canonical coordinate reassociations used along the
+three-edge and two-edge routes between the fully left- and fully right-associated products.
+
+For each edge, the source and target spaces are identified with a dependent sum in which one
+factor is a triple-fusion multiplicity space and the remaining multiplicity index is unchanged.
+These identifications do not identify the source and target multiplicity spaces: that change of
+basis belongs to the fusion comparison. The associated matrices below only permute coordinates
+within each fixed parenthesization.
+
+The same five parenthesizations also give five bond-coordinate types. Their edge equivalences are
+ordinary reassociations of finite Cartesian products. The two composites between the extreme
+parenthesizations are proved equal, together with the corresponding equality of coordinate-
+permutation matrices.
+
+No comparison matrix between different parenthesizations is defined here, and no pentagon
+identity is asserted.
+
+## References
+
+* [Bultinck--Marien--Williamson--Sahinoglu--Haegeman--Verstraete 2015]
+  arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299
+-/
+
+open Matrix
+
+namespace MPOTensor.BNTFusionIsometryFamily
+
+universe u
+
+variable {Λ : Type u} [Fintype Λ] [DecidableEq Λ] {p : ℕ}
+variable (Fam : BNTFusionIsometryFamily Λ p)
+
+/-! ### The five parenthesizations -/
+
+/-- The multiplicity space for the parenthesization ((((\alpha\beta)\gamma)\delta)\)
+with final label \(\varepsilon\).
+
+Its elements are tuples \((f,g,\mu,\nu,\rho)\), with multiplicity indices for the successive
+fusions \(\alpha\beta\to f\), \(f\gamma\to g\), and \(g\delta\to\varepsilon\).
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299. -/
+abbrev FourfoldLeftAssocMultiplicity (α β γ δ ε : Λ) : Type u :=
+  (f : Λ) × (g : Λ) × Fin (Fam.chi.dim α β f) × Fin (Fam.chi.dim f γ g) ×
+    Fin (Fam.chi.dim g δ ε)
+
+/-- The multiplicity space for the parenthesization \(((\alpha(\beta\gamma))\delta)\)
+with final label \(\varepsilon\).
+
+Its elements are tuples \((h,g,\sigma,\lambda,\rho)\), with multiplicity indices for the
+successive fusions \(\beta\gamma\to h\), \(\alpha h\to g\), and
+\(g\delta\to\varepsilon\).
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299. -/
+abbrev FourfoldLeftInnerMultiplicity (α β γ δ ε : Λ) : Type u :=
+  (h : Λ) × (g : Λ) × Fin (Fam.chi.dim β γ h) × Fin (Fam.chi.dim α h g) ×
+    Fin (Fam.chi.dim g δ ε)
+
+/-- The multiplicity space for the parenthesization \(\alpha((\beta\gamma)\delta)\)
+with final label \(\varepsilon\).
+
+Its elements are tuples \((h,i,\sigma,\omega,\kappa)\), with multiplicity indices for the
+successive fusions \(\beta\gamma\to h\), \(h\delta\to i\), and
+\(\alpha i\to\varepsilon\).
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299. -/
+abbrev FourfoldMiddleMultiplicity (α β γ δ ε : Λ) : Type u :=
+  (h : Λ) × (i : Λ) × Fin (Fam.chi.dim β γ h) × Fin (Fam.chi.dim h δ i) ×
+    Fin (Fam.chi.dim α i ε)
+
+/-- The multiplicity space for the parenthesization \(\alpha(\beta(\gamma\delta))\)
+with final label \(\varepsilon\).
+
+Its elements are tuples \((j,i,\gamma',\delta',\kappa)\), with multiplicity indices for the
+successive fusions \(\gamma\delta\to j\), \(\beta j\to i\), and
+\(\alpha i\to\varepsilon\).
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299. -/
+abbrev FourfoldRightAssocMultiplicity (α β γ δ ε : Λ) : Type u :=
+  (j : Λ) × (i : Λ) × Fin (Fam.chi.dim γ δ j) × Fin (Fam.chi.dim β j i) ×
+    Fin (Fam.chi.dim α i ε)
+
+/-- The multiplicity space for the parenthesization \((\alpha\beta)(\gamma\delta)\)
+with final label \(\varepsilon\).
+
+Its elements are tuples \((f,j,\mu,\gamma',\sigma)\), with multiplicity indices for the
+successive fusions \(\alpha\beta\to f\), \(\gamma\delta\to j\), and
+\(fj\to\varepsilon\).
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299. -/
+abbrev FourfoldPairMultiplicity (α β γ δ ε : Λ) : Type u :=
+  (f : Λ) × (j : Λ) × Fin (Fam.chi.dim α β f) × Fin (Fam.chi.dim γ δ j) ×
+    Fin (Fam.chi.dim f j ε)
+
+/-! ### The three-edge route -/
+
+/-- Reassociate the coordinates of \((((\alpha\beta)\gamma)\delta)\) so that the first
+triple-fusion multiplicity and the unchanged last multiplicity are explicit.
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299,
+the first factor on the left-hand side of equation `pentagoneq`. -/
+def leftPathFirstSourceEquiv (α β γ δ ε : Λ) :
+    Fam.FourfoldLeftAssocMultiplicity α β γ δ ε ≃
+      (g : Λ) × Fam.LeftFinalMultiplicity α β γ g × Fin (Fam.chi.dim g δ ε) where
+  toFun
+    | ⟨f, g, μ, ν, ρ⟩ => ⟨g, ⟨f, μ, ν⟩, ρ⟩
+  invFun
+    | ⟨g, ⟨f, μ, ν⟩, ρ⟩ => ⟨f, g, μ, ν, ρ⟩
+  left_inv x := by rcases x with ⟨f, g, μ, ν, ρ⟩; rfl
+  right_inv x := by rcases x with ⟨g, ⟨f, μ, ν⟩, ρ⟩; rfl
+
+/-- Reassociate the coordinates of \(((\alpha(\beta\gamma))\delta)\) so that the first
+triple-fusion multiplicity and the unchanged last multiplicity are explicit.
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299,
+the first factor on the left-hand side of equation `pentagoneq`. -/
+def leftPathFirstTargetEquiv (α β γ δ ε : Λ) :
+    Fam.FourfoldLeftInnerMultiplicity α β γ δ ε ≃
+      (g : Λ) × Fam.RightFinalMultiplicity α β γ g × Fin (Fam.chi.dim g δ ε) where
+  toFun
+    | ⟨h, g, σ, l, ρ⟩ => ⟨g, ⟨h, σ, l⟩, ρ⟩
+  invFun
+    | ⟨g, ⟨h, σ, l⟩, ρ⟩ => ⟨h, g, σ, l, ρ⟩
+  left_inv x := by rcases x with ⟨h, g, σ, l, ρ⟩; rfl
+  right_inv x := by rcases x with ⟨g, ⟨h, σ, l⟩, ρ⟩; rfl
+
+/-- Reassociate the coordinates of \(((\alpha(\beta\gamma))\delta)\) so that fusion of
+\(\alpha,h,\delta\) is isolated, with the \(\beta\gamma\to h\) multiplicity unchanged.
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299,
+the second factor on the left-hand side of equation `pentagoneq`. -/
+def leftPathSecondSourceEquiv (α β γ δ ε : Λ) :
+    Fam.FourfoldLeftInnerMultiplicity α β γ δ ε ≃
+      (h : Λ) × Fin (Fam.chi.dim β γ h) × Fam.LeftFinalMultiplicity α h δ ε where
+  toFun
+    | ⟨h, g, σ, l, ρ⟩ => ⟨h, σ, ⟨g, l, ρ⟩⟩
+  invFun
+    | ⟨h, σ, ⟨g, l, ρ⟩⟩ => ⟨h, g, σ, l, ρ⟩
+  left_inv x := by rcases x with ⟨h, g, σ, l, ρ⟩; rfl
+  right_inv x := by rcases x with ⟨h, σ, ⟨g, l, ρ⟩⟩; rfl
+
+/-- Reassociate the coordinates of \(\alpha((\beta\gamma)\delta)\) so that fusion of
+\(\alpha,h,\delta\) is isolated, with the \(\beta\gamma\to h\) multiplicity unchanged.
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299,
+the second factor on the left-hand side of equation `pentagoneq`. -/
+def leftPathSecondTargetEquiv (α β γ δ ε : Λ) :
+    Fam.FourfoldMiddleMultiplicity α β γ δ ε ≃
+      (h : Λ) × Fin (Fam.chi.dim β γ h) × Fam.RightFinalMultiplicity α h δ ε where
+  toFun
+    | ⟨h, i, σ, ω, κ⟩ => ⟨h, σ, ⟨i, ω, κ⟩⟩
+  invFun
+    | ⟨h, σ, ⟨i, ω, κ⟩⟩ => ⟨h, i, σ, ω, κ⟩
+  left_inv x := by rcases x with ⟨h, i, σ, ω, κ⟩; rfl
+  right_inv x := by rcases x with ⟨h, σ, ⟨i, ω, κ⟩⟩; rfl
+
+/-- Reassociate the coordinates of \(\alpha((\beta\gamma)\delta)\) so that fusion of
+\(\beta,\gamma,\delta\) is isolated, with the \(\alpha i\to\varepsilon\) multiplicity
+unchanged.
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299,
+the third factor on the left-hand side of equation `pentagoneq`. -/
+def leftPathThirdSourceEquiv (α β γ δ ε : Λ) :
+    Fam.FourfoldMiddleMultiplicity α β γ δ ε ≃
+      (i : Λ) × Fam.LeftFinalMultiplicity β γ δ i × Fin (Fam.chi.dim α i ε) where
+  toFun
+    | ⟨h, i, σ, ω, κ⟩ => ⟨i, ⟨h, σ, ω⟩, κ⟩
+  invFun
+    | ⟨i, ⟨h, σ, ω⟩, κ⟩ => ⟨h, i, σ, ω, κ⟩
+  left_inv x := by rcases x with ⟨h, i, σ, ω, κ⟩; rfl
+  right_inv x := by rcases x with ⟨i, ⟨h, σ, ω⟩, κ⟩; rfl
+
+/-- Reassociate the coordinates of \(\alpha(\beta(\gamma\delta))\) so that fusion of
+\(\beta,\gamma,\delta\) is isolated, with the \(\alpha i\to\varepsilon\) multiplicity
+unchanged.
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299,
+the third factor on the left-hand side of equation `pentagoneq`. -/
+def leftPathThirdTargetEquiv (α β γ δ ε : Λ) :
+    Fam.FourfoldRightAssocMultiplicity α β γ δ ε ≃
+      (i : Λ) × Fam.RightFinalMultiplicity β γ δ i × Fin (Fam.chi.dim α i ε) where
+  toFun
+    | ⟨j, i, γ', δ', κ⟩ => ⟨i, ⟨j, γ', δ'⟩, κ⟩
+  invFun
+    | ⟨i, ⟨j, γ', δ'⟩, κ⟩ => ⟨j, i, γ', δ', κ⟩
+  left_inv x := by rcases x with ⟨j, i, γ', δ', κ⟩; rfl
+  right_inv x := by rcases x with ⟨i, ⟨j, γ', δ'⟩, κ⟩; rfl
+
+/-! ### The two-edge route -/
+
+/-- Reassociate the coordinates of \((((\alpha\beta)\gamma)\delta)\) so that fusion of
+\(f,\gamma,\delta\) is isolated, with the \(\alpha\beta\to f\) multiplicity unchanged.
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299,
+the first factor on the right-hand side of equation `pentagoneq`. -/
+def rightPathFirstSourceEquiv (α β γ δ ε : Λ) :
+    Fam.FourfoldLeftAssocMultiplicity α β γ δ ε ≃
+      (f : Λ) × Fin (Fam.chi.dim α β f) × Fam.LeftFinalMultiplicity f γ δ ε where
+  toFun
+    | ⟨f, g, μ, ν, ρ⟩ => ⟨f, μ, ⟨g, ν, ρ⟩⟩
+  invFun
+    | ⟨f, μ, ⟨g, ν, ρ⟩⟩ => ⟨f, g, μ, ν, ρ⟩
+  left_inv x := by rcases x with ⟨f, g, μ, ν, ρ⟩; rfl
+  right_inv x := by rcases x with ⟨f, μ, ⟨g, ν, ρ⟩⟩; rfl
+
+/-- Reassociate the coordinates of \((\alpha\beta)(\gamma\delta)\) so that fusion of
+\(f,\gamma,\delta\) is isolated, with the \(\alpha\beta\to f\) multiplicity unchanged.
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299,
+the first factor on the right-hand side of equation `pentagoneq`. -/
+def rightPathFirstTargetEquiv (α β γ δ ε : Λ) :
+    Fam.FourfoldPairMultiplicity α β γ δ ε ≃
+      (f : Λ) × Fin (Fam.chi.dim α β f) × Fam.RightFinalMultiplicity f γ δ ε where
+  toFun
+    | ⟨f, j, μ, γ', σ⟩ => ⟨f, μ, ⟨j, γ', σ⟩⟩
+  invFun
+    | ⟨f, μ, ⟨j, γ', σ⟩⟩ => ⟨f, j, μ, γ', σ⟩
+  left_inv x := by rcases x with ⟨f, j, μ, γ', σ⟩; rfl
+  right_inv x := by rcases x with ⟨f, μ, ⟨j, γ', σ⟩⟩; rfl
+
+/-- Reassociate the coordinates of \((\alpha\beta)(\gamma\delta)\) so that fusion of
+\(\alpha,\beta,j\) is isolated, with the \(\gamma\delta\to j\) multiplicity unchanged.
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299,
+the second factor on the right-hand side of equation `pentagoneq`. -/
+def rightPathSecondSourceEquiv (α β γ δ ε : Λ) :
+    Fam.FourfoldPairMultiplicity α β γ δ ε ≃
+      (j : Λ) × Fam.LeftFinalMultiplicity α β j ε × Fin (Fam.chi.dim γ δ j) where
+  toFun
+    | ⟨f, j, μ, γ', σ⟩ => ⟨j, ⟨f, μ, σ⟩, γ'⟩
+  invFun
+    | ⟨j, ⟨f, μ, σ⟩, γ'⟩ => ⟨f, j, μ, γ', σ⟩
+  left_inv x := by rcases x with ⟨f, j, μ, γ', σ⟩; rfl
+  right_inv x := by rcases x with ⟨j, ⟨f, μ, σ⟩, γ'⟩; rfl
+
+/-- Reassociate the coordinates of \(\alpha(\beta(\gamma\delta))\) so that fusion of
+\(\alpha,\beta,j\) is isolated, with the \(\gamma\delta\to j\) multiplicity unchanged.
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299,
+the second factor on the right-hand side of equation `pentagoneq`. -/
+def rightPathSecondTargetEquiv (α β γ δ ε : Λ) :
+    Fam.FourfoldRightAssocMultiplicity α β γ δ ε ≃
+      (j : Λ) × Fam.RightFinalMultiplicity α β j ε × Fin (Fam.chi.dim γ δ j) where
+  toFun
+    | ⟨j, i, γ', δ', κ⟩ => ⟨j, ⟨i, δ', κ⟩, γ'⟩
+  invFun
+    | ⟨j, ⟨i, δ', κ⟩, γ'⟩ => ⟨j, i, γ', δ', κ⟩
+  left_inv x := by rcases x with ⟨j, i, γ', δ', κ⟩; rfl
+  right_inv x := by rcases x with ⟨j, ⟨i, δ', κ⟩, γ'⟩; rfl
+
+/-! ### Coordinate-permutation matrices -/
+
+/-- The coordinate-permutation matrix of `leftPathFirstSourceEquiv`.
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299. -/
+noncomputable def leftPathFirstSourceMatrix (α β γ δ ε : Λ) :
+    Matrix (Fam.FourfoldLeftAssocMultiplicity α β γ δ ε)
+      ((g : Λ) × Fam.LeftFinalMultiplicity α β γ g × Fin (Fam.chi.dim g δ ε)) ℂ :=
+  (Fam.leftPathFirstSourceEquiv α β γ δ ε).toPEquiv.toMatrix
+
+/-- The coordinate-permutation matrix of `leftPathFirstTargetEquiv`.
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299. -/
+noncomputable def leftPathFirstTargetMatrix (α β γ δ ε : Λ) :
+    Matrix (Fam.FourfoldLeftInnerMultiplicity α β γ δ ε)
+      ((g : Λ) × Fam.RightFinalMultiplicity α β γ g × Fin (Fam.chi.dim g δ ε)) ℂ :=
+  (Fam.leftPathFirstTargetEquiv α β γ δ ε).toPEquiv.toMatrix
+
+/-- The coordinate-permutation matrix of `leftPathSecondSourceEquiv`.
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299. -/
+noncomputable def leftPathSecondSourceMatrix (α β γ δ ε : Λ) :
+    Matrix (Fam.FourfoldLeftInnerMultiplicity α β γ δ ε)
+      ((h : Λ) × Fin (Fam.chi.dim β γ h) × Fam.LeftFinalMultiplicity α h δ ε) ℂ :=
+  (Fam.leftPathSecondSourceEquiv α β γ δ ε).toPEquiv.toMatrix
+
+/-- The coordinate-permutation matrix of `leftPathSecondTargetEquiv`.
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299. -/
+noncomputable def leftPathSecondTargetMatrix (α β γ δ ε : Λ) :
+    Matrix (Fam.FourfoldMiddleMultiplicity α β γ δ ε)
+      ((h : Λ) × Fin (Fam.chi.dim β γ h) × Fam.RightFinalMultiplicity α h δ ε) ℂ :=
+  (Fam.leftPathSecondTargetEquiv α β γ δ ε).toPEquiv.toMatrix
+
+/-- The coordinate-permutation matrix of `leftPathThirdSourceEquiv`.
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299. -/
+noncomputable def leftPathThirdSourceMatrix (α β γ δ ε : Λ) :
+    Matrix (Fam.FourfoldMiddleMultiplicity α β γ δ ε)
+      ((i : Λ) × Fam.LeftFinalMultiplicity β γ δ i × Fin (Fam.chi.dim α i ε)) ℂ :=
+  (Fam.leftPathThirdSourceEquiv α β γ δ ε).toPEquiv.toMatrix
+
+/-- The coordinate-permutation matrix of `leftPathThirdTargetEquiv`.
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299. -/
+noncomputable def leftPathThirdTargetMatrix (α β γ δ ε : Λ) :
+    Matrix (Fam.FourfoldRightAssocMultiplicity α β γ δ ε)
+      ((i : Λ) × Fam.RightFinalMultiplicity β γ δ i × Fin (Fam.chi.dim α i ε)) ℂ :=
+  (Fam.leftPathThirdTargetEquiv α β γ δ ε).toPEquiv.toMatrix
+
+/-- The coordinate-permutation matrix of `rightPathFirstSourceEquiv`.
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299. -/
+noncomputable def rightPathFirstSourceMatrix (α β γ δ ε : Λ) :
+    Matrix (Fam.FourfoldLeftAssocMultiplicity α β γ δ ε)
+      ((f : Λ) × Fin (Fam.chi.dim α β f) × Fam.LeftFinalMultiplicity f γ δ ε) ℂ :=
+  (Fam.rightPathFirstSourceEquiv α β γ δ ε).toPEquiv.toMatrix
+
+/-- The coordinate-permutation matrix of `rightPathFirstTargetEquiv`.
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299. -/
+noncomputable def rightPathFirstTargetMatrix (α β γ δ ε : Λ) :
+    Matrix (Fam.FourfoldPairMultiplicity α β γ δ ε)
+      ((f : Λ) × Fin (Fam.chi.dim α β f) × Fam.RightFinalMultiplicity f γ δ ε) ℂ :=
+  (Fam.rightPathFirstTargetEquiv α β γ δ ε).toPEquiv.toMatrix
+
+/-- The coordinate-permutation matrix of `rightPathSecondSourceEquiv`.
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299. -/
+noncomputable def rightPathSecondSourceMatrix (α β γ δ ε : Λ) :
+    Matrix (Fam.FourfoldPairMultiplicity α β γ δ ε)
+      ((j : Λ) × Fam.LeftFinalMultiplicity α β j ε × Fin (Fam.chi.dim γ δ j)) ℂ :=
+  (Fam.rightPathSecondSourceEquiv α β γ δ ε).toPEquiv.toMatrix
+
+/-- The coordinate-permutation matrix of `rightPathSecondTargetEquiv`.
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299. -/
+noncomputable def rightPathSecondTargetMatrix (α β γ δ ε : Λ) :
+    Matrix (Fam.FourfoldRightAssocMultiplicity α β γ δ ε)
+      ((j : Λ) × Fam.RightFinalMultiplicity α β j ε × Fin (Fam.chi.dim γ δ j)) ℂ :=
+  (Fam.rightPathSecondTargetEquiv α β γ δ ε).toPEquiv.toMatrix
+
+/-! ### Reassociation of four bond coordinates -/
+
+/-- The bond-coordinate type for \((((\alpha\beta)\gamma)\delta)\).
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299. -/
+abbrev FourfoldLeftAssocBondIndex (α β γ δ : Λ) : Type :=
+  Fin (((Fam.bondDim α * Fam.bondDim β) * Fam.bondDim γ) * Fam.bondDim δ)
+
+/-- The bond-coordinate type for \(((\alpha(\beta\gamma))\delta)\).
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299. -/
+abbrev FourfoldLeftInnerBondIndex (α β γ δ : Λ) : Type :=
+  Fin ((Fam.bondDim α * (Fam.bondDim β * Fam.bondDim γ)) * Fam.bondDim δ)
+
+/-- The bond-coordinate type for \(\alpha((\beta\gamma)\delta)\).
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299. -/
+abbrev FourfoldMiddleBondIndex (α β γ δ : Λ) : Type :=
+  Fin (Fam.bondDim α * ((Fam.bondDim β * Fam.bondDim γ) * Fam.bondDim δ))
+
+/-- The bond-coordinate type for \(\alpha(\beta(\gamma\delta))\).
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299. -/
+abbrev FourfoldRightAssocBondIndex (α β γ δ : Λ) : Type :=
+  Fin (Fam.bondDim α * (Fam.bondDim β * (Fam.bondDim γ * Fam.bondDim δ)))
+
+/-- The bond-coordinate type for \((\alpha\beta)(\gamma\delta)\).
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299. -/
+abbrev FourfoldPairBondIndex (α β γ δ : Λ) : Type :=
+  Fin ((Fam.bondDim α * Fam.bondDim β) * (Fam.bondDim γ * Fam.bondDim δ))
+
+/-- Reassociate the first three bond coordinates while leaving the fourth coordinate fixed.
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299,
+the first edge of the three-edge route. -/
+def fourfoldLeftAssocToLeftInnerBondEquiv (α β γ δ : Λ) :
+    Fam.FourfoldLeftAssocBondIndex α β γ δ ≃
+      Fam.FourfoldLeftInnerBondIndex α β γ δ :=
+  finProdFinEquiv.symm |>.trans
+    ((Equiv.prodCongr
+      (mulTensorAssocEquiv (Fam.bondDim α) (Fam.bondDim β) (Fam.bondDim γ))
+      (Equiv.refl (Fin (Fam.bondDim δ)))).trans finProdFinEquiv)
+
+/-- Reassociate the three factors \(\alpha,(\beta\gamma),\delta\).
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299,
+the second edge of the three-edge route. -/
+def fourfoldLeftInnerToMiddleBondEquiv (α β γ δ : Λ) :
+    Fam.FourfoldLeftInnerBondIndex α β γ δ ≃ Fam.FourfoldMiddleBondIndex α β γ δ :=
+  mulTensorAssocEquiv (Fam.bondDim α)
+    (Fam.bondDim β * Fam.bondDim γ) (Fam.bondDim δ)
+
+/-- Reassociate the last three bond coordinates while leaving the first coordinate fixed.
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299,
+the third edge of the three-edge route. -/
+def fourfoldMiddleToRightAssocBondEquiv (α β γ δ : Λ) :
+    Fam.FourfoldMiddleBondIndex α β γ δ ≃ Fam.FourfoldRightAssocBondIndex α β γ δ :=
+  finProdFinEquiv.symm |>.trans
+    ((Equiv.prodCongr (Equiv.refl (Fin (Fam.bondDim α)))
+      (mulTensorAssocEquiv (Fam.bondDim β) (Fam.bondDim γ) (Fam.bondDim δ))).trans
+        finProdFinEquiv)
+
+/-- Reassociate the factors \((\alpha\beta),\gamma,\delta\).
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299,
+the first edge of the two-edge route. -/
+def fourfoldLeftAssocToPairBondEquiv (α β γ δ : Λ) :
+    Fam.FourfoldLeftAssocBondIndex α β γ δ ≃ Fam.FourfoldPairBondIndex α β γ δ :=
+  mulTensorAssocEquiv (Fam.bondDim α * Fam.bondDim β)
+    (Fam.bondDim γ) (Fam.bondDim δ)
+
+/-- Reassociate the factors \(\alpha,\beta,(\gamma\delta)\).
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299,
+the second edge of the two-edge route. -/
+def fourfoldPairToRightAssocBondEquiv (α β γ δ : Λ) :
+    Fam.FourfoldPairBondIndex α β γ δ ≃ Fam.FourfoldRightAssocBondIndex α β γ δ :=
+  mulTensorAssocEquiv (Fam.bondDim α) (Fam.bondDim β)
+    (Fam.bondDim γ * Fam.bondDim δ)
+
+/-- The two finite-coordinate reassociations from the fully left-associated bond space to the
+fully right-associated bond space coincide.
+
+This is coherence of ordinary Cartesian-product reassociation. It does not compare fusion
+multiplicity spaces and does not assert the source's equation `pentagoneq`.
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299,
+applied only to the four bond-coordinate factors. -/
+theorem fourfoldBondReassociation_threeEdge_eq_twoEdge (α β γ δ : Λ) :
+    ((Fam.fourfoldLeftAssocToLeftInnerBondEquiv α β γ δ).trans
+      (Fam.fourfoldLeftInnerToMiddleBondEquiv α β γ δ)).trans
+        (Fam.fourfoldMiddleToRightAssocBondEquiv α β γ δ) =
+      (Fam.fourfoldLeftAssocToPairBondEquiv α β γ δ).trans
+        (Fam.fourfoldPairToRightAssocBondEquiv α β γ δ) := by
+  apply Equiv.ext
+  intro x
+  rcases finProdFinEquiv.surjective x with ⟨⟨xabc, xd⟩, rfl⟩
+  rcases finProdFinEquiv.surjective xabc with ⟨⟨xab, xc⟩, rfl⟩
+  rcases finProdFinEquiv.surjective xab with ⟨⟨xa, xb⟩, rfl⟩
+  simp [fourfoldLeftAssocToLeftInnerBondEquiv, fourfoldLeftInnerToMiddleBondEquiv,
+    fourfoldMiddleToRightAssocBondEquiv, fourfoldLeftAssocToPairBondEquiv,
+    fourfoldPairToRightAssocBondEquiv, mulTensorAssocEquiv]
+
+/-- The coordinate-permutation matrix for the first edge of the three-edge bond reassociation.
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299. -/
+noncomputable def fourfoldLeftAssocToLeftInnerBondMatrix (α β γ δ : Λ) :
+    Matrix (Fam.FourfoldLeftAssocBondIndex α β γ δ)
+      (Fam.FourfoldLeftInnerBondIndex α β γ δ) ℂ :=
+  (Fam.fourfoldLeftAssocToLeftInnerBondEquiv α β γ δ).toPEquiv.toMatrix
+
+/-- The coordinate-permutation matrix for the second edge of the three-edge bond reassociation.
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299. -/
+noncomputable def fourfoldLeftInnerToMiddleBondMatrix (α β γ δ : Λ) :
+    Matrix (Fam.FourfoldLeftInnerBondIndex α β γ δ)
+      (Fam.FourfoldMiddleBondIndex α β γ δ) ℂ :=
+  (Fam.fourfoldLeftInnerToMiddleBondEquiv α β γ δ).toPEquiv.toMatrix
+
+/-- The coordinate-permutation matrix for the third edge of the three-edge bond reassociation.
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299. -/
+noncomputable def fourfoldMiddleToRightAssocBondMatrix (α β γ δ : Λ) :
+    Matrix (Fam.FourfoldMiddleBondIndex α β γ δ)
+      (Fam.FourfoldRightAssocBondIndex α β γ δ) ℂ :=
+  (Fam.fourfoldMiddleToRightAssocBondEquiv α β γ δ).toPEquiv.toMatrix
+
+/-- The coordinate-permutation matrix for the first edge of the two-edge bond reassociation.
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299. -/
+noncomputable def fourfoldLeftAssocToPairBondMatrix (α β γ δ : Λ) :
+    Matrix (Fam.FourfoldLeftAssocBondIndex α β γ δ)
+      (Fam.FourfoldPairBondIndex α β γ δ) ℂ :=
+  (Fam.fourfoldLeftAssocToPairBondEquiv α β γ δ).toPEquiv.toMatrix
+
+/-- The coordinate-permutation matrix for the second edge of the two-edge bond reassociation.
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299. -/
+noncomputable def fourfoldPairToRightAssocBondMatrix (α β γ δ : Λ) :
+    Matrix (Fam.FourfoldPairBondIndex α β γ δ)
+      (Fam.FourfoldRightAssocBondIndex α β γ δ) ℂ :=
+  (Fam.fourfoldPairToRightAssocBondEquiv α β γ δ).toPEquiv.toMatrix
+
+/-- The product of the three coordinate-permutation matrices equals the product of the two
+coordinate-permutation matrices between the same extreme bond parenthesizations.
+
+This is the matrix form of `fourfoldBondReassociation_threeEdge_eq_twoEdge`; it makes no
+statement about fusion comparison matrices.
+
+Source: arXiv:1511.08090, `Papers/1511.08090/AnyonsPEPS.tex`, lines 279--299,
+applied only to the four bond-coordinate factors. -/
+theorem fourfoldBondMatrix_threeEdge_eq_twoEdge (α β γ δ : Λ) :
+    (Fam.fourfoldLeftAssocToLeftInnerBondMatrix α β γ δ *
+        Fam.fourfoldLeftInnerToMiddleBondMatrix α β γ δ) *
+      Fam.fourfoldMiddleToRightAssocBondMatrix α β γ δ =
+    Fam.fourfoldLeftAssocToPairBondMatrix α β γ δ *
+      Fam.fourfoldPairToRightAssocBondMatrix α β γ δ := by
+  unfold fourfoldLeftAssocToLeftInnerBondMatrix fourfoldLeftInnerToMiddleBondMatrix
+    fourfoldMiddleToRightAssocBondMatrix fourfoldLeftAssocToPairBondMatrix
+    fourfoldPairToRightAssocBondMatrix
+  rw [← PEquiv.toMatrix_trans, ← Equiv.toPEquiv_trans,
+    ← PEquiv.toMatrix_trans, ← Equiv.toPEquiv_trans,
+    ← PEquiv.toMatrix_trans, ← Equiv.toPEquiv_trans]
+  rw [Fam.fourfoldBondReassociation_threeEdge_eq_twoEdge]
+
+end MPOTensor.BNTFusionIsometryFamily

--- a/blueprint/src/Packages/tn_diagrams.py
+++ b/blueprint/src/Packages/tn_diagrams.py
@@ -78,6 +78,7 @@ _DIAGRAM_ARGS: dict[str, str] = {
     "TNMPDOZCLIdempotence": "",
     "TNMPDOFixedFinalFusionBracketings": "",
     "TNMPDOFixedFinalComparisonUnitary": "",
+    "TNMPDOFourfoldBondReassociationPentagon": "",
     "TNMPDOBNTFusionIdentity": "",
     "TNMPDOUnweightedZipperReconstruction": "",
     "TNMPDOFusionTracePower": "",

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -1229,3 +1229,62 @@ separate step.
         pentagon coherence identity is asserted here.}
     \label{fig:mpdo_fixed_final_comparison_unitary}
 \end{figure}
+
+\begin{theorem}[Coherence of four bond-coordinate reassociations]%
+    \label{thm:mpdo_fourfold_bond_coordinate_coherence}
+    \lean{MPOTensor.BNTFusionIsometryFamily.%
+        fourfoldBondReassociation_threeEdge_eq_twoEdge}
+    \lean{MPOTensor.BNTFusionIsometryFamily.%
+        fourfoldBondMatrix_threeEdge_eq_twoEdge}
+    \leanok
+    \uses{def:mpdo_operator_product_associator}
+    For finite bond-coordinate sets $A,B,C,D$, let
+    \[
+        r_{X,Y,Z}:((X\times Y)\times Z)\longrightarrow
+          X\times(Y\times Z)
+    \]
+    denote the canonical reassociation.  Define
+    \[
+    \begin{aligned}
+        r_1&=r_{A,B,C}\times 1_D,&
+        r_2&=r_{A,B\times C,D},&
+        r_3&=1_A\times r_{B,C,D},\\
+        s_1&=r_{A\times B,C,D},&
+        s_2&=r_{A,B,C\times D}.&&
+    \end{aligned}
+    \]
+    The three-edge and two-edge reassociations from
+    $(((A\times B)\times C)\times D)$ to
+    $A\times(B\times(C\times D))$ coincide:
+    \[
+        r_3\circ r_2\circ r_1=s_2\circ s_1.
+    \]
+    If $P(r)_{x,y}=1$ when $r(x)=y$ and is zero otherwise, then the
+    corresponding coordinate-permutation matrices satisfy
+    \[
+        P(r_1)P(r_2)P(r_3)=P(s_1)P(s_2).
+    \]
+    These are equalities of Cartesian bond-coordinate identifications only.
+    The MPO fusion pentagon in
+    \cite[Section~3.4, equation~(33)]{Bultinck2017Anyons} instead compares
+    products of $F$-matrix entries, summed over intermediate fusion labels and
+    multiplicities; it is not asserted here.
+\end{theorem}
+\begin{proof}\leanok
+    Every element $(((a,b),c),d)$ is sent by either composite to
+    $(a,(b,(c,d)))$.  The first equality follows.  The identity
+    $P(v\circ u)=P(u)P(v)$ then turns it into the stated matrix equality.
+\end{proof}
+
+\begin{figure}[ht]
+    \centering
+    \TNMPDOFourfoldBondReassociationPentagon
+    \caption{The five parenthesizations of four bond-coordinate factors.
+        The upper path is the three-edge composite
+        $r_3\circ r_2\circ r_1$, and the lower path is the two-edge composite
+        $s_2\circ s_1$.  This figure depicts only canonical Cartesian
+        reassociation.  It does not contain fusion multiplicity spaces or
+        $F$-matrices, and the MPO fusion pentagon identity of
+        \cite[equation~(33)]{Bultinck2017Anyons} remains unproved.}
+    \label{fig:mpdo_fourfold_bond_coordinate_reassociation}
+\end{figure}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -1237,8 +1237,17 @@ separate step.
     \lean{MPOTensor.BNTFusionIsometryFamily.%
         fourfoldBondMatrix_threeEdge_eq_twoEdge}
     \leanok
-    \uses{def:mpdo_operator_product_associator}
-    For finite bond-coordinate sets $A,B,C,D$, let
+    \uses{def:mpdo_operator_product_associator,
+        def:mpdo_bnt_fusion_isometry_family}
+    Fix four labels $\alpha,\beta,\gamma,\delta$ in a BNT fusion-isometry
+    family, and write
+    \[
+        A=\{1,\ldots,D_\alpha\},\quad
+        B=\{1,\ldots,D_\beta\},\quad
+        C=\{1,\ldots,D_\gamma\},\quad
+        D=\{1,\ldots,D_\delta\}
+    \]
+    for their bond-coordinate sets.  Let
     \[
         r_{X,Y,Z}:((X\times Y)\times Z)\longrightarrow
           X\times(Y\times Z)

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -1279,6 +1279,37 @@
     \end{tikzpicture}%
 }
 
+% The associahedron for four ordinary bond-coordinate factors.  The upper
+% three-edge route and lower two-edge route have the same endpoints.  This is
+% only Cartesian-product reassociation; the edges do not represent F-matrices.
+\newcommand{\TNMPDOFourfoldBondReassociationPentagon}{%
+    \begin{tikzpicture}[tn picture, scale=0.92]
+        \tikzset{tn assoc node/.style={
+            draw,
+            rounded corners,
+            fill=blue!8,
+            inner sep=3pt
+        },
+        tn assoc edge/.style={->, line width=0.7pt}}
+        \node[tn assoc node] (assocL) at (-5.00,0)
+            {$(((A\times B)\times C)\times D)$};
+        \node[tn assoc node] (assocLI) at (-3.00,1.80)
+            {$((A\times(B\times C))\times D)$};
+        \node[tn assoc node] (assocM) at (1.00,1.80)
+            {$(A\times((B\times C)\times D))$};
+        \node[tn assoc node] (assocR) at (4.20,0)
+            {$(A\times(B\times(C\times D)))$};
+        \node[tn assoc node] (assocP) at (-0.30,-1.80)
+            {$((A\times B)\times(C\times D))$};
+
+        \draw[tn assoc edge] (assocL) -- node[above left] {$r_1$} (assocLI);
+        \draw[tn assoc edge] (assocLI) -- node[above] {$r_2$} (assocM);
+        \draw[tn assoc edge] (assocM) -- node[above right] {$r_3$} (assocR);
+        \draw[tn assoc edge] (assocL) -- node[below left] {$s_1$} (assocP);
+        \draw[tn assoc edge] (assocP) -- node[below right] {$s_2$} (assocR);
+    \end{tikzpicture}%
+}
+
 % Local BNT fusion identity from CPSV16, eq. (Ualphabeta).  The left-hand
 % isometry combines the two incoming bond factors, while its adjoint separates
 % the outgoing factors.  The right-hand side records the weighted final-sector

--- a/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
+++ b/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
@@ -28,7 +28,7 @@ name: TNMPDOInverseContraction TNMPDOSectorPairing TNMPDOSectorZCLIdentity
 name: TNMPSInverseContraction TNBNTDecomposition TNMPDOZCLIdempotence TNMPDOFixedFinalFusionBracketings
 {{ obj.tn_svg_html }}
 
-name: TNMPDOBNTFusionIdentity TNMPDOUnweightedZipperReconstruction TNMPDOFusionTracePower TNMPDOFixedFinalComparisonUnitary
+name: TNMPDOBNTFusionIdentity TNMPDOUnweightedZipperReconstruction TNMPDOFusionTracePower TNMPDOFixedFinalComparisonUnitary TNMPDOFourfoldBondReassociationPentagon
 {{ obj.tn_svg_html }}
 
 name: TNRFPKrausIsometry TNRFPKrausIsometryReverse TNRFPIsometryCanonicalForm


### PR DESCRIPTION
## Summary

This change supplies the finite coordinate infrastructure for the fourfold coherence problem tracked in #3845.

- It defines the five weighted fixed-final coordinate spaces whose label and index order follows the two routes in Bultinck et al., Section 3.4, equation (33).
- It defines the ten edge regrouping equivalences and their coordinate-permutation matrices.
- It defines the five parenthesized bond-coordinate spaces and proves equality of the three-edge and two-edge Cartesian reassociations, both as equivalences and as matrices.
- It adds a blueprint theorem and a native TikZ associahedron showing the two routes.

The Fin factors built from the positive-diagonal chi matrices are stated only as weighted analogues of the source multiplicity indices. This pull request neither identifies them with categorical fusion multiplicities nor asserts the fusion F-matrix pentagon. The faithful pentagon remains open in #3845.

## Source

- arXiv:1606.00608, Theorem IV.13(iii), lines 986–999, for the positive-diagonal weighted coordinates.
- Bultinck et al., arXiv:1511.08090, source lines 279–299 and published equation (33), for the five parenthesizations and route/index pattern.

## Validation

- lake build TNLean
- lake exe checkdecls blueprint/lean_decls
- blueprint synchronization and reader-facing prose checks
- leanblueprint web
- diagram registry and SVG smoke render
- visual inspection of the generated five-vertex SVG
- independent source-faithfulness and full-branch reviews

Advances #3845; does not close it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formal definitions and proved Cartesian reassociation lemmas in the MPDO BNT track; no changes to auth, runtime, or existing proof obligations beyond a new import.
> 
> **Overview**
> Adds **`BNTFourfoldFusionIndices`**, wiring five fixed-final **weighted multiplicity** parenthesizations (from `Fam.chi`) plus the **three-edge** and **two-edge** route equivalences and their coordinate-permutation matrices—indexed like the pentagon in Bultinck et al., but only as **within-parenthesization** regroupings, not cross-bracketing **F**-comparisons.
> 
> The same file defines five **bond-coordinate** parenthesizations, proves the **three-edge** and **two-edge** Cartesian reassociations from fully left- to fully right-associated bond indices are **equal**, and lifts that to **matrix product** equality (`fourfoldBondReassociation_threeEdge_eq_twoEdge`, `fourfoldBondMatrix_threeEdge_eq_twoEdge`). The module is exported from **`TNLean.lean`**.
> 
> Blueprint: new theorem **Coherence of four bond-coordinate reassociations**, TikZ **`TNMPDOFourfoldBondReassociationPentagon`**, and diagram registry/template hooks—explicitly **not** the MPO fusion **F**-matrix pentagon (#3845).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0d84ce4f964d3f4db3987b52cde1fc4b3263e1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->