### PR TITLE
feat(MPS/MPDO): add vertical-sector retractions

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -420,6 +420,7 @@ import TNLean.MPS.MPDO.RFPViaTSSAL
 import TNLean.MPS.MPDO.PhysicalBlocking
 import TNLean.MPS.MPDO.HorizontalBlocking
 import TNLean.MPS.MPDO.TwoSiteVerticalCanonicalForm
+import TNLean.MPS.MPDO.VerticalSectorRetractions
 import TNLean.MPS.MPDO.PRFP
 import TNLean.MPS.MPDO.LocalPurificationRFP
 import TNLean.MPS.MPDO.SimpleLocalStructure

--- a/TNLean/MPS/MPDO/VerticalSectorRetractions.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorRetractions.lean
@@ -1,0 +1,143 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.PartialTrace
+import TNLean.MPS.MPDO.VerticalCF
+
+/-!
+# Normalized vertical-sector embeddings and partial-trace retractions
+
+For a vertical canonical decomposition with multiplicity matrices
+\(\mu_\alpha\), Appendix C.4 introduces the normalized maps
+\[
+  X_\alpha \longmapsto
+    \frac{\mu_\alpha}{\operatorname{tr}(\mu_\alpha)}\otimes X_\alpha
+\]
+and their inverse maps on the displayed weighted sectors.  Partial trace over
+the multiplicity factor gives a canonical extension of the inverse map to the
+full block matrix space.  This file defines these maps and proves the exact
+retraction identity.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Appendix C.4, lines 1957--1971.
+-/
+
+open scoped BigOperators ComplexOrder Matrix
+
+noncomputable section
+
+namespace MPOTensor
+
+/-- The direct product of the simple matrix algebras carried by the vertical
+BNT labels.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1957--1961. -/
+abbrev VerticalSectorAlgebra {g : ℕ} (dim : Fin g → ℕ) :=
+  (α : Fin g) → Matrix (Fin (dim α)) (Fin (dim α)) ℂ
+
+/-- The ambient block space containing
+`span {μ_α} ⊗ M_{dim α}` for every vertical BNT label.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1957--1961. -/
+abbrev VerticalWeightedSectorSpace {g : ℕ} (dim mult : Fin g → ℕ) :=
+  (α : Fin g) → Matrix (Fin (mult α) × Fin (dim α))
+    (Fin (mult α) × Fin (dim α)) ℂ
+
+/-- The trace of the diagonal multiplicity matrix
+`diag (weight α)`, namely `m_α = ∑_q weight α q`.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1955--1971. -/
+def verticalMultiplicityTrace {g : ℕ} {mult : Fin g → ℕ}
+    (weight : (α : Fin g) → Fin (mult α) → ℂ) (α : Fin g) : ℂ :=
+  ∑ q, weight α q
+
+/-- Positivity and nonempty multiplicity imply that the multiplicity trace is
+nonzero.
+
+Source: arXiv:1606.00608, Proposition 4.13, lines 1901--1921, and
+Appendix C.4, lines 1955--1971. -/
+theorem verticalMultiplicityTrace_ne_zero {g : ℕ} {mult : Fin g → ℕ}
+    {weight : (α : Fin g) → Fin (mult α) → ℂ}
+    (hMult : ∀ α, 0 < mult α) (hWeight : ∀ α q, (0 : ℂ) < weight α q)
+    (α : Fin g) : verticalMultiplicityTrace weight α ≠ 0 := by
+  apply ne_of_gt
+  apply Finset.sum_pos'
+  · intro q _
+    exact (hWeight α q).le
+  · let q : Fin (mult α) := ⟨0, hMult α⟩
+    exact ⟨q, Finset.mem_univ q, hWeight α q⟩
+
+/-- The normalized embedding of the vertical sector algebra into the weighted
+sector blocks:
+`X_α ↦ (diag (weight α) / m_α) ⊗ X_α`.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1962--1971. -/
+def normalizedVerticalSectorEmbedding {g : ℕ} (dim mult : Fin g → ℕ)
+    (weight : (α : Fin g) → Fin (mult α) → ℂ) :
+    VerticalSectorAlgebra dim →ₗ[ℂ] VerticalWeightedSectorSpace dim mult where
+  toFun X α := (verticalMultiplicityTrace weight α)⁻¹ •
+    Matrix.kroneckerMap (· * ·) (Matrix.diagonal (weight α)) (X α)
+  map_add' X Y := by
+    funext α i j
+    simp [Matrix.kroneckerMap_apply, mul_add]
+  map_smul' c X := by
+    funext α i j
+    simp [Matrix.kroneckerMap_apply]
+    ring
+
+@[simp]
+theorem normalizedVerticalSectorEmbedding_apply {g : ℕ} (dim mult : Fin g → ℕ)
+    (weight : (α : Fin g) → Fin (mult α) → ℂ)
+    (X : VerticalSectorAlgebra dim) (α : Fin g) :
+    normalizedVerticalSectorEmbedding dim mult weight X α =
+      (verticalMultiplicityTrace weight α)⁻¹ •
+        Matrix.kroneckerMap (· * ·) (Matrix.diagonal (weight α)) (X α) :=
+  rfl
+
+/-- Partial trace over each multiplicity factor, extending the inverse map
+`λ_α μ_α ⊗ X_α ↦ λ_α m_α X_α` from the weighted sectors to
+their ambient block spaces.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1962--1971. -/
+def verticalSectorPartialTrace {g : ℕ} (dim mult : Fin g → ℕ) :
+    VerticalWeightedSectorSpace dim mult →ₗ[ℂ] VerticalSectorAlgebra dim where
+  toFun Y α := Matrix.traceLeft (Y α)
+  map_add' X Y := by
+    funext α
+    exact Matrix.traceLeft_add (X α) (Y α)
+  map_smul' c X := by
+    funext α
+    exact Matrix.traceLeft_smul c (X α)
+
+@[simp]
+theorem verticalSectorPartialTrace_apply {g : ℕ} (dim mult : Fin g → ℕ)
+    (Y : VerticalWeightedSectorSpace dim mult) (α : Fin g) :
+    verticalSectorPartialTrace dim mult Y α = Matrix.traceLeft (Y α) :=
+  rfl
+
+/-- Partial trace is a left inverse of the normalized vertical-sector
+embedding.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1962--1971. -/
+theorem verticalSectorPartialTrace_comp_normalizedVerticalSectorEmbedding
+    {g : ℕ} (dim mult : Fin g → ℕ)
+    (weight : (α : Fin g) → Fin (mult α) → ℂ)
+    (hMult : ∀ α, 0 < mult α) (hWeight : ∀ α q, (0 : ℂ) < weight α q) :
+    (verticalSectorPartialTrace dim mult).comp
+      (normalizedVerticalSectorEmbedding dim mult weight) = LinearMap.id := by
+  apply LinearMap.ext
+  intro X
+  funext α
+  ext i j
+  simp only [LinearMap.comp_apply, verticalSectorPartialTrace_apply,
+    normalizedVerticalSectorEmbedding_apply, Matrix.traceLeft_smul,
+    Matrix.traceLeft_kronecker, Matrix.trace_diagonal, Matrix.smul_apply]
+  rw [show ∑ x, weight α x = verticalMultiplicityTrace weight α by rfl]
+  simp only [smul_eq_mul, LinearMap.id_apply]
+  field_simp [verticalMultiplicityTrace_ne_zero hMult hWeight α]
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/VerticalSectorRetractions.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorRetractions.lean
@@ -41,16 +41,17 @@ Source: arXiv:1606.00608, Appendix C.4, lines 1957--1961. -/
 abbrev VerticalSectorAlgebra {g : ℕ} (dim : Fin g → ℕ) :=
   (α : Fin g) → Matrix (Fin (dim α)) (Fin (dim α)) ℂ
 
-/-- The ambient block space containing
-`span {μ_α} ⊗ M_{dim α}` for every vertical BNT label.
+/-- The ambient block space whose \(\alpha\)-component contains
+\(\operatorname{span}\{\mu_\alpha\}\otimes M_{d_\alpha}\).
 
 Source: arXiv:1606.00608, Appendix C.4, lines 1957--1961. -/
 abbrev VerticalWeightedSectorSpace {g : ℕ} (dim mult : Fin g → ℕ) :=
   (α : Fin g) → Matrix (Fin (mult α) × Fin (dim α))
     (Fin (mult α) × Fin (dim α)) ℂ
 
-/-- The trace of the diagonal multiplicity matrix
-`diag (weight α)`, namely `m_α = ∑_q weight α q`.
+/-- The sum \(m_\alpha=\sum_q\mu_{\alpha,q}\) of the diagonal entries of
+the multiplicity matrix \(\mu_\alpha\), equal to
+\(\operatorname{tr}(\mu_\alpha)\).
 
 Source: arXiv:1606.00608, Appendix C.4, lines 1955--1971. -/
 def verticalMultiplicityTrace {g : ℕ} {mult : Fin g → ℕ}
@@ -74,8 +75,8 @@ theorem verticalMultiplicityTrace_ne_zero {g : ℕ} {mult : Fin g → ℕ}
     exact ⟨q, Finset.mem_univ q, hWeight q⟩
 
 /-- The normalized embedding of the vertical sector algebra into the weighted
-sector blocks:
-`X_α ↦ (diag (weight α) / m_α) ⊗ X_α`.
+sector blocks, mapping
+\(X_\alpha\mapsto m_\alpha^{-1}\mu_\alpha\otimes X_\alpha\) on each sector.
 
 Source: arXiv:1606.00608, Appendix C.4, lines 1962--1971. -/
 def normalizedVerticalSectorEmbedding {g : ℕ} (dim mult : Fin g → ℕ)
@@ -100,9 +101,11 @@ theorem normalizedVerticalSectorEmbedding_apply {g : ℕ} (dim mult : Fin g → 
         Matrix.kroneckerMap (· * ·) (Matrix.diagonal (weight α)) (X α) :=
   rfl
 
-/-- Partial trace over each multiplicity factor, extending the inverse map
-`λ_α μ_α ⊗ X_α ↦ λ_α m_α X_α` from the weighted sectors to
-their ambient block spaces.
+/-- Partial trace over each multiplicity factor, extending the inverse map from
+the weighted sectors to their ambient block spaces. On a weighted sector it
+satisfies
+\(\widetilde R_\mu(\lambda_\alpha\mu_\alpha\otimes X_\alpha)
+=\lambda_\alpha m_\alpha X_\alpha\).
 
 Source: arXiv:1606.00608, Appendix C.4, lines 1962--1971. -/
 def verticalSectorPartialTrace {g : ℕ} (dim mult : Fin g → ℕ) :

--- a/TNLean/MPS/MPDO/VerticalSectorRetractions.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorRetractions.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Channel.PartialTrace
-import TNLean.MPS.MPDO.VerticalCF
+import TNLean.MPS.MPDO.Defs
 
 /-!
 # Normalized vertical-sector embeddings and partial-trace retractions
@@ -18,6 +18,9 @@ For a vertical canonical decomposition with multiplicity matrices
 and their inverse maps on the displayed weighted sectors.  Partial trace over
 the multiplicity factor gives a canonical extension of the inverse map to the
 full block matrix space.  The maps below satisfy the exact retraction identity.
+The construction depends only on the sector dimensions, multiplicities, and
+positive weights, and therefore applies to either vertical canonical
+decomposition in Appendix C.4.
 
 ## References
 
@@ -61,14 +64,14 @@ Source: arXiv:1606.00608, Proposition 4.13, lines 1901--1921, and
 Appendix C.4, lines 1955--1971. -/
 theorem verticalMultiplicityTrace_ne_zero {g : ℕ} {mult : Fin g → ℕ}
     {weight : (α : Fin g) → Fin (mult α) → ℂ}
-    (hMult : ∀ α, 0 < mult α) (hWeight : ∀ α q, (0 : ℂ) < weight α q)
-    (α : Fin g) : verticalMultiplicityTrace weight α ≠ 0 := by
+    (α : Fin g) (hMult : 0 < mult α) (hWeight : ∀ q, (0 : ℂ) < weight α q) :
+    verticalMultiplicityTrace weight α ≠ 0 := by
   apply ne_of_gt
   apply Finset.sum_pos'
   · intro q _
-    exact (hWeight α q).le
-  · let q : Fin (mult α) := ⟨0, hMult α⟩
-    exact ⟨q, Finset.mem_univ q, hWeight α q⟩
+    exact (hWeight q).le
+  · let q : Fin (mult α) := ⟨0, hMult⟩
+    exact ⟨q, Finset.mem_univ q, hWeight q⟩
 
 /-- The normalized embedding of the vertical sector algebra into the weighted
 sector blocks:
@@ -137,6 +140,6 @@ theorem verticalSectorPartialTrace_comp_normalizedVerticalSectorEmbedding
     Matrix.traceLeft_kronecker, Matrix.trace_diagonal, Matrix.smul_apply]
   rw [show ∑ x, weight α x = verticalMultiplicityTrace weight α by rfl]
   simp only [smul_eq_mul, LinearMap.id_apply]
-  field_simp [verticalMultiplicityTrace_ne_zero hMult hWeight α]
+  field_simp [verticalMultiplicityTrace_ne_zero α (hMult α) (hWeight α)]
 
 end MPOTensor

--- a/TNLean/MPS/MPDO/VerticalSectorRetractions.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorRetractions.lean
@@ -17,8 +17,7 @@ For a vertical canonical decomposition with multiplicity matrices
 \]
 and their inverse maps on the displayed weighted sectors.  Partial trace over
 the multiplicity factor gives a canonical extension of the inverse map to the
-full block matrix space.  This file defines these maps and proves the exact
-retraction identity.
+full block matrix space.  The maps below satisfy the exact retraction identity.
 
 ## References
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -236,7 +236,9 @@ physical indices, as in
     \lean{MPOTensor.VerticalWeightedSectorSpace}
     \lean{MPOTensor.verticalMultiplicityTrace}
     \lean{MPOTensor.normalizedVerticalSectorEmbedding}
+    \lean{MPOTensor.normalizedVerticalSectorEmbedding_apply}
     \lean{MPOTensor.verticalSectorPartialTrace}
+    \lean{MPOTensor.verticalSectorPartialTrace_apply}
     \leanok
     Let the vertical sectors be labelled by $\alpha$, with simple matrix
     algebra $M_{d_\alpha}$ and positive diagonal multiplicity matrix
@@ -265,8 +267,6 @@ physical indices, as in
 \begin{lemma}[Retraction of the normalized vertical-sector embedding]
     \label{lem:mpdo_vertical_sector_retraction}
     \lean{MPOTensor.verticalMultiplicityTrace_ne_zero}
-    \lean{MPOTensor.normalizedVerticalSectorEmbedding_apply}
-    \lean{MPOTensor.verticalSectorPartialTrace_apply}
     \lean{MPOTensor.verticalSectorPartialTrace_comp_normalizedVerticalSectorEmbedding}
     \leanok
     \uses{def:mpdo_normalized_vertical_sector_maps}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -230,6 +230,67 @@ physical indices, as in
     $K^{[2]}$.
 \end{proof}
 
+\begin{definition}[Normalized vertical-sector maps]
+    \label{def:mpdo_normalized_vertical_sector_maps}
+    \lean{MPOTensor.VerticalSectorAlgebra}
+    \lean{MPOTensor.VerticalWeightedSectorSpace}
+    \lean{MPOTensor.verticalMultiplicityTrace}
+    \lean{MPOTensor.normalizedVerticalSectorEmbedding}
+    \lean{MPOTensor.verticalSectorPartialTrace}
+    \leanok
+    Let the vertical sectors be labelled by $\alpha$, with simple matrix
+    algebra $M_{d_\alpha}$ and positive diagonal multiplicity matrix
+    $
+        \mu_\alpha=\operatorname{diag}
+        (\mu_{\alpha,0},\ldots,\mu_{\alpha,r_\alpha-1})
+    $.
+    Write $m_\alpha=\operatorname{tr}(\mu_\alpha)$.  The normalized
+    embedding and the left partial trace are
+    \[
+        R_\mu\!\left(\bigoplus_\alpha X_\alpha\right)
+          =\bigoplus_\alpha
+            \frac{\mu_\alpha}{m_\alpha}\otimes X_\alpha,
+        \qquad
+        \widetilde R_\mu\!\left(\bigoplus_\alpha Y_\alpha\right)
+          =\bigoplus_\alpha \operatorname{tr}_{\mathrm{mult}}(Y_\alpha).
+    \]
+    On a weighted sector,
+    $\widetilde R_\mu(\lambda_\alpha\mu_\alpha\otimes X_\alpha)
+      =\lambda_\alpha m_\alpha X_\alpha$.
+    Thus the partial trace is the canonical extension to the full block
+    matrix space of the inverse map displayed in
+    \cite[Appendix~C.4, lines~1957--1971]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{lemma}[Retraction of the normalized vertical-sector embedding]
+    \label{lem:mpdo_vertical_sector_retraction}
+    \lean{MPOTensor.verticalMultiplicityTrace_ne_zero}
+    \lean{MPOTensor.normalizedVerticalSectorEmbedding_apply}
+    \lean{MPOTensor.verticalSectorPartialTrace_apply}
+    \lean{MPOTensor.verticalSectorPartialTrace_comp_normalizedVerticalSectorEmbedding}
+    \leanok
+    \uses{def:mpdo_normalized_vertical_sector_maps}
+    Suppose that every multiplicity space is nonzero and every diagonal
+    entry of $\mu_\alpha$ is positive.  Then $m_\alpha\ne0$ for every
+    $\alpha$, and
+    \[
+        \widetilde R_\mu\circ R_\mu=\operatorname{id}.
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    Positivity of the diagonal entries and nonemptiness of the multiplicity
+    space give
+    $m_\alpha=\sum_q\mu_{\alpha,q}>0$.  The Kronecker-product identity for
+    the left partial trace then gives
+    \[
+      \operatorname{tr}_{\mathrm{mult}}
+        \left(m_\alpha^{-1}\mu_\alpha\otimes X_\alpha\right)
+      =m_\alpha^{-1}\operatorname{tr}(\mu_\alpha)X_\alpha
+      =X_\alpha.
+    \]
+\end{proof}
+
 \begin{definition}[Four-site physical closure]
     \label{def:mpdo_four_site_physical_closure}
     \lean{finFourArrowEquiv, MPOTensor.physClose4}


### PR DESCRIPTION
## Summary

- define the finite direct product of vertical simple matrix algebras and its weighted block-matrix space
- define the normalized embeddings R_mu and the left-partial-trace extensions of the inverse maps from Appendix C.4
- prove that positive nonempty multiplicity sectors have nonzero trace and that the partial trace retracts the normalized embedding
- place the corresponding blueprint entries immediately after the one-site/two-site vertical canonical-form theorem

## Source faithfulness

This formalizes arXiv:1606.00608, Appendix C.4, lines 1957–1971. It does not yet claim the later comparison through the RFP channels T and S. No new axiom, sorry, or proof bypass is introduced.

Progresses #3949.

## Verification

- lake build
- lake exe checkdecls blueprint/lean_decls
- blueprint–Lean synchronization and reader-facing prose checks
- leanblueprint pdf

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New self-contained linear-algebra formalization with no axioms or sorry; limited to MPDO vertical-sector infrastructure and blueprint sync.
> 
> **Overview**
> Adds formalization of **Appendix C.4** normalized vertical-sector maps \(R_\mu\) and \(\widetilde R_\mu\) (arXiv:1606.00608, lines 1957–1971), wired into the public import surface and the blocked-RFP blueprint chapter.
> 
> **Lean:** New `TNLean/MPS/MPDO/VerticalSectorRetractions.lean` defines `VerticalSectorAlgebra`, `VerticalWeightedSectorSpace`, multiplicity trace `verticalMultiplicityTrace`, the ℂ-linear embedding `normalizedVerticalSectorEmbedding` \((\mu_\alpha/m_\alpha)\otimes X_\alpha\), and `verticalSectorPartialTrace` via `Matrix.traceLeft`. Under positive nonempty multiplicities, it proves `verticalMultiplicityTrace_ne_zero` and the retraction identity `verticalSectorPartialTrace ∘ normalizedVerticalSectorEmbedding = id`. `TNLean.lean` imports the module after `TwoSiteVerticalCanonicalForm`.
> 
> **Blueprint:** In `ch21_mpdo_rfp_blocked_rfp.tex`, immediately after the one-/two-site vertical CF theorem, adds Definition (normalized vertical-sector maps) and Lemma (retraction), with `\lean` links to the new declarations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e26e43467f4dfb1c93202c05cea6f4decb6f6443. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->