### PR TITLE
feat(MPS/MPDO): derive source ZCL from RFP maps

### DIFF
--- a/TNLean/Channel/KrausRepresentation.lean
+++ b/TNLean/Channel/KrausRepresentation.lean
@@ -61,9 +61,10 @@ theorem kraus_sum_conjTranspose_mul_of_tp
 /-- **Theorem 2.1 item 1 (normalization ⟹ TP, Eq. (2.8))**:
 If `∑ᵢ Kᵢ†Kᵢ = 𝟙`, then `T(X) = ∑ᵢ Kᵢ X Kᵢ†` is trace-preserving. -/
 theorem kraus_tp_of_sum_conjTranspose_mul
-    {r : ℕ} (K : Fin r → Matrix (Fin D) (Fin D) ℂ)
-    (hK_norm : ∑ i : Fin r, (K i)ᴴ * K i = 1) :
-    ∀ X : Matrix (Fin D) (Fin D) ℂ,
+    {α β : Type*} [Fintype α] [DecidableEq α] [Fintype β]
+    {r : ℕ} (K : Fin r → Matrix β α ℂ)
+    (hK_norm : ∑ i : Fin r, (K i)ᴴ * K i = (1 : Matrix α α ℂ)) :
+    ∀ X : Matrix α α ℂ,
       trace (∑ i : Fin r, K i * X * (K i)ᴴ) = trace X := by
   intro X
   rw [Matrix.trace_sum]

--- a/TNLean/MPS/MPDO/Defs.lean
+++ b/TNLean/MPS/MPDO/Defs.lean
@@ -430,10 +430,11 @@ This is *not* the paper's MPDO renormalization-fixed-point Definition 4.1
 (paper label RFPMixedTS, arXiv:1606.00608 line 657: existence of two
 trace-preserving CP maps T and S on the physical indices). Idempotence coincides
 with Definition 4.1 only in the pure (MPS) case. For general MPDO, Definition 4.1
-is strictly stronger:
-it implies idempotence/ZCL (Theorem 4.9, i ⟹ ii, gives ZCL and SAL), but ZCL alone
-does not imply it (line 786). Definition 4.1 is stated as `MPOTensor.IsRFPViaTS`;
-the theorem deriving idempotence from it is future work (#826, #237). -/
+implies the source zero-correlation-length condition on the physical-trace
+transfer and saturation of the mutual-information area law (Theorem 4.9,
+i ⟹ ii), not the doubled-index transfer-map equation stated here. Definition
+4.1 is `MPOTensor.IsRFPViaTS`; its physical-trace consequence is proved in
+`MPOTensor.physTraceTransfer_sq_of_isRFPViaTS`. -/
 def IsRFP (M : MPOTensor d D) : Prop :=
   transferMap M ∘ₗ transferMap M = transferMap M
 

--- a/TNLean/MPS/MPDO/KrausCPTP.lean
+++ b/TNLean/MPS/MPDO/KrausCPTP.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.MPDO.Defs
 import TNLean.Analysis.MatrixSqrt
+import TNLean.Channel.KrausRepresentation
 import TNLean.Channel.PartialTrace
 import Mathlib.Data.Matrix.PEquiv
 import Mathlib.LinearAlgebra.Matrix.Reindex
@@ -21,6 +22,7 @@ dimensions.
 
 * `IsKrausCPTP`: a trace-preserving completely positive map in rectangular
   Kraus form.
+* `IsKrausCPTP.trace_map`: a map satisfying `IsKrausCPTP` preserves trace.
 * `isKrausCPTP_id`: the identity map is trace-preserving completely positive.
 * `isKrausCPTP_of_singleKraus`: conjugation by an isometry is trace-preserving
   completely positive.
@@ -63,6 +65,19 @@ def IsKrausCPTP {α β : Type*} [Fintype α] [DecidableEq α] [Fintype β] [Deci
     (S : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ) : Prop :=
   ∃ (r : ℕ) (A : Fin r → Matrix β α ℂ),
     (∀ X, S X = ∑ i, A i * X * (A i)ᴴ) ∧ (∑ i, (A i)ᴴ * A i = (1 : Matrix α α ℂ))
+
+/-- A rectangular Kraus map whose Kraus operators resolve the identity
+preserves the matrix trace. This is the trace-preservation property used for
+the physical maps in arXiv:1606.00608, Proposition `propsimple`, lines
+1333--1340. -/
+theorem IsKrausCPTP.trace_map
+    {α β : Type*} [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]
+    {S : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ} (hS : IsKrausCPTP S)
+    (X : Matrix α α ℂ) :
+    Matrix.trace (S X) = Matrix.trace X := by
+  obtain ⟨r, A, hA, hA_norm⟩ := hS
+  rw [hA]
+  exact kraus_tp_of_sum_conjTranspose_mul A hA_norm X
 
 /-- The identity map is trace-preserving completely positive; the single Kraus
 operator is the identity matrix. -/

--- a/TNLean/MPS/MPDO/RFP.lean
+++ b/TNLean/MPS/MPDO/RFP.lean
@@ -15,8 +15,9 @@ Note that `IsRFP` is the idempotence / zero-correlation-length condition, not th
 paper's renormalization-fixed-point Definition 4.1 (paper label RFPMixedTS, the
 existence of two trace-preserving CP maps), which is an a priori different notion
 for general MPDO; see the faithfulness note on `MPOTensor.IsRFP`. Definition 4.1
-is stated as `MPOTensor.IsRFPViaTS`; the theorem deriving idempotence from it is
-future work (#826, #237).
+is stated as `MPOTensor.IsRFPViaTS`. It implies idempotence of the distinct
+physical-trace transfer, as proved in `MPOTensor.physTraceTransfer_sq_of_isRFPViaTS`;
+no implication to the doubled-index equation in this file is asserted.
 
 ## Main results
 

--- a/TNLean/MPS/MPDO/RFPViaTS.lean
+++ b/TNLean/MPS/MPDO/RFPViaTS.lean
@@ -3,7 +3,9 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Algebra.FinTupleEquiv
+import TNLean.Algebra.TracePairing
 import TNLean.MPS.MPDO.KrausCPTP
+import TNLean.MPS.MPDO.ZCL
 
 /-!
 # MPDO renormalization fixed point via trace-preserving CP maps (Definition 4.1)
@@ -45,6 +47,10 @@ the predicate.
   one-site, two-site, and three-site specializations.
 * `MPOTensor.IsRFPViaTS`: Definition 4.1, the tp-CP-map renormalization
   fixed point.
+* `MPOTensor.physTraceTransfer_sq_of_isRFPViaTS`: Definition 4.1 implies
+  idempotence of the physical-trace transfer.
+* `MPOTensor.isSourceZCL_of_isRFPViaTS`: the resulting source
+  zero-correlation-length statement when the physical-trace transfer is nonzero.
 
 ## References
 
@@ -136,6 +142,16 @@ noncomputable def physClose1 (M : MPOTensor d D) :
 @[simp] lemma physClose1_apply (M : MPOTensor d D) (X : Matrix (Fin D) (Fin D) ℂ)
     (i j : Fin d) : physClose1 M X i j = Matrix.trace (M i j * X) := rfl
 
+/-- The trace of the one-site physical closure is the trace pairing with the
+physical-trace transfer.
+
+Source: arXiv:1606.00608, Definition 4.1, line 657, and Proposition
+`propsimple`, lines 1333--1340. -/
+theorem trace_physClose1_eq (M : MPOTensor d D) (X : Matrix (Fin D) (Fin D) ℂ) :
+    Matrix.trace (physClose1 M X) = Matrix.trace (physTraceTransfer M * X) := by
+  rw [physTraceTransfer, Finset.sum_mul, Matrix.trace_sum]
+  rfl
+
 /-- Under the canonical equivalence between one-site configurations and
 physical indices, the length-one closure is `physClose1`. This is the one-site
 operator in arXiv:1606.00608, Definition 4.1, line 657 and figure MPDO_XM. -/
@@ -165,6 +181,18 @@ noncomputable def physClose2 (M : MPOTensor d D) :
 @[simp] lemma physClose2_apply (M : MPOTensor d D) (X : Matrix (Fin D) (Fin D) ℂ)
     (i j : Fin d × Fin d) :
     physClose2 M X i j = Matrix.trace (M i.1 j.1 * M i.2 j.2 * X) := rfl
+
+/-- The trace of the two-site physical closure is the trace pairing with the
+square of the physical-trace transfer.
+
+Source: arXiv:1606.00608, Definition 4.1, line 657, and Proposition
+`propsimple`, lines 1333--1340. -/
+theorem trace_physClose2_eq (M : MPOTensor d D) (X : Matrix (Fin D) (Fin D) ℂ) :
+    Matrix.trace (physClose2 M X) =
+      Matrix.trace (physTraceTransfer M * physTraceTransfer M * X) := by
+  change (∑ p : Fin d × Fin d, Matrix.trace (M p.1 p.1 * M p.2 p.2 * X)) = _
+  rw [Fintype.sum_prod_type]
+  simp only [physTraceTransfer, Finset.sum_mul, Matrix.mul_sum, Matrix.trace_sum]
 
 /-- Under the canonical equivalence between two-site configurations and pairs
 of physical indices, the length-two closure is `physClose2`. This is the
@@ -236,15 +264,45 @@ intertwining the one-site and two-site physical operators, namely
 
 This is the source's tp-CP-map renormalization fixed point. It is *distinct* from
 `MPOTensor.IsRFP`, the transfer-map idempotence (zero-correlation-length)
-condition: Definition 4.1 is strictly stronger for general MPDO. The implication
-`IsRFPViaTS M → IsRFP M` (Theorem 4.9, direction i ⟹ ii) is deferred future
-work (#2382, #826). -/
+condition on the doubled-index completely positive map. Theorem
+`physTraceTransfer_sq_of_isRFPViaTS` proves the source zero-correlation-length
+identity for the physical-trace transfer. It does not identify this identity
+with doubled-index transfer-map idempotence. -/
 def IsRFPViaTS (M : MPOTensor d D) : Prop :=
   ∃ (S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ)
     (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ),
     IsKrausCPTP S ∧ IsKrausCPTP T ∧
     (∀ X, S (physClose2 M X) = physClose1 M X) ∧
     (∀ X, T (physClose1 M X) = physClose2 M X)
+
+/-- Definition 4.1 implies literal idempotence of the physical-trace transfer.
+
+This is the zero-correlation-length part of arXiv:1606.00608, Proposition
+`propsimple`, lines 1333--1340: trace preservation of the map from one site to
+two sites identifies the traces of the one-site and two-site physical closures
+for every virtual boundary matrix. -/
+theorem physTraceTransfer_sq_of_isRFPViaTS (M : MPOTensor d D) (h : IsRFPViaTS M) :
+    physTraceTransfer M * physTraceTransfer M = physTraceTransfer M := by
+  obtain ⟨_, T, _, hT, _, hT_close⟩ := h
+  apply sub_eq_zero.mp
+  apply (Matrix.trace_mul_right_eq_zero_iff _).mp
+  intro X
+  rw [Matrix.sub_mul, Matrix.trace_sub, ← trace_physClose2_eq M X,
+    ← trace_physClose1_eq M X, ← hT_close X, hT.trace_map, sub_self]
+
+/-- Definition 4.1 gives source zero correlation length when the physical-trace
+transfer is nonzero.
+
+**Scope restriction (nonzero transfer):** The source assumes that the tensor is
+in canonical form and generates normalized density operators. The bare
+predicate `IsRFPViaTS` does not include these standing hypotheses, so the
+nonzero transfer is stated explicitly. This restriction is documented in
+`docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`.
+
+Source: arXiv:1606.00608, Proposition `propsimple`, lines 1333--1340. -/
+theorem isSourceZCL_of_isRFPViaTS (M : MPOTensor d D) (h : IsRFPViaTS M)
+    (h0 : physTraceTransfer M ≠ 0) : IsSourceZCL M :=
+  isSourceZCL_of_physTraceTransfer_sq M h0 (physTraceTransfer_sq_of_isRFPViaTS M h)
 
 @[deprecated _root_.finThreeArrowEquiv (since := "2026-07-13")]
 alias finThreeArrowEquiv := _root_.finThreeArrowEquiv

--- a/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
@@ -24,6 +24,27 @@
     need not agree.
 \end{definition}
 
+\begin{theorem}[Trace preservation from a Kraus resolution]
+    \label{thm:is_kraus_cptp_trace_map}
+    \lean{IsKrausCPTP.trace_map}
+    \leanok
+    \uses{def:is_kraus_cptp}
+    Every trace-preserving completely positive map in rectangular Kraus form
+    preserves the matrix trace.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    If $\mathcal S(X)=\sum_a A_a X A_a^\dagger$ and
+    $\sum_a A_a^\dagger A_a=I$, cyclicity gives
+    \[
+        \tr\mathcal S(X)
+        =\sum_a\tr(A_aXA_a^\dagger)
+        =\tr\left(\left(\sum_a A_a^\dagger A_a\right)X\right)
+        =\tr X.
+    \]
+\end{proof}
+
 \begin{lemma}[Identity map is trace-preserving completely positive]
     \label{lem:is_kraus_cptp_id}
     \lean{isKrausCPTP_id}
@@ -495,8 +516,9 @@
     $M_1(X)_{ij} = \tr(M^{ij} X)$ and
     $M_2(X)_{(i_1 i_2)(j_1 j_2)} = \tr(M^{i_1 j_1} M^{i_2 j_2} X)$ are the one-
     and two-site physical operators obtained by closing one or two tensors with
-    $X$. This condition is strictly stronger than transfer-map idempotence for
-    general mixed states, and coincides with it for pure states.
+    $X$. This condition is distinct from idempotence of the doubled-index
+    transfer map for general mixed states. Its source zero-correlation-length
+    consequence concerns the physical-trace transfer and is proved below.
     This is \cite[Definition~4.1, line~657]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
@@ -510,6 +532,60 @@
     \cite[Definition~4.1]{Cirac2016MPDO_arXiv}.}
     \label{fig:mpdo_renormalization_ts}
 \end{figure}
+
+\begin{theorem}[Renormalization fixed points have idempotent physical-trace transfer]
+    \label{thm:rfp_via_ts_physical_trace_idempotent}
+    \lean{MPOTensor.physTraceTransfer_sq_of_isRFPViaTS}
+    \leanok
+    \uses{def:is_rfp_via_ts, def:mpo_physical_trace_transfer,
+      thm:is_kraus_cptp_trace_map}
+    If $M$ is a renormalization fixed point via trace-preserving maps, then
+    \[
+        \mathcal T_M^2=\mathcal T_M.
+    \]
+    This proves the zero-correlation-length component of implication
+    (i)$\Rightarrow$(ii) in
+    \cite[Theorem~4.9, lines~851--893]{Cirac2016MPDO_arXiv}. The corresponding
+    calculation appears in the proposition ``RFP implies ZCL and SAL'' in
+    Appendix~C, lines~1333--1340; its strong-area-law component is separate.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    For every virtual matrix $X$, the one-site and two-site closures satisfy
+    \[
+        \tr M_1(X)=\tr(\mathcal T_M X),
+        \qquad
+        \tr M_2(X)=\tr(\mathcal T_M^2 X).
+    \]
+    Write $\Phi$ for the one-to-two trace-preserving map $\mathcal T$ of
+    Definition~\ref{def:is_rfp_via_ts}; this is distinct from the
+    physical-trace transfer $\mathcal T_M$. Then
+    $\Phi[M_1(X)]=M_2(X)$, and hence
+    \[
+        \tr(\mathcal T_M^2 X)=\tr M_2(X)
+        =\tr\Phi[M_1(X)]
+        =\tr M_1(X)=\tr(\mathcal T_M X).
+    \]
+    Nondegeneracy of the trace pairing now gives
+    $\mathcal T_M^2=\mathcal T_M$.
+\end{proof}
+
+\begin{theorem}[Renormalization fixed points have source zero correlation length]
+    \label{thm:rfp_via_ts_source_zcl}
+    \lean{MPOTensor.isSourceZCL_of_isRFPViaTS}
+    \leanok
+    \uses{thm:rfp_via_ts_physical_trace_idempotent,
+      thm:mpo_source_zcl_of_physical_trace_idempotent}
+    If $M$ is a renormalization fixed point via trace-preserving maps and
+    $\mathcal T_M\ne0$, then $M$ has source zero correlation length.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Apply the preceding idempotence theorem and take the positive scalar in
+    Definition~\ref{def:mpo_source_zcl} to be $1$.
+\end{proof}
 
 \begin{theorem}[Transfer-map idempotence iff doubled-index condition]
     \label{thm:is_rfp_iff_is_zcl}

--- a/docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex
+++ b/docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex
@@ -62,8 +62,10 @@ the doubled-index MPS transfer rather than by the MPDO ZCL diagram.
 
 \paragraph{Classification.} This is a wrong-transfer-object gap: the current
 formal predicate records doubled-index CP-transfer idempotence, while the source
-definition uses the physical-trace transfer. Until the latter transfer is
-formalized, unrestricted source ZCL remains open.
+definition uses the physical-trace transfer. The latter is now formalized as
+\texttt{MPOTensor.physTraceTransfer}, with source ZCL recorded by
+\texttt{MPOTensor.IsSourceZCL}; no identification with the doubled-index
+predicate is asserted.
 
 This deviation is witnessed in the development by
 \texttt{MPOTensor.exists\_isLocalPurificationRFP\_not\_isZCL}. Take $d=d_K=2$,
@@ -102,18 +104,20 @@ options:
   fusion and algebra statements, not the source's ZCL transfer.
 \end{enumerate}
 
-Until one of these is in place, \texttt{IsZCL} should be documented as a
-doubled-index CP-transfer idempotence condition, not as the unrestricted source
-Definition~4.2. The
-$\text{PRFP}\Leftrightarrow\text{ZCL}$ equivalence remains open
-(issues \#2395, \#2421).
+Option~1 is now in place. The predicate \texttt{IsZCL} remains documented as a
+doubled-index CP-transfer idempotence condition, while
+\texttt{IsSourceZCL} records Definition~4.2. For the renormalization condition
+of Definition~4.1, the forward implication to source ZCL is now proved under
+the explicit nonzero-transfer hypothesis above. The PRFP implication, the
+reverse implication in Theorem~4.9, and the full strong-area-law assembly
+remain open.
 
 \section{The faithful definition and its consequences}
 
 The faithful reading is Option~1 (source ZCL transfer). Writing $\mathcal T_M$
 for the physical-trace transfer, the normalized condition is
 \[
-  \texttt{IsZCL}\ M\ :=\ \mathcal T_M\ne 0\ \wedge\
+  \texttt{IsSourceZCL}\ M\ :=\ \mathcal T_M\ne 0\ \wedge\
   \exists\, \lambda\in\mathbb R,\ 0<\lambda
   \ \wedge\ \mathcal T_M^2 = \lambda\, \mathcal T_M .
 \]
@@ -140,6 +144,27 @@ but not ZCL under the definition above. Every source-facing description that
 calls the doubled-index literal notion ``definitionally zero correlation
 length'' must be weakened to a separate bridge, with the nonzero hypothesis
 stated explicitly.
+
+\paragraph{Definition~4.1 now gives the forward physical-trace equation.}
+The theorem
+\texttt{MPOTensor.physTraceTransfer\_sq\_of\_isRFPViaTS} formalizes the
+zero-correlation-length calculation in Appendix~C, Proposition
+\texttt{propsimple}, source lines 1333--1340. This proposition proves the first
+implication of Theorem~4.9 by establishing both ZCL and SAL; the present Lean
+theorem formalizes only its ZCL calculation. For every virtual matrix $X$,
+trace preservation of the one-to-two map gives
+\[
+  \operatorname{tr}(\mathcal T_M^2X)
+  =\operatorname{tr}(M_2(X))
+  =\operatorname{tr}(M_1(X))
+  =\operatorname{tr}(\mathcal T_MX).
+\]
+Nondegeneracy of the trace pairing yields
+$\mathcal T_M^2=\mathcal T_M$. Together with
+$\mathcal T_M\ne0$, this gives \texttt{MPOTensor.IsSourceZCL}. The explicit
+nonzero hypothesis is necessary because the bare predicate
+\texttt{IsRFPViaTS} omits the source's standing canonical-form and normalized
+MPDO assumptions.
 
 \paragraph{Effect on the purification witness.} The diagonal purification of
 Section~3 has $\mathcal T_M=1$, hence satisfies the source ZCL equation already.


### PR DESCRIPTION
## Summary

This proves the source zero-correlation-length consequence of the renormalization condition in Definition 4.1 of arXiv:1606.00608.

The proof follows Proposition `propsimple` (lines 1333–1340): trace preservation of the physical map from one site to two sites identifies the trace pairings of the one-site and two-site closures. Nondegeneracy of the matrix trace pairing then gives

\[
\mathcal T_M^2=\mathcal T_M.
\]

The source-ZCL wrapper records the nonzero-transfer condition explicitly because the present bare `IsRFPViaTS` predicate does not include the source standing assumptions of canonical form and normalized density operators.

This advances #3948. It does not close the issue: the strong-area-law implication remains to be formalized.

## Main declarations

- `IsKrausCPTP.trace_map`
- `MPOTensor.trace_physClose1_eq`
- `MPOTensor.trace_physClose2_eq`
- `MPOTensor.physTraceTransfer_sq_of_isRFPViaTS`
- `MPOTensor.isSourceZCL_of_isRFPViaTS`

## Validation

- `lake build TNLean`
- `leanblueprint checkdecls`
- reader-facing prose check
- changed-file proof-integrity scan
- `#print axioms` on all five new declarations: only `propext`, `Classical.choice`, and `Quot.sound`

No axiom or additional theorem hypothesis is introduced.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New theorems in the MPDO RFP/ZCL chain affect how paper results are wired; logic is localized and uses standard trace/Kraus lemmas, but mis-stated hypotheses (e.g. missing nonzero transfer) could mislead downstream proofs.
> 
> **Overview**
> Proves the **source zero-correlation-length** consequence of arXiv:1606.00608 Definition 4.1 (`IsRFPViaTS`): when tp-CP maps intertwine one- and two-site physical closures, the **physical-trace transfer** satisfies \(\mathcal T_M^2 = \mathcal T_M\), and with \(\mathcal T_M \neq 0\) this yields `IsSourceZCL`.
> 
> **New Lean:** `IsKrausCPTP.trace_map` (via generalized rectangular `kraus_tp_of_sum_conjTranspose_mul`); `trace_physClose1_eq` / `trace_physClose2_eq` linking traces of `physClose1`/`physClose2` to \(\mathcal T_M\) and \(\mathcal T_M^2\); `physTraceTransfer_sq_of_isRFPViaTS` and `isSourceZCL_of_isRFPViaTS` (trace preservation of the one-to-two map + nondegenerate trace pairing).
> 
> **Documentation:** Comments and the ZCL gap note now separate doubled-index `IsRFP`/`IsZCL` from Definition 4.1 and record that the forward ZCL implication is proved here (SAL and reverse Theorem 4.9 steps remain open). Blueprint chapter 21 adds matching theorems and proofs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b4724c4e6ad97baa449085ae41e3aaff2abc105. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->