### PR TITLE
doc(MPS/MPDO): resolve source labels and overflows

### DIFF
--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -518,8 +518,9 @@
     conclusions.
 
     For the unblocked canonical form, propagate $p$-block injectivity to the
-    lengths $2p-1$, $2p$, and $6p$. The Condition C1 form of the direct-sum
-    argument gives pair trace separation at original length $6p$. The
+    lengths $2p-1$, $2p$, and $6p$. Applying the direct-sum argument to the
+    resulting injective tensors gives pair trace separation at original
+    length $6p$. The
     bijection between blocked words of length $6$ and original words of length
     $6p$ transports this to pair trace separation for the $p$-blocked
     representatives. The preceding selector argument then applies verbatim
@@ -728,7 +729,7 @@
     Therefore $(\Id-P)HP=HP-PHP=0$.
 \end{proof}
 
-\begin{theorem}[Representative reduction from first-site contractions]
+\begin{theorem}[First-site contraction reduction]
     \label{thm:blockwise_opposite_insert_eq}
     \lean{MPSTensor.IsBNTCanonicalForm.insertedTensor_basis_eq_of_two_firstSiteActionAgree}
     \leanok
@@ -1618,10 +1619,14 @@
 \end{theorem}
 \begin{proof}\leanok
     \uses{lem:mpdo_trace_loop_chain, def:mpdo_vertical_one_site_actions}
-    Expanding the diagonal entry $(P_1 H^{(N+1)})_{(a,\rho)(a,\rho)}$ at
-    the first site gives $\sum_i P_{ai}\,\tr(M^{ia}E_\rho^{(N)})$,
-    where $E_\rho^{(N)}=M^{\rho_0\rho_0}\cdots M^{\rho_{N-1}\rho_{N-1}}$;
-    summing over $a$ and $\rho$ and collecting closes the remaining loops
+    For a length-$N$ configuration $\rho$, write
+    $E_\rho^{(N)}=M^{\rho_0\rho_0}\cdots M^{\rho_{N-1}\rho_{N-1}}$.
+    Expanding at the first site gives
+    \[
+        (P_1 H^{(N+1)})_{(a,\rho)(a,\rho)}
+        = \sum_i P_{ai}\,\tr(M^{ia}E_\rho^{(N)}).
+    \]
+    Summing over $a$ and $\rho$ and collecting closes the remaining loops
     by Lemma~\ref{lem:mpdo_trace_loop_chain}.  For the
     two-sided compression, first-site actions compose site by site,
     $P_1Q_1=(PQ)_1$, so cyclicity of the trace and idempotency reduce
@@ -1756,10 +1761,12 @@
         X^\dagger X = \omega\,\Id
     \]
     for a necessarily positive constant $\omega$, and $\omega^{-1/2}X$ is
-    unitary.  This is equation eq3 in the proof of
-    \cite[Proposition~4.13]{Cirac2016MPDO_arXiv} in the normalization
-    $X_{\alpha,1}=\Id$, together with the isometric normalization
-    $U_{\alpha,k}=\omega_{\alpha,k}^{-1/2}X_{\alpha,k}$; deriving the
+    unitary.  This is the normalized form
+    $X_{\alpha,k}^\dagger X_{\alpha,k}=\omega_{\alpha,k}\Id$ of the
+    Gram-matrix proportionality in the proof of
+    \cite[Proposition~4.13]{Cirac2016MPDO_arXiv}, with
+    $X_{\alpha,1}=\Id$ and
+    $U_{\alpha,k}=\omega_{\alpha,k}^{-1/2}X_{\alpha,k}$. Deriving the
     commutation from self-adjointness of the sector compressions is a
     separate step.
 \end{theorem}
@@ -1806,7 +1813,7 @@
     $X^\dagger X$ on the right gives the commutation.
 \end{proof}
 
-\begin{theorem}[Equation eq3 from the dressed-adjoint identities]
+\begin{theorem}[Gram-matrix proportionality from the dressed-adjoint identities]
     \label{thm:eq3_of_dressed_adjoint}
     \lean{MPSTensor.IsNormal.conjTranspose_mul_self_eq_smul_one_of_dressed_adjoint}
     \lean{MPSTensor.IsNormal.smul_mem_unitaryGroup_of_dressed_adjoint}
@@ -1821,8 +1828,8 @@
     hypotheses are the blockwise identities produced by Lemma L from the
     first diagram in the proof of
     \cite[Proposition~4.13]{Cirac2016MPDO_arXiv}, for the sectors $k$ and
-    $1$ in the normalization $X_{\alpha,1}=\Id$; the conclusion is
-    equation eq3 with its isometric normalization.
+    $1$ in the normalization $X_{\alpha,1}=\Id$; the conclusion is the
+    Gram-matrix proportionality used to normalize the gauges isometrically.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -354,11 +354,11 @@ them.
           = U_{\alpha,\beta}^\dagger H_{\alpha,\beta}^{ij}
               U_{\alpha,\beta}.
     \]
-    These are the identity-weight specialization of the zipper and
-    completeness equations in
-    \cite[Section~3, Equations~(19)--(21)]{Bultinck2017Anyons}, obtained from
-    the length-independent case described after
-    \cite[Theorem~4.14]{Cirac2016MPDO_arXiv}.
+    These are the identity-weight specialization of Equations~(19)--(21) in
+    \cite[Section~3]{Bultinck2017Anyons}. The MPDO fusion identity appears in
+    \cite[Theorem~4.14(iii), lines~986--991]{Cirac2016MPDO_arXiv}; its
+    identity-weight specialization follows from the length-independent case
+    at \cite[line~1010]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 \begin{proof}\leanok
     Length independence makes every positive diagonal entry of
@@ -382,9 +382,10 @@ them.
         fusion map, total-fusion completeness, or invertibility of a
         fixed-final comparison. The layout follows the zipper figures of
         \cite[Section~3, Equations~(19)--(21)]{Bultinck2017Anyons}; in the
-        MPDO specialization these identities arise from the length-independent
-        fusion data discussed in
-        \cite[lines~995--1008]{Cirac2016MPDO_arXiv}.}
+        MPDO specialization the fusion identity is
+        \cite[Theorem~4.14(iii), lines~986--991]{Cirac2016MPDO_arXiv}, and the
+        identity weights follow from the length-independent case at
+        \cite[line~1010]{Cirac2016MPDO_arXiv}.}
     \label{fig:mpdo_unweighted_zipper_reconstruction}
 \end{figure}
 
@@ -477,7 +478,8 @@ them.
     \label{fig:mpdo_recursive_structure_operator}
 \end{figure}
 
-The associativity of the algebra product of \cite[eq:algebra]{Cirac2016MPDO_arXiv}
+The associativity of the algebra product in
+\cite[Equation~(87)]{Cirac2016MPDO_arXiv}
 constrains the diagonal matrices $\chi_{\alpha,\beta,\gamma}$ and, through the
 isometry statement, induces a compatibility equation between the fusion
 isometries of the two ways of bracketing a triple product,


### PR DESCRIPTION
## Summary

- replaces internal source shorthand in Chapters 20 and 21 with mathematical descriptions and resolved paper equations
- corrects the fusion-isometry citation to CPSV16 Theorem 4.14(iii), lines 986–991, and separates the length-independent specialization at line 1010
- removes three known blueprint overflows without changing any mathematical statement or declaration tag

## Source verification

The revised claims were checked against arXiv:1606.00608: Equation (87), Theorem 4.14(iii), lines 986–991, line 1010, and the Gram proportionality at lines 1903–1907. The zipper wording was also checked against Equations (19)–(21) of arXiv:1511.08090v2.

## Validation

- blueprint prose and diff checks
- `leanblueprint pdf` (547 pages)
- `leanblueprint web`
- visual inspection of affected pages 416, 419, 427–429, and 450–452
- independent exact-commit review: READY

No Lean declarations or `\lean{}` tags are changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and citation wording in LaTeX blueprint chapters only; no Lean or runtime behavior changes.
> 
> **Overview**
> **Blueprint prose only** — no `\lean{}` tags or formal statements change.
> 
> Chapter 20 replaces internal paper shorthand with explicit math: the post-blocking proof now says the direct-sum argument is applied to **injective blocked tensors** (not “Condition C1”); the first-site compression trace proof introduces **`E_ρ^{(N)}`** and a displayed first-site expansion; **“eq3”** becomes **Gram-matrix proportionality** in the normal-tensor and dressed-adjoint theorems (with titles **“First-site contraction reduction”** and **“Gram-matrix proportionality from the dressed-adjoint identities”**).
> 
> Chapter 21 pins citations to **Cirac2016** Equation (87), **Theorem 4.14(iii)** (lines 986–991), and **line 1010** for the identity-weight / length-independent zipper case, and aligns **Bultinck2017** Equations (19)–(21) in the zipper theorems and figure captions (replacing vague “eq:algebra” / bundled section references).
> 
> These edits target **resolved bibliography labels** and **overflow fixes** on affected blueprint pages without altering mathematical claims.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2865e27c26b1eb0d41c7649a49b656355641b59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->