### PR TITLE
feat(MPS/MPDO): derive two-site vertical canonical form

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -419,6 +419,7 @@ import TNLean.MPS.MPDO.RFPViaTSGlobal
 import TNLean.MPS.MPDO.RFPViaTSSAL
 import TNLean.MPS.MPDO.PhysicalBlocking
 import TNLean.MPS.MPDO.HorizontalBlocking
+import TNLean.MPS.MPDO.TwoSiteVerticalCanonicalForm
 import TNLean.MPS.MPDO.PRFP
 import TNLean.MPS.MPDO.LocalPurificationRFP
 import TNLean.MPS.MPDO.SimpleLocalStructure

--- a/TNLean/MPS/MPDO/PhysicalBlocking.lean
+++ b/TNLean/MPS/MPDO/PhysicalBlocking.lean
@@ -226,6 +226,41 @@ theorem toMPSTensor_blockTwo (M : MPOTensor d D) :
     MPSTensor.blockTensor, twoSiteDoubledIndexEquiv, twoSiteBlockEquiv,
     blockedDoubledIndexEquiv, MPSTensor.wordOfBlock, Equiv.arrowCongr]
 
+/-- The concrete two-site blocking is the general length-two blocking after
+the canonical relabeling of each physical index.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1951--1956. -/
+theorem blockTwo_eq_blockTensor_reindex (M : MPOTensor d D) :
+    blockTwo M = fun i j ↦
+      blockTensor M 2 (twoSiteBlockEquiv d i) (twoSiteBlockEquiv d j) := by
+  funext i j
+  simp [blockTwo, blockTensor, twoSiteBlockEquiv, MPSTensor.wordOfBlock]
+
+/-- Closing a chain of concrete two-site blocks is the same as closing a
+chain of general length-two blocks, after relabeling every physical index.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1951--1956. -/
+theorem mpo_blockTwo_eq_reindex_blockTensor (M : MPOTensor d D) (N : ℕ) :
+    mpo (blockTwo M) N =
+      Matrix.reindex
+        (Equiv.arrowCongr (Equiv.refl (Fin N)) (twoSiteBlockEquiv d)).symm
+        (Equiv.arrowCongr (Equiv.refl (Fin N)) (twoSiteBlockEquiv d)).symm
+        (mpo (blockTensor M 2) N) := by
+  ext σ τ
+  simp only [Matrix.reindex_apply, Matrix.submatrix_apply, mpo_apply,
+    mpoMatrixEntry, evalWord_ofFn]
+  rw [blockTwo_eq_blockTensor_reindex]
+  rfl
+
+/-- Concrete two-site blocking preserves positivity of every closed MPO.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1951--1956. -/
+theorem IsMPDO.blockTwo {M : MPOTensor d D} (hM : IsMPDO M) :
+    IsMPDO (blockTwo M) := by
+  intro N
+  rw [mpo_blockTwo_eq_reindex_blockTensor, Matrix.reindex_apply]
+  exact (hM.blockTensor 2 N).submatrix _
+
 @[simp] lemma blockTwo_apply (M : MPOTensor d D) (i j : Fin (d * d)) :
     blockTwo M i j =
       M (finProdFinEquiv.symm i).1 (finProdFinEquiv.symm j).1 *

--- a/TNLean/MPS/MPDO/TwoSiteVerticalCanonicalForm.lean
+++ b/TNLean/MPS/MPDO/TwoSiteVerticalCanonicalForm.lean
@@ -1,0 +1,32 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.HorizontalBlocking
+import TNLean.MPS.MPDO.VerticalCanonicalForm
+
+/-!
+# Vertical canonical form before and after two-site blocking
+
+For a horizontally canonical matrix product density operator, Proposition 4.13
+applies both to the original tensor and to its two-site physical blocking.
+This is the first step of the two-site comparison in Appendix C.4 of
+arXiv:1606.00608.
+-/
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- A horizontally canonical matrix product density operator and its two-site
+blocking are both in vertical canonical form.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1951--1956. -/
+theorem verticalCF_and_blockTwo_of_horizontalCF (M : MPOTensor d D)
+    (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M) :
+    IsVerticalCF M ∧ IsVerticalCF (blockTwo M) := by
+  exact ⟨verticalCF_of_horizontalCF M hHorizontal hM,
+    verticalCF_of_horizontalCF (blockTwo M) hHorizontal.blockTwo hM.blockTwo⟩
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -137,6 +137,34 @@ physical indices, as in
     \cite[Theorem~4.9, lines~851--856]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
+\begin{theorem}[Concrete two-site blocking as length-two blocking]
+    \label{thm:mpdo_block_two_as_positive_blocking}
+    \lean{MPOTensor.blockTwo_eq_blockTensor_reindex}
+    \lean{MPOTensor.mpo_blockTwo_eq_reindex_blockTensor}
+    \lean{MPOTensor.IsMPDO.blockTwo}
+    \leanok
+    \uses{def:mpdo_positive_physical_blocking,
+        def:mpdo_two_site_blocking, def:mpdo}
+    Let $\varphi:\{0,\ldots,d^2-1\}\to
+    \{0,\ldots,d-1\}^2$ be the canonical bijection.  Then
+    \[
+        \bigl(K^{[2]}\bigr)^{i,j}
+          =\bigl(K^{[L]}\bigr)^{\varphi(i),\varphi(j)}\bigm|_{L=2}.
+    \]
+    Consequently, for every chain length $N$, the closed MPO of $K^{[2]}$
+    is obtained from the closed MPO of the general length-two block by
+    applying $\varphi$ independently at every ket and bra site.  In
+    particular, if $K$ generates matrix product density operators, then so
+    does $K^{[2]}$.
+\end{theorem}
+
+\begin{proof}\leanok
+    Decode a blocked index as an ordered pair.  The two local tensors are
+    then the same product $K^{i_0j_0}K^{i_1j_1}$.  Applying this equality at
+    every site gives the closed-chain reindexing, and simultaneous row and
+    column reindexing preserves positive semidefiniteness.
+\end{proof}
+
 \begin{lemma}[Two-site blocking preserves horizontal canonical form]
     \label{lem:mpdo_horizontal_cf_block_two}
     \lean{MPOTensor.IsHorizontalCF.blockTwo}
@@ -173,6 +201,33 @@ physical indices, as in
     \]
     Therefore this blocked decomposition and the same copy gauges witness
     horizontal canonical form for $K^{[2]}$.
+\end{proof}
+
+\begin{theorem}[One-site and two-site vertical canonical forms]
+    \label{thm:mpdo_vertical_cf_before_after_block_two}
+    \lean{MPOTensor.verticalCF_and_blockTwo_of_horizontalCF}
+    \leanok
+    \uses{thm:vertical_cf_of_horizontal_cf,
+        thm:mpdo_block_two_as_positive_blocking,
+        lem:mpdo_horizontal_cf_block_two}
+    Let $K$ be a horizontally canonical MPO tensor that generates matrix
+    product density operators.  Then both
+    \[
+        K
+        \qquad\text{and}\qquad
+        K^{[2]}
+    \]
+    satisfy the vertical canonical-form conditions of
+    Definition~\ref{def:vertical_cf_mpdo}.
+    This is the initial canonical-form step in
+    \cite[Appendix~C.4, lines~1951--1956]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    The preceding blocking results show that $K^{[2]}$ is horizontally
+    canonical and generates matrix product density operators.  Apply
+    Theorem~\ref{thm:vertical_cf_of_horizontal_cf} first to $K$ and then to
+    $K^{[2]}$.
 \end{proof}
 
 \begin{definition}[Four-site physical closure]


### PR DESCRIPTION
## Summary

- identify the concrete two-site MPO block with the general length-two physical block, including the corresponding closed-chain reindexing
- prove that concrete two-site blocking preserves the MPDO property
- apply horizontal blocking and Proposition 4.13 to place both the original tensor and its two-site block in vertical canonical form
- record the exact Appendix C.4 step in the blueprint

## Source alignment

This formalizes arXiv:1606.00608, Appendix C.4, lines 1951--1956. The blocked MPDO property is derived from the original MPDO hypothesis; it is not introduced as an additional assumption.

## Verification

- `lake env lean TNLean/MPS/MPDO/PhysicalBlocking.lean`
- `lake build TNLean.MPS.MPDO.TwoSiteVerticalCanonicalForm`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- no new `sorry`, `axiom`, or kernel-bypass declaration

Closes one source-order step of #3949.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization of existing MPDO blocking and canonical-form lemmas with no runtime, security, or data-path changes; risk is limited to proof correctness and build/blueprint sync.
> 
> **Overview**
> This PR adds the **blocking bridge** needed for the two-site Appendix C.4 comparison: `blockTwo` is identified with `blockTensor` at \(L=2\) after the canonical index map `twoSiteBlockEquiv`, closed chains reindex accordingly (`mpo_blockTwo_eq_reindex_blockTensor`), and **`IsMPDO.blockTwo`** is derived from existing `IsMPDO.blockTensor` rather than assumed.
> 
> A small module **`TwoSiteVerticalCanonicalForm`** proves that for horizontally canonical MPDO \(K\), both \(K\) and \(K^{[2]}\) satisfy vertical canonical form by applying Proposition 4.13 twice (using existing `IsHorizontalCF.blockTwo` and the new MPDO lemma). The blueprint chapter records the new theorems and wires Lean decls; **`TNLean.lean`** imports the new module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85a9a705a8b4e9afc55d1162a777cc2190f2d1b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->