### PR TITLE
feat(tenkz): web pipeline and audit tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ scripts/__pycache__/
 Draft/
 Draft_OLD/
 *.bak*
+blueprint/src/.tenkz_svg_cache/

--- a/blueprint/src/Packages/tenkz_pic.py
+++ b/blueprint/src/Packages/tenkz_pic.py
@@ -1,0 +1,562 @@
+r"""plasTeX renderers for tenkz tensor-network pictures (spec §1.5, §5.1).
+
+The tenkz environments (``tenkz``, ``tenkzcd``, ``tenkzlattice``,
+``tenkzplanes``, ``tenkzfree`` — the spec's four sub-languages plus the
+Phase-1 bra-ket double-layer environment that lives in the lattice layer)
+and the bridge command ``\tnpic`` are registered here as
+**verbatim-captured units**: plasTeX never tokenizes a picture body.  Each
+captured unit is compiled **standalone** against ``TEXINPUTS=tex/tenkz//``
+and converted to one SVG, cached by a per-body content hash, so editing one
+figure invalidates exactly one SVG (spec §1.5: "one edited figure
+invalidates one SVG, not 114").
+
+Design decisions
+----------------
+
+1. **Verbatim round trip, no Python-side grammar.**  The TeX library in
+   ``tex/tenkz/`` is the single authority on the picture grammar.  This
+   module captures the raw characters between ``\begin{tenkz}[...]`` and
+   ``\end{tenkz}`` (the optional key list included — with verbatim catcodes
+   it is simply the first characters of the body) and re-emits them
+   unchanged into a standalone document.  Print and web therefore compile
+   byte-identical picture sources, which is what makes the cross-engine
+   drift check (spec §5.5, G12) meaningful.
+
+2. **Engine route: xelatex → .xdv → dvisvgm, with a probed fallback.**
+   The spec pins the web pipeline to ``xelatex -no-pdf`` → ``.xdv`` →
+   ``dvisvgm`` (§1.5).  That route has a silent failure mode: under
+   xelatex, PGF emits xdvipdfmx ``pdf:code``/``pdf:bcontent`` specials,
+   which dvisvgm can only interpret through a Ghostscript (or mutool) PDF
+   interpreter.  Without one — or with dvisvgm < 3.2 against Ghostscript
+   >= 10.1, whose PostScript-based PDF interpreter was removed — dvisvgm
+   exits 0 and emits an SVG containing the text glyphs but **none of the
+   TikZ ink** (observed with dvisvgm 3.0.3 + Ghostscript 10.06 on macOS).
+   ``dvisvgm --pdf`` fails for the same reason.  We therefore compile a
+   one-time ink canary (a bare TikZ ``\draw``, no text, so any ``<path>``
+   in the output must be ink) through the xdv route; if the route fails —
+   dvisvgm missing, xelatex or dvisvgm exiting non-zero, no SVG produced,
+   or an SVG that lost its ink — every unit in this process falls back to
+   ``xelatex`` → PDF → ``pdftocairo -svg`` (poppler; no Ghostscript
+   dependency), and the fallback warning names the observed failure mode.  Both routes rasterize nothing — text becomes outlined
+   paths either way (``--no-fonts`` / cairo).  The pdf→svg fallback uses
+   pdftocairo rather than ``dvisvgm --pdf`` because the latter depends on
+   exactly the Ghostscript facility whose absence triggers the fallback.
+
+3. **Cache key.**  ``sha256(library digest ‖ standalone document)[:16]``,
+   exactly the scheme proven by the old ``tn_diagrams.py`` pipeline (whose
+   hash/cache core survives here per the Phase-3 demolition list).  The
+   library digest folds in every file of ``tex/tenkz/`` plus
+   ``macros/common.tex``: a library edit re-renders everything (correct —
+   every picture may look different), a body edit re-renders one SVG.
+
+4. **Standalone preamble.**  Units are compiled with ``macros/common`` in
+   scope so picture labels may use blueprint macros, with the same
+   ``\newcounter{chapter}`` shim the old pipeline used (standalone is
+   article-based and lacks the chapter counter that common's theorem
+   numbering expects).
+
+TODO (G20, out of Phase-0 scope): the **whole-equation reroute** — running
+math containing ``\tnpic[inline]`` must be rerouted whole-equation to the
+SVG path, because MathJax cannot typeset the atom (spec §1.5, §9.4).
+Until it lands, ``\tnpic`` inside ``$...$``/``\[...\]`` and tenkz
+environments inside display math render an ``<img>`` inside MathJax input,
+which MathJax will not typeset; Phase-0 chapter style must keep pictures
+at top level or inside ``figure`` (display-adjacent usage, maintainer
+decision §9.4).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import posixpath
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass
+from functools import lru_cache
+from html import escape
+from pathlib import Path
+from typing import Iterable
+
+log = logging.getLogger(__name__)
+
+_SRC_DIR = Path(__file__).resolve().parents[1]
+_REPO_ROOT = _SRC_DIR.parents[1]
+_TENKZ_DIR = _REPO_ROOT / "tex/tenkz"
+_CACHE_DIR = _SRC_DIR / ".tenkz_svg_cache"
+_SVG_SUBDIR = "tenkz_svg"
+
+# Every file that participates in rendering a unit.  All of them are folded
+# into the content hash: editing the library or the shared macros re-renders
+# every picture, editing one picture body re-renders exactly one SVG.
+_RENDER_SOURCE_FILES = (
+    _SRC_DIR / "macros/common.tex",
+    *sorted(_TENKZ_DIR.glob("*.sty")),
+    *sorted(_TENKZ_DIR.glob("*.code.tex")),
+)
+
+# The .tnlog dialect tag of each environment (the ``\tenkz@beginpicture``
+# argument in tex/tenkz/, spec §5.1); reused as the CSS modifier class of
+# the emitted <img>.
+_ENVIRONMENT_LANGS = {
+    "tenkz": "grid",
+    "tenkzcd": "cd",
+    "tenkzlattice": "lattice",
+    "tenkzplanes": "planes",
+    "tenkzfree": "free",
+    "tnpic": "grid",
+}
+
+# Ink canary for the route probe: a pure \draw, no text.  Any <path> in its
+# SVG is necessarily TikZ ink, so "no <path>" identifies the silent
+# dvisvgm-without-Ghostscript failure mode described in the module docstring.
+_CANARY_DOCUMENT = r"""\documentclass[border=2pt]{standalone}
+\usepackage{tikz}
+\begin{document}
+\begin{tikzpicture}\draw[line width=1pt] (0,0) -- (12pt,12pt);\end{tikzpicture}
+\end{document}
+"""
+
+
+def _latex_document(unit_source: str) -> str:
+    """Wrap one verbatim picture unit in the standalone compile document."""
+
+    return rf"""\documentclass[varwidth,border=2pt]{{standalone}}
+\usepackage{{amssymb,amsthm,amsmath,mathtools}}
+% standalone is based on article, which already supplies section and
+% subsection; only chapter is absent, so define it before loading
+% macros/common (its theorem numbering references the chapter counter).
+\newcounter{{chapter}}
+\input{{macros/common}}
+\usepackage{{tenkz}}
+\begin{{document}}
+{unit_source}
+\end{{document}}
+"""
+
+
+@lru_cache(maxsize=1)
+def _render_source_digest() -> str:
+    digest = hashlib.sha256()
+    for source_file in _RENDER_SOURCE_FILES:
+        if not source_file.is_file():
+            raise RuntimeError(f"Missing tenkz render source: {source_file}")
+        digest.update(source_file.name.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(source_file.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def unit_hash(unit_source: str) -> str:
+    """Content hash of one picture unit (library digest + full document)."""
+
+    digest = hashlib.sha256()
+    digest.update(_render_source_digest().encode("ascii"))
+    digest.update(b"\0")
+    digest.update(_latex_document(unit_source).encode("utf-8"))
+    return digest.hexdigest()[:16]
+
+
+@lru_cache(maxsize=1)
+def _tex_env() -> dict[str, str]:
+    """Compile environment: tex/tenkz// on TEXINPUTS (spec §1.5)."""
+
+    env = os.environ.copy()
+    env["TEXINPUTS"] = str(_TENKZ_DIR) + "//:" + env.get("TEXINPUTS", "")
+    kpsewhich = shutil.which("kpsewhich")
+    if kpsewhich is None:
+        return env
+    # When invoked from plasTeX the caller's environment can lack the TeX
+    # variables a homebrew/texlive split needs; resolve them once, exactly
+    # as the old tn_diagrams.py pipeline did.
+    for name in ("TEXMFCNF", "TEXMFROOT"):
+        if env.get(name):
+            continue
+        result = subprocess.run(
+            [kpsewhich, f"-var-value={name}"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            timeout=10,
+            check=False,
+        )
+        value = result.stdout.strip()
+        if result.returncode == 0 and value:
+            env[name] = value
+    return env
+
+
+def _run(cmd: Iterable[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(cmd),
+        cwd=cwd,
+        env=_tex_env(),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=120,
+        check=False,
+    )
+
+
+@dataclass(frozen=True)
+class Toolchain:
+    """The engine route chosen for this process (see module docstring §2)."""
+
+    xelatex: str
+    route: str  # "xdv" (spec primary) or "pdf" (probed fallback)
+    converter: str  # dvisvgm for "xdv", pdftocairo for "pdf"
+
+
+def _xelatex_command(xelatex: str, stem: str, *, xdv: bool) -> list[str]:
+    cmd = [xelatex]
+    if xdv:
+        cmd.append("-no-pdf")
+    cmd += [
+        "-interaction=nonstopmode",
+        "-halt-on-error",
+        "-output-directory",
+        str(_CACHE_DIR),
+        str(_CACHE_DIR / f"{stem}.tex"),
+    ]
+    return cmd
+
+
+def _dvisvgm_command(dvisvgm: str, stem: str, svg_path: Path) -> list[str]:
+    # --no-fonts: text as outlined paths (web-safe, matches the fallback);
+    # --exact --bbox=3pt: tight crop, same knobs as the old pipeline.
+    return [
+        dvisvgm,
+        "--no-fonts",
+        "--exact",
+        "--bbox=3pt",
+        f"--output={svg_path}",
+        str(_CACHE_DIR / f"{stem}.xdv"),
+    ]
+
+
+def _svg_has_ink(svg_path: Path) -> bool:
+    if not svg_path.is_file():
+        return False
+    return "<path" in svg_path.read_text(encoding="utf-8", errors="replace")
+
+
+def _xdv_route_failure(xelatex: str, dvisvgm: str) -> str | None:
+    """One-time canary through the spec's primary route (module docstring §2).
+
+    Returns None when the route renders ink, otherwise the observed failure
+    mode — the fallback warning must name what actually broke (a failed
+    compile or conversion is not the ink-stripping Ghostscript problem).
+    """
+
+    _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    stem = "tenkz-route-probe"
+    (_CACHE_DIR / f"{stem}.tex").write_text(_CANARY_DOCUMENT, encoding="utf-8")
+    svg_path = _CACHE_DIR / f"{stem}.svg"
+    svg_path.unlink(missing_ok=True)
+    engine = _run(_xelatex_command(xelatex, stem, xdv=True), cwd=_SRC_DIR)
+    if engine.returncode != 0:
+        return f"xelatex exited {engine.returncode} compiling the canary"
+    converter = _run(_dvisvgm_command(dvisvgm, stem, svg_path), cwd=_SRC_DIR)
+    if converter.returncode != 0:
+        return f"dvisvgm exited {converter.returncode} converting the canary"
+    if not svg_path.is_file():
+        return "dvisvgm exited 0 but produced no canary SVG"
+    if not _svg_has_ink(svg_path):
+        return (
+            "dvisvgm dropped the TikZ ink of the canary SVG "
+            "(Ghostscript/mutool unavailable to it?)"
+        )
+    return None
+
+
+@lru_cache(maxsize=1)
+def toolchain() -> Toolchain | None:
+    """Probe and cache the SVG toolchain; None when no usable route exists."""
+
+    xelatex = shutil.which("xelatex")
+    if xelatex is None:
+        return None
+    dvisvgm = shutil.which("dvisvgm")
+    if dvisvgm is None:
+        xdv_failure = "dvisvgm is not on PATH"
+    else:
+        xdv_failure = _xdv_route_failure(xelatex, dvisvgm)
+        if xdv_failure is None:
+            return Toolchain(xelatex=xelatex, route="xdv", converter=dvisvgm)
+    pdftocairo = shutil.which("pdftocairo")
+    if pdftocairo is not None:
+        log.warning(
+            "tenkz: xdv route unusable (%s); falling back to "
+            "xelatex -> PDF -> pdftocairo.",
+            xdv_failure,
+        )
+        return Toolchain(xelatex=xelatex, route="pdf", converter=pdftocairo)
+    return None
+
+
+def _compile_unit(unit_source: str, stem: str, svg_path: Path) -> bool:
+    """Compile one unit to ``svg_path``; False when no toolchain exists."""
+
+    chain = toolchain()
+    if chain is None:
+        return False
+    svg_path.parent.mkdir(parents=True, exist_ok=True)
+    _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    tex_path = _CACHE_DIR / f"{stem}.tex"
+    tex_path.write_text(_latex_document(unit_source), encoding="utf-8")
+
+    engine = _run(
+        _xelatex_command(chain.xelatex, stem, xdv=chain.route == "xdv"),
+        cwd=_SRC_DIR,
+    )
+    if engine.returncode != 0:
+        log_path = _CACHE_DIR / f"{stem}.compile.log"
+        log_path.write_text(engine.stdout, encoding="utf-8")
+        raise RuntimeError(
+            f"tenkz picture compilation failed for {unit_source!r}; see {log_path}"
+        )
+
+    if chain.route == "xdv":
+        converter_cmd = _dvisvgm_command(chain.converter, stem, svg_path)
+    else:
+        converter_cmd = [
+            chain.converter,
+            "-svg",
+            str(_CACHE_DIR / f"{stem}.pdf"),
+            str(svg_path),
+        ]
+    converter = _run(converter_cmd, cwd=_SRC_DIR)
+    if converter.returncode != 0 or not svg_path.is_file():
+        log_path = _CACHE_DIR / f"{stem}.convert.log"
+        log_path.write_text(converter.stdout, encoding="utf-8")
+        raise RuntimeError(
+            f"tenkz SVG conversion failed for {unit_source!r}; see {log_path}"
+        )
+
+    tex_path.unlink(missing_ok=True)
+    return True
+
+
+def render_unit(unit_source: str, svg_dir: Path) -> tuple[Path | None, bool]:
+    """Render one verbatim unit to a content-addressed SVG under ``svg_dir``.
+
+    Returns ``(svg_path, cache_hit)``; ``(None, False)`` when the SVG
+    toolchain is unavailable.  The cache is the SVG's existence: the file
+    name is the content hash, so a body edit produces a new name (miss)
+    while an untouched body finds its previous SVG (hit) — per-figure
+    invalidation with no manifest to maintain.
+    """
+
+    stem = f"tenkz-{unit_hash(unit_source)}"
+    svg_path = svg_dir / f"{stem}.svg"
+    if svg_path.exists():
+        return svg_path, True
+    if not _compile_unit(unit_source, stem, svg_path):
+        return None, False
+    return svg_path, False
+
+
+# --------------------------------------------------------------------------
+# plasTeX layer.  Deferred import so scripts/test_tenkz_pic.py can exercise
+# the compile+cache core above without a plasTeX installation.
+# --------------------------------------------------------------------------
+
+def _output_dir(doc: object) -> Path:
+    configured = Path(str(doc.config["files"]["directory"]))
+    if configured.is_absolute():
+        return configured
+    working_dir = Path(doc.userdata.get("working-dir", _SRC_DIR))
+    return (working_dir / configured).resolve()
+
+
+def _nearest_output_url(obj: object) -> str | None:
+    current = obj
+    while current is not None:
+        url = getattr(current, "url", None)
+        if url:
+            return str(url)
+        current = getattr(current, "parentNode", None)
+    return None
+
+
+def _svg_src(obj: object, svg_path: Path, output_dir: Path) -> str:
+    output_url = _nearest_output_url(obj)
+    if output_url is None:
+        return posixpath.join(_SVG_SUBDIR, svg_path.name)
+    html_path = Path(output_url)
+    if not html_path.is_absolute():
+        html_path = output_dir / html_path
+    return Path(os.path.relpath(svg_path, start=html_path.parent)).as_posix()
+
+
+def _missing_tools_html(unit_source: str) -> str:
+    return (
+        '<span class="tenkz-svg-missing">'
+        "tenkz SVG unavailable: install xelatex plus dvisvgm (with "
+        "Ghostscript/mutool) or pdftocairo to render "
+        f"<code>{escape(unit_source)}</code>."
+        "</span>"
+    )
+
+
+try:
+    from plasTeX import Command, VerbatimEnvironment
+except ImportError:  # standalone harness use; see the section comment above
+    pass
+else:
+
+    class _TenkzSvgMixin:
+        """Shared rendering: compile the captured unit, emit one <img>."""
+
+        # plasTeX's renderer reads ``templateName`` as a string attribute of
+        # the node; the template lives in plastex_templates/
+        # TenkzPictures.jinja2s and expands to ``tenkz_svg_html``.
+        templateName = "TenkzPicture"
+
+        def tenkzUnitSource(self) -> str:
+            raise NotImplementedError
+
+        @property
+        def tenkz_svg_html(self) -> str:
+            unit_source = self.tenkzUnitSource()
+            output_dir = _output_dir(self.ownerDocument)
+            svg_path, _ = render_unit(unit_source, output_dir / _SVG_SUBDIR)
+            if svg_path is None:
+                logged = self.ownerDocument.userdata.setdefault(
+                    "_tenkz_svg_missing_tools", False
+                )
+                if not logged:
+                    log.warning(
+                        "tenkz SVG rendering needs xelatex and dvisvgm or "
+                        "pdftocairo on PATH."
+                    )
+                    self.ownerDocument.userdata["_tenkz_svg_missing_tools"] = True
+                if os.environ.get("CI") == "true":
+                    raise RuntimeError(
+                        "tenkz SVG rendering needs xelatex and dvisvgm or "
+                        f"pdftocairo on PATH for {unit_source!r}."
+                    )
+                return _missing_tools_html(unit_source)
+            src = _svg_src(self, svg_path, output_dir)
+            lang = _ENVIRONMENT_LANGS[self.nodeName]
+            # The verbatim unit source doubles as the alt text: it is the
+            # only faithful textual description available before the G20
+            # accessibility follow-up (maintainer decision §9.4).
+            return (
+                f'<img class="tenkz-pic tenkz-pic-{lang}" '
+                f'src="{escape(src, quote=True)}" '
+                f'alt="{escape(unit_source, quote=True)}">'
+            )
+
+    class _TenkzVerbatimEnvironment(_TenkzSvgMixin, VerbatimEnvironment):
+        r"""Base of the four picture environments.
+
+        VerbatimEnvironment switches to verbatim catcodes right after
+        parsing the (empty) argument spec, so everything between
+        ``\begin{X}`` and ``\end{X}`` — the optional ``[keys]`` included —
+        is captured as raw characters and round-trips into the standalone
+        document byte-identically.  No tenkz key ever gets parsed in
+        Python; the TeX library is the single grammar authority.
+        """
+
+        def tenkzUnitSource(self) -> str:
+            name = self.nodeName
+            return rf"\begin{{{name}}}{self.textContent}\end{{{name}}}"
+
+    class tenkz(_TenkzVerbatimEnvironment):
+        pass
+
+    class tenkzcd(_TenkzVerbatimEnvironment):
+        pass
+
+    class tenkzlattice(_TenkzVerbatimEnvironment):
+        pass
+
+    class tenkzplanes(_TenkzVerbatimEnvironment):
+        pass
+
+    class tenkzfree(_TenkzVerbatimEnvironment):
+        pass
+
+    class tnpic(_TenkzSvgMixin, Command):
+        r"""The bridge object ``\tnpic[keys]{grid body}`` (spec §2.3).
+
+        The optional key list and the mandatory body are read with
+        verbatim catcodes and balanced-brace scanning, mirroring how
+        ``\verb`` captures its argument, so cell separators (``&``),
+        comments, and math inside the body survive untouched.
+
+        TODO (G20): running math containing ``\tnpic[inline]`` must be
+        rerouted whole-equation to the SVG path — MathJax cannot typeset
+        the atom this class emits.  Out of Phase-0 scope; until then
+        ``\tnpic`` is only supported outside math (see module docstring).
+        """
+
+        blockType = False
+
+        def invoke(self, tex):
+            self.ownerDocument.context.push(self)
+            self.parse(tex)
+            self.ownerDocument.context.setVerbatimCatcodes()
+            try:
+                self.tenkzCaptured = self._capture_call(tex)
+            finally:
+                self.ownerDocument.context.pop(self)
+            return [self]
+
+        @staticmethod
+        def _next_nonspace(tokens) -> str | None:
+            for tok in tokens:
+                if str(tok) not in " \t\r\n":
+                    return tok
+            return None
+
+        def _capture_call(self, tex) -> str:
+            tokens = iter(tex)
+            parts: list[str] = []
+            head = self._next_nonspace(tokens)
+            if head == "[":
+                # Optional key list: keys may contain braced values
+                # (``bond label={$D$ at 1-2}``), so ``]`` closes only at
+                # brace depth zero.
+                option = ["["]
+                depth = 0
+                for tok in tokens:
+                    option.append(str(tok))
+                    if tok == "{":
+                        depth += 1
+                    elif tok == "}":
+                        depth -= 1
+                    elif tok == "]" and depth == 0:
+                        break
+                else:
+                    raise ValueError(r"unterminated \tnpic optional argument")
+                parts.append("".join(option))
+                head = self._next_nonspace(tokens)
+            if head != "{":
+                raise ValueError(r"\tnpic requires a braced grid body")
+            body = ["{"]
+            depth = 1
+            for tok in tokens:
+                body.append(str(tok))
+                if tok == "{":
+                    depth += 1
+                elif tok == "}":
+                    depth -= 1
+                    if depth == 0:
+                        break
+            else:
+                raise ValueError(r"unterminated \tnpic body")
+            parts.append("".join(body))
+            return "".join(parts)
+
+        def tenkzUnitSource(self) -> str:
+            return r"\tnpic" + self.tenkzCaptured
+
+        @property
+        def source(self) -> str:
+            return self.tenkzUnitSource()

--- a/blueprint/src/plastex_templates/TenkzPictures.jinja2s
+++ b/blueprint/src/plastex_templates/TenkzPictures.jinja2s
@@ -1,0 +1,2 @@
+name: TenkzPicture
+{{ obj.tenkz_svg_html }}

--- a/docs/tenkz/DEMOLITION.md
+++ b/docs/tenkz/DEMOLITION.md
@@ -1,0 +1,52 @@
+# tenkz Phase 3 — demolition checklist
+
+The single-PR removal of the old `tex/tn/` system, executable once Phase 2
+(chapter-by-chapter inlining) completes.  This is the tracked form of the
+delete list in `DESIGN.md` §Phase 3; the entry-by-entry migration ledger is
+`MIGRATION-MAP.md`.  Nothing on this list survives in any form.
+
+## Preconditions (Phase-2 exit)
+
+- [ ] `grep -r '\\TN[A-Z]' blueprint/src/chapter/` is empty (every legacy
+      macro call inlined; countdown badge reads 0).
+- [ ] Every `tenkz-compat.tex` entry is at remaining-use count zero.
+
+## Delete — TeX (`tex/tn/`, 5,929 lines, whole directory)
+
+| File | Lines |
+|---|---:|
+| `tex/tn/tn_catalogue.tex` (114 `\TNDeclareDiagram` registrations + roles/profiles/contexts metadata) | 2,213 |
+| `tex/tn/tn_library.tex` (v/p/m×route connect macros, trivalent macros, motif constructors) | 1,440 |
+| `tex/tn/tn_core.tex` (old port registry incl. `morphism`, old `.tnlog`, raw-`\def` layout profiles) | 763 |
+| `tex/tn/tn_motifs_peps.tex` (incl. 7 hand-digitized region polygons) | 787 |
+| `tex/tn/tn_motifs_mpdo.tex` | 281 |
+| `tex/tn/tn_motifs_symmetry.tex` | 149 |
+| `tex/tn/tn_atoms.tex` (hand-synced atom registry) | 148 |
+| `tex/tn/tn_slide_catalogue.tex` + the parallel Slide* interface (`dark` theme replaces it) | 139 |
+| `tex/tn/tikzlibrarytn.code.tex` (loader stub) | 9 |
+| `tenkz-compat.tex` (the Phase-1 shim itself, deleted last) | — |
+
+## Delete — Python (the registry pipeline)
+
+| File | Lines | Note |
+|---|---:|---|
+| `blueprint/src/Packages/tn_diagrams.py` | 2,258 | per-macro plasTeX class manufacture, role/profile/contexts assert-equal checks, `_assert_no_chapter_local_tikz`, `assert_repeated_topologies_are_motifs`; the hash/cache/jinja core already survives inside `tenkz_pic.py` |
+| `scripts/check_tn_references.py` | 242 | checks the old catalogue's call sites |
+| `scripts/build_tn_gallery.py` | 385 | derives the gallery from the old registry; the auto-extracted per-chapter gallery (G15) replaces it |
+
+## Rewire — build plumbing
+
+- [ ] `blueprint/src/web.tex`: `\usepackage{tn_diagrams}` → `\usepackage{tenkz_pic}`
+      (plasTeX package swap; `packages-dirs=Packages` in `plastex.cfg` is unchanged).
+- [ ] `blueprint/src/latexmkrc`: `TEXINPUTS` `../../tex/tn//` → `../../tex/tenkz//`.
+- [ ] CI: `blueprint.yml` and `lint-blueprint.yml` steps invoking
+      `Packages/tn_diagrams.py` → tenkz equivalents; every `tex/tn/**` path
+      filter (`blueprint.yml`, `lint-blueprint.yml`, `blueprint-prose-review.yml`,
+      `claude-code-review.yml`) and `find … tex/tn` invocation → `tex/tenkz`.
+
+## Exit criteria
+
+- [ ] `grep -r '\\TN[A-Z]' blueprint/src/` is empty.
+- [ ] `git grep -l 'tex/tn/'` and `git grep -l 'tn_diagrams'` are empty.
+- [ ] Blueprint print (latexmk) and web (plasTeX) builds are green; the
+      B1–B8 corpus and the gallery pixel set render unchanged.

--- a/scripts/tenkz_audit.py
+++ b/scripts/tenkz_audit.py
@@ -1,0 +1,569 @@
+#!/usr/bin/env python3
+"""Audit a tenkz `.tnlog` event stream (tenkz spec section 5).
+
+A `.tnlog` is a line-oriented stream `event|key=value|...` written by the
+tenkz LaTeX environments.  Every picture opens with `picture|id=N|lang=L`
+(langs: grid, cd, lattice, free, planes); subsequent events carry an
+explicit `picture=N` back-reference.  `tree|picture=0` marks a `\\tntree`
+typeset outside any environment (legal in running math).
+
+Hard errors (exit 1):
+  malformed-event      A field fails its type (e.g. an unexpanded expl3
+                       token such as `\\l__tenkz_nrows_int` in a numeric
+                       slot).  The stream is the contraction record; a
+                       non-numeric coordinate names no cell, so the event
+                       describes no drawable ink.
+  duplicate-picture    Two `picture` lines share one id: picture identity
+                       is the key of every back-reference.
+  dangling-picture-ref An event references an undeclared picture.
+  empty-picture        A grid/lattice/free picture emitted no content
+                       events.  A tensor diagram with no atoms and no
+                       regions denotes no tensor network -- historically
+                       the "34 fake diagrams" class.
+
+Advisories (never affect the exit code):
+  eq-boundary-mismatch Consecutive grid pictures joined by `=` in the
+                       source have different boundary signatures.  A
+                       tensor equation equates two maps of one type, so
+                       the multisets of open legs must agree side-to-side.
+  periodic-no-dots     A traced (periodic) chain of >= 4 columns without
+                       an ellipsis cell: a closed word of generic length n
+                       drawn with every site reads as fixed length.
+  repeated-topology    Identical canonical atom+bond content in several
+                       pictures: the figure is a candidate `\\tndefine`.
+  dialect-mismatch     An event kind foreign to its picture's language
+                       (each sub-language owns its event dialect).
+  unknown-event/lang   Forward-compatibility notes.
+  stale-log            The source declares picture constructs but the log
+                       has none (failed or interrupted compile).
+
+Source heuristic (documented, deliberately simple): picture-producing
+constructs (`\\begin{tenkz...}` and `\\tnpic`) are matched to log pictures
+in order of appearance; the match is used only when the counts agree.
+Two consecutive grid pictures are "one displayed equation" when the
+source between them contains `=` and no math-mode boundary (`$`, `\\[`,
+`\\]`), no cell separator `&`, no other environment, and is short.
+
+Usage: tenkz_audit.py file.tnlog [file.tex]
+If file.tex is omitted, a sibling `<stem>.tex` is used when present.
+Exit status: 1 iff hard errors were found.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Optional
+
+INT_RE = re.compile(r"-?\d+")
+CELL_RE = re.compile(r"-?\d+--?\d+")  # r-c with signed components
+
+KNOWN_LANGS = {"grid", "cd", "lattice", "free", "planes"}
+
+# Empty-picture hard check applies exactly to the spec's list (section 5.4).
+EMPTY_CHECK_LANGS = {"grid", "lattice", "free"}
+
+# Event kinds each dialect is expected to emit.  `lattice` and `planes`
+# are left open: lattice currently emits nothing (see audit report) and
+# planes is a post-spec dialect still growing its vocabulary.
+DIALECT_KINDS = {
+    "grid": {"atom", "bond", "trace", "pairtrace", "phtrace", "cup", "hole", "boundary"},
+    "free": {"atom", "join", "boundary"},
+    "cd": {"cdcell", "cdarrow", "tree"},
+}
+
+
+def _is_int(v: str) -> bool:
+    return INT_RE.fullmatch(v) is not None
+
+
+def _is_cell(v: str) -> bool:
+    return re.fullmatch(r"\d+-\d+", v) is not None
+
+
+def _enum(*vals: str) -> Callable[[str], bool]:
+    allowed = set(vals)
+    return lambda v: v in allowed
+
+
+def _any(v: str) -> bool:
+    return v != ""
+
+
+# kind -> {field: validator}; fields absent here are accepted as opaque.
+# Numeric slots are validated strictly: they are cell/row coordinates, and
+# a coordinate that is not an integer addresses nothing.
+FIELD_VALIDATORS: dict[str, dict[str, Callable[[str], bool]]] = {
+    "picture": {"id": _is_int, "lang": _any},
+    "atom": {"picture": _is_int, "cell": _is_cell, "name": _any, "kind": _any},
+    # The emitter normalizes the user-facing `bond dir=left|right` to
+    # forward/reverse (direction along the wire); accept both spellings.
+    "bond": {"picture": _is_int, "row": _is_int, "from": _is_int, "to": _is_int,
+             "dir": _enum("none", "left", "right", "forward", "reverse")},
+    "trace": {"picture": _is_int, "row": _is_int, "side": _enum("above", "below")},
+    "pairtrace": {"picture": _is_int, "row": _is_int, "col": _is_int, "site": _is_cell},
+    "phtrace": {"picture": _is_int, "row": _is_int, "col": _is_int},
+    "cup": {"picture": _is_int, "side": _enum("west", "east"),
+            "top": _is_int, "bottom": _is_int, "matrix": _is_int},
+    "hole": {"picture": _is_int, "row": _is_int, "col": _is_int},
+    "boundary": {"picture": _is_int, "virtual-west": _is_int, "virtual-east": _is_int,
+                 "physical-up": _is_int, "physical-down": _is_int},
+    "cdcell": {"picture": _is_int, "index": _is_int},
+    "cdarrow": {"picture": _is_int, "from": _any, "to": _any},
+    "tree": {"picture": _is_int, "leaves": _is_int},
+    "join": {"picture": _is_int, "from": _any, "to": _any},
+}
+
+
+@dataclass
+class Event:
+    kind: str
+    attrs: dict[str, str]
+    line: int
+    raw: str
+
+
+@dataclass
+class Picture:
+    ident: int
+    lang: str
+    line: int
+    events: list[Event] = field(default_factory=list)
+
+    def content(self) -> list[Event]:
+        """Events that denote ink.  `boundary` is a derived signature line
+        emitted even for pictures that draw nothing, so it is excluded."""
+        return [e for e in self.events if e.kind != "boundary"]
+
+    def boundary(self) -> Optional[tuple[int, int, int, int]]:
+        for e in self.events:
+            if e.kind == "boundary":
+                try:
+                    return tuple(int(e.attrs[k].strip()) for k in
+                                 ("virtual-west", "virtual-east",
+                                  "physical-up", "physical-down"))  # type: ignore[return-value]
+                except (KeyError, ValueError):
+                    return None
+        return None
+
+    def ncols(self) -> int:
+        n = 0
+        for e in self.events:
+            if e.kind == "atom" and "cell" in e.attrs and _is_cell(e.attrs["cell"].strip()):
+                n = max(n, int(e.attrs["cell"].strip().split("-")[1]))
+            elif e.kind == "bond":
+                for k in ("from", "to"):
+                    v = e.attrs.get(k, "").strip()
+                    if _is_int(v):
+                        n = max(n, int(v))
+        return n
+
+
+@dataclass
+class Finding:
+    severity: str  # "HARD" | "ADV" | "NOTE"
+    rule: str
+    where: str
+    msg: str
+
+
+class Audit:
+    def __init__(self, log_path: Path, tex_path: Optional[Path]) -> None:
+        self.log_path = log_path
+        self.tex_path = tex_path
+        self.findings: list[Finding] = []
+        self.pictures: list[Picture] = []
+        self.by_id: dict[int, Picture] = {}
+        self.constructs: list["Construct"] = []
+        self.tex_linked = False
+
+    def hard(self, rule: str, where: str, msg: str) -> None:
+        self.findings.append(Finding("HARD", rule, where, msg))
+
+    def adv(self, rule: str, where: str, msg: str) -> None:
+        self.findings.append(Finding("ADV", rule, where, msg))
+
+    def note(self, rule: str, where: str, msg: str) -> None:
+        self.findings.append(Finding("NOTE", rule, where, msg))
+
+    # ---------------- parsing ----------------
+
+    def parse_log(self) -> None:
+        name = self.log_path.name
+        for lineno, raw in enumerate(
+                self.log_path.read_text(encoding="utf-8").splitlines(), 1):
+            line = raw.strip()
+            if not line:
+                continue
+            where = f"{name}:{lineno}"
+            parts = line.split("|")
+            kind = parts[0].strip()
+            attrs: dict[str, str] = {}
+            ok = True
+            for p in parts[1:]:
+                if "=" not in p:
+                    self.hard("malformed-event", where,
+                              f"bare field {p.strip()!r} (expected key=value): {line}")
+                    ok = False
+                    continue
+                k, v = p.split("=", 1)
+                attrs[k.strip()] = v.strip()
+            ev = Event(kind, attrs, lineno, line)
+            validators = FIELD_VALIDATORS.get(kind)
+            if validators is None:
+                self.adv("unknown-event", where, f"unrecognized event kind {kind!r}")
+            else:
+                for k, v in attrs.items():
+                    check = validators.get(k)
+                    if check is not None and not check(v):
+                        self.hard("malformed-event", where,
+                                  f"{kind} field {k}={v!r} fails validation: {line}")
+                        ok = False
+            if kind == "picture":
+                if not ok or "id" not in attrs or not _is_int(attrs["id"]):
+                    continue
+                pid = int(attrs["id"])
+                lang = attrs.get("lang", "")
+                if lang not in KNOWN_LANGS:
+                    self.adv("unknown-lang", where, f"picture {pid} has lang={lang!r}")
+                if pid in self.by_id:
+                    self.hard("duplicate-picture", where,
+                              f"picture id {pid} already declared at line "
+                              f"{self.by_id[pid].line}")
+                    continue
+                pic = Picture(pid, lang, lineno)
+                self.by_id[pid] = pic
+                self.pictures.append(pic)
+                continue
+            ref = attrs.get("picture", "")
+            if not _is_int(ref):
+                continue  # already reported as malformed above
+            pid = int(ref)
+            if pid == 0 and kind == "tree":
+                continue  # \tntree in running math, outside any picture
+            if pid not in self.by_id:
+                self.hard("dangling-picture-ref", where,
+                          f"{kind} references undeclared picture {pid}")
+                continue
+            self.by_id[pid].events.append(ev)
+
+    # ---------------- log-only checks ----------------
+
+    def check_empty_pictures(self) -> None:
+        for pic in self.pictures:
+            if pic.content():
+                continue
+            where = f"{self.log_path.name}:{pic.line}"
+            if pic.lang in EMPTY_CHECK_LANGS:
+                self.hard("empty-picture", where,
+                          f"picture {pic.ident} (lang={pic.lang}) emitted no "
+                          f"content events")
+            else:
+                self.adv("empty-picture", where,
+                         f"picture {pic.ident} (lang={pic.lang}) emitted no "
+                         f"content events (lang outside the hard-check list)")
+
+    def check_dialects(self) -> None:
+        for pic in self.pictures:
+            allowed = DIALECT_KINDS.get(pic.lang)
+            if allowed is None:
+                continue
+            for e in pic.content():
+                if e.kind not in allowed:
+                    self.adv("dialect-mismatch", f"{self.log_path.name}:{e.line}",
+                             f"{e.kind} event inside picture {pic.ident} "
+                             f"(lang={pic.lang}); not part of that dialect")
+                elif e.kind == "atom":
+                    want = "cell" if pic.lang == "grid" else "name"
+                    if want not in e.attrs:
+                        self.adv("dialect-mismatch",
+                                 f"{self.log_path.name}:{e.line}",
+                                 f"atom in {pic.lang} picture {pic.ident} lacks "
+                                 f"{want}=")
+
+    def check_repeated_topology(self) -> None:
+        groups: dict[tuple[str, str], list[Picture]] = {}
+        for pic in self.pictures:
+            atoms = [e for e in pic.content() if e.kind == "atom"]
+            if len(atoms) < 2:
+                continue  # a lone bead repeated is not worth a \tndefine
+            groups.setdefault((pic.lang, canonical_hash(pic)), []).append(pic)
+        for (lang, digest), pics in sorted(groups.items(),
+                                           key=lambda kv: kv[1][0].ident):
+            if len(pics) < 2:
+                continue
+            ids = ", ".join(str(p.ident) for p in pics)
+            self.adv("repeated-topology", self.log_path.name,
+                     f"pictures {ids} (lang={lang}) share canonical topology "
+                     f"{digest}; consider a \\tndefine")
+
+    def check_periodic_dots(self) -> None:
+        for idx, pic in enumerate(self.pictures):
+            if pic.lang != "grid":
+                continue
+            if not any(e.kind == "trace" for e in pic.events):
+                continue
+            ncols = pic.ncols()
+            if ncols < 4:
+                continue
+            if self._has_dots_cell(idx, pic, ncols):
+                continue
+            self.adv("periodic-no-dots", f"{self.log_path.name}:{pic.line}",
+                     f"picture {pic.ident}: traced chain of {ncols} columns "
+                     f"without an ellipsis cell; a generic-length word should "
+                     f"show \\tndots")
+
+    def _has_dots_cell(self, idx: int, pic: Picture, ncols: int) -> bool:
+        """Prefer the source (`\\tndots` in the matched body); otherwise use
+        the atom-gap proxy: `\\tndots` emits no atom, so a column with no
+        atom in any row is an ellipsis candidate.  The proxy over-detects
+        (`\\tnX`/`\\tnghost` also emit no atom), so it only ever
+        under-reports -- safe for an advisory."""
+        if self.tex_linked:
+            return re.search(r"\\tndots\b", self.constructs[idx].body) is not None
+        cols_with_atoms = {int(e.attrs["cell"].split("-")[1])
+                           for e in pic.events
+                           if e.kind == "atom" and _is_cell(e.attrs.get("cell", ""))}
+        return any(c not in cols_with_atoms for c in range(1, ncols + 1))
+
+    # ---------------- source-linked checks ----------------
+
+    def link_tex(self) -> None:
+        if self.tex_path is None or not self.tex_path.exists():
+            return
+        src = strip_comments(self.tex_path.read_text(encoding="utf-8"))
+        self.constructs = scan_constructs(src)
+        if len(self.constructs) == len(self.pictures) and self.pictures:
+            self.tex_linked = True
+        elif self.constructs and not self.pictures:
+            self.adv("stale-log", self.log_path.name,
+                     f"{self.tex_path.name} declares {len(self.constructs)} "
+                     f"picture construct(s) but the log has none (failed or "
+                     f"interrupted compile?)")
+        elif len(self.constructs) != len(self.pictures):
+            self.note("tex-unlinked", self.log_path.name,
+                      f"{len(self.constructs)} construct(s) in "
+                      f"{self.tex_path.name} vs {len(self.pictures)} picture(s) "
+                      f"in the log; source-linked advisories disabled "
+                      f"(macro-generated pictures?)")
+        if self.tex_linked:
+            self._tex_src = src
+
+    def check_equation_boundaries(self) -> None:
+        if not self.tex_linked:
+            return
+        for i in range(len(self.pictures) - 1):
+            a, b = self.pictures[i], self.pictures[i + 1]
+            if a.lang != "grid" or b.lang != "grid":
+                continue
+            ca, cb = self.constructs[i], self.constructs[i + 1]
+            if ca.end > cb.start:
+                continue  # nested constructs: no linear separator
+            sep = self._tex_src[ca.end:cb.start]
+            if not same_equation(sep):
+                continue
+            sig_a, sig_b = a.boundary(), b.boundary()
+            if sig_a is None or sig_b is None or sig_a == sig_b:
+                continue
+            self.adv("eq-boundary-mismatch",
+                     f"{self.log_path.name}:{a.line}",
+                     f"pictures {a.ident} and {b.ident} sit on one `=` but "
+                     f"open-leg signatures differ: "
+                     f"(vw,ve,pu,pd) {sig_a} vs {sig_b} "
+                     f"[{self.tex_path.name}:{ca.line}]")
+
+    # ---------------- driver ----------------
+
+    def run(self) -> int:
+        self.parse_log()
+        self.link_tex()
+        self.check_empty_pictures()
+        self.check_dialects()
+        self.check_equation_boundaries()
+        self.check_periodic_dots()
+        self.check_repeated_topology()
+        return self.report()
+
+    def report(self) -> int:
+        hard = [f for f in self.findings if f.severity == "HARD"]
+        advs = [f for f in self.findings if f.severity == "ADV"]
+        notes = [f for f in self.findings if f.severity == "NOTE"]
+        tex = self.tex_path.name if self.tex_path and self.tex_path.exists() else "none"
+        linked = " (linked)" if self.tex_linked else ""
+        print(f"== tenkz audit: {self.log_path.name} -- "
+              f"{len(self.pictures)} picture(s); tex: {tex}{linked} ==")
+        for f in hard + advs + notes:
+            print(f"  {f.severity:<4} [{f.rule}] {f.where}: {f.msg}")
+        if hard:
+            print(f"  FAIL: {len(hard)} hard error(s), {len(advs)} advisory(ies)")
+            return 1
+        print(f"  ok: no hard errors ({len(advs)} advisory(ies))")
+        return 0
+
+
+# ---------------- canonical topology ----------------
+
+def canonical_hash(pic: Picture) -> str:
+    """Order-free digest of a picture's content.  Attributes are sorted,
+    the `picture` back-reference is dropped (identity must not depend on
+    position in the document), and `dir=none` is normalized away so logs
+    from emitters before the `dir` attribute hash identically."""
+    lines = []
+    for e in pic.content():
+        attrs = {k: v for k, v in e.attrs.items() if k != "picture"}
+        if e.kind == "bond" and attrs.get("dir") == "none":
+            del attrs["dir"]
+        lines.append(e.kind + "|" + "|".join(
+            f"{k}={v}" for k, v in sorted(attrs.items())))
+    payload = "\n".join(sorted(lines)).encode("utf-8")
+    return hashlib.sha1(payload).hexdigest()[:12]
+
+
+# ---------------- TeX source scanning ----------------
+
+@dataclass
+class Construct:
+    name: str      # environment name or "tnpic"
+    start: int     # offset of the construct's first character
+    end: int       # offset one past its last character
+    body: str
+    line: int
+
+
+def strip_comments(src: str) -> str:
+    """Replace unescaped `%`-comments with spaces, preserving offsets so
+    positions in the stripped text index the original file."""
+    out: list[str] = []
+    for line in src.split("\n"):
+        buf = list(line)
+        i = 0
+        while i < len(buf):
+            if buf[i] == "\\":
+                i += 2
+                continue
+            if buf[i] == "%":
+                for j in range(i, len(buf)):
+                    buf[j] = " "
+                break
+            i += 1
+        out.append("".join(buf))
+    return "\n".join(out)
+
+
+def _match_group(src: str, i: int, open_ch: str, close_ch: str) -> int:
+    """Offset one past the group opening at `src[i]`, brace-aware: a `]`
+    inside `{...}` does not close a `[...]` group.  Works for both brace
+    and bracket groups.  Returns -1 if unbalanced."""
+    depth_group = 0
+    depth_brace = 0
+    while i < len(src):
+        c = src[i]
+        if c == "\\":
+            i += 2
+            continue
+        if c == open_ch and (open_ch == "{" or depth_brace == 0):
+            depth_group += 1
+        elif c == close_ch and (close_ch == "}" or depth_brace == 0):
+            depth_group -= 1
+            if depth_group == 0:
+                return i + 1
+        elif c == "{":
+            depth_brace += 1
+        elif c == "}":
+            depth_brace -= 1
+        i += 1
+    return -1
+
+
+def _find_env_end(src: str, name: str, pos: int) -> Optional[re.Match[str]]:
+    """Match of the `\\end{name}` closing the `\\begin{name}` whose body
+    starts at `pos`, depth-counting nested same-name environments so an
+    inner `\\end` never closes the outer construct.  None if unclosed."""
+    token_re = re.compile(r"\\(begin|end)\{" + re.escape(name) + r"\}")
+    depth = 1
+    for tok in token_re.finditer(src, pos):
+        depth += 1 if tok.group(1) == "begin" else -1
+        if depth == 0:
+            return tok
+    return None
+
+
+def scan_constructs(src: str) -> list[Construct]:
+    """Picture-producing constructs in source order.  tenkz assigns picture
+    ids at `\\begin` time, so source order of construct starts equals log
+    order even when a `\\tnpic` nests inside a `tenkzcd` cell."""
+    found: list[Construct] = []
+    env_re = re.compile(r"\\begin\{(tenkz(?:cd|lattice|free|planes)?)\}")
+    for m in env_re.finditer(src):
+        name = m.group(1)
+        end_m = _find_env_end(src, name, m.end())
+        end = end_m.end() if end_m else len(src)
+        body_start = m.end()
+        if src[body_start:body_start + 1] == "[":
+            closed = _match_group(src, body_start, "[", "]")
+            if closed != -1:
+                body_start = closed
+        body_end = end_m.start() if end_m else len(src)
+        found.append(Construct(name, m.start(), end,
+                               src[body_start:body_end],
+                               src.count("\n", 0, m.start()) + 1))
+    for m in re.finditer(r"\\tnpic\b", src):
+        i = m.end()
+        while i < len(src) and src[i] in " \t\n":
+            i += 1
+        if src[i:i + 1] == "[":
+            closed = _match_group(src, i, "[", "]")
+            if closed == -1:
+                continue
+            i = closed
+            while i < len(src) and src[i] in " \t\n":
+                i += 1
+        if src[i:i + 1] != "{":
+            continue
+        closed = _match_group(src, i, "{", "}")
+        if closed == -1:
+            continue
+        found.append(Construct("tnpic", m.start(), closed,
+                               src[i + 1:closed - 1],
+                               src.count("\n", 0, m.start()) + 1))
+    found.sort(key=lambda c: c.start)
+    return found
+
+
+def same_equation(sep: str) -> bool:
+    """Heuristic: the comment-stripped source between two constructs is a
+    single displayed equation's glue iff it contains `=`, crosses no
+    math-mode boundary and no other environment, and is short.  This keeps
+    the check to `A = B` pairs like the gauge/blocking benchmarks."""
+    if "=" not in sep:
+        return False
+    if any(tok in sep for tok in ("$", "\\[", "\\]", "&", "\\begin", "\\end")):
+        return False
+    return len(sep.strip()) <= 200
+
+
+# ---------------- CLI ----------------
+
+def main(argv: list[str]) -> int:
+    args = [a for a in argv if not a.startswith("-")]
+    if "-h" in argv or "--help" in argv or not 1 <= len(args) <= 2:
+        print(__doc__.strip().splitlines()[0])
+        print("usage: tenkz_audit.py file.tnlog [file.tex]")
+        return 0 if ("-h" in argv or "--help" in argv) else 2
+    log_path = Path(args[0])
+    if not log_path.exists():
+        print(f"tenkz_audit: no such file: {log_path}", file=sys.stderr)
+        return 2
+    if len(args) == 2:
+        tex_path: Optional[Path] = Path(args[1])
+    else:
+        sibling = log_path.with_suffix(".tex")
+        tex_path = sibling if sibling.exists() else None
+    return Audit(log_path, tex_path).run()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/tenkz_lint.py
+++ b/scripts/tenkz_lint.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Source lint for `.tex` files using the tenkz picture languages.
+
+Rules (findings exit 1 unless escaped):
+
+  dots     Literal `...`, `\\ldots`, or `\\cdots` inside a tenkz,
+           tenkzlattice, or tenkzplanes body (or a `\\tnpic` body, which
+           is a tenkz body by construction).  An ellipsis cell interrupts
+           the implicit wire; literal dots typeset ink that the event
+           stream cannot see, so the audited contraction graph and the
+           printed picture diverge.  `\\tndots` is the only legal
+           ellipsis.  Dots inside `[...]` option groups are exempt: a
+           label value such as `up={$i_1\\cdots i_L$}` is math content of
+           a leg label, not a wire cell (spec benchmark B4 sanctions it).
+
+  raw-ink  Raw TikZ ink inside any tenkz-family body (`line width=`,
+           `draw=`, `fill=`, `color=`, or raw `\\draw`/`\\fill`/
+           `\\filldraw`/`\\shade`/`\\node`/`\\path`/`\\tikzset`).  The
+           theme owns ink: a literal stroke or color bypasses the
+           two-layer theme/semantic split, so the picture stops
+           restyling under `\\tnset` and diverges between print and
+           dark builds.
+
+Escape: a comment `% tenkz-lint: allow <rule> <reason>` on the finding's
+line or the line directly above suppresses that rule there (`allow all`
+suppresses every rule).  Escaped findings are reported but do not fail.
+
+Usage: tenkz_lint.py FILE_OR_GLOB [FILE_OR_GLOB ...]
+Exit status: 1 iff at least one unescaped finding was reported.
+"""
+
+from __future__ import annotations
+
+import glob
+import re
+import sys
+from bisect import bisect_right
+from dataclasses import dataclass
+from pathlib import Path
+
+# Bodies scanned for the dots rule: the grid languages whose cells feed
+# the implicit wire.  (tenkzcd cells are math objects and tenkzfree has
+# no implicit wire, so a literal ellipsis there is ordinary math.)
+DOTS_ENVS = {"tenkz", "tenkzlattice", "tenkzplanes", "tnpic"}
+
+# Bodies scanned for the raw-ink rule: every tenkz-family body -- the
+# theme contract covers all five sub-languages.
+INK_ENVS = {"tenkz", "tenkzcd", "tenkzlattice", "tenkzfree", "tenkzplanes", "tnpic"}
+
+DOTS_PATTERNS = [
+    ("dots", re.compile(r"\\ldots\b|\\cdots\b|(?<!\.)\.\.\.(?!\.)")),
+]
+
+INK_PATTERNS = [
+    ("raw-ink", re.compile(
+        r"line\s+width\s*=|(?<![\w@])(?:draw|fill|color)\s*=|"
+        r"\\(?:draw|fill|filldraw|shade|node|path|tikzset)\b")),
+]
+
+ESCAPE_RE = re.compile(r"%\s*tenkz-lint:\s*allow\s+(\S+)(?:\s+(.*\S))?")
+
+
+@dataclass
+class Finding:
+    path: Path
+    line: int
+    rule: str
+    snippet: str
+    allowed: bool
+    reason: str = ""
+
+
+def strip_comments(src: str) -> str:
+    """Blank out unescaped `%`-comments, preserving offsets/line numbers."""
+    out: list[str] = []
+    for line in src.split("\n"):
+        buf = list(line)
+        i = 0
+        while i < len(buf):
+            if buf[i] == "\\":
+                i += 2
+                continue
+            if buf[i] == "%":
+                for j in range(i, len(buf)):
+                    buf[j] = " "
+                break
+            i += 1
+        out.append("".join(buf))
+    return "\n".join(out)
+
+
+def _match_group(src: str, i: int, open_ch: str, close_ch: str) -> int:
+    """Offset one past the group opening at `src[i]`, brace-aware: a `]`
+    inside `{...}` does not close a `[...]` group.  Works for both brace
+    and bracket groups.  Returns -1 if unbalanced."""
+    depth_group = 0
+    depth_brace = 0
+    while i < len(src):
+        c = src[i]
+        if c == "\\":
+            i += 2
+            continue
+        if c == open_ch and (open_ch == "{" or depth_brace == 0):
+            depth_group += 1
+        elif c == close_ch and (close_ch == "}" or depth_brace == 0):
+            depth_group -= 1
+            if depth_group == 0:
+                return i + 1
+        elif c == "{":
+            depth_brace += 1
+        elif c == "}":
+            depth_brace -= 1
+        i += 1
+    return -1
+
+
+@dataclass
+class Body:
+    name: str
+    start: int  # offset of the body's first character in the stripped source
+    text: str
+
+
+def _find_env_end(src: str, name: str, pos: int) -> "re.Match[str] | None":
+    """Match of the `\\end{name}` closing the `\\begin{name}` whose body
+    starts at `pos`, depth-counting nested same-name environments so an
+    inner `\\end` never closes the outer body.  None if unclosed."""
+    token_re = re.compile(r"\\(begin|end)\{" + re.escape(name) + r"\}")
+    depth = 1
+    for tok in token_re.finditer(src, pos):
+        depth += 1 if tok.group(1) == "begin" else -1
+        if depth == 0:
+            return tok
+    return None
+
+
+def scan_bodies(src: str) -> list[Body]:
+    """tenkz-family bodies in a comment-stripped source: environment
+    bodies (options group excluded) and balanced `\\tnpic` arguments."""
+    bodies: list[Body] = []
+    env_re = re.compile(r"\\begin\{(tenkz(?:cd|lattice|free|planes)?)\}")
+    for m in env_re.finditer(src):
+        name = m.group(1)
+        end_m = _find_env_end(src, name, m.end())
+        body_start = m.end()
+        if src[body_start:body_start + 1] == "[":
+            closed = _match_group(src, body_start, "[", "]")
+            if closed != -1:
+                body_start = closed
+        body_end = end_m.start() if end_m else len(src)
+        bodies.append(Body(name, body_start, src[body_start:body_end]))
+    for m in re.finditer(r"\\tnpic\b", src):
+        i = m.end()
+        while i < len(src) and src[i] in " \t\n":
+            i += 1
+        if src[i:i + 1] == "[":
+            closed = _match_group(src, i, "[", "]")
+            if closed == -1:
+                continue
+            i = closed
+            while i < len(src) and src[i] in " \t\n":
+                i += 1
+        if src[i:i + 1] != "{":
+            continue
+        closed = _match_group(src, i, "{", "}")
+        if closed == -1:
+            continue
+        bodies.append(Body("tnpic", i + 1, src[i + 1:closed - 1]))
+    return bodies
+
+
+def mask_option_groups(body: str) -> str:
+    """Blank out `[...]` option groups (offset-preserving): leg and bond
+    labels live there, and label math may carry `\\cdots` legitimately."""
+    buf = list(body)
+    i = 0
+    while i < len(buf):
+        c = buf[i]
+        if c == "\\":
+            i += 2
+            continue
+        if c == "[":
+            closed = _match_group(body, i, "[", "]")
+            if closed == -1:
+                break
+            for j in range(i, closed):
+                if buf[j] != "\n":
+                    buf[j] = " "
+            i = closed
+            continue
+        i += 1
+    return "".join(buf)
+
+
+def collect_escapes(src: str) -> dict[int, list[str]]:
+    """line number -> rules allowed by `% tenkz-lint: allow <rule> <reason>`."""
+    escapes: dict[int, list[str]] = {}
+    for lineno, line in enumerate(src.split("\n"), 1):
+        m = ESCAPE_RE.search(line)
+        if m:
+            escapes.setdefault(lineno, []).append(m.group(1))
+    return escapes
+
+
+def lint_file(path: Path) -> list[Finding]:
+    raw = path.read_text(encoding="utf-8")
+    escapes = collect_escapes(raw)
+    src = strip_comments(raw)
+    line_starts = [0] + [i + 1 for i, c in enumerate(src) if c == "\n"]
+    raw_lines = raw.split("\n")
+
+    def line_of(offset: int) -> int:
+        return bisect_right(line_starts, offset)
+
+    def escaped(lineno: int, rule: str) -> bool:
+        for ln in (lineno, lineno - 1):
+            for allowed in escapes.get(ln, []):
+                if allowed in (rule, "all"):
+                    return True
+        return False
+
+    findings: list[Finding] = []
+    seen: set[tuple[int, str]] = set()  # one report per (line, rule)
+
+    def scan(text: str, base: int, rules: list[tuple[str, re.Pattern[str]]]) -> None:
+        for rule, pat in rules:
+            for m in pat.finditer(text):
+                offset = base + m.start()
+                lineno = line_of(offset)
+                key = (lineno, rule)
+                if key in seen:
+                    continue
+                seen.add(key)
+                snippet = raw_lines[lineno - 1].strip() if lineno <= len(raw_lines) else ""
+                findings.append(Finding(path, lineno, rule, snippet,
+                                        escaped(lineno, rule)))
+
+    for body in scan_bodies(src):
+        if body.name in DOTS_ENVS:
+            scan(mask_option_groups(body.text), body.start, DOTS_PATTERNS)
+        if body.name in INK_ENVS:
+            scan(body.text, body.start, INK_PATTERNS)
+    findings.sort(key=lambda f: (f.line, f.rule))
+    return findings
+
+
+def expand_args(args: list[str]) -> list[Path]:
+    paths: list[Path] = []
+    for a in args:
+        if any(ch in a for ch in "*?["):
+            paths.extend(Path(p) for p in sorted(glob.glob(a)))
+        else:
+            paths.append(Path(a))
+    uniq: list[Path] = []
+    seen: set[Path] = set()
+    for p in paths:
+        if p not in seen:
+            seen.add(p)
+            uniq.append(p)
+    return uniq
+
+
+def main(argv: list[str]) -> int:
+    args = [a for a in argv if not a.startswith("-")]
+    if "-h" in argv or "--help" in argv or not args:
+        print(__doc__.strip().splitlines()[0])
+        print("usage: tenkz_lint.py FILE_OR_GLOB [FILE_OR_GLOB ...]")
+        return 0 if ("-h" in argv or "--help" in argv) else 2
+    paths = expand_args(args)
+    if not paths:
+        print("tenkz_lint: no files matched", file=sys.stderr)
+        return 2
+    total = 0
+    failed = 0
+    scanned = 0
+    for path in paths:
+        if not path.exists():
+            print(f"tenkz_lint: no such file: {path}", file=sys.stderr)
+            failed += 1
+            continue
+        scanned += 1
+        for f in lint_file(path):
+            total += 1
+            status = "allowed" if f.allowed else "FINDING"
+            print(f"{f.path}:{f.line}: [{f.rule}] {status}: {f.snippet}")
+            if not f.allowed:
+                failed += 1
+    print(f"tenkz-lint: {scanned} file(s) scanned, {total} finding(s), "
+          f"{failed} unescaped")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/test_tenkz_pic.py
+++ b/scripts/test_tenkz_pic.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+r"""Standalone test harness for the tenkz plasTeX SVG pipeline.
+
+Exercises the compile+cache core of ``blueprint/src/Packages/tenkz_pic.py``
+**without plasTeX**: the module defers its plasTeX imports, so importing it
+here only loads the pure compile machinery.  Verbatim units from the
+spec's benchmark corpus (a ``tenkz`` grid, a ``tenkzlattice`` window, a
+``tenkzplanes`` double layer, and a ``\tnpic`` sandwich atom) are rendered
+standalone; the harness asserts that
+
+  1. each SVG materializes with real drawing ink and a plausible extent
+     (a silently ink-stripped render collapses to the text glyphs' bbox —
+     the failure mode the module's route canary exists to catch);
+  2. re-rendering every unit is a pure cache hit (file untouched);
+  3. editing one body invalidates exactly that unit's SVG (new content
+     hash), leaving the other cached SVGs in place.
+
+Run:  python3 scripts/test_tenkz_pic.py
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT / "blueprint/src/Packages"))
+
+import tenkz_pic
+
+# Spec benchmark bodies (B1, B6, B8 of tenkz_final_spec.md §3), with the
+# minimum width (pt) a faithful render must exceed: an ink-stripped SVG of
+# B1 measures ~12pt (three letters), a real one ~95pt at 11mm pitch.
+UNITS: dict[str, tuple[str, float]] = {
+    "B1 tenkz grid": (
+        r"""\begin{tenkz}[periodic, physical=up, bond label={$D$ at 1-2}]
+  \tn[up=$i_1$]{A} & \tn[up=$i_2$]{A} & \tn[up=$i_3$]{A}
+\end{tenkz}""",
+        60.0,
+    ),
+    "B6 tenkzlattice": (
+        r"""\begin{tenkzlattice}[rows=4, cols=4, boundary legs]
+  \tnregion[slot=selected, name=R, label=$R$]{(1-3, 1-3)}
+  \tnregion[slot=secondary, outline, label=$S$, label at=south west]{R - (2,2)}
+  \tnedge[distinguished]{(2,3)-(2,4)}
+  \tnsite[removed]{(2,2)}
+\end{tenkzlattice}""",
+        70.0,
+    ),
+    "planes double layer": (
+        r"""\begin{tenkzplanes}[rows=2, cols=3, open={(1,2)}]
+\end{tenkzplanes}""",
+        40.0,
+    ),
+    "B8 tnpic sandwich": (
+        r"\tnpic[sandwich, inline]{\tn{A} \\ \tn*{A}}",
+        12.0,
+    ),
+}
+
+_WIDTH_PATTERN = re.compile(r"""<svg[^>]*\swidth=["']([0-9.]+)pt["']""")
+
+
+def _svg_width_pt(svg_text: str) -> float:
+    match = _WIDTH_PATTERN.search(svg_text)
+    assert match, "SVG root carries no pt width"
+    return float(match.group(1))
+
+
+def main() -> int:
+    chain = tenkz_pic.toolchain()
+    if chain is None:
+        print("FAIL: no SVG toolchain (need xelatex plus dvisvgm or pdftocairo)")
+        return 1
+    print(f"toolchain: route={chain.route} engine={chain.xelatex} "
+          f"converter={chain.converter}")
+
+    svg_dir = Path(tempfile.mkdtemp(prefix="tenkz_svg_test_"))
+    rendered: dict[str, Path] = {}
+    try:
+        # 1. Cold renders: SVGs materialize with ink and plausible extent.
+        for name, (unit, min_width) in UNITS.items():
+            start = time.monotonic()
+            svg_path, hit = tenkz_pic.render_unit(unit, svg_dir)
+            elapsed = time.monotonic() - start
+            assert svg_path is not None, f"{name}: toolchain vanished mid-run"
+            assert not hit, f"{name}: cold render reported a cache hit"
+            assert svg_path.is_file() and svg_path.stat().st_size > 0, (
+                f"{name}: SVG did not materialize"
+            )
+            text = svg_path.read_text(encoding="utf-8", errors="replace")
+            assert "<svg" in text, f"{name}: not an SVG"
+            assert "<path" in text, f"{name}: SVG carries no drawing ink"
+            width = _svg_width_pt(text)
+            assert width > min_width, (
+                f"{name}: width {width}pt <= {min_width}pt — ink was stripped?"
+            )
+            rendered[name] = svg_path
+            print(f"PASS cold  {name}: {svg_path.name} "
+                  f"({width:.1f}pt wide, {elapsed:.1f}s)")
+
+        # 2. Warm renders: byte-identical cache hits, files untouched.
+        before = {name: path.stat().st_mtime_ns for name, path in rendered.items()}
+        for name, (unit, _) in UNITS.items():
+            start = time.monotonic()
+            svg_path, hit = tenkz_pic.render_unit(unit, svg_dir)
+            elapsed = time.monotonic() - start
+            assert hit, f"{name}: warm render missed the cache"
+            assert svg_path == rendered[name], f"{name}: cache path changed"
+            assert svg_path.stat().st_mtime_ns == before[name], (
+                f"{name}: cache hit rewrote the SVG"
+            )
+            print(f"PASS warm  {name}: cache hit ({elapsed*1000:.0f}ms)")
+
+        # 3. Per-figure invalidation: one edited body, one new SVG.
+        grid_unit, _ = UNITS["B1 tenkz grid"]
+        edited = grid_unit.replace("$i_2$", "$j_2$")
+        assert tenkz_pic.unit_hash(edited) != tenkz_pic.unit_hash(grid_unit)
+        edited_path, hit = tenkz_pic.render_unit(edited, svg_dir)
+        assert edited_path is not None and not hit
+        assert edited_path.name != rendered["B1 tenkz grid"].name, (
+            "edited body reused the old content hash"
+        )
+        survivors = {path.name for path in svg_dir.glob("tenkz-*.svg")}
+        expected = {path.name for path in rendered.values()} | {edited_path.name}
+        assert survivors == expected, (
+            f"cache set drifted: {survivors ^ expected}"
+        )
+        print(f"PASS edit  one body edit invalidated exactly one SVG "
+              f"({edited_path.name})")
+    except AssertionError as failure:
+        print(f"FAIL: {failure}")
+        print(f"artifacts kept for inspection in {svg_dir}")
+        return 1
+    except RuntimeError as failure:
+        # A unit failed to compile or convert — typically a tex/tenkz
+        # library defect, not a pipeline one; the message names the
+        # compile log kept in blueprint/src/.tenkz_svg_cache/.
+        print(f"FAIL (library or toolchain): {failure}")
+        return 1
+    shutil.rmtree(svg_dir, ignore_errors=True)
+    print("all tenkz pipeline checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Stack 07. The plasTeX package (tenkz_pic.py) renders all five environments + \tnpic as content-hash-cached standalone SVGs — byte-exact verbatim capture keeps the TeX library the single grammar authority; an ink-canary probe detects the dvisvgm/Ghostscript silent-ink-loss failure mode and falls back to poppler. Plus tenkz_audit.py (the .tnlog consumer that found four real emitter bugs, all since fixed; 218-log corpus now audits clean) and tenkz_lint.py. Integration steps (web/print preamble opt-in, CSS, CI) listed in the module docstring.

https://claude.ai/code/session_01Rpby2DabUL1mbsMkFadv1q

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new build-time dependency on xelatex/dvisvgm or pdftocairo; CI fails hard when tools are missing, and incorrect SVG routing could ship text-only diagrams until integration lands.
> 
> **Overview**
> Adds the **tenkz web rendering stack** and supporting QA scripts ahead of wiring `web.tex` / CI (those steps are tracked in `docs/tenkz/DEMOLITION.md`).
> 
> **`tenkz_pic.py`** registers all five `tenkz*` environments plus `\tnpic` for plasTeX as verbatim-captured units, compiles each body standalone against `tex/tenkz//`, and emits content-hashed SVGs (`blueprint/src/.tenkz_svg_cache/` ignored). Cache keys fold in the full `tex/tenkz` library and `macros/common.tex` so library edits invalidate all figures while a single body edit invalidates one SVG. An ink-canary probes `xelatex → dvisvgm` and falls back to `xelatex → pdftocairo` when TikZ paths would be silently dropped. **`TenkzPictures.jinja2s`** renders the resulting `<img>` nodes.
> 
> **`tenkz_audit.py`** validates `.tnlog` streams (hard errors for malformed events, empty pictures, dangling refs; advisories for equation boundaries, repeated topology, etc.) with optional TeX linking.
> 
> **`tenkz_lint.py`** flags illegal ellipsis and raw TikZ inside tenkz bodies.
> 
> **`test_tenkz_pic.py`** exercises compile/cache behavior without plasTeX. **`DEMOLITION.md`** documents Phase-3 removal of `tex/tn/` and `tn_diagrams.py` once migration completes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72c554640e3d1a7ad1345c516fbb0bf2b436ce35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->