### PR TITLE
feat(MPS/MPDO): normalize grouped vertical gauges

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -398,6 +398,7 @@ import TNLean.MPS.MPDO.SectorTrace
 import TNLean.MPS.MPDO.ReflectedMarkedChain
 import TNLean.MPS.MPDO.FigureEightPairwise
 import TNLean.MPS.MPDO.GroupedFigure8
+import TNLean.MPS.MPDO.GroupedGramNormalization
 import TNLean.MPS.MPDO.BiCFDerivation
 import TNLean.MPS.MPDO.ZCL
 import TNLean.MPS.MPDO.RFP

--- a/TNLean/MPS/MPDO/GroupedGramNormalization.lean
+++ b/TNLean/MPS/MPDO/GroupedGramNormalization.lean
@@ -1,0 +1,154 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.CanonicalForm.NormalCommutant
+import TNLean.MPS.MPDO.GroupedFigure8
+
+/-!
+# Gram and unitary normalization of grouped vertical sectors
+
+This file applies normal-tensor rigidity to the grouped Figure 8 comparison.
+
+## Main results
+
+* `IsMPDO.grouped_sector_gram_eq_pos_smul_one`: each grouped gauge has Gram
+  matrix equal to a positive real multiple of the identity.
+* `IsMPDO.grouped_sector_exists_unitary_normalization`: rescaling the grouped
+  gauge by the inverse square root of that scalar makes it unitary.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Proposition 4.13, lines 1903--1921.
+-/
+
+open scoped Matrix ComplexOrder
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+section GroupedSectors
+
+variable {r : ℕ} {dim : Fin r → ℕ}
+variable (blocks : (k : Fin r) → MPSTensor (D * D) (dim k))
+
+local notation "C" => MPSTensor.mpvPhaseClassData blocks
+
+/-- The Gram matrix of an actual grouped vertical-sector gauge is a positive
+real multiple of the identity.
+
+All hypotheses are clauses furnished by
+`IsHorizontalCF.exists_verticalBNTGrouping_with_isometry`.
+
+Source: arXiv:1606.00608, proof of Proposition 4.13, lines 1903--1921. -/
+theorem IsMPDO.grouped_sector_gram_eq_pos_smul_one
+    {M : MPOTensor d D} (hM : IsMPDO M)
+    (hHorizontal : IsHorizontalCF M)
+    (μ : Fin r → ℂ) (V : (k : Fin r) → Matrix (Fin d) (Fin (dim k)) ℂ)
+    (hDimPos : ∀ k, 0 < dim k)
+    (hNormal : ∀ k, MPSTensor.IsNormalTensor (blocks k))
+    (hdim : ∀ j q, dim ((C).repr j) = dim ((C).enum j q))
+    (X : (j : Fin (C).g) → (q : Fin ((C).copies j)) →
+      GL (Fin (dim ((C).enum j q))) ℂ)
+    (ζ : (j : Fin (C).g) → Fin ((C).copies j) → ℂ)
+    (hXDist : ∀ j, X j ⟨0, (C).copies_pos j⟩ = 1)
+    (hCoeffPos : ∀ j q, (0 : ℂ) < μ ((C).enum j q) * ζ j q)
+    (hCorner : ∀ j q v,
+      (μ ((C).enum j q) * ζ j q) •
+          ((X j q : Matrix (Fin (dim ((C).enum j q)))
+              (Fin (dim ((C).enum j q))) ℂ) *
+            (cast (congrArg (MPSTensor (D * D)) (hdim j q))
+              (blocks ((C).repr j))) v *
+            (↑((X j q)⁻¹) : Matrix (Fin (dim ((C).enum j q)))
+              (Fin (dim ((C).enum j q))) ℂ)) =
+        (V ((C).enum j q))ᴴ * verticalTensor M v * V ((C).enum j q))
+    (j : Fin (C).g) (q : Fin ((C).copies j)) :
+    ∃ ω : ℝ, 0 < ω ∧
+      (X j q : Matrix (Fin (dim ((C).enum j q)))
+        (Fin (dim ((C).enum j q))) ℂ)ᴴ * X j q = (ω : ℂ) • 1 := by
+  letI : NeZero (dim ((C).enum j q)) := ⟨(hDimPos _).ne'⟩
+  let A := cast (congrArg (MPSTensor (D * D)) (hdim j q))
+    (blocks ((C).repr j))
+  have hNormalA : MPSTensor.IsNormal A :=
+    ((MPSTensor.isNormalTensor_cast_iff (hdim j q)
+      (blocks ((C).repr j))).2 (hNormal ((C).repr j))).isNormal
+  have hXdet : IsUnit
+      (X j q : Matrix (Fin (dim ((C).enum j q)))
+        (Fin (dim ((C).enum j q))) ℂ).det :=
+    Matrix.isUnits_det_units (X j q)
+  have hOneDet : IsUnit
+      (1 : Matrix (Fin (dim ((C).enum j q)))
+        (Fin (dim ((C).enum j q))) ℂ).det := by
+    simp
+  have hGramConj : ∀ v,
+      (X j q : Matrix (Fin (dim ((C).enum j q)))
+          (Fin (dim ((C).enum j q))) ℂ)ᴴ * X j q * A v *
+          (((X j q : Matrix (Fin (dim ((C).enum j q)))
+            (Fin (dim ((C).enum j q))) ℂ)ᴴ * X j q)⁻¹) =
+        (1 : Matrix (Fin (dim ((C).enum j q)))
+            (Fin (dim ((C).enum j q))) ℂ)ᴴ * 1 * A v *
+          (((1 : Matrix (Fin (dim ((C).enum j q)))
+            (Fin (dim ((C).enum j q))) ℂ)ᴴ * 1)⁻¹) := by
+    intro v
+    simpa [A] using IsMPDO.grouped_sector_gram_conj_eq blocks hM hHorizontal
+      μ V hdim X ζ hXDist hCoeffPos hCorner j q v
+  obtain ⟨ω, hω, hGram⟩ :=
+    hNormalA.gram_eq_pos_smul_gram_of_gram_conj_eq hXdet hOneDet hGramConj
+  refine ⟨ω, hω, ?_⟩
+  simpa using hGram
+
+/-- Every actual grouped vertical-sector gauge becomes unitary after division
+by the square root of its positive Gram scalar.
+
+All hypotheses are clauses furnished by
+`IsHorizontalCF.exists_verticalBNTGrouping_with_isometry`.
+
+Source: arXiv:1606.00608, proof of Proposition 4.13, lines 1903--1921. -/
+theorem IsMPDO.grouped_sector_exists_unitary_normalization
+    {M : MPOTensor d D} (hM : IsMPDO M)
+    (hHorizontal : IsHorizontalCF M)
+    (μ : Fin r → ℂ) (V : (k : Fin r) → Matrix (Fin d) (Fin (dim k)) ℂ)
+    (hDimPos : ∀ k, 0 < dim k)
+    (hNormal : ∀ k, MPSTensor.IsNormalTensor (blocks k))
+    (hdim : ∀ j q, dim ((C).repr j) = dim ((C).enum j q))
+    (X : (j : Fin (C).g) → (q : Fin ((C).copies j)) →
+      GL (Fin (dim ((C).enum j q))) ℂ)
+    (ζ : (j : Fin (C).g) → Fin ((C).copies j) → ℂ)
+    (hXDist : ∀ j, X j ⟨0, (C).copies_pos j⟩ = 1)
+    (hCoeffPos : ∀ j q, (0 : ℂ) < μ ((C).enum j q) * ζ j q)
+    (hCorner : ∀ j q v,
+      (μ ((C).enum j q) * ζ j q) •
+          ((X j q : Matrix (Fin (dim ((C).enum j q)))
+              (Fin (dim ((C).enum j q))) ℂ) *
+            (cast (congrArg (MPSTensor (D * D)) (hdim j q))
+              (blocks ((C).repr j))) v *
+            (↑((X j q)⁻¹) : Matrix (Fin (dim ((C).enum j q)))
+              (Fin (dim ((C).enum j q))) ℂ)) =
+        (V ((C).enum j q))ᴴ * verticalTensor M v * V ((C).enum j q))
+    (j : Fin (C).g) (q : Fin ((C).copies j)) :
+    ∃ ω : ℝ, 0 < ω ∧
+      ((Real.sqrt ω : ℂ))⁻¹ •
+          (X j q : Matrix (Fin (dim ((C).enum j q)))
+            (Fin (dim ((C).enum j q))) ℂ) ∈
+        Matrix.unitaryGroup (Fin (dim ((C).enum j q))) ℂ := by
+  obtain ⟨ω, hω, hGram⟩ :=
+    IsMPDO.grouped_sector_gram_eq_pos_smul_one blocks hM hHorizontal μ V
+      hDimPos hNormal hdim X ζ hXDist hCoeffPos hCorner j q
+  have hOneDet : IsUnit
+      (1 : Matrix (Fin (dim ((C).enum j q)))
+        (Fin (dim ((C).enum j q))) ℂ).det := by
+    simp
+  have hUnit := Matrix.smul_mul_nonsing_inv_mem_unitaryGroup_of_gram_eq_smul
+    (X := (X j q : Matrix (Fin (dim ((C).enum j q)))
+      (Fin (dim ((C).enum j q))) ℂ))
+    (Y := (1 : Matrix (Fin (dim ((C).enum j q)))
+      (Fin (dim ((C).enum j q))) ℂ)) hOneDet hω (by simpa using hGram)
+  refine ⟨ω, hω, ?_⟩
+  simpa using hUnit
+
+end GroupedSectors
+
+end MPOTensor

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -2242,6 +2242,45 @@
     $\sqrt\omega$ makes it unitary.
 \end{proof}
 
+\begin{theorem}[Normalization of the grouped vertical gauges]
+    \label{thm:mpdo_grouped_sector_unitary_normalization}
+    \lean{MPOTensor.IsMPDO.grouped_sector_gram_eq_pos_smul_one}
+    \lean{MPOTensor.IsMPDO.grouped_sector_exists_unitary_normalization}
+    \leanok
+    \uses{thm:mpdo_grouped_sector_gram_conjugation,
+        thm:eq3_of_dressed_adjoint,
+        thm:mpdo_vertical_bnt_grouping_with_isometries}
+    In the grouped vertical decomposition of a horizontally canonical
+    matrix-product density operator, let $X_{\alpha,k}$ be the gauge of a
+    copy of the normal representative $M_\alpha$, with the distinguished
+    gauge fixed to $X_{\alpha,1}=\Id$.  Then there is a positive real number
+    $\omega_{\alpha,k}$ such that
+    \[
+        X_{\alpha,k}^\dagger X_{\alpha,k}
+        =\omega_{\alpha,k}\Id,
+    \]
+    and
+    \[
+        U_{\alpha,k}
+        =\omega_{\alpha,k}^{-1/2}X_{\alpha,k}
+    \]
+    is unitary.  This is the normalization in
+    \cite[Proposition~4.13, lines~1903--1921]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_grouped_sector_gram_conjugation,
+        thm:eq3_of_dressed_adjoint}
+    Transport the normal representative to the bond space of the chosen
+    copy.  Theorem~\ref{thm:mpdo_grouped_sector_gram_conjugation} states that
+    conjugation by $X_{\alpha,k}^\dagger X_{\alpha,k}$ fixes every letter of
+    the transported tensor.  Apply
+    Theorem~\ref{thm:eq3_of_dressed_adjoint} with the second gauge equal to
+    the identity.  The resulting Gram identity has a positive real scalar,
+    and division by its positive square root gives the stated unitary.
+\end{proof}
+
 \begin{lemma}[Matrix product vector of the diagonal tensor]
     \label{lem:mpv_diagonal_tensor}
     \lean{MPOTensor.mpv_diagonalTensor}
@@ -2844,6 +2883,7 @@
         thm:mpdo_reflected_marked_chain,
         thm:mpdo_pairwise_vertical_gram_conjugation,
         thm:mpdo_grouped_sector_gram_conjugation,
+        thm:mpdo_grouped_sector_unitary_normalization,
         thm:vertical_sector_coisometry,
         lem:mpdo_vertical_retained_class_nonempty,
         thm:projector_closure_canonical_form,
@@ -2883,6 +2923,7 @@
         thm:mpdo_vertical_bnt_grouping_with_isometries,
         thm:mpdo_reflected_marked_chain,
         thm:mpdo_pairwise_vertical_gram_conjugation,
+        thm:mpdo_grouped_sector_unitary_normalization,
         thm:vertical_sector_coisometry,
         lem:mpdo_vertical_retained_class_nonempty,
         thm:projector_closure_canonical_form,
@@ -2946,38 +2987,38 @@
     proves the Figure~7 identity for each such sector, and
     Theorem~\ref{thm:mpdo_grouped_sector_gram_conjugation} applies the
     pairwise Gram comparison to the actual grouped corners and gives the
-    Gram-conjugation identity in Figure~8.  It remains to apply
-    Theorem~\ref{thm:eq3_of_dressed_adjoint} to derive the identity
+    Gram-conjugation identity in Figure~8.
+    Theorem~\ref{thm:mpdo_grouped_sector_unitary_normalization} applies
+    normal-tensor rigidity to the actual grouped comparison and gives
     \[
         X_{\alpha,k}^\dagger X_{\alpha,k}
-        =\omega_{\alpha,k}\,X_{\alpha,1}^\dagger X_{\alpha,1},
+        =\omega_{\alpha,k}\Id,
     \]
-    and the isometric normalization
+    and the unitary normalization
     $U_{\alpha,k}=\omega_{\alpha,k}^{-1/2}X_{\alpha,k}$ of the sector gauges
-    from the two-gauge form of the displayed identities.  The grouped
-    decomposition fixes $X_{\alpha,1}=\Id$, so this relative normalization is
-    the source's $U_{\alpha,k}$.  Put
-    $W_{\alpha,k}=V_{\alpha,k}U_{\alpha,k}$.  Conditional on the relative
-    Gram-conjugation identity, these are isometries with orthogonal ranges,
-    and their block relations become the intertwining and literal reconstruction hypotheses of
-    Theorem~\ref{thm:vertical_sector_coisometry} after the representative bond
-    spaces have been identified.  That theorem supplies all the remaining
+    using the grouped decomposition's distinguished gauge
+    $X_{\alpha,1}=\Id$.  This is the source's $U_{\alpha,k}$.  It remains to
+    identify the representative
+    and copy bond spaces and then define
+    $W_{\alpha,k}=V_{\alpha,k}U_{\alpha,k}$.  The remaining construction must
+    prove that these maps are isometries with orthogonal ranges and that their
+    block relations give the intertwining and literal reconstruction
+    hypotheses of Theorem~\ref{thm:vertical_sector_coisometry}.  That theorem
+    supplies all the remaining
     coisometry algebra and, once the source-specific identifications below are
     made, gives $U$ with
     $U\widetilde MU^\dagger=\bigoplus_\alpha\mu_\alpha\otimes M_\alpha$ and
     the corresponding reconstruction identity; each
     $\mu_\alpha$ is diagonal, so the summands regroup as repeated weighted
     copies of $M_\alpha$ exactly as in the finite regrouping of
-    Lemma~\ref{lem:vertical_grouping_equiv}.
-    Consequently, the conclusion stated at lines 1903--1908 has not yet been
-    derived from the matrix-product-density-operator hypotheses.  The generic
-    block-row construction is already proved.  The remaining step is to apply
-    normal-tensor Gram rigidity to the grouped comparison.  After the relative
-    normalization, the remaining source-specific identifications are to form the normalized
-    sector isometries, transport each copy bond space to its representative
-    bond space using the dimension equalities from the grouping theorem,
-    index the sectors by dependent pairs $(\alpha,q)$, and identify their
-    dependent disjoint union with the standard direct-sum coordinate space.
+    Lemma~\ref{lem:vertical_grouping_equiv}.  The remaining proof is to form
+    the normalized physical sector isometries, transport each copy bond space
+    to its representative bond space, and assemble the physical coisometry.  The
+    generic block-row construction is already proved, but its source-specific
+    application must still index the sectors by dependent pairs
+    $(\alpha,q)$ and identify their dependent disjoint union with the standard
+    direct-sum coordinate space.  The remaining boundary is the final
+    coisometry and literal vertical canonical-form identity.
 
     Conditional on that construction, the algebraic basis-of-normal-tensors
     clauses are verified as follows.  With the notation of the grouping
@@ -3013,12 +3054,9 @@
     the span of those of the $M_\alpha$.
 
     The empty chain is separate because the bond dimensions of
-    $\widetilde M$ and $B$ may differ.  Before choosing a representative, one
-    needs the nonemptiness assertion in
-    Lemma~\ref{lem:mpdo_vertical_retained_class_nonempty}; this is a separate
-    open obligation, since the present grouping theorem does not include
-    nonemptiness in its conclusion.  Once that lemma is proved, choose a
-    retained representative $M_{\alpha_0}$ of bond dimension
+    $\widetilde M$ and $B$ may differ.
+    Lemma~\ref{lem:mpdo_vertical_retained_class_nonempty} supplies a retained
+    representative $M_{\alpha_0}$ of bond dimension
     $d_{\alpha_0}>0$.  By
     Lemma~\ref{lem:mpv_zero_length}, assigning it the coefficient
     $d/d_{\alpha_0}$ and assigning zero to the other representatives gives

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -2923,6 +2923,7 @@
         thm:mpdo_vertical_bnt_grouping_with_isometries,
         thm:mpdo_reflected_marked_chain,
         thm:mpdo_pairwise_vertical_gram_conjugation,
+        thm:mpdo_grouped_sector_gram_conjugation,
         thm:mpdo_grouped_sector_unitary_normalization,
         thm:vertical_sector_coisometry,
         lem:mpdo_vertical_retained_class_nonempty,

--- a/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
@@ -164,9 +164,10 @@ some finite length.  The MPDO trace argument then proves that every grouped
 coefficient is positive.  This is the phase-class decomposition and positivity
 argument of source lines~1898--1902, obtained by combining the BNT
 characterization at lines~1135--1148 with the preceding isometry-preserving
-vertical sector theorem.  It does not formalize the positive-diagonal isometry
-asserted at lines~1895--1896 or the subsequent gauge normalization and final
-coisometry.  Equality of
+vertical sector theorem.  By itself it does not formalize the
+positive-diagonal isometry asserted at lines~1895--1896, the subsequent gauge
+normalization, or the final coisometry; the gauge normalization is supplied
+below.  Equality of
 the bond dimensions within each phase class is obtained from non-decay of the
 positive-length rectangular overlap, as in Lemma~\texttt{equalMPS}; the
 empty-word coefficient is not used in this comparison.
@@ -212,34 +213,38 @@ X_{\alpha,k}^\dagger X_{\alpha,k}
 The relative gauge $X_{\alpha,k}X_{\alpha,1}^{-1}$ becomes unitary after
 division by $\sqrt{\omega_{\alpha,k}}$.  The grouping theorem now exposes its choice
 $X_{\alpha,1}=\Id$, giving the normalization printed by the source
-(\path{MPSTensor.IsNormal.gram_eq_pos_smul_gram_of_gram_conj_eq} in
-\path{TNLean/MPS/CanonicalForm/NormalCommutant.lean}).
+(\path{MPOTensor.IsMPDO.grouped_sector_gram_eq_pos_smul_one} and
+\path{MPOTensor.IsMPDO.grouped_sector_exists_unitary_normalization} in
+\path{TNLean/MPS/MPDO/GroupedGramNormalization.lean}).
 
 The reflected marked-chain, two-sector separation, and dependent-dimension
-transport of source lines~1909--1919 are therefore complete.  What remains is
-to apply normal-tensor Gram rigidity to this grouped comparison and normalize
-the copy embeddings.  Their generic assembly into the direct-sum coisometry
-$U$ is already
+transport of source lines~1909--1919 are therefore complete, as is the
+positive scalar Gram identity and unitary normalization of every grouped
+gauge.  What remains is to transport these unitary gauges to common
+representative bond spaces, compose them with the physical sector isometries,
+and establish the normalized physical maps required by the final coisometry.
+Their generic assembly into the direct-sum coisometry $U$ is already
 proved by \path{Matrix.sigmaBlockRow_isCoisometry},
 \path{Matrix.sigmaBlockRow_conjugation}, and
 \path{Matrix.sigmaBlockRow_reconstruction}.  The remaining source-specific
 identifications are to transport the copy bond spaces along the dimension
 equalities supplied by the grouping theorem, index the sectors by dependent
 pairs $(\alpha,q)$, and identify the dependent disjoint union with the
-standard direct-sum coordinate space.  The algebraic BNT predicate also
-requires a retained representative; its existence must still be deduced from
-horizontal canonical form and the literal reconstruction of the nonzero
-vertical tensor.  Consequently, the relative Gram conclusion at
-lines~1903--1908 has not yet been derived from the MPDO hypotheses.  These
-gauge and coisometry conclusions are not part of the grouping theorem.  The original
+standard direct-sum coordinate space.  A retained representative is already
+supplied by
+\path{MPOTensor.IsHorizontalCF.exists_nonempty_verticalBNTGrouping} in
+\path{TNLean/MPS/MPDO/RetainedClass.lean}.  Thus only the source-specific
+normalized physical maps, their final coisometry, the direct-sum indexing,
+and the literal vertical canonical-form identity remain.  The original
 formulation of \ghissue{2536}, interpreted as a direct conversion of the
 horizontal scalar weights and diagonal restrictions, is therefore not a
 consequence of Proposition~4.13.
 
 \paragraph{Verdict.}
-This is an open gap: Figure~8 is complete for the actual grouped sectors, but
-the normal-tensor Gram normalization and the final physical coisometry have
-not yet been derived from the matrix-product-density-operator hypotheses.
+This is an open gap: Figure~8 and the normal-tensor Gram normalization are
+complete for the actual grouped sectors, but the normalized physical maps and
+their final coisometry have not yet been assembled from the
+matrix-product-density-operator hypotheses.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
@@ -173,19 +173,19 @@ $\mu_{\alpha,1}>0$ (\path{TNLean/MPS/MPDO/VerticalBNT.lean} and
 identity of the second displayed diagram at lines~1914--1919 is proved in
 \path{TNLean/MPS/MPDO/FigureEightPairwise.lean}, and its dependent transport
 to the actual grouped sectors is proved in
-\path{TNLean/MPS/MPDO/GroupedFigure8.lean}.  Together with the scalar
-commutant of a normal tensor, this identity shows that the Gram matrix of
-each sector gauge $X_{\alpha,k}$ is
-a positive real multiple of the reference Gram matrix,
+\path{TNLean/MPS/MPDO/GroupedFigure8.lean}.  Normal-tensor rigidity then shows
+that the Gram matrix of each sector gauge $X_{\alpha,k}$ is a positive real
+multiple of the reference Gram matrix,
 \[
 X_{\alpha,k}^\dagger X_{\alpha,k}
 =\omega_{\alpha,k}X_{\alpha,1}^\dagger X_{\alpha,1}.
 \]
 The relative gauge $X_{\alpha,k}X_{\alpha,1}^{-1}$ is therefore proportional
-to a unitary; the grouping chooses $X_{\alpha,1}=\Id$.  This follows because
-a normal tensor has scalar
-commutant
-(\path{TNLean/MPS/CanonicalForm/NormalCommutant.lean}). Projector closure and
+to a unitary; the grouping chooses $X_{\alpha,1}=\Id$.  The positive scalar
+identity and the unitary normalization of the actual grouped gauge are proved
+in \path{TNLean/MPS/MPDO/GroupedGramNormalization.lean}, with the source
+passage at lines~1903--1921 recorded in both theorem docstrings.  Projector
+closure and
 the absence of periodic vectors already give an abstract positive-length
 normal-block decomposition
 (\path{TNLean/MPS/CanonicalForm/ProjectorClosureSpectral.lean}). The literal
@@ -195,10 +195,11 @@ grouped into pairwise gauge-phase-distinct BNT representatives in
 \path{TNLean/MPS/MPDO/VerticalBNT.lean}. Every copy is expressed by a positive
 coefficient, a unit-modulus phase, and an invertible bond-space gauge, while
 the physical isometries and the literal vertical reconstruction are retained.
-What remains is to apply normal-tensor Gram rigidity to this grouped
-comparison, normalize the resulting sector maps, and assemble them into the
-final coisometry.  Consequently, the conclusion stated at lines~1903--1908
-has not yet been derived from the MPDO hypotheses.
+What remains is to transport the unitary gauge normalizations to common
+representative bond spaces, compose them with the physical sector isometries,
+and assemble these normalized physical maps into the final coisometry.  The
+literal vertical canonical-form identity has therefore not yet been derived
+from the MPDO hypotheses.
 
 \paragraph{Verdict.}
 This is an open gap: the source-faithful horizontal-to-vertical implication of


### PR DESCRIPTION
## Mathematical result

This completes the normal Gram and unitary normalization step in arXiv:1606.00608, Proposition 4.13, lines 1903--1921.

For every actual grouped vertical sector furnished by `exists_verticalBNTGrouping_with_isometry`, the new theorems prove that there is a real number `ω > 0` such that

[
X_{α,q}† X_{α,q} = ω I,
]

and that `ω^{-1/2} X_{α,q}` belongs to the unitary group.

The proof uses the grouped Figure 8 identity from #3907, transports normality to the copy bond space, applies the existing normal-tensor Gram rigidity theorem with the distinguished gauge equal to the identity, and then applies the existing matrix normalization lemma.

No extra mathematical hypothesis is added beyond clauses already furnished by the grouped decomposition.

## Documentation

The chapter-20 blueprint records the grouped normalization theorem and cites it in the unfinished Proposition 4.13 argument. Both vertical-grouping paper-gap notes now place the remaining boundary at the normalized physical sector maps, dependent direct-sum indexing, and final coisometry.

## Verification

- direct Lean compilation
- `lake build TNLean` (9395 jobs)
- blueprint declaration and Blueprint–Lean synchronization checks
- reader-facing prose check
- explicit `#print axioms` audit: only `propext`, `Classical.choice`, and `Quot.sound`
- prohibited-token and final-diff checks

Closes #3890.
Closes #3887.
Advances #3674.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal mathematics and documentation on the MPDO vertical canonical-form track; no runtime, auth, or data-path changes.
> 
> **Overview**
> Formalizes the **normal Gram and unitary normalization** step in Cirac et al. Proposition 4.13 (lines 1903–1921): for each grouped vertical sector from the BNT grouping, sector gauges satisfy \(X^\dagger X = \omega I\) with \(\omega > 0\), and \(\omega^{-1/2} X\) is unitary.
> 
> Adds `GroupedGramNormalization.lean` with `IsMPDO.grouped_sector_gram_eq_pos_smul_one` and `IsMPDO.grouped_sector_exists_unitary_normalization`, chaining the grouped Figure 8 Gram-conjugation identity to existing normal-tensor Gram rigidity and matrix unitary normalization (distinguished gauge \(X_{\alpha,1} = \mathrm{Id}\)). Registers the module in `TNLean.lean`.
> 
> Blueprint chapter 20 and the vertical-grouping paper-gap notes now cite this theorem and move the **remaining** Proposition 4.13 work to normalized physical sector maps (\(W_{\alpha,k} = V_{\alpha,k} U_{\alpha,k}\)), dependent direct-sum indexing, and the final coisometry—not Gram normalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c68347970921a002c660fc2f7482f2471c38a82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->