### PR TITLE
feat(tenkz): free-placement tier — tenkzfree, \tnput, \tnjoin

### DIFF
--- a/tex/tenkz/examples/free-typed-joins.tex
+++ b/tex/tenkz/examples/free-typed-joins.tex
@@ -8,4 +8,14 @@
   \tnjoin{a.east}{b.west}
   \tnjoin[route=curve, out=90, in=90, label=T]{a.north}{b.north}
 \end{tenkzfree}
+
+% bond directionality, free-tier face (design brief; the grid faces
+% live in the atoms example): \tnjoin[dir] -- the argument order IS the
+% direction, an outgoing barb from the first port toward the second
+\quad
+\begin{tenkzfree}
+  \tnput[box]{a}{(0,0)}{A}
+  \tnput[box]{b}{(1.4,0)}{B}
+  \tnjoin[dir]{a.east}{b.west}
+\end{tenkzfree}
 \end{document}

--- a/tex/tenkz/examples/free-typed-joins.tex
+++ b/tex/tenkz/examples/free-typed-joins.tex
@@ -1,0 +1,11 @@
+\documentclass[border=3pt]{standalone}
+\usepackage{amsmath}
+\usepackage{tenkz}
+\begin{document}
+\begin{tenkzfree}
+  \tnput[ports={east:virtual, north:physical}]{a}{(0,0)}{A}
+  \tnput[ports={west:virtual}]{b}{(14mm,0)}{B}
+  \tnjoin{a.east}{b.west}
+  \tnjoin[route=curve, out=90, in=90, label=T]{a.north}{b.north}
+\end{tenkzfree}
+\end{document}

--- a/tex/tenkz/tenkz-free.code.tex
+++ b/tex/tenkz/tenkz-free.code.tex
@@ -14,6 +14,8 @@
   {
     \tl_if_empty:nF {#1} { \pgfqkeys{/tenkz}{#1} }
     \tenkz@beginpicture{free}
+    % NFSS sets math fonts up lazily; force them before reading the axis
+    \check@mathfonts
     \begin{tikzpicture}[tenkz~every~picture,
       baseline={(0pt,\dim_eval:n{-\fontdimen22\textfont2})}]
   }
@@ -22,6 +24,8 @@
 % \tnput[<glyph keys>]{<name>}{<coordinate>}{<label>}
 %   glyph keys: dot|box|pill|mpo (skin), ports={e:virtual, ph:physical, ...},
 %   label pos=north|south|east|west (dot skin only)
+\tl_new:N \l__tenkz_fshape_tl    % \tnput skin word (free-owned: the tiers
+                                 % share only L0/L1, never each other's locals)
 \tl_new:N \l__tenkz_fports_tl
 \tl_new:N \l__tenkz_flpos_tl
 \tl_new:N \l__tenkz_frole_tl     % \tnput role word (empty = none)
@@ -29,11 +33,11 @@
 \tl_new:N \l__tenkz_frolesty_tl  % resolved role/species style (or empty)
 \pgfkeys{
   /tenkz/put/.is~family,
-  /tenkz/put/dot/.code={\tl_set:Nn \l__tenkz_cshape_tl {dot}},
-  /tenkz/put/box/.code={\tl_set:Nn \l__tenkz_cshape_tl {box}},
-  /tenkz/put/pill/.code={\tl_set:Nn \l__tenkz_cshape_tl {pill}},
-  /tenkz/put/mpo/.code={\tl_set:Nn \l__tenkz_cshape_tl {mpo}},
-  /tenkz/put/ring/.code={\tl_set:Nn \l__tenkz_cshape_tl {ring}},
+  /tenkz/put/dot/.code={\tl_set:Nn \l__tenkz_fshape_tl {dot}},
+  /tenkz/put/box/.code={\tl_set:Nn \l__tenkz_fshape_tl {box}},
+  /tenkz/put/pill/.code={\tl_set:Nn \l__tenkz_fshape_tl {pill}},
+  /tenkz/put/mpo/.code={\tl_set:Nn \l__tenkz_fshape_tl {mpo}},
+  /tenkz/put/ring/.code={\tl_set:Nn \l__tenkz_fshape_tl {ring}},
   /tenkz/put/ports/.store~in=\l__tenkz_fports_tl,
   % role= / species=: the semantic hue interface (see tenkz-core) —
   % the language's invariants cross the free-tier border.  Resolution
@@ -85,33 +89,31 @@
       }
   }
 
-% the resolved role/species style for glyph family #1 (tensor|outline):
-% species first, role wins — mirroring the grid's resolver
-\cs_new_protected:Npn \tenkz_free_role_style:n #1
+% the resolved role/species style: species first, role wins — the same
+% resolution as the grid's, but parameterized so ONE resolver serves
+% atoms (tensor/outline families) and joins (bond).  #1 role tl,
+% #2 species tl, #3 output tl, #4 glyph family word.
+\cs_new_protected:Npn \tenkz_free_role_style:NNNn #1#2#3#4
   {
-    \tl_clear:N \l__tenkz_frolesty_tl
+    \tl_clear:N #3
     % \c_space_tl, not ~: a space character after a control word is
     % swallowed at tokenization, so the style-name gap must be a token
-    \tl_if_empty:NF \l__tenkz_fspec_tl
-      { \tl_set:Ne \l__tenkz_frolesty_tl
-          { species~ \tl_use:N \l__tenkz_fspec_tl \c_space_tl #1 } }
-    \tl_if_empty:NF \l__tenkz_frole_tl
-      { \tl_set:Ne \l__tenkz_frolesty_tl
-          { \tl_use:N \l__tenkz_frole_tl \c_space_tl #1 } }
+    \tl_if_empty:NF #2
+      { \tl_set:Ne #3 { species~ \tl_use:N #2 \c_space_tl #4 } }
+    \tl_if_empty:NF #1
+      { \tl_set:Ne #3 { \tl_use:N #1 \c_space_tl #4 } }
   }
-\cs_new:Npn \tenkz_free_role_word:
-  { \tl_if_empty:NTF \l__tenkz_frole_tl {none}
-      { \tl_use:N \l__tenkz_frole_tl } }
-\cs_new:Npn \tenkz_free_spec_word:
-  { \tl_if_empty:NTF \l__tenkz_fspec_tl {none}
-      { \tl_use:N \l__tenkz_fspec_tl } }
+% the event word of a semantic tl: `none' when empty.  Expandable, so
+% the audit write resolves it in place.
+\cs_new:Npn \tenkz_free_word:N #1
+  { \tl_if_empty:NTF #1 {none} { \tl_use:N #1 } }
 
 \NewDocumentCommand \tnput { O{} m m m }
   {
     \group_begin:
     % the default skin is the glyph policy (tensor style=dot|box); an
     % explicit skin key overrides it below
-    \tl_set:Ne \l__tenkz_cshape_tl { \tenkz@tensorstyle }
+    \tl_set:Ne \l__tenkz_fshape_tl { \tenkz@tensorstyle }
     \tl_clear:N \l__tenkz_fports_tl
     \tl_clear:N \l__tenkz_frole_tl
     \tl_clear:N \l__tenkz_fspec_tl
@@ -120,23 +122,28 @@
     % the role/species style rides its own literal option slot (an
     % empty slot is an inert trailing option); beads resolve through
     % the tensor family, inscribed-label skins through outline
-    \str_if_eq:VnTF \l__tenkz_cshape_tl {dot}
-      { \tenkz_free_role_style:n {tensor} }
-      { \tenkz_free_role_style:n {outline} }
-    \str_case:Vn \l__tenkz_cshape_tl
+    \str_if_eq:VnTF \l__tenkz_fshape_tl {dot}
+      { \tenkz_free_role_style:NNNn \l__tenkz_frole_tl
+          \l__tenkz_fspec_tl \l__tenkz_frolesty_tl {tensor} }
+      { \tenkz_free_role_style:NNNn \l__tenkz_frole_tl
+          \l__tenkz_fspec_tl \l__tenkz_frolesty_tl {outline} }
+    % every inscribed label carries \tenkz@glyphstrut: mixed labels
+    % (descenders, superscripts) must share one glyph height (the core
+    % strut contract; free has no strut-clearing skins)
+    \str_case:Vn \l__tenkz_fshape_tl
       {
         {dot}  { \node[tensor, \l__tenkz_frolesty_tl] (#2) at #3 {};
                  \tl_if_blank:nF {#4}
                    { \exp_args:NV \tenkz_free_dot_label:nnn
                        \l__tenkz_flpos_tl {#2} {#4} } }
         {box}  { \node[box~tensor, \l__tenkz_frolesty_tl] (#2) at #3
-                   { $\tenkz@labelsize #4$ }; }
+                   { $\tenkz@labelsize \tenkz@glyphstrut #4$ }; }
         {pill} { \node[pill~tensor, \l__tenkz_frolesty_tl] (#2) at #3
-                   { $\tenkz@labelsize #4$ }; }
+                   { $\tenkz@labelsize \tenkz@glyphstrut #4$ }; }
         {mpo}  { \node[mpo~tensor, \l__tenkz_frolesty_tl] (#2) at #3
-                   { $\tenkz@labelsize #4$ }; }
+                   { $\tenkz@labelsize \tenkz@glyphstrut #4$ }; }
         {ring} { \node[on-wire~matrix, \l__tenkz_frolesty_tl] (#2) at #3
-                   { $\tenkz@labelsize #4$ }; }
+                   { $\tenkz@labelsize \tenkz@glyphstrut #4$ }; }
       }
     % register declared port types:  ports={east:virtual, north:physical}
     % (str-normalized so the document's catcode-12 colon parses)
@@ -145,7 +152,7 @@
         \exp_args:NV \clist_map_inline:nn \l__tenkz_fports_tl
           { \exp_args:Ne \tenkz_free_port:n { \tl_to_str:n { #2 . ##1 } } }
       }
-    \tenkz@event{atom|picture=\the\tenkz@pictureid|name=#2|kind=\tl_use:N \l__tenkz_cshape_tl|role=\tenkz_free_role_word:|species=\tenkz_free_spec_word:}
+    \tenkz@event{atom|picture=\the\tenkz@pictureid|name=#2|kind=\tl_use:N \l__tenkz_fshape_tl|role=\tenkz_free_word:N \l__tenkz_frole_tl|species=\tenkz_free_word:N \l__tenkz_fspec_tl}
     \group_end:
   }
 \use:e
@@ -161,8 +168,11 @@
   { \use:e { \exp_not:N \tenkz_free_port_aux:w #1 } \q_stop }
 
 % \tnjoin[<keys>]{<name.anchor>}{<name.anchor>}
+%   keys: route=straight|hv|vh|arc (curve = 0.5 alias), label=,
+%   out=/in= (arc only), dir, fused, role=, species=
 \tl_new:N \l__tenkz_jroute_tl
 \tl_new:N \l__tenkz_jlabel_tl
+\tl_new:N \l__tenkz_jlabelnode_tl % on-path label node tokens (or empty)
 \tl_new:N \l__tenkz_jout_tl
 \tl_new:N \l__tenkz_jin_tl
 \tl_new:N \l__tenkz_jstyle_tl   % resolved wire style (bond / fused bond)
@@ -240,43 +250,92 @@
           { \tl_set:Nn \l__tenkz_jmarks_tl {dir~marks} }
           { \tl_clear:N \l__tenkz_jmarks_tl }
       }
-    \tl_clear:N \l__tenkz_jrolesty_tl
-    % \c_space_tl, not ~: a space character after a control word is
-    % swallowed at tokenization, so the style-name gap must be a token
-    \tl_if_empty:NF \l__tenkz_jspec_tl
-      { \tl_set:Ne \l__tenkz_jrolesty_tl
-          { species~ \tl_use:N \l__tenkz_jspec_tl \c_space_tl bond } }
-    \tl_if_empty:NF \l__tenkz_jrole_tl
-      { \tl_set:Ne \l__tenkz_jrolesty_tl
-          { \tl_use:N \l__tenkz_jrole_tl \c_space_tl bond } }
-    \str_case:Vn \l__tenkz_jroute_tl
+    \tenkz_free_role_style:NNNn \l__tenkz_jrole_tl
+      \l__tenkz_jspec_tl \l__tenkz_jrolesty_tl {bond}
+    % the label rides the PATH, one clearance band above the ink -- the
+    % chord midpoint is off-wire for every non-straight route, and a
+    % literal offset would not scale with the compact/inline profiles.
+    % Each route names the pos where its wire runs horizontally: the
+    % chord midpoint (straight), the mid-arc apex, or the middle of the
+    % elbow's horizontal segment (pos 0.5 of -|/|- is the corner, so
+    % 0.25/0.75 is the first/second segment's midpoint).
+    \tl_clear:N \l__tenkz_jlabelnode_tl
+    % unknown routes fail CLOSED: silence here would drop the wire but
+    % keep the join event, and the audit stream would certify ink that
+    % was never drawn
+    \str_case:VnF \l__tenkz_jroute_tl
       {
-        {straight} { \draw[\tl_use:N \l__tenkz_jstyle_tl,
-                           \tl_use:N \l__tenkz_jmarks_tl,
-                           \tl_use:N \l__tenkz_jrolesty_tl] (#2) -- (#3); }
-        {hv} { \draw[\tl_use:N \l__tenkz_jstyle_tl,
-                     \tl_use:N \l__tenkz_jmarks_tl,
-                     \tl_use:N \l__tenkz_jrolesty_tl,
-                     rounded~corners=\tenkz@dim{\tenkz@r@corner}]
-                 (#2) -| (#3); }
-        {vh} { \draw[\tl_use:N \l__tenkz_jstyle_tl,
-                     \tl_use:N \l__tenkz_jmarks_tl,
-                     \tl_use:N \l__tenkz_jrolesty_tl,
-                     rounded~corners=\tenkz@dim{\tenkz@r@corner}]
-                 (#2) |- (#3); }
-        {curve} { \draw[\tl_use:N \l__tenkz_jstyle_tl,
-                        \tl_use:N \l__tenkz_jmarks_tl,
-                        \tl_use:N \l__tenkz_jrolesty_tl]
-                    (#2) to[out=\tl_use:N\l__tenkz_jout_tl,
-                            in=\tl_use:N\l__tenkz_jin_tl] (#3); }
+        {straight} { \tenkz_free_label_node:n {0.5}
+                     \tenkz_free_join_draw:nnnn {} {#2} { -- } {#3} }
+        {hv} { \tenkz_free_label_node:n {0.25}
+               \tenkz_free_join_draw:nnnn
+                 { rounded~corners=\tenkz@dim{\tenkz@r@corner} }
+                 {#2} { -| } {#3} }
+        {vh} { \tenkz_free_label_node:n {0.75}
+               \tenkz_free_join_draw:nnnn
+                 { rounded~corners=\tenkz@dim{\tenkz@r@corner} }
+                 {#2} { |- } {#3} }
+        {arc}   { \tenkz_free_arc_join:nn {#2} {#3} }
+        {curve} { \tenkz_free_arc_join:nn {#2} {#3} }
       }
-    \tl_if_empty:NF \l__tenkz_jlabel_tl
       {
-        \node[label, anchor=south] at ($(#2)!0.5!(#3)+(0,2pt)$)
-          { $\tenkz@labelsize \tl_use:N \l__tenkz_jlabel_tl$ };
+        \PackageError{tenkz}
+          {Unknown~route~'\tl_use:N \l__tenkz_jroute_tl'}
+          {Routes:~straight,~hv,~vh,~arc~(alias:~curve).}
       }
-    \tenkz@event{join|picture=\the\tenkz@pictureid|from=#2|to=#3|dir=\bool_if:NTF \l__tenkz_jdir_bool {forward}{none}|role=\tl_if_empty:NTF \l__tenkz_jrole_tl {none}{\tl_use:N \l__tenkz_jrole_tl}|species=\tl_if_empty:NTF \l__tenkz_jspec_tl {none}{\tl_use:N \l__tenkz_jspec_tl}}
+    \tenkz@event{join|picture=\the\tenkz@pictureid|from=#2|to=#3|dir=\bool_if:NTF \l__tenkz_jdir_bool {forward}{none}|role=\tenkz_free_word:N \l__tenkz_jrole_tl|species=\tenkz_free_word:N \l__tenkz_jspec_tl}
     \group_end:
+  }
+
+% the on-path label node at pos #1 (empty when the join is unlabeled)
+\cs_new_protected:Npn \tenkz_free_label_node:n #1
+  {
+    \tl_if_empty:NF \l__tenkz_jlabel_tl
+      { \tl_set:Nn \l__tenkz_jlabelnode_tl
+          { node[label, pos=#1, above=\tenkz@dim{\tenkz@r@labelclear}]
+              { $\tenkz@labelsize \tl_use:N \l__tenkz_jlabel_tl$ } } }
+  }
+
+% the join wire: #1 extra path options, #2 from, #3 path operator
+% tokens, #4 to.  The label node tokens are spliced into the path
+% BEFORE TikZ scans it: the lineto/to scanners futurelet-check for a
+% literal `node' and never expand a macro in that position.  Only the
+% \exp_not:V splice expands; every other token passes through inert.
+\cs_new_protected:Npn \tenkz_free_join_draw:nnnn #1#2#3#4
+  {
+    \use:e
+      {
+        \exp_not:n
+          { \draw [ \tl_use:N \l__tenkz_jstyle_tl,
+                    \tl_use:N \l__tenkz_jmarks_tl,
+                    \tl_use:N \l__tenkz_jrolesty_tl, #1 ]
+              (#2) #3 }
+        \exp_not:V \l__tenkz_jlabelnode_tl
+        \exp_not:n { (#4) ; }
+      }
+  }
+
+% the arc route (DESIGN spells it `arc'; `curve' survives as the 0.5
+% alias): an out=/in= curve.  The angles have no sensible default, so
+% an empty out= or in= is a hard error; the wire falls back to the
+% straight chord so a draft still shows the connection being flagged.
+\cs_new_protected:Npn \tenkz_free_arc_join:nn #1#2
+  {
+    \tenkz_free_label_node:n {0.5}
+    \bool_lazy_or:nnTF
+      { \tl_if_empty_p:N \l__tenkz_jout_tl }
+      { \tl_if_empty_p:N \l__tenkz_jin_tl }
+      {
+        \PackageError{tenkz}
+          {route=arc~needs~both~out=~and~in=~angles}
+          {Give~departure/arrival~angles,~e.g.~out=90,~in=90.}
+        \tenkz_free_join_draw:nnnn {} {#1} { -- } {#2}
+      }
+      {
+        \tenkz_free_join_draw:nnnn {} {#1}
+          { to[out=\tl_use:N\l__tenkz_jout_tl,
+               in=\tl_use:N\l__tenkz_jin_tl] } {#2}
+      }
   }
 
 \ExplSyntaxOff

--- a/tex/tenkz/tenkz-free.code.tex
+++ b/tex/tenkz/tenkz-free.code.tex
@@ -74,16 +74,16 @@
   {
     \str_case:nn {#1}
       {
-        {south} { \node[label, anchor=north] at
+        {south} { \node[tn~label, anchor=north] at
                     ($(#2.south)-(0,\tenkz@dim{\tenkz@r@labelclear})$)
                     { $\tenkz@labelsize #3$ }; }
-        {north} { \node[label, anchor=south] at
+        {north} { \node[tn~label, anchor=south] at
                     ($(#2.north)+(0,\tenkz@dim{\tenkz@r@labelclear})$)
                     { $\tenkz@labelsize #3$ }; }
-        {east}  { \node[label, anchor=west] at
+        {east}  { \node[tn~label, anchor=west] at
                     ($(#2.east)+(\tenkz@dim{\tenkz@r@labelclear},0)$)
                     { $\tenkz@labelsize #3$ }; }
-        {west}  { \node[label, anchor=east] at
+        {west}  { \node[tn~label, anchor=east] at
                     ($(#2.west)-(\tenkz@dim{\tenkz@r@labelclear},0)$)
                     { $\tenkz@labelsize #3$ }; }
       }
@@ -292,7 +292,7 @@
   {
     \tl_if_empty:NF \l__tenkz_jlabel_tl
       { \tl_set:Nn \l__tenkz_jlabelnode_tl
-          { node[label, pos=#1, above=\tenkz@dim{\tenkz@r@labelclear}]
+          { node[tn~label, pos=#1, above=\tenkz@dim{\tenkz@r@labelclear}]
               { $\tenkz@labelsize \tl_use:N \l__tenkz_jlabel_tl$ } } }
   }
 

--- a/tex/tenkz/tenkz-free.code.tex
+++ b/tex/tenkz/tenkz-free.code.tex
@@ -1,2 +1,283 @@
-%% tenkz-free -- placeholder; the real module lands later in this PR stack.
+% tenkz-free — L2d: sanctioned free placement for genuinely non-grid
+% diagrams (MERA, lassos, star tensors).  The only tier with runtime
+% port-type assertions: the grid languages are type-safe by construction.
+%
+% Phase-0 scope: \tnput places any L1 glyph with typed anchors recorded in
+% the port registry; \tnjoin draws a typed connection (straight, orthogonal,
+% or curved) and asserts endpoint types match.
+
+\ExplSyntaxOn
+
+\prop_new:N \g__tenkz_ports_prop   % "pictureid/name.anchor" -> type
+
+\NewDocumentEnvironment { tenkzfree } { O{} }
+  {
+    \tl_if_empty:nF {#1} { \pgfqkeys{/tenkz}{#1} }
+    \tenkz@beginpicture{free}
+    \begin{tikzpicture}[tenkz~every~picture,
+      baseline={(0pt,\dim_eval:n{-\fontdimen22\textfont2})}]
+  }
+  { \end{tikzpicture} }
+
+% \tnput[<glyph keys>]{<name>}{<coordinate>}{<label>}
+%   glyph keys: dot|box|pill|mpo (skin), ports={e:virtual, ph:physical, ...},
+%   label pos=north|south|east|west (dot skin only)
+\tl_new:N \l__tenkz_fports_tl
+\tl_new:N \l__tenkz_flpos_tl
+\tl_new:N \l__tenkz_frole_tl     % \tnput role word (empty = none)
+\tl_new:N \l__tenkz_fspec_tl     % \tnput species name (empty = none)
+\tl_new:N \l__tenkz_frolesty_tl  % resolved role/species style (or empty)
+\pgfkeys{
+  /tenkz/put/.is~family,
+  /tenkz/put/dot/.code={\tl_set:Nn \l__tenkz_cshape_tl {dot}},
+  /tenkz/put/box/.code={\tl_set:Nn \l__tenkz_cshape_tl {box}},
+  /tenkz/put/pill/.code={\tl_set:Nn \l__tenkz_cshape_tl {pill}},
+  /tenkz/put/mpo/.code={\tl_set:Nn \l__tenkz_cshape_tl {mpo}},
+  /tenkz/put/ring/.code={\tl_set:Nn \l__tenkz_cshape_tl {ring}},
+  /tenkz/put/ports/.store~in=\l__tenkz_fports_tl,
+  % role= / species=: the semantic hue interface (see tenkz-core) —
+  % the language's invariants cross the free-tier border.  Resolution
+  % is pure style indirection (`<role> tensor` for the bead, `<role>
+  % outline` for the inscribed-label skins); role wins when both are
+  % given, and the atom's event carries both words.
+  /tenkz/put/role/.is~choice,
+  /tenkz/put/role/operator/.code={\tl_set:Nn \l__tenkz_frole_tl {operator}},
+  /tenkz/put/role/marked/.code={\tl_set:Nn \l__tenkz_frole_tl {marked}},
+  /tenkz/put/role/extra/.code={\tl_set:Nn \l__tenkz_frole_tl {extra}},
+  /tenkz/put/role/passive/.code={\tl_set:Nn \l__tenkz_frole_tl {passive}},
+  /tenkz/put/species/.code={\tenkz_species_check:n{#1}
+      \tl_set:Nn \l__tenkz_fspec_tl {#1}},
+  % label pos = north|south|east|west: which side of a BEAD carries its
+  % external label (default south, the historical band).  A vertical or
+  % rotated chain sends a wire through the south band at every dot
+  % (plane_sweep3 panel 2a: the rotated transfer matrix E), so the free
+  % tier must let the label yield the busy side -- one clearance band
+  % (\tenkz@r@labelclear) beyond the named compass point, label anchored
+  % opposite.  Box/pill/mpo/ring skins inscribe their labels and ignore it.
+  /tenkz/put/label~pos/.is~choice,
+  /tenkz/put/label~pos/north/.code={\tl_set:Nn \l__tenkz_flpos_tl {north}},
+  /tenkz/put/label~pos/south/.code={\tl_set:Nn \l__tenkz_flpos_tl {south}},
+  /tenkz/put/label~pos/east/.code ={\tl_set:Nn \l__tenkz_flpos_tl {east}},
+  /tenkz/put/label~pos/west/.code ={\tl_set:Nn \l__tenkz_flpos_tl {west}},
+}
+
+% the dot label at compass side #1: label node one clearance band beyond
+% the bead's #1 anchor, anchored on the opposite side so the text extends
+% outward; #2 the bead's node name, #3 the label tokens.  `south` emits
+% exactly the historical band (the pre-key path), so default renders are
+% unchanged.
+\cs_new_protected:Npn \tenkz_free_dot_label:nnn #1#2#3
+  {
+    \str_case:nn {#1}
+      {
+        {south} { \node[label, anchor=north] at
+                    ($(#2.south)-(0,\tenkz@dim{\tenkz@r@labelclear})$)
+                    { $\tenkz@labelsize #3$ }; }
+        {north} { \node[label, anchor=south] at
+                    ($(#2.north)+(0,\tenkz@dim{\tenkz@r@labelclear})$)
+                    { $\tenkz@labelsize #3$ }; }
+        {east}  { \node[label, anchor=west] at
+                    ($(#2.east)+(\tenkz@dim{\tenkz@r@labelclear},0)$)
+                    { $\tenkz@labelsize #3$ }; }
+        {west}  { \node[label, anchor=east] at
+                    ($(#2.west)-(\tenkz@dim{\tenkz@r@labelclear},0)$)
+                    { $\tenkz@labelsize #3$ }; }
+      }
+  }
+
+% the resolved role/species style for glyph family #1 (tensor|outline):
+% species first, role wins — mirroring the grid's resolver
+\cs_new_protected:Npn \tenkz_free_role_style:n #1
+  {
+    \tl_clear:N \l__tenkz_frolesty_tl
+    % \c_space_tl, not ~: a space character after a control word is
+    % swallowed at tokenization, so the style-name gap must be a token
+    \tl_if_empty:NF \l__tenkz_fspec_tl
+      { \tl_set:Ne \l__tenkz_frolesty_tl
+          { species~ \tl_use:N \l__tenkz_fspec_tl \c_space_tl #1 } }
+    \tl_if_empty:NF \l__tenkz_frole_tl
+      { \tl_set:Ne \l__tenkz_frolesty_tl
+          { \tl_use:N \l__tenkz_frole_tl \c_space_tl #1 } }
+  }
+\cs_new:Npn \tenkz_free_role_word:
+  { \tl_if_empty:NTF \l__tenkz_frole_tl {none}
+      { \tl_use:N \l__tenkz_frole_tl } }
+\cs_new:Npn \tenkz_free_spec_word:
+  { \tl_if_empty:NTF \l__tenkz_fspec_tl {none}
+      { \tl_use:N \l__tenkz_fspec_tl } }
+
+\NewDocumentCommand \tnput { O{} m m m }
+  {
+    \group_begin:
+    % the default skin is the glyph policy (tensor style=dot|box); an
+    % explicit skin key overrides it below
+    \tl_set:Ne \l__tenkz_cshape_tl { \tenkz@tensorstyle }
+    \tl_clear:N \l__tenkz_fports_tl
+    \tl_clear:N \l__tenkz_frole_tl
+    \tl_clear:N \l__tenkz_fspec_tl
+    \tl_set:Nn \l__tenkz_flpos_tl {south}
+    \tl_if_empty:nF {#1} { \pgfqkeys{/tenkz/put}{#1} }
+    % the role/species style rides its own literal option slot (an
+    % empty slot is an inert trailing option); beads resolve through
+    % the tensor family, inscribed-label skins through outline
+    \str_if_eq:VnTF \l__tenkz_cshape_tl {dot}
+      { \tenkz_free_role_style:n {tensor} }
+      { \tenkz_free_role_style:n {outline} }
+    \str_case:Vn \l__tenkz_cshape_tl
+      {
+        {dot}  { \node[tensor, \l__tenkz_frolesty_tl] (#2) at #3 {};
+                 \tl_if_blank:nF {#4}
+                   { \exp_args:NV \tenkz_free_dot_label:nnn
+                       \l__tenkz_flpos_tl {#2} {#4} } }
+        {box}  { \node[box~tensor, \l__tenkz_frolesty_tl] (#2) at #3
+                   { $\tenkz@labelsize #4$ }; }
+        {pill} { \node[pill~tensor, \l__tenkz_frolesty_tl] (#2) at #3
+                   { $\tenkz@labelsize #4$ }; }
+        {mpo}  { \node[mpo~tensor, \l__tenkz_frolesty_tl] (#2) at #3
+                   { $\tenkz@labelsize #4$ }; }
+        {ring} { \node[on-wire~matrix, \l__tenkz_frolesty_tl] (#2) at #3
+                   { $\tenkz@labelsize #4$ }; }
+      }
+    % register declared port types:  ports={east:virtual, north:physical}
+    % (str-normalized so the document's catcode-12 colon parses)
+    \tl_if_empty:NF \l__tenkz_fports_tl
+      {
+        \exp_args:NV \clist_map_inline:nn \l__tenkz_fports_tl
+          { \exp_args:Ne \tenkz_free_port:n { \tl_to_str:n { #2 . ##1 } } }
+      }
+    \tenkz@event{atom|picture=\the\tenkz@pictureid|name=#2|kind=\tl_use:N \l__tenkz_cshape_tl|role=\tenkz_free_role_word:|species=\tenkz_free_spec_word:}
+    \group_end:
+  }
+\use:e
+  {
+    \cs_new_protected:Npn \exp_not:N \tenkz_free_port_aux:w
+      #1 \c_colon_str #2 \exp_not:N \q_stop
+      {
+        \prop_gput:Nen \exp_not:N \g__tenkz_ports_prop
+          { \exp_not:N \the \exp_not:N \tenkz@pictureid / #1 } {#2}
+      }
+  }
+\cs_new_protected:Npn \tenkz_free_port:n #1
+  { \use:e { \exp_not:N \tenkz_free_port_aux:w #1 } \q_stop }
+
+% \tnjoin[<keys>]{<name.anchor>}{<name.anchor>}
+\tl_new:N \l__tenkz_jroute_tl
+\tl_new:N \l__tenkz_jlabel_tl
+\tl_new:N \l__tenkz_jout_tl
+\tl_new:N \l__tenkz_jin_tl
+\tl_new:N \l__tenkz_jstyle_tl   % resolved wire style (bond / fused bond)
+\tl_new:N \l__tenkz_jmarks_tl   % resolved direction-mark style (may be empty)
+\tl_new:N \l__tenkz_jrole_tl    % join role word (empty = none)
+\tl_new:N \l__tenkz_jspec_tl    % join species name (empty = none)
+\tl_new:N \l__tenkz_jrolesty_tl % resolved role/species bond style (or empty)
+\bool_new:N \l__tenkz_jfused_bool
+\bool_new:N \l__tenkz_jdir_bool
+\pgfkeys{
+  /tenkz/join/.is~family,
+  /tenkz/join/route/.store~in=\l__tenkz_jroute_tl,
+  /tenkz/join/label/.store~in=\l__tenkz_jlabel_tl,
+  /tenkz/join/fused/.code={\bool_set_true:N \l__tenkz_jfused_bool},
+  % dir: a DIRECTED join, from the first endpoint to the second (argument
+  % order = direction).  An outgoing arrow is the vector space V, an
+  % incoming one its dual V*; the barb rides mid-wire and, with `fused`,
+  % grows to span the doubled wire.
+  /tenkz/join/dir/.code={\bool_set_true:N \l__tenkz_jdir_bool},
+  /tenkz/join/out/.store~in=\l__tenkz_jout_tl,
+  /tenkz/join/in/.store~in=\l__tenkz_jin_tl,
+  % role= / species=: the semantic hue of the WIRE (worklist item 1,
+  % the operator-hued \tnjoin, as a grammar instance).  Resolution is
+  % pure style indirection through the derived bond styles of
+  % tenkz-core; the join's event carries both words.
+  /tenkz/join/role/.is~choice,
+  /tenkz/join/role/operator/.code={\tl_set:Nn \l__tenkz_jrole_tl {operator}},
+  /tenkz/join/role/marked/.code={\tl_set:Nn \l__tenkz_jrole_tl {marked}},
+  /tenkz/join/role/extra/.code={\tl_set:Nn \l__tenkz_jrole_tl {extra}},
+  /tenkz/join/role/passive/.code={\tl_set:Nn \l__tenkz_jrole_tl {passive}},
+  /tenkz/join/species/.code={\tenkz_species_check:n{#1}
+      \tl_set:Nn \l__tenkz_jspec_tl {#1}},
+}
+
+\NewDocumentCommand \tnjoin { O{} m m }
+  {
+    \group_begin:
+    \tl_set:Nn \l__tenkz_jroute_tl {straight}
+    \tl_clear:N \l__tenkz_jlabel_tl
+    \tl_clear:N \l__tenkz_jout_tl \tl_clear:N \l__tenkz_jin_tl
+    \tl_clear:N \l__tenkz_jrole_tl
+    \tl_clear:N \l__tenkz_jspec_tl
+    \bool_set_false:N \l__tenkz_jfused_bool
+    \bool_set_false:N \l__tenkz_jdir_bool
+    \tl_if_empty:nF {#1} { \pgfqkeys{/tenkz/join}{#1} }
+    % type assertion when both endpoints declared types
+    \prop_get:NeNT \g__tenkz_ports_prop {\the\tenkz@pictureid/#2} \l_tmpa_tl
+      {
+        \prop_get:NeNT \g__tenkz_ports_prop {\the\tenkz@pictureid/#3} \l_tmpb_tl
+          {
+            \tl_if_eq:NNF \l_tmpa_tl \l_tmpb_tl
+              {
+                \PackageError{tenkz}
+                  {Port~type~mismatch:~#2~is~\l_tmpa_tl,~#3~is~\l_tmpb_tl}
+                  {Only~equal~port~types~may~be~joined.}
+              }
+          }
+      }
+    % wire style, mark style and role style stay SEPARATE option slots:
+    % pgfkeys splits the option list on literal commas before expanding,
+    % so a comma packed inside one tl would fuse both names into one
+    % unknown key.  An empty slot is an inert trailing option.  The role
+    % slot rides LAST, so its draw= wins over the base style's while the
+    % base's geometry (doubling, width) survives.
+    \bool_if:NTF \l__tenkz_jfused_bool
+      {
+        \tl_set:Nn \l__tenkz_jstyle_tl {fused~bond}
+        \bool_if:NTF \l__tenkz_jdir_bool
+          { \tl_set:Nn \l__tenkz_jmarks_tl {fused~dir~marks} }
+          { \tl_clear:N \l__tenkz_jmarks_tl }
+      }
+      {
+        \tl_set:Nn \l__tenkz_jstyle_tl {bond}
+        \bool_if:NTF \l__tenkz_jdir_bool
+          { \tl_set:Nn \l__tenkz_jmarks_tl {dir~marks} }
+          { \tl_clear:N \l__tenkz_jmarks_tl }
+      }
+    \tl_clear:N \l__tenkz_jrolesty_tl
+    % \c_space_tl, not ~: a space character after a control word is
+    % swallowed at tokenization, so the style-name gap must be a token
+    \tl_if_empty:NF \l__tenkz_jspec_tl
+      { \tl_set:Ne \l__tenkz_jrolesty_tl
+          { species~ \tl_use:N \l__tenkz_jspec_tl \c_space_tl bond } }
+    \tl_if_empty:NF \l__tenkz_jrole_tl
+      { \tl_set:Ne \l__tenkz_jrolesty_tl
+          { \tl_use:N \l__tenkz_jrole_tl \c_space_tl bond } }
+    \str_case:Vn \l__tenkz_jroute_tl
+      {
+        {straight} { \draw[\tl_use:N \l__tenkz_jstyle_tl,
+                           \tl_use:N \l__tenkz_jmarks_tl,
+                           \tl_use:N \l__tenkz_jrolesty_tl] (#2) -- (#3); }
+        {hv} { \draw[\tl_use:N \l__tenkz_jstyle_tl,
+                     \tl_use:N \l__tenkz_jmarks_tl,
+                     \tl_use:N \l__tenkz_jrolesty_tl,
+                     rounded~corners=\tenkz@dim{\tenkz@r@corner}]
+                 (#2) -| (#3); }
+        {vh} { \draw[\tl_use:N \l__tenkz_jstyle_tl,
+                     \tl_use:N \l__tenkz_jmarks_tl,
+                     \tl_use:N \l__tenkz_jrolesty_tl,
+                     rounded~corners=\tenkz@dim{\tenkz@r@corner}]
+                 (#2) |- (#3); }
+        {curve} { \draw[\tl_use:N \l__tenkz_jstyle_tl,
+                        \tl_use:N \l__tenkz_jmarks_tl,
+                        \tl_use:N \l__tenkz_jrolesty_tl]
+                    (#2) to[out=\tl_use:N\l__tenkz_jout_tl,
+                            in=\tl_use:N\l__tenkz_jin_tl] (#3); }
+      }
+    \tl_if_empty:NF \l__tenkz_jlabel_tl
+      {
+        \node[label, anchor=south] at ($(#2)!0.5!(#3)+(0,2pt)$)
+          { $\tenkz@labelsize \tl_use:N \l__tenkz_jlabel_tl$ };
+      }
+    \tenkz@event{join|picture=\the\tenkz@pictureid|from=#2|to=#3|dir=\bool_if:NTF \l__tenkz_jdir_bool {forward}{none}|role=\tl_if_empty:NTF \l__tenkz_jrole_tl {none}{\tl_use:N \l__tenkz_jrole_tl}|species=\tl_if_empty:NTF \l__tenkz_jspec_tl {none}{\tl_use:N \l__tenkz_jspec_tl}}
+    \group_end:
+  }
+
+\ExplSyntaxOff
 \endinput


### PR DESCRIPTION
Stack 03 (on 02-grid). Sanctioned escape hatch for genuinely non-grid diagrams; typed ports with runtime assertions (\tnjoin rejects virtual–physical contractions), straight/orthogonal/curved routes, fused-wire skin.

https://claude.ai/code/session_01Rpby2DabUL1mbsMkFadv1q

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a large new public LaTeX surface and runtime port-type checks, but it is scoped to the free tier and builds on existing tenkz-core styling and logging.
> 
> **Overview**
> Replaces the **tenkz-free** placeholder with the L2d free-placement tier: a `tenkzfree` TikZ environment wired into the existing picture/audit lifecycle.
> 
> Authors can **`\tnput`** named tensors at arbitrary coordinates (dot/box/pill/mpo/ring skins, optional `role`/`species`, dot **label pos**, and **`ports={anchor:type}`** entries in a per-picture registry). **`\tnjoin`** draws bonds between `name.anchor` endpoints with routes (`straight`, `hv`, `vh`, `arc`/`curve`), optional path labels, **`fused`**, and **`dir`** (direction from first to second port). When both endpoints have registered types, joins **error on mismatch**; unknown routes and incomplete arc angles fail closed while still emitting audit events for atoms/joins.
> 
> Adds **`free-typed-joins.tex`** as a minimal demo (typed virtual join, curved physical link, directed box bond).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50afa44a19d894024387e5d274668aae1e759d79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->