### PR TITLE
feat(MPS/MPDO): construct BNT Markov-sector projectors

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -433,6 +433,7 @@ import TNLean.MPS.MPDO.SimpleTensor
 import TNLean.MPS.MPDO.CommonWeightAbsorption
 import TNLean.MPS.MPDO.BNTThreeSiteCollapse
 import TNLean.MPS.MPDO.BNTMarkovKeyFormula
+import TNLean.MPS.MPDO.BNTMarkovSectorProjectors
 import TNLean.MPS.MPDO.HorizontalBlocking
 import TNLean.MPS.MPDO.TwoSiteVerticalCanonicalForm
 import TNLean.MPS.MPDO.VerticalSectorRetractions

--- a/TNLean/Algebra/MatrixAux.lean
+++ b/TNLean/Algebra/MatrixAux.lean
@@ -43,6 +43,9 @@ Extracted from various files for reusability.
   finite index space
 - `Matrix.nonempty_of_trace_eq_one`: an index space carrying a trace-one matrix
   is nonempty
+- `Matrix.exists_entry_ne_zero_of_ne_zero`: a nonzero matrix has a nonzero entry
+- `Matrix.exists_diagonal_ne_zero_of_trace_eq_one`: a trace-one matrix has a
+  nonzero diagonal entry
 - `Continuous.matrix_kronecker`: joint continuity of the Kronecker product in both factors
 -/
 
@@ -83,6 +86,25 @@ lemma nonempty_of_trace_eq_one {α : Type*} [Fintype α]
     simp
   rw [hzero] at hρ
   norm_num at hρ
+
+/-- A matrix of trace one has a nonzero diagonal entry. -/
+lemma exists_diagonal_ne_zero_of_trace_eq_one {α : Type*} [Fintype α]
+    (ρ : Matrix α α ℂ) (hρ : ρ.trace = 1) : ∃ i : α, ρ i i ≠ 0 := by
+  have hsum : (∑ i : α, ρ i i) ≠ 0 := by
+    change ρ.trace ≠ 0
+    rw [hρ]
+    exact one_ne_zero
+  obtain ⟨i, _, hi⟩ := Finset.exists_ne_zero_of_sum_ne_zero hsum
+  exact ⟨i, hi⟩
+
+/-- A nonzero matrix has a nonzero entry. -/
+lemma exists_entry_ne_zero_of_ne_zero {m n R : Type*} [Zero R]
+    (A : Matrix m n R) (hA : A ≠ 0) : ∃ i j, A i j ≠ 0 := by
+  by_contra h
+  push Not at h
+  apply hA
+  ext i j
+  exact h i j
 
 section RankOneQuadratic
 

--- a/TNLean/Algebra/OrthogonalProjection.lean
+++ b/TNLean/Algebra/OrthogonalProjection.lean
@@ -20,6 +20,7 @@ channels and irreducibility.
 * `IsOrthogonalProjection.one_sub`
 * `IsStarProjection.conjTranspose_mul_mul_of_mul_conjTranspose_eq_one`
 * `isOrthogonalProjection_posSemidef`
+* `isOrthogonalProjection_sum_of_pairwise_mul_eq_zero`
 * `orthogonalProjection_mul_eq_zero_of_sum_eq_one`
 -/
 
@@ -77,6 +78,30 @@ theorem isOrthogonalProjection_posSemidef {P : Matrix (Fin D) (Fin D) ℂ}
     (hP : IsOrthogonalProjection P) :
     P.PosSemidef :=
   Matrix.nonneg_iff_posSemidef.mp hP.isStarProjection.nonneg
+
+/-- A finite sum of pairwise orthogonal projections is an orthogonal
+projection. -/
+theorem isOrthogonalProjection_sum_of_pairwise_mul_eq_zero
+    {ι : Type*} [Fintype ι] (P : ι → Matrix (Fin D) (Fin D) ℂ)
+    (hproj : ∀ i, IsOrthogonalProjection (P i))
+    (horth : ∀ {i j}, i ≠ j → P i * P j = 0) :
+    IsOrthogonalProjection (∑ i, P i) := by
+  classical
+  constructor
+  · change (∑ i, P i)ᴴ = ∑ i, P i
+    rw [Matrix.conjTranspose_sum]
+    exact Finset.sum_congr rfl fun i _ ↦ (hproj i).1.eq
+  · calc
+      (∑ i, P i) * (∑ j, P j) = ∑ i, ∑ j, P i * P j := by
+        rw [Finset.sum_mul]
+        refine Finset.sum_congr rfl fun i _ ↦ ?_
+        rw [Finset.mul_sum]
+      _ = ∑ i, P i := by
+        refine Finset.sum_congr rfl fun i _ ↦ ?_
+        rw [Finset.sum_eq_single i]
+        · exact (hproj i).2
+        · exact fun j _ hji ↦ horth (Ne.symm hji)
+        · simp
 
 /-- **Orthogonal projections summing to the identity are mutually
 orthogonal**: `P k * P l = 0` for `k ≠ l`.  Compressing the resolution of the

--- a/TNLean/MPS/MPDO/BNTMarkovSectorProjectors.lean
+++ b/TNLean/MPS/MPDO/BNTMarkovSectorProjectors.lean
@@ -1,0 +1,501 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.MatrixAux
+import TNLean.MPS.MPDO.BNTMarkovKeyFormula
+import TNLean.MPS.MPDO.HayashiSectorProjector
+import TNLean.MPS.MPDO.SectorEtaOperator
+
+/-!
+# Normal-sector projectors from quantum-Markov sectors
+
+This module proves the existence assertion following the principal Case II
+identity in arXiv:1606.00608, Appendix C.2.  For every Hayashi sector of
+nonzero weight, at least one basis-of-normal-tensors sector has a nonzero
+diagonal block.  Under the separately stated nonzero-closing-matrix hypothesis
+used by the source cancellation, this sector is unique.  The corresponding
+sums of the canonical Hayashi projections give the normal-sector projections
+of equation `Pis` on the positive-weight support.
+
+The source discards zero blocks by assuming
+$Q_k\sigma^{(N)}_3Q_k\ne 0$.  Since the formal Hayashi decomposition retains
+summands of weight zero, the assertion is stated on the subtype $p_k\ne0$.
+This is the inactive-sector correction recorded in
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+
+## Main definitions
+
+* `MPOTensor.bntMarkovBlock`: the block $O_s^{(k)}=Q_k\mathcal K_sQ_k$ in
+  coordinates adapted to the Hayashi decomposition.
+* `MPOTensor.BNTMarkovBlockNonzero`: nonvanishing of some virtual slice of
+  $O_s^{(k)}$.
+* `MPOTensor.bntSectorLabel`: the unique label $j_k$ under the explicit
+  nonzero-closing-matrix hypothesis.
+* `MPOTensor.bntSectorProjection`: the projection
+  $P_s=\sum_{k:j_k=s}Q_k$ on the positive-weight support.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Appendix C.2, equations `QkKjs` and `Pis`, lines 1698--1737.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPOTensor
+
+variable {d g D : ℕ} {dim : Fin g → ℕ}
+
+/-- The $k$-th diagonal quantum-Markov block of one physical slice of a
+basis-of-normal-tensors sector:
+\[
+  O_s^{(k)}(\beta,\alpha)
+  =\left[U_B\kappa^{(s)}_{\beta,\alpha}U_B^\dagger\right]_{k,k}.
+\]
+
+Source: arXiv:1606.00608, Appendix C.2, equation `QkKjs`, lines 1703--1707,
+and the definition of $O_j^{(k)}$ at lines 1733--1736. -/
+noncomputable def bntMarkovBlock
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    (K : MPOTensor d D) (hη : EtaStructure ρ) (k : Fin hη.m)
+    (β α : Fin D) :
+    Matrix (Fin (hη.dL k) × Fin (hη.dR k))
+      (Fin (hη.dL k) × Fin (hη.dR k)) ℂ :=
+  fun x y ↦
+    Matrix.reindex hη.decompB hη.decompB
+        ((hη.U_B : Matrix (Fin d) (Fin d) ℂ) *
+          physicalSlice K β α *
+          (hη.U_B : Matrix (Fin d) (Fin d) ℂ)ᴴ)
+      ⟨k, x⟩ ⟨k, y⟩
+
+/-- The normal sector has a nonzero diagonal block in the $k$-th
+quantum-Markov summand when one of the virtual slices $O_s^{(k)}(\beta,\alpha)$
+is nonzero.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `QkKjs`, lines 1703--1707,
+and lines 1733--1737. -/
+def BNTMarkovBlockNonzero
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    (K : MPOTensor d D) (hη : EtaStructure ρ) (k : Fin hη.m) : Prop :=
+  ∃ β α : Fin D, bntMarkovBlock K hη k β α ≠ 0
+
+/-- Conjugating the middle physical index of a three-site family closure
+conjugates the middle tensor in every normal sector.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1726--1732. -/
+theorem conjugated_middle_threeSiteFamilyClosure
+    {K : (s : Fin g) → MPOTensor d (dim s)}
+    {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    (hρ : IsThreeSiteFamilyClosure K R ρ)
+    (U : Matrix (Fin d) (Fin d) ℂ)
+    (i₁ j₁ i₃ j₃ b b' : Fin d) :
+    (∑ i₂ : Fin d, ∑ j₂ : Fin d,
+      U b i₂ * ρ (i₁, i₂, i₃) (j₁, j₂, j₃) * star (U b' j₂)) =
+      ∑ s : Fin g, Matrix.trace
+        (K s i₁ j₁ * conjugatePhysical (K s) U b b' * K s i₃ j₃ * R s) := by
+  classical
+  unfold IsThreeSiteFamilyClosure at hρ
+  simp_rw [hρ]
+  let rotate : (Fin d × Fin d × Fin g) ≃ (Fin g × Fin d × Fin d) := {
+    toFun := fun ⟨i₂, j₂, s⟩ ↦ (s, i₂, j₂)
+    invFun := fun ⟨s, i₂, j₂⟩ ↦ (i₂, j₂, s)
+    left_inv := by rintro ⟨i₂, j₂, s⟩; rfl
+    right_inv := by rintro ⟨s, i₂, j₂⟩; rfl }
+  have sum_sector_first (f : Fin d → Fin d → Fin g → ℂ) :
+      (∑ i₂, ∑ j₂, ∑ s, f i₂ j₂ s) =
+        ∑ s, ∑ i₂, ∑ j₂, f i₂ j₂ s := by
+    classical
+    let F : Fin d × Fin d × Fin g → ℂ := fun ⟨i₂, j₂, s⟩ ↦ f i₂ j₂ s
+    have hflat : (∑ z, F z) = ∑ i₂, ∑ j₂, ∑ s, f i₂ j₂ s := by
+      simp only [Fintype.sum_prod_type, F]
+    have hflat' : (∑ z, F (rotate.symm z)) =
+        ∑ s, ∑ i₂, ∑ j₂, f i₂ j₂ s := by
+      simp [Fintype.sum_prod_type, F, rotate]
+    rw [← hflat, ← hflat']
+    exact (Equiv.sum_comp rotate.symm F).symm
+  have hmiddle (s : Fin g) : conjugatePhysical (K s) U b b' =
+      ∑ i₂ : Fin d, ∑ j₂ : Fin d,
+        (U b i₂ * star (U b' j₂)) • K s i₂ j₂ := by
+    exact conjugatePhysical_eq_sum (K s) U b b'
+  simp_rw [hmiddle]
+  simp only [Matrix.mul_sum, Matrix.mul_smul, Matrix.sum_mul,
+    Matrix.smul_mul, Matrix.trace_sum, Matrix.trace_smul, smul_eq_mul]
+  simp_rw [Finset.mul_sum, Finset.sum_mul]
+  rw [sum_sector_first]
+  refine Finset.sum_congr rfl fun s _ ↦ ?_
+  refine Finset.sum_congr rfl fun i₂ _ ↦ ?_
+  refine Finset.sum_congr rfl fun j₂ _ ↦ ?_
+  ring
+
+/-- Every quantum-Markov sector of nonzero weight has a nonzero diagonal
+block in at least one normal sector:
+\[
+  p_k\ne0 \quad\Longrightarrow\quad
+  \exists s,\; Q_k\mathcal K_sQ_k\ne0.
+\]
+
+The conclusion is the existence part of equation `QkKjs`.  It follows
+directly from the three-site family closure and the trace-one left and right
+states in the Hayashi decomposition.
+
+**Local fix (inactive sectors):** the source removes summands for which
+$Q_k\sigma^{(N)}_3Q_k=0$.  The formal statement instead retains the ambient
+decomposition and restricts to $p_k\ne0$, as recorded in
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `QkKjs`, lines 1733--1737. -/
+theorem exists_bntMarkovBlockNonzero_of_probability_ne_zero
+    {K : (s : Fin g) → MPOTensor d (dim s)}
+    {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    (hρ : IsThreeSiteFamilyClosure K R ρ)
+    (hη : EtaStructure ρ) (k : Fin hη.m) (hk : hη.p k ≠ 0) :
+    ∃ s : Fin g, BNTMarkovBlockNonzero (K s) hη k := by
+  classical
+  obtain ⟨⟨i₁, l⟩, hleft⟩ :=
+    Matrix.exists_diagonal_ne_zero_of_trace_eq_one
+      (hη.ρ_left k) (hη.hρ_left_dm k).2
+  obtain ⟨⟨r, i₃⟩, hright⟩ :=
+    Matrix.exists_diagonal_ne_zero_of_trace_eq_one
+      (hη.ρ_right k) (hη.hρ_right_dm k).2
+  let b : Fin d := hη.decompB.symm ⟨k, (l, r)⟩
+  have hs := congrFun (congrFun hη.h_state
+    (i₁, (⟨k, (l, r)⟩, i₃))) (i₁, (⟨k, (l, r)⟩, i₃))
+  rw [Matrix.reindex_apply, Matrix.submatrix_apply] at hs
+  have hindex : (HayashiMarkov.abcEquiv hη.decompB).symm
+      (i₁, (⟨k, (l, r)⟩, i₃)) = (i₁, b, i₃) := by
+    simp [HayashiMarkov.abcEquiv, b]
+  rw [hindex, HayashiMarkov.liftB_conj_apply,
+    HayashiMarkov.blockState_apply] at hs
+  have hs' :
+      (∑ i₂ : Fin d, ∑ j₂ : Fin d,
+        (hη.U_B : Matrix (Fin d) (Fin d) ℂ) b i₂ *
+          ρ (i₁, i₂, i₃) (i₁, j₂, i₃) *
+            star ((hη.U_B : Matrix (Fin d) (Fin d) ℂ) b j₂)) =
+        (hη.p k : ℂ) * hη.ρ_left k (i₁, l) (i₁, l) *
+          hη.ρ_right k (r, i₃) (r, i₃) := by
+    simpa using hs
+  have hsum_ne :
+      (∑ s : Fin g, Matrix.trace
+        (K s i₁ i₁ * conjugatePhysical (K s) hη.U_B b b *
+          K s i₃ i₃ * R s)) ≠ 0 := by
+    rw [← conjugated_middle_threeSiteFamilyClosure
+      hρ hη.U_B i₁ i₁ i₃ i₃ b b, hs']
+    exact mul_ne_zero (mul_ne_zero (Complex.ofReal_ne_zero.mpr hk) hleft) hright
+  obtain ⟨s, _, hs_ne⟩ := Finset.exists_ne_zero_of_sum_ne_zero hsum_ne
+  have hmiddle_ne : conjugatePhysical (K s) hη.U_B b b ≠ 0 := by
+    intro hzero
+    rw [hzero] at hs_ne
+    simp only [Matrix.mul_zero, Matrix.zero_mul, Matrix.trace_zero] at hs_ne
+    exact hs_ne rfl
+  obtain ⟨β, α, hentry⟩ :=
+    Matrix.exists_entry_ne_zero_of_ne_zero _ hmiddle_ne
+  refine ⟨s, β, α, ?_⟩
+  intro hblock
+  have hdiag := congrFun (congrFun hblock (l, r)) (l, r)
+  rw [bntMarkovBlock, Matrix.reindex_apply, Matrix.submatrix_apply] at hdiag
+  change conjugatePhysical (K s) hη.U_B b b β α = 0 at hdiag
+  exact hentry hdiag
+
+/-- A positive-weight quantum-Markov sector cannot have nonzero diagonal
+blocks in two distinct normal sectors.
+
+The proof is the cancellation argument following equation `QkKjs`: a
+same-sector instance of the principal identity supplies a nonzero left
+factor; a mixed normal-sector instance forces the right factor of the second
+sector to vanish; a final same-sector instance contradicts its nonzero
+block.
+
+**Scope restriction (closing matrices):** this statement assumes explicitly
+that every closing matrix $R_s$ is nonzero.  The source obtains suitable
+nonzero closing entries from the simplicity and common-weight construction at
+lines 1714--1718.  Connecting that construction to
+`IsThreeSiteFamilyClosure` remains recorded in
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `QkKjs`, lines 1733--1737. -/
+theorem bntMarkovBlockNonzero_eq_of_probability_ne_zero
+    {K : (s : Fin g) → MPOTensor d (dim s)}
+    {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse K C)
+    (hρ : IsThreeSiteFamilyClosure K R ρ) (hη : EtaStructure ρ)
+    (hR : ∀ s : Fin g, R s ≠ 0) (k : Fin hη.m) (hk : hη.p k ≠ 0)
+    {s t : Fin g} (hs : BNTMarkovBlockNonzero (K s) hη k)
+    (ht : BNTMarkovBlockNonzero (K t) hη k) : s = t := by
+  classical
+  by_contra hst
+  obtain ⟨βs, αs, hBs⟩ := hs
+  obtain ⟨⟨ls, rs⟩, ⟨ls', rs'⟩, hBs_entry⟩ :=
+    Matrix.exists_entry_ne_zero_of_ne_zero _ hBs
+  obtain ⟨β3s, α1s, hRs_entry⟩ :=
+    Matrix.exists_entry_ne_zero_of_ne_zero _ (hR s)
+  have hsame_s := isMPOBlockLeftInverse_bnt_markov_key_formula hC hρ hη
+    (⟨s, α1s, βs⟩) (⟨s, αs, β3s⟩) k k ls rs ls' rs'
+  simp only [dif_pos trivial] at hsame_s
+  change
+    (hη.p k : ℂ) *
+        bntMarkovLeftFactor C hη (⟨s, α1s, βs⟩) k ls ls' *
+          bntMarkovRightFactor C hη (⟨s, αs, β3s⟩) k rs rs' =
+      R s β3s α1s * bntMarkovBlock (K s) hη k βs αs
+        (ls, rs) (ls', rs') at hsame_s
+  have hsame_s_ne :
+      (hη.p k : ℂ) *
+          bntMarkovLeftFactor C hη (⟨s, α1s, βs⟩) k ls ls' *
+            bntMarkovRightFactor C hη (⟨s, αs, β3s⟩) k rs rs' ≠ 0 := by
+    rw [hsame_s]
+    exact mul_ne_zero hRs_entry hBs_entry
+  have hleft_s :
+      bntMarkovLeftFactor C hη (⟨s, α1s, βs⟩) k ls ls' ≠ 0 := by
+    intro hzero
+    rw [hzero, mul_zero, zero_mul] at hsame_s_ne
+    exact hsame_s_ne rfl
+  obtain ⟨βt, αt, hBt⟩ := ht
+  obtain ⟨⟨lt, rt⟩, ⟨lt', rt'⟩, hBt_entry⟩ :=
+    Matrix.exists_entry_ne_zero_of_ne_zero _ hBt
+  obtain ⟨β3t, α1t, hRt_entry⟩ :=
+    Matrix.exists_entry_ne_zero_of_ne_zero _ (hR t)
+  have hmixed := isMPOBlockLeftInverse_bnt_markov_key_formula hC hρ hη
+    (⟨s, α1s, βs⟩) (⟨t, αt, β3t⟩) k k ls rt ls' rt'
+  simp only [dif_pos trivial, dif_neg hst] at hmixed
+  have hright_t :
+      bntMarkovRightFactor C hη (⟨t, αt, β3t⟩) k rt rt' = 0 := by
+    rcases mul_eq_zero.mp hmixed with hp_left_zero | hright_zero
+    · exact False.elim <|
+        (mul_ne_zero (Complex.ofReal_ne_zero.mpr hk) hleft_s) hp_left_zero
+    · exact hright_zero
+  have hsame_t := isMPOBlockLeftInverse_bnt_markov_key_formula hC hρ hη
+    (⟨t, α1t, βt⟩) (⟨t, αt, β3t⟩) k k lt rt lt' rt'
+  simp only [dif_pos trivial] at hsame_t
+  change
+    (hη.p k : ℂ) *
+        bntMarkovLeftFactor C hη (⟨t, α1t, βt⟩) k lt lt' *
+          bntMarkovRightFactor C hη (⟨t, αt, β3t⟩) k rt rt' =
+      R t β3t α1t * bntMarkovBlock (K t) hη k βt αt
+        (lt, rt) (lt', rt') at hsame_t
+  rw [hright_t, mul_zero] at hsame_t
+  exact (mul_ne_zero hRt_entry hBt_entry) hsame_t.symm
+
+/-- Under the explicit nonzero-closing-matrix hypothesis, every
+positive-weight quantum-Markov sector has a unique normal-sector label with a
+nonzero diagonal block.
+
+**Scope restriction (closing matrices):** see
+`bntMarkovBlockNonzero_eq_of_probability_ne_zero`.  The missing derivation of
+this hypothesis from the paper's simplicity and common-weight construction is
+recorded in
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `QkKjs`, lines 1733--1737. -/
+theorem existsUnique_bntMarkovBlockNonzero_of_probability_ne_zero
+    {K : (s : Fin g) → MPOTensor d (dim s)}
+    {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse K C)
+    (hρ : IsThreeSiteFamilyClosure K R ρ) (hη : EtaStructure ρ)
+    (hR : ∀ s : Fin g, R s ≠ 0) (k : Fin hη.m) (hk : hη.p k ≠ 0) :
+    ∃! s : Fin g, BNTMarkovBlockNonzero (K s) hη k := by
+  obtain ⟨s, hs⟩ :=
+    exists_bntMarkovBlockNonzero_of_probability_ne_zero hρ hη k hk
+  refine ⟨s, hs, fun t ht ↦ ?_⟩
+  exact bntMarkovBlockNonzero_eq_of_probability_ne_zero
+    hC hρ hη hR k hk ht hs
+
+/-- The normal-sector label $j_k$ assigned to a positive-weight
+quantum-Markov sector by equation `QkKjs`.
+
+**Scope restriction (closing matrices):** the definition uses the conditional
+uniqueness theorem above; see
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `QkKjs`, lines 1733--1737. -/
+noncomputable def bntSectorLabel
+    {K : (s : Fin g) → MPOTensor d (dim s)}
+    {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse K C)
+    (hρ : IsThreeSiteFamilyClosure K R ρ) (hη : EtaStructure ρ)
+    (hR : ∀ s : Fin g, R s ≠ 0)
+    (k : {k : Fin hη.m // hη.p k ≠ 0}) : Fin g :=
+  Classical.choose
+    (existsUnique_bntMarkovBlockNonzero_of_probability_ne_zero
+      hC hρ hη hR k k.property).exists
+
+/-- The block selected by $j_k$ is nonzero.
+
+**Scope restriction (closing matrices):** see `bntSectorLabel`.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `QkKjs`, lines 1733--1737. -/
+theorem bntMarkovBlockNonzero_bntSectorLabel
+    {K : (s : Fin g) → MPOTensor d (dim s)}
+    {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse K C)
+    (hρ : IsThreeSiteFamilyClosure K R ρ) (hη : EtaStructure ρ)
+    (hR : ∀ s : Fin g, R s ≠ 0)
+    (k : {k : Fin hη.m // hη.p k ≠ 0}) :
+    BNTMarkovBlockNonzero
+      (K (bntSectorLabel hC hρ hη hR k)) hη k := by
+  exact Classical.choose_spec
+    (existsUnique_bntMarkovBlockNonzero_of_probability_ne_zero
+      hC hρ hη hR k k.property).exists
+
+/-- The label $j_k$ is characterized by nonvanishing of the corresponding
+diagonal block.
+
+**Scope restriction (closing matrices):** see `bntSectorLabel`.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `QkKjs`, lines 1733--1737. -/
+theorem bntMarkovBlockNonzero_iff_eq_bntSectorLabel
+    {K : (s : Fin g) → MPOTensor d (dim s)}
+    {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse K C)
+    (hρ : IsThreeSiteFamilyClosure K R ρ) (hη : EtaStructure ρ)
+    (hR : ∀ s : Fin g, R s ≠ 0)
+    (k : {k : Fin hη.m // hη.p k ≠ 0}) (s : Fin g) :
+    BNTMarkovBlockNonzero (K s) hη k ↔
+      s = bntSectorLabel hC hρ hη hR k := by
+  constructor
+  · intro hs
+    exact bntMarkovBlockNonzero_eq_of_probability_ne_zero
+      hC hρ hη hR k k.property hs
+        (bntMarkovBlockNonzero_bntSectorLabel hC hρ hη hR k)
+  · rintro rfl
+    exact bntMarkovBlockNonzero_bntSectorLabel hC hρ hη hR k
+
+/-- The projector
+\[
+  P_s=\sum_{k:\,j_k=s}Q_k
+\]
+formed from the positive-weight quantum-Markov sectors assigned to normal
+sector $s$.
+
+**Scope restriction (closing matrices):** this definition uses the
+conditional label $j_k$ above.  Zero-weight Markov summands do not occur in
+the sum.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `Pis`, lines 1733--1737. -/
+noncomputable def bntSectorProjection
+    {K : (s : Fin g) → MPOTensor d (dim s)}
+    {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse K C)
+    (hρ : IsThreeSiteFamilyClosure K R ρ) (hη : EtaStructure ρ)
+    (hR : ∀ s : Fin g, R s ≠ 0) (s : Fin g) :
+    Matrix (Fin d) (Fin d) ℂ :=
+  ∑ k : {k : Fin hη.m // hη.p k ≠ 0},
+    if bntSectorLabel hC hρ hη hR k = s then
+      hη.sectorProjection k
+    else 0
+
+/-- Each $P_s$ is an orthogonal projection.
+
+**Scope restriction (closing matrices):** see `bntSectorProjection`.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `Pis`, lines 1733--1737. -/
+theorem bntSectorProjection_isOrthogonal
+    {K : (s : Fin g) → MPOTensor d (dim s)}
+    {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse K C)
+    (hρ : IsThreeSiteFamilyClosure K R ρ) (hη : EtaStructure ρ)
+    (hR : ∀ s : Fin g, R s ≠ 0) (s : Fin g) :
+    IsOrthogonalProjection (bntSectorProjection hC hρ hη hR s) := by
+  classical
+  apply isOrthogonalProjection_sum_of_pairwise_mul_eq_zero
+  · intro k
+    by_cases hk : bntSectorLabel hC hρ hη hR k = s
+    · simpa [bntSectorProjection, hk] using hη.sectorProjection_isOrthogonal k
+    · simp [hk, IsOrthogonalProjection]
+  · intro k l hkl
+    by_cases hk : bntSectorLabel hC hρ hη hR k = s
+    · by_cases hl : bntSectorLabel hC hρ hη hR l = s
+      · simp only [hk, hl, if_pos]
+        exact hη.sectorProjection_mul_eq_zero fun hco ↦
+          hkl (Subtype.ext hco)
+      · simp [hl]
+    · simp [hk]
+
+/-- Projectors belonging to distinct normal-sector labels are mutually
+orthogonal.
+
+**Scope restriction (closing matrices):** see `bntSectorProjection`.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `Pis`, lines 1733--1737. -/
+theorem bntSectorProjection_mul_eq_zero
+    {K : (s : Fin g) → MPOTensor d (dim s)}
+    {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse K C)
+    (hρ : IsThreeSiteFamilyClosure K R ρ) (hη : EtaStructure ρ)
+    (hR : ∀ s : Fin g, R s ≠ 0) {s t : Fin g} (hst : s ≠ t) :
+    bntSectorProjection hC hρ hη hR s *
+      bntSectorProjection hC hρ hη hR t = 0 := by
+  classical
+  rw [bntSectorProjection, bntSectorProjection, Finset.sum_mul]
+  apply Finset.sum_eq_zero
+  intro k _
+  rw [Finset.mul_sum]
+  apply Finset.sum_eq_zero
+  intro l _
+  by_cases hk : bntSectorLabel hC hρ hη hR k = s
+  · by_cases hl : bntSectorLabel hC hρ hη hR l = t
+    · simp only [hk, hl, if_pos]
+      apply hη.sectorProjection_mul_eq_zero
+      intro hkl
+      apply hst
+      rw [← hk, ← hl]
+      congr
+      exact Subtype.ext hkl
+    · simp [hl]
+  · simp [hk]
+
+/-- The projector onto the positive-weight part of the quantum-Markov
+decomposition.
+
+**Local fix (inactive sectors):** the source removes zero blocks before
+equations `QkKjs` and `Pis`; the retained ambient decomposition is therefore
+resolved only on the positive-weight support.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1698--1707 and 1733--1737. -/
+noncomputable def activeMarkovProjection
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    (hη : EtaStructure ρ) : Matrix (Fin d) (Fin d) ℂ :=
+  ∑ k : {k : Fin hη.m // hη.p k ≠ 0}, hη.sectorProjection k
+
+/-- The $P_s$ resolve the positive-weight quantum-Markov support.
+
+**Scope restriction (closing matrices):** see `bntSectorProjection`.
+
+**Local fix (inactive sectors):** see `activeMarkovProjection`.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `Pis`, lines 1733--1737. -/
+theorem sum_bntSectorProjection
+    {K : (s : Fin g) → MPOTensor d (dim s)}
+    {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse K C)
+    (hρ : IsThreeSiteFamilyClosure K R ρ) (hη : EtaStructure ρ)
+    (hR : ∀ s : Fin g, R s ≠ 0) :
+    ∑ s : Fin g, bntSectorProjection hC hρ hη hR s =
+      activeMarkovProjection hη := by
+  classical
+  simp only [bntSectorProjection, activeMarkovProjection]
+  rw [Finset.sum_comm]
+  refine Finset.sum_congr rfl fun k _ ↦ ?_
+  simp
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/InverseMapActiveSectorRecurrence.lean
+++ b/TNLean/MPS/MPDO/InverseMapActiveSectorRecurrence.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.MatrixAux
 import TNLean.MPS.MPDO.PhysicalSectorPruning
 import TNLean.MPS.MPDO.PhysicalSectorVirtualSpanning
 import TNLean.MPS.MPDO.SectorEtaOperator
@@ -67,16 +68,6 @@ theorem conjugated_middle_threeSiteClosure
   rw [hρ i₁ i₂ i₃ j₁ j₂ j₃]
   ring
 
-private theorem exists_diagonal_ne_zero_of_trace_eq_one
-    {n : Type*} [Fintype n] (A : Matrix n n ℂ)
-    (htrace : A.trace = 1) : ∃ i, A i i ≠ 0 := by
-  have hsum : (∑ i : n, A i i) ≠ 0 := by
-    change A.trace ≠ 0
-    rw [htrace]
-    exact one_ne_zero
-  obtain ⟨i, _, hi⟩ := Finset.exists_ne_zero_of_sum_ne_zero hsum
-  exact ⟨i, hi⟩
-
 /-- Both endpoints of a nonzero neighboring operator in the zero-weight
 reparameterized inverse-map factorization have positive Hayashi weight.
 
@@ -140,10 +131,10 @@ theorem exists_active_sectorVirtualMatrix_ne_zero
   by_contra hall
   push Not at hall
   obtain ⟨⟨i₁, l⟩, hleft⟩ :=
-    exists_diagonal_ne_zero_of_trace_eq_one
+    Matrix.exists_diagonal_ne_zero_of_trace_eq_one
       (hη.ρ_left k) (hη.hρ_left_dm k).2
   obtain ⟨⟨r, i₃⟩, hright⟩ :=
-    exists_diagonal_ne_zero_of_trace_eq_one
+    Matrix.exists_diagonal_ne_zero_of_trace_eq_one
       (hη.ρ_right k) (hη.hρ_right_dm k).2
   let x : F.SectorIndex k := (l, r)
   let b : Fin d := hη.decompB.symm ⟨k, (l, r)⟩

--- a/TNLean/MPS/MPDO/PhysicalSectorSupportRecurrence.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorSupportRecurrence.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.MatrixAux
 import TNLean.Algebra.TracePairing
 import TNLean.MPS.MPDO.PhysicalSectorFactorization
 
@@ -36,14 +37,6 @@ open scoped Matrix BigOperators
 namespace MPOTensor.PhysicalSectorFactorization
 
 variable {d D : ℕ} {K : MPOTensor d D}
-
-private theorem exists_matrix_entry_ne_zero {m n : Type*}
-    (A : Matrix m n ℂ) (hA : A ≠ 0) : ∃ i j, A i j ≠ 0 := by
-  by_contra h
-  push Not at h
-  apply hA
-  ext i j
-  exact h i j
 
 /-- The virtual matrix obtained from a matrix entry within physical sector
 `k`. Its `(beta, alpha)` entry is the product of the corresponding left and
@@ -109,12 +102,14 @@ theorem exists_two_edge_return_of_neighboringOperator_ne_zero
     ∃ j : Fin F.sectorCount,
       F.neighboringOperator h j ≠ 0 ∧ F.neighboringOperator j k ≠ 0 := by
   classical
-  obtain ⟨ex, ey, heta⟩ := exists_matrix_entry_ne_zero _ hkh
+  obtain ⟨ex, ey, heta⟩ := Matrix.exists_entry_ne_zero_of_ne_zero _ hkh
   obtain ⟨⟨kx, ky, hkxy⟩, ⟨hx, hy, hhxy⟩⟩ := hnonzero hkh
-  obtain ⟨beta, alpha, hkentry⟩ := exists_matrix_entry_ne_zero _ hkxy
+  obtain ⟨beta, alpha, hkentry⟩ :=
+    Matrix.exists_entry_ne_zero_of_ne_zero _ hkxy
   have hkleft : F.leftTensor k beta kx.1 ky.1 ≠ 0 :=
     left_ne_zero_of_mul hkentry
-  obtain ⟨delta, gamma, hhentry⟩ := exists_matrix_entry_ne_zero _ hhxy
+  obtain ⟨delta, gamma, hhentry⟩ :=
+    Matrix.exists_entry_ne_zero_of_ne_zero _ hhxy
   have hhright : F.rightTensor h gamma hx.2 hy.2 ≠ 0 :=
     right_ne_zero_of_mul hhentry
   let x : F.SectorIndex k := (kx.1, ex.1)

--- a/TNLean/MPS/MPDO/SectorEtaOperator.lean
+++ b/TNLean/MPS/MPDO/SectorEtaOperator.lean
@@ -84,6 +84,26 @@ noncomputable def conjugatePhysical (K : MPOTensor d D)
       (U * physicalSlice K β α * Uᴴ) i j :=
   rfl
 
+/-- The matrix obtained by changing the physical basis is the corresponding
+linear combination of the original physical matrices.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1421--1438. -/
+theorem conjugatePhysical_eq_sum (K : MPOTensor d D)
+    (U : Matrix (Fin d) (Fin d) ℂ) (i j : Fin d) :
+    conjugatePhysical K U i j =
+      ∑ p : Fin d, ∑ q : Fin d,
+        (U i p * star (U j q)) • K p q := by
+  classical
+  ext β α
+  simp only [conjugatePhysical, Matrix.mul_apply, Matrix.conjTranspose_apply,
+    Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
+  simp_rw [Finset.sum_mul]
+  rw [Finset.sum_comm]
+  refine Finset.sum_congr rfl fun p _ ↦ ?_
+  refine Finset.sum_congr rfl fun q _ ↦ ?_
+  simp only [physicalSlice]
+  ring
+
 /-- Within one sector, the basis-conjugated local MPO matrix is the product of
 the corresponding entries of the left and right sector tensors.
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
@@ -213,6 +213,106 @@ strong subadditivity for a normalized three-site reduced state.
     nonzero closing entry.
 \end{proof}
 
+\begin{definition}[Diagonal BNT block in a Markov sector]
+    \label{def:mpdo_bnt_markov_block}
+    \lean{MPOTensor.bntMarkovBlock}
+    \lean{MPOTensor.BNTMarkovBlockNonzero}
+    \leanok
+    For a normal sector $s$ and a Markov sector $k$, let
+    \[
+      O_s^{(k)}(\beta,\alpha)
+      =\bigl[U_B\kappa^{(s)}_{\beta,\alpha}U_B^\dagger\bigr]_{k,k}.
+    \]
+    The assertion $O_s^{(k)}\ne0$ means that this block is nonzero for at
+    least one pair of virtual indices $\beta,\alpha$.
+\end{definition}
+
+\begin{theorem}[Existence of a normal-sector label]
+    \label{thm:mpdo_bnt_markov_label_exists}
+    \lean{MPOTensor.exists_bntMarkovBlockNonzero_of_probability_ne_zero}
+    \leanok
+    \uses{def:mpdo_bnt_markov_block}
+    If $p_k\ne0$, then there is a normal sector $s$ for which
+    $O_s^{(k)}\ne0$.
+
+    This is the existence part of equation~\textup{QkKjs} in
+    \cite[Appendix~C.2, lines~1733--1737]{Cirac2016MPDO_arXiv}.  Restricting
+    to $p_k\ne0$ is the literal version of the source's preceding removal of
+    summands for which $Q_k\sigma_3^{(N)}Q_k=0$.
+\end{theorem}
+
+\begin{proof}\leanok
+    Choose nonzero diagonal entries of the trace-one left and right states in
+    sector $k$.  The corresponding diagonal entry of the Hayashi
+    decomposition is nonzero because $p_k\ne0$.  Expanding the same entry by
+    the three-site normal-sector family therefore leaves at least one nonzero
+    summand, whose middle tensor has $O_s^{(k)}\ne0$.
+\end{proof}
+
+\begin{theorem}[Uniqueness from nonzero closing matrices]
+    \label{thm:mpdo_bnt_markov_label_unique_nonzero_closing}
+    \lean{MPOTensor.bntMarkovBlockNonzero_eq_of_probability_ne_zero}
+    \lean{MPOTensor.existsUnique_bntMarkovBlockNonzero_of_probability_ne_zero}
+    \leanok
+    \uses{thm:mpdo_bnt_markov_key_formula,
+      thm:mpdo_bnt_markov_label_exists,def:mpdo_bnt_markov_block}
+    Suppose, in addition, that every closing matrix $R_s$ is nonzero.  If
+    $p_k\ne0$, there is a unique normal sector $j_k$ for which
+    $O_{j_k}^{(k)}\ne0$.
+
+    This is the cancellation argument in equation~\textup{QkKjs}.  The
+    stated nonzero-closing-matrix condition isolates the step obtained in the
+    source from simplicity and the common-weight choice at
+    \cite[Appendix~C.2, lines~1714--1718]{Cirac2016MPDO_arXiv}.  Its derivation
+    from those preceding hypotheses remains separate; see
+    \path{docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex}.
+\end{theorem}
+
+\begin{proof}\leanok
+    Assume that sectors $s\ne t$ both have nonzero $k$-blocks.  A diagonal
+    instance of the BNT--Markov identity for $s$ gives a nonzero left factor.
+    A mixed instance with normal-sector labels $s,t$ forces the right factor
+    selected from $t$ to vanish.  A diagonal instance for $t$ then has zero
+    left-hand side and a nonzero right-hand side, a contradiction.
+\end{proof}
+
+\begin{definition}[Normal-sector projections on the active support]
+    \label{def:mpdo_bnt_sector_projection}
+    \lean{MPOTensor.bntSectorLabel}
+    \lean{MPOTensor.bntSectorProjection}
+    \lean{MPOTensor.activeMarkovProjection}
+    \leanok
+    Under the hypotheses of
+    Theorem~\ref{thm:mpdo_bnt_markov_label_unique_nonzero_closing}, define
+    \[
+      P_s=\sum_{\substack{k:p_k\ne0\\j_k=s}}Q_k,
+      \qquad
+      P_{\mathrm{act}}=\sum_{k:p_k\ne0}Q_k.
+    \]
+    This is equation~\textup{Pis}, restricted to the positive-weight Markov
+    support retained here.
+\end{definition}
+
+\begin{theorem}[Orthogonality and resolution on the active support]
+    \label{thm:mpdo_bnt_sector_projection_resolution}
+    \lean{MPOTensor.bntSectorProjection_isOrthogonal}
+    \lean{MPOTensor.bntSectorProjection_mul_eq_zero}
+    \lean{MPOTensor.sum_bntSectorProjection}
+    \leanok
+    \uses{def:mpdo_bnt_sector_projection}
+    Every $P_s$ is an orthogonal projection, distinct $P_s$ are mutually
+    orthogonal, and
+    \[
+      \sum_s P_s=P_{\mathrm{act}}.
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    Each $P_s$ is a sum of mutually orthogonal Markov-sector projections.
+    Distinct labels have disjoint sums.  Finally, summing over $s$ counts each
+    positive-weight Markov sector exactly once.
+\end{proof}
+
 \begin{theorem}[Saturation gives equality in strong subadditivity]
     \label{thm:mpdo_sal_ssa_equality}
     \lean{MPOTensor.isSSAEquality_tripartite_of_isSAL}

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -190,6 +190,46 @@ lines 1434--1438.
 \leanid{MPOTensor.physicalSlice_sector_factorization}, and
 \leanid{MPOTensor.exists_physicalSlice_sector_factorization}.}
 
+For a finite family of normal sectors, the diagonal blocks used in equation
+\texttt{QkKjs} are now defined by
+\[
+  O_s^{(k)}(\beta,\alpha)
+  =\bigl[U_B\kappa^{(s)}_{\beta,\alpha}U_B^\dagger\bigr]_{k,k}.
+\]
+Every sector of nonzero Hayashi weight occurs in at least one normal sector.
+Indeed, nonzero diagonal entries of the two trace-one Hayashi states give a
+nonzero diagonal entry of the three-site state, and the normal-sector family
+closure then has a nonzero summand.  This existence argument requires no
+closing-matrix assumption.
+
+The uniqueness cancellation is also formalized with its load-bearing
+hypothesis stated explicitly.  If every closing matrix $R_s$ is nonzero, the
+principal BNT--Markov identity shows that two distinct normal sectors cannot
+both have nonzero $k$-blocks.  It therefore gives the label $j_k$ and the
+projections
+\[
+  P_s=\sum_{\substack{k:p_k\ne0\\j_k=s}}Q_k,
+  \qquad \sum_s P_s=\sum_{k:p_k\ne0}Q_k.
+\]
+These projections are mutually orthogonal.\footnote{The relevant declarations
+are
+\path{MPOTensor.exists_bntMarkovBlockNonzero_of_probability_ne_zero},
+\path{MPOTensor.existsUnique_bntMarkovBlockNonzero_of_probability_ne_zero},
+\path{MPOTensor.bntSectorProjection}, and
+\path{MPOTensor.sum_bntSectorProjection}.}
+
+The remaining source-faithfulness gap is the derivation of $R_s\ne0$ from the
+preceding simplicity and common-weight construction.  Appendix~C.2 chooses a
+nonzero closing scalar for every normal sector at lines 1714--1718.  The
+present three-site family-closure structure does not yet carry the theorem
+which identifies its matrices $R_s$ with those common-weight closing
+contractions.  Until that bridge is proved, the unrestricted uniqueness
+assertion of equation \texttt{QkKjs} is not identified with the conditional
+theorem above; the blueprint states and marks only the explicitly restricted
+version.  The elimination plan is to derive the family closure from the
+absorbed common-weight normal sectors, prove every resulting $R_s$ nonzero,
+and then specialize the conditional uniqueness and projector statements.
+
 The neighboring operators are now assembled from these sector tensors.  The
 operator
 \[


### PR DESCRIPTION
## Summary

This change formalizes the normal-sector label and projector step following the Case II BNT--Markov identity.

- It defines the diagonal block O_s^(k) and proves that every positive-weight Markov sector occurs in at least one normal sector.
- Under an explicit nonzero-closing-matrix hypothesis, it proves uniqueness of the normal-sector label j_k by the three-comparison cancellation used in the source.
- It defines P_s as the sum of Q_k over positive-weight sectors with label j_k = s, proves that each P_s is an orthogonal projection, proves mutual orthogonality, and proves resolution of the positive-weight support.
- It extracts two elementary reusable matrix lemmas and removes their private duplicates.

## Source and scope

The source is arXiv:1606.00608, Appendix C.2, equations QkKjs and Pis, local source lines 1698--1737. The formal statement follows the literal nonvanishing condition Q_k K_j Q_k != 0; it does not replace this by the stronger equation Q_k K_j = Q_k.

The source removes zero blocks before this step. The statements therefore quantify over p_k != 0 and resolve the positive-weight Markov support.

The uniqueness theorem states explicitly that every closing matrix R_s is nonzero. Appendix C.2 obtains a nonzero closing scalar for every normal sector from simplicity and the common-weight construction at lines 1714--1718. The bridge identifying the family-closure matrices R_s with those closing contractions is not yet proved. Consequently, the blueprint marks only the theorem with this explicit restriction and does not claim the unrestricted source theorem. The paper-gap note records the missing bridge and its elimination plan.

## Verification

- Lean 4.32.0
- lake build TNLean
- leanblueprint checkdecls
- blueprint PDF built and the affected pages inspected
- standalone paper-gap PDF built and the affected pages inspected
- changed-file proof-integrity scan found no sorry, admit, native_decide, unsafeCast, or axiom
- print-axioms audit found only propext, Classical.choice, and Quot.sound

## Remaining work

Issue #4081 remains open for the all-length P_s-compressed density-operator realization and for the common-weight closing-matrix bridge. This pull request completes the label, projection, orthogonality, and active-support resolution portions.

Progresses #4081.
Parent: #4003.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal mathematics and documentation with no runtime, auth, or data paths; scope is additive Lean proofs and refactors of duplicate lemmas.
> 
> **Overview**
> Formalizes the **Case II** step after the BNT–Markov identity: diagonal blocks \(O_s^{(k)}\), existence of a normal sector for each **positive-weight** Markov sector \(p_k \ne 0\), and—under an explicit **nonzero closing matrix** \(R_s\) hypothesis—uniqueness of \(j_k\) and the projectors \(P_s = \sum_{k: j_k=s} Q_k\) on the active support.
> 
> Adds `BNTMarkovSectorProjectors.lean` with `bntSectorLabel`, `bntSectorProjection`, and proofs that each \(P_s\) is orthogonal, distinct \(P_s\) commute to zero, and \(\sum_s P_s\) equals the positive-weight Markov projector. Supporting lemmas include `conjugatePhysical_eq_sum`, `isOrthogonalProjection_sum_of_pairwise_mul_eq_zero`, and shared matrix facts in `MatrixAux` (replacing private copies elsewhere). Blueprint chapter 21 and the paper-gap note document the **conditional** uniqueness and the remaining bridge from simplicity/common-weight to \(R_s \ne 0\).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51433f04b54724a4aada80ab1c0a5176144fb52c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->