### PR TITLE
ci(workflows): stop saving per-run lake caches everywhere

### DIFF
--- a/.github/workflows/agent-mention.yml
+++ b/.github/workflows/agent-mention.yml
@@ -112,6 +112,11 @@ jobs:
 
       - name: Set up Lean toolchain and cache
         uses: texra-ai/lean-env-action@v1
+        with:
+          # Do not save a GitHub cache of .lake: per-run ~2.4 GB entries
+          # evict the main-branch build cache from the 10 GB repository
+          # budget within minutes. Mathlib comes from `lake exe cache get`.
+          use-github-cache: false
 
       - name: Install blueprint TeX stack
         uses: texra-ai/lean-env-action/blueprint-system-deps@v1

--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -332,6 +332,11 @@ jobs:
           steps.guard.outputs.skip != 'true' &&
           steps.review_payload.outputs.skip != 'true'
         uses: texra-ai/lean-env-action@v1
+        with:
+          # Do not save a GitHub cache of .lake: per-run ~2.4 GB entries
+          # evict the main-branch build cache from the 10 GB repository
+          # budget within minutes. Mathlib comes from `lake exe cache get`.
+          use-github-cache: false
 
       - name: Fix review comments with Claude
         if: |

--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -45,6 +45,8 @@ jobs:
         uses: leanprover/lean-action@v1
         with:
           build: true
+          # See pr-ci.yml: per-run lake caches evict the main build cache.
+          use-github-cache: false
 
       - name: Install TeX and graphviz
         uses: texra-ai/lean-env-action/blueprint-system-deps@v1

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -235,6 +235,11 @@ jobs:
 
       - name: Set up Lean toolchain and cache
         uses: texra-ai/lean-env-action@v1
+        with:
+          # Do not save a GitHub cache of .lake: per-run ~2.4 GB entries
+          # evict the main-branch build cache from the 10 GB repository
+          # budget within minutes. Mathlib comes from `lake exe cache get`.
+          use-github-cache: false
 
       - name: Run Lean build and capture warnings
         run: |

--- a/.github/workflows/issue-automation.yml
+++ b/.github/workflows/issue-automation.yml
@@ -299,8 +299,10 @@ jobs:
     steps:
       - name: Update tracking issues
         uses: actions/github-script@v8
+        # Deliberately uses the default GITHUB_TOKEN: BOT_PAT fails the
+        # sub-issues GraphQL lookups with "Bad credentials", and tracking
+        # comments do not need to retrigger other workflows.
         with:
-          github-token: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
 

--- a/.github/workflows/issue-automation.yml
+++ b/.github/workflows/issue-automation.yml
@@ -257,6 +257,11 @@ jobs:
       - name: Set up Lean toolchain and cache
         if: steps.decide.outputs.should_scout == 'true'
         uses: texra-ai/lean-env-action@v1
+        with:
+          # Do not save a GitHub cache of .lake: per-run ~2.4 GB entries
+          # evict the main-branch build cache from the 10 GB repository
+          # budget within minutes. Mathlib comes from `lake exe cache get`.
+          use-github-cache: false
 
       - name: Scout Mathlib
         if: steps.decide.outputs.should_scout == 'true'

--- a/.github/workflows/lean-linter-warning-autofix.yml
+++ b/.github/workflows/lean-linter-warning-autofix.yml
@@ -72,6 +72,11 @@ jobs:
       - name: Set up Lean toolchain and cache
         if: steps.write_mode.outputs.skip != 'true'
         uses: texra-ai/lean-env-action@v1
+        with:
+          # Do not save a GitHub cache of .lake: per-run ~2.4 GB entries
+          # evict the main-branch build cache from the 10 GB repository
+          # budget within minutes. Mathlib comes from `lake exe cache get`.
+          use-github-cache: false
 
       - name: Set up Python for warning summary
         if: always() && steps.write_mode.outputs.skip != 'true'

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -221,6 +221,11 @@ jobs:
         continue-on-error: true
         timeout-minutes: 6
         uses: texra-ai/lean-env-action@v1
+        with:
+          # Do not save a GitHub cache of .lake: per-run ~2.4 GB entries
+          # evict the main-branch build cache from the 10 GB repository
+          # budget within minutes. Mathlib comes from `lake exe cache get`.
+          use-github-cache: false
 
       - name: Install blueprint system dependencies
         if: env.TEX_CHANGED == 'true'


### PR DESCRIPTION
## Summary

Follow-up to LionSR/TNLean#4048/#4058. The main-only `tnlean-build` cache works — today's PR CI build restored it and replayed all modules in **3 min 6 s** (was 25–30 min). But `texra-ai/lean-env-action@v1` defaults `use-github-cache: true`, so the mention handler, Mathlib scout, review auto-fix, linter workflows, and the blueprint job still save a ~2.4 GB `lake-*` cache per run on their own refs (two such entries appeared today from pre-merge runs). Four of those evict the 243 MB main build cache from the 10 GB repository budget, silently reverting PR builds to full rebuilds.

## Change

`use-github-cache: false` at every remaining Lean setup: `agent-mention.yml`, `auto-fix.yml` (review job), `issue-automation.yml` (scout), `housekeeping.yml` (linter sweep), `lean-linter-warning-autofix.yml`, `pr-ci.yml` (blueprint job's toolchain setup), and `docgen.yml`. Mathlib artifacts still come from `lake exe cache get`; these jobs never benefited from the .lake GitHub cache across runs anyway, since their entries were evicted before reuse.

Known residual: the shared CI/blueprint auto-fix workflows live in `LionSR/agent-ci-actions` (`_ci-auto-fix-shared.yml`, `setup_lean: true`); if that shared workflow also defaults to saving a lake cache, it needs the same flag upstream.

## Validation

- `actionlint` clean.
- After merge: `gh api repos/LionSR/TNLean/actions/caches` should show no new `lake-*` entries appearing from mention/auto-fix runs, and `tnlean-build-*` on `refs/heads/main` staying resident.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI configuration and token choice for issue tracking only; no application code or build logic changes beyond cache persistence behavior.
> 
> **Overview**
> Stops **per-run `.lake` GitHub Actions caches** from being written on agent, auto-fix, scout, linter, blueprint, and docgen jobs by setting **`use-github-cache: false`** on `texra-ai/lean-env-action@v1` and `leanprover/lean-action@v1`. Large (~2.4 GB) entries on feature refs were evicting the small main-branch **`tnlean-build`** cache within the 10 GB repo limit; Mathlib still comes from **`lake exe cache get`**.
> 
> In **`issue-automation.yml`**, the tracking-issue **`Update tracking issues`** step no longer passes **`BOT_PAT`** and relies on the default **`GITHUB_TOKEN`**, because the PAT broke sub-issue GraphQL lookups with “Bad credentials” and tracking comments do not need to retrigger workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f8c16ebb59ef9163e7f2965f4dacbe768f33ad7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->