### PR TITLE
fix(MPS/RFP): formalize raw-weight ZCL counterexample

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -508,6 +508,7 @@ import TNLean.MPS.RFP.Decorrelation
 import TNLean.MPS.RFP.BNTOrthogonality
 import TNLean.MPS.RFP.ResidualIsometry
 import TNLean.MPS.RFP.PhaseMultiplicityCounterexample
+import TNLean.MPS.RFP.BNTWeightCounterexample
 
 -- Layer 6a: Quantum Wielandt span-growth infrastructure
 import TNLean.Wielandt.SpanGrowth.CumulativeSpan

--- a/TNLean/MPS/RFP/BNTWeightCounterexample.lean
+++ b/TNLean/MPS/RFP/BNTWeightCounterexample.lean
@@ -1,0 +1,348 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.FundamentalTheorem.SectorBNT.Examples
+import TNLean.MPS.RFP.PhaseMultiplicityCounterexample
+import TNLean.MPS.RFP.ZeroCorrelationLength
+
+/-!
+# Raw BNT weights obstruct the unrestricted pure ZCL equivalence
+
+The proof of arXiv:1606.00608, Theorem `TheoremZCLPure`, passes at lines
+1248--1251 from non-idempotence of the full transfer operator to
+non-idempotence of one normal basis tensor.  This implication fails for the
+two-layer BNT display: raw copy weights can make the assembled transfer
+non-idempotent even when the unique normal basis tensor has idempotent transfer.
+
+The concrete example below uses one physical letter, the scalar normal basis
+tensor `scalarUnitTensor`, and the two raw copy weights `1` and `1/2` from
+`SectorBNT.Examples.halvedDecomp`.  Its physical Hilbert space is
+one-dimensional, so all physical correlations are independent of separation;
+there are no distinct BNT sectors, so local orthogonality is automatic.  The
+assembled transfer is nevertheless not idempotent.
+
+See `docs/paper-gaps/cpsv16_pure_zcl_raw_weight_counterexample.tex`.
+-/
+
+open scoped Matrix BigOperators
+open Filter Topology
+
+namespace MPSTensor
+
+/-- The canonical assembly of the one-letter tensor with raw BNT copy weights
+`1` and `1/2`.
+
+This is the two-layer tensor associated with `halvedDecomp scalarUnitTensor`
+from CPSV16 equation `eq:II_ABasicTensors` (lines 271--301). -/
+noncomputable def halvedWeightTensor : MPSTensor 1
+    (SectorBNT.Examples.halvedDecomp scalarUnitTensor).totalDim :=
+  (SectorBNT.Examples.halvedDecomp scalarUnitTensor).toTensor
+
+/-- The counterexample tensor is literally the canonical assembly of its
+raw-weight BNT decomposition, not merely an equivalent MPV family.
+
+This records the canonical-form premise of CPSV16, Theorem 3.8. -/
+theorem halvedWeightTensor_eq_halvedDecomp_toTensor :
+    halvedWeightTensor =
+      (SectorBNT.Examples.halvedDecomp scalarUnitTensor).toTensor := rfl
+
+private lemma scalarUnitTensor_isIrreducibleTensor :
+    IsIrreducibleTensor scalarUnitTensor := by
+  rintro ⟨P, ⟨_, hIdem⟩, hP0, hP1, _⟩
+  have h00 := congrFun (congrFun hIdem (0 : Fin 1)) (0 : Fin 1)
+  simp only [Matrix.mul_apply, Finset.univ_unique, Fin.default_eq_zero,
+    Fin.isValue, Finset.sum_singleton] at h00
+  have hfactor : P 0 0 * (P 0 0 - 1) = 0 := by
+    linear_combination h00
+  rcases mul_eq_zero.mp hfactor with hzero | hone
+  · apply hP0
+    ext a b
+    fin_cases a
+    fin_cases b
+    simpa using hzero
+  · apply hP1
+    ext a b
+    fin_cases a
+    fin_cases b
+    simpa using sub_eq_zero.mp hone
+
+private lemma scalarUnitTensor_evalWord (w : List (Fin 1)) :
+    evalWord scalarUnitTensor w = 1 := by
+  induction w with
+  | nil => rfl
+  | cons i w ih =>
+      rw [evalWord_cons, ih]
+      simp [scalarUnitTensor]
+
+private lemma scalarUnitTensor_mpv {N : ℕ} (σ : Fin N → Fin 1) :
+    mpv scalarUnitTensor σ = 1 := by
+  simp [mpv, scalarUnitTensor_evalWord, Matrix.trace]
+
+/-- The matrix-product-vector coefficient of the raw-weight canonical assembly.
+
+This is the length-`N` coefficient of the example testing the unrestricted
+implication in CPSV16, Theorem `TheoremZCLPure` (lines 1248--1251). -/
+theorem halvedWeightTensor_mpv {N : ℕ} (σ : Fin N → Fin 1) :
+    mpv halvedWeightTensor σ = 1 + (1 / 2 : ℂ) ^ N := by
+  rw [halvedWeightTensor]
+  rw [(SectorBNT.Examples.halvedDecomp scalarUnitTensor).mpv_toTensor_eq_sum_sectors]
+  rw [Fin.sum_univ_one, Fin.sum_univ_two]
+  rw [scalarUnitTensor_mpv]
+  simp only [mul_one]
+  change (if (0 : Fin 2) = 0 then 1 else 1 / 2) ^ N +
+      (if (1 : Fin 2) = 0 then 1 else 1 / 2) ^ N =
+    1 + (1 / 2 : ℂ) ^ N
+  norm_num
+
+private theorem physicalObservableTransfer_one
+    {D : ℕ} (A : MPSTensor 1 D) (L : ℕ)
+    (O : Matrix (Fin L → Fin 1) (Fin L → Fin 1) ℂ) :
+    physicalObservableTransfer A L O =
+      O (0 : Fin L → Fin 1) (0 : Fin L → Fin 1) • (transferMap A) ^ L := by
+  apply LinearMap.ext
+  intro X
+  change physicalObservableTransfer A L O X =
+    O (0 : Fin L → Fin 1) (0 : Fin L → Fin 1) • ((transferMap A) ^ L) X
+  rw [transferMap_pow_apply']
+  simp only [physicalObservableTransfer, Finset.univ_unique, Pi.default_def,
+    Fin.default_eq_zero, Fin.isValue, Finset.sum_singleton, List.ofFn_const]
+  rw [Matrix.mul_assoc]
+  congr 1
+
+private theorem isPhysicalCID_one {D : ℕ} (A : MPSTensor 1 D) :
+    IsPhysicalCID A := by
+  intro L₁ L₂ O₁ O₂ n₁ n₂ m₁ m₂ hL₁ hL₂ hsum
+  simp only [physicalTwoPointExpectation, physicalObservableTransfer_one]
+  congr 1
+  simp only [← Module.End.mul_eq_comp]
+  simp only [smul_mul_assoc, mul_smul_comm, smul_smul]
+  congr 1
+  simp only [← pow_add]
+  congr 1
+  omega
+
+private theorem scalarUnitTensor_transferMap :
+    transferMap scalarUnitTensor = LinearMap.id := by
+  apply LinearMap.ext
+  intro X
+  ext a b
+  fin_cases a
+  fin_cases b
+  simp [transferMap_apply, scalarUnitTensor]
+
+private theorem scalarUnitTensor_isNormalTensor :
+    IsNormalTensor scalarUnitTensor := by
+  refine ⟨scalarUnitTensor_isIrreducibleTensor, ?_, ?_⟩
+  · rw [scalarUnitTensor_transferMap]
+    change spectralRadius ℂ
+      (1 : Matrix (Fin 1) (Fin 1) ℂ →L[ℂ] Matrix (Fin 1) (Fin 1) ℂ) = 1
+    exact spectrum.spectralRadius_one
+  · rw [scalarUnitTensor_transferMap]
+    apply isPrimitive_of_unique_norm_one LinearMap.id
+      (1 : Matrix (Fin 1) (Fin 1) ℂ)
+    · rfl
+    · exact one_ne_zero
+    · intro μ hμ hμnorm
+      obtain ⟨X, hX⟩ := hμ.exists_hasEigenvector
+      have hEq := hX.apply_eq_smul
+      have hX00 : X 0 0 ≠ 0 := by
+        intro hzero
+        apply hX.2
+        ext a b
+        fin_cases a
+        fin_cases b
+        simpa using hzero
+      have hEq00 := congrFun (congrFun hEq (0 : Fin 1)) (0 : Fin 1)
+      simp only [LinearMap.id_apply, Matrix.smul_apply] at hEq00
+      simp only [smul_eq_mul] at hEq00
+      apply mul_right_cancel₀ hX00
+      simpa using hEq00.symm
+
+/-- The raw-weight decomposition of `halvedWeightTensor` is a BNT canonical
+form in the line-246 normalization of arXiv:1606.00608. -/
+theorem halvedWeightTensor_isBNTCanonicalForm :
+    IsBNTCanonicalForm (SectorBNT.Examples.halvedDecomp scalarUnitTensor) := by
+  refine {
+    basis_dim_pos := by
+      intro j
+      simp
+    basis_irreducible := by
+      intro j
+      exact scalarUnitTensor_isIrreducibleTensor
+    basis_left_canonical := by
+      intro j
+      simp [IsLeftCanonical, scalarUnitTensor]
+    basis_normalized_self_overlap := by
+      intro j
+      simp [mpvOverlap, mpv, scalarUnitTensor_evalWord, Matrix.trace]
+    bnt_data := by
+      refine ⟨0, ?_⟩
+      intro N hN
+      apply LinearIndependent.of_subsingleton (i := (0 : Fin 1))
+      intro hzero
+      have h := congrArg
+        (fun v : MPVSpace 1 N => v (fun _ : Fin N => (0 : Fin 1))) hzero
+      have : (1 : ℂ) = 0 := by
+        simp [mpvState_apply, mpv, scalarUnitTensor_evalWord, Matrix.trace] at h
+      exact one_ne_zero this
+    basis_distinct := by
+      intro j k hjk
+      exact absurd (Subsingleton.elim j k) hjk
+    weight_norm_le_one := by
+      intro j q
+      change ‖(if q = 0 then (1 : ℂ) else (1 / 2 : ℂ))‖ ≤ 1
+      split_ifs
+      · simp
+      · simp
+        norm_num
+    weight_unit_exists := by
+      refine ⟨0, 0, ?_⟩
+      change ‖(if (0 : Fin 2) = 0 then (1 : ℂ) else (1 / 2 : ℂ))‖ = 1
+      simp }
+
+/-- `halvedWeightTensor` realizes the MPV family of the raw-weight
+decomposition `halvedDecomp scalarUnitTensor` at every length. -/
+theorem halvedWeightTensor_sameMPV₂_halvedDecomp :
+    SameMPV₂ halvedWeightTensor
+      (SectorBNT.Examples.halvedDecomp scalarUnitTensor).toTensor := by
+  intro N σ
+  rfl
+
+private theorem halvedWeightTensor_isCPSVBasisOfNormalTensors :
+    IsCPSVBasisOfNormalTensors halvedWeightTensor
+      (fun _ : Fin 1 => ⟨1, scalarUnitTensor⟩) := by
+  refine {
+    blocks_normal := fun _ => scalarUnitTensor_isNormalTensor
+    spans_mpv := by
+      intro N
+      refine ⟨fun _ => 1 + (1 / 2 : ℂ) ^ N, ?_⟩
+      intro σ
+      rw [halvedWeightTensor_mpv σ]
+      simp [mpv, scalarUnitTensor_evalWord, Matrix.trace]
+    eventually_li := by
+      exact halvedWeightTensor_isBNTCanonicalForm.bnt_data }
+
+/-- The concrete raw-weight tensor satisfies the source-facing pure-state ZCL
+premises of arXiv:1606.00608, Definitions 3.3, 3.5, and 3.6. -/
+theorem halvedWeightTensor_isPhysicalBNTZCL :
+    IsPhysicalBNTZCL halvedWeightTensor (fun _ : Fin 1 => scalarUnitTensor) := by
+  refine ⟨?_, ?_, ?_⟩
+  · simpa using halvedWeightTensor_isCPSVBasisOfNormalTensors
+  · exact isPhysicalCID_one halvedWeightTensor
+  · intro j k hjk
+    exact absurd (Subsingleton.elim j k) hjk
+
+/-- The raw weights `1` and `1/2` obstruct the one-letter blocking equation:
+the two diagonal blocks would force the same scalar to be both `1` and `1/2`.
+This is the failure missed at arXiv:1606.00608, lines 1248--1251. -/
+private theorem halvedWeightTensor_no_blocking_coefficient :
+    ¬ ∃ v : ℂ,
+      halvedWeightTensor 0 * halvedWeightTensor 0 = v • halvedWeightTensor 0 := by
+  rintro ⟨v, hv⟩
+  let P := SectorBNT.Examples.halvedDecomp scalarUnitTensor
+  let B : (s : Fin P.totalCopies) →
+      Matrix (Fin (P.flatDim s)) (Fin (P.flatDim s)) ℂ :=
+    fun s => (P.flatWeight s) • (P.flatBasis s 0)
+  let e : ((s : Fin P.totalCopies) × Fin (P.flatDim s)) ≃ Fin P.totalDim :=
+    finSigmaFinEquiv
+  change (Matrix.reindex e e (Matrix.blockDiagonal' B)) *
+      (Matrix.reindex e e (Matrix.blockDiagonal' B)) =
+        v • Matrix.reindex e e (Matrix.blockDiagonal' B) at hv
+  change (Matrix.reindexAlgEquiv ℂ ℂ e (Matrix.blockDiagonal' B)) *
+      (Matrix.reindexAlgEquiv ℂ ℂ e (Matrix.blockDiagonal' B)) =
+        v • Matrix.reindexAlgEquiv ℂ ℂ e (Matrix.blockDiagonal' B) at hv
+  rw [← map_mul, ← map_smul] at hv
+  have hbase : Matrix.blockDiagonal' B * Matrix.blockDiagonal' B =
+      v • Matrix.blockDiagonal' B :=
+    (Matrix.reindexAlgEquiv ℂ ℂ e).injective hv
+  rw [← Matrix.blockDiagonal'_mul, ← Matrix.blockDiagonal'_smul] at hbase
+  let s0 : Fin P.totalCopies := P.flatIndexEquiv ⟨0, 0⟩
+  let s1 : Fin P.totalCopies := P.flatIndexEquiv ⟨0, 1⟩
+  let z0 : Fin (P.flatDim s0) :=
+    ⟨0, by simp [P, SectorDecomposition.flatDim]⟩
+  let z1 : Fin (P.flatDim s1) :=
+    ⟨0, by simp [P, SectorDecomposition.flatDim]⟩
+  have h0 := congrFun (congrFun hbase ⟨s0, z0⟩) ⟨s0, z0⟩
+  have h1 := congrFun (congrFun hbase ⟨s1, z1⟩) ⟨s1, z1⟩
+  have hdim0 : P.flatDim s0 = 1 := by
+    simp [P, SectorDecomposition.flatDim]
+  have hdim1 : P.flatDim s1 = 1 := by
+    simp [P, SectorDecomposition.flatDim]
+  have hsub0 (x : Fin (P.flatDim s0)) : x = z0 := by
+    apply Fin.ext
+    have hx := x.isLt
+    omega
+  have hsub1 (x : Fin (P.flatDim s1)) : x = z1 := by
+    apply Fin.ext
+    have hx := x.isLt
+    omega
+  have hone0 :
+      (1 : Matrix (Fin (P.flatDim s0)) (Fin (P.flatDim s0)) ℂ) z0 z0 = 1 := by
+    rw [Matrix.one_apply]
+    simp
+  have hone1 :
+      (1 : Matrix (Fin (P.flatDim s1)) (Fin (P.flatDim s1)) ℂ) z1 z1 = 1 := by
+    rw [Matrix.one_apply]
+    simp
+  simp only [Matrix.blockDiagonal'_apply_eq] at h0 h1
+  dsimp [B] at h0 h1
+  simp only [Matrix.mul_apply, Matrix.smul_apply, smul_eq_mul] at h0 h1
+  simp_rw [hsub0] at h0
+  simp_rw [hsub1] at h1
+  dsimp [P, s0, s1, z0, z1] at h0 h1
+  simp only [SectorDecomposition.flatWeight, SectorDecomposition.flatBasis] at h0 h1
+  rw [Equiv.symm_apply_apply] at h0 h1
+  dsimp [SectorBNT.Examples.halvedDecomp, scalarUnitTensor] at h0 h1
+  dsimp [SectorDecomposition.weight, SectorWeightData.weight] at h0 h1
+  norm_num [SectorDecomposition.flatDim] at h0 h1
+  rcases h0 with h0 | h0
+  · rcases h1 with h1 | h1
+    · have hv1 : v = 1 := h0.symm.trans hone0
+      have hvhalf : (1 / 2 : ℂ) = v := by
+        calc
+          (1 / 2 : ℂ) = (1 / 2) * 1 := by ring
+          _ = (1 / 2) * (1 : Matrix (Fin (P.flatDim s1))
+              (Fin (P.flatDim s1)) ℂ) z1 z1 :=
+            congrArg (fun x : ℂ => (1 / 2) * x) hone1.symm
+          _ = v := h1
+      rw [hv1] at hvhalf
+      norm_num at hvhalf
+    · exact one_ne_zero (hone1.symm.trans h1)
+  · exact one_ne_zero (hone0.symm.trans h0)
+
+/-- The concrete raw-weight tensor is not a renormalization fixed point.
+
+The Kraus-isometry characterization of arXiv:1606.00608, Theorem 3.1,
+would give a scalar one-letter blocking coefficient, contradicting
+`halvedWeightTensor_no_blocking_coefficient`. -/
+theorem halvedWeightTensor_not_isRFP : ¬ IsRFP halvedWeightTensor := by
+  intro hRFP
+  apply halvedWeightTensor_no_blocking_coefficient
+  obtain ⟨V, _, hprod⟩ := (isRFP_iff_kraus_isometry halvedWeightTensor).mp hRFP
+  refine ⟨V ((0 : Fin 1), (0 : Fin 1)) (0 : Fin 1), ?_⟩
+  simpa using hprod (0 : Fin 1) (0 : Fin 1)
+
+/-- The tensor `halvedWeightTensor` is a counterexample to the unrestricted
+pure-state zero-correlation-length equivalence asserted in arXiv:1606.00608,
+Theorem `TheoremZCLPure`.  It is exactly the tensor assembled from its BNT
+canonical form and satisfies the source-facing physical zero-correlation-length
+conditions, but it is not a renormalization fixed point.  The source proof's
+inference at lines 1248--1251 misses the eigenvalues introduced by raw copy
+weights. -/
+theorem halvedWeightTensor_counterexample_to_unrestricted_zcl_iff_rfp :
+    IsBNTCanonicalForm (SectorBNT.Examples.halvedDecomp scalarUnitTensor) ∧
+      halvedWeightTensor =
+        (SectorBNT.Examples.halvedDecomp scalarUnitTensor).toTensor ∧
+      SameMPV₂ halvedWeightTensor
+        (SectorBNT.Examples.halvedDecomp scalarUnitTensor).toTensor ∧
+      IsPhysicalBNTZCL halvedWeightTensor (fun _ : Fin 1 => scalarUnitTensor) ∧
+      ¬ IsRFP halvedWeightTensor := by
+  exact ⟨halvedWeightTensor_isBNTCanonicalForm,
+    halvedWeightTensor_eq_halvedDecomp_toTensor,
+    halvedWeightTensor_sameMPV₂_halvedDecomp,
+    halvedWeightTensor_isPhysicalBNTZCL,
+    halvedWeightTensor_not_isRFP⟩
+
+end MPSTensor

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -433,6 +433,43 @@ and rates for the single-tensor transfer map $\E_A$.
     \cite[Definition~3.6]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
+\begin{theorem}[Unequal raw weights obstruct the ZCL--RFP equivalence]%
+    \label{thm:halved_weight_zcl_not_rfp}
+    \lean{MPSTensor.halvedWeightTensor_counterexample_to_unrestricted_zcl_iff_rfp}
+    \lean{MPSTensor.halvedWeightTensor_isPhysicalBNTZCL}
+    \lean{MPSTensor.halvedWeightTensor_eq_halvedDecomp_toTensor}
+    \lean{MPSTensor.halvedWeightTensor_mpv}
+    \lean{MPSTensor.halvedWeightTensor_sameMPV₂_halvedDecomp}
+    \lean{MPSTensor.halvedWeightTensor_not_isRFP}
+    \leanok
+    \uses{def:source_bnt_zcl, def:is_rfp, def:sector_bnt_cf}
+    Let $P$ be the canonical decomposition with one scalar basis tensor $C^0=(1)$,
+    two one-dimensional copies, and respective weights $1$ and $1/2$. Write
+    $A=\mathcal A(P)$ for its assembled tensor. Relative to these sector
+    coordinates, $A^0$ has block form
+    \[
+        \begin{pmatrix}1&0\\0&\tfrac12\end{pmatrix}.
+    \]
+    The weights $(1,1/2)$ satisfy the raw-weight BNT canonical-form
+    normalization, and the resulting canonical assembly is exactly $A$.
+    Moreover,
+    \[
+        V^{(N)}(A)=1+2^{-N}.
+    \]
+    The BNT has one component, so local orthogonality is vacuous. Since the
+    physical space has dimension one, all physical correlations are independent
+    of separation. Thus $A$ has zero correlation length in the sense of
+    Definition~\ref{def:source_bnt_zcl}, but $A$ is not a renormalization fixed
+    point. Consequently \cite[Theorem~3.8]{Cirac2016MPDO_arXiv} is false under
+    its stated raw-weight BNT normalization.
+\end{theorem}
+\begin{proof}\leanok
+    The two diagonal entries in the one-letter blocking equation
+    $(A^0)^2=vA^0$ would give respectively $v=1$ and $1/4=1/2$. Hence no such
+    scalar exists. The physical distance-independence assertion follows because
+    every observable on a one-letter physical space is scalar.
+\end{proof}
+
 \begin{lemma}[Source BNT zero correlation length implies its positive-gap form]%
     \label{lem:is_positive_gap_bnt_zcl_of_source_bnt_zcl}
     \lean{MPSTensor.isPositiveGapBNTZCL_of_isPhysicalBNTZCL}
@@ -1392,8 +1429,8 @@ and rates for the single-tensor transfer map $\E_A$.
     virtual-insertion correlator is independent of distance, then its transfer
     map is idempotent.
     % The reverse direction of Theorem 3.8 in arXiv:1606.00608 additionally
-    % requires realizing the virtual insertions by physical block observables;
-    % that realization step is not yet formalized.
+    % fails for raw repeated-copy weights. A corrected restricted theorem would
+    % additionally require realizing virtual insertions by physical observables.
 \end{theorem}
 \begin{proof}\leanok
     Trace nondegeneracy and invertibility of the fixed point reduce
@@ -1415,7 +1452,9 @@ and rates for the single-tensor transfer map $\E_A$.
     This is the idempotence/CID part of
     \cite[Theorem~3.8]{Cirac2016MPDO_arXiv}. The full source theorem for
     canonical-form tensors instead uses the unrestricted physical condition in
-    Definition~\ref{def:source_bnt_zcl}.
+    Definition~\ref{def:source_bnt_zcl}; under its stated raw-weight
+    normalization, that biconditional is false by
+    Theorem~\ref{thm:halved_weight_zcl_not_rfp}.
 \end{theorem}
 \begin{proof}\leanok
     The forward direction extracts the idempotence hypothesis. The reverse uses

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -55,7 +55,13 @@ For MPDO renormalization fixed points:
 - `cpsv16_pure_zcl_local_orthogonality_scope.tex` records that the current
   pure-MPS ZCL theorem is a single-block idempotence/CID equivalence. The
   source theorem also includes the BNT-level local-orthogonality equations
-  between distinct blocks.
+  between distinct blocks. The unrestricted source equivalence is false under
+  its stated raw-weight BNT normalization, as recorded in
+  `cpsv16_pure_zcl_raw_weight_counterexample.tex`.
+- `cpsv16_pure_zcl_raw_weight_counterexample.tex` gives the canonical tensor
+  $A^0=\operatorname{diag}(1,1/2)$. It satisfies physical CID and has a
+  one-component, hence locally orthogonal, BNT, but its transfer map is not
+  idempotent. It identifies the failed inference at source lines 1248--1251.
 - `cpsv16_rfp_isometry_scope.tex` records the normalization and cross-block
   content of the source's equation `III_isometry`, together with the remaining
   canonical-form hypotheses. It also records the ambiguity between a literal

--- a/docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex
+++ b/docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex
@@ -138,19 +138,21 @@ this positive-gap restriction by
 BNT implication is
 \leanid{MPSTensor.isPositiveGapBNTZCL_of_isPhysicalBNTZCL}.
 
-The remaining target theorem for tensors in canonical form is
+The unrestricted BNT-level equivalence is not a remaining proof target.  Under
+the source's raw-weight canonical-form normalization it is false.  The tensor
 \[
-  \mathrm{ZCL}_{\mathrm{BNT}}(A)
-  \Longleftrightarrow
-  \mathbb E_A^2=\mathbb E_A.
+  A^0=\operatorname{diag}(1,1/2)
 \]
-The existing single-block theorem supplies only the CID consequence of
-idempotence and should remain marked as a scope restriction until the
-canonical-form theorem is stated with the BNT predicate.\footnote{Tracked by
-\ghissue{2597}.}
+has one normal BNT component with raw weights $1$ and $1/2$.  It satisfies
+physical CID, while local orthogonality is vacuous, but its transfer matrix is
+not idempotent.  The counterexample and the failed inference at source lines
+1248--1251 are recorded in
+\path{docs/paper-gaps/cpsv16_pure_zcl_raw_weight_counterexample.tex}.\footnote{Tracked
+by \ghissue{2597}.}
 
-The present theorem is therefore a scope restriction: it records the one-block
-idempotence/CID consequence, while the BNT-level equivalence remains open.
+The existing single-block theorem remains a scope restriction: it records the
+one-block idempotence/CID consequence and does not assert the false raw-weight
+BNT equivalence.
 
 There is a second distinction in the correlation predicate. Definition~3.3
 quantifies over physical observables on arbitrary nonempty finite regions, and
@@ -197,19 +199,26 @@ The older predicate \leanid{MPSTensor.IsCID} instead quantifies directly over
 arbitrary virtual matrices $X,Y$.  Its converse to idempotence is valid, but it
 is stronger than physical CID: the source obtains the required virtual
 insertions from physical observables by block injectivity
-(lines 1250--1258).  Closing the reverse implication therefore requires a
-formal physical-realization theorem for block observables, followed by the
-nonzero power-sum argument in lines 1260--1268.  One must not identify the two
-CID predicates before that realization theorem is proved.  Since the older
+(lines 1250--1258).  For a corrected statement which removes the raw-copy
+obstruction, the reverse implication would still require a formal
+physical-realization theorem for block observables, followed by the nonzero
+power-sum argument in lines 1260--1268.  One must not identify the two CID
+predicates before that realization theorem is proved.  Since the older
 predicate universally quantifies over positive definite fixed points, it is
 also vacuous for a tensor without such a fixed point.  The periodic-chain
-predicate avoids this boundary-state issue.
+predicate avoids this boundary-state issue.  Even after a physical-realization
+theorem is supplied, the source proof cannot establish the unrestricted
+reverse implication: the step from non-idempotence of the full transfer matrix
+to non-idempotence of a normal BNT component ignores the eigenvalues contributed
+by the raw copy weights.  A theorem restricted to one unit-weight copy per BNT
+component would still require the physical-realization and power-sum arguments,
+but it would be a different statement.
 
 Accordingly, \leanid{MPSTensor.IsBNTZCL} remains the virtual-insertion
 surrogate, while \leanid{MPSTensor.IsPositiveGapBNTZCL} names the physical
 positive-gap condition. Neither is Definition~3.6; that definition is now
-\leanid{MPSTensor.IsPhysicalBNTZCL}. Its equivalence with transfer idempotence
-remains open.
+\leanid{MPSTensor.IsPhysicalBNTZCL}. Its unrestricted equivalence with transfer
+idempotence is disproved by the raw-weight counterexample above.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpsv16_pure_zcl_raw_weight_counterexample.tex
+++ b/docs/paper-gaps/cpsv16_pure_zcl_raw_weight_counterexample.tex
@@ -1,0 +1,111 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{A raw-weight counterexample to the pure-state ZCL equivalence in
+Cirac--Perez-Garcia--Schuch--Verstraete 2017}
+\author{}
+\date{2026-07-14}
+
+\begin{document}
+\maketitle
+
+\section{Source statement and failed inference}
+
+The canonical form of \cite{Cirac2016MPDO_arXiv} permits repeated copies of a
+normal tensor with coefficients of modulus at most one, provided that at least
+one coefficient equals one.  In the notation of equation
+\path{eq:II_ABasicTensors},
+\[
+  A^i = \bigoplus_{j=1}^g\bigoplus_{q=1}^{r_j}
+    \mu_{j,q}X_{j,q}A_j^iX_{j,q}^{-1}.
+\]
+Theorem~3.8, labelled \path{TheoremZCLPure} in the local source, asserts that a
+canonical-form tensor has zero correlation length if and only if its transfer
+matrix is idempotent.
+
+The converse argument begins at source lines 1248--1251.  It infers from
+$\mathbb E_A^2\ne\mathbb E_A$ that some normal basis tensor $A_j$ has a
+non-idempotent transfer matrix $\mathbb E_{j,j}$.  This inference omits the
+copy coefficients.  On the $(j,q;j',q')$ bond block, the full transfer matrix
+is
+\[
+  \mu_{j,q}\overline{\mu_{j',q'}}\,\mathbb E_{j,j'}.
+\]
+Thus the full transfer matrix can have an eigenvalue strictly between zero and
+one even when every $\mathbb E_{j,j}$ is idempotent.
+
+\section{Counterexample}
+
+Take one physical letter and the scalar normal tensor $C^0=(1)$.  Form the
+canonical tensor.  In the sector-adapted coordinates of this decomposition,
+\[
+  A^0 = C^0\oplus \tfrac12 C^0
+      = \begin{pmatrix}1&0\\0&\tfrac12\end{pmatrix}.
+\]
+This has one BNT component, two raw copies, and weights $1$ and $1/2$.  The
+weights satisfy precisely the source normalization: both have modulus at most
+one and the first equals one.  The matrix-product-vector coefficient at
+length $N$ is
+\[
+  V^{(N)}(A)=1+2^{-N},
+\]
+which is also the coefficient obtained from the two-copy BNT decomposition.
+
+There is only one BNT component, so local orthogonality is vacuous.  The
+physical Hilbert space of every finite region is one-dimensional.  Every
+physical observable is therefore scalar, and every two-region expectation is
+independent of the separation.  Hence $A$ satisfies the CID and local
+orthogonality conditions of Definition~3.6.
+
+The transfer map has the matrix units as eigenvectors, with eigenvalues
+\[
+  1,\quad \tfrac12,\quad \tfrac12,\quad \tfrac14.
+\]
+It is not idempotent.  Equivalently, the one-letter blocking equation required
+at a renormalization fixed point would give a scalar $v$ such that
+\[
+  (A^0)^2=vA^0.
+\]
+The $(0,0)$ entry gives $v=1$, while the $(1,1)$ entry would then assert
+$1/4=1/2$.
+
+All four assertions have kernel-checked proofs.\footnote{Formal conjunction:
+\leanid{MPSTensor.halvedWeightTensor_counterexample_to_unrestricted_zcl_iff_rfp}
+in \doclink{TNLean/MPS/RFP/BNTWeightCounterexample}.}
+
+\section{Consequence for the theorem surface}
+
+The unrestricted equivalence in Theorem~3.8 is false under the stated
+raw-weight canonical-form normalization.  The example disproves the
+zero-correlation-length implication to transfer idempotence.  It does not
+settle the converse implication for adjacent physical regions; the existing
+formal result in that direction assumes both complementary gaps are positive.
+
+A corrected theorem must remove the copy-weight eigenvalues from its
+conclusion.  Two possible formulations are to pass first to a canonical
+representative with one unit-weight copy of each BNT component, or to state an
+asymptotic assertion for the limiting transfer projector rather than literal
+idempotence of the raw tensor's transfer map.  A restriction merely requiring
+unit-modulus copy weights is insufficient: distinct phases can also destroy
+idempotence.  Any replacement must therefore state explicitly how repeated
+copies and their phases are treated.
+
+Issue~\ghissue{2597} should not retain the unrestricted biconditional as a
+proof target.  Its replacement should distinguish the false raw-tensor
+statement from any theorem about a selected representative of the generated
+matrix-product-vector family.
+
+The verdict is a source counterexample: the zero-correlation-length implication
+to transfer idempotence is false under the normalization stated in the cited
+canonical form.  It is not an open formalization gap.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
## Summary

- formalizes the raw-weight canonical tensor with one scalar normal block and copy weights `1` and `1/2`
- proves that the tensor satisfies the unrestricted source-facing physical zero-correlation-length conditions but is not a renormalization fixed point
- records that the tensor is literally the assembly of its BNT canonical form, closing the canonical-premise gap identified in review
- adds a paper-gap note explaining why CPSV16 Theorem 3.8 is false for unrestricted raw copy weights

## Mathematical point

For the one-letter tensor assembled from weights `1` and `1/2`, the matrix-product-vector coefficient is `1 + 2^{-N}`. Physical correlations are distance-independent because the physical space is one-dimensional, and distinct-sector orthogonality is vacuous. If the tensor were an RFP, one-letter blocking would require a scalar `v` satisfying both `1^2 = v·1` and `(1/2)^2 = v·(1/2)`, which is impossible.

The witness is definitionally the tensor assembled from `SectorBNT.Examples.halvedDecomp scalarUnitTensor`; equality of MPV families is not used as a substitute for the source canonical-form premise.

## Validation

- targeted Lean compilation and full project build
- public coefficient theorem and exact blueprint declaration tags
- proof-integrity grep and axiom audit (only `propext`, `Classical.choice`, `Quot.sound`)
- reader-facing prose and diff checks
- paper-gap PDF and blueprint PDF (547 pages), with affected pages visually inspected
- blueprint web under Python 3.9
- independent exact-commit review: READY

Closes #2597.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The change asserts a falsehood of a cited source theorem under its own normalization; errors would misstate the formal library’s claims, but scope is confined to RFP/ZCL documentation and one new proof module.
> 
> **Overview**
> This PR **formalizes a counterexample** to the unrestricted pure-state zero-correlation-length (ZCL) ⇔ renormalization fixed point (RFP) equivalence in CPSV16 Theorem 3.8 when BNT canonical form allows **raw copy weights** (e.g. `1` and `1/2`).
> 
> The witness `halvedWeightTensor` is **definitionally** the assembly of `halvedDecomp scalarUnitTensor` (`diag(1, 1/2)` on the bond). New proofs show it is a valid raw-weight BNT canonical form, has MPV coefficient `1 + 2^{-N}`, satisfies **`IsPhysicalBNTZCL`** (physical CID and vacuous local orthogonality on a one-letter space), yet **`¬ IsRFP`** via incompatible one-letter blocking scalars. A capstone theorem bundles these facts.
> 
> **`TNLean.lean`** imports the new module. **Blueprint ch14** adds Theorem `halved_weight_zcl_not_rfp` and revises comments on Theorem 3.8 and virtual-insertion CID ⇒ RFP to cite the obstruction. **Paper-gap notes** (`cpsv16_pure_zcl_raw_weight_counterexample.tex`, README, local-orthogonality scope) record that the unrestricted biconditional is **false** under stated normalization and point at the failed inference at source lines 1248–1251 (copy-weight eigenvalues ignored).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8673d0849fa1797133f26fae41d783a9ed6e9ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->