### PR TITLE
feat(MPS/SectorBNT): realize prepared phase equivalence by gauge

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.CanonicalForm.PhaseClassSectorData
 import TNLean.MPS.CanonicalForm.SectorComparison.CommonSectorTransport
 import TNLean.MPS.Core.PhysicalReindexTransport
+import TNLean.MPS.FundamentalTheorem.Proportional
 import TNLean.MPS.FundamentalTheorem.SectorBNT.Basic
 import TNLean.MPS.Overlap.PeripheralToTransferMapGap
 
@@ -182,6 +183,54 @@ theorem dim_eq_of_MPVBlockPhaseEquiv_of_tp_primitive_irr
     have h10 : (1 : ℝ) = 0 := tendsto_nhds_unique hYX hnorm_zero
     exact one_ne_zero h10
   exact hDYDX.symm
+
+/-- **Gauge-phase realization of prepared phase-equivalent blocks.**
+
+Source: CPSV16, Proposition `prop:char-BNT`, lines 1135–1148.  If two
+left-canonical, primitive, irreducible blocks have MPV families related by a
+nonzero scalar power, then their bond dimensions agree and, after identifying
+the bond spaces, one is an invertible conjugate of the other up to a nonzero
+scalar.
+
+This is the gauge realization used in the BNT characterization.  It does not
+assert positivity of the scalar or unitarity of the gauge; those conclusions
+belong to the later MPDO-specific argument at arXiv:1606.00608, lines
+1899–1921. -/
+theorem gaugePhaseEquiv_of_MPVBlockPhaseEquiv_of_tp_primitive_irr
+    {DX DY : ℕ} [NeZero DX] [NeZero DY]
+    {X : MPSTensor d DX} {Y : MPSTensor d DY}
+    (hTPX : IsLeftCanonical X)
+    (hTPY : IsLeftCanonical Y)
+    (hPrimX : _root_.IsPrimitive (transferMap (d := d) (D := DX) X))
+    (hPrimY : _root_.IsPrimitive (transferMap (d := d) (D := DY) Y))
+    (hIrrX : IsIrreducibleTensor X)
+    (hIrrY : IsIrreducibleTensor Y)
+    (h : MPVBlockPhaseEquiv X Y) :
+    ∃ e : DX = DY,
+      GaugePhaseEquiv (cast (congr_arg (MPSTensor d) e) X) Y := by
+  classical
+  have e : DX = DY :=
+    dim_eq_of_MPVBlockPhaseEquiv_of_tp_primitive_irr
+      hTPX hTPY hPrimX hPrimY hIrrX hIrrY h
+  subst DY
+  refine ⟨rfl, ?_⟩
+  have hX_self :
+      Tendsto (fun N : ℕ => mpvOverlap (d := d) X X N) atTop (nhds (1 : ℂ)) :=
+    overlap_tendsto_one_of_peripheralPrimitive_of_irreducible
+      (d := d) (D := DX) X hIrrX hTPX hPrimX
+  have hY_self :
+      Tendsto (fun N : ℕ => mpvOverlap (d := d) Y Y N) atTop (nhds (1 : ℂ)) :=
+    overlap_tendsto_one_of_peripheralPrimitive_of_irreducible
+      (d := d) (D := DX) Y hIrrY hTPY hPrimY
+  by_contra hNot
+  obtain ⟨N, _, hN⟩ :=
+    exists_ge_not_forall_mpv_eq_mul_of_not_gaugePhaseEquiv_of_irreducible_TP
+      X Y hIrrX hIrrY hTPX hTPY hX_self hY_self hNot 0
+  have hSymm : MPVBlockPhaseEquiv Y X := MPVBlockPhaseEquiv.symm h
+  apply hN
+  refine ⟨hSymm.choose ^ N, ?_⟩
+  intro σ
+  exact hSymm.choose_spec.2 N σ
 
 /--
 **Prepared phase classes preserve the original bond dimensions.**

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1009,6 +1009,34 @@ a contradiction.
     contradicting the preceding limit.
 \end{proof}
 
+\begin{theorem}[Gauge realization of prepared phase-equivalent NTs]%
+    \label{thm:prepared_phase_equiv_gauge}
+    \lean{MPSTensor.gaugePhaseEquiv_of_MPVBlockPhaseEquiv_of_tp_primitive_irr}
+    \leanok
+    \uses{def:mpv_block_phase_equiv, def:gauge_phase_equiv,
+        def:irreducible_tensor, def:tp_kraus, def:primitive_channel}
+    Let $X$ and $Y$ be trace-preserving, primitive, irreducible NTs of positive
+    bond dimensions $D_X$ and $D_Y$. If their MPV families differ by a nonzero
+    scalar power, then $D_X=D_Y$, and after identifying the bond spaces there
+    exist $G\in\GL_{D_Y}(\C)$ and $\zeta\in\C\setminus\{0\}$ such that, for every
+    physical index $i$,
+    \[
+        Y^i=\zeta G X^i G^{-1}.
+    \]
+    The scalar is not asserted to be positive, and the gauge is not asserted to
+    be unitary.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:prepared_phase_equiv_dim_eq,
+        thm:not_gauge_phase_eventually_not_proportional}
+    Lemma~\ref{lem:prepared_phase_equiv_dim_eq} identifies the bond dimensions.
+    If no gauge-phase relation existed after this identification,
+    Theorem~\ref{thm:not_gauge_phase_eventually_not_proportional} would give a
+    length $N$ at which the two MPV states are not proportional. This contradicts
+    the assumed scalar-power identity at every length.
+\end{proof}
+
 \begin{lemma}[Prepared BNT representative classes preserve bond dimension]%
     \label{lem:prepared_phase_class_dim_eq}
     \lean{MPSTensor.mpvPhaseClassData_dim_eq_of_tp_primitive_irr}


### PR DESCRIPTION
## Summary
- formalize realization of prepared phase equivalence by a gauge transformation
- document the corresponding BNT dependency

## Verification
- `lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a localized Lean theorem and blueprint text on top of existing overlap and proportionality infrastructure; no auth, IO, or runtime behavior changes.
> 
> **Overview**
> **Prepared phase-equivalent blocks are realized by gauge-phase equivalence.** For left-canonical, primitive, irreducible blocks related by `MPVBlockPhaseEquiv`, the PR adds `gaugePhaseEquiv_of_MPVBlockPhaseEquiv_of_tp_primitive_irr`: bond dimensions are identified via the existing dimension lemma, then a contradiction argument uses `exists_ge_not_forall_mpv_eq_mul_of_not_gaugePhaseEquiv_of_irreducible_TP` (new import from `FundamentalTheorem.Proportional`) together with the symmetric phase-scalar identity at every length.
> 
> The blueprint chapter gains **Theorem** `thm:prepared_phase_equiv_gauge` (`Y^i = \zeta G X^i G^{-1}`), explicitly **without** claiming a positive scalar or unitary gauge—matching the Lean docstring and CPSV16 `prop:char-BNT` scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c608b6de60bd270ee96966f72a2bc2d5aac46b40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->