### PR TITLE
feat(MPS/MPDO): preserve horizontal canonical form under blocking

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -418,6 +418,7 @@ import TNLean.MPS.MPDO.RFPViaTS
 import TNLean.MPS.MPDO.RFPViaTSGlobal
 import TNLean.MPS.MPDO.RFPViaTSSAL
 import TNLean.MPS.MPDO.PhysicalBlocking
+import TNLean.MPS.MPDO.HorizontalBlocking
 import TNLean.MPS.MPDO.PRFP
 import TNLean.MPS.MPDO.LocalPurificationRFP
 import TNLean.MPS.MPDO.SimpleLocalStructure

--- a/TNLean/MPS/Core/PhysicalReindexTransport.lean
+++ b/TNLean/MPS/Core/PhysicalReindexTransport.lean
@@ -23,6 +23,8 @@ basic tensor properties used by blocking and canonical-form arguments.
   one-site injectivity are preserved.
 * `gaugePhaseEquiv_reindexPhysical_equiv` — gauge-phase equivalence is preserved
   when both tensors are reindexed by the same physical alphabet bijection.
+* `linearIndependent_mpvState_of_configEquiv` transports linear independence
+  through an arbitrary equivalence of configuration spaces.
 * `mpvOverlap_reindexPhysical_equiv` and
   `linearIndependent_mpvState_reindexPhysical_equiv` — closed overlaps and
   linear independence of MPV states are preserved.
@@ -149,6 +151,34 @@ theorem mpvOverlap_reindexPhysical_equiv {d₁ d₂ D₁ D₂ N : ℕ}
         rfl
       rw [hσ])
 
+/-- An equivalence of finite configuration spaces transports linear
+independence between MPV families whose coefficients correspond under that
+equivalence.
+
+Source context: arXiv:1606.00608, the blocking and physical-basis
+identifications used at lines 317--345 and in Appendix C.4, lines 1951--1956. -/
+theorem linearIndependent_mpvState_of_configEquiv
+    {d₁ d₂ r N₁ N₂ : ℕ} {dim : Fin r → ℕ}
+    (e : Cfg d₁ N₁ ≃ Cfg d₂ N₂)
+    (A : (j : Fin r) → MPSTensor d₁ (dim j))
+    (B : (j : Fin r) → MPSTensor d₂ (dim j))
+    (hAB : ∀ (j : Fin r) (σ : Cfg d₂ N₂),
+      mpv (A j) (e.symm σ) = mpv (B j) σ)
+    (hLI : LinearIndependent ℂ (fun j ↦ mpvState (B j) N₂)) :
+    LinearIndependent ℂ (fun j ↦ mpvState (A j) N₁) := by
+  let F : MPVSpace d₁ N₁ ≃ₗ[ℂ] MPVSpace d₂ N₂ :=
+    (EuclideanSpace.equiv (Cfg d₁ N₁) ℂ).toLinearEquiv |>.trans
+      (LinearEquiv.piCongrLeft' ℂ (fun _ : Cfg d₁ N₁ ↦ ℂ) e) |>.trans
+      (EuclideanSpace.equiv (Cfg d₂ N₂) ℂ).symm.toLinearEquiv
+  have hF : ∀ j : Fin r, F (mpvState (A j) N₁) = mpvState (B j) N₂ := by
+    intro j
+    ext σ
+    exact hAB j σ
+  have hMapped : LinearIndependent ℂ
+      (fun j ↦ F (mpvState (A j) N₁)) := by
+    simpa only [hF] using hLI
+  exact LinearIndependent.of_comp F.toLinearMap hMapped
+
 /-- A physical-index equivalence preserves linear independence of a family
 of MPV states at a fixed chain length.
 
@@ -162,22 +192,13 @@ theorem linearIndependent_mpvState_reindexPhysical_equiv
       (fun j ↦ mpvState (reindexPhysical e (A j)) N) := by
   let E : Cfg d₁ N ≃ Cfg d₂ N :=
     Equiv.arrowCongr (Equiv.refl (Fin N)) e
-  let F : MPVSpace d₁ N ≃ₗ[ℂ] MPVSpace d₂ N :=
-    (EuclideanSpace.equiv (Cfg d₁ N) ℂ).toLinearEquiv |>.trans
-      (LinearEquiv.piCongrLeft' ℂ (fun _ : Cfg d₁ N ↦ ℂ) E) |>.trans
-      (EuclideanSpace.equiv (Cfg d₂ N) ℂ).symm.toLinearEquiv
-  have hF : ∀ j : Fin r,
-      F (mpvState (reindexPhysical e (A j)) N) = mpvState (A j) N := by
-    intro j
-    ext σ
-    change mpv (reindexPhysical e (A j)) (E.symm σ) = mpv (A j) σ
+  apply linearIndependent_mpvState_of_configEquiv E
+    (fun j ↦ reindexPhysical e (A j)) A
+  · intro j σ
     rw [mpv_reindexPhysical]
     congr 1
     funext n
     simp [E, Equiv.arrowCongr]
-  have hMapped : LinearIndependent ℂ
-      (fun j ↦ F (mpvState (reindexPhysical e (A j)) N)) := by
-    simpa only [hF] using hLI
-  exact LinearIndependent.of_comp F.toLinearMap hMapped
+  · exact hLI
 
 end MPSTensor

--- a/TNLean/MPS/Core/PhysicalReindexTransport.lean
+++ b/TNLean/MPS/Core/PhysicalReindexTransport.lean
@@ -23,6 +23,9 @@ basic tensor properties used by blocking and canonical-form arguments.
   one-site injectivity are preserved.
 * `gaugePhaseEquiv_reindexPhysical_equiv` — gauge-phase equivalence is preserved
   when both tensors are reindexed by the same physical alphabet bijection.
+* `mpvOverlap_reindexPhysical_equiv` and
+  `linearIndependent_mpvState_reindexPhysical_equiv` — closed overlaps and
+  linear independence of MPV states are preserved.
 -/
 
 open scoped Matrix BigOperators
@@ -122,5 +125,59 @@ theorem gaugePhaseEquiv_reindexPhysical_equiv {d₁ d₂ D : ℕ}
     refine ⟨X, ζ, hζ, ?_⟩
     intro i
     simpa [reindexPhysical] using hXB (e i)
+
+/-- Reindexing both tensors by a physical-index equivalence preserves their
+closed MPV overlap.
+
+Source context: arXiv:1606.00608, the physical-basis identifications used in
+canonical-form blocking at lines 317--345. -/
+theorem mpvOverlap_reindexPhysical_equiv {d₁ d₂ D₁ D₂ N : ℕ}
+    (e : Fin d₁ ≃ Fin d₂) (A : MPSTensor d₂ D₁) (B : MPSTensor d₂ D₂) :
+    mpvOverlap (reindexPhysical e A) (reindexPhysical e B) N =
+      mpvOverlap A B N := by
+  classical
+  let E : Cfg d₁ N ≃ Cfg d₂ N :=
+    Equiv.arrowCongr (Equiv.refl (Fin N)) e
+  simp only [mpvOverlap, mpv_reindexPhysical]
+  exact Fintype.sum_equiv E
+    (fun σ : Cfg d₁ N ↦
+      mpv A (fun n ↦ e (σ n)) * star (mpv B (fun n ↦ e (σ n))))
+    (fun σ : Cfg d₂ N ↦ mpv A σ * star (mpv B σ))
+    (fun σ ↦ by
+      have hσ : (fun n ↦ e (σ n)) = E σ := by
+        funext n
+        rfl
+      rw [hσ])
+
+/-- A physical-index equivalence preserves linear independence of a family
+of MPV states at a fixed chain length.
+
+Source context: arXiv:1606.00608, the physical-basis identifications used in
+canonical-form blocking at lines 317--345. -/
+theorem linearIndependent_mpvState_reindexPhysical_equiv
+    {d₁ d₂ r N : ℕ} {dim : Fin r → ℕ}
+    (e : Fin d₁ ≃ Fin d₂) (A : (j : Fin r) → MPSTensor d₂ (dim j))
+    (hLI : LinearIndependent ℂ (fun j ↦ mpvState (A j) N)) :
+    LinearIndependent ℂ
+      (fun j ↦ mpvState (reindexPhysical e (A j)) N) := by
+  let E : Cfg d₁ N ≃ Cfg d₂ N :=
+    Equiv.arrowCongr (Equiv.refl (Fin N)) e
+  let F : MPVSpace d₁ N ≃ₗ[ℂ] MPVSpace d₂ N :=
+    (EuclideanSpace.equiv (Cfg d₁ N) ℂ).toLinearEquiv |>.trans
+      (LinearEquiv.piCongrLeft' ℂ (fun _ : Cfg d₁ N ↦ ℂ) E) |>.trans
+      (EuclideanSpace.equiv (Cfg d₂ N) ℂ).symm.toLinearEquiv
+  have hF : ∀ j : Fin r,
+      F (mpvState (reindexPhysical e (A j)) N) = mpvState (A j) N := by
+    intro j
+    ext σ
+    change mpv (reindexPhysical e (A j)) (E.symm σ) = mpv (A j) σ
+    rw [mpv_reindexPhysical]
+    congr 1
+    funext n
+    simp [E, Equiv.arrowCongr]
+  have hMapped : LinearIndependent ℂ
+      (fun j ↦ F (mpvState (reindexPhysical e (A j)) N)) := by
+    simpa only [hF] using hLI
+  exact LinearIndependent.of_comp F.toLinearMap hMapped
 
 end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Blocking.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Blocking.lean
@@ -30,8 +30,7 @@ Positive blocking preserves the full predicate `IsBNTCanonicalForm`.
 * `SectorDecomposition.sameMPV₂_blockTensor_toTensor` proves that assembling
   the blocked decomposition gives the same MPV family as blocking the assembled
   tensor.
-* `IsBNTCanonicalForm.blockTensor` proves preservation of BNT canonical form
-  under positive blocking.
+* Positive physical blocking preserves BNT canonical form.
 -/
 
 open scoped Matrix BigOperators

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Blocking.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Blocking.lean
@@ -277,28 +277,17 @@ theorem IsBNTCanonicalForm.blockTensor
     change LinearIndependent ℂ (fun j : Fin P.basisCount ↦
       mpvState (MPSTensor.blockTensor (P.basis j) p) N)
     let e := blockedConfigEquiv d N p
-    let F : MPVSpace (blockPhysDim d p) N ≃ₗ[ℂ] MPVSpace d (N * p) :=
-      (EuclideanSpace.equiv (Cfg (blockPhysDim d p) N) ℂ).toLinearEquiv |>.trans
-        (LinearEquiv.piCongrLeft' ℂ
-          (fun _ : Cfg (blockPhysDim d p) N ↦ ℂ) e) |>.trans
-        (EuclideanSpace.equiv (Cfg d (N * p)) ℂ).symm.toLinearEquiv
-    have hF : ∀ j : Fin P.basisCount,
-        F (mpvState (MPSTensor.blockTensor (P.basis j) p) N) =
-          mpvState (P.basis j) (N * p) := by
-      intro j
-      ext σ
+    apply linearIndependent_mpvState_of_configEquiv e
+      (fun j ↦ MPSTensor.blockTensor (P.basis j) p) P.basis
+    · intro j σ
       change mpv (MPSTensor.blockTensor (P.basis j) p) (e.symm σ) =
         mpv (P.basis j) σ
       simp only [mpv, MPSTensor.coeff, evalWord_blockTensor]
       rw [← ofFn_blockedConfigEquiv d N p (e.symm σ)]
       simp [e]
-    have hNp : N₀ < N * p := by
-      exact lt_of_lt_of_le hN (Nat.le_mul_of_pos_right N hp)
-    have hMapped : LinearIndependent ℂ
-        (fun j : Fin P.basisCount ↦
-          F (mpvState (MPSTensor.blockTensor (P.basis j) p) N)) := by
-      simpa only [hF] using hLI (N * p) hNp
-    exact LinearIndependent.of_comp F.toLinearMap hMapped
+    · have hNp : N₀ < N * p := by
+        exact lt_of_lt_of_le hN (Nat.le_mul_of_pos_right N hp)
+      exact hLI (N * p) hNp
   refine
     { basis_dim_pos := hCF.basis_dim_pos
       basis_irreducible := ?_

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Blocking.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Blocking.lean
@@ -2,8 +2,10 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TNLean.MPS.Core.BlockingInfrastructure
-import TNLean.MPS.SharedInfra.SectorDecomposition
+import TNLean.MPS.CanonicalForm.SectorComparison.PrimitiveBlocks
+import TNLean.MPS.Core.PhysicalReindexTransport
+import TNLean.MPS.FundamentalTheorem.SectorBNT.Basic
+import TNLean.MPS.Periodic.NormalizedSelfOverlap
 
 /-!
 # Physical blocking of sector decompositions
@@ -15,11 +17,9 @@ each representative `A_j` by `A_j^[p]`, and replaces each copy weight
 
 The two-layer representative and copy-weight structure comes from
 arXiv:1606.00608, `eq:II_ABasicTensors` and `decBSV`, lines 283--301.  Physical
-blocking of this structure is an auxiliary construction for the planned formal
-proof of Appendix C.3, Lemma L, lines 1835--1858; it is not a separate
-construction stated there.  This file does not assert that the full predicate
-`IsBNTCanonicalForm` is preserved by blocking, since that requires separate
-proofs for representative distinctness and eventual linear independence.
+blocking of this structure is an auxiliary construction used in Appendix C.3,
+Lemma L, lines 1835--1858; it is not a separate construction stated there.
+Positive blocking preserves the full predicate `IsBNTCanonicalForm`.
 
 ## Main results
 
@@ -30,13 +30,108 @@ proofs for representative distinctness and eventual linear independence.
 * `SectorDecomposition.sameMPV₂_blockTensor_toTensor` proves that assembling
   the blocked decomposition gives the same MPV family as blocking the assembled
   tensor.
+* `IsBNTCanonicalForm.blockTensor` proves preservation of BNT canonical form
+  under positive blocking.
 -/
 
 open scoped Matrix BigOperators
+open Filter
 
 namespace MPSTensor.SectorDecomposition
 
 variable {d : ℕ}
+
+/-- Reindex the physical alphabet of every representative in a sector
+decomposition. The representative labels, multiplicities, weights, and bond
+dimensions are unchanged.
+
+Source: arXiv:1606.00608, the harmless physical-basis identifications used in
+the canonical-form blocking at lines 317--345. -/
+noncomputable def reindexPhysical {d' : ℕ} (P : SectorDecomposition d)
+    (e : Fin d' ≃ Fin d) : SectorDecomposition d' where
+  basisCount := P.basisCount
+  basisDim := P.basisDim
+  basis := fun j ↦ MPSTensor.reindexPhysical e (P.basis j)
+  sectors := P.sectors
+
+@[simp]
+theorem reindexPhysical_basis {d' : ℕ} (P : SectorDecomposition d)
+    (e : Fin d' ≃ Fin d) (j : Fin P.basisCount) :
+    (P.reindexPhysical e).basis j = MPSTensor.reindexPhysical e (P.basis j) :=
+  rfl
+
+@[simp]
+theorem reindexPhysical_totalDim {d' : ℕ} (P : SectorDecomposition d)
+    (e : Fin d' ≃ Fin d) :
+    (P.reindexPhysical e).totalDim = P.totalDim :=
+  rfl
+
+@[simp]
+theorem reindexPhysical_totalCopies {d' : ℕ} (P : SectorDecomposition d)
+    (e : Fin d' ≃ Fin d) :
+    (P.reindexPhysical e).totalCopies = P.totalCopies :=
+  rfl
+
+@[simp]
+theorem reindexPhysical_flatDim {d' : ℕ} (P : SectorDecomposition d)
+    (e : Fin d' ≃ Fin d) (s : Fin P.totalCopies) :
+    (P.reindexPhysical e).flatDim s = P.flatDim s :=
+  rfl
+
+/-- Assembling a physically reindexed sector decomposition is the same as
+physically reindexing its assembled tensor.
+
+Source: arXiv:1606.00608, canonical-form blocking at lines 317--345. -/
+theorem reindexPhysical_toTensor {d' : ℕ} (P : SectorDecomposition d)
+    (e : Fin d' ≃ Fin d) :
+    (P.reindexPhysical e).toTensor = MPSTensor.reindexPhysical e P.toTensor :=
+  rfl
+
+/-- A bijective relabelling of the physical alphabet preserves BNT canonical
+form.
+
+Source: arXiv:1606.00608, the physical-basis identifications implicit in the
+blocking passage at lines 317--345. -/
+theorem IsBNTCanonicalForm.reindexPhysical {d' : ℕ}
+    {P : SectorDecomposition d} (hCF : IsBNTCanonicalForm P)
+    (e : Fin d' ≃ Fin d) :
+    IsBNTCanonicalForm (P.reindexPhysical e) where
+  basis_dim_pos := hCF.basis_dim_pos
+  basis_irreducible := fun j ↦
+    (isIrreducibleTensor_reindexPhysical_equiv e (P.basis j)).2
+      (hCF.basis_irreducible j)
+  basis_left_canonical := fun j ↦
+    (leftCanonical_reindexPhysical_equiv e (P.basis j)).2
+      (hCF.basis_left_canonical j)
+  basis_normalized_self_overlap := by
+    change ∀ j : Fin P.basisCount,
+      Tendsto (fun N : ℕ ↦ mpvOverlap
+        (MPSTensor.reindexPhysical e (P.basis j))
+        (MPSTensor.reindexPhysical e (P.basis j)) N) atTop (nhds 1)
+    intro j
+    refine (hCF.basis_normalized_self_overlap j).congr' ?_
+    filter_upwards with N
+    exact (mpvOverlap_reindexPhysical_equiv e (P.basis j) (P.basis j)).symm
+  bnt_data := by
+    change ∃ N₀ : ℕ, ∀ N > N₀,
+      LinearIndependent ℂ (fun j : Fin P.basisCount ↦
+        mpvState (MPSTensor.reindexPhysical e (P.basis j)) N)
+    obtain ⟨N₀, hLI⟩ := hCF.bnt_data
+    refine ⟨N₀, fun N hN ↦ ?_⟩
+    exact linearIndependent_mpvState_reindexPhysical_equiv e P.basis (hLI N hN)
+  basis_distinct := by
+    change ∀ j k : Fin P.basisCount, j ≠ k →
+      ∀ hdim : P.basisDim j = P.basisDim k,
+        ¬ GaugePhaseEquiv
+          (cast (congr_arg (MPSTensor d') hdim)
+            (MPSTensor.reindexPhysical e (P.basis j)))
+          (MPSTensor.reindexPhysical e (P.basis k))
+    intro j k hjk hdim hGauge
+    apply hCF.basis_distinct j k hjk hdim
+    rw [← MPSTensor.reindexPhysical_cast_dim e hdim (P.basis j)] at hGauge
+    exact (gaugePhaseEquiv_reindexPhysical_equiv e _ _).1 hGauge
+  weight_norm_le_one := hCF.weight_norm_le_one
+  weight_unit_exists := hCF.weight_unit_exists
 
 /-- The sector decomposition obtained by blocking `p` physical sites.
 
@@ -100,6 +195,23 @@ theorem blockTensor_flatBasis (P : SectorDecomposition d) (p : ℕ)
     (P.blockTensor p).flatBasis s = MPSTensor.blockTensor (P.flatBasis s) p :=
   rfl
 
+/-- Blocking a block-diagonal sector tensor is exactly the block-diagonal
+tensor of the blocked representatives with powered copy weights.
+
+Source: arXiv:1606.00608, canonical-form blocking at lines 317--345. -/
+theorem blockTensor_toTensor (P : SectorDecomposition d) (p : ℕ) :
+    MPSTensor.blockTensor P.toTensor p = (P.blockTensor p).toTensor := by
+  change MPSTensor.blockTensor
+      (toTensorFromBlocks (d := d) P.flatWeight P.flatBasis) p =
+    toTensorFromBlocks (d := blockPhysDim d p)
+      (fun s ↦ (P.flatWeight s) ^ p)
+      (fun s ↦ MPSTensor.blockTensor (P.flatBasis s) p)
+  funext i
+  rw [MPSTensor.blockTensor]
+  rw [evalWord_toTensorFromBlocks_eq_reindex_blockDiagonal]
+  simp only [toTensorFromBlocks, length_wordOfBlock]
+  rfl
+
 /-- The coefficient of the blocked decomposition at length `N` is the
 coefficient of the original decomposition at length `N * p`.
 
@@ -134,5 +246,111 @@ theorem sameMPV₂_blockTensor_toTensor (P : SectorDecomposition d) (p : ℕ) :
       (fun s ↦ (P.flatWeight s) ^ p)
       (fun s ↦ MPSTensor.blockTensor (P.flatBasis s) p))
   exact sameMPV₂_blockTensor_toTensorFromBlocks P.flatWeight P.flatBasis p
+
+/-- Positive physical blocking preserves BNT canonical form.
+
+The primitive transfer map obtained from irreducibility, left-canonicality,
+and normalized self-overlap makes every positive blocked representative
+irreducible. The canonical equivalence between blocked configurations of
+length `N` and original configurations of length `N * p` transports eventual
+linear independence. That independence also prevents two distinct blocked
+representatives from becoming gauge-phase equivalent.
+
+Source: arXiv:1606.00608, canonical-form blocking at lines 317--345, and
+arXiv:2011.12127, lines 1815--1850. -/
+theorem IsBNTCanonicalForm.blockTensor
+    {P : SectorDecomposition d} (hCF : IsBNTCanonicalForm P)
+    {p : ℕ} (hp : 0 < p) :
+    IsBNTCanonicalForm (P.blockTensor p) := by
+  classical
+  have hPrimitive : ∀ j : Fin P.basisCount,
+      _root_.IsPrimitive (transferMap (P.basis j)) := by
+    intro j
+    letI : NeZero (P.basisDim j) := ⟨(hCF.basis_dim_pos j).ne'⟩
+    exact
+      (isPrimitive_and_isNormal_of_irreducible_leftCanonical_selfOverlap_tendsto_one
+        (P.basis j) (hCF.basis_irreducible j) (hCF.basis_left_canonical j)
+          (hCF.basis_normalized_self_overlap j)).1
+  have hData : HasBNTSectorData (P.blockTensor p) := by
+    obtain ⟨N₀, hLI⟩ := hCF.bnt_data
+    refine ⟨N₀, ?_⟩
+    intro N hN
+    change LinearIndependent ℂ (fun j : Fin P.basisCount ↦
+      mpvState (MPSTensor.blockTensor (P.basis j) p) N)
+    let e := blockedConfigEquiv d N p
+    let F : MPVSpace (blockPhysDim d p) N ≃ₗ[ℂ] MPVSpace d (N * p) :=
+      (EuclideanSpace.equiv (Cfg (blockPhysDim d p) N) ℂ).toLinearEquiv |>.trans
+        (LinearEquiv.piCongrLeft' ℂ
+          (fun _ : Cfg (blockPhysDim d p) N ↦ ℂ) e) |>.trans
+        (EuclideanSpace.equiv (Cfg d (N * p)) ℂ).symm.toLinearEquiv
+    have hF : ∀ j : Fin P.basisCount,
+        F (mpvState (MPSTensor.blockTensor (P.basis j) p) N) =
+          mpvState (P.basis j) (N * p) := by
+      intro j
+      ext σ
+      change mpv (MPSTensor.blockTensor (P.basis j) p) (e.symm σ) =
+        mpv (P.basis j) σ
+      simp only [mpv, MPSTensor.coeff, evalWord_blockTensor]
+      rw [← ofFn_blockedConfigEquiv d N p (e.symm σ)]
+      simp [e]
+    have hNp : N₀ < N * p := by
+      exact lt_of_lt_of_le hN (Nat.le_mul_of_pos_right N hp)
+    have hMapped : LinearIndependent ℂ
+        (fun j : Fin P.basisCount ↦
+          F (mpvState (MPSTensor.blockTensor (P.basis j) p) N)) := by
+      simpa only [hF] using hLI (N * p) hNp
+    exact LinearIndependent.of_comp F.toLinearMap hMapped
+  refine
+    { basis_dim_pos := hCF.basis_dim_pos
+      basis_irreducible := ?_
+      basis_left_canonical := ?_
+      basis_normalized_self_overlap := ?_
+      bnt_data := hData
+      basis_distinct := ?_
+      weight_norm_le_one := ?_
+      weight_unit_exists := ?_ }
+  · intro j
+    letI : NeZero (P.basisDim j) := ⟨(hCF.basis_dim_pos j).ne'⟩
+    exact isIrreducibleTensor_blockTensor_of_tp_primitive_irr
+      (P.basis j) (hCF.basis_left_canonical j) (hPrimitive j)
+        (hCF.basis_irreducible j) hp
+  · intro j
+    exact leftCanonical_blockTensor (P.basis j) p (hCF.basis_left_canonical j)
+  · change ∀ j : Fin P.basisCount,
+      Tendsto (fun N : ℕ ↦ mpvOverlap
+        (MPSTensor.blockTensor (P.basis j) p)
+        (MPSTensor.blockTensor (P.basis j) p) N) atTop (nhds 1)
+    intro j
+    letI : NeZero (P.basisDim j) := ⟨(hCF.basis_dim_pos j).ne'⟩
+    have hMul : Tendsto (fun a : ℕ ↦ a * p) atTop atTop := by
+      refine tendsto_atTop.2 fun b ↦ ?_
+      filter_upwards [eventually_ge_atTop b] with a ha
+      exact ha.trans (Nat.le_mul_of_pos_right a hp)
+    refine ((hCF.basis_normalized_self_overlap j).comp hMul).congr' ?_
+    filter_upwards with N
+    exact (mpvOverlap_blockTensor_self_eq (P.basis j) p N).symm
+  · intro j k hjk hdim hGauge
+    obtain ⟨X, ζ, _, hX⟩ := hGauge
+    obtain ⟨N₀, hLI⟩ := hData
+    let N := N₀ + 1
+    have hState : mpvState ((P.blockTensor p).basis k) N =
+        (ζ ^ N) • mpvState ((P.blockTensor p).basis j) N := by
+      ext σ
+      change mpv ((P.blockTensor p).basis k) σ =
+        ζ ^ N * mpv ((P.blockTensor p).basis j) σ
+      rw [mpv_eq_pow_mul_of_gaugePhase _ _ X ζ hX N σ,
+        mpv_cast_dim hdim ((P.blockTensor p).basis j) N σ]
+    have hEq : (1 : ℂ) • mpvState ((P.blockTensor p).basis k) N =
+        (ζ ^ N) • mpvState ((P.blockTensor p).basis j) N := by
+      simpa using hState
+    have hkj : k = j :=
+      (hLI N (by omega)).eq_of_smul_apply_eq_smul_apply 1 (ζ ^ N) k j one_ne_zero hEq
+    exact hjk hkj.symm
+  · intro j q
+    rw [blockTensor_weight, norm_pow]
+    exact pow_le_one₀ (norm_nonneg _) (hCF.weight_norm_le_one j q)
+  · obtain ⟨j, q, hq⟩ := hCF.weight_unit_exists
+    refine ⟨j, q, ?_⟩
+    rw [blockTensor_weight, norm_pow, hq, one_pow]
 
 end MPSTensor.SectorDecomposition

--- a/TNLean/MPS/MPDO/HorizontalBlocking.lean
+++ b/TNLean/MPS/MPDO/HorizontalBlocking.lean
@@ -1,0 +1,75 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.FundamentalTheorem.SectorBNT.Blocking
+import TNLean.MPS.MPDO.HorizontalBNT
+import TNLean.MPS.MPDO.PhysicalBlocking
+
+/-!
+# Horizontal canonical form under two-site blocking
+
+Two-site physical blocking preserves horizontal canonical form. The sector
+representatives and copy weights are blocked, the physical alphabet is
+relabeled by the canonical ket--bra equivalence, and every copy retains its
+original virtual gauge.
+
+This is the blocking fact used when Proposition 4.13 is applied both to an MPO
+tensor and to its two-site blocked tensor in Appendix C.4 of
+arXiv:1606.00608, lines 1951--1956.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- Two-site physical blocking preserves horizontal canonical form.
+
+The proof blocks the BNT sector decomposition, transports it through the
+canonical ket--bra physical-index equivalence, and uses the same block-diagonal
+virtual gauge on every blocked word.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1951--1956. -/
+theorem IsHorizontalCF.blockTwo {M : MPOTensor d D}
+    (hHorizontal : IsHorizontalCF M) :
+    IsHorizontalCF (MPOTensor.blockTwo M) := by
+  classical
+  obtain ⟨S, hCF, hTotal, Xcopy, hX⟩ := hHorizontal
+  subst D
+  let e := twoSiteDoubledIndexEquiv d
+  let S' := (S.blockTensor 2).reindexPhysical e
+  have hCF' : MPSTensor.IsBNTCanonicalForm S' :=
+    MPSTensor.SectorDecomposition.IsBNTCanonicalForm.reindexPhysical
+      (MPSTensor.SectorDecomposition.IsBNTCanonicalForm.blockTensor hCF (by omega)) e
+  refine ⟨S', hCF', ?_⟩
+  refine ⟨by rfl, ?_⟩
+  simp only [S', MPSTensor.SectorDecomposition.reindexPhysical_totalCopies,
+    MPSTensor.SectorDecomposition.blockTensor_totalCopies,
+    MPSTensor.SectorDecomposition.reindexPhysical_flatDim,
+    MPSTensor.SectorDecomposition.blockTensor_flatDim,
+    MPSTensor.SectorDecomposition.reindexPhysical_toTensor,
+    MPSTensor.reindexPhysical]
+  rw [← MPSTensor.SectorDecomposition.blockTensor_toTensor]
+  refine ⟨Xcopy, ?_⟩
+  let X := MPSTensor.globalGaugeOfBlocks Xcopy
+  have hGauge : ∀ i : Fin (d * d),
+      M.toMPSTensor i =
+        (X : Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ) * S.toTensor i *
+          (((X)⁻¹ : GL (Fin S.totalDim) ℂ) :
+            Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ) := by
+    intro i
+    simpa [X] using hX i
+  intro i
+  rw [toMPSTensor_blockTwo]
+  change MPSTensor.blockTensor M.toMPSTensor 2 (e i) =
+    (X : Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ) *
+      MPSTensor.blockTensor S.toTensor 2 (e i) *
+        (((X)⁻¹ : GL (Fin S.totalDim) ℂ) :
+          Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ)
+  exact MPSTensor.evalWord_gauge X hGauge
+    (MPSTensor.wordOfBlock (d * d) 2 (e i))
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/PhysicalBlocking.lean
+++ b/TNLean/MPS/MPDO/PhysicalBlocking.lean
@@ -193,6 +193,39 @@ noncomputable def blockTwo (M : MPOTensor d D) : MPOTensor (d * d) D :=
     M (finProdFinEquiv.symm i).1 (finProdFinEquiv.symm j).1 *
       M (finProdFinEquiv.symm i).2 (finProdFinEquiv.symm j).2
 
+/-- Identify the standard two-site index `Fin (d * d)` with the general
+length-two blocked alphabet.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1951--1956. -/
+noncomputable def twoSiteBlockEquiv (d : ℕ) :
+    Fin (d * d) ≃ Fin (MPSTensor.blockPhysDim d 2) :=
+  finProdFinEquiv.symm |>.trans
+    (finTwoArrowEquiv (Fin d)).symm |>.trans
+    (MPSTensor.decodeBlockEquiv d 2).symm
+
+/-- Identify the doubled physical index of `blockTwo` with the general
+length-two block of the doubled MPS alphabet. -/
+noncomputable def twoSiteDoubledIndexEquiv (d : ℕ) :
+    Fin ((d * d) * (d * d)) ≃
+      Fin (MPSTensor.blockPhysDim (d * d) 2) :=
+  finProdFinEquiv.symm |>.trans
+    (Equiv.prodCongr (twoSiteBlockEquiv d) (twoSiteBlockEquiv d)) |>.trans
+    finProdFinEquiv |>.trans
+    (blockedDoubledIndexEquiv d 2)
+
+/-- Passing `blockTwo` to its doubled-index MPS tensor is general two-site
+blocking followed by the canonical ket--bra reindexing.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1951--1956. -/
+theorem toMPSTensor_blockTwo (M : MPOTensor d D) :
+    (blockTwo M).toMPSTensor =
+      MPSTensor.reindexPhysical (twoSiteDoubledIndexEquiv d)
+        (MPSTensor.blockTensor M.toMPSTensor 2) := by
+  funext ij
+  simp [toMPSTensor, blockTwo, MPSTensor.reindexPhysical,
+    MPSTensor.blockTensor, twoSiteDoubledIndexEquiv, twoSiteBlockEquiv,
+    blockedDoubledIndexEquiv, MPSTensor.wordOfBlock, Equiv.arrowCongr]
+
 @[simp] lemma blockTwo_apply (M : MPOTensor d D) (i j : Fin (d * d)) :
     blockTwo M i j =
       M (finProdFinEquiv.symm i).1 (finProdFinEquiv.symm j).1 *

--- a/TNLean/MPS/Periodic/NormalizedSelfOverlap.lean
+++ b/TNLean/MPS/Periodic/NormalizedSelfOverlap.lean
@@ -35,8 +35,8 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-- An irreducible left-canonical tensor whose self-overlap converges to one is
-normal.
+/-- An irreducible left-canonical tensor whose self-overlap converges to one has
+primitive transfer map and is normal.
 
 Quantum Perron--Frobenius theory gives a positive period `m` whose peripheral
 spectrum consists of all `m`-th roots of unity.  The periodic self-overlap
@@ -47,12 +47,12 @@ applies.
 
 Source context: arXiv:2011.12127, lines 1815--1837; arXiv:1708.00029,
 Appendix A; Wolf Theorem 6.6. -/
-theorem isNormal_of_irreducible_leftCanonical_selfOverlap_tendsto_one
+theorem isPrimitive_and_isNormal_of_irreducible_leftCanonical_selfOverlap_tendsto_one
     [NeZero D] (A : MPSTensor d D)
     (hIrr : IsIrreducibleTensor A)
     (hLeft : IsLeftCanonical A)
     (hSelf : Tendsto (fun N : ℕ ↦ mpvOverlap (d := d) A A N) atTop (nhds 1)) :
-    IsNormal A := by
+    _root_.IsPrimitive (transferMap (d := d) (D := D) A) ∧ IsNormal A := by
   classical
   obtain ⟨K, hUnital, hIrrK, ρ, hρpd, hρfix, rfl⟩ :=
     conjTranspose_kraus_setup A hLeft hIrr
@@ -145,7 +145,21 @@ theorem isNormal_of_irreducible_leftCanonical_selfOverlap_tendsto_one
   rw [hmOne] at hPeriodic
   have hPrim : _root_.IsPrimitive (transferMap (d := d) (D := D) A) :=
     ((IsPeriodic.one_iff_primitive A).1 hPeriodic).2.2
-  exact isNormal_of_tp_primitive_irreducible A hLeft hPrim hIrr
+  exact ⟨hPrim, isNormal_of_tp_primitive_irreducible A hLeft hPrim hIrr⟩
+
+/-- An irreducible left-canonical tensor whose self-overlap converges to one is
+normal.
+
+Source context: arXiv:2011.12127, lines 1815--1837; arXiv:1708.00029,
+Appendix A; Wolf Theorem 6.6. -/
+theorem isNormal_of_irreducible_leftCanonical_selfOverlap_tendsto_one
+    [NeZero D] (A : MPSTensor d D)
+    (hIrr : IsIrreducibleTensor A)
+    (hLeft : IsLeftCanonical A)
+    (hSelf : Tendsto (fun N : ℕ ↦ mpvOverlap (d := d) A A N) atTop (nhds 1)) :
+    IsNormal A :=
+  (isPrimitive_and_isNormal_of_irreducible_leftCanonical_selfOverlap_tendsto_one
+    A hIrr hLeft hSelf).2
 
 end MPSTensor
 

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1176,6 +1176,37 @@ single family.
     normality.
 \end{proof}
 
+\begin{theorem}[Positive blocking preserves BNT canonical form]
+    \label{thm:sector_bnt_cf_block_tensor}
+    \lean{MPSTensor.SectorDecomposition.IsBNTCanonicalForm.blockTensor}
+    \leanok
+    \uses{def:sector_decomposition_block_tensor, def:sector_bnt_cf,
+        thm:bnt_normality_from_self_overlap}
+    Let $P$ be a BNT canonical form and let $p\geq1$. Then the blocked
+    sector decomposition $P^{[p]}$ is again a BNT canonical form.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:sector_decomposition_block_tensor_mpv,
+        thm:bnt_normality_from_self_overlap}
+    For each representative $A_j$, normalized self-overlap gives peripheral
+    period one, hence a primitive transfer map. Positive blocking therefore
+    preserves irreducibility and left-canonical normalization. Moreover,
+    \[
+        O_{A_j^{[p]}A_j^{[p]}}(N)
+        =O_{A_jA_j}(Np)\longrightarrow1.
+    \]
+    Concatenation gives a bijection between blocked words of length $N$ and
+    original words of length $Np$. It carries the family of blocked MPV states
+    to the original family at length $Np$, so eventual linear independence is
+    preserved. If two distinct blocked representatives were gauge-phase
+    equivalent, their MPV states would be proportional at every length,
+    contradicting this linear independence. Finally,
+    $|\mu_{j,q}^p|=|\mu_{j,q}|^p\leq1$, and a unit-modulus weight remains of
+    unit modulus after taking its $p$-th power.
+\end{proof}
+
 \begin{theorem}[Common exact quantum-Wielandt length for BNT representatives]
     \label{thm:bnt_representatives_exact_total_dimension_pow_four}
     \lean{MPSTensor.IsBNTCanonicalForm.basis_isNBlkInjective_totalDim_pow_four}

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1149,9 +1149,9 @@ single family.
     \]
 \end{theorem}
 
-\begin{theorem}[Normality from normalized self-overlap]
-    \label{thm:bnt_normality_from_self_overlap}
-    \lean{MPSTensor.isNormal_of_irreducible_leftCanonical_selfOverlap_tendsto_one}
+\begin{theorem}[Primitivity and normality from normalized self-overlap]
+    \label{thm:bnt_primitivity_normality_from_self_overlap}
+    \lean{MPSTensor.isPrimitive_and_isNormal_of_irreducible_leftCanonical_selfOverlap_tendsto_one}
     \leanok
     \uses{def:irreducible_tensor, def:mpv_overlap, def:normal,
         thm:bnt_periodic_self_overlap_tendsto, thm:normal_tp_primitive_irred}
@@ -1160,7 +1160,7 @@ single family.
     \[
         O_{AA}(N)\longrightarrow1,
     \]
-    then $A$ is normal.
+    then the transfer map of $A$ is primitive and $A$ is normal.
 \end{theorem}
 
 \begin{proof}
@@ -1176,12 +1176,27 @@ single family.
     normality.
 \end{proof}
 
+\begin{corollary}[Normality from normalized self-overlap]
+    \label{thm:bnt_normality_from_self_overlap}
+    \lean{MPSTensor.isNormal_of_irreducible_leftCanonical_selfOverlap_tendsto_one}
+    \leanok
+    \uses{thm:bnt_primitivity_normality_from_self_overlap}
+    Let $A$ be an irreducible left-canonical tensor of positive bond dimension.
+    If $O_{AA}(N)\to1$, then $A$ is normal.
+\end{corollary}
+
+\begin{proof}
+    \leanok
+    This is the normality conclusion of
+    Theorem~\ref{thm:bnt_primitivity_normality_from_self_overlap}.
+\end{proof}
+
 \begin{theorem}[Positive blocking preserves BNT canonical form]
     \label{thm:sector_bnt_cf_block_tensor}
     \lean{MPSTensor.SectorDecomposition.IsBNTCanonicalForm.blockTensor}
     \leanok
     \uses{def:sector_decomposition_block_tensor, def:sector_bnt_cf,
-        thm:bnt_normality_from_self_overlap}
+        thm:bnt_primitivity_normality_from_self_overlap}
     Let $P$ be a BNT canonical form and let $p\geq1$. Then the blocked
     sector decomposition $P^{[p]}$ is again a BNT canonical form.
 \end{theorem}
@@ -1189,7 +1204,7 @@ single family.
 \begin{proof}
     \leanok
     \uses{thm:sector_decomposition_block_tensor_mpv,
-        thm:bnt_normality_from_self_overlap}
+        thm:bnt_primitivity_normality_from_self_overlap}
     For each representative $A_j$, normalized self-overlap gives peripheral
     period one, hence a primitive transfer map. Positive blocking therefore
     preserves irreducibility and left-canonical normalization. Moreover,
@@ -1197,12 +1212,23 @@ single family.
         O_{A_j^{[p]}A_j^{[p]}}(N)
         =O_{A_jA_j}(Np)\longrightarrow1.
     \]
-    Concatenation gives a bijection between blocked words of length $N$ and
-    original words of length $Np$. It carries the family of blocked MPV states
-    to the original family at length $Np$, so eventual linear independence is
-    preserved. If two distinct blocked representatives were gauge-phase
-    equivalent, their MPV states would be proportional at every length,
-    contradicting this linear independence. Finally,
+    Let $F_N$ be the linear isomorphism induced by concatenating blocked words,
+    from the blocked configuration space at length $N$ to the original one at
+    length $Np$. For every representative,
+    \[
+        F_N\ket{V^{(N)}(A_j^{[p]})}
+        =\ket{V^{(Np)}(A_j)}.
+    \]
+    Hence eventual linear independence is preserved. If two blocked
+    representatives were gauge-phase equivalent, then for some nonzero
+    $\zeta$ and every $N$,
+    \[
+        \ket{V^{(N)}(A_k^{[p]})}
+        =\zeta^N\ket{V^{(N)}(A_j^{[p]})}.
+    \]
+    Writing these two vectors as $f_k$ and $f_j$ gives
+    $1\cdot f_k=\zeta^N\cdot f_j$ in an eventually linearly independent
+    family, and therefore $k=j$. Finally,
     $|\mu_{j,q}^p|=|\mu_{j,q}|^p\leq1$, and a unit-modulus weight remains of
     unit modulus after taking its $p$-th power.
 \end{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -137,6 +137,30 @@ physical indices, as in
     \cite[Theorem~4.9, lines~851--856]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
+\begin{lemma}[Two-site blocking preserves horizontal canonical form]
+    \label{lem:mpdo_horizontal_cf_block_two}
+    \lean{MPOTensor.IsHorizontalCF.blockTwo}
+    \leanok
+    \uses{def:horizontal_cf_mpdo, def:mpdo_two_site_blocking}
+    If an MPO tensor $K$ is in horizontal canonical form, then its two-site
+    blocking $K^{[2]}$ is again in horizontal canonical form.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Block every normal representative in the horizontal sector decomposition
+    by two sites and square each copy weight.  Positive blocking preserves
+    irreducibility, left-canonical normalization, normalized self-overlap,
+    eventual linear independence of the representative states, and
+    inequivalence of distinct representatives.  Hence the blocked sector
+    decomposition is again a BNT canonical form.  The canonical bijection
+    between a pair of ket--bra indices and a length-two word in the doubled
+    alphabet only relabels the physical basis.  Finally, word evaluation
+    shows that the original block-diagonal virtual gauge conjugates each
+    blocked representative as well.  Thus this blocked decomposition and the
+    same copy gauges witness horizontal canonical form for $K^{[2]}$.
+\end{proof}
+
 \begin{definition}[Four-site physical closure]
     \label{def:mpdo_four_site_physical_closure}
     \lean{finFourArrowEquiv, MPOTensor.physClose4}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -141,7 +141,8 @@ physical indices, as in
     \label{lem:mpdo_horizontal_cf_block_two}
     \lean{MPOTensor.IsHorizontalCF.blockTwo}
     \leanok
-    \uses{def:horizontal_cf_mpdo, def:mpdo_two_site_blocking}
+    \uses{def:horizontal_cf_mpdo, def:mpdo_two_site_blocking,
+        thm:sector_bnt_cf_block_tensor}
     If an MPO tensor $K$ is in horizontal canonical form, then its two-site
     blocking $K^{[2]}$ is again in horizontal canonical form.
 \end{lemma}
@@ -150,15 +151,28 @@ physical indices, as in
     \leanok
     Block every normal representative in the horizontal sector decomposition
     by two sites and square each copy weight.  Positive blocking preserves
-    irreducibility, left-canonical normalization, normalized self-overlap,
-    eventual linear independence of the representative states, and
-    inequivalence of distinct representatives.  Hence the blocked sector
-    decomposition is again a BNT canonical form.  The canonical bijection
-    between a pair of ket--bra indices and a length-two word in the doubled
-    alphabet only relabels the physical basis.  Finally, word evaluation
-    shows that the original block-diagonal virtual gauge conjugates each
-    blocked representative as well.  Thus this blocked decomposition and the
-    same copy gauges witness horizontal canonical form for $K^{[2]}$.
+    irreducibility, left-canonical normalization, eventual linear
+    independence of the representative states, and inequivalence of distinct
+    representatives. Normalized self-overlap is preserved by
+    \[
+        O_{A_j^{[2]}A_j^{[2]}}(N)=O_{A_jA_j}(2N)\longrightarrow1.
+    \]
+    Hence the blocked sector decomposition is again a BNT canonical form. If
+    $\varphi$ is the canonical bijection between a pair of ket--bra indices
+    and a length-two word in the doubled alphabet, then
+    \[
+        (K^{[2]})^{\mathrm{MPS}}
+        =\varphi^*\!\left(\operatorname{block}_2(K^{\mathrm{MPS}})\right).
+    \]
+    Thus $\varphi$ only relabels the physical basis. Finally, if $X$ is the
+    original block-diagonal virtual gauge and $S$ its sector tensor, word
+    evaluation gives
+    \[
+        ((K^{[2]})^{\mathrm{MPS}})_i
+        =X\bigl(\varphi^*(S^{[2]})\bigr)_iX^{-1}.
+    \]
+    Therefore this blocked decomposition and the same copy gauges witness
+    horizontal canonical form for $K^{[2]}$.
 \end{proof}
 
 \begin{definition}[Four-site physical closure]


### PR DESCRIPTION
## Summary

- proves that every positive physical blocking of a BNT sector decomposition is again in BNT canonical form
- identifies the doubled-index MPS tensor of `MPOTensor.blockTwo` with general two-site blocking, up to the canonical ket--bra relabeling
- proves `MPOTensor.IsHorizontalCF.blockTwo` and records it in the blueprint immediately after two-site blocking

## Faithfulness to the source

Appendix C.4 of arXiv:1606.00608, lines 1951--1956, applies Proposition 4.13 both to an MPO tensor and to its two-site blocking while assuming horizontal canonical form only for the original tensor. This pull request supplies precisely the required preservation theorem; it does not add horizontal canonical form of the blocked tensor as a new hypothesis.

The supporting BNT blocking theorem preserves irreducibility, left-canonical normalization, normalized self-overlap, eventual linear independence, distinctness of representatives, and copy-weight normalization. No axiom, `sorry`, or kernel bypass is introduced.

Advances #3949.

## Verification

- `lake build` (9,414 targets)
- `leanblueprint web`
- `leanblueprint checkdecls`
- proof-integrity search over every changed Lean file
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches BNT canonical-form and horizontal MPO blocking on a critical formal proof path; changes are additive proved lemmas with no new axioms, but the blocking proof is substantial and downstream proofs may depend on the new primitivity lemma.
> 
> **Overview**
> Adds the formal infrastructure so **two-site MPO blocking keeps horizontal canonical form**, matching Appendix C.4 of arXiv:1606.00608 (lines 1951–1956).
> 
> **BNT sector blocking:** proves **`IsBNTCanonicalForm.blockTensor`** — for `p > 0`, blocking representatives and powering copy weights preserves the full BNT predicate (irreducibility, left-canonical form, self-overlap → 1, eventual MPV linear independence, distinct representatives, weight bounds). Supporting pieces include sector **`reindexPhysical`**, **`blockTensor_toTensor`**, and transport lemmas for MPV overlap / linear independence under physical reindexing and configuration equivalences.
> 
> **MPO side:** **`toMPSTensor_blockTwo`** identifies `blockTwo` with general two-site blocking plus the canonical ket–bra relabeling (`twoSiteDoubledIndexEquiv`). New **`MPOTensor.IsHorizontalCF.blockTwo`** blocks the horizontal BNT decomposition, reindexes, and reuses the original block-diagonal gauge.
> 
> **Normality:** **`isPrimitive_and_isNormal_of_irreducible_leftCanonical_selfOverlap_tendsto_one`** now also extracts primitive transfer maps (used in blocking); normality remains available as before. Blueprint chapters **ch10_bnt** and **ch21_mpdo_rfp_blocked_rfp** record the new theorems.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 375c7970b0a9db7a82452f3350bf2198dcba444c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->