### PR TITLE
feat(MPS/MPDO): attach BNT algebra clause to vertical form

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -479,6 +479,7 @@ import TNLean.MPS.MPDO.AlgebraFusionCounterexample
 import TNLean.MPS.MPDO.BNTCoefficients
 import TNLean.MPS.MPDO.LengthIndependentCoefficients
 import TNLean.MPS.MPDO.BNTTheoremData
+import TNLean.MPS.MPDO.BNTAlgebraTensorClause
 import TNLean.MPS.MPDO.BNTMultiplicityNormalization
 import TNLean.MPS.MPDO.BNTTheoremWitness
 import TNLean.MPS.MPDO.BNTTheoremWitnessConsequences

--- a/TNLean/MPS/MPDO/BNTAlgebraTensorClause.lean
+++ b/TNLean/MPS/MPDO/BNTAlgebraTensorClause.lean
@@ -1,0 +1,229 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.BNTTheoremData
+import TNLean.MPS.MPDO.VerticalCF
+
+/-!
+# The BNT algebra clause attached to an MPO tensor
+
+This file ties the algebra clause of arXiv:1606.00608, Theorem 4.14(ii), to a
+chosen vertical canonical decomposition of an MPO tensor.  The length-
+\(L\) operators are the closed MPOs of the chosen BNT tensors, and the scalar
+\(m_\alpha\) is the sum of the diagonal entries of the corresponding positive
+multiplicity matrix.
+
+No comparison with the two-site vertical canonical form is included here.  In
+particular, the definitions do not assume the eventual power-sum equality, a
+multiplicity-spectrum comparison, fusion isometries, or renormalization maps.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Theorem 4.14(ii), lines 972--993, and Appendix C.4, lines 2046--2064
+-/
+
+open scoped BigOperators ComplexOrder Matrix
+
+noncomputable section
+
+namespace MPOTensor
+
+/-- Regard a tensor with doubled physical index as an MPO tensor by separating
+the two factors of that index.
+
+For a vertical BNT tensor \(M_\alpha\), this is the MPO whose closed length-
+\(L\) operator is \(O_L(M_\alpha)\).
+
+Source: arXiv:1606.00608, lines 962--967 and Theorem 4.14(ii), lines 972--985. -/
+def verticalBNTMPO {D n : ℕ} (A : MPSTensor (D * D) n) : MPOTensor D n :=
+  fun a b => A (finProdFinEquiv (a, b))
+
+@[simp]
+theorem verticalBNTMPO_apply {D n : ℕ} (A : MPSTensor (D * D) n)
+    (a b : Fin D) :
+    verticalBNTMPO A a b = A (finProdFinEquiv (a, b)) :=
+  rfl
+
+/-- Separating and then recombining the doubled physical index recovers the
+original tensor. -/
+@[simp]
+theorem verticalBNTMPO_toMPSTensor {D n : ℕ} (A : MPSTensor (D * D) n) :
+    (verticalBNTMPO A).toMPSTensor = A := by
+  funext ab
+  change A (finProdFinEquiv (ab.divNat, ab.modNat)) = A ab
+  exact congrArg A (finProdFinEquiv.apply_symm_apply ab)
+
+/-- The concrete operator family \(O_L(M_\alpha)\) of a chosen vertical BNT
+family.
+
+Source: arXiv:1606.00608, lines 962--978 and Appendix C.4, lines 2048--2058. -/
+def verticalBNTOperatorFamily {g D : ℕ} {dim : Fin g → ℕ}
+    (A : (α : Fin g) → MPSTensor (D * D) (dim α)) :
+    BNTLabelOperatorFamily (Fin g)
+      (fun L => Matrix (Fin L → Fin D) (Fin L → Fin D) ℂ) :=
+  ⟨fun L α => mpo (verticalBNTMPO (A α)) L⟩
+
+@[simp]
+theorem verticalBNTOperatorFamily_operator {g D : ℕ} {dim : Fin g → ℕ}
+    (A : (α : Fin g) → MPSTensor (D * D) (dim α)) (L : ℕ) (α : Fin g) :
+    (verticalBNTOperatorFamily A).operator L α = mpo (verticalBNTMPO (A α)) L :=
+  rfl
+
+/-- The scalars \(m_\alpha=\operatorname{tr}(\mu_\alpha)\) of a chosen
+vertical canonical decomposition.  Since \(\mu_\alpha\) is diagonal with
+entries \(\omega_{\alpha,q}\), its trace is their sum.
+
+Source: arXiv:1606.00608, Theorem 4.14(ii), lines 981--985, and Appendix C.4,
+lines 2058--2064. -/
+def verticalBNTTraceScalarFamily {g : ℕ} {mult : Fin g → ℕ}
+    (ω : (α : Fin g) → Fin (mult α) → ℂ) :
+    BNTLabelTraceScalarFamily (Fin g) :=
+  ⟨fun α => ∑ q, ω α q⟩
+
+@[simp]
+theorem verticalBNTTraceScalarFamily_traceScalar {g : ℕ} {mult : Fin g → ℕ}
+    (ω : (α : Fin g) → Fin (mult α) → ℂ) (α : Fin g) :
+    (verticalBNTTraceScalarFamily ω).traceScalar α = ∑ q, ω α q :=
+  rfl
+
+/-- The algebra clause of Theorem 4.14(ii), attached to a chosen vertical
+canonical decomposition of the MPO tensor \(M\).
+
+The fields through `reconstruction` are precisely a witness of the vertical
+canonical form
+\[
+  U\widetilde M U^\dagger
+    = \bigoplus_\alpha \mu_\alpha\otimes M_\alpha,
+  \qquad
+  \widetilde M
+    = U^\dagger\left(\bigoplus_\alpha
+        \mu_\alpha\otimes M_\alpha\right)U.
+\]
+The final field requires the BNT algebra clause for the concrete operators
+\(O_L(M_\alpha)\) and the concrete scalars
+\(m_\alpha=\sum_q\omega_{\alpha,q}=\operatorname{tr}(\mu_\alpha)\).
+
+This structure contains no one-site/two-site BNT comparison and no channel or
+fusion hypothesis.  Those are conclusions of the remaining proof of the
+implication (ii) to (i), not part of statement (ii).
+
+Source: arXiv:1606.00608, Proposition 4.13, lines 943--951; Theorem 4.14(ii),
+lines 972--993; and Appendix C.4, lines 2046--2064 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+structure BNTAlgebraTensorClause (M : MPOTensor d D) where
+  /-- Number of BNT labels in the chosen vertical decomposition. -/
+  labelCount : ℕ
+  /-- Bond dimension of each vertical BNT tensor. -/
+  bondDim : Fin labelCount → ℕ
+  /-- Dimension of the positive diagonal matrix \(\mu_\alpha\). -/
+  multiplicity : Fin labelCount → ℕ
+  /-- Positive diagonal entries of \(\mu_\alpha\). -/
+  weight : (α : Fin labelCount) → Fin (multiplicity α) → ℂ
+  /-- The chosen vertical basis of normal tensors \(M_\alpha\). -/
+  tensor : (α : Fin labelCount) → MPSTensor (D * D) (bondDim α)
+  /-- The coisometry from the original physical space onto the retained
+  vertical sectors. -/
+  verticalCoisometry :
+    Matrix
+      (Fin (∑ q : Fin (∑ α : Fin labelCount, multiplicity α),
+        verticalCopyDim bondDim multiplicity q)) (Fin d) ℂ
+  /-- Every BNT label occurs with a nonempty multiplicity space.
+
+  Source: arXiv:1606.00608, Proposition 4.13, lines 948--951. -/
+  multiplicity_pos : ∀ α, 0 < multiplicity α
+  /-- Every diagonal entry of \(\mu_\alpha\) is positive.
+
+  Source: arXiv:1606.00608, Proposition 4.13, lines 948--951. -/
+  weight_pos : ∀ α q, (0 : ℂ) < weight α q
+  /-- The vertical change of basis is a coisometry onto the retained sectors.
+
+  Source: arXiv:1606.00608, Proposition 4.13, lines 948--951. -/
+  coisometry : verticalCoisometry * (verticalCoisometry)ᴴ = 1
+  /-- The chosen tensors form a basis of normal tensors of the vertical tensor.
+
+  Source: arXiv:1606.00608, Proposition 4.13, lines 948--951. -/
+  isBNT : MPSTensor.IsBNT (verticalTensor M) labelCount bondDim tensor
+  /-- Conjugating the vertical tensor gives the weighted BNT direct sum.
+
+  Source: arXiv:1606.00608, Proposition 4.13, lines 948--951. -/
+  forward : ∀ v : Fin (D * D),
+    verticalCoisometry * verticalTensor M v * (verticalCoisometry)ᴴ =
+      verticalAssembledTensor bondDim multiplicity weight tensor v
+  /-- The weighted BNT direct sum reconstructs the vertical tensor, including
+  the possible zero-sector complement.
+
+  Source: arXiv:1606.00608, Proposition 4.13, lines 948--951. -/
+  reconstruction : ∀ v : Fin (D * D),
+    verticalTensor M v = (verticalCoisometry)ᴴ *
+      verticalAssembledTensor bondDim multiplicity weight tensor v *
+        verticalCoisometry
+  /-- The coefficient family \(c^{(L)}_{\alpha,\beta,\gamma}\). -/
+  coeffs : BNTLabelCoefficientFamily (Fin labelCount)
+  /-- The positive chi trace-power law, the concrete same-length product law,
+  and the length-one idempotent law.
+
+  Source: arXiv:1606.00608, Theorem 4.14(ii), lines 972--985, and Appendix C.4,
+  lines 2046--2064. -/
+  algebraClause : BNTAlgebraClause coeffs
+    (verticalBNTOperatorFamily tensor) (verticalBNTTraceScalarFamily weight)
+
+namespace BNTAlgebraTensorClause
+
+/-- The chosen decomposition in a tensor-attached BNT algebra clause is a
+vertical canonical form of the underlying MPO tensor. -/
+theorem isVerticalCF {M : MPOTensor d D} (H : BNTAlgebraTensorClause M) :
+    IsVerticalCF M :=
+  ⟨H.labelCount, H.bondDim, H.multiplicity, H.weight, H.tensor,
+    H.verticalCoisometry, H.multiplicity_pos, H.weight_pos, H.coisometry,
+    H.isBNT, H.forward, H.reconstruction⟩
+
+variable {M : MPOTensor d D} (H : BNTAlgebraTensorClause M)
+
+/-- The concrete BNT-label operator family carried by the tensor-attached
+clause. -/
+def operators : BNTLabelOperatorFamily (Fin H.labelCount)
+    (fun L => Matrix (Fin L → Fin D) (Fin L → Fin D) ℂ) :=
+  verticalBNTOperatorFamily H.tensor
+
+/-- The concrete trace scalars carried by the tensor-attached clause. -/
+def traceScalars : BNTLabelTraceScalarFamily (Fin H.labelCount) :=
+  verticalBNTTraceScalarFamily H.weight
+
+@[simp]
+theorem operators_operator (L : ℕ) (α : Fin H.labelCount) :
+    H.operators.operator L α = mpo (verticalBNTMPO (H.tensor α)) L :=
+  rfl
+
+@[simp]
+theorem traceScalars_traceScalar (α : Fin H.labelCount) :
+    H.traceScalars.traceScalar α = ∑ q, H.weight α q :=
+  rfl
+
+end BNTAlgebraTensorClause
+
+/-- Existence of the BNT algebra clause for a chosen vertical canonical
+decomposition of \(M\).
+
+The standing hypotheses that \(M\) is in horizontal canonical form and
+generates MPDOs belong to the eventual equivalence theorem; they are not
+duplicated in this predicate.
+
+Source: arXiv:1606.00608, Theorem 4.14(ii), lines 972--993, and Appendix C.4,
+lines 2046--2064. -/
+def HasBNTAlgebraTensorClause (M : MPOTensor d D) : Prop :=
+  Nonempty (BNTAlgebraTensorClause M)
+
+namespace HasBNTAlgebraTensorClause
+
+/-- A tensor-attached BNT algebra clause supplies a vertical canonical form. -/
+theorem isVerticalCF {M : MPOTensor d D} (h : HasBNTAlgebraTensorClause M) :
+    IsVerticalCF M := by
+  obtain ⟨H⟩ := h
+  exact H.isVerticalCF
+
+end HasBNTAlgebraTensorClause
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
@@ -35,6 +35,39 @@
     blocked basis.
 \end{definition}
 
+\begin{definition}[BNT algebra clause of a vertical canonical decomposition]%
+    \label{def:mpdo_bnt_algebra_tensor_clause}
+    \lean{MPOTensor.verticalBNTMPO}
+    \lean{MPOTensor.verticalBNTOperatorFamily}
+    \lean{MPOTensor.verticalBNTTraceScalarFamily}
+    \lean{MPOTensor.BNTAlgebraTensorClause}
+    \lean{MPOTensor.HasBNTAlgebraTensorClause}
+    \leanok
+    \uses{def:vertical_cf_mpdo, def:mpdo_bnt_algebra_clause}
+    Choose a vertical canonical decomposition
+    \[
+        U\widetilde M U^\dagger
+        =\bigoplus_\alpha \mu_\alpha\otimes M_\alpha,
+        \qquad
+        \mu_\alpha=\operatorname{diag}
+        (\omega_{\alpha,0},\ldots,\omega_{\alpha,r_\alpha-1}).
+    \]
+    Separating the two factors of the doubled physical index of
+    $M_\alpha$ gives an MPO tensor $\widehat M_\alpha$.  Define
+    \[
+        O_L(M_\alpha)=\operatorname{mpo}(\widehat M_\alpha,L),
+        \qquad
+        m_\alpha=\sum_q\omega_{\alpha,q}
+        =\operatorname{tr}(\mu_\alpha).
+    \]
+    The chosen decomposition satisfies the tensor-attached BNT algebra clause
+    when the BNT algebra clause holds for precisely these operators and these
+    trace scalars.  This is the data in
+    \cite[Theorem~4.14(ii), lines~972--993, and Appendix~C.4,
+        lines~2046--2064]{Cirac2016MPDO_arXiv}; it does not include a comparison
+    with a two-site vertical canonical decomposition.
+\end{definition}
+
 \begin{definition}[BNT multiplicity-spectrum comparison]%
     \label{def:mpdo_bnt_multiplicity_spectrum_comparison}
     \lean{MPOTensor.BNTMultiplicitySpectrumComparison}

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -236,18 +236,17 @@ Theorem with the unequal-cardinality power-sum identity, and therefore proves
 the power-sum step used at lines~2053--2058.
 
 What remains before this constructor can be applied is the tensor-level BNT
-comparison at lines~2048--2058.  The current
-\leanid{MPOTensor.BNTAlgebraClause} does not identify its abstract operator
-family with the concrete operators $O_L(M_\alpha)$ of a chosen one-site
-vertical canonical form, and it does not identify its trace scalars with the
-entries of the corresponding matrices $\mu_\alpha$.  Moreover, the current
-vertical canonical-form theorem supplies a decomposition of $M$, but no
-single object simultaneously records that decomposition, a vertical
-canonical decomposition of the two-site blocked tensor, and the relabelling
-and unitary identifications of their BNT sectors.  Such an object must yield
-the displayed eventual power-sum equality from the same-length algebra law;
-the constructor above then supplies the spectrum comparison without any
-further mathematical hypothesis.
+comparison at lines~2048--2058.  The predicate
+\leanid{MPOTensor.BNTAlgebraTensorClause} now chooses the one-site vertical
+canonical decomposition and identifies the operators and trace scalars in the
+abstract BNT algebra clause with
+$O_L(M_\alpha)$ and $m_\alpha=\sum_q\omega_{\alpha,q}$, respectively.  It does
+not choose a vertical canonical decomposition of the two-site blocked tensor,
+nor does it assert the relabelling and unitary identifications of the one-site
+products with the two-site BNT sectors.  These identifications must yield the
+displayed eventual power-sum equality from the same-length algebra law; the
+constructor above then supplies the spectrum comparison without any further
+mathematical hypothesis.
 
 \section{BNT-label coefficient objects and remaining elimination plan}
 
@@ -810,13 +809,14 @@ two matrix equalities and the entrywise theorem above.
 
 To eliminate the source-theorem gap, the formalization should instead:
 \begin{enumerate}
-    \item define a separate, source-faithful predicate for
-        Theorem~4.14(ii), bundling the vertical canonical-form decomposition
-        from Proposition~4.13, the BNT operators $O_L(M_\alpha)$, the weights
-        $m_\alpha=\tr(\mu_\alpha)$, the positive matrices
-        $\chi_{\alpha,\beta,\gamma}$, the same-length product law, and the
-        length-one idempotent identity;
-    \item relate that predicate to the one-site and two-site vertical
+    \item use the source-faithful predicate
+        \leanid{MPOTensor.BNTAlgebraTensorClause} for Theorem~4.14(ii), which
+        chooses the vertical canonical-form decomposition from
+        Proposition~4.13 and fixes the BNT operators
+        $O_L(M_\alpha)$ and weights $m_\alpha=\tr(\mu_\alpha)$ appearing in the
+        positive chi trace-power law, same-length product law, and length-one
+        idempotent identity;
+    \item relate this predicate to the one-site and two-site vertical
         decompositions used in Appendix~C.4, lines~2048--2058, and prove the
         unitary relabelling and the positive multiset identity for the
         $\nu_{\gamma,k}$;


### PR DESCRIPTION
Advances #3949.

### Motivation

Theorem 4.14(ii) and Appendix C.4 do not use an arbitrary labelled operator family. They use the closed operators O_L(M_alpha) of a chosen vertical BNT decomposition of the tensor and the scalars m_alpha = tr(mu_alpha). The existing abstract BNT algebra clause did not record that attachment, so it could not serve as the source-facing clause of the theorem.

### Description

- Define verticalBNTMPO by separating the doubled physical index of a vertical BNT tensor.
- Define the concrete operator family O_L(M_alpha) as its length-L closed MPO.
- Define the concrete scalar family m_alpha as the sum of the positive diagonal weights of mu_alpha.
- Package a chosen Proposition 4.13 vertical canonical decomposition together with the existing BNT algebra clause specialized to exactly those families.
- Add the corresponding blueprint definition and update the paper-gap boundary.
- Assume no two-site BNT comparison, power-sum equality, multiplicity-spectrum comparison, fusion isometry, or renormalization channel.

### Remaining source step

Appendix C.4, lines 2048–2058, still requires the vertical canonical decomposition of the two-site tensor and the unitary relabelling of its sectors with products of one-site sectors. That comparison must produce the eventual power-sum equality before the existing spectrum machinery can be applied. This pull request does not claim that later step.

### Testing

- lake env lean TNLean/MPS/MPDO/BNTAlgebraTensorClause.lean
- lake build TNLean.MPS.MPDO.BNTAlgebraTensorClause
- lake build TNLean
- blueprint synchronization and leanblueprint checkdecls
- reader-facing prose, proof-integrity, line-length, and git diff checks

No axiom, sorry, kernel bypass, or additional paper hypothesis is introduced.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive definitions and documentation only; no changes to auth, runtime behavior, or existing proof obligations beyond wiring a new public import.
> 
> **Overview**
> Introduces **`MPOTensor.BNTAlgebraTensorClause`**, a source-facing packaging of Theorem 4.14(ii) that ties the abstract **`BNTAlgebraClause`** to a chosen one-site vertical canonical decomposition of an MPO tensor.
> 
> New helpers **`verticalBNTMPO`**, **`verticalBNTOperatorFamily`**, and **`verticalBNTTraceScalarFamily`** fix the operators as closed MPOs \(O_L(M_\alpha)\) and scalars as \(m_\alpha=\sum_q\omega_{\alpha,q}\). The structure bundles Proposition 4.13 vertical-CF data with **`algebraClause`** instantiated on those concrete families; **`HasBNTAlgebraTensorClause`** and **`isVerticalCF`** lemmas connect existence to **`IsVerticalCF`**.
> 
> Blueprint chapter 21 gains a matching definition; the paper-gap note now points at this predicate instead of a planned separate predicate, and states that two-site vertical comparison and sector relabelling remain outside this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a61cea8aa7bccae73f26ab3deea601e97d3c7d10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->