### PR TITLE
feat(MPS/MPDO): prove the sharp 3D^5 block-injectivity bound

### DIFF
--- a/TNLean/MPS/MPDO/BiCFDerivation.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation.lean
@@ -11,9 +11,9 @@ import TNLean.MPS.MPDO.BiCFDerivation.DiagonalRestrictionCounterexample
 This module retains the historical import path for the MPDO biCF derivation
 layer while the finite-length criteria are organized by their mathematical
 role. It imports the proof-complete obstruction and criterion layer. The
-direct-sum uniqueness capstone remains available from its own files, but is not
-imported here while it depends on the unfinished parent-Hamiltonian uniqueness
-argument.
+direct-sum uniqueness and sharp BNT block-separation theorems remain available
+from their own files; they are not imported here because this historical path
+is intended to retain the lighter criterion layer.
 
 The supporting modules are:
 
@@ -42,9 +42,9 @@ The supporting modules are:
   two injective block states have distinct MPV lines.
 * `TNLean.MPS.MPDO.BiCFDerivation.BNTDirectSum` — the BNT-facing direct-sum
   form that supplies that distinctness input from separated same-dimension
-  blocks and gives the fixed three-block pair separation for all ordered pairs,
-  while keeping the direct-sum injectivity hypotheses explicit. This capstone
-  is imported directly by users who need the unfinished uniqueness route.
+  blocks, gives the fixed three-block pair separation for all ordered pairs,
+  and proves the sharp \(3D^5\) simultaneous representative span. This heavier
+  theorem is imported directly by users who need the BNT conclusion.
 
 ## References
 

--- a/TNLean/MPS/MPDO/BiCFDerivation/BNTDirectSum.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/BNTDirectSum.lean
@@ -464,6 +464,24 @@ theorem exists_wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors_
     wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors_c1
       A hIrr hLeft hOverlap hBlocks hBlk0 hBlk1 hBlk3 hL₀⟩
 
+/-- The elementary numerical estimate in the sharp BNT block-separation bound. -/
+theorem three_mul_pred_mul_pow_four_add_one_le_three_mul_pow_five
+    {D : ℕ} (hD : 0 < D) :
+    3 * ((D - 1) * (D ^ 4 + 1)) ≤ 3 * D ^ 5 := by
+  have hDleD4 : D ≤ D ^ 4 := by
+    simpa using (pow_le_pow_right' (a := D) hD (by omega : 1 ≤ 4))
+  have hDsubLeD4 : D - 1 ≤ D ^ 4 :=
+    (Nat.sub_le D 1).trans hDleD4
+  have hCore : (D - 1) * (D ^ 4 + 1) ≤ D ^ 5 := by
+    calc
+      (D - 1) * (D ^ 4 + 1) = (D - 1) * D ^ 4 + (D - 1) := by ring
+      _ ≤ (D - 1) * D ^ 4 + D ^ 4 := Nat.add_le_add_left hDsubLeD4 _
+      _ = (D - 1) * D ^ 4 + 1 * D ^ 4 := by rw [one_mul]
+      _ = ((D - 1) + 1) * D ^ 4 := (Nat.add_mul (D - 1) 1 (D ^ 4)).symm
+      _ = D * D ^ 4 := by rw [Nat.sub_add_cancel (by omega)]
+      _ = D ^ 5 := by ring
+  exact Nat.mul_le_mul_left 3 hCore
+
 namespace IsBNTCanonicalForm
 
 variable {P : SectorDecomposition d}
@@ -541,31 +559,13 @@ theorem exists_basis_wordTupleSpanTop_le_three_totalDim_pow_five
                 ((P.totalDim ^ 4 + 1) + (P.totalDim ^ 4 + 1))) :=
         Nat.mul_le_mul_right _ hPredLe
       refine hFirst.trans ?_
-      have hDleD4 : P.totalDim ≤ P.totalDim ^ 4 := by
-        simpa using
-          (pow_le_pow_right' (a := P.totalDim) hDpos (by omega : 1 ≤ 4))
-      have hDsubLeD4 : P.totalDim - 1 ≤ P.totalDim ^ 4 :=
-        (Nat.sub_le P.totalDim 1).trans hDleD4
-      have hCore :
-          (P.totalDim - 1) * (P.totalDim ^ 4 + 1) ≤ P.totalDim ^ 5 := by
-        calc
-          (P.totalDim - 1) * (P.totalDim ^ 4 + 1) =
-              (P.totalDim - 1) * P.totalDim ^ 4 + (P.totalDim - 1) := by ring
-          _ ≤ (P.totalDim - 1) * P.totalDim ^ 4 + P.totalDim ^ 4 :=
-            Nat.add_le_add_left hDsubLeD4 _
-          _ = (P.totalDim - 1) * P.totalDim ^ 4 + 1 * P.totalDim ^ 4 := by
-            rw [one_mul]
-          _ = ((P.totalDim - 1) + 1) * P.totalDim ^ 4 :=
-            (Nat.add_mul (P.totalDim - 1) 1 (P.totalDim ^ 4)).symm
-          _ = P.totalDim * P.totalDim ^ 4 := by
-            rw [Nat.sub_add_cancel (by omega)]
-          _ = P.totalDim ^ 5 := by ring
       calc
         (P.totalDim - 1) *
             ((P.totalDim ^ 4 + 1) +
               ((P.totalDim ^ 4 + 1) + (P.totalDim ^ 4 + 1))) =
             3 * ((P.totalDim - 1) * (P.totalDim ^ 4 + 1)) := by ring
-        _ ≤ 3 * P.totalDim ^ 5 := Nat.mul_le_mul_left 3 hCore
+        _ ≤ 3 * P.totalDim ^ 5 :=
+          three_mul_pred_mul_pow_four_add_one_le_three_mul_pow_five hDpos
 
 end IsBNTCanonicalForm
 

--- a/TNLean/MPS/MPDO/BiCFDerivation/BNTDirectSum.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/BNTDirectSum.lean
@@ -5,18 +5,20 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.BNT.Construction
 import TNLean.MPS.MPDO.BiCFDerivation.DirectSumUniqueness
 import TNLean.MPS.MPDO.BiCFDerivation.Selectors
+import TNLean.MPS.Periodic.NormalizedSelfOverlap
 
 /-!
 # BNT input for the equal-size direct-sum branch
 
 This file connects the same-dimension BNT separation hypothesis to the
-parent-Hamiltonian uniqueness input for David--Perez-Garcia--Schuch--Wolf,
-Lemma `lem:direct-sum`.
+parent-Hamiltonian uniqueness input in the direct-sum proof of
+Perez-Garcia--Verstraete--Wolf--Cirac, lines 1346--1408.
 
-The statement deliberately keeps the direct-sum hypotheses explicit:
+The intermediate statements keep the direct-sum hypotheses explicit:
 `BlocksNotGaugePhaseEquiv` gives the long-chain non-proportional MPV witness,
-while injectivity and length-`L` block injectivity are still separate inputs to
-the parent-Hamiltonian argument.
+while injectivity and finite-length block injectivity are separate inputs to
+the parent-Hamiltonian argument. The final theorem derives these inputs from a
+BNT canonical form and proves the source bound \(3D^5\).
 -/
 
 open scoped Matrix BigOperators
@@ -28,8 +30,8 @@ variable {d L : ℕ}
 /-- Same-dimension BNT-separated blocks give the equal-size direct-sum
 directness conclusion once the direct-sum injectivity hypotheses are supplied.
 
-This is the BNT-facing form of the equal-size branch of
-David--Perez-Garcia--Schuch--Wolf, Lemma `lem:direct-sum`.  The theorem does
+This is the BNT-facing form of the equal-size branch of the direct-sum proof in
+Perez-Garcia--Verstraete--Wolf--Cirac, lines 1346--1408. The theorem does
 not infer injectivity or transport non-equivalence through blocking; those
 inputs remain explicit. It is exported for the pair-trace theorem below and for
 downstream direct-sum comparisons that need the image-space directness statement
@@ -60,10 +62,10 @@ theorem groundSpace_inf_eq_bot_of_blocksNotGaugePhaseEquiv_same_dim_of_dim_ge
 /-- Same-dimension BNT-separated blocks give the PGVWC directness conclusion from
 Condition C1 at a finite length \(L_0\).
 
-PGVWC07, Lemma `lem:direct-sum`, first uses Condition C1 in each block at
-length \(L_0\), then compares the spaces \(\mathcal G_{L_0+1}^{A^j}\). This
-version follows that length convention and does not assume one-site
-injectivity. -/
+Perez-Garcia--Verstraete--Wolf--Cirac, lines 1346--1408, first uses Condition
+C1 in each block at length \(L_0\), then compares the spaces
+\(\mathcal G_{L_0+1}^{A^j}\). This version follows that length convention and
+does not assume one-site injectivity. -/
 theorem groundSpace_inf_eq_bot_of_blocksNotGaugePhaseEquiv_same_dim_of_dim_ge_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -191,7 +193,7 @@ Condition C1 at \(L_0\), without the one-site special case of Condition C1.
 
 The length is \(3(L_0+1)\), written as
 \((L_0+1)+((L_0+1)+(L_0+1))\) to match the formal concatenation of the three
-blocks in PGVWC07, Lemma `lem:direct-sum`. -/
+blocks in Perez-Garcia--Verstraete--Wolf--Cirac, lines 1346--1408. -/
 theorem forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -223,6 +225,32 @@ theorem forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_c1
       hL₀
   · exact pairTraceSeparatingAt_threeBlock_of_isNBlkInjective_of_dim_ne
       (hBlk1 k) (hBlk1 j) (hBlk3 k) (hBlk3 j) hdim
+
+/-- For at least two BNT representatives, the direct-sum word tuples span the
+full product algebra at the source length \(3(r-1)(L_0+1)\).
+
+The pairwise three-block argument supplies an arbitrary value on one block and
+zero on an anchor block. Identity--zero pair selectors remove the remaining
+blocks without a separate injective prefix. This is the induction length in
+Perez-Garcia--Verstraete--Wolf--Cirac, lines 1346--1408. -/
+theorem wordTupleSpanTop_threeBlock_mul_pred_of_blocksNotGaugePhaseEquiv_c1
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    {L₀ : ℕ}
+    (hBlk0 : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hBlk1 : ∀ k : Fin r, IsNBlkInjective (A k) (L₀ + 1))
+    (hBlk3 : ∀ k : Fin r,
+      IsNBlkInjective (A k) ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))))
+    (hL₀ : 0 < L₀) (hr : 2 ≤ r) :
+    WordTupleSpanTop A
+      ((r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1)))) :=
+  wordTupleSpanTop_mul_pred_of_forall_pairTraceSeparatingAt A hr
+    (forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_c1
+      A hIrr hLeft hOverlap hBlocks hBlk0 hBlk1 hBlk3 hL₀)
 
 /-- Existential common-length form of
 `forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv`.
@@ -269,8 +297,8 @@ theorem exists_forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEqu
 /-- BNT-separated blocks give common pairwise block-separating equations at the
 three-block length, once the direct-sum injectivity hypotheses are supplied.
 
-This is the selector-facing consequence of the direct-sum input used in
-PGVWC07, Lemma `lem:direct-sum`: the homogeneous trace separation at
+This is the selector-facing consequence of the direct-sum input in
+Perez-Garcia--Verstraete--Wolf--Cirac, lines 1346--1408: homogeneous trace separation at
 \(L+(L+L)\) is converted into equations selecting one block against another. -/
 theorem hasPairBlockSeparatingWords_threeBlock_of_blocksNotGaugePhaseEquiv
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -435,5 +463,110 @@ theorem exists_wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors_
   ⟨(L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))),
     wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors_c1
       A hIrr hLeft hOverlap hBlocks hBlk0 hBlk1 hBlk3 hL₀⟩
+
+namespace IsBNTCanonicalForm
+
+variable {P : SectorDecomposition d}
+
+/-- A BNT canonical form has a simultaneous representative word span at some
+positive length at most \(3D^5\), where \(D\) is the total bond dimension.
+
+For two or more representatives, this is the source estimate
+\(3(g-1)(D^4+1)\leq 3D^5\). For one representative, ordinary block
+injectivity at \(D^4\) gives the conclusion. This is the sharp
+block-injectivity proposition of arXiv:1606.00608, lines 340--345. -/
+theorem exists_basis_wordTupleSpanTop_le_three_totalDim_pow_five
+    (hCF : IsBNTCanonicalForm P) :
+    ∃ N : ℕ, 0 < N ∧ N ≤ 3 * P.totalDim ^ 5 ∧ WordTupleSpanTop P.basis N := by
+  classical
+  obtain ⟨j₀, _q₀, _hweight⟩ := hCF.weight_unit_exists
+  have hDpos : 0 < P.totalDim :=
+    lt_of_lt_of_le (hCF.basis_dim_pos j₀) (P.basisDim_le_totalDim j₀)
+  have hD4pos : 0 < P.totalDim ^ 4 := Nat.pow_pos hDpos
+  have hBlk0 : ∀ j : Fin P.basisCount,
+      IsNBlkInjective (P.basis j) (P.totalDim ^ 4) :=
+    hCF.basis_isNBlkInjective_totalDim_pow_four
+  by_cases hCountOne : P.basisCount = 1
+  · refine ⟨P.totalDim ^ 4, hD4pos, ?_, ?_⟩
+    · calc
+        P.totalDim ^ 4 = P.totalDim ^ 4 * 1 := by simp
+        _ ≤ P.totalDim ^ 4 * (3 * P.totalDim) := by
+          exact Nat.mul_le_mul_left _ (by omega)
+        _ = 3 * P.totalDim ^ 5 := by ring
+    · exact wordTupleSpanTop_of_card_eq_one_of_isNBlkInjective
+        P.basis hCountOne hBlk0
+  · have hCountTwo : 2 ≤ P.basisCount := by
+      have hCountPos : 0 < P.basisCount :=
+        lt_of_le_of_lt (Nat.zero_le j₀) j₀.isLt
+      omega
+    letI : ∀ j : Fin P.basisCount, NeZero (P.basisDim j) :=
+      fun j ↦ ⟨(hCF.basis_dim_pos j).ne'⟩
+    have hBlk1 : ∀ j : Fin P.basisCount,
+        IsNBlkInjective (P.basis j) (P.totalDim ^ 4 + 1) := by
+      intro j
+      exact isNBlkInjective_of_le hD4pos (hBlk0 j) (by omega)
+    have hBlk3 : ∀ j : Fin P.basisCount,
+        IsNBlkInjective (P.basis j)
+          ((P.totalDim ^ 4 + 1) +
+            ((P.totalDim ^ 4 + 1) + (P.totalDim ^ 4 + 1))) := by
+      intro j
+      exact isNBlkInjective_of_le hD4pos (hBlk0 j) (by omega)
+    have hIrr : HasIrreducibleBlocks (d := d) P.basis :=
+      HasIrreducibleBlocks.ofForall hCF.basis_irreducible
+    have hLeft : IsLeftCanonicalBlockFamily (d := d) P.basis :=
+      IsLeftCanonicalBlockFamily.ofForall hCF.basis_left_canonical
+    have hOverlap : HasNormalizedSelfOverlap (d := d) P.basis :=
+      HasNormalizedSelfOverlap.ofForall hCF.basis_normalized_self_overlap
+    have hSpan : WordTupleSpanTop P.basis
+        ((P.basisCount - 1) *
+          ((P.totalDim ^ 4 + 1) +
+            ((P.totalDim ^ 4 + 1) + (P.totalDim ^ 4 + 1)))) :=
+      wordTupleSpanTop_threeBlock_mul_pred_of_blocksNotGaugePhaseEquiv_c1
+        P.basis hIrr hLeft hOverlap hCF.basis_distinct
+        hBlk0 hBlk1 hBlk3 hD4pos hCountTwo
+    refine ⟨(P.basisCount - 1) *
+      ((P.totalDim ^ 4 + 1) +
+        ((P.totalDim ^ 4 + 1) + (P.totalDim ^ 4 + 1))), ?_, ?_, hSpan⟩
+    · exact Nat.mul_pos (by omega) (by omega)
+    · have hCountLe : P.basisCount ≤ P.totalDim :=
+        P.basisCount_le_totalDim hCF.basis_dim_pos
+      have hPredLe : P.basisCount - 1 ≤ P.totalDim - 1 :=
+        Nat.sub_le_sub_right hCountLe 1
+      have hFirst :
+          (P.basisCount - 1) *
+              ((P.totalDim ^ 4 + 1) +
+                ((P.totalDim ^ 4 + 1) + (P.totalDim ^ 4 + 1))) ≤
+            (P.totalDim - 1) *
+              ((P.totalDim ^ 4 + 1) +
+                ((P.totalDim ^ 4 + 1) + (P.totalDim ^ 4 + 1))) :=
+        Nat.mul_le_mul_right _ hPredLe
+      refine hFirst.trans ?_
+      have hDleD4 : P.totalDim ≤ P.totalDim ^ 4 := by
+        simpa using
+          (pow_le_pow_right' (a := P.totalDim) hDpos (by omega : 1 ≤ 4))
+      have hDsubLeD4 : P.totalDim - 1 ≤ P.totalDim ^ 4 :=
+        (Nat.sub_le P.totalDim 1).trans hDleD4
+      have hCore :
+          (P.totalDim - 1) * (P.totalDim ^ 4 + 1) ≤ P.totalDim ^ 5 := by
+        calc
+          (P.totalDim - 1) * (P.totalDim ^ 4 + 1) =
+              (P.totalDim - 1) * P.totalDim ^ 4 + (P.totalDim - 1) := by ring
+          _ ≤ (P.totalDim - 1) * P.totalDim ^ 4 + P.totalDim ^ 4 :=
+            Nat.add_le_add_left hDsubLeD4 _
+          _ = (P.totalDim - 1) * P.totalDim ^ 4 + 1 * P.totalDim ^ 4 := by
+            rw [one_mul]
+          _ = ((P.totalDim - 1) + 1) * P.totalDim ^ 4 :=
+            (Nat.add_mul (P.totalDim - 1) 1 (P.totalDim ^ 4)).symm
+          _ = P.totalDim * P.totalDim ^ 4 := by
+            rw [Nat.sub_add_cancel (by omega)]
+          _ = P.totalDim ^ 5 := by ring
+      calc
+        (P.totalDim - 1) *
+            ((P.totalDim ^ 4 + 1) +
+              ((P.totalDim ^ 4 + 1) + (P.totalDim ^ 4 + 1))) =
+            3 * ((P.totalDim - 1) * (P.totalDim ^ 4 + 1)) := by ring
+        _ ≤ 3 * P.totalDim ^ 5 := Nat.mul_le_mul_left 3 hCore
+
+end IsBNTCanonicalForm
 
 end MPSTensor

--- a/TNLean/MPS/MPDO/BiCFDerivation/BNTDirectSum.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/BNTDirectSum.lean
@@ -12,7 +12,7 @@ import TNLean.MPS.Periodic.NormalizedSelfOverlap
 
 This file connects the same-dimension BNT separation hypothesis to the
 parent-Hamiltonian uniqueness input in the direct-sum proof of
-Perez-Garcia--Verstraete--Wolf--Cirac, lines 1346--1408.
+arXiv:quant-ph/0608197, lines 1346--1408.
 
 The intermediate statements keep the direct-sum hypotheses explicit:
 `BlocksNotGaugePhaseEquiv` gives the long-chain non-proportional MPV witness,
@@ -31,7 +31,7 @@ variable {d L : ℕ}
 directness conclusion once the direct-sum injectivity hypotheses are supplied.
 
 This is the BNT-facing form of the equal-size branch of the direct-sum proof in
-Perez-Garcia--Verstraete--Wolf--Cirac, lines 1346--1408. The theorem does
+arXiv:quant-ph/0608197, lines 1346--1408. The theorem does
 not infer injectivity or transport non-equivalence through blocking; those
 inputs remain explicit. It is exported for the pair-trace theorem below and for
 downstream direct-sum comparisons that need the image-space directness statement
@@ -62,7 +62,7 @@ theorem groundSpace_inf_eq_bot_of_blocksNotGaugePhaseEquiv_same_dim_of_dim_ge
 /-- Same-dimension BNT-separated blocks give the PGVWC directness conclusion from
 Condition C1 at a finite length \(L_0\).
 
-Perez-Garcia--Verstraete--Wolf--Cirac, lines 1346--1408, first uses Condition
+The proof in arXiv:quant-ph/0608197, lines 1346--1408, first uses Condition
 C1 in each block at length \(L_0\), then compares the spaces
 \(\mathcal G_{L_0+1}^{A^j}\). This version follows that length convention and
 does not assume one-site injectivity. -/
@@ -193,7 +193,7 @@ Condition C1 at \(L_0\), without the one-site special case of Condition C1.
 
 The length is \(3(L_0+1)\), written as
 \((L_0+1)+((L_0+1)+(L_0+1))\) to match the formal concatenation of the three
-blocks in Perez-Garcia--Verstraete--Wolf--Cirac, lines 1346--1408. -/
+blocks in arXiv:quant-ph/0608197, lines 1346--1408. -/
 theorem forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -232,7 +232,7 @@ full product algebra at the source length \(3(r-1)(L_0+1)\).
 The pairwise three-block argument supplies an arbitrary value on one block and
 zero on an anchor block. Identity--zero pair selectors remove the remaining
 blocks without a separate injective prefix. This is the induction length in
-Perez-Garcia--Verstraete--Wolf--Cirac, lines 1346--1408. -/
+arXiv:quant-ph/0608197, lines 1346--1408. -/
 theorem wordTupleSpanTop_threeBlock_mul_pred_of_blocksNotGaugePhaseEquiv_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -298,7 +298,7 @@ theorem exists_forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEqu
 three-block length, once the direct-sum injectivity hypotheses are supplied.
 
 This is the selector-facing consequence of the direct-sum input in
-Perez-Garcia--Verstraete--Wolf--Cirac, lines 1346--1408: homogeneous trace separation at
+arXiv:quant-ph/0608197, lines 1346--1408: homogeneous trace separation at
 \(L+(L+L)\) is converted into equations selecting one block against another. -/
 theorem hasPairBlockSeparatingWords_threeBlock_of_blocksNotGaugePhaseEquiv
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/TNLean/MPS/MPDO/BiCFDerivation/Selectors.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/Selectors.lean
@@ -858,11 +858,11 @@ any blocking length `L` there is only one word `w : Fin L → Fin 1`, and
 
 for that unique word, while `Δ ≠ 0`. Therefore `HasBiCF A` fails.
 
-The new predicate `PropBlockInjective` expresses one abstract finite-length route,
+The predicate `PropBlockInjective` expresses one abstract finite-length route,
 while `wordEntryFamily` gives a second, equivalent linear-algebra criterion.
-What remains open is to derive either of those finite-length witnesses from the
-repository's current BNT / canonical-form hypotheses, i.e. to formalize the full
-content of arXiv:1606.00608, lines 340--345.
+For a basis of normal tensors, the additional separation hypotheses provide
+such a finite-length witness; they do not follow from the three fields in the
+counterexample alone.
 -/
 
 end MPOTensor

--- a/TNLean/MPS/MPDO/BiCFDerivation/Selectors.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/Selectors.lean
@@ -362,7 +362,7 @@ For a chosen block, one pair interpolant gives the prescribed matrix on that
 block and zero on an anchor block. Multiplying by identity--zero pair
 selectors for the remaining `r - 2` blocks kills every other component without
 adding a separate injective prefix. This is the finite-dimensional direct-sum
-step in Perez-Garcia--Verstraete--Wolf--Cirac, lines 1346--1408. -/
+step in arXiv:quant-ph/0608197, lines 1346--1408. -/
 theorem wordTupleSpanTop_mul_pred_of_forall_pairWordTupleSpanTop
     (A : (k : Fin r) → MPSTensor d (dim k)) {S : ℕ}
     (hr : 2 ≤ r)

--- a/TNLean/MPS/MPDO/BiCFDerivation/Selectors.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/Selectors.lean
@@ -10,7 +10,7 @@ import TNLean.MPS.MPDO.BiCFDerivation.PairHomogenization
 This module builds block-selector word families from pairwise separation and
 collects the resulting finite-length witnesses into horizontal canonical-form
 data. It also proves the direct-sum interpolation step: a common full pair span
-at length `S` gives a full simultaneous span at length `(r - 1) * S`, without
+at length $S$ gives a full simultaneous span at length $(r-1)S$, without
 adding a positive-length padding or an injective prefix.
 -/
 
@@ -19,37 +19,6 @@ open scoped Matrix BigOperators
 namespace MPSTensor
 
 variable {d : ℕ} {r : ℕ} {dim : Fin r → ℕ}
-
-/-- Pair product-span at length `S` gives a length-`S` selector for the first
-block of the pair. -/
-theorem hasBlockSelectorOn_of_pairWordTupleSpanTop
-    (A : (k : Fin r) → MPSTensor d (dim k)) {S : ℕ}
-    {k j : Fin r} (hSpan : PairWordTupleSpanTop (A k) (A j) S) :
-    HasBlockSelectorOn A k S {j} := by
-  classical
-  have htarget : ((1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
-      (0 : Matrix (Fin (dim j)) (Fin (dim j)) ℂ)) ∈
-      Submodule.span ℂ (Set.range (pairWordTuple (A k) (A j) S)) := by
-    rw [hSpan]
-    exact Submodule.mem_top
-  rcases (Submodule.mem_span_range_iff_exists_fun ℂ).mp htarget with ⟨c, hc⟩
-  let M : (l : Fin r) → Matrix (Fin (dim l)) (Fin (dim l)) ℂ :=
-    fun l => ∑ w : Fin S → Fin d, c w • evalWord (A l) (List.ofFn w)
-  refine ⟨M, ?_, ?_, ?_⟩
-  · refine (Submodule.mem_span_range_iff_exists_fun ℂ).mpr ⟨c, ?_⟩
-    ext l
-    simp [M, wordTuple]
-  · have hk := congrArg
-      (LinearMap.fst ℂ (Matrix (Fin (dim k)) (Fin (dim k)) ℂ)
-        (Matrix (Fin (dim j)) (Fin (dim j)) ℂ)) hc
-    simpa [M, pairWordTuple, Fintype.linearCombination_apply] using hk
-  · intro l hl
-    have hlj : l = j := by simpa using hl
-    subst l
-    have hj := congrArg
-      (LinearMap.snd ℂ (Matrix (Fin (dim k)) (Fin (dim k)) ℂ)
-        (Matrix (Fin (dim j)) (Fin (dim j)) ℂ)) hc
-    simpa [M, pairWordTuple, Fintype.linearCombination_apply] using hj
 
 /-- Full pair product-span realizes an arbitrary matrix on the first block and
 zero on the second, without prescribing the values on the remaining blocks. -/
@@ -79,6 +48,21 @@ theorem exists_mem_span_wordTuple_eq_and_eq_zero_of_pairWordTupleSpanTop
       (LinearMap.snd ℂ (Matrix (Fin (dim k)) (Fin (dim k)) ℂ)
         (Matrix (Fin (dim j)) (Fin (dim j)) ℂ)) hc
     simpa [M, pairWordTuple, Fintype.linearCombination_apply] using hj
+
+/-- Pair product-span at length $S$ gives a length-$S$ selector for the first
+block of the pair. -/
+theorem hasBlockSelectorOn_of_pairWordTupleSpanTop
+    (A : (k : Fin r) → MPSTensor d (dim k)) {S : ℕ}
+    {k j : Fin r} (hSpan : PairWordTupleSpanTop (A k) (A j) S) :
+    HasBlockSelectorOn A k S {j} := by
+  obtain ⟨M, hM, hMk, hMj⟩ :=
+    exists_mem_span_wordTuple_eq_and_eq_zero_of_pairWordTupleSpanTop
+      A hSpan (1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ)
+  refine ⟨M, hM, hMk, ?_⟩
+  intro l hl
+  have hlj : l = j := by simpa using hl
+  subst l
+  exact hMj
 
 /-- Pair trace-separation at length `S` gives a length-`S` selector for the
 first block of the pair. -/
@@ -354,13 +338,13 @@ theorem wordTupleSpanTop_of_card_eq_one_of_isNBlkInjective
   subst k
   simpa [wordTuple] using hc
 
-/-- If every distinct pair has full product span at length `S`, then for at
+/-- If every distinct pair has full product span at length $S$, then for at
 least two blocks the simultaneous tuples have full span at length
-`(r - 1) * S`.
+$(r-1)S$.
 
 For a chosen block, one pair interpolant gives the prescribed matrix on that
 block and zero on an anchor block. Multiplying by identity--zero pair
-selectors for the remaining `r - 2` blocks kills every other component without
+selectors for the remaining $r-2$ blocks kills every other component without
 adding a separate injective prefix. This is the finite-dimensional direct-sum
 step in arXiv:quant-ph/0608197, lines 1346--1408. -/
 theorem wordTupleSpanTop_mul_pred_of_forall_pairWordTupleSpanTop

--- a/TNLean/MPS/MPDO/BiCFDerivation/Selectors.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/Selectors.lean
@@ -9,7 +9,9 @@ import TNLean.MPS.MPDO.BiCFDerivation.PairHomogenization
 
 This module builds block-selector word families from pairwise separation and
 collects the resulting finite-length witnesses into horizontal canonical-form
-data.
+data. It also proves the direct-sum interpolation step: a common full pair span
+at length `S` gives a full simultaneous span at length `(r - 1) * S`, without
+adding a positive-length padding or an injective prefix.
 -/
 
 open scoped Matrix BigOperators
@@ -45,6 +47,35 @@ theorem hasBlockSelectorOn_of_pairWordTupleSpanTop
     have hlj : l = j := by simpa using hl
     subst l
     have hj := congrArg
+      (LinearMap.snd ℂ (Matrix (Fin (dim k)) (Fin (dim k)) ℂ)
+        (Matrix (Fin (dim j)) (Fin (dim j)) ℂ)) hc
+    simpa [M, pairWordTuple, Fintype.linearCombination_apply] using hj
+
+/-- Full pair product-span realizes an arbitrary matrix on the first block and
+zero on the second, without prescribing the values on the remaining blocks. -/
+theorem exists_mem_span_wordTuple_eq_and_eq_zero_of_pairWordTupleSpanTop
+    (A : (k : Fin r) → MPSTensor d (dim k)) {S : ℕ}
+    {k j : Fin r} (hSpan : PairWordTupleSpanTop (A k) (A j) S)
+    (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ) :
+    ∃ M : (l : Fin r) → Matrix (Fin (dim l)) (Fin (dim l)) ℂ,
+      M ∈ Submodule.span ℂ (Set.range (wordTuple A S)) ∧ M k = X ∧ M j = 0 := by
+  classical
+  have htarget : (X, (0 : Matrix (Fin (dim j)) (Fin (dim j)) ℂ)) ∈
+      Submodule.span ℂ (Set.range (pairWordTuple (A k) (A j) S)) := by
+    rw [hSpan]
+    exact Submodule.mem_top
+  rcases (Submodule.mem_span_range_iff_exists_fun ℂ).mp htarget with ⟨c, hc⟩
+  let M : (l : Fin r) → Matrix (Fin (dim l)) (Fin (dim l)) ℂ :=
+    fun l => ∑ w : Fin S → Fin d, c w • evalWord (A l) (List.ofFn w)
+  refine ⟨M, ?_, ?_, ?_⟩
+  · refine (Submodule.mem_span_range_iff_exists_fun ℂ).mpr ⟨c, ?_⟩
+    ext l
+    simp [M, wordTuple]
+  · have hk := congrArg
+      (LinearMap.fst ℂ (Matrix (Fin (dim k)) (Fin (dim k)) ℂ)
+        (Matrix (Fin (dim j)) (Fin (dim j)) ℂ)) hc
+    simpa [M, pairWordTuple, Fintype.linearCombination_apply] using hk
+  · have hj := congrArg
       (LinearMap.snd ℂ (Matrix (Fin (dim k)) (Fin (dim k)) ℂ)
         (Matrix (Fin (dim j)) (Fin (dim j)) ℂ)) hc
     simpa [M, pairWordTuple, Fintype.linearCombination_apply] using hj
@@ -245,19 +276,6 @@ theorem wordTupleSpanTop_eventually_of_wordTupleSpanTop_period_window
   rw [← hlen]
   exact hpad
 
-/-- The empty word is the identity on every block, so it selects a block on the
-empty target set. -/
-theorem hasBlockSelectorOn_empty
-    (A : (k : Fin r) → MPSTensor d (dim k)) (k : Fin r) :
-    HasBlockSelectorOn A k 0 ∅ := by
-  classical
-  refine ⟨wordTuple A 0 (fun i => Fin.elim0 i), ?_, ?_, ?_⟩
-  · exact Submodule.subset_span ⟨fun i => Fin.elim0 i, rfl⟩
-  · simp [wordTuple]
-  · intro j hj
-    have hnot : j ∉ (∅ : Finset (Fin r)) := by simp
-    exact False.elim (hnot hj)
-
 /-- Multiplying two partial selectors for the same block produces a selector
 that vanishes on the union of their target sets. -/
 theorem HasBlockSelectorOn.mul
@@ -289,7 +307,12 @@ theorem hasBlockSelectorOn_finset_of_pairBlockSeparatingWords
   revert htargets
   refine Finset.induction_on targets ?base ?step
   · intro _
-    simpa using hasBlockSelectorOn_empty A k
+    have hEmpty : HasBlockSelectorOn A k 0 ∅ := by
+      refine ⟨wordTuple A 0 (fun i ↦ Fin.elim0 i), ?_, ?_, ?_⟩
+      · exact Submodule.subset_span ⟨fun i ↦ Fin.elim0 i, rfl⟩
+      · simp [wordTuple]
+      · simp
+    simpa using hEmpty
   · intro j targets hj_not_mem ih htargets_insert
     have htargets_tail : ∀ l : Fin r, l ∈ targets → l ≠ k := by
       intro l hl
@@ -306,6 +329,116 @@ theorem hasBlockSelectorOn_finset_of_pairBlockSeparatingWords
       rw [Finset.card_insert_of_notMem hj_not_mem]
       exact Nat.succ_mul targets.card S
     simpa [hsets, hlen] using hmul
+
+/-- If a finite block family has exactly one block, block injectivity of that
+block gives the simultaneous word-tuple spanning property. -/
+theorem wordTupleSpanTop_of_card_eq_one_of_isNBlkInjective
+    (A : (k : Fin r) → MPSTensor d (dim k)) {L : ℕ}
+    (hr : r = 1) (hInj : ∀ k : Fin r, IsNBlkInjective (A k) L) :
+    WordTupleSpanTop A L := by
+  classical
+  let k₀ : Fin r := ⟨0, by omega⟩
+  unfold WordTupleSpanTop
+  apply top_unique
+  intro X _
+  have hX : X k₀ ∈ Submodule.span ℂ
+      (Set.range fun w : Fin L → Fin d ↦ evalWord (A k₀) (List.ofFn w)) := by
+    rw [hInj k₀]
+    exact Submodule.mem_top
+  obtain ⟨c, hc⟩ := (Submodule.mem_span_range_iff_exists_fun ℂ).mp hX
+  refine (Submodule.mem_span_range_iff_exists_fun ℂ).mpr ⟨c, ?_⟩
+  funext k
+  have hk : k = k₀ := by
+    apply Fin.ext
+    omega
+  subst k
+  simpa [wordTuple] using hc
+
+/-- If every distinct pair has full product span at length `S`, then for at
+least two blocks the simultaneous tuples have full span at length
+`(r - 1) * S`.
+
+For a chosen block, one pair interpolant gives the prescribed matrix on that
+block and zero on an anchor block. Multiplying by identity--zero pair
+selectors for the remaining `r - 2` blocks kills every other component without
+adding a separate injective prefix. This is the finite-dimensional direct-sum
+step in Perez-Garcia--Verstraete--Wolf--Cirac, lines 1346--1408. -/
+theorem wordTupleSpanTop_mul_pred_of_forall_pairWordTupleSpanTop
+    (A : (k : Fin r) → MPSTensor d (dim k)) {S : ℕ}
+    (hr : 2 ≤ r)
+    (hPair : ∀ k j : Fin r, j ≠ k → PairWordTupleSpanTop (A k) (A j) S) :
+    WordTupleSpanTop A ((r - 1) * S) := by
+  classical
+  letI : Nontrivial (Fin r) := Fin.nontrivial_iff_two_le.mpr hr
+  unfold WordTupleSpanTop
+  apply top_unique
+  intro X _
+  have hContribution : ∀ k : Fin r,
+      ∃ M : (l : Fin r) → Matrix (Fin (dim l)) (Fin (dim l)) ℂ,
+        M ∈ Submodule.span ℂ (Set.range (wordTuple A ((r - 1) * S))) ∧
+          M k = X k ∧ ∀ l : Fin r, l ≠ k → M l = 0 := by
+    intro k
+    obtain ⟨j, hjk⟩ := exists_ne k
+    obtain ⟨M, hM, hMk, hMj⟩ :=
+      exists_mem_span_wordTuple_eq_and_eq_zero_of_pairWordTupleSpanTop
+        A (hPair k j hjk) (X k)
+    let targets : Finset (Fin r) := (Finset.univ.erase k).erase j
+    have htargets : ∀ l : Fin r, l ∈ targets → l ≠ k := by
+      intro l hl
+      exact (Finset.mem_erase.mp (Finset.mem_erase.mp hl).2).1
+    have hSelectors : HasPairBlockSeparatingWords A S :=
+      hasPairBlockSeparatingWords_of_forall_pairWordTupleSpanTop A hPair
+    obtain ⟨N, hN, hNk, hNzero⟩ :=
+      hasBlockSelectorOn_finset_of_pairBlockSeparatingWords
+        A hSelectors k targets htargets
+    have hcard : targets.card = r - 2 := by
+      simp [targets, hjk, Fintype.card_fin]
+      omega
+    have hlen : S + targets.card * S = (r - 1) * S := by
+      calc
+        S + targets.card * S = 1 * S + (r - 2) * S := by rw [hcard, one_mul]
+        _ = (1 + (r - 2)) * S := (Nat.add_mul 1 (r - 2) S).symm
+        _ = (r - 1) * S := by
+          congr 1
+          omega
+    let C : (l : Fin r) → Matrix (Fin (dim l)) (Fin (dim l)) ℂ :=
+      fun l ↦ M l * N l
+    refine ⟨C, ?_, ?_, ?_⟩
+    · have hC := pointwise_mul_mem_span_wordTuple_add A hM hN
+      rw [hlen] at hC
+      exact hC
+    · simp [C, hMk, hNk]
+    · intro l hlk
+      by_cases hlj : l = j
+      · subst l
+        simp [C, hMj]
+      · have hltarget : l ∈ targets := by
+          simp [targets, hlk, hlj]
+        simp [C, hNzero l hltarget]
+  choose M hM hMdiag hMoff using hContribution
+  have hsum : (∑ k : Fin r, M k) ∈
+      Submodule.span ℂ (Set.range (wordTuple A ((r - 1) * S))) :=
+    Submodule.sum_mem _ fun k _ ↦ hM k
+  have hsum_eq : (∑ k : Fin r, M k) = X := by
+    funext l
+    rw [Finset.sum_apply, Finset.sum_eq_single l]
+    · exact hMdiag l
+    · intro k _ hkl
+      exact hMoff k l hkl.symm
+    · intro hl
+      exact False.elim (hl (Finset.mem_univ l))
+  rw [hsum_eq] at hsum
+  exact hsum
+
+/-- Pair trace separation at a common length gives the same sharp
+simultaneous word-tuple span for a family of at least two blocks. -/
+theorem wordTupleSpanTop_mul_pred_of_forall_pairTraceSeparatingAt
+    (A : (k : Fin r) → MPSTensor d (dim k)) {S : ℕ}
+    (hr : 2 ≤ r)
+    (hPair : ∀ k j : Fin r, j ≠ k → PairTraceSeparatingAt (A k) (A j) S) :
+    WordTupleSpanTop A ((r - 1) * S) :=
+  wordTupleSpanTop_mul_pred_of_forall_pairWordTupleSpanTop A hr fun k j hjk ↦
+    pairWordTupleSpanTop_of_pairTraceSeparatingAt (A k) (A j) (hPair k j hjk)
 
 /-- Tuple-span selectors on `Finset.univ.erase k` recover coefficient-based
 block-selector words. -/

--- a/TNLean/MPS/SharedInfra/SectorDecomposition.lean
+++ b/TNLean/MPS/SharedInfra/SectorDecomposition.lean
@@ -136,6 +136,25 @@ theorem basisDim_le_totalDim (P : SectorDecomposition d) (j : Fin P.basisCount) 
   exact Finset.single_le_sum (fun t _ ↦ Nat.zero_le (P.flatDim t))
     (Finset.mem_univ s)
 
+/-- If every representative has positive bond dimension, then the number of
+representatives is at most the total bond dimension of the flattened sector
+tensor. -/
+theorem basisCount_le_totalDim (P : SectorDecomposition d)
+    (hDim : ∀ j : Fin P.basisCount, 0 < P.basisDim j) :
+    P.basisCount ≤ P.totalDim := by
+  have hFlatDim : ∀ s : Fin P.totalCopies, 0 < P.flatDim s := by
+    intro s
+    simpa [flatDim] using hDim (P.flatIndexEquiv.symm s).1
+  calc
+    P.basisCount = ∑ _j : Fin P.basisCount, 1 := by simp
+    _ ≤ ∑ j : Fin P.basisCount, P.copies j := by
+      exact Finset.sum_le_sum fun j _ ↦ P.copies_pos j
+    _ = P.totalCopies := rfl
+    _ = ∑ _s : Fin P.totalCopies, 1 := by simp
+    _ ≤ ∑ s : Fin P.totalCopies, P.flatDim s := by
+      exact Finset.sum_le_sum fun s _ ↦ hFlatDim s
+    _ = P.totalDim := rfl
+
 /-- The total tensor, obtained by flattening `(j, q)` and applying `toTensorFromBlocks`. -/
 noncomputable def toTensor (P : SectorDecomposition d) : MPSTensor d P.totalDim :=
   toTensorFromBlocks (d := d) (μ := P.flatWeight) P.flatBasis

--- a/blueprint/src/chapter/ch08_wielandt.tex
+++ b/blueprint/src/chapter/ch08_wielandt.tex
@@ -522,8 +522,10 @@ The results follow~\cite{Sanz2010Quantum}.
     The left-canonical normal blocked-injectivity estimate $D^4$ is proved
     below in
     Theorem~\ref{thm:bounded_injective_blocking_normal_left_canonical}.
-    The sharper bi-canonical blocking estimate $3D^5$ from
-    \cite{Sanz2010Quantum} is not proved here.
+    The sharper canonical-form block-separation estimate $3D^5$ is proved in
+    Theorem~\ref{thm:sharp_bnt_block_separation}, using this $D^4$ estimate
+    together with the direct-sum argument cited in
+    \cite{Sanz2010Quantum}.
 \end{remark}
 
 \begin{definition}[One-step augmentation]\label{def:one_step_augment}

--- a/blueprint/src/chapter/ch08_wielandt.tex
+++ b/blueprint/src/chapter/ch08_wielandt.tex
@@ -524,8 +524,8 @@ The results follow~\cite{Sanz2010Quantum}.
     Theorem~\ref{thm:bounded_injective_blocking_normal_left_canonical}.
     The sharper canonical-form block-separation estimate $3D^5$ is proved in
     Theorem~\ref{thm:sharp_bnt_block_separation}, using this $D^4$ estimate
-    together with the direct-sum argument cited in
-    \cite{Sanz2010Quantum}.
+    together with the direct-sum argument of
+    \cite{PerezGarcia2007Matrix}.
 \end{remark}
 
 \begin{definition}[One-step augmentation]\label{def:one_step_augment}

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -876,9 +876,14 @@ here feed the BNT canonical-form predicate below.
     nonnegative summand in the total dimension of the flattened copy family,
     so $D_j\leq D$.
 
-    For the second assertion, every representative has at least one copy and
-    each copy has positive dimension. Hence the total dimension is at least
-    the number of copies, which is at least $g$.
+    For the second assertion, every representative has multiplicity
+    $r_j\geq1$, and each copy has positive dimension $D_j>0$. Therefore
+    \[
+        g=\sum_j1
+        \leq\sum_j r_j
+        \leq\sum_j r_jD_j
+        =D.
+    \]
 \end{proof}
 
 \begin{definition}[Physical blocking of a sector decomposition]%

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -298,7 +298,7 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
         thm:common_exact_block_injectivity_normal_left_canonical,
         thm:wordspan_blk_inj_succ,
         thm:peripheral_primitive_irreducible_overlap_one,
-        lem:bnt_direct_sum_block_separation_word_span,
+        lem:bnt_direct_sum_injective_prefix_word_span,
         lem:block_separating_equations_from_pairwise_separation,
         lem:product_word_span_from_bnt_block_separation,
         lem:gauge_invariance_block_injective}

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -857,13 +857,16 @@ here feed the BNT canonical-form predicate below.
 \begin{theorem}[Representative dimensions are bounded by the total bond dimension]
     \label{thm:sector_basis_dimension_le_total_dimension}
     \lean{MPSTensor.SectorDecomposition.basisDim_le_totalDim}
+    \lean{MPSTensor.SectorDecomposition.basisCount_le_totalDim}
     \leanok
     \uses{def:sector_weight_data}
     Let the representative $A_j$ have bond dimension $D_j$, and let $D$ be
-    the bond dimension of the flattened sector tensor.  Then
+    the bond dimension of the flattened sector tensor. Then
     \[
         D_j\leq D.
     \]
+    If every $D_j$ is positive and there are $g$ representatives, then also
+    $g\leq D$.
 \end{theorem}
 
 \begin{proof}
@@ -872,6 +875,10 @@ here feed the BNT canonical-form predicate below.
     Since $r_j>0$, choose one copy of $A_j$.  Its contribution $D_j$ is one
     nonnegative summand in the total dimension of the flattened copy family,
     so $D_j\leq D$.
+
+    For the second assertion, every representative has at least one copy and
+    each copy has positive dimension. Hence the total dimension is at least
+    the number of copies, which is at least $g$.
 \end{proof}
 
 \begin{definition}[Physical blocking of a sector decomposition]%

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections.tex
@@ -811,7 +811,6 @@ parent-Hamiltonian ground space.
 \begin{lemma}[Block-separating equations from pairwise separation]
     \label{lem:block_separating_equations_from_pairwise_separation}
     \lean{MPSTensor.pointwise_mul_mem_span_wordTuple_add}
-    \lean{MPSTensor.hasBlockSelectorOn_empty}
     \lean{MPSTensor.HasBlockSelectorOn.mul}
     \lean{MPSTensor.hasBlockSelectorOn_finset_of_pairBlockSeparatingWords}
     \lean{MPSTensor.hasBlockSelectorWords_of_forall_hasBlockSelectorOn_univ_erase}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
@@ -130,10 +130,21 @@ $\bigvee_jG_{n+2}(A^j)$ and to obtain the one-step block-intersection identity.
         lem:block_separating_equations_from_pairwise_separation}
     For a prescribed matrix $X_k$ on block $k$, choose an anchor block $j$.
     Lemma~\ref{lem:pair_product_span_arbitrary_first_value} gives a length-
-    $3(L_0+1)$ tuple whose $k$- and $j$-components are $(X_k,0)$. Multiplying
-    by identity--zero selectors for the other $r-2$ blocks gives a tuple
-    supported only on block $k$, at length $3(r-1)(L_0+1)$. Summing these
-    tuples over $k$ realizes every element of the product algebra.
+    $3(L_0+1)$ tuple $M$ with $(M_k,M_j)=(X_k,0)$. For every
+    $\ell\notin\{k,j\}$, choose a selector $N^{(\ell)}$ with
+    $N^{(\ell)}_k=I$ and $N^{(\ell)}_\ell=0$, and put
+    \[
+        C_t=M_t\prod_{\ell\notin\{k,j\}}N^{(\ell)}_t.
+    \]
+    Then
+    \[
+        C_k=X_k,\qquad C_j=0,\qquad
+        C_\ell=M_\ell(\cdots)0(\cdots)=0
+        \quad(\ell\notin\{k,j\}).
+    \]
+    Thus $C$ is supported only on block $k$, at length
+    $3(r-1)(L_0+1)$. Summing these tuples over $k$ realizes every element of
+    the product algebra.
 \end{proof}
 
 \begin{lemma}[Blockwise matrix equality from trace pairings]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
@@ -13,6 +13,9 @@ $\bigvee_jG_{n+2}(A^j)$ and to obtain the one-step block-intersection identity.
     \lean{MPSTensor.propBlockInjective_of_blocksNotGaugePhaseEquiv_directSum_c1}
     \lean{MPSTensor.wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors_c1}
     \lean{MPSTensor.exists_wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors_c1}
+    \lean{MPSTensor.wordTupleSpanTop_mul_pred_of_forall_pairWordTupleSpanTop}
+    \lean{MPSTensor.wordTupleSpanTop_mul_pred_of_forall_pairTraceSeparatingAt}
+    \lean{MPSTensor.wordTupleSpanTop_threeBlock_mul_pred_of_blocksNotGaugePhaseEquiv_c1}
     \leanok
     \uses{lem:direct_sum_two_block_dimension_step,
         lem:pair_trace_separation_to_pairwise_block_separation,
@@ -45,9 +48,9 @@ $\bigvee_jG_{n+2}(A^j)$ and to obtain the one-step block-intersection identity.
         \qquad
         \sum_{|\omega|=3(L_0+1)} c^{k,j}_\omega A^j_\omega=0.
     \]
-    Consequently the simultaneous block-word tuples at length
+    If $r\geq2$, the simultaneous block-word tuples at the source length
     \[
-        (L_0+1)+(r-1)3(L_0+1)
+        3(r-1)(L_0+1)
     \]
     span the full product algebra
     \[
@@ -62,10 +65,13 @@ $\bigvee_jG_{n+2}(A^j)$ and to obtain the one-step block-intersection identity.
     normalized BNT representatives.
     Lemma~\ref{lem:pair_trace_separation_to_pairwise_block_separation}
     converts these trace-separation equations into the displayed pairwise
-    block-separating equations. Multiplying the equations for the $r-1$
-    blocks different from $k$ gives a block-separating equation for $k$, and
-    Lemma~\ref{lem:product_word_span_from_bnt_block_separation} then supplies the
-    displayed product span.
+    block-separating equations. To realize a prescribed matrix $X_k$ on block
+    $k$, choose an anchor block and use the full pair span to realize
+    $(X_k,0)$ on that pair. Multiply this element by identity--zero selectors
+    for the other $r-2$ blocks. The resulting tuple equals $X_k$ on block $k$
+    and vanishes on every other block, at length $3(r-1)(L_0+1)$. Summing
+    these tuples over $k$ realizes an arbitrary element of the product
+    algebra.
 \end{proof}
 
 \begin{lemma}[Blockwise matrix equality from trace pairings]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
@@ -112,9 +112,7 @@ $\bigvee_jG_{n+2}(A^j)$ and to obtain the one-step block-intersection identity.
     \lean{MPSTensor.wordTupleSpanTop_mul_pred_of_forall_pairTraceSeparatingAt}
     \lean{MPSTensor.wordTupleSpanTop_threeBlock_mul_pred_of_blocksNotGaugePhaseEquiv_c1}
     \leanok
-    \uses{lem:direct_sum_two_block_dimension_step,
-        lem:pair_product_span_arbitrary_first_value,
-        lem:pair_trace_separation_to_pairwise_block_separation,
+    \uses{lem:pair_product_span_arbitrary_first_value,
         lem:block_separating_equations_from_pairwise_separation}
     Under the hypotheses of the preceding lemma, suppose $r\geq2$. Then the
     simultaneous block-word tuples at the source length
@@ -126,7 +124,9 @@ $\bigvee_jG_{n+2}(A^j)$ and to obtain the one-step block-intersection identity.
 
 \begin{proof}
     \leanok
-    \uses{lem:pair_product_span_arbitrary_first_value,
+    \uses{lem:direct_sum_two_block_dimension_step,
+        lem:pair_trace_separation_to_pairwise_block_separation,
+        lem:pair_product_span_arbitrary_first_value,
         lem:block_separating_equations_from_pairwise_separation}
     For a prescribed matrix $X_k$ on block $k$, choose an anchor block $j$.
     Lemma~\ref{lem:pair_product_span_arbitrary_first_value} gives a length-

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
@@ -7,15 +7,40 @@ into blockwise matrix identities $A^j_bC^j_a=A^j_bE^jA^j_a$. The lemmas here use
 those identities to place left-boundary trace decompositions in the block sum
 $\bigvee_jG_{n+2}(A^j)$ and to obtain the one-step block-intersection identity.
 
-\begin{lemma}[BNT block separation gives a finite blockwise product span]
-    \label{lem:bnt_direct_sum_block_separation_word_span}
+\begin{lemma}[Arbitrary interpolation on one block of a pair]
+    \label{lem:pair_product_span_arbitrary_first_value}
+    \lean{MPSTensor.exists_mem_span_wordTuple_eq_and_eq_zero_of_pairWordTupleSpanTop}
+    \leanok
+    \uses{def:pair_trace_separation_words}
+    Let $(A_\ell)_{\ell=1}^r$ be a finite family of tensors. Suppose that the
+    length-$S$ pair evaluations of blocks $k$ and $j$ span their product
+    matrix algebra. For every $X\in\MN{D_k}$, there is a tuple $M=(M_\ell)_\ell$
+    in the span of the simultaneous length-$S$ word evaluations such that
+    \[
+        M_k=X,
+        \qquad
+        M_j=0.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{def:pair_trace_separation_words}
+    Full pair span gives coefficients satisfying
+    \[
+        (X,0)=\sum_{|w|=S}c_w(A_k^w,A_j^w).
+    \]
+    Define $M_\ell=\sum_{|w|=S}c_wA_\ell^w$ for every block $\ell$. Then $M$
+    lies in the simultaneous word-tuple span, and its $k$- and $j$-components
+    are $X$ and $0$, respectively.
+\end{proof}
+
+\begin{lemma}[BNT block separation with an injective prefix]
+    \label{lem:bnt_direct_sum_injective_prefix_word_span}
     \lean{MPSTensor.hasPairBlockSeparatingWords_threeBlock_of_blocksNotGaugePhaseEquiv_c1}
     \lean{MPSTensor.propBlockInjective_of_blocksNotGaugePhaseEquiv_directSum_c1}
     \lean{MPSTensor.wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors_c1}
     \lean{MPSTensor.exists_wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors_c1}
-    \lean{MPSTensor.wordTupleSpanTop_mul_pred_of_forall_pairWordTupleSpanTop}
-    \lean{MPSTensor.wordTupleSpanTop_mul_pred_of_forall_pairTraceSeparatingAt}
-    \lean{MPSTensor.wordTupleSpanTop_threeBlock_mul_pred_of_blocksNotGaugePhaseEquiv_c1}
     \leanok
     \uses{lem:direct_sum_two_block_dimension_step,
         lem:pair_trace_separation_to_pairwise_block_separation,
@@ -48,9 +73,9 @@ $\bigvee_jG_{n+2}(A^j)$ and to obtain the one-step block-intersection identity.
         \qquad
         \sum_{|\omega|=3(L_0+1)} c^{k,j}_\omega A^j_\omega=0.
     \]
-    If $r\geq2$, the simultaneous block-word tuples at the source length
+    The simultaneous block-word tuples at length
     \[
-        3(r-1)(L_0+1)
+        (L_0+1)+3(r-1)(L_0+1)
     \]
     span the full product algebra
     \[
@@ -60,18 +85,55 @@ $\bigvee_jG_{n+2}(A^j)$ and to obtain the one-step block-intersection identity.
 
 \begin{proof}
     \leanok
+    \uses{lem:direct_sum_two_block_dimension_step,
+        lem:pair_trace_separation_to_pairwise_block_separation,
+        lem:block_separating_equations_from_pairwise_separation,
+        lem:product_word_span_from_bnt_block_separation}
     Lemma~\ref{lem:direct_sum_two_block_dimension_step} gives homogeneous
     trace separation at length $3(L_0+1)$ for every ordered pair of distinct
     normalized BNT representatives.
     Lemma~\ref{lem:pair_trace_separation_to_pairwise_block_separation}
     converts these trace-separation equations into the displayed pairwise
-    block-separating equations. To realize a prescribed matrix $X_k$ on block
-    $k$, choose an anchor block and use the full pair span to realize
-    $(X_k,0)$ on that pair. Multiply this element by identity--zero selectors
-    for the other $r-2$ blocks. The resulting tuple equals $X_k$ on block $k$
-    and vanishes on every other block, at length $3(r-1)(L_0+1)$. Summing
-    these tuples over $k$ realizes an arbitrary element of the product
-    algebra.
+    block-separating equations. Multiplying the $r-1$ pair selectors for a
+    fixed block $k$ gives coefficients $b_v^{(k)}$ of length
+    $3(r-1)(L_0+1)$ such that
+    \[
+        \sum_v b_v^{(k)}A_j^v=\delta_{j,k}I.
+    \]
+    Block injectivity at length $L_0+1$ writes
+    $X_k=\sum_u a_u^{(k)}A_k^u$. Concatenating these two word families and
+    summing over $k$ realizes every tuple $(X_k)_k$ at length
+    $(L_0+1)+3(r-1)(L_0+1)$.
+\end{proof}
+
+\begin{lemma}[Sharp BNT block separation without an injective prefix]
+    \label{lem:bnt_direct_sum_block_separation_word_span}
+    \lean{MPSTensor.wordTupleSpanTop_mul_pred_of_forall_pairWordTupleSpanTop}
+    \lean{MPSTensor.wordTupleSpanTop_mul_pred_of_forall_pairTraceSeparatingAt}
+    \lean{MPSTensor.wordTupleSpanTop_threeBlock_mul_pred_of_blocksNotGaugePhaseEquiv_c1}
+    \leanok
+    \uses{lem:direct_sum_two_block_dimension_step,
+        lem:pair_product_span_arbitrary_first_value,
+        lem:pair_trace_separation_to_pairwise_block_separation,
+        lem:block_separating_equations_from_pairwise_separation}
+    Under the hypotheses of the preceding lemma, suppose $r\geq2$. Then the
+    simultaneous block-word tuples at the source length
+    \[
+        3(r-1)(L_0+1)
+    \]
+    span the full product algebra $\prod_{j=1}^r\MN{D_j}$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:pair_product_span_arbitrary_first_value,
+        lem:block_separating_equations_from_pairwise_separation}
+    For a prescribed matrix $X_k$ on block $k$, choose an anchor block $j$.
+    Lemma~\ref{lem:pair_product_span_arbitrary_first_value} gives a length-
+    $3(L_0+1)$ tuple whose $k$- and $j$-components are $(X_k,0)$. Multiplying
+    by identity--zero selectors for the other $r-2$ blocks gives a tuple
+    supported only on block $k$, at length $3(r-1)(L_0+1)$. Summing these
+    tuples over $k$ realizes every element of the product algebra.
 \end{proof}
 
 \begin{lemma}[Blockwise matrix equality from trace pairings]

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -340,6 +340,10 @@ This is the inverse identity in
 
 \begin{proof}
     \leanok
+    \uses{lem:single_block_word_tuple_span,
+        lem:pair_product_span_arbitrary_first_value,
+        lem:bnt_direct_sum_block_separation_word_span,
+        thm:sector_basis_dimension_le_total_dimension}
     Let $g$ be the number of minimal representatives. The common exact
     injective length is $D^4$. If $g=1$, ordinary block injectivity gives the
     simultaneous span at length $D^4$.
@@ -347,10 +351,12 @@ This is the inverse identity in
     Suppose $g\geq2$. Positive-length propagation gives block injectivity at
     lengths $D^4+1$ and $3(D^4+1)$. The pair-separation argument therefore
     gives the full pair span at length $3(D^4+1)$ for every pair of distinct
-    representatives. For each chosen block, realize an arbitrary value on
-    that block and zero on an anchor block, then multiply by identity--zero
-    selectors for the remaining $g-2$ representatives. Summing these
-    block-supported tuples gives the full simultaneous span at length
+    representatives. For each block $k$,
+    Lemma~\ref{lem:pair_product_span_arbitrary_first_value} gives a tuple $M$
+    with $M_k=X_k$ and $M_j=0$ for a chosen anchor block $j$. Multiplying by
+    identity--zero selectors for the remaining $g-2$ representatives gives a
+    tuple supported only on block $k$. Summing over $k$ gives the full
+    simultaneous span at length
     \[
         N=3(g-1)(D^4+1).
     \]

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -302,34 +302,44 @@ This is the inverse identity in
     nondegeneracy of the trace pairing gives finite-length trace separation.
 \end{proof}
 
-\begin{remark}[Sharp finite-length block separation]
-    \label{rem:sharp_bnt_block_separation_gap}
-    \notready
+\begin{theorem}[Sharp finite-length block separation]
+    \label{thm:sharp_bnt_block_separation}
+    \lean{MPSTensor.IsBNTCanonicalForm.exists_basis_wordTupleSpanTop_le_three_totalDim_pow_five}
+    \leanok
     \uses{thm:bnt_representatives_exact_total_dimension_pow_four,
+        thm:sector_basis_dimension_le_total_dimension,
         lem:bnt_direct_sum_block_separation_word_span}
-    Let $D$ be the total bond dimension and $g$ the number of minimal
-    representatives.  The common exact injective length is $D^4$.  For
-    $g\geq2$, the pair-separation argument works at length $3(D^4+1)$.  The
-    missing simultaneous interpolation statement should realize $(X,0)$
-    on one anchor pair and multiply by identity--zero selectors for the other
-    $g-2$ representatives.  It would give the target length
+    Let $P$ be a BNT canonical form with total bond dimension $D$. There is a
+    positive integer $N\leq3D^5$ such that the simultaneous word evaluations
+    of the minimal representatives at length $N$ span their full product
+    matrix algebra.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Let $g$ be the number of minimal representatives. The common exact
+    injective length is $D^4$. If $g=1$, ordinary block injectivity gives the
+    simultaneous span at length $D^4$.
+
+    Suppose $g\geq2$. Positive-length propagation gives block injectivity at
+    lengths $D^4+1$ and $3(D^4+1)$. The pair-separation argument therefore
+    gives the full pair span at length $3(D^4+1)$ for every pair of distinct
+    representatives. For each chosen block, realize an arbitrary value on
+    that block and zero on an anchor block, then multiply by identity--zero
+    selectors for the remaining $g-2$ representatives. Summing these
+    block-supported tuples gives the full simultaneous span at length
     \[
-        3(g-1)(D^4+1)\leq3(D-1)(D^4+1).
+        N=3(g-1)(D^4+1).
     \]
-    The preceding argument instead concatenates a separate injective prefix
-    and gives the longer length
+    Each representative has positive dimension and occurs at least once, so
+    $g\leq D$. Hence
     \[
-        D^4+3(g-1)(D^4+1).
+        N\leq3(D-1)(D^4+1)\leq3D^5,
     \]
-    Thus the sharp bound in \cite[lines~340--345]{Cirac2016MPDO_arXiv} reduces
-    to the stated anchor-pair interpolation.  The case $g=1$ follows directly
-    from ordinary block injectivity.  For $g\geq2$, the interpolation and the
-    elementary estimates above give
-    \[
-        3(D^4+1)(D-1)\leq3D^5.
-    \]
-    % Detailed audit: docs/paper-gaps/cpgsv17_bicf_block_separation.tex.
-\end{remark}
+    where the last inequality follows from $D-1\leq D^4$.
+    This is the bound in
+    \cite[lines~340--345]{Cirac2016MPDO_arXiv}.
+\end{proof}
 
 \begin{definition}[Representative word-tuple separation]
     \label{def:representative_word_tuple_span}
@@ -382,8 +392,9 @@ This is the inverse identity in
     In the first auxiliary assertion, eventual representative word-tuple
     separation is an explicit assumption.  The later post-blocked theorem
     derives the needed finite representative separation from the full BNT
-    canonical-form hypotheses.  The source's sharp $3D^5$ bound remains
-    separate, as recorded in
+    canonical-form hypotheses. The sharp $3D^5$ representative-separation
+    bound is Theorem~\ref{thm:sharp_bnt_block_separation}; its detailed source
+    comparison is recorded in
     \path{docs/paper-gaps/cpgsv17_bicf_block_separation.tex}.
 \end{theorem}
 

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -341,6 +341,8 @@ This is the inverse identity in
 \begin{proof}
     \leanok
     \uses{thm:bnt_representatives_exact_total_dimension_pow_four,
+        thm:wordspan_blk_inj_succ,
+        lem:direct_sum_two_block_dimension_step,
         lem:single_block_word_tuple_span,
         lem:pair_product_span_arbitrary_first_value,
         lem:bnt_direct_sum_block_separation_word_span,
@@ -349,14 +351,28 @@ This is the inverse identity in
     injective length is $D^4$. If $g=1$, ordinary block injectivity gives the
     simultaneous span at length $D^4$.
 
-    Suppose $g\geq2$. Positive-length propagation gives block injectivity at
-    lengths $D^4+1$ and $3(D^4+1)$. The pair-separation argument therefore
-    gives the full pair span at length $3(D^4+1)$ for every pair of distinct
-    representatives. For each block $k$,
+    Suppose $g\geq2$. Since
+    \[
+        D^4\leq D^4+1\leq3(D^4+1),
+    \]
+    Theorem~\ref{thm:wordspan_blk_inj_succ} propagates block injectivity to
+    the latter two lengths. Lemma~\ref{lem:direct_sum_two_block_dimension_step}
+    then gives the full pair span at length $3(D^4+1)$ for every pair of
+    distinct representatives. For each block $k$,
     Lemma~\ref{lem:pair_product_span_arbitrary_first_value} gives a tuple $M$
-    with $M_k=X_k$ and $M_j=0$ for a chosen anchor block $j$. Multiplying by
-    identity--zero selectors for the remaining $g-2$ representatives gives a
-    tuple supported only on block $k$. Summing over $k$ gives the full
+    with $M_k=X_k$ and $M_j=0$ for a chosen anchor block $j$. For every
+    $\ell\notin\{k,j\}$, choose an identity--zero selector $N^{(\ell)}$ and
+    form
+    \[
+        C_t=M_t\prod_{\ell\notin\{k,j\}}N^{(\ell)}_t.
+    \]
+    Since $N^{(\ell)}_k=I$ and $N^{(\ell)}_\ell=0$,
+    \[
+        C_k=X_k,\qquad C_j=0,\qquad
+        C_\ell=M_\ell(\cdots)0(\cdots)=0
+        \quad(\ell\notin\{k,j\}).
+    \]
+    Thus $C$ is supported only on block $k$. Summing over $k$ gives the full
     simultaneous span at length
     \[
         N=3(g-1)(D^4+1).

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -340,7 +340,8 @@ This is the inverse identity in
 
 \begin{proof}
     \leanok
-    \uses{lem:single_block_word_tuple_span,
+    \uses{thm:bnt_representatives_exact_total_dimension_pow_four,
+        lem:single_block_word_tuple_span,
         lem:pair_product_span_arbitrary_first_value,
         lem:bnt_direct_sum_block_separation_word_span,
         thm:sector_basis_dimension_le_total_dimension}

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -302,12 +302,35 @@ This is the inverse identity in
     nondegeneracy of the trace pairing gives finite-length trace separation.
 \end{proof}
 
+\begin{lemma}[Single-block word-tuple span]
+    \label{lem:single_block_word_tuple_span}
+    \lean{MPSTensor.wordTupleSpanTop_of_card_eq_one_of_isNBlkInjective}
+    \leanok
+    \uses{def:l_blk_injective, rem:word_tuple_span_top}
+    Let $(A_j)_{j=0}^{g-1}$ be a family with $g=1$. If its unique block is
+    $L$-block injective, then the simultaneous length-$L$ word evaluations
+    span the full one-block product algebra.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{def:l_blk_injective, rem:word_tuple_span_top}
+    For every matrix $X$, block injectivity gives coefficients such that
+    \[
+        X=\sum_{|w|=L}c_wA_0^w.
+    \]
+    Since the family has only the block $A_0$, this is precisely the required
+    simultaneous word-tuple spanning identity.
+\end{proof}
+
 \begin{theorem}[Sharp finite-length block separation]
     \label{thm:sharp_bnt_block_separation}
     \lean{MPSTensor.IsBNTCanonicalForm.exists_basis_wordTupleSpanTop_le_three_totalDim_pow_five}
+    \lean{MPSTensor.three_mul_pred_mul_pow_four_add_one_le_three_mul_pow_five}
     \leanok
     \uses{thm:bnt_representatives_exact_total_dimension_pow_four,
         thm:sector_basis_dimension_le_total_dimension,
+        lem:single_block_word_tuple_span,
         lem:bnt_direct_sum_block_separation_word_span}
     Let $P$ be a BNT canonical form with total bond dimension $D$. There is a
     positive integer $N\leq3D^5$ such that the simultaneous word evaluations

--- a/docs/paper-gaps/cpgsv17_bicf_block_separation.tex
+++ b/docs/paper-gaps/cpgsv17_bicf_block_separation.tex
@@ -283,8 +283,9 @@ decomposition from the resulting reducing projections, and proving the
 subsequent positivity and isometric normalization of its sectors, are separate
 parts of that proposition.
 
-The sharp numerical statement is therefore classified as \emph{closed}. The
-proof has the source hypothesis set: BNT canonical form supplies normality,
+The previously open gap is now resolved: the formal theorem matches the
+source's hypothesis set and conclusion, through a different proof of the
+simultaneous-interpolation step. BNT canonical form supplies normality,
 left-canonicality, normalized self-overlap, and pairwise gauge-phase
 inequivalence; no finite separation witness is added as a hypothesis. The
 source-level Lemma L needs only existence of a suitable finite length, while

--- a/docs/paper-gaps/cpgsv17_bicf_block_separation.tex
+++ b/docs/paper-gaps/cpgsv17_bicf_block_separation.tex
@@ -93,11 +93,9 @@ older per-copy trace-separation conclusion.\footnote{The criteria are
     \texttt{HorizontalCFData} constructors such as
     \texttt{horizontalCFData\_of\_propBlockInjective}.  The blueprint records
     these restricted criteria in its finite-witness remark.}
-Thus the sharp block-injectivity proposition has not been asserted without proof.  These
-statements remain correct restricted results, but the public horizontal
-canonical-form predicate no longer uses them.  It is now stated through a
-representative-indexed BNT sector decomposition, so repeated copies are
-grouped before the separation argument.
+These statements remain correct restricted results. The sharp proposition is
+now proved separately for a representative-indexed BNT sector decomposition,
+so repeated copies are grouped before the separation argument.
 
 \section{The counterexample boundary}
 
@@ -177,8 +175,8 @@ the coefficient identity
 \[
     c_{P^{[p]},j}^{(N)}=c_{P,j}^{(Np)}.
 \]
-The tensor assembled from this blocked decomposition has the same MPV family
-as the physical blocking of the original assembled tensor.
+The tensor obtained from this blocked decomposition has the same MPV family
+as the physical blocking of the original tensor.
 
 The representative-separation step has now been obtained without asserting
 preservation of the full canonical-form predicate.  If $p>0$ and every
@@ -220,46 +218,52 @@ $D^4$.  This exact common length has been formalized.\footnote{Formal
     \leanid{MPSTensor.isNBlkInjective_pow_four_of_isNormal_leftCanonical}, and
     \leanid{MPSTensor.IsBNTCanonicalForm.basis_isNBlkInjective_totalDim_pow_four}.}
 
-It remains useful to distinguish identity--zero selectors from the full tuple
-span.  Put $g$ for the number of minimal representatives and set $L_0=D^4$.
-The proved two-block argument gives the full pair span at length $3(L_0+1)$;
-in particular it can realize $(X,0)$ on a chosen block and one anchor block.
-For $g\geq2$, multiplying this pair polynomial by $g-2$ identity--zero
-selectors for the remaining representatives should give a tuple equal to $X$
-on the chosen block and zero elsewhere, at total length
+The direct-sum interpolation is now complete. Put $g$ for the number of
+minimal representatives and set $L_0=D^4$. The two-block argument gives the
+full pair span at length $S=3(L_0+1)$. For a chosen block $k$, choose an anchor
+block $j\ne k$ and use this pair span to realize an arbitrary pair $(X_k,0)$.
+Multiply that word polynomial by one identity--zero selector for each of the
+remaining $g-2$ blocks. The resulting simultaneous tuple equals $X_k$ on
+block $k$ and vanishes on every other block, at length
 \[
-    3(g-1)(D^4+1).
+    (g-1)S=3(g-1)(D^4+1).
 \]
-Since every representative has positive dimension and occurs at least once,
-$g\leq D$; hence this target length is at most the source length
-$3(D^4+1)(D-1)$.  The existing conversion from selectors to the whole product
-algebra instead concatenates an additional injective prefix of length
-$D^4$.
-\footnote{Formal declaration:
-\leanid{MPSTensor.hasBiCF_of_propBlockInjective}.}
-Its exact length is therefore
-\[
-    D^4+3(g-1)(D^4+1).
-\]
-This is within the source length when $g\leq D-1$, but exceeds it by
-$D^4$ in the extremal case $g=D$.  Thus the remaining multi-block
-mathematical point is not quantum Wielandt.  It is the simultaneous
-interpolation statement which realizes $(X,0)$ on the chosen anchor pair
-while multiplying by identity--zero selectors for the remaining
-representatives, without paying a separate injective prefix.  The
-case $g=1$ has no direct-sum obstruction and is handled by ordinary block
-injectivity.  Adding an assumed finite separation witness would conceal the
-multi-block point and is not an acceptable substitute.
+Summing these block-supported tuples over $k$ realizes every element of the
+full product algebra. No separate injective prefix is used. The length-zero
+identity occurs only as the neutral base of the finite product when there are
+no remaining selectors; it is not a padding hypothesis or a separate case in
+the theorem.
 
-Once that simultaneous interpolation is supplied, the final arithmetic is
-elementary:
-for $D\geq1$,
+If $g=1$, ordinary block injectivity gives the required span at length $D^4$.
+If $g\geq2$, positivity of the representative dimensions and multiplicities
+gives $g\leq D$. The remaining arithmetic is
 \[
   3(D^4+1)(D-1)
   =3(D^5-D^4+D-1)
   \leq 3D^5,
 \]
 because $D-1\leq D^4$.
+
+The formal proof is recorded by the following declarations:
+\begin{itemize}
+  \item
+  \leanid{MPSTensor.exists_mem_span_wordTuple_eq_and_eq_zero_of_pairWordTupleSpanTop}
+  realizes the arbitrary anchor-pair value;
+  \item
+  \leanid{MPSTensor.wordTupleSpanTop_mul_pred_of_forall_pairWordTupleSpanTop}
+  and
+  \leanid{MPSTensor.wordTupleSpanTop_mul_pred_of_forall_pairTraceSeparatingAt}
+  prove the direct-sum interpolation at length $(g-1)S$;
+  \item
+  \leanid{MPSTensor.wordTupleSpanTop_threeBlock_mul_pred_of_blocksNotGaugePhaseEquiv_c1}
+  specializes the result to the source length $3(g-1)(L_0+1)$;
+  \item
+  \leanid{MPSTensor.SectorDecomposition.basisCount_le_totalDim}
+  proves $g\leq D$;
+  \item
+  \leanid{MPSTensor.IsBNTCanonicalForm.exists_basis_wordTupleSpanTop_le_three_totalDim_pow_five}
+  gives a positive simultaneous-span length at most $3D^5$.
+\end{itemize}
 
 The public horizontal canonical-form predicate has now been replaced by the
 representative-indexed formulation.  It quantifies a BNT sector decomposition
@@ -279,15 +283,12 @@ decomposition from the resulting reducing projections, and proving the
 subsequent positivity and isometric normalization of its sectors, are separate
 parts of that proposition.
 
-The sharp numerical statement is therefore classified as an \emph{open gap}.
-For $g\geq2$, the sole remaining conceptual blocker identified here is the
-simultaneous interpolation of one arbitrary anchor-pair value with
-identity--zero pair selectors on all remaining representatives.  The formal
-proof will also require routine
-named lemmas for $g\leq D$, specialization to $L_0=D^4$, and
-$3(D^4+1)(D-1)\leq3D^5$.  For $g=1$, ordinary block injectivity supplies the
-result directly.  The source-level Lemma L needs only the existence of a
-suitable finite length, not this sharp estimate.
+The sharp numerical statement is therefore classified as \emph{closed}. The
+proof has the source hypothesis set: BNT canonical form supplies normality,
+left-canonicality, normalized self-overlap, and pairwise gauge-phase
+inequivalence; no finite separation witness is added as a hypothesis. The
+source-level Lemma L needs only existence of a suitable finite length, while
+the formal theorem also establishes the stated bound $3D^5$.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/david2006_direct_sum_input.tex
+++ b/docs/paper-gaps/david2006_direct_sum_input.tex
@@ -143,14 +143,27 @@ selector and product-span construction.\footnote{%
 \leanid{MPSTensor.forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv};
 \leanid{MPSTensor.exists_forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv}.}
 
-The already-injective BNT conclusion is now stated directly from explicit
-separated-block hypotheses, with the required injective-block hypotheses kept
-visible. In that form, when the selected BNT blocks are already injective at
-the required common lengths, the selector datum and the resulting finite
-direct-sum span are theorems rather than identity-padding assumptions.\footnote{%
+The BNT conclusion is stated directly from explicit separated-block
+hypotheses, with the required finite-length injectivity hypotheses visible.
+These hypotheses may begin at an arbitrary positive common length $L_0$;
+positive-length propagation supplies the longer lengths used in the proof.
+The selector datum and the resulting finite direct-sum span are theorems rather
+than identity-padding assumptions.\footnote{%
 \leanid{MPSTensor.hasPairBlockSeparatingWords_threeBlock_of_blocksNotGaugePhaseEquiv};
 \leanid{MPSTensor.propBlockInjective_of_blocksNotGaugePhaseEquiv_directSum};
-\leanid{MPSTensor.wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors}.}
+\leanid{MPSTensor.wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors};
+and their Condition-C1 variants in
+\path{TNLean/MPS/MPDO/BiCFDerivation/BNTDirectSum.lean}.}
+
+The sharp direct-sum interpolation does not concatenate a separate injective
+prefix. Full pair span at a common length $S$ realizes an arbitrary value
+$(X,0)$ on a chosen block and one anchor block. Multiplication by $b-2$
+identity--zero selectors removes the remaining blocks. Hence the full
+simultaneous span holds at length $(b-1)S$. For
+$S=3(L_0+1)$ this is exactly the source length
+$3(b-1)(L_0+1)$.\footnote{%
+\leanid{MPSTensor.wordTupleSpanTop_mul_pred_of_forall_pairWordTupleSpanTop};
+\leanid{MPSTensor.wordTupleSpanTop_threeBlock_mul_pred_of_blocksNotGaugePhaseEquiv_c1}.}
 
 The downstream consumers of the direct-sum input are threefold. The exact-length
 span of a direct-sum block family and its two-block trace-dual form are expressed
@@ -166,39 +179,27 @@ exact-length span for a canonical-form BNT family.\footnote{%
 
 \section{Conclusion}
 
-The formalized theorems cover the $L_0=1$ case: when the selected BNT blocks
-are already injective at length one (as supplied by the one-copy
-normal-canonical BNT formulation together with irreducible-block hypotheses),
-their pairwise not-gauge-phase-equivalence data and the fixed lengths from
-one-site injectivity imply the homogeneous pair-trace separation and
-product-word-span conclusions needed downstream. For this special case the
-formal result matches the
-paper's conclusion: distinct BNT representatives yield a direct-sum span at a
-common finite length. However, it does not formalize the full generality of the
-paper's direct-sum theorem. The older representation paper states the result for
-arbitrary $L_0$, ordered block sizes, and $b\ge2$ blocks; those features are
-replaced here by one-copy normal-canonical BNT and explicit separated-block
-hypotheses. The general-$L_0$ case, in which each normal block needs a
-Wielandt-type blocking step to reach
-length-$L_0$ injectivity, is not covered by these theorems alone; it requires
-the separate bounded and common injective-blocking results. The old warning
-against replacing exact-length span by cumulative span therefore remains
-mathematically important for that general setting.
+The arbitrary-$L_0$ direct-sum interpolation needed for the BNT specialization
+is now formalized at the exact source length $3(b-1)(L_0+1)$. The resulting
+span is homogeneous and positive-length, not cumulative. The length-zero
+identity is only the neutral base of a finite product over no remaining
+selectors. The case $b=1$ is treated separately by ordinary block injectivity.
 
-For the full after-blocking normal-CF-BNT route, the conclusion is still
-conditional. The bounded and common injective-blocking results now supply the
-Wielandt part of the input, but the final CPSV theorem is not yet unconditional:
-the proof still has to transport the blocked BNT separation hypotheses through
-the chosen reblocking/reindexing maps and feed the blocked not-GPE facts into
-the BNT sector-data theorem \leanid{MPSTensor.ft_sector_bnt_equal_sector_data}.
-That transport is the remaining bridge between the already-injective direct-sum
-theorem surface and the canonical-form after-blocking comparison.
+For a BNT canonical form of total bond dimension $D$, the common quantum
+Wielandt length is $L_0=D^4$. Every representative has positive dimension and
+occurs at least once, so $b\leq D$. The formal theorem consequently gives a
+positive simultaneous-span length at most
+\[
+  3(b-1)(D^4+1)\leq3(D-1)(D^4+1)\leq3D^5.
+\]
+This closes the sharp block-separation input cited by the 2016 MPDO source.\footnote{%
+\leanid{MPSTensor.SectorDecomposition.basisCount_le_totalDim};
+\leanid{MPSTensor.IsBNTCanonicalForm.exists_basis_wordTupleSpanTop_le_three_totalDim_pow_five}.}
 
-Accordingly, the blueprint should present the David/P\'erez-Garc\'ia
-exact-length direct-sum input as formalized for the already-injective BNT
-specialization, while keeping the after-blocking CPSV statement visibly
-conditional until the reblocking transport and blocked BNT-separation handling
-have landed.
+This conclusion concerns the finite-length direct-sum span. Other statements
+in the Fundamental Theorem that compare two canonical-form tensors still
+require their own reblocking and sector-data arguments; those are logically
+separate from the direct-sum input proved here.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

This stacked pull request proves the sharp block-separation statement used in Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, lines 317–345.

For a BNT canonical form of total bond dimension \(D\), it:

- proves simultaneous word-tuple interpolation for all minimal representatives;
- obtains a positive common length \(N\le 3D^5\);
- derives the source block-injectivity conclusion without assuming a finite separation witness;
- replaces the abstract conditional blueprint statement and closes the corresponding paper-gap entry.

The proof follows the source selector route. A pair-span polynomial realizes \((X,0)\) on an anchor pair, and identity–zero selectors remove the remaining representatives. The estimate uses \(g\le D\) and
\[
3(D^4+1)(D-1)\le 3D^5.
\]

The length-zero word occurs only as the neutral element of the finite product when no selectors remain. It is not an empty physical ring and is not a public theorem hypothesis.

This PR is stacked on #3995, which supplies the source-faithful periodic hypotheses and the common exact injectivity length \(D^4\).

## Verification

- focused Lean checks for Selectors, BNTDirectSum, and BiCFDerivation;
- full lake build;
- blueprint–Lean synchronization;
- reader-facing prose check;
- changed-file proof-integrity scan;
- no added axiom, sorry, or kernel bypass.

Closes #3952.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Substantial new formal mathematics in selector/direct-sum lemmas that downstream biCF and canonical-form proofs rely on; risk is proof-correctness and length bookkeeping rather than runtime or security.
> 
> **Overview**
> **Proves the sharp Cirac–Pérez-García–Schuch–Verstraete block-separation bound** for BNT canonical forms: some positive length \(N \le 3D^5\) at which minimal representatives’ simultaneous word evaluations span the full product matrix algebra, without assuming a separate finite separation witness.
> 
> The main mathematical change is **direct-sum interpolation without an extra injective prefix**. Pair full span at length \(S\) now yields arbitrary \((X,0)\) on an anchor pair (`exists_mem_span_wordTuple_eq_and_eq_zero_of_pairWordTupleSpanTop`); multiplying by identity–zero selectors on the other blocks gives full simultaneous span at \((r-1)S\) (`wordTupleSpanTop_mul_pred_of_forall_pairTraceSeparatingAt`). That replaces the older route that concatenated a length-\(D^4\) injective prefix and produced a longer bound.
> 
> **BNT capstone:** `wordTupleSpanTop_threeBlock_mul_pred_of_blocksNotGaugePhaseEquiv_c1` feeds BNT hypotheses at \(L_0=D^4\); `IsBNTCanonicalForm.exists_basis_wordTupleSpanTop_le_three_totalDim_pow_five` packages the \(g=1\) and \(g\ge2\) cases with `basisCount_le_totalDim` and the numeric lemma \(3(D-1)(D^4+1)\le 3D^5\).
> 
> Blueprint and paper-gap docs promote the former open \(3D^5\) remark to **Theorem sharp_bnt_block_separation** and mark the bicf/direct-sum gaps resolved; module docs note the heavier BNT direct-sum theorem is opt-in via `BNTDirectSum.lean`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8120988dda65c62f704fe152ff6f8509544b231b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->