### PR TITLE
fix(blueprint): correct tensor-network contraction semantics

### DIFF
--- a/blueprint/src/macros/tn_core.tex
+++ b/blueprint/src/macros/tn_core.tex
@@ -218,6 +218,18 @@
     -- ($(#1.center)+(0.42,-0.52)$) -| (#1.south);%
 }
 
+% Close two right virtual legs by an ordinary trace contraction.
+\newcommand{\TN@vtraceright}[3]{%
+    \draw[tn virtual closure] (#1.east) -- ++(#3,0) |- (#2.east);%
+}
+
+% Close the virtual bond through an insertion below an open tensor row.
+\newcommand{\TN@vtracevia}[5]{%
+    \draw[tn virtual closure] (#1.west) -- ++(-#4,0) |- (#2.west);%
+    \draw[tn virtual closure] (#2.east) -| ($(#3.east)+(#5,0)$)
+        -- (#3.east);%
+}
+
 \newcommand{\TN@boxedThreeSiteChain}[4]{%
     \draw[tn virtual closure] (0.40,0) rectangle (3.50,-0.46);
     \TN@tensordot{#1one}{(1.00,0)}

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -133,8 +133,8 @@
         \TN@upleg{tnA}{0.48}
         \TN@downleg{tnAc}{0.48}
         \draw[tn purification contraction]
-            (tnA.south east) .. controls (0.88,0.42) and (0.88,-0.42) ..
-            (tnAc.north east);
+            (tnA.-35) .. controls (0.88,0.42) and (0.88,-0.42) ..
+            (tnAc.35);
         \node at (-0.28,0.82) {$A$};
         \node at (-0.32,-0.82) {$\overline A$};
         \node at (0.95,0) {$k$};
@@ -1924,8 +1924,7 @@
 \newcommand{\TNAppendixBChainTransport}{%
     \begin{tikzpicture}[tn picture, scale=0.92]
         \foreach \a/\name in {150/ctA,90/ctX,30/ctB,-30/ctC,-90/ctD,-150/ctE} {
-            \node[tn tensor dot] (\name)
-                at ({1.34*cos(\a)},{1.02*sin(\a)}) {};
+            \TN@tensordot{\name}{({1.34*cos(\a)},{1.02*sin(\a)})}
         }
         \draw[tn leg] (ctA) -- (ctX) -- (ctB) -- (ctC) -- (ctD) -- (ctE) -- (ctA);
         \draw[red, line width=2.2pt] (ctA) -- (ctX);
@@ -1936,7 +1935,7 @@
         \draw[->, line width=0.7pt] (1.85,0) -- (2.75,0)
             node[midway, above] {$R_{i,\tau}^{(3)}$};
         \foreach \x/\name/\lab in {3.35/ctLA/A,4.55/ctLX/X,5.75/ctLB/B} {
-            \node[tn tensor dot] (\name) at (\x,0) {};
+            \TN@tensordot{\name}{(\x,0)}
             \node at (\x,0.38) {$\lab$};
         }
         \draw[tn leg] (ctLA) -- (ctLX) -- (ctLB);
@@ -2607,8 +2606,7 @@
         \draw[tn leg] (tnD2.east) -- ++(0.62,0);
         \draw[tn leg] ($(tnU3.west)+(-0.62,0)$) -- (tnU3.west);
         \draw[tn leg] ($(tnD3.west)+(-0.62,0)$) -- (tnD3.west);
-        \draw[tn leg] (tnU3.east) -- ++(0.70,0);
-        \draw[tn leg] (tnD3.east) -- ++(0.70,0);
+        \TN@vtraceright{tnU3}{tnD3}{0.70}
         \draw[tn phys leg] (tnU1.south) -- (tnuA.north);
         \draw[tn phys leg] (tnuA.south) -- (tnD1.north);
         \draw[tn phys leg] (tnU2.south) -- (tnuB.north);
@@ -2744,8 +2742,7 @@
         \draw[tn leg] (-0.45,0) -- (3.40,0);
         \node at (2.05,0) {$\cdots$};
         \TN@opdotbelow{tnX}{(1.48,-0.82)}{#5}
-        \draw[tn virtual closure] (-0.45,0) -- (-0.45,-0.82) -- (tnX.west);
-        \draw[tn virtual closure] (tnX.east) -- (3.40,-0.82) -- (3.40,0);
+        \TN@vtracevia{tnL}{tnX}{tnR}{0.45}{0.45}
     \end{tikzpicture}%
 }
 
@@ -3646,7 +3643,8 @@
     \begin{tikzpicture}[tn picture]
         \node[tn tensor box] (tpRho) at (-1.55,0) {$\rho$};
         \node[tn tensor box] (tpSigJ) at (-0.48,0) {$\sigma_j$};
-        \node[tn tensor box] (tpT) at (0.82,0) {$t_{ij}$};
+        \TN@tensordot{tpT}{(0.82,0)}
+        \node[anchor=north] at ($(tpT.south)+(0,-0.10)$) {$t_{ij}$};
         \node[tn tensor box] (tpSigI) at (2.12,0) {$\sigma_i$};
         \draw[tn leg] (tpRho.north east) -- (tpSigJ.north west);
         \draw[tn leg] (tpRho.south east) -- (tpSigJ.south west);

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -2721,11 +2721,10 @@
         \TN@tensordot{pA}{(0,0)}
         \TN@tensordot{pB}{(1.10,0)}
         \TN@opdotbelow{pZ}{(0.55,-0.72)}{#2}
-        \draw[tn leg] (-0.45,0) -- (1.55,0);
+        \draw[tn leg] ($(pA.west)+(-0.45,0)$) -- ($(pB.east)+(0.45,0)$);
         \TN@upleg{pA}{0.38}
         \TN@upleg{pB}{0.38}
-        \draw[tn virtual closure] (-0.45,0) -- (-0.45,-0.72) -- (pZ.west);
-        \draw[tn virtual closure] (pZ.east) -- (1.55,-0.72) -- (1.55,0);
+        \TN@vtracevia{pA}{pZ}{pB}{0.45}{0.45}
     \end{tikzpicture}%
 }
 
@@ -2739,7 +2738,7 @@
         \TN@upleg{tnR}{\TN@physleglen}
         \TN@uplabel{tnL}{\TN@physlabeloff}{#2}
         \TN@uplabel{tnR}{\TN@physlabeloff}{#3}
-        \draw[tn leg] (-0.45,0) -- (3.40,0);
+        \draw[tn leg] ($(tnL.west)+(-0.45,0)$) -- ($(tnR.east)+(0.45,0)$);
         \node at (2.05,0) {$\cdots$};
         \TN@opdotbelow{tnX}{(1.48,-0.82)}{#5}
         \TN@vtracevia{tnL}{tnX}{tnR}{0.45}{0.45}


### PR DESCRIPTION
## Summary

This pull request makes five focused corrections to the printed tensor-network diagrams.

- The local-purification ancillary contraction now has dedicated attachment points, distinct from the open virtual legs.
- The string-order right boundary is a thin solid rounded virtual trace rather than two open legs.
- The ground-space periodic closure uses the same virtual-trace primitive while passing through the boundary insertion.
- The Appendix B chain uses the common black tensor-site primitive throughout.
- The scalar coefficient in the transfer trace-pairing diagram is a rank-zero black tensor with an external label.

Ordinary one-dimensional periodic contractions remain thin solid trace closures. Dashed arrows remain reserved for explicit periodic identification of PEPS boundaries; these two meanings are intentionally not merged.

## Validation

- git diff --check
- fresh leanblueprint pdf build: 552 pages
- visual inspection of the string-order, ground-space, Appendix B transport, trace-pairing, and local-purification pages

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> LaTeX/TikZ macro and diagram-only changes in the blueprint; no application logic, auth, or data paths. Risk is limited to PDF figure appearance and build compatibility.
> 
> **Overview**
> Corrects how several blueprint tensor-network figures depict **contractions** versus **open legs**, and factors repeated virtual-trace drawing into shared helpers.
> 
> **New primitives** in `tn_core.tex`: `\TN@vtraceright` closes two right virtual legs with a solid rounded virtual trace; `\TN@vtracevia` closes a row’s virtual bond through a lower insertion (used for periodic / ground-space closures).
> 
> **Diagram fixes** in `tn_print.tex`:
> - **Local MPO purification** (`\TNMPOLocalPurification`): ancillary ket–bra curve uses anchor points `.-35` / `.35` instead of corners, so the purification link is not drawn through open virtual legs.
> - **String order** (`\TNStringOrderParameter`): right boundary uses `\TN@vtraceright` instead of two separate open horizontal legs.
> - **Periodic gauge / ground-space map**: horizontal bonds anchor on tensor nodes; periodic virtual closure uses `\TN@vtracevia` through the boundary operator.
> - **Appendix B chain transport**: ring and AXB panel sites use `\TN@tensordot` for consistent black tensor glyphs.
> - **Trace-pairing transfer** (`\TNTransferMapTracePairing`): scalar `t_{ij}` is a rank-0 tensor dot with an external label, not a labeled box tensor.
> 
> Solid virtual closures remain distinct from dashed PEPS periodic identification; behavior is TikZ-only with no runtime logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c01cd3d57d2f89d0391119b364aa445f6738f08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->