### PR TITLE
doc(MPS/MPDO): follow the source order in mixed-state chapters

### DIFF
--- a/TNLean/MPS/MPDO/CommutingForm.lean
+++ b/TNLean/MPS/MPDO/CommutingForm.lean
@@ -15,9 +15,13 @@ arXiv:1606.00608 Section 4.4 and Appendix C.2.
 For an `N`-site operator `ρ`, a commuting-form witness consists of a positive
 semidefinite two-site matrix `B`, together with proofs that its translated
 copies on the periodic chain pairwise commute and that their product
-reproduces `ρ` up to a positive scalar. This is the projector-limit version of
-the commuting-form definition in arXiv:1606.00608. This file defines the
-commuting-form witness and proves the GSNNCH equivalence built from it. The
+reproduces `ρ` up to a positive scalar. This is a single-bond presentation of
+the projector-limit form in arXiv:1606.00608. The source definition instead
+makes an orthogonal direct sum over sectors and natural multiplicities
+explicit. An arbitrary bond on the full local space may itself be block
+diagonal, and no equivalence with the source presentation is proved here.
+This file defines the single-bond witness and proves the equivalence between
+its two presentations. The
 theorem `MPOTensor.nonempty_etaLocalStructureData_of_isSAL` proves the
 entropy-side implication from SAL; its local structure gives
 `HasCommutingForm` through `MPOTensor.EtaLocalStructureData.hasCommutingForm`.
@@ -31,7 +35,7 @@ This is Proposition C.8 of arXiv:1606.00608, Appendix C.2, lines 1569--1594.
 * `MPOTensor.CommutingFormData`
 * `MPOTensor.HasCommutingForm`
 * `MPOTensor.GSNNCHData`
-* `MPOTensor.IsGSNNCH`
+* `MPOTensor.IsGSNNCH` (single-bond presentation)
 * `MPOTensor.isGSNNCH_iff_hasCommutingForm`
 * `MPOTensor.IsGSNNCHWithZCL`
 
@@ -430,11 +434,16 @@ def HasCommutingForm (M : MPOTensor d D) : Prop :=
 /-- A GSNNCH witness at chain length `N`: a commuting-form witness together with
 its positive normalization constant.
 
-This states the commuting-form definition in the equivalent positive-operator form
+**Scope restriction (single-bond presentation):** This states the positive-operator form
 `ρ⁽ᴺ⁾ = c ∏ᵢ B_{i,i+1}`, where `c > 0` and the translated bond operators
-commute pairwise. The paper's exponential form is recovered by taking
+commute pairwise. The exponential form of that sector is recovered by taking
 `B_{i,i+1} = e^{-h_{i,i+1}}` or, more generally, by the projector-limit
-convention following that definition. -/
+convention following the source definition. The full definition in
+arXiv:1606.00608, lines 829--850, also has an orthogonal direct sum over
+sectors with natural multiplicities. The bond here acts on the full local
+space and may itself be block diagonal; no equivalence with the explicit
+sector presentation is proved. See
+docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex. -/
 structure GSNNCHData (d N : ℕ) where
   /-- The underlying commuting-form data. -/
   form : CommutingFormData d N
@@ -458,12 +467,22 @@ theorem realizes_form_state (data : GSNNCHData d N) :
 
 end GSNNCHData
 
-/-- Chain-level GSNNCH predicate. -/
+/-- The chain-level single-bond presentation associated with the source
+GSNNCH condition.
+
+**Scope restriction (single-bond presentation):** No equivalence with the
+explicit source sector decomposition is asserted. See
+docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex. -/
 def IsGSNNCHAt {d N : ℕ} (ρ : ChainOperator d N) : Prop :=
   ∃ data : GSNNCHData d N, ρ = data.state
 
-/-- Global GSNNCH predicate for an MPO tensor: every chain length `N ≥ 2`
-produces a GSNNCH operator in the sense of the commuting-form definition. -/
+/-- Global single-bond commuting-product predicate for an MPO tensor: every
+chain length `N ≥ 2` has the restricted form represented by `IsGSNNCHAt`.
+
+**Scope restriction (single-bond presentation):** The source GSNNCH definition
+has explicit sector and multiplicity data, while the bond here may itself be
+block diagonal. No equivalence is asserted. See
+docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex. -/
 def IsGSNNCH (M : MPOTensor d D) : Prop :=
   ∀ N : ℕ, 2 ≤ N → IsGSNNCHAt (mpo M N)
 
@@ -507,12 +526,21 @@ theorem hasCommutingForm_of_isGSNNCH {M : MPOTensor d D}
     (hM : IsGSNNCH M) : HasCommutingForm M := fun N hN =>
   (isGSNNCHAt_iff_exists_commutingForm (mpo M N)).mp (hM N hN)
 
+/-- The two presentations of the single-bond commuting-product condition
+are equivalent.
+
+**Scope restriction (single-bond presentation):** This does not establish an
+equivalence with the explicit source GSNNCH sector decomposition. See
+docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex. -/
 theorem isGSNNCH_iff_hasCommutingForm (M : MPOTensor d D) :
     IsGSNNCH M ↔ HasCommutingForm M :=
   ⟨hasCommutingForm_of_isGSNNCH, isGSNNCH_of_hasCommutingForm⟩
 
-/-- The GSNNCH-with-zero-correlation-length branch of the simple-MPDO
-equivalence. -/
+/-- The single-bond commuting-product condition together with doubled-index
+zero correlation length.
+
+**Scope restriction (single-bond presentation):** See
+docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex. -/
 def IsGSNNCHWithZCL (M : MPOTensor d D) : Prop :=
   IsGSNNCH M ∧ IsZCL M
 

--- a/TNLean/MPS/MPDO/CommutingFormBridge.lean
+++ b/TNLean/MPS/MPDO/CommutingFormBridge.lean
@@ -22,8 +22,11 @@ gives a coherently positive physical-sector factorization satisfying
 \]
 Consequently, `MPOTensor.nonempty_etaLocalStructureData_of_isSAL` constructs
 the eta-local structure from injectivity and SAL alone. Zero correlation length
-is not used in Proposition C.8; it enters only in the later GSNNCH-with-ZCL and
-RFP consequences.
+is not used in Proposition C.8; it enters only in the later
+single-bond commuting-form-with-ZCL and RFP consequences. The full source
+GSNNCH definition also contains an orthogonal sector sum and natural
+multiplicities; see
+docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex.
 
 ## Main declarations
 
@@ -194,14 +197,21 @@ theorem positive_commuting_product_form
   ⟨(data.formAt N hN).bond_pos, data.formAt_bondAt_comm N hN,
     data.exists_positive_scalar_mpo_eq_product N hN⟩
 
-/-- The chain-level GSNNCH witness induced by the local `η`-structure at a fixed
-chain length. -/
+/-- The chain-level single-bond commuting-product witness induced by the
+local `η`-structure at a fixed chain length.
+
+**Scope restriction (single-bond presentation):** No equivalence with the
+explicit source sector decomposition is asserted. See
+docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex. -/
 theorem isGSNNCHAt (data : EtaLocalStructureData M) (N : ℕ) (hN : 2 ≤ N) :
     IsGSNNCHAt (mpo M N) :=
   (data.formAt N hN).isGSNNCHAt_of_realizes (data.formAt_realizes N hN)
 
-/-- The explicit `η`-local structure yields a GSNNCH witness on every finite
-chain. -/
+/-- The explicit `η`-local structure yields the single-bond
+commuting-product witness on every finite chain.
+
+**Scope restriction (single-bond presentation):** See
+docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex. -/
 theorem isGSNNCH (data : EtaLocalStructureData M) : IsGSNNCH M :=
   fun N hN => data.isGSNNCHAt N hN
 
@@ -210,11 +220,16 @@ theorem hasCommutingForm (data : EtaLocalStructureData M) : HasCommutingForm M :
   fun N hN => ⟨data.formAt N hN, data.formAt_realizes N hN⟩
 
 /-- The explicit `η`-local structure, together with ZCL, gives the
-GSNNCH-with-ZCL case of the simple-MPDO equivalence.
+single-bond commuting-product condition with ZCL.
 
 Source: arXiv:1606.00608, Appendix C.2, Proposition 3to4, lines 1571--1593:
 the assembled neighboring operators give a commuting nearest-neighbor product
-form. Adding ZCL gives item (iii) of Theorem 4.9 in the simple-MPDO case. -/
+form.
+
+**Scope restriction (single-bond presentation):** No equivalence with the
+orthogonal sector sum and natural multiplicities in item (iii) of Theorem 4.9
+is proved here. See
+docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex. -/
 theorem isGSNNCHWithZCL (data : EtaLocalStructureData M) (hZCL : IsZCL M) :
     IsGSNNCHWithZCL M :=
   (isGSNNCHWithZCL_iff_hasCommutingForm_and_isZCL M).2 ⟨data.hasCommutingForm, hZCL⟩
@@ -228,13 +243,20 @@ theorem hasCommutingForm_of_etaLocalStructure {M : MPOTensor d D}
     (hEta : EtaLocalStructureData M) : HasCommutingForm M :=
   hEta.hasCommutingForm
 
-/-- The explicit local `η`-structure also yields the GSNNCH condition. -/
+/-- The explicit local `η`-structure also yields the single-bond
+commuting-product condition.
+
+**Scope restriction (single-bond presentation):** See
+docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex. -/
 theorem isGSNNCH_of_etaLocalStructure {M : MPOTensor d D}
     (hEta : EtaLocalStructureData M) : IsGSNNCH M :=
   hEta.isGSNNCH
 
 /-- Once the explicit local `η`-structure has been assembled, adding ZCL gives
-the GSNNCH-with-ZCL case of the simple-MPDO equivalence. -/
+the single-bond commuting-product condition with ZCL.
+
+**Scope restriction (single-bond presentation):** See
+docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex. -/
 theorem isGSNNCHWithZCL_of_etaLocalStructure {M : MPOTensor d D}
     (hEta : EtaLocalStructureData M) (hZCL : IsZCL M) : IsGSNNCHWithZCL M :=
   hEta.isGSNNCHWithZCL hZCL

--- a/blueprint/src/chapter/ch21_mpdo_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp.tex
@@ -20,5 +20,7 @@ Chapter~\ref{ch:mpdo_rfp_algebraic}.
 \input{chapter/ch21_mpdo_rfp_pure_state_recovery}
 \input{chapter/ch21_mpdo_rfp_foundations}
 \input{chapter/ch21_mpdo_rfp_area_law}
+\input{chapter/ch21_mpdo_rfp_gsnnch_definitions}
+\input{chapter/ch21_mpdo_rfp_blocked_rfp}
 \input{chapter/ch21_mpdo_rfp_simple_local_structure}
 \input{chapter/ch21_mpdo_rfp_commuting_form_gsnnch}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_algebra_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_algebra_structure.tex
@@ -1,6 +1,9 @@
 \section{Algebra structure}
 
 \input{chapter/ch21_mpdo_rfp_algebra_tower}
+
+\subsection{The BNT-label algebra law and idempotent trace vector}
+
 \input{chapter/ch21_mpdo_rfp_bnt_coefficients}
 \input{chapter/ch21_mpdo_rfp_bnt_theorem_data}
 \input{chapter/ch21_mpdo_rfp_bnt_witnesses}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_algebra_tower.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_algebra_tower.tex
@@ -448,7 +448,7 @@ family, and the corresponding multiplication / inclusion coefficient arrays.
     Theorem~\ref{thm:mpdo_algebra_not_imply_fusion}.
 \end{remark}
 
-\section{Diagonal \texorpdfstring{$\chi$}{chi}-matrices and the trace-power formula}
+\subsection{Diagonal \texorpdfstring{$\chi$}{chi}-matrices and the trace-power formula}
 
 The following statements isolate the form of
 \cite[Theorem~4.14(ii)]{Cirac2016MPDO_arXiv}: the structure coefficients

--- a/blueprint/src/chapter/ch21_mpdo_rfp_algebraic.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_algebraic.tex
@@ -8,11 +8,48 @@
 
 This chapter continues the mixed-state renormalization analysis of
 Chapter~\ref{ch:mpdo_rfp} with the general case of
-\cite[Section~4]{Cirac2016MPDO_arXiv}.  Two-site blocking first reduces the
-tensor to the local form used by the source.  The subsequent algebraic
-characterization identifies the diagonal $\chi$-matrices governing the
-trace-power formula and culminates in the fusion-isometry description.
+\cite[Section~4]{Cirac2016MPDO_arXiv}. The source first places the tensor in
+vertical canonical form and then introduces its closed-chain operators. The
+algebraic characterization identifies the diagonal $\chi$-matrices governing
+the trace-power formula and culminates in the fusion-isometry description.
 
-\input{chapter/ch21_mpdo_rfp_blocked_rfp}
+\section{Vertical canonical form and closed-chain operators}
+
+The general case begins with the vertical canonical form of
+\cite[Proposition~4.13]{Cirac2016MPDO_arXiv}. In the notation of
+Definition~\ref{def:vertical_cf_mpdo}, there is a coisometry $U$ from the
+original physical space onto the retained nonzero sector space. Writing
+$B=\bigoplus_\alpha\mu_\alpha\otimes M_\alpha$, it satisfies
+\[
+    UU^\dagger=I,
+    \qquad U\widetilde M U^\dagger=B,
+    \qquad \widetilde M=U^\dagger B U,
+\]
+where the matrices $\mu_\alpha$ are positive and diagonal and the tensors
+$\{M_\alpha\}_\alpha$ form a basis of normal tensors. The matrix
+$U^\dagger U$ is the support projection in the original physical space; the
+reconstruction identity retains the zero-sector complement allowed by the
+source. This result was established in
+Theorem~\ref{thm:vertical_cf_of_horizontal_cf}.
+
+The source next defines $O_L(M_\alpha)$ by contracting cyclically the BNT bond
+indices of $L$ copies in the vertical reading. Write the vertical physical
+label as a pair $(a,b)$ of horizontal bond indices and set
+$\widehat M_\alpha^{ab}=M_\alpha^{(a,b)}$. For
+$\mathbf a=(a_1,\ldots,a_L)$ and
+$\mathbf b=(b_1,\ldots,b_L)$, the contraction is
+\[
+    \bigl[O_L(M_\alpha)\bigr]_{\mathbf a,\mathbf b}
+      =\operatorname{tr}\!\left(
+          \widehat M_\alpha^{a_1b_1}\cdots
+          \widehat M_\alpha^{a_Lb_L}\right)
+      =\bigl[\rho^{(L)}(\widehat M_\alpha)\bigr]_{\mathbf a,\mathbf b}.
+\]
+Thus $O_L(M_\alpha)=\rho^{(L)}(\widehat M_\alpha)$, where the trace is over the
+BNT bond space and the remaining row and column indices are the horizontal
+bond strings $\mathbf a$ and $\mathbf b$. These are the operators entering the
+algebra clause of
+\cite[Theorem~4.14]{Cirac2016MPDO_arXiv}.
+
 \input{chapter/ch21_mpdo_rfp_algebra_structure}
 \input{chapter/ch21_mpdo_rfp_fusion_isometries}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -1,65 +1,4 @@
-\section{Local structure and two-site blocking}
-
-\begin{definition}[Local simple-MPDO structure]
-    \label{def:simple_mpdo_local_structure_data}
-    \lean{MPOTensor.SimpleMPDOLocalStructureData}
-    \leanok
-    \uses{thm:sal_implies_eta_structure}
-    This structure records the local ingredients of
-    \cite[Appendix~C.2]{Cirac2016MPDO_arXiv}: a normalized three-site reduced
-    state with equality in strong subadditivity, the resulting Markov
-    decomposition, and a primitive matrix $T$ satisfying
-    \[
-        \operatorname{tr}(T)=1,
-        \qquad
-        \operatorname{tr}(T^m)=\operatorname{tr}(T)
-    \]
-    for every positive integer $m$, together with a rank-one factorization
-    \[
-        T = a b^\top, \qquad a \cdot b = 1.
-    \]
-\end{definition}
-
-\begin{theorem}[Local simple-MPDO structure from corrected rank-one criteria]
-    \label{thm:simple_mpdo_local_structure_data_of_sal_zcl}
-    \lean{MPOTensor.SimpleMPDOLocalStructureData.ofSALZCLOfPairingIdempotent}
-    \lean{MPOTensor.SimpleMPDOLocalStructureData.ofSALZCLOfPosSemidef}
-    \leanok
-    \uses{def:simple_mpdo_local_structure_data, thm:sal_implies_eta_structure,
-        thm:psd_trace_powers_rank_one_t, thm:pairing_idempotent_rank_one_t}
-    There are two sufficient forms of the local conclusion associated with
-    \cite[Lemmas~C.2, C.4, and~C.5]{Cirac2016MPDO_arXiv}. In the first,
-    $T$ is positive semidefinite,
-    $\operatorname{tr}(T)=1$, and
-    $\operatorname{tr}(T^m)=1$ for every positive integer $m$; the spectral
-    theorem then gives
-    \[
-        T = a b^\top, \qquad a \cdot b = 1.
-    \]
-    In the second, $T$ is the sector trace matrix of linearly independent
-    sector tensors satisfying the zero-correlation-length pairing identity.
-    This identity implies $T^2=T$, so trace one gives the same rank-one
-    factorization. In this second form the constancy of the positive-power
-    traces is a conclusion rather than an assumption.
-\end{theorem}
-
-The physical supports are locally orthogonal:
-\begin{center}
-    \TNMPDOBNTVerticalProduct
-\end{center}
-In contraction notation, local orthogonality is
-$\mathcal K_y^*\mathcal K_x=0$ whenever $x\ne y$.
-This is \cite[Theorem~4.9(iv), lines~863--868]{Cirac2016MPDO_arXiv}.
-
-Expanding $\sum_jP_j=\Id$ on both physical indices and using the local
-orthogonality relations leaves only the diagonal term:
-\begin{center}
-    \TNMPDOProjectorAbsorption
-\end{center}
-Equivalently, each local tensor is supported on its own sector:
-$\mathcal K_i=P_i\mathcal K_i=\mathcal K_iP_i$.
-This is the calculation in
-\cite[Appendix~C.2, lines~1745--1751]{Cirac2016MPDO_arXiv}.
+\section{Two-site and positive-length physical blocking}
 
 The two-site block is the virtual contraction of two copies of $K$:
 \begin{center}
@@ -88,9 +27,6 @@ physical indices, as in
     closed-chain operator $O_L(M)$ of
     \cite[lines~962--967]{Cirac2016MPDO_arXiv}.
 
-    The algebraic definition also assigns the identity matrix to the empty
-    product at $L=0$.  This total convention has no physical role here; every
-    blocking result below assumes $L>0$.
 \end{definition}
 
 \begin{theorem}[Doubled-index form of positive MPO blocking]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -1,103 +1,11 @@
-\section{Commuting form and GSNNCH}
-
-\begin{definition}[Commuting-form data for an MPDO]
-    \label{def:mpdo_commuting_form_data}
-    \lean{MPOTensor.CommutingFormData}
-    \leanok
-    \uses{def:mpo_tensor}
-    For a fixed chain length $N \ge 2$, this consists of a positive
-    semidefinite two-site operator $B\ge0$ whose translated copies commute
-    pairwise on the periodic $N$-site chain:
-    \[
-        [B_{i,i+1},B_{j,j+1}]=0.
-    \]
-\end{definition}
-
-\begin{definition}[Commuting form]
-    \label{def:mpdo_has_commuting_form}
-    \lean{MPOTensor.HasCommutingForm}
-    \leanok
-    \uses{def:mpdo_commuting_form_data, def:mpo_tensor}
-    An MPO tensor $M$ has the commuting-form property if for every $N \ge 2$
-    there is a two-site operator $B$ as in
-    Definition~\ref{def:mpdo_commuting_form_data} and a constant $c>0$ such
-    that
-    \[
-        \rho^{(N)}(M)=c\prod_{i=0}^{N-1}B_{i,i+1}.
-    \]
-\end{definition}
-
-\begin{definition}[GSNNCH]
-    \label{def:mpdo_is_gsnnch}
-    \lean{MPOTensor.IsGSNNCH}
-    \leanok
-    \uses{def:mpdo_has_commuting_form}
-    An MPO tensor $M$ is a Gibbs state of a nearest-neighbor commuting
-    Hamiltonian if for every $N\ge2$ its finite-chain operator admits the
-    equivalent positive-operator presentation
-    \[
-        \rho^{(N)}(M)=c\prod_{i=0}^{N-1}B_{i,i+1},
-        \qquad c>0,\qquad B\ge0,\qquad [B_{i,i+1},B_{j,j+1}]=0.
-    \]
-    The projector-limit convention in
-    \cite{Cirac2016MPDO_arXiv}
-    identifies this with the exponential Gibbs form.
-\end{definition}
-
-\begin{theorem}[GSNNCH iff commuting form]
-    \label{thm:mpdo_is_gsnnch_iff_has_commuting_form}
-    \lean{MPOTensor.isGSNNCH_iff_hasCommutingForm}
-    \leanok
-    \uses{def:mpdo_is_gsnnch, def:mpdo_has_commuting_form}
-    For an MPO tensor, the GSNNCH condition is equivalent to the existence of
-    commuting-form data on every finite chain.
-\end{theorem}
-
-\begin{proof}\leanok
-    Both directions unfold to the same identity
-    $\rho^{(N)}(M)=c\prod_{i=0}^{N-1}B_{i,i+1}$ with $c>0$: a commuting-form
-    witness for $M$ at length $N$ together with its constant $c$ is exactly a
-    GSNNCH witness for $M$ at length $N$ with that same constant, and
-    conversely.
-\end{proof}
-
-\begin{definition}[GSNNCH with doubled-index transfer idempotence]
-    \label{def:mpdo_is_gsnnch_zcl}
-    \lean{MPOTensor.IsGSNNCHWithZCL}
-    \leanok
-    \uses{def:mpdo_is_gsnnch, def:mpo_is_zcl}
-    This is the conjunction of the GSNNCH condition with the doubled-index
-    transfer condition
-    \[
-        \E_M\circ\E_M=\E_M.
-    \]
-    It is the doubled-index analogue of the ZCL clause in item~(iii) of
-    the simple-MPDO equivalence in \cite{Cirac2016MPDO_arXiv}; the
-    source physical-trace condition is Definition~\ref{def:mpo_source_zcl}.
-\end{definition}
-
-\begin{theorem}[GSNNCH with doubled-index idempotence iff commuting form with it]
-    \label{thm:mpdo_is_gsnnch_zcl_iff_has_commuting_form_and_is_zcl}
-    \lean{MPOTensor.isGSNNCHWithZCL_iff_hasCommutingForm_and_isZCL}
-    \leanok
-    \uses{def:mpdo_is_gsnnch_zcl, thm:mpdo_is_gsnnch_iff_has_commuting_form}
-    The GSNNCH branch with doubled-index transfer idempotence is equivalent to
-    the conjunction of the commuting-form property with that same idempotence
-    condition.
-\end{theorem}
-
-\begin{proof}\leanok
-    Unfold the definition of the GSNNCH branch with doubled-index transfer
-    idempotence and apply
-    Theorem~\ref{thm:mpdo_is_gsnnch_iff_has_commuting_form}.
-\end{proof}
+\section{Single-bond commuting form from the local structure}
 
 \begin{definition}[Translation-invariant two-site bond]
     \label{def:mpdo_translation_invariant_bond_data}
     \lean{MPOTensor.TranslationInvariantBondData}
     \leanok
     \uses{def:mpdo_commuting_form_data}
-    This records a single positive semidefinite two-site bond $B\ge0$ whose
+    This records one positive semidefinite two-site bond $B\ge0$ whose
     translated copies commute pairwise on the periodic $N$-site chain at
     every chain length $N\ge2$:
     \[
@@ -105,18 +13,21 @@
     \]
 \end{definition}
 
-\begin{definition}[$\eta$-local commuting-form data]
+\begin{definition}[$\eta$-local single-bond commuting-form data]
     \label{def:mpdo_eta_local_structure_data}
     \lean{MPOTensor.EtaLocalStructureData}
     \leanok
     \uses{def:mpdo_translation_invariant_bond_data, def:mpdo_has_commuting_form}
-    This defines the eta-local form of \cite[Appendix~C.2]{Cirac2016MPDO_arXiv}:
+    This defines the one-bond eta-local form constructed in
+    \cite[Appendix~C.2]{Cirac2016MPDO_arXiv}:
     a two-site bond $B$ as in
     Definition~\ref{def:mpdo_translation_invariant_bond_data} together with,
     for every chain length $N\ge2$, a constant $c>0$ such that
     \[
         \rho^{(N)}(M)=c\prod_{i=0}^{N-1}B_{i,i+1}.
     \]
+    The bond acts on the full two-site space. No identification with the
+    explicit sector data of Definition~\ref{def:mpdo_source_gsnnch} is made.
 \end{definition}
 
 \begin{definition}[Finite-chain bond form]
@@ -131,7 +42,7 @@
     commuting-form data at every length $N \ge 2$.
 \end{definition}
 
-\begin{theorem}[$\eta$-local structure carries commuting form]
+\begin{theorem}[$\eta$-local structure carries single-bond commuting form]
     \label{thm:mpdo_eta_local_structure_has_commuting_form}
     \lean{MPOTensor.EtaLocalStructureData.hasCommutingForm}
     \lean{MPOTensor.EtaLocalStructureData.formAt_realizes}
@@ -141,7 +52,8 @@
     \lean{MPOTensor.hasCommutingForm_of_etaLocalStructure}
     \leanok
     \uses{def:mpdo_eta_local_structure_data, def:mpdo_has_commuting_form}
-    The $\eta$-local structure itself determines a commuting-form witness for
+    The $\eta$-local structure itself determines a single-bond
+    commuting-form witness for
     every chain length $N \ge 2$: writing $B$ for its bond, the translated
     copies commute,
     \[
@@ -151,8 +63,11 @@
     \[
         \rho^{(N)}(M)=c\prod_{i=0}^{N-1}B_{i,i+1}.
     \]
-    This is the implication from $\eta$-local structure to commuting form in
-    \cite[Proposition~C.8]{Cirac2016MPDO_arXiv}.
+    This is the one-bond product conclusion used in
+    \cite[Proposition~C.8]{Cirac2016MPDO_arXiv}. Its relation to the explicit
+    source sector decomposition is not asserted here.
+    % Scope restriction (single-bond presentation): see
+    % docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex.
     % Gap documented in docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex.
 \end{theorem}
 
@@ -161,21 +76,25 @@
     provided by the $\eta$-local structure.
 \end{proof}
 
-\begin{theorem}[$\eta$-local structure gives GSNNCH]
+\begin{theorem}[$\eta$-local structure gives the restricted GSNNCH predicate]
     \label{thm:mpdo_eta_local_structure_is_gsnnch}
     \lean{MPOTensor.EtaLocalStructureData.isGSNNCH}
     \lean{MPOTensor.isGSNNCH_of_etaLocalStructure}
     \leanok
     \uses{def:mpdo_eta_local_structure_data, def:mpdo_is_gsnnch}
-    The same $\eta$-local structure gives a GSNNCH witness on every finite
-    periodic chain.
+    The same $\eta$-local structure gives a single-bond product witness
+    on every finite periodic chain.
+    The statement does not identify this witness with the explicit sector
+    decomposition of Definition~\ref{def:mpdo_source_gsnnch}.
+    % Scope restriction (single-bond presentation): see
+    % docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex.
 \end{theorem}
 
 \begin{proof}\leanok
     Evaluate the local structure at each chain length $N \ge 2$.
 \end{proof}
 
-\begin{theorem}[$\eta$-local structure with doubled-index idempotence]
+\begin{theorem}[Restricted commuting form with doubled-index idempotence]
     \label{thm:mpdo_eta_local_structure_is_gsnnch_zcl}
     \lean{MPOTensor.EtaLocalStructureData.isGSNNCHWithZCL}
     \lean{MPOTensor.isGSNNCHWithZCL_of_etaLocalStructure}
@@ -183,7 +102,9 @@
     \uses{thm:mpdo_eta_local_structure_has_commuting_form,
         thm:mpdo_is_gsnnch_zcl_iff_has_commuting_form_and_is_zcl}
     An $\eta$-local structure together with the doubled-index transfer
-    condition gives the corresponding GSNNCH branch.
+    condition gives the corresponding single-bond branch.
+    % Scope restriction (single-bond presentation): see
+    % docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -225,5 +146,5 @@
     physical-sector factorization, the all-length product identity is
     Theorem~\ref{thm:mpdo_exact_physical_sector_bond_product}.
     The doubled-index transfer condition enters only in the subsequent RFP and
-    GSNNCH branch conclusions.
+    single-bond branch conclusions.
 \end{remark}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
@@ -1,0 +1,131 @@
+\section{Gibbs states of nearest-neighbor commuting Hamiltonians}
+
+\begin{definition}[GSNNCH]\label{def:mpdo_source_gsnnch}
+    \notready
+    A density operator on a periodic chain is a Gibbs state of a
+    nearest-neighbor commuting Hamiltonian if
+    \[
+        \rho^{(N)}
+        \propto
+        \bigoplus_x n_x
+        \exp\!\left(-\sum_{j=1}^N\tau_j(h^{(x)})\right),
+        \qquad n_x\in\N,
+    \]
+    where the one-site spaces belonging to distinct labels $x$ are
+    orthogonal and
+    $[h^{(x)},\tau_1(h^{(x)})]=0$. With the projector-limit convention of
+    \cite[Definition~4.8, lines~829--850]{Cirac2016MPDO_arXiv}, this is
+    equivalently
+    \[
+        \rho^{(N)}
+        \propto
+        \bigoplus_x n_x
+        \prod_{j=1}^N\tau_j(B^{(x)}),
+        \qquad B^{(x)}\geq0,
+    \]
+    with commuting neighboring translates. The orthogonal sum and the
+    multiplicities are part of the definition.
+\end{definition}
+
+The following single-bond presentation does not make the sector labels or
+multiplicities explicit. Its bond acts on the full two-site space and may
+itself be block diagonal. No equivalence between this presentation and
+Definition~\ref{def:mpdo_source_gsnnch} is assumed.
+% Scope boundary: the missing comparison with the explicit sector decomposition
+% is documented in docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex.
+
+\begin{definition}[Single-bond commuting-form data for an MPDO]
+    \label{def:mpdo_commuting_form_data}
+    \lean{MPOTensor.CommutingFormData}
+    \leanok
+    \uses{def:mpo_tensor}
+    For a fixed chain length $N \ge 2$, this consists of one positive
+    semidefinite two-site operator $B\ge0$ whose translated copies commute
+    pairwise on the periodic $N$-site chain:
+    \[
+        [B_{i,i+1},B_{j,j+1}]=0.
+    \]
+\end{definition}
+
+\begin{definition}[Single-bond commuting form]
+    \label{def:mpdo_has_commuting_form}
+    \lean{MPOTensor.HasCommutingForm}
+    \leanok
+    \uses{def:mpdo_commuting_form_data, def:mpo_tensor}
+    An MPO tensor $M$ has the single-bond commuting-form property if for
+    every $N \ge 2$ there is a two-site operator $B$ as in
+    Definition~\ref{def:mpdo_commuting_form_data} and a constant $c>0$ such
+    that
+    \[
+        \rho^{(N)}(M)=c\prod_{i=0}^{N-1}B_{i,i+1}.
+    \]
+\end{definition}
+
+\begin{definition}[Single-bond product predicate]
+    \label{def:mpdo_is_gsnnch}
+    \lean{MPOTensor.IsGSNNCH}
+    \leanok
+    \uses{def:mpdo_has_commuting_form}
+    This condition asks, for every chain length $N\geq2$, for one positive
+    bond on the full two-site space and one positive normalization such that
+    \[
+        \rho^{(N)}(M)=c\prod_{i=0}^{N-1}B_{i,i+1},
+        \qquad c>0,\qquad B\ge0,
+        \qquad [B_{i,i+1},B_{j,j+1}]=0.
+    \]
+    The bond may itself be block diagonal. The condition contains no explicit
+    sector labels or multiplicities and is not identified here with
+    Definition~\ref{def:mpdo_source_gsnnch}.
+    % Scope restriction (single-bond presentation): see
+    % docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex.
+\end{definition}
+
+\begin{theorem}[Single-bond predicate iff single-bond commuting form]
+    \label{thm:mpdo_is_gsnnch_iff_has_commuting_form}
+    \lean{MPOTensor.isGSNNCH_iff_hasCommutingForm}
+    \leanok
+    \uses{def:mpdo_is_gsnnch, def:mpdo_has_commuting_form}
+    The single-bond product predicate is equivalent to the existence of
+    single-bond commuting-form data on every finite chain. This is an
+    equivalence between two presentations of the same condition; it does not
+    compare that condition with Definition~\ref{def:mpdo_source_gsnnch}.
+    % Scope restriction (single-bond presentation): see
+    % docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex.
+\end{theorem}
+
+\begin{proof}\leanok
+    Expanding the two definitions gives the same identity
+    $\rho^{(N)}(M)=c\prod_{i=0}^{N-1}B_{i,i+1}$ with $c>0$.
+\end{proof}
+
+\begin{definition}[Single-bond predicate with doubled-index idempotence]
+    \label{def:mpdo_is_gsnnch_zcl}
+    \lean{MPOTensor.IsGSNNCHWithZCL}
+    \leanok
+    \uses{def:mpdo_is_gsnnch, def:mpo_is_zcl}
+    This is the conjunction of the single-bond condition with the
+    doubled-index transfer identity
+    \[
+        \E_M\circ\E_M=\E_M.
+    \]
+    The source physical-trace condition is
+    Definition~\ref{def:mpo_source_zcl}.
+    % Scope restriction (single-bond presentation): see
+    % docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex.
+\end{definition}
+
+\begin{theorem}[Restricted predicate with idempotence iff restricted form with it]
+    \label{thm:mpdo_is_gsnnch_zcl_iff_has_commuting_form_and_is_zcl}
+    \lean{MPOTensor.isGSNNCHWithZCL_iff_hasCommutingForm_and_isZCL}
+    \leanok
+    \uses{def:mpdo_is_gsnnch_zcl,
+        thm:mpdo_is_gsnnch_iff_has_commuting_form}
+    The single-bond condition with doubled-index transfer idempotence is
+    equivalent to the conjunction of the single-bond commuting-form
+    property with that same idempotence condition.
+\end{theorem}
+
+\begin{proof}\leanok
+    Expand the restricted conjunction and apply
+    Theorem~\ref{thm:mpdo_is_gsnnch_iff_has_commuting_form}.
+\end{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -8,6 +8,8 @@
 
 \input{chapter/ch21_mpdo_rfp_simple_local_normalized_preparations}
 
+\input{chapter/ch21_mpdo_rfp_simple_local_primitivity}
+
 \input{chapter/ch21_mpdo_rfp_simple_local_refinement_channels}
 
-\input{chapter/ch21_mpdo_rfp_simple_local_primitivity}
+\input{chapter/ch21_mpdo_rfp_simple_local_structure_capstone}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -1,0 +1,62 @@
+\subsection{Local simple-MPDO structure}
+
+\begin{definition}[Local simple-MPDO structure]
+    \label{def:simple_mpdo_local_structure_data}
+    \lean{MPOTensor.SimpleMPDOLocalStructureData}
+    \leanok
+    \uses{thm:sal_implies_eta_structure}
+    This structure records the local ingredients of
+    \cite[Appendix~C.2]{Cirac2016MPDO_arXiv}: a normalized three-site reduced
+    state with equality in strong subadditivity, the resulting Markov
+    decomposition, and a primitive matrix $T$ satisfying
+    \[
+        \operatorname{tr}(T)=1,
+        \qquad
+        \operatorname{tr}(T^m)=\operatorname{tr}(T)
+    \]
+    for every positive integer $m$, together with a rank-one factorization
+    \[
+        T = a b^\top, \qquad a \cdot b = 1.
+    \]
+\end{definition}
+
+\begin{theorem}[Local simple-MPDO structure from corrected rank-one criteria]
+    \label{thm:simple_mpdo_local_structure_data_of_sal_zcl}
+    \lean{MPOTensor.SimpleMPDOLocalStructureData.ofSALZCLOfPairingIdempotent}
+    \lean{MPOTensor.SimpleMPDOLocalStructureData.ofSALZCLOfPosSemidef}
+    \leanok
+    \uses{def:simple_mpdo_local_structure_data, thm:sal_implies_eta_structure,
+        thm:psd_trace_powers_rank_one_t, thm:pairing_idempotent_rank_one_t}
+    There are two sufficient forms of the local conclusion associated with
+    \cite[Lemmas~C.2, C.4, and~C.5]{Cirac2016MPDO_arXiv}. In the first,
+    $T$ is positive semidefinite,
+    $\operatorname{tr}(T)=1$, and
+    $\operatorname{tr}(T^m)=1$ for every positive integer $m$; the spectral
+    theorem then gives
+    \[
+        T = a b^\top, \qquad a \cdot b = 1.
+    \]
+    In the second, $T$ is the sector trace matrix of linearly independent
+    sector tensors satisfying the zero-correlation-length pairing identity.
+    This identity implies $T^2=T$, so trace one gives the same rank-one
+    factorization. In this second form the constancy of the positive-power
+    traces is a conclusion rather than an assumption.
+\end{theorem}
+
+The physical supports are locally orthogonal:
+\begin{center}
+    \TNMPDOBNTVerticalProduct
+\end{center}
+In contraction notation, local orthogonality is
+$\mathcal K_y^*\mathcal K_x=0$ whenever $x\ne y$.
+This is \cite[Theorem~4.9(iv), lines~863--868]{Cirac2016MPDO_arXiv}.
+
+Expanding $\sum_jP_j=\Id$ on both physical indices and using the local
+orthogonality relations leaves only the diagonal term:
+\begin{center}
+    \TNMPDOProjectorAbsorption
+\end{center}
+Equivalently, each local tensor is supported on its own sector:
+$\mathcal K_i=P_i\mathcal K_i=\mathcal K_iP_i$.
+This is the calculation in
+\cite[Appendix~C.2, lines~1745--1751]{Cirac2016MPDO_arXiv}.

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -38,6 +38,12 @@ unless they are cited by one of the current blueprint chapters above.
 
 For MPDO renormalization fixed points:
 
+- `cpsv16_gsnnch_sector_decomposition.tex` records that
+  `MPOTensor.IsGSNNCH` describes a single-bond commuting-product presentation
+  without explicit sector or multiplicity data.  The source definition uses
+  an orthogonal direct sum of sectors with natural multiplicities.  No
+  equivalence between the two presentations has yet been proved, so the
+  source definition is stated separately in the blueprint.
 - `cpgsv17_mpdo_sal_zcl_eta_local_structure.tex` records the missing
   coherent positive choice for the inverse-map neighboring operators in
   Appendix C.2. The comparison with the conjugated Hayashi decomposition,

--- a/docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex
+++ b/docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex
@@ -1,0 +1,101 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{The Sector Decomposition in the GSNNCH Definition of
+Cirac--P\'erez-Garc\'ia--Schuch--Verstraete}
+\author{}
+\date{2026-07-15}
+
+\begin{document}
+\maketitle
+
+\section{Source definition}
+
+Cirac--P\'erez-Garc\'ia--Schuch--Verstraete define a density operator on a
+periodic chain to be a Gibbs state of a nearest-neighbor commuting Hamiltonian
+when
+\[
+  \rho^{(N)}
+  \propto
+  \bigoplus_x n_x
+  \exp\!\left(-\sum_{j=1}^N\tau_j(h^{(x)})\right),
+  \qquad n_x\in\mathbb N,
+\]
+where the one-site spaces belonging to distinct labels $x$ are orthogonal and
+$[h^{(x)},\tau_1(h^{(x)})]=0$
+in arXiv:1606.00608, Definition~4.8, lines~829--842. With the
+projector-limit convention stated immediately afterward, this is equivalently
+\[
+  \rho^{(N)}
+  \propto
+  \bigoplus_x n_x
+  \prod_{j=1}^N\tau_j(B^{(x)}),
+  \qquad B^{(x)}\geq0.
+\]
+The neighboring translates commute; see arXiv:1606.00608, lines~843--850.
+
+The direct sum and the multiplicities are part of the definition.  Passing
+from the exponential form to positive semidefinite bonds does not remove
+them.
+
+\section{Present formal boundary}
+
+The structure \leanid{MPOTensor.GSNNCHData} contains one positive two-site
+bond on the full local space, one positive normalization, and the product of
+its translates.  Thus \leanid{MPOTensor.IsGSNNCH} records the single-bond
+presentation
+\[
+  \rho^{(N)}=c_N\prod_{j=1}^N\tau_j(B_N),
+  \qquad c_N>0,
+\]
+without explicit sector or multiplicity data. The corresponding equivalence
+theorem merely identifies two presentations of this same single-bond
+condition.
+
+The single bond acts on the full two-site space and may itself be block
+diagonal.  It may therefore encode part or all of a source sector
+decomposition implicitly.  Conversely, each fixed source sector has a
+single-bond product form.  What is missing is a theorem comparing the two
+presentations: neither an assembly of the explicit sector data into the
+single-bond structure nor an extraction of the sector data from such a bond
+has been proved.
+
+\section{Elimination plan}
+
+A source-faithful structure should contain a finite sector type, mutually
+orthogonal one-site sector embeddings, multiplicities $n_x\in\mathbb N$, and
+one commuting positive bond $B^{(x)}$ for each sector.  Its represented chain
+operator must be the orthogonal direct sum of the corresponding periodic bond
+products.  The required completion has three parts:
+
+\begin{enumerate}
+  \item define the finite-chain orthogonal direct sum and prove positivity and
+        translation invariance;
+  \item construct the source GSNNCH data from the physical-sector
+        factorization in Appendix C.2, retaining all sector multiplicities;
+  \item prove the precise relationship between the single-bond presentation
+        and the source-faithful predicate, and use that result in the
+        simple-MPDO equivalence.
+\end{enumerate}
+
+Until these steps are complete, the blueprint states the source definition
+separately and describes every use of \leanid{MPOTensor.IsGSNNCH} as a
+single-bond presentation without claiming equivalence with the explicit
+sector decomposition.
+
+\section{Classification}
+
+Verdict: scope restriction with an open comparison gap.  The present formal
+predicate records only the single-bond presentation and does not retain the
+explicit sector spaces or their natural multiplicities.  The source GSNNCH
+definition is therefore stated separately in the blueprint and remains
+unformalized.  Neither direction of the comparison between these two
+presentations is claimed until the constructions above have been proved.
+
+\end{document}


### PR DESCRIPTION
This change reorganizes the mixed-state RFP blueprint so that a third-party reader encounters the material in the order of Cirac--Pérez-García--Schuch--Verstraete, Section 4 and Appendix C.2.

The first chapter now proceeds from the mixed-state RFP definition and pure-state recovery through zero correlation length, purification fixed points, saturation of the area law, the source GSNNCH definition, the simple-case local structure, and its commuting-product consequence. The second chapter begins with vertical canonical form and the closed-chain operators, then treats the algebra law, diagonal chi-matrices, and fusion isometries.

It also:
- removes the physically irrelevant empty-chain discussion from positive-length blocking;
- places primitivity before refinement, following Appendix C.2;
- corrects the coisometry and closed-chain-operator descriptions;
- states the source GSNNCH sector decomposition separately from the present single-bond Lean predicate;
- records the missing comparison theorem in docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex.

No theorem statement or proof is changed, and no axiom is introduced.

Validation:
- lake build
- focused Lean checks for CommutingForm and CommutingFormBridge
- blueprint_lean_sync --ci
- leanblueprint checkdecls
- reader-facing prose check
- leanblueprint pdf, 565 pages, with visual inspection of the table of contents and affected chapter pages
- standalone compilation and visual inspection of the paper-gap note

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are documentation, blueprint layout, and scope disclaimers only; formal mathematics and axioms are unchanged per the PR description.
> 
> **Overview**
> **Documentation and blueprint reorganization** to follow Cirac–Pérez-García–Schuch–Verstraete Section 4 / Appendix C.2 reading order. **No Lean theorem statements or proofs are modified**; `CommutingForm.lean` and `CommutingFormBridge.lean` only gain module comments and **scope restriction** notes pointing at `docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex`.
> 
> The blueprint now **states the paper GSNNCH definition** (orthogonal sector sum and multiplicities, `\notready`) in a new `ch21_mpdo_rfp_gsnnch_definitions.tex`, and **relabels** `HasCommutingForm` / `IsGSNNCH` as the **single-bond** commuting-product presentation, explicitly **not** equated to the source definition. Commuting-form/GSNNCH material is split: definitions move earlier in chapter 21; `ch21_mpdo_rfp_commuting_form_gsnnch.tex` focuses on η-local → single-bond consequences.
> 
> **Chapter structure moves:** simple local-structure capstone and blocking sections are relocated (`simple_local_structure_capstone`, `blocked_rfp` inputs reordered); the algebraic chapter **opens** with vertical canonical form and closed-chain operators `O_L(M_\alpha)` and **drops** leading simple-case blocking content from `blocked_rfp.tex` (including empty-chain blocking prose). Minor fixes to coisometry/closure wording and a BNT algebra subsection heading.
> 
> **New gap documentation:** `cpsv16_gsnnch_sector_decomposition.tex` plus README entry recording the open comparison between `MPOTensor.IsGSNNCH` and the explicit sector decomposition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 551fe009a6140102e12cecd18ec2875ac0fcd6af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->