### PR TITLE
refactor(MPS/FundamentalTheorem): make positive equality canonical

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean
@@ -377,9 +377,10 @@ theorem coeff_identity_via_matched_mpv_phase_proportional
 Assume a full matched-basis equivalence `β : Fin Q.basisCount ≃
 Fin P.basisCount`, with every `Q`-block gauge-phase equivalent to the
 corresponding `P`-block.  Substituting the MPV phase relation for each
-matched pair into `SameMPV₂ P.toTensor Q.toTensor`, reindexing the `Q`-sum
+matched pair into `SameMPV₂Pos P.toTensor Q.toTensor`, reindexing the `Q`-sum
 by `β`, and applying A-only BNT linear independence (`hP.bnt_data`) gives
-an eventual exact coefficient identity
+an eventual exact coefficient identity.  Equality of the total MPV families
+is required at every positive length.
 
 `P.coeff N (β k) = ζ_k^N * Q.coeff N k`.
 

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean
@@ -96,7 +96,7 @@ specific phases `ζ k` satisfying
 
 `mpv (Q.basis k) σ = (ζ k)^N * mpv (P.basis (β k)) σ`,
 
-then `SameMPV₂ P.toTensor Q.toTensor` and the BNT linear independence of the
+then positive-length equality of the two total MPV families and BNT linear independence of the
 `P`-basis force the eventual exact coefficient identities
 
 `P.coeff N (β k) = (ζ k)^N * Q.coeff N k`.
@@ -106,7 +106,7 @@ function explicit.  The coefficient/weight comparison is the CPSV16 Appendix
 MPV proof, lines 1187--1188, part of the equal-MPV corollary; the per-block
 gauge matrices are combined afterwards into `X = ⊕_k (𝟙_{r_k} ⊗ X_k)` in
 lines 1189--1192. -/
-theorem coeff_identity_via_matched_mpv_phasePos
+theorem coeff_identity_via_matched_mpv_phase
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P)
     (hEqual : SameMPV₂Pos P.toTensor Q.toTensor)
@@ -217,24 +217,9 @@ theorem coeff_identity_via_matched_mpv_phasePos
   have h := hN₀ N (le_of_lt hN) (β k)
   simpa [a, b] using h
 
-/-- Reformulation for the all-length `SameMPV₂` form. -/
-theorem coeff_identity_via_matched_mpv_phase
-    {P Q : SectorDecomposition d}
-    (hP : IsBNTCanonicalForm P)
-    (hEqual : SameMPV₂ P.toTensor Q.toTensor)
-    (β : Fin Q.basisCount ≃ Fin P.basisCount)
-    (ζ : Fin Q.basisCount → ℂ)
-    (hζ_mpv : ∀ (k : Fin Q.basisCount) (N : ℕ) (σ : Fin N → Fin d),
-      mpv (Q.basis k) σ = (ζ k) ^ N * mpv (P.basis (β k)) σ) :
-    ∀ k : Fin Q.basisCount, ∃ N₀, ∀ N > N₀,
-      P.coeff N (β k) = (ζ k) ^ N * Q.coeff N k :=
-  coeff_identity_via_matched_mpv_phasePos
-    (P := P) (Q := Q) hP hEqual.toSameMPV₂Pos β ζ
-      (fun k N _hN σ => hζ_mpv k N σ)
-
 /-- **Proportional matched-phase coefficient identity (scalar-threaded).**
 
-This is the proportional analogue of `coeff_identity_via_matched_mpv_phasePos`.
+This is the proportional analogue of `coeff_identity_via_matched_mpv_phase`.
 Assume a full matched-basis bijection `β` equipped with phases `ζ k` satisfying
 
 `mpv (Q.basis k) σ = (ζ k)^N * mpv (P.basis (β k)) σ`,
@@ -402,7 +387,7 @@ This is the formal counterpart of CPSV16 Appendix MPV proof, line 1188's exact
 power-sum comparison.  The finite power-sum recovery of copy weights is a
 separate algebraic step, applied after these eventual coefficient identities
 have been obtained. -/
-theorem coeff_identity_via_global_gaugePos
+theorem coeff_identity_via_global_gauge
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
     (hEqual : SameMPV₂Pos P.toTensor Q.toTensor)
@@ -433,24 +418,10 @@ theorem coeff_identity_via_global_gaugePos
       mpv (Q.basis k) σ = (ζ k) ^ N * mpv (P.basis (β k)) σ := fun k =>
     (phaseData k).property.2
   -- Feed the matched MPV phases into the fixed-phase identity.
-  have hCoeff := coeff_identity_via_matched_mpv_phasePos
+  have hCoeff := coeff_identity_via_matched_mpv_phase
     (P := P) (Q := Q) hP hEqual β ζ hζ_mpv
   intro k
   obtain ⟨N₀, hN₀⟩ := hCoeff k
   exact ⟨ζ k, hζ_norm k, N₀, hN₀⟩
-
-/-- Reformulation for the all-length `SameMPV₂` form. -/
-theorem coeff_identity_via_global_gauge
-    {P Q : SectorDecomposition d}
-    (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hEqual : SameMPV₂ P.toTensor Q.toTensor)
-    (β : Fin Q.basisCount ≃ Fin P.basisCount)
-    (hMatch : ∀ k : Fin Q.basisCount, ∃ h : P.basisDim (β k) = Q.basisDim k,
-      GaugePhaseEquiv
-        (cast (congr_arg (MPSTensor d) h) (P.basis (β k))) (Q.basis k)) :
-    ∀ k : Fin Q.basisCount, ∃ ζ : ℂ, ‖ζ‖ = 1 ∧ ∃ N₀, ∀ N > N₀,
-      P.coeff N (β k) = ζ ^ N * Q.coeff N k :=
-  coeff_identity_via_global_gaugePos
-    (P := P) (Q := Q) hP hQ hEqual.toSameMPV₂Pos β hMatch
 
 end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
@@ -360,8 +360,10 @@ The matched coefficient identities give the sectorwise power-sum comparison
   \sum_q \mu_{\beta(k),q}^N = \sum_q (\zeta_k \nu_{k,q})^N
 \]
 for all sufficiently large \(N\).  Finite power-sum comparison then gives the
-copy permutations and weight identities. -/
-theorem ft_sector_bnt_equal_matched_copy_weight_witnessesPos
+copy permutations and weight identities.
+
+Source: CPSV16, Appendix MPV proof, lines 1187–1192. -/
+theorem ft_sector_bnt_equal_matched_copy_weight_witnesses
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
     (hEqual : SameMPV₂Pos P.toTensor Q.toTensor) :
@@ -378,7 +380,7 @@ theorem ft_sector_bnt_equal_matched_copy_weight_witnessesPos
               Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ))) ∧
       Nonempty (SectorBNTCopyWeightMatching (P := P) (Q := Q) β ζ) := by
   classical
-  obtain ⟨β, hβMatchFull⟩ := bijective_match_of_sameMPVPos hP hQ hEqual
+  obtain ⟨β, hβMatchFull⟩ := bijective_match_of_sameMPV hP hQ hEqual
   let hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k :=
     fun k => (hβMatchFull k).choose
   let hGPE : ∀ k : Fin Q.basisCount,
@@ -420,32 +422,12 @@ theorem ft_sector_bnt_equal_matched_copy_weight_witnessesPos
     intro k hzero
     have hnorm := hζ_norm k
     simp [hzero] at hnorm
-  have hCoeff := coeff_identity_via_matched_mpv_phasePos hP hEqual β ζ
+  have hCoeff := coeff_identity_via_matched_mpv_phase hP hEqual β ζ
     (fun k N _hN σ => hMpv k N σ)
   let W : SectorBNTCopyWeightMatching (P := P) (Q := Q) β ζ :=
     SectorBNTCopyWeightMatching.of_coeff_identity
       (P := P) (Q := Q) β ζ hζ_ne hCoeff
   exact ⟨β, hDim, ζ, Xblock, hζ_norm, hConj, ⟨W⟩⟩
-
-/-- Reformulation for the all-length `SameMPV₂` form. -/
-theorem ft_sector_bnt_equal_matched_copy_weight_witnesses
-    {P Q : SectorDecomposition d}
-    (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
-    ∃ (β : Fin Q.basisCount ≃ Fin P.basisCount)
-      (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
-      (ζ : Fin Q.basisCount → ℂ)
-      (Xblock : (k : Fin Q.basisCount) → GL (Fin (Q.basisDim k)) ℂ),
-      (∀ k : Fin Q.basisCount, ‖ζ k‖ = 1) ∧
-      (∀ (k : Fin Q.basisCount) (i : Fin d),
-        Q.basis k i =
-          ζ k • ((Xblock k : Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ) *
-            (cast (congr_arg (MPSTensor d) (hDim k)) (P.basis (β k))) i *
-            (((Xblock k)⁻¹ : GL (Fin (Q.basisDim k)) ℂ) :
-              Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ))) ∧
-      Nonempty (SectorBNTCopyWeightMatching (P := P) (Q := Q) β ζ) :=
-  ft_sector_bnt_equal_matched_copy_weight_witnessesPos
-    (P := P) (Q := Q) hP hQ hEqual.toSameMPV₂Pos
 
 /-- **BNT equal-MPV sector-witness theorem.**
 
@@ -453,8 +435,10 @@ If two BNT sector decompositions satisfying `IsBNTCanonicalForm` generate the
 same MPV family, then their BNT basis sectors are bijectively matched by
 gauge-phase equivalence.  For each matched sector, the copy multiplicities
 agree and the raw copy weights agree after multiplying by the inverse of the
-gauge phase and permuting the copies. -/
-theorem ft_sector_bnt_equal_sector_dataPos
+gauge phase and permuting the copies.
+
+Source: CPSV16, §II.C lines 354–361 and Appendix MPV proof, lines 1182–1188. -/
+theorem ft_sector_bnt_equal_sector_data
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
     (hEqual : SameMPV₂Pos P.toTensor Q.toTensor) :
@@ -467,7 +451,7 @@ theorem ft_sector_bnt_equal_sector_dataPos
           ∀ q : Fin (Q.copies k), Q.weight k q = (ζ k)⁻¹ * P.weight (β k) (τ q) := by
   classical
   obtain ⟨β, hDim, ζ, Xblock, hζ_norm, hConj, ⟨W⟩⟩ :=
-    ft_sector_bnt_equal_matched_copy_weight_witnessesPos
+    ft_sector_bnt_equal_matched_copy_weight_witnesses
       (P := P) (Q := Q) hP hQ hEqual
   let hMatch : ∀ k : Fin Q.basisCount, ∃ h : P.basisDim (β k) = Q.basisDim k,
       GaugePhaseEquiv (cast (congr_arg (MPSTensor d) h) (P.basis (β k))) (Q.basis k) :=
@@ -483,21 +467,6 @@ theorem ft_sector_bnt_equal_sector_dataPos
   refine ⟨β, hMatch, hCopies, ζ, hζ_norm, ?_⟩
   intro k
   exact ⟨W.copy_equiv k, W.weight_eq k⟩
-
-/-- Reformulation for the all-length `SameMPV₂` form. -/
-theorem ft_sector_bnt_equal_sector_data
-    {P Q : SectorDecomposition d}
-    (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
-    ∃ (β : Fin Q.basisCount ≃ Fin P.basisCount),
-      (∀ k, ∃ h : P.basisDim (β k) = Q.basisDim k,
-        GaugePhaseEquiv (cast (congr_arg (MPSTensor d) h) (P.basis (β k))) (Q.basis k)) ∧
-      (∀ k, P.copies (β k) = Q.copies k) ∧
-      ∃ ζ : Fin Q.basisCount → ℂ, (∀ k, ‖ζ k‖ = 1) ∧
-        ∀ k, ∃ τ : Fin (Q.copies k) ≃ Fin (P.copies (β k)),
-          ∀ q : Fin (Q.copies k), Q.weight k q = (ζ k)⁻¹ * P.weight (β k) (τ q) :=
-  ft_sector_bnt_equal_sector_dataPos
-    (P := P) (Q := Q) hP hQ hEqual.toSameMPV₂Pos
 
 /-- **Global gauge in matched flattened coordinates.**
 
@@ -517,8 +486,10 @@ matrix `⊕_k (𝟙_{r_k} ⊗ X_k)`.  The remaining conversion from this
 matched-coordinate presentation to a literal `GaugeEquiv P.toTensor Q.toTensor`
 is only a coordinate permutation/cast of the flattened direct sum and is
 intentionally not hidden here; the theorem exposes the explicit CPSV16
-Appendix MPV proof witness rather than an opaque existential. -/
-theorem ft_sector_bnt_equal_global_gaugePos
+Appendix MPV proof witness rather than an opaque existential.
+
+Source: CPSV16, Appendix MPV proof, lines 1189–1192. -/
+theorem ft_sector_bnt_equal_global_gauge
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
     (hEqual : SameMPV₂Pos P.toTensor Q.toTensor) :
@@ -551,7 +522,7 @@ theorem ft_sector_bnt_equal_global_gaugePos
                   (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) := by
   classical
   obtain ⟨β, hDim, ζ, Xblock, hζ_norm, hConj, ⟨W⟩⟩ :=
-    ft_sector_bnt_equal_matched_copy_weight_witnessesPos
+    ft_sector_bnt_equal_matched_copy_weight_witnesses
       (P := P) (Q := Q) hP hQ hEqual
   have hζ_ne : ∀ k : Fin Q.basisCount, ζ k ≠ 0 := by
     intro k hzero
@@ -568,48 +539,5 @@ theorem ft_sector_bnt_equal_global_gaugePos
       (P := P) (Q := Q) β hDim ζ Xblock hζ_ne hConj W
   exact ⟨β, hDim, hCopies, τ, ζ, Xblock, hζ_norm, hConj, W.weight_eq, X, hXdef,
     hGauge⟩
-
-/-- Reformulation for the all-length `SameMPV₂` form (the CPSV16 Corollary II.2
-convention).
-
-The hypothesis is the source's all-length MPV equality, but the proof consumes only its
-positive-length restriction (`hEqual.toSameMPV₂Pos`): the empty-word (`N = 0`) component
-of `SameMPV₂` carries only the bond-dimension count, which the BNT construction already
-fixes, so it never enters the gauge-matching argument. The all-length form is kept in the
-signature to match the source statement; see
-`docs/paper-gaps/cpsv16_zero_tail_length_zero_decomposition.tex`. -/
-theorem ft_sector_bnt_equal_global_gauge
-    {P Q : SectorDecomposition d}
-    (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
-    ∃ (β : Fin Q.basisCount ≃ Fin P.basisCount)
-      (hDim : ∀ k : Fin Q.basisCount, P.basisDim (β k) = Q.basisDim k)
-      (_hCopies : ∀ k : Fin Q.basisCount, P.copies (β k) = Q.copies k)
-      (τ : (k : Fin Q.basisCount) → Fin (Q.copies k) ≃ Fin (P.copies (β k)))
-      (ζ : Fin Q.basisCount → ℂ)
-      (Xblock : (k : Fin Q.basisCount) → GL (Fin (Q.basisDim k)) ℂ),
-      (∀ k : Fin Q.basisCount, ‖ζ k‖ = 1) ∧
-      (∀ (k : Fin Q.basisCount) (i : Fin d),
-        Q.basis k i =
-          ζ k • ((Xblock k : Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ) *
-            (cast (congr_arg (MPSTensor d) (hDim k)) (P.basis (β k))) i *
-            (((Xblock k)⁻¹ : GL (Fin (Q.basisDim k)) ℂ) :
-              Matrix (Fin (Q.basisDim k)) (Fin (Q.basisDim k)) ℂ))) ∧
-      (∀ (k : Fin Q.basisCount) (q : Fin (Q.copies k)),
-        Q.weight k q = (ζ k)⁻¹ * P.weight (β k) (τ k q)) ∧
-      ∃ X : GL (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ,
-        X = globalGaugeOfBlocks (matched_block_gauge (Q := Q) Xblock) ∧
-        ∀ i : Fin d,
-          toTensorFromBlocks (d := d) (μ := Q.flatWeight) Q.flatBasis i =
-            (X : Matrix (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s))
-              (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) *
-              toTensorFromBlocks (d := d)
-                (μ := matched_p_weight (P := P) (Q := Q) β τ)
-                (matched_p_basis (P := P) (Q := Q) β hDim) i *
-              (((X)⁻¹ : GL (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) :
-                Matrix (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s))
-                  (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) :=
-  ft_sector_bnt_equal_global_gaugePos
-    (P := P) (Q := Q) hP hQ hEqual.toSameMPV₂Pos
 
 end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean
@@ -16,7 +16,8 @@ global-gauge construction is at lines 1189–1192 of the Appendix MPV proof.
 
 The bundled-witness theorem `ft_sector_bnt_equal_mps_gaugeEquiv_witnesses`
 exposes, for any two BNT sector decompositions $P$ and $Q$ satisfying
-`IsBNTCanonicalForm` and generating the same MPV family:
+`IsBNTCanonicalForm` and generating the same MPV family at every positive
+length:
 
 * the basis bijection $β : \{1,\dots,g_Q\} \simeq \{1,\dots,g_P\}$ between
   corresponding BNT sectors;
@@ -67,7 +68,7 @@ variable {d : ℕ}
 /-- **BNT equal-MPV global-gauge witness.**
 
 If two BNT sector decompositions satisfying `IsBNTCanonicalForm` generate the
-same MPV family, then there exist:
+same MPV family at every positive length, then there exist:
 
 * a basis bijection $β : \{1,\dots,g_Q\} \simeq \{1,\dots,g_P\}$,
 * per-block bond-dimension equalities $D_P^{(βk)} = D_Q^{(k)}$,
@@ -429,8 +430,8 @@ private lemma permMatrix_conj_eq_submatrix {n : Type*}
 /-- **BNT equal-MPV literal global-gauge form.**
 
 If two BNT sector decompositions satisfying `IsBNTCanonicalForm` generate the
-same MPV family, then their total bond dimensions agree, and there exists an
-explicit
+same MPV family at every positive length, then their total bond dimensions
+agree, and there exists an explicit
 $Y \in \mathrm{GL}(Q.\mathrm{totalDim},\mathbb{C})$ realizing the global gauge
 equation
 $$V_Q^i \;=\; Y \,\bigl(\mathrm{cast}\;V_P^i\bigr)\, Y^{-1}$$
@@ -553,10 +554,10 @@ theorem ft_sector_bnt_equal_mps_gaugeEquiv_literal
 
 /-- **Canonical Form II equal-case unitary global gauge.**
 
-If two BNT canonical forms generate the same MPV family, their literal total
-tensors are related by a unitary gauge.  The gauge is the product of the
-block-diagonal direct sum of the matched sector unitaries and the unitary
-permutation that restores the original sector coordinates.
+If two BNT canonical forms generate the same MPV family at every positive
+length, their literal total tensors are related by a unitary gauge.  The gauge
+is the product of the block-diagonal direct sum of the matched sector unitaries
+and the unitary permutation that restores the original sector coordinates.
 
 Source: Cirac et al., arXiv:1606.00608, Corollary C.5, lines 1197--1199. -/
 private theorem ft_sector_bnt_equal_mps_unitaryGauge_literal

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean
@@ -14,7 +14,7 @@ the main-text statement is at lines 354–361, the appendix restatement is at
 lines 1172–1179, the copy-weight comparison is at line 1188, and the
 global-gauge construction is at lines 1189–1192 of the Appendix MPV proof.
 
-The bundled-witness theorem `ft_sector_bnt_equal_mps_gaugeEquiv_witnessesPos`
+The bundled-witness theorem `ft_sector_bnt_equal_mps_gaugeEquiv_witnesses`
 exposes, for any two BNT sector decompositions $P$ and $Q$ satisfying
 `IsBNTCanonicalForm` and generating the same MPV family:
 
@@ -94,7 +94,7 @@ through the matched bijections gives the
 CPSV16 §II.C lines 354–361 and Appendix MPV proof lines 1172–1179 state the
 equal-MPV corollary; Appendix MPV proof lines 1182–1192 supply the block
 matching, copy-weight comparison, and global-gauge construction used here. -/
-theorem ft_sector_bnt_equal_mps_gaugeEquiv_witnessesPos
+theorem ft_sector_bnt_equal_mps_gaugeEquiv_witnesses
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
     (hEqual : SameMPV₂Pos P.toTensor Q.toTensor) :
@@ -127,7 +127,7 @@ theorem ft_sector_bnt_equal_mps_gaugeEquiv_witnessesPos
                      (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ)) := by
   classical
   obtain ⟨β, hDim, hCopies, τ, ζ, Xblock, hζ_norm, hConj, hWeight, X, _hXdef, hGauge⟩ :=
-    ft_sector_bnt_equal_global_gaugePos hP hQ hEqual
+    ft_sector_bnt_equal_global_gauge hP hQ hEqual
   -- `P.totalDim = Q.totalDim` follows from `sectorFlatEquiv` plus matched dims
   have hTotal : P.totalDim = Q.totalDim :=
     SectorDecomposition.totalDim_eq_of_match (P := P) (Q := Q) β hDim τ
@@ -143,8 +143,8 @@ differ only by a $\Sigma$-level permutation of flattened sector indices
 along `sectorFlatSigmaEquiv`; equivalently a permutation of
 `Fin Q.totalDim` (after the bond-dimension equality) by
 `sectorFlatDimEquiv`.  This lets us upgrade the matched-coordinate gauge
-equation of `ft_sector_bnt_equal_mps_gaugeEquiv_witnessesPos` into the literal
-form `ft_sector_bnt_equal_mps_gaugeEquiv_literalPos`, the equal-MPV corollary
+equation of `ft_sector_bnt_equal_mps_gaugeEquiv_witnesses` into the literal
+form `ft_sector_bnt_equal_mps_gaugeEquiv_literal`, the equal-MPV corollary
 form (CPSV16 §II.C lines 354–361). -/
 
 /-- Cast of an `MPSTensor` along a bond-dimension equality, evaluated at one
@@ -438,13 +438,13 @@ at every physical site $i$, where the inner factor is the bond-dim cast of the
 literal $P$-tensor along the total-dimension equality.
 
 This reformulates the matched-coordinate gauge equation
-`ft_sector_bnt_equal_mps_gaugeEquiv_witnessesPos` (CPSV16 Appendix MPV proof,
+`ft_sector_bnt_equal_mps_gaugeEquiv_witnesses` (CPSV16 Appendix MPV proof,
 lines 1189–1192) into the equal-MPV corollary labelled II_cor2 in CPSV16
 §II.C lines 354–361 by composing the matched-coordinate global gauge with the
 sector permutation.
 
 CPSV16 §II.C lines 354–361. -/
-theorem ft_sector_bnt_equal_mps_gaugeEquiv_literalPos
+theorem ft_sector_bnt_equal_mps_gaugeEquiv_literal
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
     (hEqual : SameMPV₂Pos P.toTensor Q.toTensor) :
@@ -460,7 +460,7 @@ theorem ft_sector_bnt_equal_mps_gaugeEquiv_literalPos
               Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) := by
   classical
   obtain ⟨β, hDim, _hCopies, τ, _ζ, _Xblock, _hTotal, X, _, _, _, hGauge⟩ :=
-    ft_sector_bnt_equal_mps_gaugeEquiv_witnessesPos hP hQ hEqual
+    ft_sector_bnt_equal_mps_gaugeEquiv_witnesses hP hQ hEqual
   -- Total bond dimensions agree.
   have hTotal : P.totalDim = Q.totalDim :=
     SectorDecomposition.totalDim_eq_of_match (P := P) (Q := Q) β hDim τ
@@ -559,7 +559,7 @@ block-diagonal direct sum of the matched sector unitaries and the unitary
 permutation that restores the original sector coordinates.
 
 Source: Cirac et al., arXiv:1606.00608, Corollary C.5, lines 1197--1199. -/
-private theorem ft_sector_bnt_equal_mps_unitaryGauge_literalPos
+private theorem ft_sector_bnt_equal_mps_unitaryGauge_literal
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
     (hEqual : SameMPV₂Pos P.toTensor Q.toTensor) :
@@ -578,7 +578,7 @@ private theorem ft_sector_bnt_equal_mps_unitaryGauge_literalPos
   classical
   obtain ⟨β, hDim, _hCopies, τ, _ζ, _U, X, _hζ, _hConj,
       _hWeight, hXunitary, hGauge⟩ :=
-    ft_sector_bnt_equal_unitary_global_gauge_witnessesPos hP hQ hEqual
+    ft_sector_bnt_equal_unitary_global_gauge_witnesses hP hQ hEqual
   have hTotal : P.totalDim = Q.totalDim :=
     SectorDecomposition.totalDim_eq_of_match (P := P) (Q := Q) β hDim τ
   refine ⟨hTotal, ?_⟩
@@ -658,27 +658,9 @@ private theorem ft_sector_bnt_equal_mps_unitaryGauge_literalPos
           Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ))
   simp only [Matrix.mul_assoc]
 
-/-- Reformulation for the all-length `SameMPV₂` form. -/
-theorem ft_sector_bnt_equal_mps_gaugeEquiv_literal
-    {P Q : SectorDecomposition d}
-    (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
-    ∃ (hTotal : P.totalDim = Q.totalDim) (Y : GL (Fin Q.totalDim) ℂ),
-      ∀ i : Fin d,
-        Q.toTensor i =
-          (Y : Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) *
-            cast (by rw [hTotal] :
-                Matrix (Fin P.totalDim) (Fin P.totalDim) ℂ =
-                Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ)
-              (P.toTensor i) *
-            (((Y)⁻¹ : GL (Fin Q.totalDim) ℂ) :
-              Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) :=
-  ft_sector_bnt_equal_mps_gaugeEquiv_literalPos
-    (P := P) (Q := Q) hP hQ hEqual.toSameMPV₂Pos
-
 /-- **Fundamental Theorem of MPS, equal case (CPSV16 Corollary II.2).**
 
-Two BNT canonical forms generating the same MPV family at every length are
+Two BNT canonical forms generating the same MPV family at every positive length are
 globally conjugate: their total bond dimensions agree, and a single invertible
 gauge `Y` carries one total tensor to the other.  This is the literal
 equal-case source statement on the basis-of-normal-tensors canonical-form
@@ -688,7 +670,7 @@ lines 1189–1192). -/
 theorem fundamentalTheorem_equal_canonicalForm
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
+    (hEqual : SameMPV₂Pos P.toTensor Q.toTensor) :
     ∃ (hTotal : P.totalDim = Q.totalDim) (Y : GL (Fin Q.totalDim) ℂ),
       ∀ i : Fin d,
         Q.toTensor i =
@@ -708,7 +690,7 @@ length are related by one unitary global gauge after identifying their equal
 total bond dimensions.
 
 Source: Cirac et al., arXiv:1606.00608, Corollary C.5, lines 1197--1199. -/
-theorem fundamentalTheorem_equal_canonicalForm_unitaryPos
+theorem fundamentalTheorem_equal_canonicalForm_unitary
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
     (hEqual : SameMPV₂Pos P.toTensor Q.toTensor) :
@@ -724,7 +706,7 @@ theorem fundamentalTheorem_equal_canonicalForm_unitaryPos
               (P.toTensor i) *
             (((Y)⁻¹ : GL (Fin Q.totalDim) ℂ) :
               Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) :=
-  ft_sector_bnt_equal_mps_unitaryGauge_literalPos hP hQ hEqual
+  ft_sector_bnt_equal_mps_unitaryGauge_literal hP hQ hEqual
 
 /-- **Fundamental Theorem of MPS, proportional multi-block case (CPSV16
 Theorem II.1) on the BNT canonical-form surface.**

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/StrongMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/StrongMatch.lean
@@ -23,8 +23,8 @@ The coefficient identity of CPSV16 Appendix MPV proof, lines 1187–1188
 CPSV16 (arXiv:1606.00608) Appendix MPV proof, line 1182, gives the matching
 step of the proportional theorem proof. In mathematical terms, this step
 fixes a block $B_k$ and observes that its overlaps with the $A_j$ blocks cannot
-all decay to zero, since then the two MPV families would fail to be
-proportional for all lengths. The equal-vector corollary then gives an index $j_k$ with
+all decay to zero, since then the two MPV families would fail to be eventually
+proportional. The equal-vector corollary then gives an index $j_k$ with
 $|V^{(N)}(B_k)\rangle = e^{i\phi_k N} |V^{(N)}(A_{j_k})\rangle$, and the
 single-block fundamental theorem gives
 $B_k = e^{i\phi_k} X_k A_{j_k} X_k^{-1}$.
@@ -35,7 +35,7 @@ The result is a **single `∀ k, ∃ j` existential statement** on the
 original pair. The equal-MPV proof applies `exists_block_match_exact` with
 `P` and `Q` swapped, then flips the cast direction and overlap order.
 
-The bijective matching (`bijective_match_of_sameMPVPos`) now applies the
+The bijective matching (`bijective_match_of_sameMPV`) now applies the
 exact block matcher in both directions — once with `(Q, P)` for a map
 `Fin Q.basisCount → Fin P.basisCount` and once with `(P, Q)` for the
 reverse map — to derive `P.basisCount = Q.basisCount` and the full bijection
@@ -81,7 +81,7 @@ then flips the gauge-phase equivalence and overlap order back to the displayed
 
 Paper anchor: CPSV16 Appendix MPV proof, line 1182 (arXiv:1606.00608), CPSV21
 Definition 4.2 lines 1846–1850, and the two-layer display at lines 1864–1884. -/
-theorem forall_k_exists_j_nondecaying_overlap_of_sameMPVPos
+theorem forall_k_exists_j_nondecaying_overlap_of_sameMPV
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
     (hEqual : SameMPV₂Pos P.toTensor Q.toTensor) :
@@ -105,21 +105,6 @@ theorem forall_k_exists_j_nondecaying_overlap_of_sameMPVPos
     apply hNonDecay_swapped
     exact tendsto_mpvOverlap_zero_swap (P.basis j) (Q.basis k) hTend
 
-/-- Reformulation for the all-length `SameMPV₂` form. -/
-theorem forall_k_exists_j_nondecaying_overlap_of_sameMPV
-    {P Q : SectorDecomposition d}
-    (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
-    ∀ k : Fin Q.basisCount, ∃ (j : Fin P.basisCount) (h : P.basisDim j = Q.basisDim k),
-      GaugePhaseEquiv
-          (cast (congr_arg (MPSTensor d) h) (P.basis j))
-          (Q.basis k) ∧
-      ¬ Tendsto (fun N : ℕ =>
-          mpvOverlap (d := d) (P.basis j) (Q.basis k) N)
-        atTop (𝓝 0) :=
-  forall_k_exists_j_nondecaying_overlap_of_sameMPVPos
-    (P := P) (Q := Q) hP hQ hEqual.toSameMPV₂Pos
-
 /-! ### Bijective sector matching by symmetry -/
 
 /-- **CPSV16 Appendix MPV proof, line 1182, full-basis bijection.**
@@ -137,7 +122,7 @@ and $g_B \geq g_A$".  The proof invokes the exact block matcher once with $(Q,P)
 matcher uses exact coefficient comparison rather than the dominant
 coefficient asymptotic argument, no per-sector unit-modulus copy-weight
 hypotheses are needed in the equal-MPV case. -/
-theorem bijective_match_of_sameMPVPos
+theorem bijective_match_of_sameMPV
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
     (hEqual : SameMPV₂Pos P.toTensor Q.toTensor) :
@@ -269,22 +254,5 @@ theorem bijective_match_of_sameMPVPos
   refine ⟨β, ?_⟩
   intro k
   simpa [β] using φ₀_spec k
-
-/-- Reformulation for the all-length `SameMPV₂` form. -/
-theorem bijective_match_of_sameMPV
-    {P Q : SectorDecomposition d}
-    (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hEqual : SameMPV₂ P.toTensor Q.toTensor) :
-    ∃ β : Fin Q.basisCount ≃ Fin P.basisCount,
-      ∀ k : Fin Q.basisCount, ∃ h : P.basisDim (β k) = Q.basisDim k,
-        GaugePhaseEquiv
-            (cast (congr_arg (MPSTensor d) h) (P.basis (β k)))
-            (Q.basis k) ∧
-        ¬ Tendsto (fun N : ℕ =>
-            mpvOverlap (d := d) (P.basis (β k)) (Q.basis k) N)
-          atTop (𝓝 0) :=
-  bijective_match_of_sameMPVPos
-    (P := P) (Q := Q) hP hQ hEqual.toSameMPV₂Pos
-
 
 end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/StrongMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/StrongMatch.lean
@@ -71,9 +71,10 @@ variable {d : ℕ}
 
 /-- **CPSV16 Appendix MPV proof, line 1182, Step 1 (full-basis form).**
 
-For every sector `k` of `Q`, there exists a sector `j` of `P` of equal bond
-dimension, gauge-phase equivalent to `Q.basis k` after the dimension cast, and
-with non-decaying cross-overlap.
+Suppose that the total tensors of `P` and `Q` generate the same MPV family at
+every positive length.  For every sector `k` of `Q`, there exists a sector `j`
+of `P` of equal bond dimension, gauge-phase equivalent to `Q.basis k` after the
+dimension cast, and with non-decaying cross-overlap.
 
 The proof applies `exists_block_match_exact` to the swapped pair `(Q, P)` and
 then flips the gauge-phase equivalence and overlap order back to the displayed

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Unitary.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Unitary.lean
@@ -95,7 +95,7 @@ global gauge in matched flattened coordinates.
 
 Source: arXiv:1606.00608, Corollary C.5 and Appendix MPV proof,
 lines 1182--1199. -/
-theorem ft_sector_bnt_equal_unitary_global_gauge_witnessesPos
+theorem ft_sector_bnt_equal_unitary_global_gauge_witnesses
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
     (hEqual : SameMPV₂Pos P.toTensor Q.toTensor) :
@@ -129,7 +129,7 @@ theorem ft_sector_bnt_equal_unitary_global_gauge_witnessesPos
                 (Fin (∑ s : Fin Q.totalCopies, Q.flatDim s)) ℂ) := by
   classical
   obtain ⟨β, hDim, ζ, Xblock, hζ, hConj, ⟨W⟩⟩ :=
-    ft_sector_bnt_equal_matched_copy_weight_witnessesPos hP hQ hEqual
+    ft_sector_bnt_equal_matched_copy_weight_witnesses hP hQ hEqual
   have hζ_ne : ∀ k : Fin Q.basisCount, ζ k ≠ 0 := by
     intro k hzero
     simpa [hzero] using hζ k

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -955,8 +955,9 @@ Chapter~\ref{ch:canonical}.
     \uses{def:sector_bnt_cf, thm:sector_bnt_equal_mps_gaugeEquiv_literal}
     Let $P$ and $Q$ be BNT canonical forms (Definition~\ref{def:sector_bnt_cf})
     whose total tensors $P_{\mathrm{tot}}$, $Q_{\mathrm{tot}}$ generate the same
-    MPV family for every system size~$N$. Then their total bond dimensions
-    coincide; writing the common value as~$D$, there is one invertible matrix
+    MPV family for every positive system size~$N$. Then their total bond
+    dimensions coincide; writing the common value as~$D$, there is one
+    invertible matrix
     $X \in \GL_D(\C)$ such that, for every physical index~$i$,
     \[
         Q_{\mathrm{tot}}^i

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -115,8 +115,9 @@ step uses a per-sector unit-modulus hypothesis.
     \leanok
     \uses{def:sector_bnt_cf,
         def:gauge_phase_equiv}
-    Let $P$ and $Q$ be BNT canonical forms with the same MPV family, matched by a
-    bijection $\beta:J(Q)\simeq J(P)$ with bond-dimension equalities and a
+    Let $P$ and $Q$ be BNT canonical forms with the same MPV family at every
+    positive length, matched by a bijection $\beta:J(Q)\simeq J(P)$ with
+    bond-dimension equalities and a
     gauge-phase equivalence between $Q_k$ and $P_{\beta(k)}$ for every $k$. Then
     each sector carries a unit-modulus phase $\zeta_k$, and eventually
     \begin{equation}\label{eq:ft_coeff_identity}
@@ -145,13 +146,14 @@ step uses a per-sector unit-modulus hypothesis.
     \leanok
     \uses{def:sector_bnt_cf}
     Let $P$ be a BNT canonical form, let $Q$ be a sector decomposition, and
-    assume $P_{\mathrm{tot}}$ and $Q_{\mathrm{tot}}$ have the same MPV family.
+    assume $P_{\mathrm{tot}}$ and $Q_{\mathrm{tot}}$ have the same MPV family
+    at every positive length.
     Suppose that there is a bijection
     \[
         \beta : J(Q) \simeq J(P)
     \]
     and scalars $\zeta_k \in \C$ such that, for every $k \in J(Q)$, every
-    length $N$, and every spin configuration $\sigma$ of length $N$,
+    positive length $N$, and every spin configuration $\sigma$ of length $N$,
     \begin{equation}\label{eq:ft_phase_relation_hyp}
         V^{(N)}(Q_k)_\sigma
         =
@@ -531,7 +533,7 @@ In the equal-MPV case all ingredients are unconditional.
     \leanok
     \uses{def:sector_bnt_cf}
     Let $P$ and $Q$ be BNT canonical forms whose total tensors have the same
-    MPV family. Then there are a bijection
+    MPV family at every positive length. Then there are a bijection
     $\beta:J(Q)\simeq J(P)$, bond-dimension equalities, unit-modulus phases
     $\zeta_k$, and block gauges $X_k$ such that
     \[
@@ -573,7 +575,7 @@ In the equal-MPV case all ingredients are unconditional.
     \leanok
     \uses{def:sector_bnt_cf}
     Let $P$ and $Q$ be BNT canonical forms whose total tensors have the same
-    MPV family. Then there exist:
+    MPV family at every positive length. Then there exist:
     \begin{itemize}
         \item a bijection $\beta:J(Q)\simeq J(P)$,
         \item bond-dimension equalities
@@ -631,7 +633,7 @@ In the equal-MPV case all ingredients are unconditional.
     \leanok
     \uses{def:sector_bnt_cf}
     Let $P$ and $Q$ be BNT canonical forms whose total tensors have the same
-    MPV family. Then the total bond dimensions agree;
+    MPV family at every positive length. Then the total bond dimensions agree;
     write their common value as $D$. There is
     \begin{equation}\label{eq:ft_literal_gauge_Y}
         Y\in \GL_D(\C)

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -44,8 +44,8 @@ step uses a per-sector unit-modulus hypothesis.
     \lean{MPSTensor.IsBNTCanonicalForm.norm_phase_of_matched_mpv}
     \leanok
     \uses{def:sector_bnt_cf}
-    Let $P$ and $Q$ be BNT canonical forms. If, for every length $N$ and word
-    $\sigma$, a sector $P_j$ and a sector $Q_k$ have MPV families related by
+    Let $P$ and $Q$ be BNT canonical forms. If, for every positive length $N$
+    and word $\sigma$, a sector $P_j$ and a sector $Q_k$ have MPV families related by
     \begin{equation}\label{eq:ft_matched_mpv_phase_norm}
         V^{(N)}(Q_k)_\sigma=\zeta^N V^{(N)}(P_j)_\sigma
     \end{equation}
@@ -54,7 +54,8 @@ step uses a per-sector unit-modulus hypothesis.
 
 \begin{proof}\leanok
     The BNT normalization gives self-overlap limits of modulus $1$ for both
-    sectors. The MPV identity~(\ref{eq:ft_matched_mpv_phase_norm}) gives, for every $N$,
+    sectors. The MPV identity~(\ref{eq:ft_matched_mpv_phase_norm}) gives, for
+    every positive $N$,
     \[
         O_{Q_kQ_k}(N)=|\zeta|^{2N}\,O_{P_jP_j}(N).
     \]
@@ -79,7 +80,7 @@ step uses a per-sector unit-modulus hypothesis.
     \begin{equation}\label{eq:ft_gauge_relation}
         Q_k^i=\zeta_k X_k P_{\beta(k)}^i X_k^{-1}
     \end{equation}
-    Equivalently, for every length $N$ and word $\sigma$,
+    Equivalently, for every positive length $N$ and word $\sigma$,
     \[
         V^{(N)}(Q_k)_\sigma
         =
@@ -662,7 +663,7 @@ In the equal-MPV case all ingredients are unconditional.
 
 \begin{lemma}[Unitary gauge in matched sector coordinates]
     \label{lem:sector_bnt_equal_unitary_matched_gauge}
-    \lean{MPSTensor.ft_sector_bnt_equal_unitary_global_gauge_witnessesPos}
+    \lean{MPSTensor.ft_sector_bnt_equal_unitary_global_gauge_witnesses}
     \leanok
     \uses{thm:sector_bnt_equal_global_gauge,
         lem:left_canonical_irreducible_same_phase_unitary_gauge,
@@ -706,7 +707,7 @@ In the equal-MPV case all ingredients are unconditional.
 
 \begin{corollary}[Canonical Form II unitary refinement in the equal case]%
     \label{cor:sector_bnt_equal_unitary_global_gauge}
-    \lean{MPSTensor.fundamentalTheorem_equal_canonicalForm_unitaryPos}
+    \lean{MPSTensor.fundamentalTheorem_equal_canonicalForm_unitary}
     \leanok
     \uses{lem:sector_bnt_equal_unitary_matched_gauge}
     Let $P$ and $Q$ be BNT canonical forms whose total tensors generate the

--- a/docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex
+++ b/docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex
@@ -161,9 +161,9 @@ restoring the original sector and copy coordinates is itself unitary, so their
 product is one unitary gauge on the total bond space.
 
 The matched-coordinate statement is
-\leanid{MPSTensor.ft_sector_bnt_equal_unitary_global_gauge_witnessesPos}; the
+\leanid{MPSTensor.ft_sector_bnt_equal_unitary_global_gauge_witnesses}; the
 literal total-tensor statement is
-\leanid{MPSTensor.fundamentalTheorem_equal_canonicalForm_unitaryPos}. Both use
+\leanid{MPSTensor.fundamentalTheorem_equal_canonicalForm_unitary}. Both use
 only the BNT canonical-form hypotheses and equality of the MPV families. In
 particular, neither a per-sector unit-weight assumption nor any additional
 normalization is introduced.

--- a/docs/paper-gaps/ft_one_copy_scope_restriction.tex
+++ b/docs/paper-gaps/ft_one_copy_scope_restriction.tex
@@ -193,8 +193,8 @@ copies inside a sector, has since been supplied on the SectorBNT surface.  The
 standalone Newton-Girard uniqueness input is formalized as
 \leanid{Matrix.sum_pow_eq_implies_card_eq_and_multiset_eq_of_le_max_card}; the
 BNT coefficient identity from the equal-MPV hypothesis is derived by
-\leanid{MPSTensor.coeff_identity_via_matched_mpv_phase}, with the
-phase-valued variant
+\leanid{MPSTensor.coeff_identity_via_global_gauge}, using the phase-valued
+auxiliary result
 \leanid{MPSTensor.coeff_identity_via_matched_mpv_phase}; the resulting
 power-sum expression and weight recovery are supplied by
 \leanid{MPSTensor.SectorDecomposition.coeff_eq_sum_weight_pow},

--- a/docs/paper-gaps/ft_one_copy_scope_restriction.tex
+++ b/docs/paper-gaps/ft_one_copy_scope_restriction.tex
@@ -193,7 +193,7 @@ copies inside a sector, has since been supplied on the SectorBNT surface.  The
 standalone Newton-Girard uniqueness input is formalized as
 \leanid{Matrix.sum_pow_eq_implies_card_eq_and_multiset_eq_of_le_max_card}; the
 BNT coefficient identity from the equal-MPV hypothesis is derived by
-\leanid{MPSTensor.coeff_identity_via_matched_mpv_phasePos}, with the
+\leanid{MPSTensor.coeff_identity_via_matched_mpv_phase}, with the
 phase-valued variant
 \leanid{MPSTensor.coeff_identity_via_matched_mpv_phase}; the resulting
 power-sum expression and weight recovery are supplied by


### PR DESCRIPTION
## Mathematical change

The SectorBNT equal-case fundamental theorem now has a single positive-length statement surface.

Nine corollaries whose only purpose was to strengthen a SameMPV₂Pos hypothesis to the older all-length SameMPV₂ hypothesis are removed. Their positive-length primary theorems take the established source-facing names. The unitary equal-case statements likewise lose the Pos suffix, since there is no competing physical theorem at length zero.

This removes 150 lines overall and eliminates the parallel positive/all-length proof routes without changing any proof. The blueprint now states the matched phase relations for positive lengths explicitly, and the paper-gap references follow the canonical theorem names.

This is the first increment of #4098. The remaining collapse of SameMPV₂Pos into SameMPV₂ follows after the zero-tail construction in #4101 is removed.

No compatibility aliases are introduced because the removed names encode the discarded mathematical distinction. No axioms are introduced.

## Source alignment

The renamed theorems retain explicit references to CPSV16 Section II.C and Appendix MPV proof, lines 1182–1199. The physical hypotheses quantify over N greater than zero; empty-word identities remain internal algebraic facts.

## Verification

- Lean toolchain: v4.32.0
- lake build TNLean: 9,533 targets completed
- axiom audit of all renamed public conclusions: propext, Classical.choice, Quot.sound only
- no new sorry, axiom, admit, native_decide, or unsafeCast
- git diff --check

Part of #4098.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only rename and API consolidation with no new axioms or proof changes; callers must switch from removed `SameMPV₂` wrappers to `SameMPV₂Pos` or the renamed theorem names.
> 
> **Overview**
> The SectorBNT **equal-case** API is collapsed to a single **positive-length** surface: public theorems now take **`SameMPV₂Pos`** and the nine thin **`SameMPV₂` → `toSameMPV₂Pos`** wrapper theorems (names ending in **`Pos`**) are deleted. The former **`…Pos`** primaries keep the source-facing names (`coeff_identity_via_global_gauge`, `bijective_match_of_sameMPV`, `ft_sector_bnt_equal_global_gauge`, `fundamentalTheorem_equal_canonicalForm`, unitary variants, etc.).
> 
> **`fundamentalTheorem_equal_canonicalForm`** now states equal MPV at every **positive** length directly, instead of all lengths with an internal positive restriction. Docstrings and the blueprint (`ch11_fundamental_theorem_proof.tex`) are aligned to “positive length” hypotheses; paper-gap notes point at the renamed Lean ids.
> 
> No proof bodies are rewritten beyond call-site renames; net **~150 lines** removed. Further unification of **`SameMPV₂Pos`** with **`SameMPV₂`** is deferred (per #4098 / #4101).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53ff943469ca37101be3a7688016af0260d5a72a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->