### PR TITLE
feat(MPS/MPDO): prove positivity and ZCL of BNT sectors

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -448,6 +448,7 @@ import TNLean.MPS.MPDO.BNTThreeSiteReducedClosure
 import TNLean.MPS.MPDO.BNTSourceSectorProjectors
 import TNLean.MPS.MPDO.SitewisePhysicalMatrix
 import TNLean.MPS.MPDO.BNTProjectorSelection
+import TNLean.MPS.MPDO.BNTSectorAnalyticProperties
 import TNLean.MPS.MPDO.HayashiSectorProjector
 import TNLean.MPS.MPDO.EtaPreparation
 import TNLean.MPS.MPDO.RFPSubspinMaps

--- a/TNLean/MPS/MPDO/BNTSectorAnalyticProperties.lean
+++ b/TNLean/MPS/MPDO/BNTSectorAnalyticProperties.lean
@@ -1,0 +1,182 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.BNTProjectorSelection
+
+/-!
+# Positivity and zero correlation length of the BNT sectors
+
+For a simple tensor satisfying the saturated area law and zero correlation
+length, Appendix C.2 of arXiv:1606.00608 passes from the sector compression
+formula
+\[
+  P_s^{\otimes N}\sigma^{(N)}(K)P_s^{\otimes N}
+    =n_s\sigma^{(N)}(\mathcal K_s)
+\]
+to the corresponding analytic properties of each absorbed normal
+representative \(\mathcal K_s\).
+
+This file proves the first and third properties in that passage.  Positivity
+of every \(\sigma^{(N)}(\mathcal K_s)\) follows from the compression formula
+and \(n_s>0\).  Zero correlation length follows from the blockwise transfer
+equation already used to prove that the copy weights are independent of the
+copy index.
+
+## Main results
+
+* `commonWeightAbsorbedBasisMPOTensor_isMPDO_of_projectorSelection`:
+  the positive compression formula makes every absorbed representative an
+  MPDO.
+* `commonWeightAbsorbedBasisMPOTensor_isMPDO_of_sameMPV₂Pos_isSAL`:
+  the source projector construction supplies the required compression.
+* `commonWeightAbsorbedBasisMPOTensor_isSourceZCL`:
+  source zero correlation length restricts to every absorbed representative.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Appendix C.2, lines 1753--1781.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+namespace MPOTensor
+
+variable {d : ℕ}
+
+/-- The physical-trace transfer of the absorbed representative
+\(\mathcal K_s=\mu_s A_s\) is \(\mu_s\mathcal B_s\).
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1660--1665 and 1753--1759. -/
+theorem physTraceTransfer_commonWeightAbsorbedBasisMPOTensor
+    (S : MPSTensor.SectorDecomposition (d * d))
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q') (s : Fin S.basisCount) :
+    physTraceTransfer (commonWeightAbsorbedBasisMPOTensor S hWeight s) =
+      S.commonWeight hWeight s • doubledPhysTraceTransfer d (S.basis s) := by
+  rw [← doubledPhysTraceTransfer_toMPSTensor,
+    commonWeightAbsorbedBasisMPOTensor_toMPSTensor]
+  unfold doubledPhysTraceTransfer
+  rw [Finset.smul_sum]
+  simp only [MPSTensor.SectorDecomposition.commonWeightAbsorbedBasis]
+
+/-- The source zero-correlation-length equation restricts to every absorbed
+normal representative in the horizontal canonical form.
+
+The nonnilpotence condition is used only to exclude the zero transfer.  The
+quadratic equation itself is the corresponding diagonal block of the
+zero-correlation-length equation for the full canonical-form tensor.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1646--1657 and 1781. -/
+theorem commonWeightAbsorbedBasisMPOTensor_isSourceZCL
+    {D : ℕ} (M : MPOTensor d D)
+    (S : MPSTensor.SectorDecomposition (d * d)) (hTotal : S.totalDim = D)
+    (X : (s : Fin S.totalCopies) → GL (Fin (S.flatDim s)) ℂ)
+    (hEq : ∀ i : Fin (d * d),
+      M.toMPSTensor i =
+        cast (by rw [hTotal] :
+            Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ =
+              Matrix (Fin D) (Fin D) ℂ)
+          ((MPSTensor.globalGaugeOfBlocks X :
+                Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ) *
+            S.toTensor i *
+            (((MPSTensor.globalGaugeOfBlocks X)⁻¹ :
+                GL (Fin S.totalDim) ℂ) :
+              Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ)))
+    (hZCL : IsSourceZCL M)
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q') (s : Fin S.basisCount)
+    (hnonNil : ¬ IsNilpotent (doubledPhysTraceTransfer d (S.basis s))) :
+    IsSourceZCL (commonWeightAbsorbedBasisMPOTensor S hWeight s) := by
+  obtain ⟨lam, hlam, hSq⟩ :=
+    exists_weighted_basis_physTraceTransfer_sq_of_isSourceZCL
+      S hTotal X hEq hZCL
+  have htransfer :=
+    physTraceTransfer_commonWeightAbsorbedBasisMPOTensor S hWeight s
+  have hbasis : doubledPhysTraceTransfer d (S.basis s) ≠ 0 := by
+    intro hzero
+    exact hnonNil (by rw [hzero]; exact IsNilpotent.zero)
+  have hweighted :
+      S.commonWeight hWeight s • doubledPhysTraceTransfer d (S.basis s) ≠ 0 := by
+    exact smul_ne_zero (S.commonWeight_ne_zero hWeight s) hbasis
+  have hsquare := hSq s ⟨0, S.copies_pos s⟩
+  rw [S.weight_eq_commonWeight hWeight] at hsquare
+  rw [IsSourceZCL, htransfer]
+  exact ⟨hweighted, lam, hlam, hsquare⟩
+
+/-- If the tensor-power BNT projection selects an absorbed representative,
+then that representative generates positive semidefinite operators on every
+nonempty chain.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1753--1759. -/
+theorem commonWeightAbsorbedBasisMPOTensor_isMPDO_of_projectorSelection
+    {D : ℕ} (M : MPOTensor d D)
+    (S : MPSTensor.SectorDecomposition (d * d))
+    (hM : MPSTensor.SameMPV₂Pos M.toMPSTensor S.toTensor)
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q')
+    {R : (s : Fin S.basisCount) →
+      Matrix (Fin (S.basisDim s)) (Fin (S.basisDim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex S.basisDim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse
+      (fun j ↦ S.basisMPOTensor j) C)
+    (hρ : IsThreeSiteFamilyClosure (fun j ↦ S.basisMPOTensor j) R ρ)
+    (hη : EtaStructure ρ) (hR : ∀ s : Fin S.basisCount, R s ≠ 0)
+    (hMpdo : IsMPDO M) (s : Fin S.basisCount) :
+    IsMPDO (commonWeightAbsorbedBasisMPOTensor S hWeight s) := by
+  intro N hN
+  let P := sitewisePhysicalMatrix (bntSectorProjection hC hρ hη hR s) N
+  have heq : P * mpo M N * P =
+      (S.copies s : ℂ) • mpo (commonWeightAbsorbedBasisMPOTensor S hWeight s) N :=
+    sitewise_bntSectorProjection_mul_mpo_mul_self
+      M S hM hWeight hC hρ hη hR hN s
+  have hP : P.IsHermitian := sitewisePhysicalMatrix_isHermitian
+    (bntSectorProjection_isOrthogonal hC hρ hη hR s).1 N
+  have hcompressed : (P * mpo M N * P).PosSemidef := by
+    simpa only [hP.eq] using (hMpdo N hN).mul_mul_conjTranspose_same P
+  rw [heq] at hcompressed
+  have hcopiesNonneg : (0 : ℂ) ≤ (S.copies s : ℂ) := by
+    exact_mod_cast (S.copies_pos s).le
+  have hcopiesNe : (S.copies s : ℂ) ≠ 0 := by
+    exact_mod_cast Nat.ne_of_gt (S.copies_pos s)
+  have hrescaled := hcompressed.smul (a := (S.copies s : ℂ)⁻¹)
+    (inv_nonneg.mpr hcopiesNonneg)
+  simpa only [smul_smul, inv_mul_cancel₀ hcopiesNe, one_smul] using hrescaled
+
+/-- Under the source hypotheses used to construct the BNT projectors, every
+absorbed normal representative generates an MPDO.
+
+**Scope restriction (common blocking):** the one-letter simultaneous span is
+the blocked form used for the simultaneous inverse.  Its derivation from biCF
+is recorded in `docs/paper-gaps/cpgsv17_bicf_block_separation.tex`.
+
+**Axiom boundary:** the projector construction uses the existing forward
+Hayashi--Ruskai--Hayden--Jozsa--Petz--Winter characterization of equality in
+strong subadditivity, isolated as
+`hayashi_ssa_equality_characterization_forward`.  No further axiom is used.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1680--1759. -/
+theorem commonWeightAbsorbedBasisMPOTensor_isMPDO_of_sameMPV₂Pos_isSAL
+    {D : ℕ} (M : MPOTensor d D)
+    (S : MPSTensor.SectorDecomposition (d * d))
+    (hM : MPSTensor.SameMPV₂Pos M.toMPSTensor S.toTensor)
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q')
+    (hnonNil : ∀ j,
+      ¬ IsNilpotent (doubledPhysTraceTransfer d (S.basis j)))
+    (hSpan : MPSTensor.WordTupleSpanTop S.basis 1)
+    (hSAL : IsSAL M) (s : Fin S.basisCount) :
+    IsMPDO (commonWeightAbsorbedBasisMPOTensor S hWeight s) := by
+  obtain ⟨C, hC, hη, _hlocal, _hcompression⟩ :=
+    exists_bntProjectorSelection_positiveLength_of_sameMPV₂Pos_isSAL
+      M S hM hWeight hnonNil hSpan hSAL
+  let hClosure :=
+    reducedBlockState_four_threeSiteFamilyClosure_nonzero_closing
+      M S hM hWeight hnonNil hSAL
+  exact commonWeightAbsorbedBasisMPOTensor_isMPDO_of_projectorSelection
+    M S hM hWeight hC hClosure.1 hη hClosure.2 (Classical.choose hSAL) s
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/SimpleTensor.lean
+++ b/TNLean/MPS/MPDO/SimpleTensor.lean
@@ -145,6 +145,99 @@ theorem IsSimpleCanonicalForm.isHorizontalCF {M : MPOTensor d D}
   obtain ⟨-, S, hCF, -, hTotal, X, hEq⟩ := hM
   exact ⟨S, hCF, hTotal, X, hEq⟩
 
+/-- The zero-correlation-length equation restricts to every copy of every
+normal representative in the horizontal canonical form:
+\[
+  (\mu_{j,q}\mathcal B_j)^2
+    =\lambda\,\mu_{j,q}\mathcal B_j,
+  \qquad \lambda>0.
+\]
+
+This is the block equation used before the source compares two copy indices.
+
+Source: arXiv:1606.00608, Appendix C.2, equation in lines 1652--1657. -/
+theorem exists_weighted_basis_physTraceTransfer_sq_of_isSourceZCL
+    {M : MPOTensor d D}
+    (S : MPSTensor.SectorDecomposition (d * d)) (hTotal : S.totalDim = D)
+    (X : (s : Fin S.totalCopies) → GL (Fin (S.flatDim s)) ℂ)
+    (hEq : ∀ i : Fin (d * d),
+      M.toMPSTensor i =
+        cast (by rw [hTotal] :
+            Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ =
+              Matrix (Fin D) (Fin D) ℂ)
+          ((MPSTensor.globalGaugeOfBlocks X :
+                Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ) *
+            S.toTensor i *
+            (((MPSTensor.globalGaugeOfBlocks X)⁻¹ :
+                GL (Fin S.totalDim) ℂ) :
+              Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ)))
+    (hZCL : IsSourceZCL M) :
+    ∃ lam : ℝ, 0 < lam ∧ ∀ (j : Fin S.basisCount) (q : Fin (S.copies j)),
+      (S.weight j q • doubledPhysTraceTransfer d (S.basis j)) *
+          (S.weight j q • doubledPhysTraceTransfer d (S.basis j)) =
+        (lam : ℂ) • (S.weight j q • doubledPhysTraceTransfer d (S.basis j)) := by
+  classical
+  subst hTotal
+  obtain ⟨-, lam, hlam, hsq⟩ := hZCL
+  have hX' : ∀ i : Fin (d * d), M.toMPSTensor i =
+      (MPSTensor.globalGaugeOfBlocks X :
+          Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ) *
+        S.toTensor i *
+        (((MPSTensor.globalGaugeOfBlocks X)⁻¹ : GL (Fin S.totalDim) ℂ) :
+          Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ) := fun i ↦ by
+    simpa using hEq i
+  have hT : physTraceTransfer M =
+      (MPSTensor.globalGaugeOfBlocks X :
+          Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ) *
+        doubledPhysTraceTransfer d S.toTensor *
+        (((MPSTensor.globalGaugeOfBlocks X)⁻¹ : GL (Fin S.totalDim) ℂ) :
+          Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ) := by
+    rw [← doubledPhysTraceTransfer_toMPSTensor M]
+    simp only [doubledPhysTraceTransfer]
+    rw [Matrix.mul_sum, Matrix.sum_mul]
+    exact Finset.sum_congr rfl fun i _ ↦ hX' (finProdFinEquiv (i, i))
+  rw [hT] at hsq
+  have hRR :
+      doubledPhysTraceTransfer d S.toTensor * doubledPhysTraceTransfer d S.toTensor =
+        (lam : ℂ) • doubledPhysTraceTransfer d S.toTensor := by
+    have h2 := congrArg (fun Z ↦
+      (((MPSTensor.globalGaugeOfBlocks X)⁻¹ : GL (Fin S.totalDim) ℂ) :
+          Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ) * Z *
+        (MPSTensor.globalGaugeOfBlocks X :
+          Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ)) hsq
+    simpa only [Matrix.mul_smul, Matrix.smul_mul, mul_assoc,
+      Units.inv_mul_cancel_left, Units.inv_mul, mul_one] using h2
+  rw [doubledPhysTraceTransfer_toTensor] at hRR
+  have hfun :
+      (fun s ↦ (S.flatWeight s • doubledPhysTraceTransfer d (S.flatBasis s)) *
+          (S.flatWeight s • doubledPhysTraceTransfer d (S.flatBasis s))) =
+        (lam : ℂ) • fun s ↦
+          S.flatWeight s • doubledPhysTraceTransfer d (S.flatBasis s) := by
+    apply Matrix.blockDiagonal'_injective
+    apply (Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv).injective
+    simpa only [Matrix.reindex_apply, Matrix.blockDiagonal'_mul,
+      Matrix.blockDiagonal'_smul, Matrix.submatrix_mul_equiv,
+      Matrix.submatrix_smul, Pi.smul_apply] using hRR
+  refine ⟨lam, hlam, ?_⟩
+  intro j q
+  have h :
+      (S.weight (S.flatIndexEquiv.symm (S.flatIndexEquiv ⟨j, q⟩)).1
+            (S.flatIndexEquiv.symm (S.flatIndexEquiv ⟨j, q⟩)).2 •
+          doubledPhysTraceTransfer d
+            (S.basis (S.flatIndexEquiv.symm (S.flatIndexEquiv ⟨j, q⟩)).1)) *
+        (S.weight (S.flatIndexEquiv.symm (S.flatIndexEquiv ⟨j, q⟩)).1
+            (S.flatIndexEquiv.symm (S.flatIndexEquiv ⟨j, q⟩)).2 •
+          doubledPhysTraceTransfer d
+            (S.basis (S.flatIndexEquiv.symm (S.flatIndexEquiv ⟨j, q⟩)).1)) =
+      (lam : ℂ) •
+        (S.weight (S.flatIndexEquiv.symm (S.flatIndexEquiv ⟨j, q⟩)).1
+            (S.flatIndexEquiv.symm (S.flatIndexEquiv ⟨j, q⟩)).2 •
+          doubledPhysTraceTransfer d
+            (S.basis (S.flatIndexEquiv.symm (S.flatIndexEquiv ⟨j, q⟩)).1)) :=
+    congrFun hfun (S.flatIndexEquiv ⟨j, q⟩)
+  rw [Equiv.symm_apply_apply] at h
+  simpa [Pi.smul_apply] using h
+
 /-- **Zero correlation length makes the sector weights copy independent**
 (arXiv:1606.00608, Appendix C.2, lines 1646--1661).  Let the doubled-index
 view of $M$ be in canonical form over a basis of normal tensors with per-copy
@@ -179,66 +272,9 @@ theorem weight_copy_independent_of_isSourceZCL {M : MPOTensor d D}
     (j : Fin S.basisCount) (q q' : Fin (S.copies j)) :
     S.weight j q = S.weight j q' := by
   classical
-  subst hTotal
-  obtain ⟨-, lam, hlam, hsq⟩ := hZCL
-  have hX' : ∀ i : Fin (d * d), M.toMPSTensor i =
-      (MPSTensor.globalGaugeOfBlocks X : Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ) *
-        S.toTensor i *
-        (((MPSTensor.globalGaugeOfBlocks X)⁻¹ : GL (Fin S.totalDim) ℂ) :
-          Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ) := fun i => by simpa using hEq i
-  -- Contract the ket leg against the bra leg in the canonical form.
-  have hT : physTraceTransfer M =
-      (MPSTensor.globalGaugeOfBlocks X : Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ) *
-        doubledPhysTraceTransfer d S.toTensor *
-        (((MPSTensor.globalGaugeOfBlocks X)⁻¹ : GL (Fin S.totalDim) ℂ) :
-          Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ) := by
-    rw [← doubledPhysTraceTransfer_toMPSTensor M]
-    simp only [doubledPhysTraceTransfer]
-    rw [Matrix.mul_sum, Matrix.sum_mul]
-    exact Finset.sum_congr rfl fun i _ => hX' (finProdFinEquiv (i, i))
-  rw [hT] at hsq
-  -- Cancel the global gauge in the zero-correlation-length equation.
-  have hRR : doubledPhysTraceTransfer d S.toTensor * doubledPhysTraceTransfer d S.toTensor =
-      (lam : ℂ) • doubledPhysTraceTransfer d S.toTensor := by
-    have h2 := congrArg (fun Z =>
-      (((MPSTensor.globalGaugeOfBlocks X)⁻¹ : GL (Fin S.totalDim) ℂ) :
-        Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ) * Z *
-        (MPSTensor.globalGaugeOfBlocks X :
-          Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ)) hsq
-    simpa only [Matrix.mul_smul, Matrix.smul_mul, mul_assoc, Units.inv_mul_cancel_left,
-      Units.inv_mul, mul_one] using h2
-  rw [doubledPhysTraceTransfer_toTensor] at hRR
-  -- Blockwise form of the zero-correlation-length equation.
-  have hfun : (fun s => (S.flatWeight s • doubledPhysTraceTransfer d (S.flatBasis s)) *
-        (S.flatWeight s • doubledPhysTraceTransfer d (S.flatBasis s))) =
-      (lam : ℂ) • fun s => S.flatWeight s • doubledPhysTraceTransfer d (S.flatBasis s) := by
-    apply Matrix.blockDiagonal'_injective
-    apply (Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv).injective
-    simpa only [Matrix.reindex_apply, Matrix.blockDiagonal'_mul, Matrix.blockDiagonal'_smul,
-      Matrix.submatrix_mul_equiv, Matrix.submatrix_smul, Pi.smul_apply] using hRR
-  -- Restrict to the copies of the representative `j`.
-  have key : ∀ r : Fin (S.copies j),
-      (S.weight j r • doubledPhysTraceTransfer d (S.basis j)) *
-          (S.weight j r • doubledPhysTraceTransfer d (S.basis j)) =
-        (lam : ℂ) • (S.weight j r • doubledPhysTraceTransfer d (S.basis j)) := by
-    intro r
-    have h :
-        (S.weight (S.flatIndexEquiv.symm (S.flatIndexEquiv ⟨j, r⟩)).1
-              (S.flatIndexEquiv.symm (S.flatIndexEquiv ⟨j, r⟩)).2 •
-            doubledPhysTraceTransfer d
-              (S.basis (S.flatIndexEquiv.symm (S.flatIndexEquiv ⟨j, r⟩)).1)) *
-          (S.weight (S.flatIndexEquiv.symm (S.flatIndexEquiv ⟨j, r⟩)).1
-              (S.flatIndexEquiv.symm (S.flatIndexEquiv ⟨j, r⟩)).2 •
-            doubledPhysTraceTransfer d
-              (S.basis (S.flatIndexEquiv.symm (S.flatIndexEquiv ⟨j, r⟩)).1)) =
-        (lam : ℂ) •
-          (S.weight (S.flatIndexEquiv.symm (S.flatIndexEquiv ⟨j, r⟩)).1
-              (S.flatIndexEquiv.symm (S.flatIndexEquiv ⟨j, r⟩)).2 •
-            doubledPhysTraceTransfer d
-              (S.basis (S.flatIndexEquiv.symm (S.flatIndexEquiv ⟨j, r⟩)).1)) :=
-      congrFun hfun (S.flatIndexEquiv ⟨j, r⟩)
-    rw [Equiv.symm_apply_apply] at h
-    exact h
+  obtain ⟨lam, hlam, key⟩ :=
+    exists_weighted_basis_physTraceTransfer_sq_of_isSourceZCL
+      S hTotal X hEq hZCL
   -- The basis transfer is nonzero, so the scalars can be compared.
   have hTj0 : doubledPhysTraceTransfer d (S.basis j) ≠ 0 := by
     intro h0
@@ -248,7 +284,7 @@ theorem weight_copy_independent_of_isSourceZCL {M : MPOTensor d D}
         ((lam : ℂ) / S.weight j r) • doubledPhysTraceTransfer d (S.basis j) := by
     intro r
     have hμ : S.weight j r ≠ 0 := S.weight_ne_zero j r
-    have hk := key r
+    have hk := key j r
     rw [smul_mul_smul_comm, smul_smul] at hk
     have h3 := congrArg (fun Z => (S.weight j r * S.weight j r)⁻¹ • Z) hk
     simp only [smul_smul] at h3

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_case_two.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_case_two.tex
@@ -1,12 +1,44 @@
 \subsection{Simple canonical-form weights}
 
+\begin{lemma}[Blockwise zero-correlation-length equation]
+    \label{lem:mpdo_simple_blockwise_zcl_equation}
+    \lean{MPOTensor.%
+      exists_weighted_basis_physTraceTransfer_sq_of_isSourceZCL}
+    \leanok
+    \uses{def:mpo_source_zcl, def:mpdo_doubled_phys_trace_transfer,
+        lem:mpdo_doubled_phys_trace_transfer_to_mps,
+        lem:mpdo_doubled_phys_trace_transfer_blockwise}
+    Suppose a tensor with zero correlation length is gauge-equivalent, through
+    block-diagonal copy gauges, to an assembled sector decomposition.  There
+    is a scalar $\lambda>0$ such that every copy satisfies
+    \[
+      (\mu_{j,q}\mathcal T_{A_j})^2
+        =\lambda\mu_{j,q}\mathcal T_{A_j}.
+    \]
+    This is the block equation in
+    \cite[Appendix~C.2, lines~1652--1657]{Cirac2016MPDO_arXiv}.
+\end{lemma}
+
+\begin{proof}\leanok
+    Write $\mathcal T_M=G\mathcal T_SG^{-1}$, where $G$ is the induced
+    block-diagonal gauge.  The equation
+    $\mathcal T_M^2=\lambda\mathcal T_M$ therefore becomes
+    $\mathcal T_S^2=\lambda\mathcal T_S$ after conjugation by $G^{-1}$.
+    Restriction to the $(j,q)$-th diagonal block gives
+    \[
+      (\mu_{j,q}\mathcal T_{A_j})^2
+        =\lambda\mu_{j,q}\mathcal T_{A_j}.
+    \]
+\end{proof}
+
 \begin{theorem}[Copy independence for a non-nilpotent sector decomposition]
     \label{thm:mpdo_simple_weight_copy_independent}
     \lean{MPOTensor.weight_copy_independent_of_isSourceZCL}
     \leanok
     \uses{def:mpo_source_zcl, def:mpdo_doubled_phys_trace_transfer,
         lem:mpdo_doubled_phys_trace_transfer_to_mps,
-        lem:mpdo_doubled_phys_trace_transfer_blockwise}
+        lem:mpdo_doubled_phys_trace_transfer_blockwise,
+        lem:mpdo_simple_blockwise_zcl_equation}
     Let a tensor with zero correlation length be gauge-equivalent, through
     block-diagonal copy gauges, to an assembled sector decomposition whose
     basis elements all have non-nilpotent physical-trace transfer. Then the

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
@@ -526,6 +526,65 @@ strong subadditivity for a normalized three-site reduced state.
     with $\mu_s$ absorbed locally.
 \end{proof}
 
+\begin{corollary}[Each absorbed BNT element generates MPDOs]
+    \label{cor:mpdo_absorbed_bnt_sector_is_mpdo}
+    \lean{MPOTensor.%
+      commonWeightAbsorbedBasisMPOTensor_isMPDO_of_projectorSelection}
+    \lean{MPOTensor.%
+      commonWeightAbsorbedBasisMPOTensor_isMPDO_of_sameMPV₂Pos_isSAL}
+    \leanok
+    \uses{thm:mpdo_bnt_projector_positive_length_compression}
+    Under the hypotheses of
+    Theorem~\ref{thm:mpdo_bnt_projector_positive_length_compression}, every
+    absorbed BNT element $\mathcal K_s$ generates positive semidefinite
+    operators on all nonempty periodic chains.  Indeed,
+    $P_s^{\otimes N}\sigma^{(N)}(K)P_s^{\otimes N}\geq0$ and $n_s>0$, so
+    \[
+      P_s^{\otimes N}\sigma^{(N)}(K)P_s^{\otimes N}
+        =n_s\sigma^{(N)}(\mathcal K_s)
+    \]
+    gives $\sigma^{(N)}(\mathcal K_s)\geq0$.  This is the first positivity
+    conclusion in
+    \cite[Appendix~C.2, lines~1753--1759]{Cirac2016MPDO_arXiv}.
+\end{corollary}
+
+\begin{proof}\leanok
+    Congruence by the Hermitian projection $P_s^{\otimes N}$ preserves
+    positive semidefiniteness.  Multiplication by the inverse of the positive
+    integer $n_s$ then gives positivity of the sector operator.
+\end{proof}
+
+\begin{theorem}[Zero correlation length of the absorbed BNT elements]
+    \label{thm:mpdo_absorbed_bnt_sector_zcl}
+    \lean{MPOTensor.%
+      physTraceTransfer_commonWeightAbsorbedBasisMPOTensor}
+    \lean{MPOTensor.commonWeightAbsorbedBasisMPOTensor_isSourceZCL}
+    \leanok
+    \uses{lem:mpdo_simple_blockwise_zcl_equation,
+      def:mpdo_common_sector_weight_absorption}
+    Let $K$ have zero correlation length and let
+    $\mathcal K_s=\mu_sA_s$ be an absorbed BNT element of its horizontal
+    canonical form.  If the physical-trace transfer $\mathcal B_s$ is not
+    nilpotent, then $\mathcal K_s$ has zero correlation length.  More
+    precisely,
+    \[
+      \mathcal T_{\mathcal K_s}=\mu_s\mathcal B_s\ne0,
+      \qquad
+      \mathcal T_{\mathcal K_s}^{2}
+        =\lambda\mathcal T_{\mathcal K_s},
+      \qquad \lambda>0.
+    \]
+    This is the final zero-correlation-length conclusion in
+    \cite[Appendix~C.2, line~1781]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    Lemma~\ref{lem:mpdo_simple_blockwise_zcl_equation} gives the displayed
+    quadratic identity.  The common weight is nonzero, and nonnilpotence of
+    $\mathcal B_s$ implies $\mathcal B_s\ne0$, so the absorbed transfer is
+    nonzero.
+\end{proof}
+
 \begin{definition}[Injective inverse map for a simple MPO tensor]
     \label{def:mpdo_injective_inverse_layer}
     \lean{MPOTensor.IsInjective}

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -268,7 +268,7 @@ Markov sector then has a unique BNT label, and the resulting BNT-labelled sums
 of Hayashi projections are orthogonal, mutually disjoint, and resolve the
 active Markov support.
 \footnote{The relevant declaration is
-\path{MPOTensor.exists_bntSectorProjectors_four_of_sameMPV₂_isSAL}.}
+\path{MPOTensor.exists_bntSectorProjectors_four_of_sameMPV₂Pos_isSAL}.}
 No further closing-matrix assumption is needed for this specialization.
 
 The remaining projector passage is now formalized as well.  For every physical
@@ -291,12 +291,24 @@ with the common copy weight absorbed into $\mathcal K_s$.
 \path{MPOTensor.bntSectorProjection_mul_physicalSlice_mul_eq_zero},
 \path{MPOTensor.changePhysicalBasis_bntSectorProjection_basis},
 \path{MPOTensor.sitewise_bntSectorProjection_mul_mpo_mul_self}, and
-\path{MPOTensor.exists_bntProjectorSelection_positiveLength_of_sameMPV₂_isSAL}.}
+\path{MPOTensor.exists_bntProjectorSelection_positiveLength_of_sameMPV₂Pos_isSAL}.}
 The empty-word value $N=0$ is excluded because its closed virtual trace records
-the bond dimension and is not a physical chain.  The next source step is to
-deduce positivity, SAL, and ZCL for each selected absorbed BNT representative,
-as required in the proof of Proposition~\texttt{prop2to3} after equation
-\texttt{sigmaNKj}.
+the bond dimension and is not a physical chain.  Positivity and ZCL of every
+selected absorbed BNT representative are now formalized.  Positivity follows
+by compressing the positive full-chain operator and dividing by the positive
+integer $n_s$.  ZCL follows by restricting the full transfer equation to the
+$s$-th canonical block and using nonnilpotence to exclude the zero transfer.
+\footnote{The relevant declarations are
+\path{MPOTensor.commonWeightAbsorbedBasisMPOTensor_isMPDO_of_projectorSelection},
+\path{MPOTensor.commonWeightAbsorbedBasisMPOTensor_isMPDO_of_sameMPV₂Pos_isSAL},
+and
+\path{MPOTensor.commonWeightAbsorbedBasisMPOTensor_isSourceZCL}.}
+The remaining source step after the sector-compression identity is SAL for
+each sector.  It must follow from the direct-sum entropy identity and strong
+subadditivity, including a proof that every sector normalization used there is
+nonzero; this normalization may not be silently inferred from the weaker
+displayed inequality $p_j\geq0$ in
+\cite[Appendix~C.2, lines~1760--1780]{Cirac2016MPDO_arXiv}.
 
 The neighboring operators are now assembled from these sector tensors.  The
 operator

--- a/docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex
+++ b/docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex
@@ -87,15 +87,27 @@ its conclusion for an injective tensor.
 
 The first part of the original plan---positivity and translation invariance
 of the represented finite-chain sector sum from the stored sector data---is
-complete.  The remaining comparison and assembly work has two parts:
+complete.  Appendix C.2 has also been followed through the BNT projector
+selection formula: the natural multiplicities are retained, positive-length
+compression proves that each absorbed BNT representative generates MPDOs,
+and the canonical block equation proves ZCL for each representative.
+\footnote{\raggedright Formal declarations:
+{\scriptsize\leanid{MPOTensor.exists_bntProjectorSelection_positiveLength_of_sameMPV₂Pos_isSAL}},
+{\scriptsize\leanid{MPOTensor.commonWeightAbsorbedBasisMPOTensor_isMPDO_of_sameMPV₂Pos_isSAL}},
+and
+{\scriptsize\leanid{MPOTensor.commonWeightAbsorbedBasisMPOTensor_isSourceZCL}}.}
+The remaining comparison and assembly work has two parts:
 
 \begin{enumerate}
-  \item construct the outer GSNNCH sectors from the BNT decomposition and the
-        physical-sector factorization in Appendix C.2, retaining all sector
-        multiplicities;
+  \item prove SAL for every absorbed BNT representative from the direct-sum
+        entropy identity and strong subadditivity, then
+        apply the injective one-sector theorem to those representatives and
+        assemble the outer GSNNCH sectors with their natural multiplicities;
   \item determine whether the reverse comparison with a single bond is needed
         in the simple-MPDO equivalence, and prove it only in that form.
 \end{enumerate}
+\footnote{The direct-sum entropy identity is labelled
+\texttt{entropiesj} in the source.}
 
 The local Markov labels in Appendix C.2 belong inside one injective BNT
 component.  They are not the outer labels $x$ of Definition~4.8 and must not
@@ -107,9 +119,11 @@ Verdict: the source GSNNCH data and predicate are formalized, the represented
 sector sum is proved positive semidefinite and translation invariant with
 pairwise commuting translates, and the single-bond presentation is proved to
 give the one-sector case; every injective tensor satisfying the saturated
-area law is proved GSNNCH through a one-sector witness.  The open gap is the
-construction of the outer sectors and multiplicities of a general simple
-tensor in the simple-MPDO implication, together with any reverse comparison
-actually needed by that argument.
+area law is proved GSNNCH through a one-sector witness.  For a general simple
+tensor, the BNT projectors, their positive-length compression formula, and the
+sectorwise MPDO and ZCL conclusions are formalized.  The open gap is the
+sectorwise SAL argument and the ensuing assembly of the outer sectors and
+multiplicities, together with any reverse comparison actually needed by that
+argument.
 
 \end{document}


### PR DESCRIPTION
## Summary

- extracts the canonical blockwise transfer equation used in Appendix C.2 before copy-weight comparison
- proves that every common-weight-absorbed BNT representative generates positive semidefinite MPOs on all nonempty chains, using the positive-length projector compression and the positive natural multiplicity
- proves source zero correlation length for every absorbed representative by restricting the full transfer equation to its canonical block
- updates the blueprint and paper-gap records so that sectorwise SAL via the direct-sum entropy identity and strong subadditivity is the remaining local step

This advances #4003. It does not conflate the Hayashi local Markov labels with the outer GSNNCH sector labels, and it does not assert a converse from arbitrary GSNNCH data to a single commuting bond.

## Source fidelity

The new declarations cite arXiv:1606.00608, Appendix C.2, lines 1646–1657 and 1753–1781. The positive-length condition is retained: the empty virtual trace is not treated as a physical chain. The entropy normalization issue after equation entropiesj remains explicit rather than assuming strict positivity from the displayed nonnegative sector weights.

No new axiom is introduced. The source-specialized positivity theorem inherits the existing documented Hayashi equality axiom through the projector construction; the generic positivity theorem and both ZCL results use only standard logical axioms.

## Verification

- lake build TNLean.MPS.MPDO.BNTSectorAnalyticProperties
- lake build TNLean
- python3 scripts/blueprint_lean_sync.py --ci --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/MPDO/SimpleTensor.lean TNLean/MPS/MPDO/BNTSectorAnalyticProperties.lean
- leanblueprint checkdecls
- leanblueprint pdf
- kernel axiom audit of the principal new theorems

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the formal MPDO/BNT proof chain and PSD rescaling arguments; one theorem still depends on the documented Hayashi SSA axiom, but scope is additive lemmas rather than core infrastructure rewrites.
> 
> **Overview**
> Formalizes the next analytic step after BNT projector compression in Appendix C.2: each **common-weight absorbed** representative \(\mathcal K_s\) is shown to be an **MPDO** and to inherit **source zero correlation length** from the parent simple tensor.
> 
> A new Lean module adds `physTraceTransfer_commonWeightAbsorbedBasisMPOTensor`, sector **MPDO** results from the positive compression \(P_s^{\otimes N}\sigma^{(N)}(K)P_s^{\otimes N}=n_s\sigma^{(N)}(\mathcal K_s)\) (rescaling by \(n_s>0\)), and **ZCL** on each sector by restricting the full transfer equation to the canonical block. The SAL-specialized positivity theorem still goes through the existing Hayashi SSA-equality axiom via projector construction; no new axioms are introduced.
> 
> **`SimpleTensor.lean`** refactors by extracting `exists_weighted_basis_physTraceTransfer_sq_of_isSourceZCL` (the per-copy block equation before copy-weight comparison); `weight_copy_independent_of_isSourceZCL` now calls that lemma. Blueprint and paper-gap notes record the new lemmas and state that **sectorwise SAL** from the direct-sum entropy identity remains the open step before outer GSNNCH assembly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cc713adf451262cdb680a10585889edbb077546. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->