### PR TITLE
feat(MPS/MPDO): recover representative insertions

### DIFF
--- a/TNLean/MPS/MPDO/PostBlockedRepresentativeSpan.lean
+++ b/TNLean/MPS/MPDO/PostBlockedRepresentativeSpan.lean
@@ -8,6 +8,7 @@ import TNLean.MPS.FundamentalTheorem.SectorBNT.Basic
 import TNLean.MPS.FundamentalTheorem.SectorBNT.Blocking
 import TNLean.MPS.MPDO.BiCFDerivation.BNTDirectSum
 import TNLean.MPS.MPDO.BiCFDerivation.Blocking
+import TNLean.MPS.MPDO.FirstSiteBlocking
 import TNLean.MPS.MPDO.RepresentativeGroupedLemmaL
 import TNLean.Wielandt.SpanGrowth.CumulativeSpan
 
@@ -231,5 +232,65 @@ theorem insertedTensor_basis_eq_of_sameMPV₂_firstSiteActionAgree_of_basis_inje
     ∀ j, insertedTensor Y (P.basis j) = insertedTensor Z (P.basis j) := by
   exact hCF.insertedTensor_basis_eq_of_firstSiteActionAgree_of_basis_injective
     hInj (hAct.of_sameMPV hAP)
+
+/-- Representative-grouped Lemma L before physical blocking.
+
+Suppose that every representative has full word span at one common positive
+length `L`.  Blocking `L + 1` sites makes every representative injective,
+while leaving a length-`L` tail after the first-site insertion.  Representative
+separation on the blocked tensors gives equality of the induced insertions;
+the length-`L` word span then recovers equality of the original insertions.
+
+This is the blocking step of arXiv:1606.00608, lines 318--344, composed with
+Appendix C.3, Lemma L, lines 1835--1858.
+
+**Scope restriction (common block-injectivity length):** The common positive
+length is an explicit hypothesis; its derivation from the canonical-form
+construction remains open.  See
+`docs/paper-gaps/cpgsv17_bicf_block_separation.tex`. -/
+theorem insertedTensor_basis_eq_of_firstSiteActionAgree_of_common_blockInjective
+    (hCF : IsBNTCanonicalForm P) (L : ℕ) (hL : 0 < L)
+    (hInj : ∀ j, IsNBlkInjective (P.basis j) L)
+    {Y Z : Matrix (Fin d) (Fin d) ℂ}
+    (hAct : FirstSiteActionAgree P.toTensor Y Z) :
+    ∀ j, insertedTensor Y (P.basis j) = insertedTensor Z (P.basis j) := by
+  have hInjSucc : ∀ j, IsInjective (blockTensor (P.basis j) (L + 1)) := by
+    intro j
+    exact (isNBlkInjective_iff_blockTensor_isInjective (P.basis j) (L + 1)).1
+      (isNBlkInjective_succ_of_isNBlkInjective (P.basis j) hL (hInj j))
+  have hSpan := hCF.eventuallyRepresentativeWordTupleSpan_blockTensor
+    (L + 1) (by omega) hInjSucc
+  have hActBlocked : FirstSiteActionAgree (P.blockTensor (L + 1)).toTensor
+      (firstSiteActionOnBlock L Y) (firstSiteActionOnBlock L Z) :=
+    (hAct.blockTensor L).of_sameMPV (P.sameMPV₂_blockTensor_toTensor (L + 1))
+  have hEq := (P.blockTensor (L + 1)).insertedTensor_basis_eq_of_firstSiteActionAgree
+    hSpan hActBlocked
+  intro j
+  apply insertedTensor_eq_of_firstSiteActionOnBlock_blockTensor_eq
+    (P.basis j) L (hInj j)
+  have hEqj := hEq j
+  change insertedTensor (firstSiteActionOnBlock L Y) (blockTensor (P.basis j) (L + 1)) =
+    insertedTensor (firstSiteActionOnBlock L Z) (blockTensor (P.basis j) (L + 1)) at hEqj
+  exact hEqj
+
+/-- Same-MPV transport of representative-grouped Lemma L before physical
+blocking.
+
+The common block-injectivity length is the input supplied by the canonical-form
+blocking step in arXiv:1606.00608, lines 318--344.  The representative
+conclusion is Appendix C.3, Lemma L, lines 1835--1858.
+
+**Scope restriction (common block-injectivity length):** This transport theorem
+inherits the explicit common-length hypothesis above.  See
+`docs/paper-gaps/cpgsv17_bicf_block_separation.tex`. -/
+theorem insertedTensor_basis_eq_of_sameMPV₂_firstSiteActionAgree_of_common_blockInjective
+    {D : ℕ} (A : MPSTensor d D) (hCF : IsBNTCanonicalForm P)
+    (L : ℕ) (hL : 0 < L) (hInj : ∀ j, IsNBlkInjective (P.basis j) L)
+    (hAP : SameMPV₂ A P.toTensor)
+    {Y Z : Matrix (Fin d) (Fin d) ℂ}
+    (hAct : FirstSiteActionAgree A Y Z) :
+    ∀ j, insertedTensor Y (P.basis j) = insertedTensor Z (P.basis j) := by
+  exact hCF.insertedTensor_basis_eq_of_firstSiteActionAgree_of_common_blockInjective
+    L hL hInj (hAct.of_sameMPV hAP)
 
 end MPSTensor.IsBNTCanonicalForm

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -373,6 +373,8 @@
     \lean{MPSTensor.pairTraceSeparatingAt_blockTensor}
     \lean{MPSTensor.IsBNTCanonicalForm.insertedTensor_basis_eq_of_firstSiteActionAgree_of_basis_injective}
     \lean{MPSTensor.IsBNTCanonicalForm.insertedTensor_basis_eq_of_sameMPV₂_firstSiteActionAgree_of_basis_injective}
+    \lean{MPSTensor.IsBNTCanonicalForm.insertedTensor_basis_eq_of_firstSiteActionAgree_of_common_blockInjective}
+    \lean{MPSTensor.IsBNTCanonicalForm.insertedTensor_basis_eq_of_sameMPV₂_firstSiteActionAgree_of_common_blockInjective}
     \leanok
     \uses{def:sector_bnt_cf, def:sector_decomposition_block_tensor,
       def:representative_word_tuple_span, thm:representative_grouped_insert_eq}
@@ -399,11 +401,24 @@
     has representative word-tuple separation at every blocked length
     $L\geq 6(g-1)+1$.
 
-    This is the conclusion after the blocking step in
-    \cite[lines~318--345]{Cirac2016MPDO_arXiv}. The hypothesis that each
-    representative is injective is precisely the post-blocking hypothesis;
-    the assertion does not transport a first-site action from the original
-    physical alphabet through the blocking map.
+    Finally, suppose there is a common $L>0$ for which every unblocked
+    representative $A_j$ is $L$-block injective.  If the first-site actions
+    of $Y,Z$ agree on the tensor represented by $P$, then
+    \[
+        YA_j=ZA_j
+        \quad (0\leq j<g).
+    \]
+    The same conclusion holds when the first-site equality is given for any
+    tensor with the same complete MPV family.  This composes the blocking
+    conclusion of \cite[lines~318--345]{Cirac2016MPDO_arXiv} with
+    Appendix~C.3, Lemma~L
+    \cite[lines~1835--1858]{Cirac2016MPDO_arXiv}.
+
+    \textbf{Scope restriction (common block-injectivity length).}  The last
+    assertion takes the common positive length as an explicit hypothesis.
+    Deriving its existence from the normal-representative output of the
+    canonical-form construction remains separate; see
+    \path{docs/paper-gaps/cpgsv17_bicf_block_separation.tex}.
 \end{theorem}
 
 \begin{proof}
@@ -440,6 +455,17 @@
     $6p$ transports this to pair trace separation for the $p$-blocked
     representatives. The preceding selector argument then applies verbatim
     to $P^{[p]}$.
+
+    For the final assertion, start from a common positive length $L$ at which
+    every representative is block injective and block $L+1$ sites.  Injectivity
+    propagates from length $L$ to length $L+1$, so the blocked representatives
+    are injective.  Act on the first letter of each physical block and apply
+    the blocked representative separation followed by the
+    representative-grouped Lemma~L.  This gives equality of the two induced
+    insertions on every blocked representative.  The remaining $L$ letters
+    of the first block form a spanning family, so
+    Lemma~\ref{lem:first_site_action_physical_blocking} recovers
+    $YA_j=ZA_j$ before blocking.
 \end{proof}
 
 \begin{lemma}[Blockwise equality from agreement on the MPV family]

--- a/docs/paper-gaps/cpgsv17_bicf_block_separation.tex
+++ b/docs/paper-gaps/cpgsv17_bicf_block_separation.tex
@@ -192,17 +192,24 @@ to pair separation for the blocked representatives at length $6$.  It follows
 that $P^{[p]}$ has simultaneous representative word-tuple span at every
 blocked length at least $6(g-1)+1$.
 
-It remains to compose this statement with the first-site transport.  One
-chooses a common positive $L$ for which every normal representative is
-$L$-block injective and uses $p=L+1$; positive-length propagation makes every
-$A_j^{[L+1]}$ injective.  The original length-$L$ span then recovers equality
-of the unblocked insertions from equality of the blocked insertions.  This
-length shift is essential: recovery from a physical block of length $L+1$
-uses the span of its length-$L$ tail.  The flattened
-\texttt{HorizontalCFData} formulation must then be replaced, or related
-explicitly, by this representative-indexed statement.  The older per-copy
-\texttt{biCF} theorem remains a correct restricted result, but it is no longer
-the intended route to Lemma L.
+This statement has now been composed with the first-site transport under an
+explicit common block-injectivity hypothesis.  Given a common positive $L$
+for which every representative is $L$-block injective, use $p=L+1$;
+positive-length propagation makes every $A_j^{[L+1]}$ injective.  Blocked
+representative separation and the representative-grouped Lemma L give equality
+of the induced insertions on every $A_j^{[L+1]}$.  The original length-$L$
+span then recovers equality of the unblocked insertions.  This length shift is
+essential: recovery from a physical block of length $L+1$ uses the span of its
+length-$L$ tail.
+
+Two tasks remain for the unrestricted source application.  First, the
+canonical-form construction must supply the common positive block-injectivity
+length from the normality of its minimal representatives, rather than taking
+that length as an explicit hypothesis.  Second, the flattened
+\texttt{HorizontalCFData} formulation must be replaced, or related explicitly,
+by this representative-indexed statement.  The older per-copy \texttt{biCF}
+theorem remains a correct restricted result, but it is no longer the intended
+route to Lemma L.
 
 Separately, the numerical bound in the full block-injectivity proposition still
 requires the David2006 argument: from minimality of the basis of normal tensors


### PR DESCRIPTION
## Summary

- Compose first-site physical blocking with representative separation on the blocked BNT representatives.
- Recover equality of the original representative insertions from the common length-L word span.
- Add the same-MPV transport form and update the blueprint and paper-gap account.

## Mathematical source

- arXiv:1606.00608, lines 318--344: blocking and block injectivity.
- arXiv:1606.00608, Appendix C.3, Lemma L, lines 1835--1858: representative-grouped first-site conclusion.
- Paper-gap record: docs/paper-gaps/cpgsv17_bicf_block_separation.tex.

The new theorem keeps the common positive block-injectivity length as an explicit hypothesis. It does not claim that this length has yet been derived from the canonical-form construction; that remaining step is recorded in the paper-gap note.

## Verification

- lake build
- lake build TNLean.MPS.MPDO.PostBlockedRepresentativeSpan
- python3 scripts/blueprint_lean_sync.py --root . --ci
- python3 scripts/check_reader_facing_prose.py --root . --diff-base HEAD~1 --ci
- chktex on the two changed TeX files
- Axiom audit: both new theorems use only propext, Classical.choice, and Quot.sound
- No new sorry, axiom, or proof bypass

The lower-level declaration checker retains two pre-existing root-import omissions for AppendixBStructuralData declarations; neither declaration nor its blueprint entry is changed here.

Progress toward #3713.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive formal proofs and documentation; no auth, runtime, or data paths. Remaining mathematical gaps are explicitly scoped as hypotheses, not silently closed.
> 
> **Overview**
> Adds **representative-grouped Lemma L for unblocked BNT tensors** when every minimal representative shares a common positive **L-block-injectivity** length: block **L+1** sites, run existing post-blocking representative separation, then use **first-site physical blocking** (`FirstSiteBlocking`) to lift equality from blocked insertions back to **YA_j = ZA_j** on the original representatives. A **same-MPV₂** transport variant mirrors the already-blocked case.
> 
> The blueprint theorem **Representative separation after injective blocking** gains this final assertion, its proof sketch, and `\lean` links; the paper-gap note **cpgsv17_bicf_block_separation** now records that composition as done under the explicit common-length hypothesis, with deriving that length from canonical-form construction still open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 172575b4a8f703868b73350155d6a020e09f7393. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->