### PR TITLE
feat(MPS/MPDO): separate blocked representatives

### DIFF
--- a/TNLean/MPS/Core/Blocking.lean
+++ b/TNLean/MPS/Core/Blocking.lean
@@ -208,6 +208,54 @@ lemma length_flattenBlockedWord (d L : ℕ) :
       simp [flattenBlockedWord_cons, ih, length_wordOfBlock,
         Nat.succ_mul, Nat.add_comm]
 
+/-- Blocked configurations of length `N` are equivalent to ordinary configurations of length
+`N * L`.
+
+This is the configuration-level identification implicit in physical blocking; see
+arXiv:1606.00608, lines 318--344. -/
+noncomputable def blockedConfigEquiv (d N L : ℕ) :
+    (Fin N → Fin (blockPhysDim d L)) ≃ (Fin (N * L) → Fin d) :=
+  ((Equiv.arrowCongr (Equiv.refl (Fin N)) (decodeBlockEquiv d L)).trans
+    (Equiv.curry (Fin N) (Fin L) (Fin d)).symm).trans
+    (Equiv.arrowCongr finProdFinEquiv (Equiv.refl (Fin d)))
+
+/-- Reading a blocked configuration through `blockedConfigEquiv` gives the flattened blocked
+word.  This is the word-level identification used in the blocking step of
+arXiv:1606.00608, lines 318--344. -/
+@[mps_block_words]
+lemma ofFn_blockedConfigEquiv (d N L : ℕ)
+    (σ : Fin N → Fin (blockPhysDim d L)) :
+    List.ofFn (blockedConfigEquiv d N L σ) = flattenBlockedWord d L (List.ofFn σ) := by
+  have hfun : blockedConfigEquiv d N L σ =
+      fun k : Fin (N * L) =>
+        decodeBlock d L (σ (finProdFinEquiv.symm k).1) (finProdFinEquiv.symm k).2 := by
+    funext k
+    simp [blockedConfigEquiv, Equiv.arrowCongr, Equiv.curry, decodeBlockEquiv_apply,
+      Function.comp]
+  rw [hfun, List.ofFn_mul]
+  rw [flattenBlockedWord, List.map_ofFn]
+  congr 1
+  refine congrArg List.ofFn (funext fun i => ?_)
+  have hsymm : ∀ j : Fin L,
+      finProdFinEquiv.symm
+          (⟨(i : ℕ) * L + (j : ℕ),
+            by
+              calc
+                (i : ℕ) * L + (j : ℕ) < ((i : ℕ) + 1) * L := by
+                  have := j.isLt
+                  rw [Nat.add_mul, Nat.one_mul]
+                  omega
+                _ ≤ N * L := Nat.mul_le_mul_right _ (by have := i.isLt; omega)⟩ :
+            Fin (N * L)) = (i, j) := by
+    intro j
+    rw [Equiv.symm_apply_eq]
+    apply Fin.ext
+    change (i : ℕ) * L + (j : ℕ) = (j : ℕ) + L * (i : ℕ)
+    rw [Nat.mul_comm L (i : ℕ), Nat.add_comm]
+  simp only [hsymm]
+  change (List.ofFn fun j : Fin L => decodeBlock d L (σ i) j) = (wordOfBlock d L ∘ σ) i
+  simp [wordOfBlock, Function.comp]
+
 private theorem list_ofFn_comp_fin_rev {L : ℕ} {α : Type*} (σ : Fin L → α) :
     List.ofFn (σ ∘ Fin.rev) = (List.ofFn σ).reverse := by
   calc

--- a/TNLean/MPS/MPDO/BiCFDerivation/Blocking.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/Blocking.lean
@@ -1,0 +1,46 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.Core.Blocking
+import TNLean.MPS.MPDO.BiCFDerivation.Core
+
+/-!
+# Pair separation under physical blocking
+
+This file transports homogeneous pair trace separation through physical
+blocking.  A blocked word of length `N` is identified with its flattened
+ordinary word of length `N * p`.
+
+The result is the finite-word transport used in the block-injectivity argument
+of arXiv:1606.00608, lines 318--344.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d : ℕ}
+
+/-- Pair trace separation at original length `N * p` gives pair trace
+separation at blocked length `N`.
+
+This is the finite-word transport implicit in the passage from injective
+representatives to block injectivity in arXiv:1606.00608, lines 318--344. -/
+theorem pairTraceSeparatingAt_blockTensor
+    {D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (p N : ℕ) (hSep : PairTraceSeparatingAt A B (N * p)) :
+    PairTraceSeparatingAt
+      (blockTensor (d := d) (D := D₁) A p)
+      (blockTensor (d := d) (D := D₂) B p) N := by
+  intro ΔA ΔB hΔ
+  apply hSep ΔA ΔB
+  intro τ
+  let σ := (blockedConfigEquiv d N p).symm τ
+  have hσ := hΔ σ
+  simp only [evalWord_blockTensor] at hσ
+  rw [← ofFn_blockedConfigEquiv] at hσ
+  simpa [σ] using hσ
+
+end MPSTensor

--- a/TNLean/MPS/MPDO/PostBlockedRepresentativeSpan.lean
+++ b/TNLean/MPS/MPDO/PostBlockedRepresentativeSpan.lean
@@ -5,8 +5,11 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.FundamentalTheorem.FiniteLength
 import TNLean.MPS.FundamentalTheorem.SectorBNT.Basic
+import TNLean.MPS.FundamentalTheorem.SectorBNT.Blocking
 import TNLean.MPS.MPDO.BiCFDerivation.BNTDirectSum
+import TNLean.MPS.MPDO.BiCFDerivation.Blocking
 import TNLean.MPS.MPDO.RepresentativeGroupedLemmaL
+import TNLean.Wielandt.SpanGrowth.CumulativeSpan
 
 /-!
 # Representative separation after injective blocking
@@ -16,6 +19,12 @@ already injective, the representative word tuples span the full product matrix
 algebra at every sufficiently large length.  Pairwise separation gives a fixed
 selector suffix, while one-site injectivity gives a full matrix-algebra prefix
 at every positive remaining length.
+
+The file also derives the corresponding statement from an unblocked BNT
+canonical form and a positive blocking length at which every representative
+becomes injective.  Pair separation is proved before blocking at a divisible
+word length and transported exactly to the blocked representatives; no
+preservation theorem for the full canonical-form structure is assumed.
 
 This is the post-blocking form of the block-injectivity input in
 arXiv:1606.00608, lines 318--345.  In particular, line 332 supplies the
@@ -81,6 +90,113 @@ theorem eventuallyRepresentativeWordTupleSpan_of_basis_injective
   have hPrefixPos : 0 < L - selectorLength := by omega
   have hSpan := wordTupleSpanTop_of_common_blockInjective_of_blockSelectorWords
     P.basis (fun j ↦ hBlkPos j (L - selectorLength) hPrefixPos) hSelectors
+  simpa [Nat.sub_add_cancel hSelectorLength_le] using hSpan
+
+/-- Physical blocking transports the BNT hypotheses needed for simultaneous
+representative separation, without asserting preservation of the entire
+canonical-form structure.
+
+Suppose `p > 0` and every `p`-blocked representative is injective.  Pair
+separation is first obtained for the original representatives at length
+`6 * p`, using Condition C1 at length `2 * p - 1`, and is then transported to
+length `6` for the blocked representatives.  The resulting selector suffix,
+together with injectivity of the blocked representatives, gives simultaneous
+word-tuple span at every sufficiently large blocked length.
+
+This is the representative-level form of the blocking and block-injectivity
+argument in arXiv:1606.00608, lines 318--344, used in Appendix C.3, Lemma L,
+lines 1835--1858. -/
+theorem eventuallyRepresentativeWordTupleSpan_blockTensor
+    (hCF : IsBNTCanonicalForm P) (p : ℕ) (hp : 0 < p)
+    (hInj : ∀ j, IsInjective (MPSTensor.blockTensor (P.basis j) p)) :
+    (P.blockTensor p).EventuallyRepresentativeWordTupleSpan := by
+  classical
+  letI : ∀ j : Fin P.basisCount, NeZero (P.basisDim j) :=
+    fun j ↦ ⟨(hCF.basis_dim_pos j).ne'⟩
+  have hAtP : ∀ j : Fin P.basisCount, IsNBlkInjective (P.basis j) p := by
+    intro j
+    exact (isNBlkInjective_iff_blockTensor_isInjective (P.basis j) p).2 (hInj j)
+  have hAtLeastP : ∀ (j : Fin P.basisCount) (n : ℕ), p ≤ n →
+      IsNBlkInjective (P.basis j) n := by
+    intro j n hpn
+    obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_le hpn
+    clear hpn
+    induction k with
+    | zero => simpa using hAtP j
+    | succ k ih =>
+        simpa [Nat.add_assoc] using
+          (isNBlkInjective_succ_of_isNBlkInjective
+            (P.basis j) (Nat.add_pos_left hp k) ih)
+  let L₀ := 2 * p - 1
+  have hBlk0 : ∀ j : Fin P.basisCount, IsNBlkInjective (P.basis j) L₀ := by
+    intro j
+    apply hAtLeastP j
+    dsimp [L₀]
+    omega
+  have hBlk1 : ∀ j : Fin P.basisCount, IsNBlkInjective (P.basis j) (L₀ + 1) := by
+    intro j
+    apply hAtLeastP j
+    dsimp [L₀]
+    omega
+  have hBlk3 : ∀ j : Fin P.basisCount,
+      IsNBlkInjective (P.basis j) ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) := by
+    intro j
+    apply hAtLeastP j
+    dsimp [L₀]
+    omega
+  have hIrr : HasIrreducibleBlocks (d := d) P.basis :=
+    HasIrreducibleBlocks.ofForall hCF.basis_irreducible
+  have hLeft : IsLeftCanonicalBlockFamily (d := d) P.basis :=
+    IsLeftCanonicalBlockFamily.ofForall hCF.basis_left_canonical
+  have hOverlap : HasNormalizedSelfOverlap (d := d) P.basis :=
+    HasNormalizedSelfOverlap.ofForall hCF.basis_normalized_self_overlap
+  have hBlocks : BlocksNotGaugePhaseEquiv (d := d) P.basis :=
+    hCF.basis_distinct
+  have hL₀ : 0 < L₀ := by
+    dsimp [L₀]
+    omega
+  have hSepOriginalRaw :=
+    forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_c1
+      P.basis hIrr hLeft hOverlap hBlocks hBlk0 hBlk1 hBlk3 hL₀
+  have hLength : (L₀ + 1) + ((L₀ + 1) + (L₀ + 1)) = 6 * p := by
+    dsimp [L₀]
+    omega
+  have hSepOriginal : ∀ k j : Fin P.basisCount, j ≠ k →
+      PairTraceSeparatingAt (P.basis k) (P.basis j) (6 * p) := by
+    intro k j hjk
+    rw [← hLength]
+    exact hSepOriginalRaw k j hjk
+  have hSepBlocked : ∀ k j : Fin P.basisCount, j ≠ k →
+      PairTraceSeparatingAt
+        (MPSTensor.blockTensor (P.basis k) p)
+        (MPSTensor.blockTensor (P.basis j) p) 6 := by
+    intro k j hjk
+    exact pairTraceSeparatingAt_blockTensor
+      (P.basis k) (P.basis j) p 6 (hSepOriginal k j hjk)
+  have hPair : HasPairBlockSeparatingWords (P.blockTensor p).basis 6 := by
+    change HasPairBlockSeparatingWords
+      (fun j ↦ MPSTensor.blockTensor (P.basis j) p) 6
+    exact hasPairBlockSeparatingWords_of_forall_pairTraceSeparatingAt
+      (fun j ↦ MPSTensor.blockTensor (P.basis j) p) hSepBlocked
+  let selectorLength := (P.basisCount - 1) * 6
+  have hSelectors : HasBlockSelectorWords (P.blockTensor p).basis selectorLength := by
+    change HasBlockSelectorWords (P.blockTensor p).basis ((P.basisCount - 1) * 6)
+    exact hasBlockSelectorWords_of_pairBlockSeparatingWords (P.blockTensor p).basis hPair
+  have hBlkPos : ∀ (j : Fin P.basisCount) (n : ℕ), 0 < n →
+      IsNBlkInjective ((P.blockTensor p).basis j) n := by
+    intro j n hn
+    change IsNBlkInjective (MPSTensor.blockTensor (P.basis j) p) n
+    exact (wordSpan_eq_top_iff_isNBlkInjective
+      (MPSTensor.blockTensor (P.basis j) p) n).mp
+      (wordSpan_eq_top_of_isInjective (hInj j) hn)
+  change ∃ L₁ : ℕ, ∀ L ≥ L₁, WordTupleSpanTop (P.blockTensor p).basis L
+  refine ⟨selectorLength + 1, ?_⟩
+  intro L hL
+  have hSelectorLength_le : selectorLength ≤ L := by omega
+  have hPrefixPos : 0 < L - selectorLength := by omega
+  have hSpan := wordTupleSpanTop_of_common_blockInjective_of_blockSelectorWords
+    (P.blockTensor p).basis
+    (fun j ↦ hBlkPos j (L - selectorLength) hPrefixPos) hSelectors
   simpa [Nat.sub_add_cancel hSelectorLength_le] using hSpan
 
 /-- Representative-grouped Lemma L for an already injectively blocked BNT

--- a/TNLean/MPS/Periodic/Overlap/Case3Transport.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case3Transport.lean
@@ -100,46 +100,6 @@ private lemma sum_trace_proj_overlap_shift {L' m : ℕ} [NeZero m]
   rw [trace_proj_evalWord_rotateCfg A P hShiftA u σ,
     trace_proj_evalWord_rotateCfg B Q hShiftB v σ]
 
-/-- Equivalence between blocked configurations of length `N` and physical
-configurations of length `N * m`, via `MPSTensor.decodeBlockEquiv`. -/
-private noncomputable def blockedCfgEquiv (d N m : ℕ) :
-    (Fin N → Fin (blockPhysDim d m)) ≃ (Fin (N * m) → Fin d) :=
-  ((Equiv.arrowCongr (Equiv.refl (Fin N)) (decodeBlockEquiv d m)).trans
-    (Equiv.curry (Fin N) (Fin m) (Fin d)).symm).trans
-    (Equiv.arrowCongr finProdFinEquiv (Equiv.refl (Fin d)))
-
-private lemma ofFn_blockedCfgEquiv (d N m : ℕ) (σ : Fin N → Fin (blockPhysDim d m)) :
-    List.ofFn (blockedCfgEquiv d N m σ) = flattenBlockedWord d m (List.ofFn σ) := by
-  have hfun : (blockedCfgEquiv d N m σ) =
-      fun k : Fin (N * m) =>
-        decodeBlock d m (σ (finProdFinEquiv.symm k).1) ((finProdFinEquiv.symm k).2) := by
-    funext k
-    simp [blockedCfgEquiv, Equiv.arrowCongr, Equiv.curry, decodeBlockEquiv_apply,
-      Function.comp]
-  rw [hfun, List.ofFn_mul]
-  rw [flattenBlockedWord, List.map_ofFn]
-  congr 1
-  refine congrArg List.ofFn (funext fun i => ?_)
-  -- The grouped index `⟨i*m+j⟩` decodes to `(i, j)` under `finProdFinEquiv`.
-  have hsymm : ∀ j : Fin m,
-      finProdFinEquiv.symm
-          (⟨(i : ℕ) * m + (j : ℕ),
-            by
-              calc
-                (i : ℕ) * m + (j : ℕ) < ((i : ℕ) + 1) * m := by
-                  have := j.isLt; rw [Nat.add_mul, Nat.one_mul]; omega
-                _ ≤ N * m := Nat.mul_le_mul_right _ (by have := i.isLt; omega)⟩ :
-            Fin (N * m)) = (i, j) := by
-    intro j
-    rw [Equiv.symm_apply_eq]
-    apply Fin.ext
-    -- `finProdFinEquiv (i, j) = ⟨j + m * i, _⟩` by definition.
-    change (i : ℕ) * m + (j : ℕ) = (j : ℕ) + m * (i : ℕ)
-    rw [Nat.mul_comm m (i : ℕ), Nat.add_comm]
-  simp only [hsymm]
-  change (List.ofFn fun j : Fin m => decodeBlock d m (σ i) j) = (wordOfBlock d m ∘ σ) i
-  simp [wordOfBlock, Function.comp]
-
 /-- The cross overlap of two compressed cyclic sectors, expanded via the
 `IsCyclicSectorDecomp` trace formula and reindexed to physical configurations
 of length `N * m`. -/
@@ -160,12 +120,12 @@ private lemma sectorOverlap_eq_physical_sum {m : ℕ} [NeZero D] [NeZero m]
           star ((PB v * evalWord B (List.ofFn τ)).trace) := by
   classical
   rw [mpvOverlap]
-  rw [← Equiv.sum_comp (blockedCfgEquiv d N m)
+  rw [← Equiv.sum_comp (blockedConfigEquiv d N m)
     (fun τ : Fin (N * m) → Fin d =>
       (PA u * evalWord A (List.ofFn τ)).trace *
         star ((PB v * evalWord B (List.ofFn τ)).trace))]
   refine Finset.sum_congr rfl fun σ _ => ?_
-  rw [hTraceA u N σ, hTraceB v N σ, ofFn_blockedCfgEquiv,
+  rw [hTraceA u N σ, hTraceB v N σ, ofFn_blockedConfigEquiv,
     ← evalWord_blockTensor, ← evalWord_blockTensor]
 
 /-- **One-step transport of the cross sector overlap** (positive lengths,

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -706,6 +706,8 @@ boundary conditions (PBC).
 
 \begin{lemma}[Blocked word evaluation]\label{lem:eval_word_block}
     \lean{MPSTensor.evalWord_blockTensor}
+    \lean{MPSTensor.blockedConfigEquiv}
+    \lean{MPSTensor.ofFn_blockedConfigEquiv}
     \leanok
     \uses{def:blocked_tensor, def:eval_word}
     If $w = (J_1, \ldots, J_m)$ is a word in the blocked alphabet,

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -369,11 +369,13 @@
 \begin{theorem}[Representative separation after injective blocking]
     \label{thm:postblocked_representative_grouped_insert_eq}
     \lean{MPSTensor.IsBNTCanonicalForm.eventuallyRepresentativeWordTupleSpan_of_basis_injective}
+    \lean{MPSTensor.IsBNTCanonicalForm.eventuallyRepresentativeWordTupleSpan_blockTensor}
+    \lean{MPSTensor.pairTraceSeparatingAt_blockTensor}
     \lean{MPSTensor.IsBNTCanonicalForm.insertedTensor_basis_eq_of_firstSiteActionAgree_of_basis_injective}
     \lean{MPSTensor.IsBNTCanonicalForm.insertedTensor_basis_eq_of_sameMPV₂_firstSiteActionAgree_of_basis_injective}
     \leanok
-    \uses{def:sector_bnt_cf, def:representative_word_tuple_span,
-      thm:representative_grouped_insert_eq}
+    \uses{def:sector_bnt_cf, def:sector_decomposition_block_tensor,
+      def:representative_word_tuple_span, thm:representative_grouped_insert_eq}
     Let $P$ be a BNT canonical form with basis representatives
     $(A_j)_{j=0}^{g-1}$, and suppose that the representatives have already
     been blocked so that every $A_j$ is injective. Then representative
@@ -390,6 +392,12 @@
     The same conclusion holds when the first-site equality is given for any
     tensor with the same complete MPV family as the tensor represented by
     $P$.
+
+    More generally, let $P$ be a BNT canonical form before physical blocking,
+    let $p>0$, and suppose that every $p$-blocked representative
+    $A_j^{[p]}$ is injective. Then the blocked sector decomposition $P^{[p]}$
+    has representative word-tuple separation at every blocked length
+    $L\geq 6(g-1)+1$.
 
     This is the conclusion after the blocking step in
     \cite[lines~318--345]{Cirac2016MPDO_arXiv}. The hypothesis that each
@@ -424,6 +432,14 @@
     $\prod_jM_{D_j}(\C)$. This proves eventual representative word-tuple
     separation. The representative-grouped Lemma L gives the two first-site
     conclusions.
+
+    For the unblocked canonical form, propagate $p$-block injectivity to the
+    lengths $2p-1$, $2p$, and $6p$. The Condition C1 form of the direct-sum
+    argument gives pair trace separation at original length $6p$. The
+    bijection between blocked words of length $6$ and original words of length
+    $6p$ transports this to pair trace separation for the $p$-blocked
+    representatives. The preceding selector argument then applies verbatim
+    to $P^{[p]}$.
 \end{proof}
 
 \begin{lemma}[Blockwise equality from agreement on the MPV family]

--- a/docs/paper-gaps/cpgsv17_bicf_block_separation.tex
+++ b/docs/paper-gaps/cpgsv17_bicf_block_separation.tex
@@ -184,14 +184,21 @@ the coefficient identity
 The tensor assembled from this blocked decomposition has the same MPV family
 as the physical blocking of the original assembled tensor.
 
-One should therefore choose a common positive $L$ for which every normal BNT
-representative is $L$-block injective and prove the representative-separation
-property for the sector decomposition blocked by $L+1$ sites.  The existing
-post-blocking theorem applies once this property, or the relevant preserved
-canonical-form data, is supplied.  The original length-$L$ span then recovers
-equality of the unblocked insertions from equality of the blocked insertions.
-This length shift is essential: recovery from a physical block of length
-$L+1$ uses the span of its length-$L$ tail.  The flattened
+The representative-separation step has now been obtained without asserting
+preservation of the full canonical-form predicate.  If $p>0$ and every
+$A_j^{[p]}$ is injective, then pair separation for the original representatives
+at length $6p$ transports through the bijection of blocked and unblocked words
+to pair separation for the blocked representatives at length $6$.  It follows
+that $P^{[p]}$ has simultaneous representative word-tuple span at every
+blocked length at least $6(g-1)+1$.
+
+It remains to compose this statement with the first-site transport.  One
+chooses a common positive $L$ for which every normal representative is
+$L$-block injective and uses $p=L+1$; positive-length propagation makes every
+$A_j^{[L+1]}$ injective.  The original length-$L$ span then recovers equality
+of the unblocked insertions from equality of the blocked insertions.  This
+length shift is essential: recovery from a physical block of length $L+1$
+uses the span of its length-$L$ tail.  The flattened
 \texttt{HorizontalCFData} formulation must then be replaced, or related
 explicitly, by this representative-indexed statement.  The older per-copy
 \texttt{biCF} theorem remains a correct restricted result, but it is no longer


### PR DESCRIPTION
## Summary

- expose the exact equivalence between blocked configurations of length (N) and ordinary configurations of length (Np);
- transport pair trace separation from ordinary length (Np) to blocked length (N);
- prove that a BNT canonical form whose (p)-blocked representatives are injective has eventual simultaneous representative word span after blocking;
- synchronize the blueprint and update the paper-gap note for the remaining first-site transport step.

## Mathematical argument

Let (p>0), and suppose every (p)-blocked representative is injective. This is equivalent to (p)-block injectivity of each original representative, which propagates to all lengths at least (p). Taking (L_0=2p-1), the Condition C1 direct-sum theorem gives pair trace separation at length
[
3(L_0+1)=6p.
]
The exact blocked-word equivalence transports this statement to length (6) for the blocked representatives. Multiplying the resulting pair selectors gives a selector of length (6(g-1)) for each of the (g) representatives. Injectivity supplies the remaining positive-length prefix, hence simultaneous representative word span at every blocked length at least (6(g-1)+1).

This uses only the original BNT canonical-form hypotheses and blocked representative injectivity. It does not assume preservation of the full canonical-form predicate under blocking.

Source: arXiv:1606.00608, lines 318–344 and Appendix C.3, Lemma L, lines 1835–1858. The remaining recovery step is recorded in `docs/paper-gaps/cpgsv17_bicf_block_separation.tex`.

## Verification

- `lake env lean` on each affected Lean module
- `lake env lean TNLean.lean`
- `lake build` (9,372 jobs)
- bidirectional blueprint/Lean synchronization
- reader-facing prose check
- proof-integrity grep
- `#print axioms` for all new theorems: only `propext`, `Classical.choice`, and `Quot.sound`

Advances #3713.
Related to #3674.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formal lemmas and doc/blueprint sync on MPS blocking; no auth, I/O, or runtime behavior changes.
> 
> **Overview**
> Centralizes **blocked vs. unblocked configuration identification** in `TNLean/MPS/Core/Blocking.lean` as `blockedConfigEquiv` and `ofFn_blockedConfigEquiv`, and drops the duplicate private definitions from periodic overlap transport.
> 
> Adds **`pairTraceSeparatingAt_blockTensor`**, which pulls pair trace separation from ordinary length `N·p` to blocked length `N` via that equivalence, and **`eventuallyRepresentativeWordTupleSpan_blockTensor`**: from a BNT canonical form and injective `p`-blocked representatives, it gets pair separation at length `6p` (Condition C1 at `2p−1`), transports to length `6` on blocked tensors, then builds eventual simultaneous representative word-tuple span for `P^{[p]}` without assuming full canonical-form preservation under blocking.
> 
> Blueprint and the paper-gap note are updated to cite the new Lean names and to record that representative separation is proved; **first-site transport** from blocked back to unblocked insertions is still open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1eb3d4b0ed2c381443032f66ebded7fc5ed8b80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->