### PR TITLE
fix(MPS/CanonicalForm): derive bond dimensions from overlap decay

### DIFF
--- a/TNLean/MPS/CanonicalForm/NormalTensorGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalTensorGauge.lean
@@ -151,8 +151,10 @@ This is the grouping implication in arXiv:1606.00608, Lemma `equalMPS`
 (lines 1080--1117) and Proposition `prop:char-BNT` (lines 1135--1148).
 Each tensor is first put into its trace-preserving Perron gauge.  The gauges
 are pure similarities because both tensors have spectral radius one.  The
-trace-preserving equal-overlap theorem supplies the gauge-phase relation, which
-is then transported back to the original tensors. -/
+rectangular overlap-decay theorem gives equality of the bond dimensions from
+the positive-length overlaps, without using the empty word.  The
+trace-preserving equal-overlap theorem then supplies the gauge-phase relation,
+which is transported back to the original tensors. -/
 theorem MPVBlockPhaseEquiv.dim_eq_and_gaugePhaseEquiv_of_isNormalTensor
     {DX DY : ℕ} [NeZero DX] [NeZero DY]
     {X : MPSTensor d DX} {Y : MPSTensor d DY}

--- a/TNLean/MPS/CanonicalForm/NormalTensorGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalTensorGauge.lean
@@ -162,12 +162,10 @@ theorem MPVBlockPhaseEquiv.dim_eq_and_gaugePhaseEquiv_of_isNormalTensor
       GaugePhaseEquiv
         (cast (congr_arg (MPSTensor d) hdim) X) Y := by
   classical
-  have hdim : DX = DY := h.dim_eq
-  subst hdim
   obtain ⟨σX, _hσX, _hσXfix, hTPX, hGaugeX, hPrimX, hIrrX⟩ := hX.exists_tpGauge
   obtain ⟨σY, _hσY, _hσYfix, hTPY, hGaugeY, hPrimY, hIrrY⟩ := hY.exists_tpGauge
   let X' := tpGauge (d := d) (D := DX) X σX
-  let Y' := tpGauge (d := d) (D := DX) Y σY
+  let Y' := tpGauge (d := d) (D := DY) Y σY
   have hPhase : MPVBlockPhaseEquiv X' Y' := by
     obtain ⟨ζ, hζ, hmpv⟩ := h
     refine ⟨ζ, hζ, ?_⟩
@@ -209,6 +207,10 @@ theorem MPVBlockPhaseEquiv.dim_eq_and_gaugePhaseEquiv_of_isNormalTensor
   have hCrossNorm : Tendsto
       (fun N => ‖mpvOverlap (d := d) X' Y' N‖) atTop (nhds (1 : ℝ)) :=
     hSelfNorm.congr fun N => (hCrossNormEq N).symm
+  have hdim : DX = DY :=
+    dim_eq_of_mpvOverlap_norm_tendsto_one_of_irreducible_TP
+      X' Y' hIrrX hIrrY hTPX hTPY hCrossNorm
+  subst DY
   have hGaugePhase : GaugePhaseEquiv X' Y' :=
     gaugePhaseEquiv_of_overlap_norm_tendsto_one_of_irreducible_TP
       X' Y' hIrrX hIrrY hTPX hTPY hCrossNorm

--- a/TNLean/MPS/FundamentalTheorem/Proportional.lean
+++ b/TNLean/MPS/FundamentalTheorem/Proportional.lean
@@ -154,6 +154,39 @@ private theorem gaugePhaseEquiv_of_eventually_proportionalMPV₂_of_overlap_deca
 
 /-! ## Gauge-phase equivalence from unit-modulus overlap -/
 
+/-- **Bond-dimension equality from a non-decaying rectangular overlap.**
+
+Source: arXiv:1606.00608, Lemma `equalMPS`, statement lines 1080--1091 and
+proof lines 1093--1117.  Two irreducible trace-preserving tensors whose
+rectangular MPV overlap has norm tending to one have equal bond dimensions.
+Indeed, distinct bond dimensions would force the same overlap to tend to zero.
+
+This is the bond-dimension part of the source lemma, separated from the
+same-dimension gauge recovery below.  The relation to the full source statement
+is recorded in `docs/paper-gaps/cpsv16_equalMPS_gauge_phase_gap.tex`. -/
+theorem dim_eq_of_mpvOverlap_norm_tendsto_one_of_irreducible_TP
+    {D₁ D₂ : ℕ} [NeZero D₁] [NeZero D₂]
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hA_irr : IsIrreducibleTensor A)
+    (hB_irr : IsIrreducibleTensor B)
+    (hA_norm : ∑ i : Fin d, (A i)ᴴ * A i = 1)
+    (hB_norm : ∑ i : Fin d, (B i)ᴴ * B i = 1)
+    (hOverlap :
+      Filter.Tendsto (fun N => ‖mpvOverlap (d := d) A B N‖) Filter.atTop
+        (nhds (1 : ℝ))) :
+    D₁ = D₂ := by
+  by_contra hdim
+  have hzero :
+      Filter.Tendsto (fun N => mpvOverlap (d := d) A B N) Filter.atTop
+        (nhds (0 : ℂ)) :=
+    mpvOverlap_tendsto_zero_of_dim_ne_of_irreducible_TP
+      A B hA_irr hB_irr hA_norm hB_norm hdim
+  have hnorm_zero :
+      Filter.Tendsto (fun N => ‖mpvOverlap (d := d) A B N‖) Filter.atTop
+        (nhds (0 : ℝ)) := by
+    simpa using hzero.norm
+  exact one_ne_zero (tendsto_nhds_unique hOverlap hnorm_zero)
+
 /-- **Spectral radius lower bound from unit-modulus overlap.**
 
 Source: arXiv:1606.00608, proof of Lemma equalMPS, lines 1093-1117.

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
@@ -170,18 +170,8 @@ theorem dim_eq_of_MPVBlockPhaseEquiv_of_tp_primitive_irr
     rw [hYX_eq N, norm_mul, norm_pow, hζ_norm, one_pow, one_mul]
   have hYX : Tendsto (fun N => ‖mpvOverlap (d := d) Y X N‖) atTop (𝓝 (1 : ℝ)) :=
     hXX.congr fun N => (hYX_norm_eq N).symm
-  have hDYDX : DY = DX := by
-    by_contra hD
-    have hzero :
-        Tendsto (fun N => mpvOverlap (d := d) Y X N) atTop (𝓝 (0 : ℂ)) :=
-      mpvOverlap_tendsto_zero_of_dim_ne_of_irreducible_TP
-        Y X hIrrY hIrrX hTPY hTPX hD
-    have hnorm_zero :
-        Tendsto (fun N => ‖mpvOverlap (d := d) Y X N‖) atTop (𝓝 (0 : ℝ)) := by
-      simpa using hzero.norm
-    have h10 : (1 : ℝ) = 0 := tendsto_nhds_unique hYX hnorm_zero
-    exact one_ne_zero h10
-  exact hDYDX.symm
+  exact (dim_eq_of_mpvOverlap_norm_tendsto_one_of_irreducible_TP
+    Y X hIrrY hIrrX hTPY hTPX hYX).symm
 
 /--
 **Prepared phase classes preserve the original bond dimensions.**

--- a/TNLean/MPS/MPDO/VerticalBNT.lean
+++ b/TNLean/MPS/MPDO/VerticalBNT.lean
@@ -17,8 +17,10 @@ nonzero complex scalar times an invertible conjugate of its representative.
 The physical isometries are retained unchanged, so all reducing identities and
 the literal reconstruction of every vertical letter survive the regrouping.
 
-The conclusion is precisely the display at arXiv:1606.00608, lines 1895--1898,
-using the general BNT construction at lines 259--301 and 1135--1148.  No
+This is the algebraic phase-class decomposition invoked in the first sentence
+of arXiv:1606.00608, line 1898.  It combines the BNT characterization at lines
+1135--1148 with the preceding isometry-preserving vertical sector theorem.  It
+does not prove the positive-diagonal isometry asserted at lines 1895--1896.  No
 positivity of the grouped coefficients and no unitarity of the gauges is
 asserted here; those are consequences of the subsequent MPDO argument at lines
 1898--1921.
@@ -53,8 +55,10 @@ nonzero complex number `μ (enum j q) * ζ j q`.  The representatives form a
 basis of normal tensors for the corresponding weighted block tensor and are
 pairwise gauge-phase distinct.
 
-Source: arXiv:1606.00608, Proposition `prop:vertical`, lines 1895--1898;
-Definition and characterization of a BNT, lines 259--301 and 1135--1148. -/
+Source: the algebraic phase-class decomposition in the first sentence of
+arXiv:1606.00608, line 1898, using the BNT characterization at lines
+1135--1148 and the preceding isometry-preserving vertical sector theorem.  The
+positive-diagonal isometry asserted at lines 1895--1896 is not included. -/
 theorem IsHorizontalCF.exists_verticalBNTGrouping_with_isometry
     (M : MPOTensor d D) (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M) :
     ∃ (r : ℕ) (dim : Fin r → ℕ) (μ : Fin r → ℂ)

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -120,6 +120,26 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
     of the two bond dimensions.
 \end{proof}
 
+\begin{theorem}[Non-decaying rectangular overlap determines the bond dimension]
+    \label{thm:rect_overlap_norm_one_dim_eq}
+    \lean{MPSTensor.dim_eq_of_mpvOverlap_norm_tendsto_one_of_irreducible_TP}
+    \leanok
+    \uses{def:mpv_overlap, def:irreducible_tensor, def:tp_kraus}
+    Let $A$ and $B$ be irreducible trace-preserving tensors of positive,
+    possibly different, bond dimensions. If
+    \[
+        |O_{AB}(N)|\longrightarrow 1,
+    \]
+    then their bond dimensions are equal.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:overlap_decay_rect_irr_tp}
+    If the bond dimensions differed, the rectangular overlap-decay theorem
+    would give $O_{AB}(N)\to0$, and hence $|O_{AB}(N)|\to0$, contradicting the
+    assumed limit.
+\end{proof}
+
 \begin{theorem}[Phase-equivalent normal tensors are gauge-phase equivalent]
     \label{thm:cpsv_normal_mpv_phase_gauge}
     \lean{MPSTensor.MPVBlockPhaseEquiv.dim_eq_and_gaugePhaseEquiv_of_isNormalTensor}
@@ -142,14 +162,16 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{lem:mpv_block_phase_equiv_dim_eq, thm:cpsv_normal_tp_gauge,
+    \uses{thm:cpsv_normal_tp_gauge, thm:rect_overlap_norm_one_dim_eq,
         thm:nt_overlap_norm_one_gauge}
-    Lemma~\ref{lem:mpv_block_phase_equiv_dim_eq} gives equality of bond
-    dimensions. Apply Theorem~\ref{thm:cpsv_normal_tp_gauge} to both tensors.
-    Gauge invariance of matrix product vectors preserves the phase relation,
-    whose self-overlap identities imply unit modulus for the phase. The
-    unit-overlap rigidity theorem then gives a gauge-phase equivalence between
-    the trace-preserving representatives. Conjugating by the two Perron gauges
+    Apply Theorem~\ref{thm:cpsv_normal_tp_gauge} to both tensors. Gauge
+    invariance of matrix product vectors preserves the phase relation, whose
+    self-overlap identities imply unit modulus for the phase. The resulting
+    rectangular cross-overlap has norm tending to one. If the bond dimensions
+    differed, Theorem~\ref{thm:rect_overlap_norm_one_dim_eq} would give a
+    contradiction. Thus the bond dimensions agree, and the
+    unit-overlap rigidity theorem gives a gauge-phase equivalence between the
+    trace-preserving representatives. Conjugating by the two Perron gauges
     gives the asserted relation for $A$ and $B$.
 \end{proof}
 
@@ -1144,6 +1166,7 @@ a contradiction.
 \end{lemma}
 
 \begin{proof}\leanok
+    \uses{thm:rect_overlap_norm_one_dim_eq}
     Choose $\zeta\neq0$ with
     $\ket{V^{(N)}(Y)}=\zeta^N\ket{V^{(N)}(X)}$ for every length~$N$. The
     normalized self-overlaps give $|O_{XX}(N)|\to 1$, and the phase relation

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -2302,8 +2302,8 @@
     \uses{def:mpdo, def:horizontal_cf_mpdo, def:vertical_tensor_mpdo,
         def:bnt_cpsv, def:mpv_phase_class_data}
     Under the same hypotheses, partition the normalized vertical sectors by
-    equality of their matrix product vector families up to a fixed phase per
-    site. There are normal representatives $M_\alpha$, an enumeration
+    equality of their matrix product vector families up to a fixed nonzero
+    scalar per site. There are normal representatives $M_\alpha$, an enumeration
     $k=(\alpha,q)$ of the original sectors, invertible matrices
     $X_{\alpha,q}$, and nonzero complex numbers $\zeta_{\alpha,q}$ such that
     \[

--- a/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
@@ -164,7 +164,10 @@ the first sentence of source line~1898, obtained by combining the BNT
 characterization at lines~1135--1148 with the preceding isometry-preserving
 vertical sector theorem.  It does not formalize the positive-diagonal isometry
 asserted at lines~1895--1896.  Positivity of the grouped coefficients and
-unitarity of the gauges remain part of the subsequent argument.
+unitarity of the gauges remain part of the subsequent argument.  Equality of
+the bond dimensions within each phase class is obtained from non-decay of the
+positive-length rectangular overlap, as in Lemma~\texttt{equalMPS}; the
+empty-word coefficient is not used in this comparison.
 
 The periodic-sector exclusion is also complete:
 \path{MPOTensor.hasNoPeriodicVectors_verticalTensor_of_horizontalCF} derives
@@ -195,11 +198,12 @@ $\omega_{\alpha,k}^{-1/2}X_{\alpha,k}$ unitary
 (\path{MPSTensor.IsNormal.smul_mem_unitaryGroup_of_dressed_adjoint} in
 \path{TNLean/MPS/CanonicalForm/NormalCommutant.lean}).
 
-The remaining source-level gap begins after this grouping.  One must identify
-the grouped range projections with the sector projectors carrying the
-single-site loop identities and prove that the relevant compressions are
-nonzero.  Positivity must then be used to show that the grouped coefficients
-are positive.  The copy embeddings must also be assembled into the single
+The remaining source-level gap begins after this grouping.  The ranges of the
+grouped physical isometries are already the selector projections
+$P_{\alpha,k}$ of source line~1898.  One must prove their single-site loop
+identities and show that the corresponding compressions are nonzero.  Positivity
+must then be used to show that the grouped coefficients are positive.  The copy
+embeddings must also be assembled into the single
 direct-sum coisometry $U$ (equivalently, the adjoint isometry) appearing in
 source lines~1895--1896, with the zero complement treated explicitly.  Finally,
 one must derive the dressed-adjoint identities from self-adjointness of the

--- a/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
@@ -159,9 +159,12 @@ of that representative.  The representatives are pairwise gauge-phase
 distinct and form a basis of normal tensors for the weighted block tensor.
 The physical isometries are not changed: both intertwining identities, exact
 compression, and the literal reconstruction of each vertical letter survive
-the regrouping.  This formalizes the decomposition displayed at source
-lines~1895--1898, before the subsequent positivity and unitary-gauge
-arguments.
+the regrouping.  This is the algebraic phase-class decomposition invoked in
+the first sentence of source line~1898, obtained by combining the BNT
+characterization at lines~1135--1148 with the preceding isometry-preserving
+vertical sector theorem.  It does not formalize the positive-diagonal isometry
+asserted at lines~1895--1896.  Positivity of the grouped coefficients and
+unitarity of the gauges remain part of the subsequent argument.
 
 The periodic-sector exclusion is also complete:
 \path{MPOTensor.hasNoPeriodicVectors_verticalTensor_of_horizontalCF} derives
@@ -196,9 +199,12 @@ The remaining source-level gap begins after this grouping.  One must identify
 the grouped range projections with the sector projectors carrying the
 single-site loop identities and prove that the relevant compressions are
 nonzero.  Positivity must then be used to show that the grouped coefficients
-are positive.  Finally, one must derive the dressed-adjoint identities from
-self-adjointness of the sector compressions and use them to replace each
-invertible gauge by a proportional unitary, as in source lines~1898--1921.
+are positive.  The copy embeddings must also be assembled into the single
+direct-sum coisometry $U$ (equivalently, the adjoint isometry) appearing in
+source lines~1895--1896, with the zero complement treated explicitly.  Finally,
+one must derive the dressed-adjoint identities from self-adjointness of the
+sector compressions and use them to replace each invertible gauge by a
+proportional unitary, as in source lines~1898--1921.
 These conclusions are not part of the grouping theorem.  The original
 formulation of \ghissue{2536}, interpreted as a direct conversion of the
 horizontal scalar weights and diagonal restrictions, is therefore not a

--- a/docs/paper-gaps/cpsv16_equalMPS_gauge_phase_gap.tex
+++ b/docs/paper-gaps/cpsv16_equalMPS_gauge_phase_gap.tex
@@ -102,11 +102,12 @@ theorem
 \leanid{MPSTensor.mpvOverlap_tendsto_zero_of_dim_ne_of_irreducible_TP}
 in \path{TNLean/Spectral/TransferOperatorGapNT.lean}: if the bond dimensions
 differ, the overlap tends to zero, contradicting the unit-modulus overlap
-hypothesis, so a non-decaying overlap forces $D_a=D_b$. (A standalone
-contrapositive packaging of this step in
-\path{TNLean/MPS/FundamentalTheorem/Proportional.lean} was removed as part of a
-superseded route; the decay theorem is now applied directly where blocks of
-differing dimension arise.)
+hypothesis, so a non-decaying overlap forces $D_a=D_b$.  The contrapositive is
+recorded as
+\leanid{MPSTensor.dim_eq_of_mpvOverlap_norm_tendsto_one_of_irreducible_TP}
+in \path{TNLean/MPS/FundamentalTheorem/Proportional.lean}.  Its hypotheses and
+proof involve only the positive-length asymptotic overlap and do not use the
+empty-word coefficient.
 
 This rectangular dimension recovery is genuinely needed in the proof of
 Theorem~\texttt{thm1}
@@ -122,10 +123,10 @@ after the rectangular dimension conclusion has been supplied separately.
 The same-bond-dimension gauge component is formalized without the
 source-absent MPV proportionality hypothesis. The rectangular
 bond-dimension conclusion $D_a=D_b$ follows from the rectangular overlap-decay
-theorem, which is applied directly where blocks of differing dimension arise.
-Together these two components recover the structural conclusion of the
-unit-overlap branch of Lemma~\texttt{equalMPS}, though the upstream normal-tensor
-periodicity and dichotomy statements remain separate from this note.
+theorem through its non-decay contrapositive. Together these two components
+recover the structural conclusion of the unit-overlap branch of
+Lemma~\texttt{equalMPS}, though the upstream normal-tensor periodicity and
+dichotomy statements remain separate from this note.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
### Motivation

- CPSV16 Lemma `equalMPS` proves bond-dimension equality from the non-decay of a rectangular overlap, not from an empty-word coefficient. The source is `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 1080–1117: “In the latter case, $D_a=D_b$.”
- PR #3882 used the auxiliary length-zero consequence of `MPVBlockPhaseEquiv` inside the normal-tensor comparison and described the vertical grouping too broadly as lines 1895–1898.

### Description

- Added `dim_eq_of_mpvOverlap_norm_tendsto_one_of_irreducible_TP`: unequal bond dimensions force the rectangular overlap to tend to zero, contradicting convergence of its norm to one.
- Changed `MPVBlockPhaseEquiv.dim_eq_and_gaugePhaseEquiv_of_isNormalTensor` to normalize both tensors before identifying their bond dimensions and to use the rectangular-overlap theorem.
- Reused the same result in the prepared-block dimension theorem.
- Added the corresponding checked blueprint theorem and dependency.
- Restricted the vertical-BNT source claim to the algebraic phase-class decomposition in the first sentence of source line 1898. The positive-diagonal isometry of lines 1895–1896 remains unproved.
- Corrected the paper-gap notes to record the positive-length argument and to identify the existing physical range projections with the selector projections $P_{\alpha,k}$ of line 1898.
- Coefficient positivity, dressed-adjoint identities, unitary gauges, and the final physical coisometry remain subsequent steps.

### Testing

- `lake env lean TNLean/MPS/CanonicalForm/NormalTensorGauge.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean`
- `lake env lean TNLean/MPS/MPDO/VerticalBNT.lean`
- `lake build TNLean` — 9386 jobs
- `leanblueprint web`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base main --ci`
- Proof-integrity scan and `git diff --check`
- Exact `#print axioms` audit: only `propext`, `Classical.choice`, and `Quot.sound`

---
Closes #3879
