### PR TITLE
docs(MPS/MPDO): align periodic-sector status

### DIFF
--- a/TNLean/MPS/MPDO/InvariantProjection.lean
+++ b/TNLean/MPS/MPDO/InvariantProjection.lean
@@ -23,9 +23,11 @@ the literal horizontal-canonical-form gauge and is not proved here.
 
 The file also specializes the positive-semidefinite power-commutation theorem
 to matrix product density operators.  This is only the final operator
-implication in source lines 1888--1893.  The passage from a nontrivial vertical
-period to an orthogonal projector $Q$ satisfying the required all-length
-commutation identities remains open.
+implication in source lines 1888--1893.  The cyclic projector and its word
+invariance are constructed in `TNLean/MPS/MPDO/CyclicProjector.lean`; for a
+tensor in literal horizontal canonical form, one noncommuting length suffices
+for the periodic-sector contradiction, so the stronger all-length condition is
+not required.
 
 ## Main definitions
 
@@ -382,8 +384,8 @@ representation and the commutation family at *every* length, but does not
 transport its conclusion back to `M`'s own letters), this theorem needs only
 the commutation hypothesis at chain length `2`, applies to `M`'s own tensor
 directly, and does not extend to chain length `1` (`mpo M 1`).  The missing
-literal-gauge transport is recorded in
-`docs/paper-gaps/cpgsv17_periodic_sector_projector.tex`.  At chain length `1`,
+literal-gauge transport for the general case is supplied in
+`TNLean/MPS/MPDO/HorizontalBNT.lean`.  At chain length `1`,
 the single trailing letter is the identity matrix, giving only a
 trace-level identity, not enough to separate the opposite-corner difference. -/
 theorem ketLeftMul_eq_braRightMul_of_commute_of_isInjective
@@ -439,8 +441,10 @@ density operator commutes with the density operator itself.
 This is the final operator implication in the contradiction at
 arXiv:1606.00608, lines 1888--1893 (equation eq2:proof.IV.12).  It does not
 construct the orthogonal projector $Q$ associated with a nontrivial vertical
-period or establish its commutation with $[H^{(N)}]^p$ for every $N$; that
-connection remains open. -/
+period or establish its commutation with $[H^{(N)}]^p$.  Those ingredients are
+combined in `TNLean/MPS/MPDO/CyclicProjector.lean`, where one noncommuting
+length gives the contradiction for a tensor in literal horizontal canonical
+form. -/
 theorem mpo_commute_of_commute_pow (M : MPOTensor d D) (hM : IsMPDO M) (N : ℕ)
     {p : ℕ} (hp : p ≠ 0) {Q : Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ}
     (hQ : Commute Q (mpo M N ^ p)) : Commute Q (mpo M N) :=

--- a/TNLean/MPS/MPDO/PeriodicExclusion.lean
+++ b/TNLean/MPS/MPDO/PeriodicExclusion.lean
@@ -156,9 +156,11 @@ commutation identities eq2:proof.IV.12, and positive semidefiniteness of the
 density operators rules such a projector out.
 
 **Scope restriction (conditional on the supplied projector):** the source
-proves this step outright, drawing the projector from the general theory of
-the peripheral spectrum; here that implication is the explicit hypothesis.
-Recorded in `docs/paper-gaps/cpgsv17_periodic_sector_projector.tex`. -/
+draws the projector from the general theory of the peripheral spectrum; here
+that implication is the explicit all-length hypothesis.  The general theorem
+for a tensor in literal horizontal canonical form is proved in
+`TNLean/MPS/MPDO/CyclicProjector.lean` from one noncommuting length.  Recorded
+in `docs/paper-gaps/cpgsv17_periodic_sector_projector.tex`. -/
 theorem hasNoPeriodicVectors_verticalTensor (M : MPOTensor d D)
     (hM : IsMPDO M) (hYield : PeriodicVectorYieldsProjector M) :
     MPSTensor.HasNoPeriodicVectors (verticalTensor M) := by

--- a/TNLean/MPS/MPDO/StackedLayers.lean
+++ b/TNLean/MPS/MPDO/StackedLayers.lean
@@ -350,8 +350,11 @@ constructed unconditionally in
 `exists_displaced_invariant_projector_of_periodic_vector`
 (`TNLean/MPS/MPDO/CyclicProjector.lean`); this hypothesis follows from the
 non-commutation hypothesis `NoninvariantProjectorNoncommuting` through
-`periodicVectorYieldsCyclicProjector_of_noncommutation`.  The remaining gap
-is recorded in `docs/paper-gaps/cpgsv17_periodic_sector_projector.tex`. -/
+`periodicVectorYieldsCyclicProjector_of_noncommutation`.  For a tensor in
+literal horizontal canonical form, the direct theorem
+`hasNoPeriodicVectors_verticalTensor_of_horizontalCF` avoids this stronger
+all-length hypothesis by using one noncommuting length.  The distinction is
+recorded in `docs/paper-gaps/cpgsv17_periodic_sector_projector.tex`. -/
 def PeriodicVectorYieldsCyclicProjector (M : MPOTensor d D) : Prop :=
   ∀ ⦃n : ℕ⦄ (V : Matrix (Fin d) (Fin n) ℂ) (B : MPSTensor (D * D) n)
     (ρ : Matrix (Fin n) (Fin n) ℂ) (r : ℝ),
@@ -390,10 +393,11 @@ projectors.  This is the periodic-sector step in the proof of Proposition
 4.13 of arXiv:1606.00608, lines 1888--1893, with the commutation family
 derived from the stacked-layers identity rather than assumed.
 
-**Scope restriction (conditional on the supplied cyclic projector):** the
-source proves this step outright, drawing the projector from the general
-theory of the peripheral spectrum; here the existence of the invariant,
-non-commuting projector is the explicit hypothesis.  Recorded in
+**Scope restriction (conditional on the supplied cyclic projector):** this
+theorem retains the stronger all-length projector hypothesis.  For a
+tensor in literal horizontal canonical form, that hypothesis is unnecessary:
+`hasNoPeriodicVectors_verticalTensor_of_horizontalCF` uses the same invariant
+projector at one noncommuting length.  Recorded in
 `docs/paper-gaps/cpgsv17_periodic_sector_projector.tex`. -/
 theorem hasNoPeriodicVectors_verticalTensor_of_cyclicProjector
     (M : MPOTensor d D) (hM : IsMPDO M)


### PR DESCRIPTION
## Motivation

PR #3868 completed the periodic-sector exclusion for tensors in literal horizontal canonical form by using the existential noncommuting length supplied by Lemma L. Several older module comments still described that connection as open or presented the stronger all-length interfaces as the remaining gap.

## Description

- Record that the cyclic projector and its word invariance are constructed unconditionally.
- Distinguish the retained all-length conditional interfaces from the direct horizontal-canonical-form theorem.
- Replace obsolete missing-transport and open-connection claims with references to the completed horizontal transport and periodic contradiction.

This changes documentation only. It does not claim the independent vertical BNT construction required for the full Proposition 4.13.

## Testing

- `lake build TNLean.MPS.MPDO.InvariantProjection TNLean.MPS.MPDO.PeriodicExclusion TNLean.MPS.MPDO.StackedLayers`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base main --ci`
- `git diff --check main...HEAD`

Addresses #3674

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and cross-reference edits only; no proof or runtime behavior changes.
> 
> **Overview**
> Updates **module docstrings only** in `InvariantProjection.lean`, `PeriodicExclusion.lean`, and `StackedLayers.lean` so they match work after PR #3868: the cyclic projector and word invariance live in `CyclicProjector.lean`, literal horizontal gauge transport in `HorizontalBNT.lean`, and horizontal canonical form needs only **one** noncommuting length—not the stronger all-length commutation family.
> 
> **`InvariantProjection.lean`** drops “open gap” wording for the cyclic projector and all-length conditions; **`ketLeftMul_eq_braRightMul_of_commute_of_isInjective`** now cites `HorizontalBNT.lean` for general literal-gauge transport; **`mpo_commute_of_commute_pow`** points to `CyclicProjector.lean` for projector construction rather than an unfinished connection.
> 
> **`PeriodicExclusion.lean`** and **`StackedLayers.lean`** clarify that `PeriodicVectorYieldsProjector` / `PeriodicVectorYieldsCyclicProjector` and the conditional `hasNoPeriodicVectors_*` theorems keep the **all-length** hypotheses, while `hasNoPeriodicVectors_verticalTensor_of_horizontalCF` is the direct horizontal-CF route. No Lean proofs or APIs change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41590daeeaacc450ebd953263e4a3ee185a2b188. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->