### PR TITLE
refactor(Channel): rename the single-Kraus map

### DIFF
--- a/TNLean/Channel/KrausCPTP.lean
+++ b/TNLean/Channel/KrausCPTP.lean
@@ -28,9 +28,9 @@ dimensions.
 * `isKrausCPTP_id`: the identity map is trace-preserving completely positive.
 * `isKrausCPTP_of_singleKraus`: conjugation by an isometry is trace-preserving
   completely positive.
-* `sandwichMap`: the linear map given by conjugation with one rectangular
-  matrix.
-* `sandwichMap_isKrausCPTP`: an isometric single-Kraus map is trace-preserving
+* `singleKrausMap`: the linear map `X ↦ V X V†` associated with one rectangular
+  matrix `V`.
+* `singleKrausMap_isKrausCPTP`: an isometric single-Kraus map is trace-preserving
   completely positive.
 * `isKrausCPTP_comp`: composition preserves the trace-preserving completely
   positive property.
@@ -114,24 +114,24 @@ theorem isKrausCPTP_of_singleKraus {α β : Type*} [Fintype α] [DecidableEq α]
     simpa only [Fin.sum_univ_one] using hform X
   · simpa only [Fin.sum_univ_one] using hV
 
-/-- The linear map associated with a single rectangular Kraus operator. -/
-noncomputable def sandwichMap {α β : Type*} [Fintype α] [Fintype β]
+/-- The single-Kraus map `X ↦ V X V†` associated with a rectangular matrix `V`. -/
+noncomputable def singleKrausMap {α β : Type*} [Fintype α] [Fintype β]
     (V : Matrix β α ℂ) : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ where
   toFun X := V * X * Vᴴ
   map_add' X Y := by simp [Matrix.mul_add, Matrix.add_mul]
   map_smul' c X := by simp [Matrix.mul_smul, Matrix.smul_mul]
 
-@[simp] theorem sandwichMap_apply {α β : Type*} [Fintype α] [Fintype β]
+@[simp] theorem singleKrausMap_apply {α β : Type*} [Fintype α] [Fintype β]
     (V : Matrix β α ℂ) (X : Matrix α α ℂ) :
-    sandwichMap V X = V * X * Vᴴ :=
+    singleKrausMap V X = V * X * Vᴴ :=
   rfl
 
 /-- The single-Kraus map associated with an isometry is trace-preserving and
 completely positive. -/
-theorem sandwichMap_isKrausCPTP {α β : Type*}
+theorem singleKrausMap_isKrausCPTP {α β : Type*}
     [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]
     (V : Matrix β α ℂ) (hV : Vᴴ * V = 1) :
-    IsKrausCPTP (sandwichMap V) :=
+    IsKrausCPTP (singleKrausMap V) :=
   isKrausCPTP_of_singleKraus V (fun _ ↦ rfl) hV
 
 /-- Composition of trace-preserving completely positive maps is again

--- a/TNLean/Channel/KrausCPTP.lean
+++ b/TNLean/Channel/KrausCPTP.lean
@@ -121,10 +121,16 @@ noncomputable def singleKrausMap {α β : Type*} [Fintype α] [Fintype β]
   map_add' X Y := by simp [Matrix.mul_add, Matrix.add_mul]
   map_smul' c X := by simp [Matrix.mul_smul, Matrix.smul_mul]
 
+@[deprecated singleKrausMap (since := "2026-07-16")]
+noncomputable alias sandwichMap := singleKrausMap
+
 @[simp] theorem singleKrausMap_apply {α β : Type*} [Fintype α] [Fintype β]
     (V : Matrix β α ℂ) (X : Matrix α α ℂ) :
     singleKrausMap V X = V * X * Vᴴ :=
   rfl
+
+@[deprecated singleKrausMap_apply (since := "2026-07-16")]
+alias sandwichMap_apply := singleKrausMap_apply
 
 /-- The single-Kraus map associated with an isometry is trace-preserving and
 completely positive. -/
@@ -133,6 +139,9 @@ theorem singleKrausMap_isKrausCPTP {α β : Type*}
     (V : Matrix β α ℂ) (hV : Vᴴ * V = 1) :
     IsKrausCPTP (singleKrausMap V) :=
   isKrausCPTP_of_singleKraus V (fun _ ↦ rfl) hV
+
+@[deprecated singleKrausMap_isKrausCPTP (since := "2026-07-16")]
+alias sandwichMap_isKrausCPTP := singleKrausMap_isKrausCPTP
 
 /-- Composition of trace-preserving completely positive maps is again
 trace-preserving completely positive. If `T` has Kraus operators `Bⱼ` and `S`

--- a/TNLean/Channel/WolfProps.lean
+++ b/TNLean/Channel/WolfProps.lean
@@ -16,7 +16,7 @@ This file formalises the remaining Chapter 2 representation corollaries from
 Wolf's *Quantum Channels & Operations: Guided Tour*:
 
 * **Proposition 2.2** — every sesquilinear sandwich `A * X * Bᴴ` decomposes as a
-  signed complex combination of four CP-sandwich terms (polarization
+  signed complex combination of four single-Kraus terms (polarization
   identity). Any linear map expressible as `∑ᵢ Aᵢ * X * Bᵢᴴ` is therefore
   a complex linear combination of CP maps.
 * **Proposition 2.3** — no information without disturbance: any linear map fixing
@@ -58,7 +58,7 @@ abstract Kraus-freedom sufficient-direction lemma
 `kraus_rectangular_freedom'` by embedding each state vector as the `0`-th
 column of a `D × D` matrix (with zeros elsewhere). The density equality
 `ρ_ψ = ρ_φ` then forces the embedded Kraus families to define the same
-CP sandwich `X ↦ X_{0 0} · ρ`, and reading column `0` of the resulting
+completely positive map `X ↦ X_{0 0} · ρ`, and reading column `0` of the resulting
 rectangular isometry recovers the vector relation `ψᵢ = ∑ⱼ Vᵢⱼ · φⱼ`.
 
 ## References
@@ -97,14 +97,14 @@ private theorem scalar_polarization (α β γ δ : ℂ) :
 
 /-- **Proposition 2.2 (Wolf), polarization form**. The sesquilinear sandwich
 `A * X * Bᴴ` decomposes as a signed ℂ-linear combination of four
-CP-sandwich terms `K X Kᴴ`:
+single-Kraus terms `K X Kᴴ`:
 
   `4 • (A X Bᴴ) = (A+B) X (A+B)ᴴ - (A-B) X (A-B)ᴴ
       + I • (A + I•B) X (A + I•B)ᴴ - I • (A - I•B) X (A - I•B)ᴴ`.
 
 Each summand `K X Kᴴ` on the right is manifestly completely positive (it has
 `K` as a one-element Kraus family), so this identity expresses every
-sesquilinear sandwich as a complex linear combination of CP-sandwich maps. -/
+sesquilinear sandwich as a complex linear combination of single-Kraus maps. -/
 theorem polarization_sandwich (A B X : Matrix (Fin D) (Fin D) ℂ) :
     (4 : ℂ) • (A * X * Bᴴ) =
       ((A + B) * X * (A + B)ᴴ) - ((A - B) * X * (A - B)ᴴ) +
@@ -349,7 +349,7 @@ theorem exists_isometric_mixing_of_pureEnsembleDensity_eq
       ∀ i, ψ i = fun a => ∑ j, V i j * φ j a := by
   -- Any inhabitant of `Fin D` yields the canonical column-`0` index. Factored
   -- out once since the same `⟨0, _⟩` witness is needed both when forming the
-  -- CP-sandwich equality and when reading off column `0` of the resulting
+  -- Kraus-map equality and when reading off column `0` of the resulting
   -- rectangular isometry; bundling the `0 < D` derivation into a single `Fin D`
   -- auxiliary lemma avoids rebuilding `Nat.pos_of_ne_zero` at each call site.
   let c₀_of : Fin D → Fin D :=
@@ -401,7 +401,7 @@ theorem exists_isometric_mixing_of_pureEnsembleDensity_eq
       | zero => exact absurd rfl hdne
       | succ _ => simp
     · intro h; exact absurd (Finset.mem_univ _) h
-  -- The two embedded Kraus families define the same CP sandwich map.
+  -- The two embedded Kraus families define the same completely positive map.
   have hKraus : ∀ X : Matrix (Fin D) (Fin D) ℂ,
       ∑ i, K i * X * (K i)ᴴ = ∑ j, L j * X * (L j)ᴴ := by
     intro X

--- a/TNLean/MPS/MPDO/PhysicalSectorBondTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorBondTransport.lean
@@ -466,9 +466,9 @@ Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`), lines
 private theorem rightPairMatrix_physicalPairBond
     (F : PhysicalSectorFactorization K) :
     rightPairMatrix F.physicalPairBond =
-      sandwichMap F.physicalCoordinateMatrixThreeᴴ
+      singleKrausMap F.physicalCoordinateMatrixThreeᴴ
         (rightPairMatrix F.sectorCoordinateBond) := by
-  simp [rightPairMatrix, physicalPairBond, sandwichMap_apply,
+  simp [rightPairMatrix, physicalPairBond, singleKrausMap_apply,
     physicalCoordinateMatrixTwo, physicalCoordinateMatrixThree,
     Matrix.conjTranspose_kronecker, ← Matrix.mul_kronecker_mul,
     F.physicalCoordinateMatrix_isometry, Matrix.mul_assoc]
@@ -481,15 +481,15 @@ Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`), lines
 private theorem leftPairMatrix_physicalPairBond
     (F : PhysicalSectorFactorization K) :
     leftPairMatrix F.physicalPairBond =
-      sandwichMap F.physicalCoordinateMatrixThreeᴴ
+      singleKrausMap F.physicalCoordinateMatrixThreeᴴ
         (leftPairMatrix F.sectorCoordinateBond) := by
   ext x y
-  simp only [sandwichMap_apply, Matrix.conjTranspose_conjTranspose]
+  simp only [singleKrausMap_apply, Matrix.conjTranspose_conjTranspose]
   simp only [leftPairMatrix, physicalPairBond, physicalCoordinateMatrixTwo,
     physicalCoordinateMatrixThree, Matrix.conjTranspose_kronecker,
     Matrix.reindex_apply, Matrix.submatrix_apply, Equiv.prodAssoc_symm_apply,
     Matrix.mul_apply, Matrix.kroneckerMap_apply, Fintype.sum_prod_type]
-  simp only [sandwichMap_apply, Matrix.conjTranspose_kronecker,
+  simp only [singleKrausMap_apply, Matrix.conjTranspose_kronecker,
     Matrix.conjTranspose_conjTranspose, Matrix.mul_apply,
     Matrix.kroneckerMap_apply, Fintype.sum_prod_type]
   simp only [Matrix.one_apply]
@@ -554,7 +554,7 @@ private theorem physicalPairBonds_comm (F : PhysicalSectorFactorization K) :
     leftPairMatrix F.physicalPairBond * rightPairMatrix F.physicalPairBond =
       rightPairMatrix F.physicalPairBond * leftPairMatrix F.physicalPairBond := by
   rw [F.leftPairMatrix_physicalPairBond, F.rightPairMatrix_physicalPairBond]
-  simp only [sandwichMap_apply, Matrix.conjTranspose_conjTranspose]
+  simp only [singleKrausMap_apply, Matrix.conjTranspose_conjTranspose]
   calc
     _ = F.physicalCoordinateMatrixThreeᴴ *
         leftPairMatrix F.sectorCoordinateBond *

--- a/TNLean/MPS/MPDO/PhysicalSectorBondTwoSite.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorBondTwoSite.lean
@@ -50,8 +50,8 @@ which is the tensor square of one single-site coordinate matrix. -/
 theorem swapPairMatrix_sandwich_kronecker_self
     {m n : Type*} [Fintype m] [Fintype n]
     (A : Matrix m n ℂ) (B : Matrix (m × m) (m × m) ℂ) :
-    swapPairMatrix (sandwichMap (A ⊗ₖ A)ᴴ B) =
-      sandwichMap (A ⊗ₖ A)ᴴ (swapPairMatrix B) := by
+    swapPairMatrix (singleKrausMap (A ⊗ₖ A)ᴴ B) =
+      singleKrausMap (A ⊗ₖ A)ᴴ (swapPairMatrix B) := by
   let em := Equiv.prodComm m m
   let en := Equiv.prodComm n n
   have hA : Matrix.reindex em en (A ⊗ₖ A) = A ⊗ₖ A :=
@@ -60,7 +60,7 @@ theorem swapPairMatrix_sandwich_kronecker_self
     ext x y
     have h := congrArg star (congrFun (congrFun hA y) x)
     simpa [Matrix.reindex_apply, star_mul', mul_comm] using h
-  simp only [swapPairMatrix, sandwichMap_apply,
+  simp only [swapPairMatrix, singleKrausMap_apply,
     Matrix.conjTranspose_conjTranspose]
   change (Matrix.reindexLinearEquiv ℂ ℂ en en)
       ((A ⊗ₖ A)ᴴ * B * (A ⊗ₖ A)) =
@@ -189,14 +189,14 @@ private theorem physicalPairBond_swap_comm
       swapPairMatrix F.physicalPairBond * F.physicalPairBond := by
   have hswap :
       swapPairMatrix
-          (sandwichMap F.physicalCoordinateMatrixTwoᴴ F.sectorCoordinateBond) =
-        sandwichMap F.physicalCoordinateMatrixTwoᴴ
+          (singleKrausMap F.physicalCoordinateMatrixTwoᴴ F.sectorCoordinateBond) =
+        singleKrausMap F.physicalCoordinateMatrixTwoᴴ
           (swapPairMatrix F.sectorCoordinateBond) := by
     simpa only [physicalCoordinateMatrixTwo] using
       swapPairMatrix_sandwich_kronecker_self
         F.physicalCoordinateMatrix F.sectorCoordinateBond
   rw [physicalPairBond, hswap]
-  simp only [sandwichMap_apply, Matrix.conjTranspose_conjTranspose]
+  simp only [singleKrausMap_apply, Matrix.conjTranspose_conjTranspose]
   calc
     _ = F.physicalCoordinateMatrixTwoᴴ * F.sectorCoordinateBond *
         (F.physicalCoordinateMatrixTwo * F.physicalCoordinateMatrixTwoᴴ) *

--- a/TNLean/MPS/MPDO/PhysicalSectorBondTwoSite.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorBondTwoSite.lean
@@ -47,7 +47,7 @@ private theorem reindex_prodComm_kronecker_self
 
 /-- Exchanging both physical sites commutes with a change of coordinates
 which is the tensor square of one single-site coordinate matrix. -/
-theorem swapPairMatrix_sandwich_kronecker_self
+theorem swapPairMatrix_singleKraus_kronecker_self
     {m n : Type*} [Fintype m] [Fintype n]
     (A : Matrix m n ℂ) (B : Matrix (m × m) (m × m) ℂ) :
     swapPairMatrix (singleKrausMap (A ⊗ₖ A)ᴴ B) =
@@ -69,6 +69,10 @@ theorem swapPairMatrix_sandwich_kronecker_self
     ← Matrix.reindexLinearEquiv_mul ℂ ℂ en em em,
     Matrix.coe_reindexLinearEquiv, Matrix.coe_reindexLinearEquiv,
     Matrix.coe_reindexLinearEquiv, hA, hAH]
+
+@[deprecated swapPairMatrix_singleKraus_kronecker_self (since := "2026-07-16")]
+alias swapPairMatrix_sandwich_kronecker_self :=
+  swapPairMatrix_singleKraus_kronecker_self
 
 /-- Swapping the two sector sites exchanges their sector labels and exchanges
 the outer and neighboring pairs in the regrouped coordinates. -/
@@ -193,7 +197,7 @@ private theorem physicalPairBond_swap_comm
         singleKrausMap F.physicalCoordinateMatrixTwoᴴ
           (swapPairMatrix F.sectorCoordinateBond) := by
     simpa only [physicalCoordinateMatrixTwo] using
-      swapPairMatrix_sandwich_kronecker_self
+      swapPairMatrix_singleKraus_kronecker_self
         F.physicalCoordinateMatrix F.sectorCoordinateBond
   rw [physicalPairBond, hswap]
   simp only [singleKrausMap_apply, Matrix.conjTranspose_conjTranspose]

--- a/TNLean/MPS/MPDO/PhysicalSectorCoordinateTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorCoordinateTransport.lean
@@ -158,13 +158,13 @@ theorem changePhysicalBasis_apply_eq_sum {e : ℕ}
 matrix. -/
 theorem physicalCoordinateMatrixTwo_physClose2
     (F : PhysicalSectorFactorization K) (X : Matrix (Fin D) (Fin D) ℂ) :
-    sandwichMap F.physicalCoordinateMatrixTwo (physClose2 K X) =
+    singleKrausMap F.physicalCoordinateMatrixTwo (physClose2 K X) =
       physClose2 F.sectorCoordinateTensor X := by
   rw [F.sectorCoordinateTensor_eq_changePhysicalBasis]
   ext ⟨i₁, i₂⟩ ⟨j₁, j₂⟩
   simp only [physClose2_apply]
   simp_rw [changePhysicalBasis_apply_eq_sum]
-  simp only [sandwichMap_apply, Matrix.mul_apply, Matrix.conjTranspose_apply,
+  simp only [singleKrausMap_apply, Matrix.mul_apply, Matrix.conjTranspose_apply,
     physicalCoordinateMatrixTwo, Matrix.kroneckerMap_apply, physClose2_apply,
     Matrix.sum_mul, Matrix.mul_sum, Matrix.smul_mul, Matrix.mul_smul,
     Matrix.trace_sum, Matrix.trace_smul, smul_eq_mul, star_mul']
@@ -201,13 +201,13 @@ theorem physicalCoordinateMatrixTwo_physClose2
 matrix. -/
 theorem physicalCoordinateMatrixFour_physClose4
     (F : PhysicalSectorFactorization K) (X : Matrix (Fin D) (Fin D) ℂ) :
-    sandwichMap F.physicalCoordinateMatrixFour (physClose4 K X) =
+    singleKrausMap F.physicalCoordinateMatrixFour (physClose4 K X) =
       physClose4 F.sectorCoordinateTensor X := by
   rw [F.sectorCoordinateTensor_eq_changePhysicalBasis]
   ext ⟨i₁, i₂, i₃, i₄⟩ ⟨j₁, j₂, j₃, j₄⟩
   simp only [physClose4_apply]
   simp_rw [changePhysicalBasis_apply_eq_sum]
-  simp only [sandwichMap_apply, Matrix.mul_apply, Matrix.conjTranspose_apply,
+  simp only [singleKrausMap_apply, Matrix.mul_apply, Matrix.conjTranspose_apply,
     physicalCoordinateMatrixFour, Matrix.kroneckerMap_apply, physClose4_apply,
     Matrix.sum_mul, Matrix.mul_sum, Matrix.smul_mul, Matrix.mul_smul,
     Matrix.trace_sum, Matrix.trace_smul, smul_eq_mul, star_mul']
@@ -261,22 +261,22 @@ theorem physicalCoordinateMatrixFour_physClose4
 
 theorem physicalCoordinateMatrixTwo_conjTranspose_physClose2
     (F : PhysicalSectorFactorization K) (X : Matrix (Fin D) (Fin D) ℂ) :
-    sandwichMap F.physicalCoordinateMatrixTwoᴴ
+    singleKrausMap F.physicalCoordinateMatrixTwoᴴ
         (physClose2 F.sectorCoordinateTensor X) =
       physClose2 K X := by
   rw [← F.physicalCoordinateMatrixTwo_physClose2]
-  simp only [sandwichMap_apply, Matrix.conjTranspose_conjTranspose]
+  simp only [singleKrausMap_apply, Matrix.conjTranspose_conjTranspose]
   simp only [← Matrix.mul_assoc, F.physicalCoordinateMatrixTwo_isometry,
     Matrix.one_mul]
   rw [Matrix.mul_assoc, F.physicalCoordinateMatrixTwo_isometry, Matrix.mul_one]
 
 theorem physicalCoordinateMatrixFour_conjTranspose_physClose4
     (F : PhysicalSectorFactorization K) (X : Matrix (Fin D) (Fin D) ℂ) :
-    sandwichMap F.physicalCoordinateMatrixFourᴴ
+    singleKrausMap F.physicalCoordinateMatrixFourᴴ
         (physClose4 F.sectorCoordinateTensor X) =
       physClose4 K X := by
   rw [← F.physicalCoordinateMatrixFour_physClose4]
-  simp only [sandwichMap_apply, Matrix.conjTranspose_conjTranspose]
+  simp only [singleKrausMap_apply, Matrix.conjTranspose_conjTranspose]
   simp only [← Matrix.mul_assoc, F.physicalCoordinateMatrixFour_isometry,
     Matrix.one_mul]
   rw [Matrix.mul_assoc, F.physicalCoordinateMatrixFour_isometry, Matrix.mul_one]

--- a/TNLean/MPS/MPDO/PhysicalSectorPhysicalTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorPhysicalTransport.lean
@@ -33,7 +33,7 @@ private noncomputable def physicalBlockOneMap
           Fintype.card (SectorSiteIndex F))) ℂ :=
   Matrix.equivReindexMap
       (blockedIndexEquiv (Fintype.card (SectorSiteIndex F))).symm ∘ₗ
-    sandwichMap F.physicalCoordinateMatrixTwo ∘ₗ
+    singleKrausMap F.physicalCoordinateMatrixTwo ∘ₗ
     Matrix.equivReindexMap (blockedIndexEquiv d)
 
 private noncomputable def physicalBlockOneInverseMap
@@ -44,7 +44,7 @@ private noncomputable def physicalBlockOneInverseMap
         Fintype.card (SectorSiteIndex F))) ℂ →ₗ[ℂ]
       Matrix (Fin (d * d)) (Fin (d * d)) ℂ :=
   Matrix.equivReindexMap (blockedIndexEquiv d).symm ∘ₗ
-    sandwichMap F.physicalCoordinateMatrixTwoᴴ ∘ₗ
+    singleKrausMap F.physicalCoordinateMatrixTwoᴴ ∘ₗ
     Matrix.equivReindexMap
       (blockedIndexEquiv (Fintype.card (SectorSiteIndex F)))
 
@@ -62,7 +62,7 @@ private noncomputable def physicalBlockTwoMap
             Fintype.card (SectorSiteIndex F))) ℂ :=
   Matrix.equivReindexMap
       (blockedPairEquiv (Fintype.card (SectorSiteIndex F))).symm ∘ₗ
-    sandwichMap F.physicalCoordinateMatrixFour ∘ₗ
+    singleKrausMap F.physicalCoordinateMatrixFour ∘ₗ
     Matrix.equivReindexMap (blockedPairEquiv d)
 
 private noncomputable def physicalBlockTwoInverseMap
@@ -78,7 +78,7 @@ private noncomputable def physicalBlockTwoInverseMap
             Fintype.card (SectorSiteIndex F))) ℂ →ₗ[ℂ]
       Matrix (Fin (d * d) × Fin (d * d)) (Fin (d * d) × Fin (d * d)) ℂ :=
   Matrix.equivReindexMap (blockedPairEquiv d).symm ∘ₗ
-    sandwichMap F.physicalCoordinateMatrixFourᴴ ∘ₗ
+    singleKrausMap F.physicalCoordinateMatrixFourᴴ ∘ₗ
     Matrix.equivReindexMap
       (blockedPairEquiv (Fintype.card (SectorSiteIndex F)))
 
@@ -88,7 +88,7 @@ private theorem physicalBlockOneMap_isKrausCPTP
   exact isKrausCPTP_comp
     (isKrausCPTP_comp
       (Matrix.equivReindexMap_isKrausCPTP (blockedIndexEquiv d))
-      (sandwichMap_isKrausCPTP F.physicalCoordinateMatrixTwo
+      (singleKrausMap_isKrausCPTP F.physicalCoordinateMatrixTwo
         F.physicalCoordinateMatrixTwo_isometry))
     (Matrix.equivReindexMap_isKrausCPTP
       (blockedIndexEquiv (Fintype.card (SectorSiteIndex F))).symm)
@@ -100,7 +100,7 @@ private theorem physicalBlockOneInverseMap_isKrausCPTP
     (isKrausCPTP_comp
       (Matrix.equivReindexMap_isKrausCPTP
         (blockedIndexEquiv (Fintype.card (SectorSiteIndex F))))
-      (sandwichMap_isKrausCPTP F.physicalCoordinateMatrixTwoᴴ (by
+      (singleKrausMap_isKrausCPTP F.physicalCoordinateMatrixTwoᴴ (by
         simpa using F.physicalCoordinateMatrixTwo_coisometry)))
     (Matrix.equivReindexMap_isKrausCPTP (blockedIndexEquiv d).symm)
 
@@ -110,7 +110,7 @@ private theorem physicalBlockTwoMap_isKrausCPTP
   exact isKrausCPTP_comp
     (isKrausCPTP_comp
       (Matrix.equivReindexMap_isKrausCPTP (blockedPairEquiv d))
-      (sandwichMap_isKrausCPTP F.physicalCoordinateMatrixFour
+      (singleKrausMap_isKrausCPTP F.physicalCoordinateMatrixFour
         F.physicalCoordinateMatrixFour_isometry))
     (Matrix.equivReindexMap_isKrausCPTP
       (blockedPairEquiv (Fintype.card (SectorSiteIndex F))).symm)
@@ -122,7 +122,7 @@ private theorem physicalBlockTwoInverseMap_isKrausCPTP
     (isKrausCPTP_comp
       (Matrix.equivReindexMap_isKrausCPTP
         (blockedPairEquiv (Fintype.card (SectorSiteIndex F))))
-      (sandwichMap_isKrausCPTP F.physicalCoordinateMatrixFourᴴ (by
+      (singleKrausMap_isKrausCPTP F.physicalCoordinateMatrixFourᴴ (by
         simpa using F.physicalCoordinateMatrixFour_coisometry)))
     (Matrix.equivReindexMap_isKrausCPTP (blockedPairEquiv d).symm)
 
@@ -133,7 +133,7 @@ private theorem physicalBlockOneMap_closure
   change Matrix.reindex
       (blockedIndexEquiv (Fintype.card (SectorSiteIndex F))).symm
       (blockedIndexEquiv (Fintype.card (SectorSiteIndex F))).symm
-      (sandwichMap F.physicalCoordinateMatrixTwo
+      (singleKrausMap F.physicalCoordinateMatrixTwo
         (Matrix.reindex (blockedIndexEquiv d) (blockedIndexEquiv d)
           (physClose1 (blockTwo K) X))) = _
   rw [show Matrix.reindex (blockedIndexEquiv d) (blockedIndexEquiv d)
@@ -155,7 +155,7 @@ private theorem physicalBlockOneInverseMap_closure
         (physClose1 (blockTwo F.sectorCoordinateTensor) X) =
       physClose1 (blockTwo K) X := by
   change Matrix.reindex (blockedIndexEquiv d).symm (blockedIndexEquiv d).symm
-      (sandwichMap F.physicalCoordinateMatrixTwoᴴ
+      (singleKrausMap F.physicalCoordinateMatrixTwoᴴ
         (Matrix.reindex
           (blockedIndexEquiv (Fintype.card (SectorSiteIndex F)))
           (blockedIndexEquiv (Fintype.card (SectorSiteIndex F)))
@@ -180,7 +180,7 @@ private theorem physicalBlockTwoMap_closure
   change Matrix.reindex
       (blockedPairEquiv (Fintype.card (SectorSiteIndex F))).symm
       (blockedPairEquiv (Fintype.card (SectorSiteIndex F))).symm
-      (sandwichMap F.physicalCoordinateMatrixFour
+      (singleKrausMap F.physicalCoordinateMatrixFour
         (Matrix.reindex (blockedPairEquiv d) (blockedPairEquiv d)
           (physClose2 (blockTwo K) X))) = _
   rw [show Matrix.reindex (blockedPairEquiv d) (blockedPairEquiv d)
@@ -202,7 +202,7 @@ private theorem physicalBlockTwoInverseMap_closure
         (physClose2 (blockTwo F.sectorCoordinateTensor) X) =
       physClose2 (blockTwo K) X := by
   change Matrix.reindex (blockedPairEquiv d).symm (blockedPairEquiv d).symm
-      (sandwichMap F.physicalCoordinateMatrixFourᴴ
+      (singleKrausMap F.physicalCoordinateMatrixFourᴴ
         (Matrix.reindex
           (blockedPairEquiv (Fintype.card (SectorSiteIndex F)))
           (blockedPairEquiv (Fintype.card (SectorSiteIndex F)))

--- a/TNLean/MPS/MPDO/PhysicalSectorPositiveBond.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorPositiveBond.lean
@@ -84,7 +84,7 @@ Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`), lines
 1581--1593. -/
 noncomputable def physicalPairBond (F : PhysicalSectorFactorization K) :
     Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ :=
-  sandwichMap F.physicalCoordinateMatrixTwoᴴ F.sectorCoordinateBond
+  singleKrausMap F.physicalCoordinateMatrixTwoᴴ F.sectorCoordinateBond
 
 /-- The transported bond on the original pair of physical indices is positive
 semidefinite whenever each neighboring operator is positive semidefinite.

--- a/TNLean/MPS/MPDO/PhysicalSectorProductTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorProductTransport.lean
@@ -547,7 +547,7 @@ private theorem physClose2_one_eq_physicalPairBond_mul_crossed
       singleKrausMap F.physicalCoordinateMatrixTwoᴴ
         (swapPairMatrix F.sectorCoordinateBond) := by
     simpa only [physicalPairBond, physicalCoordinateMatrixTwo] using
-      swapPairMatrix_sandwich_kronecker_self
+      swapPairMatrix_singleKraus_kronecker_self
         F.physicalCoordinateMatrix F.sectorCoordinateBond
   rw [hswap]
   simp only [physicalPairBond, singleKrausMap_apply,

--- a/TNLean/MPS/MPDO/PhysicalSectorProductTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorProductTransport.lean
@@ -151,11 +151,11 @@ matrix.
 Source: arXiv:1606.00608, Appendix C.2, lines 1581--1583. -/
 private theorem physicalCoordinateMatrixN_mpo
     (F : PhysicalSectorFactorization K) (N : ℕ) :
-    sandwichMap (F.physicalCoordinateMatrixN N) (mpo K N) =
+    singleKrausMap (F.physicalCoordinateMatrixN N) (mpo K N) =
       mpo F.sectorCoordinateTensor N := by
   rw [F.sectorCoordinateTensor_eq_changePhysicalBasis]
   ext s t
-  simp only [sandwichMap_apply, Matrix.mul_apply, Matrix.conjTranspose_apply,
+  simp only [singleKrausMap_apply, Matrix.mul_apply, Matrix.conjTranspose_apply,
     physicalCoordinateMatrixN, mpo_apply, mpoMatrixEntry,
     evalWord_changePhysicalBasis_ofFn, Matrix.trace_sum, Matrix.trace_smul,
     smul_eq_mul, star_prod]
@@ -317,14 +317,14 @@ private theorem physicalCoordinateMatrixN_two
   simp [physicalCoordinateMatrixN, physicalCoordinateMatrixTwo,
     Matrix.reindex_apply, Matrix.kroneckerMap_apply, finTwoArrowEquiv]
 
-private theorem sandwichMap_physicalCoordinateMatrixN_two_physicalBond
+private theorem singleKrausMap_physicalCoordinateMatrixN_two_physicalBond
     (F : PhysicalSectorFactorization K) :
-    sandwichMap (F.physicalCoordinateMatrixN 2) F.physicalBond =
+    singleKrausMap (F.physicalCoordinateMatrixN 2) F.physicalBond =
       F.sectorBond := by
   apply (Matrix.reindex
     (finTwoArrowEquiv (Fin (Fintype.card (SectorSiteIndex F))))
     (finTwoArrowEquiv (Fin (Fintype.card (SectorSiteIndex F))))).injective
-  simp only [sandwichMap_apply]
+  simp only [singleKrausMap_apply]
   change Matrix.reindexLinearEquiv ℂ ℂ
       (finTwoArrowEquiv (Fin (Fintype.card (SectorSiteIndex F))))
       (finTwoArrowEquiv (Fin (Fintype.card (SectorSiteIndex F))))
@@ -361,7 +361,7 @@ private theorem sandwichMap_physicalCoordinateMatrixN_two_physicalBond
     ext x y
     simp [sectorBond, Matrix.reindex_apply]
   rw [hV, hB, hVH, hSector]
-  simp only [physicalPairBond, sandwichMap_apply,
+  simp only [physicalPairBond, singleKrausMap_apply,
     Matrix.conjTranspose_conjTranspose, Matrix.mul_assoc]
   rw [← Matrix.mul_assoc F.physicalCoordinateMatrixTwo
     F.physicalCoordinateMatrixTwoᴴ,
@@ -375,7 +375,7 @@ Source: arXiv:1606.00608, Appendix C.2, Proposition C.8, lines
 1581--1593. -/
 private theorem physicalCoordinateMatrixN_embedLocalOperator_physicalBond
     (F : PhysicalSectorFactorization K) {N : ℕ} (hN : 2 ≤ N) (i : Fin N) :
-    sandwichMap (F.physicalCoordinateMatrixN N)
+    singleKrausMap (F.physicalCoordinateMatrixN N)
         (embedLocalOperator (d := d) 2 N hN i F.physicalBond) =
       embedLocalOperator
         (d := Fintype.card (SectorSiteIndex F)) 2 N hN i F.sectorBond := by
@@ -383,7 +383,7 @@ private theorem physicalCoordinateMatrixN_embedLocalOperator_physicalBond
     (d := Fintype.card (SectorSiteIndex F)) 2 N hN i
   let ep := windowComplementEquiv (d := d) 2 N hN i
   apply (Matrix.reindex es es).injective
-  simp only [sandwichMap_apply]
+  simp only [singleKrausMap_apply]
   change Matrix.reindexLinearEquiv ℂ ℂ es es
       (F.physicalCoordinateMatrixN N *
         embedLocalOperator (d := d) 2 N hN i F.physicalBond *
@@ -402,35 +402,35 @@ private theorem physicalCoordinateMatrixN_embedLocalOperator_physicalBond
   rw [hVH, reindex_embedLocalOperator_windowComplement]
   rw [← Matrix.mul_kronecker_mul, ← Matrix.mul_kronecker_mul]
   simp only [Matrix.mul_one]
-  rw [← sandwichMap_apply,
-    F.sandwichMap_physicalCoordinateMatrixN_two_physicalBond,
+  rw [← singleKrausMap_apply,
+    F.singleKrausMap_physicalCoordinateMatrixN_two_physicalBond,
     F.physicalCoordinateMatrixN_coisometry]
 
-private theorem sandwichMap_list_prod
+private theorem singleKrausMap_list_prod
     {a b : Type*} [Fintype a] [DecidableEq a]
     [Fintype b] [DecidableEq b] (V : Matrix a b ℂ)
     (hiso : Vᴴ * V = 1) (hcoiso : V * Vᴴ = 1)
     (l : List (Matrix b b ℂ)) :
-    sandwichMap V l.prod = (l.map (sandwichMap V)).prod := by
+    singleKrausMap V l.prod = (l.map (singleKrausMap V)).prod := by
   induction l with
   | nil =>
-      simp only [List.prod_nil, List.map_nil, sandwichMap_apply]
+      simp only [List.prod_nil, List.map_nil, singleKrausMap_apply]
       simpa only [Matrix.mul_one] using hcoiso
   | cons A l ih =>
-      simp only [List.prod_cons, List.map_cons, sandwichMap_apply]
+      simp only [List.prod_cons, List.map_cons, singleKrausMap_apply]
       rw [← ih]
-      simp only [sandwichMap_apply, Matrix.mul_assoc]
+      simp only [singleKrausMap_apply, Matrix.mul_assoc]
       rw [← Matrix.mul_assoc Vᴴ V, hiso, Matrix.one_mul]
 
 private theorem physicalCoordinateMatrixN_product_physicalBond
     (F : PhysicalSectorFactorization K) {N : ℕ} (hN : 2 ≤ N) :
-    sandwichMap (F.physicalCoordinateMatrixN N)
+    singleKrausMap (F.physicalCoordinateMatrixN N)
         (List.ofFn fun i : Fin N ↦
           embedLocalOperator (d := d) 2 N hN i F.physicalBond).prod =
       (List.ofFn fun i : Fin N ↦
         embedLocalOperator
           (d := Fintype.card (SectorSiteIndex F)) 2 N hN i F.sectorBond).prod := by
-  rw [sandwichMap_list_prod _ (F.physicalCoordinateMatrixN_isometry N)
+  rw [singleKrausMap_list_prod _ (F.physicalCoordinateMatrixN_isometry N)
     (F.physicalCoordinateMatrixN_coisometry N)]
   congr 1
   rw [List.map_ofFn]
@@ -455,8 +455,8 @@ private theorem mpo_eq_product_physicalBond_of_three_le
       (List.ofFn fun i : Fin N ↦
         embedLocalOperator (d := d) 2 N (by omega) i F.physicalBond).prod := by
   let V := F.physicalCoordinateMatrixN N
-  have htransport : sandwichMap V (mpo K N) =
-      sandwichMap V
+  have htransport : singleKrausMap V (mpo K N) =
+      singleKrausMap V
         (List.ofFn fun i : Fin N ↦
           embedLocalOperator (d := d) 2 N (by omega) i F.physicalBond).prod := by
     rw [F.physicalCoordinateMatrixN_mpo,
@@ -464,17 +464,17 @@ private theorem mpo_eq_product_physicalBond_of_three_le
       F.physicalCoordinateMatrixN_product_physicalBond (by omega)]
   have hiso : Vᴴ * V = 1 := F.physicalCoordinateMatrixN_isometry N
   calc
-    mpo K N = sandwichMap Vᴴ (sandwichMap V (mpo K N)) := by
-      simp only [sandwichMap_apply, Matrix.conjTranspose_conjTranspose,
+    mpo K N = singleKrausMap Vᴴ (singleKrausMap V (mpo K N)) := by
+      simp only [singleKrausMap_apply, Matrix.conjTranspose_conjTranspose,
         Matrix.mul_assoc]
       rw [hiso, Matrix.mul_one, ← Matrix.mul_assoc, hiso, Matrix.one_mul]
-    _ = sandwichMap Vᴴ (sandwichMap V
+    _ = singleKrausMap Vᴴ (singleKrausMap V
         (List.ofFn fun i : Fin N ↦
           embedLocalOperator (d := d) 2 N (by omega) i F.physicalBond).prod) := by
       rw [htransport]
     _ = (List.ofFn fun i : Fin N ↦
         embedLocalOperator (d := d) 2 N (by omega) i F.physicalBond).prod := by
-      simp only [sandwichMap_apply, Matrix.conjTranspose_conjTranspose,
+      simp only [singleKrausMap_apply, Matrix.conjTranspose_conjTranspose,
         Matrix.mul_assoc]
       rw [hiso, Matrix.mul_one, ← Matrix.mul_assoc, hiso, Matrix.one_mul]
 
@@ -544,13 +544,13 @@ private theorem physClose2_one_eq_physicalPairBond_mul_crossed
   rw [← F.physicalCoordinateMatrixTwo_conjTranspose_physClose2 1]
   rw [F.physClose2_sectorCoordinateTensor_one_eq_bond_mul_crossed]
   have hswap : swapPairMatrix F.physicalPairBond =
-      sandwichMap F.physicalCoordinateMatrixTwoᴴ
+      singleKrausMap F.physicalCoordinateMatrixTwoᴴ
         (swapPairMatrix F.sectorCoordinateBond) := by
     simpa only [physicalPairBond, physicalCoordinateMatrixTwo] using
       swapPairMatrix_sandwich_kronecker_self
         F.physicalCoordinateMatrix F.sectorCoordinateBond
   rw [hswap]
-  simp only [physicalPairBond, sandwichMap_apply,
+  simp only [physicalPairBond, singleKrausMap_apply,
     Matrix.conjTranspose_conjTranspose, Matrix.mul_assoc]
   rw [← Matrix.mul_assoc F.physicalCoordinateMatrixTwo
     F.physicalCoordinateMatrixTwoᴴ]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
@@ -92,7 +92,7 @@
 
 \begin{definition}[Single-Kraus map]
     \label{def:mpdo_single_kraus_map}
-    \lean{sandwichMap}
+    \lean{singleKrausMap}
     \leanok
     For a rectangular matrix $V:H\to K$, define the linear map
     \[
@@ -102,7 +102,7 @@
 
 \begin{lemma}[Evaluation of the single-Kraus map]
     \label{lem:mpdo_single_kraus_map_apply}
-    \lean{sandwichMap_apply}
+    \lean{singleKrausMap_apply}
     \leanok
     \uses{def:mpdo_single_kraus_map}
     For every matrix $X$, one has $\Phi_V(X)=VXV^\dagger$.
@@ -110,7 +110,7 @@
 
 \begin{theorem}[The single-Kraus map of an isometry is a channel]
     \label{thm:mpdo_single_kraus_map_cptp}
-    \lean{sandwichMap_isKrausCPTP}
+    \lean{singleKrausMap_isKrausCPTP}
     \leanok
     \uses{def:mpdo_single_kraus_map, thm:mpdo_single_kraus_isometry_cptp}
     If $V^\dagger V=I_H$, then $\Phi_V$ is trace-preserving and completely


### PR DESCRIPTION
### Motivation

- The public constructor `sandwichMap` names only the shape of the expression `X ↦ V X V†`; `singleKrausMap` states the channel-theoretic structure directly.
- The Chapter 21 blueprint already presents this construction as a single-Kraus map.
- The former terminology is genuine but less precise mathematical language, so compatibility aliases are retained according to `docs/CONTRIBUTING.md`.

### Description

- Renames the preferred constructor to `singleKrausMap` and renames its evaluation and trace-preserving-complete-positivity lemmas.
- Updates all MPDO consumers and Chapter 21 blueprint tags.
- Retains deprecated aliases for `sandwichMap`, `sandwichMap_apply`, and `sandwichMap_isKrausCPTP`.
- Replaces “CP-sandwich map” prose by “single-Kraus map” where the text names this construction. The sesquilinear “sandwich” expression in Wolf Proposition 2.2 remains where it names the polarization expression rather than the constructor.
- No theorem statement, hypothesis, or proof changes.

### Testing

- All affected Lean modules compile.
- The root `TNLean` build target compiles.
- Blueprint declaration synchronization and `leanblueprint checkdecls` pass.
- Differential prose, proof-integrity, and `git diff --check` checks pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure rename with backward-compatible deprecated aliases; no logic or API contract changes beyond preferred names.
> 
> **Overview**
> Renames the preferred Kraus conjugation constructor from **`sandwichMap`** to **`singleKrausMap`** (`X ↦ V X V†`), along with **`singleKrausMap_apply`** and **`singleKrausMap_isKrausCPTP`**. **`@[deprecated]` aliases** keep the old names until 2026-07-16.
> 
> All MPDO physical-sector transport code and related theorem names (e.g. **`swapPairMatrix_singleKraus_kronecker_self`**) now call the new API. Wolf chapter prose switches “CP-sandwich” wording to **single-Kraus** where it names this map; sesquilinear “sandwich” in polarization identities is unchanged.
> 
> Chapter 21 blueprint `\lean{...}` tags are updated to the new symbols. **No theorem statements, hypotheses, or proofs change** beyond identifiers and documentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0f782e989341b0507199a1b1b38af467a21493f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->