### PR TITLE
feat(MPS/MPDO): prove the closed-chain blocking identity

### DIFF
--- a/TNLean/MPS/MPDO/PhysicalBlocking.lean
+++ b/TNLean/MPS/MPDO/PhysicalBlocking.lean
@@ -152,6 +152,9 @@ private theorem evalWord_blockTensor_ofFn (M : MPOTensor d D) (L : ℕ) {N : ℕ
 sites gives the original closed chain of length `N * L`, after the canonical
 identification of blocked configurations with unblocked configurations.
 
+The algebraic identity holds for every natural `L`; its interpretation as
+blocking adjacent physical sites requires `L > 0`.
+
 This is the finite-index form of the physical blocking used when placing the
 one-site tensor and its two-site blocking in vertical canonical form in
 arXiv:1606.00608, Appendix C.4, lines 1952--2017. -/
@@ -168,8 +171,8 @@ theorem mpo_blockTensor_eq_reindex (M : MPOTensor d D) (L N : ℕ) :
 
 For positive `L`, this is the blocking operation used throughout the vertical
 canonical-form comparison of arXiv:1606.00608, Appendix C.4, lines 1952--2017.
-The algebraic definition is total at `L = 0`, where the same conclusion also
-holds but has no physical interpretation as a blocking operation. -/
+The statement holds for every natural `L`; `L = 0` is only the formal base
+value of the algebraic definitions, not a physical blocking operation. -/
 theorem IsMPDO.blockTensor {M : MPOTensor d D} (hM : IsMPDO M) (L : ℕ) :
     IsMPDO (blockTensor M L) := by
   intro N

--- a/TNLean/MPS/MPDO/PhysicalBlocking.lean
+++ b/TNLean/MPS/MPDO/PhysicalBlocking.lean
@@ -21,6 +21,9 @@ arXiv:1606.00608.
 
 * `MPOTensor.blockTensor`: the tensor obtained by blocking an arbitrary number
   of adjacent sites.
+* `MPOTensor.mpo_blockTensor_eq_reindex`: closing a blocked chain gives the
+  corresponding longer unblocked chain.
+* `MPOTensor.IsMPDO.blockTensor`: physical blocking preserves the MPDO property.
 * `MPOTensor.blockTwo`: the tensor obtained by blocking two adjacent sites.
 * `MPOTensor.physClose4`: the right-associated four-site physical closure.
 * `MPOTensor.physClose1_blockTwo_eq_physClose2`: one blocked site is two original sites.
@@ -30,9 +33,11 @@ arXiv:1606.00608.
 
 * [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
   Theorem 4.9, lines 851--856
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.4, lines 1952--2017
 -/
 
-open scoped Matrix
+open scoped Matrix ComplexOrder
 
 namespace MPOTensor
 
@@ -128,6 +133,49 @@ theorem blockTensor_mulTensor {D₁ D₂ : ℕ}
   rw [← (MPSTensor.decodeBlockEquiv d L).sum_comp]
   simp only [MPSTensor.decodeBlockEquiv_apply, blockTensor_apply,
     MPSTensor.wordOfBlock]
+
+private theorem evalWord_blockTensor_ofFn (M : MPOTensor d D) (L : ℕ) {N : ℕ}
+    (s t : Fin N → Fin (MPSTensor.blockPhysDim d L)) :
+    evalWord (blockTensor M L) (List.ofFn s) (List.ofFn t) =
+      evalWord M (MPSTensor.flattenBlockedWord d L (List.ofFn s))
+        (MPSTensor.flattenBlockedWord d L (List.ofFn t)) := by
+  induction N with
+  | zero =>
+      simp [MPSTensor.flattenBlockedWord]
+  | succ N ih =>
+      simp only [List.ofFn_succ, evalWord_cons, blockTensor_apply,
+        MPSTensor.flattenBlockedWord_cons]
+      rw [ih]
+      rw [evalWord_append M _ _ _ _ (by simp)]
+
+/-- Closing a chain of `N` tensors after blocking `L` consecutive physical
+sites gives the original closed chain of length `N * L`, after the canonical
+identification of blocked configurations with unblocked configurations.
+
+This is the finite-index form of the physical blocking used when placing the
+one-site tensor and its two-site blocking in vertical canonical form in
+arXiv:1606.00608, Appendix C.4, lines 1952--2017. -/
+theorem mpo_blockTensor_eq_reindex (M : MPOTensor d D) (L N : ℕ) :
+    mpo (blockTensor M L) N =
+      Matrix.reindex (MPSTensor.blockedConfigEquiv d N L).symm
+        (MPSTensor.blockedConfigEquiv d N L).symm (mpo M (N * L)) := by
+  ext σ τ
+  simp only [Matrix.reindex_apply, Matrix.submatrix_apply, mpo_apply, mpoMatrixEntry]
+  rw [evalWord_blockTensor_ofFn]
+  simp only [Equiv.symm_symm, MPSTensor.ofFn_blockedConfigEquiv]
+
+/-- Physical blocking preserves global positivity of the closed MPO family.
+
+For positive `L`, this is the blocking operation used throughout the vertical
+canonical-form comparison of arXiv:1606.00608, Appendix C.4, lines 1952--2017.
+The algebraic definition is total at `L = 0`, where the same conclusion also
+holds but has no physical interpretation as a blocking operation. -/
+theorem IsMPDO.blockTensor {M : MPOTensor d D} (hM : IsMPDO M) (L : ℕ) :
+    IsMPDO (blockTensor M L) := by
+  intro N
+  rw [mpo_blockTensor_eq_reindex]
+  rw [Matrix.reindex_apply]
+  exact (hM (N * L)).submatrix _
 
 /-! ### Two-site blocking -/
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -137,6 +137,39 @@ physical indices, as in
     the product of the two blocked tensors.
 \end{proof}
 
+\begin{theorem}[Closed MPO chains under physical blocking]
+    \label{thm:mpdo_closed_chain_physical_blocking}
+    \lean{MPOTensor.mpo_blockTensor_eq_reindex}
+    \lean{MPOTensor.IsMPDO.blockTensor}
+    \leanok
+    \uses{def:mpdo_positive_physical_blocking, def:mpo_family, def:mpdo}
+    Let $L>0$, and let
+    \[
+        \Phi_{N,L}:
+        \{0,\ldots,d^L-1\}^N
+        \longrightarrow \{0,\ldots,d-1\}^{NL}
+    \]
+    concatenate the $N$ blocked words.  For blocked configurations
+    $\sigma$ and $\tau$,
+    \[
+        \rho^{(N)}\bigl(M^{[L]}\bigr)_{\sigma,\tau}
+        =\rho^{(NL)}(M)_{\Phi_{N,L}(\sigma),\Phi_{N,L}(\tau)}.
+    \]
+    Consequently, if $M$ generates an MPDO, then $M^{[L]}$ generates an
+    MPDO.  This is the closed-chain identification implicit when the one-site
+    tensor and its two-site blocking are placed in vertical canonical form in
+    \cite[Appendix~C.4, lines~1952--2017]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:mpo_eval_word_append}
+    Concatenating the $N$ pairs of length-$L$ words turns the product of the
+    blocked matrices into the product of the original $NL$ matrices.  Taking
+    the virtual trace gives the displayed equality.  The map $\Phi_{N,L}$ is
+    a bijection, and conjugating a positive semidefinite matrix by its
+    permutation matrix preserves positive semidefiniteness.
+\end{proof}
+
 \begin{definition}[Two-site blocking of an MPO tensor]
     \label{def:mpdo_two_site_blocking}
     \lean{MPOTensor.blockTwo}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -143,7 +143,7 @@ physical indices, as in
     \lean{MPOTensor.IsMPDO.blockTensor}
     \leanok
     \uses{def:mpdo_positive_physical_blocking, def:mpo_family, def:mpdo}
-    Let $L>0$, and let
+    Let $L\in\N$, and let
     \[
         \Phi_{N,L}:
         \{0,\ldots,d^L-1\}^N
@@ -155,19 +155,36 @@ physical indices, as in
         \rho^{(N)}\bigl(M^{[L]}\bigr)_{\sigma,\tau}
         =\rho^{(NL)}(M)_{\Phi_{N,L}(\sigma),\Phi_{N,L}(\tau)}.
     \]
-    Consequently, if $M$ generates an MPDO, then $M^{[L]}$ generates an
-    MPDO.  This is the closed-chain identification implicit when the one-site
-    tensor and its two-site blocking are placed in vertical canonical form in
+    This algebraic identity and the preservation of positive semidefiniteness
+    hold for every $L\in\N$.  For $L>0$, they state that blocking $L$
+    adjacent physical sites of an MPDO again gives an MPDO.  The value $L=0$
+    is only the base value of the algebraic definitions and is not a physical
+    blocking operation.  This is the closed-chain identification implicit
+    when the one-site tensor and its two-site blocking are placed in vertical
+    canonical form in
     \cite[Appendix~C.4, lines~1952--2017]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{lem:mpo_eval_word_append}
-    Concatenating the $N$ pairs of length-$L$ words turns the product of the
-    blocked matrices into the product of the original $NL$ matrices.  Taking
-    the virtual trace gives the displayed equality.  The map $\Phi_{N,L}$ is
-    a bijection, and conjugating a positive semidefinite matrix by its
-    permutation matrix preserves positive semidefiniteness.
+    Write
+    $\sigma_k=(\sigma_{k,0},\ldots,\sigma_{k,L-1})$ and
+    $\tau_k=(\tau_{k,0},\ldots,\tau_{k,L-1})$.  For each $k$,
+    \[
+        \bigl(M^{[L]}\bigr)^{\sigma_k,\tau_k}
+        =\prod_{j=0}^{L-1}M^{\sigma_{k,j},\tau_{k,j}}.
+    \]
+    Taking both products in increasing index order gives
+    \[
+        \prod_{k=0}^{N-1}\bigl(M^{[L]}\bigr)^{\sigma_k,\tau_k}
+        =\prod_{k=0}^{N-1}\prod_{j=0}^{L-1}
+            M^{\sigma_{k,j},\tau_{k,j}}
+        =\prod_{r=0}^{NL-1}
+            M^{(\Phi_{N,L}(\sigma))_r,(\Phi_{N,L}(\tau))_r}.
+    \]
+    Taking the virtual trace gives the equality in the theorem.  The map
+    $\Phi_{N,L}$ is a bijection, and simultaneous reindexing of the rows and
+    columns preserves positive semidefiniteness.
 \end{proof}
 
 \begin{definition}[Two-site blocking of an MPO tensor]


### PR DESCRIPTION
## Summary

This pull request proves the closed-chain identity for physical MPO blocking and the resulting preservation of the MPDO property.

For an MPO tensor \(M\), block length \(L\), and blocked ring length \(N\), the theorem identifies
\[
\rho^{(N)}(M^{[L]})
\]
with the simultaneous reindexing of
\[
\rho^{(NL)}(M)
\]
under the canonical bijection that concatenates the \(N\) blocked physical words. Positivity is therefore preserved by a permutation reindexing.

This is the elementary blocking fact implicit when the one-site tensor and its two-site blocking are placed in vertical canonical form in Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, Appendix C.4, lines 1952–2017.

The reader-facing theorem assumes \(L>0\), as physical blocking does. The Lean definition is algebraically total at \(L=0\); that endpoint has no physical interpretation and is not used as an empty-ring statement.

This is a prerequisite for #3949. It does not claim the vertical-BNT comparison, fusion maps, reverse implication, or the full three-way equivalence, and therefore does not close that issue.

## Verification

- focused Lean check for PhysicalBlocking;
- downstream build of PhysicalSectorOmegaPreparation;
- full lake build;
- blueprint–Lean synchronization;
- reader-facing prose and diff checks;
- changed-file proof-integrity scan;
- no added axiom, sorry, or kernel bypass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal MPO/MPDO lemmas and blueprint sync only; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds the **closed-chain identity** for physical MPO blocking: for block length `L` and `N` sites on the blocked tensor, `ρ^{(N)}(M^{[L]})` equals `ρ^{(NL)}(M)` after simultaneous reindexing by `blockedConfigEquiv` (concatenating blocked physical words). The proof introduces `evalWord_blockTensor_ofFn` (blocked `evalWord` vs `flattenBlockedWord`) and finishes with matrix entry extension.
> 
> **`IsMPDO.blockTensor`** shows blocking preserves global positivity by rewriting through that identity and applying **`PosSemidef.submatrix`** on the longer chain. Module docs and blueprint **Theorem (Closed MPO chains under physical blocking)** are added, aligned with Cirac et al. Appendix C.4; prose notes the identity is algebraic for all `L`, with physical blocking meant for `L > 0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d817e7ec937edd44c1271ae7ac1ebb46765fa7a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->