### PR TITLE
feat(MPS/MPDO): prove positive-length BNT sector compression

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -445,6 +445,8 @@ import TNLean.MPS.MPDO.LocalPurificationRFP
 import TNLean.MPS.MPDO.SimpleLocalStructure
 import TNLean.MPS.MPDO.BNTThreeSiteReducedClosure
 import TNLean.MPS.MPDO.BNTSourceSectorProjectors
+import TNLean.MPS.MPDO.SitewisePhysicalMatrix
+import TNLean.MPS.MPDO.BNTProjectorSelection
 import TNLean.MPS.MPDO.HayashiSectorProjector
 import TNLean.MPS.MPDO.EtaPreparation
 import TNLean.MPS.MPDO.RFPSubspinMaps

--- a/TNLean/Algebra/ScalarCommutant.lean
+++ b/TNLean/Algebra/ScalarCommutant.lean
@@ -137,6 +137,108 @@ section Semiring
 
 variable {R : Type*} [Semiring R]
 
+/-- Left multiplication by a block projection fixes entries whose row belongs
+to the selected block. -/
+@[simp] theorem blockProjection_mul_apply_same
+    [Fintype ι] [(i : ι) → Fintype (n i)] [(i : ι) → DecidableEq (n i)]
+    (X : Matrix ((i : ι) × n i) ((i : ι) × n i) R)
+    (k : ι) (a : n k) (j : (i : ι) × n i) :
+    (blockProjection (n := n) (R := R) k * X) ⟨k, a⟩ j = X ⟨k, a⟩ j := by
+  rw [Matrix.mul_apply, Finset.sum_eq_single ⟨k, a⟩]
+  · simp [blockProjection]
+  · rintro ⟨i, b⟩ _ hib
+    by_cases hik : i = k
+    · subst i
+      have hba : b ≠ a := by
+        intro hba
+        apply hib
+        subst b
+        rfl
+      simp [blockProjection, Ne.symm hba]
+    · rw [show blockProjection (n := n) (R := R) k ⟨k, a⟩ ⟨i, b⟩ = 0 by
+        exact Matrix.blockDiagonal'_apply_ne _ a b (Ne.symm hik)]
+      simp
+  · simp
+
+/-- Left multiplication by a block projection kills entries whose row lies
+outside the selected block. -/
+theorem blockProjection_mul_apply_ne
+    [Fintype ι] [(i : ι) → Fintype (n i)] [(i : ι) → DecidableEq (n i)]
+    (X : Matrix ((i : ι) × n i) ((i : ι) × n i) R)
+    (k : ι) {i : ι} (hik : i ≠ k) (a : n i) (j : (i : ι) × n i) :
+    (blockProjection (n := n) (R := R) k * X) ⟨i, a⟩ j = 0 := by
+  rw [Matrix.mul_apply]
+  apply Finset.sum_eq_zero
+  rintro ⟨q, b⟩ _
+  by_cases hiq : i = q
+  · subst q
+    simp [blockProjection, hik]
+  · rw [show blockProjection (n := n) (R := R) k ⟨i, a⟩ ⟨q, b⟩ = 0 by
+      exact Matrix.blockDiagonal'_apply_ne _ a b hiq]
+    simp
+
+/-- Right multiplication by a block projection fixes entries whose column
+belongs to the selected block. -/
+@[simp] theorem mul_blockProjection_apply_same
+    [Fintype ι] [(i : ι) → Fintype (n i)] [(i : ι) → DecidableEq (n i)]
+    (X : Matrix ((i : ι) × n i) ((i : ι) × n i) R)
+    (k : ι) (i : (i : ι) × n i) (b : n k) :
+    (X * blockProjection (n := n) (R := R) k) i ⟨k, b⟩ = X i ⟨k, b⟩ := by
+  rw [Matrix.mul_apply, Finset.sum_eq_single ⟨k, b⟩]
+  · simp [blockProjection]
+  · rintro ⟨j, a⟩ _ haj
+    by_cases hjk : j = k
+    · subst j
+      have hab : a ≠ b := by
+        intro hab
+        apply haj
+        subst a
+        rfl
+      simp [blockProjection, hab]
+    · rw [show blockProjection (n := n) (R := R) k ⟨j, a⟩ ⟨k, b⟩ = 0 by
+        exact Matrix.blockDiagonal'_apply_ne _ a b hjk]
+      simp
+  · simp
+
+/-- Right multiplication by a block projection kills entries whose column
+lies outside the selected block. -/
+theorem mul_blockProjection_apply_ne
+    [Fintype ι] [(i : ι) → Fintype (n i)] [(i : ι) → DecidableEq (n i)]
+    (X : Matrix ((i : ι) × n i) ((i : ι) × n i) R)
+    (k : ι) {j : ι} (hjk : j ≠ k) (i : (i : ι) × n i) (b : n j) :
+    (X * blockProjection (n := n) (R := R) k) i ⟨j, b⟩ = 0 := by
+  rw [Matrix.mul_apply]
+  apply Finset.sum_eq_zero
+  rintro ⟨q, a⟩ _
+  by_cases hqj : q = j
+  · subst q
+    simp [blockProjection, hjk]
+  · rw [show blockProjection (n := n) (R := R) k ⟨q, a⟩ ⟨j, b⟩ = 0 by
+      exact Matrix.blockDiagonal'_apply_ne _ a b hqj]
+    simp
+
+/-- A left-right block compression vanishes when all entries in the selected
+block vanish. -/
+theorem blockProjection_mul_mul_blockProjection_eq_zero
+    [Fintype ι] [(i : ι) → Fintype (n i)] [(i : ι) → DecidableEq (n i)]
+    (X : Matrix ((i : ι) × n i) ((i : ι) × n i) R)
+    (k l : ι) (hblock : ∀ (a : n k) (b : n l), X ⟨k, a⟩ ⟨l, b⟩ = 0) :
+    blockProjection (n := n) (R := R) k * X *
+        blockProjection (n := n) (R := R) l = 0 := by
+  ext ⟨i, a⟩ ⟨j, b⟩
+  by_cases hik : i = k
+  · subst i
+    by_cases hjl : j = l
+    · subst j
+      rw [mul_blockProjection_apply_same,
+        blockProjection_mul_apply_same, hblock]
+      rfl
+    · exact mul_blockProjection_apply_ne _ _ hjl _ _
+  · rw [Matrix.mul_apply]
+    apply Finset.sum_eq_zero
+    intro x _
+    rw [blockProjection_mul_apply_ne _ _ hik, zero_mul]
+
 /-- If a matrix commutes with every block projection, then it is block diagonal.
 
 This is the algebraic off-block-zero step needed in block-decomposition
@@ -152,36 +254,8 @@ theorem isBlockDiagonal'_of_commutes_blockProjection
   rw [isBlockDiagonal'_iff_offBlock_zero]
   intro i j hij a b
   have hentry := congrFun (congrFun (hComm j) ⟨i, a⟩) ⟨j, b⟩
-  have hleft :
-      (X * blockProjection (n := n) (R := R) j) ⟨i, a⟩ ⟨j, b⟩ =
-        X ⟨i, a⟩ ⟨j, b⟩ := by
-    rw [Matrix.mul_apply, Finset.sum_eq_single ⟨j, b⟩]
-    · simp [blockProjection]
-    · rintro ⟨k, c⟩ _ hkc
-      by_cases hkj : k = j
-      · subst k
-        have hcb : c ≠ b := by
-          intro hcb
-          apply hkc
-          subst hcb
-          rfl
-        simp [blockProjection, hcb]
-      · rw [show blockProjection (n := n) (R := R) j ⟨k, c⟩ ⟨j, b⟩ = 0 from by
-          exact Matrix.blockDiagonal'_apply_ne _ c b hkj]
-        simp
-    · intro hmem
-      simp at hmem
-  have hright :
-      (blockProjection (n := n) (R := R) j * X) ⟨i, a⟩ ⟨j, b⟩ = 0 := by
-    rw [Matrix.mul_apply]
-    apply Finset.sum_eq_zero
-    rintro ⟨k, c⟩ _
-    by_cases hik : i = k
-    · subst k
-      simp [blockProjection, hij]
-    · rw [show blockProjection (n := n) (R := R) j ⟨i, a⟩ ⟨k, c⟩ = 0 from by
-        exact Matrix.blockDiagonal'_apply_ne _ a c hik]
-      simp
+  have hleft := mul_blockProjection_apply_same X j ⟨i, a⟩ b
+  have hright := blockProjection_mul_apply_ne X j hij a ⟨j, b⟩
   simpa [hleft, hright] using hentry
 
 end Semiring

--- a/TNLean/MPS/MPDO/BNTProjectorSelection.lean
+++ b/TNLean/MPS/MPDO/BNTProjectorSelection.lean
@@ -1,0 +1,700 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.BNTSourceSectorProjectors
+import TNLean.MPS.MPDO.CommonWeightAbsorption
+import TNLean.MPS.MPDO.SitewisePhysicalMatrix
+
+/-!
+# Local selection by the BNT sector projectors
+
+The projectors obtained from the Hayashi--Markov sectors select the physical
+support of the corresponding basis-of-normal-tensors representative.  More
+precisely, the physical slice of normal sector `i` has no block from `P_s` to
+`P_t` unless `s = t = i`.
+
+This is equation `PjKiPj` in arXiv:1606.00608, Appendix C.2.  It is the local
+statement used immediately afterward to derive `generateMPDO` and the
+positive-length density-operator compression formula `sigmaNKj`.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Appendix C.2, equations `PjKiPj` and `generateMPDO`, lines 1680--1759.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPOTensor
+
+variable {d g : ℕ} {dim : Fin g → ℕ}
+
+open PhysicalSectorFactorization
+
+/-- Distinct Hayashi sectors give a zero physical-slice corner.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `Qks`, lines 1698--1735. -/
+theorem sectorProjection_mul_physicalSlice_mul_sectorProjection_eq_zero_of_ne
+    {K : (s : Fin g) → MPOTensor d (dim s)}
+    {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse K C)
+    (hρ : IsThreeSiteFamilyClosure K R ρ) (hη : EtaStructure ρ)
+    (hR : ∀ s : Fin g, R s ≠ 0) (s : Fin g)
+    (β α : Fin (dim s)) {k l : Fin hη.m} (hkl : k ≠ l) :
+    hη.sectorProjection k * physicalSlice (K s) β α *
+        hη.sectorProjection l = 0 := by
+  obtain ⟨β₃, α₁, hm⟩ := Matrix.exists_entry_ne_zero_of_ne_zero _ (hR s)
+  apply EtaStructure.sectorProjection_mul_mul_sectorProjection_eq_zero_of_block hη
+  rintro ⟨aL, aR⟩ ⟨bL, bR⟩
+  exact isMPOBlockLeftInverse_bnt_markov_offdiagonal
+    hC hρ hη s hm β α hkl aL aR bL bR
+
+/-- An active diagonal Hayashi corner vanishes for every BNT representative
+except the representative assigned to that Hayashi sector.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `QkKjs`, lines 1733--1737. -/
+theorem sectorProjection_mul_physicalSlice_mul_self_eq_zero_of_ne_label
+    {K : (s : Fin g) → MPOTensor d (dim s)}
+    {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse K C)
+    (hρ : IsThreeSiteFamilyClosure K R ρ) (hη : EtaStructure ρ)
+    (hR : ∀ s : Fin g, R s ≠ 0)
+    (k : {k : Fin hη.m // hη.p k ≠ 0}) (s : Fin g)
+    (hs : s ≠ bntSectorLabel hC hρ hη hR k)
+    (β α : Fin (dim s)) :
+    hη.sectorProjection k * physicalSlice (K s) β α *
+        hη.sectorProjection k = 0 := by
+  apply EtaStructure.sectorProjection_mul_mul_sectorProjection_eq_zero_of_block hη
+  intro a b
+  by_contra hab
+  apply hs
+  apply (bntMarkovBlockNonzero_iff_eq_bntSectorLabel
+    hC hρ hη hR k s).mp
+  refine ⟨β, α, ?_⟩
+  intro hzero
+  exact hab (congrFun (congrFun hzero a) b)
+
+/-- An inactive Hayashi sector has a zero diagonal corner in every BNT
+representative.  The nonzero closing matrix prevents an invisible physical
+block from remaining in a zero-weight Markov summand.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1698--1737, where zero summands
+are removed before the projector construction. -/
+theorem sectorProjection_mul_physicalSlice_mul_self_eq_zero_of_probability_eq_zero
+    {K : (s : Fin g) → MPOTensor d (dim s)}
+    {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse K C)
+    (hρ : IsThreeSiteFamilyClosure K R ρ) (hη : EtaStructure ρ)
+    (hR : ∀ s : Fin g, R s ≠ 0) (s : Fin g)
+    (β α : Fin (dim s)) (k : Fin hη.m) (hk : hη.p k = 0) :
+    hη.sectorProjection k * physicalSlice (K s) β α *
+        hη.sectorProjection k = 0 := by
+  obtain ⟨β₃, α₁, hm⟩ := Matrix.exists_entry_ne_zero_of_ne_zero _ (hR s)
+  apply EtaStructure.sectorProjection_mul_mul_sectorProjection_eq_zero_of_block hη
+  rintro ⟨aL, aR⟩ ⟨bL, bR⟩
+  have hkey := isMPOBlockLeftInverse_bnt_markov_key_formula hC hρ hη
+    (⟨s, α₁, β⟩) (⟨s, α, β₃⟩) k k aL aR bL bR
+  simp only [dite_true, hk, Complex.ofReal_zero, zero_mul] at hkey
+  exact (mul_eq_zero.mp hkey.symm).resolve_left hm
+
+/-- An inactive Hayashi projection annihilates every physical slice on the
+left. -/
+theorem sectorProjection_mul_physicalSlice_eq_zero_of_probability_eq_zero
+    {K : (s : Fin g) → MPOTensor d (dim s)}
+    {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse K C)
+    (hρ : IsThreeSiteFamilyClosure K R ρ) (hη : EtaStructure ρ)
+    (hR : ∀ s : Fin g, R s ≠ 0) (s : Fin g)
+    (β α : Fin (dim s)) (k : Fin hη.m) (hk : hη.p k = 0) :
+    hη.sectorProjection k * physicalSlice (K s) β α = 0 := by
+  calc
+    hη.sectorProjection k * physicalSlice (K s) β α =
+        hη.sectorProjection k * physicalSlice (K s) β α * 1 := by simp
+    _ = hη.sectorProjection k * physicalSlice (K s) β α *
+        (∑ l : Fin hη.m, hη.sectorProjection l) := by
+      rw [hη.sum_sectorProjection]
+    _ = ∑ l : Fin hη.m,
+        hη.sectorProjection k * physicalSlice (K s) β α *
+          hη.sectorProjection l := by rw [Finset.mul_sum]
+    _ = 0 := by
+      apply Finset.sum_eq_zero
+      intro l _
+      by_cases hkl : k = l
+      · subst l
+        exact sectorProjection_mul_physicalSlice_mul_self_eq_zero_of_probability_eq_zero
+          hC hρ hη hR s β α k hk
+      · exact sectorProjection_mul_physicalSlice_mul_sectorProjection_eq_zero_of_ne
+          hC hρ hη hR s β α hkl
+
+/-- An active Hayashi projection assigned to another normal sector
+annihilates the physical slice on the left. -/
+theorem sectorProjection_mul_physicalSlice_eq_zero_of_ne_label
+    {K : (s : Fin g) → MPOTensor d (dim s)}
+    {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse K C)
+    (hρ : IsThreeSiteFamilyClosure K R ρ) (hη : EtaStructure ρ)
+    (hR : ∀ s : Fin g, R s ≠ 0)
+    (k : {k : Fin hη.m // hη.p k ≠ 0}) (s : Fin g)
+    (hs : s ≠ bntSectorLabel hC hρ hη hR k)
+    (β α : Fin (dim s)) :
+    hη.sectorProjection k * physicalSlice (K s) β α = 0 := by
+  calc
+    hη.sectorProjection k * physicalSlice (K s) β α =
+        hη.sectorProjection k * physicalSlice (K s) β α * 1 := by simp
+    _ = hη.sectorProjection k * physicalSlice (K s) β α *
+        (∑ l : Fin hη.m, hη.sectorProjection l) := by
+      rw [hη.sum_sectorProjection]
+    _ = ∑ l : Fin hη.m,
+        hη.sectorProjection k * physicalSlice (K s) β α *
+          hη.sectorProjection l := by rw [Finset.mul_sum]
+    _ = 0 := by
+      apply Finset.sum_eq_zero
+      intro l _
+      by_cases hkl : (k : Fin hη.m) = l
+      · subst l
+        exact sectorProjection_mul_physicalSlice_mul_self_eq_zero_of_ne_label
+          hC hρ hη hR k s hs β α
+      · exact sectorProjection_mul_physicalSlice_mul_sectorProjection_eq_zero_of_ne
+          hC hρ hη hR s β α hkl
+
+/-- An inactive Hayashi projection annihilates every physical slice on the
+right. -/
+theorem physicalSlice_mul_sectorProjection_eq_zero_of_probability_eq_zero
+    {K : (s : Fin g) → MPOTensor d (dim s)}
+    {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse K C)
+    (hρ : IsThreeSiteFamilyClosure K R ρ) (hη : EtaStructure ρ)
+    (hR : ∀ s : Fin g, R s ≠ 0) (s : Fin g)
+    (β α : Fin (dim s)) (k : Fin hη.m) (hk : hη.p k = 0) :
+    physicalSlice (K s) β α * hη.sectorProjection k = 0 := by
+  calc
+    physicalSlice (K s) β α * hη.sectorProjection k =
+        1 * physicalSlice (K s) β α * hη.sectorProjection k := by simp
+    _ = (∑ l : Fin hη.m, hη.sectorProjection l) *
+        physicalSlice (K s) β α * hη.sectorProjection k := by
+      rw [hη.sum_sectorProjection]
+    _ = ∑ l : Fin hη.m,
+        hη.sectorProjection l * physicalSlice (K s) β α *
+          hη.sectorProjection k := by rw [Finset.sum_mul, Finset.sum_mul]
+    _ = 0 := by
+      apply Finset.sum_eq_zero
+      intro l _
+      by_cases hlk : l = k
+      · subst l
+        exact sectorProjection_mul_physicalSlice_mul_self_eq_zero_of_probability_eq_zero
+          hC hρ hη hR s β α k hk
+      · exact sectorProjection_mul_physicalSlice_mul_sectorProjection_eq_zero_of_ne
+          hC hρ hη hR s β α hlk
+
+/-- An active Hayashi projection assigned to another normal sector
+annihilates the physical slice on the right. -/
+theorem physicalSlice_mul_sectorProjection_eq_zero_of_ne_label
+    {K : (s : Fin g) → MPOTensor d (dim s)}
+    {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse K C)
+    (hρ : IsThreeSiteFamilyClosure K R ρ) (hη : EtaStructure ρ)
+    (hR : ∀ s : Fin g, R s ≠ 0)
+    (k : {k : Fin hη.m // hη.p k ≠ 0}) (s : Fin g)
+    (hs : s ≠ bntSectorLabel hC hρ hη hR k)
+    (β α : Fin (dim s)) :
+    physicalSlice (K s) β α * hη.sectorProjection k = 0 := by
+  calc
+    physicalSlice (K s) β α * hη.sectorProjection k =
+        1 * physicalSlice (K s) β α * hη.sectorProjection k := by simp
+    _ = (∑ l : Fin hη.m, hη.sectorProjection l) *
+        physicalSlice (K s) β α * hη.sectorProjection k := by
+      rw [hη.sum_sectorProjection]
+    _ = ∑ l : Fin hη.m,
+        hη.sectorProjection l * physicalSlice (K s) β α *
+          hη.sectorProjection k := by rw [Finset.sum_mul, Finset.sum_mul]
+    _ = 0 := by
+      apply Finset.sum_eq_zero
+      intro l _
+      by_cases hlk : l = (k : Fin hη.m)
+      · subst l
+        exact sectorProjection_mul_physicalSlice_mul_self_eq_zero_of_ne_label
+          hC hρ hη hR k s hs β α
+      · exact sectorProjection_mul_physicalSlice_mul_sectorProjection_eq_zero_of_ne
+          hC hρ hη hR s β α hlk
+
+/-- The BNT projector labelled by `s` acts as the identity on the left of
+the physical slice of representative `s`. -/
+theorem bntSectorProjection_mul_physicalSlice_self
+    {K : (s : Fin g) → MPOTensor d (dim s)}
+    {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse K C)
+    (hρ : IsThreeSiteFamilyClosure K R ρ) (hη : EtaStructure ρ)
+    (hR : ∀ s : Fin g, R s ≠ 0) (s : Fin g)
+    (β α : Fin (dim s)) :
+    bntSectorProjection hC hρ hη hR s * physicalSlice (K s) β α =
+      physicalSlice (K s) β α := by
+  classical
+  have hinactive :
+      (∑ k : {k : Fin hη.m // ¬ hη.p k ≠ 0},
+        hη.sectorProjection k * physicalSlice (K s) β α) = 0 := by
+    apply Finset.sum_eq_zero
+    intro k _
+    exact sectorProjection_mul_physicalSlice_eq_zero_of_probability_eq_zero
+      hC hρ hη hR s β α k (not_ne_iff.mp k.property)
+  have hactive :
+      (∑ k : {k : Fin hη.m // hη.p k ≠ 0},
+        hη.sectorProjection k * physicalSlice (K s) β α) =
+          physicalSlice (K s) β α := by
+    have hsplit := Fintype.sum_subtype_add_sum_subtype
+      (p := fun k : Fin hη.m ↦ hη.p k ≠ 0)
+      (fun k ↦ hη.sectorProjection k * physicalSlice (K s) β α)
+    rw [hinactive, add_zero] at hsplit
+    calc
+      _ = ∑ k : Fin hη.m,
+          hη.sectorProjection k * physicalSlice (K s) β α := hsplit
+      _ = (∑ k : Fin hη.m, hη.sectorProjection k) *
+          physicalSlice (K s) β α := by rw [Finset.sum_mul]
+      _ = _ := by rw [hη.sum_sectorProjection, Matrix.one_mul]
+  rw [bntSectorProjection, Finset.sum_mul]
+  calc
+    (∑ k : {k : Fin hη.m // hη.p k ≠ 0},
+      (if bntSectorLabel hC hρ hη hR k = s then
+        hη.sectorProjection k else 0) * physicalSlice (K s) β α) =
+        ∑ k : {k : Fin hη.m // hη.p k ≠ 0},
+          hη.sectorProjection k * physicalSlice (K s) β α := by
+      apply Finset.sum_congr rfl
+      intro k _
+      by_cases hk : bntSectorLabel hC hρ hη hR k = s
+      · simp [hk]
+      · rw [if_neg hk, Matrix.zero_mul]
+        symm
+        exact sectorProjection_mul_physicalSlice_eq_zero_of_ne_label
+          hC hρ hη hR k s (Ne.symm hk) β α
+    _ = _ := hactive
+
+/-- The BNT projector labelled by `s` acts as the identity on the right of
+the physical slice of representative `s`. -/
+theorem physicalSlice_mul_bntSectorProjection_self
+    {K : (s : Fin g) → MPOTensor d (dim s)}
+    {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse K C)
+    (hρ : IsThreeSiteFamilyClosure K R ρ) (hη : EtaStructure ρ)
+    (hR : ∀ s : Fin g, R s ≠ 0) (s : Fin g)
+    (β α : Fin (dim s)) :
+    physicalSlice (K s) β α * bntSectorProjection hC hρ hη hR s =
+      physicalSlice (K s) β α := by
+  classical
+  have hinactive :
+      (∑ k : {k : Fin hη.m // ¬ hη.p k ≠ 0},
+        physicalSlice (K s) β α * hη.sectorProjection k) = 0 := by
+    apply Finset.sum_eq_zero
+    intro k _
+    exact physicalSlice_mul_sectorProjection_eq_zero_of_probability_eq_zero
+      hC hρ hη hR s β α k (not_ne_iff.mp k.property)
+  have hactive :
+      (∑ k : {k : Fin hη.m // hη.p k ≠ 0},
+        physicalSlice (K s) β α * hη.sectorProjection k) =
+          physicalSlice (K s) β α := by
+    have hsplit := Fintype.sum_subtype_add_sum_subtype
+      (p := fun k : Fin hη.m ↦ hη.p k ≠ 0)
+      (fun k ↦ physicalSlice (K s) β α * hη.sectorProjection k)
+    rw [hinactive, add_zero] at hsplit
+    calc
+      _ = ∑ k : Fin hη.m,
+          physicalSlice (K s) β α * hη.sectorProjection k := hsplit
+      _ = physicalSlice (K s) β α *
+          (∑ k : Fin hη.m, hη.sectorProjection k) := by rw [Finset.mul_sum]
+      _ = _ := by rw [hη.sum_sectorProjection, Matrix.mul_one]
+  rw [bntSectorProjection, Finset.mul_sum]
+  calc
+    (∑ k : {k : Fin hη.m // hη.p k ≠ 0},
+      physicalSlice (K s) β α *
+        (if bntSectorLabel hC hρ hη hR k = s then
+          hη.sectorProjection k else 0)) =
+        ∑ k : {k : Fin hη.m // hη.p k ≠ 0},
+          physicalSlice (K s) β α * hη.sectorProjection k := by
+      apply Finset.sum_congr rfl
+      intro k _
+      by_cases hk : bntSectorLabel hC hρ hη hR k = s
+      · simp [hk]
+      · rw [if_neg hk, Matrix.mul_zero]
+        symm
+        exact physicalSlice_mul_sectorProjection_eq_zero_of_ne_label
+          hC hρ hη hR k s (Ne.symm hk) β α
+    _ = _ := hactive
+
+/-- The physical slice of a normal representative is supported exactly in
+its matching BNT physical sector.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `PjKiPj` and
+`generateMPDO`, lines 1680--1755. -/
+theorem bntSectorProjection_mul_physicalSlice_mul_self
+    {K : (s : Fin g) → MPOTensor d (dim s)}
+    {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse K C)
+    (hρ : IsThreeSiteFamilyClosure K R ρ) (hη : EtaStructure ρ)
+    (hR : ∀ s : Fin g, R s ≠ 0) (s : Fin g)
+    (β α : Fin (dim s)) :
+    bntSectorProjection hC hρ hη hR s * physicalSlice (K s) β α *
+        bntSectorProjection hC hρ hη hR s = physicalSlice (K s) β α := by
+  rw [bntSectorProjection_mul_physicalSlice_self hC hρ hη hR,
+    physicalSlice_mul_bntSectorProjection_self hC hρ hη hR]
+
+/-- The BNT-labelled physical projectors select the matching normal sector:
+the corner `P_s K_i P_t` vanishes if `s ≠ t` or `i ≠ s`.
+
+**Scope restriction (closing matrices):** the generic statement retains the
+nonzero-closing hypothesis used in the cancellation argument.  The source
+specialization derives it in `BNTThreeSiteReducedClosure.lean`.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `PjKiPj`, lines 1680--1742. -/
+theorem bntSectorProjection_mul_physicalSlice_mul_eq_zero
+    {K : (s : Fin g) → MPOTensor d (dim s)}
+    {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse K C)
+    (hρ : IsThreeSiteFamilyClosure K R ρ) (hη : EtaStructure ρ)
+    (hR : ∀ s : Fin g, R s ≠ 0) (i s t : Fin g)
+    (hst : s ≠ t ∨ i ≠ s) (β α : Fin (dim i)) :
+    bntSectorProjection hC hρ hη hR s * physicalSlice (K i) β α *
+        bntSectorProjection hC hρ hη hR t = 0 := by
+  classical
+  rw [bntSectorProjection, bntSectorProjection, Finset.sum_mul,
+    Finset.sum_mul]
+  apply Finset.sum_eq_zero
+  intro k _
+  rw [Finset.mul_sum]
+  apply Finset.sum_eq_zero
+  intro l _
+  by_cases hks : bntSectorLabel hC hρ hη hR k = s
+  · by_cases hlt : bntSectorLabel hC hρ hη hR l = t
+    · simp only [hks, hlt, if_pos]
+      by_cases hkl : (k : Fin hη.m) = l
+      · have hsub : k = l := Subtype.ext hkl
+        subst l
+        rcases hst with hst | his
+        · exact False.elim (hst (hks.symm.trans hlt))
+        · apply sectorProjection_mul_physicalSlice_mul_self_eq_zero_of_ne_label
+            hC hρ hη hR k i
+          exact fun hi ↦ his (hi.trans hks)
+      · exact sectorProjection_mul_physicalSlice_mul_sectorProjection_eq_zero_of_ne
+          hC hρ hη hR i β α hkl
+    · simp [hlt]
+  · simp [hks]
+
+/-- Changing the physical basis of representative `i` by the BNT projector
+`P_s` retains that representative exactly when `s = i` and otherwise gives
+the zero tensor.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `PjKiPj` and
+`generateMPDO`, lines 1680--1755. -/
+theorem changePhysicalBasis_bntSectorProjection_basis
+    {K : (s : Fin g) → MPOTensor d (dim s)}
+    {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse K C)
+    (hρ : IsThreeSiteFamilyClosure K R ρ) (hη : EtaStructure ρ)
+    (hR : ∀ s : Fin g, R s ≠ 0) (i s : Fin g) :
+    changePhysicalBasis (bntSectorProjection hC hρ hη hR s) (K i) =
+      if s = i then K i else 0 := by
+  classical
+  let P := bntSectorProjection hC hρ hη hR s
+  have hP : IsOrthogonalProjection P :=
+    bntSectorProjection_isOrthogonal hC hρ hη hR s
+  ext a b β α
+  simp only [changePhysicalBasis]
+  rw [hP.1.eq]
+  by_cases hsi : s = i
+  · subst s
+    rw [if_pos rfl]
+    exact Matrix.ext_iff.mpr
+      (bntSectorProjection_mul_physicalSlice_mul_self
+        hC hρ hη hR i β α) a b
+  · rw [if_neg hsi]
+    have hzero := bntSectorProjection_mul_physicalSlice_mul_eq_zero
+      hC hρ hη hR i s s (Or.inr fun his ↦ hsi his.symm) β α
+    exact Matrix.ext_iff.mpr hzero a b
+
+/-- The MPO of the zero local tensor vanishes at every positive chain
+length.  The positive-length condition is essential: the empty virtual word
+is the identity matrix and retains the bond dimension under the trace. -/
+theorem mpo_zero_of_pos {D : ℕ} {N : ℕ} (hN : 0 < N) :
+    mpo (0 : MPOTensor d D) N = 0 := by
+  obtain ⟨n, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (Nat.ne_of_gt hN)
+  ext u v
+  obtain ⟨a, u', rfl⟩ : ∃ a u', u = Fin.cons a u' :=
+    ⟨u 0, u ∘ Fin.succ, (Fin.cons_self_tail u).symm⟩
+  obtain ⟨b, v', rfl⟩ : ∃ b v', v = Fin.cons b v' :=
+    ⟨v 0, v ∘ Fin.succ, (Fin.cons_self_tail v).symm⟩
+  rw [mpo_cons_cons]
+  simp
+
+/-- Sitewise compression of a BNT representative by `P_s` retains precisely
+the matching representative.
+
+The condition `0 < N` excludes the empty word, which is not a physical chain
+in the source and whose closed virtual trace records the bond dimension.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `sigmaNKj`, lines 1756--1759. -/
+theorem singleKrausMap_sitewise_bntSectorProjection_mpo_basis
+    {K : (s : Fin g) → MPOTensor d (dim s)}
+    {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse K C)
+    (hρ : IsThreeSiteFamilyClosure K R ρ) (hη : EtaStructure ρ)
+    (hR : ∀ s : Fin g, R s ≠ 0) {N : ℕ} (hN : 0 < N)
+    (i s : Fin g) :
+    singleKrausMap
+        (sitewisePhysicalMatrix (bntSectorProjection hC hρ hη hR s) N)
+        (mpo (K i) N) =
+      if s = i then mpo (K i) N else 0 := by
+  rw [singleKrausMap_sitewisePhysicalMatrix_mpo,
+    changePhysicalBasis_bntSectorProjection_basis hC hρ hη hR]
+  by_cases hsi : s = i
+  · simp [hsi]
+  · simp [hsi, mpo_zero_of_pos hN]
+
+/-- The MPO representative obtained by absorbing the common copy weight into
+the BNT representative.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `CFK`, lines 1660--1665. -/
+noncomputable def commonWeightAbsorbedBasisMPOTensor
+    (S : MPSTensor.SectorDecomposition (d * d))
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q') (j : Fin S.basisCount) :
+    MPOTensor d (S.basisDim j) :=
+  fun a b => S.commonWeight hWeight j • S.basisMPOTensor j a b
+
+/-- Returning the absorbed-weight MPO representative to doubled-index MPS
+coordinates gives the absorbed representative defined in
+`CommonWeightAbsorption.lean`. -/
+@[simp] theorem commonWeightAbsorbedBasisMPOTensor_toMPSTensor
+    (S : MPSTensor.SectorDecomposition (d * d))
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q') (j : Fin S.basisCount) :
+    (commonWeightAbsorbedBasisMPOTensor S hWeight j).toMPSTensor =
+      S.commonWeightAbsorbedBasis hWeight j := by
+  funext ab
+  change S.commonWeight hWeight j •
+      S.basis j (finProdFinEquiv (ab.divNat, ab.modNat)) =
+    S.commonWeight hWeight j • S.basis j ab
+  exact congrArg (fun x => S.commonWeight hWeight j • S.basis j x)
+    (finProdFinEquiv.apply_symm_apply ab)
+
+/-- Absorbing the common weight scales the length-`N` MPO by its `N`-th
+power. -/
+theorem mpo_commonWeightAbsorbedBasisMPOTensor
+    (S : MPSTensor.SectorDecomposition (d * d))
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q') (j : Fin S.basisCount)
+    {N : ℕ} (u v : Fin N → Fin d) :
+    mpo (commonWeightAbsorbedBasisMPOTensor S hWeight j) N u v =
+      (S.commonWeight hWeight j) ^ N * mpo (S.basisMPOTensor j) N u v := by
+  rw [← MPSTensor.mpv_toMPSTensor_pairConfig,
+    commonWeightAbsorbedBasisMPOTensor_toMPSTensor]
+  change MPSTensor.mpv
+      (fun i => S.commonWeight hWeight j • S.basis j i)
+      (fun n => finProdFinEquiv (u n, v n)) = _
+  rw [MPSTensor.mpv_smul, ← MPSTensor.mpv_toMPSTensor_pairConfig,
+    S.basisMPOTensor_toMPSTensor]
+
+/-- Compressing the full MPO by the sitewise BNT projection selects the
+matching absorbed-weight representative with its natural copy multiplicity.
+
+This is the generic form with the closing matrices and simultaneous inverse
+displayed explicitly.  The source specialization below derives these data
+from common blocking and SAL.
+
+The condition `0 < N` is the physical-chain convention of the source.  At
+`N = 0`, a closed empty virtual word records the bond dimension, so the
+displayed sector-selection identity is not asserted.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `sigmaNKj`, lines 1756--1759. -/
+theorem singleKrausMap_sitewise_bntSectorProjection_mpo
+    {D : ℕ} (M : MPOTensor d D)
+    (S : MPSTensor.SectorDecomposition (d * d))
+    (hM : MPSTensor.SameMPV₂ M.toMPSTensor S.toTensor)
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q')
+    {R : (s : Fin S.basisCount) →
+      Matrix (Fin (S.basisDim s)) (Fin (S.basisDim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex S.basisDim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse
+      (fun j ↦ S.basisMPOTensor j) C)
+    (hρ : IsThreeSiteFamilyClosure (fun j ↦ S.basisMPOTensor j) R ρ)
+    (hη : EtaStructure ρ) (hR : ∀ s : Fin S.basisCount, R s ≠ 0)
+    {N : ℕ} (hN : 0 < N) (s : Fin S.basisCount) :
+    singleKrausMap
+        (sitewisePhysicalMatrix (bntSectorProjection hC hρ hη hR s) N)
+        (mpo M N) =
+      (S.copies s : ℂ) •
+        mpo (commonWeightAbsorbedBasisMPOTensor S hWeight s) N := by
+  classical
+  have hmpo : mpo M N = ∑ j : Fin S.basisCount,
+      S.coeff N j • mpo (S.basisMPOTensor j) N := by
+    ext u v
+    rw [Matrix.sum_apply]
+    simp only [Matrix.smul_apply, smul_eq_mul]
+    exact S.mpo_eq_sum_coeff_basisMPOTensor M hM u v
+  rw [hmpo, map_sum]
+  simp_rw [map_smul]
+  simp_rw [singleKrausMap_sitewise_bntSectorProjection_mpo_basis
+    hC hρ hη hR hN]
+  rw [Finset.sum_eq_single s]
+  · simp only [if_true]
+    ext u v
+    simp only [Matrix.smul_apply, smul_eq_mul]
+    rw [S.coeff_eq_copies_mul_commonWeight_pow hWeight,
+      mpo_commonWeightAbsorbedBasisMPOTensor]
+    ring
+  · intro t _ hts
+    simp [Ne.symm hts]
+  · simp
+
+/-- The literal tensor-power form of `sigmaNKj`:
+\[
+  P_s^{\otimes N}\,\rho^{(N)}(M)\,P_s^{\otimes N}
+  =r_s\,\rho^{(N)}(\mathcal K_s).
+\]
+
+The right-hand projector is not written with an adjoint because an
+orthogonal one-site projection has a Hermitian sitewise tensor power.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `sigmaNKj`, lines 1756--1759. -/
+theorem sitewise_bntSectorProjection_mul_mpo_mul_self
+    {D : ℕ} (M : MPOTensor d D)
+    (S : MPSTensor.SectorDecomposition (d * d))
+    (hM : MPSTensor.SameMPV₂ M.toMPSTensor S.toTensor)
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q')
+    {R : (s : Fin S.basisCount) →
+      Matrix (Fin (S.basisDim s)) (Fin (S.basisDim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex S.basisDim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse
+      (fun j ↦ S.basisMPOTensor j) C)
+    (hρ : IsThreeSiteFamilyClosure (fun j ↦ S.basisMPOTensor j) R ρ)
+    (hη : EtaStructure ρ) (hR : ∀ s : Fin S.basisCount, R s ≠ 0)
+    {N : ℕ} (hN : 0 < N) (s : Fin S.basisCount) :
+    let P := sitewisePhysicalMatrix
+      (bntSectorProjection hC hρ hη hR s) N
+    P * mpo M N * P =
+      (S.copies s : ℂ) •
+        mpo (commonWeightAbsorbedBasisMPOTensor S hWeight s) N := by
+  dsimp only
+  let P := sitewisePhysicalMatrix
+    (bntSectorProjection hC hρ hη hR s) N
+  have hP : P.IsHermitian := sitewisePhysicalMatrix_isHermitian
+    (bntSectorProjection_isOrthogonal hC hρ hη hR s).1 N
+  calc
+    P * mpo M N * P = singleKrausMap P (mpo M N) := by
+      rw [singleKrausMap_apply, hP.eq]
+    _ = _ := singleKrausMap_sitewise_bntSectorProjection_mpo
+      M S hM hWeight hC hρ hη hR hN s
+
+/-- For the normalized four-site SAL marginal, the source BNT projectors obey
+the local selection rule `P_s K_i P_t = 0` unless `s = t = i`, and their
+sitewise tensor powers select the corresponding absorbed-weight MPO at every
+positive chain length:
+\[
+  P_s^{\otimes N}\,\rho^{(N)}(M)\,P_s^{\otimes N}
+  =r_s\,\rho^{(N)}(\mathcal K_s).
+\]
+
+There is no independent nonzero-closing-matrix hypothesis.  The normalized
+four-site BNT closure supplies it from SAL, copy independence, and
+nonnilpotence.
+
+**Axiom boundary:** the Hayashi decomposition uses the existing forward
+Hayashi--Ruskai--Hayden--Jozsa--Petz--Winter characterization of equality in
+strong subadditivity, isolated as
+`hayashi_ssa_equality_characterization_forward`.  No further axiom is used.
+
+**Scope restriction (blocked tensor):** the simultaneous inverse is used after
+the source's common blocking, expressed here by the one-letter simultaneous
+span.  The passage to this blocked form is recorded in
+`docs/paper-gaps/cpgsv17_bicf_block_separation.tex`.
+
+The tensor-power conclusion assumes `0 < N`.  This is the physical-chain
+convention in the source; an empty virtual word instead records the bond
+dimension.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `PjKiPj`, `generateMPDO`,
+and `sigmaNKj`, lines 1680--1759. -/
+theorem exists_bntProjectorSelection_positiveLength_of_sameMPV₂_isSAL
+    {D : ℕ} (M : MPOTensor d D)
+    (S : MPSTensor.SectorDecomposition (d * d))
+    (hM : MPSTensor.SameMPV₂ M.toMPSTensor S.toTensor)
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q')
+    (hnonNil : ∀ j,
+      ¬ IsNilpotent (doubledPhysTraceTransfer d (S.basis j)))
+    (hSpan : MPSTensor.WordTupleSpanTop S.basis 1)
+    (hSAL : IsSAL M) :
+    let ρ := Matrix.reindex (_root_.finThreeArrowEquiv (Fin d))
+      (_root_.finThreeArrowEquiv (Fin d))
+      (M.reducedBlockState 4 3 (by omega))
+    ∃ (C : Matrix (MPSTensor.BlockEntryIndex S.basisDim)
+        (Fin d × Fin d) ℂ),
+      ∃ hC : MPSTensor.IsMPOBlockLeftInverse
+          (fun j ↦ S.basisMPOTensor j) C,
+        ∃ hη : EtaStructure ρ,
+          let hρ : IsThreeSiteFamilyClosure
+              (fun j ↦ S.basisMPOTensor j)
+              (S.normalizedThreeSiteClosingMatrix M 1) ρ :=
+            (reducedBlockState_four_threeSiteFamilyClosure_nonzero_closing
+              M S hM hWeight hnonNil hSAL).1
+          let hR : ∀ j : Fin S.basisCount,
+              S.normalizedThreeSiteClosingMatrix M 1 j ≠ 0 :=
+            (reducedBlockState_four_threeSiteFamilyClosure_nonzero_closing
+              M S hM hWeight hnonNil hSAL).2
+          (∀ (i s t : Fin S.basisCount), s ≠ t ∨ i ≠ s →
+              ∀ (β α : Fin (S.basisDim i)),
+                bntSectorProjection hC hρ hη hR s *
+                    physicalSlice (S.basisMPOTensor i) β α *
+                    bntSectorProjection hC hρ hη hR t = 0) ∧
+            (∀ (N : ℕ), 0 < N → ∀ s : Fin S.basisCount,
+              let P := sitewisePhysicalMatrix
+                (bntSectorProjection hC hρ hη hR s) N
+              P * mpo M N * P =
+                (S.copies s : ℂ) •
+                  mpo (commonWeightAbsorbedBasisMPOTensor S hWeight s) N) := by
+  dsimp only
+  obtain ⟨C, hC, hη, _hunique, _hproj, _horth, _hsum⟩ :=
+    exists_bntSectorProjectors_four_of_sameMPV₂_isSAL
+      M S hM hWeight hnonNil hSpan hSAL
+  let hClosure :=
+    reducedBlockState_four_threeSiteFamilyClosure_nonzero_closing
+      M S hM hWeight hnonNil hSAL
+  let hρ := hClosure.1
+  let hR := hClosure.2
+  refine ⟨C, hC, hη, ?_, ?_⟩
+  · intro i s t hst β α
+    exact bntSectorProjection_mul_physicalSlice_mul_eq_zero
+      hC hρ hη hR i s t hst β α
+  · intro N hN s
+    exact sitewise_bntSectorProjection_mul_mpo_mul_self
+      M S hM hWeight hC hρ hη hR hN s
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/HayashiSectorProjector.lean
+++ b/TNLean/MPS/MPDO/HayashiSectorProjector.lean
@@ -184,4 +184,41 @@ theorem sectorProjection_mul_eq_zero (hη : EtaStructure rho)
     hη.sectorProjection hη.sectorProjection_isOrthogonal
     hη.sum_sectorProjection hkl
 
+/-- If the block of an operator from Hayashi sector `k` to sector `l`
+vanishes in the decomposition coordinates, then its compression by the
+corresponding physical projections is zero.
+
+This is the projection-algebra passage used for equations `Qks` and
+`PjKiPj` in arXiv:1606.00608, Appendix C.2, lines 1698--1742. -/
+theorem sectorProjection_mul_mul_sectorProjection_eq_zero_of_block
+    (hη : EtaStructure rho) (X : Matrix (Fin d) (Fin d) ℂ)
+    (k l : Fin hη.m)
+    (hblock : ∀ (a : Fin (hη.dL k) × Fin (hη.dR k))
+        (b : Fin (hη.dL l) × Fin (hη.dR l)),
+      Matrix.reindex hη.decompB hη.decompB
+          ((hη.U_B : Matrix (Fin d) (Fin d) ℂ) * X *
+            (hη.U_B : Matrix (Fin d) (Fin d) ℂ)ᴴ)
+          ⟨k, a⟩ ⟨l, b⟩ = 0) :
+    hη.sectorProjection k * X * hη.sectorProjection l = 0 := by
+  classical
+  let U : Matrix (Fin d) (Fin d) ℂ := hη.U_B
+  let E (q : Fin hη.m) := basisSectorProjection hη q
+  have hcoord : E k * (U * X * Uᴴ) * E l = 0 := by
+    apply (Matrix.reindexLinearEquiv (R := ℂ) (A := ℂ)
+      hη.decompB hη.decompB).injective
+    rw [map_zero, ← Matrix.reindexLinearEquiv_mul ℂ ℂ
+      hη.decompB hη.decompB hη.decompB,
+      ← Matrix.reindexLinearEquiv_mul ℂ ℂ
+        hη.decompB hη.decompB hη.decompB]
+    simpa [E, basisSectorProjection, coordinateSectorProjection,
+      Matrix.reindex_apply] using
+      (Matrix.blockProjection_mul_mul_blockProjection_eq_zero
+        (Matrix.reindex hη.decompB hη.decompB (U * X * Uᴴ)) k l hblock)
+  change (Uᴴ * E k * U) * X * (Uᴴ * E l * U) = 0
+  calc
+    (Uᴴ * E k * U) * X * (Uᴴ * E l * U) =
+        Uᴴ * (E k * (U * X * Uᴴ) * E l) * U := by
+      simp only [Matrix.mul_assoc]
+    _ = 0 := by rw [hcoord, Matrix.mul_zero, Matrix.zero_mul]
+
 end MPOTensor.EtaStructure

--- a/TNLean/MPS/MPDO/SitewisePhysicalMatrix.lean
+++ b/TNLean/MPS/MPDO/SitewisePhysicalMatrix.lean
@@ -1,0 +1,167 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalSectorCoordinateTransport
+
+/-!
+# Sitewise physical matrices on periodic MPOs
+
+A one-site matrix `V` acts on a chain by its sitewise tensor power.  Acting on
+both physical legs of a periodic MPO is the same as changing the physical
+basis of every local MPO matrix before closing the virtual trace.
+
+This is finite-dimensional tensor-product algebra.  The construction is used
+below with the BNT physical-sector projections of arXiv:1606.00608,
+Appendix C.2, equations `generateMPDO` and `sigmaNKj`.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPOTensor
+
+variable {d D e : ℕ}
+
+open PhysicalSectorFactorization
+
+/-- The sitewise tensor power of a one-site physical matrix, indexed by
+physical configurations rather than by nested tensor products. -/
+noncomputable def sitewisePhysicalMatrix
+    (V : Matrix (Fin e) (Fin d) ℂ) (N : ℕ) :
+    Matrix (Fin N → Fin e) (Fin N → Fin d) ℂ :=
+  fun s t ↦ ∏ n : Fin N, V (s n) (t n)
+
+private theorem list_prod_sum_ofFn {a n : Type*} [Fintype a]
+    [Fintype n] [DecidableEq n] {N : ℕ}
+    (f : (i : Fin N) → a → Matrix n n ℂ) :
+    (List.ofFn fun i : Fin N ↦ ∑ x : a, f i x).prod =
+      ∑ x : Fin N → a, (List.ofFn fun i : Fin N ↦ f i (x i)).prod := by
+  classical
+  induction N with
+  | zero => simp
+  | succ N ih =>
+      rw [List.ofFn_succ, List.prod_cons]
+      simp only [ih]
+      rw [Finset.sum_mul]
+      simp_rw [Finset.mul_sum]
+      have h := Fintype.sum_equiv
+        (Fin.consEquiv fun _ : Fin (N + 1) ↦ a)
+        (fun p : a × (Fin N → a) ↦
+          f 0 p.1 * (List.ofFn fun i : Fin N ↦ f i.succ (p.2 i)).prod)
+        (fun x : Fin (N + 1) → a ↦
+          (List.ofFn fun i : Fin (N + 1) ↦ f i (x i)).prod)
+        (fun p ↦ by simp [List.ofFn_succ])
+      rw [Fintype.sum_prod_type] at h
+      exact h
+
+private theorem list_prod_smul_ofFn {n : Type*} [Fintype n]
+    [DecidableEq n] {N : ℕ} (c : Fin N → ℂ)
+    (A : Fin N → Matrix n n ℂ) :
+    (List.ofFn fun i : Fin N ↦ c i • A i).prod =
+      (∏ i : Fin N, c i) • (List.ofFn A).prod := by
+  induction N with
+  | zero => simp
+  | succ N ih =>
+      simp only [List.ofFn_succ, List.prod_cons, ih, Fin.prod_univ_succ,
+        Matrix.smul_mul, Matrix.mul_smul, smul_smul]
+      rw [mul_comm (c 0)]
+
+private def braKetFunctionsEquiv {i a b : Type*} :
+    ((i → b) × (i → a)) ≃ (i → a × b) :=
+  (Equiv.prodComm _ _).trans
+    (Equiv.arrowProdEquivProdArrow i (fun _ ↦ a) (fun _ ↦ b)).symm
+
+/-- Word evaluation after a physical basis change, expanded over the original
+ket and bra configurations. -/
+theorem evalWord_changePhysicalBasis_ofFn
+    (V : Matrix (Fin e) (Fin d) ℂ) (M : MPOTensor d D) {N : ℕ}
+    (s t : Fin N → Fin e) :
+    evalWord (changePhysicalBasis V M) (List.ofFn s) (List.ofFn t) =
+      ∑ x : Fin N → Fin d × Fin d,
+        (∏ i : Fin N, V (s i) (x i).1 * star (V (t i) (x i).2)) •
+          evalWord M
+            (List.ofFn fun i : Fin N ↦ (x i).1)
+            (List.ofFn fun i : Fin N ↦ (x i).2) := by
+  rw [evalWord_ofFn]
+  simp_rw [changePhysicalBasis_apply_eq_sum]
+  rw [list_prod_sum_ofFn]
+  apply Finset.sum_congr rfl
+  intro x _
+  rw [list_prod_smul_ofFn, evalWord_ofFn]
+
+/-- Acting on every site by `V` sends the MPO of `M` to the MPO obtained by
+changing every local physical matrix by `V`.
+
+This is the configuration-index form of
+\((V^{\otimes N})\rho^{(N)}(M)(V^{\otimes N})^\dagger\).
+-/
+theorem singleKrausMap_sitewisePhysicalMatrix_mpo
+    (V : Matrix (Fin e) (Fin d) ℂ) (M : MPOTensor d D) (N : ℕ) :
+    singleKrausMap (sitewisePhysicalMatrix V N) (mpo M N) =
+      mpo (changePhysicalBasis V M) N := by
+  ext s t
+  simp only [singleKrausMap_apply, Matrix.mul_apply,
+    Matrix.conjTranspose_apply, sitewisePhysicalMatrix, mpo_apply,
+    mpoMatrixEntry, evalWord_changePhysicalBasis_ofFn, Matrix.trace_sum,
+    Matrix.trace_smul, smul_eq_mul, star_prod]
+  have hexpand :
+      (∑ q : Fin N → Fin d,
+        (∑ p : Fin N → Fin d,
+          (∏ i : Fin N, V (s i) (p i)) *
+            Matrix.trace (evalWord M (List.ofFn p) (List.ofFn q))) *
+          (∏ i : Fin N, star (V (t i) (q i)))) =
+        ∑ q : Fin N → Fin d, ∑ p : Fin N → Fin d,
+          ((∏ i : Fin N, V (s i) (p i)) *
+            Matrix.trace (evalWord M (List.ofFn p) (List.ofFn q))) *
+          (∏ i : Fin N, star (V (t i) (q i))) := by
+    apply Finset.sum_congr rfl
+    intro q _
+    simpa only using Finset.sum_mul Finset.univ
+      (fun p : Fin N → Fin d ↦
+        (∏ i : Fin N, V (s i) (p i)) *
+          Matrix.trace (evalWord M (List.ofFn p) (List.ofFn q)))
+      (∏ i : Fin N, star (V (t i) (q i)))
+  rw [hexpand]
+  have h := Fintype.sum_equiv
+    (braKetFunctionsEquiv (i := Fin N) (a := Fin d) (b := Fin d))
+    (fun p : (Fin N → Fin d) × (Fin N → Fin d) ↦
+      (∏ i : Fin N, V (s i) (p.2 i)) *
+        Matrix.trace (evalWord M (List.ofFn p.2) (List.ofFn p.1)) *
+        (∏ i : Fin N, star (V (t i) (p.1 i))))
+    (fun x : Fin N → Fin d × Fin d ↦
+      (∏ i : Fin N, V (s i) (x i).1 * star (V (t i) (x i).2)) *
+        Matrix.trace (evalWord M
+          (List.ofFn fun i : Fin N ↦ (x i).1)
+          (List.ofFn fun i : Fin N ↦ (x i).2)))
+    (fun p ↦ by
+      dsimp
+      change
+        (∏ i : Fin N, V (s i) (p.2 i)) *
+              Matrix.trace (evalWord M (List.ofFn p.2) (List.ofFn p.1)) *
+            (∏ i : Fin N, star (V (t i) (p.1 i))) =
+          (∏ i : Fin N,
+            V (s i) (p.2 i) * star (V (t i) (p.1 i))) *
+            Matrix.trace (evalWord M (List.ofFn p.2) (List.ofFn p.1))
+      have hprod :
+          (∏ i : Fin N,
+            V (s i) (p.2 i) * star (V (t i) (p.1 i))) =
+            (∏ i : Fin N, V (s i) (p.2 i)) *
+              (∏ i : Fin N, star (V (t i) (p.1 i))) := by
+        exact Finset.prod_mul_distrib
+      rw [hprod]
+      ring)
+  rw [Fintype.sum_prod_type] at h
+  exact h
+
+/-- The sitewise tensor power of a Hermitian one-site matrix is Hermitian. -/
+theorem sitewisePhysicalMatrix_isHermitian
+    {P : Matrix (Fin d) (Fin d) ℂ} (hP : P.IsHermitian) (N : ℕ) :
+    (sitewisePhysicalMatrix P N).IsHermitian := by
+  ext s t
+  simp only [Matrix.conjTranspose_apply, sitewisePhysicalMatrix, star_prod]
+  apply Finset.prod_congr rfl
+  intro n _
+  exact hP.apply (s n) (t n)
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
@@ -442,6 +442,92 @@ strong subadditivity for a normalized three-site reduced state.
     orthogonality, mutual disjointness, and resolution of the active support.
 \end{proof}
 
+\begin{definition}[Sitewise physical action and absorbed BNT representatives]
+    \label{def:mpdo_sitewise_physical_matrix}
+    \lean{MPOTensor.sitewisePhysicalMatrix}
+    \lean{MPOTensor.commonWeightAbsorbedBasisMPOTensor}
+    \leanok
+    For a one-site matrix $V$, write $V^{\otimes N}$ in the configuration
+    basis as
+    \[
+      (V^{\otimes N})_{s,t}=\prod_{n=1}^{N}V_{s_n,t_n}.
+    \]
+    If the copies of the $j$-th normal tensor have common coefficient
+    $\mu_j$, let $\mathcal K_j=\mu_j A_j$ denote the representative with this
+    coefficient absorbed into its local tensor.
+\end{definition}
+
+\begin{theorem}[Local selection by the BNT projectors]
+    \label{thm:mpdo_bnt_projector_local_selection}
+    \lean{MPOTensor.bntSectorProjection_mul_physicalSlice_mul_eq_zero}
+    \lean{MPOTensor.bntSectorProjection_mul_physicalSlice_mul_self}
+    \lean{MPOTensor.changePhysicalBasis_bntSectorProjection_basis}
+    \lean{MPOTensor.%
+      exists_bntProjectorSelection_positiveLength_of_sameMPV₂_isSAL}
+    \leanok
+    \uses{thm:mpdo_four_site_sal_bnt_sector_projectors}
+    Under the hypotheses of
+    Theorem~\ref{thm:mpdo_four_site_sal_bnt_sector_projectors}, the resulting
+    projectors satisfy $P_sA_iP_t=0$ whenever $s\ne t$ or $i\ne s$.
+    For the matching label, they satisfy
+    \[
+      P_iA_iP_i=A_i.
+    \]
+    Equivalently, compressing the physical legs of $A_i$ by $P_s$ retains
+    $A_i$ for $s=i$ and gives the zero local tensor otherwise.  This is
+    equations~\textup{PjKiPj} and~\textup{generateMPDO} in
+    \cite[Appendix~C.2, lines~1680--1755]{Cirac2016MPDO_arXiv}.
+
+    The Markov summands of zero Hayashi weight are retained in the ambient
+    decomposition.  They annihilate every normal-sector physical slice, so
+    the displayed local identities do not require the stronger assertion
+    $\sum_sP_s=\Id$ outside the active support.
+\end{theorem}
+
+\begin{proof}\leanok
+    Distinct Hayashi sectors give zero off-diagonal corners.  On an active
+    diagonal sector, uniqueness of the BNT label kills every normal tensor
+    except the matching one.  A zero-weight diagonal sector also kills every
+    physical slice: otherwise the nonzero closing matrix would make the
+    corresponding three-site Markov block nonzero.  Summing these statements
+    over the Hayashi sectors gives the asserted $P_sA_iP_t$ identities.
+\end{proof}
+
+\begin{theorem}[Positive-length BNT-sector compression]
+    \label{thm:mpdo_bnt_projector_positive_length_compression}
+    \lean{MPOTensor.singleKrausMap_sitewise_bntSectorProjection_mpo}
+    \lean{MPOTensor.sitewise_bntSectorProjection_mul_mpo_mul_self}
+    \lean{MPOTensor.%
+      exists_bntProjectorSelection_positiveLength_of_sameMPV₂_isSAL}
+    \leanok
+    \uses{def:mpdo_sitewise_physical_matrix,
+      thm:mpdo_bnt_projector_local_selection}
+    For every nonempty periodic chain and every normal-sector label $s$,
+    \[
+      P_s^{\otimes N}\,\sigma^{(N)}(K)\,P_s^{\otimes N}
+      =n_s\,\sigma^{(N)}(\mathcal K_s),
+      \qquad N\geq1,
+    \]
+    where $n_s$ is the number of BNT copies with label $s$.  This is
+    equation~\textup{sigmaNKj} in
+    \cite[Appendix~C.2, lines~1756--1759]{Cirac2016MPDO_arXiv}.
+
+    The restriction $N\geq1$ is intrinsic to this local selection statement.
+    At $N=0$, the empty virtual word is the identity and its closed trace
+    records the bond dimension; it is not a physical spin chain and need not
+    obey the displayed sector-selection identity.
+\end{theorem}
+
+\begin{proof}\leanok
+    Sitewise multiplication by $P_s$ is the periodic MPO obtained by changing
+    every local physical matrix by $P_s$.  The preceding theorem replaces
+    each normal representative by itself when its label is $s$ and by the
+    zero tensor otherwise.  For $N\geq1$, the latter has zero periodic MPO.
+    The surviving coefficient is
+    $n_s\mu_s^N$, which is precisely $n_s$ times the MPO of the representative
+    with $\mu_s$ absorbed locally.
+\end{proof}
+
 \begin{definition}[Injective inverse map for a simple MPO tensor]
     \label{def:mpdo_injective_inverse_layer}
     \lean{MPOTensor.IsInjective}

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -269,9 +269,34 @@ of Hayashi projections are orthogonal, mutually disjoint, and resolve the
 active Markov support.
 \footnote{The relevant declaration is
 \path{MPOTensor.exists_bntSectorProjectors_four_of_sameMPV₂_isSAL}.}
-No further closing-matrix assumption is needed for this specialization.  The
-remaining step for the source projector passage is the all-length
-$P_j$-compressed density-operator formula with the natural multiplicities.
+No further closing-matrix assumption is needed for this specialization.
+
+The remaining projector passage is now formalized as well.  For every physical
+slice of the $i$-th normal representative, $P_s A_i P_t=0$ unless $s=t=i$.
+For the matching label,
+\[
+  P_iA_iP_i=A_i.
+\]
+The zero-weight Markov summands retained by the formal decomposition annihilate
+all these physical slices, so this conclusion does not require replacing the
+active-support resolution by an ambient resolution of the identity.  Acting
+sitewise on every nonempty periodic chain then gives
+\[
+  P_s^{\otimes N}\sigma^{(N)}(K)P_s^{\otimes N}
+  =n_s\sigma^{(N)}(\mathcal K_s),
+  \qquad N\geq1,
+\]
+with the common copy weight absorbed into $\mathcal K_s$.
+\footnote{The relevant declarations are
+\path{MPOTensor.bntSectorProjection_mul_physicalSlice_mul_eq_zero},
+\path{MPOTensor.changePhysicalBasis_bntSectorProjection_basis},
+\path{MPOTensor.sitewise_bntSectorProjection_mul_mpo_mul_self}, and
+\path{MPOTensor.exists_bntProjectorSelection_positiveLength_of_sameMPV₂_isSAL}.}
+The empty-word value $N=0$ is excluded because its closed virtual trace records
+the bond dimension and is not a physical chain.  The next source step is to
+deduce positivity, SAL, and ZCL for each selected absorbed BNT representative,
+as required in the proof of Proposition~\texttt{prop2to3} after equation
+\texttt{sigmaNKj}.
 
 The neighboring operators are now assembled from these sector tensors.  The
 operator


### PR DESCRIPTION
## Summary

This proves the projector-selection passage in arXiv:1606.00608, Appendix C.2, in the paper's order:

- the local rule \(P_s A_i P_t=0\) unless \(s=t=i\), together with \(P_iA_iP_i=A_i\);
- the local identity used in equation `generateMPDO`;
- the positive-length compression formula
  \[
  P_s^{\otimes N}\sigma^{(N)}(K)P_s^{\otimes N}
  =n_s\sigma^{(N)}(\mathcal K_s),\qquad N\ge 1.
  \]

The proof retains the zero-weight Hayashi summands in the ambient decomposition and shows directly that they annihilate every BNT physical slice. It therefore needs only the already-proved resolution of the active Markov support, not an unsupported ambient identity \(\sum_s P_s=1\).

The sitewise action is expressed through the established `singleKrausMap` terminology. No `sandwichMap` terminology is introduced.

## Source scope

The source specialization assumes the common blocking explicitly through the one-letter simultaneous span. This restriction is recorded in `docs/paper-gaps/cpgsv17_bicf_block_separation.tex`.

The tensor-power statement is restricted to \(N>0\). At \(N=0\), the empty virtual word is the identity and its closed trace records the bond dimension; this is not a physical spin chain and the sector-selection formula need not hold.

The updated note `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex` identifies the next source step as positivity, SAL, and ZCL for each selected absorbed BNT representative.

## Proof integrity

No `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast` is introduced.

Kernel dependency audit:

- the new block-projection, local-selection, sitewise-action, and positive-length compression theorems use only `propext`, `Classical.choice`, and `Quot.sound`;
- the SAL specialization additionally inherits the existing `hayashi_ssa_equality_characterization_forward` boundary, which is stated in its docstring and in the blueprint;
- no new axiom is declared.

## Validation

- `lake -KmaxJobs=1 build`
- `lake exe checkdecls blueprint/lean_decls`
- blueprint/Lean synchronization
- reader-facing prose check
- oversized Lean file guard
- tensor-network diagram strict audit and smoke render
- `leanblueprint web`
- `leanblueprint pdf`, with the changed page inspected
- standalone gap-note PDF, with the changed page inspected

Closes #4086.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new formal theory on the MPDO/SAL track with a documented dependency on the existing Hayashi SSA forward axiom; no runtime or security surface, but mistakes here would affect downstream RFP proofs.
> 
> **Overview**
> Adds Lean proofs for the **Appendix C.2** projector-selection step: BNT-labelled projectors vanish on mismatched physical corners (**`P_s A_i P_t = 0`** unless **`s = t = i`**) and fix the matching slice (**`P_i A_i P_i = A_i`**), including treatment of zero-weight Hayashi summands without assuming ambient **`∑_s P_s = 1`**.
> 
> Introduces **`sitewisePhysicalMatrix`** and links sitewise **`P_s^{⊗ N}`** action to **`singleKrausMap`**, yielding **`σ^{(N)}`** compression by copy multiplicity and common-weight-absorbed representatives for **`N ≥ 1`** (explicitly excluding **`N = 0`**).
> 
> Refactors **`ScalarCommutant`** with reusable block-projection multiplication lemmas used by **`sectorProjection_mul_mul_sectorProjection_eq_zero_of_block`**. Wires new modules into **`TNLean.lean`**, extends the blueprint chapter, and updates the SAL/ZCL gap note to mark this passage done.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1c3501a1e05e4e01728aa04a3e6273fcd73ca66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->