### PR TITLE
doc(MPS/MPDO): close vertical canonical-form gap notes

### DIFF
--- a/TNLean/MPS/MPDO/NormalizedGroupedSectors.lean
+++ b/TNLean/MPS/MPDO/NormalizedGroupedSectors.lean
@@ -117,9 +117,6 @@ private theorem normalized_gauge_corner
           (X : Matrix (Fin n) (Fin n) ℂ))ᴴ =
       c • ((X : Matrix (Fin n) (Fin n) ℂ) * A *
         (↑(X⁻¹) : Matrix (Fin n) (Fin n) ℂ)) := by
-  have hs_pos : 0 < Real.sqrt omega := Real.sqrt_pos.mpr homega
-  have hs_ne : ((Real.sqrt omega : ℝ) : ℂ) ≠ 0 := by
-    exact_mod_cast hs_pos.ne'
   have hs_sq : Real.sqrt omega * Real.sqrt omega = omega :=
     Real.mul_self_sqrt homega.le
   have hconjs : star ((Real.sqrt omega : ℂ))⁻¹ =

--- a/TNLean/MPS/MPDO/PerCopyHorizontalCF.lean
+++ b/TNLean/MPS/MPDO/PerCopyHorizontalCF.lean
@@ -264,9 +264,11 @@ insertions agree on every canonical-form block.
 This formalizes the doubled-index rotation implicit in the displayed
 equation of the proof of Proposition 4.13 of arXiv:1606.00608,
 lines 1873--1887.  It does not prove that a one-sided invariant projection
-for the vertically viewed tensor supplies the first entrywise identity; that
-further identification remains part of the horizontal-to-vertical
-canonical-form argument.
+for the vertically viewed tensor supplies the first entrywise identity.  The
+corresponding invariant-projection conclusion is proved by
+`IsHorizontalCF.hasInvariantProjectorClosure_verticalTensor`; the complete
+horizontal-to-vertical implication is
+`MPOTensor.verticalCF_of_horizontalCF`.
 
 **Scope restriction (per-block separation):** inherited from
 `blockwise_insert_eq_of_mpv_agree` via `blockwise_opposite_insert_eq_of_mpv_agree`

--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -107,9 +107,13 @@ letterwise reconstruction. `TNLean.MPS.MPDO.VerticalBNT` groups these corners
 into representatives while retaining their physical isometries, and
 `TNLean.MPS.MPDO.SectorTrace` proves positivity of every grouped coefficient.
 The relative Gram algebra is formalized in
-`TNLean.MPS.CanonicalForm.NormalCommutant`.  What remains open is the reflected
-marked-chain form of Lemma L needed to apply it to the grouped data, followed
-by the final coisometry assembly.
+`TNLean.MPS.CanonicalForm.NormalCommutant`; its application to the grouped
+sectors is carried out in `TNLean.MPS.MPDO.GroupedFigure8` and
+`TNLean.MPS.MPDO.GroupedGramNormalization`.  The normalized physical maps and
+the algebraic vertical BNT are constructed in
+`TNLean.MPS.MPDO.NormalizedGroupedSectors` and
+`TNLean.MPS.MPDO.VerticalBNTConstruction`.  Their final coisometry assembly is
+proved in `TNLean.MPS.MPDO.VerticalCanonicalForm`.
 
 ## Module location
 
@@ -665,11 +669,7 @@ theorem sameMPV₂_toTensorFromBlocks_verticalAssembledTensor_of_equiv
           ∑ q : Fin (∑ α : Fin g, mult α), dim ((finSigmaFinEquiv.symm q).1)
         exact (Equiv.sum_comp finSigmaFinEquiv.symm (fun p ↦ dim p.1)).symm
 
--- The implication `verticalCF_of_horizontalCF` (arXiv:1606.00608,
--- Proposition 4.13) — every MPDO in horizontal canonical form is in vertical
--- canonical form — is tracked by the blueprint entry
--- `thm:vertical_cf_of_horizontal_cf` (currently `\notready`) and will be added
--- as a theorem together with its proof once the horizontal-to-vertical
--- canonical-form argument has been formalized.
+-- The implication `verticalCF_of_horizontalCF` from arXiv:1606.00608,
+-- Proposition 4.13, is proved in `VerticalCanonicalForm.lean`.
 
 end MPOTensor

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -3021,8 +3021,7 @@
     \label{thm:vertical_cf_of_horizontal_cf}
     \lean{MPOTensor.verticalCF_of_horizontalCF}
     \leanok
-    \uses{def:mpdo, def:horizontal_cf_mpdo, def:vertical_tensor_mpdo,
-        def:vertical_cf_mpdo}
+    \uses{def:mpdo, def:horizontal_cf_mpdo, def:vertical_cf_mpdo}
     A tensor in horizontal canonical form that generates matrix product
     density operators is also in canonical form in the vertical direction:
     there exist a basis of normal tensors $\{M_\alpha\}_\alpha$ for the

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -3040,7 +3040,8 @@
 
 \begin{proof}
     \leanok
-    \uses{thm:mpdo_vertical_bnt_grouping_with_isometries,
+    \uses{def:mpv_phase_class_data,
+        thm:mpdo_vertical_bnt_grouping_with_isometries,
         thm:mpdo_vertical_grouped_is_bnt,
         thm:mpdo_normalized_grouped_sector_maps,
         thm:vertical_cf_of_grouped_orthogonal_sectors}

--- a/docs/paper-gaps/cpgsv17_periodic_sector_projector.tex
+++ b/docs/paper-gaps/cpgsv17_periodic_sector_projector.tex
@@ -92,11 +92,12 @@ all-length condition remains only as a stronger conditional auxiliary
 statement and is not used by the source-faithful theorem.\footnote{Formal
 predicate: \leanid{MPOTensor.NoninvariantProjectorNoncommuting}.}
 
-The remaining work for Proposition~4.13 is the vertical canonical-form
-construction: applying the invariant-projector and no-periodic-vector
-criterion, producing the sector projectors and nonzero compressions, proving
-positivity of the vertical weights, deriving the dressed-adjoint identities,
-and assembling the physical-space isometry.
+The invariant-projector and no-periodic-vector criterion, the nonzero sector
+compressions, positivity of the vertical weights, the dressed-adjoint
+identities, and the physical-space coisometry are now combined in the proof of
+\path{MPOTensor.verticalCF_of_horizontalCF} in
+\path{TNLean/MPS/MPDO/VerticalCanonicalForm.lean}.  Thus the
+horizontal-to-vertical implication of Proposition~4.13 is complete.
 
 \paragraph{Verdict.} Local correction.
 

--- a/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
@@ -220,31 +220,35 @@ $X_{\alpha,1}=\Id$, giving the normalization printed by the source
 The reflected marked-chain, two-sector separation, and dependent-dimension
 transport of source lines~1909--1919 are therefore complete, as is the
 positive scalar Gram identity and unitary normalization of every grouped
-gauge.  What remains is to transport these unitary gauges to common
-representative bond spaces, compose them with the physical sector isometries,
-and establish the normalized physical maps required by the final coisometry.
-Their generic assembly into the direct-sum coisometry $U$ is already
-proved by \path{Matrix.sigmaBlockRow_isCoisometry},
-\path{Matrix.sigmaBlockRow_conjugation}, and
-\path{Matrix.sigmaBlockRow_reconstruction}.  The remaining source-specific
-identifications are to transport the copy bond spaces along the dimension
-equalities supplied by the grouping theorem, index the sectors by dependent
-pairs $(\alpha,q)$, and identify the dependent disjoint union with the
-standard direct-sum coordinate space.  A retained representative is already
-supplied by
-\path{MPOTensor.IsHorizontalCF.exists_nonempty_verticalBNTGrouping} in
-\path{TNLean/MPS/MPDO/RetainedClass.lean}.  Thus only the source-specific
-normalized physical maps, their final coisometry, the direct-sum indexing,
-and the literal vertical canonical-form identity remain.  The original
-formulation of \ghissue{2536}, interpreted as a direct conversion of the
-horizontal scalar weights and diagonal restrictions, is therefore not a
-consequence of Proposition~4.13.
+gauge.  The normalized gauges are transported to the representative bond
+spaces and composed with the physical sector isometries in
+\path{TNLean/MPS/MPDO/NormalizedGroupedSectors.lean}.  The resulting maps
+$W_{\alpha,q}$ have mutually orthogonal isometric ranges, satisfy the
+representative intertwining identities, and reconstruct every vertical letter
+exactly.
+
+The representatives are shown to form an algebraic basis of normal tensors
+for the original vertical tensor in
+\path{TNLean/MPS/MPDO/VerticalBNTConstruction.lean}.  At positive chain
+length this follows from the exact reconstruction and cyclicity of trace.  At
+length zero, one retained representative of positive bond dimension supplies
+the dimension identity required by the definition of a basis of normal
+tensors.
+
+Finally, \path{MPOTensor.verticalCF_of_horizontalCF} in
+\path{TNLean/MPS/MPDO/VerticalCanonicalForm.lean} applies the orthogonal sector
+coisometry theorem and identifies the dependent sector pairs $(\alpha,q)$
+with the standard finite direct-sum coordinates.  This gives the literal
+vertical canonical-form identities of Proposition~4.13.  The original
+formulation of \ghissue{2537}, interpreted as a direct conversion of the
+horizontal scalar weights and diagonal restrictions, remains a false route
+rather than a consequence of the proposition.
 
 \paragraph{Verdict.}
-This is an open gap: Figure~8 and the normal-tensor Gram normalization are
-complete for the actual grouped sectors, but the normalized physical maps and
-their final coisometry have not yet been assembled from the
-matrix-product-density-operator hypotheses.
+The source-faithful horizontal-to-vertical implication of Proposition~4.13 is
+complete.  The proof follows the grouped vertical sectors used in the paper;
+it does not use the unsupported diagonal-restriction statement from
+\ghissue{2537}.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
@@ -195,16 +195,21 @@ grouped into pairwise gauge-phase-distinct BNT representatives in
 \path{TNLean/MPS/MPDO/VerticalBNT.lean}. Every copy is expressed by a positive
 coefficient, a unit-modulus phase, and an invertible bond-space gauge, while
 the physical isometries and the literal vertical reconstruction are retained.
-What remains is to transport the unitary gauge normalizations to common
-representative bond spaces, compose them with the physical sector isometries,
-and assemble these normalized physical maps into the final coisometry.  The
-literal vertical canonical-form identity has therefore not yet been derived
-from the MPDO hypotheses.
+The unitary gauge normalizations are transported to the representative bond
+spaces and composed with the physical sector isometries in
+\path{TNLean/MPS/MPDO/NormalizedGroupedSectors.lean}.  The algebraic
+basis-of-normal-tensors property is established in
+\path{TNLean/MPS/MPDO/VerticalBNTConstruction.lean}, using exact
+reconstruction at positive lengths and a retained positive-dimensional
+representative at length zero.  The resulting orthogonal sector maps are
+assembled into the final coisometry in
+\path{TNLean/MPS/MPDO/VerticalCanonicalForm.lean}, which proves the literal
+vertical canonical-form identity from the MPDO hypotheses.
 
 \paragraph{Verdict.}
-This is an open gap: the source-faithful horizontal-to-vertical implication of
-Proposition~4.13 remains unformalized. The diagonal-restriction route is a
-false strengthening and cannot close that gap.
+The source-faithful horizontal-to-vertical implication of Proposition~4.13 is
+complete.  The diagonal-restriction route remains a false strengthening and
+plays no part in the proof.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex
@@ -108,10 +108,11 @@ orientation of \eqref{eq:vertical-form}, together with
 \eqref{eq:reconstruction}. This is the source-faithful statement compatible
 with \eqref{eq:dimension-bound}: the retained part is represented
 rectangularly, while the omitted part is required to be zero. No full-support
-assumption is added to Proposition~4.13. The construction of the canonical
-form from horizontal canonical form remains open and is tracked in
-\ghissue{3674}; the present correction is tracked in \ghissue{3869} and
-concerns only its conclusion.
+assumption is added to Proposition~4.13.  The construction of the canonical
+form from horizontal canonical form is proved by
+\path{MPOTensor.verticalCF_of_horizontalCF} in
+\path{TNLean/MPS/MPDO/VerticalCanonicalForm.lean}.  It uses this corrected
+coisometry condition.  The correction itself is tracked in \ghissue{3869}.
 
 \paragraph{Verdict.}
 The earlier two-sided-unitary condition was a stronger statement absent from

--- a/docs/paper-gaps/cpgsv17_vertical_tensor_definition.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_tensor_definition.tex
@@ -115,9 +115,12 @@ decomposition, not from flattening horizontal weights;
 restriction of horizontal blocks does not preserve normality.  Neither note
 documented the definitional mismatch addressed here: the former predicate
 placed the conclusion of Proposition~4.13 on the wrong tensor.  The
-source-faithful horizontal-to-vertical implication itself remains
-unformalized and is tracked by the blueprint entry for Proposition~4.13 in
-\path{blueprint/src/chapter/ch20_mpdo_canonical_forms.tex}.
+source-faithful horizontal-to-vertical implication is proved by
+\path{MPOTensor.verticalCF_of_horizontalCF} in
+\path{TNLean/MPS/MPDO/VerticalCanonicalForm.lean}; the blueprint entry for
+Proposition~4.13 in
+\path{blueprint/src/chapter/ch20_mpdo_canonical_forms.tex} records the same
+result.
 
 \paragraph{Verdict.}
 This is a corrected definitional mismatch.  The former predicate placed the
@@ -130,8 +133,9 @@ the proposition.  The realignment restores the source-faithful vertical tensor
 definition.  The later correction in
 \path{cpgsv17_vertical_isometry_zero_sector.tex} restores the source's
 one-sided isometry condition in the presence of zero sectors.  The
-horizontal-to-vertical implication of Proposition~4.13 itself remains an
-open gap.
+horizontal-to-vertical implication of Proposition~4.13 is proved in
+\path{TNLean/MPS/MPDO/VerticalCanonicalForm.lean} using this corrected
+definition.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

This brings all surrounding documentation into agreement with the vertical
canonical-form theorem merged in #3920.

- mark the Proposition 4.13 paper-gap accounts complete and point them to
  `VerticalCanonicalForm.lean`;
- correct the rejected diagonal-restriction route from issue #2536 to #2537;
- update the older `VerticalCF.lean` overview, terminal comment, and the
  local contraction docstring in `PerCopyHorizontalCF.lean`;
- add the directly used phase-class definition to the blueprint proof
  dependencies and remove a transitive statement dependency;
- remove two square-root facts left unused after the normalized-sector proof
  was simplified.

The empty-chain dimension calculation remains documented only where it is
proved, in the preceding algebraic BNT construction; the capstone blueprint
proof does not repeat it.

## Validation

- `lake build`
- `lake env lean TNLean/MPS/MPDO/NormalizedGroupedSectors.lean`
- `lake env lean TNLean/MPS/MPDO/VerticalCF.lean`
- `lake env lean TNLean/MPS/MPDO/PerCopyHorizontalCF.lean`
- reader-facing prose check against `origin/main`
- blueprint--Lean synchronization check
- `lake exe checkdecls blueprint/lean_decls`
- `leanblueprint pdf` (551 pages)
- `git diff --check`

No theorem statement, hypothesis, proof, or axiom is changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Commentary, blueprint metadata, and dead proof lines only; no axioms, hypotheses, or theorem statements change.
> 
> **Overview**
> Documentation and comments are brought in line with **`MPOTensor.verticalCF_of_horizontalCF`** (merged in #3920), without changing any theorem statements or proofs beyond a small Lean cleanup.
> 
> **Lean:** In `normalized_gauge_corner`, two unused square-root positivity lemmas are dropped after the normalized-sector proof was simplified.
> 
> **Module docs:** `VerticalCF.lean` and `PerCopyHorizontalCF.lean` no longer describe the horizontal→vertical step as open; they cite `VerticalCanonicalForm.lean`, invariant-projector closure, and the full implication.
> 
> **Blueprint:** Proposition 4.13’s horizontal→vertical theorem is marked `\leanok`; proof dependencies drop the vertical-tensor definition from `\uses` and add `def:mpv_phase_class_data`.
> 
> **Paper-gap notes:** Several `cpgsv17_*.tex` status sections now say Proposition 4.13’s source-faithful implication is **complete** and point at `VerticalCanonicalForm.lean`. The rejected diagonal-restriction route is relabeled from issue **#2536** to **#2537** where appropriate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2bb01523285eee31392e1a0d981ecd897114cb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->