### PR TITLE
feat(MPS/MPDO): prove retained phase-class nonemptiness

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -392,6 +392,7 @@ import TNLean.MPS.MPDO.StackedLayers
 import TNLean.MPS.MPDO.CyclicProjector
 import TNLean.MPS.MPDO.VerticalSpectral
 import TNLean.MPS.MPDO.VerticalBNT
+import TNLean.MPS.MPDO.RetainedClass
 import TNLean.MPS.MPDO.SectorTrace
 import TNLean.MPS.MPDO.ReflectedMarkedChain
 import TNLean.MPS.MPDO.BiCFDerivation

--- a/TNLean/MPS/MPDO/RetainedClass.lean
+++ b/TNLean/MPS/MPDO/RetainedClass.lean
@@ -1,0 +1,147 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.VerticalBNT
+
+/-!
+# Nonemptiness of the retained vertical phase classes
+
+This file proves that the vertical decomposition of a horizontally canonical
+matrix product density operator contains a nonzero sector.  The literal
+reconstruction of the vertical tensor then shows that the finite partition of
+the retained sectors into matrix-product-vector phase classes is nonempty.
+
+This is the nonemptiness observation used in arXiv:1606.00608, Proposition
+`prop:vertical`, lines 1895--1902.
+
+## Main result
+
+* `IsHorizontalCF.exists_nonempty_verticalBNTGrouping`: a horizontally
+  canonical matrix product density operator has a retained vertical
+  decomposition whose phase-class family is nonempty.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- A tensor in BNT canonical form is nonzero.
+
+The global unit-modulus witness selects a basis block and one of its copies.
+Left canonicity makes that basis tensor nonzero, while the selected copy has a
+nonzero weight. -/
+private theorem bntCanonicalForm_toTensor_ne_zero
+    (P : MPSTensor.SectorDecomposition d)
+    (hP : MPSTensor.IsBNTCanonicalForm P) : P.toTensor ≠ 0 := by
+  classical
+  obtain ⟨j, q, _hq⟩ := hP.weight_unit_exists
+  haveI : NeZero (P.basisDim j) := ⟨(hP.basis_dim_pos j).ne'⟩
+  have hBasis : ∃ i, P.basis j i ≠ 0 := by
+    by_contra hzero
+    push Not at hzero
+    have hsum : ∑ i : Fin d, (P.basis j i)ᴴ * P.basis j i = 0 := by
+      simp [hzero]
+    rw [hP.basis_left_canonical j] at hsum
+    exact one_ne_zero hsum
+  obtain ⟨i, hi⟩ := hBasis
+  let s : Fin P.totalCopies := P.flatIndexEquiv ⟨j, q⟩
+  have hs : P.flatIndexEquiv.symm s = ⟨j, q⟩ :=
+    P.flatIndexEquiv.symm_apply_apply ⟨j, q⟩
+  have hflat : P.flatBasis s i ≠ 0 := by
+    change P.basis (P.flatIndexEquiv.symm s).1 i ≠ 0
+    rw [hs]
+    exact hi
+  obtain ⟨a, b, hab⟩ : ∃ a b, P.flatBasis s i a b ≠ 0 := by
+    by_contra hentry
+    push Not at hentry
+    apply hflat
+    ext a b
+    exact hentry a b
+  intro hzero
+  have hentry := congrFun (congrFun (congrFun hzero i)
+    (finSigmaFinEquiv ⟨s, a⟩)) (finSigmaFinEquiv ⟨s, b⟩)
+  have hweight : P.flatWeight s ≠ 0 := by
+    change P.weight (P.flatIndexEquiv.symm s).1 (P.flatIndexEquiv.symm s).2 ≠ 0
+    rw [hs]
+    exact P.weight_ne_zero j q
+  apply hab
+  have : P.flatWeight s * P.flatBasis s i a b = 0 := by
+    simpa [MPSTensor.SectorDecomposition.toTensor, MPSTensor.toTensorFromBlocks,
+      Matrix.reindex_apply, Matrix.blockDiagonal'_apply_eq] using hentry.symm
+  exact (mul_eq_zero.mp this).resolve_left hweight
+
+/-- The vertical tensor of a horizontally canonical MPO tensor is nonzero.
+
+Source: arXiv:1606.00608, canonical form at lines 237--246 and Proposition
+`prop:vertical`, lines 1895--1902. -/
+private theorem IsHorizontalCF.verticalTensor_ne_zero
+    (M : MPOTensor d D) (hHorizontal : IsHorizontalCF M) : verticalTensor M ≠ 0 := by
+  obtain ⟨S, hCF, hTotal, X, hX⟩ := hHorizontal
+  subst D
+  have hSTensor : S.toTensor ≠ 0 := bntCanonicalForm_toTensor_ne_zero S hCF
+  intro hVertical
+  apply hSTensor
+  have hMzero : M.toMPSTensor = 0 := by
+    funext ij
+    apply Matrix.ext
+    intro a b
+    have hz := congrFun (congrFun (congrFun hVertical
+      (finProdFinEquiv (a, b))) ij.divNat) ij.modNat
+    simpa [verticalTensor, toMPSTensor,
+      MPSTensor.finProdFinEquiv_divNat, MPSTensor.finProdFinEquiv_modNat] using hz
+  let G := MPSTensor.globalGaugeOfBlocks X
+  have hConj : ∀ i, (G : Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ) *
+      S.toTensor i * (↑(G⁻¹) : Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ) = 0 := by
+    intro i
+    have hi := hX i
+    rw [hMzero] at hi
+    simpa using hi.symm
+  funext i
+  have hi := hConj i
+  have hcancel := congrArg
+    (fun Z : Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ ↦
+      (↑(G⁻¹) : Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ) * Z *
+        (G : Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ)) hi
+  simpa [Matrix.mul_assoc] using hcancel
+
+/-- A horizontally canonical matrix product density operator has a nonempty
+family of retained vertical phase classes.
+
+The retained normal sectors reconstruct every vertical letter.  Since the
+vertical tensor is nonzero, the sector index set is nonempty.  Its partition
+into matrix-product-vector phase classes is therefore nonempty as well.
+
+Source: arXiv:1606.00608, Proposition `prop:vertical`, lines 1895--1902. -/
+theorem IsHorizontalCF.exists_nonempty_verticalBNTGrouping
+    (M : MPOTensor d D) (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M) :
+    ∃ (r : ℕ) (dim : Fin r → ℕ) (μ : Fin r → ℂ)
+      (blocks : (k : Fin r) → MPSTensor (D * D) (dim k))
+      (V : (k : Fin r) → Matrix (Fin d) (Fin (dim k)) ℂ),
+      (∀ k, 0 < dim k) ∧
+      (∀ k, (0 : ℂ) < μ k) ∧
+      (∀ k, MPSTensor.IsNormalTensor (blocks k)) ∧
+      (∀ k, (V k)ᴴ * V k = 1) ∧
+      (∀ k l, k ≠ l → (V k)ᴴ * V l = 0) ∧
+      (∀ v, verticalTensor M v = ∑ k, V k * (μ k • blocks k v) * (V k)ᴴ) ∧
+      0 < (MPSTensor.mpvPhaseClassData blocks).g := by
+  classical
+  obtain ⟨r, dim, μ, blocks, V, hdim, hμ, hnormal, hiso, horth,
+    _hint, _hintStar, _hcorner, hreconstruct, _hgrouped⟩ :=
+    hHorizontal.exists_verticalBNTGrouping_with_isometry M hM
+  have hr : 0 < r := by
+    by_contra hr
+    have hrzero : r = 0 := Nat.eq_zero_of_not_pos hr
+    apply hHorizontal.verticalTensor_ne_zero M
+    funext v
+    rw [hreconstruct v]
+    subst r
+    simp
+  refine ⟨r, dim, μ, blocks, V, hdim, hμ, hnormal, hiso, horth,
+    hreconstruct, ?_⟩
+  exact (MPSTensor.mpvPhaseClassData blocks).g_pos_of_r_pos hr
+
+end MPOTensor

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -2652,9 +2652,11 @@
 \end{proof}
 \begin{lemma}[A retained vertical phase class exists]
     \label{lem:mpdo_vertical_retained_class_nonempty}
-    \notready
+    \lean{MPOTensor.IsHorizontalCF.exists_nonempty_verticalBNTGrouping}
+    \leanok
     \uses{def:horizontal_cf_mpdo,
-        thm:mpdo_vertical_bnt_grouping_with_isometries}
+        thm:mpdo_vertical_bnt_grouping_with_isometries,
+        lem:mpv_phase_class_nonempty}
     Under the hypotheses of
     Theorem~\ref{thm:mpdo_vertical_bnt_grouping_with_isometries}, the retained
     vertical decomposition has at least one sector and hence at least one
@@ -2662,6 +2664,7 @@
 \end{lemma}
 
 \begin{proof}
+    \leanok
     The unit-modulus weight witness in the horizontal canonical form, together
     with left canonicity of its representative, makes the doubled-index tensor
     nonzero.  Hence its vertical reshaping $\widetilde M$ is nonzero.  If the


### PR DESCRIPTION
## Summary

- proves that the vertical tensor of a horizontally canonical MPO tensor is nonzero
- deduces that the retained vertical BNT decomposition contains a sector
- applies the finite phase-class enumeration to obtain a nonempty retained phase-class family
- marks the corresponding Chapter 21 blueprint lemma as formalized

## Mathematical source

This is the nonemptiness observation used in arXiv:1606.00608, Proposition `prop:vertical`, lines 1895–1902. The theorem retains exactly the horizontal canonical-form and MPDO hypotheses used by the vertical BNT grouping theorem.

## Verification

- `lake env lean TNLean/MPS/MPDO/RetainedClass.lean`
- `lake build TNLean`
- `cd blueprint && leanblueprint checkdecls`
- `cd blueprint && leanblueprint pdf`
- reader-facing prose check
- proof-integrity scan
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New Lean proofs and blueprint linkage only; no auth, runtime, or API surface changes beyond library imports.
> 
> **Overview**
> Adds **`TNLean/MPS/MPDO/RetainedClass.lean`** and wires it into the root import list. The main export is **`IsHorizontalCF.exists_nonempty_verticalBNTGrouping`**: from horizontal canonical form and **`IsMPDO`**, it extends the existing vertical BNT grouping data with **`0 < (mpvPhaseClassData blocks).g`**, so the retained vertical decomposition has at least one MPV phase class.
> 
> The proof chain is new: BNT canonical doubled-index tensors are shown nonzero (unit-modulus weight + left canonicity), hence **`verticalTensor`** is nonzero for horizontal CF; if the sector count **`r`** were zero, literal reconstruction would force **`verticalTensor = 0`**, a contradiction. **`g_pos_of_r_pos`** then turns **`0 < r`** into a nonempty phase-class partition.
> 
> The blueprint lemma **`lem:mpdo_vertical_retained_class_nonempty`** is marked **`leanok`** and linked to that theorem (with **`lem:mpv_phase_class_nonempty`** in **`uses`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6cc39e82d376996087e4b8135979c8536661188. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->