### PR TITLE
feat(MPS/MPDO): prove copy independence of simple-sector weights

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -403,6 +403,7 @@ import TNLean.MPS.MPDO.LinearMarkedTensor
 import TNLean.MPS.MPDO.HorizontalCFMPVRepresentation
 import TNLean.MPS.MPDO.InvariantProjection
 import TNLean.MPS.MPDO.HorizontalBNT
+import TNLean.MPS.MPDO.SimpleTensor
 import TNLean.MPS.MPDO.VerticalReduction
 import TNLean.MPS.MPDO.PeriodicExclusion
 import TNLean.MPS.MPDO.StackedLayers

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -403,7 +403,6 @@ import TNLean.MPS.MPDO.LinearMarkedTensor
 import TNLean.MPS.MPDO.HorizontalCFMPVRepresentation
 import TNLean.MPS.MPDO.InvariantProjection
 import TNLean.MPS.MPDO.HorizontalBNT
-import TNLean.MPS.MPDO.SimpleTensor
 import TNLean.MPS.MPDO.VerticalReduction
 import TNLean.MPS.MPDO.PeriodicExclusion
 import TNLean.MPS.MPDO.StackedLayers
@@ -426,6 +425,7 @@ import TNLean.MPS.MPDO.RFPViaTS
 import TNLean.MPS.MPDO.RFPViaTSGlobal
 import TNLean.MPS.MPDO.RFPViaTSSAL
 import TNLean.MPS.MPDO.PhysicalBlocking
+import TNLean.MPS.MPDO.SimpleTensor
 import TNLean.MPS.MPDO.HorizontalBlocking
 import TNLean.MPS.MPDO.TwoSiteVerticalCanonicalForm
 import TNLean.MPS.MPDO.VerticalSectorRetractions

--- a/TNLean/MPS/MPDO/SimpleTensor.lean
+++ b/TNLean/MPS/MPDO/SimpleTensor.lean
@@ -1,0 +1,302 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.HorizontalBNT
+import TNLean.MPS.MPDO.PhysicalBlocking
+import TNLean.MPS.MPDO.ZCL
+
+/-!
+# Simple MPO tensors and copy-independent sector weights
+
+This file begins the "Case II: $K$ simple" analysis of arXiv:1606.00608.  The
+source views the tensor generating the MPDO as a matrix product vector whose
+doubled physical index carries the bra and ket legs, writes it in canonical
+form over a basis of normal tensors $M_k$, and attaches to each basis element
+the single-site transfer matrix $\mathcal{B}_k$ obtained by contracting the
+ket leg against the bra leg (lines 815--818).  A tensor is *simple* when no
+$\mathcal{B}_k$ is nilpotent (lines 819--822).  For simple tensors, zero
+correlation length forces the canonical-form weights $\mu_{j,q}$ to be
+independent of the copy index $q$ (Appendix C.2, lines 1646--1661).
+
+## Main declarations
+
+* `MPOTensor.doubledPhysTraceTransfer`: the transfer matrix $\sum_i B^{(i,i)}$
+  of a doubled-index tensor.
+* `MPOTensor.doubledPhysTraceTransfer_toMPSTensor`: on the doubled-index view
+  of an MPO tensor this recovers `MPOTensor.physTraceTransfer`.
+* `MPOTensor.doubledPhysTraceTransfer_toTensor`: the physical-trace transfer
+  of an assembled sector decomposition is block diagonal with blocks
+  $\mu_{j,q}\,\mathcal{B}_j$.
+* `MPOTensor.IsSimpleCanonicalForm`: simplicity for a tensor already in the
+  blocked canonical-form setting of Appendix C.2.
+* `MPOTensor.IsSimple`: the source simplicity predicate, allowing the positive
+  physical blocking required before the BNT canonical form is chosen.
+* `MPOTensor.weight_copy_independent_of_isSourceZCL`: zero correlation length
+  makes the canonical-form weights independent of the copy index.
+* `MPOTensor.IsSimpleCanonicalForm.exists_weight_copy_independent_of_isSourceZCL`:
+  the existential form for a simple canonical-form tensor.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Section 4.3 and Appendix C.2
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPOTensor
+
+/-- The **physical-trace transfer of a doubled-index tensor**: the single bond
+matrix $\sum_i B^{(i,i)}$ obtained by contracting the ket leg of one tensor
+against its bra leg.  This is the transfer object of the source
+zero-correlation-length condition (arXiv:1606.00608, Definition 4.2, lines
+735--739), applied to a single basis-of-normal-tensors element as in the
+transfer matrices $\mathcal{B}_k$ of lines 815--818. -/
+noncomputable def doubledPhysTraceTransfer (d : ℕ) {D' : ℕ} (B : MPSTensor (d * d) D') :
+    Matrix (Fin D') (Fin D') ℂ :=
+  ∑ i : Fin d, B (finProdFinEquiv (i, i))
+
+variable {d D : ℕ}
+
+/-- On the doubled-index view of an MPO tensor, the doubled physical-trace
+transfer is the physical-trace transfer $\mathcal{T}_M = \sum_i M^{ii}$ of the
+source zero-correlation-length condition (arXiv:1606.00608, Definition 4.2,
+lines 735--739). -/
+theorem doubledPhysTraceTransfer_toMPSTensor (M : MPOTensor d D) :
+    doubledPhysTraceTransfer d M.toMPSTensor = physTraceTransfer M := by
+  simp only [doubledPhysTraceTransfer, physTraceTransfer, toMPSTensor,
+    MPSTensor.finProdFinEquiv_divNat, MPSTensor.finProdFinEquiv_modNat]
+
+/-- The physical-trace transfer of an assembled sector decomposition is block
+diagonal: the block of the flattened copy $s \leftrightarrow (j, q)$ is
+$\mu_{j,q}\,\mathcal{B}_j$, where $\mathcal{B}_j$ is the physical-trace
+transfer of the basis element $A_j$.  This is the block structure obtained by
+contracting the physical legs of the canonical-form display of
+arXiv:1606.00608, equation Eq19, lines 304--308, as in the proof of the
+copy-independence lemma at lines 1652--1661. -/
+theorem doubledPhysTraceTransfer_toTensor (S : MPSTensor.SectorDecomposition (d * d)) :
+    doubledPhysTraceTransfer d S.toTensor =
+      (Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv)
+        (Matrix.blockDiagonal' fun s =>
+          S.flatWeight s • doubledPhysTraceTransfer d (S.flatBasis s)) := by
+  classical
+  ext a b
+  simp only [doubledPhysTraceTransfer, MPSTensor.SectorDecomposition.toTensor,
+    MPSTensor.toTensorFromBlocks, Matrix.sum_apply, Matrix.reindex_apply,
+    Matrix.submatrix_apply, Matrix.blockDiagonal'_apply]
+  by_cases h : (finSigmaFinEquiv.symm a).1 = (finSigmaFinEquiv.symm b).1
+  · simp only [dif_pos h, Matrix.smul_apply, Matrix.sum_apply, smul_eq_mul, Finset.mul_sum]
+  · simp only [dif_neg h, Finset.sum_const_zero]
+
+/-- **Simple MPO tensor in the chosen canonical form** (arXiv:1606.00608,
+lines 815--822).  The source
+writes the doubled-index tensor in canonical form over a basis of normal
+tensors $M_k$ and attaches to each basis element the transfer matrix
+$\mathcal{B}_k$ contracting ket against bra leg (lines 815--818).  A basis
+element is *nilpotent* when tracing $R \le D$ sites annihilates the generated
+state: $\operatorname{tr}_R \rho^{(N)}(M_k) = 0$ after tracing $R \le D$
+sites, for $N$ sufficiently large (line 819).  For the transfer matrix this
+reads $\mathcal{B}_k^R = 0$ with $R \le D$, which is matrix nilpotency, since
+the nilpotency index of a nilpotent $D \times D$ matrix is at most $D$.  The
+definition at line 822 then reads: "A tensor generating MPDO's is simple if
+none of the elements in a BNT is nilpotent."
+
+This predicate is the form used for the already-blocked tensor $K$ in
+Appendix C.2, line 1628. It retains the assumption that `M` generates MPDOs;
+its canonical-form witness has the shape of `MPOTensor.IsHorizontalCF`, with
+the additional requirement that no basis element have nilpotent
+physical-trace transfer. -/
+def IsSimpleCanonicalForm (M : MPOTensor d D) : Prop :=
+  IsMPDO M ∧
+    ∃ S : MPSTensor.SectorDecomposition (d * d),
+      MPSTensor.IsBNTCanonicalForm S ∧
+        (∀ j, ¬ IsNilpotent (doubledPhysTraceTransfer d (S.basis j))) ∧
+        ∃ hTotal : S.totalDim = D,
+          ∃ X : (s : Fin S.totalCopies) → GL (Fin (S.flatDim s)) ℂ,
+          ∀ i : Fin (d * d),
+            M.toMPSTensor i =
+              cast (by rw [hTotal] :
+                  Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ =
+                    Matrix (Fin D) (Fin D) ℂ)
+                ((MPSTensor.globalGaugeOfBlocks X :
+                      Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ) *
+                  S.toTensor i *
+                  (((MPSTensor.globalGaugeOfBlocks X)⁻¹ :
+                      GL (Fin S.totalDim) ℂ) :
+                    Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ))
+
+/-- **Simple MPO tensor** (arXiv:1606.00608, lines 815--822). Before choosing
+the BNT, the source blocks a positive number of physical sites (line 815).
+A tensor is simple when one such blocked tensor is a simple canonical-form
+tensor in the sense above. -/
+def IsSimple (M : MPOTensor d D) : Prop :=
+  IsMPDO M ∧ ∃ L : ℕ, 0 < L ∧ IsSimpleCanonicalForm (blockTensor M L)
+
+/-- A simple canonical-form tensor is in horizontal canonical form:
+simplicity is the horizontal canonical form of arXiv:1606.00608, lines
+815--818, together with the nilpotency exclusion of lines 819--822. -/
+theorem IsSimpleCanonicalForm.isHorizontalCF {M : MPOTensor d D}
+    (hM : IsSimpleCanonicalForm M) :
+    IsHorizontalCF M := by
+  obtain ⟨-, S, hCF, -, hTotal, X, hEq⟩ := hM
+  exact ⟨S, hCF, hTotal, X, hEq⟩
+
+/-- **Zero correlation length makes the sector weights copy independent**
+(arXiv:1606.00608, Appendix C.2, lines 1646--1661).  Let the doubled-index
+view of $M$ be in canonical form over a basis of normal tensors with per-copy
+weights $\mu_{j,q}$, and suppose no basis element has nilpotent physical-trace
+transfer.  If $M$ has zero correlation length, then $\mu_{j,q}$ does not
+depend on $q$.
+
+The source proof applies the zero-correlation-length equation to the
+canonical-form display: with
+$\mathcal{T}_M^2 = \lambda\,\mathcal{T}_M$, $\lambda > 0$, the block
+decomposition gives
+$\mu_{j,q}^2\,\mathcal{B}_j^2 = \lambda\,\mu_{j,q}\,\mathcal{B}_j$ on the copy
+$(j, q)$, so $\mathcal{B}_j^2 = (\lambda/\mu_{j,q})\,\mathcal{B}_j$; since
+$\mathcal{B}_j \ne 0$ ("this cannot be zero", line 1657), the scalar
+$\lambda/\mu_{j,q}$, hence $\mu_{j,q}$, is independent of $q$. -/
+theorem weight_copy_independent_of_isSourceZCL {M : MPOTensor d D}
+    (S : MPSTensor.SectorDecomposition (d * d)) (hTotal : S.totalDim = D)
+    (X : (s : Fin S.totalCopies) → GL (Fin (S.flatDim s)) ℂ)
+    (hEq : ∀ i : Fin (d * d),
+      M.toMPSTensor i =
+        cast (by rw [hTotal] :
+            Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ =
+              Matrix (Fin D) (Fin D) ℂ)
+          ((MPSTensor.globalGaugeOfBlocks X :
+                Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ) *
+            S.toTensor i *
+            (((MPSTensor.globalGaugeOfBlocks X)⁻¹ :
+                GL (Fin S.totalDim) ℂ) :
+              Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ)))
+    (hZCL : IsSourceZCL M)
+    (hnonNil : ∀ j, ¬ IsNilpotent (doubledPhysTraceTransfer d (S.basis j)))
+    (j : Fin S.basisCount) (q q' : Fin (S.copies j)) :
+    S.weight j q = S.weight j q' := by
+  classical
+  subst hTotal
+  obtain ⟨-, lam, hlam, hsq⟩ := hZCL
+  have hX' : ∀ i : Fin (d * d), M.toMPSTensor i =
+      (MPSTensor.globalGaugeOfBlocks X : Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ) *
+        S.toTensor i *
+        (((MPSTensor.globalGaugeOfBlocks X)⁻¹ : GL (Fin S.totalDim) ℂ) :
+          Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ) := fun i => by simpa using hEq i
+  -- Contract the ket leg against the bra leg in the canonical form.
+  have hT : physTraceTransfer M =
+      (MPSTensor.globalGaugeOfBlocks X : Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ) *
+        doubledPhysTraceTransfer d S.toTensor *
+        (((MPSTensor.globalGaugeOfBlocks X)⁻¹ : GL (Fin S.totalDim) ℂ) :
+          Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ) := by
+    rw [← doubledPhysTraceTransfer_toMPSTensor M]
+    simp only [doubledPhysTraceTransfer]
+    rw [Matrix.mul_sum, Matrix.sum_mul]
+    exact Finset.sum_congr rfl fun i _ => hX' (finProdFinEquiv (i, i))
+  rw [hT] at hsq
+  -- Cancel the global gauge in the zero-correlation-length equation.
+  have hRR : doubledPhysTraceTransfer d S.toTensor * doubledPhysTraceTransfer d S.toTensor =
+      (lam : ℂ) • doubledPhysTraceTransfer d S.toTensor := by
+    have h2 := congrArg (fun Z =>
+      (((MPSTensor.globalGaugeOfBlocks X)⁻¹ : GL (Fin S.totalDim) ℂ) :
+        Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ) * Z *
+        (MPSTensor.globalGaugeOfBlocks X :
+          Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ)) hsq
+    simpa only [Matrix.mul_smul, Matrix.smul_mul, mul_assoc, Units.inv_mul_cancel_left,
+      Units.inv_mul, mul_one] using h2
+  rw [doubledPhysTraceTransfer_toTensor] at hRR
+  -- Blockwise form of the zero-correlation-length equation.
+  have hfun : (fun s => (S.flatWeight s • doubledPhysTraceTransfer d (S.flatBasis s)) *
+        (S.flatWeight s • doubledPhysTraceTransfer d (S.flatBasis s))) =
+      (lam : ℂ) • fun s => S.flatWeight s • doubledPhysTraceTransfer d (S.flatBasis s) := by
+    apply Matrix.blockDiagonal'_injective
+    apply (Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv).injective
+    simpa only [Matrix.reindex_apply, Matrix.blockDiagonal'_mul, Matrix.blockDiagonal'_smul,
+      Matrix.submatrix_mul_equiv, Matrix.submatrix_smul, Pi.smul_apply] using hRR
+  -- Restrict to the copies of the representative `j`.
+  have key : ∀ r : Fin (S.copies j),
+      (S.weight j r • doubledPhysTraceTransfer d (S.basis j)) *
+          (S.weight j r • doubledPhysTraceTransfer d (S.basis j)) =
+        (lam : ℂ) • (S.weight j r • doubledPhysTraceTransfer d (S.basis j)) := by
+    intro r
+    have h :
+        (S.weight (S.flatIndexEquiv.symm (S.flatIndexEquiv ⟨j, r⟩)).1
+              (S.flatIndexEquiv.symm (S.flatIndexEquiv ⟨j, r⟩)).2 •
+            doubledPhysTraceTransfer d
+              (S.basis (S.flatIndexEquiv.symm (S.flatIndexEquiv ⟨j, r⟩)).1)) *
+          (S.weight (S.flatIndexEquiv.symm (S.flatIndexEquiv ⟨j, r⟩)).1
+              (S.flatIndexEquiv.symm (S.flatIndexEquiv ⟨j, r⟩)).2 •
+            doubledPhysTraceTransfer d
+              (S.basis (S.flatIndexEquiv.symm (S.flatIndexEquiv ⟨j, r⟩)).1)) =
+        (lam : ℂ) •
+          (S.weight (S.flatIndexEquiv.symm (S.flatIndexEquiv ⟨j, r⟩)).1
+              (S.flatIndexEquiv.symm (S.flatIndexEquiv ⟨j, r⟩)).2 •
+            doubledPhysTraceTransfer d
+              (S.basis (S.flatIndexEquiv.symm (S.flatIndexEquiv ⟨j, r⟩)).1)) :=
+      congrFun hfun (S.flatIndexEquiv ⟨j, r⟩)
+    rw [Equiv.symm_apply_apply] at h
+    exact h
+  -- The basis transfer is nonzero, so the scalars can be compared.
+  have hTj0 : doubledPhysTraceTransfer d (S.basis j) ≠ 0 := by
+    intro h0
+    exact hnonNil j (by rw [h0]; exact IsNilpotent.zero)
+  have hdiv : ∀ r : Fin (S.copies j),
+      doubledPhysTraceTransfer d (S.basis j) * doubledPhysTraceTransfer d (S.basis j) =
+        ((lam : ℂ) / S.weight j r) • doubledPhysTraceTransfer d (S.basis j) := by
+    intro r
+    have hμ : S.weight j r ≠ 0 := S.weight_ne_zero j r
+    have hk := key r
+    rw [smul_mul_smul_comm, smul_smul] at hk
+    have h3 := congrArg (fun Z => (S.weight j r * S.weight j r)⁻¹ • Z) hk
+    simp only [smul_smul] at h3
+    rw [inv_mul_cancel₀ (mul_ne_zero hμ hμ), one_smul] at h3
+    rw [h3]
+    congr 1
+    field_simp
+  have hq := (hdiv q).symm.trans (hdiv q')
+  have hscalar : (lam : ℂ) / S.weight j q = (lam : ℂ) / S.weight j q' := by
+    by_contra hne
+    have hsub : ((lam : ℂ) / S.weight j q - (lam : ℂ) / S.weight j q') •
+        doubledPhysTraceTransfer d (S.basis j) = 0 := by
+      rw [sub_smul, hq, sub_self]
+    have h4 := congrArg (fun Z =>
+      ((lam : ℂ) / S.weight j q - (lam : ℂ) / S.weight j q')⁻¹ • Z) hsub
+    simp only [smul_smul, smul_zero] at h4
+    rw [inv_mul_cancel₀ (sub_ne_zero.mpr hne), one_smul] at h4
+    exact hTj0 h4
+  have hlam0 : (lam : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr (ne_of_gt hlam)
+  rw [div_eq_div_iff (S.weight_ne_zero j q) (S.weight_ne_zero j q')] at hscalar
+  exact (mul_left_cancel₀ hlam0 hscalar).symm
+
+/-- **Copy-independent weights for a simple canonical-form tensor with zero
+correlation length** (arXiv:1606.00608, Appendix C.2, lines 1628 and
+1646--1661). A simplicity witness supplies the chosen canonical form and the
+nilpotency exclusion; zero correlation length then makes the sector weights
+$\mu_{j,q}$ independent of the copy index $q$. -/
+theorem IsSimpleCanonicalForm.exists_weight_copy_independent_of_isSourceZCL
+    {M : MPOTensor d D} (hM : IsSimpleCanonicalForm M)
+    (hZCL : IsSourceZCL M) :
+    ∃ S : MPSTensor.SectorDecomposition (d * d),
+      MPSTensor.IsBNTCanonicalForm S ∧
+        (∃ hTotal : S.totalDim = D,
+          ∃ X : (s : Fin S.totalCopies) → GL (Fin (S.flatDim s)) ℂ,
+          ∀ i : Fin (d * d),
+            M.toMPSTensor i =
+              cast (by rw [hTotal] :
+                  Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ =
+                    Matrix (Fin D) (Fin D) ℂ)
+                ((MPSTensor.globalGaugeOfBlocks X :
+                      Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ) *
+                  S.toTensor i *
+                  (((MPSTensor.globalGaugeOfBlocks X)⁻¹ :
+                      GL (Fin S.totalDim) ℂ) :
+                    Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ))) ∧
+        (∀ j, ¬ IsNilpotent (doubledPhysTraceTransfer d (S.basis j))) ∧
+        ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+          S.weight j q = S.weight j q' := by
+  obtain ⟨-, S, hCF, hnil, hTotal, X, hEq⟩ := hM
+  exact ⟨S, hCF, ⟨hTotal, X, hEq⟩, hnil, fun j q q' =>
+    weight_copy_independent_of_isSourceZCL S hTotal X hEq hZCL hnil j q q'⟩
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/SimpleTensor.lean
+++ b/TNLean/MPS/MPDO/SimpleTensor.lean
@@ -103,11 +103,13 @@ the nilpotency index of a nilpotent $D \times D$ matrix is at most $D$.  The
 definition at line 822 then reads: "A tensor generating MPDO's is simple if
 none of the elements in a BNT is nilpotent."
 
-This predicate is the form used for the already-blocked tensor $K$ in
-Appendix C.2, line 1628. It retains the assumption that `M` generates MPDOs;
-its canonical-form witness has the shape of `MPOTensor.IsHorizontalCF`, with
-the additional requirement that no basis element have nilpotent
-physical-trace transfer. -/
+This predicate records the simple horizontal-canonical-form data of the
+already-blocked tensor $K$ in Appendix C.2, line 1628. It does not include
+the separate biCF hypothesis imposed there, since the copy-independence
+argument at lines 1646--1658 does not use the inverse tensor. It retains the
+assumption that `M` generates MPDOs; its canonical-form witness has the shape
+of `MPOTensor.IsHorizontalCF`, with the additional requirement that no basis
+element have nilpotent physical-trace transfer. -/
 def IsSimpleCanonicalForm (M : MPOTensor d D) : Prop :=
   IsMPDO M ∧
     ∃ S : MPSTensor.SectorDecomposition (d * d),

--- a/blueprint/src/chapter/ch21_mpdo_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp.tex
@@ -12,15 +12,17 @@ Following the order of the mixed-state analysis in
 \cite[Section~4]{Cirac2016MPDO_arXiv}, the discussion first states the local
 renormalization condition and then records its comparison with the pure-state
 formalism.  It next passes to zero correlation length, purification fixed
-points, mutual information, and saturation of the area law.  The definition of Gibbs states of
-nearest-neighbor commuting Hamiltonians precedes the derivation of the simple
-local and commuting structures.  The boundary-theory interlude of the source
-is outside the present MPO development.  The general case and its algebraic
-characterization continue in Chapter~\ref{ch:mpdo_rfp_algebraic}.
+points, mutual information, and saturation of the area law. The source
+definitions of simple tensors and Gibbs states of nearest-neighbor commuting
+Hamiltonians precede the simple local and commuting structures. The
+boundary-theory interlude of the source is outside the present MPO development.
+The general case and its algebraic characterization continue in
+Chapter~\ref{ch:mpdo_rfp_algebraic}.
 
 \input{chapter/ch21_mpdo_rfp_renormalization}
 \input{chapter/ch21_mpdo_rfp_foundations}
 \input{chapter/ch21_mpdo_rfp_area_law}
+\input{chapter/ch21_mpdo_rfp_simple_definition}
 \input{chapter/ch21_mpdo_rfp_gsnnch_definitions}
 \input{chapter/ch21_mpdo_rfp_blocked_rfp}
 \input{chapter/ch21_mpdo_rfp_simple_local_structure}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_case_two.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_case_two.tex
@@ -1,0 +1,58 @@
+\subsection{Simple canonical-form weights}
+
+\begin{theorem}[Copy independence for a non-nilpotent sector decomposition]
+    \label{thm:mpdo_simple_weight_copy_independent}
+    \lean{MPOTensor.weight_copy_independent_of_isSourceZCL}
+    \leanok
+    \uses{def:mpo_source_zcl, def:mpdo_doubled_phys_trace_transfer,
+        lem:mpdo_doubled_phys_trace_transfer_to_mps,
+        lem:mpdo_doubled_phys_trace_transfer_blockwise}
+    Let a tensor with zero correlation length be gauge-equivalent, through
+    block-diagonal copy gauges, to an assembled sector decomposition whose
+    basis elements all have non-nilpotent physical-trace transfer. Then the
+    weights do not depend on the copy index: $\mu_{j,q}=\mu_{j}$
+    \cite[Appendix~C.2, lines~1646--1661]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    Zero correlation length states
+    $\mathcal T_M^{2}=\lambda\,\mathcal T_M$ with $\lambda>0$.  If
+    $\mathcal T_M=X\mathcal T_SX^{-1}$ is the block-diagonal gauge to the
+    transfer of the assembled sector decomposition, then cancellation of
+    $X$ and $X^{-1}$ gives
+    \[
+        \mathcal T_S^{2}=\lambda\,\mathcal T_S.
+    \]
+    By
+    Lemmas~\ref{lem:mpdo_doubled_phys_trace_transfer_to_mps}
+    and~\ref{lem:mpdo_doubled_phys_trace_transfer_blockwise} the identity
+    descends to every copy:
+    \[
+        \mu_{j,q}^{2}\,\mathcal T_{A_{j}}^{2}
+        =\lambda\,\mu_{j,q}\,\mathcal T_{A_{j}},
+        \qquad\text{hence}\qquad
+        \mathcal T_{A_{j}}^{2}
+        =\frac{\lambda}{\mu_{j,q}}\,\mathcal T_{A_{j}}.
+    \]
+    The left side does not depend on $q$, and
+    $\mathcal T_{A_{j}}\ne0$ because it is not nilpotent, so
+    $\lambda/\mu_{j,q}$ is independent of $q$, which gives
+    $\mu_{j,q}=\mu_{j,q'}$.
+\end{proof}
+
+\begin{corollary}[Simple canonical-form tensors with zero correlation length]
+    \label{cor:mpdo_simple_zcl_weight_copy_independent}
+    \lean{MPOTensor.IsSimpleCanonicalForm.exists_weight_copy_independent_of_isSourceZCL}
+    \leanok
+    \uses{def:mpdo_simple_cf_tensor, def:mpo_source_zcl,
+        thm:mpdo_simple_weight_copy_independent}
+    A simple canonical-form tensor
+    (Definition~\ref{def:mpdo_simple_cf_tensor}) with zero correlation length
+    has non-nilpotent basis transfers and weights independent of the copy
+    index.
+\end{corollary}
+
+\begin{proof}\leanok
+    Apply Theorem~\ref{thm:mpdo_simple_weight_copy_independent} to the
+    witness supplied by the simple canonical-form predicate.
+\end{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex
@@ -1,0 +1,109 @@
+\section{Simple tensors}
+
+\begin{definition}[Physical-trace transfer of a doubled-index tensor]
+    \label{def:mpdo_doubled_phys_trace_transfer}
+    \lean{MPOTensor.doubledPhysTraceTransfer}
+    \leanok
+    \uses{def:mpo_tensor}
+    For a doubled-index tensor $B$ with physical dimension $d^{2}$, the
+    physical-trace transfer is the bond matrix obtained by closing the ket
+    leg against the bra leg of one tensor:
+    \[
+        \mathcal T_{B}=\sum_{i} B^{\,ii}.
+    \]
+    This is the transfer object of the zero-correlation-length condition of
+    \cite[Definition~4.2, lines~735--739]{Cirac2016MPDO_arXiv}, applied to
+    one element of a basis of normal tensors.
+\end{definition}
+
+\begin{lemma}[Identification with the tensor-level transfer]
+    \label{lem:mpdo_doubled_phys_trace_transfer_to_mps}
+    \lean{MPOTensor.doubledPhysTraceTransfer_toMPSTensor}
+    \leanok
+    \uses{def:mpdo_doubled_phys_trace_transfer}
+    The physical-trace transfer of the doubled-index view of an MPO tensor
+    is the physical-trace transfer of the tensor itself.
+\end{lemma}
+
+\begin{proof}\leanok
+    If $M^{\mathrm{dbl}}$ is the doubled-index view of $M$, then
+    $(M^{\mathrm{dbl}})^{(i,j)}=M^{ij}$, and hence
+    \[
+        \mathcal T_{M^{\mathrm{dbl}}}
+          =\sum_i(M^{\mathrm{dbl}})^{ii}
+          =\sum_i M^{ii}
+          =\mathcal T_M.
+    \]
+\end{proof}
+
+\begin{lemma}[Blockwise form of the physical-trace transfer]
+    \label{lem:mpdo_doubled_phys_trace_transfer_blockwise}
+    \lean{MPOTensor.doubledPhysTraceTransfer_toTensor}
+    \leanok
+    \uses{def:mpdo_doubled_phys_trace_transfer}
+    For a sector decomposition with basis elements $A_{j}$ and weights
+    $\mu_{j,q}$, the physical-trace transfer of the assembled tensor is the
+    block direct sum of the weighted transfers of the copies:
+    \[
+        \mathcal T
+        =\bigoplus_{j}\bigoplus_{q}\mu_{j,q}\,\mathcal T_{A_{j}}.
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    The diagonal physical sum distributes over the block direct sum:
+    \[
+    \begin{aligned}
+        \mathcal T
+          &=\sum_i S^{ii}
+           =\sum_i\bigoplus_{j,q}\mu_{j,q}A_j^{ii} \\
+          &=\bigoplus_{j,q}\mu_{j,q}\sum_i A_j^{ii}
+           =\bigoplus_{j,q}\mu_{j,q}\mathcal T_{A_j}.
+    \end{aligned}
+    \]
+\end{proof}
+
+\begin{definition}[Simple tensor]
+    \label{def:mpdo_simple_tensor}
+    \lean{MPOTensor.IsSimple}
+    \leanok
+    \uses{def:mpdo, def:mpdo_positive_physical_blocking,
+        def:mpdo_simple_cf_tensor}
+    First block a positive number of physical sites and write the blocked
+    doubled-index tensor in canonical form over a basis of normal tensors, as
+    prescribed at line~815 of \cite{Cirac2016MPDO_arXiv}. A tensor generating
+    MPDOs is \emph{simple} if one such canonical form has no nilpotent basis
+    element \cite[line~822]{Cirac2016MPDO_arXiv}. A basis element is
+    nilpotent when tracing $R\le D$ sites annihilates its density operators
+    for all large chain lengths \cite[line~819]{Cirac2016MPDO_arXiv}; this is
+    nilpotency of its physical-trace transfer matrix.
+\end{definition}
+
+\begin{definition}[Simple tensor in blocked canonical form]
+    \label{def:mpdo_simple_cf_tensor}
+    \lean{MPOTensor.IsSimpleCanonicalForm}
+    \leanok
+    \uses{def:mpdo, def:horizontal_cf_mpdo,
+        def:mpdo_doubled_phys_trace_transfer}
+    A tensor generating MPDOs is in \emph{simple canonical form} if it has a
+    basis-of-normal-tensors decomposition whose basis elements all have
+    non-nilpotent physical-trace transfer.  This is the already-blocked form
+    of the simple tensor $K$ fixed at the start of Case II in
+    \cite[Appendix~C.2, line~1628]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{lemma}[Simple canonical-form tensors are horizontal canonical]
+    \label{lem:mpdo_simple_tensor_horizontal_cf}
+    \lean{MPOTensor.IsSimpleCanonicalForm.isHorizontalCF}
+    \leanok
+    \uses{def:mpdo_simple_cf_tensor, def:horizontal_cf_mpdo}
+    A simple tensor already in the chosen blocked canonical-form setting is
+    in horizontal canonical form.
+\end{lemma}
+
+\begin{proof}\leanok
+    The canonical-form data in the simplicity hypothesis---the sector
+    decomposition, its basis-of-normal-tensors property, and the
+    block-diagonal gauge---give a horizontal canonical form.  Positivity and
+    non-nilpotency are not needed for this conclusion.
+\end{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex
@@ -30,9 +30,9 @@
     $(M^{\mathrm{dbl}})^{(i,j)}=M^{ij}$, and hence
     \[
         \mathcal T_{M^{\mathrm{dbl}}}
-          =\sum_i(M^{\mathrm{dbl}})^{ii}
-          =\sum_i M^{ii}
-          =\mathcal T_M.
+        =\sum_i(M^{\mathrm{dbl}})^{ii}
+        =\sum_i M^{ii}
+        =\mathcal T_M.
     \]
 \end{proof}
 
@@ -53,13 +53,13 @@
 \begin{proof}\leanok
     The diagonal physical sum distributes over the block direct sum:
     \[
-    \begin{aligned}
-        \mathcal T
-          &=\sum_i S^{ii}
-           =\sum_i\bigoplus_{j,q}\mu_{j,q}A_j^{ii} \\
-          &=\bigoplus_{j,q}\mu_{j,q}\sum_i A_j^{ii}
-           =\bigoplus_{j,q}\mu_{j,q}\mathcal T_{A_j}.
-    \end{aligned}
+        \begin{aligned}
+            \mathcal T
+             & =\sum_i S^{ii}
+            =\sum_i\bigoplus_{j,q}\mu_{j,q}A_j^{ii}     \\
+             & =\bigoplus_{j,q}\mu_{j,q}\sum_i A_j^{ii}
+            =\bigoplus_{j,q}\mu_{j,q}\mathcal T_{A_j}.
+        \end{aligned}
     \]
 \end{proof}
 
@@ -87,10 +87,14 @@
         def:mpdo_doubled_phys_trace_transfer}
     A tensor generating MPDOs is in \emph{simple canonical form} if it has a
     basis-of-normal-tensors decomposition whose basis elements all have
-    non-nilpotent physical-trace transfer.  This is the already-blocked form
-    of the simple tensor $K$ fixed at the start of Case II in
+    non-nilpotent physical-trace transfer.  This records the simple
+    horizontal-canonical-form data of the already-blocked tensor $K$ fixed in
     \cite[Appendix~C.2, line~1628]{Cirac2016MPDO_arXiv}.
 \end{definition}
+% Note for maintainers: this predicate does not include the biCF
+% (bidirectional canonical form) hypothesis imposed on K at line 1628.  That
+% condition is not used by the copy-independence argument and is introduced
+% separately when the inverse tensor is needed.
 
 \begin{lemma}[Simple canonical-form tensors are horizontal canonical]
     \label{lem:mpdo_simple_tensor_horizontal_cf}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -1,5 +1,7 @@
 \section{Simple local structure from SAL and ZCL}
 
+\input{chapter/ch21_mpdo_rfp_simple_case_two}
+
 \input{chapter/ch21_mpdo_rfp_simple_local_markov_factorization}
 
 \input{chapter/ch21_mpdo_rfp_simple_local_bond_products}

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -38,6 +38,12 @@ unless they are cited by one of the current blueprint chapters above.
 
 For MPDO renormalization fixed points:
 
+- `cpsv16_simple_tensor_nilpotency.tex` identifies the source's nilpotent BNT
+  elements with nilpotent physical-trace transfer matrices and records the
+  positive physical blocking and chosen-BNT interpretation of the
+  simple-tensor predicate. The source copy-weight lemma is formalized on the
+  chosen blocked canonical form; independence of the choices is not presently
+  needed.
 - `cpsv16_gsnnch_sector_decomposition.tex` records that
   `MPOTensor.GSNNCHData` now retains the source orthogonal sectors and natural
   multiplicities. The separate single-bond presentation gives its one-sector

--- a/docs/paper-gaps/cpsv16_simple_tensor_nilpotency.tex
+++ b/docs/paper-gaps/cpsv16_simple_tensor_nilpotency.tex
@@ -1,0 +1,77 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Nilpotent Basis Elements in the Simple-Tensor Definition of
+Cirac--P\'erez-Garc\'ia--Schuch--Verstraete}
+\author{}
+\date{2026-07-16}
+
+\begin{document}
+\maketitle
+
+\section{Source definition}
+
+Cirac--P\'erez-Garc\'ia--Schuch--Verstraete define, at arXiv:1606.00608,
+line~822: ``A tensor generating MPDO's is simple if none of the elements in
+a BNT is nilpotent.''  The meaning of nilpotency is fixed at line~819: an
+element $\mathcal B_k$ of the basis of normal tensors is nilpotent when
+$\operatorname{tr}_R \rho^{(N)}(M_k)=0$ after tracing $R\le D$ sites, for
+all sufficiently large $N$.
+
+\section{Formal reading}
+
+Let $A=\mathcal B_k$ be a normal BNT representative and put
+$\mathcal T_A=\sum_i A^{ii}$. Here
+$\operatorname{tr}_R\rho^{(N)}(A)=0$ means that the reduced density
+\emph{operator} is zero after tracing $R$ consecutive sites. Its matrix
+entries are
+\begin{align}
+  \bigl(\operatorname{tr}_R\rho^{(N)}(A)\bigr)_{\mathbf i,\mathbf j}
+    &=\operatorname{tr}\!\left(
+        A^{i_1j_1}\cdots A^{i_{N-R}j_{N-R}}\mathcal T_A^R
+      \right).                                           \label{eq:nilpotent-reduced-entry}
+\end{align}
+Choose a sufficiently large $N$ for which the length-$(N-R)$ products of the
+normal representative span the full virtual matrix algebra. The trace pairing
+on that algebra is nondegenerate. Consequently,
+\begin{align}
+  \operatorname{tr}_R\rho^{(N)}(A)=0
+  \text{ for every sufficiently large }N
+  \quad\Longleftrightarrow\quad
+  \mathcal T_A^R=0.                                      \label{eq:nilpotent-equivalence}
+\end{align}
+Since the nilpotency index of a nilpotent $D\times D$ matrix is at most $D$,
+the line-819 condition is precisely nilpotency of $\mathcal T_A$. The formal
+predicate for a chosen blocked canonical form is
+\leanid{MPOTensor.IsSimpleCanonicalForm}; it records this condition for every
+basis element. The source predicate is \leanid{MPOTensor.IsSimple}; it
+existentially quantifies over the positive physical blocking required at
+line~815.
+
+The toric-code boundary tensor discussed after Theorem~4.9 of the source
+confirms the reading: its second basis element carries the one-by-one
+transfer $\mathcal T = 0$, so the tensor is not simple, matching the
+source's use of that example outside the simple case.
+
+The source states the predicate for ``a BNT'' of the blocked tensor. The basis of
+normal tensors is unique up to gauge, phase, and permutation, so the choice
+of witness is immaterial mathematically; the formal predicate quantifies
+existentially over a positive blocking and horizontal canonical-form witness,
+and records non-nilpotency for that witness. No theorem currently transports
+non-nilpotency between witnesses; a proof of witness independence can be
+added when an argument needs it.
+
+\section{Classification}
+
+Verdict: notational clarification. The formal definition is faithful to
+lines~819--822 under the identification of the line-819 partial-trace
+criterion with matrix nilpotency of the physical-trace transfer; no
+hypothesis is added or dropped.
+
+\end{document}


### PR DESCRIPTION
## Summary

This begins the simple-tensor case of arXiv:1606.00608, Appendix C.2.

- Define the physical-trace transfer of a doubled-index tensor and prove its
  block-diagonal form on a sector decomposition.
- Define `IsSimple` with the source's positive physical blocking from line
  815: the original tensor generates MPDOs, and some positive blocking has a
  BNT canonical form with no nilpotent physical-trace transfer.
- Separate `IsSimpleCanonicalForm`, the predicate for the already-blocked
  tensor used under the standing convention at Appendix C.2, line 1628.
- Prove that source zero correlation length makes the canonical-form weights
  independent of the copy index for that blocked canonical-form tensor.
- Record the partial-trace/nilpotency calculation in
  `docs/paper-gaps/cpsv16_simple_tensor_nilpotency.tex`.
- Place the simple-tensor definition before GSNNCH, and the weight argument at
  the beginning of the Appendix C.2 development in the blueprint.

The general weight lemma is stated for an explicit block-diagonal sector
decomposition. Its corollary is the form used for the simple canonical-form
tensor (K) in Appendix C.2.

## Verification

- `lake build` succeeds with Lean v4.32.0 (9517 jobs).
- `lake env lean TNLean/MPS/MPDO/SimpleTensor.lean` succeeds.
- `lake exe checkdecls blueprint/lean_decls` succeeds.
- The blueprint PDF and the paper-gap note compile; affected pages were
  rendered and inspected.
- The new theorems depend only on `propext`, `Classical.choice`, and
  `Quot.sound`.
- No `sorry`, new axiom, or kernel bypass is introduced.

Part of #4003. Related trackers: #232, #236, #2380.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formal definitions and proofs on the MPDO RFP path with no changes to auth, security, or runtime behavior; risk is mainly proof maintenance and predicate alignment with the paper.
> 
> **Overview**
> Adds **`TNLean/MPS/MPDO/SimpleTensor.lean`** and wires it into the public import list, starting the CPSV16 “simple $K$” track (Appendix C.2).
> 
> **Lean:** Introduces doubled-index **physical-trace transfer** (`doubledPhysTraceTransfer`) with lemmas tying it to `physTraceTransfer` and to block-diagonal sector assemblies. Defines **`IsSimpleCanonicalForm`** (blocked BNT canonical form with no nilpotent basis transfers) and **`IsSimple`** (positive physical blocking + such a witness). Proves that **source zero correlation length** (`IsSourceZCL`) forces sector weights $\mu_{j,q}$ to be **independent of the copy index** $q$, plus a corollary packaging the predicate for simple canonical-form tensors. Shows simple canonical form implies horizontal canonical form.
> 
> **Blueprint:** New section on simple tensors and definitions/lemmas; the copy-independence theorem and corollary live at the start of the Appendix C.2 simple-local-structure thread. Chapter 21 narrative is reordered so simple tensors precede GSNNCH.
> 
> **Docs:** `cpsv16_simple_tensor_nilpotency.tex` records the partial-trace ↔ nilpotent transfer reading of the source definition; README points to it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a42cae6a7bce10cad24f9831b0026bdb2d3eb88b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->