### PR TITLE
doc(MPS/MPDO): add localized Kraus channel blueprint entry

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
@@ -116,6 +116,38 @@
     \]
 \end{proof}
 
+\begin{theorem}[Tensor extension preserves trace-preserving complete positivity]
+    \label{thm:mpdo_tensor_map_id_cptp}
+    \lean{Matrix.tensorMapIdLM_isKrausCPTP}
+    \leanok
+    \uses{def:tensor_map_id, def:is_kraus_cptp}
+    Let $\mathcal S:\operatorname{End}_{\C}(H)\to
+        \operatorname{End}_{\C}(K)$ be trace-preserving and completely positive,
+    and let $R$ be another finite-dimensional space. Then
+    \[
+        \mathcal S\otimes\id_R:
+        \operatorname{End}_{\C}(H\otimes R)\longrightarrow
+        \operatorname{End}_{\C}(K\otimes R)
+    \]
+    is trace-preserving and completely positive. If $(A_a)_a$ is a Kraus
+    family for $\mathcal S$, then
+    $(A_a\otimes I_R)_a$ is a Kraus family for its tensor extension.
+\end{theorem}
+\begin{proof}
+    \leanok
+    The tensor extension has the Kraus form
+    \[
+        (\mathcal S\otimes\id_R)(X)
+        =\sum_a (A_a\otimes I_R)X(A_a\otimes I_R)^\dagger.
+    \]
+    Its normalization follows from that of the original family:
+    \[
+        \sum_a (A_a\otimes I_R)^\dagger(A_a\otimes I_R)
+        =\left(\sum_a A_a^\dagger A_a\right)\otimes I_R
+        =I_H\otimes I_R.
+    \]
+\end{proof}
+
 \begin{definition}[Rectangular Kraus map]
     \label{def:mpdo_rectangular_kraus_map}
     \lean{Matrix.rectangularKrausMap}


### PR DESCRIPTION
### Motivation

`Matrix.tensorMapIdLM_isKrausCPTP` is already proved, but its tensor-extension result was absent from the blueprint. This is the elementary channel operation that lets a local Kraus map act on one tensor factor while leaving the neighbouring factor unchanged in the constructions surrounding [CPGSV16, Appendix C.2, Proposition C.7].

### Description

- Add a reader-facing theorem for the tensor extension of a trace-preserving completely positive map.
- State the rectangular domain and codomain explicitly as
  `End(H ⊗ R) → End(K ⊗ R)`.
- Record the Kraus family `(A_a ⊗ I_R)_a` and its normalization equation.
- Link the exact Lean declaration and its two direct definitional dependencies.

The paper context is `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 1510–1565 (Proposition C.7 and its local channels) and lines 1821–1825 (the corresponding tensor extensions).

### Testing

- `lake build` (9,399 jobs)
- `lake exe checkdecls blueprint/lean_decls`
- `cd blueprint && leanblueprint checkdecls`
- `cd blueprint && leanblueprint pdf` (553 pages)
- Visual inspection of the rendered theorem on printed page 448
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex`
- `git diff --check`

The repository-wide `blueprint_lean_sync.py --ci` scan recognizes the new declaration and reports chapter 21 as 40/40. It also reports one unrelated reference already present on `main`, `MPSTensor.gaugePhaseEquiv_of_MPVBlockPhaseEquiv_of_tp_primitive_irr`, as absent from `blueprint/lean_decls`.

---

Closes #3927

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX in the blueprint; no Lean or runtime code changes.
> 
> **Overview**
> Adds a **blueprint theorem** in chapter 21 documenting that tensoring a trace-preserving completely positive map with the identity on a finite factor (`\mathcal S\otimes\id_R`) remains CPTP, with Kraus operators `(A_a\otimes I_R)_a` and the corresponding normalization identity.
> 
> The entry is wired to the existing Lean proof `Matrix.tensorMapIdLM_isKrausCPTP` and cites `def:tensor_map_id` and `def:is_kraus_cptp`, filling a gap needed for MPDO Proposition C.7–style local channel constructions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 777c5e8adcb0691e4fa4d7ceac27e5491539fc7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->