### PR TITLE
refactor(MPS/CanonicalForm): remove zero-tail bookkeeping

### DIFF
--- a/TNLean/MPS/CanonicalForm/Existence.lean
+++ b/TNLean/MPS/CanonicalForm/Existence.lean
@@ -41,8 +41,7 @@ obtain the arbitrary-input positive-length PGVWC07 canonical form.  After a
 positive global rescaling, the conclusion gives positive weights, unital blocks,
 diagonal full-rank dual fixed points, scalar transfer-map fixed points, and the
 bond-dimension bound.  If every positive-length MPV coefficient vanishes, the
-nonzero-block family is empty.  The remaining all-zero direct summand $A_0$
-separately records the length-zero dimension identity $D = D_0 + \sum_k D_k$.
+nonzero-block family is empty.
 
 The later Fundamental-Theorem reductions--TP gauge, period removal, common
 blocking, and normal/BNT predicates--are subsequent consequences of the
@@ -51,10 +50,10 @@ Th:TIcanonical.
 
 Maintainer note: the blueprint cites
 `MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_allow_empty` in
-`TNLean.MPS.CanonicalForm.NormalReduction.WeightNormalization`; the zero-tail
-dimension identity is recorded by
-`MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound`
-in `TNLean.MPS.CanonicalForm.NormalReduction.TPGauge`.  The audit boundary is
+`TNLean.MPS.CanonicalForm.NormalReduction.WeightNormalization`.  The
+positive-length bond-dimension bound is recorded by
+`MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary` in
+`TNLean.MPS.CanonicalForm.NormalReduction.TPGauge`.  The audit boundary is
 recorded in `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`.
 For Pérez-García, Verstraete, Wolf, and Cirac, the faithful proof order is the
 one in `Papers/quant-ph_0608197/MPSarchive.tex`: lines 765–770 for
@@ -208,10 +207,9 @@ For overlap and canonical-form hypotheses involving primitive transfer maps, we 
 /-!
 ## Zero-block vanishing at positive length
 
-These are the first low-level facts needed for a complete treatment of zero blocks.
-They show that an all-zero tensor contributes nothing on nonempty words, hence nothing to MPVs for
-system sizes `N ≥ 1`. This still does **not** permit silently discarding zero scalar blocks under
-`SameMPV₂`, because the `N = 0` sector continues to remember the total bond dimension.
+These facts show that an all-zero tensor contributes nothing on nonempty words,
+hence nothing to matrix product vectors at positive lengths.  They justify
+discarding zero blocks under the physical positive-length relation.
 -/
 
 /-- An all-zero tensor evaluates to zero on every nonempty word. -/
@@ -230,31 +228,25 @@ theorem mpv_eq_zero_of_all_zero (A : MPSTensor d D)
     (hzero : ∀ i : Fin d, A i = 0)
     {N : ℕ} (σ : Fin N → Fin d) (hN : 0 < N) :
     mpv A σ = 0 := by
-  have hw : List.ofFn σ ≠ [] := by
-    intro hnil
-    have hlen : N = 0 := by
-      simpa [List.length_ofFn] using congrArg List.length hnil
-    exact (Nat.ne_of_gt hN) hlen
+  have hw : List.ofFn σ ≠ [] :=
+    List.length_pos_iff_ne_nil.mp (by simpa only [List.length_ofFn] using hN)
   unfold mpv coeff
   rw [evalWord_eq_zero_of_all_zero (A := A) hzero (w := List.ofFn σ) hw]
   simp only [Matrix.trace_zero]
 
 /-!
-## Conditional reductions from arbitrary input
+## Irreducible decomposition from arbitrary input
 
-The arbitrary-input part of this file stops at the irreducible block decomposition and the
-zero-block bookkeeping below. The irreducible-to-TP-gauge, CFII normalization, and
-periodicity-removal theorems remain available for individual blocks satisfying their hypotheses,
-but this file does not combine them into unconditional companions of the block decomposition.
+The arbitrary-input part of this file stops at the nonzero irreducible block decomposition below.
+The blockwise trace-preserving gauge is constructed in `NormalReduction/TPGauge.lean`; subsequent
+period removal and normalization are developed in the normal-reduction modules.
 
 The normal-canonical-form file starts from a primitive weighted block family with positive bond
 dimensions and non-increasing nonzero weight moduli. This file does **not** construct that input
 from an arbitrary tensor.
 
-Remaining gap for a complete canonical-form existence theorem:
+Subsequent stages toward a complete canonical-form existence theorem are:
 
-* Apply the irreducible-to-TP-gauge theorem blockwise through the irreducible block decomposition,
-  with the length-zero contribution of possible zero blocks kept explicit.
 * Apply the TP-irreducible-to-primitive blocking theorem and then perform the post-blocking cyclic
   sector bookkeeping and weight normalization needed for non-increasing nonzero weight moduli.
 * Use the resulting data to reach the stronger normal / injective-by-blocking hypotheses needed by
@@ -262,168 +254,100 @@ Remaining gap for a complete canonical-form existence theorem:
 -/
 
 /-!
-## Zero-block separation
+## Removing zero blocks at positive lengths
 
-The irreducible block decomposition may produce all-zero blocks. Because `SameMPV₂`
-at `N = 0` includes the identity `trace(I_D) = D`, we cannot silently drop these.
-Instead we accumulate them into a single **zero block** (called `zeroTailDim` in the
-Lean formalization; the source paper says "there can be zero blocks" without assigning
-a separate name). The zero-block dimension `zeroTailDim` is the sum of bond dimensions
-of all zero blocks. The remaining **nonzero blocks** each have at least one nonzero
-Kraus operator.
-
-Key facts (matching the paper's canonical-form reduction, eq. II_Aiplusk1):
-- For `N > 0`, all-zero blocks contribute `0` to the MPV (`mpv_eq_zero_of_all_zero`).
-- For `N = 0`, each block of dimension `Dₖ` contributes `Dₖ` (the trace of the identity).
-
-The all-zero blocks are not assembled into a separate tensor in the separation theorem
-below: their total bond dimension is recorded as a plain natural number `zeroTailDim`, which
-enters only through the length-zero dimension identity `D = zeroTailDim + ∑ k, dim k`.
+The irreducible block decomposition may contain blocks whose matrices all vanish.  Such a block
+contributes zero to every matrix product vector of positive length.  We therefore retain only the
+nonzero blocks.  Their total bond dimension is bounded by the original bond dimension directly
+from the dimension identity of the invariant-subspace decomposition; no empty-word comparison is
+needed.
 -/
 
-/-- **Zero-block separation.**
+/-- **Nonzero irreducible block decomposition at positive lengths.**
 
-The paper states that in the canonical form $A^i = \oplus_{k=1}^r \mu_k A_k^i$, some blocks may
-be zero: "there can be zero blocks." Every MPS tensor `A : MPSTensor d D` admits an irreducible
-block decomposition that is faithfully partitioned into:
+Every MPS tensor is represented at every positive length by a direct sum of nonzero irreducible
+blocks.  Each retained block has positive bond dimension, and the sum of their bond dimensions is
+at most the original bond dimension.
 
-* a **zero-block dimension** `zeroTailDim`, equal to the sum of the bond dimensions of the
-  all-zero irreducible blocks, and
-* a family of **nonzero blocks** `blocks k : MPSTensor d (dim k)` for `k : Fin r`, each with at
-  least one nonzero Kraus operator, positive bond dimension, and irreducibility.
-
-The decomposition is recorded by two facts that together carry all the content:
-
-* the positive-length equality `SameMPV₂Pos A (toTensorFromBlocks μ≡1 blocks)` (the all-zero
-  blocks contribute nothing at positive length), and
-* the length-zero dimension identity `D = zeroTailDim + ∑ k, dim k` (the empty-word coefficient
-  is the bond dimension).
-
-This separation is **exact**: the positive-length vectors see only the nonzero blocks, while the
-length-zero identity D = D_0 + Σ_k D_k from the paper is preserved. -/
+This is the positive-length form of the recursive decomposition in Pérez-García, Verstraete,
+Wolf, and Cirac, Theorem `Th:TIcanonical`, proof lines 771--826.  The source notes that zero blocks
+may occur; they vanish identically on nonempty rings and are discarded here. -/
 theorem exists_irreducible_blockDecomp_nonzeroBlocks (A : MPSTensor d D) :
-    ∃ (zeroTailDim : ℕ) (r : ℕ) (dim : Fin r → ℕ)
+    ∃ (r : ℕ) (dim : Fin r → ℕ)
       (blocks : (k : Fin r) → MPSTensor d (dim k)),
       (∀ k, IsIrreducibleTensor (blocks k)) ∧
       (∀ k, ∃ i, blocks k i ≠ 0) ∧
       (∀ k, 0 < dim k) ∧
       SameMPV₂Pos A
         (toTensorFromBlocks (d := d) (μ := fun _ : Fin r => (1 : ℂ)) blocks) ∧
-      D = zeroTailDim + ∑ k : Fin r, dim k := by
+      ∑ k : Fin r, dim k ≤ D := by
   classical
-  -- Step 1: Obtain the irreducible block decomposition.
-  obtain ⟨r₀, dim₀, blocks₀, hIrr₀, hSame₀⟩ :=
+  obtain ⟨r₀, dim₀, blocks₀, hIrr₀, hSame₀, hDim₀⟩ :=
     exists_irreducible_blockDecomp (d := d) (D := D) A
-  -- Step 2: Classify blocks as nonzero or zero.
-  -- Name the nonzero-block predicate and the corresponding finite set.
   set isNonzero : Fin r₀ → Prop := fun k => ∃ i, blocks₀ k i ≠ 0 with isNonzero_def
   set nonzeroSet : Finset (Fin r₀) := Finset.univ.filter (fun k => isNonzero k)
     with nonzeroSet_def
-  set zeroSet : Finset (Fin r₀) := Finset.univ.filter (fun k => ¬ isNonzero k)
-    with zeroSet_def
-  -- The all-zero summand dimension is the sum of bond dimensions of zero blocks.
-  set zeroTailDim : ℕ := zeroSet.sum dim₀ with zeroTailDim_def
-  -- Reindex nonzero blocks via a bijection with `Fin nonzeroSet.card`.
   set nonzeroEquiv : nonzeroSet ≃ Fin nonzeroSet.card := nonzeroSet.equivFin
     with nonzeroEquiv_def
-  -- Define the new nonzero block family.
   set r := nonzeroSet.card with r_def
   set dim : Fin r → ℕ := fun j => dim₀ (nonzeroEquiv.symm j).1 with dim_def
   set newBlocks : (k : Fin r) → MPSTensor d (dim k) :=
     fun j => blocks₀ (nonzeroEquiv.symm j).1 with newBlocks_def
-  -- The MPV of `A` decomposes into the nonzero-block direct sum plus the
-  -- length-zero all-zero summand contribution.
-  have key : ∀ (N : ℕ) (σ : Fin N → Fin d),
-      mpv A σ =
-        mpv (toTensorFromBlocks (d := d) (μ := fun _ : Fin r => (1 : ℂ)) newBlocks) σ +
-          (if N = 0 then (zeroTailDim : ℂ) else 0) := by
-    intro N σ
-    -- Expand A's MPV via the original decomposition.
-    have hA : mpv A σ = ∑ k : Fin r₀, mpv (blocks₀ k) σ := by
-      have h := hSame₀ N σ
-      rw [h, mpv_toTensorFromBlocks_eq_sum]
-      simp only [one_pow, one_smul]
-    -- Expand the nonzero-block toTensorFromBlocks.
-    have hNonzero :
-        mpv (toTensorFromBlocks (d := d) (μ := fun _ : Fin r => (1 : ℂ)) newBlocks) σ =
-          ∑ j : Fin r, mpv (newBlocks j) σ := by
-      rw [mpv_toTensorFromBlocks_eq_sum]
-      simp only [one_pow, one_smul]
-    -- Split the original sum into nonzero and zero parts.
-    have hDisj : Disjoint nonzeroSet zeroSet := by
-      simp only [nonzeroSet_def, zeroSet_def]
-      exact Finset.disjoint_filter_filter_not _ _ _
-    have hUnion : nonzeroSet ∪ zeroSet = Finset.univ := by
-      simp only [nonzeroSet_def, zeroSet_def]
-      ext k
-      simp [Finset.mem_filter, Finset.mem_union, em]
-    have hSplit : ∑ k : Fin r₀, mpv (blocks₀ k) σ =
-        nonzeroSet.sum (fun k => mpv (blocks₀ k) σ) +
-          zeroSet.sum (fun k => mpv (blocks₀ k) σ) := by
-      rw [← Finset.sum_union hDisj, hUnion]
-    -- The nonzero-block sum equals ∑ over the reindexed blocks.
-    have hNonzeroSum : nonzeroSet.sum (fun k => mpv (blocks₀ k) σ) =
-        ∑ j : Fin r, mpv (newBlocks j) σ := by
-      rw [← nonzeroSet.sum_coe_sort (fun k => mpv (blocks₀ k) σ)]
-      exact (nonzeroEquiv.symm.sum_comp
-        (fun x : nonzeroSet => mpv (blocks₀ x.1) σ)).symm
-    -- The zero sum: at N > 0, each zero block contributes 0; at N = 0, it contributes dim.
-    have hZeroSum : zeroSet.sum (fun k => mpv (blocks₀ k) σ) =
-        if N = 0 then (zeroTailDim : ℂ) else 0 := by
-      split
-      case isTrue hN =>
-        subst hN
-        -- Each block contributes `dim₀ k` at N=0 (trace of identity).
-        have : zeroSet.sum (fun k => mpv (blocks₀ k) σ) =
-            zeroSet.sum (fun k => (dim₀ k : ℂ)) :=
-          Finset.sum_congr rfl (fun k _ => mpv_zero_length (blocks₀ k) σ)
-        rw [this, ← Nat.cast_sum]
-      case isFalse hN =>
-        apply Finset.sum_eq_zero
-        intro k hk
-        have hkz : ∀ i, blocks₀ k i = 0 := by
-          by_contra hne
-          push Not at hne
-          have hkNonzero : k ∈ nonzeroSet :=
-            Finset.mem_filter.mpr ⟨Finset.mem_univ k, hne⟩
-          exact absurd hkNonzero (Finset.disjoint_right.mp hDisj hk)
-        exact mpv_eq_zero_of_all_zero (blocks₀ k) hkz σ (Nat.pos_of_ne_zero hN)
-    -- Chain everything together.
-    rw [hA, hSplit, hNonzeroSum, hZeroSum, hNonzero]
-  -- Step 3: Prove all properties.
-  refine ⟨zeroTailDim, r, dim, newBlocks, ?_, ?_, ?_, ?_, ?_⟩
-  -- (a) Irreducibility of nonzero blocks.
+  refine ⟨r, dim, newBlocks, ?_, ?_, ?_, ?_, ?_⟩
   · intro k
     exact hIrr₀ (nonzeroEquiv.symm k).1
-  -- (b) Each nonzero block has a nonzero Kraus operator.
   · intro k
-    have hMem := (nonzeroEquiv.symm k).2
-    -- Membership in `nonzeroSet` means `isNonzero`.
-    have hNonzero : isNonzero (nonzeroEquiv.symm k).1 :=
-      (Finset.mem_filter.mp hMem).2
-    exact hNonzero
-  -- (c) Each nonzero block has positive bond dimension.
+    exact (Finset.mem_filter.mp (nonzeroEquiv.symm k).2).2
   · intro k
-    have hMem := (nonzeroEquiv.symm k).2
-    have hNonzero : isNonzero (nonzeroEquiv.symm k).1 :=
-      (Finset.mem_filter.mp hMem).2
-    rcases hNonzero with ⟨i, hi⟩
+    obtain ⟨i, hi⟩ := (Finset.mem_filter.mp (nonzeroEquiv.symm k).2).2
     by_contra h
     push Not at h
     have hd0 : dim k = 0 := Nat.le_zero.mp h
     have hEmpty : IsEmpty (Fin (dim k)) := by rw [hd0]; infer_instance
     have hzero : newBlocks k i = 0 := by ext a b; exact (hEmpty.false a).elim
     exact hi hzero
-  -- (d) Positive-length MPV relationship: the zero tail vanishes for `N > 0`.
   · intro N hN σ
-    have hkey := key N σ
-    rw [if_neg (Nat.ne_of_gt hN), add_zero] at hkey
-    exact hkey
-  -- (e) Length-zero dimension identity: the empty-word coefficient is the bond dimension.
-  · have h0 := key 0 (Fin.elim0 : Fin 0 → Fin d)
-    rw [if_pos rfl, mpv_zero_length, mpv_zero_length] at h0
-    -- `h0 : (D : ℂ) = (∑ k, dim k : ℂ) + (zeroTailDim : ℂ)`
-    have hnat : D = (∑ k : Fin r, dim k) + zeroTailDim := by exact_mod_cast h0
-    omega
+    have hA : mpv A σ = ∑ k : Fin r₀, mpv (blocks₀ k) σ := by
+      have h := hSame₀ N σ
+      rw [h, mpv_toTensorFromBlocks_eq_sum]
+      simp only [one_pow, one_smul]
+    have hNonzero :
+        mpv (toTensorFromBlocks (d := d) (μ := fun _ : Fin r => (1 : ℂ)) newBlocks) σ =
+          ∑ j : Fin r, mpv (newBlocks j) σ := by
+      rw [mpv_toTensorFromBlocks_eq_sum]
+      simp only [one_pow, one_smul]
+    have hNonzeroSum : nonzeroSet.sum (fun k => mpv (blocks₀ k) σ) =
+        ∑ j : Fin r, mpv (newBlocks j) σ := by
+      rw [← nonzeroSet.sum_coe_sort (fun k => mpv (blocks₀ k) σ)]
+      exact (nonzeroEquiv.symm.sum_comp
+        (fun x : nonzeroSet => mpv (blocks₀ x.1) σ)).symm
+    have hAllEqNonzero : (∑ k : Fin r₀, mpv (blocks₀ k) σ) =
+        nonzeroSet.sum (fun k => mpv (blocks₀ k) σ) := by
+      rw [nonzeroSet_def, Finset.sum_filter]
+      apply Finset.sum_congr rfl
+      intro k _
+      by_cases hk : isNonzero k
+      · simp [hk]
+      · have hkz : ∀ i, blocks₀ k i = 0 := by
+          intro i
+          by_contra hi
+          exact hk ⟨i, hi⟩
+        have hzero := mpv_eq_zero_of_all_zero (blocks₀ k) hkz σ hN
+        rw [if_neg hk]
+        exact hzero
+    calc
+      mpv A σ = ∑ k : Fin r₀, mpv (blocks₀ k) σ := hA
+      _ = nonzeroSet.sum (fun k => mpv (blocks₀ k) σ) := hAllEqNonzero
+      _ = ∑ j : Fin r, mpv (newBlocks j) σ := hNonzeroSum
+      _ = mpv (toTensorFromBlocks (d := d) (μ := fun _ : Fin r => (1 : ℂ)) newBlocks) σ :=
+        hNonzero.symm
+  · have hSelectedDim : nonzeroSet.sum dim₀ = ∑ j : Fin r, dim j := by
+      rw [← nonzeroSet.sum_coe_sort dim₀]
+      exact (nonzeroEquiv.symm.sum_comp (fun x : nonzeroSet => dim₀ x.1)).symm
+    calc
+      ∑ j : Fin r, dim j = nonzeroSet.sum dim₀ := hSelectedDim.symm
+      _ ≤ ∑ k : Fin r₀, dim₀ k :=
+        Finset.sum_le_univ_sum_of_nonneg (fun _ => Nat.zero_le _)
+      _ = D := hDim₀
 
 end MPSTensor

--- a/TNLean/MPS/CanonicalForm/NormalReduction.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction.lean
@@ -19,7 +19,7 @@ The supporting modules are:
 * `TNLean.MPS.CanonicalForm.NormalReduction.Main` — the reduction from a
   primitive weighted block decomposition to blocked normal canonical-form data.
 * `TNLean.MPS.CanonicalForm.NormalReduction.TPGauge` — the blockwise TP-gauge
-  normalization results, including the arbitrary-input zero-tail statement.
+  normalization results and arbitrary-input positive-length reductions.
 * `TNLean.MPS.CanonicalForm.NormalReduction.WeightNormalization` — the
   finite-family positive-weight normalization for the positive-length witness.
 
@@ -29,9 +29,7 @@ The imported modules provide the original public declarations:
 
 * `MPSTensor.exists_tp_gauge_blockwise`
 * `MPSTensor.exists_pgvwc07_unital_dualDiag_blockwise`
-* `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail`
-* `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound`
-* `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound`
+* `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary`
 * `MPSTensor.exists_pgvwc07_positiveLengthWitness`
 * `MPSTensor.PGVWC07PositiveLengthWitness.exists_weight_normalization`
 * `MPSTensor.PGVWC07PositiveLengthWitness.block_count_pos_of_exists_ne_zero_mpv`
@@ -39,5 +37,5 @@ The imported modules provide the original public declarations:
 * `MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_or_forall_pos_mpv_eq_zero`
 * `MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_allow_empty`
 * `MPSTensor.exists_normalCanonicalForm_of_primitive_blockDecomp`
-* `MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail`
+* `MPSTensor.exists_tp_gauge_from_arbitrary`
 -/

--- a/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
@@ -611,11 +611,13 @@ structural bond-dimension bound passes through unchanged.
 /-- **Arbitrary-input PGVWC07 unital dual-diagonal form.**
 
 Pérez-García, Verstraete, Wolf, and Cirac, Theorem `Th:TIcanonical`, proof
-lines 761--770 and 816--832.  At every positive length, an arbitrary tensor is
+lines 761--832.  At every positive length, an arbitrary tensor is
 represented by positive real weights multiplying nonzero blocks in the unital
 orientation.  Each block has only scalar transfer-map fixed points and admits a
 diagonal positive-definite fixed point of the adjoint transfer map.  The total
-bond dimension of the retained blocks is at most the original bond dimension. -/
+bond dimension of the retained blocks is at most the original bond dimension.
+The positive-length form and structural dimension bound are recorded in
+`docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
 theorem exists_pgvwc07_unital_dualDiag_from_arbitrary
     (A : MPSTensor d D) :
     ∃ (r : ℕ) (dim : Fin r → ℕ)

--- a/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
@@ -28,17 +28,12 @@ Its public outputs are:
   construction applied blockwise to a prepared nonzero irreducible decomposition.
 * `MPSTensor.exists_tp_gauge_blockwise` — blockwise Perron--Frobenius / TP-gauge
   normalization for an irreducible block decomposition.
-* `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail` —
-  the arbitrary-input version recording the positive-length nonzero-block equality
-  together with the length-zero dimension identity `D = zeroTailDim + ∑ dim`.
-* `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound` —
-  the preceding theorem together with the total bond-dimension bound.
-* `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound` —
-  the positive-length version recording only the bond-dimension bound.
+* `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary` — the
+  arbitrary-input positive-length form with the total bond-dimension bound.
 * `MPSTensor.exists_pgvwc07_positiveLengthWitness` — the same positive-length
   theorem recorded as a single structured witness.
-* `MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail` — the corresponding
-  arbitrary-input result obtained after zero-block separation.
+* `MPSTensor.exists_tp_gauge_from_arbitrary` — the corresponding arbitrary-input
+  trace-preserving gauge reduction.
 
 The auxiliary declarations stay file-local because they are elementary lemmas for
 rescaling and gauge transport.
@@ -415,25 +410,23 @@ theorem exists_pgvwc07_unital_dualDiag_blockwise
       SameMPV₂ A
         (toTensorFromBlocks (d := d) (μ := fun _ : Fin r0 => (1 : ℂ)) blocks0))
     (hNonzero0 : ∀ k, ∃ i, blocks0 k i ≠ 0) :
-    ∃ r1 : ℕ,
-      ∃ dim1 : Fin r1 → ℕ,
-      ∃ μ1 : Fin r1 → ℂ,
-      ∃ blocks1 : (k : Fin r1) → MPSTensor d (dim1 k),
+    ∃ μ1 : Fin r0 → ℂ,
+      ∃ blocks1 : (k : Fin r0) → MPSTensor d (dim0 k),
         SameMPV₂ A
           (toTensorFromBlocks (d := d) (μ := μ1) blocks1) ∧
         (∀ k,
-          ∃ Λ : Matrix (Fin (dim1 k)) (Fin (dim1 k)) ℂ,
+          ∃ Λ : Matrix (Fin (dim0 k)) (Fin (dim0 k)) ℂ,
             Λ.PosDef ∧
             Λ.IsDiag ∧
             (∑ i : Fin d, blocks1 k i * (blocks1 k i)ᴴ = 1) ∧
-            transferMap (d := d) (D := dim1 k) (fun i => (blocks1 k i)ᴴ) Λ = Λ) ∧
+            transferMap (d := d) (D := dim0 k) (fun i => (blocks1 k i)ᴴ) Λ = Λ) ∧
         (∀ k,
-          ∀ X : Matrix (Fin (dim1 k)) (Fin (dim1 k)) ℂ,
-            transferMap (d := d) (D := dim1 k) (blocks1 k) X = X →
-              ∃ c : ℂ, X = c • (1 : Matrix (Fin (dim1 k)) (Fin (dim1 k)) ℂ)) ∧
+          ∀ X : Matrix (Fin (dim0 k)) (Fin (dim0 k)) ℂ,
+            transferMap (d := d) (D := dim0 k) (blocks1 k) X = X →
+              ∃ c : ℂ, X = c • (1 : Matrix (Fin (dim0 k)) (Fin (dim0 k)) ℂ)) ∧
         (∀ k, ∃ a : ℝ, 0 < a ∧ μ1 k = (a : ℂ)) ∧
         (∀ k, μ1 k ≠ 0) ∧
-        (∀ k, 0 < dim1 k) := by
+        (∀ k, 0 < dim0 k) := by
   classical
   have hcanon :
       ∀ k : Fin r0,
@@ -513,12 +506,12 @@ theorem exists_pgvwc07_unital_dualDiag_blockwise
   have hμpos1 : ∀ k : Fin r0, ∃ a : ℝ, 0 < a ∧ μ1 k = (a : ℂ) := by
     intro k
     exact ⟨Real.sqrt (r1 k), Real.sqrt_pos.2 (hrpos1 k), rfl⟩
-  exact ⟨r0, dim0, μ1, blocks1, hSame1, hΛData, hScalarC, hμpos1, hμne1, hDim1⟩
+  exact ⟨μ1, blocks1, hSame1, hΛData, hScalarC, hμpos1, hμne1, hDim1⟩
 
 /-- Blockwise Perron--Frobenius / TP-gauge stage for an irreducible block decomposition.
 
 This theorem is the blockwise TP-normalization step used by
-`exists_tp_gauge_from_arbitrary_with_zeroTail`, and it also gives the earlier
+`exists_tp_gauge_from_arbitrary`, and it also gives the earlier
 TP-normalization route on a fixed irreducible decomposition. Its extra
 nonzero-block hypothesis lives on a chosen decomposition, so it still does not
 by itself give an unconditional arbitrary-input theorem under the current
@@ -536,16 +529,14 @@ theorem exists_tp_gauge_blockwise
       SameMPV₂ A
         (toTensorFromBlocks (d := d) (μ := fun _ : Fin r0 => (1 : ℂ)) blocks0))
     (hNonzero0 : ∀ k, ∃ i, blocks0 k i ≠ 0) :
-    ∃ r1 : ℕ,
-      ∃ dim1 : Fin r1 → ℕ,
-      ∃ μ1 : Fin r1 → ℂ,
-      ∃ blocks1 : (k : Fin r1) → MPSTensor d (dim1 k),
+    ∃ μ1 : Fin r0 → ℂ,
+      ∃ blocks1 : (k : Fin r0) → MPSTensor d (dim0 k),
         SameMPV₂ A
           (toTensorFromBlocks (d := d) (μ := μ1) blocks1) ∧
         (∀ k, IsIrreducibleTensor (blocks1 k)) ∧
         (∀ k, ∑ i : Fin d, (blocks1 k i)ᴴ * blocks1 k i = 1) ∧
         (∀ k, μ1 k ≠ 0) ∧
-        (∀ k, 0 < dim1 k) := by
+        (∀ k, 0 < dim0 k) := by
   classical
   have htp :
       ∀ k : Fin r0,
@@ -600,145 +591,26 @@ theorem exists_tp_gauge_blockwise
       funext i
       simpa [tpGauge, c] using hform1 k i
     simpa [hEq] using hIrr_gauge
-  exact ⟨r0, dim0, μ1, blocks1, hSame1, hIrr1, hLeft1, hμne1, hDim1⟩
+  exact ⟨μ1, blocks1, hSame1, hIrr1, hLeft1, hμne1, hDim1⟩
 
 /-!
-## Zero-block separation and blockwise gauge threading
+## Arbitrary-input blockwise gauge reductions
 
-This section composes the zero-block separation from `Existence.lean` with the
-blockwise Perron--Frobenius gauge theorems above, producing arbitrary-input
-results: from any `A : MPSTensor d D`, we obtain:
-
-* a zero-block dimension `zeroTailDim`, equal to the total bond dimension of the
-  all-zero irreducible blocks, and
-* a weighted family of nonzero blocks in either the PGVWC07 unital orientation
-  with dual-diagonal fixed points or the older TP-gauge orientation.
-
-The decomposition is recorded by two facts that carry all the content without
-constructing a separate zero tensor:
-
-* the positive-length equality
-  `SameMPV₂Pos A (toTensorFromBlocks μ blocks)`, and
-* the length-zero dimension identity `D = zeroTailDim + ∑ k, dim k`.
-
-The PGVWC07 unital statement below is the strongest unconditional arbitrary-input
-step available here before the final total bond-dimension bound is threaded
-through the construction.
+The nonzero irreducible decomposition from `Existence.lean` is placed blockwise
+in either the PGVWC07 unital orientation or the trace-preserving orientation.
+The blockwise gauges preserve the index set and every bond dimension, so the
+structural bond-dimension bound passes through unchanged.
 -/
 
-/-- **Arbitrary-input PGVWC07 unital dual-diagonal form with zero blocks.**
+/-- **Arbitrary-input PGVWC07 unital dual-diagonal form.**
 
-Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical, proof
-lines 765--770 and 816--832, after the recursive invariant-subspace splitting
-and all-zero-block separation have been carried out.  From any tensor `A`, the
-theorem separates a zero-block contribution and applies
-`exists_pgvwc07_unital_dualDiag_blockwise` to the remaining nonzero irreducible
-blocks.
-
-Every nonzero output block is in the source's unital orientation
-`∑ i, C i * (C i)ᴴ = 1`, has only scalar fixed points for its transfer map, and
-has a diagonal positive-definite fixed point for the adjoint transfer map.  The
-weights are positive real spectral-radius weights, and the MPV family of `A`
-is the sum of the zero-block contribution and the weighted nonzero-block
-direct sum.
-
-**Scope restriction:** This is still not the full Th:TIcanonical statement:
-the zero block is kept explicitly, and the final total bond-dimension bound is
-not included.  The boundary is recorded in
-`docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
-theorem exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail
-    (A : MPSTensor d D) :
-    ∃ (zeroTailDim : ℕ) (r : ℕ) (dim : Fin r → ℕ)
-      (μ : Fin r → ℂ)
-      (blocks : (k : Fin r) → MPSTensor d (dim k)),
-      (∀ k,
-        ∃ Λ : Matrix (Fin (dim k)) (Fin (dim k)) ℂ,
-          Λ.PosDef ∧
-          Λ.IsDiag ∧
-          (∑ i : Fin d, blocks k i * (blocks k i)ᴴ = 1) ∧
-          transferMap (d := d) (D := dim k) (fun i => (blocks k i)ᴴ) Λ = Λ) ∧
-      (∀ k,
-        ∀ X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ,
-          transferMap (d := d) (D := dim k) (blocks k) X = X →
-            ∃ c : ℂ, X = c • (1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) ∧
-      (∀ k, ∃ a : ℝ, 0 < a ∧ μ k = (a : ℂ)) ∧
-      (∀ k, μ k ≠ 0) ∧
-      (∀ k, 0 < dim k) ∧
-      SameMPV₂Pos A (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
-      D = zeroTailDim + ∑ k : Fin r, dim k := by
-  classical
-  obtain ⟨zeroTailDim, r₀, dim₀, blocks₀, hIrr₀, hNonzero₀, _hDim₀, hPos₀, hDimId₀⟩ :=
-    exists_irreducible_blockDecomp_nonzeroBlocks (d := d) (D := D) A
-  let A_nonzero := toTensorFromBlocks (d := d) (μ := fun _ : Fin r₀ => (1 : ℂ)) blocks₀
-  have hSame_refl : SameMPV₂ A_nonzero
-      (toTensorFromBlocks (d := d) (μ := fun _ : Fin r₀ => (1 : ℂ)) blocks₀) :=
-    fun _ _ => rfl
-  obtain ⟨r₁, dim₁, μ₁, blocks₁, hSame₁, hΛData₁, hScalar₁, hμPos₁, hμNe₁,
-    hDim₁⟩ :=
-    exists_pgvwc07_unital_dualDiag_blockwise A_nonzero blocks₀ hIrr₀ hSame_refl
-      hNonzero₀
-  refine ⟨zeroTailDim, r₁, dim₁, μ₁, blocks₁, hΛData₁, hScalar₁,
-    hμPos₁, hμNe₁, hDim₁, ?_, ?_⟩
-  · exact hPos₀.trans hSame₁.toSameMPV₂Pos
-  · have hsum : (∑ k : Fin r₀, dim₀ k) = ∑ k : Fin r₁, dim₁ k := by
-      have h0 := hSame₁ 0 (Fin.elim0 : Fin 0 → Fin d)
-      rw [mpv_zero_length, mpv_zero_length] at h0
-      exact_mod_cast h0
-    rw [hDimId₀, hsum]
-
-/-- **Bond-dimension identity for the arbitrary-input PGVWC07 zero-block form.**
-
-Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical, lines
-761--762, after the zero-block contribution has been retained explicitly.
-The length-zero coefficient of the MPV identity gives
-$D_0 + \sum_k D_k = D$; therefore the total bond dimension of the nonzero
-blocks is at most the original bond dimension.
-
-**Scope restriction:** This theorem still keeps the zero block as an explicit
-summand.  Removing the explicit zero-block summand from the existential
-conclusion is the remaining statement-level step, recorded in
-`docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
-theorem exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound
-    (A : MPSTensor d D) :
-    ∃ (zeroTailDim : ℕ) (r : ℕ) (dim : Fin r → ℕ)
-      (μ : Fin r → ℂ)
-      (blocks : (k : Fin r) → MPSTensor d (dim k)),
-      (∀ k,
-        ∃ Λ : Matrix (Fin (dim k)) (Fin (dim k)) ℂ,
-          Λ.PosDef ∧
-          Λ.IsDiag ∧
-          (∑ i : Fin d, blocks k i * (blocks k i)ᴴ = 1) ∧
-          transferMap (d := d) (D := dim k) (fun i => (blocks k i)ᴴ) Λ = Λ) ∧
-      (∀ k,
-        ∀ X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ,
-          transferMap (d := d) (D := dim k) (blocks k) X = X →
-            ∃ c : ℂ, X = c • (1 : Matrix (Fin (dim k)) (Fin (dim k)) ℂ)) ∧
-      (∀ k, ∃ a : ℝ, 0 < a ∧ μ k = (a : ℂ)) ∧
-      (∀ k, μ k ≠ 0) ∧
-      (∀ k, 0 < dim k) ∧
-      SameMPV₂Pos A (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
-      D = zeroTailDim + ∑ k : Fin r, dim k ∧
-      ∑ k : Fin r, dim k ≤ D := by
-  classical
-  obtain ⟨zeroTailDim, r, dim, μ, blocks, hΛ, hScalar, hμPos, hμNe, hDim, hPos, hDimId⟩ :=
-    exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail (d := d) (D := D) A
-  have hBound : ∑ k : Fin r, dim k ≤ D := by omega
-  exact ⟨zeroTailDim, r, dim, μ, blocks, hΛ, hScalar, hμPos, hμNe, hDim, hPos,
-    hDimId, hBound⟩
-
-/-- **Positive-length PGVWC07 unital dual-diagonal form.**
-
-Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical, lines
-761--762 and 816--832.  This is the zero-block theorem above after omitting the
-explicit zero summand from the displayed MPV identity.  The omission is valid for
-nonempty rings because the all-zero summand has zero MPV coefficient in positive
-length.
-
-The theorem keeps the mathematically relevant bond-dimension estimate
-\(\sum_k D_k\leq D\).  The canonical-form existence theorem is stated with this
-positive-length convention; the explicit zero-block theorem records the
-length-zero bookkeeping separately. -/
-theorem exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound
+Pérez-García, Verstraete, Wolf, and Cirac, Theorem `Th:TIcanonical`, proof
+lines 761--770 and 816--832.  At every positive length, an arbitrary tensor is
+represented by positive real weights multiplying nonzero blocks in the unital
+orientation.  Each block has only scalar transfer-map fixed points and admits a
+diagonal positive-definite fixed point of the adjoint transfer map.  The total
+bond dimension of the retained blocks is at most the original bond dimension. -/
+theorem exists_pgvwc07_unital_dualDiag_from_arbitrary
     (A : MPSTensor d D) :
     ∃ (r : ℕ) (dim : Fin r → ℕ)
       (μ : Fin r → ℂ)
@@ -758,18 +630,23 @@ theorem exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound
       SameMPV₂Pos A (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
       ∑ k : Fin r, dim k ≤ D := by
   classical
-  obtain ⟨_zeroTailDim, r, dim, μ, blocks, hΛ, hScalar, hμPos, _hμNe, hDim, hPos,
-    _hDimId, hBound⟩ :=
-    exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound
-      (d := d) (D := D) A
-  exact ⟨r, dim, μ, blocks, hΛ, hScalar, hμPos, hDim, hPos, hBound⟩
+  obtain ⟨r, dim, blocks₀, hIrr₀, hNonzero₀, _hDim₀, hPos₀, hBound₀⟩ :=
+    exists_irreducible_blockDecomp_nonzeroBlocks (d := d) (D := D) A
+  let A_nonzero := toTensorFromBlocks (d := d) (μ := fun _ : Fin r => (1 : ℂ)) blocks₀
+  have hSame_refl : SameMPV₂ A_nonzero
+      (toTensorFromBlocks (d := d) (μ := fun _ : Fin r => (1 : ℂ)) blocks₀) :=
+    fun _ _ => rfl
+  obtain ⟨μ, blocks, hSame, hΛ, hScalar, hμPos, _hμNe, hDim⟩ :=
+    exists_pgvwc07_unital_dualDiag_blockwise A_nonzero blocks₀ hIrr₀ hSame_refl
+      hNonzero₀
+  exact ⟨r, dim, μ, blocks, hΛ, hScalar, hμPos, hDim,
+    hPos₀.trans hSame.toSameMPV₂Pos, hBound₀⟩
 
 /-- **Structured positive-length PGVWC07 canonical-form witness.**
 
 Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical,
-lines 742--763, after omitting the explicit zero block from positive-length
-MPV coefficients.  This theorem is the corresponding structured form of
-`exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound`.
+lines 742--763.  This theorem is the structured form of
+`exists_pgvwc07_unital_dualDiag_from_arbitrary`.
 
 This is the unnormalized positive-length witness.  The source theorem's
 normalization `1 ≥ λ_j > 0` is supplied later by the finite-family
@@ -782,8 +659,7 @@ theorem exists_pgvwc07_positiveLengthWitness
     Nonempty (PGVWC07PositiveLengthWitness (d := d) (D := D) A) := by
   classical
   obtain ⟨r, dim, μ, blocks, hΛ, hScalar, hμPos, hDim, hSame, hBound⟩ :=
-    exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound
-      (d := d) (D := D) A
+    exists_pgvwc07_unital_dualDiag_from_arbitrary (d := d) (D := D) A
   exact ⟨
     { r := r
       dim := dim
@@ -799,13 +675,11 @@ theorem exists_pgvwc07_positiveLengthWitness
 /-- **Arbitrary-input trace-preserving gauge reduction.**
 
 This combines the invariant-subspace splitting of arXiv:1606.00608,
-lines 201-219, with zero-block separation and the canonical-form-II gauge
-passage at lines 1058-1077 for the nonzero irreducible blocks.
+lines 201--219, with the canonical-form-II gauge passage at lines 1058--1077
+for the nonzero irreducible blocks.
 
-From any `A : MPSTensor d D`, produce:
-* a zero block of dimension `zeroTailDim`, equal to the total bond dimension of
-  the all-zero irreducible blocks;
-* TP-gauged irreducible blocks `blocks k` with nonzero weights `μ k`.
+From any `A : MPSTensor d D`, it produces TP-gauged irreducible blocks
+`blocks k` with nonzero weights `μ k`.
 
 Every nonzero block satisfies:
 * `IsIrreducibleTensor`;
@@ -813,22 +687,21 @@ Every nonzero block satisfies:
 * positive bond dimension;
 * nonzero weight.
 
-At positive length, `A` has the same MPV as the weighted nonzero-block sum, and the
-zero-block contribution is recorded only through the length-zero dimension identity
-`D = zeroTailDim + ∑ k, dim k`.
+At every positive length, `A` has the same MPV as the weighted nonzero-block
+sum, whose total bond dimension is at most `D`.
 
 **Scope restriction (translation-invariant canonical-form proof step):**
 Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical,
 lines 765--770 use a full-rank positive fixed point to gauge a block into the
 unital orientation `∑ i, B i * (B i)ᴴ = 1`. This theorem supplies the dual
-left-canonical trace-preserving orientation after the all-zero-block separation.
+left-canonical trace-preserving orientation after discarding the all-zero blocks.
 The PGVWC07 unital-orientation analogue is
-`exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail` above.  This
+`exists_pgvwc07_unital_dualDiag_from_arbitrary` above.  This
 theorem remains useful as a TP-gauge reduction, but it is not the canonical-form
 statement matching PGVWC07 Theorem Th:TIcanonical.  The boundary is recorded in
 `docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
-theorem exists_tp_gauge_from_arbitrary_with_zeroTail (A : MPSTensor d D) :
-    ∃ (zeroTailDim : ℕ) (r : ℕ) (dim : Fin r → ℕ)
+theorem exists_tp_gauge_from_arbitrary (A : MPSTensor d D) :
+    ∃ (r : ℕ) (dim : Fin r → ℕ)
       (μ : Fin r → ℂ)
       (blocks : (k : Fin r) → MPSTensor d (dim k)),
       (∀ k, IsIrreducibleTensor (blocks k)) ∧
@@ -836,28 +709,18 @@ theorem exists_tp_gauge_from_arbitrary_with_zeroTail (A : MPSTensor d D) :
       (∀ k, μ k ≠ 0) ∧
       (∀ k, 0 < dim k) ∧
       SameMPV₂Pos A (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
-      D = zeroTailDim + ∑ k : Fin r, dim k := by
+      ∑ k : Fin r, dim k ≤ D := by
   classical
-  -- Step 1: Obtain the zero-block-separated irreducible decomposition.
-  obtain ⟨zeroTailDim, r₀, dim₀, blocks₀, hIrr₀, hNonzero₀, _hDim₀, hPos₀, hDimId₀⟩ :=
+  obtain ⟨r, dim, blocks₀, hIrr₀, hNonzero₀, _hDim₀, hPos₀, hBound₀⟩ :=
     exists_irreducible_blockDecomp_nonzeroBlocks (d := d) (D := D) A
-  -- Step 2: Apply blockwise TP gauge to the nonzero blocks.
-  -- We feed `A_nonzero := toTensorFromBlocks μ=1 blocks₀` as the input tensor.
-  -- The SameMPV₂ hypothesis for `exists_tp_gauge_blockwise` holds by reflexivity.
-  let A_nonzero := toTensorFromBlocks (d := d) (μ := fun _ : Fin r₀ => (1 : ℂ)) blocks₀
+  let A_nonzero := toTensorFromBlocks (d := d) (μ := fun _ : Fin r => (1 : ℂ)) blocks₀
   have hSame_refl : SameMPV₂ A_nonzero
-      (toTensorFromBlocks (d := d) (μ := fun _ : Fin r₀ => (1 : ℂ)) blocks₀) :=
+      (toTensorFromBlocks (d := d) (μ := fun _ : Fin r => (1 : ℂ)) blocks₀) :=
     fun _ _ => rfl
-  obtain ⟨r₁, dim₁, μ₁, blocks₁, hSame₁, hIrr₁, hLeft₁, hμNe₁, hDim₁⟩ :=
+  obtain ⟨μ, blocks, hSame, hIrr, hLeft, hμNe, hDim⟩ :=
     exists_tp_gauge_blockwise A_nonzero blocks₀ hIrr₀ hSame_refl hNonzero₀
-  -- Step 3: Assemble the result.
-  refine ⟨zeroTailDim, r₁, dim₁, μ₁, blocks₁, hIrr₁, hLeft₁, hμNe₁, hDim₁, ?_, ?_⟩
-  · exact hPos₀.trans hSame₁.toSameMPV₂Pos
-  · have hsum : (∑ k : Fin r₀, dim₀ k) = ∑ k : Fin r₁, dim₁ k := by
-      have h0 := hSame₁ 0 (Fin.elim0 : Fin 0 → Fin d)
-      rw [mpv_zero_length, mpv_zero_length] at h0
-      exact_mod_cast h0
-    rw [hDimId₀, hsum]
+  exact ⟨r, dim, μ, blocks, hIrr, hLeft, hμNe, hDim,
+    hPos₀.trans hSame.toSameMPV₂Pos, hBound₀⟩
 
 
 end MPSTensor

--- a/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
@@ -400,7 +400,9 @@ through the weighted direct sum.
 
 This is still a prepared-block statement.  It does not start from an arbitrary
 translation-invariant representation, does not separate all-zero blocks, and
-does not prove the total bond-dimension bound of the full source theorem. -/
+does not prove the total bond-dimension bound of the full source theorem. The
+prepared-block boundary is recorded in
+`docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
 theorem exists_pgvwc07_unital_dualDiag_blockwise
     (A : MPSTensor d D)
     {r0 : ℕ} {dim0 : Fin r0 → ℕ}
@@ -519,7 +521,11 @@ by itself give an unconditional arbitrary-input theorem under the current
 nonzero Kraus operator, excluding the all-zero scalar counterexample and
 matching the hypotheses of the corresponding irreducible-to-TP result from
 `Existence.lean`. It remains separate from the later normal-canonical-form theorem
-in `NormalReduction/Main.lean`. -/
+in `NormalReduction/Main.lean`.
+
+Source: arXiv:1606.00608, lines 1058--1077, applied independently to each nonzero irreducible
+block. The relation to the PGVWC07 unital orientation is recorded in
+`docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex`. -/
 theorem exists_tp_gauge_blockwise
     (A : MPSTensor d D)
     {r0 : ℕ} {dim0 : Fin r0 → ℕ}

--- a/TNLean/MPS/CanonicalForm/Reduction.lean
+++ b/TNLean/MPS/CanonicalForm/Reduction.lean
@@ -148,7 +148,8 @@ private lemma mpv_twoBlockTensor_eq {n m : ℕ} (A₁ : MPSTensor d n) (A₂ : M
 
 Every MPS tensor `A : MPSTensor d D` is `SameMPV₂`-equivalent to a block-diagonal tensor
 `toTensorFromBlocks (μ ≡ 1) blocks` whose every block is irreducible (has no nontrivial invariant
-orthogonal projection).
+orthogonal projection).  The direct-sum construction also gives the structural
+dimension identity `∑ k, dim k = D`.
 
 The proof proceeds by strong induction on `D`: in the inductive step, `HasInvariantProj A` gives a
 nontrivial invariant projection `P`, which we use via
@@ -169,13 +170,15 @@ theorem exists_irreducible_blockDecomp (A : MPSTensor d D) :
     ∃ r : ℕ, ∃ dim : Fin r → ℕ,
     ∃ blocks : (k : Fin r) → MPSTensor d (dim k),
       (∀ k, IsIrreducibleTensor (blocks k)) ∧
-      SameMPV₂ A (toTensorFromBlocks (d := d) (μ := fun _ : Fin r => (1 : ℂ)) blocks) := by
+      SameMPV₂ A (toTensorFromBlocks (d := d) (μ := fun _ : Fin r => (1 : ℂ)) blocks) ∧
+      ∑ k : Fin r, dim k = D := by
   -- Formulate the statement for all tensors of a given bond dimension (for strong induction).
   suffices h : ∀ (D : ℕ) (A : MPSTensor d D),
       ∃ r : ℕ, ∃ dim : Fin r → ℕ,
       ∃ blocks : (k : Fin r) → MPSTensor d (dim k),
         (∀ k, IsIrreducibleTensor (blocks k)) ∧
-        SameMPV₂ A (toTensorFromBlocks (d := d) (μ := fun _ : Fin r => (1 : ℂ)) blocks)
+        SameMPV₂ A (toTensorFromBlocks (d := d) (μ := fun _ : Fin r => (1 : ℂ)) blocks) ∧
+        ∑ k : Fin r, dim k = D
     from h D A
   intro D
   induction D using Nat.strong_induction_on with
@@ -184,18 +187,19 @@ theorem exists_irreducible_blockDecomp (A : MPSTensor d D) :
   -- ── Case split: is `A` already irreducible? ──────────────────────────────────────────────────
   by_cases hirr : IsIrreducibleTensor A
   · -- A is already irreducible: take a single block.
-    refine ⟨1, fun _ => D, fun _ => A, fun _ => hirr, fun N σ => ?_⟩
+    refine ⟨1, fun _ => D, fun _ => A, fun _ => hirr, ?_, by simp⟩
+    intro N σ
     rw [mpv_toTensorFromBlocks_eq_sum]
     simp
   · -- A has a nontrivial invariant projection; split into two strictly-smaller blocks.
     rw [IsIrreducibleTensor, not_not] at hirr
     obtain ⟨P, hP_proj, hP0, hP1, hLower⟩ := hirr
     -- Apply the strict two-block decomposition.
-    obtain ⟨n, m, _hnm, hn_lt, hm_lt, A₁, A₂, hSame_two⟩ :=
+    obtain ⟨n, m, hnm, hn_lt, hm_lt, A₁, A₂, hSame_two⟩ :=
       exists_twoBlock_decomp_of_lowerZero_strict A P hP_proj hLower hP0 hP1
     -- Apply the induction hypothesis to each block.
-    obtain ⟨r₁, dim₁, blocks₁, hirr₁, hIH₁⟩ := ih n hn_lt A₁
-    obtain ⟨r₂, dim₂, blocks₂, hirr₂, hIH₂⟩ := ih m hm_lt A₂
+    obtain ⟨r₁, dim₁, blocks₁, hirr₁, hIH₁, hDim₁⟩ := ih n hn_lt A₁
+    obtain ⟨r₂, dim₂, blocks₂, hirr₂, hIH₂, hDim₂⟩ := ih m hm_lt A₂
     -- ── Combine the two block decompositions ─────────────────────────────────────────────────
     -- Combined number of blocks and dimension function.
     let combinedDim : Fin (r₁ + r₂) → ℕ := Fin.addCases dim₁ dim₂
@@ -214,7 +218,7 @@ theorem exists_irreducible_blockDecomp (A : MPSTensor d D) :
           cast (congr_arg (MPSTensor d) (h_left k).symm) (blocks₁ k))
         (fun (k : Fin r₂) =>
           cast (congr_arg (MPSTensor d) (h_right k).symm) (blocks₂ k))
-    refine ⟨r₁ + r₂, combinedDim, combinedBlocks, ?_, ?_⟩
+    refine ⟨r₁ + r₂, combinedDim, combinedBlocks, ?_, ?_, ?_⟩
     -- ── Irreducibility of the combined blocks ─────────────────────────────────────────────────
     · intro k
       -- Split on whether k is in the left or right half.
@@ -291,5 +295,8 @@ theorem exists_irreducible_blockDecomp (A : MPSTensor d D) :
         _ = ∑ k : Fin (r₁ + r₂), (1 : ℂ) ^ N • mpv (combinedBlocks k) σ := hsplit.symm
         _ = mpv (toTensorFromBlocks (d := d) (μ := fun _ : Fin (r₁ + r₂) => (1 : ℂ))
               combinedBlocks) σ := hexpand_combined.symm
+    -- The dimension identity is inherited directly from the two summands.
+    · rw [Fin.sum_univ_add]
+      simpa [combinedDim, hDim₁, hDim₂] using hnm
 
 end MPSTensor

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean
@@ -45,16 +45,22 @@ section FundamentalTheoremAfterBlocking
 
 This is the faithful predecessor to the common nonzero-sector statement. From
 `SameMPV₂ A B`, it discards the all-zero blocks at positive lengths and then
-applies the TP gauge to obtain irreducible nonzero-weight blocks on both sides. It then
-removes the period of each block separately, producing primitive irreducible cyclic sectors for
-every nonzero-weight block. The tensor on each side agrees with its nonzero part
-at every positive length, and the two nonzero parts agree at every positive length.
+applies the TP gauge to obtain irreducible nonzero-weight blocks on both sides. It then removes the
+period of each block separately, producing primitive irreducible cyclic sectors for every
+nonzero-weight block. The tensor on each side agrees with its nonzero part at every positive
+length, and the two nonzero parts agree at every positive length.
 
 The theorem intentionally keeps the per-block period-removal lengths inside
 `HasPrimitiveIrreducibleCyclicSectors`. It does not conflate those lengths with a
 later common-refinement or Wielandt/injectivity blocking length; assembling the
 per-block cyclic sectors at one physical blocking level is the next formal
-statement in the reduction chain. -/
+statement in the reduction chain.
+
+Source: Pérez-García, Verstraete, Wolf, and Cirac, Theorem `Th:TIcanonical`, proof lines
+761--832, for the nonzero irreducible canonical blocks; arXiv:1606.00608, equation
+`eq:II_Aiplusk1`, Section II.C, and Appendix A, for removing zero blocks and resolving periodic
+blocks into cyclic sectors. The positive-length convention is recorded in
+`docs/paper-gaps/cpsv16_zero_tail_length_zero_decomposition.tex`. -/
 theorem afterBlocking_perBlockCyclicData_of_sameMPV₂
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean
@@ -13,7 +13,7 @@ open Filter
 
 This file collects the common-sector continuation of the structural
 canonical-form reduction following arXiv:1606.00608. Starting from the
-all-zero leftover block and TP-gauge decomposition, it records the per-block
+nonzero irreducible decomposition and its trace-preserving gauge, it records the per-block
 weights, blocks, and positive-length agreements of the nonzero part, chooses
 common blocking lengths, and states the relabeled common-sector families needed
 to compare the resulting sector families.
@@ -41,16 +41,14 @@ variable {d D : ℕ}
 
 section FundamentalTheoremAfterBlocking
 
-/-- **Per-block cyclic-sector decomposition after the zero-block split.**
+/-- **Per-block cyclic-sector decomposition after removing zero blocks.**
 
 This is the faithful predecessor to the common nonzero-sector statement. From
-`SameMPV₂ A B`, it first separates the all-zero leftover block and then applies
-the TP gauge to obtain irreducible nonzero-weight blocks on both sides. It then
+`SameMPV₂ A B`, it discards the all-zero blocks at positive lengths and then
+applies the TP gauge to obtain irreducible nonzero-weight blocks on both sides. It then
 removes the period of each block separately, producing primitive irreducible cyclic sectors for
 every nonzero-weight block. The tensor on each side agrees with its nonzero part
 at every positive length, and the two nonzero parts agree at every positive length.
-The length-zero coefficient is recovered separately, at the end, from equality of
-the bond dimensions.
 
 The theorem intentionally keeps the per-block period-removal lengths inside
 `HasPrimitiveIrreducibleCyclicSectors`. It does not conflate those lengths with a
@@ -80,12 +78,12 @@ theorem afterBlocking_perBlockCyclicData_of_sameMPV₂
         (toTensorFromBlocks (d := d) (μ := μB) blocksB) ∧
       (∀ k, HasPrimitiveIrreducibleCyclicSectors (blocksA k)) ∧
       (∀ k, HasPrimitiveIrreducibleCyclicSectors (blocksB k)) := by
-  obtain ⟨_zeroTailA, rA, dimA, μA, blocksA,
-      hIrrA, hTPA, hμA, hDimA, hAPos, _hDimIdA⟩ :=
-    exists_tp_gauge_from_arbitrary_with_zeroTail (d := d) (D := D₁) A
-  obtain ⟨_zeroTailB, rB, dimB, μB, blocksB,
-      hIrrB, hTPB, hμB, hDimB, hBPos, _hDimIdB⟩ :=
-    exists_tp_gauge_from_arbitrary_with_zeroTail (d := d) (D := D₂) B
+  obtain ⟨rA, dimA, μA, blocksA,
+      hIrrA, hTPA, hμA, hDimA, hAPos, _hDimBoundA⟩ :=
+    exists_tp_gauge_from_arbitrary (d := d) (D := D₁) A
+  obtain ⟨rB, dimB, μB, blocksB,
+      hIrrB, hTPB, hμB, hDimB, hBPos, _hDimBoundB⟩ :=
+    exists_tp_gauge_from_arbitrary (d := d) (D := D₂) B
   -- The two nonzero parts agree at positive length: chain through the common MPV family.
   have hBook : SameMPV₂Pos
       (toTensorFromBlocks (d := d) (μ := μA) blocksA)
@@ -268,17 +266,16 @@ decompositions are now part of this file's structural reduction. The remaining
 formal work for the completely unconditional
 `fundamentalTheorem_after_blocking_sector` is therefore narrower:
 
-1. the `N = 0` identity for the zero-tail contribution;
-2. one-site injectivity of the nonzero-weight blocks, or a blocked replacement of the
+1. one-site injectivity of the nonzero-weight blocks, or a blocked replacement of the
    rigidity hypothesis; and
-3. equality of the finite-length MPV spans for the original nonzero-weight block families
+2. equality of the finite-length MPV spans for the original nonzero-weight block families
    (or directly for the two BNT bases), equivalently a common phase/BNT comparison,
    followed by the final global gauge construction of the equal-case FT.
 
 Thus the common-period arithmetic, the blocked-word relabeling, the common
 primitive irreducible nonzero-sector families, and the abstract sector-matching
 witness have already been supplied. What remains is the CPSV derivation of the
-listed zero-tail, injectivity, and span/comparison facts for the actual sector
+listed injectivity and span/comparison facts for the actual sector
 tensors produced by the after-blocking reduction.
 -/
 

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean
@@ -38,9 +38,8 @@ Two tensors with the same MPV family have one common positive blocking length
 whose nonzero parts are weighted families of trace-preserving, primitive,
 tensor-irreducible blocks with positive bond dimensions and nonzero weights. At
 every positive length each blocked tensor equals its nonzero part, and the two
-nonzero parts equal each other. The all-zero leftover block contributes only at
-length zero, so it is omitted; the length-zero coefficient is restored once, at
-the end, from equality of the bond dimensions.
+nonzero parts equal each other. All-zero blocks are omitted because they vanish
+at every positive length.
 
 The proof uses the family-level common-alphabet nonzero-part identity directly,
 rather than passing through a separate relabeling hypothesis.

--- a/TNLean/MPS/CanonicalForm/SectorComparison/TPPrimitiveReduction.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/TPPrimitiveReduction.lean
@@ -108,9 +108,15 @@ The retained blocks have total bond dimension at most the original bond
 dimension.  This bound comes from the invariant-subspace decomposition and is
 independent of any empty-word comparison.
 
-**Note on the original blocks**: The pre-blocking blocks (from step 2) ARE
-`IsIrreducibleTensor`, but blocking does not in general preserve tensor
-irreducibility. See the module documentation for the gap analysis. -/
+Source: Pérez-García, Verstraete, Wolf, and Cirac, Theorem `Th:TIcanonical`,
+proof lines 761--832, for the nonzero irreducible blocks and their canonical
+gauge; arXiv:1606.00608, equation `eq:II_Aiplusk1`, Section II.C, and Appendix A,
+for removal of zero blocks and blocking to primitive cyclic sectors.  The
+positive-length statement and structural dimension bound are recorded in
+`docs/paper-gaps/cpsv16_zero_tail_length_zero_decomposition.tex`.
+
+**Original blocks:** The pre-blocking blocks are `IsIrreducibleTensor`, but blocking does not in
+general preserve tensor irreducibility. See the module documentation for the gap analysis. -/
 theorem exists_tp_primitive_blockDecomp_after_blocking (A : MPSTensor d D) :
     ∃ (p : ℕ) (_ : 0 < p)
       (r : ℕ) (dim : Fin r → ℕ) (μ : Fin r → ℂ)

--- a/TNLean/MPS/CanonicalForm/SectorComparison/TPPrimitiveReduction.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/TPPrimitiveReduction.lean
@@ -24,20 +24,16 @@ open Filter
 /-!
 # TP-primitive reduction after blocking
 
-This file begins the canonical-form reduction for arbitrary MPS
-families. It combines the zero-block separation, TP gauge, and
-common blocking steps into a blocked decomposition whose nontrivial blocks are
-left-canonical and have primitive transfer maps.
-
-The "zero tail" in the produced decomposition is the total bond dimension of
-the separated all-zero leftover blocks.  It is the dimension gap allowed by
-`∑ k, D_k ≤ D`, where the remaining summands are zero blocks.
+This file begins the canonical-form reduction for arbitrary MPS families. It
+combines removal of all-zero blocks at positive lengths, the TP gauge, and
+common blocking into a blocked decomposition whose blocks are left-canonical
+and have primitive transfer maps.
 
 ## Main statements
 
 * `exists_tp_primitive_blockDecomp_after_blocking` — arbitrary tensors admit a
-  positive-length blocked decomposition into TP-primitive blocks, together with
-  the separate zero-block bond-dimension count.
+  positive-length blocked decomposition into TP-primitive blocks whose total
+  bond dimension is at most the original bond dimension.
 
 ## References
 
@@ -97,8 +93,6 @@ an arbitrary `A : MPSTensor d D` and produces blocked TP-primitive data.
 For any `A : MPSTensor d D`, there exists a blocking period `p > 0` and
 a decomposition:
 
-* a **trivial block** of dimension `zeroTailDim` (accumulating all-zero irreducible
-  blocks from the original decomposition);
 * a family of **weighted blocked blocks** `blocks k` indexed by `Fin r`, each with:
   - left-canonical (TP) normalization `∑ᵢ (blocks k i)ᴴ * (blocks k i) = I`;
   - primitive transfer map `_root_.IsPrimitive (transferMap (blocks k))`;
@@ -110,16 +104,15 @@ The MPV relationship holds at every positive blocked length:
   mpv (blockTensor A p) σ = mpv (toTensorFromBlocks μ blocks) σ
 ```
 
-The zero block appears only through the length-zero bond-dimension identity
-`zeroTailDim + ∑ dim = D`. This separates the source's positive-length
-comparison from the empty-word dimension count, as described in
-`docs/paper-gaps/cpsv16_zero_tail_length_zero_decomposition.tex`.
+The retained blocks have total bond dimension at most the original bond
+dimension.  This bound comes from the invariant-subspace decomposition and is
+independent of any empty-word comparison.
 
 **Note on the original blocks**: The pre-blocking blocks (from step 2) ARE
 `IsIrreducibleTensor`, but blocking does not in general preserve tensor
 irreducibility. See the module documentation for the gap analysis. -/
 theorem exists_tp_primitive_blockDecomp_after_blocking (A : MPSTensor d D) :
-    ∃ (zeroTailDim : ℕ) (p : ℕ) (_ : 0 < p)
+    ∃ (p : ℕ) (_ : 0 < p)
       (r : ℕ) (dim : Fin r → ℕ) (μ : Fin r → ℂ)
       (blocks : (k : Fin r) → MPSTensor (blockPhysDim d p) (dim k)),
       -- (a) Blocks are left-canonical (TP)
@@ -136,13 +129,13 @@ theorem exists_tp_primitive_blockDecomp_after_blocking (A : MPSTensor d D) :
       SameMPV₂Pos
         (blockTensor (d := d) (D := D) A p)
         (toTensorFromBlocks (d := blockPhysDim d p) (μ := μ) blocks) ∧
-      -- (f) Length-zero bond-dimension count
-      zeroTailDim + ∑ k : Fin r, dim k = D := by
+      -- (f) Bond-dimension bound
+      ∑ k : Fin r, dim k ≤ D := by
   classical
   -- Step A: Get TP-gauged irreducible blocks from an arbitrary tensor.
-  obtain ⟨zeroTailDim, r₀, dim₀, μ₀, blocks₀,
-      hIrr₀, hTP₀, hμNe₀, hDim₀, hPos₀, hDimId₀⟩ :=
-    exists_tp_gauge_from_arbitrary_with_zeroTail (d := d) (D := D) A
+  obtain ⟨r₀, dim₀, μ₀, blocks₀,
+      hIrr₀, hTP₀, hμNe₀, hDim₀, hPos₀, hDimBound₀⟩ :=
+    exists_tp_gauge_from_arbitrary (d := d) (D := D) A
   -- Step B: Find a common blocking period making all transfer maps primitive.
   obtain ⟨P, hP, hPrim⟩ :=
     exists_common_blocking_all_primitive_of_TP_irr blocks₀ hTP₀ hIrr₀ hDim₀
@@ -151,7 +144,7 @@ theorem exists_tp_primitive_blockDecomp_after_blocking (A : MPSTensor d D) :
     fun k => blockTensor (d := d) (D := dim₀ k) (blocks₀ k) P with blocks₁_def
   set μ₁ : Fin r₀ → ℂ := fun k => (μ₀ k) ^ P with μ₁_def
   -- Step D: Verify all properties.
-  refine ⟨zeroTailDim, P, hP, r₀, dim₀, μ₁, blocks₁, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  refine ⟨P, hP, r₀, dim₀, μ₁, blocks₁, ?_, ?_, ?_, ?_, ?_, ?_⟩
   -- (a) TP under blocking.
   · intro k
     exact leftCanonical_blockTensor (d := d) (D := dim₀ k) (A := blocks₀ k) (L := P) (hTP₀ k)
@@ -166,7 +159,7 @@ theorem exists_tp_primitive_blockDecomp_after_blocking (A : MPSTensor d D) :
       sameMPV₂Pos_blockTensor_toTensorFromBlocks
         (d := d) (D := D) (r := r₀) (dim := dim₀)
         A μ₀ blocks₀ hPos₀ P hP
-  -- (f) Length-zero bond-dimension count.
-  · exact hDimId₀.symm
+  -- (f) Bond dimensions are unchanged by blocking.
+  · exact hDimBound₀
 
 end MPSTensor

--- a/blueprint/src/chapter/ch09_canonical.tex
+++ b/blueprint/src/chapter/ch09_canonical.tex
@@ -1280,7 +1280,7 @@ canonical form is Theorem~\ref{thm:pgvwc07_ti_canonical_form}.
 \end{remark}
 
 \section{Nonzero blocks and the trace-preserving gauge}%
-\label{sec:zero_block_separation}
+\label{sec:nonzero_blocks_tp_gauge}
 
 In an irreducible block decomposition some blocks may have all-zero Kraus
 operators. Such a block contributes nothing to a matrix product vector at any
@@ -1290,7 +1290,7 @@ using an empty-word coefficient. Each retained block is then placed in the
 trace-preserving gauge.
 
 \begin{theorem}[Nonzero irreducible block decomposition]%
-    \label{thm:zero_block_separation}
+    \label{thm:nonzero_irreducible_block_decomposition}
     \lean{MPSTensor.exists_irreducible_blockDecomp_nonzeroBlocks}
     \leanok
     \uses{def:irreducible_tensor, def:same_mpv2_pos}
@@ -1366,8 +1366,8 @@ trace-preserving gauge.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:zero_block_separation, thm:tp_data_irreducible}
-    Theorem~\ref{thm:zero_block_separation} supplies the nonzero
+    \uses{thm:nonzero_irreducible_block_decomposition, thm:tp_data_irreducible}
+    Theorem~\ref{thm:nonzero_irreducible_block_decomposition} supplies the nonzero
     irreducible blocks $(C_k)_{k=1}^r$. For every $N \ge 1$ and every $\sigma$,
     \[
         V^{(N)}(A)_\sigma
@@ -1807,7 +1807,7 @@ direct sum of primitive irreducible blocks.
 \end{proof}
 
 \begin{theorem}[Cyclic sectors after removing zero blocks]%
-    \label{thm:ft_after_blocking_per_block_cyclic_live_zero_tail}
+    \label{thm:ft_after_blocking_per_block_cyclic_nonzero_blocks}
     \lean{MPSTensor.afterBlocking_perBlockCyclicData_of_sameMPV₂}
     \leanok
     \uses{thm:tp_gauge_arbitrary, def:primitive_irreducible_cyclic_sectors,
@@ -1859,7 +1859,7 @@ direct sum of primitive irreducible blocks.
     \label{thm:ft_after_blocking_common_length_common_sector_theorem}
     \lean{MPSTensor.afterBlocking_commonLengthCommonSectorData_of_sameMPV₂}
     \leanok
-    \uses{thm:ft_after_blocking_per_block_cyclic_live_zero_tail,
+    \uses{thm:ft_after_blocking_per_block_cyclic_nonzero_blocks,
         thm:exists_common_blocked_cyclic_sector_family_common_multiple,
         thm:same_mpv2_pos_block_tensor_to_tensor_from_blocks,
         thm:same_mpv2_pos_to_tensor_from_blocks_block_power,
@@ -1888,13 +1888,13 @@ direct sum of primitive irreducible blocks.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:ft_after_blocking_per_block_cyclic_live_zero_tail,
+    \uses{thm:ft_after_blocking_per_block_cyclic_nonzero_blocks,
         thm:exists_common_blocked_cyclic_sector_family_common_multiple,
         thm:same_mpv2_pos_block_tensor_to_tensor_from_blocks,
         thm:same_mpv2_pos_to_tensor_from_blocks_block_power,
         thm:common_blocked_cyclic_sector_derived_properties}
     Start from
-    Theorem~\ref{thm:ft_after_blocking_per_block_cyclic_live_zero_tail}. With
+    Theorem~\ref{thm:ft_after_blocking_per_block_cyclic_nonzero_blocks}. With
     $p_A,p_B$ the least common multiples of the period-removal lengths on the two
     sides, use $p=\operatorname{lcm}(p_A,p_B)$. The prescribed-common-multiple
     lemma constructs both one-sided sector families at this length, and the

--- a/blueprint/src/chapter/ch09_canonical.tex
+++ b/blueprint/src/chapter/ch09_canonical.tex
@@ -738,7 +738,9 @@ irreducible unital blocks and the algebra-spanning input used later.
     \leanok
     \uses{def:irreducible_tensor}
     Every MPS tensor $A$ admits a block-diagonal tensor $\bigoplus_{k=1}^r A_k$
-    with each $A_k$ irreducible and $\mc{V}(A) = \mc{V}(\bigoplus_k A_k)$.
+    with each $A_k$ irreducible,
+    $\mc{V}(A) = \mc{V}(\bigoplus_k A_k)$, and
+    $\sum_{k=1}^rD_k=D$.
 \end{theorem}
 
 \begin{proof}
@@ -1272,59 +1274,47 @@ canonical form is Theorem~\ref{thm:pgvwc07_ti_canonical_form}.
     hypotheses in advance and produces the normal canonical form by reordering.
     It is not the arbitrary-input existence theorem
     of~\cite[Section~2.3]{Cirac2016MPDO_arXiv}; that primitive-block reduction,
-    including the zero-tail count, is
+    including its structural bond-dimension bound, is
     Theorem~\ref{thm:tp_primitive_blockdecomp} in
     Section~\ref{sec:reduction_to_normal_form}.
 \end{remark}
 
-\section{Zero-block separation and the trace-preserving gauge}%
+\section{Nonzero blocks and the trace-preserving gauge}%
 \label{sec:zero_block_separation}
 
 In an irreducible block decomposition some blocks may have all-zero Kraus
-operators. An all-zero block contributes $V^{(N)}=0$ for every $N\ge 1$, so it
-adds nothing to the positive-length MPV family; at $N=0$ the MPV coefficient is
-the bond dimension. The all-zero summand therefore enters the output not as a
-tensor but as a single count $D_0$ in the length-zero identity
-$D = D_0 + \sum_k D_k$, and all positive-length content is an equality of MPV
-families. This is the positive-length convention used throughout the reduction:
-comparisons of weighted block sums are stated for $N\ge 1$, with the zero block
-carried only by $D_0$. After separating the zero summand, each nonzero block is
-placed in the trace-preserving gauge, the furthest unconditional reduction
-available before periodicity removal.
+operators. Such a block contributes nothing to a matrix product vector at any
+positive length and is therefore discarded. The structural direct-sum identity
+implies that the retained block dimensions satisfy $\sum_k D_k\le D$ without
+using an empty-word coefficient. Each retained block is then placed in the
+trace-preserving gauge.
 
-\begin{theorem}[Zero-block separation]%
+\begin{theorem}[Nonzero irreducible block decomposition]%
     \label{thm:zero_block_separation}
     \lean{MPSTensor.exists_irreducible_blockDecomp_nonzeroBlocks}
     \leanok
     \uses{def:irreducible_tensor, def:same_mpv2_pos}
-    Every MPS tensor $A$ admits a block decomposition into a zero-block bond
-    dimension $D_0$ and a finite family of nonzero blocks $(B_k)_{k=1}^r$, each
-    irreducible, with at least one nonzero Kraus operator, and of positive bond
-    dimension, recorded by two facts. The positive-length equality of MPV
-    families: for every $N \ge 1$ and every $\sigma$,
+    Every MPS tensor $A$ admits a finite family of nonzero irreducible blocks
+    $(B_k)_{k=1}^r$, each with at least one nonzero Kraus operator and positive
+    bond dimension. For every $N \ge 1$ and every $\sigma$,
     \[
         V^{(N)}(A)_\sigma
         = V^{(N)}\!(\textstyle\bigoplus_{k=1}^r B_k)_\sigma.
     \]
-    The length-zero dimension identity
-    \[
-        D = D_0 + \sum_{k=1}^r D_k,
-    \]
-    where $D_0$ is the total bond dimension of the all-zero blocks.
+    Moreover, $\sum_{k=1}^r D_k\le D$.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{thm:irred_decomp}
     Apply the irreducible block decomposition (Theorem~\ref{thm:irred_decomp})
-    and partition the blocks by whether each has a nonzero Kraus operator; $D_0$
-    accumulates the bond dimensions of the all-zero blocks. For every all-zero
+    and retain the blocks having a nonzero Kraus operator. For every all-zero
     irreducible block $C_j$ and every $N \ge 1$, $V^{(N)}(C_j)_\sigma = 0$, so
     \[
         V^{(N)}(A)_\sigma
         = V^{(N)}\!(\textstyle\bigoplus_{k=1}^r B_k)_\sigma.
     \]
-    At $N = 0$ the MPV coefficient is the bond dimension, giving
-    $D = D_0 + \sum_{k=1}^r D_k$.
+    The dimension inequality follows by restricting the structural identity
+    $\sum_j D_j=D$ to the retained subset.
 \end{proof}
 
 \begin{theorem}[Blockwise TP-gauge normalization of irreducible blocks]%
@@ -1358,13 +1348,13 @@ available before periodicity removal.
 \subsection{Trace-preserving gauge for arbitrary tensors}%
 \label{sec:tp_gauge_arbitrary}
 
-\begin{theorem}[TP-gauge reduction for arbitrary tensors with zero-block separation]%
+\begin{theorem}[TP-gauge reduction for arbitrary tensors]%
     \label{thm:tp_gauge_arbitrary}
-    \lean{MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail}
+    \lean{MPSTensor.exists_tp_gauge_from_arbitrary}
     \leanok
     \uses{def:irreducible_tensor, def:same_mpv2_pos}
-    For any MPS tensor $A$, there exist a zero-block bond dimension $D_0$ and
-    nontrivial blocks $(B_k)_{k=1}^r$ with nonzero weights $(\mu_k)_{k=1}^r$,
+    For any MPS tensor $A$, there exist nontrivial blocks $(B_k)_{k=1}^r$ with
+    nonzero weights $(\mu_k)_{k=1}^r$,
     each block irreducible, left-canonical
     ($\sum_i (B_k^i)^\dagger B_k^i = \Id$), and of positive bond dimension, such
     that for every $N \ge 1$ and every $\sigma$,
@@ -1372,15 +1362,12 @@ available before periodicity removal.
         V^{(N)}(A)_\sigma
         = V^{(N)}\!(\textstyle\bigoplus_{k=1}^r \mu_k B_k)_\sigma,
     \]
-    and the zero-block contribution is recorded by the length-zero identity
-    \[
-        D = D_0 + \sum_{k=1}^r D_k.
-    \]
+    and $\sum_{k=1}^r D_k\le D$.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{thm:zero_block_separation, thm:tp_data_irreducible}
-    Theorem~\ref{thm:zero_block_separation} supplies $D_0$ and the nonzero
+    Theorem~\ref{thm:zero_block_separation} supplies the nonzero
     irreducible blocks $(C_k)_{k=1}^r$. For every $N \ge 1$ and every $\sigma$,
     \[
         V^{(N)}(A)_\sigma
@@ -1394,7 +1381,8 @@ available before periodicity removal.
         =
         V^{(N)}\!(\textstyle\bigoplus_{k=1}^r \mu_k B_k)_\sigma.
     \]
-    The length-zero identity $D = D_0 + \sum_{k=1}^r D_k$ is preserved.
+    The gauge preserves every block dimension, so the structural bound
+    $\sum_kD_k\le D$ is unchanged.
 \end{proof}
 
 \section{Blocking, period removal, and primitive blocks}%
@@ -1760,9 +1748,9 @@ map~\cite[Theorem~6.6]{Wolf2012Quantum}.
 This subsection completes the reduction after period removal. A
 TP-primitive-irreducible block is normal, and an arbitrary tensor becomes, after a
 positive blocking length, a weighted family of left-canonical primitive blocks
-with the zero-block dimension recorded separately. For two tensors with the same
-MPV family, the cyclic sectors can be expressed over one common blocked alphabet,
-which is the form used by the Fundamental Theorem.
+whose total bond dimension is bounded by the original bond dimension. For two
+tensors with the same MPV family, the cyclic sectors can be expressed over one
+common blocked alphabet, which is the form used by the Fundamental Theorem.
 
 \begin{theorem}[TP-primitive irreducible tensor is normal]%
     \label{thm:normal_tp_primitive_irred}
@@ -1788,16 +1776,15 @@ direct sum of primitive irreducible blocks.
     \lean{MPSTensor.exists_tp_primitive_blockDecomp_after_blocking}
     \leanok
     \uses{def:blocked_tensor, def:same_mpv2_pos}
-    For any MPS tensor $A$, there exist $p\ge 1$, a zero-tail bond dimension
-    $D_0$, nonzero weights $(\mu_k)_{k=1}^r$, and blocks $(B_k)_{k=1}^r$ such
+    For any MPS tensor $A$, there exist $p\ge 1$, nonzero weights
+    $(\mu_k)_{k=1}^r$, and blocks $(B_k)_{k=1}^r$ such
     that, for every blocked $\sigma$ of positive length $N$,
     \[
         V^{(N)}\!(A^{[p]})_\sigma
         = V^{(N)}\!(\textstyle\bigoplus_{k=1}^{r} \mu_k B_k)_\sigma.
     \]
-    The zero-block contribution is recorded separately by the length-zero
-    identity $D_0 + \sum_{k=1}^{r} D_k = D$. Each block is left-canonical and
-    primitive,
+    The retained block dimensions satisfy $\sum_{k=1}^{r}D_k\le D$. Each block
+    is left-canonical and primitive,
     \[
         \sum_i (B_k^i)^\dagger B_k^i = \Id,
         \qquad
@@ -1810,9 +1797,8 @@ direct sum of primitive irreducible blocks.
     \uses{thm:tp_gauge_arbitrary, thm:common_blocking_period,
         lem:block_weights_ne_zero,
         thm:same_mpv2_pos_block_tensor_to_tensor_from_blocks}
-    Theorem~\ref{thm:tp_gauge_arbitrary} supplies the zero-block dimension, the
-    left-canonical nontrivial blocks, the positive-length equality, and the
-    identity $D = D_0 + \sum_k D_k$.
+    Theorem~\ref{thm:tp_gauge_arbitrary} supplies the left-canonical nontrivial
+    blocks, the positive-length equality, and the bound $\sum_kD_k\le D$.
     Theorem~\ref{thm:common_blocking_period} provides a common blocking period
     $p$ making all transfer maps primitive,
     Lemma~\ref{lem:block_weights_ne_zero} keeps the blocked weights nonzero, and
@@ -1820,14 +1806,14 @@ direct sum of primitive irreducible blocks.
     the positive-length equality through blocking.
 \end{proof}
 
-\begin{theorem}[Cyclic sectors after the zero-block split]%
+\begin{theorem}[Cyclic sectors after removing zero blocks]%
     \label{thm:ft_after_blocking_per_block_cyclic_live_zero_tail}
     \lean{MPSTensor.afterBlocking_perBlockCyclicData_of_sameMPV₂}
     \leanok
     \uses{thm:tp_gauge_arbitrary, def:primitive_irreducible_cyclic_sectors,
         thm:cyclic_sector_decomp_irr_tp_prim_irr}
-    If $A$ and $B$ generate the same MPV family, then after the zero-block split
-    and the trace-preserving gauge there are weighted nonzero-block tensors
+    If $A$ and $B$ generate the same MPV family, then after removing the
+    all-zero blocks and applying the trace-preserving gauge there are weighted nonzero-block tensors
     $\bigoplus_j \mu^A_j A_j$ and $\bigoplus_k \mu^B_k B_k$ with, for every
     $N\ge 1$ and $\sigma$,
     \[

--- a/docs/audits/2026-06-01_issue2194_canonical_reduction_dedup.md
+++ b/docs/audits/2026-06-01_issue2194_canonical_reduction_dedup.md
@@ -1,5 +1,10 @@
 # Issue 2194 canonical-form reduction deduplication audit
 
+> **Status update (2026-07-17).** This audit records the declaration surface at
+> its stated commit. The later positive-length cleanup replaced
+> `exists_tp_gauge_from_arbitrary_with_zeroTail` by
+> `MPSTensor.exists_tp_gauge_from_arbitrary` and removed the zero-tail data.
+
 Date: 2026-06-01.
 
 This note records the final audit for issue #2194, whose subject is the
@@ -145,4 +150,3 @@ common_blocked_cyclic_sector_flat_weight_ne_zero
 Historical audit notes still mention some of these names as archaeology. Those
 mentions are not live theorem references and do not affect Chapter 8 or Chapter
 11b.
-

--- a/docs/audits/canonical_audit.md
+++ b/docs/audits/canonical_audit.md
@@ -1,5 +1,11 @@
 # Canonical-form chapters: read-only audit
 
+> **Status update (2026-07-17).** This audit is historical. The zero-tail
+> intermediate declarations discussed below were subsequently removed. The
+> current arbitrary-input results are
+> `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary` and
+> `MPSTensor.exists_tp_gauge_from_arbitrary`.
+
 Scope: blueprint chapters `ch08_canonical.tex`, `ch09_block_perm.tex`,
 `ch11b_after_blocking.tex` and their Lean files. No files modified.
 

--- a/docs/audits/pgvwc07_restoration_report.md
+++ b/docs/audits/pgvwc07_restoration_report.md
@@ -1,5 +1,11 @@
 # PGVWC07 intermediate-step restoration report
 
+> **Status update (2026-07-17).** This is a historical restoration record. The
+> three zero-tail declarations listed below were subsequently replaced by the
+> single positive-length theorem
+> `MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary`, whose
+> bond-dimension bound is derived structurally, without an empty-word argument.
+
 > **PR split note.** This report describes the *combined* restoration across
 > two stacked pull requests:
 >

--- a/docs/paper-gaps/cpsv16_zero_tail_length_zero_decomposition.tex
+++ b/docs/paper-gaps/cpsv16_zero_tail_length_zero_decomposition.tex
@@ -9,7 +9,7 @@
 
 \newcommand{\MPV}[2]{V^{(#1)}\!\left(#2\right)}
 
-\title{The Length-Zero (``Zero-Tail'') Bookkeeping in the\\
+\title{Removing Length-Zero Bookkeeping from the\\
   Blocked Canonical-Form Decomposition}
 \author{}
 \date{2026-05-30}
@@ -20,12 +20,11 @@
 \noindent
 This note explains why carrying the blocked canonical-form decomposition as an
 \emph{all-length} matrix-product-vector identity is the wrong formal shape, and
-records the clean replacement together with the one place where the formal
-development still keeps the awkward form.\footnote{%
+records its removal from the physical canonical-form statements.\footnote{%
   Context: PRs \ghpr{2153}, \ghpr{2156}, and \ghpr{2167} removed roughly a
   thousand lines of ``zero-tail'' plumbing built on the all-length form
   discussed here. This note records why that form is a non-source-faithful
-  overcomplication and what remains.}
+  overcomplication and why it has now been removed.}
 
 \section{The assertion}
 
@@ -102,20 +101,16 @@ Separate the two facts. The positive-length comparison
   = \MPV{N}{\textstyle\bigoplus_k \mu_k B_k}_\sigma
   \qquad (N\ge 1)\label{eq:pos}
 \end{align}
-carries all of the mathematics, and the length-zero coefficient is recovered
-\emph{once}, where an all-length statement is genuinely needed, from the single
-dimension identity~\eqref{eq:dim}: if two tensors agree at all positive lengths
-and have equal bond dimension, they agree at length zero as well, because the
-empty-word coefficient is the bond dimension.\footnote{%
-  Formally, positive-length equality is \leanid{SameMPV₂Pos} and the one-step
-  upgrade is
-  \leanid{SameMPV₂Pos.toSameMPV₂_of_bondDim_eq} in
-  \doclink{TNLean/MPS/Defs}. The canonical-form predicate now stores
-  \leanid{SameMPV₂Pos} together with a single bond-dimension field rather than
-  the all-length decomposition; see \ghpr{2153}.}
-This is the source-faithful shape: the nonzero normal blocks are compared at
-positive length, and the zero block appears only as the scalar~$z$
-in~\eqref{eq:dim}.
+carries all of the physical mathematics. The direct-sum induction independently
+gives the structural identity for the unfiltered irreducible blocks. After the
+all-zero blocks are discarded, this implies only the bound needed downstream,
+\begin{align}
+  \sum_kD_k\leq D.\label{eq:bound}
+\end{align}
+Thus no physical theorem needs an empty-word coefficient or a scalar recording
+the discarded bond-space dimension. Formally, positive-length equality is
+\leanid{SameMPV₂Pos}; the canonical-form reduction carries
+\eqref{eq:pos} and~\eqref{eq:bound}.
 
 \section{Formal status}
 
@@ -123,19 +118,20 @@ in~\eqref{eq:dim}.
 \path{thm:tp_primitive_blockdecomp} in
 \path{blueprint/src/chapter/ch09_canonical.tex}, now uses the
 source-faithful shape: its MPV clause is the positive-length comparison
-in~\eqref{eq:pos}, and the empty-word contribution is the separate identity
-\(z+\sum_k D_k=D\).  The former support lemma
-\leanid{zeroTail_toTensorFromBlocks_blockPower} has therefore been removed.
+in~\eqref{eq:pos}, and its dimension clause is the bound~\eqref{eq:bound}.
+The intermediate declarations carrying \texttt{zeroTailDim}, as well as the
+former support lemma
+\leanid{zeroTail_toTensorFromBlocks_blockPower}, have therefore been removed.
 
 \section{Conclusion}
 
-The blocked canonical form~\eqref{eq:zero-block} is correct, and the dimension
-count~\eqref{eq:dim} is part of it. The former formal defect was one of shape:
+The block decomposition~\eqref{eq:zero-block} is correct as an intermediate
+linear-algebra statement. The former formal defect was one of shape:
 stating the reduction as the all-length matrix-product-vector
 identity~\eqref{eq:all-length} fused a trivial empty-word dimension count with
-the substantive positive-length comparison. The faithful statement is the
-positive-length comparison~\eqref{eq:pos} with the length-zero coefficient
-restored once from~\eqref{eq:dim}. The development now uses this shape in the
+the substantive positive-length comparison. The physical statement is the
+positive-length comparison~\eqref{eq:pos} together with the structural
+bound~\eqref{eq:bound}. The development now uses this shape throughout the
 after-blocking primitive decomposition and its downstream consumers.
 
 \bibliographystyle{alpha}

--- a/docs/paper-gaps/mps_common_blocking_span_equality.tex
+++ b/docs/paper-gaps/mps_common_blocking_span_equality.tex
@@ -92,18 +92,13 @@ proportional and equal MPV fundamental theorems in the same form
 
 \section{The formal argument}
 
-The formal equality relation \leanid{SameMPV}\textsubscript{2} compares matrix product
-vector coefficients for all finite words, including the empty word.
-This convention is stronger than the positive-length family in the source
-definition. An all-zero block of bond dimension $D_0$ contributes nothing at
-positive length, but it contributes $D_0$ at length zero, because the empty product
-has trace $D_0$. Consequently the formal proof separates the zero-tail
-contribution from the nonzero part, proves positive-length equality for the
-nonzero parts, and records the exact $N=0$ identity separately.\footnote{See
-the zero-block separation section of the canonical-form chapter and the
-corresponding zero-tail formalization in
-\path{TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean} and
-\path{TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean}.}
+The canonical-form reduction uses the positive-length relation
+\leanid{SameMPV₂Pos}, matching the family in the source definition. All-zero
+blocks contribute nothing at positive length and are discarded. The total bond
+dimension of the retained family is bounded directly by the structural
+direct-sum identity, without an empty-word comparison.\footnote{See
+\leanid{exists_irreducible_blockDecomp_nonzeroBlocks} and
+\leanid{exists_tp_gauge_from_arbitrary}.}
 
 The common blocking step is also more explicit. For a single family of blocks,
 the source phrase ``block by the least common multiple of the periods'' hides no
@@ -118,9 +113,7 @@ part of the statement.\footnote{The common-sector data and the relabeling result
 are recorded in \path{blueprint/src/chapter/ch09_canonical.tex:1645--1824} and
 \path{blueprint/src/chapter/ch09_canonical.tex:3230--3284}. The main formal
 statement is
-\texttt{MPSTensor.fundamentalTheorem\_after\_blocking\_commonLength\_commonSector},
-with the one-sided relabeling-compatible zero-tail statement
-\texttt{MPSTensor.zeroTail\_commonFlat\_of\_reindexed}; see
+\texttt{MPSTensor.fundamentalTheorem\_after\_blocking\_commonLength\_commonSector}; see
 \path{TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean} and
 \path{TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean}.}
 This is why the canonical-form theorem supplies relabeled common-sector
@@ -169,8 +162,7 @@ for the phases supplied by the sector matching theorem.
 
 These distinctions are coupled in the single conversion from an arbitrary equality
 of MPV families to the hypotheses of the BNT sector-comparison theorem. The
-zero-tail convention determines what is known at length zero after each blocking.
-The common blocking construction determines the physical alphabet and the relabeled
+common blocking construction determines the physical alphabet and the relabeled
 sector families to which the coefficient comparison applies. Any later injectivity
 refinement is reserved for separate arguments, such as overlap-rigidity
 statements that require one-site injective blocks; it is not a hypothesis of the
@@ -179,8 +171,8 @@ copy-weight data are constructed for the relabeled nonzero-sector families, not
 for an earlier family before the common-alphabet relabeling.
 
 For this reason common blocking and coefficient comparison should be kept in one
-account. The formal proof needs the whole chain: remove the zero tail, choose one
-common physical blocking length, account for the word-relabeling, keep later
+account. The formal proof needs the whole chain: discard all-zero blocks at
+positive lengths, choose one common physical blocking length, account for the word-relabeling, keep later
 overlap-rigidity requirements separate, and turn BNT matching data into the
 sector coefficient identities and copy-weight equations used by the final gauge
 comparison.
@@ -209,17 +201,17 @@ invisible to positive-length MPVs, periods are removed by blocking, injectivity 
 obtained by a later Wielandt-type blocking, BNT bases are matched by phase and
 gauge, and coefficient multiplicities are recovered from power sums. The formal
 development exposes these operations as separate statements because the formal MPV
-relation includes the empty word, the two sides must be placed over one explicitly
-relabeled alphabet after blocking, and the downstream comparison theorem constructs
+relation is transported through explicit positive blocking, the two sides must be
+placed over one explicitly relabeled alphabet after blocking, and the downstream comparison theorem constructs
 matched-sector coefficient identities and copy-weight equations after this
 relabeling.
 
 Thus the comparison gives neither a counterexample nor a theorem-level source
 error. It explains why the formal proof cannot compress the argument into a
 single invocation of the BNT uniqueness theorem. The relevant comparison points are
-zero-tail cancellation, common primitive block construction, common blocking,
-zero-tail transport, matched-sector coefficient identities, copy-weight matching,
-and iterated-blocking relabeling.\footnote{For traceability, these are recorded in
+removal of all-zero blocks, common primitive block construction, common blocking,
+matched-sector coefficient identities, copy-weight matching, and iterated-blocking
+relabeling.\footnote{For traceability, these are recorded in
 \href{https://github.com/LionSR/TNLean/issues/652}{issue \#652},
 \href{https://github.com/LionSR/TNLean/issues/942}{issue \#942},
 \href{https://github.com/LionSR/TNLean/issues/969}{issue \#969},

--- a/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
+++ b/docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
@@ -246,43 +246,18 @@ The earlier existence path now has the following formal pieces.
           family.  This closes the blockwise assembly step after the
           irreducible summands have already been obtained.  It is still not
           the full source theorem, because the statement assumes the prepared
-          nonzero irreducible decomposition and does not yet incorporate the
-          arbitrary-input zero-block separation or the final total
-          bond-dimension bound.
+          nonzero irreducible decomposition.
 
     \item
-          \path|MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail|
-          composes the zero-block separation with the preceding blockwise
-          PGVWC07 theorem.  Starting from an arbitrary tensor, it retains the
-          all-zero summands as one zero block and puts the nonzero part into
-          the unital orientation, with positive spectral-radius weights,
-          scalar transfer-map fixed points, and diagonal positive-definite dual
-          fixed points.  This removes the prepared-family hypothesis from the
-          blockwise statement while still keeping the zero-block contribution
-          explicit in the finite-ring MPV identity.  It is still not the full
-          source theorem; this theorem itself does not include the final
-          total bond-dimension bound.
-
-    \item
-          \path|MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound|
-          adds the length-zero trace calculation to the preceding arbitrary
-          tensor theorem.  It proves
-          \(D_0+\sum_k D_k=D\), where \(D_0\) is the retained zero-block bond
-          dimension and the \(D_k\) are the nonzero block dimensions.  Hence
-          \(\sum_k D_k\leq D\), matching the total bond-dimension estimate in
-          Theorem~\texttt{Th:TIcanonical}, lines 761--762, while still keeping
-          the zero block explicit.
-
-    \item
-          \path|MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_posMPV_bondDimBound|
-          removes the explicit zero-block summand from the displayed MPV
-          identity by restricting the equality to positive chain lengths.
-          The zero block has no positive-length coefficients, so the nonzero
-          weighted direct sum has the same positive-length MPV family as the
-          original tensor, and the estimate \(\sum_k D_k\leq D\) is retained.
-          This matches the source theorem on nonempty rings.  A statement that
-          also quantifies over the empty word must either keep the zero block or
-          separately account for its bond dimension.
+          \path|MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary|
+          composes the positive-length nonzero-block decomposition with the
+          preceding blockwise PGVWC07 theorem. Starting from an arbitrary
+          tensor, it discards all-zero blocks, which vanish on nonempty rings,
+          and puts the retained blocks into the unital orientation, with
+          positive spectral-radius weights, scalar transfer-map fixed points,
+          and diagonal positive-definite dual fixed points. The structural
+          dimension identity for the original direct sum gives
+          \(\sum_k D_k\leq D\); no empty-word trace calculation is used.
 
     \item
           \path|MPSTensor.PGVWC07PositiveLengthWitness| and
@@ -334,9 +309,8 @@ The earlier existence path now has the following formal pieces.
           records the arbitrary-input zero/nonzero dichotomy for the exact
           rescaled formulation.  Either all positive-length MPV coefficients of
           the original tensor vanish, or the preceding exact rescaled normalized
-          PGVWC07 form exists.  This still keeps the zero positive-length branch
-          explicit and therefore does not by itself settle the final length-zero
-          convention for Theorem~\texttt{Th:TIcanonical}.
+          PGVWC07 form exists. The next theorem absorbs the zero branch into an
+          empty retained block family.
 
     \item
           \path|MPSTensor.exists_pgvwc07_normalized_exact_form_after_rescaling_allow_empty|
@@ -351,36 +325,29 @@ The earlier existence path now has the following formal pieces.
           normalized weighted block tensor has the same coefficients on every
           nonempty ring, and \(\sum_k D_k\leq D\).
 
-    \item
-          \path|MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound|
-          records the complementary explicit all-zero direct-summand convention before the
-          final finite-family weight normalization.  It keeps the all-zero summand
-          dimension from the arbitrary-input decomposition, proves
-          positive-length agreement with the weighted nonzero blocks, and
-          records the length-zero dimension identity
-          \(D_0+\sum_kD_k=D\), together with the bond-dimension bound.
-
     \item \path|MPSTensor.exists_irreducible_blockDecomp| formalizes the
           recursive invariant-projection splitting used in the proof of
           Theorem~\texttt{Th:TIcanonical}, lines 765--833. It starts from an
           arbitrary tensor and gives a finite direct sum of irreducible blocks
-          with the same matrix-product-vector coefficients. This is a faithful
-          partial proof step. It is not the full source theorem, because it does
+          with the same matrix-product-vector coefficients and the structural
+          identity \(\sum_kD_k=D\). This is a faithful partial proof step. It is
+          not the full source theorem, because it does
           not construct the weights $\lambda_j$, the unital block orientation,
           the diagonal full-rank matrices $\Lambda^j$, the uniqueness of the
           identity fixed point, or the final bond-dimension bound.
 
     \item \path|MPSTensor.exists_irreducible_blockDecomp_nonzeroBlocks|
-          separates the all-zero blocks from the irreducible summands and keeps
-          the length-zero trace contribution. This matches the paper's statement
-          that zero blocks may occur, but it is still only an intermediate
-          decomposition before Perron--Frobenius normalization.
+          discards the all-zero irreducible summands at positive lengths and
+          retains only blocks with a nonzero Kraus operator. It proves
+          positive-length MPV equality, positive block dimensions, and
+          \(\sum_kD_k\leq D\) directly from the preceding structural identity.
 
-    \item \path|MPSTensor.exists_tp_gauge_from_arbitrary_with_zeroTail|
+    \item \path|MPSTensor.exists_tp_gauge_from_arbitrary|
           applies Perron--Frobenius normalization block by block after the
-          all-zero summands have been separated. It produces nonzero
+          all-zero summands have been discarded. It produces nonzero
           irreducible blocks in the local left-canonical orientation
-          $\sum_i (B_k^i)^\dagger B_k^i = \mathbf{1}$. This is the dual
+          $\sum_i (B_k^i)^\dagger B_k^i = \mathbf{1}$ and preserves the
+          bond-dimension bound. This is the dual
           orientation of the unital condition in
           Theorem~\texttt{Th:TIcanonical}; the conversion is a convention issue
           only when the adjoint transfer map is carried along explicitly.
@@ -427,13 +394,10 @@ points, and the bond-dimension bound.  The nonzero-block family is allowed to
 be empty exactly in the case where every positive-length MPV coefficient
 vanishes.
 
-The explicit zero-block/length-zero bookkeeping is recorded earlier by
-\path|MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary_with_zeroTail_bondDimBound|.
-It keeps the all-zero summand dimension, gives positive-length agreement with the
-weighted nonzero blocks, and proves \(D_0+\sum_kD_k=D\), together with the
-bond-dimension bound.  This is the companion length-zero convention before the
-final finite-family weight normalization, while the blueprint cites the
-positive-length theorem as the primary statement.
+The preceding theorem
+\path|MPSTensor.exists_pgvwc07_unital_dualDiag_from_arbitrary| supplies the
+unnormalized positive-length block family and its bond-dimension bound directly,
+without a separate empty-word convention.
 
 The remaining conditional primitive, peripheral-primitive, and
 normal-canonical-form reductions are later consequences used only after their


### PR DESCRIPTION
## Mathematical change

Physical matrix product vectors are compared only at positive chain lengths. The arbitrary-input canonical-form reduction therefore discards all-zero irreducible summands immediately, instead of retaining a fictitious zero-tail dimension to reproduce the empty-word coefficient.

The dimension estimate now comes from the invariant-subspace decomposition itself:

- the recursive irreducible decomposition proves that the block dimensions sum to the original bond dimension;
- filtering to nonzero blocks gives a sum bounded by the original bond dimension;
- blockwise gauges preserve the index family and every block dimension, so the bound passes through without an N = 0 comparison.

This removes the zero-tail theorem family and its empty-word dimension-recovery arguments, and propagates the positive-length statement through the TP-gauge and primitive-block reductions. The blueprint and the relevant paper-gap records are updated accordingly.

## Paper alignment

The changes follow PGVWC07, Theorem Th:TIcanonical, proof lines 761--832, and CPSV16, equation II_Aiplusk1, Section II.C, and Appendix A. The deviations and their resolution are recorded in:

- docs/paper-gaps/cpsv16_zero_tail_length_zero_decomposition.tex
- docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex
- docs/paper-gaps/mps_common_blocking_span_equality.tex

No incomplete proof is introduced. The deleted declaration names encoded the discarded empty-chain convention, so no deprecated aliases are retained.

## Verification

- Lean 4.32.0
- lake build TNLean: 9,533 targets passed
- kernel axiom audit of all changed public theorems: only propext, Classical.choice, and Quot.sound
- leanblueprint checkdecls passed
- blueprint synchronization and changed-prose checks passed
- strict tensor-diagram audit and smoke rendering passed for all 114 diagrams
- no new sorry, axiom, admit, native_decide, or unsafeCast
- diff: 320 insertions, 579 deletions

Closes #4101.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large refactor across core canonical-form APIs and blueprint bindings; mathematical behavior shifts from all-length MPV bookkeeping to positive-length conventions, though proofs are described as complete with no new axioms.
> 
> **Overview**
> Physical comparisons use **positive-length** matrix product vectors only. The reduction **drops all-zero irreducible blocks** instead of carrying a `zeroTailDim` and recovering bond dimension at length zero.
> 
> **`exists_irreducible_blockDecomp`** now also proves **∑ block dimensions = D** from the direct-sum induction. **`exists_irreducible_blockDecomp_nonzeroBlocks`** filters to nonzero blocks, states **`SameMPV₂Pos`**, and concludes **∑ dim ≤ D** from that identity—no split of zero vs. nonzero MPV sums at `N = 0`.
> 
> The zero-tail theorem family is **removed** and replaced by **`exists_pgvwc07_unital_dualDiag_from_arbitrary`** and **`exists_tp_gauge_from_arbitrary`**, each with **∑ dim ≤ D**. Blockwise PGVWC07/TP gauge theorems **keep the same block index set and dimensions** (no extra reindexing layer). Downstream **sector comparison**, **TP-primitive blocking**, blueprint **ch09**, and **paper-gap** docs are updated to the same positive-length + structural bound story.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf81d26363307fed81f5e2e10394c61464656aab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->