### PR TITLE
doc(MPS/MPDO): move GSNNCH identifiers to footnotes

### DIFF
--- a/docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex
+++ b/docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex
@@ -1,5 +1,6 @@
 \documentclass{article}
 
+\usepackage[T1]{fontenc}
 \usepackage{amsmath,amssymb}
 \usepackage{xurl}
 \usepackage[hidelinks]{hyperref}
@@ -46,17 +47,19 @@ them.
 
 \section{Present formal boundary}
 
-The structure \leanid{MPOTensor.GSNNCHData} now records the finite outer
-sector type, its orthogonal one-site sector projections, the natural
-multiplicities, and one positive commuting bond in every sector.  The
-predicates \leanid{MPOTensor.IsGSNNCHAt} and
-\leanid{MPOTensor.IsGSNNCH} therefore retain the data in Definition~4.8.
-The chain-level predicate requires positivity and unit trace, while the
-tensor-level predicate applies it to the normalized operator
-\leanid{MPOTensor.normalizedMPO} at each length $N\geq2$.
+The formalized sector decomposition now records the finite outer sector type,
+its orthogonal one-site sector projections, the natural multiplicities, and
+one positive commuting bond in every sector.  The finite-chain and
+tensor-level predicates therefore retain the direct sum and multiplicities of
+Definition~4.8.  The finite-chain predicate requires positivity and unit
+trace, while the tensor-level predicate applies it to the normalized operator at each length
+$N\geq2$.\footnote{\raggedright Formal structure: \leanid{MPOTensor.GSNNCHData}.
+Formal declarations: \leanid{MPOTensor.IsGSNNCHAt},
+\leanid{MPOTensor.IsGSNNCH}, and \leanid{MPOTensor.normalizedMPO}.}
 
-The separate structure \leanid{MPOTensor.CommutingBondProductData} records
-the auxiliary single-bond presentation
+The auxiliary single-bond presentation is recorded separately:
+\footnote{\raggedright Formal structure:
+\leanid{MPOTensor.CommutingBondProductData}.}
 \[
   \rho^{(N)}=c_N\prod_{j=1}^N\tau_j(B_N),
   \qquad c_N>0,
@@ -66,19 +69,19 @@ one-sector case of the source definition.  No converse theorem extracting a
 single bond from arbitrary source sector data is claimed.
 
 The represented finite-chain sector sum now carries its asserted analytic
-properties: all cyclic translates of one sector bond commute pairwise
-(\leanid{MPOTensor.GSNNCHData.bondAt\_comm}), the represented operator is
-positive semidefinite
-(\leanid{MPOTensor.GSNNCHData.unnormalizedState\_posSemidef}) and invariant
-under the cyclic shift
-(\leanid{MPOTensor.GSNNCHData.unnormalizedState\_submatrix\_rotateConfig}),
-and a tensor whose finite-chain operators have the sector form with nonzero
-traces satisfies the full density-operator predicate
-(\leanid{MPOTensor.isGSNNCH\_of\_hasGSNNCHForm}).  In particular every
-injective tensor satisfying the saturated area law is now proved GSNNCH
-(\leanid{MPOTensor.isGSNNCH\_of\_isInjective\_of\_isSAL}), through a
-one-sector witness; the one-sector form is the commuting product form in
-which Proposition~C.8 states its conclusion for an injective tensor.
+properties: all cyclic translates of one sector bond commute pairwise, the
+represented operator is positive semidefinite and invariant under the
+cyclic shift, and a tensor whose finite-chain operators have the sector form
+with nonzero traces satisfies the full density-operator predicate.  In particular,
+every injective tensor satisfying the saturated area law is now proved GSNNCH
+through a one-sector witness.\footnote{\raggedright Formal declarations:
+{\scriptsize\leanid{MPOTensor.GSNNCHData.bondAt_comm}},
+{\scriptsize\leanid{MPOTensor.GSNNCHData.unnormalizedState_posSemidef}},
+{\scriptsize\leanid{MPOTensor.GSNNCHData.unnormalizedState_submatrix_rotateConfig}},
+{\scriptsize\leanid{MPOTensor.isGSNNCH_of_hasGSNNCHForm}}, and
+{\scriptsize\leanid{MPOTensor.isGSNNCH_of_isInjective_of_isSAL}}.}  The
+one-sector form is the commuting product form in which Proposition~C.8 states
+its conclusion for an injective tensor.
 
 \section{Elimination plan}
 


### PR DESCRIPTION
## Summary

- rewrite the present formal-boundary paragraphs as a self-contained mathematical account of the sector decomposition in Definition 4.8
- move all ten formal declaration references into three footnotes, attached to the corresponding assertions
- use T1 font encoding so underscores in the declaration names render literally
- leave the documented mathematical gap, classification, and elimination plan unchanged

## Verification

- compared the normalized declaration-name multisets before and after the change: all ten references are preserved
- verified that no `\leanid` reference remains outside a footnote
- compiled `cpsv16_gsnnch_sector_decomposition.tex` with the repository-local `command.tex`; the log has no box, font, reference, or undefined-command warnings
- rendered and inspected all three PDF pages for legibility, margins, footnote placement, and page numbering
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main --ci`
- `git diff --check`

No Lean source is changed, and no axiom or admission is introduced.

Closes #4044.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX prose and footnote layout; no code, axioms, or formal claims are modified.
> 
> **Overview**
> The **Present formal boundary** section of `cpsv16_gsnnch_sector_decomposition.tex` is rewritten so the body reads as standalone mathematics about the sector decomposition and predicates, instead of naming Lean structures and theorems inline.
> 
> All ten `\leanid{...}` references are moved into **three footnotes** tied to the matching claims (GSNNCH data/predicates, commuting-bond auxiliary data, and the proved analytic properties including SAL → GSNNCH). Long names in the third footnote use `{\scriptsize\leanid{...}}`. **`T1` font encoding** is added so underscores in declaration names typeset correctly.
> 
> Sections on the elimination plan and classification are unchanged; there is no Lean or proof change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0cdbbbc78fcb67e5d45cd7ed88efbc2b959a323. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->