### PR TITLE
feat(MPS/MPDO): assemble blocked complete zipper family

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -486,6 +486,7 @@ import TNLean.MPS.MPDO.BNTFixedFinalUnitarity
 import TNLean.MPS.MPDO.CompleteZipperFusion
 import TNLean.MPS.MPDO.CompleteZipperFusionInverse
 import TNLean.MPS.MPDO.CompleteZipperFusionPentagon
+import TNLean.MPS.MPDO.BlockedCompleteZipper
 import TNLean.MPS.MPDO.CommutingForm
 import TNLean.MPS.MPDO.CommutingFormBridge
 import TNLean.MPS.MPDO.BlockedRFPConstruction

--- a/TNLean/MPS/MPDO/BlockedCompleteZipper.lean
+++ b/TNLean/MPS/MPDO/BlockedCompleteZipper.lean
@@ -1,0 +1,291 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.BlockedBNTFusionIsometries
+import TNLean.MPS.MPDO.BNTTripleFusionSeparation
+import TNLean.MPS.MPDO.CompleteZipperFusionPentagon
+
+/-!
+# Complete zipper data from blocked BNT fusion isometries
+
+After one common positive blocking, the length-independent fusion map
+`U_{α,β}` is a unitary coordinate map between the product bond space and the
+direct sum of the fusion sectors.  Reindexing the product bond space as a pair,
+its adjoint is the synthesis map and the map itself is the analysis map of the
+complete zipper family.  The blocked zipper identities, reconstruction,
+injectivity, and simultaneous block-letter inverse have already been derived
+from the source BNT assumptions.
+
+The empty chain is not used: the common block length is strictly positive.
+
+## References
+
+* arXiv:1606.00608, BNT separation at lines 317--345, equation `Ualphabeta`
+  at lines 986--993, and length independence at lines 995--1010.
+* arXiv:1511.08090, fusion tensors and zipper equations at lines 161--200,
+  simultaneous inverse at lines 269--277, and common blocking at lines
+  427--431.
+-/
+
+open scoped Matrix BigOperators Kronecker
+open Matrix
+
+namespace MPOTensor.BNTFusionIsometryFamily
+
+variable {p : ℕ}
+
+/-- The blocked complete-zipper synthesis map, namely the adjoint of the
+source fusion map with the product bond index written as a pair.
+
+Source: arXiv:1511.08090, fusion tensor orientation at lines 161--163 and
+zipper equations at lines 193--200. -/
+noncomputable def blockedFusionSynthesis
+    {g : ℕ} (Fam : BNTFusionIsometryFamily (Fin g) p)
+    (α β : Fin g) :
+    Matrix (Fin (Fam.bondDim α) × Fin (Fam.bondDim β))
+      ((γ : Fin g) ×
+        (Fin (Fam.chi.dim α β γ) × Fin (Fam.bondDim γ))) ℂ :=
+  fun xy z ↦ (Fam.fusionIsometry α β)ᴴ (finProdFinEquiv xy) z
+
+/-- The blocked complete-zipper analysis map, namely the source fusion map
+with the product bond index written as a pair.
+
+Source: arXiv:1511.08090, left inverses at line 161 and the second zipper
+equation at lines 198--200. -/
+noncomputable def blockedFusionAnalysis
+    {g : ℕ} (Fam : BNTFusionIsometryFamily (Fin g) p)
+    (α β : Fin g) :
+    Matrix ((γ : Fin g) ×
+        (Fin (Fam.chi.dim α β γ) × Fin (Fam.bondDim γ)))
+      (Fin (Fam.bondDim α) × Fin (Fam.bondDim β)) ℂ :=
+  fun z xy ↦ Fam.fusionIsometry α β z (finProdFinEquiv xy)
+
+/-- Pair coisometry gives biorthogonality of the blocked analysis and
+synthesis maps.
+
+Source: arXiv:1511.08090, the fusion-tensor left-inverse relation at line
+161. -/
+theorem blockedFusionAnalysis_mul_blockedFusionSynthesis
+    {g : ℕ} (Fam : BNTFusionIsometryFamily (Fin g) p)
+    (hcoisometry : ∀ α β : Fin g,
+      Fam.fusionIsometry α β * (Fam.fusionIsometry α β)ᴴ = 1)
+    (α β : Fin g) :
+    Fam.blockedFusionAnalysis α β * Fam.blockedFusionSynthesis α β = 1 := by
+  ext x y
+  simp only [blockedFusionAnalysis, blockedFusionSynthesis, Matrix.mul_apply,
+    Matrix.one_apply]
+  have h := congrArg (fun M ↦ M x y) (hcoisometry α β)
+  calc
+    (∑ xy : Fin (Fam.bondDim α) × Fin (Fam.bondDim β),
+      Fam.fusionIsometry α β x (finProdFinEquiv xy) *
+        (Fam.fusionIsometry α β)ᴴ (finProdFinEquiv xy) y) =
+        ∑ q : Fin (Fam.bondDim α * Fam.bondDim β),
+          Fam.fusionIsometry α β x q *
+            (Fam.fusionIsometry α β)ᴴ q y :=
+      Equiv.sum_comp
+        (finProdFinEquiv :
+          (Fin (Fam.bondDim α) × Fin (Fam.bondDim β)) ≃
+            Fin (Fam.bondDim α * Fam.bondDim β))
+        (fun q ↦ Fam.fusionIsometry α β x q *
+          (Fam.fusionIsometry α β)ᴴ q y)
+    _ = if x = y then 1 else 0 := by
+      simpa [Matrix.mul_apply, Matrix.one_apply] using h
+
+/-- The blocked second zipper identity in the paired product-bond
+coordinates of the complete zipper family.
+
+Source: arXiv:1511.08090, equation `zippercondition` at lines 198--200. -/
+theorem blockedFusionAnalysis_mul_pairLetter
+    {g L : ℕ} (Fam : BNTFusionIsometryFamily (Fin g) p)
+    (α β : Fin g) (I J : Fin (MPSTensor.blockPhysDim p L))
+    (hzipper : Fam.fusionIsometry α β *
+          mulTensor (blockTensor (Fam.tensor α) L)
+            (blockTensor (Fam.tensor β) L) I J =
+        Fam.blockedUnweightedDirectSumLetter L α β I J *
+          Fam.fusionIsometry α β) :
+    Fam.blockedFusionAnalysis α β *
+        (∑ K : Fin (MPSTensor.blockPhysDim p L),
+          blockTensor (Fam.tensor α) L I K ⊗ₖ
+            blockTensor (Fam.tensor β) L K J) =
+      Fam.blockedUnweightedDirectSumLetter L α β I J *
+        Fam.blockedFusionAnalysis α β := by
+  ext x y
+  have h := congrArg (fun M ↦ M x (finProdFinEquiv y)) hzipper
+  simp only [blockedFusionAnalysis, Matrix.mul_apply]
+  calc
+    (∑ xy : Fin (Fam.bondDim α) × Fin (Fam.bondDim β),
+      Fam.fusionIsometry α β x (finProdFinEquiv xy) *
+        (∑ K : Fin (MPSTensor.blockPhysDim p L),
+          blockTensor (Fam.tensor α) L I K ⊗ₖ
+            blockTensor (Fam.tensor β) L K J) xy y) =
+        ∑ q : Fin (Fam.bondDim α * Fam.bondDim β),
+          Fam.fusionIsometry α β x q *
+            mulTensor (blockTensor (Fam.tensor α) L)
+              (blockTensor (Fam.tensor β) L) I J q
+                (finProdFinEquiv y) := by
+      simpa [mulTensor_apply] using
+        Equiv.sum_comp
+          (finProdFinEquiv :
+            (Fin (Fam.bondDim α) × Fin (Fam.bondDim β)) ≃
+              Fin (Fam.bondDim α * Fam.bondDim β))
+          (fun q ↦ Fam.fusionIsometry α β x q *
+            mulTensor (blockTensor (Fam.tensor α) L)
+              (blockTensor (Fam.tensor β) L) I J q
+                (finProdFinEquiv y))
+    _ = ∑ z, Fam.blockedUnweightedDirectSumLetter L α β I J x z *
+          Fam.fusionIsometry α β z (finProdFinEquiv y) := by
+      simpa [Matrix.mul_apply] using h
+
+/-- The blocked first zipper identity in the paired product-bond coordinates
+of the complete zipper family.
+
+Source: arXiv:1511.08090, equation `zippercondition` at lines 193--196. -/
+theorem pairLetter_mul_blockedFusionSynthesis
+    {g L : ℕ} (Fam : BNTFusionIsometryFamily (Fin g) p)
+    (α β : Fin g) (I J : Fin (MPSTensor.blockPhysDim p L))
+    (hzipper : mulTensor (blockTensor (Fam.tensor α) L)
+          (blockTensor (Fam.tensor β) L) I J *
+        (Fam.fusionIsometry α β)ᴴ =
+      (Fam.fusionIsometry α β)ᴴ *
+        Fam.blockedUnweightedDirectSumLetter L α β I J) :
+    (∑ K : Fin (MPSTensor.blockPhysDim p L),
+        blockTensor (Fam.tensor α) L I K ⊗ₖ
+          blockTensor (Fam.tensor β) L K J) *
+        Fam.blockedFusionSynthesis α β =
+      Fam.blockedFusionSynthesis α β *
+        Fam.blockedUnweightedDirectSumLetter L α β I J := by
+  ext x y
+  have h := congrArg (fun M ↦ M (finProdFinEquiv x) y) hzipper
+  simp only [blockedFusionSynthesis, Matrix.mul_apply]
+  calc
+    (∑ xy : Fin (Fam.bondDim α) × Fin (Fam.bondDim β),
+      (∑ K : Fin (MPSTensor.blockPhysDim p L),
+        blockTensor (Fam.tensor α) L I K ⊗ₖ
+          blockTensor (Fam.tensor β) L K J) x xy *
+        (Fam.fusionIsometry α β)ᴴ (finProdFinEquiv xy) y) =
+      ∑ q : Fin (Fam.bondDim α * Fam.bondDim β),
+        mulTensor (blockTensor (Fam.tensor α) L)
+            (blockTensor (Fam.tensor β) L) I J
+              (finProdFinEquiv x) q *
+          (Fam.fusionIsometry α β)ᴴ q y := by
+      simpa [mulTensor_apply] using
+        Equiv.sum_comp
+          (finProdFinEquiv :
+            (Fin (Fam.bondDim α) × Fin (Fam.bondDim β)) ≃
+              Fin (Fam.bondDim α * Fam.bondDim β))
+          (fun q ↦ mulTensor (blockTensor (Fam.tensor α) L)
+              (blockTensor (Fam.tensor β) L) I J
+                (finProdFinEquiv x) q *
+            (Fam.fusionIsometry α β)ᴴ q y)
+    _ = ∑ z, (Fam.fusionIsometry α β)ᴴ (finProdFinEquiv x) z *
+          Fam.blockedUnweightedDirectSumLetter L α β I J z y := by
+      simpa [Matrix.mul_apply] using h
+
+/-- The blocked product letter is reconstructed through the fusion support in
+the paired product-bond coordinates.
+
+Source: arXiv:1511.08090, equation `inversegaugeone` at lines 181--191. -/
+theorem pairLetter_eq_blockedFusionSynthesis_mul_directSum_mul_analysis
+    {g L : ℕ} (Fam : BNTFusionIsometryFamily (Fin g) p)
+    (α β : Fin g) (I J : Fin (MPSTensor.blockPhysDim p L))
+    (hreconstruct : mulTensor (blockTensor (Fam.tensor α) L)
+          (blockTensor (Fam.tensor β) L) I J =
+        (Fam.fusionIsometry α β)ᴴ *
+          Fam.blockedUnweightedDirectSumLetter L α β I J *
+            Fam.fusionIsometry α β) :
+    (∑ K : Fin (MPSTensor.blockPhysDim p L),
+      blockTensor (Fam.tensor α) L I K ⊗ₖ
+        blockTensor (Fam.tensor β) L K J) =
+      Fam.blockedFusionSynthesis α β *
+        Fam.blockedUnweightedDirectSumLetter L α β I J *
+          Fam.blockedFusionAnalysis α β := by
+  ext x y
+  have h := congrArg
+    (fun M ↦ M (finProdFinEquiv x) (finProdFinEquiv y)) hreconstruct
+  simpa [blockedFusionSynthesis, blockedFusionAnalysis, mulTensor_apply,
+    Matrix.mul_apply] using h
+
+/-- Length-independent source BNT fusion isometries determine complete zipper
+fusion data after one common positive blocking.
+
+The synthesis matrix is the reindexed adjoint of `U_{α,β}`, the analysis
+matrix is the reindexed `U_{α,β}`, and the fusion multiplicity is the
+dimension of the corresponding chi space.  Injectivity, the simultaneous
+block-letter inverse, and pair coisometry are derived from the BNT witness;
+none is an additional hypothesis.
+
+Source: arXiv:1606.00608, BNT separation at lines 317--345, equation
+`Ualphabeta` at lines 986--993, and length independence at lines 995--1010;
+arXiv:1511.08090, complete zipper data at lines 161--200 and simultaneous
+inverse at lines 269--277. -/
+theorem exists_blocked_completeZipperFusionFamily
+    {g D : ℕ} (Fam : BNTFusionIsometryFamily (Fin g) p)
+    {A : MPSTensor (p * p) D}
+    (hBNT : MPSTensor.IsCPSVBasisOfNormalTensors A
+      (fun γ : Fin g ↦
+        ⟨Fam.bondDim γ, (Fam.tensor γ).toMPSTensor⟩))
+    (c : BNTLabelCoefficientFamily (Fin g))
+    (hχ : c.HasPositiveLengthChiTracePowerForm Fam.chi)
+    (hLI : c.LengthIndependent) :
+    ∃ L : ℕ, 0 < L ∧
+      ∃ Fus : CompleteZipperFusionFamily
+          (Fin g) (MPSTensor.blockPhysDim p L),
+        Fus.bondDim = Fam.bondDim ∧
+        Fus.fusionMultiplicity = Fam.chi.dim ∧
+        (∀ γ, HEq (Fus.tensor γ) (blockTensor (Fam.tensor γ) L)) ∧
+        (∀ α β, HEq (Fus.fusionSynthesis α β)
+          (Fam.blockedFusionSynthesis α β)) ∧
+        ∀ α β, HEq (Fus.fusionAnalysis α β)
+          (Fam.blockedFusionAnalysis α β) := by
+  classical
+  obtain ⟨L, hL, hSpan, hInjective, hFusion⟩ :=
+    Fam.exists_positive_block_with_injective_fusion hBNT c hχ hLI
+  obtain ⟨C, hC⟩ := hSpan.exists_mpo_block_left_inverse
+  have hCoisometry : ∀ α β : Fin g,
+      Fam.fusionIsometry α β * (Fam.fusionIsometry α β)ᴴ = 1 :=
+    fun α β ↦
+      Fam.fusionIsometry_mul_conjTranspose_eq_one_of_bnt_of_lengthIndependent
+        hBNT c hχ hLI α β
+  let Fus : CompleteZipperFusionFamily
+      (Fin g) (MPSTensor.blockPhysDim p L) :=
+    { bondDim := Fam.bondDim
+      bondDim_pos := hBNT.blocks_dim_pos
+      tensor := fun γ ↦ blockTensor (Fam.tensor γ) L
+      tensor_injective := hInjective
+      fusionMultiplicity := Fam.chi.dim
+      fusionSynthesis := Fam.blockedFusionSynthesis
+      fusionAnalysis := Fam.blockedFusionAnalysis
+      analysis_mul_synthesis :=
+        Fam.blockedFusionAnalysis_mul_blockedFusionSynthesis hCoisometry
+      pairLetter_mul_synthesis := fun α β I J ↦ by
+        simpa [blockedUnweightedDirectSumLetter] using
+          Fam.pairLetter_mul_blockedFusionSynthesis α β I J
+            (hFusion α β I J).2.2.1
+      analysis_mul_pairLetter := fun α β I J ↦ by
+        simpa [blockedUnweightedDirectSumLetter] using
+          Fam.blockedFusionAnalysis_mul_pairLetter α β I J
+            (hFusion α β I J).2.1
+      pairLetter_eq_synthesis_mul_directSum_mul_analysis :=
+        fun α β I J ↦ by
+          simpa [blockedUnweightedDirectSumLetter] using
+            Fam.pairLetter_eq_blockedFusionSynthesis_mul_directSum_mul_analysis
+              α β I J (hFusion α β I J).2.2.2
+      blockLeftInverse := C
+      blockLeftInverse_apply := hC }
+  refine ⟨L, hL, Fus, rfl, rfl, ?_, ?_, ?_⟩
+  · intro γ
+    change HEq (blockTensor (Fam.tensor γ) L)
+      (blockTensor (Fam.tensor γ) L)
+    rfl
+  · intro α β
+    change HEq (Fam.blockedFusionSynthesis α β)
+      (Fam.blockedFusionSynthesis α β)
+    rfl
+  · intro α β
+    change HEq (Fam.blockedFusionAnalysis α β)
+      (Fam.blockedFusionAnalysis α β)
+    rfl
+
+end MPOTensor.BNTFusionIsometryFamily

--- a/TNLean/MPS/MPDO/SourceBNTBlocking.lean
+++ b/TNLean/MPS/MPDO/SourceBNTBlocking.lean
@@ -32,7 +32,13 @@ private theorem bondDim_pos_of_mpvState_ne_zero {A : MPSTensor d D} {N : ℕ}
   ext σ
   simp [mpvState, mpv, coeff, Matrix.trace]
 
-private theorem IsCPSVBasisOfNormalTensors.blocks_dim_pos
+/-- Every tensor in a basis of normal tensors has positive bond dimension.
+
+This follows from the eventual linear independence in the source BNT
+definition: each sufficiently long matrix product vector is nonzero.
+
+Source: arXiv:1606.00608, BNT definition at lines 271--274. -/
+theorem IsCPSVBasisOfNormalTensors.blocks_dim_pos
     {g : ℕ} {dim : Fin g → ℕ}
     {A : MPSTensor d D} {B : (j : Fin g) → MPSTensor d (dim j)}
     (hBNT : IsCPSVBasisOfNormalTensors A (fun j => ⟨dim j, B j⟩)) :

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -1431,6 +1431,46 @@ separate step.
     \cite[lines~161, 181--200, and 269--277]{Bultinck2017Anyons}.
 \end{definition}
 
+\begin{theorem}[Complete zipper family from a source BNT]%
+    \label{thm:mpdo_blocked_bnt_complete_zipper}
+    \lean{MPOTensor.BNTFusionIsometryFamily.blockedFusionSynthesis}
+    \lean{MPOTensor.BNTFusionIsometryFamily.blockedFusionAnalysis}
+    \lean{MPOTensor.BNTFusionIsometryFamily.%
+        exists_blocked_completeZipperFusionFamily}
+    \leanok
+    \uses{thm:mpdo_bnt_common_positive_blocked_fusion,
+        thm:mpdo_pair_fusion_bnt_completeness,
+        thm:mpdo_one_letter_simultaneous_inverse,
+        def:mpdo_complete_zipper_fusion_family}
+    Suppose that the labelled tensors of a length-independent fusion family
+    form a source basis of normal tensors.  There is one common positive
+    blocking at which they determine a complete zipper fusion family.  Its
+    bond dimensions are the original labelled bond dimensions, its fusion
+    multiplicities are
+    \[
+        N_{\alpha\beta}^{\gamma}
+          =\dim\chi_{\alpha,\beta,\gamma},
+    \]
+    its synthesis map is the adjoint of $U_{\alpha,\beta}$, and its analysis
+    map is $U_{\alpha,\beta}$, after the canonical identification
+    $\mathbb C^{D_\alpha D_\beta}
+      \cong\mathbb C^{D_\alpha}\otimes\mathbb C^{D_\beta}$.
+    In particular, the two zipper identities, literal reconstruction,
+    injectivity, and the simultaneous block-letter inverse are conclusions;
+    none is an additional hypothesis.
+\end{theorem}
+\begin{proof}\leanok
+    Length independence makes every chi matrix the identity.  Use the common
+    positive BNT blocking for the labelled tensors and transport the fusion
+    equation through it.  Pair completeness gives
+    $U_{\alpha,\beta}U_{\alpha,\beta}^{\dagger}=1$, so analysis followed by
+    synthesis is the identity.  The other three matrix identities are the
+    two transported zipper equations and the reconstruction equation.  The
+    common one-letter product-algebra span supplies both block injectivity and
+    the simultaneous block-letter inverse.  These data are exactly those of
+    Definition~\ref{def:mpdo_complete_zipper_fusion_family}.
+\end{proof}
+
 \begin{theorem}[Printed F-move and inverse]%
     \label{thm:mpdo_complete_zipper_printed_fmove}
     \lean{MPOTensor.CompleteZipperFusionFamily.%

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -673,13 +673,22 @@ is neither needed nor used: although its conjugation formula would reduce to
 coisometry, the equality above is instead derived from positive-length BNT
 selectors.
 
-The remaining construction is therefore narrower.  One must first construct
-the identification from the RFP tensor and the BNT of its vertical canonical
-form.  The simultaneous inverse must then be extracted from the blocked span
-and reindexed in the fusion coordinates.  One must assemble the synthesis and
-analysis maps with their biorthogonality and construct
-\leanid{MPOTensor.CompleteZipperFusionFamily}.  The existing printed
-$F$-matrix and pentagon theorem can then be applied to this family.
+The simultaneous block-letter inverse is extracted from the same one-letter
+product-algebra span by
+\leanid{MPSTensor.WordTupleSpanTop.exists_mpo_block_left_inverse}.  Reindexing
+the product bond space as a pair, the adjoint of $U_{\alpha,\beta}$ is the
+synthesis map and $U_{\alpha,\beta}$ is the analysis map.  These maps and all
+the derived blocked identities are assembled by
+\leanid{MPOTensor.BNTFusionIsometryFamily.%
+exists_blocked_completeZipperFusionFamily}.  Consequently the existing
+printed $F$-matrix and pentagon theorem apply to the length-independent source
+BNT fusion family without an additional injectivity, selector, inverse, or
+coisometry hypothesis.
+
+The remaining upstream construction is different: one must obtain the
+labelled fusion-isometry family and its identification with the BNT of the
+vertical canonical form from the RFP tensor itself.  That Appendix
+C.3--C.4 obligation is not supplied by the complete-zipper assembly above.
 
 Independently of this positive-diagonal specialization, the source-faithful
 complete zipper fusion structure is now formalized by


### PR DESCRIPTION
Closes #3937.

Parent task: #3921.

## Mathematical content

This PR assembles the length-independent source BNT fusion data into the existing `CompleteZipperFusionFamily` after one common positive blocking.

- the synthesis map is the reindexed adjoint `U_{α,β}†`;
- the analysis map is the reindexed `U_{α,β}`;
- the fusion multiplicity is `dim χ_{α,β,γ}` after length independence has proved `χ_{α,β,γ}=1`;
- biorthogonality follows from the derived pair coisometry;
- both zipper orientations and `inversegaugeone` are transported from the positive blocked fusion identities;
- block injectivity and the simultaneous block-letter inverse come from the same one-letter product-algebra span.

The block length is strictly positive. The empty chain is neither used nor needed, and no selector, injectivity, coisometry, or inverse is added as an independent hypothesis. The existing `CompleteZipperFusionFamily.inversePrintedFMatrix_pentagon` theorem therefore applies directly to the constructed family.

## Source boundary

The construction follows arXiv:1606.00608, lines 317–345 and 986–1010, together with the synthesis/analysis orientation and zipper relations of arXiv:1511.08090, lines 161–200 and 269–277. The short matrix reindexing argument is presented as a derived consequence of these ingredients, not as a verbatim proof from the papers.

## Cleanup and blueprint

The positive bond-dimension consequence of the source BNT is exposed as a reusable theorem. Chapter 21 now places the assembled complete-zipper family immediately before the already formalized printed F-move, and the paper-gap note removes the now-discharged assembly obligations while retaining the genuinely upstream Appendix C.3–C.4 construction gap.

## Verification

- `lake build TNLean` (9,401 jobs)
- `lake build TNLean.MPS.MPDO.BlockedCompleteZipper` after rebasing on current main
- blueprint PDF generation and visual inspection (554 pages; new theorem on rendered page 466)
- blueprint–Lean synchronization and `lake exe checkdecls blueprint/lean_decls`
- reader-facing prose and forbidden-token checks
- axiom audit: only `propext`, `Classical.choice`, and `Quot.sound`; no new axiom or `sorry`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Lean formalization and documentation with no runtime, auth, or data paths; risk is limited to proof maintenance and API surface (`blocks_dim_pos` now public).
> 
> **Overview**
> Adds **`TNLean.MPS.MPDO.BlockedCompleteZipper`**, wiring length-independent source BNT fusion maps into the existing **`CompleteZipperFusionFamily`**: reindexed **`U_{α,β}†`** / **`U_{α,β}`** as synthesis/analysis, **`dim χ`** as multiplicities, and proofs that transport biorthogonality, both zipper orientations, reconstruction, injectivity, and the simultaneous block-letter inverse from prior blocked-fusion lemmas—no extra selector or coisometry hypotheses.
> 
> Promotes **`IsCPSVBasisOfNormalTensors.blocks_dim_pos`** in **`SourceBNTBlocking.lean`** from private to a documented public theorem for reuse in the assembly.
> 
> Registers the module in **`TNLean.lean`**. Chapter 21 blueprint gains **Theorem: complete zipper family from a source BNT** (before the printed F-move); the CPGSV17 gap note records that assembly obligations are discharged while the upstream RFP → fusion-isometry / Appendix C.3–C.4 construction remains open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5d9a394ccccbc6060ee3658f2847115af78c060. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->