### PR TITLE
feat(MPS/MPDO): derive post-blocked representative span

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -374,6 +374,7 @@ import TNLean.MPS.MPDO.PureAreaLaw
 import TNLean.MPS.MPDO.PureRFPSAL
 import TNLean.MPS.MPDO.VerticalCF
 import TNLean.MPS.MPDO.RepresentativeGroupedLemmaL
+import TNLean.MPS.MPDO.PostBlockedRepresentativeSpan
 import TNLean.MPS.MPDO.InvariantProjection
 import TNLean.MPS.MPDO.PeriodicExclusion
 import TNLean.MPS.MPDO.StackedLayers

--- a/TNLean/MPS/MPDO/PostBlockedRepresentativeSpan.lean
+++ b/TNLean/MPS/MPDO/PostBlockedRepresentativeSpan.lean
@@ -1,0 +1,119 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.FundamentalTheorem.FiniteLength
+import TNLean.MPS.FundamentalTheorem.SectorBNT.Basic
+import TNLean.MPS.MPDO.BiCFDerivation.BNTDirectSum
+import TNLean.MPS.MPDO.RepresentativeGroupedLemmaL
+
+/-!
+# Representative separation after injective blocking
+
+For a BNT canonical-form sector decomposition whose representative tensors are
+already injective, the representative word tuples span the full product matrix
+algebra at every sufficiently large length.  Pairwise separation gives a fixed
+selector suffix, while one-site injectivity gives a full matrix-algebra prefix
+at every positive remaining length.
+
+This is the post-blocking form of the block-injectivity input in
+arXiv:1606.00608, lines 318--345.  In particular, line 332 supplies the
+injectivity hypothesis after blocking.  No right-unital normalization or
+period-window hypothesis is used.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor.IsBNTCanonicalForm
+
+variable {d : ℕ} {P : SectorDecomposition d}
+
+/-- The minimal BNT representatives have full simultaneous word-tuple span at
+every sufficiently large length once they have already been made injective by
+blocking.
+
+The fixed selector suffix is obtained from the direct-sum separation argument
+at the lengths (1), (2), and (6).  For a total length beyond the selector
+suffix, injectivity supplies the remaining positive-length prefix.
+
+**Scope restriction (already injectively blocked representatives):** the
+hypothesis `∀ j, IsInjective (P.basis j)` is the conclusion of the blocking
+step in arXiv:1606.00608, line 332.  This theorem does not transport an
+unblocked first-site action through that blocking.  See
+`docs/paper-gaps/cpgsv17_bicf_block_separation.tex`. -/
+theorem eventuallyRepresentativeWordTupleSpan_of_basis_injective
+    (hCF : IsBNTCanonicalForm P)
+    (hInj : ∀ j, IsInjective (P.basis j)) :
+    P.EventuallyRepresentativeWordTupleSpan := by
+  classical
+  letI : ∀ j : Fin P.basisCount, NeZero (P.basisDim j) :=
+    fun j ↦ ⟨(hCF.basis_dim_pos j).ne'⟩
+  have hBlkPos : ∀ (j : Fin P.basisCount) (n : ℕ), 0 < n →
+      IsNBlkInjective (P.basis j) n := by
+    intro j n hn
+    exact (wordSpan_eq_top_iff_isNBlkInjective (P.basis j) n).mp
+      (wordSpan_eq_top_of_isInjective (hInj j) hn)
+  have hIrr : HasIrreducibleBlocks (d := d) P.basis :=
+    HasIrreducibleBlocks.ofForall hCF.basis_irreducible
+  have hLeft : IsLeftCanonicalBlockFamily (d := d) P.basis :=
+    IsLeftCanonicalBlockFamily.ofForall hCF.basis_left_canonical
+  have hOverlap : HasNormalizedSelfOverlap (d := d) P.basis :=
+    HasNormalizedSelfOverlap.ofForall hCF.basis_normalized_self_overlap
+  have hBlocks : BlocksNotGaugePhaseEquiv (d := d) P.basis :=
+    hCF.basis_distinct
+  have hPair : HasPairBlockSeparatingWords P.basis 6 := by
+    simpa using
+      (hasPairBlockSeparatingWords_threeBlock_of_blocksNotGaugePhaseEquiv_c1
+        P.basis hIrr hLeft hOverlap hBlocks
+        (fun j ↦ hBlkPos j 1 (by omega))
+        (fun j ↦ hBlkPos j 2 (by omega))
+        (fun j ↦ hBlkPos j 6 (by omega))
+        (by omega : 0 < 1))
+  let selectorLength := (P.basisCount - 1) * 6
+  have hSelectors : HasBlockSelectorWords P.basis selectorLength := by
+    simpa [selectorLength] using
+      hasBlockSelectorWords_of_pairBlockSeparatingWords P.basis hPair
+  change ∃ L₀ : ℕ, ∀ L ≥ L₀, WordTupleSpanTop P.basis L
+  refine ⟨selectorLength + 1, ?_⟩
+  intro L hL
+  have hSelectorLength_le : selectorLength ≤ L := by omega
+  have hPrefixPos : 0 < L - selectorLength := by omega
+  have hSpan := wordTupleSpanTop_of_common_blockInjective_of_blockSelectorWords
+    P.basis (fun j ↦ hBlkPos j (L - selectorLength) hPrefixPos) hSelectors
+  simpa [Nat.sub_add_cancel hSelectorLength_le] using hSpan
+
+/-- Representative-grouped Lemma L for an already injectively blocked BNT
+canonical form.
+
+This removes the explicit word-tuple-span hypothesis from the grouped theorem,
+but retains the post-blocking injectivity conclusion of arXiv:1606.00608,
+line 332.  The grouping and power-sum argument is Appendix C.3, lines
+1835--1858. -/
+theorem insertedTensor_basis_eq_of_firstSiteActionAgree_of_basis_injective
+    (hCF : IsBNTCanonicalForm P)
+    (hInj : ∀ j, IsInjective (P.basis j))
+    {Y Z : Matrix (Fin d) (Fin d) ℂ}
+    (hAct : FirstSiteActionAgree P.toTensor Y Z) :
+    ∀ j, insertedTensor Y (P.basis j) = insertedTensor Z (P.basis j) := by
+  exact P.insertedTensor_basis_eq_of_firstSiteActionAgree
+    (hCF.eventuallyRepresentativeWordTupleSpan_of_basis_injective hInj) hAct
+
+/-- Same-MPV transport of representative-grouped Lemma L for an already
+injectively blocked BNT canonical form.
+
+The original tensor and the sector-decomposition tensor have the same complete
+MPV family; the finite representative separation is supplied by the
+post-blocking canonical-form hypotheses above. -/
+theorem insertedTensor_basis_eq_of_sameMPV₂_firstSiteActionAgree_of_basis_injective
+    {D : ℕ} (A : MPSTensor d D)
+    (hCF : IsBNTCanonicalForm P)
+    (hInj : ∀ j, IsInjective (P.basis j))
+    (hAP : SameMPV₂ A P.toTensor)
+    {Y Z : Matrix (Fin d) (Fin d) ℂ}
+    (hAct : FirstSiteActionAgree A Y Z) :
+    ∀ j, insertedTensor Y (P.basis j) = insertedTensor Z (P.basis j) := by
+  exact hCF.insertedTensor_basis_eq_of_firstSiteActionAgree_of_basis_injective
+    hInj (hAct.of_sameMPV hAP)
+
+end MPSTensor.IsBNTCanonicalForm

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -299,6 +299,66 @@
     first-site hypothesis to the sector-decomposition tensor.
 \end{proof}
 
+\begin{theorem}[Representative separation after injective blocking]
+    \label{thm:postblocked_representative_grouped_insert_eq}
+    \lean{MPSTensor.IsBNTCanonicalForm.eventuallyRepresentativeWordTupleSpan_of_basis_injective}
+    \lean{MPSTensor.IsBNTCanonicalForm.insertedTensor_basis_eq_of_firstSiteActionAgree_of_basis_injective}
+    \lean{MPSTensor.IsBNTCanonicalForm.insertedTensor_basis_eq_of_sameMPV₂_firstSiteActionAgree_of_basis_injective}
+    \leanok
+    \uses{def:sector_bnt_cf, def:representative_word_tuple_span,
+      thm:representative_grouped_insert_eq}
+    Let $P$ be a BNT canonical form with basis representatives
+    $(A_j)_{j=0}^{g-1}$, and suppose that the representatives have already
+    been blocked so that every $A_j$ is injective. Then representative
+    word-tuple separation holds at every length
+    \[
+        L\geq 6(g-1)+1.
+    \]
+    Consequently, if the first-site actions of $Y,Z\in M_d(\C)$ agree on the
+    complete MPV family of the tensor represented by $P$, then
+    \[
+        YA_j=ZA_j
+        \quad (0\leq j<g).
+    \]
+    The same conclusion holds when the first-site equality is given for any
+    tensor with the same complete MPV family as the tensor represented by
+    $P$.
+
+    This is the conclusion after the blocking step in
+    \cite[lines~318--345]{Cirac2016MPDO_arXiv}. The hypothesis that each
+    representative is injective is precisely the post-blocking hypothesis;
+    the assertion does not transport a first-site action from the original
+    physical alphabet through the blocking map.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:bnt_direct_sum_block_separation_word_span,
+      lem:block_separating_equations_from_pairwise_separation,
+      lem:product_word_span_from_bnt_block_separation,
+      thm:representative_grouped_insert_eq}
+    Injectivity of $A_j$ implies that its homogeneous words span
+    $M_{D_j}(\C)$ at every positive length. Apply the three-block separation
+    argument with source length $1$. For each ordered pair of distinct
+    representatives it gives a pairwise block-separating equation at length
+    $6$. Multiplying the equations for the $g-1$ representatives different
+    from $A_j$ gives coefficients $c_w^{(j)}$ satisfying
+    \[
+        \sum_{|w|=6(g-1)}c_w^{(j)}A_k^w
+        =
+        \begin{cases}
+            I, & k=j,\\
+            0, & k\neq j.
+        \end{cases}
+    \]
+    If $L\geq6(g-1)+1$, put $m=L-6(g-1)>0$. The length-$m$ words of each
+    $A_j$ span $M_{D_j}(\C)$. Concatenating these words with the displayed
+    selectors shows that the simultaneous length-$L$ word tuples span
+    $\prod_jM_{D_j}(\C)$. This proves eventual representative word-tuple
+    separation. The representative-grouped Lemma L gives the two first-site
+    conclusions.
+\end{proof}
+
 \begin{lemma}[Blockwise equality from agreement on the MPV family]
     \label{lem:blockwise_insert_eq_of_mpv_agree}
     \lean{MPOTensor.blockwise_insert_eq_of_mpv_agree}


### PR DESCRIPTION
## Mathematical content

This proves the representative-separation input for Lemma L after the BNT representatives have been blocked to injectivity, as in arXiv:1606.00608, lines 318–345.

For a BNT canonical form with (g) injective representatives, pairwise block separation produces selector words of length (6(g-1)). Homogeneous word spanning on each injective representative then gives simultaneous representative word-tuple spanning at every length
\[
L \ge 6(g-1)+1.
\]
The existing representative-grouped power-sum argument consequently yields equality of the inserted tensors from agreement of the first-site actions. A companion theorem transports this conclusion along equality of the complete MPV family.

The statement explicitly retains the post-blocking injectivity hypothesis. It does not identify the unblocked physical first-site action with its blocked counterpart; that remaining point is recorded in `docs/paper-gaps/cpgsv17_bicf_block_separation.tex`.

## Verification

- `lake build TNLean`
- `cd blueprint && leanblueprint checkdecls`
- no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast` in the new Lean module

Refs #3713

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formal proofs and blueprint text on the MPDO canonical-form track; no runtime, security, or data-path changes, with scope limits documented for the open blocking-transport gap.
> 
> **Overview**
> Adds **`PostBlockedRepresentativeSpan.lean`**, which shows that for a BNT canonical form with **injective** basis representatives, pairwise block separation yields selector words of length `6(g-1)` and injectivity supplies a spanning prefix, so **eventual representative word-tuple separation** holds for lengths `L ≥ 6(g-1)+1`. That span hypothesis is fed into the existing **`insertedTensor_basis_eq_of_firstSiteActionAgree`** chain, giving **`YA_j = ZA_j`** from agreement of first-site actions on the MPV family (including a **`SameMPV₂`** transport variant).
> 
> The module is exported via **`TNLean.lean`**. **Blueprint ch20** gains theorem **`thm:postblocked_representative_grouped_insert_eq`** with Lean links and a proof sketch aligned to the formal argument.
> 
> Docs stress the **post-blocking** injectivity assumption only: this does **not** identify unblocked physical first-site actions with blocked ones (remaining gap in `docs/paper-gaps/cpgsv17_bicf_block_separation.tex`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5536a553e39d23f8c1cae4a84f32d3f68c46bc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->