### PR TITLE
feat(Wielandt/SpanGrowth): propagate positive block injectivity

### DIFF
--- a/TNLean/Wielandt/SpanGrowth/CumulativeSpan.lean
+++ b/TNLean/Wielandt/SpanGrowth/CumulativeSpan.lean
@@ -27,6 +27,9 @@ arXiv:0909.5347 (Sanz, Pérez-García, Wolf, Cirac).
 
 - `cumulativeSpan_mono`: T_n ≤ T_{n+1}
 - `wordSpan_succ_le_mul`: S_{n+1} ⊆ span(A) * S_n
+- `wordSpan_succ_eq_mul_left`: S_{n+1} = span(A) * S_n
+- `isNBlkInjective_succ_of_isNBlkInjective`: positive-length block injectivity
+  propagates by one site
 - `cumulativeSpan_stable`: If T_n = T_{n+1}, then T_m = T_n for all m ≥ n
 - `cumulativeSpan_finrank_le`: dim(T_n) ≤ D²
 - `cumulativeSpan_finrank_strict_mono`: strict inclusion ⇒ strict dim growth
@@ -89,6 +92,49 @@ theorem wordSpan_succ_le_mul (A : MPSTensor d D) (n : ℕ) :
   apply Submodule.mul_mem_mul
   · exact Submodule.subset_span ⟨σ 0, rfl⟩
   · exact Submodule.subset_span ⟨σ ∘ Fin.succ, rfl⟩
+
+/-- The exact factorization `S_{n+1}(A) = span{A_i} S_n(A)`.
+
+This is the elementary word factorization underlying the definition of
+`S_n(A)` in arXiv:0909.5347, equation (1). -/
+theorem wordSpan_succ_eq_mul_left (A : MPSTensor d D) (n : ℕ) :
+    wordSpan A (n + 1) =
+      (Submodule.span ℂ (Set.range A)) * wordSpan A n := by
+  classical
+  apply le_antisymm
+  · exact wordSpan_succ_le_mul A n
+  · rw [wordSpan, Submodule.span_mul_span]
+    apply Submodule.span_le.mpr
+    intro M hM
+    obtain ⟨M₁, ⟨i, rfl⟩, M₂, ⟨σ, rfl⟩, rfl⟩ := Set.mem_mul.mp hM
+    apply Submodule.subset_span
+    refine ⟨Fin.cons i σ, ?_⟩
+    simp [List.ofFn_succ]
+
+/-- Block injectivity at a positive length propagates to the next length.
+
+This auxiliary statement supplies the length shift needed to combine the
+block-injectivity discussion in arXiv:1606.00608, lines 318--345, with
+Appendix C.3, Lemma L, lines 1835--1858. It is not asserted there as a
+separate result. -/
+theorem isNBlkInjective_succ_of_isNBlkInjective
+    (A : MPSTensor d D) {L : ℕ} (hLpos : 0 < L)
+    (hL : IsNBlkInjective A L) :
+    IsNBlkInjective A (L + 1) := by
+  change wordSpan A L = ⊤ at hL
+  change wordSpan A (L + 1) = ⊤
+  obtain ⟨n, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (Nat.ne_of_gt hLpos)
+  have hprev_le : wordSpan A n ≤ wordSpan A (n + 1) := by
+    rw [hL]
+    exact le_top
+  rw [wordSpan_succ_eq_mul_left A (n + 1)]
+  apply eq_top_iff.mpr
+  calc
+    ⊤ = wordSpan A (n + 1) := hL.symm
+    _ = Submodule.span ℂ (Set.range A) * wordSpan A n :=
+      wordSpan_succ_eq_mul_left A n
+    _ ≤ Submodule.span ℂ (Set.range A) * wordSpan A (n + 1) :=
+      mul_le_mul' le_rfl hprev_le
 
 /-! ### cumulativeSpan: T_n(A) -/
 

--- a/TNLean/Wielandt/SpanGrowth/InvertibleWordSpan.lean
+++ b/TNLean/Wielandt/SpanGrowth/InvertibleWordSpan.lean
@@ -27,7 +27,6 @@ Wielandt inequality (arXiv:0909.5347, Theorem 1; Wolf Section 6.9).
   is invertible.
 * `wordSpan_eq_top_of_ge_of_isUnit`: if `S_N = ⊤` and `A i₀` is invertible,
   then `S_m = ⊤` for all `m ≥ N`.
-* `wordSpan_succ_eq_mul_left`: `S_{n+1} = span{A_i} · S_n`.
 
 ### Sharp case-(2) theorem
 * `wordSpan_eq_top_of_isNormal_of_isUnit`: under `IsNormal A` and an
@@ -203,31 +202,6 @@ theorem mulLeft_pow_image_wordSpan_le (A : MPSTensor d D)
               Submodule.map_mono ih
           _ ≤ wordSpan A ((n + k) + 1) :=
               mulLeft_image_wordSpan_le_succ A i₀ (n + k)
-
-/-! ## S_{n+1} = span{A_i} * S_n -/
-
-/-- `S_{n+1} = span{A_i} · S_n` (left-multiplication decomposition).
-
-This is an auxiliary step for arXiv:0909.5347, Theorem 1 case (2); Wolf,
-Theorem 6.9. -/
-theorem wordSpan_succ_eq_mul_left (A : MPSTensor d D) (n : ℕ) :
-    wordSpan A (n + 1) =
-      (Submodule.span ℂ (Set.range A)) * wordSpan A n := by
-  apply le_antisymm
-  · exact wordSpan_succ_le_mul A n
-  · -- span{A_i} ≤ wordSpan A 1
-    have hS1 : Submodule.span ℂ (Set.range A) ≤ wordSpan A 1 := by
-      apply Submodule.span_le.mpr
-      rintro M ⟨j, rfl⟩
-      apply Submodule.subset_span
-      refine ⟨fun _ => j, ?_⟩
-      simp only [List.ofFn, Fin.foldr_succ, Fin.foldr_zero]
-      simp only [evalWord, Matrix.mul_one]
-    calc (Submodule.span ℂ (Set.range A)) * wordSpan A n
-        ≤ wordSpan A 1 * wordSpan A n :=
-          mul_le_mul' hS1 (le_refl _)
-      _ ≤ wordSpan A (1 + n) := wordSpan_mul_le A 1 n
-      _ = wordSpan A (n + 1) := by congr 1; omega
 
 /-! ## Monotonicity of wordSpan dimension under invertibility -/
 

--- a/blueprint/src/chapter/ch08_wielandt.tex
+++ b/blueprint/src/chapter/ch08_wielandt.tex
@@ -98,6 +98,37 @@ The results follow~\cite{Sanz2010Quantum}.
     length~$L$ equals $\MN{D}$.
 \end{proof}
 
+\begin{theorem}[Positive-length propagation of block injectivity]
+    \label{thm:wordspan_blk_inj_succ}
+    \lean{MPSTensor.wordSpan_succ_eq_mul_left}
+    \lean{MPSTensor.isNBlkInjective_succ_of_isNBlkInjective}
+    \leanok
+    \uses{def:word_span, def:l_blk_injective}
+    For every $n$,
+    \[
+        S_{n+1}(A)=\spn_{\C}\{A_i\}_i S_n(A).
+    \]
+    Consequently, if $L>0$ and $A$ is $L$-block injective, then
+    $A$ is $(L+1)$-block injective.
+    This is an auxiliary length-shift statement used to combine the
+    block-injectivity discussion in~\cite[lines~318--345]{Cirac2016MPDO_arXiv}
+    with Appendix~C.3, Lemma~L, lines~1835--1858; it is not stated there
+    as a separate lemma.
+\end{theorem}
+
+\begin{proof}\leanok\uses{def:word_span}
+    Every word of length $n+1$ factors into its first letter and a word
+    of length $n$, which proves the displayed equality by bilinearity.
+    Write $L=n+1$.  Since $S_L(A)=\MN{D}$, one has
+    $S_n(A)\le S_L(A)$.  Hence
+    \[
+        \MN{D}=S_L(A)
+        =\spn_{\C}\{A_i\}_i S_n(A)
+        \le \spn_{\C}\{A_i\}_i S_L(A)
+        =S_{L+1}(A).
+    \]
+\end{proof}
+
 \begin{lemma}[Zero-length word span]
     \label{lem:wordspan_zero_ne_top}
     \lean{MPSTensor.wordSpan_zero_ne_top_of_two_le}

--- a/docs/paper-gaps/cpgsv17_bicf_block_separation.tex
+++ b/docs/paper-gaps/cpgsv17_bicf_block_separation.tex
@@ -170,14 +170,18 @@ left-canonicality, and nonzero weights do not imply simultaneous separation.
 It does not satisfy the source's minimal-representative condition.
 
 The remaining task for the source-level Lemma L is to compose the results
-above with the canonical-form construction.  One should choose a common
-positive $L$ for which every normal BNT representative is $L$-block
-injective, propagate exact word-span to length $L+1$, and identify the sector
-decomposition and powered copy weights after blocking $L+1$ sites.  The
+above with the canonical-form construction.  Positive-length block injectivity
+propagates from length $L$ to length $L+1$ without a normalization hypothesis:
+the identity
+$S_{L+1}(A)=\spn\{A_i\}_iS_L(A)$, together with the same identity at length
+$L$, gives the result.  One should therefore choose a common positive $L$ for
+which every normal BNT representative is $L$-block injective and identify the
+sector decomposition and powered copy weights after blocking $L+1$ sites.  The
 representative-separation theorem then applies to that blocked decomposition,
-while the original length-$L$ span gives the converse blocking step.  This
-propagation is essential: recovery from a physical block of length $L+1$ uses
-the span of its length-$L$ tail.  The flattened
+while the original length-$L$ span recovers equality of the unblocked insertions
+from equality of the blocked insertions.  This length shift is essential:
+recovery from a physical block of length $L+1$ uses the span of its length-$L$
+tail.  The flattened
 \texttt{HorizontalCFData} formulation must then be replaced, or related
 explicitly, by this representative-indexed statement.  The older per-copy
 \texttt{biCF} theorem remains a correct restricted result, but it is no longer


### PR DESCRIPTION
## Mathematical purpose

For a tensor $A$, let $S_n(A)$ denote the span of its words of length $n$. This PR proves the exact factorization

$$S_{n+1}(A)=\operatorname{span}\{A_i\}_i S_n(A),$$

and deduces that $L$-block injectivity propagates to $(L+1)$-block injectivity whenever $L>0$. Positivity is necessary at length zero.

The factorization is moved from the higher `InvertibleWordSpan` layer into `CumulativeSpan`, where its proof uses only the definition of a word span. The propagation theorem requires no normalization, invertibility, canonicality, or primitivity assumption.

This is an auxiliary length-shift needed to combine the block-injectivity discussion in arXiv:1606.00608, lines 318–345, with Appendix C.3, Lemma L, lines 1835–1858. It is not presented as a separate theorem in the source.

## Documentation

The Wielandt blueprint records the factorization and propagation theorem. The paper-gap note `docs/paper-gaps/cpgsv17_bicf_block_separation.tex` now marks this length shift as complete while retaining the remaining tasks: the blocked BNT sector decomposition, powered copy weights, and the representative-indexed bridge replacing or relating `HorizontalCFData`.

## Verification

- `lake build`
- `lake exe checkdecls blueprint/lean_decls`
- `python3 scripts/blueprint_lean_sync.py --ci`
- `#print axioms MPSTensor.wordSpan_succ_eq_mul_left`
- `#print axioms MPSTensor.isNBlkInjective_succ_of_isNBlkInjective`

Both axiom reports contain only `propext`, `Classical.choice`, and `Quot.sound`. The changed Lean files contain no `sorry`, project `axiom`, or kernel bypass.

Advances #3713. Prerequisite for #3674; neither issue is closed by this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib formalization and doc updates; behavior of existing invertible-span proofs is preserved through the shared import.
> 
> **Overview**
> Adds the exact word-span identity **S_{n+1}(A) = span{A_i} S_n(A)** and deduces that **L-block injectivity for L > 0 implies (L+1)-block injectivity**, with no normalization or invertibility assumptions.
> 
> **`wordSpan_succ_eq_mul_left`** is relocated from `InvertibleWordSpan.lean` to `CumulativeSpan.lean` and reproved from word definitions (`Fin.cons` / `List.ofFn_succ`) instead of chaining through `wordSpan_mul_le` and `S_1`. Downstream invertible-span arguments still call the same name via the cumulative-span import.
> 
> The Wielandt blueprint gains a theorem for the factorization and propagation; the CPGSV17 paper-gap note records this length shift as done and updates the remaining Lemma L roadmap (blocked BNT sectors, representative-indexed bridge).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28dfbc2ecb6d3500852c10446ce6c96cb2dcf76c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->