### PR TITLE
feat(MPS/RFP): prove Appendix D parent-kernel intersection

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/LocalSupport.lean
+++ b/TNLean/MPS/ParentHamiltonian/LocalSupport.lean
@@ -254,8 +254,18 @@ The source writes two local projectors \(Q_{AX}\) and \(Q_{XB}\) on the
 overlapping pairs \(AX\) and \(XB\). Besides idempotence and commutation after
 lifting them to \(A X B\), Definition D.2 includes the local ground-space
 condition that the three-site subspace is the intersection of their two lifted
-kernels. Orthogonality and the construction of these projectors from the
-Appendix B basic-vector form are still separate obligations. -/
+kernels.
+
+For the Appendix B coefficient-space representatives, the canonical
+construction is proved by
+`AppendixBStructuralData.hasAppendixD2ParentCommutingHamiltonian`: the two maps
+are the canonical two-site parent interaction, their lifts commute, and their
+lifted kernels intersect in \(G_3(A)\) when \(A\) is injective. These concrete
+coefficient-space maps are orthogonal by construction, although orthogonality
+is not asserted by the condition recorded here. Identifying them with the
+source projectors on \(\mathcal H_A\otimes\mathcal H_X\) and
+\(\mathcal H_X\otimes\mathcal H_B\), and completing the general equivalence of
+Proposition D.3, remain separate obligations. -/
 structure HasAppendixD2ParentCommutingHamiltonian
     (KAXB : Submodule ℂ (NSiteSpace d 3))
     (QAX QXB : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2) : Prop where

--- a/TNLean/MPS/ParentHamiltonian/LocalSupport.lean
+++ b/TNLean/MPS/ParentHamiltonian/LocalSupport.lean
@@ -247,25 +247,14 @@ structure HasOverlappingTwoSiteCommutation
     leftPairLift QAX * rightPairLift QXB =
       rightPairLift QXB * leftPairLift QAX
 
-/-- The local projector condition of arXiv:1606.00608, Definition D.2, on one
-three-site window.
+/-- A coefficient-space condition modeled on arXiv:1606.00608, Definition D.2,
+for one three-site window.
 
-The source writes two local projectors \(Q_{AX}\) and \(Q_{XB}\) on the
-overlapping pairs \(AX\) and \(XB\). Besides idempotence and commutation after
-lifting them to \(A X B\), Definition D.2 includes the local ground-space
-condition that the three-site subspace is the intersection of their two lifted
-kernels.
-
-For the Appendix B coefficient-space representatives, the canonical
-construction is proved by
-`AppendixBStructuralData.hasAppendixD2ParentCommutingHamiltonian`: the two maps
-are the canonical two-site parent interaction, their lifts commute, and their
-lifted kernels intersect in \(G_3(A)\) when \(A\) is injective. These concrete
-coefficient-space maps are orthogonal by construction, although orthogonality
-is not asserted by the condition recorded here. Identifying them with the
-source projectors on \(\mathcal H_A\otimes\mathcal H_X\) and
-\(\mathcal H_X\otimes\mathcal H_B\), and completing the general equivalence of
-Proposition D.3, remain separate obligations. -/
+It requires two idempotent two-site maps whose lifts commute and a three-site
+subspace equal to the intersection of their lifted kernels. It does not assert
+self-adjointness or identify these maps with the source projectors on
+\(\mathcal H_A\otimes\mathcal H_X\) and
+\(\mathcal H_X\otimes\mathcal H_B\). -/
 structure HasAppendixD2ParentCommutingHamiltonian
     (KAXB : Submodule ℂ (NSiteSpace d 3))
     (QAX QXB : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2) : Prop where

--- a/TNLean/MPS/ParentHamiltonian/LocalSupportTransport.lean
+++ b/TNLean/MPS/ParentHamiltonian/LocalSupportTransport.lean
@@ -4,13 +4,15 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.ParentHamiltonian.Basic
 import TNLean.MPS.ParentHamiltonian.LocalSupport
+import TNLean.MPS.ParentHamiltonian.Martingale.Transport
 
 /-!
-# Transport of the three-site nearest-neighbor commutator
+# Three-site local support and transport of the nearest-neighbor commutator
 
-This file transports the local commutation relation between the two adjacent
-length-two parent interactions on a three-site window to every translated
-three-site window of a longer periodic chain.
+This file first identifies the three-site MPS ground space with the
+intersection of the kernels of its two adjacent length-two parent interactions.
+It then transports the local commutation relation between these interactions
+to every translated three-site window of a longer periodic chain.
 
 The chain-length hypothesis is (3 \leq N), matching the (N>2) condition in
 arXiv:1606.00608, Theorem 3.10 and the local relation
@@ -20,6 +22,53 @@ arXiv:1606.00608, Theorem 3.10 and the local relation
 namespace MPSTensor
 
 variable {d D : ℕ}
+
+/-! ### Three-site kernel intersection -/
+
+/-- On an injective MPS tensor, a vector on \(L+1\) sites lies in the local MPS
+ground space precisely when both adjacent length-\(L\) parent interactions
+annihilate it.
+
+This is the function-space form of the standard MPS intersection property. It
+is obtained from the Euclidean-space statement without changing the two local
+operators.
+
+Source: arXiv:2011.12127, Section IV.C, lines 2013--2078. -/
+theorem adjacent_localTerm_eq_zero_iff_mem_groundSpace_succ
+    {A : MPSTensor d D} (hA : IsInjective A) {L : ℕ} (hL : 1 < L)
+    {v : NSiteSpace d (L + 1)} :
+    localTerm A L (L + 1) (0 : Fin (L + 1)) v = 0 ∧
+        localTerm A L (L + 1) (1 : Fin (L + 1)) v = 0 ↔
+      v ∈ groundSpace A (L + 1) := by
+  let e := WithLp.linearEquiv 2 ℂ (NSiteSpace d (L + 1))
+  have h := adjacent_localTermES_eq_zero_iff_mem_groundSpaceES_succ
+    hA hL (v := e.symm v)
+  simpa [localTermES, e, mem_groundSpaceES_iff] using h
+
+/-- The three-site MPS ground space of an injective tensor is the intersection
+of the kernels of the two adjacent canonical two-site parent interactions:
+\[
+  G_3(A)=\ker(q_2(A)_{AX})\cap\ker(q_2(A)_{XB}).
+\]
+
+This is the three-site specialization of the MPS intersection property, written
+in the local-support notation of arXiv:1606.00608, Definition D.2. Definition
+D.2 is a separate statement in Appendix D; the source proof of Theorem 3.10
+does not invoke it.
+
+Source: arXiv:1606.00608, Definition D.2, lines 2205--2218;
+arXiv:2011.12127, Section IV.C, lines 2013--2078. -/
+theorem groundSpace_three_eq_adjacent_twoSite_parent_kernels
+    {A : MPSTensor d D} (hA : IsInjective A) :
+    groundSpace A 3 =
+      LinearMap.ker (leftPairLift (parentInteraction A 2)) ⊓
+        LinearMap.ker (rightPairLift (parentInteraction A 2)) := by
+  ext v
+  rw [Submodule.mem_inf, LinearMap.mem_ker, LinearMap.mem_ker]
+  rw [← localTerm_two_three_zero_eq_leftPairLift_parentInteraction]
+  rw [← localTerm_two_three_one_eq_rightPairLift_parentInteraction]
+  exact (adjacent_localTerm_eq_zero_iff_mem_groundSpace_succ
+    hA (by omega : 1 < 2)).symm
 
 private theorem extractWindow_two_replaceWindow_three_left
     {N : ℕ} (hN : 3 ≤ N) (i : Fin N) (τ : Cfg d N) (σ : Cfg d 3) :

--- a/TNLean/MPS/ParentHamiltonian/LocalSupportTransport.lean
+++ b/TNLean/MPS/ParentHamiltonian/LocalSupportTransport.lean
@@ -17,6 +17,20 @@ to every translated three-site window of a longer periodic chain.
 The chain-length hypothesis is (3 \leq N), matching the (N>2) condition in
 arXiv:1606.00608, Theorem 3.10 and the local relation
 \([\tau_1(P_2),P_2]=0\) in Definition 3.9.
+
+## Main statements
+
+* `adjacent_localTerm_eq_zero_iff_mem_groundSpace_succ` characterizes the
+  \((L+1)\)-site ground space by the two adjacent length-\(L\) kernels.
+* `groundSpace_three_eq_adjacent_twoSite_parent_kernels` gives the three-site
+  specialization for the canonical two-site parent interaction.
+* `localTerm_adjacent_twoSite_commute_of_threeSite_zero_one_commute` transports
+  the three-site commutator to every translated three-site window.
+
+## References
+
+* arXiv:2011.12127, Section IV.C.
+* arXiv:1606.00608, Definition 3.9 and Appendix D, Definition D.2.
 -/
 
 namespace MPSTensor
@@ -52,9 +66,7 @@ of the kernels of the two adjacent canonical two-site parent interactions:
 \]
 
 This is the three-site specialization of the MPS intersection property, written
-in the local-support notation of arXiv:1606.00608, Definition D.2. Definition
-D.2 is a separate statement in Appendix D; the source proof of Theorem 3.10
-does not invoke it.
+in the local-support notation of arXiv:1606.00608, Definition D.2.
 
 Source: arXiv:1606.00608, Definition D.2, lines 2205--2218;
 arXiv:2011.12127, Section IV.C, lines 2013--2078. -/

--- a/TNLean/MPS/RFP/AppendixBChainCommutation.lean
+++ b/TNLean/MPS/RFP/AppendixBChainCommutation.lean
@@ -23,6 +23,65 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
+/-- The canonical two-site parent interactions supplied by an Appendix B
+structural datum satisfy the algebraic and kernel-intersection clauses of
+Definition D.2 on the three-site MPS ground space, provided the tensor is
+injective.
+
+The two operators are the canonical parent interaction \(q_2(A)\), placed on
+the \(AX\) and \(XB\) faces. Their commutation was obtained from the adjacent
+virtual-bond projectors. The remaining kernel equation is the standard
+three-site MPS intersection property. The result type records idempotence,
+commutation, and the kernel equation; orthogonality of these concrete
+interactions follows separately from the definition of \(q_2(A)\).
+
+This theorem relates the Appendix B basic-vector construction to the separate
+condition in Appendix D. It is not the argument printed for the implication
+RFP \(\Rightarrow\) NNCPH: arXiv:1606.00608, lines 1305--1307, calls that
+implication an immediate consequence of the structural characterization.
+
+Source: arXiv:1606.00608, Theorem 3.11, lines 543--578; Definition D.2,
+lines 2205--2218; and the proof of Theorem 3.10, lines 1305--1307. -/
+theorem AppendixBStructuralData.hasAppendixD2ParentCommutingHamiltonian
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    (hA : IsInjective A) :
+    HasAppendixD2ParentCommutingHamiltonian (d := d) (groundSpace A 3)
+      hStruct.appendixBQAXOnCoeffSpace hStruct.appendixBQXBOnCoeffSpace := by
+  refine
+    { left_idempotent := hStruct.appendixBQAXOnCoeffSpace_idempotent
+      right_idempotent := hStruct.appendixBQXBOnCoeffSpace_idempotent
+      commute_lifts := hStruct.hasOverlappingTwoSiteCommutation.commute_lifts
+      kernel_intersection := ?_ }
+  rw [hStruct.appendixBQAXOnCoeffSpace_eq_parentInteraction]
+  rw [hStruct.appendixBQXBOnCoeffSpace_eq_parentInteraction]
+  exact groundSpace_three_eq_adjacent_twoSite_parent_kernels hA
+
+/-- A normal left-canonical RFP tensor supplies the three-site algebraic and
+kernel-intersection datum of arXiv:1606.00608, Definition D.2.
+
+Injectivity is not an additional hypothesis: it follows from normality, the RFP
+identity, and left-canonical normalization. This is a local Appendix D
+corollary of the Appendix B structural form. It is logically separate from the
+one-sentence proof of RFP \(\Rightarrow\) NNCPH at source lines 1305--1307.
+
+**Scope restriction (left-canonical local datum):** The source structural
+theorem is stated for tensors in canonical form. This result uses the proved
+left-canonical specialization recorded in
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
+
+Source: arXiv:1606.00608, Theorems 3.10--3.11, lines 534--578 and
+1305--1307; Definition D.2, lines 2205--2218. -/
+theorem rfp_hasAppendixD2ParentCommutingHamiltonian_of_leftCanonical
+    (A : MPSTensor d D) [NeZero D]
+    (hRFP : IsRFP A) (hNT : IsNormal A) (hLeft : IsLeftCanonical A) :
+    let hStruct := AppendixBStructuralData.ofRFP A hNT hRFP hLeft
+    HasAppendixD2ParentCommutingHamiltonian (d := d) (groundSpace A 3)
+      hStruct.appendixBQAXOnCoeffSpace hStruct.appendixBQXBOnCoeffSpace := by
+  dsimp only
+  exact AppendixBStructuralData.hasAppendixD2ParentCommutingHamiltonian
+    (AppendixBStructuralData.ofRFP A hNT hRFP hLeft)
+    (rfp_nt_structural_of_leftCanonical A hNT hRFP hLeft)
+
 /-- The Appendix B structural datum gives commutation of adjacent translated
 length-two parent interactions on every periodic chain of length (N>2).
 

--- a/TNLean/MPS/RFP/AppendixBChainCommutation.lean
+++ b/TNLean/MPS/RFP/AppendixBChainCommutation.lean
@@ -24,9 +24,9 @@ namespace MPSTensor
 variable {d D : ℕ}
 
 /-- The canonical two-site parent interactions supplied by an Appendix B
-structural datum satisfy the algebraic and kernel-intersection clauses of
-Definition D.2 on the three-site MPS ground space, provided the tensor is
-injective.
+structural datum satisfy the coefficient-space analogues of the algebraic and
+kernel-intersection equations in Definition D.2 on the three-site MPS ground
+space, provided the tensor is injective.
 
 The two operators are the canonical parent interaction \(q_2(A)\), placed on
 the \(AX\) and \(XB\) faces. Their commutation was obtained from the adjacent
@@ -34,10 +34,11 @@ virtual-bond projectors. The remaining kernel equation is the standard
 three-site MPS intersection property. Thus the two interactions are
 idempotent, their lifts commute, and the intersection of their lifted kernels
 is \(G_3(A)\). They are orthogonal projectors because \(q_2(A)\) is the
-canonical orthogonal parent interaction.
+canonical orthogonal parent interaction. This theorem does not identify these
+maps with the source projectors on the two explicitly factored Hilbert spaces.
 
 This theorem relates the Appendix B basic-vector construction to the separate
-condition in Appendix D. It is not the argument printed for the implication
+equations in Appendix D. It is not the argument printed for the implication
 RFP \(\Rightarrow\) NNCPH: arXiv:1606.00608, lines 1305--1307, calls that
 implication an immediate consequence of the structural characterization.
 
@@ -57,8 +58,9 @@ theorem AppendixBStructuralData.hasAppendixD2ParentCommutingHamiltonian
   rw [hStruct.appendixBQXBOnCoeffSpace_eq_parentInteraction]
   exact groundSpace_three_eq_adjacent_twoSite_parent_kernels hA
 
-/-- A normal left-canonical RFP tensor supplies the three-site algebraic and
-kernel-intersection datum of arXiv:1606.00608, Definition D.2.
+/-- A normal left-canonical RFP tensor supplies the three-site coefficient-space
+analogue of the algebraic and kernel-intersection datum in arXiv:1606.00608,
+Definition D.2.
 
 Injectivity is not an additional hypothesis: it follows from normality, the RFP
 identity, and left-canonical normalization. This is a local Appendix D

--- a/TNLean/MPS/RFP/AppendixBChainCommutation.lean
+++ b/TNLean/MPS/RFP/AppendixBChainCommutation.lean
@@ -38,12 +38,10 @@ canonical orthogonal parent interaction. This theorem does not identify these
 maps with the source projectors on the two explicitly factored Hilbert spaces.
 
 This theorem relates the Appendix B basic-vector construction to the separate
-equations in Appendix D. It is not the argument printed for the implication
-RFP \(\Rightarrow\) NNCPH: arXiv:1606.00608, lines 1305--1307, calls that
-implication an immediate consequence of the structural characterization.
+equations in Appendix D.
 
-Source: arXiv:1606.00608, Theorem 3.11, lines 543--578; Definition D.2,
-lines 2205--2218; and the proof of Theorem 3.10, lines 1305--1307. -/
+Source: arXiv:1606.00608, Theorem 3.11, lines 543--578, and Definition D.2,
+lines 2205--2218. -/
 theorem AppendixBStructuralData.hasAppendixD2ParentCommutingHamiltonian
     {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
     (hA : IsInjective A) :
@@ -63,17 +61,15 @@ analogue of the algebraic and kernel-intersection datum in arXiv:1606.00608,
 Definition D.2.
 
 Injectivity is not an additional hypothesis: it follows from normality, the RFP
-identity, and left-canonical normalization. This is a local Appendix D
-corollary of the Appendix B structural form. It is logically separate from the
-one-sentence proof of RFP \(\Rightarrow\) NNCPH at source lines 1305--1307.
+identity, and left-canonical normalization.
 
 **Scope restriction (left-canonical local datum):** The source structural
 theorem is stated for tensors in canonical form. This result uses the proved
 left-canonical specialization recorded in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
-Source: arXiv:1606.00608, Theorems 3.10--3.11, lines 534--578 and
-1305--1307; Definition D.2, lines 2205--2218. -/
+Source: arXiv:1606.00608, Theorem 3.11, lines 543--578, and Definition D.2,
+lines 2205--2218. -/
 theorem rfp_hasAppendixD2ParentCommutingHamiltonian_of_leftCanonical
     (A : MPSTensor d D) [NeZero D]
     (hRFP : IsRFP A) (hNT : IsNormal A) (hLeft : IsLeftCanonical A) :

--- a/TNLean/MPS/RFP/AppendixBChainCommutation.lean
+++ b/TNLean/MPS/RFP/AppendixBChainCommutation.lean
@@ -31,9 +31,10 @@ injective.
 The two operators are the canonical parent interaction \(q_2(A)\), placed on
 the \(AX\) and \(XB\) faces. Their commutation was obtained from the adjacent
 virtual-bond projectors. The remaining kernel equation is the standard
-three-site MPS intersection property. The result type records idempotence,
-commutation, and the kernel equation; orthogonality of these concrete
-interactions follows separately from the definition of \(q_2(A)\).
+three-site MPS intersection property. Thus the two interactions are
+idempotent, their lifts commute, and the intersection of their lifted kernels
+is \(G_3(A)\). They are orthogonal projectors because \(q_2(A)\) is the
+canonical orthogonal parent interaction.
 
 This theorem relates the Appendix B basic-vector construction to the separate
 condition in Appendix D. It is not the argument printed for the implication

--- a/TNLean/MPS/RFP/CommutingBridge.lean
+++ b/TNLean/MPS/RFP/CommutingBridge.lean
@@ -65,6 +65,10 @@ passage from the spectator range projector \(UU^*\) to the full physical
 identity are proved in `TNLean.MPS.RFP.AppendixBCommutation`. Their complements
 give the local commutator, which is transported around every periodic chain with
 \(N>2\) in `TNLean.MPS.RFP.AppendixBChainCommutation`.
+That file also combines the commutator with the standard three-site MPS
+intersection property to obtain the algebraic and kernel-intersection clauses
+of Definition D.2 on \(K_{AXB}=G_3(A)\). Definition D.2 is not used in the
+source's one-sentence proof of RFP \(\Rightarrow\) NNCPH at lines 1305--1307.
 Accordingly, the conditional structures below continue to take the translated
 idempotents as hypotheses; the unconditional commutator is proved separately in
 `TNLean.MPS.RFP.AppendixBChainCommutation`.
@@ -610,9 +614,9 @@ theorem AppendixBStructuralData.hasOverlappingTwoSiteCommutation_of_commute_lift
 once the source projectors are transported to coefficient space and identified
 with the coefficient-space representatives.
 
-This statement does not construct the source projectors \(Q_{AX}\) and
-\(Q_{XB}\).  It records the exact transport step that will be used after those
-projectors are constructed from the Appendix B basic-vector form.
+This statement is only a conditional change of representatives. The
+unconditional Appendix B algebraic datum, including the kernel-intersection
+equation, is proved separately in `TNLean.MPS.RFP.AppendixBChainCommutation`.
 
 Source: arXiv:1606.00608, lines 543--578 and Definition D.2, lines
 2205--2218. -/
@@ -698,8 +702,9 @@ length-two parent terms on the three-site window.
 
 This theorem only transports the supplied idempotency and lifted-commutator
 clauses to the canonical parent interactions identified above; the
-kernel-intersection clause is not used here.  It does not construct the source
-projectors \(Q_{AX}\) and \(Q_{XB}\) from the Appendix B basic-vector form.
+kernel-intersection clause is not used here. The unconditional local algebraic
+and kernel-intersection clauses of Definition D.2 are proved separately in
+`TNLean.MPS.RFP.AppendixBChainCommutation`.
 
 Source: arXiv:1606.00608, lines 543--578 and Definition D.2, lines
 2205--2218. -/

--- a/TNLean/MPS/RFP/CommutingBridge.lean
+++ b/TNLean/MPS/RFP/CommutingBridge.lean
@@ -66,9 +66,10 @@ identity are proved in `TNLean.MPS.RFP.AppendixBCommutation`. Their complements
 give the local commutator, which is transported around every periodic chain with
 \(N>2\) in `TNLean.MPS.RFP.AppendixBChainCommutation`.
 That file also combines the commutator with the standard three-site MPS
-intersection property to obtain the algebraic and kernel-intersection clauses
-of Definition D.2 on \(K_{AXB}=G_3(A)\). Definition D.2 is not used in the
-source's one-sentence proof of RFP \(\Rightarrow\) NNCPH at lines 1305--1307.
+intersection property to obtain the coefficient-space analogues of the
+algebraic and kernel-intersection equations in Definition D.2 on
+\(K_{AXB}=G_3(A)\). Definition D.2 is not used in the source's one-sentence
+proof of RFP \(\Rightarrow\) NNCPH at lines 1305--1307.
 Accordingly, the conditional structures below continue to take the translated
 idempotents as hypotheses; the unconditional commutator is proved separately in
 `TNLean.MPS.RFP.AppendixBChainCommutation`.
@@ -703,8 +704,9 @@ length-two parent terms on the three-site window.
 This theorem only transports the supplied idempotency and lifted-commutator
 clauses to the canonical parent interactions identified above; the
 kernel-intersection clause is not used here. The unconditional local algebraic
-and kernel-intersection clauses of Definition D.2 are proved separately in
-`TNLean.MPS.RFP.AppendixBChainCommutation`.
+and kernel-intersection coefficient-space analogues are proved separately in
+`TNLean.MPS.RFP.AppendixBChainCommutation`; identification with the source
+projectors remains a separate hypothesis.
 
 Source: arXiv:1606.00608, lines 543--578 and Definition D.2, lines
 2205--2218. -/

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -1468,12 +1468,14 @@ specialization of that Appendix~D definition.
         (\widehat Q_{XB})_{XB}(\widehat Q_{AX})_{AX}.
     \]
     Thus they satisfy the algebraic overlapping two-site condition of
-    Definition~\ref{def:overlapping_two_site_supports}.  This is precisely the
-    projector-and-commutator part of
-    \cite[Definition~D.2]{Cirac2016MPDO_arXiv}.  By itself it does not prove
-    the kernel-intersection equation in that definition and makes no assertion
-    for every chain length.  The kernel equation is established in the next
-    two results.
+    Definition~\ref{def:overlapping_two_site_supports}.  This is the
+    coefficient-space analogue of the projector-and-commutator part of
+    \cite[Definition~D.2]{Cirac2016MPDO_arXiv}.  The hatted maps have not yet
+    been identified with the source projectors on the explicitly factored
+    spaces.  By itself the result does not prove the kernel-intersection
+    equation in that definition and makes no assertion for every chain length.
+    The coefficient-space kernel equation is established in the next two
+    results.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -1484,8 +1484,8 @@ specialization of that Appendix~D definition.
     of $P_2$ commute, their complementary lifts commute as well.
 \end{proof}
 
-\begin{lemma}[Three-site intersection of adjacent parent kernels]
-    \label{lem:three_site_ground_space_adjacent_parent_kernels}
+\begin{theorem}[Three-site intersection of adjacent parent kernels]
+    \label{thm:three_site_ground_space_adjacent_parent_kernels}
     \lean{MPSTensor.adjacent_localTerm_eq_zero_iff_mem_groundSpace_succ}
     \lean{MPSTensor.groundSpace_three_eq_adjacent_twoSite_parent_kernels}
     \leanok
@@ -1502,7 +1502,7 @@ specialization of that Appendix~D definition.
     More generally, on $L+1$ sites, simultaneous annihilation by the two
     adjacent length-$L$ parent interactions is equivalent to membership in
     $G_{L+1}(A)$ whenever $A$ is injective and $L>1$.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}
     \leanok
@@ -1519,7 +1519,7 @@ specialization of that Appendix~D definition.
     \lean{MPSTensor.rfp_hasAppendixD2ParentCommutingHamiltonian_of_leftCanonical}
     \leanok
     \uses{thm:appendixB_overlapping_two_site_commutation,
-        lem:three_site_ground_space_adjacent_parent_kernels,
+        thm:three_site_ground_space_adjacent_parent_kernels,
         lem:appendixB_qax_qxb_parent_interaction}
     Let $A$ be injective and let an Appendix~B structural datum be fixed.  Put
     \[
@@ -1547,7 +1547,7 @@ specialization of that Appendix~D definition.
     Idempotency and commutation are
     Theorem~\ref{thm:appendixB_overlapping_two_site_commutation}.  The two
     coefficient representatives are $q_2(A)$, and
-    Lemma~\ref{lem:three_site_ground_space_adjacent_parent_kernels} supplies
+    Theorem~\ref{thm:three_site_ground_space_adjacent_parent_kernels} supplies
     the remaining kernel equation.  This Appendix~D corollary is not the
     argument printed for RFP $\Rightarrow$ NNCPH: the source proof at lines
     1305--1307 instead refers directly to the structural characterization.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -1548,9 +1548,10 @@ specialization of that Appendix~D definition.
     Theorem~\ref{thm:appendixB_overlapping_two_site_commutation}.  The two
     coefficient representatives are $q_2(A)$, and
     Theorem~\ref{thm:three_site_ground_space_adjacent_parent_kernels} supplies
-    the remaining kernel equation.  This Appendix~D corollary is not the
-    argument printed for RFP $\Rightarrow$ NNCPH: the source proof at lines
-    1305--1307 instead refers directly to the structural characterization.
+    the remaining kernel equation.
+    % Source-scope note: this Appendix D corollary is not the argument printed
+    % for RFP => NNCPH.  The proof at source lines 1305--1307 instead refers
+    % directly to the structural characterization.
 \end{proof}
 
 \begin{theorem}[Transport of the three-site commutator]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -16,6 +16,13 @@ condition also says that, for $N>L$, the ground space is spanned by the
 periodic MPS vectors associated to the BNT components; nearest-neighbor means
 the specialization $L=2$.
 
+The proof of the forward implication in
+\cite[Theorem~3.10]{Cirac2016MPDO_arXiv} is the single sentence at source
+lines 1305--1307 saying that it follows immediately from the structural
+characterization in Theorem~3.11.  It does not invoke Definition~D.2.  The
+three-site kernel intersection proved below is instead a separate local
+specialization of that Appendix~D definition.
+
 \begin{definition}[Overlapping two-site supports]\label{def:overlapping_two_site_supports}
     \lean{MPSTensor.axPairCfg}
     \lean{MPSTensor.xbPairCfg}
@@ -1463,9 +1470,10 @@ the specialization $L=2$.
     Thus they satisfy the algebraic overlapping two-site condition of
     Definition~\ref{def:overlapping_two_site_supports}.  This is precisely the
     projector-and-commutator part of
-    \cite[Definition~D.2]{Cirac2016MPDO_arXiv}.  It neither constructs the
-    source projectors nor proves the kernel-intersection equation in that
-    definition, and it makes no assertion for every chain length.
+    \cite[Definition~D.2]{Cirac2016MPDO_arXiv}.  By itself it does not prove
+    the kernel-intersection equation in that definition and makes no assertion
+    for every chain length.  The kernel equation is established in the next
+    two results.
 \end{theorem}
 
 \begin{proof}
@@ -1474,6 +1482,75 @@ the specialization $L=2$.
     two-site basic support projector.  Their idempotency was established in
     Lemma~\ref{lem:appendixB_qax_qxb_idempotent}.  Since the two adjacent lifts
     of $P_2$ commute, their complementary lifts commute as well.
+\end{proof}
+
+\begin{lemma}[Three-site intersection of adjacent parent kernels]
+    \label{lem:three_site_ground_space_adjacent_parent_kernels}
+    \lean{MPSTensor.adjacent_localTerm_eq_zero_iff_mem_groundSpace_succ}
+    \lean{MPSTensor.groundSpace_three_eq_adjacent_twoSite_parent_kernels}
+    \leanok
+    \uses{thm:local_term_two_three_ax_xb_lifts,
+        thm:ground_space_intersection, def:parent_interaction, def:injective}
+    If $A$ is injective, then
+    \[
+        G_3(A)
+        =
+        \ker\bigl(q_2(A)_{AX}\bigr)
+        \cap
+        \ker\bigl(q_2(A)_{XB}\bigr).
+    \]
+    More generally, on $L+1$ sites, simultaneous annihilation by the two
+    adjacent length-$L$ parent interactions is equivalent to membership in
+    $G_{L+1}(A)$ whenever $A$ is injective and $L>1$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    By Theorem~\ref{thm:ground_space_intersection}, a three-site vector belongs
+    to $G_3(A)$ exactly when its restrictions to both adjacent pairs belong to
+    $G_2(A)$.  Since $\ker q_2(A)=G_2(A)$, this is equivalent to annihilation
+    by both adjacent terms.  Theorem~\ref{thm:local_term_two_three_ax_xb_lifts}
+    identifies these terms with the two displayed lifts.
+\end{proof}
+
+\begin{theorem}[Appendix B realization of the local Appendix D kernel datum]
+    \label{thm:appendixB_definition_d2_local_realization}
+    \lean{MPSTensor.AppendixBStructuralData.hasAppendixD2ParentCommutingHamiltonian}
+    \lean{MPSTensor.rfp_hasAppendixD2ParentCommutingHamiltonian_of_leftCanonical}
+    \leanok
+    \uses{thm:appendixB_overlapping_two_site_commutation,
+        lem:three_site_ground_space_adjacent_parent_kernels,
+        lem:appendixB_qax_qxb_parent_interaction}
+    Let $A$ be injective and let an Appendix~B structural datum be fixed.  Put
+    \[
+        K_{AXB}=G_3(A),\qquad
+        Q_{AX}=q_2(A),\qquad Q_{XB}=q_2(A),
+    \]
+    with the two copies of $q_2(A)$ placed on the indicated faces.  Then
+    \[
+        [Q_{AX},Q_{XB}]=0,
+        \qquad
+        K_{AXB}
+        =\ker\bigl((Q_{AX})_{AX}\bigr)
+          \cap\ker\bigl((Q_{XB})_{XB}\bigr).
+    \]
+    Thus these canonical local interactions satisfy the idempotence,
+    commutation, and kernel-intersection clauses of
+    \cite[Definition~D.2]{Cirac2016MPDO_arXiv}.  The conclusion here is limited
+    to these three clauses.  For a normal left-canonical RFP tensor, injectivity
+    follows from the RFP structural theorem and is not an additional
+    hypothesis.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Idempotency and commutation are
+    Theorem~\ref{thm:appendixB_overlapping_two_site_commutation}.  The two
+    coefficient representatives are $q_2(A)$, and
+    Lemma~\ref{lem:three_site_ground_space_adjacent_parent_kernels} supplies
+    the remaining kernel equation.  This Appendix~D corollary is not the
+    argument printed for RFP $\Rightarrow$ NNCPH: the source proof at lines
+    1305--1307 instead refers directly to the structural characterization.
 \end{proof}
 
 \begin{theorem}[Transport of the three-site commutator]
@@ -1855,11 +1932,8 @@ the specialization $L=2$.
     \[
         \widehat Q_{AX}=q_2(A),\qquad \widehat Q_{XB}=q_2(A),
     \]
-    as coefficient-space representatives. This is not yet the construction of
-    the source projectors \(Q_{AX}\) and \(Q_{XB}\) on
-    \(\mathcal H_A\otimes\mathcal H_X\) and
-    \(\mathcal H_X\otimes\mathcal H_B\). On the three-site window the
-    coefficient representatives give the local identifications
+    as coefficient-space representatives. On the three-site window their two
+    lifts give the local identifications
     \[
         h_0^{(3)}(A,2)=(\widehat Q_{AX})_{AX},\qquad
         h_1^{(3)}(A,2)=(\widehat Q_{XB})_{XB}.
@@ -1924,9 +1998,10 @@ the specialization $L=2$.
     physical-pair factorization displayed above.  That factorization remains a
     separate conditional coefficient statement.  The full source implication
     additionally requires removal of the left-canonical hypothesis and the
-    ground-space spanning equation.  The kernel-intersection characterization
-    of the projectors in \cite[Definition~D.2]{Cirac2016MPDO_arXiv} also
-    remains separate.
+    ground-space spanning equation.  The local kernel-intersection
+    characterization of Definition~D.2 is
+    Theorem~\ref{thm:appendixB_definition_d2_local_realization}; it is a
+    separate Appendix~D statement and is not needed for the chain commutator.
 \end{remark}
 
 \begin{theorem}[Even-chain factorization and ground-space spanning give all-chain NNCPH]%

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -1513,8 +1513,8 @@ specialization of that Appendix~D definition.
     identifies these terms with the two displayed lifts.
 \end{proof}
 
-\begin{theorem}[Appendix B realization of the local Appendix D kernel datum]
-    \label{thm:appendixB_definition_d2_local_realization}
+\begin{theorem}[Appendix B coefficient-space analogue of the Appendix D kernel datum]
+    \label{thm:appendixB_definition_d2_coefficient_analogue}
     \lean{MPSTensor.AppendixBStructuralData.hasAppendixD2ParentCommutingHamiltonian}
     \lean{MPSTensor.rfp_hasAppendixD2ParentCommutingHamiltonian_of_leftCanonical}
     \leanok
@@ -1523,23 +1523,26 @@ specialization of that Appendix~D definition.
         lem:appendixB_qax_qxb_parent_interaction}
     Let $A$ be injective and let an Appendix~B structural datum be fixed.  Put
     \[
-        K_{AXB}=G_3(A),\qquad
-        Q_{AX}=q_2(A),\qquad Q_{XB}=q_2(A),
+        \widehat K_{AXB}=G_3(A),\qquad
+        \widehat Q_{AX}=q_2(A),\qquad \widehat Q_{XB}=q_2(A),
     \]
-    with the two copies of $q_2(A)$ placed on the indicated faces.  Then
+    with the two copies of $q_2(A)$ lifted to the indicated faces of the
+    three-site coefficient space.  Then
     \[
-        [Q_{AX},Q_{XB}]=0,
+        [ (\widehat Q_{AX})_{AX}, (\widehat Q_{XB})_{XB}]=0,
         \qquad
-        K_{AXB}
-        =\ker\bigl((Q_{AX})_{AX}\bigr)
-          \cap\ker\bigl((Q_{XB})_{XB}\bigr).
+        \widehat K_{AXB}
+        =\ker\bigl((\widehat Q_{AX})_{AX}\bigr)
+          \cap\ker\bigl((\widehat Q_{XB})_{XB}\bigr).
     \]
-    Thus these canonical local interactions satisfy the idempotence,
-    commutation, and kernel-intersection clauses of
-    \cite[Definition~D.2]{Cirac2016MPDO_arXiv}.  The conclusion here is limited
-    to these three clauses.  For a normal left-canonical RFP tensor, injectivity
-    follows from the RFP structural theorem and is not an additional
-    hypothesis.
+    These are the coefficient-space analogues of the idempotence, commutation,
+    and kernel-intersection equations in
+    \cite[Definition~D.2]{Cirac2016MPDO_arXiv}.  The hatted operators are not
+    identified here with the source projectors on
+    $\mathcal H_A\otimes\mathcal H_X$ and
+    $\mathcal H_X\otimes\mathcal H_B$.  For a normal left-canonical RFP tensor,
+    injectivity follows from the RFP structural theorem and is not an
+    additional hypothesis.
 \end{theorem}
 
 \begin{proof}
@@ -1999,10 +2002,11 @@ specialization of that Appendix~D definition.
     physical-pair factorization displayed above.  That factorization remains a
     separate conditional coefficient statement.  The full source implication
     additionally requires removal of the left-canonical hypothesis and the
-    ground-space spanning equation.  The local kernel-intersection
-    characterization of Definition~D.2 is
-    Theorem~\ref{thm:appendixB_definition_d2_local_realization}; it is a
-    separate Appendix~D statement and is not needed for the chain commutator.
+    ground-space spanning equation.  The coefficient-space analogue of the
+    local kernel-intersection equation is
+    Theorem~\ref{thm:appendixB_definition_d2_coefficient_analogue}; identifying
+    its hatted maps with the source projectors remains separate and is not
+    needed for the chain commutator.
 \end{remark}
 
 \begin{theorem}[Even-chain factorization and ground-space spanning give all-chain NNCPH]%

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -114,9 +114,10 @@ equivalence with ZCL, the complete canonical-form hypotheses from the source
 statement, or the Beigi ground-space characterization as an internal theorem.
 For the forward RFP-to-NNCPH direction, the three-site \(AX/XB\) support maps
 are now represented in \leanid{MPSTensor.HasOverlappingTwoSiteCommutation};
-Appendix~B supplies the basic-vector form, while the projectors
-\(Q_{AX}\) and \(Q_{XB}\) belong to the Appendix~D.2 parent-commuting
-condition.  The coefficients in the basic-vector form now define the physical
+Appendix~B supplies the basic-vector form.  The local projectors in
+Definition~D.2 belong to a separate Appendix~D discussion and are not invoked
+by the one-sentence proof of RFP \(\Rightarrow\) NNCPH at source lines
+1305--1307.  The coefficients in the basic-vector form now define the physical
 isometry
 \begin{align}
   (Uv)_i=\sum_{\alpha,\beta}U^i_{\alpha,\beta}v_{\alpha,\beta},
@@ -159,8 +160,8 @@ The coefficient-space representatives
 \leanid{MPSTensor.AppendixBStructuralData.appendixBQAXOnCoeffSpace} and
 \leanid{MPSTensor.AppendixBStructuralData.appendixBQXBOnCoeffSpace} are now identified with
 the canonical two-site parent interaction \(q_2(A)\) before placement on the
-\(AX\) and \(XB\) faces.  They should not be read as the source tripartite
-projectors themselves.  The one-bond virtual projector and its two adjacent
+\(AX\) and \(XB\) faces.  Their two lifts are the corresponding local actions
+on the tripartite space.  The one-bond virtual projector and its two adjacent
 placements are now constructed in
 \leanid{MPSTensor.AppendixBStructuralData.virtualBondProjection},
 \leanid{MPSTensor.AppendixBStructuralData.leftVirtualBondProjection}, and
@@ -178,6 +179,15 @@ and
 \leanid{MPSTensor.AppendixBStructuralData.adjacent_twoSite_localTerms_commute}.
 The resulting commuting projector family is
 \leanid{MPSTensor.AppendixBStructuralData.hasProductPairLocalProjectors}.
+The separate Appendix~D algebraic and kernel-intersection clauses are also now
+proved locally:
+\leanid{MPSTensor.AppendixBStructuralData.}
+\hspace{0pt}\leanid{hasAppendixD2ParentCommutingHamiltonian} identifies
+\(K_{AXB}=G_3(A)\) with the intersection of the two lifted kernels.  Its RFP
+corollary derives injectivity from the normal left-canonical RFP hypotheses.
+The concrete canonical parent interactions are orthogonal by construction, but
+the structure returned by this declaration does not expose self-adjointness.
+This local result is not used in the chain commutator proof.
 Consequently the forward commutation and zero-energy statements are proved for
 normal left-canonical RFP tensors by
 \leanid{MPSTensor.rfp_implies_nncph_of_leftCanonical} and

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -160,9 +160,12 @@ The coefficient-space representatives
 \leanid{MPSTensor.AppendixBStructuralData.appendixBQAXOnCoeffSpace} and
 \leanid{MPSTensor.AppendixBStructuralData.appendixBQXBOnCoeffSpace} are now identified with
 the canonical two-site parent interaction \(q_2(A)\) before placement on the
-\(AX\) and \(XB\) faces.  Their two lifts are the corresponding local actions
-on the tripartite space.  The one-bond virtual projector and its two adjacent
-placements are now constructed in
+\(AX\) and \(XB\) faces.  Write these coefficient-space maps as
+\(\widehat Q_{AX}\) and \(\widehat Q_{XB}\).  Their two lifts act on the
+three-site coefficient space; they are not yet identified with the source
+projectors on \(\mathcal H_A\otimes\mathcal H_X\) and
+\(\mathcal H_X\otimes\mathcal H_B\).  The one-bond virtual projector and its
+two adjacent placements are now constructed in
 \leanid{MPSTensor.AppendixBStructuralData.virtualBondProjection},
 \leanid{MPSTensor.AppendixBStructuralData.leftVirtualBondProjection}, and
 \leanid{MPSTensor.AppendixBStructuralData.rightVirtualBondProjection}. Their
@@ -179,15 +182,18 @@ and
 \leanid{MPSTensor.AppendixBStructuralData.adjacent_twoSite_localTerms_commute}.
 The resulting commuting projector family is
 \leanid{MPSTensor.AppendixBStructuralData.hasProductPairLocalProjectors}.
-The separate Appendix~D algebraic and kernel-intersection clauses are also now
-proved locally:
+The coefficient-space analogues of the Appendix~D algebraic and
+kernel-intersection equations are also now proved locally:
 \leanid{MPSTensor.AppendixBStructuralData.}
 \hspace{0pt}\leanid{hasAppendixD2ParentCommutingHamiltonian} identifies
-\(K_{AXB}=G_3(A)\) with the intersection of the two lifted kernels.  Its RFP
-corollary derives injectivity from the normal left-canonical RFP hypotheses.
-The concrete canonical parent interactions are orthogonal by construction, but
-the structure returned by this declaration does not expose self-adjointness.
-This local result is not used in the chain commutator proof.
+\(\widehat K_{AXB}=G_3(A)\) with the intersection of the kernels of the lifts
+of \(\widehat Q_{AX}\) and \(\widehat Q_{XB}\).  Its RFP corollary derives
+injectivity from the normal left-canonical RFP hypotheses.  The concrete
+canonical parent interactions are orthogonal by construction, but the
+condition recorded by this declaration does not assert self-adjointness.  It
+remains to construct the source projectors and identify their transported
+actions with the hatted coefficient-space maps.  This local coefficient-space
+result is not used in the chain commutator proof.
 Consequently the forward commutation and zero-energy statements are proved for
 normal left-canonical RFP tensors by
 \leanid{MPSTensor.rfp_implies_nncph_of_leftCanonical} and

--- a/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
+++ b/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
@@ -125,12 +125,11 @@ representatives are
 \leanid{MPSTensor.AppendixBStructuralData.appendixBQAXOnCoeffSpace} and
 \leanid{MPSTensor.AppendixBStructuralData.appendixBQXBOnCoeffSpace}; both are identified
 with the canonical two-site parent interaction \(q_2(A)\) before placement on
-the \(AX\) and \(XB\) faces. These representatives are not yet the source
-orthogonal projectors \(Q_{AX}\) and \(Q_{XB}\) on
-\(\mathcal H_A\otimes\mathcal H_X\) and
-\(\mathcal H_X\otimes\mathcal H_B\). Their lifted commutator is now proved
-from the adjacent virtual-bond projectors and their isometric transport, as
-recorded by
+the \(AX\) and \(XB\) faces.  Since \(q_2(A)\) is the canonical orthogonal
+projector onto \(G_2(A)^\perp\), these are precisely the orthogonal local parent
+interactions \(Q_{AX}\) and \(Q_{XB}\) required on the two source factors.
+Their lifted commutator follows from the adjacent virtual-bond projectors and
+their isometric transport, as recorded by
 \leanid{MPSTensor.AppendixBStructuralData.}\hspace{0pt}
 \leanid{twoSiteBasicSupportProjection_commute_lifts} and
 \leanid{MPSTensor.AppendixBStructuralData.hasOverlappingTwoSiteCommutation}.

--- a/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
+++ b/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
@@ -151,11 +151,14 @@ now recorded by
   G_3(A)=
   \ker(q_2(A)_{AX})\cap\ker(q_2(A)_{XB}).
 \end{align}
-Consequently the Appendix~B representatives, placed on their two faces, give
-the idempotence, commutation, and kernel-intersection clauses of Definition~D.2
-on \(K_{AXB}=G_3(A)\), as proved by
+Consequently the Appendix~B representatives, placed on their two faces, satisfy
+the coefficient-space analogues of the idempotence, commutation, and
+kernel-intersection equations in Definition~D.2, with
+\(\widehat K_{AXB}=G_3(A)\), as proved by
 \leanid{MPSTensor.AppendixBStructuralData.}
 \hspace{0pt}\leanid{hasAppendixD2ParentCommutingHamiltonian}.
+This theorem does not identify these hatted maps with the source projectors on
+the two explicitly factored Hilbert spaces.
 For a normal left-canonical RFP tensor, the injectivity used by the intersection
 property is derived from the RFP hypotheses in
 \leanid{MPSTensor.rfp_hasAppendixD2ParentCommutingHamiltonian_of_leftCanonical};

--- a/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
+++ b/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
@@ -16,6 +16,12 @@
 
 \section{Source condition}
 
+This Appendix~D condition is not the route used in the proof of the forward
+RFP-to-NNCPH implication.  The proof of Theorem~3.10 at source lines
+1305--1307 consists of one sentence saying that the implication is immediate
+from the structural characterization in Theorem~3.11.  Definition~D.2 belongs
+to the later, independent discussion of decorrelation.
+
 Definition~D.2 of \cite{Cirac2016MPDO_arXiv} states the parent commuting
 Hamiltonian condition for a tripartite Hilbert space
 \(\mathcal H_A\otimes\mathcal H_X\otimes\mathcal H_B\).  It uses local
@@ -70,11 +76,9 @@ kernel-intersection equation
 \[
   K_{AXB}=\ker((Q_{AX})_{AX})\cap\ker((Q_{XB})_{XB})
 \]
-is now recorded by
+is recorded by
 \leanid{MPSTensor.HasAppendixD2ParentCommutingHamiltonian}, whose forgetful
-projection gives the algebraic overlapping-commutation predicate.  What remains
-outside this local package is the orthogonal-projector identification and the
-construction of \(Q_{AX}\) and \(Q_{XB}\) from the Appendix~B basic-vector form.
+projection gives the algebraic overlapping-commutation predicate.
 The scalar pair-index equation has now been assembled into the physical map
 \begin{align}
   (Uv)_i=\sum_{\alpha,\beta}U^i_{\alpha,\beta}v_{\alpha,\beta},
@@ -133,21 +137,42 @@ recorded by
 The corresponding adjacent parent terms commute on every periodic chain with
 \(N>2\), by
 \leanid{MPSTensor.AppendixBStructuralData.adjacent_twoSite_localTerms_commute}.
+For an injective tensor, the general three-site MPS intersection identity is
+now recorded by
+\leanid{MPSTensor.groundSpace_three_eq_adjacent_twoSite_parent_kernels}:
+\begin{align}
+  G_3(A)=
+  \ker(q_2(A)_{AX})\cap\ker(q_2(A)_{XB}).
+\end{align}
+Consequently the Appendix~B representatives, placed on their two faces, give
+the idempotence, commutation, and kernel-intersection clauses of Definition~D.2
+on \(K_{AXB}=G_3(A)\), as proved by
+\leanid{MPSTensor.AppendixBStructuralData.}
+\hspace{0pt}\leanid{hasAppendixD2ParentCommutingHamiltonian}.
+For a normal left-canonical RFP tensor, the injectivity used by the intersection
+property is derived from the RFP hypotheses in
+\leanid{MPSTensor.rfp_hasAppendixD2ParentCommutingHamiltonian_of_leftCanonical};
+it is not an additional assumption.
 
 \section{Elimination plan}
 
-The Appendix~B commutator needed for the forward RFP-to-NNCPH argument is now
-proved. What remains for a full formalization of Definition~D.2 is different:
-construct the source projectors \(Q_{AX}\) and \(Q_{XB}\) as orthogonal
-projectors on the stated tensor factors and prove the kernel-intersection
-identity
-\[
-  K_{AXB}=\ker((Q_{AX})_{AX})\cap\ker((Q_{XB})_{XB}).
-\]
-The current coefficient-space theorem supplies the commutator part but does not
-identify that tripartite subspace. The algebraic idempotent-product declaration
-remains the lemma used in the backward direction of Proposition~D.3. The work
-is tracked by \ghissue{3373}, \ghissue{2633}, and \ghissue{190}.
+The algebraic and kernel-intersection clauses in the local Appendix~B
+specialization of Definition~D.2 are now proved: the operators are the
+canonical orthogonal parent interactions \(q_2(A)\), their lifts commute, and
+their kernel intersection is \(G_3(A)\).  This does not
+complete the general decorrelation equivalence of Proposition~D.3.  In
+particular, \leanid{Decorrelation.HasCommutingParentHam} remains only its
+algebraic idempotent-product consequence, and the generic
+\leanid{MPSTensor.HasAppendixD2ParentCommutingHamiltonian} structure does not
+itself record self-adjointness.  The concrete canonical parent interactions
+used here are orthogonal by construction, but a fully general source-facing
+package should expose that property explicitly and complete both directions of
+Proposition~D.3.  That work is tracked separately by \ghissue{190}.
+
+For Theorem~3.10, the remaining obligations are instead the full
+canonical-form scope and the all-chain ground-space spanning statement.  They
+are tracked by \ghissue{2633}; Definition~D.2 should not be presented as their
+missing proof route.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
+++ b/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
@@ -126,10 +126,18 @@ representatives are
 \leanid{MPSTensor.AppendixBStructuralData.appendixBQXBOnCoeffSpace}; both are identified
 with the canonical two-site parent interaction \(q_2(A)\) before placement on
 the \(AX\) and \(XB\) faces.  Since \(q_2(A)\) is the canonical orthogonal
-projector onto \(G_2(A)^\perp\), these are precisely the orthogonal local parent
-interactions \(Q_{AX}\) and \(Q_{XB}\) required on the two source factors.
-Their lifted commutator follows from the adjacent virtual-bond projectors and
-their isometric transport, as recorded by
+projector onto \(G_2(A)^\perp\), these coefficient-space maps are orthogonal.
+They are not, by themselves, constructions of the source projectors on
+\(\mathcal H_A\otimes\mathcal H_X\) and
+\(\mathcal H_X\otimes\mathcal H_B\), as stated in their defining docstrings in
+\texttt{TNLean/MPS/RFP/CommutingBridge.lean}.  The additional identification,
+after transporting the source projectors to coefficient space, is the explicit
+hypothesis of
+\leanid{MPSTensor.AppendixBStructuralData.}\hspace{0pt}
+\leanid{hasOverlappingTwoSiteCommutation_of_appendixD2_identified_projectors}.
+Without that identification, the lifted commutator of the coefficient-space
+maps follows directly from the adjacent virtual-bond projectors and their
+isometric transport, as recorded by
 \leanid{MPSTensor.AppendixBStructuralData.}\hspace{0pt}
 \leanid{twoSiteBasicSupportProjection_commute_lifts} and
 \leanid{MPSTensor.AppendixBStructuralData.hasOverlappingTwoSiteCommutation}.
@@ -155,13 +163,16 @@ it is not an additional assumption.
 
 \section{Elimination plan}
 
-The algebraic and kernel-intersection clauses in the local Appendix~B
-specialization of Definition~D.2 are now proved: the operators are the
-canonical orthogonal parent interactions \(q_2(A)\), their lifts commute, and
-their kernel intersection is \(G_3(A)\).  This does not
-complete the general decorrelation equivalence of Proposition~D.3.  In
-particular, \leanid{Decorrelation.HasCommutingParentHam} remains only its
-algebraic idempotent-product consequence, and the generic
+The coefficient-space analogue of the algebraic and kernel-intersection clauses
+is now proved: the operators are the canonical orthogonal parent interactions
+\(q_2(A)\), their lifts commute, and their kernel intersection is \(G_3(A)\).
+It remains to construct the source projectors on the two stated tensor factors
+and identify their transported actions with these coefficient-space maps.  The
+conditional comparison theorem cited above records precisely this missing
+identification.  This also does not complete the general decorrelation
+equivalence of Proposition~D.3.  In particular,
+\leanid{Decorrelation.HasCommutingParentHam} remains only its algebraic
+idempotent-product consequence, and the generic
 \leanid{MPSTensor.HasAppendixD2ParentCommutingHamiltonian} structure does not
 itself record self-adjointness.  The concrete canonical parent interactions
 used here are orthogonal by construction, but the general statement should

--- a/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
+++ b/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
@@ -164,8 +164,8 @@ particular, \leanid{Decorrelation.HasCommutingParentHam} remains only its
 algebraic idempotent-product consequence, and the generic
 \leanid{MPSTensor.HasAppendixD2ParentCommutingHamiltonian} structure does not
 itself record self-adjointness.  The concrete canonical parent interactions
-used here are orthogonal by construction, but a fully general source-facing
-package should expose that property explicitly and complete both directions of
+used here are orthogonal by construction, but the general statement should
+require self-adjointness explicitly and establish both directions of
 Proposition~D.3.  That work is tracked separately by \ghissue{190}.
 
 For Theorem~3.10, the remaining obligations are instead the full


### PR DESCRIPTION
## Motivation

The source parent-commuting condition in arXiv:1606.00608, Definition D.2, lines 2205–2218, requires two projectors on the explicitly factored spaces `H_A ⊗ H_X` and `H_X ⊗ H_B`, together with commutation of their tripartite actions and the equation

`K_AXB = ker((Q_AX)_AX) ∩ ker((Q_XB)_XB)`.

TNLean already has Appendix B coefficient-space representatives equal to the canonical two-site parent interaction, their overlapping commutation, and the resulting all-chain `HasProductPairLocalProjectors` witness. This PR proves the corresponding three-site kernel intersection in coefficient space. It does not construct the source projectors or identify their transported actions with the coefficient-space representatives.

This Appendix D comparison is separate from the proof of Theorem 3.10. The printed proof at arXiv:1606.00608, lines 1305–1307, says that RFP implies NNCPH immediately from the structural characterization in Theorem 3.11; it does not invoke Definition D.2.

## Description

- Transport the adjacent-local-term intersection theorem from the Euclidean realization to the coefficient-space realization.
- Prove that, for an injective tensor,
  `G_3(A) = ker(q_2(A)_AX) ∩ ker(q_2(A)_XB)`.
- Combine this identity with the existing idempotence and overlapping commutation of the Appendix B coefficient-space representatives.
- Derive the corresponding normal left-canonical RFP statement without adding injectivity as a hypothesis.
- Present the result in the blueprint with hatted coefficient-space operators, without identifying them with the source projectors.
- Update the source-scope notes:
  - `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`
  - `docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex`

The residual source obligation is to construct `Q_AX` and `Q_XB` on the two stated tensor factors and prove that, after transport to coefficient space, their actions agree with the hatted representatives used here. The general Proposition D.3 equivalence, including its self-adjointness assumptions, also remains open.

## Testing

- `lake build TNLean`
- `lake build TNLean.MPS.ParentHamiltonian.LocalSupportTransport TNLean.MPS.RFP.AppendixBChainCommutation`
- `lake env lean TNLean/MPS/RFP/CommutingBridge.lean`
- `leanblueprint web`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

Addresses #3373

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds proved formal lemmas and documentation in the MPS parent-Hamiltonian layer with no runtime, auth, or data-path changes; residual risk is mathematical scope (D.2 vs NNCPH) rather than production breakage.
> 
> **Overview**
> This PR **closes the missing kernel-intersection clause** of the coefficient-space analogue of arXiv:1606.00608 Definition D.2, without constructing the source Hilbert-space projectors \(Q_{AX}, Q_{XB}\).
> 
> **Lean:** `LocalSupportTransport.lean` now transports the Euclidean adjacent-local-term intersection to coefficient space (`adjacent_localTerm_eq_zero_iff_mem_groundSpace_succ`) and proves **`G_3(A) = \ker(q_2(A)_{AX}) \cap \ker(q_2(A)_{XB})`** for injective tensors (`groundSpace_three_eq_adjacent_twoSite_parent_kernels`). `AppendixBChainCommutation.lean` combines that with existing idempotence and overlapping commutation to prove `HasAppendixD2ParentCommutingHamiltonian` for Appendix B structural data, plus an **RFP left-canonical corollary** where injectivity is derived, not assumed. Docstrings on `HasAppendixD2ParentCommutingHamiltonian` and bridge lemmas are tightened to stress **coefficient-space analogues** and that unconditional D.2 data lives in `AppendixBChainCommutation`.
> 
> **Blueprint & gap notes:** Chapter 13 adds theorems for the three-site kernel identity and the full hatted D.2 coefficient analogue; prose clarifies that **Theorem 3.10’s one-sentence proof (lines 1305–1307) does not use Definition D.2**—the new intersection is a separate Appendix D specialization. Scope documents (`cpsv16_nncph_ground_state_scope.tex`, `cpsv16_parent_commuting_hamiltonian_scope.tex`) are updated accordingly; **identifying hatted maps with source projectors remains open**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cc93e6c61aef2c618e165a2662f41efea9f9978. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->