### PR TITLE
refactor(MPS/MPDO): clarify empty selector targets

### DIFF
--- a/TNLean/MPS/MPDO/BiCFDerivation/Selectors.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/Selectors.lean
@@ -291,12 +291,14 @@ theorem hasBlockSelectorOn_finset_of_pairBlockSeparatingWords
   revert htargets
   refine Finset.induction_on targets ?base ?step
   · intro _
-    have hEmpty : HasBlockSelectorOn A k 0 ∅ := by
+    -- This is the base of induction over the target blocks, not a physical
+    -- chain of length zero.
+    have hEmptyTargets : HasBlockSelectorOn A k 0 ∅ := by
       refine ⟨wordTuple A 0 (fun i ↦ Fin.elim0 i), ?_, ?_, ?_⟩
       · exact Submodule.subset_span ⟨fun i ↦ Fin.elim0 i, rfl⟩
       · simp [wordTuple]
       · simp
-    simpa using hEmpty
+    simpa using hEmptyTargets
   · intro j targets hj_not_mem ih htargets_insert
     have htargets_tail : ∀ l : Fin r, l ∈ targets → l ≠ k := by
       intro l hl

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections.tex
@@ -839,7 +839,9 @@ parent-Hamiltonian ground space.
 
 \begin{proof}
     \leanok
-    The empty word gives the identity tuple, corresponding to an empty target set.
+    For the base of induction over the target blocks, the empty word gives the
+    identity tuple on the empty target set. This does not represent a physical
+    chain of length zero.
     The span of word tuples is closed under pointwise multiplication because the
     product of a length-$L$ word and a length-$S$ word is the concatenated
     length-$(L+S)$ word. Inducting over the finite set of blocks different from

--- a/docs/audits/2026-04-26_issue934_pairwise_selector_assembly.md
+++ b/docs/audits/2026-04-26_issue934_pairwise_selector_assembly.md
@@ -31,14 +31,13 @@ File: `TNLean/MPS/MPDO/BiCFDerivation.lean`
   - The span of simultaneous word tuples is closed under pointwise matrix multiplication, with
     word lengths adding by concatenation.
 
-- `MPSTensor.hasBlockSelectorOn_empty`
-  - The empty word gives the identity tuple, hence a selector on the empty target set.
-
 - `MPSTensor.HasBlockSelectorOn.mul`
   - Multiplying partial selectors for the same block unions their target sets.
 
 - `MPSTensor.hasBlockSelectorOn_finset_of_pairBlockSeparatingWords`
   - Inducts over a finite target set and multiplies the relevant pairwise separators.
+  - Its empty-target base uses the empty word to give the identity tuple.  This is induction over
+    target blocks and does not represent a physical chain of length zero.
 
 - `MPSTensor.hasBlockSelectorWords_of_forall_hasBlockSelectorOn_univ_erase`
   - Converts tuple-span selectors on `Finset.univ.erase k` into the existing coefficient-based


### PR DESCRIPTION
### Motivation

- The empty base case in selector assembly can be mistaken for a tensor network on a zero-site physical chain.
- The proof actually inducts over a finite set of target blocks; the empty word supplies the identity tuple when that target set is empty.

### Description

- Renames the local witness from `hEmpty` to `hEmptyTargets`.
- States explicitly in Lean and the blueprint that the base case concerns target blocks, not physical chain length.
- Removes a stale audit reference to the deleted public empty-target theorem.
- No theorem statement or mathematical hypothesis changes.

### Testing

- `lake env lean TNLean/MPS/MPDO/BiCFDerivation/Selectors.lean`
- Blueprint declaration regeneration and `leanblueprint checkdecls`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `git diff --check`