### PR TITLE
feat(MPS/MPDO): complete the RFP ZCL and SAL proposition

### DIFF
--- a/TNLean/MPS/MPDO/RFPViaTSSAL.lean
+++ b/TNLean/MPS/MPDO/RFPViaTSSAL.lean
@@ -10,15 +10,15 @@ import TNLean.MPS.MPDO.RFPViaTSGlobal
 /-!
 # Saturation of the area law for MPDO renormalization fixed points
 
-This file proves the forward implication of Proposition `propsimple`: a
-horizontally canonical matrix product density operator satisfying the local
-renormalization fixed-point equations saturates the area law.  The proof first
-establishes the two exact finite-chain identities obtained by transferring one
-site across a bipartition, applies mutual-information data processing in both
-directions, and then identifies bipartite mutual information with the chain
-quantity `I_L`.  Horizontal canonical form, positivity, and the fixed-point
-equations supply nonzero trace at every positive length; simplicity is not used
-in this implication.
+This file proves Proposition `propsimple`: a horizontally canonical matrix
+product density operator satisfying the local renormalization fixed-point
+equations has source zero correlation length and saturates the area law.  The
+SAL proof first establishes the two exact finite-chain identities obtained by
+transferring one site across a bipartition, applies mutual-information data
+processing in both directions, and then identifies bipartite mutual information
+with the chain quantity `I_L`.  Horizontal canonical form, positivity, and the
+fixed-point equations supply nonzero trace at every positive length; simplicity
+is not used in this implication.
 
 Source: arXiv:1606.00608, Appendix C, lines 1333--1341.  See
 `docs/paper-gaps/cpsv16_rfp_sal_data_processing.tex`.
@@ -441,5 +441,30 @@ theorem isSAL_of_isRFPViaTS (M : MPOTensor d D)
         (hHalf.trans_le (Nat.div_le_self N₀ 2)) (hM N₀) :=
       (mutualInfoChain_eq_mutualInformation M N₀ (a + 2)
         (hHalf.trans_le (Nat.div_le_self N₀ 2)) (hM N₀)).symm
+
+/-- A horizontally canonical matrix product density operator satisfying the
+local renormalization fixed-point equations has zero correlation length and
+saturates the area law.
+
+This is Proposition `propsimple` of arXiv:1606.00608.  The nonzero
+physical-trace transfer required by source ZCL is derived from the nonzero
+one-site ring; it is not an additional hypothesis.
+
+Source: arXiv:1606.00608, Proposition `propsimple`, Appendix C,
+lines 1333--1341, under the canonical-form and density-operator standing
+assumptions at lines 623--628 and 849--850. -/
+theorem isSourceZCL_and_isSAL_of_isRFPViaTS (M : MPOTensor d D)
+    (hHorizontal : MPOTensor.IsHorizontalCF M) (hM : IsMPDO M)
+    (hRFP : IsRFPViaTS M) : IsSourceZCL M ∧ IsSAL M := by
+  have hTrace :=
+    trace_mpo_ne_zero_of_isHorizontalCF_isMPDO_isRFPViaTS
+      M hHorizontal hM hRFP 1 Nat.zero_lt_one
+  have hTransfer : physTraceTransfer M ≠ 0 := by
+    intro hZero
+    apply hTrace
+    rw [trace_mpo_eq_trace_verticalLoop_pow, verticalLoop_eq_physTraceTransfer, hZero]
+    simp
+  exact ⟨isSourceZCL_of_isRFPViaTS M hRFP hTransfer,
+    isSAL_of_isRFPViaTS M hHorizontal hM hRFP⟩
 
 end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
@@ -437,6 +437,27 @@
     the normalization at every positive chain length.
 \end{proof}
 
+\begin{theorem}[Renormalization fixed points have ZCL and SAL]
+    \label{thm:mpdo_rfp_implies_zcl_and_sal}
+    \lean{MPOTensor.isSourceZCL_and_isSAL_of_isRFPViaTS}
+    \leanok
+    \uses{thm:rfp_via_ts_source_zcl,
+      lem:mpdo_rfp_positive_length_trace_nonzero,
+      thm:mpdo_rfp_implies_sal}
+    Let $M$ be a horizontally canonical matrix product density operator which
+    satisfies the local renormalization fixed-point equations of
+    Definition~4.1.  Then $M$ has source zero correlation length and saturates
+    the area law.  This is Proposition~\texttt{propsimple} in Appendix~C of
+    \cite{Cirac2016MPDO_arXiv}, lines~1333--1341.
+\end{theorem}
+
+\begin{proof}\leanok
+    The preceding nonvanishing lemma at length one rules out a zero
+    physical-trace transfer.  Trace preservation of the refinement map then
+    gives source zero correlation length, while
+    Theorem~\ref{thm:mpdo_rfp_implies_sal} gives saturation of the area law.
+\end{proof}
+
 \begin{lemma}[Nonnegativity of block entropies]
     \label{lem:block_entropy_nonneg}
     \lean{blockEntropy_nonneg}

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -81,9 +81,9 @@ For MPDO renormalization fixed points:
 - `cpsv16_rfp_sal_data_processing.tex` records the source proof that a mixed-state
   renormalization fixed point satisfies saturation of the area law. The
   localized trace-preserving completely positive maps and their tensor-ring
-  identities are formalized. Mutual-information data processing for the two
-  local maps and nonzero normalization from the source's simple-biCF convention
-  remain open.
+  identities, mutual-information data processing, positive-length
+  nonvanishing, and the source-shaped ZCL-and-SAL conclusion are formalized.
+  This note is now a closure record.
 - `cpsv16_zcl_canonical_form_normalization.tex` records the corresponding
   normalization issue for mixed-state ZCL.
 

--- a/docs/paper-gaps/cpsv16_rfp_sal_data_processing.tex
+++ b/docs/paper-gaps/cpsv16_rfp_sal_data_processing.tex
@@ -151,17 +151,22 @@ positive length.\footnote{Formal declaration:
 
 Combining the consecutive-cut correspondence, the two exact local-channel
 identities, data processing in both directions, and positive-length
-nonvanishing proves the source implication.\footnote{Formal declaration:
-\leanid{MPOTensor.isSAL_of_isRFPViaTS} in
+nonvanishing proves the SAL conclusion.  At length one, the same nonvanishing
+rules out a zero physical-trace transfer.  Combining its idempotence with the
+SAL conclusion proves the full source proposition, namely ZCL and
+SAL.\footnote{Formal declarations:
+\leanid{MPOTensor.isSAL_of_isRFPViaTS} and
+\leanid{MPOTensor.isSourceZCL_and_isSAL_of_isRFPViaTS} in
 \doclink{TNLean/MPS/MPDO/RFPViaTSSAL}.}
 
 \paragraph{Classification.}
 This gap is resolved.  The formal SAL predicate is restricted to positive
 chain lengths, the normalized consecutive-cut state is identified with the
 existing prefix-entropy expression for $I_L$, and the RFP hypotheses imply
-both normalization and the equality $I_L=I_{L+1}$.  No simplicity hypothesis
-is used in this forward implication, in agreement with the source proof.  The
-horizontal hypothesis is the representative-grouped formalization of the
-source biCF assumption, not the stronger per-copy separation predicate.
+normalization, source ZCL, and the equality $I_L=I_{L+1}$.  Thus Proposition
+\texttt{propsimple} is present with its full conclusion.  No simplicity
+hypothesis is used in this forward implication, in agreement with the source
+proof.  The horizontal hypothesis is the representative-grouped formalization
+of the source biCF assumption, not the stronger per-copy separation predicate.
 
 \end{document}

--- a/docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex
+++ b/docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex
@@ -108,9 +108,12 @@ Option~1 is now in place. The predicate \texttt{IsZCL} remains documented as a
 doubled-index CP-transfer idempotence condition, while
 \texttt{IsSourceZCL} records Definition~4.2. For the renormalization condition
 of Definition~4.1, the forward implication to source ZCL is now proved under
-the explicit nonzero-transfer hypothesis above. The PRFP implication, the
-reverse implication in Theorem~4.9, and the full strong-area-law assembly
-remain open.
+the explicit nonzero-transfer hypothesis above.  Under horizontal canonical
+form and the MPDO condition, this nonzero clause is now derived from the
+positive-length ring operators, and Proposition \texttt{propsimple} is proved
+with its full ZCL and SAL conclusion by
+\texttt{MPOTensor.isSourceZCL\_and\_isSAL\_of\_isRFPViaTS}.  The PRFP
+equivalence and the reverse implications in Theorem~4.9 remain open.
 
 \section{The faithful definition and its consequences}
 
@@ -150,8 +153,10 @@ The theorem
 \texttt{MPOTensor.physTraceTransfer\_sq\_of\_isRFPViaTS} formalizes the
 zero-correlation-length calculation in Appendix~C, Proposition
 \texttt{propsimple}, source lines 1333--1340. This proposition proves the first
-implication of Theorem~4.9 by establishing both ZCL and SAL; the present Lean
-theorem formalizes only its ZCL calculation. For every virtual matrix $X$,
+implication of Theorem~4.9 by establishing both ZCL and SAL.  The physical-trace
+theorem formalizes its ZCL calculation; the source-shaped capstone cited above
+combines it with positive-length nonvanishing and the SAL theorem.  For every
+virtual matrix $X$,
 trace preservation of the one-to-two map gives
 \[
   \operatorname{tr}(\mathcal T_M^2X)
@@ -199,7 +204,7 @@ fixed-point property.
 
 Second, the proposed bridge to doubled-index idempotence is false. The witness
 above generates the maximally mixed product state $\rho^{(N)}\propto I$, which
-has vanishing mutual information at every length ($I_1=I_2=\dots=0$), hence
+has vanishing mutual information at every length ($I_1=I_2=\cdots=0$), hence
 satisfies the strong area law (Definition~\texttt{def:area-law},
 \path{Papers/1606.00608/MPDO-22-12-17-2.tex:812}) as well as zero correlation
 length, yet $\mathcal E_M\circ\mathcal E_M=\tfrac14\,\mathrm{id}\neq\mathcal E_M$.


### PR DESCRIPTION
## Summary

- state the source-shaped conclusion of Proposition propsimple: a horizontally canonical MPDO satisfying the two local renormalization equations has source ZCL and SAL
- derive nonvanishing of the physical-trace transfer internally from the positive one-site ring
- update the blueprint and paper-gap records to mark the forward ZCL-and-SAL proposition complete

## Mathematical content

The theorem assumes exactly the formal standing data used in the source argument:

- horizontal canonical form
- the MPDO condition
- the two local refinement and coarse-graining equations

It does not assume simplicity and it does not add an independent nonzero-transfer hypothesis. Nonvanishing follows at chain length one from the existing positive-length trace theorem. The existing ZCL calculation and the two-way data-processing proof of SAL then give the conjunction.

## Verification

- direct Lean check passes
- target build passes: 8,879 jobs
- leanblueprint checkdecls passes
- blueprint synchronization, diff, and proof-integrity checks pass
- no sorry, axiom, native_decide, or unsafeCast is introduced

Refs #2380
Refs #232
Refs #3948
Refs #3953

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formalization and documentation only; no runtime, auth, or data-path changes. Residual risk is ordinary proof-maintenance if downstream theorems still assumed a separate nonzero-transfer hypothesis.
> 
> **Overview**
> Adds **`MPOTensor.isSourceZCL_and_isSAL_of_isRFPViaTS`**, the full forward implication of Proposition `propsimple`: horizontally canonical MPDO + local renormalization fixed-point equations ⇒ **source ZCL** and **SAL**, without simplicity or an extra nonzero-transfer assumption.
> 
> **Nonvanishing** of `physTraceTransfer` is proved internally from the one-site ring trace (`trace_mpo_ne_zero` at length 1), then fed into the existing `isSourceZCL_of_isRFPViaTS` and `isSAL_of_isRFPViaTS` results.
> 
> Module and blueprint text now describe the **full** proposition (not SAL-only). A new blueprint theorem **`thm:mpdo_rfp_implies_zcl_and_sal`** links the capstone. Paper-gap notes **`cpsv16_rfp_sal_data_processing`** and **`cpsv16_zcl_canonical_form_normalization`** are updated to record closure of the forward ZCL-and-SAL chain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3eb0bb2c158a8719cd739c4de981ffe48aa053b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->