### PR TITLE
feat(MPS/MPDO): prove common-weight coefficient nonzero

### DIFF
--- a/TNLean/MPS/MPDO/CommonWeightAbsorption.lean
+++ b/TNLean/MPS/MPDO/CommonWeightAbsorption.lean
@@ -63,6 +63,18 @@ theorem weight_eq_commonWeight (S : SectorDecomposition d)
     S.weight j q = S.commonWeight hWeight j :=
   hWeight j q ⟨0, S.copies_pos j⟩
 
+/-- The common copy weight is nonzero.
+
+This is the coefficient nonvanishing used when the source forms
+\(m_j=q_j\widetilde m_j\) in the proof of the Markov-sector assignment.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1646--1665 and 1714--1718. -/
+theorem commonWeight_ne_zero (S : SectorDecomposition d)
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q') (j : Fin S.basisCount) :
+    S.commonWeight hWeight j ≠ 0 :=
+  S.weight_ne_zero j ⟨0, S.copies_pos j⟩
+
 /-- Once the copy weights over sector $j$ agree, its length-$N$ coefficient is
 the natural copy multiplicity $r_j$ times $\mu_j^N$:
 \[
@@ -79,6 +91,26 @@ theorem coeff_eq_copies_mul_commonWeight_pow (S : SectorDecomposition d)
   simp only [SectorDecomposition.coeff, SectorWeightData.coeff]
   simp_rw [S.weight_eq_commonWeight hWeight j]
   simp
+
+/-- When the copy weights agree, their length-\(N\) sum is nonzero for every
+chain length:
+\[
+  q_j=\sum_q \mu_{j,q}^N=r_j\mu_j^N\ne0.
+\]
+
+This discharges the coefficient part of the choice of \(m_j\) in the source.
+The independent choice of a nonzero virtual tail contraction remains a
+separate step.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1646--1665 and 1714--1718. -/
+theorem coeff_ne_zero_of_weight_copy_independent (S : SectorDecomposition d)
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q') (N : ℕ) (j : Fin S.basisCount) :
+    S.coeff N j ≠ 0 := by
+  rw [S.coeff_eq_copies_mul_commonWeight_pow hWeight N j]
+  apply mul_ne_zero
+  · exact_mod_cast (Nat.ne_of_gt (S.copies_pos j))
+  · exact pow_ne_zero N (S.commonWeight_ne_zero hWeight j)
 
 /-- Absorbing the common weight into each representative leaves precisely its
 natural horizontal copy count as the coefficient of its matrix product

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_case_two.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_case_two.tex
@@ -105,6 +105,29 @@
     Every term in the copy sum equals $\mu_j^N$, and there are $r_j$ terms.
 \end{proof}
 
+\begin{theorem}[Nonvanishing of the common-weight coefficient]
+    \label{thm:mpdo_common_weight_coefficient_ne_zero}
+    \lean{MPSTensor.SectorDecomposition.commonWeight_ne_zero}
+    \lean{MPSTensor.SectorDecomposition.coeff_ne_zero_of_weight_copy_independent}
+    \leanok
+    \uses{def:sector_weight_data,
+      thm:mpdo_common_weight_coefficient}
+    The common weight is nonzero, and hence for every chain length $N$,
+    \[
+        q_j=\sum_q\mu_{j,q}^{N}=r_j\mu_j^{N}\ne0.
+    \]
+    This is the coefficient nonvanishing used in the choice
+    $m_j=q_j\widetilde m_j$ in
+    \cite[Appendix~C.2, lines~1714--1718]{Cirac2016MPDO_arXiv}.
+    It does not assert nonvanishing of the independent virtual tail
+    contraction $\widetilde m_j$.
+\end{theorem}
+
+\begin{proof}\leanok
+    The distinguished copy weight is nonzero by the sector data.  Since
+    $r_j>0$, both factors in $r_j\mu_j^N$ are nonzero.
+\end{proof}
+
 \begin{theorem}[Canonical form with natural multiplicities]
     \label{thm:mpdo_common_weight_absorbed_mpv}
     \lean{MPSTensor.SectorDecomposition.mpv_toTensor_eq_sum_copies_mul_commonWeightAbsorbedBasis}

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -218,17 +218,28 @@ are
 \path{MPOTensor.bntSectorProjection}, and
 \path{MPOTensor.sum_bntSectorProjection}.}
 
-The remaining source-faithfulness gap is the derivation of $R_s\ne0$ from the
-preceding simplicity and common-weight construction.  Appendix~C.2 chooses a
-nonzero closing scalar for every normal sector at lines 1714--1718.  The
-present three-site family-closure structure does not yet carry the theorem
-which identifies its matrices $R_s$ with those common-weight closing
-contractions.  Until that bridge is proved, the unrestricted uniqueness
-assertion of equation \texttt{QkKjs} is not identified with the conditional
-theorem above; the blueprint states and marks only the explicitly restricted
-version.  The elimination plan is to derive the family closure from the
-absorbed common-weight normal sectors, prove every resulting $R_s$ nonzero,
-and then specialize the conditional uniqueness and projector statements.
+The coefficient half of the closing-scalar choice is now formalized.  Once
+the copy weights agree, the distinguished common weight is nonzero and
+\[
+  q_j=\sum_q\mu_{j,q}^{N}=r_j\mu_j^N\ne0
+\]
+for every chain length $N$.
+\footnote{The relevant declarations are
+\path{MPSTensor.SectorDecomposition.commonWeight_ne_zero} and
+\path{MPSTensor.SectorDecomposition.coeff_ne_zero_of_weight_copy_independent}.}
+The remaining source-faithfulness gap is the independent construction of the
+nonzero virtual tail contraction $\widetilde m_j$ and its identification with
+an entry of $R_s$.  Appendix~C.2 combines these two factors as
+$m_j=q_j\widetilde m_j\ne0$ at lines 1714--1718.  The present three-site
+family-closure structure does not yet carry the theorem which identifies its
+matrices $R_s$ with those selected tail contractions.  Until that bridge is
+proved, the unrestricted uniqueness assertion of equation \texttt{QkKjs} is
+not identified with the conditional theorem above; the blueprint states and
+marks only the explicitly restricted version.  The elimination plan is to
+derive the family closure from the absorbed common-weight normal sectors,
+construct the selected nonzero virtual tails, identify the resulting entries
+of $R_s$, and then specialize the conditional uniqueness and projector
+statements.
 
 The neighboring operators are now assembled from these sector tensors.  The
 operator


### PR DESCRIPTION
## Mathematical result

For a sector decomposition whose weights are independent of the copy index, this proves

- the common weight `mu_j` is nonzero;
- `q_j = sum_q mu_{j,q}^N = r_j mu_j^N` is nonzero for every chain length `N`.

This is the coefficient part of the choice `m_j = q_j * m_tilde_j` in arXiv:1606.00608, Appendix C.2, lines 1714--1718.

## Faithfulness boundary

This PR does not identify `q_j` with the virtual closing matrix and does not assume the remaining tail contraction is nonzero. The independent construction of a nonzero `m_tilde_j` and its identification with an entry of `R_s` remain recorded in the paper-gap note. Thus the unrestricted `QkKjs` uniqueness theorem is still not claimed.

## Documentation

The Chapter 23 blueprint states the nonvanishing theorem in source order. The paper-gap note now separates the completed coefficient argument from the remaining virtual-tail bridge.

## Verification

- Lean 4.32.0
- `lake -KmaxJobs=1 build TNLean`
- `leanblueprint web`
- `leanblueprint checkdecls`
- blueprint PDF and standalone paper-gap PDF built and visually inspected
- changed-file prohibited-token scan and `git diff --check`
- axiom audit: only `propext`, `Classical.choice`, and `Quot.sound`

Progresses #4081.
Parent: #4003.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Lean proofs and documentation only; no changes to auth, APIs, or existing theorem statements beyond new lemmas in `CommonWeightAbsorption.lean`.
> 
> **Overview**
> **Formalizes the coefficient nonvanishing** in the Cirac et al. Markov-sector assignment when copy weights agree: `commonWeight_ne_zero` and `coeff_ne_zero_of_weight_copy_independent` show \(q_j = r_j \mu_j^N \ne 0\) for every chain length \(N\), via existing sector `weight_ne_zero` and the common-weight coefficient identity.
> 
> The **Chapter 21 blueprint** adds theorem `thm:mpdo_common_weight_coefficient_ne_zero` (linked to those Lean names) and states explicitly that **virtual tail** \(\widetilde m_j\) nonvanishing is still out of scope.
> 
> The **paper-gap note** is rewritten so the **completed coefficient step** is separated from the **remaining gap** (construct/identify nonzero \(\widetilde m_j\) with an entry of \(R_s\)); unrestricted `QkKjs` uniqueness is still not claimed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65063d728b7cf8bc494532d7ff018e819ff17019. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->