### PR TITLE
feat(MPS/MPDO): place ZCL relations on active sector matrix

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -443,6 +443,7 @@ import TNLean.MPS.MPDO.PhysicalSectorProductTransport
 import TNLean.MPS.MPDO.PhysicalSectorEtaLocalStructure
 import TNLean.MPS.MPDO.PhysicalSectorPhysicalTransport
 import TNLean.MPS.MPDO.SectorPairingTransfer
+import TNLean.MPS.MPDO.InverseMapActiveSectorZCL
 import TNLean.MPS.MPDO.SectorEtaContraction
 import TNLean.MPS.MPDO.SectorEtaOperator
 import TNLean.MPS.MPDO.SectorEtaPositivity

--- a/TNLean/MPS/MPDO/InverseMapActiveSectorZCL.lean
+++ b/TNLean/MPS/MPDO/InverseMapActiveSectorZCL.lean
@@ -1,0 +1,258 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.InverseMapActiveSectorPrimitivity
+import TNLean.MPS.MPDO.SectorPairingTransfer
+
+/-!
+# Zero correlation length on the active inverse-map trace matrix
+
+The positive normalization furnished by source zero correlation length gives
+the square--cube and positive-power trace relations on the same active,
+positively rephased trace matrix that is primitive under the strong area law.
+
+The argument writes the physical-trace transfer as a rectangular product
+indexed only by sectors of nonzero Hayashi weight.  The opposite rectangular
+product is the complexification of the active trace matrix because its
+neighboring operators are positive semidefinite.
+
+## Main results
+
+* `PhysicalSectorFactorization.activeSectorTraceMatrix_normalized_relations_of_isSourceZCL`:
+  source zero correlation length gives normalized square--cube and trace-power
+  relations on the active trace matrix of a positive sector factorization.
+* `exists_rephased_inverseMap_activeSectorTraceMatrix_normalized_relations`:
+  the inverse-map construction has one rephasing for which positivity,
+  primitivity, and both normalized relations hold.
+* `exists_activeTraceMatrix_relations_of_isSAL_of_isSourceZCL`:
+  the corresponding existence statement from the strong area law and source
+  zero correlation length.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, Lemmas C.4--C.5, lines 1406--1497
+-/
+
+open scoped Matrix ComplexOrder BigOperators
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D}
+
+/-- Suppose that the left tensor vanishes in every sector of zero weight and
+that all neighboring operators are positive semidefinite.  If the original
+tensor has source zero correlation length, then one positive normalization of
+the active trace matrix satisfies
+\[
+  \widehat T^2=\widehat T^3,
+  \qquad
+  \operatorname{tr}(\widehat T^N)=\operatorname{tr}(\widehat T)
+  \quad (N\geq 1).
+\]
+
+The proof restricts the rectangular decomposition of the physical-trace
+transfer to the nonzero-weight sectors.  Positivity identifies the opposite
+rectangular product with the complexification of the real active trace
+matrix.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `Tkn` and `SALZCL`,
+lines 1473--1497.  The conclusion does not assert idempotence, rank one, or
+semisimplicity of the trace matrix. -/
+theorem activeSectorTraceMatrix_normalized_relations_of_isSourceZCL
+    (F : PhysicalSectorFactorization K) (p : Fin F.sectorCount → ℝ)
+    (hinactive : ∀ k, p k = 0 → ∀ beta, F.leftTensor k beta = 0)
+    (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
+    (hZCL : K.IsSourceZCL) :
+    ∃ lam : ℝ, 0 < lam ∧
+      let T := F.activeSectorTraceMatrix p
+      ((lam⁻¹ • T) ^ 2 = (lam⁻¹ • T) ^ 3) ∧
+        ∀ N : ℕ, 0 < N →
+          Matrix.trace ((lam⁻¹ • T) ^ N) = Matrix.trace (lam⁻¹ • T) := by
+  classical
+  obtain ⟨lam, hlam, hidem⟩ := hZCL.normalized_idempotent
+  let L : Matrix (Fin D) (F.ActiveSector p) ℂ :=
+    fun beta h ↦ (F.leftTensor h beta).trace
+  let Q : Matrix (F.ActiveSector p) (Fin D) ℂ :=
+    fun k alpha ↦ (F.rightTensor k alpha).trace
+  have hphys : MPOTensor.physTraceTransfer K = L * Q := by
+    let U : Matrix.unitaryGroup (Fin d) ℂ := ⟨F.physicalIsometry, by
+      rw [Matrix.mem_unitaryGroup_iff', Matrix.star_eq_conjTranspose]
+      exact F.physicalIsometry_isometry⟩
+    have hfactor : ∀ beta alpha,
+        Matrix.reindex F.sectorEquiv F.sectorEquiv
+            ((U : Matrix (Fin d) (Fin d) ℂ) * MPOTensor.physicalSlice K beta alpha *
+              (U : Matrix (Fin d) (Fin d) ℂ)ᴴ) =
+          Matrix.blockDiagonal' fun q ↦
+            Matrix.kroneckerMap (· * ·) (F.leftTensor q beta) (F.rightTensor q alpha) := by
+      simpa [U] using F.factorization
+    rw [MPOTensor.physTraceTransfer_eq_sum_closedSector K F.sectorEquiv U
+      F.leftTensor F.rightTensor hfactor]
+    ext beta alpha
+    simp only [MPOTensor.closedSectorPairingOperator, Matrix.sum_apply,
+      Matrix.vecMulVec_apply, Matrix.mul_apply, L, Q]
+    rw [← Finset.sum_subtype (Finset.univ.filter (fun k ↦ p k ≠ 0)) (by simp)
+      (fun k ↦ (F.leftTensor k beta).trace * (F.rightTensor k alpha).trace)]
+    rw [Finset.sum_filter]
+    apply Finset.sum_congr rfl
+    intro k _
+    by_cases hk : p k ≠ 0
+    · simp [hk]
+    · rw [if_neg hk, hinactive k (not_ne_iff.mp hk) beta, Matrix.trace_zero, zero_mul]
+  have hrect : IsIdempotentElem (((lam : ℂ)⁻¹ • L) * Q) := by
+    simpa only [Matrix.smul_mul, ← hphys] using hidem
+  let TC : Matrix (F.ActiveSector p) (F.ActiveSector p) ℂ := Q * L
+  have hTC : TC = Matrix.map (F.activeSectorTraceMatrix p) Complex.ofReal := by
+    ext k h
+    simp only [TC, Matrix.mul_apply, Q, L, Matrix.map_apply]
+    change (∑ j, (F.rightTensor (k : Fin F.sectorCount) j).trace *
+      (F.leftTensor (h : Fin F.sectorCount) j).trace) =
+        ((F.neighboringOperator k h).trace.re : ℂ)
+    rw [← (hpos k h).isHermitian.trace_eq_ofReal_re]
+    simp only [neighboringOperator, Matrix.trace, Matrix.diag, Matrix.of_apply]
+    rw [Finset.sum_comm]
+    apply Finset.sum_congr rfl
+    intro j _
+    rw [Finset.mul_sum]
+    rw [Fintype.sum_prod_type]
+    simp_rw [Finset.sum_mul]
+    rw [Finset.sum_comm]
+  refine ⟨lam, hlam, ?_⟩
+  dsimp only
+  have hmap : Matrix.map (lam⁻¹ • F.activeSectorTraceMatrix p) Complex.ofReal =
+      (lam : ℂ)⁻¹ • TC := by
+    rw [hTC]
+    ext k h
+    simp [Matrix.smul_apply, Matrix.map_apply]
+  have hmapHom :
+      Matrix.map (lam⁻¹ • F.activeSectorTraceMatrix p) (⇑Complex.ofRealHom) =
+        (lam : ℂ)⁻¹ • TC := hmap
+  constructor
+  · apply Matrix.map_injective Complex.ofReal_injective
+    change Matrix.map ((lam⁻¹ • F.activeSectorTraceMatrix p) ^ 2) (⇑Complex.ofRealHom) =
+      Matrix.map ((lam⁻¹ • F.activeSectorTraceMatrix p) ^ 3) (⇑Complex.ofRealHom)
+    rw [Matrix.map_pow, Matrix.map_pow, hmapHom]
+    simpa only [Matrix.mul_smul, TC] using
+      (Matrix.pow_two_eq_pow_three_of_rectangular_idempotent
+        ((lam : ℂ)⁻¹ • L) Q hrect)
+  · intro N hN
+    apply Complex.ofReal_injective
+    change Complex.ofRealHom (Matrix.trace ((lam⁻¹ • F.activeSectorTraceMatrix p) ^ N)) =
+      Complex.ofRealHom (Matrix.trace (lam⁻¹ • F.activeSectorTraceMatrix p))
+    rw [AddMonoidHom.map_trace Complex.ofRealHom,
+      AddMonoidHom.map_trace Complex.ofRealHom, Matrix.map_pow, hmapHom]
+    simpa only [Matrix.mul_smul, TC] using
+      (Matrix.trace_pow_eq_trace_of_rectangular_idempotent
+        ((lam : ℂ)⁻¹ • L) Q hrect N hN)
+
+end MPOTensor.PhysicalSectorFactorization
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+  {rho : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+
+/-- The inverse-map physical-sector factorization admits one coherent
+rephasing for which the neighboring operators are positive semidefinite, the
+active trace matrix is primitive, and a common positive source normalization
+gives the square--cube and positive-power trace relations.
+
+**Local fix (inactive sectors):** the physical factorization retains the
+zero-weight sectors; the trace matrix is restricted to the nonzero-weight
+subtype.  See
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+
+**Local fix (periodicity):** primitivity uses closed walks of lengths two and
+three in place of blocking periodic components.  See the same paper-gap note.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemmas C.4--C.5 (`propSN` and
+`SALZCL`), lines 1406--1497.  No idempotence, rank-one, or semisimplicity
+conclusion is made. -/
+theorem exists_rephased_inverseMap_activeSectorTraceMatrix_normalized_relations
+    (K : MPOTensor d D) (hK : K.IsInjective)
+    (R : Matrix (Fin D) (Fin D) ℂ) (hρ : IsThreeSiteClosure K R rho)
+    (hη : EtaStructure rho) (alpha beta : Fin D) (hm : R beta alpha ≠ 0)
+    (hM : IsMPDO K) (hZCL : IsSourceZCL K) :
+    let F := zeroWeightReparameterizedInverseMapPhysicalSectorFactorization
+      K hK R hρ hη alpha beta hm
+    ∃ (z : Fin F.sectorCount → Circle) (lam : ℝ), 0 < lam ∧
+      (∀ k h, ((F.rephase z).neighboringOperator k h).PosSemidef) ∧
+        Matrix.IsPrimitive ((F.rephase z).activeSectorTraceMatrix hη.p) ∧
+          let T := (F.rephase z).activeSectorTraceMatrix hη.p
+          ((lam⁻¹ • T) ^ 2 = (lam⁻¹ • T) ^ 3) ∧
+            ∀ N : ℕ, 0 < N →
+              Matrix.trace ((lam⁻¹ • T) ^ N) = Matrix.trace (lam⁻¹ • T) := by
+  let F := zeroWeightReparameterizedInverseMapPhysicalSectorFactorization
+    K hK R hρ hη alpha beta hm
+  change ∃ (z : Fin F.sectorCount → Circle) (lam : ℝ), 0 < lam ∧
+    (∀ k h, ((F.rephase z).neighboringOperator k h).PosSemidef) ∧
+      Matrix.IsPrimitive ((F.rephase z).activeSectorTraceMatrix hη.p) ∧
+        let T := (F.rephase z).activeSectorTraceMatrix hη.p
+        ((lam⁻¹ • T) ^ 2 = (lam⁻¹ • T) ^ 3) ∧
+          ∀ N : ℕ, 0 < N →
+            Matrix.trace ((lam⁻¹ • T) ^ N) = Matrix.trace (lam⁻¹ • T)
+  obtain ⟨z, hpos, hprim⟩ :=
+    exists_rephased_inverseMap_activeSectorTraceMatrix_isPrimitive
+      K hK R hρ hη alpha beta hm hM
+  have hinactive : ∀ k, hη.p k = 0 →
+      ∀ gamma, (F.rephase z).leftTensor k gamma = 0 := by
+    intro k hk gamma
+    change (z k : ℂ) • sectorTensorL K hK hη R alpha beta k gamma = 0
+    rw [sectorTensorL_eq_zero_of_weight_eq_zero K hK hη R alpha beta k gamma hk,
+      smul_zero]
+  obtain ⟨lam, hlam, hrel⟩ :=
+    (F.rephase z).activeSectorTraceMatrix_normalized_relations_of_isSourceZCL
+      hη.p hinactive hpos hZCL
+  exact ⟨z, lam, hlam, hpos, hprim, hrel⟩
+
+/-- Every injective MPO tensor satisfying the strong area law and source zero
+correlation length admits a positive physical-sector factorization whose
+active trace matrix is primitive and whose common positive normalization
+satisfies the square--cube and positive-power trace relations.
+
+The weights are nonnegative and sum to one.  Zero-weight sectors remain in
+the physical factorization and are omitted only from the auxiliary trace
+matrix.
+
+**Local fix (inactive sectors):** see
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+
+**Local fix (periodicity):** the primitivity proof uses closed walks of lengths
+two and three in place of blocking periodic components.  See the same
+paper-gap note.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemmas C.4--C.5 (`propSN` and
+`SALZCL`), lines 1406--1497.  The conclusion does not include the invalid
+rank-one inference at lines 1498--1499. -/
+theorem exists_activeTraceMatrix_relations_of_isSAL_of_isSourceZCL
+    (K : MPOTensor d D) (hK : K.IsInjective) (hSAL : IsSAL K)
+    (hZCL : IsSourceZCL K) :
+    ∃ (F : PhysicalSectorFactorization K) (p : Fin F.sectorCount → ℝ) (lam : ℝ),
+      0 < lam ∧
+        (∀ k, 0 ≤ p k) ∧
+          (∑ k, p k) = 1 ∧
+            (∀ k h, (F.neighboringOperator k h).PosSemidef) ∧
+              Matrix.IsPrimitive (F.activeSectorTraceMatrix p) ∧
+                let T := F.activeSectorTraceMatrix p
+                ((lam⁻¹ • T) ^ 2 = (lam⁻¹ • T) ^ 3) ∧
+                  ∀ N : ℕ, 0 < N →
+                    Matrix.trace ((lam⁻¹ • T) ^ N) =
+                      Matrix.trace (lam⁻¹ • T) := by
+  obtain ⟨hη⟩ := exists_etaStructure_reducedBlockState_of_isSAL K hSAL
+  obtain ⟨beta, alpha, hm⟩ :=
+    exists_normalizedFourSiteTail_entry_ne_zero
+      K ((Classical.choose_spec hSAL).1 4)
+  let F₀ := zeroWeightReparameterizedInverseMapPhysicalSectorFactorization
+    K hK (normalizedFourSiteTail K)
+      (isThreeSiteClosure_reducedBlockState K) hη alpha beta hm
+  obtain ⟨z, lam, hlam, hpos, hprim, hrel⟩ :=
+    exists_rephased_inverseMap_activeSectorTraceMatrix_normalized_relations
+      K hK (normalizedFourSiteTail K)
+        (isThreeSiteClosure_reducedBlockState K) hη alpha beta hm
+          (Classical.choose hSAL) hZCL
+  exact ⟨F₀.rephase z, hη.p, lam, hlam, hη.hp_nonneg, hη.hp_sum,
+    hpos, hprim, hrel⟩
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity.tex
@@ -358,6 +358,65 @@
     active trace-matrix power is positive. Thus $T$ is primitive.
 \end{proof}
 
+\begin{theorem}[Zero-correlation-length relations on the primitive active trace matrix]%
+    \label{thm:mpdo_active_trace_matrix_zcl_relations}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+      activeSectorTraceMatrix_normalized_relations_of_isSourceZCL}
+    \lean{MPOTensor.%
+      exists_rephased_inverseMap_activeSectorTraceMatrix_normalized_relations}
+    \lean{MPOTensor.%
+      exists_activeTraceMatrix_relations_of_isSAL_of_isSourceZCL}
+    \leanok
+    \uses{def:mpdo_active_sector_trace_matrix,
+      thm:mpdo_sector_trace_matrix_primitive,
+      thm:mpdo_closed_sector_pairing_normalized_idempotent}
+    Let ${\cal K}$ be injective and suppose that it satisfies SAL and source
+    zero correlation length. Then there are a physical-sector factorization,
+    weights $p_k\geq0$ with $\sum_k p_k=1$, and positive semidefinite
+    neighboring operators $\eta_{k,h}$ such that the active trace matrix
+    \[
+        T^*_{k,h}=\operatorname{Re}\tr(\eta_{k,h}),
+        \qquad k,h\in I_*:=\{j:p_j\ne0\},
+    \]
+    is primitive. Moreover, there is a real number $\lambda>0$ for which,
+    upon setting $\widehat T^*:=\lambda^{-1}T^*$,
+    \[
+        (\widehat T^*)^2=(\widehat T^*)^3.
+    \]
+    For every positive integer $N$,
+    \[
+        \tr((\widehat T^*)^N)=\tr(\widehat T^*).
+    \]
+    Thus the primitivity and the two normalized identities concern the same
+    active, positively rephased trace matrix. No idempotence, rank-one, or
+    semisimplicity conclusion is asserted.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_sector_trace_matrix_primitive,
+      thm:mpdo_closed_sector_pairing_normalized_idempotent}
+    Choose the coherent sector phases from
+    Theorem~\ref{thm:mpdo_sector_trace_matrix_primitive}. For the resulting
+    factorization, let $L$ have columns
+    $\bigl(\tr((l_h)_\beta)\bigr)_\beta$ and let $Q$ have rows
+    $\bigl(\tr((r_k)_\alpha)\bigr)_\alpha$, with both indices restricted to
+    $I_*$. The left tensor vanishes when $p_k=0$, so the rectangular product
+    $LQ$ is the full physical-trace transfer. Source zero correlation length
+    therefore makes $\lambda^{-1}LQ$ idempotent for some $\lambda>0$.
+
+    Positivity of the neighboring operators makes their traces real, and
+    hence $QL$ is the complexification of $T^*$. Associativity and cyclicity
+    of trace give
+    \[
+        (\lambda^{-1}QL)^2=(\lambda^{-1}QL)^3,
+        \qquad
+        \tr((\lambda^{-1}QL)^N)=\tr(\lambda^{-1}QL)
+    \]
+    for every $N\geq1$. Injectivity of the real-to-complex inclusion gives
+    the two real matrix identities.
+\end{proof}
+
 \begin{theorem}[Positivity of bipartite partial traces]
     \label{thm:matrix_possemidef_partial_traces}
     \lean{Matrix.PosSemidef.traceLeft}

--- a/docs/paper-gaps/cpgsv17_pf_rank_one.tex
+++ b/docs/paper-gaps/cpgsv17_pf_rank_one.tex
@@ -298,9 +298,37 @@ and
 {\scriptsize\leanid{MPOTensor.closedSectorTraceMatrix_normalized_relations}}
 in \doclink{TNLean/MPS/MPDO/SectorPairingTransfer}.}
 
+The normalized identities can also be placed on the same real trace matrix
+for which the strong-area-law argument proves primitivity.  After discarding
+only the zero-weight indices and choosing the coherent sector phases, set
+\[
+  T^*_{k,h}=\operatorname{Re}\operatorname{tr}(\eta_{k,h})
+  \qquad (p_kp_h\ne0).
+\]
+The left tensor of every zero-weight sector vanishes.  Consequently the
+physical-trace transfer still has the active rectangular factorization
+$LQ$, while positivity of the neighboring operators identifies $QL$ with
+the complexification of $T^*$.  The same scalar $\lambda>0$ therefore gives
+\[
+  T^*\ \text{primitive},
+  \qquad
+  (\lambda^{-1}T^*)^2=(\lambda^{-1}T^*)^3,
+  \qquad
+  \operatorname{tr}((\lambda^{-1}T^*)^N)
+    =\operatorname{tr}(\lambda^{-1}T^*)
+\]
+for every positive integer $N$.
+\footnote{\sloppy Formal declarations:
+{\scriptsize\leanid{MPOTensor.PhysicalSectorFactorization.activeSectorTraceMatrix_normalized_relations_of_isSourceZCL}},
+{\scriptsize\leanid{MPOTensor.exists_rephased_inverseMap_activeSectorTraceMatrix_normalized_relations}},
+and
+{\scriptsize\leanid{MPOTensor.exists_activeTraceMatrix_relations_of_isSAL_of_isSourceZCL}}
+in \doclink{TNLean/MPS/MPDO/InverseMapActiveSectorZCL}.}
+
 This conclusion is the scale-invariant consequence of the displayed operator
-equation; it does not imply that the normalized trace matrix is
-idempotent or has rank one.  The remaining pairing route would have to prove
+equation; it does not imply that the normalized trace matrix is idempotent or
+semisimple, nor that it has rank one.  The remaining pairing route would have
+to prove
 linear independence of one of the two closed tensor families, or supply a
 different argument excluding the generalized zero-eigenspace.  The direct sum
 in the source's sector splitting at lines 1436--1448 concerns the physical


### PR DESCRIPTION
### Motivation

- Appendix C.2 of arXiv:1606.00608 places primitivity and the zero-correlation-length identities on a single sector trace matrix before its disputed rank-one step.
- The existing development proved these ingredients separately. This change identifies their common positively rephased active matrix without assuming idempotence, rank one, semisimplicity, or linear independence.

Source: `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 1406--1497, especially Lemmas C.4--C.5 and the displays labelled `Tkn` and `SALZCL`.

### Description

- Prove that source zero correlation length gives, on the active sector trace matrix, a positive normalization satisfying
  `T̂² = T̂³` and `tr(T̂^N) = tr(T̂)` for every positive `N`.
- Combine this rectangular-product argument with the coherent positive rephasing and active-sector primitivity already obtained from the strong area law.
- Add the corresponding blueprint theorem and update `docs/paper-gaps/cpgsv17_pf_rank_one.tex` to distinguish the completed common-matrix statement from the unresolved generalized zero-eigenspace.
- Deliberately leave the rank-one conclusion open: the source argument still needs an additional property of the concrete inverse-map tensors that excludes the nilpotent zero-eigenspace.

### Testing

- `lake env lean TNLean/MPS/MPDO/InverseMapActiveSectorZCL.lean`
- `lake build`
- `cd blueprint && leanblueprint checkdecls`
- `cd blueprint && leanblueprint web`
- `cd blueprint && leanblueprint pdf`
- Axiom audit: the two factorization-level theorems use only standard Lean axioms; the SAL extraction theorem uses the repository-sanctioned `hayashi_ssa_equality_characterization_forward` already underlying the SAL-to-Hayashi decomposition.

---
Addresses #3593

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes formal lemmas on the MPDO Appendix C.2 proof track (SAL/ZCL pairing), but they are additive proofs and documentation with no runtime or security surface; incorrect wiring could misstate what is proved versus still open for rank-one.
> 
> **Overview**
> **Unifies primitivity and zero-correlation-length (ZCL) on one matrix.** New module `InverseMapActiveSectorZCL.lean` shows that when zero-weight sectors vanish on the left tensor and neighboring operators are PSD, **source ZCL** gives a positive scale \(\lambda\) so the **active** trace matrix \(\widehat T = \lambda^{-1} T^*\) satisfies \(\widehat T^2 = \widehat T^3\) and \(\mathrm{tr}(\widehat T^N) = \mathrm{tr}(\widehat T)\) for all \(N \geq 1\). The proof restricts the physical-trace transfer to an active rectangular factorization \(LQ\), uses ZCL idempotence on \(\lambda^{-1}LQ\), and transfers identities to the real active matrix via \(QL\) as its complexification.
> 
> **Stacks on existing SAL/inverse-map infrastructure.** `exists_rephased_inverseMap_activeSectorTraceMatrix_normalized_relations` combines coherent rephasing, PSD neighbors, primitivity (from `InverseMapActiveSectorPrimitivity`), and these ZCL relations. `exists_activeTraceMatrix_relations_of_isSAL_of_isSourceZCL` extracts the same bundle from **SAL + source ZCL** for injective MPO tensors.
> 
> **Docs and surface.** Root import `TNLean.lean` exposes the module; blueprint **Theorem** `thm:mpdo_active_trace_matrix_zcl_relations` and `docs/paper-gaps/cpgsv17_pf_rank_one.tex` record that primitivity and normalized identities now target the **same** active matrix, while **rank-one / idempotence / semisimplicity** remain explicitly open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d810e9289885c3eb95d58a8494c4b2d20ef64400. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->