### PR TITLE
refactor(blueprint): compose tensor-network diagrams from typed atoms

### DIFF
--- a/blueprint/src/Packages/tn_diagrams.py
+++ b/blueprint/src/Packages/tn_diagrams.py
@@ -138,6 +138,8 @@ _UNTYPED_PORT_COMMAND_PATTERN = re.compile(
 )
 _TYPED_PORT_COMMAND_ARITIES = {
     "TN@vconnectports": (2, (0, 1)),
+    "TN@vconnectportshv": (2, (0, 1)),
+    "TN@vconnectportsvh": (2, (0, 1)),
     "TN@pconnectports": (2, (0, 1)),
     "TN@mconnectports": (2, (0, 1)),
     "TN@mcompareports": (2, (0, 1)),
@@ -146,6 +148,9 @@ _TYPED_PORT_COMMAND_ARITIES = {
     "TN@vtraceportsbelow": (4, (0, 1)),
     "TN@vtraceportsabove": (4, (0, 1)),
     "TN@vtraceportsright": (4, (0, 1)),
+    "TN@ptraceportsbelow": (4, (0, 1)),
+    "TN@ptraceportsabove": (4, (0, 1)),
+    "TN@ptraceportsright": (4, (0, 1)),
 }
 
 

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -117,7 +117,7 @@
 }
 
 % Local purification of an MPO tensor: the ket and bra tensors share the
-% ancillary index (curved contraction on the right) and retain their physical
+% ancillary index (straight contraction on the right) and retain their physical
 % and virtual legs.
 \newcommand{\TNMPOLocalPurification}{%
     \begin{tikzpicture}[tn picture]
@@ -126,7 +126,7 @@
         \TN@vleg{tnM}{east}{0.62,0}
         \TN@pleg{tnM}{north}{0,0.58}
         \TN@pleg{tnM}{south}{0,-0.58}
-        \node at (-2.35,-0.34) {$M$};
+        \node[anchor=east] at (-2.50,-0.30) {$M$};
         \node at (-1.20,0) {$=$};
         \TN@tensor{tnA}{(0,0.52)}
         \TN@tensor{tnAc}{(0,-0.52)}
@@ -136,11 +136,12 @@
         \TN@vleg{tnAc}{east}{0.62,0}
         \TN@pleg{tnA}{north}{0,0.48}
         \TN@pleg{tnAc}{south}{0,-0.48}
-        \TN@ppath{
-            (tnA.-35) .. controls (0.88,0.42) and (0.88,-0.42) .. (tnAc.35);}
+        \TN@pport{tnAK}{tnA}{-35}
+        \TN@pport{tnAcK}{tnAc}{35}
+        \TN@pconnectports{tnAK}{tnAcK}
         \node at (-0.28,0.82) {$A$};
         \node at (-0.32,-0.82) {$\overline A$};
-        \node at (0.95,0) {$k$};
+        \node at (0.34,0) {$k$};
     \end{tikzpicture}%
 }
 
@@ -1264,27 +1265,33 @@
         \node (la) at (0,0) {$\alpha$};
         \node (lb) at (0.90,0) {$\beta$};
         \node (lc) at (1.80,0) {$\gamma$};
-        \TN@map{lab}{(0.45,0.78)}{U_{\alpha,\beta}^{\delta}}
-        \TN@map{labc}{(1.12,1.62)}{U_{\delta,\gamma}^{\varepsilon}}
-        \TN@vconnect{la}{north}{lab}{south west}
-        \TN@vconnect{lb}{north}{lab}{south east}
-        \TN@vconnect{lab}{north}{labc}{south west}
-        \TN@vconnect{lc}{north}{labc}{south east}
-        \TN@vpath{(labc.north) -- ++(0,0.42)
-            node[above] {$\varepsilon$}}
+        \TN@cofusionmap{lab}{(0.45,0.78)}{U_{\alpha,\beta}^{\delta}}
+        \TN@cofusionmap{labc}{(1.12,1.62)}{U_{\delta,\gamma}^{\varepsilon}}
+        \TN@vport{laOut}{la}{north}
+        \TN@vport{lbOut}{lb}{north}
+        \TN@vport{lcOut}{lc}{north}
+        \TN@vconnectports{laOut}{labLeft}
+        \TN@vconnectports{lbOut}{labRight}
+        \TN@vconnectports{labIn}{labcLeft}
+        \TN@vconnectports{lcOut}{labcRight}
+        \TN@vopenport{labcIn}{0,0.42}
+        \node[above] at (labcInOpen) {$\varepsilon$};
         \node at (0.90,-0.48) {$((\alpha\beta)\gamma)$};
 
         \node (ra) at (4.20,0) {$\alpha$};
         \node (rb) at (5.10,0) {$\beta$};
         \node (rc) at (6.00,0) {$\gamma$};
-        \TN@map{rbc}{(5.55,0.78)}{U_{\beta,\gamma}^{\eta}}
-        \TN@map{rabc}{(4.88,1.62)}{U_{\alpha,\eta}^{\varepsilon}}
-        \TN@vconnect{rb}{north}{rbc}{south west}
-        \TN@vconnect{rc}{north}{rbc}{south east}
-        \TN@vconnect{ra}{north}{rabc}{south west}
-        \TN@vconnect{rbc}{north}{rabc}{south east}
-        \TN@vpath{(rabc.north) -- ++(0,0.42)
-            node[above] {$\varepsilon$}}
+        \TN@cofusionmap{rbc}{(5.55,0.78)}{U_{\beta,\gamma}^{\eta}}
+        \TN@cofusionmap{rabc}{(4.88,1.62)}{U_{\alpha,\eta}^{\varepsilon}}
+        \TN@vport{raOut}{ra}{north}
+        \TN@vport{rbOut}{rb}{north}
+        \TN@vport{rcOut}{rc}{north}
+        \TN@vconnectports{rbOut}{rbcLeft}
+        \TN@vconnectports{rcOut}{rbcRight}
+        \TN@vconnectports{raOut}{rabcLeft}
+        \TN@vconnectports{rbcIn}{rabcRight}
+        \TN@vopenport{rabcIn}{0,0.42}
+        \node[above] at (rabcInOpen) {$\varepsilon$};
         \node at (5.10,-0.48) {$(\alpha(\beta\gamma))$};
 
         \TN@comparisonarrow[densely dashed, line width=0.4pt]{
@@ -1301,14 +1308,17 @@
         \node (pfLa) at (-4.20,-1.20) {$a$};
         \node (pfLb) at (-3.20,-1.20) {$b$};
         \node (pfLc) at (-2.20,-1.20) {$c$};
-        \TN@map{pfLab}{(-3.70,-0.34)}{X^{e}_{ab,\mu}}
-        \TN@map{pfLroot}{(-3.00,0.62)}{X^{d}_{ec,\nu}}
-        \TN@vconnect{pfLa}{north}{pfLab}{south west}
-        \TN@vconnect{pfLb}{north}{pfLab}{south east}
-        \TN@vconnect{pfLab}{north}{pfLroot}{south west}
-        \TN@vconnect{pfLc}{north}{pfLroot}{south east}
-        \TN@vpath{(pfLroot.north) -- ++(0,0.42)
-            node[above] {$d$}}
+        \TN@cofusionmap{pfLab}{(-3.70,-0.34)}{X^{e}_{ab,\mu}}
+        \TN@cofusionmap{pfLroot}{(-3.00,0.62)}{X^{d}_{ec,\nu}}
+        \TN@vport{pfLaOut}{pfLa}{north}
+        \TN@vport{pfLbOut}{pfLb}{north}
+        \TN@vport{pfLcOut}{pfLc}{north}
+        \TN@vconnectports{pfLaOut}{pfLabLeft}
+        \TN@vconnectports{pfLbOut}{pfLabRight}
+        \TN@vconnectports{pfLabIn}{pfLrootLeft}
+        \TN@vconnectports{pfLcOut}{pfLrootRight}
+        \TN@vopenport{pfLrootIn}{0,0.42}
+        \node[above] at (pfLrootInOpen) {$d$};
 
         \node at (-0.65,-0.12) {$=$};
         \node at (0.15,-0.12) {$\displaystyle\sum_{f,\lambda,\sigma}$};
@@ -1318,14 +1328,17 @@
         \node (pfRa) at (2.75,-1.20) {$a$};
         \node (pfRb) at (3.75,-1.20) {$b$};
         \node (pfRc) at (4.75,-1.20) {$c$};
-        \TN@map{pfRbc}{(4.25,-0.34)}{X^{f}_{bc,\lambda}}
-        \TN@map{pfRroot}{(3.45,0.62)}{X^{d}_{af,\sigma}}
-        \TN@vconnect{pfRb}{north}{pfRbc}{south west}
-        \TN@vconnect{pfRc}{north}{pfRbc}{south east}
-        \TN@vconnect{pfRa}{north}{pfRroot}{south west}
-        \TN@vconnect{pfRbc}{north}{pfRroot}{south east}
-        \TN@vpath{(pfRroot.north) -- ++(0,0.42)
-            node[above] {$d$}}
+        \TN@cofusionmap{pfRbc}{(4.25,-0.34)}{X^{f}_{bc,\lambda}}
+        \TN@cofusionmap{pfRroot}{(3.45,0.62)}{X^{d}_{af,\sigma}}
+        \TN@vport{pfRaOut}{pfRa}{north}
+        \TN@vport{pfRbOut}{pfRb}{north}
+        \TN@vport{pfRcOut}{pfRc}{north}
+        \TN@vconnectports{pfRbOut}{pfRbcLeft}
+        \TN@vconnectports{pfRcOut}{pfRbcRight}
+        \TN@vconnectports{pfRaOut}{pfRrootLeft}
+        \TN@vconnectports{pfRbcIn}{pfRrootRight}
+        \TN@vopenport{pfRrootIn}{0,0.42}
+        \node[above] at (pfRrootInOpen) {$d$};
     \end{tikzpicture}%
 }
 
@@ -1628,7 +1641,7 @@
         \TN@vleg{bfiG}{east}{0.48,0}
         \TN@pleg{bfiG}{north}{0,0.42}
         \TN@pleg{bfiG}{south}{0,-0.42}
-        \node at (3.94,-0.36) {$M_\gamma$};
+        \node[anchor=west] at (3.88,-0.66) {$M_\gamma$};
         \node at (3.46,0.20) {$i$};
         \node at (3.46,-0.92) {$j$};
     \end{tikzpicture}%
@@ -1984,30 +1997,28 @@
 
 \newcommand{\TNRFPKrausIsometry}{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensor{rfkA}{(0,0)}
-        \TN@tensor{rfkB}{(1.20,0)}
-        \TN@vleg{rfkA}{west}{-0.60,0}
-        \TN@vconnect{rfkA}{east}{rfkB}{west}
-        \TN@vleg{rfkB}{east}{0.60,0}
-        \TN@pleg{rfkA}{north}{0,0.46}
-        \TN@pleg{rfkB}{north}{0,0.46}
-        \TN@label{rfkA.north}{(0,0.70)}{i_1}
-        \TN@label{rfkB.north}{(0,0.70)}{i_2}
+        \TN@mpssite{rfkA}{(0,0)}{}
+        \TN@mpssite{rfkB}{(1.20,0)}{}
+        \TN@vopenport{rfkAW}{-\TN@virtualleglen,0}
+        \TN@vconnectports{rfkAE}{rfkBW}
+        \TN@vopenport{rfkBE}{\TN@virtualleglen,0}
+        \TN@popenport{rfkAN}{0,\TN@physicalleglen}
+        \TN@popenport{rfkBN}{0,\TN@physicalleglen}
+        \TN@label{rfkANOpen}{(0,0.24)}{i_1}
+        \TN@label{rfkBNOpen}{(0,0.24)}{i_2}
         \node[anchor=east] at (-0.14,-0.28) {$A$};
         \node[anchor=west] at (1.34,-0.28) {$A$};
         \node at (2.50,0) {$=$};
         \node at (3.25,0) {$\displaystyle\sum_j$};
-        \TN@tensor{rfkC}{(4.30,0)}
-        \TN@vleg{rfkC}{west}{-0.55,0}
-        \TN@vleg{rfkC}{east}{0.55,0}
+        \TN@mpssite{rfkC}{(4.30,0)}{}
+        \TN@openhorizontalports{rfkC}
         \node[anchor=west] at (4.44,-0.28) {$A$};
-        \TN@map[inner xsep=10pt, inner ysep=2pt]{rfkV}{(4.30,0.90)}{V}
-        \TN@pconnect{rfkC}{north}{rfkV}{south}
+        \TN@physicalsplitmap[inner xsep=10pt, inner ysep=2pt]
+            {rfkV}{(4.30,0.90)}{V}
+        \TN@pconnectports{rfkCN}{rfkVTrunk}
         \node[anchor=west] at (4.40,0.46) {$j$};
-        \TN@pnorthport{rfkVNLeft}{rfkV}{0.28}
-        \TN@pnorthport{rfkVNRight}{rfkV}{0.72}
-        \TN@popenport{rfkVNLeft}{0,0.34}
-        \TN@popenport{rfkVNRight}{0,0.34}
+        \TN@popenport{rfkVLeft}{0,0.34}
+        \TN@popenport{rfkVRight}{0,0.34}
         \node at (4.10,1.62) {$i_1$};
         \node at (4.50,1.62) {$i_2$};
     \end{tikzpicture}%
@@ -2017,24 +2028,24 @@
 % legs of the contracted pair recovers the single tensor.
 \newcommand{\TNRFPKrausIsometryReverse}{%
     \begin{tikzpicture}[tn picture]
-        \TN@tensor{rfrA}{(0,0)}
-        \TN@tensor{rfrB}{(1.20,0)}
-        \TN@vleg{rfrA}{west}{-0.60,0}
-        \TN@vconnect{rfrA}{east}{rfrB}{west}
-        \TN@vleg{rfrB}{east}{0.60,0}
+        \TN@mpssite{rfrA}{(0,0)}{}
+        \TN@mpssite{rfrB}{(1.20,0)}{}
+        \TN@vopenport{rfrAW}{-\TN@virtualleglen,0}
+        \TN@vconnectports{rfrAE}{rfrBW}
+        \TN@vopenport{rfrBE}{\TN@virtualleglen,0}
         \node[anchor=east] at (-0.14,-0.28) {$A$};
         \node[anchor=west] at (1.34,-0.28) {$A$};
-        \TN@map[minimum width=1.62cm]{rfrV}{(0.60,0.90)}{V^\dagger}
-        \TN@ppath{(rfrA.north) -- (rfrA.north |- rfrV.south)}
-        \TN@ppath{(rfrB.north) -- (rfrB.north |- rfrV.south)}
-        \TN@pleg{rfrV}{north}{0,0.34}
+        \TN@physicalmergemap[minimum width=1.62cm]
+            {rfrV}{(0.60,0.90)}{V^\dagger}
+        \TN@pconnectports{rfrAN}{rfrVLeft}
+        \TN@pconnectports{rfrBN}{rfrVRight}
+        \TN@popenport{rfrVTrunk}{0,0.34}
         \node[anchor=west] at (0.70,1.36) {$j$};
         \node at (2.50,0) {$=$};
-        \TN@tensor{rfrC}{(3.55,0)}
-        \TN@vleg{rfrC}{west}{-0.55,0}
-        \TN@vleg{rfrC}{east}{0.55,0}
-        \TN@pleg{rfrC}{north}{0,0.46}
-        \TN@label{rfrC.north}{(0,0.70)}{j}
+        \TN@mpssite{rfrC}{(3.55,0)}{}
+        \TN@openhorizontalports{rfrC}
+        \TN@popenport{rfrCN}{0,\TN@physicalleglen}
+        \TN@label{rfrCNOpen}{(0,0.24)}{j}
         \node[anchor=west] at (3.69,-0.28) {$A$};
     \end{tikzpicture}%
 }
@@ -2053,19 +2064,21 @@
         \node at (1.25,0) {$=$};
         \TN@insertion[label=above:$X$]{icfX}{(2.20,0)}
         \TN@insertion[label=above:$\sqrt\Lambda$]{icfL}{(3.20,0)}
-        \TN@map{icfU}{(4.30,0.75)}{U}
+        \TN@bondpairmap{icfU}{(4.30,0.75)}{U}
         \TN@insertion[label=above:$X^{-1}$]{icfXi}{(5.40,0)}
-        \TN@vleg{icfX}{west}{-0.55,0}
-        \TN@vconnect{icfX}{east}{icfL}{west}
-        \TN@vsouthport{icfUSLeft}{icfU}{0.18}
-        \TN@vsouthport{icfUSRight}{icfU}{0.82}
-        \TN@vpath[rounded corners=3pt]{(icfL.east)
-        -| (icfUSLeft)}
-        \TN@vpath[rounded corners=3pt]{(icfUSRight)
-        |- (icfXi.west)}
-        \TN@vleg{icfXi}{east}{0.55,0}
-        \TN@pleg{icfU}{north}{0,0.34}
-        \node at ($(icfU.north)+(0,0.56)$) {$i$};
+        \TN@vport{icfXW}{icfX}{west}
+        \TN@vport{icfXE}{icfX}{east}
+        \TN@vport{icfLW}{icfL}{west}
+        \TN@vport{icfLE}{icfL}{east}
+        \TN@vport{icfXiW}{icfXi}{west}
+        \TN@vport{icfXiE}{icfXi}{east}
+        \TN@vopenport{icfXW}{-0.55,0}
+        \TN@vconnectports{icfXE}{icfLW}
+        \TN@vconnectportshv{icfLE}{icfULeft}
+        \TN@vconnectportsvh{icfURight}{icfXiW}
+        \TN@vopenport{icfXiE}{0.55,0}
+        \TN@popenport{icfUPhysical}{0,0.34}
+        \node at ($(icfUPhysicalOpen)+(0,0.22)$) {$i$};
     \end{tikzpicture}%
 }
 
@@ -2081,43 +2094,43 @@
         \TN@label{icbA.north}{(0,0.70)}{i}
         \node[anchor=east] at (-0.14,-0.28) {$A$};
         \node at (1.25,0) {$=$};
-        \TN@insertion[label=above:$X$]{icbX}{(2.20,0)}
+        \TN@sectorgauge{icbX}{(2.20,0)}{X}
         \TN@insertion[label=above:$\sqrt\Lambda$]{icbL}{(3.20,0)}
-        \TN@map{icbU}{(4.30,0.75)}{U}
-        \TN@insertion[label=above:$X^{-1}$]{icbXi}{(5.40,0)}
-        \TN@vleg{icbX}{west}{-0.55,0}
-        \TN@vconnect{icbX}{east}{icbL}{west}
-        \TN@vsouthport{icbUSLeft}{icbU}{0.18}
-        \TN@vsouthport{icbUSRight}{icbU}{0.82}
-        \TN@vpath[rounded corners=3pt]{(icbL.east)
-        -| (icbUSLeft)}
-        \TN@vpath[rounded corners=3pt]{(icbUSRight)
-        |- (icbXi.west)}
-        \TN@vleg{icbXi}{east}{0.55,0}
-        \TN@pleg{icbU}{north}{0,0.34}
-        \node at ($(icbU.north)+(0,0.56)$) {$i$};
-        \TN@vpath{(1.65,-0.62) -- (5.95,-0.62)}
-        \TN@vpath{(1.65,-1.02) -- (5.95,-1.02)}
-        \node[anchor=east] at (1.56,-0.62) {$j$};
-        \node[anchor=east] at (1.56,-1.02) {$q$};
-        \TN@vpath{(icbX.south) -- (2.20,-1.02)}
-        \TN@vpath{(icbL.south) -- (3.20,-0.62)}
-        \TN@vpath{(4.16,0) -- (4.16,-0.62)}
-        \TN@vpath{(icbXi.south) -- (5.40,-1.02)}
+        \TN@bondpairmap{icbU}{(4.30,0.75)}{U}
+        \TN@inverseSectorgauge{icbXi}{(5.40,0)}{X^{-1}}
+        \TN@vport{icbLW}{icbL}{west}
+        \TN@vport{icbLE}{icbL}{east}
+        \TN@vopenport{icbXW}{-0.55,0}
+        \TN@vconnectports{icbXE}{icbLW}
+        \TN@vconnectportshv{icbLE}{icbULeft}
+        \TN@vconnectportsvh{icbURight}{icbXiW}
+        \TN@vopenport{icbXiE}{0.55,0}
+        \TN@popenport{icbUPhysical}{0,0.34}
+        \node at ($(icbUPhysicalOpen)+(0,0.22)$) {$i$};
+        \TN@vbus{icbJ}{(1.65,-0.62)}{(5.95,-0.62)}{j}
+        \TN@vparallelbus{icbQ}{icbJ}{-\TN@buspitch}{q}
+        \TN@vport{icbLBus}{icbL}{south}
+        \TN@vbusprojecttap{icbJ}{icbJX}{icbXBlock}
+        \TN@vbusprojecttap{icbQ}{icbQX}{icbXCopy}
+        \TN@vconnectports{icbXBlock}{icbJX}
+        \TN@vconnectports{icbXCopy}{icbQX}
+        \TN@vbusprojecttap{icbJ}{icbJL}{icbLBus}
+        \TN@vconnectports{icbLBus}{icbJL}
+        \TN@vterminal{icbUBlock}{(icbULeft |- icbL)}
+        \TN@anonymousjunction{(icbUBlock)}
+        \TN@vbusprojecttap{icbJ}{icbJU}{icbUBlock}
+        \TN@vconnectports{icbUBlock}{icbJU}
+        \TN@vbusprojecttap{icbJ}{icbJXi}{icbXiBlock}
+        \TN@vbusprojecttap{icbQ}{icbQXi}{icbXiCopy}
+        \TN@vconnectports{icbXiBlock}{icbJXi}
+        \TN@vconnectports{icbXiCopy}{icbQXi}
         \TN@component{icbMu}{(2.70,-1.60)}{\mu}
         \TN@vnorthport{icbMuNLeft}{icbMu}{0.15}
         \TN@vnorthport{icbMuNRight}{icbMu}{0.85}
-        \TN@vpath{(icbMuNLeft) -- (2.58,-0.62)}
-        \TN@vpath{(icbMuNRight) -- (2.82,-1.02)}
-        \TN@anonymousjunction{(2.20,-0.62)}
-        \TN@anonymousjunction{(2.20,-1.02)}
-        \TN@anonymousjunction{(3.20,-0.62)}
-        \TN@anonymousjunction{(4.16,0)}
-        \TN@anonymousjunction{(4.16,-0.62)}
-        \TN@anonymousjunction{(5.40,-0.62)}
-        \TN@anonymousjunction{(5.40,-1.02)}
-        \TN@anonymousjunction{(2.58,-0.62)}
-        \TN@anonymousjunction{(2.82,-1.02)}
+        \TN@vbusprojecttap{icbJ}{icbJMu}{icbMuNLeft}
+        \TN@vbusprojecttap{icbQ}{icbQMu}{icbMuNRight}
+        \TN@vconnectports{icbMuNLeft}{icbJMu}
+        \TN@vconnectports{icbMuNRight}{icbQMu}
     \end{tikzpicture}%
 }
 
@@ -2331,9 +2344,9 @@
         \TN@pleg{hcfK}{south}{0,-0.50}
         \node[anchor=east] at (-0.14,-0.28) {$K$};
         \node at (1.30,0) {$=$};
-        \TN@insertion[label=above:$X$]{hcfX}{(2.55,0)}
+        \TN@sectorgauge{hcfX}{(2.55,0)}{X}
         \TN@tensor{hcfC}{(3.75,0)}
-        \TN@insertion[label=above:$X^{-1}$]{hcfXi}{(4.95,0)}
+        \TN@inverseSectorgauge{hcfXi}{(4.95,0)}{X^{-1}}
         \TN@vleg{hcfX}{west}{-0.55,0}
         \TN@vconnect{hcfX}{east}{hcfC}{west}
         \TN@vconnect{hcfC}{east}{hcfXi}{west}
@@ -2341,19 +2354,21 @@
         \TN@pleg{hcfC}{north}{0,0.50}
         \TN@pleg{hcfC}{south}{0,-0.50}
         \node[anchor=west] at (3.89,0.32) {$\mathcal K$};
-        \TN@vpath{(1.95,-1.10) -- (5.55,-1.10)}
-        \TN@vpath{(1.95,-1.50) -- (5.55,-1.50)}
-        \node[anchor=east] at (1.86,-1.10) {$j$};
-        \node[anchor=east] at (1.86,-1.50) {$q$};
-        \TN@vpath{(hcfX.south) -- (2.55,-1.50)}
+        \TN@vbus{hcfJ}
+            {($(hcfX.center)+(-0.60,-\TN@busoffset)$)}
+            {($(hcfXi.center)+(0.60,-\TN@busoffset)$)}{j}
+        \TN@vparallelbus{hcfQ}{hcfJ}{-\TN@buspitch}{q}
+        \TN@vbusprojecttap{hcfJ}{hcfJX}{hcfXBlock}
+        \TN@vbusprojecttap{hcfQ}{hcfQX}{hcfXCopy}
+        \TN@vconnectports{hcfXBlock}{hcfJX}
+        \TN@vconnectports{hcfXCopy}{hcfQX}
         \TN@vport{hcfCBlock}{hcfC}{-45}
-        \TN@vpath[rounded corners=3pt]{(hcfCBlock) -- (4.15,-0.40) -- (4.15,-1.10)}
-        \TN@vpath{(hcfXi.south) -- (4.95,-1.50)}
-        \TN@anonymousjunction{(2.55,-1.10)}
-        \TN@anonymousjunction{(2.55,-1.50)}
-        \TN@anonymousjunction{(4.15,-1.10)}
-        \TN@anonymousjunction{(4.95,-1.10)}
-        \TN@anonymousjunction{(4.95,-1.50)}
+        \TN@vbusprojecttap{hcfJ}{hcfJC}{hcfCBlock}
+        \TN@vconnectports{hcfCBlock}{hcfJC}
+        \TN@vbusprojecttap{hcfJ}{hcfJXi}{hcfXiBlock}
+        \TN@vbusprojecttap{hcfQ}{hcfQXi}{hcfXiCopy}
+        \TN@vconnectports{hcfXiBlock}{hcfJXi}
+        \TN@vconnectports{hcfXiCopy}{hcfQXi}
     \end{tikzpicture}%
 }
 
@@ -2376,9 +2391,9 @@
         \node at (-0.42,-0.90) {$K$};
         \node at (1.15,0) {$=$};
         \begin{scope}[xshift=2.30cm]
-            \TN@insertion[label=above:$X$]{bijX}{(0.55,0)}
+            \TN@sectorgauge{bijX}{(0.55,0)}{X}
             \TN@tensor{bijC}{(1.75,0)}
-            \TN@insertion[label=above:$X^{-1}$]{bijXi}{(2.95,0)}
+            \TN@inverseSectorgauge{bijXi}{(2.95,0)}{X^{-1}}
             \TN@vleg{bijX}{west}{-0.50,0}
             \TN@vconnect{bijX}{east}{bijC}{west}
             \TN@vconnect{bijC}{east}{bijXi}{west}
@@ -2390,37 +2405,45 @@
             \TN@pconnect{bijIt}{south}{bijC}{north}
             \TN@vleg{bijIt}{north}{0,0.42}
             \node at (1.02,1.32) {$K^{-1}$};
-            \TN@vpath{(0,-1.10) -- (3.50,-1.10)}
-            \TN@vpath{(0,-1.50) -- (3.50,-1.50)}
-            \node[anchor=east] at (-0.09,-1.10) {$j$};
-            \node[anchor=east] at (-0.09,-1.50) {$q$};
-            \TN@vpath{(bijX.south) -- (0.55,-1.50)}
-            \TN@vpath{(bijC.south) -- (1.75,-1.10)}
-            \TN@vpath{(bijXi.south) -- (2.95,-1.50)}
-            \TN@anonymousjunction{(0.55,-1.10)}
-            \TN@anonymousjunction{(0.55,-1.50)}
-            \TN@anonymousjunction{(1.75,-1.10)}
-            \TN@anonymousjunction{(2.95,-1.10)}
-            \TN@anonymousjunction{(2.95,-1.50)}
+            \TN@vbus{bijJ}
+                {($(bijX.center)+(-0.55,-\TN@busoffset)$)}
+                {($(bijXi.center)+(0.55,-\TN@busoffset)$)}{j}
+            \TN@vparallelbus{bijQ}{bijJ}{-\TN@buspitch}{q}
+            \TN@vport{bijCBlock}{bijC}{south}
+            \TN@vbusprojecttap{bijJ}{bijJX}{bijXBlock}
+            \TN@vbusprojecttap{bijQ}{bijQX}{bijXCopy}
+            \TN@vconnectports{bijXBlock}{bijJX}
+            \TN@vconnectports{bijXCopy}{bijQX}
+            \TN@vbusprojecttap{bijJ}{bijJC}{bijCBlock}
+            \TN@vconnectports{bijCBlock}{bijJC}
+            \TN@vbusprojecttap{bijJ}{bijJXi}{bijXiBlock}
+            \TN@vbusprojecttap{bijQ}{bijQXi}{bijXiCopy}
+            \TN@vconnectports{bijXiBlock}{bijJXi}
+            \TN@vconnectports{bijXiCopy}{bijQXi}
         \end{scope}
         \node at (6.25,0) {$=$};
         \begin{scope}[xshift=6.70cm]
-            \TN@insertion[label=above:$X$]{bijPX}{(0.55,0)}
-            \TN@insertion[label=above:$X^{-1}$]{bijPXi}{(2.95,0)}
+            \TN@sectorgauge{bijPX}{(0.55,0)}{X}
+            \TN@inverseSectorgauge{bijPXi}{(2.95,0)}{X^{-1}}
             \TN@vleg{bijPX}{west}{-0.50,0}
             \TN@vleg{bijPXi}{east}{0.50,0}
             \TN@vpath[rounded corners=3pt]{(bijPX.east) -- (1.05,0) -- (1.05,1.00) -- (1.35,1.00)}
             \TN@vpath[rounded corners=3pt]{(bijPXi.west) -- (2.45,0) -- (2.45,1.00) -- (2.15,1.00)}
-            \TN@vpath{(1.75,1.50) -- (1.75,-1.10)}
-            \TN@vpath{(0,-1.10) -- (3.50,-1.10)}
-            \TN@vpath{(0,-1.50) -- (3.50,-1.50)}
-            \TN@vpath{(bijPX.south) -- (0.55,-1.50)}
-            \TN@vpath{(bijPXi.south) -- (2.95,-1.50)}
-            \TN@anonymousjunction{(0.55,-1.10)}
-            \TN@anonymousjunction{(0.55,-1.50)}
-            \TN@anonymousjunction{(1.75,-1.10)}
-            \TN@anonymousjunction{(2.95,-1.10)}
-            \TN@anonymousjunction{(2.95,-1.50)}
+            \TN@vbus{bijPJ}
+                {($(bijPX.center)+(-0.55,-\TN@busoffset)$)}
+                {($(bijPXi.center)+(0.55,-\TN@busoffset)$)}{}
+            \TN@vparallelbus{bijPQ}{bijPJ}{-\TN@buspitch}{}
+            \TN@vbusprojecttap{bijPJ}{bijPJX}{bijPXBlock}
+            \TN@vbusprojecttap{bijPQ}{bijPQX}{bijPXCopy}
+            \TN@vconnectports{bijPXBlock}{bijPJX}
+            \TN@vconnectports{bijPXCopy}{bijPQX}
+            \TN@vbusprojecttap{bijPJ}{bijPJXi}{bijPXiBlock}
+            \TN@vbusprojecttap{bijPQ}{bijPQXi}{bijPXiCopy}
+            \TN@vconnectports{bijPXiBlock}{bijPJXi}
+            \TN@vconnectports{bijPXiCopy}{bijPQXi}
+            \TN@vterminal{bijPBlockTop}{(1.75,1.50)}
+            \TN@vbusprojecttap{bijPJ}{bijPJBlock}{bijPBlockTop}
+            \TN@vconnectports{bijPBlockTop}{bijPJBlock}
         \end{scope}
     \end{tikzpicture}%
 }
@@ -2681,7 +2704,7 @@
     \begin{tikzpicture}[tn picture]
         \TN@tensor{tnL}{(0,0)}
         \TN@tensor{tnR}{(1.60,0)}
-        \TN@insertion[label=below:$#3$]{tnY}{(0.80,-0.78)}
+        \TN@insertion[label=above:$#3$]{tnY}{(0.80,-0.78)}
         \TN@pleg{tnL}{north}{0,\TN@physleglen}
         \TN@pleg{tnR}{north}{0,\TN@physleglen}
         \TN@uplabel{tnL}{\TN@physlabeloff}{#1}
@@ -2891,10 +2914,10 @@
         \begin{scope}[xshift=2.30cm]
             \TN@tensor{absBt}{(0,0)}
             \TN@pleg{absBt}{north}{0,0.44}
-            \TN@insertion[label=left:$Z_{e_1}^{\pm1}$]{absL}{(-0.70,0)}
-            \TN@insertion[label=right:$Z_{e_2}^{\pm1}$]{absR}{(0.70,0)}
-            \TN@insertion[label=below:$Z_{e_3}^{\pm1}$]{absDL}{(-0.48,-0.60)}
-            \TN@insertion[label=below:$Z_{e_4}^{\pm1}$]{absDR}{(0.48,-0.60)}
+            \TN@insertion[label=above:$Z_{e_1}^{\pm1}$]{absL}{(-0.70,0)}
+            \TN@insertion[label=above:$Z_{e_2}^{\pm1}$]{absR}{(0.70,0)}
+            \TN@insertion[label=left:$Z_{e_3}^{\pm1}$]{absDL}{(-0.48,-0.60)}
+            \TN@insertion[label=right:$Z_{e_4}^{\pm1}$]{absDR}{(0.48,-0.60)}
             \TN@vleg{absL}{west}{-0.28,0}
             \TN@vconnect{absL}{east}{absBt}{west}
             \TN@vconnect{absBt}{east}{absR}{west}
@@ -3164,11 +3187,11 @@
         \path[tn region complement, fill=none]
             (0.3,0.3) -- (1.2,0.3) -- (1.2,0.8) -- (1.7,0.8) --
             (1.7,1.7) -- (0.3,1.7) -- cycle;
-        \node[tn region label complement] at (1.48,1.35) {$U$};
         \node[tn region label selected] at (0.75,0.55) {$2\times3$};
         \node[tn region label secondary] at (1.20,1.25) {$3\times2$};
-        \node at (0.98,-0.55)
-        {$U=\bigcup_j C_j,\quad C_j\cong 2\times3\ \mathrm{or}\ 3\times2$};
+        \node[align=center] at (0.98,-0.68)
+        {$U=\bigcup_j C_j,$\\[-1pt]
+        $C_j\cong 2\times3\ \mathrm{or}\ 3\times2$};
     \end{tikzpicture}%
 }
 
@@ -3196,7 +3219,6 @@
             \TN@pepsNormalSquareLattice
             \TN@pepsNormalRegionR
             \TN@pepsNormalSingleSiteDifference
-            \node at (1.00,0.98) {$R$};
         \end{scope}
         \node at (2.85,2.00) {$\subset$};
         \begin{scope}[xshift=3.55cm]
@@ -3204,8 +3226,8 @@
             \TN@pepsNormalSquareLattice
             \TN@pepsNormalRegionS
             \TN@pepsNormalSingleSiteDifference
-            \node at (1.00,0.98) {$S=R\cup\{v\}$};
         \end{scope}
+        \node at (4.55,0.52) {$S=R\cup\{v\}$};
     \end{tikzpicture}%
 }
 
@@ -3255,7 +3277,6 @@
                 \TN@pepsNormalSquareLattice
                 \TN@pepsNormalRegionR
                 \TN@pepsNormalSingleSiteDifference
-                \node at (1.00,0.98) {$R$};
             \end{scope}
             \node at (2.85,2.00) {$\subset$};
             \begin{scope}[xshift=3.55cm]
@@ -3263,9 +3284,9 @@
                 \TN@pepsNormalSquareLattice
                 \TN@pepsNormalRegionS
                 \TN@pepsNormalSingleSiteDifference
-                \node at (1.00,0.98) {$S=R\cup\{v\}$};
             \end{scope}
-            \node at (2.85,0.98) {one-site comparison};
+            \node at (4.55,0.52) {$S=R\cup\{v\}$};
+            \node at (2.85,0.20) {one-site comparison};
         \end{scope}
     \end{tikzpicture}%
 }
@@ -3280,10 +3301,10 @@
         \begin{scope}[xshift=2.35cm]
             \TN@tensor{tiA}{(0,0)}
             \TN@pleg{tiA}{45}{0.34,0.34}
-            \TN@insertion[label=left:$X$]{tiXL}{(-0.76,0)}
-            \TN@insertion[label=right:$X^{-1}$]{tiXR}{(0.76,0)}
-            \TN@insertion[label=below:$Y$]{tiYD}{(0,-0.76)}
-            \TN@insertion[label=above:$Y^{-1}$]{tiYU}{(0,0.76)}
+            \TN@insertion[label=above:$X$]{tiXL}{(-0.76,0)}
+            \TN@insertion[label=above:$X^{-1}$]{tiXR}{(0.76,0)}
+            \TN@insertion[label=left:$Y$]{tiYD}{(0,-0.76)}
+            \TN@insertion[label=left:$Y^{-1}$]{tiYU}{(0,0.76)}
             \TN@vleg{tiXL}{west}{-0.24,0}
             \TN@vconnect{tiXL}{east}{tiA}{west}
             \TN@vconnect{tiA}{east}{tiXR}{west}
@@ -3521,10 +3542,10 @@
         \TN@vconnectports{vbS}{vbZSN}
         \TN@vconnectports{vbZSS}{vbSOpen}
         \TN@pconnectports{vbP}{vbPOpen}
-        \node at (-0.52,0.28) {$c_{v,e_1}$};
-        \node at (0.52,0.28) {$c_{v,e_2}$};
-        \node at (0.44,0.5) {$c_{v,e_3}$};
-        \node at (0.44,-0.5) {$c_{v,e_4}$};
+        \node at (-0.58,0.28) {$c_{v,e_1}$};
+        \node at (0.62,-0.28) {$c_{v,e_2}$};
+        \node at (-0.42,0.60) {$c_{v,e_3}$};
+        \node at (0.42,-0.60) {$c_{v,e_4}$};
         \node at (2.35,0) {$\displaystyle\prod_{e \ni v} c_{v,e} = 1$};
     \end{tikzpicture}%
 }

--- a/docs/slides/tn_library_dark.tex
+++ b/docs/slides/tn_library_dark.tex
@@ -121,15 +121,15 @@
     \TN@label{sltnBtwoNOpen}{(0,0.22)}{i_2}
     \TN@label{sltnBlastNOpen}{(0,0.22)}{i_{#3}}
     \node[tn label] at (4.20,0) {$\cdots$};
-    \TN@annotationpath[decorate,
-      decoration={brace, mirror, amplitude=4pt}]{
-      (1.72,-0.58) -- (5.55,-0.58)
-      node[midway, below=5pt, tn label] {$#3$ copies};}
+    \TN@annotationterminal{sltnBraceL}{(1.72,-0.58)}
+    \TN@annotationterminal{sltnBraceR}{(5.55,-0.58)}
+    \TN@spanbracebelow[text=dimwhite]
+      {sltnBraceL}{sltnBraceR}{#3\text{ copies}}
   \end{tikzpicture}%
 }
 
 \newcommand{\SlideTNMixedTransfer}[4]{%
-  \begin{tikzpicture}[tn picture]
+  \begin{tikzpicture}[tn picture, scale=0.92]
     \TN@state{sltnRho}{(-1.15,0)}{#3}
     \TN@veastport{sltnRhoTop}{sltnRho}{0.25}
     \TN@veastport{sltnRhoBottom}{sltnRho}{0.75}
@@ -154,7 +154,7 @@
     }
     \node[tn label] at (2.28,0.72) {$\cdots$};
     \node[tn label] at (2.28,-0.72) {$\cdots$};
-    \node[tn label, anchor=west] at (5.35,0)
+    \node[tn label, anchor=west] at (5.20,0)
       {$\mathcal F^{#4}_{#1,#2}(#3)$};
   \end{tikzpicture}%
 }

--- a/docs/tn_diagram_grammar.md
+++ b/docs/tn_diagram_grammar.md
@@ -109,10 +109,57 @@ constructions.
 Every contraction joins two registered ports of the same type. Virtual trace
 closures join named ports through `\TN@vtraceportsbelow`,
 `\TN@vtraceportsabove`, or `\TN@vtraceportsright`; physical trace closures use
-the corresponding physical construction. An open index ends at an explicitly
-named typed terminal; it does not end at a numerical point chosen near a tensor
-or map. A red insertion divides an index line into two contractions ending on
-the insertion.
+`\TN@ptraceportsbelow`, `\TN@ptraceportsabove`, or
+`\TN@ptraceportsright`. An open index ends at an explicitly named typed
+terminal; it does not end at a numerical point chosen near a tensor or map. A
+red insertion divides an index line into two contractions ending on the
+insertion.
+
+The library supplies four standard open interfaces. The construction
+`\TN@openhorizontalports` exposes the west and east virtual indices,
+`\TN@openvverticalports` exposes two vertical virtual indices,
+`\TN@openpverticalports` exposes the north and south physical indices, and
+`\TN@openmpoports` combines the first and third interfaces. These interfaces
+use the common virtual and physical leg lengths. Consequently two occurrences
+of the same local tensor have the same boundary geometry.
+
+Trivalent maps are typed by their mathematical domain and codomain. The maps
+`\TN@splitmap` and `\TN@mergemap` have only virtual ports. The maps
+`\TN@physicalsplitmap` and `\TN@physicalmergemap` have only physical ports.
+The construction `\TN@bondpairmap` has two virtual half-bonds and one physical
+index. Each physical split or merge uses the same `Trunk`, `Left`, and `Right`
+interface. Thus blocking a physical Hilbert space, fusing virtual sectors, and
+realizing a physical site from two virtual half-bonds cannot be confused by a
+change of labels or by reflecting the map.
+
+The action tensors of an MPO on an MPS are constructed by `\TN@actionmap` and
+`\TN@coactionmap`. Their three virtual ports are named `MPO`, `StateIn`, and
+`StateOut`, corresponding to the blocks \(a\), \(x\), and \(y\) in
+\(V_{ax}^{y,i}\). The glyph remains the ordinary trivalent linear-map box;
+the additional names record the module roles of its indices.
+
+A canonical-form gauge \(X_{j,q}\) is constructed by `\TN@sectorgauge`.
+Besides the horizontal bond ports `W` and `E`, it has distinct virtual ports
+`Block` and `Copy` for the indices \(j\) and \(q\). Attaching these ports
+separately to parallel sector buses preserves the distinction between the two
+indices. The reflected construction `\TN@inverseSectorgauge` retains these
+port roles while reversing their planar order for \(X_{j,q}^{-1}\).
+
+A sector index which passes through several factors is represented by
+`\TN@vbus`. Its endpoints and every contraction point are named virtual ports.
+A parallel sector index is obtained from it by `\TN@vparallelbus`, which
+inherits the same horizontal extent and applies a common signed displacement.
+A tap may be placed at a fixed relative position by `\TN@vbustap`, or projected
+from a port of the attached tensor by `\TN@vbusprojecttap`. Projection makes
+the attachment depend on the tensor placement rather than on a second copy of
+its horizontal coordinate.
+
+Orthogonal virtual contractions use `\TN@vconnectportshv` or
+`\TN@vconnectportsvh`; the suffix records the order of the horizontal and
+vertical segments. A span annotation such as \(n\), \(\geq \ell\), or
+\(\geq \ell'\) uses `\TN@spanbraceabove` or `\TN@spanbracebelow`. Such a brace
+is an annotation and never denotes an additional index. Its endpoints are
+named by `\TN@annotationterminal`, which deliberately carries no index type.
 
 Tensor products are written with $\otimes$. A horizontal line never means
 mere adjacency or tensor product. The construction `\TN@factorpair` displays
@@ -226,17 +273,29 @@ contracted index, the contraction is drawn explicitly instead.
 The library provides `\TN@mpssite`, `\TN@mposite`, and `\TN@pepssite` for
 local tensor sites; `\TN@doublelayer` for the local contraction in a transfer
 construction; `\TN@operatorstate` for a density matrix or operator with paired
-system ports; `\TN@splitmap`, `\TN@mergemap`, and `\TN@fusionmap` for oriented
-trivalent maps; `\TN@squarelatticepatch` and `\TN@squarepepspatch` for finite
-square lattices; and `\TN@openMPSword`, `\TN@openMPOword`, and
-`\TN@closedMPOword` for standard finite words. These constructions determine
-the conventional index directions once. Each local site atom declares stable
-boundary ports and draws no open stub. The corresponding
+system ports; `\TN@splitmap`, `\TN@mergemap`, `\TN@physicalsplitmap`,
+`\TN@physicalmergemap`, `\TN@bondpairmap`, and `\TN@fusionmap` for the typed
+trivalent maps; `\TN@vbus` for a virtual sector line;
+`\TN@squarelatticepatch` and `\TN@squarepepspatch` for finite square lattices;
+and `\TN@openMPSword`, `\TN@openMPOword`, and `\TN@closedMPOword` for standard
+finite words. MPS and MPO words are declared by distinct constructors, since
+an MPS site has one physical index whereas an MPO site has two. These
+constructions determine the conventional index directions once. Each local
+site atom declares stable boundary ports and draws no open stub. The
+corresponding
 `\TN@mpssiteWithOpenLegs`, `\TN@mpositeWithOpenLegs`,
 `\TN@pepssiteWithOpenLegs`, and `\TN@doublelayerWithOpenLegs` motifs add named
 free endpoints when a complete standalone object is required. A complete
 figure should compose these units rather than choose the same leg positions
 independently at each occurrence.
+
+The common lengths `\TN@layerpitch`, `\TN@virtualleglen`,
+`\TN@physicalleglen`, `\TN@traceclearance`, `\TN@busoffset`, and
+`\TN@buspitch` fix the standard separations. The two
+branch positions of a trivalent map are fixed by
+`\TN@branchfirstfraction` and `\TN@branchsecondfraction`. A theorem-level figure
+may scale the whole picture, but should not reproduce one of these distances
+as a local numerical constant.
 
 The web blueprint renders the same complete figure commands as cached SVG
 images. A new chapter-facing command therefore also requires an argument

--- a/tex/tn/tn_core.tex
+++ b/tex/tn/tn_core.tex
@@ -10,7 +10,7 @@
 % region boundaries are separate semantic marks and do not represent indices.
 % Dashed curves indicate grouping, a basis change, or an identified periodic
 % boundary.  Tensor labels do not change the glyph used for the tensor.
-\usetikzlibrary{backgrounds,calc,fit}
+\usetikzlibrary{backgrounds,calc,decorations.pathreplacing,fit}
 
 \tikzset{
     % Theme slots.  These are the only styles a light or dark document should
@@ -148,9 +148,23 @@
         execute at begin picture={\global\advance\TN@pictureid by 1\relax}
     }}
 
-\def\TN@physleglen{0.42}
+% Universal layout parameters.  Complete diagrams may scale the surrounding
+% picture, but constructions should use these names rather than repeat the
+% corresponding numerical distances.  A layer pitch is the displacement of
+% one layer from the midline; paired layers therefore lie two pitches apart.
+\def\TN@layerpitch{0.50}
+\def\TN@virtualleglen{0.60}
+\def\TN@physicalleglen{0.42}
+\def\TN@traceclearance{0.42}
+\def\TN@busoffset{1.10}
+\def\TN@buspitch{0.40}
+\def\TN@branchfirstfraction{0.28}
+\def\TN@branchsecondfraction{0.72}
+
+% Compatibility names used by the established library constructions.
+\def\TN@physleglen{\TN@physicalleglen}
 \def\TN@physlabeloff{0.68}
-\def\TN@doublelayersep{0.50}
+\def\TN@doublelayersep{\TN@layerpitch}
 \def\TN@chainsep{1.45}
 \def\TN@chainright{4.20}
 \def\TN@chainellipsisx{2.82}
@@ -289,6 +303,12 @@
     \TN@registerport{#1}{morphism}%
 }
 
+% Annotation endpoints carry no tensor index type.  They name only the support
+% of a brace or other explanatory mark.
+\newcommand{\TN@annotationterminal}[2]{%
+    \coordinate (#1) at #2;%
+}
+
 % A port may also lie at a specified fraction of a boundary segment.  This is
 % useful for a box carrying several indices on the same side.
 \newcommand{\TN@betweenport}[4]{%
@@ -414,6 +434,20 @@
     \TN@pconnectpoints[#1]{#2}{#3}%
 }
 
+% Orthogonal contractions retain typed endpoints.  The order in the command
+% name records whether the first segment is horizontal or vertical.
+\newcommand{\TN@vconnectportshv}[3][]{%
+    \TN@assertporttype{#2}{virtual}%
+    \TN@assertporttype{#3}{virtual}%
+    \draw[tn virtual wire,rounded corners=3pt,#1] (#2) -| (#3);%
+}
+
+\newcommand{\TN@vconnectportsvh}[3][]{%
+    \TN@assertporttype{#2}{virtual}%
+    \TN@assertporttype{#3}{virtual}%
+    \draw[tn virtual wire,rounded corners=3pt,#1] (#2) |- (#3);%
+}
+
 \newcommand{\TN@mconnectports}[3][]{%
     \TN@assertporttype{#2}{morphism}%
     \TN@assertporttype{#3}{morphism}%
@@ -505,6 +539,31 @@
         -| ($(#3)+(#4,-#5)$) -- ++(-#4,0) -- (#3);%
 }
 
+% Physical trace closures have the same compositional interface and geometry
+% as virtual trace closures, but their endpoints and strokes retain physical
+% index type.  The last two arguments are the horizontal and vertical
+% clearances.
+\newcommand{\TN@ptraceportsbelow}[5][]{%
+    \TN@assertporttype{#2}{physical}%
+    \TN@assertporttype{#3}{physical}%
+    \draw[tn physical trace,#1] (#2) -- ++(-#4,0) -- ++(0,-#5)
+        -| ($(#3)+(#4,0)$) -- (#3);%
+}
+
+\newcommand{\TN@ptraceportsabove}[5][]{%
+    \TN@assertporttype{#2}{physical}%
+    \TN@assertporttype{#3}{physical}%
+    \draw[tn physical trace,#1] (#2) -- ++(-#4,0) -- ++(0,#5)
+        -| ($(#3)+(#4,0)$) -- (#3);%
+}
+
+\newcommand{\TN@ptraceportsright}[5][]{%
+    \TN@assertporttype{#2}{physical}%
+    \TN@assertporttype{#3}{physical}%
+    \draw[tn physical trace,#1] (#2) -- ++(0,#5)
+        -| ($(#3)+(#4,-#5)$) -- ++(-#4,0) -- (#3);%
+}
+
 % General paths remain available for closures and lattice edges whose route is
 % not a single segment.  Complete contractions should still use the anchored
 % connect commands above whenever both endpoint objects are named.
@@ -552,6 +611,21 @@
     \draw[tn annotation,#1] #2;%
 }
 
+% A span brace is an annotation, not an index line.  Its endpoints may be any
+% named coordinates, including typed terminals, since the brace contracts no
+% tensor indices.
+\newcommand{\TN@spanbraceabove}[4][]{%
+    \draw[tn annotation,decorate,
+        decoration={brace,amplitude=3pt,raise=2pt},#1]
+        (#2) -- (#3) node[midway,above=5pt] {$#4$};%
+}
+
+\newcommand{\TN@spanbracebelow}[4][]{%
+    \draw[tn annotation,decorate,
+        decoration={brace,amplitude=3pt,raise=2pt,mirror},#1]
+        (#2) -- (#3) node[midway,below=5pt] {$#4$};%
+}
+
 \newcommand{\TN@openwire}[5][]{%
     \draw[#2,#1] (#3.#4) -- ++(#5);%
 }
@@ -585,13 +659,15 @@
 
 % Trace closures are index lines, not region boundaries.
 \newcommand{\TN@vtracebelow}[3]{%
-    \draw[tn virtual trace] (#1.west) -- ++(-0.42,0) -- ++(0,-#3)
-        -| ($(#2.east)+(0.42,0)$) -- (#2.east);%
+    \draw[tn virtual trace] (#1.west) -- ++(-\TN@traceclearance,0)
+        -- ++(0,-#3) -| ($(#2.east)+(\TN@traceclearance,0)$)
+        -- (#2.east);%
 }
 
 \newcommand{\TN@vtraceabove}[3]{%
-    \draw[tn virtual trace] (#1.west) -- ++(-0.42,0) -- ++(0,#3)
-        -| ($(#2.east)+(0.42,0)$) -- (#2.east);%
+    \draw[tn virtual trace] (#1.west) -- ++(-\TN@traceclearance,0)
+        -- ++(0,#3) -| ($(#2.east)+(\TN@traceclearance,0)$)
+        -- (#2.east);%
 }
 
 \newcommand{\TN@vtraceright}[3]{%
@@ -600,7 +676,7 @@
 
 \newcommand{\TN@ptraceright}[3]{%
     \draw[tn physical trace] (#1.north) -- ++(0,#3)
-        -| ($(#1.center)!0.5!(#2.center)+(0.42,0)$)
+        -| ($(#1.center)!0.5!(#2.center)+(\TN@traceclearance,0)$)
         |- ($(#2.south)+(0,-#3)$) -- (#2.south);%
 }
 

--- a/tex/tn/tn_library.tex
+++ b/tex/tn/tn_library.tex
@@ -36,6 +36,27 @@
     \TN@pverticalports{#1}%
 }
 
+% A canonical-form gauge X_{j,q} has two independent sector indices in
+% addition to its horizontal bond indices.  The sector legs meet the glyph at
+% distinct boundary ports: Block carries j and Copy carries q.  In particular,
+% attaching both ports to parallel buses never identifies the two buses.
+\newcommand{\TN@sectorgauge}[3]{%
+    \TN@insertion[label=above:$#3$]{#1}{#2}%
+    \TN@horizontalports{#1}%
+    \TN@vport{#1Block}{#1}{240}%
+    \TN@vport{#1Copy}{#1}{300}%
+}
+
+% The inverse gauge reflects the two lower legs while retaining their roles.
+% This is the planar order in the canonical-form figures: Copy is the
+% lower-left port and Block is the lower-right port of X^{-1}.
+\newcommand{\TN@inverseSectorgauge}[3]{%
+    \TN@insertion[label=above:$#3$]{#1}{#2}%
+    \TN@horizontalports{#1}%
+    \TN@vport{#1Block}{#1}{300}%
+    \TN@vport{#1Copy}{#1}{240}%
+}
+
 \newcommand{\TN@vfactor}[3]{%
     \TN@factor{#1}{#2}{#3}%
     \TN@vverticalports{#1}%
@@ -52,6 +73,29 @@
 \newcommand{\TN@vjunctionatom}[2]{%
     \TN@junction{#1}{#2}%
     \TN@cardinalports{#1}%
+}
+
+% Standard open interfaces.  These helpers extend an already declared port
+% bundle by the repository-wide semantic stub lengths; they do not redeclare
+% the boundary ports themselves.
+\newcommand{\TN@openhorizontalports}[2][]{%
+    \TN@vopenport[#1]{#2W}{-\TN@virtualleglen,0}%
+    \TN@vopenport[#1]{#2E}{\TN@virtualleglen,0}%
+}
+
+\newcommand{\TN@openvverticalports}[2][]{%
+    \TN@vopenport[#1]{#2N}{0,\TN@virtualleglen}%
+    \TN@vopenport[#1]{#2S}{0,-\TN@virtualleglen}%
+}
+
+\newcommand{\TN@openpverticalports}[2][]{%
+    \TN@popenport[#1]{#2N}{0,\TN@physicalleglen}%
+    \TN@popenport[#1]{#2S}{0,-\TN@physicalleglen}%
+}
+
+\newcommand{\TN@openmpoports}[2][]{%
+    \TN@openhorizontalports[#1]{#2}%
+    \TN@openpverticalports[#1]{#2}%
 }
 
 % An operator or density matrix has paired system ports on each side.  The
@@ -85,9 +129,8 @@
 % The corresponding standalone motif has named ports at all three free ends.
 \newcommand{\TN@mpssiteWithOpenLegs}[3]{%
     \TN@mpssite{#1}{#2}{#3}%
-    \TN@vopenport{#1W}{-0.60,0}%
-    \TN@vopenport{#1E}{0.60,0}%
-    \TN@popenport{#1N}{0,0.46}%
+    \TN@openhorizontalports{#1}%
+    \TN@popenport{#1N}{0,\TN@physicalleglen}%
 }
 
 % An MPO or MPDO tensor has west and east virtual ports and north and south
@@ -108,10 +151,7 @@
 % The standalone MPO/MPDO motif has named ports at all four free ends.
 \newcommand{\TN@mpositeWithOpenLegs}[3]{%
     \TN@mposite{#1}{#2}{#3}%
-    \TN@vopenport{#1W}{-0.60,0}%
-    \TN@vopenport{#1E}{0.60,0}%
-    \TN@popenport{#1N}{0,0.46}%
-    \TN@popenport{#1S}{0,-0.46}%
+    \TN@openmpoports{#1}%
 }
 
 % A PEPS vertex has a named north-east physical port.  Lattice-specific
@@ -161,10 +201,8 @@
 % The standalone doubled layer exposes named ports at its four virtual ends.
 \newcommand{\TN@doublelayerWithOpenLegs}[3]{%
     \TN@doublelayer{#1}{#2}{#3}%
-    \TN@vopenport{#1UW}{-0.60,0}%
-    \TN@vopenport{#1UE}{0.60,0}%
-    \TN@vopenport{#1DW}{-0.60,0}%
-    \TN@vopenport{#1DE}{0.60,0}%
+    \TN@openhorizontalports{#1U}%
+    \TN@openhorizontalports{#1D}%
 }
 
 % Two displayed tensor-product factors.  Tensor product is written explicitly;
@@ -179,16 +217,15 @@
 
 % A left-to-right fusion map with one trunk and two ordered branches.  The
 % atom retains the semantic rounded blue map glyph; its interface is named by
-% role rather than by absolute coordinates.  Top and Bottom are available for
-% additional physical indices when the same map participates in a larger
-% contraction.
+% role rather than by absolute coordinates.  LabelTop and LabelBottom are
+% annotation coordinates, not tensor indices.
 \newcommand{\TN@splitmap}[4][]{%
     \TN@map[#1]{#2}{#3}{#4}%
     \TN@vport{#2Mid}{#2}{west}%
-    \TN@vport{#2Up}{#2}{north east}%
-    \TN@vport{#2Down}{#2}{south east}%
-    \TN@pport{#2Top}{#2}{north}%
-    \TN@pport{#2Bottom}{#2}{south}%
+    \TN@veastport{#2Up}{#2}{\TN@branchfirstfraction}%
+    \TN@veastport{#2Down}{#2}{\TN@branchsecondfraction}%
+    \coordinate (#2LabelTop) at (#2.north);%
+    \coordinate (#2LabelBottom) at (#2.south);%
 }
 
 % The mirror image of \TN@splitmap: two ordered branches merge into one
@@ -198,10 +235,10 @@
 \newcommand{\TN@mergemap}[4][]{%
     \TN@map[#1]{#2}{#3}{#4}%
     \TN@vport{#2Mid}{#2}{east}%
-    \TN@vport{#2Up}{#2}{north west}%
-    \TN@vport{#2Down}{#2}{south west}%
-    \TN@pport{#2Top}{#2}{north}%
-    \TN@pport{#2Bottom}{#2}{south}%
+    \TN@vwestport{#2Up}{#2}{\TN@branchfirstfraction}%
+    \TN@vwestport{#2Down}{#2}{\TN@branchsecondfraction}%
+    \coordinate (#2LabelTop) at (#2.north);%
+    \coordinate (#2LabelBottom) at (#2.south);%
 }
 
 % A vertical fusion map has two ordered incoming sector ports and one outgoing
@@ -212,6 +249,8 @@
     \TN@vport{#2Left}{#2}{north west}%
     \TN@vport{#2Right}{#2}{north east}%
     \TN@vport{#2Out}{#2}{south}%
+    \coordinate (#2LabelTop) at (#2.north);%
+    \coordinate (#2LabelBottom) at (#2.south);%
 }
 
 \newcommand{\TN@cofusionmap}[4][]{%
@@ -219,6 +258,53 @@
     \TN@vport{#2In}{#2}{north}%
     \TN@vport{#2Left}{#2}{south west}%
     \TN@vport{#2Right}{#2}{south east}%
+    \coordinate (#2LabelTop) at (#2.north);%
+    \coordinate (#2LabelBottom) at (#2.south);%
+}
+
+% An action tensor V_ax^y is a trivalent virtual map with role names inherited
+% from the MPO action: an MPO block a acts on an incoming state block x and
+% produces an outgoing state block y.  Its reflected partner has the same
+% interface names.
+\newcommand{\TN@actionmap}[4][]{%
+    \TN@splitmap[#1]{#2}{#3}{#4}%
+    \TN@vterminal{#2StateOut}{(#2Mid)}%
+    \TN@vterminal{#2MPO}{(#2Up)}%
+    \TN@vterminal{#2StateIn}{(#2Down)}%
+}
+
+\newcommand{\TN@coactionmap}[4][]{%
+    \TN@mergemap[#1]{#2}{#3}{#4}%
+    \TN@vterminal{#2StateOut}{(#2Mid)}%
+    \TN@vterminal{#2MPO}{(#2Up)}%
+    \TN@vterminal{#2StateIn}{(#2Down)}%
+}
+
+% A physical splitter has one incoming physical index and two ordered outgoing
+% physical indices.  The merger is its vertically reflected interface.  These
+% atoms cover blocking and refinement isometries without assigning a virtual
+% type to any physical Hilbert-space index.
+\newcommand{\TN@physicalsplitmap}[4][]{%
+    \TN@map[#1]{#2}{#3}{#4}%
+    \TN@pport{#2Trunk}{#2}{south}%
+    \TN@pnorthport{#2Left}{#2}{\TN@branchfirstfraction}%
+    \TN@pnorthport{#2Right}{#2}{\TN@branchsecondfraction}%
+}
+
+\newcommand{\TN@physicalmergemap}[4][]{%
+    \TN@map[#1]{#2}{#3}{#4}%
+    \TN@psouthport{#2Left}{#2}{\TN@branchfirstfraction}%
+    \TN@psouthport{#2Right}{#2}{\TN@branchsecondfraction}%
+    \TN@pport{#2Trunk}{#2}{north}%
+}
+
+% A local isometry from two ordered virtual half-bonds to one physical site.
+% The role names, rather than the geometric anchors, form its public interface.
+\newcommand{\TN@bondpairmap}[4][]{%
+    \TN@map[#1]{#2}{#3}{#4}%
+    \TN@vsouthport{#2Left}{#2}{\TN@branchfirstfraction}%
+    \TN@vsouthport{#2Right}{#2}{\TN@branchsecondfraction}%
+    \TN@pport{#2Physical}{#2}{north}%
 }
 
 % A Stinespring isometry carries a system index from west to east and one
@@ -249,19 +335,29 @@
 % A one-dimensional tensor atom carries named boundary ports.  The centre port
 % is used only to place labels; every index line starts or ends at a boundary
 % port.
-\newcommand{\TN@declareWordTensor}[2]{%
-    \TN@tensor{#1}{#2}
-    \TN@mpoports{#1}
+\newcommand{\TN@declareMPSWordTensor}[2]{%
+    \TN@mpssite{#1}{#2}{}%
     \coordinate (#1C) at (#1.center);%
 }
 
+\newcommand{\TN@declareMPOWordTensor}[2]{%
+    \TN@mposite{#1}{#2}{}%
+    \coordinate (#1C) at (#1.center);%
+}
+
+% Compatibility name for existing complete MPDO figures.  New constructions
+% choose the MPS or MPO signature explicitly.
+\newcommand{\TN@declareWordTensor}[2]{%
+    \TN@declareMPOWordTensor{#1}{#2}%
+}
+
 \newcommand{\TN@openMPSword}[4]{%
-    \TN@declareWordTensor{#1L}{(0,0)}
-    \TN@declareWordTensor{#1M}{(\TN@chainsep,0)}
-    \TN@declareWordTensor{#1R}{(\TN@chainright,0)}
-    \TN@popenport{#1LN}{0,\TN@physleglen}
-    \TN@popenport{#1MN}{0,\TN@physleglen}
-    \TN@popenport{#1RN}{0,\TN@physleglen}
+    \TN@declareMPSWordTensor{#1L}{(0,0)}
+    \TN@declareMPSWordTensor{#1M}{(\TN@chainsep,0)}
+    \TN@declareMPSWordTensor{#1R}{(\TN@chainright,0)}
+    \TN@popenport{#1LN}{0,\TN@physicalleglen}
+    \TN@popenport{#1MN}{0,\TN@physicalleglen}
+    \TN@popenport{#1RN}{0,\TN@physicalleglen}
     \TN@label{#1LN}{(0,\TN@physlabeloff)}{#2}
     \TN@label{#1RN}{(0,\TN@physlabeloff)}{#3}
     \TN@vopenport{#1LW}{-0.8,0}
@@ -274,12 +370,12 @@
 }
 
 \newcommand{\TN@blockedMPSword}[3]{%
-    \TN@declareWordTensor{#1L}{(0,0)}
-    \TN@declareWordTensor{#1M}{(\TN@chainsep,0)}
-    \TN@declareWordTensor{#1R}{(\TN@chainright,0)}
-    \TN@popenport{#1LN}{0,\TN@physleglen}
-    \TN@popenport{#1MN}{0,\TN@physleglen}
-    \TN@popenport{#1RN}{0,\TN@physleglen}
+    \TN@declareMPSWordTensor{#1L}{(0,0)}
+    \TN@declareMPSWordTensor{#1M}{(\TN@chainsep,0)}
+    \TN@declareMPSWordTensor{#1R}{(\TN@chainright,0)}
+    \TN@popenport{#1LN}{0,\TN@physicalleglen}
+    \TN@popenport{#1MN}{0,\TN@physicalleglen}
+    \TN@popenport{#1RN}{0,\TN@physicalleglen}
     \TN@label{#1LN}{(0,\TN@physlabeloff)}{#2}
     \TN@label{#1RN}{(0,\TN@physlabeloff)}{#3}
     \TN@vconnectports{#1LE}{#1MW}
@@ -290,15 +386,12 @@
 }
 
 \newcommand{\TN@openMPOword}[6]{%
-    \TN@declareWordTensor{#1L}{(0,0)}
-    \TN@declareWordTensor{#1M}{(\TN@chainsep,0)}
-    \TN@declareWordTensor{#1R}{(\TN@chainright,0)}
-    \TN@popenport{#1LN}{0,\TN@physleglen}
-    \TN@popenport{#1LS}{0,-\TN@physleglen}
-    \TN@popenport{#1MN}{0,\TN@physleglen}
-    \TN@popenport{#1MS}{0,-\TN@physleglen}
-    \TN@popenport{#1RN}{0,\TN@physleglen}
-    \TN@popenport{#1RS}{0,-\TN@physleglen}
+    \TN@declareMPOWordTensor{#1L}{(0,0)}
+    \TN@declareMPOWordTensor{#1M}{(\TN@chainsep,0)}
+    \TN@declareMPOWordTensor{#1R}{(\TN@chainright,0)}
+    \TN@openpverticalports{#1L}
+    \TN@openpverticalports{#1M}
+    \TN@openpverticalports{#1R}
     \TN@label{#1LN}{(0,\TN@physlabeloff)}{#2}
     \TN@label{#1LS}{(0,-\TN@physlabeloff)}{#3}
     \TN@label{#1RN}{(0,\TN@physlabeloff)}{#4}
@@ -314,15 +407,12 @@
 
 % Trace-closed MPO word with open ket and bra indices.
 \newcommand{\TN@closedMPOword}[1]{%
-    \TN@declareWordTensor{#1L}{(0,0)}
-    \TN@declareWordTensor{#1M}{(1.15,0)}
-    \TN@declareWordTensor{#1R}{(3.05,0)}
-    \TN@popenport{#1LN}{0,0.46}
-    \TN@popenport{#1LS}{0,-0.46}
-    \TN@popenport{#1MN}{0,0.46}
-    \TN@popenport{#1MS}{0,-0.46}
-    \TN@popenport{#1RN}{0,0.46}
-    \TN@popenport{#1RS}{0,-0.46}
+    \TN@declareMPOWordTensor{#1L}{(0,0)}
+    \TN@declareMPOWordTensor{#1M}{(1.15,0)}
+    \TN@declareMPOWordTensor{#1R}{(3.05,0)}
+    \TN@openpverticalports{#1L}
+    \TN@openpverticalports{#1M}
+    \TN@openpverticalports{#1R}
     \TN@vconnectports{#1LE}{#1MW}
     \TN@vopenport{#1ME}{0.50,0}
     \TN@vopenport{#1RW}{-0.50,0}
@@ -332,11 +422,42 @@
 
 % MPO site with the ket and bra indices closed by a physical trace.
 \newcommand{\TN@tracedMPOSite}[2]{%
-    \TN@declareWordTensor{#1}{#2}
-    \TN@vopenport{#1W}{-0.60,0}
-    \TN@vopenport{#1E}{0.60,0}
-    \TN@ptracepath{(#1N) |- ($(#1C)+(0.42,0.52)$)
-        -- ($(#1C)+(0.42,-0.52)$) -| (#1S)}%
+    \TN@declareMPOWordTensor{#1}{#2}
+    \TN@openhorizontalports{#1}
+    \TN@ptraceportsright{#1N}{#1S}{\TN@traceclearance}{\TN@physicalleglen}%
+}
+
+% ---------- Sector buses ----------
+
+% A sector bus is a virtual index line with named endpoints.  Taps are virtual
+% contraction ports placed at relative positions along the bus, so arbitrary
+% port-bearing atoms can be attached without reconstructing the line.
+\newcommand{\TN@vbus}[5][]{%
+    \TN@vterminal{#2L}{#3}%
+    \TN@vterminal{#2R}{#4}%
+    \TN@vconnectports[#1]{#2L}{#2R}%
+    \if\relax\detokenize{#5}\relax\else
+        \node[tn label, anchor=east] at ($(#2L)+(-0.10,0)$) {$#5$};%
+    \fi
+}
+
+% A parallel bus inherits the horizontal extent of a previously declared bus.
+% Its displacement is signed, so the same construction applies above or below.
+\newcommand{\TN@vparallelbus}[5][]{%
+    \TN@vbus[#1]{#2}{($(#3L)+(0,#4)$)}{($(#3R)+(0,#4)$)}{#5}%
+}
+
+\newcommand{\TN@vbustap}[3]{%
+    \TN@vterminal{#2}{($(#1L)!#3!(#1R)$)}%
+    \TN@anonymousjunction{(#2)}%
+}
+
+% Projecting a named point onto a bus aligns a tap with an attached atom
+% without repeating its horizontal coordinate in the complete diagram.
+\newcommand{\TN@vbusprojecttap}[3]{%
+    \TN@assertporttype{#3}{virtual}%
+    \TN@vterminal{#2}{($(#1L)!(#3)!(#1R)$)}%
+    \TN@anonymousjunction{(#2)}%
 }
 
 % ---------- Repeated finite constructions ----------
@@ -535,14 +656,14 @@
         (0.3,1.3) -- (1.2,1.3) -- (1.2,1.8) -- (1.7,1.8) --
         (1.7,2.7) -- (0.3,2.7) -- cycle;
     \end{scope}
-    \node[tn region label selected] at (0.75,2.0) {$R$};%
+    \node[tn region label selected] at (0.75,2.25) {$R$};%
 }
 
 \newcommand{\TN@pepsNormalRegionS}{%
     \begin{scope}[on background layer]
         \path[tn region selected] (0.3,1.3) rectangle (1.7,2.7);
     \end{scope}
-    \node[tn region label selected] at (1.00,2.00) {$S$};%
+    \node[tn region label selected] at (1.25,2.25) {$S$};%
 }
 
 \newcommand{\TN@pepsNormalRegionT}{%
@@ -552,7 +673,7 @@
         (2.7,0.8) -- (1.3,0.8) -- (1.3,1.3) -- (0.3,1.3) -- cycle
         (-0.25,0.25) rectangle (3.25,3.25);
     \end{scope}
-    \node[tn region label selected] at (2.0,2.3) {$T$};%
+    \node[tn region label selected] at (2.25,2.25) {$T$};%
 }
 
 \newcommand{\TN@pepsNormalSingleSiteDifference}{%
@@ -584,7 +705,7 @@
         (0.3,1.3) rectangle (1.2,2.7)
         (1.3,0.8) rectangle (2.7,1.7);
     \end{scope}
-    \node[tn region label complement] at (2.38,2.45) {$A_3$};%
+    \node[tn region label complement] at (2.75,2.75) {$A_3$};%
 }
 
 \newcommand{\TN@pepsNormalCollar}{%
@@ -592,7 +713,8 @@
         \path[tn region collar] (0.3,2.55) rectangle (1.7,3.18);
         \path[tn region collar] (1.3,2.55) rectangle (2.7,3.18);
     \end{scope}
-    \node[tn region label collar] at (1.50,2.88) {top collar};%
+    \node[tn region label collar, fill=white, fill opacity=0.82,
+        text opacity=1, inner sep=1pt] at (1.75,2.75) {top collar};%
 }
 
 \newcommand{\TN@pepsBlockedNormalChain}{%


### PR DESCRIPTION
## Summary

This change refines the shared tensor-network calculus into typed, composable atoms.

- It distinguishes virtual, physical, MPO, input-state, and output-state interfaces.
- It adds fusion, cofusion, action, coaction, span-brace, orthogonal-connector, and sector-bus constructions with stable named ports.
- It migrates the MPO, MPDO, RFP, and selected PEPS figures to these common constructions, so equal graphical objects have equal geometry.
- It incorporates the useful design principles of References/2203.12563/REsubmission.tex, while preserving the notation and visual language of the blueprint.
- It records the resulting geometric conventions in the tensor-network grammar.

The MPO/RFP chapter remains enabled and its figures now use the same clean atomic language as the earlier chapters.

## Validation

- lake build
- cd blueprint && leanblueprint pdf
- cd blueprint && PATH="/Users/siruilu/Library/Python/3.9/bin:$PATH" leanblueprint web
- cd blueprint && leanblueprint checkdecls
- complete ChkTeX pass over blueprint/src and tex/tn
- Python syntax check for the diagram registry
- semantic audit and SVG rendering of all 118 registered diagrams
- independent visual inspection of the MPO, MPDO, RFP, PEPS, blueprint, and slide figures

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large TeX/visual refactor across ~100+ registered blueprint diagrams; wrong port wiring could change figure geometry or break PDF/web SVG builds, but no runtime or security surface.
> 
> **Overview**
> **Refactors tensor-network figures** so chapter macros compose **named typed ports** instead of ad-hoc `\TN@vconnect` / `\TN@vpath` wiring, with **shared leg lengths and bus geometry** in `tex/tn/tn_core.tex` and `tex/tn/tn_library.tex`.
> 
> **New primitives** include orthogonal virtual links (`\TN@vconnectportshv` / `vh`), **physical** trace closures (`\TN@ptraceports*`), span braces and annotation terminals, standard open interfaces (`\TN@openhorizontalports`, etc.), **sector gauges** (`\TN@sectorgauge` / inverse), **physical** split/merge and **bond-pair** maps, MPO **action/coaction** maps, **virtual sector buses** with projection taps, and separate **MPS vs MPO** word constructors.
> 
> **`blueprint/src/macros/tn_print.tex`** rewrites many MPDO fusion, RFP Kraus/canonical-form, and PEPS diagrams onto cofusion maps, port connects, buses, and the new map types; slides get the same brace/annotation pattern. **`docs/tn_diagram_grammar.md`** documents the conventions; **`tn_diagrams.py`** extends typed-port arity checks for the new connect/trace commands.
> 
> **Layout-only tweaks** (labels, region text, caption line breaks) appear in a few PEPS/normal figures without changing the mathematical claims.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9e498091ffdd90487e8f0b2a8dda06a137f1c12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->