### PR TITLE
feat(Analysis): expose trace norm through positive spectrum

### DIFF
--- a/TNLean/Analysis/SchattenNorm.lean
+++ b/TNLean/Analysis/SchattenNorm.lean
@@ -115,10 +115,10 @@ theorem traceNorm_eq_sum_sqrt_eigenvalues_adjoint_comp_self
     (A : Matrix (Fin D) (Fin D) ℂ) :
     traceNorm A = ∑ i : Fin D,
       Real.sqrt ((Matrix.toEuclideanLin A).isSymmetric_adjoint_comp_self.eigenvalues
-        (by simp) i) := by
+        finrank_euclideanSpace_fin i) := by
   rw [traceNorm_eq_sum_fin]
   exact Finset.sum_congr rfl fun i _ ↦
-    (Matrix.toEuclideanLin A).singularValues_fin (by simp) i
+    (Matrix.toEuclideanLin A).singularValues_fin finrank_euclideanSpace_fin i
 
 /-- The Schatten one-norm is nonnegative. -/
 theorem schattenOneNorm_nonneg (A : Matrix (Fin D) (Fin D) ℂ) :

--- a/TNLean/Analysis/SchattenNorm.lean
+++ b/TNLean/Analysis/SchattenNorm.lean
@@ -36,7 +36,7 @@ quantity is not identified with the ambient matrix operator norm.
 * `Matrix.traceNorm_eq_sum_fin` — Wolf's finite-dimensional formula summing
   over all `Fin D` indices.
 * `Matrix.traceNorm_eq_sum_sqrt_eigenvalues_adjoint_comp_self` — the trace norm
-  as the sum of the square roots of the eigenvalues of `A†A`.
+  as the sum of the square roots of the eigenvalues of $A^\dagger A$.
 
 ## References
 
@@ -110,8 +110,8 @@ theorem traceNorm_eq_sum_fin (A : Matrix (Fin D) (Fin D) ℂ) :
       exact Fin.sum_univ_eq_sum_range _ D
 
 /-- The trace norm is the sum of the square roots of the eigenvalues of the
-positive operator `A†A`. -/
-theorem traceNorm_eq_sum_sqrt_eigenvalues_adjoint_comp_self
+positive operator $A^\dagger A$. -/
+lemma traceNorm_eq_sum_sqrt_eigenvalues_adjoint_comp_self
     (A : Matrix (Fin D) (Fin D) ℂ) :
     traceNorm A = ∑ i : Fin D,
       Real.sqrt ((Matrix.toEuclideanLin A).isSymmetric_adjoint_comp_self.eigenvalues

--- a/TNLean/Analysis/SchattenNorm.lean
+++ b/TNLean/Analysis/SchattenNorm.lean
@@ -35,6 +35,8 @@ quantity is not identified with the ambient matrix operator norm.
   singular-value range.
 * `Matrix.traceNorm_eq_sum_fin` — Wolf's finite-dimensional formula summing
   over all `Fin D` indices.
+* `Matrix.traceNorm_eq_sum_sqrt_eigenvalues_adjoint_comp_self` — the trace norm
+  as the sum of the square roots of the eigenvalues of `A†A`.
 
 ## References
 
@@ -106,6 +108,17 @@ theorem traceNorm_eq_sum_fin (A : Matrix (Fin D) (Fin D) ℂ) :
     _ = ∑ i : Fin D, (Matrix.toEuclideanLin A).singularValues i := by
       symm
       exact Fin.sum_univ_eq_sum_range _ D
+
+/-- The trace norm is the sum of the square roots of the eigenvalues of the
+positive operator `A†A`. -/
+theorem traceNorm_eq_sum_sqrt_eigenvalues_adjoint_comp_self
+    (A : Matrix (Fin D) (Fin D) ℂ) :
+    traceNorm A = ∑ i : Fin D,
+      Real.sqrt ((Matrix.toEuclideanLin A).isSymmetric_adjoint_comp_self.eigenvalues
+        (by simp) i) := by
+  rw [traceNorm_eq_sum_fin]
+  exact Finset.sum_congr rfl fun i _ ↦
+    (Matrix.toEuclideanLin A).singularValues_fin (by simp) i
 
 /-- The Schatten one-norm is nonnegative. -/
 theorem schattenOneNorm_nonneg (A : Matrix (Fin D) (Fin D) ℂ) :

--- a/TNLean/Analysis/TraceNormAbs.lean
+++ b/TNLean/Analysis/TraceNormAbs.lean
@@ -96,12 +96,10 @@ theorem traceNorm_eq_re_trace_abs (A : Matrix (Fin D) (Fin D) ℂ) :
     traceNorm A = (Matrix.trace (CFC.abs A)).re := by
   have hH : (Aᴴ * A).PosSemidef := posSemidef_conjTranspose_mul_self A
   calc traceNorm A
-      = ∑ i : Fin D, (toEuclideanLin A).singularValues i := traceNorm_eq_sum_fin A
-    _ = ∑ i : Fin D,
+      = ∑ i : Fin D,
           Real.sqrt ((toEuclideanLin A).isSymmetric_adjoint_comp_self.eigenvalues
             finrank_euclideanSpace_fin i) :=
-        Finset.sum_congr rfl fun i _ ↦
-          (toEuclideanLin A).singularValues_fin finrank_euclideanSpace_fin i
+        traceNorm_eq_sum_sqrt_eigenvalues_adjoint_comp_self A
     _ = ∑ j : Fin (Fintype.card (Fin D)),
           Real.sqrt ((isSymmetric_toEuclideanLin_iff.mpr hH.isHermitian).eigenvalues
             finrank_euclideanSpace j) :=

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -189,6 +189,29 @@ Theorem~\ref{thm:trace_norm_abs}.
     by applying the right and left cases in turn.
 \end{proof}
 
+\begin{theorem}[Trace norm from the spectrum of $A^*A$]
+    \label{thm:trace_norm_sqrt_eigenvalues}
+    \lean{Matrix.traceNorm_eq_sum_sqrt_eigenvalues_adjoint_comp_self}
+    \leanok
+    \uses{def:trace_norm}
+    For every $A\in\MN{D}$, the trace norm is the sum of the square roots of
+    the eigenvalues of the positive operator $A^*A$:
+    \[
+        \lVert A\rVert_{\mathrm{tr}}
+        = \sum_{i=0}^{D-1}\sqrt{\lambda_i(A^*A)}.
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    Since $s_i(A)=\sqrt{\lambda_i(A^*A)}$ by the definition of singular value,
+    the finite singular-value expansion gives
+    \[
+        \lVert A\rVert_{\mathrm{tr}}
+        = \sum_{i=0}^{D-1}s_i(A)
+        = \sum_{i=0}^{D-1}\sqrt{\lambda_i(A^*A)}.
+    \]
+\end{proof}
+
 \section{Von Neumann entropy}
 
 \begin{definition}[Von Neumann entropy]\label{def:von_neumann_entropy}

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -189,26 +189,28 @@ Theorem~\ref{thm:trace_norm_abs}.
     by applying the right and left cases in turn.
 \end{proof}
 
-\begin{theorem}[Trace norm from the spectrum of $A^*A$]
+\begin{theorem}[Trace norm from the spectrum of $A^\dagger A$]
     \label{thm:trace_norm_sqrt_eigenvalues}
     \lean{Matrix.traceNorm_eq_sum_sqrt_eigenvalues_adjoint_comp_self}
     \leanok
     \uses{def:trace_norm}
     For every $A\in\MN{D}$, the trace norm is the sum of the square roots of
-    the eigenvalues of the positive operator $A^*A$:
+    the eigenvalues of the positive operator $A^\dagger A$:
     \[
         \lVert A\rVert_{\mathrm{tr}}
-        = \sum_{i=0}^{D-1}\sqrt{\lambda_i(A^*A)}.
+        = \sum_{i=0}^{D-1}\sqrt{\lambda_i(A^\dagger A)}.
     \]
 \end{theorem}
 
 \begin{proof}\leanok
-    Since $s_i(A)=\sqrt{\lambda_i(A^*A)}$ by the definition of singular value,
-    the finite singular-value expansion gives
+    \uses{thm:trace_norm_elementary}
+    Since $s_i(A)=\sqrt{\lambda_i(A^\dagger A)}$ by the definition of singular
+    value, the finite singular-value expansion of
+    Theorem~\ref{thm:trace_norm_elementary} gives
     \[
         \lVert A\rVert_{\mathrm{tr}}
         = \sum_{i=0}^{D-1}s_i(A)
-        = \sum_{i=0}^{D-1}\sqrt{\lambda_i(A^*A)}.
+        = \sum_{i=0}^{D-1}\sqrt{\lambda_i(A^\dagger A)}.
     \]
 \end{proof}
 

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -107,7 +107,7 @@ Theorem~\ref{thm:trace_norm_abs}.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:trace_norm_elementary}
+    \uses{lem:trace_norm_sqrt_eigenvalues}
     The map $T^\dagger T$, for $T$ the linear map on $\C^D$ represented by
     $A$, is represented by $A^\dagger A$, so the singular values of $A$ are
     $s_i(A)=\sqrt{\lambda_i}$ with $\lambda_0,\ldots,\lambda_{D-1}$ the
@@ -189,8 +189,8 @@ Theorem~\ref{thm:trace_norm_abs}.
     by applying the right and left cases in turn.
 \end{proof}
 
-\begin{theorem}[Trace norm from the spectrum of $A^\dagger A$]
-    \label{thm:trace_norm_sqrt_eigenvalues}
+\begin{lemma}[Trace norm from the spectrum of $A^\dagger A$]
+    \label{lem:trace_norm_sqrt_eigenvalues}
     \lean{Matrix.traceNorm_eq_sum_sqrt_eigenvalues_adjoint_comp_self}
     \leanok
     \uses{def:trace_norm}
@@ -200,7 +200,7 @@ Theorem~\ref{thm:trace_norm_abs}.
         \lVert A\rVert_{\mathrm{tr}}
         = \sum_{i=0}^{D-1}\sqrt{\lambda_i(A^\dagger A)}.
     \]
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok
     \uses{thm:trace_norm_elementary}


### PR DESCRIPTION
### Motivation

Recreation of #4047, which was closed when its stacked base branch (`feat/analysis-schatten-one`) was deleted after #4031 merged — the deletion closed the stacked PRs instead of retargeting them. This branch cherry-picks the original commit (authorship preserved) onto main; the author's branch `feat/analysis-trace-norm-homogeneity` is untouched.

### Description

- `Matrix.traceNorm_eq_sum_sqrt_eigenvalues_adjoint_comp_self` — the trace norm as the sum of the square roots of the eigenvalues of the positive operator $A^\dagger A$ (Wolf Ch. 8 §8.1 singular-value definition).
- Blueprint lemma `lem:trace_norm_sqrt_eigenvalues` with dependency edge to the elementary-properties theorem.

Note: the original #4047 description reported scalar homogeneity as blocked; that is superseded — #4051 proves `Matrix.traceNorm_smul` via the absolute-value route. This PR retains only the spectral-bridge lemma, which is complementary API (see the comparison at https://github.com/LionSR/TNLean/pull/4047#issuecomment-4993419485).

Heads-up: this PR and #4051 insert blueprint entries in the same ch19 region; whichever merges second needs a trivial rebase of that hunk.

### Testing

`lake env lean TNLean/Analysis/SchattenNorm.lean` passes clean against main.

https://claude.ai/code/session_014TxvMnpGSqatcyWuPUqmpd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized analysis API and blueprint dependency wiring; no auth, data, or behavioral runtime changes beyond proof structure.
> 
> **Overview**
> Adds **`Matrix.traceNorm_eq_sum_sqrt_eigenvalues_adjoint_comp_self`**, identifying the trace norm with \(\sum_i \sqrt{\lambda_i(A^\dagger A)}\) via singular values and the spectrum of the adjoint–self composition on the Euclidean linear map.
> 
> **`traceNorm_eq_re_trace_abs`** now starts from that lemma instead of repeating the finite singular-value / eigenvalue step inline.
> 
> The blueprint gains **`lem:trace_norm_sqrt_eigenvalues`** (linked to the Lean lemma); the trace-norm-as-absolute-value theorem proof depends on it rather than only the elementary finite expansion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d022129dbe1029d91086f8d8395ec89166f61a74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->