### PR TITLE
ci: remove the transitional gh-pages seeding step

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -35,32 +35,6 @@ jobs:
           ./scripts/fetch-latest-artifact.sh site-docs components/site-docs
           ./scripts/fetch-latest-artifact.sh site-badges components/site-badges
 
-      # Transitional: until the first docgen run has uploaded a site-docs
-      # artifact, reuse the API docs last published on the legacy gh-pages
-      # branch. This step becomes a no-op (and can be removed) once the
-      # gh-pages branch is deleted.
-      - name: Seed API docs from legacy gh-pages branch
-        run: |
-          if [ -d components/site-docs ]; then
-            exit 0
-          fi
-          if ! git ls-remote --exit-code --heads \
-              "https://github.com/${GITHUB_REPOSITORY}.git" gh-pages >/dev/null; then
-            echo "No gh-pages branch and no site-docs artifact; deploying without API docs"
-            exit 0
-          fi
-          echo "==> Seeding API docs from legacy gh-pages branch..."
-          git clone --branch gh-pages --single-branch --depth 1 \
-            "https://github.com/${GITHUB_REPOSITORY}.git" legacy-site
-          mkdir -p components/site-docs
-          if [ -d legacy-site/docs ]; then
-            mv legacy-site/docs components/site-docs/docs
-          fi
-          if [ -d legacy-site/paper-gaps ]; then
-            mv legacy-site/paper-gaps components/site-docs/paper-gaps
-          fi
-          rm -rf legacy-site
-
       - name: Configure Pages
         uses: actions/configure-pages@v5
 


### PR DESCRIPTION
### Motivation

Closes #4036 and #4069. Completion criteria met:
- `site-docs` artifact exists (docgen run 29542821086, 2026-07-17, 89 MB, not expired) — issue #4069's Lean/doc-gen4 v4.32.0 bump (PR #4070) fixed the previously-failing *Generate API docs* step.
- The live Pages site at https://sirui-lu.com/TNLean/docs/ serves a fresh doc-gen4 index built with Lean 4.32.0, with a last-modified timestamp matching this deploy — confirmed served from the artifact, not stale `gh-pages` content.
- `gh-pages` branch deleted (`git push origin --delete gh-pages`); no open PRs targeted it.

### Description

- Remove the *Seed API docs from legacy gh-pages branch* step from `.github/workflows/deploy-pages.yml`, per its own comment: "This step becomes a no-op (and can be removed) once the gh-pages branch is deleted."

### Testing

`python3 -c "import yaml; yaml.safe_load(...)"` validates the YAML. The next scheduled/dispatched `docgen.yml` → `deploy-pages.yml` run is the functional test; no separate CI job exercises this file directly.

https://claude.ai/code/session_014TxvMnpGSqatcyWuPUqmpd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow simplification with no runtime or application logic changes; deploy assumes `site-docs` artifacts are always available.
> 
> **Overview**
> Removes the transitional **Seed API docs from legacy gh-pages branch** job from `deploy-pages.yml`. Deploy now relies only on fetched `site-docs` (and other) artifacts, matching the artifact-based Pages flow now that `gh-pages` is gone and docgen publishes `site-docs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c2f344bbe8067de9521fb30dea89ce16001bdf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->