### PR TITLE
feat(MPS/MPDO): derive pair fusion coisometry from BNT

### DIFF
--- a/TNLean/MPS/MPDO/BNTTripleFusionSeparation.lean
+++ b/TNLean/MPS/MPDO/BNTTripleFusionSeparation.lean
@@ -5,7 +5,8 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.BNTTripleFusionComparison
 import TNLean.MPS.MPDO.BNTFinalSectorFusion
-import TNLean.MPS.MPDO.BiCFDerivation.Core
+import TNLean.MPS.MPDO.BiCFDerivation.Selectors
+import TNLean.MPS.MPDO.SourceBNTBlocking
 import TNLean.MPS.Core.CyclicTrace
 import Mathlib.LinearAlgebra.Matrix.Rank
 
@@ -76,6 +77,15 @@ def HasFinalLabelSelectorWords (S : ℕ) : Prop :=
     ∀ ε' : Λ, ε' ≠ ε →
       (∑ w : Fin S → Fin (p * p),
         c w • MPSTensor.evalWord (Fam.tensor ε').toMPSTensor (List.ofFn w)) = 0
+
+/-- Simultaneous block selectors for the labelled MPO tensors are precisely
+final-label selectors for their fusion family. -/
+theorem hasFinalLabelSelectorWords_of_hasBlockSelectorWords
+    {g : ℕ} (Fam : BNTFusionIsometryFamily (Fin g) p) {S : ℕ}
+    (hSel : MPSTensor.HasBlockSelectorWords
+      (fun ε ↦ (Fam.tensor ε).toMPSTensor) S) :
+    Fam.HasFinalLabelSelectorWords S :=
+  hSel
 
 /-- **Positive-length final-label selectors make every pair fusion map surjective.**
 
@@ -214,6 +224,37 @@ theorem fusionIsometry_mul_conjTranspose_eq_one_of_lengthIndependent_of_selector
         coeff ε w • _root_.evalWord D (List.ofFn w) := by
       simp_rw [Matrix.mul_sum, Matrix.mul_smul, hPword]
     _ = 1 := htotal
+
+/-- A source basis of normal tensors makes every length-independent pair
+fusion isometry a coisometry.
+
+The BNT hypothesis supplies a common positive word span.  Matrix-unit
+selectors extracted from that span give the final-label selectors required by
+`fusionIsometry_mul_conjTranspose_eq_one_of_lengthIndependent_of_selectorWords`.
+Thus neither selectors nor coisometry are additional hypotheses.
+
+This is a derived argument from arXiv:1606.00608, BNT separation at lines
+317--345, equation `Ualphabeta` at lines 986--993, and length independence at
+lines 995--1010.  The simultaneous-inverse interpretation agrees with
+arXiv:1511.08090, lines 269--277 and 427--431. -/
+theorem fusionIsometry_mul_conjTranspose_eq_one_of_bnt_of_lengthIndependent
+    {g D : ℕ} (Fam : BNTFusionIsometryFamily (Fin g) p)
+    {A : MPSTensor (p * p) D}
+    (hBNT : MPSTensor.IsCPSVBasisOfNormalTensors A
+      (fun γ : Fin g ↦
+        ⟨Fam.bondDim γ, (Fam.tensor γ).toMPSTensor⟩))
+    (c : BNTLabelCoefficientFamily (Fin g))
+    (hχ : c.HasPositiveLengthChiTracePowerForm Fam.chi)
+    (hLI : c.LengthIndependent) (α β : Fin g) :
+    Fam.fusionIsometry α β * (Fam.fusionIsometry α β)ᴴ = 1 := by
+  obtain ⟨S, hS, hSpan⟩ := hBNT.exists_positive_wordTupleSpanTop
+  have hBlockSelectors :=
+    MPSTensor.hasBlockSelectorWords_of_wordTupleSpanTop
+      (fun γ ↦ (Fam.tensor γ).toMPSTensor) hSpan
+  exact Fam.fusionIsometry_mul_conjTranspose_eq_one_of_lengthIndependent_of_selectorWords
+    c hχ hLI hS
+      (Fam.hasFinalLabelSelectorWords_of_hasBlockSelectorWords hBlockSelectors)
+      α β
 
 private theorem mul_conjTranspose_eq_one_of_conjTranspose_mul_eq_one_of_card_eq
     {m n : Type*} [Fintype m] [DecidableEq m] [Fintype n] [DecidableEq n]

--- a/TNLean/MPS/MPDO/SourceBNTBlocking.lean
+++ b/TNLean/MPS/MPDO/SourceBNTBlocking.lean
@@ -70,7 +70,7 @@ private theorem IsCPSVBasisOfNormalTensors.blocks_not_gaugePhaseEquiv
 
 /-- A simultaneous length-`L` word span becomes a simultaneous one-letter
 span after blocking `L` physical sites. -/
-private theorem wordTupleSpanTop_blockTensor_one
+theorem wordTupleSpanTop_blockTensor_one
     {g : ℕ} {dim : Fin g → ℕ}
     (B : (j : Fin g) → MPSTensor d (dim j)) {L : ℕ}
     (hSpan : WordTupleSpanTop B L) :
@@ -163,23 +163,23 @@ private theorem hasBlockSelectorWords_of_family_gaugeEquiv
         rw [hoff j hjk]
         simp
 
-/-- A basis of normal tensors becomes simultaneously injective after one
-common positive blocking.
+/-- A basis of normal tensors has one common positive word length at which the
+labelled word evaluations span the full product matrix algebra.
 
 The BNT hypothesis supplies positive bond dimensions and excludes
 gauge-phase-equivalent duplicate representatives.  Perron gauges put all
 representatives in left-canonical form, after which the block-injectivity
 argument gives simultaneous selectors.  The gauges are then removed and the
-entire selector length is absorbed into one physical blocking.
+resulting injectivity and selectors give the simultaneous product-algebra
+span at one positive word length.
 
 Source: arXiv:1606.00608, BNT definition at lines 271--274 and block
 injectivity at lines 317--345. -/
-theorem IsCPSVBasisOfNormalTensors.exists_blocked_wordTupleSpanTop_one
+theorem IsCPSVBasisOfNormalTensors.exists_positive_wordTupleSpanTop
     {g : ℕ} {dim : Fin g → ℕ}
     {A : MPSTensor d D} {B : (j : Fin g) → MPSTensor d (dim j)}
     (hBNT : IsCPSVBasisOfNormalTensors A (fun j => ⟨dim j, B j⟩)) :
-    ∃ L : ℕ, 0 < L ∧
-      WordTupleSpanTop (fun j => blockTensor (B j) L) 1 := by
+    ∃ L : ℕ, 0 < L ∧ WordTupleSpanTop B L := by
   classical
   have hdimPos := hBNT.blocks_dim_pos
   letI : ∀ j : Fin g, NeZero (dim j) := fun j => ⟨(hdimPos j).ne'⟩
@@ -239,7 +239,23 @@ theorem IsCPSVBasisOfNormalTensors.exists_blocked_wordTupleSpanTop_one
   have hSpan : WordTupleSpanTop B (p + selectorLength) :=
     wordTupleSpanTop_of_common_blockInjective_of_blockSelectorWords
       B hOriginalAtP hSelectors
-  refine ⟨p + selectorLength, Nat.add_pos_left hp selectorLength, ?_⟩
-  exact wordTupleSpanTop_blockTensor_one B hSpan
+  exact ⟨p + selectorLength, Nat.add_pos_left hp selectorLength, hSpan⟩
+
+/-- A basis of normal tensors becomes simultaneously injective after one
+common positive blocking.
+
+The common positive word span is absorbed into one physical letter by
+blocking the same number of sites.
+
+Source: arXiv:1606.00608, BNT definition at lines 271--274 and block
+injectivity at lines 317--345. -/
+theorem IsCPSVBasisOfNormalTensors.exists_blocked_wordTupleSpanTop_one
+    {g : ℕ} {dim : Fin g → ℕ}
+    {A : MPSTensor d D} {B : (j : Fin g) → MPSTensor d (dim j)}
+    (hBNT : IsCPSVBasisOfNormalTensors A (fun j => ⟨dim j, B j⟩)) :
+    ∃ L : ℕ, 0 < L ∧
+      WordTupleSpanTop (fun j => blockTensor (B j) L) 1 := by
+  obtain ⟨L, hL, hSpan⟩ := hBNT.exists_positive_wordTupleSpanTop
+  exact ⟨L, hL, wordTupleSpanTop_blockTensor_one B hSpan⟩
 
 end MPSTensor

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -206,6 +206,9 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
 \begin{theorem}[Simultaneous one-letter span after blocking a BNT]
     \label{thm:cpsv_bnt_blocked_simultaneous_span}
     \lean{MPSTensor.IsCPSVBasisOfNormalTensors.%
+        exists_positive_wordTupleSpanTop}
+    \lean{MPSTensor.wordTupleSpanTop_blockTensor_one}
+    \lean{MPSTensor.IsCPSVBasisOfNormalTensors.%
         exists_blocked_wordTupleSpanTop_one}
     \leanok
     \uses{def:bnt_cpsv, def:blocked_tensor,

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -858,6 +858,35 @@ separate step.
     on the full direct sum, and therefore $P=1$.
 \end{proof}
 
+\begin{theorem}[Pair fusion completeness from a source BNT]%
+    \label{thm:mpdo_pair_fusion_bnt_completeness}
+    \lean{MPOTensor.BNTFusionIsometryFamily.%
+        hasFinalLabelSelectorWords_of_hasBlockSelectorWords}
+    \lean{MPOTensor.BNTFusionIsometryFamily.%
+        fusionIsometry_mul_conjTranspose_eq_one_of_bnt_of_lengthIndependent}
+    \leanok
+    \uses{thm:cpsv_bnt_blocked_simultaneous_span,
+        thm:mpdo_pair_fusion_selector_completeness}
+    Suppose that the labelled tensors in the fusion family form a basis of
+    normal tensors and that the positive trace-power coefficients are
+    independent of the positive chain length.  Then every pair fusion
+    isometry is surjective:
+    \[
+        U_{\alpha,\beta}U_{\alpha,\beta}^{\dagger}=1.
+    \]
+    In particular, final-label selectors and coisometry are conclusions, not
+    additional hypotheses.  This is a derived consequence of the common BNT
+    word span in \cite[lines~317--345]{Cirac2016MPDO_arXiv}, the fusion
+    identity at lines~986--993, and length independence at lines~995--1010.
+\end{theorem}
+\begin{proof}\leanok
+    The basis-of-normal-tensors argument gives a positive common word length
+    at which the labelled word evaluations span the full product matrix
+    algebra.  Choosing the tuple which is the identity in one labelled block
+    and zero in every other block gives common final-label selectors.  Apply
+    Theorem~\ref{thm:mpdo_pair_fusion_selector_completeness}.
+\end{proof}
+
 \begin{theorem}[Left iterated fusion completeness]%
     \label{thm:mpdo_left_fusion_selector_completeness}
     \lean{MPOTensor.BNTFusionIsometryFamily.%

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -588,10 +588,12 @@ $\varepsilon'\ne\varepsilon$.  This is the bond-factor conclusion appearing
 at line~277 of the arXiv:1511.08090 source, but the comparison used here is
 oriented oppositely to the printed convention.
 
-This remains a scope-restricted result.  Neither the simultaneous final-label
-selectors nor one-letter injectivity of every final tensor at the present
-blocking is derived from the assumptions on the fusion-isometry family.  The
-factorization theorem alone permits a rectangular matrix $F_\varepsilon$.
+This remains a scope-restricted result when only the abstract
+fusion-isometry family is supplied.  Once its labelled tensors are linked to
+the source BNT witness, however, the simultaneous final-label selectors are
+derived rather than assumed, as described below.  One-letter injectivity at a
+chosen present blocking remains separate.  The factorization theorem alone
+permits a rectangular matrix $F_\varepsilon$.
 
 There is now a separate numerical squareness result.  Under length
 independence and eventual linear independence,
@@ -642,6 +644,22 @@ zero on the others.  One-letter injectivity and selector coefficients can
 therefore be extracted after the same common blocking, without adding either
 property to the definition of a BNT.
 
+The pre-blocking common word span is exposed by
+\leanid{MPSTensor.IsCPSVBasisOfNormalTensors.%
+exists_positive_wordTupleSpanTop}.  Its selector coefficients bridge directly
+to the fusion-family formulation.  Consequently
+\leanid{MPOTensor.BNTFusionIsometryFamily.%
+fusionIsometry_mul_conjTranspose_eq_one_of_bnt_of_lengthIndependent}
+proves
+\[
+    U_{\alpha,\beta}U_{\alpha,\beta}^{\dagger}=I
+\]
+from the BNT witness and the length-independent fusion data, with no selector
+or coisometry hypothesis.  The selector length supplied by the BNT argument is
+positive; the empty-chain case is not used.  This coisometry proof is a short
+derived argument from the cited source ingredients, not a proof printed
+verbatim in either paper.
+
 For the positive-diagonal fusion family, under the explicit hypothesis that
 identifies the labelled doubled-index tensors with a BNT witness, transport
 through the same positive block length is now formalized by
@@ -650,16 +668,16 @@ exists_positive_block_with_injective_fusion}.  The theorem derives the common
 one-letter span and injectivity of every blocked labelled tensor, and proves
 the blocked conjugation identity, both zipper orientations, and literal
 reconstruction.  Its multiplicity is exactly the dimension of the
-specialized chi space.  The positive-length condition is essential: at block
-length zero the conjugation identity would assert the unproved coisometry
-$U_{\alpha,\beta}U_{\alpha,\beta}^{\dagger}=I$.
+specialized chi space.  The blocking length remains positive.  The empty chain
+is neither needed nor used: although its conjugation formula would reduce to
+coisometry, the equality above is instead derived from positive-length BNT
+selectors.
 
 The remaining construction is therefore narrower.  One must first construct
-this identification from the RFP tensor and the BNT of its vertical canonical
+the identification from the RFP tensor and the BNT of its vertical canonical
 form.  The simultaneous inverse must then be extracted from the blocked span
-and reindexed in the fusion coordinates.  One must derive the coisometry
-rather than assume it, assemble synthesis and analysis maps with their
-biorthogonality, and construct
+and reindexed in the fusion coordinates.  One must assemble the synthesis and
+analysis maps with their biorthogonality and construct
 \leanid{MPOTensor.CompleteZipperFusionFamily}.  The existing printed
 $F$-matrix and pentagon theorem can then be applied to this family.
 


### PR DESCRIPTION
Closes #3934.

Parent task: #3921.

## Mathematical content

- exposes the positive common word span already obtained in the source-BNT blocking argument;
- extracts simultaneous final-label selectors from that product-algebra span;
- derives `U_{α,β} U_{α,β}† = 1` for every pair fusion isometry from the BNT witness and positive-length coefficient independence;
- keeps the selector length strictly positive, so the empty chain is not used.

The coisometry proof is a short derived argument from the BNT separation at arXiv:1606.00608, lines 317–345, the fusion identity at lines 986–993, and length independence at lines 995–1010. It is not presented as a proof printed verbatim in either cited paper.

## Cleanup and blueprint

The former monolithic blocking theorem is split into the pre-blocking common-span theorem and a short transport through physical blocking. The MPO/RFP blueprint and the corresponding paper-gap note now record that selectors and pair coisometry are conclusions once the fusion tensors are linked to the source BNT witness.

## Verification

- `lake build TNLean` (9,399 jobs)
- `lake build TNLean.MPS.MPDO.BNTTripleFusionSeparation`
- `lake exe checkdecls blueprint/lean_decls`
- blueprint PDF generation and visual inspection
- `git diff --check`
- axiom audit: only `propext`, `Classical.choice`, and `Quot.sound`; no new axiom or `sorry`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes formal MPDO fusion completeness arguments and theorem dependencies in core MPS/MPDO paths; mathematical risk is moderate but localized to derived conclusions rather than new axioms.
> 
> **Overview**
> When fusion-family labelled tensors are tied to a **source BNT witness**, the PR derives **pair fusion coisometry** `U_{α,β} U_{α,β}† = 1` from length-independent fusion data—without assuming final-label selectors or coisometry up front.
> 
> **Lean:** `SourceBNTBlocking` exposes **`exists_positive_wordTupleSpanTop`** (positive common word span on unblocked tensors) and keeps blocked one-letter span as a short step via **`wordTupleSpanTop_blockTensor_one`**. **`BNTTripleFusionSeparation`** adds **`hasFinalLabelSelectorWords_of_hasBlockSelectorWords`**, **`fusionIsometry_mul_conjTranspose_eq_one_of_bnt_of_lengthIndependent`**, and switches imports to **`BiCFDerivation.Selectors`** plus **`SourceBNTBlocking`**.
> 
> **Docs:** Blueprint ch10/ch21 and **`cpgsv17_blocked_chi_uniformity.tex`** record that selectors and pair completeness are **conclusions** once tensors link to the BNT witness; selector length stays **strictly positive** (empty chain unused).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c59318c51f71d9d8afee82794805fd28a7c01f98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->