### PR TITLE
feat(MPS/RFP): formalize physical blocking isometry

### DIFF
--- a/TNLean/MPS/RFP/Defs.lean
+++ b/TNLean/MPS/RFP/Defs.lean
@@ -10,13 +10,14 @@ import TNLean.Channel.KrausFreedom
 /-!
 # Pure-state renormalization fixed point (RFP) — definitions
 
-This file defines the notion of a **renormalization fixed point** (RFP) for a
-pure MPS tensor, following arXiv:1606.00608 Section 3.1
+This file gives two equivalent descriptions of a **renormalization fixed point**
+for a pure MPS tensor, following arXiv:1606.00608, Section 3.1
 (Cirac–Pérez-García–Schuch–Verstraete).
 
-The key definition is `IsRFP A`, which says that the completely positive map
-(CPM) associated to the MPS tensor `A` is **idempotent**: composing the
-transfer map with itself yields the same transfer map.
+The source definition is `HasPhysicalBlockingIsometry A`: multiplication of two
+tensor letters is obtained from one tensor letter by an isometry on the physical
+index. The equivalent predicate `IsRFP A` says that the associated completely
+positive transfer map is idempotent.
 -/
 
 open scoped Matrix BigOperators
@@ -26,16 +27,34 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-- An MPS tensor `A` is a **renormalization fixed point** (RFP) when its
-transfer map is idempotent as a linear map, i.e. `E_A ∘ E_A = E_A`.
-See arXiv:1606.00608, Definition 3.2. -/
+/-- An MPS tensor has a **physical blocking isometry** when multiplication of
+two tensor letters can be reversed by an isometry on the physical index:
+\[
+  A^{i_1}A^{i_2}=\sum_j U_{(i_1,i_2),j}A^j,
+  \qquad U^\dagger U=1.
+\]
+
+This is the renormalization fixed-point relation `AA=A` in arXiv:1606.00608,
+equation `AA=A` and Definition `defRFP`, lines 398--424. -/
+def HasPhysicalBlockingIsometry (A : MPSTensor d D) : Prop :=
+  ∃ U : Matrix (Fin d × Fin d) (Fin d) ℂ,
+    U.conjTranspose * U = 1 ∧
+    ∀ i₁ i₂ : Fin d, A i₁ * A i₂ = ∑ j : Fin d, U (i₁, i₂) j • A j
+
+/-- The transfer-map criterion for a pure-state renormalization fixed point:
+the completely positive map associated to `A` is idempotent,
+`E_A ∘ E_A = E_A`.
+
+The source defines the fixed-point property by a physical blocking isometry.
+Theorem `isRFP_iff_hasPhysicalBlockingIsometry` proves that the two conditions
+are equivalent. -/
 def IsRFP (A : MPSTensor d D) : Prop :=
   transferMap A ∘ₗ transferMap A = transferMap A
 
-/-- The backward direction of the RFP ↔ Kraus-isometry characterisation
-(arXiv:1606.00608, Theorem 3.1): if the Kraus operators of an MPS tensor
-decompose via a rectangular isometry `V` (with `V†V = 1`), then the
-transfer map is idempotent.
+/-- If the product letters of an MPS tensor are obtained from its letters by a
+rectangular isometry `V`, with `V†V = 1`, then the transfer map is idempotent.
+
+This is the Kraus-family implication used in arXiv:1606.00608, lines 1205--1209.
 
 See `isRFP_iff_kraus_isometry` for the full equivalence (both directions). -/
 theorem isRFP_of_kraus_isometry (A : MPSTensor d D)
@@ -104,7 +123,8 @@ rectangular isometry `V` with `V†V = 1`.
 
 **Backward direction**: proved as `isRFP_of_kraus_isometry`.
 
-See arXiv:1606.00608, Theorem 3.1 and Wolf Theorem 2.1 item 4. -/
+See arXiv:1606.00608, Definition `defRFP`, lines 420--424, and its Kraus-family
+argument at lines 1205--1209; see also Wolf Theorem 2.1 item 4. -/
 theorem isRFP_iff_kraus_isometry (A : MPSTensor d D) :
     IsRFP A ↔
       ∃ V : Matrix (Fin d × Fin d) (Fin d) ℂ,
@@ -140,5 +160,14 @@ theorem isRFP_iff_kraus_isometry (A : MPSTensor d D) :
   · -- Backward direction: proved as `isRFP_of_kraus_isometry`
     rintro ⟨V, hV, hprod⟩
     exact isRFP_of_kraus_isometry A V hV hprod
+
+/-- Transfer-map idempotence is equivalent to the physical blocking-isometry
+definition of a pure-state renormalization fixed point.
+
+This identifies the transfer-map criterion with equation `AA=A` and Definition
+`defRFP` in arXiv:1606.00608, lines 398--424. -/
+theorem isRFP_iff_hasPhysicalBlockingIsometry (A : MPSTensor d D) :
+    IsRFP A ↔ HasPhysicalBlockingIsometry A := by
+  simpa only [HasPhysicalBlockingIsometry] using isRFP_iff_kraus_isometry A
 
 end MPSTensor

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -969,7 +969,7 @@ specialization of that Appendix~D definition.
     \lean{MPSTensor.rfp_implies_nncph}
     \lean{Axioms.rfp_to_nncph_commute}
     \leanok
-    \uses{def:is_rfp, def:is_nncph, def:normal}
+    \uses{def:mps_transfer_idempotence, def:is_nncph, def:normal}
     If $A$ has nonzero virtual dimension and is a normal renormalization fixed
     point, then for every chain length $N > 2$ the two-site local terms
     commute. This theorem records the commutation part of the nearest-neighbor
@@ -2135,7 +2135,8 @@ specialization of that Appendix~D definition.
     \lean{MPSTensor.nncph_implies_rfp}
     \lean{Axioms.beigi_nncph_to_rfp}
     \leanok
-    \uses{def:is_rfp, def:bnt, def:has_nncph_ground_spaces, def:normal}
+    \uses{def:mps_transfer_idempotence, def:bnt, def:has_nncph_ground_spaces,
+        def:normal}
     Let $B$ be normal and in left-canonical form. Suppose that the family
     \(A_j\) is a BNT for \(B\), and that the nearest-neighbor parent
     Hamiltonian of \(B\) has the

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -349,12 +349,12 @@ and rates for the single-tensor transfer map $\E_A$.
     \label{thm:physical_blocking_isometry_iff_transfer_idempotence}
     \lean{MPSTensor.isRFP_iff_hasPhysicalBlockingIsometry}
     \leanok
-    \uses{def:physical_blocking_isometry, def:mps_transfer_idempotence,
-        thm:kraus_isometry_iff_transfer_idempotence}
+    \uses{def:physical_blocking_isometry, def:mps_transfer_idempotence}
     The transfer map of an MPS tensor is idempotent if and only if the tensor
     has a physical blocking isometry.
 \end{theorem}
 \begin{proof}\leanok
+    \uses{thm:kraus_isometry_iff_transfer_idempotence}
     This is Theorem~\ref{thm:kraus_isometry_iff_transfer_idempotence}, with the
     physical blocking relation written as
     Definition~\ref{def:physical_blocking_isometry}.

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -286,7 +286,7 @@ and rates for the single-tensor transfer map $\E_A$.
     \cite[Definition~3.2]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
-\begin{definition}[Idempotent transfer-map criterion]\label{def:is_rfp}
+\begin{definition}[Idempotent transfer-map criterion]\label{def:mps_transfer_idempotence}
     \lean{MPSTensor.IsRFP}
     \leanok
     \uses{def:transfer_map}
@@ -295,10 +295,10 @@ and rates for the single-tensor transfer map $\E_A$.
 \end{definition}
 
 \begin{theorem}[A physical blocking isometry gives transfer idempotence]
-    \label{thm:kraus_isometry_implies_rfp}
+    \label{thm:physical_blocking_implies_transfer_idempotence}
     \lean{MPSTensor.isRFP_of_kraus_isometry}
     \leanok
-    \uses{def:is_rfp}
+    \uses{def:mps_transfer_idempotence}
     Suppose there exists an isometry
     $V : \C^d \to \C^{d^2}$, written as coefficients $V_{(i_1,i_2),j}$, such
     that
@@ -320,7 +320,8 @@ and rates for the single-tensor transfer map $\E_A$.
     \label{thm:kraus_isometry_iff_transfer_idempotence}
     \lean{MPSTensor.isRFP_iff_kraus_isometry}
     \leanok
-    \uses{def:is_rfp, thm:kraus_isometry_implies_rfp}
+    \uses{def:mps_transfer_idempotence,
+        thm:physical_blocking_implies_transfer_idempotence}
     The transfer map of $A$ is idempotent if and only if there exists an
     isometry $V : \C^d \to \C^{d^2}$, written as coefficients
     $V_{(i_1,i_2),j}$ with $V^\dagger V = 1$, such that
@@ -330,9 +331,11 @@ and rates for the single-tensor transfer map $\E_A$.
     for all $i_1,i_2 \in \{0,\ldots,d-1\}$.
 \end{theorem}
 \begin{proof}\leanok
-    \uses{thm:kraus_isometry_implies_rfp, thm:kraus_rectangular_freedom'}
+    \uses{thm:physical_blocking_implies_transfer_idempotence,
+        thm:kraus_rectangular_freedom'}
     The backward implication is
-    Theorem~\ref{thm:kraus_isometry_implies_rfp}. For the forward implication,
+    Theorem~\ref{thm:physical_blocking_implies_transfer_idempotence}. For the
+    forward implication,
     expanding $\E_A^2 = \E_A$ as a Kraus sum gives, for every $X$,
     \[
         \sum_{i_1,i_2}(A^{i_1} A^{i_2})\,X\,(A^{i_1} A^{i_2})^\dagger
@@ -346,7 +349,7 @@ and rates for the single-tensor transfer map $\E_A$.
     \label{thm:physical_blocking_isometry_iff_transfer_idempotence}
     \lean{MPSTensor.isRFP_iff_hasPhysicalBlockingIsometry}
     \leanok
-    \uses{def:physical_blocking_isometry, def:is_rfp,
+    \uses{def:physical_blocking_isometry, def:mps_transfer_idempotence,
         thm:kraus_isometry_iff_transfer_idempotence}
     The transfer map of an MPS tensor is idempotent if and only if the tensor
     has a physical blocking isometry.
@@ -384,7 +387,7 @@ and rates for the single-tensor transfer map $\E_A$.
     \label{def:is_locally_orthogonal}
     \lean{MPSTensor.IsLocallyOrthogonal}
     \leanok
-    \uses{def:is_rfp}
+    \uses{def:mps_transfer_idempotence}
     For the single-block convention used here, local orthogonality means
     \[
         \E_A^2=\E_A .
@@ -479,7 +482,7 @@ and rates for the single-tensor transfer map $\E_A$.
     \lean{MPSTensor.halvedWeightTensor_sameMPV₂_halvedDecomp}
     \lean{MPSTensor.halvedWeightTensor_not_isRFP}
     \leanok
-    \uses{def:source_bnt_zcl, def:is_rfp, def:sector_bnt_cf}
+    \uses{def:source_bnt_zcl, def:mps_transfer_idempotence, def:sector_bnt_cf}
     Let $P$ be the canonical decomposition with one scalar basis tensor $C^0=(1)$,
     two one-dimensional copies, and respective weights $1$ and $1/2$. Write
     $A=\mathcal A(P)$ for its assembled tensor. Relative to these sector
@@ -526,7 +529,7 @@ and rates for the single-tensor transfer map $\E_A$.
     \label{thm:is_positive_gap_bnt_zcl_of_is_rfp_direct_sum}
     \lean{MPSTensor.isPositiveGapBNTZCL_of_isRFP_directSum}
     \leanok
-    \uses{def:is_positive_gap_bnt_zcl, def:is_rfp}
+    \uses{def:is_positive_gap_bnt_zcl, def:mps_transfer_idempotence}
     Let $(A_j)_j$ be nonzero-dimensional, irreducible, left-canonical,
     pairwise gauge-phase-distinct BNT components.  If the direct-sum tensor
     $A=\bigoplus_j A_j$ satisfies $\E_A^2=\E_A$, then $A$ has positive-gap
@@ -561,7 +564,7 @@ and rates for the single-tensor transfer map $\E_A$.
 \begin{theorem}[RFP normal tensor is injective]\label{thm:rfp_nt_injective}
     \lean{MPSTensor.rfp_nt_structural}
     \leanok
-    \uses{def:is_rfp, def:normal, def:injective}
+    \uses{def:mps_transfer_idempotence, def:normal, def:injective}
     If $A$ is a nonzero normal RFP tensor, then $A$ is injective.
 \end{theorem}
 \begin{proof}\leanok
@@ -575,7 +578,7 @@ and rates for the single-tensor transfer map $\E_A$.
     \label{thm:rfp_nt_structural_of_left_canonical}
     \lean{MPSTensor.rfp_nt_structural_of_leftCanonical}
     \leanok
-    \uses{def:is_rfp, def:normal, def:injective}
+    \uses{def:mps_transfer_idempotence, def:normal, def:injective}
     Assume $D > 0$. Let $A$ be a normal renormalization fixed point such that
     \[
         \sum_i (A^i)^\dagger A^i = \Id.
@@ -596,7 +599,7 @@ and rates for the single-tensor transfer map $\E_A$.
     \label{thm:rfp_nt_cfii_diagonal_fixed_point}
     \lean{MPSTensor.rfp_nt_cfii_diagonal_fixedPoint}
     \leanok
-    \uses{def:is_rfp, def:normal, def:transfer_map}
+    \uses{def:mps_transfer_idempotence, def:normal, def:transfer_map}
     Assume $D > 0$. Let $A$ be a normal renormalization fixed point such that
     \[
         \sum_i (A^i)^\dagger A^i = \Id.
@@ -626,7 +629,7 @@ and rates for the single-tensor transfer map $\E_A$.
     \label{thm:transferMap_eq_fixedPointProj_of_isRFP_injective}
     \lean{MPSTensor.transferMap_eq_fixedPointProj_of_isRFP_injective}
     \leanok
-    \uses{def:is_rfp, def:injective, def:fixed_point_proj,
+    \uses{def:mps_transfer_idempotence, def:injective, def:fixed_point_proj,
         thm:exponential_convergence_primitive}
     Let $A$ be an injective left-canonical RFP tensor with positive-definite
     fixed point $\rho$ of the transfer map $\E_A$. Then
@@ -897,7 +900,7 @@ and rates for the single-tensor transfer map $\E_A$.
     \label{thm:is_rfp_of_isometry_canonical_form}
     \lean{MPSTensor.isRFP_of_isIsometryCanonicalForm}
     \leanok
-    \uses{def:is_isometry_canonical_form, def:is_rfp}
+    \uses{def:is_isometry_canonical_form, def:mps_transfer_idempotence}
     A tensor in isometry canonical form is a renormalization fixed point. This is
     the backward direction of the structural characterization of pure-state
     renormalization fixed points in \cite[Section~3]{Cirac2016MPDO_arXiv}, which
@@ -981,7 +984,8 @@ and rates for the single-tensor transfer map $\E_A$.
     \label{thm:bnt_locally_orthogonal_of_rfp_direct_sum}
     \lean{MPSTensor.isBNTLocallyOrthogonal_of_isRFP_directSum}
     \leanok
-    \uses{def:is_bnt_locally_orthogonal, def:is_rfp, def:mixed_transfer_rect}
+    \uses{def:is_bnt_locally_orthogonal, def:mps_transfer_idempotence,
+        def:mixed_transfer_rect}
     Let $(A_j)_j$ be a family of distinct irreducible left-canonical blocks, no
     two of which are gauge-phase equivalent, and suppose the direct sum
     $\bigoplus_j A_j$ is a renormalization fixed point. Then for every pair of
@@ -1079,7 +1083,7 @@ and rates for the single-tensor transfer map $\E_A$.
     \label{lem:isrfp_block_of_rfp_direct_sum}
     \lean{MPSTensor.isRFP_block_of_isRFP_directSum}
     \leanok
-    \uses{def:is_rfp, def:mixed_transfer_rect}
+    \uses{def:mps_transfer_idempotence, def:mixed_transfer_rect}
     If the direct sum $\bigoplus_k B_k$ is a renormalization fixed point, with
     $\dim_k \ge 1$ for all $k$, then each block $B_j$ is a renormalization fixed
     point.
@@ -1095,7 +1099,7 @@ and rates for the single-tensor transfer map $\E_A$.
     \label{thm:residual_isometry_of_rfp_direct_sum}
     \lean{MPSTensor.exists_residualIsometryFamily_of_isRFP_directSum}
     \leanok
-    \uses{def:is_residual_isometry_family, def:is_rfp,
+    \uses{def:is_residual_isometry_family, def:mps_transfer_idempotence,
         def:is_isometry_canonical_form}
     Let $(A_j)_j$ be a family of normal, irreducible, left-canonical blocks, no
     two of which are gauge-phase equivalent, with $\dim_j \ge 1$ for all $j$, and
@@ -1139,7 +1143,8 @@ and rates for the single-tensor transfer map $\E_A$.
     \label{thm:is_rfp_of_isometry_canonical_form_direct_sum}
     \lean{MPSTensor.isRFP_directSumTensor_of_isIsometryCanonicalForm}
     \leanok
-    \uses{def:is_isometry_canonical_form, def:is_rfp, def:mixed_transfer_rect}
+    \uses{def:is_isometry_canonical_form, def:mps_transfer_idempotence,
+        def:mixed_transfer_rect}
     Let $(B_k)_k$ be a family of tensors, each in isometry canonical form, whose
     cross-block mixed transfer operators vanish, $\E_{j,j'}=0$ for $j\ne j'$. Then
     the direct sum $\bigoplus_k B_k$ is a renormalization fixed point. This is the
@@ -1177,7 +1182,8 @@ and rates for the single-tensor transfer map $\E_A$.
     \label{thm:rfp_directSumTensor_iff}
     \lean{MPSTensor.isRFP_directSumTensor_iff}
     \leanok
-    \uses{def:is_rfp, def:is_isometry_canonical_form, def:mixed_transfer_rect,
+    \uses{def:mps_transfer_idempotence, def:is_isometry_canonical_form,
+        def:mixed_transfer_rect,
         def:normal, def:irreducible_tensor, def:gauge_phase_equiv}
     Let $(B_k)_k$ be a family of normal, irreducible, left-canonical blocks with
     $\dim_k \ge 1$ for all $k$, no two of which are gauge-phase equivalent. Then
@@ -1225,7 +1231,7 @@ and rates for the single-tensor transfer map $\E_A$.
     \label{thm:phase_flip_tensor_not_rfp}
     \lean{MPSTensor.phaseFlipTensor_literal_display_ambiguity}
     \leanok
-    \uses{def:is_rfp, def:is_isometry_canonical_form}
+    \uses{def:mps_transfer_idempotence, def:is_isometry_canonical_form}
     Let $B$ be the one-letter, one-dimensional tensor $B^0=(1)$, and form two
     block-diagonal copies with phases $1$ and $-1$:
     \[
@@ -1238,7 +1244,7 @@ and rates for the single-tensor transfer map $\E_A$.
     accompanying interpretation in which the copy index also belongs to the
     physical direct sum: there is no scalar $v$ such that
     $(A^0)^2=vA^0$. In particular, $A$ is not a renormalization fixed point
-    in the sense of Definition~\ref{def:is_rfp}.
+    in the sense of Definition~\ref{def:mps_transfer_idempotence}.
 % Source ambiguity: equation III_CFI_RFP at lines 543--554 admits this literal
 % virtual-block substitution, while lines 559--563 require j,q to contribute
 % to both physical and virtual direct sums; see
@@ -1300,7 +1306,8 @@ and rates for the single-tensor transfer map $\E_A$.
 \end{proof}
 
 \begin{remark}\label{rem:zero_correlation_length}
-    \uses{thm:spectral_radius_le_one, def:correlation_length, def:is_rfp}
+    \uses{thm:spectral_radius_le_one, def:correlation_length,
+        def:mps_transfer_idempotence}
     When the transfer map is idempotent ($\E^2=\E$), connected correlations become
     separation-independent for all separations $n \ge 1$.
     Informally, this corresponds to zero correlation length ($\xi=0$).
@@ -1421,7 +1428,7 @@ and rates for the single-tensor transfer map $\E_A$.
     \label{thm:is_positive_gap_physical_cid_of_is_rfp}
     \lean{MPSTensor.isPositiveGapPhysicalCID_of_isRFP}
     \leanok
-    \uses{def:is_rfp, def:is_positive_gap_physical_cid}
+    \uses{def:mps_transfer_idempotence, def:is_positive_gap_physical_cid}
     If $\E_A^2=\E_A$, then physical correlations are independent of distance
     whenever both complementary gaps are positive.
 \end{theorem}
@@ -1461,7 +1468,7 @@ and rates for the single-tensor transfer map $\E_A$.
     \label{thm:isCID_implies_isRFP}
     \lean{MPSTensor.isCID_implies_isRFP}
     \leanok
-    \uses{def:is_cid, def:is_rfp, def:transfer_map}
+    \uses{def:is_cid, def:mps_transfer_idempotence, def:transfer_map}
     If an MPS tensor admits a positive definite right fixed point and its
     virtual-insertion correlator is independent of distance, then its transfer
     map is idempotent.
@@ -1479,7 +1486,7 @@ and rates for the single-tensor transfer map $\E_A$.
     \label{thm:zcl_iff_idempotent_transfer}
     \lean{MPSTensor.zcl_iff_idempotent_transfer}
     \leanok
-    \uses{def:is_rfp, def:is_cid, def:is_locally_orthogonal}
+    \uses{def:mps_transfer_idempotence, def:is_cid, def:is_locally_orthogonal}
     Under the single-block convention above,
     \[
         \bigl(\E_A^2=\E_A \ \text{and}\ \operatorname{CID}(A)\bigr)
@@ -1503,7 +1510,7 @@ and rates for the single-tensor transfer map $\E_A$.
     \label{thm:rfp_iff_zcl}
     \lean{MPSTensor.rfp_iff_zcl}
     \leanok
-    \uses{def:is_canonical_form, def:is_rfp, def:is_zcl}
+    \uses{def:is_canonical_form, def:mps_transfer_idempotence, def:is_zcl}
     Let $A^i=\bigoplus_k \mu_k A_k^i$ be a tensor in canonical form. For each
     $k$, the tensor $A_k$ is a renormalization fixed point if and only if
     $A_k$ has zero correlation length.

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -270,16 +270,32 @@ and rates for the single-tensor transfer map $\E_A$.
 
 \section{Renormalization fixed points and zero correlation length}
 
-\begin{definition}[Renormalization fixed point]\label{def:is_rfp}
+\begin{definition}[Physical blocking isometry]
+    \label{def:physical_blocking_isometry}
+    \lean{MPSTensor.HasPhysicalBlockingIsometry}
+    \leanok
+    An MPS tensor $A$ is a \emph{renormalization fixed point} if there is an
+    isometry $V\colon \C^d\to\C^{d^2}$, with coefficients
+    $V_{(i_1,i_2),j}$ and $V^\dagger V=1$, such that, for all physical indices
+    $i_1,i_2$,
+    \begin{equation}\label{eq:corr_physical_blocking_isometry}
+        A^{i_1}A^{i_2}
+        =\sum_{j=0}^{d-1}V_{(i_1,i_2),j}A^j.
+    \end{equation}
+    This is the relation $AA=A$ in
+    \cite[Definition~3.2]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{definition}[Idempotent transfer-map criterion]\label{def:is_rfp}
     \lean{MPSTensor.IsRFP}
     \leanok
     \uses{def:transfer_map}
-    An MPS tensor $A$ is a \emph{renormalization fixed point} (RFP) when its
-    transfer map is idempotent, $\E_A \circ \E_A = \E_A$.
-    See \cite[Definition~3.2]{Cirac2016MPDO_arXiv}.
+    The transfer map of $A$ satisfies the idempotence criterion when
+    $\E_A\circ\E_A=\E_A$.
 \end{definition}
 
-\begin{theorem}[Kraus-isometry criterion for RFP]\label{thm:kraus_isometry_implies_rfp}
+\begin{theorem}[A physical blocking isometry gives transfer idempotence]
+    \label{thm:kraus_isometry_implies_rfp}
     \lean{MPSTensor.isRFP_of_kraus_isometry}
     \leanok
     \uses{def:is_rfp}
@@ -290,8 +306,7 @@ and rates for the single-tensor transfer map $\E_A$.
         A^{i_1} A^{i_2} = \sum_{j=0}^{d-1} V_{(i_1,i_2),j} A^j
     \end{equation}
     for all $i_1,i_2 \in \{0,\ldots,d-1\}$.
-    Then $A$ is a renormalization fixed point.
-    This is the backward direction of \cite[Theorem~3.1]{Cirac2016MPDO_arXiv}.
+    Then $\E_A^2=\E_A$.
 \end{theorem}
 \begin{proof}\leanok
     Expanding $\E_A^2$ gives a double Kraus sum indexed by pairs $(i_1,i_2)$.
@@ -301,19 +316,18 @@ and rates for the single-tensor transfer map $\E_A$.
     $\{A^j\}$, hence $\E_A^2 = \E_A$.
 \end{proof}
 
-\begin{theorem}[Renormalization-fixed-point characterization]%
-    \label{thm:renormalization_flow}
+\begin{theorem}[Kraus-isometry criterion for transfer idempotence]%
+    \label{thm:kraus_isometry_iff_transfer_idempotence}
     \lean{MPSTensor.isRFP_iff_kraus_isometry}
     \leanok
     \uses{def:is_rfp, thm:kraus_isometry_implies_rfp}
-    An MPS tensor $A$ is a renormalization fixed point if and only if there
-    exists an isometry $V : \C^d \to \C^{d^2}$, written as coefficients
+    The transfer map of $A$ is idempotent if and only if there exists an
+    isometry $V : \C^d \to \C^{d^2}$, written as coefficients
     $V_{(i_1,i_2),j}$ with $V^\dagger V = 1$, such that
     \begin{equation}\label{eq:corr_AA_isometry}
         A^{i_1} A^{i_2} = \sum_{j=0}^{d-1} V_{(i_1,i_2),j} A^j
     \end{equation}
     for all $i_1,i_2 \in \{0,\ldots,d-1\}$.
-    This is \cite[Theorem~3.1]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 \begin{proof}\leanok
     \uses{thm:kraus_isometry_implies_rfp, thm:kraus_rectangular_freedom'}
@@ -327,6 +341,29 @@ and rates for the single-tensor transfer map $\E_A$.
     Theorem~\ref{thm:kraus_rectangular_freedom'} then supplies the isometry $V$
     relating the two Kraus families.
 \end{proof}
+
+\begin{theorem}[Physical and transfer-map fixed-point criteria]
+    \label{thm:physical_blocking_isometry_iff_transfer_idempotence}
+    \lean{MPSTensor.isRFP_iff_hasPhysicalBlockingIsometry}
+    \leanok
+    \uses{def:physical_blocking_isometry, def:is_rfp,
+        thm:kraus_isometry_iff_transfer_idempotence}
+    The transfer map of an MPS tensor is idempotent if and only if the tensor
+    has a physical blocking isometry.
+\end{theorem}
+\begin{proof}\leanok
+    This is Theorem~\ref{thm:kraus_isometry_iff_transfer_idempotence}, with the
+    physical blocking relation written as
+    Definition~\ref{def:physical_blocking_isometry}.
+\end{proof}
+
+\begin{theorem}[Limits of the renormalization flow]
+    \label{thm:renormalization_flow}
+    \uses{def:physical_blocking_isometry}
+    A tensor appears as a limit of the two-site renormalization flow if and only
+    if it has a physical blocking isometry. This is
+    \cite[Theorem~3.1]{Cirac2016MPDO_arXiv}.
+\end{theorem}
 
 \begin{figure}[ht]
     \centering

--- a/blueprint/src/chapter/ch15_examples.tex
+++ b/blueprint/src/chapter/ch15_examples.tex
@@ -76,7 +76,8 @@ non-injective, renormalization-fixed-point MPS.
 \begin{theorem}[GHZ tensor is an RFP]\label{thm:ghz_is_rfp}
     \lean{MPSTensor.ghz_isRFP}
     \leanok
-    \uses{def:ghz_tensor, def:is_rfp, thm:ghz_transfer_idempotent}
+    \uses{def:ghz_tensor, def:mps_transfer_idempotence,
+        thm:ghz_transfer_idempotent}
     The GHZ tensor is a renormalization fixed point.
 \end{theorem}
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
@@ -423,7 +423,7 @@
     \lean{MPSTensor.schmidtLeft_gram_eq_of_isRFP,
         MPSTensor.schmidtRight_gram_eq_of_isRFP}
     \leanok
-    \uses{def:is_rfp, lem:schmidt_gram_transfer_power}
+    \uses{def:mps_transfer_idempotence, lem:schmidt_gram_transfer_power}
     Let $A$ be a renormalization fixed point. For every $L\ge 1$ and
     $m\ge 1$, the operator-Schmidt Grams of the $L$-block and of the
     $m$-site complement are the one-site Grams:
@@ -477,7 +477,8 @@
     \label{thm:rfp-saturates-area-law}
     \lean{MPSTensor.isSAL_of_isRFP}
     \leanok
-    \uses{def:is_rfp, def:pure_sal, lem:pure_block_entropy_env_charpoly,
+    \uses{def:mps_transfer_idempotence, def:pure_sal,
+        lem:pure_block_entropy_env_charpoly,
         lem:rfp_schmidt_gram_collapse}
     If an MPS tensor $A$ is a renormalization fixed point, then it saturates the
     area law: for every chain length $N$ and every block length

--- a/blueprint/src/chapter/ch21_mpdo_rfp_foundations.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_foundations.tex
@@ -100,7 +100,8 @@
     \label{thm:mpo_is_zcl_iff_to_mps_rfp}
     \lean{MPOTensor.isZCL_iff_toMPSTensor_isRFP}
     \leanok
-    \uses{def:mpo_is_zcl, def:mpo_to_mps, def:is_rfp, lem:mpo_transfer_eq_mps}
+    \uses{def:mpo_is_zcl, def:mpo_to_mps, def:mps_transfer_idempotence,
+        lem:mpo_transfer_eq_mps}
     An MPO tensor satisfies the doubled-index transfer condition if and only if
     its doubled-index MPS view is a renormalization fixed point.
 \end{theorem}
@@ -242,7 +243,7 @@
     \label{def:mpdo_purification_rfp_witness}
     \lean{MPOTensor.HasPurificationRFPWitness}
     \leanok
-    \uses{def:mpdo_global_purification_equation, def:is_rfp}
+    \uses{def:mpdo_global_purification_equation, def:mps_transfer_idempotence}
     An MPO tensor $M$ has a purification RFP witness if it satisfies the global
     purification equation for some purifying spin--ancilla tensor $A$, and
     $\widehat A$ is a pure-state renormalization fixed point:
@@ -289,7 +290,7 @@
 \begin{definition}[Local purification RFP condition]\label{def:is_local_purification_rfp}
     \lean{MPOTensor.IsLocalPurificationRFP}
     \leanok
-    \uses{def:lpdo, def:is_rfp}
+    \uses{def:lpdo, def:mps_transfer_idempotence}
     An MPO tensor $M$ satisfies the local purification RFP condition if it is an
     LPDO whose purifying tensor $A$, viewed as a matrix product state tensor on
     the combined spin--ancilla index, is a pure-state renormalization fixed point.
@@ -391,7 +392,8 @@
     \label{thm:phys_trace_transfer_sq_of_local_purification_rfp}
     \lean{MPOTensor.physTraceTransfer_sq_of_isLocalPurificationRFP}
     \leanok
-    \uses{def:is_local_purification_rfp, def:mpo_physical_trace_transfer, def:is_rfp}
+    \uses{def:is_local_purification_rfp, def:mpo_physical_trace_transfer,
+        def:mps_transfer_idempotence}
     If an MPO tensor $M$ is the ancilla contraction of a pure-state
     renormalization fixed point, then its physical-trace transfer
     $\mathcal T_M=\sum_i M^{ii}$ is idempotent,
@@ -401,7 +403,7 @@
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{def:is_rfp}
+    \uses{def:mps_transfer_idempotence}
     Let $K' = \sum_p \overline{A_p}\otimes A_p$ be the transfer matrix of the
     purifying tensor $A$; the pure-state renormalization fixed point condition
     makes it idempotent, $K'K' = K'$. Write $X_\sigma$ for the reindexing of a

--- a/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
@@ -498,7 +498,8 @@
     \label{thm:is_rfp_iff_to_mps_rfp}
     \lean{MPOTensor.isRFP_iff_toMPSTensor_isRFP}
     \leanok
-    \uses{def:is_rfp_mpdo, def:mpo_to_mps, def:is_rfp, def:mpo_is_zcl,
+    \uses{def:is_rfp_mpdo, def:mpo_to_mps, def:mps_transfer_idempotence,
+        def:mpo_is_zcl,
         thm:mpo_is_zcl_iff_to_mps_rfp}
     MPO transfer-map idempotence is equivalent to the pure-state RFP condition
     for the doubled-index MPS tensor.
@@ -549,7 +550,8 @@
     \label{thm:to_mpo_rfp_iff_rfp}
     \lean{MPSTensor.toMPOTensor_isRFP_iff_isRFP}
     \leanok
-    \uses{def:is_rfp_mpdo, def:is_rfp, thm:to_mpo_transfer_map}
+    \uses{def:is_rfp_mpdo, def:mps_transfer_idempotence,
+        thm:to_mpo_transfer_map}
     For an MPS tensor $A$, the diagonal MPO embedding has idempotent transfer
     map if and only if $A$ is an RFP:
     \[
@@ -562,7 +564,8 @@
 
 \begin{proof}
     \leanok
-    \uses{def:is_rfp_mpdo, def:is_rfp, thm:to_mpo_transfer_map}
+    \uses{def:is_rfp_mpdo, def:mps_transfer_idempotence,
+        thm:to_mpo_transfer_map}
     Both conditions assert idempotence of the corresponding transfer map.
     Theorem~\ref{thm:to_mpo_transfer_map} identifies those transfer maps, so
     the two predicates are equivalent.

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -67,7 +67,10 @@ For MPDO renormalization fixed points:
   canonical-form hypotheses. It also records the ambiguity between a literal
   virtual-block reading of the repeated-copy display `III_CFI_RFP` and the
   accompanying physical direct-sum interpretation: the one-letter phase-flip
-  tensor fails both `AA=A` and whole-tensor transfer-map idempotence.
+  tensor fails both `AA=A` and whole-tensor transfer-map idempotence. The source
+  relation `AA=A` and its unrestricted equivalence with transfer-map
+  idempotence are formalized; the physical-space meaning of the repeated-copy
+  index remains open.
 - `cpsv16_zcl_canonical_form_normalization.tex` records the corresponding
   normalization issue for mixed-state ZCL.
 

--- a/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
+++ b/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
@@ -375,12 +375,14 @@ The calculation therefore does not show that a source RFP is rejected by the
 formal predicate.  Rather, it exposes an ambiguity in taking the displayed
 matrix formula independently of its accompanying physical-space
 interpretation.  The source definition of a pure-state RFP is the physical
-isometry relation
-\path{AA=A} (local source
-\path{Papers/1606.00608/MPDO-22-12-17-2.tex:420--425}), whereas the present
-formal predicate is literal idempotence of the transfer map.  The source then
-states the repeated-copy form in Theorem~\path{charact-MPS}, including the
-independent unit phases (local source
+isometry relation \path{AA=A} (local source
+\path{Papers/1606.00608/MPDO-22-12-17-2.tex:420--425}).  It is formalized by
+\leanid{MPSTensor.HasPhysicalBlockingIsometry}.  The unrestricted equivalence
+between this relation and transfer-map idempotence is
+\leanid{MPSTensor.isRFP_iff_hasPhysicalBlockingIsometry}; it is the Kraus-family
+argument at source lines 1205--1209.  The source then states the repeated-copy
+form in Theorem~\path{charact-MPS}, including the independent unit phases
+(local source
 \path{Papers/1606.00608/MPDO-22-12-17-2.tex:543--554}).  For the two-phase
 virtual-block reading above, neither \path{AA=A} nor literal whole-tensor
 idempotence holds.  Consequently this tensor must not be called a source RFP.
@@ -402,11 +404,13 @@ Second, the repeated-copy index $q$ must be represented at the level at which
 the source physical isometry acts.  It cannot be collapsed into a block-diagonal
 bond tensor and then tested by literal whole-tensor transfer-map idempotence,
 because the phase-flip tensor then fails the source relation \path{AA=A} as well
-as transfer-map idempotence.  A
-source-faithful characterization should formalize the relation \path{AA=A}
-itself, or an equivalent physical-isometry predicate, and prove its precise
-relation to transfer-map idempotence after stating the necessary canonical-form
-or quotient conditions.
+as transfer-map idempotence.  The relation \path{AA=A} and its unrestricted
+equivalence with transfer-map idempotence are now formalized.  The remaining
+problem is therefore not the fixed-point predicate: it is a precise
+physical-space construction of the $q$-copies that agrees with the prose at
+source lines 559--563.  Until such a construction is stated, the independent
+phases in the displayed virtual block sum do not give a valid backward
+implication.
 
 \section{Conclusion}
 


### PR DESCRIPTION
## Mathematical content

This pull request formalizes the source relation `AA=A` from arXiv:1606.00608, Definition 3.2, as `MPSTensor.HasPhysicalBlockingIsometry`. It proves that this physical-index isometry condition is equivalent to idempotence of the MPS transfer map by reusing the already proved Kraus-family equivalence.

The blueprint now distinguishes three statements that had previously been conflated:

- the source definition by a physical blocking isometry;
- the equivalent idempotent transfer-map criterion;
- Theorem 3.1 about limits of the renormalization flow.

The first two are formalized and carry declaration tags. The flow-limit theorem no longer carries an incorrect declaration tag, because no formal predicate for the renormalization flow has yet been defined.

The paper-gap note is updated accordingly. The remaining obstruction in the multi-block characterization is the precise physical-space interpretation of the repeated-copy index `q`; the literal independent-phase virtual-block reading is ruled out by the existing counterexample.

No hypothesis, axiom, or `sorry` is introduced.

## Checks

- `lake build TNLean.MPS.RFP.Defs -q --log-level=info`
- `lake build TNLean -q --log-level=info`
- `lake exe checkdecls blueprint/lean_decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `leanblueprint pdf` and visual inspection of the affected pages
- `leanblueprint web`
- strict tensor-network diagram audit and smoke rendering (118 diagrams)
- `chktex` on both changed LaTeX files
- `latexmk` on `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`
- `#print axioms` on the new definition and theorem: only `propext`, `Classical.choice`, and `Quot.sound`

Partial progress on #2598.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Definition and documentation alignment with proofs delegated to existing theorems; no new axioms, sorrys, or runtime behavior changes.
> 
> **Overview**
> Introduces **`MPSTensor.HasPhysicalBlockingIsometry`** for the Cirac et al. physical blocking relation \(A^{i_1}A^{i_2}=\sum_j U_{(i_1,i_2),j}A^j\) with \(U^\dagger U=1\), and **`isRFP_iff_hasPhysicalBlockingIsometry`**, obtained by reusing the existing Kraus-isometry equivalence (`isRFP_iff_kraus_isometry`) rather than a new proof.
> 
> The **blueprint** now separates three ideas that were previously merged: a new **physical blocking isometry** definition (lean-tagged), an **idempotent transfer-map** criterion (`def:mps_transfer_idempotence`, still `IsRFP` in Lean), and **Theorem 3.1 / renormalization flow** stated without a Lean tag until a flow predicate exists. Dependent chapters and `\uses` links are retargeted from the old `def:is_rfp` label.
> 
> **`docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`** and the README note that `AA=A` and its equivalence to transfer idempotence are formalized; the open issue is the physical-space meaning of the repeated-copy index \(q\).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e5e6a06fb2c081eb1510235818f4105dc5d0c30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->