### PR TITLE
feat(MPS/RFP): expose homogeneous Appendix D factor actions

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -17,6 +17,7 @@ The following archival modules are intentionally excluded
 -/
 
 -- Layer 0: General algebra
+import TNLean.Algebra.FinTupleEquiv
 import TNLean.Algebra.TracePairing
 import TNLean.Algebra.BlockPermutation
 import TNLean.Algebra.SkolemNoether

--- a/TNLean/Algebra/FinTupleEquiv.lean
+++ b/TNLean/Algebra/FinTupleEquiv.lean
@@ -1,0 +1,29 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Data.Fin.VecNotation
+import Mathlib.Logic.Equiv.Fin.Basic
+
+/-!
+# Equivalences for short finite tuples
+
+This file records canonical right-associated product coordinates for functions
+on short finite index types.
+-/
+
+/-- The canonical right-associated identification of a three-coordinate
+function with a triple. -/
+def finThreeArrowEquiv (α : Type*) : (Fin 3 → α) ≃ α × (α × α) :=
+  (Fin.consEquiv fun _ : Fin 3 ↦ α).symm.trans
+    (Equiv.prodCongr (Equiv.refl α) (finTwoArrowEquiv α))
+
+/-- The inverse right-associated identification sends a triple to its three
+coordinates in order. -/
+@[simp] theorem finThreeArrowEquiv_symm_apply
+    {α : Type*} (x : α × (α × α)) :
+    (finThreeArrowEquiv α).symm x = ![x.1, x.2.1, x.2.2] := by
+  funext i
+  refine Fin.cases rfl (fun j ↦ ?_) i
+  refine Fin.cases rfl (fun k ↦ ?_) j
+  exact Fin.cases rfl (fun l ↦ Fin.elim0 l) k

--- a/TNLean/Algebra/FinTupleEquiv.lean
+++ b/TNLean/Algebra/FinTupleEquiv.lean
@@ -3,9 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.Data.Fin.VecNotation
-import Mathlib.Data.Fintype.Basic
 import Mathlib.Logic.Equiv.Fin.Basic
-import Mathlib.Tactic.FinCases
 
 /-!
 # Equivalences for short finite tuples
@@ -17,6 +15,11 @@ on short finite index types.
 
 * `finThreeArrowEquiv`: identifies a function on `Fin 3` with a right-associated triple.
 * `finFourArrowEquiv`: identifies a function on `Fin 4` with a right-associated quadruple.
+
+## Implementation notes
+
+The product coordinates are right-associated and are constructed recursively
+from Mathlib's `finTwoArrowEquiv` using `Fin.consEquiv`.
 
 ## Tags
 
@@ -41,4 +44,6 @@ coordinates in order. -/
     {α : Type*} (x : α × (α × α)) :
     (finThreeArrowEquiv α).symm x = ![x.1, x.2.1, x.2.2] := by
   funext i
-  fin_cases i <;> rfl
+  refine Fin.cases rfl (fun j ↦ ?_) i
+  refine Fin.cases rfl (fun k ↦ ?_) j
+  exact Fin.cases rfl (fun l ↦ Fin.elim0 l) k

--- a/TNLean/Algebra/FinTupleEquiv.lean
+++ b/TNLean/Algebra/FinTupleEquiv.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
 -/
 import Mathlib.Data.Fin.VecNotation
 import Mathlib.Data.Fintype.Basic

--- a/TNLean/Algebra/FinTupleEquiv.lean
+++ b/TNLean/Algebra/FinTupleEquiv.lean
@@ -18,6 +18,7 @@ on short finite index types.
 * `finThreeArrowEquiv`: identifies a function on `Fin 3` with a right-associated triple.
 * `finThreeArrowEquiv_symm_apply`: gives the ordered coordinates of the inverse map.
 * `finFourArrowEquiv`: identifies a function on `Fin 4` with a right-associated quadruple.
+* `finFourArrowEquiv_symm_apply`: gives the ordered coordinates of the inverse map.
 
 ## Implementation notes
 
@@ -46,5 +47,13 @@ coordinates in order. -/
 @[simp] theorem finThreeArrowEquiv_symm_apply
     {α : Type*} (x : α × (α × α)) :
     (finThreeArrowEquiv α).symm x = ![x.1, x.2.1, x.2.2] := by
+  funext i
+  fin_cases i <;> rfl
+
+/-- The inverse right-associated identification sends a quadruple to its four
+coordinates in order. -/
+@[simp] theorem finFourArrowEquiv_symm_apply
+    {α : Type*} (x : α × (α × (α × α))) :
+    (finFourArrowEquiv α).symm x = ![x.1, x.2.1, x.2.2.1, x.2.2.2] := by
   funext i
   fin_cases i <;> rfl

--- a/TNLean/Algebra/FinTupleEquiv.lean
+++ b/TNLean/Algebra/FinTupleEquiv.lean
@@ -3,13 +3,24 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.Data.Fin.VecNotation
+import Mathlib.Data.Fintype.Basic
 import Mathlib.Logic.Equiv.Fin.Basic
+import Mathlib.Tactic.FinCases
 
 /-!
 # Equivalences for short finite tuples
 
 This file records canonical right-associated product coordinates for functions
 on short finite index types.
+
+## Main definitions
+
+* `finThreeArrowEquiv`: identifies a function on `Fin 3` with a right-associated triple.
+* `finFourArrowEquiv`: identifies a function on `Fin 4` with a right-associated quadruple.
+
+## Tags
+
+finite tuples, equivalence, product coordinates
 -/
 
 /-- The canonical right-associated identification of a three-coordinate
@@ -18,12 +29,16 @@ def finThreeArrowEquiv (α : Type*) : (Fin 3 → α) ≃ α × (α × α) :=
   (Fin.consEquiv fun _ : Fin 3 ↦ α).symm.trans
     (Equiv.prodCongr (Equiv.refl α) (finTwoArrowEquiv α))
 
+/-- The canonical right-associated identification of a four-coordinate
+function with a quadruple. -/
+def finFourArrowEquiv (α : Type*) : (Fin 4 → α) ≃ α × (α × (α × α)) :=
+  (Fin.consEquiv fun _ : Fin 4 ↦ α).symm.trans
+    (Equiv.prodCongr (Equiv.refl α) (finThreeArrowEquiv α))
+
 /-- The inverse right-associated identification sends a triple to its three
 coordinates in order. -/
 @[simp] theorem finThreeArrowEquiv_symm_apply
     {α : Type*} (x : α × (α × α)) :
     (finThreeArrowEquiv α).symm x = ![x.1, x.2.1, x.2.2] := by
   funext i
-  refine Fin.cases rfl (fun j ↦ ?_) i
-  refine Fin.cases rfl (fun k ↦ ?_) j
-  exact Fin.cases rfl (fun l ↦ Fin.elim0 l) k
+  fin_cases i <;> rfl

--- a/TNLean/Algebra/FinTupleEquiv.lean
+++ b/TNLean/Algebra/FinTupleEquiv.lean
@@ -16,8 +16,11 @@ on short finite index types.
 ## Main definitions
 
 * `finThreeArrowEquiv`: identifies a function on `Fin 3` with a right-associated triple.
-* `finThreeArrowEquiv_symm_apply`: gives the ordered coordinates of the inverse map.
 * `finFourArrowEquiv`: identifies a function on `Fin 4` with a right-associated quadruple.
+
+## Main statements
+
+* `finThreeArrowEquiv_symm_apply`: gives the ordered coordinates of the inverse map.
 * `finFourArrowEquiv_symm_apply`: gives the ordered coordinates of the inverse map.
 
 ## Implementation notes

--- a/TNLean/Algebra/FinTupleEquiv.lean
+++ b/TNLean/Algebra/FinTupleEquiv.lean
@@ -21,7 +21,9 @@ on short finite index types.
 
 ## Main statements
 
+* `finThreeArrowEquiv_apply`: gives the ordered coordinates of the forward map.
 * `finThreeArrowEquiv_symm_apply`: gives the ordered coordinates of the inverse map.
+* `finFourArrowEquiv_apply`: gives the ordered coordinates of the forward map.
 * `finFourArrowEquiv_symm_apply`: gives the ordered coordinates of the inverse map.
 
 ## Implementation notes
@@ -46,6 +48,13 @@ def finFourArrowEquiv (α : Type*) : (Fin 4 → α) ≃ α × (α × (α × α))
   (Fin.consEquiv fun _ : Fin 4 ↦ α).symm.trans
     (Equiv.prodCongr (Equiv.refl α) (finThreeArrowEquiv α))
 
+/-- The forward right-associated identification extracts the three coordinates
+in order. -/
+@[simp] theorem finThreeArrowEquiv_apply
+    {α : Type*} (x : Fin 3 → α) :
+    finThreeArrowEquiv α x = (x 0, x 1, x 2) := by
+  rfl
+
 /-- The inverse right-associated identification sends a triple to its three
 coordinates in order. -/
 @[simp] theorem finThreeArrowEquiv_symm_apply
@@ -53,6 +62,13 @@ coordinates in order. -/
     (finThreeArrowEquiv α).symm x = ![x.1, x.2.1, x.2.2] := by
   funext i
   fin_cases i <;> rfl
+
+/-- The forward right-associated identification extracts the four coordinates
+in order. -/
+@[simp] theorem finFourArrowEquiv_apply
+    {α : Type*} (x : Fin 4 → α) :
+    finFourArrowEquiv α x = (x 0, x 1, x 2, x 3) := by
+  rfl
 
 /-- The inverse right-associated identification sends a quadruple to its four
 coordinates in order. -/

--- a/TNLean/Algebra/FinTupleEquiv.lean
+++ b/TNLean/Algebra/FinTupleEquiv.lean
@@ -3,7 +3,9 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.Data.Fin.VecNotation
+import Mathlib.Data.Fintype.Basic
 import Mathlib.Logic.Equiv.Fin.Basic
+import Mathlib.Tactic.FinCases
 
 /-!
 # Equivalences for short finite tuples
@@ -14,6 +16,7 @@ on short finite index types.
 ## Main definitions
 
 * `finThreeArrowEquiv`: identifies a function on `Fin 3` with a right-associated triple.
+* `finThreeArrowEquiv_symm_apply`: gives the ordered coordinates of the inverse map.
 * `finFourArrowEquiv`: identifies a function on `Fin 4` with a right-associated quadruple.
 
 ## Implementation notes
@@ -44,6 +47,4 @@ coordinates in order. -/
     {α : Type*} (x : α × (α × α)) :
     (finThreeArrowEquiv α).symm x = ![x.1, x.2.1, x.2.2] := by
   funext i
-  refine Fin.cases rfl (fun j ↦ ?_) i
-  refine Fin.cases rfl (fun k ↦ ?_) j
-  exact Fin.cases rfl (fun l ↦ Fin.elim0 l) k
+  fin_cases i <;> rfl

--- a/TNLean/MPS/MPDO/PhysicalBlocking.lean
+++ b/TNLean/MPS/MPDO/PhysicalBlocking.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinTupleEquiv
 import TNLean.MPS.MPDO.RFPViaTS
 
 /-!

--- a/TNLean/MPS/MPDO/PhysicalBlocking.lean
+++ b/TNLean/MPS/MPDO/PhysicalBlocking.lean
@@ -50,12 +50,6 @@ noncomputable def blockTwo (M : MPOTensor d D) : MPOTensor (d * d) D :=
 
 /-! ### The four-site physical closure -/
 
-/-- The canonical right-associated identification of four-coordinate
-configurations with quadruples. -/
-def finFourArrowEquiv (α : Type*) : (Fin 4 → α) ≃ α × (α × (α × α)) :=
-  (Fin.consEquiv fun _ : Fin 4 => α).symm.trans
-    (Equiv.prodCongr (Equiv.refl α) (finThreeArrowEquiv α))
-
 /-- The four-site physical closure, with the physical indices associated as
 `Fin d × (Fin d × (Fin d × Fin d))`. Its coefficient is the virtual trace of
 four consecutive tensor matrices followed by the inserted virtual operator.

--- a/TNLean/MPS/MPDO/PhysicalBlocking.lean
+++ b/TNLean/MPS/MPDO/PhysicalBlocking.lean
@@ -122,4 +122,7 @@ theorem physClose2_blockTwo_eq_physClose4 (M : MPOTensor d D) :
   simp [Matrix.coe_reindexLinearEquiv, blockedPairEquiv, blockedIndexEquiv,
     blockTwo, Matrix.mul_assoc]
 
+@[deprecated _root_.finFourArrowEquiv (since := "2026-07-13")]
+alias finFourArrowEquiv := _root_.finFourArrowEquiv
+
 end MPOTensor

--- a/TNLean/MPS/MPDO/PhysicalBlocking.lean
+++ b/TNLean/MPS/MPDO/PhysicalBlocking.lean
@@ -87,8 +87,7 @@ theorem physCloseN_four_eq_physClose4 (M : MPOTensor d D) :
         (finFourArrowEquiv (Fin d))).toLinearMap ∘ₗ physCloseN M 4 =
       physClose4 M := by
   ext X i j
-  simp [Matrix.coe_reindexLinearEquiv, finFourArrowEquiv, finThreeArrowEquiv,
-    Matrix.mul_assoc]
+  simp [Matrix.coe_reindexLinearEquiv, Matrix.mul_assoc]
 
 /-! ### Blocking identities -/
 

--- a/TNLean/MPS/MPDO/PhysicalBlocking.lean
+++ b/TNLean/MPS/MPDO/PhysicalBlocking.lean
@@ -83,8 +83,8 @@ noncomputable def physClose4 (M : MPOTensor d D) :
 configurations with quadruples of physical indices, the general length-four
 closure is `physClose4`. -/
 theorem physCloseN_four_eq_physClose4 (M : MPOTensor d D) :
-    (Matrix.reindexLinearEquiv ℂ ℂ (finFourArrowEquiv (Fin d))
-        (finFourArrowEquiv (Fin d))).toLinearMap ∘ₗ physCloseN M 4 =
+    (Matrix.reindexLinearEquiv ℂ ℂ (_root_.finFourArrowEquiv (Fin d))
+        (_root_.finFourArrowEquiv (Fin d))).toLinearMap ∘ₗ physCloseN M 4 =
       physClose4 M := by
   ext X i j
   simp [Matrix.coe_reindexLinearEquiv, Matrix.mul_assoc]

--- a/TNLean/MPS/MPDO/PhysicalSectorBondCommutativity.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorBondCommutativity.lean
@@ -56,24 +56,25 @@ its left tensor-product lift after identifying configurations with triples.
 Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`), lines
 1589--1593. -/
 theorem reindex_embedLocalOperator_zero (F : PhysicalSectorFactorization K) :
-    Matrix.reindex (finThreeArrowEquiv (Fin d)) (finThreeArrowEquiv (Fin d))
+    Matrix.reindex (_root_.finThreeArrowEquiv (Fin d))
+        (_root_.finThreeArrowEquiv (Fin d))
         (embedLocalOperator (d := d) 2 3 (by decide) (0 : Fin 3) F.physicalBond) =
       leftPairMatrix F.physicalPairBond := by
   ext σ τ
   have hAgree :
       AgreesOutsideWindow (d := d) 2 (by decide) (0 : Fin 3)
-          ((finThreeArrowEquiv (Fin d)).symm σ)
-          ((finThreeArrowEquiv (Fin d)).symm τ) ↔
+          ((_root_.finThreeArrowEquiv (Fin d)).symm σ)
+          ((_root_.finThreeArrowEquiv (Fin d)).symm τ) ↔
         τ.2.2 = σ.2.2 := by
     constructor
     · intro ha
       have h := congrFun ha (2 : Fin 3)
-      simpa [AgreesOutsideWindow, finThreeArrowEquiv,
+      simpa [AgreesOutsideWindow, _root_.finThreeArrowEquiv,
         MPSTensor.replaceWindow, MPSTensor.extractWindow] using h
     · intro ha
       funext i
       fin_cases i <;>
-        simp [finThreeArrowEquiv,
+        simp [_root_.finThreeArrowEquiv,
           MPSTensor.replaceWindow, MPSTensor.extractWindow, ha]
   by_cases h : τ.2.2 = σ.2.2
   · have ha := hAgree.mpr h
@@ -87,8 +88,8 @@ theorem reindex_embedLocalOperator_zero (F : PhysicalSectorFactorization K) :
         (if σ.2.2 = τ.2.2 then 1 else 0)
     rw [if_pos h.symm, mul_one]
   · have ha : ¬ AgreesOutsideWindow (d := d) 2 (by decide) (0 : Fin 3)
-        ((finThreeArrowEquiv (Fin d)).symm σ)
-        ((finThreeArrowEquiv (Fin d)).symm τ) := fun ha ↦ h (hAgree.mp ha)
+        ((_root_.finThreeArrowEquiv (Fin d)).symm σ)
+        ((_root_.finThreeArrowEquiv (Fin d)).symm τ) := fun ha ↦ h (hAgree.mp ha)
     simp only [Fin.isValue, Matrix.reindex_apply, Matrix.submatrix_apply,
       embedLocalOperator_apply]
     rw [if_neg ha]
@@ -104,24 +105,25 @@ its right tensor-product lift after identifying configurations with triples.
 Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`), lines
 1589--1593. -/
 theorem reindex_embedLocalOperator_one (F : PhysicalSectorFactorization K) :
-    Matrix.reindex (finThreeArrowEquiv (Fin d)) (finThreeArrowEquiv (Fin d))
+    Matrix.reindex (_root_.finThreeArrowEquiv (Fin d))
+        (_root_.finThreeArrowEquiv (Fin d))
         (embedLocalOperator (d := d) 2 3 (by decide) (1 : Fin 3) F.physicalBond) =
       rightPairMatrix F.physicalPairBond := by
   ext σ τ
   have hAgree :
       AgreesOutsideWindow (d := d) 2 (by decide) (1 : Fin 3)
-          ((finThreeArrowEquiv (Fin d)).symm σ)
-          ((finThreeArrowEquiv (Fin d)).symm τ) ↔
+          ((_root_.finThreeArrowEquiv (Fin d)).symm σ)
+          ((_root_.finThreeArrowEquiv (Fin d)).symm τ) ↔
         τ.1 = σ.1 := by
     constructor
     · intro ha
       have h := congrFun ha (0 : Fin 3)
-      simpa [finThreeArrowEquiv, MPSTensor.replaceWindow,
+      simpa [_root_.finThreeArrowEquiv, MPSTensor.replaceWindow,
         MPSTensor.extractWindow] using h
     · intro ha
       funext i
       fin_cases i <;>
-        simp [finThreeArrowEquiv, MPSTensor.replaceWindow,
+        simp [_root_.finThreeArrowEquiv, MPSTensor.replaceWindow,
           MPSTensor.extractWindow, ha]
   by_cases h : τ.1 = σ.1
   · have ha := hAgree.mpr h
@@ -132,8 +134,8 @@ theorem reindex_embedLocalOperator_one (F : PhysicalSectorFactorization K) :
       (if σ.1 = τ.1 then 1 else 0) * F.physicalPairBond σ.2 τ.2
     rw [if_pos h.symm, one_mul]
   · have ha : ¬ AgreesOutsideWindow (d := d) 2 (by decide) (1 : Fin 3)
-        ((finThreeArrowEquiv (Fin d)).symm σ)
-        ((finThreeArrowEquiv (Fin d)).symm τ) := fun ha ↦ h (hAgree.mp ha)
+        ((_root_.finThreeArrowEquiv (Fin d)).symm σ)
+        ((_root_.finThreeArrowEquiv (Fin d)).symm τ) := fun ha ↦ h (hAgree.mp ha)
     simp only [Fin.isValue, Matrix.reindex_apply, Matrix.submatrix_apply,
       embedLocalOperator_apply]
     rw [if_neg ha]

--- a/TNLean/MPS/MPDO/PhysicalSectorBondCommutativity.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorBondCommutativity.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinTupleEquiv
 import TNLean.MPS.MPDO.PhysicalSectorPositiveBond
 import TNLean.MPS.MPDO.CommutingForm
 

--- a/TNLean/MPS/MPDO/PhysicalSectorBondCommutativity.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorBondCommutativity.lean
@@ -70,13 +70,12 @@ theorem reindex_embedLocalOperator_zero (F : PhysicalSectorFactorization K) :
     constructor
     · intro ha
       have h := congrFun ha (2 : Fin 3)
-      simpa [AgreesOutsideWindow, _root_.finThreeArrowEquiv,
-        MPSTensor.replaceWindow, MPSTensor.extractWindow] using h
+      simpa [AgreesOutsideWindow, MPSTensor.replaceWindow,
+        MPSTensor.extractWindow] using h
     · intro ha
       funext i
       fin_cases i <;>
-        simp [_root_.finThreeArrowEquiv,
-          MPSTensor.replaceWindow, MPSTensor.extractWindow, ha]
+        simp [MPSTensor.replaceWindow, MPSTensor.extractWindow, ha]
   by_cases h : τ.2.2 = σ.2.2
   · have ha := hAgree.mpr h
     simp only [Fin.isValue, Matrix.reindex_apply, Matrix.submatrix_apply,
@@ -119,13 +118,11 @@ theorem reindex_embedLocalOperator_one (F : PhysicalSectorFactorization K) :
     constructor
     · intro ha
       have h := congrFun ha (0 : Fin 3)
-      simpa [_root_.finThreeArrowEquiv, MPSTensor.replaceWindow,
-        MPSTensor.extractWindow] using h
+      simpa [MPSTensor.replaceWindow, MPSTensor.extractWindow] using h
     · intro ha
       funext i
       fin_cases i <;>
-        simp [_root_.finThreeArrowEquiv, MPSTensor.replaceWindow,
-          MPSTensor.extractWindow, ha]
+        simp [MPSTensor.replaceWindow, MPSTensor.extractWindow, ha]
   by_cases h : τ.1 = σ.1
   · have ha := hAgree.mpr h
     simp only [Fin.isValue, Matrix.reindex_apply, Matrix.submatrix_apply,

--- a/TNLean/MPS/MPDO/PhysicalSectorBondCommutativity.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorBondCommutativity.lean
@@ -77,9 +77,15 @@ theorem reindex_embedLocalOperator_zero (F : PhysicalSectorFactorization K) :
           MPSTensor.replaceWindow, MPSTensor.extractWindow, ha]
   by_cases h : τ.2.2 = σ.2.2
   · have ha := hAgree.mpr h
-    simp [Matrix.reindex_apply, embedLocalOperator_apply, ha, leftPairMatrix,
-      physicalBond, MPSTensor.extractWindow, h]
-    simp [finThreeArrowEquiv]
+    simp only [Fin.isValue, Matrix.reindex_apply, Matrix.submatrix_apply,
+      embedLocalOperator_apply]
+    rw [if_pos ha]
+    simp only [physicalBond, Matrix.reindex_apply, Matrix.submatrix_apply,
+      Equiv.symm_symm, leftPairMatrix, Matrix.kroneckerMap_apply]
+    change F.physicalPairBond (σ.1, σ.2.1) (τ.1, τ.2.1) =
+      F.physicalPairBond (σ.1, σ.2.1) (τ.1, τ.2.1) *
+        (if σ.2.2 = τ.2.2 then 1 else 0)
+    rw [if_pos h.symm, mul_one]
   · have ha : ¬ AgreesOutsideWindow (d := d) 2 (by decide) (0 : Fin 3)
         ((finThreeArrowEquiv (Fin d)).symm σ)
         ((finThreeArrowEquiv (Fin d)).symm τ) := fun ha ↦ h (hAgree.mp ha)

--- a/TNLean/MPS/MPDO/PhysicalSectorBondTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorBondTransport.lean
@@ -591,16 +591,16 @@ theorem physicalBond_zero_one_comm (F : PhysicalSectorFactorization K) :
         embedLocalOperator (d := d) 2 3 (by decide) (1 : Fin 3) F.physicalBond =
       embedLocalOperator (d := d) 2 3 (by decide) (1 : Fin 3) F.physicalBond *
         embedLocalOperator (d := d) 2 3 (by decide) (0 : Fin 3) F.physicalBond := by
-  apply (Matrix.reindex (finThreeArrowEquiv (Fin d))
-    (finThreeArrowEquiv (Fin d))).injective
-  change (Matrix.reindexLinearEquiv ℂ ℂ (finThreeArrowEquiv (Fin d))
-      (finThreeArrowEquiv (Fin d))) (_ * _) =
-    (Matrix.reindexLinearEquiv ℂ ℂ (finThreeArrowEquiv (Fin d))
-      (finThreeArrowEquiv (Fin d))) (_ * _)
-  rw [← Matrix.reindexLinearEquiv_mul ℂ ℂ (finThreeArrowEquiv (Fin d))
-      (finThreeArrowEquiv (Fin d)) (finThreeArrowEquiv (Fin d)),
-    ← Matrix.reindexLinearEquiv_mul ℂ ℂ (finThreeArrowEquiv (Fin d))
-      (finThreeArrowEquiv (Fin d)) (finThreeArrowEquiv (Fin d)),
+  apply (Matrix.reindex (_root_.finThreeArrowEquiv (Fin d))
+    (_root_.finThreeArrowEquiv (Fin d))).injective
+  change (Matrix.reindexLinearEquiv ℂ ℂ (_root_.finThreeArrowEquiv (Fin d))
+      (_root_.finThreeArrowEquiv (Fin d))) (_ * _) =
+    (Matrix.reindexLinearEquiv ℂ ℂ (_root_.finThreeArrowEquiv (Fin d))
+      (_root_.finThreeArrowEquiv (Fin d))) (_ * _)
+  rw [← Matrix.reindexLinearEquiv_mul ℂ ℂ (_root_.finThreeArrowEquiv (Fin d))
+      (_root_.finThreeArrowEquiv (Fin d)) (_root_.finThreeArrowEquiv (Fin d)),
+    ← Matrix.reindexLinearEquiv_mul ℂ ℂ (_root_.finThreeArrowEquiv (Fin d))
+      (_root_.finThreeArrowEquiv (Fin d)) (_root_.finThreeArrowEquiv (Fin d)),
     Matrix.coe_reindexLinearEquiv, F.reindex_embedLocalOperator_zero,
     F.reindex_embedLocalOperator_one, F.physicalPairBonds_comm]
 

--- a/TNLean/MPS/MPDO/RFPViaTS.lean
+++ b/TNLean/MPS/MPDO/RFPViaTS.lean
@@ -222,8 +222,7 @@ theorem physCloseN_three_eq_physClose3 (M : MPOTensor d D) :
         (_root_.finThreeArrowEquiv (Fin d))).toLinearMap ∘ₗ physCloseN M 3 =
       physClose3 M := by
   ext X i j
-  simp [Matrix.coe_reindexLinearEquiv, _root_.finThreeArrowEquiv,
-    Matrix.mul_assoc]
+  simp [Matrix.coe_reindexLinearEquiv, Matrix.mul_assoc]
 
 /-! ### MPDO renormalization fixed point (Definition 4.1) -/
 

--- a/TNLean/MPS/MPDO/RFPViaTS.lean
+++ b/TNLean/MPS/MPDO/RFPViaTS.lean
@@ -2,6 +2,7 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+import TNLean.Algebra.FinTupleEquiv
 import TNLean.MPS.MPDO.KrausCPTP
 
 /-!
@@ -178,13 +179,6 @@ theorem physCloseN_two_eq_physClose2 (M : MPOTensor d D) :
   simp [Matrix.coe_reindexLinearEquiv, finTwoArrowEquiv_symm_apply]
 
 /-! ### The three-site physical operator -/
-
-/-- The canonical right-associated identification of three-coordinate
-configurations with triples: separate the first coordinate, then identify the
-remaining two-coordinate configuration with a pair. -/
-def finThreeArrowEquiv (α : Type*) : (Fin 3 → α) ≃ α × (α × α) :=
-  (Fin.consEquiv fun _ : Fin 3 => α).symm.trans
-    (Equiv.prodCongr (Equiv.refl α) (finTwoArrowEquiv α))
 
 /-- The **three-site physical operator** as a linear map in the virtual operator
 $X$. Its physical indices are right-associated as

--- a/TNLean/MPS/MPDO/RFPViaTS.lean
+++ b/TNLean/MPS/MPDO/RFPViaTS.lean
@@ -218,11 +218,11 @@ configurations with triples of physical indices, the general length-three
 closure is `physClose3`. For $M=\mathcal K$, this identifies the two forms of
 $\mathcal K_3(X)$ in arXiv:1606.00608, Proposition C.7, lines 1510--1516. -/
 theorem physCloseN_three_eq_physClose3 (M : MPOTensor d D) :
-    (Matrix.reindexLinearEquiv ℂ ℂ (finThreeArrowEquiv (Fin d))
-        (finThreeArrowEquiv (Fin d))).toLinearMap ∘ₗ physCloseN M 3 =
+    (Matrix.reindexLinearEquiv ℂ ℂ (_root_.finThreeArrowEquiv (Fin d))
+        (_root_.finThreeArrowEquiv (Fin d))).toLinearMap ∘ₗ physCloseN M 3 =
       physClose3 M := by
   ext X i j
-  simp [Matrix.coe_reindexLinearEquiv, finThreeArrowEquiv,
+  simp [Matrix.coe_reindexLinearEquiv, _root_.finThreeArrowEquiv,
     Matrix.mul_assoc]
 
 /-! ### MPDO renormalization fixed point (Definition 4.1) -/
@@ -246,5 +246,8 @@ def IsRFPViaTS (M : MPOTensor d D) : Prop :=
     IsKrausCPTP S ∧ IsKrausCPTP T ∧
     (∀ X, S (physClose2 M X) = physClose1 M X) ∧
     (∀ X, T (physClose1 M X) = physClose2 M X)
+
+@[deprecated _root_.finThreeArrowEquiv (since := "2026-07-13")]
+alias finThreeArrowEquiv := _root_.finThreeArrowEquiv
 
 end MPOTensor

--- a/TNLean/MPS/RFP/AppendixBCommutation.lean
+++ b/TNLean/MPS/RFP/AppendixBCommutation.lean
@@ -29,18 +29,20 @@ variable {d D : ℕ}
 
 /-! ### Matrices of adjacent pair lifts -/
 
-/-- The right-associated identification of a three-coordinate function with a
-triple. -/
-private def appendixBFinThreeArrowEquiv (α : Type*) :
+/-- The canonical right-associated identification of a three-site configuration
+with a triple. -/
+def finThreeArrowEquiv (α : Type*) :
     (Fin 3 → α) ≃ α × (α × α) :=
   (Fin.consEquiv fun _ : Fin 3 ↦ α).symm.trans
     (Equiv.prodCongr (Equiv.refl α) (finTwoArrowEquiv α))
 
-@[simp] private theorem appendixBFinThreeArrowEquiv_symm_apply
+@[simp] private theorem finThreeArrowEquiv_symm_apply
     {alpha : Type*} (x : alpha × (alpha × alpha)) :
-    (appendixBFinThreeArrowEquiv alpha).symm x = ![x.1, x.2.1, x.2.2] := by
+    (finThreeArrowEquiv alpha).symm x = ![x.1, x.2.1, x.2.2] := by
   funext k
   fin_cases k <;> rfl
+
+private abbrev appendixBFinThreeArrowEquiv := finThreeArrowEquiv
 
 @[simp] private theorem axPairCfg_vecCons (a b c : Fin d) :
     axPairCfg ![a, b, c] = ![a, b] := by
@@ -78,12 +80,16 @@ private theorem replaceXBCfg_eq_iff (sigma tau : Cfg d 3) (beta : Cfg d 2) :
     funext k
     fin_cases k <;> simp [replaceXBCfg, xbPairCfg, h]
 
-/-- Reindexing the coefficient matrix of the first physical pair lift gives
-the standard tensor-product matrix lift. -/
-private theorem leftPairLift_toMatrix_reindex
+/-- Under the canonical two-site and three-site reindexings, the first-pair
+action is \(Q\otimes 1\).
+
+This is the homogeneous three-single-site coefficient-space specialization of
+the \(AX\) factor action in arXiv:1606.00608, lines 2185--2186 and 2205--2218.
+-/
+theorem leftPairLift_toMatrix_reindex
     (Q : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2) :
-    Matrix.reindex (appendixBFinThreeArrowEquiv (Fin d))
-        (appendixBFinThreeArrowEquiv (Fin d))
+    Matrix.reindex (finThreeArrowEquiv (Fin d))
+        (finThreeArrowEquiv (Fin d))
         (LinearMap.toMatrix' (leftPairLift Q)) =
       appendixBLeftPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin d))
         (finTwoArrowEquiv (Fin d)) (LinearMap.toMatrix' Q)) := by
@@ -129,12 +135,16 @@ private theorem leftPairLift_toMatrix_reindex
     rw [hslice]
     simp [h]
 
-/-- Reindexing the coefficient matrix of the second physical pair lift gives
-the standard tensor-product matrix lift. -/
-private theorem rightPairLift_toMatrix_reindex
+/-- Under the canonical two-site and three-site reindexings, the final-pair
+action is \(1\otimes Q\).
+
+This is the homogeneous three-single-site coefficient-space specialization of
+the \(XB\) factor action in arXiv:1606.00608, lines 2185--2186 and 2205--2218.
+-/
+theorem rightPairLift_toMatrix_reindex
     (Q : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2) :
-    Matrix.reindex (appendixBFinThreeArrowEquiv (Fin d))
-        (appendixBFinThreeArrowEquiv (Fin d))
+    Matrix.reindex (finThreeArrowEquiv (Fin d))
+        (finThreeArrowEquiv (Fin d))
         (LinearMap.toMatrix' (rightPairLift Q)) =
       appendixBRightPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin d))
         (finTwoArrowEquiv (Fin d)) (LinearMap.toMatrix' Q)) := by
@@ -179,6 +189,34 @@ private theorem rightPairLift_toMatrix_reindex
           ((finTwoArrowEquiv (Fin d)).symm (σ.2.1, σ.2.2))
     rw [hslice]
     simp [h]
+
+/-- The hatted Appendix B coefficient representatives act on a homogeneous
+three-single-site coefficient space by
+\(\widehat Q_{AX}\otimes 1\) and \(1\otimes\widehat Q_{XB}\), respectively,
+under the canonical right-associated reindexings.
+
+This is only the three-single-site coefficient-factor specialization of the
+local actions in Definition D.2. It does not construct projectors for an
+arbitrary factorization
+\(\mathcal H_A\otimes\mathcal H_X\otimes\mathcal H_B\).
+
+Source: arXiv:1606.00608, factor spaces at lines 2185--2186 and Definition D.2,
+lines 2205--2218. -/
+theorem AppendixBStructuralData.appendixBQAXQXB_factor_actions
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    (Matrix.reindex (finThreeArrowEquiv (Fin d))
+          (finThreeArrowEquiv (Fin d))
+          (LinearMap.toMatrix' (leftPairLift hStruct.appendixBQAXOnCoeffSpace)) =
+        appendixBLeftPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin d))
+          (finTwoArrowEquiv (Fin d))
+          (LinearMap.toMatrix' hStruct.appendixBQAXOnCoeffSpace))) ∧
+      Matrix.reindex (finThreeArrowEquiv (Fin d))
+          (finThreeArrowEquiv (Fin d))
+          (LinearMap.toMatrix' (rightPairLift hStruct.appendixBQXBOnCoeffSpace)) =
+        appendixBRightPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin d))
+          (finTwoArrowEquiv (Fin d))
+          (LinearMap.toMatrix' hStruct.appendixBQXBOnCoeffSpace)) := by
+  exact ⟨leftPairLift_toMatrix_reindex _, rightPairLift_toMatrix_reindex _⟩
 
 /-! ### Virtual replacement slices -/
 

--- a/TNLean/MPS/RFP/AppendixBCommutation.lean
+++ b/TNLean/MPS/RFP/AppendixBCommutation.lean
@@ -176,33 +176,47 @@ theorem rightPairLift_toMatrix_reindex
     rw [hslice]
     simp [h]
 
-/-- The hatted Appendix B coefficient representatives act on a homogeneous
-three-single-site coefficient space by
-\(\widehat Q_{AX}\otimes 1\) and \(1\otimes\widehat Q_{XB}\), respectively,
-under the canonical right-associated reindexings.
+/-- The hatted Appendix B (AX) coefficient representative acts on a
+homogeneous three-single-site coefficient space by
+\(\widehat Q_{AX}\otimes 1\) under the canonical right-associated reindexing.
 
 This is only the three-single-site coefficient-factor specialization of the
-local actions in Definition D.2. It does not construct projectors for an
+left local action in Definition D.2. It does not construct a projector for an
 arbitrary factorization
 \(\mathcal H_A\otimes\mathcal H_X\otimes\mathcal H_B\).
 
 Source: arXiv:1606.00608, factor spaces at lines 2185--2186 and Definition D.2,
 lines 2205--2218. -/
-theorem AppendixBStructuralData.appendixBQAXQXB_factor_actions
+theorem AppendixBStructuralData.appendixBQAX_factor_action
     {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
-    (Matrix.reindex (finThreeArrowEquiv (Fin d))
-          (finThreeArrowEquiv (Fin d))
-          (LinearMap.toMatrix' (leftPairLift hStruct.appendixBQAXOnCoeffSpace)) =
-        appendixBLeftPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin d))
-          (finTwoArrowEquiv (Fin d))
-          (LinearMap.toMatrix' hStruct.appendixBQAXOnCoeffSpace))) ∧
-      Matrix.reindex (finThreeArrowEquiv (Fin d))
+    Matrix.reindex (finThreeArrowEquiv (Fin d))
+        (finThreeArrowEquiv (Fin d))
+        (LinearMap.toMatrix' (leftPairLift hStruct.appendixBQAXOnCoeffSpace)) =
+      appendixBLeftPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin d))
+        (finTwoArrowEquiv (Fin d))
+        (LinearMap.toMatrix' hStruct.appendixBQAXOnCoeffSpace)) := by
+  exact leftPairLift_toMatrix_reindex _
+
+/-- The hatted Appendix B (XB) coefficient representative acts on a
+homogeneous three-single-site coefficient space by
+\(1\otimes\widehat Q_{XB}\) under the canonical right-associated reindexing.
+
+This is only the three-single-site coefficient-factor specialization of the
+right local action in Definition D.2. It does not construct a projector for an
+arbitrary factorization
+\(\mathcal H_A\otimes\mathcal H_X\otimes\mathcal H_B\).
+
+Source: arXiv:1606.00608, factor spaces at lines 2185--2186 and Definition D.2,
+lines 2205--2218. -/
+theorem AppendixBStructuralData.appendixBQXB_factor_action
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    Matrix.reindex (finThreeArrowEquiv (Fin d))
           (finThreeArrowEquiv (Fin d))
           (LinearMap.toMatrix' (rightPairLift hStruct.appendixBQXBOnCoeffSpace)) =
-        appendixBRightPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin d))
-          (finTwoArrowEquiv (Fin d))
-          (LinearMap.toMatrix' hStruct.appendixBQXBOnCoeffSpace)) := by
-  exact ⟨leftPairLift_toMatrix_reindex _, rightPairLift_toMatrix_reindex _⟩
+      appendixBRightPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin d))
+        (finTwoArrowEquiv (Fin d))
+        (LinearMap.toMatrix' hStruct.appendixBQXBOnCoeffSpace)) := by
+  exact rightPairLift_toMatrix_reindex _
 
 /-! ### Virtual replacement slices -/
 

--- a/TNLean/MPS/RFP/AppendixBCommutation.lean
+++ b/TNLean/MPS/RFP/AppendixBCommutation.lean
@@ -2,6 +2,7 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+import TNLean.Algebra.FinTupleEquiv
 import TNLean.MPS.RFP.AppendixBSupport
 import TNLean.MPS.RFP.KroneckerTransport
 
@@ -28,21 +29,6 @@ namespace MPSTensor
 variable {d D : ℕ}
 
 /-! ### Matrices of adjacent pair lifts -/
-
-/-- The canonical right-associated identification of a three-site configuration
-with a triple. -/
-def finThreeArrowEquiv (α : Type*) :
-    (Fin 3 → α) ≃ α × (α × α) :=
-  (Fin.consEquiv fun _ : Fin 3 ↦ α).symm.trans
-    (Equiv.prodCongr (Equiv.refl α) (finTwoArrowEquiv α))
-
-@[simp] private theorem finThreeArrowEquiv_symm_apply
-    {alpha : Type*} (x : alpha × (alpha × alpha)) :
-    (finThreeArrowEquiv alpha).symm x = ![x.1, x.2.1, x.2.2] := by
-  funext k
-  fin_cases k <;> rfl
-
-private abbrev appendixBFinThreeArrowEquiv := finThreeArrowEquiv
 
 @[simp] private theorem axPairCfg_vecCons (a b c : Fin d) :
     axPairCfg ![a, b, c] = ![a, b] := by
@@ -97,9 +83,9 @@ theorem leftPairLift_toMatrix_reindex
   ext σ τ
   by_cases h : σ.2.2 = τ.2.2
   · have hslice : (fun α ↦
-        (Pi.single ((appendixBFinThreeArrowEquiv (Fin d)).symm τ) (1 : ℂ) :
+        (Pi.single ((finThreeArrowEquiv (Fin d)).symm τ) (1 : ℂ) :
           NSiteSpace d 3)
-          (replaceAXCfg ((appendixBFinThreeArrowEquiv (Fin d)).symm σ) α)) =
+          (replaceAXCfg ((finThreeArrowEquiv (Fin d)).symm σ) α)) =
         (Pi.single ((finTwoArrowEquiv (Fin d)).symm (τ.1, τ.2.1)) (1 : ℂ) :
           NSiteSpace d 2) := by
       funext α
@@ -107,28 +93,28 @@ theorem leftPairLift_toMatrix_reindex
       simp only [replaceAXCfg_eq_iff]
       simp [finTwoArrowEquiv, h]
     change Q (fun α ↦
-        (Pi.single ((appendixBFinThreeArrowEquiv (Fin d)).symm τ) (1 : ℂ) :
+        (Pi.single ((finThreeArrowEquiv (Fin d)).symm τ) (1 : ℂ) :
           NSiteSpace d 3)
-          (replaceAXCfg ((appendixBFinThreeArrowEquiv (Fin d)).symm σ) α))
-        (axPairCfg ((appendixBFinThreeArrowEquiv (Fin d)).symm σ)) =
+          (replaceAXCfg ((finThreeArrowEquiv (Fin d)).symm σ) α))
+        (axPairCfg ((finThreeArrowEquiv (Fin d)).symm σ)) =
       Q (Pi.single ((finTwoArrowEquiv (Fin d)).symm (τ.1, τ.2.1)) (1 : ℂ))
         ((finTwoArrowEquiv (Fin d)).symm (σ.1, σ.2.1)) *
           (if σ.2.2 = τ.2.2 then 1 else 0)
     rw [hslice]
     simp [finTwoArrowEquiv, h]
   · have hslice : (fun α ↦
-        (Pi.single ((appendixBFinThreeArrowEquiv (Fin d)).symm τ) (1 : ℂ) :
+        (Pi.single ((finThreeArrowEquiv (Fin d)).symm τ) (1 : ℂ) :
           NSiteSpace d 3)
-          (replaceAXCfg ((appendixBFinThreeArrowEquiv (Fin d)).symm σ) α)) = 0 := by
+          (replaceAXCfg ((finThreeArrowEquiv (Fin d)).symm σ) α)) = 0 := by
       funext α
       simp only [Pi.single_apply, Pi.zero_apply]
       simp only [replaceAXCfg_eq_iff]
       simp [h]
     change Q (fun α ↦
-        (Pi.single ((appendixBFinThreeArrowEquiv (Fin d)).symm τ) (1 : ℂ) :
+        (Pi.single ((finThreeArrowEquiv (Fin d)).symm τ) (1 : ℂ) :
           NSiteSpace d 3)
-          (replaceAXCfg ((appendixBFinThreeArrowEquiv (Fin d)).symm σ) α))
-        (axPairCfg ((appendixBFinThreeArrowEquiv (Fin d)).symm σ)) =
+          (replaceAXCfg ((finThreeArrowEquiv (Fin d)).symm σ) α))
+        (axPairCfg ((finThreeArrowEquiv (Fin d)).symm σ)) =
       Q (Pi.single ((finTwoArrowEquiv (Fin d)).symm (τ.1, τ.2.1)) (1 : ℂ))
         ((finTwoArrowEquiv (Fin d)).symm (σ.1, σ.2.1)) *
           (if σ.2.2 = τ.2.2 then 1 else 0)
@@ -152,9 +138,9 @@ theorem rightPairLift_toMatrix_reindex
   ext σ τ
   by_cases h : σ.1 = τ.1
   · have hslice : (fun β ↦
-        (Pi.single ((appendixBFinThreeArrowEquiv (Fin d)).symm τ) (1 : ℂ) :
+        (Pi.single ((finThreeArrowEquiv (Fin d)).symm τ) (1 : ℂ) :
           NSiteSpace d 3)
-          (replaceXBCfg ((appendixBFinThreeArrowEquiv (Fin d)).symm σ) β)) =
+          (replaceXBCfg ((finThreeArrowEquiv (Fin d)).symm σ) β)) =
         (Pi.single ((finTwoArrowEquiv (Fin d)).symm (τ.2.1, τ.2.2)) (1 : ℂ) :
           NSiteSpace d 2) := by
       funext β
@@ -162,28 +148,28 @@ theorem rightPairLift_toMatrix_reindex
       simp only [replaceXBCfg_eq_iff]
       simp [finTwoArrowEquiv, h]
     change Q (fun β ↦
-        (Pi.single ((appendixBFinThreeArrowEquiv (Fin d)).symm τ) (1 : ℂ) :
+        (Pi.single ((finThreeArrowEquiv (Fin d)).symm τ) (1 : ℂ) :
           NSiteSpace d 3)
-          (replaceXBCfg ((appendixBFinThreeArrowEquiv (Fin d)).symm σ) β))
-        (xbPairCfg ((appendixBFinThreeArrowEquiv (Fin d)).symm σ)) =
+          (replaceXBCfg ((finThreeArrowEquiv (Fin d)).symm σ) β))
+        (xbPairCfg ((finThreeArrowEquiv (Fin d)).symm σ)) =
       (if σ.1 = τ.1 then 1 else 0) *
         Q (Pi.single ((finTwoArrowEquiv (Fin d)).symm (τ.2.1, τ.2.2)) (1 : ℂ))
           ((finTwoArrowEquiv (Fin d)).symm (σ.2.1, σ.2.2))
     rw [hslice]
     simp [finTwoArrowEquiv, h]
   · have hslice : (fun β ↦
-        (Pi.single ((appendixBFinThreeArrowEquiv (Fin d)).symm τ) (1 : ℂ) :
+        (Pi.single ((finThreeArrowEquiv (Fin d)).symm τ) (1 : ℂ) :
           NSiteSpace d 3)
-          (replaceXBCfg ((appendixBFinThreeArrowEquiv (Fin d)).symm σ) β)) = 0 := by
+          (replaceXBCfg ((finThreeArrowEquiv (Fin d)).symm σ) β)) = 0 := by
       funext β
       simp only [Pi.single_apply, Pi.zero_apply]
       simp only [replaceXBCfg_eq_iff]
       simp [h]
     change Q (fun β ↦
-        (Pi.single ((appendixBFinThreeArrowEquiv (Fin d)).symm τ) (1 : ℂ) :
+        (Pi.single ((finThreeArrowEquiv (Fin d)).symm τ) (1 : ℂ) :
           NSiteSpace d 3)
-          (replaceXBCfg ((appendixBFinThreeArrowEquiv (Fin d)).symm σ) β))
-        (xbPairCfg ((appendixBFinThreeArrowEquiv (Fin d)).symm σ)) =
+          (replaceXBCfg ((finThreeArrowEquiv (Fin d)).symm σ) β))
+        (xbPairCfg ((finThreeArrowEquiv (Fin d)).symm σ)) =
       (if σ.1 = τ.1 then 1 else 0) *
         Q (Pi.single ((finTwoArrowEquiv (Fin d)).symm (τ.2.1, τ.2.2)) (1 : ℂ))
           ((finTwoArrowEquiv (Fin d)).symm (σ.2.1, σ.2.2))
@@ -365,8 +351,8 @@ private theorem AppendixBStructuralData.physicalIsometryMatrix_isometry
 left pair matrix of the two-site virtual projector. -/
 private theorem AppendixBStructuralData.leftVirtualBondProjection_matrix
     {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
-    Matrix.reindex (appendixBFinThreeArrowEquiv (Fin D × Fin D))
-        (appendixBFinThreeArrowEquiv (Fin D × Fin D))
+    Matrix.reindex (finThreeArrowEquiv (Fin D × Fin D))
+        (finThreeArrowEquiv (Fin D × Fin D))
         (LinearMap.toMatrix' hStruct.leftVirtualBondProjection) =
       appendixBLeftPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin D × Fin D))
         (finTwoArrowEquiv (Fin D × Fin D))
@@ -379,22 +365,22 @@ private theorem AppendixBStructuralData.leftVirtualBondProjection_matrix
       AppendixBStructuralData.leftVirtualBondProjection,
       AppendixBStructuralData.twoSiteVirtualBondProjection,
       hStruct.replaceVirtualBond01_eq_iff,
-      appendixBFirstPairCfg, appendixBFinThreeArrowEquiv, finTwoArrowEquiv,
+      appendixBFirstPairCfg, finThreeArrowEquiv, finTwoArrowEquiv,
       Pi.single_apply, hs]
   · simp [appendixBLeftPairMatrix, appendixBLeftPairMatrixAux,
       Matrix.reindex_apply, LinearMap.toMatrix'_apply,
       AppendixBStructuralData.leftVirtualBondProjection,
       AppendixBStructuralData.twoSiteVirtualBondProjection,
       hStruct.replaceVirtualBond01_eq_iff,
-      appendixBFirstPairCfg, appendixBFinThreeArrowEquiv, finTwoArrowEquiv,
+      appendixBFirstPairCfg, finThreeArrowEquiv, finTwoArrowEquiv,
       Pi.single_apply, hs]
 
 /-- Reindexing the second three-site virtual bond projector gives the standard
 right pair matrix of the two-site virtual projector. -/
 private theorem AppendixBStructuralData.rightVirtualBondProjection_matrix
     {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
-    Matrix.reindex (appendixBFinThreeArrowEquiv (Fin D × Fin D))
-        (appendixBFinThreeArrowEquiv (Fin D × Fin D))
+    Matrix.reindex (finThreeArrowEquiv (Fin D × Fin D))
+        (finThreeArrowEquiv (Fin D × Fin D))
         (LinearMap.toMatrix' hStruct.rightVirtualBondProjection) =
       appendixBRightPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin D × Fin D))
         (finTwoArrowEquiv (Fin D × Fin D))
@@ -407,14 +393,14 @@ private theorem AppendixBStructuralData.rightVirtualBondProjection_matrix
       AppendixBStructuralData.rightVirtualBondProjection,
       AppendixBStructuralData.twoSiteVirtualBondProjection,
       hStruct.replaceVirtualBond12_eq_iff,
-      appendixBLastPairCfg, appendixBFinThreeArrowEquiv, finTwoArrowEquiv,
+      appendixBLastPairCfg, finThreeArrowEquiv, finTwoArrowEquiv,
       Pi.single_apply, Matrix.one_apply, hs]
   · simp [appendixBRightPairMatrix, appendixBRightPairMatrixAux,
       Matrix.reindex_apply, LinearMap.toMatrix'_apply,
       AppendixBStructuralData.rightVirtualBondProjection,
       AppendixBStructuralData.twoSiteVirtualBondProjection,
       hStruct.replaceVirtualBond12_eq_iff,
-      appendixBLastPairCfg, appendixBFinThreeArrowEquiv, finTwoArrowEquiv,
+      appendixBLastPairCfg, finThreeArrowEquiv, finTwoArrowEquiv,
       Pi.single_apply, hs]
 
 /-- The two standard pair matrices of the virtual bond projector commute. -/
@@ -434,7 +420,7 @@ private theorem AppendixBStructuralData.virtualPairMatrices_comm
           (LinearMap.toMatrix' hStruct.twoSiteVirtualBondProjection)) := by
   rw [← hStruct.leftVirtualBondProjection_matrix,
     ← hStruct.rightVirtualBondProjection_matrix]
-  let e := appendixBFinThreeArrowEquiv (Fin D × Fin D)
+  let e := finThreeArrowEquiv (Fin D × Fin D)
   have hMatrix := congrArg LinearMap.toMatrix'
     hStruct.leftVirtualBondProjection_comp_right
   rw [LinearMap.toMatrix'_comp, LinearMap.toMatrix'_comp] at hMatrix
@@ -496,7 +482,7 @@ private theorem AppendixBStructuralData.transportedTwoSiteBondProjection_commute
         leftPairLift hStruct.transportedTwoSiteBondProjection := by
   apply LinearMap.toMatrix'.injective
   simp only [LinearMap.toMatrix'_mul]
-  let e := appendixBFinThreeArrowEquiv (Fin d)
+  let e := finThreeArrowEquiv (Fin d)
   apply (Matrix.reindexLinearEquiv ℂ ℂ e e).injective
   simp only [Matrix.coe_reindexLinearEquiv]
   calc

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -28,7 +28,7 @@ specialization of that Appendix~D definition.
     \lean{MPSTensor.xbPairCfg}
     \lean{MPSTensor.replaceAXCfg}
     \lean{MPSTensor.replaceXBCfg}
-    \lean{MPSTensor.finThreeArrowEquiv}
+    \lean{finThreeArrowEquiv}
     \lean{MPSTensor.leftPairLift}
     \lean{MPSTensor.rightPairLift}
     \lean{MPSTensor.leftPairLift_sub}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -1446,29 +1446,48 @@ specialization of that Appendix~D definition.
     coefficient representative later placed on the \(XB\) face.
 \end{definition}
 
-\begin{theorem}[Factor actions of the Appendix B coefficient representatives]
-    \label{thm:appendixB_qax_qxb_factor_actions}
-    \lean{MPSTensor.AppendixBStructuralData.appendixBQAXQXB_factor_actions}
+\begin{theorem}[The (AX) factor action]
+    \label{thm:appendixB_qax_factor_action}
+    \lean{MPSTensor.AppendixBStructuralData.appendixBQAX_factor_action}
     \leanok
-    \uses{def:appendixB_qax, def:appendixB_qxb,
-        thm:pair_lift_kronecker_matrices}
+    \uses{def:appendixB_qax, thm:pair_lift_kronecker_matrices}
     On the homogeneous three-single-site coefficient space
-    $(\C^d)^{\otimes3}$, the hatted Appendix~B representatives act as
+    $(\C^d)^{\otimes3}$, the hatted Appendix~B (AX) representative acts as
     \[
-        [\widehat Q_{AX}]_{AX}=[\widehat Q_{AX}]\otimes I_d,
-        \qquad
-        [\widehat Q_{XB}]_{XB}=I_d\otimes[\widehat Q_{XB}].
+        [\widehat Q_{AX}]_{AX}=[\widehat Q_{AX}]\otimes I_d.
     \]
-    These equations give the coefficient-factor specialization of the two
-    local actions in \cite[Definition~D.2]{Cirac2016MPDO_arXiv}.  They do not
-    construct projectors for an arbitrary factorization
+    This equation gives the coefficient-factor specialization of the left
+    local action in \cite[Definition~D.2]{Cirac2016MPDO_arXiv}.  It does not
+    construct a projector for an arbitrary factorization
     $\mathcal H_A\otimes\mathcal H_X\otimes\mathcal H_B$.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    Apply Theorem~\ref{thm:pair_lift_kronecker_matrices} first to
-    $\widehat Q_{AX}$ and then to $\widehat Q_{XB}$.
+    Apply the left identity in
+    Theorem~\ref{thm:pair_lift_kronecker_matrices} to $\widehat Q_{AX}$.
+\end{proof}
+
+\begin{theorem}[The (XB) factor action]
+    \label{thm:appendixB_qxb_factor_action}
+    \lean{MPSTensor.AppendixBStructuralData.appendixBQXB_factor_action}
+    \leanok
+    \uses{def:appendixB_qxb, thm:pair_lift_kronecker_matrices}
+    On the homogeneous three-single-site coefficient space
+    $(\C^d)^{\otimes3}$, the hatted Appendix~B (XB) representative acts as
+    \[
+        [\widehat Q_{XB}]_{XB}=I_d\otimes[\widehat Q_{XB}].
+    \]
+    This equation gives the coefficient-factor specialization of the right
+    local action in \cite[Definition~D.2]{Cirac2016MPDO_arXiv}.  It does not
+    construct a projector for an arbitrary factorization
+    $\mathcal H_A\otimes\mathcal H_X\otimes\mathcal H_B$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Apply the right identity in
+    Theorem~\ref{thm:pair_lift_kronecker_matrices} to $\widehat Q_{XB}$.
 \end{proof}
 
 \begin{lemma}[Appendix B coefficient representatives and the parent interaction]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -28,6 +28,7 @@ specialization of that Appendix~D definition.
     \lean{MPSTensor.xbPairCfg}
     \lean{MPSTensor.replaceAXCfg}
     \lean{MPSTensor.replaceXBCfg}
+    \lean{MPSTensor.finThreeArrowEquiv}
     \lean{MPSTensor.leftPairLift}
     \lean{MPSTensor.rightPairLift}
     \lean{MPSTensor.leftPairLift_sub}
@@ -102,6 +103,45 @@ specialization of that Appendix~D definition.
     \(P_{AX},P_{XB}\) satisfies the same idempotent-and-commutation condition on
     the three-site space.
 \end{definition}
+
+\begin{theorem}[Matrices of the two adjacent factor actions]
+    \label{thm:pair_lift_kronecker_matrices}
+    \lean{MPSTensor.leftPairLift_toMatrix_reindex}
+    \lean{MPSTensor.rightPairLift_toMatrix_reindex}
+    \leanok
+    \uses{def:overlapping_two_site_supports}
+    Let $\mathcal H=\C^d$, and let $Q$ be an endomorphism of
+    $\mathcal H\otimes\mathcal H$.  Under the canonical identifications of
+    two- and three-site configurations with pairs and right-associated triples,
+    the matrices of its two adjacent actions are
+    \[
+        [Q_{AX}]=[Q]\otimes I_d,
+        \qquad
+        [Q_{XB}]=I_d\otimes[Q].
+    \]
+    Equivalently, for all $a,x,b,a',x',b'\in\{0,\ldots,d-1\}$,
+    \[
+        [Q_{AX}]_{(a,x,b),(a',x',b')}
+          =[Q]_{(a,x),(a',x')}\delta_{b,b'},
+    \]
+    and
+    \[
+        [Q_{XB}]_{(a,x,b),(a',x',b')}
+          =\delta_{a,a'}[Q]_{(x,b),(x',b')}.
+    \]
+    This is the homogeneous three-single-site specialization of the factor
+    actions on $\mathcal H_A\otimes\mathcal H_X\otimes\mathcal H_B$ in
+    \cite[Definition~D.2]{Cirac2016MPDO_arXiv}; here
+    $\mathcal H_A=\mathcal H_X=\mathcal H_B=\mathcal H$.  No assertion is made
+    for unequal factor spaces.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    On the first pair, the final coordinate is unchanged, which contributes
+    $\delta_{b,b'}$ to the matrix coefficient.  On the final pair, the first
+    coordinate is unchanged, which contributes $\delta_{a,a'}$.
+\end{proof}
 
 \begin{theorem}[Three-site translated local terms]
     \label{thm:local_term_two_three_ax_xb_lifts}
@@ -1405,6 +1445,31 @@ specialization of that Appendix~D definition.
     \(\mathcal H_X\otimes\mathcal H_B\).  The displayed operator is the
     coefficient representative later placed on the \(XB\) face.
 \end{definition}
+
+\begin{theorem}[Factor actions of the Appendix B coefficient representatives]
+    \label{thm:appendixB_qax_qxb_factor_actions}
+    \lean{MPSTensor.AppendixBStructuralData.appendixBQAXQXB_factor_actions}
+    \leanok
+    \uses{def:appendixB_qax, def:appendixB_qxb,
+        thm:pair_lift_kronecker_matrices}
+    On the homogeneous three-single-site coefficient space
+    $(\C^d)^{\otimes3}$, the hatted Appendix~B representatives act as
+    \[
+        [\widehat Q_{AX}]_{AX}=[\widehat Q_{AX}]\otimes I_d,
+        \qquad
+        [\widehat Q_{XB}]_{XB}=I_d\otimes[\widehat Q_{XB}].
+    \]
+    These equations give the coefficient-factor specialization of the two
+    local actions in \cite[Definition~D.2]{Cirac2016MPDO_arXiv}.  They do not
+    construct projectors for an arbitrary factorization
+    $\mathcal H_A\otimes\mathcal H_X\otimes\mathcal H_B$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Apply Theorem~\ref{thm:pair_lift_kronecker_matrices} first to
+    $\widehat Q_{AX}$ and then to $\widehat Q_{XB}$.
+\end{proof}
 
 \begin{lemma}[Appendix B coefficient representatives and the parent interaction]
     \label{lem:appendixB_qax_qxb_parent_interaction}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -96,7 +96,7 @@
 
 \begin{definition}[Four-site physical closure]
     \label{def:mpdo_four_site_physical_closure}
-    \lean{MPOTensor.finFourArrowEquiv, MPOTensor.physClose4}
+    \lean{finFourArrowEquiv, MPOTensor.physClose4}
     \leanok
     For a virtual matrix $X$, the four-site physical closure of $K$ is the
     operator $K_4(X)$ whose matrix coefficients are

--- a/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
@@ -432,7 +432,7 @@
 
 \begin{lemma}[Three-site physical closure]
     \label{lem:phys_close_three}
-    \lean{MPOTensor.finThreeArrowEquiv,
+    \lean{finThreeArrowEquiv,
       MPOTensor.physCloseN_three_apply, MPOTensor.physClose3_apply,
       MPOTensor.physCloseN_three_eq_physClose3}
     \leanok

--- a/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
+++ b/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
@@ -135,9 +135,10 @@ two-site and right-associated three-site reindexings,
 The generic matrix identities are
 \leanid{MPSTensor.leftPairLift_toMatrix_reindex} and
 \leanid{MPSTensor.rightPairLift_toMatrix_reindex}; their specialization to the
-hatted Appendix~B representatives is
-\leanid{MPSTensor.AppendixBStructuralData.}
-\hspace{0pt}\leanid{appendixBQAXQXB_factor_actions}.  This realizes only the
+hatted Appendix~B representatives is given separately by
+\leanid{MPSTensor.AppendixBStructuralData.appendixBQAX_factor_action} and
+\leanid{MPSTensor.AppendixBStructuralData.appendixBQXB_factor_action}.  This
+realizes only the
 homogeneous choice
 \(\mathcal H_A=\mathcal H_X=\mathcal H_B=\mathbb C^d\) of the factor spaces
 introduced at source lines 2185--2186.  It does not supply the arbitrary

--- a/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
+++ b/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
@@ -125,7 +125,24 @@ representatives are
 \leanid{MPSTensor.AppendixBStructuralData.appendixBQAXOnCoeffSpace} and
 \leanid{MPSTensor.AppendixBStructuralData.appendixBQXBOnCoeffSpace}; both are identified
 with the canonical two-site parent interaction \(q_2(A)\) before placement on
-the \(AX\) and \(XB\) faces.  Since \(q_2(A)\) is the canonical orthogonal
+the \(AX\) and \(XB\) faces.  Their factor actions on the homogeneous
+three-single-site coefficient space are now explicit.  Under the canonical
+two-site and right-associated three-site reindexings,
+\begin{align}
+  [\widehat Q_{AX}]_{AX}&=[\widehat Q_{AX}]\otimes I_d,\\
+  [\widehat Q_{XB}]_{XB}&=I_d\otimes[\widehat Q_{XB}].
+\end{align}
+The generic matrix identities are
+\leanid{MPSTensor.leftPairLift_toMatrix_reindex} and
+\leanid{MPSTensor.rightPairLift_toMatrix_reindex}; their specialization to the
+hatted Appendix~B representatives is
+\leanid{MPSTensor.AppendixBStructuralData.}
+\hspace{0pt}\leanid{appendixBQAXQXB_factor_actions}.  This realizes only the
+homogeneous choice
+\(\mathcal H_A=\mathcal H_X=\mathcal H_B=\mathbb C^d\) of the factor spaces
+introduced at source lines 2185--2186.  It does not supply the arbitrary
+factorization used in Definition~D.2 at lines 2205--2218.
+Since \(q_2(A)\) is the canonical orthogonal
 projector onto \(G_2(A)^\perp\), these coefficient-space maps are orthogonal.
 They are not, by themselves, constructions of the source projectors on
 \(\mathcal H_A\otimes\mathcal H_X\) and


### PR DESCRIPTION
## Motivation

The parent commuting Hamiltonian condition in arXiv:1606.00608 introduces the factor spaces `H_AX = H_A ⊗ H_X` and `H_XB = H_X ⊗ H_B` at lines 2185–2186, and Definition D.2 at lines 2205–2218 requires projectors acting on those two factors. The merged coefficient-space result identifies hatted Appendix B representatives and proves their algebraic and kernel-intersection properties, but their two adjacent factor actions were not yet recorded as explicit matrix identities.

## Description

- Expose the canonical right-associated reindexing of three single-site configurations.
- Prove for every two-site coefficient-space endomorphism `Q` that the first-pair lift has matrix `Q ⊗ I` and the final-pair lift has matrix `I ⊗ Q` under the canonical two-site and three-site reindexings.
- Specialize these identities to the hatted Appendix B representatives `Q̂_AX` and `Q̂_XB`.
- Add the two exact formulas to the blueprint and record their scope in the parent-commuting-Hamiltonian gap note.

This PR proves only the homogeneous three-single-site coefficient-factor specialization with `H_A = H_X = H_B = C^d`. It does not construct projectors for arbitrary factor spaces, and it does not identify the hatted representatives with the source projectors of Definition D.2. Those obligations remain open.

## Testing

- `lake env lean TNLean/MPS/RFP/AppendixBCommutation.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/check_oversized_lean_files.py`
- integrity scan for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast`
- `git diff --check origin/main..HEAD`

Addresses #3373

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Library refactor plus new formal lemmas and documentation; no runtime, auth, or data-path changes. Residual risk is Mathlib proof breakage from renamed imports and deprecated aliases.
> 
> **Overview**
> Introduces **`TNLean/Algebra/FinTupleEquiv`** with shared **`finThreeArrowEquiv`** / **`finFourArrowEquiv`** (and `@[simp]` coordinate lemmas), wires it into the root import, and **removes duplicate local definitions** from MPDO physical-closure and Appendix B code. Call sites now use the root equivalences; **deprecated aliases** keep old names in `PhysicalBlocking` and `RFPViaTS`.
> 
> On the RFP side, **`leftPairLift_toMatrix_reindex`** and **`rightPairLift_toMatrix_reindex`** are **public** and record that adjacent pair lifts reindex to **`Q ⊗ I`** and **`I ⊗ Q`**. **`AppendixBStructuralData.appendixBQAX_factor_action`** / **`appendixBQXB_factor_action`** specialize that to the hatted Appendix B coefficient maps. MPDO bond-commutation proofs are adjusted to the shared equiv (mostly proof cleanup).
> 
> Blueprint chapter 13 gains the pair-lift Kronecker theorem and AX/XB factor-action theorems; blueprint lean tags and **`docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex`** document the **homogeneous `ℂ^d` three-site** scope only (not arbitrary Definition D.2 factor spaces).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4f8113726588c73bd759608c25f79d98a048e3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->