### PR TITLE
fix(MPS/MPDO): expose nilpotent global PRFP obstruction

### DIFF
--- a/TNLean/MPS/MPDO/LocalPurificationRFP.lean
+++ b/TNLean/MPS/MPDO/LocalPurificationRFP.lean
@@ -74,8 +74,11 @@ pure-state RFP.
 * `MPOTensor.isNondegeneratePRFP_iff`: this predicate is equivalent to
   a local purification density operator (`IsLPDO`) together with a nonzero
   idempotent physical-trace transfer.
-* `MPOTensor.exists_isPRFP_not_isSourceZCL`: the zero purifier shows why the
-  bare global predicate needs a nondegeneracy condition.
+* `MPOTensor.exists_isPRFP_not_isSourceZCL`: the zero purifier obstructs the
+  source ZCL conclusion for the bare global predicate.
+* `MPOTensor.exists_isPRFP_isMPDO_physTraceTransfer_ne_zero_not_isSourceZCL`:
+  even MPDO positivity and a nonzero physical-trace transfer do not remove a
+  nilpotent sector invisible to the positive-length global density operators.
 
 ## References
 
@@ -119,12 +122,11 @@ local purification form of arXiv:1606.00608, line 747, whose
 purifying tensor is a pure-state RFP and whose physical-trace transfer is
 nonzero.
 
-The last condition records the nondegeneracy implicit when the source speaks of
-density operators and excludes the zero purifier. Together with the local
-purification identity, it is the normalized convention under which
-the PRFP-to-ZCL implication at lines 775--786 is valid. It is stronger than the
-bare positive-length global predicate `IsPRFP`; no converse from that global
-predicate is asserted. See
+The last condition excludes the zero purifier. Together with the local
+purification identity, it is sufficient for the corresponding ZCL conclusion.
+It is stronger than the bare positive-length global predicate `IsPRFP` and does
+not repair that global predicate: MPDO positivity and nonzero physical-trace
+transfer still leave trace-invisible nilpotent sectors. See
 `docs/paper-gaps/cpsv16_purification_rfp_definition.tex`. -/
 def IsNondegeneratePRFP (M : MPOTensor d D) : Prop :=
   IsLocalPurificationRFP M ∧ physTraceTransfer M ≠ 0
@@ -593,5 +595,152 @@ theorem exists_isPRFP_not_isSourceZCL :
   refine ⟨0, isPRFP_of_isLocalPurificationRFP hLocal, ?_⟩
   intro hZCL
   exact hZCL.1 (by simp [physTraceTransfer])
+
+/-! ## A nonzero global PRFP tensor that is not source ZCL -/
+
+private def nilpotentTransfer : Matrix (Fin 3) (Fin 3) ℂ :=
+  !![(1 : ℂ), 0, 0; 0, 0, 1; 0, 0, 0]
+
+private def supportProjection : Matrix (Fin 3) (Fin 3) ℂ :=
+  !![(1 : ℂ), 0, 0; 0, 0, 0; 0, 0, 0]
+
+private def nilpotentGlobalPRFP : MPOTensor 1 3 :=
+  fun _ _ => nilpotentTransfer
+
+private def scalarPurifier : Fin 1 → Fin 1 → Matrix (Fin 1) (Fin 1) ℂ :=
+  fun _ _ => 1
+
+private lemma nilpotentGlobalPRFP_not_isSourceZCL :
+    ¬ IsSourceZCL nilpotentGlobalPRFP := by
+  intro hZCL
+  obtain ⟨_, lam, hlam, hsq⟩ := hZCL
+  have h12 := congrFun (congrFun hsq (1 : Fin 3)) (2 : Fin 3)
+  norm_num [physTraceTransfer, nilpotentGlobalPRFP, nilpotentTransfer,
+    Matrix.mul_apply, Fin.sum_univ_three] at h12
+  simp at h12
+  exact (Complex.ofReal_ne_zero.mpr (ne_of_gt hlam)) h12.symm
+
+private lemma physTraceTransfer_nilpotentGlobalPRFP_ne_zero :
+    physTraceTransfer nilpotentGlobalPRFP ≠ 0 := by
+  intro h
+  have h00 := congrFun (congrFun h (0 : Fin 3)) (0 : Fin 3)
+  norm_num [physTraceTransfer, nilpotentGlobalPRFP, nilpotentTransfer] at h00
+
+private lemma evalWord_nilpotentGlobalPRFP {N : ℕ} (σ τ : Fin N → Fin 1) :
+    evalWord nilpotentGlobalPRFP (List.ofFn σ) (List.ofFn τ) = nilpotentTransfer ^ N := by
+  rw [evalWord_ofFn]
+  simp [nilpotentGlobalPRFP]
+
+private lemma nilpotentTransfer_sq :
+    nilpotentTransfer * nilpotentTransfer = supportProjection := by
+  ext i j
+  fin_cases i <;> fin_cases j
+  all_goals simp [nilpotentTransfer, supportProjection, Matrix.mul_apply,
+    Fin.sum_univ_three]
+
+private lemma supportProjection_mul_nilpotentTransfer :
+    supportProjection * nilpotentTransfer = supportProjection := by
+  ext i j
+  fin_cases i <;> fin_cases j
+  all_goals simp [nilpotentTransfer, supportProjection, Matrix.mul_apply,
+    Fin.sum_univ_three]
+
+private lemma nilpotentTransfer_pow_add_two (n : ℕ) :
+    nilpotentTransfer ^ (n + 2) = supportProjection := by
+  induction n with
+  | zero =>
+      simpa [pow_two] using nilpotentTransfer_sq
+  | succ n ih =>
+      rw [Nat.succ_add, pow_succ, ih, supportProjection_mul_nilpotentTransfer]
+
+private lemma trace_nilpotentTransfer_pow {N : ℕ} (hN : 0 < N) :
+    Matrix.trace (nilpotentTransfer ^ N) = 1 := by
+  obtain rfl | ⟨n, rfl⟩ : N = 1 ∨ ∃ n, N = n + 2 := by
+    by_cases h : N = 1
+    · exact Or.inl h
+    · right
+      obtain ⟨n, hn⟩ := Nat.exists_eq_add_of_le (show 2 ≤ N by omega)
+      exact ⟨n, by omega⟩
+  · simp [nilpotentTransfer, Matrix.trace, Fin.sum_univ_three]
+  · rw [nilpotentTransfer_pow_add_two]
+    simp [supportProjection, Matrix.trace, Fin.sum_univ_three]
+
+private lemma scalarPurifier_evalWord (w : List (Fin (1 * 1))) :
+    MPSTensor.evalWord (purificationTensor scalarPurifier) w = 1 := by
+  induction w with
+  | nil => rfl
+  | cons i w ih =>
+      rw [MPSTensor.evalWord_cons, ih]
+      simp [purificationTensor, scalarPurifier]
+
+private lemma scalarPurifier_mpv {N : ℕ} (σ : Fin N → Fin (1 * 1)) :
+    MPSTensor.mpv (purificationTensor scalarPurifier) σ = 1 := by
+  simp [MPSTensor.mpv, MPSTensor.coeff, scalarPurifier_evalWord, Matrix.trace]
+
+private lemma purificationDensity_scalarPurifier (N : ℕ) :
+    purificationDensity scalarPurifier N = 1 := by
+  ext σ τ
+  simp only [purificationDensity, Matrix.of_apply]
+  rw [Fintype.sum_unique]
+  rw [scalarPurifier_mpv, scalarPurifier_mpv]
+  have hστ : σ = τ := Subsingleton.elim _ _
+  subst τ
+  rw [Matrix.one_apply_eq]
+  simp
+
+private lemma mpo_nilpotentGlobalPRFP (N : ℕ) (hN : 0 < N) :
+    mpo nilpotentGlobalPRFP N = 1 := by
+  ext σ τ
+  rw [mpo_apply]
+  rw [mpoMatrixEntry, evalWord_nilpotentGlobalPRFP,
+    trace_nilpotentTransfer_pow hN]
+  have hστ : σ = τ := Subsingleton.elim _ _
+  subst τ
+  rw [Matrix.one_apply_eq]
+
+private lemma scalarPurifier_isTransferIdempotent :
+    MPSTensor.IsTransferIdempotent (purificationTensor scalarPurifier) := by
+  rw [MPSTensor.IsTransferIdempotent]
+  apply LinearMap.ext
+  intro X
+  ext a b
+  fin_cases a
+  fin_cases b
+  simp [LinearMap.comp_apply, MPSTensor.transferMap_apply, purificationTensor,
+    scalarPurifier]
+
+private lemma nilpotentGlobalPRFP_isPRFP : IsPRFP nilpotentGlobalPRFP := by
+  refine ⟨1, 1, scalarPurifier, ?_, scalarPurifier_isTransferIdempotent⟩
+  intro N hN
+  rw [mpo_nilpotentGlobalPRFP N hN, purificationDensity_scalarPurifier]
+
+private lemma mpo_nilpotentGlobalPRFP_zero :
+    mpo nilpotentGlobalPRFP 0 = (3 : ℂ) • 1 := by
+  ext σ τ
+  have hστ : σ = τ := Subsingleton.elim _ _
+  subst τ
+  simp [mpo_apply, mpoMatrixEntry, Matrix.trace, Matrix.smul_apply]
+
+open scoped ComplexOrder in
+private lemma nilpotentGlobalPRFP_isMPDO : IsMPDO nilpotentGlobalPRFP := by
+  intro N
+  by_cases hN : N = 0
+  · subst N
+    rw [mpo_nilpotentGlobalPRFP_zero]
+    exact Matrix.PosSemidef.one.smul (by positivity)
+  · rw [mpo_nilpotentGlobalPRFP N (Nat.pos_of_ne_zero hN)]
+    exact Matrix.PosSemidef.one
+
+/-- The global purification equation, MPDO positivity, and a nonzero physical
+trace transfer do not imply source zero correlation length. This is the
+nilpotent-sector obstruction in arXiv:1606.00608, Definition 4.3 and Theorem
+4.4, lines 744--784; see
+`docs/paper-gaps/cpsv16_purification_rfp_definition.tex`. -/
+theorem exists_isPRFP_isMPDO_physTraceTransfer_ne_zero_not_isSourceZCL :
+    ∃ M : MPOTensor 1 3,
+      IsPRFP M ∧ IsMPDO M ∧ physTraceTransfer M ≠ 0 ∧ ¬ IsSourceZCL M := by
+  exact ⟨nilpotentGlobalPRFP, nilpotentGlobalPRFP_isPRFP,
+    nilpotentGlobalPRFP_isMPDO, physTraceTransfer_nilpotentGlobalPRFP_ne_zero,
+    nilpotentGlobalPRFP_not_isSourceZCL⟩
 
 end MPOTensor

--- a/TNLean/MPS/MPDO/PRFP.lean
+++ b/TNLean/MPS/MPDO/PRFP.lean
@@ -29,12 +29,12 @@ ancilla gives a trace-preserving completely positive map on the spin degrees of
 freedom. This structure is proved separately for the ancillary trace map.
 
 The predicate `IsPRFP` below records the displayed positive-length equation and
-pure-state transfer idempotence literally. It is a bare global predicate: the
-zero purifying tensor satisfies it, although the source theorem at lines
-775--786 concerns nondegenerate density operators. The nondegenerate tensor-level
-predicate `IsNondegeneratePRFP`, its structural characterization, and its
-forward implication to source zero correlation length are in
-`TNLean.MPS.MPDO.LocalPurificationRFP`.
+pure-state transfer idempotence literally. It is a bare global predicate. Even
+MPDO positivity and a nonzero physical-trace transfer do not make its printed
+PRFP-to-ZCL implication valid, because positive-length traces can miss a
+nilpotent bond sector. The counterexample, the stronger local tensor predicate
+`IsNondegeneratePRFP`, and that local predicate's forward implication to source
+zero correlation length are in `TNLean.MPS.MPDO.LocalPurificationRFP`.
 
 ## Main definitions
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_foundations.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_foundations.tex
@@ -775,3 +775,30 @@ Definition~\ref{def:mpo_source_zcl} permits the positive factor $\lambda$.
     equation holds. Its physical-trace transfer is zero, which is excluded by
     source zero correlation length.
 \end{proof}
+
+\begin{theorem}[A nonzero global PRFP need not have source ZCL]
+    \label{thm:nonzero_global_prfp_not_source_zcl}
+    \lean{MPOTensor.exists_isPRFP_isMPDO_physTraceTransfer_ne_zero_not_isSourceZCL}
+    \leanok
+    \uses{def:mpdo, def:mpdo_is_prfp, def:mpo_physical_trace_transfer,
+        def:mpo_source_zcl}
+    There is an MPO tensor which is an MPDO, satisfies the positive-length
+    global purification RFP predicate, and has nonzero physical-trace transfer,
+    but does not have source zero correlation length.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Take one physical state and bond dimension three, with the only tensor entry
+    \[
+        Q=\begin{pmatrix}1&0&0\\0&0&1\\0&0&0\end{pmatrix}.
+    \]
+    Since $\operatorname{tr}(Q^N)=1$ for every $N>0$, all positive-length MPOs
+    equal the scalar density operator $1$ and are purified by the scalar
+    pure-state RFP tensor $A=1$. At length zero the MPO is the positive scalar
+    $3$, so the tensor is an MPDO at every length. Its physical-trace transfer
+    is the nonzero matrix $Q$. However,
+    $Q^2=\operatorname{diag}(1,0,0)$ is not a positive scalar multiple of $Q$,
+    because the $(2,3)$ entry is lost on squaring. Thus source ZCL fails. The
+    global equation cannot detect this nilpotent bond sector.
+\end{proof}

--- a/docs/counterexamples.md
+++ b/docs/counterexamples.md
@@ -26,6 +26,22 @@ mathematical obstruction.
 - Witness: two scalar blocks over one physical letter with weights `1` and `2`;
   the trace-pairing cancellation cannot isolate the two blocks.
 
+### Positive-length global PRFP data do not imply tensor-level ZCL
+
+- Location: `TNLean/MPS/MPDO/LocalPurificationRFP.lean`
+- Main declaration:
+  `MPOTensor.exists_isPRFP_isMPDO_physTraceTransfer_ne_zero_not_isSourceZCL`
+- Statement refuted: the global PRFP equation, MPDO positivity, and a nonzero
+  physical-trace transfer imply source zero correlation length.
+- Witness: the one-letter tensor with sole entry
+  $Q=\left(\begin{smallmatrix}1&0&0\\0&0&1\\0&0&0\end{smallmatrix}\right)$.
+  Every positive power has trace one, but $Q^2$ is not a positive scalar
+  multiple of $Q$.
+- Relevance: positive-length density operators do not detect a nilpotent bond
+  sector. A local purification identity or a source-specified minimality or
+  canonical-representative condition is therefore necessary for a
+  global-to-local implication.
+
 ## Block Separation and Canonical Form
 
 ### Weighted MPV cancellation does not imply per-block SameMPV

--- a/docs/paper-gaps/cpsv16_purification_rfp_definition.tex
+++ b/docs/paper-gaps/cpsv16_purification_rfp_definition.tex
@@ -9,7 +9,7 @@
 
 \title{Purification RFP in Cirac--Perez-Garcia--Schuch--Verstraete 2017}
 \author{}
-\date{2026-06-05}
+\date{2026-07-16}
 
 \begin{document}
 \maketitle
@@ -77,9 +77,9 @@ replacement is tracked by
 MPDO coverage tracker
 \href{https://github.com/LionSR/TNLean/issues/2380}{issue \#2380}.}
 
-\section{Faithful replacement}
+\section{Global formalization and its obstruction}
 
-A faithful formalization should state the purification RFP definition with the
+A literal formalization of the printed purification RFP definition states the
 positive-length global purification equation \path{eq:MPDO-Puri-1} and require
 the purifying spin--ancilla tensor to be a pure-state RFP. The trace over the
 ancillary index, discussed after Definition \path{def:Puri-RFP}, is a separate
@@ -89,27 +89,44 @@ one-site tpCPM; it is not the two-map mixed-state RFP condition
 \leanid{MPOTensor.HasGlobalPurificationEquation}, the pure-state witness is
 \leanid{MPOTensor.HasPurificationRFPWitness}, and the bare positive-length
 global predicate is \leanid{MPOTensor.IsPRFP}. The latter records the displayed
-equation and pure-state transfer idempotence, but not the nondegeneracy implicit
-when the source speaks of density operators. The ancillary-trace map is
+equation and pure-state transfer idempotence. The ancillary-trace map is
 \leanid{MPOTensor.ancillaryTraceMap}; its Kraus-form trace-preserving
 complete positivity is
 \leanid{MPOTensor.ancillaryTraceMap_isKrausCPTP}, and the corresponding
 spin-reduction condition is
-\leanid{MPOTensor.HasTracePreservingSpinReduction}. Only after the remaining
-global-to-local theorem is proved may the nondegenerate global predicate be
-identified with the local purification condition.  Its normalized endpoint is
-the nonzero idempotence equation for the physical-trace transfer.  This equation
-implies source zero correlation length by taking its positive scalar to be
-$1$.  The converse passage, from a source zero-correlation-length equation with
-an arbitrary positive scalar to strict idempotence, requires a normalization
-argument and remains open.
-No equivalence with zero correlation length can be attached to the bare global
-predicate, since the zero purifying tensor is a counterexample.
+\leanid{MPOTensor.HasTracePreservingSpinReduction}.
 
-No theorem should assert that the normalized, nondegenerate source PRFP fails to
-imply ZCL. A counterexample to the bare Lean predicate must be identified as a
-failure of its missing nondegeneracy condition, not as a counterexample to the
-source theorem.
+The positive-length global equation does not, however, determine the one-site
+MPO tensor. This prevents a global-to-local theorem even after imposing MPDO
+positivity and a nonzero physical-trace transfer. Let $d=1$, $D=3$, and let the
+only tensor entry be
+\[
+  Q=
+  \begin{pmatrix}
+    1&0&0\\
+    0&0&1\\
+    0&0&0
+  \end{pmatrix}.
+\]
+For every $N>0$, one has $\operatorname{tr}(Q^N)=1$. Thus the generated density
+operator is the scalar $1$, which is the purification density of the scalar
+pure-state RFP tensor $A=1$. Every generated MPO is positive semidefinite and
+the physical-trace transfer is $Q\ne0$. Nevertheless
+\[
+  Q^2=\operatorname{diag}(1,0,0)
+\]
+is not a positive scalar multiple of $Q$, since its $(2,3)$ entry vanishes while
+the corresponding entry of $Q$ is $1$. Hence source ZCL fails. The theorem
+\leanid{MPOTensor.exists_isPRFP_isMPDO_physTraceTransfer_ne_zero_not_isSourceZCL}
+formalizes this example.
+
+Consequently nondegeneracy cannot repair the printed global statement. The
+source may instead intend the local purification graphic \path{Psipuri}, or a
+minimal or canonical representative excluding trace-invisible nilpotent bond
+sectors; neither condition is stated in Definition \path{def:Puri-RFP}. No such
+additional condition is introduced here. The global-to-local implication and
+the PRFP--ZCL equivalence therefore require clarification of the source
+statement rather than a proof from its present hypotheses.
 
 \section{Status}
 
@@ -150,11 +167,12 @@ identity with $\mathcal T_M\neq0$. The theorem
   \right).
 \]
 This is an exact structural characterization of the nondegenerate local
-purification predicate. It is not yet the source PRFP--ZCL equivalence of
-Theorem~4.4. The forward implication from this predicate to source zero
-correlation length is proved below. The converse from source zero correlation
-length, and the passage from a tensor known only through the positive-length
-global equation to the local tensor identity, remain open.
+purification predicate. It is not the source PRFP--ZCL equivalence of
+Theorem~4.4. The forward implication from this stronger local predicate to
+source zero correlation length is proved below. The converse from source zero
+correlation length remains open. The passage from a tensor known only through
+the positive-length global equation to the local tensor identity is false by
+the nilpotent example above.
 
 \section{Normalized local equivalence on the physical-trace transfer}
 
@@ -165,7 +183,8 @@ purification renormalization fixed point to zero correlation length,
 $M^{ij}=(\sum_k A^{(i,k)}\otimes\overline{A^{(j,k)}})_e$, not the global
 Definition \path{def:Puri-RFP} at line 758) and to the physical-trace-transfer
 notion of zero correlation length, is formalized as below; the unrestricted
-global implication remains open (see the Status section). That the object
+global implication is false for the printed hypotheses (see the preceding
+section). That the object
 $\mathcal T_M=\sum_i M^{ii}$ (Definition~4.2, lines 735--739) is the source
 zero-correlation-length object is the verdict of the companion note
 \path{cpsv16_zcl_canonical_form_normalization.tex}. The theorem
@@ -190,7 +209,7 @@ transfer-matrix representation recovers transfer-map idempotence. Existentially
 packaging the purifying data gives
 \leanid{MPOTensor.isLocalPurificationRFP_iff_isLPDO_and_physTraceTransfer_sq}.
 
-The source-faithful conclusion that $M$ has source zero correlation length,
+The corresponding local conclusion that $M$ has source zero correlation length,
 \leanid{MPOTensor.isSourceZCL_of_isLocalPurificationRFP}, carries the extra
 hypothesis $\mathcal T_M\neq 0$. This records a normalization restriction: the
 unconditional implication is false. The zero tensor at $D=D'=d_K=1$ with
@@ -202,6 +221,10 @@ fixed point being a normalized pure-state fixed point with leading eigenvalue
 $1$, a normalization that \leanid{MPOTensor.IsLocalPurificationRFP} drops.
 The theorem \leanid{MPOTensor.exists_isPRFP_not_isSourceZCL} now records this
 zero-purifier obstruction for the bare global predicate itself.
+The stronger theorem
+\leanid{MPOTensor.exists_isPRFP_isMPDO_physTraceTransfer_ne_zero_not_isSourceZCL}
+shows that global MPDO positivity and $\mathcal T_M\ne0$ still do not suffice:
+positive-length traces do not see the nilpotent bond sector of $Q$.
 
 \section{Remaining density-form obstruction}
 
@@ -217,11 +240,12 @@ two-phase counterexample recorded in
 \path{docs/paper-gaps/cpsv16_rfp_isometry_scope.tex} and closed issue~\#2598.
 
 Consequently the normalized local PRFP-to-ZCL implication is complete. The
-converse implication required for the source equivalence remains open, as does
-the global-to-local passage from Definition~4.3. The repeated-copy density
-formula remains source-obstructed pending an author correction or erratum. No
-copy-indexed physical map or additional structural hypothesis should be
-introduced merely to force that printed formula.
+converse implication required for the source equivalence remains open, while
+the global-to-local passage from Definition~4.3 is disproved under the printed
+hypotheses. The repeated-copy density formula remains source-obstructed pending
+an author correction or erratum. No copy-indexed physical map, minimality
+condition, or additional structural hypothesis should be introduced merely to
+force either printed claim.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

- formalize a three-dimensional nilpotent-sector example satisfying the printed positive-length global PRFP equation
- prove that the example is an MPDO and has nonzero physical-trace transfer, while source ZCL fails
- correct the blueprint and paper-gap note: nondegeneracy does not repair the printed global statement

## Mathematical point

For the one-site tensor with sole entry
[
Q=egin{pmatrix}1&0&0\\0&0&1\\0&0&0end{pmatrix},
]
one has (operatorname{tr}(Q^N)=1) for every (N>0). Hence every positive-length MPO is the scalar density operator purified by the scalar pure-state RFP tensor. Nevertheless (Q^2) is not a positive scalar multiple of (Q), so the source ZCL equation fails. The global equation cannot see the nilpotent bond sector.

No additional hypothesis is introduced to force the source implication.

## Verification

- targeted Lean compilation passes
- target build passes
- blueprint-to-Lean synchronization passes
- diff and proof-integrity checks pass
- no sorry, axiom, native_decide, or unsafeCast is introduced

Refs #3947
Refs #2380

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to new Lean proofs and documentation/blueprint alignment; no runtime, auth, or data-path behavior is affected.
> 
> **Overview**
> Formalizes **`MPOTensor.exists_isPRFP_isMPDO_physTraceTransfer_ne_zero_not_isSourceZCL`**: a one-site, bond-dimension-3 tensor with constant entry \(Q\) that satisfies the positive-length global purification RFP (via scalar purifier \(A=1\)), is an MPDO at every chain length, has nonzero \(\mathcal T_M=Q\), yet **fails** source zero correlation length because \(Q^2\) is not a positive scalar multiple of \(Q\).
> 
> The obstruction is a **nilpotent bond sector** invisible to positive-length traces (\(\operatorname{tr}(Q^N)=1\) for \(N>0\)), so the global density operators do not determine the one-site tensor.
> 
> **Docs and narrative corrections:** module docstrings and `IsNondegeneratePRFP` commentary now state that MPDO positivity and \(\mathcal T_M\neq 0\) do **not** repair the bare global `IsPRFP` predicate; the blueprint gains theorem `thm:nonzero_global_prfp_not_source_zcl`; `docs/counterexamples.md` and `docs/paper-gaps/cpsv16_purification_rfp_definition.tex` are updated to treat the global PRFP→ZCL passage as **false under printed hypotheses**, not merely blocked by the zero purifier.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c7b86cdcc863ed74e766c4374206d8e87dafcd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->