### PR TITLE
feat(MPS/RFP): define physical zero correlation length

### DIFF
--- a/TNLean/MPS/RFP/ZeroCorrelationLength.lean
+++ b/TNLean/MPS/RFP/ZeroCorrelationLength.lean
@@ -17,6 +17,7 @@ tensors, following arXiv:1606.00608 Section 3.2
 
 The following conditions are introduced:
 
+* `IsPhysicalCID A` — the source condition for all disjoint physical regions.
 * `IsPositiveGapPhysicalCID A` — physical block-observable correlations are
   independent of distance when both complementary gaps are positive.
 * `IsCID A` — the stronger virtual-insertion CID condition used by the current
@@ -25,13 +26,15 @@ The following conditions are introduced:
   transfer-map idempotence.
 * `IsBNTLocallyOrthogonal blocks` — the source BNT-level mixed-sector
   equations.
+* `IsPhysicalBNTZCL A blocks` — the source BNT zero-correlation-length
+  condition.
 * `IsBNTZCL A blocks` — the older virtual-insertion BNT surrogate.
 * `IsPositiveGapBNTZCL A blocks` — the physical positive-gap BNT condition.
 * `IsZCL A` — the conjunction of local orthogonality and CID.
 
 The proved local result identifies this single-block convention with an
-idempotent transfer map (`IsRFP`).  Neither BNT predicate records the source
-condition for all disjoint regions; the full BNT-level ZCL theorem is tracked in
+idempotent transfer map (`IsRFP`). The source BNT predicate is now stated, but
+its equivalence with transfer idempotence remains open and is tracked in
 `docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex`.
 -/
 
@@ -70,6 +73,25 @@ noncomputable def physicalTwoPointExpectation (A : MPSTensor d D)
     (physicalObservableTransfer A L₂ O₂ ∘ₗ ((transferMap A) ^ n₂) ∘ₗ
       physicalObservableTransfer A L₁ O₁ ∘ₗ ((transferMap A) ^ n₁))
 
+/-- Physical correlations independent of distance in the sense of
+arXiv:1606.00608, Definition 3.3 (lines 437--445): for two observables on
+disjoint contiguous regions, translating one region without crossing the
+other does not change the expectation. In the periodic-chain formula at
+lines 490--496, the two complementary gap lengths may therefore be
+redistributed while their sum, and hence the chain length, remains fixed.
+
+The physical block lengths are positive, as the source regions are nonempty.
+The gap lengths are arbitrary natural numbers. In particular, a zero gap
+represents adjacent regions, as permitted by the source definition. -/
+def IsPhysicalCID (A : MPSTensor d D) : Prop :=
+  ∀ (L₁ L₂ : ℕ)
+    (O₁ : Matrix (Fin L₁ → Fin d) (Fin L₁ → Fin d) ℂ)
+    (O₂ : Matrix (Fin L₂ → Fin d) (Fin L₂ → Fin d) ℂ)
+    (n₁ n₂ m₁ m₂ : ℕ),
+    1 ≤ L₁ → 1 ≤ L₂ → n₁ + n₂ = m₁ + m₂ →
+    physicalTwoPointExpectation A L₁ L₂ O₁ O₂ n₁ n₂ =
+      physicalTwoPointExpectation A L₁ L₂ O₁ O₂ m₁ m₂
+
 /-- Positive-gap physical correlations independent of distance, in the transfer
 formula surrounding arXiv:1606.00608, Definition 3.3 (lines 437--445) and the
 two-observable formula at lines 490--496: translating either physical block
@@ -77,8 +99,9 @@ observable through the unobserved part of a fixed periodic chain does not change
 two-region expectation.  Thus the two complementary gaps may change while
 their sum, and hence the chain length, remains fixed.
 
-The definition permits observables on blocks of arbitrary finite lengths and
-does not replace physical observables by arbitrary virtual bond matrices.
+The definition permits observables on blocks of arbitrary positive finite
+lengths and does not replace physical observables by arbitrary virtual bond
+matrices.
 
 **Scope restriction (arXiv:1606.00608, Definition 3.3):** the source quantifies
 over all disjoint regions, including adjacent regions.  Here both complementary
@@ -91,9 +114,18 @@ def IsPositiveGapPhysicalCID (A : MPSTensor d D) : Prop :=
     (O₁ : Matrix (Fin L₁ → Fin d) (Fin L₁ → Fin d) ℂ)
     (O₂ : Matrix (Fin L₂ → Fin d) (Fin L₂ → Fin d) ℂ)
     (n₁ n₂ m₁ m₂ : ℕ),
+    1 ≤ L₁ → 1 ≤ L₂ →
     1 ≤ n₁ → 1 ≤ n₂ → 1 ≤ m₁ → 1 ≤ m₂ → n₁ + n₂ = m₁ + m₂ →
     physicalTwoPointExpectation A L₁ L₂ O₁ O₂ n₁ n₂ =
       physicalTwoPointExpectation A L₁ L₂ O₁ O₂ m₁ m₂
+
+/-- Physical CID implies its positive-gap restriction. This is the direct
+restriction of arXiv:1606.00608, Definition 3.3 (lines 437--445), to positive
+complementary gaps. -/
+theorem isPositiveGapPhysicalCID_of_isPhysicalCID (A : MPSTensor d D)
+    (hCID : IsPhysicalCID A) : IsPositiveGapPhysicalCID A := by
+  intro L₁ L₂ O₁ O₂ n₁ n₂ m₁ m₂ hL₁ hL₂ _ _ _ _ hsum
+  exact hCID L₁ L₂ O₁ O₂ n₁ n₂ m₁ m₂ hL₁ hL₂ hsum
 
 /-- Virtual-insertion correlations independent of distance: the connected
 two-point expression through the transfer map is constant in the separation
@@ -129,7 +161,7 @@ does not identify $\mathbb{E}^0$ with $\mathbb{E}$.  This is recorded in
 `docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex`. -/
 theorem isPositiveGapPhysicalCID_of_isRFP (A : MPSTensor d D) (hRFP : IsRFP A) :
     IsPositiveGapPhysicalCID A := by
-  intro L₁ L₂ O₁ O₂ n₁ n₂ m₁ m₂ hn₁ hn₂ hm₁ hm₂ _
+  intro L₁ L₂ O₁ O₂ n₁ n₂ m₁ m₂ _ _ hn₁ hn₂ hm₁ hm₂ _
   have hIdem : IsIdempotentElem (transferMap A) := hRFP
   have hpow_n₁ : (transferMap A) ^ n₁ = transferMap A :=
     hIdem.pow_eq (by omega)
@@ -178,6 +210,16 @@ lemma isBNTLocallyOrthogonal_iff
       ∀ j j' : Fin g, j ≠ j' → mixedTransferMap₂ (blocks j) (blocks j') = 0 :=
   Iff.rfl
 
+/-- BNT zero correlation length in the source sense of arXiv:1606.00608,
+Definition 3.6 (lines 476--478): `blocks` is a basis of normal tensors for
+`A`, the physical correlations of `A` satisfy Definition 3.3 (lines 437--445),
+and distinct BNT components satisfy the local-orthogonality equations of
+Definition 3.5 (lines 467--474). -/
+def IsPhysicalBNTZCL (A : MPSTensor d D)
+    (blocks : (j : Fin g) → MPSTensor d (dim j)) : Prop :=
+  IsCPSVBasisOfNormalTensors A (fun j => ⟨dim j, blocks j⟩) ∧
+    IsPhysicalCID A ∧ IsBNTLocallyOrthogonal blocks
+
 /-- BNT-level virtual-insertion zero correlation length: `blocks` is a basis of
 normal tensors for `A`, the virtual correlator is independent of distance, and
 the mixed-sector local-orthogonality equations hold.
@@ -225,6 +267,15 @@ lemma isPositiveGapBNTZCL_iff (A : MPSTensor d D)
       IsCPSVBasisOfNormalTensors A (fun j => ⟨dim j, blocks j⟩) ∧
         IsPositiveGapPhysicalCID A ∧ IsBNTLocallyOrthogonal blocks :=
   Iff.rfl
+
+/-- Source BNT zero correlation length implies its positive-gap restriction.
+The CID component is restricted from all disjoint regions in arXiv:1606.00608,
+Definition 3.3 (lines 437--445), while the BNT and local-orthogonality
+components of Definition 3.6 (lines 476--478) are unchanged. -/
+theorem isPositiveGapBNTZCL_of_isPhysicalBNTZCL (A : MPSTensor d D)
+    (blocks : (j : Fin g) → MPSTensor d (dim j))
+    (hZCL : IsPhysicalBNTZCL A blocks) : IsPositiveGapBNTZCL A blocks := by
+  exact ⟨hZCL.1, isPositiveGapPhysicalCID_of_isPhysicalCID A hZCL.2.1, hZCL.2.2⟩
 
 /-- Zero correlation length in the single-block convention: a tensor has ZCL
 when it satisfies the local idempotence convention above and has correlations

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -442,6 +442,7 @@ and rates for the single-tensor transfer map $\E_A$.
     regions, then it has positive-gap BNT zero correlation length.
 \end{lemma}
 \begin{proof}\leanok
+    \uses{lem:is_positive_gap_physical_cid_of_physical_cid}
     Restrict the physical distance-independence condition to configurations in
     which both complementary gaps are positive. The BNT relation and local
     orthogonality are unchanged.

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -423,7 +423,8 @@ and rates for the single-tensor transfer map $\E_A$.
 
 \begin{definition}[BNT zero correlation length]%
     \label{def:source_bnt_zcl}
-    \notready
+    \lean{MPSTensor.IsPhysicalBNTZCL}
+    \leanok
     \uses{def:bnt_cpsv, def:source_physical_cid,
         def:is_bnt_locally_orthogonal}
     A BNT family has zero correlation length when the associated matrix-product
@@ -431,6 +432,20 @@ and rates for the single-tensor transfer map $\E_A$.
     regions and the BNT components are locally orthogonal.  This is
     \cite[Definition~3.6]{Cirac2016MPDO_arXiv}.
 \end{definition}
+
+\begin{lemma}[Source BNT zero correlation length implies its positive-gap form]%
+    \label{lem:is_positive_gap_bnt_zcl_of_source_bnt_zcl}
+    \lean{MPSTensor.isPositiveGapBNTZCL_of_isPhysicalBNTZCL}
+    \leanok
+    \uses{def:source_bnt_zcl, def:is_positive_gap_bnt_zcl}
+    If a BNT family has zero correlation length for all disjoint physical
+    regions, then it has positive-gap BNT zero correlation length.
+\end{lemma}
+\begin{proof}\leanok
+    Restrict the physical distance-independence condition to configurations in
+    which both complementary gaps are positive. The BNT relation and local
+    orthogonality are unchanged.
+\end{proof}
 
 \begin{theorem}[Direct-sum RFP implies positive-gap BNT zero correlation length]%
     \label{thm:is_positive_gap_bnt_zcl_of_is_rfp_direct_sum}
@@ -1230,16 +1245,6 @@ and rates for the single-tensor transfer map $\E_A$.
     \]
 \end{definition}
 
-\begin{definition}[Physical correlations independent of distance]%
-    \label{def:source_physical_cid}
-    \notready
-    \uses{def:transfer_map}
-    For every pair of observables supported on disjoint physical regions,
-    translating either observable without crossing the other leaves their
-    expectation unchanged.  This includes adjacent regions and is
-    \cite[Definition~3.3]{Cirac2016MPDO_arXiv}.
-\end{definition}
-
 \begin{definition}[Physical observable transfer]
     \label{def:physical_observable_transfer}
     \lean{MPSTensor.physicalObservableTransfer}
@@ -1273,6 +1278,28 @@ and rates for the single-tensor transfer map $\E_A$.
     \cite[lines~490--496]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
+\begin{definition}[Physical correlations independent of distance]%
+    \label{def:source_physical_cid}
+    \lean{MPSTensor.IsPhysicalCID}
+    \leanok
+    \uses{def:physical_two_point_expectation}
+    Let $O_1,O_2$ act on two disjoint contiguous regions of positive lengths
+    $L_1,L_2\geq1$ in a periodic chain, with complementary gap lengths
+    $n_1,n_2\geq0$. Physical correlations are independent of distance when, for
+    every $m_1,m_2\geq0$ satisfying
+    $n_1+n_2=m_1+m_2$, one has
+    \[
+      \operatorname{Tr}_{\MN{D}}\!\left(
+        \E_{O_2}\circ\E_A^{n_2}\circ\E_{O_1}\circ\E_A^{n_1}\right)
+      =
+      \operatorname{Tr}_{\MN{D}}\!\left(
+        \E_{O_2}\circ\E_A^{m_2}\circ\E_{O_1}\circ\E_A^{m_1}\right).
+    \]
+    Thus either region may be translated without crossing the other. Zero
+    gaps, corresponding to adjacent regions, are included. This is
+    \cite[Definition~3.3 and lines~490--496]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
 \begin{definition}[Positive-gap physical distance independence]%
     \label{def:is_positive_gap_physical_cid}
     \lean{MPSTensor.IsPositiveGapPhysicalCID}
@@ -1285,8 +1312,8 @@ and rates for the single-tensor transfer map $\E_A$.
         \langle\boldsymbol j|O|\boldsymbol i\rangle
         A^{\boldsymbol i}X(A^{\boldsymbol j})^\dagger .
     \]
-    Place two finite-block observables $O_1,O_2$ on a periodic chain, with
-    positive complementary gap lengths $n_1,n_2$.  The tensor has
+    Place two observables $O_1,O_2$ on nonempty finite blocks of a periodic
+    chain, with positive complementary gap lengths $n_1,n_2$. The tensor has
     \emph{positive-gap physical correlations independent of distance} when the expectation
     is unchanged upon replacing these gaps by positive $m_1,m_2$ satisfying
     $n_1+n_2=m_1+m_2$:
@@ -1302,6 +1329,18 @@ and rates for the single-tensor transfer map $\E_A$.
     Theorem~3.8]{Cirac2016MPDO_arXiv}, restricted to positive complementary
     gaps.  It excludes adjacent regions.
 \end{definition}
+
+\begin{lemma}[Physical CID implies positive-gap physical CID]%
+    \label{lem:is_positive_gap_physical_cid_of_physical_cid}
+    \lean{MPSTensor.isPositiveGapPhysicalCID_of_isPhysicalCID}
+    \leanok
+    \uses{def:source_physical_cid, def:is_positive_gap_physical_cid}
+    Correlations independent of distance for all disjoint physical regions are
+    independent of distance when both complementary gaps are positive.
+\end{lemma}
+\begin{proof}\leanok
+    Restrict the four gap lengths to positive integers.
+\end{proof}
 
 \begin{theorem}[Idempotent transfer implies positive-gap physical CID]%
     \label{thm:is_positive_gap_physical_cid_of_is_rfp}

--- a/docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex
+++ b/docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex
@@ -82,18 +82,36 @@ already contains $\mathbb E_A^2=\mathbb E_A$.
 
 This is a useful local statement, but it is not the source theorem at
 lines 498--502 and 1248--1268. The source theorem uses unrestricted physical CID
-together with the BNT-family mixed-sector equations (LO).  That source
-predicate has no formal counterpart; in particular, it is not the
-virtual-insertion predicate \leanid{MPSTensor.IsBNTZCL}.
+together with the BNT-family mixed-sector equations (LO). The source predicates
+now have formal counterparts. The predicate \leanid{MPSTensor.IsPhysicalCID}
+quantifies over two nonempty physical blocks and arbitrary natural
+complementary gap lengths, including zero, and requires the two-region
+expectation to be unchanged when the gaps are redistributed with fixed sum.
+The predicate \leanid{MPSTensor.IsPhysicalBNTZCL} is the conjunction of the BNT
+relation, this unrestricted physical CID condition, and BNT local
+orthogonality.
+
+These new predicates state Definitions~3.3 and 3.6; they do not prove the
+equivalence in Theorem~3.8. In particular, the theorem
+\leanid{MPSTensor.zcl_iff_idempotent_transfer} still concerns the older
+single-block and virtual-insertion predicates.
 
 \section{Elimination plan}
 
-The formalization now has a BNT-family version of local orthogonality,
+The formalization has a BNT-family version of local orthogonality,
 \leanid{MPSTensor.IsBNTLocallyOrthogonal}, carrying the equations
-$\mathbb E_{j,j'}=0$ for all $j\ne j'$, and two BNT-family predicates built on
-it.  Writing $\mathrm{BNT}(A)$ for the condition that the family is a basis of
-normal tensors for $A$, the predicate \leanid{MPSTensor.IsBNTZCL} uses the
-virtual-insertion condition,
+$\mathbb E_{j,j'}=0$ for all $j\ne j'$. Writing $\mathrm{BNT}(A)$ for the
+condition that the family is a basis of normal tensors for $A$, the source
+predicate is now
+\[
+  \mathrm{ZCL}_{\mathrm{BNT}}(A)
+  :=
+  \mathrm{BNT}(A)\wedge
+  \mathrm{CID}_{\rm physical}(A)\wedge
+  \bigl(\forall j\ne j',\, \mathbb E_{j,j'}=0\bigr).
+\]
+Its formal name is \leanid{MPSTensor.IsPhysicalBNTZCL}. The older predicate
+\leanid{MPSTensor.IsBNTZCL} uses the virtual-insertion condition,
 \[
   \mathrm{ZCL}^{\mathrm{virt}}_{\mathrm{BNT}}(A)
   :=
@@ -114,17 +132,13 @@ matrices. The positive-gap formal predicate uses the physical condition below,
 \]
 where $\mathrm{CID}^{\mathrm{pos}}_{\mathrm{physical}}$ is the positive-gap
 physical predicate.\footnote{The formal predicate is
-\path{MPSTensor.IsPositiveGapPhysicalCID}.} Neither
-predicate contains the unrestricted physical CID of Definition~3.3, so the
-source zero-correlation-length predicate
-\[
-  \mathrm{ZCL}_{\mathrm{BNT}}(A)
-  :=
-  \mathrm{CID}_{\rm physical}(A)\wedge
-  \bigl(\forall j\ne j',\, \mathbb E_{j,j'}=0\bigr)
-\]
-remains without a formal counterpart.
-The remaining target theorem for tensors in canonical form is then
+\path{MPSTensor.IsPositiveGapPhysicalCID}.} The unrestricted predicate implies
+this positive-gap restriction by
+\leanid{MPSTensor.isPositiveGapPhysicalCID_of_isPhysicalCID}; the analogous
+BNT implication is
+\leanid{MPSTensor.isPositiveGapBNTZCL_of_isPhysicalBNTZCL}.
+
+The remaining target theorem for tensors in canonical form is
 \[
   \mathrm{ZCL}_{\mathrm{BNT}}(A)
   \Longleftrightarrow
@@ -139,8 +153,8 @@ The present theorem is therefore a scope restriction: it records the one-block
 idempotence/CID consequence, while the BNT-level equivalence remains open.
 
 There is a second distinction in the correlation predicate. Definition~3.3
-quantifies over physical observables on arbitrary finite regions, and the
-two-observable formula at lines 490--496 inserts such an observable through
+quantifies over physical observables on arbitrary nonempty finite regions, and
+the two-observable formula at lines 490--496 inserts such an observable through
 
 \[
   \mathbb E_O(X)
@@ -170,8 +184,10 @@ proves\footnote{The formal theorem is
   \operatorname{CID}_{\rm physical}^{\text{positive gaps}}(A).
 \]
 
-This is not yet Definition~3.3, which quantifies over all disjoint regions and
-therefore includes adjacent regions. For an adjacent pair, one complementary
+The positive-gap predicate is not Definition~3.3, which quantifies over all
+disjoint regions and therefore includes adjacent regions. The unrestricted
+predicate \leanid{MPSTensor.IsPhysicalCID} now records Definition~3.3. For an
+adjacent pair, one complementary
 transfer power in the formula at lines 490--496 is $\mathbb E_A^0=1$. Idempotence gives
 $\mathbb E_A^n=\mathbb E_A$ only for $n\geq1$ and does not identify
 $\mathbb E_A^0$ with $\mathbb E_A$.  The positive-gap theorem is consequently
@@ -191,9 +207,9 @@ predicate avoids this boundary-state issue.
 
 Accordingly, \leanid{MPSTensor.IsBNTZCL} remains the virtual-insertion
 surrogate, while \leanid{MPSTensor.IsPositiveGapBNTZCL} names the physical
-positive-gap condition.  Neither is Definition~3.6.  The unrestricted source
-BNT zero-correlation-length predicate and its equivalence with transfer
-idempotence remain open.
+positive-gap condition. Neither is Definition~3.6; that definition is now
+\leanid{MPSTensor.IsPhysicalBNTZCL}. Its equivalence with transfer idempotence
+remains open.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
### Motivation

- Theorem 3.8 of arXiv:1606.00608 uses physical correlations independent of distance for arbitrary disjoint regions, including adjacent regions, together with BNT local orthogonality.
- The existing formal predicates covered either arbitrary virtual insertions or only configurations with both complementary gaps positive. The source predicates themselves were therefore missing.

Source: `Papers/1606.00608/MPDO-22-12-17-2.tex`, Definition 3.3 at lines 437--445, Definitions 3.5--3.6 at lines 467--478, and the two-observable transfer formula at lines 490--496.

### Description

- Define `MPSTensor.IsPhysicalCID` using two nonempty contiguous observable blocks and arbitrary natural complementary gaps. Redistributing the two gaps at fixed sum expresses translation at fixed periodic-chain length; zero gaps include adjacent regions.
- Define `MPSTensor.IsPhysicalBNTZCL` as the source BNT relation together with unrestricted physical CID and mixed-sector local orthogonality.
- Prove the direct restriction lemmas from both source predicates to their existing positive-gap forms.
- Mark the two source definitions and restriction lemmas in the blueprint, and update the paper-gap note to distinguish this completed predicate layer from the still-open equivalence in Theorem 3.8.

This PR does not claim that transfer-map idempotence implies unrestricted physical CID, nor does it mark `TheoremZCLPure` as formalized. The adjacent-region boundary remains the substantive open step.

### Testing

- `lake env lean TNLean/MPS/RFP/ZeroCorrelationLength.lean`
- `lake build`
- `cd blueprint && leanblueprint checkdecls`
- `cd blueprint && leanblueprint web`
- `cd blueprint && leanblueprint pdf` (542 pages on the original base)
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check origin/main...HEAD`

---
Addresses #2597

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Predicate-layer and documentation changes with trivial implication proofs; no change to existing idempotence or virtual-insertion theorems beyond proof tweaks for new hypotheses.
> 
> **Overview**
> Adds **formal counterparts** to Cirac et al. Definitions 3.3 and 3.6 that were previously missing: `IsPhysicalCID` (nonempty physical blocks, arbitrary complementary gaps including zero) and `IsPhysicalBNTZCL` (BNT basis + unrestricted physical CID + BNT local orthogonality).
> 
> Also proves the direct **restriction lemmas** to the existing positive-gap predicates (`isPositiveGapPhysicalCID_of_isPhysicalCID`, `isPositiveGapBNTZCL_of_isPhysicalBNTZCL`), aligns `IsPositiveGapPhysicalCID` with positive block lengths, and wires the new names into the blueprint and the ZCL scope note.
> 
> **Does not** prove transfer idempotence ⇒ unrestricted physical CID or mark Theorem 3.8 complete; adjacent-region / \(\mathbb{E}^0\) gaps stay documented as open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a6d30d67ff6d685f67352c93aa48b679b1292a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->