### PR TITLE
doc(MPS/MPDO): draw BNT operator trace closure

### DIFF
--- a/blueprint/src/Packages/tn_diagrams.py
+++ b/blueprint/src/Packages/tn_diagrams.py
@@ -94,6 +94,7 @@ _DIAGRAM_ARGS: dict[str, str] = {
     "TNMPDOTwoSiteBlocking": "",
     "TNMPDOBNTVerticalProduct": "",
     "TNMPDOBlockClosureMap": "",
+    "TNMPDOBNTOperatorTraceClosure": "",
     "TNMPDOFirstSiteInsertionHypothesis": "",
     "TNMPDOFirstSiteInsertionBlockwise": "",
     "TNMPDOInsertionTracePairing": "",

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -29,6 +29,16 @@
     comparison step must relate it to the chosen blocked support algebras.
 \end{definition}
 
+\begin{figure}[ht]
+    \centering
+    \TNMPDOBNTOperatorTraceClosure
+    \caption{The operator $O_L(M_\alpha)$: the vertical indices of $L$
+        copies of $M_\alpha$ are contracted cyclically, while their horizontal
+        legs remain open. This is the graphical definition in
+        \cite[lines~962--967]{Cirac2016MPDO_arXiv}.}
+    \label{fig:mpdo_bnt_operator_trace_closure}
+\end{figure}
+
 \begin{definition}[Same-length BNT product form]%
     \label{def:mpdo_bnt_label_same_length_product_form}
     \lean{MPOTensor.BNTLabelOperatorFamily.HasSameLengthProductForm}

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -1999,6 +1999,31 @@
     \end{tikzpicture}%
 }
 
+% The BNT-label operator O_L(M_alpha): L vertically read copies of M_alpha
+% are multiplied along the vertical index and closed by the trace, while the
+% horizontal legs remain open.  This follows source figure MPDO_O_L_A_.png.
+\newcommand{\TNMPDOBNTOperatorTraceClosure}{%
+    \begin{tikzpicture}[tn picture, scale=0.92]
+        \path[draw=black, opacity=0, use as bounding box]
+            (-3.08,-2.00) rectangle (1.40,2.00);
+        \node[anchor=east] at (-1.08,0) {$O_L(M_\alpha)\;=$};
+        \TN@tensordot{botcTop}{(0,1.08)}
+        \TN@tensordot{botcBottom}{(0,-1.08)}
+        \foreach \n in {botcTop,botcBottom} {
+            \TN@leftleg{\n}{0.62}
+            \TN@rightleg{\n}{0.62}
+        }
+        \draw[tn phys leg] (botcTop.south) -- (0,0.38);
+        \draw[tn phys leg] (0,-0.38) -- (botcBottom.north);
+        \node at (0,0) {$\vdots$};
+        \draw[tn phys leg, rounded corners=4pt]
+            (botcTop.north) -- (0,1.56) -- (-0.76,1.56)
+            -- (-0.76,-1.56) -- (0,-1.56) -- (botcBottom.south);
+        \node[anchor=south west] at (0.18,1.12) {$M_\alpha$};
+        \node[anchor=south west] at (0.18,-1.04) {$M_\alpha$};
+    \end{tikzpicture}%
+}
+
 % First-site insertion agreement on the closed word: inserting Y on the
 % physical leg of the first site of the matrix product vector gives the
 % same vector as inserting Z.

--- a/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
+++ b/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
@@ -43,7 +43,7 @@ name: TNRFPKrausIsometry TNRFPKrausIsometryReverse TNRFPIsometryCanonicalForm
 name: TNRFPIsometryCanonicalFormBlocks TNMPDOTwoSiteBlocking
 {{ obj.tn_svg_html }}
 
-name: TNMPDOBNTVerticalProduct TNMPDOBlockClosureMap
+name: TNMPDOBNTVerticalProduct TNMPDOBlockClosureMap TNMPDOBNTOperatorTraceClosure
 {{ obj.tn_svg_html }}
 
 name: TNGaugeConjugation TNPhysicalRealization TNLinearTwist


### PR DESCRIPTION
## Motivation

The BNT-coefficient section defines the operator family O_L(M_alpha) algebraically, but it does not yet show the source contraction that gives this operator. The original paper displays the vertical cyclic trace closure in MPDO_O_L_A_.png at lines 962–967.

## Description

- Add a source-faithful TikZ reconstruction of the vertical trace closure of L copies of M_alpha.
- Leave every horizontal leg open, matching the operator O_L(M_alpha).
- Register the new semantic tensor-network macro for both print and web rendering.
- Place the figure immediately after the BNT-label operator-family definition and cite the exact source lines.

The diagram adds no mathematical claim beyond the existing definition.

## Testing

- `python3 blueprint/src/Packages/tn_diagrams.py --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base main --ci`
- `python3 scripts/blueprint_lean_sync.py --ci`
- `leanblueprint pdf`
- `leanblueprint web`
- isolated SVG smoke render and visual inspection
- `git diff --check main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and diagram plumbing only; no changes to formal definitions, Lean, or runtime logic.
> 
> **Overview**
> Adds a **source-faithful tensor-network figure** for the BNT-label operator \(O_L(M_\alpha)\): \(L\) copies of \(M_\alpha\) stacked vertically, **cyclic trace closure** on the vertical index, and **open horizontal legs**.
> 
> The new `\TNMPDOBNTOperatorTraceClosure` macro is wired through **`tn_diagrams.py`** and the **plasTeX web template** so PDF and web share the same diagram. A **figure** is inserted in the BNT-coefficients chapter right after the BNT-label operator-family definition, with a caption pointing to Cirac et al. (lines 962–967).
> 
> No new mathematical claims beyond the existing definition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b7b1ca471e153099e44838b5c8d815c3b16ce29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->