### PR TITLE
doc(MPS/MPDO): correct commuting-form source status

### DIFF
--- a/TNLean/MPS/MPDO/CommutingForm.lean
+++ b/TNLean/MPS/MPDO/CommutingForm.lean
@@ -16,9 +16,12 @@ For an `N`-site operator `ρ`, a commuting-form witness consists of a positive
 semidefinite two-site matrix `B`, together with proofs that its translated
 copies on the periodic chain pairwise commute and that their product
 reproduces `ρ` up to a positive scalar. This is the projector-limit version of
-the commuting-form definition in arXiv:1606.00608. The actual entropy-side derivation
-`SAL ⟹ HasCommutingForm` is not yet formalized here; this file starts from the
-commuting-form witness and proves the GSNNCH equivalence built from that data.
+the commuting-form definition in arXiv:1606.00608. This file defines the
+commuting-form witness and proves the GSNNCH equivalence built from it. The
+theorem `MPOTensor.nonempty_etaLocalStructureData_of_isSAL` proves the
+entropy-side implication from SAL; its local structure gives
+`HasCommutingForm` through `MPOTensor.EtaLocalStructureData.hasCommutingForm`.
+This is Proposition C.8 of arXiv:1606.00608, Appendix C.2, lines 1569--1594.
 
 ## Main declarations
 

--- a/TNLean/MPS/MPDO/CommutingFormBridge.lean
+++ b/TNLean/MPS/MPDO/CommutingFormBridge.lean
@@ -7,36 +7,23 @@ import TNLean.MPS.MPDO.PhysicalSectorBondPairwise
 /-!
 # Local-to-global commuting-form data
 
-This file states the exact eta-local structure still needed after the
-sector-local operators have been obtained in the simple-MPDO SAL + ZCL analysis
-of arXiv:1606.00608 Appendix C.2, in order to conclude
-`MPOTensor.HasCommutingForm`.
+This file defines the eta-local structure used to express the simple-MPDO
+commuting product form of arXiv:1606.00608, Appendix C.2. Conditional on a
+physical-sector factorization with positive neighboring operators,
+`PhysicalSectorFactorization.etaLocalStructureData` gives one positive two-site
+bond whose translates commute and whose ordered product realizes every finite
+chain.
 
-The current repository already exposes the local entropy-side ingredients
-
-* `MPOTensor.EtaStructure`,
-* `MPOTensor.sal_implies_eta_structure`, and
-* the positive-semidefinite and pairing-idempotence rank-one criteria in
-  `SimpleLocalStructure.lean`,
-
-and `SimpleLocalStructure` gives a canonical sector-reduced family through
-`MPOTensor.ExplicitEtaOperators.ofHayashiMarkov`. That family is not the
-inverse-map family used in Appendix C.2: its trace matrix is identically one,
-whereas the source allows a general primitive trace matrix. The earliest
-remaining result is therefore Lemma propSN, which derives from the concrete
-tensor `K` a sector factorization satisfying, for every `N`,
+For an injective tensor `K` satisfying SAL, the inverse-map sector construction
+gives a coherently positive physical-sector factorization satisfying
 \[
   \widetilde\sigma^{(N)}(K)
     = \bigoplus_{k_1,\ldots,k_N}\bigotimes_{n=1}^N \eta_{k_n,k_{n+1}}.
 \]
-Conditional on a physical-sector factorization with positive neighboring
-operators, Proposition 3to4 is completed by
-`PhysicalSectorFactorization.etaLocalStructureData`.
-
-*Proof-state note.* To reach `EtaLocalStructureData M` from SAL, it remains to
-establish the inverse-map sector factorization of Lemma propSN with a coherent
-positive choice of all neighboring operators. The conditional bond,
-commutativity, product realization, and eta-local structure are complete.
+Consequently, `MPOTensor.nonempty_etaLocalStructureData_of_isSAL` constructs
+the eta-local structure from injectivity and SAL alone. Zero correlation length
+is not used in Proposition C.8; it enters only in the later GSNNCH-with-ZCL and
+RFP consequences.
 
 ## Main declarations
 
@@ -133,9 +120,12 @@ Concretely, this structure stores the single translation-invariant bond extracte
 from the local simple-MPDO analysis, together with proofs that it realizes the
 finite-chain MPO operators. This is stronger than `HasCommutingForm M`, since
 it requires one bond that works for every chain length rather than a separate
-commuting-form witness at each length. The remaining assembly theorem should
-construct this structure from the SAL and ZCL hypotheses, the sector-reduced
-`η_{k,h}` family, and the inverse-map realization layer. -/
+commuting-form witness at each length. For every injective tensor satisfying
+SAL, `MPOTensor.nonempty_etaLocalStructureData_of_isSAL` constructs this
+structure from the inverse-map sector factorization and its coherently positive
+neighboring operators. No zero-correlation-length hypothesis is required.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8, lines 1569--1594. -/
 structure EtaLocalStructureData (M : MPOTensor d D) where
   /-- The chain-independent nearest-neighbor bond extracted from the local
   `η_{k,h}` operators. -/

--- a/TNLean/MPS/MPDO/PhysicalSectorProductTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorProductTransport.lean
@@ -457,8 +457,9 @@ Source: arXiv:1606.00608, Appendix C.2, Proposition C.8, lines
 
 **Scope restriction (given physical-sector factorization):** The source
 derives this factorization and positivity of the neighboring operators from
-SAL. That upstream construction remains documented in
-`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`. -/
+SAL. The theorem `MPOTensor.nonempty_etaLocalStructureData_of_isSAL` supplies that
+factorization and the complete positive commuting product form from injectivity
+and SAL; the present theorem records only the conditional product identity. -/
 private theorem mpo_eq_product_physicalBond_of_three_le
     (F : PhysicalSectorFactorization K) {N : ℕ} [NeZero N] (hN : 3 ≤ N) :
     mpo K N =
@@ -623,8 +624,9 @@ Source: arXiv:1606.00608, Appendix C.2, Proposition C.8, lines
 
 **Scope restriction (given physical-sector factorization):** The source
 derives this factorization and positivity of the neighboring operators from
-SAL. That upstream construction remains documented in
-`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`. -/
+SAL. The theorem `MPOTensor.nonempty_etaLocalStructureData_of_isSAL` supplies that
+factorization and the complete positive commuting product form from injectivity
+and SAL; the present theorem records only the conditional product identity. -/
 theorem mpo_eq_product_physicalBond
     (F : PhysicalSectorFactorization K) {N : ℕ} (hN : 2 ≤ N) :
     mpo K N =
@@ -644,8 +646,9 @@ Source: arXiv:1606.00608, Appendix C.2, Proposition C.8, lines
 
 **Scope restriction (given physical-sector factorization):** The source
 derives this factorization and positivity of the neighboring operators from
-SAL. That upstream construction remains documented in
-`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`. -/
+SAL. The theorem `MPOTensor.nonempty_etaLocalStructureData_of_isSAL` supplies that
+factorization and the complete positive commuting product form from injectivity
+and SAL; the present theorem records only the conditional scalar formulation. -/
 theorem exists_positive_scalar_mpo_eq_product_physicalBond
     (F : PhysicalSectorFactorization K) {N : ℕ} (hN : 2 ≤ N) :
     ∃ c : ℝ, 0 < c ∧

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -107,15 +107,16 @@ identified.
 
 The raw double inverse-map contraction (arXiv:1606.00608, Appendix C.2,
 lines 1415--1438) is `MPOTensor.inverseMapThreeSiteContraction_eq`. The
-remaining passage from this contraction to the neighboring-sector operators
-must produce a
-factorization of the concrete tensor `K` satisfying, for every `N`,
+Hayashi-sector comparison then gives a factorization of the concrete tensor
+`K` whose neighboring operators satisfy, for every `N`,
 \[
   \widetilde\sigma^{(N)}(K)
     = \bigoplus_{k_1,\ldots,k_N}\bigotimes_{n=1}^N \eta_{k_n,k_{n+1}}.
 \]
-Only after that identity is available can its sector operators be assembled
-into the common two-site bond of Proposition 3to4.
+The inverse-map factorization has a coherently positive choice, and
+`MPOTensor.nonempty_etaLocalStructureData_of_isSAL` assembles its neighboring
+operators into the common two-site bond of Proposition C.8 from injectivity and
+SAL alone.
 
 Lemma C.5 is further isolated to the finite-dimensional Perron–Frobenius step:
 for a primitive nonnegative matrix `T`, constant traces of positive powers are
@@ -144,9 +145,12 @@ functionals $(r_k|$, the pairing $T_{k,h}=(r_k|l_h)$, and the
 zero-correlation-length identity at lines 1490--1493. The theorem
 `MPOTensor.sal_zcl_implies_rank_one_T_of_pairing_idempotent` derives the
 rank-one factorization once the closed sector tensors are linearly independent.
-Three obligations remain: construct the sector families and their pairing from
-the inverse-map factorization at lines 1407--1482, derive the operator identity
-from zero correlation length, and prove linear independence. They are recorded in
+For the concrete inverse-map sector families,
+`MPOTensor.closedSectorTraceMatrix_normalized_relations` proves the normalized
+square--cube and trace-power identities from source zero correlation length.
+The remaining problem is to exclude the nilpotent generalized zero-eigenspace
+of the concrete trace matrix without an additional hypothesis absent from
+Lemma C.5. It is recorded in
 `docs/paper-gaps/cpgsv17_pf_rank_one.tex`.
 
 ## References


### PR DESCRIPTION
## Mathematical change

The module introductions and theorem comments now state the completed form of Proposition C.8 of arXiv:1606.00608, Appendix C.2, lines 1569–1594. For every injective tensor satisfying SAL, `nonempty_etaLocalStructureData_of_isSAL` supplies the positive physical-sector factorization, pairwise commuting translated bonds, and the exact periodic product formula for every length `N ≥ 2`.

The comments also isolate the remaining Lemma C.5 problem correctly: source zero correlation length gives the normalized square–cube and trace-power identities, while exclusion of the nilpotent generalized zero-eigenspace remains open. No positive-semidefinite, Gram, linear-independence, or semisimplicity hypothesis is inserted.

This pull request changes reader-facing comments only; mathematical declarations and proofs are unchanged. It accompanies the closure of #823 and the corrected status comments on #236 and #3593.

## Verification

- `lake env lean TNLean/MPS/MPDO/CommutingForm.lean`
- `lake env lean TNLean/MPS/MPDO/CommutingFormBridge.lean`
- `lake env lean TNLean/MPS/MPDO/SimpleLocalStructure.lean`
- `lake env lean TNLean/MPS/MPDO/PhysicalSectorProductTransport.lean`
- whitespace, 100-column, and reader-facing prose checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only documentation in MPS/MPDO modules; no executable or proof changes.
> 
> **Overview**
> Updates **reader-facing module and theorem comments** in four MPS/MPDO files so they match the current formalization status for arXiv:1606.00608 Appendix C.2 (Proposition C.8).
> 
> The docs now state that **`nonempty_etaLocalStructureData_of_isSAL`** already supplies the SAL → positive physical-sector factorization → commuting bond product story from **injectivity + SAL alone**, with **ZCL not required** for Proposition C.8. Stale “proof-state / assembly still needed” wording and pointers to `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex` for that upstream step are removed or replaced in **`PhysicalSectorProductTransport`**.
> 
> **`SimpleLocalStructure`** is adjusted so the inverse-map sector path and completed eta-local assembly are described accurately, while the **Lemma C.5** gap (nilpotent generalized zero-eigenspace of the concrete trace matrix) stays pointed at `docs/paper-gaps/cpgsv17_pf_rank_one.tex`.
> 
> **No Lean declarations, proofs, or imports are modified**—comments only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42ffdffba66ffda12b356f22ad57e8222a0790da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->