### PR TITLE
feat(MPS/MPDO): prove RFP saturation of the area law

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -414,6 +414,7 @@ import TNLean.MPS.MPDO.ZCL
 import TNLean.MPS.MPDO.RFP
 import TNLean.MPS.MPDO.RFPViaTS
 import TNLean.MPS.MPDO.RFPViaTSGlobal
+import TNLean.MPS.MPDO.RFPViaTSSAL
 import TNLean.MPS.MPDO.PhysicalBlocking
 import TNLean.MPS.MPDO.PRFP
 import TNLean.MPS.MPDO.LocalPurificationRFP

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -379,6 +379,7 @@ import TNLean.PiAlgebra.GlobalSymmetry
 import TNLean.MPS.MPDO.Defs
 import TNLean.MPS.MPDO.AreaLaw
 import TNLean.MPS.MPDO.MutualInfoMonotone
+import TNLean.MPS.MPDO.MutualInfoBridge
 import TNLean.MPS.MPDO.PureAreaLaw
 import TNLean.MPS.MPDO.PureRFPSAL
 import TNLean.MPS.MPDO.VerticalCF

--- a/TNLean/MPS/MPDO/InvariantProjection.lean
+++ b/TNLean/MPS/MPDO/InvariantProjection.lean
@@ -126,6 +126,25 @@ noncomputable def firstSiteMatrix (P : Matrix (Fin d) (Fin d) ℂ) (N : ℕ) :
     Matrix (Fin (N + 1) → Fin d) (Fin (N + 1) → Fin d) ℂ :=
   fun σ τ => P (σ 0) (τ 0) * (if σ ∘ Fin.succ = τ ∘ Fin.succ then 1 else 0)
 
+/-- Acting by the identity on the first site gives the identity on the full
+chain. -/
+@[simp] theorem firstSiteMatrix_one (N : ℕ) :
+    firstSiteMatrix (1 : Matrix (Fin d) (Fin d) ℂ) N = 1 := by
+  ext σ τ
+  by_cases hστ : σ = τ
+  · subst τ
+    simp [firstSiteMatrix]
+  · have hne : σ 0 ≠ τ 0 ∨ σ ∘ Fin.succ ≠ τ ∘ Fin.succ := by
+      by_contra h
+      push Not at h
+      apply hστ
+      funext i
+      refine Fin.cases h.1 (fun j ↦ ?_) i
+      exact congrFun h.2 j
+    rcases hne with hhead | htail
+    · simp [firstSiteMatrix, hστ, hhead]
+    · simp [firstSiteMatrix, Matrix.one_apply, hστ, htail]
+
 /-- The first-spin action of a Hermitian matrix is Hermitian. -/
 theorem firstSiteMatrix_isHermitian {P : Matrix (Fin d) (Fin d) ℂ}
     (hP : P.IsHermitian) (N : ℕ) : (firstSiteMatrix P N).IsHermitian := by

--- a/TNLean/MPS/MPDO/MutualInfoBridge.lean
+++ b/TNLean/MPS/MPDO/MutualInfoBridge.lean
@@ -1,0 +1,190 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Entropy.MutualInformation
+import TNLean.MPS.MPDO.MutualInfoMonotone
+
+/-!
+# Contiguous-chain mutual information as bipartite mutual information
+
+This file identifies the block-entropy expression for the mutual information of
+a periodic matrix product density operator with the ordinary bipartite mutual
+information of the normalized density operator, reindexed across the contiguous
+cut after the first `L` sites.
+
+## References
+
+* arXiv:1606.00608, lines 792--797 and Appendix C, lines 1338--1340.
+-/
+
+open Matrix
+open scoped Matrix ComplexOrder
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- The identification of the two factors at the contiguous cut after `L` sites
+with configurations of the full `N`-site chain. -/
+noncomputable def chainBipartitionEquiv (d N L : ℕ) (hL : L ≤ N) :
+    Fin (d ^ L) × Fin (d ^ (N - L)) ≃ (Fin N → Fin d) :=
+  (biSplitEquiv d L (N - L)).symm.trans (blockReindexEquiv d N L hL).symm
+
+/-- The normalized `N`-site MPO, viewed as a bipartite matrix across the
+contiguous cut after `L` sites.
+
+Source: arXiv:1606.00608, lines 792--797. -/
+noncomputable def bipartitionedNormalizedMPO (M : MPOTensor d D) (N L : ℕ)
+    (hL : L ≤ N) :
+    Matrix (Fin (d ^ L) × Fin (d ^ (N - L)))
+      (Fin (d ^ L) × Fin (d ^ (N - L))) ℂ :=
+  (normalizedMPO M N).submatrix (chainBipartitionEquiv d N L hL)
+    (chainBipartitionEquiv d N L hL)
+
+private theorem append_empty {K : ℕ} {n : Type*} (u : Fin K → n) (g : Fin 0 → n) :
+    Fin.append u g = fun i ↦ u (Fin.cast (Nat.add_zero K) i) := by
+  funext i
+  refine Fin.addCases (fun j ↦ ?_) (fun j ↦ j.elim0) i
+  rw [Fin.append_left]
+  congr 1
+
+private theorem append_sub_self {K : ℕ} {n : Type*} (u : Fin K → n)
+    (g : Fin (K - K) → n) (h : K = K + (K - K)) :
+    Fin.append u g ∘ Fin.cast h = u := by
+  funext i
+  have hi : Fin.cast h i = Fin.castAdd (K - K) i := by
+    apply Fin.ext
+    simp
+  rw [Function.comp_apply, hi, Fin.append_left]
+
+/-- Keeping all `N` sites of the normalized MPO leaves the state unchanged. -/
+theorem reducedBlockState_full (M : MPOTensor d D) (N : ℕ) :
+    reducedBlockState M N N (le_refl N) = normalizedMPO M N := by
+  ext i j
+  simp only [reducedBlockState, blockReducedState, Matrix.partialTraceRight_apply,
+    Matrix.submatrix_apply, blockSplitEquiv_symm_apply, blockReindexEquiv,
+    Equiv.arrowCongr_symm, Equiv.refl_symm, finCongr_symm]
+  letI : Unique (Fin (N - N) → Fin d) :=
+    { default := fun i ↦ (Fin.cast (Nat.sub_self N) i).elim0
+      uniq := fun _ ↦ funext fun i ↦ (Fin.cast (Nat.sub_self N) i).elim0 }
+  rw [Fintype.sum_unique]
+  have hi :
+      ((finCongr (Nat.add_sub_cancel' (le_refl N))).arrowCongr (Equiv.refl (Fin d)))
+          (Fin.append i default) =
+        Fin.append i default ∘ Fin.cast (Nat.add_sub_cancel' (le_refl N)).symm := rfl
+  have hj :
+      ((finCongr (Nat.add_sub_cancel' (le_refl N))).arrowCongr (Equiv.refl (Fin d)))
+          (Fin.append j default) =
+        Fin.append j default ∘ Fin.cast (Nat.add_sub_cancel' (le_refl N)).symm := rfl
+  rw [hi, hj, append_sub_self, append_sub_self]
+
+/-- The first marginal at the contiguous cut is the first-`L` reduced state,
+up to the standard flattening of configurations.
+
+Source: arXiv:1606.00608, lines 792--797 and Appendix C, lines 1338--1340. -/
+theorem traceRight_bipartitionedNormalizedMPO (M : MPOTensor d D) (N L : ℕ)
+    (hL : L ≤ N) :
+    Matrix.traceRight (bipartitionedNormalizedMPO M N L hL) =
+      (reducedBlockState M N L hL).submatrix finFunctionFinEquiv.symm
+        finFunctionFinEquiv.symm := by
+  ext i j
+  simp only [Matrix.traceRight_apply, bipartitionedNormalizedMPO, Matrix.submatrix_apply,
+    chainBipartitionEquiv, Equiv.trans_apply, biSplitEquiv, Equiv.symm_trans_apply,
+    Equiv.prodCongr_symm, Equiv.prodCongr_apply, Prod.map, blockSplitEquiv_symm_apply,
+    blockReindexEquiv, Equiv.arrowCongr_symm, Equiv.refl_symm, finCongr_symm]
+  rw [reducedBlockState_eq_sum]
+  let f : (Fin (N - L) → Fin d) → ℂ := fun w ↦
+    M.normalizedMPO N
+      ((Fin.append (finFunctionFinEquiv.symm i) w) ∘
+        Fin.cast (show N = L + (N - L) by omega))
+      ((Fin.append (finFunctionFinEquiv.symm j) w) ∘
+        Fin.cast (show N = L + (N - L) by omega))
+  change (∑ x : Fin (d ^ (N - L)), f (finFunctionFinEquiv.symm x)) = ∑ w, f w
+  exact Fintype.sum_equiv finFunctionFinEquiv.symm _ f (fun _ ↦ rfl)
+
+/-- The second marginal at the contiguous cut is the reduced state on `N-L`
+sites, up to the standard flattening of configurations. Translation invariance
+moves the final `N-L` sites to the beginning of the periodic chain.
+
+Source: arXiv:1606.00608, lines 792--797 and Appendix C, lines 1338--1340. -/
+theorem traceLeft_bipartitionedNormalizedMPO (M : MPOTensor d D) (N L : ℕ)
+    (hL : L ≤ N) :
+    Matrix.traceLeft (bipartitionedNormalizedMPO M N L hL) =
+      (reducedBlockState M N (N - L) (Nat.sub_le N L)).submatrix
+        finFunctionFinEquiv.symm finFunctionFinEquiv.symm := by
+  ext i j
+  simp only [Matrix.traceLeft_apply, bipartitionedNormalizedMPO, Matrix.submatrix_apply,
+    chainBipartitionEquiv, Equiv.trans_apply, biSplitEquiv, Equiv.symm_trans_apply,
+    Equiv.prodCongr_symm, Equiv.prodCongr_apply, Prod.map, blockSplitEquiv_symm_apply,
+    blockReindexEquiv, Equiv.arrowCongr_symm, Equiv.refl_symm, finCongr_symm]
+  let f : (Fin L → Fin d) → ℂ := fun x ↦
+    M.normalizedMPO N
+      ((Fin.append x (finFunctionFinEquiv.symm i)) ∘
+        Fin.cast (show N = L + (N - L) by omega))
+      ((Fin.append x (finFunctionFinEquiv.symm j)) ∘
+        Fin.cast (show N = L + (N - L) by omega))
+  change (∑ x : Fin (d ^ L), f (finFunctionFinEquiv.symm x)) = _
+  rw [Fintype.sum_equiv finFunctionFinEquiv.symm _ f (fun _ ↦ rfl)]
+  have key :=
+    window_block_entropy M (p := L) (m := N - L) (s := 0)
+      (show N = L + (N - L) + 0 by omega)
+      (finFunctionFinEquiv.symm i) (finFunctionFinEquiv.symm j)
+  rw [← key]
+  refine Finset.sum_congr rfl (fun x _ ↦ ?_)
+  rw [Fintype.sum_unique]
+  dsimp only [f]
+  congr 1 <;> funext k
+  all_goals rw [append_empty]
+  all_goals simp only [Function.comp_apply, Fin.cast_eq_self]
+
+/-- The block-entropy expression `I_L` is the ordinary bipartite mutual
+information of the normalized MPO across the contiguous `L | (N-L)` cut.
+
+This is the identification used in arXiv:1606.00608, lines 792--797 and in the
+data-processing argument of Appendix C, lines 1338--1340. No trace-one
+assumption is needed for this entropy identity. -/
+theorem mutualInfoChain_eq_mutualInformation (M : MPOTensor d D) (N L : ℕ)
+    (hL : L ≤ N) (hM : (mpo M N).PosSemidef) :
+    mutualInfoChain M N L hL hM =
+      Entropy.mutualInformation (bipartitionedNormalizedMPO M N L hL)
+        ((normalizedMPO_isHermitian M N hM).submatrix
+          (chainBipartitionEquiv d N L hL)) := by
+  simp only [mutualInfoChain, blockEntropy, Entropy.mutualInformation,
+    _root_.mutualInformation]
+  have hright :
+      vonNeumannEntropy (Matrix.traceRight (bipartitionedNormalizedMPO M N L hL))
+          (Matrix.traceRight_isHermitian
+            ((normalizedMPO_isHermitian M N hM).submatrix
+              (chainBipartitionEquiv d N L hL))) =
+        vonNeumannEntropy (reducedBlockState M N L hL)
+          (reducedBlockState_isHermitian M N L hL hM) := by
+    rw [vonNeumannEntropy_congr (traceRight_bipartitionedNormalizedMPO M N L hL) _
+      ((reducedBlockState_isHermitian M N L hL hM).submatrix _),
+      vonNeumannEntropy_submatrix_equiv]
+  have hleft :
+      vonNeumannEntropy (Matrix.traceLeft (bipartitionedNormalizedMPO M N L hL))
+          (Matrix.traceLeft_isHermitian
+            ((normalizedMPO_isHermitian M N hM).submatrix
+              (chainBipartitionEquiv d N L hL))) =
+        vonNeumannEntropy (reducedBlockState M N (N - L) (Nat.sub_le N L))
+          (reducedBlockState_isHermitian M N (N - L) (Nat.sub_le N L) hM) := by
+    rw [vonNeumannEntropy_congr (traceLeft_bipartitionedNormalizedMPO M N L hL) _
+      ((reducedBlockState_isHermitian M N (N - L) (Nat.sub_le N L) hM).submatrix _),
+      vonNeumannEntropy_submatrix_equiv]
+  have hfull :
+      vonNeumannEntropy (reducedBlockState M N N (le_refl N))
+          (reducedBlockState_isHermitian M N N (le_refl N) hM) =
+        vonNeumannEntropy (normalizedMPO M N) (normalizedMPO_isHermitian M N hM) := by
+    exact vonNeumannEntropy_congr (reducedBlockState_full M N) _ _
+  have hjoint :
+      vonNeumannEntropy (bipartitionedNormalizedMPO M N L hL)
+          ((normalizedMPO_isHermitian M N hM).submatrix
+            (chainBipartitionEquiv d N L hL)) =
+        vonNeumannEntropy (normalizedMPO M N) (normalizedMPO_isHermitian M N hM) := by
+    exact vonNeumannEntropy_submatrix_equiv (chainBipartitionEquiv d N L hL)
+      (normalizedMPO M N) (normalizedMPO_isHermitian M N hM)
+  rw [hright, hleft, hfull, hjoint]
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/MutualInfoBridge.lean
+++ b/TNLean/MPS/MPDO/MutualInfoBridge.lean
@@ -99,7 +99,7 @@ theorem reducedBlockState_full (M : MPOTensor d D) (N : ℕ) :
 up to the standard flattening of configurations.
 
 Source: arXiv:1606.00608, lines 792--797 and Appendix C, lines 1338--1340. -/
-theorem traceRight_bipartitionedNormalizedMPO (M : MPOTensor d D) (N L : ℕ)
+theorem bipartitionedNormalizedMPO_traceRight (M : MPOTensor d D) (N L : ℕ)
     (hL : L ≤ N) :
     Matrix.traceRight
         (bipartitionedNormalizedMPO M N L (N - L) (by omega)) =
@@ -125,7 +125,7 @@ sites, up to the standard flattening of configurations. Translation invariance
 moves the final `N-L` sites to the beginning of the periodic chain.
 
 Source: arXiv:1606.00608, lines 792--797 and Appendix C, lines 1338--1340. -/
-theorem traceLeft_bipartitionedNormalizedMPO (M : MPOTensor d D) (N L : ℕ)
+theorem bipartitionedNormalizedMPO_traceLeft (M : MPOTensor d D) (N L : ℕ)
     (hL : L ≤ N) :
     Matrix.traceLeft
         (bipartitionedNormalizedMPO M N L (N - L) (by omega)) =
@@ -180,7 +180,7 @@ theorem mutualInfoChain_eq_mutualInformation (M : MPOTensor d D) (N L : ℕ)
               (chainBipartitionEquiv d N L (N - L) (by omega)).symm)) =
         vonNeumannEntropy (reducedBlockState M N L hL)
           (reducedBlockState_isHermitian M N L hL hM) := by
-    rw [vonNeumannEntropy_congr (traceRight_bipartitionedNormalizedMPO M N L hL) _
+    rw [vonNeumannEntropy_congr (bipartitionedNormalizedMPO_traceRight M N L hL) _
       ((reducedBlockState_isHermitian M N L hL hM).submatrix _),
       vonNeumannEntropy_submatrix_equiv]
   have hleft :
@@ -192,7 +192,7 @@ theorem mutualInfoChain_eq_mutualInformation (M : MPOTensor d D) (N L : ℕ)
               (chainBipartitionEquiv d N L (N - L) (by omega)).symm)) =
         vonNeumannEntropy (reducedBlockState M N (N - L) (Nat.sub_le N L))
           (reducedBlockState_isHermitian M N (N - L) (Nat.sub_le N L) hM) := by
-    rw [vonNeumannEntropy_congr (traceLeft_bipartitionedNormalizedMPO M N L hL) _
+    rw [vonNeumannEntropy_congr (bipartitionedNormalizedMPO_traceLeft M N L hL) _
       ((reducedBlockState_isHermitian M N (N - L) (Nat.sub_le N L) hM).submatrix _),
       vonNeumannEntropy_submatrix_equiv]
   have hfull :

--- a/TNLean/MPS/MPDO/MutualInfoBridge.lean
+++ b/TNLean/MPS/MPDO/MutualInfoBridge.lean
@@ -26,22 +26,37 @@ namespace MPOTensor
 
 variable {d D : ℕ}
 
-/-- The identification of the two factors at the contiguous cut after `L` sites
-with configurations of the full `N`-site chain. -/
-noncomputable def chainBipartitionEquiv (d N L : ℕ) (hL : L ≤ N) :
-    Fin (d ^ L) × Fin (d ^ (N - L)) ≃ (Fin N → Fin d) :=
-  (biSplitEquiv d L (N - L)).symm.trans (blockReindexEquiv d N L hL).symm
+/-- Split a length-`N` configuration into consecutive blocks of lengths `L`
+and `K`, and flatten each block to a finite index. -/
+noncomputable def chainBipartitionEquiv (d N L K : ℕ) (h : N = L + K) :
+    (Fin N → Fin d) ≃ Fin (d ^ L) × Fin (d ^ K) :=
+  (Equiv.arrowCongr (finCongr h) (Equiv.refl (Fin d))).trans
+    (biSplitEquiv d L K)
 
 /-- The normalized `N`-site MPO, viewed as a bipartite matrix across the
 contiguous cut after `L` sites.
 
 Source: arXiv:1606.00608, lines 792--797. -/
-noncomputable def bipartitionedNormalizedMPO (M : MPOTensor d D) (N L : ℕ)
-    (hL : L ≤ N) :
-    Matrix (Fin (d ^ L) × Fin (d ^ (N - L)))
-      (Fin (d ^ L) × Fin (d ^ (N - L))) ℂ :=
-  (normalizedMPO M N).submatrix (chainBipartitionEquiv d N L hL)
-    (chainBipartitionEquiv d N L hL)
+noncomputable def bipartitionedNormalizedMPO (M : MPOTensor d D)
+    (N L K : ℕ) (h : N = L + K) :
+    Matrix (Fin (d ^ L) × Fin (d ^ K)) (Fin (d ^ L) × Fin (d ^ K)) ℂ :=
+  (normalizedMPO M N).submatrix (chainBipartitionEquiv d N L K h).symm
+    (chainBipartitionEquiv d N L K h).symm
+
+/-- Positivity of the normalized state is preserved by the bipartition
+reindexing. -/
+theorem bipartitionedNormalizedMPO_posSemidef (M : MPOTensor d D)
+    (N L K : ℕ) (h : N = L + K) (hM : (mpo M N).PosSemidef) :
+    (bipartitionedNormalizedMPO M N L K h).PosSemidef := by
+  exact (normalizedMPO_posSemidef M N hM).submatrix _
+
+/-- A normalized periodic MPO has unit trace whenever its unnormalized trace
+is nonzero. -/
+theorem bipartitionedNormalizedMPO_trace (M : MPOTensor d D)
+    (N L K : ℕ) (h : N = L + K) (htr : (mpo M N).trace ≠ 0) :
+    (bipartitionedNormalizedMPO M N L K h).trace = 1 := by
+  rw [bipartitionedNormalizedMPO, Matrix.trace_submatrix_equiv,
+    normalizedMPO_trace M N htr]
 
 private theorem append_empty {K : ℕ} {n : Type*} (u : Fin K → n) (g : Fin 0 → n) :
     Fin.append u g = fun i ↦ u (Fin.cast (Nat.add_zero K) i) := by
@@ -86,14 +101,15 @@ up to the standard flattening of configurations.
 Source: arXiv:1606.00608, lines 792--797 and Appendix C, lines 1338--1340. -/
 theorem traceRight_bipartitionedNormalizedMPO (M : MPOTensor d D) (N L : ℕ)
     (hL : L ≤ N) :
-    Matrix.traceRight (bipartitionedNormalizedMPO M N L hL) =
+    Matrix.traceRight
+        (bipartitionedNormalizedMPO M N L (N - L) (by omega)) =
       (reducedBlockState M N L hL).submatrix finFunctionFinEquiv.symm
         finFunctionFinEquiv.symm := by
   ext i j
   simp only [Matrix.traceRight_apply, bipartitionedNormalizedMPO, Matrix.submatrix_apply,
-    chainBipartitionEquiv, Equiv.trans_apply, biSplitEquiv, Equiv.symm_trans_apply,
+    chainBipartitionEquiv, biSplitEquiv, Equiv.symm_trans_apply,
     Equiv.prodCongr_symm, Equiv.prodCongr_apply, Prod.map, blockSplitEquiv_symm_apply,
-    blockReindexEquiv, Equiv.arrowCongr_symm, Equiv.refl_symm, finCongr_symm]
+    Equiv.arrowCongr_symm, Equiv.refl_symm, finCongr_symm]
   rw [reducedBlockState_eq_sum]
   let f : (Fin (N - L) → Fin d) → ℂ := fun w ↦
     M.normalizedMPO N
@@ -111,14 +127,15 @@ moves the final `N-L` sites to the beginning of the periodic chain.
 Source: arXiv:1606.00608, lines 792--797 and Appendix C, lines 1338--1340. -/
 theorem traceLeft_bipartitionedNormalizedMPO (M : MPOTensor d D) (N L : ℕ)
     (hL : L ≤ N) :
-    Matrix.traceLeft (bipartitionedNormalizedMPO M N L hL) =
+    Matrix.traceLeft
+        (bipartitionedNormalizedMPO M N L (N - L) (by omega)) =
       (reducedBlockState M N (N - L) (Nat.sub_le N L)).submatrix
         finFunctionFinEquiv.symm finFunctionFinEquiv.symm := by
   ext i j
   simp only [Matrix.traceLeft_apply, bipartitionedNormalizedMPO, Matrix.submatrix_apply,
-    chainBipartitionEquiv, Equiv.trans_apply, biSplitEquiv, Equiv.symm_trans_apply,
+    chainBipartitionEquiv, biSplitEquiv, Equiv.symm_trans_apply,
     Equiv.prodCongr_symm, Equiv.prodCongr_apply, Prod.map, blockSplitEquiv_symm_apply,
-    blockReindexEquiv, Equiv.arrowCongr_symm, Equiv.refl_symm, finCongr_symm]
+    Equiv.arrowCongr_symm, Equiv.refl_symm, finCongr_symm]
   let f : (Fin L → Fin d) → ℂ := fun x ↦
     M.normalizedMPO N
       ((Fin.append x (finFunctionFinEquiv.symm i)) ∘
@@ -148,26 +165,31 @@ assumption is needed for this entropy identity. -/
 theorem mutualInfoChain_eq_mutualInformation (M : MPOTensor d D) (N L : ℕ)
     (hL : L ≤ N) (hM : (mpo M N).PosSemidef) :
     mutualInfoChain M N L hL hM =
-      Entropy.mutualInformation (bipartitionedNormalizedMPO M N L hL)
+      Entropy.mutualInformation
+        (bipartitionedNormalizedMPO M N L (N - L) (by omega))
         ((normalizedMPO_isHermitian M N hM).submatrix
-          (chainBipartitionEquiv d N L hL)) := by
+          (chainBipartitionEquiv d N L (N - L) (by omega)).symm) := by
   simp only [mutualInfoChain, blockEntropy, Entropy.mutualInformation,
     _root_.mutualInformation]
   have hright :
-      vonNeumannEntropy (Matrix.traceRight (bipartitionedNormalizedMPO M N L hL))
+      vonNeumannEntropy
+          (Matrix.traceRight
+            (bipartitionedNormalizedMPO M N L (N - L) (by omega)))
           (Matrix.traceRight_isHermitian
             ((normalizedMPO_isHermitian M N hM).submatrix
-              (chainBipartitionEquiv d N L hL))) =
+              (chainBipartitionEquiv d N L (N - L) (by omega)).symm)) =
         vonNeumannEntropy (reducedBlockState M N L hL)
           (reducedBlockState_isHermitian M N L hL hM) := by
     rw [vonNeumannEntropy_congr (traceRight_bipartitionedNormalizedMPO M N L hL) _
       ((reducedBlockState_isHermitian M N L hL hM).submatrix _),
       vonNeumannEntropy_submatrix_equiv]
   have hleft :
-      vonNeumannEntropy (Matrix.traceLeft (bipartitionedNormalizedMPO M N L hL))
+      vonNeumannEntropy
+          (Matrix.traceLeft
+            (bipartitionedNormalizedMPO M N L (N - L) (by omega)))
           (Matrix.traceLeft_isHermitian
             ((normalizedMPO_isHermitian M N hM).submatrix
-              (chainBipartitionEquiv d N L hL))) =
+              (chainBipartitionEquiv d N L (N - L) (by omega)).symm)) =
         vonNeumannEntropy (reducedBlockState M N (N - L) (Nat.sub_le N L))
           (reducedBlockState_isHermitian M N (N - L) (Nat.sub_le N L) hM) := by
     rw [vonNeumannEntropy_congr (traceLeft_bipartitionedNormalizedMPO M N L hL) _
@@ -179,11 +201,13 @@ theorem mutualInfoChain_eq_mutualInformation (M : MPOTensor d D) (N L : ℕ)
         vonNeumannEntropy (normalizedMPO M N) (normalizedMPO_isHermitian M N hM) := by
     exact vonNeumannEntropy_congr (reducedBlockState_full M N) _ _
   have hjoint :
-      vonNeumannEntropy (bipartitionedNormalizedMPO M N L hL)
+      vonNeumannEntropy
+          (bipartitionedNormalizedMPO M N L (N - L) (by omega))
           ((normalizedMPO_isHermitian M N hM).submatrix
-            (chainBipartitionEquiv d N L hL)) =
+            (chainBipartitionEquiv d N L (N - L) (by omega)).symm) =
         vonNeumannEntropy (normalizedMPO M N) (normalizedMPO_isHermitian M N hM) := by
-    exact vonNeumannEntropy_submatrix_equiv (chainBipartitionEquiv d N L hL)
+    exact vonNeumannEntropy_submatrix_equiv
+      (chainBipartitionEquiv d N L (N - L) (by omega)).symm
       (normalizedMPO M N) (normalizedMPO_isHermitian M N hM)
   rw [hright, hleft, hfull, hjoint]
 

--- a/TNLean/MPS/MPDO/RFPViaTSGlobal.lean
+++ b/TNLean/MPS/MPDO/RFPViaTSGlobal.lean
@@ -5,7 +5,9 @@ Authors: TNLean contributors
 -/
 import TNLean.Algebra.FinTupleEquiv
 import TNLean.Channel.LocalizedKrausCPTP
+import TNLean.MPS.MPDO.RetainedClass
 import TNLean.MPS.MPDO.RFPViaTS
+import TNLean.MPS.MPDO.SectorTrace
 
 /-!
 # Global action of the MPDO renormalization maps
@@ -38,6 +40,9 @@ source argument are recorded in
   the localized maps respectively insert and remove one tensor in every periodic MPO.
 * `MPOTensor.exists_global_renormalization_maps`: a renormalization fixed point
   supplies localized channels with the global physical-closure identities.
+* `MPOTensor.trace_mpo_ne_zero_of_isHorizontalCF_isMPDO_isRFPViaTS`: a
+  horizontally canonical MPDO satisfying Definition 4.1 has nonzero trace at
+  every positive chain length.
 
 ## References
 
@@ -238,5 +243,42 @@ theorem exists_global_renormalization_maps (M : MPOTensor d D)
   obtain ⟨S, T, hS, hT, hSclose, hTclose⟩ := h
   exact ⟨S, T, hS, hT, coarsenFirstTwoSites_physCloseN M S hSclose,
     refineFirstSite_physCloseN M T hTclose⟩
+
+/-- A horizontally canonical MPDO satisfying Definition 4.1 has nonzero trace
+at every positive chain length.
+
+The BNT representation supplies one sufficiently long nonzero density
+operator. Positivity makes its trace nonzero. Definition 4.1 makes the
+physical-trace transfer idempotent, so the trace is the same at every positive
+length.
+
+Source: arXiv:1606.00608, canonical-form standing assumptions at lines
+623--628 and 849--850, Definition 4.1 at lines 657--660, and Proposition
+`propsimple` at lines 1333--1340. -/
+theorem trace_mpo_ne_zero_of_isHorizontalCF_isMPDO_isRFPViaTS
+    (M : MPOTensor d D) (hHorizontal : IsHorizontalCF M) (hMPDO : IsMPDO M)
+    (hRFP : IsRFPViaTS M) :
+    ∀ N, 0 < N → Matrix.trace (mpo M N) ≠ 0 := by
+  have hCorner : ∃ v, (1 : Matrix (Fin d) (Fin d) ℂ) * verticalTensor M v * 1 ≠ 0 := by
+    by_contra h
+    push Not at h
+    apply hHorizontal.verticalTensor_ne_zero M
+    funext v
+    simpa using h v
+  obtain ⟨L, hCompression⟩ :=
+    hHorizontal.exists_sectorCompression_ne_zero_of_corner M 1 hCorner
+  have hMpo : mpo M (L + 1) ≠ 0 := by
+    simpa [sectorCompression_def] using hCompression
+  have hSeedTrace : Matrix.trace (mpo M (L + 1)) ≠ 0 := by
+    intro hTrace
+    exact hMpo ((Matrix.PosSemidef.trace_eq_zero_iff (hMPDO (L + 1))).mp hTrace)
+  have hLoopIdempotent : IsIdempotentElem (verticalLoop M) := by
+    rw [isIdempotentElem_iff, verticalLoop_eq_physTraceTransfer]
+    exact physTraceTransfer_sq_of_isRFPViaTS M hRFP
+  intro N hN
+  rw [trace_mpo_eq_trace_verticalLoop_pow, hLoopIdempotent.pow_eq hN.ne']
+  rw [trace_mpo_eq_trace_verticalLoop_pow,
+    hLoopIdempotent.pow_eq (Nat.succ_ne_zero L)] at hSeedTrace
+  exact hSeedTrace
 
 end MPOTensor

--- a/TNLean/MPS/MPDO/RFPViaTSSAL.lean
+++ b/TNLean/MPS/MPDO/RFPViaTSSAL.lean
@@ -8,16 +8,17 @@ import TNLean.MPS.MPDO.MutualInfoBridge
 import TNLean.MPS.MPDO.RFPViaTSGlobal
 
 /-!
-# The conditional mutual-information step for MPDO renormalization fixed points
+# Saturation of the area law for MPDO renormalization fixed points
 
-This file isolates the entropic part of the proof that a mixed-state
-renormalization fixed point saturates the area law.  The result below is a
-conditional helper, not a formalization of Proposition `propsimple`.  It proves
-the two exact finite-chain identifications obtained by transferring one site
-across a bipartition and derives the resulting mutual-information equality.
-The separate normalization argument uses horizontal canonical form, the MPDO
-condition, and the renormalization maps; simplicity is not needed for the
-forward implication of the source proposition.
+This file proves the forward implication of Proposition `propsimple`: a
+horizontally canonical matrix product density operator satisfying the local
+renormalization fixed-point equations saturates the area law.  The proof first
+establishes the two exact finite-chain identities obtained by transferring one
+site across a bipartition, applies mutual-information data processing in both
+directions, and then identifies bipartite mutual information with the chain
+quantity `I_L`.  Horizontal canonical form, positivity, and the fixed-point
+equations supply nonzero trace at every positive length; simplicity is not used
+in this implication.
 
 Source: arXiv:1606.00608, Appendix C, lines 1333--1341.  See
 `docs/paper-gaps/cpsv16_rfp_sal_data_processing.tex`.
@@ -363,5 +364,82 @@ theorem mutualInformation_bipartition_eq_of_isRFPViaTS
   obtain ⟨S, T, hS, hT, hSclose, hTclose⟩ := hRFP
   exact mutualInformation_bipartition_eq_of_local_transfers M N a b hIn hOut hM htr
     S T hS hT hSclose hTclose
+
+private theorem mutualInformation_bipartition_eq_of_isRFPViaTS_of_right_eq
+    (M : MPOTensor d D) (hRFP : IsRFPViaTS M)
+    (N a b KIn KOut : ℕ) (hKIn : KIn = b + 2) (hKOut : KOut = b + 1)
+    (hIn : N = (a + 1) + KIn) (hOut : N = (a + 2) + KOut)
+    (hM : (mpo M N).PosSemidef) (htr : (mpo M N).trace ≠ 0) :
+    Entropy.mutualInformation
+        (bipartitionedNormalizedMPO M N (a + 1) KIn hIn)
+        (bipartitionedNormalizedMPO_posSemidef M N (a + 1) KIn hIn hM).isHermitian =
+      Entropy.mutualInformation
+        (bipartitionedNormalizedMPO M N (a + 2) KOut hOut)
+        (bipartitionedNormalizedMPO_posSemidef M N (a + 2) KOut hOut hM).isHermitian := by
+  subst KIn
+  subst KOut
+  exact mutualInformation_bipartition_eq_of_isRFPViaTS
+    M hRFP N a b hIn hOut hM htr
+
+/-- A horizontally canonical matrix product density operator satisfying the
+local renormalization fixed-point equations saturates the area law.
+
+The two local channels transfer one site across a consecutive bipartition.
+Data processing in both directions gives equality of the bipartite mutual
+informations, and `mutualInfoChain_eq_mutualInformation` identifies these with
+the chain quantities `I_L` and `I_{L+1}`.  Horizontal canonical form,
+positivity, and the fixed-point equations give the nonzero trace required to
+normalize every positive-length ring.  No empty-chain condition is used.
+
+Source: arXiv:1606.00608, Proposition `propsimple`, Appendix C,
+lines 1333--1341, under the canonical-form and density-operator standing
+assumptions at lines 623--628 and 849--850. -/
+theorem isSAL_of_isRFPViaTS (M : MPOTensor d D)
+    (hHorizontal : MPOTensor.IsHorizontalCF M) (hM : IsMPDO M)
+    (hRFP : IsRFPViaTS M) : IsSAL M := by
+  refine ⟨hM, MPOTensor.trace_mpo_ne_zero_of_isHorizontalCF_isMPDO_isRFPViaTS
+    M hHorizontal hM hRFP, ?_⟩
+  intro N L hL hHalf
+  obtain ⟨a, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (by omega : L ≠ 0)
+  let b := N - (a + 1) - 2
+  let N₀ := (a + 1) + (b + 2)
+  have hN : N = N₀ := by
+    dsimp [N₀, b]
+    omega
+  clear_value b
+  subst N
+  have hNpos : 0 < N₀ := by omega
+  have htr := MPOTensor.trace_mpo_ne_zero_of_isHorizontalCF_isMPDO_isRFPViaTS
+    M hHorizontal hM hRFP N₀ hNpos
+  have hKIn : N₀ - (a + 1) = b + 2 := by
+    dsimp [N₀]
+    omega
+  have hKOut : N₀ - (a + 2) = b + 1 := by
+    dsimp [N₀]
+    omega
+  have hIn : N₀ = (a + 1) + (N₀ - (a + 1)) := by omega
+  have hOut : N₀ = (a + 2) + (N₀ - (a + 2)) := by omega
+  have hBipartition :=
+    mutualInformation_bipartition_eq_of_isRFPViaTS_of_right_eq
+      M hRFP N₀ a b (N₀ - (a + 1)) (N₀ - (a + 2))
+      hKIn hKOut hIn hOut (hM N₀) htr
+  calc
+    mutualInfoChain M N₀ (a + 1)
+        (Nat.le_of_lt (hHalf.trans_le (Nat.div_le_self N₀ 2))) (hM N₀) =
+      Entropy.mutualInformation
+        (bipartitionedNormalizedMPO M N₀ (a + 1) (N₀ - (a + 1)) (by omega))
+        ((normalizedMPO_isHermitian M N₀ (hM N₀)).submatrix
+          (chainBipartitionEquiv d N₀ (a + 1) (N₀ - (a + 1)) (by omega)).symm) :=
+      mutualInfoChain_eq_mutualInformation M N₀ (a + 1)
+        (Nat.le_of_lt (hHalf.trans_le (Nat.div_le_self N₀ 2))) (hM N₀)
+    _ = Entropy.mutualInformation
+        (bipartitionedNormalizedMPO M N₀ (a + 2) (N₀ - (a + 2)) (by omega))
+        ((normalizedMPO_isHermitian M N₀ (hM N₀)).submatrix
+          (chainBipartitionEquiv d N₀ (a + 2) (N₀ - (a + 2)) (by omega)).symm) := by
+      exact hBipartition
+    _ = mutualInfoChain M N₀ (a + 2)
+        (hHalf.trans_le (Nat.div_le_self N₀ 2)) (hM N₀) :=
+      (mutualInfoChain_eq_mutualInformation M N₀ (a + 2)
+        (hHalf.trans_le (Nat.div_le_self N₀ 2)) (hM N₀)).symm
 
 end MPOTensor

--- a/TNLean/MPS/MPDO/RFPViaTSSAL.lean
+++ b/TNLean/MPS/MPDO/RFPViaTSSAL.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Entropy.MutualInformationDataProcessing
-import TNLean.MPS.MPDO.MutualInfoMonotone
+import TNLean.MPS.MPDO.MutualInfoBridge
 import TNLean.MPS.MPDO.RFPViaTSGlobal
 
 /-!
@@ -29,35 +29,6 @@ open Matrix
 namespace MPOTensor
 
 variable {d D : ℕ}
-
-/-- Split a length-`N` configuration into consecutive blocks of lengths `L`
-and `K`, and flatten each block to a `Fin` index. -/
-noncomputable def chainBiSplitEquiv (d N L K : ℕ) (h : N = L + K) :
-    (Fin N → Fin d) ≃ Fin (d ^ L) × Fin (d ^ K) :=
-  (Equiv.arrowCongr (finCongr h) (Equiv.refl (Fin d))).trans
-    (biSplitEquiv d L K)
-
-/-- The normalized periodic MPO viewed across a consecutive bipartition. -/
-noncomputable def splitNormalizedMPO (M : MPOTensor d D) (N L K : ℕ)
-    (h : N = L + K) :
-    Matrix (Fin (d ^ L) × Fin (d ^ K)) (Fin (d ^ L) × Fin (d ^ K)) ℂ :=
-  (normalizedMPO M N).submatrix (chainBiSplitEquiv d N L K h).symm
-    (chainBiSplitEquiv d N L K h).symm
-
-/-- Positivity of the normalized state is preserved by the bipartition
-reindexing. -/
-theorem splitNormalizedMPO_posSemidef (M : MPOTensor d D) (N L K : ℕ)
-    (h : N = L + K) (hM : (mpo M N).PosSemidef) :
-    (splitNormalizedMPO M N L K h).PosSemidef := by
-  exact (normalizedMPO_posSemidef M N hM).submatrix _
-
-/-- A positive-length normalized periodic MPO has unit trace whenever its
-unnormalized trace is nonzero. -/
-theorem splitNormalizedMPO_trace (M : MPOTensor d D) (N L K : ℕ)
-    (h : N = L + K) (htr : (mpo M N).trace ≠ 0) :
-    (splitNormalizedMPO M N L K h).trace = 1 := by
-  rw [splitNormalizedMPO, Matrix.trace_submatrix_equiv,
-    normalizedMPO_trace M N htr]
 
 /-- The localized one-to-two map, with its input and output block
 configurations flattened to `Fin` indices. -/
@@ -124,30 +95,30 @@ private theorem splitMPO_slice
     (u v : Fin K → Fin d) :
     Matrix.equivReindexMap finFunctionFinEquiv.symm
         (Matrix.bipartiteSlice
-          ((mpo M N).submatrix (chainBiSplitEquiv d N L K h).symm
-            (chainBiSplitEquiv d N L K h).symm)
+          ((mpo M N).submatrix (chainBipartitionEquiv d N L K h).symm
+            (chainBipartitionEquiv d N L K h).symm)
           (finFunctionFinEquiv u) (finFunctionFinEquiv v)) =
       physCloseN M L (evalWord M (List.ofFn u) (List.ofFn v)) := by
   subst N
   ext x y
   simp [Matrix.equivReindexMap, Matrix.coe_reindexLinearEquiv,
-    Matrix.reindex_apply, chainBiSplitEquiv, biSplitEquiv,
+    Matrix.reindex_apply, chainBipartitionEquiv, biSplitEquiv,
     Matrix.bipartiteSlice, blockSplitEquiv_symm_apply, mpoMatrixEntry,
     List.ofFn_fin_append, evalWord_append]
 
 /-- The preceding slice identity for the normalized periodic MPO. -/
-private theorem splitNormalizedMPO_slice
+private theorem bipartitionedNormalizedMPO_slice
     (M : MPOTensor d D) (N L K : ℕ) (h : N = L + K)
     (u v : Fin K → Fin d) :
     Matrix.equivReindexMap finFunctionFinEquiv.symm
-        (Matrix.bipartiteSlice (splitNormalizedMPO M N L K h)
+        (Matrix.bipartiteSlice (bipartitionedNormalizedMPO M N L K h)
           (finFunctionFinEquiv u) (finFunctionFinEquiv v)) =
       (Matrix.trace (mpo M N))⁻¹ •
         physCloseN M L (evalWord M (List.ofFn u) (List.ofFn v)) := by
   have hs := splitMPO_slice M N L K h u v
   ext x y
   have hsxy := congrFun (congrFun hs x) y
-  simpa [splitNormalizedMPO, normalizedMPO, Matrix.equivReindexMap,
+  simpa [bipartitionedNormalizedMPO, normalizedMPO, Matrix.equivReindexMap,
     Matrix.coe_reindexLinearEquiv, Matrix.reindex_apply,
     Matrix.bipartiteSlice, Matrix.smul_apply, smul_eq_mul] using
       congrArg (fun z ↦ (Matrix.trace (mpo M N))⁻¹ * z) hsxy
@@ -156,7 +127,7 @@ private theorem splitNormalizedMPO_slice
 bipartition of a periodic normalized MPO.
 
 Source: arXiv:1606.00608, Appendix C, lines 1337--1341. -/
-theorem tensorMapBoth_splitNormalizedMPO
+theorem tensorMapBoth_bipartitionedNormalizedMPO
     (M : MPOTensor d D) (N a b : ℕ)
     (hIn : N = (a + 1) + (b + 2)) (hOut : N = (a + 2) + (b + 1))
     (S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
@@ -166,8 +137,8 @@ theorem tensorMapBoth_splitNormalizedMPO
     (hSclose : ∀ X, S (physClose2 M X) = physClose1 M X)
     (hTclose : ∀ X, T (physClose1 M X) = physClose2 M X) :
     Matrix.tensorMapBoth (refineFirstBlock T a) (coarsenFirstBlock S b)
-        (splitNormalizedMPO M N (a + 1) (b + 2) hIn) =
-      splitNormalizedMPO M N (a + 2) (b + 1) hOut := by
+        (bipartitionedNormalizedMPO M N (a + 1) (b + 2) hIn) =
+      bipartitionedNormalizedMPO M N (a + 2) (b + 1) hOut := by
   ext p q
   rcases p with ⟨pA, pB⟩
   rcases q with ⟨qA, qB⟩
@@ -184,7 +155,7 @@ theorem tensorMapBoth_splitNormalizedMPO
       finFunctionFinEquiv.symm)
       (Matrix.bipartiteSlice
         ((Matrix.tensorMapId (refineFirstBlock T a)
-          (splitNormalizedMPO M N (a + 1) (b + 2) hIn)).submatrix
+          (bipartitionedNormalizedMPO M N (a + 1) (b + 2) hIn)).submatrix
             Prod.swap Prod.swap) pA qA)
   change (coarsenFirstTwoSites S b Y) (finFunctionFinEquiv.symm pB)
       (finFunctionFinEquiv.symm qB) = _
@@ -193,9 +164,9 @@ theorem tensorMapBoth_splitNormalizedMPO
     change (refineFirstSite T a
         (Matrix.equivReindexMap finFunctionFinEquiv.symm
           (Matrix.bipartiteSlice
-            (splitNormalizedMPO M N (a + 1) (b + 2) hIn)
+            (bipartitionedNormalizedMPO M N (a + 1) (b + 2) hIn)
             (finFunctionFinEquiv u) (finFunctionFinEquiv v)))) uA vA = _
-    rw [splitNormalizedMPO_slice M N (a + 1) (b + 2) hIn u v,
+    rw [bipartitionedNormalizedMPO_slice M N (a + 1) (b + 2) hIn u v,
       map_smul, refineFirstSite_physCloseN M T hTclose]
     simp only [Matrix.smul_apply, smul_eq_mul, physCloseN_apply]
     congr 1
@@ -203,10 +174,10 @@ theorem tensorMapBoth_splitNormalizedMPO
   rw [hY, map_smul, coarsenFirstTwoSites_physCloseN M S hSclose]
   let uB : Fin (b + 1) → Fin d := finFunctionFinEquiv.symm pB
   let vB : Fin (b + 1) → Fin d := finFunctionFinEquiv.symm qB
-  have hout := splitNormalizedMPO_slice M N (a + 2) (b + 1) hOut uB vB
+  have hout := bipartitionedNormalizedMPO_slice M N (a + 2) (b + 1) hOut uB vB
   have houtxy := congrFun (congrFun hout uA) vA
   have houtEntry :
-      splitNormalizedMPO M N (a + 2) (b + 1) hOut (pA, pB) (qA, qB) =
+      bipartitionedNormalizedMPO M N (a + 2) (b + 1) hOut (pA, pB) (qA, qB) =
         (Matrix.trace (mpo M N))⁻¹ *
           Matrix.trace (evalWord M (List.ofFn uA) (List.ofFn vA) *
             evalWord M (List.ofFn uB) (List.ofFn vB)) := by
@@ -223,7 +194,7 @@ the same bipartition.
 
 Source: arXiv:1606.00608, Definition 4.1 and Appendix C,
 lines 1337--1341. -/
-theorem tensorMapBoth_splitNormalizedMPO_reverse
+theorem tensorMapBoth_bipartitionedNormalizedMPO_reverse
     (M : MPOTensor d D) (N a b : ℕ)
     (hIn : N = (a + 1) + (b + 2)) (hOut : N = (a + 2) + (b + 1))
     (S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
@@ -233,8 +204,8 @@ theorem tensorMapBoth_splitNormalizedMPO_reverse
     (hSclose : ∀ X, S (physClose2 M X) = physClose1 M X)
     (hTclose : ∀ X, T (physClose1 M X) = physClose2 M X) :
     Matrix.tensorMapBoth (coarsenFirstBlock S a) (refineFirstBlock T b)
-        (splitNormalizedMPO M N (a + 2) (b + 1) hOut) =
-      splitNormalizedMPO M N (a + 1) (b + 2) hIn := by
+        (bipartitionedNormalizedMPO M N (a + 2) (b + 1) hOut) =
+      bipartitionedNormalizedMPO M N (a + 1) (b + 2) hIn := by
   ext p q
   rcases p with ⟨pA, pB⟩
   rcases q with ⟨qA, qB⟩
@@ -251,7 +222,7 @@ theorem tensorMapBoth_splitNormalizedMPO_reverse
       finFunctionFinEquiv.symm)
       (Matrix.bipartiteSlice
         ((Matrix.tensorMapId (coarsenFirstBlock S a)
-          (splitNormalizedMPO M N (a + 2) (b + 1) hOut)).submatrix
+          (bipartitionedNormalizedMPO M N (a + 2) (b + 1) hOut)).submatrix
             Prod.swap Prod.swap) pA qA)
   change (refineFirstSite T b Y) (finFunctionFinEquiv.symm pB)
       (finFunctionFinEquiv.symm qB) = _
@@ -260,9 +231,9 @@ theorem tensorMapBoth_splitNormalizedMPO_reverse
     change (coarsenFirstTwoSites S a
         (Matrix.equivReindexMap finFunctionFinEquiv.symm
           (Matrix.bipartiteSlice
-            (splitNormalizedMPO M N (a + 2) (b + 1) hOut)
+            (bipartitionedNormalizedMPO M N (a + 2) (b + 1) hOut)
             (finFunctionFinEquiv u) (finFunctionFinEquiv v)))) uA vA = _
-    rw [splitNormalizedMPO_slice M N (a + 2) (b + 1) hOut u v,
+    rw [bipartitionedNormalizedMPO_slice M N (a + 2) (b + 1) hOut u v,
       map_smul, coarsenFirstTwoSites_physCloseN M S hSclose]
     simp only [Matrix.smul_apply, smul_eq_mul, physCloseN_apply]
     congr 1
@@ -270,10 +241,10 @@ theorem tensorMapBoth_splitNormalizedMPO_reverse
   rw [hY, map_smul, refineFirstSite_physCloseN M T hTclose]
   let uB : Fin (b + 2) → Fin d := finFunctionFinEquiv.symm pB
   let vB : Fin (b + 2) → Fin d := finFunctionFinEquiv.symm qB
-  have hout := splitNormalizedMPO_slice M N (a + 1) (b + 2) hIn uB vB
+  have hout := bipartitionedNormalizedMPO_slice M N (a + 1) (b + 2) hIn uB vB
   have houtxy := congrFun (congrFun hout uA) vA
   have houtEntry :
-      splitNormalizedMPO M N (a + 1) (b + 2) hIn (pA, pB) (qA, qB) =
+      bipartitionedNormalizedMPO M N (a + 1) (b + 2) hIn (pA, pB) (qA, qB) =
         (Matrix.trace (mpo M N))⁻¹ *
           Matrix.trace (evalWord M (List.ofFn uA) (List.ofFn vA) *
             evalWord M (List.ofFn uB) (List.ofFn vB)) := by
@@ -303,7 +274,7 @@ Source: arXiv:1606.00608, Appendix C, lines 1333--1341.
 **Scope restriction:** This is the conditional entropic helper documented in
 `docs/paper-gaps/cpsv16_rfp_sal_data_processing.tex`, not Proposition
 `propsimple`. -/
-theorem mutualInformation_split_eq_of_local_transfers
+theorem mutualInformation_bipartition_eq_of_local_transfers
     (M : MPOTensor d D) (N a b : ℕ)
     (hIn : N = (a + 1) + (b + 2)) (hOut : N = (a + 2) + (b + 1))
     (hM : (mpo M N).PosSemidef) (htr : (mpo M N).trace ≠ 0)
@@ -315,48 +286,48 @@ theorem mutualInformation_split_eq_of_local_transfers
     (hSclose : ∀ X, S (physClose2 M X) = physClose1 M X)
     (hTclose : ∀ X, T (physClose1 M X) = physClose2 M X) :
     Entropy.mutualInformation
-        (splitNormalizedMPO M N (a + 1) (b + 2) hIn)
-        (splitNormalizedMPO_posSemidef M N (a + 1) (b + 2) hIn hM).isHermitian =
+        (bipartitionedNormalizedMPO M N (a + 1) (b + 2) hIn)
+        (bipartitionedNormalizedMPO_posSemidef M N (a + 1) (b + 2) hIn hM).isHermitian =
       Entropy.mutualInformation
-        (splitNormalizedMPO M N (a + 2) (b + 1) hOut)
-        (splitNormalizedMPO_posSemidef M N (a + 2) (b + 1) hOut hM).isHermitian := by
-  have hρ := splitNormalizedMPO_posSemidef M N (a + 1) (b + 2) hIn hM
-  have hσ := splitNormalizedMPO_posSemidef M N (a + 2) (b + 1) hOut hM
-  have hρtr := splitNormalizedMPO_trace M N (a + 1) (b + 2) hIn htr
-  have hσtr := splitNormalizedMPO_trace M N (a + 2) (b + 1) hOut htr
-  have hforward := tensorMapBoth_splitNormalizedMPO M N a b hIn hOut S T hSclose hTclose
+        (bipartitionedNormalizedMPO M N (a + 2) (b + 1) hOut)
+        (bipartitionedNormalizedMPO_posSemidef M N (a + 2) (b + 1) hOut hM).isHermitian := by
+  have hρ := bipartitionedNormalizedMPO_posSemidef M N (a + 1) (b + 2) hIn hM
+  have hσ := bipartitionedNormalizedMPO_posSemidef M N (a + 2) (b + 1) hOut hM
+  have hρtr := bipartitionedNormalizedMPO_trace M N (a + 1) (b + 2) hIn htr
+  have hσtr := bipartitionedNormalizedMPO_trace M N (a + 2) (b + 1) hOut htr
+  have hforward := tensorMapBoth_bipartitionedNormalizedMPO M N a b hIn hOut S T hSclose hTclose
   have hbackward :=
-    tensorMapBoth_splitNormalizedMPO_reverse M N a b hIn hOut S T hSclose hTclose
+    tensorMapBoth_bipartitionedNormalizedMPO_reverse M N a b hIn hOut S T hSclose hTclose
   have hforward_le :=
     (refineFirstBlock_isKrausCPTP hT a).mutualInformation_tensorMapBoth_le
       (coarsenFirstBlock_isKrausCPTP hS b)
-      (splitNormalizedMPO M N (a + 1) (b + 2) hIn) hρ hρtr
+      (bipartitionedNormalizedMPO M N (a + 1) (b + 2) hIn) hρ hρtr
   have hbackward_le :=
     (coarsenFirstBlock_isKrausCPTP hS a).mutualInformation_tensorMapBoth_le
       (refineFirstBlock_isKrausCPTP hT b)
-      (splitNormalizedMPO M N (a + 2) (b + 1) hOut) hσ hσtr
+      (bipartitionedNormalizedMPO M N (a + 2) (b + 1) hOut) hσ hσtr
   have hσρ :
       Entropy.mutualInformation
-          (splitNormalizedMPO M N (a + 2) (b + 1) hOut) hσ.isHermitian ≤
+          (bipartitionedNormalizedMPO M N (a + 2) (b + 1) hOut) hσ.isHermitian ≤
         Entropy.mutualInformation
-          (splitNormalizedMPO M N (a + 1) (b + 2) hIn) hρ.isHermitian := by
+          (bipartitionedNormalizedMPO M N (a + 1) (b + 2) hIn) hρ.isHermitian := by
     calc
       _ = Entropy.mutualInformation
           (Matrix.tensorMapBoth (refineFirstBlock T a) (coarsenFirstBlock S b)
-            (splitNormalizedMPO M N (a + 1) (b + 2) hIn))
+            (bipartitionedNormalizedMPO M N (a + 1) (b + 2) hIn))
           ((refineFirstBlock_isKrausCPTP hT a).tensorMapBoth_posSemidef
             (coarsenFirstBlock_isKrausCPTP hS b) hρ).isHermitian :=
         (mutualInformation_congr hforward _ _).symm
       _ ≤ _ := hforward_le
   have hρσ :
       Entropy.mutualInformation
-          (splitNormalizedMPO M N (a + 1) (b + 2) hIn) hρ.isHermitian ≤
+          (bipartitionedNormalizedMPO M N (a + 1) (b + 2) hIn) hρ.isHermitian ≤
         Entropy.mutualInformation
-          (splitNormalizedMPO M N (a + 2) (b + 1) hOut) hσ.isHermitian := by
+          (bipartitionedNormalizedMPO M N (a + 2) (b + 1) hOut) hσ.isHermitian := by
     calc
       _ = Entropy.mutualInformation
           (Matrix.tensorMapBoth (coarsenFirstBlock S a) (refineFirstBlock T b)
-            (splitNormalizedMPO M N (a + 2) (b + 1) hOut))
+            (bipartitionedNormalizedMPO M N (a + 2) (b + 1) hOut))
           ((coarsenFirstBlock_isKrausCPTP hS a).tensorMapBoth_posSemidef
             (refineFirstBlock_isKrausCPTP hT b) hσ).isHermitian :=
         (mutualInformation_congr hbackward _ _).symm
@@ -379,18 +350,18 @@ lines 1333--1341.
 **Scope restriction:** The explicit nonzero-trace hypothesis is confined to
 this helper and is not added to the source proposition; see
 `docs/paper-gaps/cpsv16_rfp_sal_data_processing.tex`. -/
-theorem mutualInformation_split_eq_of_isRFPViaTS
+theorem mutualInformation_bipartition_eq_of_isRFPViaTS
     (M : MPOTensor d D) (hRFP : IsRFPViaTS M) (N a b : ℕ)
     (hIn : N = (a + 1) + (b + 2)) (hOut : N = (a + 2) + (b + 1))
     (hM : (mpo M N).PosSemidef) (htr : (mpo M N).trace ≠ 0) :
     Entropy.mutualInformation
-        (splitNormalizedMPO M N (a + 1) (b + 2) hIn)
-        (splitNormalizedMPO_posSemidef M N (a + 1) (b + 2) hIn hM).isHermitian =
+        (bipartitionedNormalizedMPO M N (a + 1) (b + 2) hIn)
+        (bipartitionedNormalizedMPO_posSemidef M N (a + 1) (b + 2) hIn hM).isHermitian =
       Entropy.mutualInformation
-        (splitNormalizedMPO M N (a + 2) (b + 1) hOut)
-        (splitNormalizedMPO_posSemidef M N (a + 2) (b + 1) hOut hM).isHermitian := by
+        (bipartitionedNormalizedMPO M N (a + 2) (b + 1) hOut)
+        (bipartitionedNormalizedMPO_posSemidef M N (a + 2) (b + 1) hOut hM).isHermitian := by
   obtain ⟨S, T, hS, hT, hSclose, hTclose⟩ := hRFP
-  exact mutualInformation_split_eq_of_local_transfers M N a b hIn hOut hM htr
+  exact mutualInformation_bipartition_eq_of_local_transfers M N a b hIn hOut hM htr
     S T hS hT hSclose hTclose
 
 end MPOTensor

--- a/TNLean/MPS/MPDO/RFPViaTSSAL.lean
+++ b/TNLean/MPS/MPDO/RFPViaTSSAL.lean
@@ -1,0 +1,396 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Entropy.MutualInformationDataProcessing
+import TNLean.MPS.MPDO.MutualInfoMonotone
+import TNLean.MPS.MPDO.RFPViaTSGlobal
+
+/-!
+# The conditional mutual-information step for MPDO renormalization fixed points
+
+This file isolates the entropic part of the proof that a mixed-state
+renormalization fixed point saturates the area law.  The result below is a
+conditional helper, not a formalization of Proposition `propsimple`.  It proves
+the two exact finite-chain identifications obtained by transferring one site
+across a bipartition and derives the resulting mutual-information equality.
+The separate normalization argument uses horizontal canonical form, the MPDO
+condition, and the renormalization maps; simplicity is not needed for the
+forward implication of the source proposition.
+
+Source: arXiv:1606.00608, Appendix C, lines 1333--1341.  See
+`docs/paper-gaps/cpsv16_rfp_sal_data_processing.tex`.
+-/
+
+open scoped Matrix ComplexOrder
+open Matrix
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- Split a length-`N` configuration into consecutive blocks of lengths `L`
+and `K`, and flatten each block to a `Fin` index. -/
+noncomputable def chainBiSplitEquiv (d N L K : ℕ) (h : N = L + K) :
+    (Fin N → Fin d) ≃ Fin (d ^ L) × Fin (d ^ K) :=
+  (Equiv.arrowCongr (finCongr h) (Equiv.refl (Fin d))).trans
+    (biSplitEquiv d L K)
+
+/-- The normalized periodic MPO viewed across a consecutive bipartition. -/
+noncomputable def splitNormalizedMPO (M : MPOTensor d D) (N L K : ℕ)
+    (h : N = L + K) :
+    Matrix (Fin (d ^ L) × Fin (d ^ K)) (Fin (d ^ L) × Fin (d ^ K)) ℂ :=
+  (normalizedMPO M N).submatrix (chainBiSplitEquiv d N L K h).symm
+    (chainBiSplitEquiv d N L K h).symm
+
+/-- Positivity of the normalized state is preserved by the bipartition
+reindexing. -/
+theorem splitNormalizedMPO_posSemidef (M : MPOTensor d D) (N L K : ℕ)
+    (h : N = L + K) (hM : (mpo M N).PosSemidef) :
+    (splitNormalizedMPO M N L K h).PosSemidef := by
+  exact (normalizedMPO_posSemidef M N hM).submatrix _
+
+/-- A positive-length normalized periodic MPO has unit trace whenever its
+unnormalized trace is nonzero. -/
+theorem splitNormalizedMPO_trace (M : MPOTensor d D) (N L K : ℕ)
+    (h : N = L + K) (htr : (mpo M N).trace ≠ 0) :
+    (splitNormalizedMPO M N L K h).trace = 1 := by
+  rw [splitNormalizedMPO, Matrix.trace_submatrix_equiv,
+    normalizedMPO_trace M N htr]
+
+/-- The localized one-to-two map, with its input and output block
+configurations flattened to `Fin` indices. -/
+noncomputable def refineFirstBlock
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ) (n : ℕ) :
+    Matrix (Fin (d ^ (n + 1))) (Fin (d ^ (n + 1))) ℂ →ₗ[ℂ]
+      Matrix (Fin (d ^ (n + 2))) (Fin (d ^ (n + 2))) ℂ :=
+  Matrix.equivReindexMap finFunctionFinEquiv ∘ₗ
+    refineFirstSite T n ∘ₗ
+      Matrix.equivReindexMap finFunctionFinEquiv.symm
+
+/-- The localized two-to-one map, with its input and output block
+configurations flattened to `Fin` indices. -/
+noncomputable def coarsenFirstBlock
+    (S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d) (Fin d) ℂ) (n : ℕ) :
+    Matrix (Fin (d ^ (n + 2))) (Fin (d ^ (n + 2))) ℂ →ₗ[ℂ]
+      Matrix (Fin (d ^ (n + 1))) (Fin (d ^ (n + 1))) ℂ :=
+  Matrix.equivReindexMap finFunctionFinEquiv ∘ₗ
+    coarsenFirstTwoSites S n ∘ₗ
+      Matrix.equivReindexMap finFunctionFinEquiv.symm
+
+/-- Flattening a localized refinement channel preserves the channel
+property. -/
+theorem refineFirstBlock_isKrausCPTP
+    {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ}
+    (hT : IsKrausCPTP T) (n : ℕ) :
+    IsKrausCPTP (refineFirstBlock T n) := by
+  exact isKrausCPTP_comp
+    (isKrausCPTP_comp
+      (Matrix.equivReindexMap_isKrausCPTP finFunctionFinEquiv.symm)
+      (refineFirstSite_isKrausCPTP hT n))
+    (Matrix.equivReindexMap_isKrausCPTP finFunctionFinEquiv)
+
+/-- Flattening a localized coarse-graining channel preserves the channel
+property. -/
+theorem coarsenFirstBlock_isKrausCPTP
+    {S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d) (Fin d) ℂ}
+    (hS : IsKrausCPTP S) (n : ℕ) :
+    IsKrausCPTP (coarsenFirstBlock S n) := by
+  exact isKrausCPTP_comp
+    (isKrausCPTP_comp
+      (Matrix.equivReindexMap_isKrausCPTP finFunctionFinEquiv.symm)
+      (coarsenFirstTwoSites_isKrausCPTP hS n))
+    (Matrix.equivReindexMap_isKrausCPTP finFunctionFinEquiv)
+
+/-- Mutual information is congruent under equality of the bipartite density
+matrix; the Hermiticity witnesses carry no additional data. -/
+private theorem mutualInformation_congr
+    {dA dB : ℕ}
+    {ρ σ : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ}
+    (h : ρ = σ) (hρ : ρ.IsHermitian) (hσ : σ.IsHermitian) :
+    Entropy.mutualInformation ρ hρ = Entropy.mutualInformation σ hσ := by
+  subst σ
+  rfl
+
+/-- Fixing the second block of a flattened bipartition leaves the first-block
+physical closure, with the fixed word inserted as its virtual boundary. -/
+private theorem splitMPO_slice
+    (M : MPOTensor d D) (N L K : ℕ) (h : N = L + K)
+    (u v : Fin K → Fin d) :
+    Matrix.equivReindexMap finFunctionFinEquiv.symm
+        (Matrix.bipartiteSlice
+          ((mpo M N).submatrix (chainBiSplitEquiv d N L K h).symm
+            (chainBiSplitEquiv d N L K h).symm)
+          (finFunctionFinEquiv u) (finFunctionFinEquiv v)) =
+      physCloseN M L (evalWord M (List.ofFn u) (List.ofFn v)) := by
+  subst N
+  ext x y
+  simp [Matrix.equivReindexMap, Matrix.coe_reindexLinearEquiv,
+    Matrix.reindex_apply, chainBiSplitEquiv, biSplitEquiv,
+    Matrix.bipartiteSlice, blockSplitEquiv_symm_apply, mpoMatrixEntry,
+    List.ofFn_fin_append, evalWord_append]
+
+/-- The preceding slice identity for the normalized periodic MPO. -/
+private theorem splitNormalizedMPO_slice
+    (M : MPOTensor d D) (N L K : ℕ) (h : N = L + K)
+    (u v : Fin K → Fin d) :
+    Matrix.equivReindexMap finFunctionFinEquiv.symm
+        (Matrix.bipartiteSlice (splitNormalizedMPO M N L K h)
+          (finFunctionFinEquiv u) (finFunctionFinEquiv v)) =
+      (Matrix.trace (mpo M N))⁻¹ •
+        physCloseN M L (evalWord M (List.ofFn u) (List.ofFn v)) := by
+  have hs := splitMPO_slice M N L K h u v
+  ext x y
+  have hsxy := congrFun (congrFun hs x) y
+  simpa [splitNormalizedMPO, normalizedMPO, Matrix.equivReindexMap,
+    Matrix.coe_reindexLinearEquiv, Matrix.reindex_apply,
+    Matrix.bipartiteSlice, Matrix.smul_apply, smul_eq_mul] using
+      congrArg (fun z ↦ (Matrix.trace (mpo M N))⁻¹ * z) hsxy
+
+/-- The local closure equations transfer one site across a flattened
+bipartition of a periodic normalized MPO.
+
+Source: arXiv:1606.00608, Appendix C, lines 1337--1341. -/
+theorem tensorMapBoth_splitNormalizedMPO
+    (M : MPOTensor d D) (N a b : ℕ)
+    (hIn : N = (a + 1) + (b + 2)) (hOut : N = (a + 2) + (b + 1))
+    (S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d) (Fin d) ℂ)
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
+    (hSclose : ∀ X, S (physClose2 M X) = physClose1 M X)
+    (hTclose : ∀ X, T (physClose1 M X) = physClose2 M X) :
+    Matrix.tensorMapBoth (refineFirstBlock T a) (coarsenFirstBlock S b)
+        (splitNormalizedMPO M N (a + 1) (b + 2) hIn) =
+      splitNormalizedMPO M N (a + 2) (b + 1) hOut := by
+  ext p q
+  rcases p with ⟨pA, pB⟩
+  rcases q with ⟨qA, qB⟩
+  simp only [Matrix.tensorMapBoth, Matrix.idTensorMap, Matrix.submatrix_apply,
+    Matrix.tensorMapId_apply, Prod.swap_prod_mk]
+  simp only [coarsenFirstBlock, LinearMap.coe_comp, Function.comp_apply,
+    Matrix.equivReindexMap]
+  let uA : Fin (a + 2) → Fin d := finFunctionFinEquiv.symm pA
+  let vA : Fin (a + 2) → Fin d := finFunctionFinEquiv.symm qA
+  let X : Matrix (Fin D) (Fin D) ℂ :=
+    evalWord M (List.ofFn uA) (List.ofFn vA)
+  let Y : Matrix (Fin (b + 2) → Fin d) (Fin (b + 2) → Fin d) ℂ :=
+    (Matrix.reindexLinearEquiv ℂ ℂ finFunctionFinEquiv.symm
+      finFunctionFinEquiv.symm)
+      (Matrix.bipartiteSlice
+        ((Matrix.tensorMapId (refineFirstBlock T a)
+          (splitNormalizedMPO M N (a + 1) (b + 2) hIn)).submatrix
+            Prod.swap Prod.swap) pA qA)
+  change (coarsenFirstTwoSites S b Y) (finFunctionFinEquiv.symm pB)
+      (finFunctionFinEquiv.symm qB) = _
+  have hY : Y = (Matrix.trace (mpo M N))⁻¹ • physCloseN M (b + 2) X := by
+    ext u v
+    change (refineFirstSite T a
+        (Matrix.equivReindexMap finFunctionFinEquiv.symm
+          (Matrix.bipartiteSlice
+            (splitNormalizedMPO M N (a + 1) (b + 2) hIn)
+            (finFunctionFinEquiv u) (finFunctionFinEquiv v)))) uA vA = _
+    rw [splitNormalizedMPO_slice M N (a + 1) (b + 2) hIn u v,
+      map_smul, refineFirstSite_physCloseN M T hTclose]
+    simp only [Matrix.smul_apply, smul_eq_mul, physCloseN_apply]
+    congr 1
+    exact Matrix.trace_mul_comm _ _
+  rw [hY, map_smul, coarsenFirstTwoSites_physCloseN M S hSclose]
+  let uB : Fin (b + 1) → Fin d := finFunctionFinEquiv.symm pB
+  let vB : Fin (b + 1) → Fin d := finFunctionFinEquiv.symm qB
+  have hout := splitNormalizedMPO_slice M N (a + 2) (b + 1) hOut uB vB
+  have houtxy := congrFun (congrFun hout uA) vA
+  have houtEntry :
+      splitNormalizedMPO M N (a + 2) (b + 1) hOut (pA, pB) (qA, qB) =
+        (Matrix.trace (mpo M N))⁻¹ *
+          Matrix.trace (evalWord M (List.ofFn uA) (List.ofFn vA) *
+            evalWord M (List.ofFn uB) (List.ofFn vB)) := by
+    simpa [Matrix.equivReindexMap, Matrix.coe_reindexLinearEquiv,
+      Matrix.reindex_apply, Matrix.bipartiteSlice, Matrix.smul_apply,
+      smul_eq_mul, physCloseN_apply, uA, vA, uB, vB] using houtxy
+  rw [houtEntry]
+  simp only [Matrix.smul_apply, smul_eq_mul, physCloseN_apply]
+  congr 1
+  exact Matrix.trace_mul_comm _ _
+
+/-- The reverse pair of localized closure maps transfers the site back across
+the same bipartition.
+
+Source: arXiv:1606.00608, Definition 4.1 and Appendix C,
+lines 1337--1341. -/
+theorem tensorMapBoth_splitNormalizedMPO_reverse
+    (M : MPOTensor d D) (N a b : ℕ)
+    (hIn : N = (a + 1) + (b + 2)) (hOut : N = (a + 2) + (b + 1))
+    (S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d) (Fin d) ℂ)
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
+    (hSclose : ∀ X, S (physClose2 M X) = physClose1 M X)
+    (hTclose : ∀ X, T (physClose1 M X) = physClose2 M X) :
+    Matrix.tensorMapBoth (coarsenFirstBlock S a) (refineFirstBlock T b)
+        (splitNormalizedMPO M N (a + 2) (b + 1) hOut) =
+      splitNormalizedMPO M N (a + 1) (b + 2) hIn := by
+  ext p q
+  rcases p with ⟨pA, pB⟩
+  rcases q with ⟨qA, qB⟩
+  simp only [Matrix.tensorMapBoth, Matrix.idTensorMap, Matrix.submatrix_apply,
+    Matrix.tensorMapId_apply, Prod.swap_prod_mk]
+  simp only [refineFirstBlock, LinearMap.coe_comp, Function.comp_apply,
+    Matrix.equivReindexMap]
+  let uA : Fin (a + 1) → Fin d := finFunctionFinEquiv.symm pA
+  let vA : Fin (a + 1) → Fin d := finFunctionFinEquiv.symm qA
+  let X : Matrix (Fin D) (Fin D) ℂ :=
+    evalWord M (List.ofFn uA) (List.ofFn vA)
+  let Y : Matrix (Fin (b + 1) → Fin d) (Fin (b + 1) → Fin d) ℂ :=
+    (Matrix.reindexLinearEquiv ℂ ℂ finFunctionFinEquiv.symm
+      finFunctionFinEquiv.symm)
+      (Matrix.bipartiteSlice
+        ((Matrix.tensorMapId (coarsenFirstBlock S a)
+          (splitNormalizedMPO M N (a + 2) (b + 1) hOut)).submatrix
+            Prod.swap Prod.swap) pA qA)
+  change (refineFirstSite T b Y) (finFunctionFinEquiv.symm pB)
+      (finFunctionFinEquiv.symm qB) = _
+  have hY : Y = (Matrix.trace (mpo M N))⁻¹ • physCloseN M (b + 1) X := by
+    ext u v
+    change (coarsenFirstTwoSites S a
+        (Matrix.equivReindexMap finFunctionFinEquiv.symm
+          (Matrix.bipartiteSlice
+            (splitNormalizedMPO M N (a + 2) (b + 1) hOut)
+            (finFunctionFinEquiv u) (finFunctionFinEquiv v)))) uA vA = _
+    rw [splitNormalizedMPO_slice M N (a + 2) (b + 1) hOut u v,
+      map_smul, coarsenFirstTwoSites_physCloseN M S hSclose]
+    simp only [Matrix.smul_apply, smul_eq_mul, physCloseN_apply]
+    congr 1
+    exact Matrix.trace_mul_comm _ _
+  rw [hY, map_smul, refineFirstSite_physCloseN M T hTclose]
+  let uB : Fin (b + 2) → Fin d := finFunctionFinEquiv.symm pB
+  let vB : Fin (b + 2) → Fin d := finFunctionFinEquiv.symm qB
+  have hout := splitNormalizedMPO_slice M N (a + 1) (b + 2) hIn uB vB
+  have houtxy := congrFun (congrFun hout uA) vA
+  have houtEntry :
+      splitNormalizedMPO M N (a + 1) (b + 2) hIn (pA, pB) (qA, qB) =
+        (Matrix.trace (mpo M N))⁻¹ *
+          Matrix.trace (evalWord M (List.ofFn uA) (List.ofFn vA) *
+            evalWord M (List.ofFn uB) (List.ofFn vB)) := by
+    simpa [Matrix.equivReindexMap, Matrix.coe_reindexLinearEquiv,
+      Matrix.reindex_apply, Matrix.bipartiteSlice, Matrix.smul_apply,
+      smul_eq_mul, physCloseN_apply, uA, vA, uB, vB] using houtxy
+  rw [houtEntry]
+  simp only [Matrix.smul_apply, smul_eq_mul, physCloseN_apply]
+  congr 1
+  exact Matrix.trace_mul_comm _ _
+
+/-- **Conditional Appendix C mutual-information equality.**
+
+Let `A` and `B` have lengths `a+1` and `b+2`.  If applying the localized
+one-to-two map to `A` and the localized two-to-one map to `B` gives the same
+periodic state with block lengths `a+2` and `b+1`, and the reverse pair of
+localized maps recovers the original split state, then the two mutual
+informations coincide.
+
+Both finite-chain identifications are derived from the physical-closure
+equations above.  The only normalization hypothesis is the nonzero trace of
+the `N`-site operator.  The displayed decomposition makes `N` positive, so no
+empty-chain condition is used.
+
+Source: arXiv:1606.00608, Appendix C, lines 1333--1341.
+
+**Scope restriction:** This is the conditional entropic helper documented in
+`docs/paper-gaps/cpsv16_rfp_sal_data_processing.tex`, not Proposition
+`propsimple`. -/
+theorem mutualInformation_split_eq_of_local_transfers
+    (M : MPOTensor d D) (N a b : ℕ)
+    (hIn : N = (a + 1) + (b + 2)) (hOut : N = (a + 2) + (b + 1))
+    (hM : (mpo M N).PosSemidef) (htr : (mpo M N).trace ≠ 0)
+    (S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d) (Fin d) ℂ)
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
+    (hS : IsKrausCPTP S) (hT : IsKrausCPTP T)
+    (hSclose : ∀ X, S (physClose2 M X) = physClose1 M X)
+    (hTclose : ∀ X, T (physClose1 M X) = physClose2 M X) :
+    Entropy.mutualInformation
+        (splitNormalizedMPO M N (a + 1) (b + 2) hIn)
+        (splitNormalizedMPO_posSemidef M N (a + 1) (b + 2) hIn hM).isHermitian =
+      Entropy.mutualInformation
+        (splitNormalizedMPO M N (a + 2) (b + 1) hOut)
+        (splitNormalizedMPO_posSemidef M N (a + 2) (b + 1) hOut hM).isHermitian := by
+  have hρ := splitNormalizedMPO_posSemidef M N (a + 1) (b + 2) hIn hM
+  have hσ := splitNormalizedMPO_posSemidef M N (a + 2) (b + 1) hOut hM
+  have hρtr := splitNormalizedMPO_trace M N (a + 1) (b + 2) hIn htr
+  have hσtr := splitNormalizedMPO_trace M N (a + 2) (b + 1) hOut htr
+  have hforward := tensorMapBoth_splitNormalizedMPO M N a b hIn hOut S T hSclose hTclose
+  have hbackward :=
+    tensorMapBoth_splitNormalizedMPO_reverse M N a b hIn hOut S T hSclose hTclose
+  have hforward_le :=
+    (refineFirstBlock_isKrausCPTP hT a).mutualInformation_tensorMapBoth_le
+      (coarsenFirstBlock_isKrausCPTP hS b)
+      (splitNormalizedMPO M N (a + 1) (b + 2) hIn) hρ hρtr
+  have hbackward_le :=
+    (coarsenFirstBlock_isKrausCPTP hS a).mutualInformation_tensorMapBoth_le
+      (refineFirstBlock_isKrausCPTP hT b)
+      (splitNormalizedMPO M N (a + 2) (b + 1) hOut) hσ hσtr
+  have hσρ :
+      Entropy.mutualInformation
+          (splitNormalizedMPO M N (a + 2) (b + 1) hOut) hσ.isHermitian ≤
+        Entropy.mutualInformation
+          (splitNormalizedMPO M N (a + 1) (b + 2) hIn) hρ.isHermitian := by
+    calc
+      _ = Entropy.mutualInformation
+          (Matrix.tensorMapBoth (refineFirstBlock T a) (coarsenFirstBlock S b)
+            (splitNormalizedMPO M N (a + 1) (b + 2) hIn))
+          ((refineFirstBlock_isKrausCPTP hT a).tensorMapBoth_posSemidef
+            (coarsenFirstBlock_isKrausCPTP hS b) hρ).isHermitian :=
+        (mutualInformation_congr hforward _ _).symm
+      _ ≤ _ := hforward_le
+  have hρσ :
+      Entropy.mutualInformation
+          (splitNormalizedMPO M N (a + 1) (b + 2) hIn) hρ.isHermitian ≤
+        Entropy.mutualInformation
+          (splitNormalizedMPO M N (a + 2) (b + 1) hOut) hσ.isHermitian := by
+    calc
+      _ = Entropy.mutualInformation
+          (Matrix.tensorMapBoth (coarsenFirstBlock S a) (refineFirstBlock T b)
+            (splitNormalizedMPO M N (a + 2) (b + 1) hOut))
+          ((coarsenFirstBlock_isKrausCPTP hS a).tensorMapBoth_posSemidef
+            (refineFirstBlock_isKrausCPTP hT b) hσ).isHermitian :=
+        (mutualInformation_congr hbackward _ _).symm
+      _ ≤ _ := hbackward_le
+  exact le_antisymm hρσ hσρ
+
+/-- A renormalization fixed point has equal bipartite mutual information when
+one site is transferred across either side of a nontrivial cut.
+
+This is the conditional entropic conclusion of Appendix C.  It still does not
+assert Proposition `propsimple`, because identifying this flattened bipartite
+quantity with `mutualInfoChain` and assembling the positive-chain SAL statement
+remain separate steps.  The required nonzero trace follows separately from
+horizontal canonical form, the MPDO condition, and the renormalization maps;
+source simplicity is not used in this implication.
+
+Source: arXiv:1606.00608, Definition 4.1 and Appendix C,
+lines 1333--1341.
+
+**Scope restriction:** The explicit nonzero-trace hypothesis is confined to
+this helper and is not added to the source proposition; see
+`docs/paper-gaps/cpsv16_rfp_sal_data_processing.tex`. -/
+theorem mutualInformation_split_eq_of_isRFPViaTS
+    (M : MPOTensor d D) (hRFP : IsRFPViaTS M) (N a b : ℕ)
+    (hIn : N = (a + 1) + (b + 2)) (hOut : N = (a + 2) + (b + 1))
+    (hM : (mpo M N).PosSemidef) (htr : (mpo M N).trace ≠ 0) :
+    Entropy.mutualInformation
+        (splitNormalizedMPO M N (a + 1) (b + 2) hIn)
+        (splitNormalizedMPO_posSemidef M N (a + 1) (b + 2) hIn hM).isHermitian =
+      Entropy.mutualInformation
+        (splitNormalizedMPO M N (a + 2) (b + 1) hOut)
+        (splitNormalizedMPO_posSemidef M N (a + 2) (b + 1) hOut hM).isHermitian := by
+  obtain ⟨S, T, hS, hT, hSclose, hTclose⟩ := hRFP
+  exact mutualInformation_split_eq_of_local_transfers M N a b hIn hOut hM htr
+    S T hS hT hSclose hTclose
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
@@ -19,7 +19,7 @@
 \end{definition}
 
 \begin{definition}[Mutual information of an MPDO]\label{def:mutual_info_chain}
-    \lean{MPOTensor.mutualInfoChain}
+    \lean{MPOTensor.mutualInfoChain, MPOTensor.mutualInfoChain_eq}
     \leanok
     \uses{def:block_entropy}
     For the same fixed system size $N$, block length $L\le N$, and positive
@@ -384,6 +384,56 @@
     channels and to the reverse pair.  The two transfer identities turn the
     resulting inequalities into opposite inequalities between the displayed
     mutual informations.
+\end{proof}
+
+\begin{lemma}[Nonvanishing of positive-length RFP rings]
+    \label{lem:mpdo_rfp_positive_length_trace_nonzero}
+    \lean{MPOTensor.firstSiteMatrix_one,
+      MPOTensor.trace_mpo_ne_zero_of_isHorizontalCF_isMPDO_isRFPViaTS}
+    \leanok
+    \uses{def:is_rfp_via_ts}
+    Let $M$ be horizontally canonical, generate positive semidefinite ring
+    operators, and satisfy the local renormalization fixed-point equations.
+    Then
+    \[
+      \operatorname{tr}\rho^{(N)}(M)\neq0
+      \qquad (N\geq1).
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    Horizontal canonical form gives a nonzero sector compression for one
+    positive length.  Positivity makes its trace nonzero.  The fixed-point
+    equations make the physical-trace transfer idempotent, so the trace of its
+    positive powers is independent of the positive exponent.
+\end{proof}
+
+\begin{theorem}[Renormalization fixed points saturate the area law]
+    \label{thm:mpdo_rfp_implies_sal}
+    \lean{MPOTensor.isSAL_of_isRFPViaTS}
+    \leanok
+    \uses{lem:mpdo_chain_mutual_information_bipartition,
+      lem:mpdo_rfp_transfer_across_cut,
+      thm:mpdo_rfp_split_mutual_information_eq,
+      lem:mpdo_rfp_positive_length_trace_nonzero}
+    Let $M$ be a horizontally canonical matrix product density operator which
+    satisfies the local renormalization fixed-point equations of
+    Definition~4.1.  Then $M$ saturates the area law:
+    \[
+      I_L(M)=I_{L+1}(M),
+      \qquad 1\leq L<\lfloor N/2\rfloor.
+    \]
+    This is the forward implication of Proposition~\texttt{propsimple} in
+    Appendix~C of \cite{Cirac2016MPDO_arXiv}.  Simplicity is among the ambient
+    hypotheses of Theorem~4.9 but is not used in this implication.
+\end{theorem}
+
+\begin{proof}\leanok
+    Write the cut as $(a+1):(b+2)$.  The local channels transfer one site to
+    obtain $(a+2):(b+1)$, and data processing in both directions gives equality
+    of the two bipartite mutual informations.  The consecutive-cut
+    identification turns this into $I_L=I_{L+1}$.  The preceding lemma supplies
+    the normalization at every positive chain length.
 \end{proof}
 
 \begin{lemma}[Nonnegativity of block entropies]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
@@ -285,6 +285,84 @@
     Apply the two one-sided inequalities successively.
 \end{proof}
 
+\begin{definition}[Normalized state across a consecutive bipartition]
+    \label{def:mpdo_split_normalized_mpo}
+    \lean{MPOTensor.chainBiSplitEquiv,
+      MPOTensor.splitNormalizedMPO,
+      MPOTensor.splitNormalizedMPO_posSemidef,
+      MPOTensor.splitNormalizedMPO_trace,
+      MPOTensor.refineFirstBlock,
+      MPOTensor.coarsenFirstBlock,
+      MPOTensor.refineFirstBlock_isKrausCPTP,
+      MPOTensor.coarsenFirstBlock_isKrausCPTP}
+    \leanok
+    For $N=L+K$, split a physical configuration into consecutive intervals of
+    lengths $L$ and $K$, flatten each interval to a finite index, and denote the
+    resulting bipartite form of the normalized periodic MPO by
+    $\sigma^{(N)}_{L:K}$.  The flattened local maps on the two factors are
+    denoted by $\widehat{\mathcal T}_L$ and
+    $\widehat{\mathcal S}_K$.
+\end{definition}
+
+\begin{lemma}[Renormalization maps transfer one site across a cut]
+    \label{lem:mpdo_rfp_transfer_across_cut}
+    \lean{MPOTensor.tensorMapBoth_splitNormalizedMPO,
+      MPOTensor.tensorMapBoth_splitNormalizedMPO_reverse}
+    \leanok
+    \uses{def:mpdo_split_normalized_mpo,
+      thm:mpdo_global_renormalization_maps}
+    Suppose that $N=(a+1)+(b+2)=(a+2)+(b+1)$.  The local closure equations
+    imply
+    \[
+      (\widehat{\mathcal T}_a\otimes\widehat{\mathcal S}_b)
+        \bigl(\sigma^{(N)}_{a+1:b+2}\bigr)
+        =\sigma^{(N)}_{a+2:b+1},
+    \]
+    while the reverse pair satisfies
+    \[
+      (\widehat{\mathcal S}_a\otimes\widehat{\mathcal T}_b)
+        \bigl(\sigma^{(N)}_{a+2:b+1}\bigr)
+        =\sigma^{(N)}_{a+1:b+2}.
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    Fixing the word on the second interval leaves a physical closure on the
+    first interval, whose virtual boundary is the fixed word evaluation.
+    Apply the appropriate global closure identity to this slice.  Fixing the
+    resulting word on the first interval gives the closure on the second
+    interval.  Cyclicity of the virtual trace identifies the two cuts of the
+    periodic contraction.  The reverse identity is the same argument with
+    $\mathcal S$ and $\mathcal T$ interchanged.
+\end{proof}
+
+\begin{theorem}[Conditional RFP mutual-information equality]
+    \label{thm:mpdo_rfp_split_mutual_information_eq}
+    \lean{MPOTensor.mutualInformation_split_eq_of_local_transfers,
+      MPOTensor.mutualInformation_split_eq_of_isRFPViaTS}
+    \leanok
+    \uses{lem:mpdo_rfp_transfer_across_cut,
+      thm:mpdo_mutual_information_data_processing}
+    Let $M$ be a renormalization fixed point.  If its $N$-site operator is
+    positive semidefinite and has nonzero trace, then
+    \[
+       I\bigl(\sigma^{(N)}_{a+1:b+2}\bigr)
+       =I\bigl(\sigma^{(N)}_{a+2:b+1}\bigr).
+    \]
+    This is the channel calculation in
+    \cite[Appendix~C, lines~1333--1341]{Cirac2016MPDO_arXiv}.  For the forward
+    implication of the source proposition, the required nonzero trace follows
+    from horizontal canonical form, the MPDO condition, and the renormalization
+    maps; simplicity is not used.
+\end{theorem}
+
+\begin{proof}\leanok
+    Apply mutual-information data processing to the forward pair of local
+    channels and to the reverse pair.  The two transfer identities turn the
+    resulting inequalities into opposite inequalities between the displayed
+    mutual informations.
+\end{proof}
+
 \begin{lemma}[Nonnegativity of block entropies]
     \label{lem:block_entropy_nonneg}
     \lean{blockEntropy_nonneg}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
@@ -307,8 +307,8 @@
 \begin{lemma}[Chain mutual information across a consecutive cut]
     \label{lem:mpdo_chain_mutual_information_bipartition}
     \lean{MPOTensor.reducedBlockState_full,
-      MPOTensor.traceRight_bipartitionedNormalizedMPO,
-      MPOTensor.traceLeft_bipartitionedNormalizedMPO,
+      MPOTensor.bipartitionedNormalizedMPO_traceRight,
+      MPOTensor.bipartitionedNormalizedMPO_traceLeft,
       MPOTensor.mutualInfoChain_eq_mutualInformation}
     \leanok
     \uses{def:mpdo_split_normalized_mpo}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
@@ -287,10 +287,10 @@
 
 \begin{definition}[Normalized state across a consecutive bipartition]
     \label{def:mpdo_split_normalized_mpo}
-    \lean{MPOTensor.chainBiSplitEquiv,
-      MPOTensor.splitNormalizedMPO,
-      MPOTensor.splitNormalizedMPO_posSemidef,
-      MPOTensor.splitNormalizedMPO_trace,
+    \lean{MPOTensor.chainBipartitionEquiv,
+      MPOTensor.bipartitionedNormalizedMPO,
+      MPOTensor.bipartitionedNormalizedMPO_posSemidef,
+      MPOTensor.bipartitionedNormalizedMPO_trace,
       MPOTensor.refineFirstBlock,
       MPOTensor.coarsenFirstBlock,
       MPOTensor.refineFirstBlock_isKrausCPTP,
@@ -304,10 +304,33 @@
     $\widehat{\mathcal S}_K$.
 \end{definition}
 
+\begin{lemma}[Chain mutual information across a consecutive cut]
+    \label{lem:mpdo_chain_mutual_information_bipartition}
+    \lean{MPOTensor.reducedBlockState_full,
+      MPOTensor.traceRight_bipartitionedNormalizedMPO,
+      MPOTensor.traceLeft_bipartitionedNormalizedMPO,
+      MPOTensor.mutualInfoChain_eq_mutualInformation}
+    \leanok
+    \uses{def:mpdo_split_normalized_mpo}
+    Across the consecutive cut after the first $L$ sites, the two marginals
+    of $\sigma^{(N)}_{L:N-L}$ are the reduced states on $L$ and $N-L$ sites,
+    up to the standard finite-index identifications.  Consequently,
+    $I_L(M)$ is the ordinary bipartite mutual information of
+    $\sigma^{(N)}_{L:N-L}$.
+\end{lemma}
+
+\begin{proof}\leanok
+    The first marginal is the defining partial trace over the last $N-L$
+    sites.  Periodic translation invariance identifies the second marginal
+    with the reduced state on the first $N-L$ sites.  Entropy is invariant
+    under the finite-index identifications, and retaining the full chain
+    leaves the normalized state unchanged.
+\end{proof}
+
 \begin{lemma}[Renormalization maps transfer one site across a cut]
     \label{lem:mpdo_rfp_transfer_across_cut}
-    \lean{MPOTensor.tensorMapBoth_splitNormalizedMPO,
-      MPOTensor.tensorMapBoth_splitNormalizedMPO_reverse}
+    \lean{MPOTensor.tensorMapBoth_bipartitionedNormalizedMPO,
+      MPOTensor.tensorMapBoth_bipartitionedNormalizedMPO_reverse}
     \leanok
     \uses{def:mpdo_split_normalized_mpo,
       thm:mpdo_global_renormalization_maps}
@@ -338,8 +361,8 @@
 
 \begin{theorem}[Conditional RFP mutual-information equality]
     \label{thm:mpdo_rfp_split_mutual_information_eq}
-    \lean{MPOTensor.mutualInformation_split_eq_of_local_transfers,
-      MPOTensor.mutualInformation_split_eq_of_isRFPViaTS}
+    \lean{MPOTensor.mutualInformation_bipartition_eq_of_local_transfers,
+      MPOTensor.mutualInformation_bipartition_eq_of_isRFPViaTS}
     \leanok
     \uses{lem:mpdo_rfp_transfer_across_cut,
       thm:mpdo_mutual_information_data_processing}

--- a/docs/paper-gaps/cpsv16_rfp_sal_data_processing.tex
+++ b/docs/paper-gaps/cpsv16_rfp_sal_data_processing.tex
@@ -114,9 +114,9 @@ cut.  Applying the reverse pair recovers the original split state.  Data
 processing in the two directions therefore proves equality of the two
 bipartite mutual informations, conditional only on positivity and the
 nonzero trace needed for normalization.\footnote{Formal declarations:
-\leanid{MPOTensor.tensorMapBoth_splitNormalizedMPO},
-\leanid{MPOTensor.tensorMapBoth_splitNormalizedMPO_reverse}, and
-\leanid{MPOTensor.mutualInformation_split_eq_of_isRFPViaTS} in
+\leanid{MPOTensor.tensorMapBoth_bipartitionedNormalizedMPO},
+\leanid{MPOTensor.tensorMapBoth_bipartitionedNormalizedMPO_reverse}, and
+\leanid{MPOTensor.mutualInformation_bipartition_eq_of_isRFPViaTS} in
 \doclink{TNLean/MPS/MPDO/RFPViaTSSAL}.}
 
 \section{Exact remaining step}

--- a/docs/paper-gaps/cpsv16_rfp_sal_data_processing.tex
+++ b/docs/paper-gaps/cpsv16_rfp_sal_data_processing.tex
@@ -7,8 +7,8 @@
 
 \input{command}
 
-\title{The remaining steps in deriving saturation of the area law from MPDO
-renormalization fixed points}
+\title{Deriving saturation of the area law from MPDO renormalization fixed
+points}
 \author{}
 \date{2026-07-15}
 
@@ -53,10 +53,9 @@ that the tensor generates nonzero density operators at the lengths under
 consideration; it does not add an independent nonvanishing hypothesis to the
 Appendix~C proposition.
 
-Definition~4.6 concerns positive-length spin chains.  The current formal
-predicate asks for nonzero trace also at length zero.  This should be corrected
-to a positive-length condition.  The bipartition argument below never invokes
-an empty-chain operator, since its interval lengths force $N\geq3$.
+Definition~4.6 concerns positive-length spin chains.  The formal predicate now
+asks for nonzero trace only when $N\geq1$.  The bipartition argument below never
+invokes an empty-chain operator, since its interval lengths force $N\geq3$.
 
 \section{The established global identities}
 
@@ -119,39 +118,39 @@ nonzero trace needed for normalization.\footnote{Formal declarations:
 \leanid{MPOTensor.mutualInformation_bipartition_eq_of_isRFPViaTS} in
 \doclink{TNLean/MPS/MPDO/RFPViaTSSAL}.}
 
-\section{Exact remaining step}
+\section{Completion of the implication}
 
-One source-faithful step remains before the implication to saturation of the
-area law is established.
-
-\begin{enumerate}
-  \item \textbf{Identification with the area-law interface.}
-  The channel calculation is stated for the bipartite mutual information of
-  the normalized operator after the two consecutive intervals have been
-  flattened to finite indices.  The present area-law interface instead
-  defines $I_L$ as $S_L+S_{N-L}-S_N$ using prefix reduced states.  A final
-  correspondence lemma must identify these two expressions, using translation
-  invariance for the complementary interval.  This lemma will turn the
-  established bipartite equality into the declaration
-  $\operatorname{mutualInfoChain}(L)=
-    \operatorname{mutualInfoChain}(L+1)$ required by SAL.
-\end{enumerate}
+The consecutive-cut correspondence is now proved.  The first marginal of the
+flattened bipartite state is the prefix reduced state on $L$ sites.  Translation
+invariance moves the second interval to the beginning of the periodic chain,
+so its marginal has the same entropy as the prefix reduced state on $N-L$
+sites.  Retaining all $N$ sites leaves the normalized state unchanged.  Hence
+the bipartite mutual information is exactly
+$S_L+S_{N-L}-S_N=I_L$.\footnote{Formal declarations:
+\leanid{MPOTensor.traceRight_bipartitionedNormalizedMPO},
+\leanid{MPOTensor.traceLeft_bipartitionedNormalizedMPO}, and
+\leanid{MPOTensor.mutualInfoChain_eq_mutualInformation} in
+\doclink{TNLean/MPS/MPDO/MutualInfoBridge}.}
 
 Nonvanishing is not an additional source assumption in this implication.
-Horizontal canonical form, the MPDO condition, and the renormalization maps
-give positive trace at every positive chain length under consideration;
-simplicity is not used.  Once the remaining correspondence is established,
-the source proof applies the two localized channels, invokes data processing to obtain
-$I_{L+1}\leq I_L$, and combines this with the already formalized inequality
-$I_L\leq I_{L+1}$.
+Horizontal canonical form gives one nonzero positive-length ring, positivity
+makes its trace nonzero, and the renormalization equations make the
+physical-trace transfer idempotent.  The trace is therefore nonzero at every
+positive length.\footnote{Formal declaration:
+\leanid{MPOTensor.trace_mpo_ne_zero_of_isHorizontalCF_isMPDO_isRFPViaTS} in
+\doclink{TNLean/MPS/MPDO/RFPViaTSGlobal}.}
+
+Combining the consecutive-cut correspondence, the two exact local-channel
+identities, data processing in both directions, and positive-length
+nonvanishing proves the source implication.\footnote{Formal declaration:
+\leanid{MPOTensor.isSAL_of_isRFPViaTS} in
+\doclink{TNLean/MPS/MPDO/RFPViaTSSAL}.}
 
 \paragraph{Classification.}
-This is an open gap.  The global tensor-ring identities, the required
-mutual-information data-processing theorem, and their application to the
-source bipartition are proved.  Positive trace for the relevant nonempty chains
-follows without simplicity.  The correspondence with the existing
-prefix-entropy definition of $I_L$ and the positive-length correction to the
-formal SAL predicate remain necessary for a faithful proof of saturation of
-the area law.
+This gap is resolved.  The formal SAL predicate is restricted to positive
+chain lengths, the normalized consecutive-cut state is identified with the
+existing prefix-entropy expression for $I_L$, and the RFP hypotheses imply
+both normalization and the equality $I_L=I_{L+1}$.  No simplicity hypothesis
+is used in this forward implication, in agreement with the source proof.
 
 \end{document}

--- a/docs/paper-gaps/cpsv16_rfp_sal_data_processing.tex
+++ b/docs/paper-gaps/cpsv16_rfp_sal_data_processing.tex
@@ -53,6 +53,14 @@ that the tensor generates nonzero density operators at the lengths under
 consideration; it does not add an independent nonvanishing hypothesis to the
 Appendix~C proposition.
 
+The formal predicate leanid{MPOTensor.IsHorizontalCF} used below is the
+representative-grouped BNT decomposition: gauge-equivalent copies are grouped
+over one minimal normal representative and retain their nonzero weights.  It
+formalizes the source assumption that $K$ is in biCF at lines 849--850.  It is
+not the restricted per-copy predicate leanid{HorizontalCFData}, which demands
+separation of every copy individually and is strictly stronger than the
+source's grouped canonical form.
+
 Definition~4.6 concerns positive-length spin chains.  The formal predicate now
 asks for nonzero trace only when $N\geq1$.  The bipartition argument below never
 invokes an empty-chain operator, since its interval lengths force $N\geq3$.
@@ -127,8 +135,8 @@ so its marginal has the same entropy as the prefix reduced state on $N-L$
 sites.  Retaining all $N$ sites leaves the normalized state unchanged.  Hence
 the bipartite mutual information is exactly
 $S_L+S_{N-L}-S_N=I_L$.\footnote{Formal declarations:
-\leanid{MPOTensor.traceRight_bipartitionedNormalizedMPO},
-\leanid{MPOTensor.traceLeft_bipartitionedNormalizedMPO}, and
+\leanid{MPOTensor.bipartitionedNormalizedMPO_traceRight},
+\leanid{MPOTensor.bipartitionedNormalizedMPO_traceLeft}, and
 \leanid{MPOTensor.mutualInfoChain_eq_mutualInformation} in
 \doclink{TNLean/MPS/MPDO/MutualInfoBridge}.}
 
@@ -151,6 +159,8 @@ This gap is resolved.  The formal SAL predicate is restricted to positive
 chain lengths, the normalized consecutive-cut state is identified with the
 existing prefix-entropy expression for $I_L$, and the RFP hypotheses imply
 both normalization and the equality $I_L=I_{L+1}$.  No simplicity hypothesis
-is used in this forward implication, in agreement with the source proof.
+is used in this forward implication, in agreement with the source proof.  The
+horizontal hypothesis is the representative-grouped formalization of the
+source biCF assumption, not the stronger per-copy separation predicate.
 
 \end{document}

--- a/docs/paper-gaps/cpsv16_rfp_sal_data_processing.tex
+++ b/docs/paper-gaps/cpsv16_rfp_sal_data_processing.tex
@@ -53,11 +53,12 @@ that the tensor generates nonzero density operators at the lengths under
 consideration; it does not add an independent nonvanishing hypothesis to the
 Appendix~C proposition.
 
-The formal predicate leanid{MPOTensor.IsHorizontalCF} used below is the
+The formal predicate \leanid{MPOTensor.IsHorizontalCF} used below is the
 representative-grouped BNT decomposition: gauge-equivalent copies are grouped
 over one minimal normal representative and retain their nonzero weights.  It
 formalizes the source assumption that $K$ is in biCF at lines 849--850.  It is
-not the restricted per-copy predicate leanid{HorizontalCFData}, which demands
+not the restricted per-copy predicate
+\leanid{MPOTensor.HorizontalCFData}, which demands
 separation of every copy individually and is strictly stronger than the
 source's grouped canonical form.
 

--- a/docs/paper-gaps/cpsv16_rfp_sal_data_processing.tex
+++ b/docs/paper-gaps/cpsv16_rfp_sal_data_processing.tex
@@ -53,6 +53,11 @@ that the tensor generates nonzero density operators at the lengths under
 consideration; it does not add an independent nonvanishing hypothesis to the
 Appendix~C proposition.
 
+Definition~4.6 concerns positive-length spin chains.  The current formal
+predicate asks for nonzero trace also at length zero.  This should be corrected
+to a positive-length condition.  The bipartition argument below never invokes
+an empty-chain operator, since its interval lengths force $N\geq3$.
+
 \section{The established global identities}
 
 Let $N$ denote the number of spectator sites.  Tensoring the local maps with
@@ -101,49 +106,52 @@ entropy under that isometry, and then invokes monotonicity under discarding
 the environment.  Exchanging the two tensor factors and applying the
 one-sided inequality twice gives the two-channel form used by the source.
 
-\section{Exact remaining steps}
+The two local maps have now also been assembled on a consecutive bipartition.
+After flattening each interval to a finite matrix index, applying the localized
+one-to-two map on the first interval and the localized two-to-one map on the
+second gives exactly the normalized state with one site transferred across the
+cut.  Applying the reverse pair recovers the original split state.  Data
+processing in the two directions therefore proves equality of the two
+bipartite mutual informations, conditional only on positivity and the
+nonzero trace needed for normalization.\footnote{Formal declarations:
+\leanid{MPOTensor.tensorMapBoth_splitNormalizedMPO},
+\leanid{MPOTensor.tensorMapBoth_splitNormalizedMPO_reverse}, and
+\leanid{MPOTensor.mutualInformation_split_eq_of_isRFPViaTS} in
+\doclink{TNLean/MPS/MPDO/RFPViaTSSAL}.}
 
-Two source-faithful steps remain before the implication to saturation of the
+\section{Exact remaining step}
+
+One source-faithful step remains before the implication to saturation of the
 area law is established.
 
 \begin{enumerate}
-  \item \textbf{The source standing nonvanishing condition.}
-  The present formal condition for a matrix product density operator asserts
-  positivity at every length but permits the zero operator.\footnote{Formal
-  declaration: \leanid{MPOTensor.IsMPDO}.}
-  The available per-copy horizontal canonical form is stronger than the
-  source's grouped biCF and still admits degenerate empty data.  It therefore
-  does not yet imply, from the source condition ``simple in biCF generating
-  density operators'', that
-  $\tr(\operatorname{mpo}(\mathcal K,N))\ne0$ for every relevant
-  $N$.  This must be repaired by formalizing the source simple-biCF standing
-  data, including generation of normalized density operators, and deriving the
-  nonvanishing used by the normalization in Definition~4.6.
-
-  \item \textbf{Application to the source bipartition.}
-  The global closure identities and the abstract data-processing inequality
-  have not yet been assembled into the inequality $I_{L+1}\leq I_L$ used in
-  Appendix~C. One must reindex the periodic operator according to the
-  consecutive intervals $A$ and $B$, localize $\mathcal T$ on the first spin
-  of $A$ and $\mathcal S$ on the first two spins of $B$, and identify the two
-  channel outputs with the normalized states defining $I_{L+1}$ and $I_L$.
-  This is the formal counterpart of lines 1333--1341; it is not supplied by
-  the channel theorem alone.
+  \item \textbf{Identification with the area-law interface.}
+  The channel calculation is stated for the bipartite mutual information of
+  the normalized operator after the two consecutive intervals have been
+  flattened to finite indices.  The present area-law interface instead
+  defines $I_L$ as $S_L+S_{N-L}-S_N$ using prefix reduced states.  A final
+  correspondence lemma must identify these two expressions, using translation
+  invariance for the complementary interval.  This lemma will turn the
+  established bipartite equality into the declaration
+  $\operatorname{mutualInfoChain}(L)=
+    \operatorname{mutualInfoChain}(L+1)$ required by SAL.
 \end{enumerate}
 
-The first point is not resolved by adding
-$\forall N,\tr(\operatorname{mpo}(\mathcal K,N))\ne0$ as a new
-hypothesis to the source-labelled theorem, since that condition is absent from
-the printed statement. Once both remaining steps are established, the source
-proof applies the two localized channels, invokes data processing to obtain
+Nonvanishing is not an additional source assumption in this implication.
+Horizontal canonical form, the MPDO condition, and the renormalization maps
+give positive trace at every positive chain length under consideration;
+simplicity is not used.  Once the remaining correspondence is established,
+the source proof applies the two localized channels, invokes data processing to obtain
 $I_{L+1}\leq I_L$, and combines this with the already formalized inequality
 $I_L\leq I_{L+1}$.
 
 \paragraph{Classification.}
-This is an open gap.  The global tensor-ring identities and the required
-mutual-information data-processing theorem are proved. The derivation of
-nonzero normalization from the source's simple-biCF convention and the
-application to the source bipartition remain necessary for a faithful proof
-of saturation of the area law.
+This is an open gap.  The global tensor-ring identities, the required
+mutual-information data-processing theorem, and their application to the
+source bipartition are proved.  Positive trace for the relevant nonempty chains
+follows without simplicity.  The correspondence with the existing
+prefix-entropy definition of $I_L$ and the positive-length correction to the
+formal SAL predicate remain necessary for a faithful proof of saturation of
+the area law.
 
 \end{document}


### PR DESCRIPTION
## Motivation

Appendix C of arXiv:1606.00608 proves that the local renormalization fixed-point equations imply saturation of the area law. The repository had the mutual-information data-processing theorem and the global transfer identities, but not their source-faithful assembly into the stated implication.

This pull request is stacked on #4017, which restricts the SAL normalization condition to positive-length physical chains.

## Description

- identify the chain mutual information I_L with bipartite mutual information across a consecutive periodic cut;
- prove nonvanishing of every positive-length RFP ring from horizontal canonical form, positivity, and the local fixed-point equations;
- assemble the two local transfer channels and apply data processing in both directions;
- prove MPOTensor.isSAL_of_isRFPViaTS with exactly horizontal canonical form, IsMPDO, and IsRFPViaTS;
- update the blueprint and mark the corresponding paper-gap note resolved.

The proof does not use simplicity, does not impose an empty-chain condition, and introduces no axiom or additional source hypothesis.

Source: arXiv:1606.00608, Proposition propsimple, Appendix C, lines 1333–1341, under the standing assumptions at lines 623–628 and 849–850.

## Testing

- lake env lean TNLean/MPS/MPDO/RFPViaTSSAL.lean
- lake build TNLean
- leanblueprint checkdecls
- full blueprint PDF build: 573 pages
- blueprint-to-Lean synchronization and reverse declaration coverage
- strict tensor-network diagram audit: 114 diagrams rendered
- prose and TeX checks
- proof-integrity scan for sorry, axiom, admit, native_decide, and unsafeCast

Closes #4006

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new formal proof chain in MPDO entropy/RFP theory with many dependencies on existing channel and entropy infrastructure; incorrect reindexing or hypotheses could invalidate the capstone theorem without affecting runtime systems.
> 
> **Overview**
> Completes the **forward implication** of Appendix C Proposition `propsimple`: horizontally canonical MPDOs satisfying the local renormalization fixed-point maps (`IsRFPViaTS`) **saturate the area law** (`isSAL_of_isRFPViaTS`), using horizontal CF, `IsMPDO`, and the RFP maps only—**no simplicity** and no extra trace hypothesis on the source statement.
> 
> Adds **`MutualInfoBridge`**, which reindexes the normalized periodic MPO across a consecutive `L | (N−L)` cut and proves **`mutualInfoChain_eq_mutualInformation`** (chain `I_L` equals ordinary bipartite mutual information). **`RFPViaTSSAL`** flattens the global refine/coarsen channels on bipartite blocks, proves exact forward/reverse **site-transfer** identities on the normalized state, combines **mutual-information data processing** in both directions, and assembles `I_L = I_{L+1}`.
> 
> **`RFPViaTSGlobal`** now derives **nonzero trace at every positive length** from horizontal CF, positivity, and idempotent physical-trace transfer. A small **`firstSiteMatrix_one`** lemma supports the blueprint trace argument. Root imports, **blueprint ch.21**, and the **paper-gap note** are updated to document and link the finished proof.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d17000d23c521fb25bf5ba322ebb6d26c3d4c55a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->