### PR TITLE
feat(MPS/MPDO): transport first-site actions through blocking

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -373,6 +373,7 @@ import TNLean.MPS.MPDO.MutualInfoMonotone
 import TNLean.MPS.MPDO.PureAreaLaw
 import TNLean.MPS.MPDO.PureRFPSAL
 import TNLean.MPS.MPDO.VerticalCF
+import TNLean.MPS.MPDO.FirstSiteBlocking
 import TNLean.MPS.MPDO.RepresentativeGroupedLemmaL
 import TNLean.MPS.MPDO.PostBlockedRepresentativeSpan
 import TNLean.MPS.MPDO.InvariantProjection

--- a/TNLean/MPS/MPDO/FirstSiteBlocking.lean
+++ b/TNLean/MPS/MPDO/FirstSiteBlocking.lean
@@ -1,0 +1,185 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.Core.Blocking
+import TNLean.MPS.MPDO.VerticalCF
+
+/-!
+# First-site actions under physical blocking
+
+This file gives auxiliary blocking statements for combining the
+block-injectivity argument of arXiv:1606.00608, lines 318--345, with the
+first-site identity in Appendix C.3, Lemma L, lines 1835--1858.  On a block
+of length `L + 1`, the induced matrix acts on the first letter and fixes the
+remaining `L` letters.  Its insertion into the blocked tensor is the original
+insertion followed by the word carried by those remaining letters.
+
+If the length-`L` words span the full matrix algebra, equality of two such
+blocked insertions implies equality before blocking.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- The physical matrix induced on a block of length `L + 1` by a matrix on
+its first letter.  In decoded coordinates it is `Y ⊗ 1`.
+
+This auxiliary construction is used to relate the block-injectivity argument
+of arXiv:1606.00608, lines 318--345, to Appendix C.3, Lemma L,
+lines 1835--1858. -/
+noncomputable def firstSiteActionOnBlock (L : ℕ)
+    (Y : Matrix (Fin d) (Fin d) ℂ) :
+    Matrix (Fin (blockPhysDim d (L + 1))) (Fin (blockPhysDim d (L + 1))) ℂ :=
+  fun I J =>
+    Y (decodeBlock d (L + 1) I 0) (decodeBlock d (L + 1) J 0) *
+      if (fun k : Fin L => decodeBlock d (L + 1) I k.succ) =
+          (fun k : Fin L => decodeBlock d (L + 1) J k.succ) then 1 else 0
+
+/-- The all-length first-site identity is equivalent to equality of the trace
+pairings obtained by inserting the two physical matrices before an arbitrary
+word.
+
+Source: arXiv:1606.00608, Appendix C.3, Lemma L, lines 1835--1847. -/
+theorem firstSiteActionAgree_iff_trace (A : MPSTensor d D)
+    (Y Z : Matrix (Fin d) (Fin d) ℂ) :
+    FirstSiteActionAgree A Y Z ↔
+      ∀ (L : ℕ) (s : Fin d) (w : Fin L → Fin d),
+        Matrix.trace (insertedTensor Y A s * evalWord A (List.ofFn w)) =
+          Matrix.trace (insertedTensor Z A s * evalWord A (List.ofFn w)) := by
+  constructor
+  · intro h L s w
+    have h' := h L (Fin.cons s w)
+    simpa [FirstSiteActionAgree, mpv, coeff, List.ofFn_succ, Fin.cons_zero,
+      Fin.cons_succ, insertedTensor, Finset.sum_mul, Matrix.trace_sum,
+      Matrix.smul_mul, Matrix.trace_smul, smul_eq_mul] using h'
+  · intro h L σ
+    have h' := h L (σ 0) (σ ∘ Fin.succ)
+    simpa [FirstSiteActionAgree, mpv, coeff, List.ofFn_succ, Fin.cons_zero,
+      Fin.cons_succ, insertedTensor, Finset.sum_mul, Matrix.trace_sum,
+      Matrix.smul_mul, Matrix.trace_smul, smul_eq_mul, Function.comp_def] using h'
+
+/-- The trace-pairing form of a first-site identity for an arbitrary finite
+word. -/
+theorem FirstSiteActionAgree.trace_evalWord {A : MPSTensor d D}
+    {Y Z : Matrix (Fin d) (Fin d) ℂ} (h : FirstSiteActionAgree A Y Z)
+    (s : Fin d) (w : List (Fin d)) :
+    Matrix.trace (insertedTensor Y A s * evalWord A w) =
+      Matrix.trace (insertedTensor Z A s * evalWord A w) := by
+  simpa using (firstSiteActionAgree_iff_trace A Y Z).mp h w.length s w.get
+
+/-- Inserting the induced first-site action into a blocked tensor inserts the
+original matrix before the word carried by the remaining letters of the
+block.
+
+This auxiliary identity is used to relate the block-injectivity argument of
+arXiv:1606.00608, lines 318--345, to Appendix C.3, Lemma L,
+lines 1835--1858. -/
+theorem insertedTensor_firstSiteActionOnBlock_blockTensor
+    (A : MPSTensor d D) (L : ℕ) (Y : Matrix (Fin d) (Fin d) ℂ)
+    (I : Fin (blockPhysDim d (L + 1))) :
+    insertedTensor (firstSiteActionOnBlock L Y) (blockTensor A (L + 1)) I =
+      insertedTensor Y A (decodeBlock d (L + 1) I 0) *
+        evalWord A
+          (List.ofFn fun k : Fin L => decodeBlock d (L + 1) I k.succ) := by
+  classical
+  rw [insertedTensor]
+  rw [← Equiv.sum_comp (decodeBlockEquiv d (L + 1)).symm
+    (fun J : Fin (blockPhysDim d (L + 1)) =>
+      firstSiteActionOnBlock L Y I J • blockTensor A (L + 1) J)]
+  rw [← (Fin.consEquiv (fun _ : Fin (L + 1) => Fin d)).sum_comp]
+  rw [Fintype.sum_prod_type]
+  rw [insertedTensor, Finset.sum_mul]
+  apply Finset.sum_congr rfl
+  intro j _
+  rw [Fintype.sum_eq_single
+    (fun k : Fin L => decodeBlock d (L + 1) I k.succ)]
+  · simp [firstSiteActionOnBlock, blockTensor, wordOfBlock, List.ofFn_succ,
+      evalWord_cons]
+  · intro w hw
+    simp only [Fin.consEquiv_apply, firstSiteActionOnBlock,
+      decodeBlock_decodeBlockEquiv_symm, Fin.cons_zero, Fin.cons_succ]
+    rw [if_neg]
+    · simp
+    · exact fun h => hw h.symm
+
+/-- A first-site action identity remains valid after physical blocking when
+the action on each block is induced from its first letter.
+
+This auxiliary transport is used to relate the block-injectivity argument of
+arXiv:1606.00608, lines 318--345, to Appendix C.3, Lemma L,
+lines 1835--1858. -/
+theorem FirstSiteActionAgree.blockTensor {A : MPSTensor d D}
+    {Y Z : Matrix (Fin d) (Fin d) ℂ} (h : FirstSiteActionAgree A Y Z)
+    (L : ℕ) :
+    FirstSiteActionAgree (blockTensor A (L + 1))
+      (firstSiteActionOnBlock L Y) (firstSiteActionOnBlock L Z) := by
+  rw [firstSiteActionAgree_iff_trace]
+  intro N I w
+  rw [insertedTensor_firstSiteActionOnBlock_blockTensor,
+    insertedTensor_firstSiteActionOnBlock_blockTensor]
+  simp only [evalWord_blockTensor, Matrix.mul_assoc, ← evalWord_append]
+  exact h.trace_evalWord (decodeBlock d (L + 1) I 0)
+    (List.ofFn (fun k : Fin L => decodeBlock d (L + 1) I k.succ) ++
+      flattenBlockedWord d (L + 1) (List.ofFn w))
+
+/-- Equality of the induced insertions on a block of length `L + 1` implies
+equality of the original insertions when the remaining length-`L` words span
+the full matrix algebra.
+
+This supporting statement combines the block-injectivity result of
+arXiv:1606.00608, lines 318--345, with the insertion in Lemma L.  It uses no
+normalization or positivity hypothesis.
+
+Source context: arXiv:1606.00608, lines 318--345 and Appendix C.3,
+Lemma L, lines 1848--1858. -/
+theorem insertedTensor_eq_of_firstSiteActionOnBlock_blockTensor_eq
+    (A : MPSTensor d D) (L : ℕ) (hInj : IsNBlkInjective A L)
+    {Y Z : Matrix (Fin d) (Fin d) ℂ}
+    (hEq :
+      insertedTensor (firstSiteActionOnBlock L Y) (blockTensor A (L + 1)) =
+        insertedTensor (firstSiteActionOnBlock L Z) (blockTensor A (L + 1))) :
+    insertedTensor Y A = insertedTensor Z A := by
+  funext s
+  apply sub_eq_zero.mp
+  let Δ := insertedTensor Y A s - insertedTensor Z A s
+  change Δ = 0
+  have hzero : ∀ w : Fin L → Fin d, Δ * evalWord A (List.ofFn w) = 0 := by
+    intro w
+    let I : Fin (blockPhysDim d (L + 1)) :=
+      (decodeBlockEquiv d (L + 1)).symm (Fin.cons s w)
+    have hI := congrFun hEq I
+    rw [insertedTensor_firstSiteActionOnBlock_blockTensor,
+      insertedTensor_firstSiteActionOnBlock_blockTensor] at hI
+    have hdecode : decodeBlock d (L + 1) I = Fin.cons s w := by
+      exact decodeBlock_decodeBlockEquiv_symm d (L + 1) (Fin.cons s w)
+    have hfirst : decodeBlock d (L + 1) I 0 = s := by
+      rw [hdecode]
+      simp
+    have htail : (fun k : Fin L => decodeBlock d (L + 1) I k.succ) = w := by
+      funext k
+      rw [hdecode]
+      simp
+    rw [hfirst, htail] at hI
+    dsimp [Δ]
+    rw [Matrix.sub_mul, hI, sub_self]
+  have hzero_span : ∀ M ∈ Submodule.span ℂ
+      (Set.range fun w : Fin L → Fin d => evalWord A (List.ofFn w)), Δ * M = 0 := by
+    apply Submodule.span_induction
+    · intro M hM
+      obtain ⟨w, rfl⟩ := hM
+      exact hzero w
+    · simp
+    · intro M N _ _ hM hN
+      simp [Matrix.mul_add, hM, hN]
+    · intro c M _ hM
+      simp [hM]
+  have hOne : Δ * (1 : Matrix (Fin D) (Fin D) ℂ) = 0 :=
+    hzero_span 1 (hInj.symm ▸ Submodule.mem_top)
+  simpa using hOne
+
+end MPSTensor

--- a/TNLean/MPS/MPDO/FirstSiteBlocking.lean
+++ b/TNLean/MPS/MPDO/FirstSiteBlocking.lean
@@ -18,6 +18,29 @@ insertion followed by the word carried by those remaining letters.
 
 If the length-`L` words span the full matrix algebra, equality of two such
 blocked insertions implies equality before blocking.
+
+## Main definitions
+
+* `firstSiteActionOnBlock`: the physical matrix induced on a block by an
+  action on its first letter.
+
+## Main statements
+
+* `firstSiteActionAgree_iff_trace`: the trace-pairing form of the all-length
+  first-site identity.
+* `FirstSiteActionAgree.trace_evalWord`: its consequence for an arbitrary
+  finite word.
+* `insertedTensor_firstSiteActionOnBlock_blockTensor`: the induced insertion
+  factors as the original insertion followed by the remaining word.
+* `FirstSiteActionAgree.blockTensor`: first-site agreement is preserved by
+  physical blocking.
+* `insertedTensor_eq_of_firstSiteActionOnBlock_blockTensor_eq`: block
+  injectivity recovers equality before blocking.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  lines 318--345 and Appendix C.3, Lemma L, lines 1835--1858.
 -/
 
 open scoped Matrix BigOperators

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -299,6 +299,63 @@
     first-site hypothesis to the sector-decomposition tensor.
 \end{proof}
 
+\begin{lemma}[First-site actions under physical blocking]
+    \label{lem:first_site_action_physical_blocking}
+    \lean{MPSTensor.firstSiteActionOnBlock}
+    \lean{MPSTensor.firstSiteActionAgree_iff_trace}
+    \lean{MPSTensor.insertedTensor_firstSiteActionOnBlock_blockTensor}
+    \lean{MPSTensor.FirstSiteActionAgree.blockTensor}
+    \lean{MPSTensor.insertedTensor_eq_of_firstSiteActionOnBlock_blockTensor_eq}
+    \leanok
+    \uses{def:blocked_tensor, def:l_blk_injective}
+    This auxiliary statement supplies the transport needed to combine the
+    block-injectivity argument of arXiv:1606.00608, lines 318--345, with
+    Appendix C.3, Lemma L, lines 1835--1858.
+
+    Let $A$ be a tensor, let $Y\in M_d(\C)$, and write a physical index of
+    $A^{[L+1]}$ as $I=(i_0,\ldots,i_L)$.  Define the induced matrix on the
+    blocked physical space by
+    \[
+        Y^{[L+1]}_{I,J}
+        =Y_{i_0,j_0}\prod_{k=1}^{L}\delta_{i_k,j_k}.
+    \]
+    Its insertion into the blocked tensor satisfies
+    \[
+        \bigl(Y^{[L+1]}A^{[L+1]}\bigr)^I
+        =(YA)^{i_0}A^{i_1}\cdots A^{i_L}.
+    \]
+    Hence equality of the first-site actions of $Y,Z$ on the MPV family of
+    $A$ implies equality of the first-block actions of
+    $Y^{[L+1]},Z^{[L+1]}$ on the MPV family of $A^{[L+1]}$.
+
+    The first-site actions of $Y,Z$ agree at every length if and only if
+    \[
+        \tr\bigl((YA)^i A^w\bigr)=\tr\bigl((ZA)^i A^w\bigr)
+    \]
+    for every physical index $i$ and every finite word $w$.
+
+    Conversely, suppose that $A$ is $L$-block injective.  If the two induced
+    insertion tensors on $A^{[L+1]}$ are equal, then $YA=ZA$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    For the forward implication, split the first block into its first letter
+    and its remaining $L$ letters.  The displayed insertion identity reduces
+    the blocked MPV equality to the original first-site equality, with the
+    remaining letters of the first block prepended to the flattened tail.
+
+    For the converse, put $\Delta^i=(YA)^i-(ZA)^i$.  Equality after blocking
+    gives
+    \[
+        \Delta^i A^w=0
+        \qquad (|w|=L).
+    \]
+    Since the length-$L$ words span $\MN{D}$, the same equality holds with
+    $A^w$ replaced by the identity, and therefore $\Delta^i=0$ for every
+    physical index $i$.
+\end{proof}
+
 \begin{theorem}[Representative separation after injective blocking]
     \label{thm:postblocked_representative_grouped_insert_eq}
     \lean{MPSTensor.IsBNTCanonicalForm.eventuallyRepresentativeWordTupleSpan_of_basis_injective}

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -309,8 +309,9 @@
     \leanok
     \uses{def:blocked_tensor, def:l_blk_injective}
     This auxiliary statement supplies the transport needed to combine the
-    block-injectivity argument of arXiv:1606.00608, lines 318--345, with
-    Appendix C.3, Lemma L, lines 1835--1858.
+    block-injectivity argument
+    \cite[lines~318--345]{Cirac2016MPDO_arXiv} with Appendix~C.3, Lemma~L
+    \cite[lines~1835--1858]{Cirac2016MPDO_arXiv}.
 
     Let $A$ be a tensor, let $Y\in M_d(\C)$, and write a physical index of
     $A^{[L+1]}$ as $I=(i_0,\ldots,i_L)$.  Define the induced matrix on the
@@ -346,10 +347,9 @@
     remaining letters of the first block prepended to the flattened tail.
 
     For the converse, put $\Delta^i=(YA)^i-(ZA)^i$.  Equality after blocking
-    gives
+    gives, for every word $w$ of length $L$,
     \[
-        \Delta^i A^w=0
-        \qquad (|w|=L).
+        \Delta^i A^w=0.
     \]
     Since the length-$L$ words span $\MN{D}$, the same equality holds with
     $A^w$ replaced by the identity, and therefore $\Delta^i=0$ for every

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -303,6 +303,7 @@
     \label{lem:first_site_action_physical_blocking}
     \lean{MPSTensor.firstSiteActionOnBlock}
     \lean{MPSTensor.firstSiteActionAgree_iff_trace}
+    \lean{MPSTensor.FirstSiteActionAgree.trace_evalWord}
     \lean{MPSTensor.insertedTensor_firstSiteActionOnBlock_blockTensor}
     \lean{MPSTensor.FirstSiteActionAgree.blockTensor}
     \lean{MPSTensor.insertedTensor_eq_of_firstSiteActionOnBlock_blockTensor_eq}

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -299,29 +299,38 @@
     first-site hypothesis to the sector-decomposition tensor.
 \end{proof}
 
+\begin{definition}[First-site action on a physical block]
+    \label{def:first_site_action_physical_blocking}
+    \lean{MPSTensor.firstSiteActionOnBlock}
+    \leanok
+    \uses{def:blocked_tensor}
+    Let $Y\in M_d(\C)$, and write physical indices of an $(L+1)$-site block
+    as $I=(i_0,\ldots,i_L)$ and $J=(j_0,\ldots,j_L)$.  The induced matrix on
+    the blocked physical space is
+    \[
+        Y^{[L+1]}_{I,J}
+        =Y_{i_0,j_0}\prod_{k=1}^{L}\delta_{i_k,j_k}.
+    \]
+\end{definition}
+
 \begin{lemma}[First-site actions under physical blocking]
     \label{lem:first_site_action_physical_blocking}
-    \lean{MPSTensor.firstSiteActionOnBlock}
     \lean{MPSTensor.firstSiteActionAgree_iff_trace}
     \lean{MPSTensor.FirstSiteActionAgree.trace_evalWord}
     \lean{MPSTensor.insertedTensor_firstSiteActionOnBlock_blockTensor}
     \lean{MPSTensor.FirstSiteActionAgree.blockTensor}
     \lean{MPSTensor.insertedTensor_eq_of_firstSiteActionOnBlock_blockTensor_eq}
     \leanok
-    \uses{def:blocked_tensor, def:l_blk_injective}
+    \uses{def:first_site_action_physical_blocking, def:blocked_tensor,
+        def:l_blk_injective}
     This auxiliary statement supplies the transport needed to combine the
     block-injectivity argument
     \cite[lines~318--345]{Cirac2016MPDO_arXiv} with Appendix~C.3, Lemma~L
     \cite[lines~1835--1858]{Cirac2016MPDO_arXiv}.
 
-    Let $A$ be a tensor, let $Y\in M_d(\C)$, and write a physical index of
-    $A^{[L+1]}$ as $I=(i_0,\ldots,i_L)$.  Define the induced matrix on the
-    blocked physical space by
-    \[
-        Y^{[L+1]}_{I,J}
-        =Y_{i_0,j_0}\prod_{k=1}^{L}\delta_{i_k,j_k}.
-    \]
-    Its insertion into the blocked tensor satisfies
+    Let $A$ be a tensor, and let $Y^{[L+1]}$ be the physical-block action
+    induced by $Y\in M_d(\C)$.  For $I=(i_0,\ldots,i_L)$, its insertion into
+    the blocked tensor satisfies
     \[
         \bigl(Y^{[L+1]}A^{[L+1]}\bigr)^I
         =(YA)^{i_0}A^{i_1}\cdots A^{i_L}.

--- a/docs/paper-gaps/cpgsv17_bicf_block_separation.tex
+++ b/docs/paper-gaps/cpgsv17_bicf_block_separation.tex
@@ -127,46 +127,67 @@ normal tensors in the sense of the source characterization.
 
 \section{Consequence for Lemma L}
 
-The same counterexample marks a restriction one level up, in the consumer of
-\texttt{biCF}. The source's Lemma L (Appendix~C.3,
-lines~1835--1858 of the local source) separates blockwise contributions at
-the level of a minimal basis of normal tensors: writing the canonical-form
-decomposition as $\bigoplus_{j,q}\mu_{j,q}X_{j,q}A_jX_{j,q}^{-1}$, with $j$
-ranging over the minimal representatives and $q$ over the gauge-equivalent
-copies of each, the proof groups by $j$ and disposes of the weight sum
-$\sum_q\mu_{j,q}^N$ by the nonvanishing power-sum step of Lemma~app\_simple
-(lines~1858 and the appendix lemma it cites). No hypothesis beyond canonical
-form is used: the minimal-basis characterization already excludes distinct
-$j$'s from being gauge-equivalent, so the grouped separation needs no
-additional data.
+The same counterexample marks the restriction in the older theorem
+\texttt{blockwise\_insert\_eq\_of\_mpv\_agree}, which assumes
+\texttt{biCF} on the full family of copies.  The source's Lemma L
+(Appendix~C.3, lines~1835--1858) instead writes the canonical-form tensor as
+$\bigoplus_{j,q}\mu_{j,q}X_{j,q}A_jX_{j,q}^{-1}$, groups all copies over the
+same minimal representative $A_j$, and obtains the coefficient
+$c_j^{(N)}=\sum_q\mu_{j,q}^N$.  The nonvanishing power-sum lemma then supplies
+a length at which $c_j^{(N)}\ne0$.
 
-The formal \texttt{blockwise\_insert\_eq\_of\_mpv\_agree} instead demands
-\texttt{biCF} directly on the full per-block family, with no grouping by
-representative. Since \texttt{biCF} fails exactly on gauge-equivalent copies
-(the counterexample above), any decomposition containing two or more copies
-of one normal tensor is excluded from the current theorem's scope, even
-though the source's Lemma L covers it. The current formalization is
-therefore restricted to multiplicity-free horizontal decompositions.
+This representative-grouped argument is now formalized.  At a fixed length,
+simultaneous word-tuple separation of the representatives forces
+$c_j^{(N)}(YA_j-ZA_j)=0$ for every $j$; the bounded nonvanishing power-sum
+argument then gives $YA_j=ZA_j$.  A second theorem proves the required
+eventual word-tuple separation when the BNT representatives have already been
+blocked to become injective.  Thus multiplicities and unequal nonzero copy
+weights are no longer an obstruction to the formal Lemma L argument.
+
+The first-site action has also been transported through physical blocking.
+For a block $I=(i_0,\ldots,i_L)$, the induced matrix is
+\[
+  Y^{[L+1]}_{I,J}=Y_{i_0,j_0}\prod_{k=1}^{L}\delta_{i_k,j_k},
+\]
+and its insertion satisfies
+\[
+  \bigl(Y^{[L+1]}A^{[L+1]}\bigr)^I
+  =(YA)^{i_0}A^{i_1}\cdots A^{i_L}.
+\]
+Consequently, an all-length first-site equality before blocking gives the
+corresponding equality after blocking.  Conversely, if the length-$L$ words
+of $A$ span the full matrix algebra, equality of the two blocked insertions
+implies $YA=ZA$.  These auxiliary statements provide the transport needed
+to combine the source's block-injectivity argument with Lemma L; they
+introduce no additional hypothesis beyond block injectivity for the
+converse.
 
 \section{Conclusion}
 
-The conclusion is provisional and should not be read as a source erratum.
-The formal statements replace the paper's finite-length block-separation theorem
-by explicit finite-length span, linear-independence, or selector hypotheses. A
-small counterexample shows that those hypotheses cannot be derived from the
-weaker assumptions alone. The full source theorem remains plausible under the
-actual canonical-form and minimal basis-of-normal-tensors hypotheses. The same
-example additionally marks \texttt{blockwise\_insert\_eq\_of\_mpv\_agree} as
-restricted to multiplicity-free decompositions until the representative-level
-grouping is formalized.
+The conclusion is provisional and should not be read as a source erratum.  A
+small counterexample shows only that per-copy blockwise injectivity,
+left-canonicality, and nonzero weights do not imply simultaneous separation.
+It does not satisfy the source's minimal-representative condition.
 
-What remains to be formalized is the David2006/Cirac--Perez-Garcia--Schuch--Verstraete 2017 finite-length
-block-separation argument: from minimality of the basis-of-normal-tensors blocks,
-together with single-block injectivity after Wielandt blocking, one must produce
-a common finite selector or entrywise linear-independence witness, with the
-paper's bound $3(L+1)(D-1)$ and hence the stated $3D^5$ corollary. Until that
-argument is available, the finite-length witness should remain an explicit
-hypothesis.
+The remaining task for the source-level Lemma L is to compose the results
+above with the canonical-form construction.  One should choose a common
+positive $L$ for which every normal BNT representative is $L$-block
+injective, propagate exact word-span to length $L+1$, and identify the sector
+decomposition and powered copy weights after blocking $L+1$ sites.  The
+representative-separation theorem then applies to that blocked decomposition,
+while the original length-$L$ span gives the converse blocking step.  This
+propagation is essential: recovery from a physical block of length $L+1$ uses
+the span of its length-$L$ tail.  The flattened
+\texttt{HorizontalCFData} formulation must then be replaced, or related
+explicitly, by this representative-indexed statement.  The older per-copy
+\texttt{biCF} theorem remains a correct restricted result, but it is no longer
+the intended route to Lemma L.
+
+Separately, the numerical bound in the full block-injectivity proposition still
+requires the David2006 argument: from minimality of the basis of normal tensors
+and single-block injectivity after Wielandt blocking, produce a common selector
+with length $3(L+1)(D-1)$ and hence the stated $3D^5$ bound.  The source-level
+Lemma L needs the existence of a suitable finite length, not this sharp bound.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Mathematical statement

For a physical block of length L+1, define the induced matrix to act by Y on the first letter and by the identity on the remaining L letters. Its insertion into the blocked tensor is

    (Y^[L+1] A^[L+1])^I = (YA)^{i_0} A^{i_1} ... A^{i_L}.

Consequently, an all-length first-site MPV identity transports from A to its (L+1)-site blocking. Conversely, if the length-L words of A span the full matrix algebra, equality of the induced blocked insertion tensors implies YA = ZA.

## Source and scope

This is an auxiliary transport for combining the block-injectivity argument at arXiv:1606.00608, lines 318–345, with Appendix C.3, Lemma L, lines 1835–1858. It does not complete Lemma L: compatible canonical-form blocking, powered copy weights, representative-level separation, and the bridge to HorizontalCFData remain open in #3713.

## Changes

- define the induced first-letter action on a physical block;
- characterize first-site agreement by trace pairings;
- prove the blocked insertion identity and forward transport;
- prove the block-injective converse;
- add the supporting blueprint entry and update the paper-gap status.

## Verification

- lake build
- targeted Lean check of FirstSiteBlocking.lean
- blueprint–Lean synchronization and reverse declaration coverage
- checkdecls
- reader-facing prose check
- proof-integrity scan
- #print axioms on both capstone theorems: only propext, Classical.choice, and Quot.sound; no new axiom

Advances #3713. Prerequisite for #3674. Tracked by #2380 and #232.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal mathematics (new lemmas, imports, blueprint and gap-note prose) with no runtime, auth, or data-handling impact.
> 
> **Overview**
> Adds **`TNLean/MPS/MPDO/FirstSiteBlocking.lean`**, wiring first-site MPV identities to physical blocking for the CPGSV17 block-injectivity / Lemma L pipeline.
> 
> It defines **`firstSiteActionOnBlock`** (act on the first letter of an \((L+1)\)-site block, identity on the tail), proves the blocked insertion factorization, equivalence of **`FirstSiteActionAgree`** with trace pairings, forward transport of first-site agreement under **`blockTensor`**, and the converse **`insertedTensor_eq_of_firstSiteActionOnBlock_blockTensor_eq`** when length-\(L\) words span the matrix algebra (**`IsNBlkInjective`**). The module is exported from **`TNLean.lean`**.
> 
> The blueprint gains **Definition** and **Lemma** for first-site actions under physical blocking; **`docs/paper-gaps/cpgsv17_bicf_block_separation.tex`** is updated to note representative-grouped Lemma L is formalized and that this blocking transport is the intended glue (full Lemma L composition with canonical-form blocking remains open).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 193ca3290b6ebf03190f43fad2757d27d483c5d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->