### PR TITLE
refactor(MPS): restrict physical comparisons to positive lengths

### DIFF
--- a/TNLean/MPS/CanonicalForm/CyclicSectors/CompressionPositive.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors/CompressionPositive.lean
@@ -67,20 +67,14 @@ theorem exists_compressedTensor_of_supported_projection_pos_mpv
           _ = A i * evalWord A w := by rw [hleft i]
           _ = evalWord A (i :: w) := by rfl
   intro N hN σ
-  cases N with
-  | zero =>
-      cases Nat.not_lt_zero _ hN
-  | succ n' =>
-      have hPw :
-          P * evalWord A (List.ofFn σ) = evalWord A (List.ofFn σ) := by
-        apply hword
-        simpa only [List.ofFn_succ] using
-          (List.cons_ne_nil (σ 0) (List.ofFn fun i => σ i.succ))
-      calc
-        mpv A σ = Matrix.trace (evalWord A (List.ofFn σ)) := by rfl
-        _ = Matrix.trace (P * evalWord A (List.ofFn σ)) :=
-              congrArg Matrix.trace hPw.symm
-        _ = mpv C σ := (hCmpv n'.succ σ).symm
+  have hPw : P * evalWord A (List.ofFn σ) = evalWord A (List.ofFn σ) := by
+    apply hword
+    exact List.ne_nil_of_length_pos (by simpa only [List.length_ofFn] using hN)
+  calc
+    mpv A σ = Matrix.trace (evalWord A (List.ofFn σ)) := by rfl
+    _ = Matrix.trace (P * evalWord A (List.ofFn σ)) :=
+          congrArg Matrix.trace hPw.symm
+    _ = mpv C σ := (hCmpv N σ).symm
 
 end CompressionPositiveMPV
 

--- a/TNLean/MPS/CanonicalForm/ProjectorClosureDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/ProjectorClosureDecomposition.lean
@@ -30,7 +30,7 @@ The remaining steps towards the full sufficient condition for canonical form —
 rescaling each block to spectral radius one and converting the absence of
 nontrivial periodic vectors into primitivity of every rescaled block — are
 carried out in `TNLean.MPS.CanonicalForm.ProjectorClosureSpectral`; the
-length-zero convention for zero blocks is recorded in
+positive-length treatment of zero blocks is recorded in
 `docs/paper-gaps/cpsv16_projector_closure_canonical_form.tex`.
 -/
 

--- a/TNLean/MPS/CanonicalForm/ProjectorClosureSpectral.lean
+++ b/TNLean/MPS/CanonicalForm/ProjectorClosureSpectral.lean
@@ -33,12 +33,9 @@ are those of arXiv:1606.00608, lines 220--230:
 
 Corners carrying the zero tensor cannot be rescaled to spectral radius one;
 they are the zero blocks of eq:II_Aiplusk1 (line 219, `∑ₖ Dₖ ≤ D`).  They
-contribute their bond dimension only to the length-zero coefficient, so the
-main conclusion states matrix-product-vector equality at every positive length
-together with the dimension bound `∑ₖ Dₖ ≤ D`.  When no corner carries the
-zero tensor the equality holds at every length, including zero; this variant
-is stated separately with the explicit no-zero-corner hypothesis.  The
-length-zero convention is recorded in
+vanish from every positive-length matrix product vector, so the conclusion
+retains only the nonzero corners and the structural dimension bound `∑ₖ Dₖ ≤ D`.
+The positive-length convention is recorded in
 `docs/paper-gaps/cpsv16_projector_closure_canonical_form.tex`.
 -/
 
@@ -244,12 +241,8 @@ matrix product vectors, with the source convention `∑ₖ Dₖ ≤ D` that allo
 zero blocks (eq:II_Aiplusk1, line 219).
 
 Corners of `A` carrying the zero tensor cannot be rescaled to spectral radius
-one and are omitted from the direct sum; each contributes its bond dimension
-only to the length-zero coefficient.  The variant
-`MPSTensor.exists_normalTensor_blockDecomp_sameMPV₂_of_hasInvariantProjectorClosure`
-states equality at every length under the explicit additional hypothesis that
-no irreducible corner of `A` carries the zero tensor.  The length-zero
-convention is recorded in
+one and are omitted from the direct sum because they vanish at every positive
+length. The positive-length convention is recorded in
 `docs/paper-gaps/cpsv16_projector_closure_canonical_form.tex`. -/
 theorem exists_normalTensor_blockDecomp_sameMPV₂Pos_of_hasInvariantProjectorClosure
     (A : MPSTensor d D) (hClosure : HasInvariantProjectorClosure A)
@@ -333,63 +326,5 @@ theorem exists_normalTensor_blockDecomp_sameMPV₂Pos_of_hasInvariantProjectorCl
       _ ≤ ∑ k : Fin r₀, dim₀ k :=
           Finset.sum_le_sum_of_subset (Finset.filter_subset _ _)
       _ = D := hDim
-
-/-- All-lengths variant of the sufficient condition for canonical form
-(arXiv:1606.00608, lines 253--255).
-
-**Scope restriction (no zero corners):** in addition to the source hypotheses,
-every irreducible corner of `A` of positive dimension is assumed to carry a
-nonzero letter matrix.  Without this hypothesis a corner may be the zero
-tensor, which cannot be rescaled to spectral radius one; the source drops
-such zero blocks (eq:II_Aiplusk1, line 219, `∑ₖ Dₖ ≤ D`), which changes the
-length-zero coefficient.  The premise `0 < n` excludes only the
-zero-dimensional corner, whose letter matrices all vanish for lack of
-entries; without it no tensor could satisfy the hypothesis.  The
-unrestricted positive-length statement is
-`MPSTensor.exists_normalTensor_blockDecomp_sameMPV₂Pos_of_hasInvariantProjectorClosure`.
-The restriction is recorded in
-`docs/paper-gaps/cpsv16_projector_closure_canonical_form.tex`. -/
-theorem exists_normalTensor_blockDecomp_sameMPV₂_of_hasInvariantProjectorClosure
-    (A : MPSTensor d D) (hClosure : HasInvariantProjectorClosure A)
-    (hPer : HasNoPeriodicVectors A)
-    (hcorner : ∀ ⦃n : ℕ⦄ (V : Matrix (Fin D) (Fin n) ℂ) (B : MPSTensor d n),
-      0 < n → Vᴴ * V = 1 → (∀ i : Fin d, A i * V = V * B i) → IsIrreducibleTensor B →
-      ∃ i, B i ≠ 0) :
-    ∃ (r : ℕ) (dim : Fin r → ℕ) (μ : Fin r → ℂ)
-      (blocks : (k : Fin r) → MPSTensor d (dim k)),
-      SameMPV₂ A (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
-      (∀ k, IsNormalTensor (blocks k)) ∧
-      (∀ k, μ k ≠ 0) := by
-  classical
-  obtain ⟨r₀, dim₀, blocks₀, V, hpos, hiso, hsum, -, hint, -, -, hirr, hSame⟩ :=
-    exists_irreducible_blockDecomp_with_isometry_of_hasInvariantProjectorClosure A hClosure
-  have hPF : ∀ k : Fin r₀,
-      ∃ (ρ : Matrix (Fin (dim₀ k)) (Fin (dim₀ k)) ℂ) (t : ℝ),
-        ρ.PosDef ∧ 0 < t ∧
-        transferMap (d := d) (D := dim₀ k) (blocks₀ k) ρ = (t : ℂ) • ρ := by
-    intro k
-    haveI : NeZero (dim₀ k) := ⟨(hpos k).ne'⟩
-    exact exists_posDef_transferMap_eigenvector_of_irreducible (blocks₀ k) (hirr k)
-      (hcorner (V k) (blocks₀ k) (hpos k) (hiso k) (hint k) (hirr k))
-  choose ρf tf hρf htf hEigf using hPF
-  have hsqrt_ne : ∀ k : Fin r₀, ((Real.sqrt (tf k) : ℝ) : ℂ) ≠ 0 := fun k =>
-    Complex.ofReal_ne_zero.mpr (Real.sqrt_pos.mpr (htf k)).ne'
-  refine ⟨r₀, dim₀, fun k => ((Real.sqrt (tf k) : ℝ) : ℂ),
-    fun k => fun i => (((Real.sqrt (tf k) : ℝ) : ℂ))⁻¹ • blocks₀ k i,
-    ?_, ?_, fun k => hsqrt_ne k⟩
-  · -- Matrix product vector equality at every length.
-    intro N σ
-    rw [hSame N σ, mpv_toTensorFromBlocks_eq_sum, mpv_toTensorFromBlocks_eq_sum]
-    refine Finset.sum_congr rfl fun k _ => ?_
-    rw [mpv_smul, one_pow, one_smul, smul_eq_mul, ← mul_assoc, ← mul_pow,
-      mul_inv_cancel₀ (hsqrt_ne k), one_pow, one_mul]
-  · -- Every rescaled corner is a normal tensor.
-    intro k
-    haveI : NeZero (dim₀ k) := ⟨(hpos k).ne'⟩
-    refine isNormalTensor_invSqrt_smul_of_unique_peripheral (blocks₀ k) (hirr k)
-      (ρf k) (tf k) (hρf k) (htf k) (hEigf k) ?_
-    intro μ hμ hnorm
-    exact hPer (V k) (blocks₀ k) (ρf k) (tf k) (hiso k) (hint k) (hirr k)
-      (hρf k) (htf k) (hEigf k) μ hμ hnorm
 
 end MPSTensor

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean
@@ -20,9 +20,9 @@ to compare the resulting sector families.
 
 ## Main statements
 
-* `afterBlocking_perBlockCyclicData_of_sameMPV₂` — per-block weights, blocks,
+* `afterBlocking_perBlockCyclicData_of_sameMPV₂Pos` — per-block weights, blocks,
   cyclic-sector decompositions, and positive-length nonzero-sector identities.
-* `afterBlocking_commonLengthCommonSectorData_of_sameMPV₂` — a two-sided
+* `afterBlocking_commonLengthCommonSectorData_of_sameMPV₂Pos` — a two-sided
   common blocking length with common-sector families.
 
 ## References
@@ -44,7 +44,7 @@ section FundamentalTheoremAfterBlocking
 /-- **Per-block cyclic-sector decomposition after removing zero blocks.**
 
 This is the faithful predecessor to the common nonzero-sector statement. From
-`SameMPV₂ A B`, it discards the all-zero blocks at positive lengths and then
+`SameMPV₂Pos A B`, it discards the all-zero blocks at positive lengths and then
 applies the TP gauge to obtain irreducible nonzero-weight blocks on both sides. It then removes the
 period of each block separately, producing primitive irreducible cyclic sectors for every
 nonzero-weight block. The tensor on each side agrees with its nonzero part at every positive
@@ -61,10 +61,10 @@ Source: Pérez-García, Verstraete, Wolf, and Cirac, Theorem `Th:TIcanonical`, p
 `eq:II_Aiplusk1`, Section II.C, and Appendix A, for removing zero blocks and resolving periodic
 blocks into cyclic sectors. The positive-length convention is recorded in
 `docs/paper-gaps/cpsv16_zero_tail_length_zero_decomposition.tex`. -/
-theorem afterBlocking_perBlockCyclicData_of_sameMPV₂
+theorem afterBlocking_perBlockCyclicData_of_sameMPV₂Pos
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
-    (hSame : SameMPV₂ A B) :
+    (hSame : SameMPV₂Pos A B) :
     ∃ (rA : ℕ) (dimA : Fin rA → ℕ) (μA : Fin rA → ℂ)
       (blocksA : (k : Fin rA) → MPSTensor d (dimA k)),
     ∃ (rB : ℕ) (dimB : Fin rB → ℕ) (μB : Fin rB → ℂ)
@@ -94,7 +94,7 @@ theorem afterBlocking_perBlockCyclicData_of_sameMPV₂
   have hBook : SameMPV₂Pos
       (toTensorFromBlocks (d := d) (μ := μA) blocksA)
       (toTensorFromBlocks (d := d) (μ := μB) blocksB) :=
-    (hAPos.symm.trans hSame.toSameMPV₂Pos).trans hBPos
+    (hAPos.symm.trans hSame).trans hBPos
   refine ⟨rA, dimA, μA, blocksA, rB, dimB, μB, blocksB,
     hIrrA, hIrrB, hTPA, hTPB, hμA, hμB, hDimA, hDimB, hAPos, hBPos,
     hBook, ?_, ?_⟩
@@ -111,16 +111,16 @@ theorem afterBlocking_perBlockCyclicData_of_sameMPV₂
 
 /-- **Two-sided common-length relabeled cyclic-sector theorem.**
 
-Starting from `SameMPV₂ A B`, this theorem chooses one positive physical blocking
+Starting from `SameMPV₂Pos A B`, this theorem chooses one positive physical blocking
 length for both sides.  At that common length it gives, for each side, the
 positive-length equality between the blocked tensor and its weighted nonzero part,
 the positive-length equality of the two nonzero parts, the relabeled
 cyclic-sector families produced by `CommonBlockedCyclicSectorFamily`, and the
 structural hypotheses for their flattened sector blocks. -/
-theorem afterBlocking_commonLengthCommonSectorData_of_sameMPV₂
+theorem afterBlocking_commonLengthCommonSectorData_of_sameMPV₂Pos
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
-    (hSame : SameMPV₂ A B) :
+    (hSame : SameMPV₂Pos A B) :
     ∃ (p : ℕ), 0 < p ∧
     ∃ (rA : ℕ) (dimA : Fin rA → ℕ) (μA : Fin rA → ℂ)
       (blocksA : (k : Fin rA) → MPSTensor d (dimA k)),
@@ -167,7 +167,7 @@ theorem afterBlocking_commonLengthCommonSectorData_of_sameMPV₂
       rB, dimB, μB, blocksB,
       _hIrrA, _hIrrB, _hTPA, _hTPB, hμA, hμB, _hDimA, _hDimB,
       hAPos, hBPos, hPos, hCycA, hCycB⟩ :=
-    afterBlocking_perBlockCyclicData_of_sameMPV₂ A B hSame
+    afterBlocking_perBlockCyclicData_of_sameMPV₂Pos A B hSame
   let periodA : Fin rA → ℕ := fun k => (hCycA k).choose
   let periodB : Fin rB → ℕ := fun k => (hCycB k).choose
   have periodA_pos : ∀ k, 0 < periodA k := fun k => (hCycA k).choose_spec.1
@@ -255,7 +255,7 @@ theorem afterBlocking_commonLengthCommonSectorData_of_sameMPV₂
 /-!
 ### What remains for the full 1606.00608 Fundamental Theorem
 
-The complete fundamental theorem should take two tensors `A, B` with `SameMPV₂ A B`
+The complete fundamental theorem should take two tensors `A, B` with `SameMPV₂Pos A B`
 and pass from the blocked reduction witnesses to the CPSV basis-of-normal-tensors
 sector comparison. The one-sided phase-class BNT construction is available as
 `exists_bnt_sectorDecomp_of_tp_primitive_irr_blocks`; the remaining overlap/span

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorTransport.lean
@@ -34,7 +34,8 @@ matrix product states, canonical form, common sectors
 
 /-- **Unconditional common primitive irreducible block decompositions.**
 
-Two tensors with the same MPV family have one common positive blocking length
+Two tensors with the same MPV family at every positive length have one common positive blocking
+length
 whose nonzero parts are weighted families of trace-preserving, primitive,
 tensor-irreducible blocks with positive bond dimensions and nonzero weights. At
 every positive length each blocked tensor equals its nonzero part, and the two
@@ -50,7 +51,7 @@ multi-block comparison. -/
 theorem unconditional_commonPrimitiveIrreducibleBlocks
     {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
-    (hSame : SameMPV₂ A B) :
+    (hSame : SameMPV₂Pos A B) :
     ∃ p : ℕ, 0 < p ∧
     ∃ (rA : ℕ) (dimA : Fin rA → ℕ) (μA : Fin rA → ℂ)
       (blocksA : (x : Fin rA) → MPSTensor (blockPhysDim d p) (dimA x)),
@@ -79,7 +80,7 @@ theorem unconditional_commonPrimitiveIrreducibleBlocks
       rB₀, dimB₀, μB₀, blocksB₀, familyA, familyB,
       hFamilyA, hFamilyB, hAPosCanon, hBPosCanon, hPosCanon,
       hμA, hμB, hTPA, hTPB, hPrimA, hPrimB, hIrrA, hIrrB, hDimA, hDimB⟩ :=
-    afterBlocking_commonLengthCommonSectorData_of_sameMPV₂ A B hSame
+    afterBlocking_commonLengthCommonSectorData_of_sameMPV₂Pos A B hSame
   have hFlatA_raw := familyA.reindexed_nonzero_part μA₀
   have hFlatB_raw := familyB.reindexed_nonzero_part μB₀
   let flatBlocksA : (x : Fin (∑ k : Fin rA₀, familyA.period k)) →

--- a/TNLean/MPS/Defs.lean
+++ b/TNLean/MPS/Defs.lean
@@ -169,19 +169,6 @@ theorem SameMPV₂.toSameMPV₂Pos {d D₁ D₂ : ℕ}
     (h : SameMPV₂ A B) : SameMPV₂Pos A B :=
   fun N _hN σ => h N σ
 
-/-- Positive-length MPV equality plus equality of bond dimensions gives full MPV equality.
-
-This isolates the length-zero contribution: at `N = 0`, the MPV coefficient is just the
-bond dimension. -/
-theorem SameMPV₂Pos.toSameMPV₂_of_bondDim_eq {d D₁ D₂ : ℕ}
-    {A : MPSTensor d D₁} {B : MPSTensor d D₂}
-    (h : SameMPV₂Pos A B) (hD : D₁ = D₂) : SameMPV₂ A B := by
-  intro N σ
-  by_cases hN : N = 0
-  · subst N
-    rw [mpv_zero_length, mpv_zero_length, hD]
-  · exact h N (Nat.pos_of_ne_zero hN) σ
-
 /-- Positive-length MPV equality is symmetric. -/
 theorem SameMPV₂Pos.symm {d D₁ D₂ : ℕ}
     {A : MPSTensor d D₁} {B : MPSTensor d D₂}
@@ -194,21 +181,21 @@ theorem SameMPV₂Pos.trans {d D₁ D₂ D₃ : ℕ}
     (hAB : SameMPV₂Pos A B) (hBC : SameMPV₂Pos B C) : SameMPV₂Pos A C :=
   fun N hN σ => (hAB N hN σ).trans (hBC N hN σ)
 
-/-- Weak scalar proportionality of MPVs.
+/-- Weak scalar proportionality of positive-length MPVs.
 
-For each `N` there exists `c_N` with `V_N(A) = c_N · V_N(B)`.  The scalar is
-not required to be nonzero.  Use `NonzeroProportionalMPV₂` for the projective
-proportionality hypothesis in arXiv:1606.00608, Theorem `thm1`. -/
+For each `N > 0` there exists `c_N` with `V_N(A) = c_N · V_N(B)`.  The scalar is not
+required to be nonzero.  Use `NonzeroProportionalMPV₂` for the projective proportionality
+hypothesis in arXiv:1606.00608, Theorem `thm1`, lines 1167--1170. -/
 def ProportionalMPV₂ {d D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂) : Prop :=
-  ∀ N : ℕ, ∃ c : ℂ, ∀ σ : Fin N → Fin d, mpv A σ = c * mpv B σ
+  ∀ N : ℕ, 0 < N → ∃ c : ℂ, ∀ σ : Fin N → Fin d, mpv A σ = c * mpv B σ
 
 /-- Nonzero proportionality of MPV families.
 
 Source: arXiv:1606.00608, Theorem `thm1`, lines 1167--1170. This is the
 formal reading of the source statement that two tensors generate MPV that are
-proportional to each other: at each length the two MPV vectors lie on the same
-nonzero projective line, with proportionality scalar allowed to depend on the
-length.
+proportional to each other: at each positive length the two MPV vectors lie on
+the same nonzero projective line, with proportionality scalar allowed to depend
+on the length. The empty word is not a physical chain.
 
 **Local fix (projective proportionality):** The source phrase
 "proportional to each other" is read projectively, so the scalar is nonzero.
@@ -216,7 +203,7 @@ This reading is documented in
 `docs/paper-gaps/cpsv16_nonzero_proportionality_reading.tex`. -/
 def NonzeroProportionalMPV₂ {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂) : Prop :=
-  ∀ N : ℕ, ∃ c : ℂ, c ≠ 0 ∧ ∀ σ : Fin N → Fin d, mpv A σ = c * mpv B σ
+  ∀ N : ℕ, 0 < N → ∃ c : ℂ, c ≠ 0 ∧ ∀ σ : Fin N → Fin d, mpv A σ = c * mpv B σ
 
 /-- Eventual nonzero proportionality of MPV families.
 
@@ -225,8 +212,8 @@ Source context: arXiv:1606.00608, Theorem `thm1`, line 1182 invokes Lemma
 the corresponding eventual version of the projective proportionality relation:
 for all sufficiently large lengths, the two MPV vectors lie on the same nonzero
 projective line. The theorem hypothesis in line 1169 gives the stronger
-all-length predicate `NonzeroProportionalMPV₂`; this predicate is used only for
-tail reductions where finitely many initial lengths are irrelevant to the
+positive-length predicate `NonzeroProportionalMPV₂`; this predicate is used only
+for tail reductions where finitely many initial lengths are irrelevant to the
 asymptotic conclusion. -/
 def EventuallyNonzeroProportionalMPV₂ {d D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂) : Prop :=
@@ -244,21 +231,23 @@ theorem NonzeroProportionalMPV₂.toProportionalMPV₂ {d D₁ D₂ : ℕ}
     {A : MPSTensor d D₁} {B : MPSTensor d D₂}
     (h : NonzeroProportionalMPV₂ A B) :
     ProportionalMPV₂ A B := by
-  intro N
-  rcases h N with ⟨c, _hc, hN⟩
-  exact ⟨c, hN⟩
+  intro N hN
+  rcases h N hN with ⟨c, _hc, hEq⟩
+  exact ⟨c, hEq⟩
 
-/-- All-length nonzero MPV proportionality gives eventual nonzero MPV proportionality.
+/-- Positive-length nonzero MPV proportionality gives eventual nonzero MPV proportionality.
 
 Source: arXiv:1606.00608, Theorem `thm1`, lines 1169--1182. The theorem assumes
-proportionality at every length; the proof later invokes the eventual
+proportionality at every positive length; the proof later invokes the eventual
 linear-independence Lemma `Lem1`, so the same hypothesis may be used in eventual
 form. -/
 theorem NonzeroProportionalMPV₂.eventually {d D₁ D₂ : ℕ}
     {A : MPSTensor d D₁} {B : MPSTensor d D₂}
     (h : NonzeroProportionalMPV₂ A B) :
     EventuallyNonzeroProportionalMPV₂ A B :=
-  Filter.Eventually.of_forall h
+  by
+    filter_upwards [Filter.eventually_gt_atTop 0] with N hN
+    exact h N hN
 
 /-- Nonzero MPV proportionality is symmetric.
 
@@ -269,14 +258,14 @@ theorem NonzeroProportionalMPV₂.symm {d D₁ D₂ : ℕ}
     {A : MPSTensor d D₁} {B : MPSTensor d D₂}
     (h : NonzeroProportionalMPV₂ A B) :
     NonzeroProportionalMPV₂ B A := by
-  intro N
-  rcases h N with ⟨c, hc, hN⟩
+  intro N hN
+  rcases h N hN with ⟨c, hc, hEq⟩
   refine ⟨c⁻¹, inv_ne_zero hc, fun σ => ?_⟩
   calc
     mpv B σ = c⁻¹ * (c * mpv B σ) := by
       rw [inv_mul_cancel_left₀ hc]
     _ = c⁻¹ * mpv A σ := by
-      rw [← hN σ]
+      rw [← hEq σ]
 
 /-- Eventual nonzero MPV proportionality is symmetric.
 
@@ -302,12 +291,12 @@ Source: arXiv:1606.00608, Corollary `II_cor2`, lines 1205--1217, supplies an
 equal-MPV hypothesis. This lemma only re-states that hypothesis as the
 corresponding instance of the proportional hypothesis in Theorem `thm1`, lines
 1167--1170. It is not a formalization of Corollary `II_cor2` itself. -/
-theorem SameMPV₂.toNonzeroProportionalMPV₂ {d D₁ D₂ : ℕ}
+theorem SameMPV₂Pos.toNonzeroProportionalMPV₂ {d D₁ D₂ : ℕ}
     {A : MPSTensor d D₁} {B : MPSTensor d D₂}
-    (h : SameMPV₂ A B) :
+    (h : SameMPV₂Pos A B) :
     NonzeroProportionalMPV₂ A B := by
-  intro N
-  exact ⟨1, one_ne_zero, fun σ => by simpa using h N σ⟩
+  intro N hN
+  exact ⟨1, one_ne_zero, fun σ => by simpa using h N hN σ⟩
 
 /-- Gauge equivalence up to a nonzero global scalar (a phase after normalization). -/
 def GaugePhaseEquiv {d D : ℕ} (A B : MPSTensor d D) : Prop :=

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/StrongMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/StrongMatch.lean
@@ -49,7 +49,7 @@ Given a sector `k` of `Q`, apply the exact matcher
 
 * feed `hQ`, `hP` (in that order);
 * supply the selected sector `k`; and
-* supply `SameMPV₂ Q.toTensor P.toTensor` via the symmetric flip of `hEqual`
+* supply `SameMPV₂Pos Q.toTensor P.toTensor` via the symmetric flip of `hEqual`
   (pointwise `.symm`).
 
 The result is a `j₀ : Fin P.basisCount` with `Q.basisDim k = P.basisDim j₀`,

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
@@ -451,7 +451,7 @@ blocks here to feed the `IsBNTCanonicalForm` constructor
 
 Construction steps:
 
-1. `unconditional_commonPrimitiveIrreducibleBlocks A A (fun _ _ => rfl)` —
+1. `unconditional_commonPrimitiveIrreducibleBlocks A A (fun _ _ _ => rfl)` —
    apply the two-sided arbitrary-input reduction at `B = A` to obtain a
    positive blocking length `p₀`, a left-canonical / primitive / irreducible
    nonzero-weight block family `blocksA`, and the positive-length identity
@@ -488,7 +488,7 @@ theorem exists_prepared_BNT_blocks_afterBlocking_pos
       hμA, _hμB, hTPA, _hTPB, hPrimA, _hPrimB,
       hIrrA, _hIrrB, hDimA, _hDimB⟩ :=
     unconditional_commonPrimitiveIrreducibleBlocks
-      (d := d) (D₁ := D) (D₂ := D) A A (fun _ _ => rfl)
+      (d := d) (D₁ := D) (D₂ := D) A A (fun _ _ _ => rfl)
   -- Step 2: common positive extra blocking that makes each block injective and
   -- preserves trace-preservation, transfer-map primitivity, and tensor
   -- irreducibility.

--- a/TNLean/MPS/MPDO/PostBlockedRepresentativeSpan.lean
+++ b/TNLean/MPS/MPDO/PostBlockedRepresentativeSpan.lean
@@ -305,19 +305,6 @@ theorem insertedTensor_basis_eq_of_sameMPV₂Pos_firstSiteActionAgree_of_basis_i
   exact hCF.insertedTensor_basis_eq_of_firstSiteActionAgree_of_basis_injective
     hInj (hAct.of_sameMPVPos hAP)
 
-/-- Full-MPV specialization of
-`insertedTensor_basis_eq_of_sameMPV₂Pos_firstSiteActionAgree_of_basis_injective`. -/
-theorem insertedTensor_basis_eq_of_sameMPV₂_firstSiteActionAgree_of_basis_injective
-    {D : ℕ} (A : MPSTensor d D)
-    (hCF : IsBNTCanonicalForm P)
-    (hInj : ∀ j, IsInjective (P.basis j))
-    (hAP : SameMPV₂ A P.toTensor)
-    {Y Z : Matrix (Fin d) (Fin d) ℂ}
-    (hAct : FirstSiteActionAgree A Y Z) :
-    ∀ j, insertedTensor Y (P.basis j) = insertedTensor Z (P.basis j) := by
-  exact hCF.insertedTensor_basis_eq_of_sameMPV₂Pos_firstSiteActionAgree_of_basis_injective
-    A hInj hAP.toSameMPV₂Pos hAct
-
 /-- Representative-grouped Lemma L before physical blocking.
 
 Suppose that every representative has full word span at one common positive
@@ -381,18 +368,6 @@ theorem insertedTensor_basis_eq_of_sameMPV₂Pos_firstSiteActionAgree_of_common_
   exact hCF.insertedTensor_basis_eq_of_firstSiteActionAgree_of_common_blockInjective
     L hL hInj (hAct.of_sameMPVPos hAP)
 
-/-- Full-MPV specialization of
-`insertedTensor_basis_eq_of_sameMPV₂Pos_firstSiteActionAgree_of_common_blockInjective`. -/
-theorem insertedTensor_basis_eq_of_sameMPV₂_firstSiteActionAgree_of_common_blockInjective
-    {D : ℕ} (A : MPSTensor d D) (hCF : IsBNTCanonicalForm P)
-    (L : ℕ) (hL : 0 < L) (hInj : ∀ j, IsNBlkInjective (P.basis j) L)
-    (hAP : SameMPV₂ A P.toTensor)
-    {Y Z : Matrix (Fin d) (Fin d) ℂ}
-    (hAct : FirstSiteActionAgree A Y Z) :
-    ∀ j, insertedTensor Y (P.basis j) = insertedTensor Z (P.basis j) := by
-  exact hCF.insertedTensor_basis_eq_of_sameMPV₂Pos_firstSiteActionAgree_of_common_blockInjective
-    A L hL hInj hAP.toSameMPV₂Pos hAct
-
 /-- Representative-grouped Lemma L for an unblocked BNT canonical form.
 
 Irreducibility, left-canonicality, and normalized self-overlap force each basis
@@ -424,16 +399,5 @@ theorem insertedTensor_basis_eq_of_sameMPV₂Pos_firstSiteActionAgree
     (hAct : FirstSiteActionAgree A Y Z) :
     ∀ j, insertedTensor Y (P.basis j) = insertedTensor Z (P.basis j) := by
   exact hCF.insertedTensor_basis_eq_of_firstSiteActionAgree (hAct.of_sameMPVPos hAP)
-
-/-- Full-MPV specialization of
-`insertedTensor_basis_eq_of_sameMPV₂Pos_firstSiteActionAgree`. -/
-theorem insertedTensor_basis_eq_of_sameMPV₂_firstSiteActionAgree
-    {D : ℕ} (A : MPSTensor d D) (hCF : IsBNTCanonicalForm P)
-    (hAP : SameMPV₂ A P.toTensor)
-    {Y Z : Matrix (Fin d) (Fin d) ℂ}
-    (hAct : FirstSiteActionAgree A Y Z) :
-    ∀ j, insertedTensor Y (P.basis j) = insertedTensor Z (P.basis j) := by
-  exact hCF.insertedTensor_basis_eq_of_sameMPV₂Pos_firstSiteActionAgree
-    A hAP.toSameMPV₂Pos hAct
 
 end MPSTensor.IsBNTCanonicalForm

--- a/TNLean/MPS/MPDO/RepresentativeGroupedLemmaL.lean
+++ b/TNLean/MPS/MPDO/RepresentativeGroupedLemmaL.lean
@@ -218,16 +218,4 @@ theorem insertedTensor_basis_eq_of_sameMPV₂Pos_firstSiteActionAgree
   exact P.insertedTensor_basis_eq_of_firstSiteActionAgree hSpan
     (hAct.of_sameMPVPos hAP)
 
-/-- Full-MPV specialization of
-`insertedTensor_basis_eq_of_sameMPV₂Pos_firstSiteActionAgree`. -/
-theorem insertedTensor_basis_eq_of_sameMPV₂_firstSiteActionAgree
-    {D : ℕ} (A : MPSTensor d D) (P : SectorDecomposition d)
-    {Y Z : Matrix (Fin d) (Fin d) ℂ}
-    (hAP : SameMPV₂ A P.toTensor)
-    (hSpan : P.EventuallyRepresentativeWordTupleSpan)
-    (hAct : FirstSiteActionAgree A Y Z) :
-    ∀ j, insertedTensor Y (P.basis j) = insertedTensor Z (P.basis j) := by
-  exact P.insertedTensor_basis_eq_of_sameMPV₂Pos_firstSiteActionAgree
-    A hAP.toSameMPV₂Pos hSpan hAct
-
 end MPSTensor.SectorDecomposition

--- a/TNLean/MPS/Periodic/FundamentalTheorem.lean
+++ b/TNLean/MPS/Periodic/FundamentalTheorem.lean
@@ -192,34 +192,39 @@ section ProportionalCase
 variable {rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
 
-/-- **Peripheral proportional case from exact MPV equality.**
+/-- **Peripheral proportional case from positive-length MPV equality.**
 
-If two periodic tensors generate the same MPV family, then their bond dimensions
-agree and they are repeated blocks after identifying those bond spaces. This is
-the single-block uniqueness direction behind the source theorem `thm:bd` once the
-proportionality scalar has been absorbed into one side.
+If two periodic tensors generate the same MPV family at every positive length, then their bond
+dimensions agree and they are repeated blocks after identifying those bond spaces. This is the
+single-block uniqueness direction behind the source theorem `thm:bd` once the proportionality
+scalar has been absorbed into one side.
 
 The proof combines `periodicOverlapDichotomy` with `periodicSelfOverlap_tendsto`:
 the decay branch would force the self-overlap of `A` to tend to `0`, contradicting
 its periodic self-overlap limit `m_a` along the subsequence `m_a * ℕ`.
 
-As with `periodicOverlapDichotomy`, this theorem currently inherits the admitted
-sub-lemmas in `Periodic/Overlap`. -/
-theorem peripheralProportionalCase_periodicFT_of_sameMPV
+Source: arXiv:1708.00029, theorem `thm:bd`, lines 613--623, with the periodic overlap
+dichotomy from Appendix A, lines 1023--1117. The positive-length formulation is recorded in
+`docs/paper-gaps/1708_periodic_overlap_route_alignment.tex`.
+
+As with `periodicOverlapDichotomy`, this theorem currently inherits the admitted sub-lemmas in
+`Periodic/Overlap`. -/
+theorem peripheralProportionalCase_periodicFT_of_sameMPV₂Pos
     {D₁ D₂ : ℕ} [NeZero D₁] [NeZero D₂]
     (A : MPSTensor d D₁) (B : MPSTensor d D₂) {m_a m_b : ℕ}
     (hA : IsPeriodic m_a A) (hB : IsPeriodic m_b B)
-    (hSame : SameMPV₂ A B) :
+    (hSame : SameMPV₂Pos A B) :
     HetRepeatedBlocks A B := by
   rcases periodicOverlapDichotomy A B hA hB with hDecay | ⟨hdim, hRep⟩
-  · have hSameOverlap : ∀ N : ℕ, mpvOverlap (d := d) A B N = mpvOverlap A A N := by
-      intro N
+  · have hSameOverlap : ∀ᶠ N : ℕ in Filter.atTop,
+        mpvOverlap (d := d) A B N = mpvOverlap A A N := by
+      filter_upwards [Filter.eventually_gt_atTop 0] with N hN
       unfold mpvOverlap
       refine Finset.sum_congr rfl ?_
       intro σ _
-      rw [hSame N σ]
+      rw [hSame N hN σ]
     have hSelfZero : Filter.Tendsto (fun N => mpvOverlap A A N) Filter.atTop (nhds 0) :=
-      Filter.Tendsto.congr' (Filter.Eventually.of_forall hSameOverlap) hDecay
+      Filter.Tendsto.congr' hSameOverlap hDecay
     have hMulAtTop : Filter.Tendsto (fun k : ℕ => m_a * k) Filter.atTop Filter.atTop := by
       rw [Filter.tendsto_atTop]
       intro n
@@ -238,22 +243,30 @@ theorem peripheralProportionalCase_periodicFT_of_sameMPV
 /-- **Phase-rescaling reduction for the peripheral proportional case.**
 
 This Prop isolates the remaining scalar-absorption step behind
-`peripheralProportionalCase_periodicFT_of_sameMPV`: whenever a periodic tensor
+`peripheralProportionalCase_periodicFT_of_sameMPV₂Pos`: whenever a periodic tensor
 has an MPV family proportional to that of another tensor, one can rescale the
-periodic side by a unit-modulus phase so that the MPV families agree exactly. -/
+periodic side by a unit-modulus phase so that the MPV families agree at every positive length.
+
+Source: arXiv:1708.00029, theorem `thm:bd`, lines 613--623. This definition isolates the
+phase-rescaling step discussed in
+`docs/paper-gaps/1708_periodic_overlap_route_alignment.tex`. -/
 def PeripheralProportionalCaseRootFromRescaling (d D₁ D₂ : ℕ) : Prop :=
   ∀ {A : MPSTensor d D₁} {B : MPSTensor d D₂} {m_a : ℕ},
     IsPeriodic m_a A →
     ProportionalMPV₂ A B →
-      ∃ ξ : ℂ, ‖ξ‖ = 1 ∧ SameMPV₂ (fun i => ξ • A i) B
+      ∃ ξ : ℂ, ‖ξ‖ = 1 ∧ SameMPV₂Pos (fun i => ξ • A i) B
 
 /-- **Peripheral proportional case from phase rescaling.**
 
-Assuming `PeripheralProportionalCaseRootFromRescaling`, the exact-equality theorem
-`peripheralProportionalCase_periodicFT_of_sameMPV` upgrades proportional periodic
+Assuming `PeripheralProportionalCaseRootFromRescaling`, the positive-length equality theorem
+`peripheralProportionalCase_periodicFT_of_sameMPV₂Pos` upgrades proportional periodic
 MPVs to `HetRepeatedBlocks`. Thus the remaining single-block proportional gap in
 the source theorem `thm:bd` is exactly the phase-rescaling step provided by that
-hypothesis. -/
+hypothesis.
+
+Source: arXiv:1708.00029, theorem `thm:bd`, lines 613--623. The missing phase-rescaling
+argument is recorded in `docs/paper-gaps/1708_periodic_overlap_route_alignment.tex`. This proof
+inherits the admitted Case-3 sector contraction through the positive-length equality theorem. -/
 theorem peripheralProportionalCase_periodicFT_of_rootFromRescaling
     {D₁ D₂ : ℕ} [NeZero D₁] [NeZero D₂]
     (hRescale : PeripheralProportionalCaseRootFromRescaling d D₁ D₂)
@@ -272,7 +285,7 @@ theorem peripheralProportionalCase_periodicFT_of_rootFromRescaling
       simp [A']
     exact (HetRepeatedBlocks.of_repeatedBlocks hRep).symm
   have hRepeated : HetRepeatedBlocks A' B :=
-    peripheralProportionalCase_periodicFT_of_sameMPV A' B hA' hB hSame
+    peripheralProportionalCase_periodicFT_of_sameMPV₂Pos A' B hA' hB hSame
   exact hScale.trans hRepeated
 
 /-- **Proportional theorem `thm:bd` (arXiv:1708.00029, lines 613--623).**
@@ -295,7 +308,7 @@ The single-block proportional-to-equal reduction is now split explicitly.
 `PeripheralProportionalCaseRootFromRescaling` provides the missing phase-rescaling
 step, and `peripheralProportionalCase_periodicFT_of_rootFromRescaling` shows that,
 once this step is available, the exact-MPV theorem
-`peripheralProportionalCase_periodicFT_of_sameMPV` yields the repeated-block
+`peripheralProportionalCase_periodicFT_of_sameMPV₂Pos` yields the repeated-block
 conclusion for different bond dimensions. Thus the remaining mathematical gap is the multi-block
 existence step that turns proportionality of the assembled tensors into the
 non-decaying cross-overlap hypotheses `exists_nondecaying_A/B`.

--- a/TNLean/MPS/Periodic/Overlap/Case3.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case3.lean
@@ -91,9 +91,9 @@ private lemma overlap_norm_tendsto_one_of_gaugePhase_cast
 
 /-- Nonzero sector dimensions propagate one step around a cyclic sector decomposition.
 
-The proof uses only the projection-shift and trace identities in a cyclic sector decomposition:
-if `dim u ≠ 0` then the projection `P u` is nonzero by the `N = 0` trace identity. If
-`P (u + 1)` were zero, the cyclic relation `E†(P (u + 1)) = P u` would force `P u = 0`,
+The corner equivalences identify a positive-dimensional matrix algebra with the corner of
+`P u`, so `P u` is nonzero. If `dim (u + 1) = 0`, the corner of `P (u + 1)` is trivial and
+therefore `P (u + 1) = 0`; the cyclic relation `E†(P (u + 1)) = P u` then gives a
 contradiction. -/
 private lemma sectorDim_ne_zero_succ_of_cyclicSectorDecomp
     [NeZero D] (A : MPSTensor d D)
@@ -104,30 +104,39 @@ private lemma sectorDim_ne_zero_succ_of_cyclicSectorDecomp
     {u : Fin m} (hNondeg : dim u ≠ 0) :
     dim (u + 1) ≠ 0 := by
   classical
-  obtain ⟨P, _φ, hPproj, _hPsum, hShift, _hComm, hTrace, _hIntertwine, _hMul, _hStar⟩ :=
+  obtain ⟨P, φ, hPproj, _hPsum, hShift, _hComm, _hTrace, _hIntertwine, _hMul, _hStar⟩ :=
     hCyclic
+  have hPu_ne : P u ≠ 0 := by
+    intro hPu
+    have hφ_one_zero :
+        φ u (1 : Matrix (Fin (dim u)) (Fin (dim u)) ℂ) = 0 := by
+      apply Subtype.ext
+      have hmem := (φ u (1 : Matrix (Fin (dim u)) (Fin (dim u)) ℂ)).property
+      calc
+        (φ u (1 : Matrix (Fin (dim u)) (Fin (dim u)) ℂ)).1 =
+            P u * (φ u (1 : Matrix (Fin (dim u)) (Fin (dim u)) ℂ)).1 * P u := hmem.symm
+        _ = 0 := by simp only [hPu, zero_mul, mul_zero]
+    have hone_zero : (1 : Matrix (Fin (dim u)) (Fin (dim u)) ℂ) = 0 := by
+      apply (φ u).injective
+      simpa only [map_zero] using hφ_one_zero
+    haveI : NeZero (dim u) := ⟨hNondeg⟩
+    exact one_ne_zero hone_zero
   intro hzero
-  have htrace_succ :
-      Matrix.trace (P (u + 1)) = 0 := by
-    have h0 := hTrace (u + 1) 0 Fin.elim0
-    simp only [mpv, coeff, List.ofFn_zero, evalWord_nil, Matrix.mul_one] at h0
-    rw [← h0, Matrix.trace_one, Fintype.card_fin, hzero, Nat.cast_zero]
-  have hPsucc_zero : P (u + 1) = 0 :=
-    (isOrthogonalProjection_posSemidef (hPproj (u + 1))).trace_eq_zero_iff.mp htrace_succ
+  have hPsucc_zero : P (u + 1) = 0 := by
+    let Q : cornerSubmodule (P (u + 1)) :=
+      ⟨P (u + 1), by
+        change P (u + 1) * P (u + 1) * P (u + 1) = P (u + 1)
+        rw [(hPproj (u + 1)).2, (hPproj (u + 1)).2]⟩
+    obtain ⟨X, hX⟩ := (φ (u + 1)).surjective Q
+    have hXzero : X = 0 := by
+      ext i j
+      exact Fin.elim0 (Fin.cast hzero i)
+    have hQzero : Q = 0 := by
+      rw [← hX, hXzero, map_zero]
+    exact congrArg Subtype.val hQzero
   have hPu_zero : P u = 0 := by
     rw [← hShift u, hPsucc_zero, map_zero]
-  have htrace_u : Matrix.trace (P u) = 0 := by
-    rw [hPu_zero, Matrix.trace_zero]
-  have hdim_zero : dim u = 0 := by
-    have h0 := hTrace u 0 Fin.elim0
-    simp only [mpv, coeff, List.ofFn_zero, evalWord_nil, Matrix.mul_one] at h0
-    have hcast : (dim u : ℂ) = 0 := by
-      have htrace_one_zero :
-          Matrix.trace (1 : Matrix (Fin (dim u)) (Fin (dim u)) ℂ) = 0 := by
-        exact h0.trans htrace_u
-      simpa [Matrix.trace_one, Fintype.card_fin] using htrace_one_zero
-    exact Nat.cast_eq_zero.mp hcast
-  exact hNondeg hdim_zero
+  exact hPu_ne hPu_zero
 
 /-- One-step cyclic gauge-transport of a sector match.
 

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -247,7 +247,9 @@ boundary conditions (PBC).
     For tensors $A$ and $B$ of possibly different bond
     dimensions $D_1$ and $D_2$,
     we write $\mc{V}(A) = \mc{V}(B)$ if
-    $\ket{V^{(N)}(A)} = \ket{V^{(N)}(B)}$ for every $N$.
+    $\ket{V^{(N)}(A)} = \ket{V^{(N)}(B)}$ for every word length $N$,
+    including the empty word. This algebraic relation is used for exact
+    direct-sum identities.
 \end{definition}
 
 \begin{definition}[Positive-length same MPV - different bond dimensions]%
@@ -259,23 +261,6 @@ boundary conditions (PBC).
     we write $\mc{V}^+(A) = \mc{V}^+(B)$ if
     $\ket{V^{(N)}(A)} = \ket{V^{(N)}(B)}$ for every $N > 0$.
 \end{definition}
-
-\begin{lemma}[Length-zero MPV coefficient]\label{lem:mpv_zero_length}
-    \lean{MPSTensor.mpv_zero_length}
-    \leanok
-    \uses{def:mpv}
-    For any MPS tensor $A$ with bond dimension $D$, the length-zero MPV
-    coefficient is $D$, the trace of the identity on the bond space.
-\end{lemma}
-
-\begin{lemma}[Positive-length equality with equal bond dimensions]%
-    \label{lem:samempv2pos_to_samempv2_of_bonddim_eq}
-    \lean{MPSTensor.SameMPV₂Pos.toSameMPV₂_of_bondDim_eq}
-    \leanok
-    \uses{def:same_mpv2_pos, def:same_mpv2, lem:mpv_zero_length}
-    If two tensors have the same positive-length MPV family and the same bond
-    dimension, then they have the same MPV family at every length.
-\end{lemma}
 
 \begin{remark}\leanok
     Definition~\ref{def:same_mpv} is the same-bond-dimension
@@ -289,7 +274,7 @@ boundary conditions (PBC).
     \leanok
     \uses{def:mpv}
     Two tensors $A$ and $B$ (of possibly different bond dimensions)
-    generate weakly proportional MPV families if for every~$N$ there
+    generate weakly proportional MPV families if for every~$N>0$ there
     exists $c_N \in \C$ such that
     $\ket{V^{(N)}(A)} = c_N \ket{V^{(N)}(B)}$.
 \end{definition}
@@ -299,7 +284,7 @@ boundary conditions (PBC).
     \leanok
     \uses{def:mpv}
     Two tensors $A$ and $B$ (of possibly different bond dimensions)
-    generate nonzero proportional MPV families if for every~$N$ there is a
+    generate nonzero proportional MPV families if for every~$N>0$ there is a
     nonzero scalar $c_N \in \C$ such that
     $\ket{V^{(N)}(A)} = c_N \ket{V^{(N)}(B)}$.
     This is the projective reading of the proportionality hypothesis in
@@ -325,13 +310,13 @@ boundary conditions (PBC).
     \lean{MPSTensor.NonzeroProportionalMPV₂.toProportionalMPV₂,
         MPSTensor.NonzeroProportionalMPV₂.eventually,
         MPSTensor.NonzeroProportionalMPV₂.symm,
-        MPSTensor.SameMPV₂.toNonzeroProportionalMPV₂}
+        MPSTensor.SameMPV₂Pos.toNonzeroProportionalMPV₂}
     \leanok
     \uses{def:proportional_mpv, def:nonzero_proportional_mpv,
-        def:eventually_nonzero_proportional_mpv, def:same_mpv2}
+        def:eventually_nonzero_proportional_mpv, def:same_mpv2_pos}
     Nonzero proportionality implies weak proportionality and eventual nonzero
     proportionality, is symmetric, and equality of MPV families is the special
-    case with scalar $1$.
+    case with scalar $1$, at every positive length.
 \end{lemma}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch09_canonical.tex
+++ b/blueprint/src/chapter/ch09_canonical.tex
@@ -580,8 +580,8 @@ the resulting splitting decomposes any tensor into irreducible blocks.
     This is the sufficient condition for canonical form
     of~\cite[Section~2]{Cirac2016MPDO_arXiv}, with that paper's convention
     $\sum_k D_k \le D$ allowing zero blocks: a corner of $A$ carrying the
-    zero tensor cannot be rescaled to spectral radius one, and contributes
-    its bond dimension only to the length-zero coefficient.
+    zero tensor cannot be rescaled to spectral radius one and is omitted
+    because it vanishes at every positive length.
 \end{theorem}
 
 \begin{proof}
@@ -610,37 +610,6 @@ the resulting splitting decomposes any tensor into irreducible blocks.
     and summing over $k$ identifies the positive-length coefficients of
     $\bigoplus_k \mu_k A_k$ with those of $A$. The kept dimensions satisfy
     $\sum_k D_k \le \sum_k \tr(V_k V_k^\dagger) = \tr(\Id) = D$.
-\end{proof}
-
-\begin{theorem}[Canonical form at every length without zero corners]
-    \label{thm:projector_closure_canonical_form_all_lengths}
-    \lean{MPSTensor.exists_normalTensor_blockDecomp_sameMPV₂_of_hasInvariantProjectorClosure}
-    \leanok
-    \uses{def:invariant_projector_closure, def:no_periodic_vectors,
-        def:nt_cpsv, def:same_mpv2, def:block_diagonal_tensor}
-    Suppose $A$ has invariant-projector closure, has no nontrivial
-    $p$-periodic vectors, and every restriction of $A$ to a minimal
-    invariant subspace of positive dimension has a nonzero matrix. Then
-    there are normal tensors
-    $A_1, \ldots, A_r$ and nonzero weights $\mu_1, \ldots, \mu_r$ with
-    \[
-        \mc{V}(A) = \mc{V}\Bigl(\bigoplus_{k=1}^r \mu_k A_k\Bigr).
-    \]
-    The no-zero-corner hypothesis is not part of the source statement; it
-    excludes exactly the zero blocks
-    of~\cite[Section~2]{Cirac2016MPDO_arXiv}, which change only the
-    length-zero coefficient.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    \uses{thm:projector_closure_irreducible_corners,
-        lem:irreducible_transfer_perron_pair,
-        lem:irreducible_block_spectral_normalization}
-    As for Theorem~\ref{thm:projector_closure_canonical_form}, with no
-    corner dropped: every corner is nonzero by hypothesis, so
-    $\bigoplus_k \mu_k A_k$ has the same coefficients as the unit-weight
-    direct sum of the corners at every length, including zero.
 \end{proof}
 
 \begin{theorem}[PSD fixed point gives invariant projection]\label{thm:fp_inv_proj}
@@ -1808,11 +1777,12 @@ direct sum of primitive irreducible blocks.
 
 \begin{theorem}[Cyclic sectors after removing zero blocks]%
     \label{thm:ft_after_blocking_per_block_cyclic_nonzero_blocks}
-    \lean{MPSTensor.afterBlocking_perBlockCyclicData_of_sameMPV₂}
+    \lean{MPSTensor.afterBlocking_perBlockCyclicData_of_sameMPV₂Pos}
     \leanok
-    \uses{thm:tp_gauge_arbitrary, def:primitive_irreducible_cyclic_sectors,
+    \uses{thm:tp_gauge_arbitrary, def:same_mpv2_pos,
+        def:primitive_irreducible_cyclic_sectors,
         thm:cyclic_sector_decomp_irr_tp_prim_irr}
-    If $A$ and $B$ generate the same MPV family, then after removing the
+    If $A$ and $B$ generate the same MPV family at every positive length, then after removing the
     all-zero blocks and applying the trace-preserving gauge there are weighted nonzero-block tensors
     $\bigoplus_j \mu^A_j A_j$ and $\bigoplus_k \mu^B_k B_k$ with, for every
     $N\ge 1$ and $\sigma$,
@@ -1850,21 +1820,21 @@ direct sum of primitive irreducible blocks.
         =
         V^{(N)}\!(\textstyle\bigoplus_k \mu^B_k B_k)_\sigma.
     \]
-    Chaining these through $V(A)=V(B)$ identifies the two nonzero parts. Finally
+    Chaining these through $V^+(A)=V^+(B)$ identifies the two nonzero parts. Finally
     apply Theorem~\ref{thm:cyclic_sector_decomp_irr_tp_prim_irr} to
     every trace-preserving irreducible nonzero-weight block.
 \end{proof}
 
 \begin{theorem}[Common blocking length for cyclic sectors]%
     \label{thm:ft_after_blocking_common_length_common_sector_theorem}
-    \lean{MPSTensor.afterBlocking_commonLengthCommonSectorData_of_sameMPV₂}
+    \lean{MPSTensor.afterBlocking_commonLengthCommonSectorData_of_sameMPV₂Pos}
     \leanok
-    \uses{thm:ft_after_blocking_per_block_cyclic_nonzero_blocks,
+    \uses{thm:ft_after_blocking_per_block_cyclic_nonzero_blocks, def:same_mpv2_pos,
         thm:exists_common_blocked_cyclic_sector_family_common_multiple,
         thm:same_mpv2_pos_block_tensor_to_tensor_from_blocks,
         thm:same_mpv2_pos_to_tensor_from_blocks_block_power,
         thm:common_blocked_cyclic_sector_derived_properties}
-    If two tensors generate the same MPV family, then the cyclic-sector
+    If two tensors generate the same MPV family at every positive length, then the cyclic-sector
     decompositions on the two sides can be expressed at one common positive
     blocking length $p$. For every $N\ge 1$ and every blocked $\sigma$, each
     blocked tensor equals its powered nonzero part,
@@ -1917,7 +1887,7 @@ direct sum of primitive irreducible blocks.
     \uses{thm:ft_after_blocking_common_length_common_sector_theorem,
         thm:common_blocked_cyclic_sector_reindexed_nonzero_part,
         def:same_mpv2_pos}
-    Let $A$ and $B$ have the same MPV family. Then there is a positive blocking
+    Let $A$ and $B$ have the same MPV family at every positive length. Then there is a positive blocking
     length at which both blocked tensors have the same positive-length MPV
     family as weighted direct sums of trace-preserving, primitive,
     tensor-irreducible blocks with positive bond dimensions and nonzero weights.

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -2069,13 +2069,14 @@ unconditional result.
     Fundamental Theorem.  The periodic extension treats periodic blocks directly.
 \end{remark}
 
-\begin{theorem}[Peripheral proportional case from exact MPV equality]
+\begin{theorem}[Peripheral proportional case from positive-length MPV equality]
     \label{thm:peripheral_periodic_ft_proportional_same}
-    \lean{MPSTensor.peripheralProportionalCase_periodicFT_of_sameMPV}
+    \lean{MPSTensor.peripheralProportionalCase_periodicFT_of_sameMPV₂Pos}
     \notready
-    \uses{def:periodic_tensor, thm:periodic_overlap_dichotomy,
+    \uses{def:periodic_tensor, def:same_mpv2_pos, thm:periodic_overlap_dichotomy,
         thm:periodic_self_overlap_tendsto}
-    Let $A$ and $B$ be periodic tensors with the same matrix product vectors.
+    Let $A$ and $B$ be periodic tensors with the same matrix product vectors
+    at every positive length.
     Then their bond dimensions agree, and after identifying the bond spaces,
     $A$ and $B$ are repeated blocks.
 \end{theorem}
@@ -2083,7 +2084,7 @@ unconditional result.
     By Theorem~\ref{thm:periodic_overlap_dichotomy}, either the overlap
     $\braket{V^{(N)}(A)}{V^{(N)}(B)}$ tends to $0$ or the bond dimensions agree
     and $A$ and $B$ are repeated blocks. In the decay case,
-    equality of the MPV families gives, for every $N$,
+    equality of the MPV families gives, for every $N>0$,
     \begin{equation}\label{eq:pft_decay_mpv_equality}
         \braket{V^{(N)}(A)}{V^{(N)}(B)}
         =
@@ -2112,12 +2113,13 @@ unconditional result.
     \uses{def:periodic_tensor, thm:peripheral_periodic_ft_proportional_same}
     Assume that whenever two periodic tensors have proportional MPV families,
     one can rescale one tensor by a unit-modulus phase so that the MPV families
-    agree exactly. Then proportional periodic MPV families already force the
+    agree at every positive length. Then proportional periodic MPV families already force the
     tensors to be repeated blocks.
 \end{theorem}
 \begin{proof}\notready
     Apply the phase-rescaling hypothesis to replace $A$ by a periodic tensor
-    $A'$ with the same MPV family as $B$. Theorem~\ref{thm:peripheral_periodic_ft_proportional_same}
+    $A'$ with the same positive-length MPV family as $B$.
+    Theorem~\ref{thm:peripheral_periodic_ft_proportional_same}
     then yields repeated-block equivalence between $A'$ and $B$. Since $A'$
     differs from $A$ only by a unit-modulus phase, $A$ and $A'$ are themselves
     repeated blocks, and transitivity gives the claim.

--- a/docs/audits/2026-05-16_pos_mpv_audit_gpt55.md
+++ b/docs/audits/2026-05-16_pos_mpv_audit_gpt55.md
@@ -1,5 +1,11 @@
 # Audit: feasibility of arbitrary-input SectorBNT supplier path via `SameMPV₂Pos`
 
+> **Historical audit (superseded 2026-07-17).** The positive-length variants
+> recommended here are now the canonical SectorBNT interface, the zero-tail
+> bookkeeping has been removed, and the common-sector reduction itself takes
+> `SameMPV₂Pos`. This document is retained as a record of the earlier state;
+> issue #4098 tracks the comparison-surface cleanup.
+
 **Date:** 2026-05-16  
 **Scope:** scout only; no Lean source edits.  
 **Target stack:** `TNLean/MPS/FundamentalTheorem/SectorBNT/`, plus the arbitrary-input reduction chain under `TNLean/MPS/CanonicalForm/Reduction.lean`, `TNLean/MPS/CanonicalForm/Existence.lean`, and `TNLean/MPS/CanonicalForm/SectorComparison/*.lean`.

--- a/docs/paper-gaps/1708_periodic_overlap_route_alignment.tex
+++ b/docs/paper-gaps/1708_periodic_overlap_route_alignment.tex
@@ -35,6 +35,21 @@ smuggled-hypothesis sense: each formal statement is a faithful (or explicitly
 restricted) version of the source, and the route substitutions are
 mathematically equivalent.
 
+\section{Positive chain lengths}
+
+The matrix-product-vector equalities used by the periodic overlap argument are
+now stated for $N\geq 1$.  In particular,
+\leanid{peripheralProportionalCase_periodicFT_of_sameMPV₂Pos} assumes equality
+at every positive length, and
+\leanid{PeripheralProportionalCaseRootFromRescaling} concludes equality at
+every positive length after phase rescaling.  This is sufficient because the
+overlap argument is asymptotic and uses only a tail of positive lengths.  The
+empty word carries only a bond-dimension trace and plays no role in
+\cite[theorem \texttt{thm:bd}, lines~613--623]{DeLasCuevas2017Irreducible}.
+Likewise, propagation of nonzero cyclic-sector dimensions is derived directly
+from the corner-algebra equivalences and the cyclic projector shift, rather
+than from the empty-word trace identity.
+
 \section{Different-period decay via the peripheral spectrum}
 
 \textbf{Source.}\footnote{\cite{DeLasCuevas2017Irreducible}, Appendix~A,

--- a/docs/paper-gaps/cpsv16_nonzero_proportionality_reading.tex
+++ b/docs/paper-gaps/cpsv16_nonzero_proportionality_reading.tex
@@ -33,13 +33,15 @@ The scalar multiple with coefficient $0$ gives no projective point.
 \section{Formal reading}
 
 The formal predicate \leanid{NonzeroProportionalMPV}\textsubscript{2} requires, at each
-length $N$, a scalar $c_N \neq 0$ such that
+positive length $N\geq 1$, a scalar $c_N \neq 0$ such that
 \begin{align}
     V^{(N)}(A) = c_N V^{(N)}(B).
 \end{align}
 This is the projective reading of proportionality: the two vectors determine
 the same point in projective space. It is the reading used by the proof of
-Theorem~\texttt{thm1}. In the block-selection step, the paper assumes that all
+Theorem~\texttt{thm1}. The empty word is excluded because it is not a physical
+chain and its coefficient records only the bond-space dimension. In the
+block-selection step, the paper assumes that all
 overlaps of a fixed block on one side with the blocks on the other side tend
 to zero, expands the two BNT decompositions, and invokes Corollary~\texttt{Lem1}
 to contradict proportionality. If $c_N$ were allowed to be zero at a
@@ -80,8 +82,9 @@ The nonzero condition does not change the intended conclusion of the source
 theorem. It records the conventional mathematical meaning of proportional
 nonzero vectors in the source argument. The weaker scalar-multiple predicate
 \leanid{ProportionalMPV}\textsubscript{2}, where $c_N$ may vanish, remains available for
-older auxiliary lemmas, but it is not used as the paper-faithful hypothesis
-for the proportional Fundamental Theorem.
+older auxiliary lemmas and is likewise indexed only by positive lengths. It is
+not used as the paper-faithful hypothesis for the proportional Fundamental
+Theorem.
 
 \section{Elimination plan}
 

--- a/docs/paper-gaps/cpsv16_projector_closure_canonical_form.tex
+++ b/docs/paper-gaps/cpsv16_projector_closure_canonical_form.tex
@@ -97,15 +97,12 @@ decomposition (arXiv:1606.00608, line 219).  Dropping a zero block changes
 exactly one datum of the generated family: the length-zero coefficient,
 which is the bond dimension.  The formalized sufficient condition therefore
 concludes equality of the generated matrix product vectors at every positive
-length, together with the source's dimension bound $\sum_k D_k \le D$.  A
-separate variant concludes equality at every length, including zero, under
-the explicit additional hypothesis that no restriction of $A$ to a minimal
-invariant subspace is the zero tensor; that hypothesis is not part of the
-source statement, and the variant is marked as
-scope-restricted.\footnote{Formal declaration:
-\leanid{MPSTensor.exists_normalTensor_blockDecomp_sameMPV₂_of_hasInvariantProjectorClosure}
-in \doclink{TNLean/MPS/CanonicalForm/ProjectorClosureSpectral}.}
-The positive-length formulation is the source-faithful shape of the
+length, together with the source's dimension bound $\sum_k D_k \le D$.  The
+former all-length variant added the hypothesis that no restriction of $A$ to
+a minimal invariant subspace is the zero tensor.  Since that hypothesis is not
+part of the source and served only to recover the empty-word coefficient, the
+variant has been removed.  The positive-length formulation is the
+source-faithful shape of the
 length-zero bookkeeping analyzed in
 \path{docs/paper-gaps/cpsv16_zero_tail_length_zero_decomposition.tex}.
 
@@ -115,9 +112,8 @@ The sufficient condition for canonical form at arXiv:1606.00608,
 lines 253--254, is formalized: projector closure and the absence of
 nontrivial $p$-periodic vectors yield a decomposition of the generated
 matrix product vectors into normal-tensor blocks with nonzero weights, at
-every positive length and with $\sum_k D_k \le D$.  The remaining deliberate
-deviation is the treatment of the length-zero coefficient in the presence of
-zero blocks, recorded in the previous section.
+every positive length and with $\sum_k D_k \le D$.  No separate physical
+statement is retained for the length-zero coefficient.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpsv16_zero_tail_length_zero_decomposition.tex
+++ b/docs/paper-gaps/cpsv16_zero_tail_length_zero_decomposition.tex
@@ -122,6 +122,13 @@ in~\eqref{eq:pos}, and its dimension clause is the bound~\eqref{eq:bound}.
 The intermediate declarations carrying \texttt{zeroTailDim}, as well as the
 former support lemma
 \leanid{zeroTail_toTensorFromBlocks_blockPower}, have therefore been removed.
+The subsequent common-sector theorems now also take
+\leanid{SameMPV₂Pos} directly; no all-length hypothesis is converted back to
+positive length inside their proofs.  The former bridge from positive-length
+equality plus equal bond dimensions to an all-length statement has been
+removed from the public comparison surface.  The empty-word coefficient lemma
+remains only as an algebraic identity in the Lean source and is not presented
+as a physical chain statement in the blueprint.
 
 \section{Conclusion}
 


### PR DESCRIPTION
## Summary

- make positive-length equality the canonical hypothesis for common-sector and periodic MPS comparison theorems
- make weak and nonzero MPV proportionality quantify only over physical chain lengths N > 0
- remove the positive-to-all-length bridge, the no-zero-corner all-length canonical-form variant, and four unused all-length MPDO wrappers
- remove empty-chain bookkeeping from cyclic-sector compression and derive nonzero periodic sector projectors from the corner-algebra equivalences
- retain all-word equality only for exact algebraic transports such as direct sums, blocking, and physical-index reindexing

## Source alignment

The statements follow the positive-chain reading of CPSV16 and the periodic theorem in arXiv:1708.00029. The corresponding blueprint entries and paper-gap records are updated. No additional hypothesis is introduced to recover the empty-word coefficient.

## Verification

- `lake build TNLean` with Lean 4.32: 9,533 jobs
- `leanblueprint checkdecls`
- blueprint/Lean synchronization
- reader-facing prose check
- strict tensor-network audit and 114 smoke renders
- changed-declaration axiom audit
- no new `sorry`, `axiom`, or kernel bypass

The two periodic consequences still inherit the pre-existing admitted Case-3 contraction lemma; this pull request introduces no new admission.

Closes #4098.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide refactor of comparison hypotheses across MPS canonical form, SectorBNT, and periodic FT; logic is intentionally narrowed to positive lengths but many downstream theorem statements changed. No new axioms; periodic results still depend on the pre-existing admitted Case-3 lemma.
> 
> **Overview**
> **Physical MPS comparison now uses `SameMPV₂Pos` (and proportionality only for `N > 0`)** across canonical-form sector reduction, SectorBNT matching, periodic overlap routes, and the blueprint/paper-gap docs. **`SameMPV₂` remains** where all word lengths are still the right algebraic notion (e.g. direct sums and blocking transports).
> 
> **Removed surface area:** the bond-dimension bridge `SameMPV₂Pos.toSameMPV₂_of_bondDim_eq`, the no-zero-corner all-length theorem `exists_normalTensor_blockDecomp_sameMPV₂_of_hasInvariantProjectorClosure`, and four unused `SameMPV₂` MPDO wrapper lemmas. **Compression / cyclic-sector proofs** no longer case-split on `N = 0`; nonzero sector projectors use corner-algebra data instead of empty-word traces.
> 
> **Call-site churn:** common-sector theorems renamed to `*sameMPV₂Pos*`, `ProportionalMPV₂` / `NonzeroProportionalMPV₂` and related lemmas require `0 < N`, and periodic proportional theorems are renamed to `*sameMPV₂Pos*` with eventual overlap arguments where needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72131a7a67e2ae798994ae7fdf053c9700945ca9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->