### PR TITLE
doc(MPS/MPDO): separate final-block selector identity

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -1623,13 +1623,25 @@ separate step.
 
 \begin{definition}[One-letter final-block selector]
     \label{def:mpdo_complete_zipper_final_block_selector}
-    \lean{MPOTensor.CompleteZipperFusionFamily.finalBlockSelector,
-        MPOTensor.CompleteZipperFusionFamily.finalBlockSelector_apply,
-        MPOTensor.CompleteZipperFusionFamily.finalBlockSelector_sum}
+    \lean{MPOTensor.CompleteZipperFusionFamily.finalBlockSelector}
     \leanok
     \uses{def:mpdo_complete_zipper_fusion_family}
     Fix a final label $d$. Summing the diagonal matrix-unit coefficients of
-    the simultaneous block inverse defines scalars $s_d(i,j)$ satisfying
+    the simultaneous block inverse defines
+    \[
+        s_d(i,j)=\sum_{x=1}^{D_d}C_{(d,x,x),(i,j)}.
+    \]
+    Here $C_{(d,x,y),(i,j)}$ denotes the coefficient of the simultaneous
+    block inverse corresponding to the matrix unit $E_{xy}$ in block $d$.
+\end{definition}
+
+\begin{lemma}[Final-block selection identity]
+    \label{lem:mpdo_complete_zipper_final_block_selector}
+    \lean{MPOTensor.CompleteZipperFusionFamily.finalBlockSelector_apply,
+        MPOTensor.CompleteZipperFusionFamily.finalBlockSelector_sum}
+    \leanok
+    \uses{def:mpdo_complete_zipper_final_block_selector}
+    The one-letter selector satisfies
     \[
         \sum_{i,j}s_d(i,j)B_e^{ij}
         =\begin{cases}
@@ -1639,7 +1651,12 @@ separate step.
     \]
     Thus one physical letter selects the identity on the chosen final block
     and annihilates every other final block.
-\end{definition}
+\end{lemma}
+\begin{proof}\leanok
+    Apply the simultaneous block inverse entrywise and sum over the diagonal
+    matrix units of block $d$. If $e=d$, their sum is $I_{D_d}$; if
+    $e\ne d$, every term vanishes.
+\end{proof}
 
 \begin{theorem}[Printed F-move and inverse]%
     \label{thm:mpdo_complete_zipper_printed_fmove}
@@ -1651,7 +1668,7 @@ separate step.
         inversePrintedFMatrix_mul_printedFMatrix}
     \leanok
     \uses{def:mpdo_complete_zipper_fusion_family,
-        def:mpdo_complete_zipper_final_block_selector,
+        lem:mpdo_complete_zipper_final_block_selector,
         lem:matrix_kronecker_identity_cancellation}
     Fix $a,b,c,d\in\Lambda$.  There is an invertible matrix
     \[

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -1629,7 +1629,7 @@ separate step.
     Fix a final label $d$. Summing the diagonal matrix-unit coefficients of
     the simultaneous block inverse defines
     \[
-        s_d(i,j)=\sum_{x=1}^{D_d}C_{(d,x,x),(i,j)}.
+        s_d(i,j)=\sum_{x=0}^{D_d-1}C_{(d,x,x),(i,j)}.
     \]
     Here $C_{(d,x,y),(i,j)}$ denotes the coefficient of the simultaneous
     block inverse corresponding to the matrix unit $E_{xy}$ in block $d$.


### PR DESCRIPTION
Closes #4008.

### Motivation

The blueprint currently places the proved block-selection identity inside the definition of the one-letter selector. The object and its characterizing theorem should be stated separately.

### Description

- Define the coefficients s_d(i,j) explicitly from the diagonal entries of the simultaneous block inverse.
- State the identity selecting I on block d and zero on every other block as a separate lemma.
- Add its short proof and make the printed F-move depend on that lemma.
- Make no Lean change.

### Testing

- git diff --check
- leanblueprint checkdecls

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and blueprint structure only; no executable Lean or runtime behavior changes.
> 
> **Overview**
> Blueprint-only refactor in `ch21_mpdo_rfp_fusion_isometries.tex`: the **one-letter final-block selector** is now defined only as the coefficients \(s_d(i,j)\) built from diagonal entries of the simultaneous block inverse, with explicit notation for \(C_{(d,x,y),(i,j)}\).
> 
> The identity that \(\sum_{i,j} s_d(i,j) B_e^{ij}\) picks \(I_{D_d}\) on block \(d\) and zero elsewhere is stated as a separate **lemma** with a short proof. Lean blueprint links move accordingly (`finalBlockSelector` on the definition; `finalBlockSelector_apply` / `finalBlockSelector_sum` on the lemma). The **printed F-move** theorem now cites that lemma instead of folding the identity into the definition. **No Lean code changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34c2f4e1b9edaaec8a26639e234731906139bbb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->