### PR TITLE
feat(MPS/MPDO): prove sector projector sum and SAL equivalence

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -444,6 +444,7 @@ import TNLean.MPS.MPDO.VerticalMapTransport
 import TNLean.MPS.MPDO.PRFP
 import TNLean.MPS.MPDO.LocalPurificationRFP
 import TNLean.MPS.MPDO.SimpleLocalStructure
+import TNLean.MPS.MPDO.SALArbitraryCut
 import TNLean.MPS.MPDO.BNTThreeSiteReducedClosure
 import TNLean.MPS.MPDO.BNTSourceSectorProjectors
 import TNLean.MPS.MPDO.SitewisePhysicalMatrix

--- a/TNLean/MPS/MPDO/BNTProjectorSelection.lean
+++ b/TNLean/MPS/MPDO/BNTProjectorSelection.lean
@@ -400,6 +400,38 @@ theorem bntSectorProjection_mul_physicalSlice_mul_eq_zero
     · simp [hlt]
   · simp [hks]
 
+/-- Summing the diagonal BNT-sector corners recovers every physical slice of
+a normal representative:
+\[
+  \sum_s P_s\,\mathcal K_i^{\beta,\alpha}\,P_s
+    =\mathcal K_i^{\beta,\alpha}.
+\]
+This is the one-site algebraic content of the orthogonal direct-sum
+decomposition of the sector states.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1733--1770. -/
+theorem sum_bntSectorProjection_mul_physicalSlice_mul_self
+    {K : (s : Fin g) → MPOTensor d (dim s)}
+    {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse K C)
+    (hρ : IsThreeSiteFamilyClosure K R ρ) (hη : EtaStructure ρ)
+    (hR : ∀ s : Fin g, R s ≠ 0) (i : Fin g)
+    (β α : Fin (dim i)) :
+    (∑ s : Fin g,
+      bntSectorProjection hC hρ hη hR s * physicalSlice (K i) β α *
+        bntSectorProjection hC hρ hη hR s) =
+      physicalSlice (K i) β α := by
+  classical
+  rw [Finset.sum_eq_single i]
+  · exact bntSectorProjection_mul_physicalSlice_mul_self
+      hC hρ hη hR i β α
+  · intro s _ hsi
+    exact bntSectorProjection_mul_physicalSlice_mul_eq_zero
+      hC hρ hη hR i s s (Or.inr (Ne.symm hsi)) β α
+  · simp
+
 /-- Changing the physical basis of representative `i` by the BNT projector
 `P_s` retains that representative exactly when `s = i` and otherwise gives
 the zero tensor.

--- a/TNLean/MPS/MPDO/SALArbitraryCut.lean
+++ b/TNLean/MPS/MPDO/SALArbitraryCut.lean
@@ -1,0 +1,159 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.SimpleLocalStructure
+
+/-!
+# SAL and arbitrary-cut strong-subadditivity equality
+
+This file proves the entropy equivalence used in the sectorwise
+saturated-area-law argument of arXiv:1606.00608, Appendix C.2.  For the
+four-region division of lengths \(m-1,1,N-m-1,1\), saturation of the area law
+is equivalent to equality in strong subadditivity for the marginal on the
+first three regions.  The converse is stated for all admissible cuts.
+
+## Main declarations
+
+- `MPOTensor.isSSAEquality_tripartite_m_of_isSAL`: SAL gives the arbitrary-cut
+  strong-subadditivity equality.
+- `MPOTensor.mutualInfoChain_one_eq_of_isSSAEquality_tripartite_m`: the
+  equality gives \(I_1=I_m\).
+- `MPOTensor.isSAL_of_isSSAEquality_tripartite_m`: the equalities at all
+  admissible cuts recover SAL.
+-/
+
+open scoped Matrix ComplexOrder BigOperators
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- Saturation of the area law gives equality in strong subadditivity for the
+three-region marginal obtained from four consecutive regions of lengths
+\(m-1,1,N-m-1,1\).  The entropy identity is
+\[
+  S_{N-1}+S_1=S_m+S_{N-m},
+\]
+which is equivalent to \(I_1=I_m\) after cancelling the full-chain entropy.
+
+**Local fix (endpoint):** The source writes \(m<\lfloor N/2\rfloor\) at
+line 1771, while its SAL chain and final comparison require the endpoint
+\(m=\lfloor N/2\rfloor\).  This correction is documented in
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1760--1780. -/
+theorem isSSAEquality_tripartite_m_of_isSAL (M : MPOTensor d D)
+    (hSAL : IsSAL M) {N m : ℕ} (hm1 : 1 ≤ m) (hmN : m ≤ N / 2) :
+    let hM : (mpo M N).PosSemidef := (Classical.choose hSAL) N (by omega)
+    let h3 : (m - 1) + 1 + (N - m - 1) ≤ N := by omega
+    let ρ_ABC := (M.reducedBlockState N ((m - 1) + 1 + (N - m - 1)) h3).submatrix
+      (tripartiteSplitEquiv d (m - 1) 1 (N - m - 1)).symm
+      (tripartiteSplitEquiv d (m - 1) 1 (N - m - 1)).symm
+    IsSSAEquality ρ_ABC
+      ((reducedBlockState_posSemidef M N ((m - 1) + 1 + (N - m - 1)) h3 hM).submatrix _).1 := by
+  classical
+  dsimp only
+  rw [IsSSAEquality]
+  let hMpdo : IsMPDO M := Classical.choose hSAL
+  have hNpos : 0 < N := by omega
+  have hEq := mutualInfoChain_eq_of_isSAL M hSAL
+    (N := N) (L := 1) (L' := m) (by omega) (by omega) hm1 hmN
+  simp only [mutualInfoChain] at hEq
+  have hEABC := vonNeumannEntropy_tripartiteSplit_eq_blockEntropy M
+    (N := N) (a := m - 1) (b := 1) (c := N - m - 1) (by omega) (hMpdo N hNpos)
+  have hEC := vonNeumannEntropy_traceC_eq_blockEntropy M
+    (N := N) (a := m - 1) (b := 1) (c := N - m - 1) (by omega) (hMpdo N hNpos)
+  have hEAC := vonNeumannEntropy_traceAC_eq_blockEntropy M
+    (N := N) (a := m - 1) (b := 1) (c := N - m - 1) (by omega) (hMpdo N hNpos)
+  have hEA := vonNeumannEntropy_traceA_eq_blockEntropy M
+    (N := N) (a := m - 1) (b := 1) (c := N - m - 1) (by omega) (hMpdo N hNpos)
+  rw [hEABC, hEAC, hEC, hEA]
+  rw [blockEntropy_congr M N
+    (show (m - 1) + 1 + (N - m - 1) = N - 1 by omega)
+    (by omega) (Nat.sub_le N 1) (hMpdo N hNpos)]
+  rw [blockEntropy_congr M N (show (m - 1) + 1 = m by omega)
+    (by omega) (by omega) (hMpdo N hNpos)]
+  rw [blockEntropy_congr M N (show 1 + (N - m - 1) = N - m by omega)
+    (by omega) (Nat.sub_le N m) (hMpdo N hNpos)]
+  linarith [hEq]
+
+/-- Conversely, equality in strong subadditivity for the regions of lengths
+\(m-1,1,N-m-1\) gives \(I_1=I_m\) on the full periodic chain.
+
+This is the entropy rearrangement used to return to the saturated-area-law
+condition in arXiv:1606.00608, Appendix C.2, lines 1770--1780.
+
+**Local fix (endpoint):** The endpoint \(m=\lfloor N/2\rfloor\), needed in
+the final comparison, is documented in
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`. -/
+theorem mutualInfoChain_one_eq_of_isSSAEquality_tripartite_m
+    (M : MPOTensor d D) (hMpdo : IsMPDO M) {N m : ℕ}
+    (hm1 : 1 ≤ m) (hmN : m ≤ N / 2)
+    (hSSA :
+      let h3 : (m - 1) + 1 + (N - m - 1) ≤ N := by omega
+      let ρ_ABC :=
+        (M.reducedBlockState N ((m - 1) + 1 + (N - m - 1)) h3).submatrix
+          (tripartiteSplitEquiv d (m - 1) 1 (N - m - 1)).symm
+          (tripartiteSplitEquiv d (m - 1) 1 (N - m - 1)).symm
+      IsSSAEquality ρ_ABC
+        ((reducedBlockState_posSemidef M N ((m - 1) + 1 + (N - m - 1)) h3
+          (hMpdo N (by omega))).submatrix _).1) :
+    mutualInfoChain M N 1 (by omega) (hMpdo N (by omega)) =
+      mutualInfoChain M N m (by omega) (hMpdo N (by omega)) := by
+  classical
+  have hNpos : 0 < N := by omega
+  dsimp only at hSSA
+  rw [IsSSAEquality] at hSSA
+  simp only [mutualInfoChain]
+  have hEABC := vonNeumannEntropy_tripartiteSplit_eq_blockEntropy M
+    (N := N) (a := m - 1) (b := 1) (c := N - m - 1) (by omega) (hMpdo N hNpos)
+  have hEC := vonNeumannEntropy_traceC_eq_blockEntropy M
+    (N := N) (a := m - 1) (b := 1) (c := N - m - 1) (by omega) (hMpdo N hNpos)
+  have hEAC := vonNeumannEntropy_traceAC_eq_blockEntropy M
+    (N := N) (a := m - 1) (b := 1) (c := N - m - 1) (by omega) (hMpdo N hNpos)
+  have hEA := vonNeumannEntropy_traceA_eq_blockEntropy M
+    (N := N) (a := m - 1) (b := 1) (c := N - m - 1) (by omega) (hMpdo N hNpos)
+  rw [hEABC, hEAC, hEC, hEA] at hSSA
+  rw [blockEntropy_congr M N
+    (show (m - 1) + 1 + (N - m - 1) = N - 1 by omega)
+    (by omega) (Nat.sub_le N 1) (hMpdo N hNpos)] at hSSA
+  rw [blockEntropy_congr M N (show (m - 1) + 1 = m by omega)
+    (by omega) (by omega) (hMpdo N hNpos)] at hSSA
+  rw [blockEntropy_congr M N (show 1 + (N - m - 1) = N - m by omega)
+    (by omega) (Nat.sub_le N m) (hMpdo N hNpos)] at hSSA
+  linarith [hSSA]
+
+/-- If every four-region marginal with lengths \(m-1,1,N-m-1,1\)
+attains equality in strong subadditivity, then the tensor saturates the area
+law, provided its periodic operators are positive and have nonzero trace.
+
+**Local fix (endpoint):** The comparison at \(L+1=\lfloor N/2\rfloor\)
+corrects the strict inequality printed at source line 1771, as documented in
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1770--1780. -/
+theorem isSAL_of_isSSAEquality_tripartite_m (M : MPOTensor d D)
+    (hMpdo : IsMPDO M)
+    (htrace : ∀ N, 0 < N → (mpo M N).trace ≠ 0)
+    (hSSA : ∀ (N m : ℕ) (hm1 : 1 ≤ m) (hmN : m ≤ N / 2),
+      let h3 : (m - 1) + 1 + (N - m - 1) ≤ N := by omega
+      let ρ_ABC :=
+        (M.reducedBlockState N ((m - 1) + 1 + (N - m - 1)) h3).submatrix
+          (tripartiteSplitEquiv d (m - 1) 1 (N - m - 1)).symm
+          (tripartiteSplitEquiv d (m - 1) 1 (N - m - 1)).symm
+      IsSSAEquality ρ_ABC
+        ((reducedBlockState_posSemidef M N ((m - 1) + 1 + (N - m - 1)) h3
+          (hMpdo N (by omega))).submatrix _).1) :
+    IsSAL M := by
+  refine ⟨hMpdo, htrace, ?_⟩
+  intro N L hL hLN
+  have hEqL := mutualInfoChain_one_eq_of_isSSAEquality_tripartite_m
+    M hMpdo hL (Nat.le_of_lt hLN) (hSSA N L hL (Nat.le_of_lt hLN))
+  have hEqSucc := mutualInfoChain_one_eq_of_isSSAEquality_tripartite_m
+    M hMpdo (m := L + 1) (by omega) (by omega)
+      (hSSA N (L + 1) (by omega) (by omega))
+  exact hEqL.symm.trans hEqSucc
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -427,6 +427,7 @@ section GlobalToLocalSAL
 
 variable {d D : ℕ}
 
+
 /-- Saturation of the area law gives equality in strong subadditivity for the
 three-region marginal used in the proof of Lemma C.2.
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
@@ -313,31 +313,49 @@ strong subadditivity for a normalized three-site reduced state.
     positive-weight Markov sector exactly once.
 \end{proof}
 
-\begin{theorem}[Saturation gives equality in strong subadditivity]
+\begin{theorem}[SAL and arbitrary-cut equality in strong subadditivity]
     \label{thm:mpdo_sal_ssa_equality}
+    \lean{MPOTensor.isSSAEquality_tripartite_m_of_isSAL}
     \lean{MPOTensor.isSSAEquality_tripartite_of_isSAL}
     \lean{MPOTensor.isSSAEquality_threeSite_of_isSAL}
+    \lean{MPOTensor.%
+      mutualInfoChain_one_eq_of_isSSAEquality_tripartite_m}
+    \lean{MPOTensor.isSAL_of_isSSAEquality_tripartite_m}
     \leanok
     \uses{def:is_sal, def:ssa_equality}
-    Let $N\geq 4$, and divide the first $N-1$ sites of the normalized periodic
-    state into consecutive regions $A,B,C$ of lengths $1,1,N-3$. If the tensor
-    saturates the area law, then
+    Let $1\leq m\leq\lfloor N/2\rfloor$, and divide the chain into four
+    consecutive regions $A,B,C,D$ of lengths $m-1,1,N-m-1,1$.  If the tensor
+    saturates the area law, then its marginal on $ABC$ satisfies
     \[
         S(ABC)+S(B)=S(AB)+S(BC).
     \]
-    In particular, the three-site reduced state of the four-site chain satisfies
-    equality in strong subadditivity.
+    Indeed, this is the entropy form of $I_1=I_m$.  Taking $m=2$ gives the
+    regions of lengths $1,1,N-3$, and then taking $N=4$ shows that the
+    three-site reduced state of the four-site chain satisfies equality in
+    strong subadditivity.  This is the choice of regions used in
+    \cite[Appendix~C.2, lines~1760--1780]{Cirac2016MPDO_arXiv}.
+    Conversely, suppose that the periodic operators are positive semidefinite
+    and have nonzero trace at every positive length.  If the displayed
+    equality holds for every $1\leq m\leq\lfloor N/2\rfloor$, then the tensor
+    saturates the area law.
+    The endpoint corrects the strict inequality printed at source line~1771:
+    Definition~4.6 and the concluding comparison both require
+    $m=\lfloor N/2\rfloor$.  This local correction is recorded in
+    \path{docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex}.
 \end{theorem}
 
 \begin{proof}
     \leanok
     \uses{thm:mpdo_tripartite_block_entropy_identifications}
-    By saturation, $I_1=I_2$. Expanding the two mutual informations and cancelling
+    By saturation, $I_1=I_m$. Expanding the two mutual informations and cancelling
     the entropy of the full chain gives
     \[
-        S_{N-1}+S_1=S_2+S_{N-2},
+        S_{N-1}+S_1=S_m+S_{N-m},
     \]
     which is the stated equality for the regions $A,B,C$.
+    Conversely, this equality gives $I_1=I_m$.  If it holds for every
+    admissible $m$, comparing the cases $m=L$ and $m=L+1$ gives
+    $I_L=I_{L+1}$ and hence saturation of the area law.
 \end{proof}
 \begin{theorem}[SAL implies local $\eta$-structure]
     \label{thm:sal_implies_eta_structure}
@@ -461,6 +479,8 @@ strong subadditivity for a normalized three-site reduced state.
     \label{thm:mpdo_bnt_projector_local_selection}
     \lean{MPOTensor.bntSectorProjection_mul_physicalSlice_mul_eq_zero}
     \lean{MPOTensor.bntSectorProjection_mul_physicalSlice_mul_self}
+    \lean{MPOTensor.%
+      sum_bntSectorProjection_mul_physicalSlice_mul_self}
     \lean{MPOTensor.changePhysicalBasis_bntSectorProjection_basis}
     \lean{MPOTensor.%
       exists_bntProjectorSelection_positiveLength_of_sameMPV₂Pos_isSAL}
@@ -473,9 +493,15 @@ strong subadditivity for a normalized three-site reduced state.
     \[
       P_iA_iP_i=A_i.
     \]
+    Consequently,
+    \[
+      \sum_sP_sA_iP_s=A_i,
+    \]
+    which is the local diagonal decomposition required for the sector entropy
+    argument.
     Equivalently, compressing the physical legs of $A_i$ by $P_s$ retains
-    $A_i$ for $s=i$ and gives the zero local tensor otherwise.  This is
-    equations~\textup{PjKiPj} and~\textup{generateMPDO} in
+    $A_i$ for $s=i$ and gives the zero local tensor otherwise.  This is the
+    local projection relation in
     \cite[Appendix~C.2, lines~1680--1755]{Cirac2016MPDO_arXiv}.
 
     The Markov summands of zero Hayashi weight are retained in the ambient

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -289,6 +289,7 @@ sitewise on every nonempty periodic chain then gives
 with the common copy weight absorbed into $\mathcal K_s$.
 \footnote{The relevant declarations are
 \path{MPOTensor.bntSectorProjection_mul_physicalSlice_mul_eq_zero},
+\path{MPOTensor.sum_bntSectorProjection_mul_physicalSlice_mul_self},
 \path{MPOTensor.changePhysicalBasis_bntSectorProjection_basis},
 \path{MPOTensor.sitewise_bntSectorProjection_mul_mpo_mul_self}, and
 \path{MPOTensor.exists_bntProjectorSelection_positiveLength_of_sameMPV₂Pos_isSAL}.}
@@ -320,6 +321,12 @@ lines~1760--1770, is also formalized as
 sector-compression identity is SAL for each sector.  It must follow from the
 direct-sum entropy identity and strong subadditivity as in
 \cite[Appendix~C.2, lines~1760--1780]{Cirac2016MPDO_arXiv}.
+There is a local endpoint typo in this passage.  Line~1771 writes
+$m<\lfloor N/2\rfloor$, but Definition~4.6 gives the equality chain through
+$I_{\lfloor N/2\rfloor}$, and the conclusion at lines~1781--1783 compares
+$m=L$ with $m=L+1$.  When $L+1=\lfloor N/2\rfloor$, that comparison requires
+the endpoint $m=\lfloor N/2\rfloor$.  The formal entropy equivalence therefore
+uses $1\leq m\leq\lfloor N/2\rfloor$.
 
 The neighboring operators are now assembled from these sector tensors.  The
 operator


### PR DESCRIPTION
## Summary

This advances the sectorwise saturated-area-law argument in arXiv:1606.00608, Appendix C.2, lines 1733–1783.

- prove that the sum of the diagonal BNT projector corners recovers each physical slice;
- prove in the focused SALArbitraryCut module that SAL gives equality in strong subadditivity for the four-region split of lengths m−1, 1, N−m−1, 1;
- prove the converse entropy rearrangement and recover SAL from these equalities at every admissible cut;
- update the root import graph, blueprint, and existing MPDO SAL/ZCL paper-gap note.

The inequalities 1 ≤ m ≤ floor(N/2) force positive physical chain length, so the proofs contain no empty-chain branch. The source prints m < floor(N/2) at line 1771, but its Definition 4.6 equality chain and final comparison require the endpoint m = floor(N/2). The local endpoint correction is recorded in docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex and marked on the affected declarations.

No axiom or sorry is introduced. Every Lean source file remains below 1,000 lines.

## Verification

- lake build: 9,535 targets on Lean 4.32.0
- lake exe lint_style
- local oversized-file guard: zero files above 1,000 lines
- blueprint and Lean synchronization
- changed-declaration blueprint coverage
- lake exe checkdecls blueprint/lean_decls
- reader-facing prose check
- proof-integrity scan
- git diff --check

Advances #4110.