### PR TITLE
feat(MPS/MPDO): absorb copy-independent canonical weights

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -428,6 +428,7 @@ import TNLean.MPS.MPDO.RFPViaTSGlobal
 import TNLean.MPS.MPDO.RFPViaTSSAL
 import TNLean.MPS.MPDO.PhysicalBlocking
 import TNLean.MPS.MPDO.SimpleTensor
+import TNLean.MPS.MPDO.CommonWeightAbsorption
 import TNLean.MPS.MPDO.HorizontalBlocking
 import TNLean.MPS.MPDO.TwoSiteVerticalCanonicalForm
 import TNLean.MPS.MPDO.VerticalSectorRetractions

--- a/TNLean/MPS/MPDO/CommonWeightAbsorption.lean
+++ b/TNLean/MPS/MPDO/CommonWeightAbsorption.lean
@@ -1,0 +1,109 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.SimpleTensor
+import TNLean.MPS.SharedInfra.Scaling
+
+/-!
+# Absorbing copy-independent weights into BNT representatives
+
+After proving that the canonical-form weights do not depend on the copy
+index, arXiv:1606.00608 absorbs the common weight into each basis-of-normal-
+tensors representative. The remaining coefficient is then the natural
+multiplicity of that representative, namely its number of horizontal copies.
+
+This file records that coefficient and matrix-product-vector identity. It does
+not identify the horizontal copy multiplicity with the number of Markov
+sectors used later to construct the physical projectors.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Appendix C.2, equation CFK, lines 1660--1665, and equation sigmaNKj,
+  lines 1756--1759.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor.SectorDecomposition
+
+variable {d : ℕ}
+
+/-- The common weight $\mu_j$ of the copies of sector $j$, chosen from its
+distinguished first copy. The hypothesis ensures that this choice represents
+every copy.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1646--1665. -/
+noncomputable def commonWeight (S : SectorDecomposition d)
+    (_hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q') (j : Fin S.basisCount) : ℂ :=
+  S.weight j ⟨0, S.copies_pos j⟩
+
+/-- The representative $\mathcal K_j=\mu_j A_j$ obtained by absorbing the
+common copy weight into the $j$-th canonical-form representative.
+
+Source: arXiv:1606.00608, Appendix C.2, equation CFK, lines 1660--1665. -/
+noncomputable def commonWeightAbsorbedBasis (S : SectorDecomposition d)
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q') (j : Fin S.basisCount) :
+    MPSTensor d (S.basisDim j) :=
+  fun i => S.commonWeight hWeight j • S.basis j i
+
+/-- Every copy weight is the chosen common weight when the weights are
+copy-independent.
+
+Source: arXiv:1606.00608, Appendix C.2, the argument labelled lemmus,
+lines 1646--1658. -/
+theorem weight_eq_commonWeight (S : SectorDecomposition d)
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q') (j : Fin S.basisCount)
+    (q : Fin (S.copies j)) :
+    S.weight j q = S.commonWeight hWeight j :=
+  hWeight j q ⟨0, S.copies_pos j⟩
+
+/-- Once the copy weights over sector $j$ agree, its length-$N$ coefficient is
+the natural copy multiplicity $r_j$ times $\mu_j^N$:
+\[
+  \sum_q \mu_{j,q}^N=r_j\mu_j^N.
+\]
+
+Source: arXiv:1606.00608, Appendix C.2, equations CFK and sigmaNKj,
+lines 1660--1665 and 1756--1759. -/
+theorem coeff_eq_copies_mul_commonWeight_pow (S : SectorDecomposition d)
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q') (N : ℕ) (j : Fin S.basisCount) :
+    S.coeff N j = (S.copies j : ℂ) * (S.commonWeight hWeight j) ^ N := by
+  classical
+  simp only [SectorDecomposition.coeff, SectorWeightData.coeff]
+  simp_rw [S.weight_eq_commonWeight hWeight j]
+  simp
+
+/-- Absorbing the common weight into each representative leaves precisely its
+natural horizontal copy count as the coefficient of its matrix product
+vector:
+\[
+  \mathcal V_N(S)=\sum_j r_j\,\mathcal V_N(\mathcal K_j),
+  \qquad \mathcal K_j=\mu_j A_j.
+\]
+
+Source: arXiv:1606.00608, Appendix C.2, equation CFK, lines 1660--1665;
+the multiplicity convention is used in equation sigmaNKj, lines 1756--1759. -/
+theorem mpv_toTensor_eq_sum_copies_mul_commonWeightAbsorbedBasis
+    (S : SectorDecomposition d)
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q') {N : ℕ} (σ : Fin N → Fin d) :
+    mpv S.toTensor σ =
+      ∑ j : Fin S.basisCount,
+        (S.copies j : ℂ) * mpv (S.commonWeightAbsorbedBasis hWeight j) σ := by
+  rw [S.mpv_toTensor_eq_sum_coeff]
+  apply Finset.sum_congr rfl
+  intro j _
+  rw [S.coeff_eq_copies_mul_commonWeight_pow hWeight N j]
+  rw [show mpv (S.commonWeightAbsorbedBasis hWeight j) σ =
+      (S.commonWeight hWeight j) ^ N * mpv (S.basis j) σ by
+    exact mpv_smul (S.commonWeight hWeight j) (S.basis j) σ]
+  ring
+
+end MPSTensor.SectorDecomposition

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_case_two.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_case_two.tex
@@ -56,3 +56,75 @@
     Apply Theorem~\ref{thm:mpdo_simple_weight_copy_independent} to the
     witness supplied by the simple canonical-form predicate.
 \end{proof}
+
+\begin{definition}[Common sector weight and absorbed representative]
+    \label{def:mpdo_common_sector_weight_absorption}
+    \lean{MPSTensor.SectorDecomposition.commonWeight}
+    \lean{MPSTensor.SectorDecomposition.commonWeightAbsorbedBasis}
+    \leanok
+    \uses{def:sector_weight_data}
+    Suppose the weights over each representative do not depend on the copy
+    index. Choose the common weight $\mu_j$ from any copy over $j$ and absorb
+    it into the representative:
+    \[
+        \mathcal K_j=\mu_j A_j.
+    \]
+    This is the convention of
+    \cite[Appendix~C.2, equation~CFK, lines~1660--1665]
+      {Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{lemma}[Every copy has the common weight]
+    \label{lem:mpdo_copy_weight_eq_common_weight}
+    \lean{MPSTensor.SectorDecomposition.weight_eq_commonWeight}
+    \leanok
+    \uses{def:mpdo_common_sector_weight_absorption}
+    For every copy $q$ over $j$, one has $\mu_{j,q}=\mu_j$.
+\end{lemma}
+
+\begin{proof}\leanok
+    Compare the $q$-th copy with the distinguished copy used to define
+    $\mu_j$.
+\end{proof}
+
+\begin{theorem}[Coefficient after common-weight absorption]
+    \label{thm:mpdo_common_weight_coefficient}
+    \lean{MPSTensor.SectorDecomposition.coeff_eq_copies_mul_commonWeight_pow}
+    \leanok
+    \uses{def:mpdo_common_sector_weight_absorption,
+      def:sector_weight_data, lem:mpdo_copy_weight_eq_common_weight}
+    Let $r_j$ be the number of horizontal copies of representative $j$. Then
+    its coefficient on a chain of length $N$ is
+    \[
+        \sum_q\mu_{j,q}^{N}=r_j\mu_j^{N}.
+    \]
+    Thus the natural multiplicity is the horizontal copy count $r_j$.
+\end{theorem}
+
+\begin{proof}\leanok
+    Every term in the copy sum equals $\mu_j^N$, and there are $r_j$ terms.
+\end{proof}
+
+\begin{theorem}[Canonical form with natural multiplicities]
+    \label{thm:mpdo_common_weight_absorbed_mpv}
+    \lean{MPSTensor.SectorDecomposition.mpv_toTensor_eq_sum_copies_mul_commonWeightAbsorbedBasis}
+    \leanok
+    \uses{def:mpdo_common_sector_weight_absorption,
+      lem:paper_decomp_formula, lem:mpv_smul,
+      thm:mpdo_common_weight_coefficient}
+    After absorbing the common weight, the matrix product vector of the
+    assembled tensor is
+    \[
+        \mathcal V_N(S)=\sum_j r_j\,\mathcal V_N(\mathcal K_j).
+    \]
+    This is equation~CFK of
+    \cite[Appendix~C.2, lines~1660--1665]{Cirac2016MPDO_arXiv}; the same
+    multiplicities occur in equation~sigmaNKj of
+    \cite[Appendix~C.2, lines~1756--1759]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    Expand the assembled tensor by representatives, use
+    Theorem~\ref{thm:mpdo_common_weight_coefficient}, and absorb
+    $\mu_j^N$ into the length-$N$ matrix product vector of $A_j$.
+\end{proof}


### PR DESCRIPTION
## Summary

This change carries out the next step of Appendix C.2 after copy independence of the canonical weights:

- it chooses the common weight μ_j of the copies of representative j;
- it defines the absorbed representative 𝒦_j = μ_j A_j;
- it proves that the length-N coefficient is r_j μ_j^N;
- it proves the resulting matrix-product-vector decomposition with natural multiplicity r_j.

Here r_j is the number of horizontal canonical-form copies of representative j. It is not identified with the number of Markov summands introduced later.

The statements follow arXiv:1606.00608, Appendix C.2, equation CFK (lines 1660–1665) and the multiplicity convention in equation sigmaNKj (lines 1756–1759).

Part of #4003.

## Verification

- Lean 4.32 full build: 9,521 jobs
- focused CommonWeightAbsorption and root-module checks
- blueprint declaration check
- reader-facing prose check
- 590-page blueprint PDF rendered; the new formulas were inspected on page 496
- no new axiom, sorry, native_decide, or unsafe cast

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formalization and documentation on the MPDO simple-case track; no changes to auth, runtime, or existing proof obligations beyond a new root import.
> 
> **Overview**
> **Adds the Appendix C.2 step after copy-independent canonical weights:** pick a common per-sector weight μ_j, define absorbed representatives 𝒦_j = μ_j A_j, and show length-N coefficients and matrix-product-vector (MPV) decompositions use horizontal copy count r_j as multiplicity (arXiv:1606.00608 CFK / sigmaNKj).
> 
> New Lean module `TNLean/MPS/MPDO/CommonWeightAbsorption.lean` introduces `commonWeight`, `commonWeightAbsorbedBasis`, and proofs `weight_eq_commonWeight`, `coeff_eq_copies_mul_commonWeight_pow`, and `mpv_toTensor_eq_sum_copies_mul_commonWeightAbsorbedBasis` (built from existing `mpv_toTensor_eq_sum_coeff` and `mpv_smul`). The file explicitly does **not** equate r_j with later Markov-sector counts.
> 
> `TNLean.lean` imports the new module. Blueprint `ch21_mpdo_rfp_simple_case_two.tex` adds matching definitions, lemmas, and theorems with `\lean` links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69d400bfaa1d2d7fc4f22e8f2a9425179fb78195. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->