### PR TITLE
feat(MPS/MPDO): construct vertical reducing sectors

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -384,6 +384,7 @@ import TNLean.MPS.MPDO.PostBlockedRepresentativeSpan
 import TNLean.MPS.MPDO.HorizontalCFMPVRepresentation
 import TNLean.MPS.MPDO.InvariantProjection
 import TNLean.MPS.MPDO.HorizontalBNT
+import TNLean.MPS.MPDO.VerticalReduction
 import TNLean.MPS.MPDO.PeriodicExclusion
 import TNLean.MPS.MPDO.StackedLayers
 import TNLean.MPS.MPDO.CyclicProjector

--- a/TNLean/MPS/MPDO/InvariantProjection.lean
+++ b/TNLean/MPS/MPDO/InvariantProjection.lean
@@ -18,14 +18,15 @@ $$
 $$
 where $P_1=P\otimes\Id^{\otimes N}$.  Given an MPV-level BNT representation,
 Lemma L transfers these identities to every minimal representative, where they
-say $(\Id-P)MP=0$.  The further transport to the original MPO letters requires
-the literal horizontal-canonical-form gauge and is not proved here.
+say $(\Id-P)MP=0$. The further transport to the original MPO letters uses the
+literal horizontal canonical form and is carried out in
+`TNLean.MPS.MPDO.HorizontalBNT`.
 
 The file also specializes the positive-semidefinite power-commutation theorem
 to matrix product density operators.  This is only the final operator
-implication in source lines 1888--1893.  The passage from a nontrivial vertical
-period to an orthogonal projector $Q$ satisfying the required all-length
-commutation identities remains open.
+implication in source lines 1888--1893. The passage from a nontrivial vertical
+period to an orthogonal projector and its exclusion are carried out in
+`TNLean.MPS.MPDO.CyclicProjector`.
 
 ## Main definitions
 
@@ -437,10 +438,10 @@ theorem ketLeftMul_eq_braRightMul_of_commute_of_isInjective
 density operator commutes with the density operator itself.
 
 This is the final operator implication in the contradiction at
-arXiv:1606.00608, lines 1888--1893 (equation eq2:proof.IV.12).  It does not
+arXiv:1606.00608, lines 1888--1893 (equation eq2:proof.IV.12). It does not
 construct the orthogonal projector $Q$ associated with a nontrivial vertical
-period or establish its commutation with $[H^{(N)}]^p$ for every $N$; that
-connection remains open. -/
+period or establish its commutation with $[H^{(N)}]^p$; these steps are proved
+in `TNLean.MPS.MPDO.CyclicProjector`. -/
 theorem mpo_commute_of_commute_pow (M : MPOTensor d D) (hM : IsMPDO M) (N : ℕ)
     {p : ℕ} (hp : p ≠ 0) {Q : Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ}
     (hQ : Commute Q (mpo M N ^ p)) : Commute Q (mpo M N) :=

--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -99,10 +99,16 @@ argument must instead follow arXiv:1606.00608, lines 1873--1921, using MPDO
 positivity and Lemma L to establish an independent vertical canonical form and
 then proving positivity of its weights.  The doubled-index coefficient
 identification in the first step is formalized in
-`TNLean.MPS.MPDO.PerCopyHorizontalCF`.  The one-sided operator identity and its
-blockwise consequence are proved in `TNLean.MPS.MPDO.InvariantProjection`; the
-periodic-sector construction and the independent vertical canonical form remain
-open.
+`TNLean.MPS.MPDO.PerCopyHorizontalCF`. The one-sided operator identity and its
+blockwise consequence are proved in `TNLean.MPS.MPDO.InvariantProjection`.
+The periodic sectors are excluded in `TNLean.MPS.MPDO.CyclicProjector`, and
+`TNLean.MPS.MPDO.VerticalReduction` constructs a complete orthogonal family of
+irreducible reducing vertical corners. The general theorem in
+`TNLean.MPS.CanonicalForm.ProjectorClosureSpectral` gives an abstract
+positive-length normal-block decomposition. What remains open is a refinement
+that retains the physical isometries and reducing projections through
+zero-corner removal and normalization, followed by the BNT grouping,
+positivity, and gauge analysis needed for the final vertical canonical form.
 
 ## Module location
 

--- a/TNLean/MPS/MPDO/VerticalReduction.lean
+++ b/TNLean/MPS/MPDO/VerticalReduction.lean
@@ -1,0 +1,157 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.CanonicalForm.ProjectorClosureDecomposition
+import TNLean.MPS.MPDO.HorizontalBNT
+
+/-!
+# Reducing sectors of the vertically viewed tensor
+
+This file carries the invariant-projection argument of arXiv:1606.00608,
+Proposition 4.13, lines 1873--1887, into the general canonical-form
+decomposition at lines 200--225 and 253--255.
+
+For a tensor in horizontal canonical form that generates matrix product
+density operators, every one-sided invariant orthogonal projection of the
+vertically viewed tensor is reducing. The general decomposition under this
+closure condition then gives complete pairwise orthogonal physical sectors,
+their exact corner tensors, and both intertwining identities. No spectral
+normalization or grouping into a basis of normal tensors is asserted here.
+
+## Main results
+
+* `MPOTensor.IsHorizontalCF.hasInvariantProjectorClosure_verticalTensor`:
+  every one-sided invariant orthogonal projection of the vertically viewed
+  tensor is reducing.
+* `MPOTensor.IsHorizontalCF.exists_irreducible_verticalBlockDecomp_with_isometry`:
+  the physical space splits into complete orthogonal irreducible reducing
+  sectors for the vertically viewed tensor.
+* `MPOTensor.IsHorizontalCF.exists_complete_verticalReducingProjectors`:
+  the range projections of these sectors are complete, pairwise orthogonal,
+  and commute with every vertical letter.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- Every invariant orthogonal projection of the vertically viewed tensor is
+reducing for an MPO tensor in horizontal canonical form that generates matrix
+product density operators.
+
+This is the conclusion of the invariant-projection argument in
+arXiv:1606.00608, Proposition 4.13, lines 1873--1887. The left-invariance
+identity is translated to the one-site MPO actions, the horizontal Lemma L
+reduction gives right invariance, and the result is translated back to the
+vertically viewed tensor. -/
+theorem IsHorizontalCF.hasInvariantProjectorClosure_verticalTensor
+    (M : MPOTensor d D) (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M) :
+    MPSTensor.HasInvariantProjectorClosure (verticalTensor M) := by
+  intro P hP hInv v
+  have hLeft : M.ketLeftMul P = (M.ketLeftMul P).braRightMul P := by
+    funext i j
+    ext a b
+    let w := finProdFinEquiv (a, b)
+    have hw : verticalTensor (M.ketLeftMul P) w =
+        verticalTensor ((M.ketLeftMul P).braRightMul P) w := by
+      rw [verticalTensor_ketLeftMul, verticalTensor_braRightMul,
+        verticalTensor_ketLeftMul]
+      exact hInv w
+    have hij := congrFun (congrFun hw i) j
+    simpa [w, verticalTensor_finProdFinEquiv] using hij
+  have hRight :=
+    hHorizontal.braRight_eq_ketLeftBraRight_of_invariant M hM hP.1 hLeft
+  rw [← verticalTensor_braRightMul, hRight, verticalTensor_braRightMul,
+    verticalTensor_ketLeftMul]
+
+/-- Complete orthogonal decomposition of the vertically viewed tensor into
+irreducible reducing corners.
+
+For a horizontally canonical MPO tensor generating matrix product density
+operators, there are isometries `V k` with pairwise orthogonal ranges summing
+to the physical identity. Every vertical letter intertwines each `V k` with
+the corresponding irreducible corner, and the adjoint intertwining and exact
+compression formula hold as well. The unit-weight direct sum of these corners
+has the same full matrix product vector family as the vertically viewed
+tensor.
+
+This specializes the canonical-form construction of arXiv:1606.00608,
+lines 200--225 and 253--255, after the invariant-projection argument of
+Proposition 4.13, lines 1873--1887. -/
+theorem IsHorizontalCF.exists_irreducible_verticalBlockDecomp_with_isometry
+    (M : MPOTensor d D) (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M) :
+    ∃ (r : ℕ) (dim : Fin r → ℕ)
+      (blocks : (k : Fin r) → MPSTensor (D * D) (dim k))
+      (V : (k : Fin r) → Matrix (Fin d) (Fin (dim k)) ℂ),
+      (∀ k, 0 < dim k) ∧
+      (∀ k, (V k)ᴴ * V k = 1) ∧
+      (∑ k : Fin r, V k * (V k)ᴴ = 1) ∧
+      (∀ k l, k ≠ l → (V k)ᴴ * V l = 0) ∧
+      (∀ k v, verticalTensor M v * V k = V k * blocks k v) ∧
+      (∀ k v, (V k)ᴴ * verticalTensor M v = blocks k v * (V k)ᴴ) ∧
+      (∀ k v, blocks k v = (V k)ᴴ * verticalTensor M v * V k) ∧
+      (∀ k, MPSTensor.IsIrreducibleTensor (blocks k)) ∧
+      MPSTensor.SameMPV₂ (verticalTensor M)
+        (MPSTensor.toTensorFromBlocks
+          (d := D * D) (μ := fun _ : Fin r => (1 : ℂ)) blocks) := by
+  exact
+    MPSTensor.exists_irreducible_blockDecomp_with_isometry_of_hasInvariantProjectorClosure
+      (verticalTensor M)
+      (hHorizontal.hasInvariantProjectorClosure_verticalTensor M hM)
+
+/-- The ranges of the vertical corner isometries form complete pairwise
+orthogonal reducing projections.
+
+This is the precursor of the grouped sector projections used in
+arXiv:1606.00608, Proposition 4.13, line 1898. At this stage the corners are
+irreducible, but possible zero corners have not been removed and the remaining
+corners have not been spectrally normalized or grouped into a basis of normal
+tensors. -/
+theorem IsHorizontalCF.exists_complete_verticalReducingProjectors
+    (M : MPOTensor d D) (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M) :
+    ∃ (r : ℕ) (P : Fin r → Matrix (Fin d) (Fin d) ℂ),
+      (∀ k, IsOrthogonalProjection (P k)) ∧
+      (∑ k, P k = 1) ∧
+      (∀ k l, k ≠ l → P k * P l = 0) ∧
+      ∀ k v, verticalTensor M v * P k = P k * verticalTensor M v := by
+  obtain ⟨r, _dim, blocks, V, _hpos, hiso, hsum, horth, hint, hintStar,
+    _hcorner, _hirr, _hMPV⟩ :=
+    hHorizontal.exists_irreducible_verticalBlockDecomp_with_isometry M hM
+  let P : Fin r → Matrix (Fin d) (Fin d) ℂ := fun k => V k * (V k)ᴴ
+  refine ⟨r, P, ?_, ?_, ?_, ?_⟩
+  · intro k
+    constructor
+    · change (V k * (V k)ᴴ)ᴴ = V k * (V k)ᴴ
+      rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose]
+    · change (V k * (V k)ᴴ) * (V k * (V k)ᴴ) = V k * (V k)ᴴ
+      calc
+        (V k * (V k)ᴴ) * (V k * (V k)ᴴ)
+            = V k * ((V k)ᴴ * V k) * (V k)ᴴ := by
+              simp only [Matrix.mul_assoc]
+        _ = V k * (V k)ᴴ := by rw [hiso k, Matrix.mul_one]
+  · exact hsum
+  · intro k l hkl
+    change (V k * (V k)ᴴ) * (V l * (V l)ᴴ) = 0
+    calc
+      (V k * (V k)ᴴ) * (V l * (V l)ᴴ)
+          = V k * ((V k)ᴴ * V l) * (V l)ᴴ := by
+            simp only [Matrix.mul_assoc]
+      _ = 0 := by rw [horth k l hkl, Matrix.mul_zero, Matrix.zero_mul]
+  · intro k v
+    change verticalTensor M v * (V k * (V k)ᴴ) =
+      (V k * (V k)ᴴ) * verticalTensor M v
+    calc
+      verticalTensor M v * (V k * (V k)ᴴ)
+          = (verticalTensor M v * V k) * (V k)ᴴ :=
+            (Matrix.mul_assoc _ _ _).symm
+      _ = (V k * blocks k v) * (V k)ᴴ := by rw [hint k v]
+      _ = V k * (blocks k v * (V k)ᴴ) := Matrix.mul_assoc _ _ _
+      _ = V k * ((V k)ᴴ * verticalTensor M v) := by rw [hintStar k v]
+      _ = (V k * (V k)ᴴ) * verticalTensor M v :=
+        (Matrix.mul_assoc _ _ _).symm
+
+end MPOTensor

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -2159,15 +2159,14 @@
         def:invariant_projector_closure,
         thm:representative_one_sub_mp_zero}
     Let $M$ be in horizontal canonical form and generate matrix product
-    density operators. If an orthogonal projection $P$ satisfies
+    density operators. If an orthogonal projection $P$ satisfies, for every
+    vertical letter $v$,
     \[
-        P\widetilde M_v=P\widetilde M_vP
-        \qquad\text{for every }v,
+        P\widetilde M_v=P\widetilde M_vP,
     \]
-    then it also satisfies
+    then, for every vertical letter $v$, it also satisfies
     \[
-        \widetilde M_vP=P\widetilde M_vP
-        \qquad\text{for every }v.
+        \widetilde M_vP=P\widetilde M_vP.
     \]
     Thus the vertically viewed tensor has invariant-projector closure.
 \end{theorem}

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -1643,8 +1643,10 @@
     $M_\alpha$ --- independently of $k$, because the sector gauge
     $X_{\alpha,k}$ cancels under the single-site loop trace,
     $\sum_i(X_{\alpha,k}M_\alpha X_{\alpha,k}^{-1})^{ii}=\sum_i M_\alpha^{ii}$.
-    Constructing
-    that decomposition, and with it these projectors, remains open.
+    The irreducible reducing projections have been constructed in
+    Theorem~\ref{thm:mpdo_vertical_complete_reducing_projectors}. Their
+    identification with the grouped normal sectors above, including the loop
+    identity $E_P=\mu E_\alpha$, remains open.
 \end{definition}
 
 \begin{theorem}[The sector trace identity]
@@ -1657,9 +1659,9 @@
     \[
         \tr\bigl(P_1H^{(N+1)}P_1\bigr)=\mu\,d_\alpha^{(N+1)}.
     \]
-    Once the vertical decomposition supplies the sector projectors
-    $P_{\alpha,k}$ --- their construction remains open
-    (Definition~\ref{def:mpdo_sector_projector}) --- this specializes to the
+    Once spectral normalization and grouping identify the reducing
+    projectors with sector projectors $P_{\alpha,k}$ satisfying
+    Definition~\ref{def:mpdo_sector_projector}, this specializes to the
     trace identification
     $\tr(P_{\alpha,k}H^{(N)}P_{\alpha,k})=\mu_{\alpha,k}d_\alpha$ used in
     the proof of \cite[Proposition~4.13]{Cirac2016MPDO_arXiv}; the source
@@ -2149,6 +2151,94 @@
     Combining these two equalities proves the claim.
 \end{proof}
 
+\begin{theorem}[Invariant vertical projections are reducing]
+    \label{thm:mpdo_vertical_projector_closure}
+    \lean{MPOTensor.IsHorizontalCF.hasInvariantProjectorClosure_verticalTensor}
+    \leanok
+    \uses{def:mpdo, def:horizontal_cf_mpdo, def:vertical_tensor_mpdo,
+        def:invariant_projector_closure,
+        thm:representative_one_sub_mp_zero}
+    Let $M$ be in horizontal canonical form and generate matrix product
+    density operators. If an orthogonal projection $P$ satisfies
+    \[
+        P\widetilde M_v=P\widetilde M_vP
+        \qquad\text{for every }v,
+    \]
+    then it also satisfies
+    \[
+        \widetilde M_vP=P\widetilde M_vP
+        \qquad\text{for every }v.
+    \]
+    Thus the vertically viewed tensor has invariant-projector closure.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:representative_one_sub_mp_zero}
+    Translate the left-invariance identity into the one-site ket and bra
+    actions of the original tensor. The horizontal canonical-form version of
+    Lemma~L gives the opposite one-sided identity. Translating back to the
+    vertically viewed tensor proves the claim.
+\end{proof}
+
+\begin{theorem}[Irreducible reducing sectors of the vertically viewed tensor]
+    \label{thm:mpdo_vertical_irreducible_reducing_sectors}
+    \lean{MPOTensor.IsHorizontalCF.exists_irreducible_verticalBlockDecomp_with_isometry}
+    \leanok
+    \uses{thm:mpdo_vertical_projector_closure,
+        thm:projector_closure_irreducible_corners}
+    Under the hypotheses of
+    Theorem~\ref{thm:mpdo_vertical_projector_closure}, there are positive
+    integers $d_k$, tensors $B_k$ of bond dimension $d_k$, and isometries
+    $V_k:\C^{d_k}\to\C^d$ such that
+    \[
+        V_k^\dagger V_k=\Id,\qquad
+        \sum_k V_kV_k^\dagger=\Id,\qquad
+        V_k^\dagger V_l=0\quad(k\ne l).
+    \]
+    Every $B_k$ is irreducible, and for every vertical letter $v$,
+    \[
+        \widetilde M_vV_k=V_kB_k^v,
+        \qquad
+        V_k^\dagger\widetilde M_v=B_k^vV_k^\dagger,
+        \qquad
+        B_k^v=V_k^\dagger\widetilde M_vV_k.
+    \]
+    Moreover, $\widetilde M$ and the unit-weight direct sum
+    $\bigoplus_k B_k$ have the same matrix product vectors at every length.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_vertical_projector_closure,
+        thm:projector_closure_irreducible_corners}
+    Apply the irreducible-corner decomposition under invariant-projector
+    closure to $\widetilde M$.
+\end{proof}
+
+\begin{theorem}[Complete vertical reducing projectors]
+    \label{thm:mpdo_vertical_complete_reducing_projectors}
+    \lean{MPOTensor.IsHorizontalCF.exists_complete_verticalReducingProjectors}
+    \leanok
+    \uses{thm:mpdo_vertical_irreducible_reducing_sectors}
+    Under the same hypotheses, there are orthogonal projections $P_k$ such
+    that
+    \[
+        \sum_kP_k=\Id,\qquad P_kP_l=0\quad(k\ne l),\qquad
+        \widetilde M_vP_k=P_k\widetilde M_v
+    \]
+    for every $k$ and every vertical letter $v$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_vertical_irreducible_reducing_sectors}
+    For the isometries of
+    Theorem~\ref{thm:mpdo_vertical_irreducible_reducing_sectors}, set
+    $P_k=V_kV_k^\dagger$. The isometry, orthogonality, completeness, and
+    intertwining identities give the four assertions directly.
+\end{proof}
+
 \begin{theorem}[Horizontal canonical form implies vertical canonical form]
     \label{thm:vertical_cf_of_horizontal_cf}
     \notready
@@ -2158,6 +2248,10 @@
         thm:mpdo_first_site_invariant_comm,
         thm:representative_one_sub_mp_zero,
         thm:mpdo_vertical_no_periodic_vectors_horizontal_cf,
+        thm:mpdo_vertical_projector_closure,
+        thm:mpdo_vertical_irreducible_reducing_sectors,
+        thm:mpdo_vertical_complete_reducing_projectors,
+        thm:projector_closure_canonical_form,
         thm:mpdo_sector_compression_trace_pos,
         def:mpdo_sector_projector,
         thm:mpdo_sector_trace_identity,
@@ -2174,9 +2268,13 @@
     density operators is also in canonical form in the vertical direction:
     there are a basis of normal tensors $\{M_\alpha\}_\alpha$ for the
     vertically viewed tensor $\widetilde M$, positive diagonal matrices
-    $\mu_\alpha$, and an isometry $U$ on the physical space with
+    $\mu_\alpha$, and a coisometry $U$ from the physical space onto the
+    retained nonzero sectors. Writing
+    $B=\bigoplus_\alpha\mu_\alpha\otimes M_\alpha$, one has
     \[
-        U\widetilde MU^\dagger=\bigoplus_\alpha\mu_\alpha\otimes M_\alpha.
+        UU^\dagger=\Id,\qquad
+        U\widetilde MU^\dagger=B,\qquad
+        \widetilde M=U^\dagger BU.
     \]
     This is \cite[Proposition~4.13]{Cirac2016MPDO_arXiv}.
 \end{theorem}
@@ -2187,6 +2285,10 @@
         thm:mpdo_first_site_invariant_comm,
         thm:representative_one_sub_mp_zero,
         thm:mpdo_vertical_no_periodic_vectors_horizontal_cf,
+        thm:mpdo_vertical_projector_closure,
+        thm:mpdo_vertical_irreducible_reducing_sectors,
+        thm:mpdo_vertical_complete_reducing_projectors,
+        thm:projector_closure_canonical_form,
         thm:mpdo_sector_compression_trace_pos,
         def:mpdo_sector_projector,
         thm:mpdo_sector_trace_identity,
@@ -2206,8 +2308,19 @@
     Theorem~\ref{thm:mpdo_vertical_no_periodic_vectors_horizontal_cf}
     excludes nontrivial $p$-periodic vectors of the vertically viewed tensor
     from the horizontal canonical-form and positivity hypotheses alone.
-    One must then apply the canonical-form theorem in the vertical direction
-    to the vertically viewed tensor $\widetilde M$, obtaining a decomposition
+    Theorem~\ref{thm:mpdo_vertical_projector_closure} proves that every
+    one-sided invariant orthogonal projection of $\widetilde M$ is reducing.
+    Theorem~\ref{thm:mpdo_vertical_irreducible_reducing_sectors} therefore
+    decomposes the physical space into complete orthogonal irreducible
+    reducing sectors, and
+    Theorem~\ref{thm:mpdo_vertical_complete_reducing_projectors} records their
+    commuting range projections. Together with the absence of periodic
+    vectors, Theorem~\ref{thm:projector_closure_canonical_form} already gives
+    an abstract positive-length decomposition into normal blocks. That theorem
+    does not retain the physical isometries and reducing projections. The
+    source argument requires a refinement that retains this data through
+    zero-corner removal and spectral normalization, and then groups the
+    resulting normal tensors, obtaining
     \[
         \widetilde M
         =\bigoplus_{\alpha,k}\mu_{\alpha,k}X_{\alpha,k}M_\alpha X_{\alpha,k}^{-1}
@@ -2232,15 +2345,17 @@
     $U_{\alpha,k}=\omega_{\alpha,k}^{-1/2}X_{\alpha,k}$ of the sector gauges
     from the blockwise dressed-adjoint identities of the two displayed
     diagrams.  Composing the sector unitaries $U_{\alpha,k}$ yields the
-    isometry $U$ with
-    $U\widetilde MU^\dagger=\bigoplus_\alpha\mu_\alpha\otimes M_\alpha$; each
+    coisometry $U$ with
+    $U\widetilde MU^\dagger=\bigoplus_\alpha\mu_\alpha\otimes M_\alpha$ and
+    the corresponding reconstruction identity; each
     $\mu_\alpha$ is diagonal, so the summands regroup as repeated weighted
     copies of $M_\alpha$ exactly as in the finite regrouping of
     Lemma~\ref{lem:vertical_grouping_equiv}.  Deriving the dressed-adjoint
     identities from self-adjointness of the sector compressions via Lemma L
-    within the vertical decomposition remains open, as does the construction
-    of the vertical canonical decomposition itself, which must also produce
-    the sector projectors of
-    Definition~\ref{def:mpdo_sector_projector} together with their loop
-    identities and the nonvanishing of a sector compression at some length.
+    within the spectrally normalized vertical decomposition remains open.
+    The remaining construction must also identify the reducing projectors
+    above with the grouped sector projectors of
+    Definition~\ref{def:mpdo_sector_projector}, prove their loop identities
+    and the nonvanishing of a sector compression at some length, and assemble
+    the positive weights and proportional-unitary gauges.
 \end{proof}

--- a/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
@@ -128,12 +128,26 @@ canonical decomposition, not by declaring the diagonal restrictions of the
 horizontal blocks to be normal blocks.
 
 The exact reindexing step \eqref{eq:regrouped-mpv} is therefore complete once
-the bijection and the pointwise block identifications are known.  The
-one-sided invariant-matrix calculation from source lines~1874--1887 is also
-formalized.  For the periodic-sector argument, positivity now gives the final
-implication from commutation with $[H^{(N)}]^p$ to commutation with
-$H^{(N)}$.  It remains to derive the orthogonal projector with the required
-all-length properties from a nontrivial vertical period.
+the bijection and the pointwise block identifications are known. The
+one-sided invariant-matrix calculation from source lines~1874--1887 now gives
+invariant-projector closure for the vertically viewed tensor
+(\path{MPOTensor.IsHorizontalCF.hasInvariantProjectorClosure_verticalTensor}).
+The general decomposition under this closure condition produces a complete
+orthogonal family of irreducible reducing corners, with isometries, both
+intertwining identities, exact compression, and equality of matrix product
+vectors at every length
+(\path{MPOTensor.IsHorizontalCF.exists_irreducible_verticalBlockDecomp_with_isometry}).
+Its range projections are complete, pairwise orthogonal, and commute with all
+vertical letters
+(\path{MPOTensor.IsHorizontalCF.exists_complete_verticalReducingProjectors}).
+
+The periodic-sector exclusion is also complete:
+\path{MPOTensor.hasNoPeriodicVectors_verticalTensor_of_horizontalCF} derives
+the displaced cyclic projector associated with a nontrivial period, together
+with its full-period word invariance, and contradicts positivity at a suitable
+chain length. The source prints an all-length inequality, whereas the proof
+only needs one noncommuting length; this local correction is recorded in
+\path{docs/paper-gaps/cpgsv17_periodic_sector_projector.tex}.
 
 Two further steps of source lines~1895--1921 now have conditional
 formalizations.  For the positive weights: granted an orthogonal sector
@@ -156,18 +170,22 @@ $\omega_{\alpha,k}^{-1/2}X_{\alpha,k}$ unitary
 (\path{MPSTensor.IsNormal.smul_mem_unitaryGroup_of_dressed_adjoint} in
 \path{TNLean/MPS/CanonicalForm/NormalCommutant.lean}).
 
-The remaining source-level gap is the construction of the vertical canonical
-decomposition itself, with its grouping into a basis of normal tensors, from
-horizontal canonical form and MPDO positivity, as done in source
-lines~1895--1921: the construction must produce the sector projectors
-together with their loop identities and a nonvanishing compression, derive
-the dressed-adjoint identities from self-adjointness of the sector
-compressions, and supply the periodic-sector exclusion above.  This is the
-mathematical content shared with the normality and grouping problem tracked
-by \ghissue{2537}; it cannot be supplied by a finite-sum identity alone.  The
-original formulation of \ghissue{2536}, interpreted as a direct conversion of
-the horizontal scalar weights and diagonal restrictions, is therefore not a
-consequence of Proposition~4.13.
+Projector closure together with the absence of periodic vectors already gives
+an abstract positive-length decomposition into normal blocks
+(\path{TNLean/MPS/CanonicalForm/ProjectorClosureSpectral.lean}).
+This theorem does not retain the physical isometries and reducing projections
+constructed above. The remaining source-level gap is the refinement that
+retains this data through zero-corner removal and spectral normalization,
+groups gauge-equivalent normal tensors, identifies the resulting grouped
+projections with the sector projectors carrying the single-site loop
+identities, and proves a nonvanishing compression. One must then derive the
+dressed-adjoint identities from self-adjointness of the sector compressions
+and assemble the positive weights and proportional-unitary gauges of source
+lines~1895--1921. This is the mathematical content shared with the normality
+and grouping problem tracked by \ghissue{2537}; it cannot be supplied by a
+finite-sum identity alone. The original formulation of \ghissue{2536},
+interpreted as a direct conversion of the horizontal scalar weights and
+diagonal restrictions, is therefore not a consequence of Proposition~4.13.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
@@ -147,9 +147,15 @@ formalized:
   QH^{(N)}=H^{(N)}Q.
 \]
 A nontrivial vertical period now yields the displaced cyclic projector and its
-word invariance.  The remaining step is the fixed-length interface: the
-present noncommutation predicate asks for a contradiction at every individual
-chain length, while Lemma~L consumes the simultaneous positive-length family.
+word invariance. The horizontal canonical-form version of Lemma~L supplies a
+chain length at which the displaced projector fails to commute; positivity at
+that length gives the contradiction. Thus nontrivial vertical periods are
+excluded without the stronger all-length inequality printed in the source.
+
+Invariant-projector closure is also established for the vertically viewed
+tensor, and it gives a complete orthogonal family of irreducible reducing
+corners with exact physical isometries
+(\path{TNLean/MPS/MPDO/VerticalReduction.lean}).
 
 The third stage now has conditional formalizations of its two closing
 arguments.  Granted orthogonal sector projectors whose insertion into the
@@ -165,11 +171,16 @@ a positive multiple $\omega_{\alpha,k}$ of the identity, in the normalization
 $X_{\alpha,1}=\Id$, and the normalized gauge
 $\omega_{\alpha,k}^{-1/2}X_{\alpha,k}$ is unitary, because a normal tensor
 has scalar commutant
-(\path{TNLean/MPS/CanonicalForm/NormalCommutant.lean}).  What remains open is
-the independent vertical canonical-form construction itself, which must
-supply the sector projectors with their loop identities and a nonvanishing
-compression, together with the derivation of the dressed-adjoint identities
-from self-adjointness of the sector compressions.
+(\path{TNLean/MPS/CanonicalForm/NormalCommutant.lean}). Projector closure and
+the absence of periodic vectors already give an abstract positive-length
+normal-block decomposition
+(\path{TNLean/MPS/CanonicalForm/ProjectorClosureSpectral.lean}). What remains
+open is the refinement that retains the physical isometries and reducing
+projections through zero-corner removal and spectral normalization, and then
+groups the normal blocks. This must identify the grouped sector projectors
+with their loop identities and a nonvanishing compression, together with the
+derivation of the dressed-adjoint identities from self-adjointness of the
+sector compressions.
 
 \paragraph{Verdict.}
 This is an open gap: the source-faithful horizontal-to-vertical implication of


### PR DESCRIPTION
### Motivation

- Proposition 4.13 requires the one-sided invariant projections of the vertically viewed tensor to be reducing before the vertical sectors can be normalized and grouped.
- The relevant source is `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 200–225, 253–255, and 1873–1898, with labels `eq:II_Aiplusk1` and `UMU-appendix`: “After a finite number of steps, r, there will be no (non-trivial) invariant subspace anymore.”
- The abstract decomposition under invariant-projector closure already existed, but its exact physical embeddings had not been specialized to the vertically viewed MPO tensor.

### Description

- Prove `MPOTensor.IsHorizontalCF.hasInvariantProjectorClosure_verticalTensor` by translating one-sided vertical invariance to the one-site MPO actions and applying the horizontal canonical-form version of Lemma L.
- Prove `MPOTensor.IsHorizontalCF.exists_irreducible_verticalBlockDecomp_with_isometry`, retaining positive corner dimensions, complete orthogonal isometries, both letterwise intertwining identities, exact compression, irreducibility, and equality of the full matrix product vector family.
- Expose the range projections as a complete pairwise orthogonal family commuting with every vertical letter in `MPOTensor.IsHorizontalCF.exists_complete_verticalReducingProjectors`.
- Add the new module to the root import and synchronize the blueprint and paper-gap notes. The documentation distinguishes the completed abstract positive-length normal-block theorem from the still-open refinement that must retain the physical isometries and reducing projections through zero-corner removal, spectral normalization, and BNT grouping.

### Testing

- `lake env lean TNLean/MPS/MPDO/VerticalReduction.lean`
- `lake env lean TNLean/MPS/MPDO/InvariantProjection.lean`
- `lake env lean TNLean/MPS/MPDO/VerticalCF.lean`
- `lake build TNLean` — 9,382 jobs
- `#print axioms` for all three new declarations — only `propext`, `Classical.choice`, and `Quot.sound`
- `python3 scripts/blueprint_lean_sync.py --update-lean-decls --ci`
- `cd blueprint && leanblueprint checkdecls`
- `cd blueprint && leanblueprint pdf`
- Standalone LaTeX builds and rendered-page inspection for both revised paper-gap notes
- `python3 scripts/check_reader_facing_prose.py --diff-base main --ci`
- `git diff --check`
- Static scan for `sorry`, `axiom`, `native_decide`, and kernel bypasses

---
Closes #3872

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only Lean additions and documentation; no runtime, auth, or data-path changes. Risk is mainly mathematical correctness of the formalization chain, which the PR description reports as built and axiom-checked.
> 
> **Overview**
> Adds **`TNLean/MPS/MPDO/VerticalReduction.lean`** and wires it into the root import. For horizontal canonical form + MPDO, it proves that one-sided invariant orthogonal projections of the vertically viewed tensor are **reducing**, then applies the existing projector-closure decomposition to obtain **irreducible corners with complete orthogonal physical isometries** (intertwining, compression, same MPV family) and the corresponding **complete pairwise orthogonal reducing projections** commuting with every vertical letter.
> 
> The proof pipeline translates vertical invariance to one-site `ketLeftMul` / `braRightMul`, invokes **`IsHorizontalCF.braRight_eq_ketLeftBraRight_of_invariant`** from horizontal BNT, and instantiates **`exists_irreducible_blockDecomp_with_isometry_of_hasInvariantProjectorClosure`**.
> 
> **Docs:** `InvariantProjection` now points letter transport to `HorizontalBNT`; `VerticalCF` and the paper-gap notes record periodic exclusion and this sector construction as done, while the full vertical canonical form remains open (retain isometries through zero-corner removal, spectral normalization, BNT grouping, sector-projector identification). The blueprint gains three linked theorems and updates the not-ready vertical-CF proof outline accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e87f7025718e99bbca19a5935af1cd091e0e520a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->