### PR TITLE
refactor(rfp): simplify MPS and MPDO proofs

### DIFF
--- a/TNLean/Algebra/ConstantPowerSums.lean
+++ b/TNLean/Algebra/ConstantPowerSums.lean
@@ -79,8 +79,7 @@ theorem eq_zero_or_eq_one_of_forall_sum_pow_eq {x : ι → ℝ} (hx : ∀ k, 0 �
       exact mul_le_of_le_one_left (hx k) (hle k)
     linarith
   have hj := (Finset.sum_eq_zero_iff_of_nonneg hterm).mp hzero j (Finset.mem_univ j)
-  have hfactor : x j * (1 - x j) = 0 := by ring_nf; linarith
-  rcases mul_eq_zero.mp hfactor with h | h
+  rcases mul_eq_zero.mp (show x j * (1 - x j) = 0 by nlinarith) with h | h
   · exact Or.inl h
   · exact Or.inr (by linarith)
 

--- a/TNLean/MPS/MPDO/AlgebraFusionCounterexample.lean
+++ b/TNLean/MPS/MPDO/AlgebraFusionCounterexample.lean
@@ -133,9 +133,10 @@ private theorem phaseFlipTensor_transferMap_pow_fixed_iff
       simp only [hij, ↓reduceIte] at hentry
       have hzero : ((-7 / 25 : ℂ) ^ n - 1) * X i j = 0 := by
         linear_combination hentry
-      rcases mul_eq_zero.mp hzero with hcoeff | hentryZero
-      · exact ((phaseFlip_eigenvalue_pow_ne_one hn) (sub_eq_zero.mp hcoeff)).elim
-      · simp [hij, hentryZero]
+      have hentryZero : X i j = 0 :=
+        (mul_eq_zero.mp hzero).resolve_left <|
+          sub_ne_zero.mpr (phaseFlip_eigenvalue_pow_ne_one hn)
+      simp [hij, hentryZero]
   · intro hX
     exact phaseFlipTensor_transferMap_pow_fixed hX n
 
@@ -207,8 +208,8 @@ of `IsRFP_MPDO_via_algebra`. -/
 theorem exists_isRFP_MPDO_via_algebra_not_isRFP_MPDO_via_fusion :
     ∃ (M : MPOTensor 2 2) (ρ : Matrix (Fin 2) (Fin 2) ℂ),
       Kraus.IsTP M.toMPSTensor ∧ ρ.PosDef ∧ MPOTensor.transferMap M ρ = ρ ∧
-        IsRFP_MPDO_via_algebra M ∧ ¬IsRFP_MPDO_via_fusion M := by
-  exact ⟨phaseFlipTensor.toMPOTensor, 1, phaseFlipMPO_isTP,
+        IsRFP_MPDO_via_algebra M ∧ ¬IsRFP_MPDO_via_fusion M :=
+  ⟨phaseFlipTensor.toMPOTensor, 1, phaseFlipMPO_isTP,
     Matrix.PosDef.one (n := Fin 2) (R := ℂ), phaseFlipMPO_one_fixed,
     phaseFlipMPO_isRFP_MPDO_via_algebra, phaseFlipMPO_not_isRFP_MPDO_via_fusion⟩
 

--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -561,9 +561,7 @@ theorem adjoint_transferMap_eigenvalue_eq_one_of_isRFP_MPDO_via_algebra
     exact hFix
   have hSub : (lam - 1) • X = 0 := by
     rw [sub_smul, hLamX, one_smul, sub_self]
-  rcases smul_eq_zero.mp hSub with hLam_sub | hX_zero
-  · exact sub_eq_zero.mp hLam_sub
-  · exact (hX_ne hX_zero).elim
+  exact sub_eq_zero.mp <| (smul_eq_zero.mp hSub).resolve_right hX_ne
 
 /-- Under the current algebra-structure predicate, the adjoint fixed points of
 every positive blocked transfer map coincide with the adjoint fixed points of
@@ -772,15 +770,15 @@ the `L`-th power. -/
 theorem matrix_pow (n : ℕ) (i j : BlockedIndex data n)
     (k : BlockedIndex data (2 * n)) (L : ℕ) :
     χ.matrix n i j k ^ L =
-      Matrix.diagonal fun r => (χ.entry n i j k r) ^ L := by
-  exact (χ.toDiagonal n).matrix_pow (Sum.inl i) (Sum.inl j) (Sum.inr k) L
+      Matrix.diagonal fun r => (χ.entry n i j k r) ^ L :=
+  (χ.toDiagonal n).matrix_pow (Sum.inl i) (Sum.inl j) (Sum.inr k) L
 
 /-- The trace of the `L`-th power of a blocked chi matrix is the corresponding
 finite sum of `L`-th powers of its diagonal entries. -/
 lemma trace_matrix_pow (n : ℕ) (i j : BlockedIndex data n)
     (k : BlockedIndex data (2 * n)) (L : ℕ) :
-    (χ.matrix n i j k ^ L).trace = χ.tracePowerCoeff n i j k L := by
-  exact (χ.toDiagonal n).trace_matrix_pow (Sum.inl i) (Sum.inl j) (Sum.inr k) L
+    (χ.matrix n i j k ^ L).trace = χ.tracePowerCoeff n i j k L :=
+  (χ.toDiagonal n).trace_matrix_pow (Sum.inl i) (Sum.inl j) (Sum.inr k) L
 
 /-- Positivity of every diagonal entry in the blocked chi family. -/
 def PosEntries : Prop :=

--- a/TNLean/MPS/MPDO/BNTAssociativity.lean
+++ b/TNLean/MPS/MPDO/BNTAssociativity.lean
@@ -91,9 +91,9 @@ theorem HasSameLengthProductForm.coeff_eq_of_linearIndependentAt
       = 0 := by
     simp_rw [sub_smul]
     rw [Finset.sum_sub_distrib, hsum, sub_self]
-  have hdiff := Fintype.linearIndependent_iff.mp hli
-    (fun δ => c.coeff L α β δ - c'.coeff L α β δ) hzero γ
-  exact sub_eq_zero.mp hdiff
+  exact sub_eq_zero.mp <|
+    Fintype.linearIndependent_iff.mp hli
+      (fun δ => c.coeff L α β δ - c'.coeff L α β δ) hzero γ
 
 /-- **Associativity constraint on the structure coefficients**: expanding
 the two associations of a triple product through the same-length product law
@@ -138,10 +138,10 @@ theorem HasSameLengthProductForm.coeff_assoc_of_linearIndependentAt
       - (∑ δ, c.coeff L β γ δ * c.coeff L α δ ε')) • op.operator L ε' = 0 := by
     simp_rw [sub_smul]
     rw [Finset.sum_sub_distrib, hsum, sub_self]
-  have hdiff := Fintype.linearIndependent_iff.mp hli
-    (fun ε' => (∑ δ, c.coeff L α β δ * c.coeff L δ γ ε')
-      - (∑ δ, c.coeff L β γ δ * c.coeff L α δ ε')) hzero ε
-  exact sub_eq_zero.mp hdiff
+  exact sub_eq_zero.mp <|
+    Fintype.linearIndependent_iff.mp hli
+      (fun ε' => (∑ δ, c.coeff L α β δ * c.coeff L δ γ ε') -
+        ∑ δ, c.coeff L β γ δ * c.coeff L α δ ε') hzero ε
 
 /-- Trace-power form of the associativity constraint: for a coefficient
 system in trace-power form, the restriction of the preceding theorem is a
@@ -168,9 +168,8 @@ theorem HasSameLengthProductForm.tracePowerCoeff_assoc_of_linearIndependentAt
     {L : ℕ} (hL : 0 < L) (hli : op.LinearIndependentAt L) (α β γ ε : Λ) :
     ∑ δ, χ.tracePowerCoeff α β δ L * χ.tracePowerCoeff δ γ ε L
       = ∑ δ, χ.tracePowerCoeff β γ δ L * χ.tracePowerCoeff α δ ε L := by
-  have hassoc := h.coeff_assoc_of_linearIndependentAt hL hli α β γ ε
-  simp_rw [htp L hL] at hassoc
-  exact hassoc
+  simpa only [htp L hL] using
+    h.coeff_assoc_of_linearIndependentAt hL hli α β γ ε
 
 end BNTLabelOperatorFamily
 

--- a/TNLean/MPS/MPDO/BNTFixedFinalUnitarity.lean
+++ b/TNLean/MPS/MPDO/BNTFixedFinalUnitarity.lean
@@ -190,6 +190,20 @@ def rightTripleFinalEquiv (α β γ : Λ) :
   rcases x with ⟨δ, μ, ν, b⟩
   rfl
 
+private theorem leftTripleFinalEquiv_symm_comp (α β γ ε : Λ) :
+    (Fam.leftTripleFinalEquiv α β γ).symm ∘
+        (fun x : Fam.LeftFinalIndex α β γ ε => ⟨ε, x⟩) =
+      Fam.leftFinalRow α β γ ε := by
+  funext x
+  exact Fam.leftTripleFinalEquiv_symm_sigmaMk α β γ ε x
+
+private theorem rightTripleFinalEquiv_symm_comp (α β γ ε : Λ) :
+    (Fam.rightTripleFinalEquiv α β γ).symm ∘
+        (fun x : Fam.RightFinalIndex α β γ ε => ⟨ε, x⟩) =
+      Fam.rightFinalRow α β γ ε := by
+  funext x
+  exact Fam.rightTripleFinalEquiv_symm_sigmaMk α β γ ε x
+
 /-- **A fixed-final comparison corner has a right adjoint inverse.**
 
 Suppose that common words of one positive length separate the final-label
@@ -216,18 +230,6 @@ theorem tripleFusionComparison_finalSector_mul_conjTranspose_eq_one
   let C := Fam.tripleFusionComparison α β γ
   let C' := C.submatrix (Fam.leftTripleFinalEquiv α β γ).symm
     (Fam.rightTripleFinalEquiv α β γ).symm
-  have hleft (i : Λ) :
-      (Fam.leftTripleFinalEquiv α β γ).symm ∘
-          (fun x : Fam.LeftFinalIndex α β γ i => ⟨i, x⟩) =
-        Fam.leftFinalRow α β γ i := by
-    funext x
-    simp
-  have hright (i : Λ) :
-      (Fam.rightTripleFinalEquiv α β γ).symm ∘
-          (fun x : Fam.RightFinalIndex α β γ i => ⟨i, x⟩) =
-        Fam.rightFinalRow α β γ i := by
-    funext x
-    simp
   have hunit : C' * C'ᴴ = 1 := by
     unfold C'
     rw [Matrix.conjTranspose_submatrix,
@@ -239,12 +241,13 @@ theorem tripleFusionComparison_finalSector_mul_conjTranspose_eq_one
         (fun x : Fam.LeftFinalIndex α β γ i => ⟨i, x⟩)
         (fun y : Fam.RightFinalIndex α β γ j => ⟨j, y⟩) = 0 := by
     intro i j hji
-    simpa only [C', Matrix.submatrix_submatrix, hleft, hright] using
+    simpa only [C', Matrix.submatrix_submatrix,
+      leftTripleFinalEquiv_symm_comp, rightTripleFinalEquiv_symm_comp] using
       Fam.tripleFusionComparison_finalSector_submatrix_eq_zero
         c hχ hLI hSel α β γ i j hji
-  have hdiag := Matrix.sigmaDiagonal_mul_conjTranspose_eq_one C' hunit hoff ε
-  simp only [C', Matrix.submatrix_submatrix, hleft, hright] at hdiag
-  exact hdiag
+  simpa only [C', Matrix.submatrix_submatrix,
+    leftTripleFinalEquiv_symm_comp, rightTripleFinalEquiv_symm_comp] using
+    Matrix.sigmaDiagonal_mul_conjTranspose_eq_one C' hunit hoff ε
 
 /-- **A fixed-final comparison corner also has a left adjoint inverse.**
 
@@ -275,18 +278,6 @@ theorem conjTranspose_mul_tripleFusionComparison_finalSector_eq_one
   let C := Fam.tripleFusionComparison α β γ
   let C' := C.submatrix (Fam.leftTripleFinalEquiv α β γ).symm
     (Fam.rightTripleFinalEquiv α β γ).symm
-  have hleft (i : Λ) :
-      (Fam.leftTripleFinalEquiv α β γ).symm ∘
-          (fun x : Fam.LeftFinalIndex α β γ i => ⟨i, x⟩) =
-        Fam.leftFinalRow α β γ i := by
-    funext x
-    simp
-  have hright (i : Λ) :
-      (Fam.rightTripleFinalEquiv α β γ).symm ∘
-          (fun x : Fam.RightFinalIndex α β γ i => ⟨i, x⟩) =
-        Fam.rightFinalRow α β γ i := by
-    funext x
-    simp
   have hunit : C'ᴴ * C' = 1 := by
     unfold C'
     rw [Matrix.conjTranspose_submatrix,
@@ -298,12 +289,13 @@ theorem conjTranspose_mul_tripleFusionComparison_finalSector_eq_one
         (fun x : Fam.LeftFinalIndex α β γ j => ⟨j, x⟩)
         (fun y : Fam.RightFinalIndex α β γ i => ⟨i, y⟩) = 0 := by
     intro i j hji
-    simpa only [C', Matrix.submatrix_submatrix, hleft, hright] using
+    simpa only [C', Matrix.submatrix_submatrix,
+      leftTripleFinalEquiv_symm_comp, rightTripleFinalEquiv_symm_comp] using
       Fam.tripleFusionComparison_finalSector_submatrix_eq_zero
         c hχ hLI hSel α β γ j i hji.symm
-  have hdiag := Matrix.sigmaDiagonal_conjTranspose_mul_eq_one C' hunit hoff ε
-  simp only [C', Matrix.submatrix_submatrix, hleft, hright] at hdiag
-  exact hdiag
+  simpa only [C', Matrix.submatrix_submatrix,
+    leftTripleFinalEquiv_symm_comp, rightTripleFinalEquiv_symm_comp] using
+    Matrix.sigmaDiagonal_conjTranspose_mul_eq_one C' hunit hoff ε
 
 /-- **Conditional unitarity of the fixed-final multiplicity matrix.**
 

--- a/TNLean/MPS/MPDO/BNTTheoremWitnessConsequences.lean
+++ b/TNLean/MPS/MPDO/BNTTheoremWitnessConsequences.lean
@@ -65,10 +65,8 @@ theorem exists_positive_length_coeff_eq_ofChi {data : AlgebraStructureData d D}
       ∀ L : ℕ, 0 < L → ∀ α β γ : W.Label,
         W.coeffs.coeff L α β γ =
           (BNTLabelCoefficientFamily.ofChi W.positiveChi.chi).coeff L α β γ := by
-  rcases h with ⟨W⟩
-  refine ⟨W, ?_⟩
-  intro L hL α β γ
-  exact W.coeff_eq_ofChi_coeff L hL α β γ
+  obtain ⟨W⟩ := h
+  exact ⟨W, fun L hL α β γ => W.coeff_eq_ofChi_coeff L hL α β γ⟩
 
 /-- Existence of the source BNT-label witness gives a concrete witness whose
 source product and idempotent laws are written with the canonical coefficient
@@ -111,12 +109,8 @@ theorem exists_source_ofChi_equations {data : AlgebraStructureData d D}
           ∑ α : W.Label, ∑ β : W.Label,
             (BNTLabelCoefficientFamily.ofChi W.positiveChi.chi).coeff 1 α β γ *
               (W.traceScalars.traceScalar α * W.traceScalars.traceScalar β)) := by
-  rcases h with ⟨W⟩
-  refine ⟨W, ?_, ?_⟩
-  · intro L hL α β
-    exact W.same_length_product_eq_sum_ofChi L hL α β
-  · intro γ
-    exact W.idempotent_eq_sum_ofChi γ
+  obtain ⟨W⟩ := h
+  exact ⟨W, W.same_length_product_eq_sum_ofChi, W.idempotent_eq_sum_ofChi⟩
 
 /-- Existence of the source BNT-label witness gives a concrete witness whose
 blocked-basis \(\chi\)-family is the pullback of the BNT-label
@@ -133,10 +127,8 @@ theorem exists_blocked_chi_pullback {data : AlgebraStructureData d D}
       ∀ (n : ℕ) (hn : 0 < n),
         W.positiveBlockedChi.toDiagonal n =
           W.positiveChi.chi.comap (W.blockedComparison.blockedLabel n hn) := by
-  rcases h with ⟨W⟩
-  refine ⟨W, ?_⟩
-  intro n hn
-  exact W.positiveBlockedChi_toDiagonal_of_pos n hn
+  obtain ⟨W⟩ := h
+  exact ⟨W, W.positiveBlockedChi_toDiagonal_of_pos⟩
 
 /-- Existence of the source BNT-label witness gives the blocked-basis
 comparison equation before the \(\chi\)-trace formula is substituted.
@@ -164,10 +156,8 @@ theorem exists_blocked_coefficient_comparison {data : AlgebraStructureData d D}
             (W.sourceLabel n hn i)
             (W.sourceLabel n hn j)
             (W.targetLabel n hn k) := by
-  rcases h with ⟨W⟩
-  refine ⟨W, ?_⟩
-  intro n hn i j k
-  exact W.blocked_coeff_eq n hn i j k
+  obtain ⟨W⟩ := h
+  exact ⟨W, W.blocked_coeff_eq⟩
 
 /-- Existence of the source BNT-label witness gives the blocked-basis
 comparison equation with the canonical coefficient family determined by the
@@ -190,10 +180,8 @@ theorem exists_blocked_coefficient_comparison_ofChi {data : AlgebraStructureData
             (W.sourceLabel n hn i)
             (W.sourceLabel n hn j)
             (W.targetLabel n hn k) := by
-  rcases h with ⟨W⟩
-  refine ⟨W, ?_⟩
-  intro n hn i j k
-  exact W.blocked_coeff_eq_ofChi n hn i j k
+  obtain ⟨W⟩ := h
+  exact ⟨W, W.blocked_coeff_eq_ofChi⟩
 
 /-- Existence of the source BNT-label witness gives the two source equations
 written with the BNT-label coefficients \(c^{(L)}_{\alpha,\beta,\gamma}\).
@@ -224,12 +212,8 @@ theorem exists_source_coefficient_equations {data : AlgebraStructureData d D}
           ∑ α : W.Label, ∑ β : W.Label,
             W.coeffs.coeff 1 α β γ *
               (W.traceScalars.traceScalar α * W.traceScalars.traceScalar β)) := by
-  rcases h with ⟨W⟩
-  refine ⟨W, ?_, ?_⟩
-  · intro L hL α β
-    exact W.same_length_product_eq_sum L hL α β
-  · intro γ
-    exact W.idempotent_eq_sum γ
+  obtain ⟨W⟩ := h
+  exact ⟨W, W.same_length_product_eq_sum, W.idempotent_eq_sum⟩
 
 /-- Existence of the source BNT-label witness gives the two source equations
 with the coefficients written as traces of the corresponding
@@ -264,12 +248,8 @@ theorem exists_source_chi_trace_equations {data : AlgebraStructureData d D}
           ∑ α : W.Label, ∑ β : W.Label,
             (W.positiveChi.chi.matrix α β γ).trace *
               (W.traceScalars.traceScalar α * W.traceScalars.traceScalar β)) := by
-  rcases h with ⟨W⟩
-  refine ⟨W, ?_, ?_⟩
-  · intro L hL α β
-    exact W.same_length_product_eq_sum_chi_trace_pow L hL α β
-  · intro γ
-    exact W.idempotent_eq_sum_chi_trace γ
+  obtain ⟨W⟩ := h
+  exact ⟨W, W.same_length_product_eq_sum_chi_trace_pow, W.idempotent_eq_sum_chi_trace⟩
 
 end HasBNTLabelTheoremWitness
 

--- a/TNLean/MPS/MPDO/CompleteZipperFusionPentagon.lean
+++ b/TNLean/MPS/MPDO/CompleteZipperFusionPentagon.lean
@@ -327,6 +327,14 @@ noncomputable def twoEdgeInversePrintedFMatrix (a b c d e : Λ) :
   Fus.pairToLeftAssocInversePrintedFMatrix a b c d e *
     Fus.rightAssocToPairInversePrintedFMatrix a b c d e
 
+private theorem mul_kronecker_one {l m n : Type*} [Fintype m]
+    (A : Matrix l m ℂ) (B : Matrix m n ℂ) (D : ℕ) :
+    (A * B) ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ) =
+      (A ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ)) *
+        (B ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ)) := by
+  simpa only [Matrix.one_mul] using Matrix.mul_kronecker_mul A B
+    (1 : Matrix (Fin D) (Fin D) ℂ) 1
+
 private theorem rightAssocToMiddleInverse_mul_middleToRightAssoc
     (a b c d e : Λ) :
     Fus.rightAssocToMiddleInversePrintedFMatrix a b c d e *
@@ -749,38 +757,10 @@ theorem rightAssocFourfoldSynthesis_mul_threeEdgePrintedFMatrix
         (Fus.threeEdgePrintedFMatrix a b c d e ⊗ₖ
           (1 : Matrix (Fin (Fus.bondDim e)) (Fin (Fus.bondDim e)) ℂ)) =
       Fus.leftAssocFourfoldSynthesis a b c d e := by
-  rw [threeEdgePrintedFMatrix]
-  have hLast :
-      ((Fus.middleToRightAssocPrintedFMatrix a b c d e *
-            Fus.leftInnerToMiddlePrintedFMatrix a b c d e) *
-          Fus.leftAssocToLeftInnerPrintedFMatrix a b c d e) ⊗ₖ
-          (1 : Matrix (Fin (Fus.bondDim e)) (Fin (Fus.bondDim e)) ℂ) =
-        ((Fus.middleToRightAssocPrintedFMatrix a b c d e *
-            Fus.leftInnerToMiddlePrintedFMatrix a b c d e) ⊗ₖ
-              (1 : Matrix (Fin (Fus.bondDim e)) (Fin (Fus.bondDim e)) ℂ)) *
-          (Fus.leftAssocToLeftInnerPrintedFMatrix a b c d e ⊗ₖ
-            (1 : Matrix (Fin (Fus.bondDim e)) (Fin (Fus.bondDim e)) ℂ)) := by
-    simpa only [Matrix.one_mul] using Matrix.mul_kronecker_mul
-      (Fus.middleToRightAssocPrintedFMatrix a b c d e *
-        Fus.leftInnerToMiddlePrintedFMatrix a b c d e)
-      (Fus.leftAssocToLeftInnerPrintedFMatrix a b c d e)
-      (1 : Matrix (Fin (Fus.bondDim e)) (Fin (Fus.bondDim e)) ℂ) 1
-  have hFirst :
-      (Fus.middleToRightAssocPrintedFMatrix a b c d e *
-          Fus.leftInnerToMiddlePrintedFMatrix a b c d e) ⊗ₖ
-          (1 : Matrix (Fin (Fus.bondDim e)) (Fin (Fus.bondDim e)) ℂ) =
-        (Fus.middleToRightAssocPrintedFMatrix a b c d e ⊗ₖ
-          (1 : Matrix (Fin (Fus.bondDim e)) (Fin (Fus.bondDim e)) ℂ)) *
-          (Fus.leftInnerToMiddlePrintedFMatrix a b c d e ⊗ₖ
-            (1 : Matrix (Fin (Fus.bondDim e)) (Fin (Fus.bondDim e)) ℂ)) := by
-    simpa only [Matrix.one_mul] using Matrix.mul_kronecker_mul
-      (Fus.middleToRightAssocPrintedFMatrix a b c d e)
-      (Fus.leftInnerToMiddlePrintedFMatrix a b c d e)
-      (1 : Matrix (Fin (Fus.bondDim e)) (Fin (Fus.bondDim e)) ℂ) 1
-  rw [hLast, hFirst, ← Matrix.mul_assoc]
-  rw [← Matrix.mul_assoc]
-  rw [Fus.rightAssocFourfoldSynthesis_mul_middleToRightAssocPrintedFMatrix]
-  rw [Fus.middleFourfoldSynthesis_mul_leftInnerToMiddlePrintedFMatrix]
+  rw [threeEdgePrintedFMatrix, mul_kronecker_one, mul_kronecker_one,
+    ← Matrix.mul_assoc, ← Matrix.mul_assoc,
+    Fus.rightAssocFourfoldSynthesis_mul_middleToRightAssocPrintedFMatrix,
+    Fus.middleFourfoldSynthesis_mul_leftInnerToMiddlePrintedFMatrix]
   exact Fus.leftInnerFourfoldSynthesis_mul_leftAssocToLeftInnerPrintedFMatrix
     a b c d e
 
@@ -794,21 +774,8 @@ theorem rightAssocFourfoldSynthesis_mul_twoEdgePrintedFMatrix
         (Fus.twoEdgePrintedFMatrix a b c d e ⊗ₖ
           (1 : Matrix (Fin (Fus.bondDim e)) (Fin (Fus.bondDim e)) ℂ)) =
       Fus.leftAssocFourfoldSynthesis a b c d e := by
-  rw [twoEdgePrintedFMatrix]
-  have hPath :
-      (Fus.pairToRightAssocPrintedFMatrix a b c d e *
-          Fus.leftAssocToPairPrintedFMatrix a b c d e) ⊗ₖ
-          (1 : Matrix (Fin (Fus.bondDim e)) (Fin (Fus.bondDim e)) ℂ) =
-        (Fus.pairToRightAssocPrintedFMatrix a b c d e ⊗ₖ
-          (1 : Matrix (Fin (Fus.bondDim e)) (Fin (Fus.bondDim e)) ℂ)) *
-          (Fus.leftAssocToPairPrintedFMatrix a b c d e ⊗ₖ
-            (1 : Matrix (Fin (Fus.bondDim e)) (Fin (Fus.bondDim e)) ℂ)) := by
-    simpa only [Matrix.one_mul] using Matrix.mul_kronecker_mul
-      (Fus.pairToRightAssocPrintedFMatrix a b c d e)
-      (Fus.leftAssocToPairPrintedFMatrix a b c d e)
-      (1 : Matrix (Fin (Fus.bondDim e)) (Fin (Fus.bondDim e)) ℂ) 1
-  rw [hPath, ← Matrix.mul_assoc]
-  rw [Fus.rightAssocFourfoldSynthesis_mul_pairToRightAssocPrintedFMatrix]
+  rw [twoEdgePrintedFMatrix, mul_kronecker_one, ← Matrix.mul_assoc,
+    Fus.rightAssocFourfoldSynthesis_mul_pairToRightAssocPrintedFMatrix]
   exact Fus.pairFourfoldSynthesis_mul_leftAssocToPairPrintedFMatrix
     a b c d e
 

--- a/TNLean/MPS/MPDO/KrausCPTP.lean
+++ b/TNLean/MPS/MPDO/KrausCPTP.lean
@@ -1,13 +1,14 @@
 /-
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
 -/
-import TNLean.MPS.MPDO.Defs
+import Mathlib.Data.Matrix.PEquiv
+import Mathlib.LinearAlgebra.Matrix.Reindex
 import TNLean.Analysis.MatrixSqrt
 import TNLean.Channel.KrausRepresentation
 import TNLean.Channel.PartialTrace
-import Mathlib.Data.Matrix.PEquiv
-import Mathlib.LinearAlgebra.Matrix.Reindex
+import TNLean.MPS.MPDO.Defs
 
 /-!
 # Trace-preserving completely positive maps in Kraus form
@@ -748,21 +749,12 @@ lemma preparationMap_isKrausCPTP
     [Fintype β] [DecidableEq β] (ρ : Matrix β β ℂ) (hρ : ρ.PosSemidef)
     (hρtr : ρ.trace = 1) : IsKrausCPTP (Matrix.preparationMap (α := α) ρ) := by
   classical
-  let R := hρ.isHermitian.cfc Real.sqrt
-  have hRherm : R.IsHermitian := hρ.cfc_sqrt_isHermitian
-  have hRR : R * R = ρ := hρ.cfc_sqrt_mul_self
-  refine ⟨Fintype.card β,
-    fun j => preparationKraus ρ hρ ((Fintype.equivFin β).symm j), ?_, ?_⟩
-  · intro X
-    ext p q
-    change X p.1 q.1 * ρ p.2 q.2 = _
-    have hRRentry : ρ p.2 q.2 = (R * R) p.2 q.2 :=
-      congrArg (fun M : Matrix β β ℂ => M p.2 q.2) hRR.symm
-    rw [hRRentry, Matrix.mul_apply, Finset.mul_sum, Matrix.sum_apply]
-    rw [← Equiv.sum_comp (Fintype.equivFin β).symm]
-    refine Finset.sum_congr rfl fun j _ => ?_
-    rw [preparationKraus_mul_conjTranspose_apply]
-    rw [hRherm.apply]
-  · exact preparationKraus_resolution ρ hρ hρtr
+  let e := Fintype.equivFin β
+  let A := fun j : β => preparationKraus (α := α) ρ hρ j
+  refine ⟨Fintype.card β, fun j => A (e.symm j), ?_, preparationKraus_resolution ρ hρ hρtr⟩
+  intro X
+  have hmap : rectangularKrausMap (fun j => A (e.symm j)) = preparationMap ρ :=
+    rectangularKrausMap_equiv e A |>.trans (rectangularKrausMap_preparationKraus_eq ρ hρ)
+  exact DFunLike.congr_fun hmap.symm X
 
 end Matrix

--- a/TNLean/MPS/MPDO/PhysicalSectorSupportRecurrence.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorSupportRecurrence.lean
@@ -37,6 +37,14 @@ namespace MPOTensor.PhysicalSectorFactorization
 
 variable {d D : ℕ} {K : MPOTensor d D}
 
+private theorem exists_matrix_entry_ne_zero {m n : Type*}
+    (A : Matrix m n ℂ) (hA : A ≠ 0) : ∃ i j, A i j ≠ 0 := by
+  by_contra h
+  push Not at h
+  apply hA
+  ext i j
+  exact h i j
+
 /-- The virtual matrix obtained from a matrix entry within physical sector
 `k`. Its `(beta, alpha)` entry is the product of the corresponding left and
 right sector-tensor entries. -/
@@ -101,29 +109,12 @@ theorem exists_two_edge_return_of_neighboringOperator_ne_zero
     ∃ j : Fin F.sectorCount,
       F.neighboringOperator h j ≠ 0 ∧ F.neighboringOperator j k ≠ 0 := by
   classical
-  obtain ⟨ex, ey, heta⟩ : ∃ ex ey, F.neighboringOperator k h ex ey ≠ 0 := by
-    by_contra hall
-    push Not at hall
-    apply hkh
-    ext x y
-    exact hall x y
+  obtain ⟨ex, ey, heta⟩ := exists_matrix_entry_ne_zero _ hkh
   obtain ⟨⟨kx, ky, hkxy⟩, ⟨hx, hy, hhxy⟩⟩ := hnonzero hkh
-  obtain ⟨beta, alpha, hkentry⟩ :
-      ∃ beta alpha, F.sectorVirtualMatrix k kx ky beta alpha ≠ 0 := by
-    by_contra hall
-    push Not at hall
-    apply hkxy
-    ext beta alpha
-    exact hall beta alpha
+  obtain ⟨beta, alpha, hkentry⟩ := exists_matrix_entry_ne_zero _ hkxy
   have hkleft : F.leftTensor k beta kx.1 ky.1 ≠ 0 :=
     left_ne_zero_of_mul hkentry
-  obtain ⟨delta, gamma, hhentry⟩ :
-      ∃ delta gamma, F.sectorVirtualMatrix h hx hy delta gamma ≠ 0 := by
-    by_contra hall
-    push Not at hall
-    apply hhxy
-    ext delta gamma
-    exact hall delta gamma
+  obtain ⟨delta, gamma, hhentry⟩ := exists_matrix_entry_ne_zero _ hhxy
   have hhright : F.rightTensor h gamma hx.2 hy.2 ≠ 0 :=
     right_ne_zero_of_mul hhentry
   let x : F.SectorIndex k := (kx.1, ex.1)

--- a/TNLean/MPS/MPDO/RecurrentSectorRephasing.lean
+++ b/TNLean/MPS/MPDO/RecurrentSectorRephasing.lean
@@ -69,6 +69,12 @@ private theorem exists_circle_smul_posSemidef_of_sectorEdge
   rw [hqzero, hqone] at hpos
   exact hpos
 
+private theorem smul_posSemidef_of_not_sectorEdge
+    {hη : EtaStructure ρ} (eta : etaOperators hη) {k h : Fin hη.m}
+    (c : ℂ) (hkh : ¬IsSectorEdge eta k h) : (c • eta k h).PosSemidef := by
+  rw [show eta k h = 0 from not_ne_iff.mp hkh, smul_zero]
+  exact Matrix.PosSemidef.zero
+
 /-- **Coherent positive vertex rephasing under recurrent support.** If every
 cyclic tensor product of a neighboring-operator family is positive
 semidefinite and every nonzero support edge lies on a directed cycle, then
@@ -96,13 +102,8 @@ theorem exists_vertexPhase_smul_posSemidef
   have hκpos : ∀ k h, (((κ k h : Circle) : ℂ) • eta k h).PosSemidef := by
     intro k h
     by_cases hkh : IsSectorEdge eta k h
-    · rw [show κ k h = Classical.choose (hedge hkh) by simp [κ, hkh]]
-      exact Classical.choose_spec (hedge hkh)
-    · have heta : eta k h = 0 := not_ne_iff.mp hkh
-      simpa [heta] using
-        (Matrix.PosSemidef.zero :
-          (0 : Matrix (Fin (hη.dR k) × Fin (hη.dL h))
-            (Fin (hη.dR k) × Fin (hη.dL h)) ℂ).PosSemidef)
+    · simpa only [κ, dif_pos hkh] using Classical.choose_spec (hedge hkh)
+    · exact smul_posSemidef_of_not_sectorEdge eta _ hkh
   have hclosed : ∀ (a : Fin hη.m)
       (w : TNLean.Algebra.DirectedWalk (IsSectorEdge eta) a a),
       TNLean.Algebra.DirectedWalk.weight (IsSectorEdge eta) κ w = 1 := by
@@ -154,11 +155,7 @@ theorem exists_vertexPhase_smul_posSemidef
   by_cases hkh : IsSectorEdge eta k h
   · rw [← hz hkh]
     exact hκpos k h
-  · have heta : eta k h = 0 := not_ne_iff.mp hkh
-    simpa [heta] using
-      (Matrix.PosSemidef.zero :
-        (0 : Matrix (Fin (hη.dR k) × Fin (hη.dL h))
-          (Fin (hη.dR k) × Fin (hη.dL h)) ℂ).PosSemidef)
+  · exact smul_posSemidef_of_not_sectorEdge eta _ hkh
 
 /-- **Positive inverse-map sector factorization under recurrent support.**
 The inverse-map sector tensors can be rephased so that all neighboring

--- a/TNLean/MPS/MPDO/SectorRecurrence.lean
+++ b/TNLean/MPS/MPDO/SectorRecurrence.lean
@@ -126,8 +126,8 @@ the elimination plan for coherent sector rephasing. -/
 theorem sectorReaches_iff_directedWalkReaches {hη : EtaStructure ρ}
     (eta : etaOperators hη) (k h : Fin hη.m) :
     SectorReaches eta k h ↔
-      TNLean.Algebra.DirectedWalk.Reaches (IsSectorEdge eta) k h := by
-  exact (TNLean.Algebra.DirectedWalk.reaches_iff_reflTransGen _).symm
+      TNLean.Algebra.DirectedWalk.Reaches (IsSectorEdge eta) k h :=
+  (TNLean.Algebra.DirectedWalk.reaches_iff_reflTransGen _).symm
 
 /-- Recurrence of the nonzero sector support is exactly the return-walk
 hypothesis for its directed edge relation.

--- a/TNLean/MPS/RFP/BNTWeightCounterexample.lean
+++ b/TNLean/MPS/RFP/BNTWeightCounterexample.lean
@@ -206,9 +206,8 @@ theorem halvedWeightTensor_isBNTCanonicalForm :
 decomposition `halvedDecomp scalarUnitTensor` at every length. -/
 theorem halvedWeightTensor_sameMPV₂_halvedDecomp :
     SameMPV₂ halvedWeightTensor
-      (SectorBNT.Examples.halvedDecomp scalarUnitTensor).toTensor := by
-  intro N σ
-  rfl
+      (SectorBNT.Examples.halvedDecomp scalarUnitTensor).toTensor :=
+  fun _ _ => rfl
 
 private theorem halvedWeightTensor_isCPSVBasisOfNormalTensors :
     IsCPSVBasisOfNormalTensors halvedWeightTensor
@@ -339,8 +338,8 @@ theorem halvedWeightTensor_counterexample_to_unrestricted_zcl_iff_rfp :
       SameMPV₂ halvedWeightTensor
         (SectorBNT.Examples.halvedDecomp scalarUnitTensor).toTensor ∧
       IsPhysicalBNTZCL halvedWeightTensor (fun _ : Fin 1 => scalarUnitTensor) ∧
-      ¬ IsTransferIdempotent halvedWeightTensor := by
-  exact ⟨halvedWeightTensor_isBNTCanonicalForm,
+      ¬ IsTransferIdempotent halvedWeightTensor :=
+  ⟨halvedWeightTensor_isBNTCanonicalForm,
     halvedWeightTensor_eq_halvedDecomp_toTensor,
     halvedWeightTensor_sameMPV₂_halvedDecomp,
     halvedWeightTensor_isPhysicalBNTZCL,

--- a/TNLean/MPS/RFP/PhaseMultiplicityCounterexample.lean
+++ b/TNLean/MPS/RFP/PhaseMultiplicityCounterexample.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
 -/
 import TNLean.MPS.RFP.StructuralFull
 
@@ -18,10 +19,9 @@ sum in the physical space after applying the isometry (lines 559--563).  The
 one-letter virtual-block reading does not realize that additional physical
 direct sum: its blocked matrix is the identity and is not a scalar multiple of
 $\operatorname{diag}(1,-1)$.  It therefore fails the defining physical-isometry
-relation $AA=A$ (lines 396--425), and its transfer map is not idempotent.  The
-example
-records an ambiguity between the literal displayed matrix formula and its
-accompanying physical-space interpretation; it is not asserted to be a source
+relation $AA=A$ (lines 396--425), and its transfer map is not idempotent. The
+example records an ambiguity between the literal displayed matrix formula and
+its accompanying physical-space interpretation; it is not asserted to be a source
 renormalization fixed point.
 -/
 
@@ -103,7 +103,8 @@ $\mathcal E(E_{01})=-E_{01}$ after one application.
 Together with `phaseFlipTensor_no_blocking_coefficient`, this distinguishes the
 literal virtual-block reading of III_CFI_RFP from the physical-isometry
 interpretation in arXiv:1606.00608, lines 559--563. -/
-theorem phaseFlipTensor_not_isTransferIdempotent : ¬ IsTransferIdempotent phaseFlipTensor := by
+theorem phaseFlipTensor_not_isTransferIdempotent :
+    ¬ IsTransferIdempotent phaseFlipTensor := by
   intro hRFP
   have h := LinearMap.congr_fun hRFP (!![0, 1; 0, 0] : Matrix (Fin 2) (Fin 2) ℂ)
   have h01 := congrFun (congrFun h 0) 1
@@ -126,8 +127,8 @@ theorem phaseFlipTensor_literal_display_ambiguity :
     IsIsometryCanonicalForm scalarUnitTensor ∧
     (¬ ∃ v : ℂ,
       phaseFlipTensor 0 * phaseFlipTensor 0 = v • phaseFlipTensor 0) ∧
-    ¬ IsTransferIdempotent phaseFlipTensor := by
-  exact ⟨phaseFlipTensor_is_two_phase_copies,
+    ¬ IsTransferIdempotent phaseFlipTensor :=
+  ⟨phaseFlipTensor_is_two_phase_copies,
     scalarUnitTensor_isIsometryCanonicalForm, phaseFlipTensor_no_blocking_coefficient,
     phaseFlipTensor_not_isTransferIdempotent⟩
 

--- a/TNLean/MPS/RFP/ZeroCorrelationLength.lean
+++ b/TNLean/MPS/RFP/ZeroCorrelationLength.lean
@@ -1,11 +1,12 @@
 /-
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
 -/
-import TNLean.MPS.RFP.Defs
 import TNLean.MPS.CanonicalForm.Definitions
-import TNLean.MPS.Core.Transfer
 import TNLean.MPS.Core.Correlations
+import TNLean.MPS.Core.Transfer
+import TNLean.MPS.RFP.Defs
 import TNLean.Spectral.MixedTransfer
 
 /-!
@@ -165,13 +166,13 @@ theorem isPositiveGapPhysicalCID_of_isTransferIdempotent
   intro L₁ L₂ O₁ O₂ n₁ n₂ m₁ m₂ _ _ hn₁ hn₂ hm₁ hm₂ _
   have hIdem : IsIdempotentElem (transferMap A) := hRFP
   have hpow_n₁ : (transferMap A) ^ n₁ = transferMap A :=
-    hIdem.pow_eq (by omega)
+    hIdem.pow_eq (Nat.ne_of_gt hn₁)
   have hpow_n₂ : (transferMap A) ^ n₂ = transferMap A :=
-    hIdem.pow_eq (by omega)
+    hIdem.pow_eq (Nat.ne_of_gt hn₂)
   have hpow_m₁ : (transferMap A) ^ m₁ = transferMap A :=
-    hIdem.pow_eq (by omega)
+    hIdem.pow_eq (Nat.ne_of_gt hm₁)
   have hpow_m₂ : (transferMap A) ^ m₂ = transferMap A :=
-    hIdem.pow_eq (by omega)
+    hIdem.pow_eq (Nat.ne_of_gt hm₂)
   simp only [physicalTwoPointExpectation, hpow_n₁, hpow_n₂, hpow_m₁, hpow_m₂]
 
 /-- Local orthogonality in the single-block convention used by this file:
@@ -276,8 +277,8 @@ Definition 3.3 (lines 437--445), while the BNT and local-orthogonality
 components of Definition 3.6 (lines 476--478) are unchanged. -/
 theorem isPositiveGapBNTZCL_of_isPhysicalBNTZCL (A : MPSTensor d D)
     (blocks : (j : Fin g) → MPSTensor d (dim j))
-    (hZCL : IsPhysicalBNTZCL A blocks) : IsPositiveGapBNTZCL A blocks := by
-  exact ⟨hZCL.1, isPositiveGapPhysicalCID_of_isPhysicalCID A hZCL.2.1, hZCL.2.2⟩
+    (hZCL : IsPhysicalBNTZCL A blocks) : IsPositiveGapBNTZCL A blocks :=
+  ⟨hZCL.1, isPositiveGapPhysicalCID_of_isPhysicalCID A hZCL.2.1, hZCL.2.2⟩
 
 /-- Zero correlation length in the single-block convention: a tensor has ZCL
 when it satisfies the local idempotence convention above and has correlations
@@ -364,9 +365,9 @@ theorem zcl_iff_idempotent_transfer (A : MPSTensor d D) :
     refine ⟨hRFP, fun ρR _ _ X Y n m hn hm => ?_⟩
     have hIdem : IsIdempotentElem (transferMap A) := hRFP
     have hpow_n : (transferMap A) ^ n = transferMap A :=
-      hIdem.pow_eq (by omega)
+      hIdem.pow_eq (Nat.ne_of_gt hn)
     have hpow_m : (transferMap A) ^ m = transferMap A :=
-      hIdem.pow_eq (by omega)
+      hIdem.pow_eq (Nat.ne_of_gt hm)
     simp only [connectedCorrelator_def, twoPointExpectation_transfer,
       hpow_n, hpow_m]
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_witnesses.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_witnesses.tex
@@ -89,8 +89,8 @@
     with the canonical coefficient family determined by these
     $\chi$-matrices, so both pairs of equations above hold equally with
     that canonical family in place of $c^{(L)}_{\alpha,\beta,\gamma}$.
-    Moreover, if $\sigma_n$ and $\tau_n$ are the source and target label maps
-    for a positive blocked length $n$, then the blocked-basis coefficients
+    If $\sigma_n$ and $\tau_n$ are the source and target label maps for a
+    positive blocked length $n$, then the blocked-basis coefficients
     satisfy
     \[
         c^{(n)}_{i,j,k}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
@@ -419,8 +419,7 @@
     \lean{Matrix.preparationMap_isKrausCPTP}
     \leanok
     \uses{def:mpdo_state_preparation_map, def:is_kraus_cptp,
-      def:mpdo_state_preparation_kraus,
-      thm:mpdo_state_preparation_kraus_resolution}
+      def:mpdo_state_preparation_kraus}
     If $\rho\geq0$ and $\tr(\rho)=1$, then
     $\mathcal P_\rho:X\mapsto X\otimes\rho$ is trace-preserving completely
     positive.
@@ -428,13 +427,18 @@
 
 \begin{proof}
     \leanok
-    The operators from Definition~\ref{def:mpdo_state_preparation_kraus}
-    satisfy
+    \uses{thm:mpdo_rectangular_kraus_map_equiv,
+      thm:mpdo_state_preparation_kraus_action,
+      thm:mpdo_state_preparation_kraus_resolution}
+    Relabel an orthonormal basis of the ancillary space by
+    $\{0,\ldots,\dim B-1\}$. Theorem~\ref{thm:mpdo_rectangular_kraus_map_equiv}
+    shows that this relabeling leaves the Kraus map unchanged, and
+    Theorem~\ref{thm:mpdo_state_preparation_kraus_action} gives
     \[
-        \sum_j A_jXA_j^\dagger=X\otimes RR=X\otimes\rho,
+        \sum_j A_jXA_j^\dagger=X\otimes\rho.
     \]
-    and Theorem~\ref{thm:mpdo_state_preparation_kraus_resolution} gives their
-    resolution of the identity.
+    Theorem~\ref{thm:mpdo_state_preparation_kraus_resolution} gives
+    $\sum_j A_j^\dagger A_j=I_A$.
 \end{proof}
 
 \begin{definition}[Physical closure maps]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_closed_sector_rephasing.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_closed_sector_rephasing.tex
@@ -1050,10 +1050,10 @@ This is the contraction in
     Let $(\eta_{k,h})$ be a neighboring-operator family for which every
     nonempty cyclic tensor product is positive semidefinite. Suppose, in
     addition, that every nonzero edge $k\to h$ admits a directed return path
-    from $h$ to $k$. Then there are unit complex numbers $z_k$ such that
+    from $h$ to $k$. Then there are unit complex numbers $z_k$ such that, for
+    all $k$ and $h$,
     \[
-        z_k^{-1}z_h\,\eta_{k,h}\geq0
-        \qquad\text{for all }k,h.
+        z_k^{-1}z_h\,\eta_{k,h}\geq0.
     \]
     Consequently, if the neighboring operators arise from the inverse-map
     physical-sector factorization of an injective MPDO and its nonzero

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity.tex
@@ -347,8 +347,8 @@
         T^*_{k,h}=\operatorname{Re}\tr(\eta_{k,h}),
         \qquad k,h\in I_*:=\{j:p_j\ne0\},
     \]
-    is primitive. Moreover, there is a real number $\lambda>0$ for which,
-    upon setting $\widehat T^*:=\lambda^{-1}T^*$,
+    is primitive. There is also a real number $\lambda>0$ for which, upon
+    setting $\widehat T^*:=\lambda^{-1}T^*$,
     \[
         (\widehat T^*)^2=(\widehat T^*)^3.
     \]
@@ -850,8 +850,9 @@ which is the displayed identity of
     \uses{def:mpdo_sector_pairing_data, thm:matrix_primitive_row_col_pos}
     Suppose the sector trace matrix $T$ of
     Definition~\ref{def:mpdo_sector_pairing_data} is primitive. Then every
-    closed sector tensor satisfies $|l_k) \neq 0$. If moreover each $|l_k)$
-    lies in its own member of an independent family of subspaces of $V$, then
+    closed sector tensor satisfies $|l_k) \neq 0$. If, in addition, each
+    $|l_k)$ lies in its own member of an independent family of subspaces of
+    $V$, then
     the vectors $|l_0), \dots, |l_{n-1})$ are linearly independent.
 \end{theorem}
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels.tex
@@ -13,7 +13,7 @@
     \uses{def:mpdo_physical_sector_three_site_neighboring_operator,
       def:mpdo_neighboring_trace_factorization,
       thm:mpdo_physical_sector_three_site_neighboring_operator_trace}
-    The sector set and every middle-subspin space are nonempty. Moreover,
+    The sector set and every middle-subspin space are nonempty. Each
     $\Omega_{k,h}$ is positive semidefinite, and
     \[
       a_kb_h=0 \quad\Longrightarrow\quad \Omega_{k,h}=0.

--- a/blueprint/src/chapter/ch26_mps_rfp_core.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp_core.tex
@@ -231,14 +231,14 @@
     \uses{def:source_bnt_zcl, def:mps_transfer_idempotence, def:sector_bnt_cf}
     Let $P$ be the canonical decomposition with one scalar basis tensor $C^0=(1)$,
     two one-dimensional copies, and respective weights $1$ and $1/2$. Write
-    $A=\mathcal A(P)$ for its assembled tensor. Relative to these sector
-    coordinates, $A^0$ has block form
+    $A=\mathcal A(P)$ for the tensor represented by $P$. Relative to these
+    sector coordinates, $A^0$ has block form
     \[
         \begin{pmatrix}1&0\\0&\tfrac12\end{pmatrix}.
     \]
     The weights $(1,1/2)$ satisfy the raw-weight BNT canonical-form
-    normalization, and the resulting canonical assembly is exactly $A$.
-    Moreover,
+    normalization, and the corresponding canonical decomposition represents
+    $A$. Its MPV coefficient at length $N$ is
     \[
         V^{(N)}(A)=1+2^{-N}.
     \]
@@ -1190,8 +1190,8 @@
     the direct sum of the basis representatives, not the repeated-copy tensor
     carrying the weights $\mu_{j,q}$.
 
-    Moreover, if the basis direct sum is a renormalization fixed point, there
-    are invertible matrices $X_j$, positive trace-normalized diagonal weights
+    If the basis direct sum is a renormalization fixed point, there are also
+    invertible matrices $X_j$, positive trace-normalized diagonal weights
     $\Lambda_j$, and residual tensors $U_j$ such that
     \[
         B_j^i=X_j\sqrt{\Lambda_j}\,U_j^iX_j^{-1},
@@ -1253,8 +1253,7 @@
     Taking the witness data of
     Definition~\ref{def:is_isometry_canonical_form} to be
     $X=\Lambda=U^0=(1)$, the scalar representative is in isometry canonical
-    form; moreover,
-    $|1|=|-1|=1$.
+    form, and $|1|=|-1|=1$.
     Direct multiplication gives $(A^0)^2=I$. Comparing diagonal entries in
     $I=vA^0$ would give simultaneously $v=1$ and $v=-1$, which is impossible.
     On the off-diagonal matrix unit $E_{01}$, the transfer map is conjugation by


### PR DESCRIPTION
## Summary

- simplify proofs and private helper structure in the MPS RFP and MPO/MPDO RFP developments
- reuse existing Kraus, Kronecker-product, linear-independence, recurrence, and positivity APIs instead of repeating entrywise or witness-assembly arguments
- synchronize the MPS-RFP and MPDO-RFP blueprint chapters with the simplified proof structure

Public declaration names and theorem statements are unchanged. The Lean diff reduces the affected code by 83 lines overall, and the blueprint edits preserve every `\lean{}` tag and label.

## Notable refactors

- replace arithmetic automation for positive exponents with direct positivity lemmas
- express the preparation channel through the established rectangular Kraus-map equivalence and resolution API
- factor repeated fixed-final fusion reindexing and Kronecker-with-identity calculations into private helpers
- simplify BNT witness projections and associativity coefficient extraction
- share matrix-entry nonvanishing and zero-edge positivity arguments in the physical-sector recurrence chain
- update the blueprint proof of the preparation channel and remove a small amount of process-oriented or repetitive prose

## Verification

- `lake build` — passed on current `main` (**9405 jobs**)
- `leanblueprint checkdecls` — passed after regenerating blueprint metadata
- blueprint compiled repeatedly with LuaLaTeX; no undefined cross-reference warnings (standalone citation warnings remain pre-existing because `print.bbl` is not generated)
- `git diff --check` — passed
- no new `sorry`, `axiom`, `unsafe`, or hypotheses

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof and documentation refactors only; no new axioms, changed statements, or behavioral API surface. Residual risk is ordinary Mathlib proof-regression if a simplification missed a side condition.
> 
> **Overview**
> This PR **shortens proofs** in the MPS RFP and MPDO developments by reusing library APIs and shared private lemmas instead of repeating entrywise or witness-assembly steps. **Theorem and definition names are unchanged.**
> 
> Lean changes cluster around: **`mul_eq_zero` / `smul_eq_zero` with `resolve_left`/`resolve_right`** (constant power sums, phase-flip counterexample, algebra eigenvalue argument); **`Fintype.linearIndependent_iff` and `simpa`** for BNT coefficient uniqueness and associativity; **`obtain` + direct witnesses** for BNT theorem witness consequences; **`mul_kronecker_one`** and fixed-final **equiv composition lemmas** for fusion pentagon and unitarity proofs; **`exists_matrix_entry_ne_zero`** in physical-sector recurrence; **`smul_posSemidef_of_not_sectorEdge`** for eta rephasing; **`preparationMap_isKrausCPTP`** routed through **`rectangularKrausMap_equiv`** and existing preparation Kraus theorems; **`Nat.ne_of_gt`** instead of `omega` in ZCL idempotence powers; minor import/order and term-style proof cleanups in counterexample files.
> 
> Blueprint chapters (**BNT witnesses**, **pure state recovery**, **sector rephasing**, **primitivity**, **refinement channels**, **MPS RFP core**) are **reworded** to match the Lean proof structure (e.g. preparation CPTP proof cites rectangular Kraus equivalence; less repetitive “Moreover” prose). `\lean{}` tags and labels are preserved per the PR description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e664a3fbcfcbaa2cb2b0d8732294902d50df24b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->