### PR TITLE
feat(MPS/MPDO): derive multiplicity spectra from power sums

### DIFF
--- a/TNLean/MPS/MPDO/BNTMultiplicityNormalization.lean
+++ b/TNLean/MPS/MPDO/BNTMultiplicityNormalization.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.MPS.FundamentalTheorem.SectorWeightComparison
 import TNLean.MPS.MPDO.BNTTheoremData
 
 /-!
@@ -18,7 +19,9 @@ multiplicity matrix with the one-site trace scalar for γ.
 
 The comparison of the two vertical canonical decompositions and the
 construction of the trace-preserving completely positive maps remain separate
-obligations.
+obligations.  Once that comparison supplies eventual equality of the
+sectorwise positive power sums, `ofEventuallyEqualPowerSums` constructs the
+required equality of multiplicity spectra.
 
 ## References
 
@@ -26,7 +29,7 @@ obligations.
   Theorem IV.13(ii) and Appendix C.4, lines 2048--2064
 -/
 
-open scoped BigOperators
+open scoped BigOperators ComplexOrder
 
 namespace MPOTensor
 
@@ -79,6 +82,87 @@ namespace BNTMultiplicitySpectrumComparison
 variable {Λ : Type*} [Fintype Λ] {χ : DiagonalChiFamily Λ}
   {m : BNTLabelTraceScalarFamily Λ}
   (C : BNTMultiplicitySpectrumComparison χ m)
+
+/-- Eventual equality of the positive power sums, together with positivity of
+all multiplicity and chi entries, constructs the multiplicity-spectrum
+comparison.
+
+This is precisely the application of the Appendix power-sum lemma after the
+one-site algebraic expansion and the two-site vertical canonical form have
+been matched sectorwise.  It does not establish that matching or derive the
+eventual power-sum equality from a matrix product density operator.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2048--2058, using the finite
+power-sum lemma at lines 1155--1163. -/
+noncomputable def ofEventuallyEqualPowerSums
+    (χ : DiagonalChiFamily Λ) (m : BNTLabelTraceScalarFamily Λ)
+    (hχ : χ.PosEntries)
+    (oneDim : Λ → ℕ) (oneEntry : ∀ α : Λ, Fin (oneDim α) → ℂ)
+    (onePos : ∀ α i, (0 : ℂ) < oneEntry α i)
+    (oneTrace : ∀ α : Λ, ∑ i, oneEntry α i = m.traceScalar α)
+    (twoDim : Λ → ℕ) (twoEntry : ∀ γ : Λ, Fin (twoDim γ) → ℂ)
+    (twoPos : ∀ γ r, (0 : ℂ) < twoEntry γ r)
+    {L₀ : ℕ}
+    (powerSums : ∀ γ : Λ, ∀ L : ℕ, L₀ < L →
+      (∑ r, twoEntry γ r ^ L) =
+        ∑ x : BNTProductMultiplicityIndex χ oneDim γ,
+          (oneEntry x.1 x.2.2.1 * oneEntry x.2.1 x.2.2.2.1 *
+            χ.entry x.1 x.2.1 γ x.2.2.2.2) ^ L) :
+    BNTMultiplicitySpectrumComparison χ m where
+  oneDim := oneDim
+  oneEntry := oneEntry
+  oneTrace := oneTrace
+  twoDim := twoDim
+  twoEntry := twoEntry
+  spectrum_eq := by
+    classical
+    intro γ
+    let I := BNTProductMultiplicityIndex χ oneDim γ
+    let productEntry : I → ℂ := fun x =>
+      oneEntry x.1 x.2.2.1 * oneEntry x.2.1 x.2.2.2.1 *
+        χ.entry x.1 x.2.1 γ x.2.2.2.2
+    let e : Fin (Fintype.card I) ≃ I := (Fintype.equivFin I).symm
+    have hTwoNe : ∀ r, twoEntry γ r ≠ 0 :=
+      fun r => (twoPos γ r).ne'
+    have hProductNe : ∀ x : I, productEntry x ≠ 0 := by
+      intro x
+      exact mul_ne_zero
+        (mul_ne_zero (onePos x.1 x.2.2.1).ne'
+          (onePos x.2.1 x.2.2.2.1).ne')
+        (hχ x.1 x.2.1 γ x.2.2.2.2).ne'
+    have hEventually : ∀ L : ℕ, L₀ + 1 ≤ L →
+        (∑ r, twoEntry γ r ^ L) =
+          ∑ i : Fin (Fintype.card I), (productEntry (e i)) ^ L := by
+      intro L hL
+      calc
+        (∑ r, twoEntry γ r ^ L) =
+            ∑ x : I, (productEntry x) ^ L := by
+          simpa [I, productEntry] using powerSums γ L (by omega)
+        _ = ∑ i : Fin (Fintype.card I), (productEntry (e i)) ^ L :=
+          (e.sum_comp fun x => (productEntry x) ^ L).symm
+    have hAll : ∀ L : ℕ,
+        (∑ r, twoEntry γ r ^ L) =
+          ∑ i : Fin (Fintype.card I), (productEntry (e i)) ^ L :=
+      MPSTensor.SectorWeightData.power_sums_eq_of_eventually_eq_hetero
+        (twoEntry γ) (fun i => productEntry (e i)) hTwoNe
+        (fun i => hProductNe (e i)) hEventually
+    have hMultiset :=
+      (Matrix.sum_pow_eq_implies_card_eq_and_multiset_eq_of_le_max_card
+        (twoDim γ) (Fintype.card I) (twoEntry γ)
+        (fun i => productEntry (e i)) hTwoNe (fun i => hProductNe (e i))
+        (fun L _ _ => hAll L)).2
+    rw [show Finset.univ.val.map (fun i => productEntry (e i)) =
+        Finset.univ.val.map productEntry by
+      calc
+        Finset.univ.val.map (fun i => productEntry (e i)) =
+            (Finset.univ.map e.toEmbedding).val.map productEntry := by
+          rw [Finset.map_val, Multiset.map_map]
+          rfl
+        _ = Finset.univ.val.map productEntry := by
+          congr 2
+          ext x
+          simp] at hMultiset
+    exact hMultiset
 
 /-- Summing the sectorwise multiplicity-spectrum comparison gives the
 corresponding equality of traces.

--- a/TNLean/MPS/MPDO/BNTMultiplicityNormalization.lean
+++ b/TNLean/MPS/MPDO/BNTMultiplicityNormalization.lean
@@ -151,17 +151,18 @@ noncomputable def ofEventuallyEqualPowerSums
         (twoDim γ) (Fintype.card I) (twoEntry γ)
         (fun i => productEntry (e i)) hTwoNe (fun i => hProductNe (e i))
         (fun L _ _ => hAll L)).2
+    have hMap :
+        Multiset.map e (Finset.univ : Finset (Fin (Fintype.card I))).val =
+          (Finset.univ : Finset I).val :=
+      Multiset.map_univ_val_equiv e
     rw [show Finset.univ.val.map (fun i => productEntry (e i)) =
         Finset.univ.val.map productEntry by
       calc
         Finset.univ.val.map (fun i => productEntry (e i)) =
-            (Finset.univ.map e.toEmbedding).val.map productEntry := by
-          rw [Finset.map_val, Multiset.map_map]
-          rfl
+            (Finset.univ.val.map e).map productEntry :=
+          (Multiset.map_map productEntry e Finset.univ.val).symm
         _ = Finset.univ.val.map productEntry := by
-          congr 2
-          ext x
-          simp] at hMultiset
+          rw [hMap]] at hMultiset
     exact hMultiset
 
 /-- Summing the sectorwise multiplicity-spectrum comparison gives the

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -776,9 +776,15 @@ multiset with multiplicity.
 \end{lemma}
 
 \begin{proof}\leanok
-    Apply Lemma~\ref{lem:finite_geometric_sum_eventual_vanishing} to the joined
-    family $(a_1,\ldots,a_m,b_1,\ldots,b_n)$ with coefficients $+1$ on the
-    first family and $-1$ on the second.
+    Set $w_l=a_l$ for $l\leq m$ and $w_{m+l}=b_l$ for $l\leq n$, with
+    coefficients $c_l=1$ for $l\leq m$ and $c_l=-1$ for $l>m$.  Then
+    \[
+        \sum_{l=1}^{m+n}c_lw_l^k
+        =\sum_i a_i^k-\sum_j b_j^k.
+    \]
+    The hypothesis makes this expression zero for every sufficiently large
+    $k$.  Lemma~\ref{lem:finite_geometric_sum_eventual_vanishing} makes it zero
+    for every $k$, which is the required power-sum equality.
 \end{proof}
 
 \begin{theorem}[Finite-range equal power sums imply equal multisets]

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -738,6 +738,49 @@ basis tensors are compared: the coefficient $\sum_q \mu_{j,q}^N$ then equals
 $\sum_q (\nu_{j,q} e^{i\phi_j})^N$, and Newton--Girard recovers the weight
 multiset with multiplicity.
 
+\begin{lemma}[Eventual vanishing of a finite geometric sum]
+    \label{lem:finite_geometric_sum_eventual_vanishing}
+    \lean{MPSTensor.SectorWeightData.geom_sum_eventually_zero}
+    \leanok
+    Let $w_1,\ldots,w_n$ be nonzero complex numbers.  If
+    \[
+        \sum_i c_i w_i^N=0
+    \]
+    for every sufficiently large $N$, then the same equality holds for every
+    nonnegative exponent.
+\end{lemma}
+
+\begin{proof}\leanok
+    Induct on the number of terms.  Subtracting $w_1$ times the equality at
+    exponent $N$ from the equality at exponent $N+1$ gives
+    \[
+        \sum_{i=2}^{n} c_i(w_i-w_1)w_i^N=0.
+    \]
+    The induction hypothesis yields this equality at every exponent, so the
+    original sum $S_N=\sum_i c_iw_i^N$ satisfies $S_{N+1}=w_1S_N$ for every
+    $N$.  Since $S_N$ eventually vanishes and $w_1\ne0$, it follows that
+    $S_0=0$ and hence $S_N=0$ for every $N$.
+\end{proof}
+
+\begin{lemma}[Eventual power-sum equality holds at every exponent]
+    \label{lem:eventual_power_sum_equality_all_exponents}
+    \lean{MPSTensor.SectorWeightData.power_sums_eq_of_eventually_eq_hetero}
+    \leanok
+    \uses{lem:finite_geometric_sum_eventual_vanishing}
+    Let $a_1,\ldots,a_m$ and $b_1,\ldots,b_n$ be nonzero complex numbers.  If
+    their power sums agree for every sufficiently large exponent, then
+    \[
+        \sum_i a_i^k=\sum_j b_j^k
+    \]
+    for every nonnegative exponent $k$.
+\end{lemma}
+
+\begin{proof}\leanok
+    Apply Lemma~\ref{lem:finite_geometric_sum_eventual_vanishing} to the joined
+    family $(a_1,\ldots,a_m,b_1,\ldots,b_n)$ with coefficients $+1$ on the
+    first family and $-1$ on the second.
+\end{proof}
+
 \begin{theorem}[Finite-range equal power sums imply equal multisets]
     \label{thm:bounded_power_sum_multiset}
     \lean{Matrix.sum_pow_eq_implies_multiset_eq_of_le_card,

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
@@ -91,6 +91,49 @@
     gives the stated identity.
 \end{proof}
 
+\begin{theorem}[Eventual power sums determine the multiplicity spectrum]%
+    \label{thm:mpdo_bnt_eventual_power_sums_determine_multiplicity_spectrum}
+    \lean{MPOTensor.BNTMultiplicitySpectrumComparison.%
+        ofEventuallyEqualPowerSums}
+    \leanok
+    \uses{def:mpdo_bnt_multiplicity_spectrum_comparison,
+        thm:bounded_power_sum_multiset}
+    Suppose that every entry of the one-site multiplicity matrices, every
+    entry of the two-site multiplicity matrices, and every entry of the
+    matrices $\chi_{\alpha,\beta,\gamma}$ is positive.  Suppose also that
+    \[
+        \sum_i \mu_{\alpha,i}=m_\alpha
+        \qquad\text{for every }\alpha.
+    \]
+    If, for every $\gamma$ and all sufficiently large $L$,
+    \[
+        \sum_r \nu_{\gamma,r}^{L}
+        =
+        \sum_{\alpha,\beta,i,j,k}
+        \bigl(
+          \mu_{\alpha,i}\mu_{\beta,j}
+          \chi_{\alpha,\beta,\gamma,k}
+        \bigr)^L,
+    \]
+    then the entries on the two sides agree as multisets.  Together with the
+    displayed one-site trace identity, these data define a BNT
+    multiplicity-spectrum comparison.
+\end{theorem}
+\begin{proof}\leanok
+    Positivity makes all entries nonzero.  Eventual equality of two finite
+    sums of geometric sequences gives
+    \[
+        \sum_r \nu_{\gamma,r}^{L}
+        =
+        \sum_{\alpha,\beta,i,j,k}
+        \bigl(\mu_{\alpha,i}\mu_{\beta,j}
+          \chi_{\alpha,\beta,\gamma,k}\bigr)^L
+        \qquad (L\geq 1).
+    \]
+    The finite power-sum identity determines both the cardinality and the
+    multiset of entries.
+\end{proof}
+
 \begin{theorem}[Multiplicity trace normalization from the spectrum comparison
     and BNT algebra clause]%
     \label{thm:mpdo_bnt_multiplicity_trace_normalization}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
@@ -100,10 +100,10 @@
         thm:bounded_power_sum_multiset}
     Suppose that every entry of the one-site multiplicity matrices, every
     entry of the two-site multiplicity matrices, and every entry of the
-    matrices $\chi_{\alpha,\beta,\gamma}$ is positive.  Suppose also that
+    matrices $\chi_{\alpha,\beta,\gamma}$ is positive.  Suppose also that, for
+    every $\alpha$,
     \[
-        \sum_i \mu_{\alpha,i}=m_\alpha
-        \qquad\text{for every }\alpha.
+        \sum_i \mu_{\alpha,i}=m_\alpha.
     \]
     If, for every $\gamma$ and all sufficiently large $L$,
     \[
@@ -116,19 +116,18 @@
         \bigr)^L,
     \]
     then the entries on the two sides agree as multisets.  Together with the
-    displayed one-site trace identity, these data define a BNT
-    multiplicity-spectrum comparison.
+    displayed one-site trace identity, the one-site and two-site multiplicity
+    entries and their dimensions define a BNT multiplicity-spectrum comparison.
 \end{theorem}
 \begin{proof}\leanok
     Positivity makes all entries nonzero.  Eventual equality of two finite
-    sums of geometric sequences gives
+    sums of geometric sequences gives, for every $L\geq 1$,
     \[
         \sum_r \nu_{\gamma,r}^{L}
         =
         \sum_{\alpha,\beta,i,j,k}
         \bigl(\mu_{\alpha,i}\mu_{\beta,j}
-          \chi_{\alpha,\beta,\gamma,k}\bigr)^L
-        \qquad (L\geq 1).
+          \chi_{\alpha,\beta,\gamma,k}\bigr)^L.
     \]
     The finite power-sum identity determines both the cardinality and the
     multiset of entries.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
@@ -91,12 +91,13 @@
     gives the stated identity.
 \end{proof}
 
-\begin{theorem}[Eventual power sums determine the multiplicity spectrum]%
-    \label{thm:mpdo_bnt_eventual_power_sums_determine_multiplicity_spectrum}
+\begin{definition}[Multiplicity-spectrum comparison from eventual power sums]%
+    \label{def:mpdo_bnt_eventual_power_sums_multiplicity_comparison}
     \lean{MPOTensor.BNTMultiplicitySpectrumComparison.%
         ofEventuallyEqualPowerSums}
     \leanok
     \uses{def:mpdo_bnt_multiplicity_spectrum_comparison,
+        lem:eventual_power_sum_equality_all_exponents,
         thm:bounded_power_sum_multiset}
     Suppose that every entry of the one-site multiplicity matrices, every
     entry of the two-site multiplicity matrices, and every entry of the
@@ -118,8 +119,7 @@
     then the entries on the two sides agree as multisets.  Together with the
     displayed one-site trace identity, the one-site and two-site multiplicity
     entries and their dimensions define a BNT multiplicity-spectrum comparison.
-\end{theorem}
-\begin{proof}\leanok
+
     Positivity makes all entries nonzero.  Eventual equality of two finite
     sums of geometric sequences gives, for every $L\geq 1$,
     \[
@@ -131,7 +131,7 @@
     \]
     The finite power-sum identity determines both the cardinality and the
     multiset of entries.
-\end{proof}
+\end{definition}
 
 \begin{theorem}[Multiplicity trace normalization from the spectrum comparison
     and BNT algebra clause]%

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -226,6 +226,29 @@ twoMultiplicityTrace_eq_traceScalar}.  Thus the idempotent law now discharges
 the precise scalar obligation at lines~2058--2064; it does not construct the
 comparison from the MPDO tensor and does not yet define the maps $T$ and $S$.
 
+The power-sum part of the preceding comparison is also isolated.  The
+constructor
+\leanid{MPOTensor.BNTMultiplicitySpectrumComparison.%
+ofEventuallyEqualPowerSums} proves that positivity and eventual sectorwise
+equality of the power sums imply the required multiset equality.  It combines
+the geometric-sequence extrapolation already used in the BNT Fundamental
+Theorem with the unequal-cardinality power-sum identity, and therefore proves
+the power-sum step used at lines~2053--2058.
+
+What remains before this constructor can be applied is the tensor-level BNT
+comparison at lines~2048--2058.  The current
+\leanid{MPOTensor.BNTAlgebraClause} does not identify its abstract operator
+family with the concrete operators $O_L(M_\alpha)$ of a chosen one-site
+vertical canonical form, and it does not identify its trace scalars with the
+entries of the corresponding matrices $\mu_\alpha$.  Moreover, the current
+vertical canonical-form theorem supplies a decomposition of $M$, but no
+single object simultaneously records that decomposition, a vertical
+canonical decomposition of the two-site blocked tensor, and the relabelling
+and unitary identifications of their BNT sectors.  Such an object must yield
+the displayed eventual power-sum equality from the same-length algebra law;
+the constructor above then supplies the spectrum comparison without any
+further mathematical hypothesis.
+
 \section{BNT-label coefficient objects and remaining elimination plan}
 
 The same-length coefficient family $c^{(L)}_{\alpha,\beta,\gamma}$, indexed


### PR DESCRIPTION
Advances #3949 without closing it.

This pull request isolates the Appendix C.4 power-sum step. For positive one-site multiplicities, positive two-site multiplicities, and positive chi entries, the source eventual sectorwise power-sum identity determines the two-site multiplicity multiset. Together with the explicit one-site trace identity, this constructs BNTMultiplicitySpectrumComparison.

The result does not assume that the present abstract BNT algebra clause already supplies the power-sum identity. The paper-gap note records the remaining tensor-level obligation: compare a concrete one-site vertical canonical form with a concrete two-site blocked vertical canonical form, including the sector relabelling and unitary identifications.

Validation:
- focused Lean build
- full build on the original isolated commit before restacking
- blueprint synchronization and changed-declaration coverage
- leanblueprint checkdecls
- reader-facing prose check
- proof-integrity scan

No axiom, sorry, or tensor-level hypothesis is introduced.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization of an isolated algebraic step using existing lemmas; no auth, runtime, or new axioms/sorries, and the tensor-level comparison obligation is explicitly left open.
> 
> **Overview**
> **Isolates Appendix C.4’s power-sum step** for BNT multiplicity normalization: given positive one-site/two-site multiplicities and χ entries, plus one-site trace scalars and **eventual** sectorwise equality of power sums, the PR builds a `BNTMultiplicitySpectrumComparison` via `ofEventuallyEqualPowerSums`.
> 
> The proof chains **eventual → all-exponent** power-sum equality (`power_sums_eq_of_eventually_eq_hetero`) with the finite **bounded power-sum multiset** lemma, then reindexes product indices to match the spectrum multiset field. It does **not** assume the abstract BNT algebra clause already supplies those power sums or construct them from an MPDO tensor.
> 
> Blueprint **ch10** adds lemmas for eventual vanishing of finite geometric sums and eventual power-sum equality; **ch21** documents the new constructor. The **cpgsv17** paper-gap note records that this closes the power-sum substep and what tensor-level BNT comparison remains upstream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9282861cbec4178b2074631c8bc347d234046796. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->