### PR TITLE
feat(MPS/MPDO): derive simultaneous block inverse

### DIFF
--- a/TNLean/MPS/MPDO/BiCFDerivation/Core.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/Core.lean
@@ -145,6 +145,87 @@ def blockEntryValue
     (x : BlockEntryIndex dim) : ℂ :=
   M x.1 x.2.1 x.2.2
 
+/-- A simultaneous one-letter product-algebra span has a left inverse which
+distinguishes the block label and both matrix indices.
+
+This is the simultaneous inverse used after blocking in arXiv:1511.08090,
+lines 269--277 and 427--431. -/
+theorem WordTupleSpanTop.exists_one_letter_simultaneous_left_inverse
+    {A : (k : Fin r) → MPSTensor d (dim k)}
+    (hSpan : WordTupleSpanTop A 1) :
+    ∃ C : Matrix (BlockEntryIndex dim) (Fin d) ℂ,
+      ∀ (k j : Fin r) (x y : Fin (dim k))
+        (x' y' : Fin (dim j)),
+        (∑ i : Fin d, C ⟨k, x, y⟩ i * A j i x' y') =
+          if h : k = j then
+            if _ : h ▸ x = x' then if _ : h ▸ y = y' then 1 else 0 else 0
+          else 0 := by
+  classical
+  let target (k : Fin r) (x y : Fin (dim k)) :
+      (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ :=
+    fun j x' y' =>
+      if h : k = j then
+        if _ : h ▸ x = x' then if _ : h ▸ y = y' then 1 else 0 else 0
+      else 0
+  have htarget (k : Fin r) (x y : Fin (dim k)) :
+      target k x y ∈ Submodule.span ℂ (Set.range (wordTuple A 1)) := by
+    rw [hSpan]
+    exact Submodule.mem_top
+  have hcoeff (k : Fin r) (x y : Fin (dim k)) :
+      ∃ c : (Fin 1 → Fin d) → ℂ,
+        ∑ w, c w • wordTuple A 1 w = target k x y :=
+    (Submodule.mem_span_range_iff_exists_fun ℂ).mp (htarget k x y)
+  choose coeff hcoeff_eq using hcoeff
+  let e := (Equiv.funUnique (Fin 1) (Fin d)).symm
+  refine ⟨fun z i ↦ coeff z.1 z.2.1 z.2.2 (e i), ?_⟩
+  intro k j x y x' y'
+  change (∑ i : Fin d, coeff k x y (e i) * A j i x' y') = _
+  rw [show (∑ i : Fin d, coeff k x y (e i) * A j i x' y') =
+      ∑ w : Fin 1 → Fin d, coeff k x y w * A j (w 0) x' y' by
+    simpa [e] using Equiv.sum_comp e
+      (fun w : Fin 1 → Fin d ↦ coeff k x y w * A j (w 0) x' y')]
+  have hentry := congrArg (fun M ↦ M j x' y') (hcoeff_eq k x y)
+  simpa [wordTuple, target, Fintype.linearCombination_apply,
+    Matrix.sum_apply, Matrix.smul_apply, List.ofFn_succ] using hentry
+
+/-- The simultaneous one-letter inverse in the ket--bra coordinates of an MPO
+tensor family.  Its orientation is the one used by the complete zipper fusion
+data.
+
+Source: arXiv:1511.08090, simultaneous inverse at lines 269--277, after the
+common blocking at lines 427--431. -/
+theorem WordTupleSpanTop.exists_mpo_block_left_inverse
+    {p : ℕ} {M : (k : Fin r) → MPOTensor p (dim k)}
+    (hSpan : WordTupleSpanTop (fun k ↦ (M k).toMPSTensor) 1) :
+    ∃ C : Matrix (BlockEntryIndex dim) (Fin p × Fin p) ℂ,
+      ∀ (k j : Fin r) (x y : Fin (dim k))
+        (x' y' : Fin (dim j)),
+        (∑ i : Fin p, ∑ l : Fin p,
+          C ⟨k, x, y⟩ (i, l) * M j i l x' y') =
+            if h : k = j then
+              if _ : h ▸ x = x' then if _ : h ▸ y = y' then 1 else 0 else 0
+            else 0 := by
+  obtain ⟨C, hC⟩ := hSpan.exists_one_letter_simultaneous_left_inverse
+  refine ⟨fun z il ↦ C z (finProdFinEquiv il), ?_⟩
+  intro k j x y x' y'
+  change (∑ i : Fin p, ∑ l : Fin p,
+    C ⟨k, x, y⟩ (finProdFinEquiv (i, l)) * M j i l x' y') = _
+  have hpair (il : Fin p × Fin p) :
+      (M j).toMPSTensor (finProdFinEquiv il) x' y' =
+        M j il.1 il.2 x' y' := by
+    rcases il with ⟨i, l⟩
+    simp [MPOTensor.toMPSTensor]
+  calc
+    _ = ∑ il : Fin p × Fin p,
+        C ⟨k, x, y⟩ (finProdFinEquiv il) * M j il.1 il.2 x' y' :=
+      (Fintype.sum_prod_type _).symm
+    _ = ∑ q : Fin (p * p),
+        C ⟨k, x, y⟩ q * (M j).toMPSTensor q x' y' := by
+      simpa only [hpair] using
+          Equiv.sum_comp finProdFinEquiv
+            (fun q ↦ C ⟨k, x, y⟩ q * (M j).toMPSTensor q x' y')
+    _ = _ := hC k j x y x' y'
+
 /-- The scalar word family obtained by reading off one chosen matrix entry of the
 block-word tuple. -/
 def wordEntryFamily

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -1304,6 +1304,39 @@ separate step.
     identity factor and gives the two asserted identities.
 \end{proof}
 
+\begin{theorem}[Simultaneous inverse from a one-letter product-algebra span]%
+    \label{thm:mpdo_one_letter_simultaneous_inverse}
+    \lean{MPSTensor.WordTupleSpanTop.%
+        exists_one_letter_simultaneous_left_inverse}
+    \lean{MPSTensor.WordTupleSpanTop.exists_mpo_block_left_inverse}
+    \leanok
+    \uses{thm:cpsv_bnt_blocked_simultaneous_span}
+    Let $A_c^q\in M_{D_c}(\mathbb C)$ be a finite labelled tensor family.  If
+    the one-letter tuples
+    \[
+        q\longmapsto (A_c^q)_c
+    \]
+    span the full product algebra $\prod_c M_{D_c}(\mathbb C)$, then there
+    are coefficients $C_{(c,x,y),q}$ such that
+    \[
+        \sum_q C_{(c,x,y),q}(A_d^q)_{x'y'}
+          =\delta_{cd}\delta_{xx'}\delta_{yy'}.
+    \]
+    For an MPO tensor the letter is the ket--bra pair $q=(i,k)$, so the same
+    coefficients form the common block-letter left inverse used in
+    \cite[lines~269--277]{Bultinck2017Anyons}.  The full product-algebra span
+    is obtained after the common blocking described in
+    \cite[lines~427--431]{Bultinck2017Anyons}.
+\end{theorem}
+
+\begin{proof}\leanok
+    Fix $(c,x,y)$ and consider the product-algebra element which is the matrix
+    unit $E_{xy}$ in block $c$ and zero in every other block.  By the spanning
+    hypothesis it is a linear combination of the one-letter tuples.  Reading
+    its $(x',y')$ entry in block $d$ gives the displayed identity.  Reindexing
+    the doubled physical letter by the ket--bra pair gives the MPO form.
+\end{proof}
+
 \begin{figure}[ht]
     \centering
     \TNMPDOFixedFinalComparisonUnitary


### PR DESCRIPTION
Closes #3932. Parent issue: #3921.

This change extracts the common one-letter left inverse from the product-algebra span used after simultaneous BNT blocking. For each block and matrix unit, the spanning hypothesis supplies coefficients that select that entry in the chosen block and vanish on every other block. A second theorem reindexes the result into the MPO ket-bra orientation required by complete zipper data.

The blueprint states the matrix-unit argument and cites arXiv:1511.08090, lines 269-277 and 427-431. The argument is presented as a derived consequence of the source ingredients, not as a proof printed verbatim in the paper.

Validation:
- full TNLean build passed before the documentation-only main rebase
- targeted BiCFDerivation.Core build passed after the rebase
- both declarations depend only on propext, Classical.choice, and Quot.sound
- blueprint PDF builds to 553 pages and the new theorem was visually inspected
- blueprint-Lean synchronization and declaration checking pass
- forbidden-token, prose, line-length, and whitespace checks pass

No new axiom, sorry, or extra mathematical hypothesis is introduced.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds formal Lean theorems and blueprint documentation in MPS/MPDO biCF derivation; no runtime, auth, or data-path changes.
> 
> **Overview**
> When one-letter simultaneous word tuples **span the full block product algebra**, this PR **proves** there exist coefficients that act as a **left inverse** selecting a single matrix unit in one block and vanishing elsewhere. A second theorem **reindexes** that construction to **MPO ket–bra** coordinates for complete zipper fusion data.
> 
> The blueprint chapter gains **Theorem** `mpdo_one_letter_simultaneous_inverse`, linked to the new Lean declarations and citing Bultinck2017 (lines 269–277, 427–431). No new axioms or `sorry`; proofs use only span membership and standard linear-algebra reindexing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7805fbf7cef9d658f263c4d4ba783eba14dd07e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->