### PR TITLE
ci: install dsfont for paper-gap PDFs in docgen

### DIFF
--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -49,8 +49,8 @@ jobs:
       - name: Install TeX and graphviz
         uses: texra-ai/lean-env-action/blueprint-system-deps@v1
         with:
-          cache-suffix: docgen-v1
-          extra-packages: latexmk texlive-science texlive-xetex
+          cache-suffix: docgen-v2
+          extra-packages: latexmk texlive-science texlive-xetex texlive-fonts-extra
 
       - name: Install leanblueprint
         uses: texra-ai/lean-env-action/leanblueprint@v1


### PR DESCRIPTION
### Motivation

The docgen workflow's *Build paper-gap PDFs* step has failed on the last three runs (29493624337 and the two scheduled runs before it) with:

```
! LaTeX Error: File 'dsfont.sty' not found.
```

`docs/paper-gaps/command.tex` line 20 loads `dsfont` (for $\mathds{1}$), but the runner's TeX installation (`latexmk texlive-science texlive-xetex`) does not include it. On Ubuntu, `dsfont.sty` ships in `texlive-fonts-extra`.

This failure blocks #4036: the first `site-docs` artifact cannot be seeded, so the `gh-pages` branch cannot be deleted yet.

### Description

- Add `texlive-fonts-extra` to the `extra-packages` of the *Install TeX and graphviz* step in `.github/workflows/docgen.yml`.
- Bump `cache-suffix` from `docgen-v1` to `docgen-v2` so the system-deps cache is rebuilt with the new package.

### Testing

CI-only change; validated by dispatching `docgen.yml` after merge (the workflow is not exercised by PR checks).

Refs #4036.

https://claude.ai/code/session_014TxvMnpGSqatcyWuPUqmpd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow dependency change with no application or runtime impact.
> 
> **Overview**
> Fixes failing **Build paper-gap PDFs** steps in the full documentation workflow by installing **`texlive-fonts-extra`**, which provides **`dsfont.sty`** required by `docs/paper-gaps/command.tex` (used for `\mathds{1}`).
> 
> The TeX install step’s **`extra-packages`** list now includes that package, and **`cache-suffix`** is bumped from **`docgen-v1`** to **`docgen-v2`** so cached system-deps are rebuilt with the new dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8bd425a837739d8b9fd546f5488fbf5456dc10f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->