### PR TITLE
feat(MPS/MPDO): specialize BNT sector projectors to SAL

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -444,6 +444,7 @@ import TNLean.MPS.MPDO.PRFP
 import TNLean.MPS.MPDO.LocalPurificationRFP
 import TNLean.MPS.MPDO.SimpleLocalStructure
 import TNLean.MPS.MPDO.BNTThreeSiteReducedClosure
+import TNLean.MPS.MPDO.BNTSourceSectorProjectors
 import TNLean.MPS.MPDO.HayashiSectorProjector
 import TNLean.MPS.MPDO.EtaPreparation
 import TNLean.MPS.MPDO.RFPSubspinMaps

--- a/TNLean/MPS/MPDO/BNTSourceSectorProjectors.lean
+++ b/TNLean/MPS/MPDO/BNTSourceSectorProjectors.lean
@@ -1,0 +1,151 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.BNTMarkovSectorProjectors
+import TNLean.MPS.MPDO.BNTThreeSiteReducedClosure
+
+/-!
+# BNT sector projectors for the four-site SAL marginal
+
+The normalized three-site marginal of a four-site tensor satisfying the strong
+area law has two descriptions.  Its horizontal basis-of-normal-tensors
+representation gives a family closure with nonzero closing matrices, while
+equality in strong subadditivity gives a Hayashi--Markov decomposition.  A
+simultaneous inverse for the normal tensors compares these descriptions and
+assigns every positive-weight Markov sector to a unique normal sector.
+
+The corresponding sums of Hayashi sector projections are orthogonal, mutually
+disjoint, and resolve the positive-weight Markov support.  This is the
+four-site specialization of the projector construction in arXiv:1606.00608,
+Appendix C.2, equations `QkKjs` and `Pis`.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Appendix C.2, lines 1666--1676 and 1714--1737.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- Reindexing the four-site state's three-site marginal by the canonical
+ordered-triple equivalence is the submatrix convention used by the
+SAL-to-Hayashi theorem.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma `Lsigma3`, lines 1351--1363. -/
+theorem reducedBlockState_four_reindex_eq_submatrix (M : MPOTensor d D) :
+    Matrix.reindex (_root_.finThreeArrowEquiv (Fin d))
+        (_root_.finThreeArrowEquiv (Fin d))
+        (M.reducedBlockState 4 3 (by omega)) =
+      (M.reducedBlockState 4 3 (by omega)).submatrix
+        (fun p : Fin d × Fin d × Fin d ↦ ![p.1, p.2.1, p.2.2])
+        (fun p : Fin d × Fin d × Fin d ↦ ![p.1, p.2.1, p.2.2]) := by
+  ext p q
+  simp
+
+/-- SAL supplies a Hayashi--Markov decomposition in the same ordered-triple
+coordinates as the BNT family closure.
+
+This statement inherits the existing forward Hayashi equality-characterization
+axiom `hayashi_ssa_equality_characterization_forward` and introduces no new
+axiom.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma `Lsigma3`, lines 1351--1363,
+and the Case II use at lines 1698--1737. -/
+theorem exists_etaStructure_reducedBlockState_four_reindex_of_isSAL
+    (M : MPOTensor d D) (hSAL : IsSAL M) :
+    Nonempty
+      (EtaStructure
+        (Matrix.reindex (_root_.finThreeArrowEquiv (Fin d))
+          (_root_.finThreeArrowEquiv (Fin d))
+          (M.reducedBlockState 4 3 (by omega)))) := by
+  rw [reducedBlockState_four_reindex_eq_submatrix]
+  exact exists_etaStructure_reducedBlockState_of_isSAL M hSAL
+
+/-- For the normalized four-site SAL marginal, every positive-weight
+Hayashi--Markov sector has a unique BNT label.  The resulting BNT-labelled
+sums of Hayashi projections are orthogonal, mutually disjoint, and resolve the
+positive-weight Markov support.
+
+There is no independent nonzero-closing-matrix hypothesis: the normalized BNT
+closure supplies it from SAL, copy independence, and nonnilpotence.
+
+**Axiom boundary:** the Hayashi decomposition uses the existing forward
+Hayashi--Ruskai--Hayden--Jozsa--Petz--Winter characterization of equality in
+strong subadditivity, isolated as
+`hayashi_ssa_equality_characterization_forward`.  No further axiom is used.
+
+**Scope restriction (blocked tensor):** the simultaneous inverse is used after
+the source's common blocking, expressed here by the one-letter simultaneous
+span.  The passage to this blocked form is recorded in
+`docs/paper-gaps/cpgsv17_bicf_block_separation.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1666--1676 and equations
+`QkKjs` and `Pis`, lines 1714--1737. -/
+theorem exists_bntSectorProjectors_four_of_sameMPV₂_isSAL
+    (M : MPOTensor d D)
+    (S : MPSTensor.SectorDecomposition (d * d))
+    (hM : MPSTensor.SameMPV₂ M.toMPSTensor S.toTensor)
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q')
+    (hnonNil : ∀ j,
+      ¬ IsNilpotent (doubledPhysTraceTransfer d (S.basis j)))
+    (hSpan : MPSTensor.WordTupleSpanTop S.basis 1)
+    (hSAL : IsSAL M) :
+    let ρ := Matrix.reindex (_root_.finThreeArrowEquiv (Fin d))
+      (_root_.finThreeArrowEquiv (Fin d))
+      (M.reducedBlockState 4 3 (by omega))
+    ∃ (C : Matrix (MPSTensor.BlockEntryIndex S.basisDim)
+        (Fin d × Fin d) ℂ),
+      ∃ hC : MPSTensor.IsMPOBlockLeftInverse
+          (fun j ↦ S.basisMPOTensor j) C,
+        ∃ hη : EtaStructure ρ,
+          let hρ : IsThreeSiteFamilyClosure
+              (fun j ↦ S.basisMPOTensor j)
+              (S.normalizedThreeSiteClosingMatrix M 1) ρ :=
+            (reducedBlockState_four_threeSiteFamilyClosure_nonzero_closing
+              M S hM hWeight hnonNil hSAL).1
+          let hR : ∀ j : Fin S.basisCount,
+              S.normalizedThreeSiteClosingMatrix M 1 j ≠ 0 :=
+            (reducedBlockState_four_threeSiteFamilyClosure_nonzero_closing
+              M S hM hWeight hnonNil hSAL).2
+          (∀ k : {k : Fin hη.m // hη.p k ≠ 0},
+              ∃! s : Fin S.basisCount,
+                BNTMarkovBlockNonzero (S.basisMPOTensor s) hη k) ∧
+            (∀ s : Fin S.basisCount,
+              IsOrthogonalProjection
+                (bntSectorProjection hC hρ hη hR s)) ∧
+            (∀ s t : Fin S.basisCount, s ≠ t →
+              bntSectorProjection hC hρ hη hR s *
+                bntSectorProjection hC hρ hη hR t = 0) ∧
+            (∑ s : Fin S.basisCount,
+              bntSectorProjection hC hρ hη hR s) =
+                activeMarkovProjection hη := by
+  dsimp only
+  have hSpan' : MPSTensor.WordTupleSpanTop
+      (fun j ↦ (S.basisMPOTensor j).toMPSTensor) 1 := by
+    simpa using hSpan
+  obtain ⟨C, hC⟩ := hSpan'.exists_mpo_block_left_inverse
+  obtain ⟨hη⟩ :=
+    exists_etaStructure_reducedBlockState_four_reindex_of_isSAL M hSAL
+  let hClosure :=
+    reducedBlockState_four_threeSiteFamilyClosure_nonzero_closing
+      M S hM hWeight hnonNil hSAL
+  let hρ := hClosure.1
+  let hR := hClosure.2
+  refine ⟨C, hC, hη, ?_, ?_, ?_, ?_⟩
+  · intro k
+    exact existsUnique_bntMarkovBlockNonzero_of_probability_ne_zero
+      hC hρ hη hR k k.property
+  · intro s
+    exact bntSectorProjection_isOrthogonal hC hρ hη hR s
+  · intro s t hst
+    exact bntSectorProjection_mul_eq_zero hC hρ hη hR hst
+  · exact sum_bntSectorProjection hC hρ hη hR
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
@@ -400,6 +400,48 @@ strong subadditivity for a normalized three-site reduced state.
     Markov decomposition.
 \end{proof}
 
+\begin{theorem}[BNT sector projectors for the four-site SAL marginal]
+    \label{thm:mpdo_four_site_sal_bnt_sector_projectors}
+    \lean{MPOTensor.reducedBlockState_four_reindex_eq_submatrix}
+    \lean{MPOTensor.%
+      exists_etaStructure_reducedBlockState_four_reindex_of_isSAL}
+    \lean{MPOTensor.exists_bntSectorProjectors_four_of_sameMPV₂_isSAL}
+    \leanok
+    \uses{thm:mpdo_normalized_three_site_bnt_family_closure,
+      thm:mpdo_bnt_sector_projection_resolution,
+      thm:mpdo_four_site_sal_eta_structure}
+    Suppose that the common blocking has been performed, so that the BNT
+    representatives have a simultaneous one-letter span.  For the normalized
+    three-site marginal $\sigma_3^{(4)}$, there are a simultaneous inverse
+    $C$ and a Hayashi decomposition such that every Markov sector $k$ with
+    $p_k\ne0$ has a unique BNT label $j_k$.  Consequently,
+    \[
+      P_s=\sum_{\substack{k:p_k\ne0\\j_k=s}}Q_k
+    \]
+    is an orthogonal projection, $P_sP_t=0$ for $s\ne t$, and
+    \[
+      \sum_sP_s=P_{\mathrm{act}}.
+    \]
+    No independent nonzero-closing-matrix hypothesis is required.  This is
+    the four-site specialization of equations~\textup{QkKjs} and
+    \textup{Pis} in
+    \cite[Appendix~C.2, lines~1714--1737]{Cirac2016MPDO_arXiv}.
+    The Hayashi decomposition uses the forward equality characterization of
+    strong subadditivity recorded in
+    Theorem~\ref{thm:hayashi_ssa_equality_characterization}; no additional
+    analytic assumption is introduced here.
+\end{theorem}
+
+\begin{proof}\leanok
+    The canonical ordered-triple reindexing is the submatrix convention of
+    the SAL-to-Hayashi theorem.  Choose the simultaneous inverse from the
+    one-letter span and the Hayashi decomposition from SAL.  By
+    Theorem~\ref{thm:mpdo_normalized_three_site_bnt_family_closure}, the same
+    marginal is a BNT family closure whose closing matrices are all nonzero.
+    The generic uniqueness and projector theorems now give the unique labels,
+    orthogonality, mutual disjointness, and resolution of the active support.
+\end{proof}
+
 \begin{definition}[Injective inverse map for a simple MPO tensor]
     \label{def:mpdo_injective_inverse_layer}
     \lean{MPOTensor.IsInjective}

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -260,11 +260,18 @@ $\widehat R_j$ is nonzero.
 and
 \path{MPOTensor.reducedBlockState_four_threeSiteFamilyClosure_nonzero_closing}.}
 Thus the explicit nonzero-closing hypothesis of the generic cancellation
-theorem is derived for the family closure used by the source.  The remaining
-formal composition is to specialize the generic uniqueness and projector
-statements simultaneously to this closure, the four-site Hayashi
-decomposition supplied by SAL, and the simultaneous inverse supplied by
-biCF.  No further closing-matrix assumption is needed for that specialization.
+theorem is derived for the family closure used by the source.  The simultaneous
+specialization is now formalized as well.  After the common blocking has made
+the BNT representatives simultaneously one-letter spanning, biCF supplies the
+inverse and SAL supplies the four-site Hayashi decomposition.  Every active
+Markov sector then has a unique BNT label, and the resulting BNT-labelled sums
+of Hayashi projections are orthogonal, mutually disjoint, and resolve the
+active Markov support.
+\footnote{The relevant declaration is
+\path{MPOTensor.exists_bntSectorProjectors_four_of_sameMPV₂_isSAL}.}
+No further closing-matrix assumption is needed for this specialization.  The
+remaining step for the source projector passage is the all-length
+$P_j$-compressed density-operator formula with the natural multiplicities.
 
 The neighboring operators are now assembled from these sector tensors.  The
 operator


### PR DESCRIPTION
## Summary

- identify the ordered-triple coordinates used by the four-site SAL marginal with the submatrix coordinates of the Hayashi theorem;
- specialize the generic BNT--Markov uniqueness and projector results to the normalized four-site marginal;
- derive all nonzero closing matrices from SAL, copy independence, and nonnilpotence, rather than assuming them independently;
- record the common-blocking restriction explicitly as a simultaneous one-letter span;
- update the blueprint and the SAL/ZCL paper-gap note.

This follows arXiv:1606.00608, Appendix C.2, lines 1666--1676 and 1714--1737.  The result resolves the positive-weight Markov support, as in the source after its zero-weight summands are removed.  It inherits the existing forward Hayashi equality-characterization axiom and introduces no new axiom.

The remaining part of the source projector passage is the all-length density-operator formula compressed by the projectors, with the natural multiplicities.

Progresses #4081 and #4003.

## Verification

- `lake env lean TNLean/MPS/MPDO/BNTSourceSectorProjectors.lean`
- `lake -KmaxJobs=1 build TNLean` (9530 jobs, Lean 4.32.0)
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `leanblueprint checkdecls`
- `leanblueprint web`
- `leanblueprint pdf`, with the changed pages inspected visually
- standalone paper-gap PDF, with the changed page inspected visually
- kernel axiom audit of all three new declarations

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New formal capstone on the MPDO RFP track with nontrivial hypotheses (blocking span, sector data); relies on the existing Hayashi SSA axiom but introduces no new axioms.
> 
> **Overview**
> Adds **`TNLean/MPS/MPDO/BNTSourceSectorProjectors.lean`** and wires it into the root import list, specializing the generic BNT–Markov projector machinery to the **normalized four-site SAL three-site marginal**.
> 
> The new Lean layer aligns **ordered-triple reindexing** with the Hayashi submatrix convention, gets an **η-structure from SAL** (still only via the existing forward Hayashi SSA axiom), and proves **`exists_bntSectorProjectors_four_of_sameMPV₂_isSAL`**: under common blocking as a **one-letter simultaneous span**, active Markov sectors get **unique BNT labels** and the **P_s** sums of Hayashi projections are orthogonal, disjoint, and sum to the active Markov projector—with **nonzero closing matrices derived** from SAL/copy independence/nonnilpotence rather than assumed.
> 
> The **blueprint** gains theorem `thm:mpdo_four_site_sal_bnt_sector_projectors`; the **SAL/ZCL paper-gap note** now records this specialization as formalized and points the remaining projector work at the all-length **P_j-compressed** density-operator formula.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4250a6d639906b5b2ce3745b3694043b4ad22ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->