### PR TITLE
style(MPS/MPDO): move positive-length quantifier into prose

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
@@ -596,10 +596,9 @@ strong subadditivity for a normalized three-site reduced state.
       cor:mpdo_absorbed_bnt_sector_is_mpdo,
       thm:mpdo_absorbed_bnt_sector_zcl}
     Let $M$ generate matrix product density operators and have source zero
-    correlation length.  Then
+    correlation length.  Then, for every $N\geq1$,
     \[
-        \tr\bigl(\sigma^{(N)}(M)\bigr)>0
-        \qquad (N\geq1).
+        \tr\bigl(\sigma^{(N)}(M)\bigr)>0.
     \]
     In particular, after a common blocking has made the simultaneous BNT
     word span full at one letter, the absorbed BNT elements selected in


### PR DESCRIPTION
## Summary

Moves the positive-length condition from a right-hand tail on the displayed
trace inequality into the preceding mathematical sentence.

## Context

PR #4112 was merged at `d572b06f32` before this accepted prose correction
could enter its frozen head. This follow-up contains only that correction and
does not alter the Lean theorem, its hypotheses, or its proof.

This addresses the exact review objection in
https://github.com/LionSR/TNLean/pull/4112#discussion_r3606709347 and follows
the displayed-equation convention in `docs/prose_style.md`.

## Validation

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex`
- `git diff origin/main...HEAD --check`

The preceding PR's hosted blueprint and declaration-synchronization checks
passed. This follow-up changes no `\lean{}` or `\uses{}` tag; its fresh hosted
blueprint check remains the final validation gate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX wording in the blueprint; no formal or proof changes.
> 
> **Overview**
> **Blueprint prose only** in `ch21_mpdo_rfp_simple_local_markov_factorization.tex`: Theorem *Strict normalization at positive length* now states **“for every \(N\geq1\)”** in the sentence before the display, instead of as a right-hand tail (`\qquad (N\geq1)`) on the trace inequality.
> 
> The displayed formula is unchanged in meaning; punctuation is adjusted (period after the inequality). This aligns with `docs/prose_style.md` (no prose quantifier tails on displayed equations). **No** `\lean{}`, `\uses{}`, Lean statements, or proofs are modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f55fccdf2260cee953d9d398cba9f554e29819ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->