### PR TITLE
doc(blueprint): refine MPO and RFP presentation

### DIFF
--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -461,10 +461,6 @@
     the resulting algebraic extension of
     \cite[Appendix~C.3, lines~1848--1858]{Cirac2016MPDO_arXiv}; it is not
     attributed to the paper as a separately stated arbitrary-mark theorem.
-    In the application to
-    \cite[Proposition~4.13, lines~1909--1919]{Cirac2016MPDO_arXiv}, the
-    marked families must still be obtained from the actual grouped vertical
-    corners before this separation theorem is applied.
 \end{theorem}
 
 \begin{proof}
@@ -2998,32 +2994,58 @@
     and the unitary normalization
     $U_{\alpha,k}=\omega_{\alpha,k}^{-1/2}X_{\alpha,k}$ of the sector gauges
     using the grouped decomposition's distinguished gauge
-    $X_{\alpha,1}=\Id$.  This is the source's $U_{\alpha,k}$.  It remains to
-    identify the representative
-    and copy bond spaces and then define
-    $W_{\alpha,k}=V_{\alpha,k}U_{\alpha,k}$.  The remaining construction must
-    prove that these maps are isometries with orthogonal ranges and that their
-    block relations give the intertwining and literal reconstruction
-    hypotheses of Theorem~\ref{thm:vertical_sector_coisometry}.  That theorem
-    supplies all the remaining
-    coisometry algebra and, once the source-specific identifications below are
-    made, gives $U$ with
-    $U\widetilde MU^\dagger=\bigoplus_\alpha\mu_\alpha\otimes M_\alpha$ and
-    the corresponding reconstruction identity; each
-    $\mu_\alpha$ is diagonal, so the summands regroup as repeated weighted
-    copies of $M_\alpha$ exactly as in the finite regrouping of
-    Lemma~\ref{lem:vertical_grouping_equiv}.  The remaining proof is to form
-    the normalized physical sector isometries, transport each copy bond space
-    to its representative bond space, and assemble the physical coisometry.  The
-    generic block-row construction is already proved, but its source-specific
-    application must still index the sectors by dependent pairs
-    $(\alpha,q)$ and identify their dependent disjoint union with the standard
-    direct-sum coordinate space.  The remaining boundary is the final
-    coisometry and literal vertical canonical-form identity.
+    $X_{\alpha,1}=\Id$.  This is the source's $U_{\alpha,k}$.
+    After identifying the bond space of each copy with that of its
+    representative, define
 
-    Conditional on that construction, the algebraic basis-of-normal-tensors
-    clauses are verified as follows.  With the notation of the grouping
-    theorem, its spectral BNT property applies to the raw weighted tensor
+    \[
+        W_{\alpha,k}=V_{\alpha,k}U_{\alpha,k}.
+    \]
+
+    Since $V_{\alpha,k}$ is an isometry and $U_{\alpha,k}$ is unitary,
+
+    \[
+        W_{\alpha,k}^\dagger W_{\alpha,k}=\Id,
+        \qquad
+        W_{\alpha,k}^\dagger W_{\beta,l}=0
+        \quad\text{if }(\alpha,k)\ne(\beta,l).
+    \]
+
+    The sector gauge relation and the literal reconstruction of
+    $\widetilde M$ become
+
+    \[
+        \widetilde M_vW_{\alpha,k}
+          =W_{\alpha,k}(\mu_{\alpha,k}M_\alpha^v),
+        \qquad
+        \widetilde M_v
+          =\sum_{\alpha,k}
+            W_{\alpha,k}(\mu_{\alpha,k}M_\alpha^v)
+            W_{\alpha,k}^\dagger.
+    \]
+
+    Theorem~\ref{thm:vertical_sector_coisometry}, indexed by the dependent
+    pairs $(\alpha,k)$, therefore gives a coisometry $U$ such that
+
+    \[
+        U\widetilde MU^\dagger
+          =\bigoplus_{\alpha,k}\mu_{\alpha,k}M_\alpha,
+        \qquad
+        \widetilde M
+          =U^\dagger\!\left(
+              \bigoplus_{\alpha,k}\mu_{\alpha,k}M_\alpha
+            \right)U.
+    \]
+
+    The dependent disjoint union of the sector bond indices has its canonical
+    identification with the standard direct-sum coordinates.  Regrouping the
+    summands by $\alpha$ gives
+    $\bigoplus_\alpha\mu_\alpha\otimes M_\alpha$ as in
+    Lemma~\ref{lem:vertical_grouping_equiv}.
+
+    The algebraic basis-of-normal-tensors clauses follow from the same
+    decomposition.  With the notation of the grouping theorem, its spectral
+    BNT property applies to the raw weighted tensor
     \[
         A_{\mathrm{ret}}
         =\bigoplus_{\alpha,k}\nu_{\alpha,k}B_{\alpha,k}.
@@ -3054,13 +3076,12 @@
     Thus the positive-length matrix product vectors of $\widetilde M$ lie in
     the span of those of the $M_\alpha$.
 
-    The empty chain is separate because the bond dimensions of
-    $\widetilde M$ and $B$ may differ.
-    Lemma~\ref{lem:mpdo_vertical_retained_class_nonempty} supplies a retained
-    representative $M_{\alpha_0}$ of bond dimension
-    $d_{\alpha_0}>0$.  By
-    Lemma~\ref{lem:mpv_zero_length}, assigning it the coefficient
-    $d/d_{\alpha_0}$ and assigning zero to the other representatives gives
-    the length-zero coefficient $d$ of $\widetilde M$.  This proves the
-    spanning clause at every length once the coisometry has been constructed.
+    The empty chain requires a separate argument because the bond dimensions
+    of $\widetilde M$ and $B$ may differ.  By
+    Lemma~\ref{lem:mpdo_vertical_retained_class_nonempty}, choose a retained
+    representative $M_{\alpha_0}$ with bond dimension $d_{\alpha_0}>0$.
+    Assign it the coefficient $d/d_{\alpha_0}$ and assign zero to every other
+    representative.  Lemma~\ref{lem:mpv_zero_length} then gives the
+    length-zero coefficient $d$ of $\widetilde M$.  Hence the spanning clause
+    holds at every length.
 \end{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -11,8 +11,7 @@
     the length-$L$ product
     $O_L(M_\alpha)O_L(M_\beta)$, not to the blocked-basis multiplication
     $\mathcal A_n\times\mathcal A_n\to\mathcal A_{2n}$.
-    When a diagonal $\chi$-family has already been constructed, it also
-    canonically determines the coefficient family
+    A diagonal $\chi$-family canonically determines the coefficient family
     $c^{(L)}_{\alpha,\beta,\gamma}
         = \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{L})
         = \sum_r\chi_{\alpha,\beta,\gamma,r}^{\,L}$, as in
@@ -25,8 +24,8 @@
     \leanok
     A BNT-label operator family records, for each chain length $L$, the
     operators $O_L(M_\alpha)$ indexed by the fixed BNT labels $\alpha$.
-    The ambient algebra at length $L$ is left abstract here; the later
-    comparison step must relate it to the chosen blocked support algebras.
+    The ambient algebra may depend on $L$ and is not identified with a chosen
+    blocked support algebra.
 \end{definition}
 
 \begin{figure}[ht]
@@ -149,8 +148,6 @@
     This is a blocked-basis comparison: the left hand side is expanded in the
     chosen basis of $\mathcal A_{2n}$, so the statement is not itself the
     same-length BNT product law.
-    This records the coefficient-comparison statement separately from the
-    construction of the label maps from the MPDO tensor.
 \end{definition}
 
 \begin{theorem}[Blocked coefficients are pulled back from BNT labels]%
@@ -229,8 +226,7 @@
     diagonal $\chi_{\alpha,\beta,\gamma}$-family, positivity of every
     diagonal entry, and the positive-length trace-power identity for the
     BNT-label coefficients. This is the coefficient statement of
-    \cite[Theorem~4.14(ii)]{Cirac2016MPDO_arXiv}; constructing the witness from an MPDO tensor and
-    comparing it to blocked bases remain separate obligations.
+    \cite[Theorem~4.14(ii)]{Cirac2016MPDO_arXiv}.
     If the coefficient family is chosen canonically from the same
     $\chi$-family, positivity of the diagonal entries alone gives such a
     witness.
@@ -381,9 +377,9 @@
         \chi_{n,i,j,k}
         = \diag\bigl(\chi_{n,i,j,k,1}, \ldots, \chi_{n,i,j,k,r_{n,i,j,k}}\bigr).
     \]
-    This is a blocked-basis analog of the uniform BNT-label family in
-    \cite[Theorem~4.14(ii)]{Cirac2016MPDO_arXiv}; the remaining uniformity
-    gap is open.
+    Unlike the uniform BNT-label family in
+    \cite[Theorem~4.14(ii)]{Cirac2016MPDO_arXiv}, the size and diagonal
+    entries may depend on the blocked length and on the chosen basis indices.
 \end{definition}
 % The uniformity gap is documented in
 % docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex.
@@ -453,8 +449,8 @@
     positive-length trace-power identity for the blocked multiplication
     coefficients. This is the blocked-basis analog of the positive
     diagonal matrices in
-    \cite[Theorem~4.14(ii)]{Cirac2016MPDO_arXiv}; the uniform BNT-label gap
-    remains open.
+    \cite[Theorem~4.14(ii)]{Cirac2016MPDO_arXiv}, without requiring a single
+    family indexed only by the BNT labels.
 \end{definition}
 % The uniformity gap is documented in
 % docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
@@ -57,6 +57,7 @@
     This is the same-length product law carried by the theorem data.
 \end{proof}
 
+
 \begin{theorem}[BNT theorem data give the idempotent scalar law]%
     \label{thm:mpdo_bnt_label_theorem_data_idempotent_eq_sum}
     \lean{MPOTensor.BNTLabelTheoremData.idempotent_eq_sum}
@@ -225,8 +226,8 @@
         =
         \chi_{\sigma_n(i),\sigma_n(j),\tau_n(k)}.
     \]
-    The size, diagonal entries, and traces of powers of $\chi_{n,i,j,k}$
-    therefore agree with those of $\chi_{\sigma_n(i),\sigma_n(j),\tau_n(k)}$.
+    Thus the two matrices have equal size, diagonal entries, and traces of all
+    powers.
 \end{theorem}
 \begin{proof}\leanok
     Apply the BNT-to-blocked witness construction to the comparison and the
@@ -309,4 +310,3 @@
     Apply the trace-power identity of the positive blocked-basis
     $\chi$-witness obtained from the theorem data.
 \end{proof}
-

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -163,10 +163,8 @@
     \[
         \rho^{(N)}(M)=c\prod_{i=0}^{N-1}B_{i,i+1}.
     \]
-    This is the commuting-form half of
-    \cite[Proposition~C.8]{Cirac2016MPDO_arXiv}, taking the $\eta$-local data as
-    given. Deriving these operators from saturation of the area law remains
-    open.
+    This is the implication from $\eta$-local structure to commuting form in
+    \cite[Proposition~C.8]{Cirac2016MPDO_arXiv}.
     % Gap documented in docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex.
 \end{theorem}
 
@@ -195,9 +193,8 @@
     \leanok
     \uses{thm:mpdo_eta_local_structure_has_commuting_form,
         thm:mpdo_is_gsnnch_zcl_iff_has_commuting_form_and_is_zcl}
-    Once the $\eta$-local structure gives the commuting nearest-neighbor
-    product form, adding the doubled-index transfer condition gives the
-    corresponding GSNNCH branch.
+    An $\eta$-local structure together with the doubled-index transfer
+    condition gives the corresponding GSNNCH branch.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -210,8 +207,8 @@
     \lean{MPOTensor.hasCommutingForm_of_etaLocalStructure}
     \leanok
     \uses{thm:mpdo_eta_local_structure_has_commuting_form}
-    Once the explicit neighboring operators $\eta_{k,h}$ have been assembled
-    into an $\eta$-local structure, the global commuting-form property follows.
+    A tensor equipped with the $\eta$-local structure determined by the
+    neighboring operators $\eta_{k,h}$ has the global commuting-form property.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -224,19 +221,18 @@
     \lean{MPOTensor.isGSNNCH_of_etaLocalStructure}
     \leanok
     \uses{thm:mpdo_eta_local_structure_is_gsnnch}
-    Once the explicit neighboring operators $\eta_{k,h}$ have been assembled
-    into the $\eta$-local structure, the GSNNCH condition follows.
+    A tensor equipped with the $\eta$-local structure determined by the
+    neighboring operators $\eta_{k,h}$ satisfies the GSNNCH condition.
 \end{theorem}
 
 \begin{proof}\leanok
     This is the GSNNCH witness already carried by the $\eta$-local structure.
 \end{proof}
 
-\begin{remark}[Entropy-side construction]
-    The remaining entropy-side step is to derive from $\mathrm{SAL}(K)$ a
-    physical-sector factorization whose neighboring operators
-    $\eta_{k,h}$ are simultaneously positive semidefinite. Given such a
-    factorization, the two-site bond is
+\begin{remark}[Positive physical-sector factorization]
+    Suppose that $K$ satisfies $\mathrm{SAL}(K)$ and admits a physical-sector
+    factorization whose neighboring operators $\eta_{k,h}$ are simultaneously
+    positive semidefinite. The associated two-site bond is
     \begin{equation}\label{eq:mpdo_eta_bond_assembly}
         B=\sum_{k,h}
         \operatorname{Id}_{H_L^{(k)}}\otimes
@@ -250,8 +246,9 @@
         \qquad c_N>0,\qquad
         [B_{i,i+1},B_{j,j+1}]=0.
     \end{equation}
+    Under this hypothesis,
     Theorem~\ref{thm:mpdo_eta_local_structure_of_positive_physical_sector_factorization}
-    constructs the $\eta$-local structure and proves
+    gives the $\eta$-local structure and proves
     (\ref{eq:mpdo_eta_bond_assembly})--(\ref{eq:mpdo_eta_product_form}) with
     $c_N=1$. Theorem~\ref{thm:mpdo_has_commuting_form_of_eta_local_structure}
     then gives the commuting-form conclusion. Adjacent translates commute on every
@@ -261,12 +258,10 @@
     Theorem~\ref{thm:mpdo_physical_two_site_crossed_bonds_comm}. Disjoint
     translates commute by
     Theorem~\ref{thm:mpdo_periodic_disjoint_physical_bonds_comm}. These cases
-    are assembled into pairwise commutativity at every length $N\geq2$ in
+    give pairwise commutativity at every length $N\geq2$ by
     Theorem~\ref{thm:mpdo_periodic_pairwise_physical_bonds_comm}. Given the
     physical-sector factorization, the all-length product identity is
-    Theorem~\ref{thm:mpdo_exact_physical_sector_bond_product}. The remaining
-    entropy-side problem is precisely the construction of a coherently
-    positive physical-sector factorization from SAL.
+    Theorem~\ref{thm:mpdo_exact_physical_sector_bond_product}.
     The doubled-index transfer condition enters only in the subsequent RFP and
     GSNNCH branch conclusions.
 \end{remark}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -1440,7 +1440,6 @@ separate step.
         left-tree coordinates indexing columns.}
     \label{fig:mpdo_complete_zipper_fusion_pentagon}
 \end{figure}
-\clearpage
 
 \begin{theorem}[Complete zipper fusion pentagon]%
     \label{thm:mpdo_complete_zipper_fusion_pentagon}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_normalized_preparations.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_normalized_preparations.tex
@@ -957,6 +957,18 @@
 \end{proof}
 \end{samepage}
 
+On each fixed $(k,h)$-summand, the controlled maps $\mathcal T_0$ and
+$\mathcal S_0$ discard coherences between distinct outer summands and take the
+displayed partial trace in each diagonal summand. In particular,
+$\mathcal S_0$ traces the whole space
+\[
+  \bigoplus_l
+  \bigl[(R_k\otimes L_l)\otimes(R_l\otimes L_h)\bigr].
+\]
+The shifts $\mathcal S_2$ and $\mathcal T_2$ are global reindexings, with all
+displayed tensor factors present at their inputs
+\cite[Appendix~C.2, lines~1521--1559]{Cirac2016MPDO_arXiv}.
+
 \begin{figure}[ht]
     \centering
     $\displaystyle\bigoplus_{k,h}$; one $(k,h)$-fiber is drawn
@@ -969,13 +981,7 @@
 
     \smallskip
     \TNMPDOThreeSiteTraceAndShift
-    \caption{Schematics on a fixed $(k,h)$-summand of the global $\bigoplus_{k,h}$ index
-    space. The controlled maps $\mathcal T_0$ and $\mathcal S_0$ discard coherences between
-    distinct outer summands and take the displayed trace in each diagonal summand; the shifts
-    $\mathcal S_2$ and $\mathcal T_2$ are global reindexings. The $l$-labelled boxes depict one
-    summand, but $\mathcal S_0$ traces the entire
-    $\bigoplus_l[(R_k\otimes L_l)\otimes(R_l\otimes L_h)]$. Both shifts begin with all displayed
-    factors supplied; no preparation or recovery identity is shown
-    \cite[Appendix~C.2, lines~1521--1559]{Cirac2016MPDO_arXiv}.}
+    \caption{Fiberwise partial traces and regrouping maps on two and three
+    physical sites. One $(k,h)$-summand and one $l$-summand are drawn.}
     \label{fig:mpdo_regrouping_partial_trace_maps}
 \end{figure}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels.tex
@@ -129,26 +129,31 @@
     this property is preserved under composition.
 \end{proof}
 
+On the active $(k,h)$-sector, $\mathcal T_0$ traces $R_k\otimes L_h$, leaving
+$a_kb_h$ times the operator on $L_k\otimes R_h$. The preparation
+$\mathcal T_1$ then adjoins
+\[
+  \widehat\Omega_{k,h}
+  =(a_kb_h)^{-1}\bigoplus_l(\eta_{k,l}\otimes\eta_{l,h}),
+\]
+and $\mathcal T_2$ orders the result as
+\[
+  (L_k\otimes R_k)\otimes(L_l\otimes R_l)\otimes(L_h\otimes R_h).
+\]
+The two rows in Figure~\ref{fig:mpdo_physical_sector_refinement_channel} use
+the sitewise sector coordinates $\mathfrak R_2$ and $\mathfrak R_3$
+\cite[Appendix~C.2, lines~1510--1516 and~1522--1545]
+  {Cirac2016MPDO_arXiv}.
+
 \begin{figure}[ht]
     \centering
     \TNMPDORefinementConstruction
 
     \medskip
     \TNMPDORefinementDirection
-    \caption{Physical-sector construction of the refinement channel
-    $\mathcal T=\mathcal T_2\mathcal T_1\mathcal T_0$. On a two-site closure,
-    the first stage traces $R_k\otimes L_h$ and leaves $a_kb_h$ multiplying
-    the operator on $L_k\otimes R_h$. On an active sector pair, the second
-    stage adjoins
-    $\widehat\Omega_{k,h}=(a_kb_h)^{-1}
-      \bigoplus_l(\eta_{k,l}\otimes\eta_{l,h})$, and the final stage orders
-    the factors as
-    $(L_k\otimes R_k)\otimes(L_l\otimes R_l)\otimes(L_h\otimes R_h)$.
-    The upper and lower rows lie in the sitewise sector coordinates
-    $\mathfrak R_2$ and $\mathfrak R_3$, respectively. The lower schematic
-    records the intended two-site to three-site action in
-    \cite[Appendix~C.2, lines~1510--1516 and~1522--1545]
-      {Cirac2016MPDO_arXiv}; no refinement closure identity is asserted here.}
+    \caption{The refinement channel
+    $\mathcal T=\mathcal T_2\mathcal T_1\mathcal T_0$ in physical-sector
+    coordinates.}
     \label{fig:mpdo_physical_sector_refinement_channel}
 \end{figure}
 


### PR DESCRIPTION
## Mathematical presentation

Rewrites the unfinished Proposition 4.13 proof paragraph as the actual normalized-sector construction: the maps W_{α,k}, their orthogonality, intertwining, literal reconstruction, dependent direct-sum coordinates, and the BNT argument are now stated directly as mathematics. Stale development-status prose is removed.

Chapter 21 receives the same editorial treatment: open-obligation prose is replaced by precise conditional assertions, two long captions are shortened, the BNT matrix comparison is broken cleanly, and the pentagon no longer leaves a nearly blank float page.

The tensor-network grammar and the source-like Figure 7 and Figure 8 diagrams are unchanged.

## Validation

- reader-facing prose checker
- blueprint web generation with the Python 3.9 leanblueprint environment
- blueprint declaration check against the current full TNLean build
- 551-page blueprint PDF generation
- visual inspection of the pentagon, channel, BNT, and Proposition 4.13 pages
- no new overfull boxes in the edited passages
- final diff and identity checks

Advances #3897.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX in the blueprint; no Lean or runtime code changes, so impact is limited to reader-facing mathematical presentation.
> 
> **Overview**
> **Proposition 4.13 (vertical CF):** The long “remaining construction” paragraph in the horizontal-CF ⇒ vertical-CF proof is replaced by explicit steps: define `W_{α,k}=V_{α,k}U_{α,k}`, state orthogonality and intertwining, invoke `vertical_sector_coisometry` for `U`, note dependent direct-sum coordinates and regrouping by `α`, then finish the BNT spanning clauses (including the empty-chain case) without conditional scaffolding.
> 
> **Chapter 21 editorial pass:** Open-obligation and “gap remains” wording is removed or turned into precise statements (BNT coefficients/operators, blocked `χ` vs uniform BNT labels, η-local ⇒ commuting form/GSNNCH, SAL remark reframed as a **positive physical-sector factorization** hypothesis). BNT theorem-data text tightens the pulled-back matrix comparison. Two channel/trace figures get prose moved out of captions into short lead-in paragraphs; pentagon figure drops `\clearpage` to avoid a nearly blank page.
> 
> **Marked-letter theorem:** Drops the extra sentence that grouped vertical corners must be built before applying separation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b334a7d5eee245b7fd696c7faf0370264982c2fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->