### PR TITLE
feat(MPS/FundamentalTheorem): normalize nonzero BNT families after blocking

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -345,6 +345,7 @@ import TNLean.MPS.FundamentalTheorem.SectorBNT.Api
 import TNLean.MPS.FundamentalTheorem.SectorBNT.Examples
 import TNLean.MPS.FundamentalTheorem.SectorBNT.ProportionalMatch
 import TNLean.MPS.FundamentalTheorem.SectorBNT.Supplier
+import TNLean.MPS.FundamentalTheorem.SectorBNT.SupplierNormalized
 import TNLean.MPS.FundamentalTheorem.SectorBNT.Unitary
 import TNLean.MPS.Periodic.Overlap
 import TNLean.MPS.Periodic.NormalizedSelfOverlap

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/SupplierNormalized.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/SupplierNormalized.lean
@@ -39,7 +39,6 @@ matrix product coefficients.
   definition and the characterization prop:char-BNT.
 -/
 
-open scoped Matrix BigOperators
 
 namespace MPSTensor
 
@@ -94,7 +93,7 @@ decomposition carries the normalized weights and the factor $m^N$ records the or
 
 The nonvanishing hypothesis: for every blocking length $p > 0$ some positive-length matrix
 product coefficient of the $p$-blocked tensor is nonzero.  The prepared block family can be
-empty ($r = 0$) exactly when every positive-length coefficient of the blocked tensor
+empty ($r = 0$) only when every positive-length coefficient of the blocked tensor
 vanishes (for example the zero tensor): the empty direct sum has all positive-length
 coefficients zero, and the positive-length agreement transfers this to the blocked tensor.
 For an empty weight family the line-246 choice "at least one weight of unit modulus" is

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/SupplierNormalized.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/SupplierNormalized.lean
@@ -14,7 +14,7 @@ The canonical form of arXiv:1606.00608 (eq:II_CF1,
 $A^i = \oplus_{k=1}^r \mu_k A_k^i$ with each $A_k$ a normal tensor, and line 246 fixes the
 weight normalization: since the states are not normalized, one can always choose
 $|\mu_k| \le 1$ with at least one weight of unit modulus, "something which we will assume from
-now on."  The supplier `MPSTensor.exists_isBNTCanonicalForm_afterBlocking_pos` leaves that
+now on."  The arbitrary-input supplier of the basis of normal tensors leaves that
 normalization choice as a hypothesis on the produced weights.  This file discharges it:
 dividing every weight by the largest modulus $m = \max_k |\mu_k|$ realizes the line-246
 choice, and the discarded factor reappears as the scalar $m^N$ multiplying the length-$N$

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/SupplierNormalized.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/SupplierNormalized.lean
@@ -29,7 +29,7 @@ matrix product coefficients.
 * `MPSTensor.exists_isBNTCanonicalForm_afterBlocking_pos_normalized` — for a tensor whose
   blocked matrix product coefficients do not vanish identically at positive lengths, some
   blocking length $p$ admits a basis-of-normal-tensors canonical form $P$ and a scale $m > 0$
-  with $V^{(N)}(A^{(p)}) = m^N V^{(N)}(P)$ at every positive length $N$.
+  with $V^{(N)}(A^{[p]}) = m^N V^{(N)}(P)$ at every positive length $N$.
 
 ## References
 
@@ -87,23 +87,27 @@ basis-of-normal-tensors definition and prop:char-BNT.
 For a tensor $A$ satisfying the nonvanishing hypothesis below, there are a positive blocking
 length $p$, a scale $m > 0$, and a sector decomposition $P$ in basis-of-normal-tensors
 canonical form such that at every positive length $N$ the matrix product coefficients satisfy
-$V^{(N)}(A^{(p)}) = m^N \, V^{(N)}(P)$, where $A^{(p)}$ denotes the $p$-blocked tensor.  The
+$V^{(N)}(A^{[p]}) = m^N \, V^{(N)}(P)$, where $A^{[p]}$ denotes the $p$-blocked tensor.  The
 scale $m$ is the largest weight modulus of the prepared block family; dividing the weights by
 $m$ realizes the line-246 choice $|\mu_k| \le 1$ with some $|\mu_k| = 1$, so the sector
 decomposition carries the normalized weights and the factor $m^N$ records the original ones.
 
 The nonvanishing hypothesis: for every blocking length $p > 0$ some positive-length matrix
-product coefficient of the $p$-blocked tensor is nonzero.  The prepared block family of
-`exists_prepared_BNT_blocks_afterBlocking_pos` can be empty ($r = 0$) exactly when every
-positive-length coefficient of the blocked tensor vanishes (for example the zero tensor):
-the empty direct sum has all positive-length coefficients zero, and the positive-length
-agreement transfers this to the blocked tensor.  For an empty weight family the line-246
-choice "at least one weight of unit modulus" is impossible, so the source's normalization
-implicitly assumes a nonvanishing matrix product vector; the hypothesis states exactly that
-assumption.  It is quantified over all $p$ because the blocking length is produced by the
-construction; since the length-$N$ coefficients of the $p$-blocked tensor are the
-length-$pN$ coefficients of $A$, it asks that the coefficients of $A$ not vanish on all
-positive multiples of any blocking length. -/
+product coefficient of the $p$-blocked tensor is nonzero.  The prepared block family can be
+empty ($r = 0$) exactly when every positive-length coefficient of the blocked tensor
+vanishes (for example the zero tensor): the empty direct sum has all positive-length
+coefficients zero, and the positive-length agreement transfers this to the blocked tensor.
+For an empty weight family the line-246 choice "at least one weight of unit modulus" is
+impossible.  Since the length-$N$ coefficients of the $p$-blocked tensor are the
+length-$pN$ coefficients of $A$, the hypothesis asks that for every $p > 0$ the
+coefficients of $A$ not vanish on all positive multiples of $p$.  This is stronger than
+nonvanishing of a single coefficient of $A$; it is quantified over every $p$ because the
+blocking length is produced by the construction.
+
+**Scope restriction (blocked nonvanishing):** the source states the line-246 choice for
+any tensor and does not carry this hypothesis; it enters only to exclude blocked families
+that vanish identically at positive lengths, where the choice is unsatisfiable.  Recorded
+in docs/paper-gaps/cpsv16_cf_normalization_and_proportional_comparison.tex. -/
 theorem exists_isBNTCanonicalForm_afterBlocking_pos_normalized
     {d D : ℕ} (A : MPSTensor d D)
     (hNZ : ∀ p : ℕ, 0 < p →

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/SupplierNormalized.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/SupplierNormalized.lean
@@ -26,8 +26,6 @@ matrix product coefficients.
   $\mu_1, \dots, \mu_r$ there is $m > 0$ with $|\mu_k / m| \le 1$ for every $k$, equality for
   some $k$, and $\mu_k / m \ne 0$ for every $k$ (the choice at line 246 of the source, with
   $m = \max_k |\mu_k|$).
-* `MPSTensor.toTensorFromBlocks_weight_mul_left` — multiplying every weight of a direct-sum
-  tensor $\oplus_k \mu_k A_k^i$ by the same scalar $c$ multiplies the assembled tensor by $c$.
 * `MPSTensor.exists_isBNTCanonicalForm_afterBlocking_pos_normalized` — for a tensor whose
   blocked matrix product coefficients do not vanish identically at positive lengths, some
   blocking length $p$ admits a basis-of-normal-tensors canonical form $P$ and a scale $m > 0$
@@ -79,27 +77,6 @@ theorem exists_weight_normalization {r : ℕ} (hr : 0 < r)
     exact (div_le_one hm_pos).mpr (hle k)
   · rw [norm_div, hm_norm, ← hk₀]
     exact div_self hm_pos.ne'
-
-/-- **Weight scaling of the direct-sum tensor.**
-
-Multiplying every weight of the direct sum $\oplus_k \mu_k A_k^i$ (eq:II_CF1,
-arXiv:1606.00608, `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 237-243) by the same scalar
-$c$ multiplies each matrix of the assembled tensor by $c$.  Together with `mpv_smul` this
-gives the factor $c^N$ on every length-$N$ matrix product coefficient. -/
-theorem toTensorFromBlocks_weight_mul_left {r : ℕ} {dim : Fin r → ℕ}
-    (c : ℂ) (μ : Fin r → ℂ) (blocks : (k : Fin r) → MPSTensor d (dim k)) :
-    toTensorFromBlocks (d := d) (μ := fun k => c * μ k) blocks =
-      fun i => c • toTensorFromBlocks (d := d) (μ := μ) blocks i := by
-  funext i
-  change (Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv)
-      (Matrix.blockDiagonal' fun k => (c * μ k) • blocks k i) =
-    c • (Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv)
-      (Matrix.blockDiagonal' fun k => μ k • blocks k i)
-  have hfam : (fun k => (c * μ k) • blocks k i) = c • fun k => μ k • blocks k i := by
-    funext k
-    rw [Pi.smul_apply, smul_smul]
-  rw [hfam, Matrix.blockDiagonal'_smul]
-  rfl
 
 /-- **Normalized arbitrary-input basis-of-normal-tensors supplier (positive length).**
 
@@ -165,12 +142,6 @@ theorem exists_isBNTCanonicalForm_afterBlocking_pos_normalized
     funext k
     rw [mul_comm]
     exact div_mul_cancel₀ (μ k) hm0
-  have htens :
-      toTensorFromBlocks (d := blockPhysDim d p)
-          (μ := fun k => (m : ℂ) * (μ k / (m : ℂ))) blocks =
-        fun i => (m : ℂ) • toTensorFromBlocks (d := blockPhysDim d p)
-          (μ := fun k => μ k / (m : ℂ)) blocks i :=
-    toTensorFromBlocks_weight_mul_left (m : ℂ) (fun k => μ k / (m : ℂ)) blocks
   calc
     mpv (blockTensor (d := d) (D := D) A p) σ
         = mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μ) blocks) σ :=
@@ -179,9 +150,8 @@ theorem exists_isBNTCanonicalForm_afterBlocking_pos_normalized
           (μ := fun k => (m : ℂ) * (μ k / (m : ℂ))) blocks) σ := by
       rw [hμeq]
     _ = (m : ℂ) ^ N * mpv (toTensorFromBlocks (d := blockPhysDim d p)
-          (μ := fun k => μ k / (m : ℂ)) blocks) σ := by
-      rw [htens]
-      exact mpv_smul (m : ℂ) _ σ
+          (μ := fun k => μ k / (m : ℂ)) blocks) σ :=
+      mpv_toTensorFromBlocks_weight_mul_left (m : ℂ) _ blocks σ
     _ = (m : ℂ) ^ N * mpv P.toTensor σ := by
       rw [hSame N σ]
 

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/SupplierNormalized.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/SupplierNormalized.lean
@@ -27,9 +27,9 @@ matrix product coefficients.
   some $k$, and $\mu_k / m \ne 0$ for every $k$ (the choice at line 246 of the source, with
   $m = \max_k |\mu_k|$).
 * `MPSTensor.exists_isBNTCanonicalForm_afterBlocking_pos_normalized` — for a tensor whose
-  blocked matrix product coefficients do not vanish identically at positive lengths, some
-  blocking length $p$ admits a basis-of-normal-tensors canonical form $P$ and a scale $m > 0$
-  with $V^{(N)}(A^{[p]}) = m^N V^{(N)}(P)$ at every positive length $N$.
+  matrix product family has a nonzero positive-length coefficient, some blocking length $p$
+  admits a basis-of-normal-tensors canonical form $P$ and a scale $m > 0$ with
+  $V^{(N)}(A^{[p]}) = m^N V^{(N)}(P)$ at every positive length $N$.
 
 ## References
 
@@ -39,10 +39,88 @@ matrix product coefficients.
   definition and the characterization prop:char-BNT.
 -/
 
-
 namespace MPSTensor
 
 variable {d : ℕ}
+
+/-- If a matrix has nonzero trace, then for every positive-step subsequence of its powers,
+some trace in that subsequence is nonzero. -/
+private lemma exists_trace_pow_mul_ne_zero {D : ℕ}
+    (M : Matrix (Fin D) (Fin D) ℂ) (hM : Matrix.trace M ≠ 0)
+    (p : ℕ) (_hp : 0 < p) :
+    ∃ q : ℕ, 0 < q ∧ Matrix.trace (M ^ (p * q)) ≠ 0 := by
+  classical
+  by_contra h
+  push Not at h
+  have htrace : ∀ q : ℕ, 0 < q →
+      Matrix.trace ((M ^ p) ^ q) = Matrix.trace ((0 : Matrix (Fin D) (Fin D) ℂ) ^ q) := by
+    intro q hq
+    rw [← pow_mul]
+    simp [h q hq, hq.ne']
+  have hchar := Matrix.charpoly_eq_of_forall_trace_pow_eq
+    (M ^ p) (0 : Matrix (Fin D) (Fin D) ℂ) htrace
+  have hnilLin : IsNilpotent (Matrix.toLin' (M ^ p)) := by
+    rw [LinearMap.isNilpotent_iff_charpoly, Matrix.charpoly_toLin', hchar,
+      Matrix.charpoly_zero]
+    simp
+  have hnilPow : IsNilpotent (M ^ p) :=
+    (Matrix.isNilpotent_toLin'_iff (M ^ p)).mp hnilLin
+  have hnilM : IsNilpotent M := IsNilpotent.of_pow hnilPow
+  exact hM (Matrix.isNilpotent_trace_of_isNilpotent hnilM).eq_zero
+
+/-- A nonzero positive-length matrix product coefficient remains nonzero at some positive
+length after every physical blocking. -/
+private lemma exists_mpv_blockTensor_ne_zero {D : ℕ} (A : MPSTensor d D)
+    (hNZ : ∃ N : ℕ, 0 < N ∧ ∃ σ : Fin N → Fin d, mpv A σ ≠ 0)
+    (p : ℕ) (hp : 0 < p) :
+    ∃ N : ℕ, 0 < N ∧ ∃ σ : Fin N → Fin (blockPhysDim d p),
+      mpv (blockTensor (d := d) (D := D) A p) σ ≠ 0 := by
+  classical
+  obtain ⟨N₀, hN₀, σ₀, hσ₀⟩ := hNZ
+  let w := List.ofFn σ₀
+  let M := evalWord A w
+  have hM : Matrix.trace M ≠ 0 := by
+    simpa [mpv, coeff, M, w] using hσ₀
+  obtain ⟨q, hq, htrace⟩ := exists_trace_pow_mul_ne_zero M hM p hp
+  have heval : ∀ r : ℕ, evalWord A (List.replicate r w).flatten = M ^ r := by
+    intro r
+    induction r with
+    | zero => simp [M]
+    | succ r ih =>
+      rw [List.replicate_succ, List.flatten_cons, evalWord_append, ih, pow_succ']
+  have hlenPow : ∀ r : ℕ, (List.replicate r w).flatten.length = r * N₀ := by
+    intro r
+    induction r with
+    | zero => simp
+    | succ r ih =>
+      rw [List.replicate_succ, List.flatten_cons, List.length_append, ih]
+      simp [w, Nat.succ_mul, Nat.add_comm]
+  let flatWord := (List.replicate (p * q) w).flatten
+  have hlen : flatWord.length = (N₀ * q) * p := by
+    calc
+      flatWord.length = (p * q) * N₀ := hlenPow (p * q)
+      _ = (N₀ * q) * p := by ac_rfl
+  let flatConfig : Fin ((N₀ * q) * p) → Fin d :=
+    fun i => flatWord.get (Fin.cast hlen.symm i)
+  have hofFn : List.ofFn flatConfig = flatWord := by
+    simp only [flatConfig]
+    conv_rhs => rw [← List.ofFn_get flatWord]
+    have hcongr :=
+      List.ofFn_congr hlen.symm
+        (fun i : Fin ((N₀ * q) * p) => flatWord.get (Fin.cast hlen.symm i))
+    simpa [Function.comp, Fin.cast_cast] using hcongr
+  let σ : Fin (N₀ * q) → Fin (blockPhysDim d p) :=
+    (blockedConfigEquiv d (N₀ * q) p).symm flatConfig
+  refine ⟨N₀ * q, Nat.mul_pos hN₀ hq, σ, ?_⟩
+  have hflat : flattenBlockedWord d p (List.ofFn σ) = flatWord := by
+    calc
+      flattenBlockedWord d p (List.ofFn σ) =
+          List.ofFn (blockedConfigEquiv d (N₀ * q) p σ) :=
+        (ofFn_blockedConfigEquiv d (N₀ * q) p σ).symm
+      _ = List.ofFn flatConfig := by
+        simp [σ]
+      _ = flatWord := hofFn
+  simpa [mpv, coeff, evalWord_blockTensor, hflat, flatWord, heval] using htrace
 
 /-- **The weight normalization at line 246 of the source.**
 
@@ -53,7 +131,8 @@ largest modulus $m = \max_k |\mu_k| > 0$ produces weights $\mu_k / m$ that are s
 have modulus at most one, and include one of modulus exactly one. -/
 theorem exists_weight_normalization {r : ℕ} (hr : 0 < r)
     (μ : Fin r → ℂ) (hμ : ∀ k, μ k ≠ 0) :
-    ∃ m : ℝ, 0 < m ∧ (∀ k, ‖μ k / (m : ℂ)‖ ≤ 1) ∧ (∃ k, ‖μ k / (m : ℂ)‖ = 1) ∧
+    ∃ m : ℝ, 0 < m ∧
+      (∀ k, ‖μ k / (m : ℂ)‖ ≤ 1) ∧ (∃ k, ‖μ k / (m : ℂ)‖ = 1) ∧
       ∀ k, μ k / (m : ℂ) ≠ 0 := by
   classical
   have hne : (Finset.univ : Finset (Fin r)).Nonempty := ⟨⟨0, hr⟩, Finset.mem_univ _⟩
@@ -77,7 +156,7 @@ theorem exists_weight_normalization {r : ℕ} (hr : 0 < r)
   · rw [norm_div, hm_norm, ← hk₀]
     exact div_self hm_pos.ne'
 
-/-- **Normalized arbitrary-input basis-of-normal-tensors supplier (positive length).**
+/-- **Normalized basis-of-normal-tensors supplier for a nonzero MPV family.**
 
 Source: arXiv:1606.00608, `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 237-246 for the
 canonical form eq:II_CF1 with the line-246 weight normalization, and lines 271-279 for the
@@ -91,27 +170,25 @@ scale $m$ is the largest weight modulus of the prepared block family; dividing t
 $m$ realizes the line-246 choice $|\mu_k| \le 1$ with some $|\mu_k| = 1$, so the sector
 decomposition carries the normalized weights and the factor $m^N$ records the original ones.
 
-The nonvanishing hypothesis: for every blocking length $p > 0$ some positive-length matrix
-product coefficient of the $p$-blocked tensor is nonzero.  The prepared block family can be
-empty ($r = 0$) only when every positive-length coefficient of the blocked tensor
-vanishes (for example the zero tensor): the empty direct sum has all positive-length
-coefficients zero, and the positive-length agreement transfers this to the blocked tensor.
-For an empty weight family the line-246 choice "at least one weight of unit modulus" is
-impossible.  Since the length-$N$ coefficients of the $p$-blocked tensor are the
-length-$pN$ coefficients of $A$, the hypothesis asks that for every $p > 0$ the
-coefficients of $A$ not vanish on all positive multiples of $p$.  This is stronger than
-nonvanishing of a single coefficient of $A$; it is quantified over every $p$ because the
-blocking length is produced by the construction.
+The hypothesis says exactly that the positive-length matrix product family is not the zero
+family.  It also suffices after every blocking.  Indeed, choose a word with evaluated matrix
+$M$ and $\operatorname{tr}(M) \ne 0$.  For each blocking length $p$, some $q > 0$ satisfies
+$\operatorname{tr}(M^{pq}) \ne 0$: otherwise Newton--Girard gives the characteristic polynomial of
+$M^p$ equal to that of the zero matrix, so $M^p$, and hence $M$, is nilpotent, contradicting
+$\operatorname{tr}(M) \ne 0$.  Repeating the word $pq$ times therefore gives a nonzero
+coefficient at a length divisible by $p$, which is a coefficient of the $p$-blocked tensor.
 
-**Scope restriction (blocked nonvanishing):** the source states the line-246 choice for
-any tensor and does not carry this hypothesis; it enters only to exclude blocked families
-that vanish identically at positive lengths, where the choice is unsatisfiable.  Recorded
-in docs/paper-gaps/cpsv16_cf_normalization_and_proportional_comparison.tex. -/
+The nonzero-family condition is the precise boundary for the line-246 unit-modulus choice:
+an empty weight family cannot contain a unit-modulus weight.
+
+**Scope restriction (nonzero MPV family):** the source proposition says "for any tensor,"
+but the zero MPV family cannot satisfy the global unit-modulus condition imposed immediately
+before that proposition.  The hypothesis below is the weakest exclusion of this degenerate
+case.  This boundary and its possible resolution by a separate zero-family clause are
+recorded in `docs/paper-gaps/cpsv16_cf_normalization_and_proportional_comparison.tex`. -/
 theorem exists_isBNTCanonicalForm_afterBlocking_pos_normalized
     {d D : ℕ} (A : MPSTensor d D)
-    (hNZ : ∀ p : ℕ, 0 < p →
-      ∃ N : ℕ, 0 < N ∧ ∃ σ : Fin N → Fin (blockPhysDim d p),
-        mpv (blockTensor (d := d) (D := D) A p) σ ≠ 0) :
+    (hNZ : ∃ N : ℕ, 0 < N ∧ ∃ σ : Fin N → Fin d, mpv A σ ≠ 0) :
     ∃ p : ℕ, 0 < p ∧ ∃ m : ℝ, 0 < m ∧
       ∃ P : SectorDecomposition (blockPhysDim d p),
         IsBNTCanonicalForm P ∧
@@ -124,7 +201,7 @@ theorem exists_isBNTCanonicalForm_afterBlocking_pos_normalized
   have hr : 0 < r := by
     rcases Nat.eq_zero_or_pos r with hr0 | hpos
     · exfalso
-      obtain ⟨N, hN, σ, hσ⟩ := hNZ p hp
+      obtain ⟨N, hN, σ, hσ⟩ := exists_mpv_blockTensor_ne_zero A hNZ p hp
       apply hσ
       rw [hSamePos N hN σ, mpv_toTensorFromBlocks_eq_sum]
       subst hr0

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/SupplierNormalized.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/SupplierNormalized.lean
@@ -1,0 +1,188 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.FundamentalTheorem.SectorBNT.Supplier
+import TNLean.MPS.SharedInfra.Scaling
+
+/-!
+# Normalized SectorBNT supplier after blocking
+
+The canonical form of arXiv:1606.00608 (eq:II_CF1,
+`Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 237-246) writes a tensor as
+$A^i = \oplus_{k=1}^r \mu_k A_k^i$ with each $A_k$ a normal tensor, and line 246 fixes the
+weight normalization: since the states are not normalized, one can always choose
+$|\mu_k| \le 1$ with at least one weight of unit modulus, "something which we will assume from
+now on."  The supplier `MPSTensor.exists_isBNTCanonicalForm_afterBlocking_pos` leaves that
+normalization choice as a hypothesis on the produced weights.  This file discharges it:
+dividing every weight by the largest modulus $m = \max_k |\mu_k|$ realizes the line-246
+choice, and the discarded factor reappears as the scalar $m^N$ multiplying the length-$N$
+matrix product coefficients.
+
+## Main declarations
+
+* `MPSTensor.exists_weight_normalization` — for a nonempty family of nonzero weights
+  $\mu_1, \dots, \mu_r$ there is $m > 0$ with $|\mu_k / m| \le 1$ for every $k$, equality for
+  some $k$, and $\mu_k / m \ne 0$ for every $k$ (the choice at line 246 of the source, with
+  $m = \max_k |\mu_k|$).
+* `MPSTensor.toTensorFromBlocks_weight_mul_left` — multiplying every weight of a direct-sum
+  tensor $\oplus_k \mu_k A_k^i$ by the same scalar $c$ multiplies the assembled tensor by $c$.
+* `MPSTensor.exists_isBNTCanonicalForm_afterBlocking_pos_normalized` — for a tensor whose
+  blocked matrix product coefficients do not vanish identically at positive lengths, some
+  blocking length $p$ admits a basis-of-normal-tensors canonical form $P$ and a scale $m > 0$
+  with $V^{(N)}(A^{(p)}) = m^N V^{(N)}(P)$ at every positive length $N$.
+
+## References
+
+* `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 237-246 — the canonical form eq:II_CF1 and
+  the line-246 weight normalization discharged here.
+* `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 271-279 — the basis-of-normal-tensors
+  definition and the characterization prop:char-BNT.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d : ℕ}
+
+/-- **The weight normalization at line 246 of the source.**
+
+Source: arXiv:1606.00608, `Papers/1606.00608/MPDO-22-12-17-2.tex`, line 246: since the states
+are not normalized, one can always choose $|\mu_k| \le 1$ with at least one weight of unit
+modulus.  For a nonempty family of nonzero weights $\mu_1, \dots, \mu_r$, dividing by the
+largest modulus $m = \max_k |\mu_k| > 0$ produces weights $\mu_k / m$ that are still nonzero,
+have modulus at most one, and include one of modulus exactly one. -/
+theorem exists_weight_normalization {r : ℕ} (hr : 0 < r)
+    (μ : Fin r → ℂ) (hμ : ∀ k, μ k ≠ 0) :
+    ∃ m : ℝ, 0 < m ∧ (∀ k, ‖μ k / (m : ℂ)‖ ≤ 1) ∧ (∃ k, ‖μ k / (m : ℂ)‖ = 1) ∧
+      ∀ k, μ k / (m : ℂ) ≠ 0 := by
+  classical
+  have hne : (Finset.univ : Finset (Fin r)).Nonempty := ⟨⟨0, hr⟩, Finset.mem_univ _⟩
+  obtain ⟨k₀, -, hk₀⟩ := Finset.exists_mem_eq_sup' hne fun k => ‖μ k‖
+  have hle : ∀ k, ‖μ k‖ ≤ Finset.univ.sup' hne fun k => ‖μ k‖ := fun k =>
+    Finset.le_sup' (fun k => ‖μ k‖) (Finset.mem_univ k)
+  have hm_pos : 0 < Finset.univ.sup' hne fun k => ‖μ k‖ := by
+    rw [hk₀]
+    exact norm_pos_iff.mpr (hμ k₀)
+  have hm_norm : ‖((Finset.univ.sup' hne fun k => ‖μ k‖ : ℝ) : ℂ)‖ =
+      Finset.univ.sup' hne fun k => ‖μ k‖ := by
+    rw [Complex.norm_real]
+    exact Real.norm_of_nonneg hm_pos.le
+  have hm_ne : ((Finset.univ.sup' hne fun k => ‖μ k‖ : ℝ) : ℂ) ≠ 0 :=
+    Complex.ofReal_ne_zero.mpr hm_pos.ne'
+  refine ⟨Finset.univ.sup' hne fun k => ‖μ k‖, hm_pos, ?_, ⟨k₀, ?_⟩,
+    fun k => div_ne_zero (hμ k) hm_ne⟩
+  · intro k
+    rw [norm_div, hm_norm]
+    exact (div_le_one hm_pos).mpr (hle k)
+  · rw [norm_div, hm_norm, ← hk₀]
+    exact div_self hm_pos.ne'
+
+/-- **Weight scaling of the direct-sum tensor.**
+
+Multiplying every weight of the direct sum $\oplus_k \mu_k A_k^i$ (eq:II_CF1,
+arXiv:1606.00608, `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 237-243) by the same scalar
+$c$ multiplies each matrix of the assembled tensor by $c$.  Together with `mpv_smul` this
+gives the factor $c^N$ on every length-$N$ matrix product coefficient. -/
+theorem toTensorFromBlocks_weight_mul_left {r : ℕ} {dim : Fin r → ℕ}
+    (c : ℂ) (μ : Fin r → ℂ) (blocks : (k : Fin r) → MPSTensor d (dim k)) :
+    toTensorFromBlocks (d := d) (μ := fun k => c * μ k) blocks =
+      fun i => c • toTensorFromBlocks (d := d) (μ := μ) blocks i := by
+  funext i
+  change (Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv)
+      (Matrix.blockDiagonal' fun k => (c * μ k) • blocks k i) =
+    c • (Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv)
+      (Matrix.blockDiagonal' fun k => μ k • blocks k i)
+  have hfam : (fun k => (c * μ k) • blocks k i) = c • fun k => μ k • blocks k i := by
+    funext k
+    rw [Pi.smul_apply, smul_smul]
+  rw [hfam, Matrix.blockDiagonal'_smul]
+  rfl
+
+/-- **Normalized arbitrary-input basis-of-normal-tensors supplier (positive length).**
+
+Source: arXiv:1606.00608, `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 237-246 for the
+canonical form eq:II_CF1 with the line-246 weight normalization, and lines 271-279 for the
+basis-of-normal-tensors definition and prop:char-BNT.
+
+For a tensor $A$ satisfying the nonvanishing hypothesis below, there are a positive blocking
+length $p$, a scale $m > 0$, and a sector decomposition $P$ in basis-of-normal-tensors
+canonical form such that at every positive length $N$ the matrix product coefficients satisfy
+$V^{(N)}(A^{(p)}) = m^N \, V^{(N)}(P)$, where $A^{(p)}$ denotes the $p$-blocked tensor.  The
+scale $m$ is the largest weight modulus of the prepared block family; dividing the weights by
+$m$ realizes the line-246 choice $|\mu_k| \le 1$ with some $|\mu_k| = 1$, so the sector
+decomposition carries the normalized weights and the factor $m^N$ records the original ones.
+
+The nonvanishing hypothesis: for every blocking length $p > 0$ some positive-length matrix
+product coefficient of the $p$-blocked tensor is nonzero.  The prepared block family of
+`exists_prepared_BNT_blocks_afterBlocking_pos` can be empty ($r = 0$) exactly when every
+positive-length coefficient of the blocked tensor vanishes (for example the zero tensor):
+the empty direct sum has all positive-length coefficients zero, and the positive-length
+agreement transfers this to the blocked tensor.  For an empty weight family the line-246
+choice "at least one weight of unit modulus" is impossible, so the source's normalization
+implicitly assumes a nonvanishing matrix product vector; the hypothesis states exactly that
+assumption.  It is quantified over all $p$ because the blocking length is produced by the
+construction; since the length-$N$ coefficients of the $p$-blocked tensor are the
+length-$pN$ coefficients of $A$, it asks that the coefficients of $A$ not vanish on all
+positive multiples of any blocking length. -/
+theorem exists_isBNTCanonicalForm_afterBlocking_pos_normalized
+    {d D : ℕ} (A : MPSTensor d D)
+    (hNZ : ∀ p : ℕ, 0 < p →
+      ∃ N : ℕ, 0 < N ∧ ∃ σ : Fin N → Fin (blockPhysDim d p),
+        mpv (blockTensor (d := d) (D := D) A p) σ ≠ 0) :
+    ∃ p : ℕ, 0 < p ∧ ∃ m : ℝ, 0 < m ∧
+      ∃ P : SectorDecomposition (blockPhysDim d p),
+        IsBNTCanonicalForm P ∧
+        ∀ N : ℕ, 0 < N → ∀ σ : Fin N → Fin (blockPhysDim d p),
+          mpv (blockTensor (d := d) (D := D) A p) σ = (m : ℂ) ^ N * mpv P.toTensor σ := by
+  classical
+  obtain ⟨p, hp, r, dim, μ, blocks, hDim, hTP, hPrim, hIrr, -, hμne, hSamePos⟩ :=
+    exists_prepared_BNT_blocks_afterBlocking_pos (d := d) (D := D) A
+  -- The nonvanishing hypothesis forces a nonempty block family.
+  have hr : 0 < r := by
+    rcases Nat.eq_zero_or_pos r with hr0 | hpos
+    · exfalso
+      obtain ⟨N, hN, σ, hσ⟩ := hNZ p hp
+      apply hσ
+      rw [hSamePos N hN σ, mpv_toTensorFromBlocks_eq_sum]
+      subst hr0
+      simp
+    · exact hpos
+  -- Normalize the weights by the largest modulus.
+  obtain ⟨m, hm, hLe, hUnit, hne⟩ := exists_weight_normalization hr μ hμne
+  have hm0 : (m : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr hm.ne'
+  -- The block properties do not involve the weights, so the normalized weights feed the
+  -- prepared-block constructor directly.
+  obtain ⟨P, hSame, hBNT⟩ :=
+    exists_isBNTCanonicalForm_of_tp_primitive_irr_blocks
+      (d := blockPhysDim d p) (r := r) (dim := dim)
+      (fun k => μ k / (m : ℂ)) blocks hDim hTP hPrim hIrr hne hLe hUnit
+  refine ⟨p, hp, m, hm, P, hBNT, ?_⟩
+  intro N hN σ
+  have hμeq : (fun k => (m : ℂ) * (μ k / (m : ℂ))) = μ := by
+    funext k
+    rw [mul_comm]
+    exact div_mul_cancel₀ (μ k) hm0
+  have htens :
+      toTensorFromBlocks (d := blockPhysDim d p)
+          (μ := fun k => (m : ℂ) * (μ k / (m : ℂ))) blocks =
+        fun i => (m : ℂ) • toTensorFromBlocks (d := blockPhysDim d p)
+          (μ := fun k => μ k / (m : ℂ)) blocks i :=
+    toTensorFromBlocks_weight_mul_left (m : ℂ) (fun k => μ k / (m : ℂ)) blocks
+  calc
+    mpv (blockTensor (d := d) (D := D) A p) σ
+        = mpv (toTensorFromBlocks (d := blockPhysDim d p) (μ := μ) blocks) σ :=
+      hSamePos N hN σ
+    _ = mpv (toTensorFromBlocks (d := blockPhysDim d p)
+          (μ := fun k => (m : ℂ) * (μ k / (m : ℂ))) blocks) σ := by
+      rw [hμeq]
+    _ = (m : ℂ) ^ N * mpv (toTensorFromBlocks (d := blockPhysDim d p)
+          (μ := fun k => μ k / (m : ℂ)) blocks) σ := by
+      rw [htens]
+      exact mpv_smul (m : ℂ) _ σ
+    _ = (m : ℂ) ^ N * mpv P.toTensor σ := by
+      rw [hSame N σ]
+
+end MPSTensor

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1667,8 +1667,8 @@ gives the arbitrary-input statement, conditional on the weight normalization.
     discharges both hypotheses at the price of one positive scalar per site.
 \end{remark}
 
-\begin{lemma}[Projective weight normalization]%
-    \label{lem:paperbnt_weight_normalization}
+\begin{theorem}[Projective weight normalization]%
+    \label{thm:paperbnt_weight_normalization}
     \lean{MPSTensor.exists_weight_normalization}
     \leanok
     For nonzero weights $\mu_1,\dots,\mu_r$ with $r\geq1$ there is a positive
@@ -1683,7 +1683,7 @@ gives the arbitrary-input statement, conditional on the weight normalization.
     This is the normalization that
     \cite[line~246]{Cirac2016MPDO_arXiv} chooses for the canonical-form
     weights.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     Take $m=\max_k|\mu_k|$; the maximum over a nonempty finite
@@ -1698,7 +1698,7 @@ gives the arbitrary-input statement, conditional on the weight normalization.
     \leanok
     \uses{thm:prepared_bnt_blocks_after_blocking,
         thm:paperbnt_supplier_prepared,
-        lem:paperbnt_weight_normalization,
+        thm:paperbnt_weight_normalization,
         lem:mpv_to_tensor_from_blocks_weight_mul_left,
         thm:mpv_decomposition}
     Let $A$ be an MPS tensor whose blocked tensors $A^{[p]}$ generate, for
@@ -1721,7 +1721,7 @@ gives the arbitrary-input statement, conditional on the weight normalization.
     The zero family admits no unit-modulus weight, so the nonvanishing
     hypothesis produces at least one prepared block. Normalize the prepared
     weights by their maximal modulus $m$
-    (Lemma~\ref{lem:paperbnt_weight_normalization}). By the weight-scaling
+    (Theorem~\ref{thm:paperbnt_weight_normalization}). By the weight-scaling
     identity of
     Lemma~\ref{lem:mpv_to_tensor_from_blocks_weight_mul_left},
     \[

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1686,7 +1686,7 @@ gives the arbitrary-input statement, conditional on the weight normalization.
 \end{lemma}
 
 \begin{proof}\leanok
-    Take $m=\max_k\lVert\mu_k\rVert$; the maximum over a nonempty finite
+    Take $m=\max_k|\mu_k|$; the maximum over a nonempty finite
     family is attained, positive because every weight is nonzero, an upper
     bound for every modulus, and equal to the modulus of the attaining
     weight.

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -282,8 +282,8 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
     evaluations of the blocked tensors span the full product algebra:
     \[
         \spn_{\C}\left\{
-            \bigl((A_1^{[L]})^i,\ldots,(A_g^{[L]})^i\bigr)
-            : 0\leq i<d^L
+        \bigl((A_1^{[L]})^i,\ldots,(A_g^{[L]})^i\bigr)
+        : 0\leq i<d^L
         \right\}
         = \prod_{j=1}^g \MN{D_j}.
     \]
@@ -1140,7 +1140,7 @@ single family.
     \lean{MPSTensor.periodicSelfOverlap_tendsto}
     \leanok
     \uses{def:mpv_overlap,def:irreducible_tensor,def:left_canonical_tensor,
-      def:peripheral_eigenvalues}
+        def:peripheral_eigenvalues}
     Let $D>0$ and $m>0$. Let $A$ be a left-canonical irreducible MPS tensor
     with bond dimension $D$, and suppose that the peripheral eigenvalues of
     its transfer map are exactly $\{z\in\mathbb C:z^m=1\}$. Then
@@ -1662,7 +1662,90 @@ gives the arbitrary-input statement, conditional on the weight normalization.
     % docs/paper-gaps/cpsv16_cf_normalization_and_proportional_comparison.tex; the
     % length-zero trace identity and the unblocked canonical form remain part of
     % the reduction in Section~\ref{sec:reduction_to_normal_form}.
+    The weight rescaling is carried out in
+    Theorem~\ref{thm:paperbnt_supplier_after_blocking_normalized} below, which
+    discharges both hypotheses at the price of one positive scalar per site.
 \end{remark}
+
+\begin{lemma}[Projective weight normalization]%
+    \label{lem:paperbnt_weight_normalization}
+    \lean{MPSTensor.exists_weight_normalization}
+    \leanok
+    For nonzero weights $\mu_1,\dots,\mu_r$ with $r\geq1$ there is a positive
+    real $m$ with
+    \[
+        \Bigl\lVert\frac{\mu_k}{m}\Bigr\rVert\leq1
+        \quad\text{for every }k,
+        \qquad
+        \Bigl\lVert\frac{\mu_k}{m}\Bigr\rVert=1
+        \quad\text{for at least one }k,
+        \qquad
+        \frac{\mu_k}{m}\neq0
+        \quad\text{for every }k.
+    \]
+    This is the normalization that
+    \cite[line~246]{Cirac2016MPDO_arXiv} chooses for the canonical-form
+    weights.
+\end{lemma}
+
+\begin{proof}\leanok
+    Take $m=\max_k\lVert\mu_k\rVert$; the maximum over a nonempty finite
+    family is attained, positive because every weight is nonzero, an upper
+    bound for every modulus, and equal to the modulus of the attaining
+    weight.
+\end{proof}
+
+\begin{lemma}[Weight scaling of the block direct sum]%
+    \label{lem:paperbnt_block_weight_scaling}
+    \lean{MPSTensor.toTensorFromBlocks_weight_mul_left}
+    \leanok
+    \uses{thm:prepared_bnt_blocks_after_blocking}
+    Multiplying every weight of a block direct sum by one scalar $c$
+    multiplies the assembled tensor by $c$:
+    \[
+        \bigoplus_k (c\,\mu_k)\,B_k
+        = c\,\Bigl(\bigoplus_k \mu_k\,B_k\Bigr).
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    Both sides scale each diagonal block of the assembled matrix by $c$.
+\end{proof}
+
+\begin{theorem}[Normalized BNT form after blocking for an arbitrary tensor]%
+    \label{thm:paperbnt_supplier_after_blocking_normalized}
+    \lean{MPSTensor.exists_isBNTCanonicalForm_afterBlocking_pos_normalized}
+    \leanok
+    \uses{thm:paperbnt_supplier_after_blocking,
+        lem:paperbnt_weight_normalization,
+        lem:paperbnt_block_weight_scaling}
+    Let $A$ be an MPS tensor whose blocked tensors $A^{[p]}$ generate, for
+    every blocking length $p\geq1$, a matrix-product family that is not
+    identically zero at positive lengths. Then there exist a blocking length
+    $p\geq1$, a positive real $m$, and a sector decomposition $P$ over the
+    blocked alphabet in the BNT canonical form of
+    Definition~\ref{def:sector_bnt_cf}, such that for every positive length
+    $N$,
+    \[
+        V^{(N)}\bigl(A^{[p]}\bigr)=m^{N}\,V^{(N)}(P).
+    \]
+    The scalar $m^{N}$ is the per-site normalization cost of the line-246
+    weight choice; the hypotheses of
+    Theorem~\ref{thm:paperbnt_supplier_after_blocking} are discharged rather
+    than assumed.
+\end{theorem}
+
+\begin{proof}\leanok
+    The zero family admits no unit-modulus weight, so the nonvanishing
+    hypothesis produces at least one prepared block. Normalize the prepared
+    weights by their maximal modulus $m$
+    (Lemma~\ref{lem:paperbnt_weight_normalization}); the scaled direct sum
+    differs from the prepared one by the factor $1/m$ per site
+    (Lemma~\ref{lem:paperbnt_block_weight_scaling}), whose matrix-product
+    family therefore carries the factor $m^{-N}$. The conditional supplier
+    of Theorem~\ref{thm:paperbnt_supplier_after_blocking} applies to the
+    normalized weights and gives the BNT canonical form.
+\end{proof}
 
 \section{Coefficient comparison and copy-weight recovery}
 \label{sec:sector_bnt_coeff_comparison}

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1611,14 +1611,11 @@ gives the arbitrary-input statement, conditional on the weight normalization.
 
 \begin{theorem}[Conditional BNT form after blocking for an arbitrary tensor]%
     \label{thm:paperbnt_supplier_after_blocking}
-    \lean{MPSTensor.exists_isBNTCanonicalForm_afterBlocking_pos,
-        MPSTensor.exists_isBNTCanonicalForm_afterBlocking_of_totalDim}
+    \lean{MPSTensor.exists_isBNTCanonicalForm_afterBlocking_pos}
     \leanok
     \uses{thm:prepared_bnt_blocks_after_blocking,
         thm:paperbnt_supplier_prepared,
-        def:same_mpv2,
-        def:same_mpv2_pos,
-        lem:samempv2pos_to_samempv2_of_bonddim_eq}
+        def:same_mpv2_pos}
     Let $A$ be an MPS tensor. Then there exists a blocking length $p \ge 1$,
     nonzero weights $\mu_k$, and blocks $B_k$ over the blocked alphabet, such
     that:
@@ -1632,9 +1629,7 @@ gives the arbitrary-input statement, conditional on the weight normalization.
     Moreover, under $|\mu_k| \le 1$ for every $k$ and $|\mu_k|=1$ for at least
     one $k$, there exists a sector decomposition $P$ over the blocked alphabet in
     the BNT canonical form of Definition~\ref{def:sector_bnt_cf} such that
-    $A^{[p]}$ and $P$ generate the same MPV family at every positive length; the
-    identity upgrades to all lengths once the total bond dimension of $P$ equals
-    that of $A^{[p]}$.
+    $A^{[p]}$ and $P$ generate the same MPV family at every positive length.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1644,10 +1639,8 @@ gives the arbitrary-input statement, conditional on the weight normalization.
     \cite[Section~2.3]{Cirac2016MPDO_arXiv} makes;
     Theorem~\ref{thm:paperbnt_supplier_prepared} then produces the sector
     decomposition, following the BNT selection of
-    \cite[Appendix~A]{Cirac2016MPDO_arXiv}. At length zero the MPV coefficient
-    is the bond dimension, so equal total bond dimensions supply the missing
-    length-zero coefficient. The remaining rescaling step is recorded in
-    Remark~\ref{rem:arbitrary_input_reduction_gap}.
+    \cite[Appendix~A]{Cirac2016MPDO_arXiv}. The remaining rescaling step is
+    recorded in Remark~\ref{rem:arbitrary_input_reduction_gap}.
 \end{proof}
 
 \begin{remark}[Arbitrary-input reduction]%
@@ -1656,12 +1649,9 @@ gives the arbitrary-input statement, conditional on the weight normalization.
     Theorem~\ref{thm:paperbnt_supplier_after_blocking}.
     % Local fix (cpsv16_cf_normalization_and_proportional_comparison): the
     % preparatory blocks (thm:prepared_bnt_blocks_after_blocking) carry no weight
-    % normalization; the all-zero summand contributes only at length zero, so the
-    % nonzero blocks identify the MPV family for N >= 1. The remaining step rescales
+    % normalization. The remaining step rescales
     % the weights to |\mu_k| <= 1 with a unit witness, recorded in
-    % docs/paper-gaps/cpsv16_cf_normalization_and_proportional_comparison.tex; the
-    % length-zero trace identity and the unblocked canonical form remain part of
-    % the reduction in Section~\ref{sec:reduction_to_normal_form}.
+    % docs/paper-gaps/cpsv16_cf_normalization_and_proportional_comparison.tex.
     The weight rescaling is carried out in
     Theorem~\ref{thm:paperbnt_supplier_after_blocking_normalized} below, which
     discharges both hypotheses at the price of one positive scalar per site.
@@ -1692,7 +1682,7 @@ gives the arbitrary-input statement, conditional on the weight normalization.
     weight.
 \end{proof}
 
-\begin{theorem}[Normalized BNT form after blocking for an arbitrary tensor]%
+\begin{theorem}[Normalized BNT form after blocking for a nonzero MPV family]%
     \label{thm:paperbnt_supplier_after_blocking_normalized}
     \lean{MPSTensor.exists_isBNTCanonicalForm_afterBlocking_pos_normalized}
     \leanok
@@ -1700,10 +1690,12 @@ gives the arbitrary-input statement, conditional on the weight normalization.
         thm:paperbnt_supplier_prepared,
         thm:paperbnt_weight_normalization,
         lem:mpv_to_tensor_from_blocks_weight_mul_left,
-        thm:mpv_decomposition}
-    Let $A$ be an MPS tensor whose blocked tensors $A^{[p]}$ generate, for
-    every blocking length $p\geq1$, a matrix-product family that is not
-    identically zero at positive lengths. Then there exist a blocking length
+        thm:mpv_decomposition,
+        thm:newton_girard,
+        lem:eval_word_append,
+        lem:eval_word_block}
+    Let $A$ be an MPS tensor whose matrix-product family has a nonzero
+    coefficient at some positive length. Then there exist a blocking length
     $p\geq1$, a positive real $m$, and a sector decomposition $P$ over the
     blocked alphabet in the BNT canonical form of
     Definition~\ref{def:sector_bnt_cf}, such that for every positive length
@@ -1715,12 +1707,25 @@ gives the arbitrary-input statement, conditional on the weight normalization.
     weight choice; the hypotheses of
     Theorem~\ref{thm:paperbnt_supplier_after_blocking} are discharged rather
     than assumed.
+
+    \textbf{Scope restriction (nonzero MPV family).} The source proposition
+    says ``for any tensor,'' but the zero MPV family cannot supply the global
+    unit-modulus weight imposed immediately before it. The hypothesis above
+    is exactly the exclusion of this degenerate case. This boundary is
+    recorded in
+    \path{docs/paper-gaps/cpsv16_cf_normalization_and_proportional_comparison.tex}.
 \end{theorem}
 
 \begin{proof}\leanok
-    The zero family admits no unit-modulus weight, so the nonvanishing
-    hypothesis produces at least one prepared block. Normalize the prepared
-    weights by their maximal modulus $m$
+    Choose a word $w$ with $\tr(A^w)\neq0$. For every $p\geq1$, there is a
+    $q\geq1$ such that $\tr((A^w)^{pq})\neq0$. Otherwise Newton--Girard applied
+    to $(A^w)^p$ and the zero matrix would show that $(A^w)^p$, and hence
+    $A^w$, is nilpotent, contradicting $\tr(A^w)\neq0$. Repeating $w$ exactly
+    $pq$ times gives a nonzero coefficient of the $p$-blocked tensor. Thus the
+    prepared family at the blocking length supplied by
+    Theorem~\ref{thm:prepared_bnt_blocks_after_blocking} is nonempty.
+
+    Normalize its weights by their maximal modulus $m$
     (Theorem~\ref{thm:paperbnt_weight_normalization}). By the weight-scaling
     identity of
     Lemma~\ref{lem:mpv_to_tensor_from_blocks_weight_mul_left},

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1699,7 +1699,8 @@ gives the arbitrary-input statement, conditional on the weight normalization.
     \uses{thm:prepared_bnt_blocks_after_blocking,
         thm:paperbnt_supplier_prepared,
         lem:paperbnt_weight_normalization,
-        lem:mpv_to_tensor_from_blocks_weight_mul_left}
+        lem:mpv_to_tensor_from_blocks_weight_mul_left,
+        thm:mpv_decomposition}
     Let $A$ be an MPS tensor whose blocked tensors $A^{[p]}$ generate, for
     every blocking length $p\geq1$, a matrix-product family that is not
     identically zero at positive lengths. Then there exist a blocking length

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1672,17 +1672,14 @@ gives the arbitrary-input statement, conditional on the weight normalization.
     \lean{MPSTensor.exists_weight_normalization}
     \leanok
     For nonzero weights $\mu_1,\dots,\mu_r$ with $r\geq1$ there is a positive
-    real $m$ with
+    real $m$ such that every normalized weight satisfies
     \[
-        \Bigl\lVert\frac{\mu_k}{m}\Bigr\rVert\leq1
-        \quad\text{for every }k,
+        \Bigl|\frac{\mu_k}{m}\Bigr|\leq1,
         \qquad
-        \Bigl\lVert\frac{\mu_k}{m}\Bigr\rVert=1
-        \quad\text{for at least one }k,
-        \qquad
-        \frac{\mu_k}{m}\neq0
-        \quad\text{for every }k.
+        \frac{\mu_k}{m}\neq0,
     \]
+    and at least one normalized weight has unit modulus,
+    $|\mu_{k_0}/m|=1$.
     This is the normalization that
     \cite[line~246]{Cirac2016MPDO_arXiv} chooses for the canonical-form
     weights.
@@ -1695,30 +1692,14 @@ gives the arbitrary-input statement, conditional on the weight normalization.
     weight.
 \end{proof}
 
-\begin{lemma}[Weight scaling of the block direct sum]%
-    \label{lem:paperbnt_block_weight_scaling}
-    \lean{MPSTensor.toTensorFromBlocks_weight_mul_left}
-    \leanok
-    \uses{thm:prepared_bnt_blocks_after_blocking}
-    Multiplying every weight of a block direct sum by one scalar $c$
-    multiplies the assembled tensor by $c$:
-    \[
-        \bigoplus_k (c\,\mu_k)\,B_k
-        = c\,\Bigl(\bigoplus_k \mu_k\,B_k\Bigr).
-    \]
-\end{lemma}
-
-\begin{proof}\leanok
-    Both sides scale each diagonal block of the assembled matrix by $c$.
-\end{proof}
-
 \begin{theorem}[Normalized BNT form after blocking for an arbitrary tensor]%
     \label{thm:paperbnt_supplier_after_blocking_normalized}
     \lean{MPSTensor.exists_isBNTCanonicalForm_afterBlocking_pos_normalized}
     \leanok
-    \uses{thm:paperbnt_supplier_after_blocking,
+    \uses{thm:prepared_bnt_blocks_after_blocking,
+        thm:paperbnt_supplier_prepared,
         lem:paperbnt_weight_normalization,
-        lem:paperbnt_block_weight_scaling}
+        lem:mpv_to_tensor_from_blocks_weight_mul_left}
     Let $A$ be an MPS tensor whose blocked tensors $A^{[p]}$ generate, for
     every blocking length $p\geq1$, a matrix-product family that is not
     identically zero at positive lengths. Then there exist a blocking length
@@ -1739,12 +1720,19 @@ gives the arbitrary-input statement, conditional on the weight normalization.
     The zero family admits no unit-modulus weight, so the nonvanishing
     hypothesis produces at least one prepared block. Normalize the prepared
     weights by their maximal modulus $m$
-    (Lemma~\ref{lem:paperbnt_weight_normalization}); the scaled direct sum
-    differs from the prepared one by the factor $1/m$ per site
-    (Lemma~\ref{lem:paperbnt_block_weight_scaling}), whose matrix-product
-    family therefore carries the factor $m^{-N}$. The conditional supplier
-    of Theorem~\ref{thm:paperbnt_supplier_after_blocking} applies to the
-    normalized weights and gives the BNT canonical form.
+    (Lemma~\ref{lem:paperbnt_weight_normalization}). By the weight-scaling
+    identity of
+    Lemma~\ref{lem:mpv_to_tensor_from_blocks_weight_mul_left},
+    \[
+        V^{(N)}\bigl(A^{[p]}\bigr)
+        = V^{(N)}\Bigl(\bigoplus_k \mu_k\,B_k\Bigr)
+        = V^{(N)}\Bigl(\bigoplus_k m\,\frac{\mu_k}{m}\,B_k\Bigr)
+        = m^{N}\,V^{(N)}\Bigl(\bigoplus_k \frac{\mu_k}{m}\,B_k\Bigr)
+        = m^{N}\,V^{(N)}(P),
+    \]
+    where the last identity is the prepared supplier of
+    Theorem~\ref{thm:paperbnt_supplier_prepared} applied to the normalized
+    weights, which gives the BNT canonical form $P$.
 \end{proof}
 
 \section{Coefficient comparison and copy-weight recovery}

--- a/docs/paper-gaps/cpsv16_cf_normalization_and_proportional_comparison.tex
+++ b/docs/paper-gaps/cpsv16_cf_normalization_and_proportional_comparison.tex
@@ -307,7 +307,7 @@ the memo and the source in a single direction, by introducing a
 convergence-to-nonzero-limits hypothesis that has no counterpart in either
 record.
 
-\paragraph{Supplier-side normalization.}
+\paragraph{Status: supplier-side normalization.}
 The arbitrary-input supplier no longer leaves the line-246 weight choice to
 the caller.
 \leanid{MPSTensor.exists\_isBNTCanonicalForm\_afterBlocking\_pos\_normalized}
@@ -326,7 +326,7 @@ single coefficient; it is the exact condition under which every blocking
 admits the unit-modulus weight of the line-246 choice, and it is absent
 from the source, which states the choice for any tensor.
 
-\paragraph{Status as of the paper-realignment PR.}
+\paragraph{Status: structural realignment.}
 The structural realignment has been done. The canonical-form definition now
 carries the source convention $|\mu_1|=1$ as a field
 of \leanid{IsNormalCanonicalFormBNT}, propagated through every constructor.

--- a/docs/paper-gaps/cpsv16_cf_normalization_and_proportional_comparison.tex
+++ b/docs/paper-gaps/cpsv16_cf_normalization_and_proportional_comparison.tex
@@ -312,7 +312,7 @@ The arbitrary-input supplier no longer leaves the line-246 weight choice to
 the caller.
 \leanid{MPSTensor.exists\_isBNTCanonicalForm\_afterBlocking\_pos\_normalized}
 rescales the prepared weights by their maximal modulus
-$m=\max_k\lVert\mu_k\rVert$
+$m=\max_k|\mu_k|$
 (\leanid{MPSTensor.exists\_weight\_normalization}), which satisfies both
 conditional premises of the earlier supplier, and tracks the cost as the
 per-site scalar $m^{N}$ in the positive-length matrix-product identity.  The

--- a/docs/paper-gaps/cpsv16_cf_normalization_and_proportional_comparison.tex
+++ b/docs/paper-gaps/cpsv16_cf_normalization_and_proportional_comparison.tex
@@ -307,6 +307,21 @@ the memo and the source in a single direction, by introducing a
 convergence-to-nonzero-limits hypothesis that has no counterpart in either
 record.
 
+\paragraph{Supplier-side normalization (2026-07-16).}
+The arbitrary-input supplier no longer leaves the line-246 weight choice to
+the caller.
+\leanid{MPSTensor.exists\_isBNTCanonicalForm\_afterBlocking\_pos\_normalized}
+rescales the prepared weights by their maximal modulus
+$m=\max_k\lVert\mu_k\rVert$
+(\leanid{MPSTensor.exists\_weight\_normalization}), which satisfies both
+conditional premises of the earlier supplier, and tracks the cost as the
+per-site scalar $m^{N}$ in the positive-length matrix-product identity.  The
+positive-length statement is the canonical source formulation; the
+length-zero total-dimension identity remains a separate refinement.  The
+nonvanishing hypothesis of the normalized supplier excludes only the
+identically zero matrix-product family, for which the source normalization
+is unsatisfiable.
+
 \paragraph{Status as of the paper-realignment PR.}
 The structural realignment has been done. The canonical-form definition now
 carries the source convention $|\mu_1|=1$ as a field

--- a/docs/paper-gaps/cpsv16_cf_normalization_and_proportional_comparison.tex
+++ b/docs/paper-gaps/cpsv16_cf_normalization_and_proportional_comparison.tex
@@ -316,15 +316,23 @@ $m=\max_k|\mu_k|$
 (\leanid{MPSTensor.exists\_weight\_normalization}), which satisfies both
 conditional premises of the earlier supplier, and tracks the cost as the
 per-site scalar $m^{N}$ in the positive-length matrix-product identity.  The
-positive-length statement is the canonical source formulation; the
-length-zero total-dimension identity remains a separate refinement.  The
-normalized supplier assumes that for every blocking length $p$ the
-$p$-blocked matrix-product family does not vanish identically at positive
-lengths --- equivalently, that the coefficients of $A$ do not vanish on all
-positive multiples of any $p$.  This is stronger than nonvanishing of a
-single coefficient; it is the exact condition under which every blocking
-admits the unit-modulus weight of the line-246 choice, and it is absent
-from the source, which states the choice for any tensor.
+positive-length statement is the canonical source formulation; no
+length-zero coefficient is part of this statement.  The normalized supplier
+assumes exactly that the positive-length matrix-product
+family is nonzero: there are $N\geq1$ and a word $w$ of length $N$ for which
+$\tr(A^w)\neq0$.  This condition persists under every blocking.  For each
+$p\geq1$, some $q\geq1$ satisfies $\tr((A^w)^{pq})\neq0$; otherwise the
+Newton--Girard trace identities would make $(A^w)^p$, and hence $A^w$,
+nilpotent, contrary to its nonzero trace.  The repeated word of length $pqN$
+therefore gives a nonzero coefficient after blocking by $p$.  Thus this
+hypothesis excludes precisely the zero positive-length family, for which the
+unit-modulus weight required at line~246 is impossible.  The subsequent
+proposition nevertheless says ``for any tensor.''  Taken literally, its zero
+case is incompatible with the preceding global unit-modulus convention and
+with the formal canonical-form predicate.  The present theorem therefore
+formalizes the nonzero-family case.  Eliminating the restriction requires a
+separate zero-family clause or a canonical-form predicate whose normalization
+condition is conditional on the presence of a sector.
 
 \paragraph{Status: structural realignment.}
 The structural realignment has been done. The canonical-form definition now

--- a/docs/paper-gaps/cpsv16_cf_normalization_and_proportional_comparison.tex
+++ b/docs/paper-gaps/cpsv16_cf_normalization_and_proportional_comparison.tex
@@ -307,7 +307,7 @@ the memo and the source in a single direction, by introducing a
 convergence-to-nonzero-limits hypothesis that has no counterpart in either
 record.
 
-\paragraph{Supplier-side normalization (2026-07-16).}
+\paragraph{Supplier-side normalization.}
 The arbitrary-input supplier no longer leaves the line-246 weight choice to
 the caller.
 \leanid{MPSTensor.exists\_isBNTCanonicalForm\_afterBlocking\_pos\_normalized}
@@ -318,9 +318,13 @@ conditional premises of the earlier supplier, and tracks the cost as the
 per-site scalar $m^{N}$ in the positive-length matrix-product identity.  The
 positive-length statement is the canonical source formulation; the
 length-zero total-dimension identity remains a separate refinement.  The
-nonvanishing hypothesis of the normalized supplier excludes only the
-identically zero matrix-product family, for which the source normalization
-is unsatisfiable.
+normalized supplier assumes that for every blocking length $p$ the
+$p$-blocked matrix-product family does not vanish identically at positive
+lengths --- equivalently, that the coefficients of $A$ do not vanish on all
+positive multiples of any $p$.  This is stronger than nonvanishing of a
+single coefficient; it is the exact condition under which every blocking
+admits the unit-modulus weight of the line-246 choice, and it is absent
+from the source, which states the choice for any tensor.
 
 \paragraph{Status as of the paper-realignment PR.}
 The structural realignment has been done. The canonical-form definition now


### PR DESCRIPTION
## Summary

This formalizes the weight normalization chosen in arXiv:1606.00608, lines 237–246, for a nonzero positive-length matrix-product family. If

`m = max_k |μ_k|`,

then the weights `μ_k / m` have modulus at most one, at least one has unit modulus, and the discarded scale appears exactly as `m^N` in every positive-length matrix-product coefficient.

The supplier now assumes only that one positive-length coefficient of the original tensor is nonzero. This is the weakest exclusion of the zero MPV family.

## Blocking argument

The new auxiliary argument proves that this single nonzero coefficient remains visible after every positive physical blocking. Choose a word with evaluated matrix `M` and `tr(M) ≠ 0`. For each `p ≥ 1`, some `q ≥ 1` satisfies

`tr(M^(p q)) ≠ 0`.

Otherwise all positive power traces of `M^p` vanish. Newton–Girard then identifies its characteristic polynomial with that of the zero matrix, so `M^p`, and hence `M`, is nilpotent, contradicting `tr(M) ≠ 0`. Repeating the word `p q` times gives a nonzero coefficient of the `p`-blocked tensor at the positive blocked length `N q`.

## Source scope

The source proposition says “for any tensor,” while the immediately preceding normalization convention requires a unit-modulus weight. The zero MPV family cannot satisfy that requirement. The theorem therefore states the nonzero-family case and carries the required scope-restriction marker, with the discrepancy recorded in `docs/paper-gaps/cpsv16_cf_normalization_and_proportional_comparison.tex`.

No length-zero coefficient or total-bond-dimension identity is part of the source-facing statement. Chapter 10 and the paper-gap note were cleaned accordingly. The low-level zero-family boundary can only be removed by a separate zero-family clause or by making the unit-modulus condition conditional on the presence of a sector.

No global positive-bond-dimension assumption is added: when `D = 0`, the nonzero-trace hypothesis is impossible, so the theorem is vacuous there.

## Verification

At exact head `5396b0b70b0e62a7e27eb13e759cfc6f8576a2a8` on Lean 4.32:

- `lake build TNLean` passes (9,533 targets);
- blueprint web generation, declaration checks, synchronization, prose checks, and the 602-page PDF pass;
- both new public theorems depend only on `propext`, `Classical.choice`, and `Quot.sound`;
- no `sorry`, axiom, or proof bypass is introduced.

Issue: #1753. Parent tracker: #3953.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization and documentation on the BNT supplier path; no runtime, auth, or data-layer changes, with logic reused from existing prepared-block and scaling lemmas.
> 
> **Overview**
> Formalizes the arXiv:1606.00608 line-246 weight convention inside the SectorBNT supplier pipeline instead of leaving it as caller hypotheses.
> 
> **Lean:** New module `SupplierNormalized.lean` (wired from `TNLean.lean`) proves `exists_weight_normalization` (divide weights by `m = max_k |μ_k|`) and `exists_isBNTCanonicalForm_afterBlocking_pos_normalized`, which chains prepared blocks after blocking with that rescaling and records the discarded factor as **`m^N`** on positive-length MPV coefficients via existing `mpv_toTensorFromBlocks_weight_mul_left`. Supporting lemmas use Newton–Girard / nilpotency to show a single nonzero positive-length MPV coefficient survives blocking.
> 
> **Blueprint:** Chapter 10 adds theorems for projective weight normalization and the normalized after-blocking supplier; the conditional arbitrary-tensor theorem drops the length-zero / equal total-dimension upgrade and points the normalization gap to the new result.
> 
> **Docs:** `cpsv16_cf_normalization_and_proportional_comparison.tex` documents supplier-side normalization and the **nonzero MPV family** scope boundary (zero family vs. unit-modulus weights).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5396b0b70b0e62a7e27eb13e759cfc6f8576a2a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->