### PR TITLE
style(blueprint): unify tensor-network diagram language

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -10,6 +10,7 @@ on:
       - 'lean-toolchain'
       - 'lake-manifest.json'
       - 'blueprint/src/**'
+      - 'docs/slides/**'
       - '.github/workflows/blueprint.yml'
       - 'home_page/**'
       - 'scripts/blueprint_bibtex.py'
@@ -44,6 +45,9 @@ jobs:
           PYTHONPATH=Packages python3 Packages/tn_diagrams.py \
             --check \
             --check-peps-usage \
+            --check-slides \
+            --audit \
+            --audit-strict \
             --smoke-render
 
       - name: Write status badges

--- a/.github/workflows/lint-blueprint.yml
+++ b/.github/workflows/lint-blueprint.yml
@@ -11,6 +11,7 @@ on:
       - 'lake-manifest.json'
       - '.github/workflows/lint-blueprint.yml'
       - 'blueprint/src/**'
+      - 'docs/slides/**'
       - 'blueprint/.chktexrc'
       - 'blueprint/latexindent.yaml'
       - 'scripts/blueprint_bibtex.py'
@@ -25,6 +26,7 @@ on:
       - 'lake-manifest.json'
       - '.github/workflows/lint-blueprint.yml'
       - 'blueprint/src/**'
+      - 'docs/slides/**'
       - 'blueprint/.chktexrc'
       - 'blueprint/latexindent.yaml'
       - 'scripts/blueprint_bibtex.py'
@@ -100,6 +102,9 @@ jobs:
           PYTHONPATH=Packages python3 Packages/tn_diagrams.py \
             --check \
             --check-peps-usage \
+            --check-slides \
+            --audit \
+            --audit-strict \
             --smoke-render
 
       - name: Lint LaTeX (chktex)

--- a/blueprint/src/Packages/tn_diagrams.py
+++ b/blueprint/src/Packages/tn_diagrams.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import json
 import logging
 import os
 import posixpath
@@ -33,9 +34,79 @@ _SVG_SUBDIR = "tn_svg"
 _RENDER_SOURCE_FILES = (
     _SRC_DIR / "macros/common.tex",
     _SRC_DIR / "macros/tn_core.tex",
+    _SRC_DIR / "macros/tn_library.tex",
     _SRC_DIR / "macros/tn_print.tex",
 )
 _TEMPLATE_FILE = _SRC_DIR / "plastex_templates/TensorNetworkDiagrams.jinja2s"
+_SLIDE_DIR = _SRC_DIR.parents[1] / "docs/slides"
+_SLIDE_LIBRARY = _SLIDE_DIR / "tn_library_dark.tex"
+
+_EXPECTED_SLIDE_DIAGRAM_CALLS = {
+    "SlideTNPeriodicMPS": 7,
+    "SlideTNGaugeConjugation": 2,
+    "SlideTNBlockingIdentity": 1,
+    "SlideTNBlockingComparison": 1,
+    "SlideTNMixedTransfer": 1,
+    "SlideTNTransferMap": 1,
+}
+
+_PUBLIC_MACRO_PATTERN = re.compile(
+    r"^\\newcommand\{\\(TN(?!@)\w+)\}(?:\[(\d+)\])?", re.MULTILINE
+)
+_LITERAL_COORDINATE_PATTERN = re.compile(
+    r"(?<![A-Za-z])\((-?\d+(?:\.\d+)?(?:cm)?),"
+    r"(-?\d+(?:\.\d+)?(?:cm)?)\)"
+)
+_RAW_GLYPH_PATTERNS = {
+    "filled circles": re.compile(r"\\fill(?:\[[^\]]*\])?[^;\n]*\bcircle\b"),
+    "circle nodes": re.compile(
+        r"\\node\[[^\]]*(?<![A-Za-z])circle(?:\s|,|\])"
+    ),
+    "styled glyph nodes": re.compile(
+        r"\\node\[[^\]]*(?<![A-Za-z])tn (?:tensor node|insertion node|"
+        r"component node|factor node|"
+        r"map node|tensor dot|operator dot|tensor box|map box)\b"
+    ),
+    "legacy glyph commands": re.compile(
+        r"\\TN@(?:tensordot|opdot(?:above|below|left|right)?|subspinbox)\b"
+    ),
+}
+_RAW_WIRE_PATTERN = re.compile(
+    r"\\draw\s*\[[^\]]*(?<![A-Za-z])tn(?:\s|/)[^\]]*\]"
+)
+_LEGACY_WIRE_COMMAND_PATTERN = re.compile(
+    r"\\TN@(?:leftleg|rightleg|upleg|downleg|subspinlink)\b"
+)
+_SEMANTIC_GLYPH_COMMANDS = frozenset(
+    {
+        "TN@component",
+        "TN@factor",
+        "TN@insertion",
+        "TN@junction",
+        "TN@map",
+        "TN@mposite",
+        "TN@mpssite",
+        "TN@pepssite",
+        "TN@pepsvertex",
+        "TN@scalar",
+        "TN@state",
+        "TN@subspinbox",
+        "TN@tensor",
+        "TN@threeLegTensorFan",
+    }
+)
+_GENERAL_WIRE_COMMANDS = frozenset(
+    {"TN@ppath", "TN@ptracepath", "TN@vpath", "TN@vtracepath"}
+)
+_POINT_CONNECTOR_COMMANDS = frozenset(
+    {"TN@connectpoints", "TN@pconnectpoints", "TN@vconnectpoints"}
+)
+_TRACE_PATH_COMMANDS = frozenset({"TN@ptracepath", "TN@vtracepath"})
+_OFFSET_ANCHOR_POINT_PATTERN = re.compile(
+    r"\(\$\(\s*(?P<reference>[#A-Za-z\\][#A-Za-z0-9@_\\-]*\."
+    r"(?:north|south|east|west)(?:\s+(?:east|west))?)\s*\)\s*[+-][^$]*\$\)"
+)
+_SIMPLE_NODE_NAME_PATTERN = re.compile(r"[#A-Za-z\\][#A-Za-z0-9@_\\-]*\Z")
 
 
 _DIAGRAM_ARGS: dict[str, str] = {
@@ -114,12 +185,10 @@ _DIAGRAM_ARGS: dict[str, str] = {
     "TNCondCOne": "twist virtual label",
     "TNCondCTwo": "virtual",
     "TNStringOrderParameter": "twist length",
-    "TNVirtualInsertion": "left middle right virtual",
     "TNInternalTraceInsertion": "left right virtual",
     "TNExternalTraceInsertion": "left right virtual",
     "TNBoundaryRegrow": "virtual left right length",
     "TNLocalEqualityStep": "left_virtual right_virtual physical",
-    "TNPeriodicGauge": "left virtual right",
     "TNGroundSpaceMap": "tensor left right length virtual",
     "TNPEPSEdgeBlockingReduction": "",
     "TNPEPSEdgeInsertedCoeff": "",
@@ -187,11 +256,7 @@ def _sample_arg_value(name: str) -> str:
         "left_virtual": "X",
         "right_virtual": "Y",
         "rendered": "\\TNPEPSNormalRegionT",
-        "body": (
-            "\\begin{tikzpicture}[tn picture]"
-            "\\node[tn tensor dot] at (0,0) {};"
-            "\\end{tikzpicture}"
-        ),
+        "body": "\\TNMPSLocal{A}{i}",
     }
     return values.get(name, "x")
 
@@ -242,6 +307,571 @@ def _assert_diagram_templates_cover_registered_macros() -> None:
             "Tensor-network diagram HTML templates are out of sync with "
             f"registered macros (missing={missing}, stale={stale})."
         )
+
+
+def _source_line(path: Path, offset: int) -> str:
+    """Return a stable ``path:line`` description for a source offset."""
+
+    text = path.read_text(encoding="utf-8")
+    try:
+        relative = path.relative_to(_SRC_DIR)
+    except ValueError:
+        relative = path
+    return f"{relative}:{text.count(chr(10), 0, offset) + 1}"
+
+
+def _pattern_locations(path: Path, pattern: re.Pattern[str]) -> list[str]:
+    text = path.read_text(encoding="utf-8")
+    return [_source_line(path, match.start()) for match in pattern.finditer(text)]
+
+
+def _assert_no_chapter_local_tikz() -> None:
+    """Require chapter sources to use the public tensor-network vocabulary."""
+
+    forbidden = re.compile(
+        r"^[ \t]*(?:\\begin\{tikzpicture\}|\\tikzset\b|\\tikzstyle\b)",
+        re.MULTILINE,
+    )
+    violations = [
+        location
+        for path in sorted((_SRC_DIR / "chapter").glob("*.tex"))
+        for location in _pattern_locations(path, forbidden)
+    ]
+    if violations:
+        raise RuntimeError(
+            "Chapter-local tensor-network TikZ is forbidden; define a public "
+            "mathematical diagram command instead: " + ", ".join(violations)
+        )
+
+
+def _assert_slide_diagram_contract() -> None:
+    """Check the independent dark-theme tensor-network slide vocabulary."""
+
+    if not _SLIDE_LIBRARY.exists():
+        raise RuntimeError(f"Missing slide tensor-network library: {_SLIDE_LIBRARY}")
+
+    preamble = (_SLIDE_DIR / "preamble.tex").read_text(encoding="utf-8")
+    if r"\input{tn_library_dark}" not in preamble:
+        raise RuntimeError("The slide preamble must load tn_library_dark.tex.")
+
+    decks = sorted(_SLIDE_DIR.glob("presentation*.tex"))
+    deck_source = "\n".join(path.read_text(encoding="utf-8") for path in decks)
+    calls = re.findall(r"\\(SlideTN[A-Z]\w*)\b", deck_source)
+    counts = {name: calls.count(name) for name in sorted(set(calls))}
+    if counts != _EXPECTED_SLIDE_DIAGRAM_CALLS:
+        raise RuntimeError(
+            "Slide tensor-network diagram calls differ from the audited collection "
+            f"(actual={counts}, expected={_EXPECTED_SLIDE_DIAGRAM_CALLS})."
+        )
+
+    legacy_style = re.compile(
+        r"(?:^|[,{ ])(?:tn|bond|phys)/\.style|"
+        r"\\(?:node|draw)\[(?:tn|bond|phys)(?:,|\])",
+        re.MULTILINE,
+    )
+    violations = [
+        location
+        for path in decks
+        for location in _pattern_locations(path, legacy_style)
+    ]
+    if violations:
+        raise RuntimeError(
+            "Slide tensor networks must use the SlideTN vocabulary, not local "
+            "tn/bond/phys styles: " + ", ".join(violations)
+        )
+
+    library_source = _SLIDE_LIBRARY.read_text(encoding="utf-8")
+    dashed_contraction = re.compile(
+        r"\\draw\[(?:[^\]]*,)?slidetn/(?:virtual wire|physical wire|trace)"
+        r"[^\]]*(?:dashed|densely dashed)"
+    )
+    if dashed_contraction.search(library_source):
+        raise RuntimeError(
+            "A slide contraction or trace is dashed; dashed strokes are reserved "
+            "for grouping regions."
+        )
+
+    macro_pattern = re.compile(
+        r"^\\newcommand\{\\(SlideTN[A-Z]\w*)\}\[(\d+)\]", re.MULTILINE
+    )
+    matches = list(macro_pattern.finditer(library_source))
+    ignored: dict[str, list[int]] = {}
+    for index, match in enumerate(matches):
+        body_end = matches[index + 1].start() if index + 1 < len(matches) else len(
+            library_source
+        )
+        body = library_source[match.end() : body_end]
+        arity = int(match.group(2))
+        missing = [argument for argument in range(1, arity + 1) if f"#{argument}" not in body]
+        if missing:
+            ignored[match.group(1)] = missing
+    if ignored:
+        raise RuntimeError(f"Slide tensor-network macros ignore arguments: {ignored}")
+
+
+def _noncore_tikz_style_locations() -> list[str]:
+    """Locate style declarations that still need migration to ``tn_core.tex``."""
+
+    core_path = (_SRC_DIR / "macros/tn_core.tex").resolve()
+    forbidden = re.compile(r"^[ \t]*(?:\\tikzset\b|\\tikzstyle\b)", re.MULTILINE)
+    return [
+        location
+        for path in sorted(_SRC_DIR.rglob("*.tex"))
+        if path.resolve() != core_path
+        for location in _pattern_locations(path, forbidden)
+    ]
+
+
+def _public_macro_bodies(source: str) -> list[tuple[str, int, str]]:
+    matches = list(_PUBLIC_MACRO_PATTERN.finditer(source))
+    return [
+        (
+            match.group(1),
+            int(match.group(2) or 0),
+            source[match.end() : matches[index + 1].start()]
+            if index + 1 < len(matches)
+            else source[match.end() :],
+        )
+        for index, match in enumerate(matches)
+    ]
+
+
+def _skip_tex_space(source: str, offset: int) -> int:
+    """Skip TeX whitespace and comments beginning at ``offset``."""
+
+    while offset < len(source):
+        if source[offset].isspace():
+            offset += 1
+            continue
+        if source[offset] == "%":
+            newline = source.find("\n", offset)
+            return len(source) if newline < 0 else _skip_tex_space(source, newline + 1)
+        return offset
+    return offset
+
+
+def _tex_group(source: str, offset: int, opener: str, closer: str) -> tuple[str, int]:
+    """Read one balanced TeX group and return its contents and final offset."""
+
+    if offset >= len(source) or source[offset] != opener:
+        raise ValueError(f"expected {opener!r} at source offset {offset}")
+    depth = 0
+    for index in range(offset, len(source)):
+        escaped = index > 0 and source[index - 1] == "\\"
+        if source[index] == opener and not escaped:
+            depth += 1
+        elif source[index] == closer and not escaped:
+            depth -= 1
+            if depth == 0:
+                return source[offset + 1 : index], index + 1
+    raise ValueError(f"unterminated {opener!r} group at source offset {offset}")
+
+
+def _tex_command_calls(
+    source: str, command_names: frozenset[str]
+) -> list[tuple[str, list[str], int, str | None]]:
+    """Find calls to selected commands, including balanced mandatory arguments."""
+
+    if not command_names:
+        return []
+    alternatives = "|".join(re.escape(name) for name in sorted(command_names))
+    pattern = re.compile(r"\\(" + alternatives + r")(?=[^A-Za-z@]|\Z)")
+    calls: list[tuple[str, list[str], int, str | None]] = []
+    for match in pattern.finditer(source):
+        offset = _skip_tex_space(source, match.end())
+        option = None
+        if offset < len(source) and source[offset] == "[":
+            option, offset = _tex_group(source, offset, "[", "]")
+            offset = _skip_tex_space(source, offset)
+        arguments = []
+        while offset < len(source) and source[offset] == "{":
+            argument, offset = _tex_group(source, offset, "{", "}")
+            arguments.append(argument)
+            offset = _skip_tex_space(source, offset)
+        calls.append((match.group(1), arguments, match.start(), option))
+    return calls
+
+
+def _tex_macro_definitions(source: str) -> list[tuple[str, str, int]]:
+    """Return complete ``newcommand`` bodies with their source offsets."""
+
+    pattern = re.compile(
+        r"^\\newcommand\{\\(?P<name>[A-Za-z@]+)\}(?:\[\d+\])?",
+        re.MULTILINE,
+    )
+    definitions = []
+    for match in pattern.finditer(source):
+        offset = _skip_tex_space(source, match.end())
+        if offset >= len(source) or source[offset] != "{":
+            continue
+        body, body_end = _tex_group(source, offset, "{", "}")
+        definitions.append((match.group("name"), body, offset + 1))
+        if body_end <= offset:
+            raise AssertionError("balanced TeX group did not advance")
+    return definitions
+
+
+def _semantic_node_names(body: str) -> set[str]:
+    names = set()
+    for _, arguments, _, _ in _tex_command_calls(body, _SEMANTIC_GLYPH_COMMANDS):
+        if not arguments:
+            continue
+        name = arguments[0].strip()
+        if _SIMPLE_NODE_NAME_PATTERN.fullmatch(name):
+            names.add(name)
+    return names
+
+
+def _named_port_debt(path: Path, source: str) -> dict[str, list[dict[str, object]]]:
+    """Locate semantic wires that bypass the atomic named-port vocabulary.
+
+    Coordinate-only lattice edges and region boundaries remain legitimate
+    geometric paths.  Explicit anchors such as ``object.east`` and
+    ``object.30`` are exact boundary ports and remain valid for curved or
+    multi-segment contractions.  Debt consists of bare semantic nodes and of
+    endpoints obtained by shifting an anchor, endpoints at an object centre,
+    and traces whose endpoints are only numerical coordinates.  The same
+    exact-attachment condition applies to point connectors.
+    """
+
+    inexact_path_endpoints: list[dict[str, object]] = []
+    bare_node_connectors: list[dict[str, object]] = []
+    for macro_name, body, body_offset in _tex_macro_definitions(source):
+        semantic_names = _semantic_node_names(body)
+        for command, arguments, call_offset, option in _tex_command_calls(
+            body, _GENERAL_WIRE_COMMANDS
+        ):
+            if not arguments:
+                continue
+            if option and re.search(r"\btn (?:factor|grouping) region\b", option):
+                continue
+            path_body = arguments[0]
+            references = {
+                name
+                for name in semantic_names
+                if re.search(r"\(\s*" + re.escape(name) + r"\s*\)", path_body)
+            }
+            stripped_path = path_body.strip().removesuffix(";").rstrip()
+            references.update(
+                match.group("reference") + " (offset)"
+                for match in _OFFSET_ANCHOR_POINT_PATTERN.finditer(stripped_path)
+                if match.start() == 0 or match.end() == len(stripped_path)
+            )
+            references.update(
+                name + ".center"
+                for name in semantic_names
+                for match in re.finditer(
+                    r"\(\s*" + re.escape(name) + r"\.center\s*\)", stripped_path
+                )
+                if match.start() == 0 or match.end() == len(stripped_path)
+            )
+            if command in _TRACE_PATH_COMMANDS and not re.search(
+                r"\(\s*(?:\$\([^)]*\)\s*)?[#A-Za-z\\]", stripped_path
+            ):
+                references.add("coordinate-only trace")
+            if references:
+                inexact_path_endpoints.append(
+                    {
+                        "location": _source_line(path, body_offset + call_offset),
+                        "macro": macro_name,
+                        "command": command,
+                        "references": sorted(references),
+                    }
+                )
+
+        for command, arguments, call_offset, _ in _tex_command_calls(
+            body, _POINT_CONNECTOR_COMMANDS
+        ):
+            point_arguments = (
+                arguments[1:3] if command == "TN@connectpoints" else arguments[:2]
+            )
+            inexact_nodes = sorted(
+                stripped
+                for argument in point_arguments
+                if (stripped := argument.strip()) in semantic_names
+                or stripped in {name + ".center" for name in semantic_names}
+            )
+            if inexact_nodes:
+                bare_node_connectors.append(
+                    {
+                        "location": _source_line(path, body_offset + call_offset),
+                        "macro": macro_name,
+                        "command": command,
+                        "references": inexact_nodes,
+                    }
+                )
+
+    return {
+        "inexact_path_endpoints": inexact_path_endpoints,
+        "bare_node_point_connectors": bare_node_connectors,
+    }
+
+
+def _source_semantic_debt(path: Path, source: str) -> dict[str, object]:
+    raw_glyph_locations = {
+        name: [_source_line(path, match.start()) for match in pattern.finditer(source)]
+        for name, pattern in _RAW_GLYPH_PATTERNS.items()
+    }
+    direct_draw_locations = [
+        _source_line(path, match.start()) for match in _RAW_WIRE_PATTERN.finditer(source)
+    ]
+    legacy_wire_locations = [
+        _source_line(path, match.start())
+        for match in _LEGACY_WIRE_COMMAND_PATTERN.finditer(source)
+    ]
+    port_debt = _named_port_debt(path, source)
+    return {
+        "raw_glyph_locations": raw_glyph_locations,
+        "raw_glyph_count": sum(len(locations) for locations in raw_glyph_locations.values()),
+        "direct_tn_draw_locations": direct_draw_locations,
+        "legacy_wire_locations": legacy_wire_locations,
+        "raw_wire_count": len(direct_draw_locations) + len(legacy_wire_locations),
+        **port_debt,
+        "named_port_debt_count": sum(len(locations) for locations in port_debt.values()),
+    }
+
+
+def _semantic_audit_counts() -> dict[str, object]:
+    """Collect migration measures without assigning mathematical meaning to them."""
+
+    print_path = _SRC_DIR / "macros/tn_print.tex"
+    core_path = _SRC_DIR / "macros/tn_core.tex"
+    print_source = print_path.read_text(encoding="utf-8")
+    core_source = core_path.read_text(encoding="utf-8")
+    library_path = _SRC_DIR / "macros/tn_library.tex"
+    library_source = (
+        library_path.read_text(encoding="utf-8") if library_path.exists() else ""
+    )
+    private_source = core_source + "\n" + library_source
+    public_macros = _public_macro_bodies(print_source)
+    chapter_paths = sorted((_SRC_DIR / "chapter").glob("*.tex"))
+    chapter_sources = [path.read_text(encoding="utf-8") for path in chapter_paths]
+    chapter_source = "\n".join(chapter_sources)
+
+    chapter_calls = re.findall(r"\\(TN[A-Z]\w+)", chapter_source)
+    ignored_arguments = {
+        name: [index for index in range(1, arity + 1) if f"#{index}" not in body]
+        for name, arity, body in public_macros
+        if arity > 0 and name != "TNTikZDiagram"
+    }
+    ignored_arguments = {
+        name: indices for name, indices in ignored_arguments.items() if indices
+    }
+    unused_diagrams = sorted(
+        name
+        for name, _, _ in public_macros
+        if name != "TNTikZDiagram" and name not in chapter_calls
+    )
+
+    audited_sources = {
+        "macros/tn_print.tex": _source_semantic_debt(print_path, print_source),
+        "macros/tn_library.tex": _source_semantic_debt(library_path, library_source),
+    }
+    raw_glyph_counts = {
+        name: sum(
+            len(source_debt["raw_glyph_locations"][name])
+            for source_debt in audited_sources.values()
+        )
+        for name in _RAW_GLYPH_PATTERNS
+    }
+    direct_wire_commands = sum(
+        len(source_debt["direct_tn_draw_locations"])
+        for source_debt in audited_sources.values()
+    )
+    legacy_wire_commands = sum(
+        len(source_debt["legacy_wire_locations"])
+        for source_debt in audited_sources.values()
+    )
+    named_port_debt = sum(
+        int(source_debt["named_port_debt_count"])
+        for source_debt in audited_sources.values()
+    )
+    return {
+        "registered": len(_DIAGRAM_ARGS),
+        "public": len(public_macros),
+        "concrete": sum(r"\begin{tikzpicture}" in body for _, _, body in public_macros),
+        "zero_argument": sum(arity == 0 for _, arity, _ in public_macros),
+        "chapter_files": sum(
+            bool(re.search(r"\\TN[A-Z]\w+", source)) for source in chapter_sources
+        ),
+        "chapter_calls": len(chapter_calls),
+        "chapter_commands": len(set(chapter_calls)),
+        "private_commands": len(
+            re.findall(r"^\\newcommand\{\\TN@\w+\}", private_source, re.MULTILINE)
+        ),
+        "private_lengths": len(
+            re.findall(r"^\\def\\TN@\w+", private_source, re.MULTILINE)
+        ),
+        "core_styles": len(
+            re.findall(r"^\s*tn [^/]+?/\.style", core_source, re.MULTILINE)
+        ),
+        "literal_coordinates": len(_LITERAL_COORDINATE_PATTERN.findall(print_source)),
+        "draw_commands": len(re.findall(r"\\draw\b", print_source)),
+        "node_commands": len(re.findall(r"\\node\b", print_source)),
+        "raw_glyph_counts": raw_glyph_counts,
+        "direct_wire_commands": direct_wire_commands,
+        "legacy_wire_commands": legacy_wire_commands,
+        "raw_wire_commands": direct_wire_commands + legacy_wire_commands,
+        "named_port_debt": named_port_debt,
+        "audited_sources": audited_sources,
+        "noncore_style_locations": _noncore_tikz_style_locations(),
+        "ignored_arguments": ignored_arguments,
+        "unused_diagrams": unused_diagrams,
+    }
+
+
+def _format_ignored_arguments(ignored: dict[str, list[int]]) -> str:
+    return ", ".join(
+        f"{name}({','.join(f'#{index}' for index in indices)})"
+        for name, indices in sorted(ignored.items())
+    )
+
+
+def _debt_locations(
+    audited_sources: dict[str, object], categories: tuple[str, ...]
+) -> list[str]:
+    locations = []
+    for source_debt in audited_sources.values():
+        assert isinstance(source_debt, dict)
+        for category in categories:
+            records = source_debt[category]
+            assert isinstance(records, list)
+            for record in records:
+                if isinstance(record, str):
+                    locations.append(record)
+                else:
+                    assert isinstance(record, dict)
+                    locations.append(str(record["location"]))
+    return locations
+
+
+def _raw_glyph_locations(audited_sources: dict[str, object]) -> list[str]:
+    locations = []
+    for source_debt in audited_sources.values():
+        assert isinstance(source_debt, dict)
+        by_kind = source_debt["raw_glyph_locations"]
+        assert isinstance(by_kind, dict)
+        locations.extend(
+            location
+            for kind_locations in by_kind.values()
+            for location in kind_locations
+        )
+    return locations
+
+
+def _abbreviate_locations(locations: list[str], limit: int = 16) -> str:
+    visible = locations[:limit]
+    suffix = f", ... ({len(locations) - limit} more)" if len(locations) > limit else ""
+    return ", ".join(visible) + suffix
+
+
+def _run_semantic_audit(*, strict: bool, machine_readable: bool) -> None:
+    """Check stable invariants and report the remaining diagram migration debt."""
+
+    _assert_diagram_args_match_print_macros()
+    _assert_diagram_templates_cover_registered_macros()
+    _assert_no_chapter_local_tikz()
+
+    counts = _semantic_audit_counts()
+    raw_glyph_counts = counts["raw_glyph_counts"]
+    assert isinstance(raw_glyph_counts, dict)
+    ignored_arguments = counts["ignored_arguments"]
+    assert isinstance(ignored_arguments, dict)
+    unused_diagrams = counts["unused_diagrams"]
+    assert isinstance(unused_diagrams, list)
+    noncore_style_locations = counts["noncore_style_locations"]
+    assert isinstance(noncore_style_locations, list)
+    audited_sources = counts["audited_sources"]
+    assert isinstance(audited_sources, dict)
+
+    if machine_readable:
+        print(json.dumps(counts, indent=2, sort_keys=True))
+    else:
+        print(
+            "tensor-network semantic audit: "
+            f"{counts['concrete']} concrete diagrams, {counts['registered']} registrations, "
+            f"{counts['chapter_calls']} calls to {counts['chapter_commands']} commands in "
+            f"{counts['chapter_files']} chapter files"
+        )
+        print(
+            "tensor-network private vocabulary: "
+            f"{counts['core_styles']} styles, {counts['private_lengths']} lengths, "
+            f"{counts['private_commands']} drawing commands"
+        )
+        print(
+            "tensor-network migration measures: "
+            f"{counts['zero_argument']} zero-argument public commands, "
+            f"{counts['literal_coordinates']} literal coordinate pairs, "
+            f"{counts['draw_commands']} draw commands, {counts['node_commands']} node commands"
+        )
+        print(
+            "tensor-network raw aliases: "
+            + ", ".join(f"{name}={value}" for name, value in raw_glyph_counts.items())
+            + f", direct tn draw commands={counts['direct_wire_commands']}, "
+            + f"legacy wire commands={counts['legacy_wire_commands']}"
+        )
+        for source_name, source_debt in audited_sources.items():
+            assert isinstance(source_debt, dict)
+            print(
+                f"tensor-network structural debt in {source_name}: "
+                f"raw glyphs={source_debt['raw_glyph_count']}, "
+                f"raw wires={source_debt['raw_wire_count']}, "
+                f"named-port violations={source_debt['named_port_debt_count']}"
+            )
+        if noncore_style_locations:
+            print(
+                "tensor-network non-core style declarations: "
+                + ", ".join(noncore_style_locations)
+            )
+        print(
+            "tensor-network ignored public arguments: "
+            + (
+                _format_ignored_arguments(ignored_arguments)
+                if ignored_arguments
+                else "none"
+            )
+        )
+        if unused_diagrams:
+            print("tensor-network unused public diagrams: " + ", ".join(unused_diagrams))
+
+    if strict:
+        failures = []
+        if noncore_style_locations:
+            failures.append(
+                "TikZ styles outside macros/tn_core.tex at "
+                + _abbreviate_locations(noncore_style_locations)
+            )
+        raw_glyph_total = sum(raw_glyph_counts.values())
+        raw_wire_total = int(counts["raw_wire_commands"])
+        if raw_glyph_total or raw_wire_total:
+            raw_locations = _raw_glyph_locations(audited_sources) + _debt_locations(
+                audited_sources,
+                ("direct_tn_draw_locations", "legacy_wire_locations"),
+            )
+            failures.append(
+                "raw glyph aliases or tensor-network draws in macros/tn_print.tex "
+                "and macros/tn_library.tex "
+                f"(glyphs={raw_glyph_total}, wires={raw_wire_total}) at "
+                + _abbreviate_locations(raw_locations)
+            )
+        named_port_total = int(counts["named_port_debt"])
+        if named_port_total:
+            port_locations = _debt_locations(
+                audited_sources,
+                ("inexact_path_endpoints", "bare_node_point_connectors"),
+            )
+            failures.append(
+                "semantic contractions bypass the atomic named-port vocabulary "
+                f"({named_port_total} calls) at "
+                + _abbreviate_locations(port_locations)
+            )
+        if ignored_arguments:
+            failures.append(
+                "public tensor-network macros ignore declared arguments: "
+                + _format_ignored_arguments(ignored_arguments)
+            )
+        if failures:
+            raise RuntimeError("Strict tensor-network audit failed: " + "; ".join(failures))
 
 
 def _read_chapter_with_includes(path: Path, seen: set[Path] | None = None) -> str:
@@ -581,6 +1211,32 @@ def _main(argv: list[str] | None = None) -> int:
         help="check that public PEPS diagram macros are used in the PEPS chapter",
     )
     parser.add_argument(
+        "--check-slides",
+        action="store_true",
+        help="check the independent dark-theme tensor-network slide vocabulary",
+    )
+    parser.add_argument(
+        "--audit",
+        action="store_true",
+        help=(
+            "enforce stable tensor-network vocabulary invariants and report "
+            "remaining migration measures without failing on them"
+        ),
+    )
+    parser.add_argument(
+        "--audit-strict",
+        action="store_true",
+        help=(
+            "also reject non-core TikZ styles, raw glyph or wire aliases, and "
+            "semantic paths that bypass the atomic named-port vocabulary"
+        ),
+    )
+    parser.add_argument(
+        "--audit-json",
+        action="store_true",
+        help="emit the semantic audit measures as JSON (requires --audit)",
+    )
+    parser.add_argument(
         "--smoke-render",
         nargs="*",
         metavar="MACRO",
@@ -591,7 +1247,18 @@ def _main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    if not args.check and not args.check_peps_usage and args.smoke_render is None:
+    if args.audit_json and not args.audit:
+        parser.error("--audit-json requires --audit")
+    if args.audit_strict and not args.audit:
+        parser.error("--audit-strict requires --audit")
+
+    if (
+        not args.check
+        and not args.check_peps_usage
+        and not args.check_slides
+        and not args.audit
+        and args.smoke_render is None
+    ):
         parser.print_help()
         return 0
 
@@ -603,6 +1270,20 @@ def _main(argv: list[str] | None = None) -> int:
     if args.check_peps_usage:
         _assert_peps_macros_used_in_chapter()
         print("checked public PEPS diagram usage in the PEPS chapter")
+
+    if args.check_slides:
+        _assert_slide_diagram_contract()
+        slide_calls = sum(_EXPECTED_SLIDE_DIAGRAM_CALLS.values())
+        print(
+            f"checked {slide_calls} tensor-network diagrams in the independent "
+            "slide collection"
+        )
+
+    if args.audit:
+        _run_semantic_audit(
+            strict=args.audit_strict,
+            machine_readable=args.audit_json,
+        )
 
     if args.smoke_render is not None:
         names = args.smoke_render or list(_DIAGRAM_ARGS)

--- a/blueprint/src/macros/tn_core.tex
+++ b/blueprint/src/macros/tn_core.tex
@@ -1,9 +1,15 @@
-% Private tensor-network TikZ kernel.
+% Semantic tensor-network TikZ grammar.
 %
-% The chapter-facing diagram commands live in macros/tn_print.tex. This file
-% contains only the common glyphs, lengths, and atomic drawing commands used by
-% those public diagrams.
-\usetikzlibrary{calc}
+% This file fixes the meaning of every glyph, wire, and region used in the
+% blueprint.  Reusable MPS, MPO, MPDO, and PEPS constructions belong in
+% macros/tn_library.tex; complete chapter-facing diagrams belong in
+% macros/tn_print.tex.
+%
+% A solid line is always an index line.  Virtual and physical index lines have
+% different widths.  Dashed curves are not contractions: they indicate a
+% grouping, a basis change, or an identified periodic boundary.  Tensor labels
+% do not change the glyph used for the tensor.
+\usetikzlibrary{backgrounds,calc,fit}
 
 \tikzset{
     tn picture/.style={
@@ -11,51 +17,96 @@
             transform shape,
             font=\scriptsize
         },
-    tn tensor dot/.style={
+    % Semantic node classes.
+    tn tensor node/.style={
             draw,
             fill,
             shape=circle,
             inner sep=0.055cm
         },
-    tn operator dot/.style={
-            tn tensor dot,
+    tn insertion node/.style={
+            tn tensor node,
             red
         },
-    % Labeled tensors remain neutral and linear maps are blue; operators
-    % inserted on individual legs remain red dots.  These styles prevent a
-    % tensor label from being mistaken for a map or for a leg insertion.
-    tn tensor box/.style={
+    % A junction is a contraction point of index lines, not a local tensor.
+    tn junction node/.style={
+            fill,
+            shape=circle,
+            inner sep=0.020cm
+        },
+    tn component node/.style={
             draw,
             fill=white,
             inner sep=1.4pt
         },
-    tn map box/.style={
+    tn factor node/.style={
+            draw=black!65,
+            fill=black!5,
+            inner sep=1.4pt
+        },
+    tn map node/.style={
             draw,
             rounded corners=2pt,
             fill=blue!8,
             inner sep=2pt
         },
-    tn leg/.style={line width=0.4pt},
-    tn phys leg/.style={line width=0.7pt},
-    % A contracted index is always solid.  Dashed strokes are reserved for
-    % grouping boundaries or for an explicitly indicated periodic
-    % identification, neither of which is an index contraction.
-    tn contraction/.style={tn leg},
-    tn phys contraction/.style={tn phys leg},
-    tn purification contraction/.style={tn phys contraction},
-    % A bent leg is an ordinary open contraction whose route contains a
-    % corner.  It is not a trace or periodic closure.
-    tn bent leg/.style={tn leg, rounded corners=3pt},
-    tn virtual closure/.style={tn contraction, rounded corners=3pt},
-    tn physical closure/.style={tn phys contraction, rounded corners=3pt},
-    tn factor boundary/.style={tn leg, rounded corners=2pt},
-    tn grouping boundary/.style={densely dashed, rounded corners=2pt},
-    tn basis change/.style={densely dashed, line width=0.4pt},
-    tn periodic identification/.style={
-            tn leg,
+    tn state node/.style={
+            draw=black!65,
+            rounded corners=2pt,
+            fill=black!4,
+            inner sep=2pt
+        },
+    % Semantic index lines.
+    tn virtual wire/.style={line width=0.4pt},
+    tn physical wire/.style={line width=0.7pt},
+    tn virtual trace/.style={tn virtual wire, rounded corners=3pt},
+    tn physical trace/.style={tn physical wire, rounded corners=3pt},
+    tn bent wire/.style={tn virtual wire, rounded corners=3pt},
+    % Regions and non-contraction marks.
+    tn factor region/.style={tn virtual wire, rounded corners=2pt},
+    tn grouping region/.style={densely dashed, rounded corners=2pt},
+    tn basis change mark/.style={densely dashed, line width=0.4pt},
+    tn periodic mark/.style={tn virtual wire, densely dashed, ->},
+    tn morphism arrow/.style={->, line width=0.60pt},
+    tn comparison arrow/.style={<->, line width=0.60pt},
+    tn selected path/.style={red, line width=0.70pt},
+    tn secondary path/.style={blue, line width=0.70pt},
+    tn region selected/.style={
+            draw=red!75!black,
+            fill=red!28,
+            thick,
+            rounded corners=1mm
+        },
+    tn region secondary/.style={
+            draw=blue!75!black,
+            fill=blue!24,
+            thick,
+            rounded corners=1mm
+        },
+    tn region complement/.style={
+            draw=black!55,
+            fill=black!8,
             densely dashed,
-            ->
-        }
+            thick,
+            rounded corners=1mm
+        },
+    tn region collar/.style={
+            draw=purple!70!black,
+            fill=purple!18,
+            thick,
+            rounded corners=1mm
+        },
+    tn edge distinguished/.style={line width=0.6mm, green!65!black},
+    tn vertex distinguished/.style={
+            circle,
+            draw=black!65,
+            fill=yellow!75!white,
+            thick
+        },
+    tn region label selected/.style={text=red!75!black},
+    tn region label secondary/.style={text=blue!75!black},
+    tn region label complement/.style={text=black!65},
+    tn region label collar/.style={text=purple!70!black}
 }
 
 \makeatletter
@@ -67,47 +118,289 @@
 \def\TN@chainright{4.20}
 \def\TN@chainellipsisx{2.82}
 
-% ---------- Atomic drawing commands ----------
+% ---------- Semantic nodes ----------
 
-\newcommand{\TN@tensordot}[2]{%
-    \node[tn tensor dot] (#1) at #2 {};%
+\newcommand{\TN@node}[5][]{%
+    \node[#2,#1] (#3) at #4 {#5};%
 }
 
-\newcommand{\TN@opdot}[2]{%
-    \node[tn operator dot] (#1) at #2 {};%
+\newcommand{\TN@tensor}[3][]{%
+    \TN@node[#1]{tn tensor node}{#2}{#3}{}%
 }
 
-\newcommand{\TN@opdotabove}[3]{%
-    \node[tn operator dot, label=above:$#3$] (#1) at #2 {};%
+% Anonymous tensor sites are used for lattice backgrounds whose sites are not
+% referenced individually by the surrounding construction.
+\newcommand{\TN@anonymoustensor}[2][]{%
+    \node[tn tensor node,#1] at #2 {};%
 }
 
-\newcommand{\TN@opdotbelow}[3]{%
-    \node[tn operator dot, label=below:$#3$] (#1) at #2 {};%
+\newcommand{\TN@component}[4][]{%
+    \TN@node[#1]{tn component node}{#2}{#3}{$#4$}%
 }
 
-\newcommand{\TN@opdotleft}[3]{%
-    \node[tn operator dot, label=left:$#3$] (#1) at #2 {};%
+\newcommand{\TN@factor}[4][]{%
+    \TN@node[#1]{tn factor node}{#2}{#3}{$#4$}%
 }
 
-\newcommand{\TN@opdotright}[3]{%
-    \node[tn operator dot, label=right:$#3$] (#1) at #2 {};%
+\newcommand{\TN@map}[4][]{%
+    \TN@node[#1]{tn map node}{#2}{#3}{$#4$}%
 }
 
-\newcommand{\TN@leftleg}[2]{%
-    \draw[tn leg] (#1.west) -- ++(-#2,0);%
+\newcommand{\TN@state}[4][]{%
+    \TN@node[#1]{tn state node}{#2}{#3}{$#4$}%
 }
 
-\newcommand{\TN@rightleg}[2]{%
-    \draw[tn leg] (#1.east) -- ++(#2,0);%
+\newcommand{\TN@insertion}[3][]{%
+    \TN@node[#1]{tn insertion node}{#2}{#3}{}%
 }
 
-\newcommand{\TN@upleg}[2]{%
-    \draw[tn phys leg] (#1.north) -- ++(0,#2);%
+\newcommand{\TN@junction}[3][]{%
+    \TN@node[#1]{tn junction node}{#2}{#3}{}%
 }
 
-\newcommand{\TN@downleg}[2]{%
-    \draw[tn phys leg] (#1.south) -- ++(0,-#2);%
+\newcommand{\TN@anonymousjunction}[2][]{%
+    \node[tn junction node,#1] at #2 {};%
 }
+
+\newcommand{\TN@scalar}[4][]{%
+    \TN@tensor[#1]{#2}{#3}%
+    \node[anchor=west] at ($(#2.east)+(0.10,0)$) {$#4$};%
+}
+
+% An external label does not alter the glyph of the object it names.
+\newcommand{\TN@label}[4][]{%
+    \node[#1] at ($(#2)+#3$) {$#4$};%
+}
+
+% ---------- Named ports ----------
+
+% Every composable object may give a stable name to one of its boundary
+% anchors.  Contractions can then be expressed solely in terms of ports.
+\newcommand{\TN@port}[3]{%
+    \coordinate (#1) at (#2.#3);%
+}
+
+% A port may also lie at a specified fraction of a boundary segment.  This is
+% useful for a box carrying several indices on the same side.
+\newcommand{\TN@betweenport}[4]{%
+    \coordinate (#1) at ($(#2)!#4!(#3)$);%
+}
+
+\newcommand{\TN@westport}[3]{%
+    \TN@betweenport{#1}{#2.north west}{#2.south west}{#3}%
+}
+
+\newcommand{\TN@eastport}[3]{%
+    \TN@betweenport{#1}{#2.north east}{#2.south east}{#3}%
+}
+
+\newcommand{\TN@northport}[3]{%
+    \TN@betweenport{#1}{#2.north west}{#2.north east}{#3}%
+}
+
+\newcommand{\TN@southport}[3]{%
+    \TN@betweenport{#1}{#2.south west}{#2.south east}{#3}%
+}
+
+% ---------- Anchored index lines ----------
+
+\newcommand{\TN@connectpoints}[4][]{%
+    \draw[#2,#1] (#3) to (#4);%
+}
+
+\newcommand{\TN@vconnectpoints}[3][]{%
+    \TN@connectpoints[#1]{tn virtual wire}{#2}{#3}%
+}
+
+\newcommand{\TN@pconnectpoints}[3][]{%
+    \TN@connectpoints[#1]{tn physical wire}{#2}{#3}%
+}
+
+% Port-to-port composition is the preferred form when a construction is
+% assembled from independently defined atoms.
+\newcommand{\TN@vconnectports}[3][]{%
+    \TN@vconnectpoints[#1]{#2}{#3}%
+}
+
+\newcommand{\TN@pconnectports}[3][]{%
+    \TN@pconnectpoints[#1]{#2}{#3}%
+}
+
+\newcommand{\TN@vconnect}[5][]{%
+    \TN@vconnectpoints[#1]{#2.#3}{#4.#5}%
+}
+
+\newcommand{\TN@pconnect}[5][]{%
+    \TN@pconnectpoints[#1]{#2.#3}{#4.#5}%
+}
+
+% Curved port-to-port contractions retain the same compositional interface as
+% straight contractions.  The two angles prescribe the tangent directions at
+% the boundary ports.
+\newcommand{\TN@vconnectcurve}[7][]{%
+    \draw[tn virtual wire,#1] (#2.#3) to[out=#4,in=#5] (#6.#7);%
+}
+
+\newcommand{\TN@vconnectbendright}[6][]{%
+    \draw[tn virtual wire,#1] (#2.#3) to[bend right=#4] (#5.#6);%
+}
+
+% Cubic connectors are useful when the route, rather than only its endpoint
+% tangents, carries geometric information in the diagram.
+\newcommand{\TN@vconnectbezier}[7][]{%
+    \draw[tn virtual wire,#1] (#2.#3) .. controls #4 and #5 .. (#6.#7);% chktex 26
+}
+
+\newcommand{\TN@pconnectbezier}[7][]{%
+    \draw[tn physical wire,#1] (#2.#3) .. controls #4 and #5 .. (#6.#7);% chktex 26
+}
+
+\newcommand{\TN@vtraceconnectbezier}[7][]{%
+    \draw[tn virtual trace,#1] (#2.#3) .. controls #4 and #5 .. (#6.#7);% chktex 26
+}
+
+\newcommand{\TN@vbezieropen}[7][]{%
+    \draw[tn virtual wire,#1] (#2.#3) .. controls #4 and #5 .. #6 -- ++(#7);% chktex 26
+}
+
+% A partial contraction terminates at the indicated fraction of the segment
+% from the object centre to an external port.
+\newcommand{\TN@vpartialconnect}[5][]{%
+    \draw[tn virtual wire,#1] (#2.#3) -- ($(#2)!#5!(#4)$);%
+}
+
+% A trace may pass through an insertion lying below three consecutive atoms.
+\newcommand{\TN@vtracevia}[6][]{%
+    \draw[tn virtual trace,#1] (#2.west) -- ++(-#5,0) |- (#3.west);%
+    \draw[tn virtual trace,#1] (#3.east) -| ($(#4.east)+(#6,0)$)
+        -- (#4.east);%
+}
+
+\newcommand{\TN@vtraceconnectpoints}[3][]{%
+    \TN@connectpoints[#1]{tn virtual trace}{#2}{#3}%
+}
+
+% A trace closure is itself composable when its two endpoints are named ports.
+% The last two arguments give the horizontal and vertical clearances.
+\newcommand{\TN@vtraceportsbelow}[5][]{%
+    \draw[tn virtual trace,#1] (#2) -- ++(-#4,0) -- ++(0,-#5)
+        -| ($(#3)+(#4,0)$) -- (#3);%
+}
+
+\newcommand{\TN@vtraceportsabove}[5][]{%
+    \draw[tn virtual trace,#1] (#2) -- ++(-#4,0) -- ++(0,#5)
+        -| ($(#3)+(#4,0)$) -- (#3);%
+}
+
+% General paths remain available for closures and lattice edges whose route is
+% not a single segment.  Complete contractions should still use the anchored
+% connect commands above whenever both endpoint objects are named.
+\newcommand{\TN@vpath}[2][]{%
+    \draw[tn virtual wire,#1] #2;%
+}
+
+\newcommand{\TN@ppath}[2][]{%
+    \draw[tn physical wire,#1] #2;%
+}
+
+\newcommand{\TN@vtracepath}[2][]{%
+    \draw[tn virtual trace,#1] #2;%
+}
+
+\newcommand{\TN@ptracepath}[2][]{%
+    \draw[tn physical trace,#1] #2;%
+}
+
+\newcommand{\TN@arrow}[2][]{%
+    \draw[tn morphism arrow,#1] #2;%
+}
+
+\newcommand{\TN@comparisonarrow}[2][]{%
+    \draw[tn comparison arrow,#1] #2;%
+}
+
+\newcommand{\TN@selectedpath}[2][]{%
+    \draw[tn selected path,#1] #2;%
+}
+
+\newcommand{\TN@secondarypath}[2][]{%
+    \draw[tn secondary path,#1] #2;%
+}
+
+\newcommand{\TN@grouppath}[2][]{%
+    \draw[tn grouping region,#1] #2;%
+}
+
+\newcommand{\TN@factorpath}[2][]{%
+    \draw[tn factor region,#1] #2;%
+}
+
+\newcommand{\TN@openwire}[5][]{%
+    \draw[#2,#1] (#3.#4) -- ++(#5);%
+}
+
+\newcommand{\TN@openport}[4][]{%
+    \draw[#2,#1] (#3) -- ++(#4);%
+}
+
+\newcommand{\TN@vopenport}[3][]{%
+    \TN@openport[#1]{tn virtual wire}{#2}{#3}%
+}
+
+\newcommand{\TN@popenport}[3][]{%
+    \TN@openport[#1]{tn physical wire}{#2}{#3}%
+}
+
+\newcommand{\TN@vleg}[4][]{%
+    \TN@openwire[#1]{tn virtual wire}{#2}{#3}{#4}%
+}
+
+\newcommand{\TN@pleg}[4][]{%
+    \TN@openwire[#1]{tn physical wire}{#2}{#3}{#4}%
+}
+
+% Trace closures are index lines, not region boundaries.
+\newcommand{\TN@vtracebelow}[3]{%
+    \draw[tn virtual trace] (#1.west) -- ++(-0.42,0) -- ++(0,-#3)
+        -| ($(#2.east)+(0.42,0)$) -- (#2.east);%
+}
+
+\newcommand{\TN@vtraceabove}[3]{%
+    \draw[tn virtual trace] (#1.west) -- ++(-0.42,0) -- ++(0,#3)
+        -| ($(#2.east)+(0.42,0)$) -- (#2.east);%
+}
+
+\newcommand{\TN@vtraceright}[3]{%
+    \draw[tn virtual trace] (#1.east) -- ++(#3,0) |- (#2.east);%
+}
+
+\newcommand{\TN@ptraceright}[3]{%
+    \draw[tn physical trace] (#1.north) -- ++(0,#3)
+        -| ($(#1.center)!0.5!(#2.center)+(0.42,0)$)
+        |- ($(#2.south)+(0,-#3)$) -- (#2.south);%
+}
+
+% ---------- Semantic regions ----------
+
+\newcommand{\TN@region}[5][]{%
+    \begin{scope}[on background layer]
+        \node[#2, fit=#4, inner sep=4pt, #1] (#3) {#5};%
+    \end{scope}%
+}
+
+\newcommand{\TN@groupregion}[4][]{%
+    \TN@region[#1]{tn grouping region}{#2}{#3}{#4}%
+}
+
+\newcommand{\TN@factorregion}[4][]{%
+    \TN@region[#1]{tn factor region}{#2}{#3}{#4}%
+}
+
+\newcommand{\TN@supportregion}[5][]{%
+    \TN@region[#1]{tn region #2}{#3}{#4}{#5}%
+}
+
+% ---------- Index labels ----------
 
 \newcommand{\TN@uplabel}[3]{%
     \node at ($(#1.north)+(0,#2)$) {$#3$};%
@@ -115,202 +408,6 @@
 
 \newcommand{\TN@downlabel}[3]{%
     \node at ($(#1.south)+(0,-#2)$) {$#3$};%
-}
-
-% A labeled Hayashi subspin factor.  The short vertical stroke follows the
-% source diagrams in Appendix C.2; horizontal strokes are added separately so
-% that a public diagram can display either a physical site or a regrouped
-% tensor product without changing the glyph.
-\newcommand{\TN@subspinbox}[3]{%
-    \node[tn tensor box, minimum width=0.72cm, minimum height=0.52cm,
-        inner sep=1pt] (#1) at #2 {$#3$};%
-    \draw[tn leg] (#1.north) -- ++(0,0.26);%
-    \draw[tn leg] (#1.south) -- ++(0,-0.26);%
-}
-
-\newcommand{\TN@subspinlink}[2]{%
-    \draw[tn leg] (#1.east) -- (#2.west);%
-}
-
-% ---------- Layout commands ----------
-
-\newcommand{\TN@openMPSword}[4]{%
-    \TN@tensordot{#1L}{(0,0)}
-    \TN@tensordot{#1M}{(\TN@chainsep,0)}
-    \TN@tensordot{#1R}{(\TN@chainright,0)}
-    \TN@upleg{#1L}{\TN@physleglen}
-    \TN@upleg{#1M}{\TN@physleglen}
-    \TN@upleg{#1R}{\TN@physleglen}
-    \TN@uplabel{#1L}{\TN@physlabeloff}{#2}
-    \TN@uplabel{#1R}{\TN@physlabeloff}{#3}
-    \TN@leftleg{#1L}{0.8}
-    \draw[tn leg] (#1L.east) -- (#1M.west);
-    \draw[tn leg] (#1M.east) -- ++(0.62,0);
-    \draw[tn leg] ($(#1R.west)+(-0.62,0)$) -- (#1R.west);
-    \TN@rightleg{#1R}{0.8}
-    \node at (\TN@chainellipsisx,0) {$\cdots$};
-    \node at (\TN@chainellipsisx,-0.56) {$#4$};%
-}
-
-\newcommand{\TN@blockedMPSword}[3]{%
-    \TN@tensordot{#1L}{(0,0)}
-    \TN@tensordot{#1M}{(\TN@chainsep,0)}
-    \TN@tensordot{#1R}{(\TN@chainright,0)}
-    \TN@upleg{#1L}{\TN@physleglen}
-    \TN@upleg{#1M}{\TN@physleglen}
-    \TN@upleg{#1R}{\TN@physleglen}
-    \TN@uplabel{#1L}{\TN@physlabeloff}{#2}
-    \TN@uplabel{#1R}{\TN@physlabeloff}{#3}
-    \draw[tn virtual closure] (-0.48,0) rectangle (4.68,-0.44);
-    \node at (\TN@chainellipsisx,0) {$\cdots$};%
-}
-
-\newcommand{\TN@openMPOword}[6]{%
-    \TN@tensordot{#1L}{(0,0)}
-    \TN@tensordot{#1M}{(\TN@chainsep,0)}
-    \TN@tensordot{#1R}{(\TN@chainright,0)}
-    \TN@upleg{#1L}{\TN@physleglen}
-    \TN@downleg{#1L}{\TN@physleglen}
-    \TN@upleg{#1M}{\TN@physleglen}
-    \TN@downleg{#1M}{\TN@physleglen}
-    \TN@upleg{#1R}{\TN@physleglen}
-    \TN@downleg{#1R}{\TN@physleglen}
-    \TN@uplabel{#1L}{\TN@physlabeloff}{#2}
-    \TN@downlabel{#1L}{\TN@physlabeloff}{#3}
-    \TN@uplabel{#1R}{\TN@physlabeloff}{#4}
-    \TN@downlabel{#1R}{\TN@physlabeloff}{#5}
-    \TN@leftleg{#1L}{0.8}
-    \draw[tn leg] (#1L.east) -- (#1M.west);
-    \draw[tn leg] (#1M.east) -- ++(0.62,0);
-    \draw[tn leg] ($(#1R.west)+(-0.62,0)$) -- (#1R.west);
-    \TN@rightleg{#1R}{0.8}
-    \node at (\TN@chainellipsisx,0) {$\cdots$};
-    \node at (\TN@chainellipsisx,-1.02) {$#6$};%
-}
-
-% Trace-closed MPO word: a row of MPO sites (first, ellipsis, last) whose
-% virtual bond is contracted along the row and closed below by the trace,
-% while every ket and bra leg stays external.
-\newcommand{\TN@closedMPOword}[1]{%
-    \TN@tensordot{#1L}{(0,0)}
-    \TN@tensordot{#1M}{(1.15,0)}
-    \TN@tensordot{#1R}{(3.05,0)}
-    \foreach \n in {#1L,#1M,#1R} {
-            \TN@upleg{\n}{0.46}
-            \TN@downleg{\n}{0.46}
-        }
-    \draw[tn leg] (#1L.east) -- (#1M.west);
-    \draw[tn leg] (#1M.east) -- ++(0.50,0);
-    \draw[tn leg] ($(#1R.west)+(-0.50,0)$) -- (#1R.west);
-    \node at (2.10,0) {$\cdots$};
-    \draw[tn virtual closure] (#1L.west) -- ++(-0.42,0) -- ++(0,-0.92)
-    -- ($(#1R.east)+(0.42,-0.92)$) -- ($(#1R.east)+(0.42,0)$) -- (#1R.east);%
-}
-
-% MPO site whose ket and bra legs are closed by a trace loop to the right of
-% the site: the physical-trace transfer matrix of the tensor.
-\newcommand{\TN@tracedMPOSite}[2]{%
-    \TN@tensordot{#1}{#2}
-    \TN@leftleg{#1}{0.60}
-    \TN@rightleg{#1}{0.60}
-    \draw[tn physical closure]
-    (#1.north) |- ($(#1.center)+(0.42,0.52)$)
-    -- ($(#1.center)+(0.42,-0.52)$) -| (#1.south);%
-}
-
-\newcommand{\TN@boxedThreeSiteChain}[4]{%
-    \draw[tn virtual closure] (0.40,0) rectangle (3.50,-0.46);
-    \TN@tensordot{#1one}{(1.00,0)}
-    \TN@tensordot{#1two}{(2.00,0)}
-    \TN@tensordot{#1three}{(3.00,0)}
-    \foreach \n in {#1one,#1two,#1three} {
-            \TN@upleg{\n}{0.46}
-        }
-    \node at ($(#1one.south)+(0,-0.30)$) {$#2$};
-    \node at ($(#1two.south)+(0,-0.30)$) {$#3$};
-    \node at ($(#1three.south)+(0,-0.30)$) {$#4$};%
-}
-
-\newcommand{\TN@boxedThreeSiteInsertion}[5]{%
-    \TN@boxedThreeSiteChain{#1}{#2}{#3}{#4}
-    \TN@opdotabove{#1X}{(1.50,0)}{#5}%
-}
-
-\newcommand{\TN@boxedThreeSitePhysicalOne}[5]{%
-    \TN@boxedThreeSiteChain{#1}{#2}{#3}{#4}
-    \TN@opdotleft{#1O}{(1.00,0.72)}{#5}
-    \draw[tn phys leg] (#1one.north) -- (#1O.south);
-    \draw[tn phys leg, red] (#1O.north) -- ++(0,0.36);%
-}
-
-\newcommand{\TN@boxedThreeSitePhysicalTwo}[5]{%
-    \TN@boxedThreeSiteChain{#1}{#2}{#3}{#4}
-    \TN@opdotleft{#1O}{(2.00,0.72)}{#5}
-    \draw[tn phys leg] (#1two.north) -- (#1O.south);
-    \draw[tn phys leg, red] (#1O.north) -- ++(0,0.36);%
-}
-
-\newcommand{\TN@pepsFiveSitePatch}[1]{%
-    \TN@tensordot{#1one}{(0,0)}
-    \TN@tensordot{#1two}{(1.00,0)}
-    \TN@tensordot{#1three}{(1.50,1.00)}
-    \TN@tensordot{#1four}{(0.60,1.50)}
-    \TN@tensordot{#1five}{(-0.60,1.50)}
-    \foreach \n in {#1one,#1two,#1three,#1four,#1five} {
-            \TN@upleg{\n}{0.50}
-        }
-    \draw[tn leg] (#1one) -- (#1two) -- (#1three) --
-    (#1four) -- (#1five) -- (#1one);
-    \draw[tn leg] (#1two) -- (#1five);%
-}
-
-\newcommand{\TN@pepsFiveSitePatchLabels}[6]{%
-    \node at ($(#1one.south)+(0,-0.25)$) {$#2$};
-    \node at ($(#1two.south)+(0,-0.25)$) {$#3$};
-    \node at ($(#1three.south)+(0,-0.25)$) {$#4$};
-    \node at ($(#1four.south)+(0,-0.25)$) {$#5$};
-    \node at ($(#1five.south)+(0,-0.25)$) {$#6$};%
-}
-
-\newcommand{\TN@twoInjectiveInsertionPair}[4]{%
-    \TN@tensordot{#1one}{(0,0)}
-    \TN@tensordot{#1two}{(2.50,0)}
-    \TN@upleg{#1one}{0.42}
-    \TN@upleg{#1two}{0.42}
-    \TN@opdotabove{#1X}{(1.25,0.45)}{#4}
-    \draw[tn leg] (#1one) to[out=30,in=180] (#1X.west);
-    \draw[tn leg] (#1X.east) to[out=0,in=150] (#1two);
-    \draw[tn leg] (#1one) to[bend right=12] (#1two);
-    \draw[tn leg] (#1one) to[bend right=38] (#1two);
-    \node at (1.25,-0.08) {$\vdots$};
-    \node at ($(#1one.south)+(0,-0.30)$) {$#2$};
-    \node at ($(#1two.south)+(0,-0.30)$) {$#3$};%
-}
-
-\newcommand{\TN@threeLegTensorFan}[2]{%
-    \TN@tensordot{#1}{(0,0)}
-    \TN@upleg{#1}{0.42}
-    \draw[tn leg] (#1) -- ++(0.75,0.45);
-    \draw[tn leg] (#1) -- ++(0.78,-0.05);
-    \draw[tn leg] (#1) -- ++(0.65,-0.55);
-    \node at ($(#1.south)+(0,-0.30)$) {$#2$};%
-}
-
-\newcommand{\TN@normalPepsGridLines}{%
-    \draw[step=0.5, tn leg] (-1,-1) grid (4,4);%
-}
-
-\newcommand{\TN@normalPepsGridDots}{%
-    \foreach \x in {0,0.5,1,1.5,2,2.5,3} {
-            \foreach \y in {0,0.5,1,1.5,2,2.5,3} {
-                    \node[tn tensor dot] at (\x,\y) {};
-                }
-        }%
-}
-
-\newcommand{\TN@normalPepsGrid}{%
-    \TN@normalPepsGridLines
-    \TN@normalPepsGridDots
 }
 
 \makeatother

--- a/blueprint/src/macros/tn_library.tex
+++ b/blueprint/src/macros/tn_library.tex
@@ -1,0 +1,479 @@
+% Reusable tensor-network constructions.
+%
+% The commands in this file compose the semantic grammar from tn_core.tex into
+% standard local tensors, chains, closures, and finite patches.  They are
+% private building blocks for the chapter-facing diagrams in tn_print.tex.
+\input{macros/tn_core} % chktex 27 (job-dir-relative path)
+
+\makeatletter
+
+% ---------- Standard tensor-network sites ----------
+
+% An MPS tensor has west and east virtual ports and one north physical port.
+% The atom itself carries no open legs, so it may be composed without erasing
+% pre-drawn index lines.
+\newcommand{\TN@mpssite}[3]{%
+    \TN@tensor{#1}{#2}%
+    \TN@port{#1W}{#1}{west}%
+    \TN@port{#1E}{#1}{east}%
+    \TN@port{#1N}{#1}{north}%
+    \if\relax\detokenize{#3}\relax\else
+        \node at ($(#1.south)+(0,-0.28)$) {$#3$};%
+    \fi
+}
+
+% The corresponding standalone motif has named ports at all three free ends.
+\newcommand{\TN@mpssiteWithOpenLegs}[3]{%
+    \TN@mpssite{#1}{#2}{#3}%
+    \coordinate (#1WOpen) at ($(#1W)+(-0.60,0)$);%
+    \coordinate (#1EOpen) at ($(#1E)+(0.60,0)$);%
+    \coordinate (#1NOpen) at ($(#1N)+(0,0.46)$);%
+    \TN@vconnectports{#1W}{#1WOpen}%
+    \TN@vconnectports{#1E}{#1EOpen}%
+    \TN@pconnectports{#1N}{#1NOpen}%
+}
+
+% An MPO or MPDO tensor has west and east virtual ports and north and south
+% physical ports.
+\newcommand{\TN@mposite}[3]{%
+    \TN@tensor{#1}{#2}%
+    \TN@port{#1W}{#1}{west}%
+    \TN@port{#1E}{#1}{east}%
+    \TN@port{#1N}{#1}{north}%
+    \TN@port{#1S}{#1}{south}%
+    \if\relax\detokenize{#3}\relax\else
+        \node[anchor=west] at ($(#1.south east)+(0.12,-0.18)$) {$#3$};%
+    \fi
+}
+
+% The standalone MPO/MPDO motif has named ports at all four free ends.
+\newcommand{\TN@mpositeWithOpenLegs}[3]{%
+    \TN@mposite{#1}{#2}{#3}%
+    \coordinate (#1WOpen) at ($(#1W)+(-0.60,0)$);%
+    \coordinate (#1EOpen) at ($(#1E)+(0.60,0)$);%
+    \coordinate (#1NOpen) at ($(#1N)+(0,0.46)$);%
+    \coordinate (#1SOpen) at ($(#1S)+(0,-0.46)$);%
+    \TN@vconnectports{#1W}{#1WOpen}%
+    \TN@vconnectports{#1E}{#1EOpen}%
+    \TN@pconnectports{#1N}{#1NOpen}%
+    \TN@pconnectports{#1S}{#1SOpen}%
+}
+
+% A PEPS vertex carries a north-east physical index.  Lattice-specific virtual
+% indices are added separately, so the physical index never replaces a virtual
+% north port.
+\newcommand{\TN@pepsvertex}[3]{%
+    \TN@tensor{#1}{#2}%
+    \TN@pleg{#1}{45}{0.38,0.38}%
+    \if\relax\detokenize{#3}\relax\else
+        \node[anchor=north east] at ($(#1.south west)+(-0.10,-0.10)$) {$#3$};%
+    \fi
+}
+
+% A square-lattice PEPS tensor has four cardinal virtual indices in addition
+% to the north-east physical index.  Its five named boundary ports form the
+% compositional interface; the base atom has no fixed open stubs.
+\newcommand{\TN@pepssite}[3]{%
+    \TN@tensor{#1}{#2}%
+    \TN@port{#1W}{#1}{west}%
+    \TN@port{#1E}{#1}{east}%
+    \TN@port{#1N}{#1}{north}%
+    \TN@port{#1S}{#1}{south}%
+    \TN@port{#1P}{#1}{45}%
+    \if\relax\detokenize{#3}\relax\else
+        \node[anchor=north east] at ($(#1.south west)+(-0.10,-0.10)$) {$#3$};%
+    \fi
+}
+
+% The standalone square-lattice site has named ports at all five free ends.
+\newcommand{\TN@pepssiteWithOpenLegs}[3]{%
+    \TN@pepssite{#1}{#2}{#3}%
+    \coordinate (#1WOpen) at ($(#1W)+(-0.58,0)$);%
+    \coordinate (#1EOpen) at ($(#1E)+(0.58,0)$);%
+    \coordinate (#1NOpen) at ($(#1N)+(0,0.58)$);%
+    \coordinate (#1SOpen) at ($(#1S)+(0,-0.58)$);%
+    \coordinate (#1POpen) at ($(#1P)+(0.38,0.38)$);%
+    \TN@vconnectports{#1W}{#1WOpen}%
+    \TN@vconnectports{#1E}{#1EOpen}%
+    \TN@vconnectports{#1N}{#1NOpen}%
+    \TN@vconnectports{#1S}{#1SOpen}%
+    \TN@pconnectports{#1P}{#1POpen}%
+}
+
+% A doubled local tensor with its physical index contracted between the two
+% layers.  The prefix names the upper and lower tensor nodes.
+\newcommand{\TN@doublelayer}[3]{%
+    \TN@tensor{#1U}{#2}%
+    \TN@tensor{#1D}{#3}%
+    \TN@port{#1UW}{#1U}{west}%
+    \TN@port{#1UE}{#1U}{east}%
+    \TN@port{#1US}{#1U}{south}%
+    \TN@port{#1DW}{#1D}{west}%
+    \TN@port{#1DE}{#1D}{east}%
+    \TN@port{#1DN}{#1D}{north}%
+    \TN@pconnectports{#1US}{#1DN}%
+}
+
+% The standalone doubled layer exposes named ports at its four virtual ends.
+\newcommand{\TN@doublelayerWithOpenLegs}[3]{%
+    \TN@doublelayer{#1}{#2}{#3}%
+    \coordinate (#1UWOpen) at ($(#1UW)+(-0.60,0)$);%
+    \coordinate (#1UEOpen) at ($(#1UE)+(0.60,0)$);%
+    \coordinate (#1DWOpen) at ($(#1DW)+(-0.60,0)$);%
+    \coordinate (#1DEOpen) at ($(#1DE)+(0.60,0)$);%
+    \TN@vconnectports{#1UW}{#1UWOpen}%
+    \TN@vconnectports{#1UE}{#1UEOpen}%
+    \TN@vconnectports{#1DW}{#1DWOpen}%
+    \TN@vconnectports{#1DE}{#1DEOpen}%
+}
+
+% Two displayed tensor-product factors.  Tensor product is written explicitly;
+% it is never represented by an index line.
+\newcommand{\TN@factorpair}[5]{%
+    \TN@factor{#1L}{#2}{#4}%
+    \TN@factor{#1R}{#3}{#5}%
+    \node at ($(#1L.center)!0.5!(#1R.center)$) {$\otimes$};%
+}
+
+% ---------- Oriented fusion maps ----------
+
+% A left-to-right fusion map with one trunk and two ordered branches.  The
+% atom retains the semantic rounded blue map glyph; its interface is named by
+% role rather than by absolute coordinates.  Top and Bottom are available for
+% additional physical indices when the same map participates in a larger
+% contraction.
+\newcommand{\TN@splitmap}[4][]{%
+    \TN@map[#1]{#2}{#3}{#4}%
+    \TN@port{#2Mid}{#2}{west}%
+    \TN@port{#2Up}{#2}{north east}%
+    \TN@port{#2Down}{#2}{south east}%
+    \TN@port{#2Top}{#2}{north}%
+    \TN@port{#2Bottom}{#2}{south}%
+}
+
+% The mirror image of \TN@splitmap: two ordered branches merge into one
+% trunk.  The port names have the same mathematical roles in both
+% orientations, so a split and a merge may be interchanged without exposing
+% TikZ anchors to the surrounding construction.
+\newcommand{\TN@mergemap}[4][]{%
+    \TN@map[#1]{#2}{#3}{#4}%
+    \TN@port{#2Mid}{#2}{east}%
+    \TN@port{#2Up}{#2}{north west}%
+    \TN@port{#2Down}{#2}{south west}%
+    \TN@port{#2Top}{#2}{north}%
+    \TN@port{#2Bottom}{#2}{south}%
+}
+
+% ---------- One-dimensional words and closures ----------
+
+% A one-dimensional tensor atom carries named boundary ports.  The centre port
+% is used only to place labels; every index line starts or ends at a boundary
+% port.
+\newcommand{\TN@declareWordTensor}[2]{%
+    \TN@tensor{#1}{#2}
+    \TN@port{#1W}{#1}{west}
+    \TN@port{#1E}{#1}{east}
+    \TN@port{#1N}{#1}{north}
+    \TN@port{#1S}{#1}{south}
+    \TN@port{#1C}{#1}{center}%
+}
+
+\newcommand{\TN@openMPSword}[4]{%
+    \TN@declareWordTensor{#1L}{(0,0)}
+    \TN@declareWordTensor{#1M}{(\TN@chainsep,0)}
+    \TN@declareWordTensor{#1R}{(\TN@chainright,0)}
+    \TN@popenport{#1LN}{0,\TN@physleglen}
+    \TN@popenport{#1MN}{0,\TN@physleglen}
+    \TN@popenport{#1RN}{0,\TN@physleglen}
+    \TN@label{#1LN}{(0,\TN@physlabeloff)}{#2}
+    \TN@label{#1RN}{(0,\TN@physlabeloff)}{#3}
+    \TN@vopenport{#1LW}{-0.8,0}
+    \TN@vconnectports{#1LE}{#1MW}
+    \TN@vopenport{#1ME}{0.62,0}
+    \TN@vopenport{#1RW}{-0.62,0}
+    \TN@vopenport{#1RE}{0.8,0}
+    \node at (\TN@chainellipsisx,0) {$\cdots$};
+    \node at (\TN@chainellipsisx,-0.56) {$#4$};%
+}
+
+\newcommand{\TN@blockedMPSword}[3]{%
+    \TN@declareWordTensor{#1L}{(0,0)}
+    \TN@declareWordTensor{#1M}{(\TN@chainsep,0)}
+    \TN@declareWordTensor{#1R}{(\TN@chainright,0)}
+    \TN@popenport{#1LN}{0,\TN@physleglen}
+    \TN@popenport{#1MN}{0,\TN@physleglen}
+    \TN@popenport{#1RN}{0,\TN@physleglen}
+    \TN@label{#1LN}{(0,\TN@physlabeloff)}{#2}
+    \TN@label{#1RN}{(0,\TN@physlabeloff)}{#3}
+    \TN@vconnectports{#1LE}{#1MW}
+    \TN@vopenport{#1ME}{0.62,0}
+    \TN@vopenport{#1RW}{-0.62,0}
+    \TN@vtraceportsbelow{#1LW}{#1RE}{0.42}{0.44}
+    \node at (\TN@chainellipsisx,0) {$\cdots$};%
+}
+
+\newcommand{\TN@openMPOword}[6]{%
+    \TN@declareWordTensor{#1L}{(0,0)}
+    \TN@declareWordTensor{#1M}{(\TN@chainsep,0)}
+    \TN@declareWordTensor{#1R}{(\TN@chainright,0)}
+    \TN@popenport{#1LN}{0,\TN@physleglen}
+    \TN@popenport{#1LS}{0,-\TN@physleglen}
+    \TN@popenport{#1MN}{0,\TN@physleglen}
+    \TN@popenport{#1MS}{0,-\TN@physleglen}
+    \TN@popenport{#1RN}{0,\TN@physleglen}
+    \TN@popenport{#1RS}{0,-\TN@physleglen}
+    \TN@label{#1LN}{(0,\TN@physlabeloff)}{#2}
+    \TN@label{#1LS}{(0,-\TN@physlabeloff)}{#3}
+    \TN@label{#1RN}{(0,\TN@physlabeloff)}{#4}
+    \TN@label{#1RS}{(0,-\TN@physlabeloff)}{#5}
+    \TN@vopenport{#1LW}{-0.8,0}
+    \TN@vconnectports{#1LE}{#1MW}
+    \TN@vopenport{#1ME}{0.62,0}
+    \TN@vopenport{#1RW}{-0.62,0}
+    \TN@vopenport{#1RE}{0.8,0}
+    \node at (\TN@chainellipsisx,0) {$\cdots$};
+    \node at (\TN@chainellipsisx,-1.02) {$#6$};%
+}
+
+% Trace-closed MPO word with open ket and bra indices.
+\newcommand{\TN@closedMPOword}[1]{%
+    \TN@declareWordTensor{#1L}{(0,0)}
+    \TN@declareWordTensor{#1M}{(1.15,0)}
+    \TN@declareWordTensor{#1R}{(3.05,0)}
+    \TN@popenport{#1LN}{0,0.46}
+    \TN@popenport{#1LS}{0,-0.46}
+    \TN@popenport{#1MN}{0,0.46}
+    \TN@popenport{#1MS}{0,-0.46}
+    \TN@popenport{#1RN}{0,0.46}
+    \TN@popenport{#1RS}{0,-0.46}
+    \TN@vconnectports{#1LE}{#1MW}
+    \TN@vopenport{#1ME}{0.50,0}
+    \TN@vopenport{#1RW}{-0.50,0}
+    \node at (2.10,0) {$\cdots$};
+    \TN@vtraceportsbelow{#1LW}{#1RE}{0.42}{0.92}%
+}
+
+% MPO site with the ket and bra indices closed by a physical trace.
+\newcommand{\TN@tracedMPOSite}[2]{%
+    \TN@declareWordTensor{#1}{#2}
+    \TN@vopenport{#1W}{-0.60,0}
+    \TN@vopenport{#1E}{0.60,0}
+    \TN@ptracepath{(#1N) |- ($(#1C)+(0.42,0.52)$)
+        -- ($(#1C)+(0.42,-0.52)$) -| (#1S)}%
+}
+
+% ---------- Repeated finite constructions ----------
+
+\newcommand{\TN@declareThreeSiteChain}[4]{%
+    \TN@declareWordTensor{#1one}{(1.00,0)}
+    \TN@declareWordTensor{#1two}{(2.00,0)}
+    \TN@declareWordTensor{#1three}{(3.00,0)}
+    \TN@label{#1oneS}{(0,-0.30)}{#2}
+    \TN@label{#1twoS}{(0,-0.30)}{#3}
+    \TN@label{#1threeS}{(0,-0.30)}{#4}%
+}
+
+\newcommand{\TN@connectThreeSiteChain}[1]{%
+    \TN@vconnectports{#1oneE}{#1twoW}
+    \TN@vconnectports{#1twoE}{#1threeW}%
+}
+
+\newcommand{\TN@closeThreeSiteChain}[1]{%
+    \TN@vtracepath{(#1oneW) -- (0.40,0) -- (0.40,-0.46)
+        -- (3.50,-0.46) -- (3.50,0) -- (#1threeE)}%
+}
+
+\newcommand{\TN@openThreeSitePhysicalPorts}[1]{%
+    \TN@popenport{#1oneN}{0,0.46}
+    \TN@popenport{#1twoN}{0,0.46}
+    \TN@popenport{#1threeN}{0,0.46}%
+}
+
+\newcommand{\TN@boxedThreeSiteChain}[4]{%
+    \TN@declareThreeSiteChain{#1}{#2}{#3}{#4}
+    \TN@connectThreeSiteChain{#1}
+    \TN@closeThreeSiteChain{#1}
+    \TN@openThreeSitePhysicalPorts{#1}%
+}
+
+\newcommand{\TN@boxedThreeSiteInsertion}[5]{%
+    \TN@declareThreeSiteChain{#1}{#2}{#3}{#4}
+    \TN@insertion[label=above:$#5$]{#1X}{(1.50,0)}
+    \TN@port{#1XW}{#1X}{west}
+    \TN@port{#1XE}{#1X}{east}
+    \TN@vconnectports{#1oneE}{#1XW}
+    \TN@vconnectports{#1XE}{#1twoW}
+    \TN@vconnectports{#1twoE}{#1threeW}
+    \TN@closeThreeSiteChain{#1}
+    \TN@openThreeSitePhysicalPorts{#1}%
+}
+
+\newcommand{\TN@boxedThreeSitePhysicalOne}[5]{%
+    \TN@declareThreeSiteChain{#1}{#2}{#3}{#4}
+    \TN@insertion[label=left:$#5$]{#1O}{(1.00,0.72)}
+    \TN@port{#1ON}{#1O}{north}
+    \TN@port{#1OS}{#1O}{south}
+    \TN@connectThreeSiteChain{#1}
+    \TN@closeThreeSiteChain{#1}
+    \TN@pconnectports{#1oneN}{#1OS}
+    \TN@popenport{#1ON}{0,0.36}
+    \TN@popenport{#1twoN}{0,0.46}
+    \TN@popenport{#1threeN}{0,0.46}%
+}
+
+\newcommand{\TN@boxedThreeSitePhysicalTwo}[5]{%
+    \TN@declareThreeSiteChain{#1}{#2}{#3}{#4}
+    \TN@insertion[label=left:$#5$]{#1O}{(2.00,0.72)}
+    \TN@port{#1ON}{#1O}{north}
+    \TN@port{#1OS}{#1O}{south}
+    \TN@connectThreeSiteChain{#1}
+    \TN@closeThreeSiteChain{#1}
+    \TN@popenport{#1oneN}{0,0.46}
+    \TN@pconnectports{#1twoN}{#1OS}
+    \TN@popenport{#1ON}{0,0.36}
+    \TN@popenport{#1threeN}{0,0.46}%
+}
+
+\newcommand{\TN@pepsFiveSitePatch}[1]{%
+    \TN@pepsvertex{#1one}{(0,0)}{}
+    \TN@pepsvertex{#1two}{(1.00,0)}{}
+    \TN@pepsvertex{#1three}{(1.50,1.00)}{}
+    \TN@pepsvertex{#1four}{(0.60,1.50)}{}
+    \TN@pepsvertex{#1five}{(-0.60,1.50)}{}
+    \TN@vconnect{#1one}{east}{#1two}{west}
+    \TN@vconnect{#1two}{63}{#1three}{243}
+    \TN@vconnect{#1three}{151}{#1four}{331}
+    \TN@vconnect{#1four}{west}{#1five}{east}
+    \TN@vconnect{#1five}{292}{#1one}{112}
+    \TN@vconnect{#1two}{137}{#1five}{317}%
+}
+
+\newcommand{\TN@pepsFiveSitePatchLabels}[6]{%
+    \node at ($(#1one.south)+(0,-0.25)$) {$#2$};
+    \node at ($(#1two.south)+(0,-0.25)$) {$#3$};
+    \node at ($(#1three.south)+(0,-0.25)$) {$#4$};
+    \node at ($(#1four.south)+(0,-0.25)$) {$#5$};
+    \node at ($(#1five.south)+(0,-0.25)$) {$#6$};%
+}
+
+\newcommand{\TN@twoInjectiveInsertionPair}[4]{%
+    \TN@tensor{#1one}{(0,0)}
+    \TN@tensor{#1two}{(2.50,0)}
+    \TN@pleg{#1one}{north}{0,0.42}
+    \TN@pleg{#1two}{north}{0,0.42}
+    \TN@insertion[label=above:$#4$]{#1X}{(1.25,0.45)}
+    \TN@vconnectcurve{#1one}{30}{30}{180}{#1X}{west}
+    \TN@vconnectcurve{#1X}{east}{0}{150}{#1two}{150}
+    \TN@vconnectbendright{#1one}{-8}{12}{#1two}{188}
+    \TN@vconnectbendright{#1one}{-28}{38}{#1two}{208}
+    \node at (1.25,-0.08) {$\vdots$};
+    \node at ($(#1one.south)+(0,-0.30)$) {$#2$};
+    \node at ($(#1two.south)+(0,-0.30)$) {$#3$};%
+}
+
+\newcommand{\TN@threeLegTensorFan}[2]{%
+    \TN@tensor{#1}{(0,0)}
+    \TN@pleg{#1}{north}{0,0.42}
+    \TN@vleg{#1}{31}{0.64,0.38}
+    \TN@vleg{#1}{-4}{0.67,-0.04}
+    \TN@vleg{#1}{-40}{0.54,-0.46}
+    \node at ($(#1.south)+(0,-0.30)$) {$#2$};%
+}
+
+\newcommand{\TN@normalPepsGridLines}{%
+    \TN@vpath[step=0.5]{(-1,-1) grid (4,4)}%
+}
+
+\newcommand{\TN@normalPepsGridDots}{%
+    \foreach \x in {0,0.5,1,1.5,2,2.5,3} {
+            \foreach \y in {0,0.5,1,1.5,2,2.5,3} {
+                    \TN@anonymoustensor{(\x,\y)}
+                }
+        }%
+}
+
+\newcommand{\TN@normalPepsGrid}{%
+    \TN@normalPepsGridLines
+    \TN@normalPepsGridDots
+}
+
+% ---------- Normal-PEPS regions ----------
+
+\newcommand{\TN@pepsNormalSquareLattice}{%
+    \TN@normalPepsGrid%
+}
+
+\newcommand{\TN@pepsNormalSquareLatticeLines}{%
+    \TN@normalPepsGridLines%
+}
+
+\newcommand{\TN@pepsNormalSquareLatticeDots}{%
+    \TN@normalPepsGridDots%
+}
+
+\newcommand{\TN@pepsNormalRegionR}{%
+    \path[tn region selected]
+    (0.3,1.3) -- (1.2,1.3) -- (1.2,1.8) -- (1.7,1.8) --
+    (1.7,2.7) -- (0.3,2.7) -- cycle;
+    \node[tn region label selected] at (0.75,2.0) {$R$};%
+}
+
+\newcommand{\TN@pepsNormalRegionS}{%
+    \path[tn region selected] (0.3,1.3) rectangle (1.7,2.7);
+    \node[tn region label selected] at (1.00,2.00) {$S$};%
+}
+
+\newcommand{\TN@pepsNormalRegionT}{%
+    \path[tn region selected, even odd rule]
+    (0.3,2.7) -- (1.2,2.7) -- (1.2,1.7) -- (2.7,1.7) --
+    (2.7,0.8) -- (1.3,0.8) -- (1.3,1.3) -- (0.3,1.3) -- cycle
+    (-0.25,0.25) rectangle (3.25,3.25);
+    \node[tn region label selected] at (2.0,2.3) {$T$};%
+}
+
+\newcommand{\TN@pepsNormalSingleSiteDifference}{%
+    \node[tn vertex distinguished, minimum size=0.32cm, inner sep=0pt]
+        at (1.5,1.5) {\scriptsize $v$};%
+}
+
+\newcommand{\TN@pepsNormalDistinguishedEdge}{%
+    \TN@vpath[tn edge distinguished]{(1,1.5) -- (1.5,1.5)}%
+}
+
+\newcommand{\TN@pepsNormalSelectedBlock}{%
+    \path[tn region selected] (0.3,1.3) rectangle (1.2,2.7);%
+}
+
+\newcommand{\TN@pepsNormalSecondaryBlock}{%
+    \path[tn region secondary] (1.3,1.7) rectangle (2.7,0.8);%
+}
+
+\newcommand{\TN@pepsNormalComplementBlock}{%
+    \path[tn region complement, even odd rule]
+    (-0.15,-0.15) rectangle (3.15,3.15)
+    (0.3,1.3) rectangle (1.2,2.7)
+    (1.3,0.8) rectangle (2.7,1.7);
+    \node[tn region label complement] at (2.38,2.45) {$A_3$};%
+}
+
+\newcommand{\TN@pepsNormalCollar}{%
+    \path[tn region collar] (0.3,2.55) rectangle (1.7,3.18);
+    \path[tn region collar] (1.3,2.55) rectangle (2.7,3.18);
+    \node[tn region label collar] at (1.50,2.88) {top collar};%
+}
+
+\newcommand{\TN@pepsBlockedNormalChain}{%
+    \TN@vpath[tn factor region]{(0.50,0) rectangle (3.50,-0.46)}
+    \TN@vpath[tn edge distinguished]{(1.00,0) -- (2.00,0)}
+    \foreach \x/\lab in {1/A_1,2/A_2,3/A_3} {
+            \TN@tensor{normalBlock\x}{(\x,0)}
+            \TN@pleg{normalBlock\x}{north}{0,0.46}
+            \node at ($(normalBlock\x.south)+(0,-0.30)$) {$\lab$};
+        }%
+}
+
+\newcommand{\TN@pepsSquareTensor}[2]{%
+    \TN@pepssiteWithOpenLegs{#1}{#2}{}%
+}
+
+\makeatother

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -5,19 +5,29 @@
 %
 % Layout policy:
 % - Public \TN... macros are chapter-facing and semantically named.
-% - Private \TN@... helpers in macros/tn_core.tex provide the atomic drawing
-%   vocabulary.
+% - Private \TN@... helpers in macros/tn_core.tex and macros/tn_library.tex
+%   provide the atomic grammar and reusable tensor-network constructions.
 % - Public diagrams default to unlabeled tensor glyphs; the surrounding
 %   formula/prose carries the tensor names.
-% - A local tensor is a black dot.  A tensor which must carry a label is a
-%   neutral square box; a linear map or insertion is a rounded blue box, and
-%   a scalar operator inserted on a leg is a red dot.
+% - A local tensor is a black dot.  A suppressed contracted component is a
+%   neutral square box, a linear map is a rounded blue box, a state is a
+%   rounded gray box, and an endomorphism inserted on an index is a red dot.
 % - Solid strokes are contracted indices.  Dashed strokes indicate only a
 %   grouping boundary, a change of multiplicity basis, or an identified
 %   boundary of a periodic lattice.
-\input{macros/tn_core} % chktex 27 (job-dir-relative path; chktex lints this file standalone)
+\input{macros/tn_library} % chktex 27 (job-dir-relative path; standalone lint)
 
 \makeatletter
+
+% A displayed algebraic factor with its two exposed index lines.  This local
+% abbreviation keeps the source-derived sector diagrams legible while using
+% the common factor glyph and anchored-leg constructors.
+\newcommand{\TN@factorwithlegs}[3]{%
+    \TN@factor[minimum width=0.72cm, minimum height=0.52cm,
+        inner sep=1pt]{#1}{#2}{#3}%
+    \TN@vleg{#1}{north}{0,0.26}%
+    \TN@vleg{#1}{south}{0,-0.26}%
+}
 
 % ---------- Public semantic macros ----------
 
@@ -25,23 +35,27 @@
 
 \newcommand{\TNMPSLocal}[2]{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{tnA}{(0,0)}
-        \TN@leftleg{tnA}{0.8}
-        \TN@rightleg{tnA}{0.8}
-        \TN@upleg{tnA}{\TN@physleglen}
+        \TN@tensor{tnA}{(0,0)}
+        \TN@vleg{tnA}{west}{-0.8,0}
+        \TN@vleg{tnA}{east}{0.8,0}
+        \TN@pleg{tnA}{north}{0,\TN@physleglen}
         \TN@uplabel{tnA}{\TN@physlabeloff}{#2}
+        \node at ($(tnA.south)+(0,-0.30)$) {$#1$};
     \end{tikzpicture}%
 }
 
 \newcommand{\TNMPSWord}[4]{%
     \begin{tikzpicture}[tn picture]
         \TN@openMPSword{tn}{#2}{#3}{#4}
+        \node[anchor=east] at (-0.85,0) {$#1$};
     \end{tikzpicture}%
 }
 
 \newcommand{\TNMPV}[4]{%
     \begin{tikzpicture}[tn picture]
         \TN@blockedMPSword{tn}{#2}{#3}
+        \node[anchor=east] at (-0.85,0) {$#1$};
+        \node at (\TN@chainellipsisx,-0.70) {$#4$};
     \end{tikzpicture}%
 }
 
@@ -51,8 +65,9 @@
 \newcommand{\TNBlocking}[4]{%
     \begin{tikzpicture}[tn picture]
         \TN@openMPSword{tn}{#2}{#3}{#4}
-        \draw[tn grouping boundary]
-        ($(tnL.west)+(-0.30,0.22)$) rectangle ($(tnR.east)+(0.30,-0.34)$);
+        \TN@vpath[tn grouping region]{
+            ($(tnL.west)+(-0.30,0.22)$)
+            rectangle ($(tnR.east)+(0.30,-0.34)$);}
     \end{tikzpicture}%
 }
 
@@ -61,33 +76,42 @@
 % both virtual rings are closed by the trace (the boxes above and below).
 \newcommand{\TNMPVOverlap}[3]{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{ovuL}{(0,0.42)}
-        \TN@tensordot{ovuM}{(\TN@chainsep,0.42)}
-        \TN@tensordot{ovuR}{(\TN@chainright,0.42)}
-        \draw[tn virtual closure] (-0.48,0.42) rectangle (4.68,0.74);
-        \TN@tensordot{ovdL}{(0,-0.42)}
-        \TN@tensordot{ovdM}{(\TN@chainsep,-0.42)}
-        \TN@tensordot{ovdR}{(\TN@chainright,-0.42)}
-        \draw[tn virtual closure] (-0.48,-0.42) rectangle (4.68,-0.74);
-        \draw[tn phys leg] (ovuL.south) -- (ovdL.north);
-        \draw[tn phys leg] (ovuM.south) -- (ovdM.north);
-        \draw[tn phys leg] (ovuR.south) -- (ovdR.north);
+        \TN@declareWordTensor{ovuL}{(0,0.42)}
+        \TN@declareWordTensor{ovuM}{(\TN@chainsep,0.42)}
+        \TN@declareWordTensor{ovuR}{(\TN@chainright,0.42)}
+        \TN@vconnectports{ovuLE}{ovuMW}
+        \TN@vopenport{ovuME}{0.62,0}
+        \TN@vopenport{ovuRW}{-0.62,0}
+        \TN@vtracepath{(ovuLW) -- (-0.48,0.42) -- (-0.48,0.74)
+            -- (4.68,0.74) -- (4.68,0.42) -- (ovuRE)}
+        \TN@declareWordTensor{ovdL}{(0,-0.42)}
+        \TN@declareWordTensor{ovdM}{(\TN@chainsep,-0.42)}
+        \TN@declareWordTensor{ovdR}{(\TN@chainright,-0.42)}
+        \TN@vconnectports{ovdLE}{ovdMW}
+        \TN@vopenport{ovdME}{0.62,0}
+        \TN@vopenport{ovdRW}{-0.62,0}
+        \TN@vtracepath{(ovdLW) -- (-0.48,-0.42) -- (-0.48,-0.74)
+            -- (4.68,-0.74) -- (4.68,-0.42) -- (ovdRE)}
+        \TN@pconnect{ovuL}{south}{ovdL}{north}
+        \TN@pconnect{ovuM}{south}{ovdM}{north}
+        \TN@pconnect{ovuR}{south}{ovdR}{north}
         % single centred ellipsis in the omitted-site column (no line crosses it)
         \node at (\TN@chainellipsisx,0) {$\cdots$};
         \node[anchor=east] at (-0.85,0.42) {$#1$};
         \node[anchor=east] at (-0.85,-0.42) {$\overline{#2}$};
+        \node at (\TN@chainellipsisx,-1.02) {$#3$};
     \end{tikzpicture}%
 }
 
 \newcommand{\TNTransferMap}[1]{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{tnUp}{(0,0.44)}
-        \TN@tensordot{tnDn}{(0,-0.44)}
-        \draw[tn leg] ($(tnUp.west)+(-0.75,0)$) -- (tnUp.west);
-        \draw[tn leg] ($(tnDn.west)+(-0.75,0)$) -- (tnDn.west);
-        \draw[tn leg] (tnUp.east) -- ++(0.75,0);
-        \draw[tn leg] (tnDn.east) -- ++(0.75,0);
-        \draw[tn phys leg] (tnUp.south) -- (tnDn.north);
+        \TN@tensor{tnUp}{(0,0.44)}
+        \TN@tensor{tnDn}{(0,-0.44)}
+        \TN@vleg{tnUp}{west}{-0.75,0}
+        \TN@vleg{tnDn}{west}{-0.75,0}
+        \TN@vleg{tnUp}{east}{0.75,0}
+        \TN@vleg{tnDn}{east}{0.75,0}
+        \TN@pconnect{tnUp}{south}{tnDn}{north}
         \node at (-1.18,0) {$X$};
         \node at (1.36,0) {$\E_{#1}(X)$};
         \node at ($(tnUp.south)!0.5!(tnDn.north)+(0.24,0)$) {$i$};
@@ -96,19 +120,21 @@
 
 \newcommand{\TNMPOCell}[3]{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{tnM}{(0,0)}
-        \TN@leftleg{tnM}{0.8}
-        \TN@rightleg{tnM}{0.8}
-        \TN@upleg{tnM}{\TN@physleglen}
-        \TN@downleg{tnM}{\TN@physleglen}
+        \TN@tensor{tnM}{(0,0)}
+        \TN@vleg{tnM}{west}{-0.8,0}
+        \TN@vleg{tnM}{east}{0.8,0}
+        \TN@pleg{tnM}{north}{0,\TN@physleglen}
+        \TN@pleg{tnM}{south}{0,-\TN@physleglen}
         \TN@uplabel{tnM}{\TN@physlabeloff}{#2}
         \TN@downlabel{tnM}{\TN@physlabeloff}{#3}
+        \node[anchor=north west] at ($(tnM.south east)+(0.12,-0.18)$) {$#1$};
     \end{tikzpicture}%
 }
 
 \newcommand{\TNMPOChain}[6]{%
     \begin{tikzpicture}[tn picture]
         \TN@openMPOword{tn}{#2}{#3}{#4}{#5}{#6}
+        \node[anchor=east] at (-0.85,0) {$#1$};
     \end{tikzpicture}%
 }
 
@@ -117,24 +143,23 @@
 % and virtual legs.
 \newcommand{\TNMPOLocalPurification}{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{tnM}{(-2.35,0)}
-        \TN@leftleg{tnM}{0.62}
-        \TN@rightleg{tnM}{0.62}
-        \TN@upleg{tnM}{0.58}
-        \TN@downleg{tnM}{0.58}
+        \TN@tensor{tnM}{(-2.35,0)}
+        \TN@vleg{tnM}{west}{-0.62,0}
+        \TN@vleg{tnM}{east}{0.62,0}
+        \TN@pleg{tnM}{north}{0,0.58}
+        \TN@pleg{tnM}{south}{0,-0.58}
         \node at (-2.35,-0.34) {$M$};
         \node at (-1.20,0) {$=$};
-        \TN@tensordot{tnA}{(0,0.52)}
-        \TN@tensordot{tnAc}{(0,-0.52)}
-        \draw[tn leg] (tnA.west) -- ++(-0.62,0);
-        \draw[tn leg] (tnA.east) -- ++(0.62,0);
-        \draw[tn leg] (tnAc.west) -- ++(-0.62,0);
-        \draw[tn leg] (tnAc.east) -- ++(0.62,0);
-        \TN@upleg{tnA}{0.48}
-        \TN@downleg{tnAc}{0.48}
-        \draw[tn purification contraction]
-            (tnA.south east) .. controls (0.88,0.42) and (0.88,-0.42) ..
-            (tnAc.north east);
+        \TN@tensor{tnA}{(0,0.52)}
+        \TN@tensor{tnAc}{(0,-0.52)}
+        \TN@vleg{tnA}{west}{-0.62,0}
+        \TN@vleg{tnA}{east}{0.62,0}
+        \TN@vleg{tnAc}{west}{-0.62,0}
+        \TN@vleg{tnAc}{east}{0.62,0}
+        \TN@pleg{tnA}{north}{0,0.48}
+        \TN@pleg{tnAc}{south}{0,-0.48}
+        \TN@ppath{
+            (tnA.-35) .. controls (0.88,0.42) and (0.88,-0.42) .. (tnAc.35);}
         \node at (-0.28,0.82) {$A$};
         \node at (-0.32,-0.82) {$\overline A$};
         \node at (0.95,0) {$k$};
@@ -144,41 +169,41 @@
 % The physical renormalization maps of the mixed-state RFP definition.
 \newcommand{\TNMPORenormalizationTS}{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{tnOne}{(-2.10,0)}
-        \TN@leftleg{tnOne}{0.62}
-        \TN@rightleg{tnOne}{0.62}
-        \TN@upleg{tnOne}{0.55}
-        \TN@downleg{tnOne}{0.55}
+        \TN@tensor{tnOne}{(-2.10,0)}
+        \TN@vleg{tnOne}{west}{-0.62,0}
+        \TN@vleg{tnOne}{east}{0.62,0}
+        \TN@pleg{tnOne}{north}{0,0.55}
+        \TN@pleg{tnOne}{south}{0,-0.55}
         \node at (-2.10,-0.88) {$M_1(X)$};
-        \TN@tensordot{tnTwoL}{(1.10,0)}
-        \TN@tensordot{tnTwoR}{(2.25,0)}
-        \draw[tn leg] (tnTwoL.west) -- ++(-0.62,0);
-        \draw[tn leg] (tnTwoL.east) -- (tnTwoR.west);
-        \draw[tn leg] (tnTwoR.east) -- ++(0.62,0);
-        \TN@upleg{tnTwoL}{0.55}
-        \TN@downleg{tnTwoL}{0.55}
-        \TN@upleg{tnTwoR}{0.55}
-        \TN@downleg{tnTwoR}{0.55}
+        \TN@tensor{tnTwoL}{(1.10,0)}
+        \TN@tensor{tnTwoR}{(2.25,0)}
+        \TN@vleg{tnTwoL}{west}{-0.62,0}
+        \TN@vconnect{tnTwoL}{east}{tnTwoR}{west}
+        \TN@vleg{tnTwoR}{east}{0.62,0}
+        \TN@pleg{tnTwoL}{north}{0,0.55}
+        \TN@pleg{tnTwoL}{south}{0,-0.55}
+        \TN@pleg{tnTwoR}{north}{0,0.55}
+        \TN@pleg{tnTwoR}{south}{0,-0.55}
         \node at (1.68,-0.88) {$M_2(X)$};
-        \draw[->, line width=0.55pt, bend left=24]
-            (-1.40,0.48) to node[above] {$\mathcal T$} (0.52,0.48);
-        \draw[->, line width=0.55pt, bend left=24]
-            (0.52,-0.48) to node[below] {$\mathcal S$} (-1.40,-0.48);
+        \TN@arrow[->, line width=0.55pt, bend left=24]{
+            (-1.40,0.48) to node[above] {$\mathcal T$} (0.52,0.48);}
+        \TN@arrow[->, line width=0.55pt, bend left=24]{
+            (0.52,-0.48) to node[below] {$\mathcal S$} (-1.40,-0.48);}
     \end{tikzpicture}%
 }
 
 % Contraction of neighbouring right and left sector tensors.
 \newcommand{\TNEtaSectorDecomposition}{%
     \begin{tikzpicture}[tn picture]
-        \node[tn tensor box, minimum width=0.52cm, minimum height=0.38cm,
-            inner sep=1pt] (tnRh) at (-0.56,0) {$r_k$};
-        \node[tn tensor box, minimum width=0.52cm, minimum height=0.38cm,
-            inner sep=1pt] (tnLk) at (0.56,0) {$l_h$};
-        \draw[tn leg] (tnRh.east) -- (tnLk.west);
-        \TN@upleg{tnRh}{0.50}
-        \TN@downleg{tnRh}{0.50}
-        \TN@upleg{tnLk}{0.50}
-        \TN@downleg{tnLk}{0.50}
+        \TN@factor[minimum width=0.52cm, minimum height=0.38cm,
+            inner sep=1pt]{tnRh}{(-0.56,0)}{r_k}
+        \TN@factor[minimum width=0.52cm, minimum height=0.38cm,
+            inner sep=1pt]{tnLk}{(0.56,0)}{l_h}
+        \TN@vconnect{tnRh}{east}{tnLk}{west}
+        \TN@pleg{tnRh}{north}{0,0.50}
+        \TN@pleg{tnRh}{south}{0,-0.50}
+        \TN@pleg{tnLk}{north}{0,0.50}
+        \TN@pleg{tnLk}{south}{0,-0.50}
         \node at (0,-0.80) {$\eta_{k,h}=r_k l_h$};
     \end{tikzpicture}%
 }
@@ -190,40 +215,40 @@
 \newcommand{\TNMPDOTwoSiteTraceAndShift}{%
     \begin{tikzpicture}[tn picture, scale=0.72]
         \node[anchor=east] at (-3.72,1.18) {$\mathcal T_0:$};
-        \TN@subspinbox{tzeroLk}{(-3.15,1.18)}{l_k}
-        \TN@subspinbox{tzeroRk}{(-2.15,1.18)}{r_k}
-        \TN@subspinbox{tzeroLh}{(-1.15,1.18)}{l_h}
-        \TN@subspinbox{tzeroRh}{(-0.15,1.18)}{r_h}
-        \TN@subspinlink{tzeroLk}{tzeroRk}
-        \TN@subspinlink{tzeroRk}{tzeroLh}
-        \TN@subspinlink{tzeroLh}{tzeroRh}
-        \draw[tn grouping boundary]
-            (-2.62,0.68) rectangle (-0.68,1.68);
+        \TN@factorwithlegs{tzeroLk}{(-3.15,1.18)}{l_k}
+        \TN@factorwithlegs{tzeroRk}{(-2.15,1.18)}{r_k}
+        \TN@factorwithlegs{tzeroLh}{(-1.15,1.18)}{l_h}
+        \TN@factorwithlegs{tzeroRh}{(-0.15,1.18)}{r_h}
+        \TN@vconnect{tzeroLk}{east}{tzeroRk}{west}
+        \TN@vconnect{tzeroRk}{east}{tzeroLh}{west}
+        \TN@vconnect{tzeroLh}{east}{tzeroRh}{west}
+        \TN@vpath[tn grouping region]{
+            (-2.62,0.68) rectangle (-0.68,1.68);}
         \node at (-1.65,0.44) {$\tr_{R_k\otimes L_h}$};
-        \draw[->, line width=0.55pt] (0.52,1.18) -- (1.32,1.18);
-        \TN@subspinbox{tzeroOutL}{(1.88,1.18)}{l_k}
-        \TN@subspinbox{tzeroOutR}{(2.88,1.18)}{r_h}
-        \TN@subspinlink{tzeroOutL}{tzeroOutR}
+        \TN@arrow[->, line width=0.55pt]{ (0.52,1.18) -- (1.32,1.18);}
+        \TN@factorwithlegs{tzeroOutL}{(1.88,1.18)}{l_k}
+        \TN@factorwithlegs{tzeroOutR}{(2.88,1.18)}{r_h}
+        \TN@vconnect{tzeroOutL}{east}{tzeroOutR}{west}
 
         \node[anchor=east] at (-3.72,-1.18) {$\mathcal S_2:$};
-        \draw[tn factor boundary] (-3.42,-1.72) rectangle (-1.38,-0.64);
-        \TN@subspinbox{sTwoLk}{(-2.90,-1.18)}{l_k}
-        \TN@subspinbox{sTwoRh}{(-1.90,-1.18)}{r_h}
-        \TN@subspinlink{sTwoLk}{sTwoRh}
+        \TN@vpath[tn factor region]{ (-3.42,-1.72) rectangle (-1.38,-0.64);}
+        \TN@factorwithlegs{sTwoLk}{(-2.90,-1.18)}{l_k}
+        \TN@factorwithlegs{sTwoRh}{(-1.90,-1.18)}{r_h}
+        \TN@vconnect{sTwoLk}{east}{sTwoRh}{west}
         \node at (-1.00,-1.18) {$\otimes$};
-        \draw[tn factor boundary] (-0.60,-1.72) rectangle (1.44,-0.64);
-        \TN@subspinbox{sTwoRk}{(-0.08,-1.18)}{r_k}
-        \TN@subspinbox{sTwoLh}{(0.92,-1.18)}{l_h}
-        \TN@subspinlink{sTwoRk}{sTwoLh}
-        \draw[->, line width=0.55pt] (1.72,-1.18) -- (2.52,-1.18);
+        \TN@vpath[tn factor region]{ (-0.60,-1.72) rectangle (1.44,-0.64);}
+        \TN@factorwithlegs{sTwoRk}{(-0.08,-1.18)}{r_k}
+        \TN@factorwithlegs{sTwoLh}{(0.92,-1.18)}{l_h}
+        \TN@vconnect{sTwoRk}{east}{sTwoLh}{west}
+        \TN@arrow[->, line width=0.55pt]{ (1.72,-1.18) -- (2.52,-1.18);}
         \begin{scope}[xshift=5.98cm]
-            \TN@subspinbox{sTwoOutLk}{(-3.15,-1.18)}{l_k}
-            \TN@subspinbox{sTwoOutRk}{(-2.15,-1.18)}{r_k}
-            \TN@subspinbox{sTwoOutLh}{(-1.15,-1.18)}{l_h}
-            \TN@subspinbox{sTwoOutRh}{(-0.15,-1.18)}{r_h}
-            \TN@subspinlink{sTwoOutLk}{sTwoOutRk}
-            \TN@subspinlink{sTwoOutRk}{sTwoOutLh}
-            \TN@subspinlink{sTwoOutLh}{sTwoOutRh}
+            \TN@factorwithlegs{sTwoOutLk}{(-3.15,-1.18)}{l_k}
+            \TN@factorwithlegs{sTwoOutRk}{(-2.15,-1.18)}{r_k}
+            \TN@factorwithlegs{sTwoOutLh}{(-1.15,-1.18)}{l_h}
+            \TN@factorwithlegs{sTwoOutRh}{(-0.15,-1.18)}{r_h}
+            \TN@vconnect{sTwoOutLk}{east}{sTwoOutRk}{west}
+            \TN@vconnect{sTwoOutRk}{east}{sTwoOutLh}{west}
+            \TN@vconnect{sTwoOutLh}{east}{sTwoOutRh}{west}
         \end{scope}
         \node at (-1.99,-2.03) {outer factors};
         \node at (0.42,-2.03) {neighbouring factors};
@@ -236,53 +261,53 @@
 \newcommand{\TNMPDOThreeSiteTraceAndShift}{%
     \begin{tikzpicture}[tn picture, scale=0.67]
         \node[anchor=east] at (-4.70,1.35) {$\mathcal S_0:$};
-        \TN@subspinbox{szeroLk}{(-4.10,1.35)}{l_k}
-        \TN@subspinbox{szeroRk}{(-3.10,1.35)}{r_k}
-        \TN@subspinbox{szeroLl}{(-2.10,1.35)}{l_l}
-        \TN@subspinbox{szeroRl}{(-1.10,1.35)}{r_l}
-        \TN@subspinbox{szeroLh}{(-0.10,1.35)}{l_h}
-        \TN@subspinbox{szeroRh}{(0.90,1.35)}{r_h}
-        \TN@subspinlink{szeroLk}{szeroRk}
-        \TN@subspinlink{szeroRk}{szeroLl}
-        \TN@subspinlink{szeroLl}{szeroRl}
-        \TN@subspinlink{szeroRl}{szeroLh}
-        \TN@subspinlink{szeroLh}{szeroRh}
-        \draw[tn grouping boundary]
-            (-3.57,0.84) rectangle (0.37,1.86);
+        \TN@factorwithlegs{szeroLk}{(-4.10,1.35)}{l_k}
+        \TN@factorwithlegs{szeroRk}{(-3.10,1.35)}{r_k}
+        \TN@factorwithlegs{szeroLl}{(-2.10,1.35)}{l_l}
+        \TN@factorwithlegs{szeroRl}{(-1.10,1.35)}{r_l}
+        \TN@factorwithlegs{szeroLh}{(-0.10,1.35)}{l_h}
+        \TN@factorwithlegs{szeroRh}{(0.90,1.35)}{r_h}
+        \TN@vconnect{szeroLk}{east}{szeroRk}{west}
+        \TN@vconnect{szeroRk}{east}{szeroLl}{west}
+        \TN@vconnect{szeroLl}{east}{szeroRl}{west}
+        \TN@vconnect{szeroRl}{east}{szeroLh}{west}
+        \TN@vconnect{szeroLh}{east}{szeroRh}{west}
+        \TN@vpath[tn grouping region]{
+            (-3.57,0.84) rectangle (0.37,1.86);}
         \node at (-1.60,0.50)
             {$\tr_{\bigoplus_l[(R_k\otimes L_l)\otimes(R_l\otimes L_h)]}$};
-        \draw[->, line width=0.55pt] (1.58,1.35) -- (2.38,1.35);
-        \TN@subspinbox{szeroOutL}{(2.94,1.35)}{l_k}
-        \TN@subspinbox{szeroOutR}{(3.94,1.35)}{r_h}
-        \TN@subspinlink{szeroOutL}{szeroOutR}
+        \TN@arrow[->, line width=0.55pt]{ (1.58,1.35) -- (2.38,1.35);}
+        \TN@factorwithlegs{szeroOutL}{(2.94,1.35)}{l_k}
+        \TN@factorwithlegs{szeroOutR}{(3.94,1.35)}{r_h}
+        \TN@vconnect{szeroOutL}{east}{szeroOutR}{west}
 
         \node[anchor=east] at (-4.70,-1.35) {$\mathcal T_2:$};
-        \draw[tn factor boundary] (-4.37,-1.90) rectangle (-2.33,-0.80);
-        \TN@subspinbox{tTwoLk}{(-3.85,-1.35)}{l_k}
-        \TN@subspinbox{tTwoRh}{(-2.85,-1.35)}{r_h}
-        \TN@subspinlink{tTwoLk}{tTwoRh}
+        \TN@vpath[tn factor region]{ (-4.37,-1.90) rectangle (-2.33,-0.80);}
+        \TN@factorwithlegs{tTwoLk}{(-3.85,-1.35)}{l_k}
+        \TN@factorwithlegs{tTwoRh}{(-2.85,-1.35)}{r_h}
+        \TN@vconnect{tTwoLk}{east}{tTwoRh}{west}
         \node at (-1.96,-1.35) {$\otimes$};
-        \draw[tn factor boundary] (-1.55,-1.90) rectangle (2.42,-0.80);
-        \TN@subspinbox{tTwoRk}{(-1.03,-1.35)}{r_k}
-        \TN@subspinbox{tTwoLl}{(-0.03,-1.35)}{l_l}
-        \TN@subspinbox{tTwoRl}{(0.97,-1.35)}{r_l}
-        \TN@subspinbox{tTwoLh}{(1.97,-1.35)}{l_h}
-        \TN@subspinlink{tTwoRk}{tTwoLl}
-        \TN@subspinlink{tTwoLl}{tTwoRl}
-        \TN@subspinlink{tTwoRl}{tTwoLh}
-        \draw[->, line width=0.55pt] (2.68,-1.35) -- (3.48,-1.35);
+        \TN@vpath[tn factor region]{ (-1.55,-1.90) rectangle (2.42,-0.80);}
+        \TN@factorwithlegs{tTwoRk}{(-1.03,-1.35)}{r_k}
+        \TN@factorwithlegs{tTwoLl}{(-0.03,-1.35)}{l_l}
+        \TN@factorwithlegs{tTwoRl}{(0.97,-1.35)}{r_l}
+        \TN@factorwithlegs{tTwoLh}{(1.97,-1.35)}{l_h}
+        \TN@vconnect{tTwoRk}{east}{tTwoLl}{west}
+        \TN@vconnect{tTwoLl}{east}{tTwoRl}{west}
+        \TN@vconnect{tTwoRl}{east}{tTwoLh}{west}
+        \TN@arrow[->, line width=0.55pt]{ (2.68,-1.35) -- (3.48,-1.35);}
         \begin{scope}[xshift=7.90cm]
-            \TN@subspinbox{tTwoOutLk}{(-4.10,-1.35)}{l_k}
-            \TN@subspinbox{tTwoOutRk}{(-3.10,-1.35)}{r_k}
-            \TN@subspinbox{tTwoOutLl}{(-2.10,-1.35)}{l_l}
-            \TN@subspinbox{tTwoOutRl}{(-1.10,-1.35)}{r_l}
-            \TN@subspinbox{tTwoOutLh}{(-0.10,-1.35)}{l_h}
-            \TN@subspinbox{tTwoOutRh}{(0.90,-1.35)}{r_h}
-            \TN@subspinlink{tTwoOutLk}{tTwoOutRk}
-            \TN@subspinlink{tTwoOutRk}{tTwoOutLl}
-            \TN@subspinlink{tTwoOutLl}{tTwoOutRl}
-            \TN@subspinlink{tTwoOutRl}{tTwoOutLh}
-            \TN@subspinlink{tTwoOutLh}{tTwoOutRh}
+            \TN@factorwithlegs{tTwoOutLk}{(-4.10,-1.35)}{l_k}
+            \TN@factorwithlegs{tTwoOutRk}{(-3.10,-1.35)}{r_k}
+            \TN@factorwithlegs{tTwoOutLl}{(-2.10,-1.35)}{l_l}
+            \TN@factorwithlegs{tTwoOutRl}{(-1.10,-1.35)}{r_l}
+            \TN@factorwithlegs{tTwoOutLh}{(-0.10,-1.35)}{l_h}
+            \TN@factorwithlegs{tTwoOutRh}{(0.90,-1.35)}{r_h}
+            \TN@vconnect{tTwoOutLk}{east}{tTwoOutRk}{west}
+            \TN@vconnect{tTwoOutRk}{east}{tTwoOutLl}{west}
+            \TN@vconnect{tTwoOutLl}{east}{tTwoOutRl}{west}
+            \TN@vconnect{tTwoOutRl}{east}{tTwoOutLh}{west}
+            \TN@vconnect{tTwoOutLh}{east}{tTwoOutRh}{west}
         \end{scope}
         \node at (-3.35,-2.24) {outer factors};
         \node at (0.44,-2.24) {$\Omega_{k,h}=\bigoplus_l(\cdots)$};
@@ -296,41 +321,41 @@
     \begin{tikzpicture}[tn picture, scale=0.85]
         \node[anchor=east] at (-5.35,2.45) {$\mathfrak R_2:$};
         \node[anchor=east] at (-4.30,2.45) {$\displaystyle\bigoplus_{k,h}$};
-        \TN@subspinbox{trefTopLk}{(-3.72,2.45)}{l_k}
-        \TN@subspinbox{trefTopRk}{(-2.72,2.45)}{r_k}
-        \TN@subspinbox{trefTopLh}{(-1.72,2.45)}{l_h}
-        \TN@subspinbox{trefTopRh}{(-0.72,2.45)}{r_h}
-        \TN@subspinlink{trefTopLk}{trefTopRk}
-        \TN@subspinlink{trefTopRk}{trefTopLh}
-        \TN@subspinlink{trefTopLh}{trefTopRh}
-        \draw[tn grouping boundary]
-            (-3.25,1.94) rectangle (-1.19,2.96);
+        \TN@factorwithlegs{trefTopLk}{(-3.72,2.45)}{l_k}
+        \TN@factorwithlegs{trefTopRk}{(-2.72,2.45)}{r_k}
+        \TN@factorwithlegs{trefTopLh}{(-1.72,2.45)}{l_h}
+        \TN@factorwithlegs{trefTopRh}{(-0.72,2.45)}{r_h}
+        \TN@vconnect{trefTopLk}{east}{trefTopRk}{west}
+        \TN@vconnect{trefTopRk}{east}{trefTopLh}{west}
+        \TN@vconnect{trefTopLh}{east}{trefTopRh}{west}
+        \TN@vpath[tn grouping region]{
+            (-3.25,1.94) rectangle (-1.19,2.96);}
         \node at (-2.22,1.68) {$\tr_{R_k\otimes L_h}$};
 
-        \draw[->, line width=0.55pt] (2.15,2.18) -- (2.15,1.22)
-            node[midway, right] {$\mathcal T_0$};
+        \TN@arrow[->, line width=0.55pt]{ (2.15,2.18) -- (2.15,1.22)
+            node[midway, right] {$\mathcal T_0$};}
         \node[anchor=east] at (-2.08,0.86)
             {$\displaystyle\bigoplus_{k,h}a_kb_h$};
-        \TN@subspinbox{trefMidLk}{(-1.50,0.86)}{l_k}
-        \TN@subspinbox{trefMidRh}{(-0.50,0.86)}{r_h}
-        \TN@subspinlink{trefMidLk}{trefMidRh}
+        \TN@factorwithlegs{trefMidLk}{(-1.50,0.86)}{l_k}
+        \TN@factorwithlegs{trefMidRh}{(-0.50,0.86)}{r_h}
+        \TN@vconnect{trefMidLk}{east}{trefMidRh}{west}
 
-        \draw[->, line width=0.55pt] (2.15,0.38) -- (2.15,-0.58)
-            node[midway, right] {$\mathcal T_2\mathcal T_1$};
+        \TN@arrow[->, line width=0.55pt]{ (2.15,0.38) -- (2.15,-0.58)
+            node[midway, right] {$\mathcal T_2\mathcal T_1$};}
         \node[anchor=east] at (-5.35,-0.96) {$\mathfrak R_3:$};
         \node[anchor=east] at (-4.30,-0.96)
             {$\displaystyle\bigoplus_{k,h,l}$};
-        \TN@subspinbox{trefBotLk}{(-3.72,-0.96)}{l_k}
-        \TN@subspinbox{trefBotRk}{(-2.72,-0.96)}{r_k}
-        \TN@subspinbox{trefBotLl}{(-1.72,-0.96)}{l_l}
-        \TN@subspinbox{trefBotRl}{(-0.72,-0.96)}{r_l}
-        \TN@subspinbox{trefBotLh}{(0.28,-0.96)}{l_h}
-        \TN@subspinbox{trefBotRh}{(1.28,-0.96)}{r_h}
-        \TN@subspinlink{trefBotLk}{trefBotRk}
-        \TN@subspinlink{trefBotRk}{trefBotLl}
-        \TN@subspinlink{trefBotLl}{trefBotRl}
-        \TN@subspinlink{trefBotRl}{trefBotLh}
-        \TN@subspinlink{trefBotLh}{trefBotRh}
+        \TN@factorwithlegs{trefBotLk}{(-3.72,-0.96)}{l_k}
+        \TN@factorwithlegs{trefBotRk}{(-2.72,-0.96)}{r_k}
+        \TN@factorwithlegs{trefBotLl}{(-1.72,-0.96)}{l_l}
+        \TN@factorwithlegs{trefBotRl}{(-0.72,-0.96)}{r_l}
+        \TN@factorwithlegs{trefBotLh}{(0.28,-0.96)}{l_h}
+        \TN@factorwithlegs{trefBotRh}{(1.28,-0.96)}{r_h}
+        \TN@vconnect{trefBotLk}{east}{trefBotRk}{west}
+        \TN@vconnect{trefBotRk}{east}{trefBotLl}{west}
+        \TN@vconnect{trefBotLl}{east}{trefBotRl}{west}
+        \TN@vconnect{trefBotRl}{east}{trefBotLh}{west}
+        \TN@vconnect{trefBotLh}{east}{trefBotRh}{west}
     \end{tikzpicture}%
 }
 
@@ -338,23 +363,23 @@
 % site counts of the channel; the closure identity belongs to its theorem.
 \newcommand{\TNMPDORefinementDirection}{%
     \begin{tikzpicture}[tn picture, scale=0.85]
-        \TN@subspinbox{trefDirTwoL}{(-2.85,0)}{\mathcal K}
-        \TN@subspinbox{trefDirTwoR}{(-1.75,0)}{\mathcal K}
-        \TN@subspinlink{trefDirTwoL}{trefDirTwoR}
-        \draw[tn leg] (trefDirTwoL.west) -- ++(-0.48,0);
-        \draw[tn leg] (trefDirTwoR.east) -- ++(0.48,0);
+        \TN@factorwithlegs{trefDirTwoL}{(-2.85,0)}{\mathcal K}
+        \TN@factorwithlegs{trefDirTwoR}{(-1.75,0)}{\mathcal K}
+        \TN@vconnect{trefDirTwoL}{east}{trefDirTwoR}{west}
+        \TN@vpath{ (trefDirTwoL.west) -- ++(-0.48,0);}
+        \TN@vpath{ (trefDirTwoR.east) -- ++(0.48,0);}
         \node at (-2.30,-0.92) {$\mathfrak R_2({\cal K}_2(X))$};
 
-        \draw[->, line width=0.65pt, bend left=18]
-            (-0.94,0.28) to node[above] {$\mathcal T$} (0.04,0.28);
+        \TN@arrow[->, line width=0.65pt, bend left=18]{
+            (-0.94,0.28) to node[above] {$\mathcal T$} (0.04,0.28);}
 
-        \TN@subspinbox{trefDirThreeL}{(0.85,0)}{\mathcal K}
-        \TN@subspinbox{trefDirThreeM}{(1.95,0)}{\mathcal K}
-        \TN@subspinbox{trefDirThreeR}{(3.05,0)}{\mathcal K}
-        \TN@subspinlink{trefDirThreeL}{trefDirThreeM}
-        \TN@subspinlink{trefDirThreeM}{trefDirThreeR}
-        \draw[tn leg] (trefDirThreeL.west) -- ++(-0.48,0);
-        \draw[tn leg] (trefDirThreeR.east) -- ++(0.48,0);
+        \TN@factorwithlegs{trefDirThreeL}{(0.85,0)}{\mathcal K}
+        \TN@factorwithlegs{trefDirThreeM}{(1.95,0)}{\mathcal K}
+        \TN@factorwithlegs{trefDirThreeR}{(3.05,0)}{\mathcal K}
+        \TN@vconnect{trefDirThreeL}{east}{trefDirThreeM}{west}
+        \TN@vconnect{trefDirThreeM}{east}{trefDirThreeR}{west}
+        \TN@vpath{ (trefDirThreeL.west) -- ++(-0.48,0);}
+        \TN@vpath{ (trefDirThreeR.east) -- ++(0.48,0);}
         \node at (1.95,-0.92) {$\mathfrak R_3({\cal K}_3(X))$};
     \end{tikzpicture}%
 }
@@ -365,64 +390,64 @@
 \newcommand{\TNMPDOBlockedRFPChannels}{%
     \begin{tikzpicture}[tn picture, scale=0.72]
         \foreach \x/\name in {-5.0/btTwoA,-4.0/btTwoB} {
-            \TN@subspinbox{\name}{(\x,1.35)}{\widehat{\cal K}}
+            \TN@factorwithlegs{\name}{(\x,1.35)}{\widehat{\cal K}}
         }
-        \TN@subspinlink{btTwoA}{btTwoB}
-        \draw[tn grouping boundary]
-            (-5.48,0.87) rectangle (-3.52,1.83);
+        \TN@vconnect{btTwoA}{east}{btTwoB}{west}
+        \TN@vpath[tn grouping region]{
+            (-5.48,0.87) rectangle (-3.52,1.83);}
         \node at (-4.50,0.54) {one blocked site};
 
         \foreach \x/\name in {-1.4/btThreeA,-0.4/btThreeB,0.6/btThreeC} {
-            \TN@subspinbox{\name}{(\x,1.35)}{\widehat{\cal K}}
+            \TN@factorwithlegs{\name}{(\x,1.35)}{\widehat{\cal K}}
         }
-        \TN@subspinlink{btThreeA}{btThreeB}
-        \TN@subspinlink{btThreeB}{btThreeC}
+        \TN@vconnect{btThreeA}{east}{btThreeB}{west}
+        \TN@vconnect{btThreeB}{east}{btThreeC}{west}
 
         \foreach \x/\name in {3.0/btFourA,4.0/btFourB,5.0/btFourC,6.0/btFourD} {
-            \TN@subspinbox{\name}{(\x,1.35)}{\widehat{\cal K}}
+            \TN@factorwithlegs{\name}{(\x,1.35)}{\widehat{\cal K}}
         }
-        \TN@subspinlink{btFourA}{btFourB}
-        \TN@subspinlink{btFourB}{btFourC}
-        \TN@subspinlink{btFourC}{btFourD}
-        \draw[tn grouping boundary]
-            (2.52,0.87) rectangle (4.48,1.83);
-        \draw[tn grouping boundary]
-            (4.52,0.87) rectangle (6.48,1.83);
+        \TN@vconnect{btFourA}{east}{btFourB}{west}
+        \TN@vconnect{btFourB}{east}{btFourC}{west}
+        \TN@vconnect{btFourC}{east}{btFourD}{west}
+        \TN@vpath[tn grouping region]{
+            (2.52,0.87) rectangle (4.48,1.83);}
+        \TN@vpath[tn grouping region]{
+            (4.52,0.87) rectangle (6.48,1.83);}
         \node at (4.50,0.54) {two blocked sites};
 
-        \draw[->, line width=0.60pt] (-3.22,1.35) -- (-1.88,1.35)
-            node[midway, above] {$\widehat{\mathcal T}$};
-        \draw[->, line width=0.60pt] (1.08,1.35) -- (2.52,1.35)
-            node[midway, above] {$\widehat{\mathcal T}_{(12)3}$};
+        \TN@arrow[->, line width=0.60pt]{ (-3.22,1.35) -- (-1.88,1.35)
+            node[midway, above] {$\widehat{\mathcal T}$};}
+        \TN@arrow[->, line width=0.60pt]{ (1.08,1.35) -- (2.52,1.35)
+            node[midway, above] {$\widehat{\mathcal T}_{(12)3}$};}
         \node at (0.50,2.25)
             {$\widehat{\mathcal T}^2:\widehat{\cal K}_2(X)
               \longmapsto\widehat{\cal K}_4(X)$};
 
         \foreach \x/\name in {3.0/bsFourA,4.0/bsFourB,5.0/bsFourC,6.0/bsFourD} {
-            \TN@subspinbox{\name}{(\x,-1.30)}{\widehat{\cal K}}
+            \TN@factorwithlegs{\name}{(\x,-1.30)}{\widehat{\cal K}}
         }
-        \TN@subspinlink{bsFourA}{bsFourB}
-        \TN@subspinlink{bsFourB}{bsFourC}
-        \TN@subspinlink{bsFourC}{bsFourD}
-        \draw[tn grouping boundary]
-            (2.52,-1.78) rectangle (4.48,-0.82);
-        \draw[tn grouping boundary]
-            (4.52,-1.78) rectangle (6.48,-0.82);
+        \TN@vconnect{bsFourA}{east}{bsFourB}{west}
+        \TN@vconnect{bsFourB}{east}{bsFourC}{west}
+        \TN@vconnect{bsFourC}{east}{bsFourD}{west}
+        \TN@vpath[tn grouping region]{
+            (2.52,-1.78) rectangle (4.48,-0.82);}
+        \TN@vpath[tn grouping region]{
+            (4.52,-1.78) rectangle (6.48,-0.82);}
         \foreach \x/\name in {-1.4/bsThreeA,-0.4/bsThreeB,0.6/bsThreeC} {
-            \TN@subspinbox{\name}{(\x,-1.30)}{\widehat{\cal K}}
+            \TN@factorwithlegs{\name}{(\x,-1.30)}{\widehat{\cal K}}
         }
-        \TN@subspinlink{bsThreeA}{bsThreeB}
-        \TN@subspinlink{bsThreeB}{bsThreeC}
+        \TN@vconnect{bsThreeA}{east}{bsThreeB}{west}
+        \TN@vconnect{bsThreeB}{east}{bsThreeC}{west}
         \foreach \x/\name in {-5.0/bsTwoA,-4.0/bsTwoB} {
-            \TN@subspinbox{\name}{(\x,-1.30)}{\widehat{\cal K}}
+            \TN@factorwithlegs{\name}{(\x,-1.30)}{\widehat{\cal K}}
         }
-        \TN@subspinlink{bsTwoA}{bsTwoB}
-        \draw[tn grouping boundary]
-            (-5.48,-1.78) rectangle (-3.52,-0.82);
-        \draw[<-, line width=0.60pt] (1.08,-1.30) -- (2.52,-1.30)
-            node[midway, above] {$\widehat{\mathcal S}_{(123)4}$};
-        \draw[<-, line width=0.60pt] (-3.22,-1.30) -- (-1.88,-1.30)
-            node[midway, above] {$\widehat{\mathcal S}$};
+        \TN@vconnect{bsTwoA}{east}{bsTwoB}{west}
+        \TN@vpath[tn grouping region]{
+            (-5.48,-1.78) rectangle (-3.52,-0.82);}
+        \TN@arrow[<-, line width=0.60pt]{ (1.08,-1.30) -- (2.52,-1.30)
+            node[midway, above] {$\widehat{\mathcal S}_{(123)4}$};}
+        \TN@arrow[<-, line width=0.60pt]{ (-3.22,-1.30) -- (-1.88,-1.30)
+            node[midway, above] {$\widehat{\mathcal S}$};}
         \node at (0.50,-2.20)
             {$\widehat{\mathcal S}^2:\widehat{\cal K}_4(X)
               \longmapsto\widehat{\cal K}_2(X)$};
@@ -436,64 +461,64 @@
 \newcommand{\TNMPDOPhysicalIsometryTransport}{%
     \begin{tikzpicture}[tn picture, scale=0.64]
         \foreach \x/\name in {-5.0/ptRawTwoA,-4.0/ptRawTwoB} {
-            \TN@subspinbox{\name}{(\x,1.45)}{\cal K}
+            \TN@factorwithlegs{\name}{(\x,1.45)}{\cal K}
         }
-        \TN@subspinlink{ptRawTwoA}{ptRawTwoB}
-        \draw[tn grouping boundary]
-            (-5.48,0.97) rectangle (-3.52,1.93);
+        \TN@vconnect{ptRawTwoA}{east}{ptRawTwoB}{west}
+        \TN@vpath[tn grouping region]{
+            (-5.48,0.97) rectangle (-3.52,1.93);}
         \node at (-4.50,2.27) {${\cal K}_2(X)$};
 
         \foreach \x/\name in {3.0/ptRawFourA,4.0/ptRawFourB,
                 5.0/ptRawFourC,6.0/ptRawFourD} {
-            \TN@subspinbox{\name}{(\x,1.45)}{\cal K}
+            \TN@factorwithlegs{\name}{(\x,1.45)}{\cal K}
         }
-        \TN@subspinlink{ptRawFourA}{ptRawFourB}
-        \TN@subspinlink{ptRawFourB}{ptRawFourC}
-        \TN@subspinlink{ptRawFourC}{ptRawFourD}
-        \draw[tn grouping boundary]
-            (2.52,0.97) rectangle (4.48,1.93);
-        \draw[tn grouping boundary]
-            (4.52,0.97) rectangle (6.48,1.93);
+        \TN@vconnect{ptRawFourA}{east}{ptRawFourB}{west}
+        \TN@vconnect{ptRawFourB}{east}{ptRawFourC}{west}
+        \TN@vconnect{ptRawFourC}{east}{ptRawFourD}{west}
+        \TN@vpath[tn grouping region]{
+            (2.52,0.97) rectangle (4.48,1.93);}
+        \TN@vpath[tn grouping region]{
+            (4.52,0.97) rectangle (6.48,1.93);}
         \node at (4.50,2.27) {${\cal K}_4(X)$};
 
         \foreach \x/\name in {-5.0/ptHatTwoA,-4.0/ptHatTwoB} {
-            \TN@subspinbox{\name}{(\x,-1.45)}{\widehat{\cal K}}
+            \TN@factorwithlegs{\name}{(\x,-1.45)}{\widehat{\cal K}}
         }
-        \TN@subspinlink{ptHatTwoA}{ptHatTwoB}
-        \draw[tn grouping boundary]
-            (-5.48,-1.93) rectangle (-3.52,-0.97);
+        \TN@vconnect{ptHatTwoA}{east}{ptHatTwoB}{west}
+        \TN@vpath[tn grouping region]{
+            (-5.48,-1.93) rectangle (-3.52,-0.97);}
         \node at (-4.50,-2.27) {$\widehat{\cal K}_2(X)$};
 
         \foreach \x/\name in {3.0/ptHatFourA,4.0/ptHatFourB,
                 5.0/ptHatFourC,6.0/ptHatFourD} {
-            \TN@subspinbox{\name}{(\x,-1.45)}{\widehat{\cal K}}
+            \TN@factorwithlegs{\name}{(\x,-1.45)}{\widehat{\cal K}}
         }
-        \TN@subspinlink{ptHatFourA}{ptHatFourB}
-        \TN@subspinlink{ptHatFourB}{ptHatFourC}
-        \TN@subspinlink{ptHatFourC}{ptHatFourD}
-        \draw[tn grouping boundary]
-            (2.52,-1.93) rectangle (4.48,-0.97);
-        \draw[tn grouping boundary]
-            (4.52,-1.93) rectangle (6.48,-0.97);
+        \TN@vconnect{ptHatFourA}{east}{ptHatFourB}{west}
+        \TN@vconnect{ptHatFourB}{east}{ptHatFourC}{west}
+        \TN@vconnect{ptHatFourC}{east}{ptHatFourD}{west}
+        \TN@vpath[tn grouping region]{
+            (2.52,-1.93) rectangle (4.48,-0.97);}
+        \TN@vpath[tn grouping region]{
+            (4.52,-1.93) rectangle (6.48,-0.97);}
         \node at (4.50,-2.27) {$\widehat{\cal K}_4(X)$};
 
-        \draw[->, line width=0.60pt, bend left=13]
-            (-3.22,1.62) to node[above] {$\mathcal T_{\cal K}^2$} (2.22,1.62);
-        \draw[->, line width=0.60pt, bend left=13]
-            (2.22,1.28) to node[below] {$\mathcal S_{\cal K}^2$} (-3.22,1.28);
-        \draw[->, line width=0.60pt, bend left=13]
-            (-3.22,-1.28) to node[above] {$\widehat{\mathcal T}^2$} (2.22,-1.28);
-        \draw[->, line width=0.60pt, bend left=13]
-            (2.22,-1.62) to node[below] {$\widehat{\mathcal S}^2$} (-3.22,-1.62);
+        \TN@arrow[->, line width=0.60pt, bend left=13]{
+            (-3.22,1.62) to node[above] {$\mathcal T_{\cal K}^2$} (2.22,1.62);}
+        \TN@arrow[->, line width=0.60pt, bend left=13]{
+            (2.22,1.28) to node[below] {$\mathcal S_{\cal K}^2$} (-3.22,1.28);}
+        \TN@arrow[->, line width=0.60pt, bend left=13]{
+            (-3.22,-1.28) to node[above] {$\widehat{\mathcal T}^2$} (2.22,-1.28);}
+        \TN@arrow[->, line width=0.60pt, bend left=13]{
+            (2.22,-1.62) to node[below] {$\widehat{\mathcal S}^2$} (-3.22,-1.62);}
 
-        \draw[->, line width=0.55pt] (-4.64,0.68) -- (-4.64,-0.68)
-            node[midway, left] {$U^{\otimes 2}$};
-        \draw[->, line width=0.55pt] (-4.36,-0.68) -- (-4.36,0.68)
-            node[midway, right] {$(U^\dagger)^{\otimes 2}$};
-        \draw[->, line width=0.55pt] (4.36,0.68) -- (4.36,-0.68)
-            node[midway, left] {$U^{\otimes 4}$};
-        \draw[->, line width=0.55pt] (4.64,-0.68) -- (4.64,0.68)
-            node[midway, right] {$(U^\dagger)^{\otimes 4}$};
+        \TN@arrow[->, line width=0.55pt]{ (-4.64,0.68) -- (-4.64,-0.68)
+            node[midway, left] {$U^{\otimes 2}$};}
+        \TN@arrow[->, line width=0.55pt]{ (-4.36,-0.68) -- (-4.36,0.68)
+            node[midway, right] {$(U^\dagger)^{\otimes 2}$};}
+        \TN@arrow[->, line width=0.55pt]{ (4.36,0.68) -- (4.36,-0.68)
+            node[midway, left] {$U^{\otimes 4}$};}
+        \TN@arrow[->, line width=0.55pt]{ (4.64,-0.68) -- (4.64,0.68)
+            node[midway, right] {$(U^\dagger)^{\otimes 4}$};}
     \end{tikzpicture}%
 }
 
@@ -502,24 +527,24 @@
 % the right-hand side shows only the proved boundary/neighbor tensor product.
 \newcommand{\TNMPDOTwoSiteClosureFactorization}{%
     \begin{tikzpicture}[tn picture, scale=0.50]
-        \TN@subspinbox{ctwoLk}{(-4.40,0.55)}{l_k}
-        \TN@subspinbox{ctwoRk}{(-3.40,0.55)}{r_k}
-        \TN@subspinbox{ctwoLh}{(-2.40,0.55)}{l_h}
-        \TN@subspinbox{ctwoRh}{(-1.40,0.55)}{r_h}
-        \TN@subspinlink{ctwoLk}{ctwoRk}
-        \TN@subspinlink{ctwoRk}{ctwoLh}
-        \TN@subspinlink{ctwoLh}{ctwoRh}
-        \TN@opdotbelow{ctwoX}{(-2.90,-0.95)}{X}
-        \draw[tn virtual closure] (ctwoLk.west)
-          .. controls (-5.05,0.55) and (-5.05,-0.95) .. (ctwoX.west);
-        \draw[tn virtual closure] (ctwoX.east)
-          .. controls (-0.75,-0.95) and (-0.75,0.55) .. (ctwoRh.east);
+        \TN@factorwithlegs{ctwoLk}{(-4.40,0.55)}{l_k}
+        \TN@factorwithlegs{ctwoRk}{(-3.40,0.55)}{r_k}
+        \TN@factorwithlegs{ctwoLh}{(-2.40,0.55)}{l_h}
+        \TN@factorwithlegs{ctwoRh}{(-1.40,0.55)}{r_h}
+        \TN@vconnect{ctwoLk}{east}{ctwoRk}{west}
+        \TN@vconnect{ctwoRk}{east}{ctwoLh}{west}
+        \TN@vconnect{ctwoLh}{east}{ctwoRh}{west}
+        \TN@insertion[label=below:$X$]{ctwoX}{(-2.90,-0.95)}
+        \TN@vtracepath{ (ctwoLk.west)
+          .. controls (-5.05,0.55) and (-5.05,-0.95) .. (ctwoX.west);}
+        \TN@vtracepath{ (ctwoX.east)
+          .. controls (-0.75,-0.95) and (-0.75,0.55) .. (ctwoRh.east);}
         \node at (0.00,0.05) {$=$};
-        \node[tn tensor box, minimum width=2.25cm,
-          minimum height=0.72cm] (ctwoB) at (1.70,0.05) {$B_{k,h}(X)$};
+        \TN@component[minimum width=2.25cm, minimum height=0.72cm]
+            {ctwoB}{(1.70,0.05)}{B_{k,h}(X)}
         \node at (3.20,0.05) {$\otimes$};
-        \node[tn tensor box, minimum width=1.75cm,
-          minimum height=0.72cm] (ctwoEta) at (4.45,0.05) {$\eta_{k,h}$};
+        \TN@factor[minimum width=1.75cm, minimum height=0.72cm]
+            {ctwoEta}{(4.45,0.05)}{\eta_{k,h}}
         \node at (1.70,-0.62) {$L_k\otimes R_h$};
         \node at (4.45,-0.62) {$R_k\otimes L_h$};
     \end{tikzpicture}%
@@ -529,31 +554,31 @@
 % No preparation, positivity, or channel identity is represented.
 \newcommand{\TNMPDOThreeSiteClosureFactorization}{%
     \begin{tikzpicture}[tn picture, scale=0.43]
-        \TN@subspinbox{cthreeLk}{(-5.70,0.62)}{l_k}
-        \TN@subspinbox{cthreeRk}{(-4.70,0.62)}{r_k}
-        \TN@subspinbox{cthreeLl}{(-3.70,0.62)}{l_l}
-        \TN@subspinbox{cthreeRl}{(-2.70,0.62)}{r_l}
-        \TN@subspinbox{cthreeLh}{(-1.70,0.62)}{l_h}
-        \TN@subspinbox{cthreeRh}{(-0.70,0.62)}{r_h}
-        \TN@subspinlink{cthreeLk}{cthreeRk}
-        \TN@subspinlink{cthreeRk}{cthreeLl}
-        \TN@subspinlink{cthreeLl}{cthreeRl}
-        \TN@subspinlink{cthreeRl}{cthreeLh}
-        \TN@subspinlink{cthreeLh}{cthreeRh}
-        \TN@opdotbelow{cthreeX}{(-3.20,-1.00)}{X}
-        \draw[tn virtual closure] (cthreeLk.west)
-          .. controls (-6.35,0.62) and (-6.35,-1.00) .. (cthreeX.west);
-        \draw[tn virtual closure] (cthreeX.east)
-          .. controls (-0.05,-1.00) and (-0.05,0.62) .. (cthreeRh.east);
+        \TN@factorwithlegs{cthreeLk}{(-5.70,0.62)}{l_k}
+        \TN@factorwithlegs{cthreeRk}{(-4.70,0.62)}{r_k}
+        \TN@factorwithlegs{cthreeLl}{(-3.70,0.62)}{l_l}
+        \TN@factorwithlegs{cthreeRl}{(-2.70,0.62)}{r_l}
+        \TN@factorwithlegs{cthreeLh}{(-1.70,0.62)}{l_h}
+        \TN@factorwithlegs{cthreeRh}{(-0.70,0.62)}{r_h}
+        \TN@vconnect{cthreeLk}{east}{cthreeRk}{west}
+        \TN@vconnect{cthreeRk}{east}{cthreeLl}{west}
+        \TN@vconnect{cthreeLl}{east}{cthreeRl}{west}
+        \TN@vconnect{cthreeRl}{east}{cthreeLh}{west}
+        \TN@vconnect{cthreeLh}{east}{cthreeRh}{west}
+        \TN@insertion[label=below:$X$]{cthreeX}{(-3.20,-1.00)}
+        \TN@vtracepath{ (cthreeLk.west)
+          .. controls (-6.35,0.62) and (-6.35,-1.00) .. (cthreeX.west);}
+        \TN@vtracepath{ (cthreeX.east)
+          .. controls (-0.05,-1.00) and (-0.05,0.62) .. (cthreeRh.east);}
         \node at (0.45,0.05) {$=$};
-        \node[tn tensor box, minimum width=2.05cm,
-          minimum height=0.72cm] at (1.85,0.05) {$B_{k,h}(X)$};
+        \TN@component[minimum width=2.05cm, minimum height=0.72cm]
+            {cthreeB}{(1.85,0.05)}{B_{k,h}(X)}
         \node at (3.15,0.05) {$\otimes$};
-        \node[tn tensor box, minimum width=1.65cm,
-          minimum height=0.72cm] at (4.20,0.05) {$\eta_{k,l}$};
+        \TN@factor[minimum width=1.65cm, minimum height=0.72cm]
+            {cthreeEtaKL}{(4.20,0.05)}{\eta_{k,l}}
         \node at (5.25,0.05) {$\otimes$};
-        \node[tn tensor box, minimum width=1.65cm,
-          minimum height=0.72cm] at (6.30,0.05) {$\eta_{l,h}$};
+        \TN@factor[minimum width=1.65cm, minimum height=0.72cm]
+            {cthreeEtaLH}{(6.30,0.05)}{\eta_{l,h}}
         \node at (1.85,-0.65) {$L_k\otimes R_h$};
         \node at (5.25,-0.65)
           {$(R_k\otimes L_l)\otimes(R_l\otimes L_h)$};
@@ -566,24 +591,38 @@
 % pairs R_k \otimes L_l and R_l \otimes L_h.
 \newcommand{\TNMPDOFixedSectorAdjacentCommutativity}{%
     \begin{tikzpicture}[tn picture, scale=0.78]
-        \foreach \x in {-5.25,-4.45,-3.65,-2.85,-2.05,-1.25,
-                        1.25,2.05,2.85,3.65,4.45,5.25} {
-            \draw[tn leg] (\x,-1.12) -- (\x,1.12);
+        % The four outer factors do not meet an operator in this comparison.
+        \foreach \x in {-5.25,-1.25,1.25,5.25} {
+            \TN@vpath{ (\x,-1.12) -- (\x,1.12);}
         }
 
-        \node[tn tensor box, minimum width=1.38cm,
-            minimum height=0.48cm, inner sep=1pt]
-            at (-4.05,0.38) {$\eta_{k,l}$};
-        \node[tn tensor box, minimum width=1.38cm,
-            minimum height=0.48cm, inner sep=1pt]
-            at (-2.45,-0.38) {$\eta_{l,h}$};
+        \TN@factor[minimum width=1.38cm, minimum height=0.48cm,
+            inner sep=1pt]{commEtaKLLeft}{(-4.05,0.38)}{\eta_{k,l}}
+        \TN@factor[minimum width=1.38cm, minimum height=0.48cm,
+            inner sep=1pt]{commEtaLHLeft}{(-2.45,-0.38)}{\eta_{l,h}}
 
-        \node[tn tensor box, minimum width=1.38cm,
-            minimum height=0.48cm, inner sep=1pt]
-            at (2.45,-0.38) {$\eta_{k,l}$};
-        \node[tn tensor box, minimum width=1.38cm,
-            minimum height=0.48cm, inner sep=1pt]
-            at (4.05,0.38) {$\eta_{l,h}$};
+        \TN@factor[minimum width=1.38cm, minimum height=0.48cm,
+            inner sep=1pt]{commEtaKLRight}{(2.45,-0.38)}{\eta_{k,l}}
+        \TN@factor[minimum width=1.38cm, minimum height=0.48cm,
+            inner sep=1pt]{commEtaLHRight}{(4.05,0.38)}{\eta_{l,h}}
+
+        % Each operator carries two factors.  The eight affected index lines
+        % terminate on named boundary ports rather than passing underneath the
+        % filled factor plates.
+        \foreach \factor/\low/\high in {
+            commEtaKLLeft/-1.26/0.50,
+            commEtaLHLeft/-0.50/1.26,
+            commEtaKLRight/-0.50/1.26,
+            commEtaLHRight/-1.26/0.50} {
+            \TN@southport{\factor SouthLeft}{\factor}{0.21}
+            \TN@southport{\factor SouthRight}{\factor}{0.79}
+            \TN@northport{\factor NorthLeft}{\factor}{0.21}
+            \TN@northport{\factor NorthRight}{\factor}{0.79}
+            \TN@vopenport{\factor SouthLeft}{0,\low}
+            \TN@vopenport{\factor SouthRight}{0,\low}
+            \TN@vopenport{\factor NorthLeft}{0,\high}
+            \TN@vopenport{\factor NorthRight}{0,\high}
+        }
 
         \node at (-3.25,1.57) {$C_{01}^{k,l,h}C_{12}^{k,l,h}$};
         \node at (3.25,1.57) {$C_{12}^{k,l,h}C_{01}^{k,l,h}$};
@@ -599,7 +638,7 @@
         \foreach \a/\b/\lab in {
             -5.58/-4.12/0,-3.98/-2.52/1,-2.38/-0.92/2,
              0.92/2.38/0, 2.52/3.98/1, 4.12/5.58/2} {
-            \draw[tn leg] (\a,-1.72) -- (\a,-1.84) -- (\b,-1.84) -- (\b,-1.72);
+            \TN@vpath{ (\a,-1.72) -- (\a,-1.84) -- (\b,-1.84) -- (\b,-1.72);}
             \node at ({(\a+\b)/2},-2.05) {site $\lab$};
         }
     \end{tikzpicture}%
@@ -610,24 +649,24 @@
 \newcommand{\TNMPDOCyclicEtaContraction}{%
     \begin{tikzpicture}[tn picture]
         \foreach \name/\x/\lab in {Zero/-2.70/0,One/-0.90/1,Last/1.30/{N-1}} {
-            \node[tn tensor box, minimum width=0.58cm, minimum height=0.38cm,
-                inner sep=1pt] (tnL\name) at (\x,0.34) {$l_{k_\lab}$};
-            \node[tn tensor box, minimum width=0.58cm, minimum height=0.38cm,
-                inner sep=1pt] (tnR\name) at (\x+1.14,0.34) {$r_{k_\lab}$};
+            \TN@factor[minimum width=0.58cm, minimum height=0.38cm,
+                inner sep=1pt]{tnL\name}{(\x,0.34)}{l_{k_\lab}}
+            \TN@factor[minimum width=0.58cm, minimum height=0.38cm,
+                inner sep=1pt]{tnR\name}{(\x+1.14,0.34)}{r_{k_\lab}}
             \node at (\x+0.57,0.34) {$\otimes$};
-            \TN@upleg{tnL\name}{0.42}
-            \TN@downleg{tnL\name}{0.42}
-            \TN@upleg{tnR\name}{0.42}
-            \TN@downleg{tnR\name}{0.42}
+            \TN@pleg{tnL\name}{north}{0,0.42}
+            \TN@pleg{tnL\name}{south}{0,-0.42}
+            \TN@pleg{tnR\name}{north}{0,0.42}
+            \TN@pleg{tnR\name}{south}{0,-0.42}
         }
-        \draw[tn leg] (tnRZero.east) -- (tnLOne.west);
-        \draw[tn leg] (tnROne.east) -- (0.62,0.34);
-        \draw[tn leg] (0.94,0.34) -- (tnLLast.west);
+        \TN@vpath{ (tnRZero.east) -- (tnLOne.west);}
+        \TN@vpath{ (tnROne.east) -- (0.62,0.34);}
+        \TN@vpath{ (0.94,0.34) -- (tnLLast.west);}
         \node at (0.78,0.34) {$\cdots$};
-        \draw[tn virtual closure] (tnRLast.east)
+        \TN@vtracepath{ (tnRLast.east)
             .. controls (3.04,0.34) and (3.04,-0.42) .. (2.60,-0.42)
             -- (-3.04,-0.42)
-            .. controls (-3.46,-0.42) and (-3.46,0.34) .. (tnLZero.west);
+            .. controls (-3.46,-0.42) and (-3.46,0.34) .. (tnLZero.west);}
         \node at (0,-0.90)
             {$\eta_{k_0,k_1}\otimes\eta_{k_1,k_2}\otimes\cdots
               \otimes\eta_{k_{N-1},k_0}$};
@@ -642,15 +681,15 @@
             {$\operatorname{reindex}_{\Phi_N}\!M_N(\widetilde{\cal K})$};
         \node at (-1.93,0) {$=$};
         \node at (-1.28,0) {$\displaystyle\bigoplus_{k_0,\ldots,k_{N-1}}$};
-        \draw[tn factor boundary] (-0.45,-0.58) rectangle (4.22,0.58);
-        \node[tn tensor box, minimum width=1.08cm, minimum height=0.44cm,
-            inner sep=1pt] (tnEtaZero) at (0.30,0) {$\eta_{k_0,k_1}$};
+        \TN@vpath[tn factor region]{ (-0.45,-0.58) rectangle (4.22,0.58);}
+        \TN@factor[minimum width=1.08cm, minimum height=0.44cm,
+            inner sep=1pt]{tnEtaZero}{(0.30,0)}{\eta_{k_0,k_1}}
         \node at (1.10,0) {$\otimes$};
-        \node[tn tensor box, minimum width=1.08cm, minimum height=0.44cm,
-            inner sep=1pt] (tnEtaOne) at (1.90,0) {$\eta_{k_1,k_2}$};
+        \TN@factor[minimum width=1.08cm, minimum height=0.44cm,
+            inner sep=1pt]{tnEtaOne}{(1.90,0)}{\eta_{k_1,k_2}}
         \node at (2.72,0) {$\otimes\cdots\otimes$};
-        \node[tn tensor box, minimum width=1.34cm, minimum height=0.44cm,
-            inner sep=1pt] (tnEtaLast) at (3.55,0) {$\eta_{k_{N-1},k_0}$};
+        \TN@factor[minimum width=1.34cm, minimum height=0.44cm,
+            inner sep=1pt]{tnEtaLast}{(3.55,0)}{\eta_{k_{N-1},k_0}}
     \end{tikzpicture}%
 }
 
@@ -661,37 +700,37 @@
     \begin{tikzpicture}[tn picture]
         % Three-site MPO word.  At the first and third sites, both physical
         % legs are contracted against the corresponding inverse tensor.
-        \TN@tensordot{tnKone}{(-3.00,0)}
-        \TN@tensordot{tnKtwo}{(-1.60,0)}
-        \TN@tensordot{tnKthree}{(-0.20,0)}
-        \draw[tn leg] (tnKone.east) -- (tnKtwo.west);
-        \draw[tn leg] (tnKtwo.east) -- (tnKthree.west);
+        \TN@tensor{tnKone}{(-3.00,0)}
+        \TN@tensor{tnKtwo}{(-1.60,0)}
+        \TN@tensor{tnKthree}{(-0.20,0)}
+        \TN@vpath{ (tnKone.east) -- (tnKtwo.west);}
+        \TN@vpath{ (tnKtwo.east) -- (tnKthree.west);}
         \node[anchor=east] at (-3.14,-0.28) {${\cal K}$};
         \node[anchor=east] at (-1.74,-0.28) {${\cal K}$};
         \node[anchor=east] at (-0.34,-0.28) {${\cal K}$};
 
-        \TN@tensordot{tnInvOne}{(-3.00,1.18)}
-        \TN@tensordot{tnInvThree}{(-0.20,1.18)}
-        \draw[tn phys leg] (tnKone.north) -- (tnInvOne.south);
-        \draw[tn phys leg] (tnKthree.north) -- (tnInvThree.south);
-        \draw[tn phys leg]
+        \TN@tensor{tnInvOne}{(-3.00,1.18)}
+        \TN@tensor{tnInvThree}{(-0.20,1.18)}
+        \TN@ppath{ (tnKone.north) -- (tnInvOne.south);}
+        \TN@ppath{ (tnKthree.north) -- (tnInvThree.south);}
+        \TN@ppath{
             (tnKone.south) .. controls (-2.18,-0.38) and (-2.18,1.62) ..
-            (tnInvOne.north);
-        \draw[tn phys leg]
+            (tnInvOne.north);}
+        \TN@ppath{
             (tnKthree.south) .. controls (-0.98,-0.38) and (-0.98,1.62) ..
-            (tnInvThree.north);
-        \TN@leftleg{tnInvOne}{0.52}
-        \TN@rightleg{tnInvOne}{0.52}
-        \TN@leftleg{tnInvThree}{0.52}
-        \TN@rightleg{tnInvThree}{0.52}
+            (tnInvThree.north);}
+        \TN@vleg{tnInvOne}{west}{-0.52,0}
+        \TN@vleg{tnInvOne}{east}{0.52,0}
+        \TN@vleg{tnInvThree}{west}{-0.52,0}
+        \TN@vleg{tnInvThree}{east}{0.52,0}
         \node[anchor=east] at (-3.12,1.55) {${\cal K}^{-1}$};
         \node[anchor=west] at (-0.08,1.55) {${\cal K}^{-1}$};
         \node[anchor=east] at (-3.58,1.18) {$\alpha_1$};
         \node[anchor=west] at (-2.42,1.18) {$\beta_1$};
         \node[anchor=east] at (-0.78,1.18) {$\alpha_3$};
         \node[anchor=west] at (0.38,1.18) {$\beta_3$};
-        \TN@upleg{tnKtwo}{0.52}
-        \TN@downleg{tnKtwo}{0.52}
+        \TN@pleg{tnKtwo}{north}{0,0.52}
+        \TN@pleg{tnKtwo}{south}{0,-0.52}
         \node at (-1.60,0.82) {$i_2$};
         \node at (-1.60,-0.82) {$j_2$};
         \node at (-2.88,0.58) {$i_1$};
@@ -700,31 +739,29 @@
         \node at (-1.08,0.48) {$j_3$};
 
         % The trace closes the three-site word through the remaining sites R.
-        \node[tn tensor box]
-            (tnTail) at (-1.60,-1.42) {$R$};
-        \draw[tn virtual closure] (tnKone.west) -- ++(-0.42,0)
-            |- ($(tnTail.east)+(0,-0.40)$) -- (tnTail.east);
-        \draw[tn virtual closure] (tnKthree.east) -- ++(0.42,0)
-            |- ($(tnTail.west)+(0,0.38)$) -- (tnTail.west);
+        \TN@component{tnTail}{(-1.60,-1.42)}{R}
+        \TN@vtracepath{ (tnKone.west) -- ++(-0.42,0)
+            |- ($(tnTail.east)+(0,-0.40)$) -- (tnTail.east);}
+        \TN@vtracepath{ (tnKthree.east) -- ++(0.42,0)
+            |- ($(tnTail.west)+(0,0.38)$) -- (tnTail.west);}
 
         \node at (0.88,0.20) {$=$};
 
         % The two surviving factors.
-        \TN@tensordot{tnMiddle}{(2.25,0.20)}
-        \TN@leftleg{tnMiddle}{0.58}
-        \TN@rightleg{tnMiddle}{0.58}
-        \TN@upleg{tnMiddle}{0.52}
-        \TN@downleg{tnMiddle}{0.52}
+        \TN@tensor{tnMiddle}{(2.25,0.20)}
+        \TN@vleg{tnMiddle}{west}{-0.58,0}
+        \TN@vleg{tnMiddle}{east}{0.58,0}
+        \TN@pleg{tnMiddle}{north}{0,0.52}
+        \TN@pleg{tnMiddle}{south}{0,-0.52}
         \node[anchor=east] at (2.11,-0.08) {${\cal K}$};
         \node at (2.25,1.02) {$i_2$};
         \node at (2.25,-0.62) {$j_2$};
         \node[anchor=east] at (1.61,0.20) {$\beta_1$};
         \node[anchor=west] at (2.89,0.20) {$\alpha_3$};
         \node at (3.50,0.20) {$\times$};
-        \node[tn tensor box]
-            (tnTailEntry) at (4.65,0.20) {$R$};
-        \draw[tn leg] (tnTailEntry.west) -- ++(-0.58,0);
-        \draw[tn leg] (tnTailEntry.east) -- ++(0.58,0);
+        \TN@component{tnTailEntry}{(4.65,0.20)}{R}
+        \TN@vpath{ (tnTailEntry.west) -- ++(-0.58,0);}
+        \TN@vpath{ (tnTailEntry.east) -- ++(0.58,0);}
         \node[anchor=east] at (4.01,0.20) {$\beta_3$};
         \node[anchor=west] at (5.29,0.20) {$\alpha_1$};
     \end{tikzpicture}%
@@ -747,18 +784,18 @@
     \begin{tikzpicture}[tn picture]
         \begin{scope}
             \TN@closedMPOword{fsl}
-            \TN@opdotleft{fslP}{(0,0.26)}{P}
+            \TN@insertion[label=left:$P$]{fslP}{(0,0.26)}
             \node[anchor=west] at (3.80,0) {$PH^{(N+1)}$};
         \end{scope}
         \begin{scope}[yshift=-2.35cm]
             \TN@closedMPOword{fsr}
-            \TN@opdotleft{fsrP}{(0,-0.26)}{P}
+            \TN@insertion[label=left:$P$]{fsrP}{(0,-0.26)}
             \node[anchor=west] at (3.80,0) {$H^{(N+1)}P$};
         \end{scope}
         \begin{scope}[yshift=-4.70cm]
             \TN@closedMPOword{fsc}
-            \TN@opdotleft{fscPu}{(0,0.26)}{P}
-            \TN@opdotleft{fscPd}{(0,-0.26)}{P}
+            \TN@insertion[label=left:$P$]{fscPu}{(0,0.26)}
+            \TN@insertion[label=left:$P$]{fscPd}{(0,-0.26)}
             \node[anchor=west] at (3.80,0) {$PH^{(N+1)}P$};
         \end{scope}
     \end{tikzpicture}%
@@ -769,29 +806,33 @@
 % a basis tensor carrying the virtual legs.
 \newcommand{\TNMPDOVerticalDirectSum}{%
     \begin{tikzpicture}[tn picture]
-        \node[tn map box] (vdUu) at (-2.55,0.76) {$U^\dagger$};
-        \TN@tensordot{vdM}{(-2.55,0)}
-        \node[tn map box] (vdUd) at (-2.55,-0.76) {$U$};
-        \draw[tn phys leg] ($(vdUu.north)+(-0.11,0)$) -- ++(0,0.36);
-        \draw[tn phys leg] ($(vdUu.north)+(0.11,0)$) -- ++(0,0.36);
-        \draw[tn phys leg] (vdUu.south) -- (vdM.north);
-        \draw[tn phys leg] (vdM.south) -- (vdUd.north);
-        \draw[tn phys leg] ($(vdUd.south)+(-0.11,0)$) -- ++(0,-0.36);
-        \draw[tn phys leg] ($(vdUd.south)+(0.11,0)$) -- ++(0,-0.36);
-        \TN@leftleg{vdM}{0.58}
-        \TN@rightleg{vdM}{0.58}
+        \TN@map{vdUu}{(-2.55,0.76)}{U^\dagger}
+        \TN@tensor{vdM}{(-2.55,0)}
+        \TN@map{vdUd}{(-2.55,-0.76)}{U}
+        \TN@northport{vdUuNLeft}{vdUu}{0.30}
+        \TN@northport{vdUuNRight}{vdUu}{0.70}
+        \TN@southport{vdUdSLeft}{vdUd}{0.30}
+        \TN@southport{vdUdSRight}{vdUd}{0.70}
+        \TN@popenport{vdUuNLeft}{0,0.36}
+        \TN@popenport{vdUuNRight}{0,0.36}
+        \TN@ppath{ (vdUu.south) -- (vdM.north);}
+        \TN@ppath{ (vdM.south) -- (vdUd.north);}
+        \TN@popenport{vdUdSLeft}{0,-0.36}
+        \TN@popenport{vdUdSRight}{0,-0.36}
+        \TN@vleg{vdM}{west}{-0.58,0}
+        \TN@vleg{vdM}{east}{0.58,0}
         \node at (-2.92,-0.26) {$\tilde M$};
         \node at (-1.43,0) {$=$};
         \node at (-0.62,0) {$\displaystyle\bigoplus_\alpha$};
-        \TN@opdot{vdMu}{(0.45,0)}
-        \draw[tn phys leg] (vdMu.north) -- ++(0,0.40);
-        \draw[tn phys leg] (vdMu.south) -- ++(0,-0.40);
+        \TN@insertion{vdMu}{(0.45,0)}
+        \TN@ppath{ (vdMu.north) -- ++(0,0.40);}
+        \TN@ppath{ (vdMu.south) -- ++(0,-0.40);}
         \node at (0.45,0.74) {$\mu_\alpha$};
-        \TN@tensordot{vdMa}{(1.55,0)}
-        \TN@upleg{vdMa}{0.44}
-        \TN@downleg{vdMa}{0.44}
-        \TN@leftleg{vdMa}{0.55}
-        \TN@rightleg{vdMa}{0.55}
+        \TN@tensor{vdMa}{(1.55,0)}
+        \TN@pleg{vdMa}{north}{0,0.44}
+        \TN@pleg{vdMa}{south}{0,-0.44}
+        \TN@vleg{vdMa}{west}{-0.55,0}
+        \TN@vleg{vdMa}{east}{0.55,0}
         \node at (1.55,0.74) {$M_\alpha$};
     \end{tikzpicture}%
 }
@@ -803,25 +844,23 @@
     \begin{tikzpicture}[tn picture, scale=0.94]
         \path[draw=black, opacity=0, use as bounding box]
             (-4.35,-1.42) rectangle (5.75,1.42);
-        \TN@tensordot{vrsM}{(-3.50,0)}
-        \TN@leftleg{vrsM}{0.58}
-        \TN@rightleg{vrsM}{0.58}
-        \TN@upleg{vrsM}{0.48}
-        \TN@downleg{vrsM}{0.48}
+        \TN@tensor{vrsM}{(-3.50,0)}
+        \TN@vleg{vrsM}{west}{-0.58,0}
+        \TN@vleg{vrsM}{east}{0.58,0}
+        \TN@pleg{vrsM}{north}{0,0.48}
+        \TN@pleg{vrsM}{south}{0,-0.48}
         \node[anchor=west] at (-3.33,0.30) {$\widetilde M$};
         \node at (-2.45,0) {$=$};
         \node at (-1.55,0) {$\displaystyle\sum_k$};
-        \node[tn map box]
-            (vrsV) at (0,0.82) {$V_k$};
-        \TN@tensordot{vrsB}{(0,0)}
-        \node[tn map box]
-            (vrsVd) at (0,-0.82) {$V_k^\dagger$};
-        \draw[tn phys leg] (vrsV.north) -- ++(0,0.34);
-        \draw[tn phys leg] (vrsV.south) -- (vrsB.north);
-        \draw[tn phys leg] (vrsB.south) -- (vrsVd.north);
-        \draw[tn phys leg] (vrsVd.south) -- ++(0,-0.34);
-        \TN@leftleg{vrsB}{0.60}
-        \TN@rightleg{vrsB}{0.60}
+        \TN@map{vrsV}{(0,0.82)}{V_k}
+        \TN@tensor{vrsB}{(0,0)}
+        \TN@map{vrsVd}{(0,-0.82)}{V_k^\dagger}
+        \TN@ppath{ (vrsV.north) -- ++(0,0.34);}
+        \TN@ppath{ (vrsV.south) -- (vrsB.north);}
+        \TN@ppath{ (vrsB.south) -- (vrsVd.north);}
+        \TN@ppath{ (vrsVd.south) -- ++(0,-0.34);}
+        \TN@vleg{vrsB}{west}{-0.60,0}
+        \TN@vleg{vrsB}{east}{0.60,0}
         \node[anchor=west] at (0.16,0.27) {$B_k$};
         \node[anchor=west, align=left] at (1.62,0.48)
             {$P_k=V_kV_k^\dagger,\qquad \sum_kP_k=I,$};
@@ -840,36 +879,36 @@
         \path[draw=black, opacity=0, use as bounding box]
             (-3.45,-1.62) rectangle (3.45,1.62);
         \begin{scope}[xshift=-1.80cm]
-            \TN@tensordot{vggL}{(0,0)}
-            \draw[tn phys leg] (vggL.west) -- ++(-0.72,0);
-            \draw[tn phys leg] (vggL.east) -- ++(0.72,0);
-            \TN@opdotright{vggLX}{(0,0.58)}{X_{\alpha,k}}
-            \TN@opdotright{vggLXd}{(0,1.18)}{X_{\alpha,k}^{\dagger}}
-            \TN@opdotright{vggLXi}{(0,-0.58)}{X_{\alpha,k}^{-1}}
-            \TN@opdotright{vggLXid}{(0,-1.18)}{(X_{\alpha,k}^{-1})^{\dagger}}
-            \draw[tn leg] (vggL.north) -- (vggLX.south);
-            \draw[tn leg] (vggLX.north) -- (vggLXd.south);
-            \draw[tn leg] (vggLXd.north) -- ++(0,0.30);
-            \draw[tn leg] (vggL.south) -- (vggLXi.north);
-            \draw[tn leg] (vggLXi.south) -- (vggLXid.north);
-            \draw[tn leg] (vggLXid.south) -- ++(0,-0.30);
+            \TN@tensor{vggL}{(0,0)}
+            \TN@ppath{ (vggL.west) -- ++(-0.72,0);}
+            \TN@ppath{ (vggL.east) -- ++(0.72,0);}
+            \TN@insertion[label=right:$X_{\alpha,k}$]{vggLX}{(0,0.58)}
+            \TN@insertion[label=right:$X_{\alpha,k}^{\dagger}$]{vggLXd}{(0,1.18)}
+            \TN@insertion[label=right:$X_{\alpha,k}^{-1}$]{vggLXi}{(0,-0.58)}
+            \TN@insertion[label=right:$(X_{\alpha,k}^{-1})^{\dagger}$]{vggLXid}{(0,-1.18)}
+            \TN@vpath{ (vggL.north) -- (vggLX.south);}
+            \TN@vpath{ (vggLX.north) -- (vggLXd.south);}
+            \TN@vpath{ (vggLXd.north) -- ++(0,0.30);}
+            \TN@vpath{ (vggL.south) -- (vggLXi.north);}
+            \TN@vpath{ (vggLXi.south) -- (vggLXid.north);}
+            \TN@vpath{ (vggLXid.south) -- ++(0,-0.30);}
             \node[anchor=east] at (-0.16,0.18) {$M_\alpha$};
         \end{scope}
         \node at (0,0) {$=$};
         \begin{scope}[xshift=1.80cm]
-            \TN@tensordot{vggR}{(0,0)}
-            \draw[tn phys leg] (vggR.west) -- ++(-0.72,0);
-            \draw[tn phys leg] (vggR.east) -- ++(0.72,0);
-            \TN@opdotright{vggRX}{(0,0.58)}{X_{\alpha,1}}
-            \TN@opdotright{vggRXd}{(0,1.18)}{X_{\alpha,1}^{\dagger}}
-            \TN@opdotright{vggRXi}{(0,-0.58)}{X_{\alpha,1}^{-1}}
-            \TN@opdotright{vggRXid}{(0,-1.18)}{(X_{\alpha,1}^{-1})^{\dagger}}
-            \draw[tn leg] (vggR.north) -- (vggRX.south);
-            \draw[tn leg] (vggRX.north) -- (vggRXd.south);
-            \draw[tn leg] (vggRXd.north) -- ++(0,0.30);
-            \draw[tn leg] (vggR.south) -- (vggRXi.north);
-            \draw[tn leg] (vggRXi.south) -- (vggRXid.north);
-            \draw[tn leg] (vggRXid.south) -- ++(0,-0.30);
+            \TN@tensor{vggR}{(0,0)}
+            \TN@ppath{ (vggR.west) -- ++(-0.72,0);}
+            \TN@ppath{ (vggR.east) -- ++(0.72,0);}
+            \TN@insertion[label=right:$X_{\alpha,1}$]{vggRX}{(0,0.58)}
+            \TN@insertion[label=right:$X_{\alpha,1}^{\dagger}$]{vggRXd}{(0,1.18)}
+            \TN@insertion[label=right:$X_{\alpha,1}^{-1}$]{vggRXi}{(0,-0.58)}
+            \TN@insertion[label=right:$(X_{\alpha,1}^{-1})^{\dagger}$]{vggRXid}{(0,-1.18)}
+            \TN@vpath{ (vggR.north) -- (vggRX.south);}
+            \TN@vpath{ (vggRX.north) -- (vggRXd.south);}
+            \TN@vpath{ (vggRXd.north) -- ++(0,0.30);}
+            \TN@vpath{ (vggR.south) -- (vggRXi.north);}
+            \TN@vpath{ (vggRXi.south) -- (vggRXid.north);}
+            \TN@vpath{ (vggRXid.south) -- ++(0,-0.30);}
             \node[anchor=east] at (-0.16,0.18) {$M_\alpha$};
         \end{scope}
     \end{tikzpicture}%
@@ -880,22 +919,22 @@
 % two pairs of virtual legs (the matrix units on the bond space).
 \newcommand{\TNMPDOInverseContraction}{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{invT}{(0,0.55)}
-        \TN@tensordot{invB}{(0,-0.55)}
-        \TN@leftleg{invT}{0.60}
-        \TN@rightleg{invT}{0.60}
-        \TN@leftleg{invB}{0.60}
-        \TN@rightleg{invB}{0.60}
-        \draw[tn phys leg] (invT.south) -- (invB.north);
+        \TN@tensor{invT}{(0,0.55)}
+        \TN@tensor{invB}{(0,-0.55)}
+        \TN@vleg{invT}{west}{-0.60,0}
+        \TN@vleg{invT}{east}{0.60,0}
+        \TN@vleg{invB}{west}{-0.60,0}
+        \TN@vleg{invB}{east}{0.60,0}
+        \TN@ppath{ (invT.south) -- (invB.north);}
         \node at (-0.50,0.88) {$K^{-1}$};
         \node at (-0.42,-0.88) {$K$};
         \node at (1.35,0) {$=$};
-        \draw[tn leg] (1.90,0.55) -- (2.15,0.55)
+        \TN@vpath{ (1.90,0.55) -- (2.15,0.55)
         .. controls (2.70,0.55) and (2.70,-0.55) .. (2.15,-0.55)
-        -- (1.90,-0.55);
-        \draw[tn leg] (3.90,0.55) -- (3.65,0.55)
+        -- (1.90,-0.55);}
+        \TN@vpath{ (3.90,0.55) -- (3.65,0.55)
         .. controls (3.10,0.55) and (3.10,-0.55) .. (3.65,-0.55)
-        -- (3.90,-0.55);
+        -- (3.90,-0.55);}
     \end{tikzpicture}%
 }
 
@@ -904,33 +943,41 @@
 % the trace-matrix entry.
 \newcommand{\TNMPDOSectorPairing}{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{spL}{(0,0)}
-        \TN@leftleg{spL}{0.60}
-        \draw[tn phys leg] (spL.north) -- (0,0.41);
-        \draw[tn phys leg] (spL.south) -- (0,-0.41);
-        \draw[tn physical closure] (0,0.41)
-        .. controls (0.46,0.41) and (0.46,-0.41) .. (0,-0.41);
+        \TN@tensor{spL}{(0,0)}
+        \TN@vleg{spL}{west}{-0.60,0}
+        \coordinate (spLTraceNorth) at (0,0.41);
+        \coordinate (spLTraceSouth) at (0,-0.41);
+        \TN@ppath{ (spL.north) -- (spLTraceNorth);}
+        \TN@ppath{ (spL.south) -- (spLTraceSouth);}
+        \TN@ptracepath{ (spLTraceNorth)
+        .. controls (0.46,0.41) and (0.46,-0.41) .. (spLTraceSouth);}
         \node at (0,0.68) {$l_k$};
         \node[anchor=west] at (0.62,0) {$=\;|l_k)$};
-        \TN@tensordot{spR}{(3.05,0)}
-        \TN@rightleg{spR}{0.60}
-        \draw[tn phys leg] (spR.north) -- (3.05,0.41);
-        \draw[tn phys leg] (spR.south) -- (3.05,-0.41);
-        \draw[tn physical closure] (3.05,0.41)
-        .. controls (2.59,0.41) and (2.59,-0.41) .. (3.05,-0.41);
+        \TN@tensor{spR}{(3.05,0)}
+        \TN@vleg{spR}{east}{0.60,0}
+        \coordinate (spRTraceNorth) at (3.05,0.41);
+        \coordinate (spRTraceSouth) at (3.05,-0.41);
+        \TN@ppath{ (spR.north) -- (spRTraceNorth);}
+        \TN@ppath{ (spR.south) -- (spRTraceSouth);}
+        \TN@ptracepath{ (spRTraceNorth)
+        .. controls (2.59,0.41) and (2.59,-0.41) .. (spRTraceSouth);}
         \node at (3.05,0.68) {$r_k$};
         \node[anchor=west] at (3.80,0) {$=\;(r_k|$};
-        \TN@tensordot{spTk}{(6.35,0)}
-        \TN@tensordot{spTh}{(7.35,0)}
-        \draw[tn leg] (spTk.east) -- (spTh.west);
-        \draw[tn phys leg] (spTk.north) -- (6.35,0.41);
-        \draw[tn phys leg] (spTk.south) -- (6.35,-0.41);
-        \draw[tn physical closure] (6.35,0.41)
-        .. controls (5.89,0.41) and (5.89,-0.41) .. (6.35,-0.41);
-        \draw[tn phys leg] (spTh.north) -- (7.35,0.41);
-        \draw[tn phys leg] (spTh.south) -- (7.35,-0.41);
-        \draw[tn physical closure] (7.35,0.41)
-        .. controls (7.81,0.41) and (7.81,-0.41) .. (7.35,-0.41);
+        \TN@tensor{spTk}{(6.35,0)}
+        \TN@tensor{spTh}{(7.35,0)}
+        \TN@vpath{ (spTk.east) -- (spTh.west);}
+        \coordinate (spTkTraceNorth) at (6.35,0.41);
+        \coordinate (spTkTraceSouth) at (6.35,-0.41);
+        \TN@ppath{ (spTk.north) -- (spTkTraceNorth);}
+        \TN@ppath{ (spTk.south) -- (spTkTraceSouth);}
+        \TN@ptracepath{ (spTkTraceNorth)
+        .. controls (5.89,0.41) and (5.89,-0.41) .. (spTkTraceSouth);}
+        \coordinate (spThTraceNorth) at (7.35,0.41);
+        \coordinate (spThTraceSouth) at (7.35,-0.41);
+        \TN@ppath{ (spTh.north) -- (spThTraceNorth);}
+        \TN@ppath{ (spTh.south) -- (spThTraceSouth);}
+        \TN@ptracepath{ (spThTraceNorth)
+        .. controls (7.81,0.41) and (7.81,-0.41) .. (spThTraceSouth);}
         \node at (6.35,0.68) {$r_k$};
         \node at (7.35,0.68) {$l_h$};
         \node[anchor=west] at (8.05,0) {$=\;T_{k,h}$};
@@ -942,48 +989,60 @@
 \newcommand{\TNMPDOSectorZCLIdentity}{%
     \begin{tikzpicture}[tn picture]
         \node at (-1.60,0) {$\displaystyle\sum_k$};
-        \TN@tensordot{zcAl}{(-0.50,0)}
-        \draw[tn leg] (zcAl.west) -- ++(-0.55,0);
-        \draw[tn phys leg] (zcAl.north) -- (-0.50,0.41);
-        \draw[tn phys leg] (zcAl.south) -- (-0.50,-0.41);
-        \draw[tn physical closure] (-0.50,0.41)
-        .. controls (-0.04,0.41) and (-0.04,-0.41) .. (-0.50,-0.41);
+        \TN@tensor{zcAl}{(-0.50,0)}
+        \TN@vpath{ (zcAl.west) -- ++(-0.55,0);}
+        \coordinate (zcAlTraceNorth) at (-0.50,0.41);
+        \coordinate (zcAlTraceSouth) at (-0.50,-0.41);
+        \TN@ppath{ (zcAl.north) -- (zcAlTraceNorth);}
+        \TN@ppath{ (zcAl.south) -- (zcAlTraceSouth);}
+        \TN@ptracepath{ (zcAlTraceNorth)
+        .. controls (-0.04,0.41) and (-0.04,-0.41) .. (zcAlTraceSouth);}
         \node at (-0.50,0.68) {$l_k$};
-        \TN@tensordot{zcAr}{(0.75,0)}
-        \draw[tn leg] (zcAr.east) -- ++(0.55,0);
-        \draw[tn phys leg] (zcAr.north) -- (0.75,0.41);
-        \draw[tn phys leg] (zcAr.south) -- (0.75,-0.41);
-        \draw[tn physical closure] (0.75,0.41)
-        .. controls (0.29,0.41) and (0.29,-0.41) .. (0.75,-0.41);
+        \TN@tensor{zcAr}{(0.75,0)}
+        \TN@vpath{ (zcAr.east) -- ++(0.55,0);}
+        \coordinate (zcArTraceNorth) at (0.75,0.41);
+        \coordinate (zcArTraceSouth) at (0.75,-0.41);
+        \TN@ppath{ (zcAr.north) -- (zcArTraceNorth);}
+        \TN@ppath{ (zcAr.south) -- (zcArTraceSouth);}
+        \TN@ptracepath{ (zcArTraceNorth)
+        .. controls (0.29,0.41) and (0.29,-0.41) .. (zcArTraceSouth);}
         \node at (0.75,0.68) {$r_k$};
         \node at (1.90,0) {$=$};
         \node at (2.70,0) {$\displaystyle\sum_{k,h}$};
-        \TN@tensordot{zcBlk}{(3.85,0)}
-        \draw[tn leg] (zcBlk.west) -- ++(-0.55,0);
-        \draw[tn phys leg] (zcBlk.north) -- (3.85,0.41);
-        \draw[tn phys leg] (zcBlk.south) -- (3.85,-0.41);
-        \draw[tn physical closure] (3.85,0.41)
-        .. controls (4.31,0.41) and (4.31,-0.41) .. (3.85,-0.41);
+        \TN@tensor{zcBlk}{(3.85,0)}
+        \TN@vpath{ (zcBlk.west) -- ++(-0.55,0);}
+        \coordinate (zcBlkTraceNorth) at (3.85,0.41);
+        \coordinate (zcBlkTraceSouth) at (3.85,-0.41);
+        \TN@ppath{ (zcBlk.north) -- (zcBlkTraceNorth);}
+        \TN@ppath{ (zcBlk.south) -- (zcBlkTraceSouth);}
+        \TN@ptracepath{ (zcBlkTraceNorth)
+        .. controls (4.31,0.41) and (4.31,-0.41) .. (zcBlkTraceSouth);}
         \node at (3.85,0.68) {$l_k$};
-        \TN@tensordot{zcBrk}{(5.10,0)}
-        \draw[tn phys leg] (zcBrk.north) -- (5.10,0.41);
-        \draw[tn phys leg] (zcBrk.south) -- (5.10,-0.41);
-        \draw[tn physical closure] (5.10,0.41)
-        .. controls (4.64,0.41) and (4.64,-0.41) .. (5.10,-0.41);
+        \TN@tensor{zcBrk}{(5.10,0)}
+        \coordinate (zcBrkTraceNorth) at (5.10,0.41);
+        \coordinate (zcBrkTraceSouth) at (5.10,-0.41);
+        \TN@ppath{ (zcBrk.north) -- (zcBrkTraceNorth);}
+        \TN@ppath{ (zcBrk.south) -- (zcBrkTraceSouth);}
+        \TN@ptracepath{ (zcBrkTraceNorth)
+        .. controls (4.64,0.41) and (4.64,-0.41) .. (zcBrkTraceSouth);}
         \node at (5.10,0.68) {$r_k$};
-        \TN@tensordot{zcBlh}{(5.90,0)}
-        \draw[tn leg] (zcBrk.east) -- (zcBlh.west);
-        \draw[tn phys leg] (zcBlh.north) -- (5.90,0.41);
-        \draw[tn phys leg] (zcBlh.south) -- (5.90,-0.41);
-        \draw[tn physical closure] (5.90,0.41)
-        .. controls (6.36,0.41) and (6.36,-0.41) .. (5.90,-0.41);
+        \TN@tensor{zcBlh}{(5.90,0)}
+        \TN@vpath{ (zcBrk.east) -- (zcBlh.west);}
+        \coordinate (zcBlhTraceNorth) at (5.90,0.41);
+        \coordinate (zcBlhTraceSouth) at (5.90,-0.41);
+        \TN@ppath{ (zcBlh.north) -- (zcBlhTraceNorth);}
+        \TN@ppath{ (zcBlh.south) -- (zcBlhTraceSouth);}
+        \TN@ptracepath{ (zcBlhTraceNorth)
+        .. controls (6.36,0.41) and (6.36,-0.41) .. (zcBlhTraceSouth);}
         \node at (5.90,0.68) {$l_h$};
-        \TN@tensordot{zcBrh}{(7.15,0)}
-        \draw[tn leg] (zcBrh.east) -- ++(0.55,0);
-        \draw[tn phys leg] (zcBrh.north) -- (7.15,0.41);
-        \draw[tn phys leg] (zcBrh.south) -- (7.15,-0.41);
-        \draw[tn physical closure] (7.15,0.41)
-        .. controls (6.69,0.41) and (6.69,-0.41) .. (7.15,-0.41);
+        \TN@tensor{zcBrh}{(7.15,0)}
+        \TN@vpath{ (zcBrh.east) -- ++(0.55,0);}
+        \coordinate (zcBrhTraceNorth) at (7.15,0.41);
+        \coordinate (zcBrhTraceSouth) at (7.15,-0.41);
+        \TN@ppath{ (zcBrh.north) -- (zcBrhTraceNorth);}
+        \TN@ppath{ (zcBrh.south) -- (zcBrhTraceSouth);}
+        \TN@ptracepath{ (zcBrhTraceNorth)
+        .. controls (6.69,0.41) and (6.69,-0.41) .. (zcBrhTraceSouth);}
         \node at (7.15,0.68) {$r_h$};
     \end{tikzpicture}%
 }
@@ -996,15 +1055,15 @@
         \node at (-3.72,0) {$\sigma_3^{(4)}({\cal K})$};
         \node at (-2.76,0) {$=$};
 
-        \TN@tensordot{tnTailOne}{(-1.48,0)}
-        \TN@tensordot{tnTailTwo}{(0,0)}
-        \TN@tensordot{tnTailThree}{(1.48,0)}
-        \draw[tn leg] (tnTailOne.east) -- (tnTailTwo.west);
-        \draw[tn leg] (tnTailTwo.east) -- (tnTailThree.west);
+        \TN@tensor{tnTailOne}{(-1.48,0)}
+        \TN@tensor{tnTailTwo}{(0,0)}
+        \TN@tensor{tnTailThree}{(1.48,0)}
+        \TN@vpath{ (tnTailOne.east) -- (tnTailTwo.west);}
+        \TN@vpath{ (tnTailTwo.east) -- (tnTailThree.west);}
 
         \foreach \n in {tnTailOne,tnTailTwo,tnTailThree} {
-            \TN@upleg{\n}{0.48}
-            \TN@downleg{\n}{0.48}
+            \TN@pleg{\n}{north}{0,0.48}
+            \TN@pleg{\n}{south}{0,-0.48}
         }
         \TN@uplabel{tnTailOne}{0.72}{i_1}
         \TN@uplabel{tnTailTwo}{0.72}{i_2}
@@ -1016,12 +1075,11 @@
         \node[anchor=east] at (-0.14,0.25) {${\cal K}$};
         \node[anchor=east] at (1.34,0.25) {${\cal K}$};
 
-        \node[tn tensor box]
-            (tnFourSiteTail) at (0,-1.42) {$R_4$};
-        \draw[tn virtual closure] (tnTailOne.west) -- ++(-0.48,0)
-            |- ($(tnFourSiteTail.east)+(0,-0.40)$) -- (tnFourSiteTail.east);
-        \draw[tn virtual closure] (tnTailThree.east) -- ++(0.48,0)
-            |- ($(tnFourSiteTail.west)+(0,0.38)$) -- (tnFourSiteTail.west);
+        \TN@component{tnFourSiteTail}{(0,-1.42)}{R_4}
+        \TN@vtracepath{ (tnTailOne.west) -- ++(-0.48,0)
+            |- ($(tnFourSiteTail.east)+(0,-0.40)$) -- (tnFourSiteTail.east);}
+        \TN@vtracepath{ (tnTailThree.east) -- ++(0.48,0)
+            |- ($(tnFourSiteTail.west)+(0,0.38)$) -- (tnFourSiteTail.west);}
 
     \end{tikzpicture}%
 }
@@ -1033,33 +1091,29 @@
         \node at (-4.55,0) {$R_{\beta_3,\alpha_1}$};
         \node at (-3.65,0) {$\cdot$};
 
-        \TN@tensordot{tnSectorK}{(-2.45,0)}
-        \TN@leftleg{tnSectorK}{0.72}
-        \TN@rightleg{tnSectorK}{0.72}
+        \TN@tensor{tnSectorK}{(-2.45,0)}
+        \TN@vleg{tnSectorK}{west}{-0.72,0}
+        \TN@vleg{tnSectorK}{east}{0.72,0}
         \node[anchor=east] at (-3.22,0) {$\beta_1$};
         \node[anchor=west] at (-1.68,0) {$\alpha_3$};
         \node[anchor=east] at (-2.58,0.25) {${\cal K}$};
 
-        \node[tn map box]
-            (tnSectorU) at (-2.45,0.88) {$U_B$};
-        \node[tn map box]
-            (tnSectorUd) at (-2.45,-0.88) {$U_B^\dagger$};
-        \draw[tn phys leg] (tnSectorK.north) -- (tnSectorU.south);
-        \draw[tn phys leg] (tnSectorU.north) -- ++(0,0.34);
-        \draw[tn phys leg] (tnSectorK.south) -- (tnSectorUd.north);
-        \draw[tn phys leg] (tnSectorUd.south) -- ++(0,-0.34);
+        \TN@map{tnSectorU}{(-2.45,0.88)}{U_B}
+        \TN@map{tnSectorUd}{(-2.45,-0.88)}{U_B^\dagger}
+        \TN@ppath{ (tnSectorK.north) -- (tnSectorU.south);}
+        \TN@ppath{ (tnSectorU.north) -- ++(0,0.34);}
+        \TN@ppath{ (tnSectorK.south) -- (tnSectorUd.north);}
+        \TN@ppath{ (tnSectorUd.south) -- ++(0,-0.34);}
         \node[anchor=west] at (-1.92,0.88) {$k;l,r$};
         \node[anchor=west] at (-1.92,-0.88) {$k;l',r'$};
 
         \node at (-0.60,0) {$=$};
         \node at (0.10,0) {$p_k$};
-        \node[tn tensor box, minimum width=1.00cm,
-            minimum height=0.62cm] (tnSectorA) at (1.25,0)
-            {$A^{(k)}_{\alpha_1,\beta_1}$};
+        \TN@factor[minimum width=1.00cm, minimum height=0.62cm]
+            {tnSectorA}{(1.25,0)}{A^{(k)}_{\alpha_1,\beta_1}}
         \node at (2.15,0) {$\otimes$};
-        \node[tn tensor box, minimum width=1.00cm,
-            minimum height=0.62cm] (tnSectorB) at (3.25,0)
-            {$B^{(k)}_{\alpha_3,\beta_3}$};
+        \TN@factor[minimum width=1.00cm, minimum height=0.62cm]
+            {tnSectorB}{(3.25,0)}{B^{(k)}_{\alpha_3,\beta_3}}
         \node at (1.25,0.62) {$l,l'$};
         \node at (3.25,0.62) {$r,r'$};
     \end{tikzpicture}%
@@ -1071,33 +1125,31 @@
 % orientation U_B K U_B^\dagger.
 \newcommand{\TNMPDOSectorFactorization}{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{sfK}{(-2.65,0)}
-        \TN@leftleg{sfK}{0.72}
-        \TN@rightleg{sfK}{0.72}
+        \TN@tensor{sfK}{(-2.65,0)}
+        \TN@vleg{sfK}{west}{-0.72,0}
+        \TN@vleg{sfK}{east}{0.72,0}
         \node[anchor=east] at (-3.42,0) {$\beta_1$};
         \node[anchor=west] at (-1.88,0) {$\alpha_3$};
         \node[anchor=east] at (-2.78,0.25) {${\cal K}$};
 
-        \node[tn map box]
-            (sfU) at (-2.65,0.88) {$U_B$};
-        \node[tn map box]
-            (sfUd) at (-2.65,-0.88) {$U_B^\dagger$};
-        \draw[tn phys leg] (sfK.north) -- (sfU.south);
-        \draw[tn phys leg] (sfU.north) -- ++(0,0.34);
-        \draw[tn phys leg] (sfK.south) -- (sfUd.north);
-        \draw[tn phys leg] (sfUd.south) -- ++(0,-0.34);
+        \TN@map{sfU}{(-2.65,0.88)}{U_B}
+        \TN@map{sfUd}{(-2.65,-0.88)}{U_B^\dagger}
+        \TN@ppath{ (sfK.north) -- (sfU.south);}
+        \TN@ppath{ (sfU.north) -- ++(0,0.34);}
+        \TN@ppath{ (sfK.south) -- (sfUd.north);}
+        \TN@ppath{ (sfUd.south) -- ++(0,-0.34);}
 
         \node at (-0.95,0) {$=$};
         \node at (-0.10,0) {$\displaystyle\bigoplus_k$};
-        \TN@tensordot{sfL}{(1.10,0)}
-        \TN@tensordot{sfR}{(2.75,0)}
-        \draw[tn leg] (sfL.west) -- ++(-0.62,0);
+        \TN@tensor{sfL}{(1.10,0)}
+        \TN@tensor{sfR}{(2.75,0)}
+        \TN@vpath{ (sfL.west) -- ++(-0.62,0);}
         \node at (1.93,0) {$\otimes$};
-        \draw[tn leg] (sfR.east) -- ++(0.62,0);
-        \TN@upleg{sfL}{0.50}
-        \TN@downleg{sfL}{0.50}
-        \TN@upleg{sfR}{0.50}
-        \TN@downleg{sfR}{0.50}
+        \TN@vpath{ (sfR.east) -- ++(0.62,0);}
+        \TN@pleg{sfL}{north}{0,0.50}
+        \TN@pleg{sfL}{south}{0,-0.50}
+        \TN@pleg{sfR}{north}{0,0.50}
+        \TN@pleg{sfR}{south}{0,-0.50}
         \node at (1.10,0.78) {$(l_k)_{\beta_1}$};
         \node at (2.75,0.78) {$(r_k)_{\alpha_3}$};
     \end{tikzpicture}%
@@ -1110,40 +1162,40 @@
 \newcommand{\TNMPDOLocalOrthogonality}{%
     \begin{tikzpicture}[tn picture]
         % One site, P_1 on the ket leg and P_2 on the bra leg.
-        \TN@tensordot{loA}{(0,0)}
-        \TN@leftleg{loA}{0.50}
-        \TN@rightleg{loA}{0.50}
-        \TN@upleg{loA}{1.00}
-        \TN@downleg{loA}{1.00}
-        \TN@opdotleft{loAu}{(0,0.55)}{P_1}
-        \TN@opdotleft{loAd}{(0,-0.55)}{P_2}
+        \TN@tensor{loA}{(0,0)}
+        \TN@vleg{loA}{west}{-0.50,0}
+        \TN@vleg{loA}{east}{0.50,0}
+        \TN@pleg{loA}{north}{0,1.00}
+        \TN@pleg{loA}{south}{0,-1.00}
+        \TN@insertion[label=left:$P_1$]{loAu}{(0,0.55)}
+        \TN@insertion[label=left:$P_2$]{loAd}{(0,-0.55)}
         \node[anchor=west] at (0.12,-0.30) {${\cal K}$};
         \node at (1.10,0) {$=$};
         % One site, P_2 on the ket leg and P_1 on the bra leg.
-        \TN@tensordot{loB}{(2.20,0)}
-        \TN@leftleg{loB}{0.50}
-        \TN@rightleg{loB}{0.50}
-        \TN@upleg{loB}{1.00}
-        \TN@downleg{loB}{1.00}
-        \TN@opdotleft{loBu}{(2.20,0.55)}{P_2}
-        \TN@opdotleft{loBd}{(2.20,-0.55)}{P_1}
+        \TN@tensor{loB}{(2.20,0)}
+        \TN@vleg{loB}{west}{-0.50,0}
+        \TN@vleg{loB}{east}{0.50,0}
+        \TN@pleg{loB}{north}{0,1.00}
+        \TN@pleg{loB}{south}{0,-1.00}
+        \TN@insertion[label=left:$P_2$]{loBu}{(2.20,0.55)}
+        \TN@insertion[label=left:$P_1$]{loBd}{(2.20,-0.55)}
         \node[anchor=west] at (2.32,-0.30) {${\cal K}$};
         \node at (3.30,0) {$=$};
         % Two neighboring sites, P_1 dressing both physical legs of the
         % first site and P_2 both physical legs of the second.
-        \TN@tensordot{loCa}{(4.40,0)}
-        \TN@tensordot{loCb}{(5.60,0)}
-        \draw[tn leg] (loCa.east) -- (loCb.west);
-        \TN@leftleg{loCa}{0.50}
-        \TN@rightleg{loCb}{0.50}
-        \TN@upleg{loCa}{1.00}
-        \TN@downleg{loCa}{1.00}
-        \TN@upleg{loCb}{1.00}
-        \TN@downleg{loCb}{1.00}
-        \TN@opdotleft{loCau}{(4.40,0.55)}{P_1}
-        \TN@opdotleft{loCad}{(4.40,-0.55)}{P_1}
-        \TN@opdotright{loCbu}{(5.60,0.55)}{P_2}
-        \TN@opdotright{loCbd}{(5.60,-0.55)}{P_2}
+        \TN@tensor{loCa}{(4.40,0)}
+        \TN@tensor{loCb}{(5.60,0)}
+        \TN@vpath{ (loCa.east) -- (loCb.west);}
+        \TN@vleg{loCa}{west}{-0.50,0}
+        \TN@vleg{loCb}{east}{0.50,0}
+        \TN@pleg{loCa}{north}{0,1.00}
+        \TN@pleg{loCa}{south}{0,-1.00}
+        \TN@pleg{loCb}{north}{0,1.00}
+        \TN@pleg{loCb}{south}{0,-1.00}
+        \TN@insertion[label=left:$P_1$]{loCau}{(4.40,0.55)}
+        \TN@insertion[label=left:$P_1$]{loCad}{(4.40,-0.55)}
+        \TN@insertion[label=right:$P_2$]{loCbu}{(5.60,0.55)}
+        \TN@insertion[label=right:$P_2$]{loCbd}{(5.60,-0.55)}
         \node[anchor=west] at (4.52,-0.30) {${\cal K}$};
         \node[anchor=west] at (5.72,-0.30) {${\cal K}$};
         \node at (6.65,0) {$=\;0$};
@@ -1156,22 +1208,22 @@
 % tensor.
 \newcommand{\TNMPSInverseContraction}{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{mpsiT}{(0,0.55)}
-        \TN@tensordot{mpsiB}{(0,-0.55)}
-        \TN@leftleg{mpsiT}{0.60}
-        \TN@rightleg{mpsiT}{0.60}
-        \TN@leftleg{mpsiB}{0.60}
-        \TN@rightleg{mpsiB}{0.60}
-        \draw[tn phys leg] (mpsiT.south) -- (mpsiB.north);
+        \TN@tensor{mpsiT}{(0,0.55)}
+        \TN@tensor{mpsiB}{(0,-0.55)}
+        \TN@vleg{mpsiT}{west}{-0.60,0}
+        \TN@vleg{mpsiT}{east}{0.60,0}
+        \TN@vleg{mpsiB}{west}{-0.60,0}
+        \TN@vleg{mpsiB}{east}{0.60,0}
+        \TN@ppath{ (mpsiT.south) -- (mpsiB.north);}
         \node at (-0.52,0.88) {$A^{-1}$};
         \node at (-0.42,-0.88) {$A$};
         \node at (1.35,0) {$=$};
-        \draw[tn leg] (1.90,0.55) -- (2.15,0.55)
+        \TN@vpath{ (1.90,0.55) -- (2.15,0.55)
         .. controls (2.70,0.55) and (2.70,-0.55) .. (2.15,-0.55)
-        -- (1.90,-0.55);
-        \draw[tn leg] (3.90,0.55) -- (3.65,0.55)
+        -- (1.90,-0.55);}
+        \TN@vpath{ (3.90,0.55) -- (3.65,0.55)
         .. controls (3.10,0.55) and (3.10,-0.55) .. (3.65,-0.55)
-        -- (3.90,-0.55);
+        -- (3.90,-0.55);}
     \end{tikzpicture}%
 }
 
@@ -1181,36 +1233,37 @@
 % index lines, so the direct sums are drawn as index lines.
 \newcommand{\TNBNTDecomposition}{%
     \begin{tikzpicture}[tn picture]
-        \TN@opdotabove{bntX}{(0,0)}{X}
-        \TN@tensordot{bntA}{(1.50,0)}
-        \TN@opdotabove{bntXi}{(3.00,0)}{X^{-1}}
-        \draw[tn leg] (bntX.west) -- ++(-0.55,0);
-        \draw[tn leg] (bntX.east) -- (bntA.west);
-        \draw[tn leg] (bntA.east) -- (bntXi.west);
-        \draw[tn leg] (bntXi.east) -- ++(0.55,0);
-        \TN@upleg{bntA}{0.46}
-        \TN@uplabel{bntA}{0.70}{i}
+        \TN@insertion[label=above:$X$]{bntX}{(0,0)}
+        \TN@tensor{bntA}{(1.50,0)}
+        \TN@insertion[label=above:$X^{-1}$]{bntXi}{(3.00,0)}
+        \TN@vleg{bntX}{west}{-0.55,0}
+        \TN@vconnect{bntX}{east}{bntA}{west}
+        \TN@vconnect{bntA}{east}{bntXi}{west}
+        \TN@vleg{bntXi}{east}{0.55,0}
+        \TN@pleg{bntA}{north}{0,0.46}
+        \TN@label{bntA.north}{(0,0.70)}{i}
         \node[anchor=west] at (1.62,-0.26) {$A_j$};
         \node[anchor=east] at (-0.70,0) {$\alpha$};
         \node[anchor=west] at (3.70,0) {$\beta$};
-        \draw[tn leg] (-0.60,-0.62) -- (3.60,-0.62);
-        \draw[tn leg] (-0.60,-1.02) -- (3.60,-1.02);
+        \TN@vpath{(-0.60,-0.62) -- (3.60,-0.62)}
+        \TN@vpath{(-0.60,-1.02) -- (3.60,-1.02)}
         \node[anchor=east] at (-0.70,-0.62) {$j$};
         \node[anchor=east] at (-0.70,-1.02) {$q$};
-        \draw[tn leg] (bntX.south) -- (0,-1.02);
-        \draw[tn leg] (bntA.south) -- (1.50,-0.62);
-        \draw[tn leg] (bntXi.south) -- (3.00,-1.02);
-        \node[tn tensor box]
-        (bntMu) at (0.75,-1.60) {$\mu$};
-        \draw[tn leg] ($(bntMu.north)+(-0.12,0)$) -- (0.63,-0.62);
-        \draw[tn leg] ($(bntMu.north)+(0.12,0)$) -- (0.87,-1.02);
-        \fill (0,-0.62) circle (0.05);
-        \fill (0,-1.02) circle (0.05);
-        \fill (1.50,-0.62) circle (0.05);
-        \fill (3.00,-0.62) circle (0.05);
-        \fill (3.00,-1.02) circle (0.05);
-        \fill (0.63,-0.62) circle (0.05);
-        \fill (0.87,-1.02) circle (0.05);
+        \TN@vpath{(bntX.south) -- (0,-1.02)}
+        \TN@vpath{(bntA.south) -- (1.50,-0.62)}
+        \TN@vpath{(bntXi.south) -- (3.00,-1.02)}
+        \TN@component{bntMu}{(0.75,-1.60)}{\mu}
+        \TN@northport{bntMuNLeft}{bntMu}{0.15}
+        \TN@northport{bntMuNRight}{bntMu}{0.85}
+        \TN@vpath{(bntMuNLeft) -- (0.63,-0.62)}
+        \TN@vpath{(bntMuNRight) -- (0.87,-1.02)}
+        \TN@anonymousjunction{(0,-0.62)}
+        \TN@anonymousjunction{(0,-1.02)}
+        \TN@anonymousjunction{(1.50,-0.62)}
+        \TN@anonymousjunction{(3.00,-0.62)}
+        \TN@anonymousjunction{(3.00,-1.02)}
+        \TN@anonymousjunction{(0.63,-0.62)}
+        \TN@anonymousjunction{(0.87,-1.02)}
     \end{tikzpicture}%
 }
 
@@ -1224,7 +1277,7 @@
         \node at (1.40,0) {$=$};
         \TN@tracedMPOSite{zciA}{(2.75,0)}
         \TN@tracedMPOSite{zciB}{(4.08,0)}
-        \draw[tn leg] (zciA.east) -- (zciB.west);
+        \TN@vconnect{zciA}{east}{zciB}{west}
         \node[anchor=east] at (2.61,-0.28) {$M$};
         \node[anchor=east] at (3.94,-0.28) {$M$};
         \node at (2.96,-0.92) {$\mathcal T_M$};
@@ -1239,36 +1292,32 @@
         \node (la) at (0,0) {$\alpha$};
         \node (lb) at (0.90,0) {$\beta$};
         \node (lc) at (1.80,0) {$\gamma$};
-        \node[tn map box]
-            (lab) at (0.45,0.78) {$U_{\alpha,\beta}^{\delta}$};
-        \node[tn map box]
-            (labc) at (1.12,1.62) {$U_{\delta,\gamma}^{\varepsilon}$};
-        \draw[tn leg] (la.north) -- (lab.south west);
-        \draw[tn leg] (lb.north) -- (lab.south east);
-        \draw[tn leg] (lab.north) -- (labc.south west);
-        \draw[tn leg] (lc.north) -- (labc.south east);
-        \draw[tn leg] (labc.north) -- ++(0,0.42)
-            node[above] {$\varepsilon$};
+        \TN@map{lab}{(0.45,0.78)}{U_{\alpha,\beta}^{\delta}}
+        \TN@map{labc}{(1.12,1.62)}{U_{\delta,\gamma}^{\varepsilon}}
+        \TN@vconnect{la}{north}{lab}{south west}
+        \TN@vconnect{lb}{north}{lab}{south east}
+        \TN@vconnect{lab}{north}{labc}{south west}
+        \TN@vconnect{lc}{north}{labc}{south east}
+        \TN@vpath{(labc.north) -- ++(0,0.42)
+            node[above] {$\varepsilon$}}
         \node at (0.90,-0.48) {$((\alpha\beta)\gamma)$};
 
         \node (ra) at (4.20,0) {$\alpha$};
         \node (rb) at (5.10,0) {$\beta$};
         \node (rc) at (6.00,0) {$\gamma$};
-        \node[tn map box]
-            (rbc) at (5.55,0.78) {$U_{\beta,\gamma}^{\eta}$};
-        \node[tn map box]
-            (rabc) at (4.88,1.62) {$U_{\alpha,\eta}^{\varepsilon}$};
-        \draw[tn leg] (rb.north) -- (rbc.south west);
-        \draw[tn leg] (rc.north) -- (rbc.south east);
-        \draw[tn leg] (ra.north) -- (rabc.south west);
-        \draw[tn leg] (rbc.north) -- (rabc.south east);
-        \draw[tn leg] (rabc.north) -- ++(0,0.42)
-            node[above] {$\varepsilon$};
+        \TN@map{rbc}{(5.55,0.78)}{U_{\beta,\gamma}^{\eta}}
+        \TN@map{rabc}{(4.88,1.62)}{U_{\alpha,\eta}^{\varepsilon}}
+        \TN@vconnect{rb}{north}{rbc}{south west}
+        \TN@vconnect{rc}{north}{rbc}{south east}
+        \TN@vconnect{ra}{north}{rabc}{south west}
+        \TN@vconnect{rbc}{north}{rabc}{south east}
+        \TN@vpath{(rabc.north) -- ++(0,0.42)
+            node[above] {$\varepsilon$}}
         \node at (5.10,-0.48) {$(\alpha(\beta\gamma))$};
 
-        \draw[tn basis change, <->]
+        \TN@comparisonarrow[densely dashed, line width=0.4pt]{
             (labc.east) -- node[above] {$F_{\varepsilon}^{\alpha\beta\gamma}$}
-            (rabc.west);
+            (rabc.west)}
     \end{tikzpicture}%
 }
 
@@ -1280,16 +1329,14 @@
         \node (pfLa) at (-4.20,-1.20) {$a$};
         \node (pfLb) at (-3.20,-1.20) {$b$};
         \node (pfLc) at (-2.20,-1.20) {$c$};
-        \node[tn map box]
-            (pfLab) at (-3.70,-0.34) {$X^{e}_{ab,\mu}$};
-        \node[tn map box]
-            (pfLroot) at (-3.00,0.62) {$X^{d}_{ec,\nu}$};
-        \draw[tn leg] (pfLa.north) -- (pfLab.south west);
-        \draw[tn leg] (pfLb.north) -- (pfLab.south east);
-        \draw[tn leg] (pfLab.north) -- (pfLroot.south west);
-        \draw[tn leg] (pfLc.north) -- (pfLroot.south east);
-        \draw[tn leg] (pfLroot.north) -- ++(0,0.42)
-            node[above] {$d$};
+        \TN@map{pfLab}{(-3.70,-0.34)}{X^{e}_{ab,\mu}}
+        \TN@map{pfLroot}{(-3.00,0.62)}{X^{d}_{ec,\nu}}
+        \TN@vconnect{pfLa}{north}{pfLab}{south west}
+        \TN@vconnect{pfLb}{north}{pfLab}{south east}
+        \TN@vconnect{pfLab}{north}{pfLroot}{south west}
+        \TN@vconnect{pfLc}{north}{pfLroot}{south east}
+        \TN@vpath{(pfLroot.north) -- ++(0,0.42)
+            node[above] {$d$}}
 
         \node at (-0.65,-0.12) {$=$};
         \node at (0.15,-0.12) {$\displaystyle\sum_{f,\lambda,\sigma}$};
@@ -1299,16 +1346,14 @@
         \node (pfRa) at (2.75,-1.20) {$a$};
         \node (pfRb) at (3.75,-1.20) {$b$};
         \node (pfRc) at (4.75,-1.20) {$c$};
-        \node[tn map box]
-            (pfRbc) at (4.25,-0.34) {$X^{f}_{bc,\lambda}$};
-        \node[tn map box]
-            (pfRroot) at (3.45,0.62) {$X^{d}_{af,\sigma}$};
-        \draw[tn leg] (pfRb.north) -- (pfRbc.south west);
-        \draw[tn leg] (pfRc.north) -- (pfRbc.south east);
-        \draw[tn leg] (pfRa.north) -- (pfRroot.south west);
-        \draw[tn leg] (pfRbc.north) -- (pfRroot.south east);
-        \draw[tn leg] (pfRroot.north) -- ++(0,0.42)
-            node[above] {$d$};
+        \TN@map{pfRbc}{(4.25,-0.34)}{X^{f}_{bc,\lambda}}
+        \TN@map{pfRroot}{(3.45,0.62)}{X^{d}_{af,\sigma}}
+        \TN@vconnect{pfRb}{north}{pfRbc}{south west}
+        \TN@vconnect{pfRc}{north}{pfRbc}{south east}
+        \TN@vconnect{pfRa}{north}{pfRroot}{south west}
+        \TN@vconnect{pfRbc}{north}{pfRroot}{south east}
+        \TN@vpath{(pfRroot.north) -- ++(0,0.42)
+            node[above] {$d$}}
     \end{tikzpicture}%
 }
 
@@ -1324,22 +1369,22 @@
         \node[anchor=east] at (-4.62,2.82) {\textup{selector}};
         \node[anchor=east] at (-4.62,2.42) {$S>0$};
         \foreach \x/\s in {-3.90/L,-2.86/M,-0.66/R} {
-            \TN@tensordot{ffSel\s}{(\x,2.62)}
-            \TN@upleg{ffSel\s}{0.31}
-            \TN@downleg{ffSel\s}{0.31}
+            \TN@tensor{ffSel\s}{(\x,2.62)}
+            \TN@pleg{ffSel\s}{north}{0,0.31}
+            \TN@pleg{ffSel\s}{south}{0,-0.31}
         }
-        \draw[tn leg] (ffSelL.east) -- (ffSelM.west);
-        \draw[tn leg] (ffSelM.east) -- ++(0.49,0);
-        \draw[tn leg] ($(ffSelR.west)+(-0.49,0)$) -- (ffSelR.west);
-        \TN@leftleg{ffSelL}{0.34}
-        \TN@rightleg{ffSelR}{0.34}
+        \TN@vconnect{ffSelL}{east}{ffSelM}{west}
+        \TN@vleg{ffSelM}{east}{0.49,0}
+        \TN@port{ffSelRW}{ffSelR}{west}
+        \TN@vopenport{ffSelRW}{-0.49,0}
+        \TN@vleg{ffSelL}{west}{-0.34,0}
+        \TN@vleg{ffSelR}{east}{0.34,0}
         \node at (-1.76,2.62) {$\cdots$};
         \node at (-2.28,2.14) {$M_{\varepsilon'}^{w}$};
-        \draw[tn grouping boundary]
-            (-4.33,2.03) rectangle (-0.23,3.17);
+        \TN@grouppath{(-4.33,2.03) rectangle (-0.23,3.17)}
         \node[fill=white, inner sep=1pt] at (-2.28,3.17)
             {$\displaystyle\sum_{|w|=S}c_{\varepsilon}(w)\,(\,\cdot\,)^{w}$};
-        \draw[->, tn leg] (0.12,2.62) -- (1.05,2.62);
+        \TN@vpath[->]{(0.12,2.62) -- (1.05,2.62)}
         \node[anchor=west] at (1.18,2.62)
             {$\displaystyle
               \begin{cases}
@@ -1353,31 +1398,27 @@
         \node (ffLa) at (-3.92,-0.20) {$\alpha$};
         \node (ffLb) at (-3.32,-0.20) {$\beta$};
         \node (ffLc) at (-2.72,-0.20) {$\gamma$};
-        \node[tn map box, inner sep=1.2pt]
-            (ffLab) at (-3.62,0.35) {$U_{\alpha,\beta}$};
-        \node[tn map box, inner sep=1.2pt]
-            (ffLroot) at (-3.17,0.94) {$U^{\mathrm L}$};
-        \draw[tn leg] (ffLa.north) -- (ffLab.south west);
-        \draw[tn leg] (ffLb.north) -- (ffLab.south east);
-        \draw[tn leg] (ffLab.north) -- (ffLroot.south west);
-        \draw[tn leg] (ffLc.north) -- (ffLroot.south east);
+        \TN@map[inner sep=1.2pt]{ffLab}{(-3.62,0.35)}{U_{\alpha,\beta}}
+        \TN@map[inner sep=1.2pt]{ffLroot}{(-3.17,0.94)}{U^{\mathrm L}}
+        \TN@vconnect{ffLa}{north}{ffLab}{south west}
+        \TN@vconnect{ffLb}{north}{ffLab}{south east}
+        \TN@vconnect{ffLab}{north}{ffLroot}{south west}
+        \TN@vconnect{ffLc}{north}{ffLroot}{south east}
         \node[above=1pt] at (ffLroot.north) {$\varepsilon$};
 
         \node (ffRa) at (2.48,-0.20) {$\alpha$};
         \node (ffRb) at (3.08,-0.20) {$\beta$};
         \node (ffRc) at (3.68,-0.20) {$\gamma$};
-        \node[tn map box, inner sep=1.2pt]
-            (ffRbc) at (3.38,0.35) {$U_{\beta,\gamma}$};
-        \node[tn map box, inner sep=1.2pt]
-            (ffRroot) at (2.93,0.94) {$U^{\mathrm R}$};
-        \draw[tn leg] (ffRb.north) -- (ffRbc.south west);
-        \draw[tn leg] (ffRc.north) -- (ffRbc.south east);
-        \draw[tn leg] (ffRa.north) -- (ffRroot.south west);
-        \draw[tn leg] (ffRbc.north) -- (ffRroot.south east);
+        \TN@map[inner sep=1.2pt]{ffRbc}{(3.38,0.35)}{U_{\beta,\gamma}}
+        \TN@map[inner sep=1.2pt]{ffRroot}{(2.93,0.94)}{U^{\mathrm R}}
+        \TN@vconnect{ffRb}{north}{ffRbc}{south west}
+        \TN@vconnect{ffRc}{north}{ffRbc}{south east}
+        \TN@vconnect{ffRa}{north}{ffRroot}{south west}
+        \TN@vconnect{ffRbc}{north}{ffRroot}{south east}
         \node[above=1pt] at (ffRroot.north) {$\varepsilon'$};
-        \draw[<-, tn leg] (ffLroot.east) -- node[above]
+        \TN@vpath[<-]{(ffLroot.east) -- node[above]
             {$C^{\varepsilon,\varepsilon'}_{\alpha,\beta,\gamma}$}
-            (ffRroot.west);
+            (ffRroot.west)}
         \node[anchor=west] at (4.18,0.94)
             {$=0\quad(\varepsilon\ne\varepsilon')$};
 
@@ -1390,12 +1431,11 @@
         \node[anchor=west] at (3.43,-1.48)
             {$\mathcal H^{\mathrm R}_{\varepsilon}$};
         \node[anchor=west] at (3.43,-2.08) {$\C^{D_\varepsilon}$};
-        \node[tn map box]
-            (ffF) at (0,-1.48) {$F_\varepsilon$};
-        \draw[<-, tn leg] (-3.36,-1.48) -- (ffF.west);
-        \draw[<-, tn leg] (ffF.east) -- (3.36,-1.48);
-        \draw[<-, tn leg] (-3.36,-2.08) -- node[below]
-            {$1_{D_\varepsilon}$} (3.36,-2.08);
+        \TN@map{ffF}{(0,-1.48)}{F_\varepsilon}
+        \TN@vpath[<-]{(-3.36,-1.48) -- (ffF.west)}
+        \TN@vpath[<-]{(ffF.east) -- (3.36,-1.48)}
+        \TN@vpath[<-]{(-3.36,-2.08) -- node[below]
+            {$1_{D_\varepsilon}$} (3.36,-2.08)}
         \node at (0,-2.62)
             {$C_\varepsilon=F_\varepsilon\otimes1_{D_\varepsilon},\qquad
               D_\varepsilon>0$};
@@ -1410,29 +1450,17 @@
 % only Cartesian-product reassociation; the edges do not represent F-matrices.
 \newcommand{\TNMPDOFourfoldBondReassociationPentagon}{%
     \begin{tikzpicture}[tn picture, scale=0.92]
-        \tikzset{tn assoc node/.style={
-            draw,
-            rounded corners,
-            fill=blue!8,
-            inner sep=3pt
-        },
-        tn assoc edge/.style={->, line width=0.7pt}}
-        \node[tn assoc node] (assocL) at (-5.00,0)
-            {$(((A\times B)\times C)\times D)$};
-        \node[tn assoc node] (assocLI) at (-3.00,1.80)
-            {$((A\times(B\times C))\times D)$};
-        \node[tn assoc node] (assocM) at (1.00,1.80)
-            {$(A\times((B\times C)\times D))$};
-        \node[tn assoc node] (assocR) at (4.20,0)
-            {$(A\times(B\times(C\times D)))$};
-        \node[tn assoc node] (assocP) at (-0.30,-1.80)
-            {$((A\times B)\times(C\times D))$};
+        \TN@state[inner sep=3pt]{assocL}{(-5.00,0)}{(((A\times B)\times C)\times D)}
+        \TN@state[inner sep=3pt]{assocLI}{(-3.00,1.80)}{((A\times(B\times C))\times D)}
+        \TN@state[inner sep=3pt]{assocM}{(1.00,1.80)}{(A\times((B\times C)\times D))}
+        \TN@state[inner sep=3pt]{assocR}{(4.20,0)}{(A\times(B\times(C\times D)))}
+        \TN@state[inner sep=3pt]{assocP}{(-0.30,-1.80)}{((A\times B)\times(C\times D))}
 
-        \draw[tn assoc edge] (assocL) -- node[above left] {$r_1$} (assocLI);
-        \draw[tn assoc edge] (assocLI) -- node[above] {$r_2$} (assocM);
-        \draw[tn assoc edge] (assocM) -- node[above right] {$r_3$} (assocR);
-        \draw[tn assoc edge] (assocL) -- node[below left] {$s_1$} (assocP);
-        \draw[tn assoc edge] (assocP) -- node[below right] {$s_2$} (assocR);
+        \TN@arrow[line width=0.7pt]{(assocL) -- node[above left] {$r_1$} (assocLI)}
+        \TN@arrow[line width=0.7pt]{(assocLI) -- node[above] {$r_2$} (assocM)}
+        \TN@arrow[line width=0.7pt]{(assocM) -- node[above right] {$r_3$} (assocR)}
+        \TN@arrow[line width=0.7pt]{(assocL) -- node[below left] {$s_1$} (assocP)}
+        \TN@arrow[line width=0.7pt]{(assocP) -- node[below right] {$s_2$} (assocR)}
     \end{tikzpicture}%
 }
 
@@ -1442,8 +1470,6 @@
 % Figure `pentagon` (n13.pdf) of arXiv:1511.08090.
 \newcommand{\TNMPDOCompleteZipperFusionPentagon}{%
     \begin{tikzpicture}[tn picture, scale=0.82]
-        \tikzset{tn pent edge/.style={->, line width=0.7pt}}
-
         % (((a b) c) d)
         \coordinate (pL-a) at (-5.70,0.75);
         \coordinate (pL-b) at (-5.15,0.75);
@@ -1452,10 +1478,10 @@
         \coordinate (pL-f) at (-5.42,0.22);
         \coordinate (pL-g) at (-5.00,-0.28);
         \coordinate (pL-e) at (-4.56,-0.80);
-        \draw[tn leg] (pL-a) -- (pL-f) -- (pL-b);
-        \draw[tn leg] (pL-f) -- (pL-g) -- (pL-c);
-        \draw[tn leg] (pL-g) -- (pL-e) -- (pL-d);
-        \draw[tn leg] (pL-e) -- ++(0,-0.48);
+        \TN@vpath{(pL-a) -- (pL-f) -- (pL-b)}
+        \TN@vpath{(pL-f) -- (pL-g) -- (pL-c)}
+        \TN@vpath{(pL-g) -- (pL-e) -- (pL-d)}
+        \TN@vpath{(pL-e) -- ++(0,-0.48)}
         \foreach \n/\t in {pL-a/a,pL-b/b,pL-c/c,pL-d/d}
             \node[above] at (\n) {$\t$};
         \node[left] at ($(pL-f)!0.55!(pL-g)$) {$f$};
@@ -1470,10 +1496,10 @@
         \coordinate (pLI-h) at (-3.38,2.99);
         \coordinate (pLI-g) at (-3.78,2.49);
         \coordinate (pLI-e) at (-3.28,1.97);
-        \draw[tn leg] (pLI-b) -- (pLI-h) -- (pLI-c);
-        \draw[tn leg] (pLI-a) -- (pLI-g) -- (pLI-h);
-        \draw[tn leg] (pLI-g) -- (pLI-e) -- (pLI-d);
-        \draw[tn leg] (pLI-e) -- ++(0,-0.48);
+        \TN@vpath{(pLI-b) -- (pLI-h) -- (pLI-c)}
+        \TN@vpath{(pLI-a) -- (pLI-g) -- (pLI-h)}
+        \TN@vpath{(pLI-g) -- (pLI-e) -- (pLI-d)}
+        \TN@vpath{(pLI-e) -- ++(0,-0.48)}
         \foreach \n/\t in {pLI-a/a,pLI-b/b,pLI-c/c,pLI-d/d}
             \node[above] at (\n) {$\t$};
         \node[right] at ($(pLI-h)!0.55!(pLI-g)$) {$h$};
@@ -1488,10 +1514,10 @@
         \coordinate (pM-h) at (0.92,2.99);
         \coordinate (pM-i) at (1.34,2.49);
         \coordinate (pM-e) at (0.84,1.97);
-        \draw[tn leg] (pM-b) -- (pM-h) -- (pM-c);
-        \draw[tn leg] (pM-h) -- (pM-i) -- (pM-d);
-        \draw[tn leg] (pM-a) -- (pM-e) -- (pM-i);
-        \draw[tn leg] (pM-e) -- ++(0,-0.48);
+        \TN@vpath{(pM-b) -- (pM-h) -- (pM-c)}
+        \TN@vpath{(pM-h) -- (pM-i) -- (pM-d)}
+        \TN@vpath{(pM-a) -- (pM-e) -- (pM-i)}
+        \TN@vpath{(pM-e) -- ++(0,-0.48)}
         \foreach \n/\t in {pM-a/a,pM-b/b,pM-c/c,pM-d/d}
             \node[above] at (\n) {$\t$};
         \node[left] at ($(pM-h)!0.55!(pM-i)$) {$h$};
@@ -1506,10 +1532,10 @@
         \coordinate (pR-j) at (5.42,0.22);
         \coordinate (pR-i) at (5.00,-0.28);
         \coordinate (pR-e) at (4.56,-0.80);
-        \draw[tn leg] (pR-c) -- (pR-j) -- (pR-d);
-        \draw[tn leg] (pR-b) -- (pR-i) -- (pR-j);
-        \draw[tn leg] (pR-a) -- (pR-e) -- (pR-i);
-        \draw[tn leg] (pR-e) -- ++(0,-0.48);
+        \TN@vpath{(pR-c) -- (pR-j) -- (pR-d)}
+        \TN@vpath{(pR-b) -- (pR-i) -- (pR-j)}
+        \TN@vpath{(pR-a) -- (pR-e) -- (pR-i)}
+        \TN@vpath{(pR-e) -- ++(0,-0.48)}
         \foreach \n/\t in {pR-a/a,pR-b/b,pR-c/c,pR-d/d}
             \node[above] at (\n) {$\t$};
         \node[right] at ($(pR-j)!0.55!(pR-i)$) {$j$};
@@ -1524,26 +1550,26 @@
         \coordinate (pP-f) at (-0.58,-2.63);
         \coordinate (pP-j) at (0.58,-2.63);
         \coordinate (pP-e) at (0,-3.18);
-        \draw[tn leg] (pP-a) -- (pP-f) -- (pP-b);
-        \draw[tn leg] (pP-c) -- (pP-j) -- (pP-d);
-        \draw[tn leg] (pP-f) -- (pP-e) -- (pP-j);
-        \draw[tn leg] (pP-e) -- ++(0,-0.48);
+        \TN@vpath{(pP-a) -- (pP-f) -- (pP-b)}
+        \TN@vpath{(pP-c) -- (pP-j) -- (pP-d)}
+        \TN@vpath{(pP-f) -- (pP-e) -- (pP-j)}
+        \TN@vpath{(pP-e) -- ++(0,-0.48)}
         \foreach \n/\t in {pP-a/a,pP-b/b,pP-c/c,pP-d/d}
             \node[above] at (\n) {$\t$};
         \node[left] at ($(pP-f)!0.55!(pP-e)$) {$f$};
         \node[right] at ($(pP-j)!0.55!(pP-e)$) {$j$};
         \node[below] at ($(pP-e)+(0,-0.48)$) {$e$};
 
-        \draw[tn pent edge] (-4.48,1.10) -- node[above left]
-            {$F^{abc}_{g}$} (-3.95,1.73);
-        \draw[tn pent edge] (-2.20,2.72) -- node[above]
-            {$F^{ahd}_{e}$} (-0.25,2.72);
-        \draw[tn pent edge] (1.80,1.78) -- node[above right]
-            {$F^{bcd}_{i}$} (4.15,1.08);
-        \draw[tn pent edge] (-3.95,-1.05) -- node[below left]
-            {$F^{fcd}_{e}$} (-1.02,-2.15);
-        \draw[tn pent edge] (1.02,-2.15) -- node[below right]
-            {$F^{abj}_{e}$} (3.95,-1.05);
+        \TN@arrow[line width=0.7pt]{(-4.48,1.10) -- node[above left]
+            {$F^{abc}_{g}$} (-3.95,1.73)}
+        \TN@arrow[line width=0.7pt]{(-2.20,2.72) -- node[above]
+            {$F^{ahd}_{e}$} (-0.25,2.72)}
+        \TN@arrow[line width=0.7pt]{(1.80,1.78) -- node[above right]
+            {$F^{bcd}_{i}$} (4.15,1.08)}
+        \TN@arrow[line width=0.7pt]{(-3.95,-1.05) -- node[below left]
+            {$F^{fcd}_{e}$} (-1.02,-2.15)}
+        \TN@arrow[line width=0.7pt]{(1.02,-2.15) -- node[below right]
+            {$F^{abj}_{e}$} (3.95,-1.05)}
     \end{tikzpicture}%
 }
 
@@ -1553,22 +1579,21 @@
 % direct sum without introducing an F-move.
 \newcommand{\TNMPDOBNTFusionIdentity}{%
     \begin{tikzpicture}[tn picture, scale=0.92]
-        \node[tn map box,
-            minimum height=1.16cm] (bfiU) at (-2.20,0) {$U_{\alpha,\beta}$};
-        \TN@tensordot{bfiA}{(-0.95,0.42)}
-        \TN@tensordot{bfiB}{(-0.95,-0.42)}
-        \node[tn map box,
-            minimum height=1.16cm] (bfiUd) at (0.30,0)
-            {$U_{\alpha,\beta}^{\dagger}$};
-        \draw[tn leg] (bfiU.north east) -- (bfiA.west);
-        \draw[tn leg] (bfiU.south east) -- (bfiB.west);
-        \draw[tn leg] (bfiA.east) -- (bfiUd.north west);
-        \draw[tn leg] (bfiB.east) -- (bfiUd.south west);
-        \draw[tn leg] (bfiU.west) -- ++(-0.48,0);
-        \draw[tn leg] (bfiUd.east) -- ++(0.48,0);
-        \draw[tn phys leg] (bfiA.south) -- (bfiB.north);
-        \TN@upleg{bfiA}{0.42}
-        \TN@downleg{bfiB}{0.42}
+        \TN@splitmap[minimum height=1.16cm]
+            {bfiU}{(-2.20,0)}{U_{\alpha,\beta}}
+        \TN@mposite{bfiA}{(-0.95,0.42)}{}
+        \TN@mposite{bfiB}{(-0.95,-0.42)}{}
+        \TN@mergemap[minimum height=1.16cm]
+            {bfiUd}{(0.30,0)}{U_{\alpha,\beta}^{\dagger}}
+        \TN@vconnectports{bfiUUp}{bfiAW}
+        \TN@vconnectports{bfiUDown}{bfiBW}
+        \TN@vconnectports{bfiAE}{bfiUdUp}
+        \TN@vconnectports{bfiBE}{bfiUdDown}
+        \TN@vopenport{bfiUMid}{-0.48,0}
+        \TN@vopenport{bfiUdMid}{0.48,0}
+        \TN@pconnect{bfiA}{south}{bfiB}{north}
+        \TN@pleg{bfiA}{north}{0,0.42}
+        \TN@pleg{bfiB}{south}{0,-0.42}
         \node at (-0.68,0.68) {$M_\alpha$};
         \node at (-0.68,-0.68) {$M_\beta$};
         \node at (-1.17,1.06) {$i$};
@@ -1576,16 +1601,15 @@
 
         \node at (1.42,0) {$=$};
         \node at (2.32,0) {$\displaystyle\bigoplus_\gamma$};
-        \node[tn tensor box, minimum width=1.08cm, minimum height=0.48cm,
-            inner sep=1pt] (bfiChi) at (3.65,0.55)
-            {$\chi_{\alpha,\beta,\gamma}$};
-        \TN@tensordot{bfiG}{(3.65,-0.36)}
-        \TN@leftleg{bfiChi}{0.48}
-        \TN@rightleg{bfiChi}{0.48}
-        \TN@leftleg{bfiG}{0.48}
-        \TN@rightleg{bfiG}{0.48}
-        \TN@upleg{bfiG}{0.42}
-        \TN@downleg{bfiG}{0.42}
+        \TN@factor[minimum width=1.08cm, minimum height=0.48cm, inner sep=1pt]
+            {bfiChi}{(3.65,0.55)}{\chi_{\alpha,\beta,\gamma}}
+        \TN@tensor{bfiG}{(3.65,-0.36)}
+        \TN@vleg{bfiChi}{west}{-0.48,0}
+        \TN@vleg{bfiChi}{east}{0.48,0}
+        \TN@vleg{bfiG}{west}{-0.48,0}
+        \TN@vleg{bfiG}{east}{0.48,0}
+        \TN@pleg{bfiG}{north}{0,0.42}
+        \TN@pleg{bfiG}{south}{0,-0.42}
         \node at (3.94,-0.36) {$M_\gamma$};
         \node at (3.46,0.20) {$i$};
         \node at (3.46,-0.92) {$j$};
@@ -1602,94 +1626,90 @@
         % U (M_alpha M_beta) = H U.
         \node[anchor=east] at (-4.72,2.35)
             {$U(M_\alpha M_\beta)=HU$};
-        \node[tn map box,
-            minimum height=1.10cm] (uzTopL) at (-3.78,2.35) {$U$};
-        \TN@tensordot{uzTopA}{(-2.48,2.72)}
-        \TN@tensordot{uzTopB}{(-2.48,1.98)}
-        \draw[tn leg] (uzTopL.west) -- ++(-0.42,0);
-        \draw[tn leg] (uzTopL.north east) -- (uzTopA.west);
-        \draw[tn leg] (uzTopL.south east) -- (uzTopB.west);
-        \TN@rightleg{uzTopA}{0.42}
-        \TN@rightleg{uzTopB}{0.42}
-        \draw[tn phys leg] (uzTopA.south) -- (uzTopB.north);
-        \TN@upleg{uzTopA}{0.34}
-        \TN@downleg{uzTopB}{0.34}
+        \TN@splitmap[minimum height=1.10cm]{uzTopL}{(-3.78,2.35)}{U}
+        \TN@mposite{uzTopA}{(-2.48,2.72)}{}
+        \TN@mposite{uzTopB}{(-2.48,1.98)}{}
+        \TN@vopenport{uzTopLMid}{-0.42,0}
+        \TN@vconnectports{uzTopLUp}{uzTopAW}
+        \TN@vconnectports{uzTopLDown}{uzTopBW}
+        \TN@vopenport{uzTopAE}{0.42,0}
+        \TN@vopenport{uzTopBE}{0.42,0}
+        \TN@pconnect{uzTopA}{south}{uzTopB}{north}
+        \TN@pleg{uzTopA}{north}{0,0.34}
+        \TN@pleg{uzTopB}{south}{0,-0.34}
         \node at (-2.18,2.72) {$M_\alpha$};
         \node at (-2.18,1.98) {$M_\beta$};
         \node at (-1.42,2.35) {$=$};
-        \node[tn tensor box, minimum width=0.72cm,
-            minimum height=0.52cm, inner sep=1pt]
-            (uzTopH) at (-0.52,2.35) {$H$};
-        \node[tn map box,
-            minimum height=1.10cm] (uzTopR) at (0.80,2.35) {$U$};
-        \draw[tn leg] (uzTopH.west) -- ++(-0.42,0);
-        \draw[tn leg] (uzTopH.east) -- (uzTopR.west);
-        \draw[tn leg] (uzTopR.north east) -- ++(0.56,0);
-        \draw[tn leg] (uzTopR.south east) -- ++(0.56,0);
-        \TN@upleg{uzTopH}{0.34}
-        \TN@downleg{uzTopH}{0.34}
+        \TN@component[minimum width=0.72cm, minimum height=0.52cm, inner sep=1pt]
+            {uzTopH}{(-0.52,2.35)}{H}
+        \TN@splitmap[minimum height=1.10cm]{uzTopR}{(0.80,2.35)}{U}
+        \TN@port{uzTopHW}{uzTopH}{west}
+        \TN@port{uzTopHE}{uzTopH}{east}
+        \TN@vopenport{uzTopHW}{-0.42,0}
+        \TN@vconnectports{uzTopHE}{uzTopRMid}
+        \TN@vopenport{uzTopRUp}{0.56,0}
+        \TN@vopenport{uzTopRDown}{0.56,0}
+        \TN@pleg{uzTopH}{north}{0,0.34}
+        \TN@pleg{uzTopH}{south}{0,-0.34}
 
         % (M_alpha M_beta) U^dagger = U^dagger H.
         \node[anchor=east] at (-4.72,0)
             {$(M_\alpha M_\beta)U^\dagger=U^\dagger H$};
-        \TN@tensordot{uzBotA}{(-3.78,0.37)}
-        \TN@tensordot{uzBotB}{(-3.78,-0.37)}
-        \TN@leftleg{uzBotA}{0.42}
-        \TN@leftleg{uzBotB}{0.42}
-        \draw[tn phys leg] (uzBotA.south) -- (uzBotB.north);
-        \TN@upleg{uzBotA}{0.34}
-        \TN@downleg{uzBotB}{0.34}
+        \TN@mposite{uzBotA}{(-3.78,0.37)}{}
+        \TN@mposite{uzBotB}{(-3.78,-0.37)}{}
+        \TN@vopenport{uzBotAW}{-0.42,0}
+        \TN@vopenport{uzBotBW}{-0.42,0}
+        \TN@pconnect{uzBotA}{south}{uzBotB}{north}
+        \TN@pleg{uzBotA}{north}{0,0.34}
+        \TN@pleg{uzBotB}{south}{0,-0.34}
         \node at (-3.48,0.37) {$M_\alpha$};
         \node at (-3.48,-0.37) {$M_\beta$};
-        \node[tn map box,
-            minimum height=1.10cm] (uzBotL) at (-2.48,0) {$U^\dagger$};
-        \draw[tn leg] (uzBotA.east) -- (uzBotL.north west);
-        \draw[tn leg] (uzBotB.east) -- (uzBotL.south west);
-        \draw[tn leg] (uzBotL.east) -- ++(0.42,0);
+        \TN@mergemap[minimum height=1.10cm]{uzBotL}{(-2.48,0)}{U^\dagger}
+        \TN@vconnectports{uzBotAE}{uzBotLUp}
+        \TN@vconnectports{uzBotBE}{uzBotLDown}
+        \TN@vopenport{uzBotLMid}{0.42,0}
         \node at (-1.42,0) {$=$};
-        \node[tn map box,
-            minimum height=1.10cm] (uzBotR) at (-0.52,0) {$U^\dagger$};
-        \node[tn tensor box, minimum width=0.72cm,
-            minimum height=0.52cm, inner sep=1pt]
-            (uzBotH) at (0.80,0) {$H$};
-        \draw[tn leg] (uzBotR.north west) -- ++(-0.56,0);
-        \draw[tn leg] (uzBotR.south west) -- ++(-0.56,0);
-        \draw[tn leg] (uzBotR.east) -- (uzBotH.west);
-        \draw[tn leg] (uzBotH.east) -- ++(0.42,0);
-        \TN@upleg{uzBotH}{0.34}
-        \TN@downleg{uzBotH}{0.34}
+        \TN@mergemap[minimum height=1.10cm]{uzBotR}{(-0.52,0)}{U^\dagger}
+        \TN@component[minimum width=0.72cm, minimum height=0.52cm, inner sep=1pt]
+            {uzBotH}{(0.80,0)}{H}
+        \TN@port{uzBotHW}{uzBotH}{west}
+        \TN@port{uzBotHE}{uzBotH}{east}
+        \TN@vopenport{uzBotRUp}{-0.56,0}
+        \TN@vopenport{uzBotRDown}{-0.56,0}
+        \TN@vconnectports{uzBotRMid}{uzBotHW}
+        \TN@vopenport{uzBotHE}{0.42,0}
+        \TN@pleg{uzBotH}{north}{0,0.34}
+        \TN@pleg{uzBotH}{south}{0,-0.34}
 
         % Local reconstruction M_alpha M_beta = U^dagger H U.
         \node[anchor=east] at (-4.72,-2.42)
             {$M_\alpha M_\beta=U^\dagger H U$};
-        \TN@tensordot{uzRecA}{(-3.78,-2.05)}
-        \TN@tensordot{uzRecB}{(-3.78,-2.79)}
-        \TN@leftleg{uzRecA}{0.42}
-        \TN@leftleg{uzRecB}{0.42}
-        \TN@rightleg{uzRecA}{0.42}
-        \TN@rightleg{uzRecB}{0.42}
-        \draw[tn phys leg] (uzRecA.south) -- (uzRecB.north);
-        \TN@upleg{uzRecA}{0.34}
-        \TN@downleg{uzRecB}{0.34}
+        \TN@mposite{uzRecA}{(-3.78,-2.05)}{}
+        \TN@mposite{uzRecB}{(-3.78,-2.79)}{}
+        \TN@vopenport{uzRecAW}{-0.42,0}
+        \TN@vopenport{uzRecBW}{-0.42,0}
+        \TN@vopenport{uzRecAE}{0.42,0}
+        \TN@vopenport{uzRecBE}{0.42,0}
+        \TN@pconnect{uzRecA}{south}{uzRecB}{north}
+        \TN@pleg{uzRecA}{north}{0,0.34}
+        \TN@pleg{uzRecB}{south}{0,-0.34}
         \node at (-3.48,-2.05) {$M_\alpha$};
         \node at (-3.48,-2.79) {$M_\beta$};
         \node at (-2.68,-2.42) {$=$};
-        \node[tn map box,
-            minimum height=1.10cm] (uzRecUd) at (-1.72,-2.42)
-            {$U^\dagger$};
-        \node[tn tensor box, minimum width=0.72cm,
-            minimum height=0.52cm, inner sep=1pt]
-            (uzRecH) at (-0.40,-2.42) {$H$};
-        \node[tn map box,
-            minimum height=1.10cm] (uzRecU) at (0.92,-2.42) {$U$};
-        \draw[tn leg] (uzRecUd.north west) -- ++(-0.52,0);
-        \draw[tn leg] (uzRecUd.south west) -- ++(-0.52,0);
-        \draw[tn leg] (uzRecUd.east) -- (uzRecH.west);
-        \draw[tn leg] (uzRecH.east) -- (uzRecU.west);
-        \draw[tn leg] (uzRecU.north east) -- ++(0.52,0);
-        \draw[tn leg] (uzRecU.south east) -- ++(0.52,0);
-        \TN@upleg{uzRecH}{0.34}
-        \TN@downleg{uzRecH}{0.34}
+        \TN@mergemap[minimum height=1.10cm]{uzRecUd}{(-1.72,-2.42)}{U^\dagger}
+        \TN@component[minimum width=0.72cm, minimum height=0.52cm, inner sep=1pt]
+            {uzRecH}{(-0.40,-2.42)}{H}
+        \TN@splitmap[minimum height=1.10cm]{uzRecU}{(0.92,-2.42)}{U}
+        \TN@port{uzRecHW}{uzRecH}{west}
+        \TN@port{uzRecHE}{uzRecH}{east}
+        \TN@vopenport{uzRecUdUp}{-0.52,0}
+        \TN@vopenport{uzRecUdDown}{-0.52,0}
+        \TN@vconnectports{uzRecUdMid}{uzRecHW}
+        \TN@vconnectports{uzRecHE}{uzRecUMid}
+        \TN@vopenport{uzRecUUp}{0.52,0}
+        \TN@vopenport{uzRecUDown}{0.52,0}
+        \TN@pleg{uzRecH}{north}{0,0.34}
+        \TN@pleg{uzRecH}{south}{0,-0.34}
         \node[anchor=west] at (-1.72,-3.48)
             {local reconstruction; not total-fusion completeness};
     \end{tikzpicture}%
@@ -1700,27 +1720,29 @@
 \newcommand{\TNMPDOFusionTracePower}{%
     \begin{tikzpicture}[tn picture, scale=0.82]
         \foreach \x/\s in {0/L,1.10/M,3.20/R} {
-            \TN@tensordot{ftpA\s}{(\x,0.52)}
-            \TN@tensordot{ftpB\s}{(\x,-0.52)}
-            \draw[tn phys leg] (ftpA\s.south) -- (ftpB\s.north);
+            \TN@tensor{ftpA\s}{(\x,0.52)}
+            \TN@tensor{ftpB\s}{(\x,-0.52)}
+            \TN@pconnect{ftpA\s}{south}{ftpB\s}{north}
         }
-        \draw[tn leg] (ftpAL.east) -- (ftpAM.west);
-        \draw[tn leg] (ftpAM.east) -- ++(0.52,0);
-        \draw[tn leg] ($(ftpAR.west)+(-0.52,0)$) -- (ftpAR.west);
-        \draw[tn leg] (ftpBL.east) -- (ftpBM.west);
-        \draw[tn leg] (ftpBM.east) -- ++(0.52,0);
-        \draw[tn leg] ($(ftpBR.west)+(-0.52,0)$) -- (ftpBR.west);
+        \TN@vconnect{ftpAL}{east}{ftpAM}{west}
+        \TN@vleg{ftpAM}{east}{0.52,0}
+        \TN@port{ftpARW}{ftpAR}{west}
+        \TN@vopenport{ftpARW}{-0.52,0}
+        \TN@vconnect{ftpBL}{east}{ftpBM}{west}
+        \TN@vleg{ftpBM}{east}{0.52,0}
+        \TN@port{ftpBRW}{ftpBR}{west}
+        \TN@vopenport{ftpBRW}{-0.52,0}
         \node at (2.15,0.52) {$\cdots$};
         \node at (2.15,-0.52) {$\cdots$};
-        \draw[tn virtual closure] (ftpAL.west) -- ++(-0.40,0) -- ++(0,0.86)
+        \TN@vtracepath{(ftpAL.west) -- ++(-0.40,0) -- ++(0,0.86)
             -- ($(ftpAR.east)+(0.40,0.86)$) -- ($(ftpAR.east)+(0.40,0)$)
-            -- (ftpAR.east);
-        \draw[tn virtual closure] (ftpBL.west) -- ++(-0.40,0) -- ++(0,-0.86)
+            -- (ftpAR.east)}
+        \TN@vtracepath{(ftpBL.west) -- ++(-0.40,0) -- ++(0,-0.86)
             -- ($(ftpBR.east)+(0.40,-0.86)$) -- ($(ftpBR.east)+(0.40,0)$)
-            -- (ftpBR.east);
+            -- (ftpBR.east)}
         \foreach \s in {L,M,R} {
-            \TN@upleg{ftpA\s}{0.34}
-            \TN@downleg{ftpB\s}{0.34}
+            \TN@pleg{ftpA\s}{north}{0,0.34}
+            \TN@pleg{ftpB\s}{south}{0,-0.34}
         }
         \node[anchor=east] at (-0.60,0.52) {$M_\alpha$};
         \node[anchor=east] at (-0.60,-0.52) {$M_\beta$};
@@ -1728,26 +1750,28 @@
         \node at (4.82,0) {$\displaystyle\sum_\gamma$};
 
         \foreach \x/\s in {5.65/L,6.75/M,8.85/R} {
-            \TN@opdot{ftpC\s}{(\x,0.52)}
-            \TN@tensordot{ftpG\s}{(\x,-0.52)}
+            \TN@insertion{ftpC\s}{(\x,0.52)}
+            \TN@tensor{ftpG\s}{(\x,-0.52)}
         }
-        \draw[tn leg] (ftpCL.east) -- (ftpCM.west);
-        \draw[tn leg] (ftpCM.east) -- ++(0.52,0);
-        \draw[tn leg] ($(ftpCR.west)+(-0.52,0)$) -- (ftpCR.west);
-        \draw[tn leg] (ftpGL.east) -- (ftpGM.west);
-        \draw[tn leg] (ftpGM.east) -- ++(0.52,0);
-        \draw[tn leg] ($(ftpGR.west)+(-0.52,0)$) -- (ftpGR.west);
+        \TN@vconnect{ftpCL}{east}{ftpCM}{west}
+        \TN@vleg{ftpCM}{east}{0.52,0}
+        \TN@port{ftpCRW}{ftpCR}{west}
+        \TN@vopenport{ftpCRW}{-0.52,0}
+        \TN@vconnect{ftpGL}{east}{ftpGM}{west}
+        \TN@vleg{ftpGM}{east}{0.52,0}
+        \TN@port{ftpGRW}{ftpGR}{west}
+        \TN@vopenport{ftpGRW}{-0.52,0}
         \node at (7.80,0.52) {$\cdots$};
         \node at (7.80,-0.52) {$\cdots$};
-        \draw[tn virtual closure] (ftpCL.west) -- ++(-0.40,0) -- ++(0,0.86)
+        \TN@vtracepath{(ftpCL.west) -- ++(-0.40,0) -- ++(0,0.86)
             -- ($(ftpCR.east)+(0.40,0.86)$) -- ($(ftpCR.east)+(0.40,0)$)
-            -- (ftpCR.east);
-        \draw[tn virtual closure] (ftpGL.west) -- ++(-0.40,0) -- ++(0,-0.86)
+            -- (ftpCR.east)}
+        \TN@vtracepath{(ftpGL.west) -- ++(-0.40,0) -- ++(0,-0.86)
             -- ($(ftpGR.east)+(0.40,-0.86)$) -- ($(ftpGR.east)+(0.40,0)$)
-            -- (ftpGR.east);
+            -- (ftpGR.east)}
         \foreach \s in {L,M,R} {
-            \TN@upleg{ftpG\s}{0.34}
-            \TN@downleg{ftpG\s}{0.34}
+            \TN@pleg{ftpG\s}{north}{0,0.34}
+            \TN@pleg{ftpG\s}{south}{0,-0.34}
         }
         \node[anchor=east] at (5.05,0.52) {$\chi_{\alpha,\beta,\gamma}$};
         \node[anchor=east] at (5.05,-0.52) {$M_\gamma$};
@@ -1765,71 +1789,69 @@
         \node at (-5.34,-0.08) {$Q=$};
 
         % First visible fusion factor.
-        \node[tn tensor box, minimum width=0.76cm,
-            minimum height=0.66cm, inner sep=1pt] (rqXone) at (-4.58,-0.44)
-            {$X$};
-        \foreach \x in {-3.92,-3.68,-3.44}
-            \draw[tn leg] (\x,-1.28) -- (\x,1.30);
+        \TN@map[minimum width=0.76cm, minimum height=0.66cm, inner sep=1pt]
+            {rqXone}{(-4.58,-0.44)}{X}
+        \foreach \x in {-3.92,-3.68,-3.44} {
+            \TN@vpath{(\x,-1.28) -- (\x,1.30)}
+        }
         \foreach \y/\x in {-0.18/-3.92,-0.34/-3.68,-0.50/-3.44} {
-            \draw[tn leg] (rqXone.east |- 0,\y) -- (\x,\y);
-            \fill (\x,\y) circle[radius=0.055cm];
+            \TN@vpath{(rqXone.east |- 0,\y) -- (\x,\y)}
+            \TN@anonymousjunction{(\x,\y)}
         }
 
         % Second factor; the lowest wire from the first factor is retained.
-        \node[tn tensor box, minimum width=0.76cm,
-            minimum height=0.66cm, inner sep=1pt] (rqXtwo) at (-2.76,-0.02)
-            {$X$};
-        \foreach \x in {-2.10,-1.86,-1.62}
-            \draw[tn leg] (\x,-1.28) -- (\x,1.30);
+        \TN@map[minimum width=0.76cm, minimum height=0.66cm, inner sep=1pt]
+            {rqXtwo}{(-2.76,-0.02)}{X}
+        \foreach \x in {-2.10,-1.86,-1.62} {
+            \TN@vpath{(\x,-1.28) -- (\x,1.30)}
+        }
         \foreach \y/\x in {0.24/-2.10,0.08/-1.86,-0.08/-1.62} {
-            \draw[tn leg] (rqXtwo.east |- 0,\y) -- (\x,\y);
-            \fill (\x,\y) circle[radius=0.055cm];
+            \TN@vpath{(rqXtwo.east |- 0,\y) -- (\x,\y)}
+            \TN@anonymousjunction{(\x,\y)}
         }
 
         % Third factor; each preceding lower wire ends on the middle vertical
         % of the next fusion bundle.
-        \node[tn tensor box, minimum width=0.76cm,
-            minimum height=0.66cm, inner sep=1pt] (rqXthree) at (-0.94,0.40)
-            {$X$};
-        \foreach \x in {-0.28,-0.04,0.20}
-            \draw[tn leg] (\x,-1.28) -- (\x,1.30);
-        \foreach \y/\x in {0.66/-0.28,0.50/-0.04,0.34/0.20} {
-            \draw[tn leg] (rqXthree.east |- 0,\y) -- (\x,\y);
-            \fill (\x,\y) circle[radius=0.055cm];
+        \TN@map[minimum width=0.76cm, minimum height=0.66cm, inner sep=1pt]
+            {rqXthree}{(-0.94,0.40)}{X}
+        \foreach \x in {-0.28,-0.04,0.20} {
+            \TN@vpath{(\x,-1.28) -- (\x,1.30)}
         }
-        \draw[tn leg] (rqXone.east |- 0,-0.66) -- (-1.86,-0.66);
-        \fill (-1.86,-0.66) circle[radius=0.055cm];
-        \draw[tn leg] (rqXtwo.east |- 0,-0.24) -- (-0.04,-0.24);
-        \fill (-0.04,-0.24) circle[radius=0.055cm];
-        \draw[tn leg] (rqXthree.east |- 0,0.10) -- (1.02,0.10);
+        \foreach \y/\x in {0.66/-0.28,0.50/-0.04,0.34/0.20} {
+            \TN@vpath{(rqXthree.east |- 0,\y) -- (\x,\y)}
+            \TN@anonymousjunction{(\x,\y)}
+        }
+        \TN@vpath{(rqXone.east |- 0,-0.66) -- (-1.86,-0.66)}
+        \TN@anonymousjunction{(-1.86,-0.66)}
+        \TN@vpath{(rqXtwo.east |- 0,-0.24) -- (-0.04,-0.24)}
+        \TN@anonymousjunction{(-0.04,-0.24)}
+        \TN@vpath{(rqXthree.east |- 0,0.10) -- (1.02,0.10)}
 
         \node at (1.30,0.10) {$\cdots$};
 
         % Final visible factor and the terminal traced tensor.
-        \node[tn tensor box, minimum width=0.76cm,
-            minimum height=0.66cm, inner sep=1pt] (rqXlast) at (2.40,0.48)
-            {$X$};
-        \foreach \x in {3.06,3.30,3.54}
-            \draw[tn leg] (\x,-1.28) -- (\x,1.30);
-        \foreach \y/\x in {0.74/3.06,0.58/3.30,0.42/3.54} {
-            \draw[tn leg] (rqXlast.east |- 0,\y) -- (\x,\y);
-            \fill (\x,\y) circle[radius=0.055cm];
+        \TN@map[minimum width=0.76cm, minimum height=0.66cm, inner sep=1pt]{rqXlast}{(2.40,0.48)}{X}
+        \foreach \x in {3.06,3.30,3.54} {
+            \TN@vpath{(\x,-1.28) -- (\x,1.30)}
         }
-        \draw[tn leg] (rqXlast.east |- 0,0.26) -- (3.84,0.26);
-        \draw[tn leg] (3.84,-1.28) -- (3.84,1.30);
-        \fill (3.84,0.26) circle[radius=0.055cm];
-        \draw[tn leg] (1.58,0.10) -- (3.30,0.10);
-        \fill (3.30,0.10) circle[radius=0.055cm];
-        \fill (3.84,-0.66) circle[radius=0.055cm];
+        \foreach \y/\x in {0.74/3.06,0.58/3.30,0.42/3.54} {
+            \TN@vpath{(rqXlast.east |- 0,\y) -- (\x,\y)}
+            \TN@anonymousjunction{(\x,\y)}
+        }
+        \TN@vpath{(rqXlast.east |- 0,0.26) -- (3.84,0.26)}
+        \TN@vpath{(3.84,-1.28) -- (3.84,1.30)}
+        \TN@anonymousjunction{(3.84,0.26)}
+        \TN@vpath{(1.58,0.10) -- (3.30,0.10)}
+        \TN@anonymousjunction{(3.30,0.10)}
+        \TN@anonymousjunction{(3.84,-0.66)}
 
-        \node[tn tensor box, minimum width=0.82cm,
-            minimum height=0.68cm, inner sep=1pt] (rqM) at (4.72,-0.66)
-            {$M_\gamma$};
-        \draw[tn leg] (3.84,-0.66) -- (rqM.west);
-        \draw[tn leg] (rqM.north) -- ++(0,0.72);
-        \draw[tn leg] (rqM.south) -- ++(0,-0.34);
-        \draw[tn virtual closure] (rqM.south west) .. controls +(0,-0.38) and +(0,-0.38)
-            .. (rqM.south east);
+        \TN@component[minimum width=0.82cm, minimum height=0.68cm, inner sep=1pt]
+            {rqM}{(4.72,-0.66)}{M_\gamma}
+        \TN@vpath{(3.84,-0.66) -- (rqM.west)}
+        \TN@vleg{rqM}{north}{0,0.72}
+        \TN@vleg{rqM}{south}{0,-0.34}
+        \TN@vtracepath{(rqM.south west) .. controls +(0,-0.38) and +(0,-0.38)
+            .. (rqM.south east)}
         \node[below] at (rqM.south |- 0,-1.58)
             {$\operatorname{tr}(M_\gamma)$};
     \end{tikzpicture}%
@@ -1846,30 +1868,29 @@
 \newcommand{\TNAppendixBAdjacentBondProjectors}{%
     \begin{tikzpicture}[tn picture, scale=0.92]
         \foreach \x/\name in {0/rfpUzero,2.20/rfpUone,4.40/rfpUtwo} {
-            \node[tn map box, minimum width=0.72cm, minimum height=0.58cm]
-                (\name) at (\x,0.92) {$U$};
-            \draw[tn phys leg] (\name.north) -- ++(0,0.42);
+            \TN@map[minimum width=0.72cm, minimum height=0.58cm]{\name}{(\x,0.92)}{U}
+            \TN@southport{\name Left}{\name}{0.28}
+            \TN@southport{\name Right}{\name}{0.72}
+            \TN@pleg{\name}{north}{0,0.42}
         }
-        \node[tn tensor box, minimum width=0.68cm, minimum height=0.50cm]
-            (rfpPhiZero) at (1.10,0) {$\varphi$};
-        \node[tn tensor box, minimum width=0.68cm, minimum height=0.50cm]
-            (rfpPhiOne) at (3.30,0) {$\varphi$};
-        \draw[tn leg] ($(rfpUzero.south)+(-0.16,0)$) -- ++(0,-0.42)
-            -- (rfpPhiZero.west);
-        \draw[tn leg] (rfpPhiZero.east) -- ++(0.36,0)
-            -- ($(rfpUone.south)+(-0.16,0)$);
-        \draw[tn leg] ($(rfpUone.south)+(0.16,0)$) -- ++(0,-0.42)
-            -- (rfpPhiOne.west);
-        \draw[tn leg] (rfpPhiOne.east) -- ++(0.36,0)
-            -- ($(rfpUtwo.south)+(0.16,0)$);
-        \draw[tn leg] ($(rfpUzero.south)+(0.16,0)$) -- ++(0,-0.80) -- ++(-0.76,0);
-        \draw[tn leg] ($(rfpUtwo.south)+(-0.16,0)$) -- ++(0,-0.80) -- ++(0.76,0);
-        \draw[red, rounded corners]
+        \TN@state[minimum width=0.68cm, minimum height=0.50cm]{rfpPhiZero}{(1.10,0)}{\varphi}
+        \TN@state[minimum width=0.68cm, minimum height=0.50cm]{rfpPhiOne}{(3.30,0)}{\varphi}
+        \TN@port{rfpPhiZeroW}{rfpPhiZero}{west}
+        \TN@port{rfpPhiZeroE}{rfpPhiZero}{east}
+        \TN@port{rfpPhiOneW}{rfpPhiOne}{west}
+        \TN@port{rfpPhiOneE}{rfpPhiOne}{east}
+        \TN@vpath{(rfpUzeroLeft) -- ++(0,-0.42) -- (rfpPhiZeroW)}
+        \TN@vpath{(rfpPhiZeroE) -- ++(0.36,0) -- (rfpUoneLeft)}
+        \TN@vpath{(rfpUoneRight) -- ++(0,-0.42) -- (rfpPhiOneW)}
+        \TN@vpath{(rfpPhiOneE) -- ++(0.36,0) -- (rfpUtwoRight)}
+        \TN@vpath{(rfpUzeroRight) -- ++(0,-0.80) -- ++(-0.76,0)}
+        \TN@vpath{(rfpUtwoLeft) -- ++(0,-0.80) -- ++(0.76,0)}
+        \TN@selectedpath[rounded corners=3pt, line width=0.4pt]{
             ($(rfpPhiZero.south west)+(-0.07,-0.07)$) rectangle
-            ($(rfpPhiZero.north east)+(0.07,0.07)$);
-        \draw[red, rounded corners]
+            ($(rfpPhiZero.north east)+(0.07,0.07)$)}
+        \TN@selectedpath[rounded corners=3pt, line width=0.4pt]{
             ($(rfpPhiOne.south west)+(-0.07,-0.07)$) rectangle
-            ($(rfpPhiOne.north east)+(0.07,0.07)$);
+            ($(rfpPhiOne.north east)+(0.07,0.07)$)}
         \node[red] at (1.10,-0.55) {$P_{01}$};
         \node[red] at (3.30,-0.55) {$P_{12}$};
     \end{tikzpicture}%
@@ -1882,37 +1903,34 @@
 \newcommand{\TNAppendixBPhysicalSupportTransport}{%
     \begin{tikzpicture}[tn picture, scale=0.90]
         \foreach \x/\name in {0/rfpTzero,2.20/rfpTone,4.40/rfpTtwo} {
-            \node[tn map box, minimum width=0.72cm, minimum height=0.58cm]
-                (\name) at (\x,0.72) {$U$};
-            \draw[tn phys leg] (\name.north) -- ++(0,0.52);
-            \fill[black] ($(\name.north)+(0,0.52)$) circle (1.4pt);
+            \TN@map[minimum width=0.72cm, minimum height=0.58cm]{\name}{(\x,0.72)}{U}
+            \TN@southport{\name Left}{\name}{0.28}
+            \TN@southport{\name Right}{\name}{0.72}
+            \TN@pleg{\name}{north}{0,0.52}
+            \TN@anonymousjunction{($(\name.north)+(0,0.52)$)}
         }
-        \node[tn tensor box, minimum width=0.68cm, minimum height=0.50cm]
-            (rfpTPhiZero) at (1.10,-0.12) {$\varphi$};
-        \node[tn tensor box, minimum width=0.68cm, minimum height=0.50cm]
-            (rfpTPhiOne) at (3.30,-0.12) {$\varphi$};
-        \draw[tn leg] ($(rfpTzero.south)+(-0.16,0)$) -- ++(0,-0.42)
-            -- (rfpTPhiZero.west);
-        \draw[tn leg] (rfpTPhiZero.east) -- ++(0.36,0)
-            -- ($(rfpTone.south)+(-0.16,0)$);
-        \draw[tn leg] ($(rfpTone.south)+(0.16,0)$) -- ++(0,-0.42)
-            -- (rfpTPhiOne.west);
-        \draw[tn leg] (rfpTPhiOne.east) -- ++(0.36,0)
-            -- ($(rfpTtwo.south)+(0.16,0)$);
-        \draw[tn leg] ($(rfpTzero.south)+(0.16,0)$) -- ++(0,-0.80) -- ++(-0.76,0);
-        \draw[tn leg] ($(rfpTtwo.south)+(-0.16,0)$) -- ++(0,-0.80) -- ++(0.76,0);
-        \draw[red, rounded corners=4pt, line width=0.7pt]
-            (-0.34,1.44) rectangle (2.54,1.74);
-        \draw[red, rounded corners=4pt, line width=0.7pt]
-            (1.86,1.84) rectangle (4.74,2.14);
+        \TN@state[minimum width=0.68cm, minimum height=0.50cm]{rfpTPhiZero}{(1.10,-0.12)}{\varphi}
+        \TN@state[minimum width=0.68cm, minimum height=0.50cm]{rfpTPhiOne}{(3.30,-0.12)}{\varphi}
+        \TN@port{rfpTPhiZeroW}{rfpTPhiZero}{west}
+        \TN@port{rfpTPhiZeroE}{rfpTPhiZero}{east}
+        \TN@port{rfpTPhiOneW}{rfpTPhiOne}{west}
+        \TN@port{rfpTPhiOneE}{rfpTPhiOne}{east}
+        \TN@vpath{(rfpTzeroLeft) -- ++(0,-0.42) -- (rfpTPhiZeroW)}
+        \TN@vpath{(rfpTPhiZeroE) -- ++(0.36,0) -- (rfpToneLeft)}
+        \TN@vpath{(rfpToneRight) -- ++(0,-0.42) -- (rfpTPhiOneW)}
+        \TN@vpath{(rfpTPhiOneE) -- ++(0.36,0) -- (rfpTtwoRight)}
+        \TN@vpath{(rfpTzeroRight) -- ++(0,-0.80) -- ++(-0.76,0)}
+        \TN@vpath{(rfpTtwoLeft) -- ++(0,-0.80) -- ++(0.76,0)}
+        \TN@selectedpath[rounded corners=4pt]{(-0.34,1.44) rectangle (2.54,1.74)}
+        \TN@selectedpath[rounded corners=4pt]{(1.86,1.84) rectangle (4.74,2.14)}
         \node[red, anchor=east] at (-0.40,1.59) {$(P_2)_{01}$};
         \node[red, anchor=west] at (4.80,1.99) {$(P_2)_{12}$};
-        \draw[red, rounded corners]
+        \TN@selectedpath[rounded corners=3pt, line width=0.4pt]{
             ($(rfpTPhiZero.south west)+(-0.07,-0.07)$) rectangle
-            ($(rfpTPhiZero.north east)+(0.07,0.07)$);
-        \draw[red, rounded corners]
+            ($(rfpTPhiZero.north east)+(0.07,0.07)$)}
+        \TN@selectedpath[rounded corners=3pt, line width=0.4pt]{
             ($(rfpTPhiOne.south west)+(-0.07,-0.07)$) rectangle
-            ($(rfpTPhiOne.north east)+(0.07,0.07)$);
+            ($(rfpTPhiOne.north east)+(0.07,0.07)$)}
         \node[red] at (1.10,-0.68) {$P_{01}$};
         \node[red] at (3.30,-0.68) {$P_{12}$};
     \end{tikzpicture}%
@@ -1924,54 +1942,54 @@
 \newcommand{\TNAppendixBChainTransport}{%
     \begin{tikzpicture}[tn picture, scale=0.92]
         \foreach \a/\name in {150/ctA,90/ctX,30/ctB,-30/ctC,-90/ctD,-150/ctE} {
-            \node[tn tensor dot] (\name)
-                at ({1.34*cos(\a)},{1.02*sin(\a)}) {};
+            \TN@tensor[inner sep=1.6pt]{\name}{({1.34*cos(\a)},{1.02*sin(\a)})}
         }
-        \draw[tn leg] (ctA) -- (ctX) -- (ctB) -- (ctC) -- (ctD) -- (ctE) -- (ctA);
-        \draw[red, line width=2.2pt] (ctA) -- (ctX);
-        \draw[blue, line width=2.2pt] (ctX) -- (ctB);
+        \TN@vpath{(ctA) -- (ctX) -- (ctB) -- (ctC) -- (ctD) -- (ctE) -- (ctA)}
+        \TN@selectedpath[line width=2.2pt]{(ctA) -- (ctX)}
+        \TN@secondarypath[line width=2.2pt]{(ctX) -- (ctB)}
         \node[red, anchor=east] at ($(ctA)+(-0.34,0.18)$) {$h_i$};
         \node[blue, anchor=west] at ($(ctB)+(0.34,0.18)$) {$h_{i+1}$};
         \node at (0,-1.46) {$N>2$};
-        \draw[->, line width=0.7pt] (1.85,0) -- (2.75,0)
-            node[midway, above] {$R_{i,\tau}^{(3)}$};
+        \TN@arrow[line width=0.7pt]{(1.85,0) -- (2.75,0)
+            node[midway, above] {$R_{i,\tau}^{(3)}$}}
         \foreach \x/\name/\lab in {3.35/ctLA/A,4.55/ctLX/X,5.75/ctLB/B} {
-            \node[tn tensor dot] (\name) at (\x,0) {};
+            \TN@tensor[inner sep=1.6pt]{\name}{(\x,0)}
             \node at (\x,0.38) {$\lab$};
         }
-        \draw[tn leg] (ctLA) -- (ctLX) -- (ctLB);
-        \draw[red, line width=1.0pt] ($(ctLA)+(0,-0.30)$) --
-            node[below] {$h_0^{(3)}$} ($(ctLX)+(0,-0.30)$);
-        \draw[blue, line width=1.0pt] ($(ctLX)+(0,-0.78)$) --
-            node[below] {$h_1^{(3)}$} ($(ctLB)+(0,-0.78)$);
+        \TN@vpath{(ctLA) -- (ctLX) -- (ctLB)}
+        \TN@selectedpath[line width=1.0pt]{($(ctLA)+(0,-0.30)$) --
+            node[below] {$h_0^{(3)}$} ($(ctLX)+(0,-0.30)$)}
+        \TN@secondarypath[line width=1.0pt]{($(ctLX)+(0,-0.78)$) --
+            node[below] {$h_1^{(3)}$} ($(ctLB)+(0,-0.78)$)}
     \end{tikzpicture}%
 }
 
 \newcommand{\TNRFPKrausIsometry}{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{rfkA}{(0,0)}
-        \TN@tensordot{rfkB}{(1.20,0)}
-        \draw[tn leg] (rfkA.west) -- ++(-0.60,0);
-        \draw[tn leg] (rfkA.east) -- (rfkB.west);
-        \draw[tn leg] (rfkB.east) -- ++(0.60,0);
-        \TN@upleg{rfkA}{0.46}
-        \TN@upleg{rfkB}{0.46}
-        \TN@uplabel{rfkA}{0.70}{i_1}
-        \TN@uplabel{rfkB}{0.70}{i_2}
+        \TN@tensor{rfkA}{(0,0)}
+        \TN@tensor{rfkB}{(1.20,0)}
+        \TN@vleg{rfkA}{west}{-0.60,0}
+        \TN@vconnect{rfkA}{east}{rfkB}{west}
+        \TN@vleg{rfkB}{east}{0.60,0}
+        \TN@pleg{rfkA}{north}{0,0.46}
+        \TN@pleg{rfkB}{north}{0,0.46}
+        \TN@label{rfkA.north}{(0,0.70)}{i_1}
+        \TN@label{rfkB.north}{(0,0.70)}{i_2}
         \node[anchor=east] at (-0.14,-0.28) {$A$};
         \node[anchor=west] at (1.34,-0.28) {$A$};
         \node at (2.50,0) {$=$};
         \node at (3.25,0) {$\displaystyle\sum_j$};
-        \TN@tensordot{rfkC}{(4.30,0)}
-        \draw[tn leg] (rfkC.west) -- ++(-0.55,0);
-        \draw[tn leg] (rfkC.east) -- ++(0.55,0);
+        \TN@tensor{rfkC}{(4.30,0)}
+        \TN@vleg{rfkC}{west}{-0.55,0}
+        \TN@vleg{rfkC}{east}{0.55,0}
         \node[anchor=west] at (4.44,-0.28) {$A$};
-        \node[tn map box,
-            inner xsep=10pt, inner ysep=2pt] (rfkV) at (4.30,0.90) {$V$};
-        \draw[tn phys leg] (rfkC.north) -- (rfkV.south);
+        \TN@map[inner xsep=10pt, inner ysep=2pt]{rfkV}{(4.30,0.90)}{V}
+        \TN@pconnect{rfkC}{north}{rfkV}{south}
         \node[anchor=west] at (4.40,0.46) {$j$};
-        \draw[tn phys leg] ($(rfkV.north)+(-0.20,0)$) -- ++(0,0.34);
-        \draw[tn phys leg] ($(rfkV.north)+(0.20,0)$) -- ++(0,0.34);
+        \TN@northport{rfkVNLeft}{rfkV}{0.28}
+        \TN@northport{rfkVNRight}{rfkV}{0.72}
+        \TN@popenport{rfkVNLeft}{0,0.34}
+        \TN@popenport{rfkVNRight}{0,0.34}
         \node at (4.10,1.62) {$i_1$};
         \node at (4.50,1.62) {$i_2$};
     \end{tikzpicture}%
@@ -1981,25 +1999,24 @@
 % legs of the contracted pair recovers the single tensor.
 \newcommand{\TNRFPKrausIsometryReverse}{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{rfrA}{(0,0)}
-        \TN@tensordot{rfrB}{(1.20,0)}
-        \draw[tn leg] (rfrA.west) -- ++(-0.60,0);
-        \draw[tn leg] (rfrA.east) -- (rfrB.west);
-        \draw[tn leg] (rfrB.east) -- ++(0.60,0);
+        \TN@tensor{rfrA}{(0,0)}
+        \TN@tensor{rfrB}{(1.20,0)}
+        \TN@vleg{rfrA}{west}{-0.60,0}
+        \TN@vconnect{rfrA}{east}{rfrB}{west}
+        \TN@vleg{rfrB}{east}{0.60,0}
         \node[anchor=east] at (-0.14,-0.28) {$A$};
         \node[anchor=west] at (1.34,-0.28) {$A$};
-        \node[tn map box,
-            minimum width=1.62cm] (rfrV) at (0.60,0.90) {$V^\dagger$};
-        \draw[tn phys leg] (rfrA.north) -- (rfrA.north |- rfrV.south);
-        \draw[tn phys leg] (rfrB.north) -- (rfrB.north |- rfrV.south);
-        \draw[tn phys leg] (rfrV.north) -- ++(0,0.34);
+        \TN@map[minimum width=1.62cm]{rfrV}{(0.60,0.90)}{V^\dagger}
+        \TN@ppath{(rfrA.north) -- (rfrA.north |- rfrV.south)}
+        \TN@ppath{(rfrB.north) -- (rfrB.north |- rfrV.south)}
+        \TN@pleg{rfrV}{north}{0,0.34}
         \node[anchor=west] at (0.70,1.36) {$j$};
         \node at (2.50,0) {$=$};
-        \TN@tensordot{rfrC}{(3.55,0)}
-        \draw[tn leg] (rfrC.west) -- ++(-0.55,0);
-        \draw[tn leg] (rfrC.east) -- ++(0.55,0);
-        \TN@upleg{rfrC}{0.46}
-        \TN@uplabel{rfrC}{0.70}{j}
+        \TN@tensor{rfrC}{(3.55,0)}
+        \TN@vleg{rfrC}{west}{-0.55,0}
+        \TN@vleg{rfrC}{east}{0.55,0}
+        \TN@pleg{rfrC}{north}{0,0.46}
+        \TN@label{rfrC.north}{(0,0.70)}{j}
         \node[anchor=west] at (3.69,-0.28) {$A$};
     \end{tikzpicture}%
 }
@@ -2009,26 +2026,27 @@
 % leg, and X^{-1}.
 \newcommand{\TNRFPIsometryCanonicalForm}{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{icfA}{(0,0)}
-        \draw[tn leg] (icfA.west) -- ++(-0.55,0);
-        \draw[tn leg] (icfA.east) -- ++(0.55,0);
-        \TN@upleg{icfA}{0.46}
-        \TN@uplabel{icfA}{0.70}{i}
+        \TN@tensor{icfA}{(0,0)}
+        \TN@vleg{icfA}{west}{-0.55,0}
+        \TN@vleg{icfA}{east}{0.55,0}
+        \TN@pleg{icfA}{north}{0,0.46}
+        \TN@label{icfA.north}{(0,0.70)}{i}
         \node[anchor=east] at (-0.14,-0.28) {$A$};
         \node at (1.25,0) {$=$};
-        \TN@opdotabove{icfX}{(2.20,0)}{X}
-        \TN@opdotabove{icfL}{(3.20,0)}{\sqrt\Lambda}
-        \node[tn map box]
-        (icfU) at (4.30,0.75) {$U$};
-        \TN@opdotabove{icfXi}{(5.40,0)}{X^{-1}}
-        \draw[tn leg] (icfX.west) -- ++(-0.55,0);
-        \draw[tn leg] (icfX.east) -- (icfL.west);
-        \draw[tn bent leg] (icfL.east)
-        -| ($(icfU.south)+(-0.14,0)$);
-        \draw[tn bent leg] ($(icfU.south)+(0.14,0)$)
-        |- (icfXi.west);
-        \draw[tn leg] (icfXi.east) -- ++(0.55,0);
-        \draw[tn phys leg] (icfU.north) -- ++(0,0.34);
+        \TN@insertion[label=above:$X$]{icfX}{(2.20,0)}
+        \TN@insertion[label=above:$\sqrt\Lambda$]{icfL}{(3.20,0)}
+        \TN@map{icfU}{(4.30,0.75)}{U}
+        \TN@insertion[label=above:$X^{-1}$]{icfXi}{(5.40,0)}
+        \TN@vleg{icfX}{west}{-0.55,0}
+        \TN@vconnect{icfX}{east}{icfL}{west}
+        \TN@southport{icfUSLeft}{icfU}{0.18}
+        \TN@southport{icfUSRight}{icfU}{0.82}
+        \TN@vpath[rounded corners=3pt]{(icfL.east)
+        -| (icfUSLeft)}
+        \TN@vpath[rounded corners=3pt]{(icfUSRight)
+        |- (icfXi.west)}
+        \TN@vleg{icfXi}{east}{0.55,0}
+        \TN@pleg{icfU}{north}{0,0.34}
         \node at ($(icfU.north)+(0,0.56)$) {$i$};
     \end{tikzpicture}%
 }
@@ -2038,48 +2056,50 @@
 % with the coefficient tensor mu on the two index lines.
 \newcommand{\TNRFPIsometryCanonicalFormBlocks}{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{icbA}{(0,0)}
-        \draw[tn leg] (icbA.west) -- ++(-0.55,0);
-        \draw[tn leg] (icbA.east) -- ++(0.55,0);
-        \TN@upleg{icbA}{0.46}
-        \TN@uplabel{icbA}{0.70}{i}
+        \TN@tensor{icbA}{(0,0)}
+        \TN@vleg{icbA}{west}{-0.55,0}
+        \TN@vleg{icbA}{east}{0.55,0}
+        \TN@pleg{icbA}{north}{0,0.46}
+        \TN@label{icbA.north}{(0,0.70)}{i}
         \node[anchor=east] at (-0.14,-0.28) {$A$};
         \node at (1.25,0) {$=$};
-        \TN@opdotabove{icbX}{(2.20,0)}{X}
-        \TN@opdotabove{icbL}{(3.20,0)}{\sqrt\Lambda}
-        \node[tn map box]
-        (icbU) at (4.30,0.75) {$U$};
-        \TN@opdotabove{icbXi}{(5.40,0)}{X^{-1}}
-        \draw[tn leg] (icbX.west) -- ++(-0.55,0);
-        \draw[tn leg] (icbX.east) -- (icbL.west);
-        \draw[tn bent leg] (icbL.east)
-        -| ($(icbU.south)+(-0.14,0)$);
-        \draw[tn bent leg] ($(icbU.south)+(0.14,0)$)
-        |- (icbXi.west);
-        \draw[tn leg] (icbXi.east) -- ++(0.55,0);
-        \draw[tn phys leg] (icbU.north) -- ++(0,0.34);
+        \TN@insertion[label=above:$X$]{icbX}{(2.20,0)}
+        \TN@insertion[label=above:$\sqrt\Lambda$]{icbL}{(3.20,0)}
+        \TN@map{icbU}{(4.30,0.75)}{U}
+        \TN@insertion[label=above:$X^{-1}$]{icbXi}{(5.40,0)}
+        \TN@vleg{icbX}{west}{-0.55,0}
+        \TN@vconnect{icbX}{east}{icbL}{west}
+        \TN@southport{icbUSLeft}{icbU}{0.18}
+        \TN@southport{icbUSRight}{icbU}{0.82}
+        \TN@vpath[rounded corners=3pt]{(icbL.east)
+        -| (icbUSLeft)}
+        \TN@vpath[rounded corners=3pt]{(icbUSRight)
+        |- (icbXi.west)}
+        \TN@vleg{icbXi}{east}{0.55,0}
+        \TN@pleg{icbU}{north}{0,0.34}
         \node at ($(icbU.north)+(0,0.56)$) {$i$};
-        \draw[tn leg] (1.65,-0.62) -- (5.95,-0.62);
-        \draw[tn leg] (1.65,-1.02) -- (5.95,-1.02);
+        \TN@vpath{(1.65,-0.62) -- (5.95,-0.62)}
+        \TN@vpath{(1.65,-1.02) -- (5.95,-1.02)}
         \node[anchor=east] at (1.56,-0.62) {$j$};
         \node[anchor=east] at (1.56,-1.02) {$q$};
-        \draw[tn leg] (icbX.south) -- (2.20,-1.02);
-        \draw[tn leg] (icbL.south) -- (3.20,-0.62);
-        \draw[tn leg] (4.16,0) -- (4.16,-0.62);
-        \draw[tn leg] (icbXi.south) -- (5.40,-1.02);
-        \node[tn tensor box]
-        (icbMu) at (2.70,-1.60) {$\mu$};
-        \draw[tn leg] ($(icbMu.north)+(-0.12,0)$) -- (2.58,-0.62);
-        \draw[tn leg] ($(icbMu.north)+(0.12,0)$) -- (2.82,-1.02);
-        \fill (2.20,-0.62) circle (0.05);
-        \fill (2.20,-1.02) circle (0.05);
-        \fill (3.20,-0.62) circle (0.05);
-        \fill (4.16,0) circle (0.05);
-        \fill (4.16,-0.62) circle (0.05);
-        \fill (5.40,-0.62) circle (0.05);
-        \fill (5.40,-1.02) circle (0.05);
-        \fill (2.58,-0.62) circle (0.05);
-        \fill (2.82,-1.02) circle (0.05);
+        \TN@vpath{(icbX.south) -- (2.20,-1.02)}
+        \TN@vpath{(icbL.south) -- (3.20,-0.62)}
+        \TN@vpath{(4.16,0) -- (4.16,-0.62)}
+        \TN@vpath{(icbXi.south) -- (5.40,-1.02)}
+        \TN@component{icbMu}{(2.70,-1.60)}{\mu}
+        \TN@northport{icbMuNLeft}{icbMu}{0.15}
+        \TN@northport{icbMuNRight}{icbMu}{0.85}
+        \TN@vpath{(icbMuNLeft) -- (2.58,-0.62)}
+        \TN@vpath{(icbMuNRight) -- (2.82,-1.02)}
+        \TN@anonymousjunction{(2.20,-0.62)}
+        \TN@anonymousjunction{(2.20,-1.02)}
+        \TN@anonymousjunction{(3.20,-0.62)}
+        \TN@anonymousjunction{(4.16,0)}
+        \TN@anonymousjunction{(4.16,-0.62)}
+        \TN@anonymousjunction{(5.40,-0.62)}
+        \TN@anonymousjunction{(5.40,-1.02)}
+        \TN@anonymousjunction{(2.58,-0.62)}
+        \TN@anonymousjunction{(2.82,-1.02)}
     \end{tikzpicture}%
 }
 
@@ -2088,26 +2108,25 @@
 % blocked physical indices (dashed box).
 \newcommand{\TNMPDOTwoSiteBlocking}{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{tsbM}{(0,0)}
-        \TN@leftleg{tsbM}{0.60}
-        \TN@rightleg{tsbM}{0.60}
-        \TN@upleg{tsbM}{0.62}
-        \TN@downleg{tsbM}{0.62}
+        \TN@tensor{tsbM}{(0,0)}
+        \TN@vleg{tsbM}{west}{-0.60,0}
+        \TN@vleg{tsbM}{east}{0.60,0}
+        \TN@pleg{tsbM}{north}{0,0.62}
+        \TN@pleg{tsbM}{south}{0,-0.62}
         \node[anchor=east] at (-0.14,-0.28) {$M$};
         \node at (1.35,0) {$=$};
-        \TN@tensordot{tsbKa}{(2.70,0)}
-        \TN@tensordot{tsbKb}{(3.90,0)}
-        \draw[tn leg] (tsbKa.west) -- ++(-0.60,0);
-        \draw[tn leg] (tsbKa.east) -- (tsbKb.west);
-        \draw[tn leg] (tsbKb.east) -- ++(0.60,0);
+        \TN@tensor{tsbKa}{(2.70,0)}
+        \TN@tensor{tsbKb}{(3.90,0)}
+        \TN@vleg{tsbKa}{west}{-0.60,0}
+        \TN@vconnect{tsbKa}{east}{tsbKb}{west}
+        \TN@vleg{tsbKb}{east}{0.60,0}
         \foreach \n in {tsbKa,tsbKb} {
-                \TN@upleg{\n}{0.62}
-                \TN@downleg{\n}{0.62}
+                \TN@pleg{\n}{north}{0,0.62}
+                \TN@pleg{\n}{south}{0,-0.62}
             }
         \node[anchor=west] at (2.80,-0.56) {$K$};
         \node[anchor=west] at (4.00,-0.56) {$K$};
-        \draw[tn grouping boundary]
-        (2.28,0.40) rectangle (4.32,-0.40);
+        \TN@grouppath{(2.28,0.40) rectangle (4.32,-0.40)}
     \end{tikzpicture}%
 }
 
@@ -2115,15 +2134,15 @@
 % shared physical index.
 \newcommand{\TNMPDOBNTVerticalProduct}{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{vpY}{(0,0.55)}
-        \TN@tensordot{vpX}{(0,-0.55)}
-        \TN@leftleg{vpY}{0.60}
-        \TN@rightleg{vpY}{0.60}
-        \TN@leftleg{vpX}{0.60}
-        \TN@rightleg{vpX}{0.60}
-        \draw[tn phys leg] (vpY.south) -- (vpX.north);
-        \draw[tn phys leg] (vpY.north) -- ++(0,0.34);
-        \draw[tn phys leg] (vpX.south) -- ++(0,-0.34);
+        \TN@tensor{vpY}{(0,0.55)}
+        \TN@tensor{vpX}{(0,-0.55)}
+        \TN@vleg{vpY}{west}{-0.60,0}
+        \TN@vleg{vpY}{east}{0.60,0}
+        \TN@vleg{vpX}{west}{-0.60,0}
+        \TN@vleg{vpX}{east}{0.60,0}
+        \TN@pconnect{vpY}{south}{vpX}{north}
+        \TN@pleg{vpY}{north}{0,0.34}
+        \TN@pleg{vpX}{south}{0,-0.34}
         \node at (-0.52,0.90) {$\mathcal K_y$};
         \node at (-0.52,-0.90) {$\mathcal K_x$};
         \node[anchor=west] at (0.95,0) {$=\;0 \quad (x \ne y)$};
@@ -2137,27 +2156,25 @@
     \begin{tikzpicture}[tn picture]
         \begin{scope}
             \node[anchor=east] at (-0.90,0) {$M_\alpha(X)\;=$};
-            \TN@opdotabove{bcmX}{(0,0)}{X}
-            \TN@tensordot{bcmM}{(1.10,0)}
-            \TN@upleg{bcmM}{0.52}
-            \TN@downleg{bcmM}{0.52}
-            \draw[tn leg] (bcmX.east) -- (bcmM.west);
-            \draw[tn virtual closure]
-            (bcmX.west) -- ++(-0.40,0) -- (-0.47,-0.95)
-            -- (1.57,-0.95) -- (1.57,0) -- (bcmM.east);
+            \TN@insertion[label=above:$X$]{bcmX}{(0,0)}
+            \TN@tensor{bcmM}{(1.10,0)}
+            \TN@pleg{bcmM}{north}{0,0.52}
+            \TN@pleg{bcmM}{south}{0,-0.52}
+            \TN@vconnect{bcmX}{east}{bcmM}{west}
+            \TN@vtracepath{(bcmX.west) -- ++(-0.40,0) -- (-0.47,-0.95)
+            -- (1.57,-0.95) -- (1.57,0) -- (bcmM.east)}
             \node at (0.55,-1.18) {$\tr$};
             \node[anchor=west] at (1.22,0.30) {$M_\alpha$};
         \end{scope}
         \begin{scope}[xshift=4.90cm]
             \node[anchor=east] at (-0.90,0) {$A_\alpha(X)\;=$};
-            \TN@opdotabove{bcaX}{(0,0)}{X}
-            \TN@tensordot{bcaA}{(1.10,0)}
-            \TN@upleg{bcaA}{0.52}
-            \TN@downleg{bcaA}{0.52}
-            \draw[tn leg] (bcaX.east) -- (bcaA.west);
-            \draw[tn virtual closure]
-            (bcaX.west) -- ++(-0.40,0) -- (-0.47,-0.95)
-            -- (1.57,-0.95) -- (1.57,0) -- (bcaA.east);
+            \TN@insertion[label=above:$X$]{bcaX}{(0,0)}
+            \TN@tensor{bcaA}{(1.10,0)}
+            \TN@pleg{bcaA}{north}{0,0.52}
+            \TN@pleg{bcaA}{south}{0,-0.52}
+            \TN@vconnect{bcaX}{east}{bcaA}{west}
+            \TN@vtracepath{(bcaX.west) -- ++(-0.40,0) -- (-0.47,-0.95)
+            -- (1.57,-0.95) -- (1.57,0) -- (bcaA.east)}
             \node at (0.55,-1.18) {$\tr$};
             \node[anchor=west] at (1.22,0.30) {$A_\alpha$};
         \end{scope}
@@ -2172,18 +2189,17 @@
         \path[draw=black, opacity=0, use as bounding box]
             (-3.08,-2.00) rectangle (1.40,2.00);
         \node[anchor=east] at (-1.08,0) {$O_L(M_\alpha)\;=$};
-        \TN@tensordot{botcTop}{(0,1.08)}
-        \TN@tensordot{botcBottom}{(0,-1.08)}
+        \TN@tensor{botcTop}{(0,1.08)}
+        \TN@tensor{botcBottom}{(0,-1.08)}
         \foreach \n in {botcTop,botcBottom} {
-            \TN@leftleg{\n}{0.62}
-            \TN@rightleg{\n}{0.62}
+            \TN@vleg{\n}{west}{-0.62,0}
+            \TN@vleg{\n}{east}{0.62,0}
         }
-        \draw[tn phys leg] (botcTop.south) -- (0,0.38);
-        \draw[tn phys leg] (0,-0.38) -- (botcBottom.north);
+        \TN@ppath{(botcTop.south) -- (0,0.38)}
+        \TN@ppath{(0,-0.38) -- (botcBottom.north)}
         \node at (0,0) {$\vdots$};
-        \draw[tn physical closure]
-            (botcTop.north) -- (0,1.56) -- (-0.76,1.56)
-            -- (-0.76,-1.56) -- (0,-1.56) -- (botcBottom.south);
+        \TN@ptracepath{(botcTop.north) -- (0,1.56) -- (-0.76,1.56)
+            -- (-0.76,-1.56) -- (0,-1.56) -- (botcBottom.south)}
         \node[anchor=south west] at (0.18,1.12) {$M_\alpha$};
         \node[anchor=south west] at (0.18,-1.04) {$M_\alpha$};
     \end{tikzpicture}%
@@ -2195,26 +2211,40 @@
 \newcommand{\TNMPDOFirstSiteInsertionHypothesis}{%
     \begin{tikzpicture}[tn picture]
         \begin{scope}
-            \TN@tensordot{fihL}{(0,0)}
-            \TN@tensordot{fihM}{(1.05,0)}
-            \TN@tensordot{fihR}{(2.60,0)}
-            \draw[tn virtual closure] (-0.42,0) rectangle (3.02,-0.44);
-            \TN@upleg{fihM}{0.42}
-            \TN@upleg{fihR}{0.42}
-            \draw[tn phys leg] (fihL.north) -- ++(0,0.86);
-            \TN@opdotleft{fihY}{(0,0.46)}{Y}
+            \TN@declareWordTensor{fihL}{(0,0)}
+            \TN@declareWordTensor{fihM}{(1.05,0)}
+            \TN@declareWordTensor{fihR}{(2.60,0)}
+            \TN@vconnectports{fihLE}{fihMW}
+            \TN@vopenport{fihME}{0.45,0}
+            \TN@vopenport{fihRW}{-0.45,0}
+            \TN@vtracepath{(fihLW) -- (-0.42,0) -- (-0.42,-0.44)
+                -- (3.02,-0.44) -- (3.02,0) -- (fihRE)}
+            \TN@popenport{fihMN}{0,0.42}
+            \TN@popenport{fihRN}{0,0.42}
+            \TN@insertion[label=left:$Y$]{fihY}{(0,0.46)}
+            \TN@port{fihYS}{fihY}{south}
+            \TN@port{fihYN}{fihY}{north}
+            \TN@pconnectports{fihLN}{fihYS}
+            \TN@popenport{fihYN}{0,0.40}
             \node at (1.85,0) {$\cdots$};
         \end{scope}
         \node at (3.60,0) {$=$};
         \begin{scope}[xshift=4.20cm]
-            \TN@tensordot{fizL}{(0,0)}
-            \TN@tensordot{fizM}{(1.05,0)}
-            \TN@tensordot{fizR}{(2.60,0)}
-            \draw[tn virtual closure] (-0.42,0) rectangle (3.02,-0.44);
-            \TN@upleg{fizM}{0.42}
-            \TN@upleg{fizR}{0.42}
-            \draw[tn phys leg] (fizL.north) -- ++(0,0.86);
-            \TN@opdotleft{fizZ}{(0,0.46)}{Z}
+            \TN@declareWordTensor{fizL}{(0,0)}
+            \TN@declareWordTensor{fizM}{(1.05,0)}
+            \TN@declareWordTensor{fizR}{(2.60,0)}
+            \TN@vconnectports{fizLE}{fizMW}
+            \TN@vopenport{fizME}{0.45,0}
+            \TN@vopenport{fizRW}{-0.45,0}
+            \TN@vtracepath{(fizLW) -- (-0.42,0) -- (-0.42,-0.44)
+                -- (3.02,-0.44) -- (3.02,0) -- (fizRE)}
+            \TN@popenport{fizMN}{0,0.42}
+            \TN@popenport{fizRN}{0,0.42}
+            \TN@insertion[label=left:$Z$]{fizZ}{(0,0.46)}
+            \TN@port{fizZS}{fizZ}{south}
+            \TN@port{fizZN}{fizZ}{north}
+            \TN@pconnectports{fizLN}{fizZS}
+            \TN@popenport{fizZN}{0,0.40}
             \node at (1.85,0) {$\cdots$};
         \end{scope}
     \end{tikzpicture}%
@@ -2224,18 +2254,18 @@
 % of Y and Z agree on each basis tensor of the canonical form.
 \newcommand{\TNMPDOFirstSiteInsertionBlockwise}{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{fibA}{(0,0)}
-        \TN@leftleg{fibA}{0.60}
-        \TN@rightleg{fibA}{0.60}
-        \draw[tn phys leg] (fibA.north) -- ++(0,0.86);
-        \TN@opdotleft{fibY}{(0,0.46)}{Y}
+        \TN@tensor{fibA}{(0,0)}
+        \TN@vleg{fibA}{west}{-0.60,0}
+        \TN@vleg{fibA}{east}{0.60,0}
+        \TN@pleg{fibA}{north}{0,0.86}
+        \TN@insertion[label=left:$Y$]{fibY}{(0,0.46)}
         \node at (0,-0.32) {$A_k$};
         \node at (1.45,0) {$=$};
-        \TN@tensordot{fibB}{(2.90,0)}
-        \TN@leftleg{fibB}{0.60}
-        \TN@rightleg{fibB}{0.60}
-        \draw[tn phys leg] (fibB.north) -- ++(0,0.86);
-        \TN@opdotleft{fibZ}{(2.90,0.46)}{Z}
+        \TN@tensor{fibB}{(2.90,0)}
+        \TN@vleg{fibB}{west}{-0.60,0}
+        \TN@vleg{fibB}{east}{0.60,0}
+        \TN@pleg{fibB}{north}{0,0.86}
+        \TN@insertion[label=left:$Z$]{fibZ}{(2.90,0.46)}
         \node at (2.90,-0.32) {$A_k$};
     \end{tikzpicture}%
 }
@@ -2246,28 +2276,24 @@
 \newcommand{\TNMPDOInsertionTracePairing}{%
     \begin{tikzpicture}[tn picture]
         \begin{scope}
-            \node[tn tensor box]
-            (itpW) at (0,0) {$W$};
-            \TN@tensordot{itpA}{(1.15,0)}
-            \draw[tn leg] (itpW.east) -- (itpA.west);
-            \draw[tn phys leg] (itpA.north) -- ++(0,0.86);
-            \TN@opdotleft{itpY}{(1.15,0.46)}{Y}
-            \draw[tn virtual closure]
-            (itpW.west) -- ++(-0.35,0) -- (-0.62,-0.80)
-            -- (1.72,-0.80) -- (1.72,0) -- (itpA.east);
+            \TN@component{itpW}{(0,0)}{W}
+            \TN@tensor{itpA}{(1.15,0)}
+            \TN@vconnect{itpW}{east}{itpA}{west}
+            \TN@pleg{itpA}{north}{0,0.86}
+            \TN@insertion[label=left:$Y$]{itpY}{(1.15,0.46)}
+            \TN@vtracepath{(itpW.west) -- ++(-0.35,0) -- (-0.62,-0.80)
+            -- (1.72,-0.80) -- (1.72,0) -- (itpA.east)}
             \node at (0.55,-1.03) {$\tr$};
         \end{scope}
         \node at (2.70,0) {$=$};
         \begin{scope}[xshift=4.05cm]
-            \node[tn tensor box]
-            (itpWz) at (0,0) {$W$};
-            \TN@tensordot{itpAz}{(1.15,0)}
-            \draw[tn leg] (itpWz.east) -- (itpAz.west);
-            \draw[tn phys leg] (itpAz.north) -- ++(0,0.86);
-            \TN@opdotleft{itpZ}{(1.15,0.46)}{Z}
-            \draw[tn virtual closure]
-            (itpWz.west) -- ++(-0.35,0) -- (-0.62,-0.80)
-            -- (1.72,-0.80) -- (1.72,0) -- (itpAz.east);
+            \TN@component{itpWz}{(0,0)}{W}
+            \TN@tensor{itpAz}{(1.15,0)}
+            \TN@vconnect{itpWz}{east}{itpAz}{west}
+            \TN@pleg{itpAz}{north}{0,0.86}
+            \TN@insertion[label=left:$Z$]{itpZ}{(1.15,0.46)}
+            \TN@vtracepath{(itpWz.west) -- ++(-0.35,0) -- (-0.62,-0.80)
+            -- (1.72,-0.80) -- (1.72,0) -- (itpAz.east)}
             \node at (0.55,-1.03) {$\tr$};
         \end{scope}
     \end{tikzpicture}%
@@ -2280,36 +2306,36 @@
 % factors tap both lines.
 \newcommand{\TNMPDOHorizontalCanonicalForm}{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{hcfK}{(0,0)}
-        \TN@leftleg{hcfK}{0.58}
-        \TN@rightleg{hcfK}{0.58}
-        \TN@upleg{hcfK}{0.50}
-        \TN@downleg{hcfK}{0.50}
+        \TN@tensor{hcfK}{(0,0)}
+        \TN@vleg{hcfK}{west}{-0.58,0}
+        \TN@vleg{hcfK}{east}{0.58,0}
+        \TN@pleg{hcfK}{north}{0,0.50}
+        \TN@pleg{hcfK}{south}{0,-0.50}
         \node[anchor=east] at (-0.14,-0.28) {$K$};
         \node at (1.30,0) {$=$};
-        \TN@opdotabove{hcfX}{(2.55,0)}{X}
-        \TN@tensordot{hcfC}{(3.75,0)}
-        \TN@opdotabove{hcfXi}{(4.95,0)}{X^{-1}}
-        \draw[tn leg] (hcfX.west) -- ++(-0.55,0);
-        \draw[tn leg] (hcfX.east) -- (hcfC.west);
-        \draw[tn leg] (hcfC.east) -- (hcfXi.west);
-        \draw[tn leg] (hcfXi.east) -- ++(0.55,0);
-        \TN@upleg{hcfC}{0.50}
-        \TN@downleg{hcfC}{0.50}
+        \TN@insertion[label=above:$X$]{hcfX}{(2.55,0)}
+        \TN@tensor{hcfC}{(3.75,0)}
+        \TN@insertion[label=above:$X^{-1}$]{hcfXi}{(4.95,0)}
+        \TN@vleg{hcfX}{west}{-0.55,0}
+        \TN@vconnect{hcfX}{east}{hcfC}{west}
+        \TN@vconnect{hcfC}{east}{hcfXi}{west}
+        \TN@vleg{hcfXi}{east}{0.55,0}
+        \TN@pleg{hcfC}{north}{0,0.50}
+        \TN@pleg{hcfC}{south}{0,-0.50}
         \node[anchor=west] at (3.89,0.32) {$\mathcal K$};
-        \draw[tn leg] (1.95,-1.10) -- (5.55,-1.10);
-        \draw[tn leg] (1.95,-1.50) -- (5.55,-1.50);
+        \TN@vpath{(1.95,-1.10) -- (5.55,-1.10)}
+        \TN@vpath{(1.95,-1.50) -- (5.55,-1.50)}
         \node[anchor=east] at (1.86,-1.10) {$j$};
         \node[anchor=east] at (1.86,-1.50) {$q$};
-        \draw[tn leg] (hcfX.south) -- (2.55,-1.50);
-        \draw[tn bent leg]
-        (hcfC.center) -- (4.15,-0.40) -- (4.15,-1.10);
-        \draw[tn leg] (hcfXi.south) -- (4.95,-1.50);
-        \fill (2.55,-1.10) circle (0.05);
-        \fill (2.55,-1.50) circle (0.05);
-        \fill (4.15,-1.10) circle (0.05);
-        \fill (4.95,-1.10) circle (0.05);
-        \fill (4.95,-1.50) circle (0.05);
+        \TN@vpath{(hcfX.south) -- (2.55,-1.50)}
+        \TN@port{hcfCBlock}{hcfC}{-45}
+        \TN@vpath[rounded corners=3pt]{(hcfCBlock) -- (4.15,-0.40) -- (4.15,-1.10)}
+        \TN@vpath{(hcfXi.south) -- (4.95,-1.50)}
+        \TN@anonymousjunction{(2.55,-1.10)}
+        \TN@anonymousjunction{(2.55,-1.50)}
+        \TN@anonymousjunction{(4.15,-1.10)}
+        \TN@anonymousjunction{(4.95,-1.10)}
+        \TN@anonymousjunction{(4.95,-1.50)}
     \end{tikzpicture}%
 }
 
@@ -2320,65 +2346,63 @@
 % block line.
 \newcommand{\TNMPDOBlockInjectiveInverse}{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{bijI}{(0,0.55)}
-        \TN@tensordot{bijK}{(0,-0.55)}
-        \TN@leftleg{bijI}{0.55}
-        \TN@rightleg{bijI}{0.55}
-        \TN@leftleg{bijK}{0.55}
-        \TN@rightleg{bijK}{0.55}
-        \draw[tn phys leg] (bijI.south) -- (bijK.north);
-        \draw[tn leg] (bijI.north) -- ++(0,0.42);
+        \TN@tensor{bijI}{(0,0.55)}
+        \TN@tensor{bijK}{(0,-0.55)}
+        \TN@vleg{bijI}{west}{-0.55,0}
+        \TN@vleg{bijI}{east}{0.55,0}
+        \TN@vleg{bijK}{west}{-0.55,0}
+        \TN@vleg{bijK}{east}{0.55,0}
+        \TN@pconnect{bijI}{south}{bijK}{north}
+        \TN@vleg{bijI}{north}{0,0.42}
         \node at (-0.58,0.90) {$K^{-1}$};
         \node at (-0.42,-0.90) {$K$};
         \node at (1.15,0) {$=$};
         \begin{scope}[xshift=2.30cm]
-            \TN@opdotabove{bijX}{(0.55,0)}{X}
-            \TN@tensordot{bijC}{(1.75,0)}
-            \TN@opdotabove{bijXi}{(2.95,0)}{X^{-1}}
-            \draw[tn leg] (bijX.west) -- ++(-0.50,0);
-            \draw[tn leg] (bijX.east) -- (bijC.west);
-            \draw[tn leg] (bijC.east) -- (bijXi.west);
-            \draw[tn leg] (bijXi.east) -- ++(0.50,0);
+            \TN@insertion[label=above:$X$]{bijX}{(0.55,0)}
+            \TN@tensor{bijC}{(1.75,0)}
+            \TN@insertion[label=above:$X^{-1}$]{bijXi}{(2.95,0)}
+            \TN@vleg{bijX}{west}{-0.50,0}
+            \TN@vconnect{bijX}{east}{bijC}{west}
+            \TN@vconnect{bijC}{east}{bijXi}{west}
+            \TN@vleg{bijXi}{east}{0.50,0}
             \node[anchor=west] at (1.89,-0.30) {$\mathcal K$};
-            \TN@tensordot{bijIt}{(1.75,1.00)}
-            \TN@leftleg{bijIt}{0.50}
-            \TN@rightleg{bijIt}{0.50}
-            \draw[tn phys leg] (bijIt.south) -- (bijC.north);
-            \draw[tn leg] (bijIt.north) -- ++(0,0.42);
+            \TN@tensor{bijIt}{(1.75,1.00)}
+            \TN@vleg{bijIt}{west}{-0.50,0}
+            \TN@vleg{bijIt}{east}{0.50,0}
+            \TN@pconnect{bijIt}{south}{bijC}{north}
+            \TN@vleg{bijIt}{north}{0,0.42}
             \node at (1.02,1.32) {$K^{-1}$};
-            \draw[tn leg] (0,-1.10) -- (3.50,-1.10);
-            \draw[tn leg] (0,-1.50) -- (3.50,-1.50);
+            \TN@vpath{(0,-1.10) -- (3.50,-1.10)}
+            \TN@vpath{(0,-1.50) -- (3.50,-1.50)}
             \node[anchor=east] at (-0.09,-1.10) {$j$};
             \node[anchor=east] at (-0.09,-1.50) {$q$};
-            \draw[tn leg] (bijX.south) -- (0.55,-1.50);
-            \draw[tn leg] (bijC.south) -- (1.75,-1.10);
-            \draw[tn leg] (bijXi.south) -- (2.95,-1.50);
-            \fill (0.55,-1.10) circle (0.05);
-            \fill (0.55,-1.50) circle (0.05);
-            \fill (1.75,-1.10) circle (0.05);
-            \fill (2.95,-1.10) circle (0.05);
-            \fill (2.95,-1.50) circle (0.05);
+            \TN@vpath{(bijX.south) -- (0.55,-1.50)}
+            \TN@vpath{(bijC.south) -- (1.75,-1.10)}
+            \TN@vpath{(bijXi.south) -- (2.95,-1.50)}
+            \TN@anonymousjunction{(0.55,-1.10)}
+            \TN@anonymousjunction{(0.55,-1.50)}
+            \TN@anonymousjunction{(1.75,-1.10)}
+            \TN@anonymousjunction{(2.95,-1.10)}
+            \TN@anonymousjunction{(2.95,-1.50)}
         \end{scope}
         \node at (6.25,0) {$=$};
         \begin{scope}[xshift=6.70cm]
-            \TN@opdotabove{bijPX}{(0.55,0)}{X}
-            \TN@opdotabove{bijPXi}{(2.95,0)}{X^{-1}}
-            \draw[tn leg] (bijPX.west) -- ++(-0.50,0);
-            \draw[tn leg] (bijPXi.east) -- ++(0.50,0);
-            \draw[tn bent leg]
-            (bijPX.east) -- (1.05,0) -- (1.05,1.00) -- (1.35,1.00);
-            \draw[tn bent leg]
-            (bijPXi.west) -- (2.45,0) -- (2.45,1.00) -- (2.15,1.00);
-            \draw[tn leg] (1.75,1.50) -- (1.75,-1.10);
-            \draw[tn leg] (0,-1.10) -- (3.50,-1.10);
-            \draw[tn leg] (0,-1.50) -- (3.50,-1.50);
-            \draw[tn leg] (bijPX.south) -- (0.55,-1.50);
-            \draw[tn leg] (bijPXi.south) -- (2.95,-1.50);
-            \fill (0.55,-1.10) circle (0.05);
-            \fill (0.55,-1.50) circle (0.05);
-            \fill (1.75,-1.10) circle (0.05);
-            \fill (2.95,-1.10) circle (0.05);
-            \fill (2.95,-1.50) circle (0.05);
+            \TN@insertion[label=above:$X$]{bijPX}{(0.55,0)}
+            \TN@insertion[label=above:$X^{-1}$]{bijPXi}{(2.95,0)}
+            \TN@vleg{bijPX}{west}{-0.50,0}
+            \TN@vleg{bijPXi}{east}{0.50,0}
+            \TN@vpath[rounded corners=3pt]{(bijPX.east) -- (1.05,0) -- (1.05,1.00) -- (1.35,1.00)}
+            \TN@vpath[rounded corners=3pt]{(bijPXi.west) -- (2.45,0) -- (2.45,1.00) -- (2.15,1.00)}
+            \TN@vpath{(1.75,1.50) -- (1.75,-1.10)}
+            \TN@vpath{(0,-1.10) -- (3.50,-1.10)}
+            \TN@vpath{(0,-1.50) -- (3.50,-1.50)}
+            \TN@vpath{(bijPX.south) -- (0.55,-1.50)}
+            \TN@vpath{(bijPXi.south) -- (2.95,-1.50)}
+            \TN@anonymousjunction{(0.55,-1.10)}
+            \TN@anonymousjunction{(0.55,-1.50)}
+            \TN@anonymousjunction{(1.75,-1.10)}
+            \TN@anonymousjunction{(2.95,-1.10)}
+            \TN@anonymousjunction{(2.95,-1.50)}
         \end{scope}
     \end{tikzpicture}%
 }
@@ -2389,25 +2413,23 @@
 % doubled physical index is drawn as a single thick leg.
 \newcommand{\TNMPDOInverseRecovery}{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{irT}{(0,1.05)}
-        \TN@tensordot{irI}{(0,0)}
-        \TN@tensordot{irB}{(0,-1.05)}
-        \draw[tn phys leg] (irT.north) -- ++(0,0.45);
-        \draw[tn bent leg]
-        (irI.west) -- ++(-0.74,0) -- (-0.82,1.05) -- (irT.west);
-        \draw[tn bent leg]
-        (irI.east) -- ++(0.74,0) -- (0.82,1.05) -- (irT.east);
-        \draw[tn phys leg] (irI.south) -- (irB.north);
-        \TN@leftleg{irB}{0.60}
-        \TN@rightleg{irB}{0.60}
+        \TN@tensor{irT}{(0,1.05)}
+        \TN@tensor{irI}{(0,0)}
+        \TN@tensor{irB}{(0,-1.05)}
+        \TN@pleg{irT}{north}{0,0.45}
+        \TN@vpath[rounded corners=3pt]{(irI.west) -- ++(-0.74,0) -- (-0.82,1.05) -- (irT.west)}
+        \TN@vpath[rounded corners=3pt]{(irI.east) -- ++(0.74,0) -- (0.82,1.05) -- (irT.east)}
+        \TN@pconnect{irI}{south}{irB}{north}
+        \TN@vleg{irB}{west}{-0.60,0}
+        \TN@vleg{irB}{east}{0.60,0}
         \node[anchor=west] at (0.12,1.33) {$K$};
         \node[anchor=west] at (0.12,0.30) {$K^{-1}$};
         \node[anchor=east] at (-0.14,-1.33) {$K$};
         \node at (1.85,0) {$=$};
-        \TN@tensordot{irR}{(3.05,0)}
-        \TN@leftleg{irR}{0.60}
-        \TN@rightleg{irR}{0.60}
-        \draw[tn phys leg] (irR.north) -- ++(0,0.45);
+        \TN@tensor{irR}{(3.05,0)}
+        \TN@vleg{irR}{west}{-0.60,0}
+        \TN@vleg{irR}{east}{0.60,0}
+        \TN@pleg{irR}{north}{0,0.45}
         \node[anchor=east] at (2.91,-0.28) {$K$};
     \end{tikzpicture}%
 }
@@ -2417,69 +2439,69 @@
 % diagonal term, so the tensor absorbs its own projector on either side.
 \newcommand{\TNMPDOProjectorAbsorption}{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{paA}{(0,0)}
-        \TN@leftleg{paA}{0.50}
-        \TN@rightleg{paA}{0.50}
-        \TN@upleg{paA}{1.00}
-        \TN@downleg{paA}{1.00}
+        \TN@tensor{paA}{(0,0)}
+        \TN@vleg{paA}{west}{-0.50,0}
+        \TN@vleg{paA}{east}{0.50,0}
+        \TN@pleg{paA}{north}{0,1.00}
+        \TN@pleg{paA}{south}{0,-1.00}
         \node[anchor=west] at (0.12,-0.30) {$\mathcal K_i$};
         \node at (1.10,0) {$=$};
         \node at (1.80,0) {$\displaystyle\sum_{j,j'}$};
-        \TN@tensordot{paB}{(2.75,0)}
-        \TN@leftleg{paB}{0.50}
-        \TN@rightleg{paB}{0.50}
-        \TN@upleg{paB}{1.00}
-        \TN@downleg{paB}{1.00}
-        \TN@opdotleft{paBu}{(2.75,0.55)}{P_j}
-        \TN@opdotleft{paBd}{(2.75,-0.55)}{P_{j'}}
+        \TN@tensor{paB}{(2.75,0)}
+        \TN@vleg{paB}{west}{-0.50,0}
+        \TN@vleg{paB}{east}{0.50,0}
+        \TN@pleg{paB}{north}{0,1.00}
+        \TN@pleg{paB}{south}{0,-1.00}
+        \TN@insertion[label=left:$P_j$]{paBu}{(2.75,0.55)}
+        \TN@insertion[label=left:$P_{j'}$]{paBd}{(2.75,-0.55)}
         \node[anchor=west] at (2.87,-0.30) {$\mathcal K_i$};
         \node at (3.90,0) {$=$};
-        \TN@tensordot{paC}{(4.85,0)}
-        \TN@leftleg{paC}{0.50}
-        \TN@rightleg{paC}{0.50}
-        \TN@upleg{paC}{1.00}
-        \TN@downleg{paC}{1.00}
-        \TN@opdotleft{paCu}{(4.85,0.55)}{P_i}
+        \TN@tensor{paC}{(4.85,0)}
+        \TN@vleg{paC}{west}{-0.50,0}
+        \TN@vleg{paC}{east}{0.50,0}
+        \TN@pleg{paC}{north}{0,1.00}
+        \TN@pleg{paC}{south}{0,-1.00}
+        \TN@insertion[label=left:$P_i$]{paCu}{(4.85,0.55)}
         \node[anchor=west] at (4.97,-0.30) {$\mathcal K_i$};
         \node at (6.00,0) {$=$};
-        \TN@tensordot{paD}{(6.95,0)}
-        \TN@leftleg{paD}{0.50}
-        \TN@rightleg{paD}{0.50}
-        \TN@upleg{paD}{1.00}
-        \TN@downleg{paD}{1.00}
-        \TN@opdotleft{paDd}{(6.95,-0.55)}{P_i}
+        \TN@tensor{paD}{(6.95,0)}
+        \TN@vleg{paD}{west}{-0.50,0}
+        \TN@vleg{paD}{east}{0.50,0}
+        \TN@pleg{paD}{north}{0,1.00}
+        \TN@pleg{paD}{south}{0,-1.00}
+        \TN@insertion[label=left:$P_i$]{paDd}{(6.95,-0.55)}
         \node[anchor=west] at (7.07,-0.30) {$\mathcal K_i$};
     \end{tikzpicture}%
 }
 
 \newcommand{\TNGaugeConjugation}[3]{%
     \begin{tikzpicture}[tn picture]
-        \TN@opdotabove{tnXl}{(-1.10,0)}{#1}
-        \TN@tensordot{tnA}{(0,0)}
-        \TN@opdotabove{tnXr}{(1.10,0)}{#3}
-        \draw[tn leg] (tnXl.west) -- ++(-0.55,0);
-        \draw[tn leg] (tnXl.east) -- (tnA.west);
-        \draw[tn leg] (tnA.east) -- (tnXr.west);
-        \draw[tn leg] (tnXr.east) -- ++(0.55,0);
-        \TN@upleg{tnA}{\TN@physleglen}
+        \TN@insertion[label=above:$#1$]{tnXl}{(-1.10,0)}
+        \TN@tensor{tnA}{(0,0)}
+        \TN@insertion[label=above:$#3$]{tnXr}{(1.10,0)}
+        \TN@vleg{tnXl}{west}{-0.55,0}
+        \TN@vconnect{tnXl}{east}{tnA}{west}
+        \TN@vconnect{tnA}{east}{tnXr}{west}
+        \TN@vleg{tnXr}{east}{0.55,0}
+        \TN@pleg{tnA}{north}{0,\TN@physleglen}
         \TN@uplabel{tnA}{\TN@physlabeloff}{#2}
     \end{tikzpicture}%
 }
 
 \newcommand{\TNPhysicalRealization}[2]{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{tnA1}{(0,0)}
-        \draw[tn leg] (tnA1.west) -- ++(-0.65,0);
-        \TN@upleg{tnA1}{\TN@physleglen}
-        \TN@opdotabove{tnX}{(0.78,0)}{#1}
-        \draw[tn leg] (tnA1.east) -- (tnX.west);
-        \draw[tn leg] (tnX.east) -- ++(0.22,0);
+        \TN@tensor{tnA1}{(0,0)}
+        \TN@vleg{tnA1}{west}{-0.65,0}
+        \TN@pleg{tnA1}{north}{0,\TN@physleglen}
+        \TN@insertion[label=above:$#1$]{tnX}{(0.78,0)}
+        \TN@vconnect{tnA1}{east}{tnX}{west}
+        \TN@vleg{tnX}{east}{0.22,0}
         \node at (1.78,0) {$=$};
-        \TN@tensordot{tnA2}{(2.65,0)}
-        \draw[tn leg] (tnA2.west) -- ++(-0.65,0);
-        \draw[tn leg] (tnA2.east) -- ++(0.65,0);
-        \TN@opdotleft{tnO}{(2.65,0.74)}{#2}
-        \draw[tn phys leg] (tnA2.north) -- (tnO.south);
+        \TN@tensor{tnA2}{(2.65,0)}
+        \TN@vleg{tnA2}{west}{-0.65,0}
+        \TN@vleg{tnA2}{east}{0.65,0}
+        \TN@insertion[label=left:$#2$]{tnO}{(2.65,0.74)}
+        \TN@pconnect{tnA2}{north}{tnO}{south}
     \end{tikzpicture}%
 }
 
@@ -2487,11 +2509,11 @@
 % general linear twists, and keep permutation twists for index relabellings.
 \newcommand{\TNLinearTwist}[2]{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{tnA}{(0,0)}
-        \TN@leftleg{tnA}{0.65}
-        \TN@rightleg{tnA}{0.65}
-        \TN@opdotleft{tnu}{(0,0.64)}{#1}
-        \draw[tn phys leg] (tnA.north) -- (tnu.south);
+        \TN@tensor{tnA}{(0,0)}
+        \TN@vleg{tnA}{west}{-0.65,0}
+        \TN@vleg{tnA}{east}{0.65,0}
+        \TN@insertion[label=left:$#1$]{tnu}{(0,0.64)}
+        \TN@pconnect{tnA}{north}{tnu}{south}
         \node at ($(tnu.north)+(0,0.18)$) {$#2$};
     \end{tikzpicture}%
 }
@@ -2500,16 +2522,16 @@
 % permutation diagrams can distinguish \sigma_h from \sigma_g.
 \newcommand{\TNPermutationTwistLabeled}[3]{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{tnL}{(0,0)}
-        \TN@leftleg{tnL}{0.65}
-        \TN@rightleg{tnL}{0.65}
-        \TN@upleg{tnL}{\TN@physleglen}
+        \TN@tensor{tnL}{(0,0)}
+        \TN@vleg{tnL}{west}{-0.65,0}
+        \TN@vleg{tnL}{east}{0.65,0}
+        \TN@pleg{tnL}{north}{0,\TN@physleglen}
         \TN@uplabel{tnL}{\TN@physlabeloff}{#1}
         \node at (1.55,0) {$\xrightarrow{\ #3\ }$};
-        \TN@tensordot{tnR}{(3.30,0)}
-        \TN@leftleg{tnR}{0.65}
-        \TN@rightleg{tnR}{0.65}
-        \TN@upleg{tnR}{\TN@physleglen}
+        \TN@tensor{tnR}{(3.30,0)}
+        \TN@vleg{tnR}{west}{-0.65,0}
+        \TN@vleg{tnR}{east}{0.65,0}
+        \TN@pleg{tnR}{north}{0,\TN@physleglen}
         \TN@uplabel{tnR}{\TN@physlabeloff}{#2}
     \end{tikzpicture}%
 }
@@ -2520,15 +2542,15 @@
 
 \newcommand{\TNTwistedTransfer}[1]{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{tnUp}{(0,\TN@doublelayersep)}
-        \TN@tensordot{tnDn}{(0,-\TN@doublelayersep)}
-        \draw[tn leg] ($(tnUp.west)+(-0.80,0)$) -- (tnUp.west);
-        \draw[tn leg] ($(tnDn.west)+(-0.80,0)$) -- (tnDn.west);
-        \draw[tn leg] (tnUp.east) -- ++(0.80,0);
-        \draw[tn leg] (tnDn.east) -- ++(0.80,0);
-        \TN@opdotleft{tnu}{(0,0)}{#1}
-        \draw[tn phys leg] (tnUp.south) -- (tnu.north);
-        \draw[tn phys leg] (tnu.south) -- (tnDn.north);
+        \TN@tensor{tnUp}{(0,\TN@doublelayersep)}
+        \TN@tensor{tnDn}{(0,-\TN@doublelayersep)}
+        \TN@vleg{tnUp}{west}{-0.80,0}
+        \TN@vleg{tnDn}{west}{-0.80,0}
+        \TN@vleg{tnUp}{east}{0.80,0}
+        \TN@vleg{tnDn}{east}{0.80,0}
+        \TN@insertion[label=left:$#1$]{tnu}{(0,0)}
+        \TN@pconnect{tnUp}{south}{tnu}{north}
+        \TN@pconnect{tnu}{south}{tnDn}{north}
         \node at (-1.25,0) {$X$};
         \node at (1.52,0) {$\E_{#1}(X)$};
         \node at ($(tnUp.north)+(0,0.28)$) {$n$};
@@ -2538,83 +2560,82 @@
 
 \newcommand{\TNCondCOne}[3]{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{tnL}{(0,0)}
-        \TN@leftleg{tnL}{0.65}
-        \TN@rightleg{tnL}{0.65}
-        \TN@upleg{tnL}{0.26}
-        \TN@opdotleft{tnu}{(0,0.64)}{#1}
-        \draw[tn phys leg] (tnL.north) -- (tnu.south);
+        \TN@tensor{tnL}{(0,0)}
+        \TN@vleg{tnL}{west}{-0.65,0}
+        \TN@vleg{tnL}{east}{0.65,0}
+        \TN@pleg{tnL}{north}{0,0.26}
+        \TN@insertion[label=left:$#1$]{tnu}{(0,0.64)}
+        \TN@pconnect{tnL}{north}{tnu}{south}
         \node at ($(tnu.north)+(0,0.18)$) {$#3$};
         \node at (1.65,0) {$=$};
-        \TN@opdotabove{tnXl}{(3.15,0)}{#2}
-        \TN@tensordot{tnA}{(4.20,0)}
-        \TN@opdotabove{tnXr}{(5.25,0)}{#2^\dagger}
-        \draw[tn leg] (tnXl.west) -- ++(-0.55,0);
-        \draw[tn leg] (tnXl.east) -- (tnA.west);
-        \draw[tn leg] (tnA.east) -- (tnXr.west);
-        \draw[tn leg] (tnXr.east) -- ++(0.55,0);
-        \TN@upleg{tnA}{\TN@physleglen}
+        \TN@insertion[label=above:$#2$]{tnXl}{(3.15,0)}
+        \TN@tensor{tnA}{(4.20,0)}
+        \TN@insertion[label=above:$#2^\dagger$]{tnXr}{(5.25,0)}
+        \TN@vleg{tnXl}{west}{-0.55,0}
+        \TN@vconnect{tnXl}{east}{tnA}{west}
+        \TN@vconnect{tnA}{east}{tnXr}{west}
+        \TN@vleg{tnXr}{east}{0.55,0}
+        \TN@pleg{tnA}{north}{0,\TN@physleglen}
         \TN@uplabel{tnA}{\TN@physlabeloff}{#3}
     \end{tikzpicture}%
 }
 
 \newcommand{\TNCondCTwo}[1]{%
     \begin{tikzpicture}[tn picture]
-        \TN@opdotabove{tnVL}{(-1.15,0.48)}{#1}
-        \TN@opdotbelow{tnVdL}{(-1.15,-0.48)}{#1^\dagger}
-        \TN@tensordot{tnLUp}{(0,0.48)}
-        \TN@tensordot{tnLDn}{(0,-0.48)}
-        \draw[tn leg] (tnVL.west) -- ++(-0.45,0);
-        \draw[tn leg] (tnVdL.west) -- ++(-0.45,0);
-        \draw[tn leg] (tnVL.east) -- (tnLUp.west);
-        \draw[tn leg] (tnVdL.east) -- (tnLDn.west);
-        \draw[tn leg] (tnLUp.east) -- ++(0.55,0);
-        \draw[tn leg] (tnLDn.east) -- ++(0.55,0);
-        \draw[tn phys leg] (tnLUp.south) -- (tnLDn.north);
+        \TN@insertion[label=above:$#1$]{tnVL}{(-1.15,0.48)}
+        \TN@insertion[label=below:$#1^\dagger$]{tnVdL}{(-1.15,-0.48)}
+        \TN@tensor{tnLUp}{(0,0.48)}
+        \TN@tensor{tnLDn}{(0,-0.48)}
+        \TN@vleg{tnVL}{west}{-0.45,0}
+        \TN@vleg{tnVdL}{west}{-0.45,0}
+        \TN@vconnect{tnVL}{east}{tnLUp}{west}
+        \TN@vconnect{tnVdL}{east}{tnLDn}{west}
+        \TN@vleg{tnLUp}{east}{0.55,0}
+        \TN@vleg{tnLDn}{east}{0.55,0}
+        \TN@pconnect{tnLUp}{south}{tnLDn}{north}
         \node at (1.55,0) {$=$};
-        \TN@tensordot{tnRUp}{(3.10,0.48)}
-        \TN@tensordot{tnRDn}{(3.10,-0.48)}
-        \TN@opdotabove{tnVR}{(4.25,0.48)}{#1}
-        \TN@opdotbelow{tnVdR}{(4.25,-0.48)}{#1^\dagger}
-        \draw[tn leg] (tnRUp.west) -- ++(-0.55,0);
-        \draw[tn leg] (tnRDn.west) -- ++(-0.55,0);
-        \draw[tn leg] (tnRUp.east) -- (tnVR.west);
-        \draw[tn leg] (tnRDn.east) -- (tnVdR.west);
-        \draw[tn leg] (tnVR.east) -- ++(0.45,0);
-        \draw[tn leg] (tnVdR.east) -- ++(0.45,0);
-        \draw[tn phys leg] (tnRUp.south) -- (tnRDn.north);
+        \TN@tensor{tnRUp}{(3.10,0.48)}
+        \TN@tensor{tnRDn}{(3.10,-0.48)}
+        \TN@insertion[label=above:$#1$]{tnVR}{(4.25,0.48)}
+        \TN@insertion[label=below:$#1^\dagger$]{tnVdR}{(4.25,-0.48)}
+        \TN@vleg{tnRUp}{west}{-0.55,0}
+        \TN@vleg{tnRDn}{west}{-0.55,0}
+        \TN@vconnect{tnRUp}{east}{tnVR}{west}
+        \TN@vconnect{tnRDn}{east}{tnVdR}{west}
+        \TN@vleg{tnVR}{east}{0.45,0}
+        \TN@vleg{tnVdR}{east}{0.45,0}
+        \TN@pconnect{tnRUp}{south}{tnRDn}{north}
     \end{tikzpicture}%
 }
 
 \newcommand{\TNStringOrderParameter}[2]{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{tnLam}{(-1.15,0)}
+        \TN@tensor{tnLam}{(-1.15,0)}
         \node at ($(tnLam.south)+(0,-0.28)$) {$\Lambda$};
-        \TN@tensordot{tnU1}{(0,\TN@doublelayersep)}
-        \TN@tensordot{tnD1}{(0,-\TN@doublelayersep)}
-        \TN@tensordot{tnU2}{(1.55,\TN@doublelayersep)}
-        \TN@tensordot{tnD2}{(1.55,-\TN@doublelayersep)}
-        \TN@tensordot{tnU3}{(4.30,\TN@doublelayersep)}
-        \TN@tensordot{tnD3}{(4.30,-\TN@doublelayersep)}
-        \TN@opdotleft{tnuA}{(0,0)}{#1}
-        \TN@opdotleft{tnuB}{(1.55,0)}{#1}
-        \TN@opdotleft{tnuC}{(4.30,0)}{#1}
-        \draw[tn leg] (tnLam.east) -- (tnU1.west);
-        \draw[tn leg] (tnLam.east) -- (tnD1.west);
-        \draw[tn leg] (tnU1.east) -- (tnU2.west);
-        \draw[tn leg] (tnD1.east) -- (tnD2.west);
-        \draw[tn leg] (tnU2.east) -- ++(0.62,0);
-        \draw[tn leg] (tnD2.east) -- ++(0.62,0);
-        \draw[tn leg] ($(tnU3.west)+(-0.62,0)$) -- (tnU3.west);
-        \draw[tn leg] ($(tnD3.west)+(-0.62,0)$) -- (tnD3.west);
-        \draw[tn leg] (tnU3.east) -- ++(0.70,0);
-        \draw[tn leg] (tnD3.east) -- ++(0.70,0);
-        \draw[tn phys leg] (tnU1.south) -- (tnuA.north);
-        \draw[tn phys leg] (tnuA.south) -- (tnD1.north);
-        \draw[tn phys leg] (tnU2.south) -- (tnuB.north);
-        \draw[tn phys leg] (tnuB.south) -- (tnD2.north);
-        \draw[tn phys leg] (tnU3.south) -- (tnuC.north);
-        \draw[tn phys leg] (tnuC.south) -- (tnD3.north);
+        \TN@tensor{tnU1}{(0,\TN@doublelayersep)}
+        \TN@tensor{tnD1}{(0,-\TN@doublelayersep)}
+        \TN@tensor{tnU2}{(1.55,\TN@doublelayersep)}
+        \TN@tensor{tnD2}{(1.55,-\TN@doublelayersep)}
+        \TN@tensor{tnU3}{(4.30,\TN@doublelayersep)}
+        \TN@tensor{tnD3}{(4.30,-\TN@doublelayersep)}
+        \TN@insertion[label=left:$#1$]{tnuA}{(0,0)}
+        \TN@insertion[label=left:$#1$]{tnuB}{(1.55,0)}
+        \TN@insertion[label=left:$#1$]{tnuC}{(4.30,0)}
+        \TN@vconnect{tnLam}{east}{tnU1}{west}
+        \TN@vconnect{tnLam}{east}{tnD1}{west}
+        \TN@vconnect{tnU1}{east}{tnU2}{west}
+        \TN@vconnect{tnD1}{east}{tnD2}{west}
+        \TN@vleg{tnU2}{east}{0.62,0}
+        \TN@vleg{tnD2}{east}{0.62,0}
+        \TN@vleg{tnU3}{west}{-0.62,0}
+        \TN@vleg{tnD3}{west}{-0.62,0}
+        \TN@vtraceright{tnU3}{tnD3}{0.70}
+        \TN@pconnect{tnU1}{south}{tnuA}{north}
+        \TN@pconnect{tnuA}{south}{tnD1}{north}
+        \TN@pconnect{tnU2}{south}{tnuB}{north}
+        \TN@pconnect{tnuB}{south}{tnD2}{north}
+        \TN@pconnect{tnU3}{south}{tnuC}{north}
+        \TN@pconnect{tnuC}{south}{tnD3}{north}
         \node at (2.92,\TN@doublelayersep) {$\cdots$};
         \node at (2.92,-\TN@doublelayersep) {$\cdots$};
         \node at (5.55,0) {$\operatorname{tr}$};
@@ -2622,130 +2643,101 @@
     \end{tikzpicture}%
 }
 
-\newcommand{\TNVirtualInsertion}[4]{%
-    \begin{tikzpicture}[tn picture]
-        \TN@tensordot{tnL}{(0,0)}
-        \TN@tensordot{tnM}{(1.45,0)}
-        \TN@tensordot{tnR}{(2.90,0)}
-        \TN@upleg{tnL}{\TN@physleglen}
-        \TN@upleg{tnM}{\TN@physleglen}
-        \TN@upleg{tnR}{\TN@physleglen}
-        \TN@uplabel{tnL}{\TN@physlabeloff}{#1}
-        \TN@uplabel{tnM}{\TN@physlabeloff}{#2}
-        \TN@uplabel{tnR}{\TN@physlabeloff}{#3}
-        \draw[tn leg] (tnL.west) -- ++(-0.65,0);
-        \draw[tn leg] (tnL.east) -- (tnM.west);
-        \draw[tn leg] (tnM.east) -- (tnR.west);
-        \draw[tn leg] (tnR.east) -- ++(0.65,0);
-        \TN@opdotabove{tnX}{(0.72,0)}{#4}
-    \end{tikzpicture}%
-}
-
 \newcommand{\TNInternalTraceInsertion}[3]{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{tnL}{(0,0)}
-        \TN@opdotabove{tnX}{(0.80,0)}{#3}
-        \TN@tensordot{tnR}{(1.60,0)}
-        \TN@upleg{tnL}{\TN@physleglen}
-        \TN@upleg{tnR}{\TN@physleglen}
+        \TN@tensor{tnL}{(0,0)}
+        \TN@insertion[label=above:$#3$]{tnX}{(0.80,0)}
+        \TN@tensor{tnR}{(1.60,0)}
+        \TN@pleg{tnL}{north}{0,\TN@physleglen}
+        \TN@pleg{tnR}{north}{0,\TN@physleglen}
         \TN@uplabel{tnL}{\TN@physlabeloff}{#1}
         \TN@uplabel{tnR}{\TN@physlabeloff}{#2}
-        \draw[tn leg] (tnL.east) -- (tnX.west);
-        \draw[tn leg] (tnX.east) -- (tnR.west);
-        \draw[tn virtual closure] (tnL.west) -- ++(-0.15,0) -- ++(0,-0.78)
-        -- ++(1.90,0) -- ++(0,0.78) -- (tnR.east);
+        \TN@vconnect{tnL}{east}{tnX}{west}
+        \TN@vconnect{tnX}{east}{tnR}{west}
+        \TN@vtracebelow{tnL}{tnR}{0.78}
         \node at (0.80,-0.88) {$\operatorname{Tr}$};
     \end{tikzpicture}%
 }
 
 \newcommand{\TNExternalTraceInsertion}[3]{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{tnL}{(0,0)}
-        \TN@tensordot{tnR}{(1.60,0)}
-        \TN@opdotbelow{tnY}{(0.80,-0.78)}{#3}
-        \TN@upleg{tnL}{\TN@physleglen}
-        \TN@upleg{tnR}{\TN@physleglen}
+        \TN@tensor{tnL}{(0,0)}
+        \TN@tensor{tnR}{(1.60,0)}
+        \TN@insertion[label=below:$#3$]{tnY}{(0.80,-0.78)}
+        \TN@pleg{tnL}{north}{0,\TN@physleglen}
+        \TN@pleg{tnR}{north}{0,\TN@physleglen}
         \TN@uplabel{tnL}{\TN@physlabeloff}{#1}
         \TN@uplabel{tnR}{\TN@physlabeloff}{#2}
-        \draw[tn leg] (tnL.east) -- (tnR.west);
-        \draw[tn virtual closure] (tnL.west) -- ++(-0.15,0) -- ++(0,-0.55) -- (tnY.west);
-        \draw[tn virtual closure] (tnY.east) -- (1.75,-0.55) -- (1.75,0) -- (tnR.east);
+        \TN@vconnect{tnL}{east}{tnR}{west}
+        \TN@vtracevia{tnL}{tnY}{tnR}{0.15}{0.15}
         \node at (0.80,-1.00) {$\operatorname{Tr}$};
     \end{tikzpicture}%
 }
 
 \newcommand{\TNBoundaryRegrow}[4]{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{rA}{(0,0)}
-        \TN@tensordot{rB}{(1.05,0)}
-        \TN@tensordot{rC}{(2.10,0)}
-        \TN@opdotabove{rX}{(3.55,0)}{#1}
+        \TN@tensor{rA}{(0,0)}
+        \TN@tensor{rB}{(1.05,0)}
+        \TN@tensor{rC}{(2.10,0)}
+        \TN@insertion[label=above:$#1$]{rX}{(3.55,0)}
         \foreach \n in {rA,rB,rC} {
-                \TN@upleg{\n}{0.44}
+                \TN@pleg{\n}{north}{0,0.44}
             }
         \TN@uplabel{rA}{0.66}{#2}
         \TN@uplabel{rC}{0.66}{#3}
-        \draw[tn leg] (rA.west) -- ++(-0.50,0);
-        \draw[tn leg] (rA.east) -- (rB.west);
-        \draw[tn leg] (rB.east) -- (rC.west);
-        \draw[tn leg] (rC.east) -- (rX.west);
-        \draw[tn leg] (rX.east) -- ++(0.45,0);
+        \TN@vleg{rA}{west}{-0.50,0}
+        \TN@vconnect{rA}{east}{rB}{west}
+        \TN@vconnect{rB}{east}{rC}{west}
+        \TN@vconnect{rC}{east}{rX}{west}
+        \TN@vleg{rX}{east}{0.45,0}
         \node at (1.78,-0.58) {$#4$};
     \end{tikzpicture}%
 }
 
 \newcommand{\TNLocalEqualityStep}[3]{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{lA}{(0,0)}
-        \TN@opdotabove{lX}{(0.82,0)}{#1}
-        \TN@tensordot{lB}{(1.65,0)}
-        \TN@upleg{lB}{0.44}
+        \TN@tensor{lA}{(0,0)}
+        \TN@insertion[label=above:$#1$]{lX}{(0.82,0)}
+        \TN@tensor{lB}{(1.65,0)}
+        \TN@pleg{lB}{north}{0,0.44}
         \TN@uplabel{lB}{0.66}{#3}
-        \draw[tn leg] (lA.west) -- ++(-0.50,0);
-        \draw[tn leg] (lA.east) -- (lX.west);
-        \draw[tn leg] (lX.east) -- (lB.west);
-        \draw[tn leg] (lB.east) -- ++(0.50,0);
+        \TN@vleg{lA}{west}{-0.50,0}
+        \TN@vconnect{lA}{east}{lX}{west}
+        \TN@vconnect{lX}{east}{lB}{west}
+        \TN@vleg{lB}{east}{0.50,0}
         \node at (2.85,0) {$=$};
-        \TN@tensordot{rA}{(4.10,0)}
-        \TN@opdotabove{rX}{(4.92,0)}{#2}
-        \TN@tensordot{rB}{(5.75,0)}
-        \TN@upleg{rB}{0.44}
+        \TN@tensor{rA}{(4.10,0)}
+        \TN@insertion[label=above:$#2$]{rX}{(4.92,0)}
+        \TN@tensor{rB}{(5.75,0)}
+        \TN@pleg{rB}{north}{0,0.44}
         \TN@uplabel{rB}{0.66}{#3}
-        \draw[tn leg] (rA.west) -- ++(-0.50,0);
-        \draw[tn leg] (rA.east) -- (rX.west);
-        \draw[tn leg] (rX.east) -- (rB.west);
-        \draw[tn leg] (rB.east) -- ++(0.50,0);
-    \end{tikzpicture}%
-}
-
-\newcommand{\TNPeriodicGauge}[3]{%
-    \begin{tikzpicture}[tn picture]
-        \TN@tensordot{pA}{(0,0)}
-        \TN@tensordot{pB}{(1.10,0)}
-        \TN@opdotbelow{pZ}{(0.55,-0.72)}{#2}
-        \draw[tn leg] (-0.45,0) -- (1.55,0);
-        \TN@upleg{pA}{0.38}
-        \TN@upleg{pB}{0.38}
-        \draw[tn virtual closure] (-0.45,0) -- (-0.45,-0.72) -- (pZ.west);
-        \draw[tn virtual closure] (pZ.east) -- (1.55,-0.72) -- (1.55,0);
+        \TN@vleg{rA}{west}{-0.50,0}
+        \TN@vconnect{rA}{east}{rX}{west}
+        \TN@vconnect{rX}{east}{rB}{west}
+        \TN@vleg{rB}{east}{0.50,0}
     \end{tikzpicture}%
 }
 
 \newcommand{\TNGroundSpaceMap}[5]{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{tnL}{(0,0)}
-        \TN@tensordot{tnM}{(1.15,0)}
-        \TN@tensordot{tnR}{(2.95,0)}
-        \TN@upleg{tnL}{\TN@physleglen}
-        \TN@upleg{tnM}{\TN@physleglen}
-        \TN@upleg{tnR}{\TN@physleglen}
+        \TN@tensor{tnL}{(0,0)}
+        \TN@tensor{tnM}{(1.15,0)}
+        \TN@tensor{tnR}{(2.95,0)}
+        \TN@pleg{tnL}{north}{0,\TN@physleglen}
+        \TN@pleg{tnM}{north}{0,\TN@physleglen}
+        \TN@pleg{tnR}{north}{0,\TN@physleglen}
         \TN@uplabel{tnL}{\TN@physlabeloff}{#2}
         \TN@uplabel{tnR}{\TN@physlabeloff}{#3}
-        \draw[tn leg] (-0.45,0) -- (3.40,0);
+        \TN@vleg{tnL}{west}{-0.45,0}
+        \TN@vconnect{tnL}{east}{tnM}{west}
+        \TN@vleg{tnM}{east}{0.56,0}
+        \TN@vleg{tnR}{west}{-0.56,0}
+        \TN@vleg{tnR}{east}{0.45,0}
         \node at (2.05,0) {$\cdots$};
-        \TN@opdotbelow{tnX}{(1.48,-0.82)}{#5}
-        \draw[tn virtual closure] (-0.45,0) -- (-0.45,-0.82) -- (tnX.west);
-        \draw[tn virtual closure] (tnX.east) -- (3.40,-0.82) -- (3.40,0);
+        \TN@insertion[label=below:$#5$]{tnX}{(1.48,-0.82)}
+        \TN@vtracevia{tnL}{tnX}{tnR}{0.45}{0.45}
+        \node at ($(tnM.south)+(0,-0.28)$) {$#1$};
+        \node at (2.05,-0.55) {$#4$};
     \end{tikzpicture}%
 }
 
@@ -2755,22 +2747,22 @@
     \begin{tikzpicture}[tn picture]
         \begin{scope}
             \TN@pepsFiveSitePatch{blockC}
-            \draw[red, line width=0.45pt] (blockCone) circle (0.30cm);
-            \draw[red, line width=0.45pt] (blockCfive) circle (0.30cm);
-            \draw[red, rounded corners=2mm, line width=0.45pt]
-            (0.40,-0.20) rectangle (1.70,1.70);
-            \node[red] at (-0.45,-0.35) {$A'_2$};
-            \node[red] at (-1.10,1.80) {$A'_1$};
-            \node[red] at (1.70,1.80) {$A'_3$};
+            \TN@vpath[tn selected path]{(blockCone) circle (0.30cm)}
+            \TN@vpath[tn selected path]{(blockCfive) circle (0.30cm)}
+            \TN@vpath[tn selected path, rounded corners=2mm]
+                {(0.40,-0.20) rectangle (1.70,1.70)}
+            \node[tn region label selected] at (-0.45,-0.35) {$A'_2$};
+            \node[tn region label selected] at (-1.10,1.80) {$A'_1$};
+            \node[tn region label selected] at (1.70,1.80) {$A'_3$};
         \end{scope}
         \node at (2.70,0.70) {$\rightsquigarrow$};
         \begin{scope}[xshift=3.75cm,yshift=0.70cm]
-            \draw[tn virtual closure] (0.20,0) rectangle (4.00,-0.46);
-            \TN@tensordot{blkL}{(0.80,0)}
-            \TN@tensordot{blkM}{(2.10,0)}
-            \TN@tensordot{blkR}{(3.40,0)}
+            \TN@vpath[tn factor region]{(0.20,0) rectangle (4.00,-0.46)}
+            \TN@tensor{blkL}{(0.80,0)}
+            \TN@tensor{blkM}{(2.10,0)}
+            \TN@tensor{blkR}{(3.40,0)}
             \foreach \n in {blkL,blkM,blkR} {
-                    \TN@upleg{\n}{0.46}
+                    \TN@pleg{\n}{north}{0,0.46}
                 }
             \node at ($(blkL.south)+(0,-0.30)$) {$A'_1$};
             \node at ($(blkM.south)+(0,-0.30)$) {$A'_3$};
@@ -2800,13 +2792,13 @@
 \newcommand{\TNPEPSInsertionPhysicalRealization}{%
     \begin{tikzpicture}[tn picture]
         \begin{scope}
-            \TN@tensordot{realLeftA}{(0,0)}
-            \TN@upleg{realLeftA}{0.50}
-            \draw[tn leg] (realLeftA.east) -- ++(0.70,0);
-            \draw[tn leg] (realLeftA.south) -- ++(0,-0.58);
-            \TN@opdotabove{realLeftM}{(-0.56,0)}{M}
-            \draw[tn leg, red] (realLeftM.west) -- ++(-0.42,0);
-            \draw[tn leg] (realLeftM.east) -- (realLeftA.west);
+            \TN@tensor{realLeftA}{(0,0)}
+            \TN@pleg{realLeftA}{north}{0,0.50}
+            \TN@vleg{realLeftA}{east}{0.70,0}
+            \TN@vleg{realLeftA}{south}{0,-0.58}
+            \TN@insertion[label=above:$M$]{realLeftM}{(-0.56,0)}
+            \TN@vleg{realLeftM}{west}{-0.42,0}
+            \TN@vconnect{realLeftM}{east}{realLeftA}{west}
             \node at ($(realLeftA.south)+(0,-0.30)$) {$A_u$};
             \node at (-0.56,-0.35) {$e$};
             \node at (0.72,-0.36) {$\eta_{\widehat e}$};
@@ -2814,14 +2806,14 @@
         \end{scope}
         \node at (1.80,0) {$=$};
         \begin{scope}[xshift=3.20cm]
-            \TN@tensordot{realRightA}{(0,0)}
-            \TN@upleg{realRightA}{0.30}
-            \TN@opdotleft{realRightO}{(0,0.62)}{O}
-            \draw[tn phys leg] (realRightA.north) -- (realRightO.south);
-            \draw[tn phys leg, red] (realRightO.north) -- ++(0,0.28);
-            \draw[tn leg] (realRightA.west) -- ++(-0.70,0);
-            \draw[tn leg] (realRightA.east) -- ++(0.70,0);
-            \draw[tn leg] (realRightA.south) -- ++(0,-0.58);
+            \TN@tensor{realRightA}{(0,0)}
+            \TN@pleg{realRightA}{north}{0,0.30}
+            \TN@insertion[label=left:$O$]{realRightO}{(0,0.62)}
+            \TN@pconnect{realRightA}{north}{realRightO}{south}
+            \TN@pleg{realRightO}{north}{0,0.28}
+            \TN@vleg{realRightA}{west}{-0.70,0}
+            \TN@vleg{realRightA}{east}{0.70,0}
+            \TN@vleg{realRightA}{south}{0,-0.58}
             \node at ($(realRightA.south)+(0,-0.30)$) {$A_u$};
             \node at (-0.72,-0.36) {$\eta_e$};
             \node at (0.72,-0.36) {$\eta_{\widehat e}$};
@@ -2851,7 +2843,8 @@
         \begin{scope}
             \TN@pepsFiveSitePatch{edgeEqA}
             \TN@pepsFiveSitePatchLabels{edgeEqA}{A_1}{A_2}{A_3}{A_4}{A_5}
-            \TN@opdotright{edgeInsA}{($(edgeEqAtwo)!0.50!(edgeEqAfive)$)}{X}
+            \TN@insertion[label=right:$X$]{edgeInsA}
+                {($(edgeEqAtwo)!0.50!(edgeEqAfive)$)}
         \end{scope}
         \node at (2.75,0.70) {$=$};
         \begin{scope}[xshift=4.15cm]
@@ -2859,7 +2852,8 @@
             \TN@pepsFiveSitePatchLabels{edgeEqB}
             {\widetilde B_1}{\widetilde B_2}{\widetilde B_3}
             {\widetilde B_4}{\widetilde B_5}
-            \TN@opdotright{edgeInsB}{($(edgeEqBtwo)!0.50!(edgeEqBfive)$)}{X}
+            \TN@insertion[label=right:$X$]{edgeInsB}
+                {($(edgeEqBtwo)!0.50!(edgeEqBfive)$)}
         \end{scope}
     \end{tikzpicture}%
 }
@@ -2867,30 +2861,30 @@
 \newcommand{\TNPEPSEdgeGaugeAbsorption}{%
     \begin{tikzpicture}[tn picture]
         \begin{scope}
-            \TN@tensordot{absB}{(0,0)}
-            \TN@upleg{absB}{0.44}
-            \draw[tn leg] (absB.west) -- ++(-0.62,0);
-            \draw[tn leg] (absB.east) -- ++(0.62,0);
-            \draw[tn leg] ($(absB.south)-(0.18,0)$) -- ++(-0.50,-0.58);
-            \draw[tn leg] ($(absB.south)+(0.18,0)$) -- ++(0.50,-0.58);
+            \TN@tensor{absB}{(0,0)}
+            \TN@pleg{absB}{north}{0,0.44}
+            \TN@vleg{absB}{west}{-0.62,0}
+            \TN@vleg{absB}{east}{0.62,0}
+            \TN@vleg{absB}{225}{-0.50,-0.50}
+            \TN@vleg{absB}{315}{0.50,-0.50}
             \node at ($(absB.south)+(0,-0.95)$) {$B_v$};
         \end{scope}
         \node at (1.15,0) {$\longmapsto$};
         \begin{scope}[xshift=2.30cm]
-            \TN@tensordot{absBt}{(0,0)}
-            \TN@upleg{absBt}{0.44}
-            \TN@opdotleft{absL}{(-0.70,0)}{Z_{e_1}^{\pm1}}
-            \TN@opdotright{absR}{(0.70,0)}{Z_{e_2}^{\pm1}}
-            \TN@opdotbelow{absDL}{(-0.48,-0.60)}{Z_{e_3}^{\pm1}}
-            \TN@opdotbelow{absDR}{(0.48,-0.60)}{Z_{e_4}^{\pm1}}
-            \draw[tn leg] (absL.west) -- ++(-0.28,0);
-            \draw[tn leg] (absL.east) -- (absBt.west);
-            \draw[tn leg] (absBt.east) -- (absR.west);
-            \draw[tn leg] (absR.east) -- ++(0.28,0);
-            \draw[tn leg] ($(absBt.south)-(0.18,0)$) -- (absDL.north);
-            \draw[tn leg] ($(absBt.south)+(0.18,0)$) -- (absDR.north);
-            \draw[tn leg] (absDL.south) -- ++(-0.20,-0.28);
-            \draw[tn leg] (absDR.south) -- ++(0.20,-0.28);
+            \TN@tensor{absBt}{(0,0)}
+            \TN@pleg{absBt}{north}{0,0.44}
+            \TN@insertion[label=left:$Z_{e_1}^{\pm1}$]{absL}{(-0.70,0)}
+            \TN@insertion[label=right:$Z_{e_2}^{\pm1}$]{absR}{(0.70,0)}
+            \TN@insertion[label=below:$Z_{e_3}^{\pm1}$]{absDL}{(-0.48,-0.60)}
+            \TN@insertion[label=below:$Z_{e_4}^{\pm1}$]{absDR}{(0.48,-0.60)}
+            \TN@vleg{absL}{west}{-0.28,0}
+            \TN@vconnect{absL}{east}{absBt}{west}
+            \TN@vconnect{absBt}{east}{absR}{west}
+            \TN@vleg{absR}{east}{0.28,0}
+            \TN@vconnect{absBt}{225}{absDL}{north}
+            \TN@vconnect{absBt}{315}{absDR}{north}
+            \TN@vleg{absDL}{south}{-0.20,-0.28}
+            \TN@vleg{absDR}{south}{0.20,-0.28}
             \node at ($(absBt.south)+(0,-1.10)$) {$\widetilde B_v$};
         \end{scope}
     \end{tikzpicture}%
@@ -2916,25 +2910,17 @@
         \node at (1.25,0) {$=$};
         \begin{scope}[xshift=2.05cm]
             \TN@threeLegTensorFan{gaugeRedBZ}{B_1}
-            \draw[red, line width=0.9pt] (0.35,-0.46) arc (-55:5:0.55);
-            \node[red] at (0.70,-0.24) {$Z$};
+            \TN@insertion[label=right:$Z$]{gaugeRedZ}{(0.52,-0.36)}
         \end{scope}
         \node at (3.30,0) {$=$};
         \begin{scope}[xshift=4.10cm]
             \TN@threeLegTensorFan{gaugeRedBU}{B_1}
-            \draw[red, line width=0.9pt] (0.35,-0.06) arc (-10:45:0.55);
-            \node[red] at (0.72,0.24) {$U$};
+            \TN@insertion[label=right:$U$]{gaugeRedU}{(0.56,0.30)}
         \end{scope}
         \node at (5.35,0) {$=$};
         \begin{scope}[xshift=6.15cm]
-            \TN@tensordot{gaugeRedBW}{(0,0)}
-            \TN@upleg{gaugeRedBW}{0.42}
-            \draw[tn leg] (gaugeRedBW) -- ++(0.75,0.45);
-            \draw[tn leg] (gaugeRedBW) -- ++(0.40,-0.07);
-            \draw[tn leg] (gaugeRedBW) -- ++(0.65,-0.55);
-            \draw[red, line width=0.9pt] (0.35,-0.46) arc (-55:45:0.55);
-            \node[red] at (0.79,0.00) {$W$};
-            \node at ($(gaugeRedBW.south)+(0,-0.30)$) {$B_1$};
+            \TN@threeLegTensorFan{gaugeRedBW}{B_1}
+            \TN@insertion[label=right:$W$]{gaugeRedW}{(0.52,-0.04)}
         \end{scope}
     \end{tikzpicture}%
 }
@@ -2942,133 +2928,74 @@
 \newcommand{\TNPEPSOneVertexComplementComparison}{%
     \begin{tikzpicture}[tn picture]
         \begin{scope}
-            \TN@tensordot{oneSiteAR}{(1.00,0)}
-            \TN@tensordot{oneSiteA}{(2.00,0)}
-            \TN@upleg{oneSiteAR}{0.42}
-            \TN@upleg{oneSiteA}{0.42}
-            \draw[tn leg] (0.50,0) -- (oneSiteAR) -- (oneSiteA) -- (2.50,0);
+            \TN@tensor{oneSiteAR}{(1.00,0)}
+            \TN@tensor{oneSiteA}{(2.00,0)}
+            \TN@pleg{oneSiteAR}{north}{0,0.42}
+            \TN@pleg{oneSiteA}{north}{0,0.42}
+            \TN@vleg{oneSiteAR}{west}{-0.50,0}
+            \TN@vconnect{oneSiteAR}{east}{oneSiteA}{west}
+            \TN@vleg{oneSiteA}{east}{0.50,0}
             \node at ($(oneSiteAR.south)+(0,-0.30)$) {$A_R$};
             \node at ($(oneSiteA.south)+(0,-0.30)$) {$A_v$};
         \end{scope}
         \node at (3.12,0) {$=$};
         \begin{scope}[xshift=3.55cm]
-            \TN@tensordot{oneSiteAS}{(1.00,0)}
-            \TN@upleg{oneSiteAS}{0.42}
-            \draw[tn leg] (0.50,0) -- (oneSiteAS) -- (1.50,0);
+            \TN@tensor{oneSiteAS}{(1.00,0)}
+            \TN@pleg{oneSiteAS}{north}{0,0.42}
+            \TN@vleg{oneSiteAS}{west}{-0.50,0}
+            \TN@vleg{oneSiteAS}{east}{0.50,0}
             \node at ($(oneSiteAS.south)+(0,-0.30)$) {$A_S$};
         \end{scope}
         \node at (5.42,0) {$\propto$};
         \begin{scope}[xshift=5.95cm]
-            \TN@tensordot{oneSiteBS}{(1.00,0)}
-            \TN@upleg{oneSiteBS}{0.42}
-            \draw[tn leg] (0.50,0) -- (oneSiteBS) -- (1.50,0);
+            \TN@tensor{oneSiteBS}{(1.00,0)}
+            \TN@pleg{oneSiteBS}{north}{0,0.42}
+            \TN@vleg{oneSiteBS}{west}{-0.50,0}
+            \TN@vleg{oneSiteBS}{east}{0.50,0}
             \node at ($(oneSiteBS.south)+(0,-0.30)$) {$\widetilde B_S$};
         \end{scope}
         \node at (7.82,0) {$=$};
         \begin{scope}[xshift=8.25cm]
-            \TN@tensordot{oneSiteBR}{(1.00,0)}
-            \TN@tensordot{oneSiteB}{(2.00,0)}
-            \TN@upleg{oneSiteBR}{0.42}
-            \TN@upleg{oneSiteB}{0.42}
-            \draw[tn leg] (0.50,0) -- (oneSiteBR) -- (oneSiteB) -- (2.50,0);
+            \TN@tensor{oneSiteBR}{(1.00,0)}
+            \TN@tensor{oneSiteB}{(2.00,0)}
+            \TN@pleg{oneSiteBR}{north}{0,0.42}
+            \TN@pleg{oneSiteB}{north}{0,0.42}
+            \TN@vleg{oneSiteBR}{west}{-0.50,0}
+            \TN@vconnect{oneSiteBR}{east}{oneSiteB}{west}
+            \TN@vleg{oneSiteB}{east}{0.50,0}
             \node at ($(oneSiteBR.south)+(0,-0.30)$) {$\widetilde B_R$};
             \node at ($(oneSiteB.south)+(0,-0.30)$) {$\widetilde B_v$};
         \end{scope}
     \end{tikzpicture}%
 }
 
-\newcommand{\pepsNormalSquareLattice}{%
-    \TN@normalPepsGrid%
-}
-
-\newcommand{\pepsNormalSquareLatticeLines}{%
-    \TN@normalPepsGridLines%
-}
-
-\newcommand{\pepsNormalSquareLatticeDots}{%
-    \TN@normalPepsGridDots%
-}
-
-\newcommand{\pepsNormalRegionR}{%
-    \draw[red, fill=red!35, thick, rounded corners=1mm]
-    (0.3,1.3) -- (1.2,1.3) -- (1.2,1.8) -- (1.7,1.8) --
-    (1.7,2.7) -- (0.3,2.7) -- cycle;
-    \node at (0.75,2.0) {$R$};%
-}
-
-\newcommand{\pepsNormalRegionS}{%
-    \draw[red, fill=red!35, thick, rounded corners=1mm]
-    (0.3,1.3) rectangle (1.7,2.7);
-    \node at (1.00,2.00) {$S$};%
-}
-
-\newcommand{\pepsNormalRegionT}{%
-    \filldraw[draw=red, fill=red!35, thick, rounded corners=1mm,
-        even odd rule]
-    (0.3,2.7) -- (1.2,2.7) -- (1.2,1.7) -- (2.7,1.7) --
-    (2.7,0.8) -- (1.3,0.8) -- (1.3,1.3) -- (0.3,1.3) -- cycle
-    (-0.25,0.25) rectangle (3.25,3.25);
-    \node at (2.0,2.3) {$T$};%
-}
-
-\newcommand{\pepsNormalSingleSiteDifference}{%
-    \filldraw[yellow!75!white, draw=black!65, thick]
-    (1.5,1.5) circle (0.16cm);
-    \node[black] at (1.5,1.5) {\scriptsize $v$};%
-}
-
-\newcommand{\pepsNormalDistinguishedEdge}{%
-    \draw[line width=0.6mm, green!65!black] (1,1.5) -- (1.5,1.5);%
-}
-
-\newcommand{\pepsNormalRedBlock}{%
-    \draw[red, thick, rounded corners=1mm] (0.3,1.3) rectangle (1.2,2.7);%
-}
-
-\newcommand{\pepsNormalBlueBlock}{%
-    \draw[blue, thick, rounded corners=1mm] (1.3,1.7) rectangle (2.7,0.8);%
-}
-
-\newcommand{\pepsNormalComplementBlock}{%
-    \filldraw[draw=black!55, fill=black!8, dashed, thick, rounded corners=1mm,
-        even odd rule]
-    (-0.15,-0.15) rectangle (3.15,3.15)
-    (0.3,1.3) rectangle (1.2,2.7)
-    (1.3,0.8) rectangle (2.7,1.7);
-    \node[black!65] at (2.38,2.45) {$A_3$};%
-}
-
-\newcommand{\pepsBlockedNormalChain}{%
-    \draw[tn virtual closure] (0.50,0) rectangle (3.50,-0.46);
-    \draw[line width=0.6mm, green!65!black] (1.00,0) -- (2.00,0);
-    \foreach \x/\c/\lab in {1/red/A_1,2/blue/A_2,3/black/A_3} {
-            \TN@tensordot{normalBlock\x}{(\x,0)}
-            \TN@upleg{normalBlock\x}{0.46}
-            \node[\c] at ($(normalBlock\x.south)+(0,-0.30)$) {$\lab$};
-        }%
-}
-
-\newcommand{\pepsSquareTensor}[2]{%
-    \TN@tensordot{#1}{#2}
-    \TN@upleg{#1}{0.46}
-    \draw[tn leg] (#1.west) -- ++(-0.60,0);
-    \draw[tn leg] (#1.east) -- ++(0.60,0);
-    \draw[tn leg] (#1.south) -- ++(0,-0.60);
-    \draw[tn leg] (#1.north) -- ++(0,0.38);%
-}
-
 \newcommand{\TNPEPSInjectiveRegionUnion}{%
     \begin{tikzpicture}[tn picture]
-        \node[tn tensor dot] (unionAB) at (0,0) {};
-        \node[tn tensor dot] (unionI) at (0.70,0.70) {};
-        \node[tn tensor dot] (unionBA) at (2.00,0) {};
-        \node[tn tensor dot] (unionC) at (1.30,-0.70) {};
+        \TN@tensor{unionAB}{(0,0)}
+        \TN@tensor{unionI}{(0.70,0.70)}
+        \TN@tensor{unionBA}{(2.00,0)}
+        \TN@tensor{unionC}{(1.30,-0.70)}
         \foreach \n in {unionAB,unionI,unionBA,unionC} {
-                \draw[tn phys leg] (\n.north) -- ++(0,0.42);
+                \TN@pleg{\n}{north}{0,0.42}
             }
-        \draw[tn leg] (unionAB) -- (unionI) -- (unionBA) -- (unionC) --
-        (unionAB) -- (unionBA);
-        \draw[tn leg] (unionI) -- (unionC);
+        \TN@port{unionABToI}{unionAB}{45}
+        \TN@port{unionIToAB}{unionI}{225}
+        \TN@port{unionIToBA}{unionI}{-28}
+        \TN@port{unionBAToI}{unionBA}{152}
+        \TN@port{unionBAToC}{unionBA}{225}
+        \TN@port{unionCToBA}{unionC}{45}
+        \TN@port{unionCToAB}{unionC}{152}
+        \TN@port{unionABToC}{unionAB}{-28}
+        \TN@port{unionABToBA}{unionAB}{east}
+        \TN@port{unionBAToAB}{unionBA}{west}
+        \TN@port{unionIToC}{unionI}{-67}
+        \TN@port{unionCToI}{unionC}{113}
+        \TN@vconnectports{unionABToI}{unionIToAB}
+        \TN@vconnectports{unionIToBA}{unionBAToI}
+        \TN@vconnectports{unionBAToC}{unionCToBA}
+        \TN@vconnectports{unionCToAB}{unionABToC}
+        \TN@vconnectports{unionABToBA}{unionBAToAB}
+        \TN@vconnectports{unionIToC}{unionCToI}
         \node[anchor=east] at ($(unionAB)+(-0.12,-0.20)$) {$A\setminus B$};
         \node[anchor=west] at ($(unionI)+(0.12,0.02)$) {$A\cap B$};
         \node[anchor=west] at ($(unionBA)+(0.12,-0.20)$) {$B\setminus A$};
@@ -3079,63 +3006,109 @@
 \newcommand{\TNPEPSInjectiveRegionUnionProof}{%
     \begin{tikzpicture}[tn picture, scale=0.82]
         \begin{scope}
-            \node[tn tensor dot] (proofAB) at (0,0) {};
-            \node[tn tensor dot] (proofI) at (0.70,0.70) {};
-            \node[tn tensor dot] (proofBA) at (2.00,0) {};
-            \node[tn tensor dot] (proofX) at (1.30,-0.70) {};
+            \TN@tensor{proofAB}{(0,0)}
+            \TN@tensor{proofI}{(0.70,0.70)}
+            \TN@tensor{proofBA}{(2.00,0)}
+            \TN@insertion{proofX}{(1.30,-0.70)}
             \foreach \n in {proofAB,proofI,proofBA} {
-                    \draw[tn phys leg] (\n.north) -- ++(0,0.36);
+                    \TN@pleg{\n}{north}{0,0.36}
                 }
-            \draw[tn leg] (proofAB) -- (proofI) -- (proofBA) -- (proofX) --
-            (proofAB) -- (proofBA);
-            \draw[tn leg] (proofI) -- (proofX);
+            \TN@port{proofABToI}{proofAB}{45}
+            \TN@port{proofIToAB}{proofI}{225}
+            \TN@port{proofIToBA}{proofI}{-28}
+            \TN@port{proofBAToI}{proofBA}{152}
+            \TN@port{proofBAToX}{proofBA}{225}
+            \TN@port{proofXToBA}{proofX}{45}
+            \TN@port{proofXToAB}{proofX}{152}
+            \TN@port{proofABToX}{proofAB}{-28}
+            \TN@port{proofABToBA}{proofAB}{east}
+            \TN@port{proofBAToAB}{proofBA}{west}
+            \TN@port{proofIToX}{proofI}{-67}
+            \TN@port{proofXToI}{proofX}{113}
+            \TN@vconnectports{proofABToI}{proofIToAB}
+            \TN@vconnectports{proofIToBA}{proofBAToI}
+            \TN@vconnectports{proofBAToX}{proofXToBA}
+            \TN@vconnectports{proofXToAB}{proofABToX}
+            \TN@vconnectports{proofABToBA}{proofBAToAB}
+            \TN@vconnectports{proofIToX}{proofXToI}
             \node at ($(proofX)+(0,-0.34)$) {$X$};
             \node at (1.00,-1.18) {$=0$};
         \end{scope}
-        \draw[->, thick] (2.60,0.00) -- (3.20,0.00)
-        node[midway, above] {$A^{-1}$};
+        \TN@arrow{(2.60,0.00) -- (3.20,0.00)
+            node[midway, above] {$A^{-1}$}}
         \begin{scope}[xshift=3.80cm]
             \coordinate (proofAone) at (0,0);
             \coordinate (proofItwo) at (0.70,0.70);
-            \node[tn tensor dot] (proofBAone) at (2.00,0) {};
-            \node[tn tensor dot] (proofXone) at (1.30,-0.70) {};
-            \draw[tn phys leg] (proofBAone.north) -- ++(0,0.36);
-            \draw[tn leg] (proofBAone) -- (proofXone);
-            \draw[tn leg] (proofXone) -- ($(proofXone)!0.34!(proofAone)$);
-            \draw[tn leg] (proofXone) -- ($(proofXone)!0.34!(proofItwo)$);
-            \draw[tn leg] (proofBAone) -- ($(proofBAone)!0.34!(proofAone)$);
-            \draw[tn leg] (proofBAone) -- ($(proofBAone)!0.34!(proofItwo)$);
+            \TN@tensor{proofBAone}{(2.00,0)}
+            \TN@insertion{proofXone}{(1.30,-0.70)}
+            \TN@pleg{proofBAone}{north}{0,0.36}
+            \TN@port{proofBAoneToX}{proofBAone}{225}
+            \TN@port{proofXoneToBA}{proofXone}{45}
+            \TN@port{proofXoneToA}{proofXone}{152}
+            \TN@port{proofXoneToI}{proofXone}{113}
+            \TN@port{proofBAoneToA}{proofBAone}{west}
+            \TN@port{proofBAoneToI}{proofBAone}{152}
+            \coordinate (proofXoneToAEnd) at ($(proofXone)!0.34!(proofAone)$);
+            \coordinate (proofXoneToIEnd) at ($(proofXone)!0.34!(proofItwo)$);
+            \coordinate (proofBAoneToAEnd) at ($(proofBAone)!0.34!(proofAone)$);
+            \coordinate (proofBAoneToIEnd) at ($(proofBAone)!0.34!(proofItwo)$);
+            \TN@vconnectports{proofBAoneToX}{proofXoneToBA}
+            \TN@vconnectports{proofXoneToA}{proofXoneToAEnd}
+            \TN@vconnectports{proofXoneToI}{proofXoneToIEnd}
+            \TN@vconnectports{proofBAoneToA}{proofBAoneToAEnd}
+            \TN@vconnectports{proofBAoneToI}{proofBAoneToIEnd}
             \node at ($(proofXone)+(0,-0.34)$) {$X$};
             \node at (1.00,-1.18) {$=0$};
         \end{scope}
-        \draw[->, thick] (6.45,0.00) -- (7.05,0.00)
-        node[midway, above] {$A\cap B$};
+        \TN@arrow{(6.45,0.00) -- (7.05,0.00)
+            node[midway, above] {$A\cap B$}}
         \begin{scope}[xshift=7.70cm]
             \coordinate (proofAtwo) at (0,0);
-            \node[tn tensor dot] (proofItwoNode) at (0.70,0.70) {};
-            \node[tn tensor dot] (proofBAtwo) at (2.00,0) {};
-            \node[tn tensor dot] (proofXtwo) at (1.30,-0.70) {};
+            \TN@tensor{proofItwoNode}{(0.70,0.70)}
+            \TN@tensor{proofBAtwo}{(2.00,0)}
+            \TN@insertion{proofXtwo}{(1.30,-0.70)}
             \foreach \n in {proofItwoNode,proofBAtwo} {
-                    \draw[tn phys leg] (\n.north) -- ++(0,0.36);
+                    \TN@pleg{\n}{north}{0,0.36}
                 }
-            \draw[tn leg] (proofBAtwo) -- (proofXtwo) -- (proofItwoNode) --
-            (proofBAtwo);
-            \draw[tn leg] (proofXtwo) -- ($(proofXtwo)!0.34!(proofAtwo)$);
-            \draw[tn leg] (proofBAtwo) -- ($(proofBAtwo)!0.34!(proofAtwo)$);
-            \draw[tn leg] (proofItwoNode) -- ($(proofItwoNode)!0.34!(proofAtwo)$);
+            \TN@port{proofBAtwoToX}{proofBAtwo}{225}
+            \TN@port{proofXtwoToBA}{proofXtwo}{45}
+            \TN@port{proofXtwoToI}{proofXtwo}{113}
+            \TN@port{proofItwoNodeToX}{proofItwoNode}{-67}
+            \TN@port{proofItwoNodeToBA}{proofItwoNode}{-28}
+            \TN@port{proofBAtwoToI}{proofBAtwo}{152}
+            \TN@port{proofXtwoToA}{proofXtwo}{152}
+            \TN@port{proofBAtwoToA}{proofBAtwo}{west}
+            \TN@port{proofItwoNodeToA}{proofItwoNode}{225}
+            \coordinate (proofXtwoToAEnd) at ($(proofXtwo)!0.34!(proofAtwo)$);
+            \coordinate (proofBAtwoToAEnd) at ($(proofBAtwo)!0.34!(proofAtwo)$);
+            \coordinate (proofItwoToAEnd) at
+                ($(proofItwoNode)!0.34!(proofAtwo)$);
+            \TN@vconnectports{proofBAtwoToX}{proofXtwoToBA}
+            \TN@vconnectports{proofXtwoToI}{proofItwoNodeToX}
+            \TN@vconnectports{proofItwoNodeToBA}{proofBAtwoToI}
+            \TN@vconnectports{proofXtwoToA}{proofXtwoToAEnd}
+            \TN@vconnectports{proofBAtwoToA}{proofBAtwoToAEnd}
+            \TN@vconnectports{proofItwoNodeToA}{proofItwoToAEnd}
             \node at ($(proofXtwo)+(0,-0.34)$) {$X$};
             \node at (1.00,-1.18) {$=0$};
         \end{scope}
-        \draw[->, thick] (10.35,0.00) -- (10.95,0.00)
-        node[midway, above] {$B^{-1}$};
+        \TN@arrow{(10.35,0.00) -- (10.95,0.00)
+            node[midway, above] {$B^{-1}$}}
         \begin{scope}[xshift=11.55cm]
             \coordinate (proofAthree) at (0,0);
             \coordinate (proofIthree) at (0.70,0.70);
             \coordinate (proofBAthree) at (2.00,0);
-            \node[tn tensor dot] (proofXthree) at (1.30,-0.70) {};
-            \draw[tn leg] (proofXthree) -- ($(proofXthree)!0.34!(proofAthree)$);
-            \draw[tn leg] (proofXthree) -- ($(proofXthree)!0.34!(proofIthree)$);
-            \draw[tn leg] (proofXthree) -- ($(proofXthree)!0.34!(proofBAthree)$);
+            \TN@insertion{proofXthree}{(1.30,-0.70)}
+            \TN@port{proofXthreeToA}{proofXthree}{152}
+            \TN@port{proofXthreeToI}{proofXthree}{113}
+            \TN@port{proofXthreeToBA}{proofXthree}{45}
+            \coordinate (proofXthreeToAEnd) at ($(proofXthree)!0.34!(proofAthree)$);
+            \coordinate (proofXthreeToIEnd) at ($(proofXthree)!0.34!(proofIthree)$);
+            \coordinate (proofXthreeToBAEnd) at
+                ($(proofXthree)!0.34!(proofBAthree)$);
+            \TN@vconnectports{proofXthreeToA}{proofXthreeToAEnd}
+            \TN@vconnectports{proofXthreeToI}{proofXthreeToIEnd}
+            \TN@vconnectports{proofXthreeToBA}{proofXthreeToBAEnd}
             \node at ($(proofXthree)+(0,-0.34)$) {$X=0$};
         \end{scope}
     \end{tikzpicture}%
@@ -3145,14 +3118,14 @@
     \begin{tikzpicture}[tn picture, scale=0.90]
         \begin{scope}
             \clip (-0.25,0.75) rectangle (2.25,3.25);
-            \pepsNormalSquareLattice
-            \pepsNormalRegionR
+            \TN@pepsNormalSquareLattice
+            \TN@pepsNormalRegionR
         \end{scope}
         \node at (2.85,2.00) {and};
         \begin{scope}[xshift=3.55cm]
             \clip (-0.25,0.75) rectangle (2.25,3.25);
-            \pepsNormalSquareLattice
-            \pepsNormalRegionS
+            \TN@pepsNormalSquareLattice
+            \TN@pepsNormalRegionS
         \end{scope}
     \end{tikzpicture}%
 }
@@ -3160,29 +3133,27 @@
 \newcommand{\TNPEPSNormalRegionT}{%
     \begin{tikzpicture}[tn picture, scale=0.90]
         \clip (-0.25,0.25) rectangle (3.25,3.25);
-        \pepsNormalSquareLattice
-        \pepsNormalRegionT
+        \TN@pepsNormalSquareLattice
+        \TN@pepsNormalRegionT
     \end{tikzpicture}%
 }
 
 \newcommand{\TNPEPSNormalRectangleCover}{%
     \begin{tikzpicture}[tn picture, scale=0.78]
-        \draw[step=0.5, tn leg, black!30] (-0.25,-0.25) grid (2.35,2.35);
-        \draw[red!75!black, fill=red!28, thick, rounded corners=1mm]
-        (0.3,0.3) rectangle (1.2,1.7);
-        \draw[blue!75!black, fill=blue!24, thick, rounded corners=1mm]
-        (0.3,0.8) rectangle (1.7,1.7);
-        \draw[black!70, dashed, thick, rounded corners=1mm]
-        (0.3,0.3) -- (1.2,0.3) -- (1.2,0.8) -- (1.7,0.8) --
-        (1.7,1.7) -- (0.3,1.7) -- cycle;
+        \TN@vpath[step=0.5]{(-0.25,-0.25) grid (2.35,2.35)}
+        \path[tn region selected] (0.3,0.3) rectangle (1.2,1.7);
+        \path[tn region secondary] (0.3,0.8) rectangle (1.7,1.7);
+        \path[tn region complement, fill=none]
+            (0.3,0.3) -- (1.2,0.3) -- (1.2,0.8) -- (1.7,0.8) --
+            (1.7,1.7) -- (0.3,1.7) -- cycle;
         \foreach \x in {0,0.5,1,1.5,2} {
                 \foreach \y in {0,0.5,1,1.5,2} {
-                        \node[tn tensor dot] at (\x,\y) {};
+                        \TN@pepsvertex{coverDot}{(\x,\y)}{}
                     }
             }
-        \node[black!70] at (1.48,1.35) {$U$};
-        \node[red!75!black] at (0.75,0.55) {$2\times3$};
-        \node[blue!75!black] at (1.20,1.25) {$3\times2$};
+        \node[tn region label complement] at (1.48,1.35) {$U$};
+        \node[tn region label selected] at (0.75,0.55) {$2\times3$};
+        \node[tn region label secondary] at (1.20,1.25) {$3\times2$};
         \node at (0.98,-0.55)
         {$U=\bigcup_j C_j,\quad C_j\cong 2\times3\ \mathrm{or}\ 3\times2$};
     \end{tikzpicture}%
@@ -3192,22 +3163,17 @@
     \begin{tikzpicture}[tn picture, scale=0.90]
         \begin{scope}
             \clip (-0.25,-0.25) rectangle (3.25,3.25);
-            \pepsNormalSquareLatticeLines
-            \pepsNormalRegionT
-            \draw[purple!70!black, fill=purple!18, thick, rounded corners=1mm]
-            (0.3,2.55) rectangle (1.7,3.18);
-            \draw[purple!70!black, fill=purple!18, thick, rounded corners=1mm]
-            (1.3,2.55) rectangle (2.7,3.18);
-            \pepsNormalSquareLatticeDots
-            \node[red!75!black] at (2.05,1.45) {$T$};
-            \node[purple!70!black] at (1.50,2.88) {top collar};
+            \TN@pepsNormalSquareLatticeLines
+            \TN@pepsNormalRegionT
+            \TN@pepsNormalCollar
+            \TN@pepsNormalSquareLatticeDots
         \end{scope}
         \node at (3.72,1.48) {$=$};
         \begin{scope}[xshift=4.35cm]
             \clip (-0.25,-0.25) rectangle (3.25,3.25);
-            \pepsNormalComplementBlock
-            \pepsNormalSquareLatticeLines
-            \pepsNormalSquareLatticeDots
+            \TN@pepsNormalComplementBlock
+            \TN@pepsNormalSquareLatticeLines
+            \TN@pepsNormalSquareLatticeDots
         \end{scope}
     \end{tikzpicture}%
 }
@@ -3216,17 +3182,17 @@
     \begin{tikzpicture}[tn picture, scale=0.90]
         \begin{scope}
             \clip (-0.25,0.75) rectangle (2.25,3.25);
-            \pepsNormalSquareLattice
-            \pepsNormalRegionR
-            \pepsNormalSingleSiteDifference
+            \TN@pepsNormalSquareLattice
+            \TN@pepsNormalRegionR
+            \TN@pepsNormalSingleSiteDifference
             \node at (1.00,0.98) {$R$};
         \end{scope}
         \node at (2.85,2.00) {$\subset$};
         \begin{scope}[xshift=3.55cm]
             \clip (-0.25,0.75) rectangle (2.25,3.25);
-            \pepsNormalSquareLattice
-            \pepsNormalRegionS
-            \pepsNormalSingleSiteDifference
+            \TN@pepsNormalSquareLattice
+            \TN@pepsNormalRegionS
+            \TN@pepsNormalSingleSiteDifference
             \node at (1.00,0.98) {$S=R\cup\{v\}$};
         \end{scope}
     \end{tikzpicture}%
@@ -3236,16 +3202,16 @@
     \begin{tikzpicture}[tn picture, scale=0.90]
         \begin{scope}
             \clip (-0.25,-0.25) rectangle (3.25,3.25);
-            \pepsNormalComplementBlock
-            \pepsNormalSquareLatticeLines
-            \pepsNormalDistinguishedEdge
-            \pepsNormalSquareLatticeDots
-            \pepsNormalRedBlock
-            \pepsNormalBlueBlock
+            \TN@pepsNormalComplementBlock
+            \TN@pepsNormalSquareLatticeLines
+            \TN@pepsNormalDistinguishedEdge
+            \TN@pepsNormalSquareLatticeDots
+            \TN@pepsNormalSelectedBlock
+            \TN@pepsNormalSecondaryBlock
         \end{scope}
         \node at (3.75,1.45) {$\Rightarrow$};
         \begin{scope}[xshift=4.45cm,yshift=1.50cm]
-            \pepsBlockedNormalChain
+            \TN@pepsBlockedNormalChain
         \end{scope}
     \end{tikzpicture}%
 }
@@ -3253,12 +3219,12 @@
 \newcommand{\TNPEPSNormalEdgeBlockingHypotheses}{%
     \begin{tikzpicture}[tn picture, scale=0.90]
         \clip (-0.25,-0.25) rectangle (3.25,3.25);
-        \pepsNormalComplementBlock
-        \pepsNormalSquareLatticeLines
-        \pepsNormalDistinguishedEdge
-        \pepsNormalSquareLatticeDots
-        \pepsNormalRedBlock
-        \pepsNormalBlueBlock
+        \TN@pepsNormalComplementBlock
+        \TN@pepsNormalSquareLatticeLines
+        \TN@pepsNormalDistinguishedEdge
+        \TN@pepsNormalSquareLatticeDots
+        \TN@pepsNormalSelectedBlock
+        \TN@pepsNormalSecondaryBlock
     \end{tikzpicture}%
 }
 
@@ -3266,29 +3232,29 @@
     \begin{tikzpicture}[tn picture, scale=0.72]
         \begin{scope}
             \clip (-0.25,-0.25) rectangle (3.25,3.25);
-            \pepsNormalComplementBlock
-            \pepsNormalSquareLatticeLines
-            \pepsNormalDistinguishedEdge
-            \pepsNormalSquareLatticeDots
-            \pepsNormalRedBlock
-            \pepsNormalBlueBlock
+            \TN@pepsNormalComplementBlock
+            \TN@pepsNormalSquareLatticeLines
+            \TN@pepsNormalDistinguishedEdge
+            \TN@pepsNormalSquareLatticeDots
+            \TN@pepsNormalSelectedBlock
+            \TN@pepsNormalSecondaryBlock
         \end{scope}
         \node at (1.50,-0.58) {edge blocking};
         \node at (3.75,1.45) {and};
         \begin{scope}[xshift=4.60cm,yshift=-0.20cm]
             \begin{scope}
                 \clip (-0.25,0.75) rectangle (2.25,3.25);
-                \pepsNormalSquareLattice
-                \pepsNormalRegionR
-                \pepsNormalSingleSiteDifference
+                \TN@pepsNormalSquareLattice
+                \TN@pepsNormalRegionR
+                \TN@pepsNormalSingleSiteDifference
                 \node at (1.00,0.98) {$R$};
             \end{scope}
             \node at (2.85,2.00) {$\subset$};
             \begin{scope}[xshift=3.55cm]
                 \clip (-0.25,0.75) rectangle (2.25,3.25);
-                \pepsNormalSquareLattice
-                \pepsNormalRegionS
-                \pepsNormalSingleSiteDifference
+                \TN@pepsNormalSquareLattice
+                \TN@pepsNormalRegionS
+                \TN@pepsNormalSingleSiteDifference
                 \node at (1.00,0.98) {$S=R\cup\{v\}$};
             \end{scope}
             \node at (2.85,0.98) {one-site comparison};
@@ -3299,25 +3265,25 @@
 \newcommand{\TNPEPSTINormalGaugeAbsorption}{%
     \begin{tikzpicture}[tn picture]
         \begin{scope}
-            \pepsSquareTensor{tiB}{(0,0)}
+            \TN@pepsSquareTensor{tiB}{(0,0)}
             \node at ($(tiB.south)+(0,-0.88)$) {$B$};
         \end{scope}
         \node at (1.25,0) {$=$};
         \begin{scope}[xshift=2.35cm]
-            \node[tn tensor dot] (tiA) at (0,0) {};
-            \node[tn operator dot, label=left:$X$] (tiXL) at (-0.76,0) {};
-            \node[tn operator dot, label=right:$X^{-1}$] (tiXR) at (0.76,0) {};
-            \node[tn operator dot, label=below:$Y$] (tiYD) at (0,-0.76) {};
-            \node[tn operator dot, label=above:$Y^{-1}$] (tiYU) at (0,0.76) {};
-            \draw[tn phys leg] (tiA.north) -- ++(0,0.46);
-            \draw[tn leg] (tiXL.west) -- ++(-0.24,0);
-            \draw[tn leg] (tiXL.east) -- (tiA.west);
-            \draw[tn leg] (tiA.east) -- (tiXR.west);
-            \draw[tn leg] (tiXR.east) -- ++(0.24,0);
-            \draw[tn leg] (tiYD.south) -- ++(0,-0.24);
-            \draw[tn leg] (tiYD.north) -- (tiA.south);
-            \draw[tn leg] (tiA.north) -- (tiYU.south);
-            \draw[tn leg] (tiYU.north) -- ++(0,0.24);
+            \TN@tensor{tiA}{(0,0)}
+            \TN@pleg{tiA}{45}{0.34,0.34}
+            \TN@insertion[label=left:$X$]{tiXL}{(-0.76,0)}
+            \TN@insertion[label=right:$X^{-1}$]{tiXR}{(0.76,0)}
+            \TN@insertion[label=below:$Y$]{tiYD}{(0,-0.76)}
+            \TN@insertion[label=above:$Y^{-1}$]{tiYU}{(0,0.76)}
+            \TN@vleg{tiXL}{west}{-0.24,0}
+            \TN@vconnect{tiXL}{east}{tiA}{west}
+            \TN@vconnect{tiA}{east}{tiXR}{west}
+            \TN@vleg{tiXR}{east}{0.24,0}
+            \TN@vleg{tiYD}{south}{0,-0.24}
+            \TN@vconnect{tiYD}{north}{tiA}{south}
+            \TN@vconnect{tiA}{north}{tiYU}{south}
+            \TN@vleg{tiYU}{north}{0,0.24}
             \node at ($(tiA.south)+(0,-1.20)$) {$\lambda A$};
         \end{scope}
     \end{tikzpicture}%
@@ -3325,13 +3291,13 @@
 
 \newcommand{\TNPEPSEdgeGaugeOrientation}{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{tnU}{(0,0)}
-        \TN@tensordot{tnW}{(3.30,0)}
-        \TN@opdotabove{tnXl}{(1.00,0)}{X_e}
-        \TN@opdotabove{tnXr}{(2.30,0)}{(X_e^{-1})^\top}
-        \draw[tn leg] (tnU.east) -- (tnXl.west);
-        \draw[tn leg] (tnXl.east) -- (tnXr.west);
-        \draw[tn leg] (tnXr.east) -- (tnW.west);
+        \TN@pepsvertex{tnU}{(0,0)}{}
+        \TN@pepsvertex{tnW}{(3.30,0)}{}
+        \TN@insertion[label=above:$X_e$]{tnXl}{(1.00,0)}
+        \TN@insertion[label=above:$(X_e^{-1})^\top$]{tnXr}{(2.30,0)}
+        \TN@vconnect{tnU}{east}{tnXl}{west}
+        \TN@vconnect{tnXl}{east}{tnXr}{west}
+        \TN@vconnect{tnXr}{east}{tnW}{west}
         \node at (1.65,0.72) {$e = (u,w)$};
         \node at ($(tnU.south)+(0,-0.28)$) {$u$};
         \node at ($(tnW.south)+(0,-0.28)$) {$w$};
@@ -3340,110 +3306,102 @@
 
 \newcommand{\TNPEPSGaugeVertexAction}{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{tnV}{(0,0)}
-        \TN@opdotleft{tnL}{(-1.05,0)}{M_{ve_1}}
-        \TN@opdotright{tnR}{(1.05,0)}{M_{ve_2}}
-        \TN@opdotbelow{tnDL}{(-0.78,-0.92)}{M_{ve_3}}
-        \TN@opdotbelow{tnDR}{(0.78,-0.92)}{M_{ve_4}}
-        \draw[tn leg] (tnL.east) -- (tnV.west);
-        \draw[tn leg] (tnV.east) -- (tnR.west);
-        \draw[tn leg] ($(tnV.south)-(0.2,0)$) -- (tnDL.north);
-        \draw[tn leg] ($(tnV.south)+(0.2,0)$) -- (tnDR.north);
-        \draw[tn leg] (tnL.west) -- ++(-0.42,0);
-        \draw[tn leg] (tnR.east) -- ++(0.42,0);
-        \draw[tn leg] (tnDL.south) -- ++(-0.30,-0.42);
-        \draw[tn leg] (tnDR.south) -- ++(0.30,-0.42);
-        \TN@upleg{tnV}{0.54}
-        \TN@uplabel{tnV}{0.80}{\sigma}
+        \TN@tensor{tnV}{(0,0)}
+        \TN@pleg{tnV}{45}{0.38,0.38}
+        \TN@insertion[label=above:$M_{ve_1}$]{tnL}{(-1.05,0)}
+        \TN@insertion[label=above:$M_{ve_2}$]{tnR}{(1.05,0)}
+        \TN@insertion[label=left:$M_{ve_3}$]{tnDL}{(-0.78,-0.92)}
+        \TN@insertion[label=right:$M_{ve_4}$]{tnDR}{(0.78,-0.92)}
+        \TN@vconnect{tnL}{east}{tnV}{west}
+        \TN@vconnect{tnV}{east}{tnR}{west}
+        \TN@vconnect{tnV}{225}{tnDL}{north}
+        \TN@vconnect{tnV}{315}{tnDR}{north}
+        \TN@vleg{tnL}{west}{-0.42,0}
+        \TN@vleg{tnR}{east}{0.42,0}
+        \TN@vleg{tnDL}{south}{-0.30,-0.42}
+        \TN@vleg{tnDR}{south}{0.30,-0.42}
+        \node at ($(tnV.45)+(0.38,0.50)$) {$\sigma$};
         \node at ($(tnV.south)+(0,-1.45)$) {$A_v \mapsto A_v^X$};
     \end{tikzpicture}%
 }
 
 \newcommand{\TNPEPSGaugeCancellation}{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{tnL}{(0,0)}
-        \TN@opdot{tnX}{(0.92,0)}
-        \TN@opdot{tnXt}{(2.18,0)}
-        \TN@tensordot{tnR}{(3.10,0)}
-        \draw[tn leg] (tnL.east) -- (tnX.west);
-        \draw[tn leg] (tnX.east) -- (tnXt.west);
-        \draw[tn leg] (tnXt.east) -- (tnR.west);
+        \TN@pepsvertex{tnL}{(0,0)}{}
+        \TN@insertion{tnX}{(0.92,0)}
+        \TN@insertion{tnXt}{(2.18,0)}
+        \TN@pepsvertex{tnR}{(3.10,0)}{}
+        \TN@vconnect{tnL}{east}{tnX}{west}
+        \TN@vconnect{tnX}{east}{tnXt}{west}
+        \TN@vconnect{tnXt}{east}{tnR}{west}
         \node at ($(tnX.north)+(0,0.28)$) {$X_e(j,i)$};
         \node at ($(tnXt.north)+(0,0.28)$) {$((X_e^{-1})^\top)(j,k)$};
         \node at (4.20,0) {$=$};
-        \TN@tensordot{tnL2}{(5.15,0)}
-        \TN@tensordot{tnR2}{(6.65,0)}
-        \draw[tn leg] (tnL2.east) -- (tnR2.west);
+        \TN@pepsvertex{tnL2}{(5.15,0)}{}
+        \TN@pepsvertex{tnR2}{(6.65,0)}{}
+        \TN@vconnect{tnL2}{east}{tnR2}{west}
         \node at (5.90,0.54) {$\sum_j X_e(j,i)\,((X_e^{-1})^\top)(j,k) = \delta(i,k)$};
     \end{tikzpicture}%
 }
 
 \newcommand{\TNPEPSBlockedMiddleLocalGaugeFormula}{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{bmA}{(0,0)}
-        \TN@tensordot{bmB}{(2.55,0)}
-        \draw[tn leg] (bmA) -- ++(40:0.55);
-        \draw[tn leg] (bmA) -- ++(100:0.55);
-        \draw[tn leg] (bmA) -- ++(160:0.55);
-        \draw[tn leg] (bmA) -- ++(220:0.55);
-        \draw[tn leg] (bmA) -- ++(300:0.55);
-        \draw[tn leg] (bmB) -- ++(40:0.55);
-        \draw[tn leg] (bmB) -- ++(100:0.55);
-        \draw[tn leg] (bmB) -- ++(160:0.55);
-        \draw[tn leg] (bmB) -- ++(220:0.55);
-        \draw[tn leg] (bmB) -- ++(300:0.55);
-        \draw[tn phys leg] (bmA.north) -- ++(0,0.62);
-        \draw[tn phys leg] (bmB.north) -- ++(0,0.62);
+        \TN@tensor{bmA}{(0,0)}
+        \TN@tensor{bmB}{(2.55,0)}
+        \foreach \a in {10,90,160,220,300} {
+                \TN@vleg{bmA}{\a}{\a:0.55}
+                \TN@vleg{bmB}{\a}{\a:0.55}
+            }
+        \TN@pleg{bmA}{45}{0.44,0.44}
+        \TN@pleg{bmB}{45}{0.44,0.44}
         \node at ($(bmA)+(0,-0.62)$) {$A_v$};
         \node at ($(bmB)+(0,-0.62)$) {$B_v$};
         \node at (1.28,0.25) {$\prod_{e\ni v}X_e$};
-        \draw[->,tn leg] (0.62,0) -- (1.93,0);
+        \TN@arrow{(0.62,0) -- (1.93,0)}
     \end{tikzpicture}%
 }
 
 \newcommand{\TNPEPSLocalGaugeExtraction}{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{tnLv}{(0,0)}
-        \TN@upleg{tnLv}{0.50}
-        \TN@uplabel{tnLv}{0.76}{\sigma}
-        \draw[tn leg] (tnLv.west) -- ++(-0.90,0);
-        \draw[tn leg] (tnLv.east) -- ++(0.90,0);
-        \draw[tn leg] ($(tnLv.south)-(0.2,0)$) -- ++(-0.72,-0.82);
-        \draw[tn leg] ($(tnLv.south)+(0.2,0)$) -- ++(0.72,-0.82);
+        \TN@tensor{tnLv}{(0,0)}
+        \TN@pleg{tnLv}{45}{0.38,0.38}
+        \node at ($(tnLv.45)+(0.38,0.48)$) {$\sigma$};
+        \TN@vleg{tnLv}{west}{-0.90,0}
+        \TN@vleg{tnLv}{east}{0.90,0}
+        \TN@vleg{tnLv}{225}{-0.72,-0.72}
+        \TN@vleg{tnLv}{315}{0.72,-0.72}
         \node at (0,-1.42) {$\mathrm{star}(v)$};
         \node at (2.85,0) {$\xrightarrow[\text{left inverse}]{\text{injective}}$};
-        \TN@tensordot{tnRv}{(5.70,0)}
-        \TN@upleg{tnRv}{0.50}
-        \TN@uplabel{tnRv}{0.76}{\sigma}
-        \TN@opdot{tnRl}{(4.62,0)}
-        \TN@opdot{tnRr}{(6.78,0)}
-        \TN@opdot{tnRdl}{(4.95,-0.86)}
-        \TN@opdot{tnRdr}{(6.45,-0.86)}
-        \draw[tn leg] (tnRl.west) -- ++(-0.42,0);
-        \draw[tn leg] (tnRl.east) -- (tnRv.west);
-        \draw[tn leg] (tnRv.east) -- (tnRr.west);
-        \draw[tn leg] (tnRr.east) -- ++(0.42,0);
-        \draw[tn leg] ($(tnRv.south)-(0.2,0)$) -- (tnRdl.north);
-        \draw[tn leg] ($(tnRv.south)+(0.2,0)$) -- (tnRdr.north);
+        \TN@tensor{tnRv}{(5.70,0)}
+        \TN@pleg{tnRv}{45}{0.38,0.38}
+        \node at ($(tnRv.45)+(0.38,0.48)$) {$\sigma$};
+        \TN@insertion{tnRl}{(4.62,0)}
+        \TN@insertion{tnRr}{(6.78,0)}
+        \TN@insertion{tnRdl}{(4.95,-0.86)}
+        \TN@insertion{tnRdr}{(6.45,-0.86)}
+        \TN@vleg{tnRl}{west}{-0.42,0}
+        \TN@vconnect{tnRl}{east}{tnRv}{west}
+        \TN@vconnect{tnRv}{east}{tnRr}{west}
+        \TN@vleg{tnRr}{east}{0.42,0}
+        \TN@vconnect{tnRv}{225}{tnRdl}{north}
+        \TN@vconnect{tnRv}{315}{tnRdr}{north}
         \node at (5.70,-1.42) {$\text{local edge gauges}$};
     \end{tikzpicture}%
 }
 
 \newcommand{\TNPEPSGlobalConsistency}{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{tnU}{(0,0)}
-        \TN@tensordot{tnW}{(3.35,0)}
-        \TN@upleg{tnU}{0.44}
-        \TN@upleg{tnW}{0.44}
-        \draw[tn leg] (tnU.west) -- ++(-0.70,0);
-        \draw[tn leg] (tnW.east) -- ++(0.70,0);
-        \draw[tn leg] (tnU.south) -- ++(-0.55,-0.68);
-        \draw[tn leg] (tnW.south) -- ++(0.55,-0.68);
-        \TN@opdotabove{tnXl}{(1.02,0)}{X_e}
-        \TN@opdotabove{tnXr}{(2.33,0)}{(X_e^{-1})^\top}
-        \draw[tn leg] (tnU.east) -- (tnXl.west);
-        \draw[tn leg] (tnXl.east) -- (tnXr.west);
-        \draw[tn leg] (tnXr.east) -- (tnW.west);
+        \TN@pepsvertex{tnU}{(0,0)}{}
+        \TN@pepsvertex{tnW}{(3.35,0)}{}
+        \TN@vleg{tnU}{west}{-0.70,0}
+        \TN@vleg{tnW}{east}{0.70,0}
+        \TN@vleg{tnU}{225}{-0.55,-0.55}
+        \TN@vleg{tnW}{315}{0.55,-0.55}
+        \TN@insertion[label=above:$X_e$]{tnXl}{(1.02,0)}
+        \TN@insertion[label=above:$(X_e^{-1})^\top$]{tnXr}{(2.33,0)}
+        \TN@vconnect{tnU}{east}{tnXl}{west}
+        \TN@vconnect{tnXl}{east}{tnXr}{west}
+        \TN@vconnect{tnXr}{east}{tnW}{west}
         \node at (1.67,0.78) {$\text{shared edge } e$};
         \node at ($(tnU.south)+(0,-0.28)$) {$u$};
         \node at ($(tnW.south)+(0,-0.28)$) {$w$};
@@ -3459,19 +3417,14 @@
     \begin{tikzpicture}[tn picture]
         \foreach \x in {0,1,2} {
             \foreach \y in {0,1,2} {
-                    \node[tn tensor dot] (pl\x\y) at (\x,\y) {};
+                    \TN@pepsvertex{pl\x\y}{(\x,\y)}{}
                 }
         }
         \foreach \y in {0,1,2} {
-            \draw[tn leg] (pl0\y) -- (pl1\y) -- (pl2\y);
+            \TN@vpath{(pl0\y) -- (pl1\y) -- (pl2\y)}
         }
         \foreach \x in {0,1,2} {
-            \draw[tn leg] (pl\x0) -- (pl\x1) -- (pl\x2);
-        }
-        \foreach \x in {0,1,2} {
-            \foreach \y in {0,1,2} {
-                    \draw[tn phys leg] (pl\x\y.center) -- ++(0.34,0.34);
-                }
+            \TN@vpath{(pl\x0) -- (pl\x1) -- (pl\x2)}
         }
     \end{tikzpicture}%
 }
@@ -3480,16 +3433,11 @@
 % physical index $\sigma$, the four thin legs are the incident virtual edges.
 \newcommand{\TNPEPSLocalTensorStar}{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{lt}{(0,0)}
-        \draw[tn phys leg] (lt.center) -- ++(0.42,0.42);
+        \TN@pepssiteWithOpenLegs{lt}{(0,0)}{}
         \node at (0.66,0.62) {$\sigma$};
-        \draw[tn leg] (lt.west) -- ++(-0.78,0);
         \node at (-0.98,0) {$e_1$};
-        \draw[tn leg] (lt.east) -- ++(0.78,0);
         \node at (0.98,0) {$e_2$};
-        \draw[tn leg] (lt.north) -- ++(0,0.66);
         \node at (0,0.86) {$e_3$};
-        \draw[tn leg] (lt.south) -- ++(0,-0.66);
         \node at (0,-0.86) {$e_4$};
         \node at (-0.40,-0.34) {$A_v$};
     \end{tikzpicture}%
@@ -3501,13 +3449,13 @@
 % this family.
 \newcommand{\TNPEPSVertexInjectivityMap}{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{vi}{(0,0)}
-        \draw[tn phys leg] (vi.north) -- ++(0,0.64);
-        \node at (0,0.92) {$\C^d$};
-        \draw[tn leg] (vi.west) -- ++(-0.62,0);
-        \draw[tn leg] (vi.east) -- ++(0.62,0);
-        \draw[tn leg] (vi.south) -- ++(-0.46,-0.56);
-        \draw[tn leg] (vi.south) -- ++(0.46,-0.56);
+        \TN@tensor{vi}{(0,0)}
+        \TN@pleg{vi}{45}{0.46,0.46}
+        \node at (0.72,0.72) {$\C^d$};
+        \TN@vleg{vi}{west}{-0.62,0}
+        \TN@vleg{vi}{east}{0.62,0}
+        \TN@vleg{vi}{225}{-0.46,-0.46}
+        \TN@vleg{vi}{315}{0.46,-0.46}
         \node at (0,-1.04) {$\eta$};
         \node at (1.95,0.30) {\scriptsize injective};
         \node at (1.95,0) {$\longmapsto$};
@@ -3532,27 +3480,22 @@
     \begin{tikzpicture}[tn picture]
         \foreach \x in {0,1,2} {
             \foreach \y in {0,1,2} {
-                    \node[tn tensor dot] (tg\x\y) at (\x,\y) {};
+                    \TN@pepsvertex{tg\x\y}{(\x,\y)}{}
                 }
         }
         \foreach \y in {0,1,2} {
-            \draw[tn leg] (tg0\y) -- (tg1\y) -- (tg2\y);
+            \TN@vpath{(tg0\y) -- (tg1\y) -- (tg2\y)}
         }
         \foreach \x in {0,1,2} {
-            \draw[tn leg] (tg\x0) -- (tg\x1) -- (tg\x2);
-        }
-        \foreach \x in {0,1,2} {
-            \foreach \y in {0,1,2} {
-                    \draw[tn phys leg] (tg\x\y.center) -- ++(0.30,0.30);
-                }
+            \TN@vpath{(tg\x0) -- (tg\x1) -- (tg\x2)}
         }
         \foreach \y in {0,1,2} {
-            \draw[tn periodic identification] (tg2\y.east) -- ++(0.5,0);
-            \draw[tn periodic identification] (tg0\y.west) -- ++(-0.5,0);
+            \TN@vleg[tn periodic mark]{tg2\y}{east}{0.5,0}
+            \TN@vleg[tn periodic mark]{tg0\y}{west}{-0.5,0}
         }
         \foreach \x in {0,1,2} {
-            \draw[tn periodic identification] (tg\x2.north) -- ++(0,0.5);
-            \draw[tn periodic identification] (tg\x0.south) -- ++(0,-0.5);
+            \TN@vleg[tn periodic mark]{tg\x2}{north}{0,0.5}
+            \TN@vleg[tn periodic mark]{tg\x0}{south}{0,-0.5}
         }
         \node at (1,-1.15) {\scriptsize rows and columns identified modulo $n,m$};
     \end{tikzpicture}%
@@ -3563,15 +3506,33 @@
 % multiply to one.
 \newcommand{\TNPEPSVertexScalarBalance}{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{vb}{(0,0)}
-        \draw[tn leg] (vb.west) -- ++(-0.85,0);
-        \TN@opdot{vbZW}{(-0.5,0)}
-        \draw[tn leg] (vb.east) -- ++(0.85,0);
-        \TN@opdot{vbZE}{(0.5,0)}
-        \draw[tn leg] (vb.north) -- ++(0,0.85);
-        \TN@opdot{vbZN}{(0,0.5)}
-        \draw[tn leg] (vb.south) -- ++(0,-0.85);
-        \TN@opdot{vbZS}{(0,-0.5)}
+        \TN@pepssite{vb}{(0,0)}{}
+        \coordinate (vbWOpen) at ($(vbW)+(-0.58,0)$);
+        \coordinate (vbEOpen) at ($(vbE)+(0.58,0)$);
+        \coordinate (vbNOpen) at ($(vbN)+(0,0.58)$);
+        \coordinate (vbSOpen) at ($(vbS)+(0,-0.58)$);
+        \coordinate (vbPOpen) at ($(vbP)+(0.38,0.38)$);
+        \TN@insertion{vbZW}{(-0.5,0)}
+        \TN@insertion{vbZE}{(0.5,0)}
+        \TN@insertion{vbZN}{(0,0.5)}
+        \TN@insertion{vbZS}{(0,-0.5)}
+        \TN@port{vbZWW}{vbZW}{west}
+        \TN@port{vbZWE}{vbZW}{east}
+        \TN@port{vbZEW}{vbZE}{west}
+        \TN@port{vbZEE}{vbZE}{east}
+        \TN@port{vbZNN}{vbZN}{north}
+        \TN@port{vbZNS}{vbZN}{south}
+        \TN@port{vbZSN}{vbZS}{north}
+        \TN@port{vbZSS}{vbZS}{south}
+        \TN@vconnectports{vbW}{vbZWE}
+        \TN@vconnectports{vbZWW}{vbWOpen}
+        \TN@vconnectports{vbE}{vbZEW}
+        \TN@vconnectports{vbZEE}{vbEOpen}
+        \TN@vconnectports{vbN}{vbZNS}
+        \TN@vconnectports{vbZNN}{vbNOpen}
+        \TN@vconnectports{vbS}{vbZSN}
+        \TN@vconnectports{vbZSS}{vbSOpen}
+        \TN@pconnectports{vbP}{vbPOpen}
         \node at (-0.52,0.28) {$c_{v,e_1}$};
         \node at (0.52,0.28) {$c_{v,e_2}$};
         \node at (0.44,0.5) {$c_{v,e_3}$};
@@ -3587,13 +3548,13 @@
 % K_i^dagger (bra) layers; rho enters on the left, T(rho) leaves on the right.
 \newcommand{\TNKrausMap}{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{krUp}{(0,0.44)}
-        \TN@tensordot{krDn}{(0,-0.44)}
-        \draw[tn leg] ($(krUp.west)+(-0.7,0)$) -- (krUp.west);
-        \draw[tn leg] ($(krDn.west)+(-0.7,0)$) -- (krDn.west);
-        \draw[tn leg] (krUp.east) -- ++(0.7,0);
-        \draw[tn leg] (krDn.east) -- ++(0.7,0);
-        \draw[tn phys leg] (krUp.south) -- (krDn.north);
+        \TN@tensor{krUp}{(0,0.44)}
+        \TN@tensor{krDn}{(0,-0.44)}
+        \TN@vleg{krUp}{west}{-0.7,0}
+        \TN@vleg{krDn}{west}{-0.7,0}
+        \TN@vleg{krUp}{east}{0.7,0}
+        \TN@vleg{krDn}{east}{0.7,0}
+        \TN@pconnect{krUp}{south}{krDn}{north}
         \node at (-1.02,0) {$\rho$};
         \node at (1.46,0) {$T(\rho)$};
         \node at ($(krUp.south)!0.5!(krDn.north)+(0.2,0)$) {$i$};
@@ -3607,16 +3568,27 @@
 % (the loop on the right), leaving the channel output T(rho) on the system legs.
 \newcommand{\TNStinespring}{%
     \begin{tikzpicture}[tn picture]
-        \node[tn map box] (sV) at (0,0.5) {$V$};
-        \node[tn map box] (sVd) at (0,-0.5) {$V^\dagger$};
+        \TN@map{sV}{(0,0.5)}{V}
+        \TN@map{sVd}{(0,-0.5)}{V^\dagger}
         \node at (-1.05,0) {$\rho$};
-        \draw[tn leg] (-0.8,0.16) -- (sV.west);
-        \draw[tn leg] (-0.8,-0.16) -- (sVd.west);
-        \draw[tn leg] (sV.east) -- ++(0.6,0);
-        \draw[tn leg] (sVd.east) -- ++(0.6,0);
+        \coordinate (sRhoU) at (-0.8,0.16);
+        \coordinate (sRhoD) at (-0.8,-0.16);
+        \TN@vconnectpoints{sRhoU}{sV.west}
+        \TN@vconnectpoints{sRhoD}{sVd.west}
+        \TN@vleg{sV}{east}{0.6,0}
+        \TN@vleg{sVd}{east}{0.6,0}
         \node at (1.0,0) {$T(\rho)$};
-        \draw[tn virtual closure] (sV.north) -- ++(0,0.3) -| (1.55,0);
-        \draw[tn virtual closure] (sVd.south) -- ++(0,-0.3) -| (1.55,0);
+        \coordinate (sEnv) at (1.55,0);
+        \coordinate (sEnvTop) at ($(sV.north)+(0,0.3)$);
+        \coordinate (sEnvTopRight) at (sEnvTop -| sEnv);
+        \coordinate (sEnvBottom) at ($(sVd.south)+(0,-0.3)$);
+        \coordinate (sEnvBottomRight) at (sEnvBottom -| sEnv);
+        \TN@vtraceconnectpoints{sV.north}{sEnvTop}
+        \TN@vtraceconnectpoints{sEnvTop}{sEnvTopRight}
+        \TN@vtraceconnectpoints{sEnvTopRight}{sEnv}
+        \TN@vtraceconnectpoints{sVd.south}{sEnvBottom}
+        \TN@vtraceconnectpoints{sEnvBottom}{sEnvBottomRight}
+        \TN@vtraceconnectpoints{sEnvBottomRight}{sEnv}
         \node at (1.78,0) {$E$};
     \end{tikzpicture}%
 }
@@ -3626,13 +3598,15 @@
 % |Omega|, presenting the map as a matrix on the doubled space.
 \newcommand{\TNChoiMatrix}{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensordot{cmU}{(0,0.42)}
-        \TN@tensordot{cmD}{(0,-0.42)}
-        \draw[tn phys leg] (cmU.south) -- (cmD.north);
-        \draw[tn leg] (cmU.east) -- ++(0.62,0);
-        \draw[tn leg] (cmD.east) -- ++(0.62,0);
-        \draw[tn leg] (cmU.west) .. controls (-1.0,0.42) and (-1.0,1.05) .. (-0.35,1.05) -- ++(0.97,0);
-        \draw[tn leg] (cmD.west) .. controls (-1.0,-0.42) and (-1.0,-1.05) .. (-0.35,-1.05) -- ++(0.97,0);
+        \TN@tensor{cmU}{(0,0.42)}
+        \TN@tensor{cmD}{(0,-0.42)}
+        \TN@pconnect{cmU}{south}{cmD}{north}
+        \TN@vleg{cmU}{east}{0.62,0}
+        \TN@vleg{cmD}{east}{0.62,0}
+        \TN@vbezieropen{cmU}{west}{(-1.0,0.42)}{(-1.0,1.05)}
+            {(-0.35,1.05)}{0.97,0}
+        \TN@vbezieropen{cmD}{west}{(-1.0,-0.42)}{(-1.0,-1.05)}
+            {(-0.35,-1.05)}{0.97,0}
         \node[anchor=east] at (-0.78,0) {$\ket{\Omega}$};
         \node at (0.3,0.66) {$T$};
     \end{tikzpicture}%
@@ -3644,21 +3618,22 @@
 % sigma_i supplies the output matrix legs.
 \newcommand{\TNTransferMapTracePairing}{%
     \begin{tikzpicture}[tn picture]
-        \node[tn tensor box] (tpRho) at (-1.55,0) {$\rho$};
-        \node[tn tensor box] (tpSigJ) at (-0.48,0) {$\sigma_j$};
-        \node[tn tensor box] (tpT) at (0.82,0) {$t_{ij}$};
-        \node[tn tensor box] (tpSigI) at (2.12,0) {$\sigma_i$};
-        \draw[tn leg] (tpRho.north east) -- (tpSigJ.north west);
-        \draw[tn leg] (tpRho.south east) -- (tpSigJ.south west);
-        \draw[tn virtual closure] (tpSigJ.north east)
-            .. controls (-0.12,0.52) and (-1.92,0.52) .. (tpRho.north west);
-        \draw[tn virtual closure] (tpSigJ.south east)
-            .. controls (-0.12,-0.52) and (-1.92,-0.52) .. (tpRho.south west);
-        \draw[tn phys leg] (tpSigJ.north)
-            .. controls (-0.32,0.78) and (0.62,0.78) .. (tpT.north);
-        \draw[tn phys leg] (tpT.east) -- (tpSigI.west);
-        \draw[tn leg] (tpSigI.north east) -- ++(0.72,0);
-        \draw[tn leg] (tpSigI.south east) -- ++(0.72,0);
+        \TN@component{tpRho}{(-1.55,0)}{\rho}
+        \TN@component{tpSigJ}{(-0.48,0)}{\sigma_j}
+        \TN@tensor{tpT}{(0.82,0)}
+        \TN@label[anchor=north]{tpT.south}{(0,-0.10)}{t_{ij}}
+        \TN@component{tpSigI}{(2.12,0)}{\sigma_i}
+        \TN@vconnectpoints{tpRho.north east}{tpSigJ.north west}
+        \TN@vconnectpoints{tpRho.south east}{tpSigJ.south west}
+        \TN@vtraceconnectbezier{tpSigJ}{north east}{(-0.12,0.52)}
+            {(-1.92,0.52)}{tpRho}{north west}
+        \TN@vtraceconnectbezier{tpSigJ}{south east}{(-0.12,-0.52)}
+            {(-1.92,-0.52)}{tpRho}{south west}
+        \TN@pconnectbezier{tpSigJ}{north}{(-0.32,0.78)}
+            {(0.62,0.78)}{tpT}{north}
+        \TN@pconnect{tpT}{east}{tpSigI}{west}
+        \TN@vleg{tpSigI}{north east}{0.72,0}
+        \TN@vleg{tpSigI}{south east}{0.72,0}
         \node at (-1.08,-0.82) {$\tr(\sigma_j\rho)$};
         \node at (3.22,0) {$T(\rho)$};
     \end{tikzpicture}%
@@ -3669,17 +3644,16 @@
 % of the transfer map E_A, insert Y, and close the line by the trace.
 \newcommand{\TNTwoPointCorrelator}{%
     \begin{tikzpicture}[tn picture]
-        \node[tn tensor box, inner sep=1.6pt] (coR) at (0,0) {$\rho^R$};
-        \TN@opdot{coX}{(1.05,0)}
-        \node[tn map box] (coE) at (2.3,0) {$\E_A^n$};
-        \TN@opdot{coY}{(3.55,0)}
-        \draw[tn leg] (coR.east) -- (coX.west);
-        \draw[tn leg] (coX.east) -- (coE.west);
-        \draw[tn leg] (coE.east) -- (coY.west);
+        \TN@component[inner sep=1.6pt]{coR}{(0,0)}{\rho^R}
+        \TN@insertion{coX}{(1.05,0)}
+        \TN@map{coE}{(2.3,0)}{\E_A^n}
+        \TN@insertion{coY}{(3.55,0)}
+        \TN@vconnect{coR}{east}{coX}{west}
+        \TN@vconnect{coX}{east}{coE}{west}
+        \TN@vconnect{coE}{east}{coY}{west}
         \node at (1.05,0.28) {$X$};
         \node at (3.55,0.28) {$Y$};
-        \draw[tn virtual closure] (coY.east) -- (4.1,0) -- (4.1,-0.85)
-            -- (-0.55,-0.85) -- (-0.55,0) -- (coR.west);
+        \TN@vtracebelow{coR}{coY}{0.85}
         \node at (1.8,-1.08) {$\tr$};
     \end{tikzpicture}%
 }

--- a/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
+++ b/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
@@ -55,13 +55,13 @@ name: TNGaugeConjugation TNPhysicalRealization TNLinearTwist
 name: TNPermutationTwistLabeled TNPermutationTwist TNTwistedTransfer
 {{ obj.tn_svg_html }}
 
-name: TNCondCOne TNCondCTwo TNStringOrderParameter TNVirtualInsertion
+name: TNCondCOne TNCondCTwo TNStringOrderParameter
 {{ obj.tn_svg_html }}
 
 name: TNInternalTraceInsertion TNExternalTraceInsertion TNBoundaryRegrow
 {{ obj.tn_svg_html }}
 
-name: TNLocalEqualityStep TNPeriodicGauge TNGroundSpaceMap
+name: TNLocalEqualityStep TNGroundSpaceMap
 {{ obj.tn_svg_html }}
 
 name: TNPEPSEdgeGaugeOrientation TNPEPSGaugeVertexAction

--- a/docs/slides/preamble.tex
+++ b/docs/slides/preamble.tex
@@ -30,6 +30,9 @@
 \definecolor{deepblue}{RGB}{50,100,170}
 \definecolor{mintgreen}{RGB}{100,210,130}
 
+% Semantic tensor-network diagrams for the independent dark-theme slides.
+\input{tn_library_dark}
+
 % ── Beamer colors ──
 \setbeamercolor{background canvas}{bg=darkbg}
 \setbeamercolor{normal text}{fg=white}

--- a/docs/slides/presentation20260207.tex
+++ b/docs/slides/presentation20260207.tex
@@ -49,24 +49,7 @@ B^i = X A^i X^{-1}
 
 \column{0.45\textwidth}
 \begin{center}
-\begin{tikzpicture}[scale=0.85]
-% Tensor nodes
-\foreach \x in {1,2,3,4,5} {
-  \node[rectangle,draw=white,fill=leangreen,minimum size=0.6cm] (A\x) at (\x*1.1,0) {\tiny $A$};
-  % Physical leg pointing upward
-  \draw[-,white,thick] (A\x.north) -- ++(0,0.4);
-  \node[above=0.45cm of A\x] {\small $i_{\x}$};
-}
-% Virtual bonds (horizontal, bond dimension D)
-\foreach \x in {1,2,3,4} {
-  \pgfmathtruncatemacro{\next}{\x+1}
-  \draw[-,white,thick] (A\x) -- (A\next);
-}
-% Trace boundary
-\draw[-,white,thick,dashed] (A1.west) -- ++(-0.25,0);
-\draw[-,white,thick,dashed] (A5.east) -- ++(0.25,0);
-\node[above] at (3*1.1,1.3) {\textcolor{white}{\textbf{Tensor Network}}};
-\end{tikzpicture}
+\SlideTNPeriodicMPS{A}{N}
 
 \vspace{1.5em}
 {\ttfamily\small

--- a/docs/slides/presentation20260208.tex
+++ b/docs/slides/presentation20260208.tex
@@ -48,47 +48,10 @@ $B^i = X A^i X^{-1}$ with $X\in\GLC(D,\mathbb{C})$ leaves \emph{every} coefficie
 
 \column{0.43\textwidth}
 \begin{center}
-\begin{tikzpicture}[scale=0.82]
-\foreach \x in {1,2,3,4,5} {
-  \node[rectangle,draw=white,fill=leangreen,minimum size=0.6cm,
-        font=\small\bfseries] (A\x) at (\x*1.1,0) {$A$};
-  \draw[-,white,thick] (A\x.north) -- ++(0,0.55);
-  \node[above=0.58cm of A\x,font=\small] {$i_{\x}$};
-}
-\foreach \x in {1,2,3,4} {
-  \pgfmathtruncatemacro{\next}{\x+1}
-  \draw[-,white,thick] (A\x.east) -- (A\next.west);
-}
-\draw[-,white,thick,densely dashed] (A1.west) -- ++(-0.5,0)
-  node[left,font=\tiny] {tr};
-\draw[-,white,thick,densely dashed] (A5.east) -- ++(0.5,0);
-\draw[-,white,thick,densely dashed,rounded corners]
-  ([xshift=-0.5cm]A1.west) -- ++(0,-0.7) -- ++(6.5,0) -- ++(0,0.7);
-\node[font=\footnotesize\bfseries,white] at (3.3,-1.2) {bond dimension $D$};
-\end{tikzpicture}
+\SlideTNPeriodicMPS{A}{N}
 
 \vspace{1.5em}
-\begin{tikzpicture}[scale=0.82]
-\node[rectangle,draw=white,fill=leangreen,minimum size=0.6cm,
-      font=\small\bfseries] (Ai) at (0,0) {$A$};
-\draw[-,white,thick] (Ai.north) -- ++(0,0.5);
-\node[above=0.55cm of Ai,font=\small] {$i$};
-\draw[-,white,thick] (Ai.west) -- ++(-0.5,0);
-\draw[-,white,thick] (Ai.east) -- ++(0.5,0);
-\node[font=\Large,white] at (2,0) {$=$};
-\node[circle,draw=white,fill=amber!80!black,minimum size=0.55cm,
-      font=\scriptsize\bfseries,text=black] (X) at (3,0) {$X$};
-\node[rectangle,draw=white,fill=leangreen,minimum size=0.6cm,
-      font=\small\bfseries] (A2) at (4.2,0) {$A$};
-\node[circle,draw=white,fill=amber!80!black,minimum size=0.55cm,
-      font=\scriptsize\bfseries,text=black] (Xi) at (5.4,0) {$X^{\!-\!1}$};
-\draw[-,white,thick] (A2.north) -- ++(0,0.5);
-\node[above=0.55cm of A2,font=\small] {$i$};
-\draw[-,white,thick] (X.west) -- ++(-0.5,0);
-\draw[-,white,thick] (X.east) -- (A2.west);
-\draw[-,white,thick] (A2.east) -- (Xi.west);
-\draw[-,white,thick] (Xi.east) -- ++(0.5,0);
-\end{tikzpicture}
+\SlideTNGaugeConjugation{B}{A}{X}
 \end{center}
 \end{columns}
 \end{frame}

--- a/docs/slides/presentation20260212.tex
+++ b/docs/slides/presentation20260212.tex
@@ -51,47 +51,10 @@
 
         \column{0.43\textwidth}
         \begin{center}
-            \begin{tikzpicture}[scale=0.82]
-                \foreach \x in {1,2,3,4,5} {
-                        \node[rectangle,draw=white,fill=leangreen,minimum size=0.6cm,
-                            font=\small\bfseries] (A\x) at (\x*1.1,0) {$A$};
-                        \draw[-,white,thick] (A\x.north) -- ++(0,0.55);
-                        \node[above=0.58cm of A\x,font=\small] {$i_{\x}$};
-                    }
-                \foreach \x in {1,2,3,4} {
-                        \pgfmathtruncatemacro{\next}{\x+1}
-                        \draw[-,white,thick] (A\x.east) -- (A\next.west);
-                    }
-                \draw[-,white,thick,densely dashed] (A1.west) -- ++(-0.5,0)
-                node[left,font=\tiny] {tr};
-                \draw[-,white,thick,densely dashed] (A5.east) -- ++(0.5,0);
-                \draw[-,white,thick,densely dashed,rounded corners]
-                ([xshift=-0.5cm]A1.west) -- ++(0,-0.7) -- ++(6.5,0) -- ++(0,0.7);
-                \node[font=\footnotesize\bfseries,white] at (3.3,-1.2) {bond dimension $D$};
-            \end{tikzpicture}
+            \SlideTNPeriodicMPS{A}{N}
 
             \vspace{1.2em}
-            \begin{tikzpicture}[scale=0.82]
-                \node[rectangle,draw=white,fill=leangreen,minimum size=0.6cm,
-                    font=\small\bfseries] (Ai) at (0,0) {$A$};
-                \draw[-,white,thick] (Ai.north) -- ++(0,0.5);
-                \node[above=0.55cm of Ai,font=\small] {$i$};
-                \draw[-,white,thick] (Ai.west) -- ++(-0.5,0);
-                \draw[-,white,thick] (Ai.east) -- ++(0.5,0);
-                \node[font=\Large,white] at (2,0) {$=$};
-                \node[circle,draw=white,fill=amber!80!black,minimum size=0.55cm,
-                    font=\scriptsize\bfseries,text=black] (X) at (3,0) {$X$};
-                \node[rectangle,draw=white,fill=leangreen,minimum size=0.6cm,
-                    font=\small\bfseries] (A2) at (4.2,0) {$A$};
-                \node[circle,draw=white,fill=amber!80!black,minimum size=0.55cm,
-                    font=\scriptsize\bfseries,text=black] (Xi) at (5.4,0) {$X^{\!-\!1}$};
-                \draw[-,white,thick] (A2.north) -- ++(0,0.5);
-                \node[above=0.55cm of A2,font=\small] {$i$};
-                \draw[-,white,thick] (X.west) -- ++(-0.5,0);
-                \draw[-,white,thick] (X.east) -- (A2.west);
-                \draw[-,white,thick] (A2.east) -- (Xi.west);
-                \draw[-,white,thick] (Xi.east) -- ++(0.5,0);
-            \end{tikzpicture}
+            \SlideTNGaugeConjugation{B}{A}{X}
         \end{center}
     \end{columns}
 

--- a/docs/slides/presentation20260218_tao_technical.tex
+++ b/docs/slides/presentation20260218_tao_technical.tex
@@ -74,41 +74,7 @@ Key references:~\cite{Perez-Garcia2007Matrix,Cirac2021Matrix,Cirac2017Annals,Wol
         \column{0.46\textwidth}
         \begin{center}
             \vspace{0.2em}
-            % MPS Tensor Network Diagram
-            \begin{tikzpicture}[
-                    tn/.style={draw=leangreen, fill=cardbg, rounded corners=2pt,
-                            minimum size=7mm, thick, text=white, font=\small},
-                    bond/.style={thick, white},
-                    phys/.style={thick, leangreen!80!white}
-                ]
-                \node[tn] (A1) at (0,0) {$A$};
-                \node[tn] (A2) at (1.5,0) {$A$};
-                \node[tn] (A3) at (3.0,0) {$A$};
-                \node[tn] (A4) at (4.5,0) {$A$};
-
-                % physical indices (up)
-                \foreach \a in {A1,A2,A3,A4}
-                    \draw[phys] (\a.north) -- ++(0,0.55);
-
-                \node[font=\scriptsize, text=dimwhite] at (0, 0.85) {$i_1$};
-                \node[font=\scriptsize, text=dimwhite] at (1.5, 0.85) {$i_2$};
-                \node[font=\scriptsize, text=dimwhite] at (3.0, 0.85) {$i_3$};
-                \node[font=\scriptsize, text=dimwhite] at (4.5, 0.85) {$i_N$};
-
-                % bond indices (horizontal)
-                \draw[bond] (A1.east) -- (A2.west);
-                \draw[bond] (A2.east) -- (A3.west);
-                \draw[bond] (A3.east) -- (A4.west);
-
-                % bond dimension labels
-                \node[font=\tiny, text=dimwhite] at (0.75,0.25) {$D$};
-
-                % trace: curved line below connecting ends
-                \draw[dimwhite, thick, densely dashed]
-                (A1.west) -- ++(-0.25,0) -- ++(0,-0.55)
-                -- ($(A4.east)+(0.25,-0.55)$) -- ++(0,0.55) -- (A4.east);
-                \node[font=\tiny, text=amber] at (2.25,-0.7) {$\mathrm{tr}$};
-            \end{tikzpicture}
+            \SlideTNPeriodicMPS{A}{N}
 
             {\scriptsize\textcolor{dimwhite}{Tensor network for $\tr(A^{i_1}\!\cdots A^{i_N})$.\\
                     Physical indices $\uparrow$, virtual indices $\leftrightarrow$.}}
@@ -345,50 +311,7 @@ Key references:~\cite{Perez-Garcia2007Matrix,Cirac2021Matrix,Cirac2017Annals,Wol
         \column{0.36\textwidth}
         \begin{center}
             \vspace{0.3em}
-            % Blocking: C = B ⊗ B ⊗ ... ⊗ B (TikZ replacement)
-            \begin{tikzpicture}[scale=0.78, every node/.style={scale=0.78},
-                    tn/.style={draw=white, fill=cardbg, rounded corners=1.5pt,
-                            minimum size=6.5mm, thick, text=white, font=\small},
-                    bond/.style={thick, white},
-                    phys/.style={thick, dimwhite}
-                ]
-                % Left side: blocked tensor C
-                \node[tn] (C) at (0,0) {$C$};
-                \draw[bond] (C.west) -- ++(-0.4,0);
-                \draw[bond] (C.east) -- ++(0.4,0);
-                \draw[phys] (C.north) -- ++(0,0.45);
-
-                % Equals
-                \node[text=white, font=\normalsize] at (1.1,0) {$=$};
-
-                % Right side: chain of B tensors
-                \node[tn, draw=leangreen, text=leangreen] (B1) at (2.0,0) {$B$};
-                \node[tn, draw=leangreen, text=leangreen] (B2) at (3.2,0) {$B$};
-                \node[tn, draw=leangreen, text=leangreen] (B3) at (4.4,0) {$B$};
-
-                % Bond connections
-                \draw[bond] (B1.west) -- ++(-0.35,0);
-                \draw[bond] (B1.east) -- (B2.west);
-                \draw[bond] (B2.east) -- (B3.west);
-                \draw[bond] (B3.east) -- ++(0.35,0);
-
-                % Physical indices
-                \draw[phys] (B1.north) -- ++(0,0.45);
-                \draw[phys] (B2.north) -- ++(0,0.45);
-                \draw[phys] (B3.north) -- ++(0,0.45);
-
-                % Ellipsis for more B's
-                \node[text=dimwhite, font=\small] at (5.1,0) {$\cdots$};
-                \node[tn, draw=leangreen, text=leangreen] (BL) at (5.8,0) {$B$};
-                \draw[bond] (BL.east) -- ++(0.35,0);
-                \draw[phys] (BL.north) -- ++(0,0.45);
-
-                % Brace underneath
-                \draw[decorate, decoration={brace, mirror, amplitude=4pt},
-                      dimwhite, thick]
-                    (1.6,-0.55) -- (6.25,-0.55)
-                    node[midway, below=5pt, font=\tiny, text=dimwhite] {$L$ copies};
-            \end{tikzpicture}
+            \SlideTNBlockingIdentity{C}{B}{L}
 
             \vspace{0.2em}
             {\scriptsize\textcolor{dimwhite}{Blocking: $C = B^{\otimes L}$.\\
@@ -876,48 +799,7 @@ def mpv (A : MPSTensor d D) {N : (*@$\mathbb{N}$@*)} ((*@$\sigma$@*) : Fin N (*@
         \column{0.50\textwidth}
         \begin{center}
             \vspace{0.2em}
-            % Overlap sandwich: two MPS layers
-            \begin{tikzpicture}[
-                    tn/.style={draw=leangreen, fill=cardbg, rounded corners=2pt,
-                            minimum size=6mm, thick, text=white, font=\scriptsize},
-                    bn/.style={draw=leanblue, fill=cardbg, rounded corners=2pt,
-                            minimum size=6mm, thick, text=leanblue, font=\scriptsize},
-                    bond/.style={thick, white},
-                    phys/.style={thick, dimwhite},
-                    xnode/.style={draw=amber, fill=cardbg, rounded corners=2pt,
-                            minimum width=5mm, minimum height=5mm, thick,
-                            text=amber, font=\scriptsize}
-                ]
-                % Top row: A tensors
-                \foreach \i in {1,2,3} {
-                        \node[tn] (A\i) at ({(\i-1)*1.4}, 0.8) {$A$};
-                    }
-                % Bottom row: B^* tensors
-                \foreach \i in {1,2,3} {
-                        \node[bn] (B\i) at ({(\i-1)*1.4}, -0.8) {$B^\dagger$};
-                    }
-                % X in the middle-left
-                \node[xnode] (X) at (-1.1, 0) {$X$};
-
-                % Horizontal bonds (top)
-                \draw[bond] (X.north east) -- (A1.west);
-                \draw[bond] (A1.east) -- (A2.west);
-                \draw[bond] (A2.east) -- (A3.west);
-                \draw[bond] (A3.east) -- ++(0.3,0);
-                % Horizontal bonds (bottom)
-                \draw[bond] (X.south east) -- (B1.west);
-                \draw[bond] (B1.east) -- (B2.west);
-                \draw[bond] (B2.east) -- (B3.west);
-                \draw[bond] (B3.east) -- ++(0.3,0);
-                % Vertical contractions (physical indices)
-                \foreach \i in {1,2,3} {
-                        \draw[phys] (A\i.south) -- (B\i.north);
-                    }
-                % Labels
-                \node[font=\tiny, text=dimwhite] at (-1.1, 1.3) {};
-                \node[font=\tiny, text=amber] at (3.2, 0) {$\cF^N(X)$};
-                \node[font=\tiny, text=dimwhite] at (0.7, 0) {$\sum_i$};
-            \end{tikzpicture}
+            \SlideTNMixedTransfer{A}{B}{X}{N}
 
             {\scriptsize\textcolor{dimwhite}{Sandwich: $\cF^N_{A,B}(X)$.\\Top: $A$, bottom: $B^\dagger$, contract physical indices.}}
         \end{center}

--- a/docs/slides/presentation20260222_technical.tex
+++ b/docs/slides/presentation20260222_technical.tex
@@ -87,24 +87,7 @@
 
         \column{0.4\textwidth}
         \begin{center}
-            \begin{tikzpicture}[
-                tn/.style={draw=leangreen, fill=cardbg, rounded corners=2pt, minimum size=6mm, text=white},
-                bond/.style={thick, white},
-                phys/.style={thick, leangreen!80!white}
-            ]
-                \node[tn] (A1) at (0,0) {$A$};
-                \node[tn] (A2) at (1.2,0) {$A$};
-                \node[tn] (A3) at (2.4,0) {$A$};
-                
-                \draw[bond] (A1) -- (A2);
-                \draw[bond] (A2) -- (A3);
-                
-                \draw[phys] (A1.north) -- ++(0,0.4);
-                \draw[phys] (A2.north) -- ++(0,0.4);
-                \draw[phys] (A3.north) -- ++(0,0.4);
-                
-                \draw[bond, dashed] (A1.west) to[bend left=45] (A3.east);
-            \end{tikzpicture}
+            \SlideTNPeriodicMPS{A}{N}
             \\ \vspace{0.5em}
             {\footnotesize Periodic Boundary Conditions (Trace)}
         \end{center}

--- a/docs/slides/presentation20260318_agentic_formalization.tex
+++ b/docs/slides/presentation20260318_agentic_formalization.tex
@@ -131,28 +131,7 @@
         \column{0.46\textwidth}
         \vspace{0.4em}
         \begin{center}
-        \begin{tikzpicture}[
-            tn/.style={draw=leangreen, fill=cardbg, rounded corners=2pt,
-              minimum size=7mm, thick, text=white, font=\small},
-            bond/.style={thick, white},
-            phys/.style={thick, leangreen!80!white}
-        ]
-            \node[tn] (A1) at (0,0) {$A$};
-            \node[tn] (A2) at (1.4,0) {$A$};
-            \node[tn] (A3) at (2.8,0) {$A$};
-            \node[tn] (A4) at (4.2,0) {$A$};
-            \foreach \a in {A1,A2,A3,A4}
-                \draw[phys] (\a.north) -- ++(0,0.55);
-            \node[font=\scriptsize, text=dimwhite] at (0,0.82) {$i_1$};
-            \node[font=\scriptsize, text=dimwhite] at (1.4,0.82) {$i_2$};
-            \node[font=\scriptsize, text=dimwhite] at (2.8,0.82) {$i_3$};
-            \node[font=\scriptsize, text=dimwhite] at (4.2,0.82) {$i_N$};
-            \draw[bond] (A1.east) -- (A2.west);
-            \draw[bond] (A2.east) -- (A3.west);
-            \draw[bond,dashed] (A3.east) -- (A4.west);
-            \draw[bond] (A1.west) -- ++(-0.5,0) node[left,font=\scriptsize,text=dimwhite]{$\tr$};
-            \draw[bond] (A4.east) -- ++(0.5,0);
-        \end{tikzpicture}
+        \SlideTNPeriodicMPS{A}{N}
         \end{center}
         \vspace{0.6em}
         {\footnotesize\textcolor{dimwhite}{MPS are the workhorse of quantum many-body physics: DMRG, tensor networks, topological order, quantum error correction. The FT characterizes the classification up to gauge.}}

--- a/docs/slides/presentation20260520.tex
+++ b/docs/slides/presentation20260520.tex
@@ -51,8 +51,6 @@
   arrdw/.style={-{Stealth}, thick, dimwhite, dashed},
   stat/.style={rounded corners=5pt, fill=cardbg, draw=leangreen!50, text=white,
     minimum width=2.7cm, minimum height=1.5cm, align=center, font=\small},
-  tn/.style={draw=leangreen, fill=cardbg, rounded corners=2pt,
-    minimum size=7mm, thick, text=white, font=\small},
 }
 
 % --- Title metadata ---
@@ -153,34 +151,7 @@
 %---------- Frame 6: Matrix product states (diagram-led) ----------
 \begin{frame}{Matrix product states}
     \begin{center}
-    \begin{tikzpicture}[bond/.style={thick,white}, phys/.style={thick,leangreen!80!white}]
-        % Sites
-        \node[tn] (A1) at (0,0)   {$A$};
-        \node[tn] (A2) at (1.6,0) {$A$};
-        \node[tn] (A3) at (3.2,0) {$A$};
-        \node[tn] (A4) at (4.8,0) {$A$};
-        \node[tn] (A5) at (6.4,0) {$A$};
-        % Physical legs
-        \foreach \a in {A1,A2,A3,A4,A5}
-            \draw[phys] (\a.north) -- ++(0,0.55);
-        \node[font=\scriptsize,text=dimwhite] at (0,0.82)   {$i_1$};
-        \node[font=\scriptsize,text=dimwhite] at (1.6,0.82) {$i_2$};
-        \node[font=\scriptsize,text=dimwhite] at (3.2,0.82) {$i_3$};
-        \node[font=\scriptsize,text=dimwhite] at (4.8,0.82) {$\cdots$};
-        \node[font=\scriptsize,text=dimwhite] at (6.4,0.82) {$i_N$};
-        % Bond legs
-        \draw[bond] (A1.east) -- (A2.west);
-        \draw[bond] (A2.east) -- (A3.west);
-        \draw[bond,dashed] (A3.east) -- (A4.west);
-        \draw[bond] (A4.east) -- (A5.west);
-        % Clean rectangular wrap-around
-        \coordinate (rL) at ($(A5.east) + (0.5,0)$);
-        \coordinate (rB) at ($(rL) + (0,-0.95)$);
-        \coordinate (lL) at ($(A1.west) + (-0.5,0)$);
-        \coordinate (lB) at ($(lL) + (0,-0.95)$);
-        \draw[bond] (A5.east) -- (rL) -- (rB) -- (lB) -- (lL) -- (A1.west);
-        \node[font=\scriptsize,text=dimwhite] at (3.2,-1.20) {trace (PBC)};
-    \end{tikzpicture}
+    \SlideTNPeriodicMPS{A}{N}
     \end{center}
     \vspace{0.4em}
     \textbf{Translation-invariant MPS~\cite{Cirac2017Annals}.} For $A = (A^i)_{i=0}^{d-1}$ with $A^i \in \MD$,
@@ -255,44 +226,7 @@
 \begin{frame}{Beyond the injective case --- where autonomy stalled}
     \vspace{-0.2em}
     \begin{center}
-    \begin{tikzpicture}[
-        scale=0.92, transform shape,
-        bond/.style={thick,white},
-        phys/.style={thick,leangreen!80!white},
-        bigtn/.style={draw=amber, fill=amber!20!cardbg, rounded corners=2pt,
-            minimum width=2.3cm, minimum height=8mm, thick, text=white, font=\small}
-    ]
-        % Panel A: original chain
-        \begin{scope}[shift={(0,0)}]
-            \foreach \i in {0,1,2,3,4,5,6,7} {
-                \node[tn] (P\i) at (\i*0.85, 0) {\scriptsize $A$};
-            }
-            \foreach \i in {0,...,6} {
-                \pgfmathtruncatemacro{\j}{\i+1}
-                \draw[bond] (P\i.east) -- (P\j.west);
-            }
-            \foreach \i in {0,...,7} {
-                \draw[phys] (P\i.north) -- ++(0,0.3);
-            }
-            \node[font=\scriptsize, text=dimwhite] at (-1.0,0) {chain of $N$:};
-        \end{scope}
-        % Panel B: blocked chain
-        \begin{scope}[shift={(0,-1.8)}]
-            \node[bigtn] (B0) at (0.85, 0) {$A^{(L)}$};
-            \node[bigtn] (B1) at (3.40, 0) {$A^{(L)}$};
-            \node[bigtn] (B2) at (5.95, 0) {$A^{(L)}$};
-            \draw[bond] (B0.east) -- (B1.west);
-            \draw[bond] (B1.east) -- (B2.west);
-            \foreach \n in {B0,B1,B2}
-                \draw[phys] (\n.north) -- ++(0,0.3);
-            \node[font=\scriptsize, text=dimwhite] at (-1.0,0) {after blocking $L$:};
-        \end{scope}
-        % Dashed bracket linking panel A blocks to B0
-        \draw[dimwhite!60, dashed] (-0.30,0.35) -- (-0.30,-1.45);
-        \draw[dimwhite!60, dashed] (2.25,0.35) -- (2.25,-1.45);
-        \draw[dimwhite!60, dashed] (4.80,0.35) -- (4.80,-1.45);
-        \draw[dimwhite!60, dashed] (7.10,0.35) -- (7.10,-1.45);
-    \end{tikzpicture}
+    \SlideTNBlockingComparison{A}{L}
     \end{center}
     \vspace{0.2em}
     \[

--- a/docs/slides/presentation20260522_gap_analysis.tex
+++ b/docs/slides/presentation20260522_gap_analysis.tex
@@ -691,36 +691,7 @@ Pi-tensors don't span product algebra \\
 
 \column{0.44\textwidth}
 \begin{center}
-\begin{tikzpicture}[scale=0.7]
-% Transfer operator tensor network:
-%   E_A(rho) = sum_i A^i rho (A^i)^dag
-%
-% Layout:  rho on left, A on top, A^dag on bottom
-% Physical index i contracted vertically between A and A^dag
-% Left virtual indices connect to rho
-% Right virtual indices are the output
-%
-\node[rectangle,draw=white,fill=leangreen!30!black,minimum size=0.6cm,
-  font=\scriptsize\bfseries] (A1) at (0,0) {$A$};
-\node[rectangle,draw=white,fill=leangreen!30!black,minimum size=0.6cm,
-  font=\scriptsize\bfseries] (A2) at (0,-1.8) {$\bar{A}$};
-\node[rectangle,draw=white,fill=amber!30!black,minimum size=0.6cm,
-  font=\scriptsize\bfseries] (rho) at (-1.8,-0.9) {$\rho$};
-% Left virtual: rho -> A (top) and rho -> A^dag (bottom)
-\draw[-,white,thick] (rho.north east) -- (A1.west);
-\draw[-,white,thick] (rho.south east) -- (A2.west);
-% Physical index i: contracted between A and A^dag
-\draw[-,white,thick] (A1.south) -- (A2.north);
-\node[font=\tiny,amber,right] at (0.05,-0.9) {$\scriptstyle\sum_i$};
-% Right virtual: output indices
-\draw[-,white,thick] (A1.east) -- ++(0.8,0);
-\draw[-,white,thick] (A2.east) -- ++(0.8,0);
-% Output brace
-\draw[decorate,decoration={brace,amplitude=3pt,mirror},white]
-  (1.0,0.1) -- (1.0,-1.9) node[midway,right=4pt,font=\tiny,white]{$\mathcal{E}_A(\rho)$};
-% Label
-\node[font=\scriptsize,white] at (-0.5,-3.0) {Transfer operator $\mathcal{E}_A$};
-\end{tikzpicture}
+\SlideTNTransferMap{A}{\rho}
 \end{center}
 \end{columns}
 

--- a/docs/slides/tn_library_dark.tex
+++ b/docs/slides/tn_library_dark.tex
@@ -1,0 +1,216 @@
+% Tensor-network diagrams for the independent TNLean slide collection.
+%
+% This file mirrors the mathematical graphical conventions of the blueprint
+% in a dark theme, but it has no dependency on blueprint sources.  Every
+% contracted index begins and ends at a named node anchor; an open index has
+% one named anchor and one deliberately free endpoint.  Dashed strokes are
+% reserved for grouping regions; contractions and trace closures are solid.
+
+\tikzset{
+  slidetn/picture/.style={transform shape, font=\scriptsize},
+  slidetn/tensor/.style={
+    circle, draw=white, fill=black, minimum size=6.5mm,
+    inner sep=1.5pt, text=white, thick, font=\scriptsize\bfseries
+  },
+  slidetn/component/.style={
+    rectangle, draw=dimwhite, fill=cardbg, minimum height=7mm,
+    inner sep=2pt, text=white, thick, font=\scriptsize\bfseries
+  },
+  slidetn/map/.style={
+    rectangle, rounded corners=2pt, draw=leanblue, fill=cardbg,
+    inner sep=2pt, text=white, thick, font=\scriptsize\bfseries
+  },
+  slidetn/state/.style={
+    rectangle, rounded corners=2pt, draw=dimwhite, fill=black!55,
+    inner sep=2pt, text=white, thick, font=\scriptsize\bfseries
+  },
+  slidetn/insertion/.style={
+    circle, draw=white, fill=softred, minimum size=5.5mm,
+    inner sep=1pt, text=black, thick, font=\scriptsize\bfseries
+  },
+  slidetn/virtual wire/.style={draw=white, line width=0.8pt},
+  slidetn/physical wire/.style={draw=leangreen!80!white, line width=1.2pt},
+  slidetn/trace/.style={slidetn/virtual wire, rounded corners=3pt},
+  slidetn/grouping/.style={draw=dimwhite, densely dashed, rounded corners=2pt},
+  slidetn/label/.style={text=dimwhite, font=\scriptsize}
+}
+
+\newcommand{\SlideTNTensor}[3]{%
+  \node[slidetn/tensor] (#1) at #2 {$#3$};%
+}
+
+\newcommand{\SlideTNComponent}[3]{%
+  \node[slidetn/component] (#1) at #2 {$#3$};%
+}
+
+\newcommand{\SlideTNState}[3]{%
+  \node[slidetn/state] (#1) at #2 {$#3$};%
+}
+
+\newcommand{\SlideTNInsertion}[3]{%
+  \node[slidetn/insertion] (#1) at #2 {$#3$};%
+}
+
+\newcommand{\SlideTNPhysicalLeg}[2]{%
+  \draw[slidetn/physical wire] (#1.north) -- ++(0,0.48);%
+  \if\relax\detokenize{#2}\relax\else
+    \node[above, slidetn/label] at ($(#1.north)+(0,0.48)$) {$#2$};%
+  \fi
+}
+
+\newcommand{\SlideTNVirtualBond}[2]{%
+  \draw[slidetn/virtual wire] (#1.east) -- (#2.west);%
+}
+
+\newcommand{\SlideTNOpenLeft}[1]{%
+  \draw[slidetn/virtual wire] (#1.west) -- ++(-0.48,0);%
+}
+
+\newcommand{\SlideTNOpenRight}[1]{%
+  \draw[slidetn/virtual wire] (#1.east) -- ++(0.48,0);%
+}
+
+\newcommand{\SlideTNOmittedChain}[2]{%
+  \draw[slidetn/virtual wire] (#1.east) -- ++(0.38,0);%
+  \draw[slidetn/virtual wire] (#2.west) -- ++(-0.38,0);%
+  \node[text=dimwhite] at ($(#1.east)!0.5!(#2.west)$) {$\cdots$};%
+}
+
+\newcommand{\SlideTNTraceClosure}[3]{%
+  \draw[slidetn/trace] (#1.west) -- ++(-0.42,0) -- ++(0,-#3)
+    -| ($(#2.east)+(0.42,0)$) -- (#2.east);%
+}
+
+% A common periodic MPS word.  Omitted sites are denoted by two open solid
+% stubs and an ellipsis, never by a dashed contraction.
+\newcommand{\SlideTNPeriodicMPS}[2]{%
+  \begin{tikzpicture}[slidetn/picture]
+    \SlideTNTensor{sltnAone}{(0,0)}{#1}
+    \SlideTNTensor{sltnAtwo}{(1.30,0)}{#1}
+    \SlideTNTensor{sltnApen}{(3.25,0)}{#1}
+    \SlideTNTensor{sltnAlast}{(4.55,0)}{#1}
+    \SlideTNVirtualBond{sltnAone}{sltnAtwo}
+    \SlideTNOmittedChain{sltnAtwo}{sltnApen}
+    \SlideTNVirtualBond{sltnApen}{sltnAlast}
+    \SlideTNPhysicalLeg{sltnAone}{i_1}
+    \SlideTNPhysicalLeg{sltnAtwo}{i_2}
+    \SlideTNPhysicalLeg{sltnApen}{i_{#2-1}}
+    \SlideTNPhysicalLeg{sltnAlast}{i_{#2}}
+    \SlideTNTraceClosure{sltnAone}{sltnAlast}{0.78}
+    \node[slidetn/label] at (2.28,-1.02) {trace; bond dimension $D$};
+  \end{tikzpicture}%
+}
+
+% The left-hand tensor is B, matching B^i = X A^i X^{-1}.
+\newcommand{\SlideTNGaugeConjugation}[3]{%
+  \begin{tikzpicture}[slidetn/picture]
+    \SlideTNTensor{sltnB}{(0,0)}{#1}
+    \SlideTNOpenLeft{sltnB}
+    \SlideTNOpenRight{sltnB}
+    \SlideTNPhysicalLeg{sltnB}{i}
+    \node[text=white, font=\Large] at (1.35,0) {$=$};
+    \SlideTNInsertion{sltnX}{(2.35,0)}{#3}
+    \SlideTNTensor{sltnA}{(3.55,0)}{#2}
+    \SlideTNInsertion{sltnXi}{(4.80,0)}{#3^{-1}}
+    \SlideTNOpenLeft{sltnX}
+    \SlideTNVirtualBond{sltnX}{sltnA}
+    \SlideTNVirtualBond{sltnA}{sltnXi}
+    \SlideTNOpenRight{sltnXi}
+    \SlideTNPhysicalLeg{sltnA}{i}
+  \end{tikzpicture}%
+}
+
+\newcommand{\SlideTNBlockingIdentity}[3]{%
+  \begin{tikzpicture}[slidetn/picture, scale=0.82]
+    \SlideTNComponent{sltnC}{(0,0)}{#1}
+    \SlideTNOpenLeft{sltnC}
+    \SlideTNOpenRight{sltnC}
+    \SlideTNPhysicalLeg{sltnC}{(i_1,\ldots,i_{#3})}
+    \node[text=white, font=\Large] at (1.25,0) {$=$};
+    \SlideTNTensor{sltnBone}{(2.10,0)}{#2}
+    \SlideTNTensor{sltnBtwo}{(3.25,0)}{#2}
+    \SlideTNTensor{sltnBlast}{(5.15,0)}{#2}
+    \SlideTNOpenLeft{sltnBone}
+    \SlideTNVirtualBond{sltnBone}{sltnBtwo}
+    \SlideTNOmittedChain{sltnBtwo}{sltnBlast}
+    \SlideTNOpenRight{sltnBlast}
+    \SlideTNPhysicalLeg{sltnBone}{i_1}
+    \SlideTNPhysicalLeg{sltnBtwo}{i_2}
+    \SlideTNPhysicalLeg{sltnBlast}{i_{#3}}
+    \draw[decorate, decoration={brace, mirror, amplitude=4pt}, dimwhite, thick]
+      (1.72,-0.58) -- (5.55,-0.58)
+      node[midway, below=5pt, slidetn/label] {$#3$ copies};
+  \end{tikzpicture}%
+}
+
+\newcommand{\SlideTNMixedTransfer}[4]{%
+  \begin{tikzpicture}[slidetn/picture]
+    \SlideTNState{sltnRho}{(-1.15,0)}{#3}
+    \foreach \name/\x in {One/0,Two/1.30,Pen/3.25,Last/4.55} {
+      \SlideTNTensor{sltnTop\name}{(\x,0.72)}{#1}
+    }
+    \foreach \name/\x in {One/0,Two/1.30,Pen/3.25,Last/4.55} {
+      \SlideTNTensor{sltnBot\name}{(\x,-0.72)}{#2^\dagger}
+    }
+    \draw[slidetn/virtual wire] (sltnRho.north east) -- (sltnTopOne.west);
+    \draw[slidetn/virtual wire] (sltnRho.south east) -- (sltnBotOne.west);
+    \SlideTNVirtualBond{sltnTopOne}{sltnTopTwo}
+    \SlideTNVirtualBond{sltnBotOne}{sltnBotTwo}
+    \SlideTNOmittedChain{sltnTopTwo}{sltnTopPen}
+    \SlideTNOmittedChain{sltnBotTwo}{sltnBotPen}
+    \SlideTNVirtualBond{sltnTopPen}{sltnTopLast}
+    \SlideTNVirtualBond{sltnBotPen}{sltnBotLast}
+    \SlideTNOpenRight{sltnTopLast}
+    \SlideTNOpenRight{sltnBotLast}
+    \foreach \name in {One,Two,Pen,Last} {
+      \draw[slidetn/physical wire] (sltnTop\name.south) -- (sltnBot\name.north);
+    }
+    \node[slidetn/label, anchor=west] at (5.35,0) {$\mathcal F^{#4}_{#1,#2}(#3)$};
+  \end{tikzpicture}%
+}
+
+\newcommand{\SlideTNTransferMap}[2]{%
+  \begin{tikzpicture}[slidetn/picture]
+    \SlideTNState{sltnInput}{(-1.55,0)}{#2}
+    \SlideTNTensor{sltnKet}{(0,0.72)}{#1}
+    \SlideTNTensor{sltnBra}{(0,-0.72)}{\overline{#1}}
+    \draw[slidetn/virtual wire] (sltnInput.north east) -- (sltnKet.west);
+    \draw[slidetn/virtual wire] (sltnInput.south east) -- (sltnBra.west);
+    \draw[slidetn/physical wire] (sltnKet.south) -- (sltnBra.north)
+      node[midway, right, slidetn/label] {$\sum_i$};
+    \SlideTNOpenRight{sltnKet}
+    \SlideTNOpenRight{sltnBra}
+    \node[slidetn/label, anchor=west] at (0.95,0) {$\mathcal E_{#1}(#2)$};
+  \end{tikzpicture}%
+}
+
+\newcommand{\SlideTNBlockingComparison}[2]{%
+  \begin{tikzpicture}[slidetn/picture, scale=0.82]
+    \node[slidetn/label, anchor=east] at (-0.55,0.75) {chain of $N$:};
+    \foreach \x/\name in {0/One,0.85/Two,1.70/Three,4.05/Pen,4.90/Last} {
+      \SlideTNTensor{sltnP\name}{(\x,0.75)}{#1}
+      \SlideTNPhysicalLeg{sltnP\name}{}
+    }
+    \SlideTNVirtualBond{sltnPOne}{sltnPTwo}
+    \SlideTNVirtualBond{sltnPTwo}{sltnPThree}
+    \SlideTNOmittedChain{sltnPThree}{sltnPPen}
+    \SlideTNVirtualBond{sltnPPen}{sltnPLast}
+    \SlideTNOpenLeft{sltnPOne}
+    \SlideTNOpenRight{sltnPLast}
+    \node[slidetn/label, anchor=east] at (-0.55,-0.85) {after blocking $#2$:};
+    \SlideTNComponent{sltnBlockOne}{(0.65,-0.85)}{#1^{(#2)}}
+    \SlideTNComponent{sltnBlockTwo}{(2.45,-0.85)}{#1^{(#2)}}
+    \SlideTNComponent{sltnBlockLast}{(4.25,-0.85)}{#1^{(#2)}}
+    \SlideTNVirtualBond{sltnBlockOne}{sltnBlockTwo}
+    \SlideTNVirtualBond{sltnBlockTwo}{sltnBlockLast}
+    \SlideTNOpenLeft{sltnBlockOne}
+    \SlideTNOpenRight{sltnBlockLast}
+    \SlideTNPhysicalLeg{sltnBlockOne}{}
+    \SlideTNPhysicalLeg{sltnBlockTwo}{}
+    \SlideTNPhysicalLeg{sltnBlockLast}{}
+    \draw[slidetn/grouping] (-0.20,0.30) -- (-0.20,-0.35);
+    \draw[slidetn/grouping] (1.55,0.30) -- (1.55,-0.35);
+    \draw[slidetn/grouping] (3.65,0.30) -- (3.65,-0.35);
+    \draw[slidetn/grouping] (5.30,0.30) -- (5.30,-0.35);
+  \end{tikzpicture}%
+}

--- a/docs/tn_diagram_grammar.md
+++ b/docs/tn_diagram_grammar.md
@@ -1,17 +1,71 @@
 # Tensor-Network Diagram Grammar
 
 This document fixes the mathematical meaning of the tensor-network glyphs used
-in the blueprint. The aim is that a reader can identify the object represented
-by a diagram before reading the surrounding proof.
+in the blueprint and slide collection. The aim is that a reader can identify
+the object represented by a diagram before reading the surrounding proof.
+Graphical appearance carries mathematical meaning: changing a label does not
+change the kind of object represented, and changing the kind of object requires
+changing its graphical form. Every index line ends exactly at the boundary of
+the object carrying that index.
+
+## Atomic Graphical Calculus
+
+The common grammar describes a tensor network by small composable units. An
+atom is a named graphical object together with named ports on its boundary. A
+port represents one occurrence of an index. Two atoms are composed by
+contracting a virtual port with a virtual port, or a physical port with a
+physical port.
+
+For example, the following construction places two tensors, names their four
+virtual ports, and contracts one pair:
+
+```tex
+\TN@tensor{leftTensor}{(0,0)}
+\TN@port{leftIn}{leftTensor}{west}
+\TN@port{leftOut}{leftTensor}{east}
+
+\TN@tensor{rightTensor}{(1.4,0)}
+\TN@port{rightIn}{rightTensor}{west}
+\TN@port{rightOut}{rightTensor}{east}
+
+\TN@vopenport{leftIn}{-0.6,0}
+\TN@vconnectports{leftOut}{rightIn}
+\TN@vopenport{rightOut}{0.6,0}
+```
+
+The names `leftOut` and `rightIn` refer to exact boundary points; no numerical
+coordinate is chosen to approximate either endpoint. The same atoms can be
+placed elsewhere or composed with different atoms without changing their
+internal definitions. This example is written in the private macro scope,
+where `@` is a letter; a standalone use should be enclosed by
+`\makeatletter` and `\makeatother`.
+
+The general constructor `\TN@port{port}{object}{anchor}` names any standard
+TikZ anchor. For a rectangular object carrying several indices on one side,
+`\TN@westport`, `\TN@eastport`, `\TN@northport`, and `\TN@southport` place a
+port at a specified fraction of that side. The more general `\TN@betweenport`
+names a point at a specified fraction of any boundary segment.
+
+The typed composition operations are `\TN@vconnectports` and
+`\TN@pconnectports`. The typed open-index operations are `\TN@vopenport` and
+`\TN@popenport`. The anchor-based forms `\TN@vconnect`, `\TN@pconnect`,
+`\TN@vleg`, and `\TN@pleg` are concise forms for atoms defined together.
 
 ## Basic Glyphs
 
 - Tensor sites are black dots. A physical index is drawn as a thicker vertical
   leg. Virtual indices are drawn as thinner horizontal or slanted legs.
-- A tensor that must carry a label is drawn as a neutral square box. A linear
-  map, including an isometry or coisometry, is drawn as a rounded blue box.
-  These labeled glyphs are distinct from the red dots used for matrices
-  inserted on individual legs.
+- A tensor label is placed outside its black dot in the blueprint; a label does
+  not change the kind of object. The enlarged tensor circles in dark slides
+  may carry the same label internally for legibility. A neutral square box
+  denotes a named tensor whose internal contraction is suppressed. A displayed
+  tensor-product or direct-sum factor is a pale plate. A linear map, including
+  an isometry or coisometry, is a rounded blue box, while a state displayed
+  without its constituent tensors is a rounded gray box. These glyphs are
+  distinct from the red dots used for matrices inserted on individual legs.
+- A contraction junction is a black dot substantially smaller than a local
+  tensor. It marks a common endpoint of several index lines and is not another
+  tensor.
 - An MPS tensor is a black dot with left and right virtual legs and one
   physical leg. A blocked MPS tensor is drawn by enclosing consecutive sites in
   a rectangle, with the blocked physical word represented by the external
@@ -49,6 +103,20 @@ by a diagram before reading the surrounding proof.
   contraction is a solid physical-index stroke joining dedicated ancillary
   legs; it is not dashed and should not share an attachment point with an open
   virtual leg.
+
+Every contraction names both endpoint anchors. The constructions
+`\TN@vconnect` and `\TN@pconnect` join named objects, while `\TN@vleg` and
+`\TN@pleg` draw open indices. The constructions `\TN@vtracebelow`,
+`\TN@vtraceabove`, and `\TN@ptraceright` draw trace closures between objects;
+`\TN@vtraceportsbelow` and `\TN@vtraceportsabove` do the same between named
+ports. A line must not end at a numerical coordinate chosen to lie near a
+tensor or map. A red insertion divides an index line into two contractions
+ending on the red dot; it is not placed over an uninterrupted line.
+
+Tensor products are written with $\otimes$. A horizontal line never means
+mere adjacency or tensor product. The construction `\TN@factorpair` displays
+two factor plates and places $\otimes$ between them. When two factors carry a
+contracted index, the contraction is drawn explicitly instead.
 
 ## Blocks, Regions, and Labels
 
@@ -135,22 +203,52 @@ by a diagram before reading the surrounding proof.
 - Public commands should be built from the common glyphs above. If a diagram
   requires a new glyph, first record the mathematical meaning here and then add
   the corresponding private TikZ primitive and web-rendering support.
-- Repeated chain and square-lattice diagrams should be built from the layout
-  commands in `blueprint/src/macros/tn_core.tex`, so that the public command
-  records the tensor network rather than a coordinate calculation.
+- Repeated chain and square-lattice diagrams should be built from the atomic
+  and layout commands in `blueprint/src/macros/tn_core.tex` and
+  `blueprint/src/macros/tn_library.tex`, so that the public command records the
+  tensor network rather than a coordinate calculation.
 - Repeated PEPS graph motifs, such as a five-site edge patch, a two-injective
   comparison pair, or a trivalent residual-gauge vertex, should likewise be
   factored through private layout commands before being used in theorem-level
   public diagrams.
-- If a theorem needs a diagram whose mathematical content is clearer in the
-  chapter source than behind a single figure command, wrap the local TikZ
-  picture in `\TNTikZDiagram{RegisteredDiagram}{...}`. The first argument is
-  the registered diagram used by the web blueprint; the second is the local
-  picture used by the printed blueprint. The two pictures must depict the same
-  diagram. Shared helpers such as `\pepsNormalSquareLattice`,
-  `\pepsNormalRegionR`, `\pepsNormalRegionS`, `\pepsNormalRegionT`,
-  `\pepsNormalDistinguishedEdge`, `\pepsNormalRedBlock`,
-  `\pepsNormalBlueBlock`, `\pepsBlockedNormalChain`, and `\pepsSquareTensor`
-  are used to keep the registered and local forms aligned.
-- Private glyphs and lengths belong in `blueprint/src/macros/tn_core.tex`.
+- A theorem-level figure belongs in `blueprint/src/macros/tn_print.tex`, even
+  when its mathematical content is specific to one chapter. This gives the
+  printed and web blueprints one common definition. Chapter sources call the
+  registered command and do not carry a second local TikZ construction.
+- Private glyphs, ports, and lengths belong in
+  `blueprint/src/macros/tn_core.tex`. Reusable MPS, MPO, MPDO, and PEPS
+  compositions belong in `blueprint/src/macros/tn_library.tex`.
   Chapter-facing diagrams belong in `blueprint/src/macros/tn_print.tex`.
+
+The library provides `\TN@mpssite`, `\TN@mposite`, and `\TN@pepssite` for
+local tensor sites; `\TN@doublelayer` for the local contraction in a transfer
+construction; `\TN@splitmap` and `\TN@mergemap` for mirrored trivalent fusion
+maps; and `\TN@openMPSword`, `\TN@openMPOword`, and `\TN@closedMPOword` for
+standard finite words. These constructions determine
+the conventional index directions once. Each local site atom declares stable
+boundary ports and draws no open stub. The corresponding
+`\TN@mpssiteWithOpenLegs`, `\TN@mpositeWithOpenLegs`,
+`\TN@pepssiteWithOpenLegs`, and `\TN@doublelayerWithOpenLegs` motifs add named
+free endpoints when a complete standalone object is required. A complete
+figure should compose these units rather than choose the same leg positions
+independently at each occurrence.
+
+The web blueprint renders the same complete figure commands as cached SVG
+images. A new chapter-facing command therefore also requires an argument
+declaration in `blueprint/src/Packages/tn_diagrams.py` and a name in
+`blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s`. A private
+construction in `tn_core.tex` or `tn_library.tex` requires no such declaration.
+
+## Slide Diagrams
+
+The slide collection has an independent dark-background implementation in
+`docs/slides/tn_library_dark.tex`. It does not import blueprint files, since a
+presentation should remain compilable without the blueprint build environment.
+It nevertheless realizes the same graphical calculus: circular local-tensor
+atoms in the dark theme, red insertions, typed physical and virtual indices,
+solid trace closures, and dashed grouping boundaries. Rectangular components
+and rounded map and state boxes retain the meanings fixed above.
+
+The slide preamble imports this library. A slide should call one of its complete
+diagram commands rather than declare local tensor-network styles or draw a
+second version of a standard construction.


### PR DESCRIPTION
## Summary

- introduces a semantic tensor-network grammar with atomic glyphs, stable named ports, typed physical and virtual contractions, and port-to-port trace closures
- factors reusable MPS, MPO, MPDO, PEPS, doubled-layer, and mirrored fusion-map constructions into a common library
- migrates every registered blueprint figure and thirteen diagrams in eight slide decks to the common graphical language
- keeps the MPDO/RFP chapters enabled and gives their factorization, closure, zipper, fusion, and isometry figures exact object-boundary attachments
- follows the compositional strengths of `References/2203.12563/REsubmission.tex` while retaining TNLean meanings for colors, maps, insertions, and wire types
- adds strict audits for raw glyphs, raw wires, bypassed ports, ignored public arguments, chapter-local TikZ, slide-local tensor-network drawings, and SVG rendering

## Graphical semantics

A black circle is a local tensor, a red circle is an endomorphism inserted on one index, a white square is a suppressed contracted component, a pale plate is an explicit factor, a blue rounded box is a map, and a gray rounded box is a state. A substantially smaller black point is a contraction junction. Every contracted line terminates on a named object port.

The new split and merge atoms expose `Mid`, `Up`, `Down`, `Top`, and `Bottom` ports. Base site atoms have no fixed stubs; separate `WithOpenLegs` motifs supply named free endpoints for standalone figures.

## Validation

- `lake build` — 9,399 jobs completed
- `leanblueprint web`
- `leanblueprint pdf` — 552 pages, including the MPDO/RFP chapters
- `leanblueprint checkdecls`
- strict tensor-network semantic audit — zero raw glyphs, raw wires, named-port violations, or ignored public arguments
- SVG smoke rendering — all 118 registered diagrams
- slide inventory — all 13 shared diagram calls accounted for
- all eight affected slide decks compiled successfully
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large LaTeX macro refactor touches every registered diagram and CI gates; risk is mainly visual/regression in PDF and web SVG output rather than runtime code paths.
> 
> **Overview**
> Unifies blueprint and slide tensor-network figures around a **semantic TikZ grammar**: glyphs, typed wires, named ports, and port-to-port contractions, with reusable MPS/MPO/PEPS-style pieces factored into a new `tn_library.tex` while `tn_core.tex` becomes the shared drawing kernel.
> 
> **`tn_diagrams.py`** gains **`--check-slides`**, **`--audit`**, and **`--audit-strict`** (plus optional JSON audit output). CI blueprint and lint workflows now watch **`docs/slides/**`** and run the expanded checks alongside existing registration, PEPS-usage, and SVG smoke rendering. Strict mode blocks chapter-local TikZ, raw glyph/wire shortcuts, named-port bypasses, and ignored public macro arguments.
> 
> SVG rendering now hashes **`tn_library.tex`** into the render cache alongside the other macro sources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 474108ba0f1b5392bcbfd63d157eb953a78beb7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->