### PR TITLE
fix(MPS/MPDO): use physical-trace BNT closing tails

### DIFF
--- a/TNLean/MPS/MPDO/BNTClosingSelection.lean
+++ b/TNLean/MPS/MPDO/BNTClosingSelection.lean
@@ -5,100 +5,127 @@ Authors: TNLean contributors
 -/
 import TNLean.Algebra.MatrixAux
 import TNLean.MPS.MPDO.CommonWeightAbsorption
-import TNLean.MPS.MPDO.SourceBNTBlocking
 
 /-!
-# Nonzero closing scalars for a basis of normal tensors
+# Nonzero physical-trace closing matrices
 
-Eventual linear independence of a basis of normal tensors supplies one common
-positive word length at which every representative has a nonzero matrix
-entry.  When the canonical-form weights are independent of the copy index,
-the coefficient of every representative is nonzero at the corresponding
-total chain length.  Their product is the nonzero scalar selected before the
-principal BNT--Markov identity in arXiv:1606.00608, Appendix C.2.
+For a simple tensor, the physical-trace transfer of each basis-of-normal-
+tensors representative is not nilpotent.  Hence a common positive power has
+a nonzero matrix entry in every representative.  When the canonical-form
+weights are independent of the copy index, multiplying this power by the
+coefficient at the corresponding total chain length gives the nonzero closing
+matrix selected before the principal BNT--Markov identity in
+arXiv:1606.00608, Appendix C.2.
 
-This file proves the selection of the nonzero scalar.  It does not yet identify
-that scalar with an entry of the closing matrix in a three-site family closure.
+The physical legs of the tail in the source diagram are traced.  Thus the
+tail is a power of the physical-trace transfer, not an arbitrary physical-word
+matrix.
 
 ## References
 
 * Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
-  BNT definition at lines 271--274 and Appendix C.2, lines 1714--1718.
+  simplicity at lines 815--822 and Appendix C.2, lines 1714--1718.
 -/
 
 open scoped Matrix BigOperators
 
 namespace MPSTensor
 
-variable {d D g : ℕ} {dim : Fin g → ℕ}
-
-/-- A basis of normal tensors has one common positive word length at which
-every representative has a nonzero matrix entry.
-
-Source: arXiv:1606.00608, BNT definition at lines 271--274 and Appendix C.2,
-lines 1714--1718. -/
-theorem IsCPSVBasisOfNormalTensors.exists_common_nonzero_word_entry
-    {A : MPSTensor d D} {B : (j : Fin g) → MPSTensor d (dim j)}
-    (hBNT : IsCPSVBasisOfNormalTensors A (fun j ↦ ⟨dim j, B j⟩)) :
-    ∃ L : ℕ, 0 < L ∧ ∀ j : Fin g,
-      ∃ (σ : Fin L → Fin d) (α β : Fin (dim j)),
-        evalWord (B j) (List.ofFn σ) α β ≠ 0 := by
-  obtain ⟨L₀, hLI⟩ := hBNT.eventually_li
-  refine ⟨L₀ + 1, by omega, ?_⟩
-  intro j
-  have hState : mpvState (d := d) (B j) (L₀ + 1) ≠ 0 :=
-    (hLI (L₀ + 1) (by omega)).ne_zero j
-  have hCoeff : ∃ σ : Fin (L₀ + 1) → Fin d, mpv (B j) σ ≠ 0 := by
-    by_contra hzero
-    push Not at hzero
-    apply hState
-    ext σ
-    rw [mpvState_apply]
-    exact hzero σ
-  obtain ⟨σ, hσ⟩ := hCoeff
-  have hWord : evalWord (B j) (List.ofFn σ) ≠ 0 := by
-    intro hzero
-    apply hσ
-    change Matrix.trace (evalWord (B j) (List.ofFn σ)) = 0
-    rw [hzero]
-    simp
-  obtain ⟨α, β, hαβ⟩ := Matrix.exists_entry_ne_zero_of_ne_zero _ hWord
-  exact ⟨σ, α, β, hαβ⟩
-
 namespace SectorDecomposition
 
-/-- At one common positive tail length `L`, every representative has a
-nonzero weighted tail entry at total chain length `L + 3`:
+variable {d : ℕ}
+
+/-- For a simple sector decomposition, one common positive power of the
+physical-trace transfers has a nonzero entry in every representative.
+
+The source tail diagram traces the two physical legs at each tail site, so its
+matrix is
 \[
-  q_j\bigl[A_j^{\sigma_1}\cdots A_j^{\sigma_L}\bigr]_{\alpha,\beta}
-  \ne 0,
+  \mathcal B_j^L,
+  \qquad \mathcal B_j=\sum_i A_j^{ii}.
+\]
+Simplicity says that no \(\mathcal B_j\) is nilpotent.
+
+Source: arXiv:1606.00608, simplicity at lines 815--822 and Appendix C.2,
+lines 1714--1718. -/
+theorem exists_common_nonzero_physicalTraceTail_entry
+    (S : SectorDecomposition (d * d))
+    (hnonNil : ∀ j,
+      ¬ IsNilpotent (MPOTensor.doubledPhysTraceTransfer d (S.basis j))) :
+    ∃ L : ℕ, 0 < L ∧ ∀ j : Fin S.basisCount,
+      ∃ α β : Fin (S.basisDim j),
+        ((MPOTensor.doubledPhysTraceTransfer d (S.basis j)) ^ L) α β ≠ 0 := by
+  refine ⟨1, by omega, ?_⟩
+  intro j
+  have hTail : (MPOTensor.doubledPhysTraceTransfer d (S.basis j)) ^ 1 ≠ 0 := by
+    intro hzero
+    exact hnonNil j ⟨1, hzero⟩
+  obtain ⟨α, β, hαβ⟩ := Matrix.exists_entry_ne_zero_of_ne_zero _ hTail
+  exact ⟨α, β, hαβ⟩
+
+/-- The closing matrix of representative \(j\) after retaining three physical
+sites and tracing a tail of length \(L\):
+\[
+  R_j=q_j\mathcal B_j^L,
   \qquad q_j=\sum_q\mu_{j,q}^{L+3}.
 \]
 
-This is the nonzero scalar denoted by
-\(m_j=q_j\widetilde m_j\) in the source.  Identifying it with an entry of a
-three-site family-closing matrix is a separate statement.
+Source: arXiv:1606.00608, Appendix C.2, lines 1714--1718 and 1726--1732. -/
+noncomputable def threeSiteClosingMatrix
+    (S : SectorDecomposition (d * d)) (L : ℕ) (j : Fin S.basisCount) :
+    Matrix (Fin (S.basisDim j)) (Fin (S.basisDim j)) ℂ :=
+  S.coeff (L + 3) j •
+    (MPOTensor.doubledPhysTraceTransfer d (S.basis j)) ^ L
+
+/-- At one common positive tail length, every three-site closing matrix has a
+nonzero entry:
+\[
+  (R_j)_{\alpha,\beta}
+  =q_j(\mathcal B_j^L)_{\alpha,\beta}\ne0.
+\]
+
+This is the scalar \(m_j=q_j\widetilde m_j\) in the source, now identified
+with an entry of the physical-trace closing matrix \(R_j\).
 
 Source: arXiv:1606.00608, Appendix C.2, lines 1714--1718. -/
-theorem exists_common_nonzero_weighted_tail_entry
-    (S : SectorDecomposition d)
+theorem exists_common_nonzero_threeSiteClosingMatrix_entry
+    (S : SectorDecomposition (d * d))
     (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
       S.weight j q = S.weight j q')
-    {A : MPSTensor d D}
-    (hBNT : IsCPSVBasisOfNormalTensors A
-      (fun j ↦ ⟨S.basisDim j, S.basis j⟩)) :
+    (hnonNil : ∀ j,
+      ¬ IsNilpotent (MPOTensor.doubledPhysTraceTransfer d (S.basis j))) :
     ∃ L : ℕ, 0 < L ∧ ∀ j : Fin S.basisCount,
-      ∃ (σ : Fin L → Fin d) (α β : Fin (S.basisDim j)),
-        S.coeff (L + 3) j *
-          evalWord (S.basis j) (List.ofFn σ) α β ≠ 0 := by
-  obtain ⟨L, hL, hWord⟩ := hBNT.exists_common_nonzero_word_entry
+      ∃ α β : Fin (S.basisDim j),
+        S.threeSiteClosingMatrix L j α β ≠ 0 := by
+  obtain ⟨L, hL, hEntry⟩ :=
+    S.exists_common_nonzero_physicalTraceTail_entry hnonNil
   refine ⟨L, hL, ?_⟩
   intro j
-  obtain ⟨σ, α, β, hEntry⟩ := hWord j
-  exact ⟨σ, α, β,
+  obtain ⟨α, β, hαβ⟩ := hEntry j
+  refine ⟨α, β, ?_⟩
+  simpa [threeSiteClosingMatrix, Matrix.smul_apply, smul_eq_mul] using
     mul_ne_zero
       (S.coeff_ne_zero_of_weight_copy_independent hWeight (L + 3) j)
-      hEntry⟩
+      hαβ
+
+/-- For one common positive tail length, every physical-trace closing matrix
+is nonzero.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1714--1718. -/
+theorem exists_common_threeSiteClosingMatrix_ne_zero
+    (S : SectorDecomposition (d * d))
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q')
+    (hnonNil : ∀ j,
+      ¬ IsNilpotent (MPOTensor.doubledPhysTraceTransfer d (S.basis j))) :
+    ∃ L : ℕ, 0 < L ∧ ∀ j : Fin S.basisCount,
+      S.threeSiteClosingMatrix L j ≠ 0 := by
+  obtain ⟨L, hL, hEntry⟩ :=
+    S.exists_common_nonzero_threeSiteClosingMatrix_entry hWeight hnonNil
+  refine ⟨L, hL, ?_⟩
+  intro j hzero
+  obtain ⟨α, β, hαβ⟩ := hEntry j
+  exact hαβ (by rw [hzero]; rfl)
 
 end SectorDecomposition
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_case_two.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_case_two.tex
@@ -130,40 +130,42 @@
 
 \begin{theorem}[Common nonzero BNT tail selection]
     \label{thm:mpdo_common_nonzero_bnt_tail_selection}
-    \lean{MPSTensor.IsCPSVBasisOfNormalTensors.exists_common_nonzero_word_entry}
-    \lean{MPSTensor.SectorDecomposition.exists_common_nonzero_weighted_tail_entry}
+    \lean{MPSTensor.SectorDecomposition.%
+      exists_common_nonzero_physicalTraceTail_entry}
+    \lean{MPSTensor.SectorDecomposition.%
+      exists_common_nonzero_threeSiteClosingMatrix_entry}
+    \lean{MPSTensor.SectorDecomposition.%
+      exists_common_threeSiteClosingMatrix_ne_zero}
     \leanok
-    \uses{def:bnt_cpsv,
+    \uses{def:mpdo_simple_tensor,
       thm:mpdo_common_weight_coefficient_ne_zero}
     Suppose the weights over each representative are independent of the copy
-    index: $\mu_{j,q}=\mu_{j,q'}$ for all $j,q,q'$.
-    There is one positive tail length $L$ such that, for every normal
-    representative $A_j$, some physical word $\sigma$ and virtual indices
+    index, and none of the physical-trace transfers
+    $\mathcal B_j=\sum_i A_j^{ii}$ is nilpotent.  There is one positive tail
+    length $L$ such that, for every representative $A_j$, some virtual indices
     $\alpha,\beta$ satisfy
     \[
         \widetilde m_j
-        =\bigl[A_j^{\sigma_1}\cdots A_j^{\sigma_L}\bigr]_{\alpha,\beta}
+        =\bigl[\mathcal B_j^L\bigr]_{\alpha,\beta}
         \ne0.
     \]
     At total chain length $L+3$, the corresponding copy coefficient is
-    $q_j=\sum_q\mu_{j,q}^{L+3}\ne0$, and hence
-    $m_j=q_j\widetilde m_j\ne0$.
-    This is the simultaneous selection made in
+    $q_j=\sum_q\mu_{j,q}^{L+3}\ne0$.  Thus the three-site closing matrix
+    \[
+        R_j=q_j\mathcal B_j^L
+    \]
+    has the nonzero entry
+    $(R_j)_{\alpha,\beta}=q_j\widetilde m_j\ne0$.
+    This is the traced-tail selection made in
     \cite[Appendix~C.2, lines~1714--1718]{Cirac2016MPDO_arXiv}.
-    Identifying these scalars with entries of the closing matrices in the
-    three-site family expansion is a separate step.
 \end{theorem}
 
 \begin{proof}\leanok
-    Choose a length beyond the eventual linear-independence threshold of the
-    BNT.  Each representative MPV is then nonzero, so for some word $\sigma$,
-    \[
-        \operatorname{tr}
-        \bigl(A_j^{\sigma_1}\cdots A_j^{\sigma_L}\bigr)\ne0.
-    \]
-    Consequently the word matrix is nonzero and has a nonzero entry.
-    The preceding theorem supplies the nonzero coefficient at length $L+3$;
-    their product is nonzero.
+    Since $\mathcal B_j$ is not nilpotent, every positive power of
+    $\mathcal B_j$ is nonzero; in particular, one common positive power has a
+    nonzero entry for every $j$.  The preceding theorem supplies the nonzero
+    coefficient at length $L+3$.  Therefore its product with the selected
+    entry of $\mathcal B_j^L$ is nonzero.
 \end{proof}
 
 \begin{theorem}[Canonical form with natural multiplicities]

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -227,24 +227,32 @@ for every chain length $N$.
 \footnote{The relevant declarations are
 \path{MPSTensor.SectorDecomposition.commonWeight_ne_zero} and
 \path{MPSTensor.SectorDecomposition.coeff_ne_zero_of_weight_copy_independent}.}
-Eventual linear independence of the BNT gives one positive tail length $L$
-at which every representative has a nonzero word entry
-$\widetilde m_j$.  Taking the coefficient at total chain length $L+3$ gives
-$m_j=q_j\widetilde m_j\ne0$, as in Appendix~C.2, lines 1714--1718.
+Simplicity says that the physical-trace transfer
+$\mathcal B_j=\sum_iA_j^{ii}$ is not nilpotent.  Hence one positive tail
+length $L$ has, for every representative, a nonzero entry
+$\widetilde m_j=(\mathcal B_j^L)_{\alpha_j,\beta_j}$.  Taking the coefficient
+at total chain length $L+3$ gives the closing matrix
+\[
+  R_j=q_j\mathcal B_j^L
+\]
+with nonzero entry
+$(R_j)_{\alpha_j,\beta_j}=q_j\widetilde m_j\ne0$, as in Appendix~C.2,
+lines 1714--1718.
 \footnote{The relevant declarations are
-\path{MPSTensor.IsCPSVBasisOfNormalTensors.exists_common_nonzero_word_entry}
+\path{MPSTensor.SectorDecomposition.exists_common_nonzero_physicalTraceTail_entry}
 and
-\path{MPSTensor.SectorDecomposition.exists_common_nonzero_weighted_tail_entry}.}
-The remaining source-faithfulness gap is the identification of these selected
-scalars with entries of the matrices $R_s$ in the concrete three-site family
-closure.  The present family-closure structure does not yet carry that
-construction from the absorbed common-weight normal sectors.  Until this
-identification is proved, the unrestricted uniqueness assertion of equation
+\path{MPSTensor.SectorDecomposition.exists_common_nonzero_threeSiteClosingMatrix_entry};
+the matrix form is
+\path{MPSTensor.SectorDecomposition.exists_common_threeSiteClosingMatrix_ne_zero}.}
+The remaining source-faithfulness gap is to prove that the normalized
+three-site reduced state of the original tensor is the family closure with
+these matrices $R_j$, including the common normalization and the transport
+through the horizontal canonical-form gauge.  Until this identification is
+proved, the unrestricted uniqueness assertion of equation
 \texttt{QkKjs} is not identified with the conditional theorem above; the
 blueprint states and marks only the explicitly restricted version.  The
-elimination plan is to construct the concrete family closure with the selected
-tails as its closing matrices and then specialize the conditional uniqueness
-and projector statements.
+elimination plan is to prove this reduced-state expansion and then specialize
+the conditional uniqueness and projector statements.
 
 The neighboring operators are now assembled from these sector tensors.  The
 operator


### PR DESCRIPTION
Corrects the source-faithfulness error introduced by #4088.

The tail in the source diagram has its physical legs traced. Consequently, the selected tail is an entry of the power of the physical-trace transfer B_j = sum_i A_j^{ii}, not an entry of an arbitrary physical word.

This change:

- replaces the arbitrary-word selection with the source hypothesis that every B_j is nonnilpotent;
- defines the three-site closing matrix R_j = q_j B_j^L in the unabsorbed-representative convention;
- proves a common positive tail length at which every R_j has a nonzero entry and hence is nonzero;
- corrects the blueprint theorem and the existing paper-gap note;
- leaves the actual remaining step explicit: identify the normalized three-site reduced state with this family closure, including normalization and horizontal gauge transport.

No axiom or stronger hidden hypothesis is introduced. The unrestricted QkKjs conclusion is still not claimed.

Checks:

- lake env lean TNLean/MPS/MPDO/BNTClosingSelection.lean
- lake -KmaxJobs=1 build TNLean
- leanblueprint web
- leanblueprint checkdecls
- full blueprint PDF and standalone gap-note PDF, visually inspected
- kernel axiom audit: only propext, Classical.choice, and Quot.sound

Progresses #4081.
Parent issue: #4003.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core MPDO Appendix C.2 closing-tail logic and theorem names in a formal proof library; scope is localized to BNT closing selection and documentation, with no new axioms per the PR description.
> 
> **Overview**
> Replaces the incorrect **arbitrary physical-word** tail selection (from #4088) with the source’s **traced physical legs**, so tails are powers of the physical-trace transfer \(\mathcal B_j = \sum_i A_j^{ii}\) on `SectorDecomposition (d * d)`.
> 
> **Lean (`BNTClosingSelection.lean`):** Drops `SourceBNTBlocking` and BNT eventual-linear-independence proofs. New hypotheses are **non-nilpotence** of `doubledPhysTraceTransfer` per representative. Adds `threeSiteClosingMatrix` \(R_j = q_j \mathcal B_j^L\) and proves a common \(L>0\) with nonzero entries and nonzero matrices, using copy-independent weights for \(q_j\).
> 
> **Docs:** Blueprint theorem **Common nonzero BNT tail selection** and the paper-gap note now state \(\widetilde m_j = (\mathcal B_j^L)_{\alpha,\beta}\) and \(R_j = q_j \mathcal B_j^L\); the remaining gap is framed as identifying the **normalized three-site reduced state** with this family closure (not merely scalar-vs-matrix identification).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4a42d60ac2c579edb631539e00a5499b858d89b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->