### PR TITLE
feat(MPS/MPDO): localize Kraus channels

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -377,6 +377,7 @@ import TNLean.MPS.MPDO.BiCFDerivation
 import TNLean.MPS.MPDO.ZCL
 import TNLean.MPS.MPDO.RFP
 import TNLean.MPS.MPDO.KrausCPTP
+import TNLean.MPS.MPDO.LocalizedKrausCPTP
 import TNLean.MPS.MPDO.RFPViaTS
 import TNLean.MPS.MPDO.PRFP
 import TNLean.MPS.MPDO.LocalPurificationRFP

--- a/TNLean/Channel/TensorMap.lean
+++ b/TNLean/Channel/TensorMap.lean
@@ -26,6 +26,8 @@ This is the key operation for constructing the Choi matrix
 
 * `Matrix.tensorMapId_apply`: elementwise formula
 * `Matrix.tensorMapId_kronecker`: `(T ⊗ id)(A ⊗ B) = T(A) ⊗ B`
+* `Matrix.tensorMapIdLM_id`: the lift of the identity map is the identity.
+* `Matrix.tensorMapIdLM_comp`: the lift preserves composition.
 
 ## References
 
@@ -37,48 +39,47 @@ open Matrix Finset BigOperators
 
 namespace Matrix
 
-variable {d d' d'' : ℕ}
+variable {α β γ δ : Type*}
 
-/-- Extract the `(i₂, j₂)`-slice of a bipartite matrix:
-for `X : M_{d·d''}`, the slice `X_{·,i₂,·,j₂}` is a `d × d` matrix. -/
+/-- Extract the `(i₂, j₂)`-slice of a bipartite matrix. For a matrix indexed by
+`α × δ`, the slice with fixed `δ`-coordinates is a matrix indexed by `α`. -/
 noncomputable def bipartiteSlice
-    (X : Matrix (Fin d × Fin d'') (Fin d × Fin d'') ℂ)
-    (i₂ j₂ : Fin d'') : Matrix (Fin d) (Fin d) ℂ :=
+    (X : Matrix (α × δ) (α × δ) ℂ)
+    (i₂ j₂ : δ) : Matrix α α ℂ :=
   fun i₁ j₁ => X (i₁, i₂) (j₁, j₂)
 
 @[simp]
 theorem bipartiteSlice_apply
-    (X : Matrix (Fin d × Fin d'') (Fin d × Fin d'') ℂ)
-    (i₂ j₂ : Fin d'') (i₁ j₁ : Fin d) :
+    (X : Matrix (α × δ) (α × δ) ℂ)
+    (i₂ j₂ : δ) (i₁ j₁ : α) :
     bipartiteSlice X i₂ j₂ i₁ j₁ = X (i₁, i₂) (j₁, j₂) := rfl
 
-/-- The tensor product of a linear map `T : M_d → M_{d'}` with the identity
-on `M_{d''}`. The result acts on bipartite matrices indexed by
-`(Fin d' × Fin d'')`:
+/-- The tensor product of a matrix linear map `T` with the identity on the
+matrix factor indexed by `δ`. The resulting map has the entrywise formula
 
   `((tensorMapId T) X) (i₁, i₂) (j₁, j₂) = (T (bipartiteSlice X i₂ j₂)) i₁ j₁`
 
 This corresponds to applying `T` to the first tensor factor and leaving
 the second factor untouched. -/
 noncomputable def tensorMapId
-    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ)
-    (X : Matrix (Fin d × Fin d'') (Fin d × Fin d'') ℂ) :
-    Matrix (Fin d' × Fin d'') (Fin d' × Fin d'') ℂ :=
+    (T : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ)
+    (X : Matrix (α × δ) (α × δ) ℂ) :
+    Matrix (β × δ) (β × δ) ℂ :=
   fun ⟨i₁, i₂⟩ ⟨j₁, j₂⟩ => (T (bipartiteSlice X i₂ j₂)) i₁ j₁
 
 @[simp]
 theorem tensorMapId_apply
-    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ)
-    (X : Matrix (Fin d × Fin d'') (Fin d × Fin d'') ℂ)
-    (i₁ : Fin d') (i₂ : Fin d'') (j₁ : Fin d') (j₂ : Fin d'') :
+    (T : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ)
+    (X : Matrix (α × δ) (α × δ) ℂ)
+    (i₁ : β) (i₂ : δ) (j₁ : β) (j₂ : δ) :
     tensorMapId T X (i₁, i₂) (j₁, j₂) =
       (T (bipartiteSlice X i₂ j₂)) i₁ j₁ := rfl
 
 /-- `tensorMapId T` as a linear map in `X`. -/
 noncomputable def tensorMapIdLM
-    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ) :
-    Matrix (Fin d × Fin d'') (Fin d × Fin d'') ℂ →ₗ[ℂ]
-    Matrix (Fin d' × Fin d'') (Fin d' × Fin d'') ℂ where
+    (T : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ) :
+    Matrix (α × δ) (α × δ) ℂ →ₗ[ℂ]
+    Matrix (β × δ) (β × δ) ℂ where
   toFun := tensorMapId T
   map_add' X Y := by
     ext ⟨i₁, i₂⟩ ⟨j₁, j₂⟩
@@ -95,10 +96,16 @@ noncomputable def tensorMapIdLM
         ext; simp [bipartiteSlice, Matrix.smul_apply, smul_eq_mul]]
     simp [map_smul]
 
+@[simp]
+theorem tensorMapIdLM_apply
+    (T : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ)
+    (X : Matrix (α × δ) (α × δ) ℂ) :
+    tensorMapIdLM T X = tensorMapId T X := rfl
+
 /-- The key property: `(T ⊗ id)(A ⊗ B) = T(A) ⊗ B` for Kronecker products. -/
 theorem tensorMapId_kronecker
-    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ)
-    (A : Matrix (Fin d) (Fin d) ℂ) (B : Matrix (Fin d'') (Fin d'') ℂ) :
+    (T : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ)
+    (A : Matrix α α ℂ) (B : Matrix δ δ ℂ) :
     tensorMapId T (kroneckerMap (· * ·) A B) =
       kroneckerMap (· * ·) (T A) B := by
   ext ⟨i₁, i₂⟩ ⟨j₁, j₂⟩
@@ -108,5 +115,27 @@ theorem tensorMapId_kronecker
       ext a b; simp [bipartiteSlice, kroneckerMap_apply]; ring]
   simp [map_smul, Matrix.smul_apply, smul_eq_mul]
   ring
+
+/-- Tensoring the identity map with the identity gives the identity map on the
+product matrix algebra. -/
+@[simp]
+theorem tensorMapIdLM_id :
+    tensorMapIdLM (δ := δ) (LinearMap.id : Matrix α α ℂ →ₗ[ℂ] Matrix α α ℂ) =
+      LinearMap.id := by
+  apply LinearMap.ext
+  intro X
+  ext ⟨i₁, i₂⟩ ⟨j₁, j₂⟩
+  rfl
+
+/-- Tensoring with the identity respects composition of matrix linear maps. -/
+theorem tensorMapIdLM_comp
+    (T : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ)
+    (S : Matrix β β ℂ →ₗ[ℂ] Matrix γ γ ℂ) :
+    tensorMapIdLM (δ := δ) (S ∘ₗ T) =
+      tensorMapIdLM (δ := δ) S ∘ₗ tensorMapIdLM (δ := δ) T := by
+  apply LinearMap.ext
+  intro X
+  ext ⟨i₁, i₂⟩ ⟨j₁, j₂⟩
+  rfl
 
 end Matrix

--- a/TNLean/MPS/MPDO/LocalizedKrausCPTP.lean
+++ b/TNLean/MPS/MPDO/LocalizedKrausCPTP.lean
@@ -1,0 +1,67 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.TensorMap
+import TNLean.MPS.MPDO.KrausCPTP
+
+/-!
+# Localized trace-preserving completely positive maps
+
+This file proves that a rectangular trace-preserving completely positive map
+remains trace-preserving and completely positive after tensoring it with the
+identity map on a finite matrix factor.
+
+## Main results
+
+* `Matrix.tensorMapIdLM_isKrausCPTP`: tensoring a Kraus-form channel with the
+  identity preserves its Kraus-form channel structure.
+
+This is the finite-dimensional localization operation used when a physical
+channel acts on one site of a blocked matrix-product density operator while
+the neighboring site is left unchanged.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Definition 4.1 and Appendix C.2, Proposition C.7
+-/
+
+open scoped Matrix BigOperators
+
+namespace Matrix
+
+variable {α β δ : Type*}
+variable [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]
+variable [Fintype δ] [DecidableEq δ]
+
+/-- Tensoring a trace-preserving completely positive matrix map with the
+identity on a finite matrix factor preserves the trace-preserving completely
+positive property. Its Kraus operators are $A_i \otimes I$, where $A_i$
+are Kraus operators for the original map. -/
+theorem tensorMapIdLM_isKrausCPTP
+    {S : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ} (hS : IsKrausCPTP S) :
+    IsKrausCPTP (tensorMapIdLM (δ := δ) S) := by
+  obtain ⟨r, A, hAform, hAtp⟩ := hS
+  refine ⟨r, fun i => Matrix.kroneckerMap (· * ·) (A i) 1, ?_, ?_⟩
+  · intro X
+    ext ⟨b, u⟩ ⟨c, v⟩
+    change tensorMapId S X (b, u) (c, v) = _
+    rw [tensorMapId_apply, hAform, Matrix.sum_apply]
+    simp only [Matrix.mul_apply, Matrix.conjTranspose_apply]
+    rw [Matrix.sum_apply]
+    refine Finset.sum_congr rfl fun i _ => ?_
+    simp only [Matrix.mul_apply, Fintype.sum_prod_type, Matrix.conjTranspose_apply,
+      Matrix.kroneckerMap_apply, Matrix.one_apply, star_mul']
+    simp [bipartiteSlice]
+  · simp_rw [Matrix.conjTranspose_kronecker, Matrix.conjTranspose_one,
+      ← Matrix.mul_kronecker_mul]
+    simp only [Matrix.one_mul]
+    change ∑ i, ((Matrix.kroneckerBilinear (R := ℂ)).flip
+      (1 : Matrix δ δ ℂ)) ((A i)ᴴ * A i) = 1
+    rw [← map_sum ((Matrix.kroneckerBilinear (R := ℂ)).flip
+      (1 : Matrix δ δ ℂ)), hAtp]
+    exact Matrix.one_kronecker_one
+
+end Matrix


### PR DESCRIPTION
## Summary
- add localized Kraus-channel constructions for MPDOs
- extend tensor-map support and export the new API

## Verification
- `lake env lean TNLean/MPS/MPDO/LocalizedKrausCPTP.lean`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formal proofs in channel/MPDO infrastructure; no runtime or security-sensitive behavior changes.
> 
> **Overview**
> **Generalizes** `Matrix.bipartiteSlice`, `tensorMapId`, and `tensorMapIdLM` in `TensorMap.lean` from `Fin d` indices to arbitrary finite types `α × δ`, and adds **`tensorMapIdLM_id`**, **`tensorMapIdLM_comp`**, and **`tensorMapIdLM_apply`** so the localized lift behaves like a functor on linear maps.
> 
> **Adds** `LocalizedKrausCPTP.lean` with **`tensorMapIdLM_isKrausCPTP`**: if `S` is Kraus trace-preserving completely positive, then `tensorMapIdLM S` is too, with Kraus operators `A_i ⊗ I`. This is the site-local channel step for blocked MPDOs (Cirac–Perez-Garcia–Schuch–Verstraete localization).
> 
> **Exports** the new module from `TNLean.lean`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 572f9cf1f93b746fe0e39ce9025ed2e293358558. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->