### PR TITLE
feat(MPS/MPDO): retain vertical sectors through normalization

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -388,6 +388,7 @@ import TNLean.MPS.MPDO.VerticalReduction
 import TNLean.MPS.MPDO.PeriodicExclusion
 import TNLean.MPS.MPDO.StackedLayers
 import TNLean.MPS.MPDO.CyclicProjector
+import TNLean.MPS.MPDO.VerticalSpectral
 import TNLean.MPS.MPDO.SectorTrace
 import TNLean.MPS.MPDO.BiCFDerivation
 import TNLean.MPS.MPDO.ZCL

--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -105,10 +105,11 @@ The periodic sectors are excluded in `TNLean.MPS.MPDO.CyclicProjector`, and
 `TNLean.MPS.MPDO.VerticalReduction` constructs a complete orthogonal family of
 irreducible reducing vertical corners. The general theorem in
 `TNLean.MPS.CanonicalForm.ProjectorClosureSpectral` gives an abstract
-positive-length normal-block decomposition. What remains open is a refinement
-that retains the physical isometries and reducing projections through
-zero-corner removal and normalization, followed by the BNT grouping,
-positivity, and gauge analysis needed for the final vertical canonical form.
+positive-length normal-block decomposition, while
+`TNLean.MPS.MPDO.VerticalSpectral` removes zero corners and normalizes the
+remaining corners without losing their physical isometries or the literal
+letterwise reconstruction. What remains open is the BNT grouping, positivity,
+and gauge analysis needed for the final vertical canonical form.
 
 ## Module location
 

--- a/TNLean/MPS/MPDO/VerticalSpectral.lean
+++ b/TNLean/MPS/MPDO/VerticalSpectral.lean
@@ -1,0 +1,160 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.CanonicalForm.ProjectorClosureSpectral
+import TNLean.MPS.MPDO.CyclicProjector
+import TNLean.MPS.MPDO.VerticalReduction
+
+/-!
+# Spectral normalization of the vertical reducing sectors
+
+This file retains the physical sector isometries from the vertical reducing
+decomposition while removing zero corners and normalizing every remaining
+corner to spectral radius one.
+
+The construction is the isometry-preserving form of the canonical-form steps
+in arXiv:1606.00608, lines 214--225, applied after the invariant-projection and
+periodic-sector arguments of Proposition 4.13, lines 1873--1893.  It gives a
+literal reconstruction of every vertical letter on the retained support.  It
+does not yet group gauge-equivalent normal tensors into a basis of normal
+tensors or prove positivity of the grouped multiplicity weights at lines
+1895--1921.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- Spectrally normalized nonzero vertical corners, with their physical
+isometries retained.
+
+Let `M` be a horizontally canonical MPO tensor generating matrix product
+density operators.  The nonzero irreducible reducing corners of its vertically
+viewed tensor can be written as positive scalar multiples of normal tensors.
+Their physical isometries remain pairwise orthogonal, both intertwining
+identities and the exact compression formula are preserved, and the retained
+corners reconstruct every vertical letter literally.
+
+The omitted irreducible corners have every letter equal to zero.  Consequently
+the retained range projections need not sum to the physical identity, but
+their orthogonal complement is a zero sector.  This is the zero-corner removal
+allowed by arXiv:1606.00608, lines 216--225, and supplies the sector embeddings
+used at lines 1895--1898 of Proposition 4.13. -/
+theorem IsHorizontalCF.exists_normal_verticalBlockDecomp_with_isometry
+    (M : MPOTensor d D) (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M) :
+    ∃ (r : ℕ) (dim : Fin r → ℕ) (μ : Fin r → ℂ)
+      (blocks : (k : Fin r) → MPSTensor (D * D) (dim k))
+      (V : (k : Fin r) → Matrix (Fin d) (Fin (dim k)) ℂ),
+      (∀ k, 0 < dim k) ∧
+      (∀ k, (0 : ℂ) < μ k) ∧
+      (∀ k, MPSTensor.IsNormalTensor (blocks k)) ∧
+      (∀ k, (V k)ᴴ * V k = 1) ∧
+      (∀ k l, k ≠ l → (V k)ᴴ * V l = 0) ∧
+      (∀ k v, verticalTensor M v * V k = V k * (μ k • blocks k v)) ∧
+      (∀ k v, (V k)ᴴ * verticalTensor M v = (μ k • blocks k v) * (V k)ᴴ) ∧
+      (∀ k v, μ k • blocks k v = (V k)ᴴ * verticalTensor M v * V k) ∧
+      ∀ v, verticalTensor M v =
+        ∑ k, V k * (μ k • blocks k v) * (V k)ᴴ := by
+  classical
+  obtain ⟨r₀, dim₀, blocks₀, V₀, hpos, hiso, hsum, horth, hint, hintStar,
+    hcorner, hirr, _hMPV⟩ :=
+    hHorizontal.exists_irreducible_verticalBlockDecomp_with_isometry M hM
+  have hPF : ∀ k : Fin r₀, (∃ v, blocks₀ k v ≠ 0) →
+      ∃ (ρ : Matrix (Fin (dim₀ k)) (Fin (dim₀ k)) ℂ) (t : ℝ),
+        ρ.PosDef ∧ 0 < t ∧
+        MPSTensor.transferMap (d := D * D) (D := dim₀ k) (blocks₀ k) ρ =
+          (t : ℂ) • ρ := by
+    intro k hk
+    haveI : NeZero (dim₀ k) := ⟨(hpos k).ne'⟩
+    exact MPSTensor.exists_posDef_transferMap_eigenvector_of_irreducible
+      (blocks₀ k) (hirr k) hk
+  choose ρf tf hρf htf hEigf using hPF
+  let κ := {k : Fin r₀ // ∃ v, blocks₀ k v ≠ 0}
+  let e : Fin (Fintype.card κ) ≃ κ := (Fintype.equivFin κ).symm
+  let μf : κ → ℂ := fun x => ((Real.sqrt (tf x.1 x.2) : ℝ) : ℂ)
+  let normalized : (x : κ) → MPSTensor (D * D) (dim₀ x.1) := fun x v =>
+    (μf x)⁻¹ • blocks₀ x.1 v
+  have hμpos : ∀ x : κ, (0 : ℂ) < μf x := by
+    intro x
+    change (0 : ℂ) < ((Real.sqrt (tf x.1 x.2) : ℝ) : ℂ)
+    exact Complex.zero_lt_real.mpr (Real.sqrt_pos.mpr (htf x.1 x.2))
+  have hμne : ∀ x : κ, μf x ≠ 0 := fun x => (hμpos x).ne'
+  have hrecover : ∀ (x : κ) (v : Fin (D * D)),
+      μf x • normalized x v = blocks₀ x.1 v := by
+    intro x v
+    simp only [normalized, smul_smul, mul_inv_cancel₀ (hμne x), one_smul]
+  have hPer := hasNoPeriodicVectors_verticalTensor_of_horizontalCF M hM hHorizontal
+  refine ⟨Fintype.card κ, fun j => dim₀ (e j).1, fun j => μf (e j),
+    fun j => normalized (e j), fun j => V₀ (e j).1,
+    fun j => hpos (e j).1, fun j => hμpos (e j), ?_,
+    fun j => hiso (e j).1, ?_, ?_, ?_, ?_, ?_⟩
+  · intro j
+    haveI : NeZero (dim₀ (e j).1) := ⟨(hpos (e j).1).ne'⟩
+    exact MPSTensor.isNormalTensor_invSqrt_smul_of_unique_peripheral
+      (blocks₀ (e j).1) (hirr (e j).1)
+      (ρf (e j).1 (e j).2) (tf (e j).1 (e j).2)
+      (hρf (e j).1 (e j).2) (htf (e j).1 (e j).2)
+      (hEigf (e j).1 (e j).2)
+      (fun z hz hnorm =>
+        hPer (V₀ (e j).1) (blocks₀ (e j).1)
+          (ρf (e j).1 (e j).2) (tf (e j).1 (e j).2)
+          (hiso (e j).1) (hint (e j).1) (hirr (e j).1)
+          (hρf (e j).1 (e j).2) (htf (e j).1 (e j).2)
+          (hEigf (e j).1 (e j).2) z hz hnorm)
+  · intro j l hjl
+    exact horth (e j).1 (e l).1 fun h => hjl (e.injective (Subtype.ext h))
+  · intro j v
+    rw [hrecover]
+    exact hint (e j).1 v
+  · intro j v
+    rw [hrecover]
+    exact hintStar (e j).1 v
+  · intro j v
+    rw [hrecover]
+    exact hcorner (e j).1 v
+  · intro v
+    have hfull : verticalTensor M v =
+        ∑ k : Fin r₀, V₀ k * blocks₀ k v * (V₀ k)ᴴ := by
+      calc
+        verticalTensor M v = verticalTensor M v * 1 :=
+          (Matrix.mul_one _).symm
+        _ = verticalTensor M v * ∑ k : Fin r₀, V₀ k * (V₀ k)ᴴ := by
+          rw [hsum]
+        _ = ∑ k : Fin r₀, verticalTensor M v * (V₀ k * (V₀ k)ᴴ) := by
+          rw [Matrix.mul_sum]
+        _ = ∑ k : Fin r₀, V₀ k * blocks₀ k v * (V₀ k)ᴴ := by
+          refine Finset.sum_congr rfl fun k _ => ?_
+          rw [← Matrix.mul_assoc, hint k v, Matrix.mul_assoc]
+    have hkeep :
+        ∑ k ∈ Finset.univ.filter (fun k => ∃ w, blocks₀ k w ≠ 0),
+            V₀ k * blocks₀ k v * (V₀ k)ᴴ =
+          ∑ k : Fin r₀, V₀ k * blocks₀ k v * (V₀ k)ᴴ := by
+      refine Finset.sum_filter_of_ne ?_
+      intro k _ hne
+      by_contra hk
+      push Not at hk
+      exact hne (by rw [hk v, Matrix.mul_zero, Matrix.zero_mul])
+    have hsubtype :
+        ∑ k ∈ Finset.univ.filter (fun k => ∃ w, blocks₀ k w ≠ 0),
+            V₀ k * blocks₀ k v * (V₀ k)ᴴ =
+          ∑ x : κ, V₀ x.1 * blocks₀ x.1 v * (V₀ x.1)ᴴ :=
+      Finset.sum_subtype _ (by simp) _
+    calc
+      verticalTensor M v =
+          ∑ k : Fin r₀, V₀ k * blocks₀ k v * (V₀ k)ᴴ := hfull
+      _ = ∑ x : κ, V₀ x.1 * blocks₀ x.1 v * (V₀ x.1)ᴴ := by
+        rw [← hkeep, hsubtype]
+      _ = ∑ j : Fin (Fintype.card κ),
+          V₀ (e j).1 * blocks₀ (e j).1 v * (V₀ (e j).1)ᴴ :=
+        (Equiv.sum_comp e
+          (fun x : κ => V₀ x.1 * blocks₀ x.1 v * (V₀ x.1)ᴴ)).symm
+      _ = ∑ j : Fin (Fintype.card κ),
+          V₀ (e j).1 * (μf (e j) • normalized (e j) v) * (V₀ (e j).1)ᴴ := by
+        refine Finset.sum_congr rfl fun j _ => ?_
+        rw [hrecover]
+
+end MPOTensor

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -2238,6 +2238,50 @@
     intertwining identities give the four assertions directly.
 \end{proof}
 
+\begin{theorem}[Spectrally normalized vertical sectors with physical isometries]
+    \label{thm:mpdo_vertical_normal_sectors_with_isometries}
+    \lean{MPOTensor.IsHorizontalCF.exists_normal_verticalBlockDecomp_with_isometry}
+    \leanok
+    \uses{thm:mpdo_vertical_irreducible_reducing_sectors,
+        thm:mpdo_vertical_no_periodic_vectors_horizontal_cf,
+        lem:irreducible_transfer_perron_pair,
+        lem:irreducible_block_spectral_normalization}
+    Under the same hypotheses, there are positive integers $d_k$, positive
+    scalars $\mu_k$, normal tensors $B_k$ of bond dimension $d_k$, and
+    isometries $V_k:\C^{d_k}\to\C^d$ with pairwise orthogonal ranges. For
+    every sector $k$ and every vertical letter $v$,
+    \[
+        \widetilde M_vV_k=V_k(\mu_kB_k^v),
+        \qquad
+        V_k^\dagger\widetilde M_v=(\mu_kB_k^v)V_k^\dagger,
+        \qquad
+        \mu_kB_k^v=V_k^\dagger\widetilde M_vV_k.
+    \]
+    Moreover, every vertical letter is reconstructed literally by
+    \[
+        \widetilde M_v
+        =\sum_k V_k(\mu_kB_k^v)V_k^\dagger.
+    \]
+    The omitted irreducible corners have all their letters equal to zero.
+    Hence the retained range projections need not sum to the identity, but
+    their orthogonal complement is a zero sector.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_vertical_irreducible_reducing_sectors,
+        thm:mpdo_vertical_no_periodic_vectors_horizontal_cf,
+        lem:irreducible_transfer_perron_pair,
+        lem:irreducible_block_spectral_normalization}
+    Retain exactly the irreducible corners containing a nonzero letter. The
+    Perron--Frobenius eigenvalue of each retained corner is positive, and the
+    absence of nontrivial periodic vectors makes the inverse-square-root
+    rescaling normal. Put the removed square root into $\mu_k$ and reindex the
+    retained corners. The original complete reducing decomposition expresses
+    each vertical letter as the sum of all compressed corners; every omitted
+    summand vanishes, which gives the displayed reconstruction.
+\end{proof}
+
 \begin{theorem}[Horizontal canonical form implies vertical canonical form]
     \label{thm:vertical_cf_of_horizontal_cf}
     \notready
@@ -2250,6 +2294,7 @@
         thm:mpdo_vertical_projector_closure,
         thm:mpdo_vertical_irreducible_reducing_sectors,
         thm:mpdo_vertical_complete_reducing_projectors,
+        thm:mpdo_vertical_normal_sectors_with_isometries,
         thm:projector_closure_canonical_form,
         thm:mpdo_sector_compression_trace_pos,
         def:mpdo_sector_projector,
@@ -2313,13 +2358,12 @@
     decomposes the physical space into complete orthogonal irreducible
     reducing sectors, and
     Theorem~\ref{thm:mpdo_vertical_complete_reducing_projectors} records their
-    commuting range projections. Together with the absence of periodic
-    vectors, Theorem~\ref{thm:projector_closure_canonical_form} already gives
-    an abstract positive-length decomposition into normal blocks. That theorem
-    does not retain the physical isometries and reducing projections. The
-    source argument requires a refinement that retains this data through
-    zero-corner removal and spectral normalization, and then groups the
-    resulting normal tensors, obtaining
+    commuting range projections. Theorem~\ref{thm:mpdo_vertical_normal_sectors_with_isometries}
+    removes the zero corners and spectrally normalizes the remaining corners
+    while retaining their physical isometries, both intertwining identities,
+    exact compression, and literal reconstruction of every vertical letter.
+    The remaining source argument must group the resulting normal tensors,
+    obtaining
     \[
         \widetilde M
         =\bigoplus_{\alpha,k}\mu_{\alpha,k}X_{\alpha,k}M_\alpha X_{\alpha,k}^{-1}

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -2262,9 +2262,6 @@
         \widetilde M_v
         =\sum_k V_k(\mu_kB_k^v)V_k^\dagger.
     \]
-    The omitted irreducible corners have all their letters equal to zero.
-    Hence the retained range projections need not sum to the identity, but
-    their orthogonal complement is a zero sector.
 \end{theorem}
 
 \begin{proof}
@@ -2279,7 +2276,9 @@
     rescaling normal. Put the removed square root into $\mu_k$ and reindex the
     retained corners. The original complete reducing decomposition expresses
     each vertical letter as the sum of all compressed corners; every omitted
-    summand vanishes, which gives the displayed reconstruction.
+    summand vanishes, which gives the displayed reconstruction. Thus the
+    retained range projections need not sum to the identity, but their
+    orthogonal complement is a zero sector.
 \end{proof}
 
 \begin{theorem}[Horizontal canonical form implies vertical canonical form]

--- a/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
@@ -140,6 +140,14 @@ vectors at every length
 Its range projections are complete, pairwise orthogonal, and commute with all
 vertical letters
 (\path{MPOTensor.IsHorizontalCF.exists_complete_verticalReducingProjectors}).
+The nonzero corners can moreover be spectrally normalized without losing
+their physical embeddings: the resulting blocks are normal, their weights
+are positive, both intertwining identities and exact compression remain, and
+the retained sectors reconstruct every vertical letter literally
+(\path{MPOTensor.IsHorizontalCF.exists_normal_verticalBlockDecomp_with_isometry}
+in \path{TNLean/MPS/MPDO/VerticalSpectral.lean}).  The complement of their
+range projections consists precisely of the omitted zero corners, so no
+false completeness assertion is made after this removal.
 
 The periodic-sector exclusion is also complete:
 \path{MPOTensor.hasNoPeriodicVectors_verticalTensor_of_horizontalCF} derives
@@ -170,15 +178,11 @@ $\omega_{\alpha,k}^{-1/2}X_{\alpha,k}$ unitary
 (\path{MPSTensor.IsNormal.smul_mem_unitaryGroup_of_dressed_adjoint} in
 \path{TNLean/MPS/CanonicalForm/NormalCommutant.lean}).
 
-Projector closure together with the absence of periodic vectors already gives
-an abstract positive-length decomposition into normal blocks
-(\path{TNLean/MPS/CanonicalForm/ProjectorClosureSpectral.lean}).
-This theorem does not retain the physical isometries and reducing projections
-constructed above. The remaining source-level gap is the refinement that
-retains this data through zero-corner removal and spectral normalization,
-groups gauge-equivalent normal tensors, identifies the resulting grouped
-projections with the sector projectors carrying the single-site loop
-identities, and proves a nonvanishing compression. One must then derive the
+The remaining source-level gap begins with grouping the normalized corners
+above into gauge-equivalent copies of a basis of normal tensors.  One must
+identify the resulting grouped projections with the sector projectors
+carrying the single-site loop identities and prove a nonvanishing
+compression. One must then derive the
 dressed-adjoint identities from self-adjointness of the sector compressions
 and assemble the positive weights and proportional-unitary gauges of source
 lines~1895--1921. This is the mathematical content shared with the normality

--- a/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
@@ -156,6 +156,11 @@ Invariant-projector closure is also established for the vertically viewed
 tensor, and it gives a complete orthogonal family of irreducible reducing
 corners with exact physical isometries
 (\path{TNLean/MPS/MPDO/VerticalReduction.lean}).
+After discarding precisely the zero corners, the remaining corners are
+spectrally normalized to normal tensors while retaining those isometries,
+both intertwining identities, exact compression, and literal reconstruction
+of every vertical letter
+(\path{TNLean/MPS/MPDO/VerticalSpectral.lean}).
 
 The third stage now has conditional formalizations of its two closing
 arguments.  Granted orthogonal sector projectors whose insertion into the
@@ -174,10 +179,10 @@ has scalar commutant
 (\path{TNLean/MPS/CanonicalForm/NormalCommutant.lean}). Projector closure and
 the absence of periodic vectors already give an abstract positive-length
 normal-block decomposition
-(\path{TNLean/MPS/CanonicalForm/ProjectorClosureSpectral.lean}). What remains
-open is the refinement that retains the physical isometries and reducing
-projections through zero-corner removal and spectral normalization, and then
-groups the normal blocks. This must identify the grouped sector projectors
+(\path{TNLean/MPS/CanonicalForm/ProjectorClosureSpectral.lean}). The literal
+isometry-preserving refinement is now supplied by
+\path{TNLean/MPS/MPDO/VerticalSpectral.lean}. What remains open is to group
+the normal blocks. This must identify the grouped sector projectors
 with their loop identities and a nonvanishing compression, together with the
 derivation of the dressed-adjoint identities from self-adjointness of the
 sector compressions.


### PR DESCRIPTION
## Summary

This PR retains the physical sector isometries while removing zero vertical
corners and spectrally normalizing every remaining irreducible corner.  It
proves, for each vertical letter, both intertwining identities, exact
compression, and a literal reconstruction as the sum over the retained
sectors.

The retained range projections are not asserted to sum to the identity.  The
reconstruction proof starts from the complete reducing decomposition and
removes exactly those summands whose corner tensor is identically zero, so the
orthogonal complement of the retained ranges is a zero sector.

The blueprint and the two relevant paper-gap notes now record that this
isometry-preserving normalization step is complete.  They continue to mark as
open the grouping into gauge-equivalent copies of a basis of normal tensors,
the loop-sector identifications and nonvanishing compressions, and the
positivity and proportional-unitary gauge arguments.

## Source

- arXiv:1606.00608, lines 214–225: zero-corner removal and spectral
  normalization in the general canonical-form construction
- arXiv:1606.00608, Proposition 4.13, lines 1895–1898: physical sector data
  needed for the vertical canonical form
- `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`
- `docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex`

## Verification

- `lake env lean TNLean/MPS/MPDO/VerticalSpectral.lean`
- `lake env lean TNLean/MPS/MPDO/VerticalCF.lean`
- `lake env lean TNLean.lean`
- `lake build TNLean.MPS.MPDO.VerticalSpectral`
- `lake build TNLean` (9,383 jobs)
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- changed-declaration blueprint coverage check
- `lake exe checkdecls blueprint/lean_decls`
- `leanblueprint pdf`, followed by visual inspection of the affected pages
- standalone PDF builds and visual inspection of both revised paper-gap notes
- `python3 scripts/check_reader_facing_prose.py --base-ref origin/main`
- static proof-integrity scan

The new theorem's `#print axioms` result is exactly `propext`,
`Classical.choice`, and `Quot.sound`.  This PR introduces no `sorry`, `axiom`,
`native_decide`, `unsafeCast`, or other proof bypass.

Closes #3876.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization and documentation on the MPDO vertical canonical-form track; no runtime, auth, or data-path changes. Residual risk is mathematical correctness of the new Lean proof, not production system impact.
> 
> **Overview**
> Adds **`TNLean/MPS/MPDO/VerticalSpectral.lean`** and the theorem `IsHorizontalCF.exists_normal_verticalBlockDecomp_with_isometry`, which starts from the irreducible vertical block decomposition and **drops identically zero corners**, **rescales** each retained corner by its Perron–Frobenius scale (weights in **μ_k**, blocks **normal**), and **keeps the original physical isometries** **V_k** and all intertwining/compression identities. It also proves **literal letterwise reconstruction** \(\widetilde M_v = \sum_k V_k(\mu_k B_k^v)V_k^\dagger\) without claiming the retained projectors sum to the identity—the complement is a **zero sector**, matching the source’s allowed removal step.
> 
> The root import, **`VerticalCF.lean`** roadmap text, blueprint **`thm:mpdo_vertical_normal_sectors_with_isometries`**, and the vertical-CF **paper-gap** notes are updated to record this step as **done** and to narrow what is still open to **BNT grouping**, sector-projector identification, and positivity/gauge arguments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 313a933c9d63fc8781aee9f01bab5a28e0d22a63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->