### PR TITLE
style(blueprint): distinguish bent legs from closures

### DIFF
--- a/blueprint/src/macros/tn_core.tex
+++ b/blueprint/src/macros/tn_core.tex
@@ -43,8 +43,12 @@
     tn contraction/.style={tn leg},
     tn phys contraction/.style={tn phys leg},
     tn purification contraction/.style={tn phys contraction},
+    % A bent leg is an ordinary open contraction whose route contains a
+    % corner.  It is not a trace or periodic closure.
+    tn bent leg/.style={tn leg, rounded corners=3pt},
     tn virtual closure/.style={tn contraction, rounded corners=3pt},
     tn physical closure/.style={tn phys contraction, rounded corners=3pt},
+    tn factor boundary/.style={tn leg, rounded corners=2pt},
     tn grouping boundary/.style={densely dashed, rounded corners=2pt},
     tn basis change/.style={densely dashed, line width=0.4pt},
     tn periodic identification/.style={

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -205,12 +205,12 @@
         \TN@subspinlink{tzeroOutL}{tzeroOutR}
 
         \node[anchor=east] at (-3.72,-1.18) {$\mathcal S_2:$};
-        \draw[rounded corners=2pt] (-3.42,-1.72) rectangle (-1.38,-0.64);
+        \draw[tn factor boundary] (-3.42,-1.72) rectangle (-1.38,-0.64);
         \TN@subspinbox{sTwoLk}{(-2.90,-1.18)}{l_k}
         \TN@subspinbox{sTwoRh}{(-1.90,-1.18)}{r_h}
         \TN@subspinlink{sTwoLk}{sTwoRh}
         \node at (-1.00,-1.18) {$\otimes$};
-        \draw[rounded corners=2pt] (-0.60,-1.72) rectangle (1.44,-0.64);
+        \draw[tn factor boundary] (-0.60,-1.72) rectangle (1.44,-0.64);
         \TN@subspinbox{sTwoRk}{(-0.08,-1.18)}{r_k}
         \TN@subspinbox{sTwoLh}{(0.92,-1.18)}{l_h}
         \TN@subspinlink{sTwoRk}{sTwoLh}
@@ -256,12 +256,12 @@
         \TN@subspinlink{szeroOutL}{szeroOutR}
 
         \node[anchor=east] at (-4.70,-1.35) {$\mathcal T_2:$};
-        \draw[rounded corners=2pt] (-4.37,-1.90) rectangle (-2.33,-0.80);
+        \draw[tn factor boundary] (-4.37,-1.90) rectangle (-2.33,-0.80);
         \TN@subspinbox{tTwoLk}{(-3.85,-1.35)}{l_k}
         \TN@subspinbox{tTwoRh}{(-2.85,-1.35)}{r_h}
         \TN@subspinlink{tTwoLk}{tTwoRh}
         \node at (-1.96,-1.35) {$\otimes$};
-        \draw[rounded corners=2pt] (-1.55,-1.90) rectangle (2.42,-0.80);
+        \draw[tn factor boundary] (-1.55,-1.90) rectangle (2.42,-0.80);
         \TN@subspinbox{tTwoRk}{(-1.03,-1.35)}{r_k}
         \TN@subspinbox{tTwoLl}{(-0.03,-1.35)}{l_l}
         \TN@subspinbox{tTwoRl}{(0.97,-1.35)}{r_l}
@@ -641,7 +641,7 @@
             {$\operatorname{reindex}_{\Phi_N}\!M_N(\widetilde{\cal K})$};
         \node at (-1.93,0) {$=$};
         \node at (-1.28,0) {$\displaystyle\bigoplus_{k_0,\ldots,k_{N-1}}$};
-        \draw[rounded corners=2pt] (-0.45,-0.58) rectangle (4.22,0.58);
+        \draw[tn factor boundary] (-0.45,-0.58) rectangle (4.22,0.58);
         \node[tn tensor box, minimum width=1.08cm, minimum height=0.44cm,
             inner sep=1pt] (tnEtaZero) at (0.30,0) {$\eta_{k_0,k_1}$};
         \node at (1.10,0) {$\otimes$};
@@ -2022,9 +2022,9 @@
         \TN@opdotabove{icfXi}{(5.40,0)}{X^{-1}}
         \draw[tn leg] (icfX.west) -- ++(-0.55,0);
         \draw[tn leg] (icfX.east) -- (icfL.west);
-        \draw[tn leg, rounded corners=2pt] (icfL.east)
+        \draw[tn bent leg] (icfL.east)
         -| ($(icfU.south)+(-0.14,0)$);
-        \draw[tn leg, rounded corners=2pt] ($(icfU.south)+(0.14,0)$)
+        \draw[tn bent leg] ($(icfU.south)+(0.14,0)$)
         |- (icfXi.west);
         \draw[tn leg] (icfXi.east) -- ++(0.55,0);
         \draw[tn phys leg] (icfU.north) -- ++(0,0.34);
@@ -2051,9 +2051,9 @@
         \TN@opdotabove{icbXi}{(5.40,0)}{X^{-1}}
         \draw[tn leg] (icbX.west) -- ++(-0.55,0);
         \draw[tn leg] (icbX.east) -- (icbL.west);
-        \draw[tn leg, rounded corners=2pt] (icbL.east)
+        \draw[tn bent leg] (icbL.east)
         -| ($(icbU.south)+(-0.14,0)$);
-        \draw[tn leg, rounded corners=2pt] ($(icbU.south)+(0.14,0)$)
+        \draw[tn bent leg] ($(icbU.south)+(0.14,0)$)
         |- (icbXi.west);
         \draw[tn leg] (icbXi.east) -- ++(0.55,0);
         \draw[tn phys leg] (icbU.north) -- ++(0,0.34);
@@ -2301,7 +2301,7 @@
         \node[anchor=east] at (1.86,-1.10) {$j$};
         \node[anchor=east] at (1.86,-1.50) {$q$};
         \draw[tn leg] (hcfX.south) -- (2.55,-1.50);
-        \draw[tn leg, rounded corners=2pt]
+        \draw[tn bent leg]
         (hcfC.center) -- (4.15,-0.40) -- (4.15,-1.10);
         \draw[tn leg] (hcfXi.south) -- (4.95,-1.50);
         \fill (2.55,-1.10) circle (0.05);
@@ -2364,9 +2364,9 @@
             \TN@opdotabove{bijPXi}{(2.95,0)}{X^{-1}}
             \draw[tn leg] (bijPX.west) -- ++(-0.50,0);
             \draw[tn leg] (bijPXi.east) -- ++(0.50,0);
-            \draw[tn virtual closure]
+            \draw[tn bent leg]
             (bijPX.east) -- (1.05,0) -- (1.05,1.00) -- (1.35,1.00);
-            \draw[tn virtual closure]
+            \draw[tn bent leg]
             (bijPXi.west) -- (2.45,0) -- (2.45,1.00) -- (2.15,1.00);
             \draw[tn leg] (1.75,1.50) -- (1.75,-1.10);
             \draw[tn leg] (0,-1.10) -- (3.50,-1.10);
@@ -2392,9 +2392,9 @@
         \TN@tensordot{irI}{(0,0)}
         \TN@tensordot{irB}{(0,-1.05)}
         \draw[tn phys leg] (irT.north) -- ++(0,0.45);
-        \draw[tn virtual closure]
+        \draw[tn bent leg]
         (irI.west) -- ++(-0.74,0) -- (-0.82,1.05) -- (irT.west);
-        \draw[tn virtual closure]
+        \draw[tn bent leg]
         (irI.east) -- ++(0.74,0) -- (0.82,1.05) -- (irT.east);
         \draw[tn phys leg] (irI.south) -- (irB.north);
         \TN@leftleg{irB}{0.60}

--- a/docs/tn_diagram_grammar.md
+++ b/docs/tn_diagram_grammar.md
@@ -38,10 +38,14 @@ by a diagram before reading the surrounding proof.
   physical legs, or by omitting the external physical legs only when the
   surrounding formula states the contraction, for example in a transfer map or
   an overlap.
-- Contracted indices are drawn with solid strokes. A one-dimensional periodic
-  trace is a rounded solid closure. Dashed strokes are reserved for grouping
-  boundaries, changes of multiplicity basis, and an explicitly identified
-  boundary of a periodic lattice; a purification contraction is not dashed.
+- Contracted indices are drawn with solid strokes. An open contraction routed
+  around another glyph uses the shared bent-leg style; it is not a closure
+  merely because its path bends. A one-dimensional periodic trace is a rounded
+  solid closure. Solid rounded rectangles around tensor-product factors are
+  factor boundaries, distinct from dashed grouping boundaries. Dashed strokes
+  are reserved for grouping boundaries, changes of multiplicity basis, and an
+  explicitly identified boundary of a periodic lattice; a purification
+  contraction is not dashed.
 
 ## Blocks, Regions, and Labels
 


### PR DESCRIPTION
## Summary

- introduce a named style for open bent contraction legs, distinct from trace and periodic closures
- introduce a named solid factor-boundary style for tensor-product factors
- replace the remaining local bent-leg and factor-boundary options in the tensor-network diagrams
- correct the open paths identified in the late review of #3902, including the block-injective inverse and inverse-recovery diagrams
- record both distinctions in the tensor-network diagram grammar

## Validation

- `PYTHONPATH=Packages python3 Packages/tn_diagrams.py --check --check-peps-usage --smoke-render`
- `cd blueprint && leanblueprint pdf` (550 pages)
- `git diff --check`

Follow-up to #3902.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and TikZ styling only; no runtime logic or formal proof changes.
> 
> **Overview**
> This PR tightens the blueprint tensor-network **stroke vocabulary** so open routed contractions and tensor-product boxes are not read as trace closures.
> 
> **New TikZ styles** in `tn_core.tex`: `tn bent leg` (solid open leg with a corner) and `tn factor boundary` (solid rounded rectangle around ⊗ factors), with comments separating them from `tn virtual closure` / grouping boundaries.
> 
> **Diagram updates** in `tn_print.tex` swap ad-hoc `rounded corners` draws for `tn factor boundary` on MPDO trace/shift and sector-adapted decompositions, and replace mistaken `tn virtual closure` (or `tn leg` + rounded corners) with `tn bent leg` on isometry canonical forms, horizontal canonical form, block-injective inverse, and inverse-recovery figures from the #3902 follow-up review.
> 
> **Grammar** in `docs/tn_diagram_grammar.md` documents bent legs vs closures and factor boundaries vs dashed grouping boxes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0eaad1fcd62822191afce46bfd388a0e7e18c0e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->