### PR TITLE
feat(MPS/MPDO): normalize grouped physical sectors

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -399,6 +399,7 @@ import TNLean.MPS.MPDO.ReflectedMarkedChain
 import TNLean.MPS.MPDO.FigureEightPairwise
 import TNLean.MPS.MPDO.GroupedFigure8
 import TNLean.MPS.MPDO.GroupedGramNormalization
+import TNLean.MPS.MPDO.NormalizedGroupedSectors
 import TNLean.MPS.MPDO.BiCFDerivation
 import TNLean.MPS.MPDO.ZCL
 import TNLean.MPS.MPDO.RFP

--- a/TNLean/MPS/MPDO/NormalizedGroupedSectors.lean
+++ b/TNLean/MPS/MPDO/NormalizedGroupedSectors.lean
@@ -1,0 +1,321 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.GroupedGramNormalization
+
+/-!
+# Normalized physical maps for grouped vertical sectors
+
+This file absorbs each normalized grouped bond gauge into its physical sector
+isometry.  The resulting maps have the representative bond dimensions, have
+pairwise orthogonal isometric ranges, intertwine the vertical tensor with the
+undressed representative tensors, and retain the literal reconstruction of
+every vertical letter.
+
+These are the source-specific identities needed before the block-row
+coisometry construction in the proof of the vertical canonical form.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Proposition 4.13, lines 1895--1921.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+section LinearAlgebra
+
+variable {m n : ℕ}
+
+/-- Absorb the normalized square gauge into a rectangular physical sector map
+and transport its column index to the representative bond dimension. -/
+noncomputable def normalizedGroupedSectorMap (h : m = n)
+    (V : Matrix (Fin d) (Fin n) ℂ) (X : Matrix (Fin n) (Fin n) ℂ)
+    (omega : ℝ) : Matrix (Fin d) (Fin m) ℂ :=
+  cast (congrArg (fun k ↦ Matrix (Fin d) (Fin k) ℂ) h.symm)
+    (V * (((Real.sqrt omega : ℂ))⁻¹ • X))
+
+private theorem normalizedGroupedSectorMap_isometry (h : m = n)
+    (V : Matrix (Fin d) (Fin n) ℂ) (X : Matrix (Fin n) (Fin n) ℂ)
+    (omega : ℝ) (hV : Vᴴ * V = 1)
+    (hQ : (((Real.sqrt omega : ℂ))⁻¹ • X) ∈
+      Matrix.unitaryGroup (Fin n) ℂ) :
+    (normalizedGroupedSectorMap h V X omega)ᴴ *
+        normalizedGroupedSectorMap h V X omega = 1 := by
+  cases h
+  simp only [normalizedGroupedSectorMap, cast_eq, Matrix.conjTranspose_mul]
+  calc
+    ((((Real.sqrt omega : ℂ))⁻¹ • X)ᴴ * Vᴴ) *
+        (V * (((Real.sqrt omega : ℂ))⁻¹ • X)) =
+      (((Real.sqrt omega : ℂ))⁻¹ • X)ᴴ *
+        (Vᴴ * V) * (((Real.sqrt omega : ℂ))⁻¹ • X) := by
+          simp only [Matrix.mul_assoc]
+    _ = (((Real.sqrt omega : ℂ))⁻¹ • X)ᴴ *
+        (((Real.sqrt omega : ℂ))⁻¹ • X) := by rw [hV, Matrix.mul_one]
+    _ = 1 := by
+      rw [← Matrix.star_eq_conjTranspose]
+      exact Matrix.mem_unitaryGroup_iff'.mp hQ
+
+private theorem normalizedGroupedSectorMap_orthogonal
+    {m₁ n₁ m₂ n₂ : ℕ} (h₁ : m₁ = n₁) (h₂ : m₂ = n₂)
+    (V₁ : Matrix (Fin d) (Fin n₁) ℂ) (V₂ : Matrix (Fin d) (Fin n₂) ℂ)
+    (X₁ : Matrix (Fin n₁) (Fin n₁) ℂ)
+    (X₂ : Matrix (Fin n₂) (Fin n₂) ℂ) (omega₁ omega₂ : ℝ)
+    (hV : V₁ᴴ * V₂ = 0) :
+    (normalizedGroupedSectorMap h₁ V₁ X₁ omega₁)ᴴ *
+        normalizedGroupedSectorMap h₂ V₂ X₂ omega₂ = 0 := by
+  cases h₁
+  cases h₂
+  simp only [normalizedGroupedSectorMap, cast_eq, Matrix.conjTranspose_mul]
+  calc
+    ((((Real.sqrt omega₁ : ℂ))⁻¹ • X₁)ᴴ * V₁ᴴ) *
+        (V₂ * (((Real.sqrt omega₂ : ℂ))⁻¹ • X₂)) =
+      (((Real.sqrt omega₁ : ℂ))⁻¹ • X₁)ᴴ *
+        (V₁ᴴ * V₂) * (((Real.sqrt omega₂ : ℂ))⁻¹ • X₂) := by
+          simp only [Matrix.mul_assoc]
+    _ = 0 := by rw [hV, Matrix.mul_zero, Matrix.zero_mul]
+
+private theorem normalized_gauge_intertwining
+    (T : Matrix (Fin d) (Fin d) ℂ) (A : Matrix (Fin n) (Fin n) ℂ)
+    (V : Matrix (Fin d) (Fin n) ℂ) (X : GL (Fin n) ℂ)
+    (c : ℂ) (omega : ℝ)
+    (hinter : T * V = V *
+      (c • ((X : Matrix (Fin n) (Fin n) ℂ) * A *
+        (↑(X⁻¹) : Matrix (Fin n) (Fin n) ℂ)))) :
+    T * (V * (((Real.sqrt omega : ℂ))⁻¹ •
+        (X : Matrix (Fin n) (Fin n) ℂ))) =
+      (V * (((Real.sqrt omega : ℂ))⁻¹ •
+        (X : Matrix (Fin n) (Fin n) ℂ))) * (c • A) := by
+  rw [← Matrix.mul_assoc, hinter]
+  simp only [Matrix.mul_assoc, Matrix.smul_mul, Matrix.mul_smul]
+  rw [show (↑(X⁻¹) : Matrix (Fin n) (Fin n) ℂ) *
+      (X : Matrix (Fin n) (Fin n) ℂ) = 1 by exact X.inv_val]
+  simp only [Matrix.mul_one, smul_smul]
+  rw [mul_comm (((Real.sqrt omega : ℂ))⁻¹) c]
+
+private theorem normalized_gauge_corner
+    (A : Matrix (Fin n) (Fin n) ℂ) (X : GL (Fin n) ℂ)
+    (c : ℂ) (omega : ℝ) (homega : 0 < omega)
+    (hGram : (X : Matrix (Fin n) (Fin n) ℂ)ᴴ * X = (omega : ℂ) • 1) :
+    (((Real.sqrt omega : ℂ))⁻¹ •
+          (X : Matrix (Fin n) (Fin n) ℂ)) * (c • A) *
+        (((Real.sqrt omega : ℂ))⁻¹ •
+          (X : Matrix (Fin n) (Fin n) ℂ))ᴴ =
+      c • ((X : Matrix (Fin n) (Fin n) ℂ) * A *
+        (↑(X⁻¹) : Matrix (Fin n) (Fin n) ℂ)) := by
+  have hs_pos : 0 < Real.sqrt omega := Real.sqrt_pos.mpr homega
+  have hs_ne : ((Real.sqrt omega : ℝ) : ℂ) ≠ 0 := by
+    exact_mod_cast hs_pos.ne'
+  have hs_sq : Real.sqrt omega * Real.sqrt omega = omega :=
+    Real.mul_self_sqrt homega.le
+  have hconjs : star ((Real.sqrt omega : ℂ))⁻¹ =
+      ((Real.sqrt omega : ℂ))⁻¹ := by
+    rw [star_inv₀]
+    congr 1
+    exact Complex.conj_ofReal _
+  have hscalar : ((Real.sqrt omega : ℂ))⁻¹ *
+      ((Real.sqrt omega : ℂ))⁻¹ * (omega : ℂ) = 1 := by
+    rw [show ((omega : ℝ) : ℂ) =
+        (Real.sqrt omega : ℂ) * (Real.sqrt omega : ℂ) by
+      rw [← Complex.ofReal_mul, hs_sq]]
+    field_simp
+  have hXstar : (X : Matrix (Fin n) (Fin n) ℂ)ᴴ =
+      (omega : ℂ) • (↑(X⁻¹) : Matrix (Fin n) (Fin n) ℂ) := by
+    have hXinv : (X : Matrix (Fin n) (Fin n) ℂ) *
+        (↑(X⁻¹) : Matrix (Fin n) (Fin n) ℂ) = 1 := by
+      exact X.val_inv
+    calc
+      (X : Matrix (Fin n) (Fin n) ℂ)ᴴ =
+          (X : Matrix (Fin n) (Fin n) ℂ)ᴴ *
+            ((X : Matrix (Fin n) (Fin n) ℂ) *
+              (↑(X⁻¹) : Matrix (Fin n) (Fin n) ℂ)) := by
+                rw [hXinv, Matrix.mul_one]
+      _ = ((X : Matrix (Fin n) (Fin n) ℂ)ᴴ * X) *
+          (↑(X⁻¹) : Matrix (Fin n) (Fin n) ℂ) := by
+            rw [Matrix.mul_assoc]
+      _ = (omega : ℂ) • (↑(X⁻¹) : Matrix (Fin n) (Fin n) ℂ) := by
+            rw [hGram, Matrix.smul_mul, Matrix.one_mul]
+  rw [Matrix.conjTranspose_smul, hconjs, hXstar]
+  simp only [Matrix.smul_mul, Matrix.mul_smul, smul_smul, Matrix.mul_assoc]
+  rw [show ((Real.sqrt omega : ℂ))⁻¹ * (omega : ℂ) *
+      (c * ((Real.sqrt omega : ℂ))⁻¹) = c by
+    calc
+      ((Real.sqrt omega : ℂ))⁻¹ * (omega : ℂ) *
+          (c * ((Real.sqrt omega : ℂ))⁻¹) =
+        c * (((Real.sqrt omega : ℂ))⁻¹ *
+          ((Real.sqrt omega : ℂ))⁻¹ * (omega : ℂ)) := by ring
+      _ = c := by rw [hscalar, mul_one]]
+
+private theorem normalizedGroupedSectorMap_intertwining {e : ℕ} (h : m = n)
+    (T : Matrix (Fin d) (Fin d) ℂ) (A : MPSTensor e m) (v : Fin e)
+    (V : Matrix (Fin d) (Fin n) ℂ) (X : GL (Fin n) ℂ)
+    (c : ℂ) (omega : ℝ)
+    (hinter : T * V = V *
+      (c • ((X : Matrix (Fin n) (Fin n) ℂ) *
+        (cast (congrArg (MPSTensor e) h) A) v *
+        (↑(X⁻¹) : Matrix (Fin n) (Fin n) ℂ)))) :
+    T * normalizedGroupedSectorMap h V X omega =
+      normalizedGroupedSectorMap h V X omega * (c • A v) := by
+  cases h
+  exact normalized_gauge_intertwining T (A v) V X c omega hinter
+
+private theorem normalizedGroupedSectorMap_corner {e : ℕ} (h : m = n)
+    (A : MPSTensor e m) (v : Fin e) (V : Matrix (Fin d) (Fin n) ℂ)
+    (X : GL (Fin n) ℂ) (c : ℂ) (omega : ℝ) (homega : 0 < omega)
+    (hGram : (X : Matrix (Fin n) (Fin n) ℂ)ᴴ * X = (omega : ℂ) • 1) :
+    normalizedGroupedSectorMap h V X omega * (c • A v) *
+        (normalizedGroupedSectorMap h V X omega)ᴴ =
+      V * (c • ((X : Matrix (Fin n) (Fin n) ℂ) *
+        (cast (congrArg (MPSTensor e) h) A) v *
+        (↑(X⁻¹) : Matrix (Fin n) (Fin n) ℂ))) * Vᴴ := by
+  cases h
+  simp only [normalizedGroupedSectorMap, cast_eq, Matrix.conjTranspose_mul]
+  calc
+    ((V * (((Real.sqrt omega : ℂ))⁻¹ • (X : Matrix (Fin m) (Fin m) ℂ))) *
+        (c • A v)) *
+      ((((Real.sqrt omega : ℂ))⁻¹ • (X : Matrix (Fin m) (Fin m) ℂ))ᴴ * Vᴴ) =
+      (V *
+        ((((Real.sqrt omega : ℂ))⁻¹ • (X : Matrix (Fin m) (Fin m) ℂ)) *
+          (c • A v) *
+          (((Real.sqrt omega : ℂ))⁻¹ • (X : Matrix (Fin m) (Fin m) ℂ))ᴴ)) *
+        Vᴴ := by simp only [Matrix.mul_assoc]
+    _ = V *
+          (c • ((X : Matrix (Fin m) (Fin m) ℂ) * A v *
+            (↑(X⁻¹) : Matrix (Fin m) (Fin m) ℂ))) * Vᴴ := by
+      rw [normalized_gauge_corner (A v) X c omega homega hGram]
+
+end LinearAlgebra
+
+section GroupedSectors
+
+variable {r : ℕ} {dim : Fin r → ℕ}
+variable (blocks : (k : Fin r) → MPSTensor (D * D) (dim k))
+
+local notation "C" => MPSTensor.mpvPhaseClassData blocks
+
+/-- The normalized grouped gauges can be absorbed into the physical sector
+isometries while preserving orthogonality, the representative intertwining,
+and literal reconstruction of every vertical letter.
+
+All hypotheses are clauses furnished by
+`IsHorizontalCF.exists_verticalBNTGrouping_with_isometry`.
+
+Source: arXiv:1606.00608, proof of Proposition 4.13, lines 1895--1921. -/
+theorem IsMPDO.exists_normalized_grouped_physical_maps
+    {M : MPOTensor d D} (hM : IsMPDO M)
+    (hHorizontal : IsHorizontalCF M)
+    (μ : Fin r → ℂ) (V : (k : Fin r) → Matrix (Fin d) (Fin (dim k)) ℂ)
+    (hDimPos : ∀ k, 0 < dim k)
+    (hNormal : ∀ k, MPSTensor.IsNormalTensor (blocks k))
+    (hdim : ∀ j q, dim ((C).repr j) = dim ((C).enum j q))
+    (X : (j : Fin (C).g) → (q : Fin ((C).copies j)) →
+      GL (Fin (dim ((C).enum j q))) ℂ)
+    (ζ : (j : Fin (C).g) → Fin ((C).copies j) → ℂ)
+    (hXDist : ∀ j, X j ⟨0, (C).copies_pos j⟩ = 1)
+    (hCoeffPos : ∀ j q, (0 : ℂ) < μ ((C).enum j q) * ζ j q)
+    (hIso : ∀ j q, (V ((C).enum j q))ᴴ * V ((C).enum j q) = 1)
+    (hOrth : ∀ j q l p, (C).enum j q ≠ (C).enum l p →
+      (V ((C).enum j q))ᴴ * V ((C).enum l p) = 0)
+    (hInter : ∀ j q v,
+      verticalTensor M v * V ((C).enum j q) =
+        V ((C).enum j q) *
+          ((μ ((C).enum j q) * ζ j q) •
+            ((X j q : Matrix (Fin (dim ((C).enum j q)))
+                (Fin (dim ((C).enum j q))) ℂ) *
+              (cast (congrArg (MPSTensor (D * D)) (hdim j q))
+                (blocks ((C).repr j))) v *
+              (↑((X j q)⁻¹) : Matrix (Fin (dim ((C).enum j q)))
+                (Fin (dim ((C).enum j q))) ℂ))))
+    (hCorner : ∀ j q v,
+      (μ ((C).enum j q) * ζ j q) •
+          ((X j q : Matrix (Fin (dim ((C).enum j q)))
+              (Fin (dim ((C).enum j q))) ℂ) *
+            (cast (congrArg (MPSTensor (D * D)) (hdim j q))
+              (blocks ((C).repr j))) v *
+            (↑((X j q)⁻¹) : Matrix (Fin (dim ((C).enum j q)))
+              (Fin (dim ((C).enum j q))) ℂ)) =
+        (V ((C).enum j q))ᴴ * verticalTensor M v * V ((C).enum j q))
+    (hReconstruct : ∀ v, verticalTensor M v =
+      ∑ j : Fin (C).g, ∑ q : Fin ((C).copies j),
+        V ((C).enum j q) *
+          ((μ ((C).enum j q) * ζ j q) •
+            ((X j q : Matrix (Fin (dim ((C).enum j q)))
+                (Fin (dim ((C).enum j q))) ℂ) *
+              (cast (congrArg (MPSTensor (D * D)) (hdim j q))
+                (blocks ((C).repr j))) v *
+              (↑((X j q)⁻¹) : Matrix (Fin (dim ((C).enum j q)))
+                (Fin (dim ((C).enum j q))) ℂ))) *
+          (V ((C).enum j q))ᴴ) :
+    ∃ (gamma : (j : Fin (C).g) → Fin ((C).copies j) → ℝ)
+      (W : (p : (j : Fin (C).g) × Fin ((C).copies j)) →
+        Matrix (Fin d) (Fin (dim ((C).repr p.1))) ℂ),
+      (∀ j q, 0 < gamma j q) ∧
+      (∀ j q,
+        W ⟨j, q⟩ = normalizedGroupedSectorMap (hdim j q)
+          (V ((C).enum j q)) (X j q) (gamma j q)) ∧
+      (∀ p, (W p)ᴴ * W p = 1) ∧
+      (∀ p s, p ≠ s → (W p)ᴴ * W s = 0) ∧
+      (∀ p v, verticalTensor M v * W p =
+        W p * ((μ ((C).enum p.1 p.2) * ζ p.1 p.2) •
+          blocks ((C).repr p.1) v)) ∧
+      ∀ v, verticalTensor M v =
+        ∑ j : Fin (C).g, ∑ q : Fin ((C).copies j),
+          W ⟨j, q⟩ *
+            ((μ ((C).enum j q) * ζ j q) • blocks ((C).repr j) v) *
+            (W ⟨j, q⟩)ᴴ := by
+  classical
+  have hData : ∀ j q, ∃ gamma : ℝ, 0 < gamma ∧
+      (X j q : Matrix (Fin (dim ((C).enum j q)))
+        (Fin (dim ((C).enum j q))) ℂ)ᴴ * X j q = (gamma : ℂ) • 1 := by
+    intro j q
+    exact IsMPDO.grouped_sector_gram_eq_pos_smul_one blocks hM hHorizontal
+      μ V hDimPos hNormal hdim X ζ hXDist hCoeffPos hCorner j q
+  choose gamma hgamma hGram using hData
+  have hUnit : ∀ j q,
+      (((Real.sqrt (gamma j q) : ℂ))⁻¹ •
+          (X j q : Matrix (Fin (dim ((C).enum j q)))
+            (Fin (dim ((C).enum j q))) ℂ)) ∈
+        Matrix.unitaryGroup (Fin (dim ((C).enum j q))) ℂ := by
+    intro j q
+    exact Matrix.smul_mem_unitaryGroup_of_conjTranspose_mul_self_eq_smul_one
+      (hgamma j q) (hGram j q)
+  let W : (p : (j : Fin (C).g) × Fin ((C).copies j)) →
+      Matrix (Fin d) (Fin (dim ((C).repr p.1))) ℂ := fun p ↦
+    normalizedGroupedSectorMap (hdim p.1 p.2) (V ((C).enum p.1 p.2))
+      (X p.1 p.2) (gamma p.1 p.2)
+  refine ⟨gamma, W, hgamma, ?_, ?_, ?_, ?_, ?_⟩
+  · intro j q
+    rfl
+  · intro p
+    exact normalizedGroupedSectorMap_isometry (hdim p.1 p.2)
+      (V ((C).enum p.1 p.2)) (X p.1 p.2) (gamma p.1 p.2)
+      (hIso p.1 p.2) (hUnit p.1 p.2)
+  · intro p s hps
+    apply normalizedGroupedSectorMap_orthogonal
+    apply hOrth
+    intro henum
+    exact hps ((C).enumEquiv.injective henum)
+  · intro p v
+    exact normalizedGroupedSectorMap_intertwining (hdim p.1 p.2)
+      (verticalTensor M v) (blocks ((C).repr p.1)) v (V ((C).enum p.1 p.2))
+      (X p.1 p.2) (μ ((C).enum p.1 p.2) * ζ p.1 p.2) (gamma p.1 p.2)
+      (hInter p.1 p.2 v)
+  · intro v
+    rw [hReconstruct v]
+    apply Finset.sum_congr rfl
+    intro j _hj
+    apply Finset.sum_congr rfl
+    intro q _hq
+    rw [normalizedGroupedSectorMap_corner (hdim j q)
+      (blocks ((C).repr j)) v (V ((C).enum j q)) (X j q)
+      (μ ((C).enum j q) * ζ j q) (gamma j q) (hgamma j q) (hGram j q)]
+
+end GroupedSectors
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -107,9 +107,14 @@ letterwise reconstruction. `TNLean.MPS.MPDO.VerticalBNT` groups these corners
 into representatives while retaining their physical isometries, and
 `TNLean.MPS.MPDO.SectorTrace` proves positivity of every grouped coefficient.
 The relative Gram algebra is formalized in
-`TNLean.MPS.CanonicalForm.NormalCommutant`.  What remains open is the reflected
-marked-chain form of Lemma L needed to apply it to the grouped data, followed
-by the final coisometry assembly.
+`TNLean.MPS.CanonicalForm.NormalCommutant`; the reflected marked-chain and
+Figure~8 arguments are proved in `TNLean.MPS.MPDO.ReflectedMarkedLemmaL` and
+`TNLean.MPS.MPDO.GroupedFigure8`.  The grouped gauges are normalized and
+absorbed into orthogonal physical sector maps in
+`TNLean.MPS.MPDO.GroupedGramNormalization` and
+`TNLean.MPS.MPDO.NormalizedGroupedSectors`.  What remains open is to transport
+the algebraic basis-of-normal-tensors spanning property to the original
+vertical tensor and apply the established coisometry assembly.
 
 ## Module location
 

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -2277,6 +2277,55 @@
     and division by its positive square root gives the stated unitary.
 \end{proof}
 
+\begin{theorem}[Normalized physical maps for the grouped vertical sectors]
+    \label{thm:mpdo_normalized_grouped_physical_maps}
+    \lean{MPOTensor.IsMPDO.exists_normalized_grouped_physical_maps}
+    \leanok
+    \uses{thm:mpdo_vertical_bnt_grouping_with_isometries,
+        thm:mpdo_grouped_sector_unitary_normalization}
+    In the grouped vertical decomposition, let $V_{\alpha,k}$ be the
+    isometry carrying the copy $(\alpha,k)$ and let
+    $U_{\alpha,k}=\omega_{\alpha,k}^{-1/2}X_{\alpha,k}$ be its normalized
+    unitary gauge.  After identifying the copy bond space with the bond space
+    of its representative, define
+    \[
+        W_{\alpha,k}=V_{\alpha,k}U_{\alpha,k}.
+    \]
+    Then the maps $W_{\alpha,k}$ are isometries with mutually orthogonal
+    ranges.  If $c_{\alpha,k}>0$ is the grouped coefficient, then
+    \[
+        \widetilde M^v W_{\alpha,k}
+          =W_{\alpha,k}\bigl(c_{\alpha,k}M_\alpha^v\bigr)
+    \]
+    for every vertical letter $v$, and
+    \[
+        \widetilde M^v
+          =\sum_{\alpha,k}W_{\alpha,k}
+            \bigl(c_{\alpha,k}M_\alpha^v\bigr)
+            W_{\alpha,k}^\dagger.
+    \]
+    This is the physical-sector normalization used in
+    \cite[Proposition~4.13, lines~1903--1921]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_grouped_sector_unitary_normalization}
+    The unitary $U_{\alpha,k}$ identifies the representative bond space with
+    the bond space of its copy.  Hence
+    $W_{\alpha,k}^\dagger W_{\alpha,k}=\Id$, while the orthogonality of two
+    distinct maps follows from
+    $V_{\alpha,k}^\dagger V_{\beta,l}=0$.
+    Since $U_{\alpha,k}$ is a nonzero scalar multiple of
+    $X_{\alpha,k}$, the scalar cancels from the similarity transform:
+    \[
+        U_{\alpha,k}M_\alpha^vU_{\alpha,k}^\dagger
+          =X_{\alpha,k}M_\alpha^vX_{\alpha,k}^{-1}.
+    \]
+    Substitution into the original sector intertwining and reconstruction
+    identities gives the two displayed formulas.
+\end{proof}
+
 \begin{lemma}[Matrix product vector of the diagonal tensor]
     \label{lem:mpv_diagonal_tensor}
     \lean{MPOTensor.mpv_diagonalTensor}
@@ -2880,6 +2929,7 @@
         thm:mpdo_pairwise_vertical_gram_conjugation,
         thm:mpdo_grouped_sector_gram_conjugation,
         thm:mpdo_grouped_sector_unitary_normalization,
+        thm:mpdo_normalized_grouped_physical_maps,
         thm:vertical_sector_coisometry,
         lem:mpdo_vertical_retained_class_nonempty,
         thm:projector_closure_canonical_form,
@@ -2921,6 +2971,7 @@
         thm:mpdo_pairwise_vertical_gram_conjugation,
         thm:mpdo_grouped_sector_gram_conjugation,
         thm:mpdo_grouped_sector_unitary_normalization,
+        thm:mpdo_normalized_grouped_physical_maps,
         thm:vertical_sector_coisometry,
         lem:mpdo_vertical_retained_class_nonempty,
         thm:projector_closure_canonical_form,
@@ -2995,8 +3046,8 @@
     $U_{\alpha,k}=\omega_{\alpha,k}^{-1/2}X_{\alpha,k}$ of the sector gauges
     using the grouped decomposition's distinguished gauge
     $X_{\alpha,1}=\Id$.  This is the source's $U_{\alpha,k}$.
-    After identifying the bond space of each copy with that of its
-    representative, define
+    Theorem~\ref{thm:mpdo_normalized_grouped_physical_maps} identifies the
+    bond space of each copy with that of its representative and defines
 
     \[
         W_{\alpha,k}=V_{\alpha,k}U_{\alpha,k}.

--- a/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
@@ -220,31 +220,36 @@ $X_{\alpha,1}=\Id$, giving the normalization printed by the source
 The reflected marked-chain, two-sector separation, and dependent-dimension
 transport of source lines~1909--1919 are therefore complete, as is the
 positive scalar Gram identity and unitary normalization of every grouped
-gauge.  What remains is to transport these unitary gauges to common
-representative bond spaces, compose them with the physical sector isometries,
-and establish the normalized physical maps required by the final coisometry.
-Their generic assembly into the direct-sum coisometry $U$ is already
+gauge.  The normalized gauges are now transported to the representative bond
+spaces and composed with the physical sector isometries in
+\path{TNLean/MPS/MPDO/NormalizedGroupedSectors.lean}.  The resulting maps
+$W_{\alpha,q}$ are isometries with mutually orthogonal ranges, satisfy the
+representative intertwining identities, and reconstruct every vertical letter
+exactly.  Their generic assembly into the direct-sum coisometry $U$ is already
 proved by \path{Matrix.sigmaBlockRow_isCoisometry},
 \path{Matrix.sigmaBlockRow_conjugation}, and
-\path{Matrix.sigmaBlockRow_reconstruction}.  The remaining source-specific
-identifications are to transport the copy bond spaces along the dimension
-equalities supplied by the grouping theorem, index the sectors by dependent
-pairs $(\alpha,q)$, and identify the dependent disjoint union with the
-standard direct-sum coordinate space.  A retained representative is already
-supplied by
+\path{Matrix.sigmaBlockRow_reconstruction}; the dependent-pair and standard
+finite-coordinate identifications are contained in
+\path{MPOTensor.isVerticalCF_of_grouped_orthogonal_sectors}.  A retained
+representative is already supplied by
 \path{MPOTensor.IsHorizontalCF.exists_nonempty_verticalBNTGrouping} in
-\path{TNLean/MPS/MPDO/RetainedClass.lean}.  Thus only the source-specific
-normalized physical maps, their final coisometry, the direct-sum indexing,
-and the literal vertical canonical-form identity remain.  The original
+\path{TNLean/MPS/MPDO/RetainedClass.lean}.  It remains to transport the
+spectral basis-of-normal-tensors property to the original vertically viewed
+tensor.  For positive chain lengths this follows from the exact sector
+reconstruction and cyclicity of trace; the empty chain requires the separate
+retained representative and its positive bond dimension.  Once this
+algebraic spanning clause is proved,
+\path{MPOTensor.isVerticalCF_of_grouped_orthogonal_sectors} gives the final
+literal vertical canonical-form identity.  The original
 formulation of \ghissue{2536}, interpreted as a direct conversion of the
 horizontal scalar weights and diagonal restrictions, is therefore not a
 consequence of Proposition~4.13.
 
 \paragraph{Verdict.}
-This is an open gap: Figure~8 and the normal-tensor Gram normalization are
-complete for the actual grouped sectors, but the normalized physical maps and
-their final coisometry have not yet been assembled from the
-matrix-product-density-operator hypotheses.
+This is an open gap: Figure~8, Gram normalization, and the normalized physical
+sector maps are complete.  The remaining obligation is the
+basis-of-normal-tensors spanning property for the original vertical tensor,
+including the empty-chain case, followed by the existing coisometry theorem.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
@@ -195,11 +195,16 @@ grouped into pairwise gauge-phase-distinct BNT representatives in
 \path{TNLean/MPS/MPDO/VerticalBNT.lean}. Every copy is expressed by a positive
 coefficient, a unit-modulus phase, and an invertible bond-space gauge, while
 the physical isometries and the literal vertical reconstruction are retained.
-What remains is to transport the unitary gauge normalizations to common
-representative bond spaces, compose them with the physical sector isometries,
-and assemble these normalized physical maps into the final coisometry.  The
-literal vertical canonical-form identity has therefore not yet been derived
-from the MPDO hypotheses.
+The unitary gauge normalizations are transported to the representative bond
+spaces and composed with the physical sector isometries in
+\path{TNLean/MPS/MPDO/NormalizedGroupedSectors.lean}.  These normalized maps
+have orthogonal isometric ranges, obey the representative intertwining, and
+retain literal reconstruction.  The remaining obligation is to prove that the
+representatives form an algebraic basis of normal tensors for the original
+vertical tensor.  Positive lengths follow from reconstruction and cyclicity of
+trace; length zero requires a separate retained representative.  The existing
+block-row theorem then supplies the final coisometry and literal vertical
+canonical-form identity.
 
 \paragraph{Verdict.}
 This is an open gap: the source-faithful horizontal-to-vertical implication of


### PR DESCRIPTION
## Mathematical statement

For the grouped vertical decomposition in Proposition 4.13 of arXiv:1606.00608, this change chooses the positive Gram scalar of every copy, normalizes its gauge to a unitary, transports the copy bond space to the representative bond space, and defines

\[
W_{\alpha,q}=V_{\operatorname{enum}(\alpha,q)}\,\omega_{\alpha,q}^{-1/2}X_{\alpha,q}.
\]

The resulting maps are isometries with mutually orthogonal ranges. They intertwine the vertically viewed tensor with the undressed representative tensors and retain the literal reconstruction of every vertical letter.

## Source

- arXiv:1606.00608, Proposition 4.13, lines 1895–1921
- blueprint: `thm:mpdo_normalized_grouped_physical_maps`
- parent tracker: #3674

The hypotheses are exactly the clauses produced by `IsHorizontalCF.exists_verticalBNTGrouping_with_isometry`, together with horizontal canonical form and the MPDO condition. No additional mathematical hypothesis is introduced.

## Verification

- `lake env lean TNLean/MPS/MPDO/NormalizedGroupedSectors.lean`
- `lake build` (9396 jobs)
- blueprint declaration check, including the new declaration
- `leanblueprint pdf` (552 pages)
- reader-facing prose check
- `#print axioms MPOTensor.IsMPDO.exists_normalized_grouped_physical_maps`: only `propext`, `Classical.choice`, and `Quot.sound`
- no new proof bypass

Closes #3912.
Advances #3674.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes are confined to MPDO vertical canonical-form formalization with no new proof axioms, but the new theorem is on a critical proof path and the linear-algebra corner arguments are easy to get wrong.
> 
> **Overview**
> Adds **`TNLean/MPS/MPDO/NormalizedGroupedSectors.lean`** and wires it into the library import surface. The capstone is **`IsMPDO.exists_normalized_grouped_physical_maps`**: from the grouped vertical BNT data (`exists_verticalBNTGrouping_with_isometry`), it builds maps **`W_{α,q} = V · ω^{-1/2} X`** on representative bond dimensions that are isometries with orthogonal ranges, intertwine **`verticalTensor`** with undressed representative blocks, and keep the literal letterwise reconstruction.
> 
> Supporting lemmas define **`normalizedGroupedSectorMap`**, show isometry and cross-sector orthogonality, and prove gauge absorption preserves intertwining and corner identities (using Gram scalars from **`GroupedGramNormalization`**).
> 
> **Blueprint** gains Theorem `thm:mpdo_normalized_grouped_physical_maps` (`\leanok`); **VerticalCF** and paper-gap notes now treat normalized physical maps as done and point the remaining vertical-CF work at the basis-of-normal-tensors spanning step plus existing coisometry assembly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b92ba1e9d3948e4818cab5bec3c3cdb84c1eb74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->