### PR TITLE
feat(MPS/MPDO): derive common representative blocking

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -329,6 +329,7 @@ import TNLean.MPS.FundamentalTheorem.SectorBNT.ProportionalMatch
 import TNLean.MPS.FundamentalTheorem.SectorBNT.Supplier
 import TNLean.MPS.FundamentalTheorem.SectorBNT.Unitary
 import TNLean.MPS.Periodic.Overlap
+import TNLean.MPS.Periodic.NormalizedSelfOverlap
 import TNLean.MPS.Periodic.FundamentalTheorem
 import TNLean.MPS.Periodic.ZGauge
 import TNLean.MPS.Periodic.Symmetry

--- a/TNLean/MPS/MPDO/PostBlockedRepresentativeSpan.lean
+++ b/TNLean/MPS/MPDO/PostBlockedRepresentativeSpan.lean
@@ -10,6 +10,7 @@ import TNLean.MPS.MPDO.BiCFDerivation.BNTDirectSum
 import TNLean.MPS.MPDO.BiCFDerivation.Blocking
 import TNLean.MPS.MPDO.FirstSiteBlocking
 import TNLean.MPS.MPDO.RepresentativeGroupedLemmaL
+import TNLean.MPS.Periodic.NormalizedSelfOverlap
 import TNLean.Wielandt.SpanGrowth.CumulativeSpan
 
 /-!
@@ -292,5 +293,37 @@ theorem insertedTensor_basis_eq_of_sameMPV₂_firstSiteActionAgree_of_common_blo
     ∀ j, insertedTensor Y (P.basis j) = insertedTensor Z (P.basis j) := by
   exact hCF.insertedTensor_basis_eq_of_firstSiteActionAgree_of_common_blockInjective
     L hL hInj (hAct.of_sameMPV hAP)
+
+/-- Representative-grouped Lemma L for an unblocked BNT canonical form.
+
+Irreducibility, left-canonicality, and normalized self-overlap force each basis
+representative to have period one and hence to be normal.  A common positive
+block-injectivity length for the finite representative family then supplies
+the blocking hypothesis of the preceding theorem.
+
+Source: arXiv:1606.00608, lines 318--344 and Appendix C.3, Lemma L,
+lines 1835--1858; the period-one characterization is the non-periodic
+canonical-form condition of arXiv:2011.12127, lines 1815--1837. -/
+theorem insertedTensor_basis_eq_of_firstSiteActionAgree
+    (hCF : IsBNTCanonicalForm P)
+    {Y Z : Matrix (Fin d) (Fin d) ℂ}
+    (hAct : FirstSiteActionAgree P.toTensor Y Z) :
+    ∀ j, insertedTensor Y (P.basis j) = insertedTensor Z (P.basis j) := by
+  obtain ⟨L, hL, hInj⟩ := hCF.exists_common_basis_isNBlkInjective
+  exact hCF.insertedTensor_basis_eq_of_firstSiteActionAgree_of_common_blockInjective
+    L hL hInj hAct
+
+/-- Same-MPV transport of representative-grouped Lemma L for an unblocked BNT
+canonical form.
+
+Source: arXiv:1606.00608, lines 318--344 and Appendix C.3, Lemma L,
+lines 1835--1858. -/
+theorem insertedTensor_basis_eq_of_sameMPV₂_firstSiteActionAgree
+    {D : ℕ} (A : MPSTensor d D) (hCF : IsBNTCanonicalForm P)
+    (hAP : SameMPV₂ A P.toTensor)
+    {Y Z : Matrix (Fin d) (Fin d) ℂ}
+    (hAct : FirstSiteActionAgree A Y Z) :
+    ∀ j, insertedTensor Y (P.basis j) = insertedTensor Z (P.basis j) := by
+  exact hCF.insertedTensor_basis_eq_of_firstSiteActionAgree (hAct.of_sameMPV hAP)
 
 end MPSTensor.IsBNTCanonicalForm

--- a/TNLean/MPS/Periodic/NormalizedSelfOverlap.lean
+++ b/TNLean/MPS/Periodic/NormalizedSelfOverlap.lean
@@ -1,0 +1,178 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.Peripheral.CyclicGroup
+import TNLean.MPS.CanonicalForm.BlockingViaAdjoint
+import TNLean.MPS.CanonicalForm.SectorComparison.NormalityChain
+import TNLean.MPS.FundamentalTheorem.SectorBNT.Basic
+import TNLean.MPS.Periodic.Overlap.SelfOverlap
+import TNLean.MPS.SharedInfra.KrausAdjointSetup
+
+/-!
+# Normality from normalized self-overlap
+
+An irreducible left-canonical tensor has a finite peripheral period.  Its
+self-overlap along multiples of that period converges to the period.  Hence a
+self-overlap converging to one forces period one, and therefore primitivity and
+normality.
+
+This is the implication needed to recover the block-injectivity content of a
+basis of normal tensors from the normalized representatives.
+
+## References
+
+* [Cirac--Pérez-García--Schuch--Verstraete, arXiv:2011.12127, lines 1815--1837]
+* [De las Cuevas--Cirac--Schuch--Pérez-García, arXiv:1708.00029, Appendix A]
+* [Wolf, *Quantum Channels & Operations*, Theorem 6.6]
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+open Filter
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- An irreducible left-canonical tensor whose self-overlap converges to one is
+normal.
+
+Quantum Perron--Frobenius theory gives a positive period `m` whose peripheral
+spectrum consists of all `m`-th roots of unity.  The periodic self-overlap
+formula gives limit `m` along lengths divisible by `m`, while the assumed full
+limit gives `1` along the same subsequence.  Thus `m = 1`; the transfer map is
+primitive, and the primitive irreducible left-canonical normality theorem
+applies.
+
+Source context: arXiv:2011.12127, lines 1815--1837; arXiv:1708.00029,
+Appendix A; Wolf Theorem 6.6. -/
+theorem isNormal_of_irreducible_leftCanonical_selfOverlap_tendsto_one
+    [NeZero D] (A : MPSTensor d D)
+    (hIrr : IsIrreducibleTensor A)
+    (hLeft : IsLeftCanonical A)
+    (hSelf : Tendsto (fun N : ℕ ↦ mpvOverlap (d := d) A A N) atTop (nhds 1)) :
+    IsNormal A := by
+  classical
+  obtain ⟨K, hUnital, hIrrK, ρ, hρpd, hρfix, rfl⟩ :=
+    conjTranspose_kraus_setup A hLeft hIrr
+  obtain ⟨hm, γ, hγroot, hPeriphK⟩ :=
+    peripheralEigenvalues_eq_range_primitiveRoot
+      (fun i ↦ (A i)ᴴ) hUnital ρ hρpd hρfix hIrrK
+  let m : ℕ := (peripheralEigenvalues_finite
+    (f := transferMap (d := d) (D := D) (fun i ↦ (A i)ᴴ))).toFinset.card
+  have hm' : 0 < m := by simpa [m] using hm
+  have hγroot' : IsPrimitiveRoot γ m := by simpa [m] using hγroot
+  have hPeriphK' :
+      peripheralEigenvalues (transferMap (d := d) (D := D) (fun i ↦ (A i)ᴴ)) =
+        Set.range (fun j : Fin m ↦ γ ^ (j : ℕ)) := by
+    simpa [m] using hPeriphK
+  haveI : NeZero m := ⟨hm'.ne'⟩
+  have hKRoots :
+      peripheralEigenvalues (transferMap (d := d) (D := D) (fun i ↦ (A i)ᴴ)) =
+        {z : ℂ | z ^ m = 1} := by
+    rw [hPeriphK']
+    ext z
+    constructor
+    · rintro ⟨j, rfl⟩
+      change (γ ^ (j : ℕ)) ^ m = 1
+      rw [← pow_mul, Nat.mul_comm, pow_mul, hγroot'.pow_eq_one, one_pow]
+    · intro hz
+      obtain ⟨i, hi, hiz⟩ := hγroot'.eq_pow_of_pow_eq_one hz
+      exact ⟨⟨i, hi⟩, hiz⟩
+  have hM : (1 : Matrix (Fin D) (Fin D) ℂ).PosDef := by
+    simpa using (Matrix.PosDef.one (n := Fin D) (R := ℂ))
+  letI : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+    Matrix.toMatrixNormedAddCommGroup (n := Fin D) (𝕜 := ℂ) 1 hM
+  letI : SeminormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+    Matrix.toMatrixSeminormedAddCommGroup (n := Fin D) (𝕜 := ℂ) 1 hM.posSemidef
+  letI : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
+    Matrix.toMatrixInnerProductSpace (n := Fin D) (𝕜 := ℂ) 1 hM.posSemidef
+  have hAdj :
+      transferMap (d := d) (D := D) (fun i ↦ (A i)ᴴ) =
+        (transferMap (d := d) (D := D) A).adjoint := by
+    simpa using (transferMap_conjTranspose_eq_adjoint (d := d) (D := D) (A := A))
+  have hPeriphA :
+      peripheralEigenvalues (transferMap (d := d) (D := D) A) =
+        {z : ℂ | z ^ m = 1} := by
+    ext z
+    constructor
+    · rintro ⟨hzEig, hzNorm⟩
+      have hstarEig : Module.End.HasEigenvalue
+          (transferMap (d := d) (D := D) (fun i ↦ (A i)ᴴ)) (star z) := by
+        rw [hAdj]
+        exact (Module.End.hasEigenvalue_adjoint_iff
+          (E := transferMap (d := d) (D := D) A) (μ := z)).1 hzEig
+      have hstarMem : star z ∈
+          peripheralEigenvalues
+            (transferMap (d := d) (D := D) (fun i ↦ (A i)ᴴ)) := by
+        exact ⟨hstarEig, by simpa using hzNorm⟩
+      have hstarPow : (star z) ^ m = 1 := by
+        simpa [hKRoots] using hstarMem
+      have := congrArg star hstarPow
+      simpa using this
+    · intro hzPow
+      have hstarPow : (star z) ^ m = 1 := by
+        have := congrArg star hzPow
+        simpa using this
+      have hstarMem : star z ∈
+          peripheralEigenvalues
+            (transferMap (d := d) (D := D) (fun i ↦ (A i)ᴴ)) := by
+        rw [hKRoots]
+        exact hstarPow
+      rcases hstarMem with ⟨hstarEig, hstarNorm⟩
+      have hzEig : Module.End.HasEigenvalue
+          (transferMap (d := d) (D := D) A) z := by
+        apply (Module.End.hasEigenvalue_adjoint_iff
+          (E := transferMap (d := d) (D := D) A) (μ := z)).2
+        simpa [hAdj] using hstarEig
+      exact ⟨hzEig, by simpa using hstarNorm⟩
+  have hPeriodic : IsPeriodic m A :=
+    ⟨hIrr, hLeft, hm', hPeriphA, ⟨γ, hγroot'⟩⟩
+  have hmul : Tendsto (fun k : ℕ ↦ m * k) atTop atTop := by
+    refine tendsto_atTop.2 fun b ↦ ?_
+    filter_upwards [eventually_ge_atTop b] with a ha
+    calc
+      b ≤ a := ha
+      _ = 1 * a := by simp
+      _ ≤ m * a := Nat.mul_le_mul_right a hm'
+  have hSubsequenceOne :
+      Tendsto (fun k : ℕ ↦ mpvOverlap A A (m * k)) atTop (nhds (1 : ℂ)) :=
+    hSelf.comp hmul
+  have hmComplex : (m : ℂ) = 1 :=
+    tendsto_nhds_unique (periodicSelfOverlap_tendsto A hPeriodic) hSubsequenceOne
+  have hmOne : m = 1 := by exact_mod_cast hmComplex
+  rw [hmOne] at hPeriodic
+  have hPrim : _root_.IsPrimitive (transferMap (d := d) (D := D) A) :=
+    ((IsPeriodic.one_iff_primitive A).1 hPeriodic).2.2
+  exact isNormal_of_tp_primitive_irreducible A hLeft hPrim hIrr
+
+end MPSTensor
+
+namespace MPSTensor.IsBNTCanonicalForm
+
+variable {d : ℕ} {P : SectorDecomposition d}
+
+/-- The finitely many representatives of a BNT canonical form have one common
+positive block-injectivity length.
+
+Each representative is irreducible and left-canonical, and its normalized
+self-overlap tends to one.  The preceding period-one theorem therefore makes
+each representative normal.  Taking a common positive multiple of their
+individual normality lengths gives the conclusion.
+
+Source context: arXiv:1606.00608, lines 318--344; arXiv:2011.12127,
+lines 1815--1837. -/
+theorem exists_common_basis_isNBlkInjective
+    (hCF : IsBNTCanonicalForm P) :
+    ∃ L : ℕ, 0 < L ∧ ∀ j : Fin P.basisCount, IsNBlkInjective (P.basis j) L := by
+  have hNormal : ∀ j : Fin P.basisCount, IsNormal (P.basis j) := by
+    intro j
+    letI : NeZero (P.basisDim j) := ⟨(hCF.basis_dim_pos j).ne'⟩
+    exact isNormal_of_irreducible_leftCanonical_selfOverlap_tendsto_one
+      (P.basis j) (hCF.basis_irreducible j) (hCF.basis_left_canonical j)
+        (hCF.basis_normalized_self_overlap j)
+  exact exists_common_isNBlkInjective_of_isNormal_leftCanonical
+    P.basis hCF.basis_left_canonical (fun j ↦ (hCF.basis_dim_pos j).ne') hNormal
+
+end MPSTensor.IsBNTCanonicalForm

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -375,6 +375,10 @@
     \lean{MPSTensor.IsBNTCanonicalForm.insertedTensor_basis_eq_of_sameMPV₂_firstSiteActionAgree_of_basis_injective}
     \lean{MPSTensor.IsBNTCanonicalForm.insertedTensor_basis_eq_of_firstSiteActionAgree_of_common_blockInjective}
     \lean{MPSTensor.IsBNTCanonicalForm.insertedTensor_basis_eq_of_sameMPV₂_firstSiteActionAgree_of_common_blockInjective}
+    \lean{MPSTensor.isNormal_of_irreducible_leftCanonical_selfOverlap_tendsto_one}
+    \lean{MPSTensor.IsBNTCanonicalForm.exists_common_basis_isNBlkInjective}
+    \lean{MPSTensor.IsBNTCanonicalForm.insertedTensor_basis_eq_of_firstSiteActionAgree}
+    \lean{MPSTensor.IsBNTCanonicalForm.insertedTensor_basis_eq_of_sameMPV₂_firstSiteActionAgree}
     \leanok
     \uses{def:sector_bnt_cf, def:sector_decomposition_block_tensor,
       def:representative_word_tuple_span, thm:representative_grouped_insert_eq}
@@ -401,8 +405,13 @@
     has representative word-tuple separation at every blocked length
     $L\geq 6(g-1)+1$.
 
-    Finally, suppose there is a common $L>0$ for which every unblocked
-    representative $A_j$ is $L$-block injective.  If the first-site actions
+    Finally, the BNT canonical-form hypotheses imply that there is a common
+    $L>0$ for which every unblocked representative $A_j$ is $L$-block
+    injective.  Indeed, irreducibility and left-canonicality give a finite
+    peripheral period $m_j$.  The self-overlap tends to $m_j$ along multiples
+    of $m_j$, but by normalization it also tends to $1$; hence $m_j=1$.
+    Thus every representative is normal, and finiteness gives a common
+    positive block-injectivity length.  If the first-site actions
     of $Y,Z$ agree on the tensor represented by $P$, then
     \[
         YA_j=ZA_j
@@ -414,11 +423,9 @@
     Appendix~C.3, Lemma~L
     \cite[lines~1835--1858]{Cirac2016MPDO_arXiv}.
 
-    \textbf{Scope restriction (common block-injectivity length).}  The last
-    assertion takes the common positive length as an explicit hypothesis.
-    Deriving its existence from the normal-representative output of the
-    canonical-form construction remains separate; see
-    \path{docs/paper-gaps/cpgsv17_bicf_block_separation.tex}.
+    No additional common-length hypothesis is required.
+    % The remaining MPDO scope question is the relation with the horizontal
+    % copy-indexed hypotheses; see docs/paper-gaps/cpgsv17_bicf_block_separation.tex.
 \end{theorem}
 
 \begin{proof}
@@ -456,8 +463,20 @@
     representatives. The preceding selector argument then applies verbatim
     to $P^{[p]}$.
 
-    For the final assertion, start from a common positive length $L$ at which
-    every representative is block injective and block $L+1$ sites.  Injectivity
+    For the final assertion, first consider one representative $A_j$.
+    Irreducibility and left-canonicality give a positive peripheral period
+    $m_j$.  The periodic self-overlap formula and the normalized self-overlap
+    hypothesis give, along the same subsequence,
+    \[
+        \lim_{k\to\infty}O_{A_jA_j}(m_jk)=m_j,
+        \qquad
+        \lim_{k\to\infty}O_{A_jA_j}(m_jk)=1.
+    \]
+    Hence $m_j=1$.
+    Primitivity then implies normality.  Taking a common
+    multiple of the finitely many normality lengths gives a positive length
+    $L$ at which every representative is block injective.  Block $L+1$ sites.
+    Injectivity
     propagates from length $L$ to length $L+1$, so the blocked representatives
     are injective.  Act on the first letter of each physical block and apply
     the blocked representative separation followed by the

--- a/docs/paper-gaps/cpgsv17_bicf_block_separation.tex
+++ b/docs/paper-gaps/cpgsv17_bicf_block_separation.tex
@@ -99,9 +99,11 @@ horizontal canonical-form trace-separation conclusion.\footnote{The criteria are
     \texttt{horizontalCFData\_of\_propBlockInjective}. The blueprint records the same
     state in \path{blueprint/src/chapter/ch20_mpdo_canonical_forms.tex}, lines 27--108.}
 Thus \texttt{propblockinj} has not been asserted without proof. The formal statements
-prove that several finite-length witnesses are sufficient, while the derivation
-of such a witness from the full canonical-form and basis-of-normal-tensors
-hypotheses remains open.
+prove that several finite-length witnesses are sufficient.  For the
+representative-indexed BNT canonical form, such a witness is now derived from
+irreducibility, left-canonicality, and normalized self-overlap.  Relating this
+representative-indexed conclusion to the flattened \texttt{HorizontalCFData}
+surface remains open.
 
 \section{The counterexample boundary}
 
@@ -164,13 +166,13 @@ converse.
 
 \section{Conclusion}
 
-The conclusion is provisional and should not be read as a source erratum.  A
+The original counterexample should not be read as a source erratum.  A
 small counterexample shows only that per-copy blockwise injectivity,
 left-canonicality, and nonzero weights do not imply simultaneous separation.
 It does not satisfy the source's minimal-representative condition.
 
-The remaining task for the source-level Lemma L is to compose the results
-above with the canonical-form construction.  Positive-length block injectivity
+The representative-level source theorem is now composed with the canonical-form
+hypotheses.  Positive-length block injectivity
 propagates from length $L$ to length $L+1$ without a normalization hypothesis:
 the identity
 $S_{L+1}(A)=\spn\{A_i\}_iS_L(A)$, together with the same identity at length
@@ -192,8 +194,8 @@ to pair separation for the blocked representatives at length $6$.  It follows
 that $P^{[p]}$ has simultaneous representative word-tuple span at every
 blocked length at least $6(g-1)+1$.
 
-This statement has now been composed with the first-site transport under an
-explicit common block-injectivity hypothesis.  Given a common positive $L$
+The first-site transport was first proved under an explicit common
+block-injectivity hypothesis.  Given a common positive $L$
 for which every representative is $L$-block injective, use $p=L+1$;
 positive-length propagation makes every $A_j^{[L+1]}$ injective.  Blocked
 representative separation and the representative-grouped Lemma L give equality
@@ -202,12 +204,19 @@ span then recovers equality of the unblocked insertions.  This length shift is
 essential: recovery from a physical block of length $L+1$ uses the span of its
 length-$L$ tail.
 
-Two tasks remain for the unrestricted source application.  First, the
-canonical-form construction must supply the common positive block-injectivity
-length from the normality of its minimal representatives, rather than taking
-that length as an explicit hypothesis.  Second, the flattened
+The first task is now closed without adding a hypothesis.  For an irreducible
+left-canonical representative, quantum Perron--Frobenius theory gives a finite
+peripheral period $m$.  Its self-overlap along multiples of $m$ tends to $m$,
+whereas the normalized BNT hypothesis makes the same subsequence tend to $1$.
+Thus $m=1$, the transfer map is primitive, and the representative is normal.
+The finitely many normal representatives have a common positive
+block-injectivity length by taking a common multiple of their individual
+lengths.  Consequently the representative-indexed Lemma L now follows from
+the BNT canonical-form predicate itself.
+
+One task remains for the unrestricted MPDO application: the flattened
 \texttt{HorizontalCFData} formulation must be replaced, or related explicitly,
-by this representative-indexed statement.  The older per-copy \texttt{biCF}
+to this representative-indexed statement.  The older per-copy \texttt{biCF}
 theorem remains a correct restricted result, but it is no longer the intended
 route to Lemma L.
 


### PR DESCRIPTION
## Summary

An irreducible left-canonical representative whose self-overlap converges to one is normal. Quantum Perron--Frobenius theory gives a finite peripheral period `m`; the periodic self-overlap formula gives limit `m` along lengths divisible by `m`, while normalized self-overlap gives limit `1` along the same subsequence. Uniqueness of limits forces `m = 1`, hence primitivity and normality.

For the finite family of BNT representatives, the individual normality witnesses therefore have a common positive multiple. This supplies a common block-injectivity length directly from `IsBNTCanonicalForm` and removes the explicit common-length hypothesis from the representative-grouped Lemma L conclusion, including its same-MPV formulation.

The blueprint and `docs/paper-gaps/cpgsv17_bicf_block_separation.tex` now record this implication as proved. The remaining MPDO task is to relate the flattened `HorizontalCFData` formulation to the representative-indexed canonical form.

## Sources

- arXiv:1606.00608, lines 318--344 and Appendix C.3, Lemma L, lines 1835--1858.
- arXiv:2011.12127, lines 1815--1837.
- arXiv:1708.00029, Appendix A.
- Wolf, *Quantum Channels & Operations*, Theorem 6.6.

## Proof integrity

No axiom, `sorry`, or kernel bypass is introduced. `#print axioms` for all four new public declarations reports only `propext`, `Classical.choice`, and `Quot.sound`.

## Verification

- `lake build`
- `lake env lean TNLean/MPS/Periodic/NormalizedSelfOverlap.lean`
- `lake env lean TNLean/MPS/MPDO/PostBlockedRepresentativeSpan.lean`
- `lake exe lint_style`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref main`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && chktex -q -l .chktexrc src/chapter/ch20_mpdo_canonical_forms.tex`
- `cd blueprint && leanblueprint checkdecls`
- `cd blueprint && leanblueprint pdf`

Progress on #3713 and #3674.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New formal theorems on the MPDO/BNT canonical-form path rely on peripheral spectrum and overlap limit arguments; scope is proof-only (no new axioms), but errors here would affect downstream Lemma L composition.
> 
> **Overview**
> **Derives a common block-injectivity length and unblocked Lemma L directly from `IsBNTCanonicalForm`, without an explicit common-length hypothesis.**
> 
> Adds `TNLean/MPS/Periodic/NormalizedSelfOverlap.lean`: an irreducible left-canonical tensor whose MPV self-overlap tends to **1** is **normal** (peripheral period forced to 1 via periodic vs. normalized subsequence limits, then primitivity). From BNT hypotheses on each representative, `exists_common_basis_isNBlkInjective` follows by combining that with the existing normality chain.
> 
> `PostBlockedRepresentativeSpan` gains **`insertedTensor_basis_eq_of_firstSiteActionAgree`** (and same-MPV variant), wiring the new existence lemma into the prior common-block-injectivity blocking argument. Root import and blueprint ch20 lean links are updated; **`docs/paper-gaps/cpgsv17_bicf_block_separation.tex`** records the closed gap and notes the remaining **`HorizontalCFData`** vs. representative-indexed formulation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd54b322e907b8f5b9cc72c630fefb7836670d03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->