### PR TITLE
feat(MPS/MPDO): prove one topological-projector fusion layer

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -484,6 +484,7 @@ import TNLean.MPS.MPDO.BNTTripleFusionComparison
 import TNLean.MPS.MPDO.BNTFinalSectorFusion
 import TNLean.MPS.MPDO.BNTFourfoldFusionIndices
 import TNLean.MPS.MPDO.BNTTripleFusionSeparation
+import TNLean.MPS.MPDO.TopologicalProjectors
 import TNLean.MPS.MPDO.BNTFixedFinalUnitarity
 import TNLean.MPS.MPDO.CompleteZipperFusion
 import TNLean.MPS.MPDO.CompleteZipperFusionInverse

--- a/TNLean/MPS/MPDO/TopologicalProjectors.lean
+++ b/TNLean/MPS/MPDO/TopologicalProjectors.lean
@@ -10,7 +10,7 @@ import TNLean.MPS.MPDO.BNTTripleFusionSeparation
 # The local projectors in the length-independent fusion form
 
 For the length-independent case following Theorem IV.13 of
-arXiv:1606.00608, every diagonal matrix
+arXiv:1606.00608, every structure matrix
 $\chi_{\alpha,\beta,\gamma}$ is the identity on its multiplicity space.
 Consequently, if the terminal matrices $P_\gamma$ are orthogonal
 projections, then

--- a/TNLean/MPS/MPDO/TopologicalProjectors.lean
+++ b/TNLean/MPS/MPDO/TopologicalProjectors.lean
@@ -35,7 +35,6 @@ decomposition are separate steps.
 -/
 
 open scoped Matrix Kronecker
-open Matrix
 
 namespace MPOTensor.BNTFusionIsometryFamily
 

--- a/TNLean/MPS/MPDO/TopologicalProjectors.lean
+++ b/TNLean/MPS/MPDO/TopologicalProjectors.lean
@@ -25,14 +25,13 @@ $U_{\alpha,\beta}^\dagger Q_{\alpha,\beta}U_{\alpha,\beta}$ is again an
 orthogonal projection.
 
 These are the one-fusion-step projector statements in the recursive
-construction denoted by `Projector-Q` in the source.  The spectral
-decomposition of the terminal matrices, iteration along an arbitrary chain,
-and the commuting Gibbs decomposition are separate steps.
+construction at source lines 999--1010.  The spectral decomposition of the
+terminal matrices, iteration along an arbitrary chain, and the commuting Gibbs
+decomposition are separate steps.
 
 ## References
 
-* arXiv:1606.00608, equation `Projector-Q` and the discussion at lines
-  999--1016.
+* arXiv:1606.00608, lines 999--1016.
 -/
 
 open scoped Matrix Kronecker
@@ -43,10 +42,10 @@ namespace MPOTensor.BNTFusionIsometryFamily
 variable {g p : ℕ}
 variable (Fam : BNTFusionIsometryFamily (Fin g) p)
 
-/-- The single fusion layer of the operator $Q$ from equation `Projector-Q`,
+/-- The single fusion layer of the operator $Q$ at source lines 999--1010,
 with terminal matrices $P_\gamma$.
 
-Source: arXiv:1606.00608, equation `Projector-Q`, lines 999--1010 of
+Source: arXiv:1606.00608, lines 999--1010 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 noncomputable def projectorQBlock
     (P : ∀ γ : Fin g,
@@ -58,8 +57,8 @@ noncomputable def projectorQBlock
         (Fin (Fam.chi.dim α β γ) × Fin (Fam.bondDim γ))) ℂ :=
   Matrix.blockDiagonal' fun γ => Fam.chi.matrix α β γ ⊗ₖ P γ
 
-/-- In the length-independent case, the chi matrices in a single
-`Projector-Q` layer are identities.
+/-- In the length-independent case, the chi matrices in a single fusion layer
+are identities.
 
 Source: arXiv:1606.00608, lines 999--1010 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
@@ -77,8 +76,9 @@ theorem projectorQBlock_eq_unweighted
   unfold projectorQBlock
   simp_rw [Fam.chi_matrix_eq_one_of_lengthIndependent c hχ hLI]
 
-/-- A single `Projector-Q` layer is a projection when its terminal matrices
-are projections and the structure coefficients are length independent.
+/-- A single fusion layer is a self-adjoint idempotent when its terminal
+matrices are self-adjoint idempotents and the structure coefficients are
+length independent.
 
 Source: arXiv:1606.00608, lines 999--1010 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
@@ -106,7 +106,7 @@ theorem projectorQBlock_isStarProjection
       simpa [Matrix.star_eq_conjTranspose] using (hP γ).isSelfAdjoint.star_eq
     rw [hPγ]
 
-/-- The `Projector-Q` layer transported to the product bond space by the
+/-- The fusion-layer operator transported to the product bond space by the
 fusion map.
 
 Source: arXiv:1606.00608, lines 999--1010 of
@@ -121,11 +121,11 @@ noncomputable def conjugatedProjectorQBlock
     Fam.fusionIsometry α β
 
 /-- For a source basis of normal tensors, the fusion map is unitary in the
-length-independent case, so conjugating a `Projector-Q` layer gives an
+length-independent case, so conjugating the fusion-layer operator gives an
 orthogonal projection on the product bond space.
 
-Source: arXiv:1606.00608, BNT separation at lines 317--345, equation
-`Ualphabeta` at lines 986--993, and `Projector-Q` at lines 999--1010 of
+Source: arXiv:1606.00608, BNT separation at lines 317--345, the fusion map at
+lines 986--993, and the recursive projector at lines 999--1010 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem conjugatedProjectorQBlock_isOrthogonalProjection
     {D : ℕ} {A : MPSTensor (p * p) D}

--- a/TNLean/MPS/MPDO/TopologicalProjectors.lean
+++ b/TNLean/MPS/MPDO/TopologicalProjectors.lean
@@ -1,0 +1,179 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.Irreducible.Basic
+import TNLean.MPS.MPDO.BNTTripleFusionSeparation
+
+/-!
+# The local projectors in the length-independent fusion form
+
+For the length-independent case following Theorem IV.13 of
+arXiv:1606.00608, every diagonal matrix
+$\chi_{\alpha,\beta,\gamma}$ is the identity on its multiplicity space.
+Consequently, if the terminal matrices $P_\gamma$ are orthogonal
+projections, then
+\[
+  Q_{\alpha,\beta}
+    = \bigoplus_\gamma
+        \chi_{\alpha,\beta,\gamma}\otimes P_\gamma
+\]
+is a projection.  If the labelled tensors form a basis of normal tensors,
+the corresponding fusion map is unitary, and
+$U_{\alpha,\beta}^\dagger Q_{\alpha,\beta}U_{\alpha,\beta}$ is again an
+orthogonal projection.
+
+These are the one-fusion-step projector statements in the recursive
+construction denoted by `Projector-Q` in the source.  The spectral
+decomposition of the terminal matrices, iteration along an arbitrary chain,
+and the commuting Gibbs decomposition are separate steps.
+
+## References
+
+* arXiv:1606.00608, equation `Projector-Q` and the discussion at lines
+  999--1016.
+-/
+
+open scoped Matrix Kronecker
+open Matrix
+
+namespace MPOTensor.BNTFusionIsometryFamily
+
+variable {g p : ℕ}
+variable (Fam : BNTFusionIsometryFamily (Fin g) p)
+
+/-- The single fusion layer of the operator $Q$ from equation `Projector-Q`,
+with terminal matrices $P_\gamma$.
+
+Source: arXiv:1606.00608, equation `Projector-Q`, lines 999--1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+noncomputable def projectorQBlock
+    (P : ∀ γ : Fin g,
+      Matrix (Fin (Fam.bondDim γ)) (Fin (Fam.bondDim γ)) ℂ)
+    (α β : Fin g) :
+    Matrix ((γ : Fin g) ×
+        (Fin (Fam.chi.dim α β γ) × Fin (Fam.bondDim γ)))
+      ((γ : Fin g) ×
+        (Fin (Fam.chi.dim α β γ) × Fin (Fam.bondDim γ))) ℂ :=
+  Matrix.blockDiagonal' fun γ => Fam.chi.matrix α β γ ⊗ₖ P γ
+
+/-- In the length-independent case, the chi matrices in a single
+`Projector-Q` layer are identities.
+
+Source: arXiv:1606.00608, lines 999--1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem projectorQBlock_eq_unweighted
+    (c : BNTLabelCoefficientFamily (Fin g))
+    (hχ : c.HasPositiveLengthChiTracePowerForm Fam.chi)
+    (hLI : c.LengthIndependent)
+    (P : ∀ γ : Fin g,
+      Matrix (Fin (Fam.bondDim γ)) (Fin (Fam.bondDim γ)) ℂ)
+    (α β : Fin g) :
+    Fam.projectorQBlock P α β =
+      Matrix.blockDiagonal' fun γ =>
+        (1 : Matrix (Fin (Fam.chi.dim α β γ))
+          (Fin (Fam.chi.dim α β γ)) ℂ) ⊗ₖ P γ := by
+  unfold projectorQBlock
+  simp_rw [Fam.chi_matrix_eq_one_of_lengthIndependent c hχ hLI]
+
+/-- A single `Projector-Q` layer is a projection when its terminal matrices
+are projections and the structure coefficients are length independent.
+
+Source: arXiv:1606.00608, lines 999--1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem projectorQBlock_isStarProjection
+    (c : BNTLabelCoefficientFamily (Fin g))
+    (hχ : c.HasPositiveLengthChiTracePowerForm Fam.chi)
+    (hLI : c.LengthIndependent)
+    (P : ∀ γ : Fin g,
+      Matrix (Fin (Fam.bondDim γ)) (Fin (Fam.bondDim γ)) ℂ)
+    (hP : ∀ γ : Fin g, IsStarProjection (P γ))
+    (α β : Fin g) :
+    IsStarProjection (Fam.projectorQBlock P α β) := by
+  rw [Fam.projectorQBlock_eq_unweighted c hχ hLI]
+  rw [isStarProjection_iff']
+  constructor
+  · rw [← Matrix.blockDiagonal'_mul]
+    congr 1
+    funext γ
+    rw [← Matrix.mul_kronecker_mul, Matrix.one_mul, (hP γ).isIdempotentElem.eq]
+  · rw [Matrix.star_eq_conjTranspose, Matrix.blockDiagonal'_conjTranspose]
+    congr 1
+    funext γ
+    rw [Matrix.conjTranspose_kronecker, Matrix.conjTranspose_one]
+    have hPγ : (P γ)ᴴ = P γ := by
+      simpa [Matrix.star_eq_conjTranspose] using (hP γ).isSelfAdjoint.star_eq
+    rw [hPγ]
+
+/-- The `Projector-Q` layer transported to the product bond space by the
+fusion map.
+
+Source: arXiv:1606.00608, lines 999--1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+noncomputable def conjugatedProjectorQBlock
+    (P : ∀ γ : Fin g,
+      Matrix (Fin (Fam.bondDim γ)) (Fin (Fam.bondDim γ)) ℂ)
+    (α β : Fin g) :
+    Matrix (Fin (Fam.bondDim α * Fam.bondDim β))
+      (Fin (Fam.bondDim α * Fam.bondDim β)) ℂ :=
+  (Fam.fusionIsometry α β)ᴴ * Fam.projectorQBlock P α β *
+    Fam.fusionIsometry α β
+
+/-- For a source basis of normal tensors, the fusion map is unitary in the
+length-independent case, so conjugating a `Projector-Q` layer gives an
+orthogonal projection on the product bond space.
+
+Source: arXiv:1606.00608, BNT separation at lines 317--345, equation
+`Ualphabeta` at lines 986--993, and `Projector-Q` at lines 999--1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem conjugatedProjectorQBlock_isOrthogonalProjection
+    {D : ℕ} {A : MPSTensor (p * p) D}
+    (hBNT : MPSTensor.IsCPSVBasisOfNormalTensors A
+      (fun γ : Fin g =>
+        ⟨Fam.bondDim γ, (Fam.tensor γ).toMPSTensor⟩))
+    (c : BNTLabelCoefficientFamily (Fin g))
+    (hχ : c.HasPositiveLengthChiTracePowerForm Fam.chi)
+    (hLI : c.LengthIndependent)
+    (P : ∀ γ : Fin g,
+      Matrix (Fin (Fam.bondDim γ)) (Fin (Fam.bondDim γ)) ℂ)
+    (hP : ∀ γ : Fin g, IsStarProjection (P γ))
+    (α β : Fin g) :
+    IsOrthogonalProjection (Fam.conjugatedProjectorQBlock P α β) := by
+  refine IsStarProjection.isOrthogonalProjection ?_
+  have hQ := Fam.projectorQBlock_isStarProjection c hχ hLI P hP α β
+  have hU := Fam.fusionIsometry_mul_conjTranspose_eq_one_of_bnt_of_lengthIndependent
+    hBNT c hχ hLI α β
+  rw [isStarProjection_iff']
+  constructor
+  · unfold conjugatedProjectorQBlock
+    calc
+      (Fam.fusionIsometry α β)ᴴ * Fam.projectorQBlock P α β *
+          Fam.fusionIsometry α β *
+          ((Fam.fusionIsometry α β)ᴴ * Fam.projectorQBlock P α β *
+            Fam.fusionIsometry α β) =
+        (Fam.fusionIsometry α β)ᴴ *
+          (Fam.projectorQBlock P α β *
+            ((Fam.fusionIsometry α β * (Fam.fusionIsometry α β)ᴴ) *
+              (Fam.projectorQBlock P α β * Fam.fusionIsometry α β))) := by
+            simp only [Matrix.mul_assoc]
+      _ = (Fam.fusionIsometry α β)ᴴ *
+          (Fam.projectorQBlock P α β *
+            (Fam.projectorQBlock P α β * Fam.fusionIsometry α β)) := by
+            rw [hU, Matrix.one_mul]
+      _ = (Fam.fusionIsometry α β)ᴴ *
+          ((Fam.projectorQBlock P α β * Fam.projectorQBlock P α β) *
+            Fam.fusionIsometry α β) := by
+            simp only [Matrix.mul_assoc]
+      _ = (Fam.fusionIsometry α β)ᴴ * Fam.projectorQBlock P α β *
+          Fam.fusionIsometry α β := by
+            rw [hQ.isIdempotentElem.eq, Matrix.mul_assoc]
+  · rw [Matrix.star_eq_conjTranspose]
+    unfold conjugatedProjectorQBlock
+    rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_mul,
+      Matrix.conjTranspose_conjTranspose]
+    have hQadj : (Fam.projectorQBlock P α β)ᴴ = Fam.projectorQBlock P α β := by
+      simpa [Matrix.star_eq_conjTranspose] using hQ.isSelfAdjoint.star_eq
+    rw [hQadj, Matrix.mul_assoc]
+
+end MPOTensor.BNTFusionIsometryFamily

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -913,6 +913,46 @@ separate step.
     Theorem~\ref{thm:mpdo_pair_fusion_selector_completeness}.
 \end{proof}
 
+\begin{theorem}[One fusion layer of the topological projector]%
+    \label{thm:mpdo_topological_projector_one_fusion}
+    \lean{MPOTensor.BNTFusionIsometryFamily.projectorQBlock}
+    \lean{MPOTensor.BNTFusionIsometryFamily.projectorQBlock_eq_unweighted}
+    \lean{MPOTensor.BNTFusionIsometryFamily.projectorQBlock_isStarProjection}
+    \lean{MPOTensor.BNTFusionIsometryFamily.conjugatedProjectorQBlock}
+    \lean{MPOTensor.BNTFusionIsometryFamily.%
+        conjugatedProjectorQBlock_isOrthogonalProjection}
+    \leanok
+    \uses{thm:mpdo_pair_fusion_bnt_completeness,
+        thm:mpdo_bnt_length_independent_zipper}
+    Let $P_\gamma$ be orthogonal projections on the terminal bond spaces.
+    For one layer of the recursive operator $Q$ in equation
+    \texttt{Projector-Q}, set
+    \[
+        Q_{\alpha,\beta}
+          =\bigoplus_\gamma
+             \chi_{\alpha,\beta,\gamma}\otimes P_\gamma.
+    \]
+    If the positive trace-power coefficients are independent of the positive
+    chain length, then
+    \[
+        Q_{\alpha,\beta}
+          =\bigoplus_\gamma
+             1_{r_{\alpha,\beta}^{\gamma}}\otimes P_\gamma
+    \]
+    is an orthogonal projection.  If the labelled tensors form a basis of
+    normal tensors, then
+    $U_{\alpha,\beta}^{\dagger}Q_{\alpha,\beta}U_{\alpha,\beta}$ is also an
+    orthogonal projection.  This is the single recursive fusion step in
+    \cite[lines~999--1010]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+\begin{proof}\leanok
+    Length independence makes each diagonal matrix
+    $\chi_{\alpha,\beta,\gamma}$ the identity.  Direct sums and tensoring
+    with an identity preserve self-adjointness and idempotence.  By
+    Theorem~\ref{thm:mpdo_pair_fusion_bnt_completeness}, the fusion map is
+    unitary, so conjugation by it preserves an orthogonal projection.
+\end{proof}
+
 \begin{theorem}[Left iterated fusion completeness]%
     \label{thm:mpdo_left_fusion_selector_completeness}
     \lean{MPOTensor.BNTFusionIsometryFamily.%

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -913,44 +913,73 @@ separate step.
     Theorem~\ref{thm:mpdo_pair_fusion_selector_completeness}.
 \end{proof}
 
-\begin{theorem}[One fusion layer of the topological projector]%
-    \label{thm:mpdo_topological_projector_one_fusion}
+\begin{definition}[One fusion layer of the topological projector]%
+    \label{def:mpdo_topological_projector_one_fusion}
     \lean{MPOTensor.BNTFusionIsometryFamily.projectorQBlock}
-    \lean{MPOTensor.BNTFusionIsometryFamily.projectorQBlock_eq_unweighted}
-    \lean{MPOTensor.BNTFusionIsometryFamily.projectorQBlock_isStarProjection}
     \lean{MPOTensor.BNTFusionIsometryFamily.conjugatedProjectorQBlock}
-    \lean{MPOTensor.BNTFusionIsometryFamily.%
-        conjugatedProjectorQBlock_isOrthogonalProjection}
     \leanok
-    \uses{thm:mpdo_pair_fusion_bnt_completeness,
-        thm:mpdo_bnt_length_independent_zipper}
-    Let $P_\gamma$ be orthogonal projections on the terminal bond spaces.
-    For one layer of the recursive operator $Q$ in equation
-    \texttt{Projector-Q}, set
+    \uses{def:mpdo_bnt_fusion_isometry_family}
+    Let $P_\gamma$ be operators on the terminal bond spaces.  Define one
+    fusion layer of the recursive operator $Q$ by
     \[
         Q_{\alpha,\beta}
           =\bigoplus_\gamma
              \chi_{\alpha,\beta,\gamma}\otimes P_\gamma.
     \]
-    If the positive trace-power coefficients are independent of the positive
-    chain length, then
+    Its transport to the product bond space is
+    \[
+        \widehat Q_{\alpha,\beta}
+          =U_{\alpha,\beta}^{\dagger}Q_{\alpha,\beta}U_{\alpha,\beta}.
+    \]
+\end{definition}
+
+\begin{theorem}[Projection property of one fusion layer]%
+    \label{thm:mpdo_topological_projector_one_fusion}
+    \lean{MPOTensor.BNTFusionIsometryFamily.projectorQBlock_eq_unweighted}
+    \lean{MPOTensor.BNTFusionIsometryFamily.projectorQBlock_isStarProjection}
+    \lean{MPOTensor.BNTFusionIsometryFamily.%
+        conjugatedProjectorQBlock_isOrthogonalProjection}
+    \leanok
+    \uses{def:mpdo_topological_projector_one_fusion,
+        thm:mpdo_pair_fusion_bnt_completeness,
+        thm:mpdo_bnt_length_independent_zipper}
+    Let $P_\gamma$ be self-adjoint idempotents on the terminal bond spaces.
+    Suppose that the matrices $\chi_{\alpha,\beta,\gamma}$ have the
+    positive-length trace-power form of the label-coefficient family and that
+    this family is independent of the positive chain length.  Then
     \[
         Q_{\alpha,\beta}
           =\bigoplus_\gamma
              1_{r_{\alpha,\beta}^{\gamma}}\otimes P_\gamma
     \]
-    is an orthogonal projection.  If the labelled tensors form a basis of
-    normal tensors, then
-    $U_{\alpha,\beta}^{\dagger}Q_{\alpha,\beta}U_{\alpha,\beta}$ is also an
-    orthogonal projection.  This is the single recursive fusion step in
+    is self-adjoint and idempotent.  If the labelled tensors form a basis of
+    normal tensors, then $\widehat Q_{\alpha,\beta}$ is an orthogonal
+    projection.  This is the single recursive fusion step in
     \cite[lines~999--1010]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 \begin{proof}\leanok
-    Length independence makes each diagonal matrix
-    $\chi_{\alpha,\beta,\gamma}$ the identity.  Direct sums and tensoring
-    with an identity preserve self-adjointness and idempotence.  By
-    Theorem~\ref{thm:mpdo_pair_fusion_bnt_completeness}, the fusion map is
-    unitary, so conjugation by it preserves an orthogonal projection.
+    The trace-power hypothesis and length independence give
+    $\chi_{\alpha,\beta,\gamma}=1$.  Hence
+    \[
+      Q_{\alpha,\beta}^{\dagger}
+        =\bigoplus_\gamma(1\otimes P_\gamma^{\dagger})
+        =Q_{\alpha,\beta},
+      \qquad
+      Q_{\alpha,\beta}^{2}
+        =\bigoplus_\gamma(1\otimes P_\gamma^{2})
+        =Q_{\alpha,\beta}.
+    \]
+    By Theorem~\ref{thm:mpdo_pair_fusion_bnt_completeness},
+    $U_{\alpha,\beta}U_{\alpha,\beta}^{\dagger}=1$.  Therefore
+    \[
+      \widehat Q_{\alpha,\beta}^{\dagger}=\widehat Q_{\alpha,\beta},
+      \qquad
+      \widehat Q_{\alpha,\beta}^{2}
+        =U_{\alpha,\beta}^{\dagger}Q_{\alpha,\beta}
+          (U_{\alpha,\beta}U_{\alpha,\beta}^{\dagger})
+          Q_{\alpha,\beta}U_{\alpha,\beta}
+        =\widehat Q_{\alpha,\beta}.
+    \]
 \end{proof}
 
 \begin{theorem}[Left iterated fusion completeness]%


### PR DESCRIPTION
## Mathematical content

This proves the single recursive fusion step in the construction denoted by `Projector-Q` in arXiv:1606.00608, lines 999–1010.

For terminal orthogonal projections $P_\gamma$, the operator

$$Q_{\alpha,\beta}=\bigoplus_\gamma \chi_{\alpha,\beta,\gamma}\otimes P_\gamma$$

is shown to be a projection under length independence. The source BNT hypothesis then makes the pair fusion isometry unitary, so $U_{\alpha,\beta}^{\dagger}Q_{\alpha,\beta}U_{\alpha,\beta}$ is also an orthogonal projection.

This is a source-faithful intermediate toward #3950. It does not claim the arbitrary-chain iteration, terminal spectral refinement, commutation, or the final Gibbs decomposition.

## Blueprint

The corresponding theorem and proof are added to the MPDO fusion-isometry chapter, with the source line range and dependencies recorded.

## Verification

- `lake env lean TNLean/MPS/MPDO/TopologicalProjectors.lean`
- `lake build TNLean.MPS.MPDO.TopologicalProjectors -q --log-level=info`
- `lake build TNLean -q --log-level=info`
- blueprint source synchronization and declaration checks
- reader-facing prose and changed-declaration coverage checks
- proof-integrity scan and `#print axioms` audit

No new `sorry`, axiom, or kernel bypass is introduced.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formal proofs and blueprint sync only; no runtime, auth, or data-path changes. Relies on established BNT fusion lemmas from adjacent modules.
> 
> **Overview**
> Adds **`TopologicalProjectors.lean`** and wires it into the root import list, formalizing the **single recursive fusion step** for the topological projector \(Q\) (arXiv:1606.00608, lines 999–1010).
> 
> **`projectorQBlock`** builds one fusion layer \(\bigoplus_\gamma \chi_{\alpha,\beta,\gamma}\otimes P_\gamma\); under length independence the \(\chi\) factors become identities. With terminal **star projections** \(P_\gamma\), that block is a **star projection**; **`conjugatedProjectorQBlock`** conjugates by the pair fusion isometry and is an **orthogonal projection** when labelled tensors form a **BNT basis** (using existing pair-fusion unitarity).
> 
> The MPDO fusion-isometries blueprint chapter gains matching **definition** and **theorem** entries with `\lean` links and a proof sketch aligned with the Lean development. This step does **not** cover chain iteration, terminal spectral refinement, or the Gibbs decomposition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62b958f73107caf85f175d494f9d34e4a92135a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->