### PR TITLE
feat(MPS/MPDO): prove pairwise Figure 8 Gram identity

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -396,6 +396,7 @@ import TNLean.MPS.MPDO.VerticalBNT
 import TNLean.MPS.MPDO.RetainedClass
 import TNLean.MPS.MPDO.SectorTrace
 import TNLean.MPS.MPDO.ReflectedMarkedChain
+import TNLean.MPS.MPDO.FigureEightPairwise
 import TNLean.MPS.MPDO.BiCFDerivation
 import TNLean.MPS.MPDO.ZCL
 import TNLean.MPS.MPDO.RFP

--- a/TNLean/MPS/MPDO/FigureEightPairwise.lean
+++ b/TNLean/MPS/MPDO/FigureEightPairwise.lean
@@ -1,0 +1,380 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.LinearMarkedTensor
+import TNLean.MPS.MPDO.ReflectedMarkedChain
+
+/-!
+# Pairwise Gram comparison for vertical corners
+
+Hermiticity gives the reflected marked-chain identity of Figure 7 separately
+for each vertical corner.  Conjugating its open indices by the adjoint of the
+vertical gauge identifies the resulting left side with the Gram-dressed
+vertical tensor, while the right side becomes the reflected adjoint of the
+common representative.  Consequently two corners of the same representative
+have equal marked chains after Gram dressing.
+
+The final separation uses only marks in the span of the physical letters of
+the horizontal tensor.  The corner equations give the required coefficient
+families explicitly, and horizontal canonical form separates them.
+
+## Main results
+
+* `IsMPDO.markedChainCoefficient_gramDressing_eq_reflectedAdjoint`: the
+  Gram-dressed chain of one corner has the common reflected chain.
+* `IsHorizontalCF.gramDressing_eq_of_two_grouped_corners`: two grouped
+  corners of a common vertical representative have equal Gram dressings.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Proposition 4.13, Figures 7--8 and lines 1909--1919.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+namespace MPOTensor
+
+variable {d D n : ℕ}
+
+/-- Multiply every vertical letter on its two virtual sides. -/
+def bondMul (P : Matrix (Fin n) (Fin n) ℂ) (A : MPSTensor (D * D) n)
+    (Q : Matrix (Fin n) (Fin n) ℂ) : MPSTensor (D * D) n :=
+  fun v ↦ P * A v * Q
+
+/-- Conjugation of a vertical tensor by the Gram matrix of an invertible
+gauge.
+
+This is the tensor appearing in the second diagram of arXiv:1606.00608,
+Proposition 4.13, lines 1914--1919. -/
+noncomputable def gramDressing (X : GL (Fin n) ℂ) (A : MPSTensor (D * D) n) :
+    MPSTensor (D * D) n :=
+  fun v ↦
+    ((X : Matrix (Fin n) (Fin n) ℂ)ᴴ *
+        (X : Matrix (Fin n) (Fin n) ℂ)) * A v *
+      (((X : Matrix (Fin n) (Fin n) ℂ)ᴴ *
+        (X : Matrix (Fin n) (Fin n) ℂ))⁻¹)
+
+/-- Multiplication on the open virtual indices is a finite linear
+combination of marked horizontal slices. -/
+theorem horizontalSlice_bondMul
+    (P Q : Matrix (Fin n) (Fin n) ℂ) (A : MPSTensor (D * D) n)
+    (r s : Fin n) :
+    horizontalSlice (bondMul P A Q) r s =
+      ∑ p : Fin n, ∑ q : Fin n,
+        (P r p * Q q s) • horizontalSlice A p q := by
+  ext a b
+  simp only [horizontalSlice, bondMul, Matrix.mul_apply, Matrix.sum_apply,
+    Matrix.smul_apply, smul_eq_mul]
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro p _
+  rw [Finset.sum_mul]
+  apply Finset.sum_congr rfl
+  intro q _
+  ring
+
+/-- Multiplication on the open virtual indices gives the corresponding
+finite linear combination of marked-chain coefficients. -/
+theorem markedChainCoefficient_bondMul
+    (P Q : Matrix (Fin n) (Fin n) ℂ) (A : MPSTensor (D * D) n)
+    (M : MPOTensor d D) (r s : Fin n) (σs τs : List (Fin d)) :
+    markedChainCoefficient (bondMul P A Q) M r s σs τs =
+      ∑ p : Fin n, ∑ q : Fin n,
+        P r p * markedChainCoefficient A M p q σs τs * Q q s := by
+  simp_rw [markedChainCoefficient]
+  rw [horizontalSlice_bondMul, Finset.sum_mul,
+    Matrix.trace_sum]
+  simp_rw [Finset.sum_mul, Matrix.trace_sum, Matrix.smul_mul,
+    Matrix.trace_smul, smul_eq_mul]
+  apply Finset.sum_congr rfl
+  intro p _
+  apply Finset.sum_congr rfl
+  intro q _
+  ring
+
+/-- A pointwise equality of marked chains is preserved by common
+multiplication on their open virtual indices. -/
+theorem markedChainCoefficient_bondMul_eq_of_eq
+    (P Q : Matrix (Fin n) (Fin n) ℂ)
+    (A B : MPSTensor (D * D) n) (M N : MPOTensor d D)
+    (r s : Fin n) (σs τs σs' τs' : List (Fin d))
+    (h : ∀ p q : Fin n,
+      markedChainCoefficient A M p q σs τs =
+        markedChainCoefficient B N p q σs' τs') :
+    markedChainCoefficient (bondMul P A Q) M r s σs τs =
+      markedChainCoefficient (bondMul P B Q) N r s σs' τs' := by
+  rw [markedChainCoefficient_bondMul, markedChainCoefficient_bondMul]
+  simp_rw [h]
+
+/-- The marked chain of a Gram-dressed vertical corner has a reflected form
+which is independent of the corner gauge.
+
+The proof conjugates the two open indices in the reflected Figure 7 identity
+by $X^\dagger$.  On the original side this produces
+$X^\dagger X A^v (X^\dagger X)^{-1}$; on the reflected side the two gauge
+factors cancel.  This is the common right side used in Figure 8 of
+arXiv:1606.00608, Proposition 4.13, lines 1909--1919. -/
+theorem IsMPDO.markedChainCoefficient_gramDressing_eq_reflectedAdjoint
+    {M : MPOTensor d D} (hM : IsMPDO M)
+    (A : MPSTensor (D * D) n) (V : Matrix (Fin d) (Fin n) ℂ)
+    (X : GL (Fin n) ℂ) (c : ℂ) (hc : (0 : ℂ) < c)
+    (hcorner : ∀ v,
+      Vᴴ * verticalTensor M v * V =
+        c • ((X : Matrix (Fin n) (Fin n) ℂ) * A v *
+          (((X)⁻¹ : GL (Fin n) ℂ) : Matrix (Fin n) (Fin n) ℂ)))
+    (N : ℕ) (r s : Fin n) (σ τ : Fin N → Fin d) :
+    markedChainCoefficient (gramDressing X A) M r s
+        (List.ofFn σ) (List.ofFn τ) =
+      markedChainCoefficient (reflectedAdjoint A) (MPOTensor.adjointTensor M) r s
+        (List.ofFn σ).reverse (List.ofFn τ).reverse := by
+  let Xm : Matrix (Fin n) (Fin n) ℂ := X
+  let Xi : Matrix (Fin n) (Fin n) ℂ :=
+    (((X)⁻¹ : GL (Fin n) ℂ) : Matrix (Fin n) (Fin n) ℂ)
+  let B : MPSTensor (D * D) n := bondMul Xm A Xi
+  have hFigure : ∀ p q : Fin n,
+      markedChainCoefficient B M p q (List.ofFn σ) (List.ofFn τ) =
+        markedChainCoefficient (reflectedAdjoint B) (MPOTensor.adjointTensor M) p q
+          (List.ofFn σ).reverse (List.ofFn τ).reverse := by
+    intro p q
+    apply hM.markedChainCoefficient_eq_reflectedAdjoint B V c hc
+    intro v
+    exact hcorner v
+  have hCov := markedChainCoefficient_bondMul_eq_of_eq Xmᴴ Xiᴴ
+    B (reflectedAdjoint B) M (MPOTensor.adjointTensor M) r s
+    (List.ofFn σ) (List.ofFn τ)
+    (List.ofFn σ).reverse (List.ofFn τ).reverse hFigure
+  have hLeft : bondMul Xmᴴ B Xiᴴ = gramDressing X A := by
+    funext v
+    dsimp only [B, Xm, Xi, bondMul, gramDressing]
+    rw [Matrix.coe_units_inv, Matrix.mul_inv_rev,
+      Matrix.conjTranspose_nonsing_inv]
+    simp only [Matrix.mul_assoc]
+  have hRight : bondMul Xmᴴ (reflectedAdjoint B) Xiᴴ =
+      reflectedAdjoint A := by
+    funext v
+    dsimp only [B, Xm, Xi, bondMul, reflectedAdjoint]
+    rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_mul,
+      Matrix.coe_units_inv]
+    simp only [Matrix.mul_assoc, ← Matrix.conjTranspose_mul,
+      ← Matrix.coe_units_inv, Units.inv_mul, Matrix.mul_one]
+    rw [← Matrix.mul_assoc, ← Units.val_mul]
+    have hXX : X⁻¹ * X = (1 : GL (Fin n) ℂ) := inv_mul_cancel X
+    rw [hXX, Units.val_one, Matrix.one_mul]
+  rw [hLeft, hRight] at hCov
+  exact hCov
+
+/-- Two grouped corners of the same vertical representative have identical
+Gram-dressed marked chains.
+
+Both sides are identified with the reflected marked chain of the common
+representative.  This is the pairwise use of Figures 7--8 in
+arXiv:1606.00608, Proposition 4.13, lines 1909--1919. -/
+theorem IsMPDO.markedChainCoefficient_gramDressing_eq_of_two_corners
+    {M : MPOTensor d D} (hM : IsMPDO M)
+    (A : MPSTensor (D * D) n)
+    (VX VY : Matrix (Fin d) (Fin n) ℂ) (X Y : GL (Fin n) ℂ)
+    (cX cY : ℂ) (hcX : (0 : ℂ) < cX) (hcY : (0 : ℂ) < cY)
+    (hcornerX : ∀ v,
+      VXᴴ * verticalTensor M v * VX =
+        cX • ((X : Matrix (Fin n) (Fin n) ℂ) * A v *
+          (((X)⁻¹ : GL (Fin n) ℂ) : Matrix (Fin n) (Fin n) ℂ)))
+    (hcornerY : ∀ v,
+      VYᴴ * verticalTensor M v * VY =
+        cY • ((Y : Matrix (Fin n) (Fin n) ℂ) * A v *
+          (((Y)⁻¹ : GL (Fin n) ℂ) : Matrix (Fin n) (Fin n) ℂ)))
+    (N : ℕ) (r s : Fin n) (σ τ : Fin N → Fin d) :
+    markedChainCoefficient (gramDressing X A) M r s
+        (List.ofFn σ) (List.ofFn τ) =
+      markedChainCoefficient (gramDressing Y A) M r s
+        (List.ofFn σ) (List.ofFn τ) := by
+  exact (hM.markedChainCoefficient_gramDressing_eq_reflectedAdjoint
+    A VX X cX hcX hcornerX N r s σ τ).trans
+      (hM.markedChainCoefficient_gramDressing_eq_reflectedAdjoint
+        A VY Y cY hcY hcornerY N r s σ τ).symm
+
+/-- A two-sided physical compression gives a linear combination of the
+physical letters after horizontal slicing. -/
+theorem horizontalSlice_twoSidedCompression
+    (M : MPOTensor d D) (L R : Matrix (Fin d) (Fin n) ℂ) (r s : Fin n) :
+    horizontalSlice (fun v ↦ Lᴴ * verticalTensor M v * R) r s =
+      ∑ i : Fin d, ∑ j : Fin d,
+        (star (L i r) * R j s) • M i j := by
+  ext a b
+  simp only [horizontalSlice, Matrix.mul_apply, Matrix.conjTranspose_apply,
+    verticalTensor_finProdFinEquiv, Matrix.sum_apply, Matrix.smul_apply,
+    smul_eq_mul]
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro i _
+  rw [Finset.sum_mul]
+  apply Finset.sum_congr rfl
+  intro j _
+  ring
+
+/-- Coefficients expressing a Gram-dressed corner in the physical-letter
+span of the horizontal tensor. -/
+noncomputable def cornerGramCoefficients
+    (V : Matrix (Fin d) (Fin n) ℂ) (X : GL (Fin n) ℂ) (c : ℂ) :
+    Fin (n * n) → Fin (d * d) → ℂ :=
+  fun u z ↦ c⁻¹ *
+    star ((V * (X : Matrix (Fin n) (Fin n) ℂ)) z.divNat u.divNat) *
+      (V * ((((X)⁻¹ : GL (Fin n) ℂ) :
+        Matrix (Fin n) (Fin n) ℂ))ᴴ) z.modNat u.modNat
+
+/-- The coefficients of a grouped corner recover the horizontal slices of
+its Gram-dressed representative. -/
+theorem linearMarkedTensor_cornerGramCoefficients
+    {M : MPOTensor d D} (A : MPSTensor (D * D) n)
+    (V : Matrix (Fin d) (Fin n) ℂ) (X : GL (Fin n) ℂ)
+    (c : ℂ) (hc : (0 : ℂ) < c)
+    (hcorner : ∀ v,
+      Vᴴ * verticalTensor M v * V =
+        c • ((X : Matrix (Fin n) (Fin n) ℂ) * A v *
+          (((X)⁻¹ : GL (Fin n) ℂ) : Matrix (Fin n) (Fin n) ℂ)))
+    (u : Fin (n * n)) :
+    MPSTensor.linearMarkedTensor (cornerGramCoefficients V X c)
+        M.toMPSTensor u =
+      horizontalSlice (gramDressing X A) u.divNat u.modNat := by
+  let Xi : Matrix (Fin n) (Fin n) ℂ :=
+    (((X)⁻¹ : GL (Fin n) ℂ) : Matrix (Fin n) (Fin n) ℂ)
+  have hScaled : ∀ v,
+      c • gramDressing X A v =
+        (V * (X : Matrix (Fin n) (Fin n) ℂ))ᴴ *
+          verticalTensor M v * (V * Xiᴴ) := by
+    intro v
+    calc
+      c • gramDressing X A v =
+          (X : Matrix (Fin n) (Fin n) ℂ)ᴴ *
+            (c • ((X : Matrix (Fin n) (Fin n) ℂ) * A v * Xi)) * Xiᴴ := by
+        dsimp only [gramDressing, Xi]
+        rw [Matrix.coe_units_inv, Matrix.mul_inv_rev,
+          Matrix.conjTranspose_nonsing_inv]
+        simp only [Matrix.mul_assoc, Matrix.mul_smul, Matrix.smul_mul]
+      _ = (X : Matrix (Fin n) (Fin n) ℂ)ᴴ *
+          (Vᴴ * verticalTensor M v * V) * Xiᴴ := by rw [hcorner]
+      _ = (V * (X : Matrix (Fin n) (Fin n) ℂ))ᴴ *
+          verticalTensor M v * (V * Xiᴴ) := by
+        rw [Matrix.conjTranspose_mul]
+        simp only [Matrix.mul_assoc]
+  have hc0 : c ≠ 0 := ne_of_gt hc
+  have hRecover : gramDressing X A = fun v ↦
+      c⁻¹ • ((V * (X : Matrix (Fin n) (Fin n) ℂ))ᴴ *
+        verticalTensor M v * (V * Xiᴴ)) := by
+    funext v
+    rw [← hScaled v]
+    simp [hc0]
+  rw [hRecover, horizontalSlice_smul,
+    horizontalSlice_twoSidedCompression]
+  rw [MPSTensor.linearMarkedTensor]
+  rw [← finProdFinEquiv.sum_comp, Fintype.sum_prod_type]
+  dsimp only [cornerGramCoefficients, MPOTensor.toMPSTensor, Xi]
+  simp only [MPSTensor.finProdFinEquiv_divNat,
+    MPSTensor.finProdFinEquiv_modNat]
+  rw [Finset.smul_sum]
+  apply Finset.sum_congr rfl
+  intro i _
+  rw [Finset.smul_sum]
+  apply Finset.sum_congr rfl
+  intro j _
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply]
+  rw [smul_smul]
+  congr 1
+  ring
+
+/-- Evaluating the doubled-index MPS view on paired physical letters is the
+same as evaluating the ket and bra words separately. -/
+theorem evalWord_toMPSTensor_ofFn (M : MPOTensor d D) (N : ℕ)
+    (w : Fin N → Fin (d * d)) :
+    MPSTensor.evalWord M.toMPSTensor (List.ofFn w) =
+      evalWord M (List.ofFn fun k ↦ (w k).divNat)
+        (List.ofFn fun k ↦ (w k).modNat) := by
+  induction N with
+  | zero => simp
+  | succ N ih =>
+      rw [List.ofFn_succ, List.ofFn_succ, List.ofFn_succ]
+      change M (w 0).divNat (w 0).modNat *
+          MPSTensor.evalWord M.toMPSTensor (List.ofFn (w ∘ Fin.succ)) =
+        M (w 0).divNat (w 0).modNat *
+          evalWord M (List.ofFn fun k ↦ (w (Fin.succ k)).divNat)
+            (List.ofFn fun k ↦ (w (Fin.succ k)).modNat)
+      rw [ih (w ∘ Fin.succ)]
+      rfl
+
+end MPOTensor
+
+namespace MPOTensor.IsHorizontalCF
+
+variable {d D n : ℕ}
+
+/-- **The pairwise Gram identity of Figure 8.**
+
+Suppose two vertical corners of the same representative tensor are positive
+scalar multiples of similarities by `X` and `Y`.  If the horizontal tensor
+is in canonical form and defines positive operators at every length, then
+conjugation of the representative by the two Gram matrices gives the same
+tensor:
+$X^\dagger X A^v (X^\dagger X)^{-1}
+ =Y^\dagger Y A^v (Y^\dagger Y)^{-1}$.
+
+Hermiticity first identifies both marked chains with the common reflected
+chain of the representative.  The corner equations express the two marks as
+linear combinations of physical letters, so horizontal canonical form
+separates them.
+
+Source: arXiv:1606.00608, proof of Proposition 4.13, Figures 7--8 and lines
+1909--1919. -/
+theorem gramDressing_eq_of_two_grouped_corners
+    (M : MPOTensor d D) (hHorizontal : M.IsHorizontalCF) (hM : IsMPDO M)
+    (A : MPSTensor (D * D) n)
+    (VX VY : Matrix (Fin d) (Fin n) ℂ) (X Y : GL (Fin n) ℂ)
+    (cX cY : ℂ) (hcX : (0 : ℂ) < cX) (hcY : (0 : ℂ) < cY)
+    (hcornerX : ∀ v,
+      VXᴴ * verticalTensor M v * VX =
+        cX • ((X : Matrix (Fin n) (Fin n) ℂ) * A v *
+          (((X)⁻¹ : GL (Fin n) ℂ) : Matrix (Fin n) (Fin n) ℂ)))
+    (hcornerY : ∀ v,
+      VYᴴ * verticalTensor M v * VY =
+        cY • ((Y : Matrix (Fin n) (Fin n) ℂ) * A v *
+          (((Y)⁻¹ : GL (Fin n) ℂ) : Matrix (Fin n) (Fin n) ℂ))) :
+    gramDressing X A = gramDressing Y A := by
+  let fX := cornerGramCoefficients VX X cX
+  let fY := cornerGramCoefficients VY Y cY
+  have hTrace : ∀ (L : ℕ) (u : Fin (n * n))
+      (w : Fin L → Fin (d * d)),
+      Matrix.trace
+          (MPSTensor.linearMarkedTensor fX M.toMPSTensor u *
+            MPSTensor.evalWord M.toMPSTensor (List.ofFn w)) =
+        Matrix.trace
+          (MPSTensor.linearMarkedTensor fY M.toMPSTensor u *
+            MPSTensor.evalWord M.toMPSTensor (List.ofFn w)) := by
+    intro L u w
+    rw [show MPSTensor.linearMarkedTensor fX M.toMPSTensor u =
+        horizontalSlice (gramDressing X A) u.divNat u.modNat by
+      exact linearMarkedTensor_cornerGramCoefficients
+        A VX X cX hcX hcornerX u]
+    rw [show MPSTensor.linearMarkedTensor fY M.toMPSTensor u =
+        horizontalSlice (gramDressing Y A) u.divNat u.modNat by
+      exact linearMarkedTensor_cornerGramCoefficients
+        A VY Y cY hcY hcornerY u]
+    rw [evalWord_toMPSTensor_ofFn]
+    exact hM.markedChainCoefficient_gramDressing_eq_of_two_corners
+      A VX VY X Y cX cY hcX hcY hcornerX hcornerY L
+        u.divNat u.modNat (fun k ↦ (w k).divNat) (fun k ↦ (w k).modNat)
+  have hMarks : MPSTensor.linearMarkedTensor fX M.toMPSTensor =
+      MPSTensor.linearMarkedTensor fY M.toMPSTensor :=
+    hHorizontal.linearMarkedTensor_eq_of_trace_agree M fX fY hTrace
+  funext v
+  obtain ⟨⟨a, b⟩, rfl⟩ := finProdFinEquiv.surjective v
+  ext r s
+  have hSlice := congrFun hMarks (finProdFinEquiv (r, s))
+  rw [linearMarkedTensor_cornerGramCoefficients
+      A VX X cX hcX hcornerX,
+    linearMarkedTensor_cornerGramCoefficients
+      A VY Y cY hcY hcornerY] at hSlice
+  simpa only [horizontalSlice, MPSTensor.finProdFinEquiv_divNat,
+    MPSTensor.finProdFinEquiv_modNat] using congrFun (congrFun hSlice a) b
+
+end MPOTensor.IsHorizontalCF

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -2052,6 +2052,66 @@
     position, and positivity of $c$ permits cancellation without a phase.
 \end{proof}
 
+\begin{theorem}[Pairwise Gram conjugation of grouped vertical corners]
+    \label{thm:mpdo_pairwise_vertical_gram_conjugation}
+    \lean{MPOTensor.gramDressing}
+    \lean{MPOTensor.cornerGramCoefficients}
+    \lean{MPOTensor.IsMPDO.markedChainCoefficient_gramDressing_eq_reflectedAdjoint}
+    \lean{MPOTensor.IsMPDO.markedChainCoefficient_gramDressing_eq_of_two_corners}
+    \lean{MPOTensor.IsHorizontalCF.gramDressing_eq_of_two_grouped_corners}
+    \leanok
+    \uses{def:mpdo, def:horizontal_cf_mpdo,
+        thm:mpdo_reflected_marked_chain,
+        cor:horizontal_cf_linear_marked_separation}
+    Let $M$ be in horizontal canonical form and generate positive
+    semidefinite operators at every length.  Suppose two vertical corners
+    are positive scalar multiples of similarities of the same tensor $A$:
+    \[
+        V_X^\dagger\widetilde M^vV_X
+          =c_X X A^vX^{-1},
+        \qquad
+        V_Y^\dagger\widetilde M^vV_Y
+          =c_Y Y A^vY^{-1},
+        \qquad c_X,c_Y>0.
+    \]
+    Then the two Gram conjugations agree for every vertical letter,
+    \[
+        (X^\dagger X)A^v(X^\dagger X)^{-1}
+        =(Y^\dagger Y)A^v(Y^\dagger Y)^{-1}.
+    \]
+    Normality of $A$ is not required for this equality; it enters only in
+    the subsequent proportionality of the Gram matrices.  This is the
+    pairwise conclusion of Figures~7--8 in
+    \cite[Proposition~4.13, lines~1909--1919]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_reflected_marked_chain,
+        cor:horizontal_cf_linear_marked_separation}
+    Conjugate the open indices in the reflected marked-chain identity for
+    the first corner by $X^\dagger$.  Its left side becomes the marked chain
+    of $(X^\dagger X)A^v(X^\dagger X)^{-1}$, while the gauge factors on the
+    reflected side cancel and leave the marked chain of $A^\sharp$.  The
+    same calculation with $Y$ gives the identical reflected chain.  Thus the
+    two Gram-dressed marks have equal closed chains for every tail word.
+
+    These marks lie in the physical-letter span.  Indeed, with
+    \[
+        L_X=V_XX,
+        \qquad R_X=V_X(X^{-1})^\dagger,
+    \]
+    their coefficients are
+    \[
+        f^X_{(r,s),(i,j)}
+          =c_X^{-1}\overline{(L_X)_{ir}}(R_X)_{js},
+    \]
+    and similarly for $Y$.  The corner identities show that these linear
+    combinations are precisely the horizontal slices of the two
+    Gram-dressed tensors.  Physical-letter marked separation therefore
+    identifies every slice, hence every vertical letter.
+\end{proof}
+
 \begin{theorem}[Gram conjugation from the adjoint dressing]
     \label{thm:gram_conj_of_dressed_adjoint}
     \lean{Matrix.gram_conj_eq_of_dressed_target}
@@ -2099,8 +2159,9 @@
     (X_{\alpha,k}^{\dagger}X_{\alpha,k})^{-1}
     =(X_{\alpha,1}^{\dagger}X_{\alpha,1})M_\alpha
     (X_{\alpha,1}^{\dagger}X_{\alpha,1})^{-1}$.
-    The horizontal Lemma~L gives this equality from self-adjointness of the
-    corresponding sector compressions. Normality is used only in the
+    Theorem~\ref{thm:mpdo_pairwise_vertical_gram_conjugation} gives this
+    equality from self-adjointness of the corresponding sector compressions
+    and horizontal marked separation. Normality is used only in the
     subsequent proportionality argument. This is
     \cite[Proposition~4.13, lines~1915--1921]{Cirac2016MPDO_arXiv}.}
     \label{fig:mpdo_vertical_gauge_gram_comparison}
@@ -2114,6 +2175,7 @@
     \lean{Matrix.smul_mul_nonsing_inv_mem_unitaryGroup_of_gram_eq_smul}
     \leanok
     \uses{def:normal, thm:gram_conj_of_dressed_adjoint,
+        thm:mpdo_pairwise_vertical_gram_conjugation,
         thm:normal_tensor_gram_rigidity}
     Let $M_\alpha$ be a normal tensor, and let $X$ and $Y$ be invertible
     gauges whose Gram matrices induce the same conjugation on each letter
@@ -2122,10 +2184,12 @@
     \[
         X^\dagger X=\omega\,Y^\dagger Y,
     \]
-    and $\omega^{-1/2}XY^{-1}$ is unitary.  The Figure~8 comparison in
-    \cite[Proposition~4.13, lines 1909--1921]{Cirac2016MPDO_arXiv} supplies
-    precisely this relative hypothesis for a sector and the distinguished
-    sector. In the normalization $Y=\Id$, the resulting unitary is
+    and $\omega^{-1/2}XY^{-1}$ is unitary.
+    Theorem~\ref{thm:mpdo_pairwise_vertical_gram_conjugation} gives the
+    Figure~8 comparison in
+    \cite[Proposition~4.13, lines 1909--1921]{Cirac2016MPDO_arXiv}.  This
+    comparison supplies precisely the relative hypothesis for a sector and
+    the distinguished sector. In the normalization $Y=\Id$, the resulting unitary is
     $\omega^{-1/2}X$.  The common-target declarations attached to this entry
     are conditional algebraic corollaries, not the reflected marked-chain
     statement itself.
@@ -2745,6 +2809,7 @@
         thm:mpdo_vertical_normal_sectors_with_isometries,
         thm:mpdo_vertical_bnt_grouping_with_isometries,
         thm:mpdo_reflected_marked_chain,
+        thm:mpdo_pairwise_vertical_gram_conjugation,
         thm:vertical_sector_coisometry,
         lem:mpdo_vertical_retained_class_nonempty,
         thm:projector_closure_canonical_form,
@@ -2783,6 +2848,7 @@
         thm:mpdo_vertical_complete_reducing_projectors,
         thm:mpdo_vertical_bnt_grouping_with_isometries,
         thm:mpdo_reflected_marked_chain,
+        thm:mpdo_pairwise_vertical_gram_conjugation,
         thm:vertical_sector_coisometry,
         lem:mpdo_vertical_retained_class_nonempty,
         thm:projector_closure_canonical_form,
@@ -2843,9 +2909,10 @@
     $c_{\alpha,1}=\nu_{\alpha,1}>0$.  From now on write
     $\mu_{\alpha,k}=c_{\alpha,k}$ for the positive coefficient in the
     source decomposition.  Theorem~\ref{thm:mpdo_reflected_marked_chain}
-    proves the Figure~7 identity for each such sector.  Once the reflected
-    form of Lemma~L compares a grouped sector with the distinguished sector
-    and gives the pairwise Gram-conjugation identity in Figure~8,
+    proves the Figure~7 identity for each such sector, and
+    Theorem~\ref{thm:mpdo_pairwise_vertical_gram_conjugation} gives the
+    pairwise Gram-conjugation identity in Figure~8 whenever the two grouped
+    corners have been transported to their common representative bond space.
     Theorem~\ref{thm:eq3_of_dressed_adjoint} derives the identity
     \[
         X_{\alpha,k}^\dagger X_{\alpha,k}
@@ -2867,11 +2934,11 @@
     the corresponding reconstruction identity; each
     $\mu_\alpha$ is diagonal, so the summands regroup as repeated weighted
     copies of $M_\alpha$ exactly as in the finite regrouping of
-    Lemma~\ref{lem:vertical_grouping_equiv}. The remaining missing proof is the
-    reflected marked-chain and Lemma~L argument of lines 1909--1919: one must
-    compare two marked sector compressions, whose adjoints reverse the tail
-    word, and obtain their relative Gram-conjugation equality without making
-    a separate raw-adjoint identification for either sector.
+    Lemma~\ref{lem:vertical_grouping_equiv}. The remaining step is to transport
+    each grouped corner along the dimension equalities of the grouping
+    theorem so that
+    Theorem~\ref{thm:mpdo_pairwise_vertical_gram_conjugation} applies on the
+    common representative bond space.
     Consequently, the conclusion stated at lines 1903--1908 has not yet been
     derived from the matrix-product-density-operator hypotheses.  The generic
     block-row construction is already proved.  After the relative

--- a/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
@@ -193,10 +193,14 @@ $c_{\alpha,k}>0$ under the normalization
 $c_{\alpha,1}=\nu_{\alpha,1}>0$.  Thus the coefficient denoted by
 $\mu_{\alpha,k}$ in the source is $\mu_{\alpha,k}=c_{\alpha,k}$
 (\path{TNLean/MPS/MPDO/VerticalBNT.lean} and
-\path{TNLean/MPS/MPDO/SectorTrace.lean}).  For the unitary gauges: granted
-the pairwise Gram-conjugation identity of the second displayed diagram at
-source lines~1914--1919, transported blockwise by a reflected form of
-Lemma~L, the scalar commutant of
+\path{TNLean/MPS/MPDO/SectorTrace.lean}).  For the unitary gauges, the
+pairwise Gram-conjugation identity of the second displayed diagram at source
+lines~1914--1919 is proved for two corners on a common representative bond
+space by
+\path{MPOTensor.IsHorizontalCF.gramDressing_eq_of_two_grouped_corners}.
+It combines the reflected marked-chain identity with physical-letter marked
+separation and does not identify either corner separately with the raw
+reflected adjoint.  The scalar commutant of
 the normal tensor $M_\alpha$
 (\path{MPSTensor.IsNormal.eq_smul_one_of_commute}) makes the relative Gram
 ratio scalar.  Positivity of the two Gram matrices then gives
@@ -211,18 +215,14 @@ $X_{\alpha,1}=\Id$, giving the normalization printed by the source
 (\path{MPSTensor.IsNormal.gram_eq_pos_smul_gram_of_gram_conj_eq} in
 \path{TNLean/MPS/CanonicalForm/NormalCommutant.lean}).
 
-The remaining missing proof is the reflected marked-chain and Lemma~L argument
-of source lines~1909--1919.  The adjoint of the marked finite chain exchanges
-the oriented bond indices and reverses its tail word.  A reflected
-marked-chain form of Lemma~L must compare sector $k$ directly with the
-distinguished sector $1$ and derive equality of their Gram conjugations.
-It must not identify either dressed sector separately with the raw reflected
-adjoint: together with the literal positive reconstruction, that stronger
-statement would force tensor-level Hermiticity, which is not invariant under
-the horizontal invertible similarities allowed by canonical form.
-The Figure~7 marked-chain identity itself is now proved in
-\path{TNLean/MPS/MPDO/ReflectedMarkedChain.lean}; the missing statement is
-precisely the two-sector separation step.
+The reflected marked-chain and two-sector separation argument of source
+lines~1909--1919 is now proved in
+\path{TNLean/MPS/MPDO/FigureEightPairwise.lean}.  The adjoint exchanges the
+oriented bond indices and reverses the tail word; eliminating the common
+reflected chain before physical-letter separation gives the relative Gram
+identity.  What remains is the dependent-dimension transport from the grouped
+vertical decomposition to two corners on the common representative bond
+space required by this theorem.
 
 Afterwards the copy embeddings can be normalized using the relative theorem
 above.  Their generic assembly into the direct-sum coisometry $U$ is already

--- a/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
@@ -169,10 +169,12 @@ separation supplies a nonzero compression.  Its trace is the sector weight
 $\mu_{\alpha,k}$ times a sector trace $d_\alpha$, so MPDO positivity forces
 $d_\alpha>0$ and $\mu_{\alpha,k}>0$ under the normalization
 $\mu_{\alpha,1}>0$ (\path{TNLean/MPS/MPDO/VerticalBNT.lean} and
-\path{TNLean/MPS/MPDO/SectorTrace.lean}). Granted the pairwise
-Gram-conjugation identity of the second displayed diagram at
-lines~1914--1919, transported blockwise by a reflected form of Lemma~L, the
-Gram matrix of each sector gauge $X_{\alpha,k}$ is
+\path{TNLean/MPS/MPDO/SectorTrace.lean}). The pairwise Gram-conjugation
+identity of the second displayed diagram at lines~1914--1919 is proved for
+two corners on a common representative bond space in
+\path{TNLean/MPS/MPDO/FigureEightPairwise.lean}.  Together with the scalar
+commutant of a normal tensor, this identity shows that the Gram matrix of
+each sector gauge $X_{\alpha,k}$ is
 a positive real multiple of the reference Gram matrix,
 \[
 X_{\alpha,k}^\dagger X_{\alpha,k}
@@ -192,16 +194,11 @@ grouped into pairwise gauge-phase-distinct BNT representatives in
 \path{TNLean/MPS/MPDO/VerticalBNT.lean}. Every copy is expressed by a positive
 coefficient, a unit-modulus phase, and an invertible bond-space gauge, while
 the physical isometries and the literal vertical reconstruction are retained.
-What remains open is the reflected marked-chain and Lemma~L argument of source
-lines~1909--1919.  Its fixed-index form exchanges the two oriented bond indices,
-and the adjoint marked chain reverses the tail word.  A corresponding
-reflected marked-chain form of Lemma~L is needed before the relative Gram
-theorem can normalize the gauges.  It must compare two grouped copies and
-derive their relative Gram-conjugation equality; identifying either copy
-separately with the raw reflected adjoint would force the non-gauge-invariant
-conclusion that the tensor itself is Hermitian.  The resulting sector maps
-must then be assembled into the final coisometry.  Consequently, the conclusion stated at
-lines~1903--1908 has not yet been derived from the MPDO hypotheses.
+The remaining step is to transport the grouped corners along their dependent
+dimension equalities to the common representative bond space required by the
+pairwise theorem.  The resulting sector maps must then be assembled into the
+final coisometry.  Consequently, the conclusion stated at lines~1903--1908
+has not yet been derived from the MPDO hypotheses.
 
 \paragraph{Verdict.}
 This is an open gap: the source-faithful horizontal-to-vertical implication of


### PR DESCRIPTION
## Summary

- proves covariance of marked-chain coefficients under multiplication on the two open bond indices
- derives the common reflected marked chain of a Gram-dressed vertical corner from the Figure 7 identity
- constructs the exact physical-letter coefficients of a Gram-dressed corner
- proves the pairwise Figure 8 identity for two grouped corners of one vertical representative
- updates Chapter 21 and the paper-gap notes so that only dependent-dimension transport remains

## Mathematical statement

Let two vertical corners of the same representative tensor satisfy
\[
V_X^\dagger \widetilde M^v V_X=c_X X A^vX^{-1},\qquad
V_Y^\dagger \widetilde M^v V_Y=c_Y Y A^vY^{-1},
\]
with positive coefficients. Under horizontal canonical form and the MPDO hypothesis, the theorem proves
\[
(X^\dagger X)A^v(X^\dagger X)^{-1}
=(Y^\dagger Y)A^v(Y^\dagger Y)^{-1}
\]
for every vertical letter.

This is the pairwise conclusion of arXiv:1606.00608, Proposition 4.13, Figures 7–8 and lines 1909–1919. Normality is not assumed here; it is used only afterward to make the relative Gram matrix scalar. The proof does not identify either corner separately with the raw reflected adjoint.

## Verification

- exact module compile
- full `lake build TNLean`
- `leanblueprint web`
- `leanblueprint checkdecls`
- `leanblueprint pdf` (551 pages)
- visual inspection of Chapter 21 pages 430–431
- reader-facing prose and blueprint synchronization checks
- proof-integrity scan
- `git diff --check`

An independent exact review checked the coefficient indices, conjugations, reflected cancellation, ket/bra word conversion, physical-span separation, source faithfulness, rendered theorem, and `texra-ai` authorship.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization and documentation in the MPDO canonical-form track; no runtime, auth, or data-path changes. Residual risk is only mathematical scope (transport to common bond space still open in the larger vertical CF proof).
> 
> **Overview**
> Adds **`TNLean/MPS/MPDO/FigureEightPairwise.lean`** and wires it into the root import list. The module introduces **`gramDressing`**, **`cornerGramCoefficients`**, and lemmas on bond-index multiplication and marked-chain coefficients, then proves that two grouped vertical corners of the same representative have equal Gram-dressed marked chains via the reflected Figure 7 identity, and finally **`IsHorizontalCF.gramDressing_eq_of_two_grouped_corners`**: under horizontal CF and MPDO, \((X^\dagger X)A^v(X^\dagger X)^{-1} = (Y^\dagger Y)A^v(Y^\dagger Y)^{-1}\) for every vertical letter.
> 
> **Blueprint** (`ch20_mpdo_canonical_forms.tex`) gains Theorem **`mpdo_pairwise_vertical_gram_conjugation`**, links it to Gram proportionality and the vertical CF capstone, and replaces the prior “missing Lemma L / Figure 8” wording with this proved pairwise step.
> 
> **Paper-gap notes** (`cpgsv17_vertical_cf_grouping.tex`, `cpgsv17_vertical_diagonal_restriction.tex`) now cite the Lean theorem and state that the remaining work is transporting grouped corners to a **common representative bond space**, not the two-sector Gram argument itself.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17b95dc6e2849347e233acd4d8a916073f3d41b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->