### PR TITLE
refactor(rfp): comprehensively simplify MPS and MPDO proofs

### DIFF
--- a/TNLean/Analysis/Entropy.lean
+++ b/TNLean/Analysis/Entropy.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
 -/
 import Mathlib.Analysis.Matrix.PosDef
 import Mathlib.Analysis.Matrix.Spectrum
@@ -30,6 +31,10 @@ the basic quantum entropy infrastructure needed for MPDO / RFP applications.
 * `vonNeumannEntropy_nonneg_of_posSemidef_trace_one`: `S(ρ) ≥ 0` for
   positive semidefinite matrices of trace `1`, over any finite index type
 * `vonNeumannEntropy_nonneg`: `S(ρ) ≥ 0` for density matrices
+* `Matrix.PosSemidef.rank_pos_of_trace_one`: a trace-one positive semidefinite
+  matrix has positive rank
+* `vonNeumannEntropy_eq_zero_of_rank_le_one`: a rank-at-most-one density matrix
+  has zero entropy
 * `traceA_ABC_isHermitian`, `traceC_ABC_isHermitian`, `traceAC_ABC_isHermitian`:
   tripartite partial traces preserve Hermiticity
 * `isSSAEquality_submatrix_prodEquiv`: equality in strong subadditivity is
@@ -315,6 +320,22 @@ theorem posSemidef_trace_one_eigenvalues_sum_one
     h ▸ hρ_tr
   exact_mod_cast key
 
+omit [DecidableEq n] in
+/-- A positive semidefinite trace-one matrix has positive rank. -/
+theorem Matrix.PosSemidef.rank_pos_of_trace_one
+    {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) (hρ_tr : ρ.trace = 1) :
+    0 < ρ.rank := by
+  classical
+  rw [hρ.isHermitian.rank_eq_card_non_zero_eigs, Fintype.card_pos_iff]
+  by_contra h
+  simp only [not_nonempty_iff] at h
+  have hzero : ∀ i, hρ.isHermitian.eigenvalues i = 0 := fun i => by
+    by_contra hi
+    exact h.false ⟨i, hi⟩
+  have hsum := posSemidef_trace_one_eigenvalues_sum_one hρ hρ_tr
+  rw [Finset.sum_eq_zero (fun i _ => hzero i)] at hsum
+  exact one_ne_zero hsum.symm
+
 /-- The eigenvalues of a positive semidefinite trace-one matrix lie in `[0, 1]`. -/
 theorem posSemidef_trace_one_eigenvalues_le_one
     {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) (hρ_tr : ρ.trace = 1) (i : n) :
@@ -354,20 +375,7 @@ theorem vonNeumannEntropy_le_log_rank
     rw [hρ.isHermitian.rank_eq_card_non_zero_eigs, hk, ht, ← hlam, Fintype.card_subtype]
   -- the eigenvalues sum to one
   have hsum_one : ∑ i : n, lam i = 1 := posSemidef_trace_one_eigenvalues_sum_one hρ hρ_tr
-  -- the support is nonempty, hence `k > 0`
-  have hk_pos : 0 < k := by
-    rw [hk, Finset.card_pos]
-    by_contra h
-    rw [Finset.not_nonempty_iff_eq_empty] at h
-    have hz : ∀ i, lam i = 0 := by
-      intro i
-      by_contra hi
-      have hmem : i ∈ t := by rw [ht]; exact Finset.mem_filter.mpr ⟨Finset.mem_univ i, hi⟩
-      rw [h] at hmem
-      simp at hmem
-    have : ∑ i : n, lam i = 0 := Finset.sum_eq_zero fun i _ => hz i
-    rw [this] at hsum_one
-    exact one_ne_zero hsum_one.symm
+  have hk_pos : 0 < k := hrank ▸ hρ.rank_pos_of_trace_one hρ_tr
   have hkR : (0 : ℝ) < k := by exact_mod_cast hk_pos
   -- restrict the sums to the support (zero eigenvalues contribute nothing)
   have hsum_t : ∑ i ∈ t, lam i = 1 := by
@@ -406,6 +414,18 @@ theorem vonNeumannEntropy_le_log_rank
   have hmul := mul_le_mul_of_nonneg_left hJensen hkR.le
   rw [hlhs, hrhs] at hmul
   rwa [hrank]
+
+/-- A positive semidefinite trace-one matrix of rank at most one has zero von
+Neumann entropy. -/
+theorem vonNeumannEntropy_eq_zero_of_rank_le_one
+    {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) (hρ_tr : ρ.trace = 1)
+    (hrank : ρ.rank ≤ 1) :
+    vonNeumannEntropy ρ hρ.isHermitian = 0 := by
+  apply le_antisymm
+  · refine (vonNeumannEntropy_le_log_rank hρ hρ_tr).trans ?_
+    exact Real.log_nonpos (by exact_mod_cast (hρ.rank_pos_of_trace_one hρ_tr).le)
+      (by exact_mod_cast hrank)
+  · exact vonNeumannEntropy_nonneg_of_posSemidef_trace_one hρ hρ_tr
 
 end VonNeumannEntropyDensity
 

--- a/TNLean/Channel/KrausCPTP.lean
+++ b/TNLean/Channel/KrausCPTP.lean
@@ -36,6 +36,8 @@ dimensions.
   positive property.
 * `Matrix.equivReindexMap_isKrausCPTP`: reindexing by an equivalence is
   trace-preserving completely positive.
+* `Matrix.rectangularKrausMap_isKrausCPTP`: any finite Kraus family resolving
+  the identity defines a trace-preserving completely positive map.
 * `Matrix.controlledKrausMap_sameBlock_apply`: the action on each diagonal
   summand of an orthogonally controlled Kraus map.
 * `Matrix.controlledKrausMap_apply_of_ne`: the vanishing of its off-diagonal
@@ -247,6 +249,19 @@ theorem rectangularKrausMap_equiv
   intro X
   exact Equiv.sum_comp e.symm (fun i : κ => A i * X * (A i)ᴴ)
 
+/-- A finite rectangular Kraus family resolving the identity defines a
+trace-preserving completely positive map. -/
+theorem rectangularKrausMap_isKrausCPTP
+    {κ α β : Type*} [Fintype κ] [Fintype α] [DecidableEq α]
+    [Fintype β] [DecidableEq β] (A : κ → Matrix β α ℂ)
+    (hA : ∑ i, (A i)ᴴ * A i = (1 : Matrix α α ℂ)) :
+    IsKrausCPTP (rectangularKrausMap A) := by
+  let e := Fintype.equivFin κ
+  refine ⟨Fintype.card κ, fun i => A (e.symm i), ?_, ?_⟩
+  · intro X
+    exact DFunLike.congr_fun (rectangularKrausMap_equiv e A).symm X
+  · exact (e.symm.sum_comp fun i => (A i)ᴴ * A i).trans hA
+
 section ControlledDirectSum
 
 variable {ι : Type*} [Fintype ι] [DecidableEq ι]
@@ -381,51 +396,38 @@ theorem controlledKrausMap_isKrausCPTP (r : ι → ℕ)
     (A : (i : ι) → Fin (r i) → Matrix (β i) (α i) ℂ)
     (htp : ∀ i, ∑ j, (A i j)ᴴ * A i j = (1 : Matrix (α i) (α i) ℂ)) :
     IsKrausCPTP (controlledKrausMap r A) := by
-  let e := Fintype.equivFin (Σ i, Fin (r i))
-  refine ⟨Fintype.card (Σ i, Fin (r i)),
-    fun j ↦ singleBlock (e.symm j).1 (A (e.symm j).1 (e.symm j).2), ?_, ?_⟩
-  · intro X
-    change (∑ p : Σ i, Fin (r i), singleBlock p.1 (A p.1 p.2) * X *
-      (singleBlock p.1 (A p.1 p.2))ᴴ) = _
-    rw [← e.symm.sum_comp]
-  · change (∑ j : Fin (Fintype.card (Σ i, Fin (r i))),
-        (singleBlock (e.symm j).1 (A (e.symm j).1 (e.symm j).2))ᴴ *
-          singleBlock (e.symm j).1 (A (e.symm j).1 (e.symm j).2)) = 1
-    have hsum :
-        (∑ p : Σ i, Fin (r i),
-          (singleBlock p.1 (A p.1 p.2))ᴴ * singleBlock p.1 (A p.1 p.2)) = 1 := by
-      rw [Fintype.sum_sigma]
-      simp_rw [singleBlock_conjTranspose_mul]
-      have hinner (i : ι) :
-          (∑ j, Matrix.blockDiagonal' (Pi.single i ((A i j)ᴴ * A i j))) =
-            Matrix.blockDiagonal' (Pi.single i (∑ j, (A i j)ᴴ * A i j)) := by
-        change (∑ j, (Matrix.blockDiagonal'AddMonoidHom α α ℂ)
-          (Pi.single i ((A i j)ᴴ * A i j))) =
-            (Matrix.blockDiagonal'AddMonoidHom α α ℂ)
-              (Pi.single i (∑ j, (A i j)ᴴ * A i j))
-        rw [← map_sum (Matrix.blockDiagonal'AddMonoidHom α α ℂ)]
-        congr 1
-        funext k
-        by_cases hki : k = i
-        · subst k
-          simp
-        · simp [hki]
-      simp_rw [hinner, htp]
-      change (∑ i, (Matrix.blockDiagonal'AddMonoidHom α α ℂ)
-        (Pi.single i (1 : Matrix (α i) (α i) ℂ))) = 1
-      rw [← map_sum (Matrix.blockDiagonal'AddMonoidHom α α ℂ)]
-      have hfamily :
-          (∑ i, Pi.single i (1 : Matrix (α i) (α i) ℂ)) =
-            (1 : ∀ i, Matrix (α i) (α i) ℂ) := by
-        funext i
-        simpa only [Finset.sum_apply, Pi.one_apply] using
-          Fintype.sum_pi_single i fun j ↦ (1 : Matrix (α j) (α j) ℂ)
-      rw [hfamily]
-      change Matrix.blockDiagonal' (1 : ∀ i, Matrix (α i) (α i) ℂ) = 1
-      exact Matrix.blockDiagonal'_one
-    exact (Equiv.sum_comp e.symm fun p : Σ i, Fin (r i) ↦
-      (singleBlock p.1 (A p.1 p.2))ᴴ * singleBlock p.1 (A p.1 p.2)).trans hsum
-
+  apply rectangularKrausMap_isKrausCPTP
+  change (∑ p : Σ i, Fin (r i),
+    (singleBlock p.1 (A p.1 p.2))ᴴ * singleBlock p.1 (A p.1 p.2)) = 1
+  rw [Fintype.sum_sigma]
+  simp_rw [singleBlock_conjTranspose_mul]
+  have hinner (i : ι) :
+      (∑ j, Matrix.blockDiagonal' (Pi.single i ((A i j)ᴴ * A i j))) =
+        Matrix.blockDiagonal' (Pi.single i (∑ j, (A i j)ᴴ * A i j)) := by
+    change (∑ j, (Matrix.blockDiagonal'AddMonoidHom α α ℂ)
+      (Pi.single i ((A i j)ᴴ * A i j))) =
+        (Matrix.blockDiagonal'AddMonoidHom α α ℂ)
+          (Pi.single i (∑ j, (A i j)ᴴ * A i j))
+    rw [← map_sum (Matrix.blockDiagonal'AddMonoidHom α α ℂ)]
+    congr 1
+    funext k
+    by_cases hki : k = i
+    · subst k
+      simp
+    · simp [hki]
+  simp_rw [hinner, htp]
+  change (∑ i, (Matrix.blockDiagonal'AddMonoidHom α α ℂ)
+    (Pi.single i (1 : Matrix (α i) (α i) ℂ))) = 1
+  rw [← map_sum (Matrix.blockDiagonal'AddMonoidHom α α ℂ)]
+  have hfamily :
+      (∑ i, Pi.single i (1 : Matrix (α i) (α i) ℂ)) =
+        (1 : ∀ i, Matrix (α i) (α i) ℂ) := by
+    funext i
+    simpa only [Finset.sum_apply, Pi.one_apply] using
+      Fintype.sum_pi_single i fun j ↦ (1 : Matrix (α j) (α j) ℂ)
+  rw [hfamily]
+  change Matrix.blockDiagonal' (1 : ∀ i, Matrix (α i) (α i) ℂ) = 1
+  exact Matrix.blockDiagonal'_one
 end ControlledDirectSum
 
 private def partialTraceRightKraus
@@ -506,50 +508,36 @@ lemma partialTraceRightLM_isKrausCPTP
     {α β : Type*} [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β] :
     IsKrausCPTP (partialTraceRightLM (α := α) (β := β)) := by
   classical
-  let e := (Fintype.equivFin β).symm
-  refine ⟨Fintype.card β,
-    fun k => partialTraceRightKraus (α := α) (β := β) (e k), ?_, ?_⟩
-  · intro X
+  have hmap :
+      rectangularKrausMap (partialTraceRightKraus (α := α) (β := β)) =
+        partialTraceRightLM := by
+    apply LinearMap.ext
+    intro X
     ext i j
-    change (∑ k : β, X (i, k) (j, k)) =
-      (∑ c : Fin (Fintype.card β),
-        partialTraceRightKraus (α := α) (β := β) (e c) * X *
-          (partialTraceRightKraus (α := α) (β := β) (e c))ᴴ) i j
+    change
+      (∑ k : β, partialTraceRightKraus (α := α) (β := β) k * X *
+        (partialTraceRightKraus (α := α) (β := β) k)ᴴ) i j =
+        ∑ k : β, X (i, k) (j, k)
     rw [Matrix.sum_apply]
-    calc
-      ∑ k : β, X (i, k) (j, k) =
-          ∑ c : Fin (Fintype.card β), X (i, e c) (j, e c) :=
-        (Equiv.sum_comp e (fun k : β => X (i, k) (j, k))).symm
-      _ = _ := Finset.sum_congr rfl fun c _ =>
-        (partialTraceRightKraus_mul_conjTranspose_apply X (e c) i j).symm
-  · change (∑ c : Fin (Fintype.card β),
-      (partialTraceRightKraus (α := α) (β := β) (e c))ᴴ *
-        partialTraceRightKraus (α := α) (β := β) (e c)) = 1
-    calc
-      _ = ∑ k : β, (partialTraceRightKraus (α := α) (β := β) k)ᴴ *
-          partialTraceRightKraus (α := α) (β := β) k :=
-        Equiv.sum_comp e (fun k : β =>
-          (partialTraceRightKraus (α := α) (β := β) k)ᴴ *
-            partialTraceRightKraus (α := α) (β := β) k)
-      _ = 1 := by
-        ext p q
-        by_cases hpq : p = q
-        · subst q
-          rw [Matrix.sum_apply, Matrix.one_apply_eq]
-          rw [Finset.sum_eq_single p.2]
-          · simp [partialTraceRightKraus_conjTranspose_mul_apply]
-          · intro k _ hk
-            simp [partialTraceRightKraus_conjTranspose_mul_apply, hk]
-          · intro hmem
-            simp at hmem
-        · rw [Matrix.sum_apply, Matrix.one_apply_ne hpq]
-          apply Finset.sum_eq_zero
-          intro k _
-          have hnot : ¬ (p.1 = q.1 ∧ k = p.2 ∧ k = q.2) := by
-            intro h
-            apply hpq
-            exact Prod.ext h.1 (h.2.1.symm.trans h.2.2)
-          simp [partialTraceRightKraus_conjTranspose_mul_apply, hnot]
+    exact Finset.sum_congr rfl fun k _ =>
+      partialTraceRightKraus_mul_conjTranspose_apply X k i j
+  rw [← hmap]
+  apply rectangularKrausMap_isKrausCPTP
+  ext p q
+  by_cases hpq : p = q
+  · subst q
+    rw [Matrix.sum_apply, Matrix.one_apply_eq, Finset.sum_eq_single p.2]
+    · simp [partialTraceRightKraus_conjTranspose_mul_apply]
+    · intro k _ hk
+      simp [partialTraceRightKraus_conjTranspose_mul_apply, hk]
+    · simp
+  · rw [Matrix.sum_apply, Matrix.one_apply_ne hpq]
+    apply Finset.sum_eq_zero
+    intro k _
+    have hnot : ¬ (p.1 = q.1 ∧ k = p.2 ∧ k = q.2) := by
+      rintro ⟨h₁, h₂, h₃⟩
+      exact hpq (Prod.ext h₁ (h₂.symm.trans h₃))
+    simp [partialTraceRightKraus_conjTranspose_mul_apply, hnot]
 
 private noncomputable def chosenKrausRank
     {α β : Type*} [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]
@@ -712,15 +700,12 @@ theorem rectangularKrausMap_preparationKraus_eq
   refine Finset.sum_congr rfl fun j _ => ?_
   rw [preparationKraus_mul_conjTranspose_apply, hRherm.apply]
 
-/-- The explicit preparation Kraus family resolves the identity,
-$\sum_j A_j^\dagger A_j=I$, when the prepared matrix has trace one. -/
-theorem preparationKraus_resolution
+private theorem preparationKraus_sum_conjTranspose_mul
     {α β : Type*} [Fintype α] [DecidableEq α]
     [Fintype β] [DecidableEq β] (ρ : Matrix β β ℂ) (hρ : ρ.PosSemidef)
     (hρtr : ρ.trace = 1) :
-    ∑ j : Fin (Fintype.card β),
-      (preparationKraus (α := α) ρ hρ ((Fintype.equivFin β).symm j))ᴴ *
-        preparationKraus (α := α) ρ hρ ((Fintype.equivFin β).symm j) = 1 := by
+    ∑ j : β, (preparationKraus (α := α) ρ hρ j)ᴴ *
+      preparationKraus (α := α) ρ hρ j = 1 := by
   classical
   let R := hρ.isHermitian.cfc Real.sqrt
   have hRherm : R.IsHermitian := hρ.cfc_sqrt_isHermitian
@@ -736,16 +721,23 @@ theorem preparationKraus_resolution
   by_cases hab : a = b
   · subst b
     rw [Matrix.one_apply_eq, Matrix.sum_apply]
-    simp_rw [preparationKraus_conjTranspose_mul_apply, if_pos]
-    change (∑ x : Fin (Fintype.card β),
-      ∑ t : β, star (R t ((Fintype.equivFin β).symm x)) *
-        R t ((Fintype.equivFin β).symm x)) = 1
-    exact (Equiv.sum_comp (Fintype.equivFin β).symm
-      (fun j : β => ∑ t : β, star (R t j) * R t j)).trans hsum
+    simpa only [preparationKraus_conjTranspose_mul_apply, if_pos] using hsum
   · rw [Matrix.one_apply_ne hab, Matrix.sum_apply]
-    apply Finset.sum_eq_zero
-    intro j _
-    rw [preparationKraus_conjTranspose_mul_apply, if_neg hab]
+    exact Finset.sum_eq_zero fun j _ => by
+      rw [preparationKraus_conjTranspose_mul_apply, if_neg hab]
+
+/-- The explicit preparation Kraus family resolves the identity,
+$\sum_j A_j^\dagger A_j=I$, when the prepared matrix has trace one. -/
+theorem preparationKraus_resolution
+    {α β : Type*} [Fintype α] [DecidableEq α]
+    [Fintype β] [DecidableEq β] (ρ : Matrix β β ℂ) (hρ : ρ.PosSemidef)
+    (hρtr : ρ.trace = 1) :
+    ∑ j : Fin (Fintype.card β),
+      (preparationKraus (α := α) ρ hρ ((Fintype.equivFin β).symm j))ᴴ *
+        preparationKraus (α := α) ρ hρ ((Fintype.equivFin β).symm j) = 1 :=
+  ((Fintype.equivFin β).symm.sum_comp fun j : β =>
+    (preparationKraus (α := α) ρ hρ j)ᴴ * preparationKraus (α := α) ρ hρ j).trans
+      (preparationKraus_sum_conjTranspose_mul ρ hρ hρtr)
 
 /-- Adjoining a positive-semidefinite matrix of trace one is a
 trace-preserving completely positive map.  Its Kraus operators are obtained
@@ -758,22 +750,8 @@ lemma preparationMap_isKrausCPTP
     {α β : Type*} [Fintype α] [DecidableEq α]
     [Fintype β] [DecidableEq β] (ρ : Matrix β β ℂ) (hρ : ρ.PosSemidef)
     (hρtr : ρ.trace = 1) : IsKrausCPTP (Matrix.preparationMap (α := α) ρ) := by
-  classical
-  let R := hρ.isHermitian.cfc Real.sqrt
-  have hRherm : R.IsHermitian := hρ.cfc_sqrt_isHermitian
-  have hRR : R * R = ρ := hρ.cfc_sqrt_mul_self
-  refine ⟨Fintype.card β,
-    fun j => preparationKraus ρ hρ ((Fintype.equivFin β).symm j), ?_, ?_⟩
-  · intro X
-    ext p q
-    change X p.1 q.1 * ρ p.2 q.2 = _
-    have hRRentry : ρ p.2 q.2 = (R * R) p.2 q.2 :=
-      congrArg (fun M : Matrix β β ℂ => M p.2 q.2) hRR.symm
-    rw [hRRentry, Matrix.mul_apply, Finset.mul_sum, Matrix.sum_apply]
-    rw [← Equiv.sum_comp (Fintype.equivFin β).symm]
-    refine Finset.sum_congr rfl fun j _ => ?_
-    rw [preparationKraus_mul_conjTranspose_apply]
-    rw [hRherm.apply]
-  · exact preparationKraus_resolution ρ hρ hρtr
+  rw [← rectangularKrausMap_preparationKraus_eq ρ hρ]
+  exact rectangularKrausMap_isKrausCPTP _
+    (preparationKraus_sum_conjTranspose_mul ρ hρ hρtr)
 
 end Matrix

--- a/TNLean/MPS/MPDO/AlgebraFusionCounterexample.lean
+++ b/TNLean/MPS/MPDO/AlgebraFusionCounterexample.lean
@@ -111,11 +111,8 @@ private theorem phaseFlipTensor_transferMap_pow_fixed
     {X : Matrix (Fin 2) (Fin 2) ℂ}
     (hX : MPSTensor.transferMap phaseFlipTensor X = X) (n : ℕ) :
     (MPSTensor.transferMap phaseFlipTensor ^ n) X = X := by
-  induction n with
-  | zero =>
-      simp [Module.End.one_eq_id]
-  | succ n ih =>
-      rw [pow_succ, Module.End.mul_eq_comp, LinearMap.comp_apply, hX, ih]
+  rw [Module.End.pow_apply]
+  exact Function.IsFixedPt.iterate hX n
 
 private theorem phaseFlipTensor_transferMap_pow_fixed_iff
     {n : ℕ} (hn : 0 < n) (X : Matrix (Fin 2) (Fin 2) ℂ) :

--- a/TNLean/MPS/MPDO/AreaLaw.lean
+++ b/TNLean/MPS/MPDO/AreaLaw.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.Defs
 import TNLean.Analysis.Entropy
@@ -50,6 +51,28 @@ SAL** when `I_1 = I_2 = ⋯` (Definition 4.6, line 811). Equivalently
 
 open scoped Matrix ComplexOrder BigOperators
 open Matrix Finset
+
+/-- A function on a finite interval is constant when it agrees at each pair of
+successive indices. -/
+theorem eq_of_forall_succ_eq_of_mem_Icc {α : Sort*} {a n i j : ℕ}
+    (f : (m : ℕ) → m ≤ n → α)
+    (hstep : ∀ m, a ≤ m → (hm : m < n) → f m hm.le = f (m + 1) hm)
+    (hai : a ≤ i) (hin : i ≤ n) (haj : a ≤ j) (hjn : j ≤ n) :
+    f i hin = f j hjn := by
+  have climb : ∀ k m, a ≤ m → ∀ h : m + k ≤ n,
+      f m (Nat.le_add_right m k |>.trans h) = f (m + k) h := by
+    intro k
+    induction k with
+    | zero => intro m _ _; rfl
+    | succ k ih =>
+        intro m ham h
+        have hmk : m + k < n := by omega
+        exact (ih m ham hmk.le).trans (hstep (m + k) (by omega) hmk)
+  rcases le_total i j with hij | hji
+  · obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_le hij
+    exact climb k i hai hjn
+  · obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_le hji
+    exact (climb k j haj hin).symm
 
 /-! ## Translation invariance of the periodic MPDO
 
@@ -321,8 +344,10 @@ theorem blockReducedState_comp {d L K₁ K₂ : ℕ}
     blockReducedState d L K₁ (blockReducedState d (L + K₁) K₂ X)
       = blockReducedState d L (K₁ + K₂)
           (X.submatrix
-            (Equiv.arrowCongr (finCongr (Nat.add_assoc L K₁ K₂)) (Equiv.refl (Fin d))).symm
-            (Equiv.arrowCongr (finCongr (Nat.add_assoc L K₁ K₂)) (Equiv.refl (Fin d))).symm) := by
+            (Equiv.arrowCongr (finCongr (Nat.add_assoc L K₁ K₂))
+              (Equiv.refl (Fin d))).symm
+            (Equiv.arrowCongr (finCongr (Nat.add_assoc L K₁ K₂))
+              (Equiv.refl (Fin d))).symm) := by
   rw [blockReducedState, blockReducedState, Matrix.partialTraceRight_submatrix_left,
     Matrix.submatrix_submatrix, Matrix.partialTraceRight_partialTraceRight,
     Matrix.partialTraceRight_submatrix_right (blockSplitEquiv d K₁ K₂),
@@ -476,23 +501,9 @@ theorem mutualInfoChain_eq_of_isSAL (M : MPOTensor d D) (hSAL : IsSAL M)
   dsimp only
   let hMpdo : IsMPDO M := Classical.choose hSAL
   rcases Classical.choose_spec hSAL with ⟨_, hstep⟩
-  -- Climbing `k` steps from a block size `m` stays an equality while `m + k ≤ ⌊N/2⌋`.
-  have climb : ∀ k m : ℕ, 1 ≤ m → ∀ h : m + k ≤ N / 2,
-      mutualInfoChain M N m
-          ((Nat.le_add_right m k).trans (h.trans (Nat.div_le_self N 2))) (hMpdo N)
-        = mutualInfoChain M N (m + k) (h.trans (Nat.div_le_self N 2)) (hMpdo N) := by
-    intro k
-    induction k with
-    | zero => intro m _ _; rfl
-    | succ k ih =>
-      intro m hm1 h
-      have hmk : m + k < N / 2 := by omega
-      exact (ih m hm1 (le_of_lt hmk)).trans (hstep N (m + k) (by omega) hmk)
-  rcases le_total L L' with hle | hle
-  · obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_le hle
-    exact climb k L hL1 hL'N
-  · obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_le hle
-    exact (climb k L' hL'1 hLN).symm
+  apply eq_of_forall_succ_eq_of_mem_Icc
+    (fun m hm => mutualInfoChain M N m (hm.trans (Nat.div_le_self N 2)) (hMpdo N))
+    (fun m hm hmn => hstep N m hm hmn) hL1 hLN hL'1 hL'N
 
 end MPOTensor
 

--- a/TNLean/MPS/MPDO/BNTAssociativity.lean
+++ b/TNLean/MPS/MPDO/BNTAssociativity.lean
@@ -70,6 +70,11 @@ def EventuallyLinearIndependent (op : BNTLabelOperatorFamily Λ O)
 
 variable [Fintype Λ]
 
+private theorem coeff_eq_of_sum_smul_eq {V : Type*} [AddCommMonoid V] [Module ℂ V]
+    {v : Λ → V} (hv : LinearIndependent ℂ v) {a b : Λ → ℂ}
+    (h : ∑ i, a i • v i = ∑ i, b i • v i) (i : Λ) : a i = b i :=
+  congrFun (linearIndependent_iff_injective_fintypeLinearCombination.mp hv h) i
+
 /-- **Uniqueness of the structure coefficients** at a linearly independent
 length: two coefficient systems satisfying the same-length product law for
 the same operator family agree wherever the operators are linearly
@@ -87,13 +92,7 @@ theorem HasSameLengthProductForm.coeff_eq_of_linearIndependentAt
   have hsum : ∑ δ, c.coeff L α β δ • op.operator L δ
       = ∑ δ, c'.coeff L α β δ • op.operator L δ := by
     rw [← h L hL α β, ← h' L hL α β]
-  have hzero : ∑ δ, (c.coeff L α β δ - c'.coeff L α β δ) • op.operator L δ
-      = 0 := by
-    simp_rw [sub_smul]
-    rw [Finset.sum_sub_distrib, hsum, sub_self]
-  exact sub_eq_zero.mp <|
-    Fintype.linearIndependent_iff.mp hli
-      (fun δ => c.coeff L α β δ - c'.coeff L α β δ) hzero γ
+  exact coeff_eq_of_sum_smul_eq hli hsum γ
 
 /-- **Associativity constraint on the structure coefficients**: expanding
 the two associations of a triple product through the same-length product law
@@ -134,14 +133,7 @@ theorem HasSameLengthProductForm.coeff_assoc_of_linearIndependentAt
         = ∑ ε', (∑ δ, c.coeff L β γ δ * c.coeff L α δ ε') •
             op.operator L ε' := by
     rw [← hexp1, ← hexp2, mul_assoc]
-  have hzero : ∑ ε', ((∑ δ, c.coeff L α β δ * c.coeff L δ γ ε')
-      - (∑ δ, c.coeff L β γ δ * c.coeff L α δ ε')) • op.operator L ε' = 0 := by
-    simp_rw [sub_smul]
-    rw [Finset.sum_sub_distrib, hsum, sub_self]
-  exact sub_eq_zero.mp <|
-    Fintype.linearIndependent_iff.mp hli
-      (fun ε' => (∑ δ, c.coeff L α β δ * c.coeff L δ γ ε') -
-        ∑ δ, c.coeff L β γ δ * c.coeff L α δ ε') hzero ε
+  exact coeff_eq_of_sum_smul_eq hli hsum ε
 
 /-- Trace-power form of the associativity constraint: for a coefficient
 system in trace-power form, the restriction of the preceding theorem is a

--- a/TNLean/MPS/MPDO/BNTCoefficients.lean
+++ b/TNLean/MPS/MPDO/BNTCoefficients.lean
@@ -146,9 +146,8 @@ Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
 Appendix C.4, lines 2015--2037 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 lemma ofChi_hasPositiveLengthChiTracePowerForm (χ : DiagonalChiFamily Λ) :
-    (ofChi χ).HasPositiveLengthChiTracePowerForm χ := by
-  intro L _hL α β γ
-  rfl
+    (ofChi χ).HasPositiveLengthChiTracePowerForm χ :=
+  fun _ _ _ _ _ => rfl
 
 end BNTLabelCoefficientFamily
 
@@ -466,10 +465,8 @@ theorem HasSameLengthProductForm.eq_sum_chi_trace_pow [Fintype Λ]
     (L : ℕ) (hL : 0 < L) (α β : Λ) :
     op.operator L α * op.operator L β =
       ∑ γ : Λ, (hχ.chi.matrix α β γ ^ L).trace • op.operator L γ := by
-  rw [BNTLabelOperatorFamily.HasSameLengthProductForm.eq_sum (op := op) hop L hL α β]
-  refine Finset.sum_congr rfl ?_
-  intro γ _hγ
-  rw [hχ.eq_trace_pow L hL α β γ]
+  simpa only [hχ.eq_trace_pow L hL] using
+    BNTLabelOperatorFamily.HasSameLengthProductForm.eq_sum (op := op) hop L hL α β
 
 /-- The same-length BNT product formula for the canonical coefficient family
 associated to a \(\chi\)-family, written directly with trace-power
@@ -487,10 +484,8 @@ theorem HasSameLengthProductForm.eq_sum_ofChi_trace_pow [Fintype Λ]
     (L : ℕ) (hL : 0 < L) (α β : Λ) :
     op.operator L α * op.operator L β =
       ∑ γ : Λ, (χ.matrix α β γ ^ L).trace • op.operator L γ := by
-  rw [BNTLabelOperatorFamily.HasSameLengthProductForm.eq_sum (op := op) hop L hL α β]
-  refine Finset.sum_congr rfl ?_
-  intro γ _hγ
-  rw [BNTLabelCoefficientFamily.ofChi_coeff_eq_trace_matrix_pow]
+  simpa only [BNTLabelCoefficientFamily.ofChi_coeff_eq_trace_matrix_pow] using
+    BNTLabelOperatorFamily.HasSameLengthProductForm.eq_sum (op := op) hop L hL α β
 
 end BNTLabelOperatorFamily
 
@@ -511,13 +506,8 @@ theorem HasIdempotentCoefficientForm.eq_sum_chi_trace [Fintype Λ]
     m.traceScalar γ =
       ∑ α : Λ, ∑ β : Λ,
         (hχ.chi.matrix α β γ).trace * (m.traceScalar α * m.traceScalar β) := by
-  rw [BNTLabelTraceScalarFamily.HasIdempotentCoefficientForm.eq_sum (m := m) hm γ]
-  refine Finset.sum_congr rfl ?_
-  intro α _hα
-  refine Finset.sum_congr rfl ?_
-  intro β _hβ
-  rw [hχ.eq_trace_pow 1 Nat.zero_lt_one α β γ]
-  simp
+  simpa only [hχ.eq_trace_pow 1 Nat.zero_lt_one, pow_one] using
+    BNTLabelTraceScalarFamily.HasIdempotentCoefficientForm.eq_sum (m := m) hm γ
 
 /-- The BNT idempotent scalar identity for the canonical coefficient family
 associated to a \(\chi\)-family, written directly with length-one traces.
@@ -533,13 +523,8 @@ theorem HasIdempotentCoefficientForm.eq_sum_ofChi_trace [Fintype Λ]
     m.traceScalar γ =
       ∑ α : Λ, ∑ β : Λ,
         (χ.matrix α β γ).trace * (m.traceScalar α * m.traceScalar β) := by
-  rw [BNTLabelTraceScalarFamily.HasIdempotentCoefficientForm.eq_sum (m := m) hm γ]
-  refine Finset.sum_congr rfl ?_
-  intro α _hα
-  refine Finset.sum_congr rfl ?_
-  intro β _hβ
-  rw [BNTLabelCoefficientFamily.ofChi_coeff_eq_trace_matrix_pow]
-  simp
+  simpa only [BNTLabelCoefficientFamily.ofChi_coeff_eq_trace_matrix_pow, pow_one] using
+    BNTLabelTraceScalarFamily.HasIdempotentCoefficientForm.eq_sum (m := m) hm γ
 
 end BNTLabelTraceScalarFamily
 

--- a/TNLean/MPS/MPDO/BNTFinalSectorFusion.lean
+++ b/TNLean/MPS/MPDO/BNTFinalSectorFusion.lean
@@ -233,14 +233,7 @@ theorem leftFinalFusion_apply (α β γ ε : Λ) (i k : Fin p) :
   let r := Fam.leftFinalRow α β γ ε
   let X := (mulTensor (mulTensor (Fam.tensor α) (Fam.tensor β)) (Fam.tensor γ)) i k
   change U.submatrix r id * X * (U.submatrix r id)ᴴ = _
-  have step1 : U.submatrix r id * X = (U * X).submatrix r id :=
-    (Matrix.submatrix_mul U X r id id Function.bijective_id).symm
-  rw [step1]
-  have step2 : (U * X).submatrix r id * (U.submatrix r id)ᴴ =
-      (U * X * Uᴴ).submatrix r r := by
-    rw [Matrix.conjTranspose_submatrix]
-    exact (Matrix.submatrix_mul (U * X) Uᴴ r id r Function.bijective_id).symm
-  rw [step2]
+  rw [Matrix.submatrix_left_conj_equiv]
   dsimp only [U, X]
   rw [Fam.leftFusion_apply]
   ext ⟨δ, μ, ν, b⟩ ⟨δ', μ', ν', b'⟩
@@ -270,14 +263,7 @@ theorem rightFinalFusion_apply (α β γ ε : Λ) (i k : Fin p) :
   let r := Fam.rightFinalRow α β γ ε
   let X := (mulTensor (Fam.tensor α) (mulTensor (Fam.tensor β) (Fam.tensor γ))) i k
   change U.submatrix r id * X * (U.submatrix r id)ᴴ = _
-  have step1 : U.submatrix r id * X = (U * X).submatrix r id :=
-    (Matrix.submatrix_mul U X r id id Function.bijective_id).symm
-  rw [step1]
-  have step2 : (U * X).submatrix r id * (U.submatrix r id)ᴴ =
-      (U * X * Uᴴ).submatrix r r := by
-    rw [Matrix.conjTranspose_submatrix]
-    exact (Matrix.submatrix_mul (U * X) Uᴴ r id r Function.bijective_id).symm
-  rw [step2]
+  rw [Matrix.submatrix_left_conj_equiv]
   dsimp only [U, X]
   rw [Fam.rightFusion_apply]
   ext ⟨δ, μ, ν, b⟩ ⟨δ', μ', ν', b'⟩

--- a/TNLean/MPS/MPDO/BNTFinalSectorFusion.lean
+++ b/TNLean/MPS/MPDO/BNTFinalSectorFusion.lean
@@ -233,7 +233,14 @@ theorem leftFinalFusion_apply (α β γ ε : Λ) (i k : Fin p) :
   let r := Fam.leftFinalRow α β γ ε
   let X := (mulTensor (mulTensor (Fam.tensor α) (Fam.tensor β)) (Fam.tensor γ)) i k
   change U.submatrix r id * X * (U.submatrix r id)ᴴ = _
-  rw [Matrix.submatrix_left_conj_equiv]
+  have hleft : U.submatrix r id * X = (U * X).submatrix r id := by
+    simpa using (Matrix.submatrix_mul U X r id id Function.bijective_id).symm
+  rw [hleft, Matrix.conjTranspose_submatrix]
+  have hright :
+      (U * X).submatrix r id * Uᴴ.submatrix id r = (U * X * Uᴴ).submatrix r r := by
+    simpa using
+      (Matrix.submatrix_mul (U * X) Uᴴ r id r Function.bijective_id).symm
+  rw [hright]
   dsimp only [U, X]
   rw [Fam.leftFusion_apply]
   ext ⟨δ, μ, ν, b⟩ ⟨δ', μ', ν', b'⟩
@@ -263,7 +270,14 @@ theorem rightFinalFusion_apply (α β γ ε : Λ) (i k : Fin p) :
   let r := Fam.rightFinalRow α β γ ε
   let X := (mulTensor (Fam.tensor α) (mulTensor (Fam.tensor β) (Fam.tensor γ))) i k
   change U.submatrix r id * X * (U.submatrix r id)ᴴ = _
-  rw [Matrix.submatrix_left_conj_equiv]
+  have hleft : U.submatrix r id * X = (U * X).submatrix r id := by
+    simpa using (Matrix.submatrix_mul U X r id id Function.bijective_id).symm
+  rw [hleft, Matrix.conjTranspose_submatrix]
+  have hright :
+      (U * X).submatrix r id * Uᴴ.submatrix id r = (U * X * Uᴴ).submatrix r r := by
+    simpa using
+      (Matrix.submatrix_mul (U * X) Uᴴ r id r Function.bijective_id).symm
+  rw [hright]
   dsimp only [U, X]
   rw [Fam.rightFusion_apply]
   ext ⟨δ, μ, ν, b⟩ ⟨δ', μ', ν', b'⟩

--- a/TNLean/MPS/MPDO/BNTFixedFinalUnitarity.lean
+++ b/TNLean/MPS/MPDO/BNTFixedFinalUnitarity.lean
@@ -111,32 +111,6 @@ theorem sigmaDiagonal_conjTranspose_mul_eq_one
     simp [hz]
   · simp
 
-private theorem mul_conjTranspose_eq_one_of_kronecker_one
-    {m n : Type*} [DecidableEq m] [Fintype n]
-    {D : ℕ} (hD : 0 < D)
-    (F : Matrix m n ℂ)
-    (hF : (F ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ)) *
-      (F ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ))ᴴ = 1) :
-    F * Fᴴ = 1 := by
-  let b : Fin D := ⟨0, hD⟩
-  ext i j
-  have hentry := congrArg (fun M => M (i, b) (j, b)) hF
-  simpa [Matrix.conjTranspose_kronecker, ← Matrix.mul_kronecker_mul,
-    Matrix.one_apply, b] using hentry
-
-private theorem conjTranspose_mul_eq_one_of_kronecker_one
-    {m n : Type*} [Fintype m] [DecidableEq n]
-    {D : ℕ} (hD : 0 < D)
-    (F : Matrix m n ℂ)
-    (hF : (F ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ))ᴴ *
-      (F ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ)) = 1) :
-    Fᴴ * F = 1 := by
-  let b : Fin D := ⟨0, hD⟩
-  ext i j
-  have hentry := congrArg (fun M => M (i, b) (j, b)) hF
-  simpa [Matrix.conjTranspose_kronecker, ← Matrix.mul_kronecker_mul,
-    Matrix.one_apply, b] using hentry
-
 end Matrix
 
 namespace MPOTensor.BNTFusionIsometryFamily

--- a/TNLean/MPS/MPDO/BNTFusionIsometries.lean
+++ b/TNLean/MPS/MPDO/BNTFusionIsometries.lean
@@ -88,8 +88,11 @@ conjugation. -/
 theorem submatrix_left_conj_equiv {l m u : Type*} [Fintype l] (A : Matrix m l ℂ)
     (r : u ≃ m) (X : Matrix l l ℂ) :
     A.submatrix r id * X * (A.submatrix r id)ᴴ = (A * X * Aᴴ).submatrix r r := by
-  rw [← submatrix_mul A X r id id Function.bijective_id, conjTranspose_submatrix,
-    ← submatrix_mul (A * X) Aᴴ r id r Function.bijective_id]
+  have hleft : A.submatrix r id * X = (A * X).submatrix r id :=
+    (submatrix_mul A X r id id Function.bijective_id).symm
+  rw [hleft]
+  rw [conjTranspose_submatrix]
+  exact (submatrix_mul (A * X) Aᴴ r id r Function.bijective_id).symm
 
 end Matrix
 

--- a/TNLean/MPS/MPDO/BNTFusionIsometries.lean
+++ b/TNLean/MPS/MPDO/BNTFusionIsometries.lean
@@ -72,6 +72,27 @@ the Appendix C.3--C.4 obligation recorded in
 open scoped Matrix BigOperators ComplexOrder Kronecker
 open Matrix
 
+namespace Matrix
+
+/-- Conjugating a dependent block-diagonal matrix by another dependent block-diagonal matrix
+acts blockwise. -/
+theorem blockDiagonal'_conj {ι : Type*} [Fintype ι] [DecidableEq ι]
+    {m n : ι → Type*} [∀ i, Fintype (n i)] (F : ∀ i, Matrix (m i) (n i) ℂ)
+    (G : ∀ i, Matrix (n i) (n i) ℂ) :
+    blockDiagonal' F * blockDiagonal' G * (blockDiagonal' F)ᴴ =
+      blockDiagonal' fun i => F i * G i * (F i)ᴴ := by
+  rw [blockDiagonal'_conjTranspose, ← blockDiagonal'_mul, ← blockDiagonal'_mul]
+
+/-- Reindexing the row space of a conjugating matrix by an equivalence commutes with
+conjugation. -/
+theorem submatrix_left_conj_equiv {l m u : Type*} [Fintype l] (A : Matrix m l ℂ)
+    (r : u ≃ m) (X : Matrix l l ℂ) :
+    A.submatrix r id * X * (A.submatrix r id)ᴴ = (A * X * Aᴴ).submatrix r r := by
+  rw [← submatrix_mul A X r id id Function.bijective_id, conjTranspose_submatrix,
+    ← submatrix_mul (A * X) Aᴴ r id r Function.bijective_id]
+
+end Matrix
+
 namespace MPOTensor
 
 /-- The fusion-isometry family of arXiv:1606.00608, Theorem IV.13(iii),

--- a/TNLean/MPS/MPDO/BNTLeftTripleFusion.lean
+++ b/TNLean/MPS/MPDO/BNTLeftTripleFusion.lean
@@ -41,17 +41,6 @@ open Matrix
 
 namespace MPOTensor
 
-/-- Conjugating a block-diagonal matrix by another block-diagonal matrix acts block by block.
-
-Source: bookkeeping lemma, not paper-specific. -/
-private theorem blockDiagonal'_conj {ι : Type*} [Fintype ι] [DecidableEq ι]
-    {m' n' : ι → Type*} [∀ i, Fintype (n' i)]
-    (F : ∀ i, Matrix (m' i) (n' i) ℂ) (G : ∀ i, Matrix (n' i) (n' i) ℂ) :
-    Matrix.blockDiagonal' F * Matrix.blockDiagonal' G * (Matrix.blockDiagonal' F)ᴴ =
-      Matrix.blockDiagonal' fun i => F i * G i * (F i)ᴴ := by
-  rw [Matrix.blockDiagonal'_conjTranspose, ← Matrix.blockDiagonal'_mul,
-    ← Matrix.blockDiagonal'_mul]
-
 /-- A sum, over the physical index `j`, of Kronecker products with a fixed left spectator factor
 `X` reassociates against `finProdFinEquiv` and `Equiv.prodAssoc` to exhibit the sum as `X` tensored
 with the corresponding letter of the product tensor `mulTensor Y Z`. The reindexing equivalence
@@ -78,22 +67,6 @@ private theorem kronecker_sum_mulTensor {p a bd1 bd2 : ℕ} (X : Matrix (Fin a) 
   rw [Finset.mul_sum]
   refine Finset.sum_congr rfl fun j _ => ?_
   ring
-
-/-- Reindexing only the row space of a conjugating matrix by an equivalence commutes with the
-conjugation: applying the reindexed matrix is the same as applying the original matrix and then
-reindexing the result on both sides.
-
-Source: bookkeeping lemma, not paper-specific. -/
-private theorem submatrix_left_conj {l m u : Type*} [Fintype l] (A : Matrix m l ℂ)
-    (r : u ≃ m) (X : Matrix l l ℂ) :
-    (A.submatrix r id) * X * (A.submatrix r id)ᴴ = (A * X * Aᴴ).submatrix r r := by
-  have step1 : A.submatrix r id * X = (A * X).submatrix r id :=
-    (Matrix.submatrix_mul A X r id id Function.bijective_id).symm
-  have step2 : (A * X).submatrix r id * (A.submatrix r id)ᴴ =
-      (A * X * Aᴴ).submatrix r r := by
-    rw [Matrix.conjTranspose_submatrix]
-    exact (Matrix.submatrix_mul (A * X) Aᴴ r id r Function.bijective_id).symm
-  rw [step1, step2]
 
 namespace BNTFusionIsometryFamily
 
@@ -333,10 +306,12 @@ theorem stays within the source's own objects and records one concrete conjugati
 such an equation would relate to the corresponding identity for the right bracketing
 `M_α (M_β M_γ)`; that comparison is left to a follow-up.
 
-The block content is stated as `χ_{α,β,δ} ⊗ (χ_{δ,γ,ε} ⊗ tensor_ε^{ij})`, right-associated in
-the Kronecker product, rather than the left-associated
-`(χ_{α,β,δ} ⊗ χ_{δ,γ,ε}) ⊗ tensor_ε^{ij}`: a harmless reassociation of the same three factors in
-the same order, forced by the natural bond splitting of `mulTensor`.
+The block content is stated as
+`χ_{α,β,δ} ⊗ (χ_{δ,γ,ε} ⊗ tensor_ε^{ij})`, right-associated in the Kronecker product,
+rather than the left-associated `(χ_{α,β,δ} ⊗ χ_{δ,γ,ε}) ⊗ tensor_ε^{ij}`. This is a
+harmless reassociation of the same three factors in the same order, forced by the natural bond
+splitting
+of `mulTensor`.
 
 Source: arXiv:1606.00608, Theorem IV.13(iii), lines 986--993, and the associativity remark, lines
 995--999, of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
@@ -347,7 +322,7 @@ theorem leftFusion_apply (α β γ : Λ) (i k : Fin p) :
       Matrix.blockDiagonal' fun δ => Matrix.blockDiagonal' fun ε =>
         Fam.chi.matrix α β δ ⊗ₖ (Fam.chi.matrix δ γ ε ⊗ₖ Fam.tensor ε i k) := by
   unfold leftFusionIsometry
-  rw [submatrix_left_conj]
+  rw [Matrix.submatrix_left_conj_equiv]
   have hreassoc :
       Matrix.blockDiagonal' (Fam.blockPiece α β γ) * Fam.fuseFirstTwoStep α β γ *
           (mulTensor (mulTensor (Fam.tensor α) (Fam.tensor β)) (Fam.tensor γ)) i k *
@@ -359,7 +334,8 @@ theorem leftFusion_apply (α β γ : Λ) (i k : Fin p) :
           (Matrix.blockDiagonal' (Fam.blockPiece α β γ))ᴴ := by
     rw [Matrix.conjTranspose_mul]
     simp only [Matrix.mul_assoc]
-  rw [hreassoc, Fam.fuseFirstTwoStep_apply, Fam.pairBond_sum_blockDiagonal, blockDiagonal'_conj]
+  rw [hreassoc, Fam.fuseFirstTwoStep_apply, Fam.pairBond_sum_blockDiagonal,
+    Matrix.blockDiagonal'_conj]
   simp_rw [Fam.blockPiece_apply]
   rw [tripleFlatten_blockDiagonal']
 

--- a/TNLean/MPS/MPDO/BNTMultiplicityNormalization.lean
+++ b/TNLean/MPS/MPDO/BNTMultiplicityNormalization.lean
@@ -151,18 +151,9 @@ noncomputable def ofEventuallyEqualPowerSums
         (twoDim γ) (Fintype.card I) (twoEntry γ)
         (fun i => productEntry (e i)) hTwoNe (fun i => hProductNe (e i))
         (fun L _ _ => hAll L)).2
-    have hMap :
-        Multiset.map e (Finset.univ : Finset (Fin (Fintype.card I))).val =
-          (Finset.univ : Finset I).val :=
-      Multiset.map_univ_val_equiv e
-    rw [show Finset.univ.val.map (fun i => productEntry (e i)) =
-        Finset.univ.val.map productEntry by
-      calc
-        Finset.univ.val.map (fun i => productEntry (e i)) =
-            (Finset.univ.val.map e).map productEntry :=
-          (Multiset.map_map productEntry e Finset.univ.val).symm
-        _ = Finset.univ.val.map productEntry := by
-          rw [hMap]] at hMultiset
+    change Finset.univ.val.map (twoEntry γ) =
+      Finset.univ.val.map (productEntry ∘ e) at hMultiset
+    rw [← Multiset.map_map, Multiset.map_univ_val_equiv] at hMultiset
     exact hMultiset
 
 /-- Summing the sectorwise multiplicity-spectrum comparison gives the
@@ -229,10 +220,9 @@ theorem twoTrace_eq_traceScalar
     (hIdempotent :
       m.HasIdempotentCoefficientForm (BNTLabelCoefficientFamily.ofChi χ))
     (γ : Λ) :
-    ∑ r, C.twoEntry γ r = m.traceScalar γ := by
-  rw [C.sum_twoEntry_eq_sum_products, C.sum_products_eq]
-  symm
-  exact hIdempotent γ
+    ∑ r, C.twoEntry γ r = m.traceScalar γ :=
+  (C.sum_twoEntry_eq_sum_products γ).trans <|
+    (C.sum_products_eq γ).trans (hIdempotent γ).symm
 
 end BNTMultiplicitySpectrumComparison
 

--- a/TNLean/MPS/MPDO/BNTRightTripleFusion.lean
+++ b/TNLean/MPS/MPDO/BNTRightTripleFusion.lean
@@ -305,13 +305,7 @@ theorem rightFusion_apply (α β γ : Λ) (i k : Fin p) :
   let r := (Fam.rightTripleFlattenEquiv α β γ).symm
   let X := (mulTensor (Fam.tensor α) (mulTensor (Fam.tensor β) (Fam.tensor γ))) i k
   change A.submatrix r id * X * (A.submatrix r id)ᴴ = _
-  have step1 : A.submatrix r id * X = (A * X).submatrix r id :=
-    (Matrix.submatrix_mul A X r id id Function.bijective_id).symm
-  have step2 : (A * X).submatrix r id * (A.submatrix r id)ᴴ =
-      (A * X * Aᴴ).submatrix r r := by
-    rw [Matrix.conjTranspose_submatrix]
-    exact (Matrix.submatrix_mul (A * X) Aᴴ r id r Function.bijective_id).symm
-  rw [step1, step2]
+  rw [Matrix.submatrix_left_conj_equiv]
   dsimp only [A, r, X]
   have hreassoc :
       Matrix.blockDiagonal' (Fam.rightBlockPiece α β γ) * Fam.fuseLastTwoStep α β γ *
@@ -325,11 +319,8 @@ theorem rightFusion_apply (α β γ : Λ) (i k : Fin p) :
           (Matrix.blockDiagonal' (Fam.rightBlockPiece α β γ))ᴴ := by
     rw [Matrix.conjTranspose_mul]
     simp only [Matrix.mul_assoc]
-  rw [hreassoc]
-  rw [Fam.fuseLastTwoStep_apply]
-  rw [Fam.lastPair_sum_blockDiagonal]
-  rw [Matrix.blockDiagonal'_conjTranspose, ← Matrix.blockDiagonal'_mul,
-    ← Matrix.blockDiagonal'_mul]
+  rw [hreassoc, Fam.fuseLastTwoStep_apply, Fam.lastPair_sum_blockDiagonal,
+    Matrix.blockDiagonal'_conj]
   simp_rw [Fam.rightBlockPiece_apply]
   rw [rightTripleFlatten_blockDiagonal']
 

--- a/TNLean/MPS/MPDO/BNTTheoremData.lean
+++ b/TNLean/MPS/MPDO/BNTTheoremData.lean
@@ -75,13 +75,8 @@ theorem idempotent_coefficient_form_ofChi :
     m.HasIdempotentCoefficientForm
       (BNTLabelCoefficientFamily.ofChi H.positiveChi.chi) := by
   intro γ
-  rw [H.idempotent γ]
-  apply Finset.sum_congr rfl
-  intro α _
-  apply Finset.sum_congr rfl
-  intro β _
-  rw [BNTLabelCoefficientFamily.ofChi_coeff,
-    ← H.positiveChi.tracePower 1 Nat.zero_lt_one α β γ]
+  simpa only [BNTLabelCoefficientFamily.ofChi_coeff,
+    ← H.positiveChi.tracePower 1 Nat.zero_lt_one] using H.idempotent γ
 
 end BNTAlgebraClause
 
@@ -268,11 +263,8 @@ theorem same_length_product_form_ofChi :
     H.operators.HasSameLengthProductForm
       (BNTLabelCoefficientFamily.ofChi H.positiveChi.chi) := by
   intro L hL α β
-  rw [BNTLabelOperatorFamily.HasSameLengthProductForm.eq_sum
-    (op := H.operators) H.same_length_product_form L hL α β]
-  refine Finset.sum_congr rfl ?_
-  intro γ _hγ
-  rw [H.coeff_eq_ofChi_coeff L hL α β γ]
+  simpa only [H.coeff_eq_ofChi_coeff L hL] using
+    H.same_length_product_form L hL α β
 
 /-- The same-length product equation carried by theorem data, written with the
 canonical coefficient family determined by the same

--- a/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
+++ b/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
@@ -75,6 +75,31 @@ structure SimpleMPDOLocalStructureData where
 
 namespace SimpleMPDOLocalStructureData
 
+private def ofData
+    {dA dB dC n : ℕ}
+    (rhoABC : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ)
+    (hRhoDM : rhoABC.PosSemidef ∧ rhoABC.trace = 1)
+    (hSSA : IsSSAEquality rhoABC hRhoDM.1.isHermitian)
+    (T : Matrix (Fin n) (Fin n) ℝ)
+    (hPrimitive : Matrix.IsPrimitive T)
+    (hTrace : Matrix.trace T = 1)
+    (hTraceConst : Matrix.TracePowersConstant T)
+    (rankOne : ∃ a b : Fin n → ℝ, T = Matrix.vecMulVec a b ∧ a ⬝ᵥ b = 1) :
+    SimpleMPDOLocalStructureData where
+  dA := dA
+  dB := dB
+  dC := dC
+  rhoABC := rhoABC
+  hRhoDM := hRhoDM
+  hSSA := hSSA
+  eta := sal_implies_eta_structure rhoABC hRhoDM hSSA
+  Tdim := n
+  T := T
+  hPrimitive := hPrimitive
+  hTrace := hTrace
+  hTraceConst := hTraceConst
+  rankOne := rankOne
+
 /-- Construct the local simple-MPDO structure from the Lemma C.2 and C.4
 hypotheses and the PSD-corrected Lemma C.5 rank-one criterion.
 
@@ -95,21 +120,9 @@ def ofSALZCLOfPosSemidef
     (hPSD : T.PosSemidef)
     (hTrace : Matrix.trace T = 1)
     (hTraceConst : Matrix.TracePowersConstant T) :
-    SimpleMPDOLocalStructureData where
-  dA := dA
-  dB := dB
-  dC := dC
-  rhoABC := rhoABC
-  hRhoDM := hRhoDM
-  hSSA := hSSA
-  eta := sal_implies_eta_structure rhoABC hRhoDM hSSA
-  Tdim := n
-  T := T
-  hPrimitive := hPrimitive
-  hTrace := hTrace
-  hTraceConst := hTraceConst
-  rankOne :=
-    sal_zcl_implies_rank_one_T_of_posSemidef T hPrimitive hPSD hTrace hTraceConst
+    SimpleMPDOLocalStructureData :=
+  ofData rhoABC hRhoDM hSSA T hPrimitive hTrace hTraceConst
+    (sal_zcl_implies_rank_one_T_of_posSemidef T hPrimitive hPSD hTrace hTraceConst)
 
 /-- Construct the local simple-MPDO structure from the Lemma C.2 and C.4
 hypotheses and the pairing-idempotence Lemma C.5 rank-one criterion: the
@@ -136,21 +149,9 @@ def ofSALZCLOfPairingIdempotent
     (hPrimitive : Matrix.IsPrimitive T)
     (hl : LinearIndependent ℝ data.l)
     (hTrace : Matrix.trace T = 1) :
-    SimpleMPDOLocalStructureData where
-  dA := dA
-  dB := dB
-  dC := dC
-  rhoABC := rhoABC
-  hRhoDM := hRhoDM
-  hSSA := hSSA
-  eta := sal_implies_eta_structure rhoABC hRhoDM hSSA
-  Tdim := n
-  T := T
-  hPrimitive := hPrimitive
-  hTrace := hTrace
-  hTraceConst := data.tracePowersConstant
-  rankOne :=
-    sal_zcl_implies_rank_one_T_of_pairing_idempotent T data hl hTrace
+    SimpleMPDOLocalStructureData :=
+  ofData rhoABC hRhoDM hSSA T hPrimitive hTrace data.tracePowersConstant
+    (sal_zcl_implies_rank_one_T_of_pairing_idempotent T data hl hTrace)
 
 end SimpleMPDOLocalStructureData
 end MPOTensor

--- a/TNLean/MPS/MPDO/CommutingForm.lean
+++ b/TNLean/MPS/MPDO/CommutingForm.lean
@@ -408,6 +408,7 @@ noncomputable def bondAt (data : CommutingFormData d N) (i : Fin N) :
       else 0 :=
   rfl
 
+/-- Any two translated copies of the local bond commute. -/
 theorem bondAt_comm (data : CommutingFormData d N) (i j : Fin N) :
     data.bondAt i * data.bondAt j = data.bondAt j * data.bondAt i :=
   data.bond_comm i j
@@ -508,6 +509,7 @@ theorem isGSNNCHAt_of_realizes (data : CommutingFormData d N)
 
 end CommutingFormData
 
+/-- A chain operator is GSNNCH exactly when it has a commuting-form realization. -/
 theorem isGSNNCHAt_iff_exists_commutingForm {d N : ℕ} (ρ : ChainOperator d N) :
     IsGSNNCHAt ρ ↔ ∃ data : CommutingFormData d N, data.Realizes ρ := by
   constructor
@@ -516,12 +518,14 @@ theorem isGSNNCHAt_iff_exists_commutingForm {d N : ℕ} (ρ : ChainOperator d N)
   · rintro ⟨data, hρ⟩
     exact data.isGSNNCHAt_of_realizes hρ
 
+/-- A global commuting form gives a GSNNCH witness at every chain length. -/
 theorem isGSNNCH_of_hasCommutingForm {M : MPOTensor d D}
     (hM : HasCommutingForm M) : IsGSNNCH M := by
   intro N hN
   obtain ⟨data, hdata⟩ := hM N hN
   exact data.isGSNNCHAt_of_realizes hdata
 
+/-- GSNNCH data at every chain length gives a global commuting form. -/
 theorem hasCommutingForm_of_isGSNNCH {M : MPOTensor d D}
     (hM : IsGSNNCH M) : HasCommutingForm M := fun N hN =>
   (isGSNNCHAt_iff_exists_commutingForm (mpo M N)).mp (hM N hN)
@@ -544,6 +548,7 @@ docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex. -/
 def IsGSNNCHWithZCL (M : MPOTensor d D) : Prop :=
   IsGSNNCH M ∧ IsZCL M
 
+/-- The GSNNCH-with-ZCL condition is a global commuting form together with ZCL. -/
 theorem isGSNNCHWithZCL_iff_hasCommutingForm_and_isZCL (M : MPOTensor d D) :
     IsGSNNCHWithZCL M ↔ HasCommutingForm M ∧ IsZCL M := by
   rw [IsGSNNCHWithZCL, isGSNNCH_iff_hasCommutingForm]

--- a/TNLean/MPS/MPDO/CompleteZipperFusion.lean
+++ b/TNLean/MPS/MPDO/CompleteZipperFusion.lean
@@ -156,54 +156,6 @@ def leftFinalRow (a b c d : Λ) :
       Fus.LeftTripleIndex a b c :=
   fun x => ⟨d, x⟩
 
-/-- The one-letter coefficient which selects the block with final label `d`.
-
-Source: arXiv:1511.08090, the simultaneous inverse at lines 269--277. -/
-private noncomputable def finalBlockSelector (d : Λ) (ik : Fin p × Fin p) : ℂ :=
-  ∑ x : Fin (Fus.bondDim d), Fus.blockLeftInverse ⟨d, x, x⟩ ik
-
-private theorem finalBlockSelector_apply (d e : Λ)
-    (x y : Fin (Fus.bondDim e)) :
-    (∑ i : Fin p, ∑ k : Fin p,
-      Fus.finalBlockSelector d (i, k) * Fus.tensor e i k x y) =
-      if h : d = e then if _ : h ▸ x = y then 1 else 0 else 0 := by
-  classical
-  simp only [finalBlockSelector, Finset.sum_mul]
-  calc
-    (∑ i : Fin p, ∑ k : Fin p, ∑ z : Fin (Fus.bondDim d),
-        Fus.blockLeftInverse ⟨d, z, z⟩ (i, k) * Fus.tensor e i k x y) =
-        ∑ z : Fin (Fus.bondDim d), ∑ i : Fin p, ∑ k : Fin p,
-          Fus.blockLeftInverse ⟨d, z, z⟩ (i, k) * Fus.tensor e i k x y := by
-      calc
-        _ = ∑ i : Fin p, ∑ z : Fin (Fus.bondDim d), ∑ k : Fin p,
-            Fus.blockLeftInverse ⟨d, z, z⟩ (i, k) * Fus.tensor e i k x y := by
-          apply Finset.sum_congr rfl
-          intro i hi
-          exact Finset.sum_comm
-        _ = _ := Finset.sum_comm
-    _ = if h : d = e then if _ : h ▸ x = y then 1 else 0 else 0 := by
-      by_cases h : d = e
-      · subst e
-        simp_rw [Fus.blockLeftInverse_apply d d]
-        simp
-      · simp_rw [Fus.blockLeftInverse_apply d e]
-        simp [h]
-
-private theorem finalBlockSelector_sum (d e : Λ) :
-    (∑ i : Fin p, ∑ k : Fin p,
-      Fus.finalBlockSelector d (i, k) •
-        (Fus.tensor e i k : Matrix (Fin (Fus.bondDim e))
-          (Fin (Fus.bondDim e)) ℂ)) =
-      if d = e then 1 else 0 := by
-  classical
-  funext x y
-  simp only [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
-  rw [Fus.finalBlockSelector_apply d e x y]
-  by_cases h : d = e
-  · subst e
-    simp [Matrix.one_apply]
-  · simp [h]
-
 private theorem rectangularIntertwiner_eq_zero (d e : Λ) (hde : d ≠ e)
     (C : Matrix (Fin (Fus.bondDim d)) (Fin (Fus.bondDim e)) ℂ)
     (hC : ∀ (i k : Fin p), Fus.tensor d i k * C = C * Fus.tensor e i k) :

--- a/TNLean/MPS/MPDO/CompleteZipperFusionInverse.lean
+++ b/TNLean/MPS/MPDO/CompleteZipperFusionInverse.lean
@@ -128,21 +128,10 @@ private theorem inverseCorner_eq_kronecker_one (a b c d : Λ) :
         (1 : Matrix (Fin (Fus.bondDim d)) (Fin (Fus.bondDim d)) ℂ) :=
   Classical.choose_spec (Fus.exists_inverseCorner_eq_kronecker_one a b c d)
 
-private theorem multiplicity_mul_eq_one_of_amplification
-    {m n : Type*} [Fintype n] [DecidableEq m] {D : ℕ} (hD : 0 < D)
-    (F : Matrix m n ℂ) (G : Matrix n m ℂ)
-    (h : (F ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ)) *
-      (G ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ)) = 1) :
-    F * G = 1 := by
-  let z : Fin D := ⟨0, hD⟩
-  funext x y
-  have hEntry := congrArg (fun M => M (x, z) (y, z)) h
-  simpa [← Matrix.mul_kronecker_mul, Matrix.one_apply, z] using hEntry
-
 /-- The printed matrix followed by the opposite comparison is the identity. -/
 theorem printedFMatrix_mul_inversePrintedFMatrix (a b c d : Λ) :
     Fus.printedFMatrix a b c d * Fus.inversePrintedFMatrix a b c d = 1 := by
-  apply multiplicity_mul_eq_one_of_amplification (Fus.bondDim_pos d)
+  apply Matrix.mul_eq_one_of_kronecker_one (Fus.bondDim_pos d)
   change (Fus.printedFMatrix a b c d ⊗ₖ
       (1 : Matrix (Fin (Fus.bondDim d)) (Fin (Fus.bondDim d)) ℂ)) *
       (Fus.inversePrintedFMatrix a b c d ⊗ₖ
@@ -200,7 +189,7 @@ theorem printedFMatrix_mul_inversePrintedFMatrix (a b c d : Λ) :
 /-- The opposite comparison followed by the printed matrix is the identity. -/
 theorem inversePrintedFMatrix_mul_printedFMatrix (a b c d : Λ) :
     Fus.inversePrintedFMatrix a b c d * Fus.printedFMatrix a b c d = 1 := by
-  apply multiplicity_mul_eq_one_of_amplification (Fus.bondDim_pos d)
+  apply Matrix.mul_eq_one_of_kronecker_one (Fus.bondDim_pos d)
   change (Fus.inversePrintedFMatrix a b c d ⊗ₖ
       (1 : Matrix (Fin (Fus.bondDim d)) (Fin (Fus.bondDim d)) ℂ)) *
       (Fus.printedFMatrix a b c d ⊗ₖ

--- a/TNLean/MPS/MPDO/CompleteZipperFusionPentagon.lean
+++ b/TNLean/MPS/MPDO/CompleteZipperFusionPentagon.lean
@@ -327,13 +327,13 @@ noncomputable def twoEdgeInversePrintedFMatrix (a b c d e : Λ) :
   Fus.pairToLeftAssocInversePrintedFMatrix a b c d e *
     Fus.rightAssocToPairInversePrintedFMatrix a b c d e
 
-private theorem mul_kronecker_one {l m n : Type*} [Fintype m]
-    (A : Matrix l m ℂ) (B : Matrix m n ℂ) (D : ℕ) :
-    (A * B) ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ) =
-      (A ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ)) *
-        (B ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ)) := by
-  simpa only [Matrix.one_mul] using Matrix.mul_kronecker_mul A B
-    (1 : Matrix (Fin D) (Fin D) ℂ) 1
+private theorem rectangular_inverse_unique {l m : Type*} [Fintype l] [Fintype m]
+    (A C : Matrix l m ℂ) (B : Matrix m l ℂ) (hAB : A * B = 1) (hBC : B * C = 1) :
+    A = C := by
+  calc
+    A = A * (B * C) := by rw [hBC, Matrix.mul_one]
+    _ = (A * B) * C := by rw [Matrix.mul_assoc]
+    _ = C := by rw [hAB, Matrix.one_mul]
 
 private theorem rightAssocToMiddleInverse_mul_middleToRightAssoc
     (a b c d e : Λ) :
@@ -820,10 +820,8 @@ theorem threeEdgePrintedFMatrix_eq_twoEdgePrintedFMatrix
               rw [Matrix.mul_assoc]
       _ = Fus.twoEdgePrintedFMatrix a b c d e ⊗ₖ I := by
             rw [Fus.rightAssocFourfoldAnalysis_mul_synthesis, Matrix.one_mul]
-  funext x y
-  let z : Fin (Fus.bondDim e) := ⟨0, Fus.bondDim_pos e⟩
-  have hEntry := congrArg (fun M => M (x, z) (y, z)) hLift
-  simpa [I, Matrix.one_apply, z] using hEntry
+  apply Matrix.kronecker_one_injective (Fus.bondDim_pos e)
+  simpa only [I] using hLift
 
 /-- The inverse-orientation composites around the fourfold associahedron
 are equal.  This is the matrix orientation printed in equation
@@ -837,65 +835,22 @@ theorem threeEdgeInversePrintedFMatrix_eq_twoEdgeInversePrintedFMatrix
   have hThreeLeft :
       Fus.threeEdgeInversePrintedFMatrix a b c d e *
         Fus.threeEdgePrintedFMatrix a b c d e = 1 := by
-    calc
-      Fus.threeEdgeInversePrintedFMatrix a b c d e *
-          Fus.threeEdgePrintedFMatrix a b c d e =
-        Fus.leftInnerToLeftAssocInversePrintedFMatrix a b c d e *
-          (Fus.middleToLeftInnerInversePrintedFMatrix a b c d e *
-            ((Fus.rightAssocToMiddleInversePrintedFMatrix a b c d e *
-                Fus.middleToRightAssocPrintedFMatrix a b c d e) *
-              Fus.leftInnerToMiddlePrintedFMatrix a b c d e) *
-            Fus.leftAssocToLeftInnerPrintedFMatrix a b c d e) := by
-              simp only [threeEdgeInversePrintedFMatrix,
-                threeEdgePrintedFMatrix, Matrix.mul_assoc]
-      _ = Fus.leftInnerToLeftAssocInversePrintedFMatrix a b c d e *
-          (Fus.middleToLeftInnerInversePrintedFMatrix a b c d e *
-            Fus.leftInnerToMiddlePrintedFMatrix a b c d e) *
-          Fus.leftAssocToLeftInnerPrintedFMatrix a b c d e := by
-            rw [Fus.rightAssocToMiddleInverse_mul_middleToRightAssoc,
-              Matrix.one_mul]
-            simp only [Matrix.mul_assoc]
-      _ = Fus.leftInnerToLeftAssocInversePrintedFMatrix a b c d e *
-          Fus.leftAssocToLeftInnerPrintedFMatrix a b c d e := by
-            rw [Fus.middleToLeftInnerInverse_mul_leftInnerToMiddle,
-              Matrix.mul_one]
-      _ = 1 := Fus.leftInnerToLeftAssocInverse_mul_leftAssocToLeftInner
-        a b c d e
+    simp only [threeEdgeInversePrintedFMatrix, threeEdgePrintedFMatrix,
+      Matrix.mul_assoc, Fus.rightAssocToMiddleInverse_mul_middleToRightAssoc,
+      Matrix.one_mul, Fus.middleToLeftInnerInverse_mul_leftInnerToMiddle,
+      Matrix.mul_one, Fus.leftInnerToLeftAssocInverse_mul_leftAssocToLeftInner]
   have hTwoRight :
       Fus.twoEdgePrintedFMatrix a b c d e *
         Fus.twoEdgeInversePrintedFMatrix a b c d e = 1 := by
-    calc
-      Fus.twoEdgePrintedFMatrix a b c d e *
-          Fus.twoEdgeInversePrintedFMatrix a b c d e =
-        Fus.pairToRightAssocPrintedFMatrix a b c d e *
-          ((Fus.leftAssocToPairPrintedFMatrix a b c d e *
-              Fus.pairToLeftAssocInversePrintedFMatrix a b c d e) *
-            Fus.rightAssocToPairInversePrintedFMatrix a b c d e) := by
-              simp only [twoEdgePrintedFMatrix,
-                twoEdgeInversePrintedFMatrix, Matrix.mul_assoc]
-      _ = Fus.pairToRightAssocPrintedFMatrix a b c d e *
-          Fus.rightAssocToPairInversePrintedFMatrix a b c d e := by
-            rw [Fus.leftAssocToPair_mul_pairToLeftAssocInverse,
-              Matrix.one_mul]
-      _ = 1 := Fus.pairToRightAssoc_mul_rightAssocToPairInverse
-        a b c d e
+    simp only [twoEdgePrintedFMatrix, twoEdgeInversePrintedFMatrix,
+      Matrix.mul_assoc, Fus.leftAssocToPair_mul_pairToLeftAssocInverse,
+      Matrix.one_mul, Fus.pairToRightAssoc_mul_rightAssocToPairInverse]
   have hThreeRight :
       Fus.threeEdgePrintedFMatrix a b c d e *
         Fus.twoEdgeInversePrintedFMatrix a b c d e = 1 := by
     rw [Fus.threeEdgePrintedFMatrix_eq_twoEdgePrintedFMatrix]
     exact hTwoRight
-  calc
-    Fus.threeEdgeInversePrintedFMatrix a b c d e =
-      Fus.threeEdgeInversePrintedFMatrix a b c d e *
-        (Fus.threeEdgePrintedFMatrix a b c d e *
-          Fus.twoEdgeInversePrintedFMatrix a b c d e) := by
-            rw [hThreeRight, Matrix.mul_one]
-    _ = (Fus.threeEdgeInversePrintedFMatrix a b c d e *
-          Fus.threeEdgePrintedFMatrix a b c d e) *
-        Fus.twoEdgeInversePrintedFMatrix a b c d e := by
-          rw [Matrix.mul_assoc]
-    _ = Fus.twoEdgeInversePrintedFMatrix a b c d e := by
-          rw [hThreeLeft, Matrix.one_mul]
+  exact rectangular_inverse_unique _ _ _ hThreeLeft hThreeRight
 
 /-- The literal indexed pentagon equation for the inverse-orientation
 `F`-matrix entries.

--- a/TNLean/MPS/MPDO/CompleteZipperFusionPentagon.lean
+++ b/TNLean/MPS/MPDO/CompleteZipperFusionPentagon.lean
@@ -327,13 +327,16 @@ noncomputable def twoEdgeInversePrintedFMatrix (a b c d e : Λ) :
   Fus.pairToLeftAssocInversePrintedFMatrix a b c d e *
     Fus.rightAssocToPairInversePrintedFMatrix a b c d e
 
-private theorem rectangular_inverse_unique {l m : Type*} [Fintype l] [Fintype m]
+private theorem rectangular_inverse_unique {l m : Type*}
+    [Fintype l] [Fintype m] [DecidableEq l] [DecidableEq m]
     (A C : Matrix l m ℂ) (B : Matrix m l ℂ) (hAB : A * B = 1) (hBC : B * C = 1) :
     A = C := by
   calc
-    A = A * (B * C) := by rw [hBC, Matrix.mul_one]
-    _ = (A * B) * C := by rw [Matrix.mul_assoc]
-    _ = C := by rw [hAB, Matrix.one_mul]
+    A = A * 1 := (Matrix.mul_one A).symm
+    _ = A * (B * C) := congrArg (A * ·) hBC.symm
+    _ = (A * B) * C := (Matrix.mul_assoc A B C).symm
+    _ = 1 * C := congrArg (· * C) hAB
+    _ = C := Matrix.one_mul C
 
 private theorem rightAssocToMiddleInverse_mul_middleToRightAssoc
     (a b c d e : Λ) :
@@ -835,16 +838,48 @@ theorem threeEdgeInversePrintedFMatrix_eq_twoEdgeInversePrintedFMatrix
   have hThreeLeft :
       Fus.threeEdgeInversePrintedFMatrix a b c d e *
         Fus.threeEdgePrintedFMatrix a b c d e = 1 := by
-    simp only [threeEdgeInversePrintedFMatrix, threeEdgePrintedFMatrix,
-      Matrix.mul_assoc, Fus.rightAssocToMiddleInverse_mul_middleToRightAssoc,
-      Matrix.one_mul, Fus.middleToLeftInnerInverse_mul_leftInnerToMiddle,
-      Matrix.mul_one, Fus.leftInnerToLeftAssocInverse_mul_leftAssocToLeftInner]
+    calc
+      Fus.threeEdgeInversePrintedFMatrix a b c d e *
+          Fus.threeEdgePrintedFMatrix a b c d e =
+        Fus.leftInnerToLeftAssocInversePrintedFMatrix a b c d e *
+          (Fus.middleToLeftInnerInversePrintedFMatrix a b c d e *
+            ((Fus.rightAssocToMiddleInversePrintedFMatrix a b c d e *
+                Fus.middleToRightAssocPrintedFMatrix a b c d e) *
+              Fus.leftInnerToMiddlePrintedFMatrix a b c d e) *
+            Fus.leftAssocToLeftInnerPrintedFMatrix a b c d e) := by
+              simp only [threeEdgeInversePrintedFMatrix,
+                threeEdgePrintedFMatrix, Matrix.mul_assoc]
+      _ = Fus.leftInnerToLeftAssocInversePrintedFMatrix a b c d e *
+          (Fus.middleToLeftInnerInversePrintedFMatrix a b c d e *
+            Fus.leftInnerToMiddlePrintedFMatrix a b c d e) *
+          Fus.leftAssocToLeftInnerPrintedFMatrix a b c d e := by
+            rw [Fus.rightAssocToMiddleInverse_mul_middleToRightAssoc,
+              Matrix.one_mul]
+            simp only [Matrix.mul_assoc]
+      _ = Fus.leftInnerToLeftAssocInversePrintedFMatrix a b c d e *
+          Fus.leftAssocToLeftInnerPrintedFMatrix a b c d e := by
+            rw [Fus.middleToLeftInnerInverse_mul_leftInnerToMiddle,
+              Matrix.mul_one]
+      _ = 1 := Fus.leftInnerToLeftAssocInverse_mul_leftAssocToLeftInner
+        a b c d e
   have hTwoRight :
       Fus.twoEdgePrintedFMatrix a b c d e *
         Fus.twoEdgeInversePrintedFMatrix a b c d e = 1 := by
-    simp only [twoEdgePrintedFMatrix, twoEdgeInversePrintedFMatrix,
-      Matrix.mul_assoc, Fus.leftAssocToPair_mul_pairToLeftAssocInverse,
-      Matrix.one_mul, Fus.pairToRightAssoc_mul_rightAssocToPairInverse]
+    calc
+      Fus.twoEdgePrintedFMatrix a b c d e *
+          Fus.twoEdgeInversePrintedFMatrix a b c d e =
+        Fus.pairToRightAssocPrintedFMatrix a b c d e *
+          ((Fus.leftAssocToPairPrintedFMatrix a b c d e *
+              Fus.pairToLeftAssocInversePrintedFMatrix a b c d e) *
+            Fus.rightAssocToPairInversePrintedFMatrix a b c d e) := by
+              simp only [twoEdgePrintedFMatrix,
+                twoEdgeInversePrintedFMatrix, Matrix.mul_assoc]
+      _ = Fus.pairToRightAssocPrintedFMatrix a b c d e *
+          Fus.rightAssocToPairInversePrintedFMatrix a b c d e := by
+            rw [Fus.leftAssocToPair_mul_pairToLeftAssocInverse,
+              Matrix.one_mul]
+      _ = 1 := Fus.pairToRightAssoc_mul_rightAssocToPairInverse
+        a b c d e
   have hThreeRight :
       Fus.threeEdgePrintedFMatrix a b c d e *
         Fus.twoEdgeInversePrintedFMatrix a b c d e = 1 := by

--- a/TNLean/MPS/MPDO/CompleteZipperFusionSupport.lean
+++ b/TNLean/MPS/MPDO/CompleteZipperFusionSupport.lean
@@ -521,20 +521,21 @@ theorem rightTripleAnalysisFull_mul_synthesis (a b c : Λ) :
     Fus.rightSecondAnalysis_mul_synthesis]
 
 
-/-- The coefficient selecting the diagonal matrix units of one final block.
+/-- The one-letter coefficient obtained by summing the diagonal matrix-unit selectors for a
+fixed final block.
 
 Source: arXiv:1511.08090, the simultaneous inverse at lines 269--277. -/
-private noncomputable def supportFinalBlockSelector
-    (d : Λ) (ik : Fin p × Fin p) : ℂ :=
+noncomputable def finalBlockSelector (d : Λ) (ik : Fin p × Fin p) : ℂ :=
   ∑ x : Fin (Fus.bondDim d), Fus.blockLeftInverse ⟨d, x, x⟩ ik
 
-private theorem supportFinalBlockSelector_apply (d e : Λ)
-    (x y : Fin (Fus.bondDim e)) :
+/-- Contracting a fixed-final-block selector with a matrix entry selects that final block and
+its diagonal entries. -/
+theorem finalBlockSelector_apply (d e : Λ) (x y : Fin (Fus.bondDim e)) :
     (∑ i : Fin p, ∑ l : Fin p,
-      Fus.supportFinalBlockSelector d (i, l) * Fus.tensor e i l x y) =
+      Fus.finalBlockSelector d (i, l) * Fus.tensor e i l x y) =
       if h : d = e then if _ : h ▸ x = y then 1 else 0 else 0 := by
   classical
-  simp only [supportFinalBlockSelector, Finset.sum_mul]
+  simp only [finalBlockSelector, Finset.sum_mul]
   calc
     (∑ i : Fin p, ∑ l : Fin p, ∑ z : Fin (Fus.bondDim d),
         Fus.blockLeftInverse ⟨d, z, z⟩ (i, l) * Fus.tensor e i l x y) =
@@ -555,16 +556,18 @@ private theorem supportFinalBlockSelector_apply (d e : Λ)
       · simp_rw [Fus.blockLeftInverse_apply d e]
         simp [h]
 
-private theorem supportFinalBlockSelector_sum (d e : Λ) :
+/-- Contracting a fixed-final-block selector with a labelled tensor gives the identity on the
+selected block and zero on every other block. -/
+theorem finalBlockSelector_sum (d e : Λ) :
     (∑ i : Fin p, ∑ l : Fin p,
-      Fus.supportFinalBlockSelector d (i, l) •
+      Fus.finalBlockSelector d (i, l) •
         (Fus.tensor e i l : Matrix (Fin (Fus.bondDim e))
           (Fin (Fus.bondDim e)) ℂ)) =
       if d = e then 1 else 0 := by
   classical
   funext x y
   simp only [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
-  rw [Fus.supportFinalBlockSelector_apply d e x y]
+  rw [Fus.finalBlockSelector_apply d e x y]
   by_cases h : d = e
   · subst e
     simp [Matrix.one_apply]
@@ -575,7 +578,7 @@ for every final label.
 
 Source: arXiv:1511.08090, the simultaneous inverse at lines 269--277. -/
 private noncomputable def totalBlockSelector (ik : Fin p × Fin p) : ℂ :=
-  ∑ d : Λ, Fus.supportFinalBlockSelector d ik
+  ∑ d : Λ, Fus.finalBlockSelector d ik
 
 /-- Contracting the total selector with any labelled block letter gives the
 identity matrix.
@@ -590,19 +593,19 @@ private theorem totalBlockSelector_sum (e : Λ) :
   simp only [totalBlockSelector, Finset.sum_smul]
   calc
     (∑ i : Fin p, ∑ l : Fin p, ∑ d : Λ,
-        Fus.supportFinalBlockSelector d (i, l) • Fus.tensor e i l) =
+        Fus.finalBlockSelector d (i, l) • Fus.tensor e i l) =
         ∑ i : Fin p, ∑ d : Λ, ∑ l : Fin p,
-          Fus.supportFinalBlockSelector d (i, l) • Fus.tensor e i l := by
+          Fus.finalBlockSelector d (i, l) • Fus.tensor e i l := by
       apply Finset.sum_congr rfl
       intro i hi
       exact Finset.sum_comm
     _ = ∑ d : Λ, ∑ i : Fin p, ∑ l : Fin p,
-          Fus.supportFinalBlockSelector d (i, l) • Fus.tensor e i l :=
+          Fus.finalBlockSelector d (i, l) • Fus.tensor e i l :=
       Finset.sum_comm
     _ = ∑ d : Λ, if d = e then 1 else 0 := by
       apply Finset.sum_congr rfl
       intro d hd
-      exact Fus.supportFinalBlockSelector_sum d e
+      exact Fus.finalBlockSelector_sum d e
     _ = 1 := by simp
 
 /-- Contracting final-block letters with the total selector gives the identity

--- a/TNLean/MPS/MPDO/Defs.lean
+++ b/TNLean/MPS/MPDO/Defs.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
 -/
 import TNLean.MPS.Defs
 import TNLean.MPS.Core.Transfer

--- a/TNLean/MPS/MPDO/InverseMapActiveSectorRecurrence.lean
+++ b/TNLean/MPS/MPDO/InverseMapActiveSectorRecurrence.lean
@@ -70,9 +70,12 @@ theorem conjugated_middle_threeSiteClosure
 private theorem exists_diagonal_ne_zero_of_trace_eq_one
     {n : Type*} [Fintype n] (A : Matrix n n ℂ)
     (htrace : A.trace = 1) : ∃ i, A i i ≠ 0 := by
-  apply Finset.exists_ne_zero_of_sum_ne_zero
-  rw [← Matrix.trace, htrace]
-  exact one_ne_zero
+  have hsum : (∑ i : n, A i i) ≠ 0 := by
+    change A.trace ≠ 0
+    rw [htrace]
+    exact one_ne_zero
+  obtain ⟨i, _, hi⟩ := Finset.exists_ne_zero_of_sum_ne_zero hsum
+  exact ⟨i, hi⟩
 
 /-- Both endpoints of a nonzero neighboring operator in the zero-weight
 reparameterized inverse-map factorization have positive Hayashi weight.

--- a/TNLean/MPS/MPDO/InverseMapActiveSectorRecurrence.lean
+++ b/TNLean/MPS/MPDO/InverseMapActiveSectorRecurrence.lean
@@ -70,12 +70,9 @@ theorem conjugated_middle_threeSiteClosure
 private theorem exists_diagonal_ne_zero_of_trace_eq_one
     {n : Type*} [Fintype n] (A : Matrix n n ℂ)
     (htrace : A.trace = 1) : ∃ i, A i i ≠ 0 := by
-  classical
-  by_contra hall
-  push Not at hall
-  have hz : A.trace = 0 := by
-    simp [Matrix.trace, hall]
-  exact one_ne_zero (htrace.symm.trans hz)
+  apply Finset.exists_ne_zero_of_sum_ne_zero
+  rw [← Matrix.trace, htrace]
+  exact one_ne_zero
 
 /-- Both endpoints of a nonzero neighboring operator in the zero-weight
 reparameterized inverse-map factorization have positive Hayashi weight.

--- a/TNLean/MPS/MPDO/LocalPurificationRFP.lean
+++ b/TNLean/MPS/MPDO/LocalPurificationRFP.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
 -/
 import TNLean.Channel.TransferMatrix
 import TNLean.MPS.Core.CyclicTrace
@@ -297,6 +298,13 @@ global equation. When the purifying tensor A is a pure-state renormalization
 fixed point, the transfer matrix of its transfer map is idempotent, and closing
 the physical legs of M transports that idempotence to 𝒯_M. -/
 
+private theorem submatrix_equiv_injective {α β R : Type*} (e : α ≃ β) :
+    Function.Injective (fun A : Matrix β β R => A.submatrix e e) := by
+  intro A B h
+  ext i j
+  simpa only [Matrix.submatrix_apply, Equiv.apply_symm_apply] using
+    congrFun (congrFun h (e.symm i)) (e.symm j)
+
 /-- **Pure-state RFP is equivalent to normalized physical-trace idempotence for
 a fixed local purification.** Suppose `M` is the ancilla contraction of `A`
 through the bond identification `e`, as in the purification tensor and global
@@ -380,15 +388,9 @@ theorem purificationTensor_isTransferIdempotent_iff_physTraceTransfer_sq
     rw [hPT, Matrix.submatrix_mul_equiv K K (⇑e) e (⇑e), hidemK]
   · intro hPTidem
     rw [hPT, Matrix.submatrix_mul_equiv K K (⇑e) e (⇑e)] at hPTidem
-    have hidemK : K * K = K := by
-      ext x y
-      have h := congrFun (congrFun hPTidem (e.symm x)) (e.symm y)
-      simpa using h
+    have hidemK : K * K = K := submatrix_equiv_injective e hPTidem
     rw [hKK', Matrix.submatrix_mul_equiv K' K' (⇑s) s (⇑s)] at hidemK
-    have hidemK' : K' * K' = K' := by
-      ext x y
-      have h := congrFun (congrFun hidemK (s.symm x)) (s.symm y)
-      simpa using h
+    have hidemK' : K' * K' = K' := submatrix_equiv_injective s hidemK
     apply transferMatrix_injective
     rw [transferMatrix_comp, ← hK']
     exact hidemK'

--- a/TNLean/MPS/MPDO/MutualInfoMonotone.lean
+++ b/TNLean/MPS/MPDO/MutualInfoMonotone.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.AreaLaw
 import TNLean.Entropy.StrongSubadditivity
@@ -143,8 +144,14 @@ theorem append_glue {d N m k k' : ℕ} (u : Fin m → Fin d) (w : Fin k → Fin 
   · have hL : Fin.cast h2 j = Fin.castAdd k' ⟨j.val, hj⟩ := by apply Fin.ext; simp
     have hR : Fin.cast h3 j = Fin.castAdd k ⟨j.val, hj⟩ := by apply Fin.ext; simp
     rw [hL, hR, Fin.append_left, Fin.append_left]
-  · have hL : Fin.cast h2 j = Fin.natAdd m ⟨j.val - m, by omega⟩ := by apply Fin.ext; simp; omega
-    have hR : Fin.cast h3 j = Fin.natAdd m ⟨j.val - m, by omega⟩ := by apply Fin.ext; simp; omega
+  · have hL : Fin.cast h2 j = Fin.natAdd m ⟨j.val - m, by omega⟩ := by
+      apply Fin.ext
+      simp
+      omega
+    have hR : Fin.cast h3 j = Fin.natAdd m ⟨j.val - m, by omega⟩ := by
+      apply Fin.ext
+      simp
+      omega
     rw [hL, hR, Fin.append_right, Fin.append_right]
     rfl
 
@@ -306,6 +313,8 @@ theorem reducedBlockState_cast {d D : ℕ} (M : MPOTensor d D) {N k k' : ℕ} (h
       = M.reducedBlockState N k' (by omega) (W ∘ Fin.cast h) (W' ∘ Fin.cast h) := by
   subst h; rfl
 
+/-- Reassociating the length of three appended configurations does not change
+that configuration. -/
 theorem append_assoc_cast {d a b c : ℕ} (A' : Fin a → Fin d) (B1 : Fin b → Fin d)
     (C1 : Fin c → Fin d) :
     (Fin.append (Fin.append A' B1) C1) ∘ Fin.cast (show a + (b + c) = a + b + c by omega)
@@ -448,16 +457,8 @@ theorem blockEntropy_zero {d D : ℕ} (M : MPOTensor d D) (N : ℕ)
     reducedBlockState_posSemidef M N 0 (Nat.zero_le N) hM
   have hTr : (reducedBlockState M N 0 (Nat.zero_le N)).trace = 1 :=
     reducedBlockState_trace M N 0 (Nat.zero_le N) htr
-  have hcard : Fintype.card (Fin 0 → Fin d) = 1 := by simp
-  have hle : (reducedBlockState M N 0 (Nat.zero_le N)).rank ≤ 1 :=
-    hcard ▸ Matrix.rank_le_card_width _
-  have hupper : M.blockEntropy N 0 (Nat.zero_le N) hM ≤ 0 := by
-    have h := vonNeumannEntropy_le_log_rank hPSD hTr
-    have hlog : Real.log ((reducedBlockState M N 0 (Nat.zero_le N)).rank : ℝ) ≤ 0 :=
-      Real.log_nonpos (by positivity) (by exact_mod_cast hle)
-    exact le_trans h hlog
-  have hlower : 0 ≤ M.blockEntropy N 0 (Nat.zero_le N) hM := blockEntropy_nonneg M _ hM htr
-  linarith
+  apply vonNeumannEntropy_eq_zero_of_rank_le_one hPSD hTr
+  simpa using Matrix.rank_le_card_width (reducedBlockState M N 0 (Nat.zero_le N))
 
 /-- The mutual information of the empty block vanishes, $I_0 = 0$. -/
 theorem mutualInfoChain_zero {d D : ℕ} (M : MPOTensor d D) (N : ℕ)

--- a/TNLean/MPS/MPDO/OperatorProduct.lean
+++ b/TNLean/MPS/MPDO/OperatorProduct.lean
@@ -38,6 +38,68 @@ Kronecker product of the bond spaces in the vertical reading.
 open scoped Matrix BigOperators ComplexOrder Kronecker
 open Matrix
 
+namespace Matrix
+
+/-- Taking the Kronecker product with a nonempty identity matrix is injective. -/
+theorem kronecker_one_injective {m n : Type*} {D : ℕ} (hD : 0 < D) :
+    Function.Injective (fun A : Matrix m n ℂ =>
+      A ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ)) := by
+  intro A B h
+  let z : Fin D := ⟨0, hD⟩
+  ext x y
+  have hEntry := congrArg (fun M => M (x, z) (y, z)) h
+  simpa [one_apply, z] using hEntry
+
+/-- Taking the Kronecker product with an identity matrix preserves matrix multiplication. -/
+theorem mul_kronecker_one {l m n : Type*} [Fintype m]
+    (A : Matrix l m ℂ) (B : Matrix m n ℂ) (D : ℕ) :
+    (A * B) ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ) =
+      (A ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ)) *
+        (B ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ)) := by
+  simpa only [one_mul] using mul_kronecker_mul A B
+    (1 : Matrix (Fin D) (Fin D) ℂ) (1 : Matrix (Fin D) (Fin D) ℂ)
+
+/-- A matrix product is the identity when its Kronecker amplification by a nonempty identity
+matrix is the identity. -/
+theorem mul_eq_one_of_kronecker_one {m n : Type*} [DecidableEq m] [Fintype n]
+    {D : ℕ} (hD : 0 < D) (F : Matrix m n ℂ) (G : Matrix n m ℂ)
+    (h : (F ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ)) *
+      (G ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ)) = 1) :
+    F * G = 1 := by
+  apply kronecker_one_injective hD
+  calc
+    (F * G) ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ) =
+        (F ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ)) *
+          (G ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ)) := mul_kronecker_one F G D
+    _ = 1 := h
+    _ = (1 : Matrix m m ℂ) ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ) :=
+      one_kronecker_one.symm
+
+/-- A matrix has orthonormal rows when its Kronecker amplification by a nonempty identity matrix
+has orthonormal rows. -/
+theorem mul_conjTranspose_eq_one_of_kronecker_one
+    {m n : Type*} [Fintype n] [DecidableEq m] {D : ℕ} (hD : 0 < D)
+    (F : Matrix m n ℂ)
+    (hF : (F ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ)) *
+      (F ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ))ᴴ = 1) :
+    F * Fᴴ = 1 := by
+  apply mul_eq_one_of_kronecker_one hD F Fᴴ
+  simpa only [conjTranspose_kronecker, conjTranspose_one] using hF
+
+/-- A matrix has orthonormal columns when its Kronecker amplification by a nonempty identity
+matrix has orthonormal columns. -/
+theorem conjTranspose_mul_eq_one_of_kronecker_one
+    {m n : Type*} [Fintype m] [DecidableEq n] {D : ℕ} (hD : 0 < D)
+    (F : Matrix m n ℂ)
+    (hF : (F ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ))ᴴ *
+      (F ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ)) = 1) :
+    Fᴴ * F = 1 := by
+  apply mul_eq_one_of_kronecker_one hD Fᴴ F
+  rw [conjTranspose_kronecker, conjTranspose_one] at hF
+  exact hF
+
+end Matrix
+
 namespace MPOTensor
 
 variable {d D D₁ D₂ D₃ : ℕ}
@@ -202,11 +264,8 @@ theorem listProd_conj_of_conjTranspose_mul_self {S : Type*} [Fintype S]
     have ih_step := ih (F ∘ Fin.succ)
     simp only [Function.comp_def] at ih_step
     rw [ih_step]
-    have key : Uᴴ * (U * ((List.ofFn fun l => F l.succ).prod * Uᴴ))
-        = (List.ofFn fun l => F l.succ).prod * Uᴴ := by
-      rw [← Matrix.mul_assoc, hU, Matrix.one_mul]
     simp only [Matrix.mul_assoc]
-    rw [key]
+    rw [← Matrix.mul_assoc Uᴴ U, hU, Matrix.one_mul]
 
 /-- The word product of block-diagonal Kronecker letters with a fixed left
 factor per block: the fixed factors accumulate into a matrix power,

--- a/TNLean/MPS/MPDO/PRFP.lean
+++ b/TNLean/MPS/MPDO/PRFP.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.Defs
 import TNLean.Channel.KrausCPTP

--- a/TNLean/MPS/MPDO/PhysicalBlocking.lean
+++ b/TNLean/MPS/MPDO/PhysicalBlocking.lean
@@ -58,6 +58,7 @@ noncomputable def blockTensor (M : MPOTensor d D) (L : ℕ) :
     MPOTensor (MPSTensor.blockPhysDim d L) D :=
   fun i j => evalWord M (MPSTensor.wordOfBlock d L i) (MPSTensor.wordOfBlock d L j)
 
+/-- Evaluating a blocked tensor gives the corresponding pair of blocked words. -/
 @[simp]
 lemma blockTensor_apply (M : MPOTensor d D) (L : ℕ)
     (i j : Fin (MPSTensor.blockPhysDim d L)) :
@@ -82,6 +83,7 @@ noncomputable def blockedDoubledIndexEquiv (d L : ℕ) :
     (Equiv.arrowCongr (Equiv.refl (Fin L)) finProdFinEquiv) |>.trans
     (MPSTensor.decodeBlockEquiv (d * d) L).symm
 
+/-- Decoding the doubled blocked index pairs the ket and bra letters pointwise. -/
 @[simp]
 lemma decodeBlock_blockedDoubledIndexEquiv (d L : ℕ)
     (ij : Fin (MPSTensor.blockPhysDim d L * MPSTensor.blockPhysDim d L))

--- a/TNLean/MPS/MPDO/PhysicalSectorEtaLocalStructure.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorEtaLocalStructure.lean
@@ -46,8 +46,8 @@ noncomputable def etaLocalStructureData
   bondData := F.translationInvariantBondData hη
   realizes_mpo := by
     intro N hN
-    refine ⟨1, zero_lt_one, ?_⟩
-    rw [one_smul]
+    refine ⟨1, by norm_num, ?_⟩
+    norm_num
     change mpo K N =
       (List.ofFn fun i : Fin N ↦
         embedLocalOperator (d := d) 2 N hN i F.physicalBond).prod

--- a/TNLean/MPS/MPDO/PhysicalSectorEtaLocalStructure.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorEtaLocalStructure.lean
@@ -46,8 +46,8 @@ noncomputable def etaLocalStructureData
   bondData := F.translationInvariantBondData hη
   realizes_mpo := by
     intro N hN
-    refine ⟨1, by norm_num, ?_⟩
-    norm_num
+    refine ⟨1, zero_lt_one, ?_⟩
+    rw [one_smul]
     change mpo K N =
       (List.ofFn fun i : Fin N ↦
         embedLocalOperator (d := d) 2 N hN i F.physicalBond).prod

--- a/TNLean/MPS/MPDO/PhysicalSectorProductRealization.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorProductRealization.lean
@@ -69,14 +69,6 @@ private theorem reindex_mpo_sectorCoordinateTensor_eq_blockDiagonal
   rw [F.mpo_sectorCoordinateTensor_eq_reindex_conjugatePhysical N]
   simpa [sectorCoordinateChainEquiv, Matrix.reindex_apply] using h
 
-private def piProdEquiv
-    {ι : Type*} {A B : ι → Type*} :
-    ((i : ι) → A i × B i) ≃ ((i : ι) → A i) × ((i : ι) → B i) where
-  toFun x := (fun i ↦ (x i).1, fun i ↦ (x i).2)
-  invFun x i := (x.1 i, x.2 i)
-  left_inv _ := rfl
-  right_inv _ := rfl
-
 /-- Regroup a fixed sector configuration from site factors
 `(L_n,R_n)` to cyclic edge factors `(R_n,L_(n+1))`.
 
@@ -86,12 +78,12 @@ private def cyclicEdgeEquiv (F : PhysicalSectorFactorization K) {N : ℕ} [NeZer
     (k : Fin N → Fin F.sectorCount) :
     ((n : Fin N) → SectorIndex F (k n)) ≃
       ((n : Fin N) → NeighborIndex F (k n) (k (n + 1))) :=
-  piProdEquiv.trans <|
+  (Equiv.arrowProdEquivProdArrow _ _ _).trans <|
     (Equiv.prodComm _ _).trans <|
       (Equiv.prodCongr (Equiv.refl _)
         (Equiv.piCongrLeft
           (fun n : Fin N ↦ Fin (F.leftDim (k n))) (finRotate N)).symm).trans <|
-        piProdEquiv.symm |>.trans <|
+        (Equiv.arrowProdEquivProdArrow _ _ _).symm |>.trans <|
           Equiv.piCongrRight fun n ↦
             Equiv.prodCongr (Equiv.refl _)
               (finCongr (congrArg F.leftDim
@@ -225,13 +217,9 @@ private noncomputable def edgePartialProduct
   ext x y
   simp only [edgePartialProduct, Finset.notMem_empty, ↓reduceIte,
     Matrix.one_apply]
-  by_cases hxy : x = y
-  · subst y
-    simp
-  · obtain ⟨n, hn⟩ := Function.ne_iff.mp hxy
-    rw [Finset.prod_eq_zero (Finset.mem_univ n)]
-    · simp [hxy]
-    · simp [hn]
+  rw [Fintype.prod_boole]
+  congr 1
+  exact funext_iff
 
 @[simp] private theorem edgePartialProduct_univ
     (F : PhysicalSectorFactorization K) {N : ℕ} [NeZero N]
@@ -241,40 +229,6 @@ private noncomputable def edgePartialProduct
         F.neighboringOperator (k n) (k (n + 1)) (x n) (y n) := by
   ext x y
   simp [edgePartialProduct]
-
-/-- Multiplying by a new single-edge factor adjoins that edge to the partial
-tensor product. -/
-private theorem edgePartialProduct_mul_singleton
-    (F : PhysicalSectorFactorization K) {N : ℕ} [NeZero N]
-    (k : Fin N → Fin F.sectorCount) (s : Finset (Fin N))
-    (i : Fin N) (hi : i ∉ s) :
-    F.edgePartialProduct k s * F.edgePartialProduct k {i} =
-      F.edgePartialProduct k (insert i s) := by
-  classical
-  ext x y
-  simp only [Matrix.mul_apply, edgePartialProduct]
-  simp_rw [← Finset.prod_mul_distrib]
-  rw [← Fintype.piFinset_univ]
-  rw [← Finset.prod_univ_sum
-    (fun n : Fin N ↦
-      (Finset.univ : Finset (NeighborIndex F (k n) (k (n + 1)))))
-    (fun n z ↦
-      (if n ∈ s then
-        F.neighboringOperator (k n) (k (n + 1)) (x n) z
-      else if x n = z then 1 else 0) *
-      (if n ∈ ({i} : Finset (Fin N)) then
-        F.neighboringOperator (k n) (k (n + 1)) z (y n)
-      else if z = y n then 1 else 0))]
-  apply Finset.prod_congr rfl
-  intro n _
-  by_cases hni : n = i
-  · subst n
-    simp [hi]
-  · by_cases hns : n ∈ s
-    · simp [hni, hns]
-    · by_cases hxy : x n = y n
-      · simp [hni, hns, hxy]
-      · simp [hni, hns, hxy]
 
 /-- Multiplying a partial tensor product on the left by a new single-edge
 factor adjoins that edge. -/
@@ -392,38 +346,6 @@ private theorem mem_cyclicWindowSupport_two {N : ℕ} (i q : Fin N) :
   · rintro (rfl | rfl)
     · exact ⟨0, by simp, by simp⟩
     · exact ⟨1, by simp, rfl⟩
-
-/-- Within a fixed pair of sectors, the sector bond carries the neighboring
-operator and the two outer factors contribute Kronecker deltas. -/
-private theorem sectorBond_fixedSector_apply
-    (F : PhysicalSectorFactorization K) (k h : Fin F.sectorCount)
-    (x x' : SectorIndex F k) (y y' : SectorIndex F h) :
-    F.sectorBond
-        ![F.sectorFinEquiv.symm ⟨k, x⟩, F.sectorFinEquiv.symm ⟨h, y⟩]
-        ![F.sectorFinEquiv.symm ⟨k, x'⟩, F.sectorFinEquiv.symm ⟨h, y'⟩] =
-      (if x.1 = x'.1 then 1 else 0) *
-        (if y.2 = y'.2 then 1 else 0) *
-          F.neighboringOperator k h (x.2, y.1) (x'.2, y'.1) := by
-  simp only [sectorBond, Matrix.reindex_apply, Matrix.submatrix_apply,
-    finTwoArrowEquiv]
-  change F.sectorCoordinateBond
-      (F.twoSiteSectorEmbedding k h (x, y))
-      (F.twoSiteSectorEmbedding k h (x', y')) = _
-  simp only [sectorCoordinateBond, Matrix.reindex_apply,
-    Matrix.submatrix_apply, Equiv.symm_symm,
-    twoSiteGlobalRegroupEquiv_twoSiteSectorEmbedding]
-  change Matrix.blockDiagonal' (fun kh :
-      Fin F.sectorCount × Fin F.sectorCount ↦
-        (1 : Matrix (BoundaryIndex F kh.1 kh.2)
-          (BoundaryIndex F kh.1 kh.2) ℂ) ⊗ₖ
-            F.neighboringOperator kh.1 kh.2)
-      ⟨(k, h), ((x.1, y.2), (x.2, y.1))⟩
-      ⟨(k, h), ((x'.1, y'.2), (x'.2, y'.1))⟩ = _
-  rw [Matrix.blockDiagonal'_apply_eq]
-  simp only [Matrix.kroneckerMap_apply, Matrix.one_apply,
-    Prod.ext_iff, neighboringOperator_apply]
-  by_cases hx : x.1 = x'.1 <;> by_cases hy : y.2 = y'.2 <;>
-    simp [hx, hy]
 
 /-- In complete cyclic-edge coordinates, a translated two-site sector bond
 is block diagonal in the sector configuration and acts only on the

--- a/TNLean/MPS/MPDO/PhysicalSectorProductRealization.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorProductRealization.lean
@@ -219,7 +219,7 @@ private noncomputable def edgePartialProduct
     Matrix.one_apply]
   rw [Fintype.prod_boole]
   congr 1
-  exact funext_iff
+  exact propext funext_iff.symm
 
 @[simp] private theorem edgePartialProduct_univ
     (F : PhysicalSectorFactorization K) {N : ℕ} [NeZero N]

--- a/TNLean/MPS/MPDO/PhysicalSectorProductTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorProductTransport.lean
@@ -59,13 +59,9 @@ private theorem physicalCoordinateMatrixN_isometry
       Matrix.one_apply] using
       congrFun (congrFun F.physicalCoordinateMatrix_isometry (x n)) (y n)
   simp_rw [hentry]
-  by_cases hxy : x = y
-  · subst y
-    simp
-  · obtain ⟨n, hn⟩ := Function.ne_iff.mp hxy
-    rw [Finset.prod_eq_zero (Finset.mem_univ n)]
-    · simp [hxy]
-    · simp [hn]
+  rw [Fintype.prod_boole]
+  congr 1
+  exact funext_iff
 
 /-- The sitewise physical coordinate matrix is a coisometry. -/
 private theorem physicalCoordinateMatrixN_coisometry
@@ -90,13 +86,9 @@ private theorem physicalCoordinateMatrixN_coisometry
       Matrix.one_apply] using
       congrFun (congrFun F.physicalCoordinateMatrix_coisometry (x n)) (y n)
   simp_rw [hentry]
-  by_cases hxy : x = y
-  · subst y
-    simp
-  · obtain ⟨n, hn⟩ := Function.ne_iff.mp hxy
-    rw [Finset.prod_eq_zero (Finset.mem_univ n)]
-    · simp [hxy]
-    · simp [hn]
+  rw [Fintype.prod_boole]
+  congr 1
+  exact funext_iff
 
 private theorem list_prod_sum_ofFn {a n : Type*} [Fintype a]
     [Fintype n] [DecidableEq n] {N : ℕ}
@@ -134,11 +126,8 @@ private theorem list_prod_smul_ofFn {n : Type*} [Fintype n]
       rw [mul_comm (c 0)]
 
 private def braKetFunctionsEquiv {i a b : Type*} :
-    ((i → b) × (i → a)) ≃ (i → a × b) where
-  toFun x j := (x.2 j, x.1 j)
-  invFun x := (fun j ↦ (x j).2, fun j ↦ (x j).1)
-  left_inv _ := rfl
-  right_inv _ := rfl
+    ((i → b) × (i → a)) ≃ (i → a × b) :=
+  (Equiv.prodComm _ _).trans (Equiv.arrowProdEquivProdArrow i (fun _ ↦ a) (fun _ ↦ b)).symm
 
 private theorem evalWord_changePhysicalBasis_ofFn {e : ℕ}
     (V : Matrix (Fin e) (Fin d) ℂ) (M : MPOTensor d D) {N : ℕ}

--- a/TNLean/MPS/MPDO/PhysicalSectorProductTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorProductTransport.lean
@@ -61,7 +61,7 @@ private theorem physicalCoordinateMatrixN_isometry
   simp_rw [hentry]
   rw [Fintype.prod_boole]
   congr 1
-  exact funext_iff
+  exact propext funext_iff.symm
 
 /-- The sitewise physical coordinate matrix is a coisometry. -/
 private theorem physicalCoordinateMatrixN_coisometry
@@ -88,7 +88,7 @@ private theorem physicalCoordinateMatrixN_coisometry
   simp_rw [hentry]
   rw [Fintype.prod_boole]
   congr 1
-  exact funext_iff
+  exact propext funext_iff.symm
 
 private theorem list_prod_sum_ofFn {a n : Type*} [Fintype a]
     [Fintype n] [DecidableEq n] {N : ℕ}

--- a/TNLean/MPS/MPDO/PureAreaLaw.lean
+++ b/TNLean/MPS/MPDO/PureAreaLaw.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.MutualInfoMonotone
 
@@ -66,7 +67,8 @@ theorem mpo_doubledTensor (A : MPSTensor d D) (N : ℕ) :
     mpo (doubledTensor A) N = MPSTensor.pureState A N := by
   ext σ τ
   rw [mpo_apply, MPOTensor.mpoMatrixEntry, evalWord_doubledTensor,
-    Matrix.trace_submatrix_equiv, Matrix.trace_kronecker, ← AddMonoidHom.map_trace (starRingEnd ℂ)]
+    Matrix.trace_submatrix_equiv, Matrix.trace_kronecker,
+    ← AddMonoidHom.map_trace (starRingEnd ℂ)]
   simp only [MPSTensor.pureState, Matrix.vecMulVec_apply, Pi.star_apply, MPSTensor.mpv,
     MPSTensor.coeff, Complex.star_def]
 
@@ -225,7 +227,8 @@ theorem pureBlockEntropy_complement (A : MPSTensor d D) (N L : ℕ) (hL : L ≤ 
   set W := schmidtMat A N L hL with hWdef
   have hc : starRingEnd ℂ c = c := by rw [hcdef, map_inv₀, trace_pureState_conj]
   have hsa : IsSelfAdjoint c := by rw [isSelfAdjoint_iff, ← starRingEnd_apply]; exact hc
-  have hHWW : (c • (Wᴴ * W)).IsHermitian := (Matrix.isHermitian_conjTranspose_mul_self W).smul hsa
+  have hHWW : (c • (Wᴴ * W)).IsHermitian :=
+    (Matrix.isHermitian_conjTranspose_mul_self W).smul hsa
   have hcWW : ((c • W) * Wᴴ).IsHermitian := by
     rw [Matrix.smul_mul]; exact (Matrix.isHermitian_mul_conjTranspose_self W).smul hsa
   have hWcW : (Wᴴ * (c • W)).IsHermitian := by rw [Matrix.mul_smul]; exact hHWW
@@ -234,7 +237,9 @@ theorem pureBlockEntropy_complement (A : MPSTensor d D) (N L : ℕ) (hL : L ≤ 
   have e1 : MPSTensor.reducedPureBlockState A N L hL = (c • W) * Wᴴ :=
     (reducedPureBlockState_eq_gram A N L hL).trans (Matrix.smul_mul c W Wᴴ).symm
   have e2 : Wᴴ * (c • W) = c • (Wᴴ * W) := Matrix.mul_smul Wᴴ c W
-  have hmapsmul : (c • (Wᴴ * W)).map (starRingEnd ℂ) = c • ((Wᴴ * W).map (starRingEnd ℂ)) := by
+  have hmapsmul :
+      (c • (Wᴴ * W)).map (starRingEnd ℂ) =
+        c • ((Wᴴ * W).map (starRingEnd ℂ)) := by
     ext i j
     simp only [Matrix.map_apply, Matrix.smul_apply, smul_eq_mul, map_mul]
     rw [hc]
@@ -288,7 +293,8 @@ theorem append_zero_eq {α : Type*} {L : ℕ} (u : Fin L → α) (g : Fin 0 → 
 
 /-- With an empty right block, the block-reduced state is the input matrix
 reindexed along the trivial length identity L + 0 = L. -/
-theorem blockReducedState_zero {L : ℕ} (Z : Matrix (Fin (L + 0) → Fin d) (Fin (L + 0) → Fin d) ℂ) :
+theorem blockReducedState_zero {L : ℕ}
+    (Z : Matrix (Fin (L + 0) → Fin d) (Fin (L + 0) → Fin d) ℂ) :
     blockReducedState d L 0 Z
       = Z.submatrix (Equiv.arrowCongr (finCongr (Nat.add_zero L).symm) (Equiv.refl (Fin d)))
           (Equiv.arrowCongr (finCongr (Nat.add_zero L).symm) (Equiv.refl (Fin d))) := by
@@ -403,15 +409,8 @@ theorem pureBlockEntropy_le (A : MPSTensor d D) (N L : ℕ) (hL : L ≤ N) (hD :
   have hTr : (reducedPureBlockState A N L hL).trace = 1 :=
     reducedPureBlockState_trace A N L hL htr
   -- its rank is positive (trace 1 ≠ 0) and at most `D²`
-  have hrk_pos : 0 < (reducedPureBlockState A N L hL).rank := by
-    rw [hPSD.isHermitian.rank_eq_card_non_zero_eigs, Fintype.card_pos_iff]
-    by_contra h
-    simp only [not_nonempty_iff] at h
-    have hall : ∀ i, hPSD.isHermitian.eigenvalues i = 0 := fun i => by
-      by_contra hi; exact h.false ⟨i, hi⟩
-    have hsum := posSemidef_trace_one_eigenvalues_sum_one hPSD hTr
-    rw [Finset.sum_eq_zero (fun i _ => hall i)] at hsum
-    exact one_ne_zero hsum.symm
+  have hrk_pos : 0 < (reducedPureBlockState A N L hL).rank :=
+    hPSD.rank_pos_of_trace_one hTr
   have hrk_le : (reducedPureBlockState A N L hL).rank ≤ D * D :=
     rank_reducedPureBlockState_le A N L hL
   -- chain the entropy bound through the rank
@@ -452,23 +451,9 @@ theorem pureBlockEntropy_eq_of_isSAL (A : MPSTensor d D) (hSAL : IsSAL A)
     {N L L' : ℕ} (hL1 : 1 ≤ L) (hLN : L ≤ N / 2) (hL'1 : 1 ≤ L') (hL'N : L' ≤ N / 2) :
     pureBlockEntropy A N L (hLN.trans (Nat.div_le_self N 2)) =
       pureBlockEntropy A N L' (hL'N.trans (Nat.div_le_self N 2)) := by
-  -- Climbing `k` steps from a block size `m` stays an equality while `m + k ≤ ⌊N/2⌋`.
-  have climb : ∀ k m : ℕ, 1 ≤ m → ∀ h : m + k ≤ N / 2,
-      pureBlockEntropy A N m
-          ((Nat.le_add_right m k).trans (h.trans (Nat.div_le_self N 2)))
-        = pureBlockEntropy A N (m + k) (h.trans (Nat.div_le_self N 2)) := by
-    intro k
-    induction k with
-    | zero => intro m _ _; rfl
-    | succ k ih =>
-      intro m hm1 h
-      have hmk : m + k < N / 2 := by omega
-      exact (ih m hm1 (le_of_lt hmk)).trans (hSAL N (m + k) (by omega) hmk)
-  rcases le_total L L' with hle | hle
-  · obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_le hle
-    exact climb k L hL1 hL'N
-  · obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_le hle
-    exact (climb k L' hL'1 hLN).symm
+  apply eq_of_forall_succ_eq_of_mem_Icc
+    (fun m hm => pureBlockEntropy A N m (hm.trans (Nat.div_le_self N 2)))
+    (fun m hm hmn => hSAL N m hm hmn) hL1 hLN hL'1 hL'N
 
 end MPSTensor
 

--- a/TNLean/MPS/MPDO/PureRFPSAL.lean
+++ b/TNLean/MPS/MPDO/PureRFPSAL.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.PureAreaLaw
 import TNLean.Spectral.MixedTransfer

--- a/TNLean/MPS/MPDO/PureRecovery.lean
+++ b/TNLean/MPS/MPDO/PureRecovery.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.Defs
 import TNLean.MPS.RFP.ZeroCorrelationLength
@@ -51,7 +52,8 @@ theorem toMPOTensor_isRFP_iff_isTransferIdempotent (A : MPSTensor d D) :
 to the pure-state zero-correlation-length condition via
 `MPSTensor.zcl_iff_idempotent_transfer`. -/
 theorem toMPOTensor_isRFP_iff_isZCL (A : MPSTensor d D) :
-    MPOTensor.IsRFP A.toMPOTensor ↔ IsZCL A := by
-  simpa [toMPOTensor_isRFP_iff_isTransferIdempotent] using (zcl_iff_idempotent_transfer A).symm
+    MPOTensor.IsRFP A.toMPOTensor ↔ IsZCL A :=
+  (toMPOTensor_isRFP_iff_isTransferIdempotent A).trans
+    (zcl_iff_idempotent_transfer A).symm
 
 end MPSTensor

--- a/TNLean/MPS/MPDO/RFP.lean
+++ b/TNLean/MPS/MPDO/RFP.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.ZCL
 
@@ -45,7 +46,7 @@ theorem isRFP_iff_isZCL (M : MPOTensor d D) : IsRFP M ↔ IsZCL M :=
 /-- `IsRFP M` is equivalent to the pure-state RFP condition for the
 doubled-index MPS tensor. -/
 theorem isRFP_iff_toMPSTensor_isTransferIdempotent (M : MPOTensor d D) :
-    IsRFP M ↔ MPSTensor.IsTransferIdempotent (M.toMPSTensor) := by
-  simpa [IsRFP, MPOTensor.IsZCL] using isZCL_iff_toMPSTensor_isTransferIdempotent M
+    IsRFP M ↔ MPSTensor.IsTransferIdempotent (M.toMPSTensor) :=
+  (isRFP_iff_isZCL M).trans (isZCL_iff_toMPSTensor_isTransferIdempotent M)
 
 end MPOTensor

--- a/TNLean/MPS/MPDO/RFPViaTS.lean
+++ b/TNLean/MPS/MPDO/RFPViaTS.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
 -/
 import TNLean.Algebra.FinTupleEquiv
 import TNLean.Algebra.TracePairing

--- a/TNLean/MPS/MPDO/TopologicalProjectors.lean
+++ b/TNLean/MPS/MPDO/TopologicalProjectors.lean
@@ -42,7 +42,8 @@ variable {g p : ℕ}
 variable (Fam : BNTFusionIsometryFamily (Fin g) p)
 
 private theorem isStarProjection_conjTranspose_mul_mul_of_mul_conjTranspose_eq_one
-    {m n : ℕ} (U : Matrix (Fin m) (Fin n) ℂ) (Q : Matrix (Fin m) (Fin m) ℂ)
+    {m n : Type*} [Fintype m] [DecidableEq m] [Fintype n]
+    (U : Matrix m n ℂ) (Q : Matrix m m ℂ)
     (hQ : IsStarProjection Q) (hU : U * Uᴴ = 1) :
     IsStarProjection (Uᴴ * Q * U) := by
   rw [isStarProjection_iff']

--- a/TNLean/MPS/MPDO/TopologicalProjectors.lean
+++ b/TNLean/MPS/MPDO/TopologicalProjectors.lean
@@ -41,6 +41,24 @@ namespace MPOTensor.BNTFusionIsometryFamily
 variable {g p : ℕ}
 variable (Fam : BNTFusionIsometryFamily (Fin g) p)
 
+private theorem isStarProjection_conjTranspose_mul_mul_of_mul_conjTranspose_eq_one
+    {m n : ℕ} (U : Matrix (Fin m) (Fin n) ℂ) (Q : Matrix (Fin m) (Fin m) ℂ)
+    (hQ : IsStarProjection Q) (hU : U * Uᴴ = 1) :
+    IsStarProjection (Uᴴ * Q * U) := by
+  rw [isStarProjection_iff']
+  constructor
+  · calc
+      (Uᴴ * Q * U) * (Uᴴ * Q * U) = Uᴴ * (Q * ((U * Uᴴ) * (Q * U))) := by
+        simp only [Matrix.mul_assoc]
+      _ = Uᴴ * (Q * (Q * U)) := by rw [hU, Matrix.one_mul]
+      _ = Uᴴ * ((Q * Q) * U) := by simp only [Matrix.mul_assoc]
+      _ = Uᴴ * Q * U := by rw [hQ.isIdempotentElem.eq, Matrix.mul_assoc]
+  · rw [Matrix.star_eq_conjTranspose, Matrix.conjTranspose_mul, Matrix.conjTranspose_mul,
+      Matrix.conjTranspose_conjTranspose]
+    have hQadj : Qᴴ = Q := by
+      simpa [Matrix.star_eq_conjTranspose] using hQ.isSelfAdjoint.star_eq
+    rw [hQadj, Matrix.mul_assoc]
+
 /-- The single fusion layer of the operator $Q$ at source lines 999--1010,
 with terminal matrices $P_\gamma$.
 
@@ -138,41 +156,11 @@ theorem conjugatedProjectorQBlock_isOrthogonalProjection
       Matrix (Fin (Fam.bondDim γ)) (Fin (Fam.bondDim γ)) ℂ)
     (hP : ∀ γ : Fin g, IsStarProjection (P γ))
     (α β : Fin g) :
-    IsOrthogonalProjection (Fam.conjugatedProjectorQBlock P α β) := by
-  refine IsStarProjection.isOrthogonalProjection ?_
-  have hQ := Fam.projectorQBlock_isStarProjection c hχ hLI P hP α β
-  have hU := Fam.fusionIsometry_mul_conjTranspose_eq_one_of_bnt_of_lengthIndependent
-    hBNT c hχ hLI α β
-  rw [isStarProjection_iff']
-  constructor
-  · unfold conjugatedProjectorQBlock
-    calc
-      (Fam.fusionIsometry α β)ᴴ * Fam.projectorQBlock P α β *
-          Fam.fusionIsometry α β *
-          ((Fam.fusionIsometry α β)ᴴ * Fam.projectorQBlock P α β *
-            Fam.fusionIsometry α β) =
-        (Fam.fusionIsometry α β)ᴴ *
-          (Fam.projectorQBlock P α β *
-            ((Fam.fusionIsometry α β * (Fam.fusionIsometry α β)ᴴ) *
-              (Fam.projectorQBlock P α β * Fam.fusionIsometry α β))) := by
-            simp only [Matrix.mul_assoc]
-      _ = (Fam.fusionIsometry α β)ᴴ *
-          (Fam.projectorQBlock P α β *
-            (Fam.projectorQBlock P α β * Fam.fusionIsometry α β)) := by
-            rw [hU, Matrix.one_mul]
-      _ = (Fam.fusionIsometry α β)ᴴ *
-          ((Fam.projectorQBlock P α β * Fam.projectorQBlock P α β) *
-            Fam.fusionIsometry α β) := by
-            simp only [Matrix.mul_assoc]
-      _ = (Fam.fusionIsometry α β)ᴴ * Fam.projectorQBlock P α β *
-          Fam.fusionIsometry α β := by
-            rw [hQ.isIdempotentElem.eq, Matrix.mul_assoc]
-  · rw [Matrix.star_eq_conjTranspose]
-    unfold conjugatedProjectorQBlock
-    rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_mul,
-      Matrix.conjTranspose_conjTranspose]
-    have hQadj : (Fam.projectorQBlock P α β)ᴴ = Fam.projectorQBlock P α β := by
-      simpa [Matrix.star_eq_conjTranspose] using hQ.isSelfAdjoint.star_eq
-    rw [hQadj, Matrix.mul_assoc]
+    IsOrthogonalProjection (Fam.conjugatedProjectorQBlock P α β) :=
+  (isStarProjection_conjTranspose_mul_mul_of_mul_conjTranspose_eq_one
+    (Fam.fusionIsometry α β) (Fam.projectorQBlock P α β)
+    (Fam.projectorQBlock_isStarProjection c hχ hLI P hP α β)
+    (Fam.fusionIsometry_mul_conjTranspose_eq_one_of_bnt_of_lengthIndependent
+      hBNT c hχ hLI α β)).isOrthogonalProjection
 
 end MPOTensor.BNTFusionIsometryFamily

--- a/TNLean/MPS/MPDO/ZCL.lean
+++ b/TNLean/MPS/MPDO/ZCL.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.Defs
 import TNLean.MPS.RFP.Defs
@@ -64,7 +65,7 @@ the doubled-index MPS tensor `M.toMPSTensor`. Both statements assert
 idempotence of the same transfer map. -/
 theorem isZCL_iff_toMPSTensor_isTransferIdempotent (M : MPOTensor d D) :
     IsZCL M ↔ MPSTensor.IsTransferIdempotent (M.toMPSTensor) := by
-  simp [IsZCL, MPSTensor.IsTransferIdempotent]
+  rw [IsZCL, MPSTensor.IsTransferIdempotent, transferMap_eq_toMPSTensor]
 
 /-- The **physical-trace transfer** `𝒯_M = ∑_i M^{ii}` of an MPO tensor: the
 single bond matrix obtained by closing the ket and bra physical legs of one

--- a/TNLean/MPS/RFP/AppendixBChainCommutation.lean
+++ b/TNLean/MPS/RFP/AppendixBChainCommutation.lean
@@ -53,8 +53,8 @@ theorem AppendixBStructuralData.hasAppendixD2ParentCommutingHamiltonian
       right_idempotent := hStruct.appendixBQXBOnCoeffSpace_idempotent
       commute_lifts := hStruct.hasOverlappingTwoSiteCommutation.commute_lifts
       kernel_intersection := ?_ }
-  rw [hStruct.appendixBQAXOnCoeffSpace_eq_parentInteraction]
-  rw [hStruct.appendixBQXBOnCoeffSpace_eq_parentInteraction]
+  rw [hStruct.appendixBQAXOnCoeffSpace_eq_parentInteraction,
+    hStruct.appendixBQXBOnCoeffSpace_eq_parentInteraction]
   exact groundSpace_three_eq_adjacent_twoSite_parent_kernels hA
 
 /-- A normal left-canonical RFP tensor supplies the three-site coefficient-space

--- a/TNLean/MPS/RFP/AppendixBSupport.lean
+++ b/TNLean/MPS/RFP/AppendixBSupport.lean
@@ -877,7 +877,9 @@ theorem AppendixBStructuralData.twoSiteBasicSupportProjection_idempotent
     hStruct.twoSiteBasicSupportProjection * hStruct.twoSiteBasicSupportProjection =
       hStruct.twoSiteBasicSupportProjection := by
   rw [hStruct.twoSiteBasicSupportProjection_eq_complement]
-  exact (parentInteraction_idempotent hStruct.coreTensor 2).one_sub
+  change IsIdempotentElem (1 - parentInteraction hStruct.coreTensor 2)
+  exact (show IsIdempotentElem (parentInteraction hStruct.coreTensor 2) from
+    parentInteraction_idempotent hStruct.coreTensor 2).one_sub
 
 /-- The range of the support projector is the range of the bond-insertion
 embedding \(U^{\otimes2}I_\varphi\).

--- a/TNLean/MPS/RFP/AppendixBSupport.lean
+++ b/TNLean/MPS/RFP/AppendixBSupport.lean
@@ -304,36 +304,42 @@ def AppendixBStructuralData.replaceVirtualBond12
     (p : Fin 3 → Fin D × Fin D) (k : Fin D) : Fin 3 → Fin D × Fin D :=
   fun t ↦ if t = 1 then ((p 1).1, k) else if t = 2 then (k, (p 2).2) else p t
 
+/-- Replacing the first virtual bond updates the outgoing index at site zero. -/
 @[simp] theorem AppendixBStructuralData.replaceVirtualBond01_zero
     {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
     (p : Fin 3 → Fin D × Fin D) (k : Fin D) :
     hStruct.replaceVirtualBond01 p k 0 = ((p 0).1, k) := by
   simp [AppendixBStructuralData.replaceVirtualBond01]
 
+/-- Replacing the first virtual bond updates the incoming index at site one. -/
 @[simp] theorem AppendixBStructuralData.replaceVirtualBond01_one
     {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
     (p : Fin 3 → Fin D × Fin D) (k : Fin D) :
     hStruct.replaceVirtualBond01 p k 1 = (k, (p 1).2) := by
   simp [AppendixBStructuralData.replaceVirtualBond01]
 
+/-- Replacing the first virtual bond leaves site two unchanged. -/
 @[simp] theorem AppendixBStructuralData.replaceVirtualBond01_two
     {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
     (p : Fin 3 → Fin D × Fin D) (k : Fin D) :
     hStruct.replaceVirtualBond01 p k 2 = p 2 := by
   simp [AppendixBStructuralData.replaceVirtualBond01]
 
+/-- Replacing the second virtual bond leaves site zero unchanged. -/
 @[simp] theorem AppendixBStructuralData.replaceVirtualBond12_zero
     {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
     (p : Fin 3 → Fin D × Fin D) (k : Fin D) :
     hStruct.replaceVirtualBond12 p k 0 = p 0 := by
   simp [AppendixBStructuralData.replaceVirtualBond12]
 
+/-- Replacing the second virtual bond updates the outgoing index at site one. -/
 @[simp] theorem AppendixBStructuralData.replaceVirtualBond12_one
     {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
     (p : Fin 3 → Fin D × Fin D) (k : Fin D) :
     hStruct.replaceVirtualBond12 p k 1 = ((p 1).1, k) := by
   simp [AppendixBStructuralData.replaceVirtualBond12]
 
+/-- Replacing the second virtual bond updates the incoming index at site two. -/
 @[simp] theorem AppendixBStructuralData.replaceVirtualBond12_two
     {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
     (p : Fin 3 → Fin D × Fin D) (k : Fin D) :
@@ -435,12 +441,14 @@ def AppendixBStructuralData.replaceTwoSiteVirtualBond
     (p : Fin 2 → Fin D × Fin D) (k : Fin D) : Fin 2 → Fin D × Fin D :=
   fun t ↦ if t = 0 then ((p 0).1, k) else (k, (p 1).2)
 
+/-- Two-site bond replacement updates the outgoing index at site zero. -/
 @[simp] theorem AppendixBStructuralData.replaceTwoSiteVirtualBond_zero
     {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
     (p : Fin 2 → Fin D × Fin D) (k : Fin D) :
     hStruct.replaceTwoSiteVirtualBond p k 0 = ((p 0).1, k) := by
   simp [AppendixBStructuralData.replaceTwoSiteVirtualBond]
 
+/-- Two-site bond replacement updates the incoming index at site one. -/
 @[simp] theorem AppendixBStructuralData.replaceTwoSiteVirtualBond_one
     {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
     (p : Fin 2 → Fin D × Fin D) (k : Fin D) :
@@ -479,11 +487,13 @@ def AppendixBStructuralData.twoSiteVirtualBondConfig
     (a c k : Fin D) : Fin 2 → Fin D × Fin D :=
   fun t ↦ if t = 0 then (a, k) else (k, c)
 
+/-- The first site of a two-site virtual bond configuration is `(a, k)`. -/
 @[simp] theorem AppendixBStructuralData.twoSiteVirtualBondConfig_zero
     {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) (a c k : Fin D) :
     hStruct.twoSiteVirtualBondConfig a c k 0 = (a, k) := by
   simp [AppendixBStructuralData.twoSiteVirtualBondConfig]
 
+/-- The second site of a two-site virtual bond configuration is `(k, c)`. -/
 @[simp] theorem AppendixBStructuralData.twoSiteVirtualBondConfig_one
     {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) (a c k : Fin D) :
     hStruct.twoSiteVirtualBondConfig a c k 1 = (k, c) := by
@@ -867,13 +877,7 @@ theorem AppendixBStructuralData.twoSiteBasicSupportProjection_idempotent
     hStruct.twoSiteBasicSupportProjection * hStruct.twoSiteBasicSupportProjection =
       hStruct.twoSiteBasicSupportProjection := by
   rw [hStruct.twoSiteBasicSupportProjection_eq_complement]
-  apply LinearMap.ext
-  intro v
-  simp only [Module.End.mul_apply, LinearMap.sub_apply, Module.End.one_apply, map_sub]
-  have hq := LinearMap.congr_fun (parentInteraction_idempotent hStruct.coreTensor 2) v
-  simp only [Module.End.mul_apply] at hq
-  rw [hq]
-  abel
+  exact (parentInteraction_idempotent hStruct.coreTensor 2).one_sub
 
 /-- The range of the support projector is the range of the bond-insertion
 embedding \(U^{\otimes2}I_\varphi\).

--- a/TNLean/MPS/RFP/Assembly.lean
+++ b/TNLean/MPS/RFP/Assembly.lean
@@ -2,9 +2,8 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TNLean.MPS.RFP.Defs
 import TNLean.MPS.RFP.ZeroCorrelationLength
-import TNLean.MPS.RFP.StructuralForm
+import TNLean.PiAlgebra.CanonicalFormSepAux
 
 /-!
 # Per-block equivalence of RFP and ZCL

--- a/TNLean/MPS/RFP/CommutingBridge.lean
+++ b/TNLean/MPS/RFP/CommutingBridge.lean
@@ -2,11 +2,10 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+import TNLean.MPS.Core.CyclicTrace
 import TNLean.MPS.ParentHamiltonian.Basic
 import TNLean.MPS.ParentHamiltonian.LocalSupport
-import TNLean.MPS.Core.CyclicTrace
 import TNLean.MPS.RFP.StructuralFull
-import Mathlib.Data.Fin.Basic
 
 /-!
 # Basic-vector form and translated two-site parent terms
@@ -89,6 +88,7 @@ def productPairWindow (N : ℕ) (σ : Cfg d (2 * N)) (p : Fin N) : Cfg d 2 :=
     have hj : j.val < 2 := j.isLt
     omega⟩
 
+/-- Evaluating a physical pair window selects sites `2 * p` and `2 * p + 1`. -/
 @[simp] lemma productPairWindow_apply (N : ℕ) (σ : Cfg d (2 * N)) (p : Fin N)
     (j : Fin 2) :
     productPairWindow N σ p j = σ ⟨2 * p.val + j.val, by
@@ -114,6 +114,7 @@ therefore has to be justified separately from the source formula. -/
 def productPairState (ψ₂ : NSiteSpace d 2) (N : ℕ) : NSiteSpace d (2 * N) :=
   fun σ => ∏ p : Fin N, ψ₂ (productPairWindow N σ p)
 
+/-- The zero-fold physical pair product is the constant-one state. -/
 @[simp] lemma productPairState_zero (ψ₂ : NSiteSpace d 2) :
     productPairState ψ₂ 0 = fun _ => (1 : ℂ) := by
   funext σ
@@ -158,6 +159,7 @@ structure HasProductPairLocalProjectors (A : MPSTensor d D) (N : ℕ) where
   hlocal : ∀ i, localTerm A 2 N i = proj i
   hcomm : ∀ i j, proj i * proj j = proj j * proj i
 
+/-- Each local term supplied by `HasProductPairLocalProjectors` is idempotent. -/
 theorem HasProductPairLocalProjectors.localTerm_idempotent
     {A : MPSTensor d D} {N : ℕ}
     (hPair : HasProductPairLocalProjectors A N) (i : Fin N) :
@@ -216,6 +218,7 @@ theorem ProductPairBridge.commuting_twoSite_localTerms
         localTerm A 2 N j * localTerm A 2 N i :=
   (hBridge.localProjectors N hN).commuting_twoSite_localTerms
 
+/-- Every local term supplied by a product-pair bridge is idempotent. -/
 theorem ProductPairBridge.localTerm_idempotent
     {A : MPSTensor d D} (hBridge : ProductPairBridge A) (N : ℕ) (hN : 2 < N)
     (i : Fin N) :
@@ -344,12 +347,8 @@ Source: arXiv:1606.00608, Theorem 3.11 and isometry equation (3.16), lines
 543--578. -/
 theorem AppendixBStructuralData.physicalIsometry_injective
     {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
-    Function.Injective hStruct.physicalIsometry := by
-  intro v w hvw
-  have hv := LinearMap.congr_fun hStruct.physicalIsometryLeftInverse_comp v
-  have hw := LinearMap.congr_fun hStruct.physicalIsometryLeftInverse_comp w
-  have hvw' := congrArg hStruct.physicalIsometryLeftInverse hvw
-  exact hv.symm.trans (hvw'.trans hw)
+    Function.Injective hStruct.physicalIsometry :=
+  LinearMap.injective_of_comp_eq_id _ _ hStruct.physicalIsometryLeftInverse_comp
 
 /-- The proved structural form gives a nonempty bundled Appendix B form. -/
 theorem AppendixBStructuralData.exists_ofRFP (A : MPSTensor d D) [NeZero D]
@@ -403,6 +402,7 @@ noncomputable def AppendixBStructuralData.coreTensor {A : MPSTensor d D}
     (hStruct : AppendixBStructuralData A) : MPSTensor d D :=
   fun i => Matrix.diagonal (fun k => (hStruct.Λ k : ℂ)) * hStruct.U i
 
+/-- The Appendix B core tensor is the residual tensor weighted by the diagonal factor. -/
 @[simp] theorem AppendixBStructuralData.coreTensor_apply {A : MPSTensor d D}
     (hStruct : AppendixBStructuralData A) (i : Fin d) :
     hStruct.coreTensor i = Matrix.diagonal (fun k => (hStruct.Λ k : ℂ)) * hStruct.U i :=

--- a/TNLean/MPS/RFP/Convergence.lean
+++ b/TNLean/MPS/RFP/Convergence.lean
@@ -2,11 +2,8 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TNLean.MPS.Core.Transfer
 import TNLean.PiAlgebra.CanonicalFormSepAux
-import TNLean.Spectral.TransferOperatorGap
 import TNLean.Spectral.QuantitativeGap
-import TNLean.MPS.RFP.Defs
 
 /-!
 # RG flow convergence for canonical-form MPS tensors

--- a/TNLean/MPS/RFP/ResidualIsometry.lean
+++ b/TNLean/MPS/RFP/ResidualIsometry.lean
@@ -396,6 +396,14 @@ namespace IsBNTCanonicalForm
 
 variable {P : SectorDecomposition d}
 
+/-- Every basis tensor in BNT canonical form is normal. -/
+private lemma basis_isNormal (hCF : IsBNTCanonicalForm P) (k : Fin P.basisCount) :
+    IsNormal (P.basis k) := by
+  letI : NeZero (P.basisDim k) := ⟨(hCF.basis_dim_pos k).ne'⟩
+  exact isNormal_of_irreducible_leftCanonical_selfOverlap_tendsto_one
+    (P.basis k) (hCF.basis_irreducible k) (hCF.basis_left_canonical k)
+      (hCF.basis_normalized_self_overlap k)
+
 /-- **Multiplicity-one characterization for the basis of normal tensors.**
 
 If `P` is in BNT canonical form, then the direct sum of its distinct basis
@@ -417,13 +425,8 @@ theorem isTransferIdempotent_basisDirectSum_iff (hCF : IsBNTCanonicalForm P) :
           mixedTransferMap₂ (P.basis j) (P.basis j') = 0) := by
   letI : ∀ k : Fin P.basisCount, NeZero (P.basisDim k) :=
     fun k => ⟨(hCF.basis_dim_pos k).ne'⟩
-  have hnormal : ∀ k : Fin P.basisCount, IsNormal (P.basis k) := by
-    intro k
-    exact isNormal_of_irreducible_leftCanonical_selfOverlap_tendsto_one
-      (P.basis k) (hCF.basis_irreducible k) (hCF.basis_left_canonical k)
-        (hCF.basis_normalized_self_overlap k)
-  exact isTransferIdempotent_directSumTensor_iff P.basis hnormal hCF.basis_irreducible
-    hCF.basis_left_canonical hCF.basis_distinct
+  exact isTransferIdempotent_directSumTensor_iff P.basis (basis_isNormal hCF)
+    hCF.basis_irreducible hCF.basis_left_canonical hCF.basis_distinct
 
 /-- **Residual isometry family for a BNT basis direct sum.**
 
@@ -451,13 +454,8 @@ theorem exists_residualIsometryFamily_of_isTransferIdempotent_basisDirectSum
       IsResidualIsometryFamily U := by
   letI : ∀ k : Fin P.basisCount, NeZero (P.basisDim k) :=
     fun k => ⟨(hCF.basis_dim_pos k).ne'⟩
-  have hnormal : ∀ k : Fin P.basisCount, IsNormal (P.basis k) := by
-    intro k
-    exact isNormal_of_irreducible_leftCanonical_selfOverlap_tendsto_one
-      (P.basis k) (hCF.basis_irreducible k) (hCF.basis_left_canonical k)
-        (hCF.basis_normalized_self_overlap k)
-  exact exists_residualIsometryFamily_of_isTransferIdempotent_directSum P.basis hnormal
-    hCF.basis_irreducible hCF.basis_left_canonical hCF.basis_distinct hRFP
+  exact exists_residualIsometryFamily_of_isTransferIdempotent_directSum P.basis
+    (basis_isNormal hCF) hCF.basis_irreducible hCF.basis_left_canonical hCF.basis_distinct hRFP
 
 end IsBNTCanonicalForm
 

--- a/TNLean/MPS/RFP/StructuralForm.lean
+++ b/TNLean/MPS/RFP/StructuralForm.lean
@@ -2,10 +2,10 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TNLean.MPS.RFP.Defs
 import TNLean.MPS.Core.CPPrimitive
-import TNLean.PiAlgebra.CanonicalFormSepAux
 import TNLean.MPS.Irreducible.FormII
+import TNLean.MPS.RFP.Defs
+import TNLean.PiAlgebra.CanonicalFormSepAux
 import TNLean.Spectral.QuantitativeGap
 
 /-!

--- a/TNLean/MPS/RFP/StructuralFull.lean
+++ b/TNLean/MPS/RFP/StructuralFull.lean
@@ -935,7 +935,7 @@ theorem isTransferIdempotent_of_isIsometryCanonicalForm (A : MPSTensor d D)
       show Xᴴ * (X⁻¹)ᴴ = (X⁻¹ * X)ᴴ from (Matrix.conjTranspose_mul X⁻¹ X).symm,
       hXinvX, Matrix.conjTranspose_one, Matrix.mul_one, Matrix.trace_diagonal,
       ← Complex.ofReal_sum, hΛ_sum, Complex.ofReal_one]
-  show transferMap A ∘ₗ transferMap A = transferMap A
+  change transferMap A ∘ₗ transferMap A = transferMap A
   apply LinearMap.ext
   intro Y
   simp only [LinearMap.comp_apply]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
@@ -40,11 +40,23 @@
     This is \cite[Definition~4.6, line~811]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
+\begin{lemma}[Constancy on a finite interval]
+    \label{lem:finite_interval_constancy}
+    \lean{eq_of_forall_succ_eq_of_mem_Icc}
+    \leanok
+    Let $f$ be defined on the integer interval $[a,n]$. If
+    $f(m)=f(m+1)$ for every $a\le m<n$, then $f(i)=f(j)$ for all
+    $i,j\in[a,n]$.
+\end{lemma}
+\begin{proof}\leanok
+    Compose the successive equalities from the smaller index to the larger.
+\end{proof}
+
 \begin{lemma}[Saturation telescopes to a constant mutual information]
     \label{lem:sal_const}
     \lean{MPOTensor.mutualInfoChain_eq_of_isSAL}
     \leanok
-    \uses{def:is_sal}
+    \uses{def:is_sal, lem:finite_interval_constancy}
     If an MPO tensor $M$ saturates the area law, then the mutual informations
     coincide for all $1\le L, L'\le \lfloor N/2\rfloor$:
     \[
@@ -52,10 +64,10 @@
     \]
 \end{lemma}
 \begin{proof}\leanok
-    \uses{def:is_sal}
-    The defining condition supplies the single-step equalities $I_m = I_{m+1}$ for
-    $1\le m<\lfloor N/2\rfloor$. Climbing one step at a time from the smaller of $L$
-    and $L'$ up to the larger composes these into the stated equality.
+    \uses{def:is_sal, lem:finite_interval_constancy}
+    The defining condition supplies $I_m=I_{m+1}$ throughout the interval
+    $1\le m<\lfloor N/2\rfloor$. Apply
+    Lemma~\ref{lem:finite_interval_constancy}.
 \end{proof}
 
 \begin{theorem}[Tripartite marginals as block entropies]
@@ -323,19 +335,46 @@
     $I_L = S_L + S_{N-L} - S_N$, using $N-(N-L) = L$.
 \end{proof}
 
+\begin{lemma}[Positive rank of a normalized state]
+    \label{lem:trace_one_positive_rank}
+    \lean{Matrix.PosSemidef.rank_pos_of_trace_one}
+    \leanok
+    A positive semidefinite matrix of trace one has positive rank.
+\end{lemma}
+\begin{proof}\leanok
+    If its rank were zero, every eigenvalue would vanish, contradicting that
+    their sum is the trace, which equals one.
+\end{proof}
+
+\begin{lemma}[Zero entropy in rank one]
+    \label{lem:rank_one_entropy_zero}
+    \lean{vonNeumannEntropy_eq_zero_of_rank_le_one}
+    \leanok
+    \uses{lem:trace_one_positive_rank, thm:entropy_le_log_rank,
+        thm:entropy_nonneg}
+    A positive semidefinite matrix of trace one and rank at most one has zero
+    von Neumann entropy.
+\end{lemma}
+\begin{proof}\leanok
+    \uses{lem:trace_one_positive_rank, thm:entropy_le_log_rank,
+        thm:entropy_nonneg}
+    Its rank is positive by Lemma~\ref{lem:trace_one_positive_rank}, hence it is
+    exactly one. The rank bound gives $S\le\log 1=0$, while entropy is
+    nonnegative.
+\end{proof}
+
 \begin{lemma}[Entropy of the empty block]
     \label{lem:block_entropy_zero}
     \lean{blockEntropy_zero}
     \leanok
-    \uses{def:block_entropy, thm:entropy_le_log_rank, lem:block_entropy_nonneg}
+    \uses{def:block_entropy, lem:rank_one_entropy_zero}
     For a normalized positive semidefinite finite-chain operator, the block entropy of
     the empty block vanishes: $S_0 = 0$.
 \end{lemma}
 \begin{proof}\leanok
-    \uses{thm:entropy_le_log_rank, lem:block_entropy_nonneg}
-    The reduced state of zero spins is one-dimensional, so its rank is one and the rank
-    bound on the entropy gives $S_0 \le \log 1 = 0$; with $S_0 \ge 0$ this forces
-    $S_0 = 0$.
+    \uses{lem:rank_one_entropy_zero}
+    The reduced state of zero spins is one-dimensional, so its rank is at most
+    one. Lemma~\ref{lem:rank_one_entropy_zero} gives $S_0=0$.
 \end{proof}
 
 \begin{lemma}[Empty-block mutual information vanishes]
@@ -734,8 +773,8 @@
 \begin{proposition}[Pure-state area-law upper bound]\label{prop:pure_area_upper}
     \lean{MPSTensor.pureBlockEntropy_le}
     \leanok
-    \uses{lem:operator_schmidt_rank, thm:entropy_le_log_rank,
-        lem:reduced_pure_block_state_density}
+    \uses{lem:operator_schmidt_rank, lem:trace_one_positive_rank,
+        thm:entropy_le_log_rank, lem:reduced_pure_block_state_density}
     Let $A$ be an MPS tensor of bond dimension $D\ge 1$ with $V^{(N)}(A)\neq 0$.
     For every block length $L\le N$,
     \[
@@ -746,12 +785,13 @@
     by a constant independent of the block size.
 \end{proposition}
 \begin{proof}\leanok
-    \uses{lem:reduced_pure_block_state_density}
+    \uses{lem:operator_schmidt_rank, lem:trace_one_positive_rank,
+        thm:entropy_le_log_rank, lem:reduced_pure_block_state_density}
     The reduced state $\rho_L^{(N)}(A)$ is a density matrix
-    (Lemma~\ref{lem:reduced_pure_block_state_density}) of rank at most $D^2$ by
-    Lemma~\ref{lem:operator_schmidt_rank}. By the rank bound on the entropy
-    (Theorem~\ref{thm:entropy_le_log_rank}),
-    $S_L^{(N)}(A) \le \log(D^2) = 2\log D$.
+    (Lemma~\ref{lem:reduced_pure_block_state_density}), so its rank is positive
+    by Lemma~\ref{lem:trace_one_positive_rank}. Its rank is at most $D^2$ by
+    Lemma~\ref{lem:operator_schmidt_rank}. The rank bound on the entropy gives
+    $S_L^{(N)}(A)\le\log(D^2)=2\log D$.
 \end{proof}
 
 \begin{lemma}[Nonnegativity of the pure-state block entropy]
@@ -807,7 +847,7 @@
     \label{lem:pure_sal_const}
     \lean{MPSTensor.pureBlockEntropy_eq_of_isSAL}
     \leanok
-    \uses{def:pure_sal}
+    \uses{def:pure_sal, lem:finite_interval_constancy}
     If an MPS tensor $A$ saturates the area law, then the block entropies
     coincide for all $1\le L, L'\le \lfloor N/2\rfloor$:
     \[
@@ -815,11 +855,11 @@
     \]
 \end{lemma}
 \begin{proof}\leanok
-    \uses{def:pure_sal}
-    The defining condition supplies the single-step equalities
-    $S_m^{(N)}(A) = S_{m+1}^{(N)}(A)$ for $1\le m<\lfloor N/2\rfloor$. Climbing one
-    step at a time from the smaller of $L$ and $L'$ up to the larger composes these
-    into the stated equality.
+    \uses{def:pure_sal, lem:finite_interval_constancy}
+    The defining condition supplies
+    $S_m^{(N)}(A)=S_{m+1}^{(N)}(A)$ throughout the interval
+    $1\le m<\lfloor N/2\rfloor$. Apply
+    Lemma~\ref{lem:finite_interval_constancy}.
 \end{proof}
 
 \begin{lemma}[Pure-state mutual information is twice the block entropy]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -255,7 +255,7 @@ them.
     where $A_r$ denotes the corresponding row reindexing.
 \end{lemma}
 \begin{proof}\leanok
-    The first identity follows because dependent block-diagonal matrices
+    The first identity follows because block-diagonal matrices
     multiply blockwise. The second follows by commuting bijective row
     reindexing with multiplication and adjunction.
 \end{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -239,6 +239,48 @@ them.
     the fixed factors accumulate into the matrix power $X_\gamma^L$.
 \end{proof}
 
+\begin{lemma}[Blockwise conjugation and restriction]
+    \label{lem:matrix_block_conjugation_restriction}
+    \lean{Matrix.blockDiagonal'_conj, Matrix.submatrix_left_conj_equiv}
+    \leanok
+    Let $F=\bigoplus_a F_a$ and $G=\bigoplus_a G_a$. Then
+    \[
+        FGF^\dagger=\bigoplus_a F_aG_aF_a^\dagger.
+    \]
+    Moreover, if $r$ is a bijective reindexing of the row space of a matrix
+    $A$, then
+    \[
+        A_r X A_r^\dagger=(AXA^\dagger)_{r,r},
+    \]
+    where $A_r$ denotes the corresponding row reindexing.
+\end{lemma}
+\begin{proof}\leanok
+    The first identity follows because dependent block-diagonal matrices
+    multiply blockwise. The second follows by commuting bijective row
+    reindexing with multiplication and adjunction.
+\end{proof}
+
+\begin{lemma}[Cancellation of a nonempty identity factor]
+    \label{lem:matrix_kronecker_identity_cancellation}
+    \lean{Matrix.kronecker_one_injective, Matrix.mul_kronecker_one,
+        Matrix.mul_eq_one_of_kronecker_one,
+        Matrix.mul_conjTranspose_eq_one_of_kronecker_one,
+        Matrix.conjTranspose_mul_eq_one_of_kronecker_one}
+    \leanok
+    Let $D>0$. The map $A\mapsto A\otimes I_D$ is injective and preserves
+    matrix products. Consequently,
+    \[
+        (F\otimes I_D)(G\otimes I_D)=I \implies FG=I.
+    \]
+    In particular, orthonormal rows or columns of $F\otimes I_D$ imply the
+    corresponding orthonormality of $F$.
+\end{lemma}
+\begin{proof}\leanok
+    Evaluate the amplified identity on one basis vector of the nonzero
+    factor. Multiplicativity of the Kronecker product gives the product and
+    adjoint specializations.
+\end{proof}
+
 \begin{definition}[Fusion-isometry family]%
     \label{def:mpdo_bnt_fusion_isometry_family}
     \lean{MPOTensor.BNTFusionIsometryFamily}
@@ -638,7 +680,8 @@ separate step.
     \label{thm:mpdo_left_fusion_apply}
     \lean{MPOTensor.BNTFusionIsometryFamily.leftFusion_apply}
     \leanok
-    \uses{def:mpdo_left_fusion_isometry, def:mpdo_operator_product}
+    \uses{def:mpdo_left_fusion_isometry, def:mpdo_operator_product,
+        lem:matrix_block_conjugation_restriction}
     Site by site,
     \[
         U^{\mathrm L}_{\alpha,\beta,\gamma}\,
@@ -651,12 +694,13 @@ separate step.
     \]
 \end{theorem}
 \begin{proof}\leanok
+    \uses{lem:matrix_block_conjugation_restriction}
     Apply the fusion identity for $U_{\alpha,\beta}$ to the first two
     tensors, summed against the physical index contracting with the third
-    tensor; regrouping the resulting sum block by block over $\delta$
-    exhibits it as $\chi_{\alpha,\beta,\delta}$ tensored with a letter of the
-    product tensor $M_\delta M_\gamma$, to which the fusion identity for
-    $U_{\delta,\gamma}$ applies.
+    tensor. Regroup the result over $\delta$ and use blockwise conjugation to
+    obtain $\chi_{\alpha,\beta,\delta}$ tensored with a letter of
+    $M_\delta M_\gamma$. The fusion identity for $U_{\delta,\gamma}$ gives the
+    second direct sum.
 \end{proof}
 
 \begin{definition}[Iterated fusion isometry of a triple product, right
@@ -695,7 +739,8 @@ separate step.
     \label{thm:mpdo_right_fusion_apply}
     \lean{MPOTensor.BNTFusionIsometryFamily.rightFusion_apply}
     \leanok
-    \uses{def:mpdo_right_fusion_isometry, def:mpdo_operator_product}
+    \uses{def:mpdo_right_fusion_isometry, def:mpdo_operator_product,
+        lem:matrix_block_conjugation_restriction}
     Site by site,
     \[
         U^{\mathrm R}_{\alpha,\beta,\gamma}\,
@@ -708,15 +753,17 @@ separate step.
     \]
 \end{theorem}
 \begin{proof}\leanok
+    \uses{lem:matrix_block_conjugation_restriction}
     Apply the fusion identity for $U_{\beta,\gamma}$ to $M_\beta M_\gamma$.
     In the summand indexed by $\delta$, exchange the first multiplicity
-    factor with the bond space of $M_\alpha$ and regroup the contraction as
+    factor with the bond space of $M_\alpha$. Blockwise conjugation regroups
+    the contraction as
     \[
         \chi_{\beta,\gamma,\delta}\otimes
         (M_\alpha M_\delta)^{i j}.
     \]
-    The fusion identity for $U_{\alpha,\delta}$ then gives the stated direct
-    sum over $\varepsilon$.
+    The fusion identity for $U_{\alpha,\delta}$ gives the sum over
+    $\varepsilon$.
 \end{proof}
 
 \begin{definition}[Full comparison of the two triple-fusion orders]%
@@ -1196,7 +1243,8 @@ separate step.
     \lean{MPOTensor.BNTFusionIsometryFamily.leftFinalFusion_apply}
     \leanok
     \uses{def:mpdo_final_sector_fusion_maps,
-        def:mpdo_operator_product, thm:mpdo_left_fusion_apply}
+        def:mpdo_operator_product, thm:mpdo_left_fusion_apply,
+        lem:matrix_block_conjugation_restriction}
     For every final label $\varepsilon$, the left-associated restriction
     satisfies the positive-diagonal weighted identity
     \[
@@ -1210,9 +1258,11 @@ separate step.
     \]
 \end{theorem}
 \begin{proof}\leanok
+    \uses{lem:matrix_block_conjugation_restriction}
     Restrict Theorem~\ref{thm:mpdo_left_fusion_apply} to the rows and columns
-    whose final label is $\varepsilon$.  The outer block-diagonal matrix then
-    retains precisely the displayed $\varepsilon$-blocks.
+    whose final label is $\varepsilon$. Reindexing the conjugating matrix
+    commutes with conjugation, and the outer block-diagonal matrix retains
+    precisely the displayed $\varepsilon$-blocks.
 \end{proof}
 
 \begin{theorem}[Right triple fusion at a fixed final label]%
@@ -1220,7 +1270,8 @@ separate step.
     \lean{MPOTensor.BNTFusionIsometryFamily.rightFinalFusion_apply}
     \leanok
     \uses{def:mpdo_final_sector_fusion_maps,
-        def:mpdo_operator_product, thm:mpdo_right_fusion_apply}
+        def:mpdo_operator_product, thm:mpdo_right_fusion_apply,
+        lem:matrix_block_conjugation_restriction}
     For every final label $\varepsilon$, the right-associated restriction
     satisfies the positive-diagonal weighted identity
     \[
@@ -1234,9 +1285,11 @@ separate step.
     \]
 \end{theorem}
 \begin{proof}\leanok
+    \uses{lem:matrix_block_conjugation_restriction}
     Restrict Theorem~\ref{thm:mpdo_right_fusion_apply} to the rows and columns
-    whose final label is $\varepsilon$.  The outer block-diagonal matrix then
-    retains precisely the displayed $\varepsilon$-blocks.
+    whose final label is $\varepsilon$. Reindexing the conjugating matrix
+    commutes with conjugation, and the outer block-diagonal matrix retains
+    precisely the displayed $\varepsilon$-blocks.
 \end{proof}
 
 \begin{theorem}[Injective fixed-final intertwiners]%
@@ -1389,7 +1442,8 @@ separate step.
     \leanok
     \uses{def:mpdo_final_label_selector_words,
         def:mpdo_final_sector_multiplicity_spaces,
-        def:mpdo_triple_fusion_comparison}
+        def:mpdo_triple_fusion_comparison,
+        lem:matrix_kronecker_identity_cancellation}
     Assume the hypotheses of
     Theorem~\ref{thm:mpdo_triple_fusion_comparison_final_sector_unitary}.
     Suppose in addition that $M_\varepsilon$ is injective at the present
@@ -1413,7 +1467,8 @@ separate step.
 \end{theorem}
 \begin{proof}\leanok
     \uses{thm:mpdo_triple_fusion_comparison_final_sector_kronecker,
-        thm:mpdo_triple_fusion_comparison_final_sector_unitary}
+        thm:mpdo_triple_fusion_comparison_final_sector_unitary,
+        lem:matrix_kronecker_identity_cancellation}
     Injectivity gives
     $C_\varepsilon=F_\varepsilon\otimes1_{D_\varepsilon}$.
     Substitute this expression into the two identities for $C_\varepsilon$:
@@ -1424,8 +1479,8 @@ separate step.
         (F_\varepsilon^\dagger F_\varepsilon)
           \otimes1_{D_\varepsilon}=1.
     \]
-    Since $D_\varepsilon>0$, evaluation at any bond basis vector cancels the
-    identity factor and gives the two asserted identities.
+    Since $D_\varepsilon>0$, Lemma~\ref{lem:matrix_kronecker_identity_cancellation}
+    removes the identity factor and gives the two asserted identities.
 \end{proof}
 
 \begin{theorem}[Simultaneous inverse from a one-letter product-algebra span]%
@@ -1566,6 +1621,26 @@ separate step.
     Definition~\ref{def:mpdo_complete_zipper_fusion_family}.
 \end{proof}
 
+\begin{definition}[One-letter final-block selector]
+    \label{def:mpdo_complete_zipper_final_block_selector}
+    \lean{MPOTensor.CompleteZipperFusionFamily.finalBlockSelector,
+        MPOTensor.CompleteZipperFusionFamily.finalBlockSelector_apply,
+        MPOTensor.CompleteZipperFusionFamily.finalBlockSelector_sum}
+    \leanok
+    \uses{def:mpdo_complete_zipper_fusion_family}
+    Fix a final label $d$. Summing the diagonal matrix-unit coefficients of
+    the simultaneous block inverse defines scalars $s_d(i,j)$ satisfying
+    \[
+        \sum_{i,j}s_d(i,j)B_e^{ij}
+        =\begin{cases}
+            I_{D_d},&e=d,\\
+            0,&e\ne d.
+          \end{cases}
+    \]
+    Thus one physical letter selects the identity on the chosen final block
+    and annihilates every other final block.
+\end{definition}
+
 \begin{theorem}[Printed F-move and inverse]%
     \label{thm:mpdo_complete_zipper_printed_fmove}
     \lean{MPOTensor.CompleteZipperFusionFamily.%
@@ -1575,7 +1650,9 @@ separate step.
     \lean{MPOTensor.CompleteZipperFusionFamily.%
         inversePrintedFMatrix_mul_printedFMatrix}
     \leanok
-    \uses{def:mpdo_complete_zipper_fusion_family}
+    \uses{def:mpdo_complete_zipper_fusion_family,
+        def:mpdo_complete_zipper_final_block_selector,
+        lem:matrix_kronecker_identity_cancellation}
     Fix $a,b,c,d\in\Lambda$.  There is an invertible matrix
     \[
         F^{abc}_d:
@@ -1597,6 +1674,8 @@ separate step.
     the printed $F$-move of \cite[Section~3.4]{Bultinck2017Anyons}.
 \end{theorem}
 \begin{proof}\leanok
+    \uses{def:mpdo_complete_zipper_final_block_selector,
+        lem:matrix_kronecker_identity_cancellation}
     Form the full left- and right-associated synthesis matrices $L$ and $R$
     and their analysis matrices $L^+$ and $R^+$.  Applying the reconstruction
     equation twice to the two associative decompositions gives
@@ -1604,9 +1683,10 @@ separate step.
         B_{abc}^{il}=L D_{\mathrm L}^{il}L^+
           =R D_{\mathrm R}^{il}R^+.
     \]
-    Contract this equality with the simultaneous inverse of the final block
-    letters and sum the diagonal final-label matrix units.  The two direct
-    sums $D_{\mathrm L}$ and $D_{\mathrm R}$ both contract to the identity.
+    Contract this equality with the one-letter final-block selector from
+    Definition~\ref{def:mpdo_complete_zipper_final_block_selector}. The two
+    direct sums $D_{\mathrm L}$ and $D_{\mathrm R}$ both contract to the
+    identity.
     Consequently,
     \[
         P:=LL^+=RR^+,
@@ -1632,7 +1712,10 @@ separate step.
     \]
     Restricting $R(R^+L)=L$ to this corner gives the displayed $F$-move.
     The corresponding fixed-final corner of $L^+R$, together with
-    $(R^+L)(L^+R)=1=(L^+R)(R^+L)$, gives the two inverse identities.
+    $(R^+L)(L^+R)=1=(L^+R)(R^+L)$, gives amplified inverse identities.
+    Lemma~\ref{lem:matrix_kronecker_identity_cancellation} removes the
+    nonempty bond-space identity factor and yields the two inverse identities
+    for $F^{abc}_d$.
 \end{proof}
 
 \begin{figure}[ht]
@@ -1721,7 +1804,8 @@ separate step.
     \lean{MPOTensor.CompleteZipperFusionFamily.inversePrintedFMatrix_pentagon}
     \leanok
     \uses{def:mpdo_complete_zipper_fourfold_fusion_data,
-        thm:mpdo_complete_zipper_printed_fmove}
+        thm:mpdo_complete_zipper_printed_fmove,
+        lem:matrix_kronecker_identity_cancellation}
     The three-edge and two-edge composites of the forward printed
     $F$-matrices are equal.  The corresponding composites of the inverse
     $F$-matrices are also equal.  In the upper/lower convention of
@@ -1740,13 +1824,16 @@ separate step.
     the $F$-move convention.
 \end{theorem}
 \begin{proof}\leanok
+    \uses{lem:matrix_kronecker_identity_cancellation}
     Apply the elementary three-block $F$-move along each of the five edges.
-    Both paths then give the same expansion in the right-associated fourfold
-    fusion map.  Its analysis map is a left inverse, by three successive
-    applications of fusion-tensor biorthogonality, so the forward composites
-    are equal.  The reverse composites are two-sided inverses of this common
-    matrix, hence they coincide.  Taking a matrix entry gives the displayed
-    identity.
+    Both paths give the same expansion in the right-associated fourfold
+    fusion map. Its analysis map is a left inverse, by three successive
+    applications of fusion-tensor biorthogonality. This gives equality after
+    tensoring with the identity on the nonzero final bond space, and
+    Lemma~\ref{lem:matrix_kronecker_identity_cancellation} gives equality of
+    the forward composites. The reverse composites are two-sided inverses of
+    this common matrix, hence they coincide. Taking a matrix entry gives the
+    displayed identity.
 \end{proof}
 
 \begin{theorem}[Coherence of four bond-coordinate reassociations]%

--- a/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
@@ -320,7 +320,7 @@
     \lean{Matrix.controlledKrausMap_isKrausCPTP}
     \leanok
     \uses{def:mpdo_controlled_kraus_map,
-        thm:mpdo_rectangular_kraus_map_cptp}
+        def:is_kraus_cptp}
     Suppose that for every $k$ the sectorwise Kraus family resolves the
     identity:
     \[
@@ -383,7 +383,7 @@
     \lean{Matrix.partialTraceRightLM_isKrausCPTP}
     \leanok
     \uses{def:mpdo_right_partial_trace_map,
-        thm:mpdo_rectangular_kraus_map_cptp}
+        def:is_kraus_cptp}
     The map $\tr_{B}$ is trace-preserving and completely positive for arbitrary
     finite-dimensional spaces $A$ and $B$.
 \end{lemma}
@@ -478,7 +478,7 @@
     \leanok
     \uses{def:mpdo_state_preparation_map,
       def:mpdo_state_preparation_kraus,
-      thm:mpdo_rectangular_kraus_map_cptp}
+      def:is_kraus_cptp}
     If $\rho\geq0$ and $\tr(\rho)=1$, then
     $\mathcal P_\rho:X\mapsto X\otimes\rho$ is trace-preserving completely
     positive.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
@@ -217,6 +217,23 @@
     \]
 \end{definition}
 
+\begin{theorem}[Rectangular Kraus resolution]
+    \label{thm:mpdo_rectangular_kraus_map_cptp}
+    \lean{Matrix.rectangularKrausMap_isKrausCPTP}
+    \leanok
+    \uses{def:is_kraus_cptp, def:mpdo_rectangular_kraus_map}
+    Let $(A_a:H\to K)_a$ be a finite family of rectangular operators. If
+    \[
+        \sum_a A_a^\dagger A_a=I_H,
+    \]
+    then $X\mapsto\sum_a A_aXA_a^\dagger$ is trace-preserving and completely
+    positive.
+\end{theorem}
+\begin{proof}\leanok
+    The displayed family is already a Kraus representation, and the assumed
+    identity is precisely its trace-preserving normalization.
+\end{proof}
+
 \begin{theorem}[Relabeling a rectangular Kraus family]
     \label{thm:mpdo_rectangular_kraus_map_equiv}
     \lean{Matrix.rectangularKrausMap_equiv}
@@ -302,7 +319,8 @@
     \label{thm:mpdo_controlled_kraus_map_cptp}
     \lean{Matrix.controlledKrausMap_isKrausCPTP}
     \leanok
-    \uses{def:mpdo_controlled_kraus_map, def:is_kraus_cptp}
+    \uses{def:mpdo_controlled_kraus_map,
+        thm:mpdo_rectangular_kraus_map_cptp}
     Suppose that for every $k$ the sectorwise Kraus family resolves the
     identity:
     \[
@@ -313,14 +331,15 @@
 \end{theorem}
 \begin{proof}
     \leanok
+    \uses{thm:mpdo_rectangular_kraus_map_cptp}
     Each embedded operator has support in one summand, and therefore
     \[
         \sum_{k,a}\widetilde A_{k,a}^{\dagger}\widetilde A_{k,a}
         =\bigoplus_k\left(\sum_a A_{k,a}^{\dagger}A_{k,a}\right)
         =\bigoplus_k I_{H_k}=I_H.
     \]
-    The displayed Kraus form gives complete positivity, while this identity
-    gives trace preservation.
+    Apply Theorem~\ref{thm:mpdo_rectangular_kraus_map_cptp} to the combined
+    rectangular Kraus family $(\widetilde A_{k,a})_{k,a}$.
 \end{proof}
 
 \begin{definition}[Right partial trace]
@@ -363,13 +382,15 @@
     \label{lem:mpdo_right_partial_trace_cptp}
     \lean{Matrix.partialTraceRightLM_isKrausCPTP}
     \leanok
-    \uses{def:mpdo_right_partial_trace_map, def:is_kraus_cptp}
+    \uses{def:mpdo_right_partial_trace_map,
+        thm:mpdo_rectangular_kraus_map_cptp}
     The map $\tr_{B}$ is trace-preserving and completely positive for arbitrary
     finite-dimensional spaces $A$ and $B$.
 \end{lemma}
 
 \begin{proof}
     \leanok
+    \uses{thm:mpdo_rectangular_kraus_map_cptp}
     For each basis vector $e_k$ of $B$, define
     $V_k:A\otimes B\to A$ by
     \[
@@ -381,6 +402,7 @@
         \qquad
         \sum_k V_k^\dagger V_k=I_{A\otimes B}.
     \]
+    Theorem~\ref{thm:mpdo_rectangular_kraus_map_cptp} applies.
 \end{proof}
 
 \begin{definition}[State-preparation map]
@@ -454,8 +476,9 @@
     \label{lem:mpdo_state_preparation_cptp}
     \lean{Matrix.preparationMap_isKrausCPTP}
     \leanok
-    \uses{def:mpdo_state_preparation_map, def:is_kraus_cptp,
-      def:mpdo_state_preparation_kraus}
+    \uses{def:mpdo_state_preparation_map,
+      def:mpdo_state_preparation_kraus,
+      thm:mpdo_rectangular_kraus_map_cptp}
     If $\rho\geq0$ and $\tr(\rho)=1$, then
     $\mathcal P_\rho:X\mapsto X\otimes\rho$ is trace-preserving completely
     positive.
@@ -463,18 +486,14 @@
 
 \begin{proof}
     \leanok
-    \uses{thm:mpdo_rectangular_kraus_map_equiv,
+    \uses{thm:mpdo_rectangular_kraus_map_cptp,
       thm:mpdo_state_preparation_kraus_action,
       thm:mpdo_state_preparation_kraus_resolution}
-    Relabel an orthonormal basis of the ancillary space by
-    $\{0,\ldots,\dim B-1\}$. Theorem~\ref{thm:mpdo_rectangular_kraus_map_equiv}
-    shows that this relabeling leaves the Kraus map unchanged, and
-    Theorem~\ref{thm:mpdo_state_preparation_kraus_action} gives
-    \[
-        \sum_j A_jXA_j^\dagger=X\otimes\rho.
-    \]
+    Theorem~\ref{thm:mpdo_state_preparation_kraus_action} identifies the map
+    with the rectangular Kraus family $(A_j)_j$, and
     Theorem~\ref{thm:mpdo_state_preparation_kraus_resolution} gives
-    $\sum_j A_j^\dagger A_j=I_A$.
+    $\sum_j A_j^\dagger A_j=I_A$. Apply
+    Theorem~\ref{thm:mpdo_rectangular_kraus_map_cptp}.
 \end{proof}
 
 \begin{definition}[Physical closure maps]


### PR DESCRIPTION
## Summary

Follow-up to #4000: run a genuinely comprehensive `LeanSimplifier` pass over the Lean modules underlying the MPS RFP and MPO/MPDO RFP blueprint chapters.

This pass reviewed the chapter-support surface in non-overlapping thematic batches and retains substantive simplifications in 43 Lean files. Highlights include:

- shared rectangular Kraus-map infrastructure for controlled, partial-trace, and preparation channels;
- common finite-interval constancy and rank-at-most-one entropy lemmas for mixed and pure area laws;
- standard equivalences and finite-product APIs in the physical-sector product constructions;
- simplified BNT coefficient comparison, multiplicity normalization, and fixed-point iteration;
- deduplicated blocked-RFP, topological-projector, and fusion-isometry arguments;
- shorter MPS RFP structural, convergence, residual-isometry, and support proofs;
- removal of unused private proof machinery and unnecessary reindexing/imports.

Public declaration names and types are preserved. The blueprint adds 14 declaration links for the reusable lemmas exposed by the refactor; the MPS RFP chapter prose required no mathematical DAG change.

## Scope

- 43 Lean files changed
- 3 MPDO RFP blueprint files changed
- 1 shared diagram-catalogue metadata file synchronized with the upstream chapter move
- net diff: 727 insertions / 745 deletions
- no new `sorry`, `axiom`, or `unsafe`
- no Mathlib source rebuild; cache obtained with `lake exe cache get`

## Verification

- [x] targeted builds for every edited batch and every serialized-build repair
- [x] full `lake build`: **9,405 jobs**
- [x] `leanblueprint checkdecls`
- [x] full blueprint compiled twice with LuaLaTeX
- [x] no specific undefined cross-references after the second pass
- [x] `git diff --check`
- [x] forbidden-addition scan for `sorry` / `axiom` / `unsafe`

All full-build regressions found by clean serialization were repaired and rechecked before publication.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with preserved APIs and no new axioms or sorry; risk is limited to accidental proof regressions in formalization, mitigated by full builds per the PR description.
> 
> **Overview**
> This PR is a broad **proof refactor** across MPS RFP and MPO/MPDO Lean (43 files) plus blueprint chapter updates. **Public theorem names and types are unchanged**; proofs are shorter and more uniform.
> 
> **New shared infrastructure**
> - **`rectangularKrausMap_isKrausCPTP`**: one lemma that a Kraus family with \(\sum A^\dagger A = I\) is CPTP. **Controlled Kraus maps**, **right partial trace**, and **state preparation** now reduce to it instead of bespoke `Fintype.equivFin` Kraus constructions.
> - **Entropy**: `rank_pos_of_trace_one` and `vonNeumannEntropy_eq_zero_of_rank_le_one`; empty-block and pure-state entropy arguments reuse these instead of inline eigenvalue/rank case splits.
> - **`eq_of_forall_succ_eq_of_mem_Icc`**: replaces repeated “climb by one step” inductions for **area-law saturation** (mixed and pure mutual information / block entropy constancy).
> - **`Matrix` utilities** in `OperatorProduct` / `BNTFusionIsometries`: Kronecker-with-\(I_D\) injectivity and “amplified identity ⇒ true identity”, block-diagonal conjugation, submatrix–conjugation commutation—**deduplicated** across fusion, zipper, and fixed-final unitarity files.
> - **BNT**: `coeff_eq_of_sum_smul_eq` for linear-independence coefficient extraction; many `eq_sum` proofs collapsed with `simpa`.
> 
> **Other simplifications**
> - Blocked RFP local structure: shared **`ofData`** constructor for PSD vs pairing-idempotent paths.
> - Physical-sector product: standard equivs (`arrowProdEquivProdArrow`), `Fintype.prod_boole` for “configuration equality” products, removed unused private lemmas.
> - Topological projectors: generic star-projection conjugation lemma.
> - Fixed-point iteration via `Function.IsFixedPt.iterate`; import/order cleanup in MPS RFP modules.
> 
> **Blueprint**
> - Adds declaration links and short lemmas for interval constancy, rank/entropy, rectangular Kraus CPTP, matrix block conjugation, and Kronecker identity cancellation; proof prose points at the new Lean lemmas instead of repeating steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ef2f9ea05a282000495a88ec0e3a3a9fb788839. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->