### PR TITLE
feat(MPS/MPDO): prove family BNT-Markov key formula

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -432,6 +432,7 @@ import TNLean.MPS.MPDO.PhysicalBlocking
 import TNLean.MPS.MPDO.SimpleTensor
 import TNLean.MPS.MPDO.CommonWeightAbsorption
 import TNLean.MPS.MPDO.BNTThreeSiteCollapse
+import TNLean.MPS.MPDO.BNTMarkovKeyFormula
 import TNLean.MPS.MPDO.HorizontalBlocking
 import TNLean.MPS.MPDO.TwoSiteVerticalCanonicalForm
 import TNLean.MPS.MPDO.VerticalSectorRetractions

--- a/TNLean/MPS/MPDO/BNTMarkovKeyFormula.lean
+++ b/TNLean/MPS/MPDO/BNTMarkovKeyFormula.lean
@@ -1,0 +1,243 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.BNTThreeSiteCollapse
+import TNLean.MPS.MPDO.HayashiSectorComparison
+
+/-!
+# Comparison of BNT and quantum-Markov sectors
+
+This module compares the outer inverse contraction of a finite family of
+basis-of-normal-tensors sectors with the blocks of a chosen quantum-Markov
+decomposition of the same three-site operator.
+
+The comparison is the entrywise form of the principal identity in
+arXiv:1606.00608, Appendix C.2, lines 1719--1732.  The Markov weight remains
+explicit; no nonvanishing, positivity, saturated-area-law, zero-correlation-
+length, or sector-ownership hypothesis enters the identity.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPOTensor
+
+variable {d g : ℕ} {dim : Fin g → ℕ}
+
+/-- The left factor obtained by contracting a simultaneous block inverse with
+the left density matrix in a quantum-Markov sector.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1719--1725. -/
+def bntMarkovLeftFactor
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    (C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ)
+    (hη : EtaStructure ρ) (x : MPSTensor.BlockEntryIndex dim)
+    (k : Fin hη.m) (l l' : Fin (hη.dL k)) : ℂ :=
+  ∑ i : Fin d, ∑ j : Fin d,
+    C x (i, j) * hη.ρ_left k (i, l) (j, l')
+
+/-- The right factor obtained by contracting a simultaneous block inverse with
+the right density matrix in a quantum-Markov sector.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1719--1725. -/
+def bntMarkovRightFactor
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    (C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ)
+    (hη : EtaStructure ρ) (x : MPSTensor.BlockEntryIndex dim)
+    (k : Fin hη.m) (r r' : Fin (hη.dR k)) : ℂ :=
+  ∑ i : Fin d, ∑ j : Fin d,
+    C x (i, j) * hη.ρ_right k (r, i) (r', j)
+
+/-- The outer inverse contraction, expressed in quantum-Markov coordinates.
+It vanishes between distinct Markov sectors; within sector `k` it is the
+weight `p_k` times the product of the left and right factors.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1719--1725. -/
+theorem outerInverseContraction_markov_block
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    (C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ)
+    (hη : EtaStructure ρ) (x y : MPSTensor.BlockEntryIndex dim)
+    (k k' : Fin hη.m)
+    (l : Fin (hη.dL k)) (r : Fin (hη.dR k))
+    (l' : Fin (hη.dL k')) (r' : Fin (hη.dR k')) :
+    Matrix.reindex hη.decompB hη.decompB
+        ((hη.U_B : Matrix (Fin d) (Fin d) ℂ) *
+          outerInverseContraction C ρ x y *
+          (hη.U_B : Matrix (Fin d) (Fin d) ℂ)ᴴ)
+        ⟨k, (l, r)⟩ ⟨k', (l', r')⟩ =
+      if h : k = k' then
+        (hη.p k : ℂ) * bntMarkovLeftFactor C hη x k l (h ▸ l') *
+          bntMarkovRightFactor C hη y k r (h ▸ r')
+      else 0 := by
+  classical
+  let b : Fin d := hη.decompB.symm ⟨k, (l, r)⟩
+  let b' : Fin d := hη.decompB.symm ⟨k', (l', r')⟩
+  let U : Matrix (Fin d) (Fin d) ℂ := hη.U_B
+  have hsector (i₁ j₁ i₃ j₃ : Fin d) :
+      (∑ i₂ : Fin d, ∑ j₂ : Fin d,
+        U b i₂ * ρ (i₁, i₂, i₃) (j₁, j₂, j₃) *
+          (starRingEnd ℂ) (U b' j₂)) =
+        if h : k = k' then
+          (hη.p k : ℂ) * hη.ρ_left k (i₁, l) (j₁, h ▸ l') *
+            hη.ρ_right k (r, i₃) (h ▸ r', j₃)
+        else 0 := by
+    have hs := congrFun (congrFun hη.h_state
+      (i₁, (⟨k, (l, r)⟩, i₃))) (j₁, (⟨k', (l', r')⟩, j₃))
+    rw [Matrix.reindex_apply, Matrix.submatrix_apply] at hs
+    have hleft : (HayashiMarkov.abcEquiv hη.decompB).symm
+        (i₁, (⟨k, (l, r)⟩, i₃)) = (i₁, b, i₃) := by
+      simp [HayashiMarkov.abcEquiv, b]
+    have hright : (HayashiMarkov.abcEquiv hη.decompB).symm
+        (j₁, (⟨k', (l', r')⟩, j₃)) = (j₁, b', j₃) := by
+      simp [HayashiMarkov.abcEquiv, b']
+    rw [hleft, hright] at hs
+    rw [HayashiMarkov.liftB_conj_apply] at hs
+    rw [HayashiMarkov.blockState_apply] at hs
+    simpa [b, b', U] using hs
+  rw [Matrix.reindex_apply, Matrix.submatrix_apply]
+  change (U * outerInverseContraction C ρ x y * Uᴴ) b b' = _
+  have hExpand :
+      (U * outerInverseContraction C ρ x y * Uᴴ) b b' =
+        ∑ i₁ : Fin d, ∑ j₁ : Fin d, ∑ i₃ : Fin d, ∑ j₃ : Fin d,
+          C x (i₁, j₁) * C y (i₃, j₃) *
+            (∑ i₂ : Fin d, ∑ j₂ : Fin d,
+              U b i₂ * ρ (i₁, i₂, i₃) (j₁, j₂, j₃) *
+                (starRingEnd ℂ) (U b' j₂)) := by
+    simp_rw [Matrix.mul_apply]
+    simp only [Matrix.conjTranspose_apply, Complex.star_def]
+    simp_rw [Finset.sum_mul]
+    rw [Finset.sum_comm]
+    simp only [outerInverseContraction]
+    let rotate :
+        (Fin d × Fin d × Fin d × Fin d × Fin d × Fin d) ≃
+          (Fin d × Fin d × Fin d × Fin d × Fin d × Fin d) := {
+      toFun := fun ⟨i₂, j₂, i₁, j₁, i₃, j₃⟩ ↦ (i₁, j₁, i₃, j₃, i₂, j₂)
+      invFun := fun ⟨i₁, j₁, i₃, j₃, i₂, j₂⟩ ↦
+        (i₂, j₂, i₁, j₁, i₃, j₃)
+      left_inv := by rintro ⟨i₂, j₂, i₁, j₁, i₃, j₃⟩; rfl
+      right_inv := by rintro ⟨i₁, j₁, i₃, j₃, i₂, j₂⟩; rfl }
+    let G : Fin d × Fin d × Fin d × Fin d × Fin d × Fin d → ℂ :=
+      fun ⟨i₂, j₂, i₁, j₁, i₃, j₃⟩ ↦
+        U b i₂ * (C x (i₁, j₁) * C y (i₃, j₃) *
+          ρ (i₁, i₂, i₃) (j₁, j₂, j₃)) * (starRingEnd ℂ) (U b' j₂)
+    have hperm :
+        (∑ i₂, ∑ j₂, ∑ i₁, ∑ j₁, ∑ i₃, ∑ j₃,
+          U b i₂ * (C x (i₁, j₁) * C y (i₃, j₃) *
+            ρ (i₁, i₂, i₃) (j₁, j₂, j₃)) * (starRingEnd ℂ) (U b' j₂)) =
+        ∑ i₁, ∑ j₁, ∑ i₃, ∑ j₃, ∑ i₂, ∑ j₂,
+          U b i₂ * (C x (i₁, j₁) * C y (i₃, j₃) *
+            ρ (i₁, i₂, i₃) (j₁, j₂, j₃)) * (starRingEnd ℂ) (U b' j₂) := by
+      have hflat : (∑ z, G z) =
+          ∑ i₂, ∑ j₂, ∑ i₁, ∑ j₁, ∑ i₃, ∑ j₃,
+            U b i₂ * (C x (i₁, j₁) * C y (i₃, j₃) *
+              ρ (i₁, i₂, i₃) (j₁, j₂, j₃)) * (starRingEnd ℂ) (U b' j₂) := by
+        simp only [Fintype.sum_prod_type, G]
+      have hflat' : (∑ z, G (rotate.symm z)) =
+          ∑ i₁, ∑ j₁, ∑ i₃, ∑ j₃, ∑ i₂, ∑ j₂,
+            U b i₂ * (C x (i₁, j₁) * C y (i₃, j₃) *
+              ρ (i₁, i₂, i₃) (j₁, j₂, j₃)) * (starRingEnd ℂ) (U b' j₂) := by
+        simp [Fintype.sum_prod_type, G, rotate]
+      rw [← hflat, ← hflat']
+      exact (Equiv.sum_comp rotate.symm G).symm
+    calc
+      _ = ∑ i₂, ∑ j₂, ∑ i₁, ∑ j₁, ∑ i₃, ∑ j₃,
+          U b i₂ * (C x (i₁, j₁) * C y (i₃, j₃) *
+            ρ (i₁, i₂, i₃) (j₁, j₂, j₃)) * (starRingEnd ℂ) (U b' j₂) := by
+        refine Finset.sum_congr rfl fun i₂ _ => Finset.sum_congr rfl fun j₂ _ => ?_
+        rw [Finset.mul_sum, Finset.sum_mul]
+        refine Finset.sum_congr rfl fun i₁ _ => ?_
+        rw [Finset.mul_sum, Finset.sum_mul]
+        refine Finset.sum_congr rfl fun j₁ _ => ?_
+        rw [Finset.mul_sum, Finset.sum_mul]
+        refine Finset.sum_congr rfl fun i₃ _ => ?_
+        rw [Finset.mul_sum, Finset.sum_mul]
+      _ = ∑ i₁, ∑ j₁, ∑ i₃, ∑ j₃, ∑ i₂, ∑ j₂,
+          U b i₂ * (C x (i₁, j₁) * C y (i₃, j₃) *
+            ρ (i₁, i₂, i₃) (j₁, j₂, j₃)) * (starRingEnd ℂ) (U b' j₂) := hperm
+      _ = _ := by
+        refine Finset.sum_congr rfl fun i₁ _ => ?_
+        refine Finset.sum_congr rfl fun j₁ _ => Finset.sum_congr rfl fun i₃ _ =>
+          Finset.sum_congr rfl fun j₃ _ => ?_
+        rw [Finset.mul_sum]
+        refine Finset.sum_congr rfl fun i₂ _ => ?_
+        rw [Finset.mul_sum]
+        refine Finset.sum_congr rfl fun j₂ _ => ?_
+        ring
+  rw [hExpand]
+  simp_rw [hsector]
+  by_cases hkk : k = k'
+  · subst k'
+    simp
+    simp only [bntMarkovLeftFactor, bntMarkovRightFactor]
+    rw [show (hη.p k : ℂ) *
+        (∑ i, ∑ j, C x (i, j) * hη.ρ_left k (i, l) (j, l')) *
+        (∑ i, ∑ j, C y (i, j) * hη.ρ_right k (r, i) (r', j)) =
+      (hη.p k : ℂ) *
+        (∑ i, ∑ j, C y (i, j) * hη.ρ_right k (r, i) (r', j)) *
+        (∑ i, ∑ j, C x (i, j) * hη.ρ_left k (i, l) (j, l')) by ring]
+    rw [Finset.mul_sum]
+    refine Finset.sum_congr rfl fun i₁ _ => ?_
+    rw [Finset.mul_sum]
+    refine Finset.sum_congr rfl fun j₁ _ => ?_
+    simp_rw [Finset.mul_sum, Finset.sum_mul]
+    refine Finset.sum_congr rfl fun i₃ _ => ?_
+    refine Finset.sum_congr rfl fun j₃ _ => ?_
+    ring
+  · simp [hkk]
+
+/-- The entrywise identity obtained by comparing the quantum-Markov and
+basis-of-normal-tensors expressions for the same outer inverse contraction.
+The Markov side vanishes unless the two middle-space indices belong to the
+same Markov sector.  The basis-of-normal-tensors side vanishes unless the two
+inverse tensors select the same normal sector.
+
+**Local fix (tail index):** the closing entry is
+$R_s(\beta_3,\alpha_1)$, as forced by the matrix-unit trace identity.  This is
+the corrected orientation of the single-sector display at lines 1422--1438,
+recorded in
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1719--1732. -/
+theorem isMPOBlockLeftInverse_bnt_markov_key_formula
+    {K : (s : Fin g) → MPOTensor d (dim s)}
+    {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse K C)
+    (hρ : IsThreeSiteFamilyClosure K R ρ) (hη : EtaStructure ρ)
+    (x y : MPSTensor.BlockEntryIndex dim) (k k' : Fin hη.m)
+    (l : Fin (hη.dL k)) (r : Fin (hη.dR k))
+    (l' : Fin (hη.dL k')) (r' : Fin (hη.dR k')) :
+    (if h : k = k' then
+        (hη.p k : ℂ) * bntMarkovLeftFactor C hη x k l (h ▸ l') *
+          bntMarkovRightFactor C hη y k r (h ▸ r')
+      else 0) =
+      if h : x.1 = y.1 then
+        R x.1 (h.symm ▸ y.2.2) x.2.1 *
+          Matrix.reindex hη.decompB hη.decompB
+            ((hη.U_B : Matrix (Fin d) (Fin d) ℂ) *
+              physicalSlice (K x.1) x.2.2 (h.symm ▸ y.2.1) *
+              (hη.U_B : Matrix (Fin d) (Fin d) ℂ)ᴴ)
+            ⟨k, (l, r)⟩ ⟨k', (l', r')⟩
+      else 0 := by
+  classical
+  rw [← outerInverseContraction_markov_block C hη x y k k' l r l' r']
+  have hcollapse :
+      outerInverseContraction C ρ x y =
+        if h : x.1 = y.1 then
+          R x.1 (h.symm ▸ y.2.2) x.2.1 •
+            physicalSlice (K x.1) x.2.2 (h.symm ▸ y.2.1)
+        else 0 := by
+    ext i₂ j₂
+    rw [isMPOBlockLeftInverse_outer_inverse_threeSite_collapse hC hρ]
+    by_cases hxy : x.1 = y.1
+    · simp [hxy, physicalSlice]
+      ring
+    · simp [hxy]
+  rw [hcollapse]
+  by_cases hxy : x.1 = y.1
+  · simp [hxy, smul_eq_mul]
+  · simp [hxy]
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
@@ -93,6 +93,97 @@ strong subadditivity for a normalized three-site reduced state.
     $Q_\ell Q_k=0$.  Taking adjoints gives $Q_kQ_\ell=0$ for $\ell\ne k$.
 \end{proof}
 
+\begin{definition}[Markov factors of a simultaneous inverse]
+    \label{def:mpdo_bnt_markov_factors}
+    \lean{MPOTensor.bntMarkovLeftFactor}
+    \lean{MPOTensor.bntMarkovRightFactor}
+    \leanok
+    \uses{def:mpdo_three_site_family_closure, def:mpdo_eta_structure}
+    Let $C_x$ and $C_y$ be two rows of a simultaneous left inverse, and
+    choose a Hayashi decomposition of the three-site operator.  In its
+    $k$-th Markov sector, set
+    \begin{align*}
+        A_x^{(k)}(l,l')
+        &=\sum_{i_1,j_1} C_{x,(i_1,j_1)}
+          \rho_{A b_1;(i_1,l),(j_1,l')}^{(k)},\\
+        B_y^{(k)}(r,r')
+        &=\sum_{i_3,j_3} C_{y,(i_3,j_3)}
+          \rho_{b_2 C;(r,i_3),(r',j_3)}^{(k)}.
+    \end{align*}
+    These are the two factors obtained in the projected contraction
+    of~\cite[Appendix~C.2, lines~1719--1725]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{theorem}[Outer inverse contraction in Markov coordinates]
+    \label{thm:mpdo_bnt_outer_inverse_markov_block}
+    \lean{MPOTensor.outerInverseContraction_markov_block}
+    \leanok
+    \uses{def:mpdo_bnt_markov_factors}
+    Let $\Gamma_{x,y}$ denote the outer inverse contraction.  In the basis of
+    the chosen Hayashi decomposition,
+    \[
+      {\bigl[U_B\Gamma_{x,y}U_B^\dagger\bigr]}_{(k,l,r),(k',l',r')}
+      =\begin{cases}
+        p_k A_x^{(k)}(l,l')B_y^{(k)}(r,r'),&k=k',\\
+        0,&k\ne k'.
+      \end{cases}
+    \]
+    In particular, the probability $p_k$ remains explicit.  This identity
+    requires neither a nonvanishing condition on $p_k$ nor assumptions of
+    saturated area law or zero correlation length.
+\end{theorem}
+
+\begin{proof}\leanok
+    Expand the two matrix products and the outer inverse contraction.  The
+    Hayashi block decomposition makes the middle-site contraction zero for
+    $k\ne k'$.  For $k=k'$, the remaining four outer sums separate into the
+    product defining $A_x^{(k)}$ and $B_y^{(k)}$, with the common factor $p_k$.
+\end{proof}
+
+\begin{theorem}[Entrywise BNT--Markov identity]
+    \label{thm:mpdo_bnt_markov_key_formula}
+    \lean{MPOTensor.isMPOBlockLeftInverse_bnt_markov_key_formula}
+    \leanok
+    \uses{thm:mpdo_bnt_three_site_outer_inverse_collapse,
+      thm:mpdo_bnt_outer_inverse_markov_block}
+    Let $x=(s,\alpha_1,\beta_1)$ and
+    $y=(t,\alpha_3,\beta_3)$.  Comparing the two expressions for the same
+    outer inverse contraction gives
+    \[
+      \begin{cases}
+        p_k A_x^{(k)}(l,l')B_y^{(k)}(r,r'),&k=k',\\
+        0,&k\ne k'
+      \end{cases}
+      =
+      \begin{cases}
+        {(R_s)}_{\beta_3,\alpha_1}
+        \bigl[U_B\kappa^{(s)}_{\beta_1,\alpha_3}U_B^\dagger\bigr]
+          _{(k,l,r),(k',l',r')},&s=t,\\
+        0,&s\ne t.
+      \end{cases}
+    \]
+    Here
+    $\kappa^{(s)}_{\beta_1,\alpha_3}(i,j)
+      ={(\mathcal K_s^{ij})}_{\beta_1,\alpha_3}$.
+    Thus both the normal-sector and Markov-sector off-diagonal entries are
+    retained in the statement, rather than being suppressed by a prior
+    choice of equal labels.  This is the full entrywise identity used
+    in~\cite[Appendix~C.2, lines~1719--1732]{Cirac2016MPDO_arXiv}.
+
+    The closing entry ${(R_s)}_{\beta_3,\alpha_1}$ is the corrected tail-index
+    orientation of the display at lines~1422--1438, recorded in
+    \path{docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex}.
+\end{theorem}
+
+\begin{proof}\leanok
+    The preceding theorem identifies the left side with the transformed outer
+    inverse contraction.  The collapse theorem identifies the contraction
+    with zero when $s\ne t$ and with
+    ${(R_s)}_{\beta_3,\alpha_1}
+      \kappa^{(s)}_{\beta_1,\alpha_3}$ when $s=t$.
+    Conjugating this matrix by $U_B$ gives the right side.
+\end{proof}
+
 \begin{theorem}[Saturation gives equality in strong subadditivity]
     \label{thm:mpdo_sal_ssa_equality}
     \lean{MPOTensor.isSSAEquality_tripartite_of_isSAL}


### PR DESCRIPTION
## Summary

- define the left and right Markov factors of a simultaneous BNT-family inverse
- prove the complete Markov-block formula for the transformed outer contraction, including off-diagonal vanishing and the explicit factor `p_k`
- combine it with the family three-site collapse to obtain the full entrywise Case II identity, with both the Markov-sector and BNT-sector case distinctions retained
- place the blueprint statement after the Hayashi projections and their resolution, following arXiv:1606.00608 Appendix C.2, lines 1693–1732

## Faithfulness

The result uses only a simultaneous MPO-block left inverse, a three-site family closure, and a chosen Hayashi decomposition. It adds no positivity, nonvanishing, saturated-area-law, zero-correlation-length, injectivity, or sector-ownership hypothesis, and it does not divide by `p_k`.

The corrected tail orientation `R_s(β₃, α₁)` is marked and linked to `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.

Advances #4003.

## Verification

- `lake build`
- focused Lean check and root import check
- `#print axioms` (standard Mathlib axioms only)
- `leanblueprint checkdecls`
- blueprint/Lean synchronization check
- reader-facing prose check
- `leanblueprint pdf`, with visual inspection of the affected pages
- no `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast` in the new Lean file