### PR TITLE
feat(MPS/MPDO): prove grouped Figure 8 comparison

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -397,6 +397,7 @@ import TNLean.MPS.MPDO.RetainedClass
 import TNLean.MPS.MPDO.SectorTrace
 import TNLean.MPS.MPDO.ReflectedMarkedChain
 import TNLean.MPS.MPDO.FigureEightPairwise
+import TNLean.MPS.MPDO.GroupedFigure8
 import TNLean.MPS.MPDO.BiCFDerivation
 import TNLean.MPS.MPDO.ZCL
 import TNLean.MPS.MPDO.RFP

--- a/TNLean/MPS/CanonicalForm/NormalCommutant.lean
+++ b/TNLean/MPS/CanonicalForm/NormalCommutant.lean
@@ -29,8 +29,9 @@ diagrams at lines 1909--1919.  Hermiticity first gives a reflected marked-chain
 identity whose adjoint reverses the unmarked tail.  Lemma L is then applied to
 two sectors together, producing equality of their Gram conjugations.  The
 resulting ratio of Gram matrices commutes with every matrix of the tensor.
-The passage from this relative equality to eq3 is proved below; deriving the
-relative equality from the reflected marked chains remains open.
+The passage from this relative equality to eq3 is proved below.  The reflected
+marked-chain argument and its specialization to the grouped vertical sectors
+are proved in the matrix-product-density-operator canonical-form development.
 
 ## Main results
 

--- a/TNLean/MPS/MPDO/GroupedFigure8.lean
+++ b/TNLean/MPS/MPDO/GroupedFigure8.lean
@@ -1,0 +1,163 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.FigureEightPairwise
+import TNLean.MPS.MPDO.VerticalBNT
+
+/-!
+# Figure 8 for grouped vertical sectors
+
+This file applies the pairwise reflected form of Lemma L to the actual
+vertical corners and gauges furnished by the grouped vertical decomposition.
+
+## Main result
+
+* `IsMPDO.grouped_sector_gram_conj_eq`: the Gram conjugation of each grouped
+  copy fixes the transported representative tensor.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Proposition 4.13, Figures 7--8 and lines 1909--1919.
+-/
+
+open scoped Matrix ComplexOrder
+
+namespace MPOTensor
+
+variable {d D m n : ℕ}
+
+/-- Transporting a vertical corner along an equality of its bond dimensions
+preserves its corner identity.
+
+Source context: arXiv:1606.00608, proof of Proposition 4.13, lines
+1898--1919. -/
+private theorem vertical_corner_cast (M : MPOTensor d D)
+    (A : MPSTensor (D * D) m) (V : Matrix (Fin d) (Fin m) ℂ)
+    (c : ℂ) (hcorner : ∀ v, Vᴴ * verticalTensor M v * V = c • A v)
+    (h : m = n) (v : Fin (D * D)) :
+    let A' := cast (congrArg (MPSTensor (D * D)) h) A
+    let V' := cast (congrArg (fun k ↦ Matrix (Fin d) (Fin k) ℂ) h) V
+    V'ᴴ * verticalTensor M v * V' = c • A' v := by
+  cases h
+  simpa using hcorner v
+
+/-- Two successive transports from a common dimension agree with the direct
+transport.  This isolates the dependent cast used for the distinguished
+sector in Figure 8.
+
+Source context: arXiv:1606.00608, proof of Proposition 4.13, lines
+1909--1919. -/
+private theorem cast_via_common_dimension {k : ℕ} (F : ℕ → Type)
+    (hmk : m = k) (hmn : m = n) (x : F m) :
+    cast (congrArg F (hmk.symm.trans hmn))
+        (cast (congrArg F hmk) x) =
+      cast (congrArg F hmn) x := by
+  subst k
+  subst n
+  rfl
+
+section GroupedSectors
+
+variable {r : ℕ} {dim : Fin r → ℕ}
+variable (blocks : (k : Fin r) → MPSTensor (D * D) (dim k))
+
+local notation "C" => MPSTensor.mpvPhaseClassData blocks
+
+/-- **Figure 8 for an actual grouped sector and its distinguished copy.**
+
+Assume the phase-class gauges, positive coefficients, and physical corner
+identities furnished by `exists_verticalBNTGrouping_with_isometry`.  For each
+copy `q`, transport the distinguished physical corner to the bond dimension
+of `q` and apply the pairwise reflected form of Lemma L.  The resulting Gram
+conjugation fixes the transported representative tensor.
+
+No identity between an individual dressed tensor and its raw reflected
+adjoint is used or asserted.
+
+Source: arXiv:1606.00608, proof of Proposition 4.13, Figures 7--8 and lines
+1909--1919. -/
+theorem IsMPDO.grouped_sector_gram_conj_eq
+    {M : MPOTensor d D} (hM : IsMPDO M)
+    (hHorizontal : IsHorizontalCF M)
+    (μ : Fin r → ℂ) (V : (k : Fin r) → Matrix (Fin d) (Fin (dim k)) ℂ)
+    (hdim : ∀ j q, dim ((C).repr j) = dim ((C).enum j q))
+    (X : (j : Fin (C).g) → (q : Fin ((C).copies j)) →
+      GL (Fin (dim ((C).enum j q))) ℂ)
+    (ζ : (j : Fin (C).g) → Fin ((C).copies j) → ℂ)
+    (hXDist : ∀ j, X j ⟨0, (C).copies_pos j⟩ = 1)
+    (hCoeffPos : ∀ j q, (0 : ℂ) < μ ((C).enum j q) * ζ j q)
+    (hCorner : ∀ j q v,
+      (μ ((C).enum j q) * ζ j q) •
+          ((X j q : Matrix (Fin (dim ((C).enum j q)))
+              (Fin (dim ((C).enum j q))) ℂ) *
+            (cast (congrArg (MPSTensor (D * D)) (hdim j q))
+              (blocks ((C).repr j))) v *
+            (↑((X j q)⁻¹) : Matrix (Fin (dim ((C).enum j q)))
+              (Fin (dim ((C).enum j q))) ℂ)) =
+        (V ((C).enum j q))ᴴ * verticalTensor M v * V ((C).enum j q))
+    (j : Fin (C).g) (q : Fin ((C).copies j))
+    (v : Fin (D * D)) :
+    let A := cast (congrArg (MPSTensor (D * D)) (hdim j q))
+      (blocks ((C).repr j))
+    let G := (X j q : Matrix (Fin (dim ((C).enum j q)))
+      (Fin (dim ((C).enum j q))) ℂ)ᴴ * X j q
+    G * A v * G⁻¹ = A v := by
+  classical
+  let q0 : Fin ((C).copies j) := ⟨0, (C).copies_pos j⟩
+  let A := cast (congrArg (MPSTensor (D * D)) (hdim j q))
+    (blocks ((C).repr j))
+  let A0 := cast (congrArg (MPSTensor (D * D)) (hdim j q0))
+    (blocks ((C).repr j))
+  let h0q := (hdim j q0).symm.trans (hdim j q)
+  let W := cast
+    (congrArg (fun k ↦ Matrix (Fin d) (Fin k) ℂ) h0q)
+    (V ((C).enum j q0))
+  let cq := μ ((C).enum j q) * ζ j q
+  let c0 := μ ((C).repr j) * ζ j q0
+  have hEnum0 : (C).enum j q0 = (C).repr j := by
+    exact MPSTensor.mpvPhaseClassData_enum_zero_eq_repr blocks j
+  have hc0 : (0 : ℂ) < c0 := by
+    simpa [c0, q0, hEnum0] using hCoeffPos j q0
+  have hcoeff0 : μ ((C).enum j q0) * ζ j q0 = c0 := by
+    change μ ((C).enum j q0) * ζ j q0 = μ ((C).repr j) * ζ j q0
+    rw [hEnum0]
+  have hCorner0 : ∀ w,
+      (V ((C).enum j q0))ᴴ * verticalTensor M w * V ((C).enum j q0) =
+        c0 • A0 w := by
+    intro w
+    have h := (hCorner j q0 w).symm
+    rw [hXDist j] at h
+    rw [inv_one, Matrix.GeneralLinearGroup.coe_one,
+      Matrix.one_mul, Matrix.mul_one] at h
+    rw [hcoeff0] at h
+    simpa [A0, q0] using h
+  have hAtransport :
+      cast (congrArg (MPSTensor (D * D)) h0q) A0 = A := by
+    exact cast_via_common_dimension (MPSTensor (D * D))
+      (hdim j q0) (hdim j q) (blocks ((C).repr j))
+  have hCorner0cast : ∀ w,
+      Wᴴ * verticalTensor M w * W = c0 • A w := by
+    intro w
+    have h := vertical_corner_cast M A0 (V ((C).enum j q0))
+      c0 hCorner0 h0q w
+    simpa [W, hAtransport] using h
+  have hCornerq : ∀ w,
+      (V ((C).enum j q))ᴴ * verticalTensor M w * V ((C).enum j q) =
+        cq • ((X j q : Matrix (Fin (dim ((C).enum j q)))
+            (Fin (dim ((C).enum j q))) ℂ) * A w *
+          (↑((X j q)⁻¹) : Matrix (Fin (dim ((C).enum j q)))
+            (Fin (dim ((C).enum j q))) ℂ)) := by
+    intro w
+    simpa [cq, A] using (hCorner j q w).symm
+  have hGram := hHorizontal.gramDressing_eq_of_two_grouped_corners
+    M hM A (V ((C).enum j q)) W (X j q) 1 cq c0
+    (hCoeffPos j q) hc0 hCornerq
+    (by intro w; simpa using hCorner0cast w)
+  simpa [gramDressing, A] using congrFun hGram v
+
+end GroupedSectors
+
+end MPOTensor

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -2112,6 +2112,38 @@
     identifies every slice, hence every vertical letter.
 \end{proof}
 
+\begin{theorem}[Gram conjugation for an actual grouped sector]
+    \label{thm:mpdo_grouped_sector_gram_conjugation}
+    \lean{MPOTensor.IsMPDO.grouped_sector_gram_conj_eq}
+    \leanok
+    \uses{thm:mpdo_pairwise_vertical_gram_conjugation,
+        thm:mpdo_vertical_bnt_grouping_with_isometries}
+    Consider the grouped vertical decomposition furnished by
+    Theorem~\ref{thm:mpdo_vertical_bnt_grouping_with_isometries}.  For a
+    phase class $\alpha$ and a copy $q$, transport its representative tensor
+    to the bond space of that copy.  If $X_{\alpha,q}$ is the corresponding
+    gauge, then
+    \[
+      (X_{\alpha,q}^\dagger X_{\alpha,q})A_{\alpha,q}^v
+      (X_{\alpha,q}^\dagger X_{\alpha,q})^{-1}
+      =A_{\alpha,q}^v
+    \]
+    for every vertical letter $v$.  This is Figure~8 for the actual witnesses
+    of the grouped decomposition.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_pairwise_vertical_gram_conjugation,
+        thm:mpdo_vertical_bnt_grouping_with_isometries}
+    Transport the distinguished corner of the phase class along the equality
+    of its bond dimension with that of the copy $q$.  Its distinguished gauge
+    is the identity.  Apply
+    Theorem~\ref{thm:mpdo_pairwise_vertical_gram_conjugation} to this corner
+    and the corner indexed by $q$.  The Gram conjugation belonging to the
+    distinguished corner is the identity, which gives the stated equality.
+\end{proof}
+
 \begin{theorem}[Gram conjugation from the adjoint dressing]
     \label{thm:gram_conj_of_dressed_adjoint}
     \lean{Matrix.gram_conj_eq_of_dressed_target}
@@ -2176,6 +2208,7 @@
     \leanok
     \uses{def:normal, thm:gram_conj_of_dressed_adjoint,
         thm:mpdo_pairwise_vertical_gram_conjugation,
+        thm:mpdo_grouped_sector_gram_conjugation,
         thm:normal_tensor_gram_rigidity}
     Let $M_\alpha$ be a normal tensor, and let $X$ and $Y$ be invertible
     gauges whose Gram matrices induce the same conjugation on each letter
@@ -2810,6 +2843,7 @@
         thm:mpdo_vertical_bnt_grouping_with_isometries,
         thm:mpdo_reflected_marked_chain,
         thm:mpdo_pairwise_vertical_gram_conjugation,
+        thm:mpdo_grouped_sector_gram_conjugation,
         thm:vertical_sector_coisometry,
         lem:mpdo_vertical_retained_class_nonempty,
         thm:projector_closure_canonical_form,
@@ -2910,10 +2944,10 @@
     $\mu_{\alpha,k}=c_{\alpha,k}$ for the positive coefficient in the
     source decomposition.  Theorem~\ref{thm:mpdo_reflected_marked_chain}
     proves the Figure~7 identity for each such sector, and
-    Theorem~\ref{thm:mpdo_pairwise_vertical_gram_conjugation} gives the
-    pairwise Gram-conjugation identity in Figure~8 whenever the two grouped
-    corners have been transported to their common representative bond space.
-    Theorem~\ref{thm:eq3_of_dressed_adjoint} derives the identity
+    Theorem~\ref{thm:mpdo_grouped_sector_gram_conjugation} applies the
+    pairwise Gram comparison to the actual grouped corners and gives the
+    Gram-conjugation identity in Figure~8.  It remains to apply
+    Theorem~\ref{thm:eq3_of_dressed_adjoint} to derive the identity
     \[
         X_{\alpha,k}^\dagger X_{\alpha,k}
         =\omega_{\alpha,k}\,X_{\alpha,1}^\dagger X_{\alpha,1},
@@ -2934,14 +2968,11 @@
     the corresponding reconstruction identity; each
     $\mu_\alpha$ is diagonal, so the summands regroup as repeated weighted
     copies of $M_\alpha$ exactly as in the finite regrouping of
-    Lemma~\ref{lem:vertical_grouping_equiv}. The remaining step is to transport
-    each grouped corner along the dimension equalities of the grouping
-    theorem so that
-    Theorem~\ref{thm:mpdo_pairwise_vertical_gram_conjugation} applies on the
-    common representative bond space.
+    Lemma~\ref{lem:vertical_grouping_equiv}.
     Consequently, the conclusion stated at lines 1903--1908 has not yet been
     derived from the matrix-product-density-operator hypotheses.  The generic
-    block-row construction is already proved.  After the relative
+    block-row construction is already proved.  The remaining step is to apply
+    normal-tensor Gram rigidity to the grouped comparison.  After the relative
     normalization, the remaining source-specific identifications are to form the normalized
     sector isometries, transport each copy bond space to its representative
     bond space using the dimension equalities from the grouping theorem,

--- a/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
@@ -195,12 +195,12 @@ $\mu_{\alpha,k}$ in the source is $\mu_{\alpha,k}=c_{\alpha,k}$
 (\path{TNLean/MPS/MPDO/VerticalBNT.lean} and
 \path{TNLean/MPS/MPDO/SectorTrace.lean}).  For the unitary gauges, the
 pairwise Gram-conjugation identity of the second displayed diagram at source
-lines~1914--1919 is proved for two corners on a common representative bond
-space by
-\path{MPOTensor.IsHorizontalCF.gramDressing_eq_of_two_grouped_corners}.
-It combines the reflected marked-chain identity with physical-letter marked
-separation and does not identify either corner separately with the raw
-reflected adjoint.  The scalar commutant of
+lines~1914--1919 is proved in
+\path{TNLean/MPS/MPDO/FigureEightPairwise.lean}.  The dependent transport to
+the actual grouped sector and its distinguished copy is proved in
+\path{TNLean/MPS/MPDO/GroupedFigure8.lean}.  This argument does not identify
+either corner separately with the raw reflected adjoint.  The scalar
+commutant of
 the normal tensor $M_\alpha$
 (\path{MPSTensor.IsNormal.eq_smul_one_of_commute}) makes the relative Gram
 ratio scalar.  Positivity of the two Gram matrices then gives
@@ -215,17 +215,11 @@ $X_{\alpha,1}=\Id$, giving the normalization printed by the source
 (\path{MPSTensor.IsNormal.gram_eq_pos_smul_gram_of_gram_conj_eq} in
 \path{TNLean/MPS/CanonicalForm/NormalCommutant.lean}).
 
-The reflected marked-chain and two-sector separation argument of source
-lines~1909--1919 is now proved in
-\path{TNLean/MPS/MPDO/FigureEightPairwise.lean}.  The adjoint exchanges the
-oriented bond indices and reverses the tail word; eliminating the common
-reflected chain before physical-letter separation gives the relative Gram
-identity.  What remains is the dependent-dimension transport from the grouped
-vertical decomposition to two corners on the common representative bond
-space required by this theorem.
-
-Afterwards the copy embeddings can be normalized using the relative theorem
-above.  Their generic assembly into the direct-sum coisometry $U$ is already
+The reflected marked-chain, two-sector separation, and dependent-dimension
+transport of source lines~1909--1919 are therefore complete.  What remains is
+to apply normal-tensor Gram rigidity to this grouped comparison and normalize
+the copy embeddings.  Their generic assembly into the direct-sum coisometry
+$U$ is already
 proved by \path{Matrix.sigmaBlockRow_isCoisometry},
 \path{Matrix.sigmaBlockRow_conjugation}, and
 \path{Matrix.sigmaBlockRow_reconstruction}.  The remaining source-specific
@@ -241,6 +235,11 @@ gauge and coisometry conclusions are not part of the grouping theorem.  The orig
 formulation of \ghissue{2536}, interpreted as a direct conversion of the
 horizontal scalar weights and diagonal restrictions, is therefore not a
 consequence of Proposition~4.13.
+
+\paragraph{Verdict.}
+This is an open gap: Figure~8 is complete for the actual grouped sectors, but
+the normal-tensor Gram normalization and the final physical coisometry have
+not yet been derived from the matrix-product-density-operator hypotheses.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
@@ -170,9 +170,10 @@ $\mu_{\alpha,k}$ times a sector trace $d_\alpha$, so MPDO positivity forces
 $d_\alpha>0$ and $\mu_{\alpha,k}>0$ under the normalization
 $\mu_{\alpha,1}>0$ (\path{TNLean/MPS/MPDO/VerticalBNT.lean} and
 \path{TNLean/MPS/MPDO/SectorTrace.lean}). The pairwise Gram-conjugation
-identity of the second displayed diagram at lines~1914--1919 is proved for
-two corners on a common representative bond space in
-\path{TNLean/MPS/MPDO/FigureEightPairwise.lean}.  Together with the scalar
+identity of the second displayed diagram at lines~1914--1919 is proved in
+\path{TNLean/MPS/MPDO/FigureEightPairwise.lean}, and its dependent transport
+to the actual grouped sectors is proved in
+\path{TNLean/MPS/MPDO/GroupedFigure8.lean}.  Together with the scalar
 commutant of a normal tensor, this identity shows that the Gram matrix of
 each sector gauge $X_{\alpha,k}$ is
 a positive real multiple of the reference Gram matrix,
@@ -194,9 +195,8 @@ grouped into pairwise gauge-phase-distinct BNT representatives in
 \path{TNLean/MPS/MPDO/VerticalBNT.lean}. Every copy is expressed by a positive
 coefficient, a unit-modulus phase, and an invertible bond-space gauge, while
 the physical isometries and the literal vertical reconstruction are retained.
-The remaining step is to transport the grouped corners along their dependent
-dimension equalities to the common representative bond space required by the
-pairwise theorem.  The resulting sector maps must then be assembled into the
+What remains is to apply normal-tensor Gram rigidity to this grouped
+comparison, normalize the resulting sector maps, and assemble them into the
 final coisometry.  Consequently, the conclusion stated at lines~1903--1908
 has not yet been derived from the MPDO hypotheses.
 


### PR DESCRIPTION
## Mathematical result

This proves the Figure 8 Gram-conjugation identity for the actual grouped vertical sectors in arXiv:1606.00608, Proposition 4.13, lines 1909--1919.

The merged pairwise theorem from #3906 compares two positive vertical corners of the same representative. This PR supplies the remaining dependent transport:

- transports the distinguished corner of a phase class to the bond dimension of an arbitrary copy;
- uses the grouping theorem's distinguished gauge identity;
- applies the pairwise Gram comparison on the common bond space;
- concludes, for every grouped copy q and vertical letter v,
  `(X_q† X_q) A_q^v (X_q† X_q)⁻¹ = A_q^v`.

No one-sector identity with the raw reflected adjoint is assumed or proved.

## Documentation

The chapter-20 blueprint now records the grouped-sector specialization separately from the pairwise theorem. The two vertical-grouping paper-gap documents place the remaining boundary at normal-tensor Gram rigidity, unitary normalization, and the final coisometry. The grouping note now includes an explicit open-gap verdict.

## Verification

- `lake build` (9394 jobs)
- targeted compilation of `GroupedFigure8.lean`
- blueprint/Lean synchronization
- `lake exe checkdecls blueprint/lean_decls`
- explicit `#print axioms` audit: only `propext`, `Classical.choice`, and `Quot.sound`
- prohibited-token and `git diff --check` audits

Closes #3897.
Advances #3890, #3887, and #3674.