### PR TITLE
feat(MPS/MPDO): prove literal horizontal BNT reduction

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -382,6 +382,7 @@ import TNLean.MPS.MPDO.RepresentativeGroupedLemmaL
 import TNLean.MPS.MPDO.PostBlockedRepresentativeSpan
 import TNLean.MPS.MPDO.HorizontalCFMPVRepresentation
 import TNLean.MPS.MPDO.InvariantProjection
+import TNLean.MPS.MPDO.HorizontalBNT
 import TNLean.MPS.MPDO.PeriodicExclusion
 import TNLean.MPS.MPDO.StackedLayers
 import TNLean.MPS.MPDO.CyclicProjector

--- a/TNLean/MPS/MPDO/CyclicProjector.lean
+++ b/TNLean/MPS/MPDO/CyclicProjector.lean
@@ -624,11 +624,13 @@ operator $H^{(N)}$ at every length.
 This is the horizontal-canonical-form step of the periodic-sector argument.
 The source assumes the tensor is in canonical form in the horizontal
 direction; the argument of lines 1874--1887 (Lemma L of the appendix,
-formalized blockwise in `TNLean/MPS/MPDO/PerCopyHorizontalCF.lean`) then turns
-all-length commutation of $Q_1$ with $H^{(N)}$ into the letter-level
-invariance $Q\widetilde M=Q\widetilde MQ$; contrapositively, a displaced
-projector cannot commute.  The derivation of this implication from a
-horizontal canonical form of `M` remains open; it is recorded in
+formalized for the literal representative-indexed horizontal canonical form
+in `TNLean/MPS/MPDO/HorizontalBNT.lean`) turns the full positive-length family
+of first-site identities into the letter-level invariance
+$Q\widetilde M=Q\widetilde MQ$.  The remaining problem is stronger: the
+predicate below asks noncommutation at every fixed length separately, while
+commutation at one fixed length does not supply the full family consumed by
+Lemma L.  This residual interface is recorded in
 `docs/paper-gaps/cpgsv17_periodic_sector_projector.tex`. -/
 def NoninvariantProjectorNoncommuting {d D : ℕ} (M : MPOTensor d D) : Prop :=
   ∀ Q : Matrix (Fin d) (Fin d) ℂ, Q.IsHermitian → IsIdempotentElem Q →
@@ -641,8 +643,9 @@ spectrum supplies the invariant, displaced projector unconditionally
 (`exists_displaced_invariant_projector_of_periodic_vector`), and the
 displacement upgrades to the all-length non-commutation family through the
 hypothesis.  This reduces the periodic-sector step of the proof of
-Proposition 4.13 of arXiv:1606.00608, lines 1888--1893, to the
-canonical-form implication of lines 1874--1887. -/
+Proposition 4.13 of arXiv:1606.00608, lines 1888--1893, to the explicit
+all-length non-commutation interface; the scope marker below records the two
+remaining ways to eliminate that interface. -/
 theorem periodicVectorYieldsCyclicProjector_of_noncommutation
     {d D : ℕ} (M : MPOTensor d D)
     (hNC : NoninvariantProjectorNoncommuting M) :
@@ -660,10 +663,13 @@ Proposition 4.13 of arXiv:1606.00608, lines 1888--1893, with the projector
 and its word invariance constructed from the cyclic decomposition of the
 peripheral spectrum (Wolf 2012, Theorem 6.6) rather than assumed.
 
-**Scope restriction (conditional on the non-commutation family):** the source
-derives the non-commutation from the horizontal canonical form through the
-argument of lines 1874--1887; here that implication is the explicit
-hypothesis.  Recorded in
+**Scope restriction (conditional on the non-commutation family):** the literal
+horizontal canonical-form argument of lines 1874--1887 rules out simultaneous
+commutation at all positive lengths and hence yields at least one noncommuting
+length.  The hypothesis here requires noncommutation at every length.  The
+remaining alternatives are to derive that stronger family from the cyclic
+decomposition and peripheral spectral hypotheses, or to weaken the final
+contradiction to consume one noncommuting length.  Recorded in
 `docs/paper-gaps/cpgsv17_periodic_sector_projector.tex`. -/
 theorem hasNoPeriodicVectors_verticalTensor_of_noncommutation
     {d D : ℕ} (M : MPOTensor d D) (hM : IsMPDO M)
@@ -699,13 +705,11 @@ several gauge-inequivalent canonical-form blocks with weights; this theorem
 covers the sub-case where `M`'s own tensor is already (single-letter)
 injective. Discharging `NoninvariantProjectorNoncommuting` for a general
 horizontal canonical form remains open, and is documented in
-`docs/paper-gaps/cpgsv17_periodic_sector_projector.tex` together with the
-reason the general route resists this proof strategy: at chain length `1`
-(the only length at which a general, block-injective argument working
-through `SameMPV₂` could plausibly reach `M`'s own letters), the single
-trailing letter is the identity, giving only one trace-level equation per
-matrix-entry pair — far short of what nondegeneracy of the trace pairing
-needs to separate a whole matrix. -/
+`docs/paper-gaps/cpgsv17_periodic_sector_projector.tex`.  Literal gauge
+transport is now available.  The residual obstruction is that the
+representative Lemma L consumes the full positive-length family, whereas
+`NoninvariantProjectorNoncommuting` demands a contradiction from commutation
+at each single fixed length. -/
 theorem hasNoPeriodicVectors_verticalTensor_of_isInjective
     {d D : ℕ} (M : MPOTensor d D) (hM : IsMPDO M)
     (hInj : MPSTensor.IsInjective M.toMPSTensor) :

--- a/TNLean/MPS/MPDO/HorizontalBNT.lean
+++ b/TNLean/MPS/MPDO/HorizontalBNT.lean
@@ -1,0 +1,446 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.BlockTriangularTrace
+import TNLean.MPS.MPDO.InvariantProjection
+import TNLean.MPS.MPDO.PostBlockedRepresentativeSpan
+
+/-!
+# Representative-indexed horizontal canonical form
+
+This file connects the public horizontal canonical-form predicate for an MPO
+to the representative-grouped form of Lemma L.  Repeated copies of a normal
+tensor are grouped by their BNT representative before the trace-separation
+argument is applied.  The resulting first-site conclusion therefore holds on
+every representative without a per-copy separation hypothesis.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608, lines 264--301
+  and Appendix C.3, Lemma L, lines 1835--1858.
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Proposition 4.13, lines 1873--1887.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- Adjoin an all-zero block of dimension `z` to an MPS tensor.
+
+The horizontal canonical form of arXiv:1606.00608, lines 217--219 permits
+such a block: the sum of the nonzero block dimensions may be strictly smaller
+than the original bond dimension. -/
+noncomputable def zeroTail (A : MPSTensor d D) (z : ℕ) : MPSTensor d (z + D) :=
+  MPSTensor.diagFin (fun _ ↦ 0) A
+
+/-- An all-zero direct summand does not change any positive-length matrix
+product vector.
+
+Source: arXiv:1606.00608, lines 217--219. -/
+theorem zeroTail_sameMPV₂Pos (A : MPSTensor d D) (z : ℕ) :
+    MPSTensor.SameMPV₂Pos (zeroTail A z) A := by
+  classical
+  intro N hN σ
+  obtain ⟨n, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (Nat.ne_of_gt hN)
+  simp only [MPSTensor.mpv, MPSTensor.coeff, zeroTail]
+  let e : (Fin z ⊕ Fin D) ≃ Fin (z + D) := finSumFinEquiv
+  change Matrix.trace (MPSTensor.evalWord
+      (fun i ↦ Matrix.reindex e e (MPSTensor.diagSum (fun _ ↦ 0) A i))
+      (List.ofFn σ)) = _
+  rw [MPSTensor.evalWord_reindex (e := e)]
+  rw [Matrix.trace_reindex]
+  rw [MPSTensor.evalWord_diagSum_is_fromBlocks]
+  rw [MPSTensor.trace_fromBlocks_upper]
+  simp [List.ofFn_succ]
+
+/-- Positive-length matrix product vector equality transports a first-site
+action identity between tensors of possibly different bond dimensions.
+
+This is the form needed when a horizontal canonical form contains the zero
+summand allowed in arXiv:1606.00608, lines 217--219: first-site identities
+only involve chains of length `N + 1`, and hence never use the empty chain. -/
+theorem FirstSiteActionAgree.of_sameMPVPos {D' : ℕ} {A : MPSTensor d D}
+    {B : MPSTensor d D'} {Y Z : Matrix (Fin d) (Fin d) ℂ}
+    (hAB : MPSTensor.SameMPV₂Pos A B) (h : FirstSiteActionAgree A Y Z) :
+    FirstSiteActionAgree B Y Z := by
+  intro N σ
+  calc
+    ∑ i : Fin d, Y (σ 0) i * MPSTensor.mpv B (Fin.cons i (σ ∘ Fin.succ)) =
+        ∑ i : Fin d, Y (σ 0) i * MPSTensor.mpv A (Fin.cons i (σ ∘ Fin.succ)) := by
+      apply Finset.sum_congr rfl
+      intro i _
+      rw [hAB (N + 1) (Nat.succ_pos N) (Fin.cons i (σ ∘ Fin.succ))]
+    _ = ∑ i : Fin d, Z (σ 0) i *
+        MPSTensor.mpv A (Fin.cons i (σ ∘ Fin.succ)) := h N σ
+    _ = ∑ i : Fin d, Z (σ 0) i *
+        MPSTensor.mpv B (Fin.cons i (σ ∘ Fin.succ)) := by
+      apply Finset.sum_congr rfl
+      intro i _
+      rw [hAB (N + 1) (Nat.succ_pos N) (Fin.cons i (σ ∘ Fin.succ))]
+
+/-- First-site insertion commutes with adjoining an all-zero summand.
+
+Source: the zero-block allowance in arXiv:1606.00608, lines 217--219. -/
+theorem insertedTensor_zeroTail (Y : Matrix (Fin d) (Fin d) ℂ)
+    (A : MPSTensor d D) (z : ℕ) :
+    insertedTensor Y (zeroTail A z) = zeroTail (insertedTensor Y A) z := by
+  funext i a b
+  generalize ha : finSumFinEquiv.symm a = a'
+  generalize hb : finSumFinEquiv.symm b = b'
+  cases a' <;> cases b' <;>
+    simp [insertedTensor, zeroTail, diagFin, diagSum, Matrix.sum_apply,
+      Matrix.smul_apply, Matrix.submatrix_apply, ha, hb]
+
+/-- First-site insertion commutes with a weighted block-diagonal direct sum.
+
+This is the linear passage from the minimal representatives to the repeated
+sectors in arXiv:1606.00608, eq. `eq:II_ABasicTensors`, lines 281--301. -/
+theorem insertedTensor_toTensorFromBlocks {r : ℕ} {dim : Fin r → ℕ}
+    (Y : Matrix (Fin d) (Fin d) ℂ) (μ : Fin r → ℂ)
+    (A : (k : Fin r) → MPSTensor d (dim k)) :
+    insertedTensor Y (toTensorFromBlocks μ A) =
+      toTensorFromBlocks μ (fun k ↦ insertedTensor Y (A k)) := by
+  funext i
+  change (∑ j, Y i j •
+      Matrix.reindexLinearEquiv ℂ ℂ finSigmaFinEquiv finSigmaFinEquiv
+        (Matrix.blockDiagonal' fun k ↦ μ k • A k j)) =
+    Matrix.reindexLinearEquiv ℂ ℂ finSigmaFinEquiv finSigmaFinEquiv
+      (Matrix.blockDiagonal' fun k ↦ μ k • insertedTensor Y (A k) i)
+  simp_rw [← (Matrix.reindexLinearEquiv ℂ ℂ
+    finSigmaFinEquiv finSigmaFinEquiv).map_smul]
+  rw [← map_sum]
+  congr 1
+  funext a b
+  rw [Matrix.sum_apply]
+  simp_rw [Matrix.smul_apply]
+  by_cases h : a.1 = b.1
+  · simp_rw [Matrix.blockDiagonal'_apply, dif_pos h]
+    simp only [insertedTensor, Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
+    calc
+      ∑ x, Y i x * (μ a.1 * A a.1 x a.2 (cast _ b.2)) =
+          ∑ x, μ a.1 * (Y i x * A a.1 x a.2 (cast _ b.2)) := by
+        apply Finset.sum_congr rfl
+        intro x _
+        ring
+      _ = μ a.1 * ∑ x, Y i x * A a.1 x a.2 (cast _ b.2) :=
+        (Finset.mul_sum ..).symm
+  · simp_rw [Matrix.blockDiagonal'_apply, dif_neg h]
+    simp
+
+/-- Equality of insertions on every minimal representative gives equality on
+the full sector decomposition, including all repeated weighted copies.
+
+Source: arXiv:1606.00608, eq. `eq:II_ABasicTensors`, lines 281--301. -/
+theorem SectorDecomposition.insertedTensor_toTensor_eq_of_basis
+    (S : SectorDecomposition d) (Y Z : Matrix (Fin d) (Fin d) ℂ)
+    (h : ∀ j, insertedTensor Y (S.basis j) = insertedTensor Z (S.basis j)) :
+    insertedTensor Y S.toTensor = insertedTensor Z S.toTensor := by
+  rw [S.toTensor_eq_toTensorFromBlocks_flat,
+    insertedTensor_toTensorFromBlocks, insertedTensor_toTensorFromBlocks]
+  congr 1
+  funext s
+  exact h (S.flatIndexEquiv.symm s).1
+
+/-- An equality between two first-site insertions is preserved by a common
+global gauge conjugation.
+
+This is the gauge transport used after the direct-sum identity in
+arXiv:1606.00608, eq. `eq:II_ABasicTensors`, lines 281--301. -/
+theorem insertedTensor_eq_of_gauge
+    {A B : MPSTensor d D} (X : GL (Fin D) ℂ)
+    (hX : ∀ i, B i = (X : Matrix (Fin D) (Fin D) ℂ) * A i *
+      (((X)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ))
+    (Y Z : Matrix (Fin d) (Fin d) ℂ)
+    (hA : insertedTensor Y A = insertedTensor Z A) :
+    insertedTensor Y B = insertedTensor Z B := by
+  funext i
+  simp only [insertedTensor]
+  simp_rw [hX]
+  calc
+    ∑ j, Y i j • ((X : Matrix (Fin D) (Fin D) ℂ) * A j *
+        (((X)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) =
+        (X : Matrix (Fin D) (Fin D) ℂ) *
+          (∑ j, Y i j • A j) *
+            (((X)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
+      rw [Matrix.mul_sum, Matrix.sum_mul]
+      apply Finset.sum_congr rfl
+      intro j _
+      simp
+    _ = (X : Matrix (Fin D) (Fin D) ℂ) *
+          (∑ j, Z i j • A j) *
+            (((X)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
+      rw [show (∑ j, Y i j • A j) = ∑ j, Z i j • A j from congrFun hA i]
+    _ = ∑ j, Z i j • ((X : Matrix (Fin D) (Fin D) ℂ) * A j *
+        (((X)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) := by
+      rw [Matrix.mul_sum, Matrix.sum_mul]
+      apply Finset.sum_congr rfl
+      intro j _
+      simp
+
+end MPSTensor
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- Horizontal canonical form for an MPO tensor.
+
+The doubled-index tensor is literally gauge-conjugate to the direct sum of an
+all-zero block and a representative-indexed BNT sector decomposition.
+Repeated gauge-equivalent copies are grouped over one representative and
+retain their individual nonzero weights.  This is the decomposition in
+arXiv:1606.00608, lines 217--219 and eq. `eq:II_ABasicTensors`, lines 281--301. -/
+def IsHorizontalCF (M : MPOTensor d D) : Prop :=
+  ∃ S : MPSTensor.SectorDecomposition (d * d),
+    MPSTensor.IsBNTCanonicalForm S ∧
+      ∃ z : ℕ, ∃ hTotal : z + S.totalDim = D, ∃ X : GL (Fin D) ℂ,
+        ∀ i : Fin (d * d),
+          M.toMPSTensor i =
+            (X : Matrix (Fin D) (Fin D) ℂ) *
+              cast (by rw [hTotal] :
+                  Matrix (Fin (z + S.totalDim)) (Fin (z + S.totalDim)) ℂ =
+                    Matrix (Fin D) (Fin D) ℂ)
+                (MPSTensor.zeroTail S.toTensor z i) *
+              (((X)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)
+
+/-- Inserting the doubled-index right action gives the doubled-index tensor of
+right multiplication of the vertically viewed MPO tensor.
+
+Source: arXiv:1606.00608, Proposition 4.13, lines 1873--1887. -/
+theorem insertedTensor_braRightAction_toMPSTensor
+    (M : MPOTensor d D) (Q : Matrix (Fin d) (Fin d) ℂ) :
+    MPSTensor.insertedTensor (MPSTensor.braRightAction Q) M.toMPSTensor =
+      (M.braRightMul Q).toMPSTensor := by
+  funext p
+  rw [MPSTensor.insertedTensor]
+  change (∑ q : Fin (d * d),
+      MPSTensor.braRightAction Q p q • M q.divNat q.modNat) =
+    ∑ k : Fin d, Q k p.modNat • M p.divNat k
+  rw [← finProdFinEquiv.sum_comp]
+  rw [Fintype.sum_prod_type]
+  simp only [MPSTensor.braRightAction, MPSTensor.finProdFinEquiv_divNat,
+    MPSTensor.finProdFinEquiv_modNat, ite_smul, zero_smul]
+  rw [Fintype.sum_eq_single p.divNat]
+  · simp
+  · intro i hi
+    simp [hi.symm]
+
+/-- Inserting the doubled-index two-sided action gives the doubled-index tensor
+of two-sided multiplication of the vertically viewed MPO tensor.
+
+Source: arXiv:1606.00608, Proposition 4.13, lines 1873--1887. -/
+theorem insertedTensor_ketLeftBraRightAction_toMPSTensor
+    (M : MPOTensor d D) (Q : Matrix (Fin d) (Fin d) ℂ) :
+    MPSTensor.insertedTensor
+        (MPSTensor.ketLeftBraRightAction Q) M.toMPSTensor =
+      ((M.ketLeftMul Q).braRightMul Q).toMPSTensor := by
+  funext p
+  rw [MPSTensor.insertedTensor]
+  change (∑ q : Fin (d * d),
+      MPSTensor.ketLeftBraRightAction Q p q • M q.divNat q.modNat) =
+    ∑ j : Fin d, Q j p.modNat • (∑ k : Fin d, Q p.divNat k • M k j)
+  rw [← finProdFinEquiv.sum_comp]
+  rw [Fintype.sum_prod_type]
+  simp only [MPSTensor.ketLeftBraRightAction,
+    MPSTensor.finProdFinEquiv_divNat, MPSTensor.finProdFinEquiv_modNat]
+  simp_rw [Finset.smul_sum, smul_smul]
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro j _
+  apply Finset.sum_congr rfl
+  intro k _
+  congr 1
+  ring
+
+/-- The two first-site identities in Proposition 4.13 imply equality of the
+opposite-corner insertions on every BNT representative.
+
+Positive-length MPV equality transports the first-site identities from the
+doubled-index tensor of `M` to the representative-indexed sector
+decomposition.  The representative-grouped Lemma L then separates the BNT
+representatives while grouping all repeated copies of each representative.
+
+Source: arXiv:1606.00608, Appendix C.3, Lemma L, lines 1835--1858, applied to
+the contractions in Proposition 4.13, lines 1873--1887. -/
+theorem representative_opposite_insert_eq_of_rotated_mpo_entries
+    (M : MPOTensor d D) (S : MPSTensor.SectorDecomposition (d * d))
+    (hCF : MPSTensor.IsBNTCanonicalForm S)
+    (hM : MPSTensor.SameMPV₂Pos M.toMPSTensor S.toTensor)
+    (Q : Matrix (Fin d) (Fin d) ℂ)
+    (hInv : ∀ (N : ℕ) (ρ : Fin (N + 1) → Fin (d * d)),
+      (∑ i : Fin d, Q (ρ 0).divNat i *
+        mpo M (N + 1) (Fin.cons i (fun n => (ρ (Fin.succ n)).divNat))
+          (Fin.cons (ρ 0).modNat (fun n => (ρ (Fin.succ n)).modNat)) =
+      ∑ i : Fin d, ∑ j : Fin d, Q (ρ 0).divNat i *
+        mpo M (N + 1) (Fin.cons i (fun n => (ρ (Fin.succ n)).divNat))
+          (Fin.cons j (fun n => (ρ (Fin.succ n)).modNat)) * Q j (ρ 0).modNat))
+    (hComm : ∀ (N : ℕ) (ρ : Fin (N + 1) → Fin (d * d)),
+      (∑ i : Fin d, Q (ρ 0).divNat i *
+        mpo M (N + 1) (Fin.cons i (fun n => (ρ (Fin.succ n)).divNat))
+          (Fin.cons (ρ 0).modNat (fun n => (ρ (Fin.succ n)).modNat)) =
+      ∑ j : Fin d,
+        mpo M (N + 1)
+          (Fin.cons (ρ 0).divNat (fun n => (ρ (Fin.succ n)).divNat))
+          (Fin.cons j (fun n => (ρ (Fin.succ n)).modNat)) * Q j (ρ 0).modNat)) :
+    ∀ j, MPSTensor.insertedTensor (MPSTensor.braRightAction Q) (S.basis j) =
+      MPSTensor.insertedTensor (MPSTensor.ketLeftBraRightAction Q) (S.basis j) := by
+  intro j
+  calc
+    MPSTensor.insertedTensor (MPSTensor.braRightAction Q) (S.basis j) =
+        MPSTensor.insertedTensor (MPSTensor.ketLeftAction Q) (S.basis j) :=
+      (hCF.insertedTensor_basis_eq_of_firstSiteActionAgree
+        ((MPSTensor.firstSiteActionAgree_ketLeft_braRight M Q hComm).of_sameMPVPos hM)
+        j).symm
+    _ = MPSTensor.insertedTensor
+        (MPSTensor.ketLeftBraRightAction Q) (S.basis j) :=
+      hCF.insertedTensor_basis_eq_of_firstSiteActionAgree
+        ((MPSTensor.firstSiteActionAgree_ketLeft_ketLeftBraRight M Q hInv).of_sameMPVPos hM)
+        j
+
+/-- A one-sided invariant Hermitian matrix reduces every horizontal BNT
+representative.
+
+If `Q M = Q M Q` for the vertically viewed tensor, positivity of every MPDO
+density operator gives the two first-site identities in Proposition 4.13.
+The representative-grouped Lemma L then shows that the insertions of `M Q`
+and `Q M Q` agree on every representative.
+
+This is the representative-indexed form of the invariant-projection step in
+arXiv:1606.00608, Proposition 4.13, lines 1873--1887. -/
+theorem representative_braRight_eq_ketLeftBraRight_of_invariant
+    (M : MPOTensor d D) (hMpdo : IsMPDO M)
+    (S : MPSTensor.SectorDecomposition (d * d))
+    (hCF : MPSTensor.IsBNTCanonicalForm S)
+    (hM : MPSTensor.SameMPV₂Pos M.toMPSTensor S.toTensor)
+    {Q : Matrix (Fin d) (Fin d) ℂ} (hQ : Q.IsHermitian)
+    (hQM : M.ketLeftMul Q = (M.ketLeftMul Q).braRightMul Q) :
+    ∀ j, MPSTensor.insertedTensor (MPSTensor.braRightAction Q) (S.basis j) =
+      MPSTensor.insertedTensor (MPSTensor.ketLeftBraRightAction Q) (S.basis j) := by
+  refine representative_opposite_insert_eq_of_rotated_mpo_entries M S hCF hM Q ?_ ?_
+  · intro N ρ
+    have h := firstSiteMatrix_mul_mpo_of_ketLeftMul_invariant M Q hQM N
+    have h2 := Matrix.ext_iff.mpr h
+      (Fin.cons (ρ 0).divNat fun n => (ρ (Fin.succ n)).divNat)
+      (Fin.cons (ρ 0).modNat fun n => (ρ (Fin.succ n)).modNat)
+    rw [mul_firstSiteMatrix_apply] at h2
+    simp only [firstSiteMatrix_mul_apply] at h2
+    simp only [Fin.cons_zero, Function.comp_def, Fin.cons_succ] at h2
+    rw [h2]
+    simp only [Finset.sum_mul]
+    exact Finset.sum_comm
+  · intro N ρ
+    have h := firstSiteMatrix_mul_mpo_comm M hMpdo hQ hQM N
+    have h2 := Matrix.ext_iff.mpr h
+      (Fin.cons (ρ 0).divNat fun n => (ρ (Fin.succ n)).divNat)
+      (Fin.cons (ρ 0).modNat fun n => (ρ (Fin.succ n)).modNat)
+    rw [mul_firstSiteMatrix_apply, firstSiteMatrix_mul_apply] at h2
+    simp only [Fin.cons_zero, Function.comp_def, Fin.cons_succ] at h2
+    exact h2
+
+/-- The public horizontal canonical-form predicate supplies the
+representative-indexed invariant-projection conclusion.
+
+The witness is the BNT sector decomposition occurring in `IsHorizontalCF`.
+Repeated copies remain grouped over their common representative; no
+per-copy trace-separation hypothesis is introduced.  The equality is stated
+for positive lengths because the permitted all-zero summand changes only the
+empty-chain coefficient.
+
+Source: arXiv:1606.00608, lines 264--301 and Proposition 4.13,
+lines 1873--1887. -/
+theorem IsHorizontalCF.exists_representative_braRight_eq_ketLeftBraRight
+    (M : MPOTensor d D) (hHorizontal : IsHorizontalCF M) (hMpdo : IsMPDO M)
+    {Q : Matrix (Fin d) (Fin d) ℂ} (hQ : Q.IsHermitian)
+    (hQM : M.ketLeftMul Q = (M.ketLeftMul Q).braRightMul Q) :
+    ∃ S : MPSTensor.SectorDecomposition (d * d),
+      MPSTensor.IsBNTCanonicalForm S ∧
+      MPSTensor.SameMPV₂Pos M.toMPSTensor S.toTensor ∧
+      ∀ j, MPSTensor.insertedTensor (MPSTensor.braRightAction Q) (S.basis j) =
+        MPSTensor.insertedTensor (MPSTensor.ketLeftBraRightAction Q) (S.basis j) := by
+  obtain ⟨S, hCF, z, hTotal, X, hX⟩ := hHorizontal
+  subst D
+  have hGauge : MPSTensor.GaugeEquiv
+      (MPSTensor.zeroTail S.toTensor z) M.toMPSTensor := by
+    refine ⟨X, ?_⟩
+    intro i
+    simpa using hX i
+  have hMZero : MPSTensor.SameMPV₂Pos M.toMPSTensor
+      (MPSTensor.zeroTail S.toTensor z) := by
+    intro N _ σ
+    exact (hGauge.sameMPV N σ).symm
+  have hM : MPSTensor.SameMPV₂Pos M.toMPSTensor S.toTensor :=
+    hMZero.trans (MPSTensor.zeroTail_sameMPV₂Pos S.toTensor z)
+  exact ⟨S, hCF, hM,
+    representative_braRight_eq_ketLeftBraRight_of_invariant
+      M hMpdo S hCF hM hQ hQM⟩
+
+/-- A one-sided invariant Hermitian matrix also reduces the MPO tensor from
+the right.
+
+The representative-grouped Lemma L first identifies the two insertions on
+every minimal BNT representative.  Linearity gives the identity on all
+repeated weighted sectors and the all-zero summand, and the global gauge in
+`IsHorizontalCF` transports it to the original tensor.  Thus the conclusion
+is a literal equality of MPO tensors, rather than merely an equality of their
+MPV families.  The source specializes `Q` to an orthogonal projector; this
+implication only uses Hermiticity.
+
+This is the equation $\widetilde M Q=Q\widetilde M Q$ in the
+invariant-projection step of arXiv:1606.00608, Proposition 4.13, lines
+1873--1887. -/
+theorem IsHorizontalCF.braRight_eq_ketLeftBraRight_of_invariant
+    (M : MPOTensor d D) (hHorizontal : IsHorizontalCF M) (hMpdo : IsMPDO M)
+    {Q : Matrix (Fin d) (Fin d) ℂ} (hQ : Q.IsHermitian)
+    (hQM : M.ketLeftMul Q = (M.ketLeftMul Q).braRightMul Q) :
+    M.braRightMul Q = (M.ketLeftMul Q).braRightMul Q := by
+  obtain ⟨S, hCF, z, hTotal, X, hX⟩ := hHorizontal
+  subst D
+  have hX' : ∀ i, M.toMPSTensor i =
+      (X : Matrix (Fin (z + S.totalDim)) (Fin (z + S.totalDim)) ℂ) *
+        MPSTensor.zeroTail S.toTensor z i *
+        (((X)⁻¹ : GL (Fin (z + S.totalDim)) ℂ) :
+          Matrix (Fin (z + S.totalDim)) (Fin (z + S.totalDim)) ℂ) := by
+    intro i
+    simpa using hX i
+  have hGauge : MPSTensor.GaugeEquiv
+      (MPSTensor.zeroTail S.toTensor z) M.toMPSTensor := ⟨X, hX'⟩
+  have hMZero : MPSTensor.SameMPV₂Pos M.toMPSTensor
+      (MPSTensor.zeroTail S.toTensor z) := by
+    intro N _ σ
+    exact (hGauge.sameMPV N σ).symm
+  have hM : MPSTensor.SameMPV₂Pos M.toMPSTensor S.toTensor :=
+    hMZero.trans (MPSTensor.zeroTail_sameMPV₂Pos S.toTensor z)
+  have hBasis := representative_braRight_eq_ketLeftBraRight_of_invariant
+    M hMpdo S hCF hM hQ hQM
+  have hSector :
+      MPSTensor.insertedTensor (MPSTensor.braRightAction Q) S.toTensor =
+        MPSTensor.insertedTensor
+          (MPSTensor.ketLeftBraRightAction Q) S.toTensor :=
+    S.insertedTensor_toTensor_eq_of_basis _ _ hBasis
+  have hZero :
+      MPSTensor.insertedTensor (MPSTensor.braRightAction Q)
+          (MPSTensor.zeroTail S.toTensor z) =
+        MPSTensor.insertedTensor (MPSTensor.ketLeftBraRightAction Q)
+          (MPSTensor.zeroTail S.toTensor z) := by
+    rw [MPSTensor.insertedTensor_zeroTail,
+      MPSTensor.insertedTensor_zeroTail, hSector]
+  have hOriginal :
+      MPSTensor.insertedTensor (MPSTensor.braRightAction Q) M.toMPSTensor =
+        MPSTensor.insertedTensor
+          (MPSTensor.ketLeftBraRightAction Q) M.toMPSTensor :=
+    MPSTensor.insertedTensor_eq_of_gauge X hX' _ _ hZero
+  have hTensor : (M.braRightMul Q).toMPSTensor =
+      ((M.ketLeftMul Q).braRightMul Q).toMPSTensor := by
+    rw [← insertedTensor_braRightAction_toMPSTensor,
+      ← insertedTensor_ketLeftBraRightAction_toMPSTensor]
+    exact hOriginal
+  funext i j
+  have hij := congrFun hTensor (finProdFinEquiv (i, j))
+  simpa [toMPSTensor] using hij
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/HorizontalBNT.lean
+++ b/TNLean/MPS/MPDO/HorizontalBNT.lean
@@ -3,7 +3,6 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.Algebra.BlockTriangularTrace
 import TNLean.MPS.MPDO.InvariantProjection
 import TNLean.MPS.MPDO.PostBlockedRepresentativeSpan
 
@@ -29,72 +28,6 @@ open scoped Matrix BigOperators
 namespace MPSTensor
 
 variable {d D : ℕ}
-
-/-- Adjoin an all-zero block of dimension `z` to an MPS tensor.
-
-The horizontal canonical form of arXiv:1606.00608, lines 217--219 permits
-such a block: the sum of the nonzero block dimensions may be strictly smaller
-than the original bond dimension. -/
-noncomputable def zeroTail (A : MPSTensor d D) (z : ℕ) : MPSTensor d (z + D) :=
-  MPSTensor.diagFin (fun _ ↦ 0) A
-
-/-- An all-zero direct summand does not change any positive-length matrix
-product vector.
-
-Source: arXiv:1606.00608, lines 217--219. -/
-theorem zeroTail_sameMPV₂Pos (A : MPSTensor d D) (z : ℕ) :
-    MPSTensor.SameMPV₂Pos (zeroTail A z) A := by
-  classical
-  intro N hN σ
-  obtain ⟨n, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (Nat.ne_of_gt hN)
-  simp only [MPSTensor.mpv, MPSTensor.coeff, zeroTail]
-  let e : (Fin z ⊕ Fin D) ≃ Fin (z + D) := finSumFinEquiv
-  change Matrix.trace (MPSTensor.evalWord
-      (fun i ↦ Matrix.reindex e e (MPSTensor.diagSum (fun _ ↦ 0) A i))
-      (List.ofFn σ)) = _
-  rw [MPSTensor.evalWord_reindex (e := e)]
-  rw [Matrix.trace_reindex]
-  rw [MPSTensor.evalWord_diagSum_is_fromBlocks]
-  rw [MPSTensor.trace_fromBlocks_upper]
-  simp [List.ofFn_succ]
-
-/-- Positive-length matrix product vector equality transports a first-site
-action identity between tensors of possibly different bond dimensions.
-
-This is the form needed when a horizontal canonical form contains the zero
-summand allowed in arXiv:1606.00608, lines 217--219: first-site identities
-only involve chains of length `N + 1`, and hence never use the empty chain. -/
-theorem FirstSiteActionAgree.of_sameMPVPos {D' : ℕ} {A : MPSTensor d D}
-    {B : MPSTensor d D'} {Y Z : Matrix (Fin d) (Fin d) ℂ}
-    (hAB : MPSTensor.SameMPV₂Pos A B) (h : FirstSiteActionAgree A Y Z) :
-    FirstSiteActionAgree B Y Z := by
-  intro N σ
-  calc
-    ∑ i : Fin d, Y (σ 0) i * MPSTensor.mpv B (Fin.cons i (σ ∘ Fin.succ)) =
-        ∑ i : Fin d, Y (σ 0) i * MPSTensor.mpv A (Fin.cons i (σ ∘ Fin.succ)) := by
-      apply Finset.sum_congr rfl
-      intro i _
-      rw [hAB (N + 1) (Nat.succ_pos N) (Fin.cons i (σ ∘ Fin.succ))]
-    _ = ∑ i : Fin d, Z (σ 0) i *
-        MPSTensor.mpv A (Fin.cons i (σ ∘ Fin.succ)) := h N σ
-    _ = ∑ i : Fin d, Z (σ 0) i *
-        MPSTensor.mpv B (Fin.cons i (σ ∘ Fin.succ)) := by
-      apply Finset.sum_congr rfl
-      intro i _
-      rw [hAB (N + 1) (Nat.succ_pos N) (Fin.cons i (σ ∘ Fin.succ))]
-
-/-- First-site insertion commutes with adjoining an all-zero summand.
-
-Source: the zero-block allowance in arXiv:1606.00608, lines 217--219. -/
-theorem insertedTensor_zeroTail (Y : Matrix (Fin d) (Fin d) ℂ)
-    (A : MPSTensor d D) (z : ℕ) :
-    insertedTensor Y (zeroTail A z) = zeroTail (insertedTensor Y A) z := by
-  funext i a b
-  generalize ha : finSumFinEquiv.symm a = a'
-  generalize hb : finSumFinEquiv.symm b = b'
-  cases a' <;> cases b' <;>
-    simp [insertedTensor, zeroTail, diagFin, diagSum, Matrix.sum_apply,
-      Matrix.smul_apply, Matrix.submatrix_apply, ha, hb]
 
 /-- First-site insertion commutes with a weighted block-diagonal direct sum.
 
@@ -190,23 +123,54 @@ variable {d D : ℕ}
 
 /-- Horizontal canonical form for an MPO tensor.
 
-The doubled-index tensor is literally gauge-conjugate to the direct sum of an
-all-zero block and a representative-indexed BNT sector decomposition.
-Repeated gauge-equivalent copies are grouped over one representative and
-retain their individual nonzero weights.  This is the decomposition in
-arXiv:1606.00608, lines 217--219 and eq. `eq:II_ABasicTensors`, lines 281--301. -/
+The doubled-index tensor is the representative-indexed BNT sector
+decomposition, with one invertible gauge on each repeated copy.  Thus the
+global gauge is the block direct sum of the copy gauges, rather than an
+arbitrary similarity that could mix distinct sectors.  Repeated
+gauge-equivalent copies are grouped over one representative and retain their
+individual nonzero weights.  There is no additional all-zero summand.
+
+Source: arXiv:1606.00608, canonical form at lines 237--244 and the BNT
+decomposition `eq:II_ABasicTensors` at lines 281--301. -/
 def IsHorizontalCF (M : MPOTensor d D) : Prop :=
   ∃ S : MPSTensor.SectorDecomposition (d * d),
     MPSTensor.IsBNTCanonicalForm S ∧
-      ∃ z : ℕ, ∃ hTotal : z + S.totalDim = D, ∃ X : GL (Fin D) ℂ,
+      ∃ hTotal : S.totalDim = D,
+        ∃ X : (s : Fin S.totalCopies) → GL (Fin (S.flatDim s)) ℂ,
         ∀ i : Fin (d * d),
           M.toMPSTensor i =
-            (X : Matrix (Fin D) (Fin D) ℂ) *
-              cast (by rw [hTotal] :
-                  Matrix (Fin (z + S.totalDim)) (Fin (z + S.totalDim)) ℂ =
-                    Matrix (Fin D) (Fin D) ℂ)
-                (MPSTensor.zeroTail S.toTensor z i) *
-              (((X)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)
+            cast (by rw [hTotal] :
+                Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ =
+                  Matrix (Fin D) (Fin D) ℂ)
+              ((MPSTensor.globalGaugeOfBlocks X :
+                    Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ) *
+                S.toTensor i *
+                (((MPSTensor.globalGaugeOfBlocks X)⁻¹ :
+                    GL (Fin S.totalDim) ℂ) :
+                  Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ))
+
+/-- A literal horizontal canonical form gives its complete BNT MPV
+representation.
+
+The block direct sum of the copy similarities leaves every closed
+matrix-product trace invariant.  The equality of bond dimensions also
+identifies the empty-chain coefficient, so the conclusion is full MPV
+equality rather than only positive-length equality.
+
+Source: arXiv:1606.00608, `eq:II_ABasicTensors` and `decBSV`, lines
+281--301. -/
+theorem IsHorizontalCF.hasHorizontalCFMPVRepresentation
+    {M : MPOTensor d D} (hHorizontal : IsHorizontalCF M) :
+    HasHorizontalCFMPVRepresentation M := by
+  obtain ⟨S, hCF, hTotal, Xcopy, hX⟩ := hHorizontal
+  subst D
+  refine ⟨S, hCF, ?_⟩
+  have hGauge : MPSTensor.GaugeEquiv S.toTensor M.toMPSTensor := by
+    refine ⟨MPSTensor.globalGaugeOfBlocks Xcopy, ?_⟩
+    intro i
+    simpa using hX i
+  intro N σ
+  exact (hGauge.sameMPV N σ).symm
 
 /-- Inserting the doubled-index right action gives the doubled-index tensor of
 right multiplication of the vertically viewed MPO tensor.
@@ -260,7 +224,7 @@ theorem insertedTensor_ketLeftBraRightAction_toMPSTensor
 /-- The two first-site identities in Proposition 4.13 imply equality of the
 opposite-corner insertions on every BNT representative.
 
-Positive-length MPV equality transports the first-site identities from the
+Complete MPV equality transports the first-site identities from the
 doubled-index tensor of `M` to the representative-indexed sector
 decomposition.  The representative-grouped Lemma L then separates the BNT
 representatives while grouping all repeated copies of each representative.
@@ -270,7 +234,7 @@ the contractions in Proposition 4.13, lines 1873--1887. -/
 theorem representative_opposite_insert_eq_of_rotated_mpo_entries
     (M : MPOTensor d D) (S : MPSTensor.SectorDecomposition (d * d))
     (hCF : MPSTensor.IsBNTCanonicalForm S)
-    (hM : MPSTensor.SameMPV₂Pos M.toMPSTensor S.toTensor)
+    (hM : MPSTensor.SameMPV₂ M.toMPSTensor S.toTensor)
     (Q : Matrix (Fin d) (Fin d) ℂ)
     (hInv : ∀ (N : ℕ) (ρ : Fin (N + 1) → Fin (d * d)),
       (∑ i : Fin d, Q (ρ 0).divNat i *
@@ -294,12 +258,12 @@ theorem representative_opposite_insert_eq_of_rotated_mpo_entries
     MPSTensor.insertedTensor (MPSTensor.braRightAction Q) (S.basis j) =
         MPSTensor.insertedTensor (MPSTensor.ketLeftAction Q) (S.basis j) :=
       (hCF.insertedTensor_basis_eq_of_firstSiteActionAgree
-        ((MPSTensor.firstSiteActionAgree_ketLeft_braRight M Q hComm).of_sameMPVPos hM)
+        ((MPSTensor.firstSiteActionAgree_ketLeft_braRight M Q hComm).of_sameMPV hM)
         j).symm
     _ = MPSTensor.insertedTensor
         (MPSTensor.ketLeftBraRightAction Q) (S.basis j) :=
       hCF.insertedTensor_basis_eq_of_firstSiteActionAgree
-        ((MPSTensor.firstSiteActionAgree_ketLeft_ketLeftBraRight M Q hInv).of_sameMPVPos hM)
+        ((MPSTensor.firstSiteActionAgree_ketLeft_ketLeftBraRight M Q hInv).of_sameMPV hM)
         j
 
 /-- A one-sided invariant Hermitian matrix reduces every horizontal BNT
@@ -316,7 +280,7 @@ theorem representative_braRight_eq_ketLeftBraRight_of_invariant
     (M : MPOTensor d D) (hMpdo : IsMPDO M)
     (S : MPSTensor.SectorDecomposition (d * d))
     (hCF : MPSTensor.IsBNTCanonicalForm S)
-    (hM : MPSTensor.SameMPV₂Pos M.toMPSTensor S.toTensor)
+    (hM : MPSTensor.SameMPV₂ M.toMPSTensor S.toTensor)
     {Q : Matrix (Fin d) (Fin d) ℂ} (hQ : Q.IsHermitian)
     (hQM : M.ketLeftMul Q = (M.ketLeftMul Q).braRightMul Q) :
     ∀ j, MPSTensor.insertedTensor (MPSTensor.braRightAction Q) (S.basis j) =
@@ -342,14 +306,54 @@ theorem representative_braRight_eq_ketLeftBraRight_of_invariant
     simp only [Fin.cons_zero, Function.comp_def, Fin.cons_succ] at h2
     exact h2
 
+/-- **Lemma L on the original bond space.**
+
+Let `M` be in literal horizontal canonical form.  If two physical operators
+have the same first-site action on every matrix product vector of `M`, then
+their inserted tensors are equal on the original bond space:
+\[
+  Y_1V^{(N)}(M)=Z_1V^{(N)}(M)\quad\hbox{for every }N
+  \quad\Longrightarrow\quad YM=ZM.
+\]
+The representative-grouped Lemma L first gives equality on each minimal BNT
+representative.  Linearity extends it to all repeated weighted sectors, and
+the block direct sum of the copy gauges transports it to `M`.
+
+Source: arXiv:1606.00608, Appendix C.3, Lemma L, lines 1835--1858, using the
+horizontal BNT decomposition at lines 281--301. -/
+theorem IsHorizontalCF.insertedTensor_eq_of_firstSiteActionAgree
+    (M : MPOTensor d D) (hHorizontal : IsHorizontalCF M)
+    {Y Z : Matrix (Fin (d * d)) (Fin (d * d)) ℂ}
+    (hAct : MPSTensor.FirstSiteActionAgree M.toMPSTensor Y Z) :
+    MPSTensor.insertedTensor Y M.toMPSTensor =
+      MPSTensor.insertedTensor Z M.toMPSTensor := by
+  obtain ⟨S, hCF, hTotal, Xcopy, hX⟩ := hHorizontal
+  subst D
+  let X := MPSTensor.globalGaugeOfBlocks Xcopy
+  have hX' : ∀ i, M.toMPSTensor i =
+      (X : Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ) * S.toTensor i *
+        (((X)⁻¹ : GL (Fin S.totalDim) ℂ) :
+          Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ) := by
+    intro i
+    simpa using hX i
+  have hGauge : MPSTensor.GaugeEquiv S.toTensor M.toMPSTensor := ⟨X, hX'⟩
+  have hM : MPSTensor.SameMPV₂ M.toMPSTensor S.toTensor := by
+    intro N σ
+    exact (hGauge.sameMPV N σ).symm
+  have hBasis :=
+    hCF.insertedTensor_basis_eq_of_sameMPV₂_firstSiteActionAgree
+      M.toMPSTensor hM hAct
+  have hSector : MPSTensor.insertedTensor Y S.toTensor =
+      MPSTensor.insertedTensor Z S.toTensor :=
+    S.insertedTensor_toTensor_eq_of_basis Y Z hBasis
+  exact MPSTensor.insertedTensor_eq_of_gauge X hX' Y Z hSector
+
 /-- The public horizontal canonical-form predicate supplies the
 representative-indexed invariant-projection conclusion.
 
 The witness is the BNT sector decomposition occurring in `IsHorizontalCF`.
 Repeated copies remain grouped over their common representative; no
-per-copy trace-separation hypothesis is introduced.  The equality is stated
-for positive lengths because the permitted all-zero summand changes only the
-empty-chain coefficient.
+per-copy trace-separation hypothesis is introduced.
 
 Source: arXiv:1606.00608, lines 264--301 and Proposition 4.13,
 lines 1873--1887. -/
@@ -359,22 +363,18 @@ theorem IsHorizontalCF.exists_representative_braRight_eq_ketLeftBraRight
     (hQM : M.ketLeftMul Q = (M.ketLeftMul Q).braRightMul Q) :
     ∃ S : MPSTensor.SectorDecomposition (d * d),
       MPSTensor.IsBNTCanonicalForm S ∧
-      MPSTensor.SameMPV₂Pos M.toMPSTensor S.toTensor ∧
+      MPSTensor.SameMPV₂ M.toMPSTensor S.toTensor ∧
       ∀ j, MPSTensor.insertedTensor (MPSTensor.braRightAction Q) (S.basis j) =
         MPSTensor.insertedTensor (MPSTensor.ketLeftBraRightAction Q) (S.basis j) := by
-  obtain ⟨S, hCF, z, hTotal, X, hX⟩ := hHorizontal
+  obtain ⟨S, hCF, hTotal, Xcopy, hX⟩ := hHorizontal
   subst D
-  have hGauge : MPSTensor.GaugeEquiv
-      (MPSTensor.zeroTail S.toTensor z) M.toMPSTensor := by
-    refine ⟨X, ?_⟩
+  have hGauge : MPSTensor.GaugeEquiv S.toTensor M.toMPSTensor := by
+    refine ⟨MPSTensor.globalGaugeOfBlocks Xcopy, ?_⟩
     intro i
     simpa using hX i
-  have hMZero : MPSTensor.SameMPV₂Pos M.toMPSTensor
-      (MPSTensor.zeroTail S.toTensor z) := by
-    intro N _ σ
+  have hM : MPSTensor.SameMPV₂ M.toMPSTensor S.toTensor := by
+    intro N σ
     exact (hGauge.sameMPV N σ).symm
-  have hM : MPSTensor.SameMPV₂Pos M.toMPSTensor S.toTensor :=
-    hMZero.trans (MPSTensor.zeroTail_sameMPV₂Pos S.toTensor z)
   exact ⟨S, hCF, hM,
     representative_braRight_eq_ketLeftBraRight_of_invariant
       M hMpdo S hCF hM hQ hQM⟩
@@ -384,7 +384,7 @@ the right.
 
 The representative-grouped Lemma L first identifies the two insertions on
 every minimal BNT representative.  Linearity gives the identity on all
-repeated weighted sectors and the all-zero summand, and the global gauge in
+repeated weighted sectors, and the direct sum of the copy gauges in
 `IsHorizontalCF` transports it to the original tensor.  Thus the conclusion
 is a literal equality of MPO tensors, rather than merely an equality of their
 MPV families.  The source specializes `Q` to an orthogonal projector; this
@@ -398,23 +398,19 @@ theorem IsHorizontalCF.braRight_eq_ketLeftBraRight_of_invariant
     {Q : Matrix (Fin d) (Fin d) ℂ} (hQ : Q.IsHermitian)
     (hQM : M.ketLeftMul Q = (M.ketLeftMul Q).braRightMul Q) :
     M.braRightMul Q = (M.ketLeftMul Q).braRightMul Q := by
-  obtain ⟨S, hCF, z, hTotal, X, hX⟩ := hHorizontal
+  obtain ⟨S, hCF, hTotal, Xcopy, hX⟩ := hHorizontal
   subst D
+  let X := MPSTensor.globalGaugeOfBlocks Xcopy
   have hX' : ∀ i, M.toMPSTensor i =
-      (X : Matrix (Fin (z + S.totalDim)) (Fin (z + S.totalDim)) ℂ) *
-        MPSTensor.zeroTail S.toTensor z i *
-        (((X)⁻¹ : GL (Fin (z + S.totalDim)) ℂ) :
-          Matrix (Fin (z + S.totalDim)) (Fin (z + S.totalDim)) ℂ) := by
+      (X : Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ) * S.toTensor i *
+        (((X)⁻¹ : GL (Fin S.totalDim) ℂ) :
+          Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ) := by
     intro i
     simpa using hX i
-  have hGauge : MPSTensor.GaugeEquiv
-      (MPSTensor.zeroTail S.toTensor z) M.toMPSTensor := ⟨X, hX'⟩
-  have hMZero : MPSTensor.SameMPV₂Pos M.toMPSTensor
-      (MPSTensor.zeroTail S.toTensor z) := by
-    intro N _ σ
+  have hGauge : MPSTensor.GaugeEquiv S.toTensor M.toMPSTensor := ⟨X, hX'⟩
+  have hM : MPSTensor.SameMPV₂ M.toMPSTensor S.toTensor := by
+    intro N σ
     exact (hGauge.sameMPV N σ).symm
-  have hM : MPSTensor.SameMPV₂Pos M.toMPSTensor S.toTensor :=
-    hMZero.trans (MPSTensor.zeroTail_sameMPV₂Pos S.toTensor z)
   have hBasis := representative_braRight_eq_ketLeftBraRight_of_invariant
     M hMpdo S hCF hM hQ hQM
   have hSector :
@@ -422,18 +418,11 @@ theorem IsHorizontalCF.braRight_eq_ketLeftBraRight_of_invariant
         MPSTensor.insertedTensor
           (MPSTensor.ketLeftBraRightAction Q) S.toTensor :=
     S.insertedTensor_toTensor_eq_of_basis _ _ hBasis
-  have hZero :
-      MPSTensor.insertedTensor (MPSTensor.braRightAction Q)
-          (MPSTensor.zeroTail S.toTensor z) =
-        MPSTensor.insertedTensor (MPSTensor.ketLeftBraRightAction Q)
-          (MPSTensor.zeroTail S.toTensor z) := by
-    rw [MPSTensor.insertedTensor_zeroTail,
-      MPSTensor.insertedTensor_zeroTail, hSector]
   have hOriginal :
       MPSTensor.insertedTensor (MPSTensor.braRightAction Q) M.toMPSTensor =
         MPSTensor.insertedTensor
           (MPSTensor.ketLeftBraRightAction Q) M.toMPSTensor :=
-    MPSTensor.insertedTensor_eq_of_gauge X hX' _ _ hZero
+    MPSTensor.insertedTensor_eq_of_gauge X hX' _ _ hSector
   have hTensor : (M.braRightMul Q).toMPSTensor =
       ((M.ketLeftMul Q).braRightMul Q).toMPSTensor := by
     rw [← insertedTensor_braRightAction_toMPSTensor,

--- a/TNLean/MPS/MPDO/PostBlockedRepresentativeSpan.lean
+++ b/TNLean/MPS/MPDO/PostBlockedRepresentativeSpan.lean
@@ -245,10 +245,10 @@ the length-`L` word span then recovers equality of the original insertions.
 This is the blocking step of arXiv:1606.00608, lines 318--344, composed with
 Appendix C.3, Lemma L, lines 1835--1858.
 
-**Scope restriction (common block-injectivity length):** The common positive
-length is an explicit hypothesis; its derivation from the canonical-form
-construction remains open.  See
-`docs/paper-gaps/cpgsv17_bicf_block_separation.tex`. -/
+The common positive length is explicit in this auxiliary theorem.  It is
+derived from the BNT canonical-form hypotheses by
+`IsBNTCanonicalForm.exists_common_basis_isNBlkInjective` and eliminated in
+`insertedTensor_basis_eq_of_firstSiteActionAgree` below. -/
 theorem insertedTensor_basis_eq_of_firstSiteActionAgree_of_common_blockInjective
     (hCF : IsBNTCanonicalForm P) (L : ℕ) (hL : 0 < L)
     (hInj : ∀ j, IsNBlkInjective (P.basis j) L)
@@ -281,9 +281,9 @@ The common block-injectivity length is the input supplied by the canonical-form
 blocking step in arXiv:1606.00608, lines 318--344.  The representative
 conclusion is Appendix C.3, Lemma L, lines 1835--1858.
 
-**Scope restriction (common block-injectivity length):** This transport theorem
-inherits the explicit common-length hypothesis above.  See
-`docs/paper-gaps/cpgsv17_bicf_block_separation.tex`. -/
+The common positive length is explicit in this auxiliary transport theorem and
+is eliminated in
+`insertedTensor_basis_eq_of_sameMPV₂_firstSiteActionAgree` below. -/
 theorem insertedTensor_basis_eq_of_sameMPV₂_firstSiteActionAgree_of_common_blockInjective
     {D : ℕ} (A : MPSTensor d D) (hCF : IsBNTCanonicalForm P)
     (L : ℕ) (hL : 0 < L) (hInj : ∀ j, IsNBlkInjective (P.basis j) L)

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -6,24 +6,31 @@
 % `Prop:IV.12` is Proposition 4.13 in the arXiv source.
 
 \begin{definition}[Horizontal canonical form for an MPO]\label{def:horizontal_cf_mpdo}
-    \notready
-    \uses{def:mpo_tensor, def:sector_bnt_cf}
+    \lean{MPOTensor.IsHorizontalCF}
+    \leanok
+    \uses{def:mpo_tensor, def:sector_bnt_cf, def:gauge_equiv}
     An MPO tensor is in \emph{horizontal canonical form} if its doubled-index
-    tensor has a literal bond-space decomposition
+    MPS tensor is globally gauge-conjugate to a BNT sector decomposition
     \[
-        \widehat M^i
-        =\bigoplus_{j=0}^{g-1}\bigoplus_{q=0}^{r_j-1}
-          \mu_{j,q}X_{j,q}A_j^iX_{j,q}^{-1},
+        \bigoplus_{j=0}^{g-1}\bigoplus_{q=0}^{r_j-1}
+        \mu_{j,q}A_j.
     \]
-    where $(A_j)_{0\leq j<g}$ is a minimal basis of normal tensors, each
-    $\mu_{j,q}$ is nonzero, and every $X_{j,q}$ is invertible.  Equivalently,
-    with
+    Here the $A_j$ are the distinct minimal representatives, $r_j>0$, and
+    every weight $\mu_{j,q}$ is nonzero, $|\mu_{j,q}|\leq1$, and at least
+    one weight has modulus one.  The BNT hypotheses include
+    irreducibility, left-canonicality, normalized self-overlap, eventual
+    linear independence of the representative MPV families, and the
+    exclusion of similarity up to phase between distinct representatives.
+    Repeated gauge-equivalent copies are retained over the same representative
+    rather than separated as distinct blocks.  The total bond dimension of
+    the displayed direct sum is exactly $D$, and there is
+    an invertible matrix $X\in M_D(\mathbb C)$ such that
     \[
-        X=\bigoplus_{j=0}^{g-1}\bigoplus_{q=0}^{r_j-1}X_{j,q},
+        M^{ab}=X\left[\bigoplus_{j,q}\mu_{j,q}A_j^{ab}\right]X^{-1}
+        \qquad (0\leq a,b<d).
     \]
-    this is the gauge-explicit decomposition of
-    \cite[Section~2.3, lines~283--297]{Cirac2016MPDO_arXiv}.
-    % No Lean tag: the literal bond-space gauge data are not yet formalized.
+    This is the canonical form and its BNT decomposition in
+    \cite[lines~237--246 and 281--301]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
 \begin{definition}[MPV representation associated with horizontal canonical form]
@@ -35,17 +42,15 @@
     its doubled-index MPS tensor generates the same complete MPV family as a
     BNT canonical form
     \[
-        \bigoplus_{j=0}^{g-1}\bigoplus_{q=0}^{r_j-1}\mu_{j,q}A_j,
+        \bigoplus_{j=0}^{g-1}\bigoplus_{q=0}^{r_j-1}\mu_{j,q}A_j.
     \]
-    where $(A_j)_{0\leq j<g}$ is a minimal basis of normal tensors and each
-    $\mu_{j,q}$ is nonzero.  Its length-$N$ matrix product vector is therefore
+    Its length-$N$ matrix product vector is
     \[
         \sum_{j=0}^{g-1}
         \left(\sum_{q=0}^{r_j-1}\mu_{j,q}^{N}\right)V^{(N)}(A_j).
     \]
     This is the MPV-level decomposition in
-    \cite[Section~2.3, lines~298--301]{Cirac2016MPDO_arXiv}.  It does not assert
-    the literal bond-space gauge of Definition~\ref{def:horizontal_cf_mpdo}.
+    \cite[Section~2.3, lines~298--301]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
 \begin{figure}[ht]
@@ -54,7 +59,8 @@
     \caption{Horizontal canonical form of the doubled tensor: the gauge $X$,
     one basis tensor $\mathcal K$ carrying the ket and bra legs, and
     $X^{-1}$, threaded by the block-index lines $j$ and $q$. In the source
-    display the weights $\mu_j$ are absorbed into the basis tensors, so the
+    specialized simple-biCF/ZCL display the weights $\mu_j$ are independent
+    of the copy index and absorbed into the basis tensors, so the
     basis tensor taps only the line $j$ while the gauge factors $X_{j,q}$
     tap both lines. This is
     \cite[Appendix~C.2, lines~1660--1665]{Cirac2016MPDO_arXiv}.}
@@ -167,8 +173,8 @@
     span, hence on the whole product algebra, so nondegeneracy of the
     product trace pairing forces every $\Delta_k=0$. Combined with
     injectivity, left-canonicality, and nonzero block weights, this
-    finite-length separation yields the horizontal canonical-form data of
-    the block-diagonal tensor.
+    finite-length separation supplies the older per-copy trace-separation
+    hypotheses for the block-diagonal tensor.
 
     The spanning hypothesis has an equivalent entrywise form. For a block
     index $k$ and matrix entry $(a,b)$, let
@@ -178,7 +184,7 @@
     be the corresponding scalar word family, indexed jointly by the triple
     $(k,a,b)$. Linear independence of this scalar family already implies
     the spanning condition, hence the separation property, and hence the
-    horizontal canonical-form data directly.
+    older per-copy trace-separation hypotheses directly.
 
     The duplicate-scalar counterexample shows that the separation property
     is strictly stronger than blockwise injectivity, left-canonicality, and
@@ -204,7 +210,7 @@
     \]
     Concatenating the injective prefix with this finite selector family
     produces the spanning condition at length $L+S$, hence the separation
-    property and the horizontal canonical-form data.
+    property and the older per-copy trace-separation hypotheses.
 \end{remark}
 
 \begin{figure}[ht]
@@ -236,11 +242,12 @@
 \begin{proof}
     \leanok
     \uses{rem:word_tuple_span_top}
-    This is the direct implication from the finite-length data to the
-    finite-length trace-separation statement. What remains open in the full
-    block-injectivity proposition of
-    \cite[lines~340--345]{Cirac2016MPDO_arXiv} is the derivation of this
-    finite witness from separated canonical-form / BNT data.
+    This is the direct implication from the finite-length hypotheses to the
+    finite-length trace-separation statement.  General BNT canonical-form
+    hypotheses now yield a finite representative-indexed witness.  What remains
+    open in the sharper block-injectivity proposition of
+    \cite[lines~340--345]{Cirac2016MPDO_arXiv} is the stated numerical bound
+    $3D^5$ and its particular selector construction.
 \end{proof}
 
 \begin{definition}[Representative word-tuple separation]
@@ -291,11 +298,11 @@
     The representative grouping is the argument of
     \cite[Appendix~C.3, lines~1835--1858]{Cirac2016MPDO_arXiv}.
 
-    \textbf{Scope restriction (finite representative span).}  Appendix~C.3
-    obtains the required separation from block injectivity of a minimal basis
-    of normal tensors.  Here eventual representative word-tuple separation is
-    an explicit assumption; its derivation from the full canonical-form
-    hypotheses remains open.  This is recorded in
+    In the first auxiliary assertion, eventual representative word-tuple
+    separation is an explicit assumption.  The later post-blocked theorem
+    derives the needed finite representative separation from the full BNT
+    canonical-form hypotheses.  The source's sharp $3D^5$ bound remains
+    separate, as recorded in
     \path{docs/paper-gaps/cpgsv17_bicf_block_separation.tex}.
 \end{theorem}
 
@@ -512,6 +519,75 @@
     of the first block form a spanning family, so
     Lemma~\ref{lem:first_site_action_physical_blocking} recovers
     $YA_j=ZA_j$ before blocking.
+\end{proof}
+
+\begin{theorem}[Representative and literal reduction from first-site contractions]
+    \label{thm:representative_one_sub_mp_zero}
+    \lean{MPSTensor.FirstSiteActionAgree.of_sameMPV}
+    \lean{MPSTensor.FirstSiteActionAgree.of_sameMPVPos}
+    \lean{MPSTensor.insertedTensor_zeroTail}
+    \lean{MPSTensor.insertedTensor_toTensorFromBlocks}
+    \lean{MPSTensor.SectorDecomposition.insertedTensor_toTensor_eq_of_basis}
+    \lean{MPSTensor.insertedTensor_eq_of_gauge}
+    \lean{MPOTensor.insertedTensor_braRightAction_toMPSTensor}
+    \lean{MPOTensor.insertedTensor_ketLeftBraRightAction_toMPSTensor}
+    \lean{MPOTensor.representative_opposite_insert_eq_of_rotated_mpo_entries}
+    \lean{MPOTensor.representative_braRight_eq_ketLeftBraRight_of_invariant}
+    \lean{MPOTensor.IsHorizontalCF.exists_representative_braRight_eq_ketLeftBraRight}
+    \lean{MPOTensor.IsHorizontalCF.braRight_eq_ketLeftBraRight_of_invariant}
+    \leanok
+    \uses{def:mpdo, def:horizontal_cf_mpdo,
+        def:mpdo_three_first_site_contractions,
+        thm:representative_grouped_insert_eq,
+        thm:postblocked_representative_grouped_insert_eq,
+        thm:mpdo_first_site_invariant_comm}
+    Let $M$ generate an MPDO and be in horizontal canonical form, with BNT
+    representatives $(A_j)_{j=0}^{g-1}$.  Suppose that $Q=Q^\dagger$ and
+    that $Q\widetilde M=Q\widetilde M Q$ on the vertically viewed tensor.
+    Then, on every representative, the insertions corresponding to
+    $\widetilde M Q$ and $Q\widetilde M Q$ agree:
+    \[
+        Y_R(Q)A_j=Y_C(Q)A_j
+        \qquad (0\leq j<g).
+    \]
+    Moreover, this equality extends through every repeated weighted sector,
+    the permitted all-zero summand, and the global gauge, so that the original
+    MPO tensor satisfies
+    \[
+        \widetilde M Q=Q\widetilde M Q.
+    \]
+    The representative transport uses equality of the positive-length matrix
+    product vectors; the all-zero summand affects only length zero.  It also
+    follows directly from the two entrywise identities
+    $Q_1H^{(N)}=Q_1H^{(N)}Q_1$ and
+    $Q_1H^{(N)}=H^{(N)}Q_1$ at every positive length.
+
+    This is the representative-indexed conclusion of the invariant-projection
+    step in
+    \cite[Proposition~4.13, lines~1873--1887]{Cirac2016MPDO_arXiv}.
+    Copies with a common normal representative are grouped before separation,
+    exactly as in Appendix~C.3, Lemma~L.
+    The source assumes that $Q$ is an orthogonal projector; this implication
+    only uses its Hermiticity.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:representative_grouped_insert_eq,
+        thm:postblocked_representative_grouped_insert_eq,
+        thm:mpdo_first_site_invariant_comm}
+    Positivity and Hermiticity give
+    \[
+        Q_1H^{(N)}=Q_1H^{(N)}Q_1=H^{(N)}Q_1.
+    \]
+    Equality of positive-length MPV families transports these two first-site
+    identities to the BNT sector decomposition.  Apply the
+    representative-grouped Lemma~L to identify first $Y_L(Q)A_j$ with
+    $Y_C(Q)A_j$ and then with $Y_R(Q)A_j$.  Transitivity gives the stated
+    equality for every representative.  First-site insertion commutes with
+    the weighted direct sum and the all-zero summand, hence the identity holds
+    on the full horizontal tensor.  Conjugating by the global gauge then gives
+    the literal equality on $\widetilde M$.
 \end{proof}
 
 \begin{lemma}[Blockwise equality from agreement on the MPV family]
@@ -860,9 +936,14 @@
     density operator generated by an MPDO commutes with the density operator
     itself.  This is the final operator implication in the periodic-sector
     contradiction in the proof of
-    \cite[Proposition~4.13]{Cirac2016MPDO_arXiv}.  It does not construct the
-    orthogonal projector $Q$ from a nontrivial vertical period or prove the
-    all-length commutation hypothesis; those steps remain open.
+    \cite[Proposition~4.13]{Cirac2016MPDO_arXiv}.  The cyclic projector and
+    its displacement are now constructed.  What remains open is the mismatch
+    between the all-length noncommutation family used by the cyclic argument
+    and the simultaneous positive-length commutation family excluded by
+    Lemma~L.  One may close it either by deriving the stronger noncommutation
+    family from the cyclic and peripheral information, or by reformulating the
+    final contradiction to use the single noncommuting length supplied by the
+    contrapositive of Lemma~L.
 \end{theorem}
 
 \begin{proof}
@@ -1220,9 +1301,14 @@
     \cite[Proposition~4.13]{Cirac2016MPDO_arXiv} assumes the tensor is in
     canonical form in the horizontal direction, and the argument of
     lines~1874--1887 turns all-length commutation of $Q_1$ with $H^{(N)}$
-    into the letter-level invariance $Q\widetilde M=Q\widetilde MQ$, so a
-    displaced projector cannot commute.  The derivation of this implication
-    from a horizontal canonical form remains open.
+    into the letter-level invariance $Q\widetilde M=Q\widetilde MQ$.  The
+    literal transport through a horizontal canonical form is now proved.
+    What remains open is the mismatch between this all-length
+    noncommutation family and the simultaneous positive-length commutation
+    family excluded by Lemma~L.  One may close it either by deriving the
+    stronger noncommutation family from the cyclic and peripheral
+    information, or by reformulating the final contradiction to use the
+    single noncommuting length supplied by the contrapositive of Lemma~L.
     % Gap recorded in docs/paper-gaps/cpgsv17_periodic_sector_projector.tex.
 \end{definition}
 
@@ -1674,14 +1760,15 @@
     product vector of the single-spin block-diagonal assembly.
 \end{proof}
 
-\begin{theorem}[Diagonal restriction need not preserve normality]
+\begin{theorem}[Per-copy horizontal hypotheses do not control diagonal normality]
     \label{thm:diagonal_restriction_not_normal}
     \lean{MPSTensor.horizontalCFData_diagBlock_not_isNormal}
     \leanok
-    \uses{def:horizontal_cf_mpdo}
+    \uses{rem:word_tuple_span_top}
     There is a left-canonical, injective doubled-index tensor with a nonzero
-    block weight satisfying the finite-length block-separation hypothesis whose
-    restriction to the diagonal physical pairs is not normal.  On bond space
+    block weight satisfying the older per-copy finite-length separation
+    hypothesis whose restriction to the diagonal physical pairs is not normal.
+    On bond space
     $\mathbb C^2$, take
     \[
         A^{(a,b)}=c_a E_{ab},
@@ -1763,6 +1850,8 @@
 
 \begin{lemma}[Matrix product vector of the vertical-assembled tensor]
     \label{lem:mpv_vertical_assembled}
+    \lean{MPOTensor.verticalCopyDim}
+    \lean{MPOTensor.verticalCopyBlocks}
     \lean{MPOTensor.mpv_verticalAssembledTensor_eq_sum}
     \leanok
     \uses{thm:mpv_decomposition, def:block_diagonal_tensor}
@@ -1966,11 +2055,13 @@
     \notready
     \uses{def:mpdo, def:horizontal_cf_mpdo, def:vertical_tensor_mpdo,
         def:vertical_cf_mpdo,
-        thm:mpdo_opposite_corner_zero, thm:blockwise_opposite_insert_eq,
-        thm:blockwise_opposite_insert_rotated_mpo,
+        thm:mpdo_opposite_corner_zero,
         thm:mpdo_first_site_invariant_comm,
-        thm:blockwise_one_sub_mp_zero,
+        thm:representative_one_sub_mp_zero,
         thm:psd_commute_of_commute_pow,
+        thm:mpdo_displaced_invariant_projector,
+        def:mpdo_noninvariant_projector_noncommuting,
+        thm:mpdo_cyclic_projector_of_noncommutation,
         def:mpdo_periodic_sector_projector,
         def:mpdo_periodic_vector_yields_projector,
         thm:mpdo_no_periodic_sector_projector,
@@ -2000,11 +2091,13 @@
 
 \begin{proof}
     \uses{def:mpdo, def:horizontal_cf_mpdo, def:vertical_cf_mpdo,
-        thm:mpdo_opposite_corner_zero, thm:blockwise_opposite_insert_eq,
-        thm:blockwise_opposite_insert_rotated_mpo,
+        thm:mpdo_opposite_corner_zero,
         thm:mpdo_first_site_invariant_comm,
-        thm:blockwise_one_sub_mp_zero,
+        thm:representative_one_sub_mp_zero,
         thm:psd_commute_of_commute_pow,
+        thm:mpdo_displaced_invariant_projector,
+        def:mpdo_noninvariant_projector_noncommuting,
+        thm:mpdo_cyclic_projector_of_noncommutation,
         def:mpdo_periodic_sector_projector,
         def:mpdo_periodic_vector_yields_projector,
         thm:mpdo_no_periodic_sector_projector,
@@ -2019,20 +2112,26 @@
         thm:eq3_of_dressed_adjoint,
         lem:mpv_diagonal_tensor,
         lem:vertical_grouping_equiv}
-    Theorem~\ref{thm:blockwise_one_sub_mp_zero} shows
+    Theorem~\ref{thm:representative_one_sub_mp_zero} shows
     that every self-adjoint $P$ with $PM=PMP$ on the vertically viewed tensor
-    gives $(\Id-P)MP=0$ on every horizontal canonical-form block.
+    gives the literal equality $MP=PMP$ on the original MPO tensor, including
+    its repeated sectors and permitted all-zero summand.  The paper takes $P$
+    to be an orthogonal projector; Hermiticity is the only part of that
+    assumption needed for this implication.
     Theorem~\ref{thm:mpdo_vertical_no_periodic_vectors} excludes nontrivial
     $p$-periodic vectors of the vertically viewed tensor:
     Theorem~\ref{thm:mpdo_no_periodic_sector_projector} rules out any
     periodic-sector projector, since by
     Theorem~\ref{thm:psd_commute_of_commute_pow} an orthogonal projector
-    commuting with $[H^{(N)}]^p$ commutes with $H^{(N)}$.  It remains to
-    prove that a nontrivial vertical period supplies a periodic-sector
-    projector with the two all-length properties stated in source
-    lines 1889--1890
-    (Definition~\ref{def:mpdo_periodic_vector_yields_projector}), which the
-    source draws from the general theory of the peripheral spectrum.
+    commuting with $[H^{(N)}]^p$ commutes with $H^{(N)}$.  A nontrivial
+    vertical period now supplies the displaced cyclic projector and its word
+    invariance.  A mismatch remains between the present non-commutation
+    interface, which asks for a contradiction at every length separately, and
+    the literal canonical-form reduction, which only rules out simultaneous
+    commutation at all positive lengths.  One must either derive the stronger
+    family from the cyclic decomposition and peripheral spectral hypotheses,
+    or weaken the final
+    contradiction to consume one noncommuting length.
     One must then apply the canonical-form theorem in the vertical direction
     to the vertically viewed tensor $\widetilde M$, obtaining a decomposition
     \[

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -10,10 +10,11 @@
     \leanok
     \uses{def:mpo_tensor, def:sector_bnt_cf, def:gauge_equiv}
     An MPO tensor is in \emph{horizontal canonical form} if its doubled-index
-    MPS tensor is globally gauge-conjugate to a BNT sector decomposition
+    MPS tensor is a BNT sector decomposition with an independent gauge on
+    every repeated copy:
     \[
-        \bigoplus_{j=0}^{g-1}\bigoplus_{q=0}^{r_j-1}
-        \mu_{j,q}A_j.
+        M^{ab}=\bigoplus_{j=0}^{g-1}\bigoplus_{q=0}^{r_j-1}
+        \mu_{j,q}X_{j,q}A_j^{ab}X_{j,q}^{-1}.
     \]
     Here the $A_j$ are the distinct minimal representatives, $r_j>0$, and
     every weight $\mu_{j,q}$ is nonzero, $|\mu_{j,q}|\leq1$, and at least
@@ -23,11 +24,11 @@
     exclusion of similarity up to phase between distinct representatives.
     Repeated gauge-equivalent copies are retained over the same representative
     rather than separated as distinct blocks.  The total bond dimension of
-    the displayed direct sum is exactly $D$, and there is
-    an invertible matrix $X\in M_D(\mathbb C)$ such that
+    the displayed direct sum is exactly $D$.  Equivalently, with the
+    block-diagonal matrix $X=\bigoplus_{j,q}X_{j,q}$,
     \[
-        M^{ab}=X\left[\bigoplus_{j,q}\mu_{j,q}A_j^{ab}\right]X^{-1}
-        \qquad (0\leq a,b<d).
+        M^{ab}=X\left[\bigoplus_{j,q}\mu_{j,q}A_j^{ab}\right]X^{-1},
+        \qquad X=\bigoplus_{j,q}X_{j,q}.
     \]
     This is the canonical form and its BNT decomposition in
     \cite[lines~237--246 and 281--301]{Cirac2016MPDO_arXiv}.
@@ -52,6 +53,23 @@
     This is the MPV-level decomposition in
     \cite[Section~2.3, lines~298--301]{Cirac2016MPDO_arXiv}.
 \end{definition}
+
+\begin{theorem}[Horizontal canonical form gives the BNT MPV representation]
+    \label{thm:horizontal_cf_gives_mpv_representation}
+    \lean{MPOTensor.IsHorizontalCF.hasHorizontalCFMPVRepresentation}
+    \leanok
+    \uses{def:horizontal_cf_mpdo,
+        def:horizontal_cf_mpv_representation}
+    Every MPO tensor in horizontal canonical form has the associated complete
+    BNT matrix-product-vector representation.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Each copy similarity cancels inside its closed matrix-product trace.
+    Since the two bond dimensions agree, this also identifies the coefficient
+    at length zero.
+\end{proof}
 
 \begin{figure}[ht]
     \centering
@@ -524,11 +542,10 @@
 \begin{theorem}[Representative and literal reduction from first-site contractions]
     \label{thm:representative_one_sub_mp_zero}
     \lean{MPSTensor.FirstSiteActionAgree.of_sameMPV}
-    \lean{MPSTensor.FirstSiteActionAgree.of_sameMPVPos}
-    \lean{MPSTensor.insertedTensor_zeroTail}
     \lean{MPSTensor.insertedTensor_toTensorFromBlocks}
     \lean{MPSTensor.SectorDecomposition.insertedTensor_toTensor_eq_of_basis}
     \lean{MPSTensor.insertedTensor_eq_of_gauge}
+    \lean{MPOTensor.IsHorizontalCF.insertedTensor_eq_of_firstSiteActionAgree}
     \lean{MPOTensor.insertedTensor_braRightAction_toMPSTensor}
     \lean{MPOTensor.insertedTensor_ketLeftBraRightAction_toMPSTensor}
     \lean{MPOTensor.representative_opposite_insert_eq_of_rotated_mpo_entries}
@@ -541,8 +558,16 @@
         thm:representative_grouped_insert_eq,
         thm:postblocked_representative_grouped_insert_eq,
         thm:mpdo_first_site_invariant_comm}
-    Let $M$ generate an MPDO and be in horizontal canonical form, with BNT
-    representatives $(A_j)_{j=0}^{g-1}$.  Suppose that $Q=Q^\dagger$ and
+    Let $M$ be in horizontal canonical form.  For doubled-index matrices
+    $Y,Z$, suppose that
+    \[
+        Y_1V^{(N)}(M)=Z_1V^{(N)}(M)
+        \qquad (N\geq1).
+    \]
+    Then the corresponding inserted tensors agree on the original bond
+    space, $YM=ZM$.
+
+    Now suppose in addition that $M$ generates an MPDO, $Q=Q^\dagger$, and
     that $Q\widetilde M=Q\widetilde M Q$ on the vertically viewed tensor.
     Then, on every representative, the insertions corresponding to
     $\widetilde M Q$ and $Q\widetilde M Q$ agree:
@@ -550,15 +575,12 @@
         Y_R(Q)A_j=Y_C(Q)A_j
         \qquad (0\leq j<g).
     \]
-    Moreover, this equality extends through every repeated weighted sector,
-    the permitted all-zero summand, and the global gauge, so that the original
-    MPO tensor satisfies
+    This equality extends through every repeated weighted sector and the
+    direct sum of the copy gauges, so that the original MPO tensor satisfies
     \[
         \widetilde M Q=Q\widetilde M Q.
     \]
-    The representative transport uses equality of the positive-length matrix
-    product vectors; the all-zero summand affects only length zero.  It also
-    follows directly from the two entrywise identities
+    The specialized assertion follows from the two entrywise identities
     $Q_1H^{(N)}=Q_1H^{(N)}Q_1$ and
     $Q_1H^{(N)}=H^{(N)}Q_1$ at every positive length.
 
@@ -576,18 +598,19 @@
     \uses{thm:representative_grouped_insert_eq,
         thm:postblocked_representative_grouped_insert_eq,
         thm:mpdo_first_site_invariant_comm}
-    Positivity and Hermiticity give
-    \[
-        Q_1H^{(N)}=Q_1H^{(N)}Q_1=H^{(N)}Q_1.
-    \]
-    Equality of positive-length MPV families transports these two first-site
-    identities to the BNT sector decomposition.  Apply the
+    For the general assertion, complete MPV equality transports the first-site
+    identity to the BNT sector decomposition.  The representative-grouped
+    Lemma~L gives $YA_j=ZA_j$ for every representative.  First-site insertion
+    commutes with the weighted direct sum, and conjugating each copy by its
+    gauge gives $YM=ZM$ on the original bond space.
+
+    For the specialized assertion, positivity and Hermiticity give
+    $Q_1H^{(N)}=Q_1H^{(N)}Q_1=H^{(N)}Q_1$.  Transport these two identities to
+    the BNT sector decomposition and apply the
     representative-grouped Lemma~L to identify first $Y_L(Q)A_j$ with
     $Y_C(Q)A_j$ and then with $Y_R(Q)A_j$.  Transitivity gives the stated
-    equality for every representative.  First-site insertion commutes with
-    the weighted direct sum and the all-zero summand, hence the identity holds
-    on the full horizontal tensor.  Conjugating by the global gauge then gives
-    the literal equality on $\widetilde M$.
+    equality for every representative, and the same direct-sum and copy-gauge
+    argument gives the literal equality on $\widetilde M$.
 \end{proof}
 
 \begin{lemma}[Blockwise equality from agreement on the MPV family]
@@ -2115,7 +2138,7 @@
     Theorem~\ref{thm:representative_one_sub_mp_zero} shows
     that every self-adjoint $P$ with $PM=PMP$ on the vertically viewed tensor
     gives the literal equality $MP=PMP$ on the original MPO tensor, including
-    its repeated sectors and permitted all-zero summand.  The paper takes $P$
+    all its repeated sectors.  The paper takes $P$
     to be an orthogonal projector; Hermiticity is the only part of that
     assumption needed for this implication.
     Theorem~\ref{thm:mpdo_vertical_no_periodic_vectors} excludes nontrivial

--- a/docs/counterexamples.md
+++ b/docs/counterexamples.md
@@ -18,7 +18,7 @@ mathematical obstruction.
   constant traces but not rank one. An additional condition excluding the
   generalized zero-eigenspace is required.
 
-### BiCF does not follow from the other horizontal canonical-form fields
+### BiCF does not follow from the other per-copy `HorizontalCFData` fields
 
 - Location: `TNLean/MPS/MPDO/BiCFDerivation.lean`
 - Statement refuted: blockwise injectivity, left-canonicality, nonzero weights,

--- a/docs/paper-gaps/cpgsv17_bicf_block_separation.tex
+++ b/docs/paper-gaps/cpgsv17_bicf_block_separation.tex
@@ -9,7 +9,7 @@
 
 \title{Finite-Length Block Separation in the CPGSV17 Proposition \texttt{propblockinj}}
 \author{}
-\date{2026-04-30}
+\date{2026-07-13}
 
 \begin{document}
 \maketitle
@@ -54,12 +54,11 @@ block-injective canonical form immediately preceding it is
 P\'erez-Garc\'ia--Verstraete--Wolf--Cirac
 \cite{PerezGarcia2007MPSReps}.
 
-\section{The formal replacement}
+\section{The older per-copy formulation}
 
-The formal treatment does not yet derive this proposition from the
-canonical-form and basis-of-normal-tensors hypotheses. Instead, it makes the
-finite-length conclusion explicit. The horizontal canonical-form data record
-the following trace-separation assumption: there is a length $N$ such that, if
+The older auxiliary horizontal block hypotheses make the finite-length conclusion
+explicit on every flattened copy.  They record the following trace-separation
+assumption: there is a length $N$ such that, if
 matrices $\Delta_j\in M_{D_j}(\mathbb C)$ satisfy
 \[
     \sum_{j=1}^g \operatorname{tr}(\Delta_j A_j^w)=0
@@ -86,28 +85,23 @@ others. Concatenating an injective prefix with such a selector suffix gives the
 full product-algebra span.
 
 In the formal files, these three finite-length criteria suffice to produce the
-horizontal canonical-form trace-separation conclusion.\footnote{The criteria are
+older per-copy trace-separation conclusion.\footnote{The criteria are
     named \texttt{WordTupleSpanTop}, \texttt{wordEntryFamily}, and
     \texttt{PropBlockInjective}. The trace-separation assumption is
     \texttt{HorizontalCFData.biCF}. The constructors from these hypotheses to
-    horizontal canonical-form data are in the modules under
+    \texttt{HorizontalCFData} structures are in the modules under
     \path{TNLean/MPS/MPDO/BiCFDerivation/}. Relevant implications include
     \texttt{hasBiCF\_of\_wordTupleSpanTop},
     \texttt{hasBiCF\_of\_wordEntryFamily\_linearIndependent},
     \texttt{hasBiCF\_of\_propBlockInjective}, and corresponding
     \texttt{HorizontalCFData} constructors such as
-    \texttt{horizontalCFData\_of\_propBlockInjective}. The blueprint records the same
-    state in \path{blueprint/src/chapter/ch20_mpdo_canonical_forms.tex}, lines 27--108.}
-Thus \texttt{propblockinj} has not been asserted without proof. The formal statements
-prove that several finite-length witnesses are sufficient.  For the
-representative-indexed BNT canonical form, such a witness is now derived from
-irreducibility, left-canonicality, and normalized self-overlap.  The predicate
-\texttt{HasHorizontalCFMPVRepresentation} records the resulting equality of
-complete MPV families with a representative-indexed BNT decomposition.  It is
-not the paper's literal horizontal canonical form: it contains no bond-space
-gauge relating the original tensor letters to the repeated BNT blocks.  The
-flattened \texttt{HorizontalCFData} formulation remains as a strictly stronger
-auxiliary hypothesis for the older per-copy results.
+    \texttt{horizontalCFData\_of\_propBlockInjective}.  The blueprint records
+    these restricted criteria in its finite-witness remark.}
+Thus \texttt{propblockinj} has not been asserted without proof.  These
+statements remain correct restricted results, but the public horizontal
+canonical-form predicate no longer uses them.  It is now stated through a
+representative-indexed BNT sector decomposition, so repeated copies are
+grouped before the separation argument.
 
 \section{The counterexample boundary}
 
@@ -218,22 +212,23 @@ block-injectivity length by taking a common multiple of their individual
 lengths.  Consequently the representative-indexed Lemma L now follows from
 the BNT canonical-form predicate itself.
 
-The MPV-level representation predicate and the representative-indexed part of
-the MPDO argument now use a \texttt{SectorDecomposition} satisfying
-\texttt{IsBNTCanonicalForm}.  Equality of the three first-site contractions is
-therefore reduced to equality on each minimal representative by the grouped
-Lemma L, with no per-copy trace-separation hypothesis.  The older
-\texttt{HorizontalCFData}, \texttt{IsPerCopyHorizontalCF}, and per-copy
-\texttt{biCF} theorems remain correct restricted results, but they are not the
-source-facing formulation of Lemma L.
+The public horizontal canonical-form predicate has now been replaced by the
+representative-indexed formulation.  It quantifies a BNT sector decomposition
+whose total bond dimension equals the original bond dimension and which is
+literally related to the doubled-index tensor by one global gauge.  Complete
+MPV equality transports the first-site identities to the BNT representatives.  The
+representative-grouped Lemma L concludes equality of the opposite-corner
+insertions on every minimal representative.  Linearity extends this equality
+to the full weighted direct sum, and gauge conjugation transports the result
+to the original MPO tensor.  The older
+per-copy \texttt{HorizontalCFData} theorems remain available only as explicitly
+restricted auxiliary statements.
 
-This does not yet prove the first conclusion of Proposition~4.13 for the
-original MPO tensor.  The source uses the literal decomposition
-$\bigoplus_{j,q}\mu_{j,q}X_{j,q}A_jX_{j,q}^{-1}$ to transport equality on the
-minimal representatives back to the original bond space.  The formal MPV-level
-predicate has no matrices $X_{j,q}$ and cannot justify that transport.  A
-faithful completion therefore requires a gauge-explicit horizontal
-canonical-form structure and the corresponding direct-sum conjugation theorem.
+This closes the multiplicity and block-separation gap in Lemma L.  It does not
+by itself complete Proposition~4.13: constructing the letterwise vertical
+decomposition from the resulting reducing projections, and proving the
+subsequent positivity and isometric normalization of its sectors, are separate
+parts of that proposition.
 
 Separately, the numerical bound in the full block-injectivity proposition still
 requires the David2006 argument: from minimality of the basis of normal tensors

--- a/docs/paper-gaps/cpgsv17_periodic_sector_projector.tex
+++ b/docs/paper-gaps/cpgsv17_periodic_sector_projector.tex
@@ -63,26 +63,19 @@ as follows.
 
 \section{The gap}
 
-The unformalized content is the construction of the projector: the source
-asserts, from the general theory of the peripheral spectrum, that a
-nontrivial vertical period supplies an orthogonal projector with the two
-all-length families of identities.  The conditional theorem does not close
-this.  Indeed, under the global positivity hypothesis the periodic-sector
-projector type is uninhabited by item~2 above, so the hypothesis of item~3
-is logically equivalent to its conclusion; the unconditional mathematical
-content of the formalized step is the projector exclusion of item~2, and
-the hypothesis of item~3 is the named interface for the missing
-construction.
-
-The construction itself is now formalized up to its final family: from the
+The projector construction and its displacement are formalized: from the
 corner data of a nontrivial vertical period, the cyclic decomposition of
 the peripheral spectrum produces an orthogonal projector on the physical
 space that is one-sided invariant for every full-period vertical word and
 fails the single-letter invariance
 (\leanid{MPOTensor.exists\_displaced\_invariant\_projector\_of\_periodic\_vector},
 in \path{TNLean/MPS/MPDO/CyclicProjector.lean}).  What the source
-additionally asserts — and what remains open — is that this single-letter
-displacement forces $QH^{(N)}\ne H^{(N)}Q$ at \emph{every} length.
+additionally asserts — and what remains open — is that the cyclic
+decomposition and peripheral spectral hypotheses force
+$QH^{(N)}\ne H^{(N)}Q$ at \emph{every} length.  Literal Lemma-L
+transport shows only that commutation cannot hold simultaneously at all
+positive lengths: its contrapositive produces at least one noncommuting
+length, not the all-length family required by the present interface.
 
 \section{Elimination plan}
 
@@ -102,25 +95,22 @@ has three ingredients.
       $[H^{(N)}]^p$.  Formalized in
       \path{TNLean/MPS/MPDO/StackedLayers.lean}
       (\leanid{MPOTensor.mpo\_stackedTensor}).
-    \item The first-site invariance argument of lines~1874--1887, already
-      formalized in \path{TNLean/MPS/MPDO/InvariantProjection.lean}, applied
-      to the stacked tensor: invariance of a cyclic projector under $p$
-      stacked layers gives commutation with $[H^{(N)}]^p$ at every length,
-      while its nontrivial cyclic displacement under one layer gives
-      non-commutation with $H^{(N)}$ at every length.  The invariance half
-      is formalized: one-sided invariance under every length-$p$ word of the
+    \item The first-site invariance argument of lines~1874--1887, formalized
+      in \path{TNLean/MPS/MPDO/HorizontalBNT.lean}, together with the stacked
+      tensor: invariance of a cyclic projector under $p$ stacked layers gives
+      commutation with $[H^{(N)}]^p$ at every length.  This invariance half is
+      formalized: one-sided invariance under every length-$p$ word of the
       vertically viewed tensor transfers to the stacked tensor
       (\leanid{MPOTensor.stackedTensor\_ketLeftMul\_invariant}) and yields
       the commutation family through item~2
       (\leanid{MPOTensor.periodicSectorProjectorOfCyclicData}).
 \end{enumerate}
 
-Items~2 and~3 are combined in
+Items~2 and the formalized half of item~3 are combined in
 \path{TNLean/MPS/MPDO/StackedLayers.lean}: the hypothesis of the
-conditional exclusion is reduced to the statement that a nontrivial
-$p$-periodic vector supplies an orthogonal projector that is one-sided
-invariant for every length-$p$ vertical word and fails to commute with
-$H^{(N)}$ at every length
+conditional exclusion is reduced to the statement that the constructed
+orthogonal projector, one-sided invariant for every length-$p$ vertical word,
+fails to commute with $H^{(N)}$ at every length
 (\leanid{MPOTensor.PeriodicVectorYieldsCyclicProjector},
 \leanid{MPOTensor.periodicVectorYieldsProjector\_of\_cyclic}).
 
@@ -142,19 +132,19 @@ every full-period vertical word and fails single-letter invariance,
 $Q\widetilde M\ne Q\widetilde MQ$
 (\leanid{MPOTensor.exists\_displaced\_invariant\_projector\_of\_periodic\_vector}).
 
-What remains open is the all-length non-commutation family: the source
-asserts $QH^{(N)}\ne H^{(N)}Q$ for every $N$, which does not follow from
-the single-letter displacement alone.  This is where the horizontal
-canonical form enters: the proposition assumes the tensor is in canonical
-form horizontally, and the argument of lines~1874--1887 (Lemma~L of the
-appendix) turns all-length commutation into the letter-level invariance
-that the displacement forbids.  This implication is recorded as the
-hypothesis \leanid{MPOTensor.NoninvariantProjectorNoncommuting}; granted
-it, the cyclic-projector hypothesis follows
+What remains open is the all-length non-commutation family asserted at source
+lines~1888--1891.  The literal horizontal canonical-form argument proves that
+simultaneous commutation at all positive lengths would imply the forbidden
+letter-level invariance.  Its contrapositive gives only the existence of a
+noncommuting length.  The stronger family is recorded as the hypothesis
+\leanid{MPOTensor.NoninvariantProjectorNoncommuting}; granted it, the
+cyclic-projector hypothesis follows
 (\leanid{MPOTensor.periodicVectorYieldsCyclicProjector\_of\_noncommutation}).
-Once the implication is proved from a horizontal canonical form, the
-conditional exclusion becomes the statement asserted by the source, and
-this note can be retired.
+Elimination therefore requires either deriving the all-length family from the
+cyclic decomposition and peripheral spectral hypotheses, as the source
+asserts, or refactoring the final
+contradiction so that one noncommuting length suffices.  Once one of these
+routes is formalized, this note can be retired.
 
 \section{The injective special case is now resolved}
 
@@ -202,11 +192,10 @@ chain length~$2$; it never constructs, and does not need, an inhabitant of
 
 \leanid{MPOTensor.NoninvariantProjectorNoncommuting} quantifies over
 \emph{every} chain length $N$ (starting at $N=0$), and the natural
-discharge route — the block-injective Lemma~L of
-\path{TNLean/MPS/MPDO/PerCopyHorizontalCF.lean}, applied to a general horizontal
-canonical-form decomposition of $M$ into several (possibly
-gauge-inequivalent) normal blocks with weights — meets two independent
-obstructions that the injective special case above sidesteps.
+discharge route uses the representative Lemma~L for a general horizontal
+canonical-form decomposition of $M$ into several normal representatives with
+weights.  One fixed-length obstruction remains; the second item below records
+the former literal-transport obstruction and its resolution.
 
 \begin{enumerate}
     \item \textbf{Chain length one supplies no data.}  At $N=1$ (chain
@@ -236,38 +225,22 @@ obstructions that the injective special case above sidesteps.
       \leanid{MPOTensor.hasNoPeriodicVectors_verticalTensor_of_isInjective}
       does above, by choosing chain length two instead of the length that
       the structure's field type superficially suggests.
-    \item \textbf{The available representation is MPV-level, not literal.}
-      \leanid{HasHorizontalCFMPVRepresentation} asserts through
-      \leanid{SameMPV₂} that $M$'s doubled-index tensor generates the
-      \emph{same matrix product vectors} as an assembled block-diagonal BNT
-      tensor.  It does not assert that $M$'s own letters \emph{literally equal} a
-      gauge-conjugated direct sum of normal blocks.  The source's own
-      canonical-form decomposition,
-      $\bigoplus_{j,q}\mu_{j,q}X_{j,q}A_jX_{j,q}^{-1}$
-      (\cite[eq:II\_ABasicTensors]{Cirac2016MPDO_arXiv}), is literal: it
-      exhibits $M$ itself, after a change of basis on the bond space, as
-      that direct sum.  The representative-grouped Lemma~L concludes letter
-      equality \emph{for the canonical-form representatives $A_j$}, which
-      live in their own (separately injective) bond space — not for $M$'s own
-      letters.  Transporting that block-level conclusion back to $M$'s
-      own bond space needs either $M$'s own injectivity (the special case
-      resolved above, where the transport is vacuous because $M$ already
-      is the sole block) or a literal, gauge-explicit multi-block
-      decomposition of $M$, which
-      \leanid{HasHorizontalCFMPVRepresentation} does not carry
-      and which is not otherwise formalized in the repository for
-      reducible MPDO tensors.  The older \leanid{HorizontalCFData} and
-      \leanid{IsPerCopyHorizontalCF} also do not carry such a gauge.  They
-      impose the stronger per-copy separation hypothesis documented in
-      \path{docs/paper-gaps/cpgsv17_bicf_block_separation.tex}.
+    \item \textbf{The former literal-transport obstruction is resolved.}
+      The public \leanid{IsHorizontalCF} now carries the source's literal
+      global gauge and an exact-dimension representative-indexed BNT
+      decomposition.  The representative-grouped Lemma~L is
+      extended over all repeated weighted sectors and transported through
+      that gauge.  Thus the first-stage conclusion is now an equality of
+      the original tensor's letters, not merely of its matrix product
+      vectors or of separate canonical-form blocks.  The older
+      \leanid{HorizontalCFData} remains only as a per-copy auxiliary.
 \end{enumerate}
 
-Both obstructions are independent of the exponent $p$ or the specific
+The remaining fixed-length obstruction is independent of the exponent $p$ or the specific
 displaced-projector construction of
 \leanid{MPOTensor.exists_displaced_invariant_projector_of_periodic_vector}:
-they are structural facts about what finite-length trace data can
-determine, and about what the available MPV representation asserts.
-Discharging \leanid{MPOTensor.NoninvariantProjectorNoncommuting}
+it concerns what one finite-length trace identity can determine.  Discharging
+\leanid{MPOTensor.NoninvariantProjectorNoncommuting}
 for a general (reducible, multi-block) horizontal canonical form therefore
 remains open, and is not a routine extension of the injective argument to
 a larger blocking length.
@@ -276,18 +249,13 @@ a larger blocking length.
 The periodic-sector step of Proposition~4.13 is now closed unconditionally
 for MPDO tensors whose doubled-index tensor is (single-letter) injective
 (\leanid{MPOTensor.hasNoPeriodicVectors_verticalTensor_of_isInjective}).
-For the general reducible case, the gap is unchanged in substance from the
-previous verdict — the projector exclusion, the stacked-layers reduction,
-and the displaced-projector construction remain unconditional, and the
-remaining stated hypothesis is
-\leanid{MPOTensor.NoninvariantProjectorNoncommuting} — but is now
-understood more precisely: it is not resolved by the representative-grouped
-Lemma~L in \path{TNLean/MPS/MPDO/HorizontalCFMPVRepresentation.lean}, because
-that theorem concludes letter equality for the canonical-form representatives,
-not for $M$'s own (possibly non-injective) bond space, and the transport
-between the two needs either
-$M$'s own injectivity or a literal, gauge-explicit multi-block
-decomposition that is not currently formalized.  The capstone
+For the general reducible case, the projector exclusion, stacked-layers
+reduction, displaced-projector construction, and literal horizontal
+canonical-form transport are unconditional.  The remaining stated
+hypothesis is \leanid{MPOTensor.NoninvariantProjectorNoncommuting}: the
+representative Lemma~L consumes the simultaneous positive-length family,
+whereas this predicate asks a contradiction from commutation at each one
+fixed length.  The capstone
 \leanid{thm:vertical_cf_of_horizontal_cf} does not consume the injective
 special case: it still needs the independent vertical canonical-form
 construction (stage~3 of \ghissue{3674}), which is unaffected by either

--- a/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
@@ -134,10 +134,10 @@ gives
   P_1H^{(N)}=P_1H^{(N)}P_1=H^{(N)}P_1,
 \]
 and the representative-grouped Lemma~L transfers this equality through every
-repeated weighted sector, the permitted all-zero summand, and the global
-gauge.  Thus the original tensor satisfies the literal equality
-$MP=PMP$, equivalently $(I-P)MP=0$.  The formal theorem assumes only
-$P=P^*$; the source specializes to an orthogonal projector.
+repeated weighted sector and the direct sum of the copy gauges.  Thus the
+original tensor satisfies the literal equality $MP=PMP$, equivalently
+$(I-P)MP=0$.  The formal theorem assumes only $P=P^*$; the source specializes
+to an orthogonal projector.
 
 For the periodic-sector stage, the final positive-operator implication is also
 formalized:

--- a/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
@@ -60,7 +60,7 @@ $M_2(\mathbb C)$.  They also satisfy
 Taking a single horizontal block makes the simultaneous block-separation
 condition identical to ordinary injectivity.  Thus this example satisfies the
 injectivity, left-canonicality, nonzero-weight, and finite-length block-separation
-assumptions in the current horizontal canonical-form structure.
+assumptions in the older per-copy \texttt{HorizontalCFData} structure.
 
 Its diagonal restriction is
 \[
@@ -133,10 +133,11 @@ gives
 \[
   P_1H^{(N)}=P_1H^{(N)}P_1=H^{(N)}P_1,
 \]
-and Lemma~L transfers this equality to every horizontal canonical-form block,
-where it is precisely $(I-P)MP=0$.  The conclusion is stated this way because
-the formal theorem assumes only $P=P^*$; the source's notation
-$P^\perp MP=0$ additionally uses that $P$ is an orthogonal projection.
+and the representative-grouped Lemma~L transfers this equality through every
+repeated weighted sector, the permitted all-zero summand, and the global
+gauge.  Thus the original tensor satisfies the literal equality
+$MP=PMP$, equivalently $(I-P)MP=0$.  The formal theorem assumes only
+$P=P^*$; the source specializes to an orthogonal projector.
 
 For the periodic-sector stage, the final positive-operator implication is also
 formalized:
@@ -145,9 +146,10 @@ formalized:
   \quad\Longrightarrow\quad
   QH^{(N)}=H^{(N)}Q.
 \]
-The remaining step is to derive, from a nontrivial vertical period, one
-orthogonal projector $Q$ having the two all-length properties in source
-lines~1889--1890.
+A nontrivial vertical period now yields the displaced cyclic projector and its
+word invariance.  The remaining step is the fixed-length interface: the
+present noncommutation predicate asks for a contradiction at every individual
+chain length, while Lemma~L consumes the simultaneous positive-length family.
 
 The third stage now has conditional formalizations of its two closing
 arguments.  Granted orthogonal sector projectors whose insertion into the


### PR DESCRIPTION
## Summary

- Define the public horizontal canonical-form predicate by the source-faithful decomposition
  \[
  M^{ab}=\bigoplus_{j,q}\mu_{j,q}X_{j,q}A_j^{ab}X_{j,q}^{-1}.
  \]
  The total displayed bond dimension is exactly the original bond dimension, there is no added zero tail, and the only global matrix is the block direct sum of the per-copy gauges.
- Keep the older per-copy trace-separation structure as a restricted auxiliary construction, distinct from the representative-grouped public predicate.
- Prove the one-way implication from literal horizontal canonical form to the complete BNT matrix-product-vector representation.
- Prove the generic Lemma L conclusion for arbitrary doubled-index matrices \(Y,Z\) on the original bond space, then derive the specialized invariant-projection identity \(\widetilde M Q=Q\widetilde M Q\).
- Synchronize the blueprint and paper-gap accounts. The separate periodic-sector interface remains explicit: the present argument excludes simultaneous commutation at all positive lengths, whereas the cyclic consumer asks for noncommutation at each fixed length.

## Source faithfulness

The canonical-form predicate follows arXiv:1606.00608, lines 237–244 and equations (17a,b), lines 281–301. A flattened copy index is a pair \((j,q)\), and the quantified gauge family is assembled only through the reindexed block diagonal matrix \(\bigoplus_{j,q}X_{j,q}\). Hence the predicate cannot mix inequivalent sectors.

The generic insertion theorem follows Appendix C.3, Lemma L, lines 1835–1858. Representatives are separated only after all repeated copies of the same normal tensor have been grouped. Proposition 4.13, lines 1873–1887, then supplies the specialized invariant-projection consequence.

An independent re-review specifically checked the exact bond dimension, absence of a zero tail, the direct-sum gauge restriction, the complete-MPV bridge, and both original-bond-space consumers; no remaining source-faithfulness defect was found.

## Proof integrity

No axiom, sorry, admit, native decision procedure, unsafe cast, or kernel bypass is introduced.

## Validation

- Full build: 9,380 jobs
- Focused compilation of HorizontalBNT
- Style lint on all changed Lean files
- Forbidden-token and reader-facing prose checks
- Blueprint–Lean synchronization; Chapter 20 canonical forms is 148/148
- Declaration checking
- Blueprint PDF generation; 539 pages
- Oversized-file check
- Whitespace check

Closes #3713
Progress toward #3674

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core MPDO canonical-form and Proposition 4.13 proof chain with substantial new formal theory; behavior is proof-only with no runtime surface, but errors here would misstate a major paper gap closure.
> 
> **Overview**
> Introduces **`MPOTensor.IsHorizontalCF`**, matching the paper’s bond-space decomposition with per-copy gauges, exact total dimension, and grouped BNT representatives (no zero tail). **`HorizontalBNT.lean`** proves literal horizontal CF ⇒ complete BNT MPV representation, representative-grouped Lemma L on the **original** bond space (`insertedTensor_eq_of_firstSiteActionAgree`), and the invariant-projection identity \(\widetilde M Q = Q\widetilde M Q\) via gauge transport—not only MPV-level facts.
> 
> **`CyclicProjector`** and gap docs are retuned: horizontal CF now supplies letter-level invariance from simultaneous commutation at all positive lengths, but **`NoninvariantProjectorNoncommuting`** still needs noncommutation at **each** fixed length separately.
> 
> Blueprint Chapter 20 marks the horizontal CF definition and a new capstone theorem as **leanok**; older per-copy `HorizontalCFData` is documented as auxiliary only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d06b59c7e1139a36df09396e394b292361c616e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->