### PR TITLE
feat(MPS/MPDO): prove strict BNT sector normalization

### DIFF
--- a/TNLean/Analysis/EntropyDecomposition.lean
+++ b/TNLean/Analysis/EntropyDecomposition.lean
@@ -32,9 +32,14 @@ in strong subadditivity.
   \(\mathrm{tr}\,\omega = 1\).
 * `vonNeumannEntropy_blockDiagonal'` — additivity over a finite orthogonal
   direct sum of Hermitian blocks: \(S\!\left(\bigoplus_j M_j\right) =
-  \sum_j S(M_j)\). The weighted Shannon form
-  \(S\!\left(\bigoplus_j p_j\,\omega_j\right) = H(\{p_j\}) + \sum_j p_j\,S(\omega_j)\)
-  is assembled downstream from this together with the scaling lemma.
+  \sum_j S(M_j)\).
+* `vonNeumannEntropy_blockDiagonal_smul` — the weighted direct-sum identity
+  \(S\!\left(\bigoplus_j p_j\,\omega_j\right)
+    = \sum_j(-p_j\log p_j+p_jS(\omega_j))\) for density matrices \(\omega_j\).
+  When the weights form a probability distribution, the first terms sum to
+  the Shannon entropy \(H(p)\).
+* `eq_of_weighted_sum_eq_of_pos_of_le` — equality of two positively weighted
+  sums, together with termwise inequalities, forces equality term by term.
 
 ## Implementation notes
 
@@ -364,5 +369,53 @@ theorem vonNeumannEntropy_blockDiagonal' (M : ∀ j, Matrix (dm j) (dm j) ℂ)
   rw [Fintype.sum_sigma]
   exact Finset.sum_congr rfl fun j _ => by
     rw [vonNeumannEntropy, hev]
+
+/-- **Entropy of a weighted finite orthogonal direct sum.** If every
+\(\omega_j\) is a density matrix, then
+\[
+  S\!\left(\bigoplus_j p_j\omega_j\right)
+    =\sum_j\bigl(-p_j\log p_j+p_jS(\omega_j)\bigr).
+\]
+
+This is the direct-sum entropy identity used in arXiv:1606.00608,
+Appendix C.2, lines 1760--1770. -/
+theorem vonNeumannEntropy_blockDiagonal_smul
+    (p : o → ℝ) (ω : ∀ j, Matrix (dm j) (dm j) ℂ)
+    (hω : ∀ j, (ω j).PosSemidef) (hωt : ∀ j, (ω j).trace = 1) :
+    vonNeumannEntropy (Matrix.blockDiagonal' (fun j => (p j : ℂ) • ω j)) (by
+      rw [Matrix.isHermitian_blockDiagonal'_iff]
+      exact fun j => (hω j).isHermitian.smul (k := (p j : ℂ))
+        (isSelfAdjoint_iff.mpr (by rw [RCLike.star_def, Complex.conj_ofReal]))) =
+      ∑ j, (negMulLog (p j) + p j * vonNeumannEntropy (ω j) (hω j).isHermitian) := by
+  classical
+  have hBlockHerm : ∀ j, ((p j : ℂ) • ω j).IsHermitian := fun j =>
+    (hω j).isHermitian.smul (k := (p j : ℂ))
+      (isSelfAdjoint_iff.mpr (by rw [RCLike.star_def, Complex.conj_ofReal]))
+  rw [vonNeumannEntropy_blockDiagonal' _ hBlockHerm]
+  apply Finset.sum_congr rfl
+  intro j _
+  simpa [add_comm] using vonNeumannEntropy_smul (hω j) (hωt j) (p j)
+
+/-- If two finite weighted sums agree, every weight is strictly positive, and
+the summands on the left are bounded above by the corresponding summands on
+the right, then every one of these inequalities is an equality.
+
+This is the finite positivity argument used after strong subadditivity in
+arXiv:1606.00608, Appendix C.2, lines 1770--1780. -/
+theorem eq_of_weighted_sum_eq_of_pos_of_le {ι : Type*} [Fintype ι]
+    (p L R : ι → ℝ) (hp : ∀ j, 0 < p j) (hle : ∀ j, L j ≤ R j)
+    (hsum : ∑ j, p j * L j = ∑ j, p j * R j) (j : ι) :
+    L j = R j := by
+  classical
+  have hnonneg : ∀ i, 0 ≤ p i * (R i - L i) := fun i =>
+    mul_nonneg (hp i).le (sub_nonneg.mpr (hle i))
+  have hzero : ∑ i, p i * (R i - L i) = 0 := by
+    simp_rw [mul_sub, Finset.sum_sub_distrib, hsum, sub_self]
+  have hterm : p j * (R j - L j) = 0 :=
+    (Finset.sum_eq_zero_iff_of_nonneg (fun i _ => hnonneg i)).mp hzero j
+      (Finset.mem_univ j)
+  have hdiff : R j - L j = 0 :=
+    (mul_eq_zero.mp hterm).resolve_left (ne_of_gt (hp j))
+  exact (sub_eq_zero.mp hdiff).symm
 
 end BlockDiagonal

--- a/TNLean/Analysis/EntropyDecomposition.lean
+++ b/TNLean/Analysis/EntropyDecomposition.lean
@@ -6,6 +6,7 @@ Authors: TNLean contributors
 import Mathlib.LinearAlgebra.Matrix.Kronecker
 import Mathlib.Data.Matrix.Block
 import TNLean.Analysis.Entropy
+import TNLean.Analysis.MatrixSqrt
 
 /-!
 # Decomposition lemmas for the von Neumann entropy
@@ -36,6 +37,7 @@ in strong subadditivity.
 * `vonNeumannEntropy_blockDiagonal_smul` — the weighted direct-sum identity
   \(S\!\left(\bigoplus_j p_j\,\omega_j\right)
     = \sum_j(-p_j\log p_j+p_jS(\omega_j))\) for density matrices \(\omega_j\).
+  The weights are nonnegative.
   When the weights form a probability distribution, the first terms sum to
   the Shannon entropy \(H(p)\).
 * `eq_of_weighted_sum_eq_of_pos_of_le` — equality of two positively weighted
@@ -371,7 +373,7 @@ theorem vonNeumannEntropy_blockDiagonal' (M : ∀ j, Matrix (dm j) (dm j) ℂ)
     rw [vonNeumannEntropy, hev]
 
 /-- **Entropy of a weighted finite orthogonal direct sum.** If every
-\(\omega_j\) is a density matrix, then
+\(\omega_j\) is a density matrix and every weight is nonnegative, then
 \[
   S\!\left(\bigoplus_j p_j\omega_j\right)
     =\sum_j\bigl(-p_j\log p_j+p_jS(\omega_j)\bigr).
@@ -381,11 +383,11 @@ This is the direct-sum entropy identity used in arXiv:1606.00608,
 Appendix C.2, lines 1760--1770. -/
 theorem vonNeumannEntropy_blockDiagonal_smul
     (p : o → ℝ) (ω : ∀ j, Matrix (dm j) (dm j) ℂ)
+    (hp : ∀ j, 0 ≤ p j)
     (hω : ∀ j, (ω j).PosSemidef) (hωt : ∀ j, (ω j).trace = 1) :
     vonNeumannEntropy (Matrix.blockDiagonal' (fun j => (p j : ℂ) • ω j)) (by
-      rw [Matrix.isHermitian_blockDiagonal'_iff]
-      exact fun j => (hω j).isHermitian.smul (k := (p j : ℂ))
-        (isSelfAdjoint_iff.mpr (by rw [RCLike.star_def, Complex.conj_ofReal]))) =
+      exact (Matrix.PosSemidef.blockDiagonal' _ fun j =>
+        (hω j).smul (a := (p j : ℂ)) (by exact_mod_cast hp j)).isHermitian) =
       ∑ j, (negMulLog (p j) + p j * vonNeumannEntropy (ω j) (hω j).isHermitian) := by
   classical
   have hBlockHerm : ∀ j, ((p j : ℂ) • ω j).IsHermitian := fun j =>

--- a/TNLean/Analysis/EntropyMarkovReverse.lean
+++ b/TNLean/Analysis/EntropyMarkovReverse.lean
@@ -558,12 +558,18 @@ theorem entropy_blockDiagonal_smul_kronecker {o : Type*} [Fintype o] [DecidableE
       = ∑ j, (negMulLog (p j)
           + p j * (vonNeumannEntropy (L j) (hL j).isHermitian
               + vonNeumannEntropy (R j) (hR j).isHermitian)) := by
-  have hBlockHerm : ∀ j, ((p j : ℂ) • ((L j) ⊗ₖ (R j))).IsHermitian := fun j =>
-    ((hL j).kronecker (hR j)).isHermitian.smul (k := (p j : ℂ))
-      (isSelfAdjoint_iff.mpr (by rw [RCLike.star_def, Complex.conj_ofReal]))
-  rw [vonNeumannEntropy_blockDiagonal' _ hBlockHerm hHerm]
+  have hKron : ∀ j, ((L j) ⊗ₖ (R j)).PosSemidef := fun j =>
+    (hL j).kronecker (hR j)
+  have hKronTrace : ∀ j, ((L j) ⊗ₖ (R j)).trace = 1 := fun j => by
+    rw [Matrix.trace_kronecker, hLt j, hRt j, mul_one]
+  rw [vonNeumannEntropy_congr rfl hHerm (by
+    rw [Matrix.isHermitian_blockDiagonal'_iff]
+    exact fun j => (hKron j).isHermitian.smul (k := (p j : ℂ))
+      (isSelfAdjoint_iff.mpr (by rw [RCLike.star_def, Complex.conj_ofReal])))]
+  rw [vonNeumannEntropy_blockDiagonal_smul p
+    (fun j => (L j) ⊗ₖ (R j)) hKron hKronTrace]
   refine Finset.sum_congr rfl fun j _ => ?_
-  rw [entropy_smul_kronecker (hL j) (hR j) (hLt j) (hRt j) (p j) (hBlockHerm j)]
+  rw [vonNeumannEntropy_kronecker (hL j) (hR j) (hLt j) (hRt j)]
 
 /-! ## Entropy invariance under conjugation by a unitary-group element -/
 

--- a/TNLean/Analysis/EntropyMarkovReverse.lean
+++ b/TNLean/Analysis/EntropyMarkovReverse.lean
@@ -544,11 +544,13 @@ theorem entropy_smul_kronecker {m n : Type*} [Fintype m] [DecidableEq m]
   rw [vonNeumannEntropy_kronecker hL hR hLt hRt]
   ring
 
-/-- The entropy of a block-diagonal sum of weighted Kronecker blocks. -/
+/-- The entropy of a block-diagonal sum of nonnegatively weighted Kronecker
+blocks. -/
 theorem entropy_blockDiagonal_smul_kronecker {o : Type*} [Fintype o] [DecidableEq o]
     {mL mR : o → Type*} [∀ j, Fintype (mL j)] [∀ j, DecidableEq (mL j)]
     [∀ j, Fintype (mR j)] [∀ j, DecidableEq (mR j)]
-    (p : o → ℝ) (L : ∀ j, Matrix (mL j) (mL j) ℂ) (R : ∀ j, Matrix (mR j) (mR j) ℂ)
+    (p : o → ℝ) (hp : ∀ j, 0 ≤ p j)
+    (L : ∀ j, Matrix (mL j) (mL j) ℂ) (R : ∀ j, Matrix (mR j) (mR j) ℂ)
     (hL : ∀ j, (L j).PosSemidef) (hR : ∀ j, (R j).PosSemidef)
     (hLt : ∀ j, (L j).trace = 1) (hRt : ∀ j, (R j).trace = 1)
     (hHerm : (Matrix.blockDiagonal'
@@ -566,8 +568,8 @@ theorem entropy_blockDiagonal_smul_kronecker {o : Type*} [Fintype o] [DecidableE
     rw [Matrix.isHermitian_blockDiagonal'_iff]
     exact fun j => (hKron j).isHermitian.smul (k := (p j : ℂ))
       (isSelfAdjoint_iff.mpr (by rw [RCLike.star_def, Complex.conj_ofReal])))]
-  rw [vonNeumannEntropy_blockDiagonal_smul p
-    (fun j => (L j) ⊗ₖ (R j)) hKron hKronTrace]
+  rw [vonNeumannEntropy_blockDiagonal_smul p (fun j => (L j) ⊗ₖ (R j)) hp
+    hKron hKronTrace]
   refine Finset.sum_congr rfl fun j _ => ?_
   rw [vonNeumannEntropy_kronecker (hL j) (hR j) (hLt j) (hRt j)]
 
@@ -613,13 +615,14 @@ theorem traceRight_density {d d' : ℕ} {ρ : Matrix (Fin d × Fin d') (Fin d ×
 This packages the chain `entropy of a submatrix-reindexed block-diagonal = entropy
 of the block-diagonal = block formula`, used by each of the four entropy terms. -/
 
-/-- The entropy of a reindexed block-diagonal of weighted Kronecker blocks of
-density matrices equals the block formula. -/
+/-- The entropy of a reindexed block-diagonal of nonnegatively weighted
+Kronecker blocks of density matrices equals the block formula. -/
 theorem entropy_submatrix_blockDiagonal_smul_kronecker {o : Type*} [Fintype o] [DecidableEq o]
     {mL mR : o → Type*} [∀ j, Fintype (mL j)] [∀ j, DecidableEq (mL j)]
     [∀ j, Fintype (mR j)] [∀ j, DecidableEq (mR j)] {ι : Type*} [Fintype ι] [DecidableEq ι]
     (φ : ι ≃ Σ j, mL j × mR j)
-    (p : o → ℝ) (L : ∀ j, Matrix (mL j) (mL j) ℂ) (R : ∀ j, Matrix (mR j) (mR j) ℂ)
+    (p : o → ℝ) (hp : ∀ j, 0 ≤ p j)
+    (L : ∀ j, Matrix (mL j) (mL j) ℂ) (R : ∀ j, Matrix (mR j) (mR j) ℂ)
     (hL : ∀ j, (L j).PosSemidef) (hR : ∀ j, (R j).PosSemidef)
     (hLt : ∀ j, (L j).trace = 1) (hRt : ∀ j, (R j).trace = 1)
     (hHerm : ((Matrix.blockDiagonal'
@@ -636,7 +639,7 @@ theorem entropy_submatrix_blockDiagonal_smul_kronecker {o : Type*} [Fintype o] [
       (isSelfAdjoint_iff.mpr (by rw [RCLike.star_def, Complex.conj_ofReal]))
   rw [vonNeumannEntropy_congr rfl hHerm ((isHermitian_submatrix_equiv φ).mpr hBlockHerm)]
   rw [vonNeumannEntropy_submatrix_equiv φ _ hBlockHerm]
-  exact entropy_blockDiagonal_smul_kronecker p L R hL hR hLt hRt hBlockHerm
+  exact entropy_blockDiagonal_smul_kronecker p hp L R hL hR hLt hRt hBlockHerm
 
 
 /-! ## Reverse direction of the Hayashi strong-subadditivity equality characterization -/
@@ -708,7 +711,7 @@ theorem hayashi_ssa_equality_characterization_reverse {dA dB dC : ℕ}
               (traceRight_density (hRdm j).1 (hRdm j).2).1.isHermitian)) := by
     rw [← vonNeumannEntropy_unitaryGroup_conj H.U_B hHermAC hConjAC]
     rw [vonNeumannEntropy_congr hAC_eq hConjAC hHermBD_AC]
-    rw [entropy_submatrix_blockDiagonal_smul_kronecker H.decompB H.p
+    rw [entropy_submatrix_blockDiagonal_smul_kronecker H.decompB H.p H.hp_nonneg
       (fun j => Matrix.traceLeft (H.ρ_left j)) (fun j => Matrix.traceRight (H.ρ_right j))
       (fun j => (traceLeft_density (hLdm j).1 (hLdm j).2).1)
       (fun j => (traceRight_density (hRdm j).1 (hRdm j).2).1)
@@ -746,7 +749,8 @@ theorem hayashi_ssa_equality_characterization_reverse {dA dB dC : ℕ}
       change L * ρ_ABC * Lᴴ = _
       rw [← hM, hM_eq]
     rw [vonNeumannEntropy_congr hWconj hConjFull hHermBD0]
-    rw [entropy_submatrix_blockDiagonal_smul_kronecker φ0 H.p H.ρ_left H.ρ_right
+    rw [entropy_submatrix_blockDiagonal_smul_kronecker φ0 H.p H.hp_nonneg
+      H.ρ_left H.ρ_right
       (fun j => (hLdm j).1) (fun j => (hRdm j).1)
       (fun j => (hLdm j).2) (fun j => (hRdm j).2) hHermBD0]
   -- Entropy of `traceC ρ_ABC = ρ_AB`.
@@ -791,7 +795,7 @@ theorem hayashi_ssa_equality_characterization_reverse {dA dB dC : ℕ}
     rw [← vonNeumannEntropy_unitaryGroup_conj WC hHermC hConjC]
     rw [vonNeumannEntropy_congr hC_eq hConjC hHermBD_C]
     rw [entropy_submatrix_blockDiagonal_smul_kronecker
-      (HayashiMarkov.cEquiv (dA := dA) H.decompB) H.p H.ρ_left
+      (HayashiMarkov.cEquiv (dA := dA) H.decompB) H.p H.hp_nonneg H.ρ_left
       (fun j => Matrix.traceRight (H.ρ_right j))
       (fun j => (hLdm j).1) (fun j => (traceRight_density (hRdm j).1 (hRdm j).2).1)
       (fun j => (hLdm j).2) (fun j => (traceRight_density (hRdm j).1 (hRdm j).2).2) hHermBD_C]
@@ -837,7 +841,7 @@ theorem hayashi_ssa_equality_characterization_reverse {dA dB dC : ℕ}
     rw [← vonNeumannEntropy_unitaryGroup_conj WA hHermA hConjA]
     rw [vonNeumannEntropy_congr hA_eq hConjA hHermBD_A]
     rw [entropy_submatrix_blockDiagonal_smul_kronecker
-      (HayashiMarkov.aEquiv (dC := dC) H.decompB) H.p
+      (HayashiMarkov.aEquiv (dC := dC) H.decompB) H.p H.hp_nonneg
       (fun j => Matrix.traceLeft (H.ρ_left j)) H.ρ_right
       (fun j => (traceLeft_density (hLdm j).1 (hLdm j).2).1) (fun j => (hRdm j).1)
       (fun j => (traceLeft_density (hLdm j).1 (hLdm j).2).2) (fun j => (hRdm j).2) hHermBD_A]

--- a/TNLean/MPS/MPDO/BNTSectorAnalyticProperties.lean
+++ b/TNLean/MPS/MPDO/BNTSectorAnalyticProperties.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.BNTProjectorSelection
+import TNLean.MPS.MPDO.SectorTrace
 
 /-!
 # Positivity and zero correlation length of the BNT sectors
@@ -33,6 +34,8 @@ copy index.
   the source projector construction supplies the required compression.
 * `commonWeightAbsorbedBasisMPOTensor_isSourceZCL`:
   source zero correlation length restricts to every absorbed representative.
+* `trace_mpo_commonWeightAbsorbedBasisMPOTensor_pos`:
+  every nonempty-chain sector normalization is strictly positive.
 
 ## References
 
@@ -178,5 +181,50 @@ theorem commonWeightAbsorbedBasisMPOTensor_isMPDO_of_sameMPV₂Pos_isSAL
       M S hM hWeight hnonNil hSAL
   exact commonWeightAbsorbedBasisMPOTensor_isMPDO_of_projectorSelection
     M S hM hWeight hC hClosure.1 hη hClosure.2 (Classical.choose hSAL) s
+
+/-- Every absorbed normal representative has strictly positive trace on each
+nonempty chain.  Positivity comes from the projector compression, while
+nonvanishing comes from the zero-correlation-length equation already
+restricted to the representative.
+
+This supplies the strict inequality required before normalizing the sector in
+the direct-sum entropy identity.  It is not inferred from the weaker displayed
+inequality \(p_s\geq 0\).
+
+**Scope restriction (common blocking):** the one-letter simultaneous span is
+the blocked form used for the simultaneous inverse.  Its derivation from biCF
+is recorded in `docs/paper-gaps/cpgsv17_bicf_block_separation.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1760--1780. -/
+theorem trace_mpo_commonWeightAbsorbedBasisMPOTensor_pos
+    {D : ℕ} (M : MPOTensor d D)
+    (S : MPSTensor.SectorDecomposition (d * d)) (hTotal : S.totalDim = D)
+    (X : (s : Fin S.totalCopies) → GL (Fin (S.flatDim s)) ℂ)
+    (hEq : ∀ i : Fin (d * d),
+      M.toMPSTensor i =
+        cast (by rw [hTotal] :
+            Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ =
+              Matrix (Fin D) (Fin D) ℂ)
+          ((MPSTensor.globalGaugeOfBlocks X :
+                Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ) *
+            S.toTensor i *
+            (((MPSTensor.globalGaugeOfBlocks X)⁻¹ :
+                GL (Fin S.totalDim) ℂ) :
+              Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ)))
+    (hM : MPSTensor.SameMPV₂Pos M.toMPSTensor S.toTensor)
+    (hZCL : IsSourceZCL M)
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q')
+    (hnonNil : ∀ j,
+      ¬ IsNilpotent (doubledPhysTraceTransfer d (S.basis j)))
+    (hSpan : MPSTensor.WordTupleSpanTop S.basis 1)
+    (hSAL : IsSAL M) (s : Fin S.basisCount)
+    {N : ℕ} (hN : 0 < N) :
+    0 < Matrix.trace (mpo (commonWeightAbsorbedBasisMPOTensor S hWeight s) N) := by
+  exact trace_mpo_pos_of_isMPDO_isSourceZCL _
+    (commonWeightAbsorbedBasisMPOTensor_isMPDO_of_sameMPV₂Pos_isSAL
+      M S hM hWeight hnonNil hSpan hSAL s)
+    (commonWeightAbsorbedBasisMPOTensor_isSourceZCL
+      M S hTotal X hEq hZCL hWeight s (hnonNil s)) hN
 
 end MPOTensor

--- a/TNLean/MPS/MPDO/SectorTrace.lean
+++ b/TNLean/MPS/MPDO/SectorTrace.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import Mathlib.LinearAlgebra.Trace
 import TNLean.MPS.MPDO.InvariantProjection
 import TNLean.MPS.MPDO.ZCL
 
@@ -52,6 +53,11 @@ the sector projector acting on one site, as in the diagrams of that proof.
 
 * `trace_mpo_eq_trace_verticalLoop_pow`:
   $\tr H^{(N)} = \tr(E^N)$ with `E = verticalLoop M`.
+* `trace_mpo_ne_zero_of_isSourceZCL`:
+  source zero correlation length forces the trace of every positive-length
+  density operator to be nonzero.
+* `trace_mpo_pos_of_isMPDO_isSourceZCL`:
+  if the tensor also generates an MPDO, these traces are strictly positive.
 * `trace_firstSiteMatrix_mul_mpo` / `trace_sectorCompression_of_idempotent`:
   the general trace computation
   $\tr(P_1H^{(N+1)}P_1) = \tr(E_P\,E^N)$ for idempotent `P`.
@@ -218,6 +224,55 @@ theorem trace_mpo_eq_trace_verticalLoop_pow (M : MPOTensor d D) (N : ℕ) :
     Matrix.trace (mpo M N) = Matrix.trace (verticalLoop M ^ N) := by
   rw [← sum_evalWord_diag_eq_verticalLoop_pow M N, Matrix.trace_sum]
   simp only [Matrix.trace, Matrix.diag, mpo_apply, mpoMatrixEntry]
+
+/-- Source zero correlation length forces the trace of every nonempty-chain
+density operator to be nonzero.  Indeed, after dividing the physical-trace
+transfer by its positive eigenvalue, one obtains a nonzero idempotent.  Its
+trace is nonzero, and all its positive powers are equal to itself.
+
+This supplies the strict normalization needed in the sector entropy identity;
+it does not use the empty-chain convention.
+
+Source: arXiv:1606.00608, Definition 4.2, lines 735--739, and Appendix C.2,
+lines 1760--1780. -/
+theorem trace_mpo_ne_zero_of_isSourceZCL (M : MPOTensor d D)
+    (hZCL : IsSourceZCL M) {N : ℕ} (hN : 0 < N) :
+    Matrix.trace (mpo M N) ≠ 0 := by
+  obtain ⟨lam, hlam, hidem⟩ := hZCL.normalized_idempotent
+  let E := ((lam : ℂ)⁻¹) • physTraceTransfer M
+  have hlamC : (lam : ℂ) ≠ 0 := by exact_mod_cast ne_of_gt hlam
+  have hEne : E ≠ 0 := by
+    dsimp only [E]
+    exact smul_ne_zero (inv_ne_zero hlamC) hZCL.1
+  have hEtrace : Matrix.trace E ≠ 0 := by
+    intro htrace
+    have hLinIdem : IsIdempotentElem (Matrix.toLinAlgEquiv' E) :=
+      hidem.map
+        (Matrix.toLinAlgEquiv' : Matrix (Fin D) (Fin D) ℂ ≃ₐ[ℂ]
+          Module.End ℂ (Fin D → ℂ)).toMonoidHom
+    have hLinZero : E.toLin' = 0 :=
+      LinearMap.IsIdempotentElem.eq_zero_of_trace_eq_zero hLinIdem
+        (by simpa using htrace)
+    exact hEne (Matrix.toLinAlgEquiv'.injective (by simpa using hLinZero))
+  have hscale : physTraceTransfer M = (lam : ℂ) • E := by
+    dsimp only [E]
+    rw [smul_smul, mul_inv_cancel₀ hlamC, one_smul]
+  rw [trace_mpo_eq_trace_verticalLoop_pow, verticalLoop_eq_physTraceTransfer,
+    hscale, smul_pow, hidem.pow_eq hN.ne', Matrix.trace_smul, smul_eq_mul]
+  exact mul_ne_zero (pow_ne_zero N hlamC) hEtrace
+
+/-- An MPDO tensor with source zero correlation length has strictly positive
+normalization on every nonempty chain.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1760--1780.  This is the strict
+form of the displayed inequality \(p_j\geq0\)
+needed to divide each sector by its trace. -/
+theorem trace_mpo_pos_of_isMPDO_isSourceZCL (M : MPOTensor d D)
+    (hM : IsMPDO M) (hZCL : IsSourceZCL M) {N : ℕ} (hN : 0 < N) :
+    0 < Matrix.trace (mpo M N) := by
+  apply Matrix.PosSemidef.trace_pos_of_ne_zero (hM N hN)
+  intro hzero
+  exact trace_mpo_ne_zero_of_isSourceZCL M hZCL hN (by rw [hzero, Matrix.trace_zero])
 
 /-! ### The first-site compression and its trace -/
 

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -1427,7 +1427,7 @@ Theorem~\ref{thm:trace_norm_abs}.
     \lean{vonNeumannEntropy_blockDiagonal_smul}
     \leanok
     \uses{thm:entropy_smul, thm:entropy_block_diagonal}
-    Let $\omega_j$ be density matrices and let $p_j$ be real numbers.  Then
+    Let $\omega_j$ be density matrices and let $p_j\geq0$.  Then
     \[
         S\!\left(\bigoplus_j p_j\omega_j\right)
           = \sum_j\bigl(-p_j\log p_j+p_jS(\omega_j)\bigr).

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -1422,6 +1422,51 @@ Theorem~\ref{thm:trace_norm_abs}.
     \]
 \end{proof}
 
+\begin{theorem}[Entropy of a weighted orthogonal direct sum]
+    \label{thm:entropy_weighted_block_diagonal}
+    \lean{vonNeumannEntropy_blockDiagonal_smul}
+    \leanok
+    \uses{thm:entropy_smul, thm:entropy_block_diagonal}
+    Let $\omega_j$ be density matrices and let $p_j$ be real numbers.  Then
+    \[
+        S\!\left(\bigoplus_j p_j\omega_j\right)
+          = \sum_j\bigl(-p_j\log p_j+p_jS(\omega_j)\bigr).
+    \]
+    In particular, when the $p_j$ form a probability distribution, this is
+    \[
+        S\!\left(\bigoplus_j p_j\omega_j\right)
+          = H(p)+\sum_j p_jS(\omega_j).
+    \]
+    This is the entropy identity used in
+    \cite[Appendix~C.2, lines~1760--1770]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    Entropy is additive over the orthogonal blocks.  Applying the scaled-state
+    formula to each block gives
+    $S(p_j\omega_j)=-p_j\log p_j+p_jS(\omega_j)$, and summing over $j$ gives
+    the result.
+\end{proof}
+
+\begin{theorem}[Equality in a positively weighted sum]
+    \label{thm:positive_weighted_sum_termwise_equality}
+    \lean{eq_of_weighted_sum_eq_of_pos_of_le}
+    \leanok
+    Suppose $p_j>0$ and $L_j\leq R_j$ for every $j$.  If
+    \[
+        \sum_j p_jL_j=\sum_j p_jR_j,
+    \]
+    then $L_j=R_j$ for every $j$.  This is the positivity argument applied to
+    strong subadditivity in
+    \cite[Appendix~C.2, lines~1770--1780]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    Each number $p_j(R_j-L_j)$ is nonnegative, and their sum vanishes.
+    Therefore every one vanishes.  Since $p_j>0$, it follows that
+    $R_j-L_j=0$.
+\end{proof}
+
 \section{Tripartite partial traces}
 
 \begin{definition}[Partial trace over $A$]\label{def:traceA_ABC}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
@@ -585,6 +585,46 @@ strong subadditivity for a normalized three-site reduced state.
     nonzero.
 \end{proof}
 
+\begin{theorem}[Strict normalization at positive length]
+    \label{thm:mpdo_source_zcl_strict_positive_length_normalization}
+    \lean{MPOTensor.trace_mpo_ne_zero_of_isSourceZCL}
+    \lean{MPOTensor.trace_mpo_pos_of_isMPDO_isSourceZCL}
+    \lean{MPOTensor.%
+      trace_mpo_commonWeightAbsorbedBasisMPOTensor_pos}
+    \leanok
+    \uses{def:mpdo, def:mpo_source_zcl, lem:mpdo_trace_loop_chain,
+      cor:mpdo_absorbed_bnt_sector_is_mpdo,
+      thm:mpdo_absorbed_bnt_sector_zcl}
+    Let $M$ generate matrix product density operators and have source zero
+    correlation length.  Then
+    \[
+        \tr\bigl(\sigma^{(N)}(M)\bigr)>0
+        \qquad (N\geq1).
+    \]
+    In particular, after a common blocking has made the simultaneous BNT
+    word span full at one letter, the absorbed BNT elements selected in
+    Theorem~\ref{thm:mpdo_absorbed_bnt_sector_zcl} have a well-defined
+    normalized state at every physical chain length.  This common-blocking
+    restriction is recorded in
+    \path{docs/paper-gaps/cpgsv17_bicf_block_separation.tex}.
+    This supplies the strict form of the sector normalization used in
+    \cite[Appendix~C.2, lines~1760--1780]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    Write the physical-trace transfer as $\mathcal T_M=\lambda E$, where
+    $\lambda>0$ and $E$ is a nonzero idempotent.  A nonzero idempotent on a
+    finite-dimensional complex vector space has nonzero trace, while
+    $E^N=E$ for $N\geq1$.  Hence
+    \[
+        \tr\bigl(\sigma^{(N)}(M)\bigr)
+        =\tr(\mathcal T_M^N)
+        =\lambda^N\tr(E)\ne0.
+    \]
+    Positivity of the density operator then makes this trace strictly
+    positive.
+\end{proof}
+
 \begin{definition}[Injective inverse map for a simple MPO tensor]
     \label{def:mpdo_injective_inverse_layer}
     \lean{MPOTensor.IsInjective}

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -303,11 +303,22 @@ $s$-th canonical block and using nonnilpotence to exclude the zero transfer.
 \path{MPOTensor.commonWeightAbsorbedBasisMPOTensor_isMPDO_of_sameMPV₂Pos_isSAL},
 and
 \path{MPOTensor.commonWeightAbsorbedBasisMPOTensor_isSourceZCL}.}
-The remaining source step after the sector-compression identity is SAL for
-each sector.  It must follow from the direct-sum entropy identity and strong
-subadditivity, including a proof that every sector normalization used there is
-nonzero; this normalization may not be silently inferred from the weaker
-displayed inequality $p_j\geq0$ in
+The strict normalization needed in the sector entropy identity is now
+formalized: an MPDO tensor with source ZCL has positive trace at every
+nonempty chain length, since its normalized physical-trace transfer is a
+nonzero idempotent.  Applied to the absorbed BNT sectors above, this proves
+$p_j^{(N)}>0$ rather than silently inferring it from the weaker displayed
+inequality $p_j\geq0$.
+\footnote{The general declarations are
+\path{MPOTensor.trace_mpo_ne_zero_of_isSourceZCL} and
+\path{MPOTensor.trace_mpo_pos_of_isMPDO_isSourceZCL}; their specialization to
+the absorbed BNT representative is
+\path{MPOTensor.trace_mpo_commonWeightAbsorbedBasisMPOTensor_pos}.}
+The weighted orthogonal-direct-sum entropy formula used in Appendix~C.2,
+lines~1760--1770, is also formalized as
+\path{vonNeumannEntropy_blockDiagonal_smul}.  The remaining source step after the
+sector-compression identity is SAL for each sector.  It must follow from the
+direct-sum entropy identity and strong subadditivity as in
 \cite[Appendix~C.2, lines~1760--1780]{Cirac2016MPDO_arXiv}.
 
 The neighboring operators are now assembled from these sector tensors.  The


### PR DESCRIPTION
## Summary

This proves the analytic prerequisites for the sectorwise saturated-area-law step in arXiv:1606.00608, Appendix C.2, lines 1760--1780.

- prove the weighted orthogonal-direct-sum entropy identity without an auxiliary Hermiticity hypothesis;
- prove that an MPDO tensor with source zero correlation length has strictly positive trace at every chain length N >= 1;
- specialize this normalization theorem to each common-weight-absorbed BNT representative;
- update the blueprint and the MPDO SAL/ZCL paper-gap note.

The normalization proof uses the nonzero idempotent obtained from the source ZCL equation. It does not use an empty-chain value and introduces no axiom. The absorbed-sector specialization has the existing common-blocking scope restriction recorded in `docs/paper-gaps/cpgsv17_bicf_block_separation.tex`. The remaining part of #4110 is the direct-sum decomposition of the relevant marginals and the sectorwise strong-subadditivity equality.

## Verification

- `lake build` (Lean 4.32.0; 9534 targets)
- blueprint/Lean synchronization
- changed-declaration blueprint coverage
- reader-facing prose check
- proof-integrity scan
- `git diff --check`

Advances #4110.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Lean formalization and documentation for entropy/MPDO analytics; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds the **weighted orthogonal direct-sum** von Neumann entropy identity and a **termwise equality** lemma for positively weighted sums, then routes Hayashi Markov **block–Kronecker** entropy through the new API with an explicit **nonnegative weights** hypothesis (`hp` / `H.hp_nonneg`) instead of duplicating block proofs.
> 
> Proves **strict positive trace** for MPDO chains when **source zero correlation length** holds (normalized physical-trace transfer is a nonzero idempotent), and specializes this to **common-weight absorbed BNT** representatives via existing MPDO/ZCL infrastructure.
> 
> Blueprint **ch19** documents the entropy lemmas; **ch21** and the MPDO SAL/ZCL gap note record strict normalization as formalized rather than inferred from \(p_j \ge 0\).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d572b06f32f155e8a2004e8ab2fd8f0161a7721f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->