### PR TITLE
ci(workflows): stop the shared auto-fix Lean setup saving lake caches

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -221,6 +221,8 @@ jobs:
       workflow_run_id: ${{ fromJSON(needs.setup.outputs.ci_run_id) }}
       pr_number: ${{ fromJSON(needs.setup.outputs.pr_number) }}
       setup_lean: true
+      # See pr-ci.yml: per-run lake caches evict the main build cache.
+      use_github_cache: false
       plugin_marketplaces: 'https://github.com/leanprover/skills.git'
       plugins: 'lean@leanprover'
       claude-prompt-file: .github/prompts/auto-fix-ci-prompt.md


### PR DESCRIPTION
## Summary

Last residual of the cache cleanup (#4048, #4064). The CI-fix job calls the reusable `_ci-auto-fix-shared.yml` in `LionSR/agent-ci-actions` with `setup_lean: true`; that workflow's Lean setup used `lean-env-action`'s default GitHub caching and saved a ~2.5 GB `.lake` entry per run on `refs/heads/main` (two appeared today at 17:58 and 18:30). Those entries compete with the 243 MB `tnlean-build` caches for the 10 GB budget.

`agent-ci-actions` v1.0.3 adds a `use_github_cache` input (default true, no change for other consumers); this PR passes `false`.

Trade-off: an auto-fix run's `lake build` no longer restores a prior auto-fix run's `.lake` snapshot — but those snapshots were usually evicted before reuse anyway, and the main build cache staying resident is worth far more.

## Validation

- `actionlint` clean.
- After merge: no new `lake-*` cache entries should appear from Auto Fix runs (`gh api repos/LionSR/TNLean/actions/caches`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to cache behavior for the CI auto-fix path; no application, auth, or data-handling code is modified.
> 
> **Overview**
> The **auto-fix-ci** job now passes **`use_github_cache: false`** into `LionSR/agent-ci-actions`’s shared `_ci-auto-fix-shared.yml` when **`setup_lean: true`**, so Lean setup no longer writes large per-run **`.lake`** GitHub Actions caches.
> 
> This matches the repo’s **`pr-ci.yml`** / other workflows pattern: those ~2.5 GB entries were crowding the 10 GB cache budget and evicting the main **`tnlean-build`** cache. Auto-fix **`lake build`** may cold-start more often, but the primary build cache staying available is the intended trade-off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7be1ecb907c9a5003f5249cced435dcebd30e37c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->