### PR TITLE
feat(MPS/MPDO): derive simultaneous BNT blocking

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -382,6 +382,7 @@ import TNLean.MPS.MPDO.PerCopyHorizontalCF
 import TNLean.MPS.MPDO.FirstSiteBlocking
 import TNLean.MPS.MPDO.RepresentativeGroupedLemmaL
 import TNLean.MPS.MPDO.PostBlockedRepresentativeSpan
+import TNLean.MPS.MPDO.SourceBNTBlocking
 import TNLean.MPS.MPDO.RepresentativeGroupedMarkedLemmaL
 import TNLean.MPS.MPDO.LinearMarkedTensor
 import TNLean.MPS.MPDO.HorizontalCFMPVRepresentation

--- a/TNLean/MPS/MPDO/SourceBNTBlocking.lean
+++ b/TNLean/MPS/MPDO/SourceBNTBlocking.lean
@@ -1,0 +1,245 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.CanonicalForm.NormalTensorGauge
+import TNLean.MPS.MPDO.PostBlockedRepresentativeSpan
+
+/-!
+# Simultaneous blocking of a basis of normal tensors
+
+A basis of normal tensors admits one positive physical blocking for which the
+blocked representatives span their full product matrix algebra in one letter.
+This is the simultaneous block-injectivity statement of arXiv:1606.00608,
+lines 317--345, applied to the basis of normal tensors defined at lines
+271--274.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+private theorem bondDim_pos_of_mpvState_ne_zero {A : MPSTensor d D} {N : ℕ}
+    (hA : mpvState (d := d) A N ≠ 0) :
+    0 < D := by
+  by_contra hD
+  have hD0 : D = 0 := Nat.eq_zero_of_not_pos hD
+  subst D
+  apply hA
+  ext σ
+  simp [mpvState, mpv, coeff, Matrix.trace]
+
+private theorem IsCPSVBasisOfNormalTensors.blocks_dim_pos
+    {g : ℕ} {dim : Fin g → ℕ}
+    {A : MPSTensor d D} {B : (j : Fin g) → MPSTensor d (dim j)}
+    (hBNT : IsCPSVBasisOfNormalTensors A (fun j => ⟨dim j, B j⟩)) :
+    ∀ j, 0 < dim j := by
+  intro j
+  obtain ⟨N₀, hLI⟩ := hBNT.eventually_li
+  have hN : N₀ < N₀ + 1 := by omega
+  have hne : mpvState (d := d) (B j) (N₀ + 1) ≠ 0 :=
+    (hLI (N₀ + 1) hN).ne_zero j
+  exact bondDim_pos_of_mpvState_ne_zero hne
+
+private theorem IsCPSVBasisOfNormalTensors.blocks_not_gaugePhaseEquiv
+    {g : ℕ} {dim : Fin g → ℕ}
+    {A : MPSTensor d D} {B : (j : Fin g) → MPSTensor d (dim j)}
+    (hBNT : IsCPSVBasisOfNormalTensors A (fun j => ⟨dim j, B j⟩)) :
+    BlocksNotGaugePhaseEquiv (d := d) B := by
+  intro j k hjk hdim hGPE
+  obtain ⟨N₀, hLI⟩ := hBNT.eventually_li
+  have hN := hLI (N₀ + 1) (by omega)
+  obtain ⟨X, ζ, _hζ, hConj⟩ := hGPE
+  have hState : ζ ^ (N₀ + 1) • mpvState (d := d) (B j) (N₀ + 1) =
+      mpvState (d := d) (B k) (N₀ + 1) := by
+    apply PiLp.ext
+    intro σ
+    simp only [PiLp.smul_apply, mpvState_apply, smul_eq_mul]
+    rw [mpv_eq_pow_mul_of_gaugePhase
+      (A := cast (congr_arg (MPSTensor d) hdim) (B j))
+      (B := B k) X ζ hConj (N₀ + 1) σ,
+      mpv_cast_dim hdim (B j) (N₀ + 1) σ]
+  have hPair : LinearIndepOn ℂ
+      (fun l : Fin g => mpvState (d := d) (B l) (N₀ + 1)) {j, k} :=
+    hN.linearIndepOn {j, k}
+  have hNot := (linearIndepOn_pair_iff _ hjk (hN.ne_zero j)).mp hPair
+  exact hNot (ζ ^ (N₀ + 1)) hState
+
+/-- A simultaneous length-`L` word span becomes a simultaneous one-letter
+span after blocking `L` physical sites. -/
+private theorem wordTupleSpanTop_blockTensor_one
+    {g : ℕ} {dim : Fin g → ℕ}
+    (B : (j : Fin g) → MPSTensor d (dim j)) {L : ℕ}
+    (hSpan : WordTupleSpanTop B L) :
+    WordTupleSpanTop (fun j => blockTensor (B j) L) 1 := by
+  unfold WordTupleSpanTop at hSpan ⊢
+  have hRange :
+      Set.range (wordTuple (fun j => blockTensor (B j) L) 1) =
+        Set.range (wordTuple B L) := by
+    ext M
+    constructor
+    · rintro ⟨σ, rfl⟩
+      let τ : Fin L → Fin d := fun i =>
+        blockedConfigEquiv d 1 L σ (Fin.cast (Nat.one_mul L).symm i)
+      refine ⟨τ, ?_⟩
+      funext j
+      change evalWord (B j) (List.ofFn τ) =
+        evalWord (blockTensor (B j) L) (List.ofFn σ)
+      rw [evalWord_blockTensor]
+      have hτ : List.ofFn τ = flattenBlockedWord d L (List.ofFn σ) := by
+        calc
+          List.ofFn τ = List.ofFn (blockedConfigEquiv d 1 L σ) := by
+            exact (List.ofFn_congr (Nat.one_mul L)
+              (blockedConfigEquiv d 1 L σ)).symm
+          _ = flattenBlockedWord d L (List.ofFn σ) :=
+            ofFn_blockedConfigEquiv d 1 L σ
+      rw [hτ]
+    · rintro ⟨τ, rfl⟩
+      let τ' : Fin (1 * L) → Fin d := fun i =>
+        τ (Fin.cast (Nat.one_mul L) i)
+      let σ : Fin 1 → Fin (blockPhysDim d L) :=
+        (blockedConfigEquiv d 1 L).symm τ'
+      refine ⟨σ, ?_⟩
+      funext j
+      change evalWord (blockTensor (B j) L) (List.ofFn σ) =
+        evalWord (B j) (List.ofFn τ)
+      rw [evalWord_blockTensor]
+      have hcfg : blockedConfigEquiv d 1 L σ = τ' := by
+        simp [σ]
+      have hlist : List.ofFn τ' = List.ofFn τ := by
+        simp [τ']
+      rw [← ofFn_blockedConfigEquiv d 1 L σ, hcfg, hlist]
+  rw [hRange, hSpan]
+
+private theorem hasBlockSelectorWords_of_family_gaugeEquiv
+    {g : ℕ} {dim : Fin g → ℕ}
+    {A B : (j : Fin g) → MPSTensor d (dim j)} {S : ℕ}
+    (hSel : HasBlockSelectorWords A S)
+    (hGauge : ∀ j, GaugeEquiv (A j) (B j)) :
+    HasBlockSelectorWords B S := by
+  intro k
+  obtain ⟨c, hself, hoff⟩ := hSel k
+  refine ⟨c, ?_, ?_⟩
+  · obtain ⟨X, hX⟩ := hGauge k
+    calc
+      (∑ w, c w • evalWord (B k) (List.ofFn w)) =
+          ∑ w, c w • ((X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ) *
+            evalWord (A k) (List.ofFn w) *
+            ((X⁻¹ : GL (Fin (dim k)) ℂ) : Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) := by
+        apply Finset.sum_congr rfl
+        intro w _
+        rw [evalWord_gauge X hX]
+      _ = (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ) *
+          (∑ w, c w • evalWord (A k) (List.ofFn w)) *
+          ((X⁻¹ : GL (Fin (dim k)) ℂ) : Matrix (Fin (dim k)) (Fin (dim k)) ℂ) := by
+        rw [Matrix.mul_sum, Finset.sum_mul]
+        apply Finset.sum_congr rfl
+        intro w _
+        simp
+      _ = 1 := by
+        rw [hself]
+        simp
+  · intro j hjk
+    obtain ⟨X, hX⟩ := hGauge j
+    calc
+      (∑ w, c w • evalWord (B j) (List.ofFn w)) =
+          ∑ w, c w • ((X : Matrix (Fin (dim j)) (Fin (dim j)) ℂ) *
+            evalWord (A j) (List.ofFn w) *
+            ((X⁻¹ : GL (Fin (dim j)) ℂ) : Matrix (Fin (dim j)) (Fin (dim j)) ℂ)) := by
+        apply Finset.sum_congr rfl
+        intro w _
+        rw [evalWord_gauge X hX]
+      _ = (X : Matrix (Fin (dim j)) (Fin (dim j)) ℂ) *
+          (∑ w, c w • evalWord (A j) (List.ofFn w)) *
+          ((X⁻¹ : GL (Fin (dim j)) ℂ) : Matrix (Fin (dim j)) (Fin (dim j)) ℂ) := by
+        rw [Matrix.mul_sum, Finset.sum_mul]
+        apply Finset.sum_congr rfl
+        intro w _
+        simp
+      _ = 0 := by
+        rw [hoff j hjk]
+        simp
+
+/-- A basis of normal tensors becomes simultaneously injective after one
+common positive blocking.
+
+The BNT hypothesis supplies positive bond dimensions and excludes
+gauge-phase-equivalent duplicate representatives.  Perron gauges put all
+representatives in left-canonical form, after which the block-injectivity
+argument gives simultaneous selectors.  The gauges are then removed and the
+entire selector length is absorbed into one physical blocking.
+
+Source: arXiv:1606.00608, BNT definition at lines 271--274 and block
+injectivity at lines 317--345. -/
+theorem IsCPSVBasisOfNormalTensors.exists_blocked_wordTupleSpanTop_one
+    {g : ℕ} {dim : Fin g → ℕ}
+    {A : MPSTensor d D} {B : (j : Fin g) → MPSTensor d (dim j)}
+    (hBNT : IsCPSVBasisOfNormalTensors A (fun j => ⟨dim j, B j⟩)) :
+    ∃ L : ℕ, 0 < L ∧
+      WordTupleSpanTop (fun j => blockTensor (B j) L) 1 := by
+  classical
+  have hdimPos := hBNT.blocks_dim_pos
+  letI : ∀ j : Fin g, NeZero (dim j) := fun j => ⟨(hdimPos j).ne'⟩
+  choose σ _hσ _hσfix hTP hGauge hPrim hIrr using
+    fun j => (hBNT.blocks_normal j).exists_tpGauge
+  let prepared : (j : Fin g) → MPSTensor d (dim j) :=
+    fun j => tpGauge (B j) (σ j)
+  have hPreparedDistinct : BlocksNotGaugePhaseEquiv (d := d) prepared := by
+    intro j k hjk hdim hGPE
+    apply hBNT.blocks_not_gaugePhaseEquiv j k hjk hdim
+    exact gaugePhaseEquiv_of_gaugeEquiv_left_right_cast hdim
+      (hGauge j) (by simpa [prepared] using hGPE) (hGauge k)
+  have hPreparedNormal : ∀ j, IsNormal (prepared j) := by
+    intro j
+    exact isNormal_of_tp_primitive_irreducible
+      (prepared j) (hTP j) (hPrim j) (hIrr j)
+  obtain ⟨p, hp, hAtP⟩ :=
+    exists_common_isNBlkInjective_of_isNormal_leftCanonical
+      prepared hTP (fun j => (hdimPos j).ne') hPreparedNormal
+  have hAtLeastP : ∀ j n, p ≤ n → IsNBlkInjective (prepared j) n := by
+    intro j n hpn
+    obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_le hpn
+    clear hpn
+    induction k with
+    | zero => simpa using hAtP j
+    | succ k ih =>
+        simpa [Nat.add_assoc] using
+          (isNBlkInjective_succ_of_isNBlkInjective
+            (prepared j) (Nat.add_pos_left hp k) ih)
+  have hPreparedIrr : HasIrreducibleBlocks (d := d) prepared :=
+    HasIrreducibleBlocks.ofForall hIrr
+  have hPreparedLeft : IsLeftCanonicalBlockFamily (d := d) prepared :=
+    IsLeftCanonicalBlockFamily.ofForall hTP
+  have hPreparedOverlap : HasNormalizedSelfOverlap (d := d) prepared :=
+    HasNormalizedSelfOverlap.ofForall fun j =>
+      overlap_tendsto_one_of_peripheralPrimitive_of_irreducible
+        (prepared j) (hIrr j) (hTP j) (hPrim j)
+  have hPair : HasPairBlockSeparatingWords prepared
+      ((p + 1) + ((p + 1) + (p + 1))) :=
+    hasPairBlockSeparatingWords_threeBlock_of_blocksNotGaugePhaseEquiv_c1
+      prepared hPreparedIrr hPreparedLeft hPreparedOverlap hPreparedDistinct
+      hAtP
+      (fun j => hAtLeastP j (p + 1) (by omega))
+      (fun j => hAtLeastP j ((p + 1) + ((p + 1) + (p + 1))) (by omega))
+      hp
+  let selectorLength :=
+    (g - 1) * ((p + 1) + ((p + 1) + (p + 1)))
+  have hPreparedSelectors : HasBlockSelectorWords prepared selectorLength := by
+    simpa [selectorLength] using
+      hasBlockSelectorWords_of_pairBlockSeparatingWords prepared hPair
+  have hSelectors : HasBlockSelectorWords B selectorLength :=
+    hasBlockSelectorWords_of_family_gaugeEquiv hPreparedSelectors
+      (fun j => (hGauge j).symm)
+  have hOriginalAtP : ∀ j, IsNBlkInjective (B j) p := by
+    intro j
+    exact isNBlkInjective_of_gaugeEquiv (hAtP j) (hGauge j).symm
+  have hSpan : WordTupleSpanTop B (p + selectorLength) :=
+    wordTupleSpanTop_of_common_blockInjective_of_blockSelectorWords
+      B hOriginalAtP hSelectors
+  refine ⟨p + selectorLength, Nat.add_pos_left hp selectorLength, ?_⟩
+  exact wordTupleSpanTop_blockTensor_one B hSpan
+
+end MPSTensor

--- a/blueprint/src/chapter/ch08_wielandt.tex
+++ b/blueprint/src/chapter/ch08_wielandt.tex
@@ -1068,6 +1068,26 @@ namely to find $n_0$ such that $S_{n_0}(A) = \MN{D}$
     Lemma~\ref{lem:blocking_transfer}.
 \end{proof}
 
+\begin{theorem}[Common exact block-injectivity length]
+    \label{thm:common_exact_block_injectivity_normal_left_canonical}
+    \lean{MPSTensor.%
+        exists_common_isNBlkInjective_of_isNormal_leftCanonical}
+    \leanok
+    \uses{def:l_blk_injective, def:normal,
+        thm:bounded_injective_blocking_normal_left_canonical}
+    Let $(A_j)_{j=1}^g$ be a finite family of positive-bond-dimension,
+    left-canonical normal tensors. There is a positive integer $L$ such that
+    every $A_j$ is $L$-block injective.
+\end{theorem}
+
+\begin{proof}\leanok
+    Apply
+    Theorem~\ref{thm:bounded_injective_blocking_normal_left_canonical} to each
+    block. The product of the finitely many positive lengths is a common
+    positive multiple, and exact block injectivity persists under positive
+    multiples.
+\end{proof}
+
 \begin{corollary}[Uniform injective blocking for separated normal-canonical families]%
     \label{cor:uniform_injective_blocking_normal_bnt}
     \lean{MPSTensor.IsNormalCanonicalFormBNT.exists_common_blockTensor_isInjective,
@@ -1349,6 +1369,27 @@ used to produce rank-one elements.
     The claim follows from the self-overlap convergence under a
     complementary transfer-map gap
     (Theorem~\ref{thm:primitive_overlap}).
+\end{proof}
+
+\begin{theorem}[Peripheral primitivity and irreducibility give normalized overlap]
+    \label{thm:peripheral_primitive_irreducible_overlap_one}
+    \lean{MPSTensor.%
+        overlap_tendsto_one_of_peripheralPrimitive_of_irreducible}
+    \leanok
+    \uses{def:primitive_channel, def:irreducible_tensor, def:mpv_overlap}
+    Let $A$ have positive bond dimension and satisfy
+    \[
+        \sum_i (A^i)^\dagger A^i=I.
+    \]
+    If $A$ is tensor-irreducible and the transfer map is primitive, then
+    $O_{AA}(N)\to1$.
+\end{theorem}
+
+\begin{proof}\leanok\uses{thm:prim_overlap_one}
+    Irreducible Perron--Frobenius theory supplies a nonzero positive fixed
+    point. Peripheral primitivity gives a strict spectral-radius bound on the
+    complementary transfer map. Thus $A$ is a primitive MPS tensor, and
+    Theorem~\ref{thm:prim_overlap_one} applies.
 \end{proof}
 
 \section{Primitivity and normality}

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -203,6 +203,56 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
     gives the conclusion for the original tensors.
 \end{proof}
 
+\begin{theorem}[Simultaneous one-letter span after blocking a BNT]
+    \label{thm:cpsv_bnt_blocked_simultaneous_span}
+    \lean{MPSTensor.IsCPSVBasisOfNormalTensors.%
+        exists_blocked_wordTupleSpanTop_one}
+    \leanok
+    \uses{def:bnt_cpsv, def:blocked_tensor,
+        def:blockwise_product_word_span}
+    Let $(A_j)_{j=1}^g$ be a basis of normal tensors, with bond dimensions
+    $D_j$. There is a positive integer $L$ such that the one-letter
+    evaluations of the blocked tensors span the full product algebra:
+    \[
+        \spn_{\C}\left\{
+            \bigl((A_1^{[L]})^i,\ldots,(A_g^{[L]})^i\bigr)
+            : 0\leq i<d^L
+        \right\}
+        = \prod_{j=1}^g \MN{D_j}.
+    \]
+    This is the existence form of simultaneous block injectivity associated
+    with \cite[lines~317--345]{Cirac2016MPDO_arXiv}; no numerical bound on
+    $L$ is asserted here.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:cpsv_normal_tp_gauge,
+        thm:normal_tp_primitive_irred,
+        thm:common_exact_block_injectivity_normal_left_canonical,
+        thm:wordspan_blk_inj_succ,
+        thm:peripheral_primitive_irreducible_overlap_one,
+        lem:bnt_direct_sum_block_separation_word_span,
+        lem:block_separating_equations_from_pairwise_separation,
+        lem:product_word_span_from_bnt_block_separation,
+        lem:gauge_invariance_block_injective}
+    Eventual linear independence implies $D_j>0$ for every $j$ and excludes
+    gauge-phase equivalence between two distinct blocks. Put every block in a
+    trace-preserving gauge. Normality gives a common positive length $p$ at
+    which every gauged block is $p$-block injective; this injectivity persists
+    at all larger lengths. Pairwise direct-sum separation at lengths $p$,
+    $p+1$, and $3(p+1)$ gives, for each ordered pair of distinct blocks, a
+    length-$3(p+1)$ polynomial equal to the identity on the first block and
+    zero on the second. Multiplying the $g-1$ pairwise polynomials gives a
+    selector for each block. Combining these selectors with the common
+    length-$p$ word spans yields the full product-algebra span at
+    \[
+        L=p+(g-1)3(p+1).
+    \]
+    Conjugation by the Perron gauges preserves this span. Finally, a one-letter
+    evaluation of $A_j^{[L]}$ is precisely a length-$L$ word evaluation of
+    $A_j$.
+\end{proof}
+
 \begin{figure}[ht]
     \centering
     \TNBNTDecomposition

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -630,10 +630,28 @@ under the explicit assumption $0<D_\varepsilon$.  The dimensional
 qualification is necessary because injectivity is vacuous when
 $D_\varepsilon=0$.  Thus the fixed-final invertibility obstruction has been
 removed under the simultaneous-selector, present-blocking injectivity, and
-positive-bond-dimension hypotheses.  The remaining steps are to derive those
-hypotheses from the source assumptions, identify the orientation convention
-with the printed $F$-matrix, and prove the pentagon-like equation mentioned at
-lines~995--999.
+positive-bond-dimension hypotheses.
+
+For an arbitrary coefficient-form BNT, the positive dimensions, a common
+positive blocking length, and the simultaneous one-letter span of the blocked
+representatives are now derived by
+\leanid{MPSTensor.IsCPSVBasisOfNormalTensors.%
+exists_blocked_wordTupleSpanTop_one}.  In particular, that theorem supplies
+a span containing every tuple that is the identity on one labelled block and
+zero on the others.  One-letter injectivity and selector coefficients can
+therefore be extracted after the same common blocking, without adding either
+property to the definition of a BNT.
+
+For the positive-diagonal fusion family, the remaining construction begins by
+linking its final-label tensors to the BNT witness that is already part of the
+source assumptions.  The simultaneous inverse must then be extracted from the
+blocked span and reindexed in the fusion coordinates.  After transporting the
+fusion equations through the same blocking, one must prove
+$U_{\alpha,\beta}U_{\alpha,\beta}^{\dagger}=I$, assemble the synthesis and
+analysis maps with their biorthogonality, prove both zipper equations and
+\texttt{inversegaugeone}, and construct
+\leanid{MPOTensor.CompleteZipperFusionFamily}.  The existing printed
+$F$-matrix and pentagon theorem can then be applied to this family.
 
 Independently of this positive-diagonal specialization, the source-faithful
 complete zipper fusion structure is now formalized by


### PR DESCRIPTION
## Summary

- Proves MPSTensor.IsCPSVBasisOfNormalTensors.exists_blocked_wordTupleSpanTop_one.
- Derives positive bond dimensions and pairwise gauge-phase separation from eventual linear independence.
- Places the normal representatives in Perron gauges, chooses one common positive injective length, derives simultaneous selectors, removes the gauges, and absorbs the selector suffix into the physical blocking.
- Records the exact unbounded existence statement in Chapters 8 and 10 and updates the blocked-chi gap note with the remaining complete-zipper construction.

## Source faithfulness

The only mathematical hypothesis is the coefficient-form basis of normal tensors from arXiv:1606.00608, lines 271--274. Injectivity, separation, selector coefficients, and the common blocking are conclusions. The blueprint states only existence and does not claim the sharper numerical bound in lines 340--345.

No sorry, new axiom, or kernel bypass is introduced. The theorem depends only on propext, Classical.choice, and Quot.sound.

## Validation

- lake build: 9399 jobs
- focused Lean check for SourceBNTBlocking.lean
- blueprint and Lean synchronization
- reader-facing prose check
- declaration check against blueprint/lean_decls
- leanblueprint pdf: 552 pages
- three independent mathematical and documentation reviews approved the final change

Closes #3923.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new formal proof on a critical MPS/BNT path; errors could misstate downstream fusion assumptions, but changes are pure Mathlib-style proofs with no runtime or security surface.
> 
> **Overview**
> Adds **`TNLean/MPS/MPDO/SourceBNTBlocking.lean`** and wires it into the root import list, proving **`IsCPSVBasisOfNormalTensors.exists_blocked_wordTupleSpanTop_one`**: from the coefficient-form BNT hypothesis alone, there is a **common positive physical blocking** after which every blocked representative has **one-letter** word evaluations spanning the full **product matrix algebra**.
> 
> The proof **derives** positive bond dimensions and **no duplicate gauge-phase blocks** from eventual linear independence, puts blocks in **Perron/TP gauges**, applies **common block injectivity** and **pairwise separating polynomials** to build **simultaneous block selectors**, then **undoes gauges** and folds selector length into blocking via **`wordTupleSpanTop_blockTensor_one`**.
> 
> Blueprint **Ch. 8** records **`exists_common_isNBlkInjective_of_isNormal_leftCanonical`** and **`overlap_tendsto_one_of_peripheralPrimitive_of_irreducible`**; **Ch. 10** states the simultaneous blocked span theorem (existence only, no sharp bound). The **blocked-χ gap** note is updated to treat BNT-derived span/selectors as available and to list remaining **complete-zipper fusion** steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4253428f9f2d0ad15eb5ff5be5f22df60265f772. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->