### PR TITLE
feat(MPS/MPDO): construct coisometry from orthogonal sectors

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -377,6 +377,7 @@ import TNLean.MPS.MPDO.MutualInfoMonotone
 import TNLean.MPS.MPDO.PureAreaLaw
 import TNLean.MPS.MPDO.PureRFPSAL
 import TNLean.MPS.MPDO.VerticalCF
+import TNLean.MPS.MPDO.VerticalCoisometry
 import TNLean.MPS.MPDO.PerCopyHorizontalCF
 import TNLean.MPS.MPDO.FirstSiteBlocking
 import TNLean.MPS.MPDO.RepresentativeGroupedLemmaL

--- a/TNLean/MPS/MPDO/VerticalCoisometry.lean
+++ b/TNLean/MPS/MPDO/VerticalCoisometry.lean
@@ -1,0 +1,179 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.VerticalCF
+
+/-!
+# Coisometries from orthogonal vertical sectors
+
+For a finite family of isometries with mutually orthogonal ranges, this file
+forms the block-row coisometry whose rows are their adjoints.  If a tensor
+intertwines each isometry with a sector tensor, conjugation by this coisometry
+is the direct sum of the sector tensors.  A literal sum over the sector
+corners gives the reverse reconstruction identity.
+
+These matrix identities isolate the finite-dimensional construction needed for
+the coisometry and direct-sum conclusion of arXiv:1606.00608,
+Proposition 4.13, lines 1863--1870.  The reverse identity proved here is the
+conditional consequence of an assumed literal sum over the sector corners.
+
+## Main definitions
+
+* `Matrix.sigmaBlockRow`: the block row formed from the adjoints of a family
+  of rectangular matrices.
+
+## Main results
+
+* `Matrix.sigmaBlockRow_isCoisometry`: orthogonal isometries give a
+  coisometry.
+* `Matrix.sigmaBlockRow_conjugation`: sector intertwinings give a
+  block-diagonal conjugation identity.
+* `Matrix.sigmaBlockRow_reconstruction`: a sum of sector corners equals the
+  reverse block-diagonal compression.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Proposition 4.13, lines 1863--1870
+-/
+
+open scoped Matrix BigOperators
+
+namespace Matrix
+
+variable {r d s : ℕ} {dim : Fin r → ℕ}
+
+/-- The block row whose sector indexed by `k` is the adjoint of `W k`.
+
+For $W_k : \mathbb C^{D_k}\to\mathbb C^d$, this is the map
+$U=\bigl(W_0^\dagger,\ldots,W_{r-1}^\dagger\bigr)^\mathsf T$ from
+$\mathbb C^d$ to $\bigoplus_k\mathbb C^{D_k}$.
+
+Source: arXiv:1606.00608, Proposition 4.13, lines 1863--1870. -/
+noncomputable def sigmaBlockRow
+    (W : (k : Fin r) → Matrix (Fin d) (Fin (dim k)) ℂ) :
+    Matrix ((k : Fin r) × Fin (dim k)) (Fin d) ℂ :=
+  fun x a ↦ (W x.1)ᴴ x.2 a
+
+@[simp]
+theorem sigmaBlockRow_conjTranspose
+    (W : (k : Fin r) → Matrix (Fin d) (Fin (dim k)) ℂ) :
+    (sigmaBlockRow W)ᴴ = fun a x ↦ W x.1 a x.2 := by
+  ext a x
+  simp [sigmaBlockRow]
+
+/-- Left multiplication of a block row by a block-diagonal matrix acts on
+each row sector separately. -/
+theorem blockDiagonal'_mul_sigmaBlockRow
+    (B : (k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ)
+    (W : (k : Fin r) → Matrix (Fin d) (Fin (dim k)) ℂ) :
+    blockDiagonal' B * sigmaBlockRow W =
+      fun x a ↦ (B x.1 * (W x.1)ᴴ) x.2 a := by
+  classical
+  ext ⟨k, x⟩ a
+  simp only [Matrix.mul_apply, ← Finset.univ_sigma_univ, Finset.sum_sigma]
+  rw [Fintype.sum_eq_single k]
+  · simp [sigmaBlockRow]
+  · intro l hl
+    apply Finset.sum_eq_zero
+    intro y hy
+    rw [blockDiagonal'_apply_ne B x y hl.symm]
+    exact zero_mul _
+
+/-- Multiplication of the adjoint block row by a matrix with the same row
+sectors is the sum of the corresponding sector products. -/
+theorem sigmaBlockRow_conjTranspose_mul
+    (W : (k : Fin r) → Matrix (Fin d) (Fin (dim k)) ℂ)
+    (C : (k : Fin r) → Matrix (Fin (dim k)) (Fin d) ℂ) :
+    (sigmaBlockRow W)ᴴ *
+        (show Matrix ((k : Fin r) × Fin (dim k)) (Fin d) ℂ from
+          fun x a ↦ C x.1 x.2 a) =
+      ∑ k, W k * C k := by
+  classical
+  ext a b
+  simp [Matrix.sum_apply, Matrix.mul_apply, ← Finset.univ_sigma_univ,
+    Finset.sum_sigma]
+
+/-- The Gram matrix of a block row is block diagonal when the ranges of its
+constituent isometries are pairwise orthogonal. -/
+theorem sigmaBlockRow_mul_conjTranspose
+    (W : (k : Fin r) → Matrix (Fin d) (Fin (dim k)) ℂ)
+    (horth : ∀ k l, k ≠ l → (W k)ᴴ * W l = 0) :
+    sigmaBlockRow W * (sigmaBlockRow W)ᴴ =
+      blockDiagonal' (fun k ↦ (W k)ᴴ * W k) := by
+  classical
+  ext ⟨k, x⟩ ⟨l, y⟩
+  by_cases hkl : k = l
+  · subst l
+    simp [sigmaBlockRow, Matrix.mul_apply]
+  · rw [blockDiagonal'_apply_ne _ _ _ hkl]
+    have h := congrFun (congrFun (horth k l hkl) x) y
+    simpa [sigmaBlockRow, Matrix.mul_apply] using h
+
+/-- The block row of pairwise orthogonal isometries is a coisometry.
+
+This is the identity $UU^\dagger=I$ in the coisometry conclusion of
+arXiv:1606.00608, Proposition 4.13, lines 1863--1870. -/
+theorem sigmaBlockRow_isCoisometry
+    (W : (k : Fin r) → Matrix (Fin d) (Fin (dim k)) ℂ)
+    (hiso : ∀ k, (W k)ᴴ * W k = 1)
+    (horth : ∀ k l, k ≠ l → (W k)ᴴ * W l = 0) :
+    sigmaBlockRow W * (sigmaBlockRow W)ᴴ = 1 := by
+  classical
+  rw [sigmaBlockRow_mul_conjTranspose W horth]
+  simp_rw [hiso]
+  exact blockDiagonal'_one
+
+/-- Intertwining on pairwise orthogonal sectors makes conjugation by their
+block-row coisometry block diagonal.
+
+This is the identity $U\widetilde M_vU^\dagger=\bigoplus_k B_k^v$ in
+arXiv:1606.00608, Proposition 4.13, lines 1863--1870. -/
+theorem sigmaBlockRow_conjugation
+    (T : Fin s → Matrix (Fin d) (Fin d) ℂ)
+    (B : (k : Fin r) → Fin s → Matrix (Fin (dim k)) (Fin (dim k)) ℂ)
+    (W : (k : Fin r) → Matrix (Fin d) (Fin (dim k)) ℂ)
+    (hiso : ∀ k, (W k)ᴴ * W k = 1)
+    (horth : ∀ k l, k ≠ l → (W k)ᴴ * W l = 0)
+    (hinter : ∀ k v, T v * W k = W k * B k v) :
+    ∀ v, sigmaBlockRow W * T v * (sigmaBlockRow W)ᴴ =
+      blockDiagonal' (fun k ↦ B k v) := by
+  classical
+  intro v
+  ext ⟨k, x⟩ ⟨l, y⟩
+  rw [Matrix.mul_assoc]
+  simp only [Matrix.mul_apply, sigmaBlockRow, sigmaBlockRow_conjTranspose]
+  conv_lhs =>
+    enter [2, a]
+    rw [show (∑ b, T v a b * W l b y) = (W l * B l v) a y by
+      exact congrFun (congrFun (hinter l v) a) y]
+  change ((W k)ᴴ * (W l * B l v)) x y = _
+  rw [← Matrix.mul_assoc]
+  by_cases hkl : k = l
+  · subst l
+    rw [hiso k, one_mul, blockDiagonal'_apply_eq]
+  · rw [horth k l hkl, Matrix.zero_mul, blockDiagonal'_apply_ne _ _ _ hkl]
+    rfl
+
+/-- A literal sum of orthogonal sector corners is reconstructed by the
+block-row coisometry and the corresponding block-diagonal matrix.
+
+This conditional reverse identity follows directly from the assumed literal
+sector decomposition; it is not a separate assertion attributed to the source. -/
+theorem sigmaBlockRow_reconstruction
+    (T : Fin s → Matrix (Fin d) (Fin d) ℂ)
+    (B : (k : Fin r) → Fin s → Matrix (Fin (dim k)) (Fin (dim k)) ℂ)
+    (W : (k : Fin r) → Matrix (Fin d) (Fin (dim k)) ℂ)
+    (hreconstruct : ∀ v, T v = ∑ k, W k * B k v * (W k)ᴴ) :
+    ∀ v, T v =
+      (sigmaBlockRow W)ᴴ * blockDiagonal' (fun k ↦ B k v) * sigmaBlockRow W := by
+  classical
+  intro v
+  rw [hreconstruct v, Matrix.mul_assoc,
+    blockDiagonal'_mul_sigmaBlockRow (fun k ↦ B k v) W,
+    sigmaBlockRow_conjTranspose_mul W (fun k ↦ B k v * (W k)ᴴ)]
+  simp_rw [← Matrix.mul_assoc]
+
+end Matrix

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -2327,6 +2327,76 @@
     coefficient positive.
 \end{proof}
 
+\begin{definition}[Block-row map of sector isometries]
+    \label{def:vertical_sector_block_row}
+    \lean{Matrix.sigmaBlockRow}
+    \leanok
+    Let $W_k:\C^{D_k}\to\C^d$ be a finite family of rectangular
+    matrices.  Their block-row map
+    $U:\C^d\to\bigoplus_k\C^{D_k}$ is defined by
+    \[
+        Ux=(W_k^\dagger x)_k.
+    \]
+    This realizes the coisometry in the conclusion of
+    \cite[Proposition~4.13, lines~1863--1870]{Cirac2016MPDO_arXiv} once the
+    sector isometries have been normalized.
+\end{definition}
+
+\begin{theorem}[Conjugation and reconstruction from orthogonal sectors]
+    \label{thm:vertical_sector_coisometry}
+    \lean{Matrix.sigmaBlockRow_isCoisometry}
+    \lean{Matrix.sigmaBlockRow_conjugation}
+    \lean{Matrix.sigmaBlockRow_reconstruction}
+    \leanok
+    \uses{def:vertical_sector_block_row}
+    Suppose that
+    \[
+        W_k^\dagger W_k=\Id,
+        \qquad
+        W_k^\dagger W_l=0\quad(k\ne l),
+    \]
+    and, for every letter $v$ and every sector $k$,
+    \[
+        T_vW_k=W_kB_k^v.
+    \]
+    Then the block-row map $U$ is a coisometry and conjugates $T$ to the
+    direct sum of the sector tensors:
+    \[
+        UU^\dagger=\Id,
+        \qquad
+        UT_vU^\dagger=\bigoplus_k B_k^v.
+    \]
+    If the letters also satisfy the literal sector decomposition
+    \[
+        T_v=\sum_k W_kB_k^vW_k^\dagger,
+    \]
+    then
+    \[
+        T_v=U^\dagger\!\left(\bigoplus_k B_k^v\right)U.
+    \]
+    This last equality is a conditional consequence of the displayed literal
+    sector decomposition; no additional assertion from the source is used.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The $(k,l)$ block of $UU^\dagger$ is $W_k^\dagger W_l$, hence the
+    first identity follows from orthonormality.  The corresponding block of
+    $UT_vU^\dagger$ is
+    \[
+        W_k^\dagger T_vW_l
+        =W_k^\dagger W_lB_l^v,
+    \]
+    which is $B_k^v$ for $k=l$ and zero otherwise.  Finally, multiplication
+    of the block diagonal matrix by the block row gives the sum
+    $\sum_kW_kB_k^vW_k^\dagger$, which is $T_v$ by hypothesis.
+    The row indices of $U$ form the dependent disjoint union
+    $\coprod_k\{0,\ldots,D_k-1\}$.  Its canonical order-preserving bijection
+    with $\{0,\ldots,\sum_kD_k-1\}$ gives the coordinate reindexing required
+    by the vertical canonical-form definition.
+    % Lean adapter: this final reindexing is `finSigmaFinEquiv`.
+\end{proof}
+
 \begin{theorem}[Horizontal canonical form implies vertical canonical form]
     \label{thm:vertical_cf_of_horizontal_cf}
     \notready


### PR DESCRIPTION
## Summary

- defines the block-row map associated with a finite family of sector isometries;
- proves the coisometry and block-diagonal conjugation identities from isometry, orthogonality, and intertwining hypotheses;
- proves reverse reconstruction under the additional literal sector-corner decomposition;
- adds a checked Chapter 20 blueprint entry and records the final dependent-sum reindexing needed by the vertical canonical-form definition.

The construction isolates the finite-dimensional assembly underlying the coisometry conclusion of CPSV16 Proposition 4.13, lines 1863–1870. It does not assume or claim the still-open reflected marked-chain step tracked by #3890.

## Verification

- `lake build TNLean.MPS.MPDO.VerticalCoisometry TNLean`
- proof-integrity scan of the new module
- `leanblueprint pdf`
- `leanblueprint web`
- `leanblueprint checkdecls`
- reader-facing prose and diff checks

## Remaining adapter

Application to `IsVerticalCF` still requires normalization of the grouped gauges, transport along the representative dimension equalities, flattening of the `(alpha,q)` sector indices, and reindexing by `finSigmaFinEquiv`. These are not hidden in the generic theorem.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New Mathlib-style matrix lemmas and documentation; no runtime, auth, or data-path changes. Risk is limited to proof maintenance and downstream formalization glue.
> 
> **Overview**
> Adds **`TNLean.MPS.MPDO.VerticalCoisometry`**, defining **`Matrix.sigmaBlockRow`** (adjoints of sector isometries stacked as one row into a dependent-sum index) and proving the finite-dimensional identities behind CPSV16 Prop. 4.13 (lines 1863–1870): **coisometry** from orthonormal orthogonal ranges, **block-diagonal conjugation** from letter–sector intertwining, and **conditional reverse reconstruction** when a literal corner sum is assumed.
> 
> The root import list and **Chapter 20** blueprint now record **`def:vertical_sector_block_row`** and **`thm:vertical_sector_coisometry`** with Lean links; the proof notes **`finSigmaFinEquiv`** for flattening sector indices. This is generic linear algebra only—wiring to **`IsVerticalCF`** (gauge normalization, representative transport, sector reindexing) remains separate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93d180c9b41e9c796590e6eb5c840816cdbfe385. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->