### PR TITLE
feat(MPS/MPDO): prove horizontal CF implies vertical CF

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -401,6 +401,7 @@ import TNLean.MPS.MPDO.FigureEightPairwise
 import TNLean.MPS.MPDO.GroupedFigure8
 import TNLean.MPS.MPDO.GroupedGramNormalization
 import TNLean.MPS.MPDO.NormalizedGroupedSectors
+import TNLean.MPS.MPDO.VerticalCFFromHorizontal
 import TNLean.MPS.MPDO.BiCFDerivation
 import TNLean.MPS.MPDO.ZCL
 import TNLean.MPS.MPDO.RFP

--- a/TNLean/MPS/MPDO/NormalizedGroupedSectors.lean
+++ b/TNLean/MPS/MPDO/NormalizedGroupedSectors.lean
@@ -117,7 +117,6 @@ private theorem normalized_gauge_corner
           (X : Matrix (Fin n) (Fin n) ℂ))ᴴ =
       c • ((X : Matrix (Fin n) (Fin n) ℂ) * A *
         (↑(X⁻¹) : Matrix (Fin n) (Fin n) ℂ)) := by
-  have hs_pos : 0 < Real.sqrt omega := Real.sqrt_pos.mpr homega
   have hs_sq : Real.sqrt omega * Real.sqrt omega = omega :=
     Real.mul_self_sqrt homega.le
   have hconjs : star ((Real.sqrt omega : ℂ))⁻¹ =

--- a/TNLean/MPS/MPDO/NormalizedGroupedSectors.lean
+++ b/TNLean/MPS/MPDO/NormalizedGroupedSectors.lean
@@ -118,8 +118,6 @@ private theorem normalized_gauge_corner
       c • ((X : Matrix (Fin n) (Fin n) ℂ) * A *
         (↑(X⁻¹) : Matrix (Fin n) (Fin n) ℂ)) := by
   have hs_pos : 0 < Real.sqrt omega := Real.sqrt_pos.mpr homega
-  have hs_ne : ((Real.sqrt omega : ℝ) : ℂ) ≠ 0 := by
-    exact_mod_cast hs_pos.ne'
   have hs_sq : Real.sqrt omega * Real.sqrt omega = omega :=
     Real.mul_self_sqrt homega.le
   have hconjs : star ((Real.sqrt omega : ℂ))⁻¹ =

--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -107,9 +107,13 @@ letterwise reconstruction. `TNLean.MPS.MPDO.VerticalBNT` groups these corners
 into representatives while retaining their physical isometries, and
 `TNLean.MPS.MPDO.SectorTrace` proves positivity of every grouped coefficient.
 The relative Gram algebra is formalized in
-`TNLean.MPS.CanonicalForm.NormalCommutant`.  What remains open is the reflected
-marked-chain form of Lemma L needed to apply it to the grouped data, followed
-by the final coisometry assembly.
+`TNLean.MPS.CanonicalForm.NormalCommutant`; its application to the grouped
+sectors is carried out in `TNLean.MPS.MPDO.GroupedFigure8` and
+`TNLean.MPS.MPDO.GroupedGramNormalization`.  The normalized physical maps and
+the algebraic vertical BNT are constructed in
+`TNLean.MPS.MPDO.NormalizedGroupedSectors` and
+`TNLean.MPS.MPDO.VerticalBNTConstruction`.  Their final coisometry assembly is
+proved in `TNLean.MPS.MPDO.VerticalCFFromHorizontal`.
 
 ## Module location
 
@@ -665,11 +669,7 @@ theorem sameMPV₂_toTensorFromBlocks_verticalAssembledTensor_of_equiv
           ∑ q : Fin (∑ α : Fin g, mult α), dim ((finSigmaFinEquiv.symm q).1)
         exact (Equiv.sum_comp finSigmaFinEquiv.symm (fun p ↦ dim p.1)).symm
 
--- The implication `verticalCF_of_horizontalCF` (arXiv:1606.00608,
--- Proposition 4.13) — every MPDO in horizontal canonical form is in vertical
--- canonical form — is tracked by the blueprint entry
--- `thm:vertical_cf_of_horizontal_cf` (currently `\notready`) and will be added
--- as a theorem together with its proof once the horizontal-to-vertical
--- canonical-form argument has been formalized.
+-- The implication `verticalCF_of_horizontalCF` from arXiv:1606.00608,
+-- Proposition 4.13, is proved in `VerticalCFFromHorizontal.lean`.
 
 end MPOTensor

--- a/TNLean/MPS/MPDO/VerticalCFFromHorizontal.lean
+++ b/TNLean/MPS/MPDO/VerticalCFFromHorizontal.lean
@@ -1,0 +1,72 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.NormalizedGroupedSectors
+import TNLean.MPS.MPDO.VerticalBNTConstruction
+import TNLean.MPS.MPDO.VerticalCoisometry
+
+/-!
+# Vertical canonical form of a horizontally canonical MPDO
+
+This file completes the vertical canonical-form construction for a matrix
+product density operator in horizontal canonical form.  The vertical sectors
+are grouped by their matrix-product-vector phase classes, their gauge matrices
+are absorbed into normalized physical isometries, and the resulting orthogonal
+sector family is assembled into the vertical coisometry.
+
+## Main result
+
+* `MPOTensor.verticalCF_of_horizontalCF`: a horizontally canonical tensor
+  generating matrix product density operators is vertically canonical.
+
+## References
+
+* Cirac--Pérez-García--Schuch--Verstraete, arXiv:1606.00608,
+  Proposition 4.13, lines 1863--1921.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- A horizontally canonical tensor generating matrix product density
+operators is in vertical canonical form.
+
+Source: arXiv:1606.00608, Proposition 4.13, lines 1863--1921. -/
+theorem verticalCF_of_horizontalCF (M : MPOTensor d D)
+    (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M) :
+    IsVerticalCF M := by
+  classical
+  obtain ⟨r, dim, μ, blocks, V, hdimPos, _hμPos, hNormal, hIso, _hOrth,
+    _hInter, hInterStar, _hCorner, hReconstruct, hGrouped⟩ :=
+    hHorizontal.exists_verticalBNTGrouping_with_isometry M hM
+  obtain ⟨hdim, X, ζ, _hζNorm, _hζNe, hXDist, _hζDist, _hGauge,
+    hBasis, _hNotGauge, _hCoeffNe, _hSector, _hCompression, hCoeffPos,
+    hIsoGrouped, hOrthGrouped, hInterGrouped, _hInterStarGrouped,
+    hCornerGrouped, hReconstructGrouped⟩ := hGrouped
+  have hBNT := hHorizontal.isBNT_verticalTensor_of_grouping M μ blocks V
+    hdimPos hIso hInterStar hReconstruct hBasis
+  obtain ⟨_omega, W, _homega, hWIso, hWOrth, hWInter, hWReconstruct⟩ :=
+    hM.exists_normalized_grouped_sector_maps blocks hHorizontal μ V
+      hdimPos hNormal hdim X ζ hXDist hCoeffPos hIsoGrouped hOrthGrouped
+      hInterGrouped hCornerGrouped hReconstructGrouped
+  let C := MPSTensor.mpvPhaseClassData blocks
+  refine isVerticalCF_of_grouped_orthogonal_sectors M
+    (fun j ↦ dim (C.repr j)) C.copies C.copies_pos
+    (fun j q ↦ μ (C.enum j q) * ζ j q) hCoeffPos
+    (fun j ↦ blocks (C.repr j)) hBNT W hWIso hWOrth hWInter ?_
+  intro v
+  rw [hWReconstruct v]
+  let f : ((j : Fin C.g) × Fin (C.copies j)) →
+      Matrix (Fin d) (Fin d) ℂ := fun p ↦
+    W p * ((μ (C.enum p.1 p.2) * ζ p.1 p.2) •
+      blocks (C.repr p.1) v) * (W p)ᴴ
+  change (∑ j, ∑ q, f ⟨j, q⟩) =
+    ∑ q, f (finSigmaFinEquiv.symm q)
+  rw [Equiv.sum_comp finSigmaFinEquiv.symm f, Fintype.sum_sigma]
+
+end MPOTensor

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -3019,9 +3019,13 @@
 
 \begin{theorem}[Horizontal canonical form implies vertical canonical form]
     \label{thm:vertical_cf_of_horizontal_cf}
-    \notready
+    \lean{MPOTensor.verticalCF_of_horizontalCF}
+    \leanok
     \uses{def:mpdo, def:horizontal_cf_mpdo, def:vertical_tensor_mpdo,
         def:vertical_cf_mpdo,
+        thm:mpdo_vertical_grouped_is_bnt,
+        thm:mpdo_normalized_grouped_sector_maps,
+        thm:vertical_cf_of_grouped_orthogonal_sectors,
         thm:mpdo_opposite_corner_zero,
         thm:mpdo_first_site_invariant_comm,
         thm:representative_one_sub_mp_zero,
@@ -3063,7 +3067,11 @@
 \end{theorem}
 
 \begin{proof}
+    \leanok
     \uses{def:mpdo, def:horizontal_cf_mpdo, def:vertical_cf_mpdo, def:bnt,
+        thm:mpdo_vertical_grouped_is_bnt,
+        thm:mpdo_normalized_grouped_sector_maps,
+        thm:vertical_cf_of_grouped_orthogonal_sectors,
         thm:mpdo_opposite_corner_zero,
         thm:mpdo_first_site_invariant_comm,
         thm:representative_one_sub_mp_zero,

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -3022,35 +3022,7 @@
     \lean{MPOTensor.verticalCF_of_horizontalCF}
     \leanok
     \uses{def:mpdo, def:horizontal_cf_mpdo, def:vertical_tensor_mpdo,
-        def:vertical_cf_mpdo,
-        thm:mpdo_vertical_grouped_is_bnt,
-        thm:mpdo_normalized_grouped_sector_maps,
-        thm:vertical_cf_of_grouped_orthogonal_sectors,
-        thm:mpdo_opposite_corner_zero,
-        thm:mpdo_first_site_invariant_comm,
-        thm:representative_one_sub_mp_zero,
-        thm:mpdo_vertical_no_periodic_vectors_horizontal_cf,
-        thm:mpdo_vertical_projector_closure,
-        thm:mpdo_vertical_irreducible_reducing_sectors,
-        thm:mpdo_vertical_complete_reducing_projectors,
-        thm:mpdo_vertical_normal_sectors_with_isometries,
-        thm:mpdo_vertical_bnt_grouping_with_isometries,
-        thm:mpdo_reflected_marked_chain,
-        thm:mpdo_pairwise_vertical_gram_conjugation,
-        thm:mpdo_grouped_sector_gram_conjugation,
-        thm:mpdo_grouped_sector_unitary_normalization,
-        thm:vertical_sector_coisometry,
-        lem:mpdo_vertical_retained_class_nonempty,
-        thm:projector_closure_canonical_form,
-        thm:mpdo_sector_compression_trace_pos,
-        def:mpdo_sector_projector,
-        thm:mpdo_sector_trace_identity,
-        thm:mpdo_sector_weight_pos,
-        thm:eq3_of_dressed_adjoint,
-        lem:mpv_diagonal_tensor,
-        lem:mpv_diagonal_tensor_eq_blocks, lem:mpv_diagonal_tensor_nonneg,
-        lem:mpv_vertical_assembled,
-        lem:vertical_grouping_equiv}
+        def:vertical_cf_mpdo}
     A tensor in horizontal canonical form that generates matrix product
     density operators is also in canonical form in the vertical direction:
     there are a basis of normal tensors $\{M_\alpha\}_\alpha$ for the
@@ -3068,183 +3040,30 @@
 
 \begin{proof}
     \leanok
-    \uses{def:mpdo, def:horizontal_cf_mpdo, def:vertical_cf_mpdo, def:bnt,
+    \uses{def:mpv_phase_class_data,
+        thm:mpdo_vertical_bnt_grouping_with_isometries,
         thm:mpdo_vertical_grouped_is_bnt,
         thm:mpdo_normalized_grouped_sector_maps,
-        thm:vertical_cf_of_grouped_orthogonal_sectors,
-        thm:mpdo_opposite_corner_zero,
-        thm:mpdo_first_site_invariant_comm,
-        thm:representative_one_sub_mp_zero,
-        thm:mpdo_vertical_no_periodic_vectors_horizontal_cf,
-        thm:mpdo_vertical_projector_closure,
-        thm:mpdo_vertical_irreducible_reducing_sectors,
-        thm:mpdo_vertical_complete_reducing_projectors,
-        thm:mpdo_vertical_bnt_grouping_with_isometries,
-        thm:mpdo_reflected_marked_chain,
-        thm:mpdo_pairwise_vertical_gram_conjugation,
-        thm:mpdo_grouped_sector_gram_conjugation,
-        thm:mpdo_grouped_sector_unitary_normalization,
-        thm:vertical_sector_coisometry,
-        lem:mpdo_vertical_retained_class_nonempty,
-        thm:projector_closure_canonical_form,
-        thm:mpdo_sector_compression_trace_pos,
-        def:mpdo_sector_projector,
-        thm:mpdo_sector_trace_identity,
-        thm:mpdo_sector_weight_pos,
-        thm:eq3_of_dressed_adjoint,
-        thm:cpsv_normal_eventually_injective,
-        thm:gauge_invariance,
-        lem:mpv_diagonal_tensor,
-        lem:vertical_grouping_equiv, lem:mpv_zero_length}
-    Theorem~\ref{thm:representative_one_sub_mp_zero} shows
-    that every self-adjoint $P$ with $PM=PMP$ on the vertically viewed tensor
-    gives the literal equality $MP=PMP$ on the original MPO tensor, including
-    all its repeated sectors.  The paper takes $P$
-    to be an orthogonal projector; Hermiticity is the only part of that
-    assumption needed for this implication.
-    Theorem~\ref{thm:mpdo_vertical_no_periodic_vectors_horizontal_cf}
-    excludes nontrivial $p$-periodic vectors of the vertically viewed tensor
-    from the horizontal canonical-form and positivity hypotheses alone.
-    Theorem~\ref{thm:mpdo_vertical_projector_closure} proves that every
-    one-sided invariant orthogonal projection of $\widetilde M$ is reducing.
-    Theorem~\ref{thm:mpdo_vertical_irreducible_reducing_sectors} therefore
-    decomposes the physical space into complete orthogonal irreducible
-    reducing sectors, and
-    Theorem~\ref{thm:mpdo_vertical_complete_reducing_projectors} records their
-    commuting range projections. Theorem~\ref{thm:mpdo_vertical_normal_sectors_with_isometries}
-    removes the zero corners and spectrally normalizes the remaining corners
-    while retaining their physical isometries, both intertwining identities,
-    exact compression, and literal reconstruction of every vertical letter.
-    Theorem~\ref{thm:mpdo_vertical_bnt_grouping_with_isometries} groups the
-    resulting normal tensors.  Write $\nu_{\alpha,k}$ for the raw sector
-    weight, $\zeta_{\alpha,k}$ for the phase of its chosen representative,
-    and
-    \[
-        c_{\alpha,k}=\nu_{\alpha,k}\zeta_{\alpha,k}.
-    \]
-    The grouped decomposition is
-    \[
-        \widetilde M
-        =\bigoplus_{\alpha,k}c_{\alpha,k}
-        X_{\alpha,k}M_\alpha X_{\alpha,k}^{-1}
-    \]
-    carried by the physical space, with normal tensors $M_\alpha$ whose
-    letters remain indexed by the horizontal bond pairs.  These blocks are not
-    obtained by restricting the horizontal blocks to diagonal physical pairs,
-    as Theorem~\ref{thm:diagonal_restriction_not_normal} shows. It also
-    identifies the physical range projectors with the grouped sectors, proves
-    their loop identities, and finds a nonzero compression for each sector.
-    Positivity then gives $c_{\alpha,k}>0$:
-    Theorem~\ref{thm:mpdo_sector_compression_trace_pos} supplies the positive
-    traces of the nonzero sector compressions,
-    Theorem~\ref{thm:mpdo_sector_trace_identity} identifies each such trace
-    as $c_{\alpha,k}d_\alpha$, and
-    Theorem~\ref{thm:mpdo_sector_weight_pos} concludes $d_\alpha>0$ and
-    $c_{\alpha,k}>0$ from the normalization
-    $c_{\alpha,1}=\nu_{\alpha,1}>0$.  From now on write
-    $\mu_{\alpha,k}=c_{\alpha,k}$ for the positive coefficient in the
-    source decomposition.  Theorem~\ref{thm:mpdo_reflected_marked_chain}
-    proves the Figure~7 identity for each such sector, and
-    Theorem~\ref{thm:mpdo_grouped_sector_gram_conjugation} applies the
-    pairwise Gram comparison to the actual grouped corners and gives the
-    Gram-conjugation identity in Figure~8.
-    Theorem~\ref{thm:mpdo_grouped_sector_unitary_normalization} applies
-    normal-tensor rigidity to the actual grouped comparison and gives
-    \[
-        X_{\alpha,k}^\dagger X_{\alpha,k}
-        =\omega_{\alpha,k}\Id,
-    \]
-    and the unitary normalization
-    $U_{\alpha,k}=\omega_{\alpha,k}^{-1/2}X_{\alpha,k}$ of the sector gauges
-    using the grouped decomposition's distinguished gauge
-    $X_{\alpha,1}=\Id$.  This is the source's $U_{\alpha,k}$.
-    After identifying the bond space of each copy with that of its
-    representative, define
+        thm:vertical_cf_of_grouped_orthogonal_sectors}
+    Choose the grouped vertical-sector decomposition supplied by
+    Theorem~\ref{thm:mpdo_vertical_bnt_grouping_with_isometries}.  For this
+    same choice of representatives, Theorem~\ref{thm:mpdo_vertical_grouped_is_bnt}
+    proves that the representatives form a basis of normal tensors for
+    $\widetilde M$.
 
-    \[
-        W_{\alpha,k}=V_{\alpha,k}U_{\alpha,k}.
-    \]
+    Theorem~\ref{thm:mpdo_normalized_grouped_sector_maps} absorbs each sector
+    gauge into its physical isometry.  The resulting maps
+    $W_{\alpha,q}$ have mutually orthogonal isometric ranges, intertwine
+    $\widetilde M$ with the positively weighted representative tensors, and
+    reconstruct every vertical letter exactly.  Hence
+    Theorem~\ref{thm:vertical_cf_of_grouped_orthogonal_sectors} supplies the
+    required coisometry and both vertical canonical-form identities.
 
-    Since $V_{\alpha,k}$ is an isometry and $U_{\alpha,k}$ is unitary,
-
-    \[
-        W_{\alpha,k}^\dagger W_{\alpha,k}=\Id,
-        \qquad
-        W_{\alpha,k}^\dagger W_{\beta,l}=0
-        \quad\text{if }(\alpha,k)\ne(\beta,l).
-    \]
-
-    The sector gauge relation and the literal reconstruction of
-    $\widetilde M$ become
-
-    \[
-        \widetilde M_vW_{\alpha,k}
-          =W_{\alpha,k}(\mu_{\alpha,k}M_\alpha^v),
-        \qquad
-        \widetilde M_v
-          =\sum_{\alpha,k}
-            W_{\alpha,k}(\mu_{\alpha,k}M_\alpha^v)
-            W_{\alpha,k}^\dagger.
-    \]
-
-    Theorem~\ref{thm:vertical_sector_coisometry}, indexed by the dependent
-    pairs $(\alpha,k)$, therefore gives a coisometry $U$ such that
-
-    \[
-        U\widetilde MU^\dagger
-          =\bigoplus_{\alpha,k}\mu_{\alpha,k}M_\alpha,
-        \qquad
-        \widetilde M
-          =U^\dagger\!\left(
-              \bigoplus_{\alpha,k}\mu_{\alpha,k}M_\alpha
-            \right)U.
-    \]
-
-    The dependent disjoint union of the sector bond indices has its canonical
-    identification with the standard direct-sum coordinates.  Regrouping the
-    summands by $\alpha$ gives
-    $\bigoplus_\alpha\mu_\alpha\otimes M_\alpha$ as in
-    Lemma~\ref{lem:vertical_grouping_equiv}.
-
-    The algebraic basis-of-normal-tensors clauses follow from the same
-    decomposition.  With the notation of the grouping theorem, its spectral
-    BNT property applies to the raw weighted tensor
-    \[
-        A_{\mathrm{ret}}
-        =\bigoplus_{\alpha,k}\nu_{\alpha,k}B_{\alpha,k}.
-    \]
-    Theorem~\ref{thm:cpsv_normal_eventually_injective} makes every
-    $M_\alpha$ algebraically normal.  Eventual linear independence is
-    unchanged because the representatives themselves are unchanged.
-
-    For the spanning clause, let
-    $\mathcal X=\bigoplus_{\alpha,k}X_{\alpha,k}$.  The gauge-phase identities
-    and $\mu_{\alpha,k}=c_{\alpha,k}=\nu_{\alpha,k}\zeta_{\alpha,k}$ give the
-    square block gauge
-    \[
-        A_{\mathrm{ret}}=\mathcal X B\mathcal X^{-1},
-        \qquad
-        B=\bigoplus_{\alpha,k}\mu_{\alpha,k}M_\alpha.
-    \]
-    Theorem~\ref{thm:gauge_invariance} therefore transfers the spectral BNT
-    spanning identity from $A_{\mathrm{ret}}$ to $B$.  For every nonempty
-    word $w=(v_1,\ldots,v_N)$, the coisometry and reconstruction identities
-    give
-    \[
-        \widetilde M^w=U^\dagger B^wU,
-        \qquad
-        \tr(\widetilde M^w)
-        =\tr(B^wUU^\dagger)=\tr(B^w).
-    \]
-    Thus the positive-length matrix product vectors of $\widetilde M$ lie in
-    the span of those of the $M_\alpha$.
-
-    The empty chain requires a separate argument because the bond dimensions
-    of $\widetilde M$ and $B$ may differ.  By
-    Lemma~\ref{lem:mpdo_vertical_retained_class_nonempty}, choose a retained
-    representative $M_{\alpha_0}$ with bond dimension $d_{\alpha_0}>0$.
-    Assign it the coefficient $d/d_{\alpha_0}$ and assign zero to every other
-    representative.  Lemma~\ref{lem:mpv_zero_length} then gives the
-    length-zero coefficient $d$ of $\widetilde M$.  Hence the spanning clause
-    holds at every length.
+    Finally, the canonical equivalence
+    $\coprod_\alpha\{1,\ldots,r_\alpha\}
+      \cong\{1,\ldots,\sum_\alpha r_\alpha\}$
+    identifies the dependent sector pairs $(\alpha,q)$ with the standard
+    direct-sum coordinates.  Under this equivalence, the reconstruction sum
+    is precisely the block tensor
+    $\bigoplus_\alpha\mu_\alpha\otimes M_\alpha$.
 \end{proof}

--- a/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
@@ -240,7 +240,7 @@ Finally, \path{MPOTensor.verticalCF_of_horizontalCF} in
 sector coisometry theorem and identifies the dependent sector pairs
 $(\alpha,q)$ with the standard finite direct-sum coordinates.  This gives the
 literal vertical canonical-form identities of Proposition~4.13.  The original
-formulation of \ghissue{2536}, interpreted as a direct conversion of the
+formulation of \ghissue{2537}, interpreted as a direct conversion of the
 horizontal scalar weights and diagonal restrictions, remains a false route
 rather than a consequence of the proposition.
 
@@ -248,7 +248,7 @@ rather than a consequence of the proposition.
 The source-faithful horizontal-to-vertical implication of Proposition~4.13 is
 complete.  The proof follows the grouped vertical sectors used in the paper;
 it does not use the unsupported diagonal-restriction statement from
-\ghissue{2536}.
+\ghissue{2537}.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
@@ -220,31 +220,35 @@ $X_{\alpha,1}=\Id$, giving the normalization printed by the source
 The reflected marked-chain, two-sector separation, and dependent-dimension
 transport of source lines~1909--1919 are therefore complete, as is the
 positive scalar Gram identity and unitary normalization of every grouped
-gauge.  What remains is to transport these unitary gauges to common
-representative bond spaces, compose them with the physical sector isometries,
-and establish the normalized physical maps required by the final coisometry.
-Their generic assembly into the direct-sum coisometry $U$ is already
-proved by \path{Matrix.sigmaBlockRow_isCoisometry},
-\path{Matrix.sigmaBlockRow_conjugation}, and
-\path{Matrix.sigmaBlockRow_reconstruction}.  The remaining source-specific
-identifications are to transport the copy bond spaces along the dimension
-equalities supplied by the grouping theorem, index the sectors by dependent
-pairs $(\alpha,q)$, and identify the dependent disjoint union with the
-standard direct-sum coordinate space.  A retained representative is already
-supplied by
-\path{MPOTensor.IsHorizontalCF.exists_nonempty_verticalBNTGrouping} in
-\path{TNLean/MPS/MPDO/RetainedClass.lean}.  Thus only the source-specific
-normalized physical maps, their final coisometry, the direct-sum indexing,
-and the literal vertical canonical-form identity remain.  The original
+gauge.  The normalized gauges are transported to the representative bond
+spaces and composed with the physical sector isometries in
+\path{TNLean/MPS/MPDO/NormalizedGroupedSectors.lean}.  The resulting maps
+$W_{\alpha,q}$ have mutually orthogonal isometric ranges, satisfy the
+representative intertwining identities, and reconstruct every vertical letter
+exactly.
+
+The representatives are shown to form an algebraic basis of normal tensors
+for the original vertical tensor in
+\path{TNLean/MPS/MPDO/VerticalBNTConstruction.lean}.  At positive chain
+length this follows from the exact reconstruction and cyclicity of trace.  At
+length zero, one retained representative of positive bond dimension supplies
+the dimension identity required by the definition of a basis of normal
+tensors.
+
+Finally, \path{MPOTensor.verticalCF_of_horizontalCF} in
+\path{TNLean/MPS/MPDO/VerticalCFFromHorizontal.lean} applies the orthogonal
+sector coisometry theorem and identifies the dependent sector pairs
+$(\alpha,q)$ with the standard finite direct-sum coordinates.  This gives the
+literal vertical canonical-form identities of Proposition~4.13.  The original
 formulation of \ghissue{2536}, interpreted as a direct conversion of the
-horizontal scalar weights and diagonal restrictions, is therefore not a
-consequence of Proposition~4.13.
+horizontal scalar weights and diagonal restrictions, remains a false route
+rather than a consequence of the proposition.
 
 \paragraph{Verdict.}
-This is an open gap: Figure~8 and the normal-tensor Gram normalization are
-complete for the actual grouped sectors, but the normalized physical maps and
-their final coisometry have not yet been assembled from the
-matrix-product-density-operator hypotheses.
+The source-faithful horizontal-to-vertical implication of Proposition~4.13 is
+complete.  The proof follows the grouped vertical sectors used in the paper;
+it does not use the unsupported diagonal-restriction statement from
+\ghissue{2536}.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
@@ -195,16 +195,21 @@ grouped into pairwise gauge-phase-distinct BNT representatives in
 \path{TNLean/MPS/MPDO/VerticalBNT.lean}. Every copy is expressed by a positive
 coefficient, a unit-modulus phase, and an invertible bond-space gauge, while
 the physical isometries and the literal vertical reconstruction are retained.
-What remains is to transport the unitary gauge normalizations to common
-representative bond spaces, compose them with the physical sector isometries,
-and assemble these normalized physical maps into the final coisometry.  The
-literal vertical canonical-form identity has therefore not yet been derived
-from the MPDO hypotheses.
+The unitary gauge normalizations are transported to the representative bond
+spaces and composed with the physical sector isometries in
+\path{TNLean/MPS/MPDO/NormalizedGroupedSectors.lean}.  The algebraic
+basis-of-normal-tensors property is established in
+\path{TNLean/MPS/MPDO/VerticalBNTConstruction.lean}, using exact
+reconstruction at positive lengths and a retained positive-dimensional
+representative at length zero.  The resulting orthogonal sector maps are
+assembled into the final coisometry in
+\path{TNLean/MPS/MPDO/VerticalCFFromHorizontal.lean}, which proves the literal
+vertical canonical-form identity from the MPDO hypotheses.
 
 \paragraph{Verdict.}
-This is an open gap: the source-faithful horizontal-to-vertical implication of
-Proposition~4.13 remains unformalized. The diagonal-restriction route is a
-false strengthening and cannot close that gap.
+The source-faithful horizontal-to-vertical implication of Proposition~4.13 is
+complete.  The diagonal-restriction route remains a false strengthening and
+plays no part in the proof.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

Proves the horizontal-to-vertical canonical-form implication of arXiv:1606.00608, Proposition 4.13.

The proof chooses the grouped vertical decomposition once and uses the same sectors throughout. The raw sector isometries give the algebraic basis of normal tensors for the vertically viewed tensor. Their normalized representative-space maps have mutually orthogonal isometric ranges, positive weights, the representative intertwining identity, and exact reconstruction of every vertical letter. The existing block-row construction then gives the required coisometry. The final equality between the nested sector sum and the standard finite direct sum is the canonical equivalence between dependent pairs and a finite interval.

The theorem assumes exactly horizontal canonical form and the matrix-product-density-operator property. It introduces no additional mathematical hypothesis.

The Chapter 20 blueprint entry is marked complete, and the two Proposition 4.13 paper-gap reports now record the completed source-faithful route. The obsolete diagonal-restriction route remains explicitly excluded. The unused square-root nonvanishing fact noted during review of the normalized-sector proof is also removed.

Closes #3918.
Advances #3674.

## Source

- arXiv:1606.00608, Proposition 4.13, lines 1863--1921
- In particular, lines 1895--1907 for the normalized sector gauges and lines 1909--1921 for the Gram comparison

## Validation

- `lake env lean TNLean/MPS/MPDO/NormalizedGroupedSectors.lean`
- `lake env lean TNLean/MPS/MPDO/VerticalCFFromHorizontal.lean`
- `lake build TNLean.MPS.MPDO.VerticalCFFromHorizontal`
- full `lake build` (9398 jobs)
- direct declaration check for `MPOTensor.verticalCF_of_horizontalCF`
- `leanblueprint pdf` (552 pages)
- reader-facing prose check
- forbidden-token and whitespace checks

The axiom audit reports only `propext`, `Classical.choice`, and `Quot.sound`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> This is a capstone formalization and documentation update on an established MPDO proof chain, with a small proof cleanup and no changes to auth, runtime APIs, or critical infrastructure.
> 
> **Overview**
> **Proposition 4.13 (horizontal ⇒ vertical canonical form)** is now proved in Lean as `MPOTensor.verticalCF_of_horizontalCF` in `VerticalCFFromHorizontal.lean`, and wired into the public import surface.
> 
> The proof threads the **grouped vertical BNT decomposition** from horizontal CF: representatives form a BNT for the vertical tensor, **normalized sector maps** `W` from `exists_normalized_grouped_sector_maps` supply orthogonal isometric intertwinings and letterwise reconstruction, and **`isVerticalCF_of_grouped_orthogonal_sectors`** builds the coisometry. A **`finSigmaFinEquiv`** reindexing closes the nested sector sum against the standard direct-sum coordinates.
> 
> **Docs and blueprint:** Chapter 20’s `thm:vertical_cf_of_horizontal_cf` is marked `\leanok` with a shorter proof sketch; `VerticalCF.lean` no longer lists this step as open. The two Proposition 4.13 **paper-gap** notes now state the source-faithful route is complete and still exclude the false diagonal-restriction path.
> 
> **Minor:** `NormalizedGroupedSectors.lean` drops unused real-square-root nonvanishing steps in `normalized_gauge_corner`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 249ecc98bbeb43345811b9edd795108cd34e77ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->