### PR TITLE
feat(MPS/MPDO): add canonical Hayashi sector projectors

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -437,6 +437,7 @@ import TNLean.MPS.MPDO.VerticalMapTransport
 import TNLean.MPS.MPDO.PRFP
 import TNLean.MPS.MPDO.LocalPurificationRFP
 import TNLean.MPS.MPDO.SimpleLocalStructure
+import TNLean.MPS.MPDO.HayashiSectorProjector
 import TNLean.MPS.MPDO.EtaPreparation
 import TNLean.MPS.MPDO.RFPSubspinMaps
 import TNLean.MPS.MPDO.HayashiSectorComparison

--- a/TNLean/Algebra/OrthogonalProjection.lean
+++ b/TNLean/Algebra/OrthogonalProjection.lean
@@ -18,6 +18,7 @@ channels and irreducibility.
 
 * `IsOrthogonalProjection`
 * `IsOrthogonalProjection.one_sub`
+* `IsStarProjection.conjTranspose_mul_mul_of_mul_conjTranspose_eq_one`
 * `isOrthogonalProjection_posSemidef`
 * `orthogonalProjection_mul_eq_zero_of_sum_eq_one`
 -/
@@ -44,6 +45,27 @@ theorem IsStarProjection.isOrthogonalProjection {P : Matrix (Fin D) (Fin D) ℂ}
   refine ⟨?_, hP.1⟩
   change Pᴴ = P
   simpa [Matrix.star_eq_conjTranspose] using hP.2
+
+/-- Let $Q$ be an orthogonal projection on one finite-dimensional space and
+let $U$ be a coisometry onto that space.  Then $U^*QU$ is an orthogonal
+projection on the domain of $U$. -/
+theorem IsStarProjection.conjTranspose_mul_mul_of_mul_conjTranspose_eq_one
+    {m n : Type*} [Fintype m] [DecidableEq m] [Fintype n]
+    {Q : Matrix m m ℂ} (hQ : IsStarProjection Q) (U : Matrix m n ℂ)
+    (hU : U * Uᴴ = 1) : IsStarProjection (Uᴴ * Q * U) := by
+  rw [isStarProjection_iff']
+  constructor
+  · calc
+      (Uᴴ * Q * U) * (Uᴴ * Q * U) = Uᴴ * (Q * ((U * Uᴴ) * (Q * U))) := by
+        simp only [Matrix.mul_assoc]
+      _ = Uᴴ * (Q * (Q * U)) := by rw [hU, Matrix.one_mul]
+      _ = Uᴴ * ((Q * Q) * U) := by simp only [Matrix.mul_assoc]
+      _ = Uᴴ * Q * U := by rw [hQ.isIdempotentElem.eq, Matrix.mul_assoc]
+  · rw [Matrix.star_eq_conjTranspose, Matrix.conjTranspose_mul,
+      Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose]
+    have hQadj : Qᴴ = Q := by
+      simpa [Matrix.star_eq_conjTranspose] using hQ.isSelfAdjoint.star_eq
+    rw [hQadj, Matrix.mul_assoc]
 
 /-- The complement of an orthogonal projection is an orthogonal projection. -/
 theorem IsOrthogonalProjection.one_sub {P : Matrix (Fin D) (Fin D) ℂ}

--- a/TNLean/MPS/MPDO/HayashiSectorProjector.lean
+++ b/TNLean/MPS/MPDO/HayashiSectorProjector.lean
@@ -1,0 +1,187 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.OrthogonalProjection
+import TNLean.Algebra.ScalarCommutant
+import TNLean.MPS.MPDO.SimpleLocalStructure
+
+/-!
+# Canonical projectors of a Hayashi--Markov decomposition
+
+A quantum-Markov decomposition of a tripartite state splits its middle
+physical space as
+\[
+  \mathcal H_B=\bigoplus_k \mathcal H^L_k\otimes\mathcal H^R_k.
+\]
+This file defines the corresponding one-site projectors in the original
+physical basis and proves that they are orthogonal and resolve the identity.
+
+The projectors $Q_k$ are defined in arXiv:1606.00608, Appendix C.2,
+lines 1364--1368.  Their resolution of the identity is recalled at lines
+1693--1697.
+
+## Main declarations
+
+* `MPOTensor.EtaStructure.coordinateSectorProjection`
+* `MPOTensor.EtaStructure.sectorProjection`
+* `MPOTensor.EtaStructure.sectorProjection_isOrthogonal`
+* `MPOTensor.EtaStructure.sectorProjection_mul_eq_zero`
+* `MPOTensor.EtaStructure.sum_sectorProjection`
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPOTensor.EtaStructure
+
+variable {d : ℕ}
+  {rho : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+
+/-- The coordinate projection onto one summand
+$\mathcal H^L_k\otimes\mathcal H^R_k$ of the middle-site Markov
+decomposition.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1364--1368. -/
+noncomputable def coordinateSectorProjection (hη : EtaStructure rho)
+    (k : Fin hη.m) :
+    Matrix (Σ j : Fin hη.m, Fin (hη.dL j) × Fin (hη.dR j))
+      (Σ j : Fin hη.m, Fin (hη.dL j) × Fin (hη.dR j)) ℂ :=
+  Matrix.blockProjection (n := fun j => Fin (hη.dL j) × Fin (hη.dR j)) k
+
+private theorem coordinateSectorProjection_isStarProjection
+    (hη : EtaStructure rho) (k : Fin hη.m) :
+    IsStarProjection (hη.coordinateSectorProjection k) := by
+  classical
+  rw [isStarProjection_iff']
+  constructor
+  · rw [coordinateSectorProjection, Matrix.blockProjection,
+      ← Matrix.blockDiagonal'_mul]
+    congr 1
+    funext i
+    by_cases hi : i = k
+    · simp [hi]
+    · simp [hi]
+  · simp only [Matrix.star_eq_conjTranspose]
+    rw [coordinateSectorProjection, Matrix.blockProjection,
+      Matrix.blockDiagonal'_conjTranspose]
+    congr 1
+    funext i
+    by_cases hi : i = k
+    · simp [hi]
+    · simp [hi]
+
+private theorem sum_coordinateSectorProjection (hη : EtaStructure rho) :
+    ∑ k : Fin hη.m, hη.coordinateSectorProjection k = 1 := by
+  classical
+  ext ⟨i, a⟩ ⟨j, b⟩
+  by_cases hij : i = j
+  · subst j
+    rw [Matrix.sum_apply, Finset.sum_eq_single i]
+    · simp [coordinateSectorProjection, Matrix.blockProjection,
+        Matrix.one_apply]
+    · intro k _ hki
+      have hik : i ≠ k := Ne.symm hki
+      simp [coordinateSectorProjection, Matrix.blockProjection, hik]
+    · simp
+  · simp [Matrix.sum_apply, coordinateSectorProjection, Matrix.blockProjection,
+      Matrix.blockDiagonal'_apply_ne _ _ _ hij, hij]
+
+private noncomputable def basisSectorProjection (hη : EtaStructure rho)
+    (k : Fin hη.m) : Matrix (Fin d) (Fin d) ℂ :=
+  Matrix.reindex hη.decompB.symm hη.decompB.symm
+    (hη.coordinateSectorProjection k)
+
+private theorem sum_basisSectorProjection (hη : EtaStructure rho) :
+    ∑ k : Fin hη.m, basisSectorProjection hη k = 1 := by
+  classical
+  ext i j
+  have hentry := congrFun (congrFun (sum_coordinateSectorProjection hη)
+    (hη.decompB i)) (hη.decompB j)
+  simpa [basisSectorProjection, Matrix.sum_apply, Matrix.reindex_apply,
+    Matrix.one_apply] using hentry
+
+private theorem basisSectorProjection_isStarProjection
+    (hη : EtaStructure rho) (k : Fin hη.m) :
+    IsStarProjection (basisSectorProjection hη k) := by
+  rw [isStarProjection_iff']
+  obtain ⟨hidem, hstar⟩ :=
+    (isStarProjection_iff'.mp (coordinateSectorProjection_isStarProjection hη k))
+  constructor
+  · change
+      Matrix.reindex hη.decompB.symm hη.decompB.symm
+          (hη.coordinateSectorProjection k) *
+        Matrix.reindex hη.decompB.symm hη.decompB.symm
+          (hη.coordinateSectorProjection k) =
+      Matrix.reindex hη.decompB.symm hη.decompB.symm
+          (hη.coordinateSectorProjection k)
+    calc
+      _ = Matrix.reindex hη.decompB.symm hη.decompB.symm
+          (hη.coordinateSectorProjection k * hη.coordinateSectorProjection k) := by
+        simpa only [Matrix.coe_reindexLinearEquiv] using
+          (Matrix.reindexLinearEquiv_mul (R := ℂ) (A := ℂ)
+            hη.decompB.symm hη.decompB.symm hη.decompB.symm
+            (hη.coordinateSectorProjection k) (hη.coordinateSectorProjection k))
+      _ = _ := congrArg
+        (Matrix.reindex hη.decompB.symm hη.decompB.symm) hidem
+  · simp only [Matrix.star_eq_conjTranspose]
+    change
+      (Matrix.reindex hη.decompB.symm hη.decompB.symm
+        (hη.coordinateSectorProjection k))ᴴ =
+      Matrix.reindex hη.decompB.symm hη.decompB.symm
+        (hη.coordinateSectorProjection k)
+    rw [Matrix.conjTranspose_reindex]
+    simpa only [Matrix.star_eq_conjTranspose] using congrArg
+      (Matrix.reindex hη.decompB.symm hη.decompB.symm) hstar
+
+/-- The projector $Q_k$ onto the $k$-th Markov summand, transported to the
+original middle-site basis.  If $E_k$ is the coordinate block projection,
+then
+\[
+  Q_k=U_B^*\,E_k\,U_B,
+\]
+where $U_B$ is the unitary implementing the middle-site Markov decomposition.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1364--1368 and 1437--1440. -/
+noncomputable def sectorProjection (hη : EtaStructure rho) (k : Fin hη.m) :
+    Matrix (Fin d) (Fin d) ℂ :=
+  (hη.U_B : Matrix (Fin d) (Fin d) ℂ)ᴴ *
+    basisSectorProjection hη k *
+    (hη.U_B : Matrix (Fin d) (Fin d) ℂ)
+
+/-- Each canonical Hayashi-sector matrix is an orthogonal projection.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1364--1368. -/
+theorem sectorProjection_isOrthogonal (hη : EtaStructure rho) (k : Fin hη.m) :
+    IsOrthogonalProjection (hη.sectorProjection k) := by
+  apply IsStarProjection.isOrthogonalProjection
+  apply IsStarProjection.conjTranspose_mul_mul_of_mul_conjTranspose_eq_one
+    (basisSectorProjection_isStarProjection hη k)
+    (hη.U_B : Matrix (Fin d) (Fin d) ℂ)
+  simpa [Matrix.star_eq_conjTranspose] using
+    Unitary.mul_star_self_of_mem hη.U_B.prop
+
+/-- The canonical Hayashi-sector projections resolve the physical identity:
+$\sum_k Q_k=\mathbf 1$.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1693--1697. -/
+theorem sum_sectorProjection (hη : EtaStructure rho) :
+    ∑ k : Fin hη.m, hη.sectorProjection k = 1 := by
+  classical
+  simp_rw [sectorProjection]
+  rw [← Finset.sum_mul, ← Finset.mul_sum, sum_basisSectorProjection,
+    Matrix.mul_one]
+  simpa [Matrix.star_eq_conjTranspose] using
+    Unitary.coe_star_mul_self hη.U_B
+
+/-- Projections onto distinct Hayashi sectors are mutually orthogonal.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1364--1368. -/
+theorem sectorProjection_mul_eq_zero (hη : EtaStructure rho)
+    {k l : Fin hη.m} (hkl : k ≠ l) :
+    hη.sectorProjection k * hη.sectorProjection l = 0 := by
+  exact orthogonalProjection_mul_eq_zero_of_sum_eq_one
+    hη.sectorProjection hη.sectorProjection_isOrthogonal
+    hη.sum_sectorProjection hkl
+
+end MPOTensor.EtaStructure

--- a/TNLean/MPS/MPDO/TopologicalProjectors.lean
+++ b/TNLean/MPS/MPDO/TopologicalProjectors.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.OrthogonalProjection
 import TNLean.Channel.Irreducible.Basic
 import TNLean.MPS.MPDO.BNTTripleFusionSeparation
 
@@ -40,25 +41,6 @@ namespace MPOTensor.BNTFusionIsometryFamily
 
 variable {g p : ℕ}
 variable (Fam : BNTFusionIsometryFamily (Fin g) p)
-
-private theorem isStarProjection_conjTranspose_mul_mul_of_mul_conjTranspose_eq_one
-    {m n : Type*} [Fintype m] [DecidableEq m] [Fintype n]
-    (U : Matrix m n ℂ) (Q : Matrix m m ℂ)
-    (hQ : IsStarProjection Q) (hU : U * Uᴴ = 1) :
-    IsStarProjection (Uᴴ * Q * U) := by
-  rw [isStarProjection_iff']
-  constructor
-  · calc
-      (Uᴴ * Q * U) * (Uᴴ * Q * U) = Uᴴ * (Q * ((U * Uᴴ) * (Q * U))) := by
-        simp only [Matrix.mul_assoc]
-      _ = Uᴴ * (Q * (Q * U)) := by rw [hU, Matrix.one_mul]
-      _ = Uᴴ * ((Q * Q) * U) := by simp only [Matrix.mul_assoc]
-      _ = Uᴴ * Q * U := by rw [hQ.isIdempotentElem.eq, Matrix.mul_assoc]
-  · rw [Matrix.star_eq_conjTranspose, Matrix.conjTranspose_mul, Matrix.conjTranspose_mul,
-      Matrix.conjTranspose_conjTranspose]
-    have hQadj : Qᴴ = Q := by
-      simpa [Matrix.star_eq_conjTranspose] using hQ.isSelfAdjoint.star_eq
-    rw [hQadj, Matrix.mul_assoc]
 
 /-- The single fusion layer of the operator $Q$ at source lines 999--1010,
 with terminal matrices $P_\gamma$.
@@ -158,9 +140,9 @@ theorem conjugatedProjectorQBlock_isOrthogonalProjection
     (hP : ∀ γ : Fin g, IsStarProjection (P γ))
     (α β : Fin g) :
     IsOrthogonalProjection (Fam.conjugatedProjectorQBlock P α β) :=
-  (isStarProjection_conjTranspose_mul_mul_of_mul_conjTranspose_eq_one
-    (Fam.fusionIsometry α β) (Fam.projectorQBlock P α β)
+  (IsStarProjection.conjTranspose_mul_mul_of_mul_conjTranspose_eq_one
     (Fam.projectorQBlock_isStarProjection c hχ hLI P hP α β)
+    (Fam.fusionIsometry α β)
     (Fam.fusionIsometry_mul_conjTranspose_eq_one_of_bnt_of_lengthIndependent
       hBNT c hχ hLI α β)).isOrthogonalProjection
 

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -635,6 +635,50 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     \]
 \end{proof}
 
+\begin{theorem}[Coisometric transport of a star projection]
+    \label{thm:star_projection_coisometric_transport}
+    \lean{IsStarProjection.conjTranspose_mul_mul_of_mul_conjTranspose_eq_one}
+    \leanok
+    Let $Q$ be a self-adjoint idempotent on a finite-dimensional space, and
+    let $U$ be a coisometry onto that space, so that $UU^\dagger=\Id$.  Then
+    $U^\dagger Q U$ is self-adjoint and idempotent.
+\end{theorem}
+
+\begin{proof}\leanok
+    Self-adjointness follows from
+    $(U^\dagger Q U)^\dagger=U^\dagger Q^\dagger U=U^\dagger Q U$.  Moreover,
+    \[
+        (U^\dagger Q U)^2
+        =U^\dagger Q(UU^\dagger)QU
+        =U^\dagger Q^2U
+        =U^\dagger Q U.
+    \]
+\end{proof}
+
+\begin{lemma}[Pairwise orthogonality from a projection resolution]
+    \label{lem:orthogonal_projection_mul_eq_zero_of_sum_eq_one}
+    \lean{orthogonalProjection_mul_eq_zero_of_sum_eq_one}
+    \leanok
+    \uses{def:orthogonal_projection_channel}
+    Let $(Q_k)_k$ be a finite family of orthogonal projections satisfying
+    $\sum_k Q_k=\Id$.  If $k\ne\ell$, then $Q_kQ_\ell=0$.
+\end{lemma}
+
+\begin{proof}\leanok
+    Multiplying the resolution of the identity on both sides by $Q_k$ gives
+    \[
+        \sum_j Q_kQ_jQ_k=Q_k.
+    \]
+    Each summand is positive semidefinite because
+    $Q_kQ_jQ_k=(Q_jQ_k)^*(Q_jQ_k)$, while the $j=k$ summand is already $Q_k$.
+    Subtracting that term and taking traces gives
+    \[
+        0=\sum_{j\ne k}\tr\bigl((Q_jQ_k)^*(Q_jQ_k)\bigr)
+         =\sum_{j\ne k}\lVert Q_jQ_k\rVert_{\mathrm F}^{2}.
+    \]
+    Hence $Q_jQ_k=0$ for $j\ne k$, and taking adjoints gives $Q_kQ_j=0$.
+\end{proof}
+
 \begin{theorem}[Complement of an orthogonal projection]
     \label{thm:orthogonal_projection_complement_channel}
     \lean{IsOrthogonalProjection.one_sub}

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -3189,7 +3189,6 @@ Theorem~\ref{thm:peripheral_cyclic_group}.
 \begin{lemma}[Cyclic shift of the Kraus operators]
     \label{lem:kraus_cyclic_shift}
     \lean{MPSTensor.one_sub_mul_kraus_mul_eq_zero_of_transferMap_proj}
-    \lean{orthogonalProjection_mul_eq_zero_of_sum_eq_one}
     \lean{MPSTensor.kraus_mul_cyclicProj}
     \lean{MPSTensor.evalWord_mul_cyclicProj}
     \lean{MPSTensor.cyclicProj_ne_zero}
@@ -3209,6 +3208,7 @@ Theorem~\ref{thm:peripheral_cyclic_group}.
 
 \begin{proof}
     \leanok
+    \uses{lem:orthogonal_projection_mul_eq_zero_of_sum_eq_one}
     Compressing $\sum_vK_vP_{k+1}K_v^\dagger=P_k$ by $\Id-P_k$ exhibits a
     vanishing sum of positive semidefinite matrices, so each summand
     vanishes: $(\Id-P_k)K_vP_{k+1}=0$.  Mutual orthogonality follows by

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -989,7 +989,9 @@ separate step.
     \leanok
     \uses{def:mpdo_topological_projector_one_fusion,
         thm:mpdo_pair_fusion_bnt_completeness,
-        thm:mpdo_bnt_length_independent_zipper}
+        thm:mpdo_bnt_length_independent_zipper,
+        thm:star_projection_coisometric_transport,
+        thm:orthogonal_projection_star_projection_channel}
     Let $P_\gamma$ be self-adjoint idempotents on the terminal bond spaces.
     Suppose that the matrices $\chi_{\alpha,\beta,\gamma}$ have the
     positive-length trace-power form of the label-coefficient family and that

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
@@ -22,6 +22,77 @@ strong subadditivity for a normalized three-site reduced state.
     \]
 \end{definition}
 
+\begin{definition}[Canonical projections of a Hayashi decomposition]
+    \label{def:mpdo_hayashi_sector_projection}
+    \lean{MPOTensor.EtaStructure.coordinateSectorProjection}
+    \lean{MPOTensor.EtaStructure.sectorProjection}
+    \leanok
+    \uses{def:mpdo_eta_structure}
+    Let
+    \[
+        B=\bigoplus_k\bigl(b_1^{(k)}\otimes b_2^{(k)}\bigr)
+    \]
+    be the middle-site decomposition, and let $E_k$ be the coordinate
+    projection onto its $k$-th summand.  In the original physical basis, define
+    \[
+        Q_k=U_B^*E_kU_B.
+    \]
+    These are the projectors introduced in
+    \cite[Appendix~C.2, lines~1364--1368]{Cirac2016MPDO_arXiv}; the unitary
+    implements the basis change described in
+    \cite[Appendix~C.2, lines~1437--1440]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{theorem}[Resolution of the identity by Hayashi-sector projections]
+    \label{thm:mpdo_hayashi_sector_projection_resolution}
+    \lean{MPOTensor.EtaStructure.sectorProjection_isOrthogonal}
+    \lean{MPOTensor.EtaStructure.sum_sectorProjection}
+    \lean{MPOTensor.EtaStructure.sectorProjection_mul_eq_zero}
+    \leanok
+    \uses{def:orthogonal_projection_channel,
+        def:mpdo_hayashi_sector_projection}
+    Each $Q_k$ is an orthogonal projection, distinct summands are mutually
+    orthogonal, and the family resolves the identity:
+    \[
+        Q_kQ_\ell=0\quad(k\ne\ell),
+        \qquad \sum_k Q_k=\Id.
+    \]
+    The first two assertions follow from the orthogonal direct-sum
+    decomposition in
+    \cite[Appendix~C.2, lines~1364--1368]{Cirac2016MPDO_arXiv}; the resolution
+    of the identity is stated in
+    \cite[Appendix~C.2, lines~1693--1697]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:mpdo_hayashi_sector_projection,
+        lem:orthogonal_projection_mul_eq_zero_of_sum_eq_one,
+        thm:star_projection_coisometric_transport,
+        thm:orthogonal_projection_star_projection_channel}
+    The coordinate projections satisfy
+    \[
+        E_k^*=E_k,
+        \qquad E_k^2=E_k,
+        \qquad \sum_k E_k=\Id.
+    \]
+    Reindexing the direct sum and conjugating by $U_B$ preserve these
+    identities.  Hence each $Q_k=U_B^*E_kU_B$ is a star projection and
+    therefore an orthogonal projection, while
+    \[
+        \sum_k Q_k=U_B^*\Bigl(\sum_kE_k\Bigr)U_B=\Id.
+    \]
+    Finally, multiplying the resolution on both sides by $Q_k$ gives
+    \[
+        \sum_\ell Q_kQ_\ell Q_k=Q_k,
+        \qquad
+        Q_kQ_\ell Q_k=(Q_\ell Q_k)^*(Q_\ell Q_k)\geq0.
+    \]
+    The $\ell=k$ term already equals $Q_k$, so every term with $\ell\ne k$
+    vanishes.  Thus $(Q_\ell Q_k)^*(Q_\ell Q_k)=0$, hence
+    $Q_\ell Q_k=0$.  Taking adjoints gives $Q_kQ_\ell=0$ for $\ell\ne k$.
+\end{proof}
+
 \begin{theorem}[Saturation gives equality in strong subadditivity]
     \label{thm:mpdo_sal_ssa_equality}
     \lean{MPOTensor.isSSAEquality_tripartite_of_isSAL}


### PR DESCRIPTION
## Summary

- define the coordinate projection E_k for a summand of an EtaStructure
- transport it through decompB and the middle-site unitary with the orientation Q_k = U_B^* E_k U_B
- prove that every Q_k is an orthogonal projection, distinct Q_k are mutually orthogonal, and their sum is the identity
- add the construction at the beginning of the Markov-factorization blueprint subsection

This is a deliberately narrow partial step toward #4003, sequenced after #4042. It does not identify the local Hayashi labels with outer sector labels, assert ownership data, or add hypotheses.

## Source

arXiv:1606.00608, Appendix C.2, lines 1693--1697.

## Verification

- lake env lean TNLean/MPS/MPDO/HayashiSectorProjector.lean
- lake build
- python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls
- python3 scripts/blueprint_lean_sync.py --root . --ci
- cd blueprint && leanblueprint checkdecls
- cd blueprint && leanblueprint pdf
- proof-integrity scan for sorry, admit, axiom, native_decide, and unsafeCast in the new module

No new axioms, sorry declarations, or kernel bypasses are introduced.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization and lemma deduplication in MPS/MPDO and blueprint text; no runtime, auth, or data-path changes.
> 
> **Overview**
> Introduces **`HayashiSectorProjector.lean`**, defining coordinate block projectors and physical-basis sector projectors `Q_k = U_B^* E_k U_B` for an `EtaStructure`, with proofs that each `Q_k` is an orthogonal projection, distinct sectors multiply to zero, and **∑_k Q_k = 1**. The module is wired into the root **`TNLean.lean`** import surface.
> 
> **Refactor:** `IsStarProjection.conjTranspose_mul_mul_of_mul_conjTranspose_eq_one` moves from **`TopologicalProjectors.lean`** to **`OrthogonalProjection.lean`**; fusion conjugated projectors and Hayashi sectors both call this shared lemma.
> 
> **Blueprint:** documents coisometric transport and pairwise orthogonality from a resolution of the identity in **ch04**, adds Hayashi projection definitions and the resolution theorem at the start of the Markov-factorization subsection in **ch21**, and tightens **ch07** lemma dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8b829692c1459fb088166829298d644df6327dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->