### PR TITLE
feat(MPS/MPDO): formalize printed zipper F-move

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -458,6 +458,8 @@ import TNLean.MPS.MPDO.BNTFinalSectorFusion
 import TNLean.MPS.MPDO.BNTFourfoldFusionIndices
 import TNLean.MPS.MPDO.BNTTripleFusionSeparation
 import TNLean.MPS.MPDO.BNTFixedFinalUnitarity
+import TNLean.MPS.MPDO.CompleteZipperFusion
+import TNLean.MPS.MPDO.CompleteZipperFusionInverse
 import TNLean.MPS.MPDO.CommutingForm
 import TNLean.MPS.MPDO.CommutingFormBridge
 import TNLean.MPS.MPDO.BlockedRFPConstruction

--- a/TNLean/MPS/MPDO/CompleteZipperFusion.lean
+++ b/TNLean/MPS/MPDO/CompleteZipperFusion.lean
@@ -1,0 +1,469 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.CompleteZipperFusionSupport
+
+/-!
+# The printed F-move
+
+This file constructs the printed-orientation F-move after the equality of the
+left- and right-associated product-MPO supports has been derived from the
+source hypotheses.
+-/
+
+open scoped Matrix BigOperators Kronecker
+open Matrix
+
+namespace MPOTensor
+
+universe u
+
+namespace CompleteZipperFusionFamily
+
+variable {Λ : Type u} [Fintype Λ] [DecidableEq Λ] {p : ℕ}
+variable (Fus : CompleteZipperFusionFamily Λ p)
+
+/-- The source-oriented full change of triple-fusion basis.  It maps the
+left-associated fusion coordinates to the right-associated fusion coordinates.
+
+Its orientation is opposite to `BNTFusionIsometryFamily.tripleFusionComparison`:
+the rows are right-tree coordinates and the columns are left-tree coordinates.
+
+Source: arXiv:1511.08090, equation `Fmove`, lines 248--251. -/
+noncomputable def fullPrintedFMatrix (a b c : Λ) :
+    Matrix (Fus.RightTripleIndex a b c) (Fus.LeftTripleIndex a b c) ℂ :=
+  Fus.rightTripleAnalysisFull a b c * Fus.leftTripleSynthesisFull a b c
+
+/-- The source-oriented full comparison intertwines the two direct sums of
+final-block letters.
+
+Source: arXiv:1511.08090, equations `zippercondition2`, `pentagon3`, and the
+argument at lines 247--277. -/
+theorem rightTripleDirectSumLetter_mul_fullPrintedFMatrix
+    (a b c : Λ) (i l : Fin p) :
+    Fus.rightTripleDirectSumLetter a b c i l * Fus.fullPrintedFMatrix a b c =
+      Fus.fullPrintedFMatrix a b c * Fus.leftTripleDirectSumLetter a b c i l := by
+  unfold fullPrintedFMatrix
+  calc
+    Fus.rightTripleDirectSumLetter a b c i l *
+          (Fus.rightTripleAnalysisFull a b c * Fus.leftTripleSynthesisFull a b c) =
+        (Fus.rightTripleDirectSumLetter a b c i l *
+          Fus.rightTripleAnalysisFull a b c) * Fus.leftTripleSynthesisFull a b c := by
+      rw [Matrix.mul_assoc]
+    _ = (Fus.rightTripleAnalysisFull a b c * Fus.tripleProductLetter a b c i l) *
+        Fus.leftTripleSynthesisFull a b c := by
+      rw [Fus.rightTripleAnalysisFull_mul_tripleProductLetter]
+    _ = Fus.rightTripleAnalysisFull a b c *
+        (Fus.tripleProductLetter a b c i l * Fus.leftTripleSynthesisFull a b c) := by
+      rw [Matrix.mul_assoc]
+    _ = Fus.rightTripleAnalysisFull a b c *
+        (Fus.leftTripleSynthesisFull a b c *
+          Fus.leftTripleDirectSumLetter a b c i l) := by
+      rw [Fus.tripleProductLetter_mul_leftTripleSynthesisFull]
+    _ = (Fus.rightTripleAnalysisFull a b c * Fus.leftTripleSynthesisFull a b c) *
+        Fus.leftTripleDirectSumLetter a b c i l := by
+      rw [Matrix.mul_assoc]
+
+/-- The full source-oriented comparison carries the right-associated synthesis
+map to the left-associated synthesis map. -/
+theorem rightTripleSynthesisFull_mul_fullPrintedFMatrix (a b c : Λ) :
+    Fus.rightTripleSynthesisFull a b c * Fus.fullPrintedFMatrix a b c =
+      Fus.leftTripleSynthesisFull a b c := by
+  unfold fullPrintedFMatrix
+  calc
+    Fus.rightTripleSynthesisFull a b c *
+          (Fus.rightTripleAnalysisFull a b c * Fus.leftTripleSynthesisFull a b c) =
+        (Fus.rightTripleSynthesisFull a b c *
+          Fus.rightTripleAnalysisFull a b c) * Fus.leftTripleSynthesisFull a b c := by
+      rw [Matrix.mul_assoc]
+    _ = (Fus.leftTripleSynthesisFull a b c *
+          Fus.leftTripleAnalysisFull a b c) * Fus.leftTripleSynthesisFull a b c := by
+      rw [Fus.leftTripleSupport_eq_rightTripleSupport]
+    _ = Fus.leftTripleSynthesisFull a b c *
+        (Fus.leftTripleAnalysisFull a b c * Fus.leftTripleSynthesisFull a b c) := by
+      rw [Matrix.mul_assoc]
+    _ = Fus.leftTripleSynthesisFull a b c := by
+      rw [Fus.leftTripleAnalysisFull_mul_synthesis, Matrix.mul_one]
+
+/-- The full comparison in the opposite orientation. -/
+noncomputable def fullInversePrintedFMatrix (a b c : Λ) :
+    Matrix (Fus.LeftTripleIndex a b c) (Fus.RightTripleIndex a b c) ℂ :=
+  Fus.leftTripleAnalysisFull a b c * Fus.rightTripleSynthesisFull a b c
+
+/-- The two full comparison matrices are inverse in this order. -/
+theorem fullPrintedFMatrix_mul_fullInversePrintedFMatrix (a b c : Λ) :
+    Fus.fullPrintedFMatrix a b c * Fus.fullInversePrintedFMatrix a b c = 1 := by
+  unfold fullPrintedFMatrix fullInversePrintedFMatrix
+  calc
+    (Fus.rightTripleAnalysisFull a b c * Fus.leftTripleSynthesisFull a b c) *
+          (Fus.leftTripleAnalysisFull a b c * Fus.rightTripleSynthesisFull a b c) =
+        Fus.rightTripleAnalysisFull a b c *
+          ((Fus.leftTripleSynthesisFull a b c *
+            Fus.leftTripleAnalysisFull a b c) *
+              Fus.rightTripleSynthesisFull a b c) := by
+      simp only [Matrix.mul_assoc]
+    _ = Fus.rightTripleAnalysisFull a b c *
+          ((Fus.rightTripleSynthesisFull a b c *
+            Fus.rightTripleAnalysisFull a b c) *
+              Fus.rightTripleSynthesisFull a b c) := by
+      rw [Fus.leftTripleSupport_eq_rightTripleSupport]
+    _ = Fus.rightTripleAnalysisFull a b c *
+        (Fus.rightTripleSynthesisFull a b c *
+          (Fus.rightTripleAnalysisFull a b c *
+            Fus.rightTripleSynthesisFull a b c)) := by
+      simp only [Matrix.mul_assoc]
+    _ = 1 := by
+      rw [Fus.rightTripleAnalysisFull_mul_synthesis, Matrix.mul_one,
+        Fus.rightTripleAnalysisFull_mul_synthesis]
+
+/-- The two full comparison matrices are inverse in the other order. -/
+theorem fullInversePrintedFMatrix_mul_fullPrintedFMatrix (a b c : Λ) :
+    Fus.fullInversePrintedFMatrix a b c * Fus.fullPrintedFMatrix a b c = 1 := by
+  unfold fullPrintedFMatrix fullInversePrintedFMatrix
+  calc
+    (Fus.leftTripleAnalysisFull a b c * Fus.rightTripleSynthesisFull a b c) *
+          (Fus.rightTripleAnalysisFull a b c * Fus.leftTripleSynthesisFull a b c) =
+        Fus.leftTripleAnalysisFull a b c *
+          ((Fus.rightTripleSynthesisFull a b c *
+            Fus.rightTripleAnalysisFull a b c) *
+              Fus.leftTripleSynthesisFull a b c) := by
+      simp only [Matrix.mul_assoc]
+    _ = Fus.leftTripleAnalysisFull a b c *
+          ((Fus.leftTripleSynthesisFull a b c *
+            Fus.leftTripleAnalysisFull a b c) *
+              Fus.leftTripleSynthesisFull a b c) := by
+      rw [← Fus.leftTripleSupport_eq_rightTripleSupport]
+    _ = Fus.leftTripleAnalysisFull a b c *
+        (Fus.leftTripleSynthesisFull a b c *
+          (Fus.leftTripleAnalysisFull a b c *
+            Fus.leftTripleSynthesisFull a b c)) := by
+      simp only [Matrix.mul_assoc]
+    _ = 1 := by
+      rw [Fus.leftTripleAnalysisFull_mul_synthesis, Matrix.mul_one,
+        Fus.leftTripleAnalysisFull_mul_synthesis]
+
+/-- Include a fixed final label in the right-associated full coordinate space. -/
+def rightFinalRow (a b c d : Λ) :
+    Fus.RightTripleMultiplicity a b c d × Fin (Fus.bondDim d) →
+      Fus.RightTripleIndex a b c :=
+  fun x => ⟨d, x⟩
+
+/-- Include a fixed final label in the left-associated full coordinate space. -/
+def leftFinalRow (a b c d : Λ) :
+    Fus.LeftTripleMultiplicity a b c d × Fin (Fus.bondDim d) →
+      Fus.LeftTripleIndex a b c :=
+  fun x => ⟨d, x⟩
+
+/-- The one-letter coefficient which selects the block with final label `d`.
+
+Source: arXiv:1511.08090, the simultaneous inverse at lines 269--277. -/
+private noncomputable def finalBlockSelector (d : Λ) (ik : Fin p × Fin p) : ℂ :=
+  ∑ x : Fin (Fus.bondDim d), Fus.blockLeftInverse ⟨d, x, x⟩ ik
+
+private theorem finalBlockSelector_apply (d e : Λ)
+    (x y : Fin (Fus.bondDim e)) :
+    (∑ i : Fin p, ∑ k : Fin p,
+      Fus.finalBlockSelector d (i, k) * Fus.tensor e i k x y) =
+      if h : d = e then if _ : h ▸ x = y then 1 else 0 else 0 := by
+  classical
+  simp only [finalBlockSelector, Finset.sum_mul]
+  calc
+    (∑ i : Fin p, ∑ k : Fin p, ∑ z : Fin (Fus.bondDim d),
+        Fus.blockLeftInverse ⟨d, z, z⟩ (i, k) * Fus.tensor e i k x y) =
+        ∑ z : Fin (Fus.bondDim d), ∑ i : Fin p, ∑ k : Fin p,
+          Fus.blockLeftInverse ⟨d, z, z⟩ (i, k) * Fus.tensor e i k x y := by
+      calc
+        _ = ∑ i : Fin p, ∑ z : Fin (Fus.bondDim d), ∑ k : Fin p,
+            Fus.blockLeftInverse ⟨d, z, z⟩ (i, k) * Fus.tensor e i k x y := by
+          apply Finset.sum_congr rfl
+          intro i hi
+          exact Finset.sum_comm
+        _ = _ := Finset.sum_comm
+    _ = if h : d = e then if _ : h ▸ x = y then 1 else 0 else 0 := by
+      by_cases h : d = e
+      · subst e
+        simp_rw [Fus.blockLeftInverse_apply d d]
+        simp
+      · simp_rw [Fus.blockLeftInverse_apply d e]
+        simp [h]
+
+private theorem finalBlockSelector_sum (d e : Λ) :
+    (∑ i : Fin p, ∑ k : Fin p,
+      Fus.finalBlockSelector d (i, k) •
+        (Fus.tensor e i k : Matrix (Fin (Fus.bondDim e))
+          (Fin (Fus.bondDim e)) ℂ)) =
+      if d = e then 1 else 0 := by
+  classical
+  funext x y
+  simp only [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
+  rw [Fus.finalBlockSelector_apply d e x y]
+  by_cases h : d = e
+  · subst e
+    simp [Matrix.one_apply]
+  · simp [h]
+
+private theorem rectangularIntertwiner_eq_zero (d e : Λ) (hde : d ≠ e)
+    (C : Matrix (Fin (Fus.bondDim d)) (Fin (Fus.bondDim e)) ℂ)
+    (hC : ∀ (i k : Fin p), Fus.tensor d i k * C = C * Fus.tensor e i k) :
+    C = 0 := by
+  classical
+  calc
+    C = (1 : Matrix (Fin (Fus.bondDim d)) (Fin (Fus.bondDim d)) ℂ) * C := by
+      rw [Matrix.one_mul]
+    _ = (∑ i : Fin p, ∑ k : Fin p,
+          Fus.finalBlockSelector d (i, k) • Fus.tensor d i k) * C := by
+      rw [Fus.finalBlockSelector_sum d d]
+      simp
+    _ = ∑ i : Fin p, ∑ k : Fin p,
+          (Fus.finalBlockSelector d (i, k) • Fus.tensor d i k) * C := by
+      rw [Matrix.sum_mul]
+      congr 1
+      funext i
+      rw [Matrix.sum_mul]
+    _ = ∑ i : Fin p, ∑ k : Fin p,
+          C * (Fus.finalBlockSelector d (i, k) • Fus.tensor e i k) := by
+      apply Finset.sum_congr rfl
+      intro i hi
+      apply Finset.sum_congr rfl
+      intro k hk
+      rw [Matrix.smul_mul, Matrix.mul_smul, hC]
+    _ = C * (∑ i : Fin p, ∑ k : Fin p,
+          Fus.finalBlockSelector d (i, k) • Fus.tensor e i k) := by
+      rw [Matrix.mul_sum]
+      congr 1
+      funext i
+      rw [Matrix.mul_sum]
+    _ = C * (0 : Matrix (Fin (Fus.bondDim e)) (Fin (Fus.bondDim e)) ℂ) := by
+      rw [Fus.finalBlockSelector_sum d e, if_neg hde]
+    _ = 0 := Matrix.mul_zero C
+
+/-- The bond-amplified corner of the printed comparison at a fixed final label. -/
+noncomputable def printedFMatrixAmplified (a b c d : Λ) :
+    Matrix (Fus.RightTripleMultiplicity a b c d × Fin (Fus.bondDim d))
+      (Fus.LeftTripleMultiplicity a b c d × Fin (Fus.bondDim d)) ℂ :=
+  (Fus.fullPrintedFMatrix a b c).submatrix
+    (Fus.rightFinalRow a b c d) (Fus.leftFinalRow a b c d)
+
+/-- The full printed comparison has no corner between distinct final labels.
+
+The simultaneous inverse of the block letters extracts the identity in one
+final block and zero in every other block.
+
+Source: arXiv:1511.08090, the simultaneous inverse and fixed-final extraction
+at lines 269--277. -/
+theorem fullPrintedFMatrix_finalSector_eq_zero
+    (a b c d d' : Λ) (hdd' : d ≠ d') :
+    (Fus.fullPrintedFMatrix a b c).submatrix
+      (Fus.rightFinalRow a b c d) (Fus.leftFinalRow a b c d') = 0 := by
+  funext x y
+  rcases x with ⟨mR, x⟩
+  rcases y with ⟨mL, y⟩
+  rcases mR with ⟨f, l, s⟩
+  rcases mL with ⟨e, μ, ν⟩
+  let mR : Fus.RightTripleMultiplicity a b c d := ⟨f, l, s⟩
+  let mL : Fus.LeftTripleMultiplicity a b c d' := ⟨e, μ, ν⟩
+  let C : Matrix (Fin (Fus.bondDim d)) (Fin (Fus.bondDim d')) ℂ :=
+    fun u v => Fus.fullPrintedFMatrix a b c
+      (Fus.rightFinalRow a b c d ⟨mR, u⟩)
+      (Fus.leftFinalRow a b c d' ⟨mL, v⟩)
+  have hC : ∀ (i k : Fin p), Fus.tensor d i k * C = C * Fus.tensor d' i k := by
+    intro i k
+    funext u v
+    have hFull := Fus.rightTripleDirectSumLetter_mul_fullPrintedFMatrix a b c i k
+    have hEntry := congrArg
+      (fun M => M (Fus.rightFinalRow a b c d ⟨mR, u⟩)
+        (Fus.leftFinalRow a b c d' ⟨mL, v⟩)) hFull
+    have hLeft :
+        (Fus.rightTripleDirectSumLetter a b c i k *
+          Fus.fullPrintedFMatrix a b c)
+            (Fus.rightFinalRow a b c d ⟨mR, u⟩)
+            (Fus.leftFinalRow a b c d' ⟨mL, v⟩) =
+          ∑ z : Fin (Fus.bondDim d), Fus.tensor d i k u z *
+            Fus.fullPrintedFMatrix a b c
+              (Fus.rightFinalRow a b c d ⟨mR, z⟩)
+              (Fus.leftFinalRow a b c d' ⟨mL, v⟩) := by
+      rw [Matrix.mul_apply, Fintype.sum_sigma]
+      rw [Finset.sum_eq_single d
+        (fun q _ hq => Finset.sum_eq_zero fun z _ => by
+          rw [rightTripleDirectSumLetter, rightFinalRow,
+            Matrix.blockDiagonal'_apply_ne _ _ _ (Ne.symm hq), zero_mul])
+        (fun h => absurd (Finset.mem_univ d) h)]
+      rw [Fintype.sum_prod_type]
+      rw [Finset.sum_eq_single mR
+        (fun q _ hq => Finset.sum_eq_zero fun z _ => by
+          rw [rightTripleDirectSumLetter, rightFinalRow,
+            Matrix.blockDiagonal'_apply_eq]
+          simp only [kroneckerMap_apply, Matrix.one_apply,
+            if_neg (Ne.symm hq), zero_mul])
+        (fun h => absurd (Finset.mem_univ mR) h)]
+      refine Finset.sum_congr rfl fun z _ => ?_
+      simp [rightTripleDirectSumLetter, rightFinalRow, leftFinalRow,
+        Matrix.blockDiagonal'_apply_eq]
+    have hRight :
+        (Fus.fullPrintedFMatrix a b c * Fus.leftTripleDirectSumLetter a b c i k)
+            (Fus.rightFinalRow a b c d ⟨mR, u⟩)
+            (Fus.leftFinalRow a b c d' ⟨mL, v⟩) =
+          ∑ z : Fin (Fus.bondDim d'),
+            Fus.fullPrintedFMatrix a b c
+              (Fus.rightFinalRow a b c d ⟨mR, u⟩)
+              (Fus.leftFinalRow a b c d' ⟨mL, z⟩) *
+                Fus.tensor d' i k z v := by
+      rw [Matrix.mul_apply, Fintype.sum_sigma]
+      rw [Finset.sum_eq_single d'
+        (fun q _ hq => Finset.sum_eq_zero fun z _ => by
+          rw [leftTripleDirectSumLetter, leftFinalRow,
+            Matrix.blockDiagonal'_apply_ne _ _ _ hq, mul_zero])
+        (fun h => absurd (Finset.mem_univ d') h)]
+      rw [Fintype.sum_prod_type]
+      rw [Finset.sum_eq_single mL
+        (fun q _ hq => Finset.sum_eq_zero fun z _ => by
+          simp [leftTripleDirectSumLetter, rightFinalRow, leftFinalRow,
+            Matrix.blockDiagonal'_apply_eq, hq])
+        (fun h => absurd (Finset.mem_univ mL) h)]
+      refine Finset.sum_congr rfl fun z _ => ?_
+      simp [leftTripleDirectSumLetter, rightFinalRow, leftFinalRow,
+        Matrix.blockDiagonal'_apply_eq]
+    exact hLeft.symm.trans (hEntry.trans hRight)
+  have hZero := Fus.rectangularIntertwiner_eq_zero d d' hdd' C hC
+  exact congrArg (fun M => M x y) hZero
+
+/-- The fixed-final corner of the printed comparison acts only on fusion
+multiplicity coordinates.
+
+Source: arXiv:1511.08090, the injectivity argument and tensor-factor
+conclusion at lines 269--277. -/
+theorem exists_printedFMatrixAmplified_eq_kronecker_one (a b c d : Λ) :
+    ∃ F : Matrix (Fus.RightTripleMultiplicity a b c d)
+        (Fus.LeftTripleMultiplicity a b c d) ℂ,
+      Fus.printedFMatrixAmplified a b c d =
+        F ⊗ₖ (1 : Matrix (Fin (Fus.bondDim d)) (Fin (Fus.bondDim d)) ℂ) := by
+  apply Matrix.exists_eq_kronecker_one_of_intertwines_span_eq_top
+    (Fus.tensor d).toMPSTensor (Fus.printedFMatrixAmplified a b c d)
+    (Fus.tensor_injective d).span_eq_top
+  intro ij
+  obtain ⟨⟨i, k⟩, rfl⟩ := finProdFinEquiv.surjective ij
+  have hFull := Fus.rightTripleDirectSumLetter_mul_fullPrintedFMatrix a b c i k
+  funext x y
+  rcases x with ⟨mR, x⟩
+  rcases y with ⟨mL, y⟩
+  have hEntry := congrArg
+    (fun M => M (Fus.rightFinalRow a b c d ⟨mR, x⟩)
+      (Fus.leftFinalRow a b c d ⟨mL, y⟩)) hFull
+  have hLeft :
+      (Fus.rightTripleDirectSumLetter a b c i k * Fus.fullPrintedFMatrix a b c)
+          (Fus.rightFinalRow a b c d ⟨mR, x⟩)
+          (Fus.leftFinalRow a b c d ⟨mL, y⟩) =
+        ∑ z : Fin (Fus.bondDim d), Fus.tensor d i k x z *
+          Fus.fullPrintedFMatrix a b c
+            (Fus.rightFinalRow a b c d ⟨mR, z⟩)
+            (Fus.leftFinalRow a b c d ⟨mL, y⟩) := by
+    rw [Matrix.mul_apply, Fintype.sum_sigma]
+    rw [Finset.sum_eq_single d
+      (fun q _ hq => Finset.sum_eq_zero fun z _ => by
+        rw [rightTripleDirectSumLetter, rightFinalRow,
+          Matrix.blockDiagonal'_apply_ne _ _ _ (Ne.symm hq), zero_mul])
+      (fun h => absurd (Finset.mem_univ d) h)]
+    rw [Fintype.sum_prod_type]
+    rw [Finset.sum_eq_single mR
+      (fun q _ hq => Finset.sum_eq_zero fun z _ => by
+        rw [rightTripleDirectSumLetter, rightFinalRow,
+          Matrix.blockDiagonal'_apply_eq]
+        simp only [kroneckerMap_apply, Matrix.one_apply,
+          if_neg (Ne.symm hq), zero_mul])
+      (fun h => absurd (Finset.mem_univ mR) h)]
+    refine Finset.sum_congr rfl fun z _ => ?_
+    simp [rightTripleDirectSumLetter, rightFinalRow, leftFinalRow,
+      Matrix.blockDiagonal'_apply_eq]
+  have hRight :
+      (Fus.fullPrintedFMatrix a b c * Fus.leftTripleDirectSumLetter a b c i k)
+          (Fus.rightFinalRow a b c d ⟨mR, x⟩)
+          (Fus.leftFinalRow a b c d ⟨mL, y⟩) =
+        ∑ z : Fin (Fus.bondDim d),
+          Fus.fullPrintedFMatrix a b c
+            (Fus.rightFinalRow a b c d ⟨mR, x⟩)
+            (Fus.leftFinalRow a b c d ⟨mL, z⟩) * Fus.tensor d i k z y := by
+    rw [Matrix.mul_apply, Fintype.sum_sigma]
+    rw [Finset.sum_eq_single d
+      (fun q _ hq => Finset.sum_eq_zero fun z _ => by
+        rw [leftTripleDirectSumLetter, leftFinalRow,
+          Matrix.blockDiagonal'_apply_ne _ _ _ hq, mul_zero])
+      (fun h => absurd (Finset.mem_univ d) h)]
+    rw [Fintype.sum_prod_type]
+    rw [Finset.sum_eq_single mL
+      (fun q _ hq => Finset.sum_eq_zero fun z _ => by
+        simp [leftTripleDirectSumLetter, rightFinalRow, leftFinalRow,
+          Matrix.blockDiagonal'_apply_eq, hq])
+      (fun h => absurd (Finset.mem_univ mL) h)]
+    refine Finset.sum_congr rfl fun z _ => ?_
+    simp [leftTripleDirectSumLetter, rightFinalRow, leftFinalRow,
+      Matrix.blockDiagonal'_apply_eq]
+  have hSimple := hLeft.symm.trans (hEntry.trans hRight)
+  simpa [printedFMatrixAmplified, MPOTensor.toMPSTensor,
+    Matrix.submatrix_apply, Matrix.mul_apply, Fintype.sum_prod_type,
+    Matrix.one_apply] using hSimple
+
+/-- The printed $F$-matrix.  Its rows are the right-tree indices
+$(f,\lambda,\sigma)$ and its columns are the left-tree indices
+$(e,\mu,\nu)$.  It is the multiplicity factor of
+$R_d^+L_d$, where $R_d^+L_d$ acts as this matrix tensored with the identity on
+the final bond space.
+
+Source: arXiv:1511.08090, equation `Fmove`, lines 248--251, and the
+fixed-final extraction at lines 269--277. -/
+noncomputable def printedFMatrix (a b c d : Λ) :
+    Matrix (Fus.RightTripleMultiplicity a b c d)
+      (Fus.LeftTripleMultiplicity a b c d) ℂ :=
+  Classical.choose (Fus.exists_printedFMatrixAmplified_eq_kronecker_one a b c d)
+
+/-- The bond-amplified fixed-final comparison is the printed $F$-matrix
+tensored with the identity. -/
+theorem printedFMatrixAmplified_eq_kronecker_one (a b c d : Λ) :
+    Fus.printedFMatrixAmplified a b c d =
+      Fus.printedFMatrix a b c d ⊗ₖ
+        (1 : Matrix (Fin (Fus.bondDim d)) (Fin (Fus.bondDim d)) ℂ) :=
+  Classical.choose_spec (Fus.exists_printedFMatrixAmplified_eq_kronecker_one a b c d)
+
+/-- **The printed F-move.**  The left-associated triple fusion tensors are
+linear combinations of the right-associated triple fusion tensors:
+\[
+ (X^e_{ab,\mu}\otimes 1)X^d_{ec,\nu}
+ =\sum_{f,\lambda,\sigma}
+   (F^{abc}_d)^{f\lambda\sigma}_{e\mu\nu}
+   (1\otimes X^f_{bc,\lambda})X^d_{af,\sigma}.
+\]
+
+The statement assumes only the complete zipper fusion family above.  It does
+not use the length-independence, selector, or present-blocking hypotheses of
+the restricted positive-diagonal specialization.
+
+Source: arXiv:1511.08090, equation `Fmove`, lines 248--251, with the
+fixed-final argument at lines 252--277. -/
+theorem rightTripleSynthesis_mul_printedFMatrix (a b c d : Λ) :
+    Fus.rightTripleSynthesis a b c d *
+        (Fus.printedFMatrix a b c d ⊗ₖ
+          (1 : Matrix (Fin (Fus.bondDim d)) (Fin (Fus.bondDim d)) ℂ)) =
+      Fus.leftTripleSynthesis a b c d := by
+  rw [← Fus.printedFMatrixAmplified_eq_kronecker_one a b c d]
+  funext x y
+  have hFull := Fus.rightTripleSynthesisFull_mul_fullPrintedFMatrix a b c
+  have hEntry := congrArg
+    (fun M => M x (Fus.leftFinalRow a b c d y)) hFull
+  rw [Matrix.mul_apply, Fintype.sum_sigma] at hEntry
+  rw [Finset.sum_eq_single d
+    (fun e _ hed => Finset.sum_eq_zero fun q _ => by
+      have hZero : Fus.fullPrintedFMatrix a b c ⟨e, q⟩
+          (Fus.leftFinalRow a b c d y) = 0 := by
+        simpa [Matrix.submatrix_apply, rightFinalRow, leftFinalRow] using
+          congrArg (fun M => M q y)
+            (Fus.fullPrintedFMatrix_finalSector_eq_zero a b c e d hed)
+      rw [hZero, mul_zero])
+    (fun h => absurd (Finset.mem_univ d) h)] at hEntry
+  simpa [Matrix.mul_apply, printedFMatrixAmplified, Matrix.submatrix_apply,
+    rightTripleSynthesisFull, leftTripleSynthesisFull, rightFinalRow,
+    leftFinalRow] using hEntry
+
+end CompleteZipperFusionFamily
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/CompleteZipperFusionDefs.lean
+++ b/TNLean/MPS/MPDO/CompleteZipperFusionDefs.lean
@@ -1,0 +1,323 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.ScalarCommutant
+import TNLean.MPS.MPDO.OperatorProduct
+
+/-!
+# Complete zipper fusion and the printed F-move
+
+A complete zipper fusion family consists of injective MPO blocks, integer fusion
+multiplicities, fusion tensors, and independently specified left inverses.  The
+left inverses are biorthogonal to the fusion tensors.  The sum of the opposite
+products is the projector onto the product-MPO support, which need not be the
+identity on the ambient product bond space.  They satisfy the two zipper
+identities.  A common left inverse for the labelled MPO letters separates the
+final block.
+
+The two ways of fusing three blocks give coordinate systems for the same
+triple-product support.  The coordinate change from the left tree to the right
+tree is oriented as in equation `Fmove` of arXiv:1511.08090: its rows are
+indexed by the right tree and its columns by the left tree.  The resulting
+matrix carries the right-associated fusion tensors to the left-associated
+fusion tensors.  Its inverse has the opposite orientation.
+
+No construction of complete zipper fusion tensors from the positive diagonal
+matrices of arXiv:1606.00608 is asserted here.
+
+## Main definitions
+
+* `CompleteZipperFusionFamily`: complete fusion tensors and their left inverses.
+* `printedFMatrix`: the source-oriented fixed-final change of fusion basis.
+
+## Main statements
+
+* `rightTripleSynthesis_mul_printedFMatrix`: equation `Fmove`.
+* `printedFMatrix_mul_inversePrintedFMatrix`: the first inverse identity.
+* `inversePrintedFMatrix_mul_printedFMatrix`: the second inverse identity.
+
+## References
+
+* arXiv:1511.08090, `AnyonsPEPS.tex`, lines 161, 181--200, 237--283.
+-/
+
+open scoped Matrix BigOperators Kronecker
+open Matrix
+
+namespace MPOTensor
+
+universe u
+
+/-- Complete zipper fusion tensors for a finite family of injective MPO blocks.
+
+The synthesis matrix collects the tensors $X^c_{ab,\mu}$ as its columns, while
+the analysis matrix collects the independently chosen left inverses
+$X^{c+}_{ab,\mu}$ as its rows.  Their product in the coordinate space encodes
+$X^{d+}_{ab,\nu}X^c_{ab,\mu}=\delta_{cd}\delta_{\mu\nu}1$.  Their product in the
+ambient product space is only a support projector.  Equation `inversegaugeone`
+states that inserting this projector reconstructs every product-MPO letter.
+The two zipper identities are recorded in the orientations printed in the
+source.  The last two fields give the simultaneous left inverse of the family
+of block letters used to distinguish the final label.
+
+Source: arXiv:1511.08090, `AnyonsPEPS.tex`, line 161, equation
+`inversegaugeone` at lines 181--191, the zipper equations at lines 193--200,
+and the simultaneous inverse at lines 269--277. -/
+structure CompleteZipperFusionFamily (Λ : Type u) [Fintype Λ] [DecidableEq Λ]
+    (p : ℕ) where
+  /-- Bond dimension of the MPO block with label `a`.
+
+  Source: arXiv:1511.08090, `AnyonsPEPS.tex`, line 161. -/
+  bondDim : Λ → ℕ
+  /-- Every MPO block has a nonzero bond space.
+
+  Source: arXiv:1511.08090, `AnyonsPEPS.tex`, line 161. -/
+  bondDim_pos : ∀ a : Λ, 0 < bondDim a
+  /-- The injective MPO blocks $B_a^{ij}$.
+
+  Source: arXiv:1511.08090, `AnyonsPEPS.tex`, lines 156--163. -/
+  tensor : ∀ a : Λ, MPOTensor p (bondDim a)
+  /-- Each labelled MPO block is injective.
+
+  Source: arXiv:1511.08090, `AnyonsPEPS.tex`, lines 156--163 and the
+  injectivity argument at lines 269--277. -/
+  tensor_injective : ∀ a : Λ, MPSTensor.IsInjective (tensor a).toMPSTensor
+  /-- The fusion multiplicity $N_{ab}^c$.
+
+  Source: arXiv:1511.08090, `AnyonsPEPS.tex`, line 161. -/
+  fusionMultiplicity : Λ → Λ → Λ → ℕ
+  /-- The matrix whose columns are the fusion tensors $X^c_{ab,\mu}$.
+
+  **Local fix (arXiv:1511.08090, line 161):** The displayed arrow for $X$ in
+  the prose is reversed.  Equations `inversegaugeone`, `zippercondition`, and
+  `Fmove` fix the orientation used here.  This is documented in
+  `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`.
+
+  Source: arXiv:1511.08090, `AnyonsPEPS.tex`, lines 161--163 and 248--251. -/
+  fusionSynthesis : ∀ a b : Λ,
+    Matrix (Fin (bondDim a) × Fin (bondDim b))
+      ((c : Λ) × (Fin (fusionMultiplicity a b c) × Fin (bondDim c))) ℂ
+  /-- The matrix whose rows are the left inverses $X^{c+}_{ab,\mu}$.
+
+  Source: arXiv:1511.08090, `AnyonsPEPS.tex`, lines 161--163. -/
+  fusionAnalysis : ∀ a b : Λ,
+    Matrix ((c : Λ) × (Fin (fusionMultiplicity a b c) × Fin (bondDim c)))
+      (Fin (bondDim a) × Fin (bondDim b)) ℂ
+  /-- The fusion left inverses are biorthogonal to the fusion tensors.
+
+  **Local fix (arXiv:1511.08090, line 161):** The displayed Kronecker factor
+  is written as $\delta_{de}$ although no label $e$ occurs in the relation.
+  The typed relation is $\delta_{dc}$ (equivalently $\delta_{cd}$), as used
+  here.  This is documented in
+  `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`.
+
+  Source: arXiv:1511.08090, `AnyonsPEPS.tex`, line 161. -/
+  analysis_mul_synthesis : ∀ a b : Λ,
+    fusionAnalysis a b * fusionSynthesis a b = 1
+  /-- The first zipper identity, $B_{ab}X=X(1_N\otimes B)$.
+
+  Source: arXiv:1511.08090, `AnyonsPEPS.tex`, lines 193--196. -/
+  pairLetter_mul_synthesis : ∀ (a b : Λ) (i k : Fin p),
+    (∑ j : Fin p, tensor a i j ⊗ₖ tensor b j k) * fusionSynthesis a b =
+      fusionSynthesis a b * Matrix.blockDiagonal' (fun c =>
+        (1 : Matrix (Fin (fusionMultiplicity a b c))
+          (Fin (fusionMultiplicity a b c)) ℂ) ⊗ₖ tensor c i k)
+  /-- The second zipper identity, $X^+B_{ab}=(1_N\otimes B)X^+$.
+
+  Source: arXiv:1511.08090, `AnyonsPEPS.tex`, lines 198--200. -/
+  analysis_mul_pairLetter : ∀ (a b : Λ) (i k : Fin p),
+    fusionAnalysis a b * (∑ j : Fin p, tensor a i j ⊗ₖ tensor b j k) =
+      Matrix.blockDiagonal' (fun c =>
+        (1 : Matrix (Fin (fusionMultiplicity a b c))
+          (Fin (fusionMultiplicity a b c)) ℂ) ⊗ₖ tensor c i k) *
+        fusionAnalysis a b
+  /-- Every product-MPO letter is reconstructed through the fusion support.
+
+  Source: arXiv:1511.08090, `AnyonsPEPS.tex`, equation `inversegaugeone` at
+  lines 184--186. -/
+  pairLetter_eq_synthesis_mul_directSum_mul_analysis : ∀
+      (a b : Λ) (i k : Fin p),
+    (∑ j : Fin p, tensor a i j ⊗ₖ tensor b j k) =
+      fusionSynthesis a b * Matrix.blockDiagonal' (fun c =>
+        (1 : Matrix (Fin (fusionMultiplicity a b c))
+          (Fin (fusionMultiplicity a b c)) ℂ) ⊗ₖ tensor c i k) *
+        fusionAnalysis a b
+  /-- A simultaneous left inverse of the labelled block-letter matrix.
+
+  Source: arXiv:1511.08090, `AnyonsPEPS.tex`, lines 269--277. -/
+  blockLeftInverse : Matrix
+    ((c : Λ) × (Fin (bondDim c) × Fin (bondDim c))) (Fin p × Fin p) ℂ
+  /-- The simultaneous inverse distinguishes the final label and both bond indices.
+
+  Source: arXiv:1511.08090, `AnyonsPEPS.tex`, lines 269--277. -/
+  blockLeftInverse_apply : ∀ (c d : Λ) (x y : Fin (bondDim c))
+      (x' y' : Fin (bondDim d)),
+    (∑ i : Fin p, ∑ k : Fin p,
+      blockLeftInverse ⟨c, x, y⟩ (i, k) * tensor d i k x' y') =
+      if h : c = d then
+        if _ : h ▸ x = x' then if _ : h ▸ y = y' then 1 else 0 else 0
+      else 0
+
+namespace CompleteZipperFusionFamily
+
+variable {Λ : Type u} [Fintype Λ] [DecidableEq Λ] {p : ℕ}
+variable (Fus : CompleteZipperFusionFamily Λ p)
+
+/-- The bond space of the left-associated triple product. -/
+abbrev TripleBond (a b c : Λ) : Type :=
+  (Fin (Fus.bondDim a) × Fin (Fus.bondDim b)) × Fin (Fus.bondDim c)
+
+/-- The left-tree multiplicity space with fixed final label `d`.
+
+Its coordinates are $(e,\mu,\nu)$ with
+$\mu=1,\ldots,N_{ab}^e$ and $\nu=1,\ldots,N_{ec}^d$.
+
+Source: arXiv:1511.08090, equation `Fmove`, lines 248--251. -/
+abbrev LeftTripleMultiplicity (a b c d : Λ) : Type u :=
+  (e : Λ) × (Fin (Fus.fusionMultiplicity a b e) ×
+    Fin (Fus.fusionMultiplicity e c d))
+
+/-- The right-tree multiplicity space with fixed final label `d`.
+
+Its coordinates are $(f,\lambda,\sigma)$ with
+$\lambda=1,\ldots,N_{bc}^f$ and $\sigma=1,\ldots,N_{af}^d$.
+
+Source: arXiv:1511.08090, equation `Fmove`, lines 248--251. -/
+abbrev RightTripleMultiplicity (a b c d : Λ) : Type u :=
+  (f : Λ) × (Fin (Fus.fusionMultiplicity b c f) ×
+    Fin (Fus.fusionMultiplicity a f d))
+
+/-- The fusion tensor $X^c_{ab,\mu}$ extracted from the total synthesis matrix.
+
+**Local fix (arXiv:1511.08090, line 161):** The displayed arrow for $X$ in
+the prose is reversed.  Equations `inversegaugeone`, `zippercondition`, and
+`Fmove` fix the orientation used here.  This is documented in
+`docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`.
+
+Source: arXiv:1511.08090, `AnyonsPEPS.tex`, lines 161--163 and 248--251. -/
+def fusionTensor (a b c : Λ) (μ : Fin (Fus.fusionMultiplicity a b c)) :
+    Matrix (Fin (Fus.bondDim a) × Fin (Fus.bondDim b))
+      (Fin (Fus.bondDim c)) ℂ :=
+  fun x y => Fus.fusionSynthesis a b x ⟨c, μ, y⟩
+
+/-- The left inverse $X^{c+}_{ab,\mu}$ extracted from the total analysis matrix.
+
+It is an independent matrix, not the adjoint of `fusionTensor`.
+
+Source: arXiv:1511.08090, `AnyonsPEPS.tex`, line 161. -/
+def fusionTensorLeftInverse (a b c : Λ)
+    (μ : Fin (Fus.fusionMultiplicity a b c)) :
+    Matrix (Fin (Fus.bondDim c))
+      (Fin (Fus.bondDim a) × Fin (Fus.bondDim b)) ℂ :=
+  fun x y => Fus.fusionAnalysis a b ⟨c, μ, x⟩ y
+
+/-- The left-associated fixed-final synthesis map.  Its column
+$(e,\mu,\nu,z)$ is the composite
+$(X^e_{ab,\mu}\otimes1)X^d_{ec,\nu}$.
+
+Source: arXiv:1511.08090, equations preceding `Fmove` and `Fmove`, lines
+242--251. -/
+noncomputable def leftTripleSynthesis (a b c d : Λ) :
+    Matrix (Fus.TripleBond a b c)
+      (Fus.LeftTripleMultiplicity a b c d × Fin (Fus.bondDim d)) ℂ :=
+  fun ⟨⟨xa, xb⟩, xc⟩ ⟨⟨e, μ, ν⟩, z⟩ =>
+    ∑ y : Fin (Fus.bondDim e),
+      Fus.fusionTensor a b e μ (xa, xb) y *
+        Fus.fusionTensor e c d ν (y, xc) z
+
+/-- The left-associated fixed-final analysis map.  Its row
+$(e,\mu,\nu,z)$ is the composite of the two fusion left inverses in reverse
+order.
+
+Source: arXiv:1511.08090, lines 161 and 242--251. -/
+noncomputable def leftTripleAnalysis (a b c d : Λ) :
+    Matrix (Fus.LeftTripleMultiplicity a b c d × Fin (Fus.bondDim d))
+      (Fus.TripleBond a b c) ℂ :=
+  fun ⟨⟨e, μ, ν⟩, z⟩ ⟨⟨xa, xb⟩, xc⟩ =>
+    ∑ y : Fin (Fus.bondDim e),
+      Fus.fusionTensorLeftInverse e c d ν z (y, xc) *
+        Fus.fusionTensorLeftInverse a b e μ y (xa, xb)
+
+/-- The right-associated fixed-final synthesis map.  Its column
+$(f,\lambda,\sigma,z)$ is the composite
+$(1\otimes X^f_{bc,\lambda})X^d_{af,\sigma}$, reindexed on the common
+left-associated triple-bond space.
+
+Source: arXiv:1511.08090, equations preceding `Fmove` and `Fmove`, lines
+242--251. -/
+noncomputable def rightTripleSynthesis (a b c d : Λ) :
+    Matrix (Fus.TripleBond a b c)
+      (Fus.RightTripleMultiplicity a b c d × Fin (Fus.bondDim d)) ℂ :=
+  fun ⟨⟨xa, xb⟩, xc⟩ ⟨⟨f, l, s⟩, z⟩ =>
+    ∑ y : Fin (Fus.bondDim f),
+      Fus.fusionTensor b c f l (xb, xc) y *
+        Fus.fusionTensor a f d s (xa, y) z
+
+/-- The right-associated fixed-final analysis map, in the reverse order from
+the right-associated synthesis composite.
+
+Source: arXiv:1511.08090, lines 161 and 242--251. -/
+noncomputable def rightTripleAnalysis (a b c d : Λ) :
+    Matrix (Fus.RightTripleMultiplicity a b c d × Fin (Fus.bondDim d))
+      (Fus.TripleBond a b c) ℂ :=
+  fun ⟨⟨f, l, s⟩, z⟩ ⟨⟨xa, xb⟩, xc⟩ =>
+    ∑ y : Fin (Fus.bondDim f),
+      Fus.fusionTensorLeftInverse a f d s z (xa, y) *
+        Fus.fusionTensorLeftInverse b c f l y (xb, xc)
+
+/-- The full left-associated triple-fusion index, including the final label and
+its bond coordinate. -/
+abbrev LeftTripleIndex (a b c : Λ) : Type u :=
+  (d : Λ) × (Fus.LeftTripleMultiplicity a b c d × Fin (Fus.bondDim d))
+
+/-- The full right-associated triple-fusion index, including the final label
+and its bond coordinate. -/
+abbrev RightTripleIndex (a b c : Λ) : Type u :=
+  (d : Λ) × (Fus.RightTripleMultiplicity a b c d × Fin (Fus.bondDim d))
+
+/-- The direct sum of all left-associated fixed-final synthesis maps. -/
+noncomputable def leftTripleSynthesisFull (a b c : Λ) :
+    Matrix (Fus.TripleBond a b c) (Fus.LeftTripleIndex a b c) ℂ :=
+  fun x y => Fus.leftTripleSynthesis a b c y.1 x y.2
+
+/-- The direct sum of all left-associated fixed-final analysis maps. -/
+noncomputable def leftTripleAnalysisFull (a b c : Λ) :
+    Matrix (Fus.LeftTripleIndex a b c) (Fus.TripleBond a b c) ℂ :=
+  fun x y => Fus.leftTripleAnalysis a b c x.1 x.2 y
+
+/-- The direct sum of all right-associated fixed-final synthesis maps. -/
+noncomputable def rightTripleSynthesisFull (a b c : Λ) :
+    Matrix (Fus.TripleBond a b c) (Fus.RightTripleIndex a b c) ℂ :=
+  fun x y => Fus.rightTripleSynthesis a b c y.1 x y.2
+
+/-- The direct sum of all right-associated fixed-final analysis maps. -/
+noncomputable def rightTripleAnalysisFull (a b c : Λ) :
+    Matrix (Fus.RightTripleIndex a b c) (Fus.TripleBond a b c) ℂ :=
+  fun x y => Fus.rightTripleAnalysis a b c x.1 x.2 y
+
+/-- A letter of the left-associated triple product on the common triple-bond
+space. -/
+noncomputable def tripleProductLetter (a b c : Λ) (i l : Fin p) :
+    Matrix (Fus.TripleBond a b c) (Fus.TripleBond a b c) ℂ :=
+  ∑ j : Fin p, ∑ k : Fin p,
+    (Fus.tensor a i j ⊗ₖ Fus.tensor b j k) ⊗ₖ Fus.tensor c k l
+
+/-- The direct sum of final-block letters in the left-tree coordinates. -/
+noncomputable def leftTripleDirectSumLetter (a b c : Λ) (i l : Fin p) :
+    Matrix (Fus.LeftTripleIndex a b c) (Fus.LeftTripleIndex a b c) ℂ :=
+  Matrix.blockDiagonal' fun d =>
+    (1 : Matrix (Fus.LeftTripleMultiplicity a b c d)
+      (Fus.LeftTripleMultiplicity a b c d) ℂ) ⊗ₖ Fus.tensor d i l
+
+/-- The direct sum of final-block letters in the right-tree coordinates. -/
+noncomputable def rightTripleDirectSumLetter (a b c : Λ) (i l : Fin p) :
+    Matrix (Fus.RightTripleIndex a b c) (Fus.RightTripleIndex a b c) ℂ :=
+  Matrix.blockDiagonal' fun d =>
+    (1 : Matrix (Fus.RightTripleMultiplicity a b c d)
+      (Fus.RightTripleMultiplicity a b c d) ℂ) ⊗ₖ Fus.tensor d i l
+
+end CompleteZipperFusionFamily
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/CompleteZipperFusionInverse.lean
+++ b/TNLean/MPS/MPDO/CompleteZipperFusionInverse.lean
@@ -1,0 +1,258 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.CompleteZipperFusion
+
+/-!
+# Inverse of the printed F-move
+
+The full comparison matrices for the two triple-fusion trees are inverse.
+Their fixed-final corners therefore give mutually inverse multiplicity
+matrices after the common final bond factor is removed.
+
+Source: arXiv:1511.08090, `AnyonsPEPS.tex`, lines 248--251 and 269--277.
+-/
+
+open scoped Matrix BigOperators Kronecker
+open Matrix
+
+namespace MPOTensor.CompleteZipperFusionFamily
+
+universe u
+
+variable {Λ : Type u} [Fintype Λ] [DecidableEq Λ] {p : ℕ}
+variable (Fus : CompleteZipperFusionFamily Λ p)
+
+private theorem leftLetter_mul_fullInverse (a b c : Λ) (i k : Fin p) :
+    Fus.leftTripleDirectSumLetter a b c i k * Fus.fullInversePrintedFMatrix a b c =
+      Fus.fullInversePrintedFMatrix a b c * Fus.rightTripleDirectSumLetter a b c i k := by
+  calc
+    _ = (Fus.fullInversePrintedFMatrix a b c * Fus.fullPrintedFMatrix a b c) *
+        (Fus.leftTripleDirectSumLetter a b c i k *
+          Fus.fullInversePrintedFMatrix a b c) := by
+      rw [Fus.fullInversePrintedFMatrix_mul_fullPrintedFMatrix, Matrix.one_mul]
+    _ = Fus.fullInversePrintedFMatrix a b c *
+        ((Fus.fullPrintedFMatrix a b c * Fus.leftTripleDirectSumLetter a b c i k) *
+          Fus.fullInversePrintedFMatrix a b c) := by simp only [Matrix.mul_assoc]
+    _ = Fus.fullInversePrintedFMatrix a b c *
+        ((Fus.rightTripleDirectSumLetter a b c i k * Fus.fullPrintedFMatrix a b c) *
+          Fus.fullInversePrintedFMatrix a b c) := by
+      rw [Fus.rightTripleDirectSumLetter_mul_fullPrintedFMatrix]
+    _ = (Fus.fullInversePrintedFMatrix a b c *
+        Fus.rightTripleDirectSumLetter a b c i k) *
+          (Fus.fullPrintedFMatrix a b c * Fus.fullInversePrintedFMatrix a b c) := by
+      simp only [Matrix.mul_assoc]
+    _ = _ := by rw [Fus.fullPrintedFMatrix_mul_fullInversePrintedFMatrix, Matrix.mul_one]
+
+private theorem exists_inverseCorner_eq_kronecker_one (a b c d : Λ) :
+    ∃ G : Matrix (Fus.LeftTripleMultiplicity a b c d)
+        (Fus.RightTripleMultiplicity a b c d) ℂ,
+      (Fus.fullInversePrintedFMatrix a b c).submatrix
+          (Fus.leftFinalRow a b c d) (Fus.rightFinalRow a b c d) =
+        G ⊗ₖ (1 : Matrix (Fin (Fus.bondDim d)) (Fin (Fus.bondDim d)) ℂ) := by
+  apply Matrix.exists_eq_kronecker_one_of_intertwines_span_eq_top
+    (Fus.tensor d).toMPSTensor
+    ((Fus.fullInversePrintedFMatrix a b c).submatrix
+      (Fus.leftFinalRow a b c d) (Fus.rightFinalRow a b c d))
+    (Fus.tensor_injective d).span_eq_top
+  intro ij
+  obtain ⟨⟨i, k⟩, rfl⟩ := finProdFinEquiv.surjective ij
+  have hFull := Fus.leftLetter_mul_fullInverse a b c i k
+  funext ⟨mL, x⟩ ⟨mR, y⟩
+  have hEntry := congrArg
+    (fun M => M (Fus.leftFinalRow a b c d ⟨mL, x⟩)
+      (Fus.rightFinalRow a b c d ⟨mR, y⟩)) hFull
+  have hLeft :
+      (Fus.leftTripleDirectSumLetter a b c i k *
+        Fus.fullInversePrintedFMatrix a b c)
+          (Fus.leftFinalRow a b c d ⟨mL, x⟩)
+          (Fus.rightFinalRow a b c d ⟨mR, y⟩) =
+        ∑ z, Fus.tensor d i k x z * Fus.fullInversePrintedFMatrix a b c
+          (Fus.leftFinalRow a b c d ⟨mL, z⟩)
+          (Fus.rightFinalRow a b c d ⟨mR, y⟩) := by
+    rw [Matrix.mul_apply, Fintype.sum_sigma]
+    rw [Finset.sum_eq_single d
+      (fun q _ hq => Finset.sum_eq_zero fun z _ => by
+        rw [leftTripleDirectSumLetter, leftFinalRow,
+          Matrix.blockDiagonal'_apply_ne _ _ _ (Ne.symm hq), zero_mul])
+      (fun h => absurd (Finset.mem_univ d) h)]
+    rw [Fintype.sum_prod_type]
+    rw [Finset.sum_eq_single mL
+      (fun q _ hq => Finset.sum_eq_zero fun z _ => by
+        rw [leftTripleDirectSumLetter, leftFinalRow,
+          Matrix.blockDiagonal'_apply_eq]
+        simp only [kroneckerMap_apply, Matrix.one_apply,
+          if_neg (Ne.symm hq), zero_mul])
+      (fun h => absurd (Finset.mem_univ mL) h)]
+    simp [leftTripleDirectSumLetter, leftFinalRow, rightFinalRow,
+      Matrix.blockDiagonal'_apply_eq]
+  have hRight :
+      (Fus.fullInversePrintedFMatrix a b c *
+        Fus.rightTripleDirectSumLetter a b c i k)
+          (Fus.leftFinalRow a b c d ⟨mL, x⟩)
+          (Fus.rightFinalRow a b c d ⟨mR, y⟩) =
+        ∑ z, Fus.fullInversePrintedFMatrix a b c
+          (Fus.leftFinalRow a b c d ⟨mL, x⟩)
+          (Fus.rightFinalRow a b c d ⟨mR, z⟩) * Fus.tensor d i k z y := by
+    rw [Matrix.mul_apply, Fintype.sum_sigma]
+    rw [Finset.sum_eq_single d
+      (fun q _ hq => Finset.sum_eq_zero fun z _ => by
+        rw [rightTripleDirectSumLetter, rightFinalRow,
+          Matrix.blockDiagonal'_apply_ne _ _ _ hq, mul_zero])
+      (fun h => absurd (Finset.mem_univ d) h)]
+    rw [Fintype.sum_prod_type]
+    rw [Finset.sum_eq_single mR
+      (fun q _ hq => Finset.sum_eq_zero fun z _ => by
+        simp [rightTripleDirectSumLetter, leftFinalRow, rightFinalRow,
+          Matrix.blockDiagonal'_apply_eq, hq])
+      (fun h => absurd (Finset.mem_univ mR) h)]
+    simp [rightTripleDirectSumLetter, leftFinalRow, rightFinalRow,
+      Matrix.blockDiagonal'_apply_eq]
+  have hSimple := hLeft.symm.trans (hEntry.trans hRight)
+  simpa [MPOTensor.toMPSTensor, Matrix.submatrix_apply, Matrix.mul_apply,
+    Fintype.sum_prod_type, Matrix.one_apply] using hSimple
+
+/-- The multiplicity matrix in the opposite orientation, obtained from the
+fixed-final corner of $L_d^+R_d$. -/
+noncomputable def inversePrintedFMatrix (a b c d : Λ) :
+    Matrix (Fus.LeftTripleMultiplicity a b c d)
+      (Fus.RightTripleMultiplicity a b c d) ℂ :=
+  Classical.choose (Fus.exists_inverseCorner_eq_kronecker_one a b c d)
+
+private theorem inverseCorner_eq_kronecker_one (a b c d : Λ) :
+    (Fus.fullInversePrintedFMatrix a b c).submatrix
+        (Fus.leftFinalRow a b c d) (Fus.rightFinalRow a b c d) =
+      Fus.inversePrintedFMatrix a b c d ⊗ₖ
+        (1 : Matrix (Fin (Fus.bondDim d)) (Fin (Fus.bondDim d)) ℂ) :=
+  Classical.choose_spec (Fus.exists_inverseCorner_eq_kronecker_one a b c d)
+
+private theorem multiplicity_mul_eq_one_of_amplification
+    {m n : Type*} [Fintype n] [DecidableEq m] {D : ℕ} (hD : 0 < D)
+    (F : Matrix m n ℂ) (G : Matrix n m ℂ)
+    (h : (F ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ)) *
+      (G ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ)) = 1) :
+    F * G = 1 := by
+  let z : Fin D := ⟨0, hD⟩
+  funext x y
+  have hEntry := congrArg (fun M => M (x, z) (y, z)) h
+  simpa [← Matrix.mul_kronecker_mul, Matrix.one_apply, z] using hEntry
+
+/-- The printed matrix followed by the opposite comparison is the identity. -/
+theorem printedFMatrix_mul_inversePrintedFMatrix (a b c d : Λ) :
+    Fus.printedFMatrix a b c d * Fus.inversePrintedFMatrix a b c d = 1 := by
+  apply multiplicity_mul_eq_one_of_amplification (Fus.bondDim_pos d)
+  change (Fus.printedFMatrix a b c d ⊗ₖ
+      (1 : Matrix (Fin (Fus.bondDim d)) (Fin (Fus.bondDim d)) ℂ)) *
+      (Fus.inversePrintedFMatrix a b c d ⊗ₖ
+        (1 : Matrix (Fin (Fus.bondDim d)) (Fin (Fus.bondDim d)) ℂ)) =
+    (1 : Matrix
+      (Fus.RightTripleMultiplicity a b c d × Fin (Fus.bondDim d))
+      (Fus.RightTripleMultiplicity a b c d × Fin (Fus.bondDim d)) ℂ)
+  have hFull := Fus.fullPrintedFMatrix_mul_fullInversePrintedFMatrix a b c
+  rw [← Fus.printedFMatrixAmplified_eq_kronecker_one a b c d,
+    ← Fus.inverseCorner_eq_kronecker_one a b c d]
+  have hF (u : Fus.RightTripleMultiplicity a b c d × Fin (Fus.bondDim d))
+      (v : Fus.LeftTripleMultiplicity a b c d × Fin (Fus.bondDim d)) :
+      Fus.fullPrintedFMatrix a b c ⟨d, u⟩ ⟨d, v⟩ =
+        Fus.printedFMatrix a b c d u.1 v.1 *
+          (1 : Matrix (Fin (Fus.bondDim d)) (Fin (Fus.bondDim d)) ℂ) u.2 v.2 := by
+    simpa [printedFMatrixAmplified, Matrix.submatrix_apply, Matrix.kronecker_apply,
+      rightFinalRow, leftFinalRow]
+      using congrArg (fun M => M u v)
+        (Fus.printedFMatrixAmplified_eq_kronecker_one a b c d)
+  have hG (u : Fus.LeftTripleMultiplicity a b c d × Fin (Fus.bondDim d))
+      (v : Fus.RightTripleMultiplicity a b c d × Fin (Fus.bondDim d)) :
+      Fus.fullInversePrintedFMatrix a b c ⟨d, u⟩ ⟨d, v⟩ =
+        Fus.inversePrintedFMatrix a b c d u.1 v.1 *
+          (1 : Matrix (Fin (Fus.bondDim d)) (Fin (Fus.bondDim d)) ℂ) u.2 v.2 := by
+    simpa [Matrix.submatrix_apply, Matrix.kronecker_apply, rightFinalRow, leftFinalRow] using
+      congrArg (fun M => M u v) (Fus.inverseCorner_eq_kronecker_one a b c d)
+  funext x y
+  rcases x with ⟨mx, bx⟩
+  rcases y with ⟨my, byy⟩
+  let x : Fus.RightTripleMultiplicity a b c d × Fin (Fus.bondDim d) := ⟨mx, bx⟩
+  let y : Fus.RightTripleMultiplicity a b c d × Fin (Fus.bondDim d) := ⟨my, byy⟩
+  have hEntry := congrArg
+    (fun M => M (Fus.rightFinalRow a b c d x) (Fus.rightFinalRow a b c d y)) hFull
+  rw [Matrix.mul_apply, Fintype.sum_sigma] at hEntry
+  rw [Finset.sum_eq_single d
+    (fun e _ hed => Finset.sum_eq_zero fun q _ => by
+      have hZero : Fus.fullPrintedFMatrix a b c
+          (Fus.rightFinalRow a b c d x) ⟨e, q⟩ = 0 := by
+        simpa [Matrix.submatrix_apply, rightFinalRow, leftFinalRow] using
+          congrArg (fun M => M x q)
+            (Fus.fullPrintedFMatrix_finalSector_eq_zero a b c d e (Ne.symm hed))
+      rw [hZero, zero_mul])
+    (fun hmem => absurd (Finset.mem_univ d) hmem)] at hEntry
+  rw [Matrix.mul_apply]
+  have hOne :
+      (1 : Matrix (Fus.RightTripleIndex a b c) (Fus.RightTripleIndex a b c) ℂ)
+          (Fus.rightFinalRow a b c d x) (Fus.rightFinalRow a b c d y) =
+        (1 : Matrix
+          (Fus.RightTripleMultiplicity a b c d × Fin (Fus.bondDim d))
+          (Fus.RightTripleMultiplicity a b c d × Fin (Fus.bondDim d)) ℂ) x y := by
+    simp [rightFinalRow, Matrix.one_apply, x, y]
+  rw [hOne] at hEntry
+  exact hEntry
+
+/-- The opposite comparison followed by the printed matrix is the identity. -/
+theorem inversePrintedFMatrix_mul_printedFMatrix (a b c d : Λ) :
+    Fus.inversePrintedFMatrix a b c d * Fus.printedFMatrix a b c d = 1 := by
+  apply multiplicity_mul_eq_one_of_amplification (Fus.bondDim_pos d)
+  change (Fus.inversePrintedFMatrix a b c d ⊗ₖ
+      (1 : Matrix (Fin (Fus.bondDim d)) (Fin (Fus.bondDim d)) ℂ)) *
+      (Fus.printedFMatrix a b c d ⊗ₖ
+        (1 : Matrix (Fin (Fus.bondDim d)) (Fin (Fus.bondDim d)) ℂ)) =
+    (1 : Matrix
+      (Fus.LeftTripleMultiplicity a b c d × Fin (Fus.bondDim d))
+      (Fus.LeftTripleMultiplicity a b c d × Fin (Fus.bondDim d)) ℂ)
+  have hFull := Fus.fullInversePrintedFMatrix_mul_fullPrintedFMatrix a b c
+  rw [← Fus.inverseCorner_eq_kronecker_one a b c d,
+    ← Fus.printedFMatrixAmplified_eq_kronecker_one a b c d]
+  have hF (u : Fus.RightTripleMultiplicity a b c d × Fin (Fus.bondDim d))
+      (v : Fus.LeftTripleMultiplicity a b c d × Fin (Fus.bondDim d)) :
+      Fus.fullPrintedFMatrix a b c ⟨d, u⟩ ⟨d, v⟩ =
+        Fus.printedFMatrix a b c d u.1 v.1 *
+          (1 : Matrix (Fin (Fus.bondDim d)) (Fin (Fus.bondDim d)) ℂ) u.2 v.2 := by
+    simpa [printedFMatrixAmplified, Matrix.submatrix_apply, Matrix.kronecker_apply,
+      rightFinalRow, leftFinalRow]
+      using congrArg (fun M => M u v)
+        (Fus.printedFMatrixAmplified_eq_kronecker_one a b c d)
+  have hG (u : Fus.LeftTripleMultiplicity a b c d × Fin (Fus.bondDim d))
+      (v : Fus.RightTripleMultiplicity a b c d × Fin (Fus.bondDim d)) :
+      Fus.fullInversePrintedFMatrix a b c ⟨d, u⟩ ⟨d, v⟩ =
+        Fus.inversePrintedFMatrix a b c d u.1 v.1 *
+          (1 : Matrix (Fin (Fus.bondDim d)) (Fin (Fus.bondDim d)) ℂ) u.2 v.2 := by
+    simpa [Matrix.submatrix_apply, Matrix.kronecker_apply, rightFinalRow, leftFinalRow] using
+      congrArg (fun M => M u v) (Fus.inverseCorner_eq_kronecker_one a b c d)
+  funext x y
+  rcases x with ⟨mx, bx⟩
+  rcases y with ⟨my, byy⟩
+  let x : Fus.LeftTripleMultiplicity a b c d × Fin (Fus.bondDim d) := ⟨mx, bx⟩
+  let y : Fus.LeftTripleMultiplicity a b c d × Fin (Fus.bondDim d) := ⟨my, byy⟩
+  have hEntry := congrArg
+    (fun M => M (Fus.leftFinalRow a b c d x) (Fus.leftFinalRow a b c d y)) hFull
+  rw [Matrix.mul_apply, Fintype.sum_sigma] at hEntry
+  rw [Finset.sum_eq_single d
+    (fun e _ hed => Finset.sum_eq_zero fun q _ => by
+      have hZero : Fus.fullPrintedFMatrix a b c ⟨e, q⟩
+          (Fus.leftFinalRow a b c d y) = 0 := by
+        simpa [Matrix.submatrix_apply, rightFinalRow, leftFinalRow] using
+          congrArg (fun M => M q y)
+            (Fus.fullPrintedFMatrix_finalSector_eq_zero a b c e d hed)
+      rw [hZero, mul_zero])
+    (fun hmem => absurd (Finset.mem_univ d) hmem)] at hEntry
+  rw [Matrix.mul_apply]
+  have hOne :
+      (1 : Matrix (Fus.LeftTripleIndex a b c) (Fus.LeftTripleIndex a b c) ℂ)
+          (Fus.leftFinalRow a b c d x) (Fus.leftFinalRow a b c d y) =
+        (1 : Matrix
+          (Fus.LeftTripleMultiplicity a b c d × Fin (Fus.bondDim d))
+          (Fus.LeftTripleMultiplicity a b c d × Fin (Fus.bondDim d)) ℂ) x y := by
+    simp [leftFinalRow, Matrix.one_apply, x, y]
+  rw [hOne] at hEntry
+  exact hEntry
+
+end MPOTensor.CompleteZipperFusionFamily

--- a/TNLean/MPS/MPDO/CompleteZipperFusionSupport.lean
+++ b/TNLean/MPS/MPDO/CompleteZipperFusionSupport.lean
@@ -1,0 +1,921 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.CompleteZipperFusionDefs
+
+/-!
+# Triple reconstruction from complete zipper fusion
+
+This file proves the two-stage triple-fusion identities and reconstructs the
+common triple-product support from the source-faithful zipper hypotheses.
+-/
+
+open scoped Matrix BigOperators Kronecker
+open Matrix
+
+namespace MPOTensor
+
+universe u
+
+namespace CompleteZipperFusionFamily
+
+variable {Λ : Type u} [Fintype Λ] [DecidableEq Λ] {p : ℕ}
+variable (Fus : CompleteZipperFusionFamily Λ p)
+
+private abbrev LeftFirstStage (a b c : Λ) : Type u :=
+  ((e : Λ) × (Fin (Fus.fusionMultiplicity a b e) × Fin (Fus.bondDim e))) ×
+    Fin (Fus.bondDim c)
+
+private abbrev LeftFirstStageNested (a b c : Λ) : Type u :=
+  (e : Λ) × (Fin (Fus.fusionMultiplicity a b e) ×
+    (Fin (Fus.bondDim e) × Fin (Fus.bondDim c)))
+
+private abbrev LeftFinalNested (a b c : Λ) : Type u :=
+  (e : Λ) × (Fin (Fus.fusionMultiplicity a b e) ×
+    ((d : Λ) × (Fin (Fus.fusionMultiplicity e c d) × Fin (Fus.bondDim d))))
+
+private def leftFirstStageEquiv (a b c : Λ) :
+    Fus.LeftFirstStage a b c ≃ Fus.LeftFirstStageNested a b c :=
+  (Equiv.sigmaProdDistrib
+    (fun e => Fin (Fus.fusionMultiplicity a b e) × Fin (Fus.bondDim e))
+    (Fin (Fus.bondDim c))).trans
+      (Equiv.sigmaCongrRight fun _ => Equiv.prodAssoc _ _ _)
+
+private def leftFinalFlattenEquiv (a b c : Λ) :
+    Fus.LeftFinalNested a b c ≃ Fus.LeftTripleIndex a b c where
+  toFun x := ⟨x.2.2.1, ⟨⟨x.1, x.2.1, x.2.2.2.1⟩, x.2.2.2.2⟩⟩
+  invFun x := ⟨x.2.1.1, ⟨x.2.1.2.1, ⟨x.1, x.2.1.2.2, x.2.2⟩⟩⟩
+  left_inv := by rintro ⟨e, μ, d, ν, z⟩; rfl
+  right_inv := by rintro ⟨d, ⟨e, μ, ν⟩, z⟩; rfl
+
+private noncomputable def leftFirstSynthesis (a b c : Λ) :
+    Matrix (Fus.TripleBond a b c) (Fus.LeftFirstStage a b c) ℂ :=
+  Fus.fusionSynthesis a b ⊗ₖ
+    (1 : Matrix (Fin (Fus.bondDim c)) (Fin (Fus.bondDim c)) ℂ)
+
+private noncomputable def leftFirstAnalysis (a b c : Λ) :
+    Matrix (Fus.LeftFirstStage a b c) (Fus.TripleBond a b c) ℂ :=
+  Fus.fusionAnalysis a b ⊗ₖ
+    (1 : Matrix (Fin (Fus.bondDim c)) (Fin (Fus.bondDim c)) ℂ)
+
+private noncomputable def leftSecondSynthesis (a b c : Λ) :
+    Matrix (Fus.LeftFirstStage a b c) (Fus.LeftTripleIndex a b c) ℂ :=
+  (Matrix.blockDiagonal' fun e =>
+    (1 : Matrix (Fin (Fus.fusionMultiplicity a b e))
+      (Fin (Fus.fusionMultiplicity a b e)) ℂ) ⊗ₖ Fus.fusionSynthesis e c).submatrix
+        (Fus.leftFirstStageEquiv a b c) (Fus.leftFinalFlattenEquiv a b c).symm
+
+private noncomputable def leftSecondAnalysis (a b c : Λ) :
+    Matrix (Fus.LeftTripleIndex a b c) (Fus.LeftFirstStage a b c) ℂ :=
+  (Matrix.blockDiagonal' fun e =>
+    (1 : Matrix (Fin (Fus.fusionMultiplicity a b e))
+      (Fin (Fus.fusionMultiplicity a b e)) ℂ) ⊗ₖ Fus.fusionAnalysis e c).submatrix
+        (Fus.leftFinalFlattenEquiv a b c).symm (Fus.leftFirstStageEquiv a b c)
+
+private theorem leftSynthesisFull_eq_stages (a b c : Λ) :
+    Fus.leftTripleSynthesisFull a b c =
+      Fus.leftFirstSynthesis a b c * Fus.leftSecondSynthesis a b c := by
+  classical
+  funext ⟨⟨xa, xb⟩, xc⟩ ⟨d, ⟨⟨e, μ, ν⟩, z⟩⟩
+  simp [leftTripleSynthesisFull, leftTripleSynthesis, leftFirstSynthesis,
+    leftSecondSynthesis, leftFirstStageEquiv, leftFinalFlattenEquiv,
+    fusionTensor, Matrix.mul_apply, Fintype.sum_sigma, Fintype.sum_prod_type,
+    Matrix.blockDiagonal'_apply, Matrix.one_apply]
+
+private theorem leftAnalysisFull_eq_stages (a b c : Λ) :
+    Fus.leftTripleAnalysisFull a b c =
+      Fus.leftSecondAnalysis a b c * Fus.leftFirstAnalysis a b c := by
+  classical
+  funext ⟨d, ⟨⟨e, μ, ν⟩, z⟩⟩ ⟨⟨xa, xb⟩, xc⟩
+  simp [leftTripleAnalysisFull, leftTripleAnalysis, leftFirstAnalysis,
+    leftSecondAnalysis, leftFirstStageEquiv, leftFinalFlattenEquiv,
+    fusionTensorLeftInverse, Matrix.mul_apply, Fintype.sum_sigma,
+    Fintype.sum_prod_type, Matrix.blockDiagonal'_apply, Matrix.one_apply]
+
+private theorem leftFirstAnalysis_mul_synthesis (a b c : Λ) :
+    Fus.leftFirstAnalysis a b c * Fus.leftFirstSynthesis a b c = 1 := by
+  rw [leftFirstSynthesis, leftFirstAnalysis, ← Matrix.mul_kronecker_mul,
+    Fus.analysis_mul_synthesis, Matrix.one_mul, Matrix.one_kronecker_one]
+
+private theorem leftSecondAnalysis_mul_synthesis (a b c : Λ) :
+    Fus.leftSecondAnalysis a b c * Fus.leftSecondSynthesis a b c = 1 := by
+  unfold leftSecondSynthesis leftSecondAnalysis
+  rw [Matrix.submatrix_mul_equiv _ _ _ (Fus.leftFirstStageEquiv a b c) _,
+    ← Matrix.blockDiagonal'_mul]
+  simp_rw [← Matrix.mul_kronecker_mul, Fus.analysis_mul_synthesis, Matrix.one_mul,
+    Matrix.one_kronecker_one]
+  change (Matrix.blockDiagonal'
+    (1 : (e : Λ) → Matrix
+      (Fin (Fus.fusionMultiplicity a b e) ×
+        ((d : Λ) × (Fin (Fus.fusionMultiplicity e c d) × Fin (Fus.bondDim d))))
+      (Fin (Fus.fusionMultiplicity a b e) ×
+        ((d : Λ) × (Fin (Fus.fusionMultiplicity e c d) × Fin (Fus.bondDim d)))) ℂ)).submatrix
+          (Fus.leftFinalFlattenEquiv a b c).symm
+          (Fus.leftFinalFlattenEquiv a b c).symm = 1
+  rw [Matrix.blockDiagonal'_one, Matrix.submatrix_one_equiv]
+
+private abbrev RightFirstStage (a b c : Λ) : Type u :=
+  Fin (Fus.bondDim a) ×
+    ((f : Λ) × (Fin (Fus.fusionMultiplicity b c f) × Fin (Fus.bondDim f)))
+
+private abbrev RightFirstStageNested (a b c : Λ) : Type u :=
+  (f : Λ) × (Fin (Fus.fusionMultiplicity b c f) ×
+    (Fin (Fus.bondDim a) × Fin (Fus.bondDim f)))
+
+private abbrev RightFinalNested (a b c : Λ) : Type u :=
+  (f : Λ) × (Fin (Fus.fusionMultiplicity b c f) ×
+    ((d : Λ) × (Fin (Fus.fusionMultiplicity a f d) × Fin (Fus.bondDim d))))
+
+private def rightBondAssocEquiv (a b c : Λ) :
+    Fus.TripleBond a b c ≃
+      Fin (Fus.bondDim a) × (Fin (Fus.bondDim b) × Fin (Fus.bondDim c)) :=
+  Equiv.prodAssoc _ _ _
+
+private def rightFirstStageEquiv (a b c : Λ) :
+    Fus.RightFirstStage a b c ≃ Fus.RightFirstStageNested a b c where
+  toFun x := ⟨x.2.1, x.2.2.1, x.1, x.2.2.2⟩
+  invFun x := ⟨x.2.2.1, ⟨x.1, x.2.1, x.2.2.2⟩⟩
+  left_inv := by rintro ⟨x, f, l, y⟩; rfl
+  right_inv := by rintro ⟨f, l, x, y⟩; rfl
+
+private def rightFinalFlattenEquiv (a b c : Λ) :
+    Fus.RightFinalNested a b c ≃ Fus.RightTripleIndex a b c where
+  toFun x := ⟨x.2.2.1, ⟨⟨x.1, x.2.1, x.2.2.2.1⟩, x.2.2.2.2⟩⟩
+  invFun x := ⟨x.2.1.1, ⟨x.2.1.2.1, ⟨x.1, x.2.1.2.2, x.2.2⟩⟩⟩
+  left_inv := by rintro ⟨f, l, d, s, z⟩; rfl
+  right_inv := by rintro ⟨d, ⟨f, l, s⟩, z⟩; rfl
+
+private noncomputable def rightFirstSynthesis (a b c : Λ) :
+    Matrix (Fus.TripleBond a b c) (Fus.RightFirstStage a b c) ℂ :=
+  ((1 : Matrix (Fin (Fus.bondDim a)) (Fin (Fus.bondDim a)) ℂ) ⊗ₖ
+    Fus.fusionSynthesis b c).submatrix (Fus.rightBondAssocEquiv a b c) (Equiv.refl _)
+
+private noncomputable def rightFirstAnalysis (a b c : Λ) :
+    Matrix (Fus.RightFirstStage a b c) (Fus.TripleBond a b c) ℂ :=
+  ((1 : Matrix (Fin (Fus.bondDim a)) (Fin (Fus.bondDim a)) ℂ) ⊗ₖ
+    Fus.fusionAnalysis b c).submatrix (Equiv.refl _) (Fus.rightBondAssocEquiv a b c)
+
+private noncomputable def rightSecondSynthesis (a b c : Λ) :
+    Matrix (Fus.RightFirstStage a b c) (Fus.RightTripleIndex a b c) ℂ :=
+  (Matrix.blockDiagonal' fun f =>
+    (1 : Matrix (Fin (Fus.fusionMultiplicity b c f))
+      (Fin (Fus.fusionMultiplicity b c f)) ℂ) ⊗ₖ Fus.fusionSynthesis a f).submatrix
+        (Fus.rightFirstStageEquiv a b c) (Fus.rightFinalFlattenEquiv a b c).symm
+
+private noncomputable def rightSecondAnalysis (a b c : Λ) :
+    Matrix (Fus.RightTripleIndex a b c) (Fus.RightFirstStage a b c) ℂ :=
+  (Matrix.blockDiagonal' fun f =>
+    (1 : Matrix (Fin (Fus.fusionMultiplicity b c f))
+      (Fin (Fus.fusionMultiplicity b c f)) ℂ) ⊗ₖ Fus.fusionAnalysis a f).submatrix
+        (Fus.rightFinalFlattenEquiv a b c).symm (Fus.rightFirstStageEquiv a b c)
+
+private theorem rightSynthesisFull_eq_stages (a b c : Λ) :
+    Fus.rightTripleSynthesisFull a b c =
+      Fus.rightFirstSynthesis a b c * Fus.rightSecondSynthesis a b c := by
+  classical
+  funext ⟨⟨xa, xb⟩, xc⟩ ⟨d, ⟨⟨f, l, s⟩, z⟩⟩
+  simp [rightTripleSynthesisFull, rightTripleSynthesis, rightFirstSynthesis,
+    rightSecondSynthesis, rightBondAssocEquiv, rightFirstStageEquiv,
+    rightFinalFlattenEquiv, fusionTensor, Matrix.mul_apply, Fintype.sum_sigma,
+    Fintype.sum_prod_type, Matrix.blockDiagonal'_apply, Matrix.one_apply]
+
+private theorem rightAnalysisFull_eq_stages (a b c : Λ) :
+    Fus.rightTripleAnalysisFull a b c =
+      Fus.rightSecondAnalysis a b c * Fus.rightFirstAnalysis a b c := by
+  classical
+  funext ⟨d, ⟨⟨f, l, s⟩, z⟩⟩ ⟨⟨xa, xb⟩, xc⟩
+  simp [rightTripleAnalysisFull, rightTripleAnalysis, rightFirstAnalysis,
+    rightSecondAnalysis, rightBondAssocEquiv, rightFirstStageEquiv,
+    rightFinalFlattenEquiv, fusionTensorLeftInverse, Matrix.mul_apply,
+    Fintype.sum_sigma, Fintype.sum_prod_type, Matrix.blockDiagonal'_apply,
+    Matrix.one_apply]
+
+private theorem rightFirstAnalysis_mul_synthesis (a b c : Λ) :
+    Fus.rightFirstAnalysis a b c * Fus.rightFirstSynthesis a b c = 1 := by
+  unfold rightFirstSynthesis rightFirstAnalysis
+  rw [Matrix.submatrix_mul_equiv _ _ _ (Fus.rightBondAssocEquiv a b c) _,
+    ← Matrix.mul_kronecker_mul, Fus.analysis_mul_synthesis, Matrix.one_mul,
+    Matrix.one_kronecker_one]
+  rfl
+
+private theorem rightSecondAnalysis_mul_synthesis (a b c : Λ) :
+    Fus.rightSecondAnalysis a b c * Fus.rightSecondSynthesis a b c = 1 := by
+  unfold rightSecondSynthesis rightSecondAnalysis
+  rw [Matrix.submatrix_mul_equiv _ _ _ (Fus.rightFirstStageEquiv a b c) _,
+    ← Matrix.blockDiagonal'_mul]
+  simp_rw [← Matrix.mul_kronecker_mul, Fus.analysis_mul_synthesis, Matrix.one_mul,
+    Matrix.one_kronecker_one]
+  change (Matrix.blockDiagonal' (1 : (f : Λ) → Matrix
+    (Fin (Fus.fusionMultiplicity b c f) × ((d : Λ) ×
+      (Fin (Fus.fusionMultiplicity a f d) × Fin (Fus.bondDim d)))) _ ℂ)).submatrix
+        (Fus.rightFinalFlattenEquiv a b c).symm
+        (Fus.rightFinalFlattenEquiv a b c).symm = 1
+  rw [Matrix.blockDiagonal'_one, Matrix.submatrix_one_equiv]
+
+private noncomputable def leftIntermediateLetter (a b c : Λ) (i l : Fin p) :
+    Matrix (Fus.LeftFirstStage a b c) (Fus.LeftFirstStage a b c) ℂ :=
+  (Matrix.blockDiagonal' fun e =>
+    (1 : Matrix (Fin (Fus.fusionMultiplicity a b e))
+      (Fin (Fus.fusionMultiplicity a b e)) ℂ) ⊗ₖ
+        (∑ k : Fin p, Fus.tensor e i k ⊗ₖ Fus.tensor c k l)).submatrix
+          (Fus.leftFirstStageEquiv a b c) (Fus.leftFirstStageEquiv a b c)
+
+private noncomputable def leftNaturalDirectSumLetter
+    (a b c : Λ) (i l : Fin p) :
+    Matrix (Fus.LeftFinalNested a b c) (Fus.LeftFinalNested a b c) ℂ :=
+  Matrix.blockDiagonal' fun e =>
+    (1 : Matrix (Fin (Fus.fusionMultiplicity a b e))
+      (Fin (Fus.fusionMultiplicity a b e)) ℂ) ⊗ₖ
+        Matrix.blockDiagonal' (fun d =>
+          (1 : Matrix (Fin (Fus.fusionMultiplicity e c d))
+            (Fin (Fus.fusionMultiplicity e c d)) ℂ) ⊗ₖ Fus.tensor d i l)
+
+private theorem tripleProductLetter_mul_leftFirstSynthesis
+    (a b c : Λ) (i l : Fin p) :
+    Fus.tripleProductLetter a b c i l * Fus.leftFirstSynthesis a b c =
+      Fus.leftFirstSynthesis a b c * Fus.leftIntermediateLetter a b c i l := by
+  classical
+  have hIntermediate : Fus.leftIntermediateLetter a b c i l =
+      ∑ k : Fin p, (Matrix.blockDiagonal' fun e =>
+        (1 : Matrix (Fin (Fus.fusionMultiplicity a b e))
+          (Fin (Fus.fusionMultiplicity a b e)) ℂ) ⊗ₖ Fus.tensor e i k) ⊗ₖ
+            Fus.tensor c k l := by
+    funext ⟨⟨e, μ, z⟩, x⟩ ⟨⟨e', μ', z'⟩, x'⟩
+    by_cases he : e = e'
+    · subst e'
+      by_cases hμ : μ = μ'
+      · subst μ'
+        simp [leftIntermediateLetter, leftFirstStageEquiv,
+          Matrix.blockDiagonal'_apply, Matrix.sum_apply]
+      · simp [leftIntermediateLetter, leftFirstStageEquiv,
+          Matrix.blockDiagonal'_apply, Matrix.sum_apply, hμ]
+    · simp [leftIntermediateLetter, leftFirstStageEquiv,
+        Matrix.blockDiagonal'_apply, Matrix.sum_apply, he]
+  rw [tripleProductLetter, leftFirstSynthesis, hIntermediate,
+    Matrix.sum_mul, Matrix.mul_sum]
+  simp_rw [Matrix.sum_mul]
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro k hk
+  have hPair := Fus.pairLetter_mul_synthesis a b i k
+  calc
+    (∑ j : Fin p,
+      ((Fus.tensor a i j ⊗ₖ Fus.tensor b j k) ⊗ₖ Fus.tensor c k l) *
+        (Fus.fusionSynthesis a b ⊗ₖ
+          (1 : Matrix (Fin (Fus.bondDim c)) (Fin (Fus.bondDim c)) ℂ))) =
+        (((∑ j : Fin p, Fus.tensor a i j ⊗ₖ Fus.tensor b j k) *
+          Fus.fusionSynthesis a b) ⊗ₖ Fus.tensor c k l) := by
+      rw [← Matrix.sum_mul]
+      have hTensor :
+          (∑ j : Fin p,
+            (Fus.tensor a i j ⊗ₖ Fus.tensor b j k) ⊗ₖ Fus.tensor c k l) =
+            (∑ j : Fin p, Fus.tensor a i j ⊗ₖ Fus.tensor b j k) ⊗ₖ
+              Fus.tensor c k l := by
+        funext x y
+        simp only [Matrix.sum_apply, kroneckerMap_apply]
+        rw [Finset.sum_mul]
+      rw [hTensor, ← Matrix.mul_kronecker_mul, Matrix.mul_one]
+    _ = ((Fus.fusionSynthesis a b * Matrix.blockDiagonal' (fun e =>
+          (1 : Matrix (Fin (Fus.fusionMultiplicity a b e))
+            (Fin (Fus.fusionMultiplicity a b e)) ℂ) ⊗ₖ Fus.tensor e i k)) ⊗ₖ
+          Fus.tensor c k l) := by rw [hPair]
+    _ = (Fus.fusionSynthesis a b ⊗ₖ
+          (1 : Matrix (Fin (Fus.bondDim c)) (Fin (Fus.bondDim c)) ℂ)) *
+        ((Matrix.blockDiagonal' fun e =>
+          (1 : Matrix (Fin (Fus.fusionMultiplicity a b e))
+            (Fin (Fus.fusionMultiplicity a b e)) ℂ) ⊗ₖ Fus.tensor e i k) ⊗ₖ
+          Fus.tensor c k l) := by
+      rw [← Matrix.mul_kronecker_mul, Matrix.one_mul]
+
+private theorem leftIntermediateLetter_mul_leftSecondSynthesis
+    (a b c : Λ) (i l : Fin p) :
+    Fus.leftIntermediateLetter a b c i l * Fus.leftSecondSynthesis a b c =
+      Fus.leftSecondSynthesis a b c * Fus.leftTripleDirectSumLetter a b c i l := by
+  classical
+  have hBlock :
+      (Matrix.blockDiagonal' fun e =>
+        (1 : Matrix (Fin (Fus.fusionMultiplicity a b e))
+          (Fin (Fus.fusionMultiplicity a b e)) ℂ) ⊗ₖ
+            (∑ k : Fin p, Fus.tensor e i k ⊗ₖ Fus.tensor c k l)) *
+        (Matrix.blockDiagonal' fun e =>
+          (1 : Matrix (Fin (Fus.fusionMultiplicity a b e))
+            (Fin (Fus.fusionMultiplicity a b e)) ℂ) ⊗ₖ Fus.fusionSynthesis e c) =
+      (Matrix.blockDiagonal' fun e =>
+        (1 : Matrix (Fin (Fus.fusionMultiplicity a b e))
+          (Fin (Fus.fusionMultiplicity a b e)) ℂ) ⊗ₖ Fus.fusionSynthesis e c) *
+        Fus.leftNaturalDirectSumLetter a b c i l := by
+    rw [← Matrix.blockDiagonal'_mul]
+    unfold leftNaturalDirectSumLetter
+    rw [← Matrix.blockDiagonal'_mul]
+    congr 1
+    funext e
+    rw [← Matrix.mul_kronecker_mul, Fus.pairLetter_mul_synthesis,
+      ← Matrix.mul_kronecker_mul, Matrix.one_mul]
+  have hFinal : Fus.leftTripleDirectSumLetter a b c i l =
+      (Fus.leftNaturalDirectSumLetter a b c i l).submatrix
+        (Fus.leftFinalFlattenEquiv a b c).symm
+        (Fus.leftFinalFlattenEquiv a b c).symm := by
+    funext ⟨d, ⟨⟨e, μ, ν⟩, z⟩⟩ ⟨d', ⟨⟨e', μ', ν'⟩, z'⟩⟩
+    by_cases hd : d = d'
+    · subst d'
+      by_cases he : e = e'
+      · subst e'
+        by_cases hμ : μ = μ'
+        · subst μ'
+          by_cases hν : ν = ν'
+          · subst ν'
+            simp [leftTripleDirectSumLetter, leftNaturalDirectSumLetter,
+              leftFinalFlattenEquiv, Matrix.blockDiagonal'_apply]
+          · simp [leftTripleDirectSumLetter, leftNaturalDirectSumLetter,
+              leftFinalFlattenEquiv, Matrix.blockDiagonal'_apply, hν]
+        · simp [leftTripleDirectSumLetter, leftNaturalDirectSumLetter,
+            leftFinalFlattenEquiv, Matrix.blockDiagonal'_apply, hμ]
+      · simp [leftTripleDirectSumLetter, leftNaturalDirectSumLetter,
+          leftFinalFlattenEquiv, Matrix.blockDiagonal'_apply, he]
+    · by_cases he : e = e'
+      · subst e'
+        simp [leftTripleDirectSumLetter, leftNaturalDirectSumLetter,
+          leftFinalFlattenEquiv, Matrix.blockDiagonal'_apply, hd]
+      · simp [leftTripleDirectSumLetter, leftNaturalDirectSumLetter,
+          leftFinalFlattenEquiv, Matrix.blockDiagonal'_apply, hd, he]
+  unfold leftIntermediateLetter leftSecondSynthesis
+  rw [Matrix.submatrix_mul_equiv _ _ _ (Fus.leftFirstStageEquiv a b c) _, hBlock,
+    hFinal, Matrix.submatrix_mul_equiv]
+
+private noncomputable def rightIntermediateLetter (a b c : Λ) (i l : Fin p) :
+    Matrix (Fus.RightFirstStage a b c) (Fus.RightFirstStage a b c) ℂ :=
+  (Matrix.blockDiagonal' fun f =>
+    (1 : Matrix (Fin (Fus.fusionMultiplicity b c f))
+      (Fin (Fus.fusionMultiplicity b c f)) ℂ) ⊗ₖ
+        (∑ j : Fin p, Fus.tensor a i j ⊗ₖ Fus.tensor f j l)).submatrix
+          (Fus.rightFirstStageEquiv a b c) (Fus.rightFirstStageEquiv a b c)
+
+private noncomputable def rightNaturalDirectSumLetter
+    (a b c : Λ) (i l : Fin p) :
+    Matrix (Fus.RightFinalNested a b c) (Fus.RightFinalNested a b c) ℂ :=
+  Matrix.blockDiagonal' fun f =>
+    (1 : Matrix (Fin (Fus.fusionMultiplicity b c f))
+      (Fin (Fus.fusionMultiplicity b c f)) ℂ) ⊗ₖ
+        Matrix.blockDiagonal' (fun d =>
+          (1 : Matrix (Fin (Fus.fusionMultiplicity a f d))
+            (Fin (Fus.fusionMultiplicity a f d)) ℂ) ⊗ₖ Fus.tensor d i l)
+
+private theorem rightSecondAnalysis_mul_rightIntermediateLetter
+    (a b c : Λ) (i l : Fin p) :
+    Fus.rightSecondAnalysis a b c * Fus.rightIntermediateLetter a b c i l =
+      Fus.rightTripleDirectSumLetter a b c i l * Fus.rightSecondAnalysis a b c := by
+  classical
+  have hBlock :
+      (Matrix.blockDiagonal' fun f =>
+        (1 : Matrix (Fin (Fus.fusionMultiplicity b c f))
+          (Fin (Fus.fusionMultiplicity b c f)) ℂ) ⊗ₖ Fus.fusionAnalysis a f) *
+        (Matrix.blockDiagonal' fun f =>
+          (1 : Matrix (Fin (Fus.fusionMultiplicity b c f))
+            (Fin (Fus.fusionMultiplicity b c f)) ℂ) ⊗ₖ
+              (∑ j : Fin p, Fus.tensor a i j ⊗ₖ Fus.tensor f j l)) =
+      Fus.rightNaturalDirectSumLetter a b c i l *
+        (Matrix.blockDiagonal' fun f =>
+          (1 : Matrix (Fin (Fus.fusionMultiplicity b c f))
+            (Fin (Fus.fusionMultiplicity b c f)) ℂ) ⊗ₖ Fus.fusionAnalysis a f) := by
+    rw [← Matrix.blockDiagonal'_mul]
+    unfold rightNaturalDirectSumLetter
+    rw [← Matrix.blockDiagonal'_mul]
+    congr 1
+    funext f
+    rw [← Matrix.mul_kronecker_mul, Fus.analysis_mul_pairLetter,
+      ← Matrix.mul_kronecker_mul, Matrix.one_mul]
+  have hFinal : Fus.rightTripleDirectSumLetter a b c i l =
+      (Fus.rightNaturalDirectSumLetter a b c i l).submatrix
+        (Fus.rightFinalFlattenEquiv a b c).symm
+        (Fus.rightFinalFlattenEquiv a b c).symm := by
+    funext ⟨d, ⟨⟨f, m, n⟩, z⟩⟩ ⟨d', ⟨⟨f', m', n'⟩, z'⟩⟩
+    by_cases hd : d = d'
+    · subst d'
+      by_cases hf : f = f'
+      · subst f'
+        by_cases hm : m = m'
+        · subst m'
+          by_cases hn : n = n'
+          · subst n'
+            simp [rightTripleDirectSumLetter, rightNaturalDirectSumLetter,
+              rightFinalFlattenEquiv, Matrix.blockDiagonal'_apply]
+          · simp [rightTripleDirectSumLetter, rightNaturalDirectSumLetter,
+              rightFinalFlattenEquiv, Matrix.blockDiagonal'_apply, hn]
+        · simp [rightTripleDirectSumLetter, rightNaturalDirectSumLetter,
+            rightFinalFlattenEquiv, Matrix.blockDiagonal'_apply, hm]
+      · simp [rightTripleDirectSumLetter, rightNaturalDirectSumLetter,
+          rightFinalFlattenEquiv, Matrix.blockDiagonal'_apply, hf]
+    · by_cases hf : f = f'
+      · subst f'
+        simp [rightTripleDirectSumLetter, rightNaturalDirectSumLetter,
+          rightFinalFlattenEquiv, Matrix.blockDiagonal'_apply, hd]
+      · simp [rightTripleDirectSumLetter, rightNaturalDirectSumLetter,
+          rightFinalFlattenEquiv, Matrix.blockDiagonal'_apply, hd, hf]
+  unfold rightSecondAnalysis rightIntermediateLetter
+  rw [Matrix.submatrix_mul_equiv _ _ _ (Fus.rightFirstStageEquiv a b c) _, hBlock,
+    hFinal, Matrix.submatrix_mul_equiv]
+
+private theorem rightFirstAnalysis_mul_tripleProductLetter
+    (a b c : Λ) (i l : Fin p) :
+    Fus.rightFirstAnalysis a b c * Fus.tripleProductLetter a b c i l =
+      Fus.rightIntermediateLetter a b c i l * Fus.rightFirstAnalysis a b c := by
+  classical
+  let P : Matrix
+      (Fin (Fus.bondDim a) × (Fin (Fus.bondDim b) × Fin (Fus.bondDim c)))
+      (Fin (Fus.bondDim a) × (Fin (Fus.bondDim b) × Fin (Fus.bondDim c))) ℂ :=
+    ∑ j : Fin p, Fus.tensor a i j ⊗ₖ
+      (∑ k : Fin p, Fus.tensor b j k ⊗ₖ Fus.tensor c k l)
+  let E : Matrix (Fus.RightFirstStage a b c) (Fus.RightFirstStage a b c) ℂ :=
+    ∑ j : Fin p, Fus.tensor a i j ⊗ₖ Matrix.blockDiagonal' (fun f =>
+      (1 : Matrix (Fin (Fus.fusionMultiplicity b c f))
+        (Fin (Fus.fusionMultiplicity b c f)) ℂ) ⊗ₖ Fus.tensor f j l)
+  have hP : Fus.tripleProductLetter a b c i l =
+      P.submatrix (Fus.rightBondAssocEquiv a b c)
+        (Fus.rightBondAssocEquiv a b c) := by
+    funext ⟨⟨xa, xb⟩, xc⟩ ⟨⟨ya, yb⟩, yc⟩
+    simp [P, tripleProductLetter, rightBondAssocEquiv, Matrix.sum_apply,
+      Finset.mul_sum]
+    ring_nf
+  have hE : Fus.rightIntermediateLetter a b c i l = E := by
+    funext ⟨x, ⟨f, m, z⟩⟩ ⟨x', ⟨f', m', z'⟩⟩
+    by_cases hf : f = f'
+    · subst f'
+      by_cases hm : m = m'
+      · subst m'
+        simp [E, rightIntermediateLetter, rightFirstStageEquiv,
+          Matrix.blockDiagonal'_apply, Matrix.sum_apply]
+      · simp [E, rightIntermediateLetter, rightFirstStageEquiv,
+          Matrix.blockDiagonal'_apply, Matrix.sum_apply, hm]
+    · simp [E, rightIntermediateLetter, rightFirstStageEquiv,
+        Matrix.blockDiagonal'_apply, Matrix.sum_apply, hf]
+  have hCore :
+      ((1 : Matrix (Fin (Fus.bondDim a)) (Fin (Fus.bondDim a)) ℂ) ⊗ₖ
+          Fus.fusionAnalysis b c) * P =
+        E * ((1 : Matrix (Fin (Fus.bondDim a)) (Fin (Fus.bondDim a)) ℂ) ⊗ₖ
+          Fus.fusionAnalysis b c) := by
+    dsimp only [P, E]
+    rw [Matrix.mul_sum, Matrix.sum_mul]
+    apply Finset.sum_congr rfl
+    intro j hj
+    rw [← Matrix.mul_kronecker_mul, Matrix.one_mul,
+      Fus.analysis_mul_pairLetter, ← Matrix.mul_kronecker_mul, Matrix.mul_one]
+  unfold rightFirstAnalysis
+  rw [hP, Matrix.submatrix_mul_equiv _ _ _ (Fus.rightBondAssocEquiv a b c) _,
+    hCore, ← hE]
+  simpa using Matrix.submatrix_mul
+    (Fus.rightIntermediateLetter a b c i l)
+    ((1 : Matrix (Fin (Fus.bondDim a)) (Fin (Fus.bondDim a)) ℂ) ⊗ₖ
+      Fus.fusionAnalysis b c)
+    (Equiv.refl _) (Equiv.refl _) (Fus.rightBondAssocEquiv a b c)
+    (Equiv.refl _).bijective
+
+/-- The left-associated triple synthesis satisfies the zipper identity.
+
+Source: arXiv:1511.08090, equations `zippercondition2` and the first identity
+at lines 242--245. -/
+theorem tripleProductLetter_mul_leftTripleSynthesisFull
+    (a b c : Λ) (i l : Fin p) :
+    Fus.tripleProductLetter a b c i l * Fus.leftTripleSynthesisFull a b c =
+      Fus.leftTripleSynthesisFull a b c * Fus.leftTripleDirectSumLetter a b c i l := by
+  rw [Fus.leftSynthesisFull_eq_stages, ← Matrix.mul_assoc,
+    Fus.tripleProductLetter_mul_leftFirstSynthesis, Matrix.mul_assoc,
+    Fus.leftIntermediateLetter_mul_leftSecondSynthesis, Matrix.mul_assoc]
+
+/-- The right-associated triple analysis satisfies the reverse zipper identity.
+
+Source: arXiv:1511.08090, equations `zippercondition2` and the second identity
+at lines 242--246. -/
+theorem rightTripleAnalysisFull_mul_tripleProductLetter
+    (a b c : Λ) (i l : Fin p) :
+    Fus.rightTripleAnalysisFull a b c * Fus.tripleProductLetter a b c i l =
+      Fus.rightTripleDirectSumLetter a b c i l *
+        Fus.rightTripleAnalysisFull a b c := by
+  rw [Fus.rightAnalysisFull_eq_stages, Matrix.mul_assoc,
+    Fus.rightFirstAnalysis_mul_tripleProductLetter, ← Matrix.mul_assoc,
+    Fus.rightSecondAnalysis_mul_rightIntermediateLetter, Matrix.mul_assoc]
+
+/-- The left-associated triple analysis followed by its synthesis is the
+identity on the full left fusion-coordinate space.
+
+Source: arXiv:1511.08090, the biorthogonality relation at line 161, applied
+twice. -/
+theorem leftTripleAnalysisFull_mul_synthesis (a b c : Λ) :
+    Fus.leftTripleAnalysisFull a b c * Fus.leftTripleSynthesisFull a b c = 1 := by
+  rw [Fus.leftSynthesisFull_eq_stages, Fus.leftAnalysisFull_eq_stages,
+    Matrix.mul_assoc, ← Matrix.mul_assoc (Fus.leftFirstAnalysis a b c),
+    Fus.leftFirstAnalysis_mul_synthesis, Matrix.one_mul,
+    Fus.leftSecondAnalysis_mul_synthesis]
+
+/-- The right-associated triple analysis followed by its synthesis is the
+identity on the full right fusion-coordinate space.
+
+Source: arXiv:1511.08090, the biorthogonality relation at line 161, applied
+twice. -/
+theorem rightTripleAnalysisFull_mul_synthesis (a b c : Λ) :
+    Fus.rightTripleAnalysisFull a b c * Fus.rightTripleSynthesisFull a b c = 1 := by
+  rw [Fus.rightSynthesisFull_eq_stages, Fus.rightAnalysisFull_eq_stages,
+    Matrix.mul_assoc, ← Matrix.mul_assoc (Fus.rightFirstAnalysis a b c),
+    Fus.rightFirstAnalysis_mul_synthesis, Matrix.one_mul,
+    Fus.rightSecondAnalysis_mul_synthesis]
+
+
+/-- The coefficient selecting the diagonal matrix units of one final block.
+
+Source: arXiv:1511.08090, the simultaneous inverse at lines 269--277. -/
+private noncomputable def supportFinalBlockSelector
+    (d : Λ) (ik : Fin p × Fin p) : ℂ :=
+  ∑ x : Fin (Fus.bondDim d), Fus.blockLeftInverse ⟨d, x, x⟩ ik
+
+private theorem supportFinalBlockSelector_apply (d e : Λ)
+    (x y : Fin (Fus.bondDim e)) :
+    (∑ i : Fin p, ∑ l : Fin p,
+      Fus.supportFinalBlockSelector d (i, l) * Fus.tensor e i l x y) =
+      if h : d = e then if _ : h ▸ x = y then 1 else 0 else 0 := by
+  classical
+  simp only [supportFinalBlockSelector, Finset.sum_mul]
+  calc
+    (∑ i : Fin p, ∑ l : Fin p, ∑ z : Fin (Fus.bondDim d),
+        Fus.blockLeftInverse ⟨d, z, z⟩ (i, l) * Fus.tensor e i l x y) =
+        ∑ z : Fin (Fus.bondDim d), ∑ i : Fin p, ∑ l : Fin p,
+          Fus.blockLeftInverse ⟨d, z, z⟩ (i, l) * Fus.tensor e i l x y := by
+      calc
+        _ = ∑ i : Fin p, ∑ z : Fin (Fus.bondDim d), ∑ l : Fin p,
+            Fus.blockLeftInverse ⟨d, z, z⟩ (i, l) * Fus.tensor e i l x y := by
+          apply Finset.sum_congr rfl
+          intro i hi
+          exact Finset.sum_comm
+        _ = _ := Finset.sum_comm
+    _ = if h : d = e then if _ : h ▸ x = y then 1 else 0 else 0 := by
+      by_cases h : d = e
+      · subst e
+        simp_rw [Fus.blockLeftInverse_apply d d]
+        simp
+      · simp_rw [Fus.blockLeftInverse_apply d e]
+        simp [h]
+
+private theorem supportFinalBlockSelector_sum (d e : Λ) :
+    (∑ i : Fin p, ∑ l : Fin p,
+      Fus.supportFinalBlockSelector d (i, l) •
+        (Fus.tensor e i l : Matrix (Fin (Fus.bondDim e))
+          (Fin (Fus.bondDim e)) ℂ)) =
+      if d = e then 1 else 0 := by
+  classical
+  funext x y
+  simp only [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
+  rw [Fus.supportFinalBlockSelector_apply d e x y]
+  by_cases h : d = e
+  · subst e
+    simp [Matrix.one_apply]
+  · simp [h]
+
+/-- The total coefficient obtained by summing diagonal matrix-unit selectors
+for every final label.
+
+Source: arXiv:1511.08090, the simultaneous inverse at lines 269--277. -/
+private noncomputable def totalBlockSelector (ik : Fin p × Fin p) : ℂ :=
+  ∑ d : Λ, Fus.supportFinalBlockSelector d ik
+
+/-- Contracting the total selector with any labelled block letter gives the
+identity matrix.
+
+Source: arXiv:1511.08090, the simultaneous inverse at lines 269--277. -/
+private theorem totalBlockSelector_sum (e : Λ) :
+    (∑ i : Fin p, ∑ l : Fin p,
+      Fus.totalBlockSelector (i, l) •
+        (Fus.tensor e i l : Matrix (Fin (Fus.bondDim e))
+          (Fin (Fus.bondDim e)) ℂ)) = 1 := by
+  classical
+  simp only [totalBlockSelector, Finset.sum_smul]
+  calc
+    (∑ i : Fin p, ∑ l : Fin p, ∑ d : Λ,
+        Fus.supportFinalBlockSelector d (i, l) • Fus.tensor e i l) =
+        ∑ i : Fin p, ∑ d : Λ, ∑ l : Fin p,
+          Fus.supportFinalBlockSelector d (i, l) • Fus.tensor e i l := by
+      apply Finset.sum_congr rfl
+      intro i hi
+      exact Finset.sum_comm
+    _ = ∑ d : Λ, ∑ i : Fin p, ∑ l : Fin p,
+          Fus.supportFinalBlockSelector d (i, l) • Fus.tensor e i l :=
+      Finset.sum_comm
+    _ = ∑ d : Λ, if d = e then 1 else 0 := by
+      apply Finset.sum_congr rfl
+      intro d hd
+      exact Fus.supportFinalBlockSelector_sum d e
+    _ = 1 := by simp
+
+/-- Contracting final-block letters with the total selector gives the identity
+in the left-associated coordinate space. -/
+private theorem totalBlockSelector_leftDirectSum (a b c : Λ) :
+    (∑ i : Fin p, ∑ l : Fin p,
+      Fus.totalBlockSelector (i, l) • Fus.leftTripleDirectSumLetter a b c i l) =
+      1 := by
+  classical
+  funext ⟨d, m, x⟩ ⟨e, n, y⟩
+  simp only [Matrix.sum_apply, Matrix.smul_apply]
+  by_cases hde : d = e
+  · subst e
+    by_cases hmn : m = n
+    · subst n
+      simpa [leftTripleDirectSumLetter, Matrix.blockDiagonal'_apply_eq,
+        Matrix.one_apply, Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul] using congrArg
+          (fun M => M x y) (Fus.totalBlockSelector_sum d)
+    · simp [leftTripleDirectSumLetter, Matrix.blockDiagonal'_apply_eq, hmn]
+  · simp [leftTripleDirectSumLetter, Matrix.blockDiagonal'_apply_ne, hde]
+
+/-- Contracting final-block letters with the total selector gives the identity
+in the right-associated coordinate space. -/
+private theorem totalBlockSelector_rightDirectSum (a b c : Λ) :
+    (∑ i : Fin p, ∑ l : Fin p,
+      Fus.totalBlockSelector (i, l) • Fus.rightTripleDirectSumLetter a b c i l) =
+      1 := by
+  classical
+  funext ⟨d, m, x⟩ ⟨e, n, y⟩
+  simp only [Matrix.sum_apply, Matrix.smul_apply]
+  by_cases hde : d = e
+  · subst e
+    by_cases hmn : m = n
+    · subst n
+      simpa [rightTripleDirectSumLetter, Matrix.blockDiagonal'_apply_eq,
+        Matrix.one_apply, Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul] using congrArg
+          (fun M => M x y) (Fus.totalBlockSelector_sum d)
+    · simp [rightTripleDirectSumLetter, Matrix.blockDiagonal'_apply_eq, hmn]
+  · simp [rightTripleDirectSumLetter, Matrix.blockDiagonal'_apply_ne, hde]
+
+/-- Every triple-product letter is reconstructed through the left-associated
+fusion support.
+
+Source: arXiv:1511.08090, equation `inversegaugeone` at lines 184--186,
+applied to the two fusions in lines 238--243. -/
+theorem tripleProductLetter_eq_left_reconstruction
+    (a b c : Λ) (i l : Fin p) :
+    Fus.tripleProductLetter a b c i l =
+      Fus.leftTripleSynthesisFull a b c *
+        Fus.leftTripleDirectSumLetter a b c i l *
+          Fus.leftTripleAnalysisFull a b c := by
+  classical
+  have hFirst : Fus.tripleProductLetter a b c i l =
+      Fus.leftFirstSynthesis a b c * Fus.leftIntermediateLetter a b c i l *
+        Fus.leftFirstAnalysis a b c := by
+    have hIntermediate : Fus.leftIntermediateLetter a b c i l =
+        ∑ k : Fin p, (Matrix.blockDiagonal' fun e =>
+          (1 : Matrix (Fin (Fus.fusionMultiplicity a b e))
+            (Fin (Fus.fusionMultiplicity a b e)) ℂ) ⊗ₖ Fus.tensor e i k) ⊗ₖ
+              Fus.tensor c k l := by
+      funext ⟨⟨e, μ, z⟩, x⟩ ⟨⟨e', μ', z'⟩, x'⟩
+      by_cases he : e = e'
+      · subst e'
+        by_cases hμ : μ = μ'
+        · subst μ'
+          simp [leftIntermediateLetter, leftFirstStageEquiv,
+            Matrix.blockDiagonal'_apply, Matrix.sum_apply]
+        · simp [leftIntermediateLetter, leftFirstStageEquiv,
+            Matrix.blockDiagonal'_apply, Matrix.sum_apply, hμ]
+      · simp [leftIntermediateLetter, leftFirstStageEquiv,
+          Matrix.blockDiagonal'_apply, Matrix.sum_apply, he]
+    rw [tripleProductLetter, leftFirstSynthesis, leftFirstAnalysis, hIntermediate,
+      Matrix.mul_sum]
+    simp_rw [Matrix.sum_mul]
+    rw [Finset.sum_comm]
+    apply Finset.sum_congr rfl
+    intro k hk
+    have hTensor :
+        (∑ j : Fin p,
+          (Fus.tensor a i j ⊗ₖ Fus.tensor b j k) ⊗ₖ Fus.tensor c k l) =
+          (∑ j : Fin p, Fus.tensor a i j ⊗ₖ Fus.tensor b j k) ⊗ₖ
+            Fus.tensor c k l := by
+      funext x y
+      simp only [Matrix.sum_apply, kroneckerMap_apply]
+      rw [Finset.sum_mul]
+    rw [hTensor, Fus.pairLetter_eq_synthesis_mul_directSum_mul_analysis a b i k]
+    rw [← Matrix.mul_kronecker_mul, Matrix.one_mul,
+      ← Matrix.mul_kronecker_mul, Matrix.mul_one]
+  have hSecond : Fus.leftIntermediateLetter a b c i l =
+      Fus.leftSecondSynthesis a b c * Fus.leftTripleDirectSumLetter a b c i l *
+        Fus.leftSecondAnalysis a b c := by
+    have hBlock :
+        (Matrix.blockDiagonal' fun e =>
+          (1 : Matrix (Fin (Fus.fusionMultiplicity a b e))
+            (Fin (Fus.fusionMultiplicity a b e)) ℂ) ⊗ₖ
+              (∑ k : Fin p, Fus.tensor e i k ⊗ₖ Fus.tensor c k l)) =
+        (Matrix.blockDiagonal' fun e =>
+          (1 : Matrix (Fin (Fus.fusionMultiplicity a b e))
+            (Fin (Fus.fusionMultiplicity a b e)) ℂ) ⊗ₖ Fus.fusionSynthesis e c) *
+        Fus.leftNaturalDirectSumLetter a b c i l *
+        (Matrix.blockDiagonal' fun e =>
+          (1 : Matrix (Fin (Fus.fusionMultiplicity a b e))
+            (Fin (Fus.fusionMultiplicity a b e)) ℂ) ⊗ₖ Fus.fusionAnalysis e c) := by
+      unfold leftNaturalDirectSumLetter
+      rw [← Matrix.blockDiagonal'_mul, ← Matrix.blockDiagonal'_mul]
+      congr 1
+      funext e
+      rw [← Matrix.mul_kronecker_mul, Matrix.one_mul,
+        Fus.pairLetter_eq_synthesis_mul_directSum_mul_analysis e c i l,
+        ← Matrix.mul_kronecker_mul, Matrix.one_mul]
+    have hFinal : Fus.leftTripleDirectSumLetter a b c i l =
+        (Fus.leftNaturalDirectSumLetter a b c i l).submatrix
+          (Fus.leftFinalFlattenEquiv a b c).symm
+          (Fus.leftFinalFlattenEquiv a b c).symm := by
+      funext ⟨d, ⟨⟨e, μ, ν⟩, z⟩⟩ ⟨d', ⟨⟨e', μ', ν'⟩, z'⟩⟩
+      by_cases hd : d = d'
+      · subst d'
+        by_cases he : e = e'
+        · subst e'
+          by_cases hμ : μ = μ'
+          · subst μ'
+            by_cases hν : ν = ν'
+            · subst ν'
+              simp [leftTripleDirectSumLetter, leftNaturalDirectSumLetter,
+                leftFinalFlattenEquiv, Matrix.blockDiagonal'_apply]
+            · simp [leftTripleDirectSumLetter, leftNaturalDirectSumLetter,
+                leftFinalFlattenEquiv, Matrix.blockDiagonal'_apply, hν]
+          · simp [leftTripleDirectSumLetter, leftNaturalDirectSumLetter,
+              leftFinalFlattenEquiv, Matrix.blockDiagonal'_apply, hμ]
+        · simp [leftTripleDirectSumLetter, leftNaturalDirectSumLetter,
+            leftFinalFlattenEquiv, Matrix.blockDiagonal'_apply, he]
+      · by_cases he : e = e'
+        · subst e'
+          simp [leftTripleDirectSumLetter, leftNaturalDirectSumLetter,
+            leftFinalFlattenEquiv, Matrix.blockDiagonal'_apply, hd]
+        · simp [leftTripleDirectSumLetter, leftNaturalDirectSumLetter,
+            leftFinalFlattenEquiv, Matrix.blockDiagonal'_apply, hd, he]
+    unfold leftIntermediateLetter leftSecondSynthesis leftSecondAnalysis
+    rw [hFinal, Matrix.submatrix_mul_equiv, Matrix.submatrix_mul_equiv, ← hBlock]
+  rw [Fus.leftSynthesisFull_eq_stages, Fus.leftAnalysisFull_eq_stages,
+    hFirst, hSecond]
+  simp only [Matrix.mul_assoc]
+
+/-- Every triple-product letter is reconstructed through the right-associated
+fusion support.
+
+Source: arXiv:1511.08090, equation `inversegaugeone` at lines 184--186,
+applied to the two fusions in lines 244--247. -/
+theorem tripleProductLetter_eq_right_reconstruction
+    (a b c : Λ) (i l : Fin p) :
+    Fus.tripleProductLetter a b c i l =
+      Fus.rightTripleSynthesisFull a b c *
+        Fus.rightTripleDirectSumLetter a b c i l *
+          Fus.rightTripleAnalysisFull a b c := by
+  classical
+  have hFirst : Fus.tripleProductLetter a b c i l =
+      Fus.rightFirstSynthesis a b c * Fus.rightIntermediateLetter a b c i l *
+        Fus.rightFirstAnalysis a b c := by
+    let P : Matrix
+        (Fin (Fus.bondDim a) × (Fin (Fus.bondDim b) × Fin (Fus.bondDim c)))
+        (Fin (Fus.bondDim a) × (Fin (Fus.bondDim b) × Fin (Fus.bondDim c))) ℂ :=
+      ∑ j : Fin p, Fus.tensor a i j ⊗ₖ
+        (∑ k : Fin p, Fus.tensor b j k ⊗ₖ Fus.tensor c k l)
+    let E : Matrix (Fus.RightFirstStage a b c) (Fus.RightFirstStage a b c) ℂ :=
+      ∑ j : Fin p, Fus.tensor a i j ⊗ₖ Matrix.blockDiagonal' (fun f =>
+        (1 : Matrix (Fin (Fus.fusionMultiplicity b c f))
+          (Fin (Fus.fusionMultiplicity b c f)) ℂ) ⊗ₖ Fus.tensor f j l)
+    have hP : Fus.tripleProductLetter a b c i l =
+        P.submatrix (Fus.rightBondAssocEquiv a b c)
+          (Fus.rightBondAssocEquiv a b c) := by
+      funext ⟨⟨xa, xb⟩, xc⟩ ⟨⟨ya, yb⟩, yc⟩
+      simp [P, tripleProductLetter, rightBondAssocEquiv, Matrix.sum_apply,
+        Finset.mul_sum]
+      ring_nf
+    have hE : Fus.rightIntermediateLetter a b c i l = E := by
+      funext ⟨x, ⟨f, m, z⟩⟩ ⟨x', ⟨f', m', z'⟩⟩
+      by_cases hf : f = f'
+      · subst f'
+        by_cases hm : m = m'
+        · subst m'
+          simp [E, rightIntermediateLetter, rightFirstStageEquiv,
+            Matrix.blockDiagonal'_apply, Matrix.sum_apply]
+        · simp [E, rightIntermediateLetter, rightFirstStageEquiv,
+            Matrix.blockDiagonal'_apply, Matrix.sum_apply, hm]
+      · simp [E, rightIntermediateLetter, rightFirstStageEquiv,
+          Matrix.blockDiagonal'_apply, Matrix.sum_apply, hf]
+    have hCore : P =
+        ((1 : Matrix (Fin (Fus.bondDim a)) (Fin (Fus.bondDim a)) ℂ) ⊗ₖ
+          Fus.fusionSynthesis b c) * E *
+        ((1 : Matrix (Fin (Fus.bondDim a)) (Fin (Fus.bondDim a)) ℂ) ⊗ₖ
+          Fus.fusionAnalysis b c) := by
+      dsimp only [P, E]
+      rw [Matrix.mul_sum]
+      simp_rw [Matrix.sum_mul]
+      apply Finset.sum_congr rfl
+      intro j hj
+      rw [← Matrix.mul_kronecker_mul, Matrix.one_mul,
+        Fus.pairLetter_eq_synthesis_mul_directSum_mul_analysis b c j l,
+        ← Matrix.mul_kronecker_mul, Matrix.mul_one]
+    unfold rightFirstSynthesis rightFirstAnalysis
+    rw [hP, hE, hCore]
+    symm
+    change
+      ((1 : Matrix (Fin (Fus.bondDim a)) (Fin (Fus.bondDim a)) ℂ) ⊗ₖ
+            Fus.fusionSynthesis b c).submatrix (Fus.rightBondAssocEquiv a b c)
+              (Equiv.refl _) *
+          E.submatrix (Equiv.refl _) (Equiv.refl _) *
+        ((1 : Matrix (Fin (Fus.bondDim a)) (Fin (Fus.bondDim a)) ℂ) ⊗ₖ
+            Fus.fusionAnalysis b c).submatrix (Equiv.refl _)
+              (Fus.rightBondAssocEquiv a b c) = _
+    rw [Matrix.submatrix_mul_equiv, Matrix.submatrix_mul_equiv]
+  have hSecond : Fus.rightIntermediateLetter a b c i l =
+      Fus.rightSecondSynthesis a b c * Fus.rightTripleDirectSumLetter a b c i l *
+        Fus.rightSecondAnalysis a b c := by
+    have hBlock :
+        (Matrix.blockDiagonal' fun f =>
+          (1 : Matrix (Fin (Fus.fusionMultiplicity b c f))
+            (Fin (Fus.fusionMultiplicity b c f)) ℂ) ⊗ₖ
+              (∑ j : Fin p, Fus.tensor a i j ⊗ₖ Fus.tensor f j l)) =
+        (Matrix.blockDiagonal' fun f =>
+          (1 : Matrix (Fin (Fus.fusionMultiplicity b c f))
+            (Fin (Fus.fusionMultiplicity b c f)) ℂ) ⊗ₖ Fus.fusionSynthesis a f) *
+        Fus.rightNaturalDirectSumLetter a b c i l *
+        (Matrix.blockDiagonal' fun f =>
+          (1 : Matrix (Fin (Fus.fusionMultiplicity b c f))
+            (Fin (Fus.fusionMultiplicity b c f)) ℂ) ⊗ₖ Fus.fusionAnalysis a f) := by
+      unfold rightNaturalDirectSumLetter
+      rw [← Matrix.blockDiagonal'_mul, ← Matrix.blockDiagonal'_mul]
+      congr 1
+      funext f
+      rw [← Matrix.mul_kronecker_mul, Matrix.one_mul,
+        Fus.pairLetter_eq_synthesis_mul_directSum_mul_analysis a f i l,
+        ← Matrix.mul_kronecker_mul, Matrix.one_mul]
+    have hFinal : Fus.rightTripleDirectSumLetter a b c i l =
+        (Fus.rightNaturalDirectSumLetter a b c i l).submatrix
+          (Fus.rightFinalFlattenEquiv a b c).symm
+          (Fus.rightFinalFlattenEquiv a b c).symm := by
+      funext ⟨d, ⟨⟨f, m, n⟩, z⟩⟩ ⟨d', ⟨⟨f', m', n'⟩, z'⟩⟩
+      by_cases hd : d = d'
+      · subst d'
+        by_cases hf : f = f'
+        · subst f'
+          by_cases hm : m = m'
+          · subst m'
+            by_cases hn : n = n'
+            · subst n'
+              simp [rightTripleDirectSumLetter, rightNaturalDirectSumLetter,
+                rightFinalFlattenEquiv, Matrix.blockDiagonal'_apply]
+            · simp [rightTripleDirectSumLetter, rightNaturalDirectSumLetter,
+                rightFinalFlattenEquiv, Matrix.blockDiagonal'_apply, hn]
+          · simp [rightTripleDirectSumLetter, rightNaturalDirectSumLetter,
+              rightFinalFlattenEquiv, Matrix.blockDiagonal'_apply, hm]
+        · simp [rightTripleDirectSumLetter, rightNaturalDirectSumLetter,
+            rightFinalFlattenEquiv, Matrix.blockDiagonal'_apply, hf]
+      · by_cases hf : f = f'
+        · subst f'
+          simp [rightTripleDirectSumLetter, rightNaturalDirectSumLetter,
+            rightFinalFlattenEquiv, Matrix.blockDiagonal'_apply, hd]
+        · simp [rightTripleDirectSumLetter, rightNaturalDirectSumLetter,
+            rightFinalFlattenEquiv, Matrix.blockDiagonal'_apply, hd, hf]
+    unfold rightIntermediateLetter rightSecondSynthesis rightSecondAnalysis
+    rw [hFinal, Matrix.submatrix_mul_equiv, Matrix.submatrix_mul_equiv, ← hBlock]
+  rw [Fus.rightSynthesisFull_eq_stages, Fus.rightAnalysisFull_eq_stages,
+    hFirst, hSecond]
+  simp only [Matrix.mul_assoc]
+
+/-- The left- and right-associated triple-fusion maps have the same support
+projector in the ambient triple-bond space.
+
+The equality is derived by contracting the two triple-letter reconstructions
+with the simultaneous inverse of the final block letters.
+
+Source: arXiv:1511.08090, equation `inversegaugeone` at lines 184--186, the
+associative decompositions at lines 238--247, and the simultaneous inverse at
+lines 269--277. -/
+theorem leftTripleSupport_eq_rightTripleSupport (a b c : Λ) :
+    Fus.leftTripleSynthesisFull a b c * Fus.leftTripleAnalysisFull a b c =
+      Fus.rightTripleSynthesisFull a b c * Fus.rightTripleAnalysisFull a b c := by
+  classical
+  let contracted := ∑ i : Fin p, ∑ l : Fin p,
+    Fus.totalBlockSelector (i, l) • Fus.tripleProductLetter a b c i l
+  have hLeft : contracted =
+      Fus.leftTripleSynthesisFull a b c * Fus.leftTripleAnalysisFull a b c := by
+    dsimp only [contracted]
+    simp_rw [Fus.tripleProductLetter_eq_left_reconstruction]
+    calc
+      _ = Fus.leftTripleSynthesisFull a b c *
+          (∑ i : Fin p, ∑ l : Fin p,
+            Fus.totalBlockSelector (i, l) •
+              Fus.leftTripleDirectSumLetter a b c i l) *
+            Fus.leftTripleAnalysisFull a b c := by
+        symm
+        rw [Matrix.mul_sum, Matrix.sum_mul]
+        simp_rw [Matrix.mul_sum, Matrix.sum_mul, Matrix.mul_smul, Matrix.smul_mul]
+      _ = _ := by
+        rw [Fus.totalBlockSelector_leftDirectSum, Matrix.mul_one]
+  have hRight : contracted =
+      Fus.rightTripleSynthesisFull a b c * Fus.rightTripleAnalysisFull a b c := by
+    dsimp only [contracted]
+    simp_rw [Fus.tripleProductLetter_eq_right_reconstruction]
+    calc
+      _ = Fus.rightTripleSynthesisFull a b c *
+          (∑ i : Fin p, ∑ l : Fin p,
+            Fus.totalBlockSelector (i, l) •
+              Fus.rightTripleDirectSumLetter a b c i l) *
+            Fus.rightTripleAnalysisFull a b c := by
+        symm
+        rw [Matrix.mul_sum, Matrix.sum_mul]
+        simp_rw [Matrix.mul_sum, Matrix.sum_mul, Matrix.mul_smul, Matrix.smul_mul]
+      _ = _ := by
+        rw [Fus.totalBlockSelector_rightDirectSum, Matrix.mul_one]
+  exact hLeft.symm.trans hRight
+
+end CompleteZipperFusionFamily
+
+end MPOTensor

--- a/blueprint/src/Packages/tn_diagrams.py
+++ b/blueprint/src/Packages/tn_diagrams.py
@@ -79,6 +79,7 @@ _DIAGRAM_ARGS: dict[str, str] = {
     "TNMPDOFixedFinalFusionBracketings": "",
     "TNMPDOFixedFinalComparisonUnitary": "",
     "TNMPDOFourfoldBondReassociationPentagon": "",
+    "TNMPDOPrintedFMove": "",
     "TNMPDOBNTFusionIdentity": "",
     "TNMPDOUnweightedZipperReconstruction": "",
     "TNMPDOFusionTracePower": "",

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -1230,6 +1230,132 @@ separate step.
     \label{fig:mpdo_fixed_final_comparison_unitary}
 \end{figure}
 
+\begin{definition}[Complete zipper fusion family]%
+    \label{def:mpdo_complete_zipper_fusion_family}
+    \lean{MPOTensor.CompleteZipperFusionFamily}
+    \leanok
+    \uses{def:mpo_tensor}
+    Let $\Lambda$ be a finite set.  A \emph{complete zipper fusion family}
+    consists of positive bond dimensions $D_a$, MPO blocks
+    $B_a^{ij}\in M_{D_a}(\mathbb C)$, fusion multiplicities $N_{ab}^{c}$,
+    and matrices
+    \[
+        X^c_{ab,\mu}:\mathbb C^{D_c}\longrightarrow
+          \mathbb C^{D_a}\otimes\mathbb C^{D_b},
+        \qquad
+        X^{c+}_{ab,\mu}:\mathbb C^{D_a}\otimes\mathbb C^{D_b}
+          \longrightarrow\mathbb C^{D_c}.
+    \]
+    The matrices $X^{c+}_{ab,\mu}$ are independently chosen left inverses,
+    not adjoints.  For all labels and multiplicity indices,
+    \[
+        X^{d+}_{ab,\nu}X^c_{ab,\mu}
+          =\delta_{cd}\delta_{\mu\nu}1_{D_c}.
+    \]
+    The opposite product
+    $P_{ab}=\sum_{c,\mu}X^c_{ab,\mu}X^{c+}_{ab,\mu}$ is the projector onto
+    the product-MPO support; it need not be the identity on the ambient bond
+    space.  Every product-MPO letter is reconstructed on this support:
+    \[
+        B_{ab}^{ik}
+          =\sum_{c,\mu}X^c_{ab,\mu}B_c^{ik}X^{c+}_{ab,\mu}.
+    \]
+    Writing $B_{ab}^{ik}=\sum_j B_a^{ij}\otimes B_b^{jk}$, the two zipper
+    identities are
+    \[
+    \begin{aligned}
+        B_{ab}^{ik}X^c_{ab,\mu}&=X^c_{ab,\mu}B_c^{ik},\\
+        X^{c+}_{ab,\mu}B_{ab}^{ik}&=B_c^{ik}X^{c+}_{ab,\mu}.
+    \end{aligned}
+    \]
+    Each block is injective, and the labelled block-letter matrix has a common
+    left inverse: its contraction with $B_d^{ij}$ is
+    $\delta_{cd}E_{xy}$ on the block selected by $(c,x,y)$.
+    These are the fusion-tensor, reconstruction, zipper, and simultaneous
+    inverse relations of
+    \cite[lines~161, 181--200, and 269--277]{Bultinck2017Anyons}.
+\end{definition}
+
+\begin{theorem}[Printed F-move and inverse]%
+    \label{thm:mpdo_complete_zipper_printed_fmove}
+    \lean{MPOTensor.CompleteZipperFusionFamily.%
+        rightTripleSynthesis_mul_printedFMatrix}
+    \lean{MPOTensor.CompleteZipperFusionFamily.%
+        printedFMatrix_mul_inversePrintedFMatrix}
+    \lean{MPOTensor.CompleteZipperFusionFamily.%
+        inversePrintedFMatrix_mul_printedFMatrix}
+    \leanok
+    \uses{def:mpdo_complete_zipper_fusion_family}
+    Fix $a,b,c,d\in\Lambda$.  There is an invertible matrix
+    \[
+        F^{abc}_d:
+        \bigoplus_e\mathbb C^{N_{ab}^{e}}\otimes
+          \mathbb C^{N_{ec}^{d}}
+        \longrightarrow
+        \bigoplus_f\mathbb C^{N_{bc}^{f}}\otimes
+          \mathbb C^{N_{af}^{d}}
+    \]
+    whose rows are indexed by $(f,\lambda,\sigma)$ and whose columns are
+    indexed by $(e,\mu,\nu)$.  Its entries satisfy
+    \[
+        (X^e_{ab,\mu}\otimes1)X^d_{ec,\nu}
+        =\sum_{f,\lambda,\sigma}
+          (F^{abc}_d)^{f\lambda\sigma}_{e\mu\nu}
+          (1\otimes X^f_{bc,\lambda})X^d_{af,\sigma}.
+    \]
+    The matrix in the opposite orientation is its two-sided inverse.  This is
+    the $F$-move of \cite[equation~(Fmove)]{Bultinck2017Anyons}.
+\end{theorem}
+\begin{proof}\leanok
+    Form the full left- and right-associated synthesis matrices $L$ and $R$
+    and their analysis matrices $L^+$ and $R^+$.  Applying the reconstruction
+    equation twice to the two associative decompositions gives
+    \[
+        B_{abc}^{il}=L D_{\mathrm L}^{il}L^+
+          =R D_{\mathrm R}^{il}R^+.
+    \]
+    Contract this equality with the simultaneous inverse of the final block
+    letters and sum the diagonal final-label matrix units.  The two direct
+    sums $D_{\mathrm L}$ and $D_{\mathrm R}$ both contract to the identity.
+    Consequently,
+    \[
+        P:=LL^+=RR^+,
+        \qquad L^+L=R^+R=1.
+    \]
+    Hence $R^+L$ changes left-tree coordinates into right-tree coordinates and
+    \[
+        R(R^+L)=(RR^+)L=PL=(LL^+)L=L.
+    \]
+    Its opposite-oriented comparison is $L^+R$.  Using the same support
+    identity,
+    \[
+        (R^+L)(L^+R)=R^+PR=1,
+        \qquad
+        (L^+R)(R^+L)=L^+PL=1.
+    \]
+    The zipper identities show that $R^+L$ intertwines the direct sums of the
+    final-block letters.  The simultaneous block inverse annihilates its
+    corners with different final labels.  On the $d$-diagonal corner,
+    injectivity gives
+    \[
+        (R^+L)_d=F^{abc}_d\otimes1_{D_d}.
+    \]
+    Restricting $R(R^+L)=L$ to this corner gives the displayed $F$-move.
+    The corresponding fixed-final corner of $L^+R$, together with
+    $(R^+L)(L^+R)=1=(L^+R)(R^+L)$, gives the two inverse identities.
+\end{proof}
+
+\begin{figure}[ht]
+    \centering
+    \TNMPDOPrintedFMove
+    \caption{The source-oriented $F$-move.  The left-associated fusion tensor
+        is expanded in the right-associated fusion basis.  The upper indices
+        $(f,\lambda,\sigma)$ label the rows of $F^{abc}_d$, and the lower
+        indices $(e,\mu,\nu)$ label its columns, as in
+        \cite[equation~(Fmove)]{Bultinck2017Anyons}.}
+    \label{fig:mpdo_complete_zipper_printed_fmove}
+\end{figure}
+
 \begin{theorem}[Coherence of four bond-coordinate reassociations]%
     \label{thm:mpdo_fourfold_bond_coordinate_coherence}
     \lean{MPOTensor.BNTFusionIsometryFamily.%

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -1186,6 +1186,46 @@
     \end{tikzpicture}%
 }
 
+% The source-oriented F-move.  The left tree is expanded in the basis of
+% right trees.  The multiplicity labels and the direction of F agree with
+% equation (Fmove) of arXiv:1511.08090.
+\newcommand{\TNMPDOPrintedFMove}{%
+    \begin{tikzpicture}[tn picture, scale=0.92]
+        \node (pfLa) at (-4.20,-1.20) {$a$};
+        \node (pfLb) at (-3.20,-1.20) {$b$};
+        \node (pfLc) at (-2.20,-1.20) {$c$};
+        \node[draw, rounded corners, fill=blue!8, inner sep=2pt]
+            (pfLab) at (-3.70,-0.34) {$X^{e}_{ab,\mu}$};
+        \node[draw, rounded corners, fill=blue!8, inner sep=2pt]
+            (pfLroot) at (-3.00,0.62) {$X^{d}_{ec,\nu}$};
+        \draw[tn leg] (pfLa.north) -- (pfLab.south west);
+        \draw[tn leg] (pfLb.north) -- (pfLab.south east);
+        \draw[tn leg] (pfLab.north) -- (pfLroot.south west);
+        \draw[tn leg] (pfLc.north) -- (pfLroot.south east);
+        \draw[tn leg] (pfLroot.north) -- ++(0,0.42)
+            node[above] {$d$};
+
+        \node at (-0.65,-0.12) {$=$};
+        \node at (0.15,-0.12) {$\displaystyle\sum_{f,\lambda,\sigma}$};
+        \node at (1.33,-0.12)
+            {$\displaystyle(F^{abc}_{d})^{f\lambda\sigma}_{e\mu\nu}$};
+
+        \node (pfRa) at (2.75,-1.20) {$a$};
+        \node (pfRb) at (3.75,-1.20) {$b$};
+        \node (pfRc) at (4.75,-1.20) {$c$};
+        \node[draw, rounded corners, fill=blue!8, inner sep=2pt]
+            (pfRbc) at (4.25,-0.34) {$X^{f}_{bc,\lambda}$};
+        \node[draw, rounded corners, fill=blue!8, inner sep=2pt]
+            (pfRroot) at (3.45,0.62) {$X^{d}_{af,\sigma}$};
+        \draw[tn leg] (pfRb.north) -- (pfRbc.south west);
+        \draw[tn leg] (pfRc.north) -- (pfRbc.south east);
+        \draw[tn leg] (pfRa.north) -- (pfRroot.south west);
+        \draw[tn leg] (pfRbc.north) -- (pfRroot.south east);
+        \draw[tn leg] (pfRroot.north) -- ++(0,0.42)
+            node[above] {$d$};
+    \end{tikzpicture}%
+}
+
 % The fixed-final comparison argument in three graphical steps.  A
 % positive-length simultaneous word selector isolates one final label, the
 % resulting comparison is block diagonal in that label, and injectivity

--- a/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
+++ b/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
@@ -28,7 +28,7 @@ name: TNMPDOInverseContraction TNMPDOSectorPairing TNMPDOSectorZCLIdentity
 name: TNMPSInverseContraction TNBNTDecomposition TNMPDOZCLIdempotence TNMPDOFixedFinalFusionBracketings
 {{ obj.tn_svg_html }}
 
-name: TNMPDOBNTFusionIdentity TNMPDOUnweightedZipperReconstruction TNMPDOFusionTracePower TNMPDOFixedFinalComparisonUnitary TNMPDOFourfoldBondReassociationPentagon
+name: TNMPDOBNTFusionIdentity TNMPDOUnweightedZipperReconstruction TNMPDOFusionTracePower TNMPDOFixedFinalComparisonUnitary TNMPDOFourfoldBondReassociationPentagon TNMPDOPrintedFMove
 {{ obj.tn_svg_html }}
 
 name: TNRFPKrausIsometry TNRFPKrausIsometryReverse TNRFPIsometryCanonicalForm

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -635,6 +635,53 @@ hypotheses from the source assumptions, identify the orientation convention
 with the printed $F$-matrix, and prove the pentagon-like equation mentioned at
 lines~995--999.
 
+Independently of this positive-diagonal specialization, the source-faithful
+complete zipper package is now formalized by
+\leanid{MPOTensor.CompleteZipperFusionFamily}.  Its data are the integer
+fusion multiplicities, independently specified synthesis and analysis
+tensors, their biorthogonality, the product-letter reconstruction equation
+\texttt{inversegaugeone}, the two zipper equations, injectivity of the labelled
+blocks, and the simultaneous one-letter inverse from lines~269--277 of
+\texttt{AnyonsPEPS.tex}.  In particular, the product-MPO projector discussed at
+lines~181--191 is not identified with the identity on the ambient product bond
+space.  Applying \texttt{inversegaugeone} to the two associative decompositions
+at lines~238--247 reconstructs every triple-product letter through either
+fusion tree.  Contracting these equal reconstructions with the simultaneous
+inverse derives equality of the two triple-product support projectors.  These
+assumptions suffice to construct the
+printed-orientation matrix
+\leanid{MPOTensor.CompleteZipperFusionFamily.printedFMatrix}, whose rows are
+right-tree multiplicities and whose columns are left-tree multiplicities.
+The exact equation \texttt{Fmove} and both inverse identities are proved by
+\leanid{MPOTensor.CompleteZipperFusionFamily.%
+rightTripleSynthesis_mul_printedFMatrix},
+\leanid{MPOTensor.CompleteZipperFusionFamily.%
+printedFMatrix_mul_inversePrintedFMatrix}, and
+\leanid{MPOTensor.CompleteZipperFusionFamily.%
+inversePrintedFMatrix_mul_printedFMatrix}.  Thus no length-independent
+coefficient system, selector words, or additional present-blocking
+injectivity hypothesis is imposed on this source-labelled result.
+
+This new package does not close the gap for the positive-diagonal family:
+constructing its complete zipper data from the assumptions of
+arXiv:1606.00608 remains open.  It also stops before the genuine fourfold,
+entrywise pentagon equation of \texttt{AnyonsPEPS.tex}, lines~279--283.  The
+two-sided printed $F$-move is therefore complete, while the pentagon remains a
+separate open formalization problem.
+
+\paragraph{Local fixes in the fusion-tensor display.}
+The prose at line~161 of \texttt{AnyonsPEPS.tex} displays the arrow for
+$X^c_{ab,\mu}$ in the direction from the product bond space to the $c$ bond
+space.  The equations at lines~163--200 and the printed $F$-move at
+lines~248--251 require the reverse direction,
+$X^c_{ab,\mu}:\mathbb C^{D_c}\to
+\mathbb C^{D_a}\otimes\mathbb C^{D_b}$, with $X^{c+}_{ab,\mu}$ as its left
+inverse.  The formalization uses this equation-compatible orientation.
+The same display writes the Kronecker factor in
+$X^{d+}_{ab,\nu}X^c_{ab,\mu}$ as $\delta_{de}$, although no label $e$ occurs
+in the relation.  Its typed form is $\delta_{dc}$ (equivalently
+$\delta_{cd}$), which is the index relation used in the formalization.
+
 To eliminate the source-theorem gap, the formalization should instead:
 \begin{enumerate}
     \item define a separate, source-faithful predicate for


### PR DESCRIPTION
## Mathematical content

This formalizes the source-oriented (F)-move of Bultinck–Mariën–Williamson–Şahinoğlu–Haegeman–Verstraete from `AnyonsPEPS.tex`, lines 161–277.

The new complete zipper-fusion package records:

- integer fusion multiplicities and independently chosen synthesis/analysis tensors;
- biorthogonality on fusion-coordinate spaces;
- both printed zipper identities;
- the exact `inversegaugeone` reconstruction of each product-MPO letter;
- injectivity and the simultaneous inverse of the labelled final-block letters.

Crucially, no ambient completeness identity is assumed: 
\(
\sum_{c,\mu}X^c_{ab,\mu}X^{c+}_{ab,\mu}
\)
may be a proper support projector, exactly as the source states. Applying `inversegaugeone` twice gives left- and right-associated reconstructions of the same triple-product letter. Contracting these reconstructions with the simultaneous block inverse proves (LL^+=RR^+). The matrix (F=R^+L) then satisfies the printed (F)-move, and (L^+R) is its two-sided inverse.

The paper-gap note records two local typographical corrections in the source's line-161 display: the reversed arrow for (X), and the unused index (e) in `delta_de`.

## Blueprint

- Adds a source-like native TikZ fusion-tree diagram with the printed row/column orientation.
- Registers the diagram for web rendering.
- States explicitly that the genuine fourfold entrywise pentagon remains open.

## Verification

- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `lake exe checkdecls blueprint/lean_decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint pdf` (532 pages)
- `PYTHONPATH=Packages python3 Packages/tn_diagrams.py --check --check-peps-usage --smoke-render`
- visual inspection of the rendered theorem and fusion-tree figure
- no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast` in the new modules
- all new Lean modules are below 1000 lines and satisfy the 100-column limit

Refs #3845

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new proof surface (~2k LOC) in core MPDO fusion theory; errors would misstate mathematical claims, but there is no runtime, auth, or data-handling impact.
> 
> **Overview**
> Adds a **source-faithful** `CompleteZipperFusionFamily` package and formal proofs of the printed **F-move** (Bultinck et al., `Fmove`) from zipper fusion hypotheses alone—without the positive-diagonal BNT selector or length-independence assumptions used elsewhere.
> 
> The new Lean stack defines fusion synthesis/analysis, triple-tree coordinates, support reconstruction (`inversegaugeone`), equality of left/right triple-product projectors, then builds `printedFMatrix` and proves **`rightTripleSynthesis_mul_printedFMatrix`** plus mutual inverses. Blueprint and paper-gap docs gain the definition, theorem, TikZ `TNMPDOPrintedFMove`, and notes on two line-161 typographical fixes; constructing this data from arXiv:1606.00608 and the **fourfold pentagon** remain explicitly open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f07843703ed1d3b96b01137bbd572eb93f3b232c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->