### PR TITLE
ci(review): use Claude Sonnet 5

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -130,7 +130,8 @@ jobs:
         uses: LionSR/agent-ci-actions@v1
         with:
           provider: ${{ matrix.provider }}
-          model-tier: opus
+          model-tier: sonnet
+          claude-sonnet-model: claude-sonnet-5
           allowed-bots: 'claude,chatgpt-codex-connector,cursor[bot],cursor,copilot-pull-request-reviewer'
           plugin_marketplaces: |
             https://github.com/anthropics/claude-code.git


### PR DESCRIPTION
### Motivation

- The Anthropic code-review job currently requests the Opus model tier.
- Claude Sonnet 5 is the requested review model and should be selected explicitly rather than inherited from the action's older Sonnet default.

### Description

- Change the code-review action from the Opus tier to the Sonnet tier.
- Pin the Anthropic Sonnet model to `claude-sonnet-5`.
- Leave the provider matrix and the remaining review configuration unchanged.

### Testing

- `git diff --check`
- Parsed `.github/workflows/claude-code-review.yml` with Ruby's YAML parser.
- `actionlint .github/workflows/claude-code-review.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to review model selection; no application code, auth, or data paths affected.
> 
> **Overview**
> The **Claude Code Review (Lean)** workflow now runs on the **Sonnet** tier instead of **Opus**, and pins the Anthropic model to **`claude-sonnet-5`** via `claude-sonnet-model`.
> 
> Provider matrix, triggers, Lean setup, plugins, and prompts are unchanged. This matches other Sonnet-based jobs (e.g. blueprint prose review) while leaving Opus on interactive/auto-fix workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d51f156ef980871db7336e6952be86ac6d8c2ad1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->