### PR TITLE
doc(MPS/MPDO): illustrate vertical reducing sectors

### DIFF
--- a/blueprint/src/Packages/tn_diagrams.py
+++ b/blueprint/src/Packages/tn_diagrams.py
@@ -66,6 +66,7 @@ _DIAGRAM_ARGS: dict[str, str] = {
     "TNMPDOHorizontalOperator": "",
     "TNMPDOFirstSiteContractions": "",
     "TNMPDOVerticalDirectSum": "",
+    "TNMPDOVerticalReducingSectors": "",
     "TNMPDOInverseContraction": "",
     "TNMPDOSectorPairing": "",
     "TNMPDOSectorZCLIdentity": "",

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -2238,6 +2238,20 @@
     intertwining identities give the four assertions directly.
 \end{proof}
 
+\begin{figure}[ht]
+    \centering
+    \TNMPDOVerticalReducingSectors
+    \caption{The vertically viewed tensor decomposes through complete
+    orthogonal physical sectors. Each $V_k$ embeds the irreducible tensor
+    $B_k$, while $P_k=V_kV_k^\dagger$ is its reducing range projection. The
+    open-leg identity is equivalent, for every vertical letter $v$, to
+    $\widetilde M_v=\sum_kV_kB_{k,v}V_k^\dagger$.
+    This is the iterated invariant-subspace construction in
+    \cite[lines~200--219]{Cirac2016MPDO_arXiv}, applied to the reduction in
+    \cite[Proposition~4.13, lines~1873--1887]{Cirac2016MPDO_arXiv}.}
+    \label{fig:mpdo_vertical_reducing_sectors}
+\end{figure}
+
 \begin{theorem}[Spectrally normalized vertical sectors with physical isometries]
     \label{thm:mpdo_vertical_normal_sectors_with_isometries}
     \lean{MPOTensor.IsHorizontalCF.exists_normal_verticalBlockDecomp_with_isometry}

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -789,6 +789,42 @@
     \end{tikzpicture}%
 }
 
+% Complete orthogonal reducing-sector decomposition of the vertical tensor.
+% The physical isometries V_k surround the irreducible corner B_k; their
+% range projections resolve the physical identity and reduce every letter.
+\newcommand{\TNMPDOVerticalReducingSectors}{%
+    \begin{tikzpicture}[tn picture, scale=0.94]
+        \path[draw=black, opacity=0, use as bounding box]
+            (-4.35,-1.42) rectangle (5.75,1.42);
+        \TN@tensordot{vrsM}{(-3.50,0)}
+        \TN@leftleg{vrsM}{0.58}
+        \TN@rightleg{vrsM}{0.58}
+        \TN@upleg{vrsM}{0.48}
+        \TN@downleg{vrsM}{0.48}
+        \node[anchor=west] at (-3.33,0.30) {$\widetilde M$};
+        \node at (-2.45,0) {$=$};
+        \node at (-1.55,0) {$\displaystyle\sum_k$};
+        \node[draw, rounded corners, fill=blue!8, inner sep=2pt]
+            (vrsV) at (0,0.82) {$V_k$};
+        \TN@tensordot{vrsB}{(0,0)}
+        \node[draw, rounded corners, fill=blue!8, inner sep=2pt]
+            (vrsVd) at (0,-0.82) {$V_k^\dagger$};
+        \draw[tn phys leg] (vrsV.north) -- ++(0,0.34);
+        \draw[tn phys leg] (vrsV.south) -- (vrsB.north);
+        \draw[tn phys leg] (vrsB.south) -- (vrsVd.north);
+        \draw[tn phys leg] (vrsVd.south) -- ++(0,-0.34);
+        \TN@leftleg{vrsB}{0.60}
+        \TN@rightleg{vrsB}{0.60}
+        \node[anchor=west] at (0.16,0.27) {$B_k$};
+        \node[anchor=west, align=left] at (1.62,0.48)
+            {$P_k=V_kV_k^\dagger,\qquad \sum_kP_k=I,$};
+        \node[anchor=west, align=left] at (1.62,-0.18)
+            {$P_kP_l=0\ (k\ne l),$};
+        \node[anchor=west, align=left] at (1.62,-0.78)
+            {$P_k\widetilde M=\widetilde MP_k.$};
+    \end{tikzpicture}%
+}
+
 % Inverse-map contraction for an injective simple tensor: contracting the
 % inverse tensor with the tensor through the physical index identifies the
 % two pairs of virtual legs (the matrix units on the bond space).

--- a/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
+++ b/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
@@ -22,6 +22,9 @@ name: TNMPDOHayashiSectorComparison TNMPDOSectorFactorization
 name: TNMPDOHorizontalOperator TNMPDOFirstSiteContractions TNMPDOVerticalDirectSum
 {{ obj.tn_svg_html }}
 
+name: TNMPDOVerticalReducingSectors
+{{ obj.tn_svg_html }}
+
 name: TNMPDOInverseContraction TNMPDOSectorPairing TNMPDOSectorZCLIdentity
 {{ obj.tn_svg_html }}
 


### PR DESCRIPTION
## Summary

- add a source-like TikZ depiction of the complete reducing-sector decomposition of the vertically viewed MPDO tensor;
- place the figure between the proved complete-projector decomposition and the spectrally normalized vertical-sector theorem;
- register the diagram consistently for print and web rendering.

The caption follows the iterative invariant-subspace construction in arXiv:1606.00608, lines 200–219, and its use in Proposition 4.13, lines 1873–1887. It records only the proved isometric sector decomposition and reducing-projector identities; it does not mark the remaining horizontal-to-vertical canonical-form theorem as complete.

Addresses #3674.

## Validation

- `lake build TNLean`
- `cd blueprint && leanblueprint checkdecls`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- tensor-diagram registry, PEPS-usage, and focused SVG smoke checks
- `cd blueprint && leanblueprint pdf`
- configured Python 3.9 `leanblueprint web`, with no missing files or unrendered TikZ
- visual inspection of PDF page 431 and the exact generated web SVG
- `git diff --check`

## Integrity

- documentation-only change;
- no new `sorry`, axiom, or theorem claim;
- commit author is `texra-ai <texra-ai@outlook.com>`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only: new TikZ macro, figure placement, and diagram registry entries with no changes to Lean formalization or claimed theorems.
> 
> **Overview**
> This PR adds documentation for the **complete orthogonal reducing-sector decomposition** of the vertically viewed MPDO tensor \(\widetilde M\).
> 
> A new `\TNMPDOVerticalReducingSectors` TikZ macro depicts \(\widetilde M\) as a sum over sectors with physical isometries \(V_k\), irreducible corners \(B_k\), and reducing projections \(P_k=V_kV_k^\dagger\), together with the projector identities. The figure is inserted in **ch20** immediately after the complete vertical reducing projectors theorem and before the spectrally normalized vertical-sector theorem, with a caption tied to Cirac et al. (arXiv:1606.00608).
> 
> The macro is registered in `tn_diagrams.py` and the plastex HTML template so PDF and web blueprints render the same diagram. **No Lean proofs or theorem status change**—documentation and diagram pipeline only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 249c14d73459ba654b0b13f53049cfe225b98e00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->