### PR TITLE
feat(Analysis): expose trace norm through positive spectrum

### DIFF
--- a/TNLean/Analysis/SchattenNorm.lean
+++ b/TNLean/Analysis/SchattenNorm.lean
@@ -35,6 +35,8 @@ quantity is not identified with the ambient matrix operator norm.
   singular-value range.
 * `Matrix.traceNorm_eq_sum_fin` — Wolf's finite-dimensional formula summing
   over all `Fin D` indices.
+* `Matrix.traceNorm_eq_sum_sqrt_eigenvalues_adjoint_comp_self` — the trace norm
+  as the sum of the square roots of the eigenvalues of `A†A`.
 
 ## References
 
@@ -106,6 +108,17 @@ theorem traceNorm_eq_sum_fin (A : Matrix (Fin D) (Fin D) ℂ) :
     _ = ∑ i : Fin D, (Matrix.toEuclideanLin A).singularValues i := by
       symm
       exact Fin.sum_univ_eq_sum_range _ D
+
+/-- The trace norm is the sum of the square roots of the eigenvalues of the
+positive operator `A†A`. -/
+theorem traceNorm_eq_sum_sqrt_eigenvalues_adjoint_comp_self
+    (A : Matrix (Fin D) (Fin D) ℂ) :
+    traceNorm A = ∑ i : Fin D,
+      Real.sqrt ((Matrix.toEuclideanLin A).isSymmetric_adjoint_comp_self.eigenvalues
+        (by simp) i) := by
+  rw [traceNorm_eq_sum_fin]
+  exact Finset.sum_congr rfl fun i _ ↦
+    (Matrix.toEuclideanLin A).singularValues_fin (by simp) i
 
 /-- The Schatten one-norm is nonnegative. -/
 theorem schattenOneNorm_nonneg (A : Matrix (Fin D) (Fin D) ℂ) :

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -88,6 +88,30 @@ $\lVert A\rVert_1=\operatorname{tr}\lvert A\rvert$
     \]
 \end{proof}
 
+\begin{theorem}[Trace norm from the spectrum of $A^*A$]
+    \label{thm:trace_norm_sqrt_eigenvalues}
+    \lean{Matrix.traceNorm_eq_sum_sqrt_eigenvalues_adjoint_comp_self}
+    \leanok
+    \uses{def:trace_norm}
+    For every $A\in\MN{D}$, the trace norm is the sum of the square roots of
+    the eigenvalues of the positive operator $A^*A$:
+    \[
+        \lVert A\rVert_{\mathrm{tr}}
+        = \sum_{i=0}^{D-1}\sqrt{\lambda_i(A^*A)}.
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:trace_norm_elementary}
+    Since $s_i(A)=\sqrt{\lambda_i(A^*A)}$ by the definition of singular value,
+    the finite singular-value expansion gives
+    \[
+        \lVert A\rVert_{\mathrm{tr}}
+        = \sum_{i=0}^{D-1}s_i(A)
+        = \sum_{i=0}^{D-1}\sqrt{\lambda_i(A^*A)}.
+    \]
+\end{proof}
+
 \section{Von Neumann entropy}
 
 \begin{definition}[Von Neumann entropy]\label{def:von_neumann_entropy}


### PR DESCRIPTION
## Summary

- expose `Matrix.traceNorm` as the sum of square roots of the ordered eigenvalues of the positive operator associated to `A†A`
- add a dependency-tracked blueprint lemma for the spectral bridge
- keep the increment deliberately below scalar homogeneity and triangle inequality after checking Mathlib 4.32 and current Mathlib master

## Dependency

Stacked on LionSR/TNLean#4031 (`feat/analysis-schatten-one`). The diff should be reviewed against that branch; retarget to `main` after LionSR/TNLean#4031 merges.

## Source and scope

Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 8, §8.1 defines the trace norm through singular values. This PR adds the Mathlib-facing spectral bridge used by the next analytic layer; it does not claim a new theorem from Wolf beyond that exact context.

Scalar homogeneity from Wolf's matrix-norm axioms remains blocked because Mathlib has no theorem that ordered eigenvalues scale pointwise under nonnegative scalar multiplication, hence no `LinearMap.singularValues_smul`. Triangle inequality remains a larger Ky Fan / variational-duality gap: Mathlib has no SVD, partial-sum singular-value inequality, nuclear norm, or trace-norm duality supporting it. Accordingly this PR does not add a raw `Matrix` norm instance.

## Declaration

- `Matrix.traceNorm_eq_sum_sqrt_eigenvalues_adjoint_comp_self`

## Verification

- `lake env lean TNLean/Analysis/SchattenNorm.lean`
- `lake build TNLean.Analysis.SchattenNorm`
- `lake exe lint_style`
- blueprint sync reports the changed Chapter 19 entry formalized and the repository in sync after declaration regeneration
- `git diff --check`
- no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast` in the changed Lean module

Tracks the foundational part of LionSR/QICLean#212.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive analysis lemma on top of existing trace-norm definitions; no security, data, or architectural changes.
> 
> **Overview**
> Adds **`Matrix.traceNorm_eq_sum_sqrt_eigenvalues_adjoint_comp_self`**, identifying the trace norm with \(\sum_i \sqrt{\lambda_i(A^\dagger A)}\) by rewriting the existing finite singular-value sum and applying Mathlib’s link between singular values and ordered eigenvalues of the adjoint–composition self-adjoint operator.
> 
> The **`SchattenNorm`** module doc now lists this result. **Blueprint Chapter 19** gains a dependency-tracked theorem (`thm:trace_norm_sqrt_eigenvalues`) with a short proof from the elementary trace-norm expansion and \(s_i(A)=\sqrt{\lambda_i(A^*A)}\).
> 
> Scope stays a spectral bridge only; no scalar homogeneity, triangle inequality, or `Matrix` norm instance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d61f8dde7d6705d18a6b2abee3ffcdc49812d254. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->