### PR TITLE
feat(MPS/RFP): characterize direct-sum transfer idempotence

### DIFF
--- a/TNLean/MPS/RFP/BNTOrthogonality.lean
+++ b/TNLean/MPS/RFP/BNTOrthogonality.lean
@@ -26,6 +26,9 @@ The diagonal `j = j'` case is `IsIsometryCanonicalForm`
   transfer sum: its `(j, j')` bond block acts as
   `mixedTransferMap₂ (B j) (B j')`.  This is the reusable foundation, parallel
   to `evalWord_blockDiagonal'`.
+* `isTransferIdempotent_directSumTensor_iff_pairwise_mixedTransferMap₂_isIdempotentElem`
+  — exact reduction of whole-tensor transfer idempotence to every mixed block
+  pair.
 
 ## Route
 
@@ -254,6 +257,78 @@ theorem mixedTransferMap₂_isIdempotentElem_of_isTransferIdempotent_directSum
     _ = (blockTransferSum B Y).submatrix (blockIncl j dim) (blockIncl j' dim) := by
           rw [blockTransferSum_blockTransferSum B hRFP]
     _ = mixedTransferMap₂ (B j) (B j') Z := e1.symm
+
+/-- If every mixed transfer operator of a block family is idempotent, then the
+block-diagonal transfer sum is idempotent.
+
+The transfer sum acts independently on each $(j,j')$ bond block through
+`mixedTransferMap₂ (B j) (B j')`. Thus its idempotence is checked one block pair
+at a time. This is the exact direct-sum algebra needed when interpreting the
+repeated-block display in arXiv:1606.00608, Theorem charact-MPS, lines 543--555. -/
+theorem blockTransferSum_idempotent_of_pairwise_mixedTransferMap₂
+    (B : (k : Fin r) → MPSTensor d (dim k))
+    (hidem : ∀ j j', IsIdempotentElem (mixedTransferMap₂ (B j) (B j')))
+    (Y : Matrix ((k : Fin r) × Fin (dim k)) ((k : Fin r) × Fin (dim k)) ℂ) :
+    blockTransferSum B (blockTransferSum B Y) = blockTransferSum B Y := by
+  classical
+  have hStage1 : ∀ (W : Matrix ((k : Fin r) × Fin (dim k))
+        ((k : Fin r) × Fin (dim k)) ℂ) (j j' : Fin r),
+      (blockTransferSum B W).submatrix (blockIncl j dim) (blockIncl j' dim) =
+        mixedTransferMap₂ (B j) (B j')
+          (W.submatrix (blockIncl j dim) (blockIncl j' dim)) := by
+    intro W j j'
+    simpa only [blockTransferSum] using blockDiagonal'_transferSum_toBlock B W j j'
+  have blockEq : ∀ j j' : Fin r,
+      (blockTransferSum B (blockTransferSum B Y)).submatrix
+          (blockIncl j dim) (blockIncl j' dim) =
+        (blockTransferSum B Y).submatrix (blockIncl j dim) (blockIncl j' dim) := by
+    intro j j'
+    rw [hStage1 (blockTransferSum B Y) j j', hStage1 Y j j']
+    simpa only [Module.End.mul_apply] using
+      LinearMap.congr_fun (hidem j j')
+        (Y.submatrix (blockIncl j dim) (blockIncl j' dim))
+  ext jx jy
+  obtain ⟨j, a⟩ := jx
+  obtain ⟨j', a'⟩ := jy
+  simpa only [Matrix.submatrix_apply, blockIncl] using
+    congrFun (congrFun (blockEq j j') a) a'
+
+/-- Transfer idempotence of a direct-sum tensor is equivalent to idempotence of
+every mixed transfer operator between its blocks.
+
+This statement includes both diagonal and off-diagonal block pairs. In
+particular, repeated virtual copies cannot be checked only one block at a time:
+their mixed transfer operators also enter the whole-tensor idempotence equation.
+See arXiv:1606.00608, Theorem charact-MPS, lines 543--555. -/
+theorem isTransferIdempotent_directSumTensor_iff_pairwise_mixedTransferMap₂_isIdempotentElem
+    [∀ k, NeZero (dim k)] (B : (k : Fin r) → MPSTensor d (dim k)) :
+    IsTransferIdempotent (directSumTensor B) ↔
+      ∀ j j', IsIdempotentElem (mixedTransferMap₂ (B j) (B j')) := by
+  constructor
+  · intro hRFP j j'
+    exact mixedTransferMap₂_isIdempotentElem_of_isTransferIdempotent_directSum
+      B hRFP j j'
+  · intro hidem
+    classical
+    set e := finSigmaFinEquiv (m := r) (n := dim)
+    change transferMap (directSumTensor B) ∘ₗ transferMap (directSumTensor B) =
+      transferMap (directSumTensor B)
+    refine LinearMap.ext fun Z => ?_
+    rw [LinearMap.comp_apply]
+    obtain ⟨Y, rfl⟩ : ∃ Y, Matrix.reindex e e Y = Z :=
+      ⟨(Matrix.reindex e e).symm Z, (Matrix.reindex e e).apply_symm_apply Z⟩
+    calc
+      transferMap (directSumTensor B)
+            (transferMap (directSumTensor B) (Matrix.reindex e e Y)) =
+          transferMap (directSumTensor B)
+            (Matrix.reindex e e (blockTransferSum B Y)) := by
+              rw [transferMap_directSumTensor_reindex B Y]
+      _ = Matrix.reindex e e (blockTransferSum B (blockTransferSum B Y)) :=
+            transferMap_directSumTensor_reindex B (blockTransferSum B Y)
+      _ = Matrix.reindex e e (blockTransferSum B Y) := by
+            rw [blockTransferSum_idempotent_of_pairwise_mixedTransferMap₂ B hidem Y]
+      _ = transferMap (directSumTensor B) (Matrix.reindex e e Y) :=
+            (transferMap_directSumTensor_reindex B Y).symm
 
 end BlockDecomposition
 

--- a/TNLean/MPS/RFP/ResidualIsometry.lean
+++ b/TNLean/MPS/RFP/ResidualIsometry.lean
@@ -290,37 +290,14 @@ theorem blockTransferSum_idempotent_of_isIsometryCanonicalForm
     (hortho : ∀ j j' : Fin r, j ≠ j' → mixedTransferMap₂ (B j) (B j') = 0)
     (Y : Matrix ((k : Fin r) × Fin (dim k)) ((k : Fin r) × Fin (dim k)) ℂ) :
     blockTransferSum B (blockTransferSum B Y) = blockTransferSum B Y := by
-  classical
-  have hStage1 : ∀ (W : Matrix ((k : Fin r) × Fin (dim k))
-        ((k : Fin r) × Fin (dim k)) ℂ) (j j' : Fin r),
-      (blockTransferSum B W).submatrix (blockIncl j dim) (blockIncl j' dim) =
-        mixedTransferMap₂ (B j) (B j')
-          (W.submatrix (blockIncl j dim) (blockIncl j' dim)) := by
-    intro W j j'
-    simpa only [blockTransferSum] using blockDiagonal'_transferSum_toBlock B W j j'
-  have blockEq : ∀ j j' : Fin r,
-      (blockTransferSum B (blockTransferSum B Y)).submatrix
-          (blockIncl j dim) (blockIncl j' dim) =
-        (blockTransferSum B Y).submatrix (blockIncl j dim) (blockIncl j' dim) := by
-    intro j j'
-    -- Rewrite both the doubly-applied outer block and the once-applied inner
-    -- block to `mixedTransferMap₂ (B j) (B j')` of the corresponding submatrix
-    -- of `Y`, so the goal becomes idempotence of that per-pair operator.
-    rw [hStage1 (blockTransferSum B Y) j j', hStage1 Y j j']
-    by_cases hjj' : j = j'
-    · subst hjj'
-      rw [mixedTransferMap₂_self]
-      have hRFPj : IsTransferIdempotent (B j) :=
-        isTransferIdempotent_of_isIsometryCanonicalForm (B j) (hCF j)
-      simpa only [LinearMap.comp_apply] using
-        LinearMap.congr_fun hRFPj (Y.submatrix (blockIncl j dim) (blockIncl j dim))
-    · rw [hortho j j' hjj']
-      simp
-  ext jx jy
-  obtain ⟨j, a⟩ := jx
-  obtain ⟨j', a'⟩ := jy
-  simpa only [Matrix.submatrix_apply, blockIncl] using
-    congrFun (congrFun (blockEq j j') a) a'
+  apply blockTransferSum_idempotent_of_pairwise_mixedTransferMap₂ B (Y := Y)
+  intro j j'
+  by_cases hjj' : j = j'
+  · subst hjj'
+    rw [mixedTransferMap₂_self]
+    exact isTransferIdempotent_of_isIsometryCanonicalForm (B j) (hCF j)
+  · rw [hortho j j' hjj']
+    exact IsIdempotentElem.zero
 
 /-- **Backward direction of the structural characterization of pure-state
 renormalization fixed points** (arXiv:1606.00608, Theorem charact-MPS, line 543),

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -980,6 +980,73 @@ and rates for the single-tensor transfer map $\E_A$.
     \]
 \end{proof}
 
+\begin{lemma}[Pairwise idempotence of the block transfer sum]%
+    \label{lem:block_transfer_sum_idempotent_of_pairwise_mixed}
+    \lean{MPSTensor.blockTransferSum_idempotent_of_pairwise_mixedTransferMap₂}
+    \leanok
+    \uses{def:mixed_transfer_rect, lem:block_diagonal_transfer_sum_to_block}
+    Let $(B_k)_k$ be a family of tensors. If every mixed transfer operator
+    $\E_{j,j'}$ is idempotent, then the block transfer sum $\mathcal S_B$ is
+    idempotent:
+    \[
+        \mathcal S_B\bigl(\mathcal S_B(X)\bigr)=\mathcal S_B(X).
+    \]
+\end{lemma}
+\begin{proof}\leanok
+    By Lemma~\ref{lem:block_diagonal_transfer_sum_to_block}, the $(j,j')$
+    block satisfies
+    \[
+        \bigl(\mathcal S_B^2(X)\bigr)_{j,j'}
+        = \E_{j,j'}^2(X_{j,j'})
+        = \E_{j,j'}(X_{j,j'})
+        = \bigl(\mathcal S_B(X)\bigr)_{j,j'}.
+    \]
+    Equality on every block gives the asserted equality on the total bond
+    space.
+\end{proof}
+
+\begin{theorem}[Pairwise mixed-transfer criterion for a direct sum]%
+    \label{thm:direct_sum_transfer_idempotent_iff_pairwise_mixed}
+    \lean{MPSTensor.isTransferIdempotent_directSumTensor_iff_pairwise_mixedTransferMap₂_isIdempotentElem}
+    \leanok
+    \uses{def:mps_transfer_idempotence, def:mixed_transfer_rect,
+        lem:block_diagonal_transfer_sum_to_block,
+        lem:block_transfer_sum_idempotent_of_pairwise_mixed}
+    Suppose every bond dimension is positive. The transfer map of
+    $\bigoplus_k B_k$ is idempotent if and only if, for every pair $j,j'$,
+    the mixed transfer operator is idempotent:
+    \[
+        \E_{\oplus_k B_k}^2=\E_{\oplus_k B_k}
+        \quad\Longleftrightarrow\quad
+        \E_{j,j'}^2=\E_{j,j'}.
+    \]
+\end{theorem}
+\begin{proof}\leanok
+    By Lemma~\ref{lem:block_diagonal_transfer_sum_to_block}, the $(j,j')$
+    block of the direct-sum transfer map depends only on the $(j,j')$ block of
+    its argument and is obtained by applying $\E_{j,j'}$. Thus pairwise
+    idempotence gives
+    \[
+        \bigl(\E_{\oplus_k B_k}^2(X)\bigr)_{j,j'}
+        = \E_{j,j'}^2(X_{j,j'})
+        = \E_{j,j'}(X_{j,j'})
+        = \bigl(\E_{\oplus_k B_k}(X)\bigr)_{j,j'}
+    \]
+    for every pair of blocks, and hence gives idempotence on the total bond
+    space, as in
+    Lemma~\ref{lem:block_transfer_sum_idempotent_of_pairwise_mixed}.
+    Conversely, every matrix $M$ of the appropriate rectangular size occurs as
+    the $(j,j')$ block of some $Y$ on the total bond space. Applying
+    Lemma~\ref{lem:block_diagonal_transfer_sum_to_block} and whole-tensor
+    idempotence gives
+    \[
+        \E_{j,j'}^2(M)
+        = \bigl(\E_{\oplus_k B_k}^2(Y)\bigr)_{j,j'}
+        = \bigl(\E_{\oplus_k B_k}(Y)\bigr)_{j,j'}
+        = \E_{j,j'}(M).
+    \]
+\end{proof}
+
 \begin{theorem}[Cross-block transfer vanishing for a direct-sum fixed point]%
     \label{thm:bnt_locally_orthogonal_of_rfp_direct_sum}
     \lean{MPSTensor.isBNTLocallyOrthogonal_of_isTransferIdempotent_directSum}

--- a/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
+++ b/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
@@ -332,6 +332,20 @@ isometry family.  This discharges the canonical-form extraction for the
 multiplicity-one basis direct sum.  It does not identify that direct sum with
 the repeated-copy tensor carrying the weights $\mu_{j,q}$.
 
+For a literal direct sum of any block family $(B_k)_k$, whole-tensor transfer
+idempotence has now been reduced exactly to the mixed block equations
+\[
+  \mathcal E_{\oplus_k B_k}^2=\mathcal E_{\oplus_k B_k}
+  \quad\Longleftrightarrow\quad
+  \mathcal E_{j,j'}^2=\mathcal E_{j,j'}
+  \quad\text{for every }j,j'.
+\]
+This is formalized by
+\leanid{MPSTensor.isTransferIdempotent_directSumTensor_iff_pairwise_mixedTransferMap₂_isIdempotentElem}.
+It shows that repeated virtual copies necessarily impose equations between
+distinct copies of the same normal tensor; checking only the representative
+block omits part of the whole-tensor fixed-point condition.
+
 \section{Ambiguity of a literal repeated-phase reading}
 
 Equation~\path{III_CFI_RFP} allows a fixed normal tensor indexed by $j$ to occur
@@ -384,11 +398,9 @@ Thus $\mathcal E_A^2\ne\mathcal E_A$.  The formal theorem
 \leanid{MPSTensor.phaseFlipTensor_not_isTransferIdempotent} proves that this tensor does not
 satisfy the present predicate \leanid{MPSTensor.IsTransferIdempotent}.
 
-The calculation therefore does not show that a source RFP is rejected by the
-formal predicate.  Rather, it exposes an ambiguity in taking the displayed
-matrix formula independently of its accompanying physical-space
-interpretation.  The source definition of a pure-state RFP is the physical
-isometry relation \path{AA=A} (local source
+The calculation exposes a gap between the displayed theorem and its
+accompanying physical-space interpretation.  The source definition of a
+pure-state RFP is the physical isometry relation \path{AA=A} (local source
 \path{Papers/1606.00608/MPDO-22-12-17-2.tex:420--425}).  It is formalized by
 \leanid{MPSTensor.HasPhysicalBlockingIsometry}.  The unrestricted equivalence
 between this relation and transfer-map idempotence is
@@ -398,25 +410,37 @@ form in Theorem~\path{charact-MPS}, including the independent unit phases
 (local source
 \path{Papers/1606.00608/MPDO-22-12-17-2.tex:543--554}).  For the two-phase
 virtual-block reading above, neither \path{AA=A} nor literal whole-tensor
-idempotence holds.  Consequently this tensor must not be called a source RFP.
-Before formalizing the full characterization, the copy index must be represented
-in a way that implements the physical direct sum described at lines 559--563.
+idempotence holds.
+
+The displayed isometry equation at lines 551--554 contains $j$ but no $q$.
+The prose at lines 561--563 says that $j,q$ participate in physical and virtual
+direct sums, but it gives neither a $q$-indexed isometry nor an equation for such
+an isometry.  In particular, a formal construction would also require a
+dimension condition for embedding the resulting direct sum into the physical
+space; no such condition occurs in the theorem.  Adding these data to a Lean
+statement would therefore add hypotheses absent from the cited statement and
+would violate the faithfulness rule.  The full repeated-copy theorem cannot be
+marked as formalized without a corrected source statement.
 
 \section{Elimination plan}
 
 The canonical-form extraction is discharged for the multiplicity-one basis
-direct sum by the two theorems cited above.  The remaining gap is the
-repeated-copy index $q$, which must be represented at the level at which
-the source physical isometry acts.  It cannot be collapsed into a block-diagonal
-bond tensor and then tested by literal whole-tensor transfer-map idempotence,
-because the phase-flip tensor then fails the source relation \path{AA=A} as well
-as transfer-map idempotence.  The relation \path{AA=A} and its unrestricted
-equivalence with transfer-map idempotence are now formalized.  The remaining
-problem is therefore not the fixed-point predicate: it is a precise
-physical-space construction of the $q$-copies that agrees with the prose at
-source lines 559--563.  Until such a construction is stated, the independent
-phases in the displayed virtual block sum do not give a valid backward
-implication.
+direct sum by the two theorems cited above.  For the literal repeated virtual
+block sum, the next formal step is to combine the pairwise mixed-transfer
+criterion with the scaling law
+\[
+  \mathcal E_{\mu B,\nu C}
+    = \mu\overline\nu\,\mathcal E_{B,C}.
+\]
+For two copies of the same trace-normalized isometry-canonical block, this
+forces $\mu_q\overline{\mu_{q'}}=1$ and hence equality of all phases within that
+copy class.  This yields a mathematically correct literal-block replacement,
+but it must be labelled as a correction rather than as the printed theorem.
+
+The independent-phase statement itself requires an author correction or an
+erratum specifying the missing $q$-dependent physical map, its isometry
+equation, and the necessary dimension hypothesis.  No such data will be
+introduced as new assumptions merely to obtain a formal equivalence.
 
 \section{Conclusion}
 
@@ -448,11 +472,13 @@ normal-tensor-block level by
 \leanid{MPSTensor.exists_residualIsometryFamily_of_isTransferIdempotent_directSum}.  For the
 multiplicity-one basis direct sum, the single BNT canonical-form predicate now
 supplies all blockwise hypotheses and the residual family.  The remaining part
-is a faithful treatment of repeated phase copies at the physical-isometry
-level.  The tensor $A^0=\operatorname{diag}(1,-1)$ proves that this
-cannot be represented by a literal virtual block diagonal on a one-dimensional
-physical space: that reading fails both \path{AA=A} and whole-tensor
-transfer-map idempotence.
+of the printed theorem is not presently a well-specified mathematical
+statement: its displayed isometry omits $q$, while the prose invokes an
+unspecified physical direct sum.  The tensor
+$A^0=\operatorname{diag}(1,-1)$ proves that the literal virtual-block reading
+fails both \path{AA=A} and whole-tensor transfer-map idempotence.  The formal
+development therefore records the exact literal-block criterion and leaves the
+independent-phase claim unmarked pending a corrected source statement.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

This pull request proves the exact blockwise criterion for transfer idempotence
of a direct-sum MPS tensor:

\[
\mathcal E_{\bigoplus_k B_k}^2=\mathcal E_{\bigoplus_k B_k}
\quad\Longleftrightarrow\quad
\mathcal E_{j,j'}^2=\mathcal E_{j,j'}
\quad\text{for every }j,j'.
\]

The new theorem is
`MPSTensor.isTransferIdempotent_directSumTensor_iff_pairwise_mixedTransferMap₂_isIdempotentElem`.
The backward direction uses the existing decomposition of the direct-sum
transfer map into its mixed `(j,j')` blocks. The existing specialized proof for
isometry-canonical blocks is shortened to an application of this general
criterion.

This is partial progress on #2598.

## Source-faithfulness correction

The paper-gap note now records a sharper reading of CPSV16 Theorem
`charact-MPS`, lines 543–563:

- the displayed isometry equation contains the block index `j` but not the copy
  index `q`;
- the following prose invokes a physical direct sum involving `q`, but gives no
  `q`-indexed map, isometry equation, or dimension condition;
- adding such data to the Lean theorem would add hypotheses absent from the
  cited statement.

Accordingly, this pull request does not introduce a physical-space construction
for `q`. It records the exact criterion for the literal virtual direct sum. The
next literal-block step is the scaling law
`E_(μB,νC) = μ * conj(ν) * E_(B,C)`, from which the missing phase-coherence
condition can be derived. That corrected statement must be distinguished from
the printed independent-phase theorem.

## Validation

- `lake build TNLean -q --log-level=warning`
- `lake build TNLean.MPS.RFP.BNTOrthogonality TNLean.MPS.RFP.ResidualIsometry`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check`
- `#print axioms` audit of both new theorems and the refactored specialized
  theorem

The axiom audit reports only `propext`, `Classical.choice`, and `Quot.sound`.
No new axiom, incomplete proof, or kernel bypass is introduced.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal mathematics and documentation; no runtime, auth, or data-path changes. Refactor only shrinks duplicated proof code while preserving theorem statements.
> 
> **Overview**
> Adds the **exact blockwise criterion** for transfer idempotence of a literal virtual direct sum: whole-tensor idempotence is equivalent to idempotence of every mixed operator `mixedTransferMap₂ (B j) (B j')` on all pairs `(j,j')`, including repeated copies of the same block.
> 
> In Lean, **`blockTransferSum_idempotent_of_pairwise_mixedTransferMap₂`** and **`isTransferIdempotent_directSumTensor_iff_pairwise_mixedTransferMap₂_isIdempotentElem`** live in `BNTOrthogonality.lean`; **`blockTransferSum_idempotent_of_isIsometryCanonicalForm`** in `ResidualIsometry.lean` is shortened to a case split (diagonal RFP vs. vanishing off-diagonal) on that shared lemma.
> 
> The blueprint chapter gains matching lemma/theorem entries with `\leanok` links. The CPSV16 isometry scope note now cites the pairwise criterion, reframes the phase-flip example as a **faithfulness gap** (displayed isometry omits copy index `q`), and outlines the next literal-block step via mixed-transfer scaling—not a new physical `q` construction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92459cb3a854b3ea8736ec5e355aa31247aab2ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->