### PR TITLE
ci(workflows): save the Lean build cache only from main

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -28,13 +28,47 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Build-cache policy: the cache is saved only from main and restored
+# everywhere. lean-action's built-in GitHub cache is disabled because it
+# saved a ~2.4 GB entry per PR run; those entries cycled through the 10 GB
+# repository cache budget within minutes, evicting main's entry, so no run
+# ever restored usable TNLean oleans and every run rebuilt all modules.
+# Mathlib and its dependencies are intentionally excluded from the cache:
+# `lake exe cache get` (run inside lean-action) restores them faster than
+# a GitHub cache of that size could.
+env:
+  BUILD_CACHE_PATHS: |
+    .lake/build
+    .lake/packages/Gametheory/.lake/build
+    .lake/packages/checkdecls/.lake/build
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v6
+
+      - name: Restore Lean build cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.BUILD_CACHE_PATHS }}
+          key: tnlean-build-${{ hashFiles('lean-toolchain', 'lake-manifest.json', 'lakefile.toml') }}-${{ github.sha }}
+          restore-keys: |
+            tnlean-build-${{ hashFiles('lean-toolchain', 'lake-manifest.json', 'lakefile.toml') }}-
+
       - uses: leanprover/lean-action@v1
+        with:
+          use-github-cache: false
 
       - name: Run text-based style linter
         run: lake exe lint_style --github
+
+      # Save even when the build failed: a partial cache still spares the
+      # next run the modules that did compile.
+      - name: Save Lean build cache (main only)
+        if: always() && github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.BUILD_CACHE_PATHS }}
+          key: tnlean-build-${{ hashFiles('lean-toolchain', 'lake-manifest.json', 'lakefile.toml') }}-${{ github.sha }}


### PR DESCRIPTION
## Summary

A 7-day CI audit found that every `Lean Action CI` run rebuilds all ~855 TNLean modules (~25–30 min) even when a GitHub cache is restored. Root cause: `lean-action`'s built-in cache saves a ~2.4 GB entry from **every PR run**, scoped to `refs/pull/N/merge`. Five such entries exceed the repository's 10 GB cache budget, so the LRU evicts the main-branch entry within minutes and no run ever restores usable TNLean oleans (verified: cache-hit runs still rebuilt 855/855 modules; the cache inventory held 12.8 GB, all on PR refs, none on `refs/heads/main`).

## Change

- Disable `lean-action`'s built-in GitHub cache (`use-github-cache: false`).
- Restore the build cache explicitly on every run (`actions/cache/restore`).
- Save it only from main-branch runs (`actions/cache/save`), including failed builds (partial caches still help).
- Cache only `.lake/build` plus the Gametheory/checkdecls package builds; mathlib and its dependencies stay on `lake exe cache get`, which is faster for that volume and keeps the entry small.

## Expected effect

- One stable main cache instead of churning PR caches.
- Median PR build drops from ~25 min to the diff-downstream rebuild (67% of recent main commits touch only high-layer modules; median 1 file changed).
- The ~6,200 min/week currently burned by cancelled full rebuilds shrinks with the build time.

## Validation

- `actionlint` and YAML parse clean.
- First main run after merge saves the seed cache; the next PR run should restore it (verify `Restored from key: tnlean-build-…` in the lean-action log and a short build).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to cache paths and lean-action flags; no application or auth logic touched.
> 
> **Overview**
> **Replaces `lean-action`'s built-in GitHub cache** with an explicit restore/save split so PR runs stop writing ~2.4 GB cache entries that evicted the repo's 10 GB budget and forced full TNLean rebuilds every time.
> 
> Every run **restores** via `actions/cache/restore@v4` before `leanprover/lean-action@v1`, with **`use-github-cache: false`**. **Saves** happen only on `refs/heads/main` via `actions/cache/save@v4` (`if: always()` so failed builds still contribute partial oleans). Cached paths are scoped to `.lake/build` plus Gametheory and checkdecls package builds; mathlib stays on `lake exe cache get` inside lean-action.
> 
> Cache keys hash `lean-toolchain`, `lake-manifest.json`, and `lakefile.toml`, with restore-keys for prefix fallback across commits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec5e8143205a833a00cd834902128a15b4c8add1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->