### PR TITLE
feat(MPS/ParentHamiltonian): discharge the PGVWC comparison hypothesis

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
@@ -397,7 +397,7 @@ and these boundary identities place each single-block vector
 of length at least \((L_0+1)+3(r-1)(L_0+1)\), the normalized BNT
 block-separation theorem derives the tail-word span from the hypotheses already
 present, so the comparison is derived, not assumed, at those tails. Relative to
-the conditional comparison theorem, the opened-boundary $C^j, D^j$ comparison
+the conditional comparison theorem, the opened-boundary \(C^j, D^j\) comparison
 hypothesis is removed; relative to the full crossing-span theorem, the span
 hypothesis is restricted to the crossing tails shorter than the BNT
 block-separation bound.

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
@@ -383,9 +383,16 @@ opened-boundary \(C^j,D^j\) comparison
 \[
   A^j_\beta C^j_{i,\rho}
   =
-  \bigl((\mu_j^NX_j)A^j_\beta\bigr)A^j_\rho ,
+  \bigl((\mu_j^NX_j)A^j_\beta\bigr)A^j_\rho .
 \]
-and the normalized \(E^j\)-calculation then places each single-block vector
+Since \(\sum_\rho A^j_\rho A^{j\dagger}_\rho=I\) over the outside words \(\rho\),
+this comparison yields, for each outside word \(\rho\), a matrix
+\(E_{j,i,\rho}=\bigl(\sum_\gamma C^j_{i,\gamma}A^{j\dagger}_\gamma\bigr)A^j_\rho\)
+with
+\[
+  \bigl((\mu_j^NX_j)A^j_\beta\bigr)A^j_\rho=A^j_\beta E_{j,i,\rho},
+\]
+and these boundary identities place each single-block vector
 \(\Gamma_N^{A_j}(\mu_j^NX_j)\) in \(\mathcal G_{N,L}(A_j)\). For crossing tails
 of length at least \((L_0+1)+3(r-1)(L_0+1)\), the normalized BNT
 block-separation theorem derives the tail-word span from the hypotheses already
@@ -440,22 +447,20 @@ theorem exists_blockDiagonal_boundary_chainGroundSpace_of_short_crossing_span_bn
         ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X)) ∧
       ∀ j : Fin r,
         groundSpaceMap (A j) N ((μ j) ^ N • X j) ∈ chainGroundSpace (A j) L N := by
+  let m : ℕ :=
+    (L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1)))
   have hCrossingSpan :
       ∀ i : Fin N, N < i.val + L → WordTupleSpanTop A (N - i.val) := by
     intro i hi
-    rcases Nat.lt_or_ge (N - i.val)
-        ((L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1)))) with hlt | hge
+    rcases Nat.lt_or_ge (N - i.val) m with hlt | hge
     · exact hShortSpan i hi hlt
     · exact
         wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1
           A hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hge
-  refine
-    exists_blockDiagonal_boundary_chainGroundSpace_of_pgvwc_comparison_bnt_c1
-      μ A hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange hNlarge hψ ?_
-  intro X hψX
   exact
-    blockDiagonal_boundary_crossing_pgvwc_comparison_of_chainGroundSpace
-      μ A hμ hN hLN hCrossingSpan hψ X hψX
+    exists_blockDiagonal_boundary_chainGroundSpace_of_crossing_pgvwc_comparison_bnt_c1
+      μ A hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange hNlarge
+      hCrossingSpan hψ
 
 /-- Boundary-crossing local constraints give the block-diagonal periodic-boundary
 equality in the finite BNT range.

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
@@ -397,10 +397,9 @@ and these boundary identities place each single-block vector
 of length at least \((L_0+1)+3(r-1)(L_0+1)\), the normalized BNT
 block-separation theorem derives the tail-word span from the hypotheses already
 present, so the comparison is derived, not assumed, at those tails. Relative to
-`exists_blockDiagonal_boundary_chainGroundSpace_of_pgvwc_comparison_bnt_c1`,
-the explicit hypothesis `hComparison` is removed; relative to
-`exists_blockDiagonal_boundary_chainGroundSpace_of_crossing_pgvwc_comparison_bnt_c1`,
-the span hypothesis is restricted to the crossing tails shorter than the BNT
+the conditional comparison theorem, the opened-boundary $C^j, D^j$ comparison
+hypothesis is removed; relative to the full crossing-span theorem, the span
+hypothesis is restricted to the crossing tails shorter than the BNT
 block-separation bound.
 
 The comparison derived here is the boundary-condition comparison of

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
@@ -371,6 +371,92 @@ theorem
     exists_blockDiagonal_boundary_chainGroundSpace_of_crossing_pgvwc_comparison_of_boundary
       μ A hμ hBlk hUnital hN hLN hNlarge hCrossingSpan hψ hBoundary
 
+/-- The boundary-crossing comparison derived from the local constraint gives the
+periodic-boundary upgrade at all long crossing tails; only the short-tail span
+remains an explicit hypothesis.
+
+Under the normalized BNT hypotheses, every vector in the block-diagonal
+periodic-boundary ground space has a block-diagonal boundary representation
+\(X_j\). For a boundary-crossing interval beginning at \(i\), the local
+constraint and the simultaneous tail-word span at length \(N-i\) produce the
+opened-boundary \(C^j,D^j\) comparison
+\[
+  A^j_\beta C^j_{i,\rho}
+  =
+  \bigl((\mu_j^NX_j)A^j_\beta\bigr)A^j_\rho ,
+\]
+and the normalized \(E^j\)-calculation then places each single-block vector
+\(\Gamma_N^{A_j}(\mu_j^NX_j)\) in \(\mathcal G_{N,L}(A_j)\). For crossing tails
+of length at least \((L_0+1)+3(r-1)(L_0+1)\), the normalized BNT
+block-separation theorem derives the tail-word span from the hypotheses already
+present, so the comparison is derived, not assumed, at those tails. Relative to
+`exists_blockDiagonal_boundary_chainGroundSpace_of_pgvwc_comparison_bnt_c1`,
+the explicit hypothesis `hComparison` is removed; relative to
+`exists_blockDiagonal_boundary_chainGroundSpace_of_crossing_pgvwc_comparison_bnt_c1`,
+the span hypothesis is restricted to the crossing tails shorter than the BNT
+block-separation bound.
+
+The comparison derived here is the boundary-condition comparison of
+arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, specialized to the
+block-diagonal boundary conditions of arXiv:2011.12127, Section IV.C, lines
+2126--2128.
+
+**Scope restriction (length-\(L_0\) injectivity range):** Theorem 12 of
+arXiv:quant-ph/0608197 assumes \(L\ge 3(b-1)(L_0+1)+1\). This theorem is stated
+in the current BNT range derived from length-\(L_0\) block injectivity,
+\((L_0+1)+3(r-1)(L_0+1)+1\le L\). The source-range comparison is recorded in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+
+**Scope restriction (short crossing tails):** The hypothesis `hShortSpan`
+assumes the simultaneous tail-word span at the crossing tails of length
+\(N-i<(L_0+1)+3(r-1)(L_0+1)\). For the interval beginning at \(i=N-1\) the tail
+length is \(1\), so the finite BNT range does not supply this span. Replacing
+it by the source \(C^j,D^j\) comparison in the source range is the residual
+recorded in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
+theorem exists_blockDiagonal_boundary_chainGroundSpace_of_short_crossing_span_bnt_c1
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    {L₀ L N : ℕ}
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    [NeZero d] (hN : 0 < N) (hL : 0 < L) (hLN : L ≤ N)
+    (hRange :
+      (L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) + 1 ≤ L)
+    (hNlarge : L + L₀ ≤ N)
+    (hShortSpan :
+      ∀ i : Fin N, N < i.val + L →
+        N - i.val < (L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) →
+        WordTupleSpanTop A (N - i.val))
+    {ψ : NSiteSpace d N}
+    (hψ : ψ ∈ chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N) :
+    ∃ X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+      ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+        ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X)) ∧
+      ∀ j : Fin r,
+        groundSpaceMap (A j) N ((μ j) ^ N • X j) ∈ chainGroundSpace (A j) L N := by
+  have hCrossingSpan :
+      ∀ i : Fin N, N < i.val + L → WordTupleSpanTop A (N - i.val) := by
+    intro i hi
+    rcases Nat.lt_or_ge (N - i.val)
+        ((L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1)))) with hlt | hge
+    · exact hShortSpan i hi hlt
+    · exact
+        wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1
+          A hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hge
+  refine
+    exists_blockDiagonal_boundary_chainGroundSpace_of_pgvwc_comparison_bnt_c1
+      μ A hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange hNlarge hψ ?_
+  intro X hψX
+  exact
+    blockDiagonal_boundary_crossing_pgvwc_comparison_of_chainGroundSpace
+      μ A hμ hN hLN hCrossingSpan hψ X hψX
+
 /-- Boundary-crossing local constraints give the block-diagonal periodic-boundary
 equality in the finite BNT range.
 

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
@@ -1348,13 +1348,53 @@ in both cases.
     \]
 \end{proof}
 
-\begin{lemma}[Short crossing-tail spans give periodic single-block states]
+\begin{theorem}[Crossing-tail spans give periodic single-block states]
+    \label{thm:block_diagonal_boundary_periodic_components_from_crossing_span}
+    \lean{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_crossing_pgvwc_comparison_bnt_c1}
+    \leanok
+    \uses{lem:bnt_block_diagonal_open_boundary_matrices,
+        lem:block_diagonal_boundary_periodic_components_from_crossing_boundary}
+    With the hypotheses and notation of
+    Lemma~\ref{lem:bnt_block_diagonal_open_boundary_matrices}, assume in
+    addition that $L+L_0\le N$ and that every boundary-crossing interval
+    beginning at $i$ has the simultaneous tail-word spanning property: the
+    products
+    \[
+        w\longmapsto (A^1_w,\ldots,A^g_w),
+        \qquad |w|=N-i,
+    \]
+    span the product algebra $\prod_j\MN{D_j}$. Let
+    \[
+        \psi\in
+        \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right).
+    \]
+    Then there are block-diagonal boundary conditions $X_j$ with
+    \[
+        \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right)
+    \]
+    and, for every $j$,
+    \[
+        \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j).
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:bnt_block_diagonal_open_boundary_matrices,
+        lem:block_diagonal_boundary_periodic_components_from_crossing_boundary}
+    Lemma~\ref{lem:bnt_block_diagonal_open_boundary_matrices} supplies
+    block-diagonal boundary conditions $X_j$, and
+    Lemma~\ref{lem:block_diagonal_boundary_periodic_components_from_crossing_boundary}
+    applied with the assumed tail-word spans places each
+    $\Gamma_N^{A_j}(\mu_j^NX_j)$ in $\mathcal G_{N,L}(A_j)$.
+\end{proof}
+
+\begin{theorem}[Short crossing-tail spans give periodic single-block states]
     \label{lem:block_diagonal_boundary_periodic_components_from_short_crossing_span}
     \lean{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_short_crossing_span_bnt_c1}
     \leanok
-    \uses{lem:bnt_block_diagonal_open_boundary_matrices,
-        lem:unital_block_separating_product_span,
-        lem:block_diagonal_boundary_periodic_components_from_crossing_boundary}
+    \uses{thm:block_diagonal_boundary_periodic_components_from_crossing_span,
+        lem:unital_block_separating_product_span}
     With the hypotheses and notation of
     Lemma~\ref{lem:bnt_block_diagonal_open_boundary_matrices}, assume in
     addition that $L+L_0\le N$. Assume also that, for every boundary-crossing
@@ -1383,16 +1423,15 @@ in both cases.
     \]
     This derives the boundary-condition comparison of
     \cite[Theorem~12, proof lines~1446--1456]{PerezGarcia2007Matrix} at every
-    crossing tail whose length reaches the displayed block-separation bound;
-    the remaining input is the span at the shorter crossing tails, recorded in
-    \path{docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex}.
-\end{lemma}
+    crossing tail whose length reaches the displayed block-separation bound.
+    % The remaining input is the span at the shorter crossing tails, recorded
+    % in docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex.
+\end{theorem}
 
 \begin{proof}
     \leanok
-    \uses{lem:bnt_block_diagonal_open_boundary_matrices,
-        lem:unital_block_separating_product_span,
-        lem:block_diagonal_boundary_periodic_components_from_crossing_boundary}
+    \uses{thm:block_diagonal_boundary_periodic_components_from_crossing_span,
+        lem:unital_block_separating_product_span}
     For a boundary-crossing interval beginning at $i$, either
     \[
         N-i<(L_0+1)+(g-1)\bigl((L_0+1)+((L_0+1)+(L_0+1))\bigr)
@@ -1404,15 +1443,9 @@ in both cases.
     In the first case the assumed short-tail span applies; in the second case
     Lemma~\ref{lem:unital_block_separating_product_span} gives the
     simultaneous product span at length $N-i$. Hence every boundary-crossing
-    interval has the tail-word spanning property.
-    Lemma~\ref{lem:bnt_block_diagonal_open_boundary_matrices} supplies
-    block-diagonal boundary conditions $X_j$ with
-    \[
-        \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right),
-    \]
-    and
-    Lemma~\ref{lem:block_diagonal_boundary_periodic_components_from_crossing_boundary}
-    applied with these tail-word spans gives, for every $j$,
+    interval has the tail-word spanning property, and
+    Theorem~\ref{thm:block_diagonal_boundary_periodic_components_from_crossing_span}
+    gives the block-diagonal boundary conditions and, for every $j$,
     \[
         \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j).
     \]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
@@ -1390,7 +1390,7 @@ in both cases.
 \end{proof}
 
 \begin{theorem}[Short crossing-tail spans give periodic single-block states]
-    \label{lem:block_diagonal_boundary_periodic_components_from_short_crossing_span}
+    \label{thm:block_diagonal_boundary_periodic_components_from_short_crossing_span}
     \lean{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_short_crossing_span_bnt_c1}
     \leanok
     \uses{thm:block_diagonal_boundary_periodic_components_from_crossing_span,

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
@@ -1348,6 +1348,76 @@ in both cases.
     \]
 \end{proof}
 
+\begin{lemma}[Short crossing-tail spans give periodic single-block states]
+    \label{lem:block_diagonal_boundary_periodic_components_from_short_crossing_span}
+    \lean{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_short_crossing_span_bnt_c1}
+    \leanok
+    \uses{lem:bnt_block_diagonal_open_boundary_matrices,
+        lem:unital_block_separating_product_span,
+        lem:block_diagonal_boundary_periodic_components_from_crossing_boundary}
+    With the hypotheses and notation of
+    Lemma~\ref{lem:bnt_block_diagonal_open_boundary_matrices}, assume in
+    addition that $L+L_0\le N$. Assume also that, for every boundary-crossing
+    interval beginning at $i$ whose tail length lies below the
+    block-separation bound,
+    \[
+        N-i<(L_0+1)+(g-1)\bigl((L_0+1)+((L_0+1)+(L_0+1))\bigr),
+    \]
+    the simultaneous products
+    \[
+        w\longmapsto (A^1_w,\ldots,A^g_w),
+        \qquad |w|=N-i,
+    \]
+    span the product algebra $\prod_j\MN{D_j}$. Let
+    \[
+        \psi\in
+        \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right).
+    \]
+    Then there are block-diagonal boundary conditions $X_j$ with
+    \[
+        \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right)
+    \]
+    and, for every $j$,
+    \[
+        \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j).
+    \]
+    This derives the boundary-condition comparison of
+    \cite[Theorem~12, proof lines~1446--1456]{PerezGarcia2007Matrix} at every
+    crossing tail whose length reaches the displayed block-separation bound;
+    the remaining input is the span at the shorter crossing tails, recorded in
+    \path{docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex}.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:bnt_block_diagonal_open_boundary_matrices,
+        lem:unital_block_separating_product_span,
+        lem:block_diagonal_boundary_periodic_components_from_crossing_boundary}
+    For a boundary-crossing interval beginning at $i$, either
+    \[
+        N-i<(L_0+1)+(g-1)\bigl((L_0+1)+((L_0+1)+(L_0+1))\bigr)
+    \]
+    or
+    \[
+        N-i\ge(L_0+1)+(g-1)\bigl((L_0+1)+((L_0+1)+(L_0+1))\bigr).
+    \]
+    In the first case the assumed short-tail span applies; in the second case
+    Lemma~\ref{lem:unital_block_separating_product_span} gives the
+    simultaneous product span at length $N-i$. Hence every boundary-crossing
+    interval has the tail-word spanning property.
+    Lemma~\ref{lem:bnt_block_diagonal_open_boundary_matrices} supplies
+    block-diagonal boundary conditions $X_j$ with
+    \[
+        \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right),
+    \]
+    and
+    Lemma~\ref{lem:block_diagonal_boundary_periodic_components_from_crossing_boundary}
+    applied with these tail-word spans gives, for every $j$,
+    \[
+        \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j).
+    \]
+\end{proof}
+
 \begin{lemma}[Matrix identities give periodic single-block states]
     \label{lem:block_diagonal_boundary_periodic_components_from_complementary_identities}
     \lean{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_complementary_identities_bnt_c1}


### PR DESCRIPTION
## Summary

Progress on #3597 (residual of the periodic-boundary PGVWC comparison; feeds the forward direction of #2633 and tracker #190).

New theorem `MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_short_crossing_span_bnt_c1` (`TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean`): identical hypotheses and conclusion to the conditional `exists_blockDiagonal_boundary_chainGroundSpace_of_pgvwc_comparison_bnt_c1`, with

- **discharged**: the opened-boundary $C^j, D^j$ comparison hypothesis (arXiv:quant-ph/0608197, Theorem 12, proof lines 1446–1456; arXiv:2011.12127, §IV.C, lines 2126–2128), supplied through the proved `blockDiagonal_boundary_crossing_pgvwc_comparison_of_sum_mem_iSup` and its sum-mem-iSup input;
- **discharged**: the simultaneous tail-word span at every crossing tail at or above the block-separation bound $(L_0{+}1) + 3(r{-}1)(L_0{+}1)$, derived from the BNT direct-sum spanning theorem by a case split on the tail length;
- **remaining**: `hShortSpan` — the span at crossing tails *below* that bound. This is genuinely non-derivable at this statement (the window ending at site $N{-}1$ needs span at length one, which fails in general) and is exactly the residual recorded in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex` (lines 62–63, 573–576, 594–597), tracked by #3597.

This is the maximal honest discharge: the comparison-shaped hypotheses are eliminated, and what remains is the documented short-tail span residual, now isolated as the theorem's only extra input.

No #2971 markers needed repointing (all were moved to #3597 by #3598). Downstream same-file consumers that could gain short-span variants are noted in #3597 rather than refactored here, keeping the diff tight (+86 lines, one file).

## Verification

- `lake env lean` on the file: zero errors and warnings; module builds.
- `#print axioms`: only `propext`, `Classical.choice`, `Quot.sound`.
- No `sorry`, axioms, kernel bypasses, or `maxHeartbeats` changes.

Issues: #3597, #2633. Tracker: #190.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal math additions only (Lean proof composition and blueprint documentation); no runtime, auth, or infrastructure changes.
> 
> **Overview**
> Adds **`exists_blockDiagonal_boundary_chainGroundSpace_of_short_crossing_span_bnt_c1`**, which matches the conclusion of the conditional PGVWC comparison and full crossing-span theorems but replaces global tail-word span and the explicit opened-boundary \(C^j,D^j\) comparison with a single **`hShortSpan`** input: span only at boundary-crossing tails **shorter** than the BNT block-separation bound. The proof case-splits on tail length—short tails use `hShortSpan`, long tails use `wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1`—then calls the existing `exists_blockDiagonal_boundary_chainGroundSpace_of_crossing_pgvwc_comparison_bnt_c1`.
> 
> The blueprint chapter gains two linked theorems: full crossing-tail span (`thm:block_diagonal_boundary_periodic_components_from_crossing_span`) and the short-tail variant (`thm:block_diagonal_boundary_periodic_components_from_short_crossing_span`), with `\lean` anchors to the corresponding Lean names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3dc8b0abc5915a6e65c2a55b3f005b412c6c917. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->