### PR TITLE
feat(MPS/MPDO): prove positivity of grouped vertical coefficients

### DIFF
--- a/TNLean/MPS/CanonicalForm/NormalTensorGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalTensorGauge.lean
@@ -144,6 +144,77 @@ theorem IsNormalTensor.isNormal [NeZero D]
     isNormal_of_tp_primitive_irreducible _ hTP hPrim hIrr
   exact isNormal_of_gaugeEquiv hNormalGauge hGauge.symm
 
+/-- A normal tensor has a nonzero letter.
+
+Indeed, if every letter vanished, then its transfer map and hence its spectral
+radius would vanish, contradicting the spectral-radius-one normalization of
+arXiv:1606.00608, lines 231--235. -/
+theorem IsNormalTensor.exists_apply_ne_zero [NeZero D]
+    {A : MPSTensor d D} (h : IsNormalTensor A) : ∃ i, A i ≠ 0 := by
+  by_contra hzero
+  push Not at hzero
+  have hmap : transferMap (d := d) (D := D) A = 0 := by
+    ext X a b
+    simp [transferMap_apply, hzero]
+  have hspectral := h.spectral_radius_one
+  rw [hmap] at hspectral
+  simp at hspectral
+
+/-- The self-overlap of a normal tensor tends to one.
+
+The trace-preserving Perron gauge is a pure similarity, so it leaves every
+matrix product vector unchanged.  The assertion therefore follows from the
+primitive trace-preserving overlap limit.  This is the normalization used in
+the proof of Lemma `equalMPS` of arXiv:1606.00608, lines 1080--1097. -/
+theorem IsNormalTensor.selfOverlap_tendsto_one [NeZero D]
+    {A : MPSTensor d D} (hA : IsNormalTensor A) :
+    Tendsto (fun N => mpvOverlap (d := d) A A N) atTop (nhds (1 : ℂ)) := by
+  obtain ⟨σ, _hσ, _hσfix, hTP, hGauge, hPrim, hIrr⟩ := hA.exists_tpGauge
+  let A' := tpGauge (d := d) (D := D) A σ
+  have hPrepared : Tendsto (fun N => mpvOverlap (d := d) A' A' N)
+      atTop (nhds (1 : ℂ)) :=
+    overlap_tendsto_one_of_peripheralPrimitive_of_irreducible A' hIrr hTP hPrim
+  apply hPrepared.congr'
+  filter_upwards with N
+  apply Finset.sum_congr rfl
+  intro w _
+  rw [GaugeEquiv.sameMPV hGauge N w]
+
+/-- Identifying equal bond dimensions does not change normality. -/
+theorem isNormalTensor_cast_iff {D₁ D₂ : ℕ} (hdim : D₁ = D₂)
+    (A : MPSTensor d D₁) :
+    IsNormalTensor (cast (congr_arg (MPSTensor d) hdim) A) ↔ IsNormalTensor A := by
+  subst D₂
+  rfl
+
+/-- The scalar in an explicit gauge-phase relation between normal tensors has
+unit norm.
+
+After identifying the bond dimensions, the gauge relation multiplies the
+self-overlap by powers of $\zeta\overline\zeta$.  Since both normalized
+self-overlaps tend to one, $\lVert\zeta\rVert=1$.  This is the phase
+normalization following Lemma `equalMPS` of arXiv:1606.00608, lines
+1080--1097. -/
+theorem norm_eq_one_of_gaugePhase_cast_of_isNormalTensor
+    {D₁ D₂ : ℕ} [NeZero D₁] [NeZero D₂]
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂}
+    (hA : IsNormalTensor A) (hB : IsNormalTensor B)
+    (hdim : D₁ = D₂) {X : GL (Fin D₂) ℂ} {ζ : ℂ}
+    (hrel : ∀ i, B i = ζ • ((X : Matrix (Fin D₂) (Fin D₂) ℂ) *
+      (cast (congr_arg (MPSTensor d) hdim) A) i *
+      (↑(X⁻¹) : Matrix (Fin D₂) (Fin D₂) ℂ))) :
+    ‖ζ‖ = 1 := by
+  subst D₂
+  have hAA : Tendsto (fun N => ‖mpvOverlap (d := d) A A N‖)
+      atTop (nhds (1 : ℝ)) := by
+    simpa using hA.selfOverlap_tendsto_one.norm
+  have hBB : Tendsto (fun N => ‖mpvOverlap (d := d) B B N‖)
+      atTop (nhds (1 : ℝ)) := by
+    simpa using hB.selfOverlap_tendsto_one.norm
+  exact norm_eq_one_of_selfOverlap_scale hAA hBB
+    (mpvOverlap_self_scale_of_mpv_eq_pow_mul
+      (mpv_eq_pow_mul_of_gaugePhase A B X ζ hrel))
+
 /-- MPV phase equivalence between normal tensors is realized letterwise by a
 gauge and a nonzero scalar, after identifying their bond dimensions.
 

--- a/TNLean/MPS/CanonicalForm/PhaseCover.lean
+++ b/TNLean/MPS/CanonicalForm/PhaseCover.lean
@@ -372,4 +372,18 @@ noncomputable def mpvPhaseClassData {r : ℕ} {dim : Fin r → ℕ}
     regroup := hRegroup
   }
 
+/-- The distinguished first member of each concrete phase class is its chosen
+representative.
+
+This is the normalization used for the copy labelled $k=1$ in the proof of
+Proposition 4.13 of arXiv:1606.00608, line 1898. -/
+@[simp] theorem mpvPhaseClassData_enum_zero_eq_repr
+    {r : ℕ} {dim : Fin r → ℕ}
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (j : Fin (mpvPhaseClassData blocks).g) :
+    (mpvPhaseClassData blocks).enum j
+        ⟨0, (mpvPhaseClassData blocks).copies_pos j⟩ =
+      (mpvPhaseClassData blocks).repr j :=
+  rfl
+
 end MPSTensor

--- a/TNLean/MPS/MPDO/SectorTrace.lean
+++ b/TNLean/MPS/MPDO/SectorTrace.lean
@@ -30,6 +30,9 @@ the sector projector acting on one site, as in the diagrams of that proof.
 * `verticalLoop` / `verticalLoopWith`:
   the closed single-site vertical loop $E = \sum_i M^{ii}$, and the loop with a
   matrix $P$ inserted, $E_P = \sum_{i,j} P_{ji}\,M^{ij}$.
+* `representativeLoop`:
+  the closed loop of a vertical representative, defined entrywise by
+  $(E_\alpha)_{ab}=\operatorname{tr}(M_\alpha^{(a,b)})$.
 * `sectorCompression`:
   the compression $P_1H^{(N+1)}P_1$ of the density operator by a matrix
   acting on the first site.
@@ -62,19 +65,17 @@ the sector projector acting on one site, as in the diagrams of that proof.
   normalization $\mu_{\alpha,1}>0$ this forces $d_\alpha^{(N+1)}>0$ and
   $\mu_{\alpha,k}>0$.
 
-## What the vertical decomposition must supply
+## Application to the vertical decomposition
 
-The vertical canonical decomposition of Proposition 4.13 (still open, see
-`TNLean.MPS.MPDO.VerticalCF`) must produce, for each sector $(\alpha,k)$, the
-orthogonal projector $P_{\alpha,k}$ together with its `SectorProjectorData`:
-the loop identity holds with $\mu = \mu_{\alpha,k}$ and
-$E_\alpha = \sum_u M_\alpha^{uu}$ the closed loop of the vertical basis
-tensor, *independently of $k$*, because the sector gauge $X_{\alpha,k}$
-cancels under the single-site loop trace,
-$\tr(X_{\alpha,k}M_\alpha X_{\alpha,k}^{-1}) = \tr(M_\alpha)$ on the vertical
-index.  The nonvanishing of a sector compression at some length, which the
-paper derives from the horizontal canonical form (arXiv:1606.00608,
-line 1898), enters here as a hypothesis.
+The grouped decomposition in `TNLean.MPS.MPDO.VerticalBNT` constructs, for
+each sector $(\alpha,k)$, the orthogonal projector $P_{\alpha,k}$ and its
+`SectorProjectorData`.  The representative loop is defined entrywise by
+$(E_\alpha)_{ab}=\operatorname{tr}(M_\alpha^{(a,b)})$.  It is independent of
+$k$ because cyclicity of trace removes the internal similarity
+$X_{\alpha,k}M_\alpha^{(a,b)}X_{\alpha,k}^{-1}$.  The same decomposition uses
+the horizontal canonical form to find a nonzero sector compression, and hence
+deduces the positivity of every grouped coefficient.  The remaining argument
+of Proposition 4.13 begins with the dressed adjoints at line 1903.
 
 ## References
 
@@ -114,6 +115,38 @@ the proof of Proposition 4.13 of arXiv:1606.00608, lines 1895--1902. -/
 noncomputable def verticalLoopWith (M : MPOTensor d D)
     (P : Matrix (Fin d) (Fin d) ℂ) : Matrix (Fin D) (Fin D) ℂ :=
   ∑ a : Fin d, ∑ i : Fin d, P a i • M i a
+
+/-- The closed loop of a vertical representative tensor, written entrywise as
+
+\[
+  (E_A)_{ab}=\operatorname{tr}(A^{(a,b)}).
+\]
+
+This is the matrix $E_\alpha$ in the proof of Proposition 4.13 of
+arXiv:1606.00608, lines 1898--1901. -/
+noncomputable def representativeLoop (A : MPSTensor (D * D) n) :
+    Matrix (Fin D) (Fin D) ℂ :=
+  fun a b => Matrix.trace (A (finProdFinEquiv (a, b)))
+
+/-- Identifying equal representative bond dimensions does not change the
+closed representative loop. -/
+@[simp] theorem representativeLoop_cast {n m : ℕ} (hdim : n = m)
+    (A : MPSTensor (D * D) n) :
+    representativeLoop (cast (congr_arg (MPSTensor (D * D)) hdim) A) =
+      representativeLoop A := by
+  subst m
+  rfl
+
+/-- Entrywise, the loop with a physical insertion is the trace of the
+corresponding vertically viewed letter after multiplication by the insertion.
+This is the marked single-site contraction in arXiv:1606.00608, line 1898. -/
+theorem verticalLoopWith_apply_eq_trace_mul_verticalTensor
+    (M : MPOTensor d D) (P : Matrix (Fin d) (Fin d) ℂ) (a b : Fin D) :
+    verticalLoopWith M P a b =
+      Matrix.trace (P * verticalTensor M (finProdFinEquiv (a, b))) := by
+  simp only [verticalLoopWith, Matrix.sum_apply, Matrix.smul_apply,
+    Matrix.trace, Matrix.diag, Matrix.mul_apply, verticalTensor_finProdFinEquiv,
+    smul_eq_mul]
 
 /-- Inserting the identity recovers the plain vertical loop. -/
 @[simp] theorem verticalLoopWith_one (M : MPOTensor d D) :
@@ -314,12 +347,11 @@ the proof of Proposition 4.13 of arXiv:1606.00608, line 1898:
   contribution, $E_P = \mu\,E_\alpha$.
 
 In the source decomposition the loop identity holds with
-$\mu = \mu_{\alpha,k}$ and $E_\alpha = \sum_u M_\alpha^{uu}$ the closed
-vertical loop of the basis tensor $M_\alpha$, independently of $k$: the
-sector gauge cancels under the single-site loop trace,
-$\tr(X_{\alpha,k}M_\alpha X_{\alpha,k}^{-1}) = \tr(M_\alpha)$ on the vertical
-index.  The still-open vertical decomposition of Proposition 4.13 must
-supply this data; see the module documentation. -/
+$\mu = \mu_{\alpha,k}$ and
+$(E_\alpha)_{ab}=\operatorname{tr}(M_\alpha^{(a,b)})$, independently of $k$:
+cyclicity of trace removes the internal similarity
+$X_{\alpha,k}M_\alpha^{(a,b)}X_{\alpha,k}^{-1}$.  The grouped decomposition in
+`TNLean.MPS.MPDO.VerticalBNT` supplies this data. -/
 structure SectorProjectorData (M : MPOTensor d D)
     (P : Matrix (Fin d) (Fin d) ℂ) (μ : ℂ)
     (Eα : Matrix (Fin D) (Fin D) ℂ) : Prop where
@@ -331,6 +363,53 @@ structure SectorProjectorData (M : MPOTensor d D)
   sector: the inserted loop is the sector weight times the closed loop of the
   sector's basis tensor. -/
   loop_eq : verticalLoopWith M P = μ • Eα
+
+/-- An isometric vertical corner related to a representative by an invertible
+gauge determines the corresponding sector projector and loop identity.
+
+For $P=VV^\dagger$, cyclicity of trace gives
+
+\[
+  \operatorname{tr}(P\widetilde M_{ab})
+  =\operatorname{tr}(V^\dagger\widetilde M_{ab}V)
+  =\omega\operatorname{tr}(A^{(a,b)}),
+\]
+
+where the internal similarity cancels.  This is the sector-loop computation
+in the proof of Proposition 4.13 of arXiv:1606.00608, line 1898. -/
+theorem sectorProjectorData_of_gauge_corner
+    (M : MPOTensor d D) (A : MPSTensor (D * D) n)
+    (V : Matrix (Fin d) (Fin n) ℂ) (hV : Vᴴ * V = 1)
+    (X : GL (Fin n) ℂ) (ω : ℂ)
+    (hcorner : ∀ v,
+      ω • ((X : Matrix (Fin n) (Fin n) ℂ) * A v *
+        (↑(X⁻¹) : Matrix (Fin n) (Fin n) ℂ)) =
+          Vᴴ * verticalTensor M v * V) :
+    SectorProjectorData M (V * Vᴴ) ω (representativeLoop A) := by
+  refine ⟨?_, ?_, ?_⟩
+  · calc
+      (V * Vᴴ) * (V * Vᴴ) = V * (Vᴴ * V) * Vᴴ := by
+        simp only [Matrix.mul_assoc]
+      _ = V * Vᴴ := by rw [hV, Matrix.mul_one]
+  · change (V * Vᴴ)ᴴ = V * Vᴴ
+    rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose]
+  · ext a b
+    rw [verticalLoopWith_apply_eq_trace_mul_verticalTensor]
+    calc
+      Matrix.trace ((V * Vᴴ) * verticalTensor M (finProdFinEquiv (a, b))) =
+          Matrix.trace
+            ((Vᴴ * verticalTensor M (finProdFinEquiv (a, b))) * V) := by
+        rw [Matrix.mul_assoc]
+        exact Matrix.trace_mul_comm V
+          (Vᴴ * verticalTensor M (finProdFinEquiv (a, b)))
+      _ = Matrix.trace
+          (ω • ((X : Matrix (Fin n) (Fin n) ℂ) *
+            A (finProdFinEquiv (a, b)) *
+              (↑(X⁻¹) : Matrix (Fin n) (Fin n) ℂ))) :=
+        congrArg Matrix.trace (hcorner _).symm
+      _ = (ω • representativeLoop A) a b := by
+        rw [Matrix.trace_smul, MPSTensor.trace_conj_eq]
+        rfl
 
 /-- **The sector trace identity**
 (arXiv:1606.00608, proof of Proposition 4.13, line 1898): the trace of the

--- a/TNLean/MPS/MPDO/VerticalBNT.lean
+++ b/TNLean/MPS/MPDO/VerticalBNT.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.CanonicalForm.NormalTensorGauge
+import TNLean.MPS.MPDO.SectorTrace
 import TNLean.MPS.MPDO.VerticalSpectral
 
 /-!
@@ -12,18 +13,20 @@ import TNLean.MPS.MPDO.VerticalSpectral
 This file performs the gauge-phase grouping step in the proof of the vertical
 canonical form for matrix product density operators.  Starting from the
 spectrally normalized physical corners, it chooses one normal tensor from each
-matrix-product-vector phase class.  Every original corner is expressed as a
-nonzero complex scalar times an invertible conjugate of its representative.
-The physical isometries are retained unchanged, so all reducing identities and
-the literal reconstruction of every vertical letter survive the regrouping.
+matrix-product-vector phase class.  Every original corner is expressed using
+an invertible conjugation and a scalar of unit modulus, with the scalar of the
+chosen representative equal to one.  The physical isometries are retained
+unchanged, so all reducing identities and the literal reconstruction of every
+vertical letter survive the regrouping.
 
-This is the algebraic phase-class decomposition invoked in the first sentence
-of arXiv:1606.00608, line 1898.  It combines the BNT characterization at lines
-1135--1148 with the preceding isometry-preserving vertical sector theorem.  It
-does not prove the positive-diagonal isometry asserted at lines 1895--1896.  No
-positivity of the grouped coefficients and no unitarity of the gauges is
-asserted here; those are consequences of the subsequent MPDO argument at lines
-1898--1921.
+This is the phase-class decomposition and positivity argument of
+arXiv:1606.00608, lines 1898--1902.  It combines the BNT characterization at
+lines 1135--1148 with the preceding isometry-preserving vertical sector
+theorem.  For every grouped sector it constructs the physical selector, proves
+the corresponding loop identity, finds a nonzero finite-chain compression,
+and deduces that the grouped coefficient is positive.  The positive-diagonal
+isometry asserted at lines 1895--1896 and the gauge normalization and final
+coisometry argument at lines 1903--1921 are not included.
 
 ## Main statement
 
@@ -43,6 +46,91 @@ namespace MPOTensor
 
 variable {d D : ℕ}
 
+/-- A nonzero vertical corner of a horizontally canonical tensor has a
+nonzero first-site sector compression at some chain length.
+
+If every compression by `P` vanished, their matrix entries would say that the
+two-sided first-site insertion by `P` has the same matrix product vectors as
+zero.  Lemma L for the horizontal canonical form would then make the inserted
+tensor itself zero, forcing every corner $P\widetilde M_vP$ to vanish.  This is
+the separation assertion used in the proof of Proposition 4.13 of
+arXiv:1606.00608, line 1898. -/
+theorem IsHorizontalCF.exists_sectorCompression_ne_zero_of_corner
+    (M : MPOTensor d D) (hHorizontal : IsHorizontalCF M)
+    (P : Matrix (Fin d) (Fin d) ℂ)
+    (hcorner : ∃ v, P * verticalTensor M v * P ≠ 0) :
+    ∃ N, sectorCompression M P N ≠ 0 := by
+  by_contra hnone
+  simp only [not_exists, not_not] at hnone
+  have hAct : MPSTensor.FirstSiteActionAgree M.toMPSTensor
+      (MPSTensor.ketLeftBraRightAction P) 0 := by
+    intro N ρ
+    rw [MPSTensor.ketLeftBraRightAction_mpv]
+    simp only [Matrix.zero_apply, zero_mul, Finset.sum_const_zero]
+    have hentry := Matrix.ext_iff.mpr (hnone N)
+      (Fin.cons (ρ 0).divNat fun n => (ρ (Fin.succ n)).divNat)
+      (Fin.cons (ρ 0).modNat fun n => (ρ (Fin.succ n)).modNat)
+    rw [sectorCompression_def, mul_firstSiteMatrix_apply] at hentry
+    simp only [firstSiteMatrix_mul_apply] at hentry
+    simp only [Fin.cons_zero, Function.comp_def, Fin.cons_succ,
+      Matrix.zero_apply] at hentry
+    rw [← hentry]
+    simp only [Finset.sum_mul]
+    exact Finset.sum_comm
+  have hInserted := hHorizontal.insertedTensor_eq_of_firstSiteActionAgree M hAct
+  have hTensor : ((M.ketLeftMul P).braRightMul P).toMPSTensor = 0 := by
+    rw [← insertedTensor_ketLeftBraRightAction_toMPSTensor]
+    rw [hInserted]
+    ext v a b
+    simp [MPSTensor.insertedTensor]
+  have hMzero : (M.ketLeftMul P).braRightMul P = 0 := by
+    funext i j
+    have hij := congrFun hTensor (finProdFinEquiv (i, j))
+    simpa [toMPSTensor] using hij
+  obtain ⟨v, hv⟩ := hcorner
+  apply hv
+  have hv0 : verticalTensor ((M.ketLeftMul P).braRightMul P) v = 0 := by
+    rw [hMzero]
+    rfl
+  rw [verticalTensor_braRightMul, verticalTensor_ketLeftMul] at hv0
+  exact hv0
+
+/-- A nonzero normal representative gives a nonzero physical range corner
+through an exact gauge-corner identity. -/
+private theorem exists_rangeProjection_corner_ne_zero
+    {n : ℕ} [NeZero n] (M : MPOTensor d D) (A : MPSTensor (D * D) n)
+    (hA : A.IsNormalTensor) (V : Matrix (Fin d) (Fin n) ℂ)
+    (hV : Vᴴ * V = 1) (X : GL (Fin n) ℂ) (ω : ℂ) (hω : ω ≠ 0)
+    (hcorner : ∀ v,
+      ω • ((X : Matrix (Fin n) (Fin n) ℂ) * A v *
+        (↑(X⁻¹) : Matrix (Fin n) (Fin n) ℂ)) =
+          Vᴴ * verticalTensor M v * V) :
+    ∃ v, (V * Vᴴ) * verticalTensor M v * (V * Vᴴ) ≠ 0 := by
+  obtain ⟨v, hv⟩ := hA.exists_apply_ne_zero
+  refine ⟨v, ?_⟩
+  have hconj : (X : Matrix (Fin n) (Fin n) ℂ) * A v *
+      (↑(X⁻¹) : Matrix (Fin n) (Fin n) ℂ) ≠ 0 := by
+    intro hzero
+    apply hv
+    have hcancel := congrArg
+      (fun Z : Matrix (Fin n) (Fin n) ℂ =>
+        (↑(X⁻¹) : Matrix (Fin n) (Fin n) ℂ) * Z *
+          (X : Matrix (Fin n) (Fin n) ℂ)) hzero
+    simpa [Matrix.mul_assoc] using hcancel
+  have hsmall : Vᴴ * verticalTensor M v * V ≠ 0 := by
+    rw [← hcorner v]
+    exact smul_ne_zero hω hconj
+  intro hzero
+  apply hsmall
+  have hcancel := congrArg
+    (fun Z : Matrix (Fin d) (Fin d) ℂ => Vᴴ * Z * V) hzero
+  rw [show Vᴴ * ((V * Vᴴ) * verticalTensor M v * (V * Vᴴ)) * V =
+      Vᴴ * verticalTensor M v * V by
+    simp only [← Matrix.mul_assoc, hV, Matrix.one_mul]
+    rw [Matrix.mul_assoc (Vᴴ * verticalTensor M v * V) Vᴴ V,
+      hV, Matrix.mul_one]] at hcancel
+  simpa using hcancel
+
 /-- Group the normalized vertical corners of a horizontally canonical MPDO by
 their gauge-phase classes while retaining the physical reducing isometries.
 
@@ -50,15 +138,19 @@ For each class `j` and copy `q`, the original normalized corner is
 
 `blocks (enum j q) = ζ j q · X j q · blocks (repr j) · (X j q)⁻¹`.
 
-Consequently its coefficient in the literal vertical decomposition is the
-nonzero complex number `μ (enum j q) * ζ j q`.  The representatives form a
-basis of normal tensors for the corresponding weighted block tensor and are
-pairwise gauge-phase distinct.
+The scalar `ζ j q` has unit norm, and it is one for the chosen representative.
+Consequently the coefficient `μ (enum j q) * ζ j q` in the literal vertical
+decomposition is positive.  The representatives form a basis of normal tensors
+for the corresponding weighted block tensor and are pairwise gauge-phase
+distinct.  Each physical range projector satisfies the representative-loop
+identity and has a nonzero finite-chain compression.
 
-Source: the algebraic phase-class decomposition in the first sentence of
-arXiv:1606.00608, line 1898, using the BNT characterization at lines
+Source: the phase-class decomposition and positivity argument in
+arXiv:1606.00608, lines 1898--1902, using the BNT characterization at lines
 1135--1148 and the preceding isometry-preserving vertical sector theorem.  The
-positive-diagonal isometry asserted at lines 1895--1896 is not included. -/
+positive-diagonal isometry asserted at lines 1895--1896 and the subsequent
+gauge normalization and coisometry argument at lines 1903--1921 are not
+included. -/
 theorem IsHorizontalCF.exists_verticalBNTGrouping_with_isometry
     (M : MPOTensor d D) (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M) :
     ∃ (r : ℕ) (dim : Fin r → ℕ) (μ : Fin r → ℂ)
@@ -79,7 +171,9 @@ theorem IsHorizontalCF.exists_verticalBNTGrouping_with_isometry
         (X : (j : Fin classes.g) → (q : Fin (classes.copies j)) →
           GL (Fin (dim (classes.enum j q))) ℂ)
         (ζ : (j : Fin classes.g) → Fin (classes.copies j) → ℂ),
+        (∀ j q, ‖ζ j q‖ = 1) ∧
         (∀ j q, ζ j q ≠ 0) ∧
+        (∀ j, ζ j ⟨0, classes.copies_pos j⟩ = 1) ∧
         (∀ j q v,
           blocks (classes.enum j q) v =
             ζ j q •
@@ -95,6 +189,13 @@ theorem IsHorizontalCF.exists_verticalBNTGrouping_with_isometry
         MPSTensor.BlocksNotGaugePhaseEquiv
           (d := D * D) (fun j => blocks (classes.repr j)) ∧
         (∀ j q, μ (classes.enum j q) * ζ j q ≠ 0) ∧
+        (∀ j q, SectorProjectorData M
+          (V (classes.enum j q) * (V (classes.enum j q))ᴴ)
+          (μ (classes.enum j q) * ζ j q)
+          (representativeLoop (blocks (classes.repr j)))) ∧
+        (∀ j q, ∃ N, sectorCompression M
+          (V (classes.enum j q) * (V (classes.enum j q))ᴴ) N ≠ 0) ∧
+        (∀ j q, (0 : ℂ) < μ (classes.enum j q) * ζ j q) ∧
         (∀ j q, (V (classes.enum j q))ᴴ * V (classes.enum j q) = 1) ∧
         (∀ j q l p, classes.enum j q ≠ classes.enum l p →
           (V (classes.enum j q))ᴴ * V (classes.enum l p) = 0) ∧
@@ -145,16 +246,54 @@ theorem IsHorizontalCF.exists_verticalBNTGrouping_with_isometry
   let classes := MPSTensor.mpvPhaseClassData blocks
   haveI : ∀ k, NeZero (dim k) := fun k => ⟨(hdimPos k).ne'⟩
   have hClassGauge : ∀ j q,
-      ∃ hdim : dim (classes.repr j) = dim (classes.enum j q),
-        MPSTensor.GaugePhaseEquiv
-          (cast (congr_arg (MPSTensor (D * D)) hdim) (blocks (classes.repr j)))
-          (blocks (classes.enum j q)) := by
+      ∃ (hdim : dim (classes.repr j) = dim (classes.enum j q))
+        (X : GL (Fin (dim (classes.enum j q))) ℂ) (ζ : ℂ),
+        ‖ζ‖ = 1 ∧ ζ ≠ 0 ∧
+        (∀ v, blocks (classes.enum j q) v =
+          ζ • ((X : Matrix (Fin (dim (classes.enum j q)))
+              (Fin (dim (classes.enum j q))) ℂ) *
+            (cast (congr_arg (MPSTensor (D * D)) hdim)
+              (blocks (classes.repr j))) v *
+            (↑(X⁻¹) : Matrix (Fin (dim (classes.enum j q)))
+              (Fin (dim (classes.enum j q))) ℂ))) ∧
+        (q = ⟨0, classes.copies_pos j⟩ → ζ = 1) := by
     intro j q
-    exact MPSTensor.MPVBlockPhaseEquiv.dim_eq_and_gaugePhaseEquiv_of_isNormalTensor
-      (hNormal (classes.repr j)) (hNormal (classes.enum j q))
-      (classes.enum_phase j q)
-  choose hdim hGaugePhase using hClassGauge
-  choose X ζ hζNe hGauge using hGaugePhase
+    by_cases hq : q = ⟨0, classes.copies_pos j⟩
+    · have hEnum : classes.enum j q = classes.repr j := by
+        rw [hq]
+        exact MPSTensor.mpvPhaseClassData_enum_zero_eq_repr blocks j
+      have hdim : dim (classes.repr j) = dim (classes.enum j q) :=
+        congrArg dim hEnum.symm
+      refine ⟨hdim, 1, 1, norm_one, one_ne_zero, ?_, fun _ => rfl⟩
+      have hcast : cast (congr_arg (MPSTensor (D * D)) hdim)
+          (blocks (classes.repr j)) = blocks (classes.enum j q) := by
+        rw [cast_eq_iff_heq]
+        exact hEnum.symm.rec HEq.rfl
+      intro v
+      calc
+        blocks (classes.enum j q) v =
+            (cast (congr_arg (MPSTensor (D * D)) hdim)
+              (blocks (classes.repr j))) v := congrFun hcast.symm v
+        _ = (1 : ℂ) •
+            ((1 : Matrix (Fin (dim (classes.enum j q)))
+                (Fin (dim (classes.enum j q))) ℂ) *
+              (cast (congr_arg (MPSTensor (D * D)) hdim)
+                (blocks (classes.repr j))) v *
+              (1 : Matrix (Fin (dim (classes.enum j q)))
+                (Fin (dim (classes.enum j q))) ℂ)) := by
+          rw [Matrix.one_mul, Matrix.mul_one, one_smul]
+    · obtain ⟨hdim, hGaugePhase⟩ :=
+        MPSTensor.MPVBlockPhaseEquiv.dim_eq_and_gaugePhaseEquiv_of_isNormalTensor
+          (hNormal (classes.repr j)) (hNormal (classes.enum j q))
+          (classes.enum_phase j q)
+      obtain ⟨X, ζ, hζNe, hGauge⟩ := hGaugePhase
+      refine ⟨hdim, X, ζ, ?_, hζNe, hGauge, fun h => (hq h).elim⟩
+      exact MPSTensor.norm_eq_one_of_gaugePhase_cast_of_isNormalTensor
+        (hNormal (classes.repr j)) (hNormal (classes.enum j q)) hdim hGauge
+  choose hdim X ζ hζNorm hζNe hGauge hζDist using hClassGauge
+  have hζDist' : ∀ j, ζ j ⟨0, classes.copies_pos j⟩ = 1 := by
+    intro j
+    exact hζDist j ⟨0, classes.copies_pos j⟩ rfl
   have hCornerEq : ∀ j q v,
       μ (classes.enum j q) • blocks (classes.enum j q) v =
         (μ (classes.enum j q) * ζ j q) •
@@ -165,6 +304,55 @@ theorem IsHorizontalCF.exists_verticalBNTGrouping_with_isometry
               Matrix _ _ ℂ)) := by
     intro j q v
     rw [hGauge j q v, smul_smul]
+  have hGroupedCorner : ∀ j q v,
+      (μ (classes.enum j q) * ζ j q) •
+          ((X j q : Matrix (Fin (dim (classes.enum j q)))
+              (Fin (dim (classes.enum j q))) ℂ) *
+            (cast (congr_arg (MPSTensor (D * D)) (hdim j q))
+              (blocks (classes.repr j))) v *
+            (↑((X j q)⁻¹) : Matrix (Fin (dim (classes.enum j q)))
+              (Fin (dim (classes.enum j q))) ℂ)) =
+        (V (classes.enum j q))ᴴ * verticalTensor M v * V (classes.enum j q) := by
+    intro j q v
+    rw [← hCornerEq j q v]
+    exact hCorner (classes.enum j q) v
+  have hSector : ∀ j q, SectorProjectorData M
+      (V (classes.enum j q) * (V (classes.enum j q))ᴴ)
+      (μ (classes.enum j q) * ζ j q)
+      (representativeLoop (blocks (classes.repr j))) := by
+    intro j q
+    have hs := sectorProjectorData_of_gauge_corner M
+      (cast (congr_arg (MPSTensor (D * D)) (hdim j q))
+        (blocks (classes.repr j)))
+      (V (classes.enum j q)) (hIso (classes.enum j q)) (X j q)
+      (μ (classes.enum j q) * ζ j q) (hGroupedCorner j q)
+    rw [representativeLoop_cast (hdim j q)] at hs
+    exact hs
+  have hCompression : ∀ j q, ∃ N, sectorCompression M
+      (V (classes.enum j q) * (V (classes.enum j q))ᴴ) N ≠ 0 := by
+    intro j q
+    have hNormalCast : MPSTensor.IsNormalTensor
+        (cast (congr_arg (MPSTensor (D * D)) (hdim j q))
+          (blocks (classes.repr j))) :=
+      (MPSTensor.isNormalTensor_cast_iff (hdim j q)
+        (blocks (classes.repr j))).2 (hNormal (classes.repr j))
+    have hRange := exists_rangeProjection_corner_ne_zero M
+      (cast (congr_arg (MPSTensor (D * D)) (hdim j q))
+        (blocks (classes.repr j))) hNormalCast
+      (V (classes.enum j q)) (hIso (classes.enum j q)) (X j q)
+      (μ (classes.enum j q) * ζ j q)
+      (mul_ne_zero (hμPos (classes.enum j q)).ne' (hζNe j q))
+      (hGroupedCorner j q)
+    exact hHorizontal.exists_sectorCompression_ne_zero_of_corner M _ hRange
+  have hCoeffPos : ∀ j q, (0 : ℂ) < μ (classes.enum j q) * ζ j q := by
+    intro j q
+    let q₀ : Fin (classes.copies j) := ⟨0, classes.copies_pos j⟩
+    have hRefPos : (0 : ℂ) < μ (classes.enum j q₀) * ζ j q₀ := by
+      rw [hζDist j q₀ rfl]
+      simp only [mul_one, q₀]
+      exact hμPos (classes.repr j)
+    obtain ⟨N, hne⟩ := hCompression j q
+    exact sector_weight_pos hM (hSector j q₀) hRefPos (hSector j q) N hne
   have hBNT : MPSTensor.IsCPSVBasisOfNormalTensors
       (MPSTensor.toTensorFromBlocks (d := D * D) (μ := μ) blocks)
       (fun j => ⟨dim (classes.repr j), blocks (classes.repr j)⟩) := by
@@ -204,8 +392,9 @@ theorem IsHorizontalCF.exists_verticalBNTGrouping_with_isometry
           (fun j => blocks (classes.repr j))
           (fun j => hNormal (classes.repr j)) classes.blocks_not_equiv
   refine ⟨r, dim, μ, blocks, V, hdimPos, hμPos, hNormal, hIso, hOrth,
-    hInt, hIntStar, hCorner, hReconstruct, hdim, X, ζ, hζNe, hGauge, hBNT,
-    classes.blocks_not_equiv, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+    hInt, hIntStar, hCorner, hReconstruct, hdim, X, ζ, hζNorm, hζNe,
+    hζDist', hGauge, hBNT, classes.blocks_not_equiv, ?_, hSector, hCompression,
+    hCoeffPos, ?_, ?_, ?_, ?_, ?_, ?_⟩
   · intro j q
     exact mul_ne_zero (hμPos (classes.enum j q)).ne' (hζNe j q)
   · intro j q

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -142,6 +142,10 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
 
 \begin{theorem}[Phase-equivalent normal tensors are gauge-phase equivalent]
     \label{thm:cpsv_normal_mpv_phase_gauge}
+    \lean{MPSTensor.IsNormalTensor.exists_apply_ne_zero}
+    \lean{MPSTensor.IsNormalTensor.selfOverlap_tendsto_one}
+    \lean{MPSTensor.isNormalTensor_cast_iff}
+    \lean{MPSTensor.norm_eq_one_of_gaugePhase_cast_of_isNormalTensor}
     \lean{MPSTensor.MPVBlockPhaseEquiv.dim_eq_and_gaugePhaseEquiv_of_isNormalTensor}
     \leanok
     \uses{def:nt_cpsv, def:mpv_block_phase_equiv,
@@ -153,7 +157,7 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
         \qquad (N\geq 0).
     \]
     Then the bond dimensions are equal and there is an invertible matrix $X$
-    and a nonzero scalar $\eta$ such that
+    and a scalar $\eta$ of unit modulus such that
     \[
         B^i=\eta X A^iX^{-1}
     \]
@@ -844,7 +848,10 @@ single family.
 
 \begin{definition}[MPV phase classes]%
     \label{def:mpv_phase_class_data}
-    \lean{MPSTensor.MPVPhaseEquiv, MPSTensor.MPVPhaseClassData, MPSTensor.mpvPhaseClassData}
+    \lean{MPSTensor.MPVPhaseEquiv}
+    \lean{MPSTensor.MPVPhaseClassData}
+    \lean{MPSTensor.mpvPhaseClassData}
+    \lean{MPSTensor.mpvPhaseClassData_enum_zero_eq_repr}
     \leanok
     For a finite family of blocks, put $j \sim k$ when there is a nonzero
     scalar factor $\zeta$ such that
@@ -854,9 +861,9 @@ single family.
         \zeta^N\ket{V^{(N)}(B_j)}
     \]
     for every length~$N$. The associated tuple enumerates the finite quotient,
-    chooses one representative per class, records the scalar relating the
-    representative to each member, and proves that distinct representatives are
-    not MPV-phase equivalent.
+    chooses one representative per class, enumerates that representative first
+    in its class, records the scalar relating the representative to each member,
+    and proves that distinct representatives are not MPV-phase equivalent.
 \end{definition}
 
 \begin{lemma}[Regrouping a matrix sum by MPV phase classes]

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -1541,6 +1541,9 @@
     \label{def:mpdo_vertical_loops}
     \lean{MPOTensor.verticalLoop}
     \lean{MPOTensor.verticalLoopWith}
+    \lean{MPOTensor.representativeLoop}
+    \lean{MPOTensor.representativeLoop_cast}
+    \lean{MPOTensor.verticalLoopWith_apply_eq_trace_mul_verticalTensor}
     \lean{MPOTensor.verticalLoopWith_one}
     \lean{MPOTensor.verticalLoop_ketLeftMul}
     \lean{MPOTensor.verticalLoop_braRightMul}
@@ -1566,9 +1569,13 @@
     \[
         d_\alpha^{(N+1)}=\tr\bigl(E_\alpha\,E^{N}\bigr).
     \]
-    When $E_\alpha$ is the closed vertical loop of the basis tensor
-    $M_\alpha$, this is the scalar $d_\alpha$ displayed in the proof of
-    \cite[Proposition~4.13]{Cirac2016MPDO_arXiv}, resolved by chain length:
+    For a representative tensor $M_\alpha$ whose letters are indexed by
+    horizontal bond pairs, its closed vertical loop is defined entrywise by
+    \[
+        (E_\alpha)_{ab}=\tr\bigl(M_\alpha^{(a,b)}\bigr).
+    \]
+    In this case the chain trace is the scalar $d_\alpha$ displayed in the
+    proof of \cite[Proposition~4.13]{Cirac2016MPDO_arXiv}, resolved by chain length:
     one loop of $M_\alpha$ followed by loops of $M$, closed by the
     horizontal trace.
 \end{definition}
@@ -1624,6 +1631,7 @@
 \begin{definition}[Sector projectors of the vertical decomposition]
     \label{def:mpdo_sector_projector}
     \lean{MPOTensor.SectorProjectorData}
+    \lean{MPOTensor.sectorProjectorData_of_gauge_corner}
     \leanok
     \uses{def:mpdo_vertical_loops, def:vertical_tensor_mpdo}
     A matrix $P\in M_d(\C)$ is a sector projector for the weight
@@ -1639,15 +1647,32 @@
     physical space in the proof of
     \cite[Proposition~4.13]{Cirac2016MPDO_arXiv}, the projector
     $P_{\alpha,k}$ selecting the sector $(\alpha,k)$ has this property with
-    $\mu=\mu_{\alpha,k}$ and $E_\alpha$ the closed vertical loop of
-    $M_\alpha$ --- independently of $k$, because the sector gauge
-    $X_{\alpha,k}$ cancels under the single-site loop trace,
-    $\sum_i(X_{\alpha,k}M_\alpha X_{\alpha,k}^{-1})^{ii}=\sum_i M_\alpha^{ii}$.
-    The irreducible reducing projections have been constructed in
-    Theorem~\ref{thm:mpdo_vertical_complete_reducing_projectors}. Their
-    identification with the grouped normal sectors above, including the loop
-    identity $E_P=\mu E_\alpha$, remains open.
+    $\mu=\mu_{\alpha,k}$ and
+    $(E_\alpha)_{ab}=\tr(M_\alpha^{(a,b)})$, independently of $k$.  Indeed,
+    cyclicity of trace cancels the internal similarity
+    $X_{\alpha,k}M_\alpha^{(a,b)}X_{\alpha,k}^{-1}$.  Applied to the physical
+    isometry of a grouped normal sector, the gauge-corner identity constructs
+    the projector and proves its loop identity.
 \end{definition}
+
+\begin{theorem}[A nonzero vertical corner has a nonzero sector compression]
+    \label{thm:mpdo_grouped_sector_compression_nonzero}
+    \lean{MPOTensor.IsHorizontalCF.exists_sectorCompression_ne_zero_of_corner}
+    \leanok
+    \uses{def:horizontal_cf_mpdo, def:mpdo_vertical_loops,
+        def:vertical_tensor_mpdo, thm:representative_one_sub_mp_zero}
+    Let $M$ be horizontally canonical and let $P$ be a matrix for which
+    $P\widetilde M_vP$ is nonzero for some vertical letter $v$.  Then the
+    first-site compression $P_1H^{(N+1)}P_1$ is nonzero for some $N$.
+    This is the separation step used in
+    \cite[Proposition~4.13, line 1898]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+\begin{proof}\leanok
+    If every compression vanished, its matrix entries would say that the
+    first-site insertion by $P$ has the same matrix product vectors as zero.
+    Lemma~L for the horizontal canonical form would then force the inserted
+    tensor itself to vanish, contrary to the assumed nonzero corner.
+\end{proof}
 
 \begin{theorem}[The sector trace identity]
     \label{thm:mpdo_sector_trace_identity}
@@ -2305,7 +2330,8 @@
     equality of their matrix product vector families up to a fixed nonzero
     scalar per site. There are normal representatives $M_\alpha$, an enumeration
     $k=(\alpha,q)$ of the original sectors, invertible matrices
-    $X_{\alpha,q}$, and nonzero complex numbers $\zeta_{\alpha,q}$ such that
+    $X_{\alpha,q}$, and complex numbers $\zeta_{\alpha,q}$ of unit modulus,
+    with $\zeta_{\alpha,1}=1$, such that
     \[
         B_{\alpha,q}^v
         =\zeta_{\alpha,q}X_{\alpha,q}M_\alpha^vX_{\alpha,q}^{-1}.
@@ -2313,7 +2339,7 @@
     The representatives are pairwise gauge-phase distinct and form a basis of
     normal tensors for the weighted block tensor
     $\bigoplus_k\mu_kB_k$. Every grouped coefficient
-    $\mu_{\alpha,q}\zeta_{\alpha,q}$ is nonzero. With the physical isometries
+    $\mu_{\alpha,q}\zeta_{\alpha,q}$ is positive. With the physical isometries
     from Theorem~\ref{thm:mpdo_vertical_normal_sectors_with_isometries}
     retained unchanged, one has both reducing identities, exact compression,
     and the literal reconstruction
@@ -2325,25 +2351,35 @@
         X_{\alpha,q}M_\alpha^vX_{\alpha,q}^{-1}\bigr)
         V_{\alpha,q}^\dagger .
     \]
-    No positivity of the grouped coefficients and no unitarity of the gauges
-    is asserted at this stage. This is the decomposition at the beginning of
-    the last part of \cite[Proposition~4.13]{Cirac2016MPDO_arXiv}.
+    For each pair $(\alpha,q)$, the range projector of $V_{\alpha,q}$ obeys
+    the representative-loop identity and gives a nonzero compression at some
+    finite length. This is the decomposition and positivity argument of
+    \cite[Proposition~4.13, lines 1898--1902]{Cirac2016MPDO_arXiv}. The gauge
+    normalization beginning at line 1903 is not asserted here.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{thm:mpdo_vertical_normal_sectors_with_isometries,
         thm:cpsv_normal_mpv_phase_gauge,
-        thm:cpsv_normal_separated_eventually_li}
+        thm:cpsv_normal_separated_eventually_li,
+        thm:mpdo_grouped_sector_compression_nonzero,
+        def:mpdo_sector_projector, thm:mpdo_sector_weight_pos}
     Take one representative from each phase class. Theorem~\ref{thm:cpsv_normal_mpv_phase_gauge}
     gives equality of bond dimensions and the displayed letterwise gauge-phase
     relation for every copy. Distinct representatives are gauge-phase
     separated by construction, so
     Theorem~\ref{thm:cpsv_normal_separated_eventually_li} gives eventual linear
     independence. The phase-class regrouping of the finite sum gives the BNT
-    expansion. Substitution in the two intertwining identities, the compression
-    identity, and the literal reconstruction from
+    expansion. The representative copy has phase one, while the self-overlap
+    normalization of normal tensors shows that every phase has unit modulus.
+    Substitution in the two intertwining identities, the compression identity,
+    and the literal reconstruction from
     Theorem~\ref{thm:mpdo_vertical_normal_sectors_with_isometries} proves all
-    remaining assertions without altering any physical isometry.
+    remaining algebraic assertions without altering any physical isometry.
+    Cyclicity of trace gives the sector-loop identities. The nonzero-corner
+    separation theorem supplies a nonzero compression for every sector, and
+    the sector trace identity and MPDO positivity then make every grouped
+    coefficient positive.
 \end{proof}
 
 \begin{theorem}[Horizontal canonical form implies vertical canonical form]
@@ -2428,8 +2464,8 @@
     removes the zero corners and spectrally normalizes the remaining corners
     while retaining their physical isometries, both intertwining identities,
     exact compression, and literal reconstruction of every vertical letter.
-    The remaining source argument must group the resulting normal tensors,
-    obtaining
+    Theorem~\ref{thm:mpdo_vertical_bnt_grouping_with_isometries} groups the
+    resulting normal tensors, obtaining
     \[
         \widetilde M
         =\bigoplus_{\alpha,k}\mu_{\alpha,k}X_{\alpha,k}M_\alpha X_{\alpha,k}^{-1}
@@ -2437,8 +2473,10 @@
     carried by the physical space, with normal tensors $M_\alpha$ whose
     letters remain indexed by the horizontal bond pairs.  These blocks are not
     obtained by restricting the horizontal blocks to diagonal physical pairs,
-    as Theorem~\ref{thm:diagonal_restriction_not_normal} shows.  Positivity
-    then gives $\mu_{\alpha,k}>0$:
+    as Theorem~\ref{thm:diagonal_restriction_not_normal} shows. It also
+    identifies the physical range projectors with the grouped sectors, proves
+    their loop identities, and finds a nonzero compression for each sector.
+    Positivity then gives $\mu_{\alpha,k}>0$:
     Theorem~\ref{thm:mpdo_sector_compression_trace_pos} supplies the positive
     traces of the nonzero sector compressions,
     Theorem~\ref{thm:mpdo_sector_trace_identity} identifies each such trace
@@ -2459,12 +2497,8 @@
     the corresponding reconstruction identity; each
     $\mu_\alpha$ is diagonal, so the summands regroup as repeated weighted
     copies of $M_\alpha$ exactly as in the finite regrouping of
-    Lemma~\ref{lem:vertical_grouping_equiv}.  Deriving the dressed-adjoint
-    identities from self-adjointness of the sector compressions via Lemma L
-    within the spectrally normalized vertical decomposition remains open.
-    The remaining construction must also identify the reducing projectors
-    above with the grouped sector projectors of
-    Definition~\ref{def:mpdo_sector_projector}, prove their loop identities
-    and the nonvanishing of a sector compression at some length, and assemble
-    the positive weights and proportional-unitary gauges.
+    Lemma~\ref{lem:vertical_grouping_equiv}. The remaining source-level gap
+    begins at line 1903: one must derive the dressed-adjoint identities from
+    self-adjointness of the sector compressions via Lemma L, normalize the
+    sector gauges to unitaries, and assemble the final coisometry.
 \end{proof}

--- a/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
@@ -154,17 +154,21 @@ in
 \path{MPOTensor.IsHorizontalCF.exists_verticalBNTGrouping_with_isometry}
 (\path{TNLean/MPS/MPDO/VerticalBNT.lean}).  One normal representative is
 chosen from each class.  Every copy has the same bond dimension as its
-representative and is a nonzero complex scalar times an invertible conjugate
-of that representative.  The representatives are pairwise gauge-phase
+representative and is a unit-modulus scalar times an invertible conjugate of
+that representative; the scalar of the chosen representative is one.  The
+representatives are pairwise gauge-phase
 distinct and form a basis of normal tensors for the weighted block tensor.
 The physical isometries are not changed: both intertwining identities, exact
 compression, and the literal reconstruction of each vertical letter survive
-the regrouping.  This is the algebraic phase-class decomposition invoked in
-the first sentence of source line~1898, obtained by combining the BNT
+the regrouping.  For every grouped sector, its physical range projector
+satisfies the representative-loop identity and gives a nonzero compression at
+some finite length.  The MPDO trace argument then proves that every grouped
+coefficient is positive.  This is the phase-class decomposition and positivity
+argument of source lines~1898--1902, obtained by combining the BNT
 characterization at lines~1135--1148 with the preceding isometry-preserving
 vertical sector theorem.  It does not formalize the positive-diagonal isometry
-asserted at lines~1895--1896.  Positivity of the grouped coefficients and
-unitarity of the gauges remain part of the subsequent argument.  Equality of
+asserted at lines~1895--1896 or the subsequent gauge normalization and final
+coisometry.  Equality of
 the bond dimensions within each phase class is obtained from non-decay of the
 positive-length rectangular overlap, as in Lemma~\texttt{equalMPS}; the
 empty-word coefficient is not used in this comparison.
@@ -177,16 +181,16 @@ chain length. The source prints an all-length inequality, whereas the proof
 only needs one noncommuting length; this local correction is recorded in
 \path{docs/paper-gaps/cpgsv17_periodic_sector_projector.tex}.
 
-Two further steps of source lines~1895--1921 now have conditional
-formalizations.  For the positive weights: granted an orthogonal sector
-projector $P_{\alpha,k}$ whose insertion into the single-site vertical loop
-selects the sector contribution $\mu_{\alpha,k}E_\alpha$, with
-$E_\alpha=\sum_u M_\alpha^{uu}$ the closed loop of the basis tensor
-(\path{MPOTensor.SectorProjectorData}), the trace of the compressed density
-operator is identified as $\mu_{\alpha,k}d_\alpha$, and positivity of the
-nonzero compressions (\path{MPOTensor.mpo_compress_trace_pos}) yields
-$d_\alpha>0$ and $\mu_{\alpha,k}>0$ under the normalization
-$\mu_{\alpha,1}>0$ (\path{MPOTensor.sector_weight_pos} in
+The positive-weight step of source lines~1898--1902 is now complete.  For each
+grouped physical range projector $P_{\alpha,k}$, its insertion into the
+single-site vertical loop selects the contribution
+$\mu_{\alpha,k}E_\alpha$, where
+$(E_\alpha)_{ab}=\operatorname{tr}(M_\alpha^{(a,b)})$.  This formula is
+independent of the copy index because cyclicity of trace removes the internal
+similarity.  Horizontal separation supplies a nonzero compression; its trace
+is $\mu_{\alpha,k}d_\alpha$, and positivity yields $d_\alpha>0$ and
+$\mu_{\alpha,k}>0$ under the normalization $\mu_{\alpha,1}>0$
+(\path{TNLean/MPS/MPDO/VerticalBNT.lean} and
 \path{TNLean/MPS/MPDO/SectorTrace.lean}).  For the unitary gauges: granted
 the dressed-adjoint identities of the two displayed diagrams at source
 lines~1909--1919, transported blockwise by Lemma~L, the scalar commutant of
@@ -198,18 +202,14 @@ $\omega_{\alpha,k}^{-1/2}X_{\alpha,k}$ unitary
 (\path{MPSTensor.IsNormal.smul_mem_unitaryGroup_of_dressed_adjoint} in
 \path{TNLean/MPS/CanonicalForm/NormalCommutant.lean}).
 
-The remaining source-level gap begins after this grouping.  The ranges of the
-grouped physical isometries are already the selector projections
-$P_{\alpha,k}$ of source line~1898.  One must prove their single-site loop
-identities and show that the corresponding compressions are nonzero.  Positivity
-must then be used to show that the grouped coefficients are positive.  The copy
-embeddings must also be assembled into the single
+The remaining source-level gap begins with the dressed-adjoint argument at
+source line~1903.  The copy embeddings must be assembled into the single
 direct-sum coisometry $U$ (equivalently, the adjoint isometry) appearing in
 source lines~1895--1896, with the zero complement treated explicitly.  Finally,
 one must derive the dressed-adjoint identities from self-adjointness of the
 sector compressions and use them to replace each invertible gauge by a
 proportional unitary, as in source lines~1898--1921.
-These conclusions are not part of the grouping theorem.  The original
+These gauge and coisometry conclusions are not part of the grouping theorem.  The original
 formulation of \ghissue{2536}, interpreted as a direct conversion of the
 horizontal scalar weights and diagonal restrictions, is therefore not a
 consequence of Proposition~4.13.

--- a/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
@@ -162,14 +162,14 @@ both intertwining identities, exact compression, and literal reconstruction
 of every vertical letter
 (\path{TNLean/MPS/MPDO/VerticalSpectral.lean}).
 
-The third stage now has conditional formalizations of its two closing
-arguments.  Granted orthogonal sector projectors whose insertion into the
-single-site vertical loop selects the sector contribution, the trace of the
-density operator compressed by the projector of sector $(\alpha,k)$ is
-identified as the sector weight $\mu_{\alpha,k}$ times a sector trace
-$d_\alpha$, and positivity of the nonzero compressions forces $d_\alpha>0$
-and $\mu_{\alpha,k}>0$ under the normalization $\mu_{\alpha,1}>0$
-(\path{TNLean/MPS/MPDO/SectorTrace.lean}).  Granted the dressed-adjoint
+The positive-weight part of the third stage is complete.  The physical range
+projector of every grouped sector has the required loop identity, with
+$(E_\alpha)_{ab}=\operatorname{tr}(M_\alpha^{(a,b)})$, and horizontal
+separation supplies a nonzero compression.  Its trace is the sector weight
+$\mu_{\alpha,k}$ times a sector trace $d_\alpha$, so MPDO positivity forces
+$d_\alpha>0$ and $\mu_{\alpha,k}>0$ under the normalization
+$\mu_{\alpha,1}>0$ (\path{TNLean/MPS/MPDO/VerticalBNT.lean} and
+\path{TNLean/MPS/MPDO/SectorTrace.lean}). Granted the dressed-adjoint
 identities of the two displayed diagrams at lines~1909--1919, transported
 blockwise by Lemma~L, the Gram matrix of each sector gauge $X_{\alpha,k}$ is
 a positive multiple $\omega_{\alpha,k}$ of the identity, in the normalization
@@ -183,13 +183,12 @@ normal-block decomposition
 isometry-preserving refinement is now supplied by
 \path{TNLean/MPS/MPDO/VerticalSpectral.lean}. The normal blocks are now
 grouped into pairwise gauge-phase-distinct BNT representatives in
-\path{TNLean/MPS/MPDO/VerticalBNT.lean}. Every copy is expressed by a
-nonzero complex coefficient and an invertible bond-space gauge, while the
-physical isometries and the literal vertical reconstruction are retained.
-What remains open is to identify the grouped range projections with their
-loop identities and prove a nonvanishing compression, then derive positivity
-of the grouped coefficients and the dressed-adjoint identities needed to
-normalize the gauges to unitaries.
+\path{TNLean/MPS/MPDO/VerticalBNT.lean}. Every copy is expressed by a positive
+coefficient, a unit-modulus phase, and an invertible bond-space gauge, while
+the physical isometries and the literal vertical reconstruction are retained.
+What remains open begins with the dressed-adjoint identities at source
+line~1903: they are needed to normalize the gauges to unitaries and assemble
+the final coisometry.
 
 \paragraph{Verdict.}
 This is an open gap: the source-faithful horizontal-to-vertical implication of


### PR DESCRIPTION
## Summary

This proves the coefficient-positivity step in Proposition 4.13 of arXiv:1606.00608, source lines 1898–1902.

- normalizes every gauge-phase scalar to unit modulus and chooses phase one for the distinguished representative;
- defines the representative loop entrywise by $(E_\alpha)_{ab}=\operatorname{tr}(M_\alpha^{(a,b)})$ and proves the grouped range-projector loop identity;
- derives a nonzero finite-chain sector compression from horizontal canonical form, rather than assuming it;
- applies the sector-trace positivity argument to prove every grouped coefficient positive;
- updates the blueprint and both paper-gap notes so that the remaining source boundary begins with the dressed-adjoint argument at line 1903.

The positive-diagonal isometry at lines 1895–1896, gauge normalization, and final coisometry are not claimed here.

## Source faithfulness

The mathematical target and boundary are recorded in `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex` and `docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex`. The representative loop is stated entrywise; no diagonal restriction of the horizontal tensor is used.

## Verification

- `lake build TNLean`
- `lake build TNLean.MPS.MPDO.VerticalBNT`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `leanblueprint web`
- `leanblueprint checkdecls`
- changed-source scan for `sorry`, `axiom`, `native_decide`, `unsafeCast`, and `admit`
- `#print axioms` for every new declaration: only `propext`, `Classical.choice`, and `Quot.sound`

No new axiom or proof bypass is introduced.

Closes #3885

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes are substantial formal mathematics in the MPDO vertical canonical-form chain (positivity and sector trace), but they extend existing APIs with proofs rather than altering auth, I/O, or runtime behavior; incorrect lemmas would affect downstream vertical-CF claims only within this proof library.
> 
> **Overview**
> Closes the **coefficient-positivity** slice of vertical canonical form (arXiv:1606.00608, lines 1898–1902) by strengthening BNT grouping from algebraic gauge-phase regrouping to a full sector-trace argument.
> 
> **Normal tensors / phase classes:** Adds lemmas that normal tensors have a nonzero letter, self-overlap tends to 1, cast preserves normality, and gauge-phase scalars have **unit modulus**; documents that the first enumerated copy in each MPV phase class is the chosen representative (`mpvPhaseClassData_enum_zero_eq_repr`).
> 
> **Sector trace:** Introduces `representativeLoop` with \((E_\alpha)_{ab}=\operatorname{tr}(M_\alpha^{(a,b)})\), links `verticalLoopWith` to traces of vertically viewed letters, and proves `sectorProjectorData_of_gauge_corner` so physical range projectors satisfy `SectorProjectorData`. Module docs now point at `VerticalBNT` instead of treating this data as still open.
> 
> **Vertical BNT:** Extends `exists_verticalBNTGrouping_with_isometry` with ‖ζ‖ = 1, ζ = 1 on representatives, `SectorProjectorData` for each grouped sector, existence of nonzero `sectorCompression` (via horizontal CF + nonzero corners), and **strict positivity** of μ·ζ. New `exists_sectorCompression_ne_zero_of_corner` derives compressions from horizontal canonical form rather than assuming them.
> 
> Blueprint and paper-gap notes are updated so the remaining formalization boundary starts at the dressed-adjoint / gauge-normalization step (line 1903), not positivity of grouped coefficients.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df6475974a631057a6a507cd917f9a4e9b2e140d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->