### PR TITLE
doc(MPS/MPDO): correct finite-interval domain

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
@@ -44,7 +44,7 @@
     \label{lem:finite_interval_constancy}
     \lean{eq_of_forall_succ_eq_of_mem_Icc}
     \leanok
-    Let $f$ be defined on the integer interval $[a,n]$. If
+    Let $f$ be defined on the integer interval $[0,n]$. If
     $f(m)=f(m+1)$ for every $a\le m<n$, then $f(i)=f(j)$ for all
     $i,j\in[a,n]$.
 \end{lemma}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
@@ -44,7 +44,8 @@
     \label{lem:finite_interval_constancy}
     \lean{eq_of_forall_succ_eq_of_mem_Icc}
     \leanok
-    Let $f$ be defined on the integer interval $[0,n]$. If
+    Let $a,n\in\mathbb N$, and let $f$ be defined on the integer interval
+    $[0,n]$. If
     $f(m)=f(m+1)$ for every $a\le m<n$, then $f(i)=f(j)$ for all
     $i,j\in[a,n]$.
 \end{lemma}


### PR DESCRIPTION
Closes #4007.

### Motivation

The blueprint says that the auxiliary function is defined only on [a,n], while the Lean theorem gives it values at every natural number m ≤ n. The lower endpoint a restricts only the successive-equality hypothesis and the two indices compared.

### Description

- State the domain as the integer interval [0,n].
- Keep the constancy hypothesis on a ≤ m < n and the conclusion for i,j in [a,n].
- Make no change to the Lean theorem or its hypotheses.

### Testing

- git diff --check
- leanblueprint checkdecls

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change in a blueprint `.tex` file; no runtime or proof code touched.
> 
> **Overview**
> Aligns **Lemma “Constancy on a finite interval”** (`lem:finite_interval_constancy`) with the linked Lean statement `eq_of_forall_succ_eq_of_mem_Icc`: the auxiliary function is now said to live on **`[0,n]`** (with **`a,n ∈ ℕ`** stated explicitly), not only on **`[a,n]`**.
> 
> The successive-equality hypothesis **`f(m)=f(m+1)` for `a ≤ m < n`** and the conclusion **`f(i)=f(j)` for `i,j ∈ [a,n]`** are unchanged. No Lean code or theorem hypotheses were modified—documentation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9b543de4d0367a7d6d3ae47237b3c14587dadc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->