### PR TITLE
feat(MPS/MPDO): define fourfold zipper fusion data

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -463,6 +463,7 @@ import TNLean.MPS.MPDO.BNTTripleFusionSeparation
 import TNLean.MPS.MPDO.BNTFixedFinalUnitarity
 import TNLean.MPS.MPDO.CompleteZipperFusion
 import TNLean.MPS.MPDO.CompleteZipperFusionInverse
+import TNLean.MPS.MPDO.CompleteZipperFusionFourfold
 import TNLean.MPS.MPDO.CommutingForm
 import TNLean.MPS.MPDO.CommutingFormBridge
 import TNLean.MPS.MPDO.BlockedRFPConstruction

--- a/TNLean/MPS/MPDO/CompleteZipperFusionFourfold.lean
+++ b/TNLean/MPS/MPDO/CompleteZipperFusionFourfold.lean
@@ -1,0 +1,367 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.CompleteZipperFusionInverse
+
+/-!
+# Fourfold fusion trees for complete zipper data
+
+The five parenthesizations of four MPO blocks give five multiplicity spaces at a fixed final
+label.  Their coordinates are the fusion labels and multiplicity indices printed in the pentagon
+equation of arXiv:1511.08090.  This file also defines the corresponding fourfold fusion maps and
+the five lifted, printed-orientation `F`-matrices along the associahedron.
+
+These are categorical fusion multiplicities from `CompleteZipperFusionFamily`; they are not the
+positive-diagonal weighted coordinates of `BNTFusionIsometryFamily`.
+
+**Local fix (equation `pentagoneq`):** The source prints the entries in equation
+`pentagoneq` with the opposite upper/lower placement from equation `Fmove`.  The forward edge
+matrices below follow `Fmove`: rows are right-tree coordinates and columns are left-tree
+coordinates.  The literal index placement in `pentagoneq` therefore belongs to the inverse edge
+matrices.  This correction is documented in
+`docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`.
+
+No pentagon equality is asserted in this file.  Its proof must identify the two composites with
+the same fourfold fusion map and cancel a fusion analysis map.
+
+## References
+
+* arXiv:1511.08090, `AnyonsPEPS.tex`, equations `Fmove` and `pentagoneq`, lines 248--299.
+* arXiv:1606.00608, Theorem 4.14 and the discussion at lines 995--999.
+-/
+
+open scoped Matrix BigOperators Kronecker
+open Matrix
+
+namespace MPOTensor.CompleteZipperFusionFamily
+
+universe u
+
+variable {Λ : Type u} [Fintype Λ] [DecidableEq Λ] {p : ℕ}
+variable (Fus : CompleteZipperFusionFamily Λ p)
+
+/-! ### The five multiplicity spaces -/
+
+/-- The bond space of four MPO blocks, associated to the leftmost parenthesization. -/
+abbrev FourfoldBond (a b c d : Λ) : Type :=
+  ((Fin (Fus.bondDim a) × Fin (Fus.bondDim b)) × Fin (Fus.bondDim c)) ×
+    Fin (Fus.bondDim d)
+
+/-- Multiplicity coordinates `(f, g, mu, nu, rho)` for `(((a b) c) d) -> e`.
+
+Source: arXiv:1511.08090, equation `pentagoneq`, lines 279--283. -/
+abbrev FourfoldLeftAssocMultiplicity (a b c d e : Λ) : Type u :=
+  (f : Λ) × (g : Λ) × Fin (Fus.fusionMultiplicity a b f) ×
+    Fin (Fus.fusionMultiplicity f c g) × Fin (Fus.fusionMultiplicity g d e)
+
+/-- Multiplicity coordinates `(h, g, sigma, lambda, rho)` for `((a (b c)) d) -> e`.
+
+Source: arXiv:1511.08090, equation `pentagoneq`, lines 279--283. -/
+abbrev FourfoldLeftInnerMultiplicity (a b c d e : Λ) : Type u :=
+  (h : Λ) × (g : Λ) × Fin (Fus.fusionMultiplicity b c h) ×
+    Fin (Fus.fusionMultiplicity a h g) × Fin (Fus.fusionMultiplicity g d e)
+
+/-- Multiplicity coordinates `(h, i, sigma, omega, kappa)` for `a ((b c) d) -> e`.
+
+Source: arXiv:1511.08090, equation `pentagoneq`, lines 279--283. -/
+abbrev FourfoldMiddleMultiplicity (a b c d e : Λ) : Type u :=
+  (h : Λ) × (i : Λ) × Fin (Fus.fusionMultiplicity b c h) ×
+    Fin (Fus.fusionMultiplicity h d i) × Fin (Fus.fusionMultiplicity a i e)
+
+/-- Multiplicity coordinates `(f, j, mu, gamma, tau)` for `(a b) (c d) -> e`.
+
+Source: arXiv:1511.08090, equation `pentagoneq`, lines 279--283. -/
+abbrev FourfoldPairMultiplicity (a b c d e : Λ) : Type u :=
+  (f : Λ) × (j : Λ) × Fin (Fus.fusionMultiplicity a b f) ×
+    Fin (Fus.fusionMultiplicity c d j) × Fin (Fus.fusionMultiplicity f j e)
+
+/-- Multiplicity coordinates `(j, i, gamma, delta, kappa)` for `a (b (c d)) -> e`.
+
+Source: arXiv:1511.08090, equation `pentagoneq`, lines 279--283. -/
+abbrev FourfoldRightAssocMultiplicity (a b c d e : Λ) : Type u :=
+  (j : Λ) × (i : Λ) × Fin (Fus.fusionMultiplicity c d j) ×
+    Fin (Fus.fusionMultiplicity b j i) × Fin (Fus.fusionMultiplicity a i e)
+
+/-! ### Fourfold fusion maps -/
+
+/-- The fusion map for `(((a b) c) d) -> e`.
+
+Its column `(f, g, mu, nu, rho, z)` is
+`(((X^f_{ab,mu} tensor 1) X^g_{fc,nu}) tensor 1) X^e_{gd,rho}`.
+
+Source: arXiv:1511.08090, line 279 and the leftmost tree in Figure `pentagon`. -/
+noncomputable def leftAssocFourfoldSynthesis (a b c d e : Λ) :
+    Matrix (Fus.FourfoldBond a b c d)
+      (Fus.FourfoldLeftAssocMultiplicity a b c d e × Fin (Fus.bondDim e)) ℂ :=
+  fun ⟨⟨⟨xa, xb⟩, xc⟩, xd⟩ ⟨⟨f, g, mu, nu, rho⟩, z⟩ =>
+    ∑ yf : Fin (Fus.bondDim f), ∑ yg : Fin (Fus.bondDim g),
+      Fus.fusionTensor a b f mu (xa, xb) yf *
+        Fus.fusionTensor f c g nu (yf, xc) yg *
+          Fus.fusionTensor g d e rho (yg, xd) z
+
+/-- The fusion map for `((a (b c)) d) -> e`.
+
+Source: arXiv:1511.08090, lines 279--283 and Figure `pentagon`. -/
+noncomputable def leftInnerFourfoldSynthesis (a b c d e : Λ) :
+    Matrix (Fus.FourfoldBond a b c d)
+      (Fus.FourfoldLeftInnerMultiplicity a b c d e × Fin (Fus.bondDim e)) ℂ :=
+  fun ⟨⟨⟨xa, xb⟩, xc⟩, xd⟩ ⟨⟨h, g, sigma, lambda, rho⟩, z⟩ =>
+    ∑ yh : Fin (Fus.bondDim h), ∑ yg : Fin (Fus.bondDim g),
+      Fus.fusionTensor b c h sigma (xb, xc) yh *
+        Fus.fusionTensor a h g lambda (xa, yh) yg *
+          Fus.fusionTensor g d e rho (yg, xd) z
+
+/-- The fusion map for `a ((b c) d) -> e`.
+
+Source: arXiv:1511.08090, lines 279--283 and Figure `pentagon`. -/
+noncomputable def middleFourfoldSynthesis (a b c d e : Λ) :
+    Matrix (Fus.FourfoldBond a b c d)
+      (Fus.FourfoldMiddleMultiplicity a b c d e × Fin (Fus.bondDim e)) ℂ :=
+  fun ⟨⟨⟨xa, xb⟩, xc⟩, xd⟩ ⟨⟨h, i, sigma, omega, kappa⟩, z⟩ =>
+    ∑ yh : Fin (Fus.bondDim h), ∑ yi : Fin (Fus.bondDim i),
+      Fus.fusionTensor b c h sigma (xb, xc) yh *
+        Fus.fusionTensor h d i omega (yh, xd) yi *
+          Fus.fusionTensor a i e kappa (xa, yi) z
+
+/-- The fusion map for `(a b) (c d) -> e`.
+
+Source: arXiv:1511.08090, lines 279--283 and Figure `pentagon`. -/
+noncomputable def pairFourfoldSynthesis (a b c d e : Λ) :
+    Matrix (Fus.FourfoldBond a b c d)
+      (Fus.FourfoldPairMultiplicity a b c d e × Fin (Fus.bondDim e)) ℂ :=
+  fun ⟨⟨⟨xa, xb⟩, xc⟩, xd⟩ ⟨⟨f, j, mu, gamma, tau⟩, z⟩ =>
+    ∑ yf : Fin (Fus.bondDim f), ∑ yj : Fin (Fus.bondDim j),
+      Fus.fusionTensor a b f mu (xa, xb) yf *
+        Fus.fusionTensor c d j gamma (xc, xd) yj *
+          Fus.fusionTensor f j e tau (yf, yj) z
+
+/-- The fusion map for `a (b (c d)) -> e`.
+
+Source: arXiv:1511.08090, line 279 and the rightmost tree in Figure `pentagon`. -/
+noncomputable def rightAssocFourfoldSynthesis (a b c d e : Λ) :
+    Matrix (Fus.FourfoldBond a b c d)
+      (Fus.FourfoldRightAssocMultiplicity a b c d e × Fin (Fus.bondDim e)) ℂ :=
+  fun ⟨⟨⟨xa, xb⟩, xc⟩, xd⟩ ⟨⟨j, i, gamma, delta, kappa⟩, z⟩ =>
+    ∑ yj : Fin (Fus.bondDim j), ∑ yi : Fin (Fus.bondDim i),
+      Fus.fusionTensor c d j gamma (xc, xd) yj *
+        Fus.fusionTensor b j i delta (xb, yj) yi *
+          Fus.fusionTensor a i e kappa (xa, yi) z
+
+/-- The analysis map for the right-associated fourfold fusion tree.
+
+Its product with `rightAssocFourfoldSynthesis` will cancel the final expansion in the proof of
+the pentagon.
+
+Source: arXiv:1511.08090, fusion left inverses at line 161 and lines 279--283. -/
+noncomputable def rightAssocFourfoldAnalysis (a b c d e : Λ) :
+    Matrix (Fus.FourfoldRightAssocMultiplicity a b c d e × Fin (Fus.bondDim e))
+      (Fus.FourfoldBond a b c d) ℂ :=
+  fun ⟨⟨j, i, gamma, delta, kappa⟩, z⟩ ⟨⟨⟨xa, xb⟩, xc⟩, xd⟩ =>
+    ∑ yi : Fin (Fus.bondDim i), ∑ yj : Fin (Fus.bondDim j),
+      Fus.fusionTensorLeftInverse a i e kappa z (xa, yi) *
+        Fus.fusionTensorLeftInverse b j i delta yi (xb, yj) *
+          Fus.fusionTensorLeftInverse c d j gamma yj (xc, xd)
+
+/-! ### Regroupings for the five printed `F`-moves -/
+
+private def leftPathFirstSourceEquiv (a b c d e : Λ) :
+    Fus.FourfoldLeftAssocMultiplicity a b c d e ≃
+      (g : Λ) × (Fus.LeftTripleMultiplicity a b c g ×
+        Fin (Fus.fusionMultiplicity g d e)) where
+  toFun
+    | ⟨f, g, mu, nu, rho⟩ => ⟨g, ⟨⟨f, mu, nu⟩, rho⟩⟩
+  invFun
+    | ⟨g, ⟨⟨f, mu, nu⟩, rho⟩⟩ => ⟨f, g, mu, nu, rho⟩
+  left_inv := by rintro ⟨f, g, mu, nu, rho⟩; rfl
+  right_inv := by rintro ⟨g, ⟨⟨f, mu, nu⟩, rho⟩⟩; rfl
+
+private def leftPathFirstTargetEquiv (a b c d e : Λ) :
+    Fus.FourfoldLeftInnerMultiplicity a b c d e ≃
+      (g : Λ) × (Fus.RightTripleMultiplicity a b c g ×
+        Fin (Fus.fusionMultiplicity g d e)) where
+  toFun
+    | ⟨h, g, sigma, lambda, rho⟩ => ⟨g, ⟨⟨h, sigma, lambda⟩, rho⟩⟩
+  invFun
+    | ⟨g, ⟨⟨h, sigma, lambda⟩, rho⟩⟩ => ⟨h, g, sigma, lambda, rho⟩
+  left_inv := by rintro ⟨h, g, sigma, lambda, rho⟩; rfl
+  right_inv := by rintro ⟨g, ⟨⟨h, sigma, lambda⟩, rho⟩⟩; rfl
+
+private def leftPathSecondSourceEquiv (a b c d e : Λ) :
+    Fus.FourfoldLeftInnerMultiplicity a b c d e ≃
+      (h : Λ) × (Fin (Fus.fusionMultiplicity b c h) ×
+        Fus.LeftTripleMultiplicity a h d e) where
+  toFun
+    | ⟨h, g, sigma, lambda, rho⟩ => ⟨h, ⟨sigma, ⟨g, lambda, rho⟩⟩⟩
+  invFun
+    | ⟨h, ⟨sigma, ⟨g, lambda, rho⟩⟩⟩ => ⟨h, g, sigma, lambda, rho⟩
+  left_inv := by rintro ⟨h, g, sigma, lambda, rho⟩; rfl
+  right_inv := by rintro ⟨h, ⟨sigma, ⟨g, lambda, rho⟩⟩⟩; rfl
+
+private def leftPathSecondTargetEquiv (a b c d e : Λ) :
+    Fus.FourfoldMiddleMultiplicity a b c d e ≃
+      (h : Λ) × (Fin (Fus.fusionMultiplicity b c h) ×
+        Fus.RightTripleMultiplicity a h d e) where
+  toFun
+    | ⟨h, i, sigma, omega, kappa⟩ => ⟨h, ⟨sigma, ⟨i, omega, kappa⟩⟩⟩
+  invFun
+    | ⟨h, ⟨sigma, ⟨i, omega, kappa⟩⟩⟩ => ⟨h, i, sigma, omega, kappa⟩
+  left_inv := by rintro ⟨h, i, sigma, omega, kappa⟩; rfl
+  right_inv := by rintro ⟨h, ⟨sigma, ⟨i, omega, kappa⟩⟩⟩; rfl
+
+private def leftPathThirdSourceEquiv (a b c d e : Λ) :
+    Fus.FourfoldMiddleMultiplicity a b c d e ≃
+      (i : Λ) × (Fus.LeftTripleMultiplicity b c d i ×
+        Fin (Fus.fusionMultiplicity a i e)) where
+  toFun
+    | ⟨h, i, sigma, omega, kappa⟩ => ⟨i, ⟨⟨h, sigma, omega⟩, kappa⟩⟩
+  invFun
+    | ⟨i, ⟨⟨h, sigma, omega⟩, kappa⟩⟩ => ⟨h, i, sigma, omega, kappa⟩
+  left_inv := by rintro ⟨h, i, sigma, omega, kappa⟩; rfl
+  right_inv := by rintro ⟨i, ⟨⟨h, sigma, omega⟩, kappa⟩⟩; rfl
+
+private def leftPathThirdTargetEquiv (a b c d e : Λ) :
+    Fus.FourfoldRightAssocMultiplicity a b c d e ≃
+      (i : Λ) × (Fus.RightTripleMultiplicity b c d i ×
+        Fin (Fus.fusionMultiplicity a i e)) where
+  toFun
+    | ⟨j, i, gamma, delta, kappa⟩ => ⟨i, ⟨⟨j, gamma, delta⟩, kappa⟩⟩
+  invFun
+    | ⟨i, ⟨⟨j, gamma, delta⟩, kappa⟩⟩ => ⟨j, i, gamma, delta, kappa⟩
+  left_inv := by rintro ⟨j, i, gamma, delta, kappa⟩; rfl
+  right_inv := by rintro ⟨i, ⟨⟨j, gamma, delta⟩, kappa⟩⟩; rfl
+
+private def rightPathFirstSourceEquiv (a b c d e : Λ) :
+    Fus.FourfoldLeftAssocMultiplicity a b c d e ≃
+      (f : Λ) × (Fin (Fus.fusionMultiplicity a b f) ×
+        Fus.LeftTripleMultiplicity f c d e) where
+  toFun
+    | ⟨f, g, mu, nu, rho⟩ => ⟨f, ⟨mu, ⟨g, nu, rho⟩⟩⟩
+  invFun
+    | ⟨f, ⟨mu, ⟨g, nu, rho⟩⟩⟩ => ⟨f, g, mu, nu, rho⟩
+  left_inv := by rintro ⟨f, g, mu, nu, rho⟩; rfl
+  right_inv := by rintro ⟨f, ⟨mu, ⟨g, nu, rho⟩⟩⟩; rfl
+
+private def rightPathFirstTargetEquiv (a b c d e : Λ) :
+    Fus.FourfoldPairMultiplicity a b c d e ≃
+      (f : Λ) × (Fin (Fus.fusionMultiplicity a b f) ×
+        Fus.RightTripleMultiplicity f c d e) where
+  toFun
+    | ⟨f, j, mu, gamma, tau⟩ => ⟨f, ⟨mu, ⟨j, gamma, tau⟩⟩⟩
+  invFun
+    | ⟨f, ⟨mu, ⟨j, gamma, tau⟩⟩⟩ => ⟨f, j, mu, gamma, tau⟩
+  left_inv := by rintro ⟨f, j, mu, gamma, tau⟩; rfl
+  right_inv := by rintro ⟨f, ⟨mu, ⟨j, gamma, tau⟩⟩⟩; rfl
+
+private def rightPathSecondSourceEquiv (a b c d e : Λ) :
+    Fus.FourfoldPairMultiplicity a b c d e ≃
+      (j : Λ) × (Fus.LeftTripleMultiplicity a b j e ×
+        Fin (Fus.fusionMultiplicity c d j)) where
+  toFun
+    | ⟨f, j, mu, gamma, tau⟩ => ⟨j, ⟨⟨f, mu, tau⟩, gamma⟩⟩
+  invFun
+    | ⟨j, ⟨⟨f, mu, tau⟩, gamma⟩⟩ => ⟨f, j, mu, gamma, tau⟩
+  left_inv := by rintro ⟨f, j, mu, gamma, tau⟩; rfl
+  right_inv := by rintro ⟨j, ⟨⟨f, mu, tau⟩, gamma⟩⟩; rfl
+
+private def rightPathSecondTargetEquiv (a b c d e : Λ) :
+    Fus.FourfoldRightAssocMultiplicity a b c d e ≃
+      (j : Λ) × (Fus.RightTripleMultiplicity a b j e ×
+        Fin (Fus.fusionMultiplicity c d j)) where
+  toFun
+    | ⟨j, i, gamma, delta, kappa⟩ => ⟨j, ⟨⟨i, delta, kappa⟩, gamma⟩⟩
+  invFun
+    | ⟨j, ⟨⟨i, delta, kappa⟩, gamma⟩⟩ => ⟨j, i, gamma, delta, kappa⟩
+  left_inv := by rintro ⟨j, i, gamma, delta, kappa⟩; rfl
+  right_inv := by rintro ⟨j, ⟨⟨i, delta, kappa⟩, gamma⟩⟩; rfl
+
+/-! ### The five lifted printed `F`-matrices -/
+
+/-- The `F^{abc}_g` edge from `(((a b) c) d) -> e` to `((a (b c)) d) -> e`.
+
+Source: arXiv:1511.08090, equation `Fmove`, lines 248--251, and the first factor of
+equation `pentagoneq`, lines 280--281. -/
+noncomputable def leftAssocToLeftInnerPrintedFMatrix (a b c d e : Λ) :
+    Matrix (Fus.FourfoldLeftInnerMultiplicity a b c d e)
+      (Fus.FourfoldLeftAssocMultiplicity a b c d e) ℂ :=
+  (Matrix.blockDiagonal' fun g => Fus.printedFMatrix a b c g ⊗ₖ
+    (1 : Matrix (Fin (Fus.fusionMultiplicity g d e))
+      (Fin (Fus.fusionMultiplicity g d e)) ℂ)).submatrix
+        (Fus.leftPathFirstTargetEquiv a b c d e)
+        (Fus.leftPathFirstSourceEquiv a b c d e)
+
+/-- The `F^{ahd}_e` edge from `((a (b c)) d) -> e` to `a ((b c) d) -> e`.
+
+Source: arXiv:1511.08090, equation `Fmove`, lines 248--251, and the second factor of
+equation `pentagoneq`, lines 280--281. -/
+noncomputable def leftInnerToMiddlePrintedFMatrix (a b c d e : Λ) :
+    Matrix (Fus.FourfoldMiddleMultiplicity a b c d e)
+      (Fus.FourfoldLeftInnerMultiplicity a b c d e) ℂ :=
+  (Matrix.blockDiagonal' fun h =>
+    (1 : Matrix (Fin (Fus.fusionMultiplicity b c h))
+      (Fin (Fus.fusionMultiplicity b c h)) ℂ) ⊗ₖ Fus.printedFMatrix a h d e).submatrix
+        (Fus.leftPathSecondTargetEquiv a b c d e)
+        (Fus.leftPathSecondSourceEquiv a b c d e)
+
+/-- The `F^{bcd}_i` edge from `a ((b c) d) -> e` to `a (b (c d)) -> e`.
+
+Source: arXiv:1511.08090, equation `Fmove`, lines 248--251, and the third factor of
+equation `pentagoneq`, lines 280--281. -/
+noncomputable def middleToRightAssocPrintedFMatrix (a b c d e : Λ) :
+    Matrix (Fus.FourfoldRightAssocMultiplicity a b c d e)
+      (Fus.FourfoldMiddleMultiplicity a b c d e) ℂ :=
+  (Matrix.blockDiagonal' fun i => Fus.printedFMatrix b c d i ⊗ₖ
+    (1 : Matrix (Fin (Fus.fusionMultiplicity a i e))
+      (Fin (Fus.fusionMultiplicity a i e)) ℂ)).submatrix
+        (Fus.leftPathThirdTargetEquiv a b c d e)
+        (Fus.leftPathThirdSourceEquiv a b c d e)
+
+/-- The `F^{fcd}_e` edge from `(((a b) c) d) -> e` to `(a b) (c d) -> e`.
+
+Source: arXiv:1511.08090, equation `Fmove`, lines 248--251, and the first factor on the
+right-hand side of equation `pentagoneq`, lines 282--283. -/
+noncomputable def leftAssocToPairPrintedFMatrix (a b c d e : Λ) :
+    Matrix (Fus.FourfoldPairMultiplicity a b c d e)
+      (Fus.FourfoldLeftAssocMultiplicity a b c d e) ℂ :=
+  (Matrix.blockDiagonal' fun f =>
+    (1 : Matrix (Fin (Fus.fusionMultiplicity a b f))
+      (Fin (Fus.fusionMultiplicity a b f)) ℂ) ⊗ₖ Fus.printedFMatrix f c d e).submatrix
+        (Fus.rightPathFirstTargetEquiv a b c d e)
+        (Fus.rightPathFirstSourceEquiv a b c d e)
+
+/-- The `F^{abj}_e` edge from `(a b) (c d) -> e` to `a (b (c d)) -> e`.
+
+Source: arXiv:1511.08090, equation `Fmove`, lines 248--251, and the second factor on the
+right-hand side of equation `pentagoneq`, lines 282--283. -/
+noncomputable def pairToRightAssocPrintedFMatrix (a b c d e : Λ) :
+    Matrix (Fus.FourfoldRightAssocMultiplicity a b c d e)
+      (Fus.FourfoldPairMultiplicity a b c d e) ℂ :=
+  (Matrix.blockDiagonal' fun j => Fus.printedFMatrix a b j e ⊗ₖ
+    (1 : Matrix (Fin (Fus.fusionMultiplicity c d j))
+      (Fin (Fus.fusionMultiplicity c d j)) ℂ)).submatrix
+        (Fus.rightPathSecondTargetEquiv a b c d e)
+        (Fus.rightPathSecondSourceEquiv a b c d e)
+
+/-- The three-edge printed-`F` composite from the fully left- to the fully right-associated tree.
+
+Source: arXiv:1511.08090, equation `pentagoneq`, left-hand side, lines 280--281; its
+orientation follows equation `Fmove`, lines 248--251. -/
+noncomputable def threeEdgePrintedFMatrix (a b c d e : Λ) :
+    Matrix (Fus.FourfoldRightAssocMultiplicity a b c d e)
+      (Fus.FourfoldLeftAssocMultiplicity a b c d e) ℂ :=
+  (Fus.middleToRightAssocPrintedFMatrix a b c d e *
+    Fus.leftInnerToMiddlePrintedFMatrix a b c d e) *
+      Fus.leftAssocToLeftInnerPrintedFMatrix a b c d e
+
+/-- The two-edge printed-`F` composite from the fully left- to the fully right-associated tree.
+
+Source: arXiv:1511.08090, equation `pentagoneq`, right-hand side, lines 282--283; its
+orientation follows equation `Fmove`, lines 248--251. -/
+noncomputable def twoEdgePrintedFMatrix (a b c d e : Λ) :
+    Matrix (Fus.FourfoldRightAssocMultiplicity a b c d e)
+      (Fus.FourfoldLeftAssocMultiplicity a b c d e) ℂ :=
+  Fus.pairToRightAssocPrintedFMatrix a b c d e *
+    Fus.leftAssocToPairPrintedFMatrix a b c d e
+
+end MPOTensor.CompleteZipperFusionFamily

--- a/blueprint/src/Packages/tn_diagrams.py
+++ b/blueprint/src/Packages/tn_diagrams.py
@@ -79,6 +79,7 @@ _DIAGRAM_ARGS: dict[str, str] = {
     "TNMPDOFixedFinalFusionBracketings": "",
     "TNMPDOFixedFinalComparisonUnitary": "",
     "TNMPDOFourfoldBondReassociationPentagon": "",
+    "TNMPDOCompleteZipperFusionPentagon": "",
     "TNMPDOPrintedFMove": "",
     "TNMPDOBNTFusionIdentity": "",
     "TNMPDOUnweightedZipperReconstruction": "",

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -478,8 +478,8 @@ separate step.
     \centering
     \TNMPDOFixedFinalFusionBracketings
     \caption{The two ways of fusing three labels to a fixed final label
-        $\varepsilon$, in the diagrammatic language of
-        \cite[eq.~(Fmove)]{Bultinck2017Anyons}.  The solid fusion trees are
+        $\varepsilon$, using the printed-$F$ row/column convention of
+        \cite[Section~3.4]{Bultinck2017Anyons}.  The solid fusion trees are
         the left- and right-bracketed maps constructed below.  The dashed
         line denotes the invertible fixed-final change of multiplicity basis
         in the source.  The results below first extract its action on the
@@ -621,8 +621,8 @@ separate step.
     This definition does not select a fixed final label and makes no
     invertibility assertion.  Its orientation is from the right-associated
     sum to the left-associated sum; consequently it is adjoint-oriented with
-    respect to the $F$-matrix convention in equation (Fmove) of
-    \cite{Bultinck2017Anyons}.
+    respect to the printed-$F$ row/column convention used here for
+    \cite[Section~3.4]{Bultinck2017Anyons}.
 \end{definition}
 
 \begin{theorem}[Left range projection of the full triple-fusion comparison]%
@@ -913,8 +913,8 @@ separate step.
             \otimes \C^{\dim\chi_{\alpha,\delta,\varepsilon}}.
     \]
     These spaces have the bracketing pattern of the $(e,\mu,\nu)$ and
-    $(f,\lambda,\sigma)$ index spaces in equation (Fmove) of
-    \cite{Bultinck2017Anyons}.  Identifying the dimensions of the positive
+    $(f,\lambda,\sigma)$ index spaces in the printed-$F$ row/column convention
+    of \cite[Section~3.4]{Bultinck2017Anyons}.  Identifying the dimensions of the positive
     diagonal matrices with the fusion multiplicities of that equation
     requires the length-independent integer specialization and is not
     asserted here.  The corresponding fixed-final row spaces are
@@ -972,8 +972,8 @@ separate step.
     restricting the two iterated fusion isometries to the summands with final
     label $\varepsilon$.  Their adjoints, after the canonical reassociation
     of the triple bond space, have the orientation and bracketing pattern of
-    the weighted analogues of the two composites in equation (Fmove) of
-    \cite{Bultinck2017Anyons}.
+    the weighted analogues of the two sides in the printed-$F$ row/column
+    convention of \cite[Section~3.4]{Bultinck2017Anyons}.
 \end{definition}
 
 \begin{theorem}[Left triple fusion at a fixed final label]%
@@ -1050,7 +1050,8 @@ separate step.
     This conclusion is conditional on the supplied matrix $C$.  It does not
     assert the existence or invertibility of $C$ or $F$, and it does not
     identify the dimensions of the positive diagonal matrices $\chi$ with the
-    fusion multiplicities in \cite[eq.~(Fmove)]{Bultinck2017Anyons}.
+    fusion multiplicities in the printed-$F$ row/column convention of
+    \cite[Section~3.4]{Bultinck2017Anyons}.
 \end{theorem}
 \begin{proof}\leanok
     \uses{lem:amplified_center_scalar}
@@ -1096,7 +1097,7 @@ separate step.
     The selector identities and injectivity at the present blocking are
     additional hypotheses here.  The theorem neither asserts that
     $F_\varepsilon$ is square or invertible nor identifies it with the
-    $F$-matrix of \cite[eq.~(Fmove)]{Bultinck2017Anyons}; no pentagon identity
+    printed $F$-matrix of \cite[Section~3.4]{Bultinck2017Anyons}; no pentagon identity
     is asserted.
 \end{theorem}
 \begin{proof}\leanok
@@ -1191,7 +1192,8 @@ separate step.
         F_\varepsilon^\dagger F_\varepsilon=1.
     \]
     Thus $F_\varepsilon$ is invertible.  Its orientation is opposite to the
-    convention in equation (Fmove) of \cite{Bultinck2017Anyons}; no pentagon
+    printed-$F$ row/column convention of
+    \cite[Section~3.4]{Bultinck2017Anyons}; no pentagon
     identity is asserted.
 \end{theorem}
 \begin{proof}\leanok
@@ -1304,7 +1306,7 @@ separate step.
           (1\otimes X^f_{bc,\lambda})X^d_{af,\sigma}.
     \]
     The matrix in the opposite orientation is its two-sided inverse.  This is
-    the $F$-move of \cite[equation~(Fmove)]{Bultinck2017Anyons}.
+    the printed $F$-move of \cite[Section~3.4]{Bultinck2017Anyons}.
 \end{theorem}
 \begin{proof}\leanok
     Form the full left- and right-associated synthesis matrices $L$ and $R$
@@ -1351,10 +1353,63 @@ separate step.
     \caption{The source-oriented $F$-move.  The left-associated fusion tensor
         is expanded in the right-associated fusion basis.  The upper indices
         $(f,\lambda,\sigma)$ label the rows of $F^{abc}_d$, and the lower
-        indices $(e,\mu,\nu)$ label its columns, as in
-        \cite[equation~(Fmove)]{Bultinck2017Anyons}.}
+        indices $(e,\mu,\nu)$ label its columns.  This is the printed-$F$
+        row/column convention used here for
+        \cite[Section~3.4]{Bultinck2017Anyons}.}
     \label{fig:mpdo_complete_zipper_printed_fmove}
 \end{figure}
+
+\begin{definition}[Fourfold complete zipper fusion data]%
+    \label{def:mpdo_complete_zipper_fourfold_fusion_data}
+    \lean{MPOTensor.CompleteZipperFusionFamily.%
+        FourfoldLeftAssocMultiplicity}
+    \lean{MPOTensor.CompleteZipperFusionFamily.%
+        FourfoldLeftInnerMultiplicity}
+    \lean{MPOTensor.CompleteZipperFusionFamily.FourfoldMiddleMultiplicity}
+    \lean{MPOTensor.CompleteZipperFusionFamily.FourfoldPairMultiplicity}
+    \lean{MPOTensor.CompleteZipperFusionFamily.FourfoldRightAssocMultiplicity}
+    \lean{MPOTensor.CompleteZipperFusionFamily.leftAssocFourfoldSynthesis}
+    \lean{MPOTensor.CompleteZipperFusionFamily.leftInnerFourfoldSynthesis}
+    \lean{MPOTensor.CompleteZipperFusionFamily.middleFourfoldSynthesis}
+    \lean{MPOTensor.CompleteZipperFusionFamily.pairFourfoldSynthesis}
+    \lean{MPOTensor.CompleteZipperFusionFamily.rightAssocFourfoldSynthesis}
+    \lean{MPOTensor.CompleteZipperFusionFamily.%
+        leftAssocToLeftInnerPrintedFMatrix}
+    \lean{MPOTensor.CompleteZipperFusionFamily.%
+        leftInnerToMiddlePrintedFMatrix}
+    \lean{MPOTensor.CompleteZipperFusionFamily.%
+        middleToRightAssocPrintedFMatrix}
+    \lean{MPOTensor.CompleteZipperFusionFamily.leftAssocToPairPrintedFMatrix}
+    \lean{MPOTensor.CompleteZipperFusionFamily.pairToRightAssocPrintedFMatrix}
+    \lean{MPOTensor.CompleteZipperFusionFamily.threeEdgePrintedFMatrix}
+    \lean{MPOTensor.CompleteZipperFusionFamily.twoEdgePrintedFMatrix}
+    \leanok
+    \uses{def:mpdo_complete_zipper_fusion_family,
+        thm:mpdo_complete_zipper_printed_fmove}
+    Fix labels $a,b,c,d,e$.  The five fusion trees in equation~(33) of
+    \cite{Bultinck2017Anyons} determine five multiplicity spaces and five
+    synthesis maps into the fourfold bond space.  These spaces use the integer
+    multiplicities $N_{ab}^{c}$ of the complete zipper family, rather than the
+    weighted positive-diagonal coordinates introduced earlier.
+
+    Each edge of the pentagon carries the printed $F$-matrix for the affected
+    triple tensor factor and the identity on the untouched multiplicity
+    factor.  The three upper edges define a composite
+    $F_{\mathrm{upper}}$, while the two lower edges define
+    $F_{\mathrm{lower}}$.  These are definitions of the two matrices compared
+    by equation~(33); their equality is not asserted here.
+\end{definition}
+
+\begin{figure}[ht]
+    \centering
+    \TNMPDOCompleteZipperFusionPentagon
+    \caption{The five complete zipper fusion trees of
+        \cite[Section~3.4, equation~(33)]{Bultinck2017Anyons}.  Each arrow is
+        a printed $F$-move, with right-tree coordinates indexing rows and
+        left-tree coordinates indexing columns.}
+    \label{fig:mpdo_complete_zipper_fusion_pentagon}
+\end{figure}
+\clearpage
 
 \begin{theorem}[Coherence of four bond-coordinate reassociations]%
     \label{thm:mpdo_fourfold_bond_coordinate_coherence}

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -1350,6 +1350,117 @@
     \end{tikzpicture}%
 }
 
+% The five genuine fusion trees in the MPO pentagon.  Unlike the Cartesian
+% reassociation diagram above, every edge is a printed-orientation F-move and
+% every internal label is a fusion-sector label.  The arrangement follows
+% Figure `pentagon` (n13.pdf) of arXiv:1511.08090.
+\newcommand{\TNMPDOCompleteZipperFusionPentagon}{%
+    \begin{tikzpicture}[tn picture, scale=0.82]
+        \tikzset{tn pent edge/.style={->, line width=0.7pt}}
+
+        % (((a b) c) d)
+        \coordinate (pL-a) at (-5.70,0.75);
+        \coordinate (pL-b) at (-5.15,0.75);
+        \coordinate (pL-c) at (-4.60,0.75);
+        \coordinate (pL-d) at (-4.05,0.75);
+        \coordinate (pL-f) at (-5.42,0.22);
+        \coordinate (pL-g) at (-5.00,-0.28);
+        \coordinate (pL-e) at (-4.56,-0.80);
+        \draw[tn leg] (pL-a) -- (pL-f) -- (pL-b);
+        \draw[tn leg] (pL-f) -- (pL-g) -- (pL-c);
+        \draw[tn leg] (pL-g) -- (pL-e) -- (pL-d);
+        \draw[tn leg] (pL-e) -- ++(0,-0.48);
+        \foreach \n/\t in {pL-a/a,pL-b/b,pL-c/c,pL-d/d}
+            \node[above] at (\n) {$\t$};
+        \node[left] at ($(pL-f)!0.55!(pL-g)$) {$f$};
+        \node[left] at ($(pL-g)!0.55!(pL-e)$) {$g$};
+        \node[below] at ($(pL-e)+(0,-0.48)$) {$e$};
+
+        % ((a (b c)) d)
+        \coordinate (pLI-a) at (-4.20,3.52);
+        \coordinate (pLI-b) at (-3.65,3.52);
+        \coordinate (pLI-c) at (-3.10,3.52);
+        \coordinate (pLI-d) at (-2.55,3.52);
+        \coordinate (pLI-h) at (-3.38,2.99);
+        \coordinate (pLI-g) at (-3.78,2.49);
+        \coordinate (pLI-e) at (-3.28,1.97);
+        \draw[tn leg] (pLI-b) -- (pLI-h) -- (pLI-c);
+        \draw[tn leg] (pLI-a) -- (pLI-g) -- (pLI-h);
+        \draw[tn leg] (pLI-g) -- (pLI-e) -- (pLI-d);
+        \draw[tn leg] (pLI-e) -- ++(0,-0.48);
+        \foreach \n/\t in {pLI-a/a,pLI-b/b,pLI-c/c,pLI-d/d}
+            \node[above] at (\n) {$\t$};
+        \node[right] at ($(pLI-h)!0.55!(pLI-g)$) {$h$};
+        \node[left] at ($(pLI-g)!0.55!(pLI-e)$) {$g$};
+        \node[below] at ($(pLI-e)+(0,-0.48)$) {$e$};
+
+        % a ((b c) d)
+        \coordinate (pM-a) at (0.10,3.52);
+        \coordinate (pM-b) at (0.65,3.52);
+        \coordinate (pM-c) at (1.20,3.52);
+        \coordinate (pM-d) at (1.75,3.52);
+        \coordinate (pM-h) at (0.92,2.99);
+        \coordinate (pM-i) at (1.34,2.49);
+        \coordinate (pM-e) at (0.84,1.97);
+        \draw[tn leg] (pM-b) -- (pM-h) -- (pM-c);
+        \draw[tn leg] (pM-h) -- (pM-i) -- (pM-d);
+        \draw[tn leg] (pM-a) -- (pM-e) -- (pM-i);
+        \draw[tn leg] (pM-e) -- ++(0,-0.48);
+        \foreach \n/\t in {pM-a/a,pM-b/b,pM-c/c,pM-d/d}
+            \node[above] at (\n) {$\t$};
+        \node[left] at ($(pM-h)!0.55!(pM-i)$) {$h$};
+        \node[right] at ($(pM-i)!0.55!(pM-e)$) {$i$};
+        \node[below] at ($(pM-e)+(0,-0.48)$) {$e$};
+
+        % a (b (c d))
+        \coordinate (pR-a) at (4.05,0.75);
+        \coordinate (pR-b) at (4.60,0.75);
+        \coordinate (pR-c) at (5.15,0.75);
+        \coordinate (pR-d) at (5.70,0.75);
+        \coordinate (pR-j) at (5.42,0.22);
+        \coordinate (pR-i) at (5.00,-0.28);
+        \coordinate (pR-e) at (4.56,-0.80);
+        \draw[tn leg] (pR-c) -- (pR-j) -- (pR-d);
+        \draw[tn leg] (pR-b) -- (pR-i) -- (pR-j);
+        \draw[tn leg] (pR-a) -- (pR-e) -- (pR-i);
+        \draw[tn leg] (pR-e) -- ++(0,-0.48);
+        \foreach \n/\t in {pR-a/a,pR-b/b,pR-c/c,pR-d/d}
+            \node[above] at (\n) {$\t$};
+        \node[right] at ($(pR-j)!0.55!(pR-i)$) {$j$};
+        \node[right] at ($(pR-i)!0.55!(pR-e)$) {$i$};
+        \node[below] at ($(pR-e)+(0,-0.48)$) {$e$};
+
+        % (a b) (c d)
+        \coordinate (pP-a) at (-0.85,-2.10);
+        \coordinate (pP-b) at (-0.30,-2.10);
+        \coordinate (pP-c) at (0.30,-2.10);
+        \coordinate (pP-d) at (0.85,-2.10);
+        \coordinate (pP-f) at (-0.58,-2.63);
+        \coordinate (pP-j) at (0.58,-2.63);
+        \coordinate (pP-e) at (0,-3.18);
+        \draw[tn leg] (pP-a) -- (pP-f) -- (pP-b);
+        \draw[tn leg] (pP-c) -- (pP-j) -- (pP-d);
+        \draw[tn leg] (pP-f) -- (pP-e) -- (pP-j);
+        \draw[tn leg] (pP-e) -- ++(0,-0.48);
+        \foreach \n/\t in {pP-a/a,pP-b/b,pP-c/c,pP-d/d}
+            \node[above] at (\n) {$\t$};
+        \node[left] at ($(pP-f)!0.55!(pP-e)$) {$f$};
+        \node[right] at ($(pP-j)!0.55!(pP-e)$) {$j$};
+        \node[below] at ($(pP-e)+(0,-0.48)$) {$e$};
+
+        \draw[tn pent edge] (-4.48,1.10) -- node[above left]
+            {$F^{abc}_{g}$} (-3.95,1.73);
+        \draw[tn pent edge] (-2.20,2.72) -- node[above]
+            {$F^{ahd}_{e}$} (-0.25,2.72);
+        \draw[tn pent edge] (1.80,1.78) -- node[above right]
+            {$F^{bcd}_{i}$} (4.15,1.08);
+        \draw[tn pent edge] (-3.95,-1.05) -- node[below left]
+            {$F^{fcd}_{e}$} (-1.02,-2.15);
+        \draw[tn pent edge] (1.02,-2.15) -- node[below right]
+            {$F^{abj}_{e}$} (3.95,-1.05);
+    \end{tikzpicture}%
+}
+
 % Local BNT fusion identity from CPSV16, eq. (Ualphabeta).  The left-hand
 % isometry combines the two incoming bond factors, while its adjoint separates
 % the outgoing factors.  The right-hand side records the weighted final-sector

--- a/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
+++ b/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
@@ -31,6 +31,9 @@ name: TNMPSInverseContraction TNBNTDecomposition TNMPDOZCLIdempotence TNMPDOFixe
 name: TNMPDOBNTFusionIdentity TNMPDOUnweightedZipperReconstruction TNMPDOFusionTracePower TNMPDOFixedFinalComparisonUnitary TNMPDOFourfoldBondReassociationPentagon TNMPDOPrintedFMove
 {{ obj.tn_svg_html }}
 
+name: TNMPDOCompleteZipperFusionPentagon
+{{ obj.tn_svg_html }}
+
 name: TNAppendixBAdjacentBondProjectors TNAppendixBPhysicalSupportTransport TNAppendixBChainTransport
 {{ obj.tn_svg_html }}
 

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -669,6 +669,18 @@ entrywise pentagon equation of \texttt{AnyonsPEPS.tex}, lines~279--283.  The
 two-sided printed $F$-move is therefore complete, while the pentagon remains a
 separate open formalization problem.
 
+The five categorical fourfold multiplicity spaces, their fusion maps, and the
+five lifted printed-$F$ edges are now recorded by
+\leanid{MPOTensor.CompleteZipperFusionFamily.%
+FourfoldLeftAssocMultiplicity} through
+\leanid{MPOTensor.CompleteZipperFusionFamily.%
+twoEdgePrintedFMatrix}.  These spaces use the integer fusion multiplicities
+$N_{ab}^{c}$ of the complete zipper family.  They are not identified with the
+positive-diagonal weighted coordinates of the restricted family.  The
+remaining proof must show that the three-edge and two-edge composites give the
+same expansion in the right-associated fourfold fusion map and then cancel its
+analysis map.
+
 \paragraph{Local fixes in the fusion-tensor display.}
 The prose at line~161 of \texttt{AnyonsPEPS.tex} displays the arrow for
 $X^c_{ab,\mu}$ in the direction from the product bond space to the $c$ bond
@@ -681,6 +693,20 @@ The same display writes the Kronecker factor in
 $X^{d+}_{ab,\nu}X^c_{ab,\mu}$ as $\delta_{de}$, although no label $e$ occurs
 in the relation.  Its typed form is $\delta_{dc}$ (equivalently
 $\delta_{cd}$), which is the index relation used in the formalization.
+
+\paragraph{Local fix in the pentagon index orientation.}
+Equation \texttt{Fmove} at lines~248--251 places the right-tree indices above
+and the left-tree indices below:
+$(F^{abc}_{d})^{f\lambda\sigma}_{e\mu\nu}$.  In contrast, every factor in
+equation \texttt{pentagoneq} at lines~280--283 places the left-tree indices
+above and the right-tree indices below.  With the multiplicity types fixed by
+the fusion trees at line~279, the latter entries are entries of the inverse
+$F$-matrix.  The forward edge matrices in the formalization follow
+\texttt{Fmove}; equivalently, the literal upper/lower placement in
+\texttt{pentagoneq} is read using
+\leanid{MPOTensor.CompleteZipperFusionFamily.inversePrintedFMatrix}.  Both the
+forward identity and this inverse, literally indexed form must be stated when
+the pentagon proof is completed.
 
 To eliminate the source-theorem gap, the formalization should instead:
 \begin{enumerate}


### PR DESCRIPTION
## Summary

- define the five categorical multiplicity spaces and five fourfold synthesis maps for complete zipper fusion data
- define the five lifted printed-orientation `F`-matrix edges and the three-edge and two-edge composites
- add a source-like TikZ pentagon of genuine trivalent fusion trees and register it for both PDF and web output
- record the source index-orientation correction and update the blueprint and paper-gap account

## Source boundary

The construction follows Bultinck et al., Section 3.4, especially the printed `F`-move and equation (33), together with the length-independent fusion discussion around arXiv:1606.00608, Theorem 4.14. The paper prints equation (33) with the component indices in the inverse orientation relative to its preceding `F`-move. The forward matrices here use right-tree rows and left-tree columns; the literal opposite placement belongs to `inversePrintedFMatrix`.

This PR is a faithful scaffolding step, not completion of the pentagon theorem. It defines the two composites but does not assert their equality. The remaining proof must establish the five edge identities, identify both composites with the same fourfold synthesis map, cancel the right-associated analysis map, and then state the inverse-oriented entrywise equation.

Advances #3845.

## Validation

- `lake build`
- `leanblueprint web`
- `leanblueprint checkdecls`
- `leanblueprint pdf`
- visual inspection of the generated definition, fusion-tree figure, and Cartesian comparison pages

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive definitions and documentation with no pentagon proof or changes to existing fusion theorems; main risk is index-orientation convention drift until the pentagon is proved.
> 
> **Overview**
> Adds **fourfold complete zipper fusion** scaffolding for the MPO pentagon (Bultinck et al., eq. 33): five parenthesization multiplicity types, five synthesis maps, five lifted printed-`F` edge matrices, and the **three-edge** vs **two-edge** composites—**without** asserting pentagon equality.
> 
> Forward `F`-edges follow **`Fmove`** (right-tree rows, left-tree columns); the paper-gap doc notes that **`pentagoneq`**’s literal index placement corresponds to **`inversePrintedFMatrix`**.
> 
> **Blueprint / docs:** new pentagon TikZ macro and web diagram registration; chapter 21 definition + figure wired to the Lean names; surrounding text retargeted to the printed-`F` row/column convention; root import for `CompleteZipperFusionFourfold`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7426cabd984652d1d5f616328de5d54fbf0798d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->