### PR TITLE
refactor(MPS/MPDO): index blocked chi families positively

### DIFF
--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -57,7 +57,7 @@ and blocked-basis comparison statements for Theorem IV.13(ii) are recorded in
 For the blocked support tower, `AlgebraStructureData.BlockedStructureChiFamily`,
 `AlgebraStructureData.HasBlockedStructureChiTracePowerForm`, and
 `AlgebraStructureData.PositiveBlockedStructureChiTracePowerForm` record the
-length-dependent blocked-basis analogue for
+positive-length, length-dependent blocked-basis analogue for
 `AlgebraStructureData.blockedStructureCoefficients`, including positivity of
 the diagonal entries. The BNT-label coefficient and comparison predicates are
 recorded in `TNLean.MPS.MPDO.BNTCoefficients`; the remaining gap is the
@@ -633,11 +633,6 @@ namespace DiagonalChiFamily
 
 variable {I : Type*} (χ : DiagonalChiFamily I)
 
-/-- The diagonal chi family with empty diagonal matrices for every triple. -/
-def empty (I : Type*) : DiagonalChiFamily I where
-  dim _ _ _ := 0
-  entry _ _ _ k := Fin.elim0 k
-
 /-- Reindex a diagonal chi family along a map of labels. -/
 def comap {J : Type*} (f : J → I) : DiagonalChiFamily J where
   dim α β γ := χ.dim (f α) (f β) (f γ)
@@ -671,11 +666,6 @@ Under the scoped `ComplexOrder` instance (opened at the top of the file), a
 strict inequality `0 < z` on `ℂ` is equivalent to `0 < z.re ∧ z.im = 0`. -/
 def PosEntries : Prop :=
   ∀ α β γ : I, ∀ k : Fin (χ.dim α β γ), 0 < χ.entry α β γ k
-
-/-- The empty diagonal chi family has positive entries vacuously. -/
-theorem PosEntries.empty (I : Type*) : (empty I).PosEntries := by
-  intro α β γ k
-  exact Fin.elim0 k
 
 /-- Reindexing preserves positivity of the diagonal entries. -/
 theorem PosEntries.comap {J : Type*} {χ : DiagonalChiFamily I}
@@ -722,7 +712,7 @@ namespace AlgebraStructureData
 /-- A diagonal chi family indexed by the multiplication coefficients of a
 blocked support-algebra tower.
 
-For each blocking length `n`, the first two indices label basis elements of
+For each positive blocking length `n`, the first two indices label basis elements of
 `A n`, while the third labels a basis element of `A (2 * n)`. Thus this is the
 dependent-index version of the matrices
 `χ_{α,β,γ}` appearing in
@@ -735,10 +725,10 @@ comparison and elimination plan are recorded in
 `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`, Section "BNT-label
 coefficient objects and remaining elimination plan". -/
 structure BlockedStructureChiFamily (data : AlgebraStructureData d D) where
-  /-- For each blocked length `n`, a diagonal family on the disjoint union of
-  domain and codomain basis labels. The intended triples have shape
+  /-- For each positive blocked length `n`, a diagonal family on the disjoint
+  union of domain and codomain basis labels. The intended triples have shape
   `(Sum.inl i, Sum.inl j, Sum.inr k)`. -/
-  toDiagonal : (n : ℕ) →
+  toDiagonal : (n : ℕ) → 0 < n →
     DiagonalChiFamily (BlockedIndex data n ⊕ BlockedIndex data (2 * n))
 
 namespace BlockedStructureChiFamily
@@ -746,44 +736,46 @@ namespace BlockedStructureChiFamily
 variable {data : AlgebraStructureData d D} (χ : BlockedStructureChiFamily data)
 
 /-- Size of the diagonal matrix attached to the triple `(n, i, j, k)`. -/
-def dim (n : ℕ) (i j : BlockedIndex data n) (k : BlockedIndex data (2 * n)) : ℕ :=
-  (χ.toDiagonal n).dim (Sum.inl i) (Sum.inl j) (Sum.inr k)
+def dim (n : ℕ) (hn : 0 < n) (i j : BlockedIndex data n)
+    (k : BlockedIndex data (2 * n)) : ℕ :=
+  (χ.toDiagonal n hn).dim (Sum.inl i) (Sum.inl j) (Sum.inr k)
 
 /-- Diagonal entries of the matrix attached to `(n, i, j, k)`. -/
-def entry (n : ℕ) (i j : BlockedIndex data n) (k : BlockedIndex data (2 * n))
-    (r : Fin (χ.dim n i j k)) : ℂ :=
-  (χ.toDiagonal n).entry (Sum.inl i) (Sum.inl j) (Sum.inr k) r
+def entry (n : ℕ) (hn : 0 < n) (i j : BlockedIndex data n)
+    (k : BlockedIndex data (2 * n)) (r : Fin (χ.dim n hn i j k)) : ℂ :=
+  (χ.toDiagonal n hn).entry (Sum.inl i) (Sum.inl j) (Sum.inr k) r
 
 /-- The diagonal matrix attached to one blocked multiplication coefficient. -/
-noncomputable def matrix (n : ℕ) (i j : BlockedIndex data n)
+noncomputable def matrix (n : ℕ) (hn : 0 < n) (i j : BlockedIndex data n)
     (k : BlockedIndex data (2 * n)) :
-    Matrix (Fin (χ.dim n i j k)) (Fin (χ.dim n i j k)) ℂ :=
-  (χ.toDiagonal n).matrix (Sum.inl i) (Sum.inl j) (Sum.inr k)
+    Matrix (Fin (χ.dim n hn i j k)) (Fin (χ.dim n hn i j k)) ℂ :=
+  (χ.toDiagonal n hn).matrix (Sum.inl i) (Sum.inl j) (Sum.inr k)
 
 /-- The trace-power coefficient attached to one blocked multiplication triple. -/
-noncomputable def tracePowerCoeff (n : ℕ) (i j : BlockedIndex data n)
+noncomputable def tracePowerCoeff (n : ℕ) (hn : 0 < n) (i j : BlockedIndex data n)
     (k : BlockedIndex data (2 * n)) (L : ℕ) : ℂ :=
-  (χ.toDiagonal n).tracePowerCoeff (Sum.inl i) (Sum.inl j) (Sum.inr k) L
+  (χ.toDiagonal n hn).tracePowerCoeff (Sum.inl i) (Sum.inl j) (Sum.inr k) L
 
 /-- The `L`-th power of a blocked chi matrix is diagonal with entries raised to
 the `L`-th power. -/
-theorem matrix_pow (n : ℕ) (i j : BlockedIndex data n)
+theorem matrix_pow (n : ℕ) (hn : 0 < n) (i j : BlockedIndex data n)
     (k : BlockedIndex data (2 * n)) (L : ℕ) :
-    χ.matrix n i j k ^ L =
-      Matrix.diagonal fun r => (χ.entry n i j k r) ^ L :=
-  (χ.toDiagonal n).matrix_pow (Sum.inl i) (Sum.inl j) (Sum.inr k) L
+    χ.matrix n hn i j k ^ L =
+      Matrix.diagonal fun r => (χ.entry n hn i j k r) ^ L :=
+  (χ.toDiagonal n hn).matrix_pow (Sum.inl i) (Sum.inl j) (Sum.inr k) L
 
 /-- The trace of the `L`-th power of a blocked chi matrix is the corresponding
 finite sum of `L`-th powers of its diagonal entries. -/
-lemma trace_matrix_pow (n : ℕ) (i j : BlockedIndex data n)
+lemma trace_matrix_pow (n : ℕ) (hn : 0 < n) (i j : BlockedIndex data n)
     (k : BlockedIndex data (2 * n)) (L : ℕ) :
-    (χ.matrix n i j k ^ L).trace = χ.tracePowerCoeff n i j k L :=
-  (χ.toDiagonal n).trace_matrix_pow (Sum.inl i) (Sum.inl j) (Sum.inr k) L
+    (χ.matrix n hn i j k ^ L).trace = χ.tracePowerCoeff n hn i j k L :=
+  (χ.toDiagonal n hn).trace_matrix_pow (Sum.inl i) (Sum.inl j) (Sum.inr k) L
 
 /-- Positivity of every diagonal entry in the blocked chi family. -/
 def PosEntries : Prop :=
-  ∀ (n : ℕ) (i j : BlockedIndex data n) (k : BlockedIndex data (2 * n)),
-    ∀ r : Fin (χ.dim n i j k), 0 < χ.entry n i j k r
+  ∀ (n : ℕ) (hn : 0 < n) (i j : BlockedIndex data n)
+    (k : BlockedIndex data (2 * n)),
+    ∀ r : Fin (χ.dim n hn i j k), 0 < χ.entry n hn i j k r
 
 end BlockedStructureChiFamily
 
@@ -807,10 +799,10 @@ coefficient objects and remaining elimination plan". -/
 def HasBlockedStructureChiTracePowerForm
     (data : AlgebraStructureData d D) (χ : BlockedStructureChiFamily data) :
     Prop :=
-  ∀ (n : ℕ), 0 < n →
+  ∀ (n : ℕ) (hn : 0 < n),
     ∀ (i j : BlockedIndex data n) (k : BlockedIndex data (2 * n)),
     data.blockedStructureCoefficients n i j k =
-      χ.tracePowerCoeff n i j k n
+      χ.tracePowerCoeff n hn i j k n
 
 /-- Trace reformulation of `HasBlockedStructureChiTracePowerForm` at a positive
 blocked length. -/
@@ -820,7 +812,7 @@ theorem HasBlockedStructureChiTracePowerForm.eq_trace_matrix_pow
     (n : ℕ) (hn : 0 < n)
     (i j : BlockedIndex data n) (k : BlockedIndex data (2 * n)) :
     data.blockedStructureCoefficients n i j k =
-      (χ.matrix n i j k ^ n).trace := by
+      (χ.matrix n hn i j k ^ n).trace := by
   rw [h n hn i j k, χ.trace_matrix_pow]
 
 /-- A positive blocked chi witness for the blocked multiplication coefficients.
@@ -855,7 +847,7 @@ lemma eq_trace_pow (h : PositiveBlockedStructureChiTracePowerForm data)
     (n : ℕ) (hn : 0 < n)
     (i j : BlockedIndex data n) (k : BlockedIndex data (2 * n)) :
     data.blockedStructureCoefficients n i j k =
-      (h.chi.matrix n i j k ^ n).trace :=
+      (h.chi.matrix n hn i j k ^ n).trace :=
   h.tracePower.eq_trace_matrix_pow n hn i j k
 
 end PositiveBlockedStructureChiTracePowerForm

--- a/TNLean/MPS/MPDO/BNTCoefficients.lean
+++ b/TNLean/MPS/MPDO/BNTCoefficients.lean
@@ -586,17 +586,13 @@ lemma blocked_coeff_eq_ofChi_trace_pow
 along a blocked-basis comparison.
 
 The comparison maps are defined only for positive lengths.  The value at
-`n = 0` is therefore the empty diagonal family; this component is not used by
-the positive-length blocked trace-power identity. -/
+each positive length is the BNT-label family pulled back along the comparison
+map at that length. -/
 def pulledBlockedChiFamily
     (cmp : BNTBlockedBasisCoefficientComparison data c)
     (hχ : PositiveBNTLabelChiTracePowerForm c) :
     AlgebraStructureData.BlockedStructureChiFamily data where
-  toDiagonal n :=
-    if hn : 0 < n then
-      hχ.chi.comap (cmp.blockedLabel n hn)
-    else
-      DiagonalChiFamily.empty _
+  toDiagonal n hn := hχ.chi.comap (cmp.blockedLabel n hn)
 
 /-- At positive blocked length, the pulled-back blocked chi family is exactly
 the BNT-label chi family composed with the source and target comparison maps.
@@ -608,28 +604,21 @@ theorem pulledBlockedChiFamily_toDiagonal_of_pos
     (cmp : BNTBlockedBasisCoefficientComparison data c)
     (hχ : PositiveBNTLabelChiTracePowerForm c)
     (n : ℕ) (hn : 0 < n) :
-    (cmp.pulledBlockedChiFamily hχ).toDiagonal n =
+    (cmp.pulledBlockedChiFamily hχ).toDiagonal n hn =
       hχ.chi.comap (cmp.blockedLabel n hn) := by
-  simp [pulledBlockedChiFamily, hn]
+  rfl
 
 /-- The pulled-back blocked chi family has positive diagonal entries at every
-blocked length: at positive length the entries come from the positive BNT-label
-witness, and at length zero the family is empty.
+positive blocked length, inherited from the positive BNT-label witness.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
 Appendix C.3--C.4, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem pulledBlockedChiFamily_toDiagonal_posEntries
     (cmp : BNTBlockedBasisCoefficientComparison data c)
-    (hχ : PositiveBNTLabelChiTracePowerForm c) (n : ℕ) :
-    ((cmp.pulledBlockedChiFamily hχ).toDiagonal n).PosEntries := by
-  by_cases hn : 0 < n
-  · simpa only [pulledBlockedChiFamily, dif_pos hn] using
-      hχ.posEntries.comap (cmp.blockedLabel n hn)
-  · simpa only [pulledBlockedChiFamily, dif_neg hn] using
-      DiagonalChiFamily.PosEntries.empty
-        (AlgebraStructureData.BlockedIndex data n ⊕
-          AlgebraStructureData.BlockedIndex data (2 * n))
+    (hχ : PositiveBNTLabelChiTracePowerForm c) (n : ℕ) (hn : 0 < n) :
+    ((cmp.pulledBlockedChiFamily hχ).toDiagonal n hn).PosEntries :=
+  hχ.posEntries.comap (cmp.blockedLabel n hn)
 
 /-- At positive blocked length, the finite-sum trace-power coefficient of the
 pulled-back blocked chi family is the corresponding BNT-label trace-power
@@ -645,7 +634,7 @@ theorem pulledBlockedChi_tracePowerCoeff_of_pos
     (i j : AlgebraStructureData.BlockedIndex data n)
     (k : AlgebraStructureData.BlockedIndex data (2 * n))
     (L : ℕ) :
-    (cmp.pulledBlockedChiFamily hχ).tracePowerCoeff n i j k L =
+    (cmp.pulledBlockedChiFamily hχ).tracePowerCoeff n hn i j k L =
       hχ.chi.tracePowerCoeff
         (cmp.sourceLabel n hn i) (cmp.sourceLabel n hn j) (cmp.targetLabel n hn k) L := by
   rw [AlgebraStructureData.BlockedStructureChiFamily.tracePowerCoeff]
@@ -664,7 +653,7 @@ theorem pulledBlockedChi_dim_of_pos
     (n : ℕ) (hn : 0 < n)
     (i j : AlgebraStructureData.BlockedIndex data n)
     (k : AlgebraStructureData.BlockedIndex data (2 * n)) :
-    (cmp.pulledBlockedChiFamily hχ).dim n i j k =
+    (cmp.pulledBlockedChiFamily hχ).dim n hn i j k =
       hχ.chi.dim
         (cmp.sourceLabel n hn i) (cmp.sourceLabel n hn j) (cmp.targetLabel n hn k) := by
   rw [AlgebraStructureData.BlockedStructureChiFamily.dim]
@@ -685,7 +674,7 @@ theorem pulledBlockedChi_trace_matrix_pow_of_pos
     (i j : AlgebraStructureData.BlockedIndex data n)
     (k : AlgebraStructureData.BlockedIndex data (2 * n))
     (L : ℕ) :
-    ((cmp.pulledBlockedChiFamily hχ).matrix n i j k ^ L).trace =
+    ((cmp.pulledBlockedChiFamily hχ).matrix n hn i j k ^ L).trace =
       (hχ.chi.matrix
         (cmp.sourceLabel n hn i) (cmp.sourceLabel n hn j) (cmp.targetLabel n hn k) ^
           L).trace := by
@@ -708,7 +697,7 @@ lemma blocked_coeff_eq_pulledBlockedChi_trace_pow
     (i j : AlgebraStructureData.BlockedIndex data n)
     (k : AlgebraStructureData.BlockedIndex data (2 * n)) :
     data.blockedStructureCoefficients n i j k =
-      ((cmp.pulledBlockedChiFamily hχ).matrix n i j k ^ n).trace := by
+      ((cmp.pulledBlockedChiFamily hχ).matrix n hn i j k ^ n).trace := by
   rw [cmp.blocked_coeff_eq_trace_pow hχ n hn i j k]
   rw [cmp.pulledBlockedChi_trace_matrix_pow_of_pos hχ n hn i j k n]
 
@@ -718,8 +707,7 @@ positive blocked chi trace-power witness.
 This is a derived blocked-basis statement.  It does not construct the BNT-label
 coefficient family or comparison maps from an MPDO tensor; it only transports an
 already given uniform BNT-label witness along an already given comparison.  The
-unused zero-length component of the blocked chi family is filled by empty
-diagonal matrices.
+blocked family is indexed only at positive lengths.
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and Appendix C.3--C.4,
 lines 1830--1942 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 def toPositiveBlockedStructureChiTracePowerForm
@@ -727,8 +715,8 @@ def toPositiveBlockedStructureChiTracePowerForm
     (hχ : PositiveBNTLabelChiTracePowerForm c) :
     AlgebraStructureData.PositiveBlockedStructureChiTracePowerForm data where
   chi := cmp.pulledBlockedChiFamily hχ
-  posEntries := fun n i j k r =>
-    cmp.pulledBlockedChiFamily_toDiagonal_posEntries hχ n
+  posEntries := fun n hn i j k r =>
+    cmp.pulledBlockedChiFamily_toDiagonal_posEntries hχ n hn
       (Sum.inl i) (Sum.inl j) (Sum.inr k) r
   tracePower := by
     intro n hn i j k

--- a/TNLean/MPS/MPDO/BNTTheoremData.lean
+++ b/TNLean/MPS/MPDO/BNTTheoremData.lean
@@ -461,7 +461,7 @@ Appendix C.3--C.4, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem positiveBlockedChi_toDiagonal_of_pos
     (n : ℕ) (hn : 0 < n) :
-    H.positiveBlockedChi.toDiagonal n =
+    H.positiveBlockedChi.toDiagonal n hn =
       H.positiveChi.chi.comap (H.blockedComparison.blockedLabel n hn) :=
   H.blockedComparison.pulledBlockedChiFamily_toDiagonal_of_pos H.positiveChi n hn
 
@@ -477,7 +477,7 @@ theorem positiveBlockedChi_tracePowerCoeff_of_pos
     (i j : AlgebraStructureData.BlockedIndex data n)
     (k : AlgebraStructureData.BlockedIndex data (2 * n))
     (L : ℕ) :
-    H.positiveBlockedChi.tracePowerCoeff n i j k L =
+    H.positiveBlockedChi.tracePowerCoeff n hn i j k L =
       H.positiveChi.chi.tracePowerCoeff
         (H.sourceLabel n hn i) (H.sourceLabel n hn j) (H.targetLabel n hn k) L :=
   H.blockedComparison.pulledBlockedChi_tracePowerCoeff_of_pos
@@ -493,7 +493,7 @@ theorem positiveBlockedChi_dim_of_pos
     (n : ℕ) (hn : 0 < n)
     (i j : AlgebraStructureData.BlockedIndex data n)
     (k : AlgebraStructureData.BlockedIndex data (2 * n)) :
-    H.positiveBlockedChi.dim n i j k =
+    H.positiveBlockedChi.dim n hn i j k =
       H.positiveChi.chi.dim
         (H.sourceLabel n hn i) (H.sourceLabel n hn j) (H.targetLabel n hn k) :=
   H.blockedComparison.pulledBlockedChi_dim_of_pos H.positiveChi n hn i j k
@@ -510,7 +510,7 @@ theorem positiveBlockedChi_trace_matrix_pow_of_pos
     (i j : AlgebraStructureData.BlockedIndex data n)
     (k : AlgebraStructureData.BlockedIndex data (2 * n))
     (L : ℕ) :
-    (H.positiveBlockedChi.matrix n i j k ^ L).trace =
+    (H.positiveBlockedChi.matrix n hn i j k ^ L).trace =
       (H.positiveChi.chi.matrix
         (H.sourceLabel n hn i) (H.sourceLabel n hn j) (H.targetLabel n hn k) ^
           L).trace :=
@@ -544,11 +544,11 @@ Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
 Appendix C.3--C.4, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 lemma positiveBlockedChi_entry_pos
-    (n : ℕ) (i j : AlgebraStructureData.BlockedIndex data n)
+    (n : ℕ) (hn : 0 < n) (i j : AlgebraStructureData.BlockedIndex data n)
     (k : AlgebraStructureData.BlockedIndex data (2 * n))
-    (r : Fin (H.positiveBlockedChi.dim n i j k)) :
-    0 < H.positiveBlockedChi.entry n i j k r :=
-  H.toPositiveBlockedStructureChiTracePowerForm.posEntries n i j k r
+    (r : Fin (H.positiveBlockedChi.dim n hn i j k)) :
+    0 < H.positiveBlockedChi.entry n hn i j k r :=
+  H.toPositiveBlockedStructureChiTracePowerForm.posEntries n hn i j k r
 
 /-- The blocked-basis coefficients obtained from BNT-label theorem data are
 traces of powers of the pulled-back blocked-basis chi matrices.
@@ -561,7 +561,7 @@ lemma blocked_coeff_eq_positiveBlockedChi_trace_pow
     (i j : AlgebraStructureData.BlockedIndex data n)
     (k : AlgebraStructureData.BlockedIndex data (2 * n)) :
     data.blockedStructureCoefficients n i j k =
-      (H.positiveBlockedChi.matrix n i j k ^ n).trace :=
+      (H.positiveBlockedChi.matrix n hn i j k ^ n).trace :=
   H.toPositiveBlockedStructureChiTracePowerForm.eq_trace_pow n hn i j k
 
 end BNTLabelTheoremData

--- a/TNLean/MPS/MPDO/BNTTheoremWitness.lean
+++ b/TNLean/MPS/MPDO/BNTTheoremWitness.lean
@@ -150,11 +150,11 @@ theorem exists_blocked_coeff_eq_trace_pow {data : AlgebraStructureData d D}
     (h : HasBNTLabelTheoremWitness data) :
     ∃ χ : AlgebraStructureData.BlockedStructureChiFamily data,
       χ.PosEntries ∧
-        ∀ (n : ℕ), 0 < n →
+        ∀ (n : ℕ) (hn : 0 < n),
           ∀ (i j : AlgebraStructureData.BlockedIndex data n)
             (k : AlgebraStructureData.BlockedIndex data (2 * n)),
           data.blockedStructureCoefficients n i j k =
-            (χ.matrix n i j k ^ n).trace := by
+            (χ.matrix n hn i j k ^ n).trace := by
   rcases h.exists_blocked_chi_trace_power_form with ⟨χ, hpos, htrace⟩
   refine ⟨χ, hpos, ?_⟩
   intro n hn i j k
@@ -572,7 +572,7 @@ Appendix C.3--C.4, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem positiveBlockedChi_toDiagonal_of_pos
     (n : ℕ) (hn : 0 < n) :
-    W.positiveBlockedChi.toDiagonal n =
+    W.positiveBlockedChi.toDiagonal n hn =
       W.positiveChi.chi.comap (W.blockedComparison.blockedLabel n hn) :=
   W.toTheoremData.positiveBlockedChi_toDiagonal_of_pos n hn
 
@@ -588,7 +588,7 @@ theorem positiveBlockedChi_tracePowerCoeff_of_pos
     (i j : AlgebraStructureData.BlockedIndex data n)
     (k : AlgebraStructureData.BlockedIndex data (2 * n))
     (L : ℕ) :
-    W.positiveBlockedChi.tracePowerCoeff n i j k L =
+    W.positiveBlockedChi.tracePowerCoeff n hn i j k L =
       W.positiveChi.chi.tracePowerCoeff
         (W.sourceLabel n hn i) (W.sourceLabel n hn j) (W.targetLabel n hn k) L :=
   W.toTheoremData.positiveBlockedChi_tracePowerCoeff_of_pos n hn i j k L
@@ -604,7 +604,7 @@ theorem positiveBlockedChi_dim_of_pos
     (n : ℕ) (hn : 0 < n)
     (i j : AlgebraStructureData.BlockedIndex data n)
     (k : AlgebraStructureData.BlockedIndex data (2 * n)) :
-    W.positiveBlockedChi.dim n i j k =
+    W.positiveBlockedChi.dim n hn i j k =
       W.positiveChi.chi.dim
         (W.sourceLabel n hn i) (W.sourceLabel n hn j) (W.targetLabel n hn k) :=
   W.toTheoremData.positiveBlockedChi_dim_of_pos n hn i j k
@@ -621,7 +621,7 @@ theorem positiveBlockedChi_trace_matrix_pow_of_pos
     (i j : AlgebraStructureData.BlockedIndex data n)
     (k : AlgebraStructureData.BlockedIndex data (2 * n))
     (L : ℕ) :
-    (W.positiveBlockedChi.matrix n i j k ^ L).trace =
+    (W.positiveBlockedChi.matrix n hn i j k ^ L).trace =
       (W.positiveChi.chi.matrix
         (W.sourceLabel n hn i) (W.sourceLabel n hn j) (W.targetLabel n hn k) ^
           L).trace :=
@@ -654,11 +654,11 @@ Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and
 Appendix C.3--C.4, lines 1830--1942 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 lemma positiveBlockedChi_entry_pos
-    (n : ℕ) (i j : AlgebraStructureData.BlockedIndex data n)
+    (n : ℕ) (hn : 0 < n) (i j : AlgebraStructureData.BlockedIndex data n)
     (k : AlgebraStructureData.BlockedIndex data (2 * n))
-    (r : Fin (W.positiveBlockedChi.dim n i j k)) :
-    0 < W.positiveBlockedChi.entry n i j k r :=
-  W.toPositiveBlockedStructureChiTracePowerForm.posEntries n i j k r
+    (r : Fin (W.positiveBlockedChi.dim n hn i j k)) :
+    0 < W.positiveBlockedChi.entry n hn i j k r :=
+  W.toPositiveBlockedStructureChiTracePowerForm.posEntries n hn i j k r
 
 /-- For an existential BNT-label theorem witness, the blocked-basis
 coefficients are traces of powers of the pulled-back blocked-basis chi
@@ -672,7 +672,7 @@ lemma blocked_coeff_eq_positiveBlockedChi_trace_pow
     (i j : AlgebraStructureData.BlockedIndex data n)
     (k : AlgebraStructureData.BlockedIndex data (2 * n)) :
     data.blockedStructureCoefficients n i j k =
-      (W.positiveBlockedChi.matrix n i j k ^ n).trace :=
+      (W.positiveBlockedChi.matrix n hn i j k ^ n).trace :=
   W.toPositiveBlockedStructureChiTracePowerForm.eq_trace_pow n hn i j k
 
 end BNTLabelTheoremWitness

--- a/TNLean/MPS/MPDO/BNTTheoremWitnessConsequences.lean
+++ b/TNLean/MPS/MPDO/BNTTheoremWitnessConsequences.lean
@@ -125,7 +125,7 @@ theorem exists_blocked_chi_pullback {data : AlgebraStructureData d D}
     (h : HasBNTLabelTheoremWitness data) :
     ∃ W : BNTLabelTheoremWitness data,
       ∀ (n : ℕ) (hn : 0 < n),
-        W.positiveBlockedChi.toDiagonal n =
+        W.positiveBlockedChi.toDiagonal n hn =
           W.positiveChi.chi.comap (W.blockedComparison.blockedLabel n hn) := by
   obtain ⟨W⟩ := h
   exact ⟨W, W.positiveBlockedChi_toDiagonal_of_pos⟩

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -316,7 +316,8 @@
     \lean{MPOTensor.AlgebraStructureData.BlockedStructureChiFamily}
     \leanok
     \uses{def:mpdo_blocked_structure_coefficients}
-    For each blocked multiplication triple $(n,i,j,k)$, where $i$ and $j$
+    For each positive blocked size $n$ and multiplication triple $(i,j,k)$,
+    where $i$ and $j$
     label basis elements of $\mathcal{A}_n$ and $k$ labels a basis element of
     $\mathcal{A}_{2n}$, a size $r_{n,i,j,k} \in \N$ and diagonal entries
     $\chi_{n,i,j,k,1}, \ldots, \chi_{n,i,j,k,r_{n,i,j,k}} \in \C$, giving the
@@ -337,8 +338,8 @@
     \lean{MPOTensor.AlgebraStructureData.BlockedStructureChiFamily.trace_matrix_pow}
     \leanok
     \uses{def:mpdo_blocked_structure_chi_family}
-    For each blocked multiplication triple $(n,i,j,k)$ and every exponent
-    $L$,
+    For each positive blocked size $n$, each multiplication triple $(i,j,k)$,
+    and every exponent $L$,
     \[
         \operatorname{tr}(\chi_{n,i,j,k}^{\,L})
         = \sum_r \chi_{n,i,j,k,r}^{\,L}.
@@ -427,9 +428,6 @@
     The construction is obtained by pulling back the BNT-label
     $\chi_{\alpha,\beta,\gamma}$-matrices along the source and target label
     maps.
-    % Formalization note: the zero-length component of the blocked chi family is
-    % filled by empty diagonal matrices; it plays no role in the positive-length
-    % trace-power statement.
 \end{theorem}
 \begin{proof}\leanok
     Reindex the positive BNT-label $\chi$-family along the blocked-basis

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -64,8 +64,9 @@ therefore express a positive-length, length-dependent blocked-basis analogue:
 \]
 Here $n$ is the source blocking length of the two factors in
 $\mathcal A_n$, while the coefficient $k$ is taken in the basis of
-$\mathcal A_{2n}$. The predicate is intentionally restricted to
-$0 < n$, avoiding the degenerate length-zero constraint
+$\mathcal A_{2n}$. Both the family and its trace-power predicate are indexed
+only by $0 < n$, so there is no length-zero component and no degenerate
+constraint
 $c^{(0)}_{i,j,k} = \dim(\chi_{0,i,j,k})$, which is not part of the intended
 positive-chain statement.
 


### PR DESCRIPTION
## Summary

- Makes every blocked chi family carry the condition `0 < n` at the family level.
- Removes the artificial `n = 0` empty diagonal family and its vacuous positivity lemma.
- Propagates the positive-length index through the BNT comparison, theorem-data, and witness statements, and aligns the blueprint and paper-gap account.

## Mathematical scope

The blocked trace-power formulas were already stated only for positive blocking lengths. The change introduces no new mathematical hypothesis; it removes data outside the intended positive-chain domain. The source comparison remains arXiv:1606.00608, Theorem IV.13(ii), lines 972–985 and Appendix C.3–C.4, lines 1830–1942, with the remaining blocked-basis uniformity restriction recorded in `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`.

## Verification

- `lake build`
- `lake exe checkdecls blueprint/lean_decls`
- `git diff --check`
- no new `sorry`, axiom, admission, or kernel bypass

Closes #4099

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> API and documentation refactor across Lean formalization and blueprint; no change to stated theorems or runtime behavior beyond removing unused `n = 0` data.
> 
> **Overview**
> **Blocked χ families are now indexed only where the theory already applies:** `BlockedStructureChiFamily.toDiagonal` and the blocked `dim` / `entry` / `matrix` / trace-power API all take an explicit `0 < n` proof, instead of defining data at every `n` and filling `n = 0` with placeholders.
> 
> This removes `DiagonalChiFamily.empty` and the vacuous `PosEntries.empty` lemma, and drops the `if 0 < n then … else empty` branch in `pulledBlockedChiFamily`—pullback is always `hχ.chi.comap (cmp.blockedLabel n hn)` at positive length. The same `hn` threading is applied through BNT comparison, theorem data, witnesses, and consequences; blueprint and `cpgsv17_blocked_chi_uniformity.tex` are updated to say the family and trace-power predicates have no length-zero component.
> 
> **No new mathematical hypotheses:** blocked trace-power statements were already quantified over positive blocking lengths; this aligns types with that domain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e99f99242169cd7132ba1d5fd00ce763c53e9503. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->