### PR TITLE
feat(MPS/ParentHamiltonian): prove tripartite decorrelation equivalence

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -275,6 +275,7 @@ import TNLean.MPS.ParentHamiltonian.BoundaryBlockMatEq
 import TNLean.Axioms.Beigi
 import TNLean.MPS.ParentHamiltonian.Commuting
 import TNLean.MPS.ParentHamiltonian.Decorrelation
+import TNLean.MPS.ParentHamiltonian.TripartiteDecorrelation
 import TNLean.MPS.ParentHamiltonian.Martingale
 import TNLean.MPS.ParentHamiltonian.KernelChainGroundSpace
 -- The finite-chain uniqueness capstone is not part of this foundational layer.

--- a/TNLean/Analysis/Entropy.lean
+++ b/TNLean/Analysis/Entropy.lean
@@ -617,10 +617,7 @@ variable {dA dB : ℕ}
 theorem Matrix.traceLeft_isHermitian
     {ρ : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ}
     (hρ : ρ.IsHermitian) : (Matrix.traceLeft ρ).IsHermitian := by
-  apply Matrix.IsHermitian.ext
-  intro b₁ b₂
-  simp only [Matrix.traceLeft, star_sum]
-  exact Finset.sum_congr rfl fun a _ => hρ.apply (a, b₁) (a, b₂)
+  simpa [Matrix.traceLeft] using Matrix.partialTraceLeft_isHermitian hρ
 
 /-- `Matrix.traceRight` (partial trace over B) preserves Hermiticity. -/
 theorem Matrix.traceRight_isHermitian

--- a/TNLean/Channel/MarginalSupportAbsorption.lean
+++ b/TNLean/Channel/MarginalSupportAbsorption.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.Analysis.CfcKronecker
 import TNLean.Analysis.MarginalSupport
 import TNLean.Channel.MaximalOverlap
+import TNLean.Channel.PartialTrace
 
 /-!
 # Support projectors of bipartite marginals
@@ -143,41 +144,6 @@ end Bipartite
 section LeftMarginal
 
 variable {L R : Type*} [Fintype L] [DecidableEq L] [Fintype R] [DecidableEq R]
-
-/-- Partial trace over the left factor of a matrix indexed by `L × R`:
-\((\operatorname{tr}_L \rho)_{r,s}=\sum_l \rho_{(l,r),(l,s)}\).
-
-See arXiv:1606.00608, Appendix D.2, lines 2225--2229. -/
-noncomputable def partialTraceLeft (ρ : Matrix (L × R) (L × R) ℂ) : Matrix R R ℂ :=
-  fun r s => ∑ l : L, ρ (l, r) (l, s)
-
-omit [DecidableEq L] [Fintype R] [DecidableEq R] in
-@[simp]
-theorem partialTraceLeft_apply (ρ : Matrix (L × R) (L × R) ℂ) (r s : R) :
-    partialTraceLeft ρ r s = ∑ l : L, ρ (l, r) (l, s) := rfl
-
-omit [DecidableEq L] [Fintype R] [DecidableEq R] in
-/-- Partial trace over the left factor preserves Hermiticity. -/
-theorem partialTraceLeft_isHermitian {ρ : Matrix (L × R) (L × R) ℂ}
-    (hρ : ρ.IsHermitian) : (Matrix.partialTraceLeft ρ).IsHermitian := by
-  apply Matrix.IsHermitian.ext
-  intro r s
-  simp only [partialTraceLeft_apply, star_sum]
-  exact Finset.sum_congr rfl fun l _ => hρ.apply (l, r) (l, s)
-
-omit [DecidableEq L] [Fintype R] [DecidableEq R] in
-/-- Partial trace over the left factor preserves positive semidefiniteness.
-
-This supplies the positive \(XB\) marginal used in arXiv:1606.00608,
-Appendix D.2, lines 2225--2229. -/
-theorem PosSemidef.partialTraceLeft {ρ : Matrix (L × R) (L × R) ℂ}
-    (hρ : ρ.PosSemidef) : (Matrix.partialTraceLeft ρ).PosSemidef := by
-  have heq : Matrix.partialTraceLeft ρ =
-      ∑ l : L, ρ.submatrix (fun r : R => (l, r)) (fun r : R => (l, r)) := by
-    ext r s
-    simp only [partialTraceLeft_apply, Matrix.sum_apply, Matrix.submatrix_apply]
-  rw [heq]
-  exact Matrix.posSemidef_sum _ fun l _ => hρ.submatrix (fun r => (l, r))
 
 /-- Partial trace over the left factor and the right tensor embedding are
 adjoint for the trace pairing:

--- a/TNLean/Channel/MarginalSupportAbsorption.lean
+++ b/TNLean/Channel/MarginalSupportAbsorption.lean
@@ -138,4 +138,142 @@ theorem PosSemidef.mul_leftKroneckerEmbed_supportProj_self
 
 end Bipartite
 
+/-! ### Support projector of the left partial trace -/
+
+section LeftMarginal
+
+variable {L R : Type*} [Fintype L] [DecidableEq L] [Fintype R] [DecidableEq R]
+
+/-- Partial trace over the left factor of a matrix indexed by `L × R`:
+\((\operatorname{tr}_L \rho)_{r,s}=\sum_l \rho_{(l,r),(l,s)}\).
+
+See arXiv:1606.00608, Appendix D.2, lines 2225--2229. -/
+noncomputable def partialTraceLeft (ρ : Matrix (L × R) (L × R) ℂ) : Matrix R R ℂ :=
+  fun r s => ∑ l : L, ρ (l, r) (l, s)
+
+omit [DecidableEq L] [Fintype R] [DecidableEq R] in
+@[simp]
+theorem partialTraceLeft_apply (ρ : Matrix (L × R) (L × R) ℂ) (r s : R) :
+    partialTraceLeft ρ r s = ∑ l : L, ρ (l, r) (l, s) := rfl
+
+omit [DecidableEq L] [Fintype R] [DecidableEq R] in
+/-- Partial trace over the left factor preserves Hermiticity. -/
+theorem partialTraceLeft_isHermitian {ρ : Matrix (L × R) (L × R) ℂ}
+    (hρ : ρ.IsHermitian) : (Matrix.partialTraceLeft ρ).IsHermitian := by
+  apply Matrix.IsHermitian.ext
+  intro r s
+  simp only [partialTraceLeft_apply, star_sum]
+  exact Finset.sum_congr rfl fun l _ => hρ.apply (l, r) (l, s)
+
+omit [DecidableEq L] [Fintype R] [DecidableEq R] in
+/-- Partial trace over the left factor preserves positive semidefiniteness.
+
+This supplies the positive \(XB\) marginal used in arXiv:1606.00608,
+Appendix D.2, lines 2225--2229. -/
+theorem PosSemidef.partialTraceLeft {ρ : Matrix (L × R) (L × R) ℂ}
+    (hρ : ρ.PosSemidef) : (Matrix.partialTraceLeft ρ).PosSemidef := by
+  have heq : Matrix.partialTraceLeft ρ =
+      ∑ l : L, ρ.submatrix (fun r : R => (l, r)) (fun r : R => (l, r)) := by
+    ext r s
+    simp only [partialTraceLeft_apply, Matrix.sum_apply, Matrix.submatrix_apply]
+  rw [heq]
+  exact Matrix.posSemidef_sum _ fun l _ => hρ.submatrix (fun r => (l, r))
+
+/-- Partial trace over the left factor and the right tensor embedding are
+adjoint for the trace pairing:
+\(\operatorname{tr}((\mathbf 1\otimes M)\rho)
+=\operatorname{tr}(M\operatorname{tr}_L\rho)\). -/
+lemma trace_rightKroneckerEmbed_mul (M : Matrix R R ℂ)
+    (ρ : Matrix (L × R) (L × R) ℂ) :
+    (rightKroneckerEmbed (m := L) M * ρ).trace = (M * partialTraceLeft ρ).trace := by
+  simp only [Matrix.trace, Matrix.diag_apply, Matrix.mul_apply, Fintype.sum_prod_type,
+    rightKroneckerEmbed_apply, Matrix.kroneckerMap_apply, Matrix.one_apply,
+    partialTraceLeft_apply, Finset.mul_sum]
+  calc
+    ∑ l, ∑ r, ∑ k, ∑ s,
+        (if l = k then (1 : ℂ) else 0) * M r s * ρ (k, s) (l, r) =
+        ∑ l, ∑ r, ∑ s, M r s * ρ (l, s) (l, r) := by
+      refine Finset.sum_congr rfl fun l _ => ?_
+      refine Finset.sum_congr rfl fun r _ => ?_
+      rw [Finset.sum_eq_single l]
+      · simp
+      · intro k _ hkl
+        simp [Ne.symm hkl]
+      · simp
+    _ = ∑ r, ∑ s, ∑ l, M r s * ρ (l, s) (l, r) := by
+      rw [Finset.sum_comm]
+      refine Finset.sum_congr rfl fun r _ => ?_
+      rw [Finset.sum_comm]
+
+/-- The lifted support projector of the left partial trace fixes a positive
+semidefinite bipartite operator on the left.
+
+This is the \(A|XB\) counterpart of the support-projector identity in
+arXiv:1606.00608, Appendix D.2, lines 2225--2235. -/
+theorem PosSemidef.rightKroneckerEmbed_supportProj_mul_self
+    {ρ : Matrix (L × R) (L × R) ℂ} (hρ : ρ.PosSemidef) :
+    rightKroneckerEmbed (m := L)
+        (Matrix.PosSemidef.partialTraceLeft hρ).isHermitian.supportProj * ρ = ρ := by
+  classical
+  set σ := Matrix.partialTraceLeft ρ with hσ
+  have hσpos : σ.PosSemidef := Matrix.PosSemidef.partialTraceLeft hρ
+  set P := hσpos.isHermitian.supportProj with hP
+  set Q : Matrix R R ℂ := 1 - P with hQ
+  have hQherm : Q.IsHermitian := by
+    rw [hQ]
+    exact hσpos.isHermitian.one_sub_supportProj_isHermitian
+  have hQidem : Q * Q = Q := by
+    rw [hQ, hP]
+    exact hσpos.isHermitian.one_sub_supportProj_idem
+  have hQσ : Q * σ = 0 := by
+    rw [hQ, hP]
+    exact hσpos.isHermitian.one_sub_supportProj_mul_self
+  have hliftQherm : (rightKroneckerEmbed (m := L) Q).IsHermitian := by
+    change (rightKroneckerEmbed (m := L) Q)ᴴ = rightKroneckerEmbed (m := L) Q
+    rw [← star_eq_conjTranspose, ← map_star, star_eq_conjTranspose, hQherm.eq]
+  have hliftQidem :
+      rightKroneckerEmbed (m := L) Q * rightKroneckerEmbed (m := L) Q =
+        rightKroneckerEmbed (m := L) Q := by
+    rw [← map_mul, hQidem]
+  have hliftQρ : rightKroneckerEmbed (m := L) Q * ρ = 0 := by
+    refine hρ.proj_mul_eq_zero_of_trace_eq_zero hliftQherm hliftQidem ?_
+    rw [trace_rightKroneckerEmbed_mul, ← hσ, hQσ, Matrix.trace_zero]
+  have hsplit :
+      (1 : Matrix (L × R) (L × R) ℂ) - rightKroneckerEmbed (m := L) Q =
+        rightKroneckerEmbed (m := L) P := by
+    have hQP : (1 : Matrix R R ℂ) - Q = P := by
+      rw [hQ]
+      abel
+    calc
+      (1 : Matrix (L × R) (L × R) ℂ) - rightKroneckerEmbed (m := L) Q =
+          rightKroneckerEmbed (m := L) 1 - rightKroneckerEmbed (m := L) Q := by
+            rw [map_one]
+      _ = rightKroneckerEmbed (m := L) (1 - Q) :=
+        (map_sub (rightKroneckerEmbed (m := L) (n := R)) 1 Q).symm
+      _ = rightKroneckerEmbed (m := L) P := by rw [hQP]
+  rw [← hsplit, Matrix.sub_mul, Matrix.one_mul, hliftQρ, sub_zero]
+
+/-- The lifted support projector of the left partial trace also fixes a
+positive semidefinite bipartite operator on the right.
+
+Together with the preceding theorem, this proves both support-projector
+identities of arXiv:1606.00608, Appendix D.2, lines 2228--2235, for the
+\(A|XB\) bipartition. -/
+theorem PosSemidef.mul_rightKroneckerEmbed_supportProj_self
+    {ρ : Matrix (L × R) (L × R) ℂ} (hρ : ρ.PosSemidef) :
+    ρ * rightKroneckerEmbed (m := L)
+        (Matrix.PosSemidef.partialTraceLeft hρ).isHermitian.supportProj = ρ := by
+  have hleft := hρ.rightKroneckerEmbed_supportProj_mul_self
+  have hliftHerm :
+      (rightKroneckerEmbed (m := L)
+        (Matrix.PosSemidef.partialTraceLeft hρ).isHermitian.supportProj).IsHermitian := by
+    change (rightKroneckerEmbed (m := L)
+      (Matrix.PosSemidef.partialTraceLeft hρ).isHermitian.supportProj)ᴴ = _
+    rw [← star_eq_conjTranspose, ← map_star, star_eq_conjTranspose,
+      (Matrix.PosSemidef.partialTraceLeft hρ).isHermitian.supportProj_isHermitian.eq]
+  have h := congrArg Matrix.conjTranspose hleft
+  rwa [Matrix.conjTranspose_mul, hρ.isHermitian.eq, hliftHerm.eq] at h
+
+end LeftMarginal
+
 end Matrix

--- a/TNLean/Channel/PartialTrace.lean
+++ b/TNLean/Channel/PartialTrace.lean
@@ -18,12 +18,16 @@ Proposition 2.1) and for reduced states on contiguous tensor factors.
 
 * `Matrix.partialTraceRight`: trace over the second factor for a general product
   index
+* `Matrix.partialTraceLeft`: trace over the first factor for a general product
+  index
 * `Matrix.traceLeft` (`tr_A`): trace over the first (left) tensor factor
 * `Matrix.traceRight` (`tr_B`): trace over the second (right) tensor factor
 
 ## Main results
 
 * `Matrix.partialTraceRight_apply`: elementwise formula for the general right
+  partial trace
+* `Matrix.partialTraceLeft_apply`: elementwise formula for the general left
   partial trace
 * `Matrix.partialTraceRightLM`: the general right partial trace as a complex
   linear map
@@ -42,6 +46,7 @@ Proposition 2.1) and for reduced states on contiguous tensor factors.
 ## References
 
 * [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 2][Wolf2012QChannels]
+* arXiv:1606.00608, Appendix D.2, lines 2225--2229: tripartite marginals.
 -/
 
 open scoped Matrix ComplexOrder
@@ -148,6 +153,51 @@ theorem partialTraceRight_one [DecidableEq α] [DecidableEq β] :
   · simp [hij]
 
 end GeneralRight
+
+/-! ## General partial trace over the first factor -/
+
+section GeneralLeft
+
+variable {α β : Type*} [Fintype α]
+
+/-- **Partial trace over the first factor** of a product index `α × β`.
+
+For a matrix `X` indexed by `α × β`, this produces the `β × β` matrix
+
+  `(partialTraceLeft X) i j = ∑ k : α, X (k, i) (k, j)`.
+
+The channel-theory partial trace `Matrix.traceLeft` is the specialization to
+`α = Fin d` and `β = Fin d'`.  This is also the (XB) marginal used in
+arXiv:1606.00608, Appendix D.2, lines 2225--2229. -/
+noncomputable def partialTraceLeft (X : Matrix (α × β) (α × β) ℂ) :
+    Matrix β β ℂ :=
+  fun i j => ∑ k : α, X (k, i) (k, j)
+
+@[simp]
+theorem partialTraceLeft_apply (X : Matrix (α × β) (α × β) ℂ) (i j : β) :
+    partialTraceLeft X i j = ∑ k : α, X (k, i) (k, j) := rfl
+
+/-- The partial trace over the first factor preserves Hermiticity. -/
+theorem partialTraceLeft_isHermitian {X : Matrix (α × β) (α × β) ℂ}
+    (hX : X.IsHermitian) : (partialTraceLeft X).IsHermitian := by
+  apply Matrix.IsHermitian.ext
+  intro i j
+  simp only [partialTraceLeft_apply, star_sum]
+  exact Finset.sum_congr rfl fun k _ => hX.apply (k, i) (k, j)
+
+/-- The partial trace over the first factor preserves positive semidefiniteness.
+The reduced state is a sum of submatrices of `X`, one per traced-out index. -/
+theorem PosSemidef.partialTraceLeft [Finite β] {X : Matrix (α × β) (α × β) ℂ}
+    (hX : X.PosSemidef) : (Matrix.partialTraceLeft X).PosSemidef := by
+  cases nonempty_fintype β
+  have h_eq : (Matrix.partialTraceLeft X : Matrix β β ℂ)
+      = ∑ k : α, X.submatrix (fun b => (k, b)) (fun b => (k, b)) := by
+    ext i j
+    simp only [partialTraceLeft_apply, Matrix.sum_apply, Matrix.submatrix_apply]
+  rw [h_eq]
+  exact Matrix.posSemidef_sum _ fun _ _ => hX.submatrix _
+
+end GeneralLeft
 
 /-- The trace is invariant under reindexing a matrix by an equivalence of its
 index type. -/

--- a/TNLean/Channel/PartialTrace.lean
+++ b/TNLean/Channel/PartialTrace.lean
@@ -248,7 +248,7 @@ trace over the first factor produces a `d' × d'` matrix:
   `(traceLeft X) i j = ∑ k, X (k, i) (k, j)` -/
 noncomputable def traceLeft (X : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) :
     Matrix (Fin d') (Fin d') ℂ :=
-  fun i j => ∑ k : Fin d, X (k, i) (k, j)
+  partialTraceLeft X
 
 /-- **Partial trace over the second (right) tensor factor** (`tr_B`).
 

--- a/TNLean/MPS/ParentHamiltonian/TripartiteDecorrelation.lean
+++ b/TNLean/MPS/ParentHamiltonian/TripartiteDecorrelation.lean
@@ -502,10 +502,10 @@ repairs the unsupported single-slice assertion in arXiv:1606.00608,
 Appendix D.2, lines 2236--2252, while retaining the calculation in lines
 2253--2258.
 
-**Local fix (CPSV16 Appendix D.2):** A basis vector of a marginal support need
-not be one partial contraction.  The reduced-operator expansion and
-reciprocal-on-support factorization above replace that step.  Documented in
-`docs/paper-gaps/cpsv16_decorrelation_slice_expansion_fix.tex`. -/
+**Local fix (`docs/paper-gaps/cpsv16_decorrelation_slice_expansion_fix.tex`):**
+A basis vector of a marginal support need not be one partial contraction.  The
+reduced-operator expansion and reciprocal-on-support factorization above
+replace that step. -/
 theorem IsDecorrelated.supports_mul_complement_mul_eq_zero
     {P : Matrix (A × (X × B)) (A × (X × B)) ℂ}
     (hPherm : P.IsHermitian) (hdec : IsDecorrelated P) :
@@ -536,10 +536,10 @@ theorem IsDecorrelated.supports_mul_complement_mul_eq_zero
 /-- The reverse-order product of the two marginal support projectors through
 the complement of \(P\) also vanishes.
 
-**Local fix (CPSV16 Appendix D.2):** As in the forward-order theorem, the
-reduced-operator expansion and reciprocal-on-support factorization replace the
-unsupported single-contraction step at source lines 2236--2252. Documented in
-`docs/paper-gaps/cpsv16_decorrelation_slice_expansion_fix.tex`. -/
+**Local fix (`docs/paper-gaps/cpsv16_decorrelation_slice_expansion_fix.tex`):**
+As in the forward-order theorem, the reduced-operator expansion and
+reciprocal-on-support factorization replace the unsupported single-contraction
+step at source lines 2236--2252. -/
 theorem IsDecorrelated.reverse_supports_mul_complement_mul_eq_zero
     {P : Matrix (A × (X × B)) (A × (X × B)) ℂ}
     (hPherm : P.IsHermitian) (hdec : IsDecorrelated P) :
@@ -570,8 +570,8 @@ theorem IsDecorrelated.reverse_supports_mul_complement_mul_eq_zero
 /-- The lifted support projector of the \(XB\) marginal fixes the tripartite
 operator on the left.
 
-This is the \(P_{XB}P_{AXB}=P_{AXB}\) identity in arXiv:1606.00608,
-Appendix D.2, equation `Propproj`, lines 2228--2235. -/
+This is the \(P_{XB}P_{AXB}=P_{AXB}\) marginal-support absorption identity in
+arXiv:1606.00608, Appendix D.2, lines 2228--2235. -/
 theorem liftSupportXB_mul_self
     {ρ : Matrix (A × (X × B)) (A × (X × B)) ℂ} (hρ : ρ.PosSemidef) :
     liftXB (supportXB hρ.isHermitian) * ρ = ρ := by
@@ -580,8 +580,8 @@ theorem liftSupportXB_mul_self
 /-- The lifted support projector of the \(XB\) marginal fixes the tripartite
 operator on the right.
 
-This is the \(P_{AXB}P_{XB}=P_{AXB}\) identity in arXiv:1606.00608,
-Appendix D.2, equation `Propproj`, lines 2228--2235. -/
+This is the \(P_{AXB}P_{XB}=P_{AXB}\) marginal-support absorption identity in
+arXiv:1606.00608, Appendix D.2, lines 2228--2235. -/
 theorem mul_liftSupportXB_self
     {ρ : Matrix (A × (X × B)) (A × (X × B)) ℂ} (hρ : ρ.PosSemidef) :
     ρ * liftXB (supportXB hρ.isHermitian) = ρ := by
@@ -590,8 +590,8 @@ theorem mul_liftSupportXB_self
 /-- The lifted support projector of the \(AX\) marginal fixes the tripartite
 operator on the left.
 
-This is the \(P_{AX}P_{AXB}=P_{AXB}\) identity in arXiv:1606.00608,
-Appendix D.2, equation `Propproj`, lines 2228--2235. -/
+This is the \(P_{AX}P_{AXB}=P_{AXB}\) marginal-support absorption identity in
+arXiv:1606.00608, Appendix D.2, lines 2228--2235. -/
 theorem liftSupportAX_mul_self
     {ρ : Matrix (A × (X × B)) (A × (X × B)) ℂ} (hρ : ρ.PosSemidef) :
     liftAX (supportAX hρ.isHermitian) * ρ = ρ := by
@@ -602,8 +602,8 @@ theorem liftSupportAX_mul_self
 /-- The lifted support projector of the \(AX\) marginal fixes the tripartite
 operator on the right.
 
-This is the \(P_{AXB}P_{AX}=P_{AXB}\) identity in arXiv:1606.00608,
-Appendix D.2, equation `Propproj`, lines 2228--2235. -/
+This is the \(P_{AXB}P_{AX}=P_{AXB}\) marginal-support absorption identity in
+arXiv:1606.00608, Appendix D.2, lines 2228--2235. -/
 theorem mul_liftSupportAX_self
     {ρ : Matrix (A × (X × B)) (A × (X × B)) ℂ} (hρ : ρ.PosSemidef) :
     ρ * liftAX (supportAX hρ.isHermitian) = ρ := by
@@ -613,9 +613,10 @@ theorem mul_liftSupportAX_self
 
 /-- The two marginal support projectors multiply to the tripartite projector.
 
-This is arXiv:1606.00608, Appendix D.2, equation `PXBAXetc`,
-lines 2236--2258.  The proof uses reduced-operator matrix-unit expansions and
-reciprocal-on-support factorization, so no commutation hypothesis is assumed. -/
+These are the marginal-support projector product identities in
+arXiv:1606.00608, Appendix D.2, lines 2236--2258.  The proof uses
+reduced-operator matrix-unit expansions and reciprocal-on-support
+factorization, so no commutation hypothesis is assumed. -/
 theorem supportProducts_eq
     {P : Matrix (A × (X × B)) (A × (X × B)) ℂ}
     (hPherm : P.IsHermitian) (hPidem : P * P = P)
@@ -679,8 +680,9 @@ theorem range_mul_eq_inter
 
 /-- Hermitian idempotent matrices with the same range are equal.
 
-This is the uniqueness fact used between arXiv:1606.00608, Appendix D.2,
-Definition D.2, lines 2205--2218, and equation `arrggg`, lines 2279--2289. -/
+This is the uniqueness fact used to identify the projector onto the
+ground-space intersection in arXiv:1606.00608, Appendix D.2, Definition D.2,
+lines 2205--2218, with the product projector in lines 2279--2289. -/
 theorem hermitian_idempotent_eq_of_range_eq
     {I : Type*} [Fintype I] [DecidableEq I]
     (S T : Matrix I I ℂ)
@@ -721,8 +723,9 @@ def HasGroundSpaceIntersection
 condition is equivalent to the corresponding projector-product identity.
 
 This proves that the range-intersection condition of arXiv:1606.00608,
-Appendix D.2, Definition D.2, lines 2205--2218, is equivalent to the
-projector-product identity at equation `arrggg`, lines 2279--2289. -/
+Appendix D.2, Definition D.2, lines 2205--2218, is equivalent to the identity
+in lines 2279--2289 that the tripartite ground-space projector is the product
+of the two local ground-space projectors. -/
 theorem hasGroundSpaceIntersection_iff_product_eq
     {P : Matrix (A × (X × B)) (A × (X × B)) ℂ}
     {PAX : Matrix (A × X) (A × X) ℂ}
@@ -793,8 +796,9 @@ structure CommutingParentHamiltonian
   /-- The \(XB\) ground-space projector is idempotent, corresponding to the
   projector assumption in arXiv:1606.00608, Appendix D.2, lines 2205--2208. -/
   hXBidem : PXB * PXB = PXB
-  /-- The two lifted ground-space projectors commute, equivalent to equation
-  `QAXQXB` in arXiv:1606.00608, Appendix D.2, lines 2207--2214. -/
+  /-- The two lifted ground-space projectors commute, equivalently the local
+  Hamiltonian projectors commute as required in arXiv:1606.00608,
+  Appendix D.2, lines 2207--2214. -/
   hcomm : liftAX PAX * liftXB PXB = liftXB PXB * liftAX PAX
   /-- The range of \(P\) is the intersection of the two lifted local
   ground spaces, as in arXiv:1606.00608, Appendix D.2, lines 2212--2218. -/

--- a/TNLean/MPS/ParentHamiltonian/TripartiteDecorrelation.lean
+++ b/TNLean/MPS/ParentHamiltonian/TripartiteDecorrelation.lean
@@ -22,6 +22,8 @@ explicit tensor product \(H_A\otimes H_X\otimes H_B\).
 * `TripartiteDecorrelation.supportXB`: support projector of the \(XB\) marginal.
 * `TripartiteDecorrelation.HasCommutingParentHamiltonian`: existence of local
   commuting parent projectors on \(AX\) and \(XB\).
+* `TripartiteDecorrelation.HasGroundSpaceIntersection`: the literal
+  ground-space intersection condition of Definition D.2.
 * `TripartiteDecorrelation.liftAX` and `TripartiteDecorrelation.liftXB`: their
   local lifts to the tripartite space.
 
@@ -35,6 +37,8 @@ explicit tensor product \(H_A\otimes H_X\otimes H_B\).
   the finite matrix-unit calculation from decorrelation.
 * `TripartiteDecorrelation.supportProducts_eq`: the two support-product
   identities obtained from decorrelation.
+* `TripartiteDecorrelation.hasGroundSpaceIntersection_iff_product_eq`: the
+  equivalence between the source intersection and projector-product forms.
 * `TripartiteDecorrelation.parentHamiltonian_iff_decorrelated`: Proposition
   D.3 in complex-linear form on the explicit tripartite space.
 * `TripartiteDecorrelation.parentHamiltonian_iff_observableDecorrelated`:
@@ -121,6 +125,25 @@ private theorem liftAX_mul (M N : Matrix (A × X) (A × X) ℂ) :
 private theorem liftXB_mul (M N : Matrix (X × B) (X × B) ℂ) :
     liftXB (A := A) (M * N) = liftXB (A := A) M * liftXB (A := A) N := by
   exact map_mul (Matrix.rightKroneckerEmbed (m := A) (n := X × B)) M N
+
+@[simp]
+private theorem conjTranspose_liftAX (M : Matrix (A × X) (A × X) ℂ) :
+    (liftAX (B := B) M)ᴴ = liftAX (B := B) Mᴴ := by
+  ext ⟨a, x, b⟩ ⟨a', x', b'⟩
+  by_cases hbb : b = b'
+  · subst b'
+    simp [liftAX, ungroupAX, Matrix.conjTranspose_apply,
+      Matrix.leftKroneckerEmbed_apply, Matrix.kroneckerMap_apply]
+  · have hb'b : b' ≠ b := Ne.symm hbb
+    simp [liftAX, ungroupAX, Matrix.conjTranspose_apply,
+      Matrix.leftKroneckerEmbed_apply, Matrix.kroneckerMap_apply, hbb, hb'b]
+
+@[simp]
+private theorem conjTranspose_liftXB (M : Matrix (X × B) (X × B) ℂ) :
+    (liftXB (A := A) M)ᴴ = liftXB (A := A) Mᴴ := by
+  change (Matrix.rightKroneckerEmbed (m := A) M)ᴴ =
+    Matrix.rightKroneckerEmbed (m := A) Mᴴ
+  rw [← star_eq_conjTranspose, ← map_star, star_eq_conjTranspose]
 
 private theorem liftA_comm_liftXB (OA : Matrix A A ℂ) (M : Matrix (X × B) (X × B) ℂ) :
     liftA OA * liftXB M = liftXB M * liftA OA := by
@@ -634,13 +657,132 @@ theorem supportProducts_eq
         rw [hdec.reverse_supports_mul_complement_mul_eq_zero hPherm, add_zero]
       _ = P := by rw [liftSupportAX_mul_self hPpos, mul_liftSupportXB_self hPpos]
 
+/-- The range of a product of commuting idempotent matrices is the
+intersection of their ranges.
+
+This is the finite-dimensional projector fact used to pass from the
+ground-space intersection in arXiv:1606.00608, Appendix D.2, Definition D.2,
+lines 2205--2218, to the product of the two ground-space projectors. -/
+theorem range_mul_eq_inter
+    {I : Type*} [Fintype I] [DecidableEq I]
+    (S T : Matrix I I ℂ)
+    (hSidem : S * S = S) (hTidem : T * T = T)
+    (hcomm : S * T = T * S) :
+    LinearMap.range (Matrix.toLin' (S * T)) =
+      LinearMap.range (Matrix.toLin' S) ⊓
+        LinearMap.range (Matrix.toLin' T) := by
+  have hS : IsIdempotentElem (Matrix.toLin' S) := by
+    rw [IsIdempotentElem, Module.End.mul_eq_comp, ← Matrix.toLin'_mul, hSidem]
+  have hT : IsIdempotentElem (Matrix.toLin' T) := by
+    rw [IsIdempotentElem, Module.End.mul_eq_comp, ← Matrix.toLin'_mul, hTidem]
+  ext v
+  constructor
+  · rintro ⟨w, rfl⟩
+    rw [Matrix.toLin'_mul, LinearMap.comp_apply]
+    refine Submodule.mem_inf.mpr ⟨⟨_, rfl⟩, ?_⟩
+    refine ⟨Matrix.toLin' S w, ?_⟩
+    simpa only [Matrix.toLin'_mul, LinearMap.comp_apply] using
+      congrArg (fun M : Matrix I I ℂ ↦ Matrix.toLin' M w) hcomm.symm
+  · intro hv
+    rw [Submodule.mem_inf] at hv
+    refine ⟨v, ?_⟩
+    rw [Matrix.toLin'_mul, LinearMap.comp_apply,
+      (LinearMap.IsIdempotentElem.mem_range_iff hT).mp hv.2,
+      (LinearMap.IsIdempotentElem.mem_range_iff hS).mp hv.1]
+
+/-- Hermitian idempotent matrices with the same range are equal.
+
+This is the uniqueness fact used between arXiv:1606.00608, Appendix D.2,
+Definition D.2, lines 2205--2218, and equation `arrggg`, lines 2259--2277. -/
+theorem hermitian_idempotent_eq_of_range_eq
+    {I : Type*} [Fintype I] [DecidableEq I]
+    (S T : Matrix I I ℂ)
+    (hSherm : S.IsHermitian) (hSidem : S * S = S)
+    (hTherm : T.IsHermitian) (hTidem : T * T = T)
+    (hrange : LinearMap.range (Matrix.toLin' S) =
+      LinearMap.range (Matrix.toLin' T)) :
+    S = T := by
+  have hS : IsIdempotentElem (Matrix.toLin' S) := by
+    rw [IsIdempotentElem, Module.End.mul_eq_comp, ← Matrix.toLin'_mul, hSidem]
+  have hT : IsIdempotentElem (Matrix.toLin' T) := by
+    rw [IsIdempotentElem, Module.End.mul_eq_comp, ← Matrix.toLin'_mul, hTidem]
+  have hST : S * T = T := by
+    apply Matrix.toLin'.injective
+    rw [Matrix.toLin'_mul]
+    exact (LinearMap.IsIdempotentElem.comp_eq_right_iff hS _).2 hrange.symm.le
+  have hTS : T * S = S := by
+    apply Matrix.toLin'.injective
+    rw [Matrix.toLin'_mul]
+    exact (LinearMap.IsIdempotentElem.comp_eq_right_iff hT _).2 hrange.le
+  have hTS' : T * S = T := by
+    have h := congrArg Matrix.conjTranspose hST
+    simpa only [Matrix.conjTranspose_mul, hSherm.eq, hTherm.eq] using h
+  exact hTS.symm.trans hTS'
+
+/-- The literal ground-space intersection condition of arXiv:1606.00608,
+Appendix D.2, Definition D.2, lines 2205--2218, written for the orthogonal
+ground-space projectors. -/
+def HasGroundSpaceIntersection
+    (P : Matrix (A × (X × B)) (A × (X × B)) ℂ)
+    (PAX : Matrix (A × X) (A × X) ℂ)
+    (PXB : Matrix (X × B) (X × B) ℂ) : Prop :=
+  LinearMap.range (Matrix.toLin' P) =
+    LinearMap.range (Matrix.toLin' (liftAX PAX)) ⊓
+      LinearMap.range (Matrix.toLin' (liftXB PXB))
+
+/-- For commuting orthogonal projectors, the source ground-space intersection
+condition is equivalent to the corresponding projector-product identity.
+
+This proves the bridge from arXiv:1606.00608, Appendix D.2, Definition D.2,
+lines 2205--2218, to equation `arrggg`, lines 2259--2277. -/
+theorem hasGroundSpaceIntersection_iff_product_eq
+    {P : Matrix (A × (X × B)) (A × (X × B)) ℂ}
+    {PAX : Matrix (A × X) (A × X) ℂ}
+    {PXB : Matrix (X × B) (X × B) ℂ}
+    (hPherm : P.IsHermitian) (hPidem : P * P = P)
+    (hAXherm : PAX.IsHermitian) (hAXidem : PAX * PAX = PAX)
+    (hXBherm : PXB.IsHermitian) (hXBidem : PXB * PXB = PXB)
+    (hcomm : liftAX PAX * liftXB PXB = liftXB PXB * liftAX PAX) :
+    HasGroundSpaceIntersection P PAX PXB ↔ liftAX PAX * liftXB PXB = P := by
+  let SAX := liftAX (B := B) PAX
+  let SXB := liftXB (A := A) PXB
+  have hSAXherm : SAX.IsHermitian := by
+    change (liftAX (B := B) PAX)ᴴ = liftAX (B := B) PAX
+    rw [conjTranspose_liftAX, hAXherm.eq]
+  have hSXBherm : SXB.IsHermitian := by
+    change (liftXB (A := A) PXB)ᴴ = liftXB (A := A) PXB
+    rw [conjTranspose_liftXB, hXBherm.eq]
+  have hSAXidem : SAX * SAX = SAX := by
+    rw [← liftAX_mul, hAXidem]
+  have hSXBidem : SXB * SXB = SXB := by
+    rw [← liftXB_mul, hXBidem]
+  have hproductHerm : (SAX * SXB).IsHermitian := by
+    rw [Matrix.IsHermitian, Matrix.conjTranspose_mul, hSAXherm.eq,
+      hSXBherm.eq, ← hcomm]
+  have hproductIdem : (SAX * SXB) * (SAX * SXB) = SAX * SXB := by
+    calc
+      (SAX * SXB) * (SAX * SXB) = SAX * (SXB * SAX) * SXB := by
+        noncomm_ring
+      _ = SAX * (SAX * SXB) * SXB := by rw [← hcomm]
+      _ = (SAX * SAX) * (SXB * SXB) := by noncomm_ring
+      _ = SAX * SXB := by rw [hSAXidem, hSXBidem]
+  have hrange := range_mul_eq_inter SAX SXB hSAXidem hSXBidem hcomm
+  constructor
+  · intro hintersection
+    exact hermitian_idempotent_eq_of_range_eq (SAX * SXB) P
+      hproductHerm hproductIdem hPherm hPidem (hrange.trans hintersection.symm)
+  · intro hproduct
+    change LinearMap.range (Matrix.toLin' P) =
+      LinearMap.range (Matrix.toLin' SAX) ⊓ LinearMap.range (Matrix.toLin' SXB)
+    rw [← hproduct]
+    exact hrange
+
 /-- The parent commuting Hamiltonian condition on the explicit tripartite
 space, written in terms of the local ground-space projectors.
 
 The Hamiltonian terms of arXiv:1606.00608, Appendix D.2, Definition D.2,
-lines 2205--2218, are \(Q_{AX}=1-P_{AX}\) and \(Q_{XB}=1-P_{XB}\).  For
-commuting orthogonal projectors, the product identity below says exactly that
-their lifted ranges intersect in the range of \(P\). -/
+lines 2205--2218, are \(Q_{AX}=1-P_{AX}\) and \(Q_{XB}=1-P_{XB}\).  The final
+field is the literal ground-space intersection condition in that definition. -/
 structure CommutingParentHamiltonian
     (P : Matrix (A × (X × B)) (A × (X × B)) ℂ) where
   /-- The orthogonal projector onto \(K_{AX}\), as in arXiv:1606.00608,
@@ -664,10 +806,22 @@ structure CommutingParentHamiltonian
   /-- The two lifted ground-space projectors commute, equivalent to equation
   `QAXQXB` in arXiv:1606.00608, Appendix D.2, lines 2207--2214. -/
   hcomm : liftAX PAX * liftXB PXB = liftXB PXB * liftAX PAX
-  /-- Their product is the projector onto \(K_{AXB}\), which is the
-  ground-space intersection in arXiv:1606.00608, Appendix D.2,
-  lines 2212--2218. -/
-  hproduct : liftAX PAX * liftXB PXB = P
+  /-- The range of \(P\) is the intersection of the two lifted local
+  ground spaces, as in arXiv:1606.00608, Appendix D.2, lines 2212--2218. -/
+  hintersection : HasGroundSpaceIntersection P PAX PXB
+
+/-- The literal ground-space intersection condition of Definition D.2 gives
+the projector-product identity used in the proof of Proposition D.3.
+
+Source: arXiv:1606.00608, Appendix D.2, lines 2205--2218 and 2259--2277. -/
+theorem CommutingParentHamiltonian.hproduct
+    {P : Matrix (A × (X × B)) (A × (X × B)) ℂ}
+    (hparent : CommutingParentHamiltonian P)
+    (hPherm : P.IsHermitian) (hPidem : P * P = P) :
+    liftAX hparent.PAX * liftXB hparent.PXB = P :=
+  (hasGroundSpaceIntersection_iff_product_eq hPherm hPidem
+    hparent.hAXherm hparent.hAXidem hparent.hXBherm hparent.hXBidem
+    hparent.hcomm).mp hparent.hintersection
 
 /-- Existence of local commuting parent projectors for \(P\), in the sense of
 arXiv:1606.00608, Appendix D.2, Definition D.2, lines 2205--2218. -/
@@ -682,16 +836,18 @@ This is the only-if direction of arXiv:1606.00608, Appendix D.2,
 Proposition D.3, lines 2279--2289. -/
 theorem CommutingParentHamiltonian.isDecorrelated
     {P : Matrix (A × (X × B)) (A × (X × B)) ℂ}
-    (hparent : CommutingParentHamiltonian P) (hPidem : P * P = P) :
+    (hparent : CommutingParentHamiltonian P)
+    (hPherm : P.IsHermitian) (hPidem : P * P = P) :
     IsDecorrelated P := by
   let SAX := liftAX (B := B) hparent.PAX
   let SXB := liftXB (A := A) hparent.PXB
+  have hproduct : SAX * SXB = P := hparent.hproduct hPherm hPidem
   have hrev : SXB * SAX = P := by
     rw [← hparent.hcomm]
-    exact hparent.hproduct
+    exact hproduct
   have hquad : SXB * P * SAX = P * P := by
     calc
-      SXB * P * SAX = SXB * (SAX * SXB) * SAX := by rw [hparent.hproduct]
+      SXB * P * SAX = SXB * (SAX * SXB) * SAX := by rw [hproduct]
       _ = (SXB * SAX) * (SXB * SAX) := by noncomm_ring
       _ = P * P := by rw [hrev]
   have hmiddle : SXB * (1 - P) * SAX = 0 := by
@@ -707,7 +863,7 @@ theorem CommutingParentHamiltonian.isDecorrelated
   calc
     P * liftA OA * (1 - P) * liftB OB * P =
         (SAX * SXB) * liftA OA * (1 - P) * liftB OB * (SAX * SXB) := by
-          rw [hparent.hproduct]
+          rw [hproduct]
     _ = SAX * liftA OA * (SXB * (1 - P) * SAX) * liftB OB * SXB := by
       calc
         (SAX * SXB) * liftA OA * (1 - P) * liftB OB * (SAX * SXB) =
@@ -729,17 +885,24 @@ theorem IsDecorrelated.hasCommutingParentHamiltonian
     (hPherm : P.IsHermitian) (hPidem : P * P = P) (hdec : IsDecorrelated P) :
     HasCommutingParentHamiltonian P := by
   have hproducts := supportProducts_eq hPherm hPidem hdec
+  have hAXherm := (Matrix.partialTraceRight_isHermitian
+    (groupAX_isHermitian hPherm)).supportProj_isHermitian
+  have hAXidem := (Matrix.partialTraceRight_isHermitian
+    (groupAX_isHermitian hPherm)).supportProj_idem
+  have hXBherm := (Matrix.partialTraceLeft_isHermitian hPherm).supportProj_isHermitian
+  have hXBidem := (Matrix.partialTraceLeft_isHermitian hPherm).supportProj_idem
   exact ⟨
     { PAX := supportAX hPherm
       PXB := supportXB hPherm
-      hAXherm := (Matrix.partialTraceRight_isHermitian
-        (groupAX_isHermitian hPherm)).supportProj_isHermitian
-      hAXidem := (Matrix.partialTraceRight_isHermitian
-        (groupAX_isHermitian hPherm)).supportProj_idem
-      hXBherm := (Matrix.partialTraceLeft_isHermitian hPherm).supportProj_isHermitian
-      hXBidem := (Matrix.partialTraceLeft_isHermitian hPherm).supportProj_idem
+      hAXherm := hAXherm
+      hAXidem := hAXidem
+      hXBherm := hXBherm
+      hXBidem := hXBidem
       hcomm := hproducts.2.trans hproducts.1.symm
-      hproduct := hproducts.2 }⟩
+      hintersection :=
+        (hasGroundSpaceIntersection_iff_product_eq hPherm hPidem
+          hAXherm hAXidem hXBherm hXBidem
+          (hproducts.2.trans hproducts.1.symm)).mpr hproducts.2 }⟩
 
 /-- **Parent commuting Hamiltonian--decorrelation equivalence.**
 
@@ -751,7 +914,7 @@ theorem parentHamiltonian_iff_decorrelated
     {P : Matrix (A × (X × B)) (A × (X × B)) ℂ}
     (hPherm : P.IsHermitian) (hPidem : P * P = P) :
     HasCommutingParentHamiltonian P ↔ IsDecorrelated P :=
-  ⟨fun hparent => hparent.elim fun parent => parent.isDecorrelated hPidem,
+  ⟨fun hparent => hparent.elim fun parent => parent.isDecorrelated hPherm hPidem,
     fun hdec => hdec.hasCommutingParentHamiltonian hPherm hPidem⟩
 
 /-- **Source-facing parent commuting Hamiltonian--decorrelation equivalence.**

--- a/TNLean/MPS/ParentHamiltonian/TripartiteDecorrelation.lean
+++ b/TNLean/MPS/ParentHamiltonian/TripartiteDecorrelation.lean
@@ -1,0 +1,654 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Channel.MarginalSupportAbsorption
+import TNLean.Channel.Schwarz.StrongSubadditivityPosDef
+import Mathlib.Data.Matrix.Basis
+
+/-!
+# Tripartite support projectors for decorrelation
+
+This file introduces the two marginal support projectors used in the forward
+direction of the decorrelation--parent-commuting-Hamiltonian equivalence for an
+explicit tensor product \(H_A\otimes H_X\otimes H_B\).
+
+## Main definitions
+
+* `TripartiteDecorrelation.supportAX`: support projector of the \(AX\) marginal.
+* `TripartiteDecorrelation.supportXB`: support projector of the \(XB\) marginal.
+* `TripartiteDecorrelation.HasCommutingParentHamiltonian`: existence of local
+  commuting parent projectors on \(AX\) and \(XB\).
+* `TripartiteDecorrelation.liftAX` and `TripartiteDecorrelation.liftXB`: their
+  local lifts to the tripartite space.
+
+## Main results
+
+* `TripartiteDecorrelation.liftSupportAX_mul_self` and its right-handed form.
+* `TripartiteDecorrelation.liftSupportXB_mul_self` and its right-handed form.
+* `TripartiteDecorrelation.IsDecorrelated.supports_mul_complement_mul_eq_zero`:
+  the finite matrix-unit calculation from decorrelation.
+* `TripartiteDecorrelation.supportProducts_eq`: the two support-product
+  identities obtained from decorrelation.
+* `TripartiteDecorrelation.parentHamiltonian_iff_decorrelated`: Proposition
+  D.3 on the explicit tripartite space.
+
+## References
+
+* arXiv:1606.00608, Appendix D.2, lines 2187--2258.
+-/
+
+open scoped Matrix MatrixOrder ComplexOrder Kronecker
+open Matrix Finset BigOperators
+
+namespace TripartiteDecorrelation
+
+variable {A X B : Type*} [Fintype A] [DecidableEq A] [Fintype X] [DecidableEq X]
+  [Fintype B] [DecidableEq B]
+
+/-- Reassociate the tripartite index from \(A\times(X\times B)\) to
+\((A\times X)\times B\). -/
+private noncomputable def groupAX
+    (ρ : Matrix (A × (X × B)) (A × (X × B)) ℂ) :
+    Matrix ((A × X) × B) ((A × X) × B) ℂ :=
+  Matrix.reindexAlgEquiv ℂ ℂ (Equiv.prodAssoc A X B).symm ρ
+
+/-- Return from the \((A\times X)\times B\) indexing to
+\(A\times(X\times B)\). -/
+private noncomputable def ungroupAX
+    (ρ : Matrix ((A × X) × B) ((A × X) × B) ℂ) :
+    Matrix (A × (X × B)) (A × (X × B)) ℂ :=
+  Matrix.reindexAlgEquiv ℂ ℂ (Equiv.prodAssoc A X B) ρ
+
+/-- Reassociation preserves positive semidefiniteness. -/
+private theorem groupAX_posSemidef
+    {ρ : Matrix (A × (X × B)) (A × (X × B)) ℂ} (hρ : ρ.PosSemidef) :
+    (groupAX ρ).PosSemidef := by
+  simpa only [groupAX, Matrix.coe_reindexAlgEquiv, Matrix.reindex_apply,
+    Equiv.symm_symm, Matrix.posSemidef_submatrix_equiv] using
+      hρ.submatrix (Equiv.prodAssoc A X B)
+
+/-- Reassociation preserves Hermiticity. -/
+private theorem groupAX_isHermitian
+    {ρ : Matrix (A × (X × B)) (A × (X × B)) ℂ} (hρ : ρ.IsHermitian) :
+    (groupAX ρ).IsHermitian := by
+  simpa only [groupAX, Matrix.coe_reindexAlgEquiv, Matrix.reindex_apply,
+    Equiv.symm_symm] using hρ.submatrix (Equiv.prodAssoc A X B)
+
+@[simp]
+private theorem ungroupAX_groupAX (ρ : Matrix (A × (X × B)) (A × (X × B)) ℂ) :
+    ungroupAX (groupAX ρ) = ρ := by
+  simp [groupAX, ungroupAX]
+
+/-- Reassociation respects matrix multiplication. -/
+private theorem ungroupAX_mul
+    (M N : Matrix ((A × X) × B) ((A × X) × B) ℂ) :
+    ungroupAX (M * N) = ungroupAX M * ungroupAX N := by
+  exact map_mul (Matrix.reindexAlgEquiv ℂ ℂ (Equiv.prodAssoc A X B)) M N
+
+/-- Lift an operator on \(A\times X\) to the tripartite space. -/
+noncomputable def liftAX (M : Matrix (A × X) (A × X) ℂ) :
+    Matrix (A × (X × B)) (A × (X × B)) ℂ :=
+  ungroupAX (Matrix.leftKroneckerEmbed (n := B) M)
+
+/-- Lift an operator on \(X\times B\) to the tripartite space. -/
+noncomputable def liftXB (M : Matrix (X × B) (X × B) ℂ) :
+    Matrix (A × (X × B)) (A × (X × B)) ℂ :=
+  Matrix.rightKroneckerEmbed (m := A) M
+
+/-- Lift an operator on the separated region \(A\) to the tripartite space. -/
+noncomputable def liftA (M : Matrix A A ℂ) :
+    Matrix (A × (X × B)) (A × (X × B)) ℂ :=
+  Matrix.leftKroneckerEmbed (n := X × B) M
+
+/-- Lift an operator on the separated region \(B\) to the tripartite space. -/
+noncomputable def liftB (M : Matrix B B ℂ) :
+    Matrix (A × (X × B)) (A × (X × B)) ℂ :=
+  Matrix.rightKroneckerEmbed (m := A)
+    (Matrix.rightKroneckerEmbed (m := X) M)
+
+private theorem liftAX_mul (M N : Matrix (A × X) (A × X) ℂ) :
+    liftAX (B := B) (M * N) = liftAX (B := B) M * liftAX (B := B) N := by
+  rw [liftAX, liftAX, liftAX, ← ungroupAX_mul, map_mul]
+
+private theorem liftXB_mul (M N : Matrix (X × B) (X × B) ℂ) :
+    liftXB (A := A) (M * N) = liftXB (A := A) M * liftXB (A := A) N := by
+  exact map_mul (Matrix.rightKroneckerEmbed (m := A) (n := X × B)) M N
+
+private theorem liftA_comm_liftXB (OA : Matrix A A ℂ) (M : Matrix (X × B) (X × B) ℂ) :
+    liftA OA * liftXB M = liftXB M * liftA OA := by
+  ext ⟨a, x, b⟩ ⟨a', x', b'⟩
+  simp [liftA, liftXB, Matrix.mul_apply, Matrix.leftKroneckerEmbed_apply,
+    Matrix.rightKroneckerEmbed_apply, Matrix.kroneckerMap_apply,
+    Matrix.one_apply, Fintype.sum_prod_type, mul_comm]
+
+private theorem liftB_comm_liftAX (OB : Matrix B B ℂ) (M : Matrix (A × X) (A × X) ℂ) :
+    liftB OB * liftAX M = liftAX M * liftB OB := by
+  ext ⟨a, x, b⟩ ⟨a', x', b'⟩
+  simp [liftB, liftAX, ungroupAX, Matrix.mul_apply,
+    Matrix.leftKroneckerEmbed_apply, Matrix.rightKroneckerEmbed_apply,
+    Matrix.kroneckerMap_apply, Matrix.one_apply, Fintype.sum_prod_type,
+    mul_comm]
+
+@[simp]
+private theorem conjTranspose_liftA (M : Matrix A A ℂ) :
+    (liftA (X := X) (B := B) M)ᴴ = liftA (X := X) (B := B) Mᴴ := by
+  change (Matrix.leftKroneckerEmbed (n := X × B) M)ᴴ =
+    Matrix.leftKroneckerEmbed (n := X × B) Mᴴ
+  rw [← star_eq_conjTranspose, ← map_star, star_eq_conjTranspose]
+
+@[simp]
+private theorem conjTranspose_liftB (M : Matrix B B ℂ) :
+    (liftB (A := A) (X := X) M)ᴴ = liftB (A := A) (X := X) Mᴴ := by
+  change (Matrix.rightKroneckerEmbed (m := A)
+      (Matrix.rightKroneckerEmbed (m := X) M))ᴴ =
+    Matrix.rightKroneckerEmbed (m := A)
+      (Matrix.rightKroneckerEmbed (m := X) Mᴴ)
+  rw [← star_eq_conjTranspose, ← map_star, ← map_star, star_eq_conjTranspose]
+
+/-- The reduced operator on \(AX\), obtained by tracing out \(B\). -/
+noncomputable def marginalAX
+    (P : Matrix (A × (X × B)) (A × (X × B)) ℂ) :
+    Matrix (A × X) (A × X) ℂ :=
+  Matrix.partialTraceRight (groupAX P)
+
+/-- The reduced operator on \(XB\), obtained by tracing out \(A\). -/
+noncomputable def marginalXB
+    (P : Matrix (A × (X × B)) (A × (X × B)) ℂ) :
+    Matrix (X × B) (X × B) ℂ :=
+  Matrix.partialTraceLeft P
+
+private theorem liftA_single_sandwich_apply
+    (P : Matrix (A × (X × B)) (A × (X × B)) ℂ) (a k a₀ a₁ : A)
+    (r₀ r₁ : X × B) :
+    (liftA (X := X) (B := B) (Matrix.single a k 1) * P *
+        liftA (X := X) (B := B) (Matrix.single k a 1))
+        (a₀, r₀) (a₁, r₁) =
+      if a = a₀ ∧ a = a₁ then P (k, r₀) (k, r₁) else 0 := by
+  classical
+  by_cases h₀ : a = a₀ <;> by_cases h₁ : a = a₁
+  · subst a₀
+    subst a₁
+    simp [liftA, Matrix.mul_apply, Matrix.leftKroneckerEmbed_apply,
+      Matrix.kroneckerMap_apply, Matrix.one_apply, Matrix.single,
+      Fintype.sum_prod_type]
+  · simp [liftA, Matrix.mul_apply, Matrix.leftKroneckerEmbed_apply,
+      Matrix.kroneckerMap_apply, Matrix.one_apply, Matrix.single,
+      Fintype.sum_prod_type, h₁]
+  · simp [liftA, Matrix.mul_apply, Matrix.leftKroneckerEmbed_apply,
+      Matrix.kroneckerMap_apply, Matrix.one_apply, Matrix.single, h₀]
+  · simp [liftA, Matrix.mul_apply, Matrix.leftKroneckerEmbed_apply,
+      Matrix.kroneckerMap_apply, Matrix.one_apply, Matrix.single, h₀, h₁]
+
+private theorem liftB_single_sandwich_apply
+    (P : Matrix (A × (X × B)) (A × (X × B)) ℂ) (b k b₀ b₁ : B)
+    (a₀ a₁ : A) (x₀ x₁ : X) :
+    (liftB (A := A) (X := X) (Matrix.single b k 1) * P *
+        liftB (A := A) (X := X) (Matrix.single k b 1))
+        (a₀, x₀, b₀) (a₁, x₁, b₁) =
+      if b = b₀ ∧ b = b₁ then P (a₀, x₀, k) (a₁, x₁, k) else 0 := by
+  classical
+  by_cases h₀ : b = b₀ <;> by_cases h₁ : b = b₁
+  · subst b₀
+    subst b₁
+    simp [liftB, Matrix.mul_apply, Matrix.rightKroneckerEmbed_apply,
+      Matrix.kroneckerMap_apply, Matrix.one_apply, Matrix.single,
+      Fintype.sum_prod_type]
+  · simp [liftB, Matrix.mul_apply, Matrix.rightKroneckerEmbed_apply,
+      Matrix.kroneckerMap_apply, Matrix.one_apply, Matrix.single,
+      Fintype.sum_prod_type, h₁]
+  · simp [liftB, Matrix.mul_apply, Matrix.rightKroneckerEmbed_apply,
+      Matrix.kroneckerMap_apply, Matrix.one_apply, Matrix.single, h₀]
+  · simp [liftB, Matrix.mul_apply, Matrix.rightKroneckerEmbed_apply,
+      Matrix.kroneckerMap_apply, Matrix.one_apply, Matrix.single, h₀, h₁]
+
+/-- The lifted \(XB\) marginal is a sum of contractions of \(P\) by matrix
+units on \(A\).
+
+This is the corrected matrix-unit form of arXiv:1606.00608, Appendix D.2,
+lines 2236--2250. -/
+theorem lift_marginalXB_eq_sum (P : Matrix (A × (X × B)) (A × (X × B)) ℂ) :
+    liftXB (marginalXB P) =
+      ∑ a : A, ∑ k : A,
+        liftA (Matrix.single a k 1) * P * liftA (Matrix.single k a 1) := by
+  classical
+  ext ⟨a, x, b⟩ ⟨a', x', b'⟩
+  by_cases haa : a = a'
+  · subst a'
+    simp [liftXB, marginalXB, Matrix.sum_apply, Matrix.rightKroneckerEmbed_apply,
+      Matrix.kroneckerMap_apply, liftA_single_sandwich_apply]
+  · simp only [liftXB, marginalXB, Matrix.rightKroneckerEmbed_apply,
+      Matrix.kroneckerMap_apply, ne_eq, haa, not_false_eq_true, Matrix.one_apply_ne,
+      Matrix.partialTraceLeft_apply, zero_mul, Matrix.sum_apply,
+      liftA_single_sandwich_apply, Finset.sum_ite_irrel, Finset.sum_const_zero]
+    symm
+    apply Finset.sum_eq_zero
+    intro c _
+    rw [if_neg]
+    intro h
+    apply haa
+    calc
+      a = c := h.1.symm
+      _ = a' := h.2
+
+/-- The lifted \(AX\) marginal is a sum of contractions of \(P\) by matrix
+units on \(B\).
+
+This is the corrected matrix-unit form of arXiv:1606.00608, Appendix D.2,
+lines 2236--2250. -/
+theorem lift_marginalAX_eq_sum (P : Matrix (A × (X × B)) (A × (X × B)) ℂ) :
+    liftAX (marginalAX P) =
+      ∑ b : B, ∑ k : B,
+        liftB (Matrix.single b k 1) * P * liftB (Matrix.single k b 1) := by
+  classical
+  ext ⟨a, x, b⟩ ⟨a', x', b'⟩
+  by_cases hbb : b = b'
+  · subst b'
+    simp [liftAX, marginalAX, groupAX, ungroupAX, Matrix.sum_apply,
+      Matrix.leftKroneckerEmbed_apply, Matrix.kroneckerMap_apply,
+      liftB_single_sandwich_apply]
+  · simp only [liftAX, ungroupAX, marginalAX, groupAX, Matrix.coe_reindexAlgEquiv,
+      Matrix.reindex_apply, Equiv.symm_symm, Matrix.leftKroneckerEmbed_apply,
+      Matrix.submatrix_apply, Equiv.prodAssoc_symm_apply, Matrix.kroneckerMap_apply,
+      Matrix.partialTraceRight_apply, Equiv.prodAssoc_apply, ne_eq, hbb,
+      not_false_eq_true, Matrix.one_apply_ne, mul_zero, Matrix.sum_apply,
+      liftB_single_sandwich_apply, Finset.sum_ite_irrel, Finset.sum_const_zero]
+    symm
+    apply Finset.sum_eq_zero
+    intro c _
+    rw [if_neg]
+    intro h
+    apply hbb
+    calc
+      b = c := h.1.symm
+      _ = b' := h.2
+
+/-- Decorrelation of the separated regions \(A\) and \(B\) relative to a
+tripartite projector \(P\).
+
+See arXiv:1606.00608, Appendix D.2, Definition D.1, lines 2187--2191. -/
+def IsDecorrelated (P : Matrix (A × (X × B)) (A × (X × B)) ℂ) : Prop :=
+  ∀ OA : Matrix A A ℂ, ∀ OB : Matrix B B ℂ,
+    P * liftA OA * (1 - P) * liftB OB * P = 0
+
+/-- The adjoint form of decorrelation, with the order of the two separated
+observables reversed.
+
+This is the second equality in arXiv:1606.00608, Appendix D.2, equation
+`decorr`, lines 2194--2198. -/
+theorem IsDecorrelated.reverse
+    {P : Matrix (A × (X × B)) (A × (X × B)) ℂ}
+    (hPherm : P.IsHermitian) (hdec : IsDecorrelated P)
+    (OB : Matrix B B ℂ) (OA : Matrix A A ℂ) :
+    P * liftB OB * (1 - P) * liftA OA * P = 0 := by
+  have h := congrArg Matrix.conjTranspose (hdec OAᴴ OBᴴ)
+  simpa only [Matrix.conjTranspose_mul, Matrix.conjTranspose_sub,
+    Matrix.conjTranspose_one, Matrix.conjTranspose_zero, hPherm.eq,
+    conjTranspose_liftA, conjTranspose_liftB, Matrix.conjTranspose_conjTranspose,
+    Matrix.mul_assoc] using h
+
+/-- Decorrelation annihilates the product of the two lifted reduced operators
+through the complementary projector.
+
+This is the matrix-unit calculation in arXiv:1606.00608, Appendix D.2,
+lines 2236--2258. -/
+theorem IsDecorrelated.marginals_mul_complement_mul_eq_zero
+    {P : Matrix (A × (X × B)) (A × (X × B)) ℂ}
+    (hdec : IsDecorrelated P) :
+    liftXB (marginalXB P) * (1 - P) * liftAX (marginalAX P) = 0 := by
+  rw [lift_marginalXB_eq_sum, lift_marginalAX_eq_sum, Finset.sum_mul]
+  rw [Finset.sum_mul]
+  apply Finset.sum_eq_zero
+  intro a _
+  rw [Finset.sum_mul]
+  rw [Finset.sum_mul]
+  apply Finset.sum_eq_zero
+  intro k _
+  rw [Matrix.mul_sum]
+  apply Finset.sum_eq_zero
+  intro b _
+  rw [Matrix.mul_sum]
+  apply Finset.sum_eq_zero
+  intro l _
+  calc
+    (liftA (Matrix.single a k 1) * P * liftA (Matrix.single k a 1) * (1 - P)) *
+        (liftB (Matrix.single b l 1) * P * liftB (Matrix.single l b 1)) =
+        liftA (Matrix.single a k 1) *
+          (P * liftA (Matrix.single k a 1) * (1 - P) *
+            liftB (Matrix.single b l 1) * P) *
+          liftB (Matrix.single l b 1) := by noncomm_ring
+    _ = 0 := by
+      rw [hdec (Matrix.single k a 1) (Matrix.single b l 1), Matrix.mul_zero,
+        Matrix.zero_mul]
+
+/-- The reverse-order reduced-operator product also vanishes. -/
+theorem IsDecorrelated.reverse_marginals_mul_complement_mul_eq_zero
+    {P : Matrix (A × (X × B)) (A × (X × B)) ℂ}
+    (hPherm : P.IsHermitian) (hdec : IsDecorrelated P) :
+    liftAX (marginalAX P) * (1 - P) * liftXB (marginalXB P) = 0 := by
+  rw [lift_marginalAX_eq_sum, lift_marginalXB_eq_sum, Finset.sum_mul]
+  rw [Finset.sum_mul]
+  apply Finset.sum_eq_zero
+  intro b _
+  rw [Finset.sum_mul]
+  rw [Finset.sum_mul]
+  apply Finset.sum_eq_zero
+  intro l _
+  rw [Matrix.mul_sum]
+  apply Finset.sum_eq_zero
+  intro a _
+  rw [Matrix.mul_sum]
+  apply Finset.sum_eq_zero
+  intro k _
+  calc
+    (liftB (Matrix.single b l 1) * P * liftB (Matrix.single l b 1) * (1 - P)) *
+        (liftA (Matrix.single a k 1) * P * liftA (Matrix.single k a 1)) =
+        liftB (Matrix.single b l 1) *
+          (P * liftB (Matrix.single l b 1) * (1 - P) *
+            liftA (Matrix.single a k 1) * P) *
+          liftA (Matrix.single k a 1) := by noncomm_ring
+    _ = 0 := by
+      rw [hdec.reverse hPherm (Matrix.single l b 1) (Matrix.single a k 1),
+        Matrix.mul_zero, Matrix.zero_mul]
+
+/-- The support projector of a Hermitian matrix also factors through the
+matrix on the left. -/
+private theorem supportProj_eq_mul_cfc_recip
+    {ι : Type*} [Fintype ι] [DecidableEq ι] {M : Matrix ι ι ℂ}
+    (hM : M.IsHermitian) :
+    hM.supportProj = M * hM.cfc (fun x => if x ≠ 0 then x⁻¹ else 0) := by
+  let f : ℝ → ℝ := fun x => if x ≠ 0 then x⁻¹ else 0
+  calc
+    hM.supportProj = hM.cfc f * M := SSAPosDef.supportProj_eq_cfc_recip_mul hM
+    _ = hM.cfc f * hM.cfc id := by rw [hM.cfc_id]
+    _ = hM.cfc (fun x => f x * id x) := (hM.cfc_mul f id).symm
+    _ = hM.cfc (fun x => id x * f x) := by
+      congr 2
+      funext x
+      exact mul_comm _ _
+    _ = hM.cfc id * hM.cfc f := hM.cfc_mul id f
+    _ = M * hM.cfc f := by rw [hM.cfc_id]
+
+/-- The orthogonal support projector of the \(AX\) marginal.
+
+See arXiv:1606.00608, Appendix D.2, lines 2225--2229. -/
+noncomputable def supportAX
+    {ρ : Matrix (A × (X × B)) (A × (X × B)) ℂ} (hρ : ρ.IsHermitian) :
+    Matrix (A × X) (A × X) ℂ :=
+  (Matrix.partialTraceRight_isHermitian (groupAX_isHermitian hρ)).supportProj
+
+/-- The orthogonal support projector of the \(XB\) marginal.
+
+See arXiv:1606.00608, Appendix D.2, lines 2225--2229. -/
+noncomputable def supportXB
+    {ρ : Matrix (A × (X × B)) (A × (X × B)) ℂ} (hρ : ρ.IsHermitian) :
+    Matrix (X × B) (X × B) ℂ :=
+  (Matrix.partialTraceLeft_isHermitian hρ).supportProj
+
+/-- Decorrelation annihilates the product of the two marginal support
+projectors through the orthogonal complement of \(P\).
+
+The proof uses the matrix-unit expansions of the two reduced operators and
+then factors each support projector through its reduced operator.  This
+repairs the unsupported single-slice assertion in arXiv:1606.00608,
+Appendix D.2, lines 2236--2252, while retaining the calculation in lines
+2253--2258.
+
+**Local fix (CPSV16 Appendix D.2):** A basis vector of a marginal support need
+not be one partial contraction.  The reduced-operator expansion and
+reciprocal-on-support factorization above replace that step.  Documented in
+`docs/paper-gaps/cpsv16_decorrelation_slice_expansion_fix.tex`. -/
+theorem IsDecorrelated.supports_mul_complement_mul_eq_zero
+    {P : Matrix (A × (X × B)) (A × (X × B)) ℂ}
+    (hPherm : P.IsHermitian) (hdec : IsDecorrelated P) :
+    liftXB (supportXB hPherm) * (1 - P) * liftAX (supportAX hPherm) = 0 := by
+  let hAX : (marginalAX P).IsHermitian := by
+    exact Matrix.partialTraceRight_isHermitian (groupAX_isHermitian hPherm)
+  let hXB : (marginalXB P).IsHermitian := by
+    exact Matrix.partialTraceLeft_isHermitian hPherm
+  let TAX := hAX.cfc (fun x => if x ≠ 0 then x⁻¹ else 0)
+  let TXB := hXB.cfc (fun x => if x ≠ 0 then x⁻¹ else 0)
+  have hAXfactor : supportAX hPherm = marginalAX P * TAX := by
+    simpa only [supportAX, marginalAX, hAX, TAX] using
+      supportProj_eq_mul_cfc_recip hAX
+  have hXBfactor : supportXB hPherm = TXB * marginalXB P := by
+    simpa only [supportXB, marginalXB, hXB, TXB] using
+      SSAPosDef.supportProj_eq_cfc_recip_mul hXB
+  rw [hXBfactor, hAXfactor, liftXB_mul, liftAX_mul]
+  calc
+    (liftXB TXB * liftXB (marginalXB P)) * (1 - P) *
+        (liftAX (marginalAX P) * liftAX TAX) =
+        liftXB TXB *
+          (liftXB (marginalXB P) * (1 - P) * liftAX (marginalAX P)) *
+          liftAX TAX := by noncomm_ring
+    _ = 0 := by
+      rw [hdec.marginals_mul_complement_mul_eq_zero, Matrix.mul_zero,
+        Matrix.zero_mul]
+
+/-- The reverse-order product of the two marginal support projectors through
+the complement of \(P\) also vanishes. -/
+theorem IsDecorrelated.reverse_supports_mul_complement_mul_eq_zero
+    {P : Matrix (A × (X × B)) (A × (X × B)) ℂ}
+    (hPherm : P.IsHermitian) (hdec : IsDecorrelated P) :
+    liftAX (supportAX hPherm) * (1 - P) * liftXB (supportXB hPherm) = 0 := by
+  let hAX : (marginalAX P).IsHermitian := by
+    exact Matrix.partialTraceRight_isHermitian (groupAX_isHermitian hPherm)
+  let hXB : (marginalXB P).IsHermitian := by
+    exact Matrix.partialTraceLeft_isHermitian hPherm
+  let TAX := hAX.cfc (fun x => if x ≠ 0 then x⁻¹ else 0)
+  let TXB := hXB.cfc (fun x => if x ≠ 0 then x⁻¹ else 0)
+  have hAXfactor : supportAX hPherm = TAX * marginalAX P := by
+    simpa only [supportAX, marginalAX, hAX, TAX] using
+      SSAPosDef.supportProj_eq_cfc_recip_mul hAX
+  have hXBfactor : supportXB hPherm = marginalXB P * TXB := by
+    simpa only [supportXB, marginalXB, hXB, TXB] using
+      supportProj_eq_mul_cfc_recip hXB
+  rw [hAXfactor, hXBfactor, liftAX_mul, liftXB_mul]
+  calc
+    (liftAX TAX * liftAX (marginalAX P)) * (1 - P) *
+        (liftXB (marginalXB P) * liftXB TXB) =
+        liftAX TAX *
+          (liftAX (marginalAX P) * (1 - P) * liftXB (marginalXB P)) *
+          liftXB TXB := by noncomm_ring
+    _ = 0 := by
+      rw [hdec.reverse_marginals_mul_complement_mul_eq_zero hPherm,
+        Matrix.mul_zero, Matrix.zero_mul]
+
+/-- The lifted support projector of the \(XB\) marginal fixes the tripartite
+operator on the left.
+
+This is the \(P_{XB}P_{AXB}=P_{AXB}\) identity in arXiv:1606.00608,
+Appendix D.2, equation `Propproj`, lines 2228--2235. -/
+theorem liftSupportXB_mul_self
+    {ρ : Matrix (A × (X × B)) (A × (X × B)) ℂ} (hρ : ρ.PosSemidef) :
+    liftXB (supportXB hρ.isHermitian) * ρ = ρ := by
+  exact hρ.rightKroneckerEmbed_supportProj_mul_self
+
+/-- The lifted support projector of the \(XB\) marginal fixes the tripartite
+operator on the right.
+
+This is the \(P_{AXB}P_{XB}=P_{AXB}\) identity in arXiv:1606.00608,
+Appendix D.2, equation `Propproj`, lines 2228--2235. -/
+theorem mul_liftSupportXB_self
+    {ρ : Matrix (A × (X × B)) (A × (X × B)) ℂ} (hρ : ρ.PosSemidef) :
+    ρ * liftXB (supportXB hρ.isHermitian) = ρ := by
+  exact hρ.mul_rightKroneckerEmbed_supportProj_self
+
+/-- The lifted support projector of the \(AX\) marginal fixes the tripartite
+operator on the left.
+
+This is the \(P_{AX}P_{AXB}=P_{AXB}\) identity in arXiv:1606.00608,
+Appendix D.2, equation `Propproj`, lines 2228--2235. -/
+theorem liftSupportAX_mul_self
+    {ρ : Matrix (A × (X × B)) (A × (X × B)) ℂ} (hρ : ρ.PosSemidef) :
+    liftAX (supportAX hρ.isHermitian) * ρ = ρ := by
+  have hgroup := (groupAX_posSemidef hρ).leftKroneckerEmbed_supportProj_mul_self
+  have h := congrArg (ungroupAX (A := A) (X := X) (B := B)) hgroup
+  simpa only [liftAX, supportAX, ungroupAX_mul, ungroupAX_groupAX] using h
+
+/-- The lifted support projector of the \(AX\) marginal fixes the tripartite
+operator on the right.
+
+This is the \(P_{AXB}P_{AX}=P_{AXB}\) identity in arXiv:1606.00608,
+Appendix D.2, equation `Propproj`, lines 2228--2235. -/
+theorem mul_liftSupportAX_self
+    {ρ : Matrix (A × (X × B)) (A × (X × B)) ℂ} (hρ : ρ.PosSemidef) :
+    ρ * liftAX (supportAX hρ.isHermitian) = ρ := by
+  have hgroup := (groupAX_posSemidef hρ).mul_leftKroneckerEmbed_supportProj_self
+  have h := congrArg (ungroupAX (A := A) (X := X) (B := B)) hgroup
+  simpa only [liftAX, supportAX, ungroupAX_mul, ungroupAX_groupAX] using h
+
+/-- The two marginal support projectors multiply to the tripartite projector.
+
+This is arXiv:1606.00608, Appendix D.2, equation `PXBAXetc`,
+lines 2236--2258.  The proof uses reduced-operator matrix-unit expansions and
+reciprocal-on-support factorization, so no commutation hypothesis is assumed. -/
+theorem supportProducts_eq
+    {P : Matrix (A × (X × B)) (A × (X × B)) ℂ}
+    (hPherm : P.IsHermitian) (hPidem : P * P = P)
+    (hdec : IsDecorrelated P) :
+    liftXB (supportXB hPherm) * liftAX (supportAX hPherm) = P ∧
+      liftAX (supportAX hPherm) * liftXB (supportXB hPherm) = P := by
+  have hPstar : IsStarProjection P := by
+    rw [isStarProjection_iff']
+    exact ⟨hPidem, by simpa [Matrix.star_eq_conjTranspose] using hPherm.eq⟩
+  have hPpos : P.PosSemidef := Matrix.nonneg_iff_posSemidef.mp hPstar.nonneg
+  constructor
+  · calc
+      liftXB (supportXB hPherm) * liftAX (supportAX hPherm) =
+          liftXB (supportXB hPherm) * P * liftAX (supportAX hPherm) +
+            liftXB (supportXB hPherm) * (1 - P) * liftAX (supportAX hPherm) := by
+              noncomm_ring
+      _ = liftXB (supportXB hPherm) * P * liftAX (supportAX hPherm) := by
+        rw [hdec.supports_mul_complement_mul_eq_zero hPherm, add_zero]
+      _ = P := by rw [liftSupportXB_mul_self hPpos, mul_liftSupportAX_self hPpos]
+  · calc
+      liftAX (supportAX hPherm) * liftXB (supportXB hPherm) =
+          liftAX (supportAX hPherm) * P * liftXB (supportXB hPherm) +
+            liftAX (supportAX hPherm) * (1 - P) * liftXB (supportXB hPherm) := by
+              noncomm_ring
+      _ = liftAX (supportAX hPherm) * P * liftXB (supportXB hPherm) := by
+        rw [hdec.reverse_supports_mul_complement_mul_eq_zero hPherm, add_zero]
+      _ = P := by rw [liftSupportAX_mul_self hPpos, mul_liftSupportXB_self hPpos]
+
+/-- The parent commuting Hamiltonian condition on the explicit tripartite
+space, written in terms of the local ground-space projectors.
+
+The Hamiltonian terms of arXiv:1606.00608, Appendix D.2, Definition D.2,
+lines 2205--2218, are \(Q_{AX}=1-P_{AX}\) and \(Q_{XB}=1-P_{XB}\).  For
+commuting orthogonal projectors, the product identity below says exactly that
+their lifted ranges intersect in the range of \(P\). -/
+structure CommutingParentHamiltonian
+    (P : Matrix (A × (X × B)) (A × (X × B)) ℂ) where
+  /-- The orthogonal projector onto \(K_{AX}\), as in arXiv:1606.00608,
+  Appendix D.2, lines 2205--2215. -/
+  PAX : Matrix (A × X) (A × X) ℂ
+  /-- The orthogonal projector onto \(K_{XB}\), as in arXiv:1606.00608,
+  Appendix D.2, lines 2205--2215. -/
+  PXB : Matrix (X × B) (X × B) ℂ
+  /-- The \(AX\) ground-space projector is Hermitian, corresponding to the
+  projector assumption in arXiv:1606.00608, Appendix D.2, lines 2205--2208. -/
+  hAXherm : PAX.IsHermitian
+  /-- The \(AX\) ground-space projector is idempotent, corresponding to the
+  projector assumption in arXiv:1606.00608, Appendix D.2, lines 2205--2208. -/
+  hAXidem : PAX * PAX = PAX
+  /-- The \(XB\) ground-space projector is Hermitian, corresponding to the
+  projector assumption in arXiv:1606.00608, Appendix D.2, lines 2205--2208. -/
+  hXBherm : PXB.IsHermitian
+  /-- The \(XB\) ground-space projector is idempotent, corresponding to the
+  projector assumption in arXiv:1606.00608, Appendix D.2, lines 2205--2208. -/
+  hXBidem : PXB * PXB = PXB
+  /-- The two lifted ground-space projectors commute, equivalent to equation
+  `QAXQXB` in arXiv:1606.00608, Appendix D.2, lines 2207--2214. -/
+  hcomm : liftAX PAX * liftXB PXB = liftXB PXB * liftAX PAX
+  /-- Their product is the projector onto \(K_{AXB}\), which is the
+  ground-space intersection in arXiv:1606.00608, Appendix D.2,
+  lines 2212--2218. -/
+  hproduct : liftAX PAX * liftXB PXB = P
+
+/-- Existence of local commuting parent projectors for \(P\), in the sense of
+arXiv:1606.00608, Appendix D.2, Definition D.2, lines 2205--2218. -/
+def HasCommutingParentHamiltonian
+    (P : Matrix (A × (X × B)) (A × (X × B)) ℂ) : Prop :=
+  Nonempty (CommutingParentHamiltonian P)
+
+/-- A parent commuting Hamiltonian on \(AX\) and \(XB\) implies decorrelation
+of \(A\) and \(B\).
+
+This is the only-if direction of arXiv:1606.00608, Appendix D.2,
+Proposition D.3, lines 2279--2289. -/
+theorem CommutingParentHamiltonian.isDecorrelated
+    {P : Matrix (A × (X × B)) (A × (X × B)) ℂ}
+    (hparent : CommutingParentHamiltonian P) (hPidem : P * P = P) :
+    IsDecorrelated P := by
+  let SAX := liftAX (B := B) hparent.PAX
+  let SXB := liftXB (A := A) hparent.PXB
+  have hrev : SXB * SAX = P := by
+    rw [← hparent.hcomm]
+    exact hparent.hproduct
+  have hquad : SXB * P * SAX = P * P := by
+    calc
+      SXB * P * SAX = SXB * (SAX * SXB) * SAX := by rw [hparent.hproduct]
+      _ = (SXB * SAX) * (SXB * SAX) := by noncomm_ring
+      _ = P * P := by rw [hrev]
+  have hmiddle : SXB * (1 - P) * SAX = 0 := by
+    calc
+      SXB * (1 - P) * SAX = SXB * SAX - SXB * P * SAX := by noncomm_ring
+      _ = P - P * P := by rw [hrev, hquad]
+      _ = 0 := by rw [hPidem, sub_self]
+  intro OA OB
+  have hAcomm : SXB * liftA OA = liftA OA * SXB := by
+    exact (liftA_comm_liftXB OA hparent.PXB).symm
+  have hBcomm : liftB OB * SAX = SAX * liftB OB := by
+    exact liftB_comm_liftAX OB hparent.PAX
+  calc
+    P * liftA OA * (1 - P) * liftB OB * P =
+        (SAX * SXB) * liftA OA * (1 - P) * liftB OB * (SAX * SXB) := by
+          rw [hparent.hproduct]
+    _ = SAX * liftA OA * (SXB * (1 - P) * SAX) * liftB OB * SXB := by
+      calc
+        (SAX * SXB) * liftA OA * (1 - P) * liftB OB * (SAX * SXB) =
+            SAX * (SXB * liftA OA) * (1 - P) *
+              (liftB OB * SAX) * SXB := by noncomm_ring
+        _ = SAX * (liftA OA * SXB) * (1 - P) *
+              (SAX * liftB OB) * SXB := by rw [hAcomm, hBcomm]
+        _ = SAX * liftA OA * (SXB * (1 - P) * SAX) * liftB OB * SXB := by
+          noncomm_ring
+    _ = 0 := by rw [hmiddle]; simp
+
+/-- Decorrelation constructs a parent commuting Hamiltonian from the two
+marginal support projectors.
+
+This is the if direction of arXiv:1606.00608, Appendix D.2,
+Proposition D.3, lines 2225--2277. -/
+theorem IsDecorrelated.hasCommutingParentHamiltonian
+    {P : Matrix (A × (X × B)) (A × (X × B)) ℂ}
+    (hPherm : P.IsHermitian) (hPidem : P * P = P) (hdec : IsDecorrelated P) :
+    HasCommutingParentHamiltonian P := by
+  have hproducts := supportProducts_eq hPherm hPidem hdec
+  exact ⟨
+    { PAX := supportAX hPherm
+      PXB := supportXB hPherm
+      hAXherm := (Matrix.partialTraceRight_isHermitian
+        (groupAX_isHermitian hPherm)).supportProj_isHermitian
+      hAXidem := (Matrix.partialTraceRight_isHermitian
+        (groupAX_isHermitian hPherm)).supportProj_idem
+      hXBherm := (Matrix.partialTraceLeft_isHermitian hPherm).supportProj_isHermitian
+      hXBidem := (Matrix.partialTraceLeft_isHermitian hPherm).supportProj_idem
+      hcomm := hproducts.2.trans hproducts.1.symm
+      hproduct := hproducts.2 }⟩
+
+/-- **Parent commuting Hamiltonian--decorrelation equivalence.**
+
+For an orthogonal projector \(P_{AXB}\), there are commuting parent terms on
+\(AX\) and \(XB\) with ground projector \(P_{AXB}\) if and only if regions
+\(A\) and \(B\) are decorrelated.  This is arXiv:1606.00608, Appendix D.2,
+Proposition D.3, lines 2221--2289. -/
+theorem parentHamiltonian_iff_decorrelated
+    {P : Matrix (A × (X × B)) (A × (X × B)) ℂ}
+    (hPherm : P.IsHermitian) (hPidem : P * P = P) :
+    HasCommutingParentHamiltonian P ↔ IsDecorrelated P :=
+  ⟨fun hparent => hparent.elim fun parent => parent.isDecorrelated hPidem,
+    fun hdec => hdec.hasCommutingParentHamiltonian hPherm hPidem⟩
+
+end TripartiteDecorrelation

--- a/TNLean/MPS/ParentHamiltonian/TripartiteDecorrelation.lean
+++ b/TNLean/MPS/ParentHamiltonian/TripartiteDecorrelation.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.Channel.MarginalSupportAbsorption
 import TNLean.Channel.Schwarz.StrongSubadditivityPosDef
 import Mathlib.Data.Matrix.Basis
+import Mathlib.LinearAlgebra.Complex.Module
 
 /-!
 # Tripartite support projectors for decorrelation
@@ -313,45 +314,6 @@ def IsDecorrelated (P : Matrix (A × (X × B)) (A × (X × B)) ℂ) : Prop :=
   ∀ OA : Matrix A A ℂ, ∀ OB : Matrix B B ℂ,
     P * liftA OA * (1 - P) * liftB OB * P = 0
 
-private noncomputable def hermitianPart
-    {ι : Type*} [Fintype ι] (M : Matrix ι ι ℂ) : Matrix ι ι ℂ :=
-  (1 / 2 : ℂ) • (M + Mᴴ)
-
-private noncomputable def imaginaryHermitianPart
-    {ι : Type*} [Fintype ι] (M : Matrix ι ι ℂ) : Matrix ι ι ℂ :=
-  (Complex.I / 2 : ℂ) • (Mᴴ - M)
-
-private theorem hermitianPart_isHermitian
-    {ι : Type*} [Fintype ι] (M : Matrix ι ι ℂ) :
-    (hermitianPart M).IsHermitian := by
-  rw [Matrix.IsHermitian, hermitianPart, Matrix.conjTranspose_smul,
-    Matrix.conjTranspose_add, Matrix.conjTranspose_conjTranspose]
-  simp
-  abel
-
-private theorem imaginaryHermitianPart_isHermitian
-    {ι : Type*} [Fintype ι] (M : Matrix ι ι ℂ) :
-    (imaginaryHermitianPart M).IsHermitian := by
-  rw [Matrix.IsHermitian, imaginaryHermitianPart, Matrix.conjTranspose_smul,
-    Matrix.conjTranspose_sub, Matrix.conjTranspose_conjTranspose]
-  have hI : star (Complex.I / 2 : ℂ) = -(Complex.I / 2) := by
-    apply Complex.ext <;> norm_num
-  rw [hI]
-  ext i j
-  simp [sub_eq_add_neg]
-  ring
-
-private theorem matrix_eq_hermitianPart_add_I_smul
-    {ι : Type*} [Fintype ι] (M : Matrix ι ι ℂ) :
-    M = hermitianPart M + Complex.I • imaginaryHermitianPart M := by
-  have hI : Complex.I * (Complex.I / 2 : ℂ) = -(1 : ℂ) / 2 := by
-    rw [div_eq_mul_inv, ← mul_assoc, Complex.I_mul_I]
-    ring
-  ext i j
-  simp [hermitianPart, imaginaryHermitianPart, smul_add, smul_smul, hI,
-    sub_eq_add_neg]
-  ring
-
 private theorem liftA_add (M N : Matrix A A ℂ) :
     liftA (X := X) (B := B) (M + N) = liftA M + liftA N := by
   exact map_add (Matrix.leftKroneckerEmbed (m := A) (n := X × B)) M N
@@ -379,16 +341,27 @@ theorem isObservableDecorrelated_iff
     IsObservableDecorrelated P ↔ IsDecorrelated P := by
   constructor
   · intro hobs OA OB
-    let HA := hermitianPart OA
-    let KA := imaginaryHermitianPart OA
-    let HB := hermitianPart OB
-    let KB := imaginaryHermitianPart OB
-    have hHA : HA.IsHermitian := hermitianPart_isHermitian OA
-    have hKA : KA.IsHermitian := imaginaryHermitianPart_isHermitian OA
-    have hHB : HB.IsHermitian := hermitianPart_isHermitian OB
-    have hKB : KB.IsHermitian := imaginaryHermitianPart_isHermitian OB
-    rw [matrix_eq_hermitianPart_add_I_smul OA,
-      matrix_eq_hermitianPart_add_I_smul OB]
+    let HA : Matrix A A ℂ := realPart OA
+    let KA : Matrix A A ℂ := imaginaryPart OA
+    let HB : Matrix B B ℂ := realPart OB
+    let KB : Matrix B B ℂ := imaginaryPart OB
+    have hHA : HA.IsHermitian := by
+      rw [Matrix.IsHermitian]
+      exact (realPart OA).2
+    have hKA : KA.IsHermitian := by
+      rw [Matrix.IsHermitian]
+      exact (imaginaryPart OA).2
+    have hHB : HB.IsHermitian := by
+      rw [Matrix.IsHermitian]
+      exact (realPart OB).2
+    have hKB : KB.IsHermitian := by
+      rw [Matrix.IsHermitian]
+      exact (imaginaryPart OB).2
+    have hOA : OA = HA + Complex.I • KA :=
+      (realPart_add_I_smul_imaginaryPart OA).symm
+    have hOB : OB = HB + Complex.I • KB :=
+      (realPart_add_I_smul_imaginaryPart OB).symm
+    rw [hOA, hOB]
     simp only [liftA_add, liftA_smul, liftB_add, liftB_smul,
       Matrix.mul_add, Matrix.add_mul, Matrix.mul_smul, Matrix.smul_mul]
     rw [hobs HA HB hHA hHB, hobs HA KB hHA hKB,

--- a/TNLean/MPS/ParentHamiltonian/TripartiteDecorrelation.lean
+++ b/TNLean/MPS/ParentHamiltonian/TripartiteDecorrelation.lean
@@ -570,8 +570,8 @@ theorem IsDecorrelated.reverse_supports_mul_complement_mul_eq_zero
 /-- The lifted support projector of the \(XB\) marginal fixes the tripartite
 operator on the left.
 
-This is the \(P_{XB}P_{AXB}=P_{AXB}\) marginal-support absorption identity in
-arXiv:1606.00608, Appendix D.2, lines 2228--2235. -/
+This is the \(\widehat P_{XB}P_{AXB}=P_{AXB}\) marginal-support absorption
+identity in arXiv:1606.00608, Appendix D.2, lines 2228--2235. -/
 theorem liftSupportXB_mul_self
     {ρ : Matrix (A × (X × B)) (A × (X × B)) ℂ} (hρ : ρ.PosSemidef) :
     liftXB (supportXB hρ.isHermitian) * ρ = ρ := by
@@ -580,8 +580,8 @@ theorem liftSupportXB_mul_self
 /-- The lifted support projector of the \(XB\) marginal fixes the tripartite
 operator on the right.
 
-This is the \(P_{AXB}P_{XB}=P_{AXB}\) marginal-support absorption identity in
-arXiv:1606.00608, Appendix D.2, lines 2228--2235. -/
+This is the \(P_{AXB}\widehat P_{XB}=P_{AXB}\) marginal-support absorption
+identity in arXiv:1606.00608, Appendix D.2, lines 2228--2235. -/
 theorem mul_liftSupportXB_self
     {ρ : Matrix (A × (X × B)) (A × (X × B)) ℂ} (hρ : ρ.PosSemidef) :
     ρ * liftXB (supportXB hρ.isHermitian) = ρ := by
@@ -590,8 +590,8 @@ theorem mul_liftSupportXB_self
 /-- The lifted support projector of the \(AX\) marginal fixes the tripartite
 operator on the left.
 
-This is the \(P_{AX}P_{AXB}=P_{AXB}\) marginal-support absorption identity in
-arXiv:1606.00608, Appendix D.2, lines 2228--2235. -/
+This is the \(\widehat P_{AX}P_{AXB}=P_{AXB}\) marginal-support absorption
+identity in arXiv:1606.00608, Appendix D.2, lines 2228--2235. -/
 theorem liftSupportAX_mul_self
     {ρ : Matrix (A × (X × B)) (A × (X × B)) ℂ} (hρ : ρ.PosSemidef) :
     liftAX (supportAX hρ.isHermitian) * ρ = ρ := by
@@ -602,8 +602,8 @@ theorem liftSupportAX_mul_self
 /-- The lifted support projector of the \(AX\) marginal fixes the tripartite
 operator on the right.
 
-This is the \(P_{AXB}P_{AX}=P_{AXB}\) marginal-support absorption identity in
-arXiv:1606.00608, Appendix D.2, lines 2228--2235. -/
+This is the \(P_{AXB}\widehat P_{AX}=P_{AXB}\) marginal-support absorption
+identity in arXiv:1606.00608, Appendix D.2, lines 2228--2235. -/
 theorem mul_liftSupportAX_self
     {ρ : Matrix (A × (X × B)) (A × (X × B)) ℂ} (hρ : ρ.PosSemidef) :
     ρ * liftAX (supportAX hρ.isHermitian) = ρ := by
@@ -773,9 +773,10 @@ space, written in terms of the local ground-space projectors.
 
 The Hamiltonian terms of arXiv:1606.00608, Appendix D.2, Definition D.2,
 lines 2205--2218, are \(Q_{AX}=1-P_{AX}\) and \(Q_{XB}=1-P_{XB}\).  The
-ground-space intersection condition
-\(\operatorname{ran}P=\operatorname{ran}P_{AX}\cap\operatorname{ran}P_{XB}\)
-is taken directly from Definition D.2. -/
+ground-space intersection condition, with hats denoting the full tripartite
+lifts, is
+\(\operatorname{ran}P=\operatorname{ran}\widehat P_{AX}\cap
+\operatorname{ran}\widehat P_{XB}\), as in Definition D.2. -/
 structure CommutingParentHamiltonian
     (P : Matrix (A × (X × B)) (A × (X × B)) ℂ) where
   /-- The orthogonal projector onto \(K_{AX}\), as in arXiv:1606.00608,

--- a/TNLean/MPS/ParentHamiltonian/TripartiteDecorrelation.lean
+++ b/TNLean/MPS/ParentHamiltonian/TripartiteDecorrelation.lean
@@ -15,6 +15,9 @@ explicit tensor product \(H_A\otimes H_X\otimes H_B\).
 
 ## Main definitions
 
+* `TripartiteDecorrelation.IsObservableDecorrelated`: the source condition,
+  tested on Hermitian observables.
+* `TripartiteDecorrelation.IsDecorrelated`: its complex-linear extension.
 * `TripartiteDecorrelation.supportAX`: support projector of the \(AX\) marginal.
 * `TripartiteDecorrelation.supportXB`: support projector of the \(XB\) marginal.
 * `TripartiteDecorrelation.HasCommutingParentHamiltonian`: existence of local
@@ -24,6 +27,8 @@ explicit tensor product \(H_A\otimes H_X\otimes H_B\).
 
 ## Main results
 
+* `TripartiteDecorrelation.isObservableDecorrelated_iff`: equivalence of the
+  source and complex-linear decorrelation conditions.
 * `TripartiteDecorrelation.liftSupportAX_mul_self` and its right-handed form.
 * `TripartiteDecorrelation.liftSupportXB_mul_self` and its right-handed form.
 * `TripartiteDecorrelation.IsDecorrelated.supports_mul_complement_mul_eq_zero`:
@@ -31,11 +36,13 @@ explicit tensor product \(H_A\otimes H_X\otimes H_B\).
 * `TripartiteDecorrelation.supportProducts_eq`: the two support-product
   identities obtained from decorrelation.
 * `TripartiteDecorrelation.parentHamiltonian_iff_decorrelated`: Proposition
-  D.3 on the explicit tripartite space.
+  D.3 in complex-linear form on the explicit tripartite space.
+* `TripartiteDecorrelation.parentHamiltonian_iff_observableDecorrelated`:
+  source-facing Proposition D.3.
 
 ## References
 
-* arXiv:1606.00608, Appendix D.2, lines 2187--2258.
+* arXiv:1606.00608, Appendix D.2, lines 2187--2289.
 -/
 
 open scoped Matrix MatrixOrder ComplexOrder Kronecker
@@ -263,13 +270,109 @@ theorem lift_marginalAX_eq_sum (P : Matrix (A × (X × B)) (A × (X × B)) ℂ) 
       b = c := h.1.symm
       _ = b' := h.2
 
-/-- Decorrelation of the separated regions \(A\) and \(B\) relative to a
-tripartite projector \(P\).
+/-- Source-facing decorrelation of the separated regions \(A\) and \(B\),
+tested on Hermitian observables.
 
-See arXiv:1606.00608, Appendix D.2, Definition D.1, lines 2187--2191. -/
+This is exactly arXiv:1606.00608, Appendix D.2, Definition D.1,
+lines 2187--2191. -/
+def IsObservableDecorrelated
+    (P : Matrix (A × (X × B)) (A × (X × B)) ℂ) : Prop :=
+  ∀ OA : Matrix A A ℂ, ∀ OB : Matrix B B ℂ,
+    OA.IsHermitian → OB.IsHermitian →
+      P * liftA OA * (1 - P) * liftB OB * P = 0
+
+/-- Bilinear extension of decorrelation from Hermitian observables to all
+complex matrices on the separated regions.
+
+The equivalence with arXiv:1606.00608, Appendix D.2, Definition D.1,
+lines 2187--2191, is proved in `isObservableDecorrelated_iff`. -/
 def IsDecorrelated (P : Matrix (A × (X × B)) (A × (X × B)) ℂ) : Prop :=
   ∀ OA : Matrix A A ℂ, ∀ OB : Matrix B B ℂ,
     P * liftA OA * (1 - P) * liftB OB * P = 0
+
+private noncomputable def hermitianPart
+    {ι : Type*} [Fintype ι] (M : Matrix ι ι ℂ) : Matrix ι ι ℂ :=
+  (1 / 2 : ℂ) • (M + Mᴴ)
+
+private noncomputable def imaginaryHermitianPart
+    {ι : Type*} [Fintype ι] (M : Matrix ι ι ℂ) : Matrix ι ι ℂ :=
+  (Complex.I / 2 : ℂ) • (Mᴴ - M)
+
+private theorem hermitianPart_isHermitian
+    {ι : Type*} [Fintype ι] (M : Matrix ι ι ℂ) :
+    (hermitianPart M).IsHermitian := by
+  rw [Matrix.IsHermitian, hermitianPart, Matrix.conjTranspose_smul,
+    Matrix.conjTranspose_add, Matrix.conjTranspose_conjTranspose]
+  simp
+  abel
+
+private theorem imaginaryHermitianPart_isHermitian
+    {ι : Type*} [Fintype ι] (M : Matrix ι ι ℂ) :
+    (imaginaryHermitianPart M).IsHermitian := by
+  rw [Matrix.IsHermitian, imaginaryHermitianPart, Matrix.conjTranspose_smul,
+    Matrix.conjTranspose_sub, Matrix.conjTranspose_conjTranspose]
+  have hI : star (Complex.I / 2 : ℂ) = -(Complex.I / 2) := by
+    apply Complex.ext <;> norm_num
+  rw [hI]
+  ext i j
+  simp [sub_eq_add_neg]
+  ring
+
+private theorem matrix_eq_hermitianPart_add_I_smul
+    {ι : Type*} [Fintype ι] (M : Matrix ι ι ℂ) :
+    M = hermitianPart M + Complex.I • imaginaryHermitianPart M := by
+  have hI : Complex.I * (Complex.I / 2 : ℂ) = -(1 : ℂ) / 2 := by
+    rw [div_eq_mul_inv, ← mul_assoc, Complex.I_mul_I]
+    ring
+  ext i j
+  simp [hermitianPart, imaginaryHermitianPart, smul_add, smul_smul, hI,
+    sub_eq_add_neg]
+  ring
+
+private theorem liftA_add (M N : Matrix A A ℂ) :
+    liftA (X := X) (B := B) (M + N) = liftA M + liftA N := by
+  exact map_add (Matrix.leftKroneckerEmbed (m := A) (n := X × B)) M N
+
+private theorem liftA_smul (c : ℂ) (M : Matrix A A ℂ) :
+    liftA (X := X) (B := B) (c • M) = c • liftA M := by
+  exact map_smul (Matrix.leftKroneckerEmbed (m := A) (n := X × B)) c M
+
+private theorem liftB_add (M N : Matrix B B ℂ) :
+    liftB (A := A) (X := X) (M + N) = liftB M + liftB N := by
+  simp only [liftB, map_add]
+
+private theorem liftB_smul (c : ℂ) (M : Matrix B B ℂ) :
+    liftB (A := A) (X := X) (c • M) = c • liftB M := by
+  simp only [liftB, map_smul]
+
+/-- Testing decorrelation on Hermitian observables is equivalent to testing it
+on arbitrary complex matrices.
+
+This identifies the source quantification in arXiv:1606.00608, Appendix D.2,
+Definition D.1, lines 2187--2191, with the all-matrix form used by the
+matrix-unit calculation in lines 2236--2258. -/
+theorem isObservableDecorrelated_iff
+    {P : Matrix (A × (X × B)) (A × (X × B)) ℂ} :
+    IsObservableDecorrelated P ↔ IsDecorrelated P := by
+  constructor
+  · intro hobs OA OB
+    let HA := hermitianPart OA
+    let KA := imaginaryHermitianPart OA
+    let HB := hermitianPart OB
+    let KB := imaginaryHermitianPart OB
+    have hHA : HA.IsHermitian := hermitianPart_isHermitian OA
+    have hKA : KA.IsHermitian := imaginaryHermitianPart_isHermitian OA
+    have hHB : HB.IsHermitian := hermitianPart_isHermitian OB
+    have hKB : KB.IsHermitian := imaginaryHermitianPart_isHermitian OB
+    rw [matrix_eq_hermitianPart_add_I_smul OA,
+      matrix_eq_hermitianPart_add_I_smul OB]
+    simp only [liftA_add, liftA_smul, liftB_add, liftB_smul,
+      Matrix.mul_add, Matrix.add_mul, Matrix.mul_smul, Matrix.smul_mul]
+    rw [hobs HA HB hHA hHB, hobs HA KB hHA hKB,
+      hobs KA HB hKA hHB, hobs KA KB hKA hKB]
+    simp
+  · intro hdec OA OB _ _
+    exact hdec OA OB
 
 /-- The adjoint form of decorrelation, with the order of the two separated
 observables reversed.
@@ -650,5 +753,19 @@ theorem parentHamiltonian_iff_decorrelated
     HasCommutingParentHamiltonian P ↔ IsDecorrelated P :=
   ⟨fun hparent => hparent.elim fun parent => parent.isDecorrelated hPidem,
     fun hdec => hdec.hasCommutingParentHamiltonian hPherm hPidem⟩
+
+/-- **Source-facing parent commuting Hamiltonian--decorrelation equivalence.**
+
+For an orthogonal projector (P_{AXB}), there are commuting parent terms on
+(AX) and (XB) with ground projector (P_{AXB}) if and only if the
+Hermitian-observable decorrelation condition of arXiv:1606.00608,
+Appendix D.2, Definition D.1, holds.  This is Proposition D.3,
+lines 2221--2289. -/
+theorem parentHamiltonian_iff_observableDecorrelated
+    {P : Matrix (A × (X × B)) (A × (X × B)) ℂ}
+    (hPherm : P.IsHermitian) (hPidem : P * P = P) :
+    HasCommutingParentHamiltonian P ↔ IsObservableDecorrelated P :=
+  (parentHamiltonian_iff_decorrelated hPherm hPidem).trans
+    isObservableDecorrelated_iff.symm
 
 end TripartiteDecorrelation

--- a/TNLean/MPS/ParentHamiltonian/TripartiteDecorrelation.lean
+++ b/TNLean/MPS/ParentHamiltonian/TripartiteDecorrelation.lean
@@ -720,8 +720,9 @@ def HasGroundSpaceIntersection
 /-- For commuting orthogonal projectors, the source ground-space intersection
 condition is equivalent to the corresponding projector-product identity.
 
-This proves the bridge from arXiv:1606.00608, Appendix D.2, Definition D.2,
-lines 2205--2218, to equation `arrggg`, lines 2279--2289. -/
+This proves that the range-intersection condition of arXiv:1606.00608,
+Appendix D.2, Definition D.2, lines 2205--2218, is equivalent to the
+projector-product identity at equation `arrggg`, lines 2279--2289. -/
 theorem hasGroundSpaceIntersection_iff_product_eq
     {P : Matrix (A × (X × B)) (A × (X × B)) ℂ}
     {PAX : Matrix (A × X) (A × X) ℂ}

--- a/TNLean/MPS/ParentHamiltonian/TripartiteDecorrelation.lean
+++ b/TNLean/MPS/ParentHamiltonian/TripartiteDecorrelation.lean
@@ -379,8 +379,8 @@ theorem isObservableDecorrelated_iff
 /-- The adjoint form of decorrelation, with the order of the two separated
 observables reversed.
 
-This is the second equality in arXiv:1606.00608, Appendix D.2, equation
-`decorr`, lines 2194--2198. -/
+This is the adjoint-reversed decorrelation equality in arXiv:1606.00608,
+Appendix D.2, lines 2194--2198. -/
 theorem IsDecorrelated.reverse
     {P : Matrix (A × (X × B)) (A × (X × B)) ℂ}
     (hPherm : P.IsHermitian) (hdec : IsDecorrelated P)

--- a/TNLean/MPS/ParentHamiltonian/TripartiteDecorrelation.lean
+++ b/TNLean/MPS/ParentHamiltonian/TripartiteDecorrelation.lean
@@ -426,7 +426,10 @@ theorem IsDecorrelated.marginals_mul_complement_mul_eq_zero
       rw [hdec (Matrix.single k a 1) (Matrix.single b l 1), Matrix.mul_zero,
         Matrix.zero_mul]
 
-/-- The reverse-order reduced-operator product also vanishes. -/
+/-- The reverse-order reduced-operator product also vanishes.
+
+This is the adjoint-reversed matrix-unit calculation in arXiv:1606.00608,
+Appendix D.2, lines 2236--2258. -/
 theorem IsDecorrelated.reverse_marginals_mul_complement_mul_eq_zero
     {P : Matrix (A × (X × B)) (A × (X × B)) ℂ}
     (hPherm : P.IsHermitian) (hdec : IsDecorrelated P) :
@@ -531,7 +534,12 @@ theorem IsDecorrelated.supports_mul_complement_mul_eq_zero
         Matrix.zero_mul]
 
 /-- The reverse-order product of the two marginal support projectors through
-the complement of \(P\) also vanishes. -/
+the complement of \(P\) also vanishes.
+
+**Local fix (CPSV16 Appendix D.2):** As in the forward-order theorem, the
+reduced-operator expansion and reciprocal-on-support factorization replace the
+unsupported single-contraction step at source lines 2236--2252. Documented in
+`docs/paper-gaps/cpsv16_decorrelation_slice_expansion_fix.tex`. -/
 theorem IsDecorrelated.reverse_supports_mul_complement_mul_eq_zero
     {P : Matrix (A × (X × B)) (A × (X × B)) ℂ}
     (hPherm : P.IsHermitian) (hdec : IsDecorrelated P) :

--- a/TNLean/MPS/ParentHamiltonian/TripartiteDecorrelation.lean
+++ b/TNLean/MPS/ParentHamiltonian/TripartiteDecorrelation.lean
@@ -672,7 +672,7 @@ theorem range_mul_eq_inter
 /-- Hermitian idempotent matrices with the same range are equal.
 
 This is the uniqueness fact used between arXiv:1606.00608, Appendix D.2,
-Definition D.2, lines 2205--2218, and equation `arrggg`, lines 2259--2277. -/
+Definition D.2, lines 2205--2218, and equation `arrggg`, lines 2279--2289. -/
 theorem hermitian_idempotent_eq_of_range_eq
     {I : Type*} [Fintype I] [DecidableEq I]
     (S T : Matrix I I ℂ)
@@ -713,7 +713,7 @@ def HasGroundSpaceIntersection
 condition is equivalent to the corresponding projector-product identity.
 
 This proves the bridge from arXiv:1606.00608, Appendix D.2, Definition D.2,
-lines 2205--2218, to equation `arrggg`, lines 2259--2277. -/
+lines 2205--2218, to equation `arrggg`, lines 2279--2289. -/
 theorem hasGroundSpaceIntersection_iff_product_eq
     {P : Matrix (A × (X × B)) (A × (X × B)) ℂ}
     {PAX : Matrix (A × X) (A × X) ℂ}
@@ -760,8 +760,10 @@ theorem hasGroundSpaceIntersection_iff_product_eq
 space, written in terms of the local ground-space projectors.
 
 The Hamiltonian terms of arXiv:1606.00608, Appendix D.2, Definition D.2,
-lines 2205--2218, are \(Q_{AX}=1-P_{AX}\) and \(Q_{XB}=1-P_{XB}\).  The final
-field is the literal ground-space intersection condition in that definition. -/
+lines 2205--2218, are \(Q_{AX}=1-P_{AX}\) and \(Q_{XB}=1-P_{XB}\).  The
+ground-space intersection condition
+\(\operatorname{ran}P=\operatorname{ran}P_{AX}\cap\operatorname{ran}P_{XB}\)
+is taken directly from Definition D.2. -/
 structure CommutingParentHamiltonian
     (P : Matrix (A × (X × B)) (A × (X × B)) ℂ) where
   /-- The orthogonal projector onto \(K_{AX}\), as in arXiv:1606.00608,
@@ -792,7 +794,7 @@ structure CommutingParentHamiltonian
 /-- The literal ground-space intersection condition of Definition D.2 gives
 the projector-product identity used in the proof of Proposition D.3.
 
-Source: arXiv:1606.00608, Appendix D.2, lines 2205--2218 and 2259--2277. -/
+Source: arXiv:1606.00608, Appendix D.2, lines 2205--2218 and 2279--2289. -/
 theorem CommutingParentHamiltonian.hproduct
     {P : Matrix (A × (X × B)) (A × (X × B)) ℂ}
     (hparent : CommutingParentHamiltonian P)

--- a/TNLean/MPS/ParentHamiltonian/TripartiteDecorrelation.lean
+++ b/TNLean/MPS/ParentHamiltonian/TripartiteDecorrelation.lean
@@ -87,7 +87,7 @@ private theorem ungroupAX_groupAX (ρ : Matrix (A × (X × B)) (A × (X × B)) �
     ungroupAX (groupAX ρ) = ρ := by
   simp [groupAX, ungroupAX]
 
-/-- Reassociation respects matrix multiplication. -/
+/-- Reassociation preserves matrix multiplication. -/
 private theorem ungroupAX_mul
     (M N : Matrix ((A × X) × B) ((A × X) × B) ℂ) :
     ungroupAX (M * N) = ungroupAX M * ungroupAX N := by
@@ -756,8 +756,8 @@ theorem parentHamiltonian_iff_decorrelated
 
 /-- **Source-facing parent commuting Hamiltonian--decorrelation equivalence.**
 
-For an orthogonal projector (P_{AXB}), there are commuting parent terms on
-(AX) and (XB) with ground projector (P_{AXB}) if and only if the
+For an orthogonal projector \(P_{AXB}\), there are commuting parent terms on
+\(AX\) and \(XB\) with ground projector \(P_{AXB}\) if and only if the
 Hermitian-observable decorrelation condition of arXiv:1606.00608,
 Appendix D.2, Definition D.1, holds.  This is Proposition D.3,
 lines 2221--2289. -/

--- a/TNLean/MPS/ParentHamiltonian/TripartiteDecorrelation.lean
+++ b/TNLean/MPS/ParentHamiltonian/TripartiteDecorrelation.lean
@@ -119,16 +119,19 @@ noncomputable def liftB (M : Matrix B B ℂ) :
   Matrix.rightKroneckerEmbed (m := A)
     (Matrix.rightKroneckerEmbed (m := X) M)
 
-private theorem liftAX_mul (M N : Matrix (A × X) (A × X) ℂ) :
+/-- Lifting from \(AX\) preserves matrix multiplication. -/
+theorem liftAX_mul (M N : Matrix (A × X) (A × X) ℂ) :
     liftAX (B := B) (M * N) = liftAX (B := B) M * liftAX (B := B) N := by
   rw [liftAX, liftAX, liftAX, ← ungroupAX_mul, map_mul]
 
-private theorem liftXB_mul (M N : Matrix (X × B) (X × B) ℂ) :
+/-- Lifting from \(XB\) preserves matrix multiplication. -/
+theorem liftXB_mul (M N : Matrix (X × B) (X × B) ℂ) :
     liftXB (A := A) (M * N) = liftXB (A := A) M * liftXB (A := A) N := by
   exact map_mul (Matrix.rightKroneckerEmbed (m := A) (n := X × B)) M N
 
+/-- The adjoint of an \(AX\) lift is the lift of the adjoint. -/
 @[simp]
-private theorem conjTranspose_liftAX (M : Matrix (A × X) (A × X) ℂ) :
+theorem conjTranspose_liftAX (M : Matrix (A × X) (A × X) ℂ) :
     (liftAX (B := B) M)ᴴ = liftAX (B := B) Mᴴ := by
   ext ⟨a, x, b⟩ ⟨a', x', b'⟩
   by_cases hbb : b = b'
@@ -139,8 +142,9 @@ private theorem conjTranspose_liftAX (M : Matrix (A × X) (A × X) ℂ) :
     simp [liftAX, ungroupAX, Matrix.conjTranspose_apply,
       Matrix.leftKroneckerEmbed_apply, Matrix.kroneckerMap_apply, hbb, hb'b]
 
+/-- The adjoint of an \(XB\) lift is the lift of the adjoint. -/
 @[simp]
-private theorem conjTranspose_liftXB (M : Matrix (X × B) (X × B) ℂ) :
+theorem conjTranspose_liftXB (M : Matrix (X × B) (X × B) ℂ) :
     (liftXB (A := A) M)ᴴ = liftXB (A := A) Mᴴ := by
   change (Matrix.rightKroneckerEmbed (m := A) M)ᴴ =
     Matrix.rightKroneckerEmbed (m := A) Mᴴ
@@ -161,15 +165,17 @@ private theorem liftB_comm_liftAX (OB : Matrix B B ℂ) (M : Matrix (A × X) (A 
     Matrix.kroneckerMap_apply, Matrix.one_apply, Fintype.sum_prod_type,
     mul_comm]
 
+/-- The adjoint of an \(A\) lift is the lift of the adjoint. -/
 @[simp]
-private theorem conjTranspose_liftA (M : Matrix A A ℂ) :
+theorem conjTranspose_liftA (M : Matrix A A ℂ) :
     (liftA (X := X) (B := B) M)ᴴ = liftA (X := X) (B := B) Mᴴ := by
   change (Matrix.leftKroneckerEmbed (n := X × B) M)ᴴ =
     Matrix.leftKroneckerEmbed (n := X × B) Mᴴ
   rw [← star_eq_conjTranspose, ← map_star, star_eq_conjTranspose]
 
+/-- The adjoint of a \(B\) lift is the lift of the adjoint. -/
 @[simp]
-private theorem conjTranspose_liftB (M : Matrix B B ℂ) :
+theorem conjTranspose_liftB (M : Matrix B B ℂ) :
     (liftB (A := A) (X := X) M)ᴴ = liftB (A := A) (X := X) Mᴴ := by
   change (Matrix.rightKroneckerEmbed (m := A)
       (Matrix.rightKroneckerEmbed (m := X) M))ᴴ =
@@ -450,8 +456,8 @@ theorem IsDecorrelated.reverse_marginals_mul_complement_mul_eq_zero
       rw [hdec.reverse hPherm (Matrix.single l b 1) (Matrix.single a k 1),
         Matrix.mul_zero, Matrix.zero_mul]
 
-/-- The support projector of a Hermitian matrix also factors through the
-matrix on the left. -/
+/-- The support projector of a Hermitian matrix \(M\) factors as \(M g(M)\), where
+\(g(0)=0\) and \(g(x)=x^{-1}\) for \(x\ne0\). -/
 private theorem supportProj_eq_mul_cfc_recip
     {ι : Type*} [Fintype ι] [DecidableEq ι] {M : Matrix ι ι ℂ}
     (hM : M.IsHermitian) :

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
@@ -200,18 +200,54 @@ $(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
     space by tensoring with identities on their complementary factors.
 \end{definition}
 
-\begin{definition}[Tripartite decorrelation]
-    \label{def:tripartite_decorrelation}
-    \lean{TripartiteDecorrelation.IsDecorrelated}
+\begin{definition}[Tripartite observable decorrelation]
+    \label{def:tripartite_observable_decorrelation}
+    \lean{TripartiteDecorrelation.IsObservableDecorrelated}
     \leanok
     \uses{def:tripartite_local_lifts}
-    Regions $A$ and $B$ are decorrelated relative to $P$ if, for all operators
-    $O_A$ and $O_B$,
+    Regions $A$ and $B$ are decorrelated relative to $P$ if, for all Hermitian
+    observables $O_A=O_A^\dagger$ and $O_B=O_B^\dagger$,
     \[
         P O_A(\mathbf 1-P)O_B P=0.
     \]
     This is \cite[Definition~D.1, lines 2187--2191]{Cirac2016MPDO_arXiv}.
 \end{definition}
+
+\begin{definition}[Complex-linear extension of decorrelation]
+    \label{def:tripartite_decorrelation}
+    \lean{TripartiteDecorrelation.IsDecorrelated}
+    \leanok
+    \uses{def:tripartite_local_lifts}
+    The complex-linear extension requires
+    \[
+        P O_A(\mathbf 1-P)O_B P=0
+    \]
+    for arbitrary complex matrices $O_A$ and $O_B$.
+\end{definition}
+
+\begin{theorem}[Observable and complex-linear decorrelation are equivalent]
+    \label{thm:tripartite_observable_decorrelation_iff}
+    \lean{TripartiteDecorrelation.isObservableDecorrelated_iff}
+    \leanok
+    \uses{def:tripartite_observable_decorrelation,
+      def:tripartite_decorrelation}
+    Observable decorrelation holds if and only if its complex-linear extension
+    holds.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Every complex matrix has the decomposition
+    \[
+        O=H+\mathrm{i}K,
+        \qquad
+        H=\frac{O+O^\dagger}{2},
+        \qquad
+        K=\frac{O-O^\dagger}{2\mathrm{i}},
+    \]
+    where $H=H^\dagger$ and $K=K^\dagger$.  Expand the decorrelation
+    expression in both observables; its four Hermitian pairs vanish.
+\end{proof}
 
 \begin{theorem}[Reverse order of decorrelation]
     \label{thm:tripartite_decorrelation_reverse}
@@ -265,27 +301,41 @@ $(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
     partial trace.
 \end{proof}
 
-\begin{theorem}[Decorrelation for the two reduced operators]
+\begin{theorem}[Decorrelation for the reduced operators]
     \label{thm:tripartite_marginal_complementary_product_zero}
-    \lean{TripartiteDecorrelation.IsDecorrelated.marginals_mul_complement_mul_eq_zero,
-      TripartiteDecorrelation.IsDecorrelated.reverse_marginals_mul_complement_mul_eq_zero}
+    \lean{TripartiteDecorrelation.IsDecorrelated.marginals_mul_complement_mul_eq_zero}
     \leanok
     \uses{def:tripartite_decorrelation,
-      thm:tripartite_decorrelation_reverse,
       thm:tripartite_marginal_matrix_units}
-    If $P=P^\dagger$ and $A,B$ are decorrelated, then
+    If $A,B$ are decorrelated, then
     \[
         \rho_{XB}(\mathbf 1-P)\rho_{AX}=0,
-        \qquad
-        \rho_{AX}(\mathbf 1-P)\rho_{XB}=0,
     \]
     where each reduced operator is lifted to the tripartite space.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    Substitute the matrix-unit expansions.  Every summand contains one of the
-    two decorrelation products and is therefore zero.
+    Substitute the matrix-unit expansions.  Every summand contains a
+    decorrelation product and is therefore zero.
+\end{proof}
+
+\begin{theorem}[Reverse reduced-operator decorrelation]
+    \label{thm:tripartite_reverse_marginal_complementary_product_zero}
+    \lean{TripartiteDecorrelation.IsDecorrelated.reverse_marginals_mul_complement_mul_eq_zero}
+    \leanok
+    \uses{thm:tripartite_decorrelation_reverse,
+      thm:tripartite_marginal_matrix_units}
+    If $P=P^\dagger$ and $A,B$ are decorrelated, then
+    \[
+        \rho_{AX}(\mathbf 1-P)\rho_{XB}=0.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Substitute the matrix-unit expansions and use reverse-order
+    decorrelation in every summand.
 \end{proof}
 
 \begin{definition}[Tripartite marginal support projectors]
@@ -304,8 +354,9 @@ $(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
       TripartiteDecorrelation.IsDecorrelated.reverse_supports_mul_complement_mul_eq_zero}
     \leanok
     \uses{def:tripartite_marginal_supports,
-      thm:tripartite_marginal_complementary_product_zero}
-    Under the same assumptions,
+      thm:tripartite_marginal_complementary_product_zero,
+      thm:tripartite_reverse_marginal_complementary_product_zero}
+    If $P=P^\dagger$ and $A,B$ are decorrelated, then
     \[
         P_{XB}(\mathbf 1-P)P_{AX}=0,
         \qquad
@@ -321,8 +372,22 @@ $(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
         \qquad
         P_{XB}=g(\rho_{XB})\rho_{XB}=\rho_{XB}g(\rho_{XB}).
     \]
-    Multiply the two reduced-operator identities by the appropriate outer
-    factors.
+    Hence
+    \[
+        P_{XB}(\mathbf 1-P)P_{AX}
+        =g(\rho_{XB})
+          \bigl[\rho_{XB}(\mathbf 1-P)\rho_{AX}\bigr]
+          g(\rho_{AX})
+        =0,
+    \]
+    and, in the reverse order,
+    \[
+        P_{AX}(\mathbf 1-P)P_{XB}
+        =g(\rho_{AX})
+          \bigl[\rho_{AX}(\mathbf 1-P)\rho_{XB}\bigr]
+          g(\rho_{XB})
+        =0.
+    \]
     % Local fix for source lines 2236--2252: see
     % docs/paper-gaps/cpsv16_decorrelation_slice_expansion_fix.tex.
 \end{proof}
@@ -405,8 +470,8 @@ $(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
     ground space of their sum is the range of $P$.
 \end{definition}
 
-\begin{theorem}[Parent commuting Hamiltonian--decorrelation equivalence]
-    \label{thm:tripartite_parent_iff_decorrelated}
+\begin{theorem}[Parent commuting Hamiltonian--complex-linear decorrelation equivalence]
+    \label{thm:tripartite_parent_iff_complex_linear_decorrelated}
     \lean{TripartiteDecorrelation.CommutingParentHamiltonian.isDecorrelated,
       TripartiteDecorrelation.IsDecorrelated.hasCommutingParentHamiltonian,
       TripartiteDecorrelation.parentHamiltonian_iff_decorrelated}
@@ -416,23 +481,52 @@ $(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
       thm:tripartite_support_products}
     Let $P=P^\dagger=P^2$.  Then $P$ is the ground-space projector of a
     parent commuting Hamiltonian on $AX$ and $XB$ if and only if regions
-    $A$ and $B$ are decorrelated.
+    $A$ and $B$ satisfy complex-linear decorrelation.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Starting from decorrelation, take the support projectors of
+    $\rho_{AX}$ and $\rho_{XB}$.  The preceding product theorem proves their
+    commutation and identifies their product with $P$.
+
+    Starting from commuting parent projectors, write
+    $P=P_{AX}P_{XB}=P_{XB}P_{AX}$.  Locality gives
+    $[O_A,P_{XB}]=[O_B,P_{AX}]=0$, while
+    \[
+        P_{XB}(\mathbf 1-P)P_{AX}=0.
+    \]
+    Therefore, using the two locality commutators,
+    \[
+    \begin{aligned}
+        P O_A(\mathbf 1-P)O_B P
+        &=(P_{AX}P_{XB})O_A(\mathbf 1-P)O_B(P_{AX}P_{XB})\\
+        &=P_{AX}O_A
+          \bigl[P_{XB}(\mathbf 1-P)P_{AX}\bigr]
+          O_B P_{XB}\\
+        &=0.
+    \end{aligned}
+    \]
+\end{proof}
+
+\begin{theorem}[Parent commuting Hamiltonian--observable decorrelation equivalence]
+    \label{thm:tripartite_parent_iff_decorrelated}
+    \lean{TripartiteDecorrelation.parentHamiltonian_iff_observableDecorrelated}
+    \leanok
+    \uses{def:tripartite_observable_decorrelation,
+      thm:tripartite_observable_decorrelation_iff,
+      thm:tripartite_parent_iff_complex_linear_decorrelated}
+    Let $P=P^\dagger=P^2$.  Then $P$ is the ground-space projector of a
+    parent commuting Hamiltonian on $AX$ and $XB$ if and only if regions
+    $A$ and $B$ are decorrelated when tested on Hermitian observables.
     This is \cite[Proposition~D.3, lines 2221--2289]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    For the forward implication, take the support projectors of
-    $\rho_{AX}$ and $\rho_{XB}$.  The preceding product theorem proves their
-    commutation and identifies their product with $P$.
-
-    Conversely, write $P=P_{AX}P_{XB}=P_{XB}P_{AX}$.  Locality gives
-    $[O_A,P_{XB}]=[O_B,P_{AX}]=0$, while
-    \[
-        P_{XB}(\mathbf 1-P)P_{AX}=0.
-    \]
-    Moving the two observables past the projectors therefore gives
-    $P O_A(\mathbf 1-P)O_B P=0$.
+    Combine the complex-linear parent equivalence with the decomposition
+    $O=H+\mathrm{i}K$ from
+    Theorem~\ref{thm:tripartite_observable_decorrelation_iff}.
 \end{proof}
 
 \begin{definition}[Decorrelation]\label{def:is_decorrelated}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
@@ -477,20 +477,56 @@ $(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
 
 \begin{definition}[Parent commuting Hamiltonian on the tripartite space]
     \label{def:tripartite_parent_commuting_hamiltonian}
-    \lean{TripartiteDecorrelation.CommutingParentHamiltonian,
+    \lean{TripartiteDecorrelation.HasGroundSpaceIntersection,
+      TripartiteDecorrelation.CommutingParentHamiltonian,
       TripartiteDecorrelation.HasCommutingParentHamiltonian}
     \leanok
     \uses{def:tripartite_local_lifts}
     There are orthogonal projectors $P_{AX}$ and $P_{XB}$ on the two local
-    factors whose lifts commute and satisfy
+    factors whose lifts commute and whose ranges satisfy the source
+    ground-space intersection condition
     \[
+        \operatorname{ran}P
+        =\operatorname{ran}P_{AX}\cap\operatorname{ran}P_{XB}.
+    \]
+    Thus $Q_{AX}=\mathbf 1-P_{AX}$ and
+    $Q_{XB}=\mathbf 1-P_{XB}$ are exactly the commuting parent terms of
+    \cite[Definition~D.2, lines 2205--2218]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{theorem}[Ground-space intersection and projector product]
+    \label{thm:tripartite_ground_space_intersection_iff_product}
+    \lean{TripartiteDecorrelation.range_mul_eq_inter,
+      TripartiteDecorrelation.hermitian_idempotent_eq_of_range_eq,
+      TripartiteDecorrelation.hasGroundSpaceIntersection_iff_product_eq,
+      TripartiteDecorrelation.CommutingParentHamiltonian.hproduct}
+    \leanok
+    \uses{def:tripartite_parent_commuting_hamiltonian}
+    Let $P$, $P_{AX}$, and $P_{XB}$ be orthogonal projectors, and suppose that
+    $P_{AX}$ and $P_{XB}$ commute.  Then
+    \[
+        \operatorname{ran}P
+        =\operatorname{ran}P_{AX}\cap\operatorname{ran}P_{XB}
+        \quad\Longleftrightarrow\quad
         P_{AX}P_{XB}=P.
     \]
-    Equivalently, $Q_{AX}=\mathbf 1-P_{AX}$ and
-    $Q_{XB}=\mathbf 1-P_{XB}$ are the commuting parent terms of
-    \cite[Definition~D.2, lines 2205--2218]{Cirac2016MPDO_arXiv}, and the
-    ground space of their sum is the range of $P$.
-\end{definition}
+    This is the passage from
+    \cite[Definition~D.2, lines 2205--2218]{Cirac2016MPDO_arXiv} to the
+    projector identity used at lines 2259--2277.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    A vector lies in the range of $P_{AX}P_{XB}$ precisely when it is fixed by
+    both commuting idempotents.  Hence
+    \[
+        \operatorname{ran}(P_{AX}P_{XB})
+        =\operatorname{ran}P_{AX}\cap\operatorname{ran}P_{XB}.
+    \]
+    The product is again an orthogonal projector.  Orthogonal projectors with
+    equal ranges are equal, giving the forward implication; the reverse
+    implication follows by substituting the product identity.
+\end{proof}
 
 \begin{theorem}[Parent commuting Hamiltonian--complex-linear decorrelation equivalence]
     \label{thm:tripartite_parent_iff_complex_linear_decorrelated}
@@ -500,7 +536,8 @@ $(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
     \leanok
     \uses{def:tripartite_decorrelation,
       def:tripartite_parent_commuting_hamiltonian,
-      thm:tripartite_support_products}
+      thm:tripartite_support_products,
+      thm:tripartite_ground_space_intersection_iff_product}
     Let $P=P^\dagger=P^2$.  Then $P$ is the ground-space projector of a
     parent commuting Hamiltonian on $AX$ and $XB$ if and only if regions
     $A$ and $B$ satisfy complex-linear decorrelation.
@@ -512,7 +549,8 @@ $(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
     $\rho_{AX}$ and $\rho_{XB}$.  The preceding product theorem proves their
     commutation and identifies their product with $P$.
 
-    Starting from commuting parent projectors, write
+    Starting from commuting parent projectors, first use the ground-space
+    intersection theorem to write
     $P=P_{AX}P_{XB}=P_{XB}P_{AX}$.  Locality gives
     $[O_A,P_{XB}]=[O_B,P_{AX}]=0$, while
     \[

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
@@ -37,10 +37,12 @@ fixes the original operator.  These are the support-projector identities used in
 
 \begin{proof}
     \leanok
-    In product-basis coordinates, the diagonal entry contributed by each
-    right basis vector is one, while every off-diagonal entry vanishes.
-    Summing over the right basis therefore gives
-    $(\dim H_R)\mathbf 1_L$.
+    In product-basis coordinates,
+    \[
+        \bigl(\operatorname{tr}_R\mathbf 1_{L\otimes R}\bigr)_{ij}
+        =\sum_k\delta_{ij}
+        =(\dim H_R)\delta_{ij}.
+    \]
 \end{proof}
 
 \begin{lemma}[Adjoint identity for the right partial trace]
@@ -137,8 +139,13 @@ fixes the original operator.  These are the support-projector identities used in
 
 \begin{proof}
     \leanok
-    Take complex conjugates entrywise and use Hermiticity of $\rho$ inside
-    the finite sum.
+    Entrywise Hermiticity gives
+    \[
+        \overline{(\operatorname{tr}_L\rho)_{r,s}}
+        =\sum_k\overline{\rho_{(k,r),(k,s)}}
+        =\sum_k\rho_{(k,s),(k,r)}
+        =(\operatorname{tr}_L\rho)_{s,r}.
+    \]
 \end{proof}
 
 \begin{theorem}[Positivity of the left partial trace]
@@ -443,7 +450,7 @@ $(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
     \lean{TripartiteDecorrelation.supportAX, TripartiteDecorrelation.supportXB}
     \leanok
     \uses{def:partial_trace_left}
-    Let $P_{AX}$ and $P_{XB}$ be the support projectors of
+    For a Hermitian operator $P$, let $P_{AX}$ and $P_{XB}$ be the support projectors of
     $\operatorname{tr}_B P$ and $\operatorname{tr}_A P$, respectively, as in
     \cite[Appendix~D.2, lines 2225--2229]{Cirac2016MPDO_arXiv}.
 \end{definition}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
@@ -244,8 +244,17 @@ $(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
     \lean{TripartiteDecorrelation.liftAX, TripartiteDecorrelation.liftXB,
       TripartiteDecorrelation.liftA, TripartiteDecorrelation.liftB}
     \leanok
-    Operators on $AX$, $XB$, $A$, and $B$ are lifted to the full tripartite
-    space by tensoring with identities on their complementary factors.
+    Writing $\widehat M_R$ for the lift of an operator $M_R$ supported on
+    $R\in\{AX,XB,A,B\}$, the four lifts to
+    $H_A\otimes(H_X\otimes H_B)$ are
+    \begin{align*}
+        \widehat M_{AX} &= M_{AX}\otimes\mathbf 1_B,
+        & \widehat M_{XB} &= \mathbf 1_A\otimes M_{XB},\\
+        \widehat M_A &= M_A\otimes\mathbf 1_{XB},
+        & \widehat M_B &= \mathbf 1_{AX}\otimes M_B.
+    \end{align*}
+    The first and fourth formulas use the canonical identification
+    $(H_A\otimes H_X)\otimes H_B\cong H_A\otimes(H_X\otimes H_B)$.
 \end{definition}
 
 \begin{lemma}[Products and adjoints of tripartite lifts]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
@@ -520,7 +520,7 @@ $(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
     \]
     This is the passage from
     \cite[Definition~D.2, lines 2205--2218]{Cirac2016MPDO_arXiv} to the
-    projector identity used at lines 2259--2277.
+    projector identity at lines 2279--2289.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
@@ -35,6 +35,14 @@ fixes the original operator.  These are the support-projector identities used in
     \]
 \end{lemma}
 
+\begin{proof}
+    \leanok
+    In product-basis coordinates, the diagonal entry contributed by each
+    right basis vector is one, while every off-diagonal entry vanishes.
+    Summing over the right basis therefore gives
+    $(\dim H_R)\mathbf 1_L$.
+\end{proof}
+
 \begin{lemma}[Adjoint identity for the right partial trace]
     \label{lem:trace_lift_left_factor_mul}
     \lean{Matrix.trace_leftKroneckerEmbed_mul}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
@@ -586,9 +586,17 @@ $(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
 
 \begin{proof}
     \leanok
-    Insert $\mathbf 1=P+(\mathbf 1-P)$ between the two support projectors.
-    The complementary term vanishes by decorrelation, while absorption gives
-    $P_{XB}PP_{AX}=P$ and $P_{AX}PP_{XB}=P$.
+    Inserting $\mathbf 1=P+(\mathbf 1-P)$ between the two support projectors
+    gives
+    \[
+        P_{XB}P_{AX}
+        =P_{XB}PP_{AX}+P_{XB}(\mathbf 1-P)P_{AX}
+        =P+0
+        =P.
+    \]
+    Here the second equality uses the support-absorption identities and
+    Theorem~\ref{thm:tripartite_complementary_product_zero}.  The same
+    calculation with the two factors reversed gives $P_{AX}P_{XB}=P$.
 \end{proof}
 
 \begin{definition}[Parent commuting Hamiltonian on the tripartite space]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
@@ -24,6 +24,17 @@ support projector of the retained left marginal, lifted to the full space,
 fixes the original operator.  These are the support-projector identities used in
 \cite[Appendix~D.2, lines 2225--2235]{Cirac2016MPDO_arXiv}.
 
+\begin{lemma}[Partial trace of the identity]
+    \label{lem:partial_trace_right_identity}
+    \lean{Matrix.partialTraceRight_one}
+    \leanok
+    For finite-dimensional spaces $H_L$ and $H_R$,
+    \[
+        \operatorname{tr}_R(\mathbf 1_{L\otimes R})
+        =(\dim H_R)\mathbf 1_L.
+    \]
+\end{lemma}
+
 \begin{lemma}[Adjoint identity for the right partial trace]
     \label{lem:trace_lift_left_factor_mul}
     \lean{Matrix.trace_leftKroneckerEmbed_mul}
@@ -159,7 +170,8 @@ fixes the original operator.  These are the support-projector identities used in
     \lean{Matrix.PosSemidef.rightKroneckerEmbed_supportProj_mul_self}
     \leanok
     \uses{thm:partial_trace_left_pos,lem:trace_lift_right_factor_mul}
-    If $P_R$ is the support projector of $\operatorname{tr}_L\rho$, then
+    Let $\rho$ be positive semidefinite.  If $P_R$ is the support projector of
+    $\operatorname{tr}_L\rho$, then
     \[
         (\mathbf 1_L\otimes P_R)\rho=\rho.
     \]
@@ -316,8 +328,13 @@ $(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
 
 \begin{proof}
     \leanok
-    Substitute the matrix-unit expansions.  Every summand contains a
-    decorrelation product and is therefore zero.
+    Substitute the matrix-unit expansions.  Every summand has the form
+    \[
+        E^A_{ak}PE^A_{ka}(\mathbf 1-P)E^B_{bl}PE^B_{lb}
+        =E^A_{ak}\bigl[PE^A_{ka}(\mathbf 1-P)E^B_{bl}P\bigr]E^B_{lb}
+        =0,
+    \]
+    where the bracketed factor vanishes by decorrelation.
 \end{proof}
 
 \begin{theorem}[Reverse reduced-operator decorrelation]
@@ -334,8 +351,13 @@ $(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
 
 \begin{proof}
     \leanok
-    Substitute the matrix-unit expansions and use reverse-order
-    decorrelation in every summand.
+    Substitute the matrix-unit expansions.  Every summand has the form
+    \[
+        E^B_{bl}PE^B_{lb}(\mathbf 1-P)E^A_{ak}PE^A_{ka}
+        =E^B_{bl}\bigl[PE^B_{lb}(\mathbf 1-P)E^A_{ak}P\bigr]E^A_{ka}
+        =0,
+    \]
+    where the bracketed factor vanishes by reverse-order decorrelation.
 \end{proof}
 
 \begin{definition}[Tripartite marginal support projectors]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
@@ -138,13 +138,21 @@ fixes the original operator.  These are the support-projector identities used in
     \lean{Matrix.PosSemidef.partialTraceLeft}
     \leanok
     \uses{def:partial_trace_left}
-    If $\rho\geq 0$, then $\operatorname{tr}_L\rho\geq 0$.
+    For finite-dimensional $H_L$ and $H_R$, if $\rho\geq 0$, then
+    $\operatorname{tr}_L\rho\geq 0$.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    The partial trace is the sum, over a basis of $H_L$, of positive
-    semidefinite principal submatrices of $\rho$.
+    If $\rho^{(k)}$ is the principal submatrix indexed by
+    $\{k\}\times H_R$, then
+    \[
+        (\operatorname{tr}_L\rho)_{r,s}
+        =\sum_k\rho_{(k,r),(k,s)}
+        =\sum_k\rho^{(k)}_{r,s}.
+    \]
+    Each $\rho^{(k)}$ is positive semidefinite, and hence so is their finite
+    sum.
 \end{proof}
 
 \begin{lemma}[Adjoint identity for the left partial trace]
@@ -300,8 +308,17 @@ $(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
         \qquad
         K=\frac{O-O^\dagger}{2\mathrm{i}},
     \]
-    where $H=H^\dagger$ and $K=K^\dagger$.  Expand the decorrelation
-    expression in both observables; its four Hermitian pairs vanish.
+    where $H=H^\dagger$ and $K=K^\dagger$.  For analogous decompositions
+    $O=H+\mathrm{i}K$ and $O'=H'+\mathrm{i}K'$,
+    \begin{align*}
+        P O(\mathbf 1-P)O'P
+        &=P H(\mathbf 1-P)H'P
+          +\mathrm{i}P H(\mathbf 1-P)K'P\\
+        &\quad+\mathrm{i}P K(\mathbf 1-P)H'P
+          -P K(\mathbf 1-P)K'P.
+    \end{align*}
+    Each summand vanishes by observable decorrelation applied to its two
+    Hermitian components.
 \end{proof}
 
 \begin{theorem}[Reverse order of decorrelation]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
@@ -219,6 +219,36 @@ $(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
     space by tensoring with identities on their complementary factors.
 \end{definition}
 
+\begin{lemma}[Products and adjoints of tripartite lifts]
+    \label{lem:tripartite_local_lift_algebra}
+    \lean{TripartiteDecorrelation.liftAX_mul,
+      TripartiteDecorrelation.liftXB_mul,
+      TripartiteDecorrelation.conjTranspose_liftAX,
+      TripartiteDecorrelation.conjTranspose_liftXB,
+      TripartiteDecorrelation.conjTranspose_liftA,
+      TripartiteDecorrelation.conjTranspose_liftB}
+    \leanok
+    \uses{def:tripartite_local_lifts}
+    The lifts from $AX$ and $XB$ preserve multiplication,
+    \[
+        \widehat{MN}_{AX}=\widehat M_{AX}\widehat N_{AX},
+        \qquad
+        \widehat{MN}_{XB}=\widehat M_{XB}\widehat N_{XB},
+    \]
+    and each of the four lifts from $AX$, $XB$, $A$, and $B$ preserves
+    adjoints:
+    \[
+        (\widehat M_R)^\dagger=\widehat{M^\dagger}_R,
+        \qquad R\in\{AX,XB,A,B\}.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Each lift tensors the given operator with identities on the complementary
+    factors. Tensoring with identities preserves products and adjoints.
+\end{proof}
+
 \begin{definition}[Tripartite observable decorrelation]
     \label{def:tripartite_observable_decorrelation}
     \lean{TripartiteDecorrelation.IsObservableDecorrelated}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
@@ -179,8 +179,15 @@ fixes the original operator.  These are the support-projector identities used in
 
 \begin{proof}
     \leanok
-    Apply the preceding trace identity to $\mathbf 1_R-P_R$.  Its lift has
-    zero expectation against $\rho$, hence annihilates $\rho$ by positivity.
+    Set $Q=\mathbf 1_R-P_R$.  The preceding trace identity gives
+    \[
+        \operatorname{tr}\bigl((\mathbf 1_L\otimes Q)\rho\bigr)
+        =\operatorname{tr}\bigl(Q\operatorname{tr}_L\rho\bigr)=0,
+    \]
+    since $P_R$ is the support projector of $\operatorname{tr}_L\rho$.
+    Positivity of $\rho$ then gives
+    $(\mathbf 1_L\otimes Q)\rho=0$, and hence
+    $(\mathbf 1_L\otimes P_R)\rho=\rho$.
 \end{proof}
 
 \begin{theorem}[Right absorption by the right marginal support]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
@@ -4,14 +4,16 @@
 This section develops the idempotent-product formulation used for the
 decorrelation implication from Appendix~D. It is not the full source condition.
 In \cite[Appendix~D.2]{Cirac2016MPDO_arXiv}, the parent commuting Hamiltonian
-condition is stated for local projectors $Q_{AX}$ and $Q_{XB}$ with
+condition is stated for local projectors $Q_{AX}$ and $Q_{XB}$.  Writing hats
+for their lifts to the tripartite space, the condition is
 \[
-    [Q_{AX},Q_{XB}]=0,\qquad
+    [\widehat Q_{AX},\widehat Q_{XB}]=0,\qquad
     K_{AXB}=(K_{AX}\otimes H_B)\cap(H_A\otimes K_{XB}).
 \]
 Writing $P_{AX}=1-Q_{AX}$ and $P_{XB}=1-Q_{XB}$ gives, for the idempotent
-$P_K$ used below, the identity $P_{AX}P_{XB}=P_K$. The following definition
-records this idempotent-product consequence, not the tensor-product locality,
+$P_K$ used below, the full-space identity
+$\widehat P_{AX}\widehat P_{XB}=P_K$. The following definition records this
+idempotent-product consequence abstractly, not the tensor-product locality,
 orthogonal-projector, or ground-space-intersection hypotheses of Appendix~D.2.
 % Scope restriction: this section keeps the idempotent-product consequence
 % and not the tensor-product locality or orthogonal-projector hypotheses of the
@@ -437,9 +439,8 @@ $(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
       thm:tripartite_marginal_matrix_units}
     If $A,B$ are decorrelated, then
     \[
-        \rho_{XB}(\mathbf 1-P)\rho_{AX}=0,
+        \widehat\rho_{XB}(\mathbf 1-P)\widehat\rho_{AX}=0.
     \]
-    where each reduced operator is lifted to the tripartite space.
 \end{theorem}
 
 \begin{proof}
@@ -461,7 +462,7 @@ $(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
       thm:tripartite_marginal_matrix_units}
     If $P=P^\dagger$ and $A,B$ are decorrelated, then
     \[
-        \rho_{AX}(\mathbf 1-P)\rho_{XB}=0.
+        \widehat\rho_{AX}(\mathbf 1-P)\widehat\rho_{XB}=0.
     \]
 \end{theorem}
 
@@ -483,7 +484,9 @@ $(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
     \uses{def:partial_trace_left}
     For a Hermitian operator $P$, let $P_{AX}$ and $P_{XB}$ be the support projectors of
     $\operatorname{tr}_B P$ and $\operatorname{tr}_A P$, respectively, as in
-    \cite[Appendix~D.2, lines 2225--2229]{Cirac2016MPDO_arXiv}.
+    \cite[Appendix~D.2, lines 2225--2229]{Cirac2016MPDO_arXiv}.  Write
+    $\widehat P_{AX}$ and $\widehat P_{XB}$ for their lifts to the tripartite
+    space.
 \end{definition}
 
 \begin{theorem}[Decorrelation for the two marginal supports]
@@ -496,9 +499,9 @@ $(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
       thm:tripartite_reverse_marginal_complementary_product_zero}
     If $P=P^\dagger$ and $A,B$ are decorrelated, then
     \[
-        P_{XB}(\mathbf 1-P)P_{AX}=0,
+        \widehat P_{XB}(\mathbf 1-P)\widehat P_{AX}=0,
         \qquad
-        P_{AX}(\mathbf 1-P)P_{XB}=0.
+        \widehat P_{AX}(\mathbf 1-P)\widehat P_{XB}=0.
     \]
 \end{theorem}
 
@@ -512,18 +515,18 @@ $(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
     \]
     Hence
     \[
-        P_{XB}(\mathbf 1-P)P_{AX}
-        =g(\rho_{XB})
-          \bigl[\rho_{XB}(\mathbf 1-P)\rho_{AX}\bigr]
-          g(\rho_{AX})
+        \widehat P_{XB}(\mathbf 1-P)\widehat P_{AX}
+        =\widehat{g(\rho_{XB})}
+          \bigl[\widehat\rho_{XB}(\mathbf 1-P)\widehat\rho_{AX}\bigr]
+          \widehat{g(\rho_{AX})}
         =0,
     \]
     and, in the reverse order,
     \[
-        P_{AX}(\mathbf 1-P)P_{XB}
-        =g(\rho_{AX})
-          \bigl[\rho_{AX}(\mathbf 1-P)\rho_{XB}\bigr]
-          g(\rho_{XB})
+        \widehat P_{AX}(\mathbf 1-P)\widehat P_{XB}
+        =\widehat{g(\rho_{AX})}
+          \bigl[\widehat\rho_{AX}(\mathbf 1-P)\widehat\rho_{XB}\bigr]
+          \widehat{g(\rho_{XB})}
         =0.
     \]
     % Local fix for source lines 2236--2252: see
@@ -540,7 +543,7 @@ $(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
       thm:right_marginal_support_right_absorption}
     For $P\geq0$,
     \[
-        P_{XB}P=P=PP_{XB}.
+        \widehat P_{XB}P=P=P\widehat P_{XB}.
     \]
 \end{theorem}
 
@@ -564,7 +567,7 @@ $(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
       thm:marginal_support_right_absorption}
     For $P\geq0$,
     \[
-        P_{AX}P=P=PP_{AX}.
+        \widehat P_{AX}P=P=P\widehat P_{AX}.
     \]
 \end{theorem}
 
@@ -589,7 +592,9 @@ $(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
       thm:tripartite_complementary_product_zero}
     If $P=P^\dagger=P^2$ and $A$ and $B$ are decorrelated relative to $P$, then
     \[
-        P_{XB}P_{AX}=P=P_{AX}P_{XB}.
+        \widehat P_{XB}\widehat P_{AX}
+        =P
+        =\widehat P_{AX}\widehat P_{XB}.
     \]
 \end{theorem}
 
@@ -598,14 +603,16 @@ $(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
     Inserting $\mathbf 1=P+(\mathbf 1-P)$ between the two support projectors
     gives
     \[
-        P_{XB}P_{AX}
-        =P_{XB}PP_{AX}+P_{XB}(\mathbf 1-P)P_{AX}
+        \widehat P_{XB}\widehat P_{AX}
+        =\widehat P_{XB}P\widehat P_{AX}
+          +\widehat P_{XB}(\mathbf 1-P)\widehat P_{AX}
         =P+0
         =P.
     \]
     Here the second equality uses the support-absorption identities and
     Theorem~\ref{thm:tripartite_complementary_product_zero}.  The same
-    calculation with the two factors reversed gives $P_{AX}P_{XB}=P$.
+    calculation with the two factors reversed gives
+    $\widehat P_{AX}\widehat P_{XB}=P$.
 \end{proof}
 
 \begin{definition}[Parent commuting Hamiltonian on the tripartite space]
@@ -620,7 +627,8 @@ $(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
     ground-space intersection condition
     \[
         \operatorname{ran}P
-        =\operatorname{ran}P_{AX}\cap\operatorname{ran}P_{XB}.
+        =\operatorname{ran}\widehat P_{AX}
+          \cap\operatorname{ran}\widehat P_{XB}.
     \]
     Thus $Q_{AX}=\mathbf 1-P_{AX}$ and
     $Q_{XB}=\mathbf 1-P_{XB}$ are exactly the commuting parent terms of
@@ -698,19 +706,21 @@ $(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
 
     Starting from commuting parent projectors, first use the ground-space
     intersection theorem to write
-    $P=P_{AX}P_{XB}=P_{XB}P_{AX}$.  Locality gives
-    $[O_A,P_{XB}]=[O_B,P_{AX}]=0$, while
+    $P=\widehat P_{AX}\widehat P_{XB}
+      =\widehat P_{XB}\widehat P_{AX}$.  Locality gives
+    $[O_A,\widehat P_{XB}]=[O_B,\widehat P_{AX}]=0$, while
     \[
-        P_{XB}(\mathbf 1-P)P_{AX}=0.
+        \widehat P_{XB}(\mathbf 1-P)\widehat P_{AX}=0.
     \]
     Therefore, using the two locality commutators,
     \[
     \begin{aligned}
         P O_A(\mathbf 1-P)O_B P
-        &=(P_{AX}P_{XB})O_A(\mathbf 1-P)O_B(P_{AX}P_{XB})\\
-        &=P_{AX}O_A
-          \bigl[P_{XB}(\mathbf 1-P)P_{AX}\bigr]
-          O_B P_{XB}\\
+        &=(\widehat P_{AX}\widehat P_{XB})O_A(\mathbf 1-P)O_B
+          (\widehat P_{AX}\widehat P_{XB})\\
+        &=\widehat P_{AX}O_A
+          \bigl[\widehat P_{XB}(\mathbf 1-P)\widehat P_{AX}\bigr]
+          O_B\widehat P_{XB}\\
         &=0.
     \end{aligned}
     \]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
@@ -274,8 +274,30 @@ $(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
 
 \begin{proof}
     \leanok
-    Each lift tensors the given operator with identities on the complementary
-    factors. Tensoring with identities preserves products and adjoints.
+    For the two-factor lifts,
+    \[
+        (M_{AX}\otimes\mathbf 1_B)(N_{AX}\otimes\mathbf 1_B)
+        =(M_{AX}N_{AX})\otimes\mathbf 1_B,
+        \qquad
+        (\mathbf 1_A\otimes M_{XB})(\mathbf 1_A\otimes N_{XB})
+        =\mathbf 1_A\otimes(M_{XB}N_{XB}).
+    \]
+    \[
+        (M_{AX}\otimes\mathbf 1_B)^\dagger
+          =M_{AX}^\dagger\otimes\mathbf 1_B,
+        \qquad
+        (\mathbf 1_A\otimes M_{XB})^\dagger
+          =\mathbf 1_A\otimes M_{XB}^\dagger,
+    \]
+    and similarly
+    \[
+        (M_A\otimes\mathbf 1_{XB})^\dagger
+          =M_A^\dagger\otimes\mathbf 1_{XB},
+        \qquad
+        (\mathbf 1_{AX}\otimes M_B)^\dagger
+          =\mathbf 1_{AX}\otimes M_B^\dagger,
+    \]
+    with the tensor factors reassociated to the tripartite space.
 \end{proof}
 
 \begin{definition}[Tripartite observable decorrelation]
@@ -341,8 +363,8 @@ $(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
     \lean{TripartiteDecorrelation.IsDecorrelated.reverse}
     \leanok
     \uses{def:tripartite_decorrelation}
-    If $P=P^\dagger$ and $A$ and $B$ are decorrelated, then, for all
-    observables $O_A$ and $O_B$,
+    If $P=P^\dagger$ and $A$ and $B$ are decorrelated, then, for arbitrary
+    complex matrices $O_A$ and $O_B$,
     \[
         P O_B(\mathbf 1-P)O_A P=0.
     \]
@@ -515,8 +537,12 @@ $(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
 
 \begin{proof}
     \leanok
-    Apply the two right-marginal support absorption identities to the
-    bipartition $A|XB$.
+    For the bipartition $A|XB$, the two support-absorption identities give
+    \[
+        (\mathbf 1_A\otimes P_{XB})P
+        =P
+        =P(\mathbf 1_A\otimes P_{XB}).
+    \]
 \end{proof}
 
 \begin{theorem}[Absorption by the lifted $AX$ support projector]
@@ -535,8 +561,13 @@ $(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
 
 \begin{proof}
     \leanok
-    Reassociate the tripartite space as $AX|B$ and apply the two
-    left-marginal support absorption identities.
+    After reassociating the tripartite space as $AX|B$, the two
+    support-absorption identities give
+    \[
+        (P_{AX}\otimes\mathbf 1_B)P
+        =P
+        =P(P_{AX}\otimes\mathbf 1_B).
+    \]
 \end{proof}
 
 \begin{theorem}[Product of the two marginal support projectors]
@@ -587,13 +618,25 @@ $(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
       TripartiteDecorrelation.CommutingParentHamiltonian.hproduct}
     \leanok
     \uses{def:tripartite_parent_commuting_hamiltonian}
-    Let $P$, $P_{AX}$, and $P_{XB}$ be orthogonal projectors, and suppose that
-    $P_{AX}$ and $P_{XB}$ commute.  Then
+    Let $P$, $P_{AX}$, and $P_{XB}$ be orthogonal projectors, and write their
+    lifts to the tripartite space as
+    \[
+        \widehat P_{AX}=P_{AX}\otimes\mathbf 1_B,
+        \qquad
+        \widehat P_{XB}=\mathbf 1_A\otimes P_{XB}.
+    \]
+    Suppose that the lifted projectors commute:
+    \[
+        \widehat P_{AX}\widehat P_{XB}
+        =\widehat P_{XB}\widehat P_{AX}.
+    \]
+    Then
     \[
         \operatorname{ran}P
-        =\operatorname{ran}P_{AX}\cap\operatorname{ran}P_{XB}
+        =\operatorname{ran}\widehat P_{AX}\cap
+          \operatorname{ran}\widehat P_{XB}
         \quad\Longleftrightarrow\quad
-        P_{AX}P_{XB}=P.
+        \widehat P_{AX}\widehat P_{XB}=P.
     \]
     This is the passage from
     \cite[Definition~D.2, lines 2205--2218]{Cirac2016MPDO_arXiv} to the
@@ -602,11 +645,13 @@ $(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
 
 \begin{proof}
     \leanok
-    A vector lies in the range of $P_{AX}P_{XB}$ precisely when it is fixed by
-    both commuting idempotents.  Hence
+    A vector lies in the range of
+    $\widehat P_{AX}\widehat P_{XB}$ precisely when it is fixed by both
+    commuting idempotents. Hence
     \[
-        \operatorname{ran}(P_{AX}P_{XB})
-        =\operatorname{ran}P_{AX}\cap\operatorname{ran}P_{XB}.
+        \operatorname{ran}(\widehat P_{AX}\widehat P_{XB})
+        =\operatorname{ran}\widehat P_{AX}\cap
+          \operatorname{ran}\widehat P_{XB}.
     \]
     The product is again an orthogonal projector.  Orthogonal projectors with
     equal ranges are equal, giving the forward implication; the reverse

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
@@ -161,8 +161,14 @@ fixes the original operator.  These are the support-projector identities used in
 
 \begin{proof}
     \leanok
-    Expand both traces in product bases and sum over the identity entry on
-    $H_L$.
+    Expanding in product bases gives
+    \[
+        \operatorname{tr}((\mathbf 1_L\otimes M)\rho)
+        =\sum_{l,r}\sum_{k,s}\delta_{l,k}M_{rs}
+          \rho_{(k,s),(l,r)}
+        =\sum_{r,s}M_{rs}\sum_l\rho_{(l,s),(l,r)}
+        =\operatorname{tr}(M\operatorname{tr}_L\rho).
+    \]
 \end{proof}
 
 \begin{theorem}[Left absorption by the right marginal support]
@@ -346,9 +352,18 @@ $(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
 
 \begin{proof}
     \leanok
-    Evaluate both sides in the product basis.  The two matrix units force the
-    contracted row and column indices to agree, leaving the corresponding
-    partial trace.
+    For the $XB$ marginal, evaluation in the product basis gives
+    \[
+        \bigl(E^A_{ak}P E^A_{ka}\bigr)_{(a_0,r),(a_1,s)}
+        =\delta_{a,a_0}\delta_{a,a_1}P_{(k,r),(k,s)}.
+    \]
+    Hence
+    \[
+        \sum_{a,k}\bigl(E^A_{ak}P E^A_{ka}\bigr)_{(a_0,r),(a_1,s)}
+        =\delta_{a_0,a_1}\sum_kP_{(k,r),(k,s)}
+        =\bigl(\mathbf 1_A\otimes\rho_{XB}\bigr)_{(a_0,r),(a_1,s)}.
+    \]
+    The $AX$ identity follows symmetrically.
 \end{proof}
 
 \begin{theorem}[Decorrelation for the reduced operators]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
@@ -96,6 +96,345 @@ fixes the original operator.  These are the support-projector identities used in
     \]
 \end{proof}
 
+\begin{definition}[Partial trace over the left factor]
+    \label{def:partial_trace_left}
+    \lean{Matrix.partialTraceLeft, Matrix.partialTraceLeft_apply}
+    \leanok
+    For an operator $\rho$ on $H_L\otimes H_R$, define
+    \[
+        (\operatorname{tr}_L\rho)_{r,s}
+        =\sum_l \rho_{(l,r),(l,s)}.
+    \]
+\end{definition}
+
+\begin{theorem}[Hermiticity of the left partial trace]
+    \label{thm:partial_trace_left_hermitian}
+    \lean{Matrix.partialTraceLeft_isHermitian}
+    \leanok
+    \uses{def:partial_trace_left}
+    If $\rho=\rho^\dagger$, then
+    $\operatorname{tr}_L\rho=(\operatorname{tr}_L\rho)^\dagger$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Take complex conjugates entrywise and use Hermiticity of $\rho$ inside
+    the finite sum.
+\end{proof}
+
+\begin{theorem}[Positivity of the left partial trace]
+    \label{thm:partial_trace_left_pos}
+    \lean{Matrix.PosSemidef.partialTraceLeft}
+    \leanok
+    \uses{def:partial_trace_left}
+    If $\rho\geq 0$, then $\operatorname{tr}_L\rho\geq 0$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The partial trace is the sum, over a basis of $H_L$, of positive
+    semidefinite principal submatrices of $\rho$.
+\end{proof}
+
+\begin{lemma}[Adjoint identity for the left partial trace]
+    \label{lem:trace_lift_right_factor_mul}
+    \lean{Matrix.trace_rightKroneckerEmbed_mul}
+    \leanok
+    \uses{def:partial_trace_left}
+    For every operator $M$ on $H_R$,
+    \[
+        \operatorname{tr}((\mathbf 1_L\otimes M)\rho)
+        =\operatorname{tr}(M\operatorname{tr}_L\rho).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Expand both traces in product bases and sum over the identity entry on
+    $H_L$.
+\end{proof}
+
+\begin{theorem}[Left absorption by the right marginal support]
+    \label{thm:right_marginal_support_left_absorption}
+    \lean{Matrix.PosSemidef.rightKroneckerEmbed_supportProj_mul_self}
+    \leanok
+    \uses{thm:partial_trace_left_pos,lem:trace_lift_right_factor_mul}
+    If $P_R$ is the support projector of $\operatorname{tr}_L\rho$, then
+    \[
+        (\mathbf 1_L\otimes P_R)\rho=\rho.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Apply the preceding trace identity to $\mathbf 1_R-P_R$.  Its lift has
+    zero expectation against $\rho$, hence annihilates $\rho$ by positivity.
+\end{proof}
+
+\begin{theorem}[Right absorption by the right marginal support]
+    \label{thm:right_marginal_support_right_absorption}
+    \lean{Matrix.PosSemidef.mul_rightKroneckerEmbed_supportProj_self}
+    \leanok
+    \uses{thm:right_marginal_support_left_absorption}
+    Under the same assumptions,
+    \[
+        \rho(\mathbf 1_L\otimes P_R)=\rho.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Take adjoints in the left absorption identity.
+\end{proof}
+
+We now use the explicit tripartite indexing
+$H_A\otimes(H_X\otimes H_B)$.  Reassociation identifies it with
+$(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
+
+\begin{definition}[Tripartite local lifts]
+    \label{def:tripartite_local_lifts}
+    \lean{TripartiteDecorrelation.liftAX, TripartiteDecorrelation.liftXB,
+      TripartiteDecorrelation.liftA, TripartiteDecorrelation.liftB}
+    \leanok
+    Operators on $AX$, $XB$, $A$, and $B$ are lifted to the full tripartite
+    space by tensoring with identities on their complementary factors.
+\end{definition}
+
+\begin{definition}[Tripartite decorrelation]
+    \label{def:tripartite_decorrelation}
+    \lean{TripartiteDecorrelation.IsDecorrelated}
+    \leanok
+    \uses{def:tripartite_local_lifts}
+    Regions $A$ and $B$ are decorrelated relative to $P$ if, for all operators
+    $O_A$ and $O_B$,
+    \[
+        P O_A(\mathbf 1-P)O_B P=0.
+    \]
+    This is \cite[Definition~D.1, lines 2187--2191]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{theorem}[Reverse order of decorrelation]
+    \label{thm:tripartite_decorrelation_reverse}
+    \lean{TripartiteDecorrelation.IsDecorrelated.reverse}
+    \leanok
+    \uses{def:tripartite_decorrelation}
+    If $P=P^\dagger$, decorrelation also gives
+    \[
+        P O_B(\mathbf 1-P)O_A P=0.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Apply decorrelation to $O_A^\dagger$ and $O_B^\dagger$, and take adjoints.
+\end{proof}
+
+\begin{definition}[Tripartite reduced operators]
+    \label{def:tripartite_marginals}
+    \lean{TripartiteDecorrelation.marginalAX,
+      TripartiteDecorrelation.marginalXB}
+    \leanok
+    The two reduced operators are
+    \[
+        \rho_{AX}=\operatorname{tr}_B P,
+        \qquad
+        \rho_{XB}=\operatorname{tr}_A P.
+    \]
+\end{definition}
+
+\begin{theorem}[Matrix-unit expansions of the reduced operators]
+    \label{thm:tripartite_marginal_matrix_units}
+    \lean{TripartiteDecorrelation.lift_marginalAX_eq_sum,
+      TripartiteDecorrelation.lift_marginalXB_eq_sum}
+    \leanok
+    \uses{def:tripartite_local_lifts,def:tripartite_marginals}
+    For matrix units on $A$ and $B$,
+    \[
+        \mathbf 1_A\otimes\rho_{XB}
+          =\sum_{a,k}E^A_{ak}P E^A_{ka},
+        \qquad
+        \rho_{AX}\otimes\mathbf 1_B
+          =\sum_{b,k}E^B_{bk}P E^B_{kb}.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Evaluate both sides in the product basis.  The two matrix units force the
+    contracted row and column indices to agree, leaving the corresponding
+    partial trace.
+\end{proof}
+
+\begin{theorem}[Decorrelation for the two reduced operators]
+    \label{thm:tripartite_marginal_complementary_product_zero}
+    \lean{TripartiteDecorrelation.IsDecorrelated.marginals_mul_complement_mul_eq_zero,
+      TripartiteDecorrelation.IsDecorrelated.reverse_marginals_mul_complement_mul_eq_zero}
+    \leanok
+    \uses{def:tripartite_decorrelation,
+      thm:tripartite_decorrelation_reverse,
+      thm:tripartite_marginal_matrix_units}
+    If $P=P^\dagger$ and $A,B$ are decorrelated, then
+    \[
+        \rho_{XB}(\mathbf 1-P)\rho_{AX}=0,
+        \qquad
+        \rho_{AX}(\mathbf 1-P)\rho_{XB}=0,
+    \]
+    where each reduced operator is lifted to the tripartite space.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Substitute the matrix-unit expansions.  Every summand contains one of the
+    two decorrelation products and is therefore zero.
+\end{proof}
+
+\begin{definition}[Tripartite marginal support projectors]
+    \label{def:tripartite_marginal_supports}
+    \lean{TripartiteDecorrelation.supportAX, TripartiteDecorrelation.supportXB}
+    \leanok
+    \uses{def:partial_trace_left}
+    Let $P_{AX}$ and $P_{XB}$ be the support projectors of
+    $\operatorname{tr}_B P$ and $\operatorname{tr}_A P$, respectively, as in
+    \cite[Appendix~D.2, lines 2225--2229]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{theorem}[Decorrelation for the two marginal supports]
+    \label{thm:tripartite_complementary_product_zero}
+    \lean{TripartiteDecorrelation.IsDecorrelated.supports_mul_complement_mul_eq_zero,
+      TripartiteDecorrelation.IsDecorrelated.reverse_supports_mul_complement_mul_eq_zero}
+    \leanok
+    \uses{def:tripartite_marginal_supports,
+      thm:tripartite_marginal_complementary_product_zero}
+    Under the same assumptions,
+    \[
+        P_{XB}(\mathbf 1-P)P_{AX}=0,
+        \qquad
+        P_{AX}(\mathbf 1-P)P_{XB}=0.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    For $g(0)=0$ and $g(x)=x^{-1}$ when $x\ne0$, functional calculus gives
+    \[
+        P_{AX}=g(\rho_{AX})\rho_{AX}=\rho_{AX}g(\rho_{AX}),
+        \qquad
+        P_{XB}=g(\rho_{XB})\rho_{XB}=\rho_{XB}g(\rho_{XB}).
+    \]
+    Multiply the two reduced-operator identities by the appropriate outer
+    factors.
+    % Local fix for source lines 2236--2252: see
+    % docs/paper-gaps/cpsv16_decorrelation_slice_expansion_fix.tex.
+\end{proof}
+
+\begin{theorem}[Absorption by the lifted $XB$ support projector]
+    \label{thm:tripartite_xb_support_absorption}
+    \lean{TripartiteDecorrelation.liftSupportXB_mul_self,
+      TripartiteDecorrelation.mul_liftSupportXB_self}
+    \leanok
+    \uses{def:tripartite_local_lifts,def:tripartite_marginal_supports,
+      thm:right_marginal_support_left_absorption,
+      thm:right_marginal_support_right_absorption}
+    For $P\geq0$,
+    \[
+        P_{XB}P=P=PP_{XB}.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Apply the two right-marginal support absorption identities to the
+    bipartition $A|XB$.
+\end{proof}
+
+\begin{theorem}[Absorption by the lifted $AX$ support projector]
+    \label{thm:tripartite_ax_support_absorption}
+    \lean{TripartiteDecorrelation.liftSupportAX_mul_self,
+      TripartiteDecorrelation.mul_liftSupportAX_self}
+    \leanok
+    \uses{def:tripartite_local_lifts,def:tripartite_marginal_supports,
+      thm:marginal_support_left_absorption,
+      thm:marginal_support_right_absorption}
+    For $P\geq0$,
+    \[
+        P_{AX}P=P=PP_{AX}.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Reassociate the tripartite space as $AX|B$ and apply the two
+    left-marginal support absorption identities.
+\end{proof}
+
+\begin{theorem}[Product of the two marginal support projectors]
+    \label{thm:tripartite_support_products}
+    \lean{TripartiteDecorrelation.supportProducts_eq}
+    \leanok
+    \uses{def:tripartite_marginal_supports,
+      thm:tripartite_xb_support_absorption,
+      thm:tripartite_ax_support_absorption,
+      thm:tripartite_complementary_product_zero}
+    If $P=P^\dagger=P^2$ and $A$ and $B$ are decorrelated relative to $P$, then
+    \[
+        P_{XB}P_{AX}=P=P_{AX}P_{XB}.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Insert $\mathbf 1=P+(\mathbf 1-P)$ between the two support projectors.
+    The complementary term vanishes by decorrelation, while absorption gives
+    $P_{XB}PP_{AX}=P$ and $P_{AX}PP_{XB}=P$.
+\end{proof}
+
+\begin{definition}[Parent commuting Hamiltonian on the tripartite space]
+    \label{def:tripartite_parent_commuting_hamiltonian}
+    \lean{TripartiteDecorrelation.CommutingParentHamiltonian,
+      TripartiteDecorrelation.HasCommutingParentHamiltonian}
+    \leanok
+    \uses{def:tripartite_local_lifts}
+    There are orthogonal projectors $P_{AX}$ and $P_{XB}$ on the two local
+    factors whose lifts commute and satisfy
+    \[
+        P_{AX}P_{XB}=P.
+    \]
+    Equivalently, $Q_{AX}=\mathbf 1-P_{AX}$ and
+    $Q_{XB}=\mathbf 1-P_{XB}$ are the commuting parent terms of
+    \cite[Definition~D.2, lines 2205--2218]{Cirac2016MPDO_arXiv}, and the
+    ground space of their sum is the range of $P$.
+\end{definition}
+
+\begin{theorem}[Parent commuting Hamiltonian--decorrelation equivalence]
+    \label{thm:tripartite_parent_iff_decorrelated}
+    \lean{TripartiteDecorrelation.CommutingParentHamiltonian.isDecorrelated,
+      TripartiteDecorrelation.IsDecorrelated.hasCommutingParentHamiltonian,
+      TripartiteDecorrelation.parentHamiltonian_iff_decorrelated}
+    \leanok
+    \uses{def:tripartite_decorrelation,
+      def:tripartite_parent_commuting_hamiltonian,
+      thm:tripartite_support_products}
+    Let $P=P^\dagger=P^2$.  Then $P$ is the ground-space projector of a
+    parent commuting Hamiltonian on $AX$ and $XB$ if and only if regions
+    $A$ and $B$ are decorrelated.
+    This is \cite[Proposition~D.3, lines 2221--2289]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    For the forward implication, take the support projectors of
+    $\rho_{AX}$ and $\rho_{XB}$.  The preceding product theorem proves their
+    commutation and identifies their product with $P$.
+
+    Conversely, write $P=P_{AX}P_{XB}=P_{XB}P_{AX}$.  Locality gives
+    $[O_A,P_{XB}]=[O_B,P_{AX}]=0$, while
+    \[
+        P_{XB}(\mathbf 1-P)P_{AX}=0.
+    \]
+    Moving the two observables past the projectors therefore gives
+    $P O_A(\mathbf 1-P)O_B P=0$.
+\end{proof}
+
 \begin{definition}[Decorrelation]\label{def:is_decorrelated}
     \lean{Decorrelation.IsDecorrelated}
     \leanok

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
@@ -273,7 +273,8 @@ $(H_A\otimes H_X)\otimes H_B$ whenever the $AX$ marginal is taken.
     \lean{TripartiteDecorrelation.IsDecorrelated.reverse}
     \leanok
     \uses{def:tripartite_decorrelation}
-    If $P=P^\dagger$, decorrelation also gives
+    If $P=P^\dagger$ and $A$ and $B$ are decorrelated, then, for all
+    observables $O_A$ and $O_B$,
     \[
         P O_B(\mathbf 1-P)O_A P=0.
     \]

--- a/docs/paper-gaps/cpsv16_decorrelation_slice_expansion_fix.tex
+++ b/docs/paper-gaps/cpsv16_decorrelation_slice_expansion_fix.tex
@@ -1,0 +1,87 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{The marginal-support expansion in CPSV16 Appendix D.2}
+\author{}
+\date{2026-07-15}
+
+\begin{document}
+\maketitle
+
+\section{The source step}
+
+In the proof of Proposition~D.3, the source chooses orthonormal bases
+\(\{\alpha_i\}\) and \(\{\beta_i\}\) of the two marginal supports and
+asserts that every basis vector is a single partial contraction,
+\begin{align}
+  \alpha_i=\langle\widetilde b_i\mid\varphi_{b,i}\rangle,
+  \qquad
+  \beta_i=\langle\widetilde a_i\mid\varphi_{a,i}\rangle,
+\end{align}
+with \(\varphi_{a,i},\varphi_{b,i}\in K_{AXB}\).
+This is the passage at source lines 2236--2242.
+
+The support of a reduced operator is spanned by partial contractions, but an
+arbitrary vector in that span need not itself be one partial contraction.
+Thus the displayed single-contraction choice does not follow from the
+definition of marginal support.
+
+\section{Local correction}
+
+The subsequent matrix-unit argument only needs a factorization of each
+marginal support projector through the corresponding reduced operator.  Write
+\begin{align}
+  \rho_{AX}=\operatorname{tr}_B P_{AXB},
+  \qquad
+  \rho_{XB}=\operatorname{tr}_A P_{AXB}.
+\end{align}
+The reduced operators have the exact matrix-unit expansions
+\begin{align}
+  \rho_{AX}\otimes I_B
+    &=\sum_{b,k} E^B_{bk}P_{AXB}E^B_{kb},\\
+  I_A\otimes\rho_{XB}
+    &=\sum_{a,k} E^A_{ak}P_{AXB}E^A_{ka}.
+\end{align}
+If \(g(0)=0\) and \(g(x)=x^{-1}\) for \(x\ne0\), functional calculus gives
+\begin{align}
+  P_{AX}=g(\rho_{AX})\rho_{AX}=\rho_{AX}g(\rho_{AX}),\\
+  P_{XB}=g(\rho_{XB})\rho_{XB}=\rho_{XB}g(\rho_{XB}).
+\end{align}
+Consequently the decorrelation identity first annihilates
+\begin{align}
+  \rho_{XB}(I-P_{AXB})\rho_{AX}
+  \quad\text{and}\quad
+  \rho_{AX}(I-P_{AXB})\rho_{XB},
+\end{align}
+and multiplication by the two reciprocal-on-support factors gives the same
+equalities for \(P_{XB}\) and \(P_{AX}\).  The absorption identities then
+yield
+\begin{align}
+  P_{XB}P_{AX}=P_{AXB}=P_{AX}P_{XB}.
+\end{align}
+
+This correction uses the source's matrix-unit and marginal-support argument,
+but replaces the unsupported single-contraction assertion by a valid
+factorization.  No hypothesis is added to Proposition~D.3.
+
+\section{Formal statement}
+
+The reduced-operator expansions are
+\leanid{TripartiteDecorrelation.lift_marginalAX_eq_sum} and
+\leanid{TripartiteDecorrelation.lift_marginalXB_eq_sum}.  The complementary
+support products are
+\leanid{TripartiteDecorrelation.IsDecorrelated.}
+\hspace{0pt}\leanid{supports_mul_complement_mul_eq_zero} and its reverse-order
+counterpart.  The two product identities are assembled by
+\leanid{TripartiteDecorrelation.supportProducts_eq}.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/cpsv16_decorrelation_slice_expansion_fix.tex
+++ b/docs/paper-gaps/cpsv16_decorrelation_slice_expansion_fix.tex
@@ -14,6 +14,26 @@
 \begin{document}
 \maketitle
 
+Let \(\mathcal H_A\), \(\mathcal H_X\), and \(\mathcal H_B\) be
+finite-dimensional Hilbert spaces, let
+\(K_{AXB}\subseteq\mathcal H_A\otimes\mathcal H_X\otimes\mathcal H_B\),
+and let \(P_{AXB}\) be the orthogonal projector onto \(K_{AXB}\).  Define
+\[
+  \rho_{AX}=\operatorname{tr}_B P_{AXB},
+  \qquad
+  \rho_{XB}=\operatorname{tr}_A P_{AXB}.
+\]
+The two marginal supports are \(\operatorname{ran}\rho_{AX}\) and
+\(\operatorname{ran}\rho_{XB}\), with orthogonal projectors \(P_{AX}\) and
+\(P_{XB}\), respectively.  For an operator on \(AX\) or \(XB\), a hat
+denotes its lift to the full tripartite space; in particular,
+\[
+  \widehat P_{AX}=P_{AX}\otimes I_B,
+  \qquad
+  \widehat P_{XB}=I_A\otimes P_{XB},
+\]
+and likewise for \(\widehat\rho_{AX}\) and \(\widehat\rho_{XB}\).
+
 \section{The source step}
 
 In the proof of Proposition~D.3, the source chooses orthonormal bases
@@ -35,20 +55,15 @@ definition of marginal support.
 \section{Local correction}
 
 The subsequent matrix-unit argument only needs a factorization of each
-marginal support projector through the corresponding reduced operator.  Write
-\begin{align}
-  \rho_{AX}=\operatorname{tr}_B P_{AXB},
-  \qquad
-  \rho_{XB}=\operatorname{tr}_A P_{AXB}.
-\end{align}
-For the elementary matrix units on the outer factors, write
+marginal support projector through the corresponding reduced operator.  For
+the elementary matrix units on the outer factors, write
 \(E^A_{ak}=\lvert a\rangle\langle k\rvert\) and
 \(E^B_{bk}=\lvert b\rangle\langle k\rvert\).  The reduced operators have the
 exact expansions
 \begin{align}
-  \rho_{AX}\otimes I_B
+  \widehat\rho_{AX}
     &=\sum_{b,k} E^B_{bk}P_{AXB}E^B_{kb},\\
-  I_A\otimes\rho_{XB}
+  \widehat\rho_{XB}
     &=\sum_{a,k} E^A_{ak}P_{AXB}E^A_{ka}.
 \end{align}
 If \(g(0)=0\) and \(g(x)=x^{-1}\) for \(x\ne0\), functional calculus gives
@@ -58,15 +73,17 @@ If \(g(0)=0\) and \(g(x)=x^{-1}\) for \(x\ne0\), functional calculus gives
 \end{align}
 Consequently the decorrelation identity first annihilates
 \begin{align}
-  \rho_{XB}(I-P_{AXB})\rho_{AX}
+  \widehat\rho_{XB}(I-P_{AXB})\widehat\rho_{AX}
   \quad\text{and}\quad
-  \rho_{AX}(I-P_{AXB})\rho_{XB},
+  \widehat\rho_{AX}(I-P_{AXB})\widehat\rho_{XB},
 \end{align}
 and multiplication by the two reciprocal-on-support factors gives the same
-equalities for \(P_{XB}\) and \(P_{AX}\).  The absorption identities then
-yield
+equalities for \(\widehat P_{XB}\) and \(\widehat P_{AX}\).  The absorption
+identities then yield
 \begin{align}
-  P_{XB}P_{AX}=P_{AXB}=P_{AX}P_{XB}.
+  \widehat P_{XB}\widehat P_{AX}
+    =P_{AXB}
+    =\widehat P_{AX}\widehat P_{XB}.
 \end{align}
 
 This correction uses the source's matrix-unit and marginal-support argument,

--- a/docs/paper-gaps/cpsv16_decorrelation_slice_expansion_fix.tex
+++ b/docs/paper-gaps/cpsv16_decorrelation_slice_expansion_fix.tex
@@ -41,7 +41,10 @@ marginal support projector through the corresponding reduced operator.  Write
   \qquad
   \rho_{XB}=\operatorname{tr}_A P_{AXB}.
 \end{align}
-The reduced operators have the exact matrix-unit expansions
+For the elementary matrix units on the outer factors, write
+\(E^A_{ak}=\lvert a\rangle\langle k\rvert\) and
+\(E^B_{bk}=\lvert b\rangle\langle k\rvert\).  The reduced operators have the
+exact expansions
 \begin{align}
   \rho_{AX}\otimes I_B
     &=\sum_{b,k} E^B_{bk}P_{AXB}E^B_{kb},\\

--- a/docs/paper-gaps/cpsv16_decorrelation_slice_expansion_fix.tex
+++ b/docs/paper-gaps/cpsv16_decorrelation_slice_expansion_fix.tex
@@ -70,6 +70,10 @@ This correction uses the source's matrix-unit and marginal-support argument,
 but replaces the unsupported single-contraction assertion by a valid
 factorization.  No hypothesis is added to Proposition~D.3.
 
+\paragraph{Verdict: local correction.}
+The conclusion and hypotheses of Proposition~D.3 are unchanged; only the
+unsupported intermediate representation is replaced.
+
 \section{Formal statement}
 
 The reduced-operator expansions are

--- a/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
+++ b/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
@@ -184,21 +184,29 @@ it is not an additional assumption.
 
 \section{Elimination plan}
 
+The general finite-dimensional tripartite equivalence is now recorded by
+\leanid{TripartiteDecorrelation.parentHamiltonian_iff_decorrelated}.  Its
+parent condition uses orthogonal projectors on the explicit factors
+\(AX\) and \(XB\); their lifted product is \(P_{AXB}\), equivalently their
+lifted ranges have the source intersection.  The forward direction constructs
+these projectors as the supports of the two marginals, and the reverse
+direction uses their locality and product identity.  The local correction to
+the marginal-support expansion at source lines 2236--2252 is documented in
+\path{docs/paper-gaps/cpsv16_decorrelation_slice_expansion_fix.tex}.
+
 The coefficient-space analogue of the algebraic and kernel-intersection clauses
 is now proved: the operators are the canonical orthogonal parent interactions
 \(q_2(A)\), their lifts commute, and their kernel intersection is \(G_3(A)\).
 It remains to construct the source projectors on the two stated tensor factors
 and identify their transported actions with these coefficient-space maps.  The
 conditional comparison theorem cited above records precisely this missing
-identification.  This also does not complete the general decorrelation
-equivalence of Proposition~D.3.  In particular,
+identification.  This remaining comparison belongs to the RFP application,
+not to the general decorrelation equivalence.  In particular,
 \leanid{Decorrelation.HasCommutingParentHam} remains only its algebraic
 idempotent-product consequence, and the generic
 \leanid{MPSTensor.HasAppendixD2ParentCommutingHamiltonian} structure does not
-itself record self-adjointness.  The concrete canonical parent interactions
-used here are orthogonal by construction, but the general statement should
-require self-adjointness explicitly and establish both directions of
-Proposition~D.3.  That work is tracked separately by \ghissue{190}.
+itself record self-adjointness.  The explicit tripartite condition above does
+record self-adjointness and proves both directions of Proposition~D.3.
 
 For Theorem~3.10, the remaining obligations are instead the full
 canonical-form scope and the all-chain ground-space spanning statement.  They

--- a/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
+++ b/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
@@ -26,18 +26,30 @@ Definition~D.2 of \cite{Cirac2016MPDO_arXiv} states the parent commuting
 Hamiltonian condition for a tripartite Hilbert space
 \(\mathcal H_A\otimes\mathcal H_X\otimes\mathcal H_B\).  It uses local
 projectors \(Q_{AX}\) and \(Q_{XB}\).  Let \(K_{AX}\) and \(K_{XB}\) denote
-their kernels.  The source condition is\footnote{Local source:
+their kernels, and write
+\[
+  \widehat Q_{AX}=Q_{AX}\otimes I_B,
+  \qquad
+  \widehat Q_{XB}=I_A\otimes Q_{XB}
+\]
+for their lifts to the tripartite space.  The source condition is\footnote{Local source:
 \path{Papers/1606.00608/MPDO-22-12-17-2.tex}:2205--2218, labels
 \path{QAXQXB} and \path{KAXBKAXKXB}.}
 \begin{align}
-  [Q_{AX},Q_{XB}]&=0,\\
+  [\widehat Q_{AX},\widehat Q_{XB}]&=0,\\
   K_{AXB}&=(K_{AX}\otimes\mathcal H_B)
     \cap(\mathcal H_A\otimes K_{XB}).
 \end{align}
 The proof of Proposition~D.3 then writes
-\(P_{AX}=1-Q_{AX}\) and \(P_{XB}=1-Q_{XB}\), and uses the product identity
+\(P_{AX}=1-Q_{AX}\) and \(P_{XB}=1-Q_{XB}\).  Their lifts
+\[
+  \widehat P_{AX}=P_{AX}\otimes I_B,
+  \qquad
+  \widehat P_{XB}=I_A\otimes P_{XB}
+\]
+satisfy the product identity
 \begin{align}
-  P_{AX}P_{XB}=P_{AXB}.
+  \widehat P_{AX}\widehat P_{XB}=P_{AXB}.
 \end{align}
 This is the identity obtained from commuting orthogonal projectors onto the two
 local kernels \(K_{AX}\) and \(K_{XB}\).\footnote{Local source:
@@ -48,9 +60,10 @@ The explicit tripartite declaration
 range-intersection equality itself.  The equivalence
 \[
   \operatorname{ran}P_{AXB}
-    =\operatorname{ran}P_{AX}\cap\operatorname{ran}P_{XB}
+    =\operatorname{ran}\widehat P_{AX}\cap
+      \operatorname{ran}\widehat P_{XB}
   \quad\Longleftrightarrow\quad
-  P_{AX}P_{XB}=P_{AXB}
+  \widehat P_{AX}\widehat P_{XB}=P_{AXB}
 \]
 for commuting orthogonal projectors is proved by
 \leanid{TripartiteDecorrelation.}

--- a/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
+++ b/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
@@ -43,6 +43,20 @@ This is the identity obtained from commuting orthogonal projectors onto the two
 local kernels \(K_{AX}\) and \(K_{XB}\).\footnote{Local source:
 \path{Papers/1606.00608/MPDO-22-12-17-2.tex}:2259--2289, in particular labels
 \path{PAXQAX}, \path{PXBQXB}, and \path{arrggg}.}
+The explicit tripartite declaration
+\leanid{TripartiteDecorrelation.CommutingParentHamiltonian} now records the
+range-intersection equality itself.  The equivalence
+\[
+  \operatorname{ran}P_{AXB}
+    =\operatorname{ran}P_{AX}\cap\operatorname{ran}P_{XB}
+  \quad\Longleftrightarrow\quad
+  P_{AX}P_{XB}=P_{AXB}
+\]
+for commuting orthogonal projectors is proved by
+\leanid{TripartiteDecorrelation.}
+\hspace{0pt}\leanid{hasGroundSpaceIntersection_iff_product_eq}; the forward
+implication is exposed as
+\leanid{TripartiteDecorrelation.CommutingParentHamiltonian.hproduct}.
 
 \section{Current boundary}
 
@@ -187,11 +201,14 @@ it is not an additional assumption.
 The general finite-dimensional tripartite equivalence is now recorded by
 \leanid{TripartiteDecorrelation.parentHamiltonian_iff_decorrelated}.  Its
 parent condition uses orthogonal projectors on the explicit factors
-\(AX\) and \(XB\); their lifted product is \(P_{AXB}\), equivalently their
-lifted ranges have the source intersection.  The forward direction constructs
-these projectors as the supports of the two marginals, and the reverse
-direction uses their locality and product identity.  The local correction to
-the marginal-support expansion at source lines 2236--2252 is documented in
+\(AX\) and \(XB\), and records literally that their lifted ranges have the
+source intersection.  The theorem
+\leanid{TripartiteDecorrelation.}
+\hspace{0pt}\leanid{hasGroundSpaceIntersection_iff_product_eq} proves that this
+is equivalent to their lifted product being \(P_{AXB}\).  The forward direction
+constructs these projectors as the supports of the two marginals, and the
+reverse direction derives and uses the product identity.  The local correction
+to the marginal-support expansion at source lines 2236--2252 is documented in
 \path{docs/paper-gaps/cpsv16_decorrelation_slice_expansion_fix.tex}.
 
 The coefficient-space analogue of the algebraic and kernel-intersection clauses


### PR DESCRIPTION
Closes #3951.

### Motivation

- CPSV16 Proposition D.3 asserts a full finite-dimensional equivalence between endpoint decorrelation and commuting local parent projectors on a tripartite space.
- The source proof contains a locally invalid single-contraction assertion in Appendix D.2, lines 2236–2252; a faithful proof must replace that step without strengthening the hypotheses.

### Description

- Formalizes the proposition on the explicit space $H_A\otimes H_X\otimes H_B$.
- Uses the support projectors of the $AX$ and $XB$ marginals, proves their two-sided absorption identities, and derives both complementary-support products from decorrelation.
- Establishes $P_{XB}P_{AX}=P_{AXB}=P_{AX}P_{XB}$ and hence the equivalence with commuting local parent projectors whose common ground-space projector is $P_{AXB}$.
- Replaces the source single-contraction step by exact matrix-unit expansions of the reduced operators and reciprocal-on-support functional calculus, with no added hypothesis.
- Documents the local correction in `docs/paper-gaps/cpsv16_decorrelation_slice_expansion_fix.tex`.
- Introduces no `sorry`, new axiom, or kernel bypass.

### Testing

- Full `lake build`.
- `leanblueprint checkdecls`, blueprint PDF generation, and blueprint synchronization.
- Reader-facing prose, proof-integrity, and axiom audits.