### PR TITLE
feat(tenkz): commutative-diagram tier — tenkzcd, \tnarrow, \tntree

### DIFF
--- a/tex/tenkz/examples/cd-pentagon.tex
+++ b/tex/tenkz/examples/cd-pentagon.tex
@@ -1,0 +1,19 @@
+\documentclass[varwidth=20cm, border=6pt]{standalone}
+\usepackage{amsmath, amssymb}
+\usepackage{tenkz}
+\begin{document}
+Tree: \tntree{(((a\,b)_x\,c)_y\,d)_e}
+
+\begin{tenkzcd}[polygon=5, radius=34mm]
+  \tntree{(((a\,b)_x\,c)_y\,d)_e} &
+  \tntree{((a\,(b\,c)_u)_y\,d)_e} &
+  \tntree{(a\,((b\,c)_u\,d)_w)_e} &
+  \tntree{(a\,(b\,(c\,d)_v)_w)_e} &
+  \tntree{((a\,b)_x\,(c\,d)_v)_e}
+  \tnarrow[from=1, to=2]{F^{abc}_y}
+  \tnarrow[from=2, to=3]{F^{a,bc,d}_e}
+  \tnarrow[from=3, to=4]{F^{bcd}_w}
+  \tnarrow*[from=1, to=5]{F^{ab,c,d}_e}
+  \tnarrow*[from=5, to=4]{F^{a,b,cd}_e}
+\end{tenkzcd}
+\end{document}

--- a/tex/tenkz/tenkz-cd.code.tex
+++ b/tex/tenkz/tenkz-cd.code.tex
@@ -1,2 +1,410 @@
-%% tenkz-cd -- placeholder; the real module lands later in this PR stack.
+% tenkz-cd — L2b: the commutative-diagram sub-language.
+%
+%   \tntree[keys]{(((a\,b)_x\,c)_y\,d)_e}
+%       a fusion tree from a parenthesization word: leaves on a top
+%       line, one junction per fused pair, internal charges on the
+%       downward edges, a short rooted leg carrying the total charge.
+%
+%   \begin{tenkzcd}[polygon=n, radius=..]
+%     cell & cell & ... \tnarrow[from=i, to=j]{label} ...
+%   \end{tenkzcd}
+%       polygon mode: n cells on a circle (vertex 1 at the top,
+%       clockwise), annotation arrows between them.  \tnarrow* puts the
+%       label on the other side of its arrow.
+%
+%   \begin{tenkzcd}[keys]  ... tikz-cd material ...  \end{tenkzcd}
+%       grid mode (no polygon key): a thin wrapper around tikz-cd; cells
+%       may hold tenkz objects (\tntree, \tnpic) since those are
+%       self-contained boxes.
+%
+% Both environments and the standalone tree are math atoms: the baseline
+% is the vertical middle of the picture lowered by the math axis, so a
+% diagram centers on the axis of the surrounding formula.
+
+\ExplSyntaxOn
+
+% ---------- tree metrics (ratios of pitch) ----------
+% Sibling pitch of the leaf row and the depth of one fusion level share
+% one ratio, so every edge of a balanced pair meets its junction at 45
+% degrees; the root leg is shorter than a level so the tree reads as
+% rooted, not as one more leaf.
+\def\tenkz@r@treestep{0.55}
+\def\tenkz@r@treeleg{0.35}
+
+% ---------- state ----------
+\seq_new:N \l__tenkzcd_items_seq     % parenthesization word, one item each
+\seq_new:N \l__tenkzcd_stack_seq     % parsed subtrees: {x}{level}{charge}
+\tl_new:N  \l__tenkzcd_word_tl
+\tl_new:N  \l__tenkzcd_item_tl
+\tl_new:N  \l__tenkzcd_charge_tl
+\tl_new:N  \l__tenkzcd_ca_tl
+\tl_new:N  \l__tenkzcd_cb_tl
+\tl_new:N  \l__tenkzcd_cha_tl
+\tl_new:N  \l__tenkzcd_chb_tl
+\tl_new:N  \l__tenkzcd_anchor_tl
+\int_new:N \l__tenkzcd_leaf_int
+\int_new:N \l__tenkzcd_la_int
+\int_new:N \l__tenkzcd_lb_int
+\int_new:N \l__tenkzcd_lp_int
+\dim_new:N \l__tenkzcd_xa_dim
+\dim_new:N \l__tenkzcd_xb_dim
+\dim_new:N \l__tenkzcd_xp_dim
+\dim_new:N \l__tenkzcd_off_dim
+\dim_new:N \l__tenkzcd_axis_dim
+% tenkzcd
+\int_new:N \l__tenkzcd_ngon_int
+\int_new:N \l__tenkzcd_i_int
+\tl_new:N  \l__tenkzcd_radius_tl
+\tl_new:N  \l__tenkzcd_pass_tl
+\dim_new:N \l__tenkzcd_r_dim
+\dim_new:N \l__tenkzcd_vx_dim
+\dim_new:N \l__tenkzcd_vy_dim
+\fp_new:N  \l__tenkzcd_angle_fp
+\seq_new:N \l__tenkzcd_cells_seq
+\seq_new:N \g__tenkzcd_arrows_seq    % {from}{to}{side keys}{label}
+\tl_new:N  \l__tenkzcd_afrom_tl
+\tl_new:N  \l__tenkzcd_ato_tl
+\tl_new:N  \l__tenkzcd_body_tl
+
+% ---------- keys ----------
+\pgfkeys{
+  /tenkz/cd/.is~family,
+  /tenkz/cd/polygon/.code={\int_set:Nn \l__tenkzcd_ngon_int {#1}},
+  /tenkz/cd/radius/.store~in=\l__tenkzcd_radius_tl,
+  /tenkz/cd/pitch/.code={\pgfkeys{/tenkz/pitch=#1}},
+  /tenkz/cd/compact/.code={\pgfkeys{/tenkz/compact}},
+  /tenkz/cd/inline/.code={\pgfkeys{/tenkz/inline}},
+  % the shared forward-to-core plumbing: the glyph policy reads the same
+  % in every family, so \tnpic cells inside a cd picture obey it
+  /tenkz/cd/tensor~style/.code={\pgfqkeys{/tenkz}{tensor~style=#1}},
+  % unrecognized keys pass through to the underlying picture
+  /tenkz/cd/.unknown/.code={
+    \tl_if_eq:NNTF \pgfkeyscurrentvalue \pgfkeysnovalue@text
+      { \tl_put_right:Ne \l__tenkzcd_pass_tl
+          { \exp_not:o \pgfkeyscurrentname , } }
+      { \tl_put_right:Ne \l__tenkzcd_pass_tl
+          { \exp_not:o \pgfkeyscurrentname =
+            \exp_not:o \pgfkeyscurrentvalue , } }
+  },
+}
+\pgfkeys{
+  /tenkz/arrow/.is~family,
+  /tenkz/arrow/from/.store~in=\l__tenkzcd_afrom_tl,
+  /tenkz/arrow/to/.store~in=\l__tenkzcd_ato_tl,
+}
+
+% ---------- the fusion tree ----------
+% Grammar of the parenthesization word:
+%   node   :=  leaf  |  ( node node ) [ _ charge ]
+%   leaf, charge  :=  one character or one braced group
+% Separators (\, and spaces) are stripped before parsing.  The word is
+% flattened into a sequence of items and consumed left to right by a
+% recursive-descent parser; every finished subtree pushes its root
+% {x}{level}{charge} onto a value stack, so a fused pair pops its two
+% children, joins them, and pushes the joint.
+%
+% Layout: leaves sit on the line y = 0, spaced by one tree step; an
+% internal vertex sits at the x-midpoint of its children's roots, one
+% level below the deeper child (level = 1 + max of the child levels,
+% y = -level steps).  Charges are typeset only when the vertex's
+% downward edge is known, so they can be set clear of the ink.
+
+% y-coordinate of a fusion level (integer factor on the right)
+\cs_new:Npn \tenkz_cd_levely:n #1
+  { \dim_eval:n { -\tenkz@r@treestep\tenkz@pitch * (#1) } }
+
+% ---------- picture framing ----------
+% Every cd picture is a math atom sharing one baseline.  Read the axis
+% height (NFSS sets math fonts up lazily, so force them first), then lower
+% the picture's bounding-box centre by it so the diagram centres on the
+% surrounding formula's axis.
+\cs_new_protected:Npn \tenkz_cd_read_axis:
+  { \check@mathfonts
+    \dim_set:Nn \l__tenkzcd_axis_dim { \fontdimen22\textfont2 } }
+\tikzset{
+  tenkz~cd~baseline/.style={
+    baseline={([yshift=-\dim_use:N \l__tenkzcd_axis_dim]
+               current~bounding~box.center)} } }
+
+\cs_new_protected:Npn \tenkz_cd_tree_node:
+  {
+    \seq_pop_left:NNTF \l__tenkzcd_items_seq \l__tenkzcd_item_tl
+      {
+        \str_if_eq:VnTF \l__tenkzcd_item_tl { ( }
+          { \tenkz_cd_tree_internal: }
+          { \tenkz_cd_tree_leaf: }
+      }
+      { \PackageError{tenkz}{Malformed~tree:~unexpected~end~of~word}{} }
+  }
+
+% a leaf: a wire endpoint on the top line, its label above the tip
+\cs_new_protected:Npn \tenkz_cd_tree_leaf:
+  {
+    \dim_set:Nn \l__tenkzcd_xa_dim
+      { \tenkz@r@treestep\tenkz@pitch * \l__tenkzcd_leaf_int }
+    \int_incr:N \l__tenkzcd_leaf_int
+    \node[label, anchor=south] at
+      (\dim_use:N \l__tenkzcd_xa_dim, \tenkz@dim{\tenkz@r@labelclear})
+      { $\tenkz@labelsize \tl_use:N \l__tenkzcd_item_tl$ };
+    \seq_put_right:Ne \l__tenkzcd_stack_seq
+      { { \dim_use:N \l__tenkzcd_xa_dim }{ 0 }{ } }
+  }
+
+% ( node node ) [_ charge]
+\cs_new_protected:Npn \tenkz_cd_tree_internal:
+  {
+    \tenkz_cd_tree_node:
+    \tenkz_cd_tree_node:
+    % the closing parenthesis
+    \seq_pop_left:NNTF \l__tenkzcd_items_seq \l__tenkzcd_item_tl
+      {
+        \str_if_eq:VnF \l__tenkzcd_item_tl { ) }
+          { \PackageError{tenkz}
+              {Malformed~tree:~expected~a~closing~parenthesis}{} }
+      }
+      { \PackageError{tenkz}{Malformed~tree:~unexpected~end~of~word}{} }
+    % the optional charge (parsed after the recursion, so the local
+    % charge register belongs to this vertex).  Peek at the next item: a
+    % leading `_` consumes the charge; anything else is the next node and
+    % is left in place for the parser to pick up.
+    \tl_clear:N \l__tenkzcd_charge_tl
+    \seq_get_left:NNT \l__tenkzcd_items_seq \l__tenkzcd_item_tl
+      {
+        \str_if_eq:VnT \l__tenkzcd_item_tl { _ }
+          {
+            \seq_pop_left:NN \l__tenkzcd_items_seq \l__tenkzcd_item_tl
+            \seq_pop_left:NNF \l__tenkzcd_items_seq \l__tenkzcd_charge_tl
+              { \PackageError{tenkz}{Malformed~tree:~dangling~charge}{} }
+          }
+      }
+    % pop the two children and fuse them
+    \seq_pop_right:NN \l__tenkzcd_stack_seq \l__tenkzcd_cb_tl
+    \seq_pop_right:NN \l__tenkzcd_stack_seq \l__tenkzcd_ca_tl
+    \exp_last_unbraced:NV \tenkz_cd_unpack_a:nnn \l__tenkzcd_ca_tl
+    \exp_last_unbraced:NV \tenkz_cd_unpack_b:nnn \l__tenkzcd_cb_tl
+    \tenkz_cd_tree_fuse:
+  }
+
+\cs_new_protected:Npn \tenkz_cd_unpack_a:nnn #1#2#3
+  {
+    \dim_set:Nn \l__tenkzcd_xa_dim {#1}
+    \int_set:Nn \l__tenkzcd_la_int {#2}
+    \tl_set:Nn  \l__tenkzcd_cha_tl {#3}
+  }
+\cs_new_protected:Npn \tenkz_cd_unpack_b:nnn #1#2#3
+  {
+    \dim_set:Nn \l__tenkzcd_xb_dim {#1}
+    \int_set:Nn \l__tenkzcd_lb_int {#2}
+    \tl_set:Nn  \l__tenkzcd_chb_tl {#3}
+  }
+
+% one child edge: from (x register #1, level #2) up to the shared junction
+% at (xp, lp), which the caller has already set
+\cs_new_protected:Npn \tenkz_cd_childedge:Nn #1#2
+  {
+    \draw[bond]
+      (\dim_use:N #1, \tenkz_cd_levely:n {#2}) --
+      (\dim_use:N \l__tenkzcd_xp_dim, \tenkz_cd_levely:n {\l__tenkzcd_lp_int});
+  }
+
+% join the two children on the stack: edges, junction dot, the
+% children's charges (their downward edges are now known), push the
+% joint carrying this vertex's own charge
+\cs_new_protected:Npn \tenkz_cd_tree_fuse:
+  {
+    \int_set:Nn \l__tenkzcd_lp_int
+      { 1 + \int_max:nn { \l__tenkzcd_la_int } { \l__tenkzcd_lb_int } }
+    \dim_set:Nn \l__tenkzcd_xp_dim
+      { ( \l__tenkzcd_xa_dim + \l__tenkzcd_xb_dim ) / 2 }
+    \tenkz_cd_childedge:Nn \l__tenkzcd_xa_dim {\l__tenkzcd_la_int}
+    \tenkz_cd_childedge:Nn \l__tenkzcd_xb_dim {\l__tenkzcd_lb_int}
+    \node[tree~junction] at
+      (\dim_use:N \l__tenkzcd_xp_dim,
+       \tenkz_cd_levely:n {\l__tenkzcd_lp_int}) {};
+    \tl_if_blank:VF \l__tenkzcd_cha_tl
+      { \tenkz_cd_edge_charge:NnN \l__tenkzcd_xa_dim
+          {\l__tenkzcd_la_int} \l__tenkzcd_cha_tl }
+    \tl_if_blank:VF \l__tenkzcd_chb_tl
+      { \tenkz_cd_edge_charge:NnN \l__tenkzcd_xb_dim
+          {\l__tenkzcd_lb_int} \l__tenkzcd_chb_tl }
+    \seq_put_right:Ne \l__tenkzcd_stack_seq
+      { { \dim_use:N \l__tenkzcd_xp_dim }{ \int_use:N \l__tenkzcd_lp_int }
+        { \exp_not:V \l__tenkzcd_charge_tl } }
+  }
+
+% A charge labels its vertex's downward edge, half a fusion level below
+% the vertex, on the side of the edge away from the parent.  Both child
+% edges of the vertex lie above it and every other edge lies beyond the
+% downward edge on the parent's side, so that quadrant is ink-free by
+% construction.  #1 = x register of the vertex, #2 = its level, #3 =
+% charge register; the parent's x register is still live.
+\cs_new_protected:Npn \tenkz_cd_edge_charge:NnN #1#2#3
+  {
+    % rightward-descending edge (xp right of the vertex): label the free
+    % LEFT side, anchor east, clearance subtracted; leftward or straight:
+    % label the RIGHT side, anchor west, clearance added
+    \dim_compare:nNnTF { \l__tenkzcd_xp_dim } > { #1 }
+      { \tl_set:Nn \l__tenkzcd_anchor_tl {east}
+        \dim_set:Nn \l__tenkzcd_off_dim { -\tenkz@dim{\tenkz@r@labelclear} } }
+      { \tl_set:Nn \l__tenkzcd_anchor_tl {west}
+        \dim_set:Nn \l__tenkzcd_off_dim { \tenkz@dim{\tenkz@r@labelclear} } }
+    \node[label, anchor=\l__tenkzcd_anchor_tl] at
+      (\dim_eval:n{ #1 + \l__tenkzcd_off_dim },
+       \dim_eval:n{ \tenkz_cd_levely:n {#2}
+                    - \tenkz@r@treestep\tenkz@pitch / 2 })
+      { $\tenkz@labelsize \tl_use:N #3$ };
+  }
+
+% the root: a short downward leg; the total charge sits right of the
+% leg's midpoint
+\cs_new_protected:Npn \tenkz_cd_tree_root:nnn #1#2#3
+  {
+    \draw[bond]
+      (#1, \tenkz_cd_levely:n {#2}) --
+      (#1, \dim_eval:n{ \tenkz_cd_levely:n {#2}
+                        - \tenkz@r@treeleg\tenkz@pitch });
+    \tl_if_blank:nF {#3}
+      {
+        \node[label, anchor=west] at
+          (\dim_eval:n{ #1 + \tenkz@dim{\tenkz@r@labelclear} },
+           \dim_eval:n{ \tenkz_cd_levely:n {#2}
+                        - \tenkz@r@treeleg\tenkz@pitch / 2 })
+          { $\tenkz@labelsize #3$ };
+      }
+  }
+
+\NewDocumentCommand \tntree { O{} m }
+  { \tenkz_cd_tree:nn {#1} {#2} }
+
+\cs_new_protected:Npn \tenkz_cd_tree:nn #1#2
+  {
+    \group_begin:
+    \tl_if_empty:nF {#1} { \pgfqkeys{/tenkz}{#1} }
+    % \, and spaces are separators, not syntax; flatten to items
+    % (spaces never form items, so only \, needs stripping)
+    \tl_set:Nn \l__tenkzcd_word_tl {#2}
+    \tl_remove_all:Nn \l__tenkzcd_word_tl { \, }
+    \seq_clear:N \l__tenkzcd_items_seq
+    \tl_map_inline:Nn \l__tenkzcd_word_tl
+      { \seq_put_right:Nn \l__tenkzcd_items_seq {##1} }
+    \seq_clear:N \l__tenkzcd_stack_seq
+    \int_zero:N \l__tenkzcd_leaf_int
+    \tenkz_cd_read_axis:
+    \begin{tikzpicture}[ tenkz~every~picture, tenkz~cd~baseline ]
+      \tenkz_cd_tree_node:
+      \seq_pop_right:NNT \l__tenkzcd_stack_seq \l__tenkzcd_ca_tl
+        { \exp_last_unbraced:NV \tenkz_cd_tree_root:nnn \l__tenkzcd_ca_tl }
+      % inside the picture group, where the leaf count is still live
+      \tenkz@event{tree|picture=\the\tenkz@pictureid|leaves=\int_use:N \l__tenkzcd_leaf_int}
+    \end{tikzpicture}
+    \group_end:
+  }
+
+% ---------- annotation arrows ----------
+% \tnarrow[from=i, to=j]{label} records an arrow; the polygon renderer
+% draws all recorded arrows once every vertex exists.  The star form
+% swaps the label to the other side.  Recording is global because the
+% commands sit inside a cell's box.
+\NewDocumentCommand \tnarrow { s O{} m }
+  {
+    \unskip
+    \group_begin:
+    \tl_clear:N \l__tenkzcd_afrom_tl
+    \tl_clear:N \l__tenkzcd_ato_tl
+    \tl_if_empty:nF {#2} { \pgfqkeys{/tenkz/arrow}{#2} }
+    \seq_gput_right:Ne \g__tenkzcd_arrows_seq
+      { { \tl_use:N \l__tenkzcd_afrom_tl }{ \tl_use:N \l__tenkzcd_ato_tl }
+        { auto \IfBooleanT {#1} { , swap } }{ \exp_not:n {#3} } }
+    \group_end:
+    \ignorespaces
+  }
+
+\cs_new_protected:Npn \tenkz_cd_draw_arrow:nnnn #1#2#3#4
+  {
+    % the label's inner sep sets its gap from the shaft; the house 1pt
+    % is too tight for sub/superscripted names
+    \draw[cd~arrow] (v#1) --
+      node[label, inner~sep=2.5pt, #3] { $\tenkz@labelsize #4$ } (v#2);
+    \tenkz@event{cdarrow|picture=\the\tenkz@pictureid|from=#1|to=#2}
+  }
+
+% ---------- the environment ----------
+\NewDocumentEnvironment { tenkzcd } { O{} +b }
+  { \tenkz_cd_render:nn {#1} {#2} } { }
+
+\cs_new_protected:Npn \tenkz_cd_render:nn #1#2
+  {
+    \group_begin:
+    \int_zero:N \l__tenkzcd_ngon_int
+    \tl_set:Nn \l__tenkzcd_radius_tl {30mm}
+    \tl_clear:N \l__tenkzcd_pass_tl
+    \tl_if_empty:nF {#1} { \pgfqkeys{/tenkz/cd}{#1} }
+    \seq_gclear:N \g__tenkzcd_arrows_seq
+    \tenkz@beginpicture{cd}
+    \tenkz_cd_read_axis:
+    \int_compare:nNnTF { \l__tenkzcd_ngon_int } > {0}
+      { \exp_args:NV \tenkz_cd_polygon:nn \l__tenkzcd_pass_tl {#2} }
+      { \exp_args:NV \tenkz_cd_grid:nn    \l__tenkzcd_pass_tl {#2} }
+    \group_end:
+  }
+
+% polygon mode: cell i on the circle at 90 - (i-1) 360/n degrees.  Cells
+% render on the compact profile so a default-radius polygon of trees
+% leaves room for the arrows; a cell overrides via its own keys.
+\cs_new_protected:Npn \tenkz_cd_polygon:nn #1#2
+  {
+    \dim_set:Nn \l__tenkzcd_r_dim { \l__tenkzcd_radius_tl }
+    \seq_set_split:Nnn \l__tenkzcd_cells_seq { & } {#2}
+    \begin{tikzpicture}[ tenkz~every~picture, tenkz~cd~baseline, #1 ]
+      \int_zero:N \l__tenkzcd_i_int
+      \seq_map_inline:Nn \l__tenkzcd_cells_seq
+        {
+          \int_incr:N \l__tenkzcd_i_int
+          % vertex angle: 1 at the top (90 degrees), then clockwise
+          \fp_set:Nn \l__tenkzcd_angle_fp
+            { 90 - 360 * ( \l__tenkzcd_i_int - 1 ) / \l__tenkzcd_ngon_int }
+          \dim_set:Nn \l__tenkzcd_vx_dim
+            { \fp_to_decimal:n { cosd( \l__tenkzcd_angle_fp ) } \l__tenkzcd_r_dim }
+          \dim_set:Nn \l__tenkzcd_vy_dim
+            { \fp_to_decimal:n { sind( \l__tenkzcd_angle_fp ) } \l__tenkzcd_r_dim }
+          \node[inner~sep=3pt] (v\int_use:N \l__tenkzcd_i_int) at
+            (\dim_use:N \l__tenkzcd_vx_dim, \dim_use:N \l__tenkzcd_vy_dim)
+            { \pgfkeys{/tenkz/compact} ##1 };
+          \tenkz@event{cdcell|picture=\the\tenkz@pictureid|index=\int_use:N \l__tenkzcd_i_int}
+        }
+      \seq_map_inline:Nn \g__tenkzcd_arrows_seq
+        { \tenkz_cd_draw_arrow:nnnn ##1 }
+    \end{tikzpicture}
+  }
+
+% Grid mode is a thin wrapper around tikz-cd: cells hold tenkz objects
+% or mathematics, arrows use tikz-cd's own \arrow syntax.  The house
+% annotation line width is applied to every arrow; arrow tips stay
+% tikz-cd's defaults (restyling the computed tip is not worth the
+% coupling in Phase 0).
+%
+% The body reaches us already tokenized, so pgfmatrix's catcode trick
+% for & never fires; every & is rewritten to the cell separator it
+% would have become.  (Consequence: a raw & nested inside a cell needs
+% its own guard, e.g. a group with ampersand replacement.)
+\cs_new_protected:Npn \tenkz_cd_grid:nn #1#2
+  {
+    \tl_set:Nn \l__tenkzcd_body_tl {#2}
+    \tl_replace_all:Nnn \l__tenkzcd_body_tl { & } { \pgfmatrixnextcell }
+    \tikzcdset{ every~arrow/.append~style =
+                  { line~width = \tenkz@annwidth } }
+    \exp_args:NnV \tenkz_cd_grid_aux:nn {#1} \l__tenkzcd_body_tl
+  }
+\cs_new_protected:Npn \tenkz_cd_grid_aux:nn #1#2
+  {
+    % same baseline convention as the `tenkz cd baseline` style, inlined
+    % because tikzcd routes its options through its own key family
+    \begin{tikzcd}
+      [ baseline={([yshift=-\dim_use:N \l__tenkzcd_axis_dim]
+                   current~bounding~box.center)}, #1 ]
+      #2
+    \end{tikzcd}
+  }
+
+\ExplSyntaxOff
 \endinput

--- a/tex/tenkz/tenkz-cd.code.tex
+++ b/tex/tenkz/tenkz-cd.code.tex
@@ -62,6 +62,7 @@
 \fp_new:N  \l__tenkzcd_angle_fp
 \seq_new:N \l__tenkzcd_cells_seq
 \seq_new:N \g__tenkzcd_arrows_seq    % {from}{to}{side keys}{label}
+\bool_new:N \g__tenkzcd_inpoly_bool  % a polygon body is being typeset
 \tl_new:N  \l__tenkzcd_afrom_tl
 \tl_new:N  \l__tenkzcd_ato_tl
 \tl_new:N  \l__tenkzcd_body_tl
@@ -137,13 +138,24 @@
       { \PackageError{tenkz}{Malformed~tree:~unexpected~end~of~word}{} }
   }
 
-% a leaf: a wire endpoint on the top line, its label above the tip
+% a leaf: a wire endpoint on the top line, its label above the tip.
+% Grammar guard: `_` and `)` can only reach the leaf position through a
+% malformed word -- `(a_u\,b)_x` tries to charge a leaf (the grammar
+% attaches charges to fused pairs only), `(a)` fuses a single node --
+% and typesetting them as leaves dies later with a raw TeX error, so
+% both stop here with the grammar rule spelled out.
 \cs_new_protected:Npn \tenkz_cd_tree_leaf:
   {
+    \str_if_eq:VnT \l__tenkzcd_item_tl { _ }
+      { \PackageError{tenkz}{Malformed~tree:~a~charge~(_)~may~only~
+          follow~a~fused~pair's~closing~parenthesis}{} }
+    \str_if_eq:VnT \l__tenkzcd_item_tl { ) }
+      { \PackageError{tenkz}{Malformed~tree:~unexpected~')'~--~a~fused~
+          pair~takes~exactly~two~nodes}{} }
     \dim_set:Nn \l__tenkzcd_xa_dim
       { \tenkz@r@treestep\tenkz@pitch * \l__tenkzcd_leaf_int }
     \int_incr:N \l__tenkzcd_leaf_int
-    \node[label, anchor=south] at
+    \node[tn~label, anchor=south] at
       (\dim_use:N \l__tenkzcd_xa_dim, \tenkz@dim{\tenkz@r@labelclear})
       { $\tenkz@labelsize \tl_use:N \l__tenkzcd_item_tl$ };
     \seq_put_right:Ne \l__tenkzcd_stack_seq
@@ -248,7 +260,7 @@
         \dim_set:Nn \l__tenkzcd_off_dim { -\tenkz@dim{\tenkz@r@labelclear} } }
       { \tl_set:Nn \l__tenkzcd_anchor_tl {west}
         \dim_set:Nn \l__tenkzcd_off_dim { \tenkz@dim{\tenkz@r@labelclear} } }
-    \node[label, anchor=\l__tenkzcd_anchor_tl] at
+    \node[tn~label, anchor=\l__tenkzcd_anchor_tl] at
       (\dim_eval:n{ #1 + \l__tenkzcd_off_dim },
        \dim_eval:n{ \tenkz_cd_levely:n {#2}
                     - \tenkz@r@treestep\tenkz@pitch / 2 })
@@ -265,7 +277,7 @@
                         - \tenkz@r@treeleg\tenkz@pitch });
     \tl_if_blank:nF {#3}
       {
-        \node[label, anchor=west] at
+        \node[tn~label, anchor=west] at
           (\dim_eval:n{ #1 + \tenkz@dim{\tenkz@r@labelclear} },
            \dim_eval:n{ \tenkz_cd_levely:n {#2}
                         - \tenkz@r@treeleg\tenkz@pitch / 2 })
@@ -292,6 +304,12 @@
     \tenkz_cd_read_axis:
     \begin{tikzpicture}[ tenkz~every~picture, tenkz~cd~baseline ]
       \tenkz_cd_tree_node:
+      % exactly one tree per word: leftover items after the root parse
+      % would otherwise vanish, rendering a plausible tree of the WRONG
+      % parenthesization word (`a\,b` would draw the one-leaf tree `a`)
+      \seq_if_empty:NF \l__tenkzcd_items_seq
+        { \PackageError{tenkz}{Malformed~tree:~trailing~material~after~
+            the~root~--~a~word~denotes~exactly~one~tree}{} }
       \seq_pop_right:NNT \l__tenkzcd_stack_seq \l__tenkzcd_ca_tl
         { \exp_last_unbraced:NV \tenkz_cd_tree_root:nnn \l__tenkzcd_ca_tl }
       % inside the picture group, where the leaf count is still live
@@ -308,24 +326,62 @@
 \NewDocumentCommand \tnarrow { s O{} m }
   {
     \unskip
-    \group_begin:
-    \tl_clear:N \l__tenkzcd_afrom_tl
-    \tl_clear:N \l__tenkzcd_ato_tl
-    \tl_if_empty:nF {#2} { \pgfqkeys{/tenkz/arrow}{#2} }
-    \seq_gput_right:Ne \g__tenkzcd_arrows_seq
-      { { \tl_use:N \l__tenkzcd_afrom_tl }{ \tl_use:N \l__tenkzcd_ato_tl }
-        { auto \IfBooleanT {#1} { , swap } }{ \exp_not:n {#3} } }
-    \group_end:
+    % polygon-body syntax only: in grid mode the natural mixed-dialect
+    % mistake (tikz-cd's \arrow vs polygon's \tnarrow) used to record an
+    % arrow nothing ever drained -- a silent no-op -- and in running
+    % prose there are no vertices at all.  Both now stop here.
+    \bool_if:NTF \g__tenkzcd_inpoly_bool
+      {
+        \group_begin:
+        \tl_clear:N \l__tenkzcd_afrom_tl
+        \tl_clear:N \l__tenkzcd_ato_tl
+        \tl_if_empty:nF {#2} { \pgfqkeys{/tenkz/arrow}{#2} }
+        \seq_gput_right:Ne \g__tenkzcd_arrows_seq
+          { { \tl_use:N \l__tenkzcd_afrom_tl }{ \tl_use:N \l__tenkzcd_ato_tl }
+            { auto \IfBooleanT {#1} { , swap } }{ \exp_not:n {#3} } }
+        \group_end:
+      }
+      {
+        \PackageError{tenkz}{\string\tnarrow\space outside~a~polygon~
+          body:~it~draws~between~polygon~vertices.~Grid~mode~takes~
+          tikz-cd's~\string\arrow;~prose~has~no~vertices}{}
+      }
     \ignorespaces
   }
 
+% one endpoint check: nonempty, an integer, within 1..n -- the raw
+% pgf alternative is `No shape named 'v7'', which names neither
+% \tnarrow nor the polygon order.  A failed check clears the OK flag so
+% the arrow is not drawn (drawing it would just re-error in pgf).
+\bool_new:N \l__tenkzcd_aok_bool
+\cs_new_protected:Npn \tenkz_cd_arrow_endpoint:nn #1#2
+  {
+    \regex_match:nnTF { \A \d+ \Z } {#2}
+      {
+        \bool_lazy_and:nnF
+          { \int_compare_p:nNn {#2} > {0} }
+          { \int_compare_p:nNn {#2} < { \l__tenkzcd_ngon_int + 1 } }
+          { \bool_set_false:N \l__tenkzcd_aok_bool
+            \PackageError{tenkz}{\string\tnarrow\space #1=#2~is~outside~
+              this~polygon's~vertices~1..\int_use:N \l__tenkzcd_ngon_int}{} }
+      }
+      { \bool_set_false:N \l__tenkzcd_aok_bool
+        \PackageError{tenkz}{\string\tnarrow\space needs~#1=,~a~cell~
+          index~1..\int_use:N \l__tenkzcd_ngon_int\space (got~'#2')}{} }
+  }
 \cs_new_protected:Npn \tenkz_cd_draw_arrow:nnnn #1#2#3#4
   {
-    % the label's inner sep sets its gap from the shaft; the house 1pt
-    % is too tight for sub/superscripted names
-    \draw[cd~arrow] (v#1) --
-      node[label, inner~sep=2.5pt, #3] { $\tenkz@labelsize #4$ } (v#2);
-    \tenkz@event{cdarrow|picture=\the\tenkz@pictureid|from=#1|to=#2}
+    \bool_set_true:N \l__tenkzcd_aok_bool
+    \tenkz_cd_arrow_endpoint:nn {from} {#1}
+    \tenkz_cd_arrow_endpoint:nn {to} {#2}
+    \bool_if:NT \l__tenkzcd_aok_bool
+      {
+        % the label's inner sep sets its gap from the shaft; the house
+        % 1pt is too tight for sub/superscripted names
+        \draw[cd~arrow] (v#1) --
+          node[tn~label, inner~sep=2.5pt, #3] { $\tenkz@labelsize #4$ } (v#2);
+        \tenkz@event{cdarrow|picture=\the\tenkz@pictureid|from=#1|to=#2}
+      }
   }
 
 % ---------- the environment ----------
@@ -350,11 +406,15 @@
 
 % polygon mode: cell i on the circle at 90 - (i-1) 360/n degrees.  Cells
 % render on the compact profile so a default-radius polygon of trees
-% leaves room for the arrows; a cell overrides via its own keys.
+% leaves room for the arrows; a cell overrides via its own keys.  The
+% profile is a scale on the picture's BASE pitch, so an env-level
+% pitch= flows into every cell (compact of the stated base) instead of
+% being discarded; radius= stays the independent layout knob.
 \cs_new_protected:Npn \tenkz_cd_polygon:nn #1#2
   {
     \dim_set:Nn \l__tenkzcd_r_dim { \l__tenkzcd_radius_tl }
     \seq_set_split:Nnn \l__tenkzcd_cells_seq { & } {#2}
+    \bool_gset_true:N \g__tenkzcd_inpoly_bool
     \begin{tikzpicture}[ tenkz~every~picture, tenkz~cd~baseline, #1 ]
       \int_zero:N \l__tenkzcd_i_int
       \seq_map_inline:Nn \l__tenkzcd_cells_seq
@@ -372,9 +432,17 @@
             { \pgfkeys{/tenkz/compact} ##1 };
           \tenkz@event{cdcell|picture=\the\tenkz@pictureid|index=\int_use:N \l__tenkzcd_i_int}
         }
+      % polygon=n places exactly n cells: cell n+1's angle is vertex 1's
+      % angle minus a full turn, so it would silently OVERPRINT cell 1
+      \int_compare:nNnT { \l__tenkzcd_i_int } > { \l__tenkzcd_ngon_int }
+        { \PackageError{tenkz}{polygon=\int_use:N \l__tenkzcd_ngon_int\space
+            places~\int_use:N \l__tenkzcd_ngon_int\space cells,~but~this~
+            body~has~\int_use:N \l__tenkzcd_i_int\space --~cell~
+            \int_eval:n { \l__tenkzcd_ngon_int + 1 }\space overprints~cell~1}{} }
       \seq_map_inline:Nn \g__tenkzcd_arrows_seq
         { \tenkz_cd_draw_arrow:nnnn ##1 }
     \end{tikzpicture}
+    \bool_gset_false:N \g__tenkzcd_inpoly_bool
   }
 
 % Grid mode is a thin wrapper around tikz-cd: cells hold tenkz objects
@@ -393,6 +461,13 @@
     \tl_replace_all:Nnn \l__tenkzcd_body_tl { & } { \pgfmatrixnextcell }
     \tikzcdset{ every~arrow/.append~style =
                   { line~width = \tenkz@annwidth } }
+    % tikz-cd's `1-row diagram' .try style resets the baseline to the
+    % matrix BASE at matrix end, silently overriding the math-atom
+    % baseline passed below for the most common inline body (one row).
+    % Neutralize it inside this group so every grid diagram, one-row
+    % included, centres on the surrounding formula's axis like \tntree
+    % and the polygon pictures do.
+    \tikzcdset{ 1-row~diagram/.style = {} }
     \exp_args:NnV \tenkz_cd_grid_aux:nn {#1} \l__tenkzcd_body_tl
   }
 \cs_new_protected:Npn \tenkz_cd_grid_aux:nn #1#2


### PR DESCRIPTION
Stack 04 (on 03-free). Pentagon equations and F-moves leave the contraction grammar: \tntree builds fusion trees from parenthesization words with internal charges ((((a\,b)_x\,c)_y\,d)_e); polygon mode places diagram-valued objects on a regular n-gon with 0.40pt annotation arrows (visually distinct from 0.55pt wires); grid mode wraps tikz-cd. Includes the B5 pentagon example, verified visually over multiple render cycles.

https://claude.ai/code/session_01Rpby2DabUL1mbsMkFadv1q

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New LaTeX/TikZ surface area in an isolated module plus an example; no auth, data, or runtime infrastructure changes.
> 
> **Overview**
> Replaces the **tenkz-cd** placeholder with the full commutative-diagram layer: **`\tntree`** parses parenthesization words into fusion trees (leaves, junctions, `_` charges, root leg), with strict grammar errors and math-axis baseline alignment.
> 
> **`\begin{tenkzcd}`** branches on **`polygon=`**: polygon mode lays `&`-separated cells on a circle (default compact trees), records **`\tnarrow` / `\tnarrow*`** between vertex indices, and draws **`cd~arrow`** labels; grid mode wraps **tikz-cd** (ampersand rewrite, house annotation width, baseline fix for one-row diagrams). **`\tnarrow`** outside polygon bodies now errors instead of silently no-oping.
> 
> Adds **`examples/cd-pentagon.tex`**: a pentagon of five parenthesizations linked by F-move labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cdaef488337407987fd15dfdfbd6267b1c30e65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->