### PR TITLE
feat(MPS/MPDO): separate marked representative chains

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -382,6 +382,7 @@ import TNLean.MPS.MPDO.PerCopyHorizontalCF
 import TNLean.MPS.MPDO.FirstSiteBlocking
 import TNLean.MPS.MPDO.RepresentativeGroupedLemmaL
 import TNLean.MPS.MPDO.PostBlockedRepresentativeSpan
+import TNLean.MPS.MPDO.RepresentativeGroupedMarkedLemmaL
 import TNLean.MPS.MPDO.HorizontalCFMPVRepresentation
 import TNLean.MPS.MPDO.InvariantProjection
 import TNLean.MPS.MPDO.HorizontalBNT

--- a/TNLean/MPS/MPDO/PostBlockedRepresentativeSpan.lean
+++ b/TNLean/MPS/MPDO/PostBlockedRepresentativeSpan.lean
@@ -201,6 +201,88 @@ theorem eventuallyRepresentativeWordTupleSpan_blockTensor
     (fun j ↦ hBlkPos j (L - selectorLength) hPrefixPos) hSelectors
   simpa [Nat.sub_add_cancel hSelectorLength_le] using hSpan
 
+/-- The representatives of a BNT canonical form have eventual simultaneous word-tuple span.
+
+Choose a common positive block-injectivity length `p`.  Block injectivity propagates to every
+length at least `p`.  The three-block separation argument then gives pairwise separating words
+of length `6 * p`; multiplying them gives one selector for each representative.  Appending a
+long enough block-injective prefix spans the full product of representative matrix algebras.
+
+Source: arXiv:1606.00608, lines 318--344 and Appendix C.3, lines 1848--1858. -/
+theorem eventuallyRepresentativeWordTupleSpan
+    (hCF : IsBNTCanonicalForm P) :
+    P.EventuallyRepresentativeWordTupleSpan := by
+  classical
+  letI : ∀ j : Fin P.basisCount, NeZero (P.basisDim j) :=
+    fun j ↦ ⟨(hCF.basis_dim_pos j).ne'⟩
+  obtain ⟨p, hp, hAtP⟩ := hCF.exists_common_basis_isNBlkInjective
+  have hAtLeastP : ∀ (j : Fin P.basisCount) (n : ℕ), p ≤ n →
+      IsNBlkInjective (P.basis j) n := by
+    intro j n hpn
+    obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_le hpn
+    clear hpn
+    induction k with
+    | zero => simpa using hAtP j
+    | succ k ih =>
+        simpa [Nat.add_assoc] using
+          (isNBlkInjective_succ_of_isNBlkInjective
+            (P.basis j) (Nat.add_pos_left hp k) ih)
+  let L₀ := 2 * p - 1
+  have hBlk0 : ∀ j : Fin P.basisCount, IsNBlkInjective (P.basis j) L₀ := by
+    intro j
+    apply hAtLeastP j
+    dsimp [L₀]
+    omega
+  have hBlk1 : ∀ j : Fin P.basisCount,
+      IsNBlkInjective (P.basis j) (L₀ + 1) := by
+    intro j
+    apply hAtLeastP j
+    dsimp [L₀]
+    omega
+  have hBlk3 : ∀ j : Fin P.basisCount,
+      IsNBlkInjective (P.basis j)
+        ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) := by
+    intro j
+    apply hAtLeastP j
+    dsimp [L₀]
+    omega
+  have hIrr : HasIrreducibleBlocks (d := d) P.basis :=
+    HasIrreducibleBlocks.ofForall hCF.basis_irreducible
+  have hLeft : IsLeftCanonicalBlockFamily (d := d) P.basis :=
+    IsLeftCanonicalBlockFamily.ofForall hCF.basis_left_canonical
+  have hOverlap : HasNormalizedSelfOverlap (d := d) P.basis :=
+    HasNormalizedSelfOverlap.ofForall hCF.basis_normalized_self_overlap
+  have hBlocks : BlocksNotGaugePhaseEquiv (d := d) P.basis :=
+    hCF.basis_distinct
+  have hL₀ : 0 < L₀ := by
+    dsimp [L₀]
+    omega
+  have hSepRaw :=
+    forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_c1
+      P.basis hIrr hLeft hOverlap hBlocks hBlk0 hBlk1 hBlk3 hL₀
+  have hLength : (L₀ + 1) + ((L₀ + 1) + (L₀ + 1)) = 6 * p := by
+    dsimp [L₀]
+    omega
+  have hSep : ∀ k j : Fin P.basisCount, j ≠ k →
+      PairTraceSeparatingAt (P.basis k) (P.basis j) (6 * p) := by
+    intro k j hjk
+    rw [← hLength]
+    exact hSepRaw k j hjk
+  have hPair : HasPairBlockSeparatingWords P.basis (6 * p) :=
+    hasPairBlockSeparatingWords_of_forall_pairTraceSeparatingAt P.basis hSep
+  let selectorLength := (P.basisCount - 1) * (6 * p)
+  have hSelectors : HasBlockSelectorWords P.basis selectorLength := by
+    simpa [selectorLength] using
+      hasBlockSelectorWords_of_pairBlockSeparatingWords P.basis hPair
+  change ∃ L₁ : ℕ, ∀ L ≥ L₁, WordTupleSpanTop P.basis L
+  refine ⟨selectorLength + p, ?_⟩
+  intro L hL
+  have hSelectorLength_le : selectorLength ≤ L := by omega
+  have hPrefix : p ≤ L - selectorLength := by omega
+  have hSpan := wordTupleSpanTop_of_common_blockInjective_of_blockSelectorWords
+    P.basis (fun j ↦ hAtLeastP j (L - selectorLength) hPrefix) hSelectors
+  simpa [Nat.sub_add_cancel hSelectorLength_le] using hSpan
+
 /-- Representative-grouped Lemma L for an already injectively blocked BNT
 canonical form.
 

--- a/TNLean/MPS/MPDO/RepresentativeGroupedMarkedLemmaL.lean
+++ b/TNLean/MPS/MPDO/RepresentativeGroupedMarkedLemmaL.lean
@@ -17,9 +17,15 @@ matrices representative by representative.
 The proof first treats one length at which the simultaneous representative
 word tuples span the product matrix algebra.  A bounded nonvanishing power
 sum then selects a sufficiently large separating length for each
-representative.  The resulting statement is the arbitrary-marked-letter form
-of Lemma L needed for the two marked chains in Figures 7 and 8 of the proof of
-Proposition 4.13 of arXiv:1606.00608, lines 1909--1919.
+representative.
+
+Lemma L in arXiv:1606.00608, lines 1835--1858, is stated for matrices induced
+by physical operators on the first site.  After the closed-chain identity has
+been expanded, however, its separation calculation uses only the matrices in
+the marked slot.  The theorems below record that algebraic extension.  They do
+not assert that the paper states Lemma L for arbitrary marked matrices.  In
+the application to Figures 7 and 8, the marks must still be constructed from
+the actual grouped vertical corners.
 
 ## Main results
 
@@ -51,8 +57,10 @@ same sector-decomposition tail gives
 Representative word-tuple separation and a nonzero coefficient at `j₀` then
 give `C j₀ = E j₀`.
 
-Source: arXiv:1606.00608, Appendix C.3, lines 1848--1858, in the
-arbitrary-marked-letter form used in Proposition 4.13, lines 1909--1919. -/
+This is the algebraic extension of the separation calculation in
+arXiv:1606.00608, Appendix C.3, lines 1848--1858.  The source states the
+physical-insertion case; the unrestricted marked matrices here are an
+auxiliary consequence of the same calculation. -/
 theorem markedTensor_basis_eq_of_trace_agree_of_coeff_ne_zero
     (P : SectorDecomposition d)
     (C E : (j : Fin P.basisCount) → MPSTensor e (P.basisDim j))
@@ -101,8 +109,10 @@ For each representative, the bounded nonvanishing power-sum theorem selects
 a sufficiently large length at which its grouped coefficient is nonzero.
 The fixed-length marked separation theorem then applies.
 
-Source: arXiv:1606.00608, Appendix C.3, lines 1835--1858, in the
-arbitrary-marked-letter form used in Proposition 4.13, lines 1909--1919. -/
+This is the algebraic extension of arXiv:1606.00608, Appendix C.3,
+lines 1835--1858.  The source states the physical-insertion case; the
+unrestricted marked matrices here are an auxiliary consequence of its
+trace-separation proof. -/
 theorem markedTensor_basis_eq_of_trace_agree
     (P : SectorDecomposition d)
     (C E : (j : Fin P.basisCount) → MPSTensor e (P.basisDim j))
@@ -144,11 +154,13 @@ variable {d e : ℕ} {P : SectorDecomposition d}
 on every representative of a BNT canonical form.
 
 The BNT hypotheses give eventual simultaneous representative word-tuple span.
-The representative-grouped arbitrary-marked-letter form of Lemma L then
-separates the marked tensors.
+The algebraic marked-letter extension of the representative-grouped
+separation argument then separates the marked tensors.
 
-Source: arXiv:1606.00608, lines 318--344, Appendix C.3, lines 1835--1858,
-and the marked-chain comparison in Proposition 4.13, lines 1909--1919. -/
+The representative span is from arXiv:1606.00608, lines 318--344, and the
+separation calculation is Appendix C.3, lines 1848--1858.  The source states
+the latter for physical first-site insertions; the arbitrary marked matrices
+are an auxiliary algebraic extension. -/
 theorem markedTensor_basis_eq_of_trace_agree
     (hCF : IsBNTCanonicalForm P)
     (C E : (j : Fin P.basisCount) → MPSTensor e (P.basisDim j))

--- a/TNLean/MPS/MPDO/RepresentativeGroupedMarkedLemmaL.lean
+++ b/TNLean/MPS/MPDO/RepresentativeGroupedMarkedLemmaL.lean
@@ -1,0 +1,162 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.ScalarPowerSumIdentity
+import TNLean.MPS.MPDO.PostBlockedRepresentativeSpan
+
+/-!
+# Representative-grouped separation with an arbitrary marked letter
+
+A marked direct sum permits the first matrix in each representative chain to
+be arbitrary, while every subsequent matrix comes from the unmarked sector
+tensor.  Equality of all such closed marked chains separates the marked
+matrices representative by representative.
+
+The proof first treats one length at which the simultaneous representative
+word tuples span the product matrix algebra.  A bounded nonvanishing power
+sum then selects a sufficiently large separating length for each
+representative.  The resulting statement is the arbitrary-marked-letter form
+of Lemma L needed for the two marked chains in Figures 7 and 8 of the proof of
+Proposition 4.13 of arXiv:1606.00608, lines 1909--1919.
+
+## Main results
+
+* `SectorDecomposition.markedTensor_basis_eq_of_trace_agree_of_coeff_ne_zero`:
+  separation at one length with a nonzero grouped coefficient.
+* `SectorDecomposition.markedTensor_basis_eq_of_trace_agree`: separation under
+  eventual simultaneous representative word-tuple span.
+* `IsBNTCanonicalForm.markedTensor_basis_eq_of_trace_agree`: separation from
+  the BNT canonical-form hypotheses.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.3, lines 1835--1858, and Proposition 4.13, lines 1909--1919.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor.SectorDecomposition
+
+variable {d e : ℕ}
+
+/-- At one separating tail length, a nonzero grouped coefficient identifies
+an arbitrary marked letter on the chosen representative.
+
+For marked families `C` and `E`, equality of their closed chains against the
+same sector-decomposition tail gives
+`P.coeff (L + 1) j • (C j s - E j s) = 0` for every representative `j`.
+Representative word-tuple separation and a nonzero coefficient at `j₀` then
+give `C j₀ = E j₀`.
+
+Source: arXiv:1606.00608, Appendix C.3, lines 1848--1858, in the
+arbitrary-marked-letter form used in Proposition 4.13, lines 1909--1919. -/
+theorem markedTensor_basis_eq_of_trace_agree_of_coeff_ne_zero
+    (P : SectorDecomposition d)
+    (C E : (j : Fin P.basisCount) → MPSTensor e (P.basisDim j))
+    {L : ℕ} (hSpan : P.RepresentativeWordTupleSpanAt L)
+    (hTrace : ∀ (s : Fin e) (w : Fin L → Fin d),
+      Matrix.trace (P.markedTensor C s * evalWord P.toTensor (List.ofFn w)) =
+        Matrix.trace (P.markedTensor E s * evalWord P.toTensor (List.ofFn w)))
+    (j₀ : Fin P.basisCount) (hcoeff : P.coeff (L + 1) j₀ ≠ 0) :
+    C j₀ = E j₀ := by
+  classical
+  funext s
+  let Δ : (j : Fin P.basisCount) →
+      Matrix (Fin (P.basisDim j)) (Fin (P.basisDim j)) ℂ := fun j ↦
+    P.coeff (L + 1) j • (C j s - E j s)
+  have hΔzero : ∀ j, Δ j = 0 := by
+    apply block_matrices_eq_zero_of_wordTupleSpanTop_trace P.basis hSpan Δ
+    intro w
+    have h := hTrace s w
+    rw [P.trace_markedTensor_mul_evalWord C s (List.ofFn w),
+      P.trace_markedTensor_mul_evalWord E s (List.ofFn w)] at h
+    simp only [List.length_ofFn] at h
+    have hsubtr : ∀ j : Fin P.basisCount,
+        Matrix.trace (Δ j * evalWord (P.basis j) (List.ofFn w)) =
+          P.coeff (L + 1) j *
+              Matrix.trace (C j s * evalWord (P.basis j) (List.ofFn w)) -
+            P.coeff (L + 1) j *
+              Matrix.trace (E j s * evalWord (P.basis j) (List.ofFn w)) := by
+      intro j
+      change Matrix.trace
+          ((P.coeff (L + 1) j • (C j s - E j s)) *
+            evalWord (P.basis j) (List.ofFn w)) = _
+      rw [Matrix.smul_mul, Matrix.trace_smul, smul_eq_mul, sub_mul,
+        Matrix.trace_sub, mul_sub]
+    simp_rw [hsubtr]
+    rw [Finset.sum_sub_distrib, sub_eq_zero]
+    exact h
+  have hj := hΔzero j₀
+  have hdiff : C j₀ s - E j₀ s = 0 :=
+    (smul_eq_zero.mp hj).resolve_left hcoeff
+  exact sub_eq_zero.mp hdiff
+
+/-- Equality of all closed marked chains identifies the marked tensor on
+every representative under eventual representative word-tuple separation.
+
+For each representative, the bounded nonvanishing power-sum theorem selects
+a sufficiently large length at which its grouped coefficient is nonzero.
+The fixed-length marked separation theorem then applies.
+
+Source: arXiv:1606.00608, Appendix C.3, lines 1835--1858, in the
+arbitrary-marked-letter form used in Proposition 4.13, lines 1909--1919. -/
+theorem markedTensor_basis_eq_of_trace_agree
+    (P : SectorDecomposition d)
+    (C E : (j : Fin P.basisCount) → MPSTensor e (P.basisDim j))
+    (hSpan : P.EventuallyRepresentativeWordTupleSpan)
+    (hTrace : ∀ (L : ℕ) (s : Fin e) (w : Fin L → Fin d),
+      Matrix.trace (P.markedTensor C s * evalWord P.toTensor (List.ofFn w)) =
+        Matrix.trace (P.markedTensor E s * evalWord P.toTensor (List.ofFn w))) :
+    ∀ j, C j = E j := by
+  classical
+  obtain ⟨L₀, hSpan⟩ := hSpan
+  intro j
+  let M := L₀ + 1
+  obtain ⟨r, hrpos, _hrle, hsum⟩ :=
+    Matrix.exists_sum_pow_ne_zero_of_pos_card
+      (P.copies j) (fun q ↦ (P.weight j q) ^ M) (P.copies_pos j)
+      (fun q ↦ pow_ne_zero M (P.weight_ne_zero j q))
+  let N := M * r
+  have hNpos : 0 < N := Nat.mul_pos (by simp [M]) hrpos
+  have hcoeffN : P.coeff N j ≠ 0 := by
+    change (∑ q : Fin (P.copies j), (P.weight j q) ^ N) ≠ 0
+    simpa only [N, pow_mul] using hsum
+  let L := N - 1
+  have hLadd : L + 1 = N := Nat.sub_add_cancel hNpos
+  have hMleN : M ≤ N := Nat.le_mul_of_pos_right M hrpos
+  have hL₀leL : L₀ ≤ L := by
+    dsimp [L, M] at hMleN ⊢
+    omega
+  apply P.markedTensor_basis_eq_of_trace_agree_of_coeff_ne_zero C E
+    (hSpan L hL₀leL) (hTrace L) j
+  rwa [hLadd]
+
+end MPSTensor.SectorDecomposition
+
+namespace MPSTensor.IsBNTCanonicalForm
+
+variable {d e : ℕ} {P : SectorDecomposition d}
+
+/-- Equality of all closed marked chains identifies arbitrary marked letters
+on every representative of a BNT canonical form.
+
+The BNT hypotheses give eventual simultaneous representative word-tuple span.
+The representative-grouped arbitrary-marked-letter form of Lemma L then
+separates the marked tensors.
+
+Source: arXiv:1606.00608, lines 318--344, Appendix C.3, lines 1835--1858,
+and the marked-chain comparison in Proposition 4.13, lines 1909--1919. -/
+theorem markedTensor_basis_eq_of_trace_agree
+    (hCF : IsBNTCanonicalForm P)
+    (C E : (j : Fin P.basisCount) → MPSTensor e (P.basisDim j))
+    (hTrace : ∀ (L : ℕ) (s : Fin e) (w : Fin L → Fin d),
+      Matrix.trace (P.markedTensor C s * evalWord P.toTensor (List.ofFn w)) =
+        Matrix.trace (P.markedTensor E s * evalWord P.toTensor (List.ofFn w))) :
+    ∀ j, C j = E j := by
+  exact P.markedTensor_basis_eq_of_trace_agree C E
+    hCF.eventuallyRepresentativeWordTupleSpan hTrace
+
+end MPSTensor.IsBNTCanonicalForm

--- a/TNLean/MPS/SharedInfra/SectorDecomposition.lean
+++ b/TNLean/MPS/SharedInfra/SectorDecomposition.lean
@@ -133,6 +133,103 @@ theorem toTensor_eq_toTensorFromBlocks_flat (P : SectorDecomposition d) :
     P.toTensor = toTensorFromBlocks (d := d) (μ := P.flatWeight) P.flatBasis :=
   rfl
 
+/-! ## Direct sums with one marked letter -/
+
+/-- Pull a family of marked representative tensors back to the flattened copy index.
+
+Every copy over a fixed representative carries the same marked matrix.  The copy weight is
+inserted separately by `markedTensor`.
+
+Source: arXiv:1606.00608, Appendix C.3, lines 1835--1858, and the marked chains in the
+proof of Proposition 4.13, lines 1909--1919. -/
+noncomputable def flatMarked {e : ℕ} (P : SectorDecomposition d)
+    (C : (j : Fin P.basisCount) → MPSTensor e (P.basisDim j)) :
+    (s : Fin P.totalCopies) → MPSTensor e (P.flatDim s) :=
+  fun s ↦ C (P.flatIndexEquiv.symm s).1
+
+/-- The weighted direct sum with one arbitrary marked letter in each representative.
+
+If the unmarked sector tensor is
+`Aᵗᵒᵗ = ⊕_(j,q) μ_(j,q) A_j`, then the marked tensor associated with a family
+`C_j` is `Cᵗᵒᵗ = ⊕_(j,q) μ_(j,q) C_j`.  The alphabet indexing the marked matrices
+may differ from the alphabet of the unmarked tail.
+
+Source: arXiv:1606.00608, Appendix C.3, lines 1835--1858, and the marked chains in the
+proof of Proposition 4.13, lines 1909--1919. -/
+noncomputable def markedTensor {e : ℕ} (P : SectorDecomposition d)
+    (C : (j : Fin P.basisCount) → MPSTensor e (P.basisDim j)) :
+    MPSTensor e P.totalDim :=
+  toTensorFromBlocks (d := e) P.flatWeight (P.flatMarked C)
+
+/-- Trace expansion for a weighted direct sum with one marked letter.
+
+For a tail word `w`, all copies over representative `j` combine into the coefficient
+`P.coeff (w.length + 1) j`.  The additional power comes from the weight at the marked
+site.
+
+Source: arXiv:1606.00608, Appendix C.3, lines 1835--1858, and the marked chains in the
+proof of Proposition 4.13, lines 1909--1919. -/
+theorem trace_markedTensor_mul_evalWord {e : ℕ} (P : SectorDecomposition d)
+    (C : (j : Fin P.basisCount) → MPSTensor e (P.basisDim j))
+    (s : Fin e) (w : List (Fin d)) :
+    Matrix.trace (P.markedTensor C s * evalWord P.toTensor w) =
+      ∑ j : Fin P.basisCount, P.coeff (w.length + 1) j *
+        Matrix.trace (C j s * evalWord (P.basis j) w) := by
+  classical
+  rw [markedTensor, SectorDecomposition.toTensor,
+    evalWord_toTensorFromBlocks_eq_reindex_blockDiagonal]
+  rw [toTensorFromBlocks]
+  change Matrix.trace
+      ((Matrix.reindexLinearEquiv ℂ ℂ finSigmaFinEquiv finSigmaFinEquiv)
+          (Matrix.blockDiagonal' fun k ↦
+            P.flatWeight k • P.flatMarked C k s) *
+        (Matrix.reindexLinearEquiv ℂ ℂ finSigmaFinEquiv finSigmaFinEquiv)
+          (Matrix.blockDiagonal' fun k ↦
+            P.flatWeight k ^ w.length • evalWord (P.flatBasis k) w)) = _
+  rw [Matrix.reindexLinearEquiv_mul ℂ ℂ finSigmaFinEquiv
+    finSigmaFinEquiv finSigmaFinEquiv]
+  simp only [Matrix.coe_reindexLinearEquiv]
+  rw [Matrix.trace_reindex, ← Matrix.blockDiagonal'_mul,
+    Matrix.trace_blockDiagonal']
+  calc
+    ∑ i : Fin P.totalCopies,
+        Matrix.trace
+          ((P.flatWeight i • P.flatMarked C i s) *
+            (P.flatWeight i ^ w.length • evalWord (P.flatBasis i) w)) =
+        ∑ i : Fin P.totalCopies, P.flatWeight i ^ (w.length + 1) *
+          Matrix.trace (P.flatMarked C i s * evalWord (P.flatBasis i) w) := by
+      apply Finset.sum_congr rfl
+      intro i _
+      simp only [Matrix.smul_mul, Matrix.mul_smul, Matrix.trace_smul, smul_eq_mul]
+      rw [pow_succ']
+      ring
+    _ = ∑ x : ((j : Fin P.basisCount) × Fin (P.copies j)),
+          P.weight x.1 x.2 ^ (w.length + 1) *
+            Matrix.trace (C x.1 s * evalWord (P.basis x.1) w) := by
+      let f : ((j : Fin P.basisCount) × Fin (P.copies j)) → ℂ :=
+        fun x ↦ P.weight x.1 x.2 ^ (w.length + 1) *
+          Matrix.trace (C x.1 s * evalWord (P.basis x.1) w)
+      let g : Fin P.totalCopies → ℂ := fun i ↦
+        P.flatWeight i ^ (w.length + 1) *
+          Matrix.trace (P.flatMarked C i s * evalWord (P.flatBasis i) w)
+      exact (Fintype.sum_equiv P.flatIndexEquiv f g (fun x ↦ by
+        calc
+          f x = f (P.flatIndexEquiv.symm (P.flatIndexEquiv x)) :=
+            congrArg f (P.flatIndexEquiv.symm_apply_apply x).symm
+          _ = g (P.flatIndexEquiv x) := rfl)).symm
+    _ = ∑ j : Fin P.basisCount, ∑ q : Fin (P.copies j),
+          P.weight j q ^ (w.length + 1) *
+            Matrix.trace (C j s * evalWord (P.basis j) w) := by
+      simpa using Fintype.sum_sigma' (fun j q ↦
+        P.weight j q ^ (w.length + 1) *
+          Matrix.trace (C j s * evalWord (P.basis j) w))
+    _ = ∑ j : Fin P.basisCount, P.coeff (w.length + 1) j *
+          Matrix.trace (C j s * evalWord (P.basis j) w) := by
+      apply Finset.sum_congr rfl
+      intro j _
+      rw [← Finset.sum_mul]
+      rfl
+
 /--
 Intermediate expansion: first sum over the basis index `j`, then over its copies `q`.
 -/

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -383,6 +383,111 @@
     first-site hypothesis to the sector-decomposition tensor.
 \end{proof}
 
+\begin{definition}[Direct sum with one marked letter]
+    \label{def:marked_representative_direct_sum}
+    \lean{MPSTensor.SectorDecomposition.markedTensor}
+    \leanok
+    \uses{def:sector_weight_data}
+    Let
+    \[
+        A_{\mathrm{tot}}^i
+        =\bigoplus_{j=0}^{g-1}\bigoplus_{q=0}^{r_j-1}
+          \mu_{j,q}A_j^i
+    \]
+    be the tensor of a sector decomposition.  Let $s$ range over a second
+    finite alphabet, and for each representative $A_j$ let $C_j^s$ be a
+    matrix on its bond space.  The corresponding direct sum with one marked
+    letter is
+    \[
+        C_{\mathrm{tot}}^s
+        =\bigoplus_{j=0}^{g-1}\bigoplus_{q=0}^{r_j-1}
+          \mu_{j,q}C_j^s.
+    \]
+    The marked alphabet need not coincide with the alphabet of the unmarked
+    tensor.  This is the algebraic form of the marked matrices in the two
+    diagrams of
+    \cite[Proposition~4.13, lines~1909--1919]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{lemma}[Trace expansion with one marked letter]
+    \label{lem:marked_representative_trace_expansion}
+    \lean{MPSTensor.SectorDecomposition.trace_markedTensor_mul_evalWord}
+    \leanok
+    \uses{def:marked_representative_direct_sum, def:sector_weight_data}
+    For every marked index $s$ and every unmarked word $w$,
+    \[
+        \tr\!\left(C_{\mathrm{tot}}^s A_{\mathrm{tot}}^w\right)
+        =\sum_{j=0}^{g-1}c_j^{(|w|+1)}
+          \tr\!\left(C_j^s A_j^w\right),
+        \qquad
+        c_j^{(N)}=\sum_{q=0}^{r_j-1}\mu_{j,q}^N.
+    \]
+    The exponent $|w|+1$ includes the weight at the marked site.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Expand both matrices as direct sums.  Their product is the direct sum of
+    \[
+        \mu_{j,q}^{|w|+1}C_j^sA_j^w.
+    \]
+    Taking the trace and summing first over $q$ gives the stated coefficient
+    $c_j^{(|w|+1)}$.
+\end{proof}
+
+\begin{theorem}[Representative separation with an arbitrary marked letter]
+    \label{thm:representative_grouped_marked_separation}
+    \lean{MPSTensor.SectorDecomposition.markedTensor_basis_eq_of_trace_agree_of_coeff_ne_zero}
+    \lean{MPSTensor.SectorDecomposition.markedTensor_basis_eq_of_trace_agree}
+    \leanok
+    \uses{def:representative_word_tuple_span,
+        def:marked_representative_direct_sum,
+        lem:marked_representative_trace_expansion,
+        cor:nonvanishing_finite_power_sum}
+    Let $(C_j^s)$ and $(E_j^s)$ be two marked families over the same sector
+    decomposition.  Suppose that, for every marked index $s$ and every
+    unmarked word $w$,
+    \[
+        \tr\!\left(C_{\mathrm{tot}}^s A_{\mathrm{tot}}^w\right)
+        =\tr\!\left(E_{\mathrm{tot}}^s A_{\mathrm{tot}}^w\right).
+    \]
+    If representative word-tuple separation holds at length $L$ and
+    $c_{j_0}^{(L+1)}\neq0$, then $C_{j_0}=E_{j_0}$.  Under eventual
+    representative word-tuple separation, one has $C_j=E_j$ for every $j$.
+
+    This is the arbitrary-marked-letter form of Lemma~L used to compare the
+    two marked chains in
+    \cite[Proposition~4.13, lines~1909--1919]{Cirac2016MPDO_arXiv}; the
+    representative grouping is the argument of
+    \cite[Appendix~C.3, lines~1835--1858]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:representative_word_tuple_span,
+        lem:marked_representative_trace_expansion,
+        cor:nonvanishing_finite_power_sum}
+    Fix $s$ and a tail length $L$, and put
+    \[
+        \Delta_j=c_j^{(L+1)}(C_j^s-E_j^s).
+    \]
+    Lemma~\ref{lem:marked_representative_trace_expansion} gives, for every
+    length-$L$ word $w$,
+    \[
+        \sum_{j=0}^{g-1}\tr(\Delta_jA_j^w)=0.
+    \]
+    Representative word-tuple separation implies $\Delta_j=0$ for every
+    $j$.  If $c_{j_0}^{(L+1)}\neq0$, cancellation gives
+    $C_{j_0}^s=E_{j_0}^s$.  Since $s$ was arbitrary,
+    $C_{j_0}=E_{j_0}$.
+
+    Under eventual separation, apply
+    Corollary~\ref{cor:nonvanishing_finite_power_sum} to the nonzero weights
+    above each fixed representative, exactly as in
+    Theorem~\ref{thm:representative_grouped_insert_eq}.  This selects a
+    sufficiently large $L$ with $c_j^{(L+1)}\neq0$ and proves $C_j=E_j$.
+\end{proof}
+
 \begin{definition}[First-site action on a physical block]
     \label{def:first_site_action_physical_blocking}
     \lean{MPSTensor.firstSiteActionOnBlock}
@@ -454,6 +559,7 @@
     \label{thm:postblocked_representative_grouped_insert_eq}
     \lean{MPSTensor.IsBNTCanonicalForm.eventuallyRepresentativeWordTupleSpan_of_basis_injective}
     \lean{MPSTensor.IsBNTCanonicalForm.eventuallyRepresentativeWordTupleSpan_blockTensor}
+    \lean{MPSTensor.IsBNTCanonicalForm.eventuallyRepresentativeWordTupleSpan}
     \lean{MPSTensor.pairTraceSeparatingAt_blockTensor}
     \lean{MPSTensor.IsBNTCanonicalForm.insertedTensor_basis_eq_of_firstSiteActionAgree_of_basis_injective}
     \lean{MPSTensor.IsBNTCanonicalForm.insertedTensor_basis_eq_of_sameMPV₂_firstSiteActionAgree_of_basis_injective}
@@ -488,6 +594,12 @@
     $A_j^{[p]}$ is injective. Then the blocked sector decomposition $P^{[p]}$
     has representative word-tuple separation at every blocked length
     $L\geq 6(g-1)+1$.
+
+    Without changing the physical alphabet, a BNT canonical form also has
+    eventual representative word-tuple separation.  If $p>0$ is a common
+    block-injectivity length, then one may take pairwise separating words of
+    length $6p$, form selectors of length $6p(g-1)$, and append homogeneous
+    words of any length at least $p$.
 
     Finally, the BNT canonical-form hypotheses imply that there is a common
     $L>0$ for which every unblocked representative $A_j$ is $L$-block
@@ -548,6 +660,13 @@
     representatives. The preceding selector argument then applies verbatim
     to $P^{[p]}$.
 
+    The same pairwise equations at original length $6p$ give selectors for
+    the unblocked representatives directly.  For every
+    $L\geq6p(g-1)+p$, the remaining prefix has length at least $p$ and hence
+    spans each full representative matrix algebra.  Concatenating the prefix
+    with the selectors proves eventual representative word-tuple separation
+    before blocking.
+
     For the final assertion, first consider one representative $A_j$.
     Irreducibility and left-canonicality give a positive peripheral period
     $m_j$.  The periodic self-overlap formula and the normalized self-overlap
@@ -570,6 +689,31 @@
     of the first block form a spanning family, so
     Lemma~\ref{lem:first_site_action_physical_blocking} recovers
     $YA_j=ZA_j$ before blocking.
+\end{proof}
+
+\begin{corollary}[Marked-letter separation for a BNT canonical form]
+    \label{cor:bnt_marked_representative_separation}
+    \lean{MPSTensor.IsBNTCanonicalForm.markedTensor_basis_eq_of_trace_agree}
+    \leanok
+    \uses{def:sector_bnt_cf,
+        thm:postblocked_representative_grouped_insert_eq,
+        thm:representative_grouped_marked_separation}
+    Let $(C_j^s)$ and $(E_j^s)$ be two marked families over a BNT canonical
+    form.  If their closed marked chains agree for every marked index $s$ and
+    every unmarked word $w$, then
+    \[
+        C_j^s=E_j^s
+    \]
+    for every representative $j$ and every marked index $s$.
+\end{corollary}
+
+\begin{proof}
+    \leanok
+    \uses{thm:postblocked_representative_grouped_insert_eq,
+        thm:representative_grouped_marked_separation}
+    The BNT canonical-form hypotheses give eventual representative word-tuple
+    separation.  Apply
+    Theorem~\ref{thm:representative_grouped_marked_separation}.
 \end{proof}
 
 \begin{theorem}[Representative and literal reduction from first-site contractions]

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -435,7 +435,7 @@
     $c_j^{(|w|+1)}$.
 \end{proof}
 
-\begin{theorem}[Representative separation with an arbitrary marked letter]
+\begin{theorem}[Algebraic marked-letter extension of representative separation]
     \label{thm:representative_grouped_marked_separation}
     \lean{MPSTensor.SectorDecomposition.markedTensor_basis_eq_of_trace_agree_of_coeff_ne_zero}
     \lean{MPSTensor.SectorDecomposition.markedTensor_basis_eq_of_trace_agree}
@@ -455,11 +455,16 @@
     $c_{j_0}^{(L+1)}\neq0$, then $C_{j_0}=E_{j_0}$.  Under eventual
     representative word-tuple separation, one has $C_j=E_j$ for every $j$.
 
-    This is the arbitrary-marked-letter form of Lemma~L used to compare the
-    two marked chains in
-    \cite[Proposition~4.13, lines~1909--1919]{Cirac2016MPDO_arXiv}; the
-    representative grouping is the argument of
-    \cite[Appendix~C.3, lines~1835--1858]{Cirac2016MPDO_arXiv}.
+    Lemma~L is stated for marks induced by physical operators on the first
+    site.  After its closed-chain identity has been expanded, the separation
+    calculation uses only the matrices in the marked slot.  The theorem is
+    the resulting algebraic extension of
+    \cite[Appendix~C.3, lines~1848--1858]{Cirac2016MPDO_arXiv}; it is not
+    attributed to the paper as a separately stated arbitrary-mark theorem.
+    In the application to
+    \cite[Proposition~4.13, lines~1909--1919]{Cirac2016MPDO_arXiv}, the
+    marked families must still be obtained from the actual grouped vertical
+    corners before this separation theorem is applied.
 \end{theorem}
 
 \begin{proof}


### PR DESCRIPTION
## Summary

This change isolates the trace-separation calculation needed before the two-sector Figure 8 argument.

It adds the weighted direct sum with one marked letter, proves its exact trace expansion, proves eventual simultaneous word-tuple span for unblocked BNT representatives, and deduces equality of two marked families from equality of all closed marked chains.

The result is auxiliary infrastructure for #3897. It does not specialize to reflected MPO tensors, does not assert the Figure 8 Gram-conjugation identity, and does not complete #3897.

## Source scope

Lemma L in arXiv:1606.00608, Appendix C.3, lines 1835–1858, is stated for marks induced by physical operators on the first site. After the closed-chain identity is expanded, the separation calculation in lines 1848–1858 uses only the matrices in the marked slot. This pull request records that algebraic extension; it does not attribute an arbitrary-mark theorem to the paper.

In the later application to Proposition 4.13, lines 1909–1919, the marked families must still be constructed from the actual grouped vertical corners, and the common reflected tail must be eliminated between two sectors before any letterwise conclusion.

## Verification

- `lake env lean TNLean/MPS/MPDO/RepresentativeGroupedMarkedLemmaL.lean`
- `leanblueprint checkdecls`
- reader-facing prose check
- proof-integrity token and axiom audit
- `git diff --check`

No axiom, proof placeholder, or kernel bypass is introduced.
