### PR TITLE
feat(MPS/CanonicalForm): enumerate phase-class copies

### DIFF
--- a/TNLean/MPS/CanonicalForm/PhaseCover.lean
+++ b/TNLean/MPS/CanonicalForm/PhaseCover.lean
@@ -17,8 +17,10 @@ canonical-form equal-norm and sector comparisons.
 
 * `MPVBlockPhaseEquiv.dim_eq`: exact phase equivalence at every nonnegative
   length forces equality of bond dimensions.
+* `MPVPhaseClassData.enumEquiv`: the dependent family of class copies is
+  equivalent to the original block-index set.
 * `MPVPhaseClassData.regroup_matrix`: a matrix-valued sum can be regrouped by
-phase classes and their copies.
+  phase classes and their copies.
 -/
 
 open scoped Matrix BigOperators
@@ -240,6 +242,40 @@ lemma exists_enum_eq (classes : MPVPhaseClassData blocks) (k : Fin r) :
   have hregroup := classes.regroup (fun x : Fin r => if x = k then (1 : ℂ) else 0)
   rw [hzero, hone] at hregroup
   exact zero_ne_one hregroup
+
+/-- The phase-class enumeration is an equivalence with the original block indices.
+
+The regrouping identity shows that the dependent sum of all class copies has the same
+cardinality as the original index set.  Since every original index occurs in the enumeration,
+the enumeration is therefore bijective. -/
+noncomputable def enumEquiv (classes : MPVPhaseClassData blocks) :
+    (Σ j : Fin classes.g, Fin (classes.copies j)) ≃ Fin r := by
+  classical
+  let enumFn : (Σ j : Fin classes.g, Fin (classes.copies j)) → Fin r :=
+    fun jq ↦ classes.enum jq.1 jq.2
+  refine Equiv.ofBijective enumFn
+    ((Fintype.bijective_iff_surjective_and_card enumFn).2 ⟨?_, ?_⟩)
+  · intro k
+    obtain ⟨j, q, hq⟩ := classes.exists_enum_eq k
+    exact ⟨⟨j, q⟩, hq⟩
+  · rw [Fintype.card_sigma]
+    simp only [Fintype.card_fin]
+    have hcard := classes.regroup (fun _ ↦ (1 : ℂ))
+    simp only [Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul,
+      mul_one] at hcard
+    exact_mod_cast hcard
+
+@[simp]
+lemma enumEquiv_apply (classes : MPVPhaseClassData blocks)
+    (j : Fin classes.g) (q : Fin (classes.copies j)) :
+    classes.enumEquiv ⟨j, q⟩ = classes.enum j q :=
+  rfl
+
+/-- A nonempty block family has at least one MPV phase class. -/
+lemma g_pos_of_r_pos (classes : MPVPhaseClassData blocks) (hr : 0 < r) :
+    0 < classes.g := by
+  obtain ⟨j, _q, _hq⟩ := classes.exists_enum_eq ⟨0, hr⟩
+  exact Nat.lt_of_le_of_lt (Nat.zero_le j) j.isLt
 
 /-- Regroup a matrix-valued sum over the original block indices by phase
 classes and their copies. -/

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -852,6 +852,7 @@ single family.
     \lean{MPSTensor.MPVPhaseClassData}
     \lean{MPSTensor.mpvPhaseClassData}
     \lean{MPSTensor.mpvPhaseClassData_enum_zero_eq_repr}
+    \lean{MPSTensor.MPVPhaseClassData.enumEquiv}
     \leanok
     For a finite family of blocks, put $j \sim k$ when there is a nonzero
     scalar factor $\zeta$ such that
@@ -863,8 +864,23 @@ single family.
     for every length~$N$. The associated tuple enumerates the finite quotient,
     chooses one representative per class, enumerates that representative first
     in its class, records the scalar relating the representative to each member,
-    and proves that distinct representatives are not MPV-phase equivalent.
+    and proves that distinct representatives are not MPV-phase equivalent. The
+    pairs $(j,q)$, with $j$ a phase class and $q$ a copy in that class, are in
+    bijection with the original block indices.
 \end{definition}
+
+\begin{lemma}[Existence of an MPV phase class]
+    \label{lem:mpv_phase_class_nonempty}
+    \lean{MPSTensor.MPVPhaseClassData.g_pos_of_r_pos}
+    \leanok
+    \uses{def:mpv_phase_class_data}
+    A nonempty finite family of blocks has at least one MPV phase class.
+\end{lemma}
+
+\begin{proof}\leanok
+    Choose one original block index. Its occurrence in the phase-class
+    enumeration supplies a phase class containing it.
+\end{proof}
 
 \begin{lemma}[Regrouping a matrix sum by MPV phase classes]
     \label{lem:mpv_phase_class_regroup_matrix}


### PR DESCRIPTION
## Summary

- derives an equivalence between dependent phase-class copy pairs `(j,q)` and the original finite block-index set;
- proves the equivalence evaluates to the existing phase-class enumeration;
- proves that a nonempty original block family has at least one phase class;
- adds checked Chapter 10 blueprint coverage.

The equivalence is derived from the existing data rather than added as a new structure field. Surjectivity follows from occurrence of every original index, and the regrouping identity for the constant function gives equality of finite cardinalities.

## Verification

- isolated `lake build TNLean.MPS.CanonicalForm.PhaseCover`
- reader-facing prose check
- blueprint PDF and web builds
- visual inspection of affected Chapter 10 pages
- `git diff --check`

`leanblueprint checkdecls` recognized both new declarations; the isolated targeted build lacked only the four already-merged `sigmaBlockRow` object files outside this branch’s changed module.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized formal proofs and blueprint cross-references in canonical-form phase-cover material; no auth, runtime, or API surface changes.
> 
> **Overview**
> Adds **`MPVPhaseClassData.enumEquiv`**, proving phase-class copy pairs `(j,q)` are in bijection with original block indices `Fin r`, built from existing `exists_enum_eq` and the `regroup` cardinality identity (no new structure fields). A simp lemma **`enumEquiv_apply`** ties the equivalence to **`enum`**, and **`g_pos_of_r_pos`** shows a nonempty index family has **`0 < classes.g`**.
> 
> Chapter 10 blueprint text is updated: the MPV phase-class definition now states the bijection, and a short lemma documents nonempty phase classes, linked to the new Lean declarations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95529f8fd86e21e2168eb4caa97093c872766065. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->