### PR TITLE
feat(MPS/Overlap): prove normal overlap dichotomy

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -352,6 +352,7 @@ import TNLean.MPS.CanonicalForm.SectorComparison.CyclicSectorRelation
 import TNLean.MPS.CanonicalForm.BNTGrouping
 import TNLean.MPS.CanonicalForm.PhaseCover
 import TNLean.MPS.CanonicalForm.PhaseClassSectorData
+import TNLean.MPS.Overlap.NormalTensorDichotomy
 import TNLean.MPS.Core.BlockingInfrastructure
 import TNLean.MPS.Irreducible.FormII
 import TNLean.MPS.Irreducible.ScalarFixedPoint

--- a/TNLean/MPS/Overlap/NormalTensorDichotomy.lean
+++ b/TNLean/MPS/Overlap/NormalTensorDichotomy.lean
@@ -7,15 +7,15 @@ import TNLean.MPS.CanonicalForm.NormalTensorGauge
 /-!
 # Normal-tensor overlap dichotomy
 
-Two normal tensors have rectangular matrix product vector overlap tending to zero, unless their
-bond dimensions agree and they are related by an invertible gauge and a unit phase. In the latter
-case the overlap modulus tends to one, and the matrix product vectors differ by the corresponding
-power of the phase at every length.
+The self-overlap of each normal tensor tends to one. Two normal tensors have rectangular matrix
+product vector overlap tending to zero, unless their bond dimensions agree and they are related by
+an invertible gauge and a unit phase. In the latter case the overlap modulus tends to one, and the
+matrix product vectors differ by the corresponding power of the phase at every length.
 
 ## Main statements
 
-* `IsNormalTensor.overlap_dichotomy`: the overlap tends to zero, or its modulus tends to one and
-  the tensors are gauge-phase equivalent with a unit phase.
+* `IsNormalTensor.overlap_dichotomy`: both self-overlaps tend to one, and the cross-overlap tends
+  to zero or has modulus tending to one with gauge-phase equivalence by a unit phase.
 * `IsNormalTensor.mpv_phase_alternative`: the overlap tends to zero, or the matrix product vectors
   differ by a unit phase raised to each chain length.
 
@@ -33,22 +33,25 @@ namespace MPSTensor
 variable {d D₁ D₂ : ℕ}
 
 /-- **Normal-tensor overlap dichotomy** (arXiv:1606.00608, Appendix A,
-Lemma A.2 (equalMPS), lines 1080--1119).
+Lemma A.2 (equalMPS), lines 1080--1117).
 
-For two normal tensors of positive, possibly different, bond dimensions, either the rectangular
-overlap tends to zero, or its modulus tends to one and the tensors are related by an invertible
-gauge and a unit phase. -/
+For two normal tensors of positive, possibly different, bond dimensions, both self-overlaps tend
+to one. Their rectangular overlap either tends to zero, or its modulus tends to one and the tensors
+are related by an invertible gauge and a unit phase. -/
 theorem IsNormalTensor.overlap_dichotomy
     [NeZero D₁] [NeZero D₂]
     {A : MPSTensor d D₁} {B : MPSTensor d D₂}
     (hA : IsNormalTensor A) (hB : IsNormalTensor B) :
-    Tendsto (fun N ↦ mpvOverlap (d := d) A B N) atTop (nhds 0) ∨
-      (Tendsto (fun N ↦ ‖mpvOverlap (d := d) A B N‖) atTop (nhds (1 : ℝ)) ∧
-        ∃ hdim : D₁ = D₂,
-          ∃ X : GL (Fin D₂) ℂ, ∃ ζ : ℂ, ‖ζ‖ = 1 ∧
-            ∀ i, B i = ζ • ((X : Matrix (Fin D₂) (Fin D₂) ℂ) *
-              (cast (congr_arg (MPSTensor d) hdim) A) i *
-              (↑(X⁻¹) : Matrix (Fin D₂) (Fin D₂) ℂ))) := by
+    (Tendsto (fun N ↦ mpvOverlap (d := d) A A N) atTop (nhds 1) ∧
+      Tendsto (fun N ↦ mpvOverlap (d := d) B B N) atTop (nhds 1)) ∧
+        (Tendsto (fun N ↦ mpvOverlap (d := d) A B N) atTop (nhds 0) ∨
+          (Tendsto (fun N ↦ ‖mpvOverlap (d := d) A B N‖) atTop (nhds (1 : ℝ)) ∧
+            ∃ hdim : D₁ = D₂,
+              ∃ X : GL (Fin D₂) ℂ, ∃ ζ : ℂ, ‖ζ‖ = 1 ∧
+                ∀ i, B i = ζ • ((X : Matrix (Fin D₂) (Fin D₂) ℂ) *
+                  (cast (congr_arg (MPSTensor d) hdim) A) i *
+                  (↑(X⁻¹) : Matrix (Fin D₂) (Fin D₂) ℂ)))) := by
+  refine ⟨⟨hA.selfOverlap_tendsto_one, hB.selfOverlap_tendsto_one⟩, ?_⟩
   obtain ⟨σA, _hσA, _hσAfix, hTPA, hGaugeA, _hPrimA, hIrrA⟩ := hA.exists_tpGauge
   obtain ⟨σB, _hσB, _hσBfix, hTPB, hGaugeB, _hPrimB, hIrrB⟩ := hB.exists_tpGauge
   let A' := tpGauge (d := d) (D := D₁) A σA
@@ -112,7 +115,7 @@ theorem IsNormalTensor.mpv_phase_alternative
     Tendsto (fun N ↦ mpvOverlap (d := d) A B N) atTop (nhds 0) ∨
       ∃ ζ : ℂ, ‖ζ‖ = 1 ∧ ∀ N,
         mpvState (d := d) B N = ζ ^ N • mpvState (d := d) A N := by
-  rcases hA.overlap_dichotomy hB with hzero | ⟨_hone, hdim, X, ζ, hζ, hrel⟩
+  rcases hA.overlap_dichotomy hB with ⟨_hself, hzero | ⟨_hone, hdim, X, ζ, hζ, hrel⟩⟩
   · exact Or.inl hzero
   · right
     refine ⟨ζ, hζ, fun N ↦ ?_⟩

--- a/TNLean/MPS/Overlap/NormalTensorDichotomy.lean
+++ b/TNLean/MPS/Overlap/NormalTensorDichotomy.lean
@@ -1,0 +1,125 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.CanonicalForm.NormalTensorGauge
+
+/-!
+# Normal-tensor overlap dichotomy
+
+Two normal tensors have rectangular matrix product vector overlap tending to zero, unless their
+bond dimensions agree and they are related by an invertible gauge and a unit phase. In the latter
+case the overlap modulus tends to one, and the matrix product vectors differ by the corresponding
+power of the phase at every positive length.
+
+## Main statements
+
+* `IsNormalTensor.overlap_dichotomy`: the overlap tends to zero, or its modulus tends to one and
+  the tensors are gauge-phase equivalent with a unit phase.
+* `IsNormalTensor.mpv_phase_alternative`: the overlap tends to zero, or the matrix product vectors
+  differ by a unit phase raised to each positive chain length.
+
+## References
+
+* Cirac--Pérez-García--Schuch--Verstraete, arXiv:1606.00608, Appendix A,
+  Lemma A.2 (equalMPS) and Corollary A.3 (eqV), lines 1080--1128.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+open Filter
+
+namespace MPSTensor
+
+variable {d D₁ D₂ : ℕ}
+
+/-- **Normal-tensor overlap dichotomy** (arXiv:1606.00608, Appendix A,
+Lemma A.2 (equalMPS), lines 1080--1119).
+
+For two normal tensors of positive, possibly different, bond dimensions, either the rectangular
+overlap tends to zero, or its modulus tends to one and the tensors are related by an invertible
+gauge and a unit phase. -/
+theorem IsNormalTensor.overlap_dichotomy
+    [NeZero D₁] [NeZero D₂]
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂}
+    (hA : IsNormalTensor A) (hB : IsNormalTensor B) :
+    Tendsto (fun N ↦ mpvOverlap (d := d) A B N) atTop (nhds 0) ∨
+      (Tendsto (fun N ↦ ‖mpvOverlap (d := d) A B N‖) atTop (nhds (1 : ℝ)) ∧
+        ∃ hdim : D₁ = D₂,
+          ∃ X : GL (Fin D₂) ℂ, ∃ ζ : ℂ, ‖ζ‖ = 1 ∧
+            ∀ i, B i = ζ • ((X : Matrix (Fin D₂) (Fin D₂) ℂ) *
+              (cast (congr_arg (MPSTensor d) hdim) A) i *
+              (↑(X⁻¹) : Matrix (Fin D₂) (Fin D₂) ℂ))) := by
+  obtain ⟨σA, _hσA, _hσAfix, hTPA, hGaugeA, _hPrimA, hIrrA⟩ := hA.exists_tpGauge
+  obtain ⟨σB, _hσB, _hσBfix, hTPB, hGaugeB, _hPrimB, hIrrB⟩ := hB.exists_tpGauge
+  let A' := tpGauge (d := d) (D := D₁) A σA
+  let B' := tpGauge (d := d) (D := D₂) B σB
+  have hOverlapGauge : ∀ N,
+      mpvOverlap (d := d) A B N = mpvOverlap (d := d) A' B' N := by
+    intro N
+    apply Finset.sum_congr rfl
+    intro w _hw
+    rw [GaugeEquiv.sameMPV hGaugeA N w, GaugeEquiv.sameMPV hGaugeB N w]
+  by_cases hdim : D₁ = D₂
+  · by_cases hGPE : GaugePhaseEquiv
+        (cast (congr_arg (MPSTensor d) hdim) A) B
+    · right
+      rcases hGPE with ⟨X, ζ, _hζ, hrel⟩
+      have hζnorm : ‖ζ‖ = 1 :=
+        norm_eq_one_of_gaugePhase_cast_of_isNormalTensor hA hB hdim hrel
+      have hmpv : ∀ (N : ℕ) (w : Fin N → Fin d),
+          mpv B w = ζ ^ N * mpv A w := by
+        intro N w
+        rw [mpv_eq_pow_mul_of_gaugePhase
+          (A := cast (congr_arg (MPSTensor d) hdim) A) (B := B) X ζ hrel N w,
+          mpv_cast_dim hdim A N w]
+      have hCrossEq : ∀ N,
+          mpvOverlap (d := d) A B N =
+            (star ζ) ^ N * mpvOverlap (d := d) A A N :=
+        mpvOverlap_eq_star_pow_mul_self_of_mpv_eq_pow_mul hmpv
+      have hCrossNormEq : ∀ N,
+          ‖mpvOverlap (d := d) A B N‖ = ‖mpvOverlap (d := d) A A N‖ := by
+        intro N
+        rw [hCrossEq N, norm_mul, norm_pow, norm_star, hζnorm, one_pow, one_mul]
+      have hSelfNorm : Tendsto (fun N ↦ ‖mpvOverlap (d := d) A A N‖)
+          atTop (nhds (1 : ℝ)) := by
+        simpa using hA.selfOverlap_tendsto_one.norm
+      refine ⟨hSelfNorm.congr fun N ↦ (hCrossNormEq N).symm, hdim, X, ζ, hζnorm, hrel⟩
+    · left
+      have hNotPrepared : ¬ GaugePhaseEquiv
+          (cast (congr_arg (MPSTensor d) hdim) A') B' := by
+        intro hPrepared
+        exact hGPE (gaugePhaseEquiv_of_gaugeEquiv_left_right_cast
+          hdim hGaugeA hPrepared hGaugeB)
+      have hPrepared :=
+        mpvOverlap_tendsto_zero_of_not_gaugePhaseEquiv_cast_left_of_irreducible_TP
+          hdim A' B' hIrrA hIrrB hTPA hTPB hNotPrepared
+      exact hPrepared.congr' (Eventually.of_forall fun N ↦ (hOverlapGauge N).symm)
+  · left
+    have hPrepared := mpvOverlap_tendsto_zero_of_dim_ne_of_irreducible_TP
+      A' B' hIrrA hIrrB hTPA hTPB hdim
+    exact hPrepared.congr' (Eventually.of_forall fun N ↦ (hOverlapGauge N).symm)
+
+/-- **Exact phase alternative for normal tensors** (arXiv:1606.00608, Appendix A,
+Corollary A.3 (eqV), lines 1121--1128).
+
+For two normal tensors of positive, possibly different, bond dimensions, either the rectangular
+overlap tends to zero, or their matrix product vectors differ at every positive length by a fixed
+unit phase raised to that length. -/
+theorem IsNormalTensor.mpv_phase_alternative
+    [NeZero D₁] [NeZero D₂]
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂}
+    (hA : IsNormalTensor A) (hB : IsNormalTensor B) :
+    Tendsto (fun N ↦ mpvOverlap (d := d) A B N) atTop (nhds 0) ∨
+      ∃ ζ : ℂ, ‖ζ‖ = 1 ∧ ∀ N, 0 < N →
+        mpvState (d := d) B N = ζ ^ N • mpvState (d := d) A N := by
+  rcases hA.overlap_dichotomy hB with hzero | ⟨_hone, hdim, X, ζ, hζ, hrel⟩
+  · exact Or.inl hzero
+  · right
+    refine ⟨ζ, hζ, fun N _hN ↦ ?_⟩
+    ext w
+    simp only [PiLp.smul_apply, smul_eq_mul, mpvState_apply]
+    rw [mpv_eq_pow_mul_of_gaugePhase
+      (A := cast (congr_arg (MPSTensor d) hdim) A) (B := B) X ζ hrel N w,
+      mpv_cast_dim hdim A N w]
+
+end MPSTensor

--- a/TNLean/MPS/Overlap/NormalTensorDichotomy.lean
+++ b/TNLean/MPS/Overlap/NormalTensorDichotomy.lean
@@ -10,14 +10,14 @@ import TNLean.MPS.CanonicalForm.NormalTensorGauge
 Two normal tensors have rectangular matrix product vector overlap tending to zero, unless their
 bond dimensions agree and they are related by an invertible gauge and a unit phase. In the latter
 case the overlap modulus tends to one, and the matrix product vectors differ by the corresponding
-power of the phase at every positive length.
+power of the phase at every length.
 
 ## Main statements
 
 * `IsNormalTensor.overlap_dichotomy`: the overlap tends to zero, or its modulus tends to one and
   the tensors are gauge-phase equivalent with a unit phase.
 * `IsNormalTensor.mpv_phase_alternative`: the overlap tends to zero, or the matrix product vectors
-  differ by a unit phase raised to each positive chain length.
+  differ by a unit phase raised to each chain length.
 
 ## References
 
@@ -103,19 +103,19 @@ theorem IsNormalTensor.overlap_dichotomy
 Corollary A.3 (eqV), lines 1121--1128).
 
 For two normal tensors of positive, possibly different, bond dimensions, either the rectangular
-overlap tends to zero, or their matrix product vectors differ at every positive length by a fixed
-unit phase raised to that length. -/
+overlap tends to zero, or their matrix product vectors differ at every length by a fixed unit phase
+raised to that length. -/
 theorem IsNormalTensor.mpv_phase_alternative
     [NeZero D₁] [NeZero D₂]
     {A : MPSTensor d D₁} {B : MPSTensor d D₂}
     (hA : IsNormalTensor A) (hB : IsNormalTensor B) :
     Tendsto (fun N ↦ mpvOverlap (d := d) A B N) atTop (nhds 0) ∨
-      ∃ ζ : ℂ, ‖ζ‖ = 1 ∧ ∀ N, 0 < N →
+      ∃ ζ : ℂ, ‖ζ‖ = 1 ∧ ∀ N,
         mpvState (d := d) B N = ζ ^ N • mpvState (d := d) A N := by
   rcases hA.overlap_dichotomy hB with hzero | ⟨_hone, hdim, X, ζ, hζ, hrel⟩
   · exact Or.inl hzero
   · right
-    refine ⟨ζ, hζ, fun N _hN ↦ ?_⟩
+    refine ⟨ζ, hζ, fun N ↦ ?_⟩
     ext w
     simp only [PiLp.smul_apply, smul_eq_mul, mpvState_apply]
     rw [mpv_eq_pow_mul_of_gaugePhase

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -194,8 +194,8 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
     \[
         O_{AB}(N)\longrightarrow 0,
     \]
-    or their bond dimensions are equal and there are $X\in\GL_D(\C)$ and
-    $\zeta\in\C$, with $|\zeta|=1$, such that
+    or their bond dimensions are equal; call the common value $D$. Then there
+    are $X\in\GL_D(\C)$ and $\zeta\in\C$, with $|\zeta|=1$, such that
     \[
         B^i=\zeta X A^iX^{-1}
     \]
@@ -212,11 +212,13 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
     dimensions differ, rectangular overlap decay gives $O_{AB}(N)\to0$. If
     their dimensions agree but they are not gauge-phase equivalent, the
     equal-dimension overlap-decay theorem gives the same conclusion. In the
-    remaining case, $B^i=\zeta X A^iX^{-1}$. The gauge-phase relation gives
+    remaining case, $B^i=\zeta X A^iX^{-1}$. By
+    Theorem~\ref{thm:cpsv_normal_mpv_phase_gauge}, $|\zeta|=1$. Its proof uses
+    the gauge-phase relation to obtain
     \[
         O_{BB}(N)=|\zeta|^{2N}O_{AA}(N).
     \]
-    Since both self-overlaps tend to one, this forces $|\zeta|=1$, and hence
+    The two self-overlap limits force the asserted unit norm. Hence
     \[
         O_{AB}(N)=\overline{\zeta}^{\,N}O_{AA}(N),
         \qquad |O_{AB}(N)|=|O_{AA}(N)|\longrightarrow1.

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -179,6 +179,65 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
     gives the asserted relation for $A$ and $B$.
 \end{proof}
 
+\begin{theorem}[Normal-tensor overlap dichotomy]
+    \label{thm:cpsv_normal_overlap_dichotomy}
+    \lean{MPSTensor.IsNormalTensor.overlap_dichotomy}
+    \leanok
+    \uses{def:nt_cpsv, def:mpv_overlap, def:gauge_phase_equiv}
+    Let $A$ and $B$ be normal tensors of positive, possibly different, bond
+    dimensions. Then either
+    \[
+        O_{AB}(N)\longrightarrow 0,
+    \]
+    or their bond dimensions are equal and there are $X\in\GL_D(\C)$ and
+    $\zeta\in\C$, with $|\zeta|=1$, such that
+    \[
+        B^i=\zeta X A^iX^{-1}
+    \]
+    for every physical letter $i$. In the latter case,
+    $|O_{AB}(N)|\to 1$. This is
+    \cite[Lemma~A.2]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:cpsv_normal_tp_gauge, thm:overlap_decay_rect_irr_tp,
+        thm:overlap_decay_irr_tp, thm:gauge_invariance,
+        thm:gauge_phase_mpv_scaling, thm:cpsv_normal_mpv_phase_gauge}
+    Put both tensors in their pure trace-preserving gauges. If their bond
+    dimensions differ, rectangular overlap decay gives $O_{AB}(N)\to0$. If
+    their dimensions agree but they are not gauge-phase equivalent, the
+    equal-dimension overlap-decay theorem gives the same conclusion. In the
+    remaining case, $B^i=\zeta X A^iX^{-1}$. Normalization gives
+    $|\zeta|=1$, and hence
+    \[
+        O_{AB}(N)=\overline{\zeta}^{\,N}O_{AA}(N),
+        \qquad |O_{AB}(N)|=|O_{AA}(N)|\longrightarrow1.
+    \]
+\end{proof}
+
+\begin{theorem}[Exact phase alternative for normal tensors]
+    \label{thm:cpsv_normal_mpv_phase_alternative}
+    \lean{MPSTensor.IsNormalTensor.mpv_phase_alternative}
+    \leanok
+    \uses{def:nt_cpsv, def:mpv_overlap}
+    Let $A$ and $B$ be normal tensors of positive, possibly different, bond
+    dimensions. Then either $O_{AB}(N)\to0$, or there is a phase
+    $\zeta\in\C$, with $|\zeta|=1$, such that for every chain length $N>0$,
+    \[
+        \ket{V^{(N)}(B)}=\zeta^N\ket{V^{(N)}(A)}.
+    \]
+    This is \cite[Corollary~A.3]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:cpsv_normal_overlap_dichotomy,
+        thm:gauge_phase_mpv_scaling}
+    Apply Theorem~\ref{thm:cpsv_normal_overlap_dichotomy}. In its second
+    alternative, gauge-phase covariance gives
+    $V^{(N)}(B)_\sigma=\zeta^N V^{(N)}(A)_\sigma$ for every configuration
+    $\sigma$, and hence the asserted equality of vectors.
+\end{proof}
+
 \begin{theorem}[Separated normal tensors are eventually independent]
     \label{thm:cpsv_normal_separated_eventually_li}
     \lean{MPSTensor.exists_eventually_linearIndependent_of_normalTensor_blocks_not_gaugePhaseEquiv}

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -185,7 +185,12 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
     \leanok
     \uses{def:nt_cpsv, def:mpv_overlap, def:gauge_phase_equiv}
     Let $A$ and $B$ be normal tensors of positive, possibly different, bond
-    dimensions. Then either
+    dimensions. Their self-overlaps satisfy
+    \[
+        O_{AA}(N)\longrightarrow 1,
+        \qquad O_{BB}(N)\longrightarrow 1.
+    \]
+    Moreover, either
     \[
         O_{AB}(N)\longrightarrow 0,
     \]
@@ -207,8 +212,11 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
     dimensions differ, rectangular overlap decay gives $O_{AB}(N)\to0$. If
     their dimensions agree but they are not gauge-phase equivalent, the
     equal-dimension overlap-decay theorem gives the same conclusion. In the
-    remaining case, $B^i=\zeta X A^iX^{-1}$. Normalization gives
-    $|\zeta|=1$, and hence
+    remaining case, $B^i=\zeta X A^iX^{-1}$. The gauge-phase relation gives
+    \[
+        O_{BB}(N)=|\zeta|^{2N}O_{AA}(N).
+    \]
+    Since both self-overlaps tend to one, this forces $|\zeta|=1$, and hence
     \[
         O_{AB}(N)=\overline{\zeta}^{\,N}O_{AA}(N),
         \qquad |O_{AB}(N)|=|O_{AA}(N)|\longrightarrow1.

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -213,12 +213,7 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
     their dimensions agree but they are not gauge-phase equivalent, the
     equal-dimension overlap-decay theorem gives the same conclusion. In the
     remaining case, $B^i=\zeta X A^iX^{-1}$. By
-    Theorem~\ref{thm:cpsv_normal_mpv_phase_gauge}, $|\zeta|=1$. Its proof uses
-    the gauge-phase relation to obtain
-    \[
-        O_{BB}(N)=|\zeta|^{2N}O_{AA}(N).
-    \]
-    The two self-overlap limits force the asserted unit norm. Hence
+    Theorem~\ref{thm:cpsv_normal_mpv_phase_gauge}, $|\zeta|=1$. Hence
     \[
         O_{AB}(N)=\overline{\zeta}^{\,N}O_{AA}(N),
         \qquad |O_{AB}(N)|=|O_{AA}(N)|\longrightarrow1.

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -219,10 +219,10 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
     \label{thm:cpsv_normal_mpv_phase_alternative}
     \lean{MPSTensor.IsNormalTensor.mpv_phase_alternative}
     \leanok
-    \uses{def:nt_cpsv, def:mpv_overlap}
+    \uses{def:nt_cpsv, def:mpv_overlap, def:mpv_state}
     Let $A$ and $B$ be normal tensors of positive, possibly different, bond
     dimensions. Then either $O_{AB}(N)\to0$, or there is a phase
-    $\zeta\in\C$, with $|\zeta|=1$, such that for every chain length $N>0$,
+    $\zeta\in\C$, with $|\zeta|=1$, such that for every chain length $N$,
     \[
         \ket{V^{(N)}(B)}=\zeta^N\ket{V^{(N)}(A)}.
     \]

--- a/docs/audits/2026-05-08-mps-ft-paper-coverage.md
+++ b/docs/audits/2026-05-08-mps-ft-paper-coverage.md
@@ -100,7 +100,7 @@ Listed for completeness; detailed MPDO coverage audit is out of scope.
 |---|---|---|---|---|
 | Defn CFII (l.1058) | 1058–1060 | CFII: CF + trace-preserving CPM + full-rank diagonal fixed point | `TNLean/MPS/CanonicalForm/Existence.lean` (`CFII` data) | `leanok` |
 | **Lemma `equalMPS`** (l.1080) | 1080–1091 | Two NMPVs: overlap → 0 or 1; if 1, gauge-phase equivalent | `TNLean/MPS/Overlap/NormalTensorDichotomy.lean` (`IsNormalTensor.overlap_dichotomy`) | `leanok` |
-| **Corollary `eqV`** (l.1121) | 1121–1128 | NMPV overlap → 0 or equal up to phase factor e^{iφN} | `TNLean/MPS/Overlap/NormalTensorDichotomy.lean` (`IsNormalTensor.mpv_phase_alternative`) | `leanok` for positive chain lengths |
+| **Corollary `eqV`** (l.1121) | 1121–1128 | NMPV overlap → 0 or equal up to phase factor e^{iφN} | `TNLean/MPS/Overlap/NormalTensorDichotomy.lean` (`IsNormalTensor.mpv_phase_alternative`) | `leanok` |
 | **Corollary `Lem1`** (l.1131) | 1131–1133 | Orthogonal NMPVs are eventually linearly independent | `TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean` (`exists_eventually_linearIndependent_of_tp_primitive_irr_blocks_of_blocksNotGaugePhaseEquiv`) | `leanok` |
 | **Lemma `Lem:app_simple`** (l.1156) | 1156–1163 | Power-sum equality ⇒ multiset equality | `TNLean/Algebra/ScalarPowerSumIdentity.lean`; used by `FundamentalTheorem/SectorWeightComparison.lean` | `leanok` |
 | **Corollary `thm:Fundamental-CFII`** (l.1197) | 1197–1199 | CFII version: X, X_k unitary | No current source-faithful Lean theorem identified; CFII normalization data live in `TNLean/MPS/CanonicalForm/Existence.lean` | **open** |

--- a/docs/audits/2026-05-08-mps-ft-paper-coverage.md
+++ b/docs/audits/2026-05-08-mps-ft-paper-coverage.md
@@ -99,8 +99,8 @@ Listed for completeness; detailed MPDO coverage audit is out of scope.
 | Paper label | Lines | Paper description | Lean location | Status |
 |---|---|---|---|---|
 | Defn CFII (l.1058) | 1058–1060 | CFII: CF + trace-preserving CPM + full-rank diagonal fixed point | `TNLean/MPS/CanonicalForm/Existence.lean` (`CFII` data) | `leanok` |
-| **Lemma `equalMPS`** (l.1080) | 1080–1091 | Two NMPVs: overlap → 0 or 1; if 1, gauge-phase equivalent | Same-bond-dimension gauge recovery and the rectangular bond-dimension step are in `FundamentalTheorem/Proportional.lean`; overlap decay lives in `TNLean/MPS/Overlap/` | **partial** — the components are present, but the source lemma is not yet packaged as one theorem with the source hypothesis set |
-| **Corollary `eqV`** (l.1121) | 1121–1128 | NMPV overlap → 0 or equal up to phase factor e^{iφN} | Used in BNT construction | **needs verification** |
+| **Lemma `equalMPS`** (l.1080) | 1080–1091 | Two NMPVs: overlap → 0 or 1; if 1, gauge-phase equivalent | `TNLean/MPS/Overlap/NormalTensorDichotomy.lean` (`IsNormalTensor.overlap_dichotomy`) | `leanok` |
+| **Corollary `eqV`** (l.1121) | 1121–1128 | NMPV overlap → 0 or equal up to phase factor e^{iφN} | `TNLean/MPS/Overlap/NormalTensorDichotomy.lean` (`IsNormalTensor.mpv_phase_alternative`) | `leanok` for positive chain lengths |
 | **Corollary `Lem1`** (l.1131) | 1131–1133 | Orthogonal NMPVs are eventually linearly independent | `TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean` (`exists_eventually_linearIndependent_of_tp_primitive_irr_blocks_of_blocksNotGaugePhaseEquiv`) | `leanok` |
 | **Lemma `Lem:app_simple`** (l.1156) | 1156–1163 | Power-sum equality ⇒ multiset equality | `TNLean/Algebra/ScalarPowerSumIdentity.lean`; used by `FundamentalTheorem/SectorWeightComparison.lean` | `leanok` |
 | **Corollary `thm:Fundamental-CFII`** (l.1197) | 1197–1199 | CFII version: X, X_k unitary | No current source-faithful Lean theorem identified; CFII normalization data live in `TNLean/MPS/CanonicalForm/Existence.lean` | **open** |

--- a/docs/paper-gaps/cpsv16_equalMPS_gauge_phase_gap.tex
+++ b/docs/paper-gaps/cpsv16_equalMPS_gauge_phase_gap.tex
@@ -7,7 +7,7 @@
 
 \input{command}
 
-\title{CPSV16 Lemma~\texttt{equalMPS} Gauge-Phase Components}
+\title{CPSV16 Lemma~\texttt{equalMPS} Gauge-Phase Components and Resolution}
 \author{}
 \date{2026-05-10}
 
@@ -123,10 +123,15 @@ after the rectangular dimension conclusion has been supplied separately.
 The same-bond-dimension gauge component is formalized without the
 source-absent MPV proportionality hypothesis. The rectangular
 bond-dimension conclusion $D_a=D_b$ follows from the rectangular overlap-decay
-theorem through its non-decay contrapositive. Together these two components
-recover the structural conclusion of the unit-overlap branch of
-Lemma~\texttt{equalMPS}, though the upstream normal-tensor periodicity and
-dichotomy statements remain separate from this note.
+theorem through its non-decay contrapositive. The theorem
+\leanid{MPSTensor.IsNormalTensor.overlap_dichotomy} in
+\path{TNLean/MPS/Overlap/NormalTensorDichotomy.lean} now assembles these
+components with normalized self-overlap into the full normal-tensor dichotomy
+and structural conclusion of Lemma~\texttt{equalMPS}. Its corollary
+\leanid{MPSTensor.IsNormalTensor.mpv_phase_alternative} proves the exact
+phase relation for every chain length, as stated in Corollary~\texttt{eqV}.
+Thus the gap recorded by this note is closed; the preceding sections retain the
+mathematical decomposition used in the proof.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Mathematical result

This pull request packages the source-shaped normal-tensor alternatives from arXiv:1606.00608, Appendix A:

- Lemma A.2: each normalized self-overlap tends to one; the rectangular cross-overlap of two positive-bond-dimension normal tensors tends to zero, unless their bond dimensions agree and the tensors are related by an invertible gauge and a unit phase; in the latter case the cross-overlap modulus tends to one;
- Corollary A.3: in the non-decaying case, the matrix product vectors differ by the corresponding phase power at every chain length.

No separate empty-chain argument is needed. In the non-decaying branch, bond-dimension equality has already been obtained from rectangular overlap decay, and the gauge-phase identity then proves the N = 0 equality by the same calculation used for every N.

The new declarations are:

- `MPSTensor.IsNormalTensor.overlap_dichotomy`;
- `MPSTensor.IsNormalTensor.mpv_phase_alternative`.

The blueprint, CPSV16 coverage audit, and the resolved equalMPS paper-gap note are updated accordingly.

## Verification

- `lake build TNLean.MPS.Overlap.NormalTensorDichotomy`
- `lake build` (9,402 jobs)
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `leanblueprint checkdecls`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check`

The kernel axiom audit reports only `propext`, `Classical.choice`, and `Quot.sound` for both new theorems. No `sorry` or project axiom is introduced.

Closes #3946.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New proved Lean theorems and documentation only; no auth, runtime, or API surface changes beyond library imports.
> 
> **Overview**
> Adds **`TNLean/MPS/Overlap/NormalTensorDichotomy.lean`**, which packages Cirac–Pérez-García–Schuch–Verstraete Appendix A Lemma A.2 (`equalMPS`) and Corollary A.3 (`eqV`) as single source-shaped statements on **`IsNormalTensor`**.
> 
> **`IsNormalTensor.overlap_dichotomy`** records that both self-overlaps tend to 1 and the rectangular cross-overlap either tends to 0 or has modulus tending to 1 with equal bond dimension and a **gauge–phase** relation \(B^i = \zeta X A^i X^{-1}\) with \(|\zeta| = 1\). The proof routes through trace-preserving Perron gauges, existing rectangular / equal-dimension overlap decay, and gauge-phase MPV scaling.
> 
> **`IsNormalTensor.mpv_phase_alternative`** is the exact phase form: overlap → 0 or **`mpvState`** satisfies \(\ket{V^{(N)}(B)} = \zeta^N \ket{V^{(N)}(A)}\) for every length.
> 
> The module is wired into the root import **`TNLean.lean`**. Blueprint **`ch10_bnt.tex`** gains matching theorems with `\leanok` proofs; the CPSV16 coverage audit marks **`equalMPS`** and **`eqV`** as **`leanok`**; the **`equalMPS`** paper-gap note is updated to record the gap as closed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 925f4dbbf208ecaff9992fc782525f25e40cd97e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->