### PR TITLE
doc(blueprint): flatten renormalization chapter hierarchy

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp.tex
@@ -1,10 +1,10 @@
 %% ==================================================
-%% Chapter: Mixed States
+%% Chapter: Mixed States: Renormalization of Matrix Product Operators
 %% Collects the fixed-point and zero-correlation-length conditions for MPO and
 %% MPDO tensors.
 %% ==================================================
 
-\chapter{Mixed States}\label{ch:mpdo_rfp}
+\chapter{Mixed States: Renormalization of Matrix Product Operators}\label{ch:mpdo_rfp}
 
 Starting from the MPO, MPDO, and LPDO notation of Chapter~\ref{ch:mpdo},
 this chapter studies renormalization fixed points for density-operator chains.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_algebra_tower.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_algebra_tower.tex
@@ -448,7 +448,7 @@ family, and the corresponding multiplication / inclusion coefficient arrays.
     Theorem~\ref{thm:mpdo_algebra_not_imply_fusion}.
 \end{remark}
 
-\subsection{Diagonal \texorpdfstring{$\chi$}{chi}-matrices and the trace-power formula}
+\section{Diagonal \texorpdfstring{$\chi$}{chi}-matrices and the trace-power formula}
 
 The following statements isolate the form of
 \cite[Theorem~4.14(ii)]{Cirac2016MPDO_arXiv}: the structure coefficients

--- a/blueprint/src/chapter/ch26_mps_rfp_core.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp_core.tex
@@ -1,7 +1,5 @@
 %% Core results for the pure-state renormalization fixed-point chapter.
-\section{Renormalization fixed points and zero correlation length}
-
-\subsection{Physical blocking and transfer idempotence}
+\section{Physical blocking and transfer idempotence}
 
 \begin{definition}[Physical blocking isometry]
     \label{def:physical_blocking_isometry}
@@ -129,7 +127,7 @@
     \label{fig:rfp_kraus_isometry}
 \end{figure}
 
-\subsection{Zero-correlation-length conditions}
+\section{Zero-correlation-length conditions}
 
 \begin{definition}[Single-block local orthogonality convention]%
     \label{def:is_locally_orthogonal}
@@ -316,7 +314,7 @@
     \]
 \end{proof}
 
-\subsection{Normal tensors and isometry canonical forms}
+\section{Normal tensors and isometry canonical forms}
 
 \begin{theorem}[RFP normal tensor is injective]\label{thm:rfp_nt_injective}
     \lean{MPSTensor.rfp_nt_structural}
@@ -749,7 +747,7 @@
 % Scope restriction: cross-block orthogonality omitted here; see
 % docs/paper-gaps/cpsv16_rfp_isometry_scope.tex.
 
-\subsection{Direct sums and residual isometries}
+\section{Direct sums and residual isometries}
 
 \begin{lemma}[Block decomposition of the direct-sum transfer map]%
     \label{lem:block_diagonal_transfer_sum_to_block}
@@ -1268,7 +1266,7 @@
     Hence $\E_A^2\ne\E_A$.
 \end{proof}
 
-\subsection{Renormalization flow and physical correlations}
+\section{Renormalization flow and physical correlations}
 
 \begin{theorem}[Canonical-form blocks are injective]\label{thm:rfp_cf_structural}
     \lean{MPSTensor.rfp_cf_structural}

--- a/blueprint/src/macros/print.tex
+++ b/blueprint/src/macros/print.tex
@@ -9,6 +9,11 @@
 % sense only for the web version, such as dependency graph
 % macros.
 
+% Leave enough room for two-digit section numbers in the table of contents.
+\makeatletter
+\renewcommand*\l@section{\@dottedtocline{1}{1.5em}{3em}}
+\makeatother
+
 
 % Print-side status badges for LeanBlueprint annotations.  The web build uses
 % plasTeX userdata to put the same information in theorem headers and graph

--- a/docs/blueprint_style_guide.md
+++ b/docs/blueprint_style_guide.md
@@ -135,6 +135,10 @@ enforced by the dedicated `Blueprint Sync & Prose Review` CI workflow.
   within a subsection when one is present, and otherwise within the section.
   Thus an entry in Subsection 22.4.4 is numbered `22.4.4.n`, while an entry
   directly under Section 6.2 is numbered `6.2.n`.
+- Do not introduce a redundant sole division. If all of a chapter lies in one
+  section, remove that wrapper and promote its subsections to sections. If a
+  section would contain only one subsection, promote that subsection to a
+  section or remove the unnecessary subdivision.
 
 ### Display hierarchy for formal declarations
 


### PR DESCRIPTION
## Summary

- present the five pure-state renormalization topics as Sections 22.1--22.5, without a redundant common section;
- rename the mixed-state chapter to "Mixed States: Renormalization of Matrix Product Operators";
- promote the diagonal $\chi$-matrix and trace-power material from a lone subsection to Section 23.7;
- record the rule against sole divisions in the blueprint style guide;
- widen section-number entries in the printed contents so two-digit section numbers remain separated from their titles.

## Rationale

The pure-state chapter contains five distinct mathematical topics, while the previous wrapper made every declaration number pass through an uninformative extra level. The mixed-state algebra material likewise had a section containing a single subsection. The revised hierarchy exposes the actual mathematical organization and gives declarations shorter, section-based numbers. No mathematical statement or proof is changed.

## Validation

- `leanblueprint checkdecls`
- `leanblueprint pdf`
- `leanblueprint web`
- repository-wide `chktex` check (with the existing standalone `\blueprintcontent` resolution warnings)
- visual inspection of the contents page, both chapter openings, the pure-state Section 22.2 transition, and the mixed-state Section 23.7 transition

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and LaTeX hierarchy only; no Lean or mathematical content changes.
> 
> **Overview**
> Restructures the blueprint **table of contents** so declaration numbering matches the mathematical topics, without changing any statements or proofs.
> 
> The pure-state renormalization chapter (`ch26_mps_rfp_core.tex`) drops a redundant wrapper section; its five former subsections are now **Sections 22.1–22.5** (physical blocking, zero correlation length, normal tensors/isometry forms, direct sums, RG flow). The mixed-state chapter title becomes **“Mixed States: Renormalization of Matrix Product Operators”**, and the diagonal **χ** / trace-power block in `ch21_mpdo_rfp_algebra_tower.tex` is promoted from a lone subsection to **Section 23.7**.
> 
> `docs/blueprint_style_guide.md` now forbids **sole divisions** (one section wrapping everything, or one subsection under a section). Printed PDF TOC layout in `print.tex` widens section-number columns so two-digit section numbers do not run into titles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3a972f0e41f808871186aeb656fb21e54f0d0ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->