### PR TITLE
feat(MPS/MPDO): derive vertical form from grouped sectors

### DIFF
--- a/TNLean/MPS/MPDO/VerticalCoisometry.lean
+++ b/TNLean/MPS/MPDO/VerticalCoisometry.lean
@@ -23,6 +23,8 @@ conditional consequence of an assumed literal sum over the sector corners.
 
 * `Matrix.sigmaBlockRow`: the block row formed from the adjoints of a family
   of rectangular matrices.
+* `MPOTensor.flattenGroupedSectorMap`: the same family reindexed by its finite
+  copy label.
 
 ## Main results
 
@@ -32,6 +34,8 @@ conditional consequence of an assumed literal sum over the sector corners.
   block-diagonal conjugation identity.
 * `Matrix.sigmaBlockRow_reconstruction`: a sum of sector corners equals the
   reverse block-diagonal compression.
+* `MPOTensor.isVerticalCF_of_grouped_orthogonal_sectors`: positive grouped
+  orthogonal sectors with an exact reconstruction give vertical canonical form.
 
 ## References
 
@@ -39,7 +43,7 @@ conditional consequence of an assumed literal sum over the sector corners.
   Proposition 4.13, lines 1863--1870
 -/
 
-open scoped Matrix BigOperators
+open scoped Matrix BigOperators ComplexOrder
 
 namespace Matrix
 
@@ -177,3 +181,125 @@ theorem sigmaBlockRow_reconstruction
   simp_rw [← Matrix.mul_assoc]
 
 end Matrix
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- Reindex a family of sector maps indexed by the dependent pair
+$(\alpha,q)$ by the copy index used in the vertical direct sum. -/
+def flattenGroupedSectorMap {g : ℕ} (dim : Fin g → ℕ) (mult : Fin g → ℕ)
+    (W : (p : (α : Fin g) × Fin (mult α)) →
+      Matrix (Fin d) (Fin (dim p.1)) ℂ) :
+    (q : Fin (∑ α, mult α)) →
+      Matrix (Fin d) (Fin (verticalCopyDim dim mult q)) ℂ :=
+  fun q ↦ W (finSigmaFinEquiv.symm q)
+
+/-- Orthogonal grouped vertical sectors assemble to the vertical canonical form.
+
+The sector label is the dependent pair $(\alpha,q)$, where $\alpha$ labels a
+normal tensor and $q$ labels one diagonal entry of its positive multiplicity
+matrix.  The two canonical finite-sum equivalences identify these labels and
+their bond indices with the coordinates of the vertical direct sum.
+
+Source: arXiv:1606.00608, Proposition 4.13, lines 1863--1870. -/
+theorem isVerticalCF_of_grouped_orthogonal_sectors
+    (M : MPOTensor d D) {g : ℕ} (dim : Fin g → ℕ) (mult : Fin g → ℕ)
+    (hMult : ∀ α, 0 < mult α)
+    (ω : (α : Fin g) → Fin (mult α) → ℂ)
+    (hω : ∀ α q, (0 : ℂ) < ω α q)
+    (A : (α : Fin g) → MPSTensor (D * D) (dim α))
+    (hBNT : MPSTensor.IsBNT (verticalTensor M) g dim A)
+    (W : (p : (α : Fin g) × Fin (mult α)) →
+      Matrix (Fin d) (Fin (dim p.1)) ℂ)
+    (hiso : ∀ p, (W p)ᴴ * W p = 1)
+    (horth : ∀ p q, p ≠ q → (W p)ᴴ * W q = 0)
+    (hinter : ∀ p v, verticalTensor M v * W p =
+      W p * ((ω p.1 p.2) • A p.1 v))
+    (hreconstruct : ∀ v, verticalTensor M v =
+      ∑ q : Fin (∑ α, mult α),
+        flattenGroupedSectorMap dim mult W q *
+          ((verticalCopyWeights mult ω q) • verticalCopyBlocks dim mult A q v) *
+          (flattenGroupedSectorMap dim mult W q)ᴴ) :
+    IsVerticalCF M := by
+  classical
+  let Wflat : (q : Fin (∑ α, mult α)) →
+      Matrix (Fin d) (Fin (verticalCopyDim dim mult q)) ℂ :=
+    flattenGroupedSectorMap dim mult W
+  let B : (q : Fin (∑ α, mult α)) →
+      MPSTensor (D * D) (verticalCopyDim dim mult q) :=
+    fun q v ↦ verticalCopyWeights mult ω q • verticalCopyBlocks dim mult A q v
+  let rowEquiv : ((q : Fin (∑ α, mult α)) ×
+      Fin (verticalCopyDim dim mult q)) ≃
+      Fin (∑ q : Fin (∑ α, mult α), verticalCopyDim dim mult q) :=
+    finSigmaFinEquiv
+  let U : Matrix
+      (Fin (∑ q : Fin (∑ α, mult α), verticalCopyDim dim mult q)) (Fin d) ℂ :=
+    Matrix.reindex rowEquiv (Equiv.refl _) (Matrix.sigmaBlockRow Wflat)
+  have hisoFlat : ∀ q, (Wflat q)ᴴ * Wflat q = 1 := by
+    intro q
+    exact hiso (finSigmaFinEquiv.symm q)
+  have horthFlat : ∀ q l, q ≠ l → (Wflat q)ᴴ * Wflat l = 0 := by
+    intro q l hql
+    exact horth (finSigmaFinEquiv.symm q) (finSigmaFinEquiv.symm l)
+      (finSigmaFinEquiv.symm.injective.ne hql)
+  have hinterFlat : ∀ q v, verticalTensor M v * Wflat q = Wflat q * B q v := by
+    intro q v
+    exact hinter (finSigmaFinEquiv.symm q) v
+  have hreconstructFlat : ∀ v, verticalTensor M v =
+      ∑ q, Wflat q * B q v * (Wflat q)ᴴ := by
+    intro v
+    exact hreconstruct v
+  refine ⟨g, dim, mult, ω, A, U, hMult, hω, ?_, hBNT, ?_, ?_⟩
+  · dsimp only [U]
+    rw [Matrix.conjTranspose_reindex,
+      show Matrix.reindex rowEquiv (Equiv.refl (Fin d))
+          (Matrix.sigmaBlockRow Wflat) =
+          Matrix.reindexLinearEquiv ℂ ℂ rowEquiv (Equiv.refl _)
+            (Matrix.sigmaBlockRow Wflat) by rfl,
+      show Matrix.reindex (Equiv.refl (Fin d)) rowEquiv
+          (Matrix.sigmaBlockRow Wflat)ᴴ =
+          Matrix.reindexLinearEquiv ℂ ℂ (Equiv.refl _) rowEquiv
+            (Matrix.sigmaBlockRow Wflat)ᴴ by rfl,
+      Matrix.reindexLinearEquiv_mul ℂ ℂ rowEquiv (Equiv.refl _) rowEquiv,
+      Matrix.sigmaBlockRow_isCoisometry Wflat hisoFlat horthFlat,
+      Matrix.reindexLinearEquiv_one]
+  · intro v
+    have hsigma := Matrix.sigmaBlockRow_conjugation
+      (verticalTensor M) B Wflat hisoFlat horthFlat hinterFlat v
+    dsimp only [U]
+    rw [Matrix.conjTranspose_reindex,
+      show Matrix.reindex rowEquiv (Equiv.refl (Fin d))
+          (Matrix.sigmaBlockRow Wflat) =
+          Matrix.reindexLinearEquiv ℂ ℂ rowEquiv (Equiv.refl _)
+            (Matrix.sigmaBlockRow Wflat) by rfl,
+      show verticalTensor M v =
+          Matrix.reindexLinearEquiv ℂ ℂ (Equiv.refl _) (Equiv.refl _)
+            (verticalTensor M v) by rfl,
+      Matrix.reindexLinearEquiv_mul ℂ ℂ rowEquiv (Equiv.refl _) (Equiv.refl _),
+      show Matrix.reindex (Equiv.refl (Fin d)) rowEquiv
+          (Matrix.sigmaBlockRow Wflat)ᴴ =
+          Matrix.reindexLinearEquiv ℂ ℂ (Equiv.refl _) rowEquiv
+            (Matrix.sigmaBlockRow Wflat)ᴴ by rfl,
+      Matrix.reindexLinearEquiv_mul ℂ ℂ rowEquiv (Equiv.refl _) rowEquiv,
+      hsigma]
+    rfl
+  · intro v
+    have hsigma := Matrix.sigmaBlockRow_reconstruction
+      (verticalTensor M) B Wflat hreconstructFlat v
+    rw [hsigma]
+    dsimp only [U]
+    rw [Matrix.conjTranspose_reindex]
+    change (Matrix.sigmaBlockRow Wflat)ᴴ * Matrix.blockDiagonal' (fun q ↦ B q v) *
+        Matrix.sigmaBlockRow Wflat =
+      Matrix.reindexLinearEquiv ℂ ℂ (Equiv.refl _) rowEquiv
+          (Matrix.sigmaBlockRow Wflat)ᴴ *
+        Matrix.reindexLinearEquiv ℂ ℂ rowEquiv rowEquiv
+          (Matrix.blockDiagonal' (fun q ↦ B q v)) *
+        Matrix.reindexLinearEquiv ℂ ℂ rowEquiv (Equiv.refl _)
+          (Matrix.sigmaBlockRow Wflat)
+    rw [Matrix.reindexLinearEquiv_mul ℂ ℂ (Equiv.refl _) rowEquiv rowEquiv,
+      Matrix.reindexLinearEquiv_mul ℂ ℂ (Equiv.refl _) rowEquiv (Equiv.refl _)]
+    rfl
+
+end MPOTensor

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -2444,6 +2444,63 @@
     % Lean adapter: this final reindexing is `finSigmaFinEquiv`.
 \end{proof}
 
+\begin{theorem}[Vertical canonical form from orthogonal grouped sectors]
+    \label{thm:vertical_cf_of_grouped_orthogonal_sectors}
+    \lean{MPOTensor.isVerticalCF_of_grouped_orthogonal_sectors}
+    \leanok
+    \uses{def:vertical_tensor_mpdo, def:vertical_cf_mpdo, def:bnt}
+    Let $\{A_\alpha\}_{\alpha=0}^{g-1}$ be a BNT for the vertically viewed
+    tensor $\widetilde M$.  For each $\alpha$, let $r_\alpha>0$, let
+    $\omega_{\alpha,q}>0$ for $0\leq q<r_\alpha$, and let
+    $W_{\alpha,q}:\C^{D_\alpha}\to\C^d$ satisfy
+    \[
+        W_{\alpha,q}^\dagger W_{\alpha,q}=\Id,
+        \qquad
+        W_{\alpha,q}^\dagger W_{\beta,p}=0
+        \quad\text{if }(\alpha,q)\ne(\beta,p).
+    \]
+    Suppose that, for every vertical letter $v$ and every pair $(\alpha,q)$,
+    \[
+        \widetilde M_v W_{\alpha,q}
+          =W_{\alpha,q}(\omega_{\alpha,q}A_\alpha^v),
+    \]
+    and that the letters have the exact sector decomposition
+    \[
+        \widetilde M_v
+          =\sum_{\alpha=0}^{g-1}\sum_{q=0}^{r_\alpha-1}
+            W_{\alpha,q}(\omega_{\alpha,q}A_\alpha^v)
+            W_{\alpha,q}^\dagger.
+    \]
+    Then $M$ is in vertical canonical form.
+    This is the final finite-dimensional implication in
+    \cite[Proposition~4.13, lines~1863--1870]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:vertical_sector_coisometry}
+    Form the block-row map $U$ from the adjoints
+    $W_{\alpha,q}^\dagger$.  Theorem~\ref{thm:vertical_sector_coisometry}
+    gives
+    \[
+        UU^\dagger=\Id,
+        \qquad
+        U\widetilde M_vU^\dagger
+          =\bigoplus_{\alpha,q}\omega_{\alpha,q}A_\alpha^v,
+    \]
+    together with
+    \[
+        \widetilde M_v
+          =U^\dagger\!\left(
+              \bigoplus_{\alpha,q}\omega_{\alpha,q}A_\alpha^v
+            \right)U.
+    \]
+    Identifying the dependent pairs $(\alpha,q)$ and their bond indices with
+    the standard coordinates of the two finite direct sums gives the required
+    matrix dimensions.  Positivity of the multiplicities and weights, together
+    with the BNT hypothesis, supplies the remaining conditions of vertical
+    canonical form.
+\end{proof}
 \begin{lemma}[A retained vertical phase class exists]
     \label{lem:mpdo_vertical_retained_class_nonempty}
     \notready


### PR DESCRIPTION
## Summary

This change proves that a positive family of orthogonal grouped vertical sectors with exact reconstruction determines the vertical canonical form. The proof forms the block-row coisometry and reindexes the dependent sector coordinates by the canonical finite-sum equivalences.

The theorem is a conditional finite-dimensional implication corresponding to arXiv:1606.00608, Proposition 4.13, lines 1863–1870. It does not assert that the remaining reflected two-sector Lemma L comparison has been established.

## Verification

- targeted Lean compilation of TNLean/MPS/MPDO/VerticalCoisometry.lean
- full lake build in the isolated worktree
- leanblueprint checkdecls
- blueprint PDF and web generation
- reader-facing prose check
- visual inspection of the Chapter 20 theorem page
- proof-integrity token scan

Authored and committed as texra-ai <texra-ai@outlook.com>.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal mathematics (Lean + blueprint); no runtime, auth, or data-path changes. Risk is mainly proof maintenance and dependency on existing matrix reindexing lemmas.
> 
> **Overview**
> Adds the **final finite-dimensional step** of Cirac et al. Proposition 4.13 (lines 1863–1870): from positive grouped orthogonal vertical sectors with exact letter-wise reconstruction, conclude **`IsVerticalCF`**.
> 
> In Lean, introduces **`flattenGroupedSectorMap`** to reindex sector isometries by the vertical direct-sum copy label, then **`MPOTensor.isVerticalCF_of_grouped_orthogonal_sectors`**, which flattens \((\alpha,q)\) data, builds the block-row coisometry **`U`** via **`Matrix.sigmaBlockRow`** and **`finSigmaFinEquiv`**, and discharges the three **`IsVerticalCF`** obligations using the existing **`sigmaBlockRow_*`** matrix lemmas. Opens **`ComplexOrder`** for positivity hypotheses on weights \(\omega\).
> 
> The blueprint gains **Theorem `vertical_cf_of_grouped_orthogonal_sectors`** with a short proof citing **`vertical_sector_coisometry`**, aligned with the new Lean declaration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b881d34bdf92140616c9423267da755ae7c5ea8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->