### PR TITLE
feat(MPS/MPDO): prove saturated area law for BNT sectors

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -450,6 +450,7 @@ import TNLean.MPS.MPDO.BNTSourceSectorProjectors
 import TNLean.MPS.MPDO.SitewisePhysicalMatrix
 import TNLean.MPS.MPDO.BNTProjectorSelection
 import TNLean.MPS.MPDO.BNTSectorAnalyticProperties
+import TNLean.MPS.MPDO.BNTSectorAreaLaw
 import TNLean.MPS.MPDO.HayashiSectorProjector
 import TNLean.MPS.MPDO.EtaPreparation
 import TNLean.MPS.MPDO.RFPSubspinMaps

--- a/TNLean/Analysis/EntropyDecomposition.lean
+++ b/TNLean/Analysis/EntropyDecomposition.lean
@@ -40,6 +40,9 @@ in strong subadditivity.
   The weights are nonnegative.
   When the weights form a probability distribution, the first terms sum to
   the Shannon entropy \(H(p)\).
+* `vonNeumannEntropy_eq_sum_of_pairwise_annihilating_supports` — entropy is
+  additive for Hermitian summands carried by mutually annihilating support
+  operators, without an ambient resolution of the identity.
 * `eq_of_weighted_sum_eq_of_pos_of_le` — equality of two positively weighted
   sums, together with termwise inequalities, forces equality term by term.
 
@@ -422,7 +425,7 @@ theorem eq_of_weighted_sum_eq_of_pos_of_le {ι : Type*} [Fintype ι]
 
 end BlockDiagonal
 
-section OrthogonalSupports
+section PairwiseAnnihilatingSupports
 
 variable {o : Type*} [Fintype o]
 
@@ -435,13 +438,13 @@ The proof writes the sum as a rectangular product.  Reversing the factors
 gives the dependent block diagonal of the summands, with only additional zero
 eigenvalues.  This is the support form of the direct-sum entropy argument in
 arXiv:1606.00608, Appendix C.2, lines 1760--1770. -/
-theorem vonNeumannEntropy_eq_sum_of_orthogonal_support
+theorem vonNeumannEntropy_eq_sum_of_pairwise_annihilating_supports
     {n : Type*} [Fintype n]
     (A : Matrix n n ℂ) (hA : A.IsHermitian)
     (M P : o → Matrix n n ℂ) (hM : ∀ s, (M s).IsHermitian)
     (hsum : A = ∑ s, M s)
     (hsupport : ∀ s, P s * M s = M s ∧ M s * P s = M s)
-    (horth : ∀ s t, s ≠ t → P s * P t = 0) :
+    (hannihilate : ∀ s t, s ≠ t → P s * P t = 0) :
     open scoped Classical in
     vonNeumannEntropy A hA = ∑ s, vonNeumannEntropy (M s) (hM s) := by
   classical
@@ -464,7 +467,7 @@ theorem vonNeumannEntropy_eq_sum_of_orthogonal_support
         calc
           P s * M t = P s * (P t * M t) := by rw [(hsupport t).1]
           _ = (P s * P t) * M t := by rw [Matrix.mul_assoc]
-          _ = 0 := by rw [horth s t hst, Matrix.zero_mul]
+          _ = 0 := by rw [hannihilate s t hst, Matrix.zero_mul]
       rw [hzero, Matrix.zero_apply,
         Matrix.blockDiagonal'_apply_ne M i j hst]
   have hBlock : (Matrix.blockDiagonal' M).IsHermitian := by
@@ -486,4 +489,4 @@ theorem vonNeumannEntropy_eq_sum_of_orthogonal_support
     _ = ∑ s, vonNeumannEntropy (M s) (hM s) :=
       vonNeumannEntropy_blockDiagonal' M hM hBlock
 
-end OrthogonalSupports
+end PairwiseAnnihilatingSupports

--- a/TNLean/Analysis/EntropyDecomposition.lean
+++ b/TNLean/Analysis/EntropyDecomposition.lean
@@ -421,3 +421,69 @@ theorem eq_of_weighted_sum_eq_of_pos_of_le {ι : Type*} [Fintype ι]
   exact (sub_eq_zero.mp hdiff).symm
 
 end BlockDiagonal
+
+section OrthogonalSupports
+
+variable {o : Type*} [Fintype o]
+
+/-- Additivity of entropy for finitely many Hermitian summands carried by
+mutually disjoint support operators.  These operators need only resolve the
+support of the displayed matrix; they need not sum to the identity on the
+ambient space.
+
+The proof writes the sum as a rectangular product.  Reversing the factors
+gives the dependent block diagonal of the summands, with only additional zero
+eigenvalues.  This is the support form of the direct-sum entropy argument in
+arXiv:1606.00608, Appendix C.2, lines 1760--1770. -/
+theorem vonNeumannEntropy_eq_sum_of_orthogonal_support
+    {n : Type*} [Fintype n]
+    (A : Matrix n n ℂ) (hA : A.IsHermitian)
+    (M P : o → Matrix n n ℂ) (hM : ∀ s, (M s).IsHermitian)
+    (hsum : A = ∑ s, M s)
+    (hsupport : ∀ s, P s * M s = M s ∧ M s * P s = M s)
+    (horth : ∀ s t, s ≠ t → P s * P t = 0) :
+    open scoped Classical in
+    vonNeumannEntropy A hA = ∑ s, vonNeumannEntropy (M s) (hM s) := by
+  classical
+  let X : Matrix n (Σ _ : o, n) ℂ := fun i sj ↦ M sj.1 i sj.2
+  let Y : Matrix (Σ _ : o, n) n ℂ := fun si j ↦ P si.1 si.2 j
+  have hXY : X * Y = A := by
+    ext i j
+    rw [Matrix.mul_apply, Fintype.sum_sigma, hsum, Matrix.sum_apply]
+    apply Finset.sum_congr rfl
+    intro s _
+    change ∑ k : n, M s i k * P s k j = M s i j
+    rw [← Matrix.mul_apply, (hsupport s).2]
+  have hYX : Y * X = Matrix.blockDiagonal' M := by
+    ext ⟨s, i⟩ ⟨t, j⟩
+    change (P s * M t) i j = Matrix.blockDiagonal' M ⟨s, i⟩ ⟨t, j⟩
+    by_cases hst : s = t
+    · subst t
+      rw [(hsupport s).1, Matrix.blockDiagonal'_apply_eq]
+    · have hzero : P s * M t = 0 := by
+        calc
+          P s * M t = P s * (P t * M t) := by rw [(hsupport t).1]
+          _ = (P s * P t) * M t := by rw [Matrix.mul_assoc]
+          _ = 0 := by rw [horth s t hst, Matrix.zero_mul]
+      rw [hzero, Matrix.zero_apply,
+        Matrix.blockDiagonal'_apply_ne M i j hst]
+  have hBlock : (Matrix.blockDiagonal' M).IsHermitian := by
+    rw [Matrix.isHermitian_blockDiagonal'_iff]
+    exact hM
+  have hXYHerm : (X * Y).IsHermitian := by
+    rw [hXY]
+    exact hA
+  have hYXHerm : (Y * X).IsHermitian := by
+    rw [hYX]
+    exact hBlock
+  calc
+    vonNeumannEntropy A hA = vonNeumannEntropy (X * Y) hXYHerm := by
+      exact vonNeumannEntropy_congr hXY.symm hA hXYHerm
+    _ = vonNeumannEntropy (Y * X) hYXHerm :=
+      vonNeumannEntropy_mul_comm X Y hXYHerm hYXHerm
+    _ = vonNeumannEntropy (Matrix.blockDiagonal' M) hBlock := by
+      exact vonNeumannEntropy_congr hYX hYXHerm hBlock
+    _ = ∑ s, vonNeumannEntropy (M s) (hM s) :=
+      vonNeumannEntropy_blockDiagonal' M hM hBlock
+
+end OrthogonalSupports

--- a/TNLean/MPS/MPDO/BNTProjectorSelection.lean
+++ b/TNLean/MPS/MPDO/BNTProjectorSelection.lean
@@ -357,6 +357,44 @@ theorem bntSectorProjection_mul_physicalSlice_mul_self
   rw [bntSectorProjection_mul_physicalSlice_self hC hρ hη hR,
     physicalSlice_mul_bntSectorProjection_self hC hρ hη hR]
 
+/-- The matching BNT projection fixes the ket index of its normal
+representative.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1733--1770. -/
+theorem ketLeftMul_bntSectorProjection_basis
+    {K : (s : Fin g) → MPOTensor d (dim s)}
+    {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse K C)
+    (hρ : IsThreeSiteFamilyClosure K R ρ) (hη : EtaStructure ρ)
+    (hR : ∀ s : Fin g, R s ≠ 0) (s : Fin g) :
+    (K s).ketLeftMul (bntSectorProjection hC hρ hη hR s) = K s := by
+  ext a b β α
+  simp only [ketLeftMul, Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
+  have h := congrFun (congrFun
+    (bntSectorProjection_mul_physicalSlice_self hC hρ hη hR s β α) a) b
+  simpa only [Matrix.mul_apply, physicalSlice] using h
+
+/-- The matching BNT projection fixes the bra index of its normal
+representative.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1733--1770. -/
+theorem braRightMul_bntSectorProjection_basis
+    {K : (s : Fin g) → MPOTensor d (dim s)}
+    {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse K C)
+    (hρ : IsThreeSiteFamilyClosure K R ρ) (hη : EtaStructure ρ)
+    (hR : ∀ s : Fin g, R s ≠ 0) (s : Fin g) :
+    (K s).braRightMul (bntSectorProjection hC hρ hη hR s) = K s := by
+  ext a b β α
+  simp only [braRightMul, Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
+  have h := congrFun (congrFun
+    (physicalSlice_mul_bntSectorProjection_self hC hρ hη hR s β α) a) b
+  simpa only [Matrix.mul_apply, physicalSlice, mul_comm] using h
+
 /-- The BNT-labelled physical projectors select the matching normal sector:
 the corner `P_s K_i P_t` vanishes if `s ≠ t` or `i ≠ s`.
 
@@ -512,6 +550,43 @@ noncomputable def commonWeightAbsorbedBasisMPOTensor
     MPOTensor d (S.basisDim j) :=
   fun a b => S.commonWeight hWeight j • S.basisMPOTensor j a b
 
+/-- The matching BNT projection fixes the ket index after the common copy
+weight has been absorbed into the normal representative.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1660--1665 and 1733--1770. -/
+theorem ketLeftMul_bntSectorProjection_commonWeightAbsorbedBasis
+    (S : MPSTensor.SectorDecomposition (d * d))
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q')
+    {R : (s : Fin S.basisCount) →
+      Matrix (Fin (S.basisDim s)) (Fin (S.basisDim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex S.basisDim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse
+      (fun j ↦ S.basisMPOTensor j) C)
+    (hρ : IsThreeSiteFamilyClosure (fun j ↦ S.basisMPOTensor j) R ρ)
+    (hη : EtaStructure ρ) (hR : ∀ s : Fin S.basisCount, R s ≠ 0)
+    (s : Fin S.basisCount) :
+    (commonWeightAbsorbedBasisMPOTensor S hWeight s).ketLeftMul
+        (bntSectorProjection hC hρ hη hR s) =
+      commonWeightAbsorbedBasisMPOTensor S hWeight s := by
+  ext a b β α
+  have h := congrFun (congrFun (congrFun (congrFun
+    (ketLeftMul_bntSectorProjection_basis hC hρ hη hR s) a) b) β) α
+  simp only [ketLeftMul, commonWeightAbsorbedBasisMPOTensor,
+    Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul] at h ⊢
+  calc
+    ∑ x, bntSectorProjection hC hρ hη hR s a x *
+        (S.commonWeight hWeight s * S.basisMPOTensor s x b β α) =
+        S.commonWeight hWeight s *
+          ∑ x, bntSectorProjection hC hρ hη hR s a x *
+            S.basisMPOTensor s x b β α := by
+      rw [Finset.mul_sum]
+      apply Finset.sum_congr rfl
+      intro x _
+      ring
+    _ = _ := by rw [h]
+
 /-- Returning the absorbed-weight MPO representative to doubled-index MPS
 coordinates gives the absorbed representative defined in
 `CommonWeightAbsorption.lean`. -/
@@ -544,6 +619,29 @@ theorem mpo_commonWeightAbsorbedBasisMPOTensor
       (fun n => finProdFinEquiv (u n, v n)) = _
   rw [MPSTensor.mpv_smul, ← MPSTensor.mpv_toMPSTensor_pairConfig,
     S.basisMPOTensor_toMPSTensor]
+
+/-- The positive-length MPO is the sum of the absorbed normal
+representatives, each multiplied by its copy number.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1660--1665 and 1753--1770. -/
+theorem mpo_eq_sum_copies_smul_commonWeightAbsorbedBasisMPOTensor
+    {D : ℕ} (M : MPOTensor d D)
+    (S : MPSTensor.SectorDecomposition (d * d))
+    (hM : MPSTensor.SameMPV₂Pos M.toMPSTensor S.toTensor)
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q')
+    {N : ℕ} (hN : 0 < N) :
+    mpo M N = ∑ s : Fin S.basisCount,
+      (S.copies s : ℂ) • mpo (commonWeightAbsorbedBasisMPOTensor S hWeight s) N := by
+  ext u v
+  rw [Matrix.sum_apply]
+  simp only [Matrix.smul_apply, smul_eq_mul]
+  rw [S.mpo_eq_sum_coeff_basisMPOTensor M hM hN u v]
+  apply Finset.sum_congr rfl
+  intro s _
+  rw [S.coeff_eq_copies_mul_commonWeight_pow hWeight,
+    mpo_commonWeightAbsorbedBasisMPOTensor]
+  ring
 
 /-- Compressing the full MPO by the sitewise BNT projection selects the
 matching absorbed-weight representative with its natural copy multiplicity.

--- a/TNLean/MPS/MPDO/BNTSectorAreaLaw.lean
+++ b/TNLean/MPS/MPDO/BNTSectorAreaLaw.lean
@@ -38,14 +38,20 @@ private theorem mul_eq_self_of_isHermitian_of_mul_eq_self
   have hstar := congrArg Matrix.conjTranspose hleft
   simpa only [Matrix.conjTranspose_mul, hA.eq, hP.eq] using hstar
 
-/-- The probability of the absorbed BNT sector in the normalized length-
-`N` periodic state.  The copy number is part of the weight.
+/-- The probability of the absorbed BNT sector in the normalized positive-
+length periodic state.  The copy number is part of the weight.  Positive
+normalizations are part of the definition, so there is neither an empty-chain
+value nor a value obtained by dividing by a zero trace.
 
 Source: arXiv:1606.00608, Appendix C.2, lines 1753--1770. -/
 noncomputable def bntSectorProbability
     (M : MPOTensor d D) (S : MPSTensor.SectorDecomposition (d * d))
     (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
-      S.weight j q = S.weight j q') (N : ℕ) (s : Fin S.basisCount) : ℝ :=
+      S.weight j q = S.weight j q') (N : ℕ) (_hN : 0 < N)
+    (_hMtrace : 0 < Matrix.trace (mpo M N))
+    (_hSectorTrace : ∀ s, 0 < Matrix.trace
+      (mpo (commonWeightAbsorbedBasisMPOTensor S hWeight s) N))
+    (s : Fin S.basisCount) : ℝ :=
   (S.copies s : ℝ) *
     (Matrix.trace (mpo (commonWeightAbsorbedBasisMPOTensor S hWeight s) N)).re /
       (Matrix.trace (mpo M N)).re
@@ -56,11 +62,12 @@ theorem bntSectorProbability_pos
     (M : MPOTensor d D) (S : MPSTensor.SectorDecomposition (d * d))
     (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
       S.weight j q = S.weight j q') {N : ℕ}
+    (hN : 0 < N)
     (hMtrace : 0 < Matrix.trace (mpo M N))
     (hSectorTrace : ∀ s, 0 < Matrix.trace
       (mpo (commonWeightAbsorbedBasisMPOTensor S hWeight s) N))
     (s : Fin S.basisCount) :
-    0 < bntSectorProbability M S hWeight N s := by
+    0 < bntSectorProbability M S hWeight N hN hMtrace hSectorTrace s := by
   rw [bntSectorProbability]
   have hMre : 0 < (Matrix.trace (mpo M N)).re :=
     (RCLike.pos_iff.mp hMtrace).1
@@ -82,7 +89,7 @@ theorem normalizedMPO_eq_sum_bntSectorProbability_smul
     (hSectorTrace : ∀ s, 0 < Matrix.trace
       (mpo (commonWeightAbsorbedBasisMPOTensor S hWeight s) N)) :
     normalizedMPO M N = ∑ s : Fin S.basisCount,
-      (bntSectorProbability M S hWeight N s : ℂ) •
+      (bntSectorProbability M S hWeight N hN hMtrace hSectorTrace s : ℂ) •
         normalizedMPO (commonWeightAbsorbedBasisMPOTensor S hWeight s) N := by
   classical
   have hMtraceEq : Matrix.trace (mpo M N) =
@@ -99,7 +106,7 @@ theorem normalizedMPO_eq_sum_bntSectorProbability_smul
       · rfl
       · simpa using (RCLike.pos_iff.mp (hSectorTrace s)).2
   have hpComplex (s : Fin S.basisCount) :
-      (bntSectorProbability M S hWeight N s : ℂ) =
+      (bntSectorProbability M S hWeight N hN hMtrace hSectorTrace s : ℂ) =
         (S.copies s : ℂ) *
           Matrix.trace (mpo (commonWeightAbsorbedBasisMPOTensor S hWeight s) N) /
             Matrix.trace (mpo M N) := by
@@ -267,11 +274,12 @@ theorem reducedBlockState_eq_sum_bntSectorProbability_smul
     (hM : MPSTensor.SameMPV₂Pos M.toMPSTensor S.toTensor)
     (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
       S.weight j q = S.weight j q') {N L : ℕ} (hN : 0 < N)
-    (hL : L ≤ N) (hMtrace : 0 < Matrix.trace (mpo M N))
+    (_hLpos : 0 < L) (hL : L ≤ N)
+    (hMtrace : 0 < Matrix.trace (mpo M N))
     (hSectorTrace : ∀ s, 0 < Matrix.trace
       (mpo (commonWeightAbsorbedBasisMPOTensor S hWeight s) N)) :
     reducedBlockState M N L hL = ∑ s : Fin S.basisCount,
-      (bntSectorProbability M S hWeight N s : ℂ) •
+      (bntSectorProbability M S hWeight N hN hMtrace hSectorTrace s : ℂ) •
         reducedBlockState (commonWeightAbsorbedBasisMPOTensor S hWeight s) N L hL := by
   classical
   have hfull := normalizedMPO_eq_sum_bntSectorProbability_smul
@@ -314,8 +322,9 @@ theorem blockEntropy_eq_sum_bntSectorProbability
       (mpo (commonWeightAbsorbedBasisMPOTensor S hWeight s) N)) :
     blockEntropy M N L hL (hMpdo N hN) =
       ∑ s : Fin S.basisCount,
-        (Real.negMulLog (bntSectorProbability M S hWeight N s) +
-          bntSectorProbability M S hWeight N s *
+        (Real.negMulLog (bntSectorProbability M S hWeight N hN
+            hMtrace hSectorTrace s) +
+          bntSectorProbability M S hWeight N hN hMtrace hSectorTrace s *
             blockEntropy (commonWeightAbsorbedBasisMPOTensor S hWeight s)
               N L hL (hSectorMpdo s N hN)) := by
   classical
@@ -323,7 +332,7 @@ theorem blockEntropy_eq_sum_bntSectorProbability
   let K : (s : Fin S.basisCount) → MPOTensor d (S.basisDim s) :=
     fun s ↦ commonWeightAbsorbedBasisMPOTensor S hWeight s
   let p : Fin S.basisCount → ℝ := fun s ↦
-    bntSectorProbability M S hWeight N s
+    bntSectorProbability M S hWeight N hN hMtrace hSectorTrace s
   let ρ : (s : Fin S.basisCount) →
       Matrix (Fin (L + 1) → Fin d) (Fin (L + 1) → Fin d) ℂ :=
     fun s ↦ reducedBlockState (K s) N (L + 1) hL
@@ -331,7 +340,7 @@ theorem blockEntropy_eq_sum_bntSectorProbability
       Matrix (Fin (L + 1) → Fin d) (Fin (L + 1) → Fin d) ℂ :=
     fun s ↦ firstSiteMatrix (bntSectorProjection hC hρ₃ hη hR s) L
   have hp : ∀ s, 0 < p s := fun s ↦
-    bntSectorProbability_pos M S hWeight hMtrace hSectorTrace s
+    bntSectorProbability_pos M S hWeight hN hMtrace hSectorTrace s
   have hρpos : ∀ s, (ρ s).PosSemidef := fun s ↦
     reducedBlockState_posSemidef (K s) N (L + 1) hL (hSectorMpdo s N hN)
   have hρtrace : ∀ s, Matrix.trace (ρ s) = 1 := fun s ↦
@@ -358,8 +367,8 @@ theorem blockEntropy_eq_sum_bntSectorProbability
   have hsum : reducedBlockState M N (L + 1) hL =
       ∑ s, (p s : ℂ) • ρ s := by
     exact reducedBlockState_eq_sum_bntSectorProbability_smul
-      M S hM hWeight hN hL hMtrace hSectorTrace
-  have hadd := vonNeumannEntropy_eq_sum_of_orthogonal_support
+      M S hM hWeight hN (by omega) hL hMtrace hSectorTrace
+  have hadd := vonNeumannEntropy_eq_sum_of_pairwise_annihilating_supports
     (reducedBlockState M N (L + 1) hL)
     (reducedBlockState_isHermitian M N (L + 1) hL (hMpdo N hN))
     (fun s ↦ (p s : ℂ) • ρ s) Q
@@ -396,7 +405,7 @@ theorem blockEntropy_add_blockEntropy_eq_bntSector
       (fun j ↦ S.basisMPOTensor j) C)
     (hρ₃ : IsThreeSiteFamilyClosure (fun j ↦ S.basisMPOTensor j) R ρ₃)
     (hη : EtaStructure ρ₃) (hR : ∀ s : Fin S.basisCount, R s ≠ 0)
-    (hSAL : IsSAL M) (hZCL : IsSourceZCL M)
+    (hSAL : IsSAL M)
     (hSectorMpdo : ∀ s, IsMPDO
       (commonWeightAbsorbedBasisMPOTensor S hWeight s))
     (hSectorTrace : ∀ (N : ℕ), 0 < N → ∀ s, 0 < Matrix.trace
@@ -412,8 +421,11 @@ theorem blockEntropy_add_blockEntropy_eq_bntSector
   dsimp only
   let hMpdo : IsMPDO M := Classical.choose hSAL
   have hN : 0 < N := by omega
-  have hMtrace : 0 < Matrix.trace (mpo M N) :=
-    trace_mpo_pos_of_isMPDO_isSourceZCL M hMpdo hZCL hN
+  have hMtrace : 0 < Matrix.trace (mpo M N) := by
+    apply Matrix.PosSemidef.trace_pos_of_ne_zero (hMpdo N hN)
+    intro hzero
+    exact (Classical.choose_spec hSAL).1 N hN (by
+      rw [hzero, Matrix.trace_zero])
   have hGlobal := mutualInfoChain_eq_of_isSAL M hSAL
     (N := N) (L := 1) (L' := m) (by omega) (by omega) hm1 hmN
   simp only [mutualInfoChain] at hGlobal
@@ -431,7 +443,7 @@ theorem blockEntropy_add_blockEntropy_eq_bntSector
       (Nat.sub_le N m) hMtrace (hSectorTrace N hN)
   rw [hEABC, hEB, hEAB, hEBC] at hGlobal
   let p : Fin S.basisCount → ℝ := fun t ↦
-    bntSectorProbability M S hWeight N t
+    bntSectorProbability M S hWeight N hN hMtrace (hSectorTrace N hN) t
   let L : Fin S.basisCount → ℝ := fun t ↦
     blockEntropy (commonWeightAbsorbedBasisMPOTensor S hWeight t)
         N (N - 1) (Nat.sub_le N 1) (hSectorMpdo t N hN) +
@@ -462,7 +474,7 @@ theorem blockEntropy_add_blockEntropy_eq_bntSector
       (by omega) (Nat.sub_le N m) (hSectorMpdo t N hN)] at hineq
     exact hineq
   exact eq_of_weighted_sum_eq_of_pos_of_le p L U
-    (fun t ↦ bntSectorProbability_pos M S hWeight hMtrace
+    (fun t ↦ bntSectorProbability_pos M S hWeight hN hMtrace
       (hSectorTrace N hN) t) hle hsum s
 
 /-- Every absorbed BNT representative satisfies the saturated area law once
@@ -483,7 +495,7 @@ theorem commonWeightAbsorbedBasisMPOTensor_isSAL_of_projectorSelection
       (fun j ↦ S.basisMPOTensor j) C)
     (hρ₃ : IsThreeSiteFamilyClosure (fun j ↦ S.basisMPOTensor j) R ρ₃)
     (hη : EtaStructure ρ₃) (hR : ∀ s : Fin S.basisCount, R s ≠ 0)
-    (hSAL : IsSAL M) (hZCL : IsSourceZCL M)
+    (hSAL : IsSAL M)
     (hSectorMpdo : ∀ s, IsMPDO
       (commonWeightAbsorbedBasisMPOTensor S hWeight s))
     (hSectorTrace : ∀ (N : ℕ), 0 < N → ∀ s, 0 < Matrix.trace
@@ -494,10 +506,10 @@ theorem commonWeightAbsorbedBasisMPOTensor_isSAL_of_projectorSelection
   refine ⟨hSectorMpdo s, fun N hN ↦ ne_of_gt (hSectorTrace N hN s), ?_⟩
   intro N L hL hLN
   have hEqL := blockEntropy_add_blockEntropy_eq_bntSector
-    M S hM hWeight hC hρ₃ hη hR hSAL hZCL hSectorMpdo hSectorTrace
+    M S hM hWeight hC hρ₃ hη hR hSAL hSectorMpdo hSectorTrace
       (N := N) (m := L) hL (Nat.le_of_lt hLN) s
   have hEqSucc := blockEntropy_add_blockEntropy_eq_bntSector
-    M S hM hWeight hC hρ₃ hη hR hSAL hZCL hSectorMpdo hSectorTrace
+    M S hM hWeight hC hρ₃ hη hR hSAL hSectorMpdo hSectorTrace
       (N := N) (m := L + 1) (by omega) (by omega) s
   simp only [mutualInfoChain]
   dsimp only at hEqL hEqSucc
@@ -548,7 +560,7 @@ theorem commonWeightAbsorbedBasisMPOTensor_isSAL_of_sameMPV₂Pos
     reducedBlockState_four_threeSiteFamilyClosure_nonzero_closing
       M S hM hWeight hnonNil hSAL
   apply commonWeightAbsorbedBasisMPOTensor_isSAL_of_projectorSelection
-    M S hM hWeight hC hClosure.1 hη hClosure.2 hSAL hZCL
+    M S hM hWeight hC hClosure.1 hη hClosure.2 hSAL
   · intro t
     exact commonWeightAbsorbedBasisMPOTensor_isMPDO_of_sameMPV₂Pos_isSAL
       M S hM hWeight hnonNil hSpan hSAL t

--- a/TNLean/MPS/MPDO/BNTSectorAreaLaw.lean
+++ b/TNLean/MPS/MPDO/BNTSectorAreaLaw.lean
@@ -1,0 +1,559 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Analysis.EntropyDecomposition
+import TNLean.MPS.MPDO.BNTSectorAnalyticProperties
+import TNLean.MPS.MPDO.SimpleLocalStructure
+
+/-!
+# Saturated area law for the BNT sectors
+
+This file proves the sectorwise entropy argument in Appendix C.2 of
+arXiv:1606.00608.  The normalized periodic state and each of its nonempty
+contiguous marginals split into the mutually orthogonal BNT sectors with the
+same probabilities.  The four Shannon terms in strong subadditivity cancel;
+strict positivity of every sector probability then forces equality in every
+sector.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Appendix C.2, lines 1760--1780.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+private theorem mul_eq_self_of_isHermitian_of_mul_eq_self
+    {n : Type*} [Fintype n]
+    {A P : Matrix n n ℂ} (hA : A.IsHermitian) (hP : P.IsHermitian)
+    (hleft : P * A = A) :
+    A * P = A := by
+  classical
+  have hstar := congrArg Matrix.conjTranspose hleft
+  simpa only [Matrix.conjTranspose_mul, hA.eq, hP.eq] using hstar
+
+/-- The probability of the absorbed BNT sector in the normalized length-
+`N` periodic state.  The copy number is part of the weight.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1753--1770. -/
+noncomputable def bntSectorProbability
+    (M : MPOTensor d D) (S : MPSTensor.SectorDecomposition (d * d))
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q') (N : ℕ) (s : Fin S.basisCount) : ℝ :=
+  (S.copies s : ℝ) *
+    (Matrix.trace (mpo (commonWeightAbsorbedBasisMPOTensor S hWeight s) N)).re /
+      (Matrix.trace (mpo M N)).re
+
+/-- Every BNT-sector probability is strictly positive when the full and
+sector chain operators have positive trace. -/
+theorem bntSectorProbability_pos
+    (M : MPOTensor d D) (S : MPSTensor.SectorDecomposition (d * d))
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q') {N : ℕ}
+    (hMtrace : 0 < Matrix.trace (mpo M N))
+    (hSectorTrace : ∀ s, 0 < Matrix.trace
+      (mpo (commonWeightAbsorbedBasisMPOTensor S hWeight s) N))
+    (s : Fin S.basisCount) :
+    0 < bntSectorProbability M S hWeight N s := by
+  rw [bntSectorProbability]
+  have hMre : 0 < (Matrix.trace (mpo M N)).re :=
+    (RCLike.pos_iff.mp hMtrace).1
+  have hSre : 0 < (Matrix.trace
+      (mpo (commonWeightAbsorbedBasisMPOTensor S hWeight s) N)).re :=
+    (RCLike.pos_iff.mp (hSectorTrace s)).1
+  exact div_pos (mul_pos (by exact_mod_cast S.copies_pos s) hSre) hMre
+
+/-- The normalized full chain is the probability-weighted sum of the
+normalized absorbed BNT sectors.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1760--1770. -/
+theorem normalizedMPO_eq_sum_bntSectorProbability_smul
+    (M : MPOTensor d D) (S : MPSTensor.SectorDecomposition (d * d))
+    (hM : MPSTensor.SameMPV₂Pos M.toMPSTensor S.toTensor)
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q') {N : ℕ} (hN : 0 < N)
+    (hMtrace : 0 < Matrix.trace (mpo M N))
+    (hSectorTrace : ∀ s, 0 < Matrix.trace
+      (mpo (commonWeightAbsorbedBasisMPOTensor S hWeight s) N)) :
+    normalizedMPO M N = ∑ s : Fin S.basisCount,
+      (bntSectorProbability M S hWeight N s : ℂ) •
+        normalizedMPO (commonWeightAbsorbedBasisMPOTensor S hWeight s) N := by
+  classical
+  have hMtraceEq : Matrix.trace (mpo M N) =
+      ((Matrix.trace (mpo M N)).re : ℂ) := by
+    apply Complex.ext
+    · rfl
+    · simpa using (RCLike.pos_iff.mp hMtrace).2
+  have hSectorTraceEq : ∀ s, Matrix.trace
+      (mpo (commonWeightAbsorbedBasisMPOTensor S hWeight s) N) =
+        ((Matrix.trace
+          (mpo (commonWeightAbsorbedBasisMPOTensor S hWeight s) N)).re : ℂ) :=
+    fun s ↦ by
+      apply Complex.ext
+      · rfl
+      · simpa using (RCLike.pos_iff.mp (hSectorTrace s)).2
+  have hpComplex (s : Fin S.basisCount) :
+      (bntSectorProbability M S hWeight N s : ℂ) =
+        (S.copies s : ℂ) *
+          Matrix.trace (mpo (commonWeightAbsorbedBasisMPOTensor S hWeight s) N) /
+            Matrix.trace (mpo M N) := by
+    rw [bntSectorProbability, hMtraceEq, hSectorTraceEq s]
+    norm_num
+  have hdecomp :=
+    mpo_eq_sum_copies_smul_commonWeightAbsorbedBasisMPOTensor M S hM hWeight hN
+  rw [normalizedMPO]
+  nth_rewrite 2 [hdecomp]
+  rw [Finset.smul_sum]
+  apply Finset.sum_congr rfl
+  intro s _
+  rw [normalizedMPO, hpComplex]
+  simp only [smul_smul]
+  congr 1
+  field_simp [(ne_of_gt hMtrace), (ne_of_gt (hSectorTrace s))]
+
+/-- Left local invariance fixes the first site of every normalized periodic
+state.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1733--1770. -/
+private theorem firstSiteMatrix_mul_normalizedMPO_of_ketLeftMul_eq
+    (M : MPOTensor d D) (P : Matrix (Fin d) (Fin d) ℂ)
+    (hPM : M.ketLeftMul P = M) (N : ℕ) :
+    firstSiteMatrix P N * normalizedMPO M (N + 1) = normalizedMPO M (N + 1) := by
+  ext σ τ
+  obtain ⟨a, σ', rfl⟩ : ∃ a σ', σ = Fin.cons a σ' :=
+    ⟨σ 0, σ ∘ Fin.succ, (Fin.cons_self_tail σ).symm⟩
+  obtain ⟨b, τ', rfl⟩ : ∃ b τ', τ = Fin.cons b τ' :=
+    ⟨τ 0, τ ∘ Fin.succ, (Fin.cons_self_tail τ).symm⟩
+  rw [firstSiteMatrix_mul_apply]
+  simp only [Fin.cons_zero, Function.comp_def, Fin.cons_succ, normalizedMPO,
+    Matrix.smul_apply, smul_eq_mul, mpo_cons_cons]
+  have hPMab := congrFun (congrFun hPM a) b
+  simp only [ketLeftMul] at hPMab
+  calc
+    ∑ i : Fin d, P a i *
+        ((mpo M (N + 1)).trace⁻¹ *
+          Matrix.trace (M i b * evalWord M (List.ofFn σ') (List.ofFn τ')))
+        = (mpo M (N + 1)).trace⁻¹ *
+            ∑ i : Fin d, P a i *
+              Matrix.trace (M i b * evalWord M (List.ofFn σ') (List.ofFn τ')) := by
+          rw [Finset.mul_sum]
+          apply Finset.sum_congr rfl
+          intro i _
+          ring
+    _ = (mpo M (N + 1)).trace⁻¹ *
+        Matrix.trace ((∑ i : Fin d, P a i • M i b) *
+          evalWord M (List.ofFn σ') (List.ofFn τ')) := by
+      rw [sum_mul_trace_eq_trace_sum_smul]
+    _ = (mpo M (N + 1)).trace⁻¹ *
+        Matrix.trace (M a b * evalWord M (List.ofFn σ') (List.ofFn τ')) := by
+      rw [hPMab]
+
+/-- Left local invariance is preserved by taking a nonempty contiguous
+marginal. -/
+private theorem firstSiteMatrix_mul_reducedBlockState_of_ketLeftMul_eq
+    (M : MPOTensor d D) (P : Matrix (Fin d) (Fin d) ℂ)
+    (hPM : M.ketLeftMul P = M) {N L : ℕ} (hL : L + 1 ≤ N) :
+    firstSiteMatrix P L * reducedBlockState M N (L + 1) hL =
+      reducedBlockState M N (L + 1) hL := by
+  obtain ⟨N, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (by omega : N ≠ 0)
+  ext u v
+  obtain ⟨a, u', rfl⟩ : ∃ a u', u = Fin.cons a u' :=
+    ⟨u 0, u ∘ Fin.succ, (Fin.cons_self_tail u).symm⟩
+  obtain ⟨b, v', rfl⟩ : ∃ b v', v = Fin.cons b v' :=
+    ⟨v 0, v ∘ Fin.succ, (Fin.cons_self_tail v).symm⟩
+  rw [firstSiteMatrix_mul_apply]
+  simp only [Fin.cons_zero, Function.comp_def, Fin.cons_succ]
+  simp_rw [reducedBlockState_eq_sum]
+  simp_rw [Finset.mul_sum]
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro w _
+  simp only [normalizedMPO, Matrix.smul_apply, smul_eq_mul, mpo_apply,
+    mpoMatrixEntry]
+  let z : Fin N → Fin d :=
+    Fin.append u' w ∘ Fin.cast (show N = L + (N + 1 - (L + 1)) by omega)
+  let z' : Fin N → Fin d :=
+    Fin.append v' w ∘ Fin.cast (show N = L + (N + 1 - (L + 1)) by omega)
+  have htail (r : Fin L → Fin d) (x : Fin d) :
+      (fun i : Fin N ↦ Fin.append (Fin.cons x r) w
+        (Fin.cast (show N + 1 = L + 1 + (N + 1 - (L + 1)) by omega) i.succ)) =
+      Fin.append r w ∘
+        Fin.cast (show N = L + (N + 1 - (L + 1)) by omega) := by
+    funext i
+    by_cases hi : i.val < L
+    · have hleft : Fin.cast
+          (show N + 1 = L + 1 + (N + 1 - (L + 1)) by omega) i.succ =
+          Fin.castAdd (N + 1 - (L + 1)) (Fin.succ ⟨i.val, hi⟩) := by
+        apply Fin.ext
+        simp
+      have hright : Fin.cast
+          (show N = L + (N + 1 - (L + 1)) by omega) i =
+          Fin.castAdd (N + 1 - (L + 1)) ⟨i.val, hi⟩ := by
+        apply Fin.ext
+        simp
+      rw [hleft]
+      change Fin.append (Fin.cons x r) w
+        (Fin.castAdd (N + 1 - (L + 1)) (Fin.succ ⟨i.val, hi⟩)) =
+          Fin.append r w (Fin.cast
+            (show N = L + (N + 1 - (L + 1)) by omega) i)
+      rw [hright, Fin.append_left, Fin.append_left, Fin.cons_succ]
+    · let k : Fin (N + 1 - (L + 1)) := ⟨i.val - L, by omega⟩
+      have hleft : Fin.cast
+          (show N + 1 = L + 1 + (N + 1 - (L + 1)) by omega) i.succ =
+          Fin.natAdd (L + 1) k := by
+        apply Fin.ext
+        simp [k]
+        omega
+      have hright : Fin.cast
+          (show N = L + (N + 1 - (L + 1)) by omega) i =
+          Fin.natAdd L k := by
+        apply Fin.ext
+        simp [k]
+        omega
+      rw [hleft]
+      change Fin.append (Fin.cons x r) w (Fin.natAdd (L + 1) k) =
+        Fin.append r w (Fin.cast
+          (show N = L + (N + 1 - (L + 1)) by omega) i)
+      rw [hright, Fin.append_right, Fin.append_right]
+  have hword (x : Fin d) :
+      List.ofFn (Fin.append (Fin.cons x u') w ∘
+        Fin.cast (show N + 1 = L + 1 + (N + 1 - (L + 1)) by omega)) =
+        x :: List.ofFn z := by
+    rw [List.ofFn_succ]
+    congr 1
+    exact congrArg List.ofFn (htail u' x)
+  have hword' :
+      List.ofFn (Fin.append (Fin.cons b v') w ∘
+        Fin.cast (show N + 1 = L + 1 + (N + 1 - (L + 1)) by omega)) =
+        b :: List.ofFn z' := by
+    rw [List.ofFn_succ]
+    congr 1
+    exact congrArg List.ofFn (htail v' b)
+  simp_rw [hword, hword', evalWord_cons]
+  have hPMab := congrFun (congrFun hPM a) b
+  simp only [ketLeftMul] at hPMab
+  calc
+    ∑ x : Fin d, P a x *
+        ((mpo M (N + 1)).trace⁻¹ *
+          Matrix.trace (M x b * evalWord M (List.ofFn z) (List.ofFn z')))
+        = (mpo M (N + 1)).trace⁻¹ *
+            ∑ x : Fin d, P a x *
+              Matrix.trace (M x b * evalWord M (List.ofFn z) (List.ofFn z')) := by
+          rw [Finset.mul_sum]
+          apply Finset.sum_congr rfl
+          intro x _
+          ring
+    _ = (mpo M (N + 1)).trace⁻¹ *
+        Matrix.trace ((∑ x : Fin d, P a x • M x b) *
+          evalWord M (List.ofFn z) (List.ofFn z')) := by
+      rw [sum_mul_trace_eq_trace_sum_smul]
+    _ = (mpo M (N + 1)).trace⁻¹ *
+        Matrix.trace (M a b * evalWord M (List.ofFn z) (List.ofFn z')) := by
+      rw [hPMab]
+
+/-- Every nonempty contiguous marginal has the same BNT-sector
+probabilities as the normalized full chain.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `entropiesj`,
+lines 1760--1770. -/
+theorem reducedBlockState_eq_sum_bntSectorProbability_smul
+    (M : MPOTensor d D) (S : MPSTensor.SectorDecomposition (d * d))
+    (hM : MPSTensor.SameMPV₂Pos M.toMPSTensor S.toTensor)
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q') {N L : ℕ} (hN : 0 < N)
+    (hL : L ≤ N) (hMtrace : 0 < Matrix.trace (mpo M N))
+    (hSectorTrace : ∀ s, 0 < Matrix.trace
+      (mpo (commonWeightAbsorbedBasisMPOTensor S hWeight s) N)) :
+    reducedBlockState M N L hL = ∑ s : Fin S.basisCount,
+      (bntSectorProbability M S hWeight N s : ℂ) •
+        reducedBlockState (commonWeightAbsorbedBasisMPOTensor S hWeight s) N L hL := by
+  classical
+  have hfull := normalizedMPO_eq_sum_bntSectorProbability_smul
+    M S hM hWeight hN hMtrace hSectorTrace
+  ext u v
+  rw [reducedBlockState_eq_sum]
+  simp_rw [hfull, Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
+  simp_rw [reducedBlockState_eq_sum]
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro s _
+  rw [Finset.mul_sum]
+
+/-- Entropy of every nonempty marginal splits into the Shannon entropy of
+the BNT-sector probabilities and the probability-weighted sector entropies.
+The probability is fixed by the full length-`N` chain and is therefore the
+same for every marginal length.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `entropiesj`,
+lines 1760--1770. -/
+theorem blockEntropy_eq_sum_bntSectorProbability
+    (M : MPOTensor d D) (S : MPSTensor.SectorDecomposition (d * d))
+    (hM : MPSTensor.SameMPV₂Pos M.toMPSTensor S.toTensor)
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q')
+    {R : (s : Fin S.basisCount) →
+      Matrix (Fin (S.basisDim s)) (Fin (S.basisDim s)) ℂ}
+    {ρ₃ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex S.basisDim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse
+      (fun j ↦ S.basisMPOTensor j) C)
+    (hρ₃ : IsThreeSiteFamilyClosure (fun j ↦ S.basisMPOTensor j) R ρ₃)
+    (hη : EtaStructure ρ₃) (hR : ∀ s : Fin S.basisCount, R s ≠ 0)
+    (hMpdo : IsMPDO M)
+    (hSectorMpdo : ∀ s, IsMPDO
+      (commonWeightAbsorbedBasisMPOTensor S hWeight s))
+    {N L : ℕ} (hN : 0 < N) (hLpos : 0 < L) (hL : L ≤ N)
+    (hMtrace : 0 < Matrix.trace (mpo M N))
+    (hSectorTrace : ∀ s, 0 < Matrix.trace
+      (mpo (commonWeightAbsorbedBasisMPOTensor S hWeight s) N)) :
+    blockEntropy M N L hL (hMpdo N hN) =
+      ∑ s : Fin S.basisCount,
+        (Real.negMulLog (bntSectorProbability M S hWeight N s) +
+          bntSectorProbability M S hWeight N s *
+            blockEntropy (commonWeightAbsorbedBasisMPOTensor S hWeight s)
+              N L hL (hSectorMpdo s N hN)) := by
+  classical
+  obtain ⟨L, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (Nat.ne_of_gt hLpos)
+  let K : (s : Fin S.basisCount) → MPOTensor d (S.basisDim s) :=
+    fun s ↦ commonWeightAbsorbedBasisMPOTensor S hWeight s
+  let p : Fin S.basisCount → ℝ := fun s ↦
+    bntSectorProbability M S hWeight N s
+  let ρ : (s : Fin S.basisCount) →
+      Matrix (Fin (L + 1) → Fin d) (Fin (L + 1) → Fin d) ℂ :=
+    fun s ↦ reducedBlockState (K s) N (L + 1) hL
+  let Q : Fin S.basisCount →
+      Matrix (Fin (L + 1) → Fin d) (Fin (L + 1) → Fin d) ℂ :=
+    fun s ↦ firstSiteMatrix (bntSectorProjection hC hρ₃ hη hR s) L
+  have hp : ∀ s, 0 < p s := fun s ↦
+    bntSectorProbability_pos M S hWeight hMtrace hSectorTrace s
+  have hρpos : ∀ s, (ρ s).PosSemidef := fun s ↦
+    reducedBlockState_posSemidef (K s) N (L + 1) hL (hSectorMpdo s N hN)
+  have hρtrace : ∀ s, Matrix.trace (ρ s) = 1 := fun s ↦
+    reducedBlockState_trace (K s) N (L + 1) hL (ne_of_gt (hSectorTrace s))
+  have hQherm : ∀ s, (Q s).IsHermitian := fun s ↦
+    firstSiteMatrix_isHermitian
+      (bntSectorProjection_isOrthogonal hC hρ₃ hη hR s).1 L
+  have hQρ : ∀ s, Q s * ρ s = ρ s := fun s ↦
+    firstSiteMatrix_mul_reducedBlockState_of_ketLeftMul_eq
+      (K s) (bntSectorProjection hC hρ₃ hη hR s)
+        (ketLeftMul_bntSectorProjection_commonWeightAbsorbedBasis
+          S hWeight hC hρ₃ hη hR s) hL
+  have hρQ : ∀ s, ρ s * Q s = ρ s := fun s ↦
+    mul_eq_self_of_isHermitian_of_mul_eq_self (hρpos s).isHermitian
+      (hQherm s) (hQρ s)
+  have hQorth : ∀ s t, s ≠ t → Q s * Q t = 0 := by
+    intro s t hst
+    change firstSiteMatrix (bntSectorProjection hC hρ₃ hη hR s) L *
+      firstSiteMatrix (bntSectorProjection hC hρ₃ hη hR t) L = 0
+    rw [firstSiteMatrix_mul_firstSiteMatrix,
+      bntSectorProjection_mul_eq_zero hC hρ₃ hη hR hst]
+    ext u v
+    simp [firstSiteMatrix]
+  have hsum : reducedBlockState M N (L + 1) hL =
+      ∑ s, (p s : ℂ) • ρ s := by
+    exact reducedBlockState_eq_sum_bntSectorProbability_smul
+      M S hM hWeight hN hL hMtrace hSectorTrace
+  have hadd := vonNeumannEntropy_eq_sum_of_orthogonal_support
+    (reducedBlockState M N (L + 1) hL)
+    (reducedBlockState_isHermitian M N (L + 1) hL (hMpdo N hN))
+    (fun s ↦ (p s : ℂ) • ρ s) Q
+    (fun s ↦ ((hρpos s).smul (a := (p s : ℂ))
+      (by exact_mod_cast (hp s).le)).isHermitian)
+    hsum (fun s ↦ ⟨by rw [Matrix.mul_smul, hQρ],
+      by rw [Matrix.smul_mul, hρQ]⟩) hQorth
+  calc
+    blockEntropy M N (L + 1) hL (hMpdo N hN) =
+        ∑ s, vonNeumannEntropy ((p s : ℂ) • ρ s)
+          (((hρpos s).smul (a := (p s : ℂ))
+            (by exact_mod_cast (hp s).le)).isHermitian) := hadd
+    _ = _ := by
+      apply Finset.sum_congr rfl
+      intro s _
+      simpa only [K, p, ρ, blockEntropy, add_comm] using
+        vonNeumannEntropy_smul (hρpos s) (hρtrace s) (p s)
+
+/-- Equality in strong subadditivity descends from the full tensor to every
+absorbed BNT sector.  The four regions have lengths
+\(m-1,1,N-m-1,1\).
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1760--1780. -/
+theorem blockEntropy_add_blockEntropy_eq_bntSector
+    (M : MPOTensor d D) (S : MPSTensor.SectorDecomposition (d * d))
+    (hM : MPSTensor.SameMPV₂Pos M.toMPSTensor S.toTensor)
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q')
+    {R : (s : Fin S.basisCount) →
+      Matrix (Fin (S.basisDim s)) (Fin (S.basisDim s)) ℂ}
+    {ρ₃ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex S.basisDim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse
+      (fun j ↦ S.basisMPOTensor j) C)
+    (hρ₃ : IsThreeSiteFamilyClosure (fun j ↦ S.basisMPOTensor j) R ρ₃)
+    (hη : EtaStructure ρ₃) (hR : ∀ s : Fin S.basisCount, R s ≠ 0)
+    (hSAL : IsSAL M) (hZCL : IsSourceZCL M)
+    (hSectorMpdo : ∀ s, IsMPDO
+      (commonWeightAbsorbedBasisMPOTensor S hWeight s))
+    (hSectorTrace : ∀ (N : ℕ), 0 < N → ∀ s, 0 < Matrix.trace
+      (mpo (commonWeightAbsorbedBasisMPOTensor S hWeight s) N))
+    {N m : ℕ} (hm1 : 1 ≤ m) (hmN : m ≤ N / 2)
+    (s : Fin S.basisCount) :
+    let K := commonWeightAbsorbedBasisMPOTensor S hWeight s
+    blockEntropy K N (N - 1) (Nat.sub_le N 1) (hSectorMpdo s N (by omega)) +
+        blockEntropy K N 1 (by omega) (hSectorMpdo s N (by omega)) =
+      blockEntropy K N m (by omega) (hSectorMpdo s N (by omega)) +
+        blockEntropy K N (N - m) (Nat.sub_le N m) (hSectorMpdo s N (by omega)) := by
+  classical
+  dsimp only
+  let hMpdo : IsMPDO M := Classical.choose hSAL
+  have hN : 0 < N := by omega
+  have hMtrace : 0 < Matrix.trace (mpo M N) :=
+    trace_mpo_pos_of_isMPDO_isSourceZCL M hMpdo hZCL hN
+  have hGlobal := mutualInfoChain_eq_of_isSAL M hSAL
+    (N := N) (L := 1) (L' := m) (by omega) (by omega) hm1 hmN
+  simp only [mutualInfoChain] at hGlobal
+  have hEABC := blockEntropy_eq_sum_bntSectorProbability (L := N - 1)
+    M S hM hWeight hC hρ₃ hη hR hMpdo hSectorMpdo hN (by omega)
+      (Nat.sub_le N 1) hMtrace (hSectorTrace N hN)
+  have hEB := blockEntropy_eq_sum_bntSectorProbability (L := 1)
+    M S hM hWeight hC hρ₃ hη hR hMpdo hSectorMpdo hN (by omega)
+      (by omega) hMtrace (hSectorTrace N hN)
+  have hEAB := blockEntropy_eq_sum_bntSectorProbability (L := m)
+    M S hM hWeight hC hρ₃ hη hR hMpdo hSectorMpdo hN (by omega)
+      (by omega) hMtrace (hSectorTrace N hN)
+  have hEBC := blockEntropy_eq_sum_bntSectorProbability (L := N - m)
+    M S hM hWeight hC hρ₃ hη hR hMpdo hSectorMpdo hN (by omega)
+      (Nat.sub_le N m) hMtrace (hSectorTrace N hN)
+  rw [hEABC, hEB, hEAB, hEBC] at hGlobal
+  let p : Fin S.basisCount → ℝ := fun t ↦
+    bntSectorProbability M S hWeight N t
+  let L : Fin S.basisCount → ℝ := fun t ↦
+    blockEntropy (commonWeightAbsorbedBasisMPOTensor S hWeight t)
+        N (N - 1) (Nat.sub_le N 1) (hSectorMpdo t N hN) +
+      blockEntropy (commonWeightAbsorbedBasisMPOTensor S hWeight t)
+        N 1 (by omega) (hSectorMpdo t N hN)
+  let U : Fin S.basisCount → ℝ := fun t ↦
+    blockEntropy (commonWeightAbsorbedBasisMPOTensor S hWeight t)
+        N m (by omega) (hSectorMpdo t N hN) +
+      blockEntropy (commonWeightAbsorbedBasisMPOTensor S hWeight t)
+        N (N - m) (Nat.sub_le N m) (hSectorMpdo t N hN)
+  have hsum : ∑ t, p t * L t = ∑ t, p t * U t := by
+    simp only [p, L, U]
+    simp_rw [mul_add, Finset.sum_add_distrib]
+    simp_rw [Finset.sum_add_distrib] at hGlobal
+    linarith [hGlobal]
+  have hle : ∀ t, L t ≤ U t := by
+    intro t
+    let K := commonWeightAbsorbedBasisMPOTensor S hWeight t
+    have hineq := ssa_block_entropy K
+      (N := N) (a := m - 1) (b := 1) (c := N - m - 1)
+      (by omega) (hSectorMpdo t N hN) (ne_of_gt (hSectorTrace N hN t))
+    rw [blockEntropy_congr K N
+      (show (m - 1) + 1 + (N - m - 1) = N - 1 by omega)
+      (by omega) (Nat.sub_le N 1) (hSectorMpdo t N hN)] at hineq
+    rw [blockEntropy_congr K N (show (m - 1) + 1 = m by omega)
+      (by omega) (by omega) (hSectorMpdo t N hN)] at hineq
+    rw [blockEntropy_congr K N (show 1 + (N - m - 1) = N - m by omega)
+      (by omega) (Nat.sub_le N m) (hSectorMpdo t N hN)] at hineq
+    exact hineq
+  exact eq_of_weighted_sum_eq_of_pos_of_le p L U
+    (fun t ↦ bntSectorProbability_pos M S hWeight hMtrace
+      (hSectorTrace N hN) t) hle hsum s
+
+/-- Every absorbed BNT representative satisfies the saturated area law once
+the source projector selection, sector positivity, and strict sector
+normalizations are available.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1753--1781. -/
+theorem commonWeightAbsorbedBasisMPOTensor_isSAL_of_projectorSelection
+    (M : MPOTensor d D) (S : MPSTensor.SectorDecomposition (d * d))
+    (hM : MPSTensor.SameMPV₂Pos M.toMPSTensor S.toTensor)
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q')
+    {R : (s : Fin S.basisCount) →
+      Matrix (Fin (S.basisDim s)) (Fin (S.basisDim s)) ℂ}
+    {ρ₃ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex S.basisDim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse
+      (fun j ↦ S.basisMPOTensor j) C)
+    (hρ₃ : IsThreeSiteFamilyClosure (fun j ↦ S.basisMPOTensor j) R ρ₃)
+    (hη : EtaStructure ρ₃) (hR : ∀ s : Fin S.basisCount, R s ≠ 0)
+    (hSAL : IsSAL M) (hZCL : IsSourceZCL M)
+    (hSectorMpdo : ∀ s, IsMPDO
+      (commonWeightAbsorbedBasisMPOTensor S hWeight s))
+    (hSectorTrace : ∀ (N : ℕ), 0 < N → ∀ s, 0 < Matrix.trace
+      (mpo (commonWeightAbsorbedBasisMPOTensor S hWeight s) N))
+    (s : Fin S.basisCount) :
+    IsSAL (commonWeightAbsorbedBasisMPOTensor S hWeight s) := by
+  let K := commonWeightAbsorbedBasisMPOTensor S hWeight s
+  refine ⟨hSectorMpdo s, fun N hN ↦ ne_of_gt (hSectorTrace N hN s), ?_⟩
+  intro N L hL hLN
+  have hEqL := blockEntropy_add_blockEntropy_eq_bntSector
+    M S hM hWeight hC hρ₃ hη hR hSAL hZCL hSectorMpdo hSectorTrace
+      (N := N) (m := L) hL (Nat.le_of_lt hLN) s
+  have hEqSucc := blockEntropy_add_blockEntropy_eq_bntSector
+    M S hM hWeight hC hρ₃ hη hR hSAL hZCL hSectorMpdo hSectorTrace
+      (N := N) (m := L + 1) (by omega) (by omega) s
+  simp only [mutualInfoChain]
+  dsimp only at hEqL hEqSucc
+  linarith [hEqL, hEqSucc]
+
+/-- Every absorbed normal representative of a simple tensor satisfies the
+saturated area law.
+
+The conclusion follows by decomposing each of the four marginals in strong
+subadditivity into the same orthogonal sectors.  Their Shannon contributions
+cancel, and strict positivity of every sector probability forces equality in
+each sector separately.
+
+**Scope restriction (common blocking):** the one-letter simultaneous span is
+the blocked form used to construct the common left inverse.  Its derivation
+from the unrestricted biCF statement is recorded in
+`docs/paper-gaps/cpgsv17_bicf_block_separation.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1748--1781. -/
+theorem commonWeightAbsorbedBasisMPOTensor_isSAL_of_sameMPV₂Pos
+    {D : ℕ} (M : MPOTensor d D)
+    (S : MPSTensor.SectorDecomposition (d * d)) (hTotal : S.totalDim = D)
+    (X : (s : Fin S.totalCopies) → GL (Fin (S.flatDim s)) ℂ)
+    (hEq : ∀ i : Fin (d * d),
+      M.toMPSTensor i =
+        cast (by rw [hTotal] :
+            Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ =
+              Matrix (Fin D) (Fin D) ℂ)
+          ((MPSTensor.globalGaugeOfBlocks X :
+                Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ) *
+            S.toTensor i *
+            (((MPSTensor.globalGaugeOfBlocks X)⁻¹ :
+                GL (Fin S.totalDim) ℂ) :
+              Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ)))
+    (hM : MPSTensor.SameMPV₂Pos M.toMPSTensor S.toTensor)
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q')
+    (hnonNil : ∀ j,
+      ¬ IsNilpotent (doubledPhysTraceTransfer d (S.basis j)))
+    (hSpan : MPSTensor.WordTupleSpanTop S.basis 1)
+    (hSAL : IsSAL M) (hZCL : IsSourceZCL M)
+    (s : Fin S.basisCount) :
+    IsSAL (commonWeightAbsorbedBasisMPOTensor S hWeight s) := by
+  obtain ⟨C, hC, hη, _hlocal, _hcompression⟩ :=
+    exists_bntProjectorSelection_positiveLength_of_sameMPV₂Pos_isSAL
+      M S hM hWeight hnonNil hSpan hSAL
+  let hClosure :=
+    reducedBlockState_four_threeSiteFamilyClosure_nonzero_closing
+      M S hM hWeight hnonNil hSAL
+  apply commonWeightAbsorbedBasisMPOTensor_isSAL_of_projectorSelection
+    M S hM hWeight hC hClosure.1 hη hClosure.2 hSAL hZCL
+  · intro t
+    exact commonWeightAbsorbedBasisMPOTensor_isMPDO_of_sameMPV₂Pos_isSAL
+      M S hM hWeight hnonNil hSpan hSAL t
+  · intro N hN t
+    exact trace_mpo_commonWeightAbsorbedBasisMPOTensor_pos
+      M S hTotal X hEq hM hZCL hWeight hnonNil hSpan hSAL t hN
+
+end MPOTensor

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -1422,6 +1422,39 @@ Theorem~\ref{thm:trace_norm_abs}.
     \]
 \end{proof}
 
+\begin{theorem}[Entropy of summands on pairwise-annihilating supports]
+    \label{thm:entropy_pairwise_annihilating_support}
+    \lean{vonNeumannEntropy_eq_sum_of_orthogonal_support}
+    \leanok
+    \uses{def:von_neumann_entropy}
+    Let $A=\sum_j M_j$ be a finite sum of Hermitian matrices.  Suppose there
+    are operators $P_j$ such that
+    \[
+        P_jM_j=M_jP_j=M_j,
+        \qquad
+        P_jP_k=0 \quad (j\ne k).
+    \]
+    Then
+    \[
+        S(A)=\sum_j S(M_j).
+    \]
+    The operators $P_j$ need only resolve the support of $A$; their sum need
+    not be the identity on the ambient space.  This is the support form of
+    the direct-sum entropy identity used in
+    \cite[Appendix~C.2, lines~1760--1770]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:entropy_mul_comm, thm:entropy_block_diagonal}
+    Write $A=XY$, where $X$ maps the direct sum of the labelled ambient
+    spaces to the original space by the matrices $M_j$, and $Y$ maps back by
+    the operators $P_j$.  The support and annihilation identities give
+    $YX=\bigoplus_jM_j$.  Reversing the two rectangular factors preserves the
+    nonzero eigenvalues, while any additional eigenvalues are zero.  Entropy
+    is therefore unchanged, and additivity on the block diagonal gives the
+    result.
+\end{proof}
+
 \begin{theorem}[Entropy of a weighted orthogonal direct sum]
     \label{thm:entropy_weighted_block_diagonal}
     \lean{vonNeumannEntropy_blockDiagonal_smul}

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -1424,7 +1424,7 @@ Theorem~\ref{thm:trace_norm_abs}.
 
 \begin{theorem}[Entropy of summands on pairwise-annihilating supports]
     \label{thm:entropy_pairwise_annihilating_support}
-    \lean{vonNeumannEntropy_eq_sum_of_orthogonal_support}
+  \lean{vonNeumannEntropy_eq_sum_of_pairwise_annihilating_supports}
     \leanok
     \uses{def:von_neumann_entropy}
     Let $A=\sum_j M_j$ be a finite sum of Hermitian matrices.  Suppose there

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
@@ -336,14 +336,10 @@ strong subadditivity for a normalized three-site reduced state.
 
     Conversely, suppose the tensor generates positive semidefinite periodic
     operators and their traces are nonzero at every positive chain length.
-    If the displayed equality holds for every $N$ and every admissible $m$,
-    then the tensor saturates the area law.  This is the choice of regions
-    used in
+    If the displayed equality holds for every $N$ and every
+    $1\leq m\leq\lfloor N/2\rfloor$, then the tensor saturates the area law.
+    This is the choice of regions used in
     \cite[Appendix~C.2, lines~1760--1780]{Cirac2016MPDO_arXiv}.
-    Conversely, suppose that the periodic operators are positive semidefinite
-    and have nonzero trace at every positive length.  If the displayed
-    equality holds for every $1\leq m\leq\lfloor N/2\rfloor$, then the tensor
-    saturates the area law.
     The endpoint corrects the strict inequality printed at source line~1771:
     Definition~4.6 and the concluding comparison both require
     $m=\lfloor N/2\rfloor$.  This local correction is recorded in

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
@@ -650,6 +650,72 @@ strong subadditivity for a normalized three-site reduced state.
     positive.
 \end{proof}
 
+\begin{theorem}[Saturated area law for the absorbed BNT elements]
+    \label{thm:mpdo_absorbed_bnt_sector_sal}
+    \lean{MPOTensor.bntSectorProbability}
+    \lean{MPOTensor.bntSectorProbability_pos}
+    \lean{MPOTensor.normalizedMPO_eq_sum_bntSectorProbability_smul}
+    \lean{MPOTensor.reducedBlockState_eq_sum_bntSectorProbability_smul}
+    \lean{MPOTensor.blockEntropy_eq_sum_bntSectorProbability}
+    \lean{MPOTensor.blockEntropy_add_blockEntropy_eq_bntSector}
+    \lean{MPOTensor.%
+      commonWeightAbsorbedBasisMPOTensor_isSAL_of_projectorSelection}
+    \lean{MPOTensor.%
+      commonWeightAbsorbedBasisMPOTensor_isSAL_of_sameMPV₂Pos}
+    \leanok
+    \uses{def:is_sal, def:mpo_source_zcl,
+      def:mpdo_common_sector_weight_absorption}
+    Let $K$ saturate the area law and have zero correlation length, and let
+    its horizontal BNT canonical form, up to block-diagonal gauge, have normal
+    representatives $A_s$, common copy weights $\mu_s$, and copy numbers
+    $n_s$.  Assume that the physical-trace transfer of every $A_s$ is
+    nonnilpotent.  After a common blocking, assume explicitly that the
+    simultaneous one-letter word tuples of the $A_s$ span the direct sum of
+    their full matrix algebras.  Put $\mathcal K_s=\mu_sA_s$.
+
+    For every nonempty chain, define
+    \[
+      p_s^{(N)}=
+      \frac{n_s\,\tr\!\left(\sigma^{(N)}(\mathcal K_s)\right)}
+           {\tr\!\left(\sigma^{(N)}(K)\right)}.
+    \]
+    Then $p_s^{(N)}>0$, and every nonempty prefix marginal has the same sector
+    decomposition with these probabilities.  Translation invariance
+    identifies the other contiguous blocks of the same length.
+    Consequently, every absorbed representative $\mathcal K_s$ saturates the
+    area law.
+
+    The common-blocking assumption is a scope restriction relative to the
+    unrestricted source statement; it is recorded in
+    \path{docs/paper-gaps/cpgsv17_bicf_block_separation.tex}.  The entropy
+    conclusion is the argument of
+    \cite[Appendix~C.2, lines~1748--1781]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:entropy_pairwise_annihilating_support,
+      thm:positive_weighted_sum_termwise_equality,
+      lem:sal_const, thm:entropy_strong_subadditivity,
+      thm:mpdo_tripartite_block_entropy_identifications,
+      thm:mpdo_bnt_projector_local_selection,
+      cor:mpdo_absorbed_bnt_sector_is_mpdo,
+      thm:mpdo_source_zcl_strict_positive_length_normalization}
+    The BNT projections carry every normalized marginal on mutually
+    annihilating supports, so the preceding support form of entropy
+    additivity gives
+    \[
+      S_L(K)=H\!\left(p^{(N)}\right)
+        +\sum_s p_s^{(N)}S_L(\mathcal K_s)
+        \qquad (1\leq L\leq N).
+    \]
+    The four marginals entering strong subadditivity have the same
+    probabilities.  Substitution in the equality for $K$ cancels all four
+    Shannon terms.  Strong subadditivity gives the corresponding inequality
+    in each sector, and strict positivity of every $p_s^{(N)}$ forces every
+    such inequality to be an equality.  Comparing the equalities for block
+    lengths $L$ and $L+1$ proves saturation for $\mathcal K_s$.
+\end{proof}
+
 \begin{definition}[Injective inverse map for a simple MPO tensor]
     \label{def:mpdo_injective_inverse_layer}
     \lean{MPOTensor.IsInjective}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
@@ -332,7 +332,13 @@ strong subadditivity for a normalized three-site reduced state.
     Indeed, this is the entropy form of $I_1=I_m$.  Taking $m=2$ gives the
     regions of lengths $1,1,N-3$, and then taking $N=4$ shows that the
     three-site reduced state of the four-site chain satisfies equality in
-    strong subadditivity.  This is the choice of regions used in
+    strong subadditivity.
+
+    Conversely, suppose the tensor generates positive semidefinite periodic
+    operators and their traces are nonzero at every positive chain length.
+    If the displayed equality holds for every $N$ and every admissible $m$,
+    then the tensor saturates the area law.  This is the choice of regions
+    used in
     \cite[Appendix~C.2, lines~1760--1780]{Cirac2016MPDO_arXiv}.
     Conversely, suppose that the periodic operators are positive semidefinite
     and have nonzero trace at every positive length.  If the displayed

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -317,10 +317,21 @@ the absorbed BNT representative is
 \path{MPOTensor.trace_mpo_commonWeightAbsorbedBasisMPOTensor_pos}.}
 The weighted orthogonal-direct-sum entropy formula used in Appendix~C.2,
 lines~1760--1770, is also formalized as
-\path{vonNeumannEntropy_blockDiagonal_smul}.  The remaining source step after the
-sector-compression identity is SAL for each sector.  It must follow from the
-direct-sum entropy identity and strong subadditivity as in
-\cite[Appendix~C.2, lines~1760--1780]{Cirac2016MPDO_arXiv}.
+\path{vonNeumannEntropy_blockDiagonal_smul}, together with the form for
+pairwise-annihilating support operators
+\path{vonNeumannEntropy_eq_sum_of_orthogonal_support}.  The remaining source
+step after the sector-compression identity is now formalized: the same sector
+probabilities occur in all four marginals, the Shannon terms cancel, and
+strict positivity together with strong subadditivity forces equality in every
+sector.  Thus every absorbed BNT representative satisfies SAL under the
+explicit common-blocking restriction above.
+\footnote{The principal declarations are
+\path{MPOTensor.blockEntropy_eq_sum_bntSectorProbability},
+\path{MPOTensor.blockEntropy_add_blockEntropy_eq_bntSector}, and
+\path{MPOTensor.commonWeightAbsorbedBasisMPOTensor_isSAL_of_sameMPV₂Pos}.}
+This completes the entropy argument of
+\cite[Appendix~C.2, lines~1748--1781]{Cirac2016MPDO_arXiv} within that stated
+scope.
 There is a local endpoint typo in this passage.  Line~1771 writes
 $m<\lfloor N/2\rfloor$, but Definition~4.6 gives the equality chain through
 $I_{\lfloor N/2\rfloor}$, and the conclusion at lines~1781--1783 compares

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -319,7 +319,7 @@ The weighted orthogonal-direct-sum entropy formula used in Appendix~C.2,
 lines~1760--1770, is also formalized as
 \path{vonNeumannEntropy_blockDiagonal_smul}, together with the form for
 pairwise-annihilating support operators
-\path{vonNeumannEntropy_eq_sum_of_orthogonal_support}.  The remaining source
+\path{vonNeumannEntropy_eq_sum_of_pairwise_annihilating_supports}.  The remaining source
 step after the sector-compression identity is now formalized: the same sector
 probabilities occur in all four marginals, the Shannon terms cancel, and
 strict positivity together with strong subadditivity forces equality in every


### PR DESCRIPTION
### Motivation

This PR completes the sectorwise saturated-area-law argument requested in #4110. The mathematical source is arXiv:1606.00608, Appendix C.2, lines 1748--1781. The explicit common-blocking restriction `WordTupleSpanTop S.basis 1` remains documented in `docs/paper-gaps/cpgsv17_bicf_block_separation.tex`.

### Description

- Defines the BNT-sector probabilities with copy multiplicities only for positive chain length and strictly positive full and sector normalizations. There is no empty-chain or zero-denominator value.
- Proves that the normalized full-chain state and every nonempty prefix marginal decompose with the same probabilities.
- Proves entropy additivity for Hermitian summands carried by pairwise-annihilating support operators. No resolution of the ambient identity is assumed, and the name records the exact hypothesis rather than suggesting orthogonal projections.
- Cancels the four Shannon contributions in the saturated full-chain entropy identity, then combines sectorwise strong subadditivity with strict positivity of every sector probability to obtain equality in each sector.
- Concludes that every common-weight absorbed BNT representative satisfies SAL. The generic inheritance theorem uses the nonzero-trace clause already contained in SAL; zero correlation length is retained only where it is genuinely needed to prove strict sector normalizations.
- Uses the arbitrary-cut SAL equivalence and projector-sum identity merged in #4115 through the focused module split; duplicate declarations from the earlier base were removed during the rebase.
- Updates the entropy and MPDO blueprint entries and the source-gap account.

### Verification

- `lake build TNLean.MPS.MPDO.BNTSectorAreaLaw TNLean` (9,536 targets)
- `lake exe lint_style`
- `python3 scripts/check_oversized_lean_files.py --root .` (883 files, none over 1,000 lines)
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint checkdecls`
- Proof-integrity scan of every changed Lean file: no new `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast`
- Kernel axiom audit: the new entropy and generic sector-SAL theorems use only standard Lean axioms; the source-specialized capstone reaches the already documented `hayashi_ssa_equality_characterization_forward` boundary and introduces no axiom.

Closes #4110

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new formal proof chain in MPDO entropy/SAL with many hypotheses (traces, MPDO, projector selection); mathematical risk is moderate rather than runtime/security-critical.
> 
> **Overview**
> Formalizes the Appendix C.2 sectorwise entropy argument (arXiv:1606.00608): absorbed BNT representatives inherit the **saturated area law (SAL)** from a SAL full MPO under the documented common-blocking scope.
> 
> **Entropy infrastructure:** Adds `vonNeumannEntropy_eq_sum_of_pairwise_annihilating_supports` so marginal entropies split over BNT sectors carried by mutually annihilating first-site projectors, without requiring projectors to sum to the identity.
> 
> **BNT / MPO glue:** Extends projector selection with ket/bra invariance under matching BNT projections (including common-weight absorbed basis tensors) and expresses a positive-length MPO as a copy-weighted sum of those absorbed sector tensors.
> 
> **New `BNTSectorAreaLaw` module:** Defines sector probabilities (copy number × trace ratio), shows the normalized chain and prefix marginals share the same probability-weighted sector decomposition, proves `blockEntropy` equals Shannon weight plus weighted sector entropies, and uses global SAL plus sectorwise strong subadditivity and strict `p_s > 0` to force equality in each sector—yielding `IsSAL` for every `commonWeightAbsorbedBasisMPOTensor`, with a capstone from `sameMPV₂Pos` hypotheses.
> 
> Blueprint chapters and the SAL/ZCL gap doc are updated to mark this entropy step complete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbd6ad51453a4762e762df3291b34b88fa22f830. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->