### PR TITLE
feat(Analysis): prove the trace-norm variational formula and triangle inequality

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -78,6 +78,7 @@ import TNLean.Analysis.MatrixTraceInequalities
 import TNLean.Analysis.KyFanNorm
 import TNLean.Analysis.SchattenNorm
 import TNLean.Analysis.TraceNormAbs
+import TNLean.Analysis.TraceNormVariational
 import TNLean.Analysis.ConvexHullCompact
 import TNLean.Analysis.SuperoperatorResolvent
 import TNLean.Analysis.LiebScalarIntegral

--- a/TNLean/Analysis/TraceNormVariational.lean
+++ b/TNLean/Analysis/TraceNormVariational.lean
@@ -13,7 +13,7 @@ Wolf characterizes the trace norm variationally as
 $\|A\|_1 = \sup\{\lvert\operatorname{tr}[A^\dagger U]\rvert : UU^\dagger = 1\}$,
 Eq. (8.11) of Chapter 8.  This file proves both halves of that
 characterization for square complex matrices and derives the triangle
-inequality $\|A+B\|_1 \le \|A\|_1 + \|B\|_1$, the remaining norm axiom of
+inequality $\|A+B\|_1 \le \|A\|_1 + \|B\|_1$, the remaining norm property of
 Wolf's Section 8.1 for the trace norm.
 
 The upper bound expands the trace in an orthonormal eigenbasis of
@@ -41,7 +41,7 @@ Wolf's proof sketch, which is not available in Mathlib.
 ## References
 
 Michael M. Wolf, *Quantum Channels & Operations: Guided Tour* (July 5, 2012),
-Chapter 8, Section 8.1: norm axioms
+Chapter 8, Section 8.1: norm properties
 (Notes/WolfNoteTexSource/ch08_distance_measures.tex lines 44–49) and the
 variational characterization Eq. (8.11)
 (Notes/WolfNoteTexSource/ch08_distance_measures.tex lines 170–202).
@@ -59,15 +59,18 @@ variable {D : ℕ}
 $A^\dagger A$.
 
 Wolf §8.1; Notes/WolfNoteTexSource/ch08_distance_measures.tex lines 86–95. -/
-theorem traceNorm_eq_sum_sqrt_eigenvalues (A : Matrix (Fin D) (Fin D) ℂ) :
+lemma traceNorm_eq_sum_sqrt_eigenvalues (A : Matrix (Fin D) (Fin D) ℂ) :
     traceNorm A =
       ∑ i, Real.sqrt ((posSemidef_conjTranspose_mul_self A).isHermitian.eigenvalues i) := by
   rw [traceNorm_eq_re_trace_abs, abs_eq_cfc_real_sqrt]
   exact (posSemidef_conjTranspose_mul_self A).isHermitian.trace_cfc_eq_sum_re Real.sqrt
 
 /-- The diagonal entry $(P^\dagger Q)_{ii}$ is the Euclidean inner product of
-the `i`-th columns of `P` and `Q`. -/
-theorem conjTranspose_mul_apply_self_eq_inner (P Q : Matrix (Fin D) (Fin D) ℂ) (i : Fin D) :
+the `i`-th columns of `P` and `Q`.
+
+Local auxiliary identity for the variational formula below; it has no direct
+counterpart in Wolf. -/
+lemma conjTranspose_mul_apply_self_eq_inner (P Q : Matrix (Fin D) (Fin D) ℂ) (i : Fin D) :
     (Pᴴ * Q) i i = ⟪(WithLp.toLp 2 fun k ↦ P k i : EuclideanSpace ℂ (Fin D)),
       (WithLp.toLp 2 fun k ↦ Q k i : EuclideanSpace ℂ (Fin D))⟫_ℂ := by
   rw [EuclideanSpace.inner_toLp_toLp, Matrix.mul_apply]
@@ -76,8 +79,11 @@ theorem conjTranspose_mul_apply_self_eq_inner (P Q : Matrix (Fin D) (Fin D) ℂ)
 
 /-- Cauchy--Schwarz bound for the trace of $P^\dagger Q$, column by column:
 $\lvert\operatorname{tr}[P^\dagger Q]\rvert \le
-\sum_i \lVert Pe_i\rVert\,\lVert Qe_i\rVert$. -/
-theorem norm_trace_conjTranspose_mul_le (P Q : Matrix (Fin D) (Fin D) ℂ) :
+\sum_i \lVert Pe_i\rVert\,\lVert Qe_i\rVert$.
+
+Local auxiliary estimate for the variational formula below; it has no direct
+counterpart in Wolf. -/
+lemma norm_trace_conjTranspose_mul_le (P Q : Matrix (Fin D) (Fin D) ℂ) :
     ‖(Pᴴ * Q).trace‖ ≤
       ∑ i, Real.sqrt ((Pᴴ * P) i i).re * Real.sqrt ((Qᴴ * Q) i i).re := by
   have hnorm : ∀ (M : Matrix (Fin D) (Fin D) ℂ) (i : Fin D),
@@ -94,8 +100,11 @@ theorem norm_trace_conjTranspose_mul_le (P Q : Matrix (Fin D) (Fin D) ℂ) :
         exact norm_inner_le_norm _ _
 
 /-- The conjugation of $A^\dagger A$ by its eigenvector unitary is the diagonal
-matrix of eigenvalues. -/
-theorem star_eigenvectorUnitary_conjTranspose_mul_self_mul (A : Matrix (Fin D) (Fin D) ℂ) :
+matrix of eigenvalues.
+
+Local auxiliary restatement of the spectral theorem for $A^\dagger A$; it has
+no direct counterpart in Wolf. -/
+lemma star_eigenvectorUnitary_conjTranspose_mul_self_mul (A : Matrix (Fin D) (Fin D) ℂ) :
     star ((posSemidef_conjTranspose_mul_self A).isHermitian.eigenvectorUnitary :
         Matrix (Fin D) (Fin D) ℂ) * (Aᴴ * A) *
       ((posSemidef_conjTranspose_mul_self A).isHermitian.eigenvectorUnitary :
@@ -244,9 +253,12 @@ theorem exists_mem_unitaryGroup_trace_conjTranspose_mul_eq (A : Matrix (Fin D) (
         refine Finset.sum_congr rfl fun i _ ↦ ?_
         have hAV : ∀ k, (A * V) k i = (g i).ofLp k := by
           intro k
-          rw [Matrix.mul_apply]
-          rfl
-        have hWb : ∀ k, W k i = (b i).ofLp k := fun k ↦ rfl
+          simp only [hg, WithLp.ofLp_toLp, Matrix.mulVec, dotProduct, Matrix.mul_apply,
+            hVdef, hv, IsHermitian.eigenvectorUnitary_apply]
+        have hWb : ∀ k, W k i = (b i).ofLp k := by
+          intro k
+          rw [hW, Module.Basis.toMatrix_apply, OrthonormalBasis.coe_toBasis,
+            OrthonormalBasis.coe_toBasis_repr_apply, EuclideanSpace.basisFun_repr]
         rw [EuclideanSpace.inner_eq_star_dotProduct, Matrix.diag_apply, Matrix.mul_apply]
         simp only [conjTranspose_apply, dotProduct, Pi.star_apply, hAV, hWb]
         exact Finset.sum_congr rfl fun k _ ↦ mul_comm _ _
@@ -279,7 +291,7 @@ theorem traceNorm_eq_sSup_norm_trace_conjTranspose_mul_unitary (A : Matrix (Fin 
   ((isGreatest_norm_trace_conjTranspose_mul_unitary A).csSup_eq).symm
 
 /-- **Triangle inequality for the trace norm**:
-$\|A + B\|_1 \le \|A\|_1 + \|B\|_1$, the remaining norm axiom of Wolf's
+$\|A + B\|_1 \le \|A\|_1 + \|B\|_1$, the remaining norm property of Wolf's
 Section 8.1.  Choosing a unitary $U$ with
 $\operatorname{tr}[(A+B)^\dagger U] = \|A+B\|_1$ and splitting the trace,
 $\|A+B\|_1 \le \lvert\operatorname{tr}[A^\dagger U]\rvert +

--- a/TNLean/Analysis/TraceNormVariational.lean
+++ b/TNLean/Analysis/TraceNormVariational.lean
@@ -1,0 +1,301 @@
+/-
+Copyright (c) 2026 Sirui Lu and TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sirui Lu
+-/
+import TNLean.Analysis.TraceNormAbs
+import Mathlib.Analysis.InnerProductSpace.PiL2
+
+/-!
+# Variational unitary formula and triangle inequality for the trace norm
+
+Wolf characterizes the trace norm variationally as
+$\|A\|_1 = \sup\{\lvert\operatorname{tr}[A^\dagger U]\rvert : UU^\dagger = 1\}$,
+Eq. (8.11) of Chapter 8.  This file proves both halves of that
+characterization for square complex matrices and derives the triangle
+inequality $\|A+B\|_1 \le \|A\|_1 + \|B\|_1$, the remaining norm axiom of
+Wolf's Section 8.1 for the trace norm.
+
+The upper bound expands the trace in an orthonormal eigenbasis of
+$A^\dagger A$ and applies the Cauchy--Schwarz inequality column by column.
+Attainment constructs the maximizing unitary explicitly: the normalized
+images $Av_i/\sqrt{\lambda_i}$ of the eigenvectors of $A^\dagger A$ with
+$\lambda_i \neq 0$ form an orthonormal family, which extends to an
+orthonormal basis; the unitary sending each $v_i$ to the corresponding basis
+vector attains the supremum.  This replaces the polar decomposition used in
+Wolf's proof sketch, which is not available in Mathlib.
+
+## Main results
+
+* `Matrix.traceNorm_eq_sum_sqrt_eigenvalues` — the trace norm as the sum of
+  the square roots of the eigenvalues of $A^\dagger A$.
+* `Matrix.norm_trace_conjTranspose_mul_unitary_le` — the upper-bound half of
+  Eq. (8.11): $\lvert\operatorname{tr}[A^\dagger U]\rvert \le \|A\|_1$.
+* `Matrix.exists_mem_unitaryGroup_trace_conjTranspose_mul_eq` — attainment:
+  a unitary $U$ with $\operatorname{tr}[A^\dagger U] = \|A\|_1$.
+* `Matrix.isGreatest_norm_trace_conjTranspose_mul_unitary`,
+  `Matrix.traceNorm_eq_sSup_norm_trace_conjTranspose_mul_unitary` — Eq. (8.11)
+  as an attained supremum.
+* `Matrix.traceNorm_add_le` — the triangle inequality.
+
+## References
+
+Michael M. Wolf, *Quantum Channels & Operations: Guided Tour* (July 5, 2012),
+Chapter 8, Section 8.1: norm axioms
+(Notes/WolfNoteTexSource/ch08_distance_measures.tex lines 44–49) and the
+variational characterization Eq. (8.11)
+(Notes/WolfNoteTexSource/ch08_distance_measures.tex lines 170–202).
+-/
+
+open scoped Matrix ComplexOrder InnerProductSpace
+
+noncomputable section
+
+namespace Matrix
+
+variable {D : ℕ}
+
+/-- The trace norm is the sum of the square roots of the eigenvalues of
+$A^\dagger A$.
+
+Wolf §8.1; Notes/WolfNoteTexSource/ch08_distance_measures.tex lines 86–95. -/
+theorem traceNorm_eq_sum_sqrt_eigenvalues (A : Matrix (Fin D) (Fin D) ℂ) :
+    traceNorm A =
+      ∑ i, Real.sqrt ((posSemidef_conjTranspose_mul_self A).isHermitian.eigenvalues i) := by
+  rw [traceNorm_eq_re_trace_abs, abs_eq_cfc_real_sqrt]
+  exact (posSemidef_conjTranspose_mul_self A).isHermitian.trace_cfc_eq_sum_re Real.sqrt
+
+/-- The diagonal entry $(P^\dagger Q)_{ii}$ is the Euclidean inner product of
+the `i`-th columns of `P` and `Q`. -/
+theorem conjTranspose_mul_apply_self_eq_inner (P Q : Matrix (Fin D) (Fin D) ℂ) (i : Fin D) :
+    (Pᴴ * Q) i i = ⟪(WithLp.toLp 2 fun k ↦ P k i : EuclideanSpace ℂ (Fin D)),
+      (WithLp.toLp 2 fun k ↦ Q k i : EuclideanSpace ℂ (Fin D))⟫_ℂ := by
+  rw [EuclideanSpace.inner_toLp_toLp, Matrix.mul_apply]
+  simp only [conjTranspose_apply, dotProduct, Pi.star_apply]
+  exact Finset.sum_congr rfl fun k _ ↦ mul_comm _ _
+
+/-- Cauchy--Schwarz bound for the trace of $P^\dagger Q$, column by column:
+$\lvert\operatorname{tr}[P^\dagger Q]\rvert \le
+\sum_i \lVert Pe_i\rVert\,\lVert Qe_i\rVert$. -/
+theorem norm_trace_conjTranspose_mul_le (P Q : Matrix (Fin D) (Fin D) ℂ) :
+    ‖(Pᴴ * Q).trace‖ ≤
+      ∑ i, Real.sqrt ((Pᴴ * P) i i).re * Real.sqrt ((Qᴴ * Q) i i).re := by
+  have hnorm : ∀ (M : Matrix (Fin D) (Fin D) ℂ) (i : Fin D),
+      ‖(WithLp.toLp 2 fun k ↦ M k i : EuclideanSpace ℂ (Fin D))‖ =
+        Real.sqrt ((Mᴴ * M) i i).re := by
+    intro M i
+    rw [norm_eq_sqrt_re_inner (𝕜 := ℂ), ← conjTranspose_mul_apply_self_eq_inner]
+    rfl
+  calc ‖(Pᴴ * Q).trace‖ = ‖∑ i, (Pᴴ * Q) i i‖ := rfl
+    _ ≤ ∑ i, ‖(Pᴴ * Q) i i‖ := norm_sum_le _ _
+    _ ≤ ∑ i, Real.sqrt ((Pᴴ * P) i i).re * Real.sqrt ((Qᴴ * Q) i i).re := by
+        refine Finset.sum_le_sum fun i _ ↦ ?_
+        rw [conjTranspose_mul_apply_self_eq_inner, ← hnorm P i, ← hnorm Q i]
+        exact norm_inner_le_norm _ _
+
+/-- The conjugation of $A^\dagger A$ by its eigenvector unitary is the diagonal
+matrix of eigenvalues. -/
+theorem star_eigenvectorUnitary_conjTranspose_mul_self_mul (A : Matrix (Fin D) (Fin D) ℂ) :
+    star ((posSemidef_conjTranspose_mul_self A).isHermitian.eigenvectorUnitary :
+        Matrix (Fin D) (Fin D) ℂ) * (Aᴴ * A) *
+      ((posSemidef_conjTranspose_mul_self A).isHermitian.eigenvectorUnitary :
+        Matrix (Fin D) (Fin D) ℂ) =
+      diagonal
+        (RCLike.ofReal ∘ (posSemidef_conjTranspose_mul_self A).isHermitian.eigenvalues) := by
+  have h := (posSemidef_conjTranspose_mul_self
+    A).isHermitian.conjStarAlgAut_star_eigenvectorUnitary
+  rw [Unitary.conjStarAlgAut_star_apply] at h
+  simpa using h
+
+/-- **Upper-bound half of Wolf's Eq. (8.11)**: for every unitary $U$,
+$\lvert\operatorname{tr}[A^\dagger U]\rvert \le \|A\|_1$.
+
+Expanding in an orthonormal eigenbasis $v_i$ of $A^\dagger A$ and applying
+Cauchy--Schwarz,
+$\lvert\operatorname{tr}[A^\dagger U]\rvert
+\le \sum_i \lVert Av_i\rVert\,\lVert Uv_i\rVert
+= \sum_i \sqrt{\lambda_i} = \|A\|_1$.
+
+Wolf Thm "Variational ways to p-norms";
+Notes/WolfNoteTexSource/ch08_distance_measures.tex lines 176–202. -/
+theorem norm_trace_conjTranspose_mul_unitary_le (A : Matrix (Fin D) (Fin D) ℂ)
+    {U : Matrix (Fin D) (Fin D) ℂ} (hU : U ∈ unitaryGroup (Fin D) ℂ) :
+    ‖(Aᴴ * U).trace‖ ≤ traceNorm A := by
+  have hH : (Aᴴ * A).PosSemidef := posSemidef_conjTranspose_mul_self A
+  set V : Matrix (Fin D) (Fin D) ℂ :=
+    (hH.isHermitian.eigenvectorUnitary : Matrix (Fin D) (Fin D) ℂ) with hVdef
+  have hVmem : V ∈ unitaryGroup (Fin D) ℂ := hH.isHermitian.eigenvectorUnitary.2
+  have hVV : V * Vᴴ = 1 := by
+    have := mem_unitaryGroup_iff.mp hVmem
+    rwa [star_eq_conjTranspose] at this
+  have htr : ((A * V)ᴴ * (U * V)).trace = (Aᴴ * U).trace := by
+    have hconj : (A * V)ᴴ * (U * V) = Vᴴ * (Aᴴ * U) * V := by
+      rw [conjTranspose_mul]
+      simp only [Matrix.mul_assoc]
+    rw [hconj, trace_mul_cycle, ← Matrix.mul_assoc, hVV, Matrix.one_mul]
+  have hMM : (A * V)ᴴ * (A * V) = diagonal (RCLike.ofReal ∘ hH.isHermitian.eigenvalues) := by
+    have hconj : (A * V)ᴴ * (A * V) = star V * (Aᴴ * A) * V := by
+      rw [conjTranspose_mul, star_eq_conjTranspose]
+      simp only [Matrix.mul_assoc]
+    rw [hconj, star_eigenvectorUnitary_conjTranspose_mul_self_mul A]
+  have hNN : (U * V)ᴴ * (U * V) = 1 := by
+    have := mem_unitaryGroup_iff'.mp (mul_mem hU hVmem)
+    rwa [star_eq_conjTranspose] at this
+  calc ‖(Aᴴ * U).trace‖ = ‖((A * V)ᴴ * (U * V)).trace‖ := by rw [htr]
+    _ ≤ ∑ i, Real.sqrt (((A * V)ᴴ * (A * V)) i i).re *
+          Real.sqrt (((U * V)ᴴ * (U * V)) i i).re :=
+        norm_trace_conjTranspose_mul_le _ _
+    _ = ∑ i, Real.sqrt (hH.isHermitian.eigenvalues i) := by
+        rw [hMM, hNN]
+        refine Finset.sum_congr rfl fun i _ ↦ ?_
+        simp [diagonal_apply_eq, Matrix.one_apply_eq]
+    _ = traceNorm A := (traceNorm_eq_sum_sqrt_eigenvalues A).symm
+
+/-- **Attainment in Wolf's Eq. (8.11)**: some unitary $U$ realizes
+$\operatorname{tr}[A^\dagger U] = \|A\|_1$.
+
+The eigenvectors $v_i$ of $A^\dagger A$ with eigenvalue $\lambda_i \neq 0$
+have orthogonal images: $\langle Av_i, Av_j\rangle = \lambda_j\delta_{ij}$,
+so the normalized images $Av_i/\sqrt{\lambda_i}$ form an orthonormal family;
+extend it to an orthonormal basis $(w_i)_i$ and let $U$ be the unitary
+sending $v_i$ to $w_i$.  Then
+$\operatorname{tr}[A^\dagger U] = \sum_i \langle Av_i, w_i\rangle
+= \sum_i \sqrt{\lambda_i} = \|A\|_1$.
+
+Wolf Thm "Variational ways to p-norms";
+Notes/WolfNoteTexSource/ch08_distance_measures.tex lines 176–202.  Wolf's
+sketch invokes the polar decomposition and extreme points of the unit ball;
+the orthonormal-extension construction here proves the same statement. -/
+theorem exists_mem_unitaryGroup_trace_conjTranspose_mul_eq (A : Matrix (Fin D) (Fin D) ℂ) :
+    ∃ U ∈ unitaryGroup (Fin D) ℂ, (Aᴴ * U).trace = (traceNorm A : ℂ) := by
+  have hH : (Aᴴ * A).PosSemidef := posSemidef_conjTranspose_mul_self A
+  set lam : Fin D → ℝ := hH.isHermitian.eigenvalues with hlam
+  have hlam0 : ∀ i, 0 ≤ lam i := fun i ↦ hH.eigenvalues_nonneg i
+  set v := hH.isHermitian.eigenvectorBasis with hv
+  -- images of the eigenvectors and their inner products
+  set g : Fin D → EuclideanSpace ℂ (Fin D) := fun i ↦ WithLp.toLp 2 (A *ᵥ ⇑(v i)) with hg
+  have hgg : ∀ i j, ⟪g i, g j⟫_ℂ = if i = j then (lam j : ℂ) else 0 := by
+    intro i j
+    have hstep : ⟪g i, g j⟫_ℂ = (lam j : ℂ) * ⟪v i, v j⟫_ℂ := by
+      rw [hg]
+      rw [EuclideanSpace.inner_toLp_toLp, dotProduct_comm, star_mulVec,
+        ← Matrix.dotProduct_mulVec, mulVec_mulVec, hH.isHermitian.mulVec_eigenvectorBasis j,
+        RCLike.real_smul_eq_coe_smul (K := ℂ), dotProduct_smul, smul_eq_mul,
+        EuclideanSpace.inner_eq_star_dotProduct, dotProduct_comm]
+      rfl
+    rw [hstep, orthonormal_iff_ite.mp v.orthonormal i j]
+    by_cases hij : i = j <;> simp [hij]
+  -- the normalized images form an orthonormal family on the support
+  set s : Set (Fin D) := {i | lam i ≠ 0} with hs
+  set f : Fin D → EuclideanSpace ℂ (Fin D) :=
+    fun i ↦ ((Real.sqrt (lam i) : ℂ))⁻¹ • g i with hf
+  have hforth : Orthonormal ℂ (s.restrict f) := by
+    rw [orthonormal_iff_ite]
+    rintro ⟨i, hi⟩ ⟨j, hj⟩
+    have hinner : ⟪f i, f j⟫_ℂ =
+        (starRingEnd ℂ) ((Real.sqrt (lam i) : ℂ))⁻¹ * ((Real.sqrt (lam j) : ℂ))⁻¹ *
+          ⟪g i, g j⟫_ℂ := by
+      rw [hf]
+      simp only [inner_smul_left, inner_smul_right]
+      ring
+    show ⟪f i, f j⟫_ℂ = _
+    rw [hinner, hgg i j]
+    rcases eq_or_ne i j with rfl | hij
+    · have hlpos : 0 < lam i := (hlam0 i).lt_of_ne (Ne.symm hi)
+      have hsne : (Real.sqrt (lam i) : ℂ) ≠ 0 := by
+        exact_mod_cast (Real.sqrt_pos.mpr hlpos).ne'
+      rw [if_pos rfl, if_pos rfl, map_inv₀, Complex.conj_ofReal]
+      field_simp
+      exact_mod_cast (Real.sq_sqrt (hlam0 i)).symm
+    · rw [if_neg hij, if_neg (by simpa [Subtype.ext_iff] using hij), mul_zero]
+  -- extend to an orthonormal basis
+  obtain ⟨b, hb⟩ := hforth.exists_orthonormalBasis_extension_of_card_eq
+    (by simp [finrank_euclideanSpace])
+  -- the unitary with columns `b` composed with the inverse eigenvector unitary
+  set W : Matrix (Fin D) (Fin D) ℂ :=
+    (EuclideanSpace.basisFun (Fin D) ℂ).toBasis.toMatrix b.toBasis with hW
+  have hWmem : W ∈ unitaryGroup (Fin D) ℂ :=
+    (EuclideanSpace.basisFun (Fin D) ℂ).toMatrix_orthonormalBasis_mem_unitary b
+  set V : Matrix (Fin D) (Fin D) ℂ :=
+    (hH.isHermitian.eigenvectorUnitary : Matrix (Fin D) (Fin D) ℂ) with hVdef
+  have hVmem : V ∈ unitaryGroup (Fin D) ℂ := hH.isHermitian.eigenvectorUnitary.2
+  refine ⟨W * Vᴴ, mul_mem hWmem ?_, ?_⟩
+  · rw [← star_eq_conjTranspose]
+    exact Unitary.star_mem hVmem
+  -- the trace against `A` sums the singular values
+  have hkey : ∀ i, ⟪g i, b i⟫_ℂ = (Real.sqrt (lam i) : ℂ) := by
+    intro i
+    by_cases hi : lam i ≠ 0
+    · rw [hb i hi, hf]
+      simp only [inner_smul_right]
+      rw [hgg i i, if_pos rfl, ← Complex.ofReal_inv, ← Complex.ofReal_mul]
+      norm_cast
+      rw [inv_mul_eq_div, Real.div_sqrt]
+    · simp only [ne_eq, not_not] at hi
+      have hg0 : g i = 0 := by
+        have h := hgg i i
+        rw [if_pos rfl, hi, Complex.ofReal_zero] at h
+        exact inner_self_eq_zero.mp h
+      rw [hg0, inner_zero_left, hi, Real.sqrt_zero, Complex.ofReal_zero]
+  have htr : (Aᴴ * (W * Vᴴ)).trace = ((A * V)ᴴ * W).trace := by
+    rw [conjTranspose_mul, Matrix.mul_assoc, ← Matrix.mul_assoc Aᴴ W Vᴴ, trace_mul_comm]
+  calc (Aᴴ * (W * Vᴴ)).trace = ((A * V)ᴴ * W).trace := htr
+    _ = ∑ i, ⟪g i, b i⟫_ℂ := by
+        refine Finset.sum_congr rfl fun i _ ↦ ?_
+        have hAV : ∀ k, (A * V) k i = (g i).ofLp k := by
+          intro k
+          rw [Matrix.mul_apply]
+          rfl
+        have hWb : ∀ k, W k i = (b i).ofLp k := fun k ↦ rfl
+        rw [EuclideanSpace.inner_eq_star_dotProduct, Matrix.diag_apply, Matrix.mul_apply]
+        simp only [conjTranspose_apply, dotProduct, Pi.star_apply, hAV, hWb]
+        exact Finset.sum_congr rfl fun k _ ↦ mul_comm _ _
+    _ = ∑ i, (Real.sqrt (lam i) : ℂ) := Finset.sum_congr rfl fun i _ ↦ hkey i
+    _ = (traceNorm A : ℂ) := by
+        rw [traceNorm_eq_sum_sqrt_eigenvalues, Complex.ofReal_sum]
+
+/-- **Wolf's Eq. (8.11)** as an attained supremum: the trace norm is the
+greatest value of $\lvert\operatorname{tr}[A^\dagger U]\rvert$ over unitaries
+$U$.
+
+Wolf Thm "Variational ways to p-norms";
+Notes/WolfNoteTexSource/ch08_distance_measures.tex lines 176–202. -/
+theorem isGreatest_norm_trace_conjTranspose_mul_unitary (A : Matrix (Fin D) (Fin D) ℂ) :
+    IsGreatest {x : ℝ | ∃ U ∈ unitaryGroup (Fin D) ℂ, x = ‖(Aᴴ * U).trace‖}
+      (traceNorm A) := by
+  constructor
+  · obtain ⟨U, hU, hEq⟩ := exists_mem_unitaryGroup_trace_conjTranspose_mul_eq A
+    exact ⟨U, hU, by rw [hEq, Complex.norm_of_nonneg (traceNorm_nonneg A)]⟩
+  · rintro x ⟨U, hU, rfl⟩
+    exact norm_trace_conjTranspose_mul_unitary_le A hU
+
+/-- **Wolf's Eq. (8.11)**, supremum form:
+$\|A\|_1 = \sup\{\lvert\operatorname{tr}[A^\dagger U]\rvert : UU^\dagger = 1\}$.
+
+Wolf Thm "Variational ways to p-norms";
+Notes/WolfNoteTexSource/ch08_distance_measures.tex lines 176–202. -/
+theorem traceNorm_eq_sSup_norm_trace_conjTranspose_mul_unitary (A : Matrix (Fin D) (Fin D) ℂ) :
+    traceNorm A = sSup {x : ℝ | ∃ U ∈ unitaryGroup (Fin D) ℂ, x = ‖(Aᴴ * U).trace‖} :=
+  ((isGreatest_norm_trace_conjTranspose_mul_unitary A).csSup_eq).symm
+
+/-- **Triangle inequality for the trace norm**:
+$\|A + B\|_1 \le \|A\|_1 + \|B\|_1$, the remaining norm axiom of Wolf's
+Section 8.1.  Choosing a unitary $U$ with
+$\operatorname{tr}[(A+B)^\dagger U] = \|A+B\|_1$ and splitting the trace,
+$\|A+B\|_1 \le \lvert\operatorname{tr}[A^\dagger U]\rvert +
+\lvert\operatorname{tr}[B^\dagger U]\rvert \le \|A\|_1 + \|B\|_1$.
+
+Wolf §8.1; Notes/WolfNoteTexSource/ch08_distance_measures.tex lines 44–49. -/
+theorem traceNorm_add_le (A B : Matrix (Fin D) (Fin D) ℂ) :
+    traceNorm (A + B) ≤ traceNorm A + traceNorm B := by
+  obtain ⟨U, hU, hEq⟩ := exists_mem_unitaryGroup_trace_conjTranspose_mul_eq (A + B)
+  calc traceNorm (A + B) = ‖((A + B)ᴴ * U).trace‖ := by
+        rw [hEq, Complex.norm_of_nonneg (traceNorm_nonneg _)]
+    _ = ‖(Aᴴ * U).trace + (Bᴴ * U).trace‖ := by
+        rw [conjTranspose_add, Matrix.add_mul, trace_add]
+    _ ≤ ‖(Aᴴ * U).trace‖ + ‖(Bᴴ * U).trace‖ := norm_add_le _ _
+    _ ≤ traceNorm A + traceNorm B :=
+        add_le_add (norm_trace_conjTranspose_mul_unitary_le A hU)
+          (norm_trace_conjTranspose_mul_unitary_le B hU)
+
+end Matrix

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -214,6 +214,117 @@ Theorem~\ref{thm:trace_norm_abs}.
     \]
 \end{proof}
 
+\begin{theorem}[Trace norm from the eigenvalues of $A^\dagger A$]
+    \label{thm:trace_norm_sqrt_eigenvalues}
+    \lean{Matrix.traceNorm_eq_sum_sqrt_eigenvalues}
+    \leanok
+    \uses{def:trace_norm}
+    For every $A\in\MN{D}$, with $\lambda_0,\ldots,\lambda_{D-1}$ the
+    eigenvalues of $A^\dagger A$,
+    \[
+        \lVert A\rVert_{\mathrm{tr}}=\sum_{i=0}^{D-1}\sqrt{\lambda_i}.
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:trace_norm_abs}
+    Diagonalizing $A^\dagger A=V\operatorname{diag}(\lambda_i)V^\dagger$ gives
+    $\lvert A\rvert=V\operatorname{diag}(\sqrt{\lambda_i})V^\dagger$, so
+    \[
+        \operatorname{tr}\lvert A\rvert=\sum_{i=0}^{D-1}\sqrt{\lambda_i},
+    \]
+    and the claim follows from Theorem~\ref{thm:trace_norm_abs}.
+\end{proof}
+
+\begin{theorem}[Variational unitary formula for the trace norm]
+    \label{thm:trace_norm_variational}
+    \lean{Matrix.norm_trace_conjTranspose_mul_unitary_le}
+    \lean{Matrix.exists_mem_unitaryGroup_trace_conjTranspose_mul_eq}
+    \lean{Matrix.isGreatest_norm_trace_conjTranspose_mul_unitary}
+    \lean{Matrix.traceNorm_eq_sSup_norm_trace_conjTranspose_mul_unitary}
+    \leanok
+    \uses{def:trace_norm}
+    For every $A\in\MN{D}$,
+    \[
+        \lVert A\rVert_{\mathrm{tr}}
+        =\max\left\{\bigl|\operatorname{tr}[A^\dagger U]\bigr|
+        \;\middle|\; UU^\dagger=\Id\right\},
+    \]
+    and the maximum is attained: some unitary $U$ satisfies
+    $\operatorname{tr}[A^\dagger U]=\lVert A\rVert_{\mathrm{tr}}$.
+    This is Eq.~(8.11) of \cite[Chapter~8, Section~8.1]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:trace_norm_sqrt_eigenvalues}
+    For the upper bound, let $v_0,\ldots,v_{D-1}$ be an orthonormal
+    eigenbasis of $A^\dagger A$ with eigenvalues $\lambda_i$, and let $U$ be
+    unitary. Expanding the trace in this basis and applying the
+    Cauchy--Schwarz inequality,
+    \[
+        \bigl|\operatorname{tr}[A^\dagger U]\bigr|
+        =\Bigl|\sum_{i}\langle Av_i,\,Uv_i\rangle\Bigr|
+        \le\sum_{i}\lVert Av_i\rVert\,\lVert Uv_i\rVert
+        =\sum_{i}\sqrt{\lambda_i}
+        =\lVert A\rVert_{\mathrm{tr}},
+    \]
+    since $\lVert Av_i\rVert^2=\langle v_i,\,A^\dagger A\,v_i\rangle
+    =\lambda_i$ and $\lVert Uv_i\rVert=1$.
+
+    For attainment, the vectors $w_i=Av_i/\sqrt{\lambda_i}$, taken over the
+    indices with $\lambda_i\neq0$, satisfy
+    \[
+        \langle w_i,w_j\rangle
+        =\frac{\langle v_i,\,A^\dagger A\,v_j\rangle}
+              {\sqrt{\lambda_i}\sqrt{\lambda_j}}
+        =\delta_{ij},
+    \]
+    so they form an orthonormal family. Extend it to an orthonormal basis
+    $(w_i)_{i}$ of $\C^D$ and let $U$ be the unitary with $Uv_i=w_i$ for all
+    $i$. Then
+    \[
+        \operatorname{tr}[A^\dagger U]
+        =\sum_{i}\langle Av_i,\,w_i\rangle
+        =\sum_{\lambda_i\neq0}\frac{\lVert Av_i\rVert^2}{\sqrt{\lambda_i}}
+        =\sum_{i}\sqrt{\lambda_i}
+        =\lVert A\rVert_{\mathrm{tr}},
+    \]
+    where the indices with $\lambda_i=0$ contribute $0$ to both sides because
+    $\lVert Av_i\rVert^2=\lambda_i=0$ forces $Av_i=0$.
+\end{proof}
+
+\begin{theorem}[Trace-norm triangle inequality]
+    \label{thm:trace_norm_triangle}
+    \lean{Matrix.traceNorm_add_le}
+    \leanok
+    \uses{def:trace_norm}
+    For all $A,B\in\MN{D}$,
+    \[
+        \lVert A+B\rVert_{\mathrm{tr}}
+        \le\lVert A\rVert_{\mathrm{tr}}+\lVert B\rVert_{\mathrm{tr}}.
+    \]
+    Together with homogeneity (Theorem~\ref{thm:trace_norm_homogeneous}) and
+    definiteness (Theorem~\ref{thm:trace_norm_elementary}), this completes
+    the norm axioms of \cite[Chapter~8, Section~8.1]{Wolf2012Quantum} for the
+    trace norm.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:trace_norm_variational}
+    Choose by Theorem~\ref{thm:trace_norm_variational} a unitary $U$ with
+    $\operatorname{tr}[(A+B)^\dagger U]=\lVert A+B\rVert_{\mathrm{tr}}$.
+    Splitting the trace and applying the upper-bound half of the same
+    theorem to $A$ and to $B$ separately,
+    \[
+        \lVert A+B\rVert_{\mathrm{tr}}
+        =\bigl|\operatorname{tr}[A^\dagger U]
+              +\operatorname{tr}[B^\dagger U]\bigr|
+        \le\bigl|\operatorname{tr}[A^\dagger U]\bigr|
+          +\bigl|\operatorname{tr}[B^\dagger U]\bigr|
+        \le\lVert A\rVert_{\mathrm{tr}}+\lVert B\rVert_{\mathrm{tr}}.
+    \]
+\end{proof}
+
 \section{Von Neumann entropy}
 
 \begin{definition}[Von Neumann entropy]\label{def:von_neumann_entropy}

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -214,17 +214,17 @@ Theorem~\ref{thm:trace_norm_abs}.
     \]
 \end{proof}
 
-\begin{theorem}[Trace norm from the eigenvalues of $A^\dagger A$]
-    \label{thm:trace_norm_sqrt_eigenvalues}
+\begin{lemma}[Trace norm from the matrix eigenvalues of $A^\dagger A$]
+    \label{lem:trace_norm_sqrt_matrix_eigenvalues}
     \lean{Matrix.traceNorm_eq_sum_sqrt_eigenvalues}
     \leanok
     \uses{def:trace_norm}
     For every $A\in\MN{D}$, with $\lambda_0,\ldots,\lambda_{D-1}$ the
-    eigenvalues of $A^\dagger A$,
+    eigenvalues of the matrix $A^\dagger A$,
     \[
         \lVert A\rVert_{\mathrm{tr}}=\sum_{i=0}^{D-1}\sqrt{\lambda_i}.
     \]
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok
     \uses{thm:trace_norm_abs}
@@ -252,11 +252,11 @@ Theorem~\ref{thm:trace_norm_abs}.
     \]
     and the maximum is attained: some unitary $U$ satisfies
     $\operatorname{tr}[A^\dagger U]=\lVert A\rVert_{\mathrm{tr}}$.
-    This is Eq.~(8.11) of \cite[Chapter~8, Section~8.1]{Wolf2012Quantum}.
+    See \cite[Chapter~8, Eq.~(8.11)]{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:trace_norm_sqrt_eigenvalues}
+    \uses{lem:trace_norm_sqrt_matrix_eigenvalues}
     For the upper bound, let $v_0,\ldots,v_{D-1}$ be an orthonormal
     eigenbasis of $A^\dagger A$ with eigenvalues $\lambda_i$, and let $U$ be
     unitary. Expanding the trace in this basis and applying the


### PR DESCRIPTION
### Motivation

Third Wolf Chapter 8 trace-norm increment (tracking: LionSR/QICLean#209). Wolf characterizes the trace norm variationally as $\|A\|_1 = \sup\{|\operatorname{tr}[A^\dagger U]| : UU^\dagger = \mathbb{1}\}$ (Eq. (8.11), `Notes/WolfNoteTexSource/ch08_distance_measures.tex` lines 170–202) and lists the triangle inequality among the norm axioms of Section 8.1 (lines 44–49). Wolf's proof of Eq. (8.11) is a sketch with an explicit ellipsis (via Hoelder duality and extreme points of the unit ball), so a complete proof is supplied here.

### Description

New file `TNLean/Analysis/TraceNormVariational.lean` (imported in `TNLean.lean` after `TraceNormAbs`), building on `traceNorm` from LionSR/QICLean#209/#4051:

- `Matrix.traceNorm_eq_sum_sqrt_eigenvalues` — bridge: $\|A\|_1 = \sum_i \sqrt{\lambda_i}$ with $\lambda_i$ the eigenvalues of $A^\dagger A$.
- `Matrix.conjTranspose_mul_apply_self_eq_inner`, `Matrix.norm_trace_conjTranspose_mul_le` — Cauchy–Schwarz bound for $\operatorname{tr}[P^\dagger Q]$, column by column.
- `Matrix.norm_trace_conjTranspose_mul_unitary_le` — upper-bound half of Eq. (8.11): $|\operatorname{tr}[A^\dagger U]| \le \|A\|_1$ for every unitary $U$, by expanding in an orthonormal eigenbasis of $A^\dagger A$.
- `Matrix.exists_mem_unitaryGroup_trace_conjTranspose_mul_eq` — attainment: a unitary $U$ with $\operatorname{tr}[A^\dagger U] = \|A\|_1$ exactly. Mathlib has no polar decomposition or SVD, so the maximizer is constructed directly: the normalized images $Av_i/\sqrt{\lambda_i}$ over the nonzero eigenvalues form an orthonormal family (`Orthonormal.exists_orthonormalBasis_extension_of_card_eq` extends it to an orthonormal basis), and the change-of-basis unitary sending $v_i$ to the extended basis attains the value.
- `Matrix.isGreatest_norm_trace_conjTranspose_mul_unitary`, `Matrix.traceNorm_eq_sSup_norm_trace_conjTranspose_mul_unitary` — Eq. (8.11) packaged as an attained supremum (following the `IsGreatest` precedent of `KyFanNorm.lean`).
- `Matrix.traceNorm_add_le` — triangle inequality, by choosing the attaining unitary for $A+B$ and splitting the trace.

Blueprint (`blueprint/src/chapter/ch19_entropy.tex`, trace-norm section): new entries `thm:trace_norm_sqrt_eigenvalues`, `thm:trace_norm_variational`, `thm:trace_norm_triangle` with `\lean{}`/`\leanok` tags and proof sketches displaying the key identities.

### Testing

- `lake build` succeeds (9520 jobs), no new `sorry`/`axiom`.
- `lake env lean TNLean/Analysis/TraceNormVariational.lean` clean.
- `leanblueprint checkdecls` exit 0; `scripts/blueprint_lean_sync.py --ci` in sync.
- `scripts/check_forbidden_lean_tokens.py`, `scripts/check_reader_facing_prose.py`, `scripts/check_oversized_lean_files.py`: changed files clean.

Closes LionSR/QICLean#213

https://claude.ai/code/session_014TxvMnpGSqatcyWuPUqmpd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure analysis additions on top of existing `traceNorm` infrastructure; no auth, I/O, or runtime behavior changes. Risk is mainly proof maintenance and Mathlib API coupling in a new ~300-line module.
> 
> **Overview**
> Adds **`TNLean/Analysis/TraceNormVariational.lean`** (wired into **`TNLean.lean`** after `TraceNormAbs`) and formalizes Wolf Ch. 8 Eq. (8.11) and the trace-norm triangle inequality on square complex matrices.
> 
> The Lean development proves \(\|A\|_1 = \sup\{|\mathrm{tr}(A^\dagger U)| : U \text{ unitary}\}\) via a Cauchy–Schwarz upper bound in an eigenbasis of \(A^\dagger A\) and an **explicit attaining unitary** built by normalizing \(Av_i/\sqrt{\lambda_i}\), extending to an orthonormal basis, and composing change-of-basis matrices—avoiding polar decomposition/SVD. Results are packaged as `IsGreatest` / `sSup` (`traceNorm_eq_sSup_norm_trace_conjTranspose_mul_unitary`), and **`traceNorm_add_le`** follows from the attaining unitary for \(A+B\) plus the variational bound.
> 
> **Blueprint** (`ch19_entropy.tex`): new lemma on \(\sum\sqrt{\lambda_i(A^\dagger A)}\), the variational theorem, and the triangle inequality, with `\lean{}`/`\leanok` links to the new declarations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87af2755205210189dd3ce6182fdbfcbb813f2a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->