### PR TITLE
feat(MPS/RFP): force literal repeated phases to agree

### DIFF
--- a/TNLean/MPS/RFP/BNTOrthogonality.lean
+++ b/TNLean/MPS/RFP/BNTOrthogonality.lean
@@ -359,10 +359,10 @@ private lemma scalar_eq_one_of_smul_idempotent
 coefficients and the literal bond direct sum is transfer-idempotent, then all
 coefficients are equal.
 
-**Local fix (CPSV16, Theorem charact-MPS, lines 543--563):** This is the corrected
-literal-block consequence. The printed independent-phase statement does not
-specify the additional physical-space construction needed to avoid these mixed
-copy equations; see `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`. -/
+**Local fix (see `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`):** This is the
+corrected literal-block consequence of CPSV16, Theorem charact-MPS, lines
+543--563. The printed independent-phase statement does not specify the additional
+physical-space construction needed to avoid these mixed copy equations. -/
 theorem phases_eq_of_isTransferIdempotent_directSum_scaled_self
     {D : ℕ} [NeZero D] (A : MPSTensor d D) (hA : IsTransferIdempotent A)
     (hA_ne : transferMap A ≠ 0) (μ : Fin r → ℂ) (hμ : ∀ q, ‖μ q‖ = 1)

--- a/TNLean/MPS/RFP/BNTOrthogonality.lean
+++ b/TNLean/MPS/RFP/BNTOrthogonality.lean
@@ -367,13 +367,12 @@ theorem phases_eq_of_isTransferIdempotent_directSum_scaled_self
     {D : ℕ} [NeZero D] (A : MPSTensor d D) (hA : IsTransferIdempotent A)
     (hA_ne : transferMap A ≠ 0) (μ : Fin r → ℂ) (hμ : ∀ q, ‖μ q‖ = 1)
     (hRFP : IsTransferIdempotent
-      (directSumTensor (fun q : Fin r ↦ (fun i ↦ μ q • A i : MPSTensor d D)))) :
-    ∀ q q', μ q = μ q' := by
+      (directSumTensor (fun q : Fin r ↦ (fun i ↦ μ q • A i : MPSTensor d D))))
+    (q q' : Fin r) : μ q = μ q' := by
   have hμ_ne : ∀ q, μ q ≠ 0 := by
     intro q hq
     simpa [hq] using hμ q
-  have hphase : ∀ q q', μ q * starRingEnd ℂ (μ q') = 1 := by
-    intro q q'
+  have hphase : μ q * starRingEnd ℂ (μ q') = 1 := by
     have hidem :=
       (isTransferIdempotent_directSumTensor_iff_pairwise_mixedTransferMap₂_isIdempotentElem
         (B := fun s : Fin r ↦ (fun i ↦ μ s • A i : MPSTensor d D))).mp hRFP q q'
@@ -381,7 +380,6 @@ theorem phases_eq_of_isTransferIdempotent_directSum_scaled_self
     apply scalar_eq_one_of_smul_idempotent (transferMap A) hA hA_ne
       (μ q * starRingEnd ℂ (μ q'))
       (mul_ne_zero (hμ_ne q) ((map_ne_zero (starRingEnd ℂ)).2 (hμ_ne q'))) hidem
-  intro q q'
   have hnormSq : Complex.normSq (μ q') = 1 := by
     rw [Complex.normSq_eq_norm_sq, hμ q']
     norm_num
@@ -392,7 +390,7 @@ theorem phases_eq_of_isTransferIdempotent_directSum_scaled_self
       norm_num
     _ = (μ q * starRingEnd ℂ (μ q')) * μ q' :=
       (mul_assoc (μ q) (starRingEnd ℂ (μ q')) (μ q')).symm
-    _ = 1 * μ q' := by rw [hphase q q']
+    _ = 1 * μ q' := by rw [hphase]
     _ = μ q' := one_mul (μ q')
 
 end BlockDecomposition

--- a/TNLean/MPS/RFP/BNTOrthogonality.lean
+++ b/TNLean/MPS/RFP/BNTOrthogonality.lean
@@ -359,8 +359,8 @@ private lemma scalar_eq_one_of_smul_idempotent
 coefficients and the literal bond direct sum is transfer-idempotent, then all
 coefficients are equal.
 
-This is the corrected literal-block consequence of arXiv:1606.00608, Theorem
-charact-MPS, lines 543--563. The printed independent-phase statement does not
+**Local fix (CPSV16, Theorem charact-MPS, lines 543--563):** This is the corrected
+literal-block consequence. The printed independent-phase statement does not
 specify the additional physical-space construction needed to avoid these mixed
 copy equations; see `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`. -/
 theorem phases_eq_of_isTransferIdempotent_directSum_scaled_self

--- a/TNLean/MPS/RFP/BNTOrthogonality.lean
+++ b/TNLean/MPS/RFP/BNTOrthogonality.lean
@@ -330,6 +330,71 @@ theorem isTransferIdempotent_directSumTensor_iff_pairwise_mixedTransferMap₂_is
       _ = transferMap (directSumTensor B) (Matrix.reindex e e Y) :=
             (transferMap_directSumTensor_reindex B Y).symm
 
+/-- A nonzero idempotent linear map cannot remain idempotent after multiplication
+by a nonzero scalar other than one. -/
+private lemma scalar_eq_one_of_smul_idempotent
+    {D₁ D₂ : ℕ}
+    (F : Matrix (Fin D₁) (Fin D₂) ℂ →ₗ[ℂ]
+      Matrix (Fin D₁) (Fin D₂) ℂ)
+    (hF : IsIdempotentElem F) (hF_ne : F ≠ 0) (c : ℂ) (hc : c ≠ 0)
+    (hcF : IsIdempotentElem (c • F)) : c = 1 := by
+  change F * F = F at hF
+  change (c • F) * (c • F) = c • F at hcF
+  have hcF' : (c * c) • F = c • F := by
+    calc
+      (c * c) • F = (c • F) * (c • F) := by rw [smul_mul_smul, hF]
+      _ = c • F := hcF
+  have hzero : (c * c - c) • F = 0 := by
+    calc
+      (c * c - c) • F = (c * c) • F - c • F := sub_smul (c * c) c F
+      _ = c • F - c • F := by rw [hcF']
+      _ = 0 := sub_self (c • F)
+  have hscalar : c * c - c = 0 :=
+    (smul_eq_zero.mp hzero).resolve_right hF_ne
+  have hmul : c * c = c * 1 := by
+    simpa only [mul_one] using sub_eq_zero.mp hscalar
+  exact mul_left_cancel₀ hc hmul
+
+/-- If a nonzero transfer-idempotent tensor is repeated with unit-modulus scalar
+coefficients and the literal bond direct sum is transfer-idempotent, then all
+coefficients are equal.
+
+This is the corrected literal-block consequence of arXiv:1606.00608, Theorem
+charact-MPS, lines 543--563. The printed independent-phase statement does not
+specify the additional physical-space construction needed to avoid these mixed
+copy equations; see `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`. -/
+theorem phases_eq_of_isTransferIdempotent_directSum_scaled_self
+    {D : ℕ} [NeZero D] (A : MPSTensor d D) (hA : IsTransferIdempotent A)
+    (hA_ne : transferMap A ≠ 0) (μ : Fin r → ℂ) (hμ : ∀ q, ‖μ q‖ = 1)
+    (hRFP : IsTransferIdempotent
+      (directSumTensor (fun q : Fin r ↦ (fun i ↦ μ q • A i : MPSTensor d D)))) :
+    ∀ q q', μ q = μ q' := by
+  have hμ_ne : ∀ q, μ q ≠ 0 := by
+    intro q hq
+    simpa [hq] using hμ q
+  have hphase : ∀ q q', μ q * starRingEnd ℂ (μ q') = 1 := by
+    intro q q'
+    have hidem :=
+      (isTransferIdempotent_directSumTensor_iff_pairwise_mixedTransferMap₂_isIdempotentElem
+        (B := fun s : Fin r ↦ (fun i ↦ μ s • A i : MPSTensor d D))).mp hRFP q q'
+    rw [mixedTransferMap₂_smul, mixedTransferMap₂_self] at hidem
+    apply scalar_eq_one_of_smul_idempotent (transferMap A) hA hA_ne
+      (μ q * starRingEnd ℂ (μ q'))
+      (mul_ne_zero (hμ_ne q) ((map_ne_zero (starRingEnd ℂ)).2 (hμ_ne q'))) hidem
+  intro q q'
+  have hnormSq : Complex.normSq (μ q') = 1 := by
+    rw [Complex.normSq_eq_norm_sq, hμ q']
+    norm_num
+  calc
+    μ q = μ q * 1 := (mul_one (μ q)).symm
+    _ = μ q * (starRingEnd ℂ (μ q') * μ q') := by
+      rw [← Complex.normSq_eq_conj_mul_self, hnormSq]
+      norm_num
+    _ = (μ q * starRingEnd ℂ (μ q')) * μ q' :=
+      (mul_assoc (μ q) (starRingEnd ℂ (μ q')) (μ q')).symm
+    _ = 1 * μ q' := by rw [hphase q q']
+    _ = μ q' := one_mul (μ q')
+
 end BlockDecomposition
 
 /-! ## Spectral gap forces the off-diagonal operator to vanish -/

--- a/TNLean/Spectral/MixedTransfer.lean
+++ b/TNLean/Spectral/MixedTransfer.lean
@@ -171,6 +171,31 @@ lemma mixedTransferMap₂_self {d D : ℕ} (A : MPSTensor d D) :
     mixedTransferMap₂ A A = transferMap (d := d) (D := D) A := by
   ext X; simp only [mixedTransferMap₂_apply, transferMap_apply]
 
+/-- Linearity of the rectangular mixed transfer operator in the first tensor. -/
+private lemma mixedTransferMap₂_smul_left (c : ℂ)
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂) :
+    mixedTransferMap₂ (fun i ↦ c • A i) B = c • mixedTransferMap₂ A B := by
+  ext X
+  simp [← Finset.smul_sum]
+
+/-- Conjugate linearity of the rectangular mixed transfer operator in the
+second tensor. -/
+private lemma mixedTransferMap₂_smul_right (c : ℂ)
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂) :
+    mixedTransferMap₂ A (fun i ↦ c • B i) =
+      starRingEnd ℂ c • mixedTransferMap₂ A B := by
+  ext X
+  simp [← Finset.smul_sum]
+
+/-- Scaling the two tensors scales their rectangular mixed transfer operator by
+$c\overline e$:
+$$\mathcal E_{cA,eB}=c\overline e\,\mathcal E_{A,B}.$$ -/
+lemma mixedTransferMap₂_smul (c e : ℂ)
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂) :
+    mixedTransferMap₂ (fun i ↦ c • A i) (fun i ↦ e • B i) =
+      (c * starRingEnd ℂ e) • mixedTransferMap₂ A B := by
+  rw [mixedTransferMap₂_smul_left, mixedTransferMap₂_smul_right, smul_smul]
+
 end MixedTransferRect
 
 section IteratedTransferRect

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -1092,10 +1092,14 @@ and rates for the single-tensor transfer map $\E_A$.
         =\mu_q\overline{\mu_{q'}}\E_A.
     \]
     Hence $(\mu_q\overline{\mu_{q'}})\E_A$ is idempotent. Since $\E_A$ is
-    nonzero and idempotent,
+    nonzero and
+    $|\mu_q\overline{\mu_{q'}}|=|\mu_q||\mu_{q'}|=1$,
     \[
         (\mu_q\overline{\mu_{q'}})^2\E_A
         =\mu_q\overline{\mu_{q'}}\E_A
+        \quad\Longrightarrow\quad
+        \mu_q\overline{\mu_{q'}}
+        (\mu_q\overline{\mu_{q'}}-1)=0
         \quad\Longrightarrow\quad
         \mu_q\overline{\mu_{q'}}=1.
     \]

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -1074,11 +1074,11 @@ and rates for the single-tensor transfer map $\E_A$.
         thm:direct_sum_transfer_idempotent_iff_pairwise_mixed}
     Let $A$ have positive bond dimension and a nonzero idempotent transfer map.
     Let $\mu_q$ have unit modulus. If the literal bond direct sum
-    $\bigoplus_q \mu_qA$ has an idempotent transfer map, then
+    $\bigoplus_q \mu_qA$ has an idempotent transfer map, then for every pair
+    $q,q'$,
     \[
-        \mu_q=\mu_{q'}
+        \mu_q=\mu_{q'}.
     \]
-    for every pair $q,q'$.
 \end{theorem}
 \begin{proof}\leanok
     The pairwise criterion and

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -1047,6 +1047,58 @@ and rates for the single-tensor transfer map $\E_A$.
     \]
 \end{proof}
 
+\begin{lemma}[Scaling of a rectangular mixed transfer operator]%
+    \label{lem:mixed_transfer_rect_smul}
+    \lean{MPSTensor.mixedTransferMap₂_smul}
+    \leanok
+    \uses{def:mixed_transfer_rect}
+    For complex scalars $c,e$ and tensors $A,B$ of possibly different bond
+    dimensions,
+    \[
+        \E_{cA,eB}=c\overline e\,\E_{A,B}.
+    \]
+\end{lemma}
+\begin{proof}\leanok
+    Conjugate transposition changes the second scalar to its complex conjugate:
+    \[
+        \sum_i (cA^i)X(eB^i)^\dagger
+        =c\overline e\sum_i A^iX(B^i)^\dagger.
+    \]
+\end{proof}
+
+\begin{theorem}[Phase coherence for literal repeated blocks]%
+    \label{thm:literal_repeated_blocks_phase_coherence}
+    \lean{MPSTensor.phases_eq_of_isTransferIdempotent_directSum_scaled_self}
+    \leanok
+    \uses{def:mps_transfer_idempotence, lem:mixed_transfer_rect_smul,
+        thm:direct_sum_transfer_idempotent_iff_pairwise_mixed}
+    Let $A$ have positive bond dimension and a nonzero idempotent transfer map.
+    Let $\mu_q$ have unit modulus. If the literal bond direct sum
+    $\bigoplus_q \mu_qA$ has an idempotent transfer map, then
+    \[
+        \mu_q=\mu_{q'}
+    \]
+    for every pair $q,q'$.
+\end{theorem}
+\begin{proof}\leanok
+    The pairwise criterion and
+    Lemma~\ref{lem:mixed_transfer_rect_smul} show that
+    $(\mu_q\overline{\mu_{q'}})\E_A$ is idempotent. Since $\E_A$ is nonzero
+    and idempotent,
+    \[
+        (\mu_q\overline{\mu_{q'}})^2\E_A
+        =\mu_q\overline{\mu_{q'}}\E_A
+        \quad\Longrightarrow\quad
+        \mu_q\overline{\mu_{q'}}=1.
+    \]
+    Unit modulus then gives $\mu_q=\mu_{q'}$.
+
+    This is the exact conclusion for the literal virtual direct sum in
+    \cite[Theorem~III, lines~543--563]{Cirac2016MPDO_arXiv}. The printed
+    independent-phase statement requires a physical-space interpretation that
+    is not specified by an equation in the cited passage.
+\end{proof}
+
 \begin{theorem}[Cross-block transfer vanishing for a direct-sum fixed point]%
     \label{thm:bnt_locally_orthogonal_of_rfp_direct_sum}
     \lean{MPSTensor.isBNTLocallyOrthogonal_of_isTransferIdempotent_directSum}

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -1081,10 +1081,18 @@ and rates for the single-tensor transfer map $\E_A$.
     \]
 \end{theorem}
 \begin{proof}\leanok
-    The pairwise criterion and
-    Lemma~\ref{lem:mixed_transfer_rect_smul} show that
-    $(\mu_q\overline{\mu_{q'}})\E_A$ is idempotent. Since $\E_A$ is nonzero
-    and idempotent,
+    The pairwise criterion
+    (Theorem~\ref{thm:direct_sum_transfer_idempotent_iff_pairwise_mixed})
+    gives that $\E_{\mu_qA,\mu_{q'}A}$ is idempotent.
+    Lemma~\ref{lem:mixed_transfer_rect_smul} and
+    $\E_{A,A}=\E_A$ give
+    \[
+        \E_{\mu_qA,\mu_{q'}A}
+        =\mu_q\overline{\mu_{q'}}\E_{A,A}
+        =\mu_q\overline{\mu_{q'}}\E_A.
+    \]
+    Hence $(\mu_q\overline{\mu_{q'}})\E_A$ is idempotent. Since $\E_A$ is
+    nonzero and idempotent,
     \[
         (\mu_q\overline{\mu_{q'}})^2\E_A
         =\mu_q\overline{\mu_{q'}}\E_A

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -1100,10 +1100,10 @@ and rates for the single-tensor transfer map $\E_A$.
         =\mu_{q'}.
     \]
 
-    This is the exact conclusion for the literal virtual direct sum in
-    \cite[Theorem~III, lines~543--563]{Cirac2016MPDO_arXiv}. The printed
-    independent-phase statement requires a physical-space interpretation that
-    is not specified by an equation in the cited passage.
+% Scope note: this is the corrected literal-block conclusion from
+% \cite[Theorem~III, lines~543--563]{Cirac2016MPDO_arXiv}; the printed
+% independent-phase statement requires a physical-space construction not
+% specified by an equation in that passage.
 \end{proof}
 
 \begin{theorem}[Cross-block transfer vanishing for a direct-sum fixed point]%

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -1091,7 +1091,14 @@ and rates for the single-tensor transfer map $\E_A$.
         \quad\Longrightarrow\quad
         \mu_q\overline{\mu_{q'}}=1.
     \]
-    Unit modulus then gives $\mu_q=\mu_{q'}$.
+    Since $|\mu_{q'}|=1$ gives
+    $\overline{\mu_{q'}}\mu_{q'}=1$,
+    \[
+        \mu_q
+        =\mu_q(\overline{\mu_{q'}}\mu_{q'})
+        =(\mu_q\overline{\mu_{q'}})\mu_{q'}
+        =\mu_{q'}.
+    \]
 
     This is the exact conclusion for the literal virtual direct sum in
     \cite[Theorem~III, lines~543--563]{Cirac2016MPDO_arXiv}. The printed

--- a/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
+++ b/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
@@ -426,16 +426,19 @@ marked as formalized without a corrected source statement.
 
 The canonical-form extraction is discharged for the multiplicity-one basis
 direct sum by the two theorems cited above.  For the literal repeated virtual
-block sum, the next formal step is to combine the pairwise mixed-transfer
-criterion with the scaling law
+block sum, the scaling law is
 \[
   \mathcal E_{\mu B,\nu C}
     = \mu\overline\nu\,\mathcal E_{B,C}.
 \]
-For two copies of the same trace-normalized isometry-canonical block, this
-forces $\mu_q\overline{\mu_{q'}}=1$ and hence equality of all phases within that
-copy class.  This yields a mathematically correct literal-block replacement,
-but it must be labelled as a correction rather than as the printed theorem.
+It is formalized by \leanid{MPSTensor.mixedTransferMap₂_smul}.  Combining it
+with the pairwise mixed-transfer criterion proves that, for repeated copies of
+a nonzero transfer-idempotent block, whole-tensor idempotence forces
+$\mu_q\overline{\mu_{q'}}=1$ and hence equality of all unit-modulus phases.
+This corrected literal-block theorem is
+\leanid{MPSTensor.phases_eq_of_isTransferIdempotent_directSum_scaled_self}.
+Thus the literal-block replacement is complete, but it is a correction rather
+than a formalization of the printed independent-phase theorem.
 
 The independent-phase statement itself requires an author correction or an
 erratum specifying the missing $q$-dependent physical map, its isometry


### PR DESCRIPTION
## Mathematical result

For a nonzero transfer-idempotent tensor `A`, if the literal bond direct sum of the scaled copies `μ_q A` is transfer-idempotent and every `μ_q` has unit modulus, then all phases `μ_q` are equal.

The proof uses a new scaling identity for rectangular mixed transfer operators together with the pairwise direct-sum criterion from #3945. This is the exact corrected conclusion for the literal virtual direct sum appearing in CPSV16, Theorem `charact-MPS`, lines 543–563.

The printed independent-phase statement is not claimed as formalized: the cited passage does not specify the additional q-dependent physical-space construction required to avoid the mixed-copy equations. Issue #2598 therefore remains open pending a corrected source statement or erratum. The paper-gap note records this distinction.

No hypotheses have been added to the printed theorem under its name, and no new axioms are introduced.

## Changes

- prove `MPSTensor.mixedTransferMap₂_smul`;
- prove `MPSTensor.phases_eq_of_isTransferIdempotent_directSum_scaled_self`;
- add synchronized blueprint statements and proofs;
- update the CPSV16 paper-gap note with the completed literal-block correction.

## Validation

- `lake build TNLean -q --log-level=warning`
- `lake env lean TNLean/Spectral/MixedTransfer.lean`
- `lake env lean TNLean/MPS/RFP/BNTOrthogonality.lean`
- `lake exe checkdecls blueprint/lean_decls`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check`
- proof-integrity scan of both modified Lean files
- `#print axioms` for both new public results: only `propext`, `Classical.choice`, and `Quot.sound`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style proofs in MPS/spectral theory with no auth, I/O, or runtime behavior changes; scope is localized to formalization and documentation.
> 
> **Overview**
> Adds the **literal repeated-block phase coherence** result for CPSV16: if a nonzero transfer-idempotent tensor is copied on the bond with unit-modulus scalars `μ_q` and the direct sum `⊕_q μ_q A` is transfer-idempotent, then all `μ_q` are equal.
> 
> **Lean:** New public `MPSTensor.mixedTransferMap₂_smul` (with private left/right smul lemmas) scales rectangular mixed transfer by `c \bar{e}`. A private lemma shows a nonzero idempotent operator cannot stay idempotent under scalar multiplication unless the scalar is `1`. The main theorem `phases_eq_of_isTransferIdempotent_directSum_scaled_self` chains the pairwise direct-sum criterion (#3945), scaling, and that scalar argument to force `μ_q \overline{μ_{q'}} = 1` and hence `μ_q = μ_{q'}`.
> 
> **Docs:** Blueprint chapter 14 gains matching lemma and theorem with proofs; the CPSV16 paper-gap note records that the literal-block replacement is **complete** via these declarations, while the printed independent-phase theorem remains uncorrected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 666974d1988d32e761b1b31a83ce582260a97ee8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->