### PR TITLE
fix(MPS/MPDO): allow zero sectors in vertical form

### DIFF
--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -30,7 +30,9 @@ right-hand side is the block-diagonal tensor over the pairs $(\alpha, k)$ in whi
 the multiplicities $r_\alpha$ and the diagonal entries $\omega_{\alpha,k}$ stay explicit;
 the coefficients $m_\alpha = \operatorname{tr}(\mu_\alpha)$ appearing in the
 renormalization fixed-point characterization are recovered from them.
-The predicate `IsVerticalCF` states exactly this conclusion.
+The predicate `IsVerticalCF` states this conclusion after the zero physical
+sector has been discarded, as allowed in the source's canonical-form
+construction (arXiv:1606.00608, lines 214--225).
 
 ## Main definitions
 
@@ -46,7 +48,8 @@ The predicate `IsVerticalCF` states exactly this conclusion.
   $E_{\mathrm{diag}}(X) = \sum_i M^{ii} X (M^{ii})^\dagger$.
 * `IsVerticalCF`:
   the vertical canonical form of arXiv:1606.00608, Proposition 4.13: an
-  isometry $U$ on the physical space with
+  isometry after restriction to the nonzero physical sectors, represented by
+  a coisometry $U$ with
   $U \widetilde M_{ab} U^\dagger = (\bigoplus_\alpha \mu_\alpha \otimes M_\alpha)_{ab}$
   for every bond pair $(a, b)$, with positive diagonal matrices $\mu_\alpha$ and a
   BNT $\{M_\alpha\}$ for the vertically viewed tensor.
@@ -541,13 +544,18 @@ with at least one copy: each $\mu_\alpha$ is a positive diagonal matrix of size
 `mult α`, at least one, matching arXiv:1606.00608, line 1901, where the sector
 $(\alpha, 1)$ exists for every $\alpha$.
 
-The isometry is a unitary change of the physical basis, so both `Uᴴ * U = 1`
-and `U * Uᴴ = 1` are required: the canonical-form decomposition of
-arXiv:1606.00608 read in the vertical direction decomposes the physical space
-exactly, and the source discards $U$ because "it just changes the physical
-basis on each site" (arXiv:1606.00608, line 959).  With an isometric
-embedding alone, the decomposed space could exceed the physical space, which
-the source's conclusion excludes. -/
+The source's general canonical-form construction permits zero sectors and only
+requires the sum of the nonzero block dimensions to be at most the original
+dimension (arXiv:1606.00608, lines 214--225). In the matrix orientation used
+below, $U$ maps the original physical space onto the retained nonzero sector
+space. Thus $U U^\dagger = 1$; the matrix $U^\dagger U$ is generally the
+support projection on the original physical space.
+
+**Local fix (zero-sector complement):** An earlier formulation also required
+$U^\dagger U = 1$, which incorrectly excluded the zero sectors allowed at
+arXiv:1606.00608, lines 216--219. The correction and a two-dimensional example
+are recorded in
+`docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex`. -/
 def IsVerticalCF (M : MPOTensor d D) : Prop :=
   ∃ (g : ℕ) (dim : Fin g → ℕ) (mult : Fin g → ℕ)
     (ω : (α : Fin g) → Fin (mult α) → ℂ)
@@ -556,7 +564,6 @@ def IsVerticalCF (M : MPOTensor d D) : Prop :=
       (Fin d) ℂ),
     (∀ α, 0 < mult α) ∧
       (∀ α k, (0 : ℂ) < ω α k) ∧
-      Uᴴ * U = 1 ∧
       U * Uᴴ = 1 ∧
       MPSTensor.IsBNT (verticalTensor M) g dim A ∧
       ∀ v : Fin (D * D),

--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -534,6 +534,8 @@ positive diagonal matrices $\mu_\alpha = \operatorname{diag}(\omega_{\alpha,0}, 
 isometry $U$ on the physical space such that, letter by letter over the horizontal bond pairs
 $(a, b)$,
 $U \widetilde M_{ab} U^\dagger = (\bigoplus_\alpha \mu_\alpha \otimes M_\alpha)_{ab}$.
+The reverse identity reconstructs $\widetilde M_{ab}$ from this direct sum and
+records that the discarded orthogonal complement is a zero sector.
 
 The right-hand side keeps the multiplicities `mult α` and the diagonal
 entries `ω α k` explicit; the trace coefficients
@@ -549,7 +551,10 @@ requires the sum of the nonzero block dimensions to be at most the original
 dimension (arXiv:1606.00608, lines 214--225). In the matrix orientation used
 below, $U$ maps the original physical space onto the retained nonzero sector
 space. Thus $U U^\dagger = 1$; the matrix $U^\dagger U$ is generally the
-support projection on the original physical space.
+support projection on the original physical space. The reverse identity
+$\widetilde M = U^\dagger (\bigoplus_\alpha \mu_\alpha \otimes M_\alpha) U$
+ensures that every vertical letter is supported on this projection; a bare
+compression would not exclude nonzero discarded or off-diagonal corners.
 
 **Local fix (zero-sector complement):** An earlier formulation also required
 $U^\dagger U = 1$, which incorrectly excluded the zero sectors allowed at
@@ -566,8 +571,10 @@ def IsVerticalCF (M : MPOTensor d D) : Prop :=
       (∀ α k, (0 : ℂ) < ω α k) ∧
       U * Uᴴ = 1 ∧
       MPSTensor.IsBNT (verticalTensor M) g dim A ∧
+      (∀ v : Fin (D * D),
+        U * verticalTensor M v * Uᴴ = verticalAssembledTensor dim mult ω A v) ∧
       ∀ v : Fin (D * D),
-        U * verticalTensor M v * Uᴴ = verticalAssembledTensor dim mult ω A v
+        verticalTensor M v = Uᴴ * verticalAssembledTensor dim mult ω A v * U
 
 /-- The matrix product vector of the vertical-assembled tensor, as a sum over the
 flattened `(block, multiplicity)` index `(α, j)`:

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -113,16 +113,19 @@
     $\widetilde M$, positive diagonal matrices
     $\mu_\alpha=\operatorname{diag}(\omega_{\alpha,0},\dots,\omega_{\alpha,r_\alpha-1})$
     with $r_\alpha\geq1$,
-    and an isometry $U$ on the physical space such that
+    and a matrix $U$ from the physical space onto the retained nonzero sector
+    space such that
     \[
         U\widetilde MU^\dagger=\bigoplus_\alpha \mu_\alpha\otimes M_\alpha.
     \]
     This is the conclusion of
     \cite[Proposition~4.13, lines~1863--1870]{Cirac2016MPDO_arXiv}.
-    The isometry is a unitary change of the physical basis: the canonical
-    form decomposes the physical space exactly, and the source treats $U$ as
-    a change of the physical basis on each site
-    \cite[line~959]{Cirac2016MPDO_arXiv}.
+    In this orientation $UU^\dagger=I$ on the retained space, while
+    $U^\dagger U$ is its support projection in the original physical space.
+    The orthogonal complement may be a zero sector: the source's general
+    canonical-form construction explicitly permits the sum of the nonzero
+    block dimensions to be strictly smaller than the original dimension
+    \cite[lines~214--225]{Cirac2016MPDO_arXiv}.
     Since each $\mu_\alpha$ is diagonal, the summand
     $\mu_\alpha\otimes M_\alpha$ is the direct sum
     $\bigoplus_{k=0}^{r_\alpha-1}\omega_{\alpha,k}M_\alpha$ of weighted copies

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -116,12 +116,19 @@
     and a matrix $U$ from the physical space onto the retained nonzero sector
     space such that
     \[
-        U\widetilde MU^\dagger=\bigoplus_\alpha \mu_\alpha\otimes M_\alpha.
+        U\widetilde MU^\dagger=B,
+        \qquad
+        \widetilde M=U^\dagger B U,
+        \qquad
+        B=\bigoplus_\alpha \mu_\alpha\otimes M_\alpha.
     \]
     This is the conclusion of
     \cite[Proposition~4.13, lines~1863--1870]{Cirac2016MPDO_arXiv}.
     In this orientation $UU^\dagger=I$ on the retained space, while
     $U^\dagger U$ is its support projection in the original physical space.
+    The reconstruction identity says that every letter of $\widetilde M$ is
+    supported on this projection, so the discarded orthogonal complement and
+    the off-diagonal corners vanish.
     The orthogonal complement may be a zero sector: the source's general
     canonical-form construction explicitly permits the sum of the nonzero
     block dimensions to be strictly smaller than the original dimension

--- a/docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex
@@ -1,0 +1,112 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{The Vertical Canonical Form Retains Only the Nonzero Physical Sectors}
+\author{}
+\date{2026-07-13}
+
+\begin{document}
+\maketitle
+
+\section{The dimension allowed by canonical form}
+
+The canonical-form construction of \cite{Cirac2016MPDO_arXiv} writes a tensor
+as a direct sum of nonzero irreducible blocks of dimensions $D_k$ and states
+explicitly that
+\begin{equation}
+  \sum_k D_k\leq D,
+  \label{eq:dimension-bound}
+\end{equation}
+because zero blocks may remain in the original space (source lines~214--225).
+Proposition~4.13 later applies this construction to the vertically viewed
+tensor and obtains
+\begin{equation}
+  U\widetilde M U^\dagger
+  =\bigoplus_\alpha\mu_\alpha\otimes M_\alpha,
+  \label{eq:vertical-form}
+\end{equation}
+where the matrices $\mu_\alpha$ are positive and diagonal and the tensors
+$M_\alpha$ form a basis of normal tensors (source lines~943--951 and
+1863--1870).
+
+Let $s$ be the dimension of the right-hand side of
+\eqref{eq:vertical-form}. In the displayed orientation,
+$U:\mathbb C^D\to\mathbb C^s$ maps the original physical space onto the
+retained nonzero sector space. Consequently
+\begin{equation}
+  UU^\dagger=I_s,
+  \qquad
+  U^\dagger U=P,
+  \label{eq:coisometry}
+\end{equation}
+where $P$ is the support projection of the nonzero sectors. Equality
+$U^\dagger U=I_D$ holds only when there is no zero complement. It is not part
+of the hypotheses or conclusion of Proposition~4.13.
+
+\section{A zero-sector example}
+
+Take horizontal bond dimension one and physical dimension two, and define
+the local tensor by
+\begin{equation}
+  M^{00}=1,
+  \qquad
+  M^{01}=M^{10}=M^{11}=0.
+  \label{eq:rank-one-tensor}
+\end{equation}
+It is a one-block horizontal normal tensor. At every positive length it
+generates the positive operator
+\begin{equation}
+  \rho^{(N)}(M)
+  =\lvert 0\cdots0\rangle\langle0\cdots0\rvert.
+  \label{eq:rank-one-operator}
+\end{equation}
+The vertically viewed tensor has one letter,
+\begin{equation}
+  \widetilde M=\begin{pmatrix}1&0\\0&0\end{pmatrix}.
+  \label{eq:vertical-letter}
+\end{equation}
+Its nonzero canonical part is the one-dimensional tensor with letter $1$.
+Equation~\eqref{eq:vertical-form} holds with
+\begin{equation}
+  U=\begin{pmatrix}1&0\end{pmatrix},
+  \qquad UU^\dagger=1,
+  \qquad U^\dagger U=
+  \begin{pmatrix}1&0\\0&0\end{pmatrix}.
+  \label{eq:example-coisometry}
+\end{equation}
+
+A two-sided unitary formulation cannot describe this tensor using only
+positive normal blocks. A unitary preserves the two-dimensional space, while
+the second one-dimensional corner of \eqref{eq:vertical-letter} has weight
+zero. Positivity of every canonical weight excludes that corner, and treating
+the whole matrix as one block would not give a normal tensor. Thus the
+two-sided condition would make Proposition~4.13 false even in this elementary
+case.
+
+\section{Formal correction}
+
+The vertical canonical-form predicate now requires only
+$UU^\dagger=I_s$ in the orientation of \eqref{eq:vertical-form}. This is the
+source-faithful statement compatible with \eqref{eq:dimension-bound}. No
+full-support assumption is added to Proposition~4.13. The construction of the
+canonical form from horizontal canonical form remains open and is tracked in
+\ghissue{3674}; the present correction is tracked in \ghissue{3869} and
+concerns only its conclusion.
+
+\paragraph{Verdict.}
+The earlier two-sided-unitary condition was a stronger statement absent from
+the source and was false when the vertically viewed tensor had a zero sector.
+Replacing it by the coisometry identity $UU^\dagger=I$ is a corrected
+definitional mismatch. The correction changes no hypothesis of
+Proposition~4.13 and introduces no new mathematical assumption.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex
@@ -47,7 +47,17 @@ retained nonzero sector space. Consequently
 \end{equation}
 where $P$ is the support projection of the nonzero sectors. Equality
 $U^\dagger U=I_D$ holds only when there is no zero complement. It is not part
-of the hypotheses or conclusion of Proposition~4.13.
+of the hypotheses or conclusion of Proposition~4.13.  The assertion that the
+discarded complement is a zero sector is the reconstruction identity
+\begin{equation}
+  \widetilde M
+  =U^\dagger\left(\bigoplus_\alpha
+    \mu_\alpha\otimes M_\alpha\right)U.
+  \label{eq:reconstruction}
+\end{equation}
+Without \eqref{eq:reconstruction}, equation~\eqref{eq:vertical-form} alone is
+only a compression and does not exclude nonzero entries in the discarded or
+off-diagonal corners.
 
 \section{A zero-sector example}
 
@@ -81,30 +91,35 @@ Equation~\eqref{eq:vertical-form} holds with
   \label{eq:example-coisometry}
 \end{equation}
 
-A two-sided unitary formulation cannot describe this tensor using only
-positive normal blocks. A unitary preserves the two-dimensional space, while
-the second one-dimensional corner of \eqref{eq:vertical-letter} has weight
-zero. Positivity of every canonical weight excludes that corner, and treating
-the whole matrix as one block would not give a normal tensor. Thus the
-two-sided condition would make Proposition~4.13 false even in this elementary
-case.
+A square unitary formulation can describe this tensor if it retains the
+explicit zero block $[0]$.  The earlier formal predicate had no such block: its
+right-hand side contained only strictly positive weights multiplying normal
+tensors. Within that positive-block-only assembly, a unitary preserves the
+two-dimensional space while the second one-dimensional corner of
+\eqref{eq:vertical-letter} necessarily has weight zero. Treating the whole
+matrix as one block would not give a normal tensor. Thus the combination of a
+two-sided unitary and the positive-block-only assembly would make
+Proposition~4.13 false even in this elementary case.
 
 \section{Formal correction}
 
-The vertical canonical-form predicate now requires only
-$UU^\dagger=I_s$ in the orientation of \eqref{eq:vertical-form}. This is the
-source-faithful statement compatible with \eqref{eq:dimension-bound}. No
-full-support assumption is added to Proposition~4.13. The construction of the
-canonical form from horizontal canonical form remains open and is tracked in
+The vertical canonical-form predicate now requires $UU^\dagger=I_s$ in the
+orientation of \eqref{eq:vertical-form}, together with
+\eqref{eq:reconstruction}. This is the source-faithful statement compatible
+with \eqref{eq:dimension-bound}: the retained part is represented
+rectangularly, while the omitted part is required to be zero. No full-support
+assumption is added to Proposition~4.13. The construction of the canonical
+form from horizontal canonical form remains open and is tracked in
 \ghissue{3674}; the present correction is tracked in \ghissue{3869} and
 concerns only its conclusion.
 
 \paragraph{Verdict.}
 The earlier two-sided-unitary condition was a stronger statement absent from
 the source and was false when the vertically viewed tensor had a zero sector.
-Replacing it by the coisometry identity $UU^\dagger=I$ is a corrected
-definitional mismatch. The correction changes no hypothesis of
-Proposition~4.13 and introduces no new mathematical assumption.
+Replacing it by the coisometry identity $UU^\dagger=I$, while retaining exact
+reconstruction from the nonzero sectors, is a corrected definitional
+mismatch. The correction changes no hypothesis of Proposition~4.13 and
+introduces no new mathematical assumption.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpgsv17_vertical_tensor_definition.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_tensor_definition.tex
@@ -79,12 +79,15 @@ The realignment (\ghissue{3712}) introduces the vertically viewed tensor
 canonical-form predicate on it: there are a basis of normal tensors
 $\{M_\alpha\}_\alpha$ for $\widetilde M$, positive diagonal matrices
 $\mu_\alpha=\operatorname{diag}(\omega_{\alpha,0},\dots,\omega_{\alpha,r_\alpha-1})$
-with $r_\alpha\geq1$, and an isometry $U$ on the physical space satisfying
-\eqref{eq:umu} letter by letter over the horizontal bond pairs.  The isometry
-is required to be a unitary change of the physical basis ($U^\dagger U=\Id$
-and $UU^\dagger=\Id$): the canonical form decomposes the physical space
-exactly, and the source discards $U$ because ``it just changes the physical
-basis on each site'' (line~959).  Since each $\mu_\alpha$ is diagonal,
+with $r_\alpha\geq1$, and a coisometry $U$ onto the retained nonzero sector
+space satisfying \eqref{eq:umu} letter by letter over the horizontal bond
+pairs.  It satisfies $UU^\dagger=\Id$ on that retained space; its adjoint is
+the isometric inclusion into the original physical space.  The source's
+general canonical-form construction allows $\sum_k D_k<D$ and hence permits
+a zero orthogonal complement (lines~214--225).  Thus $U^\dagger U$ is in
+general the support projection rather than the identity.  This correction is
+documented in \path{cpgsv17_vertical_isometry_zero_sector.tex}.  Since each
+$\mu_\alpha$ is diagonal,
 the summand $\mu_\alpha\otimes M_\alpha$ is the direct sum
 $\bigoplus_{k=0}^{r_\alpha-1}\omega_{\alpha,k}M_\alpha$, so the right-hand side of
 \eqref{eq:umu} is a block-diagonal tensor over the pairs $(\alpha,k)$ in
@@ -121,8 +124,10 @@ rather than on the vertically viewed tensor $\widetilde M$ defined at source
 line~943, and the $d=2$, $D=1$ example shows the diagonal surrogate cannot
 carry the multiplicity coefficients $m_\alpha=\tr(\mu_\alpha)$ of
 \eqref{eq:umu}; a proof of the surrogate would therefore not have formalized
-the proposition.  The realignment restores the source-faithful vertical
-tensor definition and the isometry-form conclusion.  The
+the proposition.  The realignment restores the source-faithful vertical tensor
+definition.  The later correction in
+\path{cpgsv17_vertical_isometry_zero_sector.tex} restores the source's
+one-sided isometry condition in the presence of zero sectors.  The
 horizontal-to-vertical implication of Proposition~4.13 itself remains an
 open gap.
 

--- a/docs/paper-gaps/cpgsv17_vertical_tensor_definition.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_tensor_definition.tex
@@ -86,7 +86,9 @@ the isometric inclusion into the original physical space.  The source's
 general canonical-form construction allows $\sum_k D_k<D$ and hence permits
 a zero orthogonal complement (lines~214--225).  Thus $U^\dagger U$ is in
 general the support projection rather than the identity.  This correction is
-documented in \path{cpgsv17_vertical_isometry_zero_sector.tex}.  Since each
+documented in \path{cpgsv17_vertical_isometry_zero_sector.tex}.  The reverse
+identity reconstructs the original tensor from the displayed direct sum and
+therefore requires the omitted complement to be a zero sector.  Since each
 $\mu_\alpha$ is diagonal,
 the summand $\mu_\alpha\otimes M_\alpha$ is the direct sum
 $\bigoplus_{k=0}^{r_\alpha-1}\omega_{\alpha,k}M_\alpha$, so the right-hand side of


### PR DESCRIPTION
### Motivation

Proposition 4.13 of arXiv:1606.00608 gives a vertical canonical form after an
isometry, while the general canonical-form construction explicitly permits
zero sectors: the sum of the nonzero block dimensions may be strictly smaller
than the original dimension (lines 214–225).

The existing `MPOTensor.IsVerticalCF` instead required both `Uᴴ * U = 1` and
`U * Uᴴ = 1`. This forced `U` to be unitary and excluded the zero physical
complement allowed by the source. The discrepancy is already visible for the
horizontal bond-one MPDO with `M^{00} = 1` and all other entries zero: its
vertical letter is `diag(1, 0)`, whose canonical form retains one nonzero
one-dimensional sector.

- Source: `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 214–225 and
  943–951, restated at lines 1863–1870.
- Labels: `eq:II_Aiplusk1`, `Prop:IV.12`, `UMU`, and `UMU-appendix`.
- Short source statements: “there can be zero blocks” and “there exists an
  isometry U”.

### Description

- removes the source-absent identity `Uᴴ * U = 1` from
  `MPOTensor.IsVerticalCF`;
- retains `U * Uᴴ = 1`, so in the displayed orientation `U` maps the original
  physical space onto the retained nonzero sector space and `Uᴴ * U` is its
  support projection;
- adds the reverse letterwise identity
  `verticalTensor M v = Uᴴ * verticalAssembledTensor ... v * U`, which requires
  the discarded complement and both off-diagonal corners to vanish rather than
  merely compressing the tensor;
- aligns the Lean docstring and the blueprint definition with
  arXiv:1606.00608, lines 214–225 and Proposition 4.13, lines 943–951 and
  1863–1870;
- records the zero-sector example and the mathematical verdict in
  `docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex`;
- corrects the earlier vertical-tensor gap note, which had repeated the
  two-sided-unitary strengthening.

This PR changes only the formal target. The horizontal-to-vertical construction
remains open in #3674.

Closes #3869.

### Testing

- `lake env lean TNLean/MPS/MPDO/VerticalCF.lean`
- `lake build TNLean` — 9,380 jobs
- `lake exe lint_style --github`
- `leanblueprint checkdecls`
- `leanblueprint pdf`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci --diff-base main`
- `latexmk -pdf -interaction=nonstopmode cpgsv17_vertical_isometry_zero_sector.tex`
- `latexmk -pdf -interaction=nonstopmode cpgsv17_vertical_tensor_definition.tex`
- `git diff --check`
- `#print axioms MPOTensor.IsVerticalCF` reports only `propext`,
  `Classical.choice`, and `Quot.sound`
- no `sorry`, new `axiom`, `native_decide`, or kernel bypass is introduced

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Definitional and documentation alignment for `IsVerticalCF` with no changes to proofs, auth, or runtime behavior; downstream code must use the updated predicate shape.
> 
> **Overview**
> **`MPOTensor.IsVerticalCF`** is updated to match arXiv:1606.00608 when the vertically viewed tensor has **zero physical sectors** (allowed when \(\sum_k D_k < D\)).
> 
> The predicate **drops** the extra requirement **`Uᴴ * U = 1`** (full unitarity) and keeps **`U * Uᴴ = 1`**, so **`U`** is a **coisometry** onto the retained nonzero sector space and **`Uᴴ * U`** is the support projection. It **adds** the reverse letterwise identity **`verticalTensor M v = Uᴴ * verticalAssembledTensor ... v * U`**, so the form is exact reconstruction—not compression that could leave weight on discarded or off-diagonal corners.
> 
> Lean module docs, the blueprint vertical CF definition, and paper-gap notes are aligned; **`docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex`** documents the **`diag(1,0)`** counterexample. This is a **formal target / documentation** change only; the horizontal-to-vertical construction proof stays open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7fded9beab86b0b9a6c125b4bb24227433fe03a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->