### PR TITLE
feat(MPS/MPDO): derive a vertical BNT from grouped sectors

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -394,6 +394,7 @@ import TNLean.MPS.MPDO.CyclicProjector
 import TNLean.MPS.MPDO.VerticalSpectral
 import TNLean.MPS.MPDO.VerticalBNT
 import TNLean.MPS.MPDO.RetainedClass
+import TNLean.MPS.MPDO.VerticalBNTConstruction
 import TNLean.MPS.MPDO.SectorTrace
 import TNLean.MPS.MPDO.ReflectedMarkedChain
 import TNLean.MPS.MPDO.FigureEightPairwise

--- a/TNLean/MPS/MPDO/RetainedClass.lean
+++ b/TNLean/MPS/MPDO/RetainedClass.lean
@@ -78,7 +78,7 @@ private theorem bntCanonicalForm_toTensor_ne_zero
 
 Source: arXiv:1606.00608, canonical form at lines 237--246 and Proposition
 `prop:vertical`, lines 1895--1902. -/
-private theorem IsHorizontalCF.verticalTensor_ne_zero
+theorem IsHorizontalCF.verticalTensor_ne_zero
     (M : MPOTensor d D) (hHorizontal : IsHorizontalCF M) : verticalTensor M ≠ 0 := by
   obtain ⟨S, hCF, hTotal, X, hX⟩ := hHorizontal
   subst D

--- a/TNLean/MPS/MPDO/VerticalBNTConstruction.lean
+++ b/TNLean/MPS/MPDO/VerticalBNTConstruction.lean
@@ -1,0 +1,176 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.RetainedClass
+
+/-!
+# Algebraic BNT construction for grouped vertical sectors
+
+The representatives selected by the vertical grouping theorem form an
+algebraic basis of normal tensors for the vertically viewed
+tensor itself.  At positive chain length, the intertwining and literal
+reconstruction identities identify its matrix product vector with that of the
+weighted sector sum.  The empty chain is treated separately, using a retained
+representative of positive bond dimension.
+
+## Main result
+
+* `IsHorizontalCF.isBNT_verticalTensor_of_grouping`: the grouped sector
+  decomposition furnishes an `IsBNT` witness for the vertical tensor.
+
+## References
+
+* Cirac--Pérez-García--Schuch--Verstraete, arXiv:1606.00608,
+  Proposition 4.13, lines 1863--1921.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- Word evaluation respects a left intertwining by the adjoint of a sector
+isometry. -/
+private lemma conjTranspose_mul_evalWord_of_intertwining
+    {s n : ℕ} (T : MPSTensor s d) (B : MPSTensor s n)
+    (V : Matrix (Fin d) (Fin n) ℂ)
+    (hinter : ∀ v, Vᴴ * T v = B v * Vᴴ) :
+    ∀ w, Vᴴ * MPSTensor.evalWord T w = MPSTensor.evalWord B w * Vᴴ := by
+  intro w
+  induction w with
+  | nil => simp
+  | cons v w ih =>
+      rw [MPSTensor.evalWord_cons, MPSTensor.evalWord_cons, ← Matrix.mul_assoc,
+        hinter v, Matrix.mul_assoc, ih]
+      exact (Matrix.mul_assoc _ _ _).symm
+
+/-- A literal reconstruction by isometric intertwined sectors gives the
+positive-length matrix product vector of their weighted block sum. -/
+private lemma sameMPV₂Pos_toTensorFromBlocks_of_reconstruction
+    {s r : ℕ} {dim : Fin r → ℕ}
+    (T : MPSTensor s d) (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor s (dim k))
+    (V : (k : Fin r) → Matrix (Fin d) (Fin (dim k)) ℂ)
+    (hiso : ∀ k, (V k)ᴴ * V k = 1)
+    (hinter : ∀ k v, (V k)ᴴ * T v = (μ k • blocks k v) * (V k)ᴴ)
+    (hreconstruct : ∀ v, T v = ∑ k, V k * (μ k • blocks k v) * (V k)ᴴ) :
+    MPSTensor.SameMPV₂Pos T
+      (MPSTensor.toTensorFromBlocks (d := s) (μ := μ) blocks) := by
+  intro N hN σ
+  rw [MPSTensor.mpv_toTensorFromBlocks_eq_sum]
+  simp only [MPSTensor.mpv, MPSTensor.coeff]
+  have hword : List.ofFn σ ≠ [] := by
+    intro hzero
+    have hlength := congrArg List.length hzero
+    simp only [List.length_ofFn, List.length_nil] at hlength
+    omega
+  obtain ⟨v, w, hw⟩ := List.exists_cons_of_ne_nil hword
+  rw [hw, MPSTensor.evalWord_cons, hreconstruct v, Finset.sum_mul,
+    Matrix.trace_sum]
+  refine Finset.sum_congr rfl fun k _ => ?_
+  have hinterWord := conjTranspose_mul_evalWord_of_intertwining
+    T (fun x => μ k • blocks k x) (V k) (hinter k) w
+  calc
+    Matrix.trace ((V k * (μ k • blocks k v) * (V k)ᴴ) *
+        MPSTensor.evalWord T w) =
+        Matrix.trace ((V k * (μ k • blocks k v)) *
+          ((V k)ᴴ * MPSTensor.evalWord T w)) := by
+            rw [Matrix.mul_assoc, Matrix.mul_assoc]
+    _ = Matrix.trace (((V k)ᴴ * MPSTensor.evalWord T w) *
+          (V k * (μ k • blocks k v))) := Matrix.trace_mul_comm _ _
+    _ = Matrix.trace ((MPSTensor.evalWord (fun x => μ k • blocks k x) w *
+          (V k)ᴴ) * (V k * (μ k • blocks k v))) := by rw [hinterWord]
+    _ = Matrix.trace (MPSTensor.evalWord (fun x => μ k • blocks k x) w *
+          (μ k • blocks k v)) := by
+            rw [Matrix.mul_assoc, ← Matrix.mul_assoc (V k)ᴴ (V k)
+              (μ k • blocks k v), hiso k, Matrix.one_mul]
+    _ = Matrix.trace ((μ k • blocks k v) *
+          MPSTensor.evalWord (fun x => μ k • blocks k x) w) :=
+            Matrix.trace_mul_comm _ _
+    _ = Matrix.trace
+          (MPSTensor.evalWord (fun x => μ k • blocks k x) (v :: w)) := by
+            rfl
+    _ = (μ k) ^ N * Matrix.trace (MPSTensor.evalWord (blocks k) (v :: w)) := by
+      rw [MPSTensor.evalWord_smul, Matrix.trace_smul]
+      simp only [smul_eq_mul]
+      have hlength := congrArg List.length hw
+      simp only [List.length_ofFn, List.length_cons] at hlength
+      simp only [List.length_cons, hlength]
+
+/-- The BNT representatives in a particular grouped vertical decomposition
+form an algebraic BNT for the vertical tensor.
+
+The hypotheses are precisely the dimension, isometry, intertwining,
+reconstruction, and spectral-BNT clauses returned by
+`IsHorizontalCF.exists_verticalBNTGrouping_with_isometry`.  The proof uses
+those same witnesses to establish nonemptiness; it does not choose a second
+vertical grouping.
+
+Source: arXiv:1606.00608, Proposition 4.13, lines 1863--1921. -/
+theorem IsHorizontalCF.isBNT_verticalTensor_of_grouping
+    (M : MPOTensor d D) (hHorizontal : IsHorizontalCF M)
+    {r : ℕ} {dim : Fin r → ℕ} (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor (D * D) (dim k))
+    (V : (k : Fin r) → Matrix (Fin d) (Fin (dim k)) ℂ)
+    (hdimPos : ∀ k, 0 < dim k)
+    (hiso : ∀ k, (V k)ᴴ * V k = 1)
+    (hinter : ∀ k v,
+      (V k)ᴴ * verticalTensor M v = (μ k • blocks k v) * (V k)ᴴ)
+    (hreconstruct : ∀ v,
+      verticalTensor M v = ∑ k, V k * (μ k • blocks k v) * (V k)ᴴ)
+    (hBNT : let C := MPSTensor.mpvPhaseClassData blocks
+      MPSTensor.IsCPSVBasisOfNormalTensors
+        (MPSTensor.toTensorFromBlocks (d := D * D) (μ := μ) blocks)
+        (fun j => ⟨dim (C.repr j), blocks (C.repr j)⟩)) :
+    let C := MPSTensor.mpvPhaseClassData blocks
+    MPSTensor.IsBNT (verticalTensor M) C.g
+      (fun j => dim (C.repr j)) (fun j => blocks (C.repr j)) := by
+  classical
+  let C := MPSTensor.mpvPhaseClassData blocks
+  have hr : 0 < r := by
+    by_contra hr
+    have hrzero : r = 0 := Nat.eq_zero_of_not_pos hr
+    apply hHorizontal.verticalTensor_ne_zero M
+    funext v
+    rw [hreconstruct v]
+    subst r
+    simp
+  have hg : 0 < C.g := C.g_pos_of_r_pos hr
+  have hPositive : MPSTensor.SameMPV₂Pos (verticalTensor M)
+      (MPSTensor.toTensorFromBlocks (d := D * D) (μ := μ) blocks) :=
+    sameMPV₂Pos_toTensorFromBlocks_of_reconstruction
+      (verticalTensor M) μ blocks V hiso hinter hreconstruct
+  change MPSTensor.IsBNT (verticalTensor M) C.g
+    (fun j => dim (C.repr j)) (fun j => blocks (C.repr j))
+  refine ⟨?_, ?_, hBNT.eventually_li⟩
+  · intro j
+    letI : NeZero (dim (C.repr j)) := ⟨(hdimPos (C.repr j)).ne'⟩
+    exact (hBNT.blocks_normal j).isNormal
+  · intro N
+    by_cases hN : N = 0
+    · subst N
+      let j₀ : Fin C.g := ⟨0, hg⟩
+      refine ⟨fun j => if j = j₀ then
+        (d : ℂ) / (dim (C.repr j₀) : ℂ) else 0, ?_⟩
+      intro σ
+      rw [MPSTensor.mpv_zero_length]
+      simp only [MPSTensor.mpv_zero_length]
+      rw [Finset.sum_eq_single j₀]
+      · simp only [if_pos, j₀]
+        have hdimne : (dim (C.repr j₀) : ℂ) ≠ 0 := by
+          exact_mod_cast (hdimPos (C.repr j₀)).ne'
+        change (d : ℂ) = (d : ℂ) / (dim (C.repr j₀) : ℂ) *
+          (dim (C.repr j₀) : ℂ)
+        rw [div_eq_mul_inv, mul_assoc, inv_mul_cancel₀ hdimne, mul_one]
+      · intro j _ hj
+        simp [hj]
+      · simp
+    · obtain ⟨c, hc⟩ := hBNT.spans_mpv N
+      refine ⟨c, fun σ => ?_⟩
+      rw [hPositive N (Nat.pos_of_ne_zero hN) σ]
+      exact hc σ
+
+end MPOTensor

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -2862,6 +2862,103 @@
     gives a retained representative.
 \end{proof}
 
+\begin{theorem}[Nonvanishing of the vertical reshaping]
+    \label{thm:mpdo_vertical_tensor_nonzero}
+    \lean{MPOTensor.IsHorizontalCF.verticalTensor_ne_zero}
+    \leanok
+    \uses{def:horizontal_cf_mpdo, def:vertical_tensor_mpdo}
+    If an MPO tensor $M$ is in horizontal canonical form, then its vertical
+    reshaping is nonzero:
+    \[
+        \widetilde M\ne 0.
+    \]
+    This is the nonvanishing observation used in
+    \cite[Proposition~4.13, lines~1895--1902]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:horizontal_cf_mpdo, def:vertical_tensor_mpdo,
+        lem:sector_bnt_weight_unit_exists_of_struct}
+    Write the doubled-index tensor in horizontal canonical form as
+    $\widehat M=GSG^{-1}$, where $S$ is the weighted direct sum of its basis
+    tensors.  Choose a copy whose weight has unit modulus.  Its basis tensor
+    cannot have every letter equal to zero, since left canonicity gives
+    \[
+        \sum_i (A^i)^\dagger A^i=\Id.
+    \]
+    The corresponding nonzero weight and nonzero letter give $S\ne0$, hence
+    $\widehat M\ne0$.  If $\widetilde M=0$, the bijection between its vertical
+    index and the two horizontal bond indices would give $\widehat M=0$, a
+    contradiction.
+\end{proof}
+
+\begin{theorem}[Algebraic BNT from a grouped vertical decomposition]
+    \label{thm:mpdo_vertical_grouped_is_bnt}
+    \lean{MPOTensor.IsHorizontalCF.isBNT_verticalTensor_of_grouping}
+    \leanok
+    \uses{def:horizontal_cf_mpdo, def:vertical_tensor_mpdo, def:bnt,
+        def:bnt_cpsv, def:mpv_phase_class_data}
+    Let $M$ be in horizontal canonical form and put $T=\widetilde M$.  Suppose
+    that $B_k$ has positive bond dimension $d_k$, that $\mu_k\in\C$, and that
+    $V_k:\C^{d_k}\to\C^d$ is an isometry for $0\leq k<r$.  Assume, for every
+    vertical letter $v$, that
+    \[
+        V_k^\dagger T_v=(\mu_k B_k^v)V_k^\dagger,
+        \qquad
+        T_v=\sum_{k=0}^{r-1}V_k(\mu_k B_k^v)V_k^\dagger.
+    \]
+    Partition the tensors $B_k$ into matrix-product-vector phase classes and
+    choose one representative $A_\alpha$ from each class.  If
+    $\{A_\alpha\}_\alpha$ is a basis of normal tensors in the spectral sense
+    for the weighted direct sum
+    \[
+        A_{\mathrm{ret}}=\bigoplus_{k=0}^{r-1}\mu_k B_k,
+    \]
+    then $\{A_\alpha\}_\alpha$ is an algebraic basis of normal tensors for
+    $T$.
+
+    This is the basis-of-normal-tensors conclusion in
+    \cite[Proposition~4.13, lines~1863--1921]{Cirac2016MPDO_arXiv}, stated for
+    the grouped decomposition before the final coisometry is formed.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_vertical_tensor_nonzero,
+        thm:cpsv_normal_eventually_injective,
+        thm:mpv_decomposition, lem:mpv_phase_class_nonempty,
+        lem:mpv_zero_length}
+    The reconstruction and
+    Theorem~\ref{thm:mpdo_vertical_tensor_nonzero} imply $r>0$, so the phase
+    partition has a representative $A_{\alpha_0}$ of positive bond dimension
+    $d_{\alpha_0}$.
+
+    Put $C_k^v=\mu_kB_k^v$.  Induction on a word $w$ gives
+    \[
+        V_k^\dagger T^w=C_k^wV_k^\dagger.
+    \]
+    For a nonempty word $w=(v,w')$, reconstruction of its first letter,
+    cyclicity of trace, and $V_k^\dagger V_k=\Id$ therefore give
+    \begin{align*}
+        \tr(T^w)
+        &=\sum_k\tr\!\left(V_kC_k^vV_k^\dagger T^{w'}\right)\\
+        &=\sum_k\tr(C_k^vC_k^{w'})
+          =\sum_k\mu_k^{|w|}\tr(B_k^w)
+          =V^{(|w|)}(A_{\mathrm{ret}})_w.
+    \end{align*}
+    Hence the spectral BNT spanning identity for $A_{\mathrm{ret}}$ gives the
+    algebraic spanning identity for $T$ at every positive length.  At length
+    zero, assign coefficient $d/d_{\alpha_0}$ to $A_{\alpha_0}$ and zero to
+    the other representatives; then
+    \[
+        d=\frac{d}{d_{\alpha_0}}d_{\alpha_0}.
+    \]
+    Spectral normality implies algebraic normality for every representative,
+    and the eventual linear independence assertion is unchanged.  These are
+    the three algebraic BNT conditions.
+\end{proof}
+
 \begin{theorem}[Horizontal canonical form implies vertical canonical form]
     \label{thm:vertical_cf_of_horizontal_cf}
     \notready


### PR DESCRIPTION
## Mathematical result

For the particular grouped vertical decomposition supplied by horizontal canonical form, this proves that the representative tensors form an algebraic basis of normal tensors for the vertically viewed MPO tensor.

The proof uses the same grouping witnesses throughout. Nonemptiness is derived from their own literal reconstruction and nonvanishing of the vertical tensor; positive chain lengths follow from word intertwining, cyclicity of trace, and reconstruction; the empty chain is handled by one retained representative with coefficient d divided by its bond dimension.

No hypothesis beyond the clauses furnished by the grouped decomposition is introduced. This is the BNT component required in the proof of arXiv:1606.00608, Proposition 4.13.

## Verification

- dependent compilation after integration on current main
- full lake build
- temporary same-witness consumer theorem
- proof-integrity, prose, line-length, and diff checks
- independent source-faithfulness review: READY for exact commit 0810e39154c7c90c4c714c0a06a843651bba78d1
- exact author and committer texra-ai <texra-ai@outlook.com>

Advances #3897.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal mathematics and documentation; no runtime, auth, or data paths. Risk is mainly proof maintenance and import/build surface area.
> 
> **Overview**
> This PR **formalizes the BNT step** of Cirac et al. Proposition 4.13: for a horizontally canonical MPO, the **same** grouped vertical decomposition (isometries, intertwining, literal reconstruction, spectral BNT on the weighted block sum) proves the phase-class representatives are an **algebraic** `IsBNT` for `verticalTensor M`.
> 
> A new module `VerticalBNTConstruction.lean` proves `IsHorizontalCF.isBNT_verticalTensor_of_grouping` by matching positive-length MPVs to the weighted sector sum (word intertwining + trace) and handling length zero with one retained representative. **`IsHorizontalCF.verticalTensor_ne_zero`** is made **public** in `RetainedClass.lean` so nonemptiness can be derived from reconstruction without a second grouping choice.
> 
> `TNLean.lean` imports the new module. The blueprint chapter adds matching theorems for vertical nonvanishing and algebraic BNT from grouped decomposition, ahead of the full horizontal→vertical CF capstone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b48510eaf5ab1daeb40f0f00c9028ab3e2aabea6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->