### PR TITLE
doc(MPS/MPDO): add vertical Gram comparison diagram

### DIFF
--- a/blueprint/src/Packages/tn_diagrams.py
+++ b/blueprint/src/Packages/tn_diagrams.py
@@ -67,6 +67,7 @@ _DIAGRAM_ARGS: dict[str, str] = {
     "TNMPDOFirstSiteContractions": "",
     "TNMPDOVerticalDirectSum": "",
     "TNMPDOVerticalReducingSectors": "",
+    "TNMPDOVerticalGaugeGramComparison": "",
     "TNMPDOInverseContraction": "",
     "TNMPDOSectorPairing": "",
     "TNMPDOSectorZCLIdentity": "",

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -1813,6 +1813,22 @@
     $X^\dagger X$ on the right gives the commutation.
 \end{proof}
 
+\begin{figure}[ht]
+    \centering
+    \TNMPDOVerticalGaugeGramComparison
+    \caption{Equality of the Gram conjugations for two copies of the same
+    vertical normal tensor:
+    $(X_{\alpha,k}^{\dagger}X_{\alpha,k})M_\alpha
+    (X_{\alpha,k}^{\dagger}X_{\alpha,k})^{-1}
+    =(X_{\alpha,1}^{\dagger}X_{\alpha,1})M_\alpha
+    (X_{\alpha,1}^{\dagger}X_{\alpha,1})^{-1}$.
+    The horizontal Lemma~L gives this equality from self-adjointness of the
+    corresponding sector compressions. Normality is used only in the
+    subsequent proportionality argument. This is
+    \cite[Proposition~4.13, lines~1915--1921]{Cirac2016MPDO_arXiv}.}
+    \label{fig:mpdo_vertical_gauge_gram_comparison}
+\end{figure}
+
 \begin{theorem}[Gram-matrix proportionality from the dressed-adjoint identities]
     \label{thm:eq3_of_dressed_adjoint}
     \lean{MPSTensor.IsNormal.conjTranspose_mul_self_eq_smul_one_of_dressed_adjoint}

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -825,6 +825,49 @@
     \end{tikzpicture}%
 }
 
+% Equality of the Gram conjugations for two gauge-equivalent copies of one
+% vertical normal tensor. The ordering of the four gauge factors follows
+% DAVID_Fig8.png in the proof of Proposition 4.13.
+\newcommand{\TNMPDOVerticalGaugeGramComparison}{%
+    \begin{tikzpicture}[tn picture]
+        \path[draw=black, opacity=0, use as bounding box]
+            (-3.45,-1.62) rectangle (3.45,1.62);
+        \begin{scope}[xshift=-1.80cm]
+            \TN@tensordot{vggL}{(0,0)}
+            \draw[tn phys leg] (vggL.west) -- ++(-0.72,0);
+            \draw[tn phys leg] (vggL.east) -- ++(0.72,0);
+            \TN@opdotright{vggLX}{(0,0.58)}{X_{\alpha,k}}
+            \TN@opdotright{vggLXd}{(0,1.18)}{X_{\alpha,k}^{\dagger}}
+            \TN@opdotright{vggLXi}{(0,-0.58)}{X_{\alpha,k}^{-1}}
+            \TN@opdotright{vggLXid}{(0,-1.18)}{(X_{\alpha,k}^{-1})^{\dagger}}
+            \draw[tn leg] (vggL.north) -- (vggLX.south);
+            \draw[tn leg] (vggLX.north) -- (vggLXd.south);
+            \draw[tn leg] (vggLXd.north) -- ++(0,0.30);
+            \draw[tn leg] (vggL.south) -- (vggLXi.north);
+            \draw[tn leg] (vggLXi.south) -- (vggLXid.north);
+            \draw[tn leg] (vggLXid.south) -- ++(0,-0.30);
+            \node[anchor=east] at (-0.16,0.18) {$M_\alpha$};
+        \end{scope}
+        \node at (0,0) {$=$};
+        \begin{scope}[xshift=1.80cm]
+            \TN@tensordot{vggR}{(0,0)}
+            \draw[tn phys leg] (vggR.west) -- ++(-0.72,0);
+            \draw[tn phys leg] (vggR.east) -- ++(0.72,0);
+            \TN@opdotright{vggRX}{(0,0.58)}{X_{\alpha,1}}
+            \TN@opdotright{vggRXd}{(0,1.18)}{X_{\alpha,1}^{\dagger}}
+            \TN@opdotright{vggRXi}{(0,-0.58)}{X_{\alpha,1}^{-1}}
+            \TN@opdotright{vggRXid}{(0,-1.18)}{(X_{\alpha,1}^{-1})^{\dagger}}
+            \draw[tn leg] (vggR.north) -- (vggRX.south);
+            \draw[tn leg] (vggRX.north) -- (vggRXd.south);
+            \draw[tn leg] (vggRXd.north) -- ++(0,0.30);
+            \draw[tn leg] (vggR.south) -- (vggRXi.north);
+            \draw[tn leg] (vggRXi.south) -- (vggRXid.north);
+            \draw[tn leg] (vggRXid.south) -- ++(0,-0.30);
+            \node[anchor=east] at (-0.16,0.18) {$M_\alpha$};
+        \end{scope}
+    \end{tikzpicture}%
+}
+
 % Inverse-map contraction for an injective simple tensor: contracting the
 % inverse tensor with the tensor through the physical index identifies the
 % two pairs of virtual legs (the matrix units on the bond space).

--- a/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
+++ b/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
@@ -22,7 +22,7 @@ name: TNMPDOHayashiSectorComparison TNMPDOSectorFactorization
 name: TNMPDOHorizontalOperator TNMPDOFirstSiteContractions TNMPDOVerticalDirectSum
 {{ obj.tn_svg_html }}
 
-name: TNMPDOVerticalReducingSectors
+name: TNMPDOVerticalReducingSectors TNMPDOVerticalGaugeGramComparison
 {{ obj.tn_svg_html }}
 
 name: TNMPDOInverseContraction TNMPDOSectorPairing TNMPDOSectorZCLIdentity


### PR DESCRIPTION
## Summary

- adds a reusable TikZ rendering of CPSV16 `DAVID_Fig8.png`
- places the diagram between the dressed-adjoint identity and the subsequent Gram-rigidity theorem in Chapter 20
- registers the figure for both print and web blueprint renderers

## Mathematical content

The two stacks express

`(X_{α,k}† X_{α,k}) M_α (X_{α,k}† X_{α,k})⁻¹ = (X_{α,1}† X_{α,1}) M_α (X_{α,1}† X_{α,1})⁻¹`.

The caption cites CPSV16 Proposition 4.13, lines 1915–1921, and explicitly reserves proportionality of the Gram matrices for the following normality argument.

## Validation

- reader-facing prose and diff checks
- blueprint PDF and Python-3.9 web generation
- print and generated-SVG visual comparison with `Papers/1606.00608/DAVID_Fig8.png`
- complete print/web macro registration
- independent exact-commit review: READY

No Lean source or declaration tags are changed. Follow-up to #3674.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and diagram rendering only; no Lean or runtime logic changes.
> 
> **Overview**
> Adds a new tensor-network figure for **equality of Gram conjugations** across two gauge copies of the same vertical normal tensor \(M_\alpha\) (CPSV16 Prop. 4.13 / `DAVID_Fig8`).
> 
> The change introduces the TikZ macro `\TNMPDOVerticalGaugeGramComparison`, registers it for PDF and web blueprint rendering (`tn_diagrams.py`, plasTeX template), and inserts a **figure with caption** in Chapter 20 between the dressed-adjoint Gram conjugation theorem and the Gram-matrix proportionality theorem. No Lean sources or declaration tags are modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3833a94c2f4d07bb4125e01512c90ad0bd7fcc0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->