### PR TITLE
feat(MPS/MPDO): group vertical sectors into BNT representatives

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -389,6 +389,7 @@ import TNLean.MPS.MPDO.PeriodicExclusion
 import TNLean.MPS.MPDO.StackedLayers
 import TNLean.MPS.MPDO.CyclicProjector
 import TNLean.MPS.MPDO.VerticalSpectral
+import TNLean.MPS.MPDO.VerticalBNT
 import TNLean.MPS.MPDO.SectorTrace
 import TNLean.MPS.MPDO.BiCFDerivation
 import TNLean.MPS.MPDO.ZCL

--- a/TNLean/Channel/Irreducible/SpectralRadius.lean
+++ b/TNLean/Channel/Irreducible/SpectralRadius.lean
@@ -7,6 +7,7 @@ import TNLean.Channel.Irreducible.KrausSetup
 import TNLean.Channel.Irreducible.PerronFrobenius
 import TNLean.Channel.Irreducible.Similarity
 import TNLean.Channel.Irreducible.TraceAdjoint
+import TNLean.Channel.Peripheral.Conjugation
 import TNLean.MPS.Core.TPGauge
 import TNLean.Spectral.TransferOperatorGap
 import Mathlib.Algebra.Module.Equiv.Basic
@@ -25,6 +26,8 @@ for irreducible completely positive maps on `M_D(ℂ)`.
   is `r`.
 * `spectralRadius_toReal_eq_of_posDef_eigenvector_of_irreducible_cp`:
   the same statement as a real-valued identity.
+* `IsPrimitive.similarityMap_iff`: primitivity is invariant under the
+  positive-congruence similarity used for Perron gauges.
 
 ## Approach
 
@@ -116,6 +119,23 @@ private lemma spectralRadius_similarity_eq
     rw [hspec_left, hspec_alg, hspec_right]
   change spectralRadius ℂ (Φ (similarityMap (D := D) C E)) = spectralRadius ℂ (Φ E)
   rw [spectralRadius, spectralRadius, hspec]
+
+/-- Peripheral-spectrum primitivity is invariant under the positive-congruence
+similarity used to change Kraus gauges. -/
+theorem IsPrimitive.similarityMap_iff
+    (C : Matrix (Fin D) (Fin D) ℂ) (hC : C.det ≠ 0)
+    (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
+    _root_.IsPrimitive (similarityMap (D := D) C E) ↔
+      _root_.IsPrimitive E := by
+  have hsim :
+      similarityMap (D := D) C E =
+        (sandwichLinearEquiv (D := D) C hC).symm.conj E := by
+    apply LinearMap.ext
+    intro X
+    ext i j
+    simp [similarityMap, LinearEquiv.conj_apply, Matrix.mul_assoc]
+  rw [hsim]
+  exact IsPrimitive.conj_iff (sandwichLinearEquiv (D := D) C hC).symm E
 
 end SimilarityCLM
 

--- a/TNLean/MPS/CanonicalForm/NormalTensorGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalTensorGauge.lean
@@ -1,0 +1,261 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.CanonicalForm.Definitions
+import TNLean.MPS.CanonicalForm.PhaseCover
+import TNLean.MPS.CanonicalForm.ProjectorClosureSpectral
+import TNLean.MPS.CanonicalForm.SectorComparison.NormalityChain
+import TNLean.MPS.BNT.Construction
+import TNLean.MPS.FundamentalTheorem.Proportional
+import TNLean.MPS.Symmetry.StringOrderAux
+
+/-!
+# Perron gauges for normal tensors
+
+This file connects the spectral normal-tensor condition of
+Cirac--Pérez-García--Schuch--Verstraete with eventual block injectivity.
+
+For a normal tensor, irreducible Perron--Frobenius theory gives positive-definite
+right and left eigenvectors of the transfer map.  The spectral-radius-one
+normalization forces both Perron eigenvalues to be one.  Gauging with the left
+eigenvector therefore gives a trace-preserving tensor without any scalar
+rescaling.  Peripheral primitivity and irreducibility survive this gauge, so
+the trace-preserving primitive normality theorem gives eventual injectivity.
+Gauge invariance then transports eventual injectivity back to the original
+tensor.
+
+## Main statements
+
+* `IsNormalTensor.exists_tpGauge`: a normal tensor admits a pure
+  trace-preserving Perron gauge.
+* `IsNormalTensor.isNormal`: spectral normality implies eventual block
+  injectivity.
+* `MPVBlockPhaseEquiv.dim_eq_and_gaugePhaseEquiv_of_isNormalTensor`: exact MPV
+  phase equivalence between normal tensors is realized by an invertible gauge.
+* `exists_eventually_linearIndependent_of_normalTensor_blocks_not_gaugePhaseEquiv`:
+  a separated finite family of normal tensors is eventually linearly
+  independent.
+
+## References
+
+* Cirac--Pérez-García--Schuch--Verstraete, arXiv:1606.00608, lines 231--235
+  and the proof of Lemma `equalMPS`, lines 1093--1117.
+* Wolf, *Quantum Channels & Operations*, Theorem 6.3.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+open Filter
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- A positive-bond-dimension normal tensor admits a trace-preserving gauge
+with no scalar rescaling.
+
+The tensor is normal in the sense of arXiv:1606.00608, lines 231--235: its
+transfer map has spectral radius one and unique peripheral eigenvalue one.
+The positive-definite left Perron eigenvector consequently has eigenvalue one,
+so the usual Perron gauge is a pure similarity of the original tensor. -/
+theorem IsNormalTensor.exists_tpGauge [NeZero D]
+    {A : MPSTensor d D} (h : IsNormalTensor A) :
+    ∃ σ : Matrix (Fin D) (Fin D) ℂ,
+      σ.PosDef ∧
+      transferMap (d := d) (D := D) (fun i => (A i)ᴴ) σ = σ ∧
+      IsLeftCanonical (tpGauge (d := d) (D := D) A σ) ∧
+      GaugeEquiv A (tpGauge (d := d) (D := D) A σ) ∧
+      _root_.IsPrimitive
+        (transferMap (d := d) (D := D) (tpGauge (d := d) (D := D) A σ)) ∧
+      IsIrreducibleTensor (tpGauge (d := d) (D := D) A σ) := by
+  have hA : ∃ i, A i ≠ 0 := by
+    by_contra hzero
+    push Not at hzero
+    have hmap : transferMap (d := d) (D := D) A = 0 := by
+      ext X a b
+      simp [transferMap_apply, hzero]
+    have hspectral := h.spectral_radius_one
+    rw [hmap] at hspectral
+    simp at hspectral
+  have hIrrMap : IsIrreducibleMap (transferMap (d := d) (D := D) A) :=
+    isIrreducibleCP_transferMap_of_isIrreducibleTensor A h.no_invariant_proj
+  obtain ⟨ρ, r, hρ, hr, hρeig⟩ :=
+    exists_posDef_transferMap_eigenvector_of_irreducible A h.no_invariant_proj hA
+  have hradius :
+      (spectralRadius ℂ
+        ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ))
+          (transferMap (d := d) (D := D) A))).toReal = r :=
+    spectralRadius_toReal_eq_of_posDef_eigenvector_of_irreducible_cp
+      (transferMap (d := d) (D := D) A) (transferMap_isCPMap A) hIrrMap
+      ρ r hρ hr hρeig
+  have hradius_one :
+      (spectralRadius ℂ
+        ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ))
+          (transferMap (d := d) (D := D) A))).toReal = 1 := by
+    rw [h.spectral_radius_one]
+    simp
+  have hr_one : r = 1 := hradius.symm.trans hradius_one
+  obtain ⟨σ, t, hσ, ht, hσeig⟩ :=
+    exists_posDef_adjoint_eigenvector A h.no_invariant_proj hA
+  have htrace : Matrix.trace (σ * transferMap (d := d) (D := D) A ρ) =
+      Matrix.trace
+        (transferMap (d := d) (D := D) (fun i => (A i)ᴴ) σ * ρ) :=
+    trace_mul_transferMap_adjoint A rfl σ ρ
+  have htr_ne : Matrix.trace (σ * ρ) ≠ 0 := by
+    intro htr
+    exact (Matrix.PosDef.isUnit hρ).ne_zero
+      (Kraus.posSemidef_eq_zero_of_posDef_trace_mul_eq_zero
+        hρ.posSemidef hσ htr)
+  have hscalar : (r : ℂ) * Matrix.trace (σ * ρ) =
+      (t : ℂ) * Matrix.trace (σ * ρ) := by
+    calc
+      (r : ℂ) * Matrix.trace (σ * ρ) =
+          Matrix.trace (σ * ((r : ℂ) • ρ)) := by
+            rw [Matrix.mul_smul, Matrix.trace_smul, smul_eq_mul]
+      _ = Matrix.trace (σ * transferMap (d := d) (D := D) A ρ) := by rw [hρeig]
+      _ = Matrix.trace
+          (transferMap (d := d) (D := D) (fun i => (A i)ᴴ) σ * ρ) := htrace
+      _ = Matrix.trace (((t : ℂ) • σ) * ρ) := by rw [hσeig]
+      _ = (t : ℂ) * Matrix.trace (σ * ρ) := by
+            rw [Matrix.smul_mul, Matrix.trace_smul, smul_eq_mul]
+  have hrt : r = t := by
+    have hc : (r : ℂ) = (t : ℂ) := mul_right_cancel₀ htr_ne hscalar
+    exact_mod_cast hc
+  have ht_one : t = 1 := hrt ▸ hr_one
+  have hσfix : transferMap (d := d) (D := D) (fun i => (A i)ᴴ) σ = σ := by
+    simpa [ht_one] using hσeig
+  have hTP : IsLeftCanonical (tpGauge (d := d) (D := D) A σ) :=
+    tpGauge_isTP_of_transferMap_conjTranspose_fixedPoint A σ hσ hσfix
+  have hGauge : GaugeEquiv A (tpGauge (d := d) (D := D) A σ) :=
+    gaugeEquiv_tpGauge A σ hσ
+  have hPrim : _root_.IsPrimitive
+      (transferMap (d := d) (D := D) (tpGauge (d := d) (D := D) A σ)) :=
+    (isPrimitive_transferMap_tpGauge_iff A σ hσ).2 h.primitive_transfer
+  have hIrr : IsIrreducibleTensor (tpGauge (d := d) (D := D) A σ) :=
+    isIrreducibleTensor_tpGauge_of_isIrreducibleMap A σ hσ hIrrMap
+  exact ⟨σ, hσ, hσfix, hTP, hGauge, hPrim, hIrr⟩
+
+/-- A normal tensor in the spectral sense of arXiv:1606.00608 is eventually
+block-injective. -/
+theorem IsNormalTensor.isNormal [NeZero D]
+    {A : MPSTensor d D} (h : IsNormalTensor A) : IsNormal A := by
+  obtain ⟨σ, _hσ, _hσfix, hTP, hGauge, hPrim, hIrr⟩ := h.exists_tpGauge
+  have hNormalGauge : IsNormal (tpGauge (d := d) (D := D) A σ) :=
+    isNormal_of_tp_primitive_irreducible _ hTP hPrim hIrr
+  exact isNormal_of_gaugeEquiv hNormalGauge hGauge.symm
+
+/-- MPV phase equivalence between normal tensors is realized letterwise by a
+gauge and a nonzero scalar, after identifying their bond dimensions.
+
+This is the grouping implication in arXiv:1606.00608, Lemma `equalMPS`
+(lines 1080--1117) and Proposition `prop:char-BNT` (lines 1135--1148).
+Each tensor is first put into its trace-preserving Perron gauge.  The gauges
+are pure similarities because both tensors have spectral radius one.  The
+trace-preserving equal-overlap theorem supplies the gauge-phase relation, which
+is then transported back to the original tensors. -/
+theorem MPVBlockPhaseEquiv.dim_eq_and_gaugePhaseEquiv_of_isNormalTensor
+    {DX DY : ℕ} [NeZero DX] [NeZero DY]
+    {X : MPSTensor d DX} {Y : MPSTensor d DY}
+    (hX : IsNormalTensor X) (hY : IsNormalTensor Y)
+    (h : MPVBlockPhaseEquiv X Y) :
+    ∃ hdim : DX = DY,
+      GaugePhaseEquiv
+        (cast (congr_arg (MPSTensor d) hdim) X) Y := by
+  classical
+  have hdim : DX = DY := h.dim_eq
+  subst hdim
+  obtain ⟨σX, _hσX, _hσXfix, hTPX, hGaugeX, hPrimX, hIrrX⟩ := hX.exists_tpGauge
+  obtain ⟨σY, _hσY, _hσYfix, hTPY, hGaugeY, hPrimY, hIrrY⟩ := hY.exists_tpGauge
+  let X' := tpGauge (d := d) (D := DX) X σX
+  let Y' := tpGauge (d := d) (D := DX) Y σY
+  have hPhase : MPVBlockPhaseEquiv X' Y' := by
+    obtain ⟨ζ, hζ, hmpv⟩ := h
+    refine ⟨ζ, hζ, ?_⟩
+    intro N w
+    calc
+      mpv Y' w = mpv Y w := (GaugeEquiv.sameMPV hGaugeY N w).symm
+      _ = ζ ^ N * mpv X w := hmpv N w
+      _ = ζ ^ N * mpv X' w := by rw [GaugeEquiv.sameMPV hGaugeX N w]
+  have hSelf : Tendsto
+      (fun N => mpvOverlap (d := d) X' X' N) atTop (nhds (1 : ℂ)) :=
+    overlap_tendsto_one_of_peripheralPrimitive_of_irreducible
+      X' hIrrX hTPX hPrimX
+  have hSelfY : Tendsto
+      (fun N => mpvOverlap (d := d) Y' Y' N) atTop (nhds (1 : ℂ)) :=
+    overlap_tendsto_one_of_peripheralPrimitive_of_irreducible
+      Y' hIrrY hTPY hPrimY
+  have hSelfNorm : Tendsto
+      (fun N => ‖mpvOverlap (d := d) X' X' N‖) atTop (nhds (1 : ℝ)) := by
+    simpa using hSelf.norm
+  have hSelfYNorm : Tendsto
+      (fun N => ‖mpvOverlap (d := d) Y' Y' N‖) atTop (nhds (1 : ℝ)) := by
+    simpa using hSelfY.norm
+  have hζ : ‖hPhase.choose‖ = 1 :=
+    norm_eq_one_of_selfOverlap_scale hSelfNorm hSelfYNorm
+      (mpvOverlap_self_scale_of_mpv_eq_pow_mul hPhase.choose_spec.2)
+  have hCrossEq : ∀ N,
+      mpvOverlap (d := d) X' Y' N =
+        (star hPhase.choose) ^ N * mpvOverlap (d := d) X' X' N :=
+    mpvOverlap_eq_star_pow_mul_self_of_mpv_eq_pow_mul hPhase.choose_spec.2
+  have hCrossNormEq : ∀ N,
+      ‖mpvOverlap (d := d) X' Y' N‖ = ‖mpvOverlap (d := d) X' X' N‖ := by
+    intro N
+    rw [hCrossEq N, norm_mul, norm_pow]
+    calc
+      ‖star hPhase.choose‖ ^ N * ‖mpvOverlap (d := d) X' X' N‖ =
+          ‖hPhase.choose‖ ^ N * ‖mpvOverlap (d := d) X' X' N‖ := by
+            rw [norm_star]
+      _ = ‖mpvOverlap (d := d) X' X' N‖ := by rw [hζ, one_pow, one_mul]
+  have hCrossNorm : Tendsto
+      (fun N => ‖mpvOverlap (d := d) X' Y' N‖) atTop (nhds (1 : ℝ)) :=
+    hSelfNorm.congr fun N => (hCrossNormEq N).symm
+  have hGaugePhase : GaugePhaseEquiv X' Y' :=
+    gaugePhaseEquiv_of_overlap_norm_tendsto_one_of_irreducible_TP
+      X' Y' hIrrX hIrrY hTPX hTPY hCrossNorm
+  refine ⟨rfl, ?_⟩
+  exact gaugePhaseEquiv_of_gaugeEquiv_left_right hGaugeX hGaugePhase hGaugeY
+
+/-- A finite gauge-phase-separated family of normal tensors is eventually
+linearly independent at the level of matrix product vectors.
+
+This is the corollary to Lemma `equalMPS` at arXiv:1606.00608, lines
+1121--1132.  The proof puts each tensor into its trace-preserving Perron gauge,
+applies the overlap orthogonality criterion there, and uses gauge invariance of
+the matrix product vectors. -/
+theorem exists_eventually_linearIndependent_of_normalTensor_blocks_not_gaugePhaseEquiv
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hNormal : ∀ k, IsNormalTensor (A k))
+    (hDistinct : BlocksNotGaugePhaseEquiv (d := d) A) :
+    ∃ N₀ : ℕ, ∀ N > N₀,
+      LinearIndependent ℂ (fun k : Fin r => mpvState (d := d) (A k) N) := by
+  classical
+  choose σ hσ hσfix hTP hGauge hPrim hIrr using
+    fun k => (hNormal k).exists_tpGauge
+  let prepared : (k : Fin r) → MPSTensor d (dim k) :=
+    fun k => tpGauge (d := d) (D := dim k) (A k) (σ k)
+  have hPreparedDistinct : BlocksNotGaugePhaseEquiv (d := d) prepared := by
+    intro j k hjk hdim hGPE
+    apply hDistinct j k hjk hdim
+    exact gaugePhaseEquiv_of_gaugeEquiv_left_right_cast hdim
+      (hGauge j) (by simpa [prepared] using hGPE) (hGauge k)
+  obtain ⟨N₀, hLI⟩ :=
+    exists_eventually_linearIndependent_of_overlap_tendsto_orthonormal prepared
+      (fun k => overlap_tendsto_one_of_peripheralPrimitive_of_irreducible
+        (prepared k) (hIrr k) (hTP k) (hPrim k))
+      (fun j k hjk =>
+        cross_overlap_tendsto_zero_of_separated_normal_bnt_data prepared
+          (HasIrreducibleBlocks.ofForall hIrr)
+          (IsLeftCanonicalBlockFamily.ofForall hTP)
+          hPreparedDistinct j k hjk)
+  refine ⟨N₀, fun N hN => ?_⟩
+  have hFamily :
+      (fun k : Fin r => mpvState (d := d) (prepared k) N) =
+        fun k : Fin r => mpvState (d := d) (A k) N := by
+    funext k
+    ext w
+    exact (GaugeEquiv.sameMPV (hGauge k) N w).symm
+  rw [← hFamily]
+  exact hLI N hN
+
+end MPSTensor

--- a/TNLean/MPS/CanonicalForm/PhaseCover.lean
+++ b/TNLean/MPS/CanonicalForm/PhaseCover.lean
@@ -7,15 +7,22 @@ import TNLean.MPS.Overlap.CastLemmas
 import TNLean.MPS.SharedInfra.GaugePhase
 import TNLean.MPS.SharedInfra.SectorDecomposition
 
-open scoped Matrix BigOperators
-open Filter
-
 /-!
 # MPV phase covers for canonical-form block families
 
 This file contains the MPV phase-equivalence and phase-cover constructions used by the
-canonical-form equal-norm comparison and sector-comparison layers.
+canonical-form equal-norm and sector comparisons.
+
+## Main statements
+
+* `MPVBlockPhaseEquiv.dim_eq`: exact phase equivalence at every nonnegative
+  length forces equality of bond dimensions.
+* `MPVPhaseClassData.regroup_matrix`: a matrix-valued sum can be regrouped by
+phase classes and their copies.
 -/
+
+open scoped Matrix BigOperators
+open Filter
 
 namespace MPSTensor
 
@@ -57,6 +64,19 @@ lemma trans {DA DB DC : ℕ} {A : MPSTensor d DA} {B : MPSTensor d DB}
   intro N σ
   rw [hηmpv N σ, hζmpv N σ, mul_pow]
   ring
+
+/-- MPV phase equivalence at all lengths forces equality of bond dimensions.
+
+At length zero both MPV coefficients are traces of identity matrices, while
+the phase contributes the zeroth power `1`.  Thus the equality is simply
+`DB = DA`.  This observation uses the length-zero clause and does not hold for
+positive-length or merely eventual proportionality. -/
+lemma dim_eq {DA DB : ℕ} {A : MPSTensor d DA} {B : MPSTensor d DB}
+    (h : MPVBlockPhaseEquiv A B) : DA = DB := by
+  obtain ⟨ζ, _hζ, hmpv⟩ := h
+  have hzero := hmpv 0 (fun i => Fin.elim0 i)
+  simp [mpv, coeff] at hzero
+  exact_mod_cast hzero.symm
 
 /-- Gauge-phase equivalence after a dimension cast gives rectangular MPV phase equivalence. -/
 lemma of_gaugePhaseEquiv_cast {DA DB : ℕ} (A : MPSTensor d DA) (B : MPSTensor d DB)
@@ -220,6 +240,17 @@ lemma exists_enum_eq (classes : MPVPhaseClassData blocks) (k : Fin r) :
   have hregroup := classes.regroup (fun x : Fin r => if x = k then (1 : ℂ) else 0)
   rw [hzero, hone] at hregroup
   exact zero_ne_one hregroup
+
+/-- Regroup a matrix-valued sum over the original block indices by phase
+classes and their copies. -/
+lemma regroup_matrix (classes : MPVPhaseClassData blocks) {n : ℕ}
+    (f : Fin r → Matrix (Fin n) (Fin n) ℂ) :
+    ∑ j : Fin classes.g, ∑ q : Fin (classes.copies j), f (classes.enum j q) =
+      ∑ k : Fin r, f k := by
+  apply Matrix.ext
+  intro a b
+  simp_rw [Matrix.sum_apply]
+  exact classes.regroup (fun k => f k a b)
 
 /-- The chosen MPV phase-class representatives span exactly the same finite-length MPV
 subspace as the original block family.

--- a/TNLean/MPS/Defs.lean
+++ b/TNLean/MPS/Defs.lean
@@ -10,7 +10,8 @@ import Mathlib.Order.Filter.AtTopBot.Basic
 This file contains the core definitions used throughout the MPS development:
 `MPSTensor`, word evaluation, MPV coefficients, gauge equivalence, and the
 notions of injectivity, block injectivity, and normality. It also proves the
-basic gauge-invariance lemmas for `evalWord` and `SameMPV`.
+basic gauge-invariance lemmas for `evalWord`, `SameMPV`, and eventual block
+injectivity.
 -/
 
 open scoped Matrix
@@ -469,5 +470,48 @@ theorem isInjective_of_gaugeEquiv {A B : MPSTensor d D}
       ((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) = M := by
     simp [Matrix.mul_assoc]
   rwa [this] at key
+
+/-- Gauge equivalence preserves injectivity after any fixed blocking length. -/
+theorem isNBlkInjective_of_gaugeEquiv {A B : MPSTensor d D} {N : ℕ}
+    (hA : IsNBlkInjective A N) (hGauge : GaugeEquiv A B) :
+    IsNBlkInjective B N := by
+  obtain ⟨X, hX⟩ := hGauge
+  rw [IsNBlkInjective, eq_top_iff]
+  intro M _
+  have hM' : ((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) * M * (X : Matrix _ _ ℂ) ∈
+      Submodule.span ℂ
+        (Set.range fun σ : Fin N → Fin d => evalWord A (List.ofFn σ)) :=
+    hA ▸ Submodule.mem_top
+  have hConj : ∀ Y ∈ Submodule.span ℂ
+      (Set.range fun σ : Fin N → Fin d => evalWord A (List.ofFn σ)),
+      (X : Matrix _ _ ℂ) * Y *
+          ((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) ∈
+        Submodule.span ℂ
+          (Set.range fun σ : Fin N → Fin d => evalWord B (List.ofFn σ)) := by
+    intro Y hY
+    induction hY using Submodule.span_induction with
+    | mem y hy =>
+      obtain ⟨σ, rfl⟩ := hy
+      rw [← evalWord_gauge X hX]
+      exact Submodule.subset_span (Set.mem_range_self σ)
+    | zero => simp
+    | add x y _ _ hx hy =>
+      simp only [Matrix.mul_add, Matrix.add_mul]
+      exact Submodule.add_mem _ hx hy
+    | smul c y _ hy =>
+      rw [Matrix.mul_smul, Matrix.smul_mul]
+      exact Submodule.smul_mem _ c hy
+  have key := hConj _ hM'
+  have hrecover : (X : Matrix _ _ ℂ) *
+      (((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) * M * (X : Matrix _ _ ℂ)) *
+      ((X⁻¹ : GL _ ℂ) : Matrix _ _ ℂ) = M := by
+    simp [Matrix.mul_assoc]
+  rwa [hrecover] at key
+
+/-- Gauge equivalence preserves eventual block injectivity. -/
+theorem isNormal_of_gaugeEquiv {A B : MPSTensor d D}
+    (hA : IsNormal A) (hGauge : GaugeEquiv A B) : IsNormal B := by
+  obtain ⟨N, hN⟩ := hA
+  exact ⟨N, isNBlkInjective_of_gaugeEquiv hN hGauge⟩
 
 end MPSTensor

--- a/TNLean/MPS/MPDO/VerticalBNT.lean
+++ b/TNLean/MPS/MPDO/VerticalBNT.lean
@@ -1,0 +1,243 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.CanonicalForm.NormalTensorGauge
+import TNLean.MPS.MPDO.VerticalSpectral
+
+/-!
+# Grouping vertical normal sectors into BNT representatives
+
+This file performs the gauge-phase grouping step in the proof of the vertical
+canonical form for matrix product density operators.  Starting from the
+spectrally normalized physical corners, it chooses one normal tensor from each
+matrix-product-vector phase class.  Every original corner is expressed as a
+nonzero complex scalar times an invertible conjugate of its representative.
+The physical isometries are retained unchanged, so all reducing identities and
+the literal reconstruction of every vertical letter survive the regrouping.
+
+The conclusion is precisely the display at arXiv:1606.00608, lines 1895--1898,
+using the general BNT construction at lines 259--301 and 1135--1148.  No
+positivity of the grouped coefficients and no unitarity of the gauges is
+asserted here; those are consequences of the subsequent MPDO argument at lines
+1898--1921.
+
+## Main statement
+
+* `IsHorizontalCF.exists_verticalBNTGrouping_with_isometry`: the normalized
+  vertical corners grouped into BNT representatives, with the physical
+  isometries and literal reconstruction retained.
+
+## References
+
+* Cirac--Pérez-García--Schuch--Verstraete, arXiv:1606.00608, Proposition
+  `prop:vertical`, lines 1873--1921.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- Group the normalized vertical corners of a horizontally canonical MPDO by
+their gauge-phase classes while retaining the physical reducing isometries.
+
+For each class `j` and copy `q`, the original normalized corner is
+
+`blocks (enum j q) = ζ j q · X j q · blocks (repr j) · (X j q)⁻¹`.
+
+Consequently its coefficient in the literal vertical decomposition is the
+nonzero complex number `μ (enum j q) * ζ j q`.  The representatives form a
+basis of normal tensors for the corresponding weighted block tensor and are
+pairwise gauge-phase distinct.
+
+Source: arXiv:1606.00608, Proposition `prop:vertical`, lines 1895--1898;
+Definition and characterization of a BNT, lines 259--301 and 1135--1148. -/
+theorem IsHorizontalCF.exists_verticalBNTGrouping_with_isometry
+    (M : MPOTensor d D) (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M) :
+    ∃ (r : ℕ) (dim : Fin r → ℕ) (μ : Fin r → ℂ)
+      (blocks : (k : Fin r) → MPSTensor (D * D) (dim k))
+      (V : (k : Fin r) → Matrix (Fin d) (Fin (dim k)) ℂ),
+      (∀ k, 0 < dim k) ∧
+      (∀ k, (0 : ℂ) < μ k) ∧
+      (∀ k, MPSTensor.IsNormalTensor (blocks k)) ∧
+      (∀ k, (V k)ᴴ * V k = 1) ∧
+      (∀ k l, k ≠ l → (V k)ᴴ * V l = 0) ∧
+      (∀ k v, verticalTensor M v * V k = V k * (μ k • blocks k v)) ∧
+      (∀ k v, (V k)ᴴ * verticalTensor M v = (μ k • blocks k v) * (V k)ᴴ) ∧
+      (∀ k v, μ k • blocks k v = (V k)ᴴ * verticalTensor M v * V k) ∧
+      (∀ v, verticalTensor M v = ∑ k, V k * (μ k • blocks k v) * (V k)ᴴ) ∧
+      let classes := MPSTensor.mpvPhaseClassData blocks
+      ∃ (hdim : ∀ j q,
+          dim (classes.repr j) = dim (classes.enum j q))
+        (X : (j : Fin classes.g) → (q : Fin (classes.copies j)) →
+          GL (Fin (dim (classes.enum j q))) ℂ)
+        (ζ : (j : Fin classes.g) → Fin (classes.copies j) → ℂ),
+        (∀ j q, ζ j q ≠ 0) ∧
+        (∀ j q v,
+          blocks (classes.enum j q) v =
+            ζ j q •
+              ((X j q : Matrix (Fin (dim (classes.enum j q)))
+                  (Fin (dim (classes.enum j q))) ℂ) *
+                (cast (congr_arg (MPSTensor (D * D)) (hdim j q))
+                  (blocks (classes.repr j))) v *
+                (↑((X j q)⁻¹) : Matrix (Fin (dim (classes.enum j q)))
+                  (Fin (dim (classes.enum j q))) ℂ))) ∧
+        MPSTensor.IsCPSVBasisOfNormalTensors
+          (MPSTensor.toTensorFromBlocks (d := D * D) (μ := μ) blocks)
+          (fun j => ⟨dim (classes.repr j), blocks (classes.repr j)⟩) ∧
+        MPSTensor.BlocksNotGaugePhaseEquiv
+          (d := D * D) (fun j => blocks (classes.repr j)) ∧
+        (∀ j q, μ (classes.enum j q) * ζ j q ≠ 0) ∧
+        (∀ j q, (V (classes.enum j q))ᴴ * V (classes.enum j q) = 1) ∧
+        (∀ j q l p, classes.enum j q ≠ classes.enum l p →
+          (V (classes.enum j q))ᴴ * V (classes.enum l p) = 0) ∧
+        (∀ j q v,
+          verticalTensor M v * V (classes.enum j q) =
+            V (classes.enum j q) *
+              ((μ (classes.enum j q) * ζ j q) •
+                ((X j q : Matrix (Fin (dim (classes.enum j q)))
+                    (Fin (dim (classes.enum j q))) ℂ) *
+                  (cast (congr_arg (MPSTensor (D * D)) (hdim j q))
+                    (blocks (classes.repr j))) v *
+                  (↑((X j q)⁻¹) : Matrix (Fin (dim (classes.enum j q)))
+                    (Fin (dim (classes.enum j q))) ℂ)))) ∧
+        (∀ j q v,
+          (V (classes.enum j q))ᴴ * verticalTensor M v =
+            ((μ (classes.enum j q) * ζ j q) •
+                ((X j q : Matrix (Fin (dim (classes.enum j q)))
+                    (Fin (dim (classes.enum j q))) ℂ) *
+                  (cast (congr_arg (MPSTensor (D * D)) (hdim j q))
+                    (blocks (classes.repr j))) v *
+                  (↑((X j q)⁻¹) : Matrix (Fin (dim (classes.enum j q)))
+                    (Fin (dim (classes.enum j q))) ℂ))) *
+              (V (classes.enum j q))ᴴ) ∧
+        (∀ j q v,
+          (μ (classes.enum j q) * ζ j q) •
+              ((X j q : Matrix (Fin (dim (classes.enum j q)))
+                  (Fin (dim (classes.enum j q))) ℂ) *
+                (cast (congr_arg (MPSTensor (D * D)) (hdim j q))
+                  (blocks (classes.repr j))) v *
+                (↑((X j q)⁻¹) : Matrix (Fin (dim (classes.enum j q)))
+                  (Fin (dim (classes.enum j q))) ℂ)) =
+            (V (classes.enum j q))ᴴ * verticalTensor M v * V (classes.enum j q)) ∧
+        ∀ v, verticalTensor M v =
+          ∑ j : Fin classes.g, ∑ q : Fin (classes.copies j),
+            V (classes.enum j q) *
+              ((μ (classes.enum j q) * ζ j q) •
+                ((X j q : Matrix (Fin (dim (classes.enum j q)))
+                    (Fin (dim (classes.enum j q))) ℂ) *
+                  (cast (congr_arg (MPSTensor (D * D)) (hdim j q))
+                    (blocks (classes.repr j))) v *
+                  (↑((X j q)⁻¹) : Matrix (Fin (dim (classes.enum j q)))
+                    (Fin (dim (classes.enum j q))) ℂ))) *
+              (V (classes.enum j q))ᴴ := by
+  classical
+  obtain ⟨r, dim, μ, blocks, V, hdimPos, hμPos, hNormal, hIso, hOrth,
+    hInt, hIntStar, hCorner, hReconstruct⟩ :=
+    hHorizontal.exists_normal_verticalBlockDecomp_with_isometry M hM
+  let classes := MPSTensor.mpvPhaseClassData blocks
+  haveI : ∀ k, NeZero (dim k) := fun k => ⟨(hdimPos k).ne'⟩
+  have hClassGauge : ∀ j q,
+      ∃ hdim : dim (classes.repr j) = dim (classes.enum j q),
+        MPSTensor.GaugePhaseEquiv
+          (cast (congr_arg (MPSTensor (D * D)) hdim) (blocks (classes.repr j)))
+          (blocks (classes.enum j q)) := by
+    intro j q
+    exact MPSTensor.MPVBlockPhaseEquiv.dim_eq_and_gaugePhaseEquiv_of_isNormalTensor
+      (hNormal (classes.repr j)) (hNormal (classes.enum j q))
+      (classes.enum_phase j q)
+  choose hdim hGaugePhase using hClassGauge
+  choose X ζ hζNe hGauge using hGaugePhase
+  have hCornerEq : ∀ j q v,
+      μ (classes.enum j q) • blocks (classes.enum j q) v =
+        (μ (classes.enum j q) * ζ j q) •
+          ((X j q : Matrix _ _ ℂ) *
+            (cast (congr_arg (MPSTensor (D * D)) (hdim j q))
+              (blocks (classes.repr j))) v *
+            (((X j q)⁻¹ : GL (Fin (dim (classes.enum j q))) ℂ) :
+              Matrix _ _ ℂ)) := by
+    intro j q v
+    rw [hGauge j q v, smul_smul]
+  have hBNT : MPSTensor.IsCPSVBasisOfNormalTensors
+      (MPSTensor.toTensorFromBlocks (d := D * D) (μ := μ) blocks)
+      (fun j => ⟨dim (classes.repr j), blocks (classes.repr j)⟩) := by
+    refine ⟨fun j => hNormal (classes.repr j), ?_, ?_⟩
+    · intro N
+      let phase : (j : Fin classes.g) → Fin (classes.copies j) → ℂ :=
+        fun j q => (classes.enum_phase j q).choose
+      refine ⟨fun j => ∑ q : Fin (classes.copies j),
+        (μ (classes.enum j q) * phase j q) ^ N, ?_⟩
+      intro w
+      calc
+        MPSTensor.mpv
+            (MPSTensor.toTensorFromBlocks (d := D * D) (μ := μ) blocks) w =
+            ∑ k : Fin r, (μ k) ^ N * MPSTensor.mpv (blocks k) w := by
+              simpa [smul_eq_mul] using
+                (MPSTensor.mpv_toTensorFromBlocks_eq_sum
+                  (d := D * D) μ blocks w)
+        _ = ∑ j : Fin classes.g, ∑ q : Fin (classes.copies j),
+            (μ (classes.enum j q)) ^ N *
+              MPSTensor.mpv (blocks (classes.enum j q)) w :=
+              (classes.regroup fun k => (μ k) ^ N * MPSTensor.mpv (blocks k) w).symm
+        _ = ∑ j : Fin classes.g, ∑ q : Fin (classes.copies j),
+            (μ (classes.enum j q) * phase j q) ^ N *
+              MPSTensor.mpv (blocks (classes.repr j)) w := by
+              refine Finset.sum_congr rfl fun j _ =>
+                Finset.sum_congr rfl fun q _ => ?_
+              rw [(classes.enum_phase j q).choose_spec.2 N w, mul_pow]
+              ring
+        _ = ∑ j : Fin classes.g,
+            (∑ q : Fin (classes.copies j),
+              (μ (classes.enum j q) * phase j q) ^ N) *
+                MPSTensor.mpv (blocks (classes.repr j)) w := by
+              refine Finset.sum_congr rfl fun j _ => ?_
+              rw [Finset.sum_mul]
+    · exact
+        MPSTensor.exists_eventually_linearIndependent_of_normalTensor_blocks_not_gaugePhaseEquiv
+          (fun j => blocks (classes.repr j))
+          (fun j => hNormal (classes.repr j)) classes.blocks_not_equiv
+  refine ⟨r, dim, μ, blocks, V, hdimPos, hμPos, hNormal, hIso, hOrth,
+    hInt, hIntStar, hCorner, hReconstruct, hdim, X, ζ, hζNe, hGauge, hBNT,
+    classes.blocks_not_equiv, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · intro j q
+    exact mul_ne_zero (hμPos (classes.enum j q)).ne' (hζNe j q)
+  · intro j q
+    exact hIso (classes.enum j q)
+  · intro j q l p hne
+    exact hOrth (classes.enum j q) (classes.enum l p) hne
+  · intro j q v
+    rw [← hCornerEq j q v]
+    exact hInt (classes.enum j q) v
+  · intro j q v
+    rw [← hCornerEq j q v]
+    exact hIntStar (classes.enum j q) v
+  · intro j q v
+    rw [← hCornerEq j q v]
+    exact hCorner (classes.enum j q) v
+  · intro v
+    calc
+      verticalTensor M v =
+          ∑ k : Fin r, V k * (μ k • blocks k v) * (V k)ᴴ := hReconstruct v
+      _ = ∑ j : Fin classes.g, ∑ q : Fin (classes.copies j),
+          V (classes.enum j q) *
+            (μ (classes.enum j q) • blocks (classes.enum j q) v) *
+              (V (classes.enum j q))ᴴ := by
+            exact (classes.regroup_matrix fun k =>
+              V k * (μ k • blocks k v) * (V k)ᴴ).symm
+      _ = ∑ j : Fin classes.g, ∑ q : Fin (classes.copies j),
+          V (classes.enum j q) *
+            ((μ (classes.enum j q) * ζ j q) •
+              ((X j q : Matrix _ _ ℂ) *
+                (cast (congr_arg (MPSTensor (D * D)) (hdim j q))
+                  (blocks (classes.repr j))) v *
+                (((X j q)⁻¹ : GL (Fin (dim (classes.enum j q))) ℂ) :
+                  Matrix _ _ ℂ))) *
+            (V (classes.enum j q))ᴴ := by
+              refine Finset.sum_congr rfl fun j _ =>
+                Finset.sum_congr rfl fun q _ => ?_
+              rw [hCornerEq j q v]
+
+end MPOTensor

--- a/TNLean/MPS/Symmetry/StringOrderAux.lean
+++ b/TNLean/MPS/Symmetry/StringOrderAux.lean
@@ -10,6 +10,7 @@ import TNLean.Channel.FixedPoint.CanonicalGauge
 import TNLean.Channel.Irreducible.Ergodicity
 import TNLean.Channel.Irreducible.PerronFrobenius
 import TNLean.Channel.Irreducible.Similarity
+import TNLean.Channel.Irreducible.SpectralRadius
 import TNLean.Channel.Irreducible.TraceAdjoint
 import TNLean.Channel.KrausRepresentation
 import TNLean.Spectral.TransferOperatorGapNT
@@ -27,6 +28,10 @@ boundary-state invariance `V† Λ V = Λ`.
 
 * `TwistedTPGaugeSetup` — bundled TP-gauge data for the spectral radius bound
 * `transferMap_tpGauge_eq_similarityMap` — similarity transform of the transfer map
+* `isPrimitive_transferMap_tpGauge_iff` — invariance of primitivity under the
+  Perron gauge
+* `gaugePhaseEquiv_of_gaugeEquiv_left_right_cast` — transport of gauge-phase
+  equivalence across two gauges and a bond-dimension identification
 * `virtualUnitary_of_gaugePhaseEquiv_twisted` — normalization of a gauge-phase
   intertwiner to a unitary
 * `boundaryState_invariant_of_virtualUnitary` — boundary-state invariance `V† Λ V = Λ`
@@ -79,6 +84,19 @@ lemma transferMap_tpGauge_eq_similarityMap
               Matrix.mul_assoc]
   exact congrFun (congrFun hcalc i) j
 
+/-- Positive-definite TP gauging preserves peripheral-spectrum primitivity. -/
+lemma isPrimitive_transferMap_tpGauge_iff
+    (A : MPSTensor d D)
+    (σ : Matrix (Fin D) (Fin D) ℂ)
+    (hσ : σ.PosDef) :
+    _root_.IsPrimitive (transferMap (tpGauge (d := d) (D := D) A σ)) ↔
+      _root_.IsPrimitive (transferMap A) := by
+  set S : Matrix (Fin D) (Fin D) ℂ := CFC.sqrt σ
+  have hS_det : S.det ≠ 0 := by
+    exact (isUnit_det_cfc_sqrt_of_posDef (D := D) σ hσ).ne_zero
+  rw [transferMap_tpGauge_eq_similarityMap A σ hσ]
+  exact IsPrimitive.similarityMap_iff S⁻¹ (by simpa [Matrix.det_nonsing_inv] using hS_det) _
+
 /-- TP gauging preserves irreducibility when the original transfer map is
 irreducible. -/
 lemma isIrreducibleTensor_tpGauge_of_isIrreducibleMap [NeZero D]
@@ -128,7 +146,20 @@ lemma gaugePhaseEquiv_of_gaugeEquiv_left_right
     _ = ζ • (((Z⁻¹ * Y * X : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) * A i *
           (((Z⁻¹ * Y * X : GL (Fin D) ℂ)⁻¹ : GL (Fin D) ℂ) :
             Matrix (Fin D) (Fin D) ℂ)) := by
-          simp [Matrix.mul_assoc, mul_inv_rev]
+      simp [Matrix.mul_assoc, mul_inv_rev]
+
+/-- Gauge equivalence on both sides transports a casted gauge-phase
+equivalence back to the original tensors. -/
+lemma gaugePhaseEquiv_of_gaugeEquiv_left_right_cast
+    {D₁ D₂ : ℕ} (hdim : D₁ = D₂)
+    {A A' : MPSTensor d D₁} {B B' : MPSTensor d D₂}
+    (hAA' : GaugeEquiv A A')
+    (hA'B' : GaugePhaseEquiv
+      (cast (congr_arg (MPSTensor d) hdim) A') B')
+    (hBB' : GaugeEquiv B B') :
+    GaugePhaseEquiv (cast (congr_arg (MPSTensor d) hdim) A) B := by
+  subst hdim
+  simpa using gaugePhaseEquiv_of_gaugeEquiv_left_right hAA' hA'B' hBB'
 
 /-- Bundled TP-gauge data for a twisted MPS tensor, used to reduce the spectral radius
 bound to the TP-normalized setting in the string-order proofs. -/

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -517,6 +517,37 @@ boundary conditions (PBC).
     injective.
 \end{definition}
 
+\begin{lemma}[Gauge invariance of block injectivity]
+    \label{lem:gauge_invariance_block_injective}
+    \lean{MPSTensor.isNBlkInjective_of_gaugeEquiv}
+    \leanok
+    \uses{def:gauge_equiv, def:l_blk_injective}
+    If $A$ and $B$ are gauge equivalent and $A$ is $L$-block injective, then
+    $B$ is $L$-block injective.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:eval_word_gauge}
+    Conjugation by an invertible matrix maps the span of the length-$L$ words
+    of $A$ onto the span of the length-$L$ words of $B$. Since conjugation is
+    an automorphism of the full matrix algebra, fullness of the first span
+    implies fullness of the second.
+\end{proof}
+
+\begin{theorem}[Gauge transport of normality]
+    \label{thm:gauge_invariance_normal}
+    \lean{MPSTensor.isNormal_of_gaugeEquiv}
+    \leanok
+    \uses{def:gauge_equiv, def:normal}
+    If $A$ and $B$ are gauge equivalent and $A$ is normal, then $B$ is normal.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:gauge_invariance_block_injective}
+    Apply Lemma~\ref{lem:gauge_invariance_block_injective} at a blocking length
+    for which $A$ is block-injective.
+\end{proof}
+
 \begin{remark}\leanok
     \uses{lem:primitive_implies_irreducible, thm:burnside_matrix,
         thm:normal_from_primitive_posdef, thm:algspan_to_normal,

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -40,6 +40,143 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
     block MPVs $\{\ket{V^{(N)}(A_j)}\}$ are eventually linearly independent.
 \end{definition}
 
+\begin{lemma}[Perron gauges preserve primitivity]
+    \label{lem:perron_gauge_primitive_iff}
+    \lean{MPSTensor.isPrimitive_transferMap_tpGauge_iff}
+    \leanok
+    \uses{def:primitive_channel}
+    Let $\sigma$ be positive definite. The transfer map of the Perron gauge
+    determined by $\sigma$ is primitive if and only if the original transfer
+    map is primitive.
+\end{lemma}
+
+\begin{proof}\leanok
+    The two transfer maps are similar through the invertible congruence
+    $X\mapsto\sigma^{-1/2}X\sigma^{-1/2}$. Similar linear maps have the same
+    spectrum, so the condition that $1$ is the only eigenvalue on the unit
+    circle is unchanged.
+\end{proof}
+
+\begin{theorem}[Spectral normality gives a pure trace-preserving gauge]
+    \label{thm:cpsv_normal_tp_gauge}
+    \lean{MPSTensor.IsNormalTensor.exists_tpGauge}
+    \leanok
+    \uses{def:nt_cpsv}
+    Let $A$ be a normal tensor of positive bond dimension in the sense of
+    \cite[Section~2.2]{Cirac2016MPDO_arXiv}. There is a positive definite
+    matrix $\sigma$ such that the gauge obtained from $\sigma$ is
+    trace-preserving, primitive, and irreducible. No scalar rescaling is
+    needed.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:perron_gauge_primitive_iff}
+    The irreducible Perron--Frobenius theorem gives positive definite right and
+    left eigenvectors with positive eigenvalues $r$ and $t$. The spectral
+    normalization gives $r=1$. Adjointness with respect to the trace pairing
+    gives
+    \[
+        r\,\Tr(\sigma\rho)=t\,\Tr(\sigma\rho).
+    \]
+    Since $\sigma$ and $\rho$ are positive definite, their pairing is nonzero,
+    hence $t=1$. Thus the Perron gauge is a pure similarity. Irreducibility and
+    primitivity are invariant under this similarity.
+\end{proof}
+
+\begin{theorem}[Spectral normality gives eventual block injectivity]
+    \label{thm:cpsv_normal_eventually_injective}
+    \lean{MPSTensor.IsNormalTensor.isNormal}
+    \leanok
+    \uses{def:nt_cpsv, def:normal}
+    Every positive-bond-dimension normal tensor in the sense of
+    \cite[Section~2.2]{Cirac2016MPDO_arXiv} is injective after blocking by some
+    finite length.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:cpsv_normal_tp_gauge, thm:normal_tp_primitive_irred}
+    Apply Theorem~\ref{thm:cpsv_normal_tp_gauge}. The trace-preserving,
+    primitive, irreducible representative is eventually block-injective, and
+    gauge invariance transports this conclusion back to the original tensor.
+\end{proof}
+
+\begin{lemma}[Exact MPV phase equivalence determines the bond dimension]
+    \label{lem:mpv_block_phase_equiv_dim_eq}
+    \lean{MPSTensor.MPVBlockPhaseEquiv.dim_eq}
+    \leanok
+    \uses{def:mpv_block_phase_equiv}
+    Suppose that, for two tensors $A$ and $B$ and some nonzero
+    $\zeta\in\C$,
+    \[
+        \ket{V^{(N)}(B)}=\zeta^N\ket{V^{(N)}(A)}
+    \]
+    at every nonnegative length $N$. Then $A$ and $B$ have the same bond
+    dimension.
+\end{lemma}
+
+\begin{proof}\leanok
+    At length zero the two coefficients are the traces of the corresponding
+    identity matrices, while $\zeta^0=1$. Their equality is therefore equality
+    of the two bond dimensions.
+\end{proof}
+
+\begin{theorem}[Phase-equivalent normal tensors are gauge-phase equivalent]
+    \label{thm:cpsv_normal_mpv_phase_gauge}
+    \lean{MPSTensor.MPVBlockPhaseEquiv.dim_eq_and_gaugePhaseEquiv_of_isNormalTensor}
+    \leanok
+    \uses{def:nt_cpsv, def:mpv_block_phase_equiv,
+        def:gauge_phase_equiv}
+    Let $A$ and $B$ be normal tensors of positive, possibly different, bond
+    dimensions. Suppose that, for some nonzero $\zeta\in\C$,
+    \[
+        \ket{V^{(N)}(B)}=\zeta^N\ket{V^{(N)}(A)}
+        \qquad (N\geq 0).
+    \]
+    Then the bond dimensions are equal and there is an invertible matrix $X$
+    and a nonzero scalar $\eta$ such that
+    \[
+        B^i=\eta X A^iX^{-1}
+    \]
+    for every physical letter $i$. This is the gauge recovery used in
+    \cite[Appendix~A]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:mpv_block_phase_equiv_dim_eq, thm:cpsv_normal_tp_gauge,
+        thm:nt_overlap_norm_one_gauge}
+    Lemma~\ref{lem:mpv_block_phase_equiv_dim_eq} gives equality of bond
+    dimensions. Apply Theorem~\ref{thm:cpsv_normal_tp_gauge} to both tensors.
+    Gauge invariance of matrix product vectors preserves the phase relation,
+    whose self-overlap identities imply unit modulus for the phase. The
+    unit-overlap rigidity theorem then gives a gauge-phase equivalence between
+    the trace-preserving representatives. Conjugating by the two Perron gauges
+    gives the asserted relation for $A$ and $B$.
+\end{proof}
+
+\begin{theorem}[Separated normal tensors are eventually independent]
+    \label{thm:cpsv_normal_separated_eventually_li}
+    \lean{MPSTensor.exists_eventually_linearIndependent_of_normalTensor_blocks_not_gaugePhaseEquiv}
+    \leanok
+    \uses{def:nt_cpsv, def:blocks_not_gauge_phase_equiv}
+    Let $(A_j)_{j=1}^g$ be a finite family of positive-bond-dimension normal
+    tensors, no two of which are gauge-phase equivalent after identifying
+    equal bond dimensions. Then the matrix product vectors
+    $\{\ket{V^{(N)}(A_j)}\}_{j=1}^g$ are linearly independent for all
+    sufficiently large $N$, as in
+    \cite[Appendix~A]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:cpsv_normal_tp_gauge,
+        lem:bnt_finite_index_overlap_orthonormal_li}
+    Put every tensor in the pure trace-preserving gauge of
+    Theorem~\ref{thm:cpsv_normal_tp_gauge}. Distinct gauge-phase classes have
+    overlaps tending to zero, while each self-overlap tends to one. The finite
+    Gram matrix therefore tends to the identity and is invertible for all
+    sufficiently large lengths. Gauge invariance of matrix product vectors
+    gives the conclusion for the original tensors.
+\end{proof}
+
 \begin{figure}[ht]
     \centering
     \TNBNTDecomposition
@@ -699,6 +836,23 @@ single family.
     representative to each member, and proves that distinct representatives are
     not MPV-phase equivalent.
 \end{definition}
+
+\begin{lemma}[Regrouping a matrix sum by MPV phase classes]
+    \label{lem:mpv_phase_class_regroup_matrix}
+    \lean{MPSTensor.MPVPhaseClassData.regroup_matrix}
+    \leanok
+    \uses{def:mpv_phase_class_data}
+    Let $F_k$ be a finite family of square matrices indexed by the original
+    blocks. If $k=(j,q)$ enumerates the copies in the MPV phase classes, then
+    \[
+        \sum_j\sum_q F_{j,q}=\sum_k F_k.
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    Evaluate both sides at a pair of matrix indices and apply the bijective
+    enumeration of the finite phase-class quotient.
+\end{proof}
 
 \begin{definition}[BNT canonical form]%
     \label{def:sector_bnt_cf}

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -2295,6 +2295,57 @@
     orthogonal complement is a zero sector.
 \end{proof}
 
+\begin{theorem}[Vertical normal sectors grouped into BNT representatives]
+    \label{thm:mpdo_vertical_bnt_grouping_with_isometries}
+    \lean{MPOTensor.IsHorizontalCF.exists_verticalBNTGrouping_with_isometry}
+    \leanok
+    \uses{def:mpdo, def:horizontal_cf_mpdo, def:vertical_tensor_mpdo,
+        def:bnt_cpsv, def:mpv_phase_class_data}
+    Under the same hypotheses, partition the normalized vertical sectors by
+    equality of their matrix product vector families up to a fixed phase per
+    site. There are normal representatives $M_\alpha$, an enumeration
+    $k=(\alpha,q)$ of the original sectors, invertible matrices
+    $X_{\alpha,q}$, and nonzero complex numbers $\zeta_{\alpha,q}$ such that
+    \[
+        B_{\alpha,q}^v
+        =\zeta_{\alpha,q}X_{\alpha,q}M_\alpha^vX_{\alpha,q}^{-1}.
+    \]
+    The representatives are pairwise gauge-phase distinct and form a basis of
+    normal tensors for the weighted block tensor
+    $\bigoplus_k\mu_kB_k$. Every grouped coefficient
+    $\mu_{\alpha,q}\zeta_{\alpha,q}$ is nonzero. With the physical isometries
+    from Theorem~\ref{thm:mpdo_vertical_normal_sectors_with_isometries}
+    retained unchanged, one has both reducing identities, exact compression,
+    and the literal reconstruction
+    \[
+        \widetilde M_v
+        =\sum_\alpha\sum_q
+        V_{\alpha,q}
+        \bigl(\mu_{\alpha,q}\zeta_{\alpha,q}
+        X_{\alpha,q}M_\alpha^vX_{\alpha,q}^{-1}\bigr)
+        V_{\alpha,q}^\dagger .
+    \]
+    No positivity of the grouped coefficients and no unitarity of the gauges
+    is asserted at this stage. This is the decomposition at the beginning of
+    the last part of \cite[Proposition~4.13]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_vertical_normal_sectors_with_isometries,
+        thm:cpsv_normal_mpv_phase_gauge,
+        thm:cpsv_normal_separated_eventually_li}
+    Take one representative from each phase class. Theorem~\ref{thm:cpsv_normal_mpv_phase_gauge}
+    gives equality of bond dimensions and the displayed letterwise gauge-phase
+    relation for every copy. Distinct representatives are gauge-phase
+    separated by construction, so
+    Theorem~\ref{thm:cpsv_normal_separated_eventually_li} gives eventual linear
+    independence. The phase-class regrouping of the finite sum gives the BNT
+    expansion. Substitution in the two intertwining identities, the compression
+    identity, and the literal reconstruction from
+    Theorem~\ref{thm:mpdo_vertical_normal_sectors_with_isometries} proves all
+    remaining assertions without altering any physical isometry.
+\end{proof}
+
 \begin{theorem}[Horizontal canonical form implies vertical canonical form]
     \label{thm:vertical_cf_of_horizontal_cf}
     \notready
@@ -2308,6 +2359,7 @@
         thm:mpdo_vertical_irreducible_reducing_sectors,
         thm:mpdo_vertical_complete_reducing_projectors,
         thm:mpdo_vertical_normal_sectors_with_isometries,
+        thm:mpdo_vertical_bnt_grouping_with_isometries,
         thm:projector_closure_canonical_form,
         thm:mpdo_sector_compression_trace_pos,
         def:mpdo_sector_projector,
@@ -2345,6 +2397,7 @@
         thm:mpdo_vertical_projector_closure,
         thm:mpdo_vertical_irreducible_reducing_sectors,
         thm:mpdo_vertical_complete_reducing_projectors,
+        thm:mpdo_vertical_bnt_grouping_with_isometries,
         thm:projector_closure_canonical_form,
         thm:mpdo_sector_compression_trace_pos,
         def:mpdo_sector_projector,

--- a/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
@@ -149,6 +149,20 @@ in \path{TNLean/MPS/MPDO/VerticalSpectral.lean}).  The complement of their
 range projections consists precisely of the omitted zero corners, so no
 false completeness assertion is made after this removal.
 
+The normalized corners are now grouped by matrix-product-vector phase class
+in
+\path{MPOTensor.IsHorizontalCF.exists_verticalBNTGrouping_with_isometry}
+(\path{TNLean/MPS/MPDO/VerticalBNT.lean}).  One normal representative is
+chosen from each class.  Every copy has the same bond dimension as its
+representative and is a nonzero complex scalar times an invertible conjugate
+of that representative.  The representatives are pairwise gauge-phase
+distinct and form a basis of normal tensors for the weighted block tensor.
+The physical isometries are not changed: both intertwining identities, exact
+compression, and the literal reconstruction of each vertical letter survive
+the regrouping.  This formalizes the decomposition displayed at source
+lines~1895--1898, before the subsequent positivity and unitary-gauge
+arguments.
+
 The periodic-sector exclusion is also complete:
 \path{MPOTensor.hasNoPeriodicVectors_verticalTensor_of_horizontalCF} derives
 the displaced cyclic projector associated with a nontrivial period, together
@@ -178,18 +192,17 @@ $\omega_{\alpha,k}^{-1/2}X_{\alpha,k}$ unitary
 (\path{MPSTensor.IsNormal.smul_mem_unitaryGroup_of_dressed_adjoint} in
 \path{TNLean/MPS/CanonicalForm/NormalCommutant.lean}).
 
-The remaining source-level gap begins with grouping the normalized corners
-above into gauge-equivalent copies of a basis of normal tensors.  One must
-identify the resulting grouped projections with the sector projectors
-carrying the single-site loop identities and prove a nonvanishing
-compression. One must then derive the
-dressed-adjoint identities from self-adjointness of the sector compressions
-and assemble the positive weights and proportional-unitary gauges of source
-lines~1895--1921. This is the mathematical content shared with the normality
-and grouping problem tracked by \ghissue{2537}; it cannot be supplied by a
-finite-sum identity alone. The original formulation of \ghissue{2536},
-interpreted as a direct conversion of the horizontal scalar weights and
-diagonal restrictions, is therefore not a consequence of Proposition~4.13.
+The remaining source-level gap begins after this grouping.  One must identify
+the grouped range projections with the sector projectors carrying the
+single-site loop identities and prove that the relevant compressions are
+nonzero.  Positivity must then be used to show that the grouped coefficients
+are positive.  Finally, one must derive the dressed-adjoint identities from
+self-adjointness of the sector compressions and use them to replace each
+invertible gauge by a proportional unitary, as in source lines~1898--1921.
+These conclusions are not part of the grouping theorem.  The original
+formulation of \ghissue{2536}, interpreted as a direct conversion of the
+horizontal scalar weights and diagonal restrictions, is therefore not a
+consequence of Proposition~4.13.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
@@ -181,11 +181,15 @@ the absence of periodic vectors already give an abstract positive-length
 normal-block decomposition
 (\path{TNLean/MPS/CanonicalForm/ProjectorClosureSpectral.lean}). The literal
 isometry-preserving refinement is now supplied by
-\path{TNLean/MPS/MPDO/VerticalSpectral.lean}. What remains open is to group
-the normal blocks. This must identify the grouped sector projectors
-with their loop identities and a nonvanishing compression, together with the
-derivation of the dressed-adjoint identities from self-adjointness of the
-sector compressions.
+\path{TNLean/MPS/MPDO/VerticalSpectral.lean}. The normal blocks are now
+grouped into pairwise gauge-phase-distinct BNT representatives in
+\path{TNLean/MPS/MPDO/VerticalBNT.lean}. Every copy is expressed by a
+nonzero complex coefficient and an invertible bond-space gauge, while the
+physical isometries and the literal vertical reconstruction are retained.
+What remains open is to identify the grouped range projections with their
+loop identities and prove a nonvanishing compression, then derive positivity
+of the grouped coefficients and the dressed-adjoint identities needed to
+normalize the gauges to unitaries.
 
 \paragraph{Verdict.}
 This is an open gap: the source-faithful horizontal-to-vertical implication of


### PR DESCRIPTION
### Motivation

- Proposition 4.13 of arXiv:1606.00608 passes from the vertical normal-sector decomposition to gauge-phase classes before proving positivity and unitary normalization. In `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 1895--1898, the source states that the tensor “can be written as”
  \[
  \bigoplus_{\alpha,k}\mu_{\alpha,k}X_{\alpha,k}M_\alpha X_{\alpha,k}^{-1}.
  \]
- The preceding formalization supplied normalized normal corners and their physical isometries, but not the bond-dimension identifications, explicit gauges, or basis-of-normal-tensors grouping required by this display.

### Description

- Proves that spectral normality admits a pure trace-preserving Perron gauge and implies eventual block injectivity, with primitivity and normality transported through gauge equivalence.
- Proves that exact matrix-product-vector phase equivalence between normal tensors forces equality of bond dimensions and is realized by a letterwise invertible gauge and a nonzero scalar.
- Proves eventual linear independence for a finite gauge-phase-separated family of normal tensors.
- Groups every normalized vertical corner into a unique phase class, chooses pairwise distinct normal representatives, and proves that they form a basis of normal tensors for the weighted block tensor.
- Retains the original pairwise orthogonal physical isometries, both reducing identities, exact compression, and the literal double-sum reconstruction of every vertical letter.
- Updates the blueprint and the two paper-gap notes. Positivity of the grouped coefficients, loop-projector identification, dressed-adjoint identities, and unitary normalization remain explicitly outside this result.

### Testing

- `lake build TNLean`
- `lake exe checkdecls blueprint/lean_decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `leanblueprint web`
- `python3 scripts/check_reader_facing_prose.py --diff-base HEAD`
- `git diff --check`
- Audited every new declaration with `#print axioms`; each depends only on `propext`, `Classical.choice`, and `Quot.sound`.
- Searched all changed Lean files for `sorry`, `axiom`, `admit`, `native_decide`, `unsafeCast`, and related proof bypasses; none was introduced.

---
Closes #3879

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new formal proof surface on MPS canonical form and MPDO vertical CF (spectral/Perron–Frobenius and gauge invariance), but changes are additive lemmas and one grouping theorem; downstream vertical CF and positivity steps remain separate.
> 
> **Overview**
> This PR closes the **gauge-phase grouping** step in Proposition 4.13 (arXiv:1606.00608, ~1895–1898): after spectrally normalized vertical corners exist, corners are partitioned by MPV phase class and expressed as nonzero scalars times invertible conjugates of pairwise distinct normal representatives.
> 
> **Normal tensors (`NormalTensorGauge.lean`).** Spectral `IsNormalTensor` yields a **pure trace-preserving Perron gauge** (no extra rescaling when spectral radius is 1), **eventual block injectivity**, **MPV phase ⇒ gauge-phase** (with bond-dimension equality), and **eventual linear independence** for gauge-phase-separated finite families. Supporting pieces: primitivity under Perron gauge (`isPrimitive_transferMap_tpGauge_iff`, `IsPrimitive.similarityMap_iff`), gauge transport of normality/block injectivity in `Defs.lean`, `MPVBlockPhaseEquiv.dim_eq`, and matrix regrouping by phase classes.
> 
> **MPDO capstone (`VerticalBNT.lean`).** `IsHorizontalCF.exists_verticalBNTGrouping_with_isometry` retains the original orthogonal physical isometries and all intertwining/compression/reconstruction identities while proving BNT basis data and the double-sum display with grouped coefficients `μ·ζ`. Positivity of grouped weights, loop-projector identification, dressed-adjoint identities, and unitary gauge normalization are **explicitly out of scope**.
> 
> Blueprint (`ch02_mps`, `ch10_bnt`, `ch20_mpdo_canonical_forms`) and paper-gap notes are updated to match; `TNLean.lean` wires in `VerticalBNT`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc7bb41e017f4708dbb675546bbab340cc479394. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->