### PR TITLE
doc(tenkz): manual second edition — Tufte layout, formula-first

### DIFF
--- a/docs/tenkz/chapters2/ch-house.tex
+++ b/docs/tenkz/chapters2/ch-house.tex
@@ -1,0 +1,315 @@
+% chapters2/ch-house.tex — the house style: the closed glyph dictionary,
+% live over one source; the hue table in the package's own ink; the
+% label and ellipsis doctrines; the canonical spellings; and the
+% geometry appendix transcribed from the constants of
+% tenkz-core.code.tex.
+%
+% Sources: the corrected atoms corpus (atoms_test.tex) for the skins,
+% channel_test.tex for the canonical channel spelling, and the ratio
+% comments of tenkz-core.code.tex for the geometry table.
+
+% live hue chips for the table in \S(house-hues): each chip is filled
+% from the package's colour register, so a \colorlet theme re-inks the
+% table together with every picture in the manual
+\providecommand{\huechip}[1]{{\setlength{\fboxsep}{0pt}%
+  \fcolorbox{black!25}{#1}{\rule{0pt}{1.4ex}\rule{2.0em}{0pt}}}}
+
+\section{The house style}\label{ch:house}
+
+Every diagram in a document should read as the work of one hand, and
+this chapter states the hand: a closed dictionary of glyphs, a closed
+table of hues, a reserved band for every label, one spelling for every
+recurring object, and a geometry in which every constant is a named,
+motivated ratio of the one pitch.  Little of this is enforceable ink
+by ink --- the package cannot know that a document has drawn the same
+channel two different ways --- so the doctrine is stated here once,
+and the rest of the manual obeys it.
+
+% ---------------------------------------------------------------------
+\subsection{The glyph dictionary}\label{sec:house-glyphs}
+
+A glyph asserts what its tensor is.  A filled bead or an outlined box
+is a \emph{site tensor} --- which of the two is the document's glyph
+policy, one school per document (\S\ref{sec:modes-glyph}); a
+\tnval{pill} is a blocked or wide tensor, growing sideways to hold
+its label and never taller; a chirality triangle (\tnkey{tri=l},
+\tnkey{tri=r}) is a canonical-form isometry; a capsule on the wire
+(\tncmd{tnX}) is a matrix with no physical index; a wedge
+(\tncmd{tnfuse}) changes arity.  The dictionary is closed: braces,
+cuts, and region outlines are annotation ink
+(Example~\ref{ex:ref-annot}), and annotation never carries an index.
+
+\begin{tnmultiples}[
+    caption  = {one tensor, five skins},
+    formula  = {(A^{i})_{\alpha\beta}},
+    index    = {Every panel is the same one-site tensor: one west
+                stub, one east stub, one up leg, five identical
+                signature lines.  The skin is an assertion about the
+                tensor --- a \tnval{pill} claims a blocking, a
+                triangle claims an isometry --- and the event stream
+                records the resolved skin, \tnlogline{kind=dot}
+                through \tnlogline{kind=trir}.},
+    signature = {boundary|virtual-west=1|virtual-east=1|physical-up=1|physical-down=0},
+    variants = {{dot}{}, {box}{box}, {pill}{pill},
+                {tri=l}{tri=l}, {tri=r}{tri=r}},
+    label    = {ex:house-skins},
+  ]
+% one tensor, five skins: the ink changes, the indices do
+% not -- all five panels log one identical boundary line
+\begin{tenkz}[physical=up]
+  \tn[variant, up=$i$]{A}
+\end{tenkz}
+\end{tnmultiples}
+
+Two glyphs are missing from Example~\ref{ex:house-skins} because they
+are commands, not skins: no key may change how many open indices a
+picture has, and the capsule and the wedge do.  \tncmd{tnX} rides the
+wire without adding a leg (the gauge of Example~\ref{ex:gauge-eq},
+tall across a sandwich in Example~\ref{ex:ref-tallx});
+\tncmd{tnfuse} consumes its side's boundary pair and leaves one
+combined stub (Example~\ref{ex:tut-fuse}).  The sixth skin,
+\tnval{mpo}, is the box skin under another name: an operator site
+shows as an inscribed box even on a dot-school page
+(Example~\ref{ex:modes-schools}), and the event stream records
+\tnlogline{kind=mpo}, so operator sites stay distinguishable from
+state sites wherever the ink alone could not tell them apart.
+
+One school per document.  The package default, and this manual's, is
+the dot school: beads keep pictures light where diagrams stand inside
+running mathematics, and the review literature that \S\ref{ch:rmp}
+reproduces is drawn in it.  Choose the box school when a document's
+sites carry long or scripted names --- $T_g$, $A^{(2)}$,
+$\overline{B}$ --- because an inscribed label owns its glyph, while a
+bead's outside label must fit a quadrant band.  The choice is one
+\tncmd{tnset} line in the preamble, not an edit to any picture
+(\S\ref{sec:ref-policy}); switch per picture only to reproduce a
+source figure drawn in the other school, as \S\ref{ch:rmp} does.
+
+% ---------------------------------------------------------------------
+\subsection{The hues}\label{sec:house-hues}
+
+Hue is semantics, never decoration.  Structural ink --- tensors,
+bonds, legs, cups --- is \tnval{tenkzInk}; everything that departs
+from it makes a claim, and the claims are few enough for one table.
+The chips below are filled from the package's own colour registers,
+so the table is live: rebind a name with \verb|\colorlet| and it
+re-inks itself along with every picture in the manual.
+
+\medskip
+{\footnotesize
+\noindent\begin{tabularx}{\linewidth}{@{}lll>{\raggedright\arraybackslash}X@{}}
+\toprule
+ & Hue & Binding & Claim \\
+\midrule
+\huechip{tenkzInk} & \texttt{tenkzInk} & \texttt{black!92} &
+  structural ink: tensors, bonds, legs, cups (every example) \\
+\huechip{tenkzPaper} & \texttt{tenkzPaper} & \texttt{white} &
+  the page's stand-in: the fill of outlined glyphs, the gap of the
+  doubled (fused) wire \\
+\huechip{tenkzPassive} & \texttt{tenkzPassive} & \texttt{black!55} &
+  de-emphasis: cuts, removed sites, complement regions
+  (Example~\ref{ex:ref-annot}) \\
+\huechip{tenkzAction} & \texttt{tenkzAction} & \texttt{red!65!black} &
+  the act: a matrix riding the wire (Example~\ref{ex:gauge-eq}), the
+  selected region, the distinguished edge \\
+\huechip{tenkzMarked} & \texttt{tenkzMarked} & \texttt{blue!65!black} &
+  secondary emphasis and regions; this manual's command ink \\
+\huechip{tenkzExtra} & \texttt{tenkzExtra} & \texttt{violet!65!black} &
+  tertiary structure, the collar region; this manual's key ink \\
+\huechip{tenkzOperator} & \texttt{tenkzOperator} & \texttt{red!80!black} &
+  the wire of an operator layer (the \tnval{:operator} row modifier,
+  Example~\ref{ex:worked-mpoprod}) \\
+\bottomrule
+\end{tabularx}\par}
+\medskip
+
+Two rules police the table.  A hue never distinguishes two objects of
+the same kind: two different tensors differ by label, never by
+colour.  And structural ink stays \tnval{tenkzInk}: a picture whose
+bonds come out red has claimed its bonds are operator wires, not
+decorated them.  A theme may rebind the colours and nothing
+else.\sidenote{The binding site is
+\tnfile{tenkz-core.code.tex}: ``semantic hues (a theme may rebind
+colours, nothing else)''.  One line,
+\texttt{\textbackslash colorlet\{tenkzAction\}}%
+\allowbreak\texttt{\{orange!70!black\}}, restyles every acting
+matrix in a document at once.}
+
+% ---------------------------------------------------------------------
+\subsection{Label bands and the ellipsis}\label{sec:house-labels}
+
+Labels never overlap ink, by construction.  Every label site is a
+reserved band derived from the metric of
+\S\ref{sec:house-geometry}: a leg-tip label sits one clearance
+($0.12$ pitch) beyond its leg; a bead's name takes a free quadrant of
+the $0.30$-pitch dot band, chosen by the auto-quadrant algorithm; a
+boundary label sits one clearance beyond the stub tip; a bond label
+sits in the band the legs were sized to clear --- legs $0.38$ against
+stubs $0.45$.  Two labels may not share a band, and no label may
+touch structural ink.  When geometry defeats the default bands ---
+facing legs in one inter-layer gap --- the fix is the band-restoring
+key, \tnkey{layer sep=} (Example~\ref{ex:layer-sep}), never a
+hand-nudged coordinate; \tnkey{label pos=} and \tnkey{label shift=}
+exist for the residue and should be rare.
+
+The ellipsis has one spelling: \tncmd{tndots} elides sites, its wires
+pass through without closing, and the drawn leg count under an
+ellipsis is schematic --- the caption or margin states the true arity
+(Example~\ref{ex:tut-block}).  Its look-alikes are not elisions.
+\tncmd{tnskip} is a hole: the tensor deleted, its indices
+deliberately open (Example~\ref{ex:hole}).  An unnamed bead
+\tncmd{tn}\tnval{\{\}} is an anonymous tensor --- legitimate where
+the margin names the row once for all, as in
+Example~\ref{ex:layer-sep}, and wrong as a counterfeit ellipsis,
+because an anonymous tensor is still a tensor.
+
+% ---------------------------------------------------------------------
+\subsection{The canonical spellings}\label{sec:house-spellings}
+
+The strongest uniformity device is the fixed spelling: one recurring
+object, one option list, learned once and recognised by silhouette
+ever after.  Four spellings are canon; each row of the table is the
+exact source of its cited example.
+
+\medskip
+{\footnotesize
+\noindent\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}p{31mm}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}p{19mm}@{}}
+\toprule
+Object & Spelling & Lives at \\
+\midrule
+transfer map, unapplied\newline
+  $\mathcal{E}_A=\sum_i A^{i}\otimes\overline{A^{i}}$ &
+  \tnval{[sandwich]} over \tncmd{tn}\tnval{\{A\}},
+  \tncmd{tn*}\tnval{\{A\}}: a map on the doubled space, so all four
+  stubs stay open &
+  Example~\ref{ex:transfer-open} \\
+\addlinespace
+channel, applied\newline
+  $\mathcal{E}_A(X)=\sum_i A^{i}XA^{i\dagger}$ &
+  \tnval{[sandwich, east=\{cup=$X$\}]}: the east cup consumes the
+  input slot; the west pair stays open --- the output is a matrix &
+  Example~\ref{ex:channel-x} \\
+\addlinespace
+gauge equation\newline
+  $B^{i}=XA^{i}X^{-1}$ &
+  \tncmd{tnX}\tnval{\{X\}} and \tncmd{tnX}\tnval{\{$X^{-1}$\}}
+  riding the wire around the site; \tnval{physical=up} on both
+  sides, so the signatures agree &
+  Example~\ref{ex:gauge-eq} \\
+\addlinespace
+blocking\newline
+  $\bigl(A^{(L)}\bigr)^{i_1\cdots i_L}=A^{i_1}\!\cdots A^{i_L}$ &
+  \tncmd{tnspan}\tnval{[brace below]} and \tncmd{tndots} across the
+  word; one \tnval{[pill, wide=2]} glyph carrying the blocked index
+  on the right &
+  Example~\ref{ex:tut-block} \\
+\bottomrule
+\end{tabularx}\par}
+\medskip
+
+Two lesser canons ride along: the trace is spelled \tnkey{periodic}
+--- a hand-drawn return wire is not a trace --- and a genuinely
+closed object is sealed by \tnkey{boundary=none}, an assertion about
+the object, not a tidier drawing (\S\ref{sec:stubs}).  Never seal the
+west pair of an applied channel: that spells
+$\operatorname{Tr}\mathcal{E}_A(X)$, a different object.
+
+% ---------------------------------------------------------------------
+\subsection{The geometry appendix}\label{sec:house-geometry}
+
+One base pitch, $11$\,mm by default; every repeated distance is a
+named ratio of it, and the two profiles are scale factors applied at
+the base, so no literal can bypass them.\sidenote{The doctrine
+comment of \tnfile{tenkz-core.code.tex}: ``ONE base pitch; every
+repeated distance is a named ratio of it.  Profiles (compact,
+inline) are a scale factor applied at the base, so no literal can
+bypass them.''  \S\ref{sec:modes-metric} varies and measures the
+system.}  The package states each ratio's motivation once, in a
+comment beside its definition; this table transcribes those
+comments, so the design argument is on the record where a reader can
+dispute it.
+
+% the table is set as three group-tables so a page may break between
+% the groups; each repeats the head row
+\medskip
+{\footnotesize
+\noindent\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}p{26mm}p{10mm}>{\raggedright\arraybackslash}X@{}}
+\toprule
+Constant & Value & Motivation \\
+\midrule
+\multicolumn{3}{@{}l}{\emph{the base and its profiles}} \\
+base pitch & $11$\,mm & the one length; every ratio below
+  multiplies it \\
+\texttt{compact} & $\times0.8$ & the one sanctioned tighter metric
+  --- prefer it to hand-tuned pitches \\
+\texttt{inline} & $\times0.62$ & buys back the line height a picture
+  needs inside a sentence; also rebinds the two inline ratios below
+  and drops labels one script size \\
+\bottomrule
+\end{tabularx}\par}
+\smallskip
+{\footnotesize
+\noindent\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}p{26mm}p{10mm}>{\raggedright\arraybackslash}X@{}}
+\multicolumn{3}{@{}l}{\emph{ratios of the pitch}} \\
+\midrule
+layer gap & $0.80$ & layers read as layers, not as two chains \\
+physical leg & $0.38$ & a labelled leg clears the bond-label band \\
+stub & $0.45$ & an open index: longer than a leg, shorter than a
+  bond; also the reach of an inter-layer cup, so open and cup-closed
+  ends share one silhouette \\
+trace clearance & $0.62$ & the trace racetrack clears the leg labels
+  on the outer row \\
+label clearance & $0.12$ & the one clearance of every label band \\
+dot-label band & $0.30$ & the depth of a script-size dot label:
+  clearance plus text \\
+bead diameter & $0.16$ & the dot school's tensor mark \\
+\end{tabularx}\par}
+% ruleless seam: the group continues; a page may break here
+{\footnotesize
+\noindent\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}p{26mm}p{10mm}>{\raggedright\arraybackslash}X@{}}
+gate overshoot & $0.34$ & a \tnval{wires=$k$} glyph overshoots its
+  outer wire rows: the gate must visibly cover the wires it
+  terminates \\
+physical-trace reach & $0.24$ & how far east of the glyph edge the
+  per-site physical trace swings: past the glyph, yet inside the
+  bond span to the next site \\
+pair-trace reach & $0.40$ & the per-column racetrack's reach east of
+  the leg axis: under one half, so its straight clears the
+  neighbouring column's bands; wide enough that the racetrack caps
+  read as turnarounds, not kinks \\
+region margin & $0.36$ & under half a pitch, so notches read; over
+  the glyph radius \\
+corner radius & $0.14$ & the rounding of traces and hulls \\
+inline leg & $0.26$ & the inline profile shrinks legs faster than
+  the pitch \\
+inline clearance & $0.05$ & inline labels hug the ink to spare line
+  height \\
+\bottomrule
+\end{tabularx}\par}
+\smallskip
+{\footnotesize
+\noindent\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}p{26mm}p{10mm}>{\raggedright\arraybackslash}X@{}}
+\multicolumn{3}{@{}l}{\emph{absolute floors and the ink hierarchy}} \\
+\midrule
+annotation width & $0.40$\,pt & annotation strokes sit under wires:
+  a cut is never confusable with a bond \\
+wire width & $0.55$\,pt & the bond stroke, the reference width of
+  the hierarchy \\
+emphasis width & $0.80$\,pt & region outlines and distinguished
+  edges sit over wires \\
+junction floor & $0.9$\,mm & below about three wire widths a
+  junction reads as dirt \\
+\bottomrule
+\end{tabularx}\par}
+\medskip
+
+The house style ends where it began, with one hand.  Everything
+semantic goes through the key space ---
+\tncmd{tnset}\tnval{\{tensor style=box, pitch=10mm\}} in a preamble
+retunes a whole paper --- and everything cosmetic through
+\verb|\colorlet| on the hue names and \verb|\tikzset| on the named
+styles: \tnval{tensor}, \tnval{box tensor}, \tnval{on-wire matrix},
+\tnval{bond}, \tnval{operator bond}, \tnval{cut}, \tnval{brace}.
+A document that respects the two channels can be re-skinned without
+touching one picture body; a document that restyles by editing
+picture bodies has left the house.

--- a/docs/tenkz/chapters2/ch-mathematics.tex
+++ b/docs/tenkz/chapters2/ch-mathematics.tex
@@ -1,0 +1,292 @@
+% chapters2/ch2-mathematics.tex — the mathematics of the pictures.
+%
+% The semantics chapter: every piece of tenkz ink is assigned its
+% mathematical meaning before the tutorial teaches any drawing.
+% Diagrams are adapted from the v0.5 acceptance corpus
+% (boundary_test, cups_test, channel_test, atoms_test); the
+% reading-order convention follows arXiv:1804.04964, the arrow
+% semantics follow the RMP figures (arXiv:2011.12127).
+\section{The mathematics of the pictures}\label{ch:mathematics}
+
+A \pkg{} picture denotes a tensor, and the denotation is fixed by a
+short dictionary: ink that protrudes is an index left open; ink that
+closes is an index summed over.  This chapter states the dictionary
+once --- stubs, boundary signatures, traces against cups, the
+conjugate layer, directed bonds --- and every later chapter points
+back to it.  One object runs through the
+chapter, the quantum channel $\mathcal{E}_A$, because the channel
+exercises every entry of the dictionary.
+
+% ---------------------------------------------------------------------
+\subsection{An open index is protruding ink}\label{sec:stubs}
+
+A $D\times D$ matrix has a row index and a column index, and its
+picture must show them: \pkg{} draws each open virtual index as a stub
+protruding from the end of its wire, and stubs are the default.  A
+matrix product must look like a matrix.  Stubs can be named at their
+tips with \tnkey{west label} and \tnkey{east label}:
+
+\begin{tnexample}[
+    formula   = {(B^{i})_{\alpha\beta}},
+    caption   = {a matrix shows its indices},
+    index     = {Three protruding ends, three indices: the west and
+                 east stubs are the matrix indices $\alpha$ and
+                 $\beta$; the up leg is the physical index $i$.},
+    signature = {boundary|virtual-west=1|virtual-east=1|physical-up=1|physical-down=0},
+    label     = {ex:stub-matrix},
+  ]
+% (B^i)_{alpha beta}: one matrix for each physical index i;
+% the stubs are the matrix indices, named at their tips
+\begin{tenkz}[physical=up, west label=$\alpha$,
+              east label=$\beta$]
+  \tn[up=$i$]{B}
+\end{tenkz}
+\end{tnexample}
+
+The dictionary cuts both ways: a picture with \emph{no} open legs
+denotes a scalar --- never a matrix, never a state.  Sealing the ends
+of a row is therefore an assertion about the object, not a tidier
+drawing, and \tnkey{boundary=none} is the deliberate opt-in for
+objects that are closed.\sidenote{\tnkey{boundary=open} became
+the default in \pkg{}~0.5; bare chains used to render sealed.  The
+flip removed a class of wrong pictures: transfer maps drawn as
+scalars, gauge equations whose left-hand sides were vectors.}
+
+% ---------------------------------------------------------------------
+\subsection{Boundary signatures}\label{sec:signatures}
+
+Counting open ends decides what kind of object a picture denotes, so
+\pkg{} counts them on every compile.  Each picture appends its
+\emph{boundary signature} to the \tnfile{.tnlog} event stream beside
+the PDF: the number of open virtual indices at the west and at the
+east side, and the number of open physical legs pointing up and
+down.\sidenote{The signature is the last of a picture's
+\tnfile{.tnlog} events, after its \tnlogline{atom}, \tnlogline{bond},
+\tnlogline{cup}, and \tnlogline{trace} lines.  The margin of each
+example in this chapter quotes the signature line the picture
+writes.}  Two pictures may stand on the two sides of an equals sign
+only if their signatures agree --- an equality between a matrix and a
+scalar is not a false equation but a malformed one.  The gauge
+transformation is the canonical well-formed example:
+
+\begin{tnexample}[
+    formula   = {B^{i} = X A^{i} X^{-1}},
+    caption   = {a well-formed gauge equation},
+    index     = {The \tncmd{tnX} capsules are matrices riding the
+                 wire, not sites: they add no legs.  Each side exposes
+                 one west stub, one east stub, one up leg, so both
+                 pictures write the same signature line.},
+    signature = {boundary|virtual-west=1|virtual-east=1|physical-up=1|physical-down=0},
+    label     = {ex:gauge-eq},
+  ]
+% B^i = X A^i X^{-1}: both sides expose one west stub, one
+% east stub, one physical leg -- the signatures agree
+\[
+  \begin{tenkz}[physical=up]
+    \tn[up=$i$]{B}
+  \end{tenkz}
+  \;=\;
+  \begin{tenkz}[physical=up]
+    \tnX{X} & \tn[up=$i$]{A} & \tnX{X^{-1}}
+  \end{tenkz}
+\]
+\end{tnexample}
+
+Delete \tnval{physical=up} from one side of Example~\ref{ex:gauge-eq},
+or seal one side's boundary, and the two signature lines diverge; a
+referee --- human or script --- compares the two lines instead of
+squinting at ink.  Matching signatures are necessary, not sufficient:
+they count open ends but do not name them.  The counting half is the
+half a machine checks.
+
+% ---------------------------------------------------------------------
+\subsection{Two closures: the trace and the cup}\label{sec:trace-cup}
+
+Two different pieces of ink close an index, and they are not
+interchangeable.  \tnkey{periodic} closes a row \emph{to itself}: the
+east end of the wire returns to the west end, which is the trace over
+that row's virtual space.
+
+\begin{tnexample}[
+    formula   = {\operatorname{Tr}(A^{i}B^{j})},
+    caption   = {the trace: a row closed to itself},
+    index     = {The return wire re-enters the row it left, so no
+                 virtual stub survives.  The physical stubs do: the
+                 picture is one number for each pair $i,j$.},
+    signature = {boundary|virtual-west=0|virtual-east=0|physical-up=2|physical-down=0},
+    label     = {ex:trace-row},
+  ]
+% Tr(A^i B^j): periodic returns the row's east end to its
+% west end -- the virtual index is summed, i and j stay open
+\begin{tenkz}[periodic, physical=up]
+  \tn[up=$i$]{A} & \tn[up=$j$]{B}
+\end{tenkz}
+\end{tnexample}
+
+\tnkey{west=cup} and \tnkey{east=cup} close a row \emph{into its
+neighbour}: on the closed side, the ends of two adjacent rows are bent
+into one continuous wire.  That is the contraction tying a ket layer
+to its bra layer --- the topology of orthonormality conditions, fixed
+points, and expectation values --- and it is not a trace:
+
+\begin{tnexample}[
+    formula   = {\sum_s (A_L^{s})^{\dagger} A_L^{s} = 1},
+    caption   = {the cup: a layer closed into its neighbour},
+    index     = {\tnkey{west=cup} bends the ket wire into the bra
+                 wire, summing the shared left index; the sandwich
+                 pairing sums $s$.  The right-hand side is the bare
+                 cup: the identity on the open east pair.  Both sides
+                 write the same signature line.},
+    signature = {boundary|virtual-west=0|virtual-east=2|physical-up=0|physical-down=0},
+    label     = {ex:ortho-cup},
+  ]
+% sum_s (A_L^s)^dagger A_L^s = 1 : the sandwich sums the
+% physical index s; west=cup ties ket to bra on the left;
+% the bare cup on the right is the identity on the east pair
+\[
+  \begin{tenkz}[sandwich, west=cup]
+    \tn{A_L}\\
+    \tn*{A_L}
+  \end{tenkz}
+  \;=\;
+  \begin{tenkz}[rows={wire,wire}, west=cup]
+    \tnghost{}\\
+    \tnghost{}
+  \end{tenkz}
+\]
+\end{tnexample}
+
+Row to self against row to row: the trace is a racetrack around one
+row, the cup a bend between two.  The bare cup on the right of
+Example~\ref{ex:ortho-cup} is drawn over \tnval{rows=\{wire,wire\}}
+with \tncmd{tnghost} cells, so the bend has wires to tie.  A cup can
+also carry a matrix on its apex, as in \tnkey{close
+east=\{$\rho^R$\}}; the fixed-point and density-matrix diagrams of
+\S\ref{ch:rmp} live on that key.
+
+% ---------------------------------------------------------------------
+\subsection{The conjugate layer}\label{sec:conjugate}
+
+The starred cell \tncmd{tn*} denotes the complex conjugate
+$\overline{A}$, and its label is overlined automatically.  Layer order
+is part of the meaning: rows are read top to bottom, ket above bra,
+and \tnkey{sandwich} abbreviates \tnval{rows=\{ket, bra\}}, pairing
+the physical legs site by site.  The two-layer object built this way
+is the transfer map:
+
+\begin{tnexample}[
+    formula   = {\mathcal{E}_A = \sum_i A^{i}\otimes\overline{A^{i}}},
+    caption   = {the transfer map, unapplied},
+    index     = {Four stubs: the east pair is the input slot, the
+                 west pair the output --- as for any matrix, whose
+                 column index is contracted on multiplication and
+                 whose row index survives.  A map on the doubled
+                 virtual space is a matrix, and the picture keeps a
+                 matrix's worth of open ends.},
+    signature = {boundary|virtual-west=2|virtual-east=2|physical-up=0|physical-down=0},
+    label     = {ex:transfer-open},
+  ]
+% E_A = sum_i A^i (x) conj(A^i): a map on the doubled
+% virtual space, so all four virtual legs stay open
+\begin{tenkz}[sandwich]
+  \tn{A} \\
+  \tn*{A}
+\end{tenkz}
+\end{tnexample}
+
+No dagger is ever drawn.\sidenote{arXiv:1804.04964: ``the virtual
+bonds of the tensors $A_i$ read from left to right, thus the loops
+\dots\ read clockwise; hence the transpose.''}  The formula
+$\mathcal{E}_A(X)=\sum_i A^i X A^{i\dagger}$ contains a conjugate
+transpose, but the picture contains only the conjugate.  The star is
+ink; the transpose is reading order: a \pkg{} picture reads left to
+right, and a wire traversed against the reading direction contributes
+its matrix transposed.  The convention is document-level: stated
+once, never drawn.  It is the convention of arXiv:1804.04964, whose
+figures are arrow-free and whose only transpose bookkeeping is a
+footnote.
+
+\begin{tnexample}[
+    formula   = {\mathcal{E}_A(X) = \sum_i A^{i} X A^{i\dagger}},
+    caption   = {the channel applied to $X$},
+    index     = {$X$ rides the east cup: the input slot is consumed
+                 and virtual-east drops to $0$.  The west pair stays
+                 open --- the output is a matrix.  The vertical wire
+                 is the summed physical index $i$.  Read around the
+                 bend: $A^i$ west to east, then $X$, then the bra
+                 wire back --- $A^i X A^{i\dagger}$ in the order
+                 written.},
+    signature = {boundary|virtual-west=2|virtual-east=0|physical-up=0|physical-down=0},
+    label     = {ex:channel-x},
+  ]
+% E_A(X) = sum_i A^i X (A^i)^dagger : X rides the east cup
+% (the input); the west pair stays open (the output is a
+% matrix); the dagger is the star plus the transpose from
+% traversing the bra wire against the reading order
+\begin{tenkz}[sandwich, east={cup=$X$}]
+  \tn{A} \\
+  \tn*{A}
+\end{tenkz}
+\end{tnexample}
+
+Together, Examples \ref{ex:transfer-open} and \ref{ex:channel-x} give
+the manual's canonical channel spelling, previewed as
+Example~\ref{ex:channel-applied}: the unapplied map is
+\tnval{[sandwich]} --- four stubs, a matrix on the doubled space ---
+and the applied map adds \tnval{east=\{cup=$X$\}} and nothing else,
+consuming the input slot alone.  The input is the east cup because
+the input of a matrix is its column index: the west cup instead
+contracts the row indices and applies the adjoint map
+$\mathcal{E}_A^{*}(X)=\sum_i A^{i\dagger}XA^{i}$ ---
+Example~\ref{ex:ortho-cup} is exactly
+$\mathcal{E}_A^{*}(\mathbf{1})=\mathbf{1}$ for a left-canonical
+tensor.  Never seal the west pair of the applied channel: closing it
+too would turn the picture into $\operatorname{Tr}\mathcal{E}_A(X)$,
+a scalar.
+
+% ---------------------------------------------------------------------
+\subsection{Directed bonds}\label{sec:directed}
+
+Most bonds need no direction.  When the distinction between a space
+$V$ and its dual $V^{*}$ carries the mathematics --- representation
+flow along the virtual line of a symmetric MPO --- the bond takes an
+arrow: out of a tensor the leg carries $V$, into a tensor $V^{*}$,
+and a contraction joins an out to an in.  Reversing an arrow is
+mathematics, not decoration: it replaces the representation carried by
+the bond with its dual --- for a group representation, the inverse.
+
+\begin{tnmultiples}[
+    caption  = {one bond, three directions},
+    formula  = {A^{i}A^{j}},
+    index    = {The barb sits mid-bond.  Out of a tensor the leg
+                carries $V$; into a tensor, $V^{*}$.  The reversed
+                arrow is the dual (inverse) representation.  Boundary
+                signatures do not yet record direction; see
+                \S\ref{ch:trouble}.},
+    variants = {{undirected}{},
+                {bond dir=right}{bond dir=right},
+                {bond dir=left}{bond dir=left}},
+    label    = {ex:bond-dir},
+  ]
+% arrow out of a tensor = V, arrow in = V*;
+% reversing the arrow = the dual (inverse) representation
+\begin{tenkz}[physical=up, variant]
+  \tn[up=$i$]{A} & \tn[up=$j$]{A}
+\end{tenkz}
+\end{tnmultiples}
+
+The whole picture takes \tnkey{bond dir=right} or \tnval{left}; a
+single row takes the \tnkey{rows=} modifier \tnval{dir right} or
+\tnval{dir left}; a single join in free placement takes
+\tncmd{tnjoin}\tnval{[dir]}, whose argument order gives the
+direction.  On a \tnkey{periodic} ring the barb rides the return wire.
+
+Direction, chirality, and reading order are three devices with three
+jobs, and only the first takes arrows.  Draw arrows when the bond
+itself is directed; they survive rotation and reflection, where
+positional conventions die.  Use the chirality of a glyph ---
+\tnkey{tri=l} against \tnkey{tri=r}, the side a fusion bar combines
+toward --- when the object, not the bond, has an orientation: an
+isometry's domain and codomain need no arrows.  Leave everything else
+to reading order, the arrow-free regime of \S\ref{sec:conjugate}:
+left to right on the page, transposes in the text, no ink.

--- a/docs/tenkz/chapters2/ch-mathematics.tex
+++ b/docs/tenkz/chapters2/ch-mathematics.tex
@@ -1,4 +1,4 @@
-% chapters2/ch2-mathematics.tex — the mathematics of the pictures.
+% chapters2/ch-mathematics.tex — the mathematics of the pictures.
 %
 % The semantics chapter: every piece of tenkz ink is assigned its
 % mathematical meaning before the tutorial teaches any drawing.
@@ -160,9 +160,9 @@ Row to self against row to row: the trace is a racetrack around one
 row, the cup a bend between two.  The bare cup on the right of
 Example~\ref{ex:ortho-cup} is drawn over \tnval{rows=\{wire,wire\}}
 with \tncmd{tnghost} cells, so the bend has wires to tie.  A cup can
-also carry a matrix on its apex, as in \tnkey{close
-east=\{$\rho^R$\}}; the fixed-point and density-matrix diagrams of
-\S\ref{ch:rmp} live on that key.
+also carry a matrix on its apex, as in
+\tnkey{east=\{cup=$\rho^R$\}}; the fixed-point and density-matrix
+diagrams of \S\ref{ch:rmp} live on that key.
 
 % ---------------------------------------------------------------------
 \subsection{The conjugate layer}\label{sec:conjugate}

--- a/docs/tenkz/chapters2/ch-modes.tex
+++ b/docs/tenkz/chapters2/ch-modes.tex
@@ -1,0 +1,154 @@
+% chapters2/ch-modes.tex — tensor styles and small multiples: the glyph
+% policy (dot|box) varied over one source, the metric profiles in one
+% aligned row, and the uniform-height doctrine of the glyph strut.
+%
+% Sources: the corrected modes corpus (modes_test.tex / modes_suite.tex):
+% the ket/op/bra window under both policies, the two-site word under the
+% metric profiles, and the T_g/T_h double MPO row.
+\section{Modes and small multiples}\label{ch:modes}
+
+A mode is a policy, not a drawing decision.  One glyph policy per
+scope decides how every unadorned tensor renders; one base pitch,
+scaled by named profiles, sets every distance on the page.  A mode
+changes ink and nothing else: however a picture is skinned or scaled,
+its atoms contract the same indices, and every gallery in this chapter
+writes one boundary line per panel, all identical.  Because a mode's
+whole content is a visual difference, each is shown as small multiples
+--- a single source compiled once per panel, the varied keys printed
+beneath, the wire axes collinear --- so every difference the eye finds
+is attributable to the printed key.  The axes of variation that
+\emph{are} mathematics, the three boundary closures and the directed
+bonds, had their galleries in Example~\ref{ex:read-closures} and
+\S\ref{sec:directed}; what remains is the ink: the glyph, the metric,
+and the height doctrine that keeps both comparable.
+
+% ---------------------------------------------------------------------
+\subsection{The glyph policy: two schools}\label{sec:modes-glyph}
+
+Tensor-network figures descend from two drawing traditions.  In one, a
+tensor is a filled bead and its name stands beside it, in a free
+quadrant --- the school of the review literature that
+\S\ref{ch:rmp} reproduces.  In the other, a tensor is an outlined box
+and its name is typeset inside --- the Ghent school, the natural
+choice when sites carry long or scripted names.  \tnkey{tensor
+style=dot} (the default) and \tnkey{tensor style=box} select between
+them: per document, \tncmd{tnset}\tnval{\{tensor style=box\}} rebinds
+every following picture in the current group; per picture, the same
+key rides the option list and scopes itself.  The source names its
+tensors; the policy decides how a name becomes ink.
+
+\begin{tnmultiples}[
+    caption  = {one window, two schools},
+    formula  = {\langle\psi|O|\psi\rangle\ \text{(a window)}},
+    index    = {Ket, operator, bra; the vertical wires are the paired
+                physical indices, and the six stubs mark a window of
+                the full contraction, not a scalar.  The policy
+                touches only the unadorned atoms: beads become
+                inscribed boxes, and \tncmd{tn*} reads $\overline{A}$
+                either way --- beside the bead, inside the box.  The
+                \tnval{mpo} cells are identical in both panels.},
+    signature = {boundary|virtual-west=3|virtual-east=3|physical-up=0|physical-down=0},
+    variants = {{tensor style=dot}{tensor style=dot},
+                {tensor style=box}{tensor style=box}},
+    label    = {ex:modes-schools},
+  ]
+% a window of <psi|O|psi>: physical indices contract
+% vertically (ket-op, op-bra); all six virtual stubs open
+\begin{tenkz}[rows={ket, op, bra}, variant]
+  \tn{A} & \tn{A} & \tn{A} \\
+  \tn[mpo]{O} & \tn[mpo]{O} & \tn[mpo]{O} \\
+  \tn*{A} & \tn*{A} & \tn*{A}
+\end{tenkz}
+\end{tnmultiples}
+
+The operator row of Example~\ref{ex:modes-schools} does not move
+because an explicit skin --- \tnval{dot}, \tnval{box}, \tnval{pill},
+\tnval{mpo} on the cell --- always outranks the policy: a cell that
+declares its glyph has opted out of the argument.  The event stream
+records what was drawn, not what was asked
+for.\sidenote{Per unadorned atom, the left panel logs
+\tnlogline{atom|cell=1-1|kind=dot} and the right panel
+\tnlogline{atom|cell=1-1|kind=box}, while the operator row logs
+\tnlogline{kind=mpo} in both: the \emph{resolved} skin.  The two
+boundary lines are identical --- the policy is ink.}  \S\ref{ch:rmp}
+works the policy per picture, switching to \tnval{box} exactly where
+the reproduced figure inscribes its labels;
+\S\ref{sec:ref-policy} tabulates the keys.
+
+% ---------------------------------------------------------------------
+\subsection{The metric: one pitch, three knobs}\label{sec:modes-metric}
+
+Every repeated distance in a picture is a named ratio of one base
+pitch, $11$\,mm by default: a physical leg is $0.38$ pitch, a stub
+$0.45$, the layer gap $0.80$, the clearance of every label band
+$0.12$.\marginformula{\begin{aligned}
+  \text{leg}      &= 0.38\,p\\
+  \text{stub}     &= 0.45\,p\\
+  \text{layer}    &= 0.80\,p\\
+  \text{clearance}&= 0.12\,p
+\end{aligned}}
+\tnkey{pitch=} rebinds the base, and the two profiles rescale it:
+\tnkey{compact} to $0.8$, \tnkey{inline} to $0.62$ --- the latter also
+shrinking legs faster than the pitch ($0.26$) and pulling the label
+bands against the ink, buying back the line height a picture needs to
+sit inside a sentence, as one did in Example~\ref{ex:tut-inline}.
+Because no distance is a literal, no drawing can bypass a profile:
+rescaling moves glyphs, legs, bends, and label bands together, which
+is why a leg-tip label clears the ink at every pitch.
+
+\begin{tnmultiples}[
+    caption  = {one word, three metrics},
+    formula  = {A^{i}A^{j}},
+    index    = {One wire axis, three pitches.  The word, its stubs,
+                its legs, and its label bands rescale together;
+                \tnval{inline} shortens the legs beyond its share and
+                drops the labels one script size.  All three panels
+                log the same boundary line: the metric is ink.},
+    signature = {boundary|virtual-west=1|virtual-east=1|physical-up=2|physical-down=0},
+    variants = {{default}{},
+                {compact}{compact},
+                {inline}{inline}},
+    label    = {ex:modes-pitch},
+  ]
+% the same two-site word at three metrics: only the pitch
+% (and with it every named ratio) changes
+\begin{tenkz}[physical=up, variant]
+  \tn[up=$i$]{A} & \tn[up=$j$]{A}
+\end{tenkz}
+\end{tnmultiples}
+
+The knobs nest: \tncmd{tnset}\tnval{\{pitch=10mm\}} in the preamble
+retunes a whole paper, \tnkey{pitch=14mm} in one option list widens
+one picture, and a per-picture \tnkey{compact} tightens one crowded
+figure without touching its neighbours.
+
+% ---------------------------------------------------------------------
+\subsection{One height: the glyph strut}\label{sec:modes-strut}
+
+An inscribed label is the glyph's content, and \TeX{} makes a box
+exactly as tall as its content: left alone, $T_g$ would sink deeper
+than $T_h$, and $A^{(2)}$ would stand taller than $A$ --- a row of
+boxes ragged for no mathematical reason.  Every inscribed label
+therefore carries the glyph strut, \verb|\vphantom{A^{X}_{g}}|, an
+invisible ideal label with a capital, a superscript, and a descending
+subscript, so every box in a picture spans one height whatever its
+label says.  This is the small-multiples rule applied at the scale of
+a single glyph: uniform frames are what make differences legible, and
+a descender is not information.  The proof is already on the page: in
+the MPO product of Example~\ref{ex:worked-mpoprod} the $g$ descends
+and the $h$ does not, yet every box of both rows spans one height,
+because each inscribed label carries the strut.
+
+The same doctrine pins the glyphs met earlier: the \tncmd{tnX} capsule
+has a pinned minimum height, so $X$ and $X^{-1}$ ride the wire at one
+size (Example~\ref{ex:gauge-eq}), and a \tnval{pill} grows only
+sideways to hold its blocked label, never taller
+(Example~\ref{ex:tut-block}).\sidenote{The one deliberate exception:
+inscribed triangle labels (\tnkey{tri=l}, \tnkey{tri=r}) drop the
+strut.  A triangle must circumscribe its text box, so each point of
+phantom height costs about three in glyph height, and two struck
+triangle rows would collide across the default layer gap.}  Dot
+labels stand outside the ink, in a reserved band, so their scripts
+never change a bead's geometry --- which is why the dot school needs
+no strut, and why the two schools stay interchangeable over one
+source.

--- a/docs/tenkz/chapters2/ch-reference.tex
+++ b/docs/tenkz/chapters2/ch-reference.tex
@@ -4,7 +4,7 @@
 % bodies are adapted from the verified acceptance corpus
 % (boundary_test, cups_test, atoms_test, adv_brace, adv_conj, cd_test,
 % lattice_test, plane_stress, free_test) — none are invented here.
-% manual2.tex reaches this file through chapters2/ch6-reference.tex.
+% manual2.tex inputs this file directly.
 \section{Reference}\label{ch:reference}
 
 Each entry of this chapter is one object of the language: its usage
@@ -73,7 +73,7 @@ padded with bare wire.
 \noindent\begin{tabularx}{\linewidth}{@{}p{29mm}p{23mm}p{11mm}>{\raggedright\arraybackslash}X@{}}
 \texttt{trace=} & \texttt{physical} & --- &
   per-site up-into-down trace (one-row pictures) \\
-\texttt{trace=} & \texttt{\{physical} \texttt{at=\{c,\ldots\}\}} & --- &
+\texttt{trace=} & \texttt{\{(physical, c-c)\}} & --- &
   per-column ket-into-bra trace \\
 \texttt{bond dir=} & \texttt{right|left} & --- &
   arrows on every bond: out $=V$, in $=V^{*}$ \\
@@ -82,7 +82,7 @@ padded with bare wire.
 \texttt{align=} & \meta{row} & midline &
   the row set on the math axis \\
 \texttt{pitch=} & \meta{length} & \texttt{11mm} &
-  the metric unit \\
+  the metric unit (profiles scale it) \\
 \texttt{compact}, \texttt{inline} & --- & --- &
   $0.8$ and $0.62$ pitch profiles \\
 \texttt{tensor style=} & \texttt{dot|box} & \texttt{dot} &

--- a/docs/tenkz/chapters2/ch-reference.tex
+++ b/docs/tenkz/chapters2/ch-reference.tex
@@ -1,0 +1,602 @@
+% chapters2/ch-reference.tex — the reference.  Every environment, cell
+% command, and key of tenkz 0.5, one entry per object: usage line
+% (\cmdsig), per-key table, and a minimal live example.  All example
+% bodies are adapted from the verified acceptance corpus
+% (boundary_test, cups_test, atoms_test, adv_brace, adv_conj, cd_test,
+% lattice_test, plane_stress, free_test) — none are invented here.
+% manual2.tex reaches this file through chapters2/ch6-reference.tex.
+\section{Reference}\label{ch:reference}
+
+Each entry of this chapter is one object of the language: its usage
+line between thin rules, a table of its keys --- key, values, default,
+meaning --- and a live example wherever the manual has not already
+drawn one; an entry whose object appears earlier points at that
+example instead of repeating it.  Thumb-tags in the margin name the
+entries, so the chapter can be riffled.  What a picture \emph{writes}
+is part of what it means: every environment appends a
+\tnlogline{picture|id=\meta{n}|lang=\ldots} line to
+\tnfile{\meta{jobname}.tnlog}, followed by its atoms, bonds, and
+closures; grid pictures also log the boundary
+signature\sidenote{\tnlogline{boundary|\allowbreak
+picture=\meta{n}|\allowbreak virtual-west=\meta{w}|\allowbreak
+virtual-east=\meta{e}|\allowbreak physical-up=\meta{u}|\allowbreak
+physical-down=\meta{d}} --- the open-index count that two sides of an
+equation must share.  The lattice, plane, tree, and free dialects log
+their own events and carry no boundary line.} that
+\S\ref{ch:mathematics} reads.  Keys whose values contain commas
+or an equals sign must keep their braces:
+\tnval{trace=\{(physical, 2-3)\}} keeps its braces.
+
+% =====================================================================
+\subsection{The grid: \tnenv{tenkz} and \tncmd{tnpic}}
+
+% the offset drops the tag below the boundary-signature sidenote when
+% the chapter opening and this entry share a page
+\thumbtag[1.6\baselineskip]{\tnenv{tenkz}}%
+\cmdsig{\textbackslash begin\{tenkz\}[\meta{picture keys}]\
+\meta{cells}\ \textbackslash end\{tenkz\}}
+
+The grid is the workhorse: rows are layers, columns are sites,
+\texttt{\&} separates cells, \texttt{\textbackslash\textbackslash}
+separates rows, and every horizontal bond is implicit --- adjacent
+cells on a wire row are contracted.  A cell holds one atom command
+(Section~\ref{sec:ref-atoms}) or nothing; a missing trailing cell is
+padded with bare wire.
+
+\medskip
+{\footnotesize
+\noindent\begin{tabularx}{\linewidth}{@{}p{29mm}p{23mm}p{11mm}>{\raggedright\arraybackslash}X@{}}
+\toprule
+\keyhead
+\texttt{rows=} & \texttt{\{t[:m\ldots],\,\ldots\}} & \texttt{wire} &
+  row types with modifiers; see below \\
+\texttt{physical=} & \texttt{up|down|} \texttt{updown|none} & --- &
+  one-row sugar for \texttt{ket|bra|op|wire} \\
+\texttt{sandwich} & --- & --- &
+  \texttt{rows=\{ket, bra\}}, legs paired \\
+\texttt{boundary=} & \texttt{open|none} & \texttt{open} &
+  stubs at the row ends, or sealed \\
+\texttt{periodic} & --- & --- &
+  trace: each row closed to itself \\
+\texttt{west label=}, \texttt{east label=} & \meta{math} & --- &
+  boundary index at the stub tip \\
+\texttt{west=}, \texttt{east=} & \texttt{open|none|trace|cup|cup=\meta{m}} &
+  --- & the side policy; \texttt{cup} ties adjacent row pairs, the
+  \texttt{cup=} value rides the bend \\
+\texttt{layer sep=} & \meta{factor} & \texttt{1} &
+  scales the inter-layer gap \\
+\bottomrule
+\end{tabularx}\par}
+% the key table is set as two blocks so a page may break between them
+\smallskip
+{\footnotesize
+\noindent\begin{tabularx}{\linewidth}{@{}p{29mm}p{23mm}p{11mm}>{\raggedright\arraybackslash}X@{}}
+\texttt{trace=} & \texttt{physical} & --- &
+  per-site up-into-down trace (one-row pictures) \\
+\texttt{trace=} & \texttt{\{physical} \texttt{at=\{c,\ldots\}\}} & --- &
+  per-column ket-into-bra trace \\
+\texttt{bond dir=} & \texttt{right|left} & --- &
+  arrows on every bond: out $=V$, in $=V^{*}$ \\
+\texttt{bond label=} & \texttt{\{\meta{m} at \meta{c}-\meta{c}\}} &
+  bond \texttt{1-2} & label one bond \\
+\texttt{align=} & \meta{row} & midline &
+  the row set on the math axis \\
+\texttt{pitch=} & \meta{length} & \texttt{11mm} &
+  the metric unit \\
+\texttt{compact}, \texttt{inline} & --- & --- &
+  $0.8$ and $0.62$ pitch profiles \\
+\texttt{tensor style=} & \texttt{dot|box} & \texttt{dot} &
+  glyph policy (Section~\ref{sec:ref-policy}) \\
+\bottomrule
+\end{tabularx}\par}
+\medskip
+
+Row types take colon-separated modifiers, stacked freely, as in
+\tnval{rows=\{op:operator:dir right\}}:
+
+\medskip
+{\footnotesize
+\noindent\begin{tabularx}{\linewidth}{@{}p{34mm}>{\raggedright\arraybackslash}X@{}}
+\toprule
+\normalfont Modifier & Meaning \\ \midrule
+\texttt{:open}, \texttt{:none} & per-row boundary override \\
+\texttt{:nopair} & keep this row's physical legs open \\
+\texttt{:dir right}, \texttt{:dir left} & direct this row's bonds \\
+\texttt{:fused} & doubled strand: the blocked bond \\
+\texttt{:operator} & operator-hue wire (an MPO layer) \\
+\bottomrule
+\end{tabularx}\par}
+\medskip
+
+The grid in use is Example~\ref{ex:gauge-eq} --- one \tnval{ket} row
+per side of the gauge move, capsules riding the wire --- and every
+diagram of \S\ref{ch:tutorial} and \S\ref{ch:worked} is a grid.
+
+\thumbtag{\tnkey{west=cup}}%
+\tnkey{west=cup} and \tnkey{east=cup} tie adjacent open wire rows
+to \emph{each other} in pairs, top down, each pair by one smooth bend
+--- the ket-to-bra contraction of sandwich objects, distinct from
+\tnkey{periodic}, which closes a row to itself.  A cupped row draws no
+stub and contributes nothing to the signature on that side; an odd row
+out keeps its stub.  The optional value sets a fixed-point matrix on
+the bend apex.  Example~\ref{ex:ortho-cup} draws both the cup and its
+bare form over \tncmd{tnghost} anchors --- the identity on the open
+pair; Example~\ref{ex:rmp-rdm} caps both bends with fixed points.
+
+\thumbtag{\tnkey{nopair}}%
+In a \tnval{ket}-over-\tnval{bra} stack the physical legs pair
+automatically; the row modifier \tnval{nopair} suppresses the pairing
+for one row, so a cup can tie the virtual wires while every physical
+index stays open --- the reduced-density-matrix genre, drawn as the
+racetrack of Example~\ref{ex:rmp-rdm} (its \tncmd{tndots} cells elide
+sites: wires pass through, no atom is logged).  When both rails' open
+legs point into the inter-layer gap, \tnkey{layer sep=} widens it
+(Example~\ref{ex:layer-sep}).
+
+\thumbtag{\tnkey{trace=physical}}%
+\tnval{trace=physical} closes every site's up leg into its own down
+leg by an arc around the glyph --- per site the partial trace
+$\operatorname{Tr}_{\mathrm{ph}}M=\sum_s M^{ss}$.  Traced legs are
+closed indices and leave the signature.  The per-column form
+\tnval{trace=\{(physical, c)\}} instead closes chosen
+ket sites into the bra row below, one wrap loop per listed column
+--- the marginal of the kept sites; the cell-set value takes ranges
+and unions like every other cell set.  The per-site
+form carries the idempotence equation of Example~\ref{ex:rmp-zcl}:
+traced legs leave the signature, so $E\,E=E$ balances.
+
+\thumbtag{\tnkey{bond dir=}}%
+\tnkey{bond dir=} directs every wire row's bonds; the row modifiers
+\tnval{:dir right} and \tnval{:dir left} direct one row.  An outgoing
+arrow is the vector space $V$, an incoming one its dual $V^{*}$, and
+contraction joins out to in (the gallery is
+Example~\ref{ex:bond-dir}; a directed MPO product is
+Example~\ref{ex:worked-mpoprod}).  The signature still counts stubs,
+not orientations --- directed signatures are on the roadmap of
+\S\ref{ch:trouble}.
+
+\thumbtag{\tncmd{tnpic}}%
+\cmdsig{\textbackslash tnpic[\meta{picture keys}]\{\meta{cells}\}}
+
+\noindent The same grammar as a command, for pictures inside a
+sentence or a formula: \tnpic[inline]{\tn{A} & \tn{B}} sits on the
+current line, its wire axis on the math axis (\tnkey{align=} chooses
+a different row).  The \tnval{inline} profile shrinks the metric so
+the picture respects the line height.
+
+% =====================================================================
+\subsection{The atoms: cell commands}\label{sec:ref-atoms}
+
+\thumbtag{\tncmd{tn}}%
+\cmdsig{\textbackslash tn[\meta{cell keys}]\{\meta{label}\}\qquad
+\textbackslash tn*[\meta{cell keys}]\{\meta{label}\}}
+
+The tensor atom; the starred form is its conjugate, drawn as
+$\overline{A}$ beside a bead or inscribed as $\overline{A}$ in a box.
+An empty label, \tnval{\textbackslash tn\{\}}, is an anonymous tensor
+--- ink without a name, still a tensor
+(Example~\ref{ex:rmp-rdm}).
+
+\medskip
+{\footnotesize
+\noindent\begin{tabularx}{\linewidth}{@{}p{29mm}p{23mm}p{11mm}>{\raggedright\arraybackslash}X@{}}
+\toprule
+\keyhead
+\texttt{dot}, \texttt{box}, \texttt{pill}, \texttt{mpo} & --- &
+  policy & skin override for this cell \\
+\texttt{tri=} & \texttt{l|r} & --- &
+  canonical-form isometry triangle \\
+\texttt{wide=} & \meta{k} & \texttt{1} &
+  span $k$ columns \\
+\texttt{wires=} & \meta{k} & \texttt{1} &
+  span and terminate $k$ wire rows (also on \tncmd{tnX}) \\
+\texttt{legs at=} & \texttt{\{c,\ldots\}} & centre &
+  physical legs at chosen spanned columns \\
+\texttt{up=}, \texttt{down=} & \meta{math} / \texttt{\{m,\ldots\}} & --- &
+  leg labels, one per leg \\
+\texttt{label pos=} & compass & auto &
+  label quadrant of a bead \\
+\texttt{label shift=} & \texttt{\{x,y\}} & \texttt{0pt} &
+  nudge the label \\
+\texttt{no legs} & --- & --- &
+  suppress this cell's physical legs \\
+\bottomrule
+\end{tabularx}\par}
+\medskip
+
+The wide-glyph keys are live in Example~\ref{ex:rmp-blocking}: there
+\tnval{wide=2} spans the isometry across both blocked columns and
+\tnval{legs at=\{1,2\}} keeps one output leg per spanned column, so
+both sides of the drawn equation read \tnval{physical-up=2}.
+
+\thumbtag{\tncmd{tnX}}%
+\cmdsig{\textbackslash tnX[\meta{cell keys}]\{\meta{label}\}}
+
+\noindent A matrix on the wire: a capsule with no physical
+leg.\whynote{A capsule has no physical index at all, so a sandwich
+with a capsule in the ket row expects no partner beneath it.}  With
+\tnval{wires=$k$} the capsule turns tall and terminates $k$ wire rows
+--- the gauge acting on a doubled virtual space.
+
+\begin{tnexample}[
+    formula   = {\mathbb{E}\,X\,\mathbb{E},\qquad
+                 \mathbb{E}=\sum_s A^s\otimes\overline{A^s}},
+    caption   = {a tall capsule on a sandwich},
+    index     = {$X$ spans the ket and bra rows: a matrix on the
+                 doubled virtual space, between two transfer-matrix
+                 columns.  Both layers' wires end on the capsule; the
+                 flanking physical pairings are untouched.},
+    label     = {ex:ref-tallx},
+  ]
+% X spans ket and bra: both layers' wires end on the capsule;
+% the flanking physical pairings are untouched
+\begin{tenkz}[sandwich]
+  \tn{A} & \tnX[wires=2]{X} & \tn{A}\\
+  \tn*{A} & & \tn*{A}
+\end{tenkz}
+\end{tnexample}
+
+\thumbtag{\tncmd{tnfuse}}%
+\cmdsig{\textbackslash tnfuse[span=\meta{k}, combined=west|east]%
+\{\meta{label}\}}
+
+\noindent The fusing wedge $V:\mathbb{C}^{D_1}\otimes\mathbb{C}^{D_2}
+\to\mathbb{C}^{D_1 D_2}$: it consumes its side's boundary and leaves
+\emph{one} combined stub.\whynote{No key may change a picture's
+open-index count; the wedge does.}
+The combined stub counts as one open virtual index, so fused
+equations balance.
+
+\begin{tnexample}[
+    formula   = {O = X^{-1}\Bigl[\textstyle\sum_k A^k\otimes
+                 \overline{A^k}\Bigr]X},
+    caption   = {fused wedges balance an equation},
+    index     = {Each wedge's combined leg is one open index; the
+                 doubled strands between wedge and tensors are the
+                 pair it fuses.  Both sides log the quoted line.},
+    signature = {boundary|virtual-west=1|virtual-east=1|physical-up=1|physical-down=1},
+    label     = {ex:ref-fuse},
+  ]
+% O = X^{-1} [ sum_k A^k (x) conj(A^k) ] X : each combined
+% stub counts as ONE open virtual index -- both sides (1,1,1,1)
+\[
+  \begin{tenkz}[physical=updown, tensor style=box]
+    \tn{O}
+  \end{tenkz}
+  \;=\;
+  \begin{tenkz}[rows={op,op}, tensor style=box]
+    \tnfuse{X^{-1}} & \tn{A} & \tnfuse[combined=east]{X}\\
+                    & \tn*{A} &
+  \end{tenkz}
+\]
+\end{tnexample}
+
+\thumbtag{\tncmd{tnskip}}%
+\cmdsig{\textbackslash tndots\qquad \textbackslash tnskip\qquad
+\textbackslash tnghost\{\}}
+
+\noindent Three ways for a cell to hold no tensor, with three
+meanings.  \tncmd{tndots} is an ellipsis: wires pass through, sites
+are elided, nothing is logged.  \tncmd{tnskip} is a \emph{hole}: the
+tensor is deleted, its indices are not --- no bond bridges the gap,
+and a physically paired partner keeps its leg open
+(Example~\ref{ex:hole}); deleting a tensor is a statement about the
+network, not about ink.\whynote{An empty cell cannot mean absence,
+because \tnval{\textbackslash tn\{\}} is already an anonymous
+\emph{tensor}.}  \tncmd{tnghost} is invisible ink --- an anchor that
+draws nothing and routes the bond straight through; a physical
+pairing onto a ghost warns, naming \tncmd{tnskip} as the fix.
+
+\thumbtag{\tncmd{tnspan}}%
+\cmdsig{\textbackslash tnspan[brace above|below]\{\meta{n}\}%
+\{\meta{label}\}\qquad \textbackslash tncut\{\meta{label}\}}
+
+\noindent Annotation ink, written directly after the cell it
+anchors to.  \tncmd{tnspan} sets a brace over the next $n$ columns;
+\tncmd{tncut} hangs a dashed stroke across the bond east of its
+cell.\whynote{The brace names columns, the stroke crosses a bond ---
+neither belongs to a glyph.}  Neither adds nor removes an index: the signature is the
+undecorated word's, so an equation between a cut picture and an uncut
+one is well-formed.
+
+\begin{tnexample}[
+    formula   = {S_L=-\operatorname{Tr}\rho_L\log\rho_L},
+    caption   = {annotation ink: brace and cut},
+    index     = {The brace names the block $L$ of the first two
+                 sites; the dashed stroke crosses the bond severed in
+                 the Schmidt decomposition.  Four up legs, two
+                 virtual stubs: the signature is the plain word's.},
+    signature = {boundary|virtual-west=1|virtual-east=1|physical-up=4|physical-down=0},
+    label     = {ex:ref-annot},
+  ]
+% annotation ink: the brace names the blocked pair, the cut
+% crosses one bond -- neither changes any index
+\begin{tenkz}[physical=up]
+  \tn[up=$i$]{A}\tnspan[brace above]{2}{L} &
+  \tn[up=$j$]{A}\tncut{S_L} & \tn{A} & \tn{A}
+\end{tenkz}
+\end{tnexample}
+
+% =====================================================================
+\subsection{The glyph policy: \tnkey{tensor style} and
+  \tncmd{tnset}}\label{sec:ref-policy}
+
+\thumbtag{\tncmd{tnset}}%
+\cmdsig{\textbackslash tnset\{\meta{keys}\}}
+
+\noindent \tnval{\textbackslash tnset\{tensor style=box\}} rebinds
+every following picture in the current group: assignments to the
+shared key space hold until the group ends.  The same keys appear
+per picture in the option list of \tnenv{tenkz}, \tncmd{tnpic},
+\tnenv{tenkzcd}, \tnenv{tenkzlattice}, and \tnenv{tenkzfree}, and a
+picture-local assignment scopes itself.  The policy decides how an
+unadorned atom renders; explicit skins (\tnval{dot}, \tnval{box},
+\tnval{pill}, \tnval{mpo}) always override it, and the event stream
+records the resolved skin.  Example~\ref{ex:modes-schools} shows one
+window under both policies; \S\ref{ch:house} states which school a
+document should pick, and why.
+
+% =====================================================================
+\subsection{Trees and arrows: \tnenv{tenkzcd}}
+
+\thumbtag{\tnenv{tenkzcd}}%
+\cmdsig{\textbackslash begin\{tenkzcd\}[\meta{keys}]\ \meta{slots}\
+\textbackslash end\{tenkzcd\}}
+
+With \tnkey{polygon=}$n$ the \texttt{\&}-separated slots sit on an
+$n$-gon, first slot at the top, and \tncmd{tnarrow} joins them by
+slot number; each slot holds a fusion tree, a \tncmd{tnpic}, or plain
+mathematics.  Without \tnkey{polygon=} the body is a
+commutative-diagram matrix in rows and columns, with the standard
+arrow syntax of such matrices.
+
+\medskip
+{\footnotesize
+\noindent\begin{tabularx}{\linewidth}{@{}p{29mm}p{23mm}p{11mm}>{\raggedright\arraybackslash}X@{}}
+\toprule
+\keyhead
+\texttt{polygon=} & \meta{n} & --- &
+  slots on an $n$-gon; unset = matrix mode \\
+\texttt{radius=} & \meta{length} & \texttt{30mm} &
+  circumradius of the polygon \\
+\multicolumn{4}{@{}l}{\emph{other keys pass through to the
+  picture} (\texttt{pitch=}, \texttt{tensor style=}, \ldots)} \\
+\bottomrule
+\end{tabularx}\par}
+\medskip
+
+\thumbtag{\tncmd{tntree}}%
+\cmdsig{\textbackslash tntree\{\meta{bracketed word}\}\\
+\textbackslash tnarrow*[from=\meta{i}, to=\meta{j}]\{\meta{label}\}}
+
+\noindent \tncmd{tntree} draws the fusion tree of a bracketed word,
+innermost pairs first: in
+\tnval{((a\textbackslash,b)\_x\textbackslash,c)\_y} the pair
+$(a,b)$ fuses into the internal charge $x$, then with $c$ into $y$.
+\tncmd{tnarrow} labels the arrow from slot $i$ to slot $j$; the
+starred form sets the label on the other side of the shaft.  The
+five-slot pentagon, trees and all, is Example~\ref{ex:tut-pentagon}.
+
+% =====================================================================
+\subsection{Lattice windows: \tnenv{tenkzlattice}}
+
+\thumbtag{\tnenv{tenkzlattice}}%
+\cmdsig{\textbackslash begin\{tenkzlattice\}[\meta{keys}]\
+\meta{regions, edges, sites}\\
+\textbackslash end\{tenkzlattice\}}
+
+A finite window of a two-dimensional lattice: sites, bonds, and the
+regions of an entanglement argument.  The body is a list of region,
+edge, and site commands drawn over the window.
+
+\medskip
+{\footnotesize
+\noindent\begin{tabularx}{\linewidth}{@{}p{29mm}p{23mm}p{11mm}>{\raggedright\arraybackslash}X@{}}
+\toprule
+\keyhead
+\texttt{rows=}, \texttt{cols=} & \meta{n} & --- &
+  the window's extent \\
+\texttt{site=} & \texttt{dot|none} & \texttt{dot} &
+  site glyphs, or bonds only \\
+\texttt{boundary legs} & --- & --- &
+  bonds cut by the window dangle at the rim \\
+\texttt{physical=} & \texttt{up|none} & \texttt{none} &
+  a physical leg on every site \\
+\texttt{frame=} & \texttt{flat|oblique|slab} & \texttt{flat} &
+  the sheared sheet: bonds shear, glyphs and labels stay upright
+  (Example~\ref{ex:rmp-peps}) \\
+\bottomrule
+\end{tabularx}\par}
+\medskip
+
+\thumbtag{\tncmd{tnregion}}%
+\cmdsig{\textbackslash tnregion[\meta{keys}]\{\meta{cell set}\}\\
+\textbackslash tnedge[distinguished]\{(r,c)-(r,c)\}\\
+\textbackslash tnsite[removed]\{(r,c)\}}
+
+\noindent A region is a set of cells, written as ranges
+\tnval{(1-3, 2-4)}; a named region composes by set algebra, as in
+\tnval{R - (2,2)}.\whynote{Regions are open-ended in number and
+compose by name, so they are drawn commands, not window keys: the
+window is configured once, while an argument may lay any number of
+overlapping subsets over it.}  \tncmd{tnedge} strokes one bond in the
+emphasis width; \tncmd{tnsite} with any option removes the site and
+its bonds from the drawing.
+
+\medskip
+{\footnotesize
+\noindent\begin{tabularx}{\linewidth}{@{}p{26mm}p{24mm}p{13mm}>{\raggedright\arraybackslash}X@{}}
+\toprule
+\keyhead
+\texttt{slot=} & \texttt{selected|} \texttt{secondary|}
+  \texttt{complement|} \texttt{collar} & \texttt{selected} &
+  the region's fill-and-outline role \\
+\texttt{outline} & --- & --- &
+  boundary only, no fill \\
+\texttt{label=}, \texttt{label at=} & \meta{math}, compass & --- &
+  region label and its corner \\
+\texttt{name=} & \meta{id} & --- &
+  bind the set for later set algebra \\
+\texttt{inset=} & \meta{k} & \texttt{0} &
+  draw the boundary $k$ nesting units tighter \\
+\bottomrule
+\end{tabularx}\par}
+\medskip
+
+\begin{tnexample}[
+    formula   = {R=[1,3]^2,\quad S=R\setminus\{(2,2)\}},
+    caption   = {nested regions on a flat window},
+    index     = {$S$'s outer boundary coincides with $R$'s, so
+                 \tnval{inset=1} nests it one unit tighter; the ring
+                 is $S$'s inner boundary at the removed site.  The
+                 heavy bond is a distinguished edge.},
+    label     = {ex:ref-lattice},
+  ]
+% R = [1,3]x[1,3]; S = R \ {(2,2)}: S's outer boundary
+% coincides with R's, so inset=1 nests it one unit tighter;
+% the ring is S's inner boundary at the removed site
+\begin{tenkzlattice}[rows=4, cols=4, boundary legs]
+  \tnregion[slot=selected, name=R, label=$R$]{(1-3, 1-3)}
+  \tnregion[slot=secondary, outline, inset=1,
+            label=$S$, label at=south west]{R - (2,2)}
+  \tnedge[distinguished]{(2,3)-(2,4)}
+  \tnsite[removed]{(2,2)}
+\end{tenkzlattice}
+\end{tnexample}
+
+% =====================================================================
+\subsection{The double layer: \tnenv{tenkzplanes}}
+
+\thumbtag{\tnenv{tenkzplanes}}%
+\cmdsig{\textbackslash begin\{tenkzplanes\}[\meta{keys}]\
+\textbackslash end\{tenkzplanes\}}
+
+Two oblique sheets, ket over bra, with a site-wise pairing leg
+contracting each physical index --- the expectation-value object
+$\langle\Psi|\Psi\rangle$ of a two-dimensional state.  Cells listed
+in \tnkey{open=} keep their pairing legs dangling; cells listed in
+\tnkey{trace=} close by a wrap loop between the sheets, and trace
+beats open when a cell is listed in both.  The stack is fixed at
+\tnval{sheets=\{ket, bra\}}; anything else warns and draws the
+double layer (\S\ref{ch:trouble}).
+
+\medskip
+{\footnotesize
+\noindent\begin{tabularx}{\linewidth}{@{}p{29mm}p{23mm}p{11mm}>{\raggedright\arraybackslash}X@{}}
+\toprule
+\keyhead
+\texttt{rows=}, \texttt{cols=} & \meta{n} & --- &
+  the window's extent \\
+\texttt{sheets=} & \texttt{\{ket, bra\}} & \texttt{\{ket, bra\}} &
+  the supported stack \\
+\texttt{sheet sep=} & \meta{factor} & house &
+  scales the inter-sheet gap \\
+\texttt{open=} & \texttt{\{(r,c),\ldots\}} & --- &
+  cells keeping dangling pairing legs \\
+\texttt{trace=} & \texttt{\{(r,c),\ldots\}} & --- &
+  cells closed by wrap loops; beats \texttt{open=} \\
+\bottomrule
+\end{tabularx}\par}
+\medskip
+
+\begin{tnexample}[
+    formula   = {\rho_C=\operatorname{Tr}_{\overline{C}}\,
+                 |\Psi\rangle\langle\Psi|},
+    caption   = {scattered open cells, widened gap},
+    index     = {Each vertical pairing leg is one contraction
+                 $\sum_s A^s\overline{A}^s$; the cells of
+                 $C=\{(1,2)\}\cup[2,3]\times\{4\}$ keep theirs
+                 dangling, so the picture is the marginal $\rho_C$.
+                 \tnval{sheet sep=2.2} widens the gap for the
+                 dangling stubs.},
+    label     = {ex:ref-planes},
+  ]
+% ket-over-bra double layer; the open cells keep dangling
+% pairing legs -- the marginal of those sites
+\begin{tenkzplanes}[rows=3, cols=4, sheets={ket, bra},
+                    sheet sep=2.2, open={(1,2),(2-3,4)}]
+\end{tenkzplanes}
+\end{tnexample}
+
+% =====================================================================
+\subsection{Free placement: \tnenv{tenkzfree}}
+
+\thumbtag{\tnenv{tenkzfree}}%
+\cmdsig{\textbackslash begin\{tenkzfree\}[\meta{keys}]\
+\meta{puts, joins}\ \textbackslash end\{tenkzfree\}}
+
+When the grid's geometry is wrong --- loops, side-by-side maps,
+anything a paper sketches freehand --- atoms are placed at
+coordinates and wired by hand.  The house glyphs, hues, and line
+widths still apply, so a free picture matches its grid neighbours.
+
+\thumbtag{\tncmd{tnput}}%
+\cmdsig{\textbackslash tnput[\meta{keys}]\{\meta{name}\}%
+\{\meta{coordinate}\}\{\meta{label}\}}
+
+\medskip
+{\footnotesize
+\noindent\begin{tabularx}{\linewidth}{@{}p{29mm}p{23mm}p{11mm}>{\raggedright\arraybackslash}X@{}}
+\toprule
+\keyhead
+\texttt{dot}, \texttt{box}, \texttt{pill}, \texttt{mpo},
+  \texttt{ring} & --- & policy & the glyph \\
+\texttt{ports=} & \texttt{\{side:kind,\ldots\}} & --- &
+  typed ports, kinds \texttt{virtual} and \texttt{physical} \\
+\texttt{label pos=} & \texttt{north|south|} \texttt{east|west} &
+  auto & label side of a bead \\
+\bottomrule
+\end{tabularx}\par}
+\medskip
+
+\thumbtag{\tncmd{tnjoin}}%
+\cmdsig{\textbackslash tnjoin[\meta{keys}]\{\meta{a.port}\}%
+\{\meta{b.port}\}}
+
+\medskip
+{\footnotesize
+\noindent\begin{tabularx}{\linewidth}{@{}p{26mm}p{24mm}p{13mm}>{\raggedright\arraybackslash}X@{}}
+\toprule
+\keyhead
+\texttt{route=} & \texttt{straight|hv|} \texttt{vh|curve} &
+  \texttt{straight} & how the wire runs \\
+\texttt{out=}, \texttt{in=} & \meta{angle} & --- &
+  tangents of a \texttt{curve} route \\
+\texttt{label=} & \meta{math} & --- &
+  label at the wire's midpoint \\
+\texttt{fused} & --- & --- &
+  doubled strand \\
+\texttt{dir} & --- & --- &
+  directed wire: argument order is the direction \\
+\bottomrule
+\end{tabularx}\par}
+\medskip
+
+\begin{tnexample}[
+    formula   = {\textstyle\sum_{\alpha}
+                 A_{\alpha}^{\!\top}\,T\,B_{\alpha}},
+    caption   = {typed ports and a directed wire},
+    index     = {The straight wire is the summed virtual index
+                 $\alpha$; its \tnval{dir} barb points from $A$ to
+                 $B$.  The curved return joins the \tnval{physical}
+                 ports through $T$, contracting the physical vectors
+                 $A_{\alpha}$, $B_{\alpha}$ against the matrix $T$.
+                 Joining ports of different kinds warns.},
+    label     = {ex:ref-free},
+  ]
+% typed ports; the directed join reads argument order as
+% direction (out of a, into b); the curve carries T
+\begin{tenkzfree}
+  \tnput[ports={east:virtual, north:physical}]{a}{(0,0)}{A}
+  \tnput[ports={west:virtual}]{b}{(14mm,0)}{B}
+  \tnjoin[dir]{a.east}{b.west}
+  \tnjoin[route=curve, out=90, in=90, label=T]{a.north}{b.north}
+\end{tenkzfree}
+\end{tnexample}
+
+The entries above are the whole 0.5 language.  What it cannot yet
+draw --- inter-sheet closures, an operator sheet between the layers,
+directed physical legs and directed signatures, the splitting glyph
+--- is stated as mathematics in the roadmap of
+\S\ref{ch:trouble}, and the one-page card on the back page
+compresses this chapter to one line per object.

--- a/docs/tenkz/chapters2/ch-rmp.tex
+++ b/docs/tenkz/chapters2/ch-rmp.tex
@@ -2,7 +2,7 @@
 % matrix-product-state review arXiv:2011.12127 reproduced as
 % formula-first worked examples.  Every body below is adapted from the
 % verified reproduction corpus (hard01..hard12 v3, plane acceptance);
-% manual2.tex reaches this file through chapters2/ch5-rmp.tex.
+% manual2.tex inputs this file directly.
 \section{The review-article test}\label{ch:rmp}
 
 A notation earns its keep by reproducing the figures of a paper it

--- a/docs/tenkz/chapters2/ch-rmp.tex
+++ b/docs/tenkz/chapters2/ch-rmp.tex
@@ -1,0 +1,379 @@
+% chapters2/ch-rmp.tex — the review-article test: figures of the
+% matrix-product-state review arXiv:2011.12127 reproduced as
+% formula-first worked examples.  Every body below is adapted from the
+% verified reproduction corpus (hard01..hard12 v3, plane acceptance);
+% manual2.tex reaches this file through chapters2/ch5-rmp.tex.
+\section{The review-article test}\label{ch:rmp}
+
+A notation earns its keep by reproducing the figures of a paper it
+was not designed around.  This chapter works through diagrams of the
+matrix-product-state review of Cirac, P\'erez-Garc\'ia, Schuch and
+Verstraete,\sidenote{Rev.\ Mod.\ Phys.\ \textbf{93}, 045003 (2021);
+arXiv:2011.12127.  The examples follow the review's Sec.~II--III:
+canonical forms, fixed points, blocking, matrix product operators, the
+tangent space, and PEPS.} chosen because each one leans on a different
+part of the language: cups and canonical triangles, on-bend fixed-point
+matrices, per-column legs on wide gates, tall gauges spanning two
+layers, per-site physical traces, and the oblique two-dimensional
+sheets.  Wherever an equation is drawn, the margin quotes the
+boundary signature that both sides must share.
+
+\subsection{Canonical forms}
+
+A uniform MPS tensor $A_L$ is \emph{left-canonical} when its matrices
+are jointly isometric from the left.  Contracting the shared left
+virtual index and the physical index of a ket--bra pair must give the
+identity on the right pair --- so both sides of the drawn equation keep
+exactly two east stubs, and nothing else, open.
+
+\begin{tnexample}[
+    formula   = {\sum_s (A_L^s)^\dagger A_L^s = \mathbb{I}},
+    caption   = {left orthonormality of $A_L$},
+    index     = {The triangle is the left-canonical tensor; its apex
+                 points toward the surviving index.  The vertical bond
+                 is the summed physical index $s$; the west cup is the
+                 summed left virtual index $\alpha$.  Both sides keep
+                 the pair $(\beta,\beta')$ open: the equation is
+                 between matrices.},
+    signature = {boundary|virtual-west=0|virtual-east=2|physical-up=0|physical-down=0},
+    label     = {ex:rmp-ortho-left},
+  ]
+% LHS: ket A_L over bra conj(A_L); sandwich pairs the physical
+% index s; west=cup contracts the shared left
+% virtual index alpha
+\[
+  \begin{tenkz}[sandwich, west=cup]
+    \tn[tri=l]{A_L}\\
+    \tn*[tri=l]{A_L}
+  \end{tenkz}
+  \;=\;
+  % RHS: the identity on the open (beta, beta') pair -- a bare
+  % cup; the ghosts are the wire endpoints
+  \begin{tenkz}[rows={wire,wire}, west=cup]
+    \tnghost{}\\
+    \tnghost{}
+  \end{tenkz}
+\]
+\end{tnexample}
+
+The right-canonical condition is the mirror image, and so is its
+source: the triangles flip to \tnval{tri=r}, the cup moves to the east
+side, and the identity keeps the west pair open.
+
+\begin{tnexample}[
+    formula   = {\sum_s A_R^s (A_R^s)^\dagger = \mathbb{I}},
+    caption   = {right orthonormality of $A_R$},
+    index     = {Roles of the sides swap: the east cup is now the
+                 summed right index $\beta$, and the open pair
+                 $(\alpha,\alpha')$ sits west on both sides.  The
+                 review draws both equations in isometry orientation,
+                 apex up, contraction arcs below --- a mirror image
+                 of this chain geometry, same topology.},
+    signature = {boundary|virtual-west=2|virtual-east=0|physical-up=0|physical-down=0},
+    label     = {ex:rmp-ortho-right},
+  ]
+% same sandwich with right-canonical triangles; the cup is the
+% contraction over the shared right index beta
+\[
+  \begin{tenkz}[sandwich, east=cup]
+    \tn[tri=r]{A_R}\\
+    \tn*[tri=r]{A_R}
+  \end{tenkz}
+  \;=\;
+  % RHS: the identity on the open (alpha, alpha') pair
+  \begin{tenkz}[rows={wire,wire}, east=cup]
+    \tnghost{}\\
+    \tnghost{}
+  \end{tenkz}
+\]
+\end{tnexample}
+
+\subsection{The reduced density matrix}
+
+Write $A^{(s)} = A^{s_1}\!\cdots A^{s_n}$ for an $n$-site word, and let
+$\rho^L$, $\rho^R$ be the dominant left and right fixed points of the
+transfer map.  The review's $n$-site reduced density matrix is the
+racetrack: a ket rail with all up legs open, the conjugate rail below
+with all down legs open, and the two rails closed into each other at
+both ends by cups carrying the fixed points.
+
+\begin{tnexample}[
+    formula   = {[\rho_n]_{(s)(s')} =
+                 \mathrm{Tr}\bigl[\rho^L A^{(s)}\rho^R
+                 A^{(s')\dagger}\bigr]},
+    caption   = {the $n$-site reduced density matrix},
+    index     = {\tnval{nopair} keeps every physical leg open ---
+                 $\rho_n$ is a matrix on the $n$-site physical space,
+                 $n=4$ drawn.  The bends are the closure of the two
+                 rails into each other, and the dots riding them are
+                 the fixed points $\rho^L$ (west) and $\rho^R$
+                 (east); the formula reads clockwise around the
+                 racetrack from the west bend.},
+    signature = {boundary|virtual-west=0|virtual-east=0|physical-up=4|physical-down=4},
+    label     = {ex:rmp-rdm},
+  ]
+% ket rail: A^{s_1}..A^{s_4}, up legs open; bra rail: the
+% conjugates, down legs open; the cups + on-bend dots are the
+% trace through rho^L (west, the left fixed point) and rho^R
+% (east, the right fixed point)
+\[
+  \rho_n \;=\;
+  \begin{tenkz}[rows={ket:nopair, bra},
+                west={cup=$\rho^L$}, east={cup=$\rho^R$}]
+    \tn{} & \tn{} & \tn{} & \tn{}\\
+    \tn*{} & \tn*{} & \tn*{} & \tn*{}
+  \end{tenkz}
+\]
+\end{tnexample}
+
+The review then asks for the spectrum of this object.  The picture
+enters the formula like any other math atom: its wire axis sits on the
+math axis, so stretchy delimiters size and centre on the racetrack.
+
+\begin{tnexample}[
+    formula   = {\mathrm{eig}(\rho_n)},
+    caption   = {the spectrum of $\rho_n$},
+    index     = {Same racetrack as Example~\ref{ex:rmp-rdm}; the
+                 \tnval{\char`\\left( ... \char`\\right)} pair centres
+                 on the picture because the wire axis is the math
+                 axis.  eig is algebra around one picture, so there is
+                 no side-to-side signature balance to check.},
+    signature = {boundary|virtual-west=0|virtual-east=0|physical-up=4|physical-down=4},
+    label     = {ex:rmp-eig},
+  ]
+% rho_n racetrack inside stretchy parentheses: the picture's
+% wire axis rides the math axis
+\[
+  \mathrm{eig}\left(
+  \begin{tenkz}[rows={ket:nopair, bra},
+                west={cup=$\rho^L$}, east={cup=$\rho^R$}]
+    \tn{} & \tn{} & \tn{} & \tn{}\\
+    \tn*{} & \tn*{} & \tn*{} & \tn*{}
+  \end{tenkz}
+  \right)
+\]
+\end{tnexample}
+
+\subsection{Blocking to a fixed point}
+
+Under renormalization a fixed-point MPS reproduces itself when two
+sites are blocked into one: the blocked pair equals a single tensor
+followed by an isometry $U$ on the doubled physical index.  Both sides
+must show two up legs --- one per blocked site --- which is exactly
+what \tnkey{legs at=} provides on a wide glyph.
+
+\begin{tnexample}[
+    formula   = {A^{i_1}A^{i_2} = \sum_j U_{(i_1 i_2),j}\,A^j},
+    caption   = {the blocking fixed-point equation},
+    index     = {$U$ is a pill of width two; \tnval{legs
+                 at=\{1,2\}} opens one up leg over each spanned
+                 column, so both sides read physical-up $=2$.  The
+                 vertical $U$--$A$ bond is the summed index $j$;
+                 \tnval{op:none} seals $U$'s virtual boundary ---
+                 the isometry has no horizontal wires.},
+    signature = {boundary|virtual-west=1|virtual-east=1|physical-up=2|physical-down=0},
+    label     = {ex:rmp-blocking},
+  ]
+% LHS: A^{i_1} A^{i_2} -- two MPS tensors, one open up leg each
+\[
+  \begin{tenkz}[physical=up, tensor style=box]
+    \tn{A} & \tn{A}
+  \end{tenkz}
+  \;=\;
+  % RHS: U keeps one leg per blocked site (legs at={1,2}); the
+  % vertical U-A bond is the summed physical index j
+  \begin{tenkz}[rows={op:none, ket}, tensor style=box]
+    \tn[pill, wide=2, legs at={1,2}]{U} & \\
+    \tn[wide=2]{A} &
+  \end{tenkz}
+\]
+\end{tnexample}
+
+\subsection{Purification and zero correlation length}
+
+A positive matrix product operator admits a local purification: the
+MPO tensor $O$ factors, up to a gauge $X$ on the virtual index, into a
+purification tensor $A$ glued to its own conjugate.  The review draws
+$X$ as a tall capsule spanning both layers with the label inscribed,
+which is \tncmd{tnX} with \tnkey{wires=2}.
+
+\begin{tnexample}[
+    formula   = {O = X^{-1}\bigl[{\textstyle\sum_k}
+                 A^k\!\otimes\overline{A}^k\bigr]X},
+    caption   = {local purification of a positive MPO},
+    index     = {The $A$--$\overline{A}$ bond is the purification
+                 index $k$ (the automatic pairing of the two
+                 \tnval{op} rows); $s$ (up) and $s'$ (down) stay
+                 open.  Each capsule is one atom spanning both layer
+                 wires; \tnval{op:none} seals the top row, so exactly
+                 one virtual index leaves each capsule --- the
+                 signature matches $O$'s.  One recorded gap: the
+                 review's outer wire enters the capsule at its
+                 vertical centre (the fused index); the grid opens
+                 one row's boundary, so here it sits at the lower
+                 row's height.},
+    signature = {boundary|virtual-west=1|virtual-east=1|physical-up=1|physical-down=1},
+    label     = {ex:rmp-purification},
+  ]
+% LHS: the 4-leg MPO tensor O (s up, s' down, virtual a/b)
+\[
+  \begin{tenkz}[physical=updown, tensor style=box]
+    \tn{O}
+  \end{tenkz}
+  \;=\;
+  % RHS: X^{-1} [ A (x) conj(A) ] X -- capsules span both
+  % layers; the A-conj(A) bond is the purification index k;
+  % align=2 puts the open row on the math axis
+  \begin{tenkz}[rows={op:none, op}, align=2, tensor style=box]
+    \tnX[wires=2]{X^{-1}} & \tn{A} & \tnX[wires=2]{X}\\
+                          & \tn*{A} &
+  \end{tenkz}
+\]
+\end{tnexample}
+
+At the opposite extreme sit the zero-correlation-length density
+operators.  With $E = \sum_s M^{ss}$ --- the MPDO tensor with its own
+physical pair closed by a per-site trace --- the condition is that $E$
+be idempotent.  \tnkey{trace=physical} draws that per-site closure.
+
+\begin{tnexample}[
+    formula   = {E\,E = E,\quad E = {\textstyle\sum_s} M^{ss}},
+    caption   = {zero correlation length for an MPDO},
+    index     = {\tnval{trace=physical} arcs each site's up leg
+                 around the glyph into its own down leg: the per-site
+                 physical trace.  Traced legs are closed indices and
+                 leave the signature, so both sides read
+                 $(1,1,0,0)$.},
+    signature = {boundary|virtual-west=1|virtual-east=1|physical-up=0|physical-down=0},
+    label     = {ex:rmp-zcl},
+  ]
+% LHS: E.E -- two physically traced tensors, one virtual bond
+\[
+  \begin{tenkz}[physical=updown, trace=physical,
+                tensor style=box]
+    \tn[mpo]{M} & \tn[mpo]{M}
+  \end{tenkz}
+  \;=\;
+  % RHS: E -- one physically traced tensor
+  \begin{tenkz}[physical=updown, trace=physical,
+                tensor style=box]
+    \tn[mpo]{M}
+  \end{tenkz}
+\]
+\end{tnexample}
+
+\subsection{The tangent space}
+
+In the gauge where the chain is left-canonical up to site $i$ and
+right-canonical after it, the projector onto the tangent space of a
+uniform MPS is
+\[
+  P_{T(A)} \;=\; \sum_{i=1}^{n}
+    P_L^{(i-1)}\otimes\mathbb{I}_i\otimes P_R^{(i+1)}
+  \;-\; \sum_{i=1}^{n} P_L^{(i)}\otimes P_R^{(i+1)},
+\]
+where $P_L^{(k)}$ projects onto the states reached by an $A_L$-chain
+on the sites up to $k$, and $P_R^{(k)}$ mirrors it from the right.
+Each block projector is an all-legs-open window of canonical triangles
+whose edge cup is the bracket
+$\sum_\alpha|\Phi_\alpha\rangle\langle\Phi_\alpha|$; pictures set side
+by side are tensor factors, so a summand is assembled exactly as the
+formula factors it.
+
+\begin{tnexample}[
+    formula   = {P_L^{(i-1)}\otimes\mathbb{I}_i\otimes
+                 P_R^{(i+1)}},
+    caption   = {one summand of the tangent-space projector},
+    index     = {Left block: an $A_L$ window, all physical legs open
+                 (\tnval{nopair}), its east cup the bracket at the
+                 block edge; the right block mirrors it.  The
+                 site-$i$ identity is algebra, not ink: a cup cannot
+                 sit at a hole's edge, so the summand carries
+                 $\mathbb{I}_i$ symbolically.},
+    signature = {boundary|virtual-west=2|virtual-east=0|physical-up=2|physical-down=2},
+    label     = {ex:rmp-tangent},
+  ]
+% P_L^(i-1): all-legs-open A_L window; the east cup is the
+% tangent-space bracket sum_a |Phi_a><Phi_a|
+\[
+  \begin{tenkz}[rows={ket:nopair, bra}, east=cup]
+    \tndots & \tn[tri=l]{} & \tn[tri=l]{}\\
+    \tndots & \tn*[tri=l]{} & \tn*[tri=l]{}
+  \end{tenkz}
+  % 1_i: algebra, not ink -- no bare-wire atom can be bracketed
+  \otimes \mathbb{I}_i \otimes
+  % P_R^(i+1): the mirrored A_R window, bracket at the west
+  \begin{tenkz}[rows={ket:nopair, bra}, west=cup]
+    \tn[tri=r]{} & \tn[tri=r]{} & \tndots\\
+    \tn*[tri=r]{} & \tn*[tri=r]{} & \tndots
+  \end{tenkz}
+\]
+\end{tnexample}
+
+The algebraic $\mathbb{I}_i$ contributes no drawn legs, so the two
+sums balance as drawn: each summand's ink totals
+$(2,2,4,4)$,\sidenote{Per picture: the line quoted beside
+Example~\ref{ex:rmp-tangent} is a left block's; a right block mirrors
+it, \tnlogline{virtual-east=2} in place of
+\tnlogline{virtual-west=2}.} whether or not the brackets meet back to
+back --- the second summand is the same two blocks with $\otimes$
+alone between them.
+
+\subsection{Two dimensions}
+
+A PEPS assigns one five-index tensor to each site of a square lattice:
+four virtual bonds to the lattice neighbours and one physical leg.
+The review draws finite windows obliquely so the physical legs leave
+the lattice plane visibly; \tnval{frame=oblique} shears the bonds
+only, keeping dots, labels, and legs in the paper frame.
+
+\begin{tnexample}[
+    formula   = {|\Psi\rangle = \sum_{\mathbf{s}}
+                 \mathcal{C}\bigl(\{A^{s_{xy}}\}\bigr)\,
+                 |\mathbf{s}\rangle},
+    caption   = {a finite PEPS window, drawn obliquely},
+    index     = {Each dot is a site tensor $A^{s_{xy}}$; the in-sheet
+                 bonds are its four virtual indices, and
+                 \tnval{boundary legs} lets the bonds cut by the
+                 window dangle.  The short vertical stub at each site
+                 is the open physical index, readable against the
+                 sheared lattice.},
+    label     = {ex:rmp-peps},
+  ]
+% a 4x4 PEPS window: sheared bonds, per-site physical legs,
+% cut bonds dangling at the window boundary
+\begin{tenkzlattice}[rows=4, cols=4, frame=oblique,
+                     physical=up, boundary legs]
+\end{tenkzlattice}
+\end{tnexample}
+
+Expectation values double the sheet: a ket layer over its conjugate,
+with a site-wise pairing leg contracting each physical index.  Leaving
+the pairing legs of chosen cells dangling turns the double layer into
+a marginal on those cells.
+
+\begin{tnexample}[
+    formula   = {\rho_C = \operatorname{Tr}_{\overline{C}}\,
+                 |\Psi\rangle\langle\Psi|},
+    caption   = {the double layer with open columns},
+    index     = {Two sheets, ket over bra; each vertical pairing leg
+                 is one contraction $\sum_s A^s\overline{A}^s$.
+                 Cells listed in \tnval{open=} keep their pairing
+                 legs dangling --- here columns 2 and 4, so the
+                 picture is the marginal $\rho_C$ of those columns.},
+    label     = {ex:rmp-doublelayer},
+  ]
+% ket-over-bra double layer; columns 2 and 4 stay open, so the
+% object is the marginal of those columns
+\begin{tenkzplanes}[rows=4, cols=4, sheets={ket, bra},
+                    open={(1-4,2),(1-4,4)}]
+\end{tenkzplanes}
+\end{tnexample}
+
+Ten review figures, and the load was carried by a handful of keys:
+cups with on-bend matrices, \tnval{nopair}, \tnkey{legs at=},
+\tnkey{wires=2}, \tnval{trace=physical}, \tnval{frame=oblique}, and
+the double-layer environment.  What the test could not draw --- the
+bare identity wire inside a bracketed summand, the centred fused wire
+on a tall gauge --- is recorded here beside the figures that need it,
+and again in the roadmap of \S\ref{ch:trouble}.

--- a/docs/tenkz/chapters2/ch-trouble.tex
+++ b/docs/tenkz/chapters2/ch-trouble.tex
@@ -1,0 +1,315 @@
+% chapters2/ch-trouble.tex — troubleshooting and the honest roadmap.
+%
+% Examples are adapted from the corrected test corpus (boundary_test,
+% cups_test (b)/(e), atoms_test A4, hard10_v3) — no invented
+% diagrams.  Fixed-point cups: rho^L west, rho^R east (the referee
+% gate corrected hard04_v3's swapped sides: the east cup is E_A's
+% input, so the fixed point of E_A rides the east bend).  The back-page quick-reference card that belongs to this
+% chapter's scope lives in manual2.tex (the quickrefcard block).
+\section{Troubleshooting and roadmap}\label{ch:trouble}
+
+A \pkg{} picture fails in three ways.  It can assert the wrong
+object --- a map drawn as a scalar, a trace drawn as a cup; it can be
+missing ink the author believes is there, which the package announces
+in the log; or it can be right and unreadable, its labels crowded out
+of their bands.  This chapter gives the shortest correct fix for each,
+in that order, and closes with the package's known limits, stated as
+the mathematics they cannot yet draw.
+
+\subsection{Read the event stream first}
+
+Every picture appends its events to \tnfile{\meta{jobname}.tnlog}: a
+\tnlogline{picture|id=\ldots} line, one \tnlogline{atom} and
+\tnlogline{bond} line per piece of ink, and one
+\tnlogline{boundary|\ldots} line --- the signature.  When a picture
+asserts the wrong object, the log says so before the eye does: read
+the picture's boundary line and ask whether those counts belong to
+the object the formula names.  A matrix keeps two open virtual indices; a
+map on the doubled space keeps four; a scalar keeps none.  The
+classic failure is the transfer map sealed into a scalar, which is
+why open boundaries are the default and sealing is opt-in:
+
+\begin{tnmultiples}[
+    formula   = {\mathcal{E}_A=\sum_i A^i\otimes\overline{A^{i}}},
+    caption   = {a map is not a scalar},
+    index     = {Four stubs are the map's two indices on the doubled
+                 virtual space: the west ket/bra pair and the east
+                 pair.  \tnval{boundary=none} seals all four, and the
+                 sealed picture logs
+                 \tnlogline{virtual-west=0|virtual-east=0} --- it
+                 asserts a scalar, which $\mathcal{E}_A$ is not.  The
+                 fix is deletion: open is the default.},
+    signature = {boundary|virtual-west=2|virtual-east=2|physical-up=0|physical-down=0},
+    variants  = {{default (open)}{}, {boundary=none}{boundary=none}},
+    label     = {ex:sealed-map},
+  ]
+% E_A = sum_i A^i (x) conj(A^i), the unapplied transfer map:
+% a map must keep its four virtual stubs.  Sealing the same
+% source with boundary=none asserts a scalar instead.
+\begin{tenkz}[sandwich, variant]
+  \tn{A} \\
+  \tn*{A}
+\end{tenkz}
+\end{tnmultiples}
+
+An equation is checked side against side: the two pictures log
+consecutive ids, and they denote the same kind of object only if
+their boundary lines agree --- the same counts on the same sides, not
+merely the same totals.
+
+\begin{tnexample}[
+    formula   = {\mathcal{E}_A(\rho^R)=\rho^R},
+    caption   = {both sides log the same boundary line},
+    index     = {Left, the channel's ink with $\rho^R$ riding the east
+                 bend --- the applied channel closes its input side;
+                 right, the bare cap --- two ghost anchors and the
+                 same bend.  The tempting misspelling puts
+                 $\rho^R$ on a single wire (\tncmd{tnX}), which logs
+                 \tnlogline{virtual-west=1|virtual-east=1}: the same
+                 total, the wrong sides.  The signature distinguishes
+                 a matrix on one wire from the same matrix bent across
+                 a ket/bra pair.},
+    signature = {boundary|virtual-west=2|virtual-east=0|physical-up=0|physical-down=0},
+    label     = {ex:fixed-point-check},
+  ]
+% E_A(rho^R) = rho^R, the right fixed point: rho^R rides the
+% east (input) cup, the west (output) pair stays open.  Both
+% pictures log identical boundary lines, so the equation is
+% well formed; the ghosts anchor the bare cap.
+\[
+  \begin{tenkz}[sandwich, east={cup=$\rho^R$}]
+    \tn{A}\\
+    \tn*{A}
+  \end{tenkz}
+  \;=\;
+  \begin{tenkz}[rows={wire,wire}, east={cup=$\rho^R$}]
+    \tnghost{}\\
+    \tnghost{}
+  \end{tenkz}
+\]
+\end{tnexample}
+
+\subsection{A trace is not a cup}
+
+Matching signatures are necessary, never sufficient: two closed
+pictures can log identical boundary lines and denote different
+scalars.  The distinction is topological.  \tnkey{periodic} returns
+each row to \emph{itself} --- the trace over that row's virtual
+space --- while \tnkey{west=cup} and \tnkey{east=cup} tie
+\emph{adjacent rows to each other}, the ket-to-bra contraction.  On a
+sandwich the two closures produce the superoperator trace and the
+trace of the channel's output, and confusing them is the most common
+way to draw a correct-looking wrong number:
+
+\begin{tnmultiples}[
+    formula   = {\operatorname{Tr}\mathcal{E}_A^{2}
+                 \;\text{vs}\;
+                 \operatorname{Tr}\!\bigl[\mathcal{E}_A^{2}(\mathbf{1})\bigr]},
+    caption   = {same signature, different scalars},
+    index     = {\tnval{periodic} returns each row to itself: the left
+                 picture is $\operatorname{Tr}\mathcal{E}_A^{2}$, the
+                 superoperator trace.  The cups tie ket to bra: the
+                 right picture is
+                 $\operatorname{Tr}[\mathcal{E}_A^{2}(\mathbf{1})]$
+                 --- the east cup feeds in $\mathbf{1}$, the west cup
+                 traces the output.  The scalars differ for generic
+                 $A$, yet both pictures log the all-zero line quoted
+                 above.},
+    signature = {boundary|virtual-west=0|virtual-east=0|physical-up=0|physical-down=0},
+    variants  = {{periodic}{periodic},
+                 {west=cup, east=cup}{west=cup, east=cup}},
+    label     = {ex:trace-vs-cup},
+  ]
+% two closures of one two-site sandwich: a trace returns each
+% row to ITSELF; a cup ties the ket row to the bra row.
+% Tr E_A^2 (left) and Tr[E_A^2(1)] (right) differ in general.
+\begin{tenkz}[sandwich, variant]
+  \tn{A} & \tn{A} \\
+  \tn*{A} & \tn*{A}
+\end{tenkz}
+\end{tnmultiples}
+
+\subsection{Invisible ink: ghosts and holes}
+
+\tncmd{tnghost} is invisible ink --- an anchor that draws nothing;
+Example~\ref{ex:fixed-point-check} used it to give a bare cup
+something to bend around.  As a hole it is a trap: a physical pairing
+that meets a ghost silently swallows the live partner's leg, so the
+package warns.  A hole is \tncmd{tnskip}: the \emph{tensor} is
+deleted, its \emph{indices} survive.
+
+\begin{tnexample}[
+    formula   = {\partial_{C}\,\langle\Theta(B)|\Theta(C)\rangle,
+                 \quad |\Theta(C)\rangle=A_L\cdots C\cdots A_R},
+    caption   = {a hole is a deleted tensor, not deleted ink},
+    index     = {The overlap window, differentiated: removing the ket
+                 tensor $C$ leaves the tensor multiplying it, so the
+                 middle ket site is a hole.  \tncmd{tnskip} keeps the
+                 hole's indices open --- no bond bridges the gap, and
+                 the $\overline{B}$ below keeps its upward leg: the
+                 three open ends are exactly $C$'s indices.  A
+                 \tncmd{tnghost} there would drop that leg and
+                 warn.},
+    label     = {ex:hole},
+  ]
+% a tangent-space overlap window (hard10 genre), derivative in
+% the middle ket tensor: the tensor is REMOVED -- \tnskip keeps
+% the hole's virtual stubs open and leaves the bra's physical
+% leg dangling
+\begin{tenkz}[rows={ket, bra}, tensor style=box]
+  \tn{A_L} & \tnskip & \tn{A_R}\\
+  \tn*{A_L} & \tn*{B} & \tn*{A_R}
+\end{tenkz}
+\end{tnexample}
+
+Everything the package refuses to guess, it says in the log, prefixed
+\tnlogline{Package tenkz Warning}.  Six diagnostics recur:
+
+\medskip
+\noindent
+\begin{tabularx}{\textwidth}{@{}>{\raggedright\arraybackslash}p{47mm}
+                             >{\raggedright\arraybackslash}X@{}}
+\toprule
+The log says & The fix \\
+\midrule
+\emph{a physical pairing meets a \tncmd{tnghost} cell \ldots\ the
+partner's leg is dropped} &
+A ghost is invisible ink, not a hole: write \tncmd{tnskip} when the
+site is an uncontracted hole; the partner's leg then stays open. \\
+\addlinespace
+\emph{\tnval{trace=\{(physical, c)\}} \ldots\ needs a tensor cell in a ket row with
+a tensor cell in the bra row directly below} &
+The per-site partial trace contracts a ket's physical index with its
+bra's, so the traced column needs both sites; the cell was left
+untraced. \\
+\bottomrule
+\end{tabularx}
+% the diagnostics table is set as two blocks so a page may break
+% between them
+\smallskip
+\noindent
+\begin{tabularx}{\textwidth}{@{}>{\raggedright\arraybackslash}p{47mm}
+                             >{\raggedright\arraybackslash}X@{}}
+\emph{\tnval{trace=physical} currently closes single-row pictures
+only} &
+The multi-row wrap (outermost up leg into outermost down leg) is on
+the roadmap; no trace ink was drawn.  Restrict the trace to a one-row
+picture. \\
+\addlinespace
+\emph{\tnenv{tenkzplanes} draws the ket-over-bra double layer only} &
+\tnkey{sheets=} beyond \tnval{ket, bra} is on the roadmap; the double
+layer was drawn instead. \\
+\addlinespace
+\emph{\tnval{frame=vertical} does not yet transform \ldots\ the
+construct is skipped} &
+The vertical frame covers plain chains, sandwiches, periodic
+closures, and labels; the rest is horizontal-only.  Rotate the
+figure's grammar, or keep the picture horizontal. \\
+\addlinespace
+\emph{unknown cell-set name \ldots\ in a \tncmd{tnregion} expression}
+(an error) &
+Named cell sets are introduced by \tnval{name=} on an \emph{earlier}
+\tncmd{tnregion} of the same picture; check the spelling and the
+order. \\
+\bottomrule
+\end{tabularx}
+\medskip
+
+\subsection{Crowded labels}
+
+The house doctrine reserves a band for every kind of label
+(\S\ref{ch:house}), but geometry can defeat the default metric.  The
+recurring case: a rail whose open legs point \emph{into} the
+inter-layer gap and, at the default gap, descend onto the lower
+rail's ink.  The fix is \tnkey{layer sep}, a per-picture factor on
+the gap --- not a global \tnkey{pitch} change, which would dilate
+everything.
+
+\begin{tnmultiples}[
+    formula   = {A^{s_1}\!\cdots A^{s_n}\,\rho^R\,
+                 \bigl(A^{s'_1}\!\cdots A^{s'_n}\bigr)^{\dagger}},
+    caption   = {legs into the gap need a wider gap},
+    index     = {Both rails' legs point down
+                 (\tnval{rows=\{bra, bra\}}), so the upper rail's
+                 leg-tip labels descend into the inter-layer gap and,
+                 at the default gap, lose their clearance band.
+                 \tnval{layer sep=2} doubles this picture's gap and
+                 nothing else; the east bend carries the right fixed
+                 point $\rho^R$, the west pair stays open.},
+    variants  = {{default}{}, {layer sep=2}{layer sep=2}},
+    label     = {ex:layer-sep},
+  ]
+% both rails down (hard03 a2 orientation): the upper rail's
+% legs descend INTO the gap; layer sep=2 restores the label
+% band that the default gap denies them
+\begin{tenkz}[rows={bra, bra}, east={cup=$\rho^R$}, variant]
+  \tn[down=$s_1$]{} & \tndots & \tn[down=$s_n$]{}\\
+  \tn*[down=$s'_1$]{} & \tndots & \tn*[down=$s'_n$]{}
+\end{tenkz}
+\end{tnmultiples}
+
+For a single offending label, \tnkey{label pos} and
+\tnkey{label shift} move an atom's name within its cell, and
+\tnkey{no legs} silences a site whose legs carry no information.
+When a whole picture is too tight for its column, prefer
+\tnkey{compact} (one fixed smaller metric) over hand-tuned
+\tnkey{pitch} values.
+
+\subsection{Syntax traps}
+
+% long unbreakable key tokens: let these lists breathe
+\begin{itemize}\emergencystretch=3em\itemsep=2pt\parsep=2pt
+\item \textbf{Brace the value.}  Any key value containing a comma or
+  an equals sign must be braced: \tnval{rows=\{ket:nopair, bra\}},
+  \tnval{east=\{cup=$\rho^R$\}};
+  \tnval{trace=\{(physical, 2-3)\}} keeps its braces ---
+  the value carries a comma of its own.
+\item \textbf{Conjugation is the star.}  The bra-layer glyph is
+  \tncmd{tn*}; there is no \tnval{conj} key, and forgetting the star
+  leaves both layers un-conjugated with no warning: conjugation does
+  not change the counts, so the signature cannot catch it.
+\item \textbf{\tncmd{tnghost} takes an argument.}  Write
+  \tnval{\tncmd{tnghost}\{\}}; without the empty braces it swallows
+  the next token in the row.
+\end{itemize}
+
+\subsection{The roadmap}
+
+What the notation cannot yet draw: near-term items have designed
+spellings, horizon items are design work.
+
+\paragraph{Near term.}
+\begin{itemize}\emergencystretch=3em\itemsep=2pt\parsep=2pt
+\item \emph{Per-side row boundaries.}  A circuit applied to a fixed
+  input state is sealed west and open east, but \tnval{:open} and
+  \tnval{:none} treat \emph{both} ends of a row at once; the planned
+  key is \tnval{west boundary=none}.
+\item \emph{The identity strand.}  The tangent-space projector's
+  summand $P_L^{(i-1)}\otimes\mathbf{1}_i\otimes P_R^{(i+1)}$ needs a
+  bare vertical wire at site $i$; every piece of \pkg{} ink anchors
+  on a glyph, so $\mathbf{1}_i$ is today carried by algebra, not ink.
+\item \emph{Fused tall capsules.}  A gauge capsule spanning ket and
+  bra (\tnval{wires=2}) whose wire pair should continue as \emph{one}
+  combined stub; \tnkey{combined=} lives on \tncmd{tnfuse} only.
+\item \emph{Mirrored triangles.}  \tnkey{tri=} draws one orientation;
+  the mirror, needed for reflected canonical-form identities, is
+  pending.
+\item \emph{The vertical frame's missing passes.}  Cups, physical
+  traces, braces, cuts, and bond labels still assume the horizontal
+  frame; a vertical picture warns and skips them.
+\end{itemize}
+
+\paragraph{The horizon.}
+Inter-sheet closures --- $\langle\Psi|\Psi\rangle$ of a PEPS as one
+picture, the two-dimensional analogue of \tnkey{west=cup}; an
+operator sheet between ket and bra (\tnkey{sheets=} today stops at
+\tnval{ket, bra}); physical-leg arrows and directed signatures ---
+the $V$-versus-$V^{*}$ mark that graded and fermionic networks need,
+on the leg and in the boundary line; the splitting glyph, the mirror
+of \tncmd{tnfuse} and the zipper identity's missing right-hand side;
+\tncmd{tndefine}, binding a name to a glyph and its default legs
+once per document; and the web pipeline: the \tnfile{.tnlog} stream
+rendered as SVG, these diagrams on web pages without \TeX.
+
+Until then the discipline of this manual holds on its own: state the
+formula, draw the ink, and read the signature back.

--- a/docs/tenkz/chapters2/ch-tutorial.tex
+++ b/docs/tenkz/chapters2/ch-tutorial.tex
@@ -1,0 +1,328 @@
+% chapters2/ch-tutorial.tex — the tutorial: the benchmark corpus B1–B8
+% rebuilt formula-first on the 0.5 boundary doctrine.
+%
+% Sources: the corrected acceptance corpus (part_B1..B8, boundary_test,
+% channel_test, pentagon_corrected).  Every diagram keeps the default
+% open boundary — stubs are matrix indices — and every printed equation
+% has matching boundary signatures on its two sides; the one identity
+% that cannot yet satisfy that rule (the zipper) is shown one-sided and
+% deferred to the roadmap.
+\section{Tutorial}\label{ch:tutorial}
+
+The tutorial assembles a working vocabulary one declaration at a time:
+a chain, an equation, a sandwich, a cup, a blocked word, a fused pair,
+a lattice window, a pentagon, a picture inside a sentence.  Each
+concept is stated as mathematics before it is typed as source, built
+from the package's benchmark corpus B1--B8; the dictionary of
+\S\ref{ch:mathematics} fixes what the ink means, and where that
+chapter has already drawn a concept's canonical picture the tutorial
+points there instead of re-drawing it, spending its own ink on what
+is new.  It ends where the dictionary begins, with one chain closed
+three ways.
+
+% ---------------------------------------------------------------------
+\subsection{One row: sites, wires, stubs}\label{sec:tut-row}
+
+A picture is a grid whose rows are layers and whose columns are sites:
+\verb|&| moves one site east, \verb|\\| one layer down, and adjacent
+cells in a row contract implicitly --- the wire between two tensors is
+their summed virtual index.  \tnkey{physical=up} types the row as a
+ket layer, growing an upward leg on every site, labelled at its tip by
+the \tnkey{up} cell key.  The ends of the wire stay open by default
+and render as protruding stubs: the row and column indices of the
+matrix word.  \tnkey{west label} and \tnkey{east label} name them at
+their tips, and \tnkey{bond label} names one addressed bond.
+
+\begin{tnexample}[
+    formula   = {\bigl(A^{i_1}A^{i_2}A^{i_3}\bigr)_{\alpha\beta}},
+    caption   = {a three-site matrix-product word},
+    index     = {Dots are sites; the wire through them is the
+                 contracted virtual index, with the bond $1$--$2$
+                 carrying the dimension label $D$.  The stubs are the
+                 open matrix indices, named $\alpha$, $\beta$ at their
+                 tips; each up leg carries one physical index.},
+    signature = {boundary|virtual-west=1|virtual-east=1|physical-up=3|physical-down=0},
+    label     = {ex:tut-chain},
+  ]
+% (A^{i_1} A^{i_2} A^{i_3})_{alpha beta}: one matrix per
+% site; the wire is the summed virtual index, the stubs are
+% the open matrix indices alpha, beta
+\begin{tenkz}[physical=up, west label=$\alpha$,
+              east label=$\beta$, bond label={$D$ at 1-2}]
+  \tn[up=$i_1$]{A} & \tn[up=$i_2$]{A} & \tn[up=$i_3$]{A}
+\end{tenkz}
+\end{tnexample}
+
+The source of Example~\ref{ex:tut-chain} contains no coordinate, no
+anchor, no offset: leg-tip, bond, and boundary labels sit in reserved
+bands computed from the metric, so they clear the ink at every pitch
+and under every glyph policy (\S\ref{ch:modes}).
+
+% ---------------------------------------------------------------------
+\subsection{Equations on the wire axis}\label{sec:tut-axis}
+
+Every picture is a math atom whose wire axis is pinned to the math
+axis of the surrounding formula, so \texttt{=}, $\otimes$, $\sum$, and
+stretchy parentheses compose pictures with no glue commands.  The
+gauge equation of Example~\ref{ex:gauge-eq} is typed exactly that
+way: two \tnenv{tenkz} pictures around a bare \verb|=| inside display
+math, wires and equals sign collinear because each picture behaves as
+one math atom.  \tncmd{tnX} sets a matrix \emph{on} the wire --- a
+capsule of pinned height, so $X$ and $X^{-1}$ render at the same size
+--- and adds no legs, which is what keeps the equation well-formed:
+both sides write the same boundary signature, and diffing the two
+\tnfile{.tnlog} lines is the mechanical half of checking a
+diagrammatic equation (\S\ref{sec:signatures}).
+
+% ---------------------------------------------------------------------
+\subsection{Typed rows and the sandwich}\label{sec:tut-layers}
+
+Multi-layer pictures are typed, not drawn: \tnkey{rows=\{ket, op,
+bra\}} declares a state layer, an operator layer, a conjugate state
+layer, and facing legs pair automatically, column by column; only the
+outermost legs stay open.  The starred cell \tncmd{tn*} is the
+conjugate tensor, its label overlined.  The two-layer case earns its
+own word --- \tnkey{sandwich} abbreviates \tnval{rows=\{ket, bra\}}
+--- and the transfer map of Example~\ref{ex:transfer-open} is its
+canonical inhabitant: ket over bra, the paired physical legs the
+summed index $i$, all four virtual stubs open, because a map on the
+doubled space is a matrix.  The picture draws no dagger, although the
+formula it denotes, $\mathcal{E}_A(X)=\sum_i A^{i}XA^{i\dagger}$,
+contains one: the star is ink, the transpose is reading order --- the
+arrow-free convention of \S\ref{sec:conjugate}.
+
+% ---------------------------------------------------------------------
+\subsection{Cups: closing one side}\label{sec:tut-cups}
+
+A cup ties the ends of two adjacent rows into a single bend:
+\tnkey{west=cup} on the left, \tnkey{east=cup} on the right, and
+an optional braced argument sets a matrix on the bend's apex.  One
+cup turns the unapplied transfer map into the applied channel of
+Example~\ref{ex:channel-x}: \tnval{east=\{cup=$X$\}} added to the
+sandwich and nothing else, the east bend consuming the input slot.
+The west pair must stay open: closing that side as well would draw
+the scalar $\operatorname{Tr}\mathcal{E}_A(X)$.  A bare cup is the
+identity on its open pair (Example~\ref{ex:ortho-cup}); with a fixed
+point on the apex, as in \tnval{east=\{cup=$\rho^R$\}}, the same
+construction draws the fixed-point equations and reduced density
+matrices of \S\ref{ch:rmp}.\sidenote{Boundary policy is per-row too:
+\tnval{rows=\{op:open, ket:none\}} keeps an operator row's virtual
+indices open above a sealed state row.  \S\ref{ch:reference} lists the
+row modifiers.}
+
+% ---------------------------------------------------------------------
+\subsection{Blocking: braces, ellipses, wide glyphs}\label{sec:tut-block}
+
+Blocking $L$ sites into one is three devices in a single source:
+\tncmd{tnspan} sets a brace over a run of columns starting at the
+current cell, \tncmd{tndots} is the ellipsis cell that interrupts the
+wire without closing it, and a \tnkey{wide=2} \tnkey{pill} glyph spans
+two columns, growing sideways --- never taller --- to hold the blocked
+label.
+
+\begin{tnexample}[
+    formula   = {\bigl(A^{(L)}\bigr)^{i_1\cdots i_L}
+                 = A^{i_1}\!\cdots A^{i_L}},
+    caption   = {blocking $L$ sites into one},
+    index     = {The brace spans the four columns of the word;
+                 \tncmd{tndots} interrupts the wire without closing
+                 it.  Under an ellipsis the drawn leg count is
+                 schematic: the left picture logs three up legs, the
+                 pill logs one wide leg standing for the whole
+                 $L$-tuple, so this is the one equation whose
+                 signatures are compared by eye, not by diff.},
+    label     = {ex:tut-block},
+  ]
+% (A^{(L)})^{i_1...i_L} = A^{i_1} ... A^{i_L}: the brace and
+% the ellipsis keep the site count schematic; the pill spans
+% two columns and carries the blocked physical index
+\[
+  \begin{tenkz}[physical=up]
+    \tn[up=$i_1$]{A}\tnspan[brace below]{4}{L\text{ copies}} &
+    \tn[up=$i_2$]{A} & \tndots & \tn[up=$i_L$]{A}
+  \end{tenkz}
+  \;=\;
+  \begin{tenkz}[physical=up]
+    \tn[pill, wide=2, up={$i_1\cdots i_L$}]{A^{(L)}}
+  \end{tenkz}
+\]
+\end{tnexample}
+
+% ---------------------------------------------------------------------
+\subsection{Fusing two wires into one}\label{sec:tut-fuse}
+
+An MPO acting on an MPS leaves two virtual wires on each side of the
+window; the fusing wedge \tncmd{tnfuse} merges such a pair into one
+combined index.  The wedge spans its own row and the next, and its
+combined leg --- leaving west by default --- is \emph{one} open index:
+a fuse consumes its side's boundary pair.
+
+\begin{tnexample}[
+    formula   = {\begin{aligned}[t]
+                   &V\,T^{s_1}\!\cdots T^{s_n},\\
+                   &T^{s}=\textstyle\sum_{s'}O^{ss'}\!\otimes A^{s'}
+                 \end{aligned}},
+    caption   = {the fusing wedge},
+    index     = {Each column is the composite tensor $T^{s}$ on the
+                 paired virtual space: the op row's down legs pair
+                 into the ket row's up legs, and the open up legs are
+                 the physical indices.  The single stroke leaving the
+                 wedge west is the combined index --- one open leg
+                 where the pair entered.},
+    signature = {boundary|virtual-west=1|virtual-east=2|physical-up=2|physical-down=0},
+    label     = {ex:tut-fuse},
+  ]
+% V T^{s_1} ... T^{s_n} with T^s = sum_{s'} O^{s s'} (x) A^{s'}:
+% the wedge V consumes the west pair; its combined leg is one
+% open index
+\begin{tenkz}[rows={op, ket}]
+  \tnfuse[span=2]{V} &
+  \tn[mpo]{O}\tnspan[brace above]{3}{n} &
+  \tndots & \tn[mpo]{O} \\
+  & \tn{A} & \tndots & \tn{A}
+\end{tenkz}
+\end{tnexample}
+
+\tnkey{combined=east} mirrors the wedge for the other end of a chain.
+What the wedge cannot yet do is stand on both sides of the zipper
+(pulling-through) identity: the identity's right-hand side needs the
+mirror-image \emph{splitting} glyph, one combined bond opening back
+into its pair.  Until that glyph exists, the two mirrored spellings
+log mirrored signatures --- one combined stub west against one
+combined stub east --- and may not face each other across an equals
+sign.  The splitting glyph is on the roadmap
+(\S\ref{ch:trouble}).
+
+% ---------------------------------------------------------------------
+\subsection{The lattice window}\label{sec:tut-lattice}
+
+Region schematics over a lattice window are cell-set data, never
+hand-traced polygons: \tncmd{tnregion} takes a set expression built
+from rectangles, singletons, registered names, and $+$/$-$ for union
+and difference, and the tracer computes the rectilinear boundary ---
+notches, holes, interior loops --- from the member sites.  Regions
+bind to semantic slots that carry document-wide colours, so ``the
+selected region'' looks the same in every figure.
+
+\begin{tnexample}[
+    formula   = {S = R\smallsetminus\{(2,2)\}},
+    caption   = {a window, a region, a hole},
+    index     = {\tnval{slot=selected} fills $R=(1$--$3)\times
+                 (1$--$3)$; \tnval{secondary} with \tnkey{outline}
+                 traces $S$, acquiring an interior loop around the
+                 removed site.  The rim legs are the virtual indices
+                 the window cuts; one distinguished edge is marked.},
+    label     = {ex:tut-lattice},
+  ]
+% R = (1-3, 1-3); S = R minus (2,2): the tracer computes the
+% outer boundary and the interior loop around the hole;
+% boundary legs mark the bonds the window cuts
+\begin{tenkzlattice}[rows=4, cols=4, boundary legs]
+  \tnregion[slot=selected,  name=R, label=$R$]{(1-3, 1-3)}
+  \tnregion[slot=secondary, outline, label=$S$,
+            label at=south west]{R - (2,2)}
+  \tnedge[distinguished]{(2,3)-(2,4)}
+  \tnsite[removed]{(2,2)}
+\end{tenkzlattice}
+\end{tnexample}
+
+% ---------------------------------------------------------------------
+\subsection{Fusion trees and the pentagon}\label{sec:tut-cd}
+
+Commutative diagrams are not contractions, so they live in their own
+environment.  In \tnenv{tenkzcd}'s polygon mode, \tnkey{polygon=5}
+sets five cells on a circle, vertex $1$ on top, clockwise;
+\tncmd{tntree} builds a fusion tree from a parenthesised word whose
+subscripts are the internal charges; \tncmd{tnarrow} draws a labelled
+arrow between vertices, and the starred form sets its label on the
+arrow's other side.
+
+\begin{tnexample}[
+    formula   = {\begin{aligned}[t]
+                   &\textstyle\sum_{u}
+                    \bigl[F^{abc}_{y}\bigr]_{xu}
+                    \bigl[F^{aud}_{e}\bigr]_{yw}\\
+                   &\hspace{2.1em}\times
+                    \bigl[F^{bcd}_{w}\bigr]_{uv}\\
+                   &=\bigl[F^{xcd}_{e}\bigr]_{yv}
+                     \bigl[F^{abv}_{e}\bigr]_{xw}
+                 \end{aligned}},
+    caption   = {the pentagon},
+    index     = {Each \tncmd{tntree} word is one association of
+                 $a,b,c,d$ fusing to $e$; the subscripts $x=ab$,
+                 $y=abc$, $u=bc$, $w=bcd$, $v=cd$ are the internal
+                 charges.  The two arrow paths from vertex $1$ to
+                 vertex $4$ compose to the same map, with the sum
+                 over $u$ running along the three-move path.},
+    label     = {ex:tut-pentagon},
+  ]
+% pentagon for a,b,c,d -> e; internal charges x=ab, y=abc,
+% u=bc, w=bcd, v=cd; the two F-move paths from vertex 1 to
+% vertex 4 agree, with a sum over u on the three-move path
+\begin{tenkzcd}[polygon=5, radius=32mm]
+  \tntree{(((a\,b)_x\,c)_y\,d)_e} &
+  \tntree{((a\,(b\,c)_u)_y\,d)_e} &
+  \tntree{(a\,((b\,c)_u\,d)_w)_e} &
+  \tntree{(a\,(b\,(c\,d)_v)_w)_e} &
+  \tntree{((a\,b)_x\,(c\,d)_v)_e}
+  \tnarrow[from=1, to=2]{F^{abc}_y}
+  \tnarrow[from=2, to=3]{F^{aud}_e}
+  \tnarrow[from=3, to=4]{F^{bcd}_w}
+  \tnarrow*[from=1, to=5]{F^{xcd}_e}
+  \tnarrow*[from=5, to=4]{F^{abv}_e}
+\end{tenkzcd}
+\end{tnexample}
+
+The tree is its word: \verb|(((a\,b)_x\,c)_y\,d)_e| says fuse $a$ with
+$b$ into $x$, then with $c$ into $y$, then with $d$ into the total
+charge $e$.  Every $F$-symbol slot holds a simple charge --- the mixed
+slots carry $x$, $u$, $v$, never a composite label like
+$bc$.\sidenote{Conventions of arXiv:1511.08090, eq.~(33): fused
+charges up, total charge down, the $F$-move mapping the
+left-associated tree to the right-associated one.}
+
+% ---------------------------------------------------------------------
+\subsection{A picture in a sentence}\label{sec:tut-inline}
+
+\tncmd{tnpic} is the command form of the environment --- the same
+grammar, the same keys --- and its \tnkey{inline} profile tightens the
+metric enough to sit inside running mathematics:
+
+\begin{tnexample}[
+    formula   = {X\succeq 0\;\Rightarrow\;\mathcal{E}_A(X)\succeq 0},
+    caption   = {a picture in running math},
+    index     = {The \tnkey{inline} profile shrinks the pitch,
+                 shortens the legs faster than the pitch, and
+                 tightens the label bands to spare the line height.
+                 The summand is the unapplied sandwich: four stubs,
+                 a map.},
+    signature = {boundary|virtual-west=2|virtual-east=2|physical-up=0|physical-down=0},
+    label     = {ex:tut-inline},
+  ]
+% each summand of E_A is the congruence X -> A^i X (A^i)^dagger
+Positivity is termwise: since
+$\mathcal{E}_A(X)=\sum_{i}\,
+ \tnpic[sandwich, inline]{\tn{A^i} \\ \tn*{A^i}}\,(X)$,
+each summand is a congruence, and a sum of congruences
+preserves positivity.
+\end{tnexample}
+
+% ---------------------------------------------------------------------
+\subsection{One chain, three closures}\label{sec:tut-closures}
+
+The vocabulary can now say precisely what the tutorial's first chain
+denotes --- three different objects, depending on nothing but its
+boundary key.  Example~\ref{ex:read-closures} ran the gallery over a
+two-site word, and the same three closures apply verbatim to the
+chain of Example~\ref{ex:tut-chain}: \tnval{boundary=open} keeps the
+matrix word $(A^{i_1}A^{i_2}A^{i_3})_{\alpha\beta}$,
+\tnval{boundary=none} seals it into one number $c_{i_1i_2i_3}$ per
+configuration, and \tnval{periodic} returns the wire to itself ---
+the trace $\operatorname{Tr}\bigl(A^{i_1}A^{i_2}A^{i_3}\bigr)$.
+Nothing but the boundary key changes, and with it the object.
+
+From here the manual forks: \S\ref{ch:worked} composes this vocabulary
+into expectation-value windows and multi-layer identities,
+\S\ref{ch:modes} varies the glyph and metric systems over fixed
+sources, and \S\ref{ch:reference} lists every environment, command,
+and key.

--- a/docs/tenkz/chapters2/ch-worked.tex
+++ b/docs/tenkz/chapters2/ch-worked.tex
@@ -1,0 +1,260 @@
+% chapters2/ch-worked.tex — worked examples.  Six objects, each carried
+% from formula to finished diagram: the expectation-value window, an
+% MPO--MPO product (operator hue + dir), a periodic operator on a
+% periodic state, the entanglement cut, gauge insertions on a fused
+% chain, and the zipper with its tracked splitting-glyph note.  All
+% sources are adapted from the verified Phase-0.5 corpus (gallery
+% S1--S5 and B7) — none are invented for this chapter; every quoted
+% signature line was checked against the emitter's .tnlog output.
+\section{Worked examples}\label{ch:worked}
+
+The six diagrams of this chapter are the ones a working physicist draws
+between two lines of a calculation: a window of an expectation value, a
+product of two matrix-product operators, an operator acting on a
+periodic state, an entanglement cut, a gauge transformation on a
+blocked chain, and the zipper that pulls an operator through a state.
+Each is carried from formula to finished picture.  The margin records
+which ink is which index, and the quoted \tnfile{.tnlog} line says why
+each boundary comes out open or closed --- the bookkeeping of
+\S\ref{ch:mathematics}, applied.
+
+% ---------------------------------------------------------------------
+\subsection{The expectation-value window}\label{sec:worked-window}
+
+An expectation value $\langle\psi|O_1O_2O_3|\psi\rangle$ in a
+matrix-product state is a three-layer contraction: the ket word above,
+the operator between, the conjugate word below.
+Example~\ref{ex:worked-window} draws three columns of it as a
+\emph{window}: each column contracts its physical indices vertically,
+and every virtual index is left protruding.  A window is a map on the
+tripled bond space --- one column is the dressed transfer matrix
+$\mathbb{E}_O$ of the margin --- so the picture must keep all six
+stubs.  Sealing them with \tnkey{boundary=none} would assert a scalar
+that the mathematics does not contain; capping them with boundary
+vectors or fixed points is the business of cups (\S\ref{ch:rmp}).
+
+\begin{tnexample}[
+    formula   = {\mathbb{E}_O=\sum_{s,s'}A^{s}\otimes O^{ss'}
+                 \otimes\bar A^{s'}},
+    caption   = {a window of $\langle\psi|O|\psi\rangle$},
+    index     = {Top to bottom: ket row $A$, operator row $O$ (an
+                 \tnval{mpo} atom keeps an up and a down leg), bra row
+                 $\bar A$.  Each column contracts its physical indices
+                 vertically; the six stubs, three per side, are the
+                 window's virtual matrix indices.},
+    signature = {boundary|virtual-west=3|virtual-east=3|physical-up=0|physical-down=0},
+    label     = {ex:worked-window},
+  ]
+% a window of <psi|O|psi>: ket over operator over bra; each
+% column contracts its physical indices vertically (ket-op,
+% then op-bra); all six virtual indices protrude -- a window
+% of a larger contraction is a map, never a scalar
+\begin{tenkz}[rows={ket, op, bra}]
+  \tn{A} & \tn{A} & \tn{A} \\
+  \tn[mpo]{O} & \tn[mpo]{O} & \tn[mpo]{O} \\
+  \tn*{A} & \tn*{A} & \tn*{A}
+\end{tenkz}
+\end{tnexample}
+
+% ---------------------------------------------------------------------
+\subsection{A product of matrix-product operators}\label{sec:worked-mpoprod}
+
+Stacking two matrix-product operators multiplies them: each column of
+Example~\ref{ex:worked-mpoprod} contracts the physical index between
+$T_g$ and $T_h$, and the result is again a matrix-product operator
+whose site tensor is the margin's $\sum_r T_g^{sr}\otimes T_h^{rs'}$.
+Two pieces of apparatus earn their keep here.  The row modifier
+\tnval{operator} hues the wire, so that in pictures where state and
+operator bonds coexist the two species stay distinguishable at a
+glance.  And \tnval{dir right} puts a barb on every bond: an arrow
+leaving a glyph is an index in the bond space $V$, an arrow entering
+one is an index in the dual $V^{*}$, and reversing every arrow passes
+to the dual representation.\sidenote{The signature counts indices; it
+does not yet record their orientation.  Directed boundary signatures
+are on the roadmap (\S\ref{ch:trouble}).}  Orientation starts to
+matter exactly in this genre --- when the $T_g$ represent a group and
+$T_gT_h=T_{gh}$ holds only up to isometries on the hued bonds.
+
+\begin{tnexample}[
+    formula   = {(T_gT_h)^{ss'}=\sum_{r}T_g^{sr}\otimes T_h^{rs'}},
+    caption   = {the product $T_gT_h$, hued and directed},
+    index     = {Both rows are operator rows: the wires take the
+                 operator hue, and each bond's barb points east ---
+                 out of one glyph ($V$) and into the next ($V^{*}$).
+                 The four stubs are the two operator bonds' matrix
+                 indices; each column keeps one up and one down
+                 physical leg.},
+    signature = {boundary|virtual-west=2|virtual-east=2|physical-up=2|physical-down=2},
+    label     = {ex:worked-mpoprod},
+  ]
+% T_g over T_h: each column contracts one physical index
+% between the layers; `operator' hues both bonds as MPO
+% bonds and `dir right' orients them, arrow out = V,
+% arrow in = V*
+\begin{tenkz}[rows={op:operator:dir right,
+                    op:operator:dir right}]
+  \tn[mpo]{T_g} & \tndots & \tn[mpo]{T_g} \\
+  \tn[mpo]{T_h} & \tndots & \tn[mpo]{T_h}
+\end{tenkz}
+\end{tnexample}
+
+% ---------------------------------------------------------------------
+\subsection{A periodic operator on a periodic state}\label{sec:worked-opsi}
+
+On a ring both the state and the operator close, and the coefficients
+of $O|\psi\rangle$ are a pair of traces with the physical $j$'s
+contracted between them.  The key \tnval{periodic} closes \emph{each
+wire row to itself} by a return loop around its own layer --- the
+row-to-self closure, the diagrammatic trace --- which is a different
+topology from the cups of \tnval{west=cup}/\tnval{east=cup}, which
+tie adjacent rows to each other (\S\ref{ch:mathematics}).  Here the
+right topology is one return wire per layer, two separate traces; the
+only open ink left is the row of $i$'s above, so the picture \emph{is}
+the tensor $(O|\psi\rangle)^{i_1i_2i_3}$.
+
+\begin{tnexample}[
+    formula   = {\begin{gathered}(O|\psi\rangle)^{i_1i_2i_3}\\
+                 =\textstyle\sum_{\vec\jmath}\operatorname{Tr}
+                 \bigl[M^{i_1j_1}M^{i_2j_2}M^{i_3j_3}\bigr]\\
+                 \quad\times\operatorname{Tr}
+                 \bigl[A^{j_1}A^{j_2}A^{j_3}\bigr]\end{gathered}},
+    caption   = {$O|\psi\rangle$, periodic on periodic},
+    index     = {No stubs anywhere: each row's wire returns to itself,
+                 one trace per layer.  The $j$'s contract between the
+                 rows; the three $i$'s above are the only open ink.},
+    signature = {boundary|virtual-west=0|virtual-east=0|physical-up=3|physical-down=0},
+    label     = {ex:worked-opsi},
+  ]
+% O|psi>, periodic on periodic: `periodic' closes EACH row
+% to itself (one return loop per layer, so one trace per
+% layer); the j's contract between the rows; the i's stay
+% open above
+\begin{tenkz}[periodic, rows={op, ket}]
+  \tn[mpo]{M} & \tn[mpo]{M} & \tn[mpo]{M} \\
+  \tn{A} & \tn{A} & \tn{A}
+\end{tenkz}
+\end{tnexample}
+
+% ---------------------------------------------------------------------
+\subsection{The entanglement cut}\label{sec:worked-cut}
+
+A cut is a statement about a bond, not a change to the network.
+\tncmd{tncut}, attached to a cell, hangs a dashed stroke across the
+bond east of that cell and sets its label beside it.  In
+Example~\ref{ex:worked-cut} it marks the bond severed in the Schmidt
+decomposition of the bipartition $[1,2]\,|\,[3,4]$ --- the virtual
+index whose spectrum gives the entanglement entropy of the margin.
+Because a cut is annotation ink, the signature is exactly that of the
+undecorated word, and an equation between a cut picture and an uncut
+one is well-formed.
+
+\begin{tnexample}[
+    formula   = {S_{[1,2]}=-\operatorname{Tr}\,
+                 \rho_{[1,2]}\log\rho_{[1,2]}},
+    caption   = {an entanglement cut},
+    index     = {The dashed stroke crosses one bond --- the index
+                 summed in the Schmidt decomposition across
+                 $[1,2]\,|\,[3,4]$.  A cut adds no index and removes
+                 none: the signature is the uncut word's.},
+    signature = {boundary|virtual-west=1|virtual-east=1|physical-up=4|physical-down=0},
+    label     = {ex:worked-cut},
+  ]
+% a four-site word; the cut is annotation ink crossing the
+% bond between sites 2 and 3 -- the Schmidt index of the
+% bipartition [1,2] | [3,4]; no index changes
+\begin{tenkz}[physical=up]
+  \tn{A} & \tn{A}\tncut{S_{[1,2]}} & \tn{A} & \tn{A}
+\end{tenkz}
+\end{tnexample}
+
+% ---------------------------------------------------------------------
+\subsection{Fused gauge chains}\label{sec:worked-fused}
+
+Blocking sites fuses their bonds, and the row modifier \tnval{fused}
+draws the blocked bond as a doubled strand, so a coarse-grained chain
+never masquerades as a microscopic one.  On the fused wire the gauge
+freedom of a chain becomes visible arithmetic: \tncmd{tnX} capsules
+put $X$ and $X^{-1}$ on the wire between the blocks, and the value of
+Example~\ref{ex:worked-fused} is the matrix product
+$B_1XB_2X^{-1}B_3$, read west to east.  Whether one absorbs the
+capsules outward, $(B_1X)\,B_2\,(X^{-1}B_3)$, or inward,
+$B_1\,(XB_2X^{-1})\,B_3$, is invisible in the ink --- associativity
+has no diagram --- and that invisibility is the gauge freedom: the
+picture fixes the product, never the grouping.
+
+\begin{tnexample}[
+    formula   = {\begin{gathered}(B_1X)\,B_2\,(X^{-1}B_3)\\
+                 =B_1\,(XB_2X^{-1})\,B_3\end{gathered}},
+    caption   = {gauge insertions on a fused wire},
+    index     = {The doubled strand is the fused bond space; $X$ and
+                 $X^{-1}$ ride it as capsules.  Absorbing a capsule
+                 into a neighbouring block moves a block boundary;
+                 the two end stubs are the chain's matrix indices.},
+    signature = {boundary|virtual-west=1|virtual-east=1|physical-up=0|physical-down=0},
+    label     = {ex:worked-fused},
+  ]
+% three blocks on one fused (doubled) wire; X and X^{-1} are
+% matrices ON the wire: regrouping them into the neighbouring
+% blocks moves the block boundaries without changing the
+% product
+\begin{tenkz}[rows={wire:fused}]
+  \tn[box]{B_1} & \tnX{X} & \tn[box]{B_2} & \tnX{X^{-1}} &
+  \tn[box]{B_3}
+\end{tenkz}
+\end{tnexample}
+
+% ---------------------------------------------------------------------
+\subsection{The zipper}\label{sec:worked-zipper}
+
+The zipper pulls an operator through a state
+(arXiv:2203.12563, eq.~(28)): a fusion isometry
+$V:\mathbb{C}^{D_O}\!\otimes\mathbb{C}^{D_A}\to\mathbb{C}^{D_B}$ eats
+the operator and state bonds at one end, and out comes a word of fused
+sites, $B^{i}\,V=\sum_{j}V\,(O^{ij}\otimes A^{j})$, with $V$ waiting
+at the other end.  On the left of Example~\ref{ex:worked-zipper},
+\tncmd{tnfuse} with \tnval{rows=2} terminates both layers' wires on
+one glyph whose single west leg is the combined index; the east
+$O$/$A$ pair stays open.  On the right the fused word runs on a single
+wire.  The two sides do not yet balance as
+pictures: the right-hand end should carry a
+bond-\emph{splitting} glyph --- $V$ standing at the east end of a
+one-row word, splitting the fused bond back into the $O$/$A$ pair.
+That glyph is a tracked primitive (\S\ref{ch:trouble}); until it
+lands, $V$ closes the equation as a symbol, and the two signature
+lines in the margin record exactly the index it stands in for.
+
+\begin{tnexample}[
+    formula   = {\begin{gathered}
+                 V\bigl(O^{[1,n]}\otimes A^{[1,n]}\bigr)
+                 =B^{[1,n]}\,V\\
+                 B^{i}\,V=\sum_{j}V\,(O^{ij}\otimes A^{j})
+                 \end{gathered}},
+    caption   = {the zipper},
+    index     = {LHS \tnlogline{virtual-west=1|virtual-east=2}: $V$'s
+                 combined leg west, the open $O$/$A$ pair east.  RHS
+                 \tnlogline{virtual-west=1|virtual-east=1}: the east
+                 index is the fused bond, closed here by the printed
+                 symbol $V$ --- the splitting glyph's stand-in.  Both
+                 sides read \tnlogline{physical-up=2} as drawn.},
+    label     = {ex:worked-zipper},
+  ]
+% zipper (arXiv:2203.12563 eq 28): V fuses the O and A bond
+% spaces, C^{D_O} x C^{D_A} -> C^{D_B}
+\[
+  \begin{tenkz}[rows={op, ket}]
+    \tnfuse[span=2]{V} &
+    \tn[mpo]{O}\tnspan[brace above]{3}{n} &
+    \tndots & \tn[mpo]{O} \\
+    & \tn{A} & \tndots & \tn{A}
+  \end{tenkz}
+  \;=\;
+  % the bond-SPLITTING glyph (V at the east end of a one-row
+  % word) is a tracked primitive: until it lands, V closes
+  % the fused index of the right-hand word as a symbol
+  \begin{tenkz}[physical=up]
+    \tn[box, up=$i_1$]{B}\tnspan[brace above]{3}{n} &
+    \tndots & \tn[box, up=$i_n$]{B}
+  \end{tenkz}
+  \,V
+\]
+\end{tnexample}

--- a/docs/tenkz/chapters2/ch-worked.tex
+++ b/docs/tenkz/chapters2/ch-worked.tex
@@ -212,7 +212,7 @@ $V:\mathbb{C}^{D_O}\!\otimes\mathbb{C}^{D_A}\to\mathbb{C}^{D_B}$ eats
 the operator and state bonds at one end, and out comes a word of fused
 sites, $B^{i}\,V=\sum_{j}V\,(O^{ij}\otimes A^{j})$, with $V$ waiting
 at the other end.  On the left of Example~\ref{ex:worked-zipper},
-\tncmd{tnfuse} with \tnval{rows=2} terminates both layers' wires on
+\tncmd{tnfuse} with \tnval{span=2} terminates both layers' wires on
 one glyph whose single west leg is the combined index; the east
 $O$/$A$ pair stays open.  On the right the fused word runs on a single
 wire.  The two sides do not yet balance as

--- a/docs/tenkz/manual2.tex
+++ b/docs/tenkz/manual2.tex
@@ -170,14 +170,14 @@ whole language.
 %  Chapters (one file per chapter; they run on, Tufte-handout style —
 %  the page budget is spent on examples, not on chapter-break whitespace)
 % =====================================================================
-\input{chapters2/ch2-mathematics}
+\input{chapters2/ch-mathematics}
 \input{chapters2/ch-tutorial}
-\input{chapters2/ch3-worked}
-\input{chapters2/ch4-modes-multiples}
-\input{chapters2/ch5-rmp}
-\input{chapters2/ch6-reference}
+\input{chapters2/ch-worked}
+\input{chapters2/ch-modes}
+\input{chapters2/ch-rmp}
+\input{chapters2/ch-reference}
 \input{chapters2/ch-house}
-\input{chapters2/ch8-trouble-roadmap}
+\input{chapters2/ch-trouble}
 
 % =====================================================================
 %  Back page — the quick-reference card (content owned by the

--- a/docs/tenkz/manual2.tex
+++ b/docs/tenkz/manual2.tex
@@ -1,0 +1,294 @@
+% manual2.tex — the tenkz manual, second edition.
+%
+% A new document, not a revision of manual.tex: the page is an asymmetric
+% grid with a 50 mm margin column, and every example is one measured unit —
+% formula in the margin, rendered diagram first, quiet source block beneath,
+% ink-to-index correspondence as a numbered sidenote.  All examples are
+% live-compiled through tenkzmanual2.sty; nothing rendered here is pasted.
+%
+% Compile from docs/tenkz/ (two passes for the table of contents):
+%
+%   TEXINPUTS="../../tex/tenkz//:" xelatex manual2.tex
+%
+\documentclass[11pt]{article}
+\usepackage{tenkzmanual2}
+\usepackage[colorlinks=true, linkcolor=tenkzMarked,
+            urlcolor=tenkzMarked]{hyperref}
+\pdfstringdefDisableCommands{%
+  \def\tncmd#1{\textbackslash #1}%
+  \def\tnenv#1{#1}%
+  \def\tnkey#1{#1}%
+  \def\tnval#1{#1}%
+  \def\tnfile#1{#1}%
+}
+\hypersetup{pdftitle={The tenkz manual, second edition},
+            pdfauthor={The TNLean project}}
+
+\newcommand\pkg{\texttt{tenkz}}
+
+\begin{document}
+
+% =====================================================================
+%  Title page — the hero row is live: three diagrams compiled from the
+%  package on every run, including the canonical channel spelling.
+% =====================================================================
+\thispagestyle{empty}
+\begin{fullwidth}
+  \centering
+  \vspace*{10mm}
+  {\Huge The \pkg{} manual\par}
+  \vspace{2.5mm}
+  {\Large second edition \quad---\quad the equation is the diagram\par}
+  \vspace{4mm}
+  {documenting \pkg{} 0.5 \quad---\quad 17 July 2026 \quad---\quad
+   The TNLean project\par}
+  \vspace{14mm}
+
+  % an open matrix-product word: the stubs ARE the matrix indices
+  \begin{tenkz}[physical=up, west label=$\alpha$, east label=$\beta$]
+    \tn[up=$i_1$]{A} & \tn[up=$i_2$]{A} & \tn[up=$i_3$]{A}
+  \end{tenkz}
+  \hspace{11mm}
+  % E_A(X) = sum_i A^i X (A^i)^dagger — the canonical channel spelling:
+  % X rides the east cup (the input: it contracts the column indices),
+  % the west pair stays open (the output is a matrix)
+  \begin{tenkz}[sandwich, east={cup=$X$}]
+    \tn{A} \\
+    \tn*{A}
+  \end{tenkz}
+  \hspace{11mm}
+  % rho_n: all physical legs open, both bends capped by fixed points
+  % (rho^L, the fixed point of E_A^*, caps the west; rho^R, the fixed
+  % point of E_A, caps the east)
+  \begin{tenkz}[rows={ket:nopair, bra},
+                west={cup=$\rho^L$}, east={cup=$\rho^R$}]
+    \tn[up=$s_1$]{} & \tndots & \tn[up=$s_n$]{}\\
+    \tn*[down=$s'_1$]{} & \tndots & \tn*[down=$s'_n$]{}
+  \end{tenkz}
+
+  \vspace{14mm}
+  \begin{minipage}{0.8\mfullwidth}
+    \small
+    A tensor-network diagram is a formula, and \pkg{} treats it as one:
+    rows are layers, columns are sites, bonds are implicit, and an open
+    index is a protruding stub --- a picture with no open legs is a
+    scalar, never a matrix.  This manual states the mathematics of each
+    picture before the picture, in the margin beside it; every rendered
+    diagram is produced, at compile time, by the exact source printed
+    under it.  The three diagrams above are the first three proofs: an
+    open matrix-product word $\smash{A^{i_1}A^{i_2}A^{i_3}}$ with its
+    boundary indices $\alpha,\beta$; the quantum channel
+    $\smash{\mathcal{E}_A(X)=\sum_i A^i X A^{i\dagger}}$ applied to $X$,
+    its output legs open because the output is a matrix; and a reduced
+    density matrix whose bends are capped by the fixed points
+    $\rho^L,\rho^R$.
+  \end{minipage}
+\end{fullwidth}
+
+\clearpage
+\setcounter{tocdepth}{1}
+\tableofcontents
+\bigskip
+
+% =====================================================================
+%  How to read this manual — skeleton-owned; the living model of the
+%  example unit that every chapter uses.  Examples here are numbered 0.n.
+% =====================================================================
+\section*{How to read this manual}
+\addcontentsline{toc}{section}{How to read this manual}
+
+Every example in this manual is one measured unit, read in the order a
+working physicist reads: the \emph{formula} stands in the margin; the
+\emph{rendered diagram} comes first in the text column, because the
+diagram is the object under discussion; the \emph{source} that produced
+it follows in a quiet block, with its \verb|%| comments intact --- the
+comments state the mathematics and are part of the pedagogy; and the
+\emph{ink-to-index correspondence} hangs beside the unit as a numbered
+sidenote.\sidenote{Sidenotes look like this.  They carry the
+correspondence between ink and indices, design notes, and quoted
+\tnfile{.tnlog} lines.}  Nothing is pasted: each unit is written to an
+auxiliary file at compile time and read back, so the render is produced
+by the exact source shown.
+
+\begin{tnexample}[
+    formula   = {\mathcal{E}_A(X)=\sum_i A^i X A^{i\dagger}},
+    caption   = {the channel applied to $X$},
+    index     = {The east cup is the input: $X$ bridges the ket layer
+                 (top) and the bra layer (bottom).  The vertical wire is
+                 the summed physical index $i$.  The west pair stays
+                 open: the output is a matrix, so the picture must keep
+                 two stubs.},
+    signature = {boundary|virtual-west=2|virtual-east=0},
+    label     = {ex:channel-applied},
+  ]
+% E_A(X) = sum_i A^i X (A^i)^dagger : X rides the east cup
+% (the input side); the west ket/bra pair stays open, because
+% the output is a matrix, not a scalar
+\begin{tenkz}[sandwich, east={cup=$X$}]
+  \tn{A} \\
+  \tn*{A}
+\end{tenkz}
+\end{tnexample}
+
+Example~\ref{ex:channel-applied} is the manual's canonical channel: the
+applied map closes only its input side.  The unapplied map
+$\mathcal{E}_A$ keeps all four virtual legs open --- same source, no cup.
+Two sides of a diagrammatic equation are the same kind of object only if
+their boundary signatures agree, and each picture writes its signature to
+the \tnfile{.tnlog} event stream; the margin quotes the signature line
+whenever it carries the argument.
+
+When one key is under discussion, the manual varies that key and nothing
+else, in aligned panels compiled from a single shared source; the varied
+key appears in the source as the option \tnkey{variant} and is printed
+beneath each panel:
+
+\begin{tnmultiples}[
+    caption  = {one word, three boundary closures},
+    formula  = {A^{i}B^{j}},
+    index    = {\tnval{boundary=open} keeps the virtual matrix indices
+                as stubs; \tnval{boundary=none} seals them --- a scalar
+                for each $i,j$; \tnval{periodic} closes the row to
+                itself, the trace.},
+    variants = {{boundary=open}{boundary=open},
+                {boundary=none}{boundary=none},
+                {periodic}{periodic}},
+    label    = {ex:read-closures},
+  ]
+% one source, three closures: only `variant' changes
+\begin{tenkz}[physical=up, variant]
+  \tn[up=$i$]{A} & \tn[up=$j$]{B}
+\end{tenkz}
+\end{tnmultiples}
+
+The margin column also carries thumb-tags\thumbtag{\tnkey{boundary=}}
+at every reference entry, so the reference chapter can be navigated by
+riffling, and the back page is a one-page quick-reference card of the
+whole language.
+
+% =====================================================================
+%  Chapters (one file per chapter; they run on, Tufte-handout style —
+%  the page budget is spent on examples, not on chapter-break whitespace)
+% =====================================================================
+\input{chapters2/ch2-mathematics}
+\input{chapters2/ch-tutorial}
+\input{chapters2/ch3-worked}
+\input{chapters2/ch4-modes-multiples}
+\input{chapters2/ch5-rmp}
+\input{chapters2/ch6-reference}
+\input{chapters2/ch-house}
+\input{chapters2/ch8-trouble-roadmap}
+
+% =====================================================================
+%  Back page — the quick-reference card (content owned by the
+%  troubleshooting chapter's writer; one line per object).
+% =====================================================================
+\begin{quickrefcard}
+  \qrsection{Environments}
+  \qritem{tenkz}{the contraction grid: rows are layers, columns are
+    sites; bonds implicit}
+  \qritem{tenkzcd}{commutative diagrams and fusion trees}
+  \qritem{tenkzlattice}{lattice windows and regions}
+  \qritem{tenkzplanes}{ket-over-bra double layer}
+  \qritem{tenkzfree}{typed free placement}
+  \qritem{\textbackslash tnpic[keys]\{cells\}}{inline picture in text
+    or math}
+
+  \qrsection{Cell commands (tenkz)}
+  \qritem{\textbackslash tn[opts]\{A\}}{tensor atom;
+    \textbackslash tn* = the conjugate}
+  \qritem{\textbackslash tnX\{X\}}{matrix on the wire, no physical
+    leg; \texttt{wires=k} spans k rows}
+  \qritem{\textbackslash tnfuse[span=k]\{V\}}{fusing wedge; its
+    combined leg is one open index; \texttt{combined=west|east}}
+  \qritem{\textbackslash tndots}{ellipsis; wires pass through}
+  \qritem{\textbackslash tnskip}{hole: the tensor is deleted, its
+    indices stay open}
+  \qritem{\textbackslash tnghost\{\}}{invisible anchor; pairing onto
+    it warns}
+  \qritem{\textbackslash tnspan[brace above|below]\{n\}\{L\}}{brace
+    over n columns}
+  \qritem{\textbackslash tncut\{S\}}{dashed cut across the bond east
+    of the cell; adds no index}
+
+  \qrsection{Picture keys (tenkz)}
+  \qritem{rows=\{ket:nopair, bra\}}{row types ket, bra, op, wire, with
+    modifiers}
+  \qritem{physical=up|down|updown|none}{one-row sugar for
+    ket|bra|op|wire}
+  \qritem{sandwich}{rows=\{ket, bra\}, physical legs paired}
+  \qritem{boundary=open|none}{stubs (default) or sealed ends}
+  \qritem{periodic}{trace: each row closed to itself}
+  \qritem{west=cup, east=\{cup=$X$\}}{cup tying adjacent rows;
+    optional matrix on the bend}
+  \qritem{west label=, east label=}{boundary index labels at the stub
+    tips}
+  \qritem{layer sep=f}{multiply the inter-layer gap}
+  \qritem{trace=physical}{per-site up-into-down trace (one row)}
+  \qritem{trace=\{(physical, 2-3)\}}{per-column partial trace;
+    the braces are load-bearing}
+  \qritem{bond dir=right|left}{directed bonds: arrow out $=V$, in
+    $=V^{*}$}
+  \qritem{bond label=\{$D$ at 1-2\}}{label one bond}
+  \qritem{align=row}{the row set on the math axis}
+  \qritem{pitch=, compact, inline}{the metric}
+  \qritem{tensor style=dot|box}{glyph policy}
+  \qritem{frame=vertical}{rotate the chain grammar: bonds run
+    south, physical legs point west}
+  \qritem{\textbackslash tnset\{keys\}}{rebind the shared key space
+    document-wide}
+
+  \qrsection{Row modifiers (rows=)}
+  \qritem{:open, :none}{per-row boundary policy}
+  \qritem{:nopair}{keep this row's physical legs open}
+  \qritem{:dir right, :dir left}{directed row}
+  \qritem{:fused, :operator}{bond flavour: doubled, operator}
+
+  \qrsection{Cell keys (\textbackslash tn)}
+  \qritem{dot, box, pill, mpo}{glyph override}
+  \qritem{wide=k}{span k columns}
+  \qritem{wires=k}{span and terminate k wire rows}
+  \qritem{legs at=\{1,2\}}{physical legs at chosen spanned columns}
+  \qritem{tri=l|r}{canonical isometry triangle}
+  \qritem{up=\{$i$\}, down=\{$j$\}}{physical-leg labels}
+  \qritem{label pos=, label shift=}{atom-label placement}
+  \qritem{no legs}{suppress physical legs}
+
+  \qrsection{Lattices (tenkzlattice)}
+  \qritem{rows=, cols=, site=none}{the window}
+  \qritem{frame=oblique}{the sheared PEPS sheet}
+  \qritem{physical=up, boundary legs}{legs on sites and rim}
+  \qritem{\textbackslash tnregion[slot=, label=, label at=, inset=,
+    outline, name=]\{(1-3, 2-4)\}}{region; named sets compose:
+    \texttt{R - (2,2)}}
+  \qritem{\textbackslash tnedge[style]\{(2,3)-(2,4)\}}{one edge}
+  \qritem{\textbackslash tnsite[style]\{(2,2)\}}{one site}
+
+  \qrsection{Planes (tenkzplanes)}
+  \qritem{rows=, cols=, sheets=\{ket, bra\}}{the double layer,
+    site-wise pairing}
+  \qritem{open=\{(1-4, 2)\}}{cells keeping dangling stubs}
+  \qritem{sheet sep=, trace=}{the gap; traced cells}
+
+  \qrsection{Trees and arrows (tenkzcd)}
+  \qritem{\textbackslash tntree\{(((a\,b)\_x\,c)\_y\,d)\_e\}}{fusion
+    tree from a bracketed word}
+  \qritem{\textbackslash tnarrow[from=1, to=2]\{F\}}{arrow between
+    slots; starred = other side}
+  \qritem{polygon=5, radius=}{slots on a polygon}
+
+  \qrsection{Free placement (tenkzfree)}
+  \qritem{\textbackslash tnput[shape, ports=]\{name\}\{(x,y)\}\{A\}}{%
+    typed node; shapes dot|box|pill|mpo|ring}
+  \qritem{\textbackslash tnjoin[route=, dir, fused, label=, out=,
+    in=]\{a.east\}\{b.west\}}{wire; \texttt{route=}
+    straight|hv|vh|curve; \texttt{dir}: argument order = direction}
+
+  \qrsection{The event stream}
+  \qritem{.tnlog}{one \texttt{picture|atom|bond|boundary} line per
+    event, beside the PDF}
+  \qritem{boundary|virtual-west=..|..}{the signature: two sides of an
+    equation must log matching lines}
+\end{quickrefcard}
+
+\end{document}

--- a/docs/tenkz/tenkzmanual2.sty
+++ b/docs/tenkz/tenkzmanual2.sty
@@ -1,0 +1,409 @@
+% tenkzmanual2.sty — typographic system for the tenkz manual, second edition.
+%
+% Loaded by docs/tenkz/manual2.tex only.  The page is an asymmetric grid:
+% a 112 mm text column and a 50 mm margin column.  Mathematics lives in the
+% margin column, beside the diagram it describes; the diagram itself is the
+% primary object and is set first; the source that produced it follows in a
+% quiet block.  Every example is live-compiled: the body of a tnexample or
+% tnmultiples environment is written verbatim to an auxiliary file and read
+% back, so the rendered output is produced by the exact source shown.  If an
+% example stops compiling, the manual stops compiling.
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesPackage{tenkzmanual2}[2026/07/17 v2.0 tenkz manual second-edition typography]
+
+% ---------------------------------------------------------------------------
+%  Page grid (Tufte-lite, one-sided; margin column on the right)
+% ---------------------------------------------------------------------------
+\RequirePackage[a4paper,
+  left=20mm, textwidth=112mm,
+  marginparsep=7mm, marginparwidth=50mm,
+  top=25mm, bottom=30mm, headsep=7mm, head=14pt]{geometry}
+
+\RequirePackage{amsmath, amssymb}
+\RequirePackage{booktabs, array, tabularx, multicol}
+\RequirePackage{fancyvrb}
+\RequirePackage{needspace}
+\RequirePackage{fancyhdr}
+\RequirePackage{marginnote}
+\RequirePackage{tenkz}
+
+% full measure = text column + gutter + margin column (for hero rows,
+% wide diagrams, and the quick-reference card)
+\newlength{\mfullwidth}
+\AtBeginDocument{%
+  \setlength{\mfullwidth}{\dimexpr\textwidth+\marginparsep+\marginparwidth\relax}}
+
+% ---------------------------------------------------------------------------
+%  Palette (bound to the package's semantic hues)
+% ---------------------------------------------------------------------------
+\colorlet{mcmd}{tenkzMarked}          % command names
+\colorlet{mkey}{tenkzExtra}           % key names, sidenote numbers
+\definecolor{mrule}{gray}{0.60}       % example-unit rules
+\definecolor{msrcrule}{gray}{0.78}    % source-block left rule
+\definecolor{mquiet}{gray}{0.35}      % de-emphasised text
+\definecolor{mtag}{gray}{0.13}        % thumb-tags
+
+% ---------------------------------------------------------------------------
+%  Metrics (vertical rhythm of the example unit, panel spacing)
+% ---------------------------------------------------------------------------
+% \baselineskip- and em-relative values must be evaluated where they are
+% used, so these are macros rather than lengths
+\newcommand*{\mtwo@unitsep}{0.62\baselineskip}  % space above/below a unit
+\newcommand*{\mtwo@unitseam}{0.3\baselineskip}  % rule/caption/diagram/source seams
+\newcommand*{\mtwo@panelsep}{2.2em}             % gap between small-multiples panels
+\newcommand*{\mtwo@panellabelsep}{4pt}          % panel-to-variant-label gap
+
+% ---------------------------------------------------------------------------
+%  Margin apparatus: sidenotes, margin formulas, thumb-tags
+% ---------------------------------------------------------------------------
+\renewcommand*{\marginfont}{\footnotesize\normalfont\raggedright}
+
+% numbered sidenotes, numbers restart with each section
+\newcounter{sidenote}[section]
+\renewcommand*{\theHsidenote}{\arabic{section}.\arabic{sidenote}}
+\newcommand*{\msidemark}{\textsuperscript{\textcolor{mkey}{\arabic{sidenote}}}}
+% margin text opened by its sidenote number (shared by \sidenote and the
+% example unit's margin block)
+\newcommand{\mtwo@sidenotetext}[1]{\msidemark\hspace{0.3em}#1}
+% \sidenote{<text>} — superscript mark here, numbered note in the margin
+\newcommand{\sidenote}[1]{%
+  \refstepcounter{sidenote}\msidemark
+  \marginnote{\mtwo@sidenotetext{#1}}}
+
+% display-style formula at margin size (shared by \marginformula and the
+% example unit's margin block)
+\newcommand{\mtwo@displayformula}[1]{\footnotesize$\displaystyle #1$}
+% \marginformula{<math, no dollar signs>} — a display-style formula in the
+% margin column, anchored at the current line
+\newcommand{\marginformula}[1]{%
+  \marginnote{\mtwo@displayformula{#1}}}
+
+% \thumbtag[<voffset>]{<text>} — a reference thumb-tag, flush toward the
+% outer edge; place one at each reference entry (typically
+% \thumbtag{\textbackslash tn} or \thumbtag{boundary=}).  The optional
+% vertical offset shifts the tag down past a neighbouring margin block
+% when the two would share a line.
+% neutralise coloured markup inside tags: tags are white-on-dark
+\newcommand{\mtwo@tagreset}{%
+  \def\tncmd##1{\texttt{\char`\\##1}}%
+  \def\tnkey##1{\texttt{##1}}%
+  \def\tnenv##1{\texttt{##1}}}
+\newcommand{\thumbtag}[2][0pt]{%
+  \marginnote{\makebox[\linewidth][r]{%
+    \setlength{\fboxsep}{3.5pt}%
+    \colorbox{mtag}{\color{white}\mtwo@tagreset
+      \ttfamily\footnotesize\vphantom{gj\textbackslash}#2}}}[#1]}
+
+% \tnlogline{<line>} — one line of a .tnlog event stream, for quoting
+% boundary signatures inside sidenotes
+\newcommand{\tnlogline}[1]{{\ttfamily\scriptsize #1}}
+
+% ---------------------------------------------------------------------------
+%  Inline markup
+% ---------------------------------------------------------------------------
+\newcommand{\meta}[1]{{\normalfont\itshape$\langle$#1$\rangle$}}
+\newcommand{\tncmd}[1]{\textcolor{mcmd}{\texttt{\char`\\#1}}}
+\newcommand{\tnkey}[1]{\textcolor{mkey}{\texttt{#1}}}
+\newcommand{\tnval}[1]{\texttt{#1}}
+\newcommand{\tnenv}[1]{\textcolor{mcmd}{\texttt{#1}}}
+\newcommand{\tnfile}[1]{\texttt{#1}}
+
+% ---------------------------------------------------------------------------
+%  Reference apparatus
+% ---------------------------------------------------------------------------
+% the thin grey rule that frames example units and command signatures
+\newcommand*{\mtwo@thinrule}{{\color{mrule}\hrule height 0.5pt}}
+
+% \cmdsig{<signature>} — the usage line of a command or environment,
+% set between two thin rules
+\newcommand{\cmdsig}[1]{%
+  \par\addvspace{0.52\baselineskip}%
+  \mtwo@thinrule
+  \nobreak\vspace{0.28\baselineskip}%
+  {\noindent\ttfamily #1\par}%
+  \nobreak\vspace{0.28\baselineskip}%
+  \mtwo@thinrule
+  \par\addvspace{0.32\baselineskip}\noindent\ignorespaces}
+
+% \whynote{<text>} — the "why a command and not a key?" design note,
+% set as a sidenote beside the entry it explains
+\newcommand{\whynote}[1]{\sidenote{\textit{Why a command, not a key?}\ #1}}
+
+% header row for per-key tables
+\newcommand{\keyhead}{\normalfont Key & Values & Default & Meaning \\ \midrule}
+
+% ---------------------------------------------------------------------------
+%  Full-measure block (hero rows, wide diagrams)
+% ---------------------------------------------------------------------------
+% material between \mtwo@beginfullbox and \mtwo@endfullbox is boxed at the
+% full measure and hung from the text column's left edge, overhanging the
+% margin column (shared by fullwidth, wide example output, quickrefcard)
+\newsavebox{\mfwbox}
+\newcommand{\mtwo@beginfullbox}{%
+  \begin{lrbox}{\mfwbox}\begin{minipage}{\mfullwidth}}
+\newcommand{\mtwo@endfullbox}{%
+  \end{minipage}\end{lrbox}\makebox[\textwidth][l]{\usebox{\mfwbox}}}
+
+\newenvironment{fullwidth}
+  {\par\addvspace{0.8\baselineskip}\noindent\mtwo@beginfullbox}
+  {\mtwo@endfullbox\par\addvspace{0.8\baselineskip}}
+
+% ---------------------------------------------------------------------------
+%  The example unit
+% ---------------------------------------------------------------------------
+% Shared key family for tnexample and tnmultiples.
+\ExplSyntaxOn
+\box_new:N \l_mtwo_panel_box
+\box_new:N \l_mtwo_panellab_box
+\dim_new:N \l_mtwo_panel_dim
+\tl_new:N  \l_mtwo_sigbreak_tl
+\tl_new:N  \l_mtwo_formula_tl
+\tl_new:N  \l_mtwo_caption_tl
+\tl_new:N  \l_mtwo_index_tl
+\tl_new:N  \l_mtwo_signature_tl
+\tl_new:N  \l_mtwo_label_tl
+\tl_new:N  \l_mtwo_variants_tl
+\bool_new:N \l_mtwo_wide_bool
+\bool_new:N \l_mtwo_source_bool
+\bool_new:N \l_mtwo_first_bool
+\clist_new:N \l_mtwo_variants_clist
+
+\keys_define:nn { mtwo / unit }
+  {
+    formula   .tl_set:N   = \l_mtwo_formula_tl,
+    caption   .tl_set:N   = \l_mtwo_caption_tl,
+    index     .tl_set:N   = \l_mtwo_index_tl,
+    signature .tl_set:N   = \l_mtwo_signature_tl,
+    label     .tl_set:N   = \l_mtwo_label_tl,
+    variants  .tl_set:N   = \l_mtwo_variants_tl,
+    wide      .bool_set:N = \l_mtwo_wide_bool,
+    wide      .default:n  = { true },
+    source    .bool_set:N = \l_mtwo_source_bool,
+  }
+
+\cs_new_protected:Npn \mtwo_unit_setup:n #1
+  {
+    \tl_clear:N \l_mtwo_formula_tl
+    \tl_clear:N \l_mtwo_caption_tl
+    \tl_clear:N \l_mtwo_index_tl
+    \tl_clear:N \l_mtwo_signature_tl
+    \tl_clear:N \l_mtwo_label_tl
+    \tl_clear:N \l_mtwo_variants_tl
+    \bool_set_false:N \l_mtwo_wide_bool
+    \bool_set_true:N  \l_mtwo_source_bool
+    \keys_set:nn { mtwo / unit } {#1}
+  }
+
+% The caption line: rule, "example <n> . <caption>", label, sidenote mark,
+% and the combined margin block (formula over legend over signature).
+\cs_new_protected:Npn \mtwo_unit_head:
+  {
+    \par \addvspace{\mtwo@unitsep}
+    \mtwo@thinrule
+    \nobreak \vspace{\mtwo@unitseam}
+    \refstepcounter{tnexample}
+    \noindent
+    {
+      \small
+      {\scshape example~\thetnexample}
+      \tl_if_empty:NF \l_mtwo_caption_tl
+        { ~~\textcolor{mquiet}{$\cdot$}~~ \tl_use:N \l_mtwo_caption_tl }
+    }
+    \tl_if_empty:NF \l_mtwo_label_tl
+      { \exp_args:NV \label \l_mtwo_label_tl }
+    \tl_if_empty:NF \l_mtwo_index_tl
+      { \refstepcounter{sidenote} \, \msidemark }
+    \mtwo_unit_margin:
+    \par \nobreak
+  }
+
+\cs_new_protected:Npn \mtwo_unit_margin:
+  {
+    \bool_lazy_all:nF
+      {
+        { \tl_if_empty_p:N \l_mtwo_formula_tl }
+        { \tl_if_empty_p:N \l_mtwo_index_tl }
+        { \tl_if_empty_p:N \l_mtwo_signature_tl }
+      }
+      {
+        \marginnote
+          {
+            \tl_if_empty:NF \l_mtwo_formula_tl
+              {
+                \mtwo@displayformula { \tl_use:N \l_mtwo_formula_tl }
+                \par \smallskip
+              }
+            \tl_if_empty:NF \l_mtwo_index_tl
+              {
+                \footnotesize
+                \mtwo@sidenotetext { \tl_use:N \l_mtwo_index_tl }
+                \par
+              }
+            \tl_if_empty:NF \l_mtwo_signature_tl
+              {
+                \smallskip
+                % a .tnlog line; break points after each `|' so the
+                % signature wraps inside the margin column
+                \tl_set_eq:NN \l_mtwo_sigbreak_tl \l_mtwo_signature_tl
+                \tl_replace_all:Nnn \l_mtwo_sigbreak_tl { | } { | \allowbreak }
+                { \ttfamily \scriptsize \tl_use:N \l_mtwo_sigbreak_tl \par }
+              }
+          }
+      }
+  }
+
+% The rendered output, centred, at full or text measure.
+\cs_new_protected:Npn \mtwo_unit_output:n #1
+  {
+    \par \nobreak \vspace{\mtwo@unitseam}
+    \bool_if:NTF \l_mtwo_wide_bool
+      {
+        \noindent
+        \mtwo@beginfullbox
+        \centering #1 \par
+        \mtwo@endfullbox
+      }
+      { { \centering #1 \par } }
+  }
+
+% The quiet source block.  The \needspace check keeps a block from
+% opening with an orphan line or two at a page bottom: with less than
+% about four source lines of room, the break falls at the seam between
+% the rendered diagram and the source instead of inside the verbatim.
+\cs_new_protected:Npn \mtwo_unit_source:n #1
+  {
+    \par \nobreak \vspace{\mtwo@unitseam}
+    \needspace{3.2\baselineskip}
+    \VerbatimInput[fontsize=\footnotesize, baselinestretch=0.89,
+      frame=leftline,
+      framerule=0.8pt, rulecolor=\color{msrcrule},
+      framesep=0.9em, xleftmargin=0.9em]{#1}
+    \par \addvspace{\mtwo@unitsep}
+  }
+
+\cs_new_protected:Npn \mtwo_example_render:
+  {
+    \mtwo_unit_head:
+    \mtwo_unit_output:n { \input{\jobname.exa} }
+    \bool_if:NT \l_mtwo_source_bool
+      { \mtwo_unit_source:n { \jobname.exa } }
+  }
+
+% One small-multiples panel: define the `variant' style at grid and cell
+% level, render the shared body, set the variant keys beneath it.  The
+% panel's reference point is the render's own baseline (the wire axis),
+% so the wires of all panels in a row are collinear.
+\cs_new_protected:Npn \mtwo_variant_panel:nn #1 #2
+  {
+    \mode_leave_vertical:
+    \pgfqkeys{/tenkz/grid}{ variant/.style = {#2} }
+    \pgfqkeys{/tenkz/cell}{ variant/.style = {#2} }
+    \hbox_set:Nn \l_mtwo_panel_box { \input{\jobname.exm} \unskip }
+    \hbox_set:Nn \l_mtwo_panellab_box { \scriptsize \ttfamily #1 }
+    \dim_set:Nn \l_mtwo_panel_dim
+      {
+        \dim_max:nn { \box_wd:N \l_mtwo_panel_box }
+                    { \box_wd:N \l_mtwo_panellab_box }
+      }
+    \vtop
+      {
+        \hbox_to_wd:nn { \l_mtwo_panel_dim }
+          { \tex_hss:D \box_use:N \l_mtwo_panel_box \tex_hss:D }
+        \skip_vertical:n { \mtwo@panellabelsep }
+        \hbox_to_wd:nn { \l_mtwo_panel_dim }
+          { \tex_hss:D \box_use:N \l_mtwo_panellab_box \tex_hss:D }
+      }
+  }
+
+\cs_new_protected:Npn \mtwo_multiples_render:
+  {
+    \mtwo_unit_head:
+    \clist_set:NV \l_mtwo_variants_clist \l_mtwo_variants_tl
+    \mtwo_unit_output:n
+      {
+        \bool_set_true:N \l_mtwo_first_bool
+        \clist_map_inline:Nn \l_mtwo_variants_clist
+          {
+            \bool_if:NTF \l_mtwo_first_bool
+              { \bool_set_false:N \l_mtwo_first_bool }
+              { \hspace{\mtwo@panelsep} }
+            \mtwo_variant_panel:nn ##1
+          }
+      }
+    \bool_if:NT \l_mtwo_source_bool
+      { \mtwo_unit_source:n { \jobname.exm } }
+  }
+
+\NewDocumentCommand{\mtwoUnitSetup}{m}{\mtwo_unit_setup:n {#1}}
+\NewDocumentCommand{\mtwoExampleRender}{}{\mtwo_example_render:}
+\NewDocumentCommand{\mtwoMultiplesRender}{}{\mtwo_multiples_render:}
+\ExplSyntaxOff
+
+% example numbering restarts with each section
+\newcounter{tnexample}[section]
+\renewcommand{\thetnexample}{\arabic{section}.\arabic{tnexample}}
+\renewcommand*{\theHtnexample}{\thetnexample}
+
+% ----- tnexample -----------------------------------------------------------
+% \begin{tnexample}[<keys>]  <tenkz source, verbatim>  \end{tnexample}
+%
+% Keys: formula   = <math for the margin, no dollar signs>
+%       caption   = <caption text>
+%       index     = <ink-to-index legend, becomes a numbered sidenote>
+%       signature = <.tnlog boundary-signature line, quoted in the margin>
+%       label     = <\label name, referenced as Example \ref{...}>
+%       wide      (render the output at full measure)
+%       source    = false (suppress the printed source block)
+%
+% The body is written to \jobname.exa and rendered output-first: caption
+% line, diagram, then the source.  Inline % comments in the body are part
+% of the pedagogy: they are invisible in the render and visible in print.
+% Keep body lines at or below 68 characters --- the source block is set
+% verbatim at \footnotesize in the 112 mm text column and does not wrap.
+\newenvironment{tnexample}[1][]
+  {\mtwoUnitSetup{#1}%
+   \VerbatimEnvironment
+   \begin{VerbatimOut}{\jobname.exa}}
+  {\end{VerbatimOut}%
+   \mtwoExampleRender}
+
+% ----- tnmultiples ---------------------------------------------------------
+% \begin{tnmultiples}[<keys>, variants={{<lab>}{<opts>}, ...}]
+%   <tenkz source using the option `variant'>
+% \end{tnmultiples}
+%
+% The body is compiled once per variant; in each panel the grid/cell option
+% `variant' expands to that panel's <opts>, and <lab> is set beneath the
+% panel.  All tnexample keys apply; the shared source prints once.
+\newenvironment{tnmultiples}[1][]
+  {\mtwoUnitSetup{#1}%
+   \VerbatimEnvironment
+   \begin{VerbatimOut}{\jobname.exm}}
+  {\end{VerbatimOut}%
+   \mtwoMultiplesRender}
+
+% ---------------------------------------------------------------------------
+%  Quick-reference card (the back page)
+% ---------------------------------------------------------------------------
+% \begin{quickrefcard}[<title>] ... \end{quickrefcard} — a full-measure,
+% three-column card on its own page; structure it with \qrsection and \qritem.
+\newenvironment{quickrefcard}[1][The tenkz quick reference]
+  {\clearpage\thispagestyle{empty}\noindent\mtwo@beginfullbox
+   {\Large\scshape #1}\par\smallskip
+   {\color{mrule}\hrule height 0.8pt}\medskip
+   \begin{multicols}{3}\footnotesize\raggedright}
+  {\end{multicols}\mtwo@endfullbox\clearpage}
+\newcommand{\qrsection}[1]{\par\medskip{\normalfont\bfseries\small #1}\par\nobreak\smallskip}
+\newcommand{\qritem}[2]{\par\noindent\hangindent=1.1em\hangafter=1
+  {\ttfamily#1}\enspace\textcolor{mquiet}{---}\enspace#2\par}
+
+% ---------------------------------------------------------------------------
+%  Running heads
+% ---------------------------------------------------------------------------
+\pagestyle{fancy}
+\fancyhf{}
+\fancyhead[L]{\small\itshape The \texttt{tenkz} manual\quad second edition}
+\fancyhead[R]{\small\thepage}
+\renewcommand{\headrulewidth}{0pt}
+
+\endinput


### PR DESCRIPTION
Stack 06 (on 05-lattice). The from-scratch second edition: 40 pages, asymmetric Tufte margin-column layout, formula-first discipline (every example: formula in the margin -> rendered diagram -> verbatim source -> ink-to-index sidenote), live-compiled throughout. Chapters: the mathematics of the pictures (boundary doctrine, signatures, canonical channel spellings), tutorial, worked examples, glyph modes, the review-article test (RMP reproductions), complete reference incl. all 0.5 keys, house style with the geometry appendix, troubleshooting + honest roadmap. Gate passes (assembly polish, mathematical referee, prose) land as follow-up commits.

https://claude.ai/code/session_01Rpby2DabUL1mbsMkFadv1q

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no runtime or API changes to the LaTeX package; main risk is manual build fragility and maintenance of two parallel manuals until the first edition is retired.
> 
> **Overview**
> Adds a **new** second-edition manual (`manual2.tex` + `tenkzmanual2.sty`) alongside the existing `manual.tex`, built as a separate ~40-page document rather than a rewrite of the first edition.
> 
> The edition introduces a **Tufte-style** page (112 mm text + 50 mm margin), **formula-first** example units (`tnexample` / `tnmultiples`: margin formula → live diagram → verbatim source → ink-to-index sidenote and optional `.tnlog` signature), and **small-multiples** panels compiled from one shared source via a `variant` key. Examples are **live-compiled** through aux files (`\jobname.exa` / `.exm`); the manual fails if an example fails.
> 
> **Nine new chapters** under `chapters2/`: picture semantics and boundary signatures, tutorial (B1–B8), worked examples, glyph/metric modes, RMP figure reproductions, full 0.5 reference, house style (glyphs, hues, geometry table), and troubleshooting plus an honest roadmap. The back page is a **quick-reference card**; margin **thumb-tags** support riffling the reference.
> 
> No changes to the `tenkz` package itself in this diff—documentation and manual-only typography only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13f3da8cbf17d061d521fd82a7f555fe90c21d96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->