### PR TITLE
feat(MPS/FundamentalTheorem/SectorBNT): block sector decompositions

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -314,6 +314,7 @@ import TNLean.MPS.Overlap.PeripheralToTransferMapGap
 import TNLean.MPS.FundamentalTheorem.Multi
 import TNLean.MPS.FundamentalTheorem.SectorWeightComparison
 import TNLean.MPS.FundamentalTheorem.SectorBNT.Basic
+import TNLean.MPS.FundamentalTheorem.SectorBNT.Blocking
 import TNLean.MPS.FundamentalTheorem.SectorBNT.CoeffIdentity
 import TNLean.MPS.FundamentalTheorem.SectorBNT.CopyWeightMatching
 import TNLean.MPS.FundamentalTheorem.SectorBNT.EqualModulus

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Blocking.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Blocking.lean
@@ -1,0 +1,138 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.Core.BlockingInfrastructure
+import TNLean.MPS.SharedInfra.SectorDecomposition
+
+/-!
+# Physical blocking of sector decompositions
+
+This file packages physical blocking for a BNT sector decomposition.  Blocking
+by `p` sites leaves the representative and copy indices unchanged, replaces
+each representative `A_j` by `A_j^[p]`, and replaces each copy weight
+`μ_{j,q}` by `μ_{j,q}^p`.
+
+The two-layer representative and copy-weight structure comes from
+arXiv:1606.00608, `eq:II_ABasicTensors` and `decBSV`, lines 283--301.  Physical
+blocking of this structure is an auxiliary construction for the planned formal
+proof of Appendix C.3, Lemma L, lines 1835--1858; it is not a separate
+construction stated there.  This file does not assert that the full predicate
+`IsBNTCanonicalForm` is preserved by blocking, since that requires separate
+proofs for representative distinctness and eventual linear independence.
+
+## Main results
+
+* `SectorDecomposition.blockTensor` is the sector decomposition obtained by
+  physical blocking.
+* `SectorDecomposition.coeff_blockTensor` identifies its coefficient with the
+  original coefficient at the corresponding unblocked length.
+* `SectorDecomposition.sameMPV₂_blockTensor_toTensor` proves that assembling
+  the blocked decomposition gives the same MPV family as blocking the assembled
+  tensor.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor.SectorDecomposition
+
+variable {d : ℕ}
+
+/-- The sector decomposition obtained by blocking `p` physical sites.
+
+The representative family becomes `A_j^[p]`, while every copy weight becomes
+`μ_{j,q}^p`.  The underlying two-layer decomposition is
+arXiv:1606.00608, `eq:II_ABasicTensors` and `decBSV`, lines 283--301.  The
+blocked form is an auxiliary construction for the planned formal proof of
+Appendix C.3, Lemma L, lines 1835--1858. -/
+noncomputable def blockTensor (P : SectorDecomposition d) (p : ℕ) :
+    SectorDecomposition (blockPhysDim d p) where
+  basisCount := P.basisCount
+  basisDim := P.basisDim
+  basis := fun j ↦ MPSTensor.blockTensor (P.basis j) p
+  sectors :=
+    { copies := P.copies
+      copies_pos := P.copies_pos
+      weight := fun j q ↦ (P.weight j q) ^ p
+      weight_ne_zero := fun j q ↦ pow_ne_zero p (P.weight_ne_zero j q) }
+
+@[simp]
+theorem blockTensor_basis (P : SectorDecomposition d) (p : ℕ)
+    (j : Fin P.basisCount) :
+    (P.blockTensor p).basis j = MPSTensor.blockTensor (P.basis j) p :=
+  rfl
+
+@[simp]
+theorem blockTensor_weight (P : SectorDecomposition d) (p : ℕ)
+    (j : Fin P.basisCount) (q : Fin (P.copies j)) :
+    (P.blockTensor p).weight j q = (P.weight j q) ^ p :=
+  rfl
+
+@[simp]
+theorem blockTensor_copies (P : SectorDecomposition d) (p : ℕ) :
+    (P.blockTensor p).copies = P.copies :=
+  rfl
+
+@[simp]
+theorem blockTensor_totalCopies (P : SectorDecomposition d) (p : ℕ) :
+    (P.blockTensor p).totalCopies = P.totalCopies :=
+  rfl
+
+@[simp]
+theorem blockTensor_flatDim (P : SectorDecomposition d) (p : ℕ) :
+    (P.blockTensor p).flatDim = P.flatDim :=
+  rfl
+
+@[simp]
+theorem blockTensor_totalDim (P : SectorDecomposition d) (p : ℕ) :
+    (P.blockTensor p).totalDim = P.totalDim :=
+  rfl
+
+@[simp]
+theorem blockTensor_flatWeight (P : SectorDecomposition d) (p : ℕ)
+    (s : Fin P.totalCopies) :
+    (P.blockTensor p).flatWeight s = (P.flatWeight s) ^ p :=
+  rfl
+
+@[simp]
+theorem blockTensor_flatBasis (P : SectorDecomposition d) (p : ℕ)
+    (s : Fin P.totalCopies) :
+    (P.blockTensor p).flatBasis s = MPSTensor.blockTensor (P.flatBasis s) p :=
+  rfl
+
+/-- The coefficient of the blocked decomposition at length `N` is the
+coefficient of the original decomposition at length `N * p`.
+
+This is the copy-weight identity
+`∑_q (μ_{j,q}^p)^N = ∑_q μ_{j,q}^{Np}` for the two-layer coefficients in
+arXiv:1606.00608, `eq:II_ABasicTensors` and `decBSV`, lines 283--301.  It is an
+auxiliary identity for the planned formal proof of Appendix C.3, Lemma L,
+lines 1835--1858. -/
+theorem coeff_blockTensor (P : SectorDecomposition d) (p N : ℕ)
+    (j : Fin P.basisCount) :
+    (P.blockTensor p).coeff N j = P.coeff (N * p) j := by
+  change (∑ q : Fin (P.copies j), ((P.weight j q) ^ p) ^ N) =
+    ∑ q : Fin (P.copies j), (P.weight j q) ^ (N * p)
+  rw [Nat.mul_comm N p]
+  simp only [pow_mul]
+
+/-- Blocking the tensor assembled from a sector decomposition gives the same
+MPV family as assembling its blocked representatives with powered copy
+weights.
+
+The two-layer expansion is arXiv:1606.00608, `eq:II_ABasicTensors` and
+`decBSV`, lines 283--301.  This blocked form is an auxiliary identity for the
+planned formal proof of Appendix C.3, Lemma L, lines 1835--1858. -/
+theorem sameMPV₂_blockTensor_toTensor (P : SectorDecomposition d) (p : ℕ) :
+    SameMPV₂
+      (MPSTensor.blockTensor P.toTensor p)
+      (P.blockTensor p).toTensor := by
+  change SameMPV₂
+    (MPSTensor.blockTensor
+      (toTensorFromBlocks (d := d) P.flatWeight P.flatBasis) p)
+    (toTensorFromBlocks (d := blockPhysDim d p)
+      (fun s ↦ (P.flatWeight s) ^ p)
+      (fun s ↦ MPSTensor.blockTensor (P.flatBasis s) p))
+  exact sameMPV₂_blockTensor_toTensorFromBlocks P.flatWeight P.flatBasis p
+
+end MPSTensor.SectorDecomposition

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -573,6 +573,70 @@ here feed the BNT canonical-form predicate below.
     $(A_j)_{j=1}^g$ together with these multiplicities and weights.
 \end{definition}
 
+\begin{definition}[Physical blocking of a sector decomposition]%
+    \label{def:sector_decomposition_block_tensor}
+    \lean{MPSTensor.SectorDecomposition.blockTensor}
+    \leanok
+    \uses{def:sector_weight_data, def:blocked_tensor}
+    Let $P$ be a sector decomposition with representatives $A_j$,
+    multiplicities $r_j$, and copy weights $\mu_{j,q}$.  Its physical
+    $p$-site blocking has the same representative and copy indices, with
+    \[
+        A_j\longmapsto A_j^{[p]},
+        \qquad
+        \mu_{j,q}\longmapsto \mu_{j,q}^{p}.
+    \]
+    The two-layer decomposition is
+    \cite[lines~283--301]{Cirac2016MPDO_arXiv}.
+    Its blocked form is an auxiliary construction for the planned formal proof
+    of Appendix~C.3, Lemma~L, lines~1835--1858; it is not stated there as a
+    separate construction.
+\end{definition}
+
+\begin{theorem}[Indices, dimensions, weights, and representatives under blocking]%
+    \label{thm:sector_decomposition_block_tensor_data}
+    \lean{MPSTensor.SectorDecomposition.blockTensor_basis}
+    \lean{MPSTensor.SectorDecomposition.blockTensor_weight}
+    \lean{MPSTensor.SectorDecomposition.blockTensor_copies}
+    \lean{MPSTensor.SectorDecomposition.blockTensor_totalCopies}
+    \lean{MPSTensor.SectorDecomposition.blockTensor_flatDim}
+    \lean{MPSTensor.SectorDecomposition.blockTensor_totalDim}
+    \lean{MPSTensor.SectorDecomposition.blockTensor_flatWeight}
+    \lean{MPSTensor.SectorDecomposition.blockTensor_flatBasis}
+    \leanok
+    \uses{def:sector_decomposition_block_tensor}
+    Physical blocking preserves the copy sets and bond dimensions.  On the
+    flattened copy index, the weight is raised to the $p$-th power and the
+    representative is replaced by its $p$-site blocking.
+\end{theorem}
+
+\begin{proof}\leanok\uses{def:sector_decomposition_block_tensor}
+    These identities follow directly from the definition.
+\end{proof}
+
+\begin{theorem}[Blocked sector coefficients and assembled tensor]%
+    \label{thm:sector_decomposition_block_tensor_mpv}
+    \lean{MPSTensor.SectorDecomposition.coeff_blockTensor}
+    \lean{MPSTensor.SectorDecomposition.sameMPV₂_blockTensor_toTensor}
+    \leanok
+    \uses{def:sector_decomposition_block_tensor, thm:block_tensor_to_tensor_from_blocks}
+    The coefficient of the blocked decomposition satisfies
+    \[
+        c_{P^{[p]},j}^{(N)}
+        =\sum_q\bigl(\mu_{j,q}^{p}\bigr)^N
+        =c_{P,j}^{(Np)}.
+    \]
+    Moreover, blocking the tensor assembled from $P$ gives the same MPV family
+    as the tensor assembled from the blocked sector decomposition.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:block_tensor_to_tensor_from_blocks}
+    The coefficient identity is $(\mu^p)^N=\mu^{pN}$.  The tensor identity is
+    Theorem~\ref{thm:block_tensor_to_tensor_from_blocks} applied to the
+    flattened copy family.
+\end{proof}
+
 \begin{lemma}[Sector decomposition formula]%
     \label{lem:paper_decomp_formula}
     \lean{MPSTensor.SectorDecomposition.mpv_toTensor_eq_sum_coeff}

--- a/docs/paper-gaps/cpgsv17_bicf_block_separation.tex
+++ b/docs/paper-gaps/cpgsv17_bicf_block_separation.tex
@@ -174,14 +174,24 @@ above with the canonical-form construction.  Positive-length block injectivity
 propagates from length $L$ to length $L+1$ without a normalization hypothesis:
 the identity
 $S_{L+1}(A)=\spn\{A_i\}_iS_L(A)$, together with the same identity at length
-$L$, gives the result.  One should therefore choose a common positive $L$ for
-which every normal BNT representative is $L$-block injective and identify the
-sector decomposition and powered copy weights after blocking $L+1$ sites.  The
-representative-separation theorem then applies to that blocked decomposition,
-while the original length-$L$ span recovers equality of the unblocked insertions
-from equality of the blocked insertions.  This length shift is essential:
-recovery from a physical block of length $L+1$ uses the span of its length-$L$
-tail.  The flattened
+$L$, gives the result.  Physical blocking of a sector decomposition has also
+been defined explicitly: it preserves the representative and copy indices,
+replaces $A_j$ by $A_j^{[p]}$, replaces $\mu_{j,q}$ by $\mu_{j,q}^p$, and gives
+the coefficient identity
+\[
+    c_{P^{[p]},j}^{(N)}=c_{P,j}^{(Np)}.
+\]
+The tensor assembled from this blocked decomposition has the same MPV family
+as the physical blocking of the original assembled tensor.
+
+One should therefore choose a common positive $L$ for which every normal BNT
+representative is $L$-block injective and prove the representative-separation
+property for the sector decomposition blocked by $L+1$ sites.  The existing
+post-blocking theorem applies once this property, or the relevant preserved
+canonical-form data, is supplied.  The original length-$L$ span then recovers
+equality of the unblocked insertions from equality of the blocked insertions.
+This length shift is essential: recovery from a physical block of length
+$L+1$ uses the span of its length-$L$ tail.  The flattened
 \texttt{HorizontalCFData} formulation must then be replaced, or related
 explicitly, by this representative-indexed statement.  The older per-copy
 \texttt{biCF} theorem remains a correct restricted result, but it is no longer


### PR DESCRIPTION
## Mathematical purpose

Let $P$ be a sector decomposition with representatives $A_j$, multiplicities $r_j$, and copy weights $\mu_{j,q}$. This PR defines its physical $p$-site blocking by

$$A_j\mapsto A_j^{[p]},\qquad \mu_{j,q}\mapsto \mu_{j,q}^p,$$

with the representative and copy indices unchanged. It proves

$$c_{P^{[p]},j}^{(N)}=c_{P,j}^{(Np)}$$

and shows that blocking the tensor assembled from $P$ gives the same complete MPV family as assembling the blocked sector decomposition.

The two-layer representative and copy-weight structure is the one in arXiv:1606.00608, `eq:II_ABasicTensors` and `decBSV`, lines 283–301. Physical blocking is an auxiliary construction for the planned proof of Appendix C.3, Lemma L; it is not claimed as a separately stated source theorem.

## Scope

This PR deliberately does not claim preservation of `IsBNTCanonicalForm`. Such a theorem must additionally transport representative distinctness, normalized self-overlap, eventual linear independence, and irreducibility. The present structural identity is the next atomic prerequisite for #3713 after PRs #3852 and #3854.

## Documentation

The BNT blueprint records the construction, its index and dimension identities, the powered coefficient formula, and the assembled-tensor identity. The paper-gap note now marks the sector decomposition and powered-copy-weight step as complete while leaving representative separation for the blocked decomposition and the `HorizontalCFData` bridge open.

## Verification

- `lake build`
- `lake exe checkdecls blueprint/lean_decls`
- `python3 scripts/blueprint_lean_sync.py --ci`
- `#print axioms MPSTensor.SectorDecomposition.coeff_blockTensor`
- `#print axioms MPSTensor.SectorDecomposition.sameMPV₂_blockTensor_toTensor`

Both axiom reports contain only `propext`, `Classical.choice`, and `Quot.sound`. The new Lean module contains no `sorry`, project `axiom`, or kernel bypass.

Advances #3713. Prerequisite for #3674; neither issue is closed by this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds proved Lean lemmas and documentation on an auxiliary BNT/Lemma L track; no runtime, auth, or data-path changes, and main theorems delegate to existing blocking infrastructure.
> 
> **Overview**
> Introduces **physical $p$-site blocking** on BNT sector decompositions: representatives become $A_j^{[p]}$, copy weights become $\mu_{j,q}^p$, and indices/multiplicities are unchanged. The new Lean module `TNLean/MPS/FundamentalTheorem/SectorBNT/Blocking.lean` defines `blockTensor`, proves simp identities on flat data, **`coeff_blockTensor`** ($c_{P^{[p]},j}^{(N)} = c_{P,j}^{(Np)}$), and **`sameMPV₂_blockTensor_toTensor`** by reducing to existing `sameMPV₂_blockTensor_toTensorFromBlocks` in blocking infrastructure. The root import list and BNT blueprint (`ch10_bnt.tex`) record the construction and linked theorems. The Lemma L paper-gap note now treats this blocking step as in place and reframes the remaining work as representative separation on the $(L{+}1)$-blocked decomposition and bridging `HorizontalCFData`.
> 
> **Out of scope:** preservation of `IsBNTCanonicalForm` under blocking is explicitly not claimed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d02c7474e605e69c61b82cc4fb1f4e88ed43f424. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->