### PR TITLE
fix(MPS/CanonicalForm): restrict phase equivalence to positive length

### DIFF
--- a/TNLean/MPS/CanonicalForm/NormalTensorGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalTensorGauge.lean
@@ -243,10 +243,10 @@ theorem MPVBlockPhaseEquiv.dim_eq_and_gaugePhaseEquiv_of_isNormalTensor
   have hPhase : MPVBlockPhaseEquiv X' Y' := by
     obtain ⟨ζ, hζ, hmpv⟩ := h
     refine ⟨ζ, hζ, ?_⟩
-    intro N w
+    intro N hN w
     calc
       mpv Y' w = mpv Y w := (GaugeEquiv.sameMPV hGaugeY N w).symm
-      _ = ζ ^ N * mpv X w := hmpv N w
+      _ = ζ ^ N * mpv X w := hmpv N hN w
       _ = ζ ^ N * mpv X' w := by rw [GaugeEquiv.sameMPV hGaugeX N w]
   have hSelf : Tendsto
       (fun N => mpvOverlap (d := d) X' X' N) atTop (nhds (1 : ℂ)) :=
@@ -263,16 +263,16 @@ theorem MPVBlockPhaseEquiv.dim_eq_and_gaugePhaseEquiv_of_isNormalTensor
       (fun N => ‖mpvOverlap (d := d) Y' Y' N‖) atTop (nhds (1 : ℝ)) := by
     simpa using hSelfY.norm
   have hζ : ‖hPhase.choose‖ = 1 :=
-    norm_eq_one_of_selfOverlap_scale hSelfNorm hSelfYNorm
-      (mpvOverlap_self_scale_of_mpv_eq_pow_mul hPhase.choose_spec.2)
-  have hCrossEq : ∀ N,
+    norm_eq_one_of_selfOverlap_scale_pos hSelfNorm hSelfYNorm
+      (mpvOverlap_self_scale_of_mpv_eq_pow_mul_pos hPhase.choose_spec.2)
+  have hCrossEq : ∀ N, 0 < N →
       mpvOverlap (d := d) X' Y' N =
         (star hPhase.choose) ^ N * mpvOverlap (d := d) X' X' N :=
-    mpvOverlap_eq_star_pow_mul_self_of_mpv_eq_pow_mul hPhase.choose_spec.2
-  have hCrossNormEq : ∀ N,
+    mpvOverlap_eq_star_pow_mul_self_of_mpv_eq_pow_mul_pos hPhase.choose_spec.2
+  have hCrossNormEq : ∀ N, 0 < N →
       ‖mpvOverlap (d := d) X' Y' N‖ = ‖mpvOverlap (d := d) X' X' N‖ := by
-    intro N
-    rw [hCrossEq N, norm_mul, norm_pow]
+    intro N hN
+    rw [hCrossEq N hN, norm_mul, norm_pow]
     calc
       ‖star hPhase.choose‖ ^ N * ‖mpvOverlap (d := d) X' X' N‖ =
           ‖hPhase.choose‖ ^ N * ‖mpvOverlap (d := d) X' X' N‖ := by
@@ -280,7 +280,9 @@ theorem MPVBlockPhaseEquiv.dim_eq_and_gaugePhaseEquiv_of_isNormalTensor
       _ = ‖mpvOverlap (d := d) X' X' N‖ := by rw [hζ, one_pow, one_mul]
   have hCrossNorm : Tendsto
       (fun N => ‖mpvOverlap (d := d) X' Y' N‖) atTop (nhds (1 : ℝ)) :=
-    hSelfNorm.congr fun N => (hCrossNormEq N).symm
+    hSelfNorm.congr' (by
+      filter_upwards [eventually_ge_atTop 1] with N hN
+      exact (hCrossNormEq N hN).symm)
   have hdim : DX = DY :=
     dim_eq_of_mpvOverlap_norm_tendsto_one_of_irreducible_TP
       X' Y' hIrrX hIrrY hTPX hTPY hCrossNorm

--- a/TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean
+++ b/TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean
@@ -59,25 +59,26 @@ noncomputable def collapsedBntSectorDecomp
     sectors := sectors
   }
 
-/-- The total tensor of `collapsedBntSectorDecomp` has the same MPV at every length
-as the original `toTensorFromBlocks μ blocks`.  Exposed (was previously `private`)
-for the prepared-block SectorBNT constructor. -/
-theorem collapsedBntSectorDecomp_sameMPV₂
+/-- The total tensor of `collapsedBntSectorDecomp` has the same MPV at every positive
+length as the original `toTensorFromBlocks μ blocks`.
+
+Source: CPSV16, Proposition `prop:char-BNT`, lines 1135–1148. -/
+theorem collapsedBntSectorDecomp_sameMPV₂Pos
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ)
     (blocks : (k : Fin r) → MPSTensor d (dim k))
     (hμne : ∀ k, μ k ≠ 0) :
-    SameMPV₂ (collapsedBntSectorDecomp (d := d) μ blocks hμne).toTensor
+    SameMPV₂Pos (collapsedBntSectorDecomp (d := d) μ blocks hμne).toTensor
       (toTensorFromBlocks (d := d) (μ := μ) blocks) := by
   classical
   let classes := mpvPhaseClassData blocks
   let ζFn : (j : Fin classes.g) → Fin (classes.copies j) → ℂ :=
     fun j q => (classes.enum_phase j q).choose
-  have hζ_mpv : ∀ j q (N : ℕ) (σ : Fin N → Fin d),
+  have hζ_mpv : ∀ j q (N : ℕ), 0 < N → ∀ σ : Fin N → Fin d,
       mpv (blocks (classes.enum j q)) σ = (ζFn j q) ^ N * mpv (blocks (classes.repr j)) σ :=
-    fun j q N σ => (classes.enum_phase j q).choose_spec.2 N σ
+    fun j q N hN σ => (classes.enum_phase j q).choose_spec.2 N hN σ
   let P := collapsedBntSectorDecomp (d := d) μ blocks hμne
-  intro N σ
+  intro N hN σ
   calc mpv P.toTensor σ
       = ∑ j : Fin P.basisCount,
           ∑ q : Fin (P.copies j), (P.weight j q) ^ N * mpv (P.basis j) σ :=
@@ -92,7 +93,7 @@ theorem collapsedBntSectorDecomp_sameMPV₂
             (μ (classes.enum j q)) ^ N * mpv (blocks (classes.enum j q)) σ := by
             refine Finset.sum_congr rfl (fun j _ =>
               Finset.sum_congr rfl (fun q _ => ?_))
-            rw [mul_pow, hζ_mpv j q N σ]
+            rw [mul_pow, hζ_mpv j q N hN σ]
             ring
     _ = ∑ k : Fin r, (μ k) ^ N * mpv (blocks k) σ :=
           classes.regroup (fun k => (μ k) ^ N * mpv (blocks k) σ)
@@ -106,11 +107,8 @@ If every block in an MPV phase class has the same bond dimension as the
 chosen representative of that class, then the collapsed BNT sector
 decomposition has the same total bond dimension as the original direct sum.
 
-This is the length-zero dimension statement needed in the arbitrary-input
-supplier: without the displayed same-dimension hypothesis, the quotient is
-allowed to identify MPV-phase-equivalent blocks of differing bond dimensions,
-and the length-zero MPV coefficient need not be preserved by dimension counting
-alone. -/
+This is a finite-sum identity for the multiplicities of the grouped blocks; it
+does not enter the positive-length MPV relation. -/
 theorem collapsedBntSectorDecomp_totalDim_eq_sum_dim
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ)

--- a/TNLean/MPS/CanonicalForm/PhaseCover.lean
+++ b/TNLean/MPS/CanonicalForm/PhaseCover.lean
@@ -16,8 +16,6 @@ canonical-form equal-norm and sector comparisons.
 
 ## Main statements
 
-* `MPVBlockPhaseEquiv.dim_eq`: exact phase equivalence at every nonnegative
-  length forces equality of bond dimensions.
 * `MPVPhaseClassData.enumEquiv`: the dependent family of class copies is
   equivalent to the original block-index set.
 * `MPVPhaseClassData.regroup_matrix`: a matrix-valued sum can be regrouped by
@@ -36,25 +34,27 @@ variable {d : ℕ}
 /-- MPV phase equivalence between two individual blocks with possibly different bond dimensions.
 
 `MPVBlockPhaseEquiv A B` means that the finite-chain MPV of `B` is a nonzero
-scalar power times the finite-chain MPV of `A`, uniformly in the chain length and
-physical word.  The bond dimensions of `A` and `B` may differ. -/
+scalar power times the finite-chain MPV of `A`, uniformly in every positive
+chain length and physical word.  The bond dimensions of `A` and `B` may differ.
+
+Source: CPSV16, Proposition `prop:char-BNT`, lines 1135–1148. -/
 def MPVBlockPhaseEquiv {d DA DB : ℕ} (A : MPSTensor d DA) (B : MPSTensor d DB) : Prop :=
-  ∃ ζ : ℂ, ζ ≠ 0 ∧ ∀ (N : ℕ) (σ : Fin N → Fin d),
+  ∃ ζ : ℂ, ζ ≠ 0 ∧ ∀ (N : ℕ), 0 < N → ∀ σ : Fin N → Fin d,
     mpv B σ = ζ ^ N * mpv A σ
 
 namespace MPVBlockPhaseEquiv
 
 /-- Reflexivity of MPV phase equivalence for different bond dimensions. -/
 lemma refl {D : ℕ} (A : MPSTensor d D) : MPVBlockPhaseEquiv A A :=
-  ⟨1, one_ne_zero, fun N σ => by simp⟩
+  ⟨1, one_ne_zero, fun N _hN σ => by simp⟩
 
 /-- Symmetry of MPV phase equivalence for different bond dimensions. -/
 lemma symm {DA DB : ℕ} {A : MPSTensor d DA} {B : MPSTensor d DB}
     (h : MPVBlockPhaseEquiv A B) : MPVBlockPhaseEquiv B A := by
   rcases h with ⟨ζ, hζ, hmpv⟩
   refine ⟨ζ⁻¹, inv_ne_zero hζ, ?_⟩
-  intro N σ
-  rw [hmpv N σ]
+  intro N hN σ
+  rw [hmpv N hN σ]
   rw [inv_pow, ← mul_assoc, inv_mul_cancel₀ (pow_ne_zero N hζ), one_mul]
 
 /-- Transitivity of MPV phase equivalence for different bond dimensions. -/
@@ -64,22 +64,9 @@ lemma trans {DA DB DC : ℕ} {A : MPSTensor d DA} {B : MPSTensor d DB}
   rcases hAB with ⟨ζ, hζ, hζmpv⟩
   rcases hBC with ⟨η, hη, hηmpv⟩
   refine ⟨η * ζ, mul_ne_zero hη hζ, ?_⟩
-  intro N σ
-  rw [hηmpv N σ, hζmpv N σ, mul_pow]
+  intro N hN σ
+  rw [hηmpv N hN σ, hζmpv N hN σ, mul_pow]
   ring
-
-/-- MPV phase equivalence at all lengths forces equality of bond dimensions.
-
-At length zero both MPV coefficients are traces of identity matrices, while
-the phase contributes the zeroth power `1`.  Thus the equality is simply
-`DB = DA`.  This observation uses the length-zero clause and does not hold for
-positive-length or merely eventual proportionality. -/
-lemma dim_eq {DA DB : ℕ} {A : MPSTensor d DA} {B : MPSTensor d DB}
-    (h : MPVBlockPhaseEquiv A B) : DA = DB := by
-  obtain ⟨ζ, _hζ, hmpv⟩ := h
-  have hzero := hmpv 0 (fun i => Fin.elim0 i)
-  simp [mpv, coeff] at hzero
-  exact_mod_cast hzero.symm
 
 /-- Gauge-phase equivalence after a dimension cast gives rectangular MPV phase equivalence. -/
 lemma of_gaugePhaseEquiv_cast {DA DB : ℕ} (A : MPSTensor d DA) (B : MPSTensor d DB)
@@ -89,20 +76,20 @@ lemma of_gaugePhaseEquiv_cast {DA DB : ℕ} (A : MPSTensor d DA) (B : MPSTensor 
     MPVBlockPhaseEquiv A B := by
   rcases hGPE with ⟨X, ζ, hζ, hX⟩
   refine ⟨ζ, hζ, ?_⟩
-  intro N σ
+  intro N _hN σ
   rw [mpv_eq_pow_mul_of_gaugePhase
     (A := cast (congr_arg (MPSTensor d) hdim) A) (B := B) X ζ hX N σ,
     mpv_cast_dim hdim A N σ]
 
 /-- MPV phase equivalence gives a scalar-power equality of MPV state vectors. -/
 lemma exists_mpvState_eq_smul {DA DB : ℕ} {A : MPSTensor d DA} {B : MPSTensor d DB}
-    (h : MPVBlockPhaseEquiv A B) (N : ℕ) :
+    (h : MPVBlockPhaseEquiv A B) (N : ℕ) (hN : 0 < N) :
     ∃ ζ : ℂ, ζ ≠ 0 ∧ mpvState (d := d) B N = ζ ^ N • mpvState (d := d) A N := by
   rcases h with ⟨ζ, hζ, hmpv⟩
   refine ⟨ζ, hζ, ?_⟩
   ext σ
   simp only [PiLp.smul_apply, smul_eq_mul, mpvState_apply]
-  exact hmpv N σ
+  exact hmpv N hN σ
 
 end MPVBlockPhaseEquiv
 
@@ -131,8 +118,8 @@ structure MPVCommonPhaseCover {d rA rB : ℕ}
 
 `MPVPhaseEquiv blocks j k` means that block `k` has the same MPV family as
 block `j` after multiplying length-`N` vectors by a nonzero scalar power
-`ζ ^ N`.  Gauge-phase equivalence implies this relation, and quotienting a
-finite family by this relation is enough to absorb all repeated scalar-power
+`ζ ^ N` for positive `N`. Gauge-phase equivalence implies this relation, and
+quotienting a finite family by this relation is enough to absorb all repeated scalar-power
 copies into sector weights.
 
 This is the family-indexed specialization of `MPVBlockPhaseEquiv`, so the
@@ -173,10 +160,10 @@ lemma MPVPhaseEquiv.of_gaugePhaseEquiv_cast {r : ℕ} {dim : Fin r → ℕ}
 /-- MPV phase equivalence gives a scalar-power equality of finite-length MPV state vectors. -/
 lemma MPVPhaseEquiv.exists_mpvState_eq_smul {r : ℕ} {dim : Fin r → ℕ}
     {blocks : (k : Fin r) → MPSTensor d (dim k)} {j k : Fin r}
-    (h : MPVPhaseEquiv blocks j k) (N : ℕ) :
+    (h : MPVPhaseEquiv blocks j k) (N : ℕ) (hN : 0 < N) :
     ∃ ζ : ℂ, ζ ≠ 0 ∧
       mpvState (d := d) (blocks k) N = ζ ^ N • mpvState (d := d) (blocks j) N :=
-  MPVBlockPhaseEquiv.exists_mpvState_eq_smul h N
+  MPVBlockPhaseEquiv.exists_mpvState_eq_smul h N hN
 
 
 
@@ -294,8 +281,9 @@ subspace as the original block family.
 
 Each representative is one of the original blocks, giving one inclusion. Conversely, every
 original block occurs in a phase class and is a nonzero scalar-power multiple of that class's
-representative at each length, hence lies in the representative span. -/
-theorem representative_mpv_span_eq (classes : MPVPhaseClassData blocks) (N : ℕ) :
+representative at each positive length, hence lies in the representative span. -/
+theorem representative_mpv_span_eq (classes : MPVPhaseClassData blocks) (N : ℕ)
+    (hN : 0 < N) :
     Submodule.span ℂ (Set.range (fun j : Fin classes.g =>
       mpvState (d := d) (blocks (classes.repr j)) N)) =
     Submodule.span ℂ (Set.range (fun k : Fin r =>
@@ -315,7 +303,7 @@ theorem representative_mpv_span_eq (classes : MPVPhaseClassData blocks) (N : ℕ
     change mpvState (d := d) (blocks k) N ∈
       Submodule.span ℂ (Set.range (fun j : Fin classes.g =>
         mpvState (d := d) (blocks (classes.repr j)) N))
-    obtain ⟨ζ, _hζ, hstate⟩ := hphase.exists_mpvState_eq_smul N
+    obtain ⟨ζ, _hζ, hstate⟩ := hphase.exists_mpvState_eq_smul N hN
     rw [hstate]
     exact Submodule.smul_mem _ _ (Submodule.subset_span ⟨j, rfl⟩)
 

--- a/TNLean/MPS/CanonicalForm/PhaseCover.lean
+++ b/TNLean/MPS/CanonicalForm/PhaseCover.lean
@@ -165,8 +165,6 @@ lemma MPVPhaseEquiv.exists_mpvState_eq_smul {r : ℕ} {dim : Fin r → ℕ}
       mpvState (d := d) (blocks k) N = ζ ^ N • mpvState (d := d) (blocks j) N :=
   MPVBlockPhaseEquiv.exists_mpvState_eq_smul h N hN
 
-
-
 /-- Equivalence relation on block indices given by MPV phase equivalence. -/
 def mpvPhaseSetoid {r : ℕ} {dim : Fin r → ℕ}
     (blocks : (k : Fin r) → MPSTensor d (dim k)) : Setoid (Fin r) where

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean
@@ -48,7 +48,7 @@ theorem IsBNTCanonicalForm.norm_phase_of_matched_mpv
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
     {j : Fin P.basisCount} {k : Fin Q.basisCount} {ζ : ℂ}
-    (hmpv : ∀ (N : ℕ) (σ : Fin N → Fin d),
+    (hmpv : ∀ (N : ℕ), 0 < N → ∀ σ : Fin N → Fin d,
       mpv (Q.basis k) σ = ζ ^ N * mpv (P.basis j) σ) :
     ‖ζ‖ = 1 := by
   have hAA : Tendsto (fun N => ‖mpvOverlap (d := d) (P.basis j) (P.basis j) N‖)
@@ -59,8 +59,8 @@ theorem IsBNTCanonicalForm.norm_phase_of_matched_mpv
       atTop (𝓝 (1 : ℝ)) := by
     have h1 := (hQ.basis_normalized_self_overlap k).norm
     simpa using h1
-  exact norm_eq_one_of_selfOverlap_scale (ζ := ζ) hAA hBB
-    (mpvOverlap_self_scale_of_mpv_eq_pow_mul (A := P.basis j) (B := Q.basis k)
+  exact norm_eq_one_of_selfOverlap_scale_pos (ζ := ζ) hAA hBB
+    (mpvOverlap_self_scale_of_mpv_eq_pow_mul_pos (A := P.basis j) (B := Q.basis k)
       (ζ := ζ) hmpv)
 
 /-- **Auxiliary lemma: gauge-phase data gives an MPV-level scalar-power identity with unit phase.**
@@ -68,7 +68,7 @@ theorem IsBNTCanonicalForm.norm_phase_of_matched_mpv
 Given a matched bond-dimension equality `h : P.basisDim j = Q.basisDim k`
 and a cast-left gauge-phase equivalence between `P.basis j` and `Q.basis k`,
 extract a phase `ζ` with `‖ζ‖ = 1` and
-`mpv (Q.basis k) σ = ζ^N * mpv (P.basis j) σ` for all lengths and words.
+`mpv (Q.basis k) σ = ζ^N * mpv (P.basis j) σ` for all positive lengths and words.
 
 This is CPSV16's Lemma `equalMPS` (lines 1080–1097) plus the normalized
 self-overlap/unit-phase closure used in the non-periodic setting. -/
@@ -80,7 +80,7 @@ private lemma extract_unit_gauge_phase_mpv
     (hGPE : GaugePhaseEquiv
         (cast (congr_arg (MPSTensor d) h) (P.basis j)) (Q.basis k)) :
     ∃ ζ : ℂ, ‖ζ‖ = 1 ∧
-      ∀ (N : ℕ) (σ : Fin N → Fin d),
+      ∀ (N : ℕ), 0 < N → ∀ σ : Fin N → Fin d,
         mpv (Q.basis k) σ = ζ ^ N * mpv (P.basis j) σ := by
   classical
   obtain ⟨ζ, _hζne, hmpv⟩ :=
@@ -112,7 +112,7 @@ theorem coeff_identity_via_matched_mpv_phasePos
     (hEqual : SameMPV₂Pos P.toTensor Q.toTensor)
     (β : Fin Q.basisCount ≃ Fin P.basisCount)
     (ζ : Fin Q.basisCount → ℂ)
-    (hζ_mpv : ∀ (k : Fin Q.basisCount) (N : ℕ) (σ : Fin N → Fin d),
+    (hζ_mpv : ∀ (k : Fin Q.basisCount) (N : ℕ), 0 < N → ∀ σ : Fin N → Fin d,
       mpv (Q.basis k) σ = (ζ k) ^ N * mpv (P.basis (β k)) σ) :
     ∀ k : Fin Q.basisCount, ∃ N₀, ∀ N > N₀,
       P.coeff N (β k) = (ζ k) ^ N * Q.coeff N k := by
@@ -167,7 +167,7 @@ theorem coeff_identity_via_matched_mpv_phasePos
           ((ζ k) ^ N) • mpvState (d := d) (P.basis (β k)) N := by
         apply PiLp.ext
         intro σ
-        simpa [mpvState_apply, smul_eq_mul] using hζ_mpv k N σ
+        simpa [mpvState_apply, smul_eq_mul] using hζ_mpv k N hN σ
       calc
         Q.coeff N k • mpvState (d := d) (Q.basis k) N
             = Q.coeff N k • (((ζ k) ^ N) •
@@ -229,7 +229,8 @@ theorem coeff_identity_via_matched_mpv_phase
     ∀ k : Fin Q.basisCount, ∃ N₀, ∀ N > N₀,
       P.coeff N (β k) = (ζ k) ^ N * Q.coeff N k :=
   coeff_identity_via_matched_mpv_phasePos
-    (P := P) (Q := Q) hP hEqual.toSameMPV₂Pos β ζ hζ_mpv
+    (P := P) (Q := Q) hP hEqual.toSameMPV₂Pos β ζ
+      (fun k N _hN σ => hζ_mpv k N σ)
 
 /-- **Proportional matched-phase coefficient identity (scalar-threaded).**
 
@@ -276,8 +277,8 @@ theorem coeff_identity_via_matched_mpv_phase_proportional
       ∃ N₀, ∀ N > N₀, ∀ k : Fin Q.basisCount,
         P.coeff N (β k) = c N * (ζ k) ^ N * Q.coeff N k := by
   classical
-  -- The global proportionality scalar at each length, with a junk value off the
-  -- proportionality tail.
+  -- The global proportionality scalar at each length, with an arbitrary value outside the
+  -- eventual range where proportionality is known.
   obtain ⟨c, hc_ne, hc_prop⟩ :
       ∃ c : ℕ → ℂ, (∀ᶠ N in atTop, c N ≠ 0) ∧
         (∀ᶠ N in atTop, ∀ σ : Fin N → Fin d,
@@ -416,7 +417,7 @@ theorem coeff_identity_via_global_gaugePos
   -- relation `mpv (Q.basis k) σ = ζ ^ N * mpv (P.basis (β k)) σ`.
   let phaseData : (k : Fin Q.basisCount) →
       { ζ : ℂ // ‖ζ‖ = 1 ∧
-        ∀ (N : ℕ) (σ : Fin N → Fin d),
+        ∀ (N : ℕ), 0 < N → ∀ σ : Fin N → Fin d,
           mpv (Q.basis k) σ = ζ ^ N * mpv (P.basis (β k)) σ } := fun k =>
     let hm := hMatch k
     let hdim : P.basisDim (β k) = Q.basisDim k := hm.choose
@@ -428,7 +429,7 @@ theorem coeff_identity_via_global_gaugePos
   let ζ : Fin Q.basisCount → ℂ := fun k => (phaseData k).val
   have hζ_norm : ∀ k : Fin Q.basisCount, ‖ζ k‖ = 1 := fun k =>
     (phaseData k).property.1
-  have hζ_mpv : ∀ (k : Fin Q.basisCount) (N : ℕ) (σ : Fin N → Fin d),
+  have hζ_mpv : ∀ (k : Fin Q.basisCount) (N : ℕ), 0 < N → ∀ σ : Fin N → Fin d,
       mpv (Q.basis k) σ = (ζ k) ^ N * mpv (P.basis (β k)) σ := fun k =>
     (phaseData k).property.2
   -- Feed the matched MPV phases into the fixed-phase identity.

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
@@ -420,7 +420,8 @@ theorem ft_sector_bnt_equal_matched_copy_weight_witnessesPos
     intro k hzero
     have hnorm := hζ_norm k
     simp [hzero] at hnorm
-  have hCoeff := coeff_identity_via_matched_mpv_phasePos hP hEqual β ζ hMpv
+  have hCoeff := coeff_identity_via_matched_mpv_phasePos hP hEqual β ζ
+    (fun k N _hN σ => hMpv k N σ)
   let W : SectorBNTCopyWeightMatching (P := P) (Q := Q) β ζ :=
     SectorBNTCopyWeightMatching.of_coeff_identity
       (P := P) (Q := Q) β ζ hζ_ne hCoeff

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch.lean
@@ -261,7 +261,7 @@ theorem ft_sector_bnt_proportional_sector_match_witnesses
       mpv_cast_dim (hDim k) (P.basis (β k)) N σ]
   have hζ_norm : ∀ k : Fin Q.basisCount, ‖ζ k‖ = 1 := by
     intro k
-    exact hP.norm_phase_of_matched_mpv hQ (hMpv k)
+    exact hP.norm_phase_of_matched_mpv hQ (fun N _hN σ => hMpv k N σ)
   exact ⟨β, hDim, ζ, Xblock, hζ_norm, hConj, hMpv⟩
 
 end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
@@ -76,13 +76,13 @@ phase scalar `h.choose` has unit norm.
 Proof sketch (scout memo §2.4):
 1. The phase equivalence supplies the scaling relation
    `mpv Y σ = h.choose ^ N * mpv X σ`.
-2. `mpvOverlap_self_scale_of_mpv_eq_pow_mul`
+2. `mpvOverlap_self_scale_of_mpv_eq_pow_mul_pos`
    (`SharedInfra/GaugePhase.lean`) converts this into a scaling
    `mpvOverlap Y Y N = (ζ · conj ζ)^N · mpvOverlap X X N`.
 3. Both self-overlaps tend to `1` by
    `overlap_tendsto_one_of_peripheralPrimitive_of_irreducible`
    (`Overlap/PeripheralToTransferMapGap.lean`).
-4. `norm_eq_one_of_selfOverlap_scale` (`SharedInfra/GaugePhase.lean`)
+4. `norm_eq_one_of_selfOverlap_scale_pos` (`SharedInfra/GaugePhase.lean`)
    concludes `‖ζ‖ = 1`.
 -/
 lemma norm_choose_MPVBlockPhaseEquiv_eq_one

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
@@ -18,7 +18,7 @@ blocks with nonzero weights satisfying the CPSV16 §II.C line-246 normalization
 (`|μ_k| ≤ 1` and at least one `|μ_k| = 1`), this file produces a
 `SectorDecomposition` `P` together with a proof that
 
-* `P.toTensor` has the same MPV at every length as the original
+* `P.toTensor` has the same MPV at every positive length as the original
   `toTensorFromBlocks μ blocks`, and
 * `P` satisfies `IsBNTCanonicalForm`.
 
@@ -44,8 +44,7 @@ phase-equivalent TP/primitive/irreducible blocks.
 ## Gap record
 
 * `docs/paper-gaps/cpsv16_cf_normalization_and_proportional_comparison.tex` —
-  records the remaining canonical-form weight-normalization and length-zero
-  dimension gaps for the arbitrary-input supplier path.
+  records the canonical-form normalization and proportional-comparison analysis.
 
 ## Layering
 
@@ -98,9 +97,9 @@ lemma norm_choose_MPVBlockPhaseEquiv_eq_one
     (h : MPVBlockPhaseEquiv X Y) :
     ‖h.choose‖ = 1 := by
   classical
-  have hmpv : ∀ (N : ℕ) (σ : Fin N → Fin d),
+  have hmpv : ∀ (N : ℕ), 0 < N → ∀ σ : Fin N → Fin d,
       mpv Y σ = h.choose ^ N * mpv X σ := h.choose_spec.2
-  exact norm_eq_one_of_selfOverlap_scale
+  exact norm_eq_one_of_selfOverlap_scale_pos
     (by
       simpa using
         (overlap_tendsto_one_of_peripheralPrimitive_of_irreducible
@@ -109,7 +108,7 @@ lemma norm_choose_MPVBlockPhaseEquiv_eq_one
       simpa using
         (overlap_tendsto_one_of_peripheralPrimitive_of_irreducible
           (d := d) (D := DY) Y hIrrY hTPY hPrimY).norm)
-    (mpvOverlap_self_scale_of_mpv_eq_pow_mul
+    (mpvOverlap_self_scale_of_mpv_eq_pow_mul_pos
       (A := X) (B := Y) (ζ := h.choose) hmpv)
 
 /-!
@@ -153,25 +152,27 @@ theorem dim_eq_of_MPVBlockPhaseEquiv_of_tp_primitive_irr
   have hζ_norm : ‖h.choose‖ = 1 :=
     norm_choose_MPVBlockPhaseEquiv_eq_one
       (X := X) (Y := Y) hTPX hTPY hPrimX hPrimY hIrrX hIrrY h
-  have hmpv : ∀ (N : ℕ) (σ : Fin N → Fin d),
+  have hmpv : ∀ (N : ℕ), 0 < N → ∀ σ : Fin N → Fin d,
       mpv Y σ = h.choose ^ N * mpv X σ := h.choose_spec.2
   have hXX_c : Tendsto (fun N => mpvOverlap (d := d) X X N) atTop (𝓝 (1 : ℂ)) :=
     overlap_tendsto_one_of_peripheralPrimitive_of_irreducible
       (d := d) (D := DX) X hIrrX hTPX hPrimX
   have hXX : Tendsto (fun N => ‖mpvOverlap (d := d) X X N‖) atTop (𝓝 (1 : ℝ)) := by
     simpa using hXX_c.norm
-  have hYX_eq : ∀ N : ℕ,
+  have hYX_eq : ∀ N : ℕ, 0 < N →
       mpvOverlap (d := d) Y X N =
         h.choose ^ N * mpvOverlap (d := d) X X N := by
-    intro N
+    intro N hN
     exact mpvOverlap_eq_mul_of_mpv_eq_mul
-      (d := d) (A := Y) (B := X) (N := N) (c := h.choose ^ N) (hmpv N) X
-  have hYX_norm_eq : ∀ N : ℕ,
+      (d := d) (A := Y) (B := X) (N := N) (c := h.choose ^ N) (hmpv N hN) X
+  have hYX_norm_eq : ∀ N : ℕ, 0 < N →
       ‖mpvOverlap (d := d) Y X N‖ = ‖mpvOverlap (d := d) X X N‖ := by
-    intro N
-    rw [hYX_eq N, norm_mul, norm_pow, hζ_norm, one_pow, one_mul]
+    intro N hN
+    rw [hYX_eq N hN, norm_mul, norm_pow, hζ_norm, one_pow, one_mul]
   have hYX : Tendsto (fun N => ‖mpvOverlap (d := d) Y X N‖) atTop (𝓝 (1 : ℝ)) :=
-    hXX.congr fun N => (hYX_norm_eq N).symm
+    hXX.congr' (by
+      filter_upwards [eventually_ge_atTop 1] with N hN
+      exact (hYX_norm_eq N hN).symm)
   exact (dim_eq_of_mpvOverlap_norm_tendsto_one_of_irreducible_TP
     Y X hIrrY hIrrX hTPY hTPX hYX).symm
 
@@ -214,14 +215,14 @@ theorem gaugePhaseEquiv_of_MPVBlockPhaseEquiv_of_tp_primitive_irr
     overlap_tendsto_one_of_peripheralPrimitive_of_irreducible
       (d := d) (D := DX) Y hIrrY hTPY hPrimY
   by_contra hNot
-  obtain ⟨N, _, hN⟩ :=
+  obtain ⟨N, hNpos, hN⟩ :=
     exists_ge_not_forall_mpv_eq_mul_of_not_gaugePhaseEquiv_of_irreducible_TP
-      X Y hIrrX hIrrY hTPX hTPY hX_self hY_self hNot 0
+      X Y hIrrX hIrrY hTPX hTPY hX_self hY_self hNot 1
   have hSymm : MPVBlockPhaseEquiv Y X := MPVBlockPhaseEquiv.symm h
   apply hN
   refine ⟨hSymm.choose ^ N, ?_⟩
   intro σ
-  exact hSymm.choose_spec.2 N σ
+  exact hSymm.choose_spec.2 N hNpos σ
 
 /--
 **Prepared phase classes preserve the original bond dimensions.**
@@ -309,7 +310,7 @@ theorem exists_isBNTCanonicalForm_of_tp_primitive_irr_blocks
     (hμLe : ∀ k, ‖μ k‖ ≤ 1)
     (hμUnit : ∃ k, ‖μ k‖ = 1) :
     ∃ P : SectorDecomposition d,
-      SameMPV₂ P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
+      SameMPV₂Pos P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
       IsBNTCanonicalForm P := by
   classical
   -- Promote `0 < dim k` to a `NeZero (dim k)` typeclass instance.
@@ -337,8 +338,8 @@ theorem exists_isBNTCanonicalForm_of_tp_primitive_irr_blocks
         (hIrr (classes.repr j)) (hIrr (classes.enum j q))
         hPE
   -- Same-MPV with the original direct-sum tensor.
-  have hSame : SameMPV₂ P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) :=
-    collapsedBntSectorDecomp_sameMPV₂ (d := d) μ blocks hμne
+  have hSame : SameMPV₂Pos P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) :=
+    collapsedBntSectorDecomp_sameMPV₂Pos (d := d) μ blocks hμne
   -- HasBNTSectorData.
   have hBNT : HasBNTSectorData (d := d) P :=
     collapsedBntSectorDecomp_hasBNT (d := d) μ blocks hTP hIrr hPrim hμne
@@ -690,51 +691,8 @@ theorem exists_isBNTCanonicalForm_afterBlocking_pos
   refine ⟨P, ?_, hBNT⟩
   -- Chain the positive-length MPV identity with the prepared-block agreement.
   -- `hSamePos`: `mpv (blockTensor A p) σ = mpv (toTensorFromBlocks μ blocks) σ` for `N > 0`.
-  -- `hSame`:    `mpv P.toTensor σ = mpv (toTensorFromBlocks μ blocks) σ` for all `N`.
+  -- `hSame`:    `mpv P.toTensor σ = mpv (toTensorFromBlocks μ blocks) σ` for `N > 0`.
   intro N hN σ
-  exact (hSamePos N hN σ).trans (hSame N σ).symm
-
-/-- **Arbitrary-input BNT block preparation with explicit length-zero discharge.**
-
-This theorem refines `exists_isBNTCanonicalForm_afterBlocking_pos` by adding the
-length-zero condition. It keeps the same prepared-block output and the same
-CPSV16 §II.C line-246 normalization hypotheses. In addition, after a normalized
-BNT sector decomposition is chosen, it records that the positive-length MPV
-identity upgrades to full `SameMPV₂` as soon as the zero-length trace identity is
-supplied in the concrete form `D = P.totalDim`.
-
-It does not prove the missing normalization or the total-dimension equality;
-those are precisely the remaining arbitrary-input bridge obligations recorded
-in `docs/paper-gaps/cpsv16_cf_normalization_and_proportional_comparison.tex`. -/
-theorem exists_isBNTCanonicalForm_afterBlocking_of_totalDim
-    {d D : ℕ} (A : MPSTensor d D) :
-    ∃ p : ℕ, 0 < p ∧
-    ∃ r : ℕ, ∃ dim : Fin r → ℕ, ∃ μ : Fin r → ℂ,
-    ∃ blocks : (k : Fin r) → MPSTensor (blockPhysDim d p) (dim k),
-      (∀ k, 0 < dim k) ∧
-      (∀ k, IsLeftCanonical (blocks k)) ∧
-      (∀ k, _root_.IsPrimitive (transferMap (blocks k))) ∧
-      (∀ k, IsIrreducibleTensor (blocks k)) ∧
-      (∀ k, IsInjective (blocks k)) ∧
-      (∀ k, μ k ≠ 0) ∧
-      SameMPV₂Pos (blockTensor (d := d) (D := D) A p)
-        (toTensorFromBlocks (d := blockPhysDim d p) (μ := μ) blocks) ∧
-      (∀ (_hμLe : ∀ k, ‖μ k‖ ≤ 1) (_hμUnit : ∃ k, ‖μ k‖ = 1),
-        ∃ P : SectorDecomposition (blockPhysDim d p),
-          SameMPV₂Pos (blockTensor (d := d) (D := D) A p) P.toTensor ∧
-          (D = P.totalDim →
-            SameMPV₂ (blockTensor (d := d) (D := D) A p) P.toTensor) ∧
-          IsBNTCanonicalForm P) := by
-  classical
-  obtain ⟨p, hp, r, dim, μ, blocks, hDim, hTP, hPrim, hIrr, hInj, hμne,
-      hSamePos, hMake⟩ :=
-    exists_isBNTCanonicalForm_afterBlocking_pos (d := d) (D := D) A
-  refine ⟨p, hp, r, dim, μ, blocks, hDim, hTP, hPrim, hIrr, hInj, hμne,
-    hSamePos, ?_⟩
-  intro hμLe hμUnit
-  obtain ⟨P, hPPos, hBNT⟩ := hMake hμLe hμUnit
-  refine ⟨P, hPPos, ?_, hBNT⟩
-  intro hDimEq
-  exact hPPos.toSameMPV₂_of_bondDim_eq hDimEq
+  exact (hSamePos N hN σ).trans (hSame N hN σ).symm
 
 end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/SupplierNormalized.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/SupplierNormalized.lean
@@ -233,6 +233,6 @@ theorem exists_isBNTCanonicalForm_afterBlocking_pos_normalized
           (μ := fun k => μ k / (m : ℂ)) blocks) σ :=
       mpv_toTensorFromBlocks_weight_mul_left (m : ℂ) _ blocks σ
     _ = (m : ℂ) ^ N * mpv P.toTensor σ := by
-      rw [hSame N σ]
+      rw [hSame N hN σ]
 
 end MPSTensor

--- a/TNLean/MPS/MPDO/VerticalBNT.lean
+++ b/TNLean/MPS/MPDO/VerticalBNT.lean
@@ -384,7 +384,7 @@ theorem IsHorizontalCF.exists_verticalBNTGrouping_with_isometry
               MPSTensor.mpv (blocks (classes.repr j)) w := by
               refine Finset.sum_congr rfl fun j _ =>
                 Finset.sum_congr rfl fun q _ => ?_
-              rw [(classes.enum_phase j q).choose_spec.2 N w, mul_pow]
+              rw [(classes.enum_phase j q).choose_spec.2 N _hN w, mul_pow]
               ring
         _ = ∑ j : Fin classes.g,
             (∑ q : Fin (classes.copies j),

--- a/TNLean/MPS/SharedInfra/GaugePhase.lean
+++ b/TNLean/MPS/SharedInfra/GaugePhase.lean
@@ -87,6 +87,27 @@ theorem mpvOverlap_cross_scale_of_mpv_eq_pow_mul
       fun x => by ring]
   rw [← Finset.mul_sum, mul_pow]
 
+/-- Positive-length form of `mpvOverlap_cross_scale_of_mpv_eq_pow_mul`. -/
+theorem mpvOverlap_cross_scale_of_mpv_eq_pow_mul_pos
+    {D D1 D2 : ℕ} {A : MPSTensor d D} {B1 : MPSTensor d D1} {B2 : MPSTensor d D2}
+    {ζ1 ζ2 : ℂ}
+    (hmpv1 : ∀ (N : ℕ), 0 < N → ∀ σ : Fin N → Fin d,
+      mpv B1 σ = ζ1 ^ N * mpv A σ)
+    (hmpv2 : ∀ (N : ℕ), 0 < N → ∀ σ : Fin N → Fin d,
+      mpv B2 σ = ζ2 ^ N * mpv A σ) :
+    ∀ N : ℕ, 0 < N →
+      mpvOverlap (d := d) B1 B2 N =
+        (ζ1 * star ζ2) ^ N * mpvOverlap (d := d) A A N := by
+  intro N hN
+  classical
+  simp only [mpvOverlap]
+  simp_rw [hmpv1 N hN, hmpv2 N hN, star_mul, star_pow]
+  simp_rw [show ∀ x : Cfg d N,
+      ζ1 ^ N * mpv A x * (star (mpv A x) * (star ζ2) ^ N) =
+        ζ1 ^ N * (star ζ2) ^ N * (mpv A x * star (mpv A x)) from
+      fun x => by ring]
+  rw [← Finset.mul_sum, mul_pow]
+
 /-- If `mpv B σ = ζ ^ N * mpv A σ` for every system size `N` and configuration `σ`, then the
 self-overlap of `B` scales by `(ζ * conj ζ) ^ N` times the self-overlap of `A`. -/
 theorem mpvOverlap_self_scale_of_mpv_eq_pow_mul
@@ -97,6 +118,18 @@ theorem mpvOverlap_self_scale_of_mpv_eq_pow_mul
         (ζ * starRingEnd ℂ ζ) ^ N * mpvOverlap (d := d) A A N := by
   simpa using
     (mpvOverlap_cross_scale_of_mpv_eq_pow_mul
+      (A := A) (B1 := B) (B2 := B) (ζ1 := ζ) (ζ2 := ζ) hmpv hmpv)
+
+/-- Positive-length form of `mpvOverlap_self_scale_of_mpv_eq_pow_mul`. -/
+theorem mpvOverlap_self_scale_of_mpv_eq_pow_mul_pos
+    {D D' : ℕ} {A : MPSTensor d D} {B : MPSTensor d D'} {ζ : ℂ}
+    (hmpv : ∀ (N : ℕ), 0 < N → ∀ σ : Fin N → Fin d,
+      mpv B σ = ζ ^ N * mpv A σ) :
+    ∀ N : ℕ, 0 < N →
+      mpvOverlap (d := d) B B N =
+        (ζ * starRingEnd ℂ ζ) ^ N * mpvOverlap (d := d) A A N := by
+  simpa using
+    (mpvOverlap_cross_scale_of_mpv_eq_pow_mul_pos
       (A := A) (B1 := B) (B2 := B) (ζ1 := ζ) (ζ2 := ζ) hmpv hmpv)
 
 /-- If all matrix-product amplitudes of `B` are obtained from those of `A` by the
@@ -117,6 +150,36 @@ theorem mpvOverlap_eq_star_pow_mul_self_of_mpv_eq_pow_mul
           refine Finset.sum_congr rfl ?_
           intro σ _
           rw [hmpv N σ]
+    _ = ∑ σ : Cfg d N,
+        (star ζ) ^ N * (mpv A σ * star (mpv A σ)) := by
+          refine Finset.sum_congr rfl ?_
+          intro σ _
+          have hstar :
+              star (ζ ^ N * mpv A σ) = star (mpv A σ) * (star ζ) ^ N := by
+            rw [StarMul.star_mul, star_pow]
+          rw [hstar]
+          ring
+    _ = (star ζ) ^ N * mpvOverlap (d := d) A A N := by
+          simp [mpvOverlap, Finset.mul_sum]
+
+/-- Positive-length form of
+`mpvOverlap_eq_star_pow_mul_self_of_mpv_eq_pow_mul`. -/
+theorem mpvOverlap_eq_star_pow_mul_self_of_mpv_eq_pow_mul_pos
+    {D D' : ℕ} {A : MPSTensor d D} {B : MPSTensor d D'} {ζ : ℂ}
+    (hmpv : ∀ (N : ℕ), 0 < N → ∀ σ : Fin N → Fin d,
+      mpv B σ = ζ ^ N * mpv A σ) :
+    ∀ N : ℕ, 0 < N →
+      mpvOverlap (d := d) A B N =
+        (star ζ) ^ N * mpvOverlap (d := d) A A N := by
+  intro N hN
+  classical
+  calc
+    mpvOverlap (d := d) A B N =
+        ∑ σ : Cfg d N, mpv A σ * star (ζ ^ N * mpv A σ) := by
+          simp only [mpvOverlap]
+          refine Finset.sum_congr rfl ?_
+          intro σ _
+          rw [hmpv N hN σ]
     _ = ∑ σ : Cfg d N,
         (star ζ) ^ N * (mpv A σ * star (mpv A σ)) := by
           refine Finset.sum_congr rfl ?_
@@ -180,6 +243,46 @@ theorem norm_eq_one_of_selfOverlap_scale
         (ζ * starRingEnd ℂ ζ) ^ N * mpvOverlap (d := d) A A N) :
     ‖ζ‖ = 1 :=
   norm_eq_one_of_selfOverlap_scale_at_nonzero_limit one_ne_zero hAA hBB hSelf
+
+/-- Positive-length form of `norm_eq_one_of_selfOverlap_scale`.  The proof only
+uses the scaling identity eventually, so no value at length zero is required. -/
+theorem norm_eq_one_of_selfOverlap_scale_pos
+    {D D' : ℕ} {A : MPSTensor d D} {B : MPSTensor d D'} {ζ : ℂ}
+    (hAA : Filter.Tendsto (fun N => ‖mpvOverlap (d := d) A A N‖) Filter.atTop (nhds 1))
+    (hBB : Filter.Tendsto (fun N => ‖mpvOverlap (d := d) B B N‖) Filter.atTop (nhds 1))
+    (hSelf : ∀ N : ℕ, 0 < N →
+      mpvOverlap (d := d) B B N =
+        (ζ * starRingEnd ℂ ζ) ^ N * mpvOverlap (d := d) A A N) :
+    ‖ζ‖ = 1 := by
+  have hAA_ne : ∀ᶠ N in Filter.atTop, ‖mpvOverlap (d := d) A A N‖ ≠ 0 :=
+    hAA.eventually_ne one_ne_zero
+  have hRatio : Filter.Tendsto (fun N => ‖mpvOverlap (d := d) B B N‖ /
+      ‖mpvOverlap (d := d) A A N‖) Filter.atTop (nhds 1) := by
+    change Filter.Tendsto
+      ((fun N => ‖mpvOverlap (d := d) B B N‖) /
+        fun N => ‖mpvOverlap (d := d) A A N‖) Filter.atTop (nhds 1)
+    simpa using hBB.div hAA one_ne_zero
+  have hRatioEq : ∀ᶠ N in Filter.atTop,
+      ‖mpvOverlap (d := d) B B N‖ / ‖mpvOverlap (d := d) A A N‖ = (‖ζ‖ ^ 2) ^ N := by
+    filter_upwards [hAA_ne, Filter.eventually_ge_atTop 1] with N hN hNpos
+    rw [hSelf N hNpos, norm_mul, norm_pow,
+      show ‖ζ * starRingEnd ℂ ζ‖ = ‖ζ‖ ^ 2 from by
+        rw [norm_mul, RCLike.norm_conj, sq]]
+    rw [← pow_mul, Nat.mul_comm, pow_mul]
+    exact mul_div_cancel_of_imp (fun h => absurd h hN)
+  have hPow : Filter.Tendsto (fun N => (‖ζ‖ ^ 2) ^ N) Filter.atTop (nhds 1) :=
+    hRatio.congr' hRatioEq
+  have h1 : ‖ζ‖ ^ 2 = 1 := by
+    by_contra hne'
+    rcases lt_or_gt_of_ne hne' with h | h
+    · exact one_ne_zero
+        (tendsto_nhds_unique hPow (tendsto_pow_atTop_nhds_zero_of_lt_one (by positivity) h))
+    · have hlt2 : ∀ᶠ n in Filter.atTop, (‖ζ‖ ^ 2) ^ n < 2 :=
+        hPow.eventually (Iio_mem_nhds (by norm_num : (1 : ℝ) < 2))
+      rcases ((Filter.tendsto_atTop.1 (tendsto_pow_atTop_atTop_of_one_lt h) 2).and hlt2).exists
+        with ⟨n, hn1, hn2⟩
+      exact not_lt_of_ge hn1 hn2
+  nlinarith [norm_nonneg ζ]
 
 
 

--- a/TNLean/MPS/SharedInfra/GaugePhase.lean
+++ b/TNLean/MPS/SharedInfra/GaugePhase.lean
@@ -66,6 +66,22 @@ theorem mpv_eq_pow_mul_of_gaugePhase
     _ = ζ ^ N * mpv A σ := by
           simp [mpv, coeff, w, hwlen]
 
+private theorem mpvOverlap_cross_scale_of_mpv_eq_pow_mul_at
+    {D D1 D2 N : ℕ} {A : MPSTensor d D} {B1 : MPSTensor d D1} {B2 : MPSTensor d D2}
+    {ζ1 ζ2 : ℂ}
+    (hmpv1 : ∀ σ : Fin N → Fin d, mpv B1 σ = ζ1 ^ N * mpv A σ)
+    (hmpv2 : ∀ σ : Fin N → Fin d, mpv B2 σ = ζ2 ^ N * mpv A σ) :
+    mpvOverlap (d := d) B1 B2 N =
+      (ζ1 * star ζ2) ^ N * mpvOverlap (d := d) A A N := by
+  classical
+  simp only [mpvOverlap]
+  simp_rw [hmpv1, hmpv2, star_mul, star_pow]
+  simp_rw [show ∀ x : Cfg d N,
+      ζ1 ^ N * mpv A x * (star (mpv A x) * (star ζ2) ^ N) =
+        ζ1 ^ N * (star ζ2) ^ N * (mpv A x * star (mpv A x)) from
+      fun x => by ring]
+  rw [← Finset.mul_sum, mul_pow]
+
 /-- If two matrix-product vector families are obtained from a common family by
 length-dependent phases `ζ1 ^ N` and `ζ2 ^ N`, then their mixed overlap is
 `(ζ1 * conj ζ2) ^ N` times the self-overlap of the common family. -/
@@ -76,18 +92,10 @@ theorem mpvOverlap_cross_scale_of_mpv_eq_pow_mul
     (hmpv2 : ∀ (N : ℕ) (σ : Fin N → Fin d), mpv B2 σ = ζ2 ^ N * mpv A σ) :
     ∀ N : ℕ,
       mpvOverlap (d := d) B1 B2 N =
-        (ζ1 * star ζ2) ^ N * mpvOverlap (d := d) A A N := by
-  intro N
-  classical
-  simp only [mpvOverlap]
-  simp_rw [hmpv1 N, hmpv2 N, star_mul, star_pow]
-  simp_rw [show ∀ x : Cfg d N,
-      ζ1 ^ N * mpv A x * (star (mpv A x) * (star ζ2) ^ N) =
-        ζ1 ^ N * (star ζ2) ^ N * (mpv A x * star (mpv A x)) from
-      fun x => by ring]
-  rw [← Finset.mul_sum, mul_pow]
+        (ζ1 * star ζ2) ^ N * mpvOverlap (d := d) A A N :=
+  fun N => mpvOverlap_cross_scale_of_mpv_eq_pow_mul_at (hmpv1 N) (hmpv2 N)
 
-/-- Positive-length form of `mpvOverlap_cross_scale_of_mpv_eq_pow_mul`. -/
+/-- Positive-length overlap scaling for two MPV families with a common representative. -/
 theorem mpvOverlap_cross_scale_of_mpv_eq_pow_mul_pos
     {D D1 D2 : ℕ} {A : MPSTensor d D} {B1 : MPSTensor d D1} {B2 : MPSTensor d D2}
     {ζ1 ζ2 : ℂ}
@@ -97,16 +105,8 @@ theorem mpvOverlap_cross_scale_of_mpv_eq_pow_mul_pos
       mpv B2 σ = ζ2 ^ N * mpv A σ) :
     ∀ N : ℕ, 0 < N →
       mpvOverlap (d := d) B1 B2 N =
-        (ζ1 * star ζ2) ^ N * mpvOverlap (d := d) A A N := by
-  intro N hN
-  classical
-  simp only [mpvOverlap]
-  simp_rw [hmpv1 N hN, hmpv2 N hN, star_mul, star_pow]
-  simp_rw [show ∀ x : Cfg d N,
-      ζ1 ^ N * mpv A x * (star (mpv A x) * (star ζ2) ^ N) =
-        ζ1 ^ N * (star ζ2) ^ N * (mpv A x * star (mpv A x)) from
-      fun x => by ring]
-  rw [← Finset.mul_sum, mul_pow]
+        (ζ1 * star ζ2) ^ N * mpvOverlap (d := d) A A N :=
+  fun N hN => mpvOverlap_cross_scale_of_mpv_eq_pow_mul_at (hmpv1 N hN) (hmpv2 N hN)
 
 /-- If `mpv B σ = ζ ^ N * mpv A σ` for every system size `N` and configuration `σ`, then the
 self-overlap of `B` scales by `(ζ * conj ζ) ^ N` times the self-overlap of `A`. -/
@@ -132,16 +132,11 @@ theorem mpvOverlap_self_scale_of_mpv_eq_pow_mul_pos
     (mpvOverlap_cross_scale_of_mpv_eq_pow_mul_pos
       (A := A) (B1 := B) (B2 := B) (ζ1 := ζ) (ζ2 := ζ) hmpv hmpv)
 
-/-- If all matrix-product amplitudes of `B` are obtained from those of `A` by the
-length-dependent phase `ζ ^ N`, then the mixed overlap with `A` is
-`(conj ζ) ^ N` times the self-overlap of `A`. -/
-theorem mpvOverlap_eq_star_pow_mul_self_of_mpv_eq_pow_mul
-    {D D' : ℕ} {A : MPSTensor d D} {B : MPSTensor d D'} {ζ : ℂ}
-    (hmpv : ∀ (N : ℕ) (σ : Fin N → Fin d), mpv B σ = ζ ^ N * mpv A σ) :
-    ∀ N : ℕ,
-      mpvOverlap (d := d) A B N =
-        (star ζ) ^ N * mpvOverlap (d := d) A A N := by
-  intro N
+private theorem mpvOverlap_eq_star_pow_mul_self_of_mpv_eq_pow_mul_at
+    {D D' N : ℕ} {A : MPSTensor d D} {B : MPSTensor d D'} {ζ : ℂ}
+    (hmpv : ∀ σ : Fin N → Fin d, mpv B σ = ζ ^ N * mpv A σ) :
+    mpvOverlap (d := d) A B N =
+      (star ζ) ^ N * mpvOverlap (d := d) A A N := by
   classical
   calc
     mpvOverlap (d := d) A B N =
@@ -149,7 +144,7 @@ theorem mpvOverlap_eq_star_pow_mul_self_of_mpv_eq_pow_mul
           simp only [mpvOverlap]
           refine Finset.sum_congr rfl ?_
           intro σ _
-          rw [hmpv N σ]
+          rw [hmpv σ]
     _ = ∑ σ : Cfg d N,
         (star ζ) ^ N * (mpv A σ * star (mpv A σ)) := by
           refine Finset.sum_congr rfl ?_
@@ -161,6 +156,17 @@ theorem mpvOverlap_eq_star_pow_mul_self_of_mpv_eq_pow_mul
           ring
     _ = (star ζ) ^ N * mpvOverlap (d := d) A A N := by
           simp [mpvOverlap, Finset.mul_sum]
+
+/-- If all matrix-product amplitudes of `B` are obtained from those of `A` by the
+length-dependent phase `ζ ^ N`, then the mixed overlap with `A` is
+`(conj ζ) ^ N` times the self-overlap of `A`. -/
+theorem mpvOverlap_eq_star_pow_mul_self_of_mpv_eq_pow_mul
+    {D D' : ℕ} {A : MPSTensor d D} {B : MPSTensor d D'} {ζ : ℂ}
+    (hmpv : ∀ (N : ℕ) (σ : Fin N → Fin d), mpv B σ = ζ ^ N * mpv A σ) :
+    ∀ N : ℕ,
+      mpvOverlap (d := d) A B N =
+        (star ζ) ^ N * mpvOverlap (d := d) A A N :=
+  fun N => mpvOverlap_eq_star_pow_mul_self_of_mpv_eq_pow_mul_at (hmpv N)
 
 /-- Positive-length form of
 `mpvOverlap_eq_star_pow_mul_self_of_mpv_eq_pow_mul`. -/
@@ -170,36 +176,15 @@ theorem mpvOverlap_eq_star_pow_mul_self_of_mpv_eq_pow_mul_pos
       mpv B σ = ζ ^ N * mpv A σ) :
     ∀ N : ℕ, 0 < N →
       mpvOverlap (d := d) A B N =
-        (star ζ) ^ N * mpvOverlap (d := d) A A N := by
-  intro N hN
-  classical
-  calc
-    mpvOverlap (d := d) A B N =
-        ∑ σ : Cfg d N, mpv A σ * star (ζ ^ N * mpv A σ) := by
-          simp only [mpvOverlap]
-          refine Finset.sum_congr rfl ?_
-          intro σ _
-          rw [hmpv N hN σ]
-    _ = ∑ σ : Cfg d N,
-        (star ζ) ^ N * (mpv A σ * star (mpv A σ)) := by
-          refine Finset.sum_congr rfl ?_
-          intro σ _
-          have hstar :
-              star (ζ ^ N * mpv A σ) = star (mpv A σ) * (star ζ) ^ N := by
-            rw [StarMul.star_mul, star_pow]
-          rw [hstar]
-          ring
-    _ = (star ζ) ^ N * mpvOverlap (d := d) A A N := by
-          simp [mpvOverlap, Finset.mul_sum]
+        (star ζ) ^ N * mpvOverlap (d := d) A A N :=
+  fun N hN => mpvOverlap_eq_star_pow_mul_self_of_mpv_eq_pow_mul_at (hmpv N hN)
 
-/-- If two self-overlaps have the same nonzero norm limit, and one scales from
-the other by powers of `ζ * conj ζ`, then `ζ` has unit norm. -/
-theorem norm_eq_one_of_selfOverlap_scale_at_nonzero_limit
+private theorem norm_eq_one_of_selfOverlap_scale_at_nonzero_limit_pos_aux
     {D D' : ℕ} {A : MPSTensor d D} {B : MPSTensor d D'} {ζ : ℂ}
     {r : ℝ} (hr : r ≠ 0)
     (hAA : Filter.Tendsto (fun N => ‖mpvOverlap (d := d) A A N‖) Filter.atTop (nhds r))
     (hBB : Filter.Tendsto (fun N => ‖mpvOverlap (d := d) B B N‖) Filter.atTop (nhds r))
-    (hSelf : ∀ N : ℕ,
+    (hSelf : ∀ N : ℕ, 0 < N →
       mpvOverlap (d := d) B B N =
         (ζ * starRingEnd ℂ ζ) ^ N * mpvOverlap (d := d) A A N) :
     ‖ζ‖ = 1 := by
@@ -211,57 +196,6 @@ theorem norm_eq_one_of_selfOverlap_scale_at_nonzero_limit
       ((fun N => ‖mpvOverlap (d := d) B B N‖) /
         fun N => ‖mpvOverlap (d := d) A A N‖) Filter.atTop (nhds 1)
     simpa [div_self hr] using hBB.div hAA hr
-  have hRatioEq : ∀ᶠ N in Filter.atTop,
-      ‖mpvOverlap (d := d) B B N‖ / ‖mpvOverlap (d := d) A A N‖ = (‖ζ‖ ^ 2) ^ N := by
-    filter_upwards [hAA_ne] with N hN
-    rw [hSelf N, norm_mul, norm_pow, show ‖ζ * starRingEnd ℂ ζ‖ = ‖ζ‖ ^ 2 from by
-      rw [norm_mul, RCLike.norm_conj, sq]]
-    rw [← pow_mul, Nat.mul_comm, pow_mul]
-    exact mul_div_cancel_of_imp (fun h => absurd h hN)
-  have hPow : Filter.Tendsto (fun N => (‖ζ‖ ^ 2) ^ N) Filter.atTop (nhds 1) :=
-    hRatio.congr' hRatioEq
-  have h1 : ‖ζ‖ ^ 2 = 1 := by
-    by_contra hne'
-    rcases lt_or_gt_of_ne hne' with h | h
-    · exact one_ne_zero
-        (tendsto_nhds_unique hPow (tendsto_pow_atTop_nhds_zero_of_lt_one (by positivity) h))
-    · have hlt2 : ∀ᶠ n in Filter.atTop, (‖ζ‖ ^ 2) ^ n < 2 :=
-        hPow.eventually (Iio_mem_nhds (by norm_num : (1 : ℝ) < 2))
-      rcases ((Filter.tendsto_atTop.1 (tendsto_pow_atTop_atTop_of_one_lt h) 2).and hlt2).exists
-        with ⟨n, hn1, hn2⟩
-      exact not_lt_of_ge hn1 hn2
-  nlinarith [norm_nonneg ζ]
-
-/-- If two self-overlaps both have norm limit `1`, and one scales from the other by powers of
-`ζ * conj ζ`, then `ζ` has unit norm. -/
-theorem norm_eq_one_of_selfOverlap_scale
-    {D D' : ℕ} {A : MPSTensor d D} {B : MPSTensor d D'} {ζ : ℂ}
-    (hAA : Filter.Tendsto (fun N => ‖mpvOverlap (d := d) A A N‖) Filter.atTop (nhds 1))
-    (hBB : Filter.Tendsto (fun N => ‖mpvOverlap (d := d) B B N‖) Filter.atTop (nhds 1))
-    (hSelf : ∀ N : ℕ,
-      mpvOverlap (d := d) B B N =
-        (ζ * starRingEnd ℂ ζ) ^ N * mpvOverlap (d := d) A A N) :
-    ‖ζ‖ = 1 :=
-  norm_eq_one_of_selfOverlap_scale_at_nonzero_limit one_ne_zero hAA hBB hSelf
-
-/-- Positive-length form of `norm_eq_one_of_selfOverlap_scale`.  The proof only
-uses the scaling identity eventually, so no value at length zero is required. -/
-theorem norm_eq_one_of_selfOverlap_scale_pos
-    {D D' : ℕ} {A : MPSTensor d D} {B : MPSTensor d D'} {ζ : ℂ}
-    (hAA : Filter.Tendsto (fun N => ‖mpvOverlap (d := d) A A N‖) Filter.atTop (nhds 1))
-    (hBB : Filter.Tendsto (fun N => ‖mpvOverlap (d := d) B B N‖) Filter.atTop (nhds 1))
-    (hSelf : ∀ N : ℕ, 0 < N →
-      mpvOverlap (d := d) B B N =
-        (ζ * starRingEnd ℂ ζ) ^ N * mpvOverlap (d := d) A A N) :
-    ‖ζ‖ = 1 := by
-  have hAA_ne : ∀ᶠ N in Filter.atTop, ‖mpvOverlap (d := d) A A N‖ ≠ 0 :=
-    hAA.eventually_ne one_ne_zero
-  have hRatio : Filter.Tendsto (fun N => ‖mpvOverlap (d := d) B B N‖ /
-      ‖mpvOverlap (d := d) A A N‖) Filter.atTop (nhds 1) := by
-    change Filter.Tendsto
-      ((fun N => ‖mpvOverlap (d := d) B B N‖) /
-        fun N => ‖mpvOverlap (d := d) A A N‖) Filter.atTop (nhds 1)
-    simpa using hBB.div hAA one_ne_zero
   have hRatioEq : ∀ᶠ N in Filter.atTop,
       ‖mpvOverlap (d := d) B B N‖ / ‖mpvOverlap (d := d) A A N‖ = (‖ζ‖ ^ 2) ^ N := by
     filter_upwards [hAA_ne, Filter.eventually_ge_atTop 1] with N hN hNpos
@@ -284,7 +218,43 @@ theorem norm_eq_one_of_selfOverlap_scale_pos
       exact not_lt_of_ge hn1 hn2
   nlinarith [norm_nonneg ζ]
 
+/-- If two self-overlaps have the same nonzero norm limit, and one scales from
+the other by powers of `ζ * conj ζ`, then `ζ` has unit norm. -/
+theorem norm_eq_one_of_selfOverlap_scale_at_nonzero_limit
+    {D D' : ℕ} {A : MPSTensor d D} {B : MPSTensor d D'} {ζ : ℂ}
+    {r : ℝ} (hr : r ≠ 0)
+    (hAA : Filter.Tendsto (fun N => ‖mpvOverlap (d := d) A A N‖) Filter.atTop (nhds r))
+    (hBB : Filter.Tendsto (fun N => ‖mpvOverlap (d := d) B B N‖) Filter.atTop (nhds r))
+    (hSelf : ∀ N : ℕ,
+      mpvOverlap (d := d) B B N =
+        (ζ * starRingEnd ℂ ζ) ^ N * mpvOverlap (d := d) A A N) :
+    ‖ζ‖ = 1 :=
+  norm_eq_one_of_selfOverlap_scale_at_nonzero_limit_pos_aux hr hAA hBB
+    (fun N _hN => hSelf N)
 
+/-- If two self-overlaps both have norm limit `1`, and one scales from the other by powers of
+`ζ * conj ζ`, then `ζ` has unit norm. -/
+theorem norm_eq_one_of_selfOverlap_scale
+    {D D' : ℕ} {A : MPSTensor d D} {B : MPSTensor d D'} {ζ : ℂ}
+    (hAA : Filter.Tendsto (fun N => ‖mpvOverlap (d := d) A A N‖) Filter.atTop (nhds 1))
+    (hBB : Filter.Tendsto (fun N => ‖mpvOverlap (d := d) B B N‖) Filter.atTop (nhds 1))
+    (hSelf : ∀ N : ℕ,
+      mpvOverlap (d := d) B B N =
+        (ζ * starRingEnd ℂ ζ) ^ N * mpvOverlap (d := d) A A N) :
+    ‖ζ‖ = 1 :=
+  norm_eq_one_of_selfOverlap_scale_at_nonzero_limit one_ne_zero hAA hBB hSelf
+
+/-- Positive-length form of `norm_eq_one_of_selfOverlap_scale`.  The proof only
+uses the scaling identity eventually, so no value at length zero is required. -/
+theorem norm_eq_one_of_selfOverlap_scale_pos
+    {D D' : ℕ} {A : MPSTensor d D} {B : MPSTensor d D'} {ζ : ℂ}
+    (hAA : Filter.Tendsto (fun N => ‖mpvOverlap (d := d) A A N‖) Filter.atTop (nhds 1))
+    (hBB : Filter.Tendsto (fun N => ‖mpvOverlap (d := d) B B N‖) Filter.atTop (nhds 1))
+    (hSelf : ∀ N : ℕ, 0 < N →
+      mpvOverlap (d := d) B B N =
+        (ζ * starRingEnd ℂ ζ) ^ N * mpvOverlap (d := d) A A N) :
+    ‖ζ‖ = 1 :=
+  norm_eq_one_of_selfOverlap_scale_at_nonzero_limit_pos_aux one_ne_zero hAA hBB hSelf
 
 /-! ### Symmetry, transitivity, and cast-composition of `GaugePhaseEquiv`
 

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -100,26 +100,6 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
     gauge invariance transports this conclusion back to the original tensor.
 \end{proof}
 
-\begin{lemma}[Exact MPV phase equivalence determines the bond dimension]
-    \label{lem:mpv_block_phase_equiv_dim_eq}
-    \lean{MPSTensor.MPVBlockPhaseEquiv.dim_eq}
-    \leanok
-    \uses{def:mpv_block_phase_equiv}
-    Suppose that, for two tensors $A$ and $B$ and some nonzero
-    $\zeta\in\C$,
-    \[
-        \ket{V^{(N)}(B)}=\zeta^N\ket{V^{(N)}(A)}
-    \]
-    at every nonnegative length $N$. Then $A$ and $B$ have the same bond
-    dimension.
-\end{lemma}
-
-\begin{proof}\leanok
-    At length zero the two coefficients are the traces of the corresponding
-    identity matrices, while $\zeta^0=1$. Their equality is therefore equality
-    of the two bond dimensions.
-\end{proof}
-
 \begin{theorem}[Non-decaying rectangular overlap determines the bond dimension]
     \label{thm:rect_overlap_norm_one_dim_eq}
     \lean{MPSTensor.dim_eq_of_mpvOverlap_norm_tendsto_one_of_irreducible_TP}
@@ -548,7 +528,7 @@ transfer map), the BNT definition algebraically (eventual block injectivity).
 
 \section{Permutation rigidity for bases of normal tensors}
 
-When two bases of normal tensors generate the same MPV subspace at every length,
+When two bases of normal tensors generate the same MPV subspace at every positive length,
 the blocks must agree up to a permutation and per-block gauge phases. The
 argument turns the equality of spans into an invertible change-of-basis matrix,
 then analyses its asymptotics through the overlaps.
@@ -1024,7 +1004,8 @@ single family.
     \leanok
     \uses{def:mpv}
     Two blocks $A$ and $B$ are MPV-phase equivalent if there is a nonzero
-    scalar $\zeta$ such that, for every system size~$N$ and every physical word,
+    scalar $\zeta$ such that, for every positive system size~$N$ and every
+    physical word,
     \[
         V^{(N)}(B)_\sigma
         =
@@ -1060,7 +1041,8 @@ single family.
         =
         \zeta^N\ket{V^{(N)}(B_j)}
     \]
-    for every length~$N$. The associated tuple enumerates the finite quotient,
+    for every positive length~$N$. The associated tuple enumerates the finite
+    quotient,
     chooses one representative per class, enumerates that representative first
     in its class, records the scalar relating the representative to each member,
     and proves that distinct representatives are not MPV-phase equivalent. The
@@ -1438,7 +1420,8 @@ form by quotienting gauge-phase-equivalent blocks into sectors.
         \item \textbf{global unit witness:} $|\mu_k| = 1$ for some $k$.
     \end{enumerate}
     Then there exists a sector decomposition $P$ such that $P$ and
-    $\bigoplus_{k=1}^{r} \mu_k B_k$ generate the same MPV family at every length,
+    $\bigoplus_{k=1}^{r} \mu_k B_k$ generate the same MPV family at every
+    positive length,
     and $P$ satisfies the basis-of-normal-tensors conditions
     (Definition~\ref{def:bnt_cpsv}) together with the multiplicity, span, and
     weight-bound conditions of Definition~\ref{def:sector_bnt_cf}.
@@ -1523,7 +1506,8 @@ a contradiction.
 \begin{proof}\leanok
     \uses{thm:rect_overlap_norm_one_dim_eq}
     Choose $\zeta\neq0$ with
-    $\ket{V^{(N)}(Y)}=\zeta^N\ket{V^{(N)}(X)}$ for every length~$N$. The
+    $\ket{V^{(N)}(Y)}=\zeta^N\ket{V^{(N)}(X)}$ for every positive length~$N$.
+    The
     normalized self-overlaps give $|O_{XX}(N)|\to 1$, and the phase relation
     gives
     \[
@@ -1565,8 +1549,8 @@ a contradiction.
     Lemma~\ref{lem:prepared_phase_equiv_dim_eq} identifies the bond dimensions.
     If no gauge-phase relation existed after this identification,
     Theorem~\ref{thm:not_gauge_phase_eventually_not_proportional} would give a
-    length $N$ at which the two MPV states are not proportional. This contradicts
-    the assumed scalar-power identity at every length.
+    positive length $N$ at which the two MPV states are not proportional. This
+    contradicts the assumed scalar-power identity at every positive length.
 \end{proof}
 
 \begin{lemma}[Prepared BNT representative classes preserve bond dimension]%


### PR DESCRIPTION
## Mathematical change

MPV phase equivalence now compares finite chains only for positive lengths. Consequently, its former bond-dimension lemma, which evaluated the equality at length zero and compared traces of identity matrices, is removed.

For normal tensors, equality of bond dimensions is instead deduced from the asymptotic mixed-overlap criterion. The proof first derives unit modulus of the phase from normalized self-overlaps and then applies the rectangular overlap theorem. The phase-class contraction and prepared BNT construction now produce positive-length MPV equality throughout.

The finite-sum identity for the total dimension of a phase-class decomposition is retained: it is a genuine multiplicity identity and no longer presented as an empty-chain argument. The obsolete theorem that upgraded prepared positive-length equality using a separately supplied total-dimension equality is removed.

The blueprint statement for CPSV16 Proposition prop:char-BNT is updated to state positive system sizes explicitly.

No axioms are introduced.

## Verification

- Lean toolchain: v4.32.0
- lake build TNLean: 9,533 targets completed
- changed declarations axiom audit: propext, Classical.choice, Quot.sound only
- no new sorry, axiom, admit, native_decide, or unsafeCast
- git diff --check

Blueprint web generation could not be run locally because the installed leanblueprint Python environment cannot load its pygraphviz extension. The Lean declarations and the complete Lean library build successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core MPS canonical-form and fundamental-theorem proof chains across many files; mathematical scope change (no longer inferring bond dimension from length zero) but behavior is intentionally aligned with asymptotic overlap theory and existing `SameMPV₂Pos` layering.
> 
> **Overview**
> **MPV phase equivalence** (`MPVBlockPhaseEquiv` and dependents) now requires the scalar-power identity only for **positive** chain lengths `N > 0`, aligned with CPSV16 prop:char-BNT. The old **`MPVBlockPhaseEquiv.dim_eq`** lemma (bond dimension from length-zero traces) is **removed**.
> 
> Downstream proofs switch to **`_pos`** overlap lemmas (`mpvOverlap_self_scale_of_mpv_eq_pow_mul_pos`, `norm_eq_one_of_selfOverlap_scale_pos`, etc.) and use **`eventually_ge_atTop 1`** where limit arguments need the scaling identity only eventually. **Prepared BNT** and phase-class contraction now state **`SameMPV₂Pos`** / **`collapsedBntSectorDecomp_sameMPV₂Pos`** instead of full **`SameMPV₂`**. **`exists_isBNTCanonicalForm_afterBlocking_of_totalDim`** (upgrade via `D = P.totalDim`) is **deleted**.
> 
> The blueprint drops the length-zero dimension lemma and states positive lengths explicitly in definitions and supplier theorems.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26e0fe61f9cdfafcbfa676a2b767afa40a07722c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->