### PR TITLE
feat(MPS/MPDO): collapse three-site family contractions

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -429,6 +429,7 @@ import TNLean.MPS.MPDO.RFPViaTSSAL
 import TNLean.MPS.MPDO.PhysicalBlocking
 import TNLean.MPS.MPDO.SimpleTensor
 import TNLean.MPS.MPDO.CommonWeightAbsorption
+import TNLean.MPS.MPDO.BNTThreeSiteCollapse
 import TNLean.MPS.MPDO.HorizontalBlocking
 import TNLean.MPS.MPDO.TwoSiteVerticalCanonicalForm
 import TNLean.MPS.MPDO.VerticalSectorRetractions

--- a/TNLean/MPS/MPDO/BNTThreeSiteCollapse.lean
+++ b/TNLean/MPS/MPDO/BNTThreeSiteCollapse.lean
@@ -74,8 +74,11 @@ def IsThreeSiteFamilyClosure
 /-- Contract a tripartite operator with inverse tensors at its first and third
 sites, leaving a matrix on the middle physical space.
 
-Source: arXiv:1606.00608, Appendix C.2, equation `Qketc2`, lines
-1719--1725. -/
+This is the sector-family form of the outer-site contraction in the Case I
+calculation at lines 1415--1438.  The same construction is used with sector
+projectors in equation `Qketc2`, lines 1719--1725.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1415--1438 and 1719--1725. -/
 def outerInverseContraction
     (C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ)
     (ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ)

--- a/TNLean/MPS/MPDO/BNTThreeSiteCollapse.lean
+++ b/TNLean/MPS/MPDO/BNTThreeSiteCollapse.lean
@@ -23,13 +23,14 @@ inverse-map contraction proved in
 `MPOTensor.inverseMap_threeSite_closure_collapse`.  The present statements
 retain a finite family of basis-of-normal-tensors sectors and use one inverse
 which selects the sector together with the two virtual indices.
+They use `MPSTensor.IsMPOBlockLeftInverse`, defined in
+`BiCFDerivation.Core`, to characterize a coefficient matrix that simultaneously
+inverts every sector of the family.
 
 ## Main definitions
 
 * `MPOTensor.IsThreeSiteFamilyClosure`: a sum of three-site closures over a
   family of sectors.
-* `MPSTensor.IsMPOBlockLeftInverse`: a physical tensor selecting a sector and
-  a virtual matrix unit.
 
 ## Main statements
 
@@ -43,7 +44,7 @@ which selects the sector together with the two virtual indices.
 ## References
 
 * Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
-  Appendix C.2, lines 1666--1676 and 1719--1732.
+  Appendix C.2, lines 1415--1438, 1666--1676, and 1719--1732.
 -/
 
 open scoped Matrix BigOperators
@@ -95,10 +96,17 @@ entry has indices $(\beta_3,\alpha_1)$.
 
 **Local fix (tail index):** the closing entry is
 $R_s(\beta_3,\alpha_1)$, as forced by the matrix-unit trace identity.  This is
-the corrected orientation of the analogous source display, recorded in
+the corrected orientation of the single-sector display at lines 1422--1438,
+recorded in
 `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
 
-Source: arXiv:1606.00608, Appendix C.2, lines 1666--1676 and 1719--1732. -/
+This is the sector-family form of the Case I contraction at lines 1415--1438,
+used with the basis-of-normal-tensors inverse from lines 1666--1676 in the
+Case II calculation at lines 1719--1732.  Compare the single-sector identity
+`MPOTensor.inverseMapThreeSiteContraction_eq`.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1415--1438, 1666--1676,
+and 1719--1732. -/
 theorem isMPOBlockLeftInverse_outer_inverse_threeSite_collapse
     {K : (s : Fin g) → MPOTensor d (dim s)}
     {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
@@ -217,7 +225,12 @@ middle slice and closing entry.
 $R_s(\beta_3,\alpha_1)$ documented in
 `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
 
-Source: arXiv:1606.00608, Appendix C.2, lines 1666--1676 and 1719--1732. -/
+The corrected orientation comes from the Case I display at lines 1422--1438;
+the family inverse is constructed at lines 1666--1676 and used in Case II at
+lines 1719--1732.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1422--1438, 1666--1676,
+and 1719--1732. -/
 theorem exists_isMPOBlockLeftInverse_outer_inverse_threeSite_collapse
     (K : (s : Fin g) → MPOTensor d (dim s))
     (hSpan : MPSTensor.WordTupleSpanTop (fun s ↦ (K s).toMPSTensor) 1) :

--- a/TNLean/MPS/MPDO/BNTThreeSiteCollapse.lean
+++ b/TNLean/MPS/MPDO/BNTThreeSiteCollapse.lean
@@ -63,8 +63,8 @@ tensors when each sector is closed against its own virtual matrix:
     (K_s^{i_1j_1}K_s^{i_2j_2}K_s^{i_3j_3}R_s).
 \]
 
-Source: arXiv:1606.00608, Appendix C.2, equation `sigma3bka`, lines
-1343--1348, and its Case II use at lines 1726--1732. -/
+Source: arXiv:1606.00608, Appendix C.2, lines 1343--1348, and its Case II use
+at lines 1726--1732. -/
 def IsThreeSiteFamilyClosure
     (K : (s : Fin g) → MPOTensor d (dim s))
     (R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ)
@@ -78,7 +78,7 @@ sites, leaving a matrix on the middle physical space.
 
 This is the sector-family form of the outer-site contraction in the Case I
 calculation at lines 1415--1438.  The same construction is used with sector
-projectors in equation `Qketc2`, lines 1719--1725.
+projectors at lines 1719--1725.
 
 Source: arXiv:1606.00608, Appendix C.2, lines 1415--1438 and 1719--1725. -/
 def outerInverseContraction

--- a/TNLean/MPS/MPDO/BNTThreeSiteCollapse.lean
+++ b/TNLean/MPS/MPDO/BNTThreeSiteCollapse.lean
@@ -1,0 +1,240 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.BiCFDerivation.Core
+
+/-!
+# Three-site contraction of a basis of normal tensors
+
+For a family of MPO tensors, a three-site operator can be closed against one
+virtual matrix in each basis-of-normal-tensors sector.  A simultaneous left
+inverse on the physical letters selects both the sector and a virtual matrix
+unit.  Applying two such inverse tensors at the outer sites leaves one entry of
+the middle tensor and one entry of the closing matrix.
+
+This is the algebraic contraction used in the simple-tensor argument of
+arXiv:1606.00608, Appendix C.2.  No positivity, saturated-area-law, or
+zero-correlation-length assumption enters this contraction.
+
+The single-sector counterpart is `MPOTensor.IsThreeSiteClosure`, with its
+inverse-map contraction proved in
+`MPOTensor.inverseMap_threeSite_closure_collapse`.  The present statements
+retain a finite family of basis-of-normal-tensors sectors and use one inverse
+which selects the sector together with the two virtual indices.
+
+## Main definitions
+
+* `MPOTensor.IsThreeSiteFamilyClosure`: a sum of three-site closures over a
+  family of sectors.
+* `MPSTensor.IsMPOBlockLeftInverse`: a physical tensor selecting a sector and
+  a virtual matrix unit.
+
+## Main statements
+
+* `MPOTensor.isMPOBlockLeftInverse_outer_inverse_threeSite_collapse`: two outer
+  inverse contractions leave the middle slice and the closing entry in the
+  selected sector.
+* `MPOTensor.exists_isMPOBlockLeftInverse_outer_inverse_threeSite_collapse`:
+  the simultaneous inverse and collapse follow from a one-letter simultaneous
+  word span.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Appendix C.2, lines 1666--1676 and 1719--1732.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPOTensor
+
+variable {d g : ℕ} {dim : Fin g → ℕ}
+
+/-- A tripartite operator is a sum of three-site closures of a family of MPO
+tensors when each sector is closed against its own virtual matrix:
+\[
+  \rho_{i_1i_2i_3,j_1j_2j_3}
+  =\sum_s\operatorname{tr}
+    (K_s^{i_1j_1}K_s^{i_2j_2}K_s^{i_3j_3}R_s).
+\]
+
+Source: arXiv:1606.00608, Appendix C.2, equation `sigma3bka`, lines
+1343--1348, and its Case II use at lines 1726--1732. -/
+def IsThreeSiteFamilyClosure
+    (K : (s : Fin g) → MPOTensor d (dim s))
+    (R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ)
+    (ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ) : Prop :=
+  ∀ i₁ i₂ i₃ j₁ j₂ j₃,
+    ρ (i₁, i₂, i₃) (j₁, j₂, j₃) =
+      ∑ s : Fin g, Matrix.trace (K s i₁ j₁ * K s i₂ j₂ * K s i₃ j₃ * R s)
+
+/-- Contract a tripartite operator with inverse tensors at its first and third
+sites, leaving a matrix on the middle physical space.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `Qketc2`, lines
+1719--1725. -/
+def outerInverseContraction
+    (C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ)
+    (ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ)
+    (x y : MPSTensor.BlockEntryIndex dim) : Matrix (Fin d) (Fin d) ℂ :=
+  fun i₂ j₂ ↦ ∑ i₁ : Fin d, ∑ j₁ : Fin d, ∑ i₃ : Fin d, ∑ j₃ : Fin d,
+    C x (i₁, j₁) * C y (i₃, j₃) * ρ (i₁, i₂, i₃) (j₁, j₂, j₃)
+
+/-- Applying simultaneous inverse tensors at the two outer sites of a
+three-site family closure selects a common sector.  If the two inverse tensors
+carry different sector labels, the contraction is zero.  If their label is
+$s$, the contraction is
+\[
+  K_s^{i_2j_2}(\beta_1,\alpha_3)
+  R_s(\beta_3,\alpha_1).
+\]
+Thus the middle slice has virtual indices $(\beta_1,\alpha_3)$ and the closing
+entry has indices $(\beta_3,\alpha_1)$.
+
+**Local fix (tail index):** the closing entry is
+$R_s(\beta_3,\alpha_1)$, as forced by the matrix-unit trace identity.  This is
+the corrected orientation of the analogous source display, recorded in
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1666--1676 and 1719--1732. -/
+theorem isMPOBlockLeftInverse_outer_inverse_threeSite_collapse
+    {K : (s : Fin g) → MPOTensor d (dim s)}
+    {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse K C)
+    (hρ : IsThreeSiteFamilyClosure K R ρ)
+    (x y : MPSTensor.BlockEntryIndex dim) (i₂ j₂ : Fin d) :
+    outerInverseContraction C ρ x y i₂ j₂ =
+      if h : x.1 = y.1 then
+        K x.1 i₂ j₂ x.2.2 (h.symm ▸ y.2.1) * R x.1 (h.symm ▸ y.2.2) x.2.1
+      else 0 := by
+  classical
+  rcases x with ⟨sx, alpha₁, beta₁⟩
+  rcases y with ⟨sy, alpha₃, beta₃⟩
+  let x : MPSTensor.BlockEntryIndex dim := ⟨sx, alpha₁, beta₁⟩
+  let y : MPSTensor.BlockEntryIndex dim := ⟨sy, alpha₃, beta₃⟩
+  unfold IsThreeSiteFamilyClosure at hρ
+  rw [outerInverseContraction]
+  simp_rw [hρ]
+  have hInv (z : MPSTensor.BlockEntryIndex dim) (s : Fin g) :
+      (∑ i : Fin d, ∑ j : Fin d, C z (i, j) • K s i j) =
+        if h : z.1 = s then
+          Matrix.single (h ▸ z.2.1) (h ▸ z.2.2) (1 : ℂ)
+        else 0 := by
+    ext alpha beta
+    simp only [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
+    by_cases hzs : z.1 = s
+    · subst s
+      rw [hC z.1 z.1 z.2.1 z.2.2 alpha beta]
+      by_cases ha : z.2.1 = alpha <;> by_cases hb : z.2.2 = beta <;>
+        simp [ha, hb]
+    · simpa [hzs] using hC z.1 s z.2.1 z.2.2 alpha beta
+  let L (z : MPSTensor.BlockEntryIndex dim) (s : Fin g) :
+      Matrix (Fin (dim s)) (Fin (dim s)) ℂ :=
+    ∑ i : Fin d, ∑ j : Fin d, C z (i, j) • K s i j
+  let sectorFirstEquiv :
+      (Fin d × Fin d × Fin d × Fin d × Fin g) ≃
+        (Fin g × Fin d × Fin d × Fin d × Fin d) := {
+    toFun := fun ⟨i₁, j₁, i₃, j₃, s⟩ ↦ (s, i₁, j₁, i₃, j₃)
+    invFun := fun ⟨s, i₁, j₁, i₃, j₃⟩ ↦ (i₁, j₁, i₃, j₃, s)
+    left_inv := by rintro ⟨i₁, j₁, i₃, j₃, s⟩; rfl
+    right_inv := by rintro ⟨s, i₁, j₁, i₃, j₃⟩; rfl }
+  have sum_sector_first
+      (f : Fin d → Fin d → Fin d → Fin d → Fin g → ℂ) :
+      (∑ i₁, ∑ j₁, ∑ i₃, ∑ j₃, ∑ s, f i₁ j₁ i₃ j₃ s) =
+        ∑ s, ∑ i₁, ∑ j₁, ∑ i₃, ∑ j₃, f i₁ j₁ i₃ j₃ s := by
+    let G : Fin g × Fin d × Fin d × Fin d × Fin d → ℂ :=
+      fun ⟨s, i₁, j₁, i₃, j₃⟩ ↦ f i₁ j₁ i₃ j₃ s
+    simpa [Fintype.sum_prod_type, G, sectorFirstEquiv] using
+      Equiv.sum_comp sectorFirstEquiv G
+  let swapOuterPairsEquiv :
+      (Fin d × Fin d × Fin d × Fin d) ≃ (Fin d × Fin d × Fin d × Fin d) := {
+    toFun := fun ⟨i₃, j₃, i₁, j₁⟩ ↦ (i₁, j₁, i₃, j₃)
+    invFun := fun ⟨i₁, j₁, i₃, j₃⟩ ↦ (i₃, j₃, i₁, j₁)
+    left_inv := by rintro ⟨i₃, j₃, i₁, j₁⟩; rfl
+    right_inv := by rintro ⟨i₁, j₁, i₃, j₃⟩; rfl }
+  have sum_pair_swap (f : Fin d → Fin d → Fin d → Fin d → ℂ) :
+      (∑ i₃, ∑ j₃, ∑ i₁, ∑ j₁, f i₁ j₁ i₃ j₃) =
+        ∑ i₁, ∑ j₁, ∑ i₃, ∑ j₃, f i₁ j₁ i₃ j₃ := by
+    let G : Fin d × Fin d × Fin d × Fin d → ℂ :=
+      fun ⟨i₁, j₁, i₃, j₃⟩ ↦ f i₁ j₁ i₃ j₃
+    simpa [Fintype.sum_prod_type, G, swapOuterPairsEquiv] using
+      Equiv.sum_comp swapOuterPairsEquiv G
+  have hRegroup :
+      (∑ i₁ : Fin d, ∑ j₁ : Fin d, ∑ i₃ : Fin d, ∑ j₃ : Fin d,
+          C x (i₁, j₁) * C y (i₃, j₃) *
+            ∑ s : Fin g, Matrix.trace (K s i₁ j₁ * K s i₂ j₂ * K s i₃ j₃ * R s)) =
+        ∑ s : Fin g, Matrix.trace (L x s * K s i₂ j₂ * L y s * R s) := by
+    simp only [L, Matrix.sum_mul, Matrix.mul_sum, Matrix.trace_sum,
+      Matrix.smul_mul, Matrix.mul_smul, Matrix.trace_smul, smul_eq_mul]
+    simp_rw [Finset.mul_sum]
+    rw [sum_sector_first]
+    apply Finset.sum_congr rfl
+    intro s _
+    rw [sum_pair_swap]
+    apply Finset.sum_congr rfl
+    intro i₁ _
+    apply Finset.sum_congr rfl
+    intro j₁ _
+    apply Finset.sum_congr rfl
+    intro i₃ _
+    apply Finset.sum_congr rfl
+    intro j₃ _
+    ring
+  rw [hRegroup]
+  have hL (z : MPSTensor.BlockEntryIndex dim) (s : Fin g) :
+      L z s = if h : z.1 = s then
+        Matrix.single (h ▸ z.2.1) (h ▸ z.2.2) (1 : ℂ)
+      else 0 := hInv z s
+  simp_rw [hL]
+  by_cases hxy : x.1 = y.1
+  · have hsysx : sx = sy := by simpa [x, y] using hxy
+    subst sy
+    rw [dif_pos rfl, Finset.sum_eq_single sx]
+    · simp [x, y, Matrix.trace_single_mul]
+    · intro s _ hs
+      have hxs : sx ≠ s := Ne.symm hs
+      simp [x, y, hxs]
+    · simp
+  · rw [dif_neg hxy]
+    apply Finset.sum_eq_zero
+    intro s _
+    by_cases hxs : x.1 = s
+    · have hys : y.1 ≠ s := by
+        intro hys
+        exact hxy (hxs.trans hys.symm)
+      simp [hxs, hys]
+    · simp [hxs]
+
+/-- A one-letter simultaneous word span supplies inverse tensors whose two
+outer contractions of every three-site family closure leave the selected
+middle slice and closing entry.
+
+**Local fix (tail index):** the closing entry has the corrected orientation
+$R_s(\beta_3,\alpha_1)$ documented in
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1666--1676 and 1719--1732. -/
+theorem exists_isMPOBlockLeftInverse_outer_inverse_threeSite_collapse
+    (K : (s : Fin g) → MPOTensor d (dim s))
+    (hSpan : MPSTensor.WordTupleSpanTop (fun s ↦ (K s).toMPSTensor) 1) :
+    ∃ C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ,
+      MPSTensor.IsMPOBlockLeftInverse K C ∧
+        ∀ (R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ)
+          (ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ),
+          IsThreeSiteFamilyClosure K R ρ →
+            ∀ (x y : MPSTensor.BlockEntryIndex dim) (i₂ j₂ : Fin d),
+              outerInverseContraction C ρ x y i₂ j₂ =
+                if h : x.1 = y.1 then
+                  K x.1 i₂ j₂ x.2.2 (h.symm ▸ y.2.1) *
+                    R x.1 (h.symm ▸ y.2.2) x.2.1
+                else 0 := by
+  obtain ⟨C, hC⟩ := hSpan.exists_mpo_block_left_inverse
+  refine ⟨C, hC, ?_⟩
+  intro R ρ hρ
+  exact isMPOBlockLeftInverse_outer_inverse_threeSite_collapse hC hρ
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/BNTThreeSiteCollapse.lean
+++ b/TNLean/MPS/MPDO/BNTThreeSiteCollapse.lean
@@ -31,6 +31,8 @@ inverts every sector of the family.
 
 * `MPOTensor.IsThreeSiteFamilyClosure`: a sum of three-site closures over a
   family of sectors.
+* `MPOTensor.outerInverseContraction`: contraction of the two outer physical
+  sites against simultaneous inverse coefficients.
 
 ## Main statements
 

--- a/TNLean/MPS/MPDO/BiCFDerivation/Core.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/Core.lean
@@ -189,6 +189,21 @@ theorem WordTupleSpanTop.exists_one_letter_simultaneous_left_inverse
   simpa [wordTuple, target, Fintype.linearCombination_apply,
     Matrix.sum_apply, Matrix.smul_apply, List.ofFn_succ] using hentry
 
+/-- A simultaneous left inverse in the ket--bra coordinates of an MPO tensor
+family.  It selects the block label and both virtual matrix indices.
+
+This is the inverse identity used in arXiv:1606.00608, Appendix C.2, lines
+1666--1676, and in the complete zipper fusion data of arXiv:1511.08090,
+lines 269--277. -/
+def IsMPOBlockLeftInverse
+    {p : ℕ} (M : (k : Fin r) → MPOTensor p (dim k))
+    (C : Matrix (BlockEntryIndex dim) (Fin p × Fin p) ℂ) : Prop :=
+  ∀ (k j : Fin r) (x y : Fin (dim k)) (x' y' : Fin (dim j)),
+    (∑ i : Fin p, ∑ l : Fin p, C ⟨k, x, y⟩ (i, l) * M j i l x' y') =
+      if h : k = j then
+        if _ : h ▸ x = x' then if _ : h ▸ y = y' then 1 else 0 else 0
+      else 0
+
 /-- The simultaneous one-letter inverse in the ket--bra coordinates of an MPO
 tensor family.  Its orientation is the one used by the complete zipper fusion
 data.
@@ -199,13 +214,7 @@ theorem WordTupleSpanTop.exists_mpo_block_left_inverse
     {p : ℕ} {M : (k : Fin r) → MPOTensor p (dim k)}
     (hSpan : WordTupleSpanTop (fun k ↦ (M k).toMPSTensor) 1) :
     ∃ C : Matrix (BlockEntryIndex dim) (Fin p × Fin p) ℂ,
-      ∀ (k j : Fin r) (x y : Fin (dim k))
-        (x' y' : Fin (dim j)),
-        (∑ i : Fin p, ∑ l : Fin p,
-          C ⟨k, x, y⟩ (i, l) * M j i l x' y') =
-            if h : k = j then
-              if _ : h ▸ x = x' then if _ : h ▸ y = y' then 1 else 0 else 0
-            else 0 := by
+      IsMPOBlockLeftInverse M C := by
   obtain ⟨C, hC⟩ := hSpan.exists_one_letter_simultaneous_left_inverse
   refine ⟨fun z il ↦ C z (finProdFinEquiv il), ?_⟩
   intro k j x y x' y'

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -1485,13 +1485,30 @@ separate step.
     removes the identity factor and gives the two asserted identities.
 \end{proof}
 
+\begin{definition}[Simultaneous MPO block left inverse]
+    \label{def:mpdo_block_left_inverse}
+    \lean{MPSTensor.IsMPOBlockLeftInverse}
+    \leanok
+    Let $M_c^{ik}\in M_{D_c}(\mathbb C)$ be a finite labelled MPO tensor
+    family.  A simultaneous block left inverse consists of coefficients
+    $C_{(c,x,y),(i,k)}$ such that
+    \[
+        \sum_{i,k}C_{(c,x,y),(i,k)}(M_d^{ik})_{x'y'}
+        =\delta_{cd}\delta_{xx'}\delta_{yy'}.
+    \]
+    This is the common block inverse used in
+    \cite[Appendix~C.2, lines~1666--1676]{Cirac2016MPDO_arXiv} and
+    \cite[lines~269--277]{Bultinck2017Anyons}.
+\end{definition}
+
 \begin{theorem}[Simultaneous inverse from a one-letter product-algebra span]%
     \label{thm:mpdo_one_letter_simultaneous_inverse}
     \lean{MPSTensor.WordTupleSpanTop.%
         exists_one_letter_simultaneous_left_inverse}
     \lean{MPSTensor.WordTupleSpanTop.exists_mpo_block_left_inverse}
     \leanok
-    \uses{thm:cpsv_bnt_blocked_simultaneous_span}
+    \uses{def:mpdo_block_left_inverse,
+      thm:cpsv_bnt_blocked_simultaneous_span}
     Let $A_c^q\in M_{D_c}(\mathbb C)$ be a finite labelled tensor family.  If
     the one-letter tuples
     \[

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -1489,11 +1489,11 @@ separate step.
     \label{def:mpdo_block_left_inverse}
     \lean{MPSTensor.IsMPOBlockLeftInverse}
     \leanok
-    Let $M_c^{ik}\in M_{D_c}(\mathbb C)$ be a finite labelled MPO tensor
+    Let $M_c^{il}\in M_{D_c}(\mathbb C)$ be a finite labelled MPO tensor
     family.  A simultaneous block left inverse consists of coefficients
-    $C_{(c,x,y),(i,k)}$ such that
+    $C_{(c,x,y),(i,l)}$ such that
     \[
-        \sum_{i,k}C_{(c,x,y),(i,k)}(M_d^{ik})_{x'y'}
+        \sum_{i,l}C_{(c,x,y),(i,l)}(M_d^{il})_{x'y'}
         =\delta_{cd}\delta_{xx'}\delta_{yy'}.
     \]
     This is the common block inverse used in

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_case_two.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_case_two.tex
@@ -158,8 +158,9 @@
     \cite[Appendix~C.2, lines~1343--1348]{Cirac2016MPDO_arXiv}, used with the
     block-canonical tensor in the Case II calculation at
     \cite[Appendix~C.2, lines~1726--1732]{Cirac2016MPDO_arXiv}.  The outer
-    contraction is the algebraic form of the displayed projected contraction at
-    \cite[Appendix~C.2, lines~1719--1725]{Cirac2016MPDO_arXiv}.
+    contraction is the sector-family form of the Case I contraction in
+    \cite[Appendix~C.2, lines~1415--1438]{Cirac2016MPDO_arXiv}; the same
+    construction is used with sector projectors at lines~1719--1725.
 \end{definition}
 
 \begin{theorem}[Collapse of the outer inverse contraction]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_case_two.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_case_two.tex
@@ -179,11 +179,13 @@
     \]
     In particular, the contraction retains precisely one entry of the middle
     physical slice and one entry of the closing matrix, with the orientation
-    shown above.  This is the algebraic contraction in
-    \cite[Appendix~C.2, lines~1666--1676 and 1719--1732]
-      {Cirac2016MPDO_arXiv}.
+    shown above.  This is the sector-family form of the Case I contraction in
+    \cite[Appendix~C.2, lines~1415--1438]{Cirac2016MPDO_arXiv}.  The
+    basis-of-normal-tensors inverse is constructed at lines~1666--1676 and the
+    resulting contraction is used in the Case II calculation at
+    lines~1719--1732 of the same appendix.
     The closing entry $R_s(\beta_3,\alpha_1)$ is the corrected tail-index
-    orientation recorded in
+    orientation of the display at lines~1422--1438, recorded in
     \path{docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex}.
 \end{theorem}
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_case_two.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_case_two.tex
@@ -128,3 +128,99 @@
     Theorem~\ref{thm:mpdo_common_weight_coefficient}, and absorb
     $\mu_j^N$ into the length-$N$ matrix product vector of $A_j$.
 \end{proof}
+
+\begin{definition}[Three-site family closure and outer inverse contraction]
+    \label{def:mpdo_three_site_family_closure}
+    \lean{MPOTensor.IsThreeSiteFamilyClosure}
+    \lean{MPOTensor.outerInverseContraction}
+    \leanok
+    Let $(\mathcal K_s)_s$ be a finite family of MPO tensors, with
+    $\mathcal K_s^{ij}\in M_{D_s}(\C)$, and let $R_s\in M_{D_s}(\C)$.
+    A three-site operator is a family closure when
+    \[
+        \rho_{i_1i_2i_3,j_1j_2j_3}
+        =\sum_s\tr\!\left(
+          \mathcal K_s^{i_1j_1}\mathcal K_s^{i_2j_2}
+          \mathcal K_s^{i_3j_3}R_s\right).
+    \]
+    Given a simultaneous left inverse $C$ as in
+    Theorem~\ref{thm:mpdo_one_letter_simultaneous_inverse}, contracting $C$
+    against the first and third physical sites of $\rho$ defines the outer
+    inverse contraction
+    \[
+        (\Gamma_{x,y})_{i_2j_2}
+        =\sum_{i_1,j_1,i_3,j_3}
+          C_{x,(i_1,j_1)}C_{y,(i_3,j_3)}
+          \rho_{(i_1,i_2,i_3),(j_1,j_2,j_3)}.
+    \]
+    The closure is the sector-sum form of the displayed equation for
+    $\sigma_3^{(N)}$ in
+    \cite[Appendix~C.2, lines~1343--1348]{Cirac2016MPDO_arXiv}, used with the
+    block-canonical tensor in the Case II calculation at
+    \cite[Appendix~C.2, lines~1726--1732]{Cirac2016MPDO_arXiv}.  The outer
+    contraction is the algebraic form of the displayed projected contraction at
+    \cite[Appendix~C.2, lines~1719--1725]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{theorem}[Collapse of the outer inverse contraction]
+    \label{thm:mpdo_bnt_three_site_outer_inverse_collapse}
+    \lean{MPOTensor.%
+      isMPOBlockLeftInverse_outer_inverse_threeSite_collapse}
+    \leanok
+    \uses{def:mpdo_three_site_family_closure,
+      def:mpdo_block_left_inverse}
+    Let $x=(s,\alpha_1,\beta_1)$ and
+    $y=(t,\alpha_3,\beta_3)$.  For a three-site family closure and a
+    simultaneous left inverse, the outer inverse contraction vanishes when
+    $s\ne t$.  When $s=t$, it is
+    \[
+        (\mathcal K_s^{i_2j_2})_{\beta_1,\alpha_3}
+        (R_s)_{\beta_3,\alpha_1}.
+    \]
+    In particular, the contraction retains precisely one entry of the middle
+    physical slice and one entry of the closing matrix, with the orientation
+    shown above.  This is the algebraic contraction in
+    \cite[Appendix~C.2, lines~1666--1676 and 1719--1732]
+      {Cirac2016MPDO_arXiv}.
+    The closing entry $R_s(\beta_3,\alpha_1)$ is the corrected tail-index
+    orientation recorded in
+    \path{docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex}.
+\end{theorem}
+
+\begin{proof}\leanok
+    Expand the family closure and interchange the finite sector and physical
+    sums.  For $x=(x_s,x_\alpha,x_\beta)$, the inverse identity is
+    \[
+        \sum_{i,j} C_{x,(i,j)}\mathcal K_s^{ij}
+        =\begin{cases}
+          E_{x_\alpha,x_\beta},&x_s=s,\\
+          0,&x_s\ne s.
+        \end{cases}
+    \]
+    Hence distinct labels give zero.  For equal labels, the remaining trace is
+    \[
+        \tr\!\left(E_{\alpha_1,\beta_1}\mathcal K_s^{i_2j_2}
+          E_{\alpha_3,\beta_3}R_s\right)
+        =(\mathcal K_s^{i_2j_2})_{\beta_1,\alpha_3}
+          (R_s)_{\beta_3,\alpha_1}.
+    \]
+\end{proof}
+
+\begin{corollary}[Three-site collapse from the one-letter span]
+    \label{cor:mpdo_bnt_three_site_outer_inverse_collapse}
+    \lean{MPOTensor.%
+      exists_isMPOBlockLeftInverse_outer_inverse_threeSite_collapse}
+    \leanok
+    \uses{thm:mpdo_one_letter_simultaneous_inverse,
+      thm:mpdo_bnt_three_site_outer_inverse_collapse}
+    Under the one-letter product-algebra spanning hypothesis, there is a
+    simultaneous left inverse for which every three-site family closure has
+    the preceding diagonal-sector contraction and vanishing off-diagonal
+    contractions.
+\end{corollary}
+
+\begin{proof}\leanok
+    Choose the simultaneous left inverse from
+    Theorem~\ref{thm:mpdo_one_letter_simultaneous_inverse} and apply
+    Theorem~\ref{thm:mpdo_bnt_three_site_outer_inverse_collapse}.
+\end{proof}


### PR DESCRIPTION
## Summary

This pull request formalizes the algebraic outer-site contraction used in Appendix C.2 of arXiv:1606.00608.

- It defines a three-site closure for a finite family of MPO sectors and a common simultaneous left inverse.
- It derives the simultaneous inverse from the one-letter product-algebra spanning condition already used for block-injective canonical form.
- It proves that inverse contractions on the first and third sites vanish for distinct sector labels and, for a common label s, equal the middle entry K_s(i₂,j₂; β₁,α₃) times the closing entry R_s(β₃,α₁).
- It records the statement and proof in the blueprint in source order.

The result is an algebraic prerequisite for the Case II projector key formula. It does not yet assert the Markov-projector identity or sector ownership.

Part of #4003.

## Source faithfulness

The simultaneous inverse is the block-injective inverse of Appendix C.2, lines 1666–1676. The three-site contraction is the calculation used at lines 1719–1732. No positivity, saturated-area-law, zero-correlation-length, injectivity, nonvanishing, or owner-map hypothesis is added to this algebraic lemma.

## Verification

- Lean 4.32 focused check
- root import check
- full lake build (9523 jobs)
- blueprint declaration and synchronization checks
- reader-facing prose check
- blueprint PDF build and visual inspection of the affected pages
- proof-integrity and diff checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization of finite sums and matrix algebra on the MPDO track; no runtime, auth, or data-path changes. Risk is mainly proof maintenance and index-orientation correctness for downstream Case II lemmas.
> 
> **Overview**
> Adds the **multi-sector** algebraic step from Cirac et al. Appendix C.2: contracting a three-site operator built from a finite MPO sector family with a **simultaneous block left inverse** on the outer sites.
> 
> **Lean:** New module `BNTThreeSiteCollapse` defines `IsThreeSiteFamilyClosure` and `outerInverseContraction`, proves collapse to one middle tensor entry times one closing matrix entry when sector labels match (zero otherwise), with the documented **tail-index fix** \(R_s(\beta_3,\alpha_1)\). A corollary obtains the inverse from the existing one-letter `WordTupleSpanTop` span via `exists_mpo_block_left_inverse`. `BiCFDerivation.Core` introduces `IsMPOBlockLeftInverse` and refactors `exists_mpo_block_left_inverse` to return that predicate. Root import updated.
> 
> **Blueprint:** Records the block left inverse definition in the fusion chapter; adds definitions, collapse theorem, and span corollary in the simple Case II chapter, aligned with the Lean names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e4559be7bc794780ad8e3eec59081009458fd7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->