### PR TITLE
feat(MPS/MPDO): prove the reflected marked-chain identity

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -392,6 +392,7 @@ import TNLean.MPS.MPDO.CyclicProjector
 import TNLean.MPS.MPDO.VerticalSpectral
 import TNLean.MPS.MPDO.VerticalBNT
 import TNLean.MPS.MPDO.SectorTrace
+import TNLean.MPS.MPDO.ReflectedMarkedChain
 import TNLean.MPS.MPDO.BiCFDerivation
 import TNLean.MPS.MPDO.ZCL
 import TNLean.MPS.MPDO.RFP

--- a/TNLean/MPS/CanonicalForm/NormalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/NormalCommutant.lean
@@ -24,16 +24,13 @@ X_{\alpha,1}^\dagger X_{\alpha,1}$ and the unitary normalization of the
 relative gauge $X_{\alpha,k}X_{\alpha,1}^{-1}$.  In the source normalization
 $X_{\alpha,1} = \Id$, this is
 $U_{\alpha,k} = \omega_{\alpha,k}^{-1/2} X_{\alpha,k}$ from lines 1906--1908.
-The commutation hypothesis arises from the two displayed diagrams of lines
-1909--1919: the first diagram, transported blockwise by Lemma L, says that the
-sector-dressed tensor equals its adjoint dressing,
-$X A^v X^{-1} = (X^{-1})^\dagger C^v X^\dagger$, where the fixed adjoint
-orientation gives $C^v=(A^{v^{\mathrm{op}}})^\dagger$.  The second diagram
-eliminates this common target between two sector gauges.  The resulting ratio
-of their Gram matrices commutes with every matrix of the tensor.  The passage
-from a common dressed target to the relative form of eq3 is proved below;
-deriving the common target from self-adjointness of the sector compressions,
-including the reflected tail word, remains open.
+The commutation hypothesis is the relative conclusion of the two displayed
+diagrams at lines 1909--1919.  Hermiticity first gives a reflected marked-chain
+identity whose adjoint reverses the unmarked tail.  Lemma L is then applied to
+two sectors together, producing equality of their Gram conjugations.  The
+resulting ratio of Gram matrices commutes with every matrix of the tensor.
+The passage from this relative equality to eq3 is proved below; deriving the
+relative equality from the reflected marked chains remains open.
 
 ## Main results
 
@@ -50,7 +47,7 @@ including the reflected tail word, remains open.
   same-letter specializations of the common-target argument.
 * `Matrix.gram_conj_eq_of_dressed_target` /
   `Matrix.gram_conj_eq_gram_conj_of_common_dressed_target`:
-  the source-faithful common-target form of the two displayed diagrams.
+  conditional algebraic consequences of an abstract common target.
 * `MPSTensor.IsNormal.gram_eq_pos_smul_gram_of_gram_conj_eq` /
   `MPSTensor.IsNormal.gram_eq_pos_smul_gram_of_common_dressed_target`:
   the relative two-gauge form of eq3, without a self-adjoint-letter
@@ -71,11 +68,13 @@ namespace Matrix
 
 variable {n : Type*} [Fintype n] [DecidableEq n]
 
-/-- **From the first displayed diagram to the second** (arXiv:1606.00608,
-proof of Proposition 4.13, lines 1909--1919): if conjugation by an invertible
-gauge carries `B` to the dressing of a common target `C`, then conjugation by
-the Gram matrix carries `B` to `C`.  In the source, `C` is the adjoint of the
-letter with its oriented bond indices exchanged. -/
+/-- If conjugation by an invertible gauge carries `B` to the dressing of an
+abstract target `C`, then conjugation by the Gram matrix carries `B` to `C`.
+
+This is a conditional algebraic route to the relative Gram identity in
+arXiv:1606.00608, proof of Proposition 4.13, lines 1909--1919.  The source's
+reflected marked-chain argument does not identify such a target separately
+for each sector. -/
 theorem gram_conj_eq_of_dressed_target
     {X B C : Matrix n n ℂ} (hX : IsUnit X.det)
     (hdress : X * B * X⁻¹ = X⁻¹ᴴ * C * Xᴴ) :
@@ -285,13 +284,14 @@ theorem IsNormal.gram_eq_pos_smul_gram_of_gram_conj_eq
     exact (Complex.ext (Complex.ofReal_re c.re)
       (by rw [Complex.ofReal_im]; exact hcIm)).symm
 
-/-- **Relative equation eq3 from the common dressed target.**  If two
+/-- **Conditional relative equation eq3 from a common dressed target.**  If two
 invertible gauges dress every letter of a normal tensor to the same target,
 then their Gram matrices differ by a positive real scalar.  The target may
-depend on the letter; for the MPO adjoint in Figure 7 it is the adjoint of the
-letter with exchanged oriented bond indices.
+depend on the letter.
 
-Source: arXiv:1606.00608, proof of Proposition 4.13, lines 1909--1921. -/
+This is an algebraic consequence of the Figure 8 equality in
+arXiv:1606.00608, proof of Proposition 4.13, lines 1909--1921.  It is not the
+source-facing reflected marked-chain statement. -/
 theorem IsNormal.gram_eq_pos_smul_gram_of_common_dressed_target
     {A C : MPSTensor d D} (hA : IsNormal A)
     {X Y : Matrix (Fin D) (Fin D) ℂ} (hX : IsUnit X.det) (hY : IsUnit Y.det)
@@ -372,11 +372,11 @@ theorem IsNormal.smul_mem_unitaryGroup_of_commute
 dressings and the letters themselves are self-adjoint, then
 $X^\dagger X = \omega\,\Id$ for a necessarily positive constant $\omega$.
 
-**Scope restriction (self-adjoint letters):** the fixed orientation of Figure
-7 instead has the common target $(A^{v^{\mathrm{op}}})^\dagger$ and does not
-assume $(A^v)^\dagger=A^v$.  Thus this theorem is only the same-letter
-specialization.  The relative common-target statement is
-`IsNormal.gram_eq_pos_smul_gram_of_common_dressed_target`.  See
+**Scope restriction (self-adjoint letters):** the reflected marked-chain
+argument of Figure 7 does not assume $(A^v)^\dagger=A^v$ and does not assert
+an individual dressed-adjoint identity.  Thus this theorem is only a
+same-letter conditional specialization.  The source-facing relative theorem
+is `IsNormal.gram_eq_pos_smul_gram_of_gram_conj_eq`.  See
 `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`. -/
 theorem IsNormal.conjTranspose_mul_self_eq_smul_one_of_dressed_adjoint
     {A : MPSTensor d D} (hA : IsNormal A)

--- a/TNLean/MPS/MPDO/ReflectedMarkedChain.lean
+++ b/TNLean/MPS/MPDO/ReflectedMarkedChain.lean
@@ -1,0 +1,253 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.VerticalCF
+
+/-!
+# Reflected marked chains for vertical sectors
+
+Hermiticity of a matrix-product density operator gives a reflected identity
+for a chain with one vertical sector marked.  Taking the adjoint exchanges the
+two oriented horizontal bond indices and reverses the unmarked tail.  This is
+the indexed content of Figure 7 in the proof of Proposition 4.13 of
+arXiv:1606.00608, lines 1909--1913.
+
+The reflected tail is retained explicitly.  In particular, the result is not
+a same-tail first-site identity and does not assert that an individual
+sector-dressed tensor equals its raw reflected adjoint.  The latter statement
+is not invariant under the horizontal invertible similarities allowed by
+canonical form.  Figure 8 requires a subsequent relative comparison of two
+grouped sectors.
+
+## Main definitions
+
+* `horizontalSlice`: the horizontal-bond matrix obtained by fixing the two
+  vertical indices of a vertically viewed tensor.
+* `reflectedAdjoint`: conjugate transpose together with exchange of the
+  oriented horizontal bond indices.
+* `markedChainCoefficient`: the closed horizontal chain with one vertical
+  tensor marked.
+
+## Main statement
+
+* `IsMPDO.markedChainCoefficient_eq_reflectedAdjoint`: Hermiticity of the
+  density operators gives the reflected marked-chain identity of Figure 7.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  proof of Proposition 4.13, lines 1909--1919
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+namespace MPOTensor
+
+variable {d D n : ℕ}
+
+/-- Fixing the two vertical indices of a vertically viewed tensor gives a
+matrix on the horizontal bond space.
+
+For a tensor $A^v$ with $v=(a,b)$, this matrix has entries
+$(\mathcal R(A)^{rs})_{ab}=(A^{(a,b)})_{rs}$.  It is the marked horizontal
+matrix in Figure 7 of arXiv:1606.00608, lines 1909--1913. -/
+def horizontalSlice (A : MPSTensor (D * D) n) (r s : Fin n) :
+    Matrix (Fin D) (Fin D) ℂ :=
+  fun a b => A (finProdFinEquiv (a, b)) r s
+
+/-- Reflect a vertical tensor by exchanging its oriented horizontal bond
+indices and taking the conjugate transpose of each vertical matrix:
+$(A^\sharp)^v=(A^{v^{\mathrm{op}}})^\dagger$.
+
+This is the marked tensor on the right side of Figure 7 in
+arXiv:1606.00608, lines 1909--1913. -/
+def reflectedAdjoint (A : MPSTensor (D * D) n) : MPSTensor (D * D) n :=
+  fun v => (A (bondPairSwap v))ᴴ
+
+/-- Horizontal slicing converts the reflected vertical tensor into the
+conjugate transpose of the oppositely ordered slice. -/
+@[simp] theorem horizontalSlice_reflectedAdjoint
+    (A : MPSTensor (D * D) n) (r s : Fin n) :
+    horizontalSlice (reflectedAdjoint A) r s = (horizontalSlice A s r)ᴴ := by
+  ext a b
+  simp [horizontalSlice, reflectedAdjoint, Matrix.conjTranspose_apply]
+
+/-- Horizontal slicing commutes with scalar multiplication of every vertical
+letter. -/
+@[simp] theorem horizontalSlice_smul (c : ℂ) (A : MPSTensor (D * D) n)
+    (r s : Fin n) :
+    horizontalSlice (fun v => c • A v) r s = c • horizontalSlice A r s := by
+  ext a b
+  simp [horizontalSlice]
+
+/-- The coefficient of a closed horizontal chain with one vertical tensor
+marked and an unmarked MPO tail. -/
+noncomputable def markedChainCoefficient (A : MPSTensor (D * D) n)
+    (M : MPOTensor d D) (r s : Fin n) (σs τs : List (Fin d)) : ℂ :=
+  Matrix.trace (horizontalSlice A r s * evalWord M σs τs)
+
+/-- The reflected marked chain is the complex conjugate of the original
+chain with the two open vertical indices exchanged.
+
+The right tail is evaluated in the adjoint tensor on the reversed ket and bra
+words.  Thus neither the reversal nor the change from `M` to
+`adjointTensor M` is hidden in a same-tail equality.  This is the algebraic
+form of the right side of Figure 7 in arXiv:1606.00608, lines 1909--1913. -/
+theorem markedChainCoefficient_reflectedAdjoint (A : MPSTensor (D * D) n)
+    (M : MPOTensor d D) (r s : Fin n) (σs τs : List (Fin d))
+    (hlen : σs.length = τs.length) :
+    markedChainCoefficient (reflectedAdjoint A) (adjointTensor M) r s
+        σs.reverse τs.reverse =
+      star (markedChainCoefficient A M s r τs σs) := by
+  rw [markedChainCoefficient, markedChainCoefficient,
+    horizontalSlice_reflectedAdjoint,
+    evalWord_adjointTensor M σs.reverse τs.reverse (by simp [hlen]),
+    List.reverse_reverse, List.reverse_reverse,
+    ← Matrix.trace_conjTranspose, Matrix.conjTranspose_mul]
+  exact Matrix.trace_mul_comm _ _
+
+/-- Compressing the first physical site by a matrix gives the marked-chain
+coefficient of the corresponding vertical corner.
+
+This is the entrywise conversion between a first-site compression and the
+left side of Figure 7 in arXiv:1606.00608, lines 1909--1913. -/
+theorem coordinateCompression_eq_markedChainCoefficient
+    (M : MPOTensor d D) (V : Matrix (Fin d) (Fin n) ℂ)
+    (N : ℕ) (r s : Fin n) (σ τ : Fin N → Fin d) :
+    (∑ i : Fin d, ∑ j : Fin d,
+        star (V i r) *
+          mpo M (N + 1) (Fin.cons i σ) (Fin.cons j τ) * V j s) =
+      markedChainCoefficient
+        (fun v => Vᴴ * verticalTensor M v * V) M r s
+        (List.ofFn σ) (List.ofFn τ) := by
+  have hslice :
+      horizontalSlice (fun v => Vᴴ * verticalTensor M v * V) r s =
+        ∑ i : Fin d, ∑ j : Fin d, (star (V i r) * V j s) • M i j := by
+    ext a b
+    simp only [horizontalSlice, Matrix.mul_apply, Matrix.conjTranspose_apply,
+      verticalTensor_finProdFinEquiv, Matrix.sum_apply, Matrix.smul_apply,
+      smul_eq_mul]
+    rw [Finset.sum_comm]
+    apply Finset.sum_congr rfl
+    intro i _
+    rw [Finset.sum_mul]
+    apply Finset.sum_congr rfl
+    intro j _
+    ring
+  rw [markedChainCoefficient, hslice, Finset.sum_mul, Matrix.trace_sum]
+  simp_rw [Finset.sum_mul, Matrix.trace_sum, Matrix.smul_mul,
+    Matrix.trace_smul, smul_eq_mul]
+  simp only [mpo_apply, mpoMatrixEntry, List.ofFn_succ, Fin.cons_zero,
+    Fin.cons_succ, evalWord_cons]
+  apply Finset.sum_congr rfl
+  intro i _
+  apply Finset.sum_congr rfl
+  intro j _
+  ring
+
+/-- The coordinate compression of an MPDO is Hermitian for every tail
+length. -/
+theorem IsMPDO.coordinateCompression_star
+    {M : MPOTensor d D} (hM : IsMPDO M)
+    (V : Matrix (Fin d) (Fin n) ℂ) (N : ℕ)
+    (r s : Fin n) (σ τ : Fin N → Fin d) :
+    (∑ i : Fin d, ∑ j : Fin d,
+        star (V i r) *
+          mpo M (N + 1) (Fin.cons i σ) (Fin.cons j τ) * V j s) =
+      star (∑ i : Fin d, ∑ j : Fin d,
+        star (V i s) *
+          mpo M (N + 1) (Fin.cons i τ) (Fin.cons j σ) * V j r) := by
+  have hstar :
+      star (∑ i : Fin d, ∑ j : Fin d,
+          star (V i s) *
+            mpo M (N + 1) (Fin.cons i τ) (Fin.cons j σ) * V j r) =
+        ∑ i : Fin d, ∑ j : Fin d,
+          star (V j r) *
+            star (mpo M (N + 1) (Fin.cons i τ) (Fin.cons j σ)) * V i s := by
+    change (starRingEnd ℂ) (∑ i : Fin d, ∑ j : Fin d,
+        star (V i s) *
+          mpo M (N + 1) (Fin.cons i τ) (Fin.cons j σ) * V j r) = _
+    rw [map_sum]
+    apply Finset.sum_congr rfl
+    intro i _
+    rw [map_sum]
+    apply Finset.sum_congr rfl
+    intro j _
+    change star (star (V i s) *
+        mpo M (N + 1) (Fin.cons i τ) (Fin.cons j σ) * V j r) = _
+    rw [star_mul', star_mul', star_star]
+    ring
+  rw [hstar, Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro i _
+  apply Finset.sum_congr rfl
+  intro j _
+  rw [(hM (N + 1)).isHermitian.apply]
+
+/-- **The reflected marked-chain identity of Figure 7.**
+
+Suppose that the vertical corner selected by `V` is a positive scalar `c`
+times a tensor `A`.  Hermiticity of every MPDO density operator then identifies
+the marked chain of `A` with the chain of its reflected adjoint, evaluated in
+the adjoint MPO tensor on the reversed tail.
+
+The conclusion is valid for every tail length, including the empty tail.  It
+does not identify the two marked tensors letterwise: the two sides have
+different unmarked tails.  A relative reflected form of Lemma L is still
+needed to pass from this identity for two grouped sectors to Figure 8.
+
+Source: arXiv:1606.00608, proof of Proposition 4.13, Figure 7 and lines
+1909--1913. -/
+theorem IsMPDO.markedChainCoefficient_eq_reflectedAdjoint
+    {M : MPOTensor d D} (hM : IsMPDO M)
+    (A : MPSTensor (D * D) n) (V : Matrix (Fin d) (Fin n) ℂ)
+    (c : ℂ) (hc : (0 : ℂ) < c)
+    (hcorner : ∀ v, Vᴴ * verticalTensor M v * V = c • A v)
+    (N : ℕ) (r s : Fin n) (σ τ : Fin N → Fin d) :
+    markedChainCoefficient A M r s (List.ofFn σ) (List.ofFn τ) =
+      markedChainCoefficient (reflectedAdjoint A) (MPOTensor.adjointTensor M) r s
+        (List.ofFn σ).reverse (List.ofFn τ).reverse := by
+  have hcstar : star c = c := by
+    obtain ⟨_, hcim⟩ := Complex.pos_iff.mp hc
+    apply Complex.ext
+    · simp
+    · change -c.im = c.im
+      calc
+        -c.im = -0 := congrArg Neg.neg hcim.symm
+        _ = 0 := neg_zero
+        _ = c.im := hcim
+  have hscale : ∀ (r s : Fin n) (σs τs : List (Fin d)),
+      markedChainCoefficient
+          (fun v => Vᴴ * verticalTensor M v * V) M r s
+          σs τs = c * markedChainCoefficient A M r s σs τs := by
+    intro r s σs τs
+    rw [show (fun v => Vᴴ * verticalTensor M v * V) = fun v => c • A v by
+      funext v
+      exact hcorner v]
+    simp [markedChainCoefficient]
+  have hscaleSwap :
+      markedChainCoefficient
+          (fun v => Vᴴ * verticalTensor M v * V) M s r
+          (List.ofFn τ) (List.ofFn σ) =
+        c * markedChainCoefficient A M s r (List.ofFn τ) (List.ofFn σ) := by
+    exact hscale s r (List.ofFn τ) (List.ofFn σ)
+  have hcoord := hM.coordinateCompression_star V N r s σ τ
+  rw [coordinateCompression_eq_markedChainCoefficient,
+    coordinateCompression_eq_markedChainCoefficient,
+    hscale r s (List.ofFn σ) (List.ofFn τ), hscaleSwap] at hcoord
+  change c * markedChainCoefficient A M r s (List.ofFn σ) (List.ofFn τ) =
+    (starRingEnd ℂ)
+      (c * markedChainCoefficient A M s r (List.ofFn τ) (List.ofFn σ)) at hcoord
+  rw [map_mul] at hcoord
+  change c * markedChainCoefficient A M r s (List.ofFn σ) (List.ofFn τ) =
+    star c * star (markedChainCoefficient A M s r
+      (List.ofFn τ) (List.ofFn σ)) at hcoord
+  rw [hcstar] at hcoord
+  have hc0 : c ≠ 0 := ne_of_gt hc
+  rw [MPOTensor.markedChainCoefficient_reflectedAdjoint A M r s
+    (List.ofFn σ) (List.ofFn τ) (by simp)]
+  exact mul_left_cancel₀ hc0 hcoord
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/SectorTrace.lean
+++ b/TNLean/MPS/MPDO/SectorTrace.lean
@@ -75,7 +75,8 @@ $k$ because cyclicity of trace removes the internal similarity
 $X_{\alpha,k}M_\alpha^{(a,b)}X_{\alpha,k}^{-1}$.  The same decomposition uses
 the horizontal canonical form to find a nonzero sector compression, and hence
 deduces the positivity of every grouped coefficient.  The remaining argument
-of Proposition 4.13 begins with the dressed adjoints at line 1903.
+of Proposition 4.13 begins with the reflected marked-chain comparison at line
+1909.
 
 ## References
 

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -1803,6 +1803,50 @@
     Gram matrix the identity.
 \end{proof}
 
+\begin{theorem}[Reflected marked-chain identity]
+    \label{thm:mpdo_reflected_marked_chain}
+    \lean{MPOTensor.horizontalSlice}
+    \lean{MPOTensor.reflectedAdjoint}
+    \lean{MPOTensor.markedChainCoefficient}
+    \lean{MPOTensor.IsMPDO.markedChainCoefficient_eq_reflectedAdjoint}
+    \leanok
+    \uses{def:mpdo, def:vertical_tensor_mpdo,
+        thm:mpo_adjoint_reflection}
+    Let $M$ generate positive semidefinite operators at every length, let
+    $A$ be a vertical tensor, and suppose that a matrix $V$ selects the
+    vertical corner
+    \[
+        V^\dagger\widetilde M_vV=cA^v,
+        \qquad c>0.
+    \]
+    For vertical indices $r,s$, write
+    $(\mathcal R(A)^{rs})_{ab}=(A^{(a,b)})_{rs}$, and set
+    $(A^\sharp)^v=(A^{v^{\mathrm{op}}})^\dagger$.  Then, for every pair of
+    equal-length tail words $\sigma,\tau$,
+    \[
+    \begin{split}
+      \operatorname{tr}\!\left(\mathcal R(A)^{rs}
+        M^{\sigma_1\tau_1}\cdots M^{\sigma_L\tau_L}\right)
+      ={}&\operatorname{tr}\!\left(\mathcal R(A^\sharp)^{rs}
+        (M^\dagger)^{\sigma_L\tau_L}\cdots
+        (M^\dagger)^{\sigma_1\tau_1}\right).
+    \end{split}
+    \]
+    Thus the adjoint exchanges the oriented horizontal bond pair and reverses
+    the unmarked tail.  In particular, this is not a same-tail identity and
+    does not identify $A$ with $A^\sharp$ letterwise.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Compress the first site of the positive operator by $V$.  The resulting
+    matrix is Hermitian.  Expanding one matrix entry gives the marked chain on
+    the left and the complex conjugate of the entry with $r,s$ and the ket--bra
+    words exchanged.  Taking the conjugate transpose reverses the tail
+    product, cyclicity of trace returns the marked factor to the first
+    position, and positivity of $c$ permits cancellation without a phase.
+\end{proof}
+
 \begin{theorem}[Gram conjugation from the adjoint dressing]
     \label{thm:gram_conj_of_dressed_adjoint}
     \lean{Matrix.gram_conj_eq_of_dressed_target}
@@ -1820,12 +1864,13 @@
     \[
         (X^\dagger X)\,B\,(X^\dagger X)^{-1} = C.
     \]
-    Hence any two gauges satisfying the identity with the same target have
-    equal Gram conjugations, and the ratio of their Gram matrices commutes
-    with $B$.  Applied letterwise to a vertical tensor $A$, take $B=A^v$ and,
-    in the fixed orientation $v=(a,b)$, take
-    $C=(A^{(b,a)})^\dagger$ in the first diagram of
+    Hence any two gauges satisfying this conditional identity with the same
+    target have equal Gram conjugations, and the ratio of their Gram matrices commutes
+    with $B$.  This is a useful algebraic route from an abstract common target
+    to the relative identity in
     \cite[Proposition~4.13, lines 1909--1919]{Cirac2016MPDO_arXiv}.
+    The reflected marked-chain argument in the source does not identify the
+    target separately for either sector.
     The same-letter choice $C=B^\dagger$ and the
     further specialization $B^\dagger=B$ are useful corollaries, but the
     latter is not assumed by the source.
@@ -1856,7 +1901,7 @@
     \label{fig:mpdo_vertical_gauge_gram_comparison}
 \end{figure}
 
-\begin{theorem}[Gram-matrix proportionality from the dressed-adjoint identities]
+\begin{theorem}[Gram-matrix proportionality from relative Gram conjugations]
     \label{thm:eq3_of_dressed_adjoint}
     \lean{MPSTensor.IsNormal.gram_eq_pos_smul_gram_of_gram_conj_eq}
     \lean{MPSTensor.IsNormal.gram_eq_pos_smul_gram_of_common_dressed_target}
@@ -1866,17 +1911,19 @@
     \uses{def:normal, thm:gram_conj_of_dressed_adjoint,
         thm:normal_tensor_gram_rigidity}
     Let $M_\alpha$ be a normal tensor, and let $X$ and $Y$ be invertible
-    gauges which dress each letter $M_\alpha^v$ to the same target $C^v$.
+    gauges whose Gram matrices induce the same conjugation on each letter
+    $M_\alpha^v$.
     Then there is a positive real number $\omega$ such that
     \[
         X^\dagger X=\omega\,Y^\dagger Y,
     \]
-    and $\omega^{-1/2}XY^{-1}$ is unitary.  For the first diagram in the
-    proof of \cite[Proposition~4.13, lines 1909--1921]{Cirac2016MPDO_arXiv},
-    the target is $C^v=(M_\alpha^{v^{\mathrm{op}}})^\dagger$.  Taking $Y$ to
-    be the distinguished sector gauge gives the Gram-matrix proportionality
-    used at lines 1903--1907. In the normalization $Y=\Id$, the resulting
-    unitary is $\omega^{-1/2}X$.
+    and $\omega^{-1/2}XY^{-1}$ is unitary.  The Figure~8 comparison in
+    \cite[Proposition~4.13, lines 1909--1921]{Cirac2016MPDO_arXiv} supplies
+    precisely this relative hypothesis for a sector and the distinguished
+    sector. In the normalization $Y=\Id$, the resulting unitary is
+    $\omega^{-1/2}X$.  The common-target declarations attached to this entry
+    are conditional algebraic corollaries, not the reflected marked-chain
+    statement itself.
 \end{theorem}
 
 \begin{proof}
@@ -2397,72 +2444,6 @@
     % Lean adapter: this final reindexing is `finSigmaFinEquiv`.
 \end{proof}
 
-\begin{theorem}[Dressed adjoint from all-length sector compressions]
-    \label{thm:mpdo_grouped_sector_dressed_adjoint}
-    \notready
-    \uses{def:mpdo, def:horizontal_cf_mpdo, def:vertical_tensor_mpdo}
-    Let $M$ be in horizontal canonical form and generate matrix product
-    density operators.  Let $A$ be a normal vertical tensor, let
-    $V:\C^n\to\C^d$ be an isometry, let $X\in\GL_n(\C)$, and let
-    $c>0$.  Suppose that these matrices and maps satisfy the identities of one
-    reducing vertical sector: for every vertical letter $v$,
-    \[
-        \widetilde M_vV
-          =V\bigl(cXA^vX^{-1}\bigr),
-        \qquad
-        V^\dagger\widetilde M_v
-          =\bigl(cXA^vX^{-1}\bigr)V^\dagger,
-    \]
-    and
-    \[
-        cXA^vX^{-1}=V^\dagger\widetilde M_vV.
-    \]
-    For a vertical letter $v=(a,b)$, write
-    $v^{\mathrm{op}}=(b,a)$.  Then, for every vertical letter $v$, the gauge
-    dressing agrees with the adjoint dressing of the oppositely oriented
-    letter:
-    \[
-        XA^vX^{-1}
-        =(X^{-1})^\dagger(A^{v^{\mathrm{op}}})^\dagger X^\dagger.
-    \]
-    This is the dressed-target conclusion obtained from the two displayed
-    diagrams and Lemma~L in
-    \cite[Proposition~4.13, lines~1909--1919]{Cirac2016MPDO_arXiv}.
-\end{theorem}
-
-\begin{proof}
-    \uses{thm:mpdo_sector_compression_trace_pos,
-        thm:mpo_adjoint_reflection, lem:vertical_tensor_adjoint_reflection,
-        thm:mpo_translation_invariant,
-        thm:representative_one_sub_mp_zero}
-    Put $P=VV^\dagger$.  For every $N\geq 1$, the compression
-    $P_1H^{(N)}P_1$ is positive semidefinite, and is therefore self-adjoint.
-    Taking its adjoint produces the reflected chain of the adjoint tensor and
-    reverses the tail word.  The adjoint-reflection identity exchanges the two
-    oriented bond indices.  Cyclic translation of the periodic chain then
-    returns the marked sector to the first site.  Thus the first-site
-    contractions for $A^v$ and $(A^{v^{\mathrm{op}}})^\dagger$ agree for every
-    chain length and every pair of physical configurations.  This is the input
-    required by a reflected marked-chain form of the horizontal Lemma~L.  The
-    existing same-tail first-site-action theorem does not cover the reversed
-    tail word.  Proving this generalized separation statement is the open
-    step.  Conditional on that statement, the corresponding inserted tensors
-    are equal on the original bond space.
-
-    Compress that tensor equality on the left by $V^\dagger$ and on the right
-    by $V$.  The reducing and corner identities give
-    \[
-        cXA^vX^{-1}
-        =\overline c\,(X^{-1})^\dagger
-        (A^{v^{\mathrm{op}}})^\dagger X^\dagger.
-    \]
-    Since $c>0$, one has $\overline c=c\ne0$; cancelling $c$ gives the
-    asserted dressed-adjoint identity.  The existence of one nonzero sector
-    compression is not used here: that existential statement belongs to the
-    preceding proof that $c$ is positive, whereas Lemma~L requires the
-    self-adjoint compression identity at every length.
-\end{proof}
-
 \begin{lemma}[A retained vertical phase class exists]
     \label{lem:mpdo_vertical_retained_class_nonempty}
     \notready
@@ -2498,7 +2479,7 @@
         thm:mpdo_vertical_complete_reducing_projectors,
         thm:mpdo_vertical_normal_sectors_with_isometries,
         thm:mpdo_vertical_bnt_grouping_with_isometries,
-        thm:mpdo_grouped_sector_dressed_adjoint,
+        thm:mpdo_reflected_marked_chain,
         thm:vertical_sector_coisometry,
         lem:mpdo_vertical_retained_class_nonempty,
         thm:projector_closure_canonical_form,
@@ -2536,7 +2517,7 @@
         thm:mpdo_vertical_irreducible_reducing_sectors,
         thm:mpdo_vertical_complete_reducing_projectors,
         thm:mpdo_vertical_bnt_grouping_with_isometries,
-        thm:mpdo_grouped_sector_dressed_adjoint,
+        thm:mpdo_reflected_marked_chain,
         thm:vertical_sector_coisometry,
         lem:mpdo_vertical_retained_class_nonempty,
         thm:projector_closure_canonical_form,
@@ -2596,19 +2577,11 @@
     $c_{\alpha,k}>0$ from the normalization
     $c_{\alpha,1}=\nu_{\alpha,1}>0$.  From now on write
     $\mu_{\alpha,k}=c_{\alpha,k}$ for the positive coefficient in the
-    source decomposition, and put
-    $P_{\alpha,k}=V_{\alpha,k}V_{\alpha,k}^\dagger$.  The remaining
-    all-length marked-chain step is isolated in
-    Theorem~\ref{thm:mpdo_grouped_sector_dressed_adjoint}.  Applied to each
-    grouped sector with $c=c_{\alpha,k}=\mu_{\alpha,k}$, it gives, for
-    $v=(a,b)$,
-    \[
-        X_{\alpha,k}M_\alpha^vX_{\alpha,k}^{-1}
-        =(X_{\alpha,k}^{-1})^\dagger
-        (M_\alpha^{(b,a)})^\dagger X_{\alpha,k}^\dagger.
-    \]
-    The target $(M_\alpha^{(b,a)})^\dagger$ is independent of $k$.
-    Theorem~\ref{thm:eq3_of_dressed_adjoint} therefore derives the identity
+    source decomposition.  Theorem~\ref{thm:mpdo_reflected_marked_chain}
+    proves the Figure~7 identity for each such sector.  Once the reflected
+    form of Lemma~L compares a grouped sector with the distinguished sector
+    and gives the pairwise Gram-conjugation identity in Figure~8,
+    Theorem~\ref{thm:eq3_of_dressed_adjoint} derives the identity
     \[
         X_{\alpha,k}^\dagger X_{\alpha,k}
         =\omega_{\alpha,k}\,X_{\alpha,1}^\dagger X_{\alpha,1},
@@ -2618,9 +2591,9 @@
     from the two-gauge form of the displayed identities.  The grouped
     decomposition fixes $X_{\alpha,1}=\Id$, so this relative normalization is
     the source's $U_{\alpha,k}$.  Put
-    $W_{\alpha,k}=V_{\alpha,k}U_{\alpha,k}$.  Conditional on the dressed-adjoint
-    theorem, these are isometries with orthogonal ranges, and their block
-    relations become the intertwining and literal reconstruction hypotheses of
+    $W_{\alpha,k}=V_{\alpha,k}U_{\alpha,k}$.  Conditional on the relative
+    Gram-conjugation identity, these are isometries with orthogonal ranges,
+    and their block relations become the intertwining and literal reconstruction hypotheses of
     Theorem~\ref{thm:vertical_sector_coisometry} after the representative bond
     spaces have been identified.  That theorem supplies all the remaining
     coisometry algebra and, once the source-specific identifications below are
@@ -2629,18 +2602,19 @@
     the corresponding reconstruction identity; each
     $\mu_\alpha$ is diagonal, so the summands regroup as repeated weighted
     copies of $M_\alpha$ exactly as in the finite regrouping of
-    Lemma~\ref{lem:vertical_grouping_equiv}.  Since
-    Theorem~\ref{thm:mpdo_grouped_sector_dressed_adjoint} remains open, the
-    conclusion stated at lines 1903--1908 has not yet been derived from the
-    matrix-product-density-operator hypotheses.  The generic block-row
-    construction is already proved.  The remaining source-specific
-    identifications are to form the normalized sector isometries above,
-    transport each copy bond space to its representative bond space using the
-    dimension equalities supplied by the grouping theorem, regard the sectors
-    as dependent pairs $(\alpha,q)$, and identify their dependent disjoint
-    union with the standard direct-sum coordinate space.
-    % Lean adapter: the four steps use the normalized gauges, `hdim`, the pair
-    % `(alpha, q)`, and `finSigmaFinEquiv`, respectively.
+    Lemma~\ref{lem:vertical_grouping_equiv}. The remaining missing proof is the
+    reflected marked-chain and Lemma~L argument of lines 1909--1919: one must
+    compare two marked sector compressions, whose adjoints reverse the tail
+    word, and obtain their relative Gram-conjugation equality without making
+    a separate raw-adjoint identification for either sector.
+    Consequently, the conclusion stated at lines 1903--1908 has not yet been
+    derived from the matrix-product-density-operator hypotheses.  The generic
+    block-row construction is already proved.  After the relative
+    normalization, the remaining source-specific identifications are to form the normalized
+    sector isometries, transport each copy bond space to its representative
+    bond space using the dimension equalities from the grouping theorem,
+    index the sectors by dependent pairs $(\alpha,q)$, and identify their
+    dependent disjoint union with the standard direct-sum coordinate space.
 
     Conditional on that construction, the algebraic basis-of-normal-tensors
     clauses are verified as follows.  With the notation of the grouping

--- a/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
@@ -194,8 +194,9 @@ $c_{\alpha,1}=\nu_{\alpha,1}>0$.  Thus the coefficient denoted by
 $\mu_{\alpha,k}$ in the source is $\mu_{\alpha,k}=c_{\alpha,k}$
 (\path{TNLean/MPS/MPDO/VerticalBNT.lean} and
 \path{TNLean/MPS/MPDO/SectorTrace.lean}).  For the unitary gauges: granted
-the dressed-adjoint identities of the two displayed diagrams at source
-lines~1909--1919, transported blockwise by Lemma~L, the scalar commutant of
+the pairwise Gram-conjugation identity of the second displayed diagram at
+source lines~1914--1919, transported blockwise by a reflected form of
+Lemma~L, the scalar commutant of
 the normal tensor $M_\alpha$
 (\path{MPSTensor.IsNormal.eq_smul_one_of_commute}) makes the relative Gram
 ratio scalar.  Positivity of the two Gram matrices then gives
@@ -207,51 +208,36 @@ X_{\alpha,k}^\dagger X_{\alpha,k}
 The relative gauge $X_{\alpha,k}X_{\alpha,1}^{-1}$ becomes unitary after
 division by $\sqrt{\omega_{\alpha,k}}$.  The grouping theorem now exposes its choice
 $X_{\alpha,1}=\Id$, giving the normalization printed by the source
-(\path{MPSTensor.IsNormal.gram_eq_pos_smul_gram_of_common_dressed_target} in
+(\path{MPSTensor.IsNormal.gram_eq_pos_smul_gram_of_gram_conj_eq} in
 \path{TNLean/MPS/CanonicalForm/NormalCommutant.lean}).
 
-The remaining source-level gap begins with the dressed-adjoint argument at
-source line~1909.  For every chain length, positivity makes the sector
-compression $(P_{\alpha,k})_1H^{(N)}(P_{\alpha,k})_1$ self-adjoint.  Taking its
-adjoint reverses the tail word, and vertical adjoint reflection exchanges the
-two oriented bond indices.  Spatial reflection followed by cyclic translation
-must return this marked chain to a first-site contraction.  Only the resulting
-all-length family can be passed to Lemma~L.  For every $v=(a,b)$ it must give
-\[
-  X_{\alpha,k}M_\alpha^vX_{\alpha,k}^{-1}
-  =(X_{\alpha,k}^{-1})^\dagger
-    (M_\alpha^{(b,a)})^\dagger X_{\alpha,k}^\dagger.
-\]
-Thus the common target is $(M_\alpha^{(b,a)})^\dagger$, not the adjoint of
-the same oriented letter.  A reflected marked-chain form of Lemma~L is still
-required to derive this identity from the sector compressions.
+The remaining missing proof is the reflected marked-chain and Lemma~L argument
+of source lines~1909--1919.  The adjoint of the marked finite chain exchanges
+the oriented bond indices and reverses its tail word.  A reflected
+marked-chain form of Lemma~L must compare sector $k$ directly with the
+distinguished sector $1$ and derive equality of their Gram conjugations.
+It must not identify either dressed sector separately with the raw reflected
+adjoint: together with the literal positive reconstruction, that stronger
+statement would force tensor-level Hermiticity, which is not invariant under
+the horizontal invertible similarities allowed by canonical form.
+The Figure~7 marked-chain identity itself is now proved in
+\path{TNLean/MPS/MPDO/ReflectedMarkedChain.lean}; the missing statement is
+precisely the two-sector separation step.
 
-The one length at which a sector compression is known to be nonzero is used
-only to prove positivity of its coefficient; it does not suffice for
-Lemma~L.  In cancelling the coefficient from the displayed identity, one must
-use the already established positivity
-$c_{\alpha,k}=\nu_{\alpha,k}\zeta_{\alpha,k}
-=\mu_{\alpha,k}>0$, which gives both
-$\overline c_{\alpha,k}=c_{\alpha,k}$ and $c_{\alpha,k}\ne0$.
-
-After the dressed-adjoint identities have been proved, each invertible gauge
-can be replaced by a proportional unitary.  The generic assembly of
-orthogonal sector isometries into the single direct-sum coisometry $U$ is now
-proved by the block-row identities
-\path{Matrix.sigmaBlockRow_isCoisometry},
+Afterwards the copy embeddings can be normalized using the relative theorem
+above.  Their generic assembly into the direct-sum coisometry $U$ is already
+proved by \path{Matrix.sigmaBlockRow_isCoisometry},
 \path{Matrix.sigmaBlockRow_conjugation}, and
-\path{Matrix.sigmaBlockRow_reconstruction}.  Only the source-specific adapter
-remains: form the normalized sector isometries, transport them along the
-bond-dimension equalities \path{hdim} supplied by the grouping theorem,
-flatten the dependent pair $(\alpha,q)$, and use
-\path{finSigmaFinEquiv} to reindex the dependent disjoint union as the standard
-direct-sum coordinate space.  The length-zero clause in the
-algebraic BNT predicate also requires a retained representative.  The present
-grouping theorem does not state that its phase-class index is nonempty; this
-must be derived from horizontal canonical form and the literal reconstruction
-of the nonzero vertical tensor before a representative is chosen.  These
-source-specific gauge and indexing conclusions are not part of the grouping
-theorem.  The original
+\path{Matrix.sigmaBlockRow_reconstruction}.  The remaining source-specific
+identifications are to transport the copy bond spaces along the dimension
+equalities supplied by the grouping theorem, index the sectors by dependent
+pairs $(\alpha,q)$, and identify the dependent disjoint union with the
+standard direct-sum coordinate space.  The algebraic BNT predicate also
+requires a retained representative; its existence must still be deduced from
+horizontal canonical form and the literal reconstruction of the nonzero
+vertical tensor.  Consequently, the relative Gram conclusion at
+lines~1903--1908 has not yet been derived from the MPDO hypotheses.  These
+gauge and coisometry conclusions are not part of the grouping theorem.  The original
 formulation of \ghissue{2536}, interpreted as a direct conversion of the
 horizontal scalar weights and diagonal restrictions, is therefore not a
 consequence of Proposition~4.13.

--- a/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
@@ -169,9 +169,10 @@ separation supplies a nonzero compression.  Its trace is the sector weight
 $\mu_{\alpha,k}$ times a sector trace $d_\alpha$, so MPDO positivity forces
 $d_\alpha>0$ and $\mu_{\alpha,k}>0$ under the normalization
 $\mu_{\alpha,1}>0$ (\path{TNLean/MPS/MPDO/VerticalBNT.lean} and
-\path{TNLean/MPS/MPDO/SectorTrace.lean}). Granted the dressed-adjoint
-identities of the two displayed diagrams at lines~1909--1919, transported
-blockwise by Lemma~L, the Gram matrix of each sector gauge $X_{\alpha,k}$ is
+\path{TNLean/MPS/MPDO/SectorTrace.lean}). Granted the pairwise
+Gram-conjugation identity of the second displayed diagram at
+lines~1914--1919, transported blockwise by a reflected form of Lemma~L, the
+Gram matrix of each sector gauge $X_{\alpha,k}$ is
 a positive real multiple of the reference Gram matrix,
 \[
 X_{\alpha,k}^\dagger X_{\alpha,k}
@@ -195,8 +196,11 @@ What remains open is the reflected marked-chain and Lemma~L argument of source
 lines~1909--1919.  Its fixed-index form exchanges the two oriented bond indices,
 and the adjoint marked chain reverses the tail word.  A corresponding
 reflected marked-chain form of Lemma~L is needed before the relative Gram
-theorem can normalize the gauges; the resulting sector maps must then be
-assembled into the final coisometry.  Consequently, the conclusion stated at
+theorem can normalize the gauges.  It must compare two grouped copies and
+derive their relative Gram-conjugation equality; identifying either copy
+separately with the raw reflected adjoint would force the non-gauge-invariant
+conclusion that the tensor itself is Hermitian.  The resulting sector maps
+must then be assembled into the final coisometry.  Consequently, the conclusion stated at
 lines~1903--1908 has not yet been derived from the MPDO hypotheses.
 
 \paragraph{Verdict.}


### PR DESCRIPTION
## Summary

This contribution proves the reflected marked-chain identity represented by Figure 7 in the proof of Proposition 4.13 of arXiv:1606.00608.

For a positive vertical corner
\[
V^\dagger \widetilde M_v V=cA^v, \qquad c>0,
\]
Hermiticity of the matrix-product density operators gives equality between the marked chain of (A) and the marked chain of
\[
(A^\sharp)^v=(A^{v^{\mathrm{op}}})^\dagger
\]
against the adjoint MPO tensor with the unmarked tail reversed. The statement includes the empty-tail case.

The contribution also corrects the surrounding source-facing account. The paper does not provide a separate raw-adjoint identity for each grouped sector. Such an identity would force tensor-level Hermiticity and would not be invariant under the horizontal invertible similarities allowed by canonical form. The correct Figure 8 target is the pairwise equality of Gram conjugations.

## Contents

- define horizontal slices, reflected adjoints, and marked-chain coefficients;
- expand a first-site coordinate compression as a marked-chain coefficient;
- derive its Hermitian symmetry from the MPDO hypothesis;
- prove the reflected marked-chain identity with explicit tail reversal;
- add the corresponding blueprint theorem;
- correct the documentation of the conditional common-target lemmas and both relevant paper-gap notes.

## Scope

This does not prove the pairwise Figure 8 comparison or the final unitary normalization. The reflected two-sector form of Lemma L is tracked in #3897. Thus this pull request contributes to #3890 but does not close it.

## Verification

- `lake env lean TNLean/MPS/MPDO/ReflectedMarkedChain.lean`
- `lake build`
- `lake exe checkdecls blueprint/lean_decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check`
- forbidden-device scan for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast`

The axiom audit of all new theorems reports only `propext`, `Classical.choice`, and `Quot.sound`.

## References

- Parent target: #3890
- Reflected two-sector separation: #3897
- Vertical grouping tracker: #3887
- Proposition 4.13 tracker: #3674
- Source: `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 1909--1919

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New Mathlib proofs and prose/blueprint edits only; no auth, runtime, or API surface outside the MPDO formalization track.
> 
> **Overview**
> Adds **`TNLean/MPS/MPDO/ReflectedMarkedChain.lean`** with horizontal slices, reflected adjoints, marked-chain coefficients, and **`IsMPDO.markedChainCoefficient_eq_reflectedAdjoint`**: for a positive vertical corner \(V^\dagger \widetilde M_v V = c A^v\), MPDO Hermiticity equates the marked chain of \(A\) with that of \((A^\sharp)^v = (A^{v^{\mathrm{op}}})^\dagger\) on the **adjoint MPO** with the **tail reversed** (including empty tail).
> 
> **Documentation alignment:** `NormalCommutant`, blueprint ch.20, `SectorTrace`, and both `cpgsv17_*` gap notes now treat per-sector “dressed adjoint” / common-target lemmas as **conditional algebra**, not the paper’s Figure 7 step. The blueprint drops the open **`mpdo_grouped_sector_dressed_adjoint`** theorem in favor of **`thm:mpdo_reflected_marked_chain`**; Figure 8 is described as **pairwise Gram conjugation**, still open via reflected Lemma L (#3897).
> 
> Root import **`ReflectedMarkedChain`** is wired in `TNLean.lean`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d3fe239f332d65f0a381a5ed83e5795dee3a85b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->