### PR TITLE
feat(MPS/MPDO): prove BNT Markov off-diagonal vanishing

### DIFF
--- a/TNLean/MPS/MPDO/BNTMarkovKeyFormula.lean
+++ b/TNLean/MPS/MPDO/BNTMarkovKeyFormula.lean
@@ -168,7 +168,7 @@ theorem outerInverseContraction_markov_block
   simp_rw [hsector]
   by_cases hkk : k = k'
   · subst k'
-    simp
+    simp only [reduceDIte]
     simp only [bntMarkovLeftFactor, bntMarkovRightFactor]
     rw [show (hη.p k : ℂ) *
         (∑ i, ∑ j, C x (i, j) * hη.ρ_left k (i, l) (j, l')) *
@@ -239,5 +239,39 @@ theorem isMPOBlockLeftInverse_bnt_markov_key_formula
   by_cases hxy : x.1 = y.1
   · simp [hxy, smul_eq_mul]
   · simp [hxy]
+
+/-- Distinct Markov sectors give a zero block of every physical slice in a
+fixed basis-of-normal-tensors sector, once the nonzero closing entry selected
+in the source is fixed.
+
+**Local fix (tail index):** the nonzero closing entry is
+$R_s(\beta_3,\alpha_1)$, as forced by the matrix-unit trace identity.  This is
+the corrected orientation of the single-sector display at lines 1422--1438,
+recorded in
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `Qks`, lines 1730--1735. -/
+theorem isMPOBlockLeftInverse_bnt_markov_offdiagonal
+    {K : (s : Fin g) → MPOTensor d (dim s)}
+    {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse K C)
+    (hρ : IsThreeSiteFamilyClosure K R ρ) (hη : EtaStructure ρ)
+    (s : Fin g) {α₁ β₃ : Fin (dim s)} (hm : R s β₃ α₁ ≠ 0)
+    (β₁ α₃ : Fin (dim s)) {k k' : Fin hη.m} (hkk' : k ≠ k')
+    (l : Fin (hη.dL k)) (r : Fin (hη.dR k))
+    (l' : Fin (hη.dL k')) (r' : Fin (hη.dR k')) :
+    Matrix.reindex hη.decompB hη.decompB
+        ((hη.U_B : Matrix (Fin d) (Fin d) ℂ) *
+          physicalSlice (K s) β₁ α₃ *
+          (hη.U_B : Matrix (Fin d) (Fin d) ℂ)ᴴ)
+        ⟨k, (l, r)⟩ ⟨k', (l', r')⟩ = 0 := by
+  classical
+  have hkey := isMPOBlockLeftInverse_bnt_markov_key_formula hC hρ hη
+    (⟨s, α₁, β₁⟩) (⟨s, α₃, β₃⟩) k k' l r l' r'
+  simp [hkk'] at hkey
+  simpa [Matrix.reindex_apply, Matrix.submatrix_apply] using
+    hkey.resolve_left hm
 
 end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
@@ -184,6 +184,35 @@ strong subadditivity for a normalized three-site reduced state.
     Conjugating this matrix by $U_B$ gives the right side.
 \end{proof}
 
+\begin{theorem}[Off-diagonal Markov blocks of a BNT sector]
+    \label{thm:mpdo_bnt_markov_offdiagonal}
+    \lean{MPOTensor.isMPOBlockLeftInverse_bnt_markov_offdiagonal}
+    \leanok
+    \uses{thm:mpdo_bnt_markov_key_formula}
+    Fix a normal sector $s$ and virtual indices $\alpha_1,\beta_3$ for which
+    ${(R_s)}_{\beta_3,\alpha_1}\ne0$.  Then, for every $\beta_1,\alpha_3$
+    and every pair of distinct Markov sectors $k\ne k'$, one has
+    \[
+      \bigl[U_B\kappa^{(s)}_{\beta_1,\alpha_3}U_B^\dagger\bigr]
+        _{(k,l,r),(k',l',r')}=0.
+    \]
+    Thus each physical slice of the $s$-th normal tensor is block diagonal in
+    the Markov decomposition.  This is equation~\textup{Qks}
+    in~\cite[Appendix~C.2, lines~1682--1688 and 1730--1735]
+      {Cirac2016MPDO_arXiv}.
+
+    The nonzero closing entry uses the corrected orientation
+    ${(R_s)}_{\beta_3,\alpha_1}$ recorded in
+    \path{docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex}.
+\end{theorem}
+
+\begin{proof}\leanok
+    In the entrywise BNT--Markov identity, take equal normal-sector labels and
+    distinct Markov-sector labels.  The left side vanishes, while the right
+    side is the selected closing entry times the displayed block.  Cancel the
+    nonzero closing entry.
+\end{proof}
+
 \begin{theorem}[Saturation gives equality in strong subadditivity]
     \label{thm:mpdo_sal_ssa_equality}
     \lean{MPOTensor.isSSAEquality_tripartite_of_isSAL}


### PR DESCRIPTION
## Summary

- derive the Case II `Qks` consequence from the full entrywise BNT–Markov identity
- show that every physical slice of a fixed BNT sector has zero matrix entries between distinct Hayashi sectors
- record the result immediately after the key formula in the source-ordered blueprint
- replace one flexible simplification in the preceding proof by the exact dependent-if reduction reported by Lean 4.32

## Faithfulness

The only new hypothesis is the nonzero closing entry `R_s(β₃, α₁) ≠ 0` chosen immediately before the Case II calculation in arXiv:1606.00608, Appendix C.2. The proof does not assume `p_k ≠ 0`, does not divide by `p_k`, and does not introduce a Markov-to-BNT owner assignment. The owner assignment and projectors `P_s` remain subsequent source steps.

The corrected tail orientation is linked to `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.

Advances #4003.

## Verification

- `lake build`
- focused Lean check and root import check
- `#print axioms` (standard Mathlib axioms only)
- `leanblueprint checkdecls`
- blueprint/Lean synchronization check
- reader-facing prose check
- `leanblueprint pdf`, with visual inspection of the affected page
- no new `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast`