### PR TITLE
feat(MPS/MPDO): prove relative Gram rigidity for dressed vertical sectors

### DIFF
--- a/TNLean/MPS/CanonicalForm/NormalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/NormalCommutant.lean
@@ -20,18 +20,20 @@ These are the rigidity facts invoked at the step "since $M_\alpha$ is a NT in
 the vertical direction" in the proof of Proposition 4.13 of arXiv:1606.00608,
 line 1921: they produce equation eq3:proof.IV.12,
 $X_{\alpha,k}^\dagger X_{\alpha,k} = \omega_{\alpha,k}
-X_{\alpha,1}^\dagger X_{\alpha,1}$, in the normalization $X_{\alpha,1} = \Id$,
-together with the isometric normalization
-$U_{\alpha,k} = \omega_{\alpha,k}^{-1/2} X_{\alpha,k}$ of lines 1906--1908.
+X_{\alpha,1}^\dagger X_{\alpha,1}$ and the unitary normalization of the
+relative gauge $X_{\alpha,k}X_{\alpha,1}^{-1}$.  In the source normalization
+$X_{\alpha,1} = \Id$, this is
+$U_{\alpha,k} = \omega_{\alpha,k}^{-1/2} X_{\alpha,k}$ from lines 1906--1908.
 The commutation hypothesis arises from the two displayed diagrams of lines
 1909--1919: the first diagram, transported blockwise by Lemma L, says that the
 sector-dressed tensor equals its adjoint dressing,
-$X A^i X^{-1} = (X^{-1})^\dagger (A^i)^\dagger X^\dagger$; the second diagram
-is its Gram-conjugation form, and in the normalization $X_{\alpha,1} = \Id$ it
-becomes the commutation of $X^\dagger X$ with every matrix of the tensor.
-The passage from the first diagram to the second and onward to eq3 is proved
-below; deriving the first diagram's blockwise identity from self-adjointness
-of the sector compressions within the vertical decomposition remains open.
+$X A^v X^{-1} = (X^{-1})^\dagger C^v X^\dagger$, where the fixed adjoint
+orientation gives $C^v=(A^{v^{\mathrm{op}}})^\dagger$.  The second diagram
+eliminates this common target between two sector gauges.  The resulting ratio
+of their Gram matrices commutes with every matrix of the tensor.  The passage
+from a common dressed target to the relative form of eq3 is proved below;
+deriving the common target from self-adjointness of the sector compressions,
+including the reflected tail word, remains open.
 
 ## Main results
 
@@ -45,12 +47,17 @@ of the sector compressions within the vertical decomposition remains open.
 * `Matrix.gram_conj_eq_conjTranspose_of_dressed_adjoint` /
   `Matrix.gram_conj_eq_gram_conj_of_dressed_adjoint` /
   `Matrix.commute_gram_of_dressed_adjoint_of_conjTranspose_eq`:
-  the passage from the first displayed diagram to the second, and to the
-  commutation of the Gram matrix with a self-adjoint letter.
+  same-letter specializations of the common-target argument.
+* `Matrix.gram_conj_eq_of_dressed_target` /
+  `Matrix.gram_conj_eq_gram_conj_of_common_dressed_target`:
+  the source-faithful common-target form of the two displayed diagrams.
+* `MPSTensor.IsNormal.gram_eq_pos_smul_gram_of_gram_conj_eq` /
+  `MPSTensor.IsNormal.gram_eq_pos_smul_gram_of_common_dressed_target`:
+  the relative two-gauge form of eq3, without a self-adjoint-letter
+  hypothesis.
 * `MPSTensor.IsNormal.conjTranspose_mul_self_eq_smul_one_of_dressed_adjoint` /
   `MPSTensor.IsNormal.smul_mem_unitaryGroup_of_dressed_adjoint`:
-  eq3 and its isometric normalization derived end to end from the
-  dressed-adjoint identities.
+  conditional same-letter specializations in the identity reference gauge.
 
 ## References
 
@@ -65,6 +72,27 @@ namespace Matrix
 variable {n : Type*} [Fintype n] [DecidableEq n]
 
 /-- **From the first displayed diagram to the second** (arXiv:1606.00608,
+proof of Proposition 4.13, lines 1909--1919): if conjugation by an invertible
+gauge carries `B` to the dressing of a common target `C`, then conjugation by
+the Gram matrix carries `B` to `C`.  In the source, `C` is the adjoint of the
+letter with its oriented bond indices exchanged. -/
+theorem gram_conj_eq_of_dressed_target
+    {X B C : Matrix n n ℂ} (hX : IsUnit X.det)
+    (hdress : X * B * X⁻¹ = X⁻¹ᴴ * C * Xᴴ) :
+    Xᴴ * X * B * (Xᴴ * X)⁻¹ = C := by
+  have hXH : IsUnit (Xᴴ).det := by
+    rw [Matrix.det_conjTranspose]
+    exact hX.star
+  have h1 : Xᴴ * (X * B * X⁻¹) * X⁻¹ᴴ = Xᴴ * X * B * (Xᴴ * X)⁻¹ := by
+    rw [Matrix.mul_inv_rev, Matrix.conjTranspose_nonsing_inv]
+    simp only [Matrix.mul_assoc]
+  have h2 : Xᴴ * (X⁻¹ᴴ * C * Xᴴ) * X⁻¹ᴴ = C := by
+    rw [Matrix.conjTranspose_nonsing_inv, ← Matrix.mul_assoc, ← Matrix.mul_assoc,
+      Matrix.mul_nonsing_inv _ hXH, Matrix.one_mul, Matrix.mul_assoc,
+      Matrix.mul_nonsing_inv _ hXH, Matrix.mul_one]
+  rw [← h1, hdress, h2]
+
+/-- **From the first displayed diagram to the second** (arXiv:1606.00608,
 proof of Proposition 4.13, lines 1909--1919): if a letter dressed by an
 invertible gauge equals its adjoint dressing,
 $XBX^{-1} = (X^{-1})^\dagger B^\dagger X^\dagger$, then conjugation by the
@@ -72,18 +100,19 @@ Gram matrix $X^\dagger X$ carries the letter to its adjoint. -/
 theorem gram_conj_eq_conjTranspose_of_dressed_adjoint
     {X B : Matrix n n ℂ} (hX : IsUnit X.det)
     (hdress : X * B * X⁻¹ = X⁻¹ᴴ * Bᴴ * Xᴴ) :
-    Xᴴ * X * B * (Xᴴ * X)⁻¹ = Bᴴ := by
-  have hXH : IsUnit (Xᴴ).det := by
-    rw [Matrix.det_conjTranspose]
-    exact hX.star
-  have h1 : Xᴴ * (X * B * X⁻¹) * X⁻¹ᴴ = Xᴴ * X * B * (Xᴴ * X)⁻¹ := by
-    rw [Matrix.mul_inv_rev, Matrix.conjTranspose_nonsing_inv]
-    simp only [Matrix.mul_assoc]
-  have h2 : Xᴴ * (X⁻¹ᴴ * Bᴴ * Xᴴ) * X⁻¹ᴴ = Bᴴ := by
-    rw [Matrix.conjTranspose_nonsing_inv, ← Matrix.mul_assoc, ← Matrix.mul_assoc,
-      Matrix.mul_nonsing_inv _ hXH, Matrix.one_mul, Matrix.mul_assoc,
-      Matrix.mul_nonsing_inv _ hXH, Matrix.mul_one]
-  rw [← h1, hdress, h2]
+    Xᴴ * X * B * (Xᴴ * X)⁻¹ = Bᴴ :=
+  gram_conj_eq_of_dressed_target hX hdress
+
+/-- **The second displayed diagram** (arXiv:1606.00608, proof of Proposition
+4.13, lines 1914--1919): two gauges whose dressings carry the same letter `B`
+to the same target `C` have equal Gram conjugations. -/
+theorem gram_conj_eq_gram_conj_of_common_dressed_target
+    {X Y B C : Matrix n n ℂ} (hX : IsUnit X.det) (hY : IsUnit Y.det)
+    (hdX : X * B * X⁻¹ = X⁻¹ᴴ * C * Xᴴ)
+    (hdY : Y * B * Y⁻¹ = Y⁻¹ᴴ * C * Yᴴ) :
+    Xᴴ * X * B * (Xᴴ * X)⁻¹ = Yᴴ * Y * B * (Yᴴ * Y)⁻¹ := by
+  rw [gram_conj_eq_of_dressed_target hX hdX,
+    gram_conj_eq_of_dressed_target hY hdY]
 
 /-- **The second displayed diagram** (arXiv:1606.00608, proof of Proposition
 4.13, lines 1914--1919): two gauges whose dressings both equal the adjoint
@@ -93,15 +122,45 @@ theorem gram_conj_eq_gram_conj_of_dressed_adjoint
     {X Y B : Matrix n n ℂ} (hX : IsUnit X.det) (hY : IsUnit Y.det)
     (hdX : X * B * X⁻¹ = X⁻¹ᴴ * Bᴴ * Xᴴ)
     (hdY : Y * B * Y⁻¹ = Y⁻¹ᴴ * Bᴴ * Yᴴ) :
-    Xᴴ * X * B * (Xᴴ * X)⁻¹ = Yᴴ * Y * B * (Yᴴ * Y)⁻¹ := by
-  rw [gram_conj_eq_conjTranspose_of_dressed_adjoint hX hdX,
-    gram_conj_eq_conjTranspose_of_dressed_adjoint hY hdY]
+    Xᴴ * X * B * (Xᴴ * X)⁻¹ = Yᴴ * Y * B * (Yᴴ * Y)⁻¹ :=
+  gram_conj_eq_gram_conj_of_common_dressed_target hX hY hdX hdY
 
-/-- **The second diagram in the normalization $X_{\alpha,1} = \Id$**
-(arXiv:1606.00608, proof of Proposition 4.13, lines 1909--1919): for a
-self-adjoint letter, the dressed-adjoint identity makes the Gram matrix
-$X^\dagger X$ commute with the letter.  Self-adjointness of the letter is the
-first diagram for the sector $k = 1$ with $X_{\alpha,1} = \Id$. -/
+/-- **The relative commutant in the second displayed diagram**
+(arXiv:1606.00608, proof of Proposition 4.13, lines 1914--1921): if two
+invertible matrices have the same Gram conjugation of a matrix, then the
+ratio of their Gram matrices commutes with that matrix. -/
+theorem commute_gram_ratio_of_gram_conj_eq
+    {X Y B : Matrix n n ℂ} (hX : IsUnit X.det) (hY : IsUnit Y.det)
+    (h : Xᴴ * X * B * (Xᴴ * X)⁻¹ = Yᴴ * Y * B * (Yᴴ * Y)⁻¹) :
+    (Yᴴ * Y)⁻¹ * (Xᴴ * X) * B =
+      B * ((Yᴴ * Y)⁻¹ * (Xᴴ * X)) := by
+  have hGX : IsUnit (Xᴴ * X).det := by
+    rw [Matrix.det_mul, Matrix.det_conjTranspose]
+    exact hX.star.mul hX
+  have hGY : IsUnit (Yᴴ * Y).det := by
+    rw [Matrix.det_mul, Matrix.det_conjTranspose]
+    exact hY.star.mul hY
+  have hGYinv : (Yᴴ * Y)⁻¹ * (Yᴴ * Y) = 1 :=
+    Matrix.nonsing_inv_mul _ hGY
+  calc
+    (Yᴴ * Y)⁻¹ * (Xᴴ * X) * B =
+        (Yᴴ * Y)⁻¹ * (Xᴴ * X) * B * ((Xᴴ * X)⁻¹ * (Xᴴ * X)) := by
+          rw [Matrix.nonsing_inv_mul _ hGX, Matrix.mul_one]
+    _ = (Yᴴ * Y)⁻¹ *
+        (Xᴴ * X * B * (Xᴴ * X)⁻¹) * (Xᴴ * X) := by
+          simp only [Matrix.mul_assoc]
+    _ = (Yᴴ * Y)⁻¹ *
+        (Yᴴ * Y * B * (Yᴴ * Y)⁻¹) * (Xᴴ * X) := by rw [h]
+    _ = ((Yᴴ * Y)⁻¹ * (Yᴴ * Y)) * B *
+        ((Yᴴ * Y)⁻¹ * (Xᴴ * X)) := by noncomm_ring
+    _ = B * ((Yᴴ * Y)⁻¹ * (Xᴴ * X)) := by rw [hGYinv, Matrix.one_mul]
+
+/-- For a self-adjoint matrix, equality with its dressing by the inverse
+conjugate transpose makes the Gram matrix $X^\dagger X$ commute with it.
+
+This is a purely algebraic same-letter specialization.  The vertical-sector
+identity in arXiv:1606.00608, proof of Proposition 4.13, lines 1909--1919,
+instead exchanges the two oriented horizontal bond indices. -/
 theorem commute_gram_of_dressed_adjoint_of_conjTranspose_eq
     {X B : Matrix n n ℂ} (hX : IsUnit X.det)
     (hdress : X * B * X⁻¹ = X⁻¹ᴴ * Bᴴ * Xᴴ) (hB : Bᴴ = B) :
@@ -117,6 +176,32 @@ theorem commute_gram_of_dressed_adjoint_of_conjTranspose_eq
     _ = Xᴴ * X * B * (Xᴴ * X)⁻¹ * (Xᴴ * X) := by
       simp only [Matrix.mul_assoc]
     _ = B * (Xᴴ * X) := by rw [h]
+
+/-- A relative Gram identity gives the unitary normalization of the relative
+gauge.  This is the two-gauge form of the normalization used in
+arXiv:1606.00608, proof of Proposition 4.13, lines 1904--1908. -/
+theorem smul_mul_nonsing_inv_mem_unitaryGroup_of_gram_eq_smul
+    {X Y : Matrix n n ℂ} (hY : IsUnit Y.det) {ω : ℝ} (hω : 0 < ω)
+    (hgram : Xᴴ * X = (ω : ℂ) • (Yᴴ * Y)) :
+    ((Real.sqrt ω : ℂ))⁻¹ • (X * Y⁻¹) ∈ Matrix.unitaryGroup n ℂ := by
+  apply smul_mem_unitaryGroup_of_conjTranspose_mul_self_eq_smul_one hω
+  have hYH : IsUnit (Yᴴ).det := by
+    rw [Matrix.det_conjTranspose]
+    exact hY.star
+  have hleft : Y⁻¹ᴴ * Yᴴ = 1 := by
+    rw [Matrix.conjTranspose_nonsing_inv]
+    exact Matrix.nonsing_inv_mul _ hYH
+  have hright : Y * Y⁻¹ = 1 := Matrix.mul_nonsing_inv _ hY
+  calc
+    (X * Y⁻¹)ᴴ * (X * Y⁻¹) = Y⁻¹ᴴ * (Xᴴ * X) * Y⁻¹ := by
+      rw [Matrix.conjTranspose_mul]
+      noncomm_ring
+    _ = Y⁻¹ᴴ * ((ω : ℂ) • (Yᴴ * Y)) * Y⁻¹ := by rw [hgram]
+    _ = (ω : ℂ) • ((Y⁻¹ᴴ * Yᴴ) * (Y * Y⁻¹)) := by
+      simp only [Matrix.mul_smul, Matrix.smul_mul]
+      congr 1
+      noncomm_ring
+    _ = (ω : ℂ) • 1 := by rw [hleft, hright, Matrix.one_mul]
 
 end Matrix
 
@@ -142,6 +227,95 @@ theorem IsNormal.eq_smul_one_of_commute {A : MPSTensor d D} (hA : IsNormal A)
   obtain ⟨c, hc⟩ := Matrix.isScalar_of_commute_span_eq_top S hN hwords
   refine ⟨c, ?_⟩
   rw [hc, Matrix.scalar_apply, Matrix.smul_one_eq_diagonal]
+
+/-- **Relative equation eq3:proof.IV.12.**  If two invertible Gram matrices
+induce the same conjugation on every letter of a normal tensor, then one Gram
+matrix is a positive real multiple of the other:
+$X^\dagger X=\omega Y^\dagger Y$ with $\omega>0$.
+
+This is the conclusion drawn from the second displayed diagram in the proof
+of Proposition 4.13 of arXiv:1606.00608, lines 1914--1921.  It compares the
+sector $k$ directly with the distinguished sector $1$ and does not assume that
+the letters of the representative tensor are self-adjoint. -/
+theorem IsNormal.gram_eq_pos_smul_gram_of_gram_conj_eq
+    {A : MPSTensor d D} (hA : IsNormal A)
+    {X Y : Matrix (Fin D) (Fin D) ℂ} (hX : IsUnit X.det) (hY : IsUnit Y.det)
+    (hgram : ∀ i,
+      Xᴴ * X * A i * (Xᴴ * X)⁻¹ = Yᴴ * Y * A i * (Yᴴ * Y)⁻¹) :
+    ∃ ω : ℝ, 0 < ω ∧ Xᴴ * X = (ω : ℂ) • (Yᴴ * Y) := by
+  have hGY : IsUnit (Yᴴ * Y).det := by
+    rw [Matrix.det_mul, Matrix.det_conjTranspose]
+    exact hY.star.mul hY
+  have hcomm : ∀ i, (Yᴴ * Y)⁻¹ * (Xᴴ * X) * A i =
+      A i * ((Yᴴ * Y)⁻¹ * (Xᴴ * X)) := fun i =>
+    Matrix.commute_gram_ratio_of_gram_conj_eq hX hY (hgram i)
+  obtain ⟨c, hc⟩ := hA.eq_smul_one_of_commute hcomm
+  have hcGram : Xᴴ * X = c • (Yᴴ * Y) := by
+    calc
+      Xᴴ * X = (Yᴴ * Y) * ((Yᴴ * Y)⁻¹ * (Xᴴ * X)) := by
+        rw [← Matrix.mul_assoc, Matrix.mul_nonsing_inv _ hGY, Matrix.one_mul]
+      _ = (Yᴴ * Y) * (c • 1) := by rw [hc]
+      _ = c • (Yᴴ * Y) := by
+        rw [Matrix.mul_smul, Matrix.mul_one]
+  rcases Nat.eq_zero_or_pos D with hD | hD
+  · subst D
+    refine ⟨1, by positivity, ?_⟩
+    ext i
+    exact i.elim0
+  · let i : Fin D := ⟨0, hD⟩
+    have hXunit : IsUnit X := (Matrix.isUnit_iff_isUnit_det X).mpr hX
+    have hYunit : IsUnit Y := (Matrix.isUnit_iff_isUnit_det Y).mpr hY
+    have hGXpd : (Xᴴ * X).PosDef :=
+      Matrix.PosDef.conjTranspose_mul_self X
+        (Matrix.mulVec_injective_of_isUnit hXunit)
+    have hGYpd : (Yᴴ * Y).PosDef :=
+      Matrix.PosDef.conjTranspose_mul_self Y
+        (Matrix.mulVec_injective_of_isUnit hYunit)
+    have hcEntry : (Xᴴ * X) i i = c * (Yᴴ * Y) i i := by
+      simpa [Matrix.smul_apply] using congr_fun (congr_fun hcGram i) i
+    have hcPos : (0 : ℂ) < c := by
+      apply pos_of_mul_pos_left
+      · rw [← hcEntry]
+        exact hGXpd.diag_pos
+      · exact hGYpd.diag_pos.le
+    obtain ⟨hcRe, hcIm⟩ := Complex.pos_iff.mp hcPos
+    refine ⟨c.re, hcRe, ?_⟩
+    rw [hcGram]
+    congr 1
+    exact (Complex.ext (Complex.ofReal_re c.re)
+      (by rw [Complex.ofReal_im]; exact hcIm)).symm
+
+/-- **Relative equation eq3 from the common dressed target.**  If two
+invertible gauges dress every letter of a normal tensor to the same target,
+then their Gram matrices differ by a positive real scalar.  The target may
+depend on the letter; for the MPO adjoint in Figure 7 it is the adjoint of the
+letter with exchanged oriented bond indices.
+
+Source: arXiv:1606.00608, proof of Proposition 4.13, lines 1909--1921. -/
+theorem IsNormal.gram_eq_pos_smul_gram_of_common_dressed_target
+    {A C : MPSTensor d D} (hA : IsNormal A)
+    {X Y : Matrix (Fin D) (Fin D) ℂ} (hX : IsUnit X.det) (hY : IsUnit Y.det)
+    (hdX : ∀ i, X * A i * X⁻¹ = X⁻¹ᴴ * C i * Xᴴ)
+    (hdY : ∀ i, Y * A i * Y⁻¹ = Y⁻¹ᴴ * C i * Yᴴ) :
+    ∃ ω : ℝ, 0 < ω ∧ Xᴴ * X = (ω : ℂ) • (Yᴴ * Y) :=
+  hA.gram_eq_pos_smul_gram_of_gram_conj_eq hX hY fun i =>
+    Matrix.gram_conj_eq_gram_conj_of_common_dressed_target
+      hX hY (hdX i) (hdY i)
+
+/-- The relative gauge of the preceding theorem becomes unitary after
+division by the square root of its positive Gram scalar.  In the normalization
+$Y=\Id$, this is $\omega^{-1/2}X$ from arXiv:1606.00608, lines 1904--1908. -/
+theorem IsNormal.smul_mul_nonsing_inv_mem_unitaryGroup_of_common_dressed_target
+    {A C : MPSTensor d D} (hA : IsNormal A)
+    {X Y : Matrix (Fin D) (Fin D) ℂ} (hX : IsUnit X.det) (hY : IsUnit Y.det)
+    (hdX : ∀ i, X * A i * X⁻¹ = X⁻¹ᴴ * C i * Xᴴ)
+    (hdY : ∀ i, Y * A i * Y⁻¹ = Y⁻¹ᴴ * C i * Yᴴ) :
+    ∃ ω : ℝ, 0 < ω ∧
+      ((Real.sqrt ω : ℂ))⁻¹ • (X * Y⁻¹) ∈ Matrix.unitaryGroup (Fin D) ℂ := by
+  obtain ⟨ω, hω, hgram⟩ :=
+    hA.gram_eq_pos_smul_gram_of_common_dressed_target hX hY hdX hdY
+  exact ⟨ω, hω,
+    Matrix.smul_mul_nonsing_inv_mem_unitaryGroup_of_gram_eq_smul hY hω hgram⟩
 
 /-- **Equation eq3:proof.IV.12 in the normalization $X_{\alpha,1} = \Id$.**
 If $X \ne 0$ and the Gram matrix $X^\dagger X$ commutes with every matrix of
@@ -194,13 +368,16 @@ theorem IsNormal.smul_mem_unitaryGroup_of_commute
   exact ⟨ω, hω,
     Matrix.smul_mem_unitaryGroup_of_conjTranspose_mul_self_eq_smul_one hω hXX⟩
 
-/-- **Equation eq3:proof.IV.12 from the dressed-adjoint identities.**  If the
-gauge-dressed letters of a normal tensor equal their adjoint dressings (the
-first displayed diagram of arXiv:1606.00608, proof of Proposition 4.13, lines
-1909--1913, transported blockwise by Lemma L) and the letters are self-adjoint
-(the same identity for the sector $k = 1$ in the normalization
-$X_{\alpha,1} = \Id$), then $X^\dagger X = \omega\,\Id$ for a necessarily
-positive constant $\omega$. -/
+/-- If the gauge-dressed letters of a normal tensor equal their adjoint
+dressings and the letters themselves are self-adjoint, then
+$X^\dagger X = \omega\,\Id$ for a necessarily positive constant $\omega$.
+
+**Scope restriction (self-adjoint letters):** the fixed orientation of Figure
+7 instead has the common target $(A^{v^{\mathrm{op}}})^\dagger$ and does not
+assume $(A^v)^\dagger=A^v$.  Thus this theorem is only the same-letter
+specialization.  The relative common-target statement is
+`IsNormal.gram_eq_pos_smul_gram_of_common_dressed_target`.  See
+`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`. -/
 theorem IsNormal.conjTranspose_mul_self_eq_smul_one_of_dressed_adjoint
     {A : MPSTensor d D} (hA : IsNormal A)
     {X : Matrix (Fin D) (Fin D) ℂ} (hX : IsUnit X.det) (hX0 : X ≠ 0)
@@ -213,7 +390,11 @@ theorem IsNormal.conjTranspose_mul_self_eq_smul_one_of_dressed_adjoint
 /-- **The isometric normalization from the dressed-adjoint identities**
 (arXiv:1606.00608, proof of Proposition 4.13, lines 1906--1908 and
 1909--1919): under the hypotheses of the preceding theorem,
-$\omega^{-1/2}X$ is unitary. -/
+$\omega^{-1/2}X$ is unitary.
+
+**Scope restriction (self-adjoint letters):** this is the normalization of the
+same-letter specialization, not the relative two-gauge conclusion of the
+source.  See `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`. -/
 theorem IsNormal.smul_mem_unitaryGroup_of_dressed_adjoint
     {A : MPSTensor d D} (hA : IsNormal A)
     {X : Matrix (Fin D) (Fin D) ℂ} (hX : IsUnit X.det) (hX0 : X ≠ 0)

--- a/TNLean/MPS/MPDO/VerticalBNT.lean
+++ b/TNLean/MPS/MPDO/VerticalBNT.lean
@@ -139,6 +139,7 @@ For each class `j` and copy `q`, the original normalized corner is
 `blocks (enum j q) = ζ j q · X j q · blocks (repr j) · (X j q)⁻¹`.
 
 The scalar `ζ j q` has unit norm, and it is one for the chosen representative.
+The gauge `X j q` is also the identity for the chosen representative.
 Consequently the coefficient `μ (enum j q) * ζ j q` in the literal vertical
 decomposition is positive.  The representatives form a basis of normal tensors
 for the corresponding weighted block tensor and are pairwise gauge-phase
@@ -173,6 +174,7 @@ theorem IsHorizontalCF.exists_verticalBNTGrouping_with_isometry
         (ζ : (j : Fin classes.g) → Fin (classes.copies j) → ℂ),
         (∀ j q, ‖ζ j q‖ = 1) ∧
         (∀ j q, ζ j q ≠ 0) ∧
+        (∀ j, X j ⟨0, classes.copies_pos j⟩ = 1) ∧
         (∀ j, ζ j ⟨0, classes.copies_pos j⟩ = 1) ∧
         (∀ j q v,
           blocks (classes.enum j q) v =
@@ -256,7 +258,7 @@ theorem IsHorizontalCF.exists_verticalBNTGrouping_with_isometry
               (blocks (classes.repr j))) v *
             (↑(X⁻¹) : Matrix (Fin (dim (classes.enum j q)))
               (Fin (dim (classes.enum j q))) ℂ))) ∧
-        (q = ⟨0, classes.copies_pos j⟩ → ζ = 1) := by
+        (q = ⟨0, classes.copies_pos j⟩ → X = 1 ∧ ζ = 1) := by
     intro j q
     by_cases hq : q = ⟨0, classes.copies_pos j⟩
     · have hEnum : classes.enum j q = classes.repr j := by
@@ -264,7 +266,7 @@ theorem IsHorizontalCF.exists_verticalBNTGrouping_with_isometry
         exact MPSTensor.mpvPhaseClassData_enum_zero_eq_repr blocks j
       have hdim : dim (classes.repr j) = dim (classes.enum j q) :=
         congrArg dim hEnum.symm
-      refine ⟨hdim, 1, 1, norm_one, one_ne_zero, ?_, fun _ => rfl⟩
+      refine ⟨hdim, 1, 1, norm_one, one_ne_zero, ?_, fun _ => ⟨rfl, rfl⟩⟩
       have hcast : cast (congr_arg (MPSTensor (D * D)) hdim)
           (blocks (classes.repr j)) = blocks (classes.enum j q) := by
         rw [cast_eq_iff_heq]
@@ -290,10 +292,13 @@ theorem IsHorizontalCF.exists_verticalBNTGrouping_with_isometry
       refine ⟨hdim, X, ζ, ?_, hζNe, hGauge, fun h => (hq h).elim⟩
       exact MPSTensor.norm_eq_one_of_gaugePhase_cast_of_isNormalTensor
         (hNormal (classes.repr j)) (hNormal (classes.enum j q)) hdim hGauge
-  choose hdim X ζ hζNorm hζNe hGauge hζDist using hClassGauge
+  choose hdim X ζ hζNorm hζNe hGauge hDist using hClassGauge
+  have hXDist : ∀ j, X j ⟨0, classes.copies_pos j⟩ = 1 := by
+    intro j
+    exact (hDist j ⟨0, classes.copies_pos j⟩ rfl).1
   have hζDist' : ∀ j, ζ j ⟨0, classes.copies_pos j⟩ = 1 := by
     intro j
-    exact hζDist j ⟨0, classes.copies_pos j⟩ rfl
+    exact (hDist j ⟨0, classes.copies_pos j⟩ rfl).2
   have hCornerEq : ∀ j q v,
       μ (classes.enum j q) • blocks (classes.enum j q) v =
         (μ (classes.enum j q) * ζ j q) •
@@ -348,7 +353,7 @@ theorem IsHorizontalCF.exists_verticalBNTGrouping_with_isometry
     intro j q
     let q₀ : Fin (classes.copies j) := ⟨0, classes.copies_pos j⟩
     have hRefPos : (0 : ℂ) < μ (classes.enum j q₀) * ζ j q₀ := by
-      rw [hζDist j q₀ rfl]
+      rw [hζDist' j]
       simp only [mul_one, q₀]
       exact hμPos (classes.repr j)
     obtain ⟨N, hne⟩ := hCompression j q
@@ -393,7 +398,7 @@ theorem IsHorizontalCF.exists_verticalBNTGrouping_with_isometry
           (fun j => hNormal (classes.repr j)) classes.blocks_not_equiv
   refine ⟨r, dim, μ, blocks, V, hdimPos, hμPos, hNormal, hIso, hOrth,
     hInt, hIntStar, hCorner, hReconstruct, hdim, X, ζ, hζNorm, hζNe,
-    hζDist', hGauge, hBNT, classes.blocks_not_equiv, ?_, hSector, hCompression,
+    hXDist, hζDist', hGauge, hBNT, classes.blocks_not_equiv, ?_, hSector, hCompression,
     hCoeffPos, ?_, ?_, ?_, ?_, ?_, ?_⟩
   · intro j q
     exact mul_ne_zero (hμPos (classes.enum j q)).ne' (hζNe j q)

--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -106,8 +106,10 @@ remaining corners without losing their physical isometries or the literal
 letterwise reconstruction. `TNLean.MPS.MPDO.VerticalBNT` groups these corners
 into representatives while retaining their physical isometries, and
 `TNLean.MPS.MPDO.SectorTrace` proves positivity of every grouped coefficient.
-What remains open is the dressed-adjoint argument that normalizes the gauges
-and assembles the final coisometry.
+The relative Gram algebra is formalized in
+`TNLean.MPS.CanonicalForm.NormalCommutant`.  What remains open is the reflected
+marked-chain form of Lemma L needed to apply it to the grouped data, followed
+by the final coisometry assembly.
 
 ## Module location
 
@@ -358,6 +360,24 @@ arXiv:1606.00608, Proposition 4.13, is a statement about this tensor. -/
 def verticalTensor (M : MPOTensor d D) : MPSTensor (D * D) d :=
   fun ab i j => M i j ab.divNat ab.modNat
 
+/-- Exchange the two oriented horizontal bond indices of a vertical letter.
+For `ab = (a,b)`, this is `bondPairSwap ab = (b,a)`.
+
+This is the bond-index exchange under adjunction in the first diagram of the
+proof of Proposition 4.13 of arXiv:1606.00608, lines 1909--1913. -/
+def bondPairSwap (ab : Fin (D * D)) : Fin (D * D) :=
+  finProdFinEquiv (ab.modNat, ab.divNat)
+
+@[simp] theorem bondPairSwap_finProdFinEquiv (a b : Fin D) :
+    bondPairSwap (finProdFinEquiv (a, b)) = finProdFinEquiv (b, a) := by
+  simp [bondPairSwap]
+
+@[simp] theorem bondPairSwap_involutive (ab : Fin (D * D)) :
+    bondPairSwap (bondPairSwap ab) = ab := by
+  rw [show ab = finProdFinEquiv (ab.divNat, ab.modNat) by
+    exact (finProdFinEquiv.apply_symm_apply ab).symm]
+  simp
+
 @[simp] lemma verticalTensor_apply (M : MPOTensor d D) (ab : Fin (D * D))
     (i j : Fin d) : verticalTensor M ab i j = M i j ab.divNat ab.modNat :=
   rfl
@@ -367,6 +387,19 @@ lemma verticalTensor_finProdFinEquiv (M : MPOTensor d D) (a b : Fin D)
     (i j : Fin d) :
     verticalTensor M (finProdFinEquiv (a, b)) i j = M i j a b := by
   simp
+
+/-- The vertical view of the MPO adjoint exchanges the oriented horizontal
+bond indices and conjugate-transposes the resulting vertical letter:
+$\widetilde{M^\dagger}_{a,b}=(\widetilde M_{b,a})^\dagger$.
+
+This is the indexed adjoint convention in the first displayed diagram of the
+proof of Proposition 4.13 of arXiv:1606.00608, lines 1909--1913. -/
+@[simp] theorem verticalTensor_adjointTensor (M : MPOTensor d D)
+    (ab : Fin (D * D)) :
+    verticalTensor (adjointTensor M) ab =
+      (verticalTensor M (bondPairSwap ab))ᴴ := by
+  ext i j
+  simp [verticalTensor_apply, bondPairSwap, Matrix.conjTranspose_apply]
 
 /-- The diagonal MPS tensor extracted from an MPO by restricting to equal ket
 and bra indices.  Its matrix product vectors are the diagonal entries

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -103,6 +103,28 @@
     vectors of the vertical direction.
 \end{definition}
 
+\begin{lemma}[Vertical reflection identity for the adjoint tensor]
+    \label{lem:vertical_tensor_adjoint_reflection}
+    \lean{MPOTensor.bondPairSwap}
+    \lean{MPOTensor.bondPairSwap_finProdFinEquiv}
+    \lean{MPOTensor.bondPairSwap_involutive}
+    \lean{MPOTensor.verticalTensor_adjointTensor}
+    \leanok
+    \uses{def:vertical_tensor_mpdo, def:mpo_adjoint_tensor}
+    Adjunction exchanges the two oriented horizontal bond indices in the
+    vertical view:
+    \[
+        \widetilde{M^\dagger}_{a,b}
+        = (\widetilde M_{b,a})^\dagger.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    This follows entrywise from the exchange of the ket and bra indices and
+    conjugate transposition of the virtual matrix.
+\end{proof}
+
 \begin{definition}[Vertical canonical form for an MPO]\label{def:vertical_cf_mpdo}
     \lean{MPOTensor.IsVerticalCF}
     \leanok
@@ -1783,34 +1805,39 @@
 
 \begin{theorem}[Gram conjugation from the adjoint dressing]
     \label{thm:gram_conj_of_dressed_adjoint}
+    \lean{Matrix.gram_conj_eq_of_dressed_target}
+    \lean{Matrix.gram_conj_eq_gram_conj_of_common_dressed_target}
     \lean{Matrix.gram_conj_eq_conjTranspose_of_dressed_adjoint}
     \lean{Matrix.gram_conj_eq_gram_conj_of_dressed_adjoint}
+    \lean{Matrix.commute_gram_ratio_of_gram_conj_eq}
     \lean{Matrix.commute_gram_of_dressed_adjoint_of_conjTranspose_eq}
     \leanok
-    Let $X$ be invertible and let $B$ satisfy the dressed-adjoint identity
+    Let $X$ be invertible and suppose that $B$ and a target $C$ satisfy
     \[
-        XBX^{-1} = (X^{-1})^\dagger B^\dagger X^\dagger.
+        XBX^{-1} = (X^{-1})^\dagger C X^\dagger.
     \]
-    Then conjugation by the Gram matrix carries $B$ to its adjoint,
+    Then conjugation by the Gram matrix carries $B$ to $C$,
     \[
-        (X^\dagger X)\,B\,(X^\dagger X)^{-1} = B^\dagger,
+        (X^\dagger X)\,B\,(X^\dagger X)^{-1} = C.
     \]
-    so any two gauges satisfying the identity have equal Gram conjugations,
-    and if moreover $B^\dagger = B$ then $X^\dagger X$ commutes with $B$.
-    Applied to the letters of a vertical sector, the first display is the
-    blockwise form of the first diagram in the proof of
-    \cite[Proposition~4.13]{Cirac2016MPDO_arXiv}, the second is the second
-    diagram, and the commutation is its form in the normalization
-    $X_{\alpha,1}=\Id$.
+    Hence any two gauges satisfying the identity with the same target have
+    equal Gram conjugations, and the ratio of their Gram matrices commutes
+    with $B$.  Applied letterwise to a vertical tensor $A$, take $B=A^v$ and,
+    in the fixed orientation $v=(a,b)$, take
+    $C=(A^{(b,a)})^\dagger$ in the first diagram of
+    \cite[Proposition~4.13, lines 1909--1919]{Cirac2016MPDO_arXiv}.
+    The same-letter choice $C=B^\dagger$ and the
+    further specialization $B^\dagger=B$ are useful corollaries, but the
+    latter is not assumed by the source.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    Multiply the dressed-adjoint identity by $X^\dagger$ on the left and by
+    Multiply the dressed-target identity by $X^\dagger$ on the left and by
     $(X^{-1})^\dagger$ on the right.  The left side becomes
     $(X^\dagger X)B(X^\dagger X)^{-1}$ and the right side collapses to
-    $B^\dagger$.  If $B^\dagger = B$, multiplying the resulting identity by
-    $X^\dagger X$ on the right gives the commutation.
+    $C$.  Eliminating the common target for two gauges and multiplying by the
+    inverse Gram matrix gives the relative commutation relation.
 \end{proof}
 
 \begin{figure}[ht]
@@ -1831,30 +1858,39 @@
 
 \begin{theorem}[Gram-matrix proportionality from the dressed-adjoint identities]
     \label{thm:eq3_of_dressed_adjoint}
-    \lean{MPSTensor.IsNormal.conjTranspose_mul_self_eq_smul_one_of_dressed_adjoint}
-    \lean{MPSTensor.IsNormal.smul_mem_unitaryGroup_of_dressed_adjoint}
+    \lean{MPSTensor.IsNormal.gram_eq_pos_smul_gram_of_gram_conj_eq}
+    \lean{MPSTensor.IsNormal.gram_eq_pos_smul_gram_of_common_dressed_target}
+    \lean{MPSTensor.IsNormal.smul_mul_nonsing_inv_mem_unitaryGroup_of_common_dressed_target}
+    \lean{Matrix.smul_mul_nonsing_inv_mem_unitaryGroup_of_gram_eq_smul}
     \leanok
     \uses{def:normal, thm:gram_conj_of_dressed_adjoint,
         thm:normal_tensor_gram_rigidity}
-    Let $M_\alpha$ be a normal tensor with self-adjoint letters and let
-    $X \ne 0$ be invertible with
-    $XM_\alpha^iX^{-1} = (X^{-1})^\dagger (M_\alpha^i)^\dagger X^\dagger$
-    for every letter.  Then $X^\dagger X = \omega\,\Id$ for a necessarily
-    positive constant $\omega$, and $\omega^{-1/2}X$ is unitary.  The
-    hypotheses are the blockwise identities produced by Lemma L from the
-    first diagram in the proof of
-    \cite[Proposition~4.13]{Cirac2016MPDO_arXiv}, for the sectors $k$ and
-    $1$ in the normalization $X_{\alpha,1}=\Id$; the conclusion is the
-    Gram-matrix proportionality used to normalize the gauges isometrically.
+    Let $M_\alpha$ be a normal tensor, and let $X$ and $Y$ be invertible
+    gauges which dress each letter $M_\alpha^v$ to the same target $C^v$.
+    Then there is a positive real number $\omega$ such that
+    \[
+        X^\dagger X=\omega\,Y^\dagger Y,
+    \]
+    and $\omega^{-1/2}XY^{-1}$ is unitary.  For the first diagram in the
+    proof of \cite[Proposition~4.13, lines 1909--1921]{Cirac2016MPDO_arXiv},
+    the target is $C^v=(M_\alpha^{v^{\mathrm{op}}})^\dagger$.  Taking $Y$ to
+    be the distinguished sector gauge gives the Gram-matrix proportionality
+    used at lines 1903--1907. In the normalization $Y=\Id$, the resulting
+    unitary is $\omega^{-1/2}X$.
 \end{theorem}
 
 \begin{proof}
     \leanok
     \uses{thm:gram_conj_of_dressed_adjoint, thm:normal_tensor_gram_rigidity}
-    By Theorem~\ref{thm:gram_conj_of_dressed_adjoint} the Gram matrix
-    $X^\dagger X$ commutes with every letter of $M_\alpha$.
-    Theorem~\ref{thm:normal_tensor_gram_rigidity} then makes it a positive
-    multiple of the identity and normalizes $X$ to a unitary.
+    By Theorem~\ref{thm:gram_conj_of_dressed_adjoint}, the ratio
+    $(Y^\dagger Y)^{-1}(X^\dagger X)$ commutes with every letter of
+    $M_\alpha$.  Theorem~\ref{thm:normal_tensor_gram_rigidity} makes this
+    ratio scalar.  When the matrix dimension is positive, positive
+    definiteness of the two Gram matrices makes the scalar a positive real
+    number $\omega$.  In dimension zero the equality is vacuous and one may
+    choose $\omega=1$.  Conjugating the relative Gram identity by $Y^{-1}$
+    shows that $XY^{-1}$ has Gram matrix $\omega\Id$; division by
+    $\sqrt\omega$ makes it unitary.
 \end{proof}
 
 \begin{lemma}[Matrix product vector of the diagonal tensor]
@@ -2238,7 +2274,7 @@
     scalar per site. There are normal representatives $M_\alpha$, an enumeration
     $k=(\alpha,q)$ of the original sectors, invertible matrices
     $X_{\alpha,q}$, and complex numbers $\zeta_{\alpha,q}$ of unit modulus,
-    with $\zeta_{\alpha,1}=1$, such that
+    with $X_{\alpha,1}=\Id$ and $\zeta_{\alpha,1}=1$, such that
     \[
         B_{\alpha,q}^v
         =\zeta_{\alpha,q}X_{\alpha,q}M_\alpha^vX_{\alpha,q}^{-1}.
@@ -2261,8 +2297,9 @@
     For each pair $(\alpha,q)$, the range projector of $V_{\alpha,q}$ obeys
     the representative-loop identity and gives a nonzero compression at some
     finite length. This is the decomposition and positivity argument of
-    \cite[Proposition~4.13, lines 1898--1902]{Cirac2016MPDO_arXiv}. The gauge
-    normalization beginning at line 1903 is not asserted here.
+    \cite[Proposition~4.13, lines 1898--1902]{Cirac2016MPDO_arXiv}. The
+    relative Gram identity and proportional-unitary normalization of lines
+    1903--1908 are not asserted here.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -2277,7 +2314,8 @@
     separated by construction, so
     Theorem~\ref{thm:cpsv_normal_separated_eventually_li} gives eventual linear
     independence. The phase-class regrouping of the finite sum gives the BNT
-    expansion. The representative copy has phase one, while the self-overlap
+    expansion. The representative copy is assigned the identity gauge and
+    phase one, while the self-overlap
     normalization of normal tensors shows that every phase has unit modulus.
     Substitution in the two intertwining identities, the compression identity,
     and the literal reconstruction from
@@ -2292,7 +2330,31 @@
 \begin{theorem}[Horizontal canonical form implies vertical canonical form]
     \label{thm:vertical_cf_of_horizontal_cf}
     \notready
-    \uses{def:mpdo, def:horizontal_cf_mpdo, def:vertical_cf_mpdo}
+    \uses{def:mpdo, def:horizontal_cf_mpdo, def:vertical_tensor_mpdo,
+        def:vertical_cf_mpdo,
+        thm:mpdo_opposite_corner_zero,
+        thm:mpdo_first_site_invariant_comm,
+        thm:representative_one_sub_mp_zero,
+        thm:mpdo_vertical_no_periodic_vectors_horizontal_cf,
+        thm:mpdo_vertical_projector_closure,
+        thm:mpdo_vertical_irreducible_reducing_sectors,
+        thm:mpdo_vertical_complete_reducing_projectors,
+        thm:mpdo_vertical_normal_sectors_with_isometries,
+        thm:mpdo_vertical_bnt_grouping_with_isometries,
+        thm:projector_closure_canonical_form,
+        thm:mpdo_sector_compression_trace_pos,
+        def:mpdo_sector_projector,
+        thm:mpdo_sector_trace_identity,
+        thm:mpdo_sector_weight_pos,
+        thm:normal_tensor_gram_rigidity,
+        thm:mpo_adjoint_reflection,
+        lem:vertical_tensor_adjoint_reflection,
+        thm:gram_conj_of_dressed_adjoint,
+        thm:eq3_of_dressed_adjoint,
+        lem:mpv_diagonal_tensor,
+        lem:mpv_diagonal_tensor_eq_blocks, lem:mpv_diagonal_tensor_nonneg,
+        lem:mpv_vertical_assembled,
+        lem:vertical_grouping_equiv}
     A tensor in horizontal canonical form that generates matrix product
     density operators is also in canonical form in the vertical direction:
     there are a basis of normal tensors $\{M_\alpha\}_\alpha$ for the
@@ -2309,104 +2371,112 @@
 \end{theorem}
 
 \begin{proof}
-    \uses{def:bnt, def:bnt_cpsv, def:mpv_phase_class_data,
-        thm:mpdo_vertical_bnt_grouping_with_isometries,
-        thm:mpo_adjoint_reflection,
+    \uses{def:mpdo, def:horizontal_cf_mpdo, def:vertical_cf_mpdo, def:bnt,
+        thm:mpdo_opposite_corner_zero,
+        thm:mpdo_first_site_invariant_comm,
         thm:representative_one_sub_mp_zero,
+        thm:mpdo_vertical_no_periodic_vectors_horizontal_cf,
+        thm:mpdo_vertical_projector_closure,
+        thm:mpdo_vertical_irreducible_reducing_sectors,
+        thm:mpdo_vertical_complete_reducing_projectors,
+        thm:mpdo_vertical_bnt_grouping_with_isometries,
+        thm:projector_closure_canonical_form,
+        thm:mpdo_sector_compression_trace_pos,
+        def:mpdo_sector_projector,
+        thm:mpdo_sector_trace_identity,
+        thm:mpdo_sector_weight_pos,
+        thm:normal_tensor_gram_rigidity,
+        thm:mpo_adjoint_reflection,
+        lem:vertical_tensor_adjoint_reflection,
+        thm:gram_conj_of_dressed_adjoint,
         thm:eq3_of_dressed_adjoint,
         thm:cpsv_normal_eventually_injective,
-        thm:gauge_invariance, lem:mpv_zero_length}
-    Apply Theorem~\ref{thm:mpdo_vertical_bnt_grouping_with_isometries}.  It
-    gives normalized sectors $B_{\alpha,q}$, physical isometries
-    $V_{\alpha,q}$, normal representatives $M_\alpha$, positive numbers
-    $\mu_{\alpha,q}$, phases $\zeta_{\alpha,q}$, and invertible gauges
-    $X_{\alpha,q}$.  Write $q=1$ for the first copy in each class.  The
-    representative-first enumeration of
-    Definition~\ref{def:mpv_phase_class_data} gives
-    $B_{\alpha,1}=M_\alpha$.  Redefine the witness for this copy by
+        thm:gauge_invariance,
+        lem:mpv_diagonal_tensor,
+        lem:vertical_grouping_equiv, lem:mpv_zero_length}
+    Theorem~\ref{thm:representative_one_sub_mp_zero} shows
+    that every self-adjoint $P$ with $PM=PMP$ on the vertically viewed tensor
+    gives the literal equality $MP=PMP$ on the original MPO tensor, including
+    all its repeated sectors.  The paper takes $P$
+    to be an orthogonal projector; Hermiticity is the only part of that
+    assumption needed for this implication.
+    Theorem~\ref{thm:mpdo_vertical_no_periodic_vectors_horizontal_cf}
+    excludes nontrivial $p$-periodic vectors of the vertically viewed tensor
+    from the horizontal canonical-form and positivity hypotheses alone.
+    Theorem~\ref{thm:mpdo_vertical_projector_closure} proves that every
+    one-sided invariant orthogonal projection of $\widetilde M$ is reducing.
+    Theorem~\ref{thm:mpdo_vertical_irreducible_reducing_sectors} therefore
+    decomposes the physical space into complete orthogonal irreducible
+    reducing sectors, and
+    Theorem~\ref{thm:mpdo_vertical_complete_reducing_projectors} records their
+    commuting range projections. Theorem~\ref{thm:mpdo_vertical_normal_sectors_with_isometries}
+    removes the zero corners and spectrally normalizes the remaining corners
+    while retaining their physical isometries, both intertwining identities,
+    exact compression, and literal reconstruction of every vertical letter.
+    Theorem~\ref{thm:mpdo_vertical_bnt_grouping_with_isometries} groups the
+    resulting normal tensors, obtaining
     \[
-        X_{\alpha,1}=\Id,
-        \qquad
-        \zeta_{\alpha,1}=1;
-    \]
-    the gauge-phase identity is then literal.  Set
-    \[
-        c_{\alpha,q}=\mu_{\alpha,q}\zeta_{\alpha,q}>0,
-        \qquad
-        \mu_\alpha=\operatorname{diag}
-        (c_{\alpha,1},\ldots,c_{\alpha,r_\alpha}).
-    \]
-    Thus every $\mu_\alpha$ is positive diagonal, and for every vertical
-    letter $v$ one has
-    \[
-        \widetilde M_v
-        =\sum_{\alpha,q}V_{\alpha,q}
-        \bigl(c_{\alpha,q}X_{\alpha,q}M_\alpha^v
-        X_{\alpha,q}^{-1}\bigr)V_{\alpha,q}^\dagger.
-    \]
-
-    It remains to normalize the gauges compatibly with the adjoint.  Put
-    $P_{\alpha,q}=V_{\alpha,q}V_{\alpha,q}^\dagger$.  The sector compression
-    $(P_{\alpha,q})_1H^{(N)}(P_{\alpha,q})_1$ is positive semidefinite, hence
-    self-adjoint, and it is nonzero at the length supplied by the grouping
-    theorem.  Theorem~\ref{thm:mpo_adjoint_reflection} converts this
-    self-adjointness into equality of the two reflected horizontal first-site
-    contractions.  Theorem~\ref{thm:representative_one_sub_mp_zero} then
-    applies the horizontal Lemma~L and gives equality of the corresponding
-    inserted tensors on the original bond space.  Compressing that equality
-    on the left by $V_{\alpha,q}^\dagger$ and on the right by
-    $V_{\alpha,q}$ gives
-    \[
-        X_{\alpha,q}M_\alpha^vX_{\alpha,q}^{-1}
-        =(X_{\alpha,q}^{-1})^\dagger
-        (M_\alpha^v)^\dagger X_{\alpha,q}^\dagger.
-    \]
-    For $q=1$, the identities $B_{\alpha,1}=M_\alpha$,
-    $X_{\alpha,1}=\Id$, and $\zeta_{\alpha,1}=1$ reduce this to
-    \[
-        (M_\alpha^v)^\dagger=M_\alpha^v.
-    \]
-    Theorem~\ref{thm:eq3_of_dressed_adjoint} then yields positive numbers
-    $\omega_{\alpha,q}$ such that
-    \[
-        X_{\alpha,q}^\dagger X_{\alpha,q}
-        =\omega_{\alpha,q}\Id,
-        \qquad
-        Y_{\alpha,q}=\omega_{\alpha,q}^{-1/2}X_{\alpha,q}
-        \quad\text{is unitary}.
-    \]
-
-    Define $U$ by taking its $(\alpha,q)$ block row to be
-    $Y_{\alpha,q}^{-1}V_{\alpha,q}^\dagger$.  Orthogonality of the ranges of
-    the $V_{\alpha,q}$ gives $UU^\dagger=\Id$.  Since conjugation by
-    $Y_{\alpha,q}$ equals conjugation by $X_{\alpha,q}$, the compression and
-    reconstruction identities give
-    \[
-        U\widetilde M U^\dagger
-        =\bigoplus_\alpha\mu_\alpha\otimes M_\alpha,
-        \qquad
         \widetilde M
-        =U^\dagger\bigl(\bigoplus_\alpha
-        \mu_\alpha\otimes M_\alpha\bigr)U.
+        =\bigoplus_{\alpha,k}\mu_{\alpha,k}X_{\alpha,k}M_\alpha X_{\alpha,k}^{-1}
     \]
-    It remains to verify the three clauses of the algebraic
-    basis-of-normal-tensors property.  The grouping theorem supplies the
-    spectral BNT property for
+    carried by the physical space, with normal tensors $M_\alpha$ whose
+    letters remain indexed by the horizontal bond pairs.  These blocks are not
+    obtained by restricting the horizontal blocks to diagonal physical pairs,
+    as Theorem~\ref{thm:diagonal_restriction_not_normal} shows. It also
+    identifies the physical range projectors with the grouped sectors, proves
+    their loop identities, and finds a nonzero compression for each sector.
+    Positivity then gives $\mu_{\alpha,k}>0$:
+    Theorem~\ref{thm:mpdo_sector_compression_trace_pos} supplies the positive
+    traces of the nonzero sector compressions,
+    Theorem~\ref{thm:mpdo_sector_trace_identity} identifies each such trace
+    as $\mu_{\alpha,k}d_\alpha$, and
+    Theorem~\ref{thm:mpdo_sector_weight_pos} concludes $d_\alpha>0$ and
+    $\mu_{\alpha,k}>0$ from the normalization $\mu_{\alpha,1}>0$.
+    Once the common reflected-adjoint target in the first diagram has been
+    obtained for each grouped sector, Theorem~\ref{thm:eq3_of_dressed_adjoint}
+    derives the identity
+    \[
+        X_{\alpha,k}^\dagger X_{\alpha,k}
+        =\omega_{\alpha,k}\,X_{\alpha,1}^\dagger X_{\alpha,1},
+    \]
+    and the isometric normalization
+    $U_{\alpha,k}=\omega_{\alpha,k}^{-1/2}X_{\alpha,k}$ of the sector gauges
+    from the two-gauge form of the displayed identities.  The grouped
+    decomposition fixes $X_{\alpha,1}=\Id$, so this relative normalization is
+    the source's $U_{\alpha,k}$.  Composing the sector unitaries would yield the
+    coisometry $U$ with
+    $U\widetilde MU^\dagger=\bigoplus_\alpha\mu_\alpha\otimes M_\alpha$ and
+    the corresponding reconstruction identity; each
+    $\mu_\alpha$ is diagonal, so the summands regroup as repeated weighted
+    copies of $M_\alpha$ exactly as in the finite regrouping of
+    Lemma~\ref{lem:vertical_grouping_equiv}. The remaining missing proof is the
+    reflected marked-chain and Lemma~L argument of lines 1909--1919: one must
+    transport the Hermiticity of each marked sector compression, whose adjoint
+    reverses the tail word, to obtain the common reflected-adjoint target.
+    Consequently, the conclusion stated at lines 1903--1908 has not yet been
+    derived from the matrix-product-density-operator hypotheses.  After
+    applying the relative normalization proved above, the remaining sector
+    maps must be assembled into the final coisometry.
+
+    Conditional on that construction, the algebraic basis-of-normal-tensors
+    clauses are verified as follows.  With the notation of the grouping
+    theorem, its spectral BNT property applies to
     \[
         A_{\mathrm{ret}}
-        =\bigoplus_{\alpha,q}\mu_{\alpha,q}B_{\alpha,q}.
+        =\bigoplus_{\alpha,k}\mu_{\alpha,k}B_{\alpha,k}.
     \]
     Theorem~\ref{thm:cpsv_normal_eventually_injective} makes every
-    $M_\alpha$ algebraically normal.  The eventual linear independence clause
-    is unchanged because the representatives themselves are unchanged.
+    $M_\alpha$ algebraically normal.  Eventual linear independence is
+    unchanged because the representatives themselves are unchanged.
 
-    For the spanning clause, let
-    $\mathcal X=\bigoplus_{\alpha,q}X_{\alpha,q}$.  The gauge-phase identities
-    and the definition of $c_{\alpha,q}$ give the square block gauge
+    For the spanning clause, set
+    $c_{\alpha,k}=\mu_{\alpha,k}\zeta_{\alpha,k}>0$ and let
+    $\mathcal X=\bigoplus_{\alpha,k}X_{\alpha,k}$.  The gauge-phase identities
+    give the square block gauge
     \[
         A_{\mathrm{ret}}=\mathcal X B\mathcal X^{-1},
         \qquad
-        B=\bigoplus_{\alpha,q}c_{\alpha,q}M_\alpha.
+        B=\bigoplus_{\alpha,k}c_{\alpha,k}M_\alpha.
     \]
     Theorem~\ref{thm:gauge_invariance} therefore transfers the spectral BNT
     spanning identity from $A_{\mathrm{ret}}$ to $B$.  For every nonempty
@@ -2427,10 +2497,5 @@
     Lemma~\ref{lem:mpv_zero_length}, assigning it the coefficient
     $d/d_{\alpha_0}$ and assigning zero to the other representatives gives
     the length-zero coefficient $d$ of $\widetilde M$.  This proves the
-    spanning clause at every length and hence the required algebraic BNT
-    property for $\widetilde M$.  The adjoint normalization is the final
-    argument of
-    \cite[Proposition~4.13, lines~1903--1921]{Cirac2016MPDO_arXiv}; the
-    last three paragraphs give the BNT clause in the vertical canonical form
-    above.
+    spanning clause at every length once the coisometry has been constructed.
 \end{proof}

--- a/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
@@ -193,20 +193,31 @@ $\mu_{\alpha,k}>0$ under the normalization $\mu_{\alpha,1}>0$
 the dressed-adjoint identities of the two displayed diagrams at source
 lines~1909--1919, transported blockwise by Lemma~L, the scalar commutant of
 the normal tensor $M_\alpha$
-(\path{MPSTensor.IsNormal.eq_smul_one_of_commute}) makes each Gram matrix
-$X_{\alpha,k}^\dagger X_{\alpha,k}$ a positive multiple of the identity, in
-the normalization $X_{\alpha,1}=\Id$, and
-$\omega_{\alpha,k}^{-1/2}X_{\alpha,k}$ unitary
-(\path{MPSTensor.IsNormal.smul_mem_unitaryGroup_of_dressed_adjoint} in
+(\path{MPSTensor.IsNormal.eq_smul_one_of_commute}) makes the relative Gram
+ratio scalar.  Positivity of the two Gram matrices then gives
+\[
+X_{\alpha,k}^\dagger X_{\alpha,k}
+=\omega_{\alpha,k}X_{\alpha,1}^\dagger X_{\alpha,1},
+\qquad \omega_{\alpha,k}>0.
+\]
+The relative gauge $X_{\alpha,k}X_{\alpha,1}^{-1}$ becomes unitary after
+division by $\sqrt{\omega_{\alpha,k}}$.  The grouping theorem now exposes its choice
+$X_{\alpha,1}=\Id$, giving the normalization printed by the source
+(\path{MPSTensor.IsNormal.gram_eq_pos_smul_gram_of_common_dressed_target} in
 \path{TNLean/MPS/CanonicalForm/NormalCommutant.lean}).
 
-The remaining source-level gap begins with the dressed-adjoint argument at
-source line~1903.  The copy embeddings must be assembled into the single
-direct-sum coisometry $U$ (equivalently, the adjoint isometry) appearing in
-source lines~1895--1896, with the zero complement treated explicitly.  Finally,
-one must derive the dressed-adjoint identities from self-adjointness of the
-sector compressions and use them to replace each invertible gauge by a
-proportional unitary, as in source lines~1898--1921.
+The remaining missing proof is the reflected marked-chain and Lemma~L argument
+of source lines~1909--1919.  In a fixed oriented-bond convention the common target is
+$(M_\alpha^{(b,a)})^\dagger$, not the same letter
+$(M_\alpha^{(a,b)})^\dagger$.  The adjoint of the marked finite chain also
+reverses its tail word.  A reflected marked-chain form of Lemma~L is therefore
+still required to derive the common dressed target from self-adjointness of
+the sector compressions.  Afterwards the copy embeddings must be normalized
+using the relative theorem above and assembled into the single direct-sum
+coisometry $U$ (equivalently, the adjoint isometry) appearing in source
+lines~1895--1896, with the zero complement treated explicitly.  Consequently,
+the relative Gram conclusion stated at lines~1903--1908 has not yet been
+derived from the MPDO hypotheses.
 These gauge and coisometry conclusions are not part of the grouping theorem.  The original
 formulation of \ghissue{2536}, interpreted as a direct conversion of the
 horizontal scalar weights and diagonal restrictions, is therefore not a

--- a/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
@@ -172,10 +172,15 @@ $\mu_{\alpha,1}>0$ (\path{TNLean/MPS/MPDO/VerticalBNT.lean} and
 \path{TNLean/MPS/MPDO/SectorTrace.lean}). Granted the dressed-adjoint
 identities of the two displayed diagrams at lines~1909--1919, transported
 blockwise by Lemma~L, the Gram matrix of each sector gauge $X_{\alpha,k}$ is
-a positive multiple $\omega_{\alpha,k}$ of the identity, in the normalization
-$X_{\alpha,1}=\Id$, and the normalized gauge
-$\omega_{\alpha,k}^{-1/2}X_{\alpha,k}$ is unitary, because a normal tensor
-has scalar commutant
+a positive real multiple of the reference Gram matrix,
+\[
+X_{\alpha,k}^\dagger X_{\alpha,k}
+=\omega_{\alpha,k}X_{\alpha,1}^\dagger X_{\alpha,1}.
+\]
+The relative gauge $X_{\alpha,k}X_{\alpha,1}^{-1}$ is therefore proportional
+to a unitary; the grouping chooses $X_{\alpha,1}=\Id$.  This follows because
+a normal tensor has scalar
+commutant
 (\path{TNLean/MPS/CanonicalForm/NormalCommutant.lean}). Projector closure and
 the absence of periodic vectors already give an abstract positive-length
 normal-block decomposition
@@ -186,9 +191,13 @@ grouped into pairwise gauge-phase-distinct BNT representatives in
 \path{TNLean/MPS/MPDO/VerticalBNT.lean}. Every copy is expressed by a positive
 coefficient, a unit-modulus phase, and an invertible bond-space gauge, while
 the physical isometries and the literal vertical reconstruction are retained.
-What remains open begins with the dressed-adjoint identities at source
-line~1903: they are needed to normalize the gauges to unitaries and assemble
-the final coisometry.
+What remains open is the reflected marked-chain and Lemma~L argument of source
+lines~1909--1919.  Its fixed-index form exchanges the two oriented bond indices,
+and the adjoint marked chain reverses the tail word.  A corresponding
+reflected marked-chain form of Lemma~L is needed before the relative Gram
+theorem can normalize the gauges; the resulting sector maps must then be
+assembled into the final coisometry.  Consequently, the conclusion stated at
+lines~1903--1908 has not yet been derived from the MPDO hypotheses.
 
 \paragraph{Verdict.}
 This is an open gap: the source-faithful horizontal-to-vertical implication of


### PR DESCRIPTION
## Motivation

In the proof of Proposition 4.13 of arXiv:1606.00608, the two displayed
diagrams in lines 1909--1919 do not identify a vertically viewed letter with
its own adjoint. For an oriented horizontal bond pair \(v=(a,b)\), adjunction
produces the common target
\[
  C^v = \bigl(A^{v^{\mathrm{op}}}\bigr)^\dagger,
  \qquad v^{\mathrm{op}}=(b,a).
\]
Consequently, the Gram-matrix argument must compare two gauges dressing the
same tensor to this common target. The existing conditional result treated
only the stronger self-adjoint-letter specialization.

The current capstone proof text on `main` suppresses this bond-pair exchange
and presents the reflected marked-chain use of Lemma L as complete. This pull
request restores the source-faithful boundary: that marked-chain argument is
still required before the common target may be used.

## Changes

- Define the involution `bondPairSwap` on horizontal bond pairs and prove
  \[
    \widetilde{M^\dagger}_{a,b}
      = \bigl(\widetilde M_{b,a}\bigr)^\dagger.
  \]
- Generalize the dressed-adjoint matrix argument to two invertible gauges
  dressing a tensor to a common target.
- For a normal tensor, prove
  \[
    X^\dagger X=\omega\,Y^\dagger Y,\qquad \omega>0,
  \]
  and prove that \(\omega^{-1/2}XY^{-1}\) is unitary.
- Record explicitly the already chosen normalization
  \(X_{\alpha,1}=\mathbf 1\) in the grouped vertical BNT theorem.
- Retain the previous same-letter results as explicitly marked
  self-adjoint-letter specializations.
- Correct the blueprint capstone and paper-gap notes so that they identify the
  reflected marked-chain argument as the remaining source step.

This pull request is a prerequisite for #3887. It does not derive the common
dressed target from Hermiticity of the sector compressions, and it does not
construct the final coisometry.

## Source faithfulness

The indexed adjoint convention follows arXiv:1606.00608, lines 1909--1913.
The relative Gram relation follows the comparison in lines 1914--1921 once the
common dressed target has been obtained. No assumption that individual
vertical letters are self-adjoint is used in the generalized result.

The remaining source step is recorded in:

- `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`
- `docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex`

## Verification

- `lake env lean TNLean/MPS/CanonicalForm/NormalCommutant.lean`
- `lake env lean TNLean/MPS/MPDO/VerticalCF.lean`
- `lake env lean TNLean/MPS/MPDO/VerticalBNT.lean`
- `lake build`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `leanblueprint checkdecls`
- `git diff --check`

The new declarations depend only on `propext`, `Classical.choice`, and
`Quot.sound`. No project axiom or proof bypass is introduced.

Advances #3887.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are formal Lean proofs, blueprint sync, and documentation boundaries around an already-tracked open proof step; no runtime, auth, or data-path impact.
> 
> **Overview**
> Formalizes the **source-faithful** Gram-matrix step for Proposition 4.13: two sector gauges that dress every letter of a normal tensor to a **common target** (not necessarily the same letter’s adjoint) satisfy \(X^\dagger X = \omega Y^\dagger Y\) with \(\omega > 0\), and \(\omega^{-1/2} X Y^{-1}\) is unitary.
> 
> **Lean:** In `NormalCommutant`, the dressed-adjoint algebra is generalized via `gram_conj_eq_of_dressed_target`, `gram_conj_eq_gram_conj_of_common_dressed_target`, and `commute_gram_ratio_of_gram_conj_eq`, with new `IsNormal.gram_eq_pos_smul_gram_of_*` and relative unitary normalization. Prior single-gauge / self-adjoint-letter results are kept as explicitly scoped specializations. In `VerticalCF`, adds `bondPairSwap` and `verticalTensor_adjointTensor` (\(\widetilde{M^\dagger}_{a,b} = (\widetilde M_{b,a})^\dagger\)). `VerticalBNT` now records **\(X_{\alpha,1} = \mathrm{Id}\)** for class representatives alongside \(\zeta_{\alpha,1} = 1\).
> 
> **Docs:** Blueprint and paper-gap notes are updated so the capstone no longer treats the reflected marked-chain / Lemma L step as done; the open step is deriving the common dressed target (bond-index swap and reversed tail word) before applying the new relative Gram theorems and assembling the final coisometry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6957d4154de4b6e142ada04e2f96ebf02c5fbef9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->