### PR TITLE
feat(MPS/MPDO): contract vertical CF with bond matrices

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -427,6 +427,7 @@ import TNLean.MPS.MPDO.PhysicalBlocking
 import TNLean.MPS.MPDO.HorizontalBlocking
 import TNLean.MPS.MPDO.TwoSiteVerticalCanonicalForm
 import TNLean.MPS.MPDO.VerticalSectorRetractions
+import TNLean.MPS.MPDO.VerticalBoundaryContraction
 import TNLean.MPS.MPDO.PRFP
 import TNLean.MPS.MPDO.LocalPurificationRFP
 import TNLean.MPS.MPDO.SimpleLocalStructure

--- a/TNLean/MPS/MPDO/VerticalBoundaryContraction.lean
+++ b/TNLean/MPS/MPDO/VerticalBoundaryContraction.lean
@@ -65,8 +65,7 @@ theorem contractBondMatrix_apply (A : MPSTensor (D * D) d)
 /-- Contraction commutes with multiplying every tensor letter on the left and
 right by fixed matrices.
 
-This is the linear contraction of the letterwise vertical canonical-form
-identity in arXiv:1606.00608, Appendix C.4, lines 1955--1979. -/
+Equivalently, if $B_{ab}=L A_{ab}K$, then $B(X)=L A(X)K$. -/
 theorem contractBondMatrix_mul_mul
     (A : MPSTensor (D * D) d) (L : Matrix (Fin R) (Fin d) ℂ)
     (K : Matrix (Fin d) (Fin R) ℂ) (X : Matrix (Fin D) (Fin D) ℂ) :

--- a/TNLean/MPS/MPDO/VerticalBoundaryContraction.lean
+++ b/TNLean/MPS/MPDO/VerticalBoundaryContraction.lean
@@ -27,7 +27,7 @@ form.
 ## References
 
 * Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
-  Appendix C.4, lines 1955--1976.
+  Appendix C.4, lines 1955--1979.
 -/
 
 open scoped BigOperators Matrix
@@ -44,7 +44,7 @@ $X_{ba} A_{ab}$ agrees with the trace convention
 $\operatorname{tr}(A_{ab}X)$.
 
 For a vertical BNT block $M_\alpha$, this is the operator denoted
-$M_\alpha(X)$ in arXiv:1606.00608, Appendix C.4, lines 1955--1976. -/
+$M_\alpha(X)$ in arXiv:1606.00608, Appendix C.4, lines 1955--1979. -/
 def contractBondMatrix (A : MPSTensor (D * D) d) :
     Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ where
   toFun X := ∑ ab : Fin (D * D), X ab.modNat ab.divNat • A ab
@@ -66,7 +66,7 @@ theorem contractBondMatrix_apply (A : MPSTensor (D * D) d)
 right by fixed matrices.
 
 This is the linear contraction of the letterwise vertical canonical-form
-identity in arXiv:1606.00608, Appendix C.4, lines 1955--1976. -/
+identity in arXiv:1606.00608, Appendix C.4, lines 1955--1979. -/
 theorem contractBondMatrix_mul_mul
     (A : MPSTensor (D * D) d) (L : Matrix (Fin R) (Fin d) ℂ)
     (K : Matrix (Fin d) (Fin R) ℂ) (X : Matrix (Fin D) (Fin D) ℂ) :
@@ -80,7 +80,7 @@ the contractions into its blocks, with the same weights.
 
 This is the explicit weighted direct sum
 $\bigoplus_\alpha \mu_\alpha\otimes M_\alpha(X)$ in
-arXiv:1606.00608, Appendix C.4, lines 1955--1976, with the diagonal entries of
+arXiv:1606.00608, Appendix C.4, lines 1955--1979, with the diagonal entries of
 each $\mu_\alpha$ written as repeated blocks. -/
 theorem contractBondMatrix_toTensorFromBlocks {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor (D * D) (dim k))
@@ -103,7 +103,7 @@ variable {d D R : ℕ}
 one-site physical closure.
 
 Source: arXiv:1606.00608, Definition 4.1, line 657, and Appendix C.4,
-lines 1955--1976. -/
+lines 1955--1979. -/
 theorem contractBondMatrix_verticalTensor_eq_physClose1 (M : MPOTensor d D) :
     MPSTensor.contractBondMatrix (verticalTensor M) = physClose1 M := by
   apply LinearMap.ext
@@ -116,7 +116,7 @@ theorem contractBondMatrix_verticalTensor_eq_physClose1 (M : MPOTensor d D) :
 /-- The bond-matrix contraction of an assembled vertical tensor is the
 weighted block diagonal of the contractions into its repeated BNT blocks.
 
-Source: arXiv:1606.00608, Appendix C.4, lines 1955--1976. -/
+Source: arXiv:1606.00608, Appendix C.4, lines 1955--1979. -/
 theorem contractBondMatrix_verticalAssembledTensor {g : ℕ}
     (dim mult : Fin g → ℕ) (weight : (α : Fin g) → Fin (mult α) → ℂ)
     (A : (α : Fin g) → MPSTensor (D * D) (dim α))
@@ -129,12 +129,12 @@ theorem contractBondMatrix_verticalAssembledTensor {g : ℕ}
   exact MPSTensor.contractBondMatrix_toTensorFromBlocks
     (verticalCopyWeights mult weight) (verticalCopyBlocks dim mult A) X
 
-/-- A letterwise vertical canonical-form identity remains valid after
-contracting an arbitrary horizontal bond matrix $X$.  On the left, the
-contraction is the one-site physical closure $M(X)$; on the right, it is the
-weighted direct sum of the sector operators $M_\alpha(X)$.
+/-- A letterwise identity between two vertical tensors remains valid after
+contracting an arbitrary horizontal bond matrix $X$.  For the vertically
+viewed MPO tensor, the contraction on the left is the one-site physical
+closure $M(X)$; the contraction on the right is $B(X)$.
 
-Source: arXiv:1606.00608, Appendix C.4, lines 1955--1976. -/
+Source: arXiv:1606.00608, Appendix C.4, lines 1955--1979. -/
 theorem mul_physClose1_mul_conjTranspose_of_vertical_forward
     (M : MPOTensor d D) (B : MPSTensor (D * D) R)
     (U : Matrix (Fin R) (Fin d) ℂ)
@@ -152,7 +152,7 @@ theorem mul_physClose1_mul_conjTranspose_of_vertical_forward
 written as the explicit weighted direct sum of the sector operators
 $M_\alpha(X)$.
 
-Source: arXiv:1606.00608, Appendix C.4, lines 1955--1976. -/
+Source: arXiv:1606.00608, Appendix C.4, lines 1955--1979. -/
 theorem mul_physClose1_mul_conjTranspose_of_verticalAssembledTensor
     (M : MPOTensor d D) {g : ℕ} (dim mult : Fin g → ℕ)
     (weight : (α : Fin g) → Fin (mult α) → ℂ)
@@ -172,10 +172,10 @@ theorem mul_physClose1_mul_conjTranspose_of_verticalAssembledTensor
     (verticalAssembledTensor dim mult weight A) U hForward X]
   exact contractBondMatrix_verticalAssembledTensor dim mult weight A X
 
-/-- The contracted reverse identity reconstructs the one-site physical
-closure from the weighted vertical sectors.
+/-- A reverse letterwise identity reconstructs the one-site physical closure
+as $U^\dagger B(X)U$ after bond-matrix contraction.
 
-Source: arXiv:1606.00608, Appendix C.4, lines 1955--1976. -/
+Source: arXiv:1606.00608, Appendix C.4, lines 1955--1979. -/
 theorem physClose1_eq_of_vertical_reconstruction
     (M : MPOTensor d D) (B : MPSTensor (D * D) R)
     (U : Matrix (Fin R) (Fin d) ℂ)
@@ -196,7 +196,7 @@ theorem physClose1_eq_of_vertical_reconstruction
 /-- The one-site physical closure reconstructed from an assembled vertical
 canonical form, with its weighted sector direct sum written explicitly.
 
-Source: arXiv:1606.00608, Appendix C.4, lines 1955--1976. -/
+Source: arXiv:1606.00608, Appendix C.4, lines 1955--1979. -/
 theorem physClose1_eq_of_verticalAssembledTensor_reconstruction
     (M : MPOTensor d D) {g : ℕ} (dim mult : Fin g → ℕ)
     (weight : (α : Fin g) → Fin (mult α) → ℂ)

--- a/TNLean/MPS/MPDO/VerticalBoundaryContraction.lean
+++ b/TNLean/MPS/MPDO/VerticalBoundaryContraction.lean
@@ -62,21 +62,11 @@ theorem contractBondMatrix_apply (A : MPSTensor (D * D) d)
       ∑ ab : Fin (D * D), X ab.modNat ab.divNat • A ab :=
   rfl
 
-/-- Contracting a bond matrix commutes with a fixed change of matrix
-coordinates.
+/-- Contraction commutes with multiplying every tensor letter on the left and
+right by fixed matrices.
 
 This is the linear contraction of the letterwise vertical canonical-form
 identity in arXiv:1606.00608, Appendix C.4, lines 1955--1976. -/
-theorem mul_contractBondMatrix_mul_conjTranspose
-    (A : MPSTensor (D * D) d) (U : Matrix (Fin R) (Fin d) ℂ)
-    (X : Matrix (Fin D) (Fin D) ℂ) :
-    U * contractBondMatrix A X * Uᴴ =
-      contractBondMatrix (fun ab ↦ U * A ab * Uᴴ) X := by
-  simp only [contractBondMatrix_apply, Matrix.mul_sum, Matrix.sum_mul,
-    Matrix.mul_smul, Matrix.smul_mul]
-
-/-- Contraction commutes with multiplying every tensor letter on the left and
-right by fixed matrices. -/
 theorem contractBondMatrix_mul_mul
     (A : MPSTensor (D * D) d) (L : Matrix (Fin R) (Fin d) ℂ)
     (K : Matrix (Fin d) (Fin R) ℂ) (X : Matrix (Fin D) (Fin D) ℂ) :
@@ -152,7 +142,7 @@ theorem mul_physClose1_mul_conjTranspose_of_vertical_forward
     (X : Matrix (Fin D) (Fin D) ℂ) :
     U * physClose1 M X * Uᴴ = MPSTensor.contractBondMatrix B X := by
   rw [← contractBondMatrix_verticalTensor_eq_physClose1]
-  rw [MPSTensor.mul_contractBondMatrix_mul_conjTranspose]
+  rw [← MPSTensor.contractBondMatrix_mul_mul]
   apply congrArg (fun C : MPSTensor (D * D) R ↦
     MPSTensor.contractBondMatrix C X)
   funext ab

--- a/TNLean/MPS/MPDO/VerticalBoundaryContraction.lean
+++ b/TNLean/MPS/MPDO/VerticalBoundaryContraction.lean
@@ -1,0 +1,229 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.RFPViaTS
+import TNLean.MPS.MPDO.VerticalCF
+
+/-!
+# Contraction of vertical canonical form with a bond matrix
+
+Appendix C.4 of arXiv:1606.00608 contracts the horizontal bond indices of the
+one-site vertical canonical-form identity against an arbitrary matrix $X$.
+The resulting physical operator is
+
+\[
+  M(X) = U^\dagger
+    \left(\bigoplus_\alpha \mu_\alpha \otimes M_\alpha(X)\right) U.
+\]
+
+This file records the coefficient-level contraction and proves that, for the
+vertically viewed MPO tensor, it is exactly the one-site physical closure from
+Definition 4.1.  It also proves that the contraction commutes with the
+coisometric change of physical coordinates appearing in vertical canonical
+form.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Appendix C.4, lines 1955--1976.
+-/
+
+open scoped BigOperators Matrix
+
+noncomputable section
+
+namespace MPSTensor
+
+variable {d D R : ℕ}
+
+/-- Contract a matrix $X$ into the paired bond index of a tensor whose
+letters are indexed by $\operatorname{Fin}(D^2)$.  The order
+$X_{ba} A_{ab}$ agrees with the trace convention
+$\operatorname{tr}(A_{ab}X)$.
+
+For a vertical BNT block $M_\alpha$, this is the operator denoted
+$M_\alpha(X)$ in arXiv:1606.00608, Appendix C.4, lines 1955--1976. -/
+def contractBondMatrix (A : MPSTensor (D * D) d) :
+    Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ where
+  toFun X := ∑ ab : Fin (D * D), X ab.modNat ab.divNat • A ab
+  map_add' X Y := by
+    ext i j
+    simp [Matrix.sum_apply, Matrix.smul_apply, add_mul, Finset.sum_add_distrib]
+  map_smul' c X := by
+    ext i j
+    simp [Matrix.sum_apply, Matrix.smul_apply, Finset.mul_sum, mul_assoc]
+
+@[simp]
+theorem contractBondMatrix_apply (A : MPSTensor (D * D) d)
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    contractBondMatrix A X =
+      ∑ ab : Fin (D * D), X ab.modNat ab.divNat • A ab :=
+  rfl
+
+/-- Contracting a bond matrix commutes with a fixed change of matrix
+coordinates.
+
+This is the linear contraction of the letterwise vertical canonical-form
+identity in arXiv:1606.00608, Appendix C.4, lines 1955--1976. -/
+theorem mul_contractBondMatrix_mul_conjTranspose
+    (A : MPSTensor (D * D) d) (U : Matrix (Fin R) (Fin d) ℂ)
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    U * contractBondMatrix A X * Uᴴ =
+      contractBondMatrix (fun ab ↦ U * A ab * Uᴴ) X := by
+  simp only [contractBondMatrix_apply, Matrix.mul_sum, Matrix.sum_mul,
+    Matrix.mul_smul, Matrix.smul_mul]
+
+/-- Contraction commutes with multiplying every tensor letter on the left and
+right by fixed matrices. -/
+theorem contractBondMatrix_mul_mul
+    (A : MPSTensor (D * D) d) (L : Matrix (Fin R) (Fin d) ℂ)
+    (K : Matrix (Fin d) (Fin R) ℂ) (X : Matrix (Fin D) (Fin D) ℂ) :
+    contractBondMatrix (fun ab ↦ L * A ab * K) X =
+      L * contractBondMatrix A X * K := by
+  simp only [contractBondMatrix_apply, Matrix.mul_sum, Matrix.sum_mul,
+    Matrix.mul_smul, Matrix.smul_mul]
+
+/-- Contracting a bond matrix into a direct-sum tensor gives the direct sum of
+the contractions into its blocks, with the same weights.
+
+This is the explicit weighted direct sum
+$\bigoplus_\alpha \mu_\alpha\otimes M_\alpha(X)$ in
+arXiv:1606.00608, Appendix C.4, lines 1955--1976, with the diagonal entries of
+each $\mu_\alpha$ written as repeated blocks. -/
+theorem contractBondMatrix_toTensorFromBlocks {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor (D * D) (dim k))
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    contractBondMatrix (toTensorFromBlocks μ A) X =
+      Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv
+        (Matrix.blockDiagonal' fun k ↦ μ k • contractBondMatrix (A k) X) := by
+  ext p q
+  simp [contractBondMatrix, toTensorFromBlocks, Matrix.reindex_apply,
+    Matrix.blockDiagonal'_apply, Matrix.sum_apply, Matrix.smul_apply,
+    Finset.mul_sum, mul_left_comm]
+
+end MPSTensor
+
+namespace MPOTensor
+
+variable {d D R : ℕ}
+
+/-- Contracting a bond matrix into the vertically viewed MPO tensor gives the
+one-site physical closure.
+
+Source: arXiv:1606.00608, Definition 4.1, line 657, and Appendix C.4,
+lines 1955--1976. -/
+theorem contractBondMatrix_verticalTensor_eq_physClose1 (M : MPOTensor d D) :
+    MPSTensor.contractBondMatrix (verticalTensor M) = physClose1 M := by
+  apply LinearMap.ext
+  intro X
+  ext i j
+  rw [MPSTensor.contractBondMatrix_apply, Matrix.sum_apply]
+  rw [← finProdFinEquiv.sum_comp, Fintype.sum_prod_type]
+  simp [Matrix.trace, Matrix.mul_apply, mul_comm]
+
+/-- The bond-matrix contraction of an assembled vertical tensor is the
+weighted block diagonal of the contractions into its repeated BNT blocks.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1955--1976. -/
+theorem contractBondMatrix_verticalAssembledTensor {g : ℕ}
+    (dim mult : Fin g → ℕ) (weight : (α : Fin g) → Fin (mult α) → ℂ)
+    (A : (α : Fin g) → MPSTensor (D * D) (dim α))
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    MPSTensor.contractBondMatrix (verticalAssembledTensor dim mult weight A) X =
+      Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv
+        (Matrix.blockDiagonal' fun q ↦
+          verticalCopyWeights mult weight q •
+            MPSTensor.contractBondMatrix (verticalCopyBlocks dim mult A q) X) := by
+  exact MPSTensor.contractBondMatrix_toTensorFromBlocks
+    (verticalCopyWeights mult weight) (verticalCopyBlocks dim mult A) X
+
+/-- A letterwise vertical canonical-form identity remains valid after
+contracting an arbitrary horizontal bond matrix $X$.  On the left, the
+contraction is the one-site physical closure $M(X)$; on the right, it is the
+weighted direct sum of the sector operators $M_\alpha(X)$.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1955--1976. -/
+theorem mul_physClose1_mul_conjTranspose_of_vertical_forward
+    (M : MPOTensor d D) (B : MPSTensor (D * D) R)
+    (U : Matrix (Fin R) (Fin d) ℂ)
+    (hForward : ∀ ab, U * verticalTensor M ab * Uᴴ = B ab)
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    U * physClose1 M X * Uᴴ = MPSTensor.contractBondMatrix B X := by
+  rw [← contractBondMatrix_verticalTensor_eq_physClose1]
+  rw [MPSTensor.mul_contractBondMatrix_mul_conjTranspose]
+  apply congrArg (fun C : MPSTensor (D * D) R ↦
+    MPSTensor.contractBondMatrix C X)
+  funext ab
+  exact hForward ab
+
+/-- The contracted forward identity in vertical canonical coordinates,
+written as the explicit weighted direct sum of the sector operators
+$M_\alpha(X)$.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1955--1976. -/
+theorem mul_physClose1_mul_conjTranspose_of_verticalAssembledTensor
+    (M : MPOTensor d D) {g : ℕ} (dim mult : Fin g → ℕ)
+    (weight : (α : Fin g) → Fin (mult α) → ℂ)
+    (A : (α : Fin g) → MPSTensor (D * D) (dim α))
+    (U : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g, mult α), verticalCopyDim dim mult q))
+      (Fin d) ℂ)
+    (hForward : ∀ ab,
+      U * verticalTensor M ab * Uᴴ = verticalAssembledTensor dim mult weight A ab)
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    U * physClose1 M X * Uᴴ =
+      Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv
+        (Matrix.blockDiagonal' fun q ↦
+          verticalCopyWeights mult weight q •
+            MPSTensor.contractBondMatrix (verticalCopyBlocks dim mult A q) X) := by
+  rw [mul_physClose1_mul_conjTranspose_of_vertical_forward M
+    (verticalAssembledTensor dim mult weight A) U hForward X]
+  exact contractBondMatrix_verticalAssembledTensor dim mult weight A X
+
+/-- The contracted reverse identity reconstructs the one-site physical
+closure from the weighted vertical sectors.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1955--1976. -/
+theorem physClose1_eq_of_vertical_reconstruction
+    (M : MPOTensor d D) (B : MPSTensor (D * D) R)
+    (U : Matrix (Fin R) (Fin d) ℂ)
+    (hReconstruct : ∀ ab, verticalTensor M ab = Uᴴ * B ab * U)
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    physClose1 M X = Uᴴ * MPSTensor.contractBondMatrix B X * U := by
+  rw [← contractBondMatrix_verticalTensor_eq_physClose1]
+  calc
+    MPSTensor.contractBondMatrix (verticalTensor M) X =
+        MPSTensor.contractBondMatrix (fun ab ↦ Uᴴ * B ab * U) X := by
+      apply congrArg (fun C : MPSTensor (D * D) d ↦
+        MPSTensor.contractBondMatrix C X)
+      funext ab
+      exact hReconstruct ab
+    _ = Uᴴ * MPSTensor.contractBondMatrix B X * U :=
+      MPSTensor.contractBondMatrix_mul_mul B Uᴴ U X
+
+/-- The one-site physical closure reconstructed from an assembled vertical
+canonical form, with its weighted sector direct sum written explicitly.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1955--1976. -/
+theorem physClose1_eq_of_verticalAssembledTensor_reconstruction
+    (M : MPOTensor d D) {g : ℕ} (dim mult : Fin g → ℕ)
+    (weight : (α : Fin g) → Fin (mult α) → ℂ)
+    (A : (α : Fin g) → MPSTensor (D * D) (dim α))
+    (U : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g, mult α), verticalCopyDim dim mult q))
+      (Fin d) ℂ)
+    (hReconstruct : ∀ ab,
+      verticalTensor M ab = Uᴴ * verticalAssembledTensor dim mult weight A ab * U)
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    physClose1 M X = Uᴴ *
+      Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv
+        (Matrix.blockDiagonal' fun q ↦
+          verticalCopyWeights mult weight q •
+            MPSTensor.contractBondMatrix (verticalCopyBlocks dim mult A q) X) * U := by
+  rw [physClose1_eq_of_vertical_reconstruction M
+    (verticalAssembledTensor dim mult weight A) U hReconstruct X]
+  rw [contractBondMatrix_verticalAssembledTensor]
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -308,7 +308,6 @@ physical indices, as in
 
 \begin{lemma}[Contraction of the one-site vertical canonical form]
     \label{lem:mpdo_vertical_bond_matrix_contraction}
-    \lean{MPSTensor.mul_contractBondMatrix_mul_conjTranspose}
     \lean{MPSTensor.contractBondMatrix_mul_mul}
     \lean{MPSTensor.contractBondMatrix_toTensorFromBlocks}
     \lean{MPOTensor.contractBondMatrix_verticalTensor_eq_physClose1}
@@ -343,8 +342,13 @@ physical indices, as in
 \begin{proof}\leanok
     The coefficient of $A_{ab}$ in the trace
     $\operatorname{tr}(M^{ij}X)$ is $X_{ba}$, which proves the first
-    identification.  Multiplication by $U$ and $U^\dagger$ commutes with the
-    finite sum over $(a,b)$.  Finally, contraction commutes with the
+    identification.  Moreover,
+    \[
+        U\left(\sum_{a,b}X_{ba}A_{ab}\right)U^\dagger
+          =\sum_{a,b}X_{ba}\left(UA_{ab}U^\dagger\right).
+    \]
+    Combining this equality with the forward hypothesis gives the contracted
+    canonical-form identity.  Finally, contraction commutes with the
     block-diagonal assembly, leaving its weights unchanged and replacing each
     vertical block $M_\alpha$ by $M_\alpha(X)$.
 \end{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -306,15 +306,68 @@ physical indices, as in
     $A_{ab,ij}=M^{ij}_{ab}$.
 \end{definition}
 
+\begin{lemma}[Contraction of a letterwise forward identity]
+    \label{lem:mpdo_vertical_bond_contraction_forward}
+    \lean{MPOTensor.mul_physClose1_mul_conjTranspose_of_vertical_forward}
+    \leanok
+    \uses{def:phys_close, def:mpdo_vertical_bond_matrix_contraction}
+    Let $B_{ab}$ be an arbitrary vertical tensor.  If
+    \[
+        U\widetilde M_{ab}U^\dagger=B_{ab}
+    \]
+    for every pair $(a,b)$, then, for every bond matrix $X$,
+    \[
+        U M(X)U^\dagger=B(X).
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    By the definition of bond-matrix contraction,
+    \[
+        U M(X)U^\dagger
+          =U\left(\sum_{a,b}X_{ba}\widetilde M_{ab}\right)U^\dagger
+          =\sum_{a,b}X_{ba}
+            \left(U\widetilde M_{ab}U^\dagger\right)
+          =\sum_{a,b}X_{ba}B_{ab}
+          =B(X).
+    \]
+\end{proof}
+
+\begin{lemma}[Contraction of a letterwise reconstruction identity]
+    \label{lem:mpdo_vertical_bond_contraction_reconstruction}
+    \lean{MPOTensor.physClose1_eq_of_vertical_reconstruction}
+    \leanok
+    \uses{def:phys_close, def:mpdo_vertical_bond_matrix_contraction}
+    Let $B_{ab}$ be an arbitrary vertical tensor.  If
+    \[
+        \widetilde M_{ab}=U^\dagger B_{ab}U
+    \]
+    for every pair $(a,b)$, then, for every bond matrix $X$,
+    \[
+        M(X)=U^\dagger B(X)U.
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    Contracting the letterwise identity gives
+    \[
+        M(X)
+          =\sum_{a,b}X_{ba}\widetilde M_{ab}
+          =\sum_{a,b}X_{ba}\left(U^\dagger B_{ab}U\right)
+          =U^\dagger\left(\sum_{a,b}X_{ba}B_{ab}\right)U
+          =U^\dagger B(X)U.
+    \]
+\end{proof}
+
 \begin{lemma}[Contraction of the one-site vertical canonical form]
     \label{lem:mpdo_vertical_bond_matrix_contraction}
-    \lean{MPOTensor.mul_physClose1_mul_conjTranspose_of_vertical_forward}
     \lean{MPOTensor.mul_physClose1_mul_conjTranspose_of_verticalAssembledTensor}
-    \lean{MPOTensor.physClose1_eq_of_vertical_reconstruction}
     \lean{MPOTensor.physClose1_eq_of_verticalAssembledTensor_reconstruction}
     \leanok
     \uses{def:vertical_cf_mpdo, def:phys_close,
-      def:mpdo_vertical_bond_matrix_contraction}
+      def:mpdo_vertical_bond_matrix_contraction,
+      lem:mpdo_vertical_bond_contraction_forward,
+      lem:mpdo_vertical_bond_contraction_reconstruction}
     Suppose that
     \[
         U\widetilde M_{ab}U^\dagger
@@ -336,9 +389,12 @@ physical indices, as in
 \end{lemma}
 
 \begin{proof}\leanok
-    The coefficient of $A_{ab}$ in the trace
-    $\operatorname{tr}(M^{ij}X)$ is $X_{ba}$, which proves the first
-    identification.  Moreover,
+    Since $A(X)_{ij}=\sum_{a,b}X_{ba}A_{ab,ij}$ and
+    $\widetilde M_{ab,ij}=M^{ij}_{ab}$, one has
+    \[
+        M(X)=\sum_{a,b}X_{ba}\widetilde M_{ab}.
+    \]
+    Moreover,
     \[
         U\left(\sum_{a,b}X_{ba}A_{ab}\right)U^\dagger
           =\sum_{a,b}X_{ba}\left(UA_{ab}U^\dagger\right).

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -348,9 +348,11 @@ physical indices, as in
           =\sum_{a,b}X_{ba}\left(UA_{ab}U^\dagger\right).
     \]
     Combining this equality with the forward hypothesis gives the contracted
-    canonical-form identity.  Finally, contraction commutes with the
-    block-diagonal assembly, leaving its weights unchanged and replacing each
-    vertical block $M_\alpha$ by $M_\alpha(X)$.
+    canonical-form identity.  Applied blockwise, the same calculation gives
+    \[
+        \left(\bigoplus_\alpha \mu_\alpha\otimes M_\alpha\right)(X)
+          =\bigoplus_\alpha \mu_\alpha\otimes M_\alpha(X).
+    \]
 \end{proof}
 
 \begin{definition}[Four-site physical closure]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -294,7 +294,6 @@ physical indices, as in
 \begin{definition}[Bond-matrix contraction of a vertical tensor]
     \label{def:mpdo_vertical_bond_matrix_contraction}
     \lean{MPSTensor.contractBondMatrix}
-    \lean{MPSTensor.contractBondMatrix_apply}
     \leanok
     Let $A$ be a tensor whose physical label is a pair $(a,b)$ of horizontal
     bond indices.  For a bond matrix $X$, define
@@ -306,11 +305,91 @@ physical indices, as in
     $A_{ab,ij}=M^{ij}_{ab}$.
 \end{definition}
 
+\begin{lemma}[Contraction under fixed left and right multiplication]
+    \label{lem:mpdo_bond_contraction_composition}
+    \lean{MPSTensor.contractBondMatrix_mul_mul}
+    \leanok
+    \uses{def:mpdo_vertical_bond_matrix_contraction}
+    Let $L$ and $K$ be fixed matrices of compatible sizes.  Then
+    \[
+        \left((a,b)\mapsto L A_{ab}K\right)(X)=L A(X)K.
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    Distributivity of matrix multiplication over finite sums gives
+    \[
+        \sum_{a,b}X_{ba}\left(LA_{ab}K\right)
+          =L\left(\sum_{a,b}X_{ba}A_{ab}\right)K.
+    \]
+\end{proof}
+
+\begin{lemma}[Contraction of a weighted block sum]
+    \label{lem:mpdo_bond_contraction_block_sum}
+    \lean{MPSTensor.contractBondMatrix_toTensorFromBlocks}
+    \leanok
+    \uses{def:mpdo_vertical_bond_matrix_contraction}
+    For a weighted block-diagonal tensor
+    $A=\bigoplus_\alpha\mu_\alpha A_\alpha$, one has
+    \[
+        A(X)=\bigoplus_\alpha\mu_\alpha A_\alpha(X).
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    Each matrix coefficient on the left is a finite sum of coefficients from
+    a single diagonal block.  Interchanging this sum with the bond-index sum
+    gives the stated block-diagonal matrix.
+\end{proof}
+
+\begin{lemma}[Vertical contraction and physical closure]
+    \label{lem:mpdo_vertical_bond_contraction_phys_close}
+    \lean{MPOTensor.contractBondMatrix_verticalTensor_eq_physClose1}
+    \leanok
+    \uses{def:phys_close, def:mpdo_vertical_bond_matrix_contraction}
+    For the vertically viewed tensor
+    $\widetilde M_{ab,ij}=M^{ij}_{ab}$, bond-matrix contraction is the
+    one-site physical closure:
+    \[
+        \widetilde M(X)=M(X).
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    For every pair of physical indices,
+    \[
+        \widetilde M(X)_{ij}
+          =\sum_{a,b}X_{ba}M^{ij}_{ab}
+          =\operatorname{tr}(M^{ij}X)
+          =M(X)_{ij}.
+    \]
+\end{proof}
+
+\begin{lemma}[Contraction of the assembled vertical tensor]
+    \label{lem:mpdo_vertical_bond_contraction_assembled}
+    \lean{MPOTensor.contractBondMatrix_verticalAssembledTensor}
+    \leanok
+    \uses{lem:mpdo_bond_contraction_block_sum}
+    The contraction of the assembled vertical tensor is the weighted block
+    diagonal of the contractions into its repeated sectors:
+    \[
+        \left(\bigoplus_\alpha\mu_\alpha\otimes M_\alpha\right)(X)
+          =\bigoplus_\alpha\mu_\alpha\otimes M_\alpha(X).
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    Apply bond-matrix contraction to the repeated-block expression for the
+    assembled tensor and use the preceding weighted-block identity.
+\end{proof}
+
 \begin{lemma}[Contraction of a letterwise forward identity]
     \label{lem:mpdo_vertical_bond_contraction_forward}
     \lean{MPOTensor.mul_physClose1_mul_conjTranspose_of_vertical_forward}
     \leanok
-    \uses{def:phys_close, def:mpdo_vertical_bond_matrix_contraction}
+    \uses{def:phys_close, def:mpdo_vertical_bond_matrix_contraction,
+      lem:mpdo_bond_contraction_composition,
+      lem:mpdo_vertical_bond_contraction_phys_close}
     Let $B_{ab}$ be an arbitrary vertical tensor.  If
     \[
         U\widetilde M_{ab}U^\dagger=B_{ab}
@@ -337,7 +416,9 @@ physical indices, as in
     \label{lem:mpdo_vertical_bond_contraction_reconstruction}
     \lean{MPOTensor.physClose1_eq_of_vertical_reconstruction}
     \leanok
-    \uses{def:phys_close, def:mpdo_vertical_bond_matrix_contraction}
+    \uses{def:phys_close, def:mpdo_vertical_bond_matrix_contraction,
+      lem:mpdo_bond_contraction_composition,
+      lem:mpdo_vertical_bond_contraction_phys_close}
     Let $B_{ab}$ be an arbitrary vertical tensor.  If
     \[
         \widetilde M_{ab}=U^\dagger B_{ab}U
@@ -367,7 +448,8 @@ physical indices, as in
     \uses{def:vertical_cf_mpdo, def:phys_close,
       def:mpdo_vertical_bond_matrix_contraction,
       lem:mpdo_vertical_bond_contraction_forward,
-      lem:mpdo_vertical_bond_contraction_reconstruction}
+      lem:mpdo_vertical_bond_contraction_reconstruction,
+      lem:mpdo_vertical_bond_contraction_assembled}
     Suppose that
     \[
         U\widetilde M_{ab}U^\dagger
@@ -394,7 +476,8 @@ physical indices, as in
     \[
         M(X)=\sum_{a,b}X_{ba}\widetilde M_{ab}.
     \]
-    Moreover,
+    Distributivity of fixed left and right multiplication over finite sums
+    gives
     \[
         U\left(\sum_{a,b}X_{ba}A_{ab}\right)U^\dagger
           =\sum_{a,b}X_{ba}\left(UA_{ab}U^\dagger\right).

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -291,6 +291,64 @@ physical indices, as in
     \]
 \end{proof}
 
+\begin{definition}[Bond-matrix contraction of a vertical tensor]
+    \label{def:mpdo_vertical_bond_matrix_contraction}
+    \lean{MPSTensor.contractBondMatrix}
+    \lean{MPSTensor.contractBondMatrix_apply}
+    \leanok
+    Let $A$ be a tensor whose physical label is a pair $(a,b)$ of horizontal
+    bond indices.  For a bond matrix $X$, define
+    \[
+        A(X)=\sum_{a,b}X_{ba}A_{ab}.
+    \]
+    The order of the entries of $X$ is chosen so that
+    $A(X)_{ij}=\operatorname{tr}(M^{ij}X)$ when
+    $A_{ab,ij}=M^{ij}_{ab}$.
+\end{definition}
+
+\begin{lemma}[Contraction of the one-site vertical canonical form]
+    \label{lem:mpdo_vertical_bond_matrix_contraction}
+    \lean{MPSTensor.mul_contractBondMatrix_mul_conjTranspose}
+    \lean{MPSTensor.contractBondMatrix_mul_mul}
+    \lean{MPSTensor.contractBondMatrix_toTensorFromBlocks}
+    \lean{MPOTensor.contractBondMatrix_verticalTensor_eq_physClose1}
+    \lean{MPOTensor.contractBondMatrix_verticalAssembledTensor}
+    \lean{MPOTensor.mul_physClose1_mul_conjTranspose_of_vertical_forward}
+    \lean{MPOTensor.mul_physClose1_mul_conjTranspose_of_verticalAssembledTensor}
+    \lean{MPOTensor.physClose1_eq_of_vertical_reconstruction}
+    \lean{MPOTensor.physClose1_eq_of_verticalAssembledTensor_reconstruction}
+    \leanok
+    \uses{def:vertical_cf_mpdo, def:phys_close,
+      def:mpdo_vertical_bond_matrix_contraction}
+    Suppose that
+    \[
+        U\widetilde M_{ab}U^\dagger
+          =\left(\bigoplus_\alpha\mu_\alpha\otimes M_\alpha\right)_{ab}
+    \]
+    is a one-site vertical canonical-form identity.  Contracting against an
+    arbitrary bond matrix $X$ gives
+    \[
+        U M(X)U^\dagger
+          =\bigoplus_\alpha\mu_\alpha\otimes M_\alpha(X).
+    \]
+    If the reverse letterwise identity is also given, then
+    \[
+        M(X)=U^\dagger
+          \left(\bigoplus_\alpha\mu_\alpha\otimes M_\alpha(X)\right)U.
+    \]
+    These are the contracted canonical-form identities used in
+    \cite[Appendix~C.4, lines~1955--1976]{Cirac2016MPDO_arXiv}.
+\end{lemma}
+
+\begin{proof}\leanok
+    The coefficient of $A_{ab}$ in the trace
+    $\operatorname{tr}(M^{ij}X)$ is $X_{ba}$, which proves the first
+    identification.  Multiplication by $U$ and $U^\dagger$ commutes with the
+    finite sum over $(a,b)$.  Finally, contraction commutes with the
+    block-diagonal assembly, leaving its weights unchanged and replacing each
+    vertical block $M_\alpha$ by $M_\alpha(X)$.
+\end{proof}
+
 \begin{definition}[Four-site physical closure]
     \label{def:mpdo_four_site_physical_closure}
     \lean{finFourArrowEquiv, MPOTensor.physClose4}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -337,9 +337,14 @@ physical indices, as in
 \end{lemma}
 
 \begin{proof}\leanok
-    Each matrix coefficient on the left is a finite sum of coefficients from
-    a single diagonal block.  Interchanging this sum with the bond-index sum
-    gives the stated block-diagonal matrix.
+    Since each tensor letter is block diagonal,
+    \[
+        \sum_{a,b}X_{ba}
+          \left(\bigoplus_\alpha\mu_\alpha A_\alpha\right)_{ab}
+          =\bigoplus_\alpha\mu_\alpha
+            \sum_{a,b}X_{ba}(A_\alpha)_{ab}
+          =\bigoplus_\alpha\mu_\alpha A_\alpha(X).
+    \]
 \end{proof}
 
 \begin{lemma}[Vertical contraction and physical closure]
@@ -379,8 +384,12 @@ physical indices, as in
 \end{lemma}
 
 \begin{proof}\leanok
-    Apply bond-matrix contraction to the repeated-block expression for the
-    assembled tensor and use the preceding weighted-block identity.
+    The assembled vertical tensor is the weighted block sum of its repeated
+    sector tensors.  The preceding lemma gives
+    \[
+        \left(\bigoplus_\alpha\mu_\alpha\otimes M_\alpha\right)(X)
+          =\bigoplus_\alpha\mu_\alpha\otimes M_\alpha(X).
+    \]
 \end{proof}
 
 \begin{lemma}[Contraction of a letterwise forward identity]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -376,7 +376,7 @@ physical indices, as in
     \leanok
     \uses{lem:mpdo_bond_contraction_block_sum}
     The contraction of the assembled vertical tensor is the weighted block
-    diagonal of the contractions into its repeated sectors:
+    diagonal of the sector contractions:
     \[
         \left(\bigoplus_\alpha\mu_\alpha\otimes M_\alpha\right)(X)
           =\bigoplus_\alpha\mu_\alpha\otimes M_\alpha(X).
@@ -488,8 +488,9 @@ physical indices, as in
     Distributivity of fixed left and right multiplication over finite sums
     gives
     \[
-        U\left(\sum_{a,b}X_{ba}A_{ab}\right)U^\dagger
-          =\sum_{a,b}X_{ba}\left(UA_{ab}U^\dagger\right).
+        U\left(\sum_{a,b}X_{ba}\widetilde M_{ab}\right)U^\dagger
+          =\sum_{a,b}X_{ba}
+            \left(U\widetilde M_{ab}U^\dagger\right).
     \]
     Substituting the forward hypothesis into this equality gives
     \[
@@ -502,6 +503,20 @@ physical indices, as in
     \[
         \left(\bigoplus_\alpha \mu_\alpha\otimes M_\alpha\right)(X)
           =\bigoplus_\alpha \mu_\alpha\otimes M_\alpha(X).
+    \]
+    If the reverse letterwise identity is given, the same calculation yields
+    \[
+    \begin{aligned}
+        M(X)
+          &=\sum_{a,b}X_{ba}\widetilde M_{ab} \\
+          &=U^\dagger\left(
+              \sum_{a,b}X_{ba}
+              \left(\bigoplus_\alpha\mu_\alpha\otimes M_\alpha\right)_{ab}
+            \right)U \\
+          &=U^\dagger\left(
+              \bigoplus_\alpha\mu_\alpha\otimes M_\alpha(X)
+            \right)U.
+    \end{aligned}
     \]
 \end{proof}
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -384,8 +384,8 @@ physical indices, as in
 \end{lemma}
 
 \begin{proof}\leanok
-    The assembled vertical tensor is the weighted block sum of its repeated
-    sector tensors.  The preceding lemma gives
+    Applying the preceding lemma to the block form
+    $\bigoplus_\alpha\mu_\alpha\otimes M_\alpha$ of the assembled tensor gives
     \[
         \left(\bigoplus_\alpha\mu_\alpha\otimes M_\alpha\right)(X)
           =\bigoplus_\alpha\mu_\alpha\otimes M_\alpha(X).

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -308,10 +308,6 @@ physical indices, as in
 
 \begin{lemma}[Contraction of the one-site vertical canonical form]
     \label{lem:mpdo_vertical_bond_matrix_contraction}
-    \lean{MPSTensor.contractBondMatrix_mul_mul}
-    \lean{MPSTensor.contractBondMatrix_toTensorFromBlocks}
-    \lean{MPOTensor.contractBondMatrix_verticalTensor_eq_physClose1}
-    \lean{MPOTensor.contractBondMatrix_verticalAssembledTensor}
     \lean{MPOTensor.mul_physClose1_mul_conjTranspose_of_vertical_forward}
     \lean{MPOTensor.mul_physClose1_mul_conjTranspose_of_verticalAssembledTensor}
     \lean{MPOTensor.physClose1_eq_of_vertical_reconstruction}
@@ -336,7 +332,7 @@ physical indices, as in
           \left(\bigoplus_\alpha\mu_\alpha\otimes M_\alpha(X)\right)U.
     \]
     These are the contracted canonical-form identities used in
-    \cite[Appendix~C.4, lines~1955--1976]{Cirac2016MPDO_arXiv}.
+    \cite[Appendix~C.4, lines~1955--1979]{Cirac2016MPDO_arXiv}.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -347,8 +343,14 @@ physical indices, as in
         U\left(\sum_{a,b}X_{ba}A_{ab}\right)U^\dagger
           =\sum_{a,b}X_{ba}\left(UA_{ab}U^\dagger\right).
     \]
-    Combining this equality with the forward hypothesis gives the contracted
-    canonical-form identity.  Applied blockwise, the same calculation gives
+    Substituting the forward hypothesis into this equality gives
+    \[
+        U M(X)U^\dagger
+          =\sum_{a,b}X_{ba}
+            \left(\bigoplus_\alpha\mu_\alpha\otimes M_\alpha\right)_{ab}
+          =\left(\bigoplus_\alpha\mu_\alpha\otimes M_\alpha\right)(X).
+    \]
+    Applied blockwise, the same calculation gives
     \[
         \left(\bigoplus_\alpha \mu_\alpha\otimes M_\alpha\right)(X)
           =\bigoplus_\alpha \mu_\alpha\otimes M_\alpha(X).


### PR DESCRIPTION
## Summary

- define contraction of a horizontal bond matrix into a vertically viewed tensor;
- identify this contraction with the one-site physical closure of an MPO tensor;
- prove that contraction commutes with the vertical coisometry and with weighted block-diagonal assembly;
- derive both the forward and reconstruction identities for the explicit vertical canonical-form sectors;
- record the result in the blueprint immediately after the normalized vertical-sector retraction.

The statements follow arXiv:1606.00608, Appendix C.4, lines 1955--1979. No hypothesis beyond the corresponding letterwise canonical-form identity is introduced.

## Verification

- full lake build: 9417 jobs passed;
- blueprint declaration check passed;
- blueprint/Lean synchronization passed;
- reader-facing prose check passed;
- leanblueprint PDF build passed (582 pages), with the changed pages rendered and inspected;
- axiom audit found only propext, Classical.choice, and Quot.sound.

Advances #3949.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formalization and documentation on the MPDO vertical-CF track; no changes to runtime behavior or existing theorem interfaces beyond new imports.
> 
> **Overview**
> Adds **`MPSTensor.contractBondMatrix`** and formal proofs that contracting a horizontal bond matrix into the vertically viewed MPO tensor is **`physClose1`**, and that this operation commutes with left/right multiplication and with weighted block-diagonal assembly.
> 
> Derives the **forward and reconstruction** identities for one-site vertical canonical form: \(U M(X) U^\dagger\) equals the weighted direct sum \(\bigoplus_\alpha \mu_\alpha \otimes M_\alpha(X)\) (and the conjugate reconstruction), matching arXiv:1606.00608 Appendix C.4. Wires the module into the root import list and extends **blueprint ch21** with matching definitions, lemmas, and `\lean` links immediately after the normalized vertical-sector retraction material.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc4d98ae0eb6c3469e66a059de951c8f68167c0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

