### PR TITLE
feat(MPS/RFP): package the BNT basis characterization

### DIFF
--- a/TNLean/MPS/RFP/ResidualIsometry.lean
+++ b/TNLean/MPS/RFP/ResidualIsometry.lean
@@ -2,6 +2,7 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+import TNLean.MPS.Periodic.NormalizedSelfOverlap
 import TNLean.MPS.RFP.BNTOrthogonality
 import TNLean.MPS.RFP.StructuralFull
 
@@ -411,5 +412,74 @@ theorem isRFP_directSumTensor_iff [∀ k, NeZero (dim k)]
     exact isRFP_directSumTensor_of_isIsometryCanonicalForm B hCF hortho
 
 end Blocks
+
+namespace IsBNTCanonicalForm
+
+variable {P : SectorDecomposition d}
+
+/-- **Multiplicity-one characterization for the basis of normal tensors.**
+
+If `P` is in BNT canonical form, then the direct sum of its distinct basis
+tensors is a renormalization fixed point exactly when every basis tensor is in
+isometry canonical form and the mixed transfer operators between distinct
+basis tensors vanish.  The blockwise normality, irreducibility,
+left-canonical normalization, positive bond dimensions, and gauge-phase
+distinctness required by `isRFP_directSumTensor_iff` all follow from the one
+BNT canonical-form hypothesis.
+
+This is the multiplicity-one, phase-one specialization of CPSV16,
+Theorem `charact-MPS` and Corollary `III.cor3` (arXiv:1606.00608, lines
+543--584).  The repeated-copy physical-space construction remains separate;
+see `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`. -/
+theorem isRFP_basisDirectSum_iff (hCF : IsBNTCanonicalForm P) :
+    IsRFP (directSumTensor P.basis) ↔
+      ((∀ k, IsIsometryCanonicalForm (P.basis k)) ∧
+        ∀ j j' : Fin P.basisCount, j ≠ j' →
+          mixedTransferMap₂ (P.basis j) (P.basis j') = 0) := by
+  letI : ∀ k : Fin P.basisCount, NeZero (P.basisDim k) :=
+    fun k => ⟨(hCF.basis_dim_pos k).ne'⟩
+  have hnormal : ∀ k : Fin P.basisCount, IsNormal (P.basis k) := by
+    intro k
+    exact isNormal_of_irreducible_leftCanonical_selfOverlap_tendsto_one
+      (P.basis k) (hCF.basis_irreducible k) (hCF.basis_left_canonical k)
+        (hCF.basis_normalized_self_overlap k)
+  exact isRFP_directSumTensor_iff P.basis hnormal hCF.basis_irreducible
+    hCF.basis_left_canonical hCF.basis_distinct
+
+/-- **Residual isometry family for a BNT basis direct sum.**
+
+If `P` is in BNT canonical form and the direct sum of its basis tensors is a
+renormalization fixed point, then those basis tensors have simultaneous
+trace-normalized isometry canonical forms whose residual tensors satisfy the
+full within-block and cross-block isometry equations.
+
+This is the multiplicity-one, phase-one form of CPSV16, Corollary `III.cor3`
+(arXiv:1606.00608, lines 583--589).  The repeated-copy physical-space
+construction remains outside this statement; see
+`docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`. -/
+theorem exists_residualIsometryFamily_of_isRFP_basisDirectSum
+    (hCF : IsBNTCanonicalForm P) (hRFP : IsRFP (directSumTensor P.basis)) :
+    ∃ (X : (j : Fin P.basisCount) →
+        Matrix (Fin (P.basisDim j)) (Fin (P.basisDim j)) ℂ)
+      (Λ : (j : Fin P.basisCount) → Fin (P.basisDim j) → ℝ)
+      (U : (j : Fin P.basisCount) → MPSTensor d (P.basisDim j)),
+      (∀ j, (X j).det ≠ 0) ∧
+      (∀ j k, 0 < Λ j k) ∧
+      (∀ j, ∑ k, Λ j k = 1) ∧
+      (∀ j i, P.basis j i =
+        X j * Matrix.diagonal (fun k => (Real.sqrt (Λ j k) : ℂ)) *
+          U j i * (X j)⁻¹) ∧
+      IsResidualIsometryFamily U := by
+  letI : ∀ k : Fin P.basisCount, NeZero (P.basisDim k) :=
+    fun k => ⟨(hCF.basis_dim_pos k).ne'⟩
+  have hnormal : ∀ k : Fin P.basisCount, IsNormal (P.basis k) := by
+    intro k
+    exact isNormal_of_irreducible_leftCanonical_selfOverlap_tendsto_one
+      (P.basis k) (hCF.basis_irreducible k) (hCF.basis_left_canonical k)
+        (hCF.basis_normalized_self_overlap k)
+  exact exists_residualIsometryFamily_of_isRFP_directSum P.basis hnormal
+    hCF.basis_irreducible hCF.basis_left_canonical hCF.basis_distinct hRFP
+
+end IsBNTCanonicalForm
 
 end MPSTensor

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -1227,6 +1227,50 @@ and rates for the single-tensor transfer map $\E_A$.
     (Theorem~\ref{thm:is_rfp_of_isometry_canonical_form_direct_sum}).
 \end{proof}
 
+\begin{corollary}[BNT basis direct-sum characterization]%
+    \label{cor:rfp_bnt_basis_direct_sum_iff}
+    \lean{MPSTensor.IsBNTCanonicalForm.isRFP_basisDirectSum_iff}
+    \lean{MPSTensor.IsBNTCanonicalForm.exists_residualIsometryFamily_of_isRFP_basisDirectSum}
+    \leanok
+    \uses{def:sector_bnt_cf, def:mps_transfer_idempotence,
+        def:is_isometry_canonical_form, def:mixed_transfer_rect,
+        def:is_residual_isometry_family}
+    Let $P$ be in BNT canonical form, with distinct basis tensors $(B_j)_j$.
+    Then the direct sum containing one copy of each basis tensor is a
+    renormalization fixed point if and only if every $B_j$ is in isometry
+    canonical form and
+    \[
+        \E_{j,j'}=0 \qquad (j\ne j').
+    \]
+    This is the multiplicity-one, phase-one specialization of
+    \cite[Theorem~III and Corollary~III.3]{Cirac2016MPDO_arXiv}.  It concerns
+    the direct sum of the basis representatives, not the repeated-copy tensor
+    carrying the weights $\mu_{j,q}$.
+
+    Moreover, if the basis direct sum is a renormalization fixed point, there
+    are invertible matrices $X_j$, positive trace-normalized diagonal weights
+    $\Lambda_j$, and residual tensors $U_j$ such that
+    \[
+        B_j^i=X_j\sqrt{\Lambda_j}\,U_j^iX_j^{-1},
+    \]
+    and the family $(U_j)_j$ satisfies the full residual isometry condition,
+    including the cross-block equations for $j\ne j'$.
+% The physical-space construction of the repeated-copy index is recorded in
+% docs/paper-gaps/cpsv16_rfp_isometry_scope.tex.
+\end{corollary}
+\begin{proof}\leanok
+    \uses{thm:rfp_directSumTensor_iff}
+    Positive basis dimensions supply the nonzero bond spaces.  For each basis
+    tensor, irreducibility and left-canonical normalization are part of the BNT
+    canonical form.  Its normalized self-overlap converges to one; the periodic
+    self-overlap formula therefore forces peripheral period one, and hence
+    normality.  Gauge-phase distinctness is also part of the BNT canonical
+    form.  The equivalence now follows from
+    Theorem~\ref{thm:rfp_directSumTensor_iff}; the same derived hypotheses in
+    Theorem~\ref{thm:residual_isometry_of_rfp_direct_sum} give the residual
+    isometry family.
+\end{proof}
+
 \begin{theorem}[Ambiguity of the literal repeated-phase display]%
     \label{thm:phase_flip_tensor_not_rfp}
     \lean{MPSTensor.phaseFlipTensor_literal_display_ambiguity}

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -63,10 +63,12 @@ For MPDO renormalization fixed points:
   one-component, hence locally orthogonal, BNT, but its transfer map is not
   idempotent. It identifies the failed inference at source lines 1248--1251.
 - `cpsv16_rfp_isometry_scope.tex` records the normalization and cross-block
-  content of the source's equation `III_isometry`, together with the remaining
-  canonical-form hypotheses. It also records the ambiguity between a literal
-  virtual-block reading of the repeated-copy display `III_CFI_RFP` and the
-  accompanying physical direct-sum interpretation: the one-letter phase-flip
+  content of the source's equation `III_isometry`. The blockwise hypotheses are
+  now derived from the single BNT canonical-form predicate for the
+  multiplicity-one basis direct sum. The note also records the ambiguity
+  between a literal virtual-block reading of the repeated-copy display
+  `III_CFI_RFP` and its accompanying physical direct-sum interpretation: the
+  one-letter phase-flip
   tensor fails both `AA=A` and whole-tensor transfer-map idempotence. The source
   relation `AA=A` and its unrestricted equivalence with transfer-map
   idempotence are formalized; the physical-space meaning of the repeated-copy

--- a/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
+++ b/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
@@ -319,6 +319,19 @@ their phases and scalar weights, requires care about the physical direct sum
 carried by the copy index.  A literal virtual-block substitution need not
 satisfy the defining physical-isometry relation.
 
+For a sector decomposition $P$ satisfying the single BNT canonical-form
+predicate, the explicit blockwise hypotheses are now eliminated.  The theorem
+\leanid{MPSTensor.IsBNTCanonicalForm.isRFP_basisDirectSum_iff} derives positive
+bond dimensions, normality, irreducibility, left-canonical normalization, and
+gauge-phase distinctness from that predicate and gives the preceding
+characterization for the direct sum of the basis representatives.  Under the
+forward hypothesis,
+\leanid{MPSTensor.IsBNTCanonicalForm.exists_residualIsometryFamily_of_isRFP_basisDirectSum}
+also supplies the trace-normalized decompositions and the full residual
+isometry family.  This discharges the canonical-form extraction for the
+multiplicity-one basis direct sum.  It does not identify that direct sum with
+the repeated-copy tensor carrying the weights $\mu_{j,q}$.
+
 \section{Ambiguity of a literal repeated-phase reading}
 
 Equation~\path{III_CFI_RFP} allows a fixed normal tensor indexed by $j$ to occur
@@ -391,16 +404,9 @@ in a way that implements the physical direct sum described at lines 559--563.
 
 \section{Elimination plan}
 
-There are two remaining gaps.  First, Corollary~III.cor3 assumes
-a single predicate ``$A$ in canonical form is a renormalization fixed point'',
-whereas the formal theorem takes the per-block normality, irreducibility,
-left-canonical condition, and gauge-phase distinctness of a basis of normal
-tensors as explicit hypotheses.  A source-faithful version should derive those
-per-block conditions from the single canonical-form renormalization-fixed-point
-predicate, so that the residual isometry family follows from the whole-tensor
-predicate alone, by the block-level argument of the previous section.
-
-Second, the repeated-copy index $q$ must be represented at the level at which
+The canonical-form extraction is discharged for the multiplicity-one basis
+direct sum by the two theorems cited above.  The remaining gap is the
+repeated-copy index $q$, which must be represented at the level at which
 the source physical isometry acts.  It cannot be collapsed into a block-diagonal
 bond tensor and then tested by literal whole-tensor transfer-map idempotence,
 because the phase-flip tensor then fails the source relation \path{AA=A} as well
@@ -439,12 +445,11 @@ $\Lambda_\alpha=\rho_{\alpha,\alpha}/\tr\rho$ and the square-root dressing
 $\sqrt\Lambda$ of the unit isometry.  The cross-block $\delta_{j,j'}$
 orthogonality equations of \path{eq:III_isometry} are formalized at the
 normal-tensor-block level by
-\leanid{MPSTensor.exists_residualIsometryFamily_of_isRFP_directSum}.  Two parts
-remain: the extraction of the per-block normality,
-irreducibility, left-canonical condition, and gauge-phase distinctness from a
-single canonical-form renormalization-fixed-point predicate, the hypothesis form
-of Corollary~III.cor3; and a faithful treatment of repeated phase copies at the
-physical-isometry level.  The tensor $A^0=\operatorname{diag}(1,-1)$ proves that the latter
+\leanid{MPSTensor.exists_residualIsometryFamily_of_isRFP_directSum}.  For the
+multiplicity-one basis direct sum, the single BNT canonical-form predicate now
+supplies all blockwise hypotheses and the residual family.  The remaining part
+is a faithful treatment of repeated phase copies at the physical-isometry
+level.  The tensor $A^0=\operatorname{diag}(1,-1)$ proves that this
 cannot be represented by a literal virtual block diagonal on a one-dimensional
 physical space: that reading fails both \path{AA=A} and whole-tensor
 transfer-map idempotence.


### PR DESCRIPTION
## Summary

This pull request packages the multiplicity-one pure-state RFP characterization under the existing BNT canonical-form predicate.

It adds:

- `MPSTensor.IsBNTCanonicalForm.isRFP_basisDirectSum_iff`, which characterizes transfer idempotence of the direct sum containing one copy of every BNT basis representative;
- `MPSTensor.IsBNTCanonicalForm.exists_residualIsometryFamily_of_isRFP_basisDirectSum`, which obtains the simultaneous trace-normalized isometry canonical forms and the full residual isometry family from the same canonical-form hypothesis;
- the corresponding blueprint corollary and an updated paper-gap boundary.

The proof derives positive bond dimensions, normality, irreducibility, left-canonical normalization, and gauge-phase distinctness from `IsBNTCanonicalForm`. Normality follows from irreducibility, left-canonical normalization, and convergence of the normalized self-overlap to one.

## Source and scope

Source: CPSV16, arXiv:1606.00608, Theorem `charact-MPS`, equation `eq:III_isometry`, and Corollary `III.cor3`, lines 543–589.

This is the multiplicity-one, phase-one basis direct sum. It does not identify the basis direct sum with the repeated-copy tensor carrying the weights `mu_{j,q}`. The remaining physical-space construction of the copy index is recorded in `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`.

No hypothesis absent from the stated multiplicity-one specialization is introduced. No new axiom or incomplete proof is introduced.

## Verification

- `lake build TNLean.MPS.RFP.ResidualIsometry -q --log-level=info`
- `lake build TNLean -q --log-level=info`
- blueprint declaration synchronization and `lake exe checkdecls blueprint/lean_decls`
- `leanblueprint web`
- `leanblueprint pdf`, with the affected pages inspected
- the paper-gap note compiled with `latexmk`
- strict tensor-network audit and smoke rendering: 118 registrations and 118 SVGs, with zero raw glyph, raw wire, or named-port violations
- `#print axioms` for both new theorems: only `propext`, `Classical.choice`, and `Quot.sound`
- `git diff --check`

Progress on #2598.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive Lean wrappers and documentation around existing block-level theorems; no security-sensitive or runtime behavior. Remaining scope (repeated-copy tensor vs basis direct sum) is explicitly bounded in paper-gap notes.
> 
> **Overview**
> Packages the **multiplicity-one, phase-one** pure-state RFP story so callers only assume **`IsBNTCanonicalForm P`**, instead of listing per-block normality, irreducibility, left-canonical data, bond dimensions, and gauge-phase distinctness.
> 
> Adds **`MPSTensor.IsBNTCanonicalForm.isRFP_basisDirectSum_iff`** (transfer idempotence of `directSumTensor P.basis` ↔ per-basis isometry canonical form + vanishing cross-block `mixedTransferMap₂`) and **`exists_residualIsometryFamily_of_isRFP_basisDirectSum`** (from basis direct-sum RFP, the trace-normalized decompositions and full **`IsResidualIsometryFamily`**). Normality of each basis tensor is derived via **`isNormal_of_irreducible_leftCanonical_selfOverlap_tendsto_one`** from the new **`NormalizedSelfOverlap`** import.
> 
> The blueprint gains corollary **`cor:rfp_bnt_basis_direct_sum_iff`**; **`docs/paper-gaps`** records that canonical-form extraction for this basis direct sum is discharged, while the repeated-copy physical index **`q`** remains open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22b745863d666f8ad69511742785e13899c760d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->