### PR TITLE
feat(MPS/RFP): transport Appendix B commutation to chains

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -252,6 +252,7 @@ import TNLean.MPS.ParentHamiltonian.Nonvanishing
 import TNLean.MPS.ParentHamiltonian.IntersectionProperty
 import TNLean.MPS.ParentHamiltonian.CyclicWindow
 import TNLean.MPS.ParentHamiltonian.LocalSupport
+import TNLean.MPS.ParentHamiltonian.LocalSupportTransport
 import TNLean.MPS.ParentHamiltonian.ChainGroundSpace
 import TNLean.MPS.ParentHamiltonian.SuffixWindow
 import TNLean.MPS.ParentHamiltonian.BoundaryOverlap
@@ -490,6 +491,7 @@ import TNLean.MPS.RFP.CommutingBridge
 import TNLean.MPS.RFP.KroneckerTransport
 import TNLean.MPS.RFP.AppendixBSupport
 import TNLean.MPS.RFP.AppendixBCommutation
+import TNLean.MPS.RFP.AppendixBChainCommutation
 import TNLean.MPS.RFP.Convergence
 import TNLean.MPS.RFP.Assembly
 import TNLean.MPS.RFP.Decorrelation

--- a/TNLean/Axioms/Beigi.lean
+++ b/TNLean/Axioms/Beigi.lean
@@ -121,7 +121,7 @@ See the module docstring for the formalization plan. -/
 axiom rfp_to_nncph_commute {d D : ℕ} [NeZero D]
     (A : MPSTensor d D) (_hNT : MPSTensor.IsNormal A)
     (_hRFP : MPSTensor.IsRFP A) :
-    ∀ N : ℕ, 3 ≤ N → ∀ i j : Fin N,
+    ∀ N : ℕ, 2 < N → ∀ i j : Fin N,
       MPSTensor.localTerm A 2 N i * MPSTensor.localTerm A 2 N j =
         MPSTensor.localTerm A 2 N j * MPSTensor.localTerm A 2 N i
 

--- a/TNLean/Axioms/Beigi.lean
+++ b/TNLean/Axioms/Beigi.lean
@@ -56,18 +56,12 @@ in the proofs of
 
 ## TODO
 
-Replace `Axioms.rfp_to_nncph_commute` with a Lean proof that uses the
-structural characterization theorem in arXiv:1606.00608, source lines
-543--555. The structural
-construction in
-`TNLean/MPS/RFP/CommutingBridge.lean` (`ProductPairBridge`) already
-encodes the key combinatorial content; the missing piece is the
-extraction of a `ProductPairBridge A` witness from `IsRFP A` and
-normality. In that construction one may pass to a normalized
-representative only for building the witness and establishing the NNCPH
-conclusion, whose content is insensitive to this scaling; this is not
-a claim that `IsRFP` itself is preserved under rescaling. This is
-internal to the library.
+Replace `Axioms.rfp_to_nncph_commute` by transporting the proved
+left-canonical theorem `MPSTensor.rfp_implies_nncph_of_leftCanonical` to the
+canonical-form scope of the source. The Appendix B projector commutator and its
+transport to every chain with (N>2) are now internal. The remaining
+obligation is the canonical gauge passage needed to remove the explicit
+left-canonical hypothesis without strengthening the source theorem.
 
 Replace `Axioms.beigi_nncph_to_rfp` with a Lean proof that internalizes
 S. Beigi's (2012) classification of ground spaces of nearest-neighbor
@@ -103,7 +97,7 @@ Theorem 3.10.
 
 For a normal MPS tensor `A` in RFP, the two-site parent-Hamiltonian
 `localTerm` projectors pairwise commute on every finite periodic chain
-of length at least `2`.
+of length greater than `2`.
 
 Unfolded on the NNCPH side, the commutativity condition is exactly
 `MPSTensor.IsNNCPH A N` (as defined in
@@ -117,11 +111,17 @@ the file that consumes it.
 construction for the product-of-entangled-pairs form lives in
 `TNLean/MPS/RFP/CommutingBridge.lean` as `ProductPairBridge`.
 
+**Scope restriction (normal commutation):** The source theorem is stated for
+canonical-form tensors and includes the ground-space spanning condition of
+Definition 3.9.  This axiom records only the commutation equations under
+normality and the RFP hypothesis.  The difference is recorded in
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
+
 See the module docstring for the formalization plan. -/
 axiom rfp_to_nncph_commute {d D : ℕ} [NeZero D]
     (A : MPSTensor d D) (_hNT : MPSTensor.IsNormal A)
     (_hRFP : MPSTensor.IsRFP A) :
-    ∀ N : ℕ, 2 ≤ N → ∀ i j : Fin N,
+    ∀ N : ℕ, 3 ≤ N → ∀ i j : Fin N,
       MPSTensor.localTerm A 2 N i * MPSTensor.localTerm A 2 N j =
         MPSTensor.localTerm A 2 N j * MPSTensor.localTerm A 2 N i
 

--- a/TNLean/MPS/ParentHamiltonian/Commuting.lean
+++ b/TNLean/MPS/ParentHamiltonian/Commuting.lean
@@ -349,7 +349,7 @@ theorem HasProductPairLocalProjectors.isNNCPH {A : MPSTensor d D} {N : ℕ}
 /-- The even-chain physical-pair factorization and the two-site projector
 identities give NNCPH on each finite chain of length greater than two. -/
 theorem ProductPairBridge.isNNCPH {A : MPSTensor d D} (hBridge : ProductPairBridge A)
-    (N : ℕ) (hN : 3 ≤ N) :
+    (N : ℕ) (hN : 2 < N) :
     IsNNCPH A N :=
   (hBridge.localProjectors N hN).isNNCPH
 
@@ -388,7 +388,7 @@ theorem rfp_implies_nncph_of_appendixBExtraction (A : MPSTensor d D) [NeZero D]
     (hRFP : IsRFP A) (hNT : IsNormal A) (hLeft : IsLeftCanonical A)
     (hExtract : AppendixBProductPairExtraction
       (AppendixBStructuralData.ofRFP A hNT hRFP hLeft))
-    (N : ℕ) (hN : 3 ≤ N) :
+    (N : ℕ) (hN : 2 < N) :
     IsNNCPH A N :=
   commuting_twoSite_localTerms_of_rfp_of_appendixBExtraction
     A hNT hRFP hLeft hExtract N hN
@@ -411,7 +411,7 @@ theorem rfp_implies_nncph_ground_state_of_appendixBExtraction
     (hRFP : IsRFP A) (hNT : IsNormal A) (hLeft : IsLeftCanonical A)
     (hExtract : AppendixBProductPairExtraction
       (AppendixBStructuralData.ofRFP A hNT hRFP hLeft))
-    (N : ℕ) (hN : 3 ≤ N) :
+    (N : ℕ) (hN : 2 < N) :
     IsNNCPHGroundState A N :=
   have hNN := rfp_implies_nncph_of_appendixBExtraction A hRFP hNT hLeft hExtract N hN
   hNN.isNNCPHGroundState (by omega)
@@ -475,7 +475,7 @@ normality and the RFP hypothesis.  The difference is recorded in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
 theorem rfp_implies_nncph (A : MPSTensor d D) [NeZero D]
     (hRFP : IsRFP A) (hNT : IsNormal A)
-    (N : ℕ) (hN : 3 ≤ N) :
+    (N : ℕ) (hN : 2 < N) :
     IsNNCPH A N := by
   classical
   unfold IsNNCPH IsCommutingParentHam
@@ -497,7 +497,7 @@ zero-energy equations for \(V^{(N)}(A)\). Documented in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
 theorem rfp_implies_nncph_ground_state (A : MPSTensor d D) [NeZero D]
     (hRFP : IsRFP A) (hNT : IsNormal A)
-    (N : ℕ) (hN : 3 ≤ N) :
+    (N : ℕ) (hN : 2 < N) :
     IsNNCPHGroundState A N :=
   (rfp_implies_nncph A hRFP hNT N hN).isNNCPHGroundState (by omega)
 

--- a/TNLean/MPS/ParentHamiltonian/Commuting.lean
+++ b/TNLean/MPS/ParentHamiltonian/Commuting.lean
@@ -347,9 +347,9 @@ theorem HasProductPairLocalProjectors.isNNCPH {A : MPSTensor d D} {N : ℕ}
   hPair.commuting_twoSite_localTerms
 
 /-- The even-chain physical-pair factorization and the two-site projector
-identities give NNCPH on each finite chain of length at least two. -/
+identities give NNCPH on each finite chain of length greater than two. -/
 theorem ProductPairBridge.isNNCPH {A : MPSTensor d D} (hBridge : ProductPairBridge A)
-    (N : ℕ) (hN : 2 ≤ N) :
+    (N : ℕ) (hN : 3 ≤ N) :
     IsNNCPH A N :=
   (hBridge.localProjectors N hN).isNNCPH
 
@@ -368,7 +368,7 @@ theorem ProductPairBridge.hasNNCPHGroundSpaces_of_groundSpaceSpanning
     (hSpan : HasParentHamiltonianGroundSpaceSpanning B 2 A) :
     HasNNCPHGroundSpaces B A := by
   intro N hN
-  exact ⟨(hBridge.isNNCPH N (le_of_lt hN)).isNNCPHGroundState (le_of_lt hN),
+  exact ⟨(hBridge.isNNCPH N (by omega)).isNNCPHGroundState (by omega),
     hSpan N hN⟩
 
 /-- Conditional internal theorem for Theorem 3.10(i)⟹(iii).
@@ -378,15 +378,17 @@ A normal left-canonical RFP tensor has the Appendix B structural form
 associated two-site amplitude gives the even-chain physical-pair factorization
 and the two-site parent terms are identified with commuting
 idempotents, then the nearest-neighbor parent Hamiltonian is commuting on every
-finite chain of length at least two.
+finite chain of length greater than two.
 
-This theorem does not use `Axioms.rfp_to_nncph_commute`; it states the precise
-conditional theorem left after the structural form has been internalized. -/
+This theorem does not use `Axioms.rfp_to_nncph_commute`.  The extraction
+hypothesis includes a physical-pair coefficient factorization; the later theorem
+`rfp_implies_nncph_of_leftCanonical` obtains the commutation conclusion directly
+from the Appendix B structural datum. -/
 theorem rfp_implies_nncph_of_appendixBExtraction (A : MPSTensor d D) [NeZero D]
     (hRFP : IsRFP A) (hNT : IsNormal A) (hLeft : IsLeftCanonical A)
     (hExtract : AppendixBProductPairExtraction
       (AppendixBStructuralData.ofRFP A hNT hRFP hLeft))
-    (N : ℕ) (hN : 2 ≤ N) :
+    (N : ℕ) (hN : 3 ≤ N) :
     IsNNCPH A N :=
   commuting_twoSite_localTerms_of_rfp_of_appendixBExtraction
     A hNT hRFP hLeft hExtract N hN
@@ -409,10 +411,10 @@ theorem rfp_implies_nncph_ground_state_of_appendixBExtraction
     (hRFP : IsRFP A) (hNT : IsNormal A) (hLeft : IsLeftCanonical A)
     (hExtract : AppendixBProductPairExtraction
       (AppendixBStructuralData.ofRFP A hNT hRFP hLeft))
-    (N : ℕ) (hN : 2 ≤ N) :
+    (N : ℕ) (hN : 3 ≤ N) :
     IsNNCPHGroundState A N :=
   have hNN := rfp_implies_nncph_of_appendixBExtraction A hRFP hNT hLeft hExtract N hN
-  hNN.isNNCPHGroundState hN
+  hNN.isNNCPHGroundState (by omega)
 
 /-- Conditional full source form of Theorem 3.10(i)⟹(iii).
 
@@ -464,10 +466,16 @@ terms.
 Per arXiv:1606.00608 Section 3.3, the proof passage at source line 1307
 derives this direction from the structural characterization theorem, so it does
 not depend on S. Beigi (2012). It is conditioned on that source theorem
-(source lines 543--555), stated here as `Axioms.rfp_to_nncph_commute`. -/
+(source lines 543--555), stated here as `Axioms.rfp_to_nncph_commute`.
+
+**Scope restriction (normal commutation):** The source theorem is stated for
+canonical-form tensors and includes the ground-space spanning condition of
+Definition 3.9.  This theorem records only the commutation equations under
+normality and the RFP hypothesis.  The difference is recorded in
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
 theorem rfp_implies_nncph (A : MPSTensor d D) [NeZero D]
     (hRFP : IsRFP A) (hNT : IsNormal A)
-    (N : ℕ) (hN : 2 ≤ N) :
+    (N : ℕ) (hN : 3 ≤ N) :
     IsNNCPH A N := by
   classical
   unfold IsNNCPH IsCommutingParentHam
@@ -476,7 +484,7 @@ theorem rfp_implies_nncph (A : MPSTensor d D) [NeZero D]
 
 /-- **Theorem 3.10(i)⟹(iii)** (arXiv:1606.00608), ground-vector form:
 RFP implies that the periodic MPS vector satisfies the zero-energy equation for
-commuting nearest-neighbor parent terms on every chain of length at least two.
+commuting nearest-neighbor parent terms on every chain of length greater than two.
 
 This theorem adds the frustration-free ground-vector equation to
 `rfp_implies_nncph`.
@@ -489,9 +497,9 @@ zero-energy equations for \(V^{(N)}(A)\). Documented in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
 theorem rfp_implies_nncph_ground_state (A : MPSTensor d D) [NeZero D]
     (hRFP : IsRFP A) (hNT : IsNormal A)
-    (N : ℕ) (hN : 2 ≤ N) :
+    (N : ℕ) (hN : 3 ≤ N) :
     IsNNCPHGroundState A N :=
-  (rfp_implies_nncph A hRFP hNT N hN).isNNCPHGroundState hN
+  (rfp_implies_nncph A hRFP hNT N hN).isNNCPHGroundState (by omega)
 
 /-- **Theorem 3.10(iii)⟹(i)** (arXiv:1606.00608): all-chain
 nearest-neighbor commuting parent-Hamiltonian ground spaces imply RFP in the

--- a/TNLean/MPS/ParentHamiltonian/LocalSupportTransport.lean
+++ b/TNLean/MPS/ParentHamiltonian/LocalSupportTransport.lean
@@ -1,0 +1,267 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.ParentHamiltonian.Basic
+import TNLean.MPS.ParentHamiltonian.LocalSupport
+
+/-!
+# Transport of the three-site nearest-neighbor commutator
+
+This file transports the local commutation relation between the two adjacent
+length-two parent interactions on a three-site window to every translated
+three-site window of a longer periodic chain.
+
+The chain-length hypothesis is (3 \leq N), matching the (N>2) condition in
+arXiv:1606.00608, Theorem 3.10 and the local relation
+\([\tau_1(P_2),P_2]=0\) in Definition 3.9.
+-/
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+private theorem extractWindow_two_replaceWindow_three_left
+    {N : ℕ} (hN : 3 ≤ N) (i : Fin N) (τ : Cfg d N) (σ : Cfg d 3) :
+    extractWindow 2 i (replaceWindow 3 hN i τ σ) = extractWindow 2 (0 : Fin 3) σ := by
+  funext j
+  have hfull := congrFun (extractWindow_replaceWindow 3 hN i τ σ)
+    (Fin.castLE (by omega) j)
+  rw [show extractWindow 2 i (replaceWindow 3 hN i τ σ) j =
+      extractWindow 3 i (replaceWindow 3 hN i τ σ) (Fin.castLE (by omega) j) by
+    rfl]
+  rw [hfull]
+  apply congrArg σ
+  apply Fin.ext
+  simpa only [Fin.val_castLE, Fin.val_mk, Fin.val_zero, Nat.zero_add] using
+    (Nat.mod_eq_of_lt (by omega : j.val < 3)).symm
+
+private theorem extractWindow_two_replaceWindow_three_right
+    {N : ℕ} (hN : 3 ≤ N) (i : Fin N) (τ : Cfg d N) (σ : Cfg d 3) :
+    extractWindow 2 (cyclicForwardSite i 1) (replaceWindow 3 hN i τ σ) =
+      extractWindow 2 (1 : Fin 3) σ := by
+  funext j
+  let k : Fin 3 := ⟨j.val + 1, by omega⟩
+  have hfull := congrFun (extractWindow_replaceWindow 3 hN i τ σ) k
+  rw [show extractWindow 2 (cyclicForwardSite i 1) (replaceWindow 3 hN i τ σ) j =
+      extractWindow 3 i (replaceWindow 3 hN i τ σ) k by
+    apply congrArg (replaceWindow 3 hN i τ σ)
+    apply Fin.ext
+    change (cyclicForwardSite (cyclicForwardSite i 1) j.val).val =
+      (cyclicForwardSite i k.val).val
+    rw [cyclicForwardSite_forwardSite]
+    congr 2
+    simp [k, Nat.add_comm]]
+  rw [hfull]
+  apply congrArg σ
+  apply Fin.ext
+  change k.val = (1 + j.val) % 3
+  rw [show k.val = 1 + j.val by simp [k, Nat.add_comm],
+    Nat.mod_eq_of_lt (by omega)]
+
+private theorem replaceWindow_three_replaceWindow_two_left
+    {N : ℕ} (hN : 3 ≤ N) (i : Fin N) (τ : Cfg d N) (σ : Cfg d 3)
+    (α : Cfg d 2) :
+    replaceWindow 3 hN i τ (replaceWindow 2 (by omega) (0 : Fin 3) σ α) =
+      replaceWindow 2 (by omega) i (replaceWindow 3 hN i τ σ) α := by
+  funext k
+  let off := (k.val + N - i.val) % N
+  by_cases h3 : off < 3
+  · have hoff : off = 0 ∨ off = 1 ∨ off = 2 := by omega
+    rcases hoff with hoff | hoff | hoff
+    · have hk : (k.val + N - i.val) % N = 0 := by simpa [off] using hoff
+      simp [replaceWindow, hk]
+    · have hk : (k.val + N - i.val) % N = 1 := by simpa [off] using hoff
+      simp [replaceWindow, hk]
+    · have hk : (k.val + N - i.val) % N = 2 := by simpa [off] using hoff
+      simp [replaceWindow, hk]
+  · have h2 : ¬off < 2 := by omega
+    simp [replaceWindow, off, h3, h2]
+
+private theorem replaceWindow_three_replaceWindow_two_right
+    {N : ℕ} (hN : 3 ≤ N) (i : Fin N) (τ : Cfg d N) (σ : Cfg d 3)
+    (β : Cfg d 2) :
+    replaceWindow 3 hN i τ (replaceWindow 2 (by omega) (1 : Fin 3) σ β) =
+      replaceWindow 2 (by omega) (cyclicForwardSite i 1)
+        (replaceWindow 3 hN i τ σ) β := by
+  funext k
+  simp only [replaceWindow]
+  by_cases hzero : (k.val + N - i.val) % N = 0
+  · have hk : k = i := by
+      have hk' := eq_cyclic_site_of_offset_eq (Fin.pos i) hzero
+      simpa [Nat.mod_eq_of_lt i.isLt] using hk'
+    subst k
+    have hshift_eq :
+        (i.val + N - (cyclicForwardSite i 1).val) % N = N - 1 := by
+      by_cases hi : i.val + 1 < N
+      · have hval : (cyclicForwardSite i 1).val = i.val + 1 := by
+          simp [cyclicForwardSite, Nat.mod_eq_of_lt hi]
+        rw [hval]
+        have hsub : i.val + N - (i.val + 1) = N - 1 := by omega
+        rw [hsub]
+        exact Nat.mod_eq_of_lt (by omega)
+      · have hiN : i.val + 1 = N := by omega
+        have hval : (cyclicForwardSite i 1).val = 0 := by
+          simp [cyclicForwardSite, hiN]
+        rw [hval]
+        have hsub : i.val + N - 0 = (N - 1) + N := by omega
+        rw [hsub, Nat.add_mod_right]
+        exact Nat.mod_eq_of_lt (by omega)
+    have hshift : ¬((i.val + N - (cyclicForwardSite i 1).val) % N < 2) := by
+      rw [hshift_eq]
+      omega
+    rw [dif_pos (by omega : (i.val + N - i.val) % N < 3), dif_neg hshift]
+    simp
+  · let r := (k.val + N - i.val) % N
+    have hrpos : 0 < r := Nat.pos_of_ne_zero hzero
+    have hrN : r < N := Nat.mod_lt _ (Fin.pos i)
+    have hk_site : k = cyclicForwardSite i r := by
+      have hsite := eq_cyclic_site_of_offset_eq (Fin.pos i) (r := r) rfl
+      simpa [cyclicForwardSite, r] using hsite
+    have hshift_site : k = cyclicForwardSite (cyclicForwardSite i 1) (r - 1) := by
+      rw [hk_site, cyclicForwardSite_forwardSite]
+      congr 1
+      omega
+    have hshift_eq :
+        (k.val + N - (cyclicForwardSite i 1).val) % N = r - 1 := by
+      rw [hshift_site]
+      change (((cyclicForwardSite i 1).val + (r - 1)) % N + N -
+          (cyclicForwardSite i 1).val) % N = r - 1
+      exact offset_mod_eq (cyclicForwardSite i 1).isLt (by omega)
+    by_cases hsmall : (k.val + N - i.val) % N < 3
+    · have hshiftSmall :
+          (k.val + N - (cyclicForwardSite i 1).val) % N < 2 := by
+        rw [hshift_eq]
+        omega
+      rw [dif_pos hsmall, dif_pos hshiftSmall]
+      have hr : r = 1 ∨ r = 2 := by
+        change r < 3 at hsmall
+        omega
+      rcases hr with hr | hr
+      · have hout : (k.val + N - i.val) % N = 1 := by simpa [r] using hr
+        have hright :
+            (k.val + N - (cyclicForwardSite i 1).val) % N = 0 := by
+          rw [hshift_eq, hr]
+        simp [hout, hright]
+      · have hout : (k.val + N - i.val) % N = 2 := by simpa [r] using hr
+        have hright :
+            (k.val + N - (cyclicForwardSite i 1).val) % N = 1 := by
+          rw [hshift_eq, hr]
+        simp [hout, hright]
+    · have hshiftLarge :
+          ¬((k.val + N - (cyclicForwardSite i 1).val) % N < 2) := by
+        rw [hshift_eq]
+        omega
+      rw [dif_neg hsmall, dif_neg hshiftLarge]
+      simp [hsmall]
+
+/-! ### Restriction intertwiners -/
+
+/-- Restriction to the three-site window beginning at (i) intertwines the
+length-two term at (i) with the term at site (0) of the three-site chain.
+
+This is the left-face transport for the local relation
+\([\tau_1(P_2),P_2]=0\) in arXiv:1606.00608, Definition 3.9, source lines
+517--524. -/
+theorem cyclicRestrictₗ_three_localTerm_left
+    {A : MPSTensor d D} {N : ℕ} (hN : 3 ≤ N) (i : Fin N) (τ : Cfg d N)
+    (ψ : NSiteSpace d N) :
+    cyclicRestrictₗ (by omega) 3 i τ (localTerm A 2 N i ψ) =
+      localTerm A 2 3 (0 : Fin 3) (cyclicRestrictₗ (by omega) 3 i τ ψ) := by
+  ext σ
+  simp only [cyclicRestrictₗ_apply]
+  rw [localTerm_apply_of_le A 2 N (by omega) i]
+  rw [localTerm_apply_of_le A 2 3 (by omega) (0 : Fin 3)]
+  change parentInteraction A 2
+      (fun α => ψ (replaceWindow 2 (by omega) i
+        (replaceWindow 3 hN i τ σ) α))
+      (extractWindow 2 i (replaceWindow 3 hN i τ σ)) =
+    parentInteraction A 2
+      (fun α => ψ (replaceWindow 3 hN i τ
+        (replaceWindow 2 (by omega) (0 : Fin 3) σ α)))
+      (extractWindow 2 (0 : Fin 3) σ)
+  rw [extractWindow_two_replaceWindow_three_left]
+  have hfun :
+      (fun α => ψ (replaceWindow 2 (by omega) i
+        (replaceWindow 3 hN i τ σ) α)) =
+      fun α => ψ (replaceWindow 3 hN i τ
+        (replaceWindow 2 (by omega) (0 : Fin 3) σ α)) := by
+    funext α
+    rw [replaceWindow_three_replaceWindow_two_left]
+  rw [hfun]
+
+/-- Restriction to the three-site window beginning at (i) intertwines the
+length-two term at (i+1) with the term at site (1) of the three-site chain.
+
+This is the right-face transport for the local relation
+\([\tau_1(P_2),P_2]=0\) in arXiv:1606.00608, Definition 3.9, source lines
+517--524. -/
+theorem cyclicRestrictₗ_three_localTerm_right
+    {A : MPSTensor d D} {N : ℕ} (hN : 3 ≤ N) (i : Fin N) (τ : Cfg d N)
+    (ψ : NSiteSpace d N) :
+    cyclicRestrictₗ (by omega) 3 i τ
+        (localTerm A 2 N (cyclicForwardSite i 1) ψ) =
+      localTerm A 2 3 (1 : Fin 3) (cyclicRestrictₗ (by omega) 3 i τ ψ) := by
+  ext σ
+  simp only [cyclicRestrictₗ_apply]
+  rw [localTerm_apply_of_le A 2 N (by omega) (cyclicForwardSite i 1)]
+  rw [localTerm_apply_of_le A 2 3 (by omega) (1 : Fin 3)]
+  change parentInteraction A 2
+      (fun β => ψ (replaceWindow 2 (by omega) (cyclicForwardSite i 1)
+        (replaceWindow 3 hN i τ σ) β))
+      (extractWindow 2 (cyclicForwardSite i 1) (replaceWindow 3 hN i τ σ)) =
+    parentInteraction A 2
+      (fun β => ψ (replaceWindow 3 hN i τ
+        (replaceWindow 2 (by omega) (1 : Fin 3) σ β)))
+      (extractWindow 2 (1 : Fin 3) σ)
+  rw [extractWindow_two_replaceWindow_three_right]
+  have hfun :
+      (fun β => ψ (replaceWindow 2 (by omega) (cyclicForwardSite i 1)
+        (replaceWindow 3 hN i τ σ) β)) =
+      fun β => ψ (replaceWindow 3 hN i τ
+        (replaceWindow 2 (by omega) (1 : Fin 3) σ β)) := by
+    funext β
+    rw [replaceWindow_three_replaceWindow_two_right]
+  rw [hfun]
+
+private theorem cyclicRestrictₗ_three_extractWindow
+    {N : ℕ} (hN : 3 ≤ N) (i : Fin N) (σ : Cfg d N) (ψ : NSiteSpace d N) :
+    cyclicRestrictₗ (by omega) 3 i σ ψ (extractWindow 3 i σ) = ψ σ := by
+  change ψ (replaceWindow 3 hN i σ (extractWindow 3 i σ)) = ψ σ
+  rw [replaceWindow_extractWindow]
+
+/-! ### Transport of the commutator -/
+
+/-- Commutation of the two adjacent length-two parent interactions on the
+three-site chain implies commutation of every adjacent translated pair on every
+periodic chain of length (N>2).
+
+This is the finite-chain transport of the source relation
+\([\tau_1(P_2),P_2]=0\) from arXiv:1606.00608, Definition 3.9, source lines
+517--524.  The bound (3\leq N) is exactly the (N>2) range in Theorem 3.10,
+source lines 534--540.  No assertion is made for (N=2), where the two cyclic
+windows traverse the same pair of sites in opposite orders. -/
+theorem localTerm_adjacent_twoSite_commute_of_threeSite_zero_one_commute
+    {A : MPSTensor d D}
+    (h₃ :
+      localTerm A 2 3 (0 : Fin 3) * localTerm A 2 3 (1 : Fin 3) =
+        localTerm A 2 3 (1 : Fin 3) * localTerm A 2 3 (0 : Fin 3))
+    {N : ℕ} (hN : 3 ≤ N) (i : Fin N) :
+    localTerm A 2 N i * localTerm A 2 N (cyclicForwardSite i 1) =
+      localTerm A 2 N (cyclicForwardSite i 1) * localTerm A 2 N i := by
+  apply LinearMap.ext
+  intro ψ
+  funext σ
+  have hcomm := LinearMap.congr_fun h₃ (cyclicRestrictₗ (by omega) 3 i σ ψ)
+  simp only [Module.End.mul_apply] at hcomm
+  rw [← cyclicRestrictₗ_three_localTerm_right hN i σ ψ,
+    ← cyclicRestrictₗ_three_localTerm_left hN i σ
+      (localTerm A 2 N (cyclicForwardSite i 1) ψ)] at hcomm
+  rw [← cyclicRestrictₗ_three_localTerm_left hN i σ ψ,
+    ← cyclicRestrictₗ_three_localTerm_right hN i σ (localTerm A 2 N i ψ)] at hcomm
+  have hvalue := congrFun hcomm (extractWindow 3 i σ)
+  rw [cyclicRestrictₗ_three_extractWindow hN i σ,
+    cyclicRestrictₗ_three_extractWindow hN i σ] at hvalue
+  simpa only [Module.End.mul_apply] using hvalue
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/Martingale/OverlapReduction.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/OverlapReduction.lean
@@ -109,7 +109,7 @@ noncomputable def AppendixBProductPairExtraction.ofCoreTensorFactorizationAndOve
     {A : MPSTensor d D} {hStruct : AppendixBStructuralData A}
     (hCore : ∀ N, 0 < N → ∀ σ : Cfg d (2 * N),
       mpv hStruct.coreTensor σ = productPairState hStruct.twoSiteAmplitude N σ)
-    (hOverlap : ∀ N, 3 ≤ N → ∀ i j : Fin N, cyclicWindowsOverlap N 2 i j →
+    (hOverlap : ∀ N, 2 < N → ∀ i j : Fin N, cyclicWindowsOverlap N 2 i j →
       localTerm A 2 N i * localTerm A 2 N j =
         localTerm A 2 N j * localTerm A 2 N i) :
     AppendixBProductPairExtraction hStruct :=
@@ -129,7 +129,7 @@ noncomputable def AppendixBProductPairExtraction.ofCoreTensorFactorizationAndAdj
     {A : MPSTensor d D} {hStruct : AppendixBStructuralData A}
     (hCore : ∀ N, 0 < N → ∀ σ : Cfg d (2 * N),
       mpv hStruct.coreTensor σ = productPairState hStruct.twoSiteAmplitude N σ)
-    (hAdjacent : ∀ N, 3 ≤ N → ∀ i : Fin N,
+    (hAdjacent : ∀ N, 2 < N → ∀ i : Fin N,
       localTerm A 2 N i * localTerm A 2 N (cyclicForwardSite i 1) =
         localTerm A 2 N (cyclicForwardSite i 1) * localTerm A 2 N i) :
     AppendixBProductPairExtraction hStruct :=

--- a/TNLean/MPS/ParentHamiltonian/Martingale/OverlapReduction.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/OverlapReduction.lean
@@ -109,14 +109,14 @@ noncomputable def AppendixBProductPairExtraction.ofCoreTensorFactorizationAndOve
     {A : MPSTensor d D} {hStruct : AppendixBStructuralData A}
     (hCore : ∀ N, 0 < N → ∀ σ : Cfg d (2 * N),
       mpv hStruct.coreTensor σ = productPairState hStruct.twoSiteAmplitude N σ)
-    (hOverlap : ∀ N, 2 ≤ N → ∀ i j : Fin N, cyclicWindowsOverlap N 2 i j →
+    (hOverlap : ∀ N, 3 ≤ N → ∀ i j : Fin N, cyclicWindowsOverlap N 2 i j →
       localTerm A 2 N i * localTerm A 2 N j =
         localTerm A 2 N j * localTerm A 2 N i) :
     AppendixBProductPairExtraction hStruct :=
   AppendixBProductPairExtraction.ofCoreTensorFactorization hCore
     (fun N hN =>
       HasProductPairLocalProjectors.of_twoSite_cyclicWindowsOverlap_commute
-        (A := A) hN (hOverlap N hN))
+        (A := A) (by omega) (hOverlap N hN))
 
 /-- Construct the conditional Appendix B extraction from the coefficient
 factorization and the adjacent length-two cyclic-window commutation equations on
@@ -129,13 +129,13 @@ noncomputable def AppendixBProductPairExtraction.ofCoreTensorFactorizationAndAdj
     {A : MPSTensor d D} {hStruct : AppendixBStructuralData A}
     (hCore : ∀ N, 0 < N → ∀ σ : Cfg d (2 * N),
       mpv hStruct.coreTensor σ = productPairState hStruct.twoSiteAmplitude N σ)
-    (hAdjacent : ∀ N, 2 ≤ N → ∀ i : Fin N,
+    (hAdjacent : ∀ N, 3 ≤ N → ∀ i : Fin N,
       localTerm A 2 N i * localTerm A 2 N (cyclicForwardSite i 1) =
         localTerm A 2 N (cyclicForwardSite i 1) * localTerm A 2 N i) :
     AppendixBProductPairExtraction hStruct :=
   AppendixBProductPairExtraction.ofCoreTensorFactorization hCore
     (fun N hN =>
       HasProductPairLocalProjectors.of_adjacent_twoSite_commute
-        (A := A) hN (hAdjacent N hN))
+        (A := A) (by omega) (hAdjacent N hN))
 
 end MPSTensor

--- a/TNLean/MPS/RFP/AppendixBChainCommutation.lean
+++ b/TNLean/MPS/RFP/AppendixBChainCommutation.lean
@@ -1,0 +1,116 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.ParentHamiltonian.LocalSupportTransport
+import TNLean.MPS.ParentHamiltonian.Martingale.OverlapReduction
+import TNLean.MPS.RFP.AppendixBCommutation
+
+/-!
+# Appendix B commutation on finite periodic chains
+
+The Appendix B basic-vector form gives commutation of the two adjacent
+length-two support projectors on a three-site window.  This file transports
+that local equation around a periodic chain and obtains the finite-chain family
+of commuting parent interactions used in the RFP-to-NNCPH direction.
+
+The chain length is restricted to (N>2), exactly as in arXiv:1606.00608,
+Theorem 3.10.  The case (N=2) is not part of the source statement: its two
+cyclic windows traverse the same pair of sites in opposite orders.
+-/
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- The Appendix B structural datum gives commutation of adjacent translated
+length-two parent interactions on every periodic chain of length (N>2).
+
+Source: arXiv:1606.00608, Definition 3.9, source lines 517--524; Theorem 3.10,
+source lines 534--540; and the structural characterization and basic-vector
+form, source lines 543--578. -/
+theorem AppendixBStructuralData.adjacent_twoSite_localTerms_commute
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    {N : ℕ} (hN : 3 ≤ N) (i : Fin N) :
+    localTerm A 2 N i * localTerm A 2 N (cyclicForwardSite i 1) =
+      localTerm A 2 N (cyclicForwardSite i 1) * localTerm A 2 N i :=
+  localTerm_adjacent_twoSite_commute_of_threeSite_zero_one_commute
+    (hStruct.localTerm_two_three_zero_one_commute_of_overlapping
+      hStruct.hasOverlappingTwoSiteCommutation)
+    hN i
+
+/-- The Appendix B structural datum supplies the commuting local-projector
+family on every periodic chain of length (N>2).
+
+The projectors are the translated canonical length-two parent interactions.
+Their idempotency is general; their commutation follows from the source
+three-site projector equation and cyclic transport.
+
+Source: arXiv:1606.00608, Definition 3.9, source lines 517--524; Theorem 3.10,
+source lines 534--540; and the structural characterization and basic-vector
+form, source lines 543--578. -/
+noncomputable def AppendixBStructuralData.hasProductPairLocalProjectors
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    {N : ℕ} (hN : 3 ≤ N) :
+    HasProductPairLocalProjectors A N :=
+  HasProductPairLocalProjectors.of_adjacent_twoSite_commute (by omega)
+    (hStruct.adjacent_twoSite_localTerms_commute hN)
+
+/-- The Appendix B structural datum satisfies the nearest-neighbor commutation
+equations on every periodic chain of length (N>2).
+
+Source: arXiv:1606.00608, Definition 3.9, source lines 517--524; Theorem 3.10,
+source lines 534--540; and the structural characterization and basic-vector
+form, source lines 543--578. -/
+theorem AppendixBStructuralData.isNNCPH
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    {N : ℕ} (hN : 3 ≤ N) :
+    IsNNCPH A N :=
+  (hStruct.hasProductPairLocalProjectors hN).isNNCPH
+
+/-- A normal left-canonical renormalization fixed-point tensor has commuting
+length-two parent interactions on every periodic chain of length (N>2).
+
+This internalizes the commutation part of arXiv:1606.00608,
+Theorem 3.10(i) implies (iii), in the left-canonical scope used by the proved
+Appendix B structural theorem.  It does not use
+`Axioms.rfp_to_nncph_commute` and does not assert the ground-space spanning
+clause of Definition 3.9.
+
+**Scope restriction (left-canonical commutation):** The source theorem is stated
+for tensors in canonical form.  This theorem assumes the left-canonical gauge
+used by the proved Appendix B structural theorem.  The removal of this extra
+hypothesis is recorded in
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
+
+Source: arXiv:1606.00608, Theorem 3.10, source lines 534--540; structural
+characterization and basic-vector form, source lines 543--578. -/
+theorem rfp_implies_nncph_of_leftCanonical
+    (A : MPSTensor d D) [NeZero D]
+    (hRFP : IsRFP A) (hNT : IsNormal A) (hLeft : IsLeftCanonical A)
+    (N : ℕ) (hN : 3 ≤ N) :
+    IsNNCPH A N :=
+  (AppendixBStructuralData.ofRFP A hNT hRFP hLeft).isNNCPH hN
+
+/-- Ground-vector form of `rfp_implies_nncph_of_leftCanonical`.
+
+The translated parent terms commute and annihilate the periodic MPS vector.
+The source ground-space spanning clause remains separate.
+
+**Scope restriction (ground vector):** The source implication includes the
+ground-space spanning equation and is stated in canonical-form scope.  This
+theorem proves the commutation and zero-energy equations under an explicit
+left-canonical hypothesis.  The two restrictions are recorded in
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
+
+Source: arXiv:1606.00608, Definition 3.9, source lines 517--524, and
+Theorem 3.10, source lines 534--540. -/
+theorem rfp_implies_nncph_ground_state_of_leftCanonical
+    (A : MPSTensor d D) [NeZero D]
+    (hRFP : IsRFP A) (hNT : IsNormal A) (hLeft : IsLeftCanonical A)
+    (N : ℕ) (hN : 3 ≤ N) :
+    IsNNCPHGroundState A N :=
+  (rfp_implies_nncph_of_leftCanonical A hRFP hNT hLeft N hN).isNNCPHGroundState
+    (by omega)
+
+end MPSTensor

--- a/TNLean/MPS/RFP/AppendixBChainCommutation.lean
+++ b/TNLean/MPS/RFP/AppendixBChainCommutation.lean
@@ -31,13 +31,13 @@ source lines 534--540; and the structural characterization and basic-vector
 form, source lines 543--578. -/
 theorem AppendixBStructuralData.adjacent_twoSite_localTerms_commute
     {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
-    {N : ℕ} (hN : 3 ≤ N) (i : Fin N) :
+    {N : ℕ} (hN : 2 < N) (i : Fin N) :
     localTerm A 2 N i * localTerm A 2 N (cyclicForwardSite i 1) =
       localTerm A 2 N (cyclicForwardSite i 1) * localTerm A 2 N i :=
   localTerm_adjacent_twoSite_commute_of_threeSite_zero_one_commute
     (hStruct.localTerm_two_three_zero_one_commute_of_overlapping
       hStruct.hasOverlappingTwoSiteCommutation)
-    hN i
+    (by omega) i
 
 /-- The Appendix B structural datum supplies the commuting local-projector
 family on every periodic chain of length (N>2).
@@ -51,7 +51,7 @@ source lines 534--540; and the structural characterization and basic-vector
 form, source lines 543--578. -/
 noncomputable def AppendixBStructuralData.hasProductPairLocalProjectors
     {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
-    {N : ℕ} (hN : 3 ≤ N) :
+    {N : ℕ} (hN : 2 < N) :
     HasProductPairLocalProjectors A N :=
   HasProductPairLocalProjectors.of_adjacent_twoSite_commute (by omega)
     (hStruct.adjacent_twoSite_localTerms_commute hN)
@@ -64,7 +64,7 @@ source lines 534--540; and the structural characterization and basic-vector
 form, source lines 543--578. -/
 theorem AppendixBStructuralData.isNNCPH
     {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
-    {N : ℕ} (hN : 3 ≤ N) :
+    {N : ℕ} (hN : 2 < N) :
     IsNNCPH A N :=
   (hStruct.hasProductPairLocalProjectors hN).isNNCPH
 
@@ -88,7 +88,7 @@ characterization and basic-vector form, source lines 543--578. -/
 theorem rfp_implies_nncph_of_leftCanonical
     (A : MPSTensor d D) [NeZero D]
     (hRFP : IsRFP A) (hNT : IsNormal A) (hLeft : IsLeftCanonical A)
-    (N : ℕ) (hN : 3 ≤ N) :
+    (N : ℕ) (hN : 2 < N) :
     IsNNCPH A N :=
   (AppendixBStructuralData.ofRFP A hNT hRFP hLeft).isNNCPH hN
 
@@ -108,7 +108,7 @@ Theorem 3.10, source lines 534--540. -/
 theorem rfp_implies_nncph_ground_state_of_leftCanonical
     (A : MPSTensor d D) [NeZero D]
     (hRFP : IsRFP A) (hNT : IsNormal A) (hLeft : IsLeftCanonical A)
-    (N : ℕ) (hN : 3 ≤ N) :
+    (N : ℕ) (hN : 2 < N) :
     IsNNCPHGroundState A N :=
   (rfp_implies_nncph_of_leftCanonical A hRFP hNT hLeft N hN).isNNCPHGroundState
     (by omega)

--- a/TNLean/MPS/RFP/AppendixBCommutation.lean
+++ b/TNLean/MPS/RFP/AppendixBCommutation.lean
@@ -11,9 +11,10 @@ import TNLean.MPS.RFP.KroneckerTransport
 This file transports the two commuting placements of the virtual rank-one bond
 projector through the three-site physical isometry.  The calculation uses the
 identity \(U^*U=1\) and does not require the physical isometry to be
-surjective.  It proves a local three-site commutator, rather than an all-chain
-nearest-neighbor commutation statement.  The all-chain and ground-space
-upgrade is recorded in
+surjective.  It proves a local three-site commutator, which is transported to
+every periodic chain with \(N>2\) in
+`TNLean.MPS.RFP.AppendixBChainCommutation`.  The remaining canonical-form and
+ground-space spanning restrictions are recorded in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
 Source: arXiv:1606.00608, equations (3.16)--(3.18), lines 549--578, and the

--- a/TNLean/MPS/RFP/AppendixBSupport.lean
+++ b/TNLean/MPS/RFP/AppendixBSupport.lean
@@ -16,8 +16,10 @@ vector on two sites, identifies the resulting physical image with
 
 The adjacent virtual placements commute.  Their transport to the physical
 three-site coefficient space uses only the isometry identity \(U^*U=1\); no
-surjectivity of \(U\) is required.  The distinction between this local result
-and an all-chain statement is recorded in
+surjectivity of \(U\) is required.  The physical three-site commutator is proved
+in `TNLean.MPS.RFP.AppendixBCommutation` and transported around periodic chains
+in `TNLean.MPS.RFP.AppendixBChainCommutation`.  The remaining canonical-form and
+ground-space spanning restrictions are recorded in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 -/
 

--- a/TNLean/MPS/RFP/CommutingBridge.lean
+++ b/TNLean/MPS/RFP/CommutingBridge.lean
@@ -28,9 +28,11 @@ The source then writes the corresponding basic vectors as
   |\varphi_j\rangle=\sum_m\lambda_m|m,m\rangle,
 \]
 where \(\varphi_j\) is shared by \(b_n\) and \(a_{n+1}\), and \(U\) acts on
-\((a_n,b_n)\). The remaining parent-Hamiltonian step is to pass from this
-basic-vector form to commutativity of the translated two-site terms
-\(h_i=\tau_i(P_2^\perp)\).
+\((a_n,b_n)\). The parent-Hamiltonian step passes from this basic-vector form
+to commutativity of the translated two-site terms
+\(h_i=\tau_i(P_2^\perp)\). It is completed in
+`TNLean.MPS.RFP.AppendixBCommutation` and
+`TNLean.MPS.RFP.AppendixBChainCommutation`.
 
 The declarations below separate the following mathematical statements:
 
@@ -52,21 +54,20 @@ arXiv:1606.00608 supplies the parent-commuting condition for the \(Q_{AX}\) and
 \(\widehat Q_{XB}\) below are only the common two-site coefficient-space
 representative \(q_2(\Lambda U)\), identified with \(q_2(A)\) after the
 Appendix B core-tensor comparison, before it is placed on the \(AX\) and \(XB\)
-faces. They do not by themselves construct the source projectors on
+faces. The declarations in this file do not by themselves construct the source
+projectors on
 \(\mathcal H_A\otimes\mathcal H_X\) and
 \(\mathcal H_X\otimes\mathcal H_B\), nor do they prove the lifted commutator.
 The tensor-power and physical support constructions are provided in
-`TNLean.MPS.RFP.AppendixBSupport`. The remaining step is to construct the
-orthogonal projector onto the virtual bond subspace \(\mathbb C\varphi_j\), place
-two copies on a three-site virtual chain, transport them through
-\(U^{\otimes3}\), and pass from the spectator range projector \(UU^*\) to the
-full physical identity.  This last passage must use the containment of the
-two-site support in \(\operatorname{ran}(U)^{\otimes2}\).  The complements of
-the resulting physical support projectors can then be identified with the two
-coefficient representatives.  For this reason commutativity of the translated
-idempotents is kept as an explicit hypothesis. The remaining commutator step is
-recorded in
-`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
+`TNLean.MPS.RFP.AppendixBSupport`. The orthogonal virtual bond projector, its
+two three-site placements, their transport through \(U^{\otimes3}\), and the
+passage from the spectator range projector \(UU^*\) to the full physical
+identity are proved in `TNLean.MPS.RFP.AppendixBCommutation`. Their complements
+give the local commutator, which is transported around every periodic chain with
+\(N>2\) in `TNLean.MPS.RFP.AppendixBChainCommutation`.
+Accordingly, the conditional structures below continue to take the translated
+idempotents as hypotheses; the unconditional commutator is proved separately in
+`TNLean.MPS.RFP.AppendixBChainCommutation`.
 -/
 
 open scoped Matrix BigOperators
@@ -189,29 +190,29 @@ noncomputable def HasProductPairLocalProjectors.of_commuting_localTerms
 
 /-- Conditional hypotheses for a tensor whose positive even-chain coefficients
 factor through one repeated two-site amplitude and whose nearest-neighbor parent
-terms are commuting idempotents on every finite chain of length at least two. -/
+terms are commuting idempotents on every finite chain of length greater than two. -/
 structure ProductPairBridge (A : MPSTensor d D) where
   pairAmplitude : NSiteSpace d 2
   hmpv : ∀ N, 0 < N → ∀ σ : Cfg d (2 * N),
     mpv A σ = productPairState pairAmplitude N σ
-  localProjectors : ∀ N, 2 ≤ N → HasProductPairLocalProjectors A N
+  localProjectors : ∀ N, 3 ≤ N → HasProductPairLocalProjectors A N
 
 /-- The conditional physical-pair hypotheses yield the unfolded `IsNNCPH`
 conclusion: all two-site local terms commute on every finite chain of length at
-least two.
+least three.
 
 The statement is written as the commutation equation for the translated
 two-site parent terms, which is the nearest-neighbor commutation condition in
 arXiv:1606.00608, Definition 3.9. -/
 theorem ProductPairBridge.commuting_twoSite_localTerms
-    {A : MPSTensor d D} (hBridge : ProductPairBridge A) (N : ℕ) (hN : 2 ≤ N) :
+    {A : MPSTensor d D} (hBridge : ProductPairBridge A) (N : ℕ) (hN : 3 ≤ N) :
     ∀ i j : Fin N,
       localTerm A 2 N i * localTerm A 2 N j =
         localTerm A 2 N j * localTerm A 2 N i :=
   (hBridge.localProjectors N hN).commuting_twoSite_localTerms
 
 theorem ProductPairBridge.localTerm_idempotent
-    {A : MPSTensor d D} (hBridge : ProductPairBridge A) (N : ℕ) (hN : 2 ≤ N)
+    {A : MPSTensor d D} (hBridge : ProductPairBridge A) (N : ℕ) (hN : 3 ≤ N)
     (i : Fin N) :
     localTerm A 2 N i * localTerm A 2 N i = localTerm A 2 N i :=
   (hBridge.localProjectors N hN).localTerm_idempotent i
@@ -790,24 +791,22 @@ theorem AppendixBStructuralData.mpv_eq_productPairState_one {A : MPSTensor d D}
     mpv A σ = productPairState hStruct.twoSiteAmplitude 1 σ := by
   rw [productPairState_one, hStruct.twoSiteAmplitude_eq_mpv]
 
-/-- The remaining even-chain physical-pair factorization needed after the source
+/-- The even-chain physical-pair factorization considered after the source
 basic-vector expression.
 
-For a fixed structural form, this captures the two facts that are still not
-produced by the Appendix B structural datum: the coefficient formula for
-\(U^{\otimes N}\varphi_j^{\otimes N}\) must be related to the repeated
-physical-pair two-site amplitude stated here, and the translated length-two
-parent terms on each finite chain must be shown to commute.  The latter step is
-the source \(Q_{AX},Q_{XB}\) projector construction and lifted-commutator
-argument, not a consequence of the coefficient representatives alone. -/
+For a fixed structural form, this captures the proposed identification of
+\(U^{\otimes N}\varphi_j^{\otimes N}\) with the repeated physical-pair
+two-site amplitude stated here. It also records the translated
+length-two local projectors explicitly; the Appendix B commutation results provide
+those projectors without using the physical-pair factorization. -/
 structure AppendixBProductPairExtraction {A : MPSTensor d D}
     (hStruct : AppendixBStructuralData A) where
   /-- Positive even-chain factorization through the structural two-site amplitude. -/
   hmpv : ∀ N, 0 < N → ∀ σ : Cfg d (2 * N),
     mpv A σ = productPairState hStruct.twoSiteAmplitude N σ
   /-- Local projectors realizing the nearest-neighbor parent terms for chains
-  of length at least two. -/
-  localProjectors : ∀ N, 2 ≤ N → HasProductPairLocalProjectors A N
+  of length greater than two. -/
+  localProjectors : ∀ N, 3 ≤ N → HasProductPairLocalProjectors A N
 
 /-- Construct the coefficient part of the conditional structure from the
 Appendix B core tensor.
@@ -818,7 +817,7 @@ noncomputable def AppendixBProductPairExtraction.ofCoreTensorFactorization
     {A : MPSTensor d D} {hStruct : AppendixBStructuralData A}
     (hCore : ∀ N, 0 < N → ∀ σ : Cfg d (2 * N),
       mpv hStruct.coreTensor σ = productPairState hStruct.twoSiteAmplitude N σ)
-    (hProj : ∀ N, 2 ≤ N → HasProductPairLocalProjectors A N) :
+    (hProj : ∀ N, 3 ≤ N → HasProductPairLocalProjectors A N) :
     AppendixBProductPairExtraction hStruct where
   hmpv := by
     intro N hN σ
@@ -827,7 +826,7 @@ noncomputable def AppendixBProductPairExtraction.ofCoreTensorFactorization
   localProjectors := hProj
 
 /-- Construct the conditional Appendix B extraction from the coefficient
-factorization and the \(N \ge 2\) commutation equations for the translated
+factorization and the \(N > 2\) commutation equations for the translated
 length-two parent terms.
 
 The idempotency of the local terms is supplied by `localTerm_idempotent`; the
@@ -836,7 +835,7 @@ noncomputable def AppendixBProductPairExtraction.ofCoreTensorFactorizationAndCom
     {A : MPSTensor d D} {hStruct : AppendixBStructuralData A}
     (hCore : ∀ N, 0 < N → ∀ σ : Cfg d (2 * N),
       mpv hStruct.coreTensor σ = productPairState hStruct.twoSiteAmplitude N σ)
-    (hComm : ∀ N, 2 ≤ N → ∀ i j : Fin N,
+    (hComm : ∀ N, 3 ≤ N → ∀ i j : Fin N,
       localTerm A 2 N i * localTerm A 2 N j =
         localTerm A 2 N j * localTerm A 2 N i) :
     AppendixBProductPairExtraction hStruct :=
@@ -854,10 +853,10 @@ noncomputable def AppendixBProductPairExtraction.toProductPairBridge
   localProjectors := hExtract.localProjectors
 
 /-- The conditional Appendix B hypotheses give the unfolded nearest-neighbor
-commutation statement on every finite chain of length at least two. -/
+commutation statement on every finite chain of length greater than two. -/
 theorem AppendixBProductPairExtraction.commuting_twoSite_localTerms
     {A : MPSTensor d D} {hStruct : AppendixBStructuralData A}
-    (hExtract : AppendixBProductPairExtraction hStruct) (N : ℕ) (hN : 2 ≤ N) :
+    (hExtract : AppendixBProductPairExtraction hStruct) (N : ℕ) (hN : 3 ≤ N) :
     ∀ i j : Fin N,
       localTerm A 2 N i * localTerm A 2 N j =
         localTerm A 2 N j * localTerm A 2 N i :=
@@ -870,17 +869,17 @@ commutation equation as soon as the even-chain physical-pair coefficient conditi
 and the translated two-site commutation identities are supplied for the
 resulting structural form.
 
-This theorem deliberately stops short of claiming the full Beigi-independent
-`rfp_implies_nncph`: the missing hypothesis is exactly
-`AppendixBProductPairExtraction` for the structural form produced by
-`AppendixBStructuralData.ofRFP`. -/
+The direct chain-transport theorem `rfp_implies_nncph_of_leftCanonical` in
+`TNLean.MPS.RFP.AppendixBChainCommutation` removes the extraction hypothesis
+for the commutation conclusion; the extraction remains relevant only to the
+separate physical-pair coefficient factorization. -/
 theorem commuting_twoSite_localTerms_of_rfp_of_appendixBExtraction
     (A : MPSTensor d D) [NeZero D]
     (hNT : IsNormal A) (hRFP : IsRFP A)
     (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1)
     (hExtract : AppendixBProductPairExtraction
       (AppendixBStructuralData.ofRFP A hNT hRFP hLeft))
-    (N : ℕ) (hN : 2 ≤ N) :
+    (N : ℕ) (hN : 3 ≤ N) :
     ∀ i j : Fin N,
       localTerm A 2 N i * localTerm A 2 N j =
         localTerm A 2 N j * localTerm A 2 N i :=

--- a/TNLean/MPS/RFP/CommutingBridge.lean
+++ b/TNLean/MPS/RFP/CommutingBridge.lean
@@ -195,7 +195,7 @@ structure ProductPairBridge (A : MPSTensor d D) where
   pairAmplitude : NSiteSpace d 2
   hmpv : ∀ N, 0 < N → ∀ σ : Cfg d (2 * N),
     mpv A σ = productPairState pairAmplitude N σ
-  localProjectors : ∀ N, 3 ≤ N → HasProductPairLocalProjectors A N
+  localProjectors : ∀ N, 2 < N → HasProductPairLocalProjectors A N
 
 /-- The conditional physical-pair hypotheses yield the unfolded `IsNNCPH`
 conclusion: all two-site local terms commute on every finite chain of length at
@@ -205,14 +205,14 @@ The statement is written as the commutation equation for the translated
 two-site parent terms, which is the nearest-neighbor commutation condition in
 arXiv:1606.00608, Definition 3.9. -/
 theorem ProductPairBridge.commuting_twoSite_localTerms
-    {A : MPSTensor d D} (hBridge : ProductPairBridge A) (N : ℕ) (hN : 3 ≤ N) :
+    {A : MPSTensor d D} (hBridge : ProductPairBridge A) (N : ℕ) (hN : 2 < N) :
     ∀ i j : Fin N,
       localTerm A 2 N i * localTerm A 2 N j =
         localTerm A 2 N j * localTerm A 2 N i :=
   (hBridge.localProjectors N hN).commuting_twoSite_localTerms
 
 theorem ProductPairBridge.localTerm_idempotent
-    {A : MPSTensor d D} (hBridge : ProductPairBridge A) (N : ℕ) (hN : 3 ≤ N)
+    {A : MPSTensor d D} (hBridge : ProductPairBridge A) (N : ℕ) (hN : 2 < N)
     (i : Fin N) :
     localTerm A 2 N i * localTerm A 2 N i = localTerm A 2 N i :=
   (hBridge.localProjectors N hN).localTerm_idempotent i
@@ -806,7 +806,7 @@ structure AppendixBProductPairExtraction {A : MPSTensor d D}
     mpv A σ = productPairState hStruct.twoSiteAmplitude N σ
   /-- Local projectors realizing the nearest-neighbor parent terms for chains
   of length greater than two. -/
-  localProjectors : ∀ N, 3 ≤ N → HasProductPairLocalProjectors A N
+  localProjectors : ∀ N, 2 < N → HasProductPairLocalProjectors A N
 
 /-- Construct the coefficient part of the conditional structure from the
 Appendix B core tensor.
@@ -817,7 +817,7 @@ noncomputable def AppendixBProductPairExtraction.ofCoreTensorFactorization
     {A : MPSTensor d D} {hStruct : AppendixBStructuralData A}
     (hCore : ∀ N, 0 < N → ∀ σ : Cfg d (2 * N),
       mpv hStruct.coreTensor σ = productPairState hStruct.twoSiteAmplitude N σ)
-    (hProj : ∀ N, 3 ≤ N → HasProductPairLocalProjectors A N) :
+    (hProj : ∀ N, 2 < N → HasProductPairLocalProjectors A N) :
     AppendixBProductPairExtraction hStruct where
   hmpv := by
     intro N hN σ
@@ -835,7 +835,7 @@ noncomputable def AppendixBProductPairExtraction.ofCoreTensorFactorizationAndCom
     {A : MPSTensor d D} {hStruct : AppendixBStructuralData A}
     (hCore : ∀ N, 0 < N → ∀ σ : Cfg d (2 * N),
       mpv hStruct.coreTensor σ = productPairState hStruct.twoSiteAmplitude N σ)
-    (hComm : ∀ N, 3 ≤ N → ∀ i j : Fin N,
+    (hComm : ∀ N, 2 < N → ∀ i j : Fin N,
       localTerm A 2 N i * localTerm A 2 N j =
         localTerm A 2 N j * localTerm A 2 N i) :
     AppendixBProductPairExtraction hStruct :=
@@ -856,7 +856,7 @@ noncomputable def AppendixBProductPairExtraction.toProductPairBridge
 commutation statement on every finite chain of length greater than two. -/
 theorem AppendixBProductPairExtraction.commuting_twoSite_localTerms
     {A : MPSTensor d D} {hStruct : AppendixBStructuralData A}
-    (hExtract : AppendixBProductPairExtraction hStruct) (N : ℕ) (hN : 3 ≤ N) :
+    (hExtract : AppendixBProductPairExtraction hStruct) (N : ℕ) (hN : 2 < N) :
     ∀ i j : Fin N,
       localTerm A 2 N i * localTerm A 2 N j =
         localTerm A 2 N j * localTerm A 2 N i :=
@@ -879,7 +879,7 @@ theorem commuting_twoSite_localTerms_of_rfp_of_appendixBExtraction
     (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1)
     (hExtract : AppendixBProductPairExtraction
       (AppendixBStructuralData.ofRFP A hNT hRFP hLeft))
-    (N : ℕ) (hN : 3 ≤ N) :
+    (N : ℕ) (hN : 2 < N) :
     ∀ i j : Fin N,
       localTerm A 2 N i * localTerm A 2 N j =
         localTerm A 2 N j * localTerm A 2 N i :=

--- a/blueprint/src/Packages/tn_diagrams.py
+++ b/blueprint/src/Packages/tn_diagrams.py
@@ -85,6 +85,7 @@ _DIAGRAM_ARGS: dict[str, str] = {
     "TNMPDOFusionTracePower": "",
     "TNAppendixBAdjacentBondProjectors": "",
     "TNAppendixBPhysicalSupportTransport": "",
+    "TNAppendixBChainTransport": "",
     "TNRFPKrausIsometry": "",
     "TNRFPKrausIsometryReverse": "",
     "TNRFPIsometryCanonicalForm": "",

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -924,16 +924,19 @@ the specialization $L=2$.
     \leanok
     \uses{def:is_rfp, def:is_nncph, def:normal}
     If $A$ has nonzero virtual dimension and is a normal renormalization fixed
-    point, then for every chain length $N \ge 2$ the two-site local terms
+    point, then for every chain length $N > 2$ the two-site local terms
     commute. This theorem records the commutation part of the nearest-neighbor
     source condition, not the ground-space spanning part.
     This implication is cited here from the structural characterization theorem
     for renormalization fixed points in~\cite{Cirac2016MPDO_arXiv}; the source
     proof says that RFP $\Rightarrow$ NNCPH follows from that theorem.
-    At present this implication remains an unproved hypothesis. The source
-    derivation from the basic-vector formula
-    $V^{(N)}(A_j)=U^{\otimes N}\varphi_j^{\otimes N}$ and the corresponding
-    two-site projectors remains to be proved.
+    The unrestricted statement remains an unproved hypothesis.  In the
+    left-canonical gauge, the derivation from the basic-vector formula
+    $V^{(N)}(A_j)=U^{\otimes N}\varphi_j^{\otimes N}$ is proved below: the
+    corresponding two-site projectors commute on a three-site window, and the
+    commutator is transported to every periodic chain with $N>2$.  What remains
+    is removal of the additional gauge hypothesis and the separate
+    ground-space spanning equation.
 \end{theorem}
 
 \begin{theorem}[Renormalization fixed points satisfy the NNCPH commutation and zero-energy equations]%
@@ -943,7 +946,7 @@ the specialization $L=2$.
     \leanok
     \uses{thm:rfp_implies_nncph, def:is_nncph_ground_state}
     If $A$ has nonzero virtual dimension and is a normal renormalization fixed
-    point, then for every chain length $N \ge 2$ the MPS vector $V^{(N)}(A)$
+    point, then for every chain length $N > 2$ the MPS vector $V^{(N)}(A)$
     satisfies the commutation and zero-energy equations for nearest-neighbor
     local terms:
     \[
@@ -1473,6 +1476,111 @@ the specialization $L=2$.
     of $P_2$ commute, their complementary lifts commute as well.
 \end{proof}
 
+\begin{theorem}[Transport of the three-site commutator]
+    \label{thm:three_site_commutator_chain_transport}
+    \lean{MPSTensor.cyclicRestrictₗ_three_localTerm_left}
+    \lean{MPSTensor.cyclicRestrictₗ_three_localTerm_right}
+    \lean{MPSTensor.localTerm_adjacent_twoSite_commute_of_threeSite_zero_one_commute}
+    \leanok
+    \uses{def:local_term_parent}
+    Suppose the first two length-two parent interactions commute on the
+    three-site chain:
+    \[
+        h_0^{(3)}h_1^{(3)}=h_1^{(3)}h_0^{(3)}.
+    \]
+    Then, for every $N>2$ and every $i\in\mathbb Z/N\mathbb Z$, the two
+    adjacent translates commute:
+    \[
+        h_i^{(N)}h_{i+1}^{(N)}=h_{i+1}^{(N)}h_i^{(N)}.
+    \]
+    For each exterior configuration $\tau$, let $R_{i,\tau}^{(3)}$ restrict to
+    the cyclic three-site window beginning at $i$.  It intertwines the two
+    $N$-site terms with the two three-site terms:
+    \[
+        R_{i,\tau}^{(3)}h_i^{(N)}=h_0^{(3)}R_{i,\tau}^{(3)},\qquad
+        R_{i,\tau}^{(3)}h_{i+1}^{(N)}=h_1^{(3)}R_{i,\tau}^{(3)}.
+    \]
+    Diagrammatically, the same local $A\!X\!B$ calculation is placed at every
+    cyclic translate:
+    \[
+        \TNAppendixBChainTransport
+    \]
+    The hypothesis $N>2$ is essential to this transport: at $N=2$ the two
+    cyclic windows contain the same sites in opposite orders.  This case
+    is not part of \cite[Theorem~3.10]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:local_term_parent}
+    Restrict an $N$-site vector to the cyclic window $(i,i+1,i+2)$ while
+    holding all other physical indices fixed.  Window extraction and
+    replacement identify the two restricted local terms with
+    $h_0^{(3)}$ and $h_1^{(3)}$.  Apply the three-site commutator to the
+    restricted vector and then evaluate at the original three-site
+    configuration.  Replacing a window by the values extracted from that
+    configuration recovers the original $N$-site configuration.
+\end{proof}
+
+\begin{theorem}[Appendix B adjacent commutation on periodic chains]
+    \label{thm:appendixB_adjacent_chain_commutation}
+    \lean{MPSTensor.AppendixBStructuralData.adjacent_twoSite_localTerms_commute}
+    \leanok
+    \uses{thm:appendixB_overlapping_two_site_commutation,
+        thm:three_site_commutator_chain_transport}
+    For every Appendix~B structural datum and every periodic chain of length
+    $N>2$, the adjacent translated length-two parent interactions commute.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Theorem~\ref{thm:appendixB_overlapping_two_site_commutation} gives the
+    three-site commutator, and
+    Theorem~\ref{thm:three_site_commutator_chain_transport} places it at every
+    adjacent pair on the periodic chain.
+\end{proof}
+
+\begin{definition}[Appendix B local-projector family]
+    \label{def:appendixB_chain_local_projectors}
+    \lean{MPSTensor.AppendixBStructuralData.hasProductPairLocalProjectors}
+    \leanok
+    \uses{thm:appendixB_adjacent_chain_commutation,
+        lem:nncph_from_adjacent_two_site_commutation}
+    For an Appendix~B structural datum and a periodic chain of length $N>2$,
+    set
+    \[
+        p_i=h_i^{(N)},\qquad i\in\mathbb Z/N\mathbb Z,
+    \]
+    where $h_i^{(N)}$ is the translated length-two parent interaction.  These
+    maps are idempotent and commute pairwise: adjacent commutation follows from
+    Theorem~\ref{thm:appendixB_adjacent_chain_commutation}, while disjoint
+    length-two interactions commute by locality.
+\end{definition}
+
+\begin{theorem}[Left-canonical RFP commutation and zero energy]
+    \label{thm:left_canonical_rfp_chain_commutation}
+    \lean{MPSTensor.AppendixBStructuralData.isNNCPH}
+    \lean{MPSTensor.rfp_implies_nncph_of_leftCanonical}
+    \lean{MPSTensor.rfp_implies_nncph_ground_state_of_leftCanonical}
+    \leanok
+    \uses{def:appendixB_chain_local_projectors}
+    A normal left-canonical renormalization fixed-point tensor has pairwise
+    commuting length-two parent interactions on every periodic chain of length
+    $N>2$, and its periodic matrix product vector is annihilated by every such
+    interaction.  The removal of the left-canonical hypothesis and the
+    ground-space spanning equation in
+    \cite[Definition~3.9]{Cirac2016MPDO_arXiv} remain separate.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The Appendix~B structural theorem supplies the datum used in
+    Definition~\ref{def:appendixB_chain_local_projectors}.  Its commuting
+    idempotents are precisely the translated parent interactions.  The
+    standard frustration-free identity shows that each interaction annihilates
+    the periodic matrix product vector.
+\end{proof}
+
 \begin{lemma}[Appendix B overlapping condition from the lifted commutator]
     \label{lem:appendixB_overlapping_condition_from_lift_commutator}
     \lean{MPSTensor.AppendixBStructuralData.hasOverlappingTwoSiteCommutation_of_commute_lifts}
@@ -1793,32 +1901,31 @@ the specialization $L=2$.
     the even-chain physical-pair factorization above.
     On a three-site chain, the two adjacent length-two local terms are the
     \(AX\) and \(XB\) actions of the canonical two-site parent interaction.
-    Appendix~B supplies the basic-vector expression, while Appendix~D.2 supplies
-    the parent-commuting condition for the source projectors. The
-    coefficient-representative identification above does not prove the
-    overlapping commutation relation
+    Theorem~\ref{thm:appendixB_overlapping_two_site_commutation} constructs the
+    adjacent physical support projectors from the basic-vector expression and
+    proves the overlapping relation
     \[
         (\widehat Q_{AX})_{AX}(\widehat Q_{XB})_{XB}
         =
         (\widehat Q_{XB})_{XB}(\widehat Q_{AX})_{AX}.
     \]
-    Nor does it construct the source projectors \(Q_{AX},Q_{XB}\) on the
-    two overlapping tensor factors, or their lifted actions on the tripartite
-    space. For the all-chain statement, the remaining local condition is the
-    following commutation equation: for every chain length $N\geq2$ and every
+    Theorem~\ref{thm:three_site_commutator_chain_transport} transports this
+    identity around a periodic chain.  Consequently, for every $N>2$ and every
     pair of sites $i,j\in\mathbb Z/N\mathbb Z$,
     \[
         h_i(A,2)h_j(A,2)=h_j(A,2)h_i(A,2).
     \]
-    The idempotency equation $h_i(A,2)^2=h_i(A,2)$ is already
-    Lemma~\ref{lem:local_term_idempotent}.
-    The overlapping commutation theorem and the justification of any passage
-    from the source coefficients to this even-chain factorization are the
-    remaining obligations before the conditional theorem can be applied; once
-    they are proved, the local terms commute. Together with
-    Lemma~\ref{lem:parent_hamiltonian_ff}, the same factorization also gives
-    the zero-energy equation for $V^{(N)}(A)$ when $N\geq2$, still without
-    asserting the source ground-space spanning condition.
+    Definition~\ref{def:appendixB_chain_local_projectors} collects these maps
+    into a commuting idempotent family; idempotency is
+    Lemma~\ref{lem:local_term_idempotent}.  Together with
+    Lemma~\ref{lem:parent_hamiltonian_ff}, this gives the zero-energy equation
+    for $V^{(N)}(A)$.  Neither conclusion requires the even-chain
+    physical-pair factorization displayed above.  That factorization remains a
+    separate conditional coefficient statement.  The full source implication
+    additionally requires removal of the left-canonical hypothesis and the
+    ground-space spanning equation.  The kernel-intersection characterization
+    of the projectors in \cite[Definition~D.2]{Cirac2016MPDO_arXiv} also
+    remains separate.
 \end{remark}
 
 \begin{theorem}[Even-chain factorization and ground-space spanning give all-chain NNCPH]%

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -1564,7 +1564,8 @@ the specialization $L=2$.
     \lean{MPSTensor.rfp_implies_nncph_ground_state_of_leftCanonical}
     \leanok
     \uses{def:appendixB_chain_local_projectors}
-    A normal left-canonical renormalization fixed-point tensor has pairwise
+    A normal left-canonical renormalization fixed-point tensor of nonzero
+    virtual dimension has pairwise
     commuting length-two parent interactions on every periodic chain of length
     $N>2$, and its periodic matrix product vector is annihilated by every such
     interaction.  The removal of the left-canonical hypothesis and the

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -1642,6 +1642,35 @@
     \end{tikzpicture}%
 }
 
+% Cyclic transport of the local three-site Appendix B commutator.  The left
+% panel shows one three-site window inside an N-site ring; the right panel is
+% the source AXB window with its two overlapping length-two interactions.
+\newcommand{\TNAppendixBChainTransport}{%
+    \begin{tikzpicture}[tn picture, scale=0.92]
+        \foreach \a/\name in {150/ctA,90/ctX,30/ctB,-30/ctC,-90/ctD,-150/ctE} {
+            \node[circle, fill=black, inner sep=1.6pt] (\name)
+                at ({1.34*cos(\a)},{1.02*sin(\a)}) {};
+        }
+        \draw[tn leg] (ctA) -- (ctX) -- (ctB) -- (ctC) -- (ctD) -- (ctE) -- (ctA);
+        \draw[red, line width=2.2pt] (ctA) -- (ctX);
+        \draw[blue, line width=2.2pt] (ctX) -- (ctB);
+        \node[red, anchor=east] at ($(ctA)+(-0.34,0.18)$) {$h_i$};
+        \node[blue, anchor=west] at ($(ctB)+(0.34,0.18)$) {$h_{i+1}$};
+        \node at (0,-1.46) {$N>2$};
+        \draw[->, line width=0.7pt] (1.85,0) -- (2.75,0)
+            node[midway, above] {$R_{i,\tau}^{(3)}$};
+        \foreach \x/\name/\lab in {3.35/ctLA/A,4.55/ctLX/X,5.75/ctLB/B} {
+            \node[circle, fill=black, inner sep=1.6pt] (\name) at (\x,0) {};
+            \node at (\x,0.38) {$\lab$};
+        }
+        \draw[tn leg] (ctLA) -- (ctLX) -- (ctLB);
+        \draw[red, line width=1.0pt] ($(ctLA)+(0,-0.30)$) --
+            node[below] {$h_0^{(3)}$} ($(ctLX)+(0,-0.30)$);
+        \draw[blue, line width=1.0pt] ($(ctLX)+(0,-0.78)$) --
+            node[below] {$h_1^{(3)}$} ($(ctLB)+(0,-0.78)$);
+    \end{tikzpicture}%
+}
+
 \newcommand{\TNRFPKrausIsometry}{%
     \begin{tikzpicture}[tn picture]
         \TN@tensordot{rfkA}{(0,0)}

--- a/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
+++ b/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
@@ -31,7 +31,7 @@ name: TNMPSInverseContraction TNBNTDecomposition TNMPDOZCLIdempotence TNMPDOFixe
 name: TNMPDOBNTFusionIdentity TNMPDOUnweightedZipperReconstruction TNMPDOFusionTracePower TNMPDOFixedFinalComparisonUnitary TNMPDOFourfoldBondReassociationPentagon TNMPDOPrintedFMove
 {{ obj.tn_svg_html }}
 
-name: TNAppendixBAdjacentBondProjectors TNAppendixBPhysicalSupportTransport
+name: TNAppendixBAdjacentBondProjectors TNAppendixBPhysicalSupportTransport TNAppendixBChainTransport
 {{ obj.tn_svg_html }}
 
 name: TNRFPKrausIsometry TNRFPKrausIsometryReverse TNRFPIsometryCanonicalForm

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -27,8 +27,9 @@ conditions are equivalent:\footnote{Local source:
   \forall N>2,\; |V^{(N)}(A)\rangle
   \text{ is a ground state of a NNCPH}.
 \end{align}
-The formal implication below is stated for $N\ge2$; it therefore includes the
-extra endpoint $N=2$.
+The formal implications below use the same range $N>2$. No claim is made for
+$N=2$, where the two periodic length-two windows traverse the same sites in
+opposite orders.
 The preceding definition constructs
 \begin{align}
   H_L^{(N)}=\sum_{j=0}^{N-1}\tau_j(P_L^\perp)
@@ -159,32 +160,34 @@ The coefficient-space representatives
 \leanid{MPSTensor.AppendixBStructuralData.appendixBQXBOnCoeffSpace} are now identified with
 the canonical two-site parent interaction \(q_2(A)\) before placement on the
 \(AX\) and \(XB\) faces.  They should not be read as the source tripartite
-projectors themselves.  A supplied lifted commutator for these representatives
-has been transported to the first two translated three-site parent terms.  The
-remaining local step begins by constructing the orthogonal projector onto the
-one-bond virtual subspace \(\mathbb C\varphi\), which is distinct from the
-physical projector \(P_2\) above.  Two copies must be placed on the adjacent
-virtual bonds of a three-site chain and proved to commute.  Their actions must
-then be transported through \(U^{\otimes3}\) on the isometry range and extended
-to the full physical \(AX\) and \(XB\) support projectors.  Since \(U\) need not
-be surjective, direct transport has the spectator range projector \(R=UU^*\) in
-place of the full identity.  The spectator identity must be decomposed as
-\(R+(1-R)\), and the containment \(P_2\leq R\otimes R\) must be used to show
-that the cross-products involving \(1-R\) vanish.  Taking orthogonal
-complements can then identify the physical projectors with the two coefficient
-representatives above and give their lifted commutator.  One must finally
-extend the local transport to the all-chain family of two-site parent
-projectors.  On
-the coefficient side, the source statement is the basic-vector formula
-\(|V^{(L)}(A_j)\rangle=U^{\otimes L}|\varphi_j\rangle^{\otimes L}\), where
-\(\varphi_j\) is shared between neighboring virtual spins.  The even-chain
-physical-pair factorization is a separate conditional statement and should not
-be read as the source formula itself.
+projectors themselves.  The one-bond virtual projector and its two adjacent
+placements are now constructed in
+\leanid{MPSTensor.AppendixBStructuralData.virtualBondProjection},
+\leanid{MPSTensor.AppendixBStructuralData.leftVirtualBondProjection}, and
+\leanid{MPSTensor.AppendixBStructuralData.rightVirtualBondProjection}. Their
+commutation is transported through \(U^{\otimes3}\) to the two adjacent physical
+support projectors, giving
+\leanid{MPSTensor.AppendixBStructuralData.}\hspace{0pt}
+\leanid{twoSiteBasicSupportProjection_commute_lifts} and hence the
+unconditional coefficient-space relation
+\leanid{MPSTensor.AppendixBStructuralData.hasOverlappingTwoSiteCommutation}.
+The cyclic three-site restriction transports this commutator to every adjacent
+pair on every chain with \(N>2\), as recorded by
+\leanid{MPSTensor.localTerm_adjacent_twoSite_commute_of_threeSite_zero_one_commute}
+and
+\leanid{MPSTensor.AppendixBStructuralData.adjacent_twoSite_localTerms_commute}.
+The resulting commuting projector family is
+\leanid{MPSTensor.AppendixBStructuralData.hasProductPairLocalProjectors}.
+Consequently the forward commutation and zero-energy statements are proved for
+normal left-canonical RFP tensors by
+\leanid{MPSTensor.rfp_implies_nncph_of_leftCanonical} and
+\leanid{MPSTensor.rfp_implies_nncph_ground_state_of_leftCanonical}.
 The reverse theorem now consumes both the explicit BNT relation
 \leanid{MPSTensor.IsBNT} and the named all-chain condition
 \leanid{MPSTensor.HasNNCPHGroundSpaces}, but the implication still depends on
-the axiom \leanid{Axioms.beigi_nncph_to_rfp}. The RFP-to-NNCPH direction still
-depends on \leanid{Axioms.rfp_to_nncph_commute}.
+the axiom \leanid{Axioms.beigi_nncph_to_rfp}. The general RFP-to-NNCPH theorem
+still uses \leanid{Axioms.rfp_to_nncph_commute}, but its left-canonical
+specialization no longer does.
 
 \section{Elimination plan}
 
@@ -212,15 +215,14 @@ physical isometric embedding and all tensor powers with explicit left
 inverses, the two-site bond insertion, the equality of its physical image with
 \(G_2(A_{\mathrm{core}})\), its orthogonal support projector, the three-site
 \(AX/XB\) support maps, and the coefficient form of
-\(U^{\otimes L}\varphi_j^{\otimes L}\).  It still lacks the orthogonal
-projector onto \(\mathbb C\varphi_j\), its two adjacent placements on a
-three-site virtual chain, the spectator-complement passage from \(UU^*\) to the
-physical identity, and the resulting lifted commutator, the local-projector
-hypotheses for all chains of length at least two, and a
-justified relation between the source formula and the even-chain physical-pair
-factorization used by the conditional theorem.
-The axiom-backed theorem still supplies the commutation direction used by the
-unconditional statements.
+\(U^{\otimes L}\varphi_j^{\otimes L}\), the adjacent virtual and physical
+projectors, their three-site commutator, and its transport to every periodic
+chain with \(N>2\). The remaining forward obligation is to transport the
+proved left-canonical statement to the full canonical-form scope without an
+extra hypothesis. The even-chain physical-pair factorization remains a
+separate conditional construction and is not needed for the proved chain
+commutator. The full source implication also still requires the ground-space
+spanning clause.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
+++ b/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
@@ -121,41 +121,33 @@ representatives are
 \leanid{MPSTensor.AppendixBStructuralData.appendixBQAXOnCoeffSpace} and
 \leanid{MPSTensor.AppendixBStructuralData.appendixBQXBOnCoeffSpace}; both are identified
 with the canonical two-site parent interaction \(q_2(A)\) before placement on
-the \(AX\) and \(XB\) faces.  These representatives are not yet the source
+the \(AX\) and \(XB\) faces. These representatives are not yet the source
 orthogonal projectors \(Q_{AX}\) and \(Q_{XB}\) on
 \(\mathcal H_A\otimes\mathcal H_X\) and
-\(\mathcal H_X\otimes\mathcal H_B\).  A supplied lifted commutator or supplied
-Definition~D.2 datum for the representatives is transported to the corresponding
-three-site translated parent terms by
-\leanid{MPSTensor.AppendixBStructuralData.localTerm_two_three_zero_one_commute_of_commute_lifts}
-and
-\leanid{MPSTensor.AppendixBStructuralData.localTerm_two_three_zero_one_commute_of_appendixD2}.
+\(\mathcal H_X\otimes\mathcal H_B\). Their lifted commutator is now proved
+from the adjacent virtual-bond projectors and their isometric transport, as
+recorded by
+\leanid{MPSTensor.AppendixBStructuralData.}\hspace{0pt}
+\leanid{twoSiteBasicSupportProjection_commute_lifts} and
+\leanid{MPSTensor.AppendixBStructuralData.hasOverlappingTwoSiteCommutation}.
+The corresponding adjacent parent terms commute on every periodic chain with
+\(N>2\), by
+\leanid{MPSTensor.AppendixBStructuralData.adjacent_twoSite_localTerms_commute}.
 
 \section{Elimination plan}
 
-A source-faithful continuation should first construct the orthogonal projector
-onto the one-bond virtual subspace \(\mathbb C\varphi\), where
-\(\varphi=\sum_m\lambda_m\lvert m,m\rangle\).  This is distinct from the
-physical two-site support projector constructed above.  Two copies of the
-virtual projector must then be placed on the adjacent bonds of a three-site
-virtual chain.  They commute because they act on distinct bond factors.  Their
-actions must be transported through \(U^{\otimes3}\) on the isometry range and
-then extended to the full physical \(AX\) and \(XB\) support projectors.  Here
-\(U\) is only an isometry.  If \(R=UU^*\), direct transport gives
-\(P_{2,AX}\otimes R_B\) and \(R_A\otimes P_{2,XB}\), rather than the full lifts
-with spectator identity.
-One must decompose each spectator identity as \(R+(1-R)\) and use
-\(P_2\leq R\otimes R\) to show that every cross-product involving a spectator
-complement vanishes.  Passing to orthogonal complements should then identify
-the resulting projectors with the two lifted copies of \(q_2(A)\), prove the
-lifted commutator, and derive the idempotent-product declaration above as a
-lemma, with \(P_K=P_{AXB}\).
-
-After that source-level version is available, the blueprint entry for the source
-parent commuting Hamiltonian condition should point to that statement.  The
-current idempotent-product declaration can remain as the
-algebraic lemma used in the backward direction of Proposition~D.3.  The work is
-tracked by \ghissue{3373}, \ghissue{2633}, and \ghissue{190}.
+The Appendix~B commutator needed for the forward RFP-to-NNCPH argument is now
+proved. What remains for a full formalization of Definition~D.2 is different:
+construct the source projectors \(Q_{AX}\) and \(Q_{XB}\) as orthogonal
+projectors on the stated tensor factors and prove the kernel-intersection
+identity
+\[
+  K_{AXB}=\ker((Q_{AX})_{AX})\cap\ker((Q_{XB})_{XB}).
+\]
+The current coefficient-space theorem supplies the commutator part but does not
+identify that tripartite subspace. The algebraic idempotent-product declaration
+remains the lemma used in the backward direction of Proposition~D.3. The work
+is tracked by \ghissue{3373}, \ghissue{2633}, and \ghissue{190}.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

- transport the Appendix B three-site commutator to every adjacent pair of translated length-two parent interactions on a cyclic chain of length `N > 2`
- package the resulting commuting local-projector family and the left-canonical RFP zero-energy consequence
- align source-facing chain bounds with the paper and update the blueprint, gap notes, and source-like TikZ diagram

## Source boundary

The construction follows CPSV16, Appendix B and the pure-state NNCPH discussion (arXiv:1606.00608, lines 517–524, 534–540, and 543–578). The restriction `N > 2` is explicit: at `N = 2`, the two cyclic windows use the same physical sites in opposite orders, which is not the source argument.

This PR proves the all-chain commutation equations and zero energy for a normal left-canonical RFP tensor. It does not claim the remaining canonical-gauge removal or the source ground-space spanning equation; those remain recorded in the paper-gap notes and tracker.

Advances #3373 and #2633.

## Validation

- `lake build`
- `leanblueprint web`
- `leanblueprint checkdecls`
- `leanblueprint pdf`
- visual inspection of the generated blueprint pages 224–225

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Substantial new formal proofs on the parent-Hamiltonian / RFP critical path and a breaking tightening of chain-length hypotheses (`2 < N`); scope is mathematical correctness rather than runtime security.
> 
> **Overview**
> Proves the **RFP ⇒ NNCPH commutation** step internally for **normal left-canonical** tensors by chaining the existing Appendix B three-site projector commutator with new **cyclic window transport** on periodic chains, without `Axioms.rfp_to_nncph_commute`. New modules `LocalSupportTransport` and `AppendixBChainCommutation` add restriction intertwiners and capstones such as `rfp_implies_nncph_of_leftCanonical` / ground-state variants; the unrestricted `rfp_implies_nncph` still goes through the axiom.
> 
> **Chain-length alignment:** NNCPH / axiom / bridge hypotheses move from **`N ≥ 2` to `N > 2`**, matching CPSV16 Theorem 3.10 (explicitly excluding the `N = 2` cyclic-window pathology). Related `ProductPairBridge`, `AppendixBProductPairExtraction`, and martingale overlap constructors are updated accordingly.
> 
> **Docs & blueprint:** Gap notes and the parent-Hamiltonian chapter now record that local commutator + transport are proved and that remaining work is **canonical-gauge removal** and **ground-space spanning**; adds `TNAppendixBChainTransport` diagram wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe79266aebd2182882294d51a1be93d9d0b3444d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->