### PR TITLE
feat(MPS/RFP): prove Appendix B support commutation

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -486,7 +486,9 @@ import TNLean.MPS.MPDO.PureRecovery
 import TNLean.MPS.RFP.StructuralForm
 import TNLean.MPS.RFP.StructuralFull
 import TNLean.MPS.RFP.CommutingBridge
+import TNLean.MPS.RFP.KroneckerTransport
 import TNLean.MPS.RFP.AppendixBSupport
+import TNLean.MPS.RFP.AppendixBCommutation
 import TNLean.MPS.RFP.Convergence
 import TNLean.MPS.RFP.Assembly
 import TNLean.MPS.RFP.Decorrelation

--- a/TNLean/MPS/RFP/AppendixBCommutation.lean
+++ b/TNLean/MPS/RFP/AppendixBCommutation.lean
@@ -77,21 +77,6 @@ private theorem replaceXBCfg_eq_iff (sigma tau : Cfg d 3) (beta : Cfg d 2) :
     funext k
     fin_cases k <;> simp [replaceXBCfg, xbPairCfg, h]
 
-/-- Matrix lift of a two-site operator to the first two factors of a
-right-associated triple. -/
-private noncomputable def leftPairMatrix {n : Type*} [Fintype n] [DecidableEq n]
-    (B : Matrix (n × n) (n × n) ℂ) :
-    Matrix (n × (n × n)) (n × (n × n)) ℂ :=
-  Matrix.reindex (Equiv.prodAssoc n n n) (Equiv.prodAssoc n n n)
-    (B ⊗ₖ (1 : Matrix n n ℂ))
-
-/-- Matrix lift of a two-site operator to the final two factors of a
-right-associated triple. -/
-private noncomputable def rightPairMatrix {n : Type*} [Fintype n] [DecidableEq n]
-    (B : Matrix (n × n) (n × n) ℂ) :
-    Matrix (n × (n × n)) (n × (n × n)) ℂ :=
-  (1 : Matrix n n ℂ) ⊗ₖ B
-
 /-- Reindexing the coefficient matrix of the first physical pair lift gives
 the standard tensor-product matrix lift. -/
 private theorem leftPairLift_toMatrix_reindex
@@ -99,7 +84,7 @@ private theorem leftPairLift_toMatrix_reindex
     Matrix.reindex (appendixBFinThreeArrowEquiv (Fin d))
         (appendixBFinThreeArrowEquiv (Fin d))
         (LinearMap.toMatrix' (leftPairLift Q)) =
-      leftPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin d))
+      appendixBLeftPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin d))
         (finTwoArrowEquiv (Fin d)) (LinearMap.toMatrix' Q)) := by
   classical
   ext σ τ
@@ -150,7 +135,7 @@ private theorem rightPairLift_toMatrix_reindex
     Matrix.reindex (appendixBFinThreeArrowEquiv (Fin d))
         (appendixBFinThreeArrowEquiv (Fin d))
         (LinearMap.toMatrix' (rightPairLift Q)) =
-      rightPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin d))
+      appendixBRightPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin d))
         (finTwoArrowEquiv (Fin d)) (LinearMap.toMatrix' Q)) := by
   classical
   ext σ τ
@@ -270,25 +255,6 @@ private theorem AppendixBStructuralData.replaceVirtualBond12_eq_iff
 
 /-! ### Matrices of the physical and virtual two-site transports -/
 
-/-- Reindexing carries a product of three matrices to the product of their
-three compatible reindexings. -/
-private theorem reindex_three_mul
-    {m n o p m' n' o' p' : Type*}
-    [Fintype n] [Fintype n'] [Fintype o] [Fintype o']
-    (em : m ≃ m') (en : n ≃ n') (eo : o ≃ o') (ep : p ≃ p')
-    (M : Matrix m n ℂ) (N : Matrix n o ℂ) (P : Matrix o p ℂ) :
-    Matrix.reindex em ep ((M * N) * P) =
-      (Matrix.reindex em en M * Matrix.reindex en eo N) *
-        Matrix.reindex eo ep P := by
-  calc
-    _ = Matrix.reindex em eo (M * N) * Matrix.reindex eo ep P := by
-      simpa only [Matrix.coe_reindexLinearEquiv] using
-        (Matrix.reindexLinearEquiv_mul ℂ ℂ em eo ep (M * N) P).symm
-    _ = _ := by
-      simpa only [Matrix.coe_reindexLinearEquiv] using congrArg
-        (fun Q ↦ Q * Matrix.reindex eo ep P)
-        (Matrix.reindexLinearEquiv_mul ℂ ℂ em en eo M N).symm
-
 /-- The one-site physical isometry in the pair-index basis. -/
 private noncomputable def AppendixBStructuralData.physicalIsometryMatrix
     {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
@@ -363,19 +329,21 @@ private theorem AppendixBStructuralData.leftVirtualBondProjection_matrix
     Matrix.reindex (appendixBFinThreeArrowEquiv (Fin D × Fin D))
         (appendixBFinThreeArrowEquiv (Fin D × Fin D))
         (LinearMap.toMatrix' hStruct.leftVirtualBondProjection) =
-      leftPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin D × Fin D))
+      appendixBLeftPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin D × Fin D))
         (finTwoArrowEquiv (Fin D × Fin D))
         (LinearMap.toMatrix' hStruct.twoSiteVirtualBondProjection)) := by
   classical
   ext p q
   by_cases hs : p.2.2 = q.2.2
-  · simp [leftPairMatrix, Matrix.reindex_apply, LinearMap.toMatrix'_apply,
+  · simp [appendixBLeftPairMatrix, appendixBLeftPairMatrixAux,
+      Matrix.reindex_apply, LinearMap.toMatrix'_apply,
       AppendixBStructuralData.leftVirtualBondProjection,
       AppendixBStructuralData.twoSiteVirtualBondProjection,
       hStruct.replaceVirtualBond01_eq_iff,
       appendixBFirstPairCfg, appendixBFinThreeArrowEquiv, finTwoArrowEquiv,
       Pi.single_apply, hs]
-  · simp [leftPairMatrix, Matrix.reindex_apply, LinearMap.toMatrix'_apply,
+  · simp [appendixBLeftPairMatrix, appendixBLeftPairMatrixAux,
+      Matrix.reindex_apply, LinearMap.toMatrix'_apply,
       AppendixBStructuralData.leftVirtualBondProjection,
       AppendixBStructuralData.twoSiteVirtualBondProjection,
       hStruct.replaceVirtualBond01_eq_iff,
@@ -389,19 +357,21 @@ private theorem AppendixBStructuralData.rightVirtualBondProjection_matrix
     Matrix.reindex (appendixBFinThreeArrowEquiv (Fin D × Fin D))
         (appendixBFinThreeArrowEquiv (Fin D × Fin D))
         (LinearMap.toMatrix' hStruct.rightVirtualBondProjection) =
-      rightPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin D × Fin D))
+      appendixBRightPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin D × Fin D))
         (finTwoArrowEquiv (Fin D × Fin D))
         (LinearMap.toMatrix' hStruct.twoSiteVirtualBondProjection)) := by
   classical
   ext p q
   by_cases hs : p.1 = q.1
-  · simp [rightPairMatrix, Matrix.reindex_apply, LinearMap.toMatrix'_apply,
+  · simp [appendixBRightPairMatrix, appendixBRightPairMatrixAux,
+      Matrix.reindex_apply, LinearMap.toMatrix'_apply,
       AppendixBStructuralData.rightVirtualBondProjection,
       AppendixBStructuralData.twoSiteVirtualBondProjection,
       hStruct.replaceVirtualBond12_eq_iff,
       appendixBLastPairCfg, appendixBFinThreeArrowEquiv, finTwoArrowEquiv,
       Pi.single_apply, Matrix.one_apply, hs]
-  · simp [rightPairMatrix, Matrix.reindex_apply, LinearMap.toMatrix'_apply,
+  · simp [appendixBRightPairMatrix, appendixBRightPairMatrixAux,
+      Matrix.reindex_apply, LinearMap.toMatrix'_apply,
       AppendixBStructuralData.rightVirtualBondProjection,
       AppendixBStructuralData.twoSiteVirtualBondProjection,
       hStruct.replaceVirtualBond12_eq_iff,
@@ -411,16 +381,16 @@ private theorem AppendixBStructuralData.rightVirtualBondProjection_matrix
 /-- The two standard pair matrices of the virtual bond projector commute. -/
 private theorem AppendixBStructuralData.virtualPairMatrices_comm
     {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
-    leftPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin D × Fin D))
+    appendixBLeftPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin D × Fin D))
           (finTwoArrowEquiv (Fin D × Fin D))
           (LinearMap.toMatrix' hStruct.twoSiteVirtualBondProjection)) *
-        rightPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin D × Fin D))
+        appendixBRightPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin D × Fin D))
           (finTwoArrowEquiv (Fin D × Fin D))
           (LinearMap.toMatrix' hStruct.twoSiteVirtualBondProjection)) =
-      rightPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin D × Fin D))
+      appendixBRightPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin D × Fin D))
           (finTwoArrowEquiv (Fin D × Fin D))
           (LinearMap.toMatrix' hStruct.twoSiteVirtualBondProjection)) *
-        leftPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin D × Fin D))
+        appendixBLeftPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin D × Fin D))
           (finTwoArrowEquiv (Fin D × Fin D))
           (LinearMap.toMatrix' hStruct.twoSiteVirtualBondProjection)) := by
   rw [← hStruct.leftVirtualBondProjection_matrix,
@@ -450,16 +420,16 @@ private theorem AppendixBStructuralData.virtualPairMatrices_comm
 three physical sites. -/
 private theorem AppendixBStructuralData.transportedPairMatrices_comm
     {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
-    leftPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin d))
+    appendixBLeftPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin d))
           (finTwoArrowEquiv (Fin d))
           (LinearMap.toMatrix' hStruct.transportedTwoSiteBondProjection)) *
-        rightPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin d))
+        appendixBRightPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin d))
           (finTwoArrowEquiv (Fin d))
           (LinearMap.toMatrix' hStruct.transportedTwoSiteBondProjection)) =
-      rightPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin d))
+      appendixBRightPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin d))
           (finTwoArrowEquiv (Fin d))
           (LinearMap.toMatrix' hStruct.transportedTwoSiteBondProjection)) *
-        leftPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin d))
+        appendixBLeftPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin d))
           (finTwoArrowEquiv (Fin d))
           (LinearMap.toMatrix' hStruct.transportedTwoSiteBondProjection)) := by
   rw [hStruct.transportedTwoSiteBondProjection_matrix]
@@ -468,9 +438,11 @@ private theorem AppendixBStructuralData.transportedPairMatrices_comm
     (LinearMap.toMatrix' hStruct.twoSiteVirtualBondProjection)
   have hB : appendixBLeftPairMatrix B * appendixBRightPairMatrix B =
       appendixBRightPairMatrix B * appendixBLeftPairMatrix B := by
-    simpa [B, leftPairMatrix, rightPairMatrix, appendixBLeftPairMatrixAux,
+    simpa [B, appendixBLeftPairMatrix, appendixBRightPairMatrix,
+      appendixBLeftPairMatrixAux,
       appendixBRightPairMatrixAux] using hStruct.virtualPairMatrices_comm
-  simpa [B, leftPairMatrix, rightPairMatrix, appendixBLeftPairMatrixAux,
+  simpa [B, appendixBLeftPairMatrix, appendixBRightPairMatrix,
+    appendixBLeftPairMatrixAux,
     appendixBRightPairMatrixAux] using
     appendixB_transportedPairMatrices_comm hStruct.physicalIsometryMatrix B
       hStruct.physicalIsometryMatrix_isometry hB
@@ -498,10 +470,10 @@ private theorem AppendixBStructuralData.transportedTwoSiteBondProjection_commute
           (LinearMap.toMatrix' (leftPairLift hStruct.transportedTwoSiteBondProjection))
           (LinearMap.toMatrix'
             (rightPairLift hStruct.transportedTwoSiteBondProjection))).symm
-    _ = leftPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin d))
+    _ = appendixBLeftPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin d))
           (finTwoArrowEquiv (Fin d))
           (LinearMap.toMatrix' hStruct.transportedTwoSiteBondProjection)) *
-        rightPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin d))
+        appendixBRightPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin d))
           (finTwoArrowEquiv (Fin d))
           (LinearMap.toMatrix' hStruct.transportedTwoSiteBondProjection)) := by
       rw [leftPairLift_toMatrix_reindex, rightPairLift_toMatrix_reindex]

--- a/TNLean/MPS/RFP/AppendixBCommutation.lean
+++ b/TNLean/MPS/RFP/AppendixBCommutation.lean
@@ -1,0 +1,878 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.RFP.AppendixBSupport
+import TNLean.MPS.RFP.KroneckerTransport
+
+/-!
+# Appendix B support-projector commutation
+
+This file transports the two commuting placements of the virtual rank-one bond
+projector through the three-site physical isometry.  The calculation uses the
+identity \(U^*U=1\) and does not require the physical isometry to be
+surjective.  It proves a local three-site commutator, rather than an all-chain
+nearest-neighbor commutation statement.  The all-chain and ground-space
+upgrade is recorded in
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
+
+Source: arXiv:1606.00608, equations (3.16)--(3.18), lines 549--578, and the
+parent-space construction, lines 511--524.
+-/
+
+open scoped Matrix BigOperators InnerProductSpace Kronecker
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-! ### Matrices of adjacent pair lifts -/
+
+/-- The right-associated identification of a three-coordinate function with a
+triple. -/
+private def appendixBFinThreeArrowEquiv (α : Type*) :
+    (Fin 3 → α) ≃ α × (α × α) :=
+  (Fin.consEquiv fun _ : Fin 3 ↦ α).symm.trans
+    (Equiv.prodCongr (Equiv.refl α) (finTwoArrowEquiv α))
+
+@[simp] private theorem appendixBFinThreeArrowEquiv_symm_apply
+    {alpha : Type*} (x : alpha × (alpha × alpha)) :
+    (appendixBFinThreeArrowEquiv alpha).symm x = ![x.1, x.2.1, x.2.2] := by
+  funext k
+  fin_cases k <;> rfl
+
+@[simp] private theorem axPairCfg_vecCons (a b c : Fin d) :
+    axPairCfg ![a, b, c] = ![a, b] := by
+  funext k
+  fin_cases k <;> rfl
+
+@[simp] private theorem xbPairCfg_vecCons (a b c : Fin d) :
+    xbPairCfg ![a, b, c] = ![b, c] := by
+  funext k
+  fin_cases k <;> rfl
+
+/-- Replacing the first pair gives a prescribed triple precisely when the new
+pair and untouched final coordinate agree. -/
+private theorem replaceAXCfg_eq_iff (sigma tau : Cfg d 3) (alpha : Cfg d 2) :
+    replaceAXCfg sigma alpha = tau ↔
+      alpha = axPairCfg tau ∧ sigma 2 = tau 2 := by
+  constructor
+  · intro h
+    exact ⟨by simpa using congrArg axPairCfg h,
+      by simpa [replaceAXCfg] using congrFun h (2 : Fin 3)⟩
+  · rintro ⟨rfl, h⟩
+    funext k
+    fin_cases k <;> simp [replaceAXCfg, axPairCfg, h]
+
+/-- Replacing the final pair gives a prescribed triple precisely when the new
+pair and untouched initial coordinate agree. -/
+private theorem replaceXBCfg_eq_iff (sigma tau : Cfg d 3) (beta : Cfg d 2) :
+    replaceXBCfg sigma beta = tau ↔
+      beta = xbPairCfg tau ∧ sigma 0 = tau 0 := by
+  constructor
+  · intro h
+    exact ⟨by simpa using congrArg xbPairCfg h,
+      by simpa [replaceXBCfg] using congrFun h (0 : Fin 3)⟩
+  · rintro ⟨rfl, h⟩
+    funext k
+    fin_cases k <;> simp [replaceXBCfg, xbPairCfg, h]
+
+/-- Matrix lift of a two-site operator to the first two factors of a
+right-associated triple. -/
+private noncomputable def leftPairMatrix {n : Type*} [Fintype n] [DecidableEq n]
+    (B : Matrix (n × n) (n × n) ℂ) :
+    Matrix (n × (n × n)) (n × (n × n)) ℂ :=
+  Matrix.reindex (Equiv.prodAssoc n n n) (Equiv.prodAssoc n n n)
+    (B ⊗ₖ (1 : Matrix n n ℂ))
+
+/-- Matrix lift of a two-site operator to the final two factors of a
+right-associated triple. -/
+private noncomputable def rightPairMatrix {n : Type*} [Fintype n] [DecidableEq n]
+    (B : Matrix (n × n) (n × n) ℂ) :
+    Matrix (n × (n × n)) (n × (n × n)) ℂ :=
+  (1 : Matrix n n ℂ) ⊗ₖ B
+
+/-- Reindexing the coefficient matrix of the first physical pair lift gives
+the standard tensor-product matrix lift. -/
+private theorem leftPairLift_toMatrix_reindex
+    (Q : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2) :
+    Matrix.reindex (appendixBFinThreeArrowEquiv (Fin d))
+        (appendixBFinThreeArrowEquiv (Fin d))
+        (LinearMap.toMatrix' (leftPairLift Q)) =
+      leftPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin d))
+        (finTwoArrowEquiv (Fin d)) (LinearMap.toMatrix' Q)) := by
+  classical
+  ext σ τ
+  by_cases h : σ.2.2 = τ.2.2
+  · have hslice : (fun α ↦
+        (Pi.single ((appendixBFinThreeArrowEquiv (Fin d)).symm τ) (1 : ℂ) :
+          NSiteSpace d 3)
+          (replaceAXCfg ((appendixBFinThreeArrowEquiv (Fin d)).symm σ) α)) =
+        (Pi.single ((finTwoArrowEquiv (Fin d)).symm (τ.1, τ.2.1)) (1 : ℂ) :
+          NSiteSpace d 2) := by
+      funext α
+      simp only [Pi.single_apply]
+      simp only [replaceAXCfg_eq_iff]
+      simp [finTwoArrowEquiv, h]
+    change Q (fun α ↦
+        (Pi.single ((appendixBFinThreeArrowEquiv (Fin d)).symm τ) (1 : ℂ) :
+          NSiteSpace d 3)
+          (replaceAXCfg ((appendixBFinThreeArrowEquiv (Fin d)).symm σ) α))
+        (axPairCfg ((appendixBFinThreeArrowEquiv (Fin d)).symm σ)) =
+      Q (Pi.single ((finTwoArrowEquiv (Fin d)).symm (τ.1, τ.2.1)) (1 : ℂ))
+        ((finTwoArrowEquiv (Fin d)).symm (σ.1, σ.2.1)) *
+          (if σ.2.2 = τ.2.2 then 1 else 0)
+    rw [hslice]
+    simp [finTwoArrowEquiv, h]
+  · have hslice : (fun α ↦
+        (Pi.single ((appendixBFinThreeArrowEquiv (Fin d)).symm τ) (1 : ℂ) :
+          NSiteSpace d 3)
+          (replaceAXCfg ((appendixBFinThreeArrowEquiv (Fin d)).symm σ) α)) = 0 := by
+      funext α
+      simp only [Pi.single_apply, Pi.zero_apply]
+      simp only [replaceAXCfg_eq_iff]
+      simp [h]
+    change Q (fun α ↦
+        (Pi.single ((appendixBFinThreeArrowEquiv (Fin d)).symm τ) (1 : ℂ) :
+          NSiteSpace d 3)
+          (replaceAXCfg ((appendixBFinThreeArrowEquiv (Fin d)).symm σ) α))
+        (axPairCfg ((appendixBFinThreeArrowEquiv (Fin d)).symm σ)) =
+      Q (Pi.single ((finTwoArrowEquiv (Fin d)).symm (τ.1, τ.2.1)) (1 : ℂ))
+        ((finTwoArrowEquiv (Fin d)).symm (σ.1, σ.2.1)) *
+          (if σ.2.2 = τ.2.2 then 1 else 0)
+    rw [hslice]
+    simp [h]
+
+/-- Reindexing the coefficient matrix of the second physical pair lift gives
+the standard tensor-product matrix lift. -/
+private theorem rightPairLift_toMatrix_reindex
+    (Q : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2) :
+    Matrix.reindex (appendixBFinThreeArrowEquiv (Fin d))
+        (appendixBFinThreeArrowEquiv (Fin d))
+        (LinearMap.toMatrix' (rightPairLift Q)) =
+      rightPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin d))
+        (finTwoArrowEquiv (Fin d)) (LinearMap.toMatrix' Q)) := by
+  classical
+  ext σ τ
+  by_cases h : σ.1 = τ.1
+  · have hslice : (fun β ↦
+        (Pi.single ((appendixBFinThreeArrowEquiv (Fin d)).symm τ) (1 : ℂ) :
+          NSiteSpace d 3)
+          (replaceXBCfg ((appendixBFinThreeArrowEquiv (Fin d)).symm σ) β)) =
+        (Pi.single ((finTwoArrowEquiv (Fin d)).symm (τ.2.1, τ.2.2)) (1 : ℂ) :
+          NSiteSpace d 2) := by
+      funext β
+      simp only [Pi.single_apply]
+      simp only [replaceXBCfg_eq_iff]
+      simp [finTwoArrowEquiv, h]
+    change Q (fun β ↦
+        (Pi.single ((appendixBFinThreeArrowEquiv (Fin d)).symm τ) (1 : ℂ) :
+          NSiteSpace d 3)
+          (replaceXBCfg ((appendixBFinThreeArrowEquiv (Fin d)).symm σ) β))
+        (xbPairCfg ((appendixBFinThreeArrowEquiv (Fin d)).symm σ)) =
+      (if σ.1 = τ.1 then 1 else 0) *
+        Q (Pi.single ((finTwoArrowEquiv (Fin d)).symm (τ.2.1, τ.2.2)) (1 : ℂ))
+          ((finTwoArrowEquiv (Fin d)).symm (σ.2.1, σ.2.2))
+    rw [hslice]
+    simp [finTwoArrowEquiv, h]
+  · have hslice : (fun β ↦
+        (Pi.single ((appendixBFinThreeArrowEquiv (Fin d)).symm τ) (1 : ℂ) :
+          NSiteSpace d 3)
+          (replaceXBCfg ((appendixBFinThreeArrowEquiv (Fin d)).symm σ) β)) = 0 := by
+      funext β
+      simp only [Pi.single_apply, Pi.zero_apply]
+      simp only [replaceXBCfg_eq_iff]
+      simp [h]
+    change Q (fun β ↦
+        (Pi.single ((appendixBFinThreeArrowEquiv (Fin d)).symm τ) (1 : ℂ) :
+          NSiteSpace d 3)
+          (replaceXBCfg ((appendixBFinThreeArrowEquiv (Fin d)).symm σ) β))
+        (xbPairCfg ((appendixBFinThreeArrowEquiv (Fin d)).symm σ)) =
+      (if σ.1 = τ.1 then 1 else 0) *
+        Q (Pi.single ((finTwoArrowEquiv (Fin d)).symm (τ.2.1, τ.2.2)) (1 : ℂ))
+          ((finTwoArrowEquiv (Fin d)).symm (σ.2.1, σ.2.2))
+    rw [hslice]
+    simp [h]
+
+/-! ### Virtual replacement slices -/
+
+/-- The first two coordinates of a three-coordinate function, without a
+restriction on the coordinate type. -/
+private def appendixBFirstPairCfg {alpha : Type*} (p : Fin 3 → alpha) : Fin 2 → alpha :=
+  ![p 0, p 1]
+
+/-- The final two coordinates of a three-coordinate function, without a
+restriction on the coordinate type. -/
+private def appendixBLastPairCfg {alpha : Type*} (p : Fin 3 → alpha) : Fin 2 → alpha :=
+  ![p 1, p 2]
+
+/-- Restricting a replacement on the first virtual bond to the first two sites
+is the corresponding two-site replacement. -/
+private theorem AppendixBStructuralData.axPairCfg_replaceVirtualBond01
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    (p : Fin 3 → Fin D × Fin D) (k : Fin D) :
+    appendixBFirstPairCfg (hStruct.replaceVirtualBond01 p k) =
+      hStruct.replaceTwoSiteVirtualBond (appendixBFirstPairCfg p) k := by
+  funext t
+  fin_cases t <;> simp [appendixBFirstPairCfg]
+
+/-- Restricting a replacement on the second virtual bond to the final two
+sites is the corresponding two-site replacement. -/
+private theorem AppendixBStructuralData.xbPairCfg_replaceVirtualBond12
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    (p : Fin 3 → Fin D × Fin D) (k : Fin D) :
+    appendixBLastPairCfg (hStruct.replaceVirtualBond12 p k) =
+      hStruct.replaceTwoSiteVirtualBond (appendixBLastPairCfg p) k := by
+  funext t
+  fin_cases t <;> simp [appendixBLastPairCfg]
+
+/-- A first-bond replacement gives a prescribed virtual triple precisely when
+its first face and untouched final pair agree. -/
+private theorem AppendixBStructuralData.replaceVirtualBond01_eq_iff
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    (p q : Fin 3 → Fin D × Fin D) (k : Fin D) :
+    hStruct.replaceVirtualBond01 p k = q ↔
+      hStruct.replaceTwoSiteVirtualBond (appendixBFirstPairCfg p) k =
+          appendixBFirstPairCfg q ∧ p 2 = q 2 := by
+  constructor
+  · intro h
+    exact ⟨by
+      rw [← hStruct.axPairCfg_replaceVirtualBond01]
+      exact congrArg appendixBFirstPairCfg h,
+      congrFun h 2⟩
+  · rintro ⟨hface, hs⟩
+    funext t
+    fin_cases t
+    · simpa [appendixBFirstPairCfg] using congrFun hface 0
+    · simpa [appendixBFirstPairCfg] using congrFun hface 1
+    · simpa using hs
+
+/-- A second-bond replacement gives a prescribed virtual triple precisely when
+its final face and untouched initial pair agree. -/
+private theorem AppendixBStructuralData.replaceVirtualBond12_eq_iff
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    (p q : Fin 3 → Fin D × Fin D) (k : Fin D) :
+    hStruct.replaceVirtualBond12 p k = q ↔
+      hStruct.replaceTwoSiteVirtualBond (appendixBLastPairCfg p) k =
+          appendixBLastPairCfg q ∧ p 0 = q 0 := by
+  constructor
+  · intro h
+    exact ⟨by
+      rw [← hStruct.xbPairCfg_replaceVirtualBond12]
+      exact congrArg appendixBLastPairCfg h,
+      congrFun h 0⟩
+  · rintro ⟨hface, hs⟩
+    funext t
+    fin_cases t
+    · simpa using hs
+    · simpa [appendixBLastPairCfg] using congrFun hface 0
+    · simpa [appendixBLastPairCfg] using congrFun hface 1
+
+/-! ### Matrices of the physical and virtual two-site transports -/
+
+/-- Reindexing carries a product of three matrices to the product of their
+three compatible reindexings. -/
+private theorem reindex_three_mul
+    {m n o p m' n' o' p' : Type*}
+    [Fintype n] [Fintype n'] [Fintype o] [Fintype o']
+    (em : m ≃ m') (en : n ≃ n') (eo : o ≃ o') (ep : p ≃ p')
+    (M : Matrix m n ℂ) (N : Matrix n o ℂ) (P : Matrix o p ℂ) :
+    Matrix.reindex em ep ((M * N) * P) =
+      (Matrix.reindex em en M * Matrix.reindex en eo N) *
+        Matrix.reindex eo ep P := by
+  calc
+    _ = Matrix.reindex em eo (M * N) * Matrix.reindex eo ep P := by
+      simpa only [Matrix.coe_reindexLinearEquiv] using
+        (Matrix.reindexLinearEquiv_mul ℂ ℂ em eo ep (M * N) P).symm
+    _ = _ := by
+      simpa only [Matrix.coe_reindexLinearEquiv] using congrArg
+        (fun Q ↦ Q * Matrix.reindex eo ep P)
+        (Matrix.reindexLinearEquiv_mul ℂ ℂ em en eo M N).symm
+
+/-- The one-site physical isometry in the pair-index basis. -/
+private noncomputable def AppendixBStructuralData.physicalIsometryMatrix
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    Matrix (Fin d) (Fin D × Fin D) ℂ :=
+  fun i p ↦ hStruct.U i p.1 p.2
+
+/-- The reindexed two-site tensor-power matrix is the Kronecker square of the
+one-site physical isometry. -/
+private theorem AppendixBStructuralData.physicalIsometryTensorPower_two_matrix
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    Matrix.reindex (finTwoArrowEquiv (Fin d)) (finTwoArrowEquiv (Fin D × Fin D))
+        (LinearMap.toMatrix' (hStruct.physicalIsometryTensorPower 2)) =
+      hStruct.physicalIsometryMatrix ⊗ₖ hStruct.physicalIsometryMatrix := by
+  classical
+  ext σ p
+  simp [Matrix.reindex_apply, LinearMap.toMatrix'_apply,
+    AppendixBStructuralData.physicalIsometryTensorPower,
+    AppendixBStructuralData.physicalIsometryMatrix, finTwoArrowEquiv,
+    Pi.single_apply, Fin.prod_univ_two]
+
+/-- The reindexed two-site coefficient-adjoint matrix is the Kronecker square
+of the conjugate transpose of the one-site physical isometry. -/
+private theorem AppendixBStructuralData.physicalIsometryTensorPowerLeftInverse_two_matrix
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    Matrix.reindex (finTwoArrowEquiv (Fin D × Fin D)) (finTwoArrowEquiv (Fin d))
+        (LinearMap.toMatrix' (hStruct.physicalIsometryTensorPowerLeftInverse 2)) =
+      hStruct.physicalIsometryMatrixᴴ ⊗ₖ hStruct.physicalIsometryMatrixᴴ := by
+  classical
+  ext p σ
+  simp [Matrix.reindex_apply, LinearMap.toMatrix'_apply,
+    AppendixBStructuralData.physicalIsometryTensorPowerLeftInverse,
+    AppendixBStructuralData.physicalIsometryMatrix, finTwoArrowEquiv,
+    Pi.single_apply, Fin.prod_univ_two, Matrix.conjTranspose_apply]
+
+/-- The reindexed two-site transported matrix is the virtual bond matrix
+sandwiched by the Kronecker square of the physical isometry. -/
+private theorem AppendixBStructuralData.transportedTwoSiteBondProjection_matrix
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    Matrix.reindex (finTwoArrowEquiv (Fin d)) (finTwoArrowEquiv (Fin d))
+        (LinearMap.toMatrix' hStruct.transportedTwoSiteBondProjection) =
+      (hStruct.physicalIsometryMatrix ⊗ₖ hStruct.physicalIsometryMatrix) *
+        Matrix.reindex (finTwoArrowEquiv (Fin D × Fin D))
+          (finTwoArrowEquiv (Fin D × Fin D))
+          (LinearMap.toMatrix' hStruct.twoSiteVirtualBondProjection) *
+        (hStruct.physicalIsometryMatrixᴴ ⊗ₖ hStruct.physicalIsometryMatrixᴴ) := by
+  rw [AppendixBStructuralData.transportedTwoSiteBondProjection,
+    LinearMap.toMatrix'_comp, LinearMap.toMatrix'_comp]
+  rw [← Matrix.mul_assoc]
+  rw [← hStruct.physicalIsometryTensorPower_two_matrix,
+    ← hStruct.physicalIsometryTensorPowerLeftInverse_two_matrix]
+  exact reindex_three_mul (finTwoArrowEquiv (Fin d))
+    (finTwoArrowEquiv (Fin D × Fin D)) (finTwoArrowEquiv (Fin D × Fin D))
+    (finTwoArrowEquiv (Fin d)) _ _ _
+
+/-- The one-site physical matrix is an isometry on the virtual pair space. -/
+private theorem AppendixBStructuralData.physicalIsometryMatrix_isometry
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    hStruct.physicalIsometryMatrixᴴ * hStruct.physicalIsometryMatrix = 1 := by
+  classical
+  ext p q
+  by_cases hpq : p = q
+  · subst q
+    simpa [Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.one_apply,
+      AppendixBStructuralData.physicalIsometryMatrix] using hStruct.hU_pair p p
+  · simpa [Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.one_apply, hpq,
+      AppendixBStructuralData.physicalIsometryMatrix] using hStruct.hU_pair p q
+
+/-- Reindexing the first three-site virtual bond projector gives the standard
+left pair matrix of the two-site virtual projector. -/
+private theorem AppendixBStructuralData.leftVirtualBondProjection_matrix
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    Matrix.reindex (appendixBFinThreeArrowEquiv (Fin D × Fin D))
+        (appendixBFinThreeArrowEquiv (Fin D × Fin D))
+        (LinearMap.toMatrix' hStruct.leftVirtualBondProjection) =
+      leftPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin D × Fin D))
+        (finTwoArrowEquiv (Fin D × Fin D))
+        (LinearMap.toMatrix' hStruct.twoSiteVirtualBondProjection)) := by
+  classical
+  ext p q
+  by_cases hs : p.2.2 = q.2.2
+  · simp [leftPairMatrix, Matrix.reindex_apply, LinearMap.toMatrix'_apply,
+      AppendixBStructuralData.leftVirtualBondProjection,
+      AppendixBStructuralData.twoSiteVirtualBondProjection,
+      hStruct.replaceVirtualBond01_eq_iff,
+      appendixBFirstPairCfg, appendixBFinThreeArrowEquiv, finTwoArrowEquiv,
+      Pi.single_apply, hs]
+  · simp [leftPairMatrix, Matrix.reindex_apply, LinearMap.toMatrix'_apply,
+      AppendixBStructuralData.leftVirtualBondProjection,
+      AppendixBStructuralData.twoSiteVirtualBondProjection,
+      hStruct.replaceVirtualBond01_eq_iff,
+      appendixBFirstPairCfg, appendixBFinThreeArrowEquiv, finTwoArrowEquiv,
+      Pi.single_apply, hs]
+
+/-- Reindexing the second three-site virtual bond projector gives the standard
+right pair matrix of the two-site virtual projector. -/
+private theorem AppendixBStructuralData.rightVirtualBondProjection_matrix
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    Matrix.reindex (appendixBFinThreeArrowEquiv (Fin D × Fin D))
+        (appendixBFinThreeArrowEquiv (Fin D × Fin D))
+        (LinearMap.toMatrix' hStruct.rightVirtualBondProjection) =
+      rightPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin D × Fin D))
+        (finTwoArrowEquiv (Fin D × Fin D))
+        (LinearMap.toMatrix' hStruct.twoSiteVirtualBondProjection)) := by
+  classical
+  ext p q
+  by_cases hs : p.1 = q.1
+  · simp [rightPairMatrix, Matrix.reindex_apply, LinearMap.toMatrix'_apply,
+      AppendixBStructuralData.rightVirtualBondProjection,
+      AppendixBStructuralData.twoSiteVirtualBondProjection,
+      hStruct.replaceVirtualBond12_eq_iff,
+      appendixBLastPairCfg, appendixBFinThreeArrowEquiv, finTwoArrowEquiv,
+      Pi.single_apply, Matrix.one_apply, hs]
+  · simp [rightPairMatrix, Matrix.reindex_apply, LinearMap.toMatrix'_apply,
+      AppendixBStructuralData.rightVirtualBondProjection,
+      AppendixBStructuralData.twoSiteVirtualBondProjection,
+      hStruct.replaceVirtualBond12_eq_iff,
+      appendixBLastPairCfg, appendixBFinThreeArrowEquiv, finTwoArrowEquiv,
+      Pi.single_apply, hs]
+
+/-- The two standard pair matrices of the virtual bond projector commute. -/
+private theorem AppendixBStructuralData.virtualPairMatrices_comm
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    leftPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin D × Fin D))
+          (finTwoArrowEquiv (Fin D × Fin D))
+          (LinearMap.toMatrix' hStruct.twoSiteVirtualBondProjection)) *
+        rightPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin D × Fin D))
+          (finTwoArrowEquiv (Fin D × Fin D))
+          (LinearMap.toMatrix' hStruct.twoSiteVirtualBondProjection)) =
+      rightPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin D × Fin D))
+          (finTwoArrowEquiv (Fin D × Fin D))
+          (LinearMap.toMatrix' hStruct.twoSiteVirtualBondProjection)) *
+        leftPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin D × Fin D))
+          (finTwoArrowEquiv (Fin D × Fin D))
+          (LinearMap.toMatrix' hStruct.twoSiteVirtualBondProjection)) := by
+  rw [← hStruct.leftVirtualBondProjection_matrix,
+    ← hStruct.rightVirtualBondProjection_matrix]
+  let e := appendixBFinThreeArrowEquiv (Fin D × Fin D)
+  have hMatrix := congrArg LinearMap.toMatrix'
+    hStruct.leftVirtualBondProjection_comp_right
+  rw [LinearMap.toMatrix'_comp, LinearMap.toMatrix'_comp] at hMatrix
+  calc
+    _ = Matrix.reindex e e
+        (LinearMap.toMatrix' hStruct.leftVirtualBondProjection *
+          LinearMap.toMatrix' hStruct.rightVirtualBondProjection) := by
+      simpa only [Matrix.coe_reindexLinearEquiv] using
+        Matrix.reindexLinearEquiv_mul ℂ ℂ e e e
+          (LinearMap.toMatrix' hStruct.leftVirtualBondProjection)
+          (LinearMap.toMatrix' hStruct.rightVirtualBondProjection)
+    _ = Matrix.reindex e e
+        (LinearMap.toMatrix' hStruct.rightVirtualBondProjection *
+          LinearMap.toMatrix' hStruct.leftVirtualBondProjection) := congrArg _ hMatrix
+    _ = _ := by
+      simpa only [Matrix.coe_reindexLinearEquiv] using
+        (Matrix.reindexLinearEquiv_mul ℂ ℂ e e e
+          (LinearMap.toMatrix' hStruct.rightVirtualBondProjection)
+          (LinearMap.toMatrix' hStruct.leftVirtualBondProjection)).symm
+
+/-- The two pair placements of the transported virtual bond matrix commute on
+three physical sites. -/
+private theorem AppendixBStructuralData.transportedPairMatrices_comm
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    leftPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin d))
+          (finTwoArrowEquiv (Fin d))
+          (LinearMap.toMatrix' hStruct.transportedTwoSiteBondProjection)) *
+        rightPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin d))
+          (finTwoArrowEquiv (Fin d))
+          (LinearMap.toMatrix' hStruct.transportedTwoSiteBondProjection)) =
+      rightPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin d))
+          (finTwoArrowEquiv (Fin d))
+          (LinearMap.toMatrix' hStruct.transportedTwoSiteBondProjection)) *
+        leftPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin d))
+          (finTwoArrowEquiv (Fin d))
+          (LinearMap.toMatrix' hStruct.transportedTwoSiteBondProjection)) := by
+  rw [hStruct.transportedTwoSiteBondProjection_matrix]
+  let B := Matrix.reindex (finTwoArrowEquiv (Fin D × Fin D))
+    (finTwoArrowEquiv (Fin D × Fin D))
+    (LinearMap.toMatrix' hStruct.twoSiteVirtualBondProjection)
+  have hB : appendixBLeftPairMatrix B * appendixBRightPairMatrix B =
+      appendixBRightPairMatrix B * appendixBLeftPairMatrix B := by
+    simpa [B, leftPairMatrix, rightPairMatrix, appendixBLeftPairMatrixAux,
+      appendixBRightPairMatrixAux] using hStruct.virtualPairMatrices_comm
+  simpa [B, leftPairMatrix, rightPairMatrix, appendixBLeftPairMatrixAux,
+    appendixBRightPairMatrixAux] using
+    appendixB_transportedPairMatrices_comm hStruct.physicalIsometryMatrix B
+      hStruct.physicalIsometryMatrix_isometry hB
+
+/-- The two adjacent lifts of the transported virtual bond projector commute
+on the three-site physical coefficient space. -/
+private theorem AppendixBStructuralData.transportedTwoSiteBondProjection_commute_lifts
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    leftPairLift hStruct.transportedTwoSiteBondProjection *
+        rightPairLift hStruct.transportedTwoSiteBondProjection =
+      rightPairLift hStruct.transportedTwoSiteBondProjection *
+        leftPairLift hStruct.transportedTwoSiteBondProjection := by
+  apply LinearMap.toMatrix'.injective
+  simp only [LinearMap.toMatrix'_mul]
+  let e := appendixBFinThreeArrowEquiv (Fin d)
+  apply (Matrix.reindexLinearEquiv ℂ ℂ e e).injective
+  simp only [Matrix.coe_reindexLinearEquiv]
+  calc
+    _ = Matrix.reindex e e
+          (LinearMap.toMatrix' (leftPairLift hStruct.transportedTwoSiteBondProjection)) *
+        Matrix.reindex e e
+          (LinearMap.toMatrix' (rightPairLift hStruct.transportedTwoSiteBondProjection)) := by
+      simpa only [Matrix.coe_reindexLinearEquiv] using
+        (Matrix.reindexLinearEquiv_mul ℂ ℂ e e e
+          (LinearMap.toMatrix' (leftPairLift hStruct.transportedTwoSiteBondProjection))
+          (LinearMap.toMatrix'
+            (rightPairLift hStruct.transportedTwoSiteBondProjection))).symm
+    _ = leftPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin d))
+          (finTwoArrowEquiv (Fin d))
+          (LinearMap.toMatrix' hStruct.transportedTwoSiteBondProjection)) *
+        rightPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin d))
+          (finTwoArrowEquiv (Fin d))
+          (LinearMap.toMatrix' hStruct.transportedTwoSiteBondProjection)) := by
+      rw [leftPairLift_toMatrix_reindex, rightPairLift_toMatrix_reindex]
+    _ = _ := hStruct.transportedPairMatrices_comm
+    _ = Matrix.reindex e e
+          (LinearMap.toMatrix' (rightPairLift hStruct.transportedTwoSiteBondProjection)) *
+        Matrix.reindex e e
+          (LinearMap.toMatrix' (leftPairLift hStruct.transportedTwoSiteBondProjection)) := by
+      rw [leftPairLift_toMatrix_reindex, rightPairLift_toMatrix_reindex]
+    _ = _ := by
+      simpa only [Matrix.coe_reindexLinearEquiv] using
+        Matrix.reindexLinearEquiv_mul ℂ ℂ e e e
+          (LinearMap.toMatrix' (rightPairLift hStruct.transportedTwoSiteBondProjection))
+          (LinearMap.toMatrix' (leftPairLift hStruct.transportedTwoSiteBondProjection))
+
+/-! ### Euclidean transports and adjoints -/
+
+/-- Regard a coefficient-space linear map as a map between the corresponding
+Euclidean spaces. -/
+private noncomputable def coefficientEuclideanMap
+    {ι κ : Type*} [Fintype ι] [Fintype κ]
+    (T : (ι → ℂ) →ₗ[ℂ] (κ → ℂ)) :
+    EuclideanSpace ℂ ι →ₗ[ℂ] EuclideanSpace ℂ κ :=
+  (WithLp.linearEquiv 2 ℂ (κ → ℂ)).symm.toLinearMap.comp
+    (T.comp (WithLp.linearEquiv 2 ℂ (ι → ℂ)).toLinearMap)
+
+/-- The two-site physical tensor power as a Euclidean linear map. -/
+private noncomputable def AppendixBStructuralData.physicalIsometryTwoES
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    EuclideanSpace ℂ (Fin 2 → Fin D × Fin D) →ₗ[ℂ]
+      EuclideanSpace ℂ (Cfg d 2) :=
+  coefficientEuclideanMap (hStruct.physicalIsometryTensorPower 2)
+
+/-- The two-site conjugate coefficient map as a Euclidean linear map. -/
+private noncomputable def AppendixBStructuralData.physicalIsometryTwoAdjointES
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    EuclideanSpace ℂ (Cfg d 2) →ₗ[ℂ]
+      EuclideanSpace ℂ (Fin 2 → Fin D × Fin D) :=
+  coefficientEuclideanMap (hStruct.physicalIsometryTensorPowerLeftInverse 2)
+
+/-- The conjugate coefficient map is the Hilbert-space adjoint of the two-site
+physical isometry. -/
+private theorem AppendixBStructuralData.physicalIsometryTwoAdjointES_eq_adjoint
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    hStruct.physicalIsometryTwoAdjointES = hStruct.physicalIsometryTwoES.adjoint := by
+  apply (LinearMap.eq_adjoint_iff _ _).2
+  intro ψ v
+  simpa [AppendixBStructuralData.physicalIsometryTwoAdjointES,
+    AppendixBStructuralData.physicalIsometryTwoES, coefficientEuclideanMap] using
+    (hStruct.physicalIsometryTensorPower_adjoint_inner 2
+      ((WithLp.linearEquiv 2 ℂ (NSiteSpace d 2)) ψ)
+      ((WithLp.linearEquiv 2 ℂ ((Fin 2 → Fin D × Fin D) → ℂ)) v)).symm
+
+/-- The two-site virtual bond projector as a Euclidean endomorphism. -/
+private noncomputable def AppendixBStructuralData.twoSiteVirtualBondProjectionES
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    EuclideanSpace ℂ (Fin 2 → Fin D × Fin D) →ₗ[ℂ]
+      EuclideanSpace ℂ (Fin 2 → Fin D × Fin D) :=
+  coefficientEuclideanMap hStruct.twoSiteVirtualBondProjection
+
+/-- The transported two-site bond operator as a Euclidean endomorphism. -/
+private noncomputable def AppendixBStructuralData.transportedTwoSiteBondProjectionES
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    EuclideanSpace ℂ (Cfg d 2) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d 2) :=
+  coefficientEuclideanMap hStruct.transportedTwoSiteBondProjection
+
+/-- Euclidean transport respects the three factors in the definition of the
+transported bond operator. -/
+private theorem AppendixBStructuralData.transportedTwoSiteBondProjectionES_eq
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    hStruct.transportedTwoSiteBondProjectionES =
+      hStruct.physicalIsometryTwoES.comp
+        (hStruct.twoSiteVirtualBondProjectionES.comp
+          hStruct.physicalIsometryTwoAdjointES) := by
+  apply LinearMap.ext
+  intro v
+  rfl
+
+/-- Bond insertion and normalized bond contraction are adjoint up to the
+squared norm of the bond vector. -/
+private theorem AppendixBStructuralData.twoSiteBondInsertion_adjoint_inner
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    (hφ : hStruct.virtualBondNormSq ≠ 0) (v : Fin D × Fin D → ℂ)
+    (w : (Fin 2 → Fin D × Fin D) → ℂ) :
+    ⟪(WithLp.linearEquiv 2 ℂ ((Fin 2 → Fin D × Fin D) → ℂ)).symm
+          (hStruct.twoSiteBondInsertion v),
+        (WithLp.linearEquiv 2 ℂ ((Fin 2 → Fin D × Fin D) → ℂ)).symm w⟫_ℂ =
+      hStruct.virtualBondNormSq *
+        ⟪(WithLp.linearEquiv 2 ℂ (Fin D × Fin D → ℂ)).symm v,
+          (WithLp.linearEquiv 2 ℂ (Fin D × Fin D → ℂ)).symm
+            (hStruct.twoSiteVirtualBoundaryContraction w)⟫_ℂ := by
+  classical
+  change (∑ p : Fin 2 → Fin D × Fin D,
+      w p * star (hStruct.twoSiteBondInsertion v p)) =
+    hStruct.virtualBondNormSq * ∑ ac : Fin D × Fin D,
+      hStruct.twoSiteVirtualBoundaryContraction w ac * star (v ac)
+  have hstar (p₀ p₁ : Fin D × Fin D) :
+      star (if p₀.2 = p₁.1 then
+        (hStruct.Λ p₀.2 : ℂ) * v (p₀.1, p₁.2) else 0) =
+        if p₀.2 = p₁.1 then
+          (hStruct.Λ p₀.2 : ℂ) * star (v (p₀.1, p₁.2)) else 0 := by
+    split <;> simp_all
+  have hconfig (a b c : Fin D) :
+      hStruct.twoSiteVirtualBondConfig a c b = ![(a, b), (b, c)] := by
+    funext t
+    fin_cases t <;> simp
+  calc
+    _ = ∑ p₀ : Fin D × Fin D, ∑ p₁ : Fin D × Fin D,
+        w ((finTwoArrowEquiv (Fin D × Fin D)).symm (p₀, p₁)) *
+          star (if p₀.2 = p₁.1 then
+            (hStruct.Λ p₀.2 : ℂ) * v (p₀.1, p₁.2) else 0) := by
+      rw [← (finTwoArrowEquiv (Fin D × Fin D)).symm.sum_comp]
+      rw [Fintype.sum_prod_type]
+      simp [AppendixBStructuralData.twoSiteBondInsertion,
+        finTwoArrowEquiv_symm_apply]
+    _ = ∑ a : Fin D, ∑ b : Fin D, ∑ c : Fin D,
+        w (hStruct.twoSiteVirtualBondConfig a c b) *
+          (hStruct.Λ b : ℂ) * star (v (a, c)) := by
+      simp_rw [hstar]
+      simp [Fintype.sum_prod_type, mul_assoc]
+      simp_rw [hconfig]
+    _ = hStruct.virtualBondNormSq * ∑ ac : Fin D × Fin D,
+        hStruct.twoSiteVirtualBoundaryContraction w ac * star (v ac) := by
+      simp only [AppendixBStructuralData.twoSiteVirtualBoundaryContraction,
+        Fintype.sum_prod_type]
+      rw [Finset.mul_sum]
+      apply Finset.sum_congr rfl
+      intro a _
+      rw [Finset.sum_comm]
+      rw [Finset.mul_sum]
+      apply Finset.sum_congr rfl
+      intro c _
+      change (∑ x : Fin D, w (hStruct.twoSiteVirtualBondConfig a c x) *
+          (hStruct.Λ x : ℂ) * star (v (a, c))) =
+        hStruct.virtualBondNormSq *
+          ((hStruct.virtualBondNormSq⁻¹ * ∑ k : Fin D,
+            (hStruct.Λ k : ℂ) *
+              w (hStruct.twoSiteVirtualBondConfig a c k)) * star (v (a, c)))
+      rw [← mul_assoc, ← mul_assoc, mul_inv_cancel₀ hφ, one_mul, Finset.sum_mul]
+      apply Finset.sum_congr rfl
+      intro b _
+      ring
+
+/-- The squared norm of the real-weight bond vector is fixed by complex
+conjugation. -/
+private theorem AppendixBStructuralData.star_virtualBondNormSq
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    star hStruct.virtualBondNormSq = hStruct.virtualBondNormSq := by
+  simp [AppendixBStructuralData.virtualBondNormSq, star_sum, star_mul]
+
+/-- The normalized virtual bond projector is symmetric for the Euclidean inner
+product. -/
+private theorem AppendixBStructuralData.twoSiteVirtualBondProjection_inner
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    (hφ : hStruct.virtualBondNormSq ≠ 0)
+    (v w : (Fin 2 → Fin D × Fin D) → ℂ) :
+    ⟪(WithLp.linearEquiv 2 ℂ ((Fin 2 → Fin D × Fin D) → ℂ)).symm
+          (hStruct.twoSiteVirtualBondProjection v),
+        (WithLp.linearEquiv 2 ℂ ((Fin 2 → Fin D × Fin D) → ℂ)).symm w⟫_ℂ =
+      ⟪(WithLp.linearEquiv 2 ℂ ((Fin 2 → Fin D × Fin D) → ℂ)).symm v,
+        (WithLp.linearEquiv 2 ℂ ((Fin 2 → Fin D × Fin D) → ℂ)).symm
+          (hStruct.twoSiteVirtualBondProjection w)⟫_ℂ := by
+  rw [hStruct.twoSiteVirtualBondProjection_eq_comp]
+  simp only [LinearMap.comp_apply]
+  calc
+    _ = hStruct.virtualBondNormSq *
+        ⟪(WithLp.linearEquiv 2 ℂ (Fin D × Fin D → ℂ)).symm
+            (hStruct.twoSiteVirtualBoundaryContraction v),
+          (WithLp.linearEquiv 2 ℂ (Fin D × Fin D → ℂ)).symm
+            (hStruct.twoSiteVirtualBoundaryContraction w)⟫_ℂ :=
+      hStruct.twoSiteBondInsertion_adjoint_inner hφ _ _
+    _ = star (⟪(WithLp.linearEquiv 2 ℂ ((Fin 2 → Fin D × Fin D) → ℂ)).symm
+          (hStruct.twoSiteBondInsertion
+            (hStruct.twoSiteVirtualBoundaryContraction w)),
+        (WithLp.linearEquiv 2 ℂ ((Fin 2 → Fin D × Fin D) → ℂ)).symm v⟫_ℂ) := by
+      rw [hStruct.twoSiteBondInsertion_adjoint_inner hφ]
+      simp only [star_mul, hStruct.star_virtualBondNormSq]
+      have hi : star (⟪(WithLp.linearEquiv 2 ℂ (Fin D × Fin D → ℂ)).symm
+          (hStruct.twoSiteVirtualBoundaryContraction w),
+        (WithLp.linearEquiv 2 ℂ (Fin D × Fin D → ℂ)).symm
+          (hStruct.twoSiteVirtualBoundaryContraction v)⟫_ℂ) =
+          ⟪(WithLp.linearEquiv 2 ℂ (Fin D × Fin D → ℂ)).symm
+            (hStruct.twoSiteVirtualBoundaryContraction v),
+          (WithLp.linearEquiv 2 ℂ (Fin D × Fin D → ℂ)).symm
+            (hStruct.twoSiteVirtualBoundaryContraction w)⟫_ℂ :=
+        inner_conj_symm _ _
+      rw [hi]
+      exact mul_comm _ _
+    _ = _ := inner_conj_symm _ _
+
+/-- The virtual bond projector is a symmetric projection on the Euclidean
+coefficient space. -/
+private theorem AppendixBStructuralData.twoSiteVirtualBondProjectionES_isSymmetricProjection
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    (hφ : hStruct.virtualBondNormSq ≠ 0) :
+    hStruct.twoSiteVirtualBondProjectionES.IsSymmetricProjection where
+  isIdempotentElem := by
+    apply LinearMap.ext
+    intro v
+    simpa [AppendixBStructuralData.twoSiteVirtualBondProjectionES,
+      coefficientEuclideanMap, Module.End.mul_apply] using
+      LinearMap.congr_fun (hStruct.twoSiteVirtualBondProjection_idempotent hφ)
+        ((WithLp.linearEquiv 2 ℂ ((Fin 2 → Fin D × Fin D) → ℂ)) v)
+  isSymmetric := by
+    intro v w
+    simpa [AppendixBStructuralData.twoSiteVirtualBondProjectionES,
+      coefficientEuclideanMap] using
+      hStruct.twoSiteVirtualBondProjection_inner hφ
+        ((WithLp.linearEquiv 2 ℂ ((Fin 2 → Fin D × Fin D) → ℂ)) v)
+        ((WithLp.linearEquiv 2 ℂ ((Fin 2 → Fin D × Fin D) → ℂ)) w)
+
+/-- The transported virtual bond operator is a symmetric projection on the
+two-site physical Euclidean space. -/
+private theorem AppendixBStructuralData.transportedTwoSiteBondProjectionES_isSymmetricProjection
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    (hφ : hStruct.virtualBondNormSq ≠ 0) :
+    hStruct.transportedTwoSiteBondProjectionES.IsSymmetricProjection where
+  isIdempotentElem := by
+    apply LinearMap.ext
+    intro v
+    simpa [AppendixBStructuralData.transportedTwoSiteBondProjectionES,
+      coefficientEuclideanMap, Module.End.mul_apply] using
+      LinearMap.congr_fun (hStruct.transportedTwoSiteBondProjection_idempotent hφ)
+        ((WithLp.linearEquiv 2 ℂ (NSiteSpace d 2)) v)
+  isSymmetric := by
+    rw [hStruct.transportedTwoSiteBondProjectionES_eq,
+      hStruct.physicalIsometryTwoAdjointES_eq_adjoint]
+    exact (hStruct.twoSiteVirtualBondProjectionES_isSymmetricProjection hφ).isSymmetric
+      |>.conj_adjoint hStruct.physicalIsometryTwoES
+
+/-- The Euclidean transported projector has the canonical two-site ground
+space as its range. -/
+private theorem AppendixBStructuralData.transportedTwoSiteBondProjectionES_range
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    (hφ : hStruct.virtualBondNormSq ≠ 0) :
+    LinearMap.range hStruct.transportedTwoSiteBondProjectionES =
+      groundSpaceES hStruct.coreTensor 2 := by
+  ext ψ
+  constructor
+  · rintro ⟨v, rfl⟩
+    apply (mem_groundSpaceES_iff hStruct.coreTensor 2 _).2
+    change hStruct.transportedTwoSiteBondProjection
+      ((WithLp.linearEquiv 2 ℂ (NSiteSpace d 2)) v) ∈
+        groundSpace hStruct.coreTensor 2
+    rw [← AppendixBStructuralData.twoSiteBasicSpace]
+    rw [← hStruct.twoSiteBasicEmbedding_range,
+      ← hStruct.transportedTwoSiteBondProjection_range hφ]
+    exact ⟨_, rfl⟩
+  · intro hψ
+    have hraw : (WithLp.linearEquiv 2 ℂ (NSiteSpace d 2)) ψ ∈
+        LinearMap.range hStruct.transportedTwoSiteBondProjection := by
+      rw [hStruct.transportedTwoSiteBondProjection_range hφ,
+        hStruct.twoSiteBasicEmbedding_range]
+      exact (mem_groundSpaceES_iff hStruct.coreTensor 2 ψ).1 hψ
+    obtain ⟨v, hv⟩ := hraw
+    refine ⟨(WithLp.linearEquiv 2 ℂ (NSiteSpace d 2)).symm v, ?_⟩
+    apply (WithLp.linearEquiv 2 ℂ (NSiteSpace d 2)).injective
+    simpa [AppendixBStructuralData.transportedTwoSiteBondProjectionES,
+      coefficientEuclideanMap] using hv
+
+/-- For a nonzero virtual bond, its physical transport is the canonical
+orthogonal support projector onto the two-site basic space. -/
+private theorem AppendixBStructuralData.transportedTwoSiteBondProjection_eq_support_of_ne
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    (hφ : hStruct.virtualBondNormSq ≠ 0) :
+    hStruct.transportedTwoSiteBondProjection =
+      hStruct.twoSiteBasicSupportProjection := by
+  have hEq : hStruct.transportedTwoSiteBondProjectionES =
+      (groundSpaceES hStruct.coreTensor 2).starProjection.toLinearMap :=
+    (hStruct.transportedTwoSiteBondProjectionES_isSymmetricProjection hφ).ext
+      (Submodule.isSymmetricProjection_starProjection _)
+      (by
+        rw [Submodule.range_starProjection]
+        exact hStruct.transportedTwoSiteBondProjectionES_range hφ)
+  apply LinearMap.ext
+  intro ψ
+  have hψ := LinearMap.congr_fun hEq
+    ((WithLp.linearEquiv 2 ℂ (NSiteSpace d 2)).symm ψ)
+  apply (WithLp.linearEquiv 2 ℂ (NSiteSpace d 2)).symm.injective
+  simpa [AppendixBStructuralData.transportedTwoSiteBondProjectionES,
+    coefficientEuclideanMap,
+    AppendixBStructuralData.twoSiteBasicSupportProjection] using hψ
+
+/-- The physical transport of the rank-one virtual bond projector is the
+canonical two-site basic support projector.  The statement also covers the
+zero-dimensional virtual space, where both maps vanish.
+
+Source: arXiv:1606.00608, equations (3.16)--(3.18), lines 549--578, and the
+parent-space construction, lines 511--524. -/
+theorem AppendixBStructuralData.transportedTwoSiteBondProjection_eq_support
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    hStruct.transportedTwoSiteBondProjection =
+      hStruct.twoSiteBasicSupportProjection := by
+  cases isEmpty_or_nonempty (Fin D) with
+  | inr hnonempty =>
+      letI : Nonempty (Fin D) := hnonempty
+      exact hStruct.transportedTwoSiteBondProjection_eq_support_of_ne
+        hStruct.virtualBondNormSq_ne_zero
+  | inl hempty =>
+      letI : IsEmpty (Fin D) := hempty
+      have hInsertion : hStruct.twoSiteBondInsertion = 0 := by
+        apply LinearMap.ext
+        intro v
+        funext p
+        exact isEmptyElim (p 0).1
+      have hEmbedding : hStruct.twoSiteBasicEmbedding = 0 := by
+        simp [AppendixBStructuralData.twoSiteBasicEmbedding, hInsertion]
+      have hSupport : hStruct.twoSiteBasicSupportProjection = 0 := by
+        apply LinearMap.range_eq_bot.mp
+        rw [hStruct.twoSiteBasicSupportProjection_range_eq_embedding, hEmbedding]
+        exact LinearMap.range_zero
+      have hTransport : hStruct.transportedTwoSiteBondProjection = 0 := by
+        apply LinearMap.ext
+        intro ψ
+        simp only [AppendixBStructuralData.transportedTwoSiteBondProjection,
+          LinearMap.comp_apply]
+        have hleft : hStruct.physicalIsometryTensorPowerLeftInverse 2 ψ = 0 := by
+          funext p
+          exact isEmptyElim (p 0).1
+        rw [hleft, map_zero, map_zero, LinearMap.zero_apply]
+      rw [hTransport, hSupport]
+
+/-- The two adjacent lifts of the canonical two-site basic support projector
+commute on the three-site coefficient space.
+
+Source: arXiv:1606.00608, parent-space construction, lines 511--524, and the
+Appendix B basic-vector form, equations (3.16)--(3.18), lines 543--578. -/
+theorem AppendixBStructuralData.twoSiteBasicSupportProjection_commute_lifts
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    leftPairLift hStruct.twoSiteBasicSupportProjection *
+        rightPairLift hStruct.twoSiteBasicSupportProjection =
+      rightPairLift hStruct.twoSiteBasicSupportProjection *
+        leftPairLift hStruct.twoSiteBasicSupportProjection := by
+  rw [← hStruct.transportedTwoSiteBondProjection_eq_support]
+  exact hStruct.transportedTwoSiteBondProjection_commute_lifts
+
+/-- Commutation of the two lifted basic-support projectors implies the
+overlapping two-site commutation condition for their complementary Appendix B
+parent interactions.
+
+Source: arXiv:1606.00608, parent construction, lines 511--524, equations
+(3.17)--(3.18), lines 564--578, and Definition D.2, lines 2205--2218. -/
+theorem AppendixBStructuralData.hasOverlappingTwoSiteCommutation_of_support_commute
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    (hcomm :
+      leftPairLift hStruct.twoSiteBasicSupportProjection *
+          rightPairLift hStruct.twoSiteBasicSupportProjection =
+        rightPairLift hStruct.twoSiteBasicSupportProjection *
+          leftPairLift hStruct.twoSiteBasicSupportProjection) :
+    HasOverlappingTwoSiteCommutation (d := d) hStruct.appendixBQAXOnCoeffSpace
+      hStruct.appendixBQXBOnCoeffSpace := by
+  let hSupport : HasOverlappingTwoSiteCommutation (d := d)
+      hStruct.twoSiteBasicSupportProjection hStruct.twoSiteBasicSupportProjection :=
+    { left_idempotent := hStruct.twoSiteBasicSupportProjection_idempotent
+      right_idempotent := hStruct.twoSiteBasicSupportProjection_idempotent
+      commute_lifts := hcomm }
+  have hComplement := hSupport.complement
+  simpa [hStruct.twoSiteBasicSupportProjection_eq_complement,
+    AppendixBStructuralData.appendixBQAXOnCoeffSpace,
+    AppendixBStructuralData.appendixBQXBOnCoeffSpace] using hComplement
+
+/-- The two overlapping Appendix B parent interactions commute on three sites.
+
+Source: arXiv:1606.00608, parent-space construction, lines 511--524,
+equations (3.16)--(3.18), lines 543--578, and Definition D.2, lines
+2205--2218. -/
+theorem AppendixBStructuralData.hasOverlappingTwoSiteCommutation
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    HasOverlappingTwoSiteCommutation (d := d) hStruct.appendixBQAXOnCoeffSpace
+      hStruct.appendixBQXBOnCoeffSpace :=
+  hStruct.hasOverlappingTwoSiteCommutation_of_support_commute
+    hStruct.twoSiteBasicSupportProjection_commute_lifts
+
+end MPSTensor

--- a/TNLean/MPS/RFP/AppendixBSupport.lean
+++ b/TNLean/MPS/RFP/AppendixBSupport.lean
@@ -9,17 +9,19 @@ import TNLean.MPS.RFP.CommutingBridge
 
 This file develops the local support construction arising from the Appendix B
 basic-vector expression in arXiv:1606.00608, equations (3.16)--(3.18).  It
-constructs every tensor power of the physical isometry, inserts the virtual bond
+constructs every tensor power of the physical isometry, the rank-one virtual
+bond projector and its adjacent three-site placements, inserts the virtual bond
 vector on two sites, identifies the resulting physical image with
 \(G_2(\Lambda U)\), and constructs its orthogonal support projector.
 
-The subsequent three-site commutator still requires the virtual projector onto
-\(\mathbb C\varphi\), its two adjacent placements, and the spectator-complement
-argument for the possibly non-surjective physical isometry.  That boundary is
-recorded in `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
+The adjacent virtual placements commute.  Their transport to the physical
+three-site coefficient space uses only the isometry identity \(U^*U=1\); no
+surjectivity of \(U\) is required.  The distinction between this local result
+and an all-chain statement is recorded in
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 -/
 
-open scoped Matrix BigOperators
+open scoped Matrix BigOperators InnerProductSpace
 
 namespace MPSTensor
 
@@ -172,7 +174,336 @@ theorem AppendixBStructuralData.physicalIsometryTensorPower_injective
   LinearMap.injective_of_comp_eq_id _ _
     (hStruct.physicalIsometryTensorPowerLeftInverse_comp N)
 
+/-- The coefficient map called the left inverse above is the Hilbert-space
+adjoint of the physical tensor power.
+
+Source: arXiv:1606.00608, pair-index isometry equation (3.16) and basic-vector
+equation (3.17), lines 549--578. -/
+theorem AppendixBStructuralData.physicalIsometryTensorPower_adjoint_inner
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) (N : ℕ)
+    (ψ : NSiteSpace d N) (v : (Fin N → Fin D × Fin D) → ℂ) :
+    ⟪(WithLp.linearEquiv 2 ℂ (NSiteSpace d N)).symm ψ,
+        (WithLp.linearEquiv 2 ℂ (NSiteSpace d N)).symm
+          (hStruct.physicalIsometryTensorPower N v)⟫_ℂ =
+      ⟪(WithLp.linearEquiv 2 ℂ ((Fin N → Fin D × Fin D) → ℂ)).symm
+          (hStruct.physicalIsometryTensorPowerLeftInverse N ψ),
+        (WithLp.linearEquiv 2 ℂ ((Fin N → Fin D × Fin D) → ℂ)).symm v⟫_ℂ := by
+  classical
+  change (∑ σ : Cfg d N,
+      (∑ p : Fin N → Fin D × Fin D,
+        (∏ t : Fin N, hStruct.U (σ t) (p t).1 (p t).2) * v p) * star (ψ σ)) =
+    ∑ p : Fin N → Fin D × Fin D, v p * star (∑ σ : Cfg d N,
+      (∏ t : Fin N, star (hStruct.U (σ t) (p t).1 (p t).2)) * ψ σ)
+  calc
+    _ = ∑ σ : Cfg d N, ∑ p : Fin N → Fin D × Fin D,
+        ((∏ t : Fin N, hStruct.U (σ t) (p t).1 (p t).2) * v p) * star (ψ σ) := by
+      apply Finset.sum_congr rfl
+      intro σ _
+      rw [Finset.sum_mul]
+    _ = ∑ p : Fin N → Fin D × Fin D, ∑ σ : Cfg d N,
+        v p * (star (ψ σ) * ∏ t : Fin N,
+          hStruct.U (σ t) (p t).1 (p t).2) := by
+      rw [Finset.sum_comm]
+      apply Finset.sum_congr rfl
+      intro p _
+      apply Finset.sum_congr rfl
+      intro σ _
+      ring
+    _ = _ := by
+      apply Finset.sum_congr rfl
+      intro p _
+      rw [star_sum, Finset.mul_sum]
+      apply Finset.sum_congr rfl
+      intro σ _
+      simp only [star_mul, star_prod, star_star]
+
+/-- Every physical tensor power preserves the Hilbert-space inner product.
+
+Source: arXiv:1606.00608, pair-index isometry equation (3.16), lines
+549--554. -/
+theorem AppendixBStructuralData.physicalIsometryTensorPower_inner
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) (N : ℕ)
+    (v w : (Fin N → Fin D × Fin D) → ℂ) :
+    ⟪(WithLp.linearEquiv 2 ℂ (NSiteSpace d N)).symm
+          (hStruct.physicalIsometryTensorPower N v),
+        (WithLp.linearEquiv 2 ℂ (NSiteSpace d N)).symm
+          (hStruct.physicalIsometryTensorPower N w)⟫_ℂ =
+      ⟪(WithLp.linearEquiv 2 ℂ ((Fin N → Fin D × Fin D) → ℂ)).symm v,
+        (WithLp.linearEquiv 2 ℂ ((Fin N → Fin D × Fin D) → ℂ)).symm w⟫_ℂ := by
+  rw [hStruct.physicalIsometryTensorPower_adjoint_inner]
+  have hleft := LinearMap.congr_fun
+    (hStruct.physicalIsometryTensorPowerLeftInverse_comp N) v
+  simp only [LinearMap.comp_apply, Module.End.one_apply] at hleft
+  rw [hleft]
+
+/-! ### The virtual bond projector -/
+
+/-- The squared norm
+\(\langle\varphi,\varphi\rangle=\sum_b\lambda_b^2\) of the Appendix B bond
+vector \(\varphi=\sum_b\lambda_b\lvert b,b\rangle\).
+
+Source: arXiv:1606.00608, equations (3.17)--(3.18), lines 564--578. -/
+noncomputable def AppendixBStructuralData.virtualBondNormSq
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) : ℂ :=
+  ∑ k : Fin D, (hStruct.Λ k : ℂ) * (hStruct.Λ k : ℂ)
+
+/-- Strict positivity of the bond weights makes the squared bond norm nonzero
+whenever the virtual space is nonempty.
+
+Source: arXiv:1606.00608, equation (3.18), lines 573--578. -/
+theorem AppendixBStructuralData.virtualBondNormSq_ne_zero
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    [Nonempty (Fin D)] : hStruct.virtualBondNormSq ≠ 0 := by
+  let k₀ : Fin D := Classical.choice inferInstance
+  have hnonneg : ∀ k ∈ Finset.univ, 0 ≤ hStruct.Λ k * hStruct.Λ k := by
+    intro k _
+    exact mul_nonneg (le_of_lt (hStruct.hΛ_pos k)) (le_of_lt (hStruct.hΛ_pos k))
+  have hpos : 0 < ∑ k : Fin D, hStruct.Λ k * hStruct.Λ k := by
+    apply Finset.sum_pos' hnonneg
+    exact ⟨k₀, Finset.mem_univ k₀, mul_pos (hStruct.hΛ_pos k₀) (hStruct.hΛ_pos k₀)⟩
+  have hc : ((∑ k : Fin D, hStruct.Λ k * hStruct.Λ k : ℝ) : ℂ) ≠ 0 := by
+    exact_mod_cast ne_of_gt hpos
+  simpa [AppendixBStructuralData.virtualBondNormSq] using hc
+
+/-- The rank-one orthogonal projector onto
+\(\mathbb C\varphi\), written in the pair-index basis.
+
+Source: arXiv:1606.00608, equations (3.17)--(3.18), lines 564--578. -/
+noncomputable def AppendixBStructuralData.virtualBondProjection
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    ((Fin D × Fin D → ℂ) →ₗ[ℂ] (Fin D × Fin D → ℂ)) where
+  toFun v p :=
+    if p.1 = p.2 then
+      (hStruct.Λ p.1 : ℂ) / hStruct.virtualBondNormSq *
+        ∑ k : Fin D, (hStruct.Λ k : ℂ) * v (k, k)
+    else 0
+  map_add' v w := by
+    funext p
+    by_cases hp : p.1 = p.2
+    · simp only [hp, if_true, Pi.add_apply, mul_add, Finset.sum_add_distrib]
+    · simp only [Pi.add_apply, hp, if_false, add_zero]
+  map_smul' c v := by
+    funext p
+    by_cases hp : p.1 = p.2
+    · simp [hp, Finset.mul_sum, mul_assoc, mul_comm]
+    · simp [hp]
+
+/-- Replace the virtual bond joining sites zero and one by the diagonal basis
+vector indexed by `k`, leaving the four remaining virtual indices unchanged. -/
+def AppendixBStructuralData.replaceVirtualBond01
+    {A : MPSTensor d D} (_hStruct : AppendixBStructuralData A)
+    (p : Fin 3 → Fin D × Fin D) (k : Fin D) : Fin 3 → Fin D × Fin D :=
+  fun t ↦ if t = 0 then ((p 0).1, k) else if t = 1 then (k, (p 1).2) else p t
+
+/-- Replace the virtual bond joining sites one and two by the diagonal basis
+vector indexed by `k`, leaving the four remaining virtual indices unchanged. -/
+def AppendixBStructuralData.replaceVirtualBond12
+    {A : MPSTensor d D} (_hStruct : AppendixBStructuralData A)
+    (p : Fin 3 → Fin D × Fin D) (k : Fin D) : Fin 3 → Fin D × Fin D :=
+  fun t ↦ if t = 1 then ((p 1).1, k) else if t = 2 then (k, (p 2).2) else p t
+
+@[simp] theorem AppendixBStructuralData.replaceVirtualBond01_zero
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    (p : Fin 3 → Fin D × Fin D) (k : Fin D) :
+    hStruct.replaceVirtualBond01 p k 0 = ((p 0).1, k) := by
+  simp [AppendixBStructuralData.replaceVirtualBond01]
+
+@[simp] theorem AppendixBStructuralData.replaceVirtualBond01_one
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    (p : Fin 3 → Fin D × Fin D) (k : Fin D) :
+    hStruct.replaceVirtualBond01 p k 1 = (k, (p 1).2) := by
+  simp [AppendixBStructuralData.replaceVirtualBond01]
+
+@[simp] theorem AppendixBStructuralData.replaceVirtualBond01_two
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    (p : Fin 3 → Fin D × Fin D) (k : Fin D) :
+    hStruct.replaceVirtualBond01 p k 2 = p 2 := by
+  simp [AppendixBStructuralData.replaceVirtualBond01]
+
+@[simp] theorem AppendixBStructuralData.replaceVirtualBond12_zero
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    (p : Fin 3 → Fin D × Fin D) (k : Fin D) :
+    hStruct.replaceVirtualBond12 p k 0 = p 0 := by
+  simp [AppendixBStructuralData.replaceVirtualBond12]
+
+@[simp] theorem AppendixBStructuralData.replaceVirtualBond12_one
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    (p : Fin 3 → Fin D × Fin D) (k : Fin D) :
+    hStruct.replaceVirtualBond12 p k 1 = ((p 1).1, k) := by
+  simp [AppendixBStructuralData.replaceVirtualBond12]
+
+@[simp] theorem AppendixBStructuralData.replaceVirtualBond12_two
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    (p : Fin 3 → Fin D × Fin D) (k : Fin D) :
+    hStruct.replaceVirtualBond12 p k 2 = (k, (p 2).2) := by
+  simp [AppendixBStructuralData.replaceVirtualBond12]
+
+/-- The replacement of the two adjacent virtual bonds is independent of its
+order. -/
+theorem AppendixBStructuralData.replaceVirtualBonds_commute
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    (p : Fin 3 → Fin D × Fin D) (k l : Fin D) :
+    hStruct.replaceVirtualBond01 (hStruct.replaceVirtualBond12 p l) k =
+      hStruct.replaceVirtualBond12 (hStruct.replaceVirtualBond01 p k) l := by
+  funext t
+  fin_cases t <;> simp
+
+/-- The placement of the virtual bond projector on the bond joining sites zero
+and one of three virtual pairs.
+
+Source: arXiv:1606.00608, equations (3.17)--(3.18), lines 564--578. -/
+noncomputable def AppendixBStructuralData.leftVirtualBondProjection
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    (((Fin 3 → Fin D × Fin D) → ℂ) →ₗ[ℂ]
+      ((Fin 3 → Fin D × Fin D) → ℂ)) where
+  toFun v p :=
+    if (p 0).2 = (p 1).1 then
+      (hStruct.Λ (p 0).2 : ℂ) / hStruct.virtualBondNormSq *
+        ∑ k : Fin D, (hStruct.Λ k : ℂ) * v (hStruct.replaceVirtualBond01 p k)
+    else 0
+  map_add' v w := by
+    funext p
+    by_cases hp : (p 0).2 = (p 1).1
+    · simp only [hp, if_true, Pi.add_apply, mul_add, Finset.sum_add_distrib]
+    · simp only [Pi.add_apply, hp, if_false, add_zero]
+  map_smul' c v := by
+    funext p
+    by_cases hp : (p 0).2 = (p 1).1
+    · simp [hp, Finset.mul_sum, mul_assoc, mul_comm]
+    · simp [hp]
+
+/-- The placement of the virtual bond projector on the bond joining sites one
+and two of three virtual pairs.
+
+Source: arXiv:1606.00608, equations (3.17)--(3.18), lines 564--578. -/
+noncomputable def AppendixBStructuralData.rightVirtualBondProjection
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    (((Fin 3 → Fin D × Fin D) → ℂ) →ₗ[ℂ]
+      ((Fin 3 → Fin D × Fin D) → ℂ)) where
+  toFun v p :=
+    if (p 1).2 = (p 2).1 then
+      (hStruct.Λ (p 1).2 : ℂ) / hStruct.virtualBondNormSq *
+        ∑ k : Fin D, (hStruct.Λ k : ℂ) * v (hStruct.replaceVirtualBond12 p k)
+    else 0
+  map_add' v w := by
+    funext p
+    by_cases hp : (p 1).2 = (p 2).1
+    · simp only [hp, if_true, Pi.add_apply, mul_add, Finset.sum_add_distrib]
+    · simp only [Pi.add_apply, hp, if_false, add_zero]
+  map_smul' c v := by
+    funext p
+    by_cases hp : (p 1).2 = (p 2).1
+    · simp [hp, Finset.mul_sum, mul_assoc, mul_comm]
+    · simp [hp]
+
+/-- The two adjacent placements of the rank-one virtual bond projector commute.
+They act on the two disjoint contracted bonds among three virtual site pairs.
+
+Source: arXiv:1606.00608, equations (3.17)--(3.18), lines 564--578. -/
+theorem AppendixBStructuralData.leftVirtualBondProjection_comp_right
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    hStruct.leftVirtualBondProjection.comp hStruct.rightVirtualBondProjection =
+      hStruct.rightVirtualBondProjection.comp hStruct.leftVirtualBondProjection := by
+  apply LinearMap.ext
+  intro v
+  funext p
+  by_cases h01 : (p 0).2 = (p 1).1
+  · by_cases h12 : (p 1).2 = (p 2).1
+    · simp [LinearMap.comp_apply, AppendixBStructuralData.leftVirtualBondProjection,
+        AppendixBStructuralData.rightVirtualBondProjection, h01, h12]
+      simp_rw [← hStruct.replaceVirtualBonds_commute]
+      simp only [Finset.mul_sum]
+      rw [Finset.sum_comm]
+      apply Finset.sum_congr rfl
+      intro k _
+      apply Finset.sum_congr rfl
+      intro l _
+      ring
+    · simp [LinearMap.comp_apply, AppendixBStructuralData.leftVirtualBondProjection,
+        AppendixBStructuralData.rightVirtualBondProjection, h01, h12]
+  · simp [LinearMap.comp_apply, AppendixBStructuralData.leftVirtualBondProjection,
+      AppendixBStructuralData.rightVirtualBondProjection, h01]
+
 /-! ### The two-site virtual bond -/
+
+/-- Replace the contracted virtual bond in two virtual site pairs by the
+diagonal basis vector indexed by `k`. -/
+def AppendixBStructuralData.replaceTwoSiteVirtualBond
+    {A : MPSTensor d D} (_hStruct : AppendixBStructuralData A)
+    (p : Fin 2 → Fin D × Fin D) (k : Fin D) : Fin 2 → Fin D × Fin D :=
+  fun t ↦ if t = 0 then ((p 0).1, k) else (k, (p 1).2)
+
+@[simp] theorem AppendixBStructuralData.replaceTwoSiteVirtualBond_zero
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    (p : Fin 2 → Fin D × Fin D) (k : Fin D) :
+    hStruct.replaceTwoSiteVirtualBond p k 0 = ((p 0).1, k) := by
+  simp [AppendixBStructuralData.replaceTwoSiteVirtualBond]
+
+@[simp] theorem AppendixBStructuralData.replaceTwoSiteVirtualBond_one
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    (p : Fin 2 → Fin D × Fin D) (k : Fin D) :
+    hStruct.replaceTwoSiteVirtualBond p k 1 = (k, (p 1).2) := by
+  simp [AppendixBStructuralData.replaceTwoSiteVirtualBond]
+
+/-- The rank-one virtual bond projector acting on the contracted indices of two
+virtual site pairs and as the identity on their outer indices.
+
+Source: arXiv:1606.00608, equations (3.17)--(3.18), lines 564--578. -/
+noncomputable def AppendixBStructuralData.twoSiteVirtualBondProjection
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    (((Fin 2 → Fin D × Fin D) → ℂ) →ₗ[ℂ]
+      ((Fin 2 → Fin D × Fin D) → ℂ)) where
+  toFun v p :=
+    if (p 0).2 = (p 1).1 then
+      (hStruct.Λ (p 0).2 : ℂ) / hStruct.virtualBondNormSq *
+        ∑ k : Fin D,
+          (hStruct.Λ k : ℂ) * v (hStruct.replaceTwoSiteVirtualBond p k)
+    else 0
+  map_add' v w := by
+    funext p
+    by_cases hp : (p 0).2 = (p 1).1
+    · simp only [hp, if_true, Pi.add_apply, mul_add, Finset.sum_add_distrib]
+    · simp only [Pi.add_apply, hp, if_false, add_zero]
+  map_smul' c v := by
+    funext p
+    by_cases hp : (p 0).2 = (p 1).1
+    · simp [hp, Finset.mul_sum, mul_assoc, mul_comm]
+    · simp [hp]
+
+/-- The two-site virtual configuration with outer indices `a,c` and diagonal
+bond index `k`. -/
+def AppendixBStructuralData.twoSiteVirtualBondConfig
+    {A : MPSTensor d D} (_hStruct : AppendixBStructuralData A)
+    (a c k : Fin D) : Fin 2 → Fin D × Fin D :=
+  fun t ↦ if t = 0 then (a, k) else (k, c)
+
+@[simp] theorem AppendixBStructuralData.twoSiteVirtualBondConfig_zero
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) (a c k : Fin D) :
+    hStruct.twoSiteVirtualBondConfig a c k 0 = (a, k) := by
+  simp [AppendixBStructuralData.twoSiteVirtualBondConfig]
+
+@[simp] theorem AppendixBStructuralData.twoSiteVirtualBondConfig_one
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) (a c k : Fin D) :
+    hStruct.twoSiteVirtualBondConfig a c k 1 = (k, c) := by
+  simp [AppendixBStructuralData.twoSiteVirtualBondConfig]
+
+/-- Contract a two-site virtual coefficient tensor against the normalized bond
+vector while retaining its two outer indices. -/
+noncomputable def AppendixBStructuralData.twoSiteVirtualBoundaryContraction
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    (((Fin 2 → Fin D × Fin D) → ℂ) →ₗ[ℂ] (Fin D × Fin D → ℂ)) where
+  toFun v ac := hStruct.virtualBondNormSq⁻¹ *
+    ∑ k : Fin D, (hStruct.Λ k : ℂ) *
+      v (hStruct.twoSiteVirtualBondConfig ac.1 ac.2 k)
+  map_add' v w := by
+    funext ac
+    simp only [Pi.add_apply, mul_add, Finset.sum_add_distrib]
+  map_smul' c v := by
+    funext ac
+    simp only [Pi.smul_apply, RingHom.id_apply, smul_eq_mul, Finset.mul_sum]
+    apply Finset.sum_congr rfl
+    intro k _
+    ring_nf
 
 /-- Insert the bond vector
 \(\varphi=\sum_b\lambda_b\lvert b,b\rangle\) between two virtual site pairs.
@@ -202,6 +533,118 @@ noncomputable def AppendixBStructuralData.twoSiteBondInsertion
     · simp [h, mul_assoc, mul_comm]
     · simp [h]
 
+/-- Replacing the contracted bond while retaining the outer indices gives the
+canonical virtual-bond configuration. -/
+theorem AppendixBStructuralData.replaceTwoSiteVirtualBond_eq_config
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    (p : Fin 2 → Fin D × Fin D) (k : Fin D) :
+    hStruct.replaceTwoSiteVirtualBond p k =
+      hStruct.twoSiteVirtualBondConfig (p 0).1 (p 1).2 k := by
+  funext t
+  fin_cases t <;> simp
+
+/-- The two-site virtual bond projector is bond insertion after contraction of
+the same bond.
+
+Source: arXiv:1606.00608, equations (3.17)--(3.18), lines 564--578. -/
+theorem AppendixBStructuralData.twoSiteVirtualBondProjection_eq_comp
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    hStruct.twoSiteVirtualBondProjection =
+      hStruct.twoSiteBondInsertion.comp hStruct.twoSiteVirtualBoundaryContraction := by
+  apply LinearMap.ext
+  intro v
+  funext p
+  by_cases hp : (p 0).2 = (p 1).1
+  · simp [AppendixBStructuralData.twoSiteVirtualBondProjection,
+      AppendixBStructuralData.twoSiteBondInsertion,
+      AppendixBStructuralData.twoSiteVirtualBoundaryContraction, hp]
+    simp_rw [hStruct.replaceTwoSiteVirtualBond_eq_config]
+    ring_nf
+  · simp [AppendixBStructuralData.twoSiteVirtualBondProjection,
+      AppendixBStructuralData.twoSiteBondInsertion, hp]
+
+/-- If the bond vector is nonzero, its virtual support projector fixes every
+inserted-bond vector.
+
+Source: arXiv:1606.00608, equations (3.17)--(3.18), lines 564--578. -/
+theorem AppendixBStructuralData.twoSiteVirtualBondProjection_apply_insertion
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    (hφ : hStruct.virtualBondNormSq ≠ 0) (v : Fin D × Fin D → ℂ) :
+    hStruct.twoSiteVirtualBondProjection (hStruct.twoSiteBondInsertion v) =
+      hStruct.twoSiteBondInsertion v := by
+  have hsum : (∑ k : Fin D, (hStruct.Λ k : ℂ) ^ 2) ≠ 0 := by
+    simpa [AppendixBStructuralData.virtualBondNormSq, pow_two] using hφ
+  funext p
+  by_cases hp : (p 0).2 = (p 1).1
+  · simp [AppendixBStructuralData.twoSiteVirtualBondProjection,
+      AppendixBStructuralData.twoSiteBondInsertion,
+      AppendixBStructuralData.replaceTwoSiteVirtualBond, hp,
+      AppendixBStructuralData.virtualBondNormSq]
+    field_simp [hsum]
+    have hv : (∑ x : Fin D,
+        (hStruct.Λ x : ℂ) ^ 2 * v ((p 0).1, (p 1).2)) =
+        (∑ x : Fin D, (hStruct.Λ x : ℂ) ^ 2) * v ((p 0).1, (p 1).2) := by
+      rw [Finset.sum_mul]
+    rw [hv]
+    ac_rfl
+  · simp [AppendixBStructuralData.twoSiteVirtualBondProjection,
+      AppendixBStructuralData.twoSiteBondInsertion, hp]
+
+/-- For a nonzero bond vector, the two-site virtual bond projector is
+idempotent.
+
+Source: arXiv:1606.00608, equations (3.17)--(3.18), lines 564--578. -/
+theorem AppendixBStructuralData.twoSiteVirtualBondProjection_idempotent
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    (hφ : hStruct.virtualBondNormSq ≠ 0) :
+    hStruct.twoSiteVirtualBondProjection * hStruct.twoSiteVirtualBondProjection =
+      hStruct.twoSiteVirtualBondProjection := by
+  apply LinearMap.ext
+  intro v
+  rw [Module.End.mul_apply]
+  rw [show hStruct.twoSiteVirtualBondProjection v =
+      hStruct.twoSiteBondInsertion
+        (hStruct.twoSiteVirtualBoundaryContraction v) by
+    exact LinearMap.congr_fun hStruct.twoSiteVirtualBondProjection_eq_comp v]
+  rw [hStruct.twoSiteVirtualBondProjection_apply_insertion hφ]
+
+/-- The physical transport of the virtual bond projector through the two-site
+isometry.
+
+Source: arXiv:1606.00608, equations (3.16)--(3.18), lines 549--578. -/
+noncomputable def AppendixBStructuralData.transportedTwoSiteBondProjection
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2 :=
+  (hStruct.physicalIsometryTensorPower 2).comp
+    (hStruct.twoSiteVirtualBondProjection.comp
+      (hStruct.physicalIsometryTensorPowerLeftInverse 2))
+
+/-- For a nonzero bond vector, the transported two-site bond operator is
+idempotent.
+
+Source: arXiv:1606.00608, equations (3.16)--(3.18), lines 549--578. -/
+theorem AppendixBStructuralData.transportedTwoSiteBondProjection_idempotent
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    (hφ : hStruct.virtualBondNormSq ≠ 0) :
+    hStruct.transportedTwoSiteBondProjection *
+        hStruct.transportedTwoSiteBondProjection =
+      hStruct.transportedTwoSiteBondProjection := by
+  apply LinearMap.ext
+  intro v
+  simp only [Module.End.mul_apply,
+    AppendixBStructuralData.transportedTwoSiteBondProjection, LinearMap.comp_apply]
+  have hleft := LinearMap.congr_fun
+    (hStruct.physicalIsometryTensorPowerLeftInverse_comp 2)
+    (hStruct.twoSiteVirtualBondProjection
+      (hStruct.physicalIsometryTensorPowerLeftInverse 2 v))
+  simp only [LinearMap.comp_apply, Module.End.one_apply] at hleft
+  rw [hleft]
+  have hV := LinearMap.congr_fun
+    (hStruct.twoSiteVirtualBondProjection_idempotent hφ)
+    (hStruct.physicalIsometryTensorPowerLeftInverse 2 v)
+  simp only [Module.End.mul_apply] at hV
+  rw [hV]
+
 /-- The two-site basic-vector embedding
 \(U^{\otimes 2}I_\varphi\), with the bond vector inserted between the two
 neighboring virtual sites.
@@ -211,6 +654,34 @@ noncomputable def AppendixBStructuralData.twoSiteBasicEmbedding
     {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
     ((Fin D × Fin D → ℂ) →ₗ[ℂ] NSiteSpace d 2) :=
   (hStruct.physicalIsometryTensorPower 2).comp hStruct.twoSiteBondInsertion
+
+/-- For a nonzero bond vector, the transported virtual projector has exactly
+the two-site basic-vector range.
+
+Source: arXiv:1606.00608, equations (3.16)--(3.18), lines 549--578. -/
+theorem AppendixBStructuralData.transportedTwoSiteBondProjection_range
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    (hφ : hStruct.virtualBondNormSq ≠ 0) :
+    LinearMap.range hStruct.transportedTwoSiteBondProjection =
+      LinearMap.range hStruct.twoSiteBasicEmbedding := by
+  apply le_antisymm
+  · rintro ψ ⟨v, rfl⟩
+    refine ⟨hStruct.twoSiteVirtualBoundaryContraction
+      (hStruct.physicalIsometryTensorPowerLeftInverse 2 v), ?_⟩
+    simp only [AppendixBStructuralData.transportedTwoSiteBondProjection,
+      AppendixBStructuralData.twoSiteBasicEmbedding, LinearMap.comp_apply]
+    rw [hStruct.twoSiteVirtualBondProjection_eq_comp]
+    rfl
+  · rintro ψ ⟨v, rfl⟩
+    refine ⟨hStruct.twoSiteBasicEmbedding v, ?_⟩
+    simp only [AppendixBStructuralData.transportedTwoSiteBondProjection,
+      AppendixBStructuralData.twoSiteBasicEmbedding, LinearMap.comp_apply]
+    have hleft := LinearMap.congr_fun
+      (hStruct.physicalIsometryTensorPowerLeftInverse_comp 2)
+      (hStruct.twoSiteBondInsertion v)
+    simp only [LinearMap.comp_apply, Module.End.one_apply] at hleft
+    rw [hleft]
+    rw [hStruct.twoSiteVirtualBondProjection_apply_insertion hφ]
 
 /-- Identify a boundary matrix \(Y\) with its two outer virtual indices by
 \(v_{a,c}=\lambda_aY_{c,a}\).

--- a/TNLean/MPS/RFP/KroneckerTransport.lean
+++ b/TNLean/MPS/RFP/KroneckerTransport.lean
@@ -7,9 +7,11 @@ import TNLean.MPS.RFP.CommutingBridge
 /-!
 # Three-site transport of commuting pair matrices
 
-This file contains the finite-dimensional matrix calculation which transports
-two commuting adjacent pair operators through a tensor cube of an isometry.
-It is independent of the particular virtual bond operator used in Appendix B.
+This file contains the finite-dimensional matrix calculation used in the
+Appendix B argument to transport two commuting adjacent pair operators through
+a tensor cube of an isometry.  The calculation does not depend on the
+particular virtual bond operator, but its exported names remain Appendix B
+specific because they support that argument.
 -/
 
 open scoped Matrix Kronecker
@@ -54,7 +56,7 @@ private noncomputable def tripleMatrix
 
 /-- Reindexing carries a product of three matrices to the product of their
 three compatible reindexings. -/
-private theorem reindex_three_mul
+theorem reindex_three_mul
     {m n o p m' n' o' p' : Type*}
     [Fintype n] [Fintype n'] [Fintype o] [Fintype o']
     (em : m ≃ m') (en : n ≃ n') (eo : o ≃ o') (ep : p ≃ p')

--- a/TNLean/MPS/RFP/KroneckerTransport.lean
+++ b/TNLean/MPS/RFP/KroneckerTransport.lean
@@ -1,0 +1,315 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.RFP.CommutingBridge
+
+/-!
+# Three-site transport of commuting pair matrices
+
+This file contains the finite-dimensional matrix calculation which transports
+two commuting adjacent pair operators through a tensor cube of an isometry.
+It is independent of the particular virtual bond operator used in Appendix B.
+-/
+
+open scoped Matrix Kronecker
+
+namespace MPSTensor
+
+/-- A pair matrix on the first two factors, with a possibly different
+spectator type. -/
+noncomputable def appendixBLeftPairMatrixAux
+    {a b s : Type*} [Fintype s] [DecidableEq s]
+    (B : Matrix (a × a) (b × b) ℂ) :
+    Matrix (a × (a × s)) (b × (b × s)) ℂ :=
+  Matrix.reindex (Equiv.prodAssoc a a s) (Equiv.prodAssoc b b s)
+    (B ⊗ₖ (1 : Matrix s s ℂ))
+
+/-- A pair matrix on the final two factors, with a possibly different
+spectator type. -/
+noncomputable def appendixBRightPairMatrixAux
+    {s a b : Type*} [Fintype s] [DecidableEq s]
+    (B : Matrix (a × a) (b × b) ℂ) :
+    Matrix (s × (a × a)) (s × (b × b)) ℂ :=
+  (1 : Matrix s s ℂ) ⊗ₖ B
+
+/-- A square pair matrix on the first two factors. -/
+noncomputable abbrev appendixBLeftPairMatrix
+    {a : Type*} [Fintype a] [DecidableEq a]
+    (B : Matrix (a × a) (a × a) ℂ) :=
+  appendixBLeftPairMatrixAux (s := a) B
+
+/-- A square pair matrix on the final two factors. -/
+noncomputable abbrev appendixBRightPairMatrix
+    {a : Type*} [Fintype a] [DecidableEq a]
+    (B : Matrix (a × a) (a × a) ℂ) :=
+  appendixBRightPairMatrixAux (s := a) B
+
+/-- A right-associated Kronecker product of three matrices. -/
+private noncomputable def tripleMatrix
+    {a b c d e f : Type*}
+    (A : Matrix a b ℂ) (B : Matrix c d ℂ) (C : Matrix e f ℂ) :
+    Matrix (a × (c × e)) (b × (d × f)) ℂ :=
+  A ⊗ₖ (B ⊗ₖ C)
+
+/-- Reindexing carries a product of three matrices to the product of their
+three compatible reindexings. -/
+private theorem reindex_three_mul
+    {m n o p m' n' o' p' : Type*}
+    [Fintype n] [Fintype n'] [Fintype o] [Fintype o']
+    (em : m ≃ m') (en : n ≃ n') (eo : o ≃ o') (ep : p ≃ p')
+    (M : Matrix m n ℂ) (N : Matrix n o ℂ) (P : Matrix o p ℂ) :
+    Matrix.reindex em ep ((M * N) * P) =
+      (Matrix.reindex em en M * Matrix.reindex en eo N) *
+        Matrix.reindex eo ep P := by
+  calc
+    _ = Matrix.reindex em eo (M * N) * Matrix.reindex eo ep P := by
+      simpa only [Matrix.coe_reindexLinearEquiv] using
+        (Matrix.reindexLinearEquiv_mul ℂ ℂ em eo ep (M * N) P).symm
+    _ = _ := by
+      simpa only [Matrix.coe_reindexLinearEquiv] using congrArg
+        (fun Q ↦ Q * Matrix.reindex eo ep P)
+        (Matrix.reindexLinearEquiv_mul ℂ ℂ em en eo M N).symm
+
+/-- Componentwise multiplication of right-associated triple matrices. -/
+private theorem tripleMatrix_mul
+    {a b c d e f g h i : Type*}
+    [Fintype b] [Fintype e] [Fintype h]
+    (A : Matrix a b ℂ) (A' : Matrix b c ℂ)
+    (B : Matrix d e ℂ) (B' : Matrix e f ℂ)
+    (C : Matrix g h ℂ) (C' : Matrix h i ℂ) :
+    tripleMatrix A B C * tripleMatrix A' B' C' =
+      tripleMatrix (A * A') (B * B') (C * C') := by
+  simp only [tripleMatrix]
+  rw [← Matrix.mul_kronecker_mul, ← Matrix.mul_kronecker_mul]
+
+/-- Transporting a pair matrix on the first two factors through a tensor cube
+gives a three-factor matrix sandwich. -/
+private theorem leftPairMatrix_transport
+    {p v : Type*} [Fintype p] [DecidableEq p]
+    [Fintype v]
+    (U : Matrix p v ℂ) (B : Matrix (v × v) (v × v) ℂ) :
+    appendixBLeftPairMatrix (((U ⊗ₖ U) * B) * (Uᴴ ⊗ₖ Uᴴ)) =
+      ((tripleMatrix U U (1 : Matrix p p ℂ) *
+        appendixBLeftPairMatrixAux (s := p) B) *
+        tripleMatrix Uᴴ Uᴴ (1 : Matrix p p ℂ)) := by
+  have h₁ :
+      ((((U ⊗ₖ U) * B) * (Uᴴ ⊗ₖ Uᴴ)) ⊗ₖ (1 : Matrix p p ℂ)) =
+        (((U ⊗ₖ U) * B) ⊗ₖ (1 : Matrix p p ℂ)) *
+          ((Uᴴ ⊗ₖ Uᴴ) ⊗ₖ (1 : Matrix p p ℂ)) := by
+    simpa only [mul_one] using
+      Matrix.mul_kronecker_mul ((U ⊗ₖ U) * B) (Uᴴ ⊗ₖ Uᴴ)
+        (1 : Matrix p p ℂ) (1 : Matrix p p ℂ)
+  have h₂ :
+      (((U ⊗ₖ U) * B) ⊗ₖ (1 : Matrix p p ℂ)) =
+        ((U ⊗ₖ U) ⊗ₖ (1 : Matrix p p ℂ)) *
+          (B ⊗ₖ (1 : Matrix p p ℂ)) := by
+    simpa only [mul_one] using Matrix.mul_kronecker_mul (U ⊗ₖ U) B
+      (1 : Matrix p p ℂ) (1 : Matrix p p ℂ)
+  unfold appendixBLeftPairMatrix appendixBLeftPairMatrixAux
+  rw [h₁, h₂]
+  rw [reindex_three_mul (Equiv.prodAssoc p p p) (Equiv.prodAssoc v v p)
+    (Equiv.prodAssoc v v p) (Equiv.prodAssoc p p p)]
+  rw [Matrix.kronecker_assoc, Matrix.kronecker_assoc]
+  rfl
+
+/-- Transporting a pair matrix on the final two factors through a tensor cube
+gives the analogous three-factor matrix sandwich. -/
+private theorem rightPairMatrix_transport
+    {p v : Type*} [Fintype p] [DecidableEq p]
+    [Fintype v]
+    (U : Matrix p v ℂ) (B : Matrix (v × v) (v × v) ℂ) :
+    appendixBRightPairMatrix (((U ⊗ₖ U) * B) * (Uᴴ ⊗ₖ Uᴴ)) =
+      ((tripleMatrix (1 : Matrix p p ℂ) U U *
+        appendixBRightPairMatrixAux (s := p) B) *
+        tripleMatrix (1 : Matrix p p ℂ) Uᴴ Uᴴ) := by
+  have h₁ :
+      (1 : Matrix p p ℂ) ⊗ₖ (((U ⊗ₖ U) * B) * (Uᴴ ⊗ₖ Uᴴ)) =
+        ((1 : Matrix p p ℂ) ⊗ₖ ((U ⊗ₖ U) * B)) *
+          ((1 : Matrix p p ℂ) ⊗ₖ (Uᴴ ⊗ₖ Uᴴ)) := by
+    simpa only [one_mul] using Matrix.mul_kronecker_mul (1 : Matrix p p ℂ)
+      (1 : Matrix p p ℂ)
+      ((U ⊗ₖ U) * B) (Uᴴ ⊗ₖ Uᴴ)
+  have h₂ :
+      (1 : Matrix p p ℂ) ⊗ₖ ((U ⊗ₖ U) * B) =
+        ((1 : Matrix p p ℂ) ⊗ₖ (U ⊗ₖ U)) *
+          ((1 : Matrix p p ℂ) ⊗ₖ B) := by
+    simpa only [one_mul] using Matrix.mul_kronecker_mul (1 : Matrix p p ℂ)
+      (1 : Matrix p p ℂ)
+      (U ⊗ₖ U) B
+  unfold appendixBRightPairMatrix appendixBRightPairMatrixAux tripleMatrix
+  rw [h₁, h₂]
+
+/-- A map on the spectator factor commutes naturally past a pair matrix on the
+first two factors. -/
+private theorem leftPairMatrixAux_naturality
+    {a s t : Type*} [Fintype a] [DecidableEq a]
+    [Fintype s] [DecidableEq s] [Fintype t] [DecidableEq t]
+    (B : Matrix (a × a) (a × a) ℂ) (V : Matrix s t ℂ) :
+    appendixBLeftPairMatrixAux (s := s) B *
+        tripleMatrix (1 : Matrix a a ℂ) (1 : Matrix a a ℂ) V =
+      tripleMatrix (1 : Matrix a a ℂ) (1 : Matrix a a ℂ) V *
+        appendixBLeftPairMatrixAux (s := t) B := by
+  let es := Equiv.prodAssoc a a s
+  let et := Equiv.prodAssoc a a t
+  have hAssoc : tripleMatrix (1 : Matrix a a ℂ) (1 : Matrix a a ℂ) V =
+      Matrix.reindex es et ((1 : Matrix (a × a) (a × a) ℂ) ⊗ₖ V) := by
+    unfold tripleMatrix
+    rw [← Matrix.kronecker_assoc (1 : Matrix a a ℂ) (1 : Matrix a a ℂ) V]
+    simp only [Matrix.one_kronecker_one, es, et]
+  rw [hAssoc]
+  unfold appendixBLeftPairMatrixAux
+  calc
+    _ = Matrix.reindex es et
+        ((B ⊗ₖ (1 : Matrix s s ℂ)) *
+          ((1 : Matrix (a × a) (a × a) ℂ) ⊗ₖ V)) := by
+      simpa only [es, et, Matrix.coe_reindexLinearEquiv] using
+        Matrix.reindexLinearEquiv_mul ℂ ℂ es es et
+          (B ⊗ₖ (1 : Matrix s s ℂ))
+          ((1 : Matrix (a × a) (a × a) ℂ) ⊗ₖ V)
+    _ = Matrix.reindex es et (B ⊗ₖ V) := by
+      congr 1
+      rw [← Matrix.mul_kronecker_mul]
+      simp only [Matrix.mul_one, Matrix.one_mul]
+    _ = Matrix.reindex es et
+        (((1 : Matrix (a × a) (a × a) ℂ) ⊗ₖ V) *
+          (B ⊗ₖ (1 : Matrix t t ℂ))) := by
+      congr 1
+      rw [← Matrix.mul_kronecker_mul]
+      simp only [Matrix.mul_one, Matrix.one_mul]
+    _ = _ := by
+      simpa only [es, et, Matrix.coe_reindexLinearEquiv] using
+        (Matrix.reindexLinearEquiv_mul ℂ ℂ es et et
+          ((1 : Matrix (a × a) (a × a) ℂ) ⊗ₖ V)
+          (B ⊗ₖ (1 : Matrix t t ℂ))).symm
+
+/-- A map on the spectator factor commutes naturally past a pair matrix on the
+final two factors. -/
+private theorem rightPairMatrixAux_naturality
+    {a s t : Type*} [Fintype a] [DecidableEq a]
+    [Fintype s] [DecidableEq s] [Fintype t] [DecidableEq t]
+    (B : Matrix (a × a) (a × a) ℂ) (V : Matrix s t ℂ) :
+    appendixBRightPairMatrixAux (s := s) B *
+        tripleMatrix V (1 : Matrix a a ℂ) (1 : Matrix a a ℂ) =
+      tripleMatrix V (1 : Matrix a a ℂ) (1 : Matrix a a ℂ) *
+        appendixBRightPairMatrixAux (s := t) B := by
+  unfold appendixBRightPairMatrixAux tripleMatrix
+  rw [← Matrix.mul_kronecker_mul, ← Matrix.mul_kronecker_mul]
+  simp only [Matrix.one_kronecker_one, Matrix.one_mul, Matrix.mul_one]
+
+/-- The product with the first transported pair on the left is the tensor-cube
+sandwich of the corresponding virtual product. -/
+private theorem transportedPairProduct_left
+    {p v : Type*} [Fintype p] [DecidableEq p]
+    [Fintype v] [DecidableEq v]
+    (U : Matrix p v ℂ) (B : Matrix (v × v) (v × v) ℂ)
+    (hU : Uᴴ * U = 1) :
+    appendixBLeftPairMatrix (((U ⊗ₖ U) * B) * (Uᴴ ⊗ₖ Uᴴ)) *
+        appendixBRightPairMatrix (((U ⊗ₖ U) * B) * (Uᴴ ⊗ₖ Uᴴ)) =
+      tripleMatrix U U U *
+          (appendixBLeftPairMatrix B * appendixBRightPairMatrix B) *
+        tripleMatrix Uᴴ Uᴴ Uᴴ := by
+  rw [leftPairMatrix_transport, rightPairMatrix_transport]
+  let LA := tripleMatrix U U (1 : Matrix p p ℂ)
+  let LHA := tripleMatrix Uᴴ Uᴴ (1 : Matrix p p ℂ)
+  let RA := tripleMatrix (1 : Matrix p p ℂ) U U
+  let RHA := tripleMatrix (1 : Matrix p p ℂ) Uᴴ Uᴴ
+  let UL := tripleMatrix (1 : Matrix v v ℂ) (1 : Matrix v v ℂ) U
+  let HL := tripleMatrix Uᴴ (1 : Matrix v v ℂ) (1 : Matrix v v ℂ)
+  let LBp := appendixBLeftPairMatrixAux (s := p) B
+  let RBp := appendixBRightPairMatrixAux (s := p) B
+  let LBv := appendixBLeftPairMatrix B
+  let RBv := appendixBRightPairMatrix B
+  have hCross : LHA * RA = UL * HL := by
+    dsimp [LHA, RA, UL, HL]
+    rw [tripleMatrix_mul, tripleMatrix_mul]
+    simp only [hU, Matrix.one_mul, Matrix.mul_one]
+  have hOuterLeft : LA * UL = tripleMatrix U U U := by
+    dsimp [LA, UL]
+    rw [tripleMatrix_mul]
+    simp only [Matrix.mul_one, Matrix.one_mul]
+  have hOuterRight : HL * RHA = tripleMatrix Uᴴ Uᴴ Uᴴ := by
+    dsimp [HL, RHA]
+    rw [tripleMatrix_mul]
+    simp only [Matrix.mul_one, Matrix.one_mul]
+  change ((LA * LBp) * LHA) * ((RA * RBp) * RHA) =
+    tripleMatrix U U U * (LBv * RBv) * tripleMatrix Uᴴ Uᴴ Uᴴ
+  calc
+    _ = LA * LBp * (LHA * RA) * RBp * RHA := by
+      simp only [Matrix.mul_assoc]
+    _ = LA * LBp * (UL * HL) * RBp * RHA := by rw [hCross]
+    _ = LA * (LBp * UL) * (HL * RBp) * RHA := by
+      simp only [Matrix.mul_assoc]
+    _ = LA * (UL * LBv) * (RBv * HL) * RHA := by
+      rw [leftPairMatrixAux_naturality (s := p) (t := v) B U,
+        ← rightPairMatrixAux_naturality (s := v) (t := p) B Uᴴ]
+    _ = (LA * UL) * (LBv * RBv) * (HL * RHA) := by
+      simp only [Matrix.mul_assoc]
+    _ = _ := by rw [hOuterLeft, hOuterRight]
+
+/-- The reverse transported product is the tensor-cube sandwich of the reverse
+virtual product. -/
+private theorem transportedPairProduct_right
+    {p v : Type*} [Fintype p] [DecidableEq p]
+    [Fintype v] [DecidableEq v]
+    (U : Matrix p v ℂ) (B : Matrix (v × v) (v × v) ℂ)
+    (hU : Uᴴ * U = 1) :
+    appendixBRightPairMatrix (((U ⊗ₖ U) * B) * (Uᴴ ⊗ₖ Uᴴ)) *
+        appendixBLeftPairMatrix (((U ⊗ₖ U) * B) * (Uᴴ ⊗ₖ Uᴴ)) =
+      tripleMatrix U U U *
+          (appendixBRightPairMatrix B * appendixBLeftPairMatrix B) *
+        tripleMatrix Uᴴ Uᴴ Uᴴ := by
+  rw [leftPairMatrix_transport, rightPairMatrix_transport]
+  let LA := tripleMatrix U U (1 : Matrix p p ℂ)
+  let LHA := tripleMatrix Uᴴ Uᴴ (1 : Matrix p p ℂ)
+  let RA := tripleMatrix (1 : Matrix p p ℂ) U U
+  let RHA := tripleMatrix (1 : Matrix p p ℂ) Uᴴ Uᴴ
+  let UF := tripleMatrix U (1 : Matrix v v ℂ) (1 : Matrix v v ℂ)
+  let HF := tripleMatrix (1 : Matrix v v ℂ) (1 : Matrix v v ℂ) Uᴴ
+  let LBp := appendixBLeftPairMatrixAux (s := p) B
+  let RBp := appendixBRightPairMatrixAux (s := p) B
+  let LBv := appendixBLeftPairMatrix B
+  let RBv := appendixBRightPairMatrix B
+  have hCross : RHA * LA = UF * HF := by
+    dsimp [RHA, LA, UF, HF]
+    rw [tripleMatrix_mul, tripleMatrix_mul]
+    simp only [hU, Matrix.one_mul, Matrix.mul_one]
+  have hOuterLeft : RA * UF = tripleMatrix U U U := by
+    dsimp [RA, UF]
+    rw [tripleMatrix_mul]
+    simp only [Matrix.mul_one, Matrix.one_mul]
+  have hOuterRight : HF * LHA = tripleMatrix Uᴴ Uᴴ Uᴴ := by
+    dsimp [HF, LHA]
+    rw [tripleMatrix_mul]
+    simp only [Matrix.mul_one, Matrix.one_mul]
+  change ((RA * RBp) * RHA) * ((LA * LBp) * LHA) =
+    tripleMatrix U U U * (RBv * LBv) * tripleMatrix Uᴴ Uᴴ Uᴴ
+  calc
+    _ = RA * RBp * (RHA * LA) * LBp * LHA := by
+      simp only [Matrix.mul_assoc]
+    _ = RA * RBp * (UF * HF) * LBp * LHA := by rw [hCross]
+    _ = RA * (RBp * UF) * (HF * LBp) * LHA := by
+      simp only [Matrix.mul_assoc]
+    _ = RA * (UF * RBv) * (LBv * HF) * LHA := by
+      rw [rightPairMatrixAux_naturality (s := p) (t := v) B U,
+        ← leftPairMatrixAux_naturality (s := v) (t := p) B Uᴴ]
+    _ = (RA * UF) * (RBv * LBv) * (HF * LHA) := by
+      simp only [Matrix.mul_assoc]
+    _ = _ := by rw [hOuterLeft, hOuterRight]
+
+/-- An isometric one-site matrix transports commuting adjacent pair matrices
+to commuting adjacent pair matrices on the physical space. -/
+theorem appendixB_transportedPairMatrices_comm
+    {p v : Type*} [Fintype p] [DecidableEq p]
+    [Fintype v] [DecidableEq v]
+    (U : Matrix p v ℂ) (B : Matrix (v × v) (v × v) ℂ)
+    (hU : Uᴴ * U = 1)
+    (hB : appendixBLeftPairMatrix B * appendixBRightPairMatrix B =
+      appendixBRightPairMatrix B * appendixBLeftPairMatrix B) :
+    appendixBLeftPairMatrix (((U ⊗ₖ U) * B) * (Uᴴ ⊗ₖ Uᴴ)) *
+        appendixBRightPairMatrix (((U ⊗ₖ U) * B) * (Uᴴ ⊗ₖ Uᴴ)) =
+      appendixBRightPairMatrix (((U ⊗ₖ U) * B) * (Uᴴ ⊗ₖ Uᴴ)) *
+        appendixBLeftPairMatrix (((U ⊗ₖ U) * B) * (Uᴴ ⊗ₖ Uᴴ)) := by
+  rw [transportedPairProduct_left U B hU, transportedPairProduct_right U B hU, hB]
+
+end MPSTensor

--- a/blueprint/src/Packages/tn_diagrams.py
+++ b/blueprint/src/Packages/tn_diagrams.py
@@ -83,6 +83,8 @@ _DIAGRAM_ARGS: dict[str, str] = {
     "TNMPDOBNTFusionIdentity": "",
     "TNMPDOUnweightedZipperReconstruction": "",
     "TNMPDOFusionTracePower": "",
+    "TNAppendixBAdjacentBondProjectors": "",
+    "TNAppendixBPhysicalSupportTransport": "",
     "TNRFPKrausIsometry": "",
     "TNRFPKrausIsometryReverse": "",
     "TNRFPIsometryCanonicalForm": "",

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -1179,6 +1179,50 @@ the specialization $L=2$.
     coefficients.
 \end{definition}
 
+\begin{definition}[Virtual bond projector and its adjacent placements]
+    \label{def:appendixB_virtual_bond_projectors}
+    \lean{MPSTensor.AppendixBStructuralData.virtualBondProjection}
+    \lean{MPSTensor.AppendixBStructuralData.leftVirtualBondProjection}
+    \lean{MPSTensor.AppendixBStructuralData.rightVirtualBondProjection}
+    \leanok
+    \uses{def:appendixB_two_site_bond_embedding}
+    Write
+    \[
+        s=\langle\varphi,\varphi\rangle=\sum_b\lambda_b^2.
+    \]
+    The orthogonal projector onto $\mathbb C\varphi$ has pair-index
+    coefficients
+    \[
+        (P_\varphi v)_{b,b'}
+        =\delta_{b,b'}\frac{\lambda_b}{s}
+          \sum_k\lambda_kv_{k,k}.
+    \]
+    On three virtual site pairs, let $P_{01}$ place this projector on the bond
+    joining the right index of site zero to the left index of site one, and let
+    $P_{12}$ place it on the next bond.
+\end{definition}
+
+\begin{theorem}[Commutation of the adjacent virtual bond projectors]
+    \label{thm:appendixB_virtual_bond_projectors_commute}
+    \lean{MPSTensor.AppendixBStructuralData.leftVirtualBondProjection_comp_right}
+    \leanok
+    \uses{def:appendixB_virtual_bond_projectors}
+    The two adjacent placements commute:
+    \[
+        \TNAppendixBAdjacentBondProjectors
+        \qquad
+        P_{01}P_{12}=P_{12}P_{01}.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The contracted bond coordinates are disjoint.  Thus replacing the first
+    bond by the diagonal basis vector $\lvert k,k\rangle$ and the second by
+    $\lvert \ell,\ell\rangle$ is independent of the order.  Expanding both
+    rank-one projectors gives the same double sum over $(k,\ell)$.
+\end{proof}
+
 \begin{theorem}[Surjectivity of the weighted boundary parametrization]
     \label{thm:appendixB_weighted_two_site_boundary_surjective}
     \lean{MPSTensor.AppendixBStructuralData.weightedTwoSiteBoundary_surjective}
@@ -1278,6 +1322,49 @@ the specialization $L=2$.
     \]
 \end{proof}
 
+\begin{theorem}[Commutation of adjacent two-site basic support projectors]
+    \label{thm:appendixB_two_site_basic_support_projectors_commute}
+    \lean{MPSTensor.AppendixBStructuralData.twoSiteBasicSupportProjection_commute_lifts}
+    \leanok
+    \uses{thm:appendixB_virtual_bond_projectors_commute,
+        thm:appendixB_physical_isometry_tensor_power,
+        thm:appendixB_two_site_basic_support_projector}
+    Let $(P_2)_{01}$ and $(P_2)_{12}$ be the two adjacent placements of the
+    two-site basic support projector on three physical sites.  Then
+    \[
+        (P_2)_{01}(P_2)_{12}=(P_2)_{12}(P_2)_{01}.
+    \]
+    This is the local three-site consequence of the parent-space construction
+    and the basic-vector form in
+    \cite[Definition~3.9, Equations~(3.16)--(3.18), and
+    Appendix~B]{Cirac2016MPDO_arXiv}.  It does not assert commutation for every
+    chain length.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The one-site map $U$ is an isometry.  The preceding range identity
+    therefore identifies the physical projector with the isometric transport
+    of the virtual bond projector:
+    \[
+        P_2=U^{\otimes2}P_\varphi (U^*)^{\otimes2}.
+    \]
+    On three sites, multiplication of the two adjacent transports cancels the
+    middle factors by $U^*U=1$.  Consequently their products are
+    \[
+        U^{\otimes3}P_{01}P_{12}(U^*)^{\otimes3}
+        \quad\text{and}\quad
+        U^{\otimes3}P_{12}P_{01}(U^*)^{\otimes3},
+    \]
+    respectively.  They agree by
+    Theorem~\ref{thm:appendixB_virtual_bond_projectors_commute}.
+    Diagrammatically, the same argument transports the two disjoint virtual
+    bond contractions through the three one-site isometries:
+    \[
+        \TNAppendixBPhysicalSupportTransport
+    \]
+\end{proof}
+
 \begin{definition}[Appendix B \(AX\) coefficient representative]
     \label{def:appendixB_qax}
     \lean{MPSTensor.AppendixBStructuralData.appendixBQAXOnCoeffSpace}
@@ -1347,6 +1434,43 @@ the specialization $L=2$.
     By the preceding identification, both representatives are the canonical
     two-site parent interaction \(q_2(A)\).  The latter is an orthogonal
     projector, hence is idempotent.
+\end{proof}
+
+\begin{theorem}[Appendix B overlapping two-site commutation]
+    \label{thm:appendixB_overlapping_two_site_commutation}
+    \lean{MPSTensor.AppendixBStructuralData.hasOverlappingTwoSiteCommutation}
+    \leanok
+    \uses{thm:appendixB_two_site_basic_support_projectors_commute,
+        thm:appendixB_two_site_basic_support_projector,
+        lem:appendixB_qax_qxb_idempotent,
+        def:overlapping_two_site_supports}
+    The two Appendix~B coefficient representatives satisfy
+    \[
+        \widehat Q_{AX}^{\,2}=\widehat Q_{AX},
+        \qquad
+        \widehat Q_{XB}^{\,2}=\widehat Q_{XB},
+    \]
+    and their adjacent actions on the common three-site coefficient space
+    commute:
+    \[
+        (\widehat Q_{AX})_{AX}(\widehat Q_{XB})_{XB}
+        =
+        (\widehat Q_{XB})_{XB}(\widehat Q_{AX})_{AX}.
+    \]
+    Thus they satisfy the algebraic overlapping two-site condition of
+    Definition~\ref{def:overlapping_two_site_supports}.  This is precisely the
+    projector-and-commutator part of
+    \cite[Definition~D.2]{Cirac2016MPDO_arXiv}.  It neither constructs the
+    source projectors nor proves the kernel-intersection equation in that
+    definition, and it makes no assertion for every chain length.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Both coefficient representatives are the complement $1-P_2$ of the
+    two-site basic support projector.  Their idempotency was established in
+    Lemma~\ref{lem:appendixB_qax_qxb_idempotent}.  Since the two adjacent lifts
+    of $P_2$ commute, their complementary lifts commute as well.
 \end{proof}
 
 \begin{lemma}[Appendix B overlapping condition from the lifted commutator]

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -1562,6 +1562,86 @@
 % Fusion isometry of the renormalization fixed-point characterization: two
 % contracted copies of the tensor equal one copy with the isometry merging
 % the summed index into the physical pair.
+
+% Appendix B basic-vector geometry.  This is the vector counterpart of the
+% source figure II_RFP_MPS.png: each U acts on the two virtual halves at one
+% physical site, while the two highlighted rank-one projectors act on the
+% separate bonds shared by adjacent sites.
+\newcommand{\TNAppendixBAdjacentBondProjectors}{%
+    \begin{tikzpicture}[tn picture, scale=0.92]
+        \foreach \x/\name in {0/rfpUzero,2.20/rfpUone,4.40/rfpUtwo} {
+            \node[draw, fill=white, minimum width=0.72cm, minimum height=0.58cm]
+                (\name) at (\x,0.92) {$U$};
+            \draw[tn phys leg] (\name.north) -- ++(0,0.42);
+        }
+        \node[draw, fill=white, minimum width=0.68cm, minimum height=0.50cm]
+            (rfpPhiZero) at (1.10,0) {$\varphi$};
+        \node[draw, fill=white, minimum width=0.68cm, minimum height=0.50cm]
+            (rfpPhiOne) at (3.30,0) {$\varphi$};
+        \draw[tn leg] ($(rfpUzero.south)+(-0.16,0)$) -- ++(0,-0.42)
+            -- (rfpPhiZero.west);
+        \draw[tn leg] (rfpPhiZero.east) -- ++(0.36,0)
+            -- ($(rfpUone.south)+(-0.16,0)$);
+        \draw[tn leg] ($(rfpUone.south)+(0.16,0)$) -- ++(0,-0.42)
+            -- (rfpPhiOne.west);
+        \draw[tn leg] (rfpPhiOne.east) -- ++(0.36,0)
+            -- ($(rfpUtwo.south)+(0.16,0)$);
+        \draw[tn leg] ($(rfpUzero.south)+(0.16,0)$) -- ++(0,-0.80) -- ++(-0.76,0);
+        \draw[tn leg] ($(rfpUtwo.south)+(-0.16,0)$) -- ++(0,-0.80) -- ++(0.76,0);
+        \draw[red, rounded corners]
+            ($(rfpPhiZero.south west)+(-0.07,-0.07)$) rectangle
+            ($(rfpPhiZero.north east)+(0.07,0.07)$);
+        \draw[red, rounded corners]
+            ($(rfpPhiOne.south west)+(-0.07,-0.07)$) rectangle
+            ($(rfpPhiOne.north east)+(0.07,0.07)$);
+        \node[red] at (1.10,-0.55) {$P_{01}$};
+        \node[red] at (3.30,-0.55) {$P_{12}$};
+    \end{tikzpicture}%
+}
+
+% Isometric transport of the two virtual bond projectors to the adjacent
+% physical two-site basic-support projectors.  The upper row retains the
+% source's three U tensors and diagonal bond vectors; the upper red brackets
+% record the two overlapping physical supports.
+\newcommand{\TNAppendixBPhysicalSupportTransport}{%
+    \begin{tikzpicture}[tn picture, scale=0.90]
+        \foreach \x/\name in {0/rfpTzero,2.20/rfpTone,4.40/rfpTtwo} {
+            \node[draw, fill=white, minimum width=0.72cm, minimum height=0.58cm]
+                (\name) at (\x,0.72) {$U$};
+            \draw[tn phys leg] (\name.north) -- ++(0,0.52);
+            \fill[black] ($(\name.north)+(0,0.52)$) circle (1.4pt);
+        }
+        \node[draw, fill=white, minimum width=0.68cm, minimum height=0.50cm]
+            (rfpTPhiZero) at (1.10,-0.12) {$\varphi$};
+        \node[draw, fill=white, minimum width=0.68cm, minimum height=0.50cm]
+            (rfpTPhiOne) at (3.30,-0.12) {$\varphi$};
+        \draw[tn leg] ($(rfpTzero.south)+(-0.16,0)$) -- ++(0,-0.42)
+            -- (rfpTPhiZero.west);
+        \draw[tn leg] (rfpTPhiZero.east) -- ++(0.36,0)
+            -- ($(rfpTone.south)+(-0.16,0)$);
+        \draw[tn leg] ($(rfpTone.south)+(0.16,0)$) -- ++(0,-0.42)
+            -- (rfpTPhiOne.west);
+        \draw[tn leg] (rfpTPhiOne.east) -- ++(0.36,0)
+            -- ($(rfpTtwo.south)+(0.16,0)$);
+        \draw[tn leg] ($(rfpTzero.south)+(0.16,0)$) -- ++(0,-0.80) -- ++(-0.76,0);
+        \draw[tn leg] ($(rfpTtwo.south)+(-0.16,0)$) -- ++(0,-0.80) -- ++(0.76,0);
+        \draw[red, rounded corners=4pt, line width=0.7pt]
+            (-0.34,1.44) rectangle (2.54,1.74);
+        \draw[red, rounded corners=4pt, line width=0.7pt]
+            (1.86,1.84) rectangle (4.74,2.14);
+        \node[red, anchor=east] at (-0.40,1.59) {$(P_2)_{01}$};
+        \node[red, anchor=west] at (4.80,1.99) {$(P_2)_{12}$};
+        \draw[red, rounded corners]
+            ($(rfpTPhiZero.south west)+(-0.07,-0.07)$) rectangle
+            ($(rfpTPhiZero.north east)+(0.07,0.07)$);
+        \draw[red, rounded corners]
+            ($(rfpTPhiOne.south west)+(-0.07,-0.07)$) rectangle
+            ($(rfpTPhiOne.north east)+(0.07,0.07)$);
+        \node[red] at (1.10,-0.68) {$P_{01}$};
+        \node[red] at (3.30,-0.68) {$P_{12}$};
+    \end{tikzpicture}%
+}
+
 \newcommand{\TNRFPKrausIsometry}{%
     \begin{tikzpicture}[tn picture]
         \TN@tensordot{rfkA}{(0,0)}

--- a/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
+++ b/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
@@ -31,6 +31,9 @@ name: TNMPSInverseContraction TNBNTDecomposition TNMPDOZCLIdempotence TNMPDOFixe
 name: TNMPDOBNTFusionIdentity TNMPDOUnweightedZipperReconstruction TNMPDOFusionTracePower TNMPDOFixedFinalComparisonUnitary TNMPDOFourfoldBondReassociationPentagon TNMPDOPrintedFMove
 {{ obj.tn_svg_html }}
 
+name: TNAppendixBAdjacentBondProjectors TNAppendixBPhysicalSupportTransport
+{{ obj.tn_svg_html }}
+
 name: TNRFPKrausIsometry TNRFPKrausIsometryReverse TNRFPIsometryCanonicalForm
 {{ obj.tn_svg_html }}
 


### PR DESCRIPTION
## Mathematical content

This pull request proves the local three-site commutation statement arising from the Appendix B basic-vector form of arXiv:1606.00608.

- It defines the normalized rank-one projector onto the virtual bond vector and proves that its two adjacent placements commute.
- It identifies the physical transport of this projector with the canonical two-site basic-support projector. The proof treats the zero-dimensional virtual space explicitly.
- It proves a generic Kronecker transport theorem showing that adjacent transported pair operators commute whenever the one-site matrix satisfies (U^*U=1); no surjectivity assumption is introduced.
- It deduces commutation of the two adjacent physical support projectors and then of their complementary Appendix B coefficient representatives.
- It records the result in the blueprint with two TikZ diagrams modeled on the geometry of `II_RFP_MPS.png`.

The result is deliberately stated as a local three-site theorem. It does not claim the all-chain nearest-neighbor commuting-parent-Hamiltonian statement or the kernel-intersection clause of Definition D.2. Those remaining steps stay tracked in #3373 and the existing paper-gap notes.

Source anchors: arXiv:1606.00608, parent-space construction at lines 511–524, equations (3.16)–(3.18) at lines 543–578, and Definition D.2 at lines 2205–2218.

## Verification

- `lake build TNLean` on the latest `main`
- `lake exe checkdecls blueprint/lean_decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `leanblueprint web`
- `leanblueprint pdf` (533 pages)
- diagram registry and smoke rendering for all 114 macros
- visual inspection of PDF pages 220–223
- proof-integrity, line-length, and diff checks

Refs #3373

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds formal proofs and blueprint documentation on the RFP track; no auth, runtime, or data-path changes. Scope is explicitly local—remaining chain-level gaps stay documented elsewhere.
> 
> **Overview**
> Formalizes the **local three-site** Appendix B commutation chain from arXiv:1606.00608 (eqs. 3.16–3.18): rank-one virtual bond projectors, their transport through the physical isometry, and overlapping `Q_AX` / `Q_XB` commutation on three sites—not a full-chain nearest-neighbor or Definition D.2 kernel-intersection claim.
> 
> **Lean:** `AppendixBSupport` adds `virtualBondNormSq`, normalized virtual bond projectors (`virtualBondProjection`, `leftVirtualBondProjection`, `rightVirtualBondProjection`), two-site virtual transport (`twoSiteVirtualBondProjection`, `transportedTwoSiteBondProjection`), adjoint/inner-product lemmas for tensor powers, and proofs that adjacent virtual placements commute. New `KroneckerTransport.lean` proves commuting pair matrices stay commuting after isometric `U⊗U` sandwich (`UᴴU = 1`, no surjectivity). New `AppendixBCommutation.lean` identifies transported virtual projectors with `twoSiteBasicSupportProjection` (including `D = 0`), lifts commutation to three-site physical pair operators, and exports `hasOverlappingTwoSiteCommutation`. Root imports wire `KroneckerTransport` and `AppendixBCommutation`.
> 
> **Blueprint:** Chapter 13 gains definitions/theorems for virtual bond projectors, physical support-projector commutation, and overlapping two-site commutation, plus TikZ macros `TNAppendixBAdjacentBondProjectors` and `TNAppendixBPhysicalSupportTransport` in the diagram registry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 661e8b7964d5489af7ca04419e3f488b8862ad78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->