### PR TITLE
feat(MPS/MPDO): globalize RFP physical channels

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -411,6 +411,7 @@ import TNLean.MPS.MPDO.RFP
 import TNLean.MPS.MPDO.KrausCPTP
 import TNLean.MPS.MPDO.LocalizedKrausCPTP
 import TNLean.MPS.MPDO.RFPViaTS
+import TNLean.MPS.MPDO.RFPViaTSGlobal
 import TNLean.MPS.MPDO.PhysicalBlocking
 import TNLean.MPS.MPDO.PRFP
 import TNLean.MPS.MPDO.LocalPurificationRFP

--- a/TNLean/Algebra/FinTupleEquiv.lean
+++ b/TNLean/Algebra/FinTupleEquiv.lean
@@ -23,6 +23,10 @@ on short finite index types.
 
 ## Main statements
 
+* `finSuccArrowEquiv_apply`: gives the first coordinate and the remaining tuple.
+* `finSuccArrowEquiv_symm_apply`: reconstructs a tuple from its first coordinate and tail.
+* `finAddTwoArrowEquiv_apply`: gives the first two coordinates and the remaining tuple.
+* `finAddTwoArrowEquiv_symm_apply`: reconstructs a tuple from its first two coordinates and tail.
 * `finThreeArrowEquiv_apply`: gives the ordered coordinates of the forward map.
 * `finThreeArrowEquiv_symm_apply`: gives the ordered coordinates of the inverse map.
 * `finFourArrowEquiv_apply`: gives the ordered coordinates of the forward map.
@@ -87,11 +91,13 @@ def finSuccArrowEquiv (α : Type*) (N : ℕ) :
     (Fin (N + 1) → α) ≃ α × (Fin N → α) :=
   (Fin.consEquiv fun _ : Fin (N + 1) ↦ α).symm
 
+/-- The forward identification extracts the first coordinate and the remaining tuple. -/
 @[simp] theorem finSuccArrowEquiv_apply {α : Type*} (N : ℕ)
     (σ : Fin (N + 1) → α) :
     finSuccArrowEquiv α N σ = (σ 0, Fin.tail σ) :=
   rfl
 
+/-- The inverse identification reconstructs a tuple from its first coordinate and tail. -/
 @[simp] theorem finSuccArrowEquiv_symm_apply {α : Type*} (N : ℕ)
     (p : α × (Fin N → α)) :
     (finSuccArrowEquiv α N).symm p = Fin.cons p.1 p.2 :=
@@ -104,11 +110,13 @@ def finAddTwoArrowEquiv (α : Type*) (N : ℕ) :
     ((Equiv.prodCongr (Equiv.refl α) (finSuccArrowEquiv α N)).trans
       (Equiv.prodAssoc α α (Fin N → α)).symm)
 
+/-- The forward identification extracts the first two coordinates and the remaining tuple. -/
 @[simp] theorem finAddTwoArrowEquiv_apply {α : Type*} (N : ℕ)
     (σ : Fin (N + 2) → α) :
     finAddTwoArrowEquiv α N σ = ((σ 0, σ 1), Fin.tail (Fin.tail σ)) :=
   rfl
 
+/-- The inverse identification reconstructs a tuple from its first two coordinates and tail. -/
 @[simp] theorem finAddTwoArrowEquiv_symm_apply {α : Type*} (N : ℕ)
     (p : (α × α) × (Fin N → α)) :
     (finAddTwoArrowEquiv α N).symm p = Fin.cons p.1.1 (Fin.cons p.1.2 p.2) :=

--- a/TNLean/Algebra/FinTupleEquiv.lean
+++ b/TNLean/Algebra/FinTupleEquiv.lean
@@ -9,10 +9,12 @@ import Mathlib.Logic.Equiv.Fin.Basic
 import Mathlib.Tactic.FinCases
 
 /-!
-# Equivalences for short finite tuples
+# Equivalences for finite tuples
 
-This file records canonical right-associated product coordinates for functions
-on short finite index types.
+This file records canonical product coordinates for functions on finite index
+types.  It includes right-associated coordinates in lengths three and four,
+and equivalences separating the first one or two coordinates from a tuple of
+arbitrary remaining length.
 
 ## Main definitions
 
@@ -34,8 +36,10 @@ on short finite index types.
 
 ## Implementation notes
 
-The product coordinates are right-associated and are constructed recursively
-from Mathlib's `finTwoArrowEquiv` using `Fin.consEquiv`.
+The fixed-length product coordinates are right-associated and are constructed
+recursively from Mathlib's `finTwoArrowEquiv` using `Fin.consEquiv`.  The
+variable-length equivalences use `Fin.consEquiv` to separate the prescribed
+initial coordinates from the remaining tuple.
 
 ## Tags
 

--- a/TNLean/Algebra/FinTupleEquiv.lean
+++ b/TNLean/Algebra/FinTupleEquiv.lean
@@ -18,8 +18,8 @@ on short finite index types.
 
 * `finThreeArrowEquiv`: identifies a function on `Fin 3` with a right-associated triple.
 * `finFourArrowEquiv`: identifies a function on `Fin 4` with a right-associated quadruple.
-* `MPOTensor.firstSiteRestEquiv`: separates the first coordinate from a finite tuple.
-* `MPOTensor.firstTwoSitesRestEquiv`: separates the first two coordinates.
+* `finSuccArrowEquiv`: separates the first coordinate from a finite tuple.
+* `finAddTwoArrowEquiv`: separates the first two coordinates.
 
 ## Main statements
 
@@ -80,40 +80,36 @@ coordinates in order. -/
   funext i
   fin_cases i <;> rfl
 
-namespace MPOTensor
-
 /-! ### A fixed initial segment and a variable remaining tuple -/
 
-/-- Separate the first physical index from the remaining `N` indices. -/
-def firstSiteRestEquiv (d N : ℕ) :
-    (Fin (N + 1) → Fin d) ≃ Fin d × (Fin N → Fin d) :=
-  (Fin.consEquiv fun _ : Fin (N + 1) ↦ Fin d).symm
+/-- Separate the first coordinate from the remaining `N` coordinates. -/
+def finSuccArrowEquiv (α : Type*) (N : ℕ) :
+    (Fin (N + 1) → α) ≃ α × (Fin N → α) :=
+  (Fin.consEquiv fun _ : Fin (N + 1) ↦ α).symm
 
-@[simp] theorem firstSiteRestEquiv_apply (d N : ℕ)
-    (σ : Fin (N + 1) → Fin d) :
-    firstSiteRestEquiv d N σ = (σ 0, Fin.tail σ) :=
+@[simp] theorem finSuccArrowEquiv_apply {α : Type*} (N : ℕ)
+    (σ : Fin (N + 1) → α) :
+    finSuccArrowEquiv α N σ = (σ 0, Fin.tail σ) :=
   rfl
 
-@[simp] theorem firstSiteRestEquiv_symm_apply (d N : ℕ)
-    (p : Fin d × (Fin N → Fin d)) :
-    (firstSiteRestEquiv d N).symm p = Fin.cons p.1 p.2 :=
+@[simp] theorem finSuccArrowEquiv_symm_apply {α : Type*} (N : ℕ)
+    (p : α × (Fin N → α)) :
+    (finSuccArrowEquiv α N).symm p = Fin.cons p.1 p.2 :=
   rfl
 
-/-- Separate the first two physical indices from the remaining `N` indices. -/
-def firstTwoSitesRestEquiv (d N : ℕ) :
-    (Fin (N + 2) → Fin d) ≃ (Fin d × Fin d) × (Fin N → Fin d) :=
-  (firstSiteRestEquiv d (N + 1)).trans
-    ((Equiv.prodCongr (Equiv.refl (Fin d)) (firstSiteRestEquiv d N)).trans
-      (Equiv.prodAssoc (Fin d) (Fin d) (Fin N → Fin d)).symm)
+/-- Separate the first two coordinates from the remaining `N` coordinates. -/
+def finAddTwoArrowEquiv (α : Type*) (N : ℕ) :
+    (Fin (N + 2) → α) ≃ (α × α) × (Fin N → α) :=
+  (finSuccArrowEquiv α (N + 1)).trans
+    ((Equiv.prodCongr (Equiv.refl α) (finSuccArrowEquiv α N)).trans
+      (Equiv.prodAssoc α α (Fin N → α)).symm)
 
-@[simp] theorem firstTwoSitesRestEquiv_apply (d N : ℕ)
-    (σ : Fin (N + 2) → Fin d) :
-    firstTwoSitesRestEquiv d N σ = ((σ 0, σ 1), Fin.tail (Fin.tail σ)) :=
+@[simp] theorem finAddTwoArrowEquiv_apply {α : Type*} (N : ℕ)
+    (σ : Fin (N + 2) → α) :
+    finAddTwoArrowEquiv α N σ = ((σ 0, σ 1), Fin.tail (Fin.tail σ)) :=
   rfl
 
-@[simp] theorem firstTwoSitesRestEquiv_symm_apply (d N : ℕ)
-    (p : (Fin d × Fin d) × (Fin N → Fin d)) :
-    (firstTwoSitesRestEquiv d N).symm p = Fin.cons p.1.1 (Fin.cons p.1.2 p.2) :=
+@[simp] theorem finAddTwoArrowEquiv_symm_apply {α : Type*} (N : ℕ)
+    (p : (α × α) × (Fin N → α)) :
+    (finAddTwoArrowEquiv α N).symm p = Fin.cons p.1.1 (Fin.cons p.1.2 p.2) :=
   rfl
-
-end MPOTensor

--- a/TNLean/Algebra/FinTupleEquiv.lean
+++ b/TNLean/Algebra/FinTupleEquiv.lean
@@ -18,6 +18,8 @@ on short finite index types.
 
 * `finThreeArrowEquiv`: identifies a function on `Fin 3` with a right-associated triple.
 * `finFourArrowEquiv`: identifies a function on `Fin 4` with a right-associated quadruple.
+* `MPOTensor.firstSiteRestEquiv`: separates the first coordinate from a finite tuple.
+* `MPOTensor.firstTwoSitesRestEquiv`: separates the first two coordinates.
 
 ## Main statements
 
@@ -77,3 +79,41 @@ coordinates in order. -/
     (finFourArrowEquiv α).symm x = ![x.1, x.2.1, x.2.2.1, x.2.2.2] := by
   funext i
   fin_cases i <;> rfl
+
+namespace MPOTensor
+
+/-! ### A fixed initial segment and a variable remaining tuple -/
+
+/-- Separate the first physical index from the remaining `N` indices. -/
+def firstSiteRestEquiv (d N : ℕ) :
+    (Fin (N + 1) → Fin d) ≃ Fin d × (Fin N → Fin d) :=
+  (Fin.consEquiv fun _ : Fin (N + 1) ↦ Fin d).symm
+
+@[simp] theorem firstSiteRestEquiv_apply (d N : ℕ)
+    (σ : Fin (N + 1) → Fin d) :
+    firstSiteRestEquiv d N σ = (σ 0, Fin.tail σ) :=
+  rfl
+
+@[simp] theorem firstSiteRestEquiv_symm_apply (d N : ℕ)
+    (p : Fin d × (Fin N → Fin d)) :
+    (firstSiteRestEquiv d N).symm p = Fin.cons p.1 p.2 :=
+  rfl
+
+/-- Separate the first two physical indices from the remaining `N` indices. -/
+def firstTwoSitesRestEquiv (d N : ℕ) :
+    (Fin (N + 2) → Fin d) ≃ (Fin d × Fin d) × (Fin N → Fin d) :=
+  (firstSiteRestEquiv d (N + 1)).trans
+    ((Equiv.prodCongr (Equiv.refl (Fin d)) (firstSiteRestEquiv d N)).trans
+      (Equiv.prodAssoc (Fin d) (Fin d) (Fin N → Fin d)).symm)
+
+@[simp] theorem firstTwoSitesRestEquiv_apply (d N : ℕ)
+    (σ : Fin (N + 2) → Fin d) :
+    firstTwoSitesRestEquiv d N σ = ((σ 0, σ 1), Fin.tail (Fin.tail σ)) :=
+  rfl
+
+@[simp] theorem firstTwoSitesRestEquiv_symm_apply (d N : ℕ)
+    (p : (Fin d × Fin d) × (Fin N → Fin d)) :
+    (firstTwoSitesRestEquiv d N).symm p = Fin.cons p.1.1 (Fin.cons p.1.2 p.2) :=
+  rfl
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/RFPViaTS.lean
+++ b/TNLean/MPS/MPDO/RFPViaTS.lean
@@ -98,6 +98,15 @@ noncomputable def physCloseN (M : MPOTensor d D) (N : ℕ) :
       Matrix.trace (evalWord M (List.ofFn σ) (List.ofFn τ) * X) :=
   rfl
 
+/-- Closing the virtual boundary by the identity matrix gives the periodic MPO
+operator.
+
+Source: arXiv:1606.00608, lines 638--654 and Definition 4.1. -/
+theorem physCloseN_identity_eq_mpo (M : MPOTensor d D) (N : ℕ) :
+    physCloseN M N (1 : Matrix (Fin D) (Fin D) ℂ) = mpo M N := by
+  ext σ τ
+  simp [mpoMatrixEntry]
+
 /-- The length-one physical closure has the source coefficient formula from
 arXiv:1606.00608, Definition 4.1, line 657 and figure MPDO_XM. -/
 lemma physCloseN_one_apply (M : MPOTensor d D)

--- a/TNLean/MPS/MPDO/RFPViaTSGlobal.lean
+++ b/TNLean/MPS/MPDO/RFPViaTSGlobal.lean
@@ -11,10 +11,10 @@ import TNLean.MPS.MPDO.RFPViaTS
 # Global action of the MPDO renormalization maps
 
 The maps in Definition 4.1 of arXiv:1606.00608 act on one or two neighboring
-physical sites. This file tensors those maps with the identity on the remaining
-sites and proves that their local closure identities extend to a chain of any
-length. These are the channel identities used in the strong-area-law argument
-of arXiv:1606.00608, Appendix C, lines 1333--1341.
+physical sites. Tensoring them with the identity on the remaining sites gives
+trace-preserving completely positive maps whose local closure identities extend
+to a chain of any length. These are the channel identities used in the
+strong-area-law argument of arXiv:1606.00608, Appendix C, lines 1333--1341.
 
 The remaining local-channel data-processing theorem and the source standing
 nonvanishing condition are recorded in

--- a/TNLean/MPS/MPDO/RFPViaTSGlobal.lean
+++ b/TNLean/MPS/MPDO/RFPViaTSGlobal.lean
@@ -33,6 +33,10 @@ nonvanishing condition are recorded in
 * `MPOTensor.refineFirstSite_physCloseN` and
   `MPOTensor.coarsenFirstTwoSites_physCloseN`: the localized maps respectively
   insert and remove one tensor in every physical closure.
+* `MPOTensor.refineFirstSite_mpo` and `MPOTensor.coarsenFirstTwoSites_mpo`:
+  the localized maps respectively insert and remove one tensor in every periodic MPO.
+* `MPOTensor.exists_global_renormalization_maps`: a renormalization fixed point
+  supplies localized channels with the global physical-closure identities.
 
 ## References
 

--- a/TNLean/MPS/MPDO/RFPViaTSGlobal.lean
+++ b/TNLean/MPS/MPDO/RFPViaTSGlobal.lean
@@ -1,0 +1,278 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.LocalizedKrausCPTP
+import TNLean.MPS.MPDO.RFPViaTS
+
+/-!
+# Global action of the MPDO renormalization maps
+
+The maps in Definition 4.1 of arXiv:1606.00608 act on one or two neighboring
+physical sites. This file tensors those maps with the identity on the remaining
+sites and proves that their local closure identities extend to a chain of any
+length. These are the channel identities used in the strong-area-law argument
+of Proposition `propsimple`, lines 1333--1341.
+
+The remaining local-channel data-processing theorem and the source standing
+nonvanishing condition are recorded in
+`docs/paper-gaps/cpsv16_rfp_sal_data_processing.tex`.
+
+## Main definitions
+
+* `MPOTensor.refineFirstSite`: apply the one-to-two map to the first site.
+* `MPOTensor.coarsenFirstTwoSites`: apply the two-to-one map to the first two sites.
+
+## Main results
+
+* `MPOTensor.refineFirstSite_isKrausCPTP` and
+  `MPOTensor.coarsenFirstTwoSites_isKrausCPTP`: the localized maps are channels.
+* `MPOTensor.refineFirstSite_physCloseN` and
+  `MPOTensor.coarsenFirstTwoSites_physCloseN`: the localized maps respectively
+  insert and remove one tensor in every physical closure.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Definition 4.1 and Proposition `propsimple`, lines 1333--1341
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-! ### Regrouping the first physical sites -/
+
+/-- Separate the first physical index from the remaining `N` indices. -/
+def firstSiteRestEquiv (d N : ℕ) :
+    (Fin (N + 1) → Fin d) ≃ Fin d × (Fin N → Fin d) :=
+  (Fin.consEquiv fun _ : Fin (N + 1) ↦ Fin d).symm
+
+@[simp] theorem firstSiteRestEquiv_apply (d N : ℕ)
+    (σ : Fin (N + 1) → Fin d) :
+    firstSiteRestEquiv d N σ = (σ 0, Fin.tail σ) :=
+  rfl
+
+@[simp] theorem firstSiteRestEquiv_symm_apply (d N : ℕ)
+    (p : Fin d × (Fin N → Fin d)) :
+    (firstSiteRestEquiv d N).symm p = Fin.cons p.1 p.2 :=
+  rfl
+
+/-- Separate the first two physical indices from the remaining `N` indices. -/
+def firstTwoSitesRestEquiv (d N : ℕ) :
+    (Fin (N + 2) → Fin d) ≃ (Fin d × Fin d) × (Fin N → Fin d) :=
+  (firstSiteRestEquiv d (N + 1)).trans
+    ((Equiv.prodCongr (Equiv.refl (Fin d)) (firstSiteRestEquiv d N)).trans
+      (Equiv.prodAssoc (Fin d) (Fin d) (Fin N → Fin d)).symm)
+
+@[simp] theorem firstTwoSitesRestEquiv_apply (d N : ℕ)
+    (σ : Fin (N + 2) → Fin d) :
+    firstTwoSitesRestEquiv d N σ = ((σ 0, σ 1), Fin.tail (Fin.tail σ)) :=
+  rfl
+
+@[simp] theorem firstTwoSitesRestEquiv_symm_apply (d N : ℕ)
+    (p : (Fin d × Fin d) × (Fin N → Fin d)) :
+    (firstTwoSitesRestEquiv d N).symm p = Fin.cons p.1.1 (Fin.cons p.1.2 p.2) :=
+  rfl
+
+/-! ### Localized renormalization maps -/
+
+/-- Apply a one-to-two physical map to the first site and leave the remaining
+`N` sites unchanged.
+
+Source: arXiv:1606.00608, Proposition `propsimple`, lines 1337--1341. -/
+noncomputable def refineFirstSite
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ) (N : ℕ) :
+    Matrix (Fin (N + 1) → Fin d) (Fin (N + 1) → Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin (N + 2) → Fin d) (Fin (N + 2) → Fin d) ℂ :=
+  Matrix.equivReindexMap (firstTwoSitesRestEquiv d N).symm ∘ₗ
+    Matrix.tensorMapIdLM (δ := Fin N → Fin d) T ∘ₗ
+      Matrix.equivReindexMap (firstSiteRestEquiv d N)
+
+/-- Apply a two-to-one physical map to the first two sites and leave the
+remaining `N` sites unchanged.
+
+Source: arXiv:1606.00608, Proposition `propsimple`, lines 1337--1341. -/
+noncomputable def coarsenFirstTwoSites
+    (S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d) (Fin d) ℂ) (N : ℕ) :
+    Matrix (Fin (N + 2) → Fin d) (Fin (N + 2) → Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin (N + 1) → Fin d) (Fin (N + 1) → Fin d) ℂ :=
+  Matrix.equivReindexMap (firstSiteRestEquiv d N).symm ∘ₗ
+    Matrix.tensorMapIdLM (δ := Fin N → Fin d) S ∘ₗ
+      Matrix.equivReindexMap (firstTwoSitesRestEquiv d N)
+
+/-- Localizing a one-to-two channel at the first site again gives a
+trace-preserving completely positive map.
+
+Source: arXiv:1606.00608, Proposition `propsimple`, lines 1337--1341. -/
+theorem refineFirstSite_isKrausCPTP
+    {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ}
+    (hT : IsKrausCPTP T) (N : ℕ) :
+    IsKrausCPTP (refineFirstSite T N) := by
+  exact isKrausCPTP_comp
+    (isKrausCPTP_comp
+      (Matrix.equivReindexMap_isKrausCPTP (firstSiteRestEquiv d N))
+      (Matrix.tensorMapIdLM_isKrausCPTP hT))
+    (Matrix.equivReindexMap_isKrausCPTP (firstTwoSitesRestEquiv d N).symm)
+
+/-- Localizing a two-to-one channel at the first two sites again gives a
+trace-preserving completely positive map.
+
+Source: arXiv:1606.00608, Proposition `propsimple`, lines 1337--1341. -/
+theorem coarsenFirstTwoSites_isKrausCPTP
+    {S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d) (Fin d) ℂ}
+    (hS : IsKrausCPTP S) (N : ℕ) :
+    IsKrausCPTP (coarsenFirstTwoSites S N) := by
+  exact isKrausCPTP_comp
+    (isKrausCPTP_comp
+      (Matrix.equivReindexMap_isKrausCPTP (firstTwoSitesRestEquiv d N))
+      (Matrix.tensorMapIdLM_isKrausCPTP hS))
+    (Matrix.equivReindexMap_isKrausCPTP (firstSiteRestEquiv d N).symm)
+
+/-! ### Action on physical closures -/
+
+/-- The first-factor slice of a regrouped closure is the one-site closure with
+the remaining word absorbed into the virtual boundary matrix. -/
+private theorem firstSiteSlice_physCloseN (M : MPOTensor d D) (N : ℕ)
+    (X : Matrix (Fin D) (Fin D) ℂ) (u v : Fin N → Fin d) :
+    Matrix.bipartiteSlice
+        (Matrix.equivReindexMap (firstSiteRestEquiv d N)
+          (physCloseN M (N + 1) X)) u v =
+      physClose1 M (evalWord M (List.ofFn u) (List.ofFn v) * X) := by
+  ext i j
+  simp [Matrix.equivReindexMap, Matrix.coe_reindexLinearEquiv,
+    Matrix.reindex_apply, Matrix.submatrix_apply, List.ofFn_succ,
+    evalWord_cons, Matrix.mul_assoc]
+
+/-- The first-factor slice of a regrouped closure is the two-site closure with
+the remaining word absorbed into the virtual boundary matrix. -/
+private theorem firstTwoSitesSlice_physCloseN (M : MPOTensor d D) (N : ℕ)
+    (X : Matrix (Fin D) (Fin D) ℂ) (u v : Fin N → Fin d) :
+    Matrix.bipartiteSlice
+        (Matrix.equivReindexMap (firstTwoSitesRestEquiv d N)
+          (physCloseN M (N + 2) X)) u v =
+      physClose2 M (evalWord M (List.ofFn u) (List.ofFn v) * X) := by
+  ext i j
+  simp [Matrix.equivReindexMap, Matrix.coe_reindexLinearEquiv,
+    Matrix.reindex_apply, Matrix.submatrix_apply, List.ofFn_succ,
+    evalWord_cons, Matrix.mul_assoc]
+
+/-- If `T` sends every one-site physical closure to the corresponding two-site
+closure, then its localization at the first site inserts one copy of the tensor
+in a closure of arbitrary length.
+
+This is the global channel identity used when `T` is applied to the first spin
+of the first interval in the proof of the strong area law.
+
+Source: arXiv:1606.00608, Proposition `propsimple`, lines 1337--1341. -/
+theorem refineFirstSite_physCloseN (M : MPOTensor d D)
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
+    (hT : ∀ X, T (physClose1 M X) = physClose2 M X)
+    (N : ℕ) (X : Matrix (Fin D) (Fin D) ℂ) :
+    refineFirstSite T N (physCloseN M (N + 1) X) =
+      physCloseN M (N + 2) X := by
+  ext σ τ
+  change Matrix.tensorMapId T
+      (Matrix.equivReindexMap (firstSiteRestEquiv d N)
+        (physCloseN M (N + 1) X))
+      (firstTwoSitesRestEquiv d N σ) (firstTwoSitesRestEquiv d N τ) = _
+  rw [Matrix.tensorMapId_apply]
+  simp only [firstTwoSitesRestEquiv_apply]
+  rw [firstSiteSlice_physCloseN, hT]
+  simp [List.ofFn_succ, evalWord_cons, Matrix.mul_assoc, Fin.tail_def]
+
+/-- If `S` sends every two-site physical closure to the corresponding one-site
+closure, then its localization at the first two sites removes one copy of the
+tensor from a closure of arbitrary length.
+
+This is the global channel identity used when `S` is applied to the first two
+spins of the second interval in the proof of the strong area law.
+
+Source: arXiv:1606.00608, Proposition `propsimple`, lines 1337--1341. -/
+theorem coarsenFirstTwoSites_physCloseN (M : MPOTensor d D)
+    (S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d) (Fin d) ℂ)
+    (hS : ∀ X, S (physClose2 M X) = physClose1 M X)
+    (N : ℕ) (X : Matrix (Fin D) (Fin D) ℂ) :
+    coarsenFirstTwoSites S N (physCloseN M (N + 2) X) =
+      physCloseN M (N + 1) X := by
+  ext σ τ
+  change Matrix.tensorMapId S
+      (Matrix.equivReindexMap (firstTwoSitesRestEquiv d N)
+        (physCloseN M (N + 2) X))
+      (firstSiteRestEquiv d N σ) (firstSiteRestEquiv d N τ) = _
+  rw [Matrix.tensorMapId_apply]
+  simp only [firstSiteRestEquiv_apply]
+  rw [firstTwoSitesSlice_physCloseN, hS]
+  simp [List.ofFn_succ, evalWord_cons, Matrix.mul_assoc, Fin.tail_def]
+
+/-- Closing the virtual boundary by the identity matrix gives the periodic MPO
+operator.
+
+Source: arXiv:1606.00608, lines 638--654 and Definition 4.1. -/
+theorem physCloseN_identity_eq_mpo (M : MPOTensor d D) (N : ℕ) :
+    physCloseN M N (1 : Matrix (Fin D) (Fin D) ℂ) = mpo M N := by
+  ext σ τ
+  simp [mpoMatrixEntry]
+
+/-- The localized refinement map inserts one site in every periodic MPO
+operator whenever the one-to-two closure identity of Definition 4.1 holds.
+
+Source: arXiv:1606.00608, Proposition `propsimple`, lines 1337--1341. -/
+theorem refineFirstSite_mpo (M : MPOTensor d D)
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
+    (hT : ∀ X, T (physClose1 M X) = physClose2 M X) (N : ℕ) :
+    refineFirstSite T N (mpo M (N + 1)) = mpo M (N + 2) := by
+  rw [← physCloseN_identity_eq_mpo M (N + 1),
+    refineFirstSite_physCloseN M T hT N,
+    physCloseN_identity_eq_mpo]
+
+/-- The localized coarse-graining map removes one site from every periodic MPO
+operator whenever the two-to-one closure identity of Definition 4.1 holds.
+
+Source: arXiv:1606.00608, Proposition `propsimple`, lines 1337--1341. -/
+theorem coarsenFirstTwoSites_mpo (M : MPOTensor d D)
+    (S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d) (Fin d) ℂ)
+    (hS : ∀ X, S (physClose2 M X) = physClose1 M X) (N : ℕ) :
+    coarsenFirstTwoSites S N (mpo M (N + 2)) = mpo M (N + 1) := by
+  rw [← physCloseN_identity_eq_mpo M (N + 2),
+    coarsenFirstTwoSites_physCloseN M S hS N,
+    physCloseN_identity_eq_mpo]
+
+/-- A renormalization fixed point in the sense of Definition 4.1 has one pair
+of trace-preserving completely positive maps whose localizations insert and
+remove a tensor in physical closures of every length.
+
+This is the global channel statement used in the proof of the strong area law
+in Proposition `propsimple`. The parameter `N` counts the sites on which the
+identity channel acts; even when `N = 0`, the input closure contains one or two
+physical sites, so no empty-chain operator is involved.
+
+Source: arXiv:1606.00608, Definition 4.1 and Proposition `propsimple`,
+lines 1333--1341. -/
+theorem exists_global_renormalization_maps (M : MPOTensor d D)
+    (h : IsRFPViaTS M) :
+    ∃ (S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
+        Matrix (Fin d) (Fin d) ℂ)
+      (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
+        Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ),
+      IsKrausCPTP S ∧ IsKrausCPTP T ∧
+      (∀ N X, coarsenFirstTwoSites S N (physCloseN M (N + 2) X) =
+        physCloseN M (N + 1) X) ∧
+      (∀ N X, refineFirstSite T N (physCloseN M (N + 1) X) =
+        physCloseN M (N + 2) X) := by
+  obtain ⟨S, T, hS, hT, hSclose, hTclose⟩ := h
+  exact ⟨S, T, hS, hT, coarsenFirstTwoSites_physCloseN M S hSclose,
+    refineFirstSite_physCloseN M T hTclose⟩
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/RFPViaTSGlobal.lean
+++ b/TNLean/MPS/MPDO/RFPViaTSGlobal.lean
@@ -13,7 +13,7 @@ The maps in Definition 4.1 of arXiv:1606.00608 act on one or two neighboring
 physical sites. This file tensors those maps with the identity on the remaining
 sites and proves that their local closure identities extend to a chain of any
 length. These are the channel identities used in the strong-area-law argument
-of Proposition `propsimple`, lines 1333--1341.
+of arXiv:1606.00608, Appendix C, lines 1333--1341.
 
 The remaining local-channel data-processing theorem and the source standing
 nonvanishing condition are recorded in
@@ -35,7 +35,7 @@ nonvanishing condition are recorded in
 ## References
 
 * [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
-  Definition 4.1 and Proposition `propsimple`, lines 1333--1341
+  Definition 4.1 and Appendix C, lines 1333--1341
 -/
 
 open scoped Matrix BigOperators
@@ -83,7 +83,7 @@ def firstTwoSitesRestEquiv (d N : ℕ) :
 /-- Apply a one-to-two physical map to the first site and leave the remaining
 `N` sites unchanged.
 
-Source: arXiv:1606.00608, Proposition `propsimple`, lines 1337--1341. -/
+Source: arXiv:1606.00608, Appendix C, lines 1337--1341. -/
 noncomputable def refineFirstSite
     (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
       Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ) (N : ℕ) :
@@ -96,7 +96,7 @@ noncomputable def refineFirstSite
 /-- Apply a two-to-one physical map to the first two sites and leave the
 remaining `N` sites unchanged.
 
-Source: arXiv:1606.00608, Proposition `propsimple`, lines 1337--1341. -/
+Source: arXiv:1606.00608, Appendix C, lines 1337--1341. -/
 noncomputable def coarsenFirstTwoSites
     (S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
       Matrix (Fin d) (Fin d) ℂ) (N : ℕ) :
@@ -109,7 +109,7 @@ noncomputable def coarsenFirstTwoSites
 /-- Localizing a one-to-two channel at the first site again gives a
 trace-preserving completely positive map.
 
-Source: arXiv:1606.00608, Proposition `propsimple`, lines 1337--1341. -/
+Source: arXiv:1606.00608, Appendix C, lines 1337--1341. -/
 theorem refineFirstSite_isKrausCPTP
     {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
       Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ}
@@ -124,7 +124,7 @@ theorem refineFirstSite_isKrausCPTP
 /-- Localizing a two-to-one channel at the first two sites again gives a
 trace-preserving completely positive map.
 
-Source: arXiv:1606.00608, Proposition `propsimple`, lines 1337--1341. -/
+Source: arXiv:1606.00608, Appendix C, lines 1337--1341. -/
 theorem coarsenFirstTwoSites_isKrausCPTP
     {S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
       Matrix (Fin d) (Fin d) ℂ}
@@ -171,7 +171,7 @@ in a closure of arbitrary length.
 This is the global channel identity used when `T` is applied to the first spin
 of the first interval in the proof of the strong area law.
 
-Source: arXiv:1606.00608, Proposition `propsimple`, lines 1337--1341. -/
+Source: arXiv:1606.00608, Appendix C, lines 1337--1341. -/
 theorem refineFirstSite_physCloseN (M : MPOTensor d D)
     (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
       Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
@@ -196,7 +196,7 @@ tensor from a closure of arbitrary length.
 This is the global channel identity used when `S` is applied to the first two
 spins of the second interval in the proof of the strong area law.
 
-Source: arXiv:1606.00608, Proposition `propsimple`, lines 1337--1341. -/
+Source: arXiv:1606.00608, Appendix C, lines 1337--1341. -/
 theorem coarsenFirstTwoSites_physCloseN (M : MPOTensor d D)
     (S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
       Matrix (Fin d) (Fin d) ℂ)
@@ -217,7 +217,7 @@ theorem coarsenFirstTwoSites_physCloseN (M : MPOTensor d D)
 /-- The localized refinement map inserts one site in every periodic MPO
 operator whenever the one-to-two closure identity of Definition 4.1 holds.
 
-Source: arXiv:1606.00608, Proposition `propsimple`, lines 1337--1341. -/
+Source: arXiv:1606.00608, Appendix C, lines 1337--1341. -/
 theorem refineFirstSite_mpo (M : MPOTensor d D)
     (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
       Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
@@ -230,7 +230,7 @@ theorem refineFirstSite_mpo (M : MPOTensor d D)
 /-- The localized coarse-graining map removes one site from every periodic MPO
 operator whenever the two-to-one closure identity of Definition 4.1 holds.
 
-Source: arXiv:1606.00608, Proposition `propsimple`, lines 1337--1341. -/
+Source: arXiv:1606.00608, Appendix C, lines 1337--1341. -/
 theorem coarsenFirstTwoSites_mpo (M : MPOTensor d D)
     (S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
       Matrix (Fin d) (Fin d) ℂ)
@@ -245,11 +245,11 @@ of trace-preserving completely positive maps whose localizations insert and
 remove a tensor in physical closures of every length.
 
 This is the global channel statement used in the proof of the strong area law
-in Proposition `propsimple`. The parameter `N` counts the sites on which the
+in arXiv:1606.00608, Appendix C. The parameter `N` counts the sites on which the
 identity channel acts; even when `N = 0`, the input closure contains one or two
 physical sites, so no empty-chain operator is involved.
 
-Source: arXiv:1606.00608, Definition 4.1 and Proposition `propsimple`,
+Source: arXiv:1606.00608, Definition 4.1 and Appendix C,
 lines 1333--1341. -/
 theorem exists_global_renormalization_maps (M : MPOTensor d D)
     (h : IsRFPViaTS M) :

--- a/TNLean/MPS/MPDO/RFPViaTSGlobal.lean
+++ b/TNLean/MPS/MPDO/RFPViaTSGlobal.lean
@@ -14,7 +14,8 @@ The maps in Definition 4.1 of arXiv:1606.00608 act on one or two neighboring
 physical sites. Tensoring them with the identity on the remaining sites gives
 trace-preserving completely positive maps whose local closure identities extend
 to a chain of any length. These are the channel identities used in the
-strong-area-law argument of arXiv:1606.00608, Appendix C, lines 1333--1341.
+argument establishing saturation of the area law in arXiv:1606.00608,
+Appendix C, lines 1333--1341.
 
 The remaining local-channel data-processing theorem and the source standing
 nonvanishing condition are recorded in
@@ -136,7 +137,7 @@ closure, then its localization at the first site inserts one copy of the tensor
 in a closure of arbitrary length.
 
 This is the global channel identity used when `T` is applied to the first spin
-of the first interval in the proof of the strong area law.
+of the first interval in the proof of saturation of the area law.
 
 Source: arXiv:1606.00608, Appendix C, lines 1337--1341. -/
 theorem refineFirstSite_physCloseN (M : MPOTensor d D)
@@ -161,7 +162,7 @@ closure, then its localization at the first two sites removes one copy of the
 tensor from a closure of arbitrary length.
 
 This is the global channel identity used when `S` is applied to the first two
-spins of the second interval in the proof of the strong area law.
+spins of the second interval in the proof of saturation of the area law.
 
 Source: arXiv:1606.00608, Appendix C, lines 1337--1341. -/
 theorem coarsenFirstTwoSites_physCloseN (M : MPOTensor d D)
@@ -211,7 +212,7 @@ theorem coarsenFirstTwoSites_mpo (M : MPOTensor d D)
 of trace-preserving completely positive maps whose localizations insert and
 remove a tensor in physical closures of every length.
 
-This is the global channel statement used in the proof of the strong area law
+This is the global channel statement used to prove saturation of the area law
 in arXiv:1606.00608, Appendix C. The parameter `N` counts the sites on which the
 identity channel acts; even when `N = 0`, the input closure contains one or two
 physical sites, so no empty-chain operator is involved.

--- a/TNLean/MPS/MPDO/RFPViaTSGlobal.lean
+++ b/TNLean/MPS/MPDO/RFPViaTSGlobal.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinTupleEquiv
 import TNLean.MPS.MPDO.LocalizedKrausCPTP
 import TNLean.MPS.MPDO.RFPViaTS
 
@@ -43,40 +44,6 @@ open scoped Matrix
 namespace MPOTensor
 
 variable {d D : ℕ}
-
-/-! ### Regrouping the first physical sites -/
-
-/-- Separate the first physical index from the remaining `N` indices. -/
-def firstSiteRestEquiv (d N : ℕ) :
-    (Fin (N + 1) → Fin d) ≃ Fin d × (Fin N → Fin d) :=
-  (Fin.consEquiv fun _ : Fin (N + 1) ↦ Fin d).symm
-
-@[simp] theorem firstSiteRestEquiv_apply (d N : ℕ)
-    (σ : Fin (N + 1) → Fin d) :
-    firstSiteRestEquiv d N σ = (σ 0, Fin.tail σ) :=
-  rfl
-
-@[simp] theorem firstSiteRestEquiv_symm_apply (d N : ℕ)
-    (p : Fin d × (Fin N → Fin d)) :
-    (firstSiteRestEquiv d N).symm p = Fin.cons p.1 p.2 :=
-  rfl
-
-/-- Separate the first two physical indices from the remaining `N` indices. -/
-def firstTwoSitesRestEquiv (d N : ℕ) :
-    (Fin (N + 2) → Fin d) ≃ (Fin d × Fin d) × (Fin N → Fin d) :=
-  (firstSiteRestEquiv d (N + 1)).trans
-    ((Equiv.prodCongr (Equiv.refl (Fin d)) (firstSiteRestEquiv d N)).trans
-      (Equiv.prodAssoc (Fin d) (Fin d) (Fin N → Fin d)).symm)
-
-@[simp] theorem firstTwoSitesRestEquiv_apply (d N : ℕ)
-    (σ : Fin (N + 2) → Fin d) :
-    firstTwoSitesRestEquiv d N σ = ((σ 0, σ 1), Fin.tail (Fin.tail σ)) :=
-  rfl
-
-@[simp] theorem firstTwoSitesRestEquiv_symm_apply (d N : ℕ)
-    (p : (Fin d × Fin d) × (Fin N → Fin d)) :
-    (firstTwoSitesRestEquiv d N).symm p = Fin.cons p.1.1 (Fin.cons p.1.2 p.2) :=
-  rfl
 
 /-! ### Localized renormalization maps -/
 

--- a/TNLean/MPS/MPDO/RFPViaTSGlobal.lean
+++ b/TNLean/MPS/MPDO/RFPViaTSGlobal.lean
@@ -38,7 +38,7 @@ nonvanishing condition are recorded in
   Definition 4.1 and Appendix C, lines 1333--1341
 -/
 
-open scoped Matrix BigOperators
+open scoped Matrix
 
 namespace MPOTensor
 

--- a/TNLean/MPS/MPDO/RFPViaTSGlobal.lean
+++ b/TNLean/MPS/MPDO/RFPViaTSGlobal.lean
@@ -56,9 +56,9 @@ noncomputable def refineFirstSite
       Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ) (N : ℕ) :
     Matrix (Fin (N + 1) → Fin d) (Fin (N + 1) → Fin d) ℂ →ₗ[ℂ]
       Matrix (Fin (N + 2) → Fin d) (Fin (N + 2) → Fin d) ℂ :=
-  Matrix.equivReindexMap (firstTwoSitesRestEquiv d N).symm ∘ₗ
+  Matrix.equivReindexMap (finAddTwoArrowEquiv (Fin d) N).symm ∘ₗ
     Matrix.tensorMapIdLM (δ := Fin N → Fin d) T ∘ₗ
-      Matrix.equivReindexMap (firstSiteRestEquiv d N)
+      Matrix.equivReindexMap (finSuccArrowEquiv (Fin d) N)
 
 /-- Apply a two-to-one physical map to the first two sites and leave the
 remaining `N` sites unchanged.
@@ -69,9 +69,9 @@ noncomputable def coarsenFirstTwoSites
       Matrix (Fin d) (Fin d) ℂ) (N : ℕ) :
     Matrix (Fin (N + 2) → Fin d) (Fin (N + 2) → Fin d) ℂ →ₗ[ℂ]
       Matrix (Fin (N + 1) → Fin d) (Fin (N + 1) → Fin d) ℂ :=
-  Matrix.equivReindexMap (firstSiteRestEquiv d N).symm ∘ₗ
+  Matrix.equivReindexMap (finSuccArrowEquiv (Fin d) N).symm ∘ₗ
     Matrix.tensorMapIdLM (δ := Fin N → Fin d) S ∘ₗ
-      Matrix.equivReindexMap (firstTwoSitesRestEquiv d N)
+      Matrix.equivReindexMap (finAddTwoArrowEquiv (Fin d) N)
 
 /-- Localizing a one-to-two channel at the first site again gives a
 trace-preserving completely positive map.
@@ -84,9 +84,9 @@ theorem refineFirstSite_isKrausCPTP
     IsKrausCPTP (refineFirstSite T N) := by
   exact isKrausCPTP_comp
     (isKrausCPTP_comp
-      (Matrix.equivReindexMap_isKrausCPTP (firstSiteRestEquiv d N))
+      (Matrix.equivReindexMap_isKrausCPTP (finSuccArrowEquiv (Fin d) N))
       (Matrix.tensorMapIdLM_isKrausCPTP hT))
-    (Matrix.equivReindexMap_isKrausCPTP (firstTwoSitesRestEquiv d N).symm)
+    (Matrix.equivReindexMap_isKrausCPTP (finAddTwoArrowEquiv (Fin d) N).symm)
 
 /-- Localizing a two-to-one channel at the first two sites again gives a
 trace-preserving completely positive map.
@@ -99,9 +99,9 @@ theorem coarsenFirstTwoSites_isKrausCPTP
     IsKrausCPTP (coarsenFirstTwoSites S N) := by
   exact isKrausCPTP_comp
     (isKrausCPTP_comp
-      (Matrix.equivReindexMap_isKrausCPTP (firstTwoSitesRestEquiv d N))
+      (Matrix.equivReindexMap_isKrausCPTP (finAddTwoArrowEquiv (Fin d) N))
       (Matrix.tensorMapIdLM_isKrausCPTP hS))
-    (Matrix.equivReindexMap_isKrausCPTP (firstSiteRestEquiv d N).symm)
+    (Matrix.equivReindexMap_isKrausCPTP (finSuccArrowEquiv (Fin d) N).symm)
 
 /-! ### Action on physical closures -/
 
@@ -110,7 +110,7 @@ the remaining word absorbed into the virtual boundary matrix. -/
 private theorem firstSiteSlice_physCloseN (M : MPOTensor d D) (N : ℕ)
     (X : Matrix (Fin D) (Fin D) ℂ) (u v : Fin N → Fin d) :
     Matrix.bipartiteSlice
-        (Matrix.equivReindexMap (firstSiteRestEquiv d N)
+        (Matrix.equivReindexMap (finSuccArrowEquiv (Fin d) N)
           (physCloseN M (N + 1) X)) u v =
       physClose1 M (evalWord M (List.ofFn u) (List.ofFn v) * X) := by
   ext i j
@@ -123,7 +123,7 @@ the remaining word absorbed into the virtual boundary matrix. -/
 private theorem firstTwoSitesSlice_physCloseN (M : MPOTensor d D) (N : ℕ)
     (X : Matrix (Fin D) (Fin D) ℂ) (u v : Fin N → Fin d) :
     Matrix.bipartiteSlice
-        (Matrix.equivReindexMap (firstTwoSitesRestEquiv d N)
+        (Matrix.equivReindexMap (finAddTwoArrowEquiv (Fin d) N)
           (physCloseN M (N + 2) X)) u v =
       physClose2 M (evalWord M (List.ofFn u) (List.ofFn v) * X) := by
   ext i j
@@ -148,11 +148,11 @@ theorem refineFirstSite_physCloseN (M : MPOTensor d D)
       physCloseN M (N + 2) X := by
   ext σ τ
   change Matrix.tensorMapId T
-      (Matrix.equivReindexMap (firstSiteRestEquiv d N)
+      (Matrix.equivReindexMap (finSuccArrowEquiv (Fin d) N)
         (physCloseN M (N + 1) X))
-      (firstTwoSitesRestEquiv d N σ) (firstTwoSitesRestEquiv d N τ) = _
+      (finAddTwoArrowEquiv (Fin d) N σ) (finAddTwoArrowEquiv (Fin d) N τ) = _
   rw [Matrix.tensorMapId_apply]
-  simp only [firstTwoSitesRestEquiv_apply]
+  simp only [finAddTwoArrowEquiv_apply]
   rw [firstSiteSlice_physCloseN, hT]
   simp [List.ofFn_succ, evalWord_cons, Matrix.mul_assoc, Fin.tail_def]
 
@@ -173,11 +173,11 @@ theorem coarsenFirstTwoSites_physCloseN (M : MPOTensor d D)
       physCloseN M (N + 1) X := by
   ext σ τ
   change Matrix.tensorMapId S
-      (Matrix.equivReindexMap (firstTwoSitesRestEquiv d N)
+      (Matrix.equivReindexMap (finAddTwoArrowEquiv (Fin d) N)
         (physCloseN M (N + 2) X))
-      (firstSiteRestEquiv d N σ) (firstSiteRestEquiv d N τ) = _
+      (finSuccArrowEquiv (Fin d) N σ) (finSuccArrowEquiv (Fin d) N τ) = _
   rw [Matrix.tensorMapId_apply]
-  simp only [firstSiteRestEquiv_apply]
+  simp only [finSuccArrowEquiv_apply]
   rw [firstTwoSitesSlice_physCloseN, hS]
   simp [List.ofFn_succ, evalWord_cons, Matrix.mul_assoc, Fin.tail_def]
 

--- a/TNLean/MPS/MPDO/RFPViaTSGlobal.lean
+++ b/TNLean/MPS/MPDO/RFPViaTSGlobal.lean
@@ -214,15 +214,6 @@ theorem coarsenFirstTwoSites_physCloseN (M : MPOTensor d D)
   rw [firstTwoSitesSlice_physCloseN, hS]
   simp [List.ofFn_succ, evalWord_cons, Matrix.mul_assoc, Fin.tail_def]
 
-/-- Closing the virtual boundary by the identity matrix gives the periodic MPO
-operator.
-
-Source: arXiv:1606.00608, lines 638--654 and Definition 4.1. -/
-theorem physCloseN_identity_eq_mpo (M : MPOTensor d D) (N : ℕ) :
-    physCloseN M N (1 : Matrix (Fin D) (Fin D) ℂ) = mpo M N := by
-  ext σ τ
-  simp [mpoMatrixEntry]
-
 /-- The localized refinement map inserts one site in every periodic MPO
 operator whenever the one-to-two closure identity of Definition 4.1 holds.
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -164,6 +164,11 @@ physical indices, as in
     \]
 \end{lemma}
 
+\begin{proof}\leanok
+    Both identities follow from the definition of the canonical
+    right-associated regrouping.
+\end{proof}
+
 \begin{theorem}[General and right-associated four-site closures]
     \label{thm:mpdo_phys_close_four}
     \lean{MPOTensor.physCloseN_four_eq_physClose4}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -150,6 +150,21 @@ physical indices, as in
     \]
 \end{definition}
 
+\begin{lemma}[Coordinates of the four-site regrouping]
+    \label{lem:fin_four_arrow_equiv_coordinates}
+    \lean{finFourArrowEquiv_apply, finFourArrowEquiv_symm_apply}
+    \leanok
+    \uses{def:mpdo_four_site_physical_closure}
+    The canonical four-coordinate regrouping and its inverse satisfy
+    \[
+        R_4(\sigma)
+          =(\sigma_0,(\sigma_1,(\sigma_2,\sigma_3))),
+        \qquad
+        R_4^{-1}(i_0,(i_1,(i_2,i_3)))
+          =(i_0,i_1,i_2,i_3).
+    \]
+\end{lemma}
+
 \begin{theorem}[General and right-associated four-site closures]
     \label{thm:mpdo_phys_close_four}
     \lean{MPOTensor.physCloseN_four_eq_physClose4}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -154,7 +154,6 @@ physical indices, as in
     \label{lem:fin_four_arrow_equiv_coordinates}
     \lean{finFourArrowEquiv_apply, finFourArrowEquiv_symm_apply}
     \leanok
-    \uses{def:mpdo_four_site_physical_closure}
     The canonical four-coordinate regrouping and its inverse satisfy
     \[
         R_4(\sigma)

--- a/blueprint/src/chapter/ch21_mpdo_rfp_foundations.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_foundations.tex
@@ -123,7 +123,8 @@ Definition~\ref{def:mpo_source_zcl} permits the positive factor $\lambda$.
     (i)$\Rightarrow$(ii) in
     \cite[Theorem~4.9, lines~851--893]{Cirac2016MPDO_arXiv}. The corresponding
     calculation appears in the proposition ``RFP implies ZCL and SAL'' in
-    Appendix~C, lines~1333--1340; its strong-area-law component is separate.
+    Appendix~C, lines~1333--1340; the part establishing saturation of the area
+    law is separate.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
@@ -678,7 +678,9 @@
     \]
     Equality of all blocks proves the refinement identity.  Interchanging
     $M_1$, $M_2$ and using $\mathcal S[M_2(Y)]=M_1(Y)$ proves the coarsening
-    identity.
+    identity.  Taking the virtual closure to be the identity and using the
+    identification of this closure with the periodic MPO gives the two
+    periodic-ring identities.
 \end{proof}
 
 \begin{definition}[Diagonal pure-state embedding as an MPO]\label{def:to_mpo_tensor}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
@@ -443,7 +443,8 @@
 
 \begin{definition}[Physical closure maps]
     \label{def:phys_close}
-    \lean{MPOTensor.physCloseN, MPOTensor.physClose1,
+    \lean{MPOTensor.physCloseN, MPOTensor.physCloseN_apply,
+      MPOTensor.physClose1,
       MPOTensor.physClose2, MPOTensor.physClose3}
     \leanok
     \uses{def:mpo_eval_word}
@@ -464,23 +465,6 @@
     $N=2,3$ occur in
     \cite[Proposition~C.7, lines~1510--1516]{Cirac2016MPDO_arXiv}.
 \end{definition}
-
-\begin{lemma}[Matrix entries of a physical closure]
-    \label{lem:phys_close_apply}
-    \lean{MPOTensor.physCloseN_apply}
-    \leanok
-    \uses{def:phys_close}
-    For physical words $\boldsymbol i,\boldsymbol j$ of length $N$,
-    \[
-        M_N(X)_{\boldsymbol i,\boldsymbol j}
-        =\tr\!\left(M^{i_0j_0}\cdots M^{i_{N-1}j_{N-1}}X\right).
-    \]
-\end{lemma}
-
-\begin{proof}
-    \leanok
-    This is the defining matrix entry of the physical closure.
-\end{proof}
 
 \begin{lemma}[Periodic closure]
     \label{lem:phys_close_identity}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
@@ -486,7 +486,7 @@
     \label{lem:phys_close_identity}
     \lean{MPOTensor.physCloseN_identity_eq_mpo}
     \leanok
-    \uses{def:phys_close, def:mpo_tensor}
+    \uses{def:phys_close, def:mpo_family}
     Closing the virtual legs with the identity gives the periodic MPO
     operator:
     \[
@@ -595,20 +595,19 @@
     \uses{def:mpdo_global_renormalization_maps}
     For a physical word $\sigma$ of length $N+1$,
     \[
-      R_1(\sigma)=\bigl(\sigma(0),\operatorname{tail}(\sigma)\bigr),
+      R_1(\sigma)=\bigl(\sigma_0,(\sigma_1,\ldots,\sigma_N)\bigr),
       \qquad
-      R_1^{-1}(i,\sigma')=\operatorname{cons}(i,\sigma').
+      R_1^{-1}\bigl(i,(a_1,\ldots,a_N)\bigr)=(i,a_1,\ldots,a_N).
     \]
     For a physical word $\sigma$ of length $N+2$,
     \[
       R_2(\sigma)
-        =\bigl((\sigma(0),\sigma(1)),
-          \operatorname{tail}(\operatorname{tail}(\sigma))\bigr),
+        =\bigl((\sigma_0,\sigma_1),(\sigma_2,\ldots,\sigma_{N+1})\bigr),
     \]
     and
     \[
-      R_2^{-1}((i,j),\sigma')
-        =\operatorname{cons}\bigl(i,\operatorname{cons}(j,\sigma')\bigr).
+      R_2^{-1}\bigl((i,j),(a_1,\ldots,a_N)\bigr)
+        =(i,j,a_1,\ldots,a_N).
     \]
 \end{lemma}
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
@@ -474,14 +474,19 @@
     Closing the virtual legs with the identity gives the periodic MPO
     operator:
     \[
-        M_N(1)=\operatorname{MPO}_N(M).
+        M_N(1)=\rho^{(N)}(M).
     \]
 \end{lemma}
 
 \begin{proof}
     \leanok
-    At every pair of physical words, both sides are the trace of the same
-    virtual word evaluation.
+    For every pair of physical words $\sigma,\tau$,
+    \[
+        M_N(1)_{\sigma,\tau}
+          = \tr\!\left(M^{\sigma,\tau}\cdot 1\right)
+          = \tr\!\left(M^{\sigma,\tau}\right)
+          = \rho^{(N)}(M)_{\sigma,\tau}. \qedhere
+    \]
 \end{proof}
 
 \begin{theorem}[One- and two-site physical closures]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
@@ -679,9 +679,15 @@
     \]
     Equality of all blocks proves the refinement identity.  Interchanging
     $M_1$, $M_2$ and using $\mathcal S[M_2(Y)]=M_1(Y)$ proves the coarsening
-    identity.  Taking the virtual closure to be the identity and using the
-    identification of this closure with the periodic MPO gives the two
-    periodic-ring identities.
+    identity.  Setting $X=1$ and using
+    $M_N(1)=\rho^{(N)}(M)$
+    (Lemma~\ref{lem:phys_close_identity}) gives the periodic-ring identities
+    \[
+      \widehat{\mathcal T}_N[\rho^{(N+1)}(M)]
+        =\rho^{(N+2)}(M),\qquad
+      \widehat{\mathcal S}_N[\rho^{(N+2)}(M)]
+        =\rho^{(N+1)}(M).
+    \]
 \end{proof}
 
 \begin{definition}[Diagonal pure-state embedding as an MPO]\label{def:to_mpo_tensor}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
@@ -663,7 +663,8 @@
 
 \begin{proof}
     \leanok
-    \uses{lem:phys_close_identity}
+    \uses{lem:mpdo_global_renormalization_regrouping,
+      lem:phys_close_identity}
     For words $u,v$ on the $N$ spectator sites, write $M^{u,v}$ for their
     virtual word evaluation and write $[Y]^{(r)}_{u,v}$ for the block of an
     operator $Y$ on the first $r$ sites.  Regrouping the first site gives

--- a/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
@@ -528,6 +528,81 @@
     \TNMPORenormalizationTS
 \end{definition}
 
+\begin{definition}[Renormalization maps on a longer ring]
+    \label{def:mpdo_global_renormalization_maps}
+    \lean{MPOTensor.firstSiteRestEquiv,
+      MPOTensor.firstTwoSitesRestEquiv,
+      MPOTensor.refineFirstSite,
+      MPOTensor.coarsenFirstTwoSites}
+    \leanok
+    \uses{def:is_rfp_via_ts}
+    Let $N$ count the sites that are left unchanged.  Regroup a ring of
+    $N+1$ sites as one site followed by $N$ sites, and a ring of $N+2$ sites
+    as two sites followed by $N$ sites.  For physical maps
+    $\mathcal T:M_d\to M_{d^2}$ and $\mathcal S:M_{d^2}\to M_d$, define
+    \[
+       \widehat{\mathcal T}_N
+       =\mathcal T\otimes\id_N,
+       \qquad
+       \widehat{\mathcal S}_N
+       =\mathcal S\otimes\id_N,
+    \]
+    using these regroupings.  Thus $N=0$ leaves no spectator site, but the
+    maps still act on a one-site or two-site operator; no empty ring occurs.
+\end{definition}
+
+\begin{lemma}[Localized renormalization maps are channels]
+    \label{lem:mpdo_global_renormalization_maps_cptp}
+    \lean{MPOTensor.refineFirstSite_isKrausCPTP,
+      MPOTensor.coarsenFirstTwoSites_isKrausCPTP}
+    \leanok
+    \uses{def:mpdo_global_renormalization_maps, def:is_kraus_cptp}
+    If $\mathcal S$ and $\mathcal T$ are trace-preserving completely positive,
+    then so are $\widehat{\mathcal S}_N$ and
+    $\widehat{\mathcal T}_N$ for every $N$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Tensor each Kraus operator with the identity on the spectator sites and
+    conjugate by the two regrouping equivalences.
+\end{proof}
+
+\begin{theorem}[Global action of the renormalization maps]
+    \label{thm:mpdo_global_renormalization_maps}
+    \lean{MPOTensor.refineFirstSite_physCloseN,
+      MPOTensor.coarsenFirstTwoSites_physCloseN,
+      MPOTensor.physCloseN_identity_eq_mpo,
+      MPOTensor.refineFirstSite_mpo,
+      MPOTensor.coarsenFirstTwoSites_mpo,
+      MPOTensor.exists_global_renormalization_maps}
+    \leanok
+    \uses{def:phys_close, def:is_rfp_via_ts,
+      def:mpdo_global_renormalization_maps,
+      lem:mpdo_global_renormalization_maps_cptp}
+    Suppose that $\mathcal S[M_2(X)]=M_1(X)$ and
+    $\mathcal T[M_1(X)]=M_2(X)$ for every virtual operator $X$.  Then, for
+    every $N$ and $X$,
+    \[
+      \widehat{\mathcal S}_N[M_{N+2}(X)]=M_{N+1}(X),
+      \qquad
+      \widehat{\mathcal T}_N[M_{N+1}(X)]=M_{N+2}(X).
+    \]
+    In particular, these identities hold for every periodic MPO operator.
+    Hence the two maps supplied by a renormalization fixed point act on rings
+    of every length as required in the proof of
+    \cite[Proposition \texttt{propsimple}, lines~1333--1341]
+    {Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    After separating the first one or two sites, each matrix block is the
+    corresponding one-site or two-site closure, with the remaining word
+    absorbed into the virtual boundary operator.  Apply the defining local
+    closure identity to every block.
+\end{proof}
+
 \begin{definition}[Diagonal pure-state embedding as an MPO]\label{def:to_mpo_tensor}
     \lean{MPSTensor.toMPOTensor}
     \leanok

--- a/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
@@ -563,36 +563,43 @@
     \TNMPORenormalizationTS
 \end{definition}
 
+\begin{definition}[Initial-coordinate regroupings]
+    \label{def:finite_tuple_regroupings}
+    \lean{finSuccArrowEquiv,
+      finAddTwoArrowEquiv}
+    \leanok
+    Let $R_1$ identify an $(N+1)$-tuple with its first coordinate and the
+    remaining $N$-tuple.  Let $R_2$ identify an $(N+2)$-tuple with its first
+    two coordinates and the remaining $N$-tuple.
+\end{definition}
+
 \begin{definition}[Renormalization maps on a longer ring]
     \label{def:mpdo_global_renormalization_maps}
-    \lean{MPOTensor.firstSiteRestEquiv,
-      MPOTensor.firstTwoSitesRestEquiv,
-      MPOTensor.refineFirstSite,
+    \lean{MPOTensor.refineFirstSite,
       MPOTensor.coarsenFirstTwoSites}
     \leanok
-    Let $N$ count the sites that are left unchanged.  Regroup a ring of
-    $N+1$ sites as one site followed by $N$ sites, and a ring of $N+2$ sites
-    as two sites followed by $N$ sites.  For physical maps
+    \uses{def:finite_tuple_regroupings}
+    Let $N$ count the sites that are left unchanged.  For physical maps
     $\mathcal T:M_d\to M_{d^2}$ and $\mathcal S:M_{d^2}\to M_d$, define
     \[
        \widehat{\mathcal T}_N
-       =\mathcal T\otimes\id_{N},
+       =\mathcal T\otimes\id_{d^N},
        \qquad
        \widehat{\mathcal S}_N
-       =\mathcal S\otimes\id_{N},
+       =\mathcal S\otimes\id_{d^N},
     \]
-    using these regroupings.  Thus $N=0$ leaves no spectator site, but the
+    using $R_1$ and $R_2$.  Thus $N=0$ leaves no spectator site, but the
     maps still act on a one-site or two-site operator; no empty ring occurs.
 \end{definition}
 
 \begin{lemma}[Regrouping the first physical sites]
     \label{lem:mpdo_global_renormalization_regrouping}
-    \lean{MPOTensor.firstSiteRestEquiv_apply,
-      MPOTensor.firstSiteRestEquiv_symm_apply,
-      MPOTensor.firstTwoSitesRestEquiv_apply,
-      MPOTensor.firstTwoSitesRestEquiv_symm_apply}
+    \lean{finSuccArrowEquiv_apply,
+      finSuccArrowEquiv_symm_apply,
+      finAddTwoArrowEquiv_apply,
+      finAddTwoArrowEquiv_symm_apply}
     \leanok
-    \uses{def:mpdo_global_renormalization_maps}
+    \uses{def:finite_tuple_regroupings}
     For a physical word $\sigma$ of length $N+1$,
     \[
       R_1(\sigma)=\bigl(\sigma_0,(\sigma_1,\ldots,\sigma_N)\bigr),
@@ -631,11 +638,11 @@
     \leanok
     If $(K_j)_j$ are Kraus operators for $\mathcal T$ with
     $\sum_j K_j^\dagger K_j=I_d$, then the localized map has Kraus operators
-    $K_j\otimes I_N$, and
+    $K_j\otimes I_{d^N}$, and
     \[
-      \sum_j (K_j\otimes I_N)^\dagger(K_j\otimes I_N)
-        =\left(\sum_j K_j^\dagger K_j\right)\otimes I_N
-        =I_d\otimes I_N.
+      \sum_j (K_j\otimes I_{d^N})^\dagger(K_j\otimes I_{d^N})
+        =\left(\sum_j K_j^\dagger K_j\right)\otimes I_{d^N}
+        =I_d\otimes I_{d^N}.
     \]
     The two regroupings are unitary conjugations and preserve complete
     positivity and the trace.  The argument for $\mathcal S$ is identical.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
@@ -531,11 +531,14 @@
 \begin{definition}[Renormalization maps on a longer ring]
     \label{def:mpdo_global_renormalization_maps}
     \lean{MPOTensor.firstSiteRestEquiv,
+      MPOTensor.firstSiteRestEquiv_apply,
+      MPOTensor.firstSiteRestEquiv_symm_apply,
       MPOTensor.firstTwoSitesRestEquiv,
+      MPOTensor.firstTwoSitesRestEquiv_apply,
+      MPOTensor.firstTwoSitesRestEquiv_symm_apply,
       MPOTensor.refineFirstSite,
       MPOTensor.coarsenFirstTwoSites}
     \leanok
-    \uses{def:is_rfp_via_ts}
     Let $N$ count the sites that are left unchanged.  Regroup a ring of
     $N+1$ sites as one site followed by $N$ sites, and a ring of $N+2$ sites
     as two sites followed by $N$ sites.  For physical maps
@@ -578,8 +581,7 @@
       MPOTensor.exists_global_renormalization_maps}
     \leanok
     \uses{def:phys_close, def:is_rfp_via_ts,
-      def:mpdo_global_renormalization_maps,
-      lem:mpdo_global_renormalization_maps_cptp}
+      def:mpdo_global_renormalization_maps}
     Suppose that $\mathcal S[M_2(X)]=M_1(X)$ and
     $\mathcal T[M_1(X)]=M_2(X)$ for every virtual operator $X$.  Then, for
     every $N$ and $X$,

--- a/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
@@ -443,8 +443,8 @@
 
 \begin{definition}[Physical closure maps]
     \label{def:phys_close}
-    \lean{MPOTensor.physCloseN, MPOTensor.physCloseN_apply,
-      MPOTensor.physClose1, MPOTensor.physClose2, MPOTensor.physClose3}
+    \lean{MPOTensor.physCloseN, MPOTensor.physClose1,
+      MPOTensor.physClose2, MPOTensor.physClose3}
     \leanok
     \uses{def:mpo_eval_word}
     For an MPO tensor $M$, a length $N$, and a virtual operator $X$, define the
@@ -464,6 +464,23 @@
     $N=2,3$ occur in
     \cite[Proposition~C.7, lines~1510--1516]{Cirac2016MPDO_arXiv}.
 \end{definition}
+
+\begin{lemma}[Matrix entries of a physical closure]
+    \label{lem:phys_close_apply}
+    \lean{MPOTensor.physCloseN_apply}
+    \leanok
+    \uses{def:phys_close}
+    For physical words $\boldsymbol i,\boldsymbol j$ of length $N$,
+    \[
+        M_N(X)_{\boldsymbol i,\boldsymbol j}
+        =\tr\!\left(M^{i_0j_0}\cdots M^{i_{N-1}j_{N-1}}X\right).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    This is the defining matrix entry of the physical closure.
+\end{proof}
 
 \begin{theorem}[One- and two-site physical closures]
     \label{thm:phys_close_one_two}
@@ -531,11 +548,7 @@
 \begin{definition}[Renormalization maps on a longer ring]
     \label{def:mpdo_global_renormalization_maps}
     \lean{MPOTensor.firstSiteRestEquiv,
-      MPOTensor.firstSiteRestEquiv_apply,
-      MPOTensor.firstSiteRestEquiv_symm_apply,
       MPOTensor.firstTwoSitesRestEquiv,
-      MPOTensor.firstTwoSitesRestEquiv_apply,
-      MPOTensor.firstTwoSitesRestEquiv_symm_apply,
       MPOTensor.refineFirstSite,
       MPOTensor.coarsenFirstTwoSites}
     \leanok
@@ -545,14 +558,33 @@
     $\mathcal T:M_d\to M_{d^2}$ and $\mathcal S:M_{d^2}\to M_d$, define
     \[
        \widehat{\mathcal T}_N
-       =\mathcal T\otimes\id_N,
+       =\mathcal T\otimes\id_{N},
        \qquad
        \widehat{\mathcal S}_N
-       =\mathcal S\otimes\id_N,
+       =\mathcal S\otimes\id_{N},
     \]
     using these regroupings.  Thus $N=0$ leaves no spectator site, but the
     maps still act on a one-site or two-site operator; no empty ring occurs.
 \end{definition}
+
+\begin{lemma}[Regrouping the first physical sites]
+    \label{lem:mpdo_global_renormalization_regrouping}
+    \lean{MPOTensor.firstSiteRestEquiv_apply,
+      MPOTensor.firstSiteRestEquiv_symm_apply,
+      MPOTensor.firstTwoSitesRestEquiv_apply,
+      MPOTensor.firstTwoSitesRestEquiv_symm_apply}
+    \leanok
+    \uses{def:mpdo_global_renormalization_maps}
+    The regrouping equivalences and their inverses preserve every physical
+    component: they merely separate the first site, or the first two sites,
+    from the remaining word.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Both identities follow by evaluating the corresponding product-index
+    equivalence and its inverse.
+\end{proof}
 
 \begin{lemma}[Localized renormalization maps are channels]
     \label{lem:mpdo_global_renormalization_maps_cptp}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
@@ -482,6 +482,24 @@
     This is the defining matrix entry of the physical closure.
 \end{proof}
 
+\begin{lemma}[Periodic closure]
+    \label{lem:phys_close_identity}
+    \lean{MPOTensor.physCloseN_identity_eq_mpo}
+    \leanok
+    \uses{def:phys_close, def:mpo_tensor}
+    Closing the virtual legs with the identity gives the periodic MPO
+    operator:
+    \[
+        M_N(1)=\operatorname{MPO}_N(M).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    At every pair of physical words, both sides are the trace of the same
+    virtual word evaluation.
+\end{proof}
+
 \begin{theorem}[One- and two-site physical closures]
     \label{thm:phys_close_one_two}
     \lean{MPOTensor.physCloseN_one_eq_physClose1,
@@ -575,15 +593,28 @@
       MPOTensor.firstTwoSitesRestEquiv_symm_apply}
     \leanok
     \uses{def:mpdo_global_renormalization_maps}
-    The regrouping equivalences and their inverses preserve every physical
-    component: they merely separate the first site, or the first two sites,
-    from the remaining word.
+    For a physical word $\sigma$ of length $N+1$,
+    \[
+      R_1(\sigma)=\bigl(\sigma(0),\operatorname{tail}(\sigma)\bigr),
+      \qquad
+      R_1^{-1}(i,\sigma')=\operatorname{cons}(i,\sigma').
+    \]
+    For a physical word $\sigma$ of length $N+2$,
+    \[
+      R_2(\sigma)
+        =\bigl((\sigma(0),\sigma(1)),
+          \operatorname{tail}(\operatorname{tail}(\sigma))\bigr),
+    \]
+    and
+    \[
+      R_2^{-1}((i,j),\sigma')
+        =\operatorname{cons}\bigl(i,\operatorname{cons}(j,\sigma')\bigr).
+    \]
 \end{lemma}
 
 \begin{proof}
     \leanok
-    Both identities follow by evaluating the corresponding product-index
-    equivalence and its inverse.
+    All four identities hold by definition of the product-index equivalences.
 \end{proof}
 
 \begin{lemma}[Localized renormalization maps are channels]
@@ -615,7 +646,6 @@
     \label{thm:mpdo_global_renormalization_maps}
     \lean{MPOTensor.refineFirstSite_physCloseN,
       MPOTensor.coarsenFirstTwoSites_physCloseN,
-      MPOTensor.physCloseN_identity_eq_mpo,
       MPOTensor.refineFirstSite_mpo,
       MPOTensor.coarsenFirstTwoSites_mpo,
       MPOTensor.exists_global_renormalization_maps}
@@ -638,6 +668,7 @@
 
 \begin{proof}
     \leanok
+    \uses{lem:phys_close_identity}
     For words $u,v$ on the $N$ spectator sites, write $M^{u,v}$ for their
     virtual word evaluation and write $[Y]^{(r)}_{u,v}$ for the block of an
     operator $Y$ on the first $r$ sites.  Regrouping the first site gives

--- a/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
@@ -443,8 +443,8 @@
 
 \begin{definition}[Physical closure maps]
     \label{def:phys_close}
-    \lean{MPOTensor.physCloseN, MPOTensor.physClose1, MPOTensor.physClose2,
-      MPOTensor.physClose3}
+    \lean{MPOTensor.physCloseN, MPOTensor.physCloseN_apply,
+      MPOTensor.physClose1, MPOTensor.physClose2, MPOTensor.physClose3}
     \leanok
     \uses{def:mpo_eval_word}
     For an MPO tensor $M$, a length $N$, and a virtual operator $X$, define the
@@ -567,8 +567,16 @@
 
 \begin{proof}
     \leanok
-    Tensor each Kraus operator with the identity on the spectator sites and
-    conjugate by the two regrouping equivalences.
+    If $(K_j)_j$ are Kraus operators for $\mathcal T$ with
+    $\sum_j K_j^\dagger K_j=I_d$, then the localized map has Kraus operators
+    $K_j\otimes I_N$, and
+    \[
+      \sum_j (K_j\otimes I_N)^\dagger(K_j\otimes I_N)
+        =\left(\sum_j K_j^\dagger K_j\right)\otimes I_N
+        =I_d\otimes I_N.
+    \]
+    The two regroupings are unitary conjugations and preserve complete
+    positivity and the trace.  The argument for $\mathcal S$ is identical.
 \end{proof}
 
 \begin{theorem}[Global action of the renormalization maps]
@@ -593,16 +601,26 @@
     In particular, these identities hold for every periodic MPO operator.
     Hence the two maps supplied by a renormalization fixed point act on rings
     of every length as required in the proof of
-    \cite[Proposition \texttt{propsimple}, lines~1333--1341]
-    {Cirac2016MPDO_arXiv}.
+    \cite[Appendix~C, lines~1333--1341]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    After separating the first one or two sites, each matrix block is the
-    corresponding one-site or two-site closure, with the remaining word
-    absorbed into the virtual boundary operator.  Apply the defining local
-    closure identity to every block.
+    For words $u,v$ on the $N$ spectator sites, write $M^{u,v}$ for their
+    virtual word evaluation and write $[Y]^{(r)}_{u,v}$ for the block of an
+    operator $Y$ on the first $r$ sites.  Regrouping the first site gives
+    \[
+      [M_{N+1}(X)]^{(1)}_{u,v}=M_1(M^{u,v}X).
+    \]
+    Therefore
+    \[
+      \mathcal T\bigl([M_{N+1}(X)]^{(1)}_{u,v}\bigr)
+        =M_2(M^{u,v}X)
+        =[M_{N+2}(X)]^{(2)}_{u,v}.
+    \]
+    Equality of all blocks proves the refinement identity.  Interchanging
+    $M_1$, $M_2$ and using $\mathcal S[M_2(Y)]=M_1(Y)$ proves the coarsening
+    identity.
 \end{proof}
 
 \begin{definition}[Diagonal pure-state embedding as an MPO]\label{def:to_mpo_tensor}

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -79,6 +79,12 @@ For MPDO renormalization fixed points:
   relation `AA=A` and its unrestricted equivalence with transfer-map
   idempotence are formalized; the physical-space meaning of the repeated-copy
   index remains open.
+- `cpsv16_rfp_sal_data_processing.tex` records the source proof that a mixed-state
+  renormalization fixed point satisfies saturation of the area law. The
+  localized trace-preserving completely positive maps and their tensor-ring
+  identities are formalized. Mutual-information data processing for the two
+  local maps and nonzero normalization from the source's simple-biCF convention
+  remain open.
 - `cpsv16_zcl_canonical_form_normalization.tex` records the corresponding
   normalization issue for mixed-state ZCL.
 

--- a/docs/paper-gaps/cpsv16_rfp_sal_data_processing.tex
+++ b/docs/paper-gaps/cpsv16_rfp_sal_data_processing.tex
@@ -66,10 +66,10 @@ identities imply, for every $N$ and every virtual operator $X$,
 \]
 These identities, including the trace-preserving completely positive
 property, have been proved for arbitrary $N$.\footnote{Formal declarations:
-\leanid{MPOTensor.refineFirstSite\_isKrausCPTP},
-\leanid{MPOTensor.coarsenFirstTwoSites\_isKrausCPTP},
-\leanid{MPOTensor.refineFirstSite\_physCloseN}, and
-\leanid{MPOTensor.coarsenFirstTwoSites\_physCloseN} in
+\leanid{MPOTensor.refineFirstSite_isKrausCPTP},
+\leanid{MPOTensor.coarsenFirstTwoSites_isKrausCPTP},
+\leanid{MPOTensor.refineFirstSite_physCloseN}, and
+\leanid{MPOTensor.coarsenFirstTwoSites_physCloseN} in
 \doclink{TNLean/MPS/MPDO/RFPViaTSGlobal}.}
 Taking $X=1$ gives the corresponding identities for every periodic tensor
 ring.  If $N=0$, the local map still acts from one site to two sites, or
@@ -80,7 +80,7 @@ Strong subadditivity already gives the opposite inequality
   I_L\leq I_{L+1}
 \]
 by adjoining one physical site to an interval.\footnote{Formal declaration:
-\leanid{MPOTensor.mutualInfoChain\_monotone}.}
+\leanid{MPOTensor.mutualInfoChain_monotone}.}
 
 \section{Exact remaining implications}
 

--- a/docs/paper-gaps/cpsv16_rfp_sal_data_processing.tex
+++ b/docs/paper-gaps/cpsv16_rfp_sal_data_processing.tex
@@ -1,0 +1,113 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{The remaining data-processing step in the strong-area-law consequence
+of MPDO renormalization fixed points}
+\author{}
+\date{2026-07-15}
+
+\begin{document}
+\maketitle
+
+\section{Source statement and proof}
+
+Definition~4.1 of Cirac--P\'erez-Garc\'ia--Schuch--Verstraete
+(local label \texttt{RFPMixedTS},
+\path{Papers/1606.00608/MPDO-22-12-17-2.tex:638--660}) defines a mixed-state
+renormalization fixed point by trace-preserving completely positive maps
+$\mathcal S$ and $\mathcal T$ satisfying
+\[
+  \mathcal S[M_2(X)]=M_1(X),
+  \qquad
+  \mathcal T[M_1(X)]=M_2(X)
+\]
+for every virtual boundary operator $X$.
+
+Theorem~4.9, implication (i)$\Rightarrow$(ii)
+(\path{Papers/1606.00608/MPDO-22-12-17-2.tex:849--893}), is stated for a
+simple tensor $\mathcal K$ in biCF generating density operators.  Its
+Appendix~C proof, Proposition \texttt{propsimple}
+(\path{Papers/1606.00608/MPDO-22-12-17-2.tex:1331--1341}), treats a bipartition
+of a ring into consecutive intervals $A$ and $B$.  It applies $\mathcal T$ to
+the first spin of $A$ and $\mathcal S$ to the first two spins of $B$.  The
+closure identities return the same tensor ring with one spin transferred from
+$B$ to $A$.  Since these are local channels, data processing gives
+\[
+  I_{L+1}\leq I_L.
+\]
+Proposition~4.5 supplies the reverse inequality $I_L\leq I_{L+1}$, hence
+equality and the strong area law.
+
+The entropic convention immediately preceding Definition~4.6
+(\path{Papers/1606.00608/MPDO-22-12-17-2.tex:792--793}) normalizes every
+operator by its trace.  The source theorem therefore uses, as standing data,
+that the tensor generates nonzero density operators at the lengths under
+consideration; it does not add an independent nonvanishing hypothesis to
+Proposition \texttt{propsimple}.
+
+\section{Formalized part of the source path}
+
+The local condition is \texttt{MPOTensor.IsRFPViaTS}.  The file
+\path{TNLean/MPS/MPDO/RFPViaTSGlobal.lean} now defines the localized maps
+\texttt{refineFirstSite} and \texttt{coarsenFirstTwoSites}.  It proves that
+they are trace-preserving completely positive and that, for every $N$ and
+virtual operator $X$,
+\[
+  \widehat{\mathcal T}_N[M_{N+1}(X)]=M_{N+2}(X),
+  \qquad
+  \widehat{\mathcal S}_N[M_{N+2}(X)]=M_{N+1}(X).
+\]
+Taking $X$ to be the identity gives the corresponding identities for every
+periodic MPO operator.  Here $N$ counts the spectator sites.  Thus $N=0$
+still describes a map from one site to two sites, or conversely; it does not
+introduce an empty-chain state.
+
+The opposite mutual-information inequality is already formalized as
+\texttt{MPOTensor.mutualInfoChain\_monotone}.  It is obtained from strong
+subadditivity by enlarging one interval by one physical site.
+
+\section{Exact remaining implications}
+
+Two source-faithful ingredients remain before the implication to
+\texttt{MPOTensor.IsSAL} can be stated without an additional hypothesis.
+
+\begin{enumerate}
+  \item \textbf{Local-channel data processing.}
+  The entropy library proves mutual-information monotonicity under discarding
+  a subsystem, and the channel library contains Kraus-form local channels.
+  There is not yet a theorem stating that mutual information cannot increase
+  when arbitrary trace-preserving completely positive maps act separately on
+  the two factors.  The required theorem should be proved either from a
+  Stinespring isometry followed by the existing partial-trace inequality, or
+  from relative-entropy data processing for an arbitrary Kraus channel.  It
+  must then be combined with the cyclic regrouping that places the $A$ and $B$
+  boundary sites in the first tensor factors.
+
+  \item \textbf{The source standing nonvanishing condition.}
+  The current predicate \texttt{MPOTensor.IsMPDO} asserts positivity but
+  permits the zero operator.  The available per-copy horizontal canonical-form
+  structure is stronger than the source's grouped biCF and also permits
+  degenerate empty or zero-dimensional data.  Consequently the present API
+  does not derive, from a faithful formal counterpart of ``simple in biCF
+  generating density operators'', that
+  $\operatorname{tr}(\operatorname{mpo}(\mathcal K,N))\ne0$ for every relevant
+  $N$.  This must be repaired by formalizing the source simple-biCF standing
+  data, including generation of normalized density operators, and deriving the
+  nonvanishing used by the normalization in Definition~4.6.
+\end{enumerate}
+
+Neither point is resolved by adding
+$\forall N,\operatorname{tr}(\operatorname{mpo}(\mathcal K,N))\ne0$ as a new
+hypothesis to the source-labelled theorem: that would be a stronger-hypothesis
+surrogate.  Once the two ingredients above are available, the source proof
+applies the two localized channels, invokes data processing to obtain
+$I_{L+1}\leq I_L$, and combines this with the already formalized inequality
+$I_L\leq I_{L+1}$.
+
+\end{document}

--- a/docs/paper-gaps/cpsv16_rfp_sal_data_processing.tex
+++ b/docs/paper-gaps/cpsv16_rfp_sal_data_processing.tex
@@ -7,7 +7,7 @@
 
 \input{command}
 
-\title{The remaining data-processing step in the strong-area-law consequence
+\title{The remaining data-processing step for saturation of the area law
 of MPDO renormalization fixed points}
 \author{}
 \date{2026-07-15}
@@ -43,7 +43,7 @@ processing gives
   I_{L+1}\leq I_L.
 \]
 Proposition~4.5 supplies the reverse inequality $I_L\leq I_{L+1}$, hence
-equality and the strong area law.
+equality and saturation of the area law.
 
 The entropic convention immediately preceding Definition~4.6 normalizes every
 operator by its trace.\footnote{Source:
@@ -127,6 +127,6 @@ $I_L\leq I_{L+1}$.
 This is an open gap.  The global tensor-ring identities are proved, but the
 mutual-information data-processing theorem and the derivation of nonzero
 normalization from the source's simple-biCF convention remain necessary for a
-faithful proof of the strong area law.
+faithful proof of saturation of the area law.
 
 \end{document}

--- a/docs/paper-gaps/cpsv16_rfp_sal_data_processing.tex
+++ b/docs/paper-gaps/cpsv16_rfp_sal_data_processing.tex
@@ -33,7 +33,7 @@ Theorem~4.9, implication (i)$\Rightarrow$(ii), is stated for a simple tensor
 $\mathcal K$ in biCF generating density operators.\footnote{Source:
 \path{Papers/1606.00608/MPDO-22-12-17-2.tex:849--893}.}
 Its Appendix~C proof treats a bipartition of a ring into consecutive intervals
-$A$ and $B$.\footnote{Proposition \texttt{propsimple},
+$A$ and $B$.\footnote{Source:
 \path{Papers/1606.00608/MPDO-22-12-17-2.tex:1331--1341}.}
 It applies $\mathcal T$ to the first spin of $A$ and $\mathcal S$ to the first
 two spins of $B$.  The closure identities return the same tensor ring with one
@@ -50,8 +50,8 @@ operator by its trace.\footnote{Source:
 \path{Papers/1606.00608/MPDO-22-12-17-2.tex:792--793}.}
 The source theorem therefore uses, as standing data,
 that the tensor generates nonzero density operators at the lengths under
-consideration; it does not add an independent nonvanishing hypothesis to
-Proposition \texttt{propsimple}.
+consideration; it does not add an independent nonvanishing hypothesis to the
+Appendix~C proposition.
 
 \section{The established global identities}
 

--- a/docs/paper-gaps/cpsv16_rfp_sal_data_processing.tex
+++ b/docs/paper-gaps/cpsv16_rfp_sal_data_processing.tex
@@ -17,11 +17,11 @@ of MPDO renormalization fixed points}
 
 \section{Source statement and proof}
 
-Definition~4.1 of Cirac--P\'erez-Garc\'ia--Schuch--Verstraete
-(local label \texttt{RFPMixedTS},
-\path{Papers/1606.00608/MPDO-22-12-17-2.tex:638--660}) defines a mixed-state
-renormalization fixed point by trace-preserving completely positive maps
-$\mathcal S$ and $\mathcal T$ satisfying
+Definition~4.1 of Cirac--P\'erez-Garc\'ia--Schuch--Verstraete defines a
+mixed-state renormalization fixed point by trace-preserving completely positive
+maps $\mathcal S$ and $\mathcal T$ satisfying\footnote{Source label
+\texttt{RFPMixedTS},
+\path{Papers/1606.00608/MPDO-22-12-17-2.tex:638--660}.}
 \[
   \mathcal S[M_2(X)]=M_1(X),
   \qquad
@@ -29,73 +29,86 @@ $\mathcal S$ and $\mathcal T$ satisfying
 \]
 for every virtual boundary operator $X$.
 
-Theorem~4.9, implication (i)$\Rightarrow$(ii)
-(\path{Papers/1606.00608/MPDO-22-12-17-2.tex:849--893}), is stated for a
-simple tensor $\mathcal K$ in biCF generating density operators.  Its
-Appendix~C proof, Proposition \texttt{propsimple}
-(\path{Papers/1606.00608/MPDO-22-12-17-2.tex:1331--1341}), treats a bipartition
-of a ring into consecutive intervals $A$ and $B$.  It applies $\mathcal T$ to
-the first spin of $A$ and $\mathcal S$ to the first two spins of $B$.  The
-closure identities return the same tensor ring with one spin transferred from
-$B$ to $A$.  Since these are local channels, data processing gives
+Theorem~4.9, implication (i)$\Rightarrow$(ii), is stated for a simple tensor
+$\mathcal K$ in biCF generating density operators.\footnote{Source:
+\path{Papers/1606.00608/MPDO-22-12-17-2.tex:849--893}.}
+Its Appendix~C proof treats a bipartition of a ring into consecutive intervals
+$A$ and $B$.\footnote{Proposition \texttt{propsimple},
+\path{Papers/1606.00608/MPDO-22-12-17-2.tex:1331--1341}.}
+It applies $\mathcal T$ to the first spin of $A$ and $\mathcal S$ to the first
+two spins of $B$.  The closure identities return the same tensor ring with one
+spin transferred from $B$ to $A$.  Since these are local channels, data
+processing gives
 \[
   I_{L+1}\leq I_L.
 \]
 Proposition~4.5 supplies the reverse inequality $I_L\leq I_{L+1}$, hence
 equality and the strong area law.
 
-The entropic convention immediately preceding Definition~4.6
-(\path{Papers/1606.00608/MPDO-22-12-17-2.tex:792--793}) normalizes every
-operator by its trace.  The source theorem therefore uses, as standing data,
+The entropic convention immediately preceding Definition~4.6 normalizes every
+operator by its trace.\footnote{Source:
+\path{Papers/1606.00608/MPDO-22-12-17-2.tex:792--793}.}
+The source theorem therefore uses, as standing data,
 that the tensor generates nonzero density operators at the lengths under
 consideration; it does not add an independent nonvanishing hypothesis to
 Proposition \texttt{propsimple}.
 
-\section{Formalized part of the source path}
+\section{The established global identities}
 
-The local condition is \texttt{MPOTensor.IsRFPViaTS}.  The file
-\path{TNLean/MPS/MPDO/RFPViaTSGlobal.lean} now defines the localized maps
-\texttt{refineFirstSite} and \texttt{coarsenFirstTwoSites}.  It proves that
-they are trace-preserving completely positive and that, for every $N$ and
-virtual operator $X$,
+Let $N$ denote the number of spectator sites.  Tensoring the local maps with
+the identity on these sites gives trace-preserving completely positive maps
+$\widehat{\mathcal T}_N$ and $\widehat{\mathcal S}_N$.  The local closure
+identities imply, for every $N$ and every virtual operator $X$,
 \[
   \widehat{\mathcal T}_N[M_{N+1}(X)]=M_{N+2}(X),
   \qquad
   \widehat{\mathcal S}_N[M_{N+2}(X)]=M_{N+1}(X).
 \]
-Taking $X$ to be the identity gives the corresponding identities for every
-periodic MPO operator.  Here $N$ counts the spectator sites.  Thus $N=0$
-still describes a map from one site to two sites, or conversely; it does not
-introduce an empty-chain state.
+These identities, including the trace-preserving completely positive
+property, have been proved for arbitrary $N$.\footnote{Formal declarations:
+\leanid{MPOTensor.refineFirstSite\_isKrausCPTP},
+\leanid{MPOTensor.coarsenFirstTwoSites\_isKrausCPTP},
+\leanid{MPOTensor.refineFirstSite\_physCloseN}, and
+\leanid{MPOTensor.coarsenFirstTwoSites\_physCloseN} in
+\doclink{TNLean/MPS/MPDO/RFPViaTSGlobal}.}
+Taking $X=1$ gives the corresponding identities for every periodic tensor
+ring.  If $N=0$, the local map still acts from one site to two sites, or
+conversely; no operator on an empty ring is introduced.
 
-The opposite mutual-information inequality is already formalized as
-\texttt{MPOTensor.mutualInfoChain\_monotone}.  It is obtained from strong
-subadditivity by enlarging one interval by one physical site.
+Strong subadditivity already gives the opposite inequality
+\[
+  I_L\leq I_{L+1}
+\]
+by adjoining one physical site to an interval.\footnote{Formal declaration:
+\leanid{MPOTensor.mutualInfoChain\_monotone}.}
 
 \section{Exact remaining implications}
 
-Two source-faithful ingredients remain before the implication to
-\texttt{MPOTensor.IsSAL} can be stated without an additional hypothesis.
+Two source-faithful ingredients remain before the implication to the strong
+area law can be stated without an additional hypothesis.
 
 \begin{enumerate}
   \item \textbf{Local-channel data processing.}
-  The entropy library proves mutual-information monotonicity under discarding
-  a subsystem, and the channel library contains Kraus-form local channels.
-  There is not yet a theorem stating that mutual information cannot increase
-  when arbitrary trace-preserving completely positive maps act separately on
-  the two factors.  The required theorem should be proved either from a
-  Stinespring isometry followed by the existing partial-trace inequality, or
-  from relative-entropy data processing for an arbitrary Kraus channel.  It
-  must then be combined with the cyclic regrouping that places the $A$ and $B$
-  boundary sites in the first tensor factors.
+  For a bipartite density operator $\rho_{AB}$ and trace-preserving completely
+  positive maps $\Phi_A$ and $\Psi_B$, one needs
+  \[
+    I(A':B')_{(\Phi_A\otimes\Psi_B)(\rho)}
+      \leq I(A:B)_\rho.
+  \]
+  This may be derived from Stinespring dilations followed by monotonicity under
+  partial trace, or from relative-entropy data processing.  The result must
+  then be combined with the cyclic regrouping that places the two boundary
+  sites in the first tensor factors.  The available entropy results treat
+  discarding a subsystem, but not yet this arbitrary pair of local channels.
 
   \item \textbf{The source standing nonvanishing condition.}
-  The current predicate \texttt{MPOTensor.IsMPDO} asserts positivity but
-  permits the zero operator.  The available per-copy horizontal canonical-form
-  structure is stronger than the source's grouped biCF and also permits
-  degenerate empty or zero-dimensional data.  Consequently the present API
-  does not derive, from a faithful formal counterpart of ``simple in biCF
-  generating density operators'', that
+  The present formal condition for a matrix product density operator asserts
+  positivity at every length but permits the zero operator.\footnote{Formal
+  declaration: \leanid{MPOTensor.IsMPDO}.}
+  The available per-copy horizontal canonical form is stronger than the
+  source's grouped biCF and still admits degenerate empty data.  It therefore
+  does not yet imply, from the source condition ``simple in biCF generating
+  density operators'', that
   $\operatorname{tr}(\operatorname{mpo}(\mathcal K,N))\ne0$ for every relevant
   $N$.  This must be repaired by formalizing the source simple-biCF standing
   data, including generation of normalized density operators, and deriving the
@@ -104,10 +117,16 @@ Two source-faithful ingredients remain before the implication to
 
 Neither point is resolved by adding
 $\forall N,\operatorname{tr}(\operatorname{mpo}(\mathcal K,N))\ne0$ as a new
-hypothesis to the source-labelled theorem: that would be a stronger-hypothesis
-surrogate.  Once the two ingredients above are available, the source proof
-applies the two localized channels, invokes data processing to obtain
+hypothesis to the source-labelled theorem, since that condition is absent from
+the printed statement.  Once the two ingredients above are available, the
+source proof applies the two localized channels, invokes data processing to obtain
 $I_{L+1}\leq I_L$, and combines this with the already formalized inequality
 $I_L\leq I_{L+1}$.
+
+\paragraph{Classification.}
+This is an open gap.  The global tensor-ring identities are proved, but the
+mutual-information data-processing theorem and the derivation of nonzero
+normalization from the source's simple-biCF convention remain necessary for a
+faithful proof of the strong area law.
 
 \end{document}

--- a/docs/paper-gaps/cpsv16_rfp_sal_data_processing.tex
+++ b/docs/paper-gaps/cpsv16_rfp_sal_data_processing.tex
@@ -109,14 +109,14 @@ area law can be stated without an additional hypothesis.
   source's grouped biCF and still admits degenerate empty data.  It therefore
   does not yet imply, from the source condition ``simple in biCF generating
   density operators'', that
-  $\operatorname{tr}(\operatorname{mpo}(\mathcal K,N))\ne0$ for every relevant
+  $\tr(\operatorname{mpo}(\mathcal K,N))\ne0$ for every relevant
   $N$.  This must be repaired by formalizing the source simple-biCF standing
   data, including generation of normalized density operators, and deriving the
   nonvanishing used by the normalization in Definition~4.6.
 \end{enumerate}
 
 Neither point is resolved by adding
-$\forall N,\operatorname{tr}(\operatorname{mpo}(\mathcal K,N))\ne0$ as a new
+$\forall N,\tr(\operatorname{mpo}(\mathcal K,N))\ne0$ as a new
 hypothesis to the source-labelled theorem, since that condition is absent from
 the printed statement.  Once the two ingredients above are available, the
 source proof applies the two localized channels, invokes data processing to obtain

--- a/tex/tn/tn_catalogue.tex
+++ b/tex/tn/tn_catalogue.tex
@@ -1216,7 +1216,7 @@
     {display}
     {compact}
     {\TNMPDOBNTVerticalProduct}
-    {chapter/ch21_mpdo_rfp_blocked_rfp.tex}{%
+    {chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex}{%
     \begin{TNEquationRow}[compact]
         \TNTerm{%
             \TNStackedMPOProduct{vp}{at=origin}{\mathcal K_y}{\mathcal K_x}{}
@@ -1369,7 +1369,7 @@
     {display}
     {compact}
     {\TNMPDOProjectorAbsorption}
-    {chapter/ch21_mpdo_rfp_blocked_rfp.tex}{%
+    {chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex}{%
     \begin{TNEquationRow}[compact]
         \ensuremath{
             \mathcal K_i


### PR DESCRIPTION
## Mathematical content

This proves the global channel identities needed in the source proof of the strong area law, advancing #3948.

The one-to-two and two-to-one maps of Definition 4.1 are tensored with the identity on the remaining physical sites. The resulting maps are proved trace-preserving and completely positive, and their actions on arbitrary physical closures are established:

$$T_1\bigl(\operatorname{close}_{N+1}(M;X)\bigr)
  =\operatorname{close}_{N+2}(M;X),$$

$$S_{12}\bigl(\operatorname{close}_{N+2}(M;X)\bigr)
  =\operatorname{close}_{N+1}(M;X).$$

The corresponding periodic-MPO identities and the global consequence of `IsRFPViaTS` are then derived. Here $N=0$ means that there are no spectator sites; the local map still acts on a one- or two-site closure, so no empty physical chain occurs.

## Source boundary

This is a proved intermediate toward Proposition `propsimple` in arXiv:1606.00608, lines 1333–1341. The final SAL implication still requires:

1. mutual-information data processing for arbitrary local Kraus CPTP maps;
2. a faithful simple-biCF standing predicate from which nonzero normalized MPO states follow.

The present `IsMPDO` predicate permits the zero MPO. No all-length nonvanishing hypothesis is introduced as a substitute for the source convention; the exact remaining obligations are recorded in the paper-gap note.

## Verification

- targeted Lean compilation and module build
- blueprint source synchronization and declaration checks
- reader-facing prose and changed-declaration coverage checks
- `git diff --check`
- proof-integrity scan

No new `sorry`, axiom, or kernel bypass is introduced.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formal proofs and documentation on the MPDO RFP track; no auth, runtime, or breaking API changes. Remaining SAL gaps are explicitly scoped, not silently assumed.
> 
> **Overview**
> Extends Definition 4.1 renormalization maps from one- and two-site physical closures to **arbitrary chain length** by localizing \(\mathcal T\) and \(\mathcal S\) on the first site(s) and tensoring with identity on \(N\) spectator sites (`refineFirstSite`, `coarsenFirstTwoSites` in `RFPViaTSGlobal.lean`).
> 
> Adds variable-length tuple equivalences `finSuccArrowEquiv` and `finAddTwoArrowEquiv` in `FinTupleEquiv.lean` to regroup physical indices for those maps. Proves the localized maps are Kraus CPTP and satisfy global closure identities \( \widehat{\mathcal T}_N[M_{N+1}(X)] = M_{N+2}(X) \), \( \widehat{\mathcal S}_N[M_{N+2}(X)] = M_{N+1}(X) \), with the same for periodic MPOs via new `physCloseN_identity_eq_mpo`. `exists_global_renormalization_maps` packages this from `IsRFPViaTS`.
> 
> Blueprint chapters document regroupings, global channel action, and periodic closure; a new paper-gap note records that **SAL** still needs mutual-information data processing for paired local channels and faithful simple-biCF nonvanishing—not new ad hoc trace hypotheses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbfb64964452ece363bc9122b39d350672570556. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->