### PR TITLE
refactor(MPS/PEPS): require positive physical chain dimensions

### DIFF
--- a/TNLean/MPS/Chain/BlockedChainFT.lean
+++ b/TNLean/MPS/Chain/BlockedChainFT.lean
@@ -70,11 +70,13 @@ lemma blockedChain_isInjective (A : MPSTensor d D) (L n : ℕ)
 
 /-- **Fundamental Theorem for blocked chains**.
 
-If `A` is `L`-block injective and the constant blocked chains built from
+If the bond dimension and chain length are positive, `A` is `L`-block injective, and the
+constant blocked chains built from
 `A^{[L]}` and `B^{[L]}` satisfy `SameMPV` on their combined tensors, then
 the blocked chains are gauge equivalent. -/
 theorem fundamentalTheorem_blockedChain
     (A B : MPSTensor d D) (L n : ℕ)
+    (hn : 0 < n) (hD : 0 < D)
     (hA_block : MPSTensor.IsNBlkInjective A L)
     (hMPV : MPSTensor.SameMPV
       (MPSTensor.chainCombinedTensor (blockedChain A L n))
@@ -83,6 +85,7 @@ theorem fundamentalTheorem_blockedChain
   fundamentalTheorem_injective_chain
     (blockedChain A L n)
     (blockedChain B L n)
+    hn hD
     (blockedChain_isInjective A L n hA_block)
     hMPV
 

--- a/TNLean/MPS/Chain/FundamentalTheorem.lean
+++ b/TNLean/MPS/Chain/FundamentalTheorem.lean
@@ -32,15 +32,16 @@ variable {d D n : ℕ}
 /-- **Combined-tensor form of the injective chain Fundamental Theorem**
 (Theorem 1 of arXiv:1804.04964).
 
-If `A` and `B` are `n`-site chains with `A` injective and
-`SameMPV (chainCombinedTensor A) (chainCombinedTensor B)`, then `A` and `B`
-are cyclically gauge equivalent. The hypothesis is stated for the combined
+If `A` and `B` are nonempty chains of positive bond dimension, with `A`
+injective and `SameMPV (chainCombinedTensor A) (chainCombinedTensor B)`, then
+`A` and `B` are cyclically gauge equivalent. The hypothesis is stated for the combined
 tensors, whose physical index in `Fin (n * d)` is identified with a pair
 `(k, i)` by `finProdFinEquiv`. The proof produces a uniform gauge (the same
 `X ∈ GL(D, ℂ)` at every bond), which is a special case of cyclic gauge
 equivalence. -/
 theorem fundamentalTheorem_injective_chain
     (A B : MPSChainTensor d D n)
+    (hn : 0 < n) (_hD : 0 < D)
     (hA : IsInjective A)
     (hMPV : MPSTensor.SameMPV (MPSTensor.chainCombinedTensor A)
       (MPSTensor.chainCombinedTensor B)) :
@@ -48,18 +49,12 @@ theorem fundamentalTheorem_injective_chain
   /- Note: this formulation only assumes injectivity of `A`. The proof applies
   the single-block theorem to `chainCombinedTensor A`; no separate injectivity
   hypothesis on `B` is required. -/
-  rcases n with _ | n
-  · -- n = 0: no sites, gauge equivalence is vacuously true.
-    exact ⟨Fin.elim0, fun k => k.elim0⟩
-  · -- n ≥ 1: the combined tensor inherits injectivity from site 0.
-    have hCA : MPSTensor.IsInjective (MPSTensor.chainCombinedTensor A) :=
-      MPSTensor.chainCombinedTensor_isInjective A ⟨0, Nat.succ_pos n⟩ (hA ⟨0, Nat.succ_pos n⟩)
-    -- Apply the single-block fundamental theorem to the combined tensor.
-    obtain ⟨X, hX⟩ := MPSTensor.fundamentalTheorem_singleBlock hCA hMPV
-    -- The uniform gauge X at every bond gives cyclic gauge equivalence.
-    exact ⟨fun _ => X, fun k i => by
-      have := hX (finProdFinEquiv (k, i))
-      simp only [MPSTensor.chainCombinedTensor_apply] at this
-      exact this⟩
+  have hCA : MPSTensor.IsInjective (MPSTensor.chainCombinedTensor A) :=
+    MPSTensor.chainCombinedTensor_isInjective A ⟨0, hn⟩ (hA ⟨0, hn⟩)
+  obtain ⟨X, hX⟩ := MPSTensor.fundamentalTheorem_singleBlock hCA hMPV
+  exact ⟨fun _ => X, fun k i => by
+    have := hX (finProdFinEquiv (k, i))
+    simp only [MPSTensor.chainCombinedTensor_apply] at this
+    exact this⟩
 
 end MPSChainTensor

--- a/TNLean/MPS/Chain/GaugePhase.lean
+++ b/TNLean/MPS/Chain/GaugePhase.lean
@@ -51,14 +51,16 @@ variable {d D n : ℕ}
 
 /-- **Injective-chain Fundamental Theorem up to a nonzero scalar.**
 
-If `GaugePhaseEquiv (chainCombinedTensor A) (chainCombinedTensor B)` and
-`A` is injective, there exist `Z_k ∈ GL(D, ℂ)` and `ζ ≠ 0` such that
+For nonempty chains of positive bond dimension, if
+`GaugePhaseEquiv (chainCombinedTensor A) (chainCombinedTensor B)` and `A` is
+injective, there exist `Z_k ∈ GL(D, ℂ)` and `ζ ≠ 0` such that
 $$
   B_k^i = \zeta\, Z_k\, A_k^i\, Z_{k+1}^{-1}
 $$
 for all sites `k` and physical indices `i`. -/
 theorem fundamentalTheorem_injective_chain_gaugePhase
     (A B : MPSChainTensor d D n)
+    (hn : 0 < n) (hD : 0 < D)
     (hA : IsInjective A)
     (hGauge : MPSTensor.GaugePhaseEquiv
       (MPSTensor.chainCombinedTensor A)
@@ -96,7 +98,7 @@ theorem fundamentalTheorem_injective_chain_gaugePhase
         (MPSTensor.chainCombinedTensor A)
         (MPSTensor.chainCombinedTensor B') :=
     MPSTensor.GaugeEquiv.sameMPV hCombinedGauge
-  obtain ⟨Z, hZ⟩ := fundamentalTheorem_injective_chain A B' hA hSame
+  obtain ⟨Z, hZ⟩ := fundamentalTheorem_injective_chain A B' hn hD hA hSame
   refine ⟨Z, ζ, hζ, ?_⟩
   intro k i
   calc

--- a/TNLean/MPS/Chain/SameStateBridge.lean
+++ b/TNLean/MPS/Chain/SameStateBridge.lean
@@ -48,16 +48,18 @@ theorem sameMPV_chainCombined_of_sameState
       (MPSTensor.chainCombinedTensor B) :=
   hBridge.sameMPV_of_sameState A B hA hn hState
 
-/-- Chain Fundamental Theorem: assuming the blocking hypothesis `hBridge`,
-fixed-length `SameState` at `n ≥ 3` implies cyclic gauge equivalence for injective `A`. -/
+/-- Chain Fundamental Theorem: at positive bond dimension, assuming the blocking hypothesis
+`hBridge`, fixed-length `SameState` at `n ≥ 3` implies cyclic gauge equivalence for
+injective `A`. -/
 theorem fundamentalTheorem_injective_chain_of_sameState
     (hBridge : SameStateBridgeHyp d D)
     (A B : MPSChainTensor d D n)
+    (hD : 0 < D)
     (hA : IsInjective A)
     (hn : 3 ≤ n)
     (hState : SameState A B) :
     GaugeEquiv A B :=
-  fundamentalTheorem_injective_chain A B hA
+  fundamentalTheorem_injective_chain A B (by omega) hD hA
     (sameMPV_chainCombined_of_sameState hBridge A B hA hn hState)
 
 end MPSChainTensor

--- a/TNLean/MPS/Chain/TensorEquality.lean
+++ b/TNLean/MPS/Chain/TensorEquality.lean
@@ -75,6 +75,7 @@ variable {d D : ℕ}
 agree under all virtual insertions on both bonds are proportional. -/
 theorem tensor_proportional
     (A₁ A₂ B₁ B₂ : MPSTensor d D)
+    (hD : 0 < D)
     (hA₁ : IsInjective A₁) (hA₂ : IsInjective A₂)
     (hB₁ : IsInjective B₁) (hB₂ : IsInjective B₂)
     (hInt : ∀ (X : Matrix (Fin D) (Fin D) ℂ) (i j : Fin d),
@@ -83,11 +84,6 @@ theorem tensor_proportional
       Matrix.trace (A₂ j * Y * A₁ i) = Matrix.trace (B₂ j * Y * B₁ i)) :
     ∃ (lambda_ : ℂ), lambda_ ≠ 0 ∧
       (∀ i, A₁ i = lambda_ • B₁ i) ∧ (∀ j, A₂ j = lambda_⁻¹ • B₂ j) := by
-  -- Handle D = 0: the matrix ring is trivial, all matrices are equal.
-  by_cases hD : D = 0
-  · subst hD
-    exact ⟨1, one_ne_zero, fun i => Subsingleton.elim _ _, fun j => by
-      simp [Subsingleton.elim (A₂ j) (B₂ j)]⟩
   -- Step 1: From trace conditions, derive matrix product equalities.
   have hProdL : ∀ i j, A₂ j * A₁ i = B₂ j * B₁ i :=
     internal_products_eq A₁ A₂ B₁ B₂ hInt
@@ -162,7 +158,7 @@ theorem tensor_proportional
     intro h; rw [h, zero_smul] at hZ_eq; rw [hZ_eq, zero_mul] at hZW
     -- hZW : 0 = 1 in Matrix (Fin D) (Fin D) ℂ; D ≥ 1 so 1 ≠ 0
     have : (1 : Matrix (Fin D) (Fin D) ℂ) ≠ 0 := by
-      have : NeZero D := ⟨hD⟩
+      have : NeZero D := ⟨Nat.ne_of_gt hD⟩
       exact one_ne_zero
     exact this hZW.symm
   -- Step 9: Derive A₁ i = lambda_ • B₁ i.

--- a/TNLean/PEPS/CycleMPSChainOverlapCapstone.lean
+++ b/TNLean/PEPS/CycleMPSChainOverlapCapstone.lean
@@ -481,17 +481,11 @@ while here all sites share one physical dimension `d` and all bonds one
 bond dimension `D`.  Documented in
 `docs/paper-gaps/peps_normal_ft_section3_route.tex`. -/
 theorem fundamentalTheorem_normalMPSChain_of_overlap {n L d D : ℕ} [NeZero n]
-    (hL : 0 < L) (hn : 2 * L + 1 ≤ n) (A B : MPSChainTensor d D n)
+    (hL : 0 < L) (hn : 2 * L + 1 ≤ n) (hD : 0 < D)
+    (A B : MPSChainTensor d D n)
     (hA : IsWindowInjective A L) (hB : IsWindowInjective B L)
     (hAB : SameState A B) : GaugeEquiv A B := by
   classical
-  rcases Nat.eq_zero_or_pos D with hD0 | hD
-  · -- All `0 × 0` matrices are equal.
-    subst hD0
-    exact ⟨fun _ => 1, fun k i => by
-      apply Matrix.ext
-      intro a b
-      exact a.elim0⟩
   obtain ⟨m', rfl⟩ : ∃ m', n = m' + 1 := ⟨n - 1, by omega⟩
   -- The per-bond conjugations, chosen once per site of the chain and read
   -- at arbitrary starting sites through the residue of the chain length.
@@ -499,7 +493,7 @@ theorem fundamentalTheorem_normalMPSChain_of_overlap {n L d D : ℕ} [NeZero n]
       ∀ w : List (Fin d), w.length = m' + 1 →
       arcEval B v.val w = (Zv : Matrix (Fin D) (Fin D) ℂ) * arcEval A v.val w *
         ((Zv⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) :=
-    fun v => exists_conjugation_of_sameState hL hn A B hA hB hAB v.val
+    fun v => exists_conjugation_of_sameState hL hn hD A B hA hB hAB v.val
   choose Z₀ hZ₀ using hZc
   set Z : ℕ → GL (Fin D) ℂ := fun p => Z₀ ((p : ℕ) : Fin (m' + 1)) with hZdef
   have hZ : ∀ (p : ℕ) (w : List (Fin d)), w.length = m' + 1 →
@@ -696,10 +690,10 @@ same closed-chain state are cyclically gauge equivalent.  This is the
 `TNLean.PEPS.fundamentalTheorem_normalMPSChain_of_overlap`; at length one,
 window injectivity is exactly sitewise algebraic injectivity. -/
 theorem fundamentalTheorem_injectiveMPSChain_of_sameState {n d D : ℕ} [NeZero n]
-    (hn : 3 ≤ n) (A B : MPSChainTensor d D n) (hA : IsInjective A)
+    (hn : 3 ≤ n) (hD : 0 < D) (A B : MPSChainTensor d D n) (hA : IsInjective A)
     (hB : IsInjective B) (hAB : SameState A B) : GaugeEquiv A B :=
   fundamentalTheorem_normalMPSChain_of_overlap (hL := Nat.zero_lt_one)
-    (hn := by simpa using hn) A B
+    (hn := by simpa using hn) hD A B
     (isWindowInjective_one_of_isInjective hA)
     (isWindowInjective_one_of_isInjective hB) hAB
 
@@ -715,9 +709,9 @@ This is the first step in the source proof of the translation-invariant
 description corollary at line 1804.  The subsequent telescoping step, which
 constructs a single repeated tensor, is not part of this theorem. -/
 theorem fundamentalTheorem_injectiveMPSChain_cyclicShift {n d D : ℕ} [NeZero n]
-    (hn : 3 ≤ n) (A : MPSChainTensor d D n) (hA : IsInjective A)
+    (hn : 3 ≤ n) (hD : 0 < D) (A : MPSChainTensor d D n) (hA : IsInjective A)
     (hTI : IsCyclicShiftInvariantState A) : GaugeEquiv A (cyclicShift A) :=
-  fundamentalTheorem_injectiveMPSChain_of_sameState hn A (cyclicShift A) hA
+  fundamentalTheorem_injectiveMPSChain_of_sameState hn hD A (cyclicShift A) hA
     (IsInjective.cyclicShift hA) hTI
 
 /-- **Gauge-to-first-tensor form of an injective closed-chain MPS**
@@ -731,13 +725,13 @@ source's displayed \(L_i,R_i\) step before the final repeated-tensor
 collapse. -/
 theorem exists_gauge_to_first_of_cyclicShiftInvariantState
     {n d D : ℕ} [NeZero n]
-    (hn : 3 ≤ n) (A : MPSChainTensor d D n) (hA : IsInjective A)
+    (hn : 3 ≤ n) (hD : 0 < D) (A : MPSChainTensor d D n) (hA : IsInjective A)
     (hTI : IsCyclicShiftInvariantState A) :
     ∀ k : Fin n, ∃ L R : GL (Fin D) ℂ, ∀ i : Fin d,
       A k i = (L : Matrix (Fin D) (Fin D) ℂ) * A 0 i *
         (((R⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) :=
   MPSChainTensor.exists_gauge_to_first_of_cyclicShift_gaugeEquiv
-    (fundamentalTheorem_injectiveMPSChain_cyclicShift hn A hA hTI)
+    (fundamentalTheorem_injectiveMPSChain_cyclicShift hn hD A hA hTI)
 
 /-- **Uniqueness of the injective closed-chain gauge**, the uniqueness clause
 of arXiv:1804.04964, Theorem `thm:inj_MPS`, line 724.
@@ -745,7 +739,7 @@ of arXiv:1804.04964, Theorem `thm:inj_MPS`, line 724.
 If two cyclic gauge families relate the same injective chain `A` to `B`, then
 they differ by one nonzero scalar, independent of the bond. -/
 theorem fundamentalTheorem_injectiveMPSChain_gauge_unique {n d D : ℕ} [NeZero n]
-    (A B : MPSChainTensor d D n) (hA : IsInjective A)
+    (hD : 0 < D) (A B : MPSChainTensor d D n) (hA : IsInjective A)
     (Z Z' : Fin n → GL (Fin D) ℂ)
     (hZ : ∀ (k : Fin n) (i : Fin d),
       B k i = (Z k : Matrix (Fin D) (Fin D) ℂ) * A k i *
@@ -758,112 +752,108 @@ theorem fundamentalTheorem_injectiveMPSChain_gauge_unique {n d D : ℕ} [NeZero 
     ∃ c : ℂˣ, ∀ k : Fin n, (Z' k : Matrix (Fin D) (Fin D) ℂ) =
       (c : ℂ) • (Z k : Matrix (Fin D) (Fin D) ℂ) := by
   classical
-  cases D with
-  | zero =>
-      refine ⟨1, fun k => ?_⟩
-      exact Subsingleton.elim _ _
-  | succ D' =>
-      let C : Fin n → GL (Fin (Nat.succ D')) ℂ := fun k => (Z k)⁻¹ * Z' k
-      have hinter : ∀ (k : Fin n) (i : Fin d),
-          (C k : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) * A k i =
-            A k i * (C (k + 1) :
-              Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) := by
-        intro k i
-        have hEq :
-            (Z k : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) * A k i *
-                (((Z (cyclicSucc k))⁻¹ : GL (Fin (Nat.succ D')) ℂ) :
-                  Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ)
-              =
-            (Z' k : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) * A k i *
-                (((Z' (cyclicSucc k))⁻¹ : GL (Fin (Nat.succ D')) ℂ) :
-                  Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) := by
-          rw [← hZ k i, hZ' k i]
-        have hcong := congrArg
-          (fun M : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ =>
-            (((Z k)⁻¹ : GL (Fin (Nat.succ D')) ℂ) :
-                Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) * M *
-              (Z' (k + 1) : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ)) hEq
-        simpa [C, Matrix.mul_assoc] using hcong.symm
-      have hmul_all : ∀ (k : Fin n) (M : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ),
-          M ∈ Submodule.span ℂ (Set.range (A k)) →
-            (C k : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) * M =
-              M * (C (k + 1) : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) := by
-        intro k M hM
-        induction hM using Submodule.span_induction with
-        | mem M hM =>
-            rcases hM with ⟨i, rfl⟩
-            exact hinter k i
-        | zero => simp
-        | add X Y _ _ hX hY =>
-            rw [Matrix.mul_add, Matrix.add_mul, hX, hY]
-        | smul a X _ hX =>
-            rw [Matrix.mul_smul, Matrix.smul_mul, hX]
-      have hCstep : ∀ k : Fin n,
-          (C k : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) =
-            (C (k + 1) : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) := by
-        intro k
-        have hmem : (1 : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) ∈
-            Submodule.span ℂ (Set.range (A k)) := by
-          rw [hA k]
-          exact Submodule.mem_top
-        simpa using hmul_all k 1 hmem
-      have hC_eq_zero : ∀ k : Fin n,
-          (C k : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) =
-            (C 0 : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) :=
-        fin_cyclic_induction rfl (fun k hk => by
-          calc
-            (C (k + 1) : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ)
-                = (C k : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) :=
-                  (hCstep k).symm
-            _ = (C 0 : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) := hk)
-      have hcommA0 : ∀ i : Fin d,
-          (C 0 : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) * A 0 i =
-            A 0 i * (C 0 : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) := by
-        intro i
-        have h := hinter 0 i
-        rw [hC_eq_zero (0 + 1)] at h
-        exact h
-      have hscalar := Matrix.isScalar_of_commute_span_eq_top
-        (Z := (C 0 : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ))
-        (MPSTensor.IsInjective.span_eq_top (hA 0)) (fun M hM => by
-          rcases hM with ⟨i, rfl⟩
-          exact hcommA0 i)
-      rcases hscalar with ⟨c, hc⟩
-      have hc_ne : c ≠ 0 := by
-        intro hc0
-        have hC0 : (C 0 : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) = 0 := by
-          rw [hc]
-          ext i j
-          simp [hc0]
-        have hmul :
-            (C 0 : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) *
-                (((C 0)⁻¹ : GL (Fin (Nat.succ D')) ℂ) :
-                  Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) = 1 := by
-          simp
-        rw [hC0, Matrix.zero_mul] at hmul
-        exact
-          (one_ne_zero :
-            (1 : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) ≠ 0) hmul.symm
-      refine ⟨Units.mk0 c hc_ne, fun k => ?_⟩
+  letI : Nonempty (Fin D) := ⟨⟨0, hD⟩⟩
+  let C : Fin n → GL (Fin D) ℂ := fun k => (Z k)⁻¹ * Z' k
+  have hinter : ∀ (k : Fin n) (i : Fin d),
+      (C k : Matrix (Fin D) (Fin D) ℂ) * A k i =
+        A k i * (C (k + 1) :
+          Matrix (Fin D) (Fin D) ℂ) := by
+    intro k i
+    have hEq :
+        (Z k : Matrix (Fin D) (Fin D) ℂ) * A k i *
+            (((Z (cyclicSucc k))⁻¹ : GL (Fin D) ℂ) :
+              Matrix (Fin D) (Fin D) ℂ)
+          =
+        (Z' k : Matrix (Fin D) (Fin D) ℂ) * A k i *
+            (((Z' (cyclicSucc k))⁻¹ : GL (Fin D) ℂ) :
+              Matrix (Fin D) (Fin D) ℂ) := by
+      rw [← hZ k i, hZ' k i]
+    have hcong := congrArg
+      (fun M : Matrix (Fin D) (Fin D) ℂ =>
+        (((Z k)⁻¹ : GL (Fin D) ℂ) :
+            Matrix (Fin D) (Fin D) ℂ) * M *
+          (Z' (k + 1) : Matrix (Fin D) (Fin D) ℂ)) hEq
+    simpa [C, Matrix.mul_assoc] using hcong.symm
+  have hmul_all : ∀ (k : Fin n) (M : Matrix (Fin D) (Fin D) ℂ),
+      M ∈ Submodule.span ℂ (Set.range (A k)) →
+        (C k : Matrix (Fin D) (Fin D) ℂ) * M =
+          M * (C (k + 1) : Matrix (Fin D) (Fin D) ℂ) := by
+    intro k M hM
+    induction hM using Submodule.span_induction with
+    | mem M hM =>
+        rcases hM with ⟨i, rfl⟩
+        exact hinter k i
+    | zero => simp
+    | add X Y _ _ hX hY =>
+        rw [Matrix.mul_add, Matrix.add_mul, hX, hY]
+    | smul a X _ hX =>
+        rw [Matrix.mul_smul, Matrix.smul_mul, hX]
+  have hCstep : ∀ k : Fin n,
+      (C k : Matrix (Fin D) (Fin D) ℂ) =
+        (C (k + 1) : Matrix (Fin D) (Fin D) ℂ) := by
+    intro k
+    have hmem : (1 : Matrix (Fin D) (Fin D) ℂ) ∈
+        Submodule.span ℂ (Set.range (A k)) := by
+      rw [hA k]
+      exact Submodule.mem_top
+    simpa using hmul_all k 1 hmem
+  have hC_eq_zero : ∀ k : Fin n,
+      (C k : Matrix (Fin D) (Fin D) ℂ) =
+        (C 0 : Matrix (Fin D) (Fin D) ℂ) :=
+    fin_cyclic_induction rfl (fun k hk => by
       calc
-        (Z' k : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ)
-            = (Z k : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) *
-                (C k : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) := by
-              simp [C]
-        _ = (Z k : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) *
-              (C 0 : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) := by
-              rw [hC_eq_zero k]
-        _ = (Z k : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) *
-              Matrix.scalar (Fin (Nat.succ D')) c := by
-              rw [hc]
-        _ = (Z k : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) *
-              (c • (1 : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ)) := by
-              rw [Matrix.smul_one_eq_diagonal, Matrix.scalar_apply]
-        _ = c • (Z k : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) := by
-              rw [Matrix.mul_smul, Matrix.mul_one]
-        _ = ((Units.mk0 c hc_ne : ℂˣ) : ℂ) •
-              (Z k : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) := by
-              simp
+        (C (k + 1) : Matrix (Fin D) (Fin D) ℂ)
+            = (C k : Matrix (Fin D) (Fin D) ℂ) :=
+              (hCstep k).symm
+        _ = (C 0 : Matrix (Fin D) (Fin D) ℂ) := hk)
+  have hcommA0 : ∀ i : Fin d,
+      (C 0 : Matrix (Fin D) (Fin D) ℂ) * A 0 i =
+        A 0 i * (C 0 : Matrix (Fin D) (Fin D) ℂ) := by
+    intro i
+    have h := hinter 0 i
+    rw [hC_eq_zero (0 + 1)] at h
+    exact h
+  have hscalar := Matrix.isScalar_of_commute_span_eq_top
+    (Z := (C 0 : Matrix (Fin D) (Fin D) ℂ))
+    (MPSTensor.IsInjective.span_eq_top (hA 0)) (fun M hM => by
+      rcases hM with ⟨i, rfl⟩
+      exact hcommA0 i)
+  rcases hscalar with ⟨c, hc⟩
+  have hc_ne : c ≠ 0 := by
+    intro hc0
+    have hC0 : (C 0 : Matrix (Fin D) (Fin D) ℂ) = 0 := by
+      rw [hc]
+      ext i j
+      simp [hc0]
+    have hmul :
+        (C 0 : Matrix (Fin D) (Fin D) ℂ) *
+            (((C 0)⁻¹ : GL (Fin D) ℂ) :
+              Matrix (Fin D) (Fin D) ℂ) = 1 := by
+      simp
+    rw [hC0, Matrix.zero_mul] at hmul
+    exact
+      (one_ne_zero :
+        (1 : Matrix (Fin D) (Fin D) ℂ) ≠ 0) hmul.symm
+  refine ⟨Units.mk0 c hc_ne, fun k => ?_⟩
+  calc
+    (Z' k : Matrix (Fin D) (Fin D) ℂ)
+        = (Z k : Matrix (Fin D) (Fin D) ℂ) *
+            (C k : Matrix (Fin D) (Fin D) ℂ) := by
+          simp [C]
+    _ = (Z k : Matrix (Fin D) (Fin D) ℂ) *
+          (C 0 : Matrix (Fin D) (Fin D) ℂ) := by
+          rw [hC_eq_zero k]
+    _ = (Z k : Matrix (Fin D) (Fin D) ℂ) *
+          Matrix.scalar (Fin D) c := by
+          rw [hc]
+    _ = (Z k : Matrix (Fin D) (Fin D) ℂ) *
+          (c • (1 : Matrix (Fin D) (Fin D) ℂ)) := by
+          rw [Matrix.smul_one_eq_diagonal, Matrix.scalar_apply]
+    _ = c • (Z k : Matrix (Fin D) (Fin D) ℂ) := by
+          rw [Matrix.mul_smul, Matrix.mul_one]
+    _ = ((Units.mk0 c hc_ne : ℂˣ) : ℂ) •
+          (Z k : Matrix (Fin D) (Fin D) ℂ) := by
+          simp
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/CycleMPSChainOverlapInsertion.lean
+++ b/TNLean/PEPS/CycleMPSChainOverlapInsertion.lean
@@ -559,20 +559,13 @@ while here all sites share one physical dimension `d` and all bonds one
 bond dimension `D`.  Documented in
 `docs/paper-gaps/peps_normal_ft_section3_route.tex`. -/
 theorem exists_conjugation_of_sameState [NeZero n] {L : ℕ} (hL : 0 < L)
-    (hn : 2 * L + 1 ≤ n) (A B : MPSChainTensor d D n)
+    (hn : 2 * L + 1 ≤ n) (hD : 0 < D) (A B : MPSChainTensor d D n)
     (hA : IsWindowInjective A L) (hB : IsWindowInjective B L)
     (hAB : SameState A B) (p : ℕ) :
     ∃ Z : GL (Fin D) ℂ, ∀ w : List (Fin d), w.length = n →
       arcEval B p w = (Z : Matrix (Fin D) (Fin D) ℂ) * arcEval A p w *
         ((Z⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
   classical
-  rcases Nat.eq_zero_or_pos D with hD0 | hD
-  · -- All `0 × 0` matrices are equal.
-    subst hD0
-    refine ⟨1, fun w hw => ?_⟩
-    apply Matrix.ext
-    intro a b
-    exact a.elim0
   -- The insertion correspondence at the bond `(p - 1, p)`, reading the
   -- chain from the window start `p + (n - L)`.
   obtain ⟨Φ, hΦone, hΦmul, hpair⟩ :=

--- a/TNLean/PEPS/CycleMPSConstantDescription.lean
+++ b/TNLean/PEPS/CycleMPSConstantDescription.lean
@@ -81,23 +81,14 @@ every tensor through the first; the seam relation `A_{n+1} ≡ A_0` pins the loo
 product to a scalar; and an `n`-th root absorbs that scalar into the repeated
 tensor. -/
 theorem exists_constant_injectiveMPS_of_cyclicShiftInvariantState
-    {n d D : ℕ} [NeZero n] (hn : 3 ≤ n) (A : MPSChainTensor d D n)
+    {n d D : ℕ} [NeZero n] (hn : 3 ≤ n) (hD : 0 < D)
+    (A : MPSChainTensor d D n)
     (hA : IsInjective A) (hTI : IsCyclicShiftInvariantState A) :
     ∃ B : MPSTensor d D, MPSTensor.IsInjective B ∧ SameState A (fun _ : Fin n => B) := by
   have hn0 : 0 < n := by omega
-  -- A vanishing bond dimension makes every matrix the unique `0 × 0` matrix.
-  rcases Nat.eq_zero_or_pos D with hD0 | hD
-  · subst hD0
-    refine ⟨fun _ => 0, ?_, ?_⟩
-    · refine eq_top_iff.mpr fun x _ => ?_
-      rw [Subsingleton.elim x 0]
-      exact Submodule.zero_mem _
-    · intro σ
-      simp only [MPSChainTensor.coeff_eq, Matrix.trace, Matrix.diag,
-        Finset.univ_eq_empty, Finset.sum_empty]
   haveI : Nonempty (Fin D) := ⟨⟨0, hD⟩⟩
   -- The cyclic-shift comparison: one invertible gauge per bond.
-  obtain ⟨Z, hZ0⟩ := fundamentalTheorem_injectiveMPSChain_cyclicShift hn A hA hTI
+  obtain ⟨Z, hZ0⟩ := fundamentalTheorem_injectiveMPSChain_cyclicShift hn hD A hA hTI
   have hZ : ∀ (k : Fin n) (i : Fin d), A (cyclicSucc k) i =
       (Z k : Matrix (Fin D) (Fin D) ℂ) * A k i *
         (((Z (cyclicSucc k))⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) :=

--- a/TNLean/PEPS/CycleMPSFundamentalTheorem.lean
+++ b/TNLean/PEPS/CycleMPSFundamentalTheorem.lean
@@ -51,11 +51,10 @@ per edge, and merges the constants into one because the relation
 nonzero tensor `B`.
 
 The matrix-level hypotheses match the source corollary: `0 < L` (implicit in
-blocking `L` consecutive sites), `L`-block injectivity of both tensors, and
-equality of the closed-chain coefficients at the single size `n`.  The
-positivity side conditions of the graph-level corollary are discharged here,
-not assumed: a vanishing bond dimension makes the conclusion trivial, and a
-vanishing physical dimension contradicts block injectivity.
+blocking `L` consecutive sites), positive bond dimension, `L`-block
+injectivity of both tensors, and equality of the closed-chain coefficients at
+the single size `n`.  A vanishing physical dimension is already excluded by
+block injectivity.
 
 ## References
 
@@ -446,13 +445,13 @@ Source: arXiv:1804.04964, Section 3, first corollary after the theorem
 labelled `normal`, lines 1585--1631 of `Papers/1804.04964/paper_normal.tex`,
 strengthened to `n ≥ 2L + 1` per line 1623 and Section `normal_alt`. -/
 theorem fundamentalTheorem_normalMPS {n L d D : ℕ} [NeZero n] (hL : 0 < L)
-    (hn : 2 * L + 1 ≤ n)
+    (hn : 2 * L + 1 ≤ n) (hD : 0 < D)
     (A B : MPSTensor d D) (hA : MPSTensor.IsNBlkInjective A L)
     (hB : MPSTensor.IsNBlkInjective B L)
     (hAB : ∀ σ : Fin n → Fin d, MPSTensor.mpv A σ = MPSTensor.mpv B σ) :
     ∃ Z : Fin n → GL (Fin D) ℂ, ∀ (v : Fin n) (i : Fin d),
       B i = ((Z v)⁻¹ : GL (Fin D) ℂ) * A i * (Z (v + 1) : GL (Fin D) ℂ) :=
-  fundamentalTheorem_normalMPS_of_overlap hL hn A B hA hB hAB
+  fundamentalTheorem_normalMPS_of_overlap hL hn hD A B hA hB hAB
 
 /-- **Uniqueness clause of the Fundamental Theorem for translation-invariant
 normal MPS on a closed chain** (arXiv:1804.04964, Section 3, first corollary
@@ -477,7 +476,8 @@ Source: arXiv:1804.04964, Section 3, first corollary after the theorem
 labelled `normal`, lines 1585--1631 of
 `Papers/1804.04964/paper_normal.tex`. -/
 theorem fundamentalTheorem_normalMPS_gauge_unique {n L d D : ℕ} [NeZero n] (hL : 0 < L)
-    (hn : 3 * L ≤ n) (A B : MPSTensor d D) (hA : MPSTensor.IsNBlkInjective A L)
+    (hn : 3 * L ≤ n) (hD : 0 < D) (A B : MPSTensor d D)
+    (hA : MPSTensor.IsNBlkInjective A L)
     (hB : MPSTensor.IsNBlkInjective B L) (Z Z' : Fin n → GL (Fin D) ℂ)
     (hZ : ∀ (v : Fin n) (i : Fin d),
       B i = ((Z v)⁻¹ : GL (Fin D) ℂ) * A i * (Z (v + 1) : GL (Fin D) ℂ))
@@ -485,12 +485,6 @@ theorem fundamentalTheorem_normalMPS_gauge_unique {n L d D : ℕ} [NeZero n] (hL
       B i = ((Z' v)⁻¹ : GL (Fin D) ℂ) * A i * (Z' (v + 1) : GL (Fin D) ℂ)) :
     ∃ c : ℂˣ, ∀ v : Fin n, (Z' v : Matrix (Fin D) (Fin D) ℂ) =
       (c : ℂ) • (Z v : Matrix (Fin D) (Fin D) ℂ) := by
-  rcases Nat.eq_zero_or_pos D with hD0 | hD
-  · subst hD0
-    refine ⟨1, fun v => ?_⟩
-    apply Matrix.ext
-    intro a b
-    exact a.elim0
   have hn3 : 3 ≤ n := by omega
   have hLn : L < n := by omega
   -- Convert each per-bond family back into a per-edge family.

--- a/TNLean/PEPS/CycleMPSOverlapCapstone.lean
+++ b/TNLean/PEPS/CycleMPSOverlapCapstone.lean
@@ -353,19 +353,14 @@ the source corollary needs no system size and is
 Source: arXiv:1804.04964, Section `normal_alt`, the corollary after Lemma 5,
 lines 2256--2295 of `Papers/1804.04964/paper_normal.tex`. -/
 theorem fundamentalTheorem_normalMPS_translationInvariant_of_overlap
-    {n L d D : ℕ} (hL : 0 < L) (hn : 2 * L + 1 ≤ n) (A B : MPSTensor d D)
+    {n L d D : ℕ} (hL : 0 < L) (hn : 2 * L + 1 ≤ n) (hD : 0 < D)
+    (A B : MPSTensor d D)
     (hA : MPSTensor.IsNBlkInjective A L) (hB : MPSTensor.IsNBlkInjective B L)
     (hAB : ∀ σ : Fin n → Fin d, MPSTensor.mpv A σ = MPSTensor.mpv B σ) :
     ∃ (Z : GL (Fin D) ℂ) (lam : ℂ), lam ^ n = 1 ∧
       ∀ i : Fin d, B i = lam • ((Z⁻¹ : GL (Fin D) ℂ) * A i * (Z : GL (Fin D) ℂ)) := by
-  rcases Nat.eq_zero_or_pos D with hD0 | hD
-  · subst hD0
-    refine ⟨1, 1, one_pow n, fun i => ?_⟩
-    apply Matrix.ext
-    intro a b
-    exact a.elim0
   -- The conjugation at length `n` from the insertion correspondence.
-  obtain ⟨P, hP⟩ := MPSTensor.exists_conjugation_of_mpv_eq hL hn A B hA hB hAB
+  obtain ⟨P, hP⟩ := MPSTensor.exists_conjugation_of_mpv_eq hL hn hD A B hA hB hAB
   -- Absorb the gauge: the conjugated `B` has equal word products with `A`.
   set Q : GL (Fin D) ℂ := P⁻¹ with hQdef
   set C : MPSTensor d D := fun i => (Q : Matrix (Fin D) (Fin D) ℂ) * B i *
@@ -413,13 +408,13 @@ gauge from any such family, so the two forms agree.
 Source: arXiv:1804.04964, Section `normal_alt`, the corollary after Lemma 5,
 lines 2256--2295 of `Papers/1804.04964/paper_normal.tex`. -/
 theorem fundamentalTheorem_normalMPS_of_overlap {n L d D : ℕ} [NeZero n]
-    (hL : 0 < L) (hn : 2 * L + 1 ≤ n) (A B : MPSTensor d D)
+    (hL : 0 < L) (hn : 2 * L + 1 ≤ n) (hD : 0 < D) (A B : MPSTensor d D)
     (hA : MPSTensor.IsNBlkInjective A L) (hB : MPSTensor.IsNBlkInjective B L)
     (hAB : ∀ σ : Fin n → Fin d, MPSTensor.mpv A σ = MPSTensor.mpv B σ) :
     ∃ Z : Fin n → GL (Fin D) ℂ, ∀ (v : Fin n) (i : Fin d),
       B i = ((Z v)⁻¹ : GL (Fin D) ℂ) * A i * (Z (v + 1) : GL (Fin D) ℂ) := by
   obtain ⟨Z₀, lam, hlamn, hZ₀⟩ :=
-    fundamentalTheorem_normalMPS_translationInvariant_of_overlap hL hn A B hA hB hAB
+    fundamentalTheorem_normalMPS_translationInvariant_of_overlap hL hn hD A B hA hB hAB
   have hlam0 : lam ≠ 0 := by
     intro h0
     rw [h0, zero_pow (by omega : n ≠ 0)] at hlamn

--- a/TNLean/PEPS/CycleMPSOverlapInsertion.lean
+++ b/TNLean/PEPS/CycleMPSOverlapInsertion.lean
@@ -267,19 +267,13 @@ matrix algebra, and by Skolem--Noether (the source's argument at lines
 closed-chain words of length `n` transfers the conjugation to the word
 products. -/
 theorem exists_conjugation_of_mpv_eq {n L : ℕ} (hL : 0 < L) (hn : 2 * L + 1 ≤ n)
+    (hD : 0 < D)
     (A B : MPSTensor d D) (hA : IsNBlkInjective A L) (hB : IsNBlkInjective B L)
     (hAB : ∀ σ : Fin n → Fin d, mpv A σ = mpv B σ) :
     ∃ Z : GL (Fin D) ℂ, ∀ w : List (Fin d), w.length = n →
       evalWord B w = (Z : Matrix (Fin D) (Fin D) ℂ) * evalWord A w *
         ((Z⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
   classical
-  rcases Nat.eq_zero_or_pos D with hD0 | hD
-  · -- All `0 × 0` matrices are equal.
-    subst hD0
-    refine ⟨1, fun w hw => ?_⟩
-    apply Matrix.ext
-    intro a b
-    exact a.elim0
   -- The word transport from the same-state hypothesis.
   obtain ⟨Λ, hΛ⟩ := exists_mpvTransport (k := L) (q := n - L) (by omega) hA
     (isNBlkInjective_of_le hL hA (by omega)) hAB

--- a/TNLean/PEPS/CycleMPSTranslationInvariant.lean
+++ b/TNLean/PEPS/CycleMPSTranslationInvariant.lean
@@ -236,12 +236,12 @@ Source: arXiv:1804.04964, Section 3, the corollary for TI MPS, lines
 1624--1661 of `Papers/1804.04964/paper_normal.tex`, strengthened to
 `n ≥ 2L + 1` per line 1623 and Section `normal_alt`. -/
 theorem fundamentalTheorem_normalMPS_translationInvariant {n L d D : ℕ} [NeZero n]
-    (hL : 0 < L) (hn : 2 * L + 1 ≤ n) (A B : MPSTensor d D)
+    (hL : 0 < L) (hn : 2 * L + 1 ≤ n) (hD : 0 < D) (A B : MPSTensor d D)
     (hA : MPSTensor.IsNBlkInjective A L) (hB : MPSTensor.IsNBlkInjective B L)
     (hAB : ∀ σ : Fin n → Fin d, MPSTensor.mpv A σ = MPSTensor.mpv B σ) :
     ∃ (Z : GL (Fin D) ℂ) (lam : ℂ), lam ^ n = 1 ∧
       ∀ i : Fin d, B i = lam • ((Z⁻¹ : GL (Fin D) ℂ) * A i * (Z : GL (Fin D) ℂ)) :=
-  fundamentalTheorem_normalMPS_translationInvariant_of_overlap hL hn A B hA hB hAB
+  fundamentalTheorem_normalMPS_translationInvariant_of_overlap hL hn hD A B hA hB hAB
 
 /-- **Uniqueness clause of the Fundamental Theorem for translation-invariant
 normal MPS, single-gauge form** (arXiv:1804.04964, Section 3, the corollary
@@ -259,7 +259,8 @@ needed.
 Source: arXiv:1804.04964, Section 3, the corollary for TI MPS, lines
 1624--1661 of `Papers/1804.04964/paper_normal.tex`. -/
 theorem fundamentalTheorem_normalMPS_translationInvariant_gauge_unique {L d D : ℕ}
-    (hL : 0 < L) (A B : MPSTensor d D) (hA : MPSTensor.IsNBlkInjective A L)
+    (hL : 0 < L) (hD : 0 < D) (A B : MPSTensor d D)
+    (hA : MPSTensor.IsNBlkInjective A L)
     (hB : MPSTensor.IsNBlkInjective B L) (Z Z' : GL (Fin D) ℂ) (lam lam' : ℂ)
     (hZ : ∀ i : Fin d,
       B i = lam • ((Z⁻¹ : GL (Fin D) ℂ) * A i * (Z : GL (Fin D) ℂ)))
@@ -267,12 +268,6 @@ theorem fundamentalTheorem_normalMPS_translationInvariant_gauge_unique {L d D : 
       B i = lam' • ((Z'⁻¹ : GL (Fin D) ℂ) * A i * (Z' : GL (Fin D) ℂ))) :
     ∃ c : ℂˣ, (Z' : Matrix (Fin D) (Fin D) ℂ) =
       (c : ℂ) • (Z : Matrix (Fin D) (Fin D) ℂ) := by
-  rcases Nat.eq_zero_or_pos D with hD0 | hD
-  · subst hD0
-    refine ⟨1, ?_⟩
-    apply Matrix.ext
-    intro a b
-    exact a.elim0
   obtain ⟨i₀, hi₀⟩ := exists_ne_zero_of_isNBlkInjective hL hD hB
   have hlam : lam ≠ 0 := by
     intro h0

--- a/blueprint/src/chapter/ch23_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch23_algebraic_ft.tex
@@ -355,7 +355,7 @@ shows that this agreement forces the local tensors to be proportional.
     \leanok
     \uses{def:injective, def:decomposition_map, lem:center_scalar}
     Let $A_1, A_2$ and $B_1, B_2$ be injective MPS tensors with
-    the same bond dimension $D$.
+    the same positive bond dimension $D$.
     Suppose that for all $X \in \MN{D}$ (on the internal bond),
     all $Y \in \MN{D}$ (on the external bond), and all physical indices $i,j$,
     \begin{align}
@@ -436,8 +436,9 @@ separate same-state reduction hypothesis, treated below.
     \leanok
     \uses{def:non_ti_chain, def:same_mpv}
     Let $\mathbf{A} = (A_0, \ldots, A_{n-1})$ and
-    $\mathbf{B} = (B_0, \ldots, B_{n-1})$ be two $n$-site chains with
-    common bond dimension $D$, and assume that $\mathbf{A}$ is injective.
+    $\mathbf{B} = (B_0, \ldots, B_{n-1})$ be two chains with $n>0$ sites
+    and common positive bond dimension $D$, and assume that $\mathbf{A}$ is
+    injective.
     Suppose that, after combining the site index and physical index into a
     single MPS tensor, the resulting two tensors generate the same MPV
     family. Then $\mathbf{A}$ and $\mathbf{B}$ are cyclically gauge
@@ -489,8 +490,9 @@ separate same-state reduction hypothesis, treated below.
     \uses{thm:fundamentalTheorem_injective_chain, def:gauge_phase_equiv,
         def:non_ti_chain}
     Let $\mathbf{A} = (A_0, \ldots, A_{n-1})$ and
-    $\mathbf{B} = (B_0, \ldots, B_{n-1})$ be two $n$-site chains with common
-    bond dimension $D$, and assume that $\mathbf{A}$ is injective.
+    $\mathbf{B} = (B_0, \ldots, B_{n-1})$ be two chains with $n>0$ sites and
+    common positive bond dimension $D$, and assume that $\mathbf{A}$ is
+    injective.
     Suppose that the combined tensors $\widetilde{\mathbf{A}}$ and
     $\widetilde{\mathbf{B}}$ are gauge-phase equivalent.
     Then there exist invertible matrices $Z_0, \ldots, Z_{n-1} \in \GL_D(\C)$
@@ -541,7 +543,7 @@ the virtual bond gauge and proportionality lemmas above.
     \uses{def:same_state_reduction_hyp, def:non_ti_chain, def:same_mpv}
     Assume a same-state reduction hypothesis for $(d,D)$.
     Let $\mathbf{A}$ and $\mathbf{B}$ be $n$-site chains with common bond
-    dimension $D$, with $n \ge 3$, and assume that $\mathbf{A}$ is
+    dimension $D>0$, with $n \ge 3$, and assume that $\mathbf{A}$ is
     injective.
     If $\mathbf{A}$ and $\mathbf{B}$ generate the same chain state, then the
     combined tensors of $\mathbf{A}$ and $\mathbf{B}$ generate the same MPV
@@ -817,8 +819,8 @@ Chapter~\ref{ch:symmetry}.
     \lean{MPSChainTensor.fundamentalTheorem_blockedChain}
     \leanok
     \uses{def:blocked_chain, def:same_mpv}
-    Let $A$ and $B$ be MPS tensors of bond dimension $D$, let $L$ be a
-    blocking length, and let $n$ be a chain length.
+    Let $A$ and $B$ be MPS tensors of positive bond dimension $D$, let $L$ be
+    a blocking length, and let $n>0$ be a chain length.
     Assume that $A$ is $L$-block injective and that the combined tensors of the
     two constant blocked chains built from $A^{[L]}$ and $B^{[L]}$ generate the
     same MPV family.

--- a/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
@@ -522,7 +522,8 @@ translation-invariant corollary of \cite[Section~4]{Molnar2018NormalPEPS}.
     \leanok
     \uses{def:l_blk_injective, def:mpv}
     Let $n$ be positive, let $0 < L$ with $2L + 1 \le n$, and let $A$ and $B$
-    be tensors of $D \times D$ matrices over physical dimension $d$, each
+    be tensors of $D \times D$ matrices with $D>0$, over physical dimension
+    $d$, each
     $L$-block injective, whose matrix product vectors agree at system size
     $n$: $V^{(n)}(A)_\sigma = V^{(n)}(B)_\sigma$ for every configuration
     $\sigma$.  Then there are invertible matrices $Z_v$, one per bond of the
@@ -540,9 +541,8 @@ translation-invariant corollary of \cite[Section~4]{Molnar2018NormalPEPS}.
     proof''), rather than the $n \ge 3L$ of the blocking route.  The source's
     translation-invariant corollary (a single gauge $Z$ and a constant
     $\lambda$ with $\lambda^n = 1$) refines this conclusion and is not part
-    of this statement.  Positivity of the physical and bond dimensions is not
-    assumed: a vanishing bond dimension makes the conclusion trivial, and a
-    vanishing physical dimension contradicts block injectivity.
+    of this statement.  A vanishing physical dimension is already excluded
+    by block injectivity.
 \end{corollary}
 \begin{proof}\leanok
     \uses{cor:fundamentalTheorem_normalMPS_of_overlap}
@@ -559,7 +559,8 @@ translation-invariant corollary of \cite[Section~4]{Molnar2018NormalPEPS}.
     \leanok
     \uses{def:l_blk_injective}
     Let $n$ be positive, let $0 < L$ with $3L \le n$, and let $A$ and $B$ be
-    tensors of $D \times D$ matrices, each $L$-block injective.  If two
+    tensors of $D \times D$ matrices with $D>0$, each $L$-block injective.
+    If two
     families $Z$ and $Z'$ of invertible matrices on the bonds of the closed
     chain both satisfy $B^i = Z_v^{-1} A^i Z_{v+1}$ at every site, then they
     are proportional by a single constant: there is a nonzero scalar $c$
@@ -618,7 +619,8 @@ translation-invariant corollary of \cite[Section~4]{Molnar2018NormalPEPS}.
     \leanok
     \uses{def:l_blk_injective, def:mpv}
     Let $n$ be positive, let $0 < L$ with $2L + 1 \le n$, and let $A$ and $B$
-    be tensors of $D \times D$ matrices over physical dimension $d$, each
+    be tensors of $D \times D$ matrices with $D>0$, over physical dimension
+    $d$, each
     $L$-block injective, whose matrix product vectors agree at system size
     $n$: $V^{(n)}(A)_\sigma = V^{(n)}(B)_\sigma$ for every configuration
     $\sigma$.  Then there are an invertible matrix $Z$ and a constant
@@ -630,8 +632,7 @@ translation-invariant corollary of \cite[Section~4]{Molnar2018NormalPEPS}.
     \cite[Section~4]{Molnar2018NormalPEPS}, the statement for TI MPS
     following the first corollary after the general normal-PEPS theorem.  The
     system size is the optimal $n \ge 2L + 1$ of the source's alternative
-    proof.  Positivity of the bond dimension is not assumed: a vanishing bond
-    dimension makes the conclusion trivial.
+    proof.
 \end{corollary}
 \begin{proof}\leanok
     \uses{cor:fundamentalTheorem_normalMPS_translationInvariant_of_overlap}
@@ -646,7 +647,7 @@ translation-invariant corollary of \cite[Section~4]{Molnar2018NormalPEPS}.
     \lean{TNLean.PEPS.fundamentalTheorem_normalMPS_translationInvariant_gauge_unique}
     \leanok
     \uses{def:l_blk_injective}
-    Let $0 < L$ and let $A$ and $B$ be tensors of $D \times D$ matrices,
+    Let $0 < L$ and $0<D$, and let $A$ and $B$ be tensors of $D \times D$ matrices,
     each $L$-block injective.  If invertible matrices $Z$, $Z'$ and
     constants $\lambda$, $\lambda'$ satisfy
     $B^i = \lambda\, Z^{-1} A^i Z$ and $B^i = \lambda'\, Z'^{-1} A^i Z'$ for
@@ -659,8 +660,7 @@ translation-invariant corollary of \cite[Section~4]{Molnar2018NormalPEPS}.
 \begin{proof}\leanok
     \uses{def:eval_word}
     The scalar $\lambda$ is nonzero because $B$ is $L$-block injective with
-    positive bond dimension (a vanishing bond dimension makes the
-    conclusion trivial), so some $B^{i_0} \neq 0$.  Iterating each relation
+    positive bond dimension, so some $B^{i_0} \neq 0$.  Iterating each relation
     along a word $x$ of length $L$ gives
     $B^{x_1} \cdots B^{x_L} = \lambda^L\, Z^{-1} A^{x_1} \cdots A^{x_L} Z$
     and the primed analogue; the word products span the full matrix algebra
@@ -810,7 +810,7 @@ to $n \ge 2L + 1$.
     \lean{MPSTensor.exists_conjugation_of_mpv_eq}
     \leanok
     \uses{def:l_blk_injective, def:mpv, def:eval_word}
-    Let $0 < L$ with $2L + 1 \le n$, and let $A$ and $B$ be tensors of
+    Let $0 < L$ with $2L + 1 \le n$ and $0<D$, and let $A$ and $B$ be tensors of
     $D \times D$ matrices over physical dimension $d$, each $L$-block
     injective, whose matrix product vectors agree at system size $n$.
     Then there is an invertible matrix $Z$ with
@@ -881,7 +881,7 @@ to $n \ge 2L + 1$.
     \lean{TNLean.PEPS.fundamentalTheorem_normalMPS_translationInvariant_of_overlap}
     \leanok
     \uses{def:l_blk_injective, def:mpv}
-    Let $0 < L$ with $2L + 1 \le n$, and let $A$ and $B$ be tensors of
+    Let $0 < L$ with $2L + 1 \le n$ and $0<D$, and let $A$ and $B$ be tensors of
     $D \times D$ matrices over physical dimension $d$, each $L$-block
     injective, whose matrix product vectors agree at system size $n$:
     $V^{(n)}(A)_\sigma = V^{(n)}(B)_\sigma$ for every configuration
@@ -900,8 +900,6 @@ to $n \ge 2L + 1$.
     corollary — the gauge $Z$ is unique up to a multiplicative constant —
     needs no system size and is
     Corollary~\ref{cor:fundamentalTheorem_normalMPS_translationInvariant_gauge_unique}.
-    Positivity of the bond dimension is not assumed: a vanishing bond
-    dimension makes the conclusion trivial.
 \end{corollary}
 \begin{proof}\leanok
     \uses{lem:exists_conjugation_of_mpv_eq, lem:proportional_of_evalWord_eq}
@@ -920,8 +918,8 @@ to $n \ge 2L + 1$.
     \lean{TNLean.PEPS.fundamentalTheorem_normalMPS_of_overlap}
     \leanok
     \uses{def:l_blk_injective, def:mpv}
-    Let $n$ be positive, let $0 < L$ with $2L + 1 \le n$, and let $A$ and
-    $B$ be tensors of $D \times D$ matrices over physical dimension $d$,
+    Let $n$ be positive, let $0 < L$ with $2L + 1 \le n$ and $0<D$, and let
+    $A$ and $B$ be tensors of $D \times D$ matrices over physical dimension $d$,
     each $L$-block injective, whose matrix product vectors agree at system
     size $n$.  Then there are invertible matrices $Z_v$, one per bond of
     the closed chain ($v = 1, \ldots, n$, $n + 1 \equiv 1$), with
@@ -1154,7 +1152,8 @@ recorded in the route note
     \leanok
     \uses{def:chain_arc_window_injective, def:non_ti_chain}
     Let $0 < L$ with $2L + 1 \le n$, and let $A$ and $B$ be
-    site-dependent chains on $n$ sites, each window injective at length
+    site-dependent chains on $n$ sites with a common positive bond dimension,
+    each window injective at length
     $L$, generating the same closed-chain state.  Then for every site $p$
     there is an invertible matrix $Z$ with
     \[
@@ -1181,7 +1180,8 @@ recorded in the route note
     \leanok
     \uses{def:chain_arc_window_injective, def:non_ti_chain}
     Let $0 < L$ with $2L + 1 \le n$, and let $A$ and $B$ be
-    site-dependent chains on $n$ sites, each window injective at length
+    site-dependent chains on $n$ sites with a common positive bond dimension,
+    each window injective at length
     $L$, generating the same closed-chain state.  Then the chains are
     gauge equivalent: there are invertible matrices $Z_v$, one per bond
     of the closed chain, with
@@ -1200,8 +1200,7 @@ recorded in the route note
     \uses{lem:chain_exists_conjugation_of_sameState,
         lem:chain_overlapWindow_exists_bondOperator,
         lem:isWindowInjective_arc_span}
-    For a vanishing bond dimension the conclusion is trivial.  Otherwise
-    the per-bond conjugations
+    The per-bond conjugations
     (Lemma~\ref{lem:chain_exists_conjugation_of_sameState}) give window
     covariance with nonzero scalars: on every arc of $m$ sites with
     $L \le m$ and $m + L \le n$, the conjugation at the near end
@@ -1254,7 +1253,7 @@ recorded in the route note
         lem:isWindowInjective_one_of_isInjective}
     Let \(A_0,\ldots,A_{n-1}\) and \(B_0,\ldots,B_{n-1}\) be two
     site-dependent closed chains on \(n \ge 3\) sites, with common physical
-    dimension and common bond dimension.  Suppose every local tensor in
+    dimension and common positive bond dimension.  Suppose every local tensor in
     both chains is injective and the two closed-chain states are equal.
     Then there are invertible matrices \(Z_0,\ldots,Z_{n-1}\), one per
     bond of the closed chain, such that
@@ -1294,7 +1293,8 @@ recorded in the route note
     \uses{cor:fundamentalTheorem_injectiveMPSChain_of_sameState,
         def:mps_chain_cyclic_shift}
     Let \(A_0,\ldots,A_{n-1}\) be an injective site-dependent closed chain
-    on \(n\ge 3\) sites.  If its generated state is invariant under the
+    with positive bond dimension on \(n\ge 3\) sites.  If its generated state
+    is invariant under the
     cyclic shift \(A_v\mapsto A_{v+1}\), then there are invertible matrices
     \(Z_0,\ldots,Z_{n-1}\), one per bond, such that
     \[
@@ -1340,7 +1340,8 @@ recorded in the route note
     \uses{cor:fundamentalTheorem_injectiveMPSChain_cyclicShift,
         cor:exists_gauge_to_first_of_cyclicShift_gaugeEquiv}
     Let \(A_0,\ldots,A_{n-1}\) be an injective site-dependent closed chain
-    on \(n\ge 3\) sites.  If its generated state is invariant under the
+    with positive bond dimension on \(n\ge 3\) sites.  If its generated state
+    is invariant under the
     cyclic translation of the sites, then for every site \(v\) there are
     invertible matrices \(L_v\) and \(R_v\) such that
     \[
@@ -1363,8 +1364,8 @@ recorded in the route note
     \uses{cor:fundamentalTheorem_injectiveMPSChain_cyclicShift,
         def:mps_chain_cyclic_shift}
     Let \(A_0,\ldots,A_{n-1}\) be an injective site-dependent closed chain on
-    \(n\ge 3\) sites, with one physical dimension \(d\) and one bond dimension
-    \(D\).  If the closed-chain state is invariant under the cyclic shift
+    \(n\ge 3\) sites, with one physical dimension \(d\) and one positive bond
+    dimension \(D\).  If the closed-chain state is invariant under the cyclic shift
     \(A_v\mapsto A_{v+1}\), then there is an injective tensor \(B\), with bond
     dimension \(D\), such that for every physical configuration \(\sigma\),
     \[
@@ -1508,7 +1509,7 @@ recorded in the route note
     \leanok
     \uses{cor:fundamentalTheorem_injectiveMPSChain_of_sameState,
         def:chain_arc_window_injective}
-    Under the hypotheses of
+    Under the positive-bond-dimension hypotheses of
     Corollary~\ref{cor:fundamentalTheorem_injectiveMPSChain_of_sameState},
     suppose \(Z_v\) and \(Z'_v\) are two families of invertible matrices
     satisfying

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -2660,11 +2660,11 @@ two-bond factorization of the gauge action
 goes through the graph-level per-edge clause and a merge: the conjugation
 relation for both families fixes the nonzero tensor $B$ by the scalar
 $\mu_v^{-1}\mu_{v+1}$, so consecutive per-bond constants agree around the
-cycle.  The matrix-level statements carry no positivity hypotheses: a
-vanishing bond dimension makes the conclusions trivial, and a vanishing
-physical dimension contradicts block injectivity, so the
-counterexample-backed positivity corrections of the graph-level corollary
-are discharged rather than assumed.  The statements specialize the source's
+cycle.  The matrix and site-dependent closed-chain statements now assume
+positive bond dimension, matching the source's tensor-network setting and
+excluding the vacuous $0\times0$ matrix algebra; a vanishing physical
+dimension is already excluded by block injectivity.  The statements
+specialize the source's
 site-dependent families to one repeated tensor; the source's
 translation-invariant corollary (lines 1624--1661: a single gauge $Z$ and a
 constant $\lambda$ with $\lambda^n = 1$) is delivered in single-gauge form


### PR DESCRIPTION
## Summary

- require positive chain length and bond dimension on the physical injective-chain Fundamental Theorem and its blocked, phase, and same-state forms
- require positive bond dimension throughout the cycle-MPS/PEPS overlap, gauge, uniqueness, and constant-description theorem surface
- delete the exceptional proofs by empty chains or the trivial `0 × 0` matrix algebra
- align the corresponding blueprint statements and the Section 3 paper-gap account

The generic finite-dimensional algebraic cases remain unchanged: projector-closure induction, consequences derived from nonzero or invertible data, and local empty-configuration lemmas are not physical chain theorems and retain their mathematically natural zero-dimensional cases.

No axiom or unproved assertion is introduced.

Closes #4100.

## Verification

- `lake env lean --version` (Lean 4.32.0)
- `lake build TNLean` (9,534 targets)
- reader-facing prose check
- blueprint/Lean synchronization check
- generated declaration list checked by `checkdecls`
- `git diff --check`
- proof-integrity scan of all changed Lean files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a broad API change across many formal theorems and call sites; proofs are simplified rather than weakened, but any downstream code must supply the new `hn`/`hD` arguments.
> 
> **Overview**
> MPS and PEPS **fundamental theorems** now assume **nonempty chains** (`0 < n`) and **positive bond dimension** (`0 < D`) instead of treating `n = 0` or `D = 0` with vacuous proofs.
> 
> The core injective-chain theorem (`fundamentalTheorem_injective_chain`) drops its `n = 0` case split; blocked, gauge-phase, same-state, and `tensor_proportional` lemmas take the new hypotheses and thread them through callers. The cycle-MPS overlap, conjugation, translation-invariant, constant-description, and gauge-uniqueness surface does the same—**`D = 0` branches are removed** and proofs use `Fin D` nonempty from `hD`.
> 
> Blueprint chapters and the Section 3 paper-gap note now state **positive bond dimension** explicitly and no longer claim bond dimension may vanish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22dc34557b7c0c041315b38105af37105f0f4a94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->