### PR TITLE
feat(MPS/MPDO): prove GSNNCH sector-sum positivity and shift invariance

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -69,6 +69,7 @@ import TNLean.Analysis.ProjectionGeometry
 -- Layer 0b: Hermitian functional calculus for finite-dimensional matrices
 import TNLean.Analysis.TraceCFC
 import TNLean.Analysis.MatrixSqrt
+import TNLean.Analysis.PosSemidefCommute
 import TNLean.Analysis.CfcConjugation
 import TNLean.Analysis.MatrixOrderTopology
 import TNLean.Analysis.CfcLogAdditive
@@ -509,6 +510,7 @@ import TNLean.MPS.MPDO.CompleteZipperFusionPentagon
 import TNLean.MPS.MPDO.BlockedCompleteZipper
 import TNLean.MPS.MPDO.CommutingForm
 import TNLean.MPS.MPDO.CommutingFormBridge
+import TNLean.MPS.MPDO.GSNNCHSectorSum
 import TNLean.MPS.MPDO.BlockedRFPConstruction
 
 -- MPS examples

--- a/TNLean/Analysis/PosSemidefCommute.lean
+++ b/TNLean/Analysis/PosSemidefCommute.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Commute
+import Mathlib.Analysis.Matrix.Order
+
+/-!
+# Products of commuting positive-semidefinite matrices
+
+A product of two commuting positive-semidefinite matrices is positive
+semidefinite, and so is the ordered product of any list of pairwise commuting
+positive-semidefinite matrices.
+
+## Main results
+
+* `Matrix.PosSemidef.mul_of_commute`: the product of two commuting
+  positive-semidefinite matrices is positive semidefinite.
+* `Matrix.posSemidef_list_prod`: the product of a list of pairwise commuting
+  positive-semidefinite matrices is positive semidefinite.
+-/
+
+open scoped ComplexOrder MatrixOrder
+
+namespace Matrix
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- The product of two commuting positive-semidefinite matrices is positive
+semidefinite: writing `A = √A * √A`, the square root commutes with `B` as
+well, so `A * B = (√A)ᴴ * B * √A` is a conjugate of `B`. -/
+theorem PosSemidef.mul_of_commute {A B : Matrix n n ℂ} (hA : A.PosSemidef)
+    (hB : B.PosSemidef) (hAB : A * B = B * A) : (A * B).PosSemidef := by
+  have hcomm : Commute (CFC.sqrt A) B :=
+    Commute.cfcₙ_nnreal ((commute_iff_eq A B).mpr hAB) NNReal.sqrt
+  have hpsd : (CFC.sqrt A).PosSemidef := nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg A)
+  have key : (CFC.sqrt A)ᴴ * B * CFC.sqrt A = A * B :=
+    calc (CFC.sqrt A)ᴴ * B * CFC.sqrt A
+        = CFC.sqrt A * B * CFC.sqrt A := by rw [hpsd.isHermitian.eq]
+      _ = B * CFC.sqrt A * CFC.sqrt A := by rw [hcomm.eq]
+      _ = B * (CFC.sqrt A * CFC.sqrt A) := by rw [mul_assoc]
+      _ = B * A := by rw [CFC.sqrt_mul_sqrt_self A hA.nonneg]
+      _ = A * B := hAB.symm
+  rw [← key]
+  exact hB.conjTranspose_mul_mul_same (CFC.sqrt A)
+
+/-- The product of a list of pairwise commuting positive-semidefinite matrices
+is positive semidefinite. -/
+theorem posSemidef_list_prod {l : List (Matrix n n ℂ)}
+    (hpos : ∀ A ∈ l, A.PosSemidef)
+    (hcomm : l.Pairwise fun A B => A * B = B * A) : l.prod.PosSemidef := by
+  induction l with
+  | nil =>
+    rw [List.prod_nil]
+    exact PosSemidef.one
+  | cons A l ih =>
+    rw [List.pairwise_cons] at hcomm
+    rw [List.prod_cons]
+    have hA : A.PosSemidef := hpos A (by simp)
+    have hl : l.prod.PosSemidef :=
+      ih (fun B hB => hpos B (List.mem_cons_of_mem A hB)) hcomm.2
+    exact hA.mul_of_commute hl (Commute.list_prod_right l A fun C hC => hcomm.1 C hC).eq
+
+end Matrix

--- a/TNLean/Analysis/PosSemidefCommute.lean
+++ b/TNLean/Analysis/PosSemidefCommute.lean
@@ -27,8 +27,9 @@ namespace Matrix
 variable {n : Type*} [Fintype n] [DecidableEq n]
 
 /-- The product of two commuting positive-semidefinite matrices is positive
-semidefinite: writing `A = √A * √A`, the square root commutes with `B` as
-well, so `A * B = (√A)ᴴ * B * √A` is a conjugate of `B`. -/
+semidefinite: writing $A = \sqrt{A}\,\sqrt{A}$, the square root commutes with
+$B$ as well, so $A B = \sqrt{A}^{\dagger}\,B\,\sqrt{A}$ is a conjugate of
+$B$. -/
 theorem PosSemidef.mul_of_commute {A B : Matrix n n ℂ} (hA : A.PosSemidef)
     (hB : B.PosSemidef) (hAB : A * B = B * A) : (A * B).PosSemidef := by
   have hcomm : Commute (CFC.sqrt A) B :=

--- a/TNLean/Analysis/PosSemidefCommute.lean
+++ b/TNLean/Analysis/PosSemidefCommute.lean
@@ -1,8 +1,8 @@
 /-
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
 -/
-import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Commute
 import Mathlib.Analysis.Matrix.Order
 
 /-!
@@ -24,20 +24,21 @@ open scoped ComplexOrder MatrixOrder
 
 namespace Matrix
 
-variable {n : Type*} [Fintype n] [DecidableEq n]
+variable {n : Type*} [Fintype n]
 
 /-- The product of two commuting positive-semidefinite matrices is positive
 semidefinite: the matrix form of the fact that the product of commuting
 nonnegative elements of a C⋆-algebra is nonnegative. -/
 theorem PosSemidef.mul_of_commute {A B : Matrix n n ℂ} (hA : A.PosSemidef)
-    (hB : B.PosSemidef) (hAB : A * B = B * A) : (A * B).PosSemidef :=
-  nonneg_iff_posSemidef.mp
-    (Commute.mul_nonneg (nonneg_iff_posSemidef.mpr hA) (nonneg_iff_posSemidef.mpr hB)
-      ((commute_iff_eq A B).mpr hAB))
+    (hB : B.PosSemidef) (hAB : A * B = B * A) : (A * B).PosSemidef := by
+  classical
+  exact nonneg_iff_posSemidef.mp <|
+    Commute.mul_nonneg (nonneg_iff_posSemidef.mpr hA) (nonneg_iff_posSemidef.mpr hB)
+      ((commute_iff_eq A B).mpr hAB)
 
 /-- The product of a list of pairwise commuting positive-semidefinite matrices
 is positive semidefinite. -/
-theorem posSemidef_list_prod {l : List (Matrix n n ℂ)}
+theorem posSemidef_list_prod [DecidableEq n] {l : List (Matrix n n ℂ)}
     (hpos : ∀ A ∈ l, A.PosSemidef)
     (hcomm : l.Pairwise fun A B => A * B = B * A) : l.prod.PosSemidef := by
   induction l with

--- a/TNLean/Analysis/PosSemidefCommute.lean
+++ b/TNLean/Analysis/PosSemidefCommute.lean
@@ -27,23 +27,13 @@ namespace Matrix
 variable {n : Type*} [Fintype n] [DecidableEq n]
 
 /-- The product of two commuting positive-semidefinite matrices is positive
-semidefinite: writing $A = \sqrt{A}\,\sqrt{A}$, the square root commutes with
-$B$ as well, so $A B = \sqrt{A}^{\dagger}\,B\,\sqrt{A}$ is a conjugate of
-$B$. -/
+semidefinite: the matrix form of the fact that the product of commuting
+nonnegative elements of a C⋆-algebra is nonnegative. -/
 theorem PosSemidef.mul_of_commute {A B : Matrix n n ℂ} (hA : A.PosSemidef)
-    (hB : B.PosSemidef) (hAB : A * B = B * A) : (A * B).PosSemidef := by
-  have hcomm : Commute (CFC.sqrt A) B :=
-    Commute.cfcₙ_nnreal ((commute_iff_eq A B).mpr hAB) NNReal.sqrt
-  have hpsd : (CFC.sqrt A).PosSemidef := nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg A)
-  have key : (CFC.sqrt A)ᴴ * B * CFC.sqrt A = A * B :=
-    calc (CFC.sqrt A)ᴴ * B * CFC.sqrt A
-        = CFC.sqrt A * B * CFC.sqrt A := by rw [hpsd.isHermitian.eq]
-      _ = B * CFC.sqrt A * CFC.sqrt A := by rw [hcomm.eq]
-      _ = B * (CFC.sqrt A * CFC.sqrt A) := by rw [mul_assoc]
-      _ = B * A := by rw [CFC.sqrt_mul_sqrt_self A hA.nonneg]
-      _ = A * B := hAB.symm
-  rw [← key]
-  exact hB.conjTranspose_mul_mul_same (CFC.sqrt A)
+    (hB : B.PosSemidef) (hAB : A * B = B * A) : (A * B).PosSemidef :=
+  nonneg_iff_posSemidef.mp
+    (Commute.mul_nonneg (nonneg_iff_posSemidef.mpr hA) (nonneg_iff_posSemidef.mpr hB)
+      ((commute_iff_eq A B).mpr hAB))
 
 /-- The product of a list of pairwise commuting positive-semidefinite matrices
 is positive semidefinite. -/

--- a/TNLean/MPS/MPDO/GSNNCHSectorSum.lean
+++ b/TNLean/MPS/MPDO/GSNNCHSectorSum.lean
@@ -308,9 +308,9 @@ theorem sectorProduct_submatrix_rotateConfig (data : GSNNCHData d N)
 configurations by the cyclic shift leaves
 $\bigoplus_x n_x \prod_j \tau_j(B^{(x)})$ unchanged.
 
-Source: arXiv:1606.00608, lines 838--842: the density operator of equation
-`rhoNComm` is translationally invariant, where spin `N+1` is identified with
-the first. -/
+Source: arXiv:1606.00608, lines 838--842: the density operator is
+translationally invariant on the periodic chain, where spin $N+1$ is
+identified with the first. -/
 theorem unnormalizedState_submatrix_rotateConfig (data : GSNNCHData d N) :
     data.unnormalizedState.submatrix (rotateConfig N d) (rotateConfig N d)
       = data.unnormalizedState := by

--- a/TNLean/MPS/MPDO/GSNNCHSectorSum.lean
+++ b/TNLean/MPS/MPDO/GSNNCHSectorSum.lean
@@ -28,9 +28,9 @@ finite-chain operator $\bigoplus_x n_x \prod_j \tau_j(B^{(x)})$ of equation
 Consequently, an injective tensor satisfying the saturated area law generates
 Gibbs states of a nearest-neighbor commuting Hamiltonian: the commuting
 product form of Proposition C.8 (arXiv:1606.00608, Appendix C.2, lines
-1569--1594) together with the density normalization of Definition 4.8. For an
-injective tensor the basis of normal tensors has a single element, so the
-one-sector form is the full source conclusion in this case.
+1569--1594) together with the density normalization of Definition 4.8. The
+one-sector form is the commuting product form in which Proposition C.8 states
+its conclusion for an injective tensor.
 
 This completes the first step of the elimination plan in
 `docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex`. Constructing the
@@ -41,12 +41,15 @@ basis of normal tensors remains open; see the same note.
 
 * `MPOTensor.embedLocalOperator_submatrix_rotateConfig`
 * `MPOTensor.embedLocalOperator_posSemidef`
+* `MPOTensor.GSNNCHData.bondAt_posSemidef`
 * `MPOTensor.GSNNCHData.bondAt_comm`
 * `MPOTensor.GSNNCHData.sectorProduct_posSemidef`
 * `MPOTensor.GSNNCHData.unnormalizedState_posSemidef`
+* `MPOTensor.GSNNCHData.sectorProduct_submatrix_rotateConfig`
 * `MPOTensor.GSNNCHData.unnormalizedState_submatrix_rotateConfig`
 * `MPOTensor.HasGSNNCHFormAt.posSemidef`
 * `MPOTensor.HasGSNNCHFormAt.submatrix_rotateConfig`
+* `MPOTensor.hasGSNNCHFormAt_normalizedMPO`
 * `MPOTensor.isGSNNCH_of_hasGSNNCHForm`
 * `MPOTensor.isGSNNCH_of_isInjective_of_isSAL`
 
@@ -386,8 +389,9 @@ theorem isGSNNCH_of_hasGSNNCHForm {M : MPOTensor d D}
 /-- **An injective tensor with the saturated area law generates Gibbs states
 of a nearest-neighbor commuting Hamiltonian.** The commuting product form is
 Proposition C.8; positivity and normalization then give the density-operator
-form of Definition 4.8. For an injective tensor the basis of normal tensors
-has one element, so the one-sector form is the full source conclusion.
+form of Definition 4.8, realized through one sector. The one-sector form is
+the commuting product form in which Proposition C.8 states its conclusion for
+an injective tensor.
 
 Source: arXiv:1606.00608, Appendix C.2, Proposition C.8, lines 1569--1594,
 and Definition 4.8, lines 829--850. -/

--- a/TNLean/MPS/MPDO/GSNNCHSectorSum.lean
+++ b/TNLean/MPS/MPDO/GSNNCHSectorSum.lean
@@ -1,0 +1,401 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Analysis.PosSemidefCommute
+import TNLean.MPS.MPDO.InverseMapActiveSectorRecurrence
+
+/-!
+# Positivity and translation invariance of the GSNNCH sector sum
+
+For the sector data of Definition 4.8 of arXiv:1606.00608 (`GSNNCHData`),
+this file proves the properties the source asserts of the represented
+finite-chain operator $\bigoplus_x n_x \prod_j \tau_j(B^{(x)})$ of equation
+`rhoNCommv2`:
+
+* all cyclic translates of one sector bond commute pairwise, extending the
+  neighboring commutation $[B^{(x)}, \tau_1(B^{(x)})] = 0$ required by the
+  definition (arXiv:1606.00608, lines 843--850);
+* the represented operator is positive semidefinite, as each summand is a
+  product of commuting positive bonds with a natural multiplicity;
+* the represented operator is invariant under the cyclic shift; this is the
+  translation invariance stated at arXiv:1606.00608, lines 838--842;
+* every chain operator with the sector form is positive semidefinite, so an
+  MPO tensor with the sector form at every length and nonvanishing traces
+  satisfies the full density-operator predicate `IsGSNNCH`
+  (arXiv:1606.00608, Definition 4.8, lines 829--850).
+
+Consequently, an injective tensor satisfying the saturated area law generates
+Gibbs states of a nearest-neighbor commuting Hamiltonian: the commuting
+product form of Proposition C.8 (arXiv:1606.00608, Appendix C.2, lines
+1569--1594) together with the density normalization of Definition 4.8. For an
+injective tensor the basis of normal tensors has a single element, so the
+one-sector form is the full source conclusion in this case.
+
+This completes the first step of the elimination plan in
+`docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex`. Constructing the
+outer sectors and natural multiplicities of a general simple tensor from its
+basis of normal tensors remains open; see the same note.
+
+## Main declarations
+
+* `MPOTensor.embedLocalOperator_submatrix_rotateConfig`
+* `MPOTensor.embedLocalOperator_posSemidef`
+* `MPOTensor.GSNNCHData.bondAt_comm`
+* `MPOTensor.GSNNCHData.sectorProduct_posSemidef`
+* `MPOTensor.GSNNCHData.unnormalizedState_posSemidef`
+* `MPOTensor.GSNNCHData.unnormalizedState_submatrix_rotateConfig`
+* `MPOTensor.HasGSNNCHFormAt.posSemidef`
+* `MPOTensor.HasGSNNCHFormAt.submatrix_rotateConfig`
+* `MPOTensor.isGSNNCH_of_hasGSNNCHForm`
+* `MPOTensor.isGSNNCH_of_isInjective_of_isSAL`
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Definition 4.8 and Appendix C.2
+-/
+
+open scoped Matrix Kronecker ComplexOrder
+open Matrix
+
+namespace MPOTensor
+
+attribute [local instance] Classical.decEq Classical.propDecidable
+
+variable {d D N : ℕ}
+
+/-! ## Transport of embedded local operators along the cyclic shift -/
+
+/-- The cyclic shift moves the residue offset of a site from a window base
+the same way it moves the base. -/
+private theorem rotate_offset_eq {N : ℕ} (k i : Fin N) :
+    (((finRotate N) k).val + N - ((finRotate N) i).val) % N
+      = (k.val + N - i.val) % N := by
+  have hkN := k.isLt
+  have hiN := i.isLt
+  rw [coe_finRotate_mod, coe_finRotate_mod]
+  rcases Nat.lt_or_ge (k.val + 1) N with hk1 | hk1 <;>
+    rcases Nat.lt_or_ge (i.val + 1) N with hi1 | hi1
+  · rw [Nat.mod_eq_of_lt hk1, Nat.mod_eq_of_lt hi1]
+    congr 1
+    omega
+  · have h2 : (i.val + 1) % N = 0 := by
+      rw [show i.val + 1 = N by omega, Nat.mod_self]
+    rw [Nat.mod_eq_of_lt hk1, h2,
+      show k.val + 1 + N - 0 = k.val + 1 + N by omega, Nat.add_mod_right,
+      show k.val + N - i.val = k.val + 1 by omega]
+  · have h1 : (k.val + 1) % N = 0 := by
+      rw [show k.val + 1 = N by omega, Nat.mod_self]
+    rw [h1, Nat.mod_eq_of_lt hi1,
+      show 0 + N - (i.val + 1) = N - i.val - 1 by omega,
+      show k.val + N - i.val = N + (N - i.val - 1) by omega, Nat.add_mod_left]
+  · rw [show k.val = i.val by omega,
+      show (i.val + 1) % N + N - (i.val + 1) % N = N by omega,
+      show i.val + N - i.val = N by omega]
+
+/-- Extracting a cyclic window from a shifted configuration extracts the
+window at the shifted base site. -/
+private theorem extractWindow_comp_finRotate {N : ℕ} (L : ℕ) (i : Fin N)
+    (σ : Fin N → Fin d) :
+    MPSTensor.extractWindow L i (σ ∘ (finRotate N : Fin N → Fin N))
+      = MPSTensor.extractWindow L (finRotate N i) σ := by
+  funext j
+  simp only [MPSTensor.extractWindow, Function.comp_apply]
+  congr 1
+  apply Fin.ext
+  simp only [coe_finRotate_mod]
+  rw [Nat.mod_add_mod, Nat.mod_add_mod]
+  congr 1
+  omega
+
+/-- Two shifted configurations agree outside the window at `i` exactly when
+the original configurations agree outside the window at the shifted base. -/
+private theorem agreesOutsideWindow_comp_finRotate {N : ℕ} (L : ℕ) (hLN : L ≤ N)
+    (i : Fin N) (σ τ : Fin N → Fin d) :
+    AgreesOutsideWindow (d := d) L hLN i
+        (σ ∘ (finRotate N : Fin N → Fin N)) (τ ∘ (finRotate N : Fin N → Fin N))
+      ↔ AgreesOutsideWindow (d := d) L hLN (finRotate N i) σ τ := by
+  rw [agreesOutsideWindow_iff, agreesOutsideWindow_iff]
+  constructor
+  · intro h k hk
+    have hk' : ¬ ((((finRotate N).symm k).val + N - i.val) % N < L) := by
+      rw [← rotate_offset_eq ((finRotate N).symm k) i, Equiv.apply_symm_apply]
+      exact hk
+    have := h ((finRotate N).symm k) hk'
+    rwa [Function.comp_apply, Function.comp_apply, Equiv.apply_symm_apply] at this
+  · intro h k hk
+    have hk' : ¬ ((((finRotate N) k).val + N - ((finRotate N) i).val) % N < L) := by
+      rw [rotate_offset_eq]
+      exact hk
+    exact h ((finRotate N) k) hk'
+
+/-- **Transport of an embedded local operator along the cyclic shift.**
+Reindexing both configurations of $\tau_i(B)$ by the cyclic shift gives the
+translate at the shifted base site.
+
+Source: arXiv:1606.00608, Definition 4.8, lines 829--842: the translates
+$\tau_j(B)$ are the cyclic shifts of one two-site operator. -/
+theorem embedLocalOperator_submatrix_rotateConfig (L : ℕ) {N : ℕ} (hLN : L ≤ N)
+    (i : Fin N) (B : Matrix (Fin L → Fin d) (Fin L → Fin d) ℂ) :
+    (embedLocalOperator (d := d) L N hLN i B).submatrix
+        (rotateConfig N d) (rotateConfig N d)
+      = embedLocalOperator (d := d) L N hLN (finRotate N i) B := by
+  ext σ τ
+  simp only [Matrix.submatrix_apply, rotateConfig_apply, embedLocalOperator_apply,
+    extractWindow_comp_finRotate, agreesOutsideWindow_comp_finRotate]
+
+/-- Reindexing by the cyclic shift is multiplicative on chain operators. -/
+private theorem submatrix_rotateConfig_mul (A B : ChainOperator d N) :
+    (A * B).submatrix (rotateConfig N d) (rotateConfig N d)
+      = A.submatrix (rotateConfig N d) (rotateConfig N d)
+        * B.submatrix (rotateConfig N d) (rotateConfig N d) :=
+  (Matrix.submatrix_mul_equiv A B _ (rotateConfig N d) _).symm
+
+/-! ## Positivity of embedded local operators -/
+
+/-- An embedded positive-semidefinite local operator is positive semidefinite:
+in cyclic-window coordinates it is the Kronecker product of the local operator
+with the identity on the complement. -/
+theorem embedLocalOperator_posSemidef (L : ℕ) {N : ℕ} (hLN : L ≤ N) (i : Fin N)
+    {B : Matrix (Fin L → Fin d) (Fin L → Fin d) ℂ} (hB : B.PosSemidef) :
+    (embedLocalOperator (d := d) L N hLN i B).PosSemidef := by
+  have h := reindex_embedLocalOperator_windowComplement (d := d) L N hLN i B
+  have h2 : embedLocalOperator (d := d) L N hLN i B
+      = (B ⊗ₖ (1 : Matrix (Fin (N - L) → Fin d) (Fin (N - L) → Fin d) ℂ)).submatrix
+          (windowComplementEquiv (d := d) L N hLN i)
+          (windowComplementEquiv (d := d) L N hLN i) := by
+    rw [← h]
+    ext σ τ
+    simp [Matrix.reindex_apply]
+  rw [h2]
+  exact (hB.kronecker Matrix.PosSemidef.one).submatrix _
+
+namespace GSNNCHData
+
+variable {N : ℕ}
+
+/-- Every translate of a sector bond is positive semidefinite.
+
+Source: arXiv:1606.00608, equation `rhoNCommv2`, lines 843--850: each
+$B^{(x)}$ is positive semidefinite. -/
+theorem bondAt_posSemidef (data : GSNNCHData d N) (x : Fin data.sectorCount)
+    (i : Fin N) : (data.bondAt x i).PosSemidef :=
+  embedLocalOperator_posSemidef 2 data.hN i (data.bond_pos x)
+
+/-- **All cyclic translates of one sector bond commute pairwise.** Translates
+with disjoint windows commute by locality; the neighboring commutation
+required by Definition 4.8 covers the overlapping pairs after transport along
+the cyclic shift.
+
+Source: arXiv:1606.00608, Definition 4.8, lines 829--850: the definition
+requires $[B^{(x)}, \tau_1(B^{(x)})] = 0$, and the product over all
+translates is unambiguous exactly because all translates commute. -/
+theorem bondAt_comm (data : GSNNCHData d N) (x : Fin data.sectorCount)
+    (i j : Fin N) :
+    data.bondAt x i * data.bondAt x j = data.bondAt x j * data.bondAt x i := by
+  have hN2 : 2 ≤ N := data.hN
+  have hadj : ∀ p : ℕ,
+      data.bondAt x ((finRotate N : Fin N → Fin N)^[p] ⟨0, by omega⟩) *
+          data.bondAt x ((finRotate N : Fin N → Fin N)^[p] ⟨1, by omega⟩)
+        = data.bondAt x ((finRotate N : Fin N → Fin N)^[p] ⟨1, by omega⟩) *
+            data.bondAt x ((finRotate N : Fin N → Fin N)^[p] ⟨0, by omega⟩) := by
+    intro p
+    induction p with
+    | zero => simpa [GSNNCHData.bondAt] using data.neighboring_comm x
+    | succ p ih =>
+        have h := congrArg (fun A : ChainOperator d N =>
+          A.submatrix (rotateConfig N d) (rotateConfig N d)) ih
+        simp only [submatrix_rotateConfig_mul, GSNNCHData.bondAt,
+          embedLocalOperator_submatrix_rotateConfig] at h
+        simpa [GSNNCHData.bondAt, Function.iterate_succ_apply'] using h
+  have hstep : ∀ k : Fin N,
+      data.bondAt x k * data.bondAt x (MPSTensor.cyclicForwardSite k 1)
+        = data.bondAt x (MPSTensor.cyclicForwardSite k 1) * data.bondAt x k := by
+    intro k
+    have h := hadj k.val
+    have h0 : (finRotate N : Fin N → Fin N)^[k.val] ⟨0, by omega⟩ = k := by
+      apply Fin.ext
+      rw [coe_finRotate_pow]
+      simpa using Nat.mod_eq_of_lt k.isLt
+    have h1 : (finRotate N : Fin N → Fin N)^[k.val] ⟨1, by omega⟩
+        = MPSTensor.cyclicForwardSite k 1 := by
+      apply Fin.ext
+      rw [coe_finRotate_pow]
+      simp [MPSTensor.cyclicForwardSite, Nat.add_comm]
+    rwa [h0, h1] at h
+  by_cases hover : MPSTensor.cyclicWindowsOverlap N 2 i j
+  · rcases MPSTensor.cyclicWindowsOverlap_twoSite_cases hover with rfl | rfl | rfl
+    · rfl
+    · exact hstep i
+    · exact (hstep j).symm
+  · simpa [GSNNCHData.bondAt] using
+      embedLocalOperator_commute_of_not_cyclicWindowsOverlap 2 N data.hN hover
+        (data.bond x) (data.bond x)
+
+/-- **Each sector product is positive semidefinite**: it is a product of
+pairwise commuting positive-semidefinite translates of one sector bond.
+
+Source: arXiv:1606.00608, Definition 4.8, lines 843--850: each summand
+$\prod_j \tau_j(B^{(x)})$ with $B^{(x)} \ge 0$ and commuting translates
+represents the positive operator $e^{-\sum_j \tau_j(h^{(x)})}$ of equation
+`rhoNComm`. -/
+theorem sectorProduct_posSemidef (data : GSNNCHData d N)
+    (x : Fin data.sectorCount) : (data.sectorProduct x).PosSemidef := by
+  refine Matrix.posSemidef_list_prod (fun A hA => ?_) ?_
+  · rw [List.mem_ofFn] at hA
+    obtain ⟨i, rfl⟩ := hA
+    exact data.bondAt_posSemidef x i
+  · rw [List.pairwise_ofFn]
+    intro a b _
+    exact data.bondAt_comm x a b
+
+/-- **The GSNNCH sector sum is positive semidefinite.**
+
+Source: arXiv:1606.00608, Definition 4.8, lines 829--850: the represented
+operator is a density operator up to normalization. -/
+theorem unnormalizedState_posSemidef (data : GSNNCHData d N) :
+    data.unnormalizedState.PosSemidef := by
+  refine Finset.sum_induction _ Matrix.PosSemidef (fun a b ha hb => ha.add hb)
+    Matrix.PosSemidef.zero (fun x _ => ?_)
+  rw [(Complex.ofReal_natCast (data.multiplicity x)).symm]
+  exact (data.sectorProduct_posSemidef x).smul
+    (by exact_mod_cast Nat.cast_nonneg (data.multiplicity x))
+
+/-- Each sector product is invariant under the cyclic shift: the shift
+permutes its commuting factors cyclically.
+
+Source: arXiv:1606.00608, lines 838--842: the represented density operator is
+translationally invariant on the periodic chain. -/
+theorem sectorProduct_submatrix_rotateConfig (data : GSNNCHData d N)
+    (x : Fin data.sectorCount) :
+    (data.sectorProduct x).submatrix (rotateConfig N d) (rotateConfig N d)
+      = data.sectorProduct x := by
+  have hdist : ∀ l : List (ChainOperator d N),
+      l.prod.submatrix (rotateConfig N d) (rotateConfig N d)
+        = (l.map fun A : ChainOperator d N =>
+            A.submatrix (rotateConfig N d) (rotateConfig N d)).prod := by
+    intro l
+    induction l with
+    | nil =>
+        simp only [List.prod_nil, List.map_nil]
+        exact Matrix.submatrix_one_equiv (α := ℂ) (rotateConfig N d)
+    | cons A l ih =>
+        simp only [List.prod_cons, List.map_cons, submatrix_rotateConfig_mul, ih]
+  rw [GSNNCHData.sectorProduct, hdist, List.map_ofFn]
+  have hshift : ((fun A : ChainOperator d N =>
+        A.submatrix (rotateConfig N d) (rotateConfig N d))
+          ∘ fun i => data.bondAt x i)
+      = fun i => data.bondAt x (finRotate N i) := by
+    funext i
+    simp only [Function.comp_apply, GSNNCHData.bondAt,
+      embedLocalOperator_submatrix_rotateConfig]
+  rw [hshift]
+  have hperm : (List.ofFn fun i => data.bondAt x (finRotate N i)).Perm
+      (List.ofFn fun i => data.bondAt x i) :=
+    Equiv.Perm.ofFn_comp_perm (finRotate N) fun i => data.bondAt x i
+  have hpair : (List.ofFn fun i => data.bondAt x (finRotate N i)).Pairwise
+      Commute := by
+    rw [List.pairwise_ofFn]
+    intro a b _
+    exact (commute_iff_eq _ _).mpr (data.bondAt_comm x _ _)
+  exact hperm.prod_eq' hpair
+
+/-- **Translation invariance of the GSNNCH sector sum.** Reindexing both
+configurations by the cyclic shift leaves
+$\bigoplus_x n_x \prod_j \tau_j(B^{(x)})$ unchanged.
+
+Source: arXiv:1606.00608, lines 838--842: the density operator of equation
+`rhoNComm` is translationally invariant, where spin `N+1` is identified with
+the first. -/
+theorem unnormalizedState_submatrix_rotateConfig (data : GSNNCHData d N) :
+    data.unnormalizedState.submatrix (rotateConfig N d) (rotateConfig N d)
+      = data.unnormalizedState := by
+  ext σ τ
+  simp only [GSNNCHData.unnormalizedState, Matrix.submatrix_apply,
+    Matrix.sum_apply, Matrix.smul_apply]
+  refine Finset.sum_congr rfl fun x _ => ?_
+  congr 1
+  have h := congrFun (congrFun (data.sectorProduct_submatrix_rotateConfig x) σ) τ
+  simpa [Matrix.submatrix_apply] using h
+
+end GSNNCHData
+
+/-! ## Consequences for chain operators with the sector form -/
+
+/-- A chain operator with the sector form of Definition 4.8 is positive
+semidefinite.
+
+Source: arXiv:1606.00608, Definition 4.8, lines 829--850. -/
+theorem HasGSNNCHFormAt.posSemidef {ρ : ChainOperator d N}
+    (h : HasGSNNCHFormAt ρ) : ρ.PosSemidef := by
+  obtain ⟨data, c, hc, rfl⟩ := h
+  exact data.unnormalizedState_posSemidef.smul
+    (by exact_mod_cast le_of_lt hc : (0 : ℂ) ≤ (c : ℂ))
+
+/-- A chain operator with the sector form of Definition 4.8 is invariant
+under the cyclic shift.
+
+Source: arXiv:1606.00608, lines 838--842. -/
+theorem HasGSNNCHFormAt.submatrix_rotateConfig {ρ : ChainOperator d N}
+    (h : HasGSNNCHFormAt ρ) :
+    ρ.submatrix (rotateConfig N d) (rotateConfig N d) = ρ := by
+  obtain ⟨data, c, hc, rfl⟩ := h
+  ext σ τ
+  simp only [Matrix.submatrix_apply, Matrix.smul_apply]
+  congr 1
+  have h := congrFun (congrFun data.unnormalizedState_submatrix_rotateConfig σ) τ
+  simpa [Matrix.submatrix_apply] using h
+
+/-- The sector form passes from the chain operator to its trace
+normalization. -/
+theorem hasGSNNCHFormAt_normalizedMPO {M : MPOTensor d D} {N : ℕ}
+    (h : HasGSNNCHFormAt (mpo M N)) (htr : (mpo M N).trace ≠ 0) :
+    HasGSNNCHFormAt (normalizedMPO M N) := by
+  have hpsd : (mpo M N).PosSemidef := h.posSemidef
+  have htr_nonneg : (0 : ℂ) ≤ (mpo M N).trace := hpsd.trace_nonneg
+  have hre : 0 ≤ (mpo M N).trace.re := (RCLike.nonneg_iff.mp htr_nonneg).1
+  have him : (mpo M N).trace.im = 0 := (RCLike.nonneg_iff.mp htr_nonneg).2
+  set r : ℝ := (mpo M N).trace.re with hr
+  have htr_eq : (mpo M N).trace = (r : ℂ) := Complex.ext rfl (by simp [him, hr])
+  have hr_pos : 0 < r := by
+    rcases lt_or_eq_of_le hre with h' | h'
+    · exact h'
+    · exact absurd (by rw [htr_eq, ← h']; simp) htr
+  obtain ⟨data, c, hc, heq⟩ := h
+  refine ⟨data, r⁻¹ * c, by positivity, ?_⟩
+  rw [normalizedMPO, htr_eq, heq, smul_smul]
+  congr 1
+  push_cast
+  ring
+
+/-- **An MPO tensor with the sector form and nonvanishing traces is GSNNCH.**
+Positivity of the normalized chain operators is derived from the sector form
+itself, so only the nonvanishing of the traces is assumed.
+
+Source: arXiv:1606.00608, Definition 4.8, lines 829--850. -/
+theorem isGSNNCH_of_hasGSNNCHForm {M : MPOTensor d D}
+    (hForm : HasGSNNCHForm M)
+    (htr : ∀ N : ℕ, 2 ≤ N → (mpo M N).trace ≠ 0) : IsGSNNCH M := by
+  intro N hN
+  have hform := hForm N hN
+  exact ⟨normalizedMPO_posSemidef M N hform.posSemidef,
+    normalizedMPO_trace M N (htr N hN),
+    hasGSNNCHFormAt_normalizedMPO hform (htr N hN)⟩
+
+/-- **An injective tensor with the saturated area law generates Gibbs states
+of a nearest-neighbor commuting Hamiltonian.** The commuting product form is
+Proposition C.8; positivity and normalization then give the density-operator
+form of Definition 4.8. For an injective tensor the basis of normal tensors
+has one element, so the one-sector form is the full source conclusion.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8, lines 1569--1594,
+and Definition 4.8, lines 829--850. -/
+theorem isGSNNCH_of_isInjective_of_isSAL (K : MPOTensor d D)
+    (hK : K.IsInjective) (hSAL : IsSAL K) : IsGSNNCH K := by
+  obtain ⟨data⟩ := nonempty_etaLocalStructureData_of_isSAL K hK hSAL
+  refine isGSNNCH_of_hasGSNNCHForm data.hasGSNNCHForm fun N hN => ?_
+  obtain ⟨hMpdo, htr, -⟩ := hSAL
+  exact htr N (by omega)
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/GSNNCHSectorSum.lean
+++ b/TNLean/MPS/MPDO/GSNNCHSectorSum.lean
@@ -10,8 +10,8 @@ import TNLean.MPS.MPDO.InverseMapActiveSectorRecurrence
 
 For the sector data of Definition 4.8 of arXiv:1606.00608 (`GSNNCHData`),
 this file proves the properties the source asserts of the represented
-finite-chain operator $\bigoplus_x n_x \prod_j \tau_j(B^{(x)})$ of equation
-`rhoNCommv2`:
+finite-chain operator $\bigoplus_x n_x \prod_j \tau_j(B^{(x)})$
+(arXiv:1606.00608, lines 843--850):
 
 * all cyclic translates of one sector bond commute pairwise, extending the
   neighboring commutation $[B^{(x)}, \tau_1(B^{(x)})] = 0$ required by the
@@ -180,8 +180,8 @@ variable {N : ℕ}
 
 /-- Every translate of a sector bond is positive semidefinite.
 
-Source: arXiv:1606.00608, equation `rhoNCommv2`, lines 843--850: each
-$B^{(x)}$ is positive semidefinite. -/
+Source: arXiv:1606.00608, lines 843--850: each $B^{(x)}$ is positive
+semidefinite. -/
 theorem bondAt_posSemidef (data : GSNNCHData d N) (x : Fin data.sectorCount)
     (i : Fin N) : (data.bondAt x i).PosSemidef :=
   embedLocalOperator_posSemidef 2 data.hN i (data.bond_pos x)
@@ -241,8 +241,8 @@ pairwise commuting positive-semidefinite translates of one sector bond.
 
 Source: arXiv:1606.00608, Definition 4.8, lines 843--850: each summand
 $\prod_j \tau_j(B^{(x)})$ with $B^{(x)} \ge 0$ and commuting translates
-represents the positive operator $e^{-\sum_j \tau_j(h^{(x)})}$ of equation
-`rhoNComm`. -/
+represents the positive operator $e^{-\sum_j \tau_j(h^{(x)})}$ of the
+defining equation at lines 829--842. -/
 theorem sectorProduct_posSemidef (data : GSNNCHData d N)
     (x : Fin data.sectorCount) : (data.sectorProduct x).PosSemidef := by
   refine Matrix.posSemidef_list_prod (fun A hA => ?_) ?_

--- a/TNLean/MPS/MPDO/GSNNCHSectorSum.lean
+++ b/TNLean/MPS/MPDO/GSNNCHSectorSum.lean
@@ -352,7 +352,9 @@ theorem HasGSNNCHFormAt.submatrix_rotateConfig {ρ : ChainOperator d N}
   simpa [Matrix.submatrix_apply] using h
 
 /-- The sector form passes from the chain operator to its trace
-normalization. -/
+normalization.
+
+Source: arXiv:1606.00608, Definition 4.8, lines 829--850. -/
 theorem hasGSNNCHFormAt_normalizedMPO {M : MPOTensor d D} {N : ℕ}
     (h : HasGSNNCHFormAt (mpo M N)) (htr : (mpo M N).trace ≠ 0) :
     HasGSNNCHFormAt (normalizedMPO M N) := by
@@ -393,6 +395,10 @@ Proposition C.8; positivity and normalization then give the density-operator
 form of Definition 4.8, realized through one sector. The one-sector form is
 the commuting product form in which Proposition C.8 states its conclusion for
 an injective tensor.
+
+**Local fix (inactive sectors):** the local structure data is constructed
+through the inactive-sector repair; see
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
 
 Source: arXiv:1606.00608, Appendix C.2, Proposition C.8, lines 1569--1594,
 and Definition 4.8, lines 829--850. -/

--- a/TNLean/MPS/MPDO/GSNNCHSectorSum.lean
+++ b/TNLean/MPS/MPDO/GSNNCHSectorSum.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
 -/
 import TNLean.Analysis.PosSemidefCommute
 import TNLean.MPS.MPDO.InverseMapActiveSectorRecurrence

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -132,10 +132,10 @@
     Every injective MPO tensor satisfying SAL generates Gibbs states of a
     nearest-neighbor commuting Hamiltonian: the normalized finite-chain
     states are density operators with the explicit sector form of
-    Definition~\ref{def:mpdo_source_gsnnch}. For an injective tensor the
-    basis of normal tensors has a single element, so the one-sector form is
-    the full conclusion of \cite[Proposition~C.8]{Cirac2016MPDO_arXiv}
-    together with the density normalization of
+    Definition~\ref{def:mpdo_source_gsnnch}, realized through one sector.
+    The one-sector form is the commuting product form in which
+    \cite[Proposition~C.8]{Cirac2016MPDO_arXiv} states its conclusion for an
+    injective tensor, combined here with the density normalization of
     \cite[Definition~4.8]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -122,6 +122,31 @@
     chain length.
 \end{proof}
 
+\begin{theorem}[Injective SAL tensors generate GSNNCH states]
+    \label{thm:mpdo_injective_sal_is_gsnnch}
+    \lean{MPOTensor.isGSNNCH_of_isInjective_of_isSAL}
+    \leanok
+    \uses{def:is_sal, cor:mpdo_eta_local_structure_of_is_sal,
+        thm:mpdo_eta_local_structure_has_gsnnch_form,
+        thm:mpdo_gsnnch_of_sector_form}
+    Every injective MPO tensor satisfying SAL generates Gibbs states of a
+    nearest-neighbor commuting Hamiltonian: the normalized finite-chain
+    states are density operators with the explicit sector form of
+    Definition~\ref{def:mpdo_source_gsnnch}. For an injective tensor the
+    basis of normal tensors has a single element, so the one-sector form is
+    the full conclusion of \cite[Proposition~C.8]{Cirac2016MPDO_arXiv}
+    together with the density normalization of
+    \cite[Definition~4.8]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    Corollary~\ref{cor:mpdo_eta_local_structure_of_is_sal} gives the
+    $\eta$-local structure, whose single positive bond gives the one-sector
+    form by Theorem~\ref{thm:mpdo_eta_local_structure_has_gsnnch_form}. SAL
+    includes the nonvanishing of every positive-length trace, so
+    Theorem~\ref{thm:mpdo_gsnnch_of_sector_form} applies.
+\end{proof}
+
 \begin{remark}[Positive physical-sector factorization]
     Suppose that $K$ satisfies $\mathrm{SAL}(K)$ and admits a physical-sector
     factorization whose neighboring operators $\eta_{k,h}$ are simultaneously

--- a/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
@@ -161,8 +161,8 @@ Definition~\ref{def:mpdo_source_gsnnch}; the converse comparison is not used.
     sites. Reindexing both chain configurations by $r$ carries the embedded
     operator to its translate at the shifted base site:
     \[
-        \tau_i(B)[\sigma\circ r,\,\tau\circ r]
-        = \tau_{r(i)}(B)[\sigma,\tau].
+        \tau_i(B)[\sigma\circ r,\,\eta\circ r]
+        = \tau_{r(i)}(B)[\sigma,\eta].
     \]
 \end{lemma}
 
@@ -240,8 +240,9 @@ Definition~\ref{def:mpdo_source_gsnnch}; the converse comparison is not used.
 \begin{proof}\leanok
     A product of pairwise commuting positive semidefinite matrices is
     positive semidefinite: for two commuting factors $A$ and $B$, the square
-    root of $A$ commutes with $B$, so $AB=\sqrt A\,B\,\sqrt A$ is a conjugate
-    of $B$; iterate along the product. Each sector product is such a product
+    root of $A$ commutes with $B$, so $AB=\sqrt A\,B\,\sqrt A\geq 0$, as
+    congruence by $\sqrt A$ preserves positive semidefiniteness; iterate
+    along the product. Each sector product is such a product
     by Lemmas~\ref{lem:mpdo_gsnnch_translate_pos}
     and~\ref{lem:mpdo_gsnnch_bond_translates_comm}, and the sum with natural
     coefficients preserves positivity.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
@@ -210,10 +210,14 @@ Definition~\ref{def:mpdo_source_gsnnch}; the converse comparison is not used.
 \end{lemma}
 
 \begin{proof}\leanok
-    In the coordinates splitting the chain into the window and its cyclic
-    complement, the embedded operator is the tensor product of the local
-    factor with the identity, and $B^{(x)}\geq0$ by
-    Definition~\ref{def:mpdo_source_gsnnch}.
+    In the coordinates given by the window-plus-complement splitting of the
+    chain, the embedded operator decomposes as
+    \[
+        \tau_i(B)\;\cong\;B\otimes\operatorname{Id}_{\mathrm{comp}},
+    \]
+    where the identity acts on the cyclic complement of the window. A tensor
+    product of positive semidefinite operators is positive semidefinite, and
+    $B^{(x)}\geq0$ by Definition~\ref{def:mpdo_source_gsnnch}.
 \end{proof}
 
 \begin{lemma}[Positivity of the sector sum]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
@@ -150,3 +150,93 @@ Definition~\ref{def:mpdo_source_gsnnch}; the converse comparison is not used.
     Take one sector, its one-site projection to be the identity, its
     multiplicity to be one, and its bond to be the given bond.
 \end{proof}
+
+\begin{lemma}[Translates of a sector bond commute pairwise]
+    \label{lem:mpdo_gsnnch_bond_translates_comm}
+    \lean{MPOTensor.embedLocalOperator_submatrix_rotateConfig}
+    \lean{MPOTensor.GSNNCHData.bondAt_comm}
+    \leanok
+    \uses{def:mpdo_source_gsnnch}
+    For every sector $x$ of an explicit GSNNCH decomposition and every finite
+    chain length $N\geq2$, all cyclic translates of the sector bond commute:
+    \[
+        [\tau_i(B^{(x)}),\tau_j(B^{(x)})]=0 .
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    Translates with disjoint windows commute because they act on disjoint
+    sites. For the overlapping pairs the two starting sites coincide or are
+    cyclic neighbors, and conjugating the neighboring commutation
+    $[B^{(x)},\tau_1(B^{(x)})]=0$ of Definition~\ref{def:mpdo_source_gsnnch}
+    by powers of the cyclic shift covers these cases.
+\end{proof}
+
+\begin{lemma}[Positivity of the sector sum]
+    \label{lem:mpdo_gsnnch_sector_sum_pos}
+    \lean{MPOTensor.embedLocalOperator_posSemidef}
+    \lean{MPOTensor.GSNNCHData.bondAt_posSemidef}
+    \lean{MPOTensor.GSNNCHData.sectorProduct_posSemidef}
+    \lean{MPOTensor.GSNNCHData.unnormalizedState_posSemidef}
+    \lean{MPOTensor.HasGSNNCHFormAt.posSemidef}
+    \leanok
+    \uses{def:mpdo_source_gsnnch, lem:mpdo_gsnnch_bond_translates_comm}
+    The represented operator
+    \[
+        \bigoplus_x n_x \prod_{j=1}^N\tau_j(B^{(x)})
+    \]
+    of an explicit GSNNCH decomposition is positive semidefinite, and so is
+    every chain operator equal to a positive multiple of it.
+\end{lemma}
+
+\begin{proof}\leanok
+    A product of pairwise commuting positive semidefinite matrices is
+    positive semidefinite: for two commuting factors $A$ and $B$, the square
+    root of $A$ commutes with $B$, so $AB=\sqrt A\,B\,\sqrt A$ is a conjugate
+    of $B$; iterate along the product. Each sector product is such a product
+    by Lemma~\ref{lem:mpdo_gsnnch_bond_translates_comm}, each translate is
+    positive because the sector bond is, and the sum with natural
+    coefficients preserves positivity.
+\end{proof}
+
+\begin{lemma}[Translation invariance of the sector sum]
+    \label{lem:mpdo_gsnnch_sector_sum_translation_invariant}
+    \lean{MPOTensor.GSNNCHData.sectorProduct_submatrix_rotateConfig}
+    \lean{MPOTensor.GSNNCHData.unnormalizedState_submatrix_rotateConfig}
+    \lean{MPOTensor.HasGSNNCHFormAt.submatrix_rotateConfig}
+    \leanok
+    \uses{def:mpdo_source_gsnnch, lem:mpdo_gsnnch_bond_translates_comm}
+    The represented operator of an explicit GSNNCH decomposition is invariant
+    under the cyclic shift of the periodic chain, where spin $N+1$ is
+    identified with the first
+    \cite[lines~838--842]{Cirac2016MPDO_arXiv}.
+\end{lemma}
+
+\begin{proof}\leanok
+    The cyclic shift carries each translate $\tau_j(B^{(x)})$ to
+    $\tau_{j+1}(B^{(x)})$, so it permutes the factors of each sector product
+    cyclically. All factors commute by
+    Lemma~\ref{lem:mpdo_gsnnch_bond_translates_comm}, so the product is
+    unchanged, and so is the sum over sectors.
+\end{proof}
+
+\begin{theorem}[Sector form with nonvanishing traces gives GSNNCH]
+    \label{thm:mpdo_gsnnch_of_sector_form}
+    \lean{MPOTensor.hasGSNNCHFormAt_normalizedMPO}
+    \lean{MPOTensor.isGSNNCH_of_hasGSNNCHForm}
+    \leanok
+    \uses{def:mpdo_source_gsnnch, lem:mpdo_gsnnch_sector_sum_pos}
+    If every finite-chain operator of an MPO tensor has the explicit sector
+    form of Definition~\ref{def:mpdo_source_gsnnch} and a nonzero trace, then
+    the normalized finite-chain states are density operators with that sector
+    form, so the tensor generates Gibbs states of a nearest-neighbor
+    commuting Hamiltonian.
+\end{theorem}
+
+\begin{proof}\leanok
+    Positivity of each chain operator follows from
+    Lemma~\ref{lem:mpdo_gsnnch_sector_sum_pos}. A positive semidefinite
+    operator with nonzero trace has positive trace, so the normalization is
+    by a positive constant, which preserves the sector form and yields unit
+    trace.
+\end{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
@@ -151,12 +151,32 @@ Definition~\ref{def:mpdo_source_gsnnch}; the converse comparison is not used.
     multiplicity to be one, and its bond to be the given bond.
 \end{proof}
 
+\begin{lemma}[Cyclic-shift transport of an embedded local operator]
+    \label{lem:mpdo_gsnnch_shift_transport}
+    \lean{MPOTensor.embedLocalOperator_submatrix_rotateConfig}
+    \leanok
+    \uses{def:mpdo_commuting_form_data}
+    Let $B$ act on $L$ consecutive spins of the periodic $N$-site chain,
+    embedded at base site $i$, and let $r$ denote the cyclic shift of
+    sites. Reindexing both chain configurations by $r$ carries the embedded
+    operator to its translate at the shifted base site:
+    \[
+        \tau_i(B)[\sigma\circ r,\,\tau\circ r]
+        = \tau_{r(i)}(B)[\sigma,\tau].
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    Entrywise from the definitions: the shift carries the window at $i$ to
+    the window at $r(i)$, preserves agreement of two configurations outside
+    the window, and preserves the extracted window values.
+\end{proof}
+
 \begin{lemma}[Translates of a sector bond commute pairwise]
     \label{lem:mpdo_gsnnch_bond_translates_comm}
-    \lean{MPOTensor.embedLocalOperator_submatrix_rotateConfig}
     \lean{MPOTensor.GSNNCHData.bondAt_comm}
     \leanok
-    \uses{def:mpdo_source_gsnnch}
+    \uses{def:mpdo_source_gsnnch, lem:mpdo_gsnnch_shift_transport}
     For every sector $x$ of an explicit GSNNCH decomposition and every finite
     chain length $N\geq2$, all cyclic translates of the sector bond commute:
     \[
@@ -166,27 +186,51 @@ Definition~\ref{def:mpdo_source_gsnnch}; the converse comparison is not used.
 
 \begin{proof}\leanok
     Translates with disjoint windows commute because they act on disjoint
-    sites. For the overlapping pairs the two starting sites coincide or are
-    cyclic neighbors, and conjugating the neighboring commutation
-    $[B^{(x)},\tau_1(B^{(x)})]=0$ of Definition~\ref{def:mpdo_source_gsnnch}
-    by powers of the cyclic shift covers these cases.
+    sites, and two length-two windows overlap only when their starting sites
+    coincide or are cyclic neighbors. For the neighboring pairs, applying the
+    transport identity of Lemma~\ref{lem:mpdo_gsnnch_shift_transport} $p$
+    times to the neighboring commutation
+    $[\tau_0(B^{(x)}),\tau_1(B^{(x)})]=0$ of
+    Definition~\ref{def:mpdo_source_gsnnch} gives
+    \[
+        [\tau_p(B^{(x)}),\tau_{p+1}(B^{(x)})]=0
+    \]
+    for every $p$, which covers all overlapping pairs.
+\end{proof}
+
+\begin{lemma}[Positivity of the sector-bond translates]
+    \label{lem:mpdo_gsnnch_translate_pos}
+    \lean{MPOTensor.embedLocalOperator_posSemidef}
+    \lean{MPOTensor.GSNNCHData.bondAt_posSemidef}
+    \leanok
+    \uses{def:mpdo_source_gsnnch, def:mpdo_commuting_form_data}
+    An operator embedded into the periodic chain from a positive
+    semidefinite local factor is positive semidefinite; in particular every
+    translate $\tau_i(B^{(x)})$ of a sector bond is positive semidefinite.
+\end{lemma}
+
+\begin{proof}\leanok
+    In the coordinates splitting the chain into the window and its cyclic
+    complement, the embedded operator is the tensor product of the local
+    factor with the identity, and $B^{(x)}\geq0$ by
+    Definition~\ref{def:mpdo_source_gsnnch}.
 \end{proof}
 
 \begin{lemma}[Positivity of the sector sum]
     \label{lem:mpdo_gsnnch_sector_sum_pos}
-    \lean{MPOTensor.embedLocalOperator_posSemidef}
-    \lean{MPOTensor.GSNNCHData.bondAt_posSemidef}
     \lean{MPOTensor.GSNNCHData.sectorProduct_posSemidef}
     \lean{MPOTensor.GSNNCHData.unnormalizedState_posSemidef}
     \lean{MPOTensor.HasGSNNCHFormAt.posSemidef}
     \leanok
-    \uses{def:mpdo_source_gsnnch, lem:mpdo_gsnnch_bond_translates_comm}
-    The represented operator
+    \uses{def:mpdo_source_gsnnch, lem:mpdo_gsnnch_bond_translates_comm,
+        lem:mpdo_gsnnch_translate_pos}
+    Each sector product $\prod_{j=1}^N\tau_j(B^{(x)})$ of an explicit GSNNCH
+    decomposition is positive semidefinite; hence so are the represented
+    operator
     \[
         \bigoplus_x n_x \prod_{j=1}^N\tau_j(B^{(x)})
     \]
-    of an explicit GSNNCH decomposition is positive semidefinite, and so is
-    every chain operator equal to a positive multiple of it.
+    and every chain operator equal to a positive multiple of it.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -194,8 +238,8 @@ Definition~\ref{def:mpdo_source_gsnnch}; the converse comparison is not used.
     positive semidefinite: for two commuting factors $A$ and $B$, the square
     root of $A$ commutes with $B$, so $AB=\sqrt A\,B\,\sqrt A$ is a conjugate
     of $B$; iterate along the product. Each sector product is such a product
-    by Lemma~\ref{lem:mpdo_gsnnch_bond_translates_comm}, each translate is
-    positive because the sector bond is, and the sum with natural
+    by Lemmas~\ref{lem:mpdo_gsnnch_translate_pos}
+    and~\ref{lem:mpdo_gsnnch_bond_translates_comm}, and the sum with natural
     coefficients preserves positivity.
 \end{proof}
 
@@ -205,27 +249,46 @@ Definition~\ref{def:mpdo_source_gsnnch}; the converse comparison is not used.
     \lean{MPOTensor.GSNNCHData.unnormalizedState_submatrix_rotateConfig}
     \lean{MPOTensor.HasGSNNCHFormAt.submatrix_rotateConfig}
     \leanok
-    \uses{def:mpdo_source_gsnnch, lem:mpdo_gsnnch_bond_translates_comm}
-    The represented operator of an explicit GSNNCH decomposition is invariant
+    \uses{def:mpdo_source_gsnnch, lem:mpdo_gsnnch_bond_translates_comm,
+        lem:mpdo_gsnnch_shift_transport}
+    Each sector product of an explicit GSNNCH decomposition is invariant
     under the cyclic shift of the periodic chain, where spin $N+1$ is
-    identified with the first
+    identified with the first; hence so are the represented operator and
+    every chain operator equal to a positive multiple of it
     \cite[lines~838--842]{Cirac2016MPDO_arXiv}.
 \end{lemma}
 
 \begin{proof}\leanok
-    The cyclic shift carries each translate $\tau_j(B^{(x)})$ to
+    By the transport identity of Lemma~\ref{lem:mpdo_gsnnch_shift_transport},
+    the cyclic shift carries each translate $\tau_j(B^{(x)})$ to
     $\tau_{j+1}(B^{(x)})$, so it permutes the factors of each sector product
     cyclically. All factors commute by
     Lemma~\ref{lem:mpdo_gsnnch_bond_translates_comm}, so the product is
     unchanged, and so is the sum over sectors.
 \end{proof}
 
-\begin{theorem}[Sector form with nonvanishing traces gives GSNNCH]
-    \label{thm:mpdo_gsnnch_of_sector_form}
+\begin{lemma}[The sector form passes to the trace normalization]
+    \label{lem:mpdo_gsnnch_form_normalized}
     \lean{MPOTensor.hasGSNNCHFormAt_normalizedMPO}
-    \lean{MPOTensor.isGSNNCH_of_hasGSNNCHForm}
     \leanok
     \uses{def:mpdo_source_gsnnch, lem:mpdo_gsnnch_sector_sum_pos}
+    If a finite-chain operator of an MPO tensor has the explicit sector form
+    of Definition~\ref{def:mpdo_source_gsnnch} and nonzero trace, then its
+    trace normalization has the sector form as well.
+\end{lemma}
+
+\begin{proof}\leanok
+    By Lemma~\ref{lem:mpdo_gsnnch_sector_sum_pos} the operator is positive
+    semidefinite, so its nonzero trace is positive and the normalization
+    multiplies the sector sum by a positive constant.
+\end{proof}
+
+\begin{theorem}[Sector form with nonvanishing traces gives GSNNCH]
+    \label{thm:mpdo_gsnnch_of_sector_form}
+    \lean{MPOTensor.isGSNNCH_of_hasGSNNCHForm}
+    \leanok
+    \uses{def:mpdo_source_gsnnch, lem:mpdo_gsnnch_sector_sum_pos,
+        lem:mpdo_gsnnch_form_normalized}
     If every finite-chain operator of an MPO tensor has the explicit sector
     form of Definition~\ref{def:mpdo_source_gsnnch} and a nonzero trace, then
     the normalized finite-chain states are density operators with that sector
@@ -235,8 +298,7 @@ Definition~\ref{def:mpdo_source_gsnnch}; the converse comparison is not used.
 
 \begin{proof}\leanok
     Positivity of each chain operator follows from
-    Lemma~\ref{lem:mpdo_gsnnch_sector_sum_pos}. A positive semidefinite
-    operator with nonzero trace has positive trace, so the normalization is
-    by a positive constant, which preserves the sector form and yields unit
-    trace.
+    Lemma~\ref{lem:mpdo_gsnnch_sector_sum_pos}, and the normalized state has
+    unit trace and keeps the sector form by
+    Lemma~\ref{lem:mpdo_gsnnch_form_normalized}.
 \end{proof}

--- a/docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex
+++ b/docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex
@@ -65,13 +65,28 @@ without explicit outer sectors.  A theorem embeds this presentation as the
 one-sector case of the source definition.  No converse theorem extracting a
 single bond from arbitrary source sector data is claimed.
 
+The represented finite-chain sector sum now carries its asserted analytic
+properties: all cyclic translates of one sector bond commute pairwise
+(\leanid{MPOTensor.GSNNCHData.bondAt\_comm}), the represented operator is
+positive semidefinite
+(\leanid{MPOTensor.GSNNCHData.unnormalizedState\_posSemidef}) and invariant
+under the cyclic shift
+(\leanid{MPOTensor.GSNNCHData.unnormalizedState\_submatrix\_rotateConfig}),
+and a tensor whose finite-chain operators have the sector form with nonzero
+traces satisfies the full density-operator predicate
+(\leanid{MPOTensor.isGSNNCH\_of\_hasGSNNCHForm}).  In particular every
+injective tensor satisfying the saturated area law is now proved GSNNCH
+(\leanid{MPOTensor.isGSNNCH\_of\_isInjective\_of\_isSAL}); for an injective
+tensor the basis of normal tensors has one element, so the one-sector form is
+the full source conclusion in that case.
+
 \section{Elimination plan}
 
-The remaining comparison and assembly work has three parts:
+The first part of the original plan---positivity and translation invariance
+of the represented finite-chain sector sum from the stored sector data---is
+complete.  The remaining comparison and assembly work has two parts:
 
 \begin{enumerate}
-  \item prove positivity and translation invariance of the represented
-        finite-chain sector sum from the stored sector data;
   \item construct the outer GSNNCH sectors from the BNT decomposition and the
         physical-sector factorization in Appendix C.2, retaining all sector
         multiplicities;
@@ -85,10 +100,13 @@ be substituted for those outer sectors.
 
 \section{Classification}
 
-Verdict: the source GSNNCH data and predicate are formalized, and the
-single-bond presentation is proved to give their one-sector case.  The open
-gap is the construction of the outer sectors and multiplicities in the
-simple-MPDO implication, together with any reverse comparison actually needed
-by that argument.
+Verdict: the source GSNNCH data and predicate are formalized, the represented
+sector sum is proved positive semidefinite and translation invariant with
+pairwise commuting translates, and the single-bond presentation is proved to
+give the one-sector case; the injective saturated-area-law case of the GSNNCH
+conclusion is complete.  The open gap is the construction of the outer
+sectors and multiplicities of a general simple tensor in the simple-MPDO
+implication, together with any reverse comparison actually needed by that
+argument.
 
 \end{document}

--- a/docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex
+++ b/docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex
@@ -76,9 +76,9 @@ and a tensor whose finite-chain operators have the sector form with nonzero
 traces satisfies the full density-operator predicate
 (\leanid{MPOTensor.isGSNNCH\_of\_hasGSNNCHForm}).  In particular every
 injective tensor satisfying the saturated area law is now proved GSNNCH
-(\leanid{MPOTensor.isGSNNCH\_of\_isInjective\_of\_isSAL}); for an injective
-tensor the basis of normal tensors has one element, so the one-sector form is
-the full source conclusion in that case.
+(\leanid{MPOTensor.isGSNNCH\_of\_isInjective\_of\_isSAL}), through a
+one-sector witness; the one-sector form is the commuting product form in
+which Proposition~C.8 states its conclusion for an injective tensor.
 
 \section{Elimination plan}
 
@@ -103,10 +103,10 @@ be substituted for those outer sectors.
 Verdict: the source GSNNCH data and predicate are formalized, the represented
 sector sum is proved positive semidefinite and translation invariant with
 pairwise commuting translates, and the single-bond presentation is proved to
-give the one-sector case; the injective saturated-area-law case of the GSNNCH
-conclusion is complete.  The open gap is the construction of the outer
-sectors and multiplicities of a general simple tensor in the simple-MPDO
-implication, together with any reverse comparison actually needed by that
-argument.
+give the one-sector case; every injective tensor satisfying the saturated
+area law is proved GSNNCH through a one-sector witness.  The open gap is the
+construction of the outer sectors and multiplicities of a general simple
+tensor in the simple-MPDO implication, together with any reverse comparison
+actually needed by that argument.
 
 \end{document}


### PR DESCRIPTION
## Summary

Progress on LionSR/TNLean#4003 (source GSNNCH definition, arXiv:1606.00608, Definition 4.8, lines 829–850). This PR completes the first step of the elimination plan in `docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex`: the represented finite-chain sector sum $\bigoplus_x n_x \prod_j \tau_j(B^{(x)})$ now carries its asserted analytic properties, proved from the stored sector data alone.

### New results (`TNLean/MPS/MPDO/GSNNCHSectorSum.lean`)

- `MPOTensor.GSNNCHData.bondAt_comm` — all cyclic translates of one sector bond commute pairwise. Disjoint windows commute by locality; the overlapping pairs are the coincident or cyclically adjacent starting sites, and conjugating the neighboring commutation $[B^{(x)}, \tau_1(B^{(x)})] = 0$ required by Definition 4.8 along powers of the cyclic shift covers them (transport lemma `MPOTensor.embedLocalOperator_submatrix_rotateConfig`).
- `MPOTensor.GSNNCHData.sectorProduct_posSemidef`, `unnormalizedState_posSemidef`, `MPOTensor.HasGSNNCHFormAt.posSemidef` — the sector sum is positive semidefinite (lines 843–850: each $B^{(x)} \ge 0$).
- `MPOTensor.GSNNCHData.unnormalizedState_submatrix_rotateConfig`, `MPOTensor.HasGSNNCHFormAt.submatrix_rotateConfig` — translation invariance under the cyclic shift (lines 838–842), in the repository's `rotateConfig` convention.
- `MPOTensor.isGSNNCH_of_hasGSNNCHForm` — a tensor whose finite-chain operators carry the sector form with nonzero traces satisfies the full density-operator predicate `IsGSNNCH`; positivity is now derived from the sector form instead of assumed.
- `MPOTensor.isGSNNCH_of_isInjective_of_isSAL` — every injective tensor satisfying SAL is GSNNCH (Proposition C.8, lines 1569–1594, combined with the density normalization of Definition 4.8). For an injective tensor the basis of normal tensors has a single element, so the one-sector form is the full source conclusion in this case; no scope restriction is needed.

### Infrastructure (`TNLean/Analysis/PosSemidefCommute.lean`)

- `Matrix.PosSemidef.mul_of_commute`, `Matrix.posSemidef_list_prod` — products of (pairwise) commuting positive-semidefinite matrices are positive semidefinite, via the functional-calculus square root.

### Blueprint and gap note

- New entries in `ch21_mpdo_rfp_gsnnch_definitions.tex` and `ch21_mpdo_rfp_commuting_form_gsnnch.tex` with `\lean{}`/`\leanok`.
- `docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex` updated: elimination-plan step 1 recorded complete; the remaining gap is the outer-sector construction from the BNT decomposition of a general simple tensor (and any reverse single-bond comparison that argument actually needs), which stays open in LionSR/TNLean#4003.

## Verification

- `lake build` succeeds; both new files compile with zero errors and zero warnings.
- `#print axioms` on every new theorem: only `propext`, `Classical.choice`, `Quot.sound`.
- No `sorry`, no new axioms, no kernel bypasses, no `maxHeartbeats` changes.
- `leanblueprint checkdecls` and `leanblueprint web` pass with no unresolved labels; chktex and latexindent clean on the changed chapters.

Trackers: LionSR/TNLean#236, LionSR/TNLean#232. Paper audit: LionSR/TNLean#2380.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Lean proofs on the MPDO formalization track with no runtime or security surface; main review focus is mathematical correctness of the new theorems and blueprint alignment.
> 
> **Overview**
> Adds formal proofs that the **GSNNCH** sector sum from stored `GSNNCHData` is positive semidefinite, cyclically translation invariant, and built from **pairwise commuting** bond translates—closing elimination-plan step 1 in the gap note.
> 
> **`TNLean/Analysis/PosSemidefCommute.lean`** introduces `Matrix.PosSemidef.mul_of_commute` and `Matrix.posSemidef_list_prod` for products of commuting PSD matrices.
> 
> **`TNLean/MPS/MPDO/GSNNCHSectorSum.lean`** proves cyclic-shift transport for embedded local operators, extends neighboring commutation to all translates (`bondAt_comm`), derives sector-sum PSD and `rotateConfig` invariance, and shows `HasGSNNCHForm` with nonzero traces implies `IsGSNNCH`. **`isGSNNCH_of_isInjective_of_isSAL`** gives injective SAL tensors a one-sector GSNNCH witness via existing η-local structure.
> 
> Root imports, blueprint chapter 21 lemmas/theorems (`\leanok`), and `docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex` are updated to record completed analytic properties and the remaining outer-sector construction gap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ee40da9c4fcd4da1815a3b5e7220bd75b4bb997. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->