### PR TITLE
doc(MPS/MPDO): record the source label alongside Proposition C.8

### DIFF
--- a/TNLean/MPS/MPDO/GSNNCHSectorSum.lean
+++ b/TNLean/MPS/MPDO/GSNNCHSectorSum.lean
@@ -400,8 +400,8 @@ an injective tensor.
 through the inactive-sector repair; see
 `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
 
-Source: arXiv:1606.00608, Appendix C.2, Proposition C.8, lines 1569--1594,
-and Definition 4.8, lines 829--850. -/
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (source label 3to4),
+lines 1569--1594, and Definition 4.8, lines 829--850. -/
 theorem isGSNNCH_of_isInjective_of_isSAL (K : MPOTensor d D)
     (hK : K.IsInjective) (hSAL : IsSAL K) : IsGSNNCH K := by
   obtain ⟨data⟩ := nonempty_etaLocalStructureData_of_isSAL K hK hSAL


### PR DESCRIPTION
### Motivation

Follow-up to a review advisory on #4034 (merged before this landed): `GSNNCHSectorSum.lean` cited "Proposition C.8" while `CommutingFormBridge.lean` cites "Proposition 3to4" for the same passage. Verified against `Papers/1606.00608/MPDO-22-12-17-2.tex:1570`: the proposition at lines 1569--1594 carries the source-internal label `3to4` and is printed as Proposition C.8 — the same result.

### Description

- Cite both forms in the `isGSNNCH_of_isInjective_of_isSAL` docstring: "Proposition C.8 (source label 3to4)".

### Testing

`lake env lean TNLean/MPS/MPDO/GSNNCHSectorSum.lean` passes clean (docstring-only change).

https://claude.ai/code/session_014TxvMnpGSqatcyWuPUqmpd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only docstring edit with no runtime or proof impact.
> 
> **Overview**
> Updates the `isGSNNCH_of_isInjective_of_isSAL` docstring in `GSNNCHSectorSum.lean` so the arXiv reference reads **Proposition C.8 (source label 3to4)** instead of only “Proposition C.8,” matching how the same passage is cited elsewhere (e.g. `CommutingFormBridge.lean`).
> 
> No Lean proofs or definitions change—documentation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cdd8b29dfe353ea14f0995b6ae7ab263bb4c203. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->