### PR TITLE
refactor(Algebra): move finite-interval constancy

### DIFF
--- a/TNLean/Algebra/NatInterval.lean
+++ b/TNLean/Algebra/NatInterval.lean
@@ -1,0 +1,41 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Data.Nat.Order.Lemmas
+
+/-!
+# Constancy on finite natural-number intervals
+
+This file proves that a function is constant on a finite interval when its
+values agree at every pair of successive indices.
+
+## Main results
+
+* `eq_of_forall_succ_eq_of_mem_Icc`: equality of any two values in the interval.
+-/
+
+/-- A function on a finite interval is constant when it agrees at each pair of
+successive indices. -/
+theorem eq_of_forall_succ_eq_of_mem_Icc {α : Sort*} {a n i j : ℕ}
+    (f : (m : ℕ) → m ≤ n → α)
+    (hstep : ∀ m, a ≤ m → (hm : m < n) → f m hm.le = f (m + 1) hm)
+    (hai : a ≤ i) (hin : i ≤ n) (haj : a ≤ j) (hjn : j ≤ n) :
+    f i hin = f j hjn := by
+  have climb : ∀ k m, a ≤ m → ∀ h : m + k ≤ n,
+      f m (Nat.le_add_right m k |>.trans h) = f (m + k) h := by
+    intro k
+    induction k with
+    | zero => intro m _ _; rfl
+    | succ k ih =>
+        intro m ham h
+        have hmk : m + k < n := by
+          apply Nat.lt_of_succ_le
+          simpa [Nat.add_assoc] using h
+        exact (ih m ham hmk.le).trans
+          (hstep (m + k) (ham.trans (Nat.le_add_right m k)) hmk)
+  rcases le_total i j with hij | hji
+  · obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_le hij
+    exact climb k i hai hjn
+  · obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_le hji
+    exact (climb k j haj hin).symm

--- a/TNLean/MPS/MPDO/AreaLaw.lean
+++ b/TNLean/MPS/MPDO/AreaLaw.lean
@@ -3,8 +3,9 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.MPDO.Defs
+import TNLean.Algebra.NatInterval
 import TNLean.Analysis.Entropy
+import TNLean.MPS.MPDO.Defs
 import Mathlib.Data.List.Rotate
 import Mathlib.Logic.Equiv.Fin.Rotate
 
@@ -49,28 +50,6 @@ SAL** when `I_1 = I_2 = ⋯` (Definition 4.6, line 811). Equivalently
 
 open scoped Matrix ComplexOrder BigOperators
 open Matrix Finset
-
-/-- A function on a finite interval is constant when it agrees at each pair of
-successive indices. -/
-theorem eq_of_forall_succ_eq_of_mem_Icc {α : Sort*} {a n i j : ℕ}
-    (f : (m : ℕ) → m ≤ n → α)
-    (hstep : ∀ m, a ≤ m → (hm : m < n) → f m hm.le = f (m + 1) hm)
-    (hai : a ≤ i) (hin : i ≤ n) (haj : a ≤ j) (hjn : j ≤ n) :
-    f i hin = f j hjn := by
-  have climb : ∀ k m, a ≤ m → ∀ h : m + k ≤ n,
-      f m (Nat.le_add_right m k |>.trans h) = f (m + k) h := by
-    intro k
-    induction k with
-    | zero => intro m _ _; rfl
-    | succ k ih =>
-        intro m ham h
-        have hmk : m + k < n := by omega
-        exact (ih m ham hmk.le).trans (hstep (m + k) (by omega) hmk)
-  rcases le_total i j with hij | hji
-  · obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_le hij
-    exact climb k i hai hjn
-  · obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_le hji
-    exact (climb k j haj hin).symm
 
 /-! ## Translation invariance of the periodic MPDO
 


### PR DESCRIPTION
Closes #4009.

### Motivation

The finite-interval constancy theorem is a general fact about natural numbers. It does not depend on matrix product operators, entropy, or saturation of the area law.

### Description

- Move eq_of_forall_succ_eq_of_mem_Icc to a new shared module, TNLean/Algebra/NatInterval.lean.
- Import that module from AreaLaw.lean without changing the theorem name or signature.
- Replace the two small arithmetic uses of omega by explicit natural-number order lemmas.
- Keep the existing blueprint declaration unchanged.
- Introduce no axiom, sorry, or additional hypothesis.

### Testing

- lake env lean TNLean/Algebra/NatInterval.lean
- lake build TNLean.Algebra.NatInterval
- lake env lean TNLean/MPS/MPDO/AreaLaw.lean
- lake build TNLean.MPS.MPDO.AreaLaw
- proof-integrity scan and git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of a general Nat lemma into Algebra with no API or hypothesis changes; only proof-style tweaks in the moved theorem.
> 
> **Overview**
> **`eq_of_forall_succ_eq_of_mem_Icc`** is moved out of `AreaLaw.lean` into a new shared module **`TNLean/Algebra/NatInterval.lean`**, with a short module doc and `Mathlib.Data.Nat.Order.Lemmas` as the only import.
> 
> **`AreaLaw.lean`** drops the local theorem, adds `import TNLean.Algebra.NatInterval`, and keeps call sites (e.g. `mutualInfoChain_eq_of_isSAL`) unchanged by name and signature. Downstream files that import `AreaLaw` still get the theorem transitively.
> 
> In the relocated proof, the two **`omega`** steps are replaced by **`Nat.lt_of_succ_le`** / **`Nat.add_assoc`** and an explicit **`ham.trans (Nat.le_add_right m k)`** bound for the successor case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c429907332a6cce6947468005ff2c23a7ad1c0c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->