### PR TITLE
feat(MPS/MPDO): select nonzero BNT closing data

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -431,6 +431,7 @@ import TNLean.MPS.MPDO.RFPViaTSSAL
 import TNLean.MPS.MPDO.PhysicalBlocking
 import TNLean.MPS.MPDO.SimpleTensor
 import TNLean.MPS.MPDO.CommonWeightAbsorption
+import TNLean.MPS.MPDO.BNTClosingSelection
 import TNLean.MPS.MPDO.BNTThreeSiteCollapse
 import TNLean.MPS.MPDO.BNTMarkovKeyFormula
 import TNLean.MPS.MPDO.BNTMarkovSectorProjectors

--- a/TNLean/MPS/MPDO/BNTClosingSelection.lean
+++ b/TNLean/MPS/MPDO/BNTClosingSelection.lean
@@ -8,7 +8,7 @@ import TNLean.MPS.MPDO.CommonWeightAbsorption
 import TNLean.MPS.MPDO.SourceBNTBlocking
 
 /-!
-# Nonzero closing data for a basis of normal tensors
+# Nonzero closing scalars for a basis of normal tensors
 
 Eventual linear independence of a basis of normal tensors supplies one common
 positive word length at which every representative has a nonzero matrix

--- a/TNLean/MPS/MPDO/BNTClosingSelection.lean
+++ b/TNLean/MPS/MPDO/BNTClosingSelection.lean
@@ -1,0 +1,105 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.MatrixAux
+import TNLean.MPS.MPDO.CommonWeightAbsorption
+import TNLean.MPS.MPDO.SourceBNTBlocking
+
+/-!
+# Nonzero closing data for a basis of normal tensors
+
+Eventual linear independence of a basis of normal tensors supplies one common
+positive word length at which every representative has a nonzero matrix
+entry.  When the canonical-form weights are independent of the copy index,
+the coefficient of every representative is nonzero at the corresponding
+total chain length.  Their product is the nonzero scalar selected before the
+principal BNT--Markov identity in arXiv:1606.00608, Appendix C.2.
+
+This file proves the selection of the nonzero scalar.  It does not yet identify
+that scalar with an entry of the closing matrix in a three-site family closure.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  BNT definition at lines 271--274 and Appendix C.2, lines 1714--1718.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d D g : ℕ} {dim : Fin g → ℕ}
+
+/-- A basis of normal tensors has one common positive word length at which
+every representative has a nonzero matrix entry.
+
+Source: arXiv:1606.00608, BNT definition at lines 271--274 and Appendix C.2,
+lines 1714--1718. -/
+theorem IsCPSVBasisOfNormalTensors.exists_common_nonzero_word_entry
+    {A : MPSTensor d D} {B : (j : Fin g) → MPSTensor d (dim j)}
+    (hBNT : IsCPSVBasisOfNormalTensors A (fun j ↦ ⟨dim j, B j⟩)) :
+    ∃ L : ℕ, 0 < L ∧ ∀ j : Fin g,
+      ∃ (σ : Fin L → Fin d) (α β : Fin (dim j)),
+        evalWord (B j) (List.ofFn σ) α β ≠ 0 := by
+  obtain ⟨L₀, hLI⟩ := hBNT.eventually_li
+  refine ⟨L₀ + 1, by omega, ?_⟩
+  intro j
+  have hState : mpvState (d := d) (B j) (L₀ + 1) ≠ 0 :=
+    (hLI (L₀ + 1) (by omega)).ne_zero j
+  have hCoeff : ∃ σ : Fin (L₀ + 1) → Fin d, mpv (B j) σ ≠ 0 := by
+    by_contra hzero
+    push Not at hzero
+    apply hState
+    ext σ
+    rw [mpvState_apply]
+    exact hzero σ
+  obtain ⟨σ, hσ⟩ := hCoeff
+  have hWord : evalWord (B j) (List.ofFn σ) ≠ 0 := by
+    intro hzero
+    apply hσ
+    change Matrix.trace (evalWord (B j) (List.ofFn σ)) = 0
+    rw [hzero]
+    simp
+  obtain ⟨α, β, hαβ⟩ := Matrix.exists_entry_ne_zero_of_ne_zero _ hWord
+  exact ⟨σ, α, β, hαβ⟩
+
+namespace SectorDecomposition
+
+/-- At one common positive tail length `L`, every representative has a
+nonzero weighted tail entry at total chain length `L + 3`:
+\[
+  q_j\bigl[A_j^{\sigma_1}\cdots A_j^{\sigma_L}\bigr]_{\alpha,\beta}
+  \ne 0,
+  \qquad q_j=\sum_q\mu_{j,q}^{L+3}.
+\]
+
+This is the nonzero scalar denoted by
+\(m_j=q_j\widetilde m_j\) in the source.  Identifying it with an entry of a
+three-site family-closing matrix is a separate statement.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1714--1718. -/
+theorem exists_common_nonzero_weighted_tail_entry
+    (S : SectorDecomposition d)
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q')
+    {A : MPSTensor d D}
+    (hBNT : IsCPSVBasisOfNormalTensors A
+      (fun j ↦ ⟨S.basisDim j, S.basis j⟩)) :
+    ∃ L : ℕ, 0 < L ∧ ∀ j : Fin S.basisCount,
+      ∃ (σ : Fin L → Fin d) (α β : Fin (S.basisDim j)),
+        S.coeff (L + 3) j *
+          evalWord (S.basis j) (List.ofFn σ) α β ≠ 0 := by
+  obtain ⟨L, hL, hWord⟩ := hBNT.exists_common_nonzero_word_entry
+  refine ⟨L, hL, ?_⟩
+  intro j
+  obtain ⟨σ, α, β, hEntry⟩ := hWord j
+  exact ⟨σ, α, β,
+    mul_ne_zero
+      (S.coeff_ne_zero_of_weight_copy_independent hWeight (L + 3) j)
+      hEntry⟩
+
+end SectorDecomposition
+
+end MPSTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_case_two.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_case_two.tex
@@ -128,6 +128,38 @@
     $r_j>0$, both factors in $r_j\mu_j^N$ are nonzero.
 \end{proof}
 
+\begin{theorem}[Common nonzero BNT tail selection]
+    \label{thm:mpdo_common_nonzero_bnt_tail_selection}
+    \lean{MPSTensor.IsCPSVBasisOfNormalTensors.exists_common_nonzero_word_entry}
+    \lean{MPSTensor.SectorDecomposition.exists_common_nonzero_weighted_tail_entry}
+    \leanok
+    \uses{def:bnt_cpsv,
+      thm:mpdo_common_weight_coefficient_ne_zero}
+    There is one positive tail length $L$ such that, for every normal
+    representative $A_j$, some physical word $\sigma$ and virtual indices
+    $\alpha,\beta$ satisfy
+    \[
+        \widetilde m_j
+        =\bigl[A_j^{\sigma_1}\cdots A_j^{\sigma_L}\bigr]_{\alpha,\beta}
+        \ne0.
+    \]
+    At total chain length $L+3$, the corresponding copy coefficient is
+    $q_j=\sum_q\mu_{j,q}^{L+3}\ne0$, and hence
+    $m_j=q_j\widetilde m_j\ne0$.
+    This is the simultaneous selection made in
+    \cite[Appendix~C.2, lines~1714--1718]{Cirac2016MPDO_arXiv}.
+    Identifying these scalars with entries of the closing matrices in the
+    three-site family expansion is a separate step.
+\end{theorem}
+
+\begin{proof}\leanok
+    Choose a length beyond the eventual linear-independence threshold of the
+    BNT.  Each representative MPV is then nonzero, so one of its word
+    coefficients, and therefore one entry of that word matrix, is nonzero.
+    The preceding theorem supplies the nonzero coefficient at length $L+3$;
+    their product is nonzero.
+\end{proof}
+
 \begin{theorem}[Canonical form with natural multiplicities]
     \label{thm:mpdo_common_weight_absorbed_mpv}
     \lean{MPSTensor.SectorDecomposition.mpv_toTensor_eq_sum_copies_mul_commonWeightAbsorbedBasis}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_case_two.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_case_two.tex
@@ -156,8 +156,12 @@
 
 \begin{proof}\leanok
     Choose a length beyond the eventual linear-independence threshold of the
-    BNT.  Each representative MPV is then nonzero, so one of its word
-    coefficients, and therefore one entry of that word matrix, is nonzero.
+    BNT.  Each representative MPV is then nonzero, so for some word $\sigma$,
+    \[
+        \operatorname{tr}
+        \bigl(A_j^{\sigma_1}\cdots A_j^{\sigma_L}\bigr)\ne0.
+    \]
+    Consequently the word matrix is nonzero and has a nonzero entry.
     The preceding theorem supplies the nonzero coefficient at length $L+3$;
     their product is nonzero.
 \end{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_case_two.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_case_two.tex
@@ -135,6 +135,8 @@
     \leanok
     \uses{def:bnt_cpsv,
       thm:mpdo_common_weight_coefficient_ne_zero}
+    Suppose the weights over each representative are independent of the copy
+    index: $\mu_{j,q}=\mu_{j,q'}$ for all $j,q,q'$.
     There is one positive tail length $L$ such that, for every normal
     representative $A_j$, some physical word $\sigma$ and virtual indices
     $\alpha,\beta$ satisfy

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -218,8 +218,8 @@ are
 \path{MPOTensor.bntSectorProjection}, and
 \path{MPOTensor.sum_bntSectorProjection}.}
 
-The coefficient half of the closing-scalar choice is now formalized.  Once
-the copy weights agree, the distinguished common weight is nonzero and
+Both factors in the closing-scalar choice are now selected.  Once the copy
+weights agree, the distinguished common weight is nonzero and
 \[
   q_j=\sum_q\mu_{j,q}^{N}=r_j\mu_j^N\ne0
 \]
@@ -227,19 +227,24 @@ for every chain length $N$.
 \footnote{The relevant declarations are
 \path{MPSTensor.SectorDecomposition.commonWeight_ne_zero} and
 \path{MPSTensor.SectorDecomposition.coeff_ne_zero_of_weight_copy_independent}.}
-The remaining source-faithfulness gap is the independent construction of the
-nonzero virtual tail contraction $\widetilde m_j$ and its identification with
-an entry of $R_s$.  Appendix~C.2 combines these two factors as
-$m_j=q_j\widetilde m_j\ne0$ at lines 1714--1718.  The present three-site
-family-closure structure does not yet carry the theorem which identifies its
-matrices $R_s$ with those selected tail contractions.  Until that bridge is
-proved, the unrestricted uniqueness assertion of equation \texttt{QkKjs} is
-not identified with the conditional theorem above; the blueprint states and
-marks only the explicitly restricted version.  The elimination plan is to
-derive the family closure from the absorbed common-weight normal sectors,
-construct the selected nonzero virtual tails, identify the resulting entries
-of $R_s$, and then specialize the conditional uniqueness and projector
-statements.
+Eventual linear independence of the BNT gives one positive tail length $L$
+at which every representative has a nonzero word entry
+$\widetilde m_j$.  Taking the coefficient at total chain length $L+3$ gives
+$m_j=q_j\widetilde m_j\ne0$, as in Appendix~C.2, lines 1714--1718.
+\footnote{The relevant declarations are
+\path{MPSTensor.IsCPSVBasisOfNormalTensors.exists_common_nonzero_word_entry}
+and
+\path{MPSTensor.SectorDecomposition.exists_common_nonzero_weighted_tail_entry}.}
+The remaining source-faithfulness gap is the identification of these selected
+scalars with entries of the matrices $R_s$ in the concrete three-site family
+closure.  The present family-closure structure does not yet carry that
+construction from the absorbed common-weight normal sectors.  Until this
+bridge is proved, the unrestricted uniqueness assertion of equation
+\texttt{QkKjs} is not identified with the conditional theorem above; the
+blueprint states and marks only the explicitly restricted version.  The
+elimination plan is to construct the concrete family closure with the selected
+tails as its closing matrices and then specialize the conditional uniqueness
+and projector statements.
 
 The neighboring operators are now assembled from these sector tensors.  The
 operator

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -239,7 +239,7 @@ The remaining source-faithfulness gap is the identification of these selected
 scalars with entries of the matrices $R_s$ in the concrete three-site family
 closure.  The present family-closure structure does not yet carry that
 construction from the absorbed common-weight normal sectors.  Until this
-bridge is proved, the unrestricted uniqueness assertion of equation
+identification is proved, the unrestricted uniqueness assertion of equation
 \texttt{QkKjs} is not identified with the conditional theorem above; the
 blueprint states and marks only the explicitly restricted version.  The
 elimination plan is to construct the concrete family closure with the selected


### PR DESCRIPTION
## Summary

- prove that eventual BNT linear independence supplies one common positive tail length at which every representative has a nonzero word entry
- combine this entry with the nonzero common-weight coefficient at total chain length `L + 3`
- record the remaining source-faithfulness gap: identifying the selected scalars with entries of the concrete family-closing matrices `R_s`

This follows arXiv:1606.00608, Appendix C.2, lines 1714–1718. It does not assume or assert the missing `R_s` identification.

Progresses #4081.
Parent: #4003.

## Checks

- `lake env lean TNLean/MPS/MPDO/BNTClosingSelection.lean`
- `lake build TNLean.MPS.MPDO.BNTClosingSelection`
- `lake -KmaxJobs=1 build TNLean` (9,528 targets)
- `leanblueprint web`
- `leanblueprint checkdecls`
- `leanblueprint pdf`, visually inspected
- standalone paper-gap PDF, visually inspected
- kernel dependency audit: only `propext`, `Classical.choice`, and `Quot.sound`
- `git diff --check`

Toolchain: Lean 4.32.0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds proved Lean theorems and documentation on an existing MPDO/BNT track; no auth, runtime, or API behavior changes. Residual mathematical risk is explicitly scoped to the not-yet-proved \(R_s\) identification, not this PR’s selection lemmas.
> 
> **Overview**
> Formalizes the **second half** of the Appendix C.2 closing-scalar choice (arXiv:1606.00608, lines 1714–1718): beyond the already-proved nonzero copy coefficient \(q_j\), eventual BNT linear independence yields a **single positive tail length** \(L\) where every normal representative has a nonzero word-matrix entry \(\widetilde m_j\), and under copy-independent weights the product \(m_j = q_j \widetilde m_j\) is nonzero at total length \(L+3\).
> 
> Adds `TNLean/MPS/MPDO/BNTClosingSelection.lean` with `IsCPSVBasisOfNormalTensors.exists_common_nonzero_word_entry` (nonzero MPV → nonzero trace → nonzero matrix entry) and `SectorDecomposition.exists_common_nonzero_weighted_tail_entry` (multiplies by `coeff_ne_zero_of_weight_copy_independent`). Registers the module in `TNLean.lean`, links both theorems in blueprint **Common nonzero BNT tail selection**, and updates the paper-gap note to record that both factors are selected while **identifying** these scalars with entries of the three-site family-closing matrices \(R_s\) remains open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb8e7459f2659d296be1dd9fbd8a33b928cd9d1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->