### PR TITLE
fix(blueprint): remove unrelated gauge dependency

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -983,8 +983,7 @@ specialization of that Appendix~D definition.
 \end{lemma}
 
 \begin{proof}\leanok
-    \uses{thm:physical_blocking_isometry_iff_transfer_idempotence,
-        rem:product_pair_projectors}
+    \uses{thm:physical_blocking_isometry_iff_transfer_idempotence}
     Suppose $B^i=XA^iX^{-1}$ for every physical letter. If the blocking
     relation for $A$ is
     \[


### PR DESCRIPTION
## Summary

The proof of gauge invariance for the nearest-neighbor parent interaction now lists only the physical-blocking/transfer-idempotence equivalence that it actually uses. The unrelated product-pair-projector remark has been removed from its blueprint dependency edge.

This is a blueprint dependency correction only. It changes no reader-facing mathematical statement, Lean declaration, theorem hypothesis, proof, or axiom.

## Verification

- `lake build TNLean`
- `leanblueprint web`
- `leanblueprint checkdecls`
- repository-wide ChkTeX
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only blueprint dependency edge correction with no Lean or reader-facing math changes.
> 
> **Overview**
> The **gauge invariance** proof for fixed points and parent interactions (`lem:rfp_parent_gauge_invariance`) no longer declares a blueprint dependency on `rem:product_pair_projectors`. Its `\uses{...}` block now cites only `thm:physical_blocking_isometry_iff_transfer_idempotence`, matching what that proof actually invokes (blocking/transfer idempotence under virtual similarity, then equality of local MPS spaces and parent terms).
> 
> No theorem text, Lean links, or mathematical claims change; `rem:product_pair_projectors` remains in the chapter and is still referenced where it is needed (e.g. the product-pair / NNCPH ground-spaces theorem).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a14fac81f6e064d100ab130cdeb2402133909000. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->