### PR TITLE
fix(MPS/MPDO): restrict SAL to nonempty chains

### DIFF
--- a/TNLean/MPS/MPDO/AreaLaw.lean
+++ b/TNLean/MPS/MPDO/AreaLaw.lean
@@ -471,15 +471,19 @@ theorem mutualInfoChain_eq (M : MPOTensor d D) (N L : ℕ) (hL : L ≤ N)
   rfl
 
 /-- A tensor `M` **verifies saturation of the area law** (SAL) if it generates
-MPDO, every system-size density operator has nonzero trace (so the normalized
+MPDO, every positive-length density operator has nonzero trace (so the normalized
 state is well defined), and the mutual information is constant in the block size:
 `I_L = I_{L+1}` for all `L` with `1 ≤ L < ⌊N/2⌋`, for all `N` (i.e. the chain
 `I_1 = I_2 = ⋯ = I_{⌊N/2⌋}`).
 
+The normalization condition is restricted to `0 < N`: Definition 4.6 concerns
+physical chains, and neither its mutual informations nor its proof uses an
+empty-chain operator.
+
 Source: arXiv:1606.00608, Definition 4.6 (line 811), with the equivalent
 form `I_L = I_{L+1}` for `L < ⌊N/2⌋` (line 815); the chain starts at `I_1`. -/
 def IsSAL (M : MPOTensor d D) : Prop :=
-  ∃ hMpdo : IsMPDO M, (∀ N, (mpo M N).trace ≠ 0) ∧
+  ∃ hMpdo : IsMPDO M, (∀ N, 0 < N → (mpo M N).trace ≠ 0) ∧
     ∀ N L : ℕ, 1 ≤ L → (hL : L < N / 2) →
       mutualInfoChain M N L (Nat.le_of_lt (hL.trans_le (Nat.div_le_self N 2))) (hMpdo N)
         = mutualInfoChain M N (L + 1) (hL.trans_le (Nat.div_le_self N 2)) (hMpdo N)

--- a/TNLean/MPS/MPDO/InverseMapActiveSectorPrimitivity.lean
+++ b/TNLean/MPS/MPDO/InverseMapActiveSectorPrimitivity.lean
@@ -170,7 +170,7 @@ theorem exists_positive_physicalSectorFactorization_activeSectorTraceMatrix_isPr
   obtain ⟨hη⟩ := exists_etaStructure_reducedBlockState_of_isSAL K hSAL
   obtain ⟨beta, alpha, hm⟩ :=
     exists_normalizedFourSiteTail_entry_ne_zero
-      K ((Classical.choose_spec hSAL).1 4)
+      K ((Classical.choose_spec hSAL).1 4 (by omega))
   let F₀ := zeroWeightReparameterizedInverseMapPhysicalSectorFactorization
     K hK (normalizedFourSiteTail K)
       (isThreeSiteClosure_reducedBlockState K) hη alpha beta hm

--- a/TNLean/MPS/MPDO/InverseMapActiveSectorRecurrence.lean
+++ b/TNLean/MPS/MPDO/InverseMapActiveSectorRecurrence.lean
@@ -304,7 +304,7 @@ theorem exists_positive_physicalSectorFactorization_of_isSAL
   obtain ⟨hη⟩ := exists_etaStructure_reducedBlockState_of_isSAL K hSAL
   obtain ⟨beta, alpha, hm⟩ :=
     exists_normalizedFourSiteTail_entry_ne_zero
-      K ((Classical.choose_spec hSAL).1 4)
+      K ((Classical.choose_spec hSAL).1 4 (by omega))
   exact exists_positive_inverseMapPhysicalSectorFactorization K hK
     (normalizedFourSiteTail K) (isThreeSiteClosure_reducedBlockState K)
     hη alpha beta hm (Classical.choose hSAL)

--- a/TNLean/MPS/MPDO/InverseMapActiveSectorZCL.lean
+++ b/TNLean/MPS/MPDO/InverseMapActiveSectorZCL.lean
@@ -243,7 +243,7 @@ theorem exists_activeTraceMatrix_relations_of_isSAL_of_isSourceZCL
   obtain ⟨hη⟩ := exists_etaStructure_reducedBlockState_of_isSAL K hSAL
   obtain ⟨beta, alpha, hm⟩ :=
     exists_normalizedFourSiteTail_entry_ne_zero
-      K ((Classical.choose_spec hSAL).1 4)
+      K ((Classical.choose_spec hSAL).1 4 (by omega))
   let F₀ := zeroWeightReparameterizedInverseMapPhysicalSectorFactorization
     K hK (normalizedFourSiteTail K)
       (isThreeSiteClosure_reducedBlockState K) hη alpha beta hm

--- a/TNLean/MPS/MPDO/InverseMapPhysicalSectorFactorization.lean
+++ b/TNLean/MPS/MPDO/InverseMapPhysicalSectorFactorization.lean
@@ -109,7 +109,8 @@ theorem nonempty_physicalSectorFactorization_of_isSAL
     Nonempty (PhysicalSectorFactorization K) := by
   obtain ⟨hη⟩ := exists_etaStructure_reducedBlockState_of_isSAL K hSAL
   obtain ⟨β₃, α₁, hm⟩ :=
-    exists_normalizedFourSiteTail_entry_ne_zero K ((Classical.choose_spec hSAL).1 4)
+    exists_normalizedFourSiteTail_entry_ne_zero K
+      ((Classical.choose_spec hSAL).1 4 (by omega))
   exact ⟨inverseMapPhysicalSectorFactorization K hK (normalizedFourSiteTail K)
     (isThreeSiteClosure_reducedBlockState K) hη α₁ β₃ hm⟩
 

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -539,7 +539,8 @@ theorem exists_etaStructure_reducedBlockState_of_isSAL
   have hρflatTrace : ρflat.trace = 1 := by
     dsimp only [ρflat]
     rw [Matrix.trace_submatrix_equiv]
-    exact reducedBlockState_trace K 4 3 (by omega) ((Classical.choose_spec hSAL).1 4)
+    exact reducedBlockState_trace K 4 3 (by omega)
+      ((Classical.choose_spec hSAL).1 4 (by omega))
   have hEqFlat : IsSSAEquality ρflat hρflatPos.isHermitian := by
     simpa [ρflat, hM] using isSSAEquality_threeSite_of_isSAL K hSAL
   have hEqSite :

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
@@ -32,8 +32,8 @@
     \lean{MPOTensor.IsSAL}
     \leanok
     \uses{def:mutual_info_chain}
-    An MPO tensor $M$ that generates an MPDO and whose finite-chain operators
-    $\rho^{(N)}(M)$ all have nonzero trace (so the normalized states are
+    An MPO tensor $M$ that generates an MPDO and whose positive-length
+    finite-chain operators $\rho^{(N)}(M)$ all have nonzero trace (so the normalized states are
     well-defined) \emph{saturates the area law} if
     $I_L = I_{L+1}$ for all $1 \le L < \lfloor N/2 \rfloor$ and all $N$; that is,
     the mutual information is constant, $I_1 = I_2 = \cdots = I_{\lfloor N/2 \rfloor}$.


### PR DESCRIPTION
### Motivation

Definition 4.6 of arXiv:1606.00608 concerns mutual information on physical chains and begins with block length one. The existing `MPOTensor.IsSAL` nevertheless required the trace of the zero-site MPO to be nonzero. That extra empty-chain condition is absent from the source and is not used by the SAL argument.

Advances #4006.

### Description

- restricts the normalization clause of `MPOTensor.IsSAL` to positive chain lengths;
- supplies the resulting `0 < 4` witnesses at the five four-site consumers;
- updates the blueprint statement to say positive-length finite-chain operators.

No theorem gains an additional hypothesis, and no axiom or placeholder is introduced.

### Testing

- `lake build TNLean.MPS.MPDO.AreaLaw TNLean.MPS.MPDO.SimpleLocalStructure TNLean.MPS.MPDO.InverseMapActiveSectorPrimitivity TNLean.MPS.MPDO.InverseMapActiveSectorRecurrence TNLean.MPS.MPDO.InverseMapActiveSectorZCL TNLean.MPS.MPDO.InverseMapPhysicalSectorFactorization`
- `leanblueprint pdf`
- `leanblueprint checkdecls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- proof-integrity scan on the changed Lean files
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Definitional alignment with the paper; proof updates are local witnesses at `N = 4` with no new theorem hypotheses or runtime behavior.
> 
> **Overview**
> **`MPOTensor.IsSAL`** no longer requires a nonzero trace for the zero-site (`N = 0`) MPO. The normalization clause is now **`∀ N, 0 < N → (mpo M N).trace ≠ 0`**, matching arXiv:1606.00608 Definition 4.6 (physical chains and block length starting at 1). Doc comments note that mutual information and the cited proof do not use an empty-chain operator.
> 
> Downstream proofs that pull a four-site trace witness from SAL now supply **`0 < 4`** via **`(by omega)`** when applying **`(Classical.choose_spec hSAL).1`** in five inverse-map / simple-local-structure consumers.
> 
> The blueprint definition **`def:is_sal`** is updated to say **positive-length** finite-chain operators must have nonzero trace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7622193cdf932146fd1ece8d616c1a5814965d24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->