### PR TITLE
style(MPS/MPDO): avoid predecessor shadowing

### DIFF
--- a/TNLean/MPS/MPDO/BNTSectorAreaLaw.lean
+++ b/TNLean/MPS/MPDO/BNTSectorAreaLaw.lean
@@ -168,7 +168,7 @@ private theorem firstSiteMatrix_mul_reducedBlockState_of_ketLeftMul_eq
     (hPM : M.ketLeftMul P = M) {N L : ℕ} (hL : L + 1 ≤ N) :
     firstSiteMatrix P L * reducedBlockState M N (L + 1) hL =
       reducedBlockState M N (L + 1) hL := by
-  obtain ⟨N, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (by omega : N ≠ 0)
+  obtain ⟨N', rfl⟩ := Nat.exists_eq_succ_of_ne_zero (by omega : N ≠ 0)
   ext u v
   obtain ⟨a, u', rfl⟩ : ∃ a u', u = Fin.cons a u' :=
     ⟨u 0, u ∘ Fin.succ, (Fin.cons_self_tail u).symm⟩
@@ -183,42 +183,42 @@ private theorem firstSiteMatrix_mul_reducedBlockState_of_ketLeftMul_eq
   intro w _
   simp only [normalizedMPO, Matrix.smul_apply, smul_eq_mul, mpo_apply,
     mpoMatrixEntry]
-  let z : Fin N → Fin d :=
-    Fin.append u' w ∘ Fin.cast (show N = L + (N + 1 - (L + 1)) by omega)
-  let z' : Fin N → Fin d :=
-    Fin.append v' w ∘ Fin.cast (show N = L + (N + 1 - (L + 1)) by omega)
+  let z : Fin N' → Fin d :=
+    Fin.append u' w ∘ Fin.cast (show N' = L + (N' + 1 - (L + 1)) by omega)
+  let z' : Fin N' → Fin d :=
+    Fin.append v' w ∘ Fin.cast (show N' = L + (N' + 1 - (L + 1)) by omega)
   have htail (r : Fin L → Fin d) (x : Fin d) :
-      (fun i : Fin N ↦ Fin.append (Fin.cons x r) w
-        (Fin.cast (show N + 1 = L + 1 + (N + 1 - (L + 1)) by omega) i.succ)) =
+      (fun i : Fin N' ↦ Fin.append (Fin.cons x r) w
+        (Fin.cast (show N' + 1 = L + 1 + (N' + 1 - (L + 1)) by omega) i.succ)) =
       Fin.append r w ∘
-        Fin.cast (show N = L + (N + 1 - (L + 1)) by omega) := by
+        Fin.cast (show N' = L + (N' + 1 - (L + 1)) by omega) := by
     funext i
     by_cases hi : i.val < L
     · have hleft : Fin.cast
-          (show N + 1 = L + 1 + (N + 1 - (L + 1)) by omega) i.succ =
-          Fin.castAdd (N + 1 - (L + 1)) (Fin.succ ⟨i.val, hi⟩) := by
+          (show N' + 1 = L + 1 + (N' + 1 - (L + 1)) by omega) i.succ =
+          Fin.castAdd (N' + 1 - (L + 1)) (Fin.succ ⟨i.val, hi⟩) := by
         apply Fin.ext
         simp
       have hright : Fin.cast
-          (show N = L + (N + 1 - (L + 1)) by omega) i =
-          Fin.castAdd (N + 1 - (L + 1)) ⟨i.val, hi⟩ := by
+          (show N' = L + (N' + 1 - (L + 1)) by omega) i =
+          Fin.castAdd (N' + 1 - (L + 1)) ⟨i.val, hi⟩ := by
         apply Fin.ext
         simp
       rw [hleft]
       change Fin.append (Fin.cons x r) w
-        (Fin.castAdd (N + 1 - (L + 1)) (Fin.succ ⟨i.val, hi⟩)) =
+        (Fin.castAdd (N' + 1 - (L + 1)) (Fin.succ ⟨i.val, hi⟩)) =
           Fin.append r w (Fin.cast
-            (show N = L + (N + 1 - (L + 1)) by omega) i)
+            (show N' = L + (N' + 1 - (L + 1)) by omega) i)
       rw [hright, Fin.append_left, Fin.append_left, Fin.cons_succ]
-    · let k : Fin (N + 1 - (L + 1)) := ⟨i.val - L, by omega⟩
+    · let k : Fin (N' + 1 - (L + 1)) := ⟨i.val - L, by omega⟩
       have hleft : Fin.cast
-          (show N + 1 = L + 1 + (N + 1 - (L + 1)) by omega) i.succ =
+          (show N' + 1 = L + 1 + (N' + 1 - (L + 1)) by omega) i.succ =
           Fin.natAdd (L + 1) k := by
         apply Fin.ext
         simp [k]
         omega
       have hright : Fin.cast
-          (show N = L + (N + 1 - (L + 1)) by omega) i =
+          (show N' = L + (N' + 1 - (L + 1)) by omega) i =
           Fin.natAdd L k := by
         apply Fin.ext
         simp [k]
@@ -226,18 +226,18 @@ private theorem firstSiteMatrix_mul_reducedBlockState_of_ketLeftMul_eq
       rw [hleft]
       change Fin.append (Fin.cons x r) w (Fin.natAdd (L + 1) k) =
         Fin.append r w (Fin.cast
-          (show N = L + (N + 1 - (L + 1)) by omega) i)
+          (show N' = L + (N' + 1 - (L + 1)) by omega) i)
       rw [hright, Fin.append_right, Fin.append_right]
   have hword (x : Fin d) :
       List.ofFn (Fin.append (Fin.cons x u') w ∘
-        Fin.cast (show N + 1 = L + 1 + (N + 1 - (L + 1)) by omega)) =
+        Fin.cast (show N' + 1 = L + 1 + (N' + 1 - (L + 1)) by omega)) =
         x :: List.ofFn z := by
     rw [List.ofFn_succ]
     congr 1
     exact congrArg List.ofFn (htail u' x)
   have hword' :
       List.ofFn (Fin.append (Fin.cons b v') w ∘
-        Fin.cast (show N + 1 = L + 1 + (N + 1 - (L + 1)) by omega)) =
+        Fin.cast (show N' + 1 = L + 1 + (N' + 1 - (L + 1)) by omega)) =
         b :: List.ofFn z' := by
     rw [List.ofFn_succ]
     congr 1
@@ -247,20 +247,20 @@ private theorem firstSiteMatrix_mul_reducedBlockState_of_ketLeftMul_eq
   simp only [ketLeftMul] at hPMab
   calc
     ∑ x : Fin d, P a x *
-        ((mpo M (N + 1)).trace⁻¹ *
+        ((mpo M (N' + 1)).trace⁻¹ *
           Matrix.trace (M x b * evalWord M (List.ofFn z) (List.ofFn z')))
-        = (mpo M (N + 1)).trace⁻¹ *
+        = (mpo M (N' + 1)).trace⁻¹ *
             ∑ x : Fin d, P a x *
               Matrix.trace (M x b * evalWord M (List.ofFn z) (List.ofFn z')) := by
           rw [Finset.mul_sum]
           apply Finset.sum_congr rfl
           intro x _
           ring
-    _ = (mpo M (N + 1)).trace⁻¹ *
+    _ = (mpo M (N' + 1)).trace⁻¹ *
         Matrix.trace ((∑ x : Fin d, P a x • M x b) *
           evalWord M (List.ofFn z) (List.ofFn z')) := by
       rw [sum_mul_trace_eq_trace_sum_smul]
-    _ = (mpo M (N + 1)).trace⁻¹ *
+    _ = (mpo M (N' + 1)).trace⁻¹ *
         Matrix.trace (M a b * evalWord M (List.ofFn z) (List.ofFn z')) := by
       rw [hPMab]
 
@@ -328,26 +328,26 @@ theorem blockEntropy_eq_sum_bntSectorProbability
             blockEntropy (commonWeightAbsorbedBasisMPOTensor S hWeight s)
               N L hL (hSectorMpdo s N hN)) := by
   classical
-  obtain ⟨L, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (Nat.ne_of_gt hLpos)
+  obtain ⟨L', rfl⟩ := Nat.exists_eq_succ_of_ne_zero (Nat.ne_of_gt hLpos)
   let K : (s : Fin S.basisCount) → MPOTensor d (S.basisDim s) :=
     fun s ↦ commonWeightAbsorbedBasisMPOTensor S hWeight s
   let p : Fin S.basisCount → ℝ := fun s ↦
     bntSectorProbability M S hWeight N hN hMtrace hSectorTrace s
   let ρ : (s : Fin S.basisCount) →
-      Matrix (Fin (L + 1) → Fin d) (Fin (L + 1) → Fin d) ℂ :=
-    fun s ↦ reducedBlockState (K s) N (L + 1) hL
+      Matrix (Fin (L' + 1) → Fin d) (Fin (L' + 1) → Fin d) ℂ :=
+    fun s ↦ reducedBlockState (K s) N (L' + 1) hL
   let Q : Fin S.basisCount →
-      Matrix (Fin (L + 1) → Fin d) (Fin (L + 1) → Fin d) ℂ :=
-    fun s ↦ firstSiteMatrix (bntSectorProjection hC hρ₃ hη hR s) L
+      Matrix (Fin (L' + 1) → Fin d) (Fin (L' + 1) → Fin d) ℂ :=
+    fun s ↦ firstSiteMatrix (bntSectorProjection hC hρ₃ hη hR s) L'
   have hp : ∀ s, 0 < p s := fun s ↦
     bntSectorProbability_pos M S hWeight hN hMtrace hSectorTrace s
   have hρpos : ∀ s, (ρ s).PosSemidef := fun s ↦
-    reducedBlockState_posSemidef (K s) N (L + 1) hL (hSectorMpdo s N hN)
+    reducedBlockState_posSemidef (K s) N (L' + 1) hL (hSectorMpdo s N hN)
   have hρtrace : ∀ s, Matrix.trace (ρ s) = 1 := fun s ↦
-    reducedBlockState_trace (K s) N (L + 1) hL (ne_of_gt (hSectorTrace s))
+    reducedBlockState_trace (K s) N (L' + 1) hL (ne_of_gt (hSectorTrace s))
   have hQherm : ∀ s, (Q s).IsHermitian := fun s ↦
     firstSiteMatrix_isHermitian
-      (bntSectorProjection_isOrthogonal hC hρ₃ hη hR s).1 L
+      (bntSectorProjection_isOrthogonal hC hρ₃ hη hR s).1 L'
   have hQρ : ∀ s, Q s * ρ s = ρ s := fun s ↦
     firstSiteMatrix_mul_reducedBlockState_of_ketLeftMul_eq
       (K s) (bntSectorProjection hC hρ₃ hη hR s)
@@ -358,26 +358,26 @@ theorem blockEntropy_eq_sum_bntSectorProbability
       (hQherm s) (hQρ s)
   have hQorth : ∀ s t, s ≠ t → Q s * Q t = 0 := by
     intro s t hst
-    change firstSiteMatrix (bntSectorProjection hC hρ₃ hη hR s) L *
-      firstSiteMatrix (bntSectorProjection hC hρ₃ hη hR t) L = 0
+    change firstSiteMatrix (bntSectorProjection hC hρ₃ hη hR s) L' *
+      firstSiteMatrix (bntSectorProjection hC hρ₃ hη hR t) L' = 0
     rw [firstSiteMatrix_mul_firstSiteMatrix,
       bntSectorProjection_mul_eq_zero hC hρ₃ hη hR hst]
     ext u v
     simp [firstSiteMatrix]
-  have hsum : reducedBlockState M N (L + 1) hL =
+  have hsum : reducedBlockState M N (L' + 1) hL =
       ∑ s, (p s : ℂ) • ρ s := by
     exact reducedBlockState_eq_sum_bntSectorProbability_smul
       M S hM hWeight hN (by omega) hL hMtrace hSectorTrace
   have hadd := vonNeumannEntropy_eq_sum_of_pairwise_annihilating_supports
-    (reducedBlockState M N (L + 1) hL)
-    (reducedBlockState_isHermitian M N (L + 1) hL (hMpdo N hN))
+    (reducedBlockState M N (L' + 1) hL)
+    (reducedBlockState_isHermitian M N (L' + 1) hL (hMpdo N hN))
     (fun s ↦ (p s : ℂ) • ρ s) Q
     (fun s ↦ ((hρpos s).smul (a := (p s : ℂ))
       (by exact_mod_cast (hp s).le)).isHermitian)
     hsum (fun s ↦ ⟨by rw [Matrix.mul_smul, hQρ],
       by rw [Matrix.smul_mul, hρQ]⟩) hQorth
   calc
-    blockEntropy M N (L + 1) hL (hMpdo N hN) =
+    blockEntropy M N (L' + 1) hL (hMpdo N hN) =
         ∑ s, vonNeumannEntropy ((p s : ℂ) • ρ s)
           (((hρpos s).smul (a := (p s : ℂ))
             (by exact_mod_cast (hp s).le)).isHermitian) := hadd


### PR DESCRIPTION
## Motivation

The exact-head post-merge review of #4118 identified two proof-body predecessor variables that shadowed the corresponding theorem binders:

- https://github.com/LionSR/TNLean/pull/4118#discussion_r3607067064
- https://github.com/LionSR/TNLean/pull/4118#discussion_r3607067158

## Description

Use fresh names `N′` and `L′` for the predecessor witnesses and rename only their dependent proof-body references. The theorem statements and mathematical argument are unchanged.

## Testing

- `lake build TNLean.MPS.MPDO.BNTSectorAreaLaw`
- `lake env lean TNLean/MPS/MPDO/BNTSectorAreaLaw.lean`
- `lake build` (9536 jobs)
- `python3 scripts/check_oversized_lean_files.py --root .`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check`
- proof-integrity token scan on the changed file

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only renames with identical types and proof structure; no API or runtime behavior changes.
> 
> **Overview**
> Fixes **variable shadowing** in two proof bodies in `BNTSectorAreaLaw.lean`, with no change to theorem statements or the math.
> 
> In **`firstSiteMatrix_mul_reducedBlockState_of_ketLeftMul_eq`**, the `obtain` predecessor for `N ≠ 0` is now **`N′`** instead of reusing **`N`**, and every dependent cast/`mpo` reference in that proof follows **`N′`**.
> 
> In **`blockEntropy_eq_sum_bntSectorProbability`**, the successor witness from **`hLpos`** is **`L′`** instead of **`L`**, and local definitions (`ρ`, `Q`, `blockEntropy` calls, etc.) use **`L′ + 1`** and **`L′`** for the first-site matrix index.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2966db405ba47bbe7c896b940ad54115ef7484c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->