### PR TITLE
feat(Analysis): expose trace norm through positive spectrum

### DIFF
--- a/TNLean/Analysis/SchattenNorm.lean
+++ b/TNLean/Analysis/SchattenNorm.lean
@@ -35,6 +35,8 @@ quantity is not identified with the ambient matrix operator norm.
   singular-value range.
 * `Matrix.traceNorm_eq_sum_fin` — Wolf's finite-dimensional formula summing
   over all `Fin D` indices.
+* `Matrix.traceNorm_eq_sum_sqrt_eigenvalues_adjoint_comp_self` — the trace norm
+  as the sum of the square roots of the eigenvalues of `A†A`.
 
 ## References
 
@@ -106,6 +108,17 @@ theorem traceNorm_eq_sum_fin (A : Matrix (Fin D) (Fin D) ℂ) :
     _ = ∑ i : Fin D, (Matrix.toEuclideanLin A).singularValues i := by
       symm
       exact Fin.sum_univ_eq_sum_range _ D
+
+/-- The trace norm is the sum of the square roots of the eigenvalues of the
+positive operator `A†A`. -/
+theorem traceNorm_eq_sum_sqrt_eigenvalues_adjoint_comp_self
+    (A : Matrix (Fin D) (Fin D) ℂ) :
+    traceNorm A = ∑ i : Fin D,
+      Real.sqrt ((Matrix.toEuclideanLin A).isSymmetric_adjoint_comp_self.eigenvalues
+        (by simp) i) := by
+  rw [traceNorm_eq_sum_fin]
+  exact Finset.sum_congr rfl fun i _ ↦
+    (Matrix.toEuclideanLin A).singularValues_fin (by simp) i
 
 /-- The Schatten one-norm is nonnegative. -/
 theorem schattenOneNorm_nonneg (A : Matrix (Fin D) (Fin D) ℂ) :

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -88,6 +88,30 @@ $\lVert A\rVert_1=\operatorname{tr}\lvert A\rvert$
     \]
 \end{proof}
 
+\begin{theorem}[Trace norm from the spectrum of $A^*A$]
+    \label{thm:trace_norm_sqrt_eigenvalues}
+    \lean{Matrix.traceNorm_eq_sum_sqrt_eigenvalues_adjoint_comp_self}
+    \leanok
+    \uses{def:trace_norm}
+    For every $A\in\MN{D}$, the trace norm is the sum of the square roots of
+    the eigenvalues of the positive operator $A^*A$:
+    \[
+        \lVert A\rVert_{\mathrm{tr}}
+        = \sum_{i=0}^{D-1}\sqrt{\lambda_i(A^*A)}.
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:trace_norm_elementary}
+    Since $s_i(A)=\sqrt{\lambda_i(A^*A)}$ by the definition of singular value,
+    the finite singular-value expansion gives
+    \[
+        \lVert A\rVert_{\mathrm{tr}}
+        = \sum_{i=0}^{D-1}s_i(A)
+        = \sum_{i=0}^{D-1}\sqrt{\lambda_i(A^*A)}.
+    \]
+\end{proof}
+
 \section{Von Neumann entropy}
 
 \begin{definition}[Von Neumann entropy]\label{def:von_neumann_entropy}

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -88,27 +88,27 @@ $\lVert A\rVert_1=\operatorname{tr}\lvert A\rvert$
     \]
 \end{proof}
 
-\begin{theorem}[Trace norm from the spectrum of $A^*A$]
+\begin{theorem}[Trace norm from the spectrum of $A^\dagger A$]
     \label{thm:trace_norm_sqrt_eigenvalues}
     \lean{Matrix.traceNorm_eq_sum_sqrt_eigenvalues_adjoint_comp_self}
     \leanok
     \uses{def:trace_norm}
     For every $A\in\MN{D}$, the trace norm is the sum of the square roots of
-    the eigenvalues of the positive operator $A^*A$:
+    the eigenvalues of the positive operator $A^\dagger A$:
     \[
         \lVert A\rVert_{\mathrm{tr}}
-        = \sum_{i=0}^{D-1}\sqrt{\lambda_i(A^*A)}.
+        = \sum_{i=0}^{D-1}\sqrt{\lambda_i(A^\dagger A)}.
     \]
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{thm:trace_norm_elementary}
-    Since $s_i(A)=\sqrt{\lambda_i(A^*A)}$ by the definition of singular value,
+    Since $s_i(A)=\sqrt{\lambda_i(A^\dagger A)}$ by the definition of singular value,
     the finite singular-value expansion gives
     \[
         \lVert A\rVert_{\mathrm{tr}}
         = \sum_{i=0}^{D-1}s_i(A)
-        = \sum_{i=0}^{D-1}\sqrt{\lambda_i(A^*A)}.
+        = \sum_{i=0}^{D-1}\sqrt{\lambda_i(A^\dagger A)}.
     \]
 \end{proof}
 


### PR DESCRIPTION
## Summary

- expose `Matrix.traceNorm` as the sum of square roots of the ordered eigenvalues of the positive operator associated to `A†A`
- add a dependency-tracked blueprint theorem for the spectral bridge
- keep the increment deliberately below scalar homogeneity and triangle inequality after checking Mathlib 4.32 and current Mathlib master

## Dependency

PR LionSR/TNLean#4031 is merged. This branch is rebased onto current `main`.

## Source and scope

Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 8, §8.1 defines the trace norm through singular values. This PR adds the Mathlib-facing spectral bridge used by the next analytic layer; it does not claim a new theorem from Wolf beyond that exact context.

Scalar homogeneity from Wolf's matrix-norm axioms remains blocked because Mathlib has no theorem that ordered eigenvalues scale pointwise under nonnegative scalar multiplication, hence no `LinearMap.singularValues_smul`. Triangle inequality remains a larger Ky Fan / variational-duality gap: Mathlib has no SVD, partial-sum singular-value inequality, nuclear norm, or trace-norm duality supporting it. Accordingly this PR does not add a raw `Matrix` norm instance.

## Declaration

- `Matrix.traceNorm_eq_sum_sqrt_eigenvalues_adjoint_comp_self`

## Verification

- `lake env lean TNLean/Analysis/SchattenNorm.lean`
- `lake build TNLean.Analysis.SchattenNorm`
- `lake exe lint_style`
- blueprint sync check
- `git diff --check`
- no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast` in the changed Lean module

Supersedes closed stacked PR LionSR/TNLean#4047 after its base PR merged. Tracks the foundational part of LionSR/QICLean#212.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive change in `SchattenNorm.lean` and blueprint text; proof reuses existing lemmas with no auth, data, or API surface changes.
> 
> **Overview**
> Adds **`Matrix.traceNorm_eq_sum_sqrt_eigenvalues_adjoint_comp_self`**, identifying the trace norm with \(\sum_i \sqrt{\lambda_i(A^\dagger A)}\) via `traceNorm_eq_sum_fin` and Mathlib’s `singularValues_fin` link between singular values and the spectrum of the adjoint–self product.
> 
> The module docstring lists the new result, and **blueprint** chapter 19 gains theorem `thm:trace_norm_sqrt_eigenvalues` with a `\lean` anchor and a short proof from the finite singular-value expansion. No new norm axioms or `Matrix` norm instance—scope stays the spectral bridge for downstream analysis.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5291f25b7d46addcb832f8611b548b447aef0f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->