### PR TITLE
feat(MPS/MPDO): transport fusion through positive blocking

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -474,6 +474,7 @@ import TNLean.MPS.MPDO.BNTTheoremData
 import TNLean.MPS.MPDO.BNTTheoremWitness
 import TNLean.MPS.MPDO.BNTTheoremWitnessConsequences
 import TNLean.MPS.MPDO.BNTFusionIsometries
+import TNLean.MPS.MPDO.BlockedBNTFusionIsometries
 import TNLean.MPS.MPDO.BNTAssociativity
 import TNLean.MPS.MPDO.BNTLeftTripleFusion
 import TNLean.MPS.MPDO.BNTRightTripleFusion

--- a/TNLean/MPS/MPDO/BiCFDerivation/Core.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/Core.lean
@@ -76,6 +76,65 @@ def WordTupleSpanTop
     (L : ℕ) : Prop :=
   Submodule.span ℂ (Set.range (wordTuple A L)) = ⊤
 
+/-- Reindexing the common physical alphabet by an equivalence preserves the
+simultaneous word-tuple span.
+
+This is the index transport used in the simultaneous BNT blocking of
+arXiv:1606.00608, lines 317--345. -/
+theorem wordTupleSpanTop_reindexPhysical_equiv {d' : ℕ}
+    (e : Fin d' ≃ Fin d) (A : (k : Fin r) → MPSTensor d (dim k)) (L : ℕ) :
+    WordTupleSpanTop (fun k ↦ reindexPhysical e (A k)) L ↔
+      WordTupleSpanTop A L := by
+  unfold WordTupleSpanTop
+  have hRange :
+      Set.range (wordTuple (fun k ↦ reindexPhysical e (A k)) L) =
+        Set.range (wordTuple A L) := by
+    ext X
+    constructor
+    · rintro ⟨w, rfl⟩
+      refine ⟨fun i ↦ e (w i), ?_⟩
+      funext k
+      simp [wordTuple, evalWord_reindexPhysical, List.map_ofFn,
+        Function.comp_def]
+    · rintro ⟨w, rfl⟩
+      refine ⟨fun i ↦ e.symm (w i), ?_⟩
+      funext k
+      simp [wordTuple, evalWord_reindexPhysical, List.map_ofFn,
+        Function.comp_def]
+  rw [hRange]
+
+/-- A simultaneous one-letter span makes every member of the tensor family
+injective.
+
+This is the projection to one labelled block in the simultaneous block
+injectivity statement of arXiv:1606.00608, lines 317--345. -/
+theorem WordTupleSpanTop.isInjective_one
+    {A : (k : Fin r) → MPSTensor d (dim k)}
+    (hSpan : WordTupleSpanTop A 1) (j : Fin r) :
+    IsInjective (A j) := by
+  classical
+  unfold IsInjective
+  apply top_unique
+  intro X _
+  let Xj : (k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ :=
+    fun k ↦ if h : k = j then h ▸ X else 0
+  have hXj : Xj ∈ Submodule.span ℂ (Set.range (wordTuple A 1)) := by
+    rw [hSpan]
+    exact Submodule.mem_top
+  have hcomponent : Xj j ∈ Submodule.span ℂ (Set.range (A j)) := by
+    exact Submodule.span_induction (p := fun Y _ ↦
+        Y j ∈ Submodule.span ℂ (Set.range (A j)))
+      (fun Y hY ↦ by
+        rcases hY with ⟨w, rfl⟩
+        apply Submodule.subset_span
+        refine ⟨w 0, ?_⟩
+        simp [wordTuple, List.ofFn_succ])
+      (Submodule.zero_mem _)
+      (fun Y Z _ _ hY hZ ↦ Submodule.add_mem _ hY hZ)
+      (fun c Y _ hY ↦ Submodule.smul_mem _ c hY)
+      hXj
+  simpa [Xj] using hcomponent
+
 /-- Index type for a matrix entry inside a block family. -/
 abbrev BlockEntryIndex (dim : Fin r → ℕ) :=
   Σ k : Fin r, Fin (dim k) × Fin (dim k)

--- a/TNLean/MPS/MPDO/BlockedBNTFusionIsometries.lean
+++ b/TNLean/MPS/MPDO/BlockedBNTFusionIsometries.lean
@@ -115,7 +115,7 @@ theorem blocked_fusion_of_lengthIndependent
 
 Source: arXiv:1606.00608, lines 986--1010; arXiv:1511.08090, equation
 `zippercondition2`, lines 193--196. -/
-theorem fusionIsometry_mul_blockedMulTensor_of_lengthIndependent
+theorem fusionIsometry_mul_blocked_mulTensor_of_lengthIndependent
     (c : BNTLabelCoefficientFamily Λ)
     (hχ : c.HasPositiveLengthChiTracePowerForm Fam.chi)
     (hLI : c.LengthIndependent) {L : ℕ} (hL : 0 < L)
@@ -139,7 +139,7 @@ theorem fusionIsometry_mul_blockedMulTensor_of_lengthIndependent
 
 Source: arXiv:1606.00608, lines 986--1010; arXiv:1511.08090, equation
 `zippercondition2`, lines 198--200. -/
-theorem blockedMulTensor_mul_fusionIsometry_conjTranspose_of_lengthIndependent
+theorem blocked_mulTensor_mul_fusionIsometry_conjTranspose_of_lengthIndependent
     (c : BNTLabelCoefficientFamily Λ)
     (hχ : c.HasPositiveLengthChiTracePowerForm Fam.chi)
     (hLI : c.LengthIndependent) {L : ℕ} (hL : 0 < L)
@@ -165,7 +165,7 @@ isometry and the unweighted blocked direct sum.
 
 Source: arXiv:1606.00608, lines 986--1010; arXiv:1511.08090, equation
 `inversegaugeone`, lines 181--191. -/
-theorem blockedMulTensor_eq_conjTranspose_mul_unweightedDirectSum_mul
+theorem blocked_mulTensor_eq_conjTranspose_mul_unweightedDirectSum_mul
     (c : BNTLabelCoefficientFamily Λ)
     (hχ : c.HasPositiveLengthChiTracePowerForm Fam.chi)
     (hLI : c.LengthIndependent) {L : ℕ} (hL : 0 < L)
@@ -201,7 +201,7 @@ for the label `γ` is `Fam.chi.dim α β γ`, the dimension of the chi space.
 
 Source: arXiv:1606.00608, BNT blocking at lines 317--345, equation
 `Ualphabeta` at lines 986--993, and length independence at lines 995--1010. -/
-theorem exists_positiveBlock_with_injectiveFusion
+theorem exists_positive_block_with_injective_fusion
     {g D : ℕ} (Fam : MPOTensor.BNTFusionIsometryFamily (Fin g) p)
     {A : MPSTensor (p * p) D}
     (hBNT : MPSTensor.IsCPSVBasisOfNormalTensors A
@@ -254,10 +254,10 @@ theorem exists_positiveBlock_with_injectiveFusion
   refine ⟨L, hL, hSpanBlocked, fun γ ↦ hSpanBlocked.isInjective_one γ, ?_⟩
   intro α β I J
   exact ⟨Fam.blocked_fusion_of_lengthIndependent c hχ hLI hL α β I J,
-    Fam.fusionIsometry_mul_blockedMulTensor_of_lengthIndependent c hχ hLI hL α β I J,
-    Fam.blockedMulTensor_mul_fusionIsometry_conjTranspose_of_lengthIndependent
+    Fam.fusionIsometry_mul_blocked_mulTensor_of_lengthIndependent c hχ hLI hL α β I J,
+    Fam.blocked_mulTensor_mul_fusionIsometry_conjTranspose_of_lengthIndependent
       c hχ hLI hL α β I J,
-    Fam.blockedMulTensor_eq_conjTranspose_mul_unweightedDirectSum_mul
+    Fam.blocked_mulTensor_eq_conjTranspose_mul_unweightedDirectSum_mul
       c hχ hLI hL α β I J⟩
 
 end MPOTensor.BNTFusionIsometryFamily

--- a/TNLean/MPS/MPDO/BlockedBNTFusionIsometries.lean
+++ b/TNLean/MPS/MPDO/BlockedBNTFusionIsometries.lean
@@ -1,0 +1,263 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.BNTFusionIsometries
+import TNLean.MPS.MPDO.PhysicalBlocking
+import TNLean.MPS.MPDO.SourceBNTBlocking
+
+/-!
+# Blocking the length-independent BNT fusion isometries
+
+The basis of normal tensors admits one common positive physical blocking for
+which the labelled tensors are simultaneously injective.  At that same block
+length, the fusion isometries of Theorem IV.13 satisfy the unweighted fusion
+identity and both zipper orientations.
+
+The exclusion of the empty block is essential.  At block length zero the
+conjugated fusion identity would assert that the fusion isometry is also a
+coisometry, which is not an assumption of Theorem IV.13.
+
+## References
+
+* arXiv:1606.00608, BNT definition and blocking, lines 271--274 and 317--345.
+* arXiv:1606.00608, equation `Ualphabeta`, lines 986--993.
+* arXiv:1606.00608, length independence, lines 995--1010.
+-/
+
+open scoped Matrix BigOperators ComplexOrder Kronecker
+open Matrix
+
+namespace MPOTensor.BNTFusionIsometryFamily
+
+variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {p : ℕ}
+variable (Fam : MPOTensor.BNTFusionIsometryFamily Λ p)
+
+/-- The unweighted direct-sum letter obtained after blocking a positive
+number of physical sites.  Its multiplicity space for the label `γ` is the
+chi space of `χ_{α,β,γ}`.
+
+Source: arXiv:1606.00608, equation `Ualphabeta`, lines 986--993, specialized
+by the length-independence observation at lines 995--1010. -/
+noncomputable def blockedUnweightedDirectSumLetter
+    (L : ℕ) (α β : Λ) (I J : Fin (MPSTensor.blockPhysDim p L)) :
+    Matrix ((γ : Λ) × (Fin (Fam.chi.dim α β γ) × Fin (Fam.bondDim γ)))
+      ((γ : Λ) × (Fin (Fam.chi.dim α β γ) × Fin (Fam.bondDim γ))) ℂ :=
+  Matrix.blockDiagonal' fun γ =>
+    (1 : Matrix (Fin (Fam.chi.dim α β γ))
+      (Fin (Fam.chi.dim α β γ)) ℂ) ⊗ₖ
+        blockTensor (Fam.tensor γ) L I J
+
+/-- The fusion identity transported through a positive physical block.  The
+same fusion map conjugates a blocked product letter onto the unweighted direct
+sum of the blocked labelled letters.
+
+Source: arXiv:1606.00608, equation `Ualphabeta`, lines 986--993, and length
+independence at lines 995--1010. -/
+theorem blocked_fusion_of_lengthIndependent
+    (c : BNTLabelCoefficientFamily Λ)
+    (hχ : c.HasPositiveLengthChiTracePowerForm Fam.chi)
+    (hLI : c.LengthIndependent) {L : ℕ} (hL : 0 < L)
+    (α β : Λ) (I J : Fin (MPSTensor.blockPhysDim p L)) :
+    Fam.fusionIsometry α β *
+          mulTensor (blockTensor (Fam.tensor α) L)
+            (blockTensor (Fam.tensor β) L) I J *
+        (Fam.fusionIsometry α β)ᴴ =
+      Fam.blockedUnweightedDirectSumLetter L α β I J := by
+  obtain ⟨n, rfl⟩ : ∃ n, L = n + 1 :=
+    ⟨L - 1, (Nat.succ_pred_eq_of_pos hL).symm⟩
+  rw [← blockTensor_mulTensor (Fam.tensor α) (Fam.tensor β)]
+  simp only [blockTensor_apply, MPSTensor.wordOfBlock, evalWord_ofFn]
+  let F : Fin (n + 1) →
+      Matrix (Fin (Fam.bondDim α * Fam.bondDim β))
+        (Fin (Fam.bondDim α * Fam.bondDim β)) ℂ :=
+    fun l ↦ mulTensor (Fam.tensor α) (Fam.tensor β)
+      (MPSTensor.decodeBlock p (n + 1) I l)
+      (MPSTensor.decodeBlock p (n + 1) J l)
+  let G : ∀ γ : Λ, Fin (n + 1) →
+      Matrix (Fin (Fam.bondDim γ)) (Fin (Fam.bondDim γ)) ℂ :=
+    fun γ l ↦ Fam.tensor γ
+      (MPSTensor.decodeBlock p (n + 1) I l)
+      (MPSTensor.decodeBlock p (n + 1) J l)
+  unfold blockedUnweightedDirectSumLetter
+  simp only [blockTensor_apply, MPSTensor.wordOfBlock, evalWord_ofFn]
+  change Fam.fusionIsometry α β * (List.ofFn F).prod *
+      (Fam.fusionIsometry α β)ᴴ =
+    Matrix.blockDiagonal' fun γ ↦
+      (1 : Matrix (Fin (Fam.chi.dim α β γ))
+        (Fin (Fam.chi.dim α β γ)) ℂ) ⊗ₖ (List.ofFn (G γ)).prod
+  calc
+    _ = (List.ofFn fun l ↦ Fam.fusionIsometry α β * F l *
+        (Fam.fusionIsometry α β)ᴴ).prod :=
+      (listProd_conj_of_conjTranspose_mul_self
+        (Fam.fusionIsometry α β) (Fam.isometry α β) F).symm
+    _ = (List.ofFn fun l ↦ Matrix.blockDiagonal' fun γ ↦
+        Fam.chi.matrix α β γ ⊗ₖ G γ l).prod := by
+      congr 1
+      rw [List.ofFn_inj]
+      funext l
+      exact Fam.fusion α β
+        (MPSTensor.decodeBlock p (n + 1) I l)
+        (MPSTensor.decodeBlock p (n + 1) J l)
+    _ = Matrix.blockDiagonal' (fun γ ↦
+        ((Fam.chi.matrix α β γ) ^ (n + 1)) ⊗ₖ
+          (List.ofFn (G γ)).prod) := by
+      rw [listProd_blockDiagonal'_kronecker]
+    _ = Matrix.blockDiagonal' (fun γ ↦
+        (1 : Matrix (Fin (Fam.chi.dim α β γ))
+          (Fin (Fam.chi.dim α β γ)) ℂ) ⊗ₖ
+            (List.ofFn (G γ)).prod) := by
+      simp_rw [Fam.chi_matrix_eq_one_of_lengthIndependent c hχ hLI]
+      simp
+
+/-- The left zipper identity for the same positive physical blocking.
+
+Source: arXiv:1606.00608, lines 986--1010; arXiv:1511.08090, equation
+`zippercondition2`, lines 193--196. -/
+theorem fusionIsometry_mul_blockedMulTensor_of_lengthIndependent
+    (c : BNTLabelCoefficientFamily Λ)
+    (hχ : c.HasPositiveLengthChiTracePowerForm Fam.chi)
+    (hLI : c.LengthIndependent) {L : ℕ} (hL : 0 < L)
+    (α β : Λ) (I J : Fin (MPSTensor.blockPhysDim p L)) :
+    Fam.fusionIsometry α β *
+        mulTensor (blockTensor (Fam.tensor α) L)
+          (blockTensor (Fam.tensor β) L) I J =
+      Fam.blockedUnweightedDirectSumLetter L α β I J *
+        Fam.fusionIsometry α β := by
+  calc
+    _ = (Fam.fusionIsometry α β *
+          mulTensor (blockTensor (Fam.tensor α) L)
+            (blockTensor (Fam.tensor β) L) I J *
+          (Fam.fusionIsometry α β)ᴴ) *
+        Fam.fusionIsometry α β := by
+      rw [Matrix.mul_assoc, Fam.isometry, Matrix.mul_one]
+    _ = _ := by
+      rw [Fam.blocked_fusion_of_lengthIndependent c hχ hLI hL]
+
+/-- The right zipper identity for the same positive physical blocking.
+
+Source: arXiv:1606.00608, lines 986--1010; arXiv:1511.08090, equation
+`zippercondition2`, lines 198--200. -/
+theorem blockedMulTensor_mul_fusionIsometry_conjTranspose_of_lengthIndependent
+    (c : BNTLabelCoefficientFamily Λ)
+    (hχ : c.HasPositiveLengthChiTracePowerForm Fam.chi)
+    (hLI : c.LengthIndependent) {L : ℕ} (hL : 0 < L)
+    (α β : Λ) (I J : Fin (MPSTensor.blockPhysDim p L)) :
+    mulTensor (blockTensor (Fam.tensor α) L)
+          (blockTensor (Fam.tensor β) L) I J *
+        (Fam.fusionIsometry α β)ᴴ =
+      (Fam.fusionIsometry α β)ᴴ *
+        Fam.blockedUnweightedDirectSumLetter L α β I J := by
+  calc
+    _ = (Fam.fusionIsometry α β)ᴴ *
+        (Fam.fusionIsometry α β *
+          mulTensor (blockTensor (Fam.tensor α) L)
+            (blockTensor (Fam.tensor β) L) I J *
+          (Fam.fusionIsometry α β)ᴴ) := by
+      rw [← Matrix.mul_assoc, ← Matrix.mul_assoc, Fam.isometry,
+        Matrix.one_mul]
+    _ = _ := by
+      rw [Fam.blocked_fusion_of_lengthIndependent c hχ hLI hL]
+
+/-- Literal reconstruction of a blocked product letter through the fusion
+isometry and the unweighted blocked direct sum.
+
+Source: arXiv:1606.00608, lines 986--1010; arXiv:1511.08090, equation
+`inversegaugeone`, lines 181--191. -/
+theorem blockedMulTensor_eq_conjTranspose_mul_unweightedDirectSum_mul
+    (c : BNTLabelCoefficientFamily Λ)
+    (hχ : c.HasPositiveLengthChiTracePowerForm Fam.chi)
+    (hLI : c.LengthIndependent) {L : ℕ} (hL : 0 < L)
+    (α β : Λ) (I J : Fin (MPSTensor.blockPhysDim p L)) :
+    mulTensor (blockTensor (Fam.tensor α) L)
+        (blockTensor (Fam.tensor β) L) I J =
+      (Fam.fusionIsometry α β)ᴴ *
+        Fam.blockedUnweightedDirectSumLetter L α β I J *
+        Fam.fusionIsometry α β := by
+  calc
+    _ = ((Fam.fusionIsometry α β)ᴴ * Fam.fusionIsometry α β) *
+          mulTensor (blockTensor (Fam.tensor α) L)
+            (blockTensor (Fam.tensor β) L) I J *
+          ((Fam.fusionIsometry α β)ᴴ * Fam.fusionIsometry α β) := by
+      rw [Fam.isometry, Matrix.one_mul, Matrix.mul_one]
+    _ = (Fam.fusionIsometry α β)ᴴ *
+        (Fam.fusionIsometry α β *
+          mulTensor (blockTensor (Fam.tensor α) L)
+            (blockTensor (Fam.tensor β) L) I J *
+          (Fam.fusionIsometry α β)ᴴ) *
+        Fam.fusionIsometry α β := by
+      simp only [Matrix.mul_assoc]
+    _ = _ := by
+      rw [Fam.blocked_fusion_of_lengthIndependent c hχ hLI hL]
+
+/-- A basis of normal tensors and its length-independent fusion isometries have
+one common positive block length at which all labelled MPO tensors are
+injective and all four unweighted fusion identities hold.
+
+The block length is obtained from the BNT property; it is not an additional
+hypothesis.  After the length-independent specialization, the multiplicity
+for the label `γ` is `Fam.chi.dim α β γ`, the dimension of the chi space.
+
+Source: arXiv:1606.00608, BNT blocking at lines 317--345, equation
+`Ualphabeta` at lines 986--993, and length independence at lines 995--1010. -/
+theorem exists_positiveBlock_with_injectiveFusion
+    {g D : ℕ} (Fam : MPOTensor.BNTFusionIsometryFamily (Fin g) p)
+    {A : MPSTensor (p * p) D}
+    (hBNT : MPSTensor.IsCPSVBasisOfNormalTensors A
+      (fun γ : Fin g ↦
+        ⟨Fam.bondDim γ, (Fam.tensor γ).toMPSTensor⟩))
+    (c : BNTLabelCoefficientFamily (Fin g))
+    (hχ : c.HasPositiveLengthChiTracePowerForm Fam.chi)
+    (hLI : c.LengthIndependent) :
+    ∃ L : ℕ, 0 < L ∧
+      MPSTensor.WordTupleSpanTop
+        (fun γ ↦ (blockTensor (Fam.tensor γ) L).toMPSTensor) 1 ∧
+      (∀ γ, MPSTensor.IsInjective
+        (blockTensor (Fam.tensor γ) L).toMPSTensor) ∧
+      ∀ (α β : Fin g) (I J : Fin (MPSTensor.blockPhysDim p L)),
+        (Fam.fusionIsometry α β *
+              mulTensor (blockTensor (Fam.tensor α) L)
+                (blockTensor (Fam.tensor β) L) I J *
+            (Fam.fusionIsometry α β)ᴴ =
+          Fam.blockedUnweightedDirectSumLetter L α β I J) ∧
+        (Fam.fusionIsometry α β *
+              mulTensor (blockTensor (Fam.tensor α) L)
+                (blockTensor (Fam.tensor β) L) I J =
+          Fam.blockedUnweightedDirectSumLetter L α β I J *
+            Fam.fusionIsometry α β) ∧
+        (mulTensor (blockTensor (Fam.tensor α) L)
+              (blockTensor (Fam.tensor β) L) I J *
+            (Fam.fusionIsometry α β)ᴴ =
+          (Fam.fusionIsometry α β)ᴴ *
+            Fam.blockedUnweightedDirectSumLetter L α β I J) ∧
+        (mulTensor (blockTensor (Fam.tensor α) L)
+              (blockTensor (Fam.tensor β) L) I J =
+          (Fam.fusionIsometry α β)ᴴ *
+            Fam.blockedUnweightedDirectSumLetter L α β I J *
+            Fam.fusionIsometry α β) := by
+  obtain ⟨L, hL, hSpan⟩ := hBNT.exists_blocked_wordTupleSpanTop_one
+  have hReindexed :=
+    (MPSTensor.wordTupleSpanTop_reindexPhysical_equiv
+      (blockedDoubledIndexEquiv p L)
+      (fun γ ↦ MPSTensor.blockTensor (Fam.tensor γ).toMPSTensor L) 1).2 hSpan
+  have hFamily :
+      (fun γ ↦ (blockTensor (Fam.tensor γ) L).toMPSTensor) =
+        fun γ ↦ MPSTensor.reindexPhysical (blockedDoubledIndexEquiv p L)
+          (MPSTensor.blockTensor (Fam.tensor γ).toMPSTensor L) := by
+    funext γ
+    exact toMPSTensor_blockTensor (Fam.tensor γ)
+  have hSpanBlocked : MPSTensor.WordTupleSpanTop
+      (fun γ ↦ (blockTensor (Fam.tensor γ) L).toMPSTensor) 1 := by
+    rw [hFamily]
+    exact hReindexed
+  refine ⟨L, hL, hSpanBlocked, fun γ ↦ hSpanBlocked.isInjective_one γ, ?_⟩
+  intro α β I J
+  exact ⟨Fam.blocked_fusion_of_lengthIndependent c hχ hLI hL α β I J,
+    Fam.fusionIsometry_mul_blockedMulTensor_of_lengthIndependent c hχ hLI hL α β I J,
+    Fam.blockedMulTensor_mul_fusionIsometry_conjTranspose_of_lengthIndependent
+      c hχ hLI hL α β I J,
+    Fam.blockedMulTensor_eq_conjTranspose_mul_unweightedDirectSum_mul
+      c hχ hLI hL α β I J⟩
+
+end MPOTensor.BNTFusionIsometryFamily

--- a/TNLean/MPS/MPDO/PhysicalBlocking.lean
+++ b/TNLean/MPS/MPDO/PhysicalBlocking.lean
@@ -4,17 +4,23 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Algebra.FinTupleEquiv
+import TNLean.MPS.Core.CyclicTrace
+import TNLean.MPS.Core.PhysicalReindexTransport
+import TNLean.MPS.MPDO.OperatorProduct
 import TNLean.MPS.MPDO.RFPViaTS
 
 /-!
-# Two-site physical blocking of MPO tensors
+# Physical blocking of MPO tensors
 
-This file defines the tensor obtained by blocking two adjacent physical sites
-of an MPO tensor and identifies its one-site and two-site physical closures
-with the two-site and four-site closures of the original tensor.
+This file defines arbitrary physical blocking of an MPO tensor, together with
+the two-site specialization used in the renormalization maps.  Ket words and
+bra words are grouped separately, as in the operator notation of
+arXiv:1606.00608.
 
 ## Main definitions
 
+* `MPOTensor.blockTensor`: the tensor obtained by blocking an arbitrary number
+  of adjacent sites.
 * `MPOTensor.blockTwo`: the tensor obtained by blocking two adjacent sites.
 * `MPOTensor.physClose4`: the right-associated four-site physical closure.
 * `MPOTensor.physClose1_blockTwo_eq_physClose2`: one blocked site is two original sites.
@@ -31,6 +37,97 @@ open scoped Matrix
 namespace MPOTensor
 
 variable {d D : ℕ}
+
+/-! ### Arbitrary physical blocking -/
+
+/-- The MPO tensor obtained by blocking `L` adjacent physical sites.  A ket
+index and a bra index each encode a word of length `L`; the corresponding
+letter is the ordered product of the original MPO matrices along those two
+words.
+
+This is the MPO counterpart of the blocking used to make the basis of normal
+tensors block injective in arXiv:1606.00608, lines 317--345.  The ket and bra
+indices remain separate.  This local tensor should not be confused with the
+closed-chain operator `O_L(M)` defined at lines 962--967. -/
+noncomputable def blockTensor (M : MPOTensor d D) (L : ℕ) :
+    MPOTensor (MPSTensor.blockPhysDim d L) D :=
+  fun i j => evalWord M (MPSTensor.wordOfBlock d L i) (MPSTensor.wordOfBlock d L j)
+
+@[simp]
+lemma blockTensor_apply (M : MPOTensor d D) (L : ℕ)
+    (i j : Fin (MPSTensor.blockPhysDim d L)) :
+    blockTensor M L i j =
+      evalWord M (MPSTensor.wordOfBlock d L i) (MPSTensor.wordOfBlock d L j) :=
+  rfl
+
+/-- Canonical identification between the doubled physical index of an
+`L`-site MPO block and the `L`-site block of the doubled MPS index.
+
+The map decodes the blocked ket and bra words, pairs their letters site by
+site, and then encodes the resulting word in `Fin (d * d)`.  This is the
+index identification implicit in the blocking argument of
+arXiv:1606.00608, lines 317--345. -/
+noncomputable def blockedDoubledIndexEquiv (d L : ℕ) :
+    Fin (MPSTensor.blockPhysDim d L * MPSTensor.blockPhysDim d L) ≃
+      Fin (MPSTensor.blockPhysDim (d * d) L) :=
+  finProdFinEquiv.symm |>.trans
+    (Equiv.prodCongr (MPSTensor.decodeBlockEquiv d L)
+      (MPSTensor.decodeBlockEquiv d L)) |>.trans
+    (Equiv.arrowProdEquivProdArrow (Fin L) (fun _ ↦ Fin d) (fun _ ↦ Fin d)).symm |>.trans
+    (Equiv.arrowCongr (Equiv.refl (Fin L)) finProdFinEquiv) |>.trans
+    (MPSTensor.decodeBlockEquiv (d * d) L).symm
+
+@[simp]
+lemma decodeBlock_blockedDoubledIndexEquiv (d L : ℕ)
+    (ij : Fin (MPSTensor.blockPhysDim d L * MPSTensor.blockPhysDim d L))
+    (k : Fin L) :
+    MPSTensor.decodeBlock (d * d) L (blockedDoubledIndexEquiv d L ij) k =
+      finProdFinEquiv
+        (MPSTensor.decodeBlock d L ij.divNat k,
+          MPSTensor.decodeBlock d L ij.modNat k) := by
+  simp [blockedDoubledIndexEquiv, Equiv.arrowCongr,
+    MPSTensor.decodeBlockEquiv_apply]
+
+/-- Physical blocking commutes with passing from an MPO tensor to its
+doubled-index MPS tensor, up to the canonical pairing of the blocked ket and
+bra words. -/
+theorem toMPSTensor_blockTensor (M : MPOTensor d D) {L : ℕ} :
+    (blockTensor M L).toMPSTensor =
+      MPSTensor.reindexPhysical (blockedDoubledIndexEquiv d L)
+        (MPSTensor.blockTensor M.toMPSTensor L) := by
+  funext ij
+  simp only [toMPSTensor, blockTensor_apply, MPSTensor.reindexPhysical,
+    MPSTensor.blockTensor]
+  simp only [MPSTensor.wordOfBlock, MPOTensor.evalWord_ofFn,
+    MPSTensor.evalWord_ofFn_eq_prod]
+  simp only [toMPSTensor, decodeBlock_blockedDoubledIndexEquiv,
+    MPSTensor.finProdFinEquiv_divNat, MPSTensor.finProdFinEquiv_modNat]
+
+/-- Injectivity of an MPO block is the injectivity of the corresponding block
+of its doubled-index MPS tensor. -/
+theorem isInjective_toMPSTensor_blockTensor_iff
+    (M : MPOTensor d D) {L : ℕ} :
+    MPSTensor.IsInjective (blockTensor M L).toMPSTensor ↔
+      MPSTensor.IsInjective (MPSTensor.blockTensor M.toMPSTensor L) := by
+  rw [toMPSTensor_blockTensor M,
+    MPSTensor.isInjective_reindexPhysical_equiv]
+
+/-- Physical blocking commutes with the product of MPO tensors.  The
+intermediate physical word is merely reindexed from a function `Fin L → Fin d`
+to one blocked physical index. -/
+theorem blockTensor_mulTensor {D₁ D₂ : ℕ}
+    (M : MPOTensor d D₁) (N : MPOTensor d D₂) {L : ℕ} :
+    blockTensor (mulTensor M N) L =
+      mulTensor (blockTensor M L) (blockTensor N L) := by
+  funext I K
+  rw [blockTensor_apply, mulTensor_apply]
+  change evalWord (mulTensor M N)
+      (List.ofFn (MPSTensor.decodeBlock d L I))
+      (List.ofFn (MPSTensor.decodeBlock d L K)) = _
+  rw [evalWord_mulTensor]
+  rw [← (MPSTensor.decodeBlockEquiv d L).sum_comp]
+  simp only [MPSTensor.decodeBlockEquiv_apply, blockTensor_apply,
+    MPSTensor.wordOfBlock]
 
 /-! ### Two-site blocking -/
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -80,6 +80,74 @@
     \label{fig:mpdo_two_site_blocking}
 \end{figure}
 
+\begin{definition}[Positive-length physical blocking of an MPO tensor]
+    \label{def:mpdo_positive_physical_blocking}
+    \lean{MPOTensor.blockTensor}
+    \lean{MPOTensor.blockTensor_apply}
+    \leanok
+    For a positive integer $L$, group $L$ adjacent physical sites and denote
+    the resulting local tensor by $M^{[L]}$.  It has a length-$L$ ket word
+    $I=(i_1,\ldots,i_L)$ and a length-$L$ bra word
+    $J=(j_1,\ldots,j_L)$ as its physical indices, and
+    \[
+        \bigl(M^{[L]}\bigr)^{I,J}
+          =M^{i_1j_1}\cdots M^{i_Lj_L}.
+    \]
+    Thus the ket and bra words are grouped separately.  This is the MPO
+    version of the physical blocking used for the basis of normal tensors in
+    \cite[lines~317--345]{Cirac2016MPDO_arXiv}.  It is a local tensor, not the
+    closed-chain operator $O_L(M)$ of
+    \cite[lines~962--967]{Cirac2016MPDO_arXiv}.
+
+    The algebraic definition also assigns the identity matrix to the empty
+    product at $L=0$.  This total convention has no physical role here; every
+    blocking result below assumes $L>0$.
+\end{definition}
+
+\begin{theorem}[Doubled-index form of positive MPO blocking]
+    \label{thm:mpdo_positive_blocking_doubled_index}
+    \lean{MPOTensor.blockedDoubledIndexEquiv}
+    \lean{MPOTensor.decodeBlock_blockedDoubledIndexEquiv}
+    \lean{MPOTensor.toMPSTensor_blockTensor}
+    \lean{MPOTensor.isInjective_toMPSTensor_blockTensor_iff}
+    \leanok
+    \uses{def:mpdo_positive_physical_blocking, def:blocked_tensor}
+    Let $L>0$.  Pairing the ket and bra letters site by site gives the
+    canonical identification
+    \[
+      \{0,\ldots,d^L-1\}^2
+        \simeq \{0,\ldots,d^2-1\}^L.
+    \]
+    Under this identification, the doubled-index MPS tensor of $M^{[L]}$
+    is the physical reindexing of the $L$-blocked doubled-index MPS tensor
+    of $M$.  In particular, one is injective if and only if the other is.
+\end{theorem}
+
+\begin{proof}\leanok
+    Decode the blocked ket and bra words, pair their letters at each site,
+    and compare the two ordered matrix products.  Physical reindexing by a
+    bijection preserves the span of the tensor matrices.
+\end{proof}
+
+\begin{theorem}[Positive blocking commutes with the MPO product]
+    \label{thm:mpdo_positive_blocking_product}
+    \lean{MPOTensor.blockTensor_mulTensor}
+    \leanok
+    \uses{def:mpdo_positive_physical_blocking, def:mpdo_operator_product}
+    For $L>0$ and two MPO tensors $M,N$ with the same physical dimension,
+    let juxtaposition denote the MPO tensor product obtained by contracting
+    the intermediate physical index.  Then
+    \[
+        (MN)^{[L]}=M^{[L]}N^{[L]}.
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    Expand the product tensor and sum over its length-$L$ intermediate
+    physical word.  Reindexing this word by one blocked physical index gives
+    the product of the two blocked tensors.
+\end{proof}
+
 \begin{definition}[Two-site blocking of an MPO tensor]
     \label{def:mpdo_two_site_blocking}
     \lean{MPOTensor.blockTwo}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -378,13 +378,13 @@ them.
     \lean{MPOTensor.BNTFusionIsometryFamily.%
         blocked_fusion_of_lengthIndependent}
     \lean{MPOTensor.BNTFusionIsometryFamily.%
-        fusionIsometry_mul_blockedMulTensor_of_lengthIndependent}
+        fusionIsometry_mul_blocked_mulTensor_of_lengthIndependent}
     \lean{MPOTensor.BNTFusionIsometryFamily.%
-        blockedMulTensor_mul_fusionIsometry_conjTranspose_of_lengthIndependent}
+        blocked_mulTensor_mul_fusionIsometry_conjTranspose_of_lengthIndependent}
     \lean{MPOTensor.BNTFusionIsometryFamily.%
-        blockedMulTensor_eq_conjTranspose_mul_unweightedDirectSum_mul}
+        blocked_mulTensor_eq_conjTranspose_mul_unweightedDirectSum_mul}
     \lean{MPOTensor.BNTFusionIsometryFamily.%
-        exists_positiveBlock_with_injectiveFusion}
+        exists_positive_block_with_injective_fusion}
     \leanok
     \uses{thm:cpsv_bnt_blocked_simultaneous_span,
         thm:mpdo_positive_blocking_doubled_index,

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -369,6 +369,80 @@ them.
     letter and apply the fusion identity between the two inserted factors.
 \end{proof}
 
+\begin{theorem}[Common positive blocking of the BNT fusion isometries]
+    \label{thm:mpdo_bnt_common_positive_blocked_fusion}
+    \lean{MPSTensor.wordTupleSpanTop_reindexPhysical_equiv}
+    \lean{MPSTensor.WordTupleSpanTop.isInjective_one}
+    \lean{MPOTensor.BNTFusionIsometryFamily.%
+        blockedUnweightedDirectSumLetter}
+    \lean{MPOTensor.BNTFusionIsometryFamily.%
+        blocked_fusion_of_lengthIndependent}
+    \lean{MPOTensor.BNTFusionIsometryFamily.%
+        fusionIsometry_mul_blockedMulTensor_of_lengthIndependent}
+    \lean{MPOTensor.BNTFusionIsometryFamily.%
+        blockedMulTensor_mul_fusionIsometry_conjTranspose_of_lengthIndependent}
+    \lean{MPOTensor.BNTFusionIsometryFamily.%
+        blockedMulTensor_eq_conjTranspose_mul_unweightedDirectSum_mul}
+    \lean{MPOTensor.BNTFusionIsometryFamily.%
+        exists_positiveBlock_with_injectiveFusion}
+    \leanok
+    \uses{thm:cpsv_bnt_blocked_simultaneous_span,
+        thm:mpdo_positive_blocking_doubled_index,
+        thm:mpdo_positive_blocking_product,
+        thm:mpdo_bnt_length_independent_zipper}
+    Suppose that the labelled doubled-index tensors form the basis of normal
+    tensors, and that their fusion-isometry family has positive trace-power
+    coefficients independent of the positive chain length.  Then there is
+    one integer $L>0$ such that the blocked tensors $M_\gamma^{[L]}$ span
+    their full product matrix algebra in one letter.  Hence every
+    $M_\gamma^{[L]}$ is injective.
+
+    For this same $L$, write
+    \[
+      P_{\alpha,\beta}^{I J}
+        =(M_\alpha^{[L]}M_\beta^{[L]})^{I J},
+      \qquad
+      H_{\alpha,\beta}^{I J}
+        =\bigoplus_\gamma
+          1_{r_{\alpha,\beta,\gamma}}
+            \otimes (M_\gamma^{[L]})^{I J},
+    \]
+    where $r_{\alpha,\beta,\gamma}$ is the dimension of the specialized
+    chi space.  The original fusion isometry satisfies
+    \[
+      U_{\alpha,\beta}P_{\alpha,\beta}^{I J}
+          U_{\alpha,\beta}^\dagger
+        =H_{\alpha,\beta}^{I J},
+    \]
+    the two blocked zipper identities
+    \[
+      U_{\alpha,\beta}P_{\alpha,\beta}^{I J}
+        =H_{\alpha,\beta}^{I J}U_{\alpha,\beta},
+      \qquad
+      P_{\alpha,\beta}^{I J}U_{\alpha,\beta}^\dagger
+        =U_{\alpha,\beta}^\dagger H_{\alpha,\beta}^{I J},
+    \]
+    and the literal reconstruction
+    \[
+      P_{\alpha,\beta}^{I J}
+        =U_{\alpha,\beta}^\dagger
+          H_{\alpha,\beta}^{I J}U_{\alpha,\beta}.
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    Choose the positive block length supplied by simultaneous BNT blocking.
+    The canonical pairing of the blocked ket and bra words transfers the
+    one-letter product-algebra span to the blocked MPO tensors, and projection
+    to each labelled factor gives injectivity.  Along a nonempty block, the
+    products of the conjugated fusion letters telescope using only
+    $U_{\alpha,\beta}^\dagger U_{\alpha,\beta}=1$.  Length independence
+    replaces every chi matrix by the identity on its own chi space.  The two
+    zipper identities and reconstruction then follow by multiplying the
+    blocked fusion identity by $U_{\alpha,\beta}$ or
+    $U_{\alpha,\beta}^\dagger$ on the appropriate side.
+\end{proof}
+
 \begin{figure}[ht]
     \centering
     \TNMPDOUnweightedZipperReconstruction

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -646,7 +646,7 @@ For the positive-diagonal fusion family, under the explicit hypothesis that
 identifies the labelled doubled-index tensors with a BNT witness, transport
 through the same positive block length is now formalized by
 \leanid{MPOTensor.BNTFusionIsometryFamily.%
-exists_positiveBlock_with_injectiveFusion}.  The theorem derives the common
+exists_positive_block_with_injective_fusion}.  The theorem derives the common
 one-letter span and injectivity of every blocked labelled tensor, and proves
 the blocked conjugation identity, both zipper orientations, and literal
 reconstruction.  Its multiplicity is exactly the dimension of the

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -642,14 +642,24 @@ zero on the others.  One-letter injectivity and selector coefficients can
 therefore be extracted after the same common blocking, without adding either
 property to the definition of a BNT.
 
-For the positive-diagonal fusion family, the remaining construction begins by
-linking its final-label tensors to the BNT witness that is already part of the
-source assumptions.  The simultaneous inverse must then be extracted from the
-blocked span and reindexed in the fusion coordinates.  After transporting the
-fusion equations through the same blocking, one must prove
-$U_{\alpha,\beta}U_{\alpha,\beta}^{\dagger}=I$, assemble the synthesis and
-analysis maps with their biorthogonality, prove both zipper equations and
-\texttt{inversegaugeone}, and construct
+For the positive-diagonal fusion family, under the explicit hypothesis that
+identifies the labelled doubled-index tensors with a BNT witness, transport
+through the same positive block length is now formalized by
+\leanid{MPOTensor.BNTFusionIsometryFamily.%
+exists_positiveBlock_with_injectiveFusion}.  The theorem derives the common
+one-letter span and injectivity of every blocked labelled tensor, and proves
+the blocked conjugation identity, both zipper orientations, and literal
+reconstruction.  Its multiplicity is exactly the dimension of the
+specialized chi space.  The positive-length condition is essential: at block
+length zero the conjugation identity would assert the unproved coisometry
+$U_{\alpha,\beta}U_{\alpha,\beta}^{\dagger}=I$.
+
+The remaining construction is therefore narrower.  One must first construct
+this identification from the RFP tensor and the BNT of its vertical canonical
+form.  The simultaneous inverse must then be extracted from the blocked span
+and reindexed in the fusion coordinates.  One must derive the coisometry
+rather than assume it, assemble synthesis and analysis maps with their
+biorthogonality, and construct
 \leanid{MPOTensor.CompleteZipperFusionFamily}.  The existing printed
 $F$-matrix and pentagon theorem can then be applied to this family.
 


### PR DESCRIPTION
## Summary

- define arbitrary physical blocking of an MPO tensor, with ket and bra words grouped separately
- identify its doubled-index MPS form with the corresponding blocked MPS tensor by the canonical reindexing
- transport the common one-letter BNT span to the blocked MPO family and derive injectivity of every labelled block
- transport the length-independent fusion identity through that same positive block length, yielding both zipper orientations and literal reconstruction
- synchronize the Chapter 21 blueprint and narrow the remaining paper-gap note

The local blocked tensor is explicitly distinguished from the closed-chain operator $O_L(M)$ in arXiv:1606.00608. The algebraic definition is total at $L=0$, but every physical fusion statement assumes $L>0$; the empty block is not used physically.

The theorem assumes an explicit identification of the labelled fusion tensors with the BNT witness. It does not claim the still-missing construction of that identification from the RFP tensor, coisometry, a simultaneous inverse, or the complete zipper family.

Closes #3926.
Parent tracking issue: #3921.

## Source alignment

- arXiv:1606.00608, BNT blocking, lines 317–345
- arXiv:1606.00608, equation `Ualphabeta`, lines 986–993
- arXiv:1606.00608, length independence, lines 995–1010
- arXiv:1511.08090, zipper and reconstruction equations, lines 181–200

## Verification

- `lake build TNLean` (9,400 jobs)
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `leanblueprint pdf` (553 pages, new entries visually inspected)
- `leanblueprint web`
- kernel axiom audit of the new declarations: only `propext`, `Classical.choice`, and `Quot.sound`; no new axiom or placeholder proof

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core MPDO fusion/BNT formalization and new blocking infrastructure; assumptions are explicit (BNT witness identification, L>0) and proofs are additive rather than changing existing fusion axioms.
> 
> **Overview**
> Adds **arbitrary-length MPO physical blocking** (`blockTensor`) with separate ket/bra words, doubled-index identification with blocked MPS tensors, and commutation with `mulTensor`. Extends **BiCF** with reindexing invariance of `WordTupleSpanTop` and injectivity of each block from a one-letter span.
> 
> New module **`BlockedBNTFusionIsometries`** proves that at a **common positive block length** from BNT data, length-independent fusion isometries satisfy the **blocked conjugation identity**, **both zipper orientations**, and **literal reconstruction** (`exists_positive_block_with_injective_fusion`), assuming explicit identification of labelled tensors with a BNT witness and **L > 0** (empty block excluded to avoid unproved coisometry).
> 
> **Blueprint** Chapter 21 and **paper-gap** notes are updated to match; remaining work is narrowed to constructing the witness from the RFP tensor, coisometry, and complete zipper family—not assumed here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98082834f9f33edeb234b00d1c7ad34ff1f3e7f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->