### PR TITLE
feat(MPS/MPDO): normalize BNT multiplicity traces

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -473,6 +473,7 @@ import TNLean.MPS.MPDO.AlgebraFusionCounterexample
 import TNLean.MPS.MPDO.BNTCoefficients
 import TNLean.MPS.MPDO.LengthIndependentCoefficients
 import TNLean.MPS.MPDO.BNTTheoremData
+import TNLean.MPS.MPDO.BNTMultiplicityNormalization
 import TNLean.MPS.MPDO.BNTTheoremWitness
 import TNLean.MPS.MPDO.BNTTheoremWitnessConsequences
 import TNLean.MPS.MPDO.BNTFusionIsometries

--- a/TNLean/MPS/MPDO/BNTMultiplicityNormalization.lean
+++ b/TNLean/MPS/MPDO/BNTMultiplicityNormalization.lean
@@ -23,7 +23,7 @@ obligations.
 ## References
 
 * [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
-  Theorem IV.13(ii) and Appendix C.4, lines 2048--2085
+  Theorem IV.13(ii) and Appendix C.4, lines 2048--2064
 -/
 
 open scoped BigOperators

--- a/TNLean/MPS/MPDO/BNTMultiplicityNormalization.lean
+++ b/TNLean/MPS/MPDO/BNTMultiplicityNormalization.lean
@@ -1,0 +1,210 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.BNTTheoremData
+
+/-!
+# Multiplicity normalization in the BNT algebra-to-RFP implication
+
+This file isolates the scalar normalization step in the implication from the
+BNT algebra clause to the renormalization fixed-point channels.  After the
+one-site and two-site vertical canonical decompositions have been compared,
+the two-site multiplicity entries in sector `gamma` are, with multiplicity,
+the products
+`mu_{alpha,i} mu_{beta,j} chi_{alpha,beta,gamma,k}`.  The length-one
+idempotent law then identifies the trace of the two-site multiplicity matrix
+with the one-site trace scalar `m_gamma`.
+
+The comparison of the two vertical canonical decompositions and the
+construction of the trace-preserving completely positive maps remain separate
+obligations.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Theorem IV.13(ii) and Appendix C.4, lines 2048--2085
+-/
+
+open scoped BigOperators
+
+namespace MPOTensor
+
+/-- Indices of the products of one-site multiplicity entries and a chi entry
+which contribute to a fixed two-site sector `gamma`.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2058--2063 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+abbrev BNTProductMultiplicityIndex {Λ : Type*} [Fintype Λ]
+    (χ : DiagonalChiFamily Λ) (oneDim : Λ → ℕ) (γ : Λ) :=
+  Σ α : Λ, Σ β : Λ,
+    Fin (oneDim α) × Fin (oneDim β) × Fin (χ.dim α β γ)
+
+/-- The multiplicity-spectrum comparison used in the algebra-to-RFP direction
+of Theorem IV.13.
+
+The one-site entries are the diagonal entries of `mu_alpha`; the two-site
+entries are those of `nu_gamma`.  The final field records the multiset
+identity obtained in the source from the comparison of the two vertical BNT
+decompositions and the positive power-sum lemma.
+
+This structure does not assert that an arbitrary algebra structure supplies
+the comparison.  Constructing it from the canonical-form MPDO tensor is the
+preceding obligation in Appendix C.4.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2048--2058 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+structure BNTMultiplicitySpectrumComparison {Λ : Type*} [Fintype Λ]
+    (χ : DiagonalChiFamily Λ) (m : BNTLabelTraceScalarFamily Λ) where
+  /-- Size of the one-site multiplicity matrix `mu_alpha`. -/
+  oneDim : Λ → ℕ
+  /-- Diagonal entries of the one-site multiplicity matrix `mu_alpha`. -/
+  oneEntry : ∀ α : Λ, Fin (oneDim α) → ℂ
+  /-- The trace of `mu_alpha` is the scalar `m_alpha`. -/
+  oneTrace : ∀ α : Λ, ∑ i, oneEntry α i = m.traceScalar α
+  /-- Size of the two-site multiplicity matrix `nu_gamma`. -/
+  twoDim : Λ → ℕ
+  /-- Diagonal entries of the two-site multiplicity matrix `nu_gamma`. -/
+  twoEntry : ∀ γ : Λ, Fin (twoDim γ) → ℂ
+  /-- Sectorwise equality, with multiplicity, of the two-site spectrum and
+  the products of the one-site and chi entries. -/
+  spectrum_eq : ∀ γ : Λ,
+    Finset.univ.val.map (twoEntry γ) =
+      Finset.univ.val.map fun x : BNTProductMultiplicityIndex χ oneDim γ =>
+        oneEntry x.1 x.2.2.1 * oneEntry x.2.1 x.2.2.2.1 *
+          χ.entry x.1 x.2.1 γ x.2.2.2.2
+
+namespace BNTMultiplicitySpectrumComparison
+
+variable {Λ : Type*} [Fintype Λ] {χ : DiagonalChiFamily Λ}
+  {m : BNTLabelTraceScalarFamily Λ}
+  (C : BNTMultiplicitySpectrumComparison χ m)
+
+/-- Summing the sectorwise multiplicity-spectrum comparison gives the
+corresponding equality of traces.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2058--2063 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem sum_twoEntry_eq_sum_products (γ : Λ) :
+    ∑ r, C.twoEntry γ r =
+      ∑ x : BNTProductMultiplicityIndex χ C.oneDim γ,
+        C.oneEntry x.1 x.2.2.1 * C.oneEntry x.2.1 x.2.2.2.1 *
+          χ.entry x.1 x.2.1 γ x.2.2.2.2 := by
+  classical
+  have h := congrArg Multiset.sum (C.spectrum_eq γ)
+  change (Finset.univ.val.map (C.twoEntry γ)).sum =
+    (Finset.univ.val.map fun x : BNTProductMultiplicityIndex χ C.oneDim γ =>
+      C.oneEntry x.1 x.2.2.1 * C.oneEntry x.2.1 x.2.2.2.1 *
+        χ.entry x.1 x.2.1 γ x.2.2.2.2).sum at h
+  change (Finset.univ.val.map (C.twoEntry γ)).sum =
+    (Finset.univ.val.map fun x : BNTProductMultiplicityIndex χ C.oneDim γ =>
+      C.oneEntry x.1 x.2.2.1 * C.oneEntry x.2.1 x.2.2.2.1 *
+        χ.entry x.1 x.2.1 γ x.2.2.2.2).sum
+  exact h
+
+/-- The product multiplicity sum factors into the one-site traces and the
+length-one chi coefficient.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2058--2063 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem sum_products_eq (γ : Λ) :
+    (∑ x : BNTProductMultiplicityIndex χ C.oneDim γ,
+        C.oneEntry x.1 x.2.2.1 * C.oneEntry x.2.1 x.2.2.2.1 *
+          χ.entry x.1 x.2.1 γ x.2.2.2.2) =
+      ∑ α : Λ, ∑ β : Λ,
+        χ.tracePowerCoeff α β γ 1 *
+          (m.traceScalar α * m.traceScalar β) := by
+  classical
+  simp only [Fintype.sum_sigma, Fintype.sum_prod_type,
+    DiagonalChiFamily.tracePowerCoeff, pow_one]
+  apply Finset.sum_congr rfl
+  intro α _
+  apply Finset.sum_congr rfl
+  intro β _
+  calc
+    (∑ i, ∑ j, ∑ k,
+        C.oneEntry α i * C.oneEntry β j * χ.entry α β γ k) =
+        ∑ i, ∑ j, (C.oneEntry α i * C.oneEntry β j) *
+          ∑ k, χ.entry α β γ k := by
+      simp only [Finset.mul_sum, mul_assoc]
+    _ =
+        (∑ i, C.oneEntry α i) *
+          ((∑ j, C.oneEntry β j) * ∑ k, χ.entry α β γ k) := by
+      rw [Fintype.sum_mul_sum, Fintype.sum_mul_sum]
+      simp only [Finset.mul_sum, mul_assoc]
+    _ = (∑ i, C.oneEntry α i) * (∑ j, C.oneEntry β j) *
+          ∑ k, χ.entry α β γ k := by
+      ring
+    _ = (∑ k, χ.entry α β γ k) *
+          (m.traceScalar α * m.traceScalar β) := by
+      rw [C.oneTrace, C.oneTrace]
+      ring
+
+/-- The idempotent algebra law normalizes every two-site multiplicity matrix:
+`tr(nu_gamma) = m_gamma`.
+
+This is the scalar conclusion required before the source defines the
+preparation map with density matrix `nu_gamma / m_gamma`.  No channel or
+renormalization fixed-point conclusion is asserted here.
+
+Source: arXiv:1606.00608, Theorem IV.13(ii), lines 1933--1942, and
+Appendix C.4, lines 2058--2071 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem twoTrace_eq_traceScalar
+    (hIdempotent :
+      m.HasIdempotentCoefficientForm (BNTLabelCoefficientFamily.ofChi χ))
+    (γ : Λ) :
+    ∑ r, C.twoEntry γ r = m.traceScalar γ := by
+  rw [C.sum_twoEntry_eq_sum_products, C.sum_products_eq]
+  symm
+  exact hIdempotent γ
+
+end BNTMultiplicitySpectrumComparison
+
+namespace BNTAlgebraClause
+
+variable {Λ : Type*} [Fintype Λ] {O : ℕ → Type*}
+  [∀ L : ℕ, AddCommMonoid (O L)] [∀ L : ℕ, Module ℂ (O L)]
+  [∀ L : ℕ, Mul (O L)]
+  {c : BNTLabelCoefficientFamily Λ} {operators : BNTLabelOperatorFamily Λ O}
+  {m : BNTLabelTraceScalarFamily Λ}
+  (H : BNTAlgebraClause c operators m)
+
+/-- The idempotent law of a BNT algebra clause may be transferred to the
+canonical coefficient family determined by its chi matrices.
+
+Source: arXiv:1606.00608, Theorem IV.13(ii), lines 1933--1942 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem idempotent_coefficient_form_ofChi :
+    m.HasIdempotentCoefficientForm
+      (BNTLabelCoefficientFamily.ofChi H.positiveChi.chi) := by
+  intro γ
+  rw [H.idempotent γ]
+  apply Finset.sum_congr rfl
+  intro α _
+  apply Finset.sum_congr rfl
+  intro β _
+  rw [BNTLabelCoefficientFamily.ofChi_coeff,
+    ← H.positiveChi.tracePower 1 Nat.zero_lt_one α β γ]
+
+/-- A BNT algebra clause, together with the multiplicity-spectrum comparison
+of the one-site and two-site vertical canonical decompositions, normalizes the
+two-site multiplicity trace:
+`tr(nu_gamma) = m_gamma`.
+
+This is the first load-bearing conclusion in the algebra-to-RFP implication:
+it makes `nu_gamma / m_gamma` a trace-one matrix once positivity and nonzero
+sector weights have been supplied by the canonical decomposition.
+
+Source: arXiv:1606.00608, Theorem IV.13(ii), lines 1933--1942, and
+Appendix C.4, lines 2048--2071 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem twoMultiplicityTrace_eq_traceScalar
+    (C : BNTMultiplicitySpectrumComparison H.positiveChi.chi m) (γ : Λ) :
+    ∑ r, C.twoEntry γ r = m.traceScalar γ :=
+  C.twoTrace_eq_traceScalar H.idempotent_coefficient_form_ofChi γ
+
+end BNTAlgebraClause
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/BNTMultiplicityNormalization.lean
+++ b/TNLean/MPS/MPDO/BNTMultiplicityNormalization.lean
@@ -11,11 +11,10 @@ import TNLean.MPS.MPDO.BNTTheoremData
 This file isolates the scalar normalization step in the implication from the
 BNT algebra clause to the renormalization fixed-point channels.  After the
 one-site and two-site vertical canonical decompositions have been compared,
-the two-site multiplicity entries in sector `gamma` are, with multiplicity,
-the products
-`mu_{alpha,i} mu_{beta,j} chi_{alpha,beta,gamma,k}`.  The length-one
-idempotent law then identifies the trace of the two-site multiplicity matrix
-with the one-site trace scalar `m_gamma`.
+the two-site multiplicity entries in sector γ are, with multiplicity, the
+products of two one-site entries and the corresponding diagonal chi entry.
+The length-one idempotent law then identifies the trace of the two-site
+multiplicity matrix with the one-site trace scalar for γ.
 
 The comparison of the two vertical canonical decompositions and the
 construction of the trace-preserving completely positive maps remain separate
@@ -32,7 +31,7 @@ open scoped BigOperators
 namespace MPOTensor
 
 /-- Indices of the products of one-site multiplicity entries and a chi entry
-which contribute to a fixed two-site sector `gamma`.
+which contribute to a fixed two-site sector γ.
 
 Source: arXiv:1606.00608, Appendix C.4, lines 2058--2063 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
@@ -44,10 +43,10 @@ abbrev BNTProductMultiplicityIndex {Λ : Type*} [Fintype Λ]
 /-- The multiplicity-spectrum comparison used in the algebra-to-RFP direction
 of Theorem IV.13.
 
-The one-site entries are the diagonal entries of `mu_alpha`; the two-site
-entries are those of `nu_gamma`.  The final field records the multiset
-identity obtained in the source from the comparison of the two vertical BNT
-decompositions and the positive power-sum lemma.
+The one-site entries are the diagonal entries of the multiplicity matrix for
+α; the two-site entries are those of the multiplicity matrix for γ.  The final
+field records the multiset identity obtained in the source from the comparison
+of the two vertical BNT decompositions and the positive power-sum lemma.
 
 This structure does not assert that an arbitrary algebra structure supplies
 the comparison.  Constructing it from the canonical-form MPDO tensor is the
@@ -57,15 +56,15 @@ Source: arXiv:1606.00608, Appendix C.4, lines 2048--2058 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 structure BNTMultiplicitySpectrumComparison {Λ : Type*} [Fintype Λ]
     (χ : DiagonalChiFamily Λ) (m : BNTLabelTraceScalarFamily Λ) where
-  /-- Size of the one-site multiplicity matrix `mu_alpha`. -/
+  /-- Size of the one-site multiplicity matrix for α. -/
   oneDim : Λ → ℕ
-  /-- Diagonal entries of the one-site multiplicity matrix `mu_alpha`. -/
+  /-- Diagonal entries of the one-site multiplicity matrix for α. -/
   oneEntry : ∀ α : Λ, Fin (oneDim α) → ℂ
-  /-- The trace of `mu_alpha` is the scalar `m_alpha`. -/
+  /-- The trace of the one-site multiplicity matrix for α is its trace scalar. -/
   oneTrace : ∀ α : Λ, ∑ i, oneEntry α i = m.traceScalar α
-  /-- Size of the two-site multiplicity matrix `nu_gamma`. -/
+  /-- Size of the two-site multiplicity matrix for γ. -/
   twoDim : Λ → ℕ
-  /-- Diagonal entries of the two-site multiplicity matrix `nu_gamma`. -/
+  /-- Diagonal entries of the two-site multiplicity matrix for γ. -/
   twoEntry : ∀ γ : Λ, Fin (twoDim γ) → ℂ
   /-- Sectorwise equality, with multiplicity, of the two-site spectrum and
   the products of the one-site and chi entries. -/
@@ -141,12 +140,12 @@ theorem sum_products_eq (γ : Λ) :
       rw [C.oneTrace, C.oneTrace]
       ring
 
-/-- The idempotent algebra law normalizes every two-site multiplicity matrix:
-`tr(nu_gamma) = m_gamma`.
+/-- The idempotent algebra law identifies the trace of every two-site
+multiplicity matrix with the corresponding one-site trace scalar.
 
 This is the scalar conclusion required before the source defines the
-preparation map with density matrix `nu_gamma / m_gamma`.  No channel or
-renormalization fixed-point conclusion is asserted here.
+preparation map by dividing the two-site multiplicity matrix by this scalar.
+No channel or renormalization fixed-point conclusion is asserted here.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 1933--1942, and
 Appendix C.4, lines 2058--2071 of
@@ -189,13 +188,13 @@ theorem idempotent_coefficient_form_ofChi :
     ← H.positiveChi.tracePower 1 Nat.zero_lt_one α β γ]
 
 /-- A BNT algebra clause, together with the multiplicity-spectrum comparison
-of the one-site and two-site vertical canonical decompositions, normalizes the
-two-site multiplicity trace:
-`tr(nu_gamma) = m_gamma`.
+of the one-site and two-site vertical canonical decompositions, identifies the
+two-site multiplicity trace with the corresponding one-site trace scalar.
 
 This is the first load-bearing conclusion in the algebra-to-RFP implication:
-it makes `nu_gamma / m_gamma` a trace-one matrix once positivity and nonzero
-sector weights have been supplied by the canonical decomposition.
+it makes the quotient of the two-site multiplicity matrix by that scalar a
+trace-one matrix once positivity and nonzero sector weights have been supplied
+by the canonical decomposition.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 1933--1942, and
 Appendix C.4, lines 2048--2071 of

--- a/TNLean/MPS/MPDO/BNTMultiplicityNormalization.lean
+++ b/TNLean/MPS/MPDO/BNTMultiplicityNormalization.lean
@@ -89,18 +89,8 @@ theorem sum_twoEntry_eq_sum_products (γ : Λ) :
     ∑ r, C.twoEntry γ r =
       ∑ x : BNTProductMultiplicityIndex χ C.oneDim γ,
         C.oneEntry x.1 x.2.2.1 * C.oneEntry x.2.1 x.2.2.2.1 *
-          χ.entry x.1 x.2.1 γ x.2.2.2.2 := by
-  classical
-  have h := congrArg Multiset.sum (C.spectrum_eq γ)
-  change (Finset.univ.val.map (C.twoEntry γ)).sum =
-    (Finset.univ.val.map fun x : BNTProductMultiplicityIndex χ C.oneDim γ =>
-      C.oneEntry x.1 x.2.2.1 * C.oneEntry x.2.1 x.2.2.2.1 *
-        χ.entry x.1 x.2.1 γ x.2.2.2.2).sum at h
-  change (Finset.univ.val.map (C.twoEntry γ)).sum =
-    (Finset.univ.val.map fun x : BNTProductMultiplicityIndex χ C.oneDim γ =>
-      C.oneEntry x.1 x.2.2.1 * C.oneEntry x.2.1 x.2.2.2.1 *
-        χ.entry x.1 x.2.1 γ x.2.2.2.2).sum
-  exact h
+          χ.entry x.1 x.2.1 γ x.2.2.2.2 :=
+  congrArg Multiset.sum (C.spectrum_eq γ)
 
 /-- The product multiplicity sum factors into the one-site traces and the
 length-one chi coefficient.
@@ -148,7 +138,7 @@ preparation map by dividing the two-site multiplicity matrix by this scalar.
 No channel or renormalization fixed-point conclusion is asserted here.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 1933--1942, and
-Appendix C.4, lines 2058--2071 of
+Appendix C.4, lines 2058--2064 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem twoTrace_eq_traceScalar
     (hIdempotent :
@@ -170,23 +160,6 @@ variable {Λ : Type*} [Fintype Λ] {O : ℕ → Type*}
   {m : BNTLabelTraceScalarFamily Λ}
   (H : BNTAlgebraClause c operators m)
 
-/-- The idempotent law of a BNT algebra clause may be transferred to the
-canonical coefficient family determined by its chi matrices.
-
-Source: arXiv:1606.00608, Theorem IV.13(ii), lines 1933--1942 of
-`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
-theorem idempotent_coefficient_form_ofChi :
-    m.HasIdempotentCoefficientForm
-      (BNTLabelCoefficientFamily.ofChi H.positiveChi.chi) := by
-  intro γ
-  rw [H.idempotent γ]
-  apply Finset.sum_congr rfl
-  intro α _
-  apply Finset.sum_congr rfl
-  intro β _
-  rw [BNTLabelCoefficientFamily.ofChi_coeff,
-    ← H.positiveChi.tracePower 1 Nat.zero_lt_one α β γ]
-
 /-- A BNT algebra clause, together with the multiplicity-spectrum comparison
 of the one-site and two-site vertical canonical decompositions, identifies the
 two-site multiplicity trace with the corresponding one-site trace scalar.
@@ -197,7 +170,7 @@ trace-one matrix once positivity and nonzero sector weights have been supplied
 by the canonical decomposition.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 1933--1942, and
-Appendix C.4, lines 2048--2071 of
+Appendix C.4, lines 2048--2064 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem twoMultiplicityTrace_eq_traceScalar
     (C : BNTMultiplicitySpectrumComparison H.positiveChi.chi m) (γ : Λ) :

--- a/TNLean/MPS/MPDO/BNTTheoremData.lean
+++ b/TNLean/MPS/MPDO/BNTTheoremData.lean
@@ -58,6 +58,33 @@ structure BNTAlgebraClause {Λ : Type*} [Fintype Λ] {O : ℕ → Type*}
   Source: arXiv:1606.00608, Theorem IV.13(ii), lines 981--985. -/
   idempotent : traceScalars.HasIdempotentCoefficientForm coeffs
 
+namespace BNTAlgebraClause
+
+variable {Λ : Type*} [Fintype Λ] {O : ℕ → Type*}
+  [∀ L : ℕ, AddCommMonoid (O L)] [∀ L : ℕ, Module ℂ (O L)]
+  [∀ L : ℕ, Mul (O L)]
+  {c : BNTLabelCoefficientFamily Λ} {operators : BNTLabelOperatorFamily Λ O}
+  {m : BNTLabelTraceScalarFamily Λ}
+  (H : BNTAlgebraClause c operators m)
+
+/-- The idempotent law of a BNT algebra clause may be transferred to the
+canonical coefficient family determined by its chi matrices.
+
+Source: arXiv:1606.00608, Theorem IV.13(ii), lines 1933--1942. -/
+theorem idempotent_coefficient_form_ofChi :
+    m.HasIdempotentCoefficientForm
+      (BNTLabelCoefficientFamily.ofChi H.positiveChi.chi) := by
+  intro γ
+  rw [H.idempotent γ]
+  apply Finset.sum_congr rfl
+  intro α _
+  apply Finset.sum_congr rfl
+  intro β _
+  rw [BNTLabelCoefficientFamily.ofChi_coeff,
+    ← H.positiveChi.tracePower 1 Nat.zero_lt_one α β γ]
+
+end BNTAlgebraClause
+
 /-- The BNT-label data asserted by the source theorem, together with its
 blocked-basis comparison.
 
@@ -272,15 +299,8 @@ Appendix C.4, lines 2015--2037 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem idempotent_coefficient_form_ofChi :
     H.traceScalars.HasIdempotentCoefficientForm
-      (BNTLabelCoefficientFamily.ofChi H.positiveChi.chi) := by
-  intro γ
-  rw [BNTLabelTraceScalarFamily.HasIdempotentCoefficientForm.eq_sum
-    (m := H.traceScalars) H.idempotent_coefficient_form γ]
-  refine Finset.sum_congr rfl ?_
-  intro α _hα
-  refine Finset.sum_congr rfl ?_
-  intro β _hβ
-  rw [H.coeff_eq_ofChi_coeff 1 Nat.zero_lt_one α β γ]
+      (BNTLabelCoefficientFamily.ofChi H.positiveChi.chi) :=
+  H.algebraClause.idempotent_coefficient_form_ofChi
 
 /-- The idempotent scalar equation carried by theorem data, written with the
 canonical coefficient family determined by the same

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
@@ -35,6 +35,65 @@
     blocked basis.
 \end{definition}
 
+\begin{definition}[BNT multiplicity-spectrum comparison]%
+    \label{def:mpdo_bnt_multiplicity_spectrum_comparison}
+    \lean{MPOTensor.BNTProductMultiplicityIndex}
+    \lean{MPOTensor.BNTMultiplicitySpectrumComparison}
+    \leanok
+    \uses{def:mpdo_bnt_algebra_clause}
+    Fix the one-site diagonal multiplicity matrices $\mu_\alpha$ and the
+    two-site diagonal multiplicity matrices $\nu_\gamma$ in the respective
+    vertical canonical decompositions.  A multiplicity-spectrum comparison
+    records
+    \[
+        \operatorname{tr}(\mu_\alpha)=m_\alpha
+    \]
+    and, for every $\gamma$, equality with multiplicity between the entries
+    of $\nu_\gamma$ and the products
+    \[
+        \mu_{\alpha,i}\mu_{\beta,j}
+        \chi_{\alpha,\beta,\gamma,k}.
+    \]
+    This is the conclusion of the vertical BNT comparison and positive
+    power-sum argument in
+    \cite[Appendix~C.4, lines~2048--2058]{Cirac2016MPDO_arXiv}.  The
+    definition does not assert that arbitrary support-algebra data supply
+    such a comparison.
+\end{definition}
+
+\begin{theorem}[Multiplicity trace normalization from the BNT algebra clause]%
+    \label{thm:mpdo_bnt_multiplicity_trace_normalization}
+    \lean{MPOTensor.BNTMultiplicitySpectrumComparison.sum_twoEntry_eq_sum_products}
+    \lean{MPOTensor.BNTMultiplicitySpectrumComparison.sum_products_eq}
+    \lean{MPOTensor.BNTMultiplicitySpectrumComparison.twoTrace_eq_traceScalar}
+    \lean{MPOTensor.BNTAlgebraClause.idempotent_coefficient_form_ofChi}
+    \lean{MPOTensor.BNTAlgebraClause.twoMultiplicityTrace_eq_traceScalar}
+    \leanok
+    \uses{def:mpdo_bnt_algebra_clause,
+        def:mpdo_bnt_multiplicity_spectrum_comparison}
+    Suppose that the BNT algebra clause holds and that the one-site and
+    two-site vertical multiplicity spectra have been compared as above.
+    Then every two-site multiplicity matrix has the prescribed trace:
+    \[
+        \operatorname{tr}(\nu_\gamma)
+        = \sum_{\alpha,\beta,i,j,k}
+          \mu_{\alpha,i}\mu_{\beta,j}
+          \chi_{\alpha,\beta,\gamma,k}
+        = \sum_{\alpha,\beta}
+          c^{(1)}_{\alpha,\beta,\gamma}m_\alpha m_\beta
+        = m_\gamma.
+    \]
+    This is the normalization used for the preparation matrix
+    $\nu_\gamma/m_\gamma$ in the algebra-to-RFP implication of
+    \cite[Appendix~C.4, lines~2058--2071]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+\begin{proof}\leanok
+    Sum the multiset equality of the two spectra.  The resulting product sum
+    factors into the two one-site traces and
+    $\operatorname{tr}(\chi_{\alpha,\beta,\gamma})$.  The length-one
+    idempotent law of the BNT algebra clause gives the final equality.
+\end{proof}
+
 \begin{definition}[BNT-label theorem data]%
     \label{def:mpdo_bnt_label_theorem_data}
     \lean{MPOTensor.BNTLabelTheoremData}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
@@ -76,6 +76,21 @@
     \]
 \end{lemma}
 
+\begin{proof}\leanok
+    The chi representation at length one gives
+    \[
+        c^{(1)}_{\alpha,\beta,\gamma}
+        =\tr(\chi_{\alpha,\beta,\gamma}).
+    \]
+    Substitution into the idempotent law
+    \[
+        m_\gamma
+        =\sum_{\alpha,\beta}
+          c^{(1)}_{\alpha,\beta,\gamma}m_\alpha m_\beta
+    \]
+    gives the stated identity.
+\end{proof}
+
 \begin{theorem}[Multiplicity trace normalization from the spectrum comparison
     and BNT algebra clause]%
     \label{thm:mpdo_bnt_multiplicity_trace_normalization}
@@ -114,8 +129,23 @@
         \left(\sum_j\mu_{\beta,j}\right)
         \left(\sum_k\chi_{\alpha,\beta,\gamma,k}\right).
     \]
-    The one-site trace identities and the length-one idempotent law of the BNT
-    algebra clause give the final equality.
+    The identities
+    \[
+        \sum_i\mu_{\alpha,i}=m_\alpha,
+        \qquad
+        \sum_j\mu_{\beta,j}=m_\beta,
+        \qquad
+        \sum_k\chi_{\alpha,\beta,\gamma,k}
+          =c^{(1)}_{\alpha,\beta,\gamma}
+    \]
+    therefore give
+    \[
+        \tr(\nu_\gamma)
+        =\sum_{\alpha,\beta}
+          m_\alpha m_\beta c^{(1)}_{\alpha,\beta,\gamma}
+        =m_\gamma,
+    \]
+    where the final equality is the length-one idempotent law.
 \end{proof}
 
 \begin{definition}[BNT-label theorem data]%

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
@@ -101,13 +101,21 @@
     \]
     This is the normalization used for the preparation matrix
     $\nu_\gamma/m_\gamma$ in the algebra-to-RFP implication of
-    \cite[Appendix~C.4, lines~2058--2071]{Cirac2016MPDO_arXiv}.
+    \cite[Appendix~C.4, lines~2058--2064]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 \begin{proof}\leanok
-    Sum the multiset equality of the two spectra.  The resulting product sum
-    factors into the two one-site traces and
-    $\operatorname{tr}(\chi_{\alpha,\beta,\gamma})$.  The length-one
-    idempotent law of the BNT algebra clause gives the final equality.
+    Sum the multiset equality of the two spectra.  For each
+    $\alpha,\beta,\gamma$, the resulting product sum satisfies
+    \[
+        \sum_{i,j,k}
+          \mu_{\alpha,i}\mu_{\beta,j}\chi_{\alpha,\beta,\gamma,k}
+        =
+        \left(\sum_i\mu_{\alpha,i}\right)
+        \left(\sum_j\mu_{\beta,j}\right)
+        \left(\sum_k\chi_{\alpha,\beta,\gamma,k}\right).
+    \]
+    The one-site trace identities and the length-one idempotent law of the BNT
+    algebra clause give the final equality.
 \end{proof}
 
 \begin{definition}[BNT-label theorem data]%

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
@@ -37,7 +37,6 @@
 
 \begin{definition}[BNT multiplicity-spectrum comparison]%
     \label{def:mpdo_bnt_multiplicity_spectrum_comparison}
-    \lean{MPOTensor.BNTProductMultiplicityIndex}
     \lean{MPOTensor.BNTMultiplicitySpectrumComparison}
     \leanok
     \uses{def:mpdo_bnt_algebra_clause}
@@ -57,20 +56,35 @@
     This is the conclusion of the vertical BNT comparison and positive
     power-sum argument in
     \cite[Appendix~C.4, lines~2048--2058]{Cirac2016MPDO_arXiv}.  The
-    definition does not assert that arbitrary support-algebra data supply
-    such a comparison.
+    definition does not require this comparison to follow from a BNT algebra
+    clause; constructing it from the MPDO tensor is a separate obligation.
 \end{definition}
+
+\begin{lemma}[Idempotence for the canonical chi coefficients]%
+    \label{lem:mpdo_bnt_idempotent_coefficient_form_of_chi}
+    \lean{MPOTensor.BNTAlgebraClause.idempotent_coefficient_form_ofChi}
+    \leanok
+    \uses{def:mpdo_bnt_algebra_clause}
+    The length-one idempotent law of a BNT algebra clause also holds for the
+    coefficient family determined by its diagonal chi matrices:
+    \[
+        m_\gamma
+        =\sum_{\alpha,\beta}
+          \operatorname{tr}(\chi_{\alpha,\beta,\gamma})
+          m_\alpha m_\beta.
+    \]
+\end{lemma}
 
 \begin{theorem}[Multiplicity trace normalization from the BNT algebra clause]%
     \label{thm:mpdo_bnt_multiplicity_trace_normalization}
     \lean{MPOTensor.BNTMultiplicitySpectrumComparison.sum_twoEntry_eq_sum_products}
     \lean{MPOTensor.BNTMultiplicitySpectrumComparison.sum_products_eq}
     \lean{MPOTensor.BNTMultiplicitySpectrumComparison.twoTrace_eq_traceScalar}
-    \lean{MPOTensor.BNTAlgebraClause.idempotent_coefficient_form_ofChi}
     \lean{MPOTensor.BNTAlgebraClause.twoMultiplicityTrace_eq_traceScalar}
     \leanok
     \uses{def:mpdo_bnt_algebra_clause,
-        def:mpdo_bnt_multiplicity_spectrum_comparison}
+        def:mpdo_bnt_multiplicity_spectrum_comparison,
+        lem:mpdo_bnt_idempotent_coefficient_form_of_chi}
     Suppose that the BNT algebra clause holds and that the one-site and
     two-site vertical multiplicity spectra have been compared as above.
     Then every two-site multiplicity matrix has the prescribed trace:

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
@@ -39,7 +39,8 @@
     \label{def:mpdo_bnt_multiplicity_spectrum_comparison}
     \lean{MPOTensor.BNTMultiplicitySpectrumComparison}
     \leanok
-    \uses{def:mpdo_bnt_algebra_clause}
+    \uses{def:mpdo_diagonal_chi_family,
+        def:mpdo_bnt_label_trace_scalar_family}
     Fix the one-site diagonal multiplicity matrices $\mu_\alpha$ and the
     two-site diagonal multiplicity matrices $\nu_\gamma$ in the respective
     vertical canonical decompositions.  A multiplicity-spectrum comparison
@@ -75,7 +76,8 @@
     \]
 \end{lemma}
 
-\begin{theorem}[Multiplicity trace normalization from the BNT algebra clause]%
+\begin{theorem}[Multiplicity trace normalization from the spectrum comparison
+    and BNT algebra clause]%
     \label{thm:mpdo_bnt_multiplicity_trace_normalization}
     \lean{MPOTensor.BNTMultiplicitySpectrumComparison.sum_twoEntry_eq_sum_products}
     \lean{MPOTensor.BNTMultiplicitySpectrumComparison.sum_products_eq}

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -211,6 +211,21 @@ fusion formulation must construct the BNT-label theorem witness from the MPDO
 tensor and then use the one-site retract criterion
 \leanid{MPOTensor.fusionIsometryData_one_iff_isRFP}.
 
+The scalar normalization step is now isolated independently of the still
+missing channel construction.  The structure
+\leanid{MPOTensor.BNTMultiplicitySpectrumComparison} records the one-site
+traces and the sectorwise multiset equality obtained from the vertical BNT
+comparison at lines~2048--2058.  Given this comparison, the BNT algebra
+clause proves
+\[
+    \tr(\nu_\gamma)=m_\gamma
+\]
+through
+\leanid{MPOTensor.BNTAlgebraClause.%
+twoMultiplicityTrace_eq_traceScalar}.  Thus the idempotent law now discharges
+the precise scalar obligation at lines~2058--2064; it does not construct the
+comparison from the MPDO tensor and does not yet define the maps $T$ and $S$.
+
 \section{BNT-label coefficient objects and remaining elimination plan}
 
 The same-length coefficient family $c^{(L)}_{\alpha,\beta,\gamma}$, indexed


### PR DESCRIPTION
Advances #3949 by formalizing the first scalar normalization step in the algebra-to-RFP implication of Theorem IV.13.

The new comparison object records the source-derived equality, with multiplicity, between the two-site spectrum and the products of one-site multiplicities with the diagonal chi entries. From this comparison and the BNT idempotent law, the main theorem proves

    tr(nu_gamma) = m_gamma.

This is exactly the normalization needed before the source forms nu_gamma / m_gamma. The pull request does not claim the full algebra-to-RFP implication: deriving the spectrum comparison from the canonical MPDO decomposition and constructing the CPTP maps T and S remain explicit obligations in the paper-gap note.

No new axiom, sorry, or kernel bypass is introduced.

Validation:
- targeted Lean check and build
- full lake build
- blueprint web generation
- leanblueprint checkdecls
- formatting and proof-integrity scans

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib formalization of isolated predicates and proofs; no axioms, runtime, or auth paths. Refactor only deduplicates an idempotent lemma on `BNTAlgebraClause`.
> 
> **Overview**
> Adds **`BNTMultiplicityNormalization.lean`**, which formalizes the scalar step in the BNT algebra-to-RFP route (Theorem IV.13 / Appendix C.4): a **`BNTMultiplicitySpectrumComparison`** hypothesis records sectorwise multiset equality between two-site multiplicity entries and products of one-site entries with χ; proved lemmas chain that to **∑ two-site entries = m_γ** via the length-one idempotent law.
> 
> **`BNTAlgebraClause.idempotent_coefficient_form_ofChi`** is moved into `BNTTheoremData.lean` on the algebra clause; theorem-data’s `idempotent_coefficient_form_ofChi` now delegates there instead of inlining the proof.
> 
> Blueprint chapter 21 and the CPGSV17 paper-gap note document the new definitions and state that this discharges the trace normalization for ν_γ/m_γ while MPDO-derived spectrum comparison and CPTP maps **T**/**S** remain open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b2015a8e6b2c86b099f8e4d9970a69b26499915. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->