### PR TITLE
feat(MPS/MPDO): identify normalized BNT family closure

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -443,6 +443,7 @@ import TNLean.MPS.MPDO.VerticalMapTransport
 import TNLean.MPS.MPDO.PRFP
 import TNLean.MPS.MPDO.LocalPurificationRFP
 import TNLean.MPS.MPDO.SimpleLocalStructure
+import TNLean.MPS.MPDO.BNTThreeSiteReducedClosure
 import TNLean.MPS.MPDO.HayashiSectorProjector
 import TNLean.MPS.MPDO.EtaPreparation
 import TNLean.MPS.MPDO.RFPSubspinMaps

--- a/TNLean/MPS/MPDO/BNTMarkovSectorProjectors.lean
+++ b/TNLean/MPS/MPDO/BNTMarkovSectorProjectors.lean
@@ -214,6 +214,8 @@ assumes explicitly that every closing matrix $R_s$ is nonzero.  For the
 normalized three-site reduced state used by the source, this condition follows
 from simplicity, SAL, and the common-weight construction by
 `MPOTensor.reducedBlockState_four_threeSiteFamilyClosure_nonzero_closing`.
+The generic scope restriction is documented in
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
 
 Source: arXiv:1606.00608, Appendix C.2, equation `QkKjs`, lines 1733--1737. -/
 theorem bntMarkovBlockNonzero_eq_of_probability_ne_zero
@@ -287,6 +289,8 @@ nonzero diagonal block.
 `bntMarkovBlockNonzero_eq_of_probability_ne_zero`.  The source construction
 discharges this hypothesis through
 `MPOTensor.reducedBlockState_four_threeSiteFamilyClosure_nonzero_closing`.
+The generic scope restriction is documented in
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
 
 Source: arXiv:1606.00608, Appendix C.2, equation `QkKjs`, lines 1733--1737. -/
 theorem existsUnique_bntMarkovBlockNonzero_of_probability_ne_zero

--- a/TNLean/MPS/MPDO/BNTMarkovSectorProjectors.lean
+++ b/TNLean/MPS/MPDO/BNTMarkovSectorProjectors.lean
@@ -209,12 +209,11 @@ factor; a mixed normal-sector instance forces the right factor of the second
 sector to vanish; a final same-sector instance contradicts its nonzero
 block.
 
-**Scope restriction (closing matrices):** this statement assumes explicitly
-that every closing matrix $R_s$ is nonzero.  The source obtains suitable
-nonzero closing entries from the simplicity and common-weight construction at
-lines 1714--1718.  Connecting that construction to
-`IsThreeSiteFamilyClosure` remains recorded in
-`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+**Scope restriction (closing matrices):** this generic algebraic statement
+assumes explicitly that every closing matrix $R_s$ is nonzero.  For the
+normalized three-site reduced state used by the source, this condition follows
+from simplicity, SAL, and the common-weight construction by
+`MPOTensor.reducedBlockState_four_threeSiteFamilyClosure_nonzero_closing`.
 
 Source: arXiv:1606.00608, Appendix C.2, equation `QkKjs`, lines 1733--1737. -/
 theorem bntMarkovBlockNonzero_eq_of_probability_ne_zero
@@ -285,10 +284,9 @@ positive-weight quantum-Markov sector has a unique normal-sector label with a
 nonzero diagonal block.
 
 **Scope restriction (closing matrices):** see
-`bntMarkovBlockNonzero_eq_of_probability_ne_zero`.  The missing derivation of
-this hypothesis from the paper's simplicity and common-weight construction is
-recorded in
-`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+`bntMarkovBlockNonzero_eq_of_probability_ne_zero`.  The source construction
+discharges this hypothesis through
+`MPOTensor.reducedBlockState_four_threeSiteFamilyClosure_nonzero_closing`.
 
 Source: arXiv:1606.00608, Appendix C.2, equation `QkKjs`, lines 1733--1737. -/
 theorem existsUnique_bntMarkovBlockNonzero_of_probability_ne_zero

--- a/TNLean/MPS/MPDO/BNTThreeSiteReducedClosure.lean
+++ b/TNLean/MPS/MPDO/BNTThreeSiteReducedClosure.lean
@@ -1,0 +1,347 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.FinTupleEquiv
+import TNLean.MPS.MPDO.BNTClosingSelection
+import TNLean.MPS.MPDO.BNTThreeSiteCollapse
+import TNLean.MPS.MPDO.MutualInfoMonotone
+import TNLean.MPS.MPDO.SectorTrace
+import TNLean.MPS.MPDO.VerticalCF
+
+/-!
+# Three-site reduced states from BNT closing matrices
+
+Tracing all but three consecutive physical sites closes the three exposed
+tensors against a power of the physical-trace transfer.  For a horizontal
+basis-of-normal-tensors representation, the reduced state is therefore a
+finite family closure.  Its closing matrix in sector (j) is the product of
+the normalization scalar, the canonical-form coefficient, and the traced
+virtual tail.
+
+This is the reduced-state expansion used in the Case II calculation of
+arXiv:1606.00608, Appendix C.2.  The result below includes the normalization
+of the density operator and transports the formula through equality of the
+complete matrix-product-vector families.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Appendix C.2, lines 1660--1665 and 1714--1732.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor.SectorDecomposition
+
+variable {d : ℕ}
+
+/-- Read a doubled-index BNT representative as an MPO tensor:
+
+\[
+  (\mathcal A_j)^{ab}=A_j^{(a,b)}.
+\]
+
+Source: arXiv:1606.00608, Appendix C.2, the BNT convention at lines
+1628--1632 and the canonical-form display at lines 1660--1665. -/
+def basisMPOTensor (S : SectorDecomposition (d * d))
+    (j : Fin S.basisCount) : MPOTensor d (S.basisDim j) :=
+  fun a b ↦ S.basis j (finProdFinEquiv (a, b))
+
+/-- Converting the representative MPO back to a doubled-index MPS tensor
+recovers the original BNT representative.
+
+Source: arXiv:1606.00608, Appendix C.2, the doubled-index convention at lines
+1628--1632. -/
+@[simp] theorem basisMPOTensor_toMPSTensor
+    (S : SectorDecomposition (d * d)) (j : Fin S.basisCount) :
+    (S.basisMPOTensor j).toMPSTensor = S.basis j := by
+  funext ab
+  change S.basis j (finProdFinEquiv (ab.divNat, ab.modNat)) = S.basis j ab
+  exact congrArg (S.basis j) (finProdFinEquiv.apply_symm_apply ab)
+
+/-- The physical trace transfer of a representative MPO is its doubled-index
+physical trace transfer.
+
+Source: arXiv:1606.00608, Appendix C.2, the traced physical legs in the
+closing construction at lines 1714--1718. -/
+@[simp] theorem basisMPOTensor_verticalLoop
+    (S : SectorDecomposition (d * d)) (j : Fin S.basisCount) :
+    MPOTensor.verticalLoop (S.basisMPOTensor j) =
+    MPOTensor.doubledPhysTraceTransfer d (S.basis j) := by
+  simp [MPOTensor.verticalLoop, MPOTensor.physTraceTransfer,
+    MPOTensor.doubledPhysTraceTransfer, basisMPOTensor]
+
+/-- Equality of the complete doubled-index matrix-product-vector families
+gives the representative expansion of every MPO matrix entry.
+
+Source: arXiv:1606.00608, equations `decBSV` and `CFK`, lines 298--301 and
+1660--1665. -/
+theorem mpo_eq_sum_coeff_basisMPOTensor
+    {D : ℕ} (M : MPOTensor d D) (S : SectorDecomposition (d * d))
+    (hM : SameMPV₂ M.toMPSTensor S.toTensor) {N : ℕ}
+    (u v : Fin N → Fin d) :
+    MPOTensor.mpo M N u v =
+      ∑ j : Fin S.basisCount,
+        S.coeff N j * MPOTensor.mpo (S.basisMPOTensor j) N u v := by
+  rw [← MPSTensor.mpv_toMPSTensor_pairConfig, hM,
+    S.mpv_toTensor_eq_sum_coeff]
+  apply Finset.sum_congr rfl
+  intro j _
+  rw [← MPSTensor.mpv_toMPSTensor_pairConfig,
+    S.basisMPOTensor_toMPSTensor]
+
+/-- The normalized closing matrix of sector (j) after tracing a tail of
+length (L):
+
+\[
+  \widehat R_j=
+  \operatorname{tr}(\rho^{(L+3)})^{-1}
+  q_j\mathcal B_j^L.
+\]
+
+The unnormalized factor (q_j\mathcal B_j^L) is
+`threeSiteClosingMatrix`.  The additional scalar is exactly the normalization
+in the density operator (sigma^{(L+3)}).
+
+Source: arXiv:1606.00608, lines 792--793 and Appendix C.2, lines
+1714--1732. -/
+noncomputable def normalizedThreeSiteClosingMatrix
+    {D : ℕ} (M : MPOTensor d D) (S : SectorDecomposition (d * d))
+    (L : ℕ) (j : Fin S.basisCount) :
+    Matrix (Fin (S.basisDim j)) (Fin (S.basisDim j)) ℂ :=
+  (Matrix.trace (MPOTensor.mpo M (L + 3)))⁻¹ •
+    S.threeSiteClosingMatrix L j
+
+/-- A nonzero unnormalized closing matrix remains nonzero after density-operator
+normalization, provided the total state has nonzero trace.
+
+Source: arXiv:1606.00608, lines 792--793 and Appendix C.2, lines
+1714--1718. -/
+theorem normalizedThreeSiteClosingMatrix_ne_zero
+    {D : ℕ} (M : MPOTensor d D) (S : SectorDecomposition (d * d))
+    (L : ℕ) (j : Fin S.basisCount)
+    (htrace : Matrix.trace (MPOTensor.mpo M (L + 3)) ≠ 0)
+    (hR : S.threeSiteClosingMatrix L j ≠ 0) :
+    S.normalizedThreeSiteClosingMatrix M L j ≠ 0 := by
+  exact smul_ne_zero (inv_ne_zero htrace) hR
+
+/-- Under copy independence and simplicity, the one-site-tail closing matrix
+is nonzero in every sector.  Thus the common choice may be made at total
+chain length four, the length used by the formal SAL-to-Markov theorem.
+
+Source: arXiv:1606.00608, simplicity at lines 815--822 and Appendix C.2,
+lines 1646--1665 and 1714--1718. -/
+theorem threeSiteClosingMatrix_one_ne_zero
+    (S : SectorDecomposition (d * d))
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q')
+    (hnonNil : ∀ j,
+      ¬ IsNilpotent (MPOTensor.doubledPhysTraceTransfer d (S.basis j)))
+    (j : Fin S.basisCount) :
+    S.threeSiteClosingMatrix 1 j ≠ 0 := by
+  have hTail :
+      (MPOTensor.doubledPhysTraceTransfer d (S.basis j)) ^ 1 ≠ 0 := by
+    intro hzero
+    exact hnonNil j ⟨1, hzero⟩
+  exact smul_ne_zero
+    (S.coeff_ne_zero_of_weight_copy_independent hWeight 4 j) hTail
+
+end MPSTensor.SectorDecomposition
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- Tracing a tail of length (L) after three exposed sites closes the
+three-site word against the (L)-th power of the physical-trace transfer.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1343--1348 and its Case II use
+at lines 1714--1732. -/
+theorem sum_mpo_threeSite_prefix_diagonal_tail
+    (K : MPOTensor d D) (L : ℕ) (u v : Fin 3 → Fin d) :
+    (∑ w : Fin L → Fin d,
+      mpo K (3 + L) (Fin.append u w) (Fin.append v w)) =
+      Matrix.trace
+        (K.evalWord (List.ofFn u) (List.ofFn v) * K.verticalLoop ^ L) := by
+  simp only [mpo_apply, mpoMatrixEntry]
+  have hwords (a : Fin 3 → Fin d) (w : Fin L → Fin d) :
+      List.ofFn (Fin.append a w) = List.ofFn a ++ List.ofFn w := by
+    exact List.ofFn_fin_append a w
+  simp_rw [hwords]
+  have heval (w : Fin L → Fin d) :
+      K.evalWord (List.ofFn u ++ List.ofFn w) (List.ofFn v ++ List.ofFn w) =
+        K.evalWord (List.ofFn u) (List.ofFn v) *
+          K.evalWord (List.ofFn w) (List.ofFn w) := by
+    exact K.evalWord_append _ _ _ _ (by simp)
+  simp_rw [heval]
+  rw [← Matrix.trace_sum]
+  congr 1
+  rw [← Finset.mul_sum, K.sum_evalWord_diag_eq_verticalLoop_pow]
+
+/-- The normalized three-site reduced state of an MPO with a horizontal BNT
+representation is the family closure whose virtual boundaries are the
+normalized physical-trace closing matrices.
+
+The matrix is reindexed from length-three configurations to ordered triples
+only to match `IsThreeSiteFamilyClosure`.
+
+Source: arXiv:1606.00608, lines 792--793 and Appendix C.2, equations `CFK`,
+`sigma3bka`, and `keyformula`, lines 1660--1665 and 1714--1732. -/
+theorem reducedBlockState_reindex_isThreeSiteFamilyClosure_of_sameMPV₂
+    {D : ℕ} (M : MPOTensor d D)
+    (S : MPSTensor.SectorDecomposition (d * d))
+    (hM : MPSTensor.SameMPV₂ M.toMPSTensor S.toTensor) (L : ℕ) :
+    IsThreeSiteFamilyClosure
+      (fun j ↦ S.basisMPOTensor j)
+      (S.normalizedThreeSiteClosingMatrix M L)
+      (Matrix.reindex (_root_.finThreeArrowEquiv (Fin d))
+        (_root_.finThreeArrowEquiv (Fin d))
+        (M.reducedBlockState (L + 3) 3 (by omega))) := by
+  classical
+  unfold IsThreeSiteFamilyClosure
+  intro i₁ i₂ i₃ j₁ j₂ j₃
+  let u : Fin 3 → Fin d := ![i₁, i₂, i₃]
+  let v : Fin 3 → Fin d := ![j₁, j₂, j₃]
+  have hReduced :
+      M.reducedBlockState (L + 3) 3 (by omega) u v =
+        (Matrix.trace (M.mpo (L + 3)))⁻¹ *
+          ∑ w : Fin L → Fin d,
+            M.mpo (3 + L) (Fin.append u w) (Fin.append v w) := by
+    rw [reducedBlockState_eq_sum]
+    simp only [normalizedMPO, Matrix.smul_apply, smul_eq_mul]
+    rw [Finset.mul_sum]
+    apply Finset.sum_congr rfl
+    intro w _
+    simp only [mpo_apply, mpoMatrixEntry]
+    have hwords (a : Fin 3 → Fin d) :
+        List.ofFn
+            (Fin.append a w ∘ Fin.cast (show L + 3 = 3 + L by omega)) =
+          List.ofFn a ++ List.ofFn w := by
+      rw [← List.ofFn_fin_append]
+      apply List.ext_getElem
+      · simp
+        omega
+      · intro n hn₁ hn₂
+        simp only [List.getElem_ofFn, Function.comp_apply]
+        congr 1
+    rw [hwords u, hwords v, List.ofFn_fin_append, List.ofFn_fin_append]
+    rfl
+  rw [Matrix.reindex_apply]
+  change M.reducedBlockState (L + 3) 3 (by omega) u v = _
+  rw [hReduced]
+  simp_rw [S.mpo_eq_sum_coeff_basisMPOTensor M hM]
+  rw [Finset.mul_sum]
+  simp_rw [Finset.mul_sum]
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro j _
+  calc
+    (∑ w, (Matrix.trace (M.mpo (L + 3)))⁻¹ *
+          (S.coeff (3 + L) j *
+            mpo (S.basisMPOTensor j) (3 + L) (Fin.append u w) (Fin.append v w))) =
+        ((Matrix.trace (M.mpo (L + 3)))⁻¹ * S.coeff (3 + L) j) *
+          ∑ w, mpo (S.basisMPOTensor j) (3 + L)
+            (Fin.append u w) (Fin.append v w) := by
+      rw [Finset.mul_sum]
+      apply Finset.sum_congr rfl
+      intro w _
+      ring
+    _ = ((Matrix.trace (M.mpo (L + 3)))⁻¹ * S.coeff (3 + L) j) *
+          Matrix.trace
+            ((S.basisMPOTensor j).evalWord (List.ofFn u) (List.ofFn v) *
+              (S.basisMPOTensor j).verticalLoop ^ L) := by
+      rw [sum_mpo_threeSite_prefix_diagonal_tail]
+    _ = Matrix.trace
+          (S.basisMPOTensor j i₁ j₁ * S.basisMPOTensor j i₂ j₂ *
+            S.basisMPOTensor j i₃ j₃ *
+              S.normalizedThreeSiteClosingMatrix M L j) := by
+      simp only [MPSTensor.SectorDecomposition.normalizedThreeSiteClosingMatrix,
+        MPSTensor.SectorDecomposition.threeSiteClosingMatrix,
+        MPSTensor.SectorDecomposition.basisMPOTensor_verticalLoop,
+        Matrix.mul_smul, Matrix.trace_smul,
+        smul_smul, smul_eq_mul]
+      have hcoeff : S.coeff (L + 3) j = S.coeff (3 + L) j := by
+        congr 1
+        omega
+      rw [hcoeff]
+      simp [MPSTensor.SectorDecomposition.basisMPOTensor, u, v,
+        evalWord, Matrix.mul_assoc]
+
+/-- Under the source hypotheses of simplicity, SAL, and copy-independent
+canonical-form weights, one normalized three-site reduced state has a BNT
+family closure with every closing matrix nonzero.
+
+The SAL hypothesis supplies the nonzero normalization trace.  Simplicity is
+used through the nonnilpotence of every physical-trace transfer, and the
+horizontal canonical form is used through equality of the complete
+matrix-product-vector families.
+
+Source: arXiv:1606.00608, simplicity and SAL at lines 815--822, and Appendix
+C.2, lines 1646--1665 and 1714--1732. -/
+theorem exists_reducedBlockState_threeSiteFamilyClosure_nonzero_closing
+    {D : ℕ} (M : MPOTensor d D)
+    (S : MPSTensor.SectorDecomposition (d * d))
+    (hM : MPSTensor.SameMPV₂ M.toMPSTensor S.toTensor)
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q')
+    (hnonNil : ∀ j,
+      ¬ IsNilpotent (doubledPhysTraceTransfer d (S.basis j)))
+    (hSAL : IsSAL M) :
+    ∃ L : ℕ, 0 < L ∧
+      IsThreeSiteFamilyClosure
+        (fun j ↦ S.basisMPOTensor j)
+        (S.normalizedThreeSiteClosingMatrix M L)
+        (Matrix.reindex (_root_.finThreeArrowEquiv (Fin d))
+          (_root_.finThreeArrowEquiv (Fin d))
+          (M.reducedBlockState (L + 3) 3 (by omega))) ∧
+      ∀ j : Fin S.basisCount,
+        S.normalizedThreeSiteClosingMatrix M L j ≠ 0 := by
+  obtain ⟨_hMPDO, htrace, _hSAL⟩ := hSAL
+  obtain ⟨L, hL, hR⟩ :=
+    S.exists_common_threeSiteClosingMatrix_ne_zero hWeight hnonNil
+  refine ⟨L, hL, ?_, ?_⟩
+  · simpa [Nat.add_comm] using
+      reducedBlockState_reindex_isThreeSiteFamilyClosure_of_sameMPV₂ M S hM L
+  · intro j
+    exact S.normalizedThreeSiteClosingMatrix_ne_zero M L j
+      (htrace (L + 3) (by omega)) (hR j)
+
+/-- At chain length four, the normalized three-site reduced state is a BNT
+family closure with every closing matrix nonzero.
+
+This is the form directly compatible with the four-site SAL-to-Markov
+decomposition.  No independent closing-matrix hypothesis remains: SAL gives
+the nonzero normalization, copy independence gives the nonzero coefficient,
+and simplicity gives the nonzero physical-trace tail.
+
+Source: arXiv:1606.00608, simplicity and SAL at lines 815--822, and Appendix
+C.2, lines 1646--1665 and 1714--1732. -/
+theorem reducedBlockState_four_threeSiteFamilyClosure_nonzero_closing
+    {D : ℕ} (M : MPOTensor d D)
+    (S : MPSTensor.SectorDecomposition (d * d))
+    (hM : MPSTensor.SameMPV₂ M.toMPSTensor S.toTensor)
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q')
+    (hnonNil : ∀ j,
+      ¬ IsNilpotent (doubledPhysTraceTransfer d (S.basis j)))
+    (hSAL : IsSAL M) :
+    IsThreeSiteFamilyClosure
+        (fun j ↦ S.basisMPOTensor j)
+        (S.normalizedThreeSiteClosingMatrix M 1)
+        (Matrix.reindex (_root_.finThreeArrowEquiv (Fin d))
+          (_root_.finThreeArrowEquiv (Fin d))
+          (M.reducedBlockState 4 3 (by omega))) ∧
+      ∀ j : Fin S.basisCount,
+        S.normalizedThreeSiteClosingMatrix M 1 j ≠ 0 := by
+  obtain ⟨_hMPDO, htrace, _hSAL⟩ := hSAL
+  constructor
+  · simpa using
+      reducedBlockState_reindex_isThreeSiteFamilyClosure_of_sameMPV₂ M S hM 1
+  · intro j
+    exact S.normalizedThreeSiteClosingMatrix_ne_zero M 1 j
+      (htrace 4 (by omega))
+      (S.threeSiteClosingMatrix_one_ne_zero hWeight hnonNil j)
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_case_two.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_case_two.tex
@@ -226,6 +226,52 @@
     construction is used with sector projectors at lines~1719--1725.
 \end{definition}
 
+\begin{theorem}[Normalized three-site BNT family closure]
+    \label{thm:mpdo_normalized_three_site_bnt_family_closure}
+    \lean{MPSTensor.SectorDecomposition.basisMPOTensor}
+    \lean{MPSTensor.SectorDecomposition.normalizedThreeSiteClosingMatrix}
+    \lean{MPOTensor.%
+      reducedBlockState_reindex_isThreeSiteFamilyClosure_of_sameMPV₂}
+    \lean{MPOTensor.%
+      reducedBlockState_four_threeSiteFamilyClosure_nonzero_closing}
+    \leanok
+    \uses{def:mpdo_three_site_family_closure,
+      thm:mpdo_common_nonzero_bnt_tail_selection}
+    Suppose that the doubled-index tensor has the horizontal BNT
+    representation $S$, the copy weights over each representative agree, the
+    physical-trace transfers
+    $\mathcal B_j=\sum_iA_j^{ii}$ are not nilpotent, and the original tensor
+    satisfies SAL.  After identifying length-three configurations with
+    ordered triples, the normalized three-site marginal of the four-site
+    state is the family closure
+    \[
+      (\sigma^{(4)}_3)_{i_1i_2i_3,j_1j_2j_3}
+      =\sum_j\tr\!\left(
+        A_j^{i_1j_1}A_j^{i_2j_2}A_j^{i_3j_3}\widehat R_j\right),
+    \]
+    where
+    \[
+      \widehat R_j
+      =\tr(\rho^{(4)})^{-1}q_j\mathcal B_j,
+      \qquad q_j=\sum_q\mu_{j,q}^{4}.
+    \]
+    Every $\widehat R_j$ is nonzero.  More generally, a tail of length $L$
+    gives
+    $\widehat R_j=\tr(\rho^{(L+3)})^{-1}q_j\mathcal B_j^L$.
+    This is the normalized traced-tail expansion used in
+    \cite[Appendix~C.2, lines~1714--1732]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    Equality of the complete matrix-product-vector families expands every
+    matrix entry of the original operator as the sum of the BNT entries with
+    coefficients $q_j$.  Summing the diagonal physical configurations of the
+    tail gives $\mathcal B_j^L$.  The global normalization multiplies every
+    closing matrix by $\tr(\rho^{(L+3)})^{-1}$.  At $L=1$, SAL makes this
+    scalar nonzero, copy independence makes $q_j$ nonzero, and
+    nonnilpotence makes $\mathcal B_j$ nonzero.
+\end{proof}
+
 \begin{theorem}[Collapse of the outer inverse contraction]
     \label{thm:mpdo_bnt_three_site_outer_inverse_collapse}
     \lean{MPOTensor.%

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
@@ -264,8 +264,8 @@ strong subadditivity for a normalized three-site reduced state.
     stated nonzero-closing-matrix condition isolates the step obtained in the
     source from simplicity and the common-weight choice at
     \cite[Appendix~C.2, lines~1714--1718]{Cirac2016MPDO_arXiv}.  Its derivation
-    from those preceding hypotheses remains separate; see
-    \path{docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex}.
+    from those preceding hypotheses is
+    Theorem~\ref{thm:mpdo_normalized_three_site_bnt_family_closure}.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -244,15 +244,27 @@ and
 \path{MPSTensor.SectorDecomposition.exists_common_nonzero_threeSiteClosingMatrix_entry};
 the matrix form is
 \path{MPSTensor.SectorDecomposition.exists_common_threeSiteClosingMatrix_ne_zero}.}
-The remaining source-faithfulness gap is to prove that the normalized
-three-site reduced state of the original tensor is the family closure with
-these matrices $R_j$, including the common normalization and the transport
-through the horizontal canonical-form gauge.  Until this identification is
-proved, the unrestricted uniqueness assertion of equation
-\texttt{QkKjs} is not identified with the conditional theorem above; the
-blueprint states and marks only the explicitly restricted version.  The
-elimination plan is to prove this reduced-state expansion and then specialize
-the conditional uniqueness and projector statements.
+This closing-matrix bridge is now formalized with the normalization included.
+Equality of the complete matrix-product-vector families transports the
+original tensor to its horizontal BNT representation, and the normalized
+three-site reduced state has closing matrices
+\[
+  \widehat R_j=\tr(\rho^{(L+3)})^{-1}q_j\mathcal B_j^L.
+\]
+At the four-site length used by the formal SAL-to-Markov theorem, one takes
+$L=1$.  SAL makes the normalization scalar nonzero, so every
+$\widehat R_j$ is nonzero.
+\footnote{The relevant declarations are
+\path{MPSTensor.SectorDecomposition.normalizedThreeSiteClosingMatrix},
+\path{MPOTensor.reducedBlockState_reindex_isThreeSiteFamilyClosure_of_sameMPV₂},
+and
+\path{MPOTensor.reducedBlockState_four_threeSiteFamilyClosure_nonzero_closing}.}
+Thus the explicit nonzero-closing hypothesis of the generic cancellation
+theorem is derived for the family closure used by the source.  The remaining
+formal composition is to specialize the generic uniqueness and projector
+statements simultaneously to this closure, the four-site Hayashi
+decomposition supplied by SAL, and the simultaneous inverse supplied by
+biCF.  No further closing-matrix assumption is needed for that specialization.
 
 The neighboring operators are now assembled from these sector tensors.  The
 operator


### PR DESCRIPTION
## Summary

This change identifies the normalized three-site reduced state used in Appendix C.2 with the BNT family closure constructed from the horizontal canonical form.

- It reads each doubled-index BNT representative as an MPO tensor and transports the complete MPV-family equality entrywise.
- It proves that tracing a tail of length `L` produces the closing matrix
  `tr(ρ^(L+3))⁻¹ q_j B_j^L`.
- At `L = 1`, it combines SAL, copy independence, and nonnilpotence to show that every normalized closing matrix is nonzero, matching the four-site SAL-to-Markov statement.
- It updates the blueprint and the Appendix C.2 gap note to record that the source instance now discharges the nonzero-closing condition.

The general projector algebra remains conditional on nonzero closing matrices, since that hypothesis is necessary for an arbitrary family closure. The normalized reduced state constructed here supplies the condition without an additional source hypothesis.

Source: arXiv:1606.00608, Appendix C.2, lines 1714–1732.

Progresses #4085, #4081, and #4003.

## Checks

- `lake env lean TNLean/MPS/MPDO/BNTThreeSiteReducedClosure.lean`
- `lake -KmaxJobs=1 build TNLean` on Lean 4.32.0 (9,529 jobs)
- `leanblueprint checkdecls`
- `leanblueprint web`
- `leanblueprint pdf`, with the new theorem and revised gap-note pages visually inspected
- kernel axiom audit: only `propext`, `Classical.choice`, and `Quot.sound`
- no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast` in the changed Lean files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Lean proofs and blueprint/docs only; no runtime or security surface. Residual risk is proof-track composition (wiring this closure into the full SAL-to-Markov capstone), not the new lemmas in isolation.
> 
> **Overview**
> Adds **`BNTThreeSiteReducedClosure.lean`**, which shows the normalized three-site reduced state from horizontal BNT data is an **`IsThreeSiteFamilyClosure`** with closing matrices **\(\widehat R_j = \mathrm{tr}(\rho^{(L+3)})^{-1} q_j \mathcal B_j^L\)**, including MPV transport and tail tracing lemmas.
> 
> At **four sites** and **\(L=1\)**, **`reducedBlockState_four_threeSiteFamilyClosure_nonzero_closing`** derives **every \(\widehat R_j \neq 0\)** from SAL, copy-independent weights, and non-nilpotent physical-trace transfers—so the source Case II instance satisfies the generic nonzero-closing hypothesis used in **`BNTMarkovSectorProjectors`**.
> 
> Blueprint gains **`thm:mpdo_normalized_three_site_bnt_family_closure`**; the Appendix C.2 gap note records the bridge as formalized and points remaining work to specializing uniqueness/projectors to that closure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69543cec6af719f7dc52110090cf54affb360bf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->