### PR TITLE
feat(MPS/MPDO): group Lemma L by representatives

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -373,6 +373,7 @@ import TNLean.MPS.MPDO.MutualInfoMonotone
 import TNLean.MPS.MPDO.PureAreaLaw
 import TNLean.MPS.MPDO.PureRFPSAL
 import TNLean.MPS.MPDO.VerticalCF
+import TNLean.MPS.MPDO.RepresentativeGroupedLemmaL
 import TNLean.MPS.MPDO.InvariantProjection
 import TNLean.MPS.MPDO.PeriodicExclusion
 import TNLean.MPS.MPDO.StackedLayers

--- a/TNLean/MPS/MPDO/RepresentativeGroupedLemmaL.lean
+++ b/TNLean/MPS/MPDO/RepresentativeGroupedLemmaL.lean
@@ -1,0 +1,220 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.ScalarPowerSumIdentity
+import TNLean.MPS.MPDO.BiCFDerivation.Core
+import TNLean.MPS.SharedInfra.SectorDecomposition
+
+/-!
+# Representative-grouped form of Lemma L
+
+For a canonical-form decomposition with repeated copies of a basis normal
+tensor, the first-site action identity is grouped by the representative
+index.  At length `N`, all copies of representative `j` contribute the single
+coefficient
+`P.coeff N j = \sum_q (P.weight j q)^N`.
+
+The fixed-length theorem below separates these grouped contributions using a
+finite simultaneous word-tuple span for the representative family.  The
+all-representative theorem combines an eventual family of such finite spans
+with the bounded nonvanishing power-sum lemma.  It therefore follows the
+argument of arXiv:1606.00608, Appendix C.3, Lemma L, lines 1835--1858, while
+keeping the still-unformalized canonical-form-to-finite-span implication as an
+explicit hypothesis.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor.SectorDecomposition
+
+variable {d : ℕ}
+
+/-- The length-`L` simultaneous word tuples of the basis representatives span
+their full product matrix algebra.
+
+This is the representative-level separation condition in the proof of Lemma L
+of arXiv:1606.00608, Appendix C.3, lines 1848--1857.  It is imposed only on
+the basis tensors `P.basis j`, not on their repeated copies. -/
+def RepresentativeWordTupleSpanAt (P : SectorDecomposition d) (L : ℕ) : Prop :=
+  WordTupleSpanTop P.basis L
+
+/-- Representative word tuples span the full product algebra at every
+sufficiently large length.
+
+**Scope restriction (finite representative span):** the source obtains this
+property from block injectivity of a minimal basis of normal tensors.  That
+implication is not yet available from the abstract `SectorDecomposition`
+structure and is therefore stated explicitly.  See
+`docs/paper-gaps/cpgsv17_bicf_block_separation.tex`. -/
+def EventuallyRepresentativeWordTupleSpan (P : SectorDecomposition d) : Prop :=
+  ∃ L₀ : ℕ, ∀ L ≥ L₀, P.RepresentativeWordTupleSpanAt L
+
+/-- At one separating length, a nonzero grouped coefficient lets Lemma L
+identify the insertion on the chosen basis representative.
+
+The copies over `j` enter only through
+`P.coeff (L + 1) j = ∑_q (P.weight j q)^(L+1)`.  Thus gauge-equivalent
+copies are grouped before the word-tuple separation is applied.
+
+Source: arXiv:1606.00608, Appendix C.3, Lemma L, lines 1848--1858. -/
+theorem insertedTensor_basis_eq_of_firstSiteActionAgree_of_coeff_ne_zero
+    (P : SectorDecomposition d) {Y Z : Matrix (Fin d) (Fin d) ℂ}
+    (hAct : FirstSiteActionAgree P.toTensor Y Z)
+    {L : ℕ} (hSpan : P.RepresentativeWordTupleSpanAt L)
+    (j₀ : Fin P.basisCount) (hcoeff : P.coeff (L + 1) j₀ ≠ 0) :
+    insertedTensor Y (P.basis j₀) = insertedTensor Z (P.basis j₀) := by
+  classical
+  funext s
+  let Δ : (j : Fin P.basisCount) →
+      Matrix (Fin (P.basisDim j)) (Fin (P.basisDim j)) ℂ := fun j ↦
+    P.coeff (L + 1) j •
+      (insertedTensor Y (P.basis j) s - insertedTensor Z (P.basis j) s)
+  have hΔzero : ∀ j, Δ j = 0 := by
+    apply block_matrices_eq_zero_of_wordTupleSpanTop_trace P.basis hSpan Δ
+    intro w
+    have hA := hAct L (Fin.cons s w)
+    have hsimp : ∀ i : Fin d,
+        (Fin.cons i ((Fin.cons s w : Fin (L + 1) → Fin d) ∘ Fin.succ) :
+            Fin (L + 1) → Fin d) = Fin.cons i w :=
+      fun i ↦ by simp [Function.comp_def, Fin.cons_succ]
+    simp only [Fin.cons_zero, hsimp] at hA
+    have htrans : ∀ W : Matrix (Fin d) (Fin d) ℂ,
+        ∑ i : Fin d, W s i * P.toTensor.mpv
+            (Fin.cons i w : Fin (L + 1) → Fin d) =
+          ∑ j : Fin P.basisCount, Matrix.trace
+            (P.coeff (L + 1) j • insertedTensor W (P.basis j) s *
+              evalWord (P.basis j) (List.ofFn w)) := by
+      intro W
+      have hExp : ∀ i : Fin d,
+          P.toTensor.mpv (Fin.cons i w : Fin (L + 1) → Fin d) =
+            ∑ j : Fin P.basisCount, P.coeff (L + 1) j *
+              Matrix.trace (P.basis j i * evalWord (P.basis j) (List.ofFn w)) := by
+        intro i
+        rw [P.mpv_toTensor_eq_sum_coeff]
+        refine Finset.sum_congr rfl fun j _ ↦ ?_
+        have hof : List.ofFn (Fin.cons i w : Fin (L + 1) → Fin d) =
+            i :: List.ofFn w := by
+          simp [List.ofFn_succ, Fin.cons_zero, Fin.cons_succ]
+        simp only [MPSTensor.mpv, MPSTensor.coeff, hof, MPSTensor.evalWord_cons]
+      simp_rw [hExp, Finset.mul_sum]
+      rw [Finset.sum_comm]
+      refine Finset.sum_congr rfl fun j _ ↦ ?_
+      calc
+        ∑ i : Fin d, W s i *
+              (P.coeff (L + 1) j *
+                Matrix.trace (P.basis j i * evalWord (P.basis j) (List.ofFn w))) =
+            P.coeff (L + 1) j * ∑ i : Fin d, W s i *
+              Matrix.trace (P.basis j i * evalWord (P.basis j) (List.ofFn w)) := by
+                rw [Finset.mul_sum]
+                refine Finset.sum_congr rfl fun i _ ↦ by ring
+        _ = P.coeff (L + 1) j * ∑ i : Fin d, Matrix.trace
+              ((W s i • P.basis j i) * evalWord (P.basis j) (List.ofFn w)) := by
+                congr 1
+                refine Finset.sum_congr rfl fun i _ ↦ ?_
+                rw [Matrix.smul_mul, Matrix.trace_smul, smul_eq_mul]
+        _ = P.coeff (L + 1) j * Matrix.trace
+              (∑ i : Fin d, (W s i • P.basis j i) *
+                evalWord (P.basis j) (List.ofFn w)) := by
+                rw [Matrix.trace_sum]
+        _ = P.coeff (L + 1) j * Matrix.trace
+              ((∑ i : Fin d, W s i • P.basis j i) *
+                evalWord (P.basis j) (List.ofFn w)) := by
+                rw [Finset.sum_mul]
+        _ = P.coeff (L + 1) j * Matrix.trace
+              (insertedTensor W (P.basis j) s *
+                evalWord (P.basis j) (List.ofFn w)) := rfl
+        _ = Matrix.trace
+              (P.coeff (L + 1) j • insertedTensor W (P.basis j) s *
+                evalWord (P.basis j) (List.ofFn w)) := by
+                rw [Matrix.smul_mul, Matrix.trace_smul, smul_eq_mul]
+    rw [htrans Y, htrans Z] at hA
+    have hsubtr : ∀ j : Fin P.basisCount,
+        Matrix.trace (Δ j * evalWord (P.basis j) (List.ofFn w)) =
+          Matrix.trace
+              (P.coeff (L + 1) j • insertedTensor Y (P.basis j) s *
+                evalWord (P.basis j) (List.ofFn w)) -
+            Matrix.trace
+              (P.coeff (L + 1) j • insertedTensor Z (P.basis j) s *
+                evalWord (P.basis j) (List.ofFn w)) := by
+      intro j
+      change Matrix.trace
+          ((P.coeff (L + 1) j •
+              (insertedTensor Y (P.basis j) s - insertedTensor Z (P.basis j) s)) *
+            evalWord (P.basis j) (List.ofFn w)) = _
+      rw [smul_sub, sub_mul, Matrix.trace_sub]
+    simp_rw [hsubtr]
+    rw [Finset.sum_sub_distrib, sub_eq_zero]
+    exact hA
+  have hj := hΔzero j₀
+  have hdiff : insertedTensor Y (P.basis j₀) s -
+      insertedTensor Z (P.basis j₀) s = 0 :=
+    (smul_eq_zero.mp hj).resolve_left hcoeff
+  exact sub_eq_zero.mp hdiff
+
+/-- Representative-grouped Lemma L under an explicit eventual finite-span
+hypothesis.
+
+For each representative `j`, apply the bounded power-sum lemma to the powered
+weights `(P.weight j q)^(L₀+1)`.  It supplies a positive `r` such that the
+coefficient at `N = (L₀+1)r` is nonzero.  Since `N-1 ≥ L₀`, the
+representative word tuples at the required tail length separate the grouped
+insertion difference.
+
+**Scope restriction (finite representative span):** the only hypothesis not
+contained in the abstract sector decomposition is
+`EventuallyRepresentativeWordTupleSpan P`.  It is the finite word-span input
+supplied by the source's block-injectivity proposition for a minimal basis of
+normal tensors; deriving it from the full canonical-form hypotheses remains
+open.  See `docs/paper-gaps/cpgsv17_bicf_block_separation.tex`.
+
+Source: arXiv:1606.00608, Appendix C.3, Lemma L, lines 1835--1858. -/
+theorem insertedTensor_basis_eq_of_firstSiteActionAgree
+    (P : SectorDecomposition d) {Y Z : Matrix (Fin d) (Fin d) ℂ}
+    (hSpan : P.EventuallyRepresentativeWordTupleSpan)
+    (hAct : FirstSiteActionAgree P.toTensor Y Z) :
+    ∀ j, insertedTensor Y (P.basis j) = insertedTensor Z (P.basis j) := by
+  classical
+  obtain ⟨L₀, hSpan⟩ := hSpan
+  intro j
+  let M := L₀ + 1
+  obtain ⟨r, hrpos, _hrle, hsum⟩ :=
+    Matrix.exists_sum_pow_ne_zero_of_pos_card
+      (P.copies j) (fun q ↦ (P.weight j q) ^ M) (P.copies_pos j)
+      (fun q ↦ pow_ne_zero M (P.weight_ne_zero j q))
+  let N := M * r
+  have hNpos : 0 < N := Nat.mul_pos (by simp [M]) hrpos
+  have hcoeffN : P.coeff N j ≠ 0 := by
+    change (∑ q : Fin (P.copies j), (P.weight j q) ^ N) ≠ 0
+    simpa only [N, pow_mul] using hsum
+  let L := N - 1
+  have hLadd : L + 1 = N := by
+    exact Nat.sub_add_cancel hNpos
+  have hMleN : M ≤ N := by
+    exact Nat.le_mul_of_pos_right M hrpos
+  have hL₀leL : L₀ ≤ L := by
+    dsimp [L, M] at hMleN ⊢
+    omega
+  apply P.insertedTensor_basis_eq_of_firstSiteActionAgree_of_coeff_ne_zero
+    hAct (hSpan L hL₀leL) j
+  rwa [hLadd]
+
+/-- Transported representative-grouped Lemma L for an original tensor with
+the same complete MPV family as the sector decomposition.
+
+This is the form used when canonical-form data have first been obtained only
+up to `SameMPV₂`.  The finite representative-span restriction is unchanged.
+
+Source: arXiv:1606.00608, Appendix C.3, Lemma L, lines 1835--1858. -/
+theorem insertedTensor_basis_eq_of_sameMPV₂_firstSiteActionAgree
+    {D : ℕ} (A : MPSTensor d D) (P : SectorDecomposition d)
+    {Y Z : Matrix (Fin d) (Fin d) ℂ}
+    (hAP : SameMPV₂ A P.toTensor)
+    (hSpan : P.EventuallyRepresentativeWordTupleSpan)
+    (hAct : FirstSiteActionAgree A Y Z) :
+    ∀ j, insertedTensor Y (P.basis j) = insertedTensor Z (P.basis j) := by
+  exact P.insertedTensor_basis_eq_of_firstSiteActionAgree hSpan
+    (hAct.of_sameMPV hAP)
+
+end MPSTensor.SectorDecomposition

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -216,6 +216,89 @@
     finite witness from separated canonical-form / BNT data.
 \end{proof}
 
+\begin{definition}[Representative word-tuple separation]
+    \label{def:representative_word_tuple_span}
+    \lean{MPSTensor.SectorDecomposition.RepresentativeWordTupleSpanAt}
+    \lean{MPSTensor.SectorDecomposition.EventuallyRepresentativeWordTupleSpan}
+    \leanok
+    \uses{def:sector_weight_data, rem:word_tuple_span_top}
+    Let $(A_j)_{j=0}^{g-1}$ be the basis representatives of a sector
+    decomposition.  They have \emph{representative word-tuple separation at
+    length $L$} when
+    \[
+        \spn_{\C}\bigl\{(A_j^w)_{j=0}^{g-1}:
+        w\in\{0,\ldots,d{-}1\}^{L}\bigr\}
+        =\prod_{j=1}^g M_{D_j}(\C).
+    \]
+    They have \emph{eventual representative word-tuple separation} when this
+    equality holds at every sufficiently large length.  Notice that the
+    family is indexed by the minimal representatives $j$, and not by the
+    repeated copies lying over each $j$.
+\end{definition}
+
+\begin{theorem}[Representative-grouped Lemma L]
+    \label{thm:representative_grouped_insert_eq}
+    \lean{MPSTensor.SectorDecomposition.insertedTensor_basis_eq_of_firstSiteActionAgree_of_coeff_ne_zero}
+    \lean{MPSTensor.SectorDecomposition.insertedTensor_basis_eq_of_firstSiteActionAgree}
+    \lean{MPSTensor.SectorDecomposition.insertedTensor_basis_eq_of_sameMPV₂_firstSiteActionAgree}
+    \leanok
+    \uses{def:representative_word_tuple_span,
+      def:sector_weight_data, cor:nonvanishing_finite_power_sum}
+    Let $A_{\mathrm{tot}}$ be the tensor of a sector decomposition with basis
+    representatives $(A_j)_{j=0}^{g-1}$, multiplicities $r_j>0$, nonzero weights
+    $\mu_{j,q}$, and grouped coefficients
+    \[
+        c_j^{(N)}=\sum_{q=0}^{r_j-1}\mu_{j,q}^{N}.
+    \]
+    Suppose that the first-site actions of $Y,Z\in M_d(\C)$ agree on the MPV
+    family of $A_{\mathrm{tot}}$.  If representative word-tuple separation
+    holds at length $L$ and $c_{j_0}^{(L+1)}\neq0$, then
+    \[
+        YA_{j_0}=ZA_{j_0}.
+    \]
+    Consequently, under eventual representative word-tuple separation,
+    $YA_j=ZA_j$ for every representative $j$.  The same conclusion holds if
+    the first-site equality is initially given for any tensor with the same
+    complete MPV family as $A_{\mathrm{tot}}$.
+
+    The representative grouping is the argument of
+    \cite[Appendix~C.3, lines~1835--1858]{Cirac2016MPDO_arXiv}.
+
+    \textbf{Scope restriction (finite representative span).}  Appendix~C.3
+    obtains the required separation from block injectivity of a minimal basis
+    of normal tensors.  Here eventual representative word-tuple separation is
+    an explicit assumption; its derivation from the full canonical-form
+    hypotheses remains open.  This is recorded in
+    \path{docs/paper-gaps/cpgsv17_bicf_block_separation.tex}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:representative_word_tuple_span,
+      lem:paper_decomp_formula, cor:nonvanishing_finite_power_sum}
+    At a fixed tail length $L$, expand the first-site equality at system size
+    $L+1$ and group all copies lying over the same representative.  For every
+    length-$L$ word $w$ this gives
+    \[
+      \sum_{j=0}^{g-1}
+      \tr\!\left(c_j^{(L+1)}(YA_j-ZA_j)A_j^w\right)=0.
+    \]
+    Representative word-tuple separation therefore forces each matrix
+    $c_j^{(L+1)}(YA_j-ZA_j)$ to vanish.  A nonzero coefficient may then be
+    cancelled.
+
+    For the eventual assertion, choose a threshold $L_0$ and put
+    $M=L_0+1$.  For a fixed representative $j$, apply
+    Corollary~\ref{cor:nonvanishing_finite_power_sum} to the nonzero numbers
+    $\mu_{j,q}^{M}$.  It yields $r\geq1$ such that
+    \[
+        c_j^{(Mr)}=\sum_q(\mu_{j,q}^{M})^r\neq0.
+    \]
+    Since $Mr-1\geq L_0$, the fixed-length argument applies with
+    $L=Mr-1$.  Finally, equality of complete MPV families transports the
+    first-site hypothesis to the sector-decomposition tensor.
+\end{proof}
+
 \begin{lemma}[Blockwise equality from agreement on the MPV family]
     \label{lem:blockwise_insert_eq_of_mpv_agree}
     \lean{MPOTensor.blockwise_insert_eq_of_mpv_agree}


### PR DESCRIPTION
## Mathematical change

This pull request formalizes the representative-grouped part of Lemma L from arXiv:1606.00608, Appendix C.3, lines 1835–1858. A sector decomposition is kept in its two-level form: `j` indexes a minimal basis of normal-tensor representatives and `q` indexes repeated gauge-equivalent copies. At length `N`, the copies enter only through

```text
c_j^(N) = sum_q mu_(j,q)^N.
```

A fixed-length theorem expands the first-site action equality and applies simultaneous word separation only to the representative family. It concludes `Y A_j = Z A_j` whenever the grouped coefficient is nonzero. The all-representative theorem applies the bounded finite power-sum result to the powered weights `mu_(j,q)^(L_0+1)`, producing a nonzero coefficient at a length where representative separation holds. A final theorem transports the conclusion from any tensor with the same complete MPV family.

This removes the false per-copy separation that excludes repeated normal blocks. It does **not** claim the unrestricted source theorem: eventual representative word-tuple separation remains an explicit hypothesis until it is derived from the full canonical-form/BNT block-injectivity hypotheses. The restriction and the elimination plan remain recorded in `docs/paper-gaps/cpgsv17_bicf_block_separation.tex`.

Refs #3713. This also advances the Lemma L dependency of #3674.

## Verification

- `lake env lean TNLean/MPS/MPDO/RepresentativeGroupedLemmaL.lean`
- `lake build TNLean`
- `lake env lean TNLean.lean`
- blueprint declaration synchronization
- `cd blueprint && leanblueprint checkdecls`
- proof-bypass and whitespace checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New Mathlib proofs on existing sector-decomposition infrastructure; no auth, runtime, or API surface changes. Remaining mathematical gap is explicitly scoped as a hypothesis rather than silently assumed.
> 
> **Overview**
> Adds **`RepresentativeGroupedLemmaL.lean`**, which formalizes Appendix C.3 Lemma L with **representative grouping**: gauge-equivalent copies over index `j` enter only through grouped coefficients `c_j^(N) = ∑_q μ_(j,q)^N`, and word-tuple separation is stated on **minimal basis representatives**, not every per-copy block.
> 
> New predicates `RepresentativeWordTupleSpanAt` and `EventuallyRepresentativeWordTupleSpan` capture the finite-span input; proved lemmas show `Y A_j = Z A_j` from matching first-site MPV actions when a grouped coefficient is nonzero, for all representatives once eventual span holds, and after transport via `SameMPV₂`. **Eventual representative separation** stays an explicit hypothesis (canonical-form derivation still open), as documented in the blueprint and paper-gaps note.
> 
> The module is wired into **`TNLean.lean`**, and **chapter 20** gains matching blueprint definitions, the representative-grouped Lemma L theorem, and proof sketch aligned with the Lean names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 855e52a035597c0e56b4cbcd95c42d6c31b9b46e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->