### PR TITLE
doc(blueprint): synchronize positive-length hypotheses

### DIFF
--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1893,10 +1893,11 @@ projection.
     \leanok
     \uses{def:sector_bnt_cf,
         thm:sector_bnt_exact_block_match}
-    Let $P, Q$ be two BNT canonical forms with the same MPV family. Then for
-    every sector $k$ of $Q$ there exist a sector $j$ of $P$ with matched bond
-    dimension $\dim_P(j) = \dim_Q(k)$, a gauge-phase equivalence after
-    identifying the matched bond dimensions, and a non-decaying cross-overlap.
+    Let $P, Q$ be two BNT canonical forms with the same MPV family at every
+    positive length. Then for every sector $k$ of $Q$ there exist a sector $j$
+    of $P$ with matched bond dimension $\dim_P(j) = \dim_Q(k)$, a gauge-phase
+    equivalence after identifying the matched bond dimensions, and a
+    non-decaying cross-overlap.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1920,8 +1921,8 @@ holds on the full basis \cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     \leanok
     \uses{thm:sector_bnt_exact_block_match,
         def:sector_bnt_cf}
-    Let $P, Q$ be two BNT canonical forms with the same MPV family. Then there
-    is a bijection
+    Let $P, Q$ be two BNT canonical forms with the same MPV family at every
+    positive length. Then there is a bijection
     \[
         \beta : J(Q) \simeq J(P)
     \]

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1891,7 +1891,7 @@ projection.
     \label{thm:sector_bnt_forall_unit_k_exists_j_nondecaying_overlap_of_sameMPV}
     \lean{MPSTensor.forall_k_exists_j_nondecaying_overlap_of_sameMPV}
     \leanok
-    \uses{def:sector_bnt_cf,
+    \uses{def:sector_bnt_cf, def:same_mpv2_pos,
         thm:sector_bnt_exact_block_match}
     Let $P, Q$ be two BNT canonical forms with the same MPV family at every
     positive length. Then for every sector $k$ of $Q$ there exist a sector $j$
@@ -1920,7 +1920,7 @@ holds on the full basis \cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     \lean{MPSTensor.bijective_match_of_sameMPV}
     \leanok
     \uses{thm:sector_bnt_exact_block_match,
-        def:sector_bnt_cf}
+        def:sector_bnt_cf, def:same_mpv2_pos}
     Let $P, Q$ be two BNT canonical forms with the same MPV family at every
     positive length. Then there is a bijection
     \[

--- a/blueprint/src/chapter/ch23_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch23_algebraic_ft.tex
@@ -1485,17 +1485,18 @@ sector counts and bond dimensions before matching.
     \label{lem:ft_sector_bnt_equal_sector_data_different_dims}
     \lean{MPSTensor.ft_sector_bnt_equal_sector_data}
     \leanok
-    \uses{def:same_mpv2, def:sector_bnt_cf, def:gauge_phase_equiv}
+    \uses{def:same_mpv2_pos, def:sector_bnt_cf, def:gauge_phase_equiv}
     Let $P$ and $Q$ be two BNT canonical forms
     (Definition~\ref{def:sector_bnt_cf}), each admitting a unit-modulus copy
     weight in every basis sector, possibly with different sector counts and
     different bond dimensions before matching.
-    If their block-diagonal tensors generate the same MPV family
-    (Definition~\ref{def:same_mpv2}), then the basis sectors are
-    bijectively matched by a permutation $\beta$, each matched basis pair is
-    gauge-phase equivalent (Definition~\ref{def:gauge_phase_equiv}), the
-    matched copy multiplicities agree, and the copy weights agree up to a
-    unit-modulus phase $\zeta$ and a copy-index reindexing.
+    If their block-diagonal tensors generate the same MPV family at every
+    positive length (Definition~\ref{def:same_mpv2_pos}), then the basis
+    sectors are bijectively matched by a permutation $\beta$, each matched
+    basis pair is gauge-phase equivalent
+    (Definition~\ref{def:gauge_phase_equiv}), the matched copy multiplicities
+    agree, and the copy weights agree up to a unit-modulus phase $\zeta$ and a
+    copy-index reindexing.
     This is the sector-data form of the equal-case theorem
     \cite[Corollary~2.11, lines 354--361 and appendix 1172--1192]{Cirac2016MPDO_arXiv};
     the corresponding global gauge corollary is recorded in


### PR DESCRIPTION
## Summary

- state positive-length MPV equality for the strong and bijective sector-matching theorems
- use the positive-length relation in the algebraic equal-case sector-data entry
- keep the source-facing blueprint statements identical to the canonical Lean signatures introduced by #4102

## Validation

- `git diff --check`

Follow-up to #4102.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to blueprint LaTeX and `\uses` tags; no executable code or proof changes.
> 
> **Overview**
> Blueprint sector-matching and equal-case statements now cite **`def:same_mpv2_pos`** and say explicitly that two BNT canonical forms share the **same MPV family at every positive length**, instead of the all-length **`SameMPV₂`** wording.
> 
> **Chapter 10 (BNT):** `\uses` on the strong existential matching theorem and bijective matching theorem adds `def:same_mpv2_pos`; theorem hypotheses are tightened to positive-length MPV equality.
> 
> **Chapter 23 (algebraic FT):** The equal-case block-matching lemma with differing bond dimensions switches its `\uses` from `def:same_mpv2` to `def:same_mpv2_pos` and states the hypothesis as same MPV at every positive length, with a pointer to that definition.
> 
> No proof logic changes—documentation alignment with canonical Lean from #4102.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f966b709c0a4cc8a018fdc3d282c1be1f84fdfbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->