### PR TITLE
feat(MPS/MPDO): generate the vertical BNT sector algebra

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -442,6 +442,7 @@ import TNLean.MPS.MPDO.VerticalSectorRetractions
 import TNLean.MPS.MPDO.VerticalBoundaryContraction
 import TNLean.MPS.MPDO.VerticalMapTransport
 import TNLean.MPS.MPDO.VerticalSectorCoordinates
+import TNLean.MPS.MPDO.VerticalSectorGeneration
 import TNLean.MPS.MPDO.PRFP
 import TNLean.MPS.MPDO.LocalPurificationRFP
 import TNLean.MPS.MPDO.SimpleLocalStructure

--- a/TNLean/MPS/MPDO/VerticalSectorGeneration.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorGeneration.lean
@@ -1,0 +1,240 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.SourceBNTBlocking
+import TNLean.MPS.MPDO.VerticalSectorCoordinates
+
+/-!
+# Generation of vertical BNT sector algebras
+
+The proof of the general MPDO renormalization fixed-point theorem uses the
+fact that finite products of the weighted vertical bond contractions span the
+full direct product of the BNT matrix algebras.  This file derives that claim
+from simultaneous word-tuple span of the vertical BNT representatives.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Appendix C.4, lines 1980--1990.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+noncomputable section
+
+namespace MPSTensor
+
+/-- A matrix unit in the horizontal bond algebra selects the corresponding
+letter of a vertically viewed tensor under bond contraction.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1975--1984. -/
+@[simp]
+theorem contractBondMatrix_single_transpose
+    {D n : ℕ} (A : MPSTensor (D * D) n) (a b : Fin D) :
+    contractBondMatrix A (Matrix.single b a 1) =
+      A (finProdFinEquiv (a, b)) := by
+  rw [contractBondMatrix_apply, ← finProdFinEquiv.sum_comp]
+  classical
+  rw [Fintype.sum_eq_single (a, b)]
+  · simp
+  · intro x hx
+    simp only [Matrix.single_apply, ite_smul, one_smul, zero_smul]
+    rw [if_neg]
+    intro h
+    apply hx
+    calc
+      x = ((finProdFinEquiv x).divNat, (finProdFinEquiv x).modNat) := by
+        apply finProdFinEquiv.injective
+        exact (finProdFinEquiv.apply_symm_apply (finProdFinEquiv x)).symm
+      _ = (a, b) := Prod.ext h.2.symm h.1.symm
+
+/-- The preceding matrix-unit identity expressed directly in the encoded
+product coordinate. -/
+@[simp]
+theorem contractBondMatrix_single_mod_div
+    {D n : ℕ} (A : MPSTensor (D * D) n) (ab : Fin (D * D)) :
+    contractBondMatrix A (Matrix.single ab.modNat ab.divNat 1) = A ab := by
+  rw [contractBondMatrix_single_transpose]
+  congr 1
+  exact finProdFinEquiv.apply_symm_apply ab
+
+end MPSTensor
+
+namespace MPOTensor
+
+/-- The direct-product sector operator
+`α ↦ m α • M_α(X)` obtained by contracting the common horizontal bond
+matrix `X` into every vertical BNT representative.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1975--1984. -/
+def weightedVerticalBondContraction
+    {g D : ℕ} {dim : Fin g → ℕ}
+    (m : Fin g → ℂ)
+    (A : (α : Fin g) → MPSTensor (D * D) (dim α))
+    (X : Matrix (Fin D) (Fin D) ℂ) : VerticalSectorAlgebra dim :=
+  fun α => m α • MPSTensor.contractBondMatrix (A α) X
+
+/-- A length-`L` product of weighted vertical bond contractions, with the
+matrix product taken independently in every BNT sector.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1980--1990. -/
+def weightedVerticalBondContractionProduct
+    {g D L : ℕ} {dim : Fin g → ℕ}
+    (m : Fin g → ℂ)
+    (A : (α : Fin g) → MPSTensor (D * D) (dim α))
+    (X : Fin L → Matrix (Fin D) (Fin D) ℂ) : VerticalSectorAlgebra dim :=
+  fun α => (List.ofFn fun t => weightedVerticalBondContraction m A (X t) α).prod
+
+/-- Length-`L` products of the weighted vertical bond contractions span the
+full direct product of the BNT matrix algebras.
+
+This is the equation `C_L(V) = 𝒜₁` in the proof of the general MPDO
+renormalization fixed-point theorem.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1980--1990. -/
+def WeightedVerticalBondContractionProductSpanTop
+    {g D : ℕ} {dim : Fin g → ℕ}
+    (m : Fin g → ℂ)
+    (A : (α : Fin g) → MPSTensor (D * D) (dim α))
+    (L : ℕ) : Prop :=
+  Submodule.span ℂ
+    (Set.range (weightedVerticalBondContractionProduct (L := L) m A)) = ⊤
+
+/-- Sectorwise multiplication by nonzero scalars is a linear equivalence of
+the direct product of the BNT matrix algebras. -/
+def verticalSectorScaleEquiv
+    {g : ℕ} {dim : Fin g → ℕ}
+    (c : Fin g → ℂ) (hc : ∀ α, c α ≠ 0) :
+    VerticalSectorAlgebra dim ≃ₗ[ℂ] VerticalSectorAlgebra dim where
+  toFun X := fun α => c α • X α
+  invFun X := fun α => (c α)⁻¹ • X α
+  left_inv X := by
+    funext α
+    simp [smul_smul, hc α]
+  right_inv X := by
+    funext α
+    simp [smul_smul, hc α]
+  map_add' X Y := by
+    funext α
+    exact smul_add (c α) (X α) (Y α)
+  map_smul' a X := by
+    funext α
+    change c α • (a • X α) = a • (c α • X α)
+    rw [smul_smul, smul_smul, mul_comm]
+
+/-- Products of weighted contractions against matrix units are the
+corresponding simultaneous word tuples, scaled in sector `α` by `(m α)^L`.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1980--1990. -/
+theorem weightedVerticalBondContractionProduct_single
+    {g D L : ℕ} {dim : Fin g → ℕ}
+    (m : Fin g → ℂ)
+    (A : (α : Fin g) → MPSTensor (D * D) (dim α))
+    (w : Fin L → Fin (D * D)) :
+    weightedVerticalBondContractionProduct m A
+        (fun t => Matrix.single (w t).modNat (w t).divNat 1) =
+      fun α => (m α) ^ L • MPSTensor.wordTuple A L w α := by
+  induction L with
+  | zero =>
+    funext α
+    simp [weightedVerticalBondContractionProduct, MPSTensor.wordTuple]
+  | succ L ih =>
+    funext α
+    have hih := congrFun (ih (w ∘ Fin.succ)) α
+    simp only [weightedVerticalBondContractionProduct, Function.comp_apply] at hih
+    simp only [weightedVerticalBondContractionProduct, List.ofFn_succ,
+      List.prod_cons]
+    rw [hih]
+    simp only [weightedVerticalBondContraction,
+      MPSTensor.contractBondMatrix_single_mod_div, MPSTensor.wordTuple]
+    rw [List.ofFn_succ, MPSTensor.evalWord_cons]
+    rw [Matrix.smul_mul, Matrix.mul_smul, smul_smul]
+    simp only [pow_succ]
+    rw [mul_comm]
+    simp only [Function.comp_def]
+
+/-- A full simultaneous word-tuple span implies that length-`L` products of
+the weighted vertical bond contractions span the full sector algebra, provided
+that every sector weight is nonzero.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1980--1990. -/
+theorem weightedVerticalBondContractionProductSpanTop_of_wordTupleSpanTop
+    {g D L : ℕ} {dim : Fin g → ℕ}
+    (m : Fin g → ℂ)
+    (A : (α : Fin g) → MPSTensor (D * D) (dim α))
+    (hm : ∀ α, m α ≠ 0)
+    (hSpan : MPSTensor.WordTupleSpanTop A L) :
+    WeightedVerticalBondContractionProductSpanTop m A L := by
+  classical
+  let e := verticalSectorScaleEquiv (dim := dim) (fun α => (m α) ^ L)
+    (fun α => pow_ne_zero L (hm α))
+  have hScaledSpan :
+      Submodule.span ℂ
+          (Set.range (fun w α => (m α) ^ L • MPSTensor.wordTuple A L w α)) =
+        ⊤ := by
+    change Submodule.span ℂ (Set.range (e ∘ MPSTensor.wordTuple A L)) = ⊤
+    calc
+      _ = (Submodule.span ℂ (Set.range (MPSTensor.wordTuple A L))).map
+          e.toLinearMap := by
+        simpa only [Set.range_comp, LinearEquiv.coe_coe] using
+          (Submodule.map_span e.toLinearMap
+            (Set.range (MPSTensor.wordTuple A L))).symm
+      _ = ⊤ := by
+        rw [hSpan, Submodule.map_top, LinearEquiv.range]
+  unfold WeightedVerticalBondContractionProductSpanTop
+  apply top_unique
+  rw [← hScaledSpan]
+  apply Submodule.span_mono
+  rintro _ ⟨w, rfl⟩
+  refine ⟨fun t => Matrix.single (w t).modNat (w t).divNat 1, ?_⟩
+  exact weightedVerticalBondContractionProduct_single m A w
+
+/-- A CPSV basis of normal tensors, with nonzero sector weights, admits one
+positive length at which the weighted vertical bond contractions generate the
+full direct product of its matrix algebras.
+
+Source: arXiv:1606.00608, BNT definition at lines 271--274 and Appendix C.4,
+lines 1980--1990. -/
+theorem exists_positive_weightedVerticalBondContractionProductSpanTop_of_bnt
+    {g D E : ℕ} {dim : Fin g → ℕ}
+    {A₀ : MPSTensor (D * D) E}
+    {A : (α : Fin g) → MPSTensor (D * D) (dim α)}
+    (hBNT : MPSTensor.IsCPSVBasisOfNormalTensors A₀
+      (fun α => ⟨dim α, A α⟩))
+    (m : Fin g → ℂ) (hm : ∀ α, m α ≠ 0) :
+    ∃ L : ℕ, 0 < L ∧
+      WeightedVerticalBondContractionProductSpanTop m A L := by
+  obtain ⟨L, hL, hSpan⟩ := hBNT.exists_positive_wordTupleSpanTop
+  exact ⟨L, hL,
+    weightedVerticalBondContractionProductSpanTop_of_wordTupleSpanTop
+      m A hm hSpan⟩
+
+/-- For positive multiplicity weights, a vertical CPSV basis of normal
+tensors admits one positive length at which its bond contractions generate the
+full sector algebra.  The sector scalar is the trace of the corresponding
+multiplicity matrix.
+
+This is the claim `C_L(V) = 𝒜₁` used in the inverse-map argument for the
+general MPDO renormalization fixed-point theorem.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1955--1971 and 1980--1990. -/
+theorem exists_positive_verticalMultiplicityTraceBondContractionProductSpanTop_of_bnt
+    {g D E : ℕ} {dim mult : Fin g → ℕ}
+    {A₀ : MPSTensor (D * D) E}
+    {A : (α : Fin g) → MPSTensor (D * D) (dim α)}
+    (hBNT : MPSTensor.IsCPSVBasisOfNormalTensors A₀
+      (fun α => ⟨dim α, A α⟩))
+    (weight : (α : Fin g) → Fin (mult α) → ℂ)
+    (hMult : ∀ α, 0 < mult α)
+    (hWeight : ∀ α q, (0 : ℂ) < weight α q) :
+    ∃ L : ℕ, 0 < L ∧
+      WeightedVerticalBondContractionProductSpanTop
+        (verticalMultiplicityTrace weight) A L := by
+  apply exists_positive_weightedVerticalBondContractionProductSpanTop_of_bnt
+    hBNT (verticalMultiplicityTrace weight)
+  intro α
+  exact verticalMultiplicityTrace_ne_zero α (hMult α) (hWeight α)
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/VerticalSectorGeneration.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorGeneration.lean
@@ -64,8 +64,8 @@ end MPSTensor
 
 namespace MPOTensor
 
-/-- The direct-product sector operator
-`α ↦ m α • M_α(X)` obtained by contracting the common horizontal bond
+/-- The direct-product sector operator whose `α`-th sector is the scalar
+multiple $m_α M_α(X)$ obtained by contracting the common horizontal bond
 matrix `X` into every vertical BNT representative.
 
 Source: arXiv:1606.00608, Appendix C.4, lines 1975--1984. -/
@@ -125,7 +125,7 @@ def verticalSectorScaleEquiv
     rw [smul_smul, smul_smul, mul_comm]
 
 /-- Products of weighted contractions against matrix units are the
-corresponding simultaneous word tuples, scaled in sector `α` by `(m α)^L`.
+corresponding simultaneous word tuples, scaled in sector $α$ by $m_α^L$.
 
 Source: arXiv:1606.00608, Appendix C.4, lines 1980--1990. -/
 theorem weightedVerticalBondContractionProduct_single

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -424,8 +424,8 @@ physical indices, as in
     \]
     the matrix-unit identity and simultaneous word spanning give
     \[
-      \spn_\C\{V(X_1)\cdots V(X_L)\}
-      =\varphi_L\!\left(\spn_\C\{(M_\alpha^w)_\alpha:w\}\right)
+      \spn_{\C}\{V(X_1)\cdots V(X_L)\}
+      =\varphi_L\!\left(\spn_{\C}\{(M_\alpha^w)_\alpha:w\}\right)
       =\varphi_L\!\left(\prod_\alpha M_{d_\alpha}\right)
       =\prod_\alpha M_{d_\alpha}.
     \]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -314,14 +314,73 @@ physical indices, as in
     \]
 \end{definition}
 
-\begin{theorem}[Vertical bond contractions generate the sector algebra]
-    \label{thm:mpdo_vertical_bond_contractions_generate_sector_algebra}
+\begin{lemma}[Contraction against a matrix unit]
+    \label{lem:mpdo_vertical_bond_contraction_matrix_unit}
     \lean{MPSTensor.contractBondMatrix_single_transpose}
+    \leanok
+    \uses{def:mpdo_vertical_bond_matrix_contraction}
+    Let $M=(M_{ab})_{a,b=0}^{D-1}$ be a matrix-product tensor whose physical
+    index is identified with the ordered pair $(a,b)$.  Then
+    \[
+        M(E_{ba})=M_{ab}.
+    \]
+\end{lemma}
+
+\begin{lemma}[Contraction in the encoded product coordinate]
+    \label{lem:mpdo_vertical_bond_contraction_encoded_matrix_unit}
     \lean{MPSTensor.contractBondMatrix_single_mod_div}
+    \leanok
+    \uses{lem:mpdo_vertical_bond_contraction_matrix_unit}
+    If $r\in\{0,\ldots,D^2-1\}$ encodes the ordered pair
+    $(\lfloor r/D\rfloor,r\bmod D)$, then
+    \[
+        M\!\left(E_{(r\bmod D),\lfloor r/D\rfloor}\right)=M_r.
+    \]
+\end{lemma}
+
+\begin{definition}[Sectorwise scaling equivalence]
+    \label{def:mpdo_vertical_sector_scaling_equivalence}
     \lean{MPOTensor.verticalSectorScaleEquiv}
+    \leanok
+    For scalars $c_\alpha\ne0$, the map
+    \[
+        \varphi_c\colon\prod_\alpha M_{d_\alpha}\longrightarrow
+          \prod_\alpha M_{d_\alpha},\qquad
+        (X_\alpha)_\alpha\longmapsto(c_\alpha X_\alpha)_\alpha
+    \]
+    is a linear equivalence.
+\end{definition}
+
+\begin{lemma}[Weighted contraction of matrix-unit words]
+    \label{lem:mpdo_weighted_contraction_matrix_unit_words}
     \lean{MPOTensor.weightedVerticalBondContractionProduct_single}
+    \leanok
+    \uses{def:mpdo_weighted_vertical_contraction_products,
+        lem:mpdo_vertical_bond_contraction_encoded_matrix_unit}
+    For a word $w=((a_1,b_1),\ldots,(a_L,b_L))$,
+    \[
+        V(E_{b_1a_1})\cdots V(E_{b_La_L})
+        =\bigoplus_\alpha m_\alpha^L M_\alpha^w.
+    \]
+\end{lemma}
+
+\begin{lemma}[Transfer of simultaneous word spanning]
+    \label{lem:mpdo_weighted_contraction_span_transfer}
     \lean{MPOTensor.%
         weightedVerticalBondContractionProductSpanTop_of_wordTupleSpanTop}
+    \leanok
+    \uses{def:mpdo_vertical_sector_scaling_equivalence,
+        lem:mpdo_weighted_contraction_matrix_unit_words}
+    Fix $L\geq0$ and suppose that every $m_\alpha$ is nonzero.  If the
+    simultaneous word tuples $(M_\alpha^w)_\alpha$ of length $L$ span
+    $\prod_\alpha M_{d_\alpha}$, then
+    \[
+        C_L(V)=\prod_\alpha M_{d_\alpha}.
+    \]
+\end{lemma}
+
+\begin{theorem}[Vertical bond contractions generate the sector algebra]
+    \label{thm:mpdo_vertical_bond_contractions_generate_sector_algebra}
     \lean{MPOTensor.%
         exists_positive_weightedVerticalBondContractionProductSpanTop_of_bnt}
     \lean{MPOTensor.%
@@ -341,6 +400,8 @@ physical indices, as in
 
 \begin{proof}\leanok
     \uses{lem:mpdo_vertical_sector_retraction,
+        lem:mpdo_weighted_contraction_matrix_unit_words,
+        lem:mpdo_weighted_contraction_span_transfer,
         thm:cpsv_bnt_blocked_simultaneous_span}
     For the matrix unit $E_{ba}\in M_D$, contraction of the horizontal bond
     gives $M_\alpha(E_{ba})=M_{\alpha,ab}$.  Hence, for a word
@@ -350,11 +411,24 @@ physical indices, as in
         =\bigoplus_\alpha m_\alpha^L M_\alpha^w.
     \]
     Choose $L>0$ for which the simultaneous word tuples
-    $(M_\alpha^w)_\alpha$ span $\prod_\alpha M_{d_\alpha}$.  Positivity gives
-    $m_\alpha\ne0$ for every $\alpha$, so multiplication of the $\alpha$-th
-    sector by $m_\alpha^L$ is an invertible linear transformation of the
-    product algebra.  The displayed contraction products therefore span the
-    same product algebra.
+    $(M_\alpha^w)_\alpha$ span $\prod_\alpha M_{d_\alpha}$.  Since every
+    multiplicity space is nonzero and every diagonal entry is positive,
+    \[
+        m_\alpha
+        =\sum_{q=0}^{\operatorname{mult}(\alpha)-1}\mu_{\alpha,q}>0.
+    \]
+    Thus $m_\alpha^L\ne0$.  For the linear equivalence
+    \[
+        \varphi_L((X_\alpha)_\alpha)
+        =(m_\alpha^L X_\alpha)_\alpha,
+    \]
+    the matrix-unit identity and simultaneous word spanning give
+    \[
+      \spn_\C\{V(X_1)\cdots V(X_L)\}
+      =\varphi_L\!\left(\spn_\C\{(M_\alpha^w)_\alpha:w\}\right)
+      =\varphi_L\!\left(\prod_\alpha M_{d_\alpha}\right)
+      =\prod_\alpha M_{d_\alpha}.
+    \]
 \end{proof}
 
 \begin{definition}[Retained coordinates for the vertical-sector algebra]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -290,6 +290,73 @@ physical indices, as in
     \]
 \end{proof}
 
+\begin{definition}[Products of weighted vertical contractions]
+    \label{def:mpdo_weighted_vertical_contraction_products}
+    \lean{MPOTensor.weightedVerticalBondContraction}
+    \lean{MPOTensor.weightedVerticalBondContractionProduct}
+    \lean{MPOTensor.WeightedVerticalBondContractionProductSpanTop}
+    \leanok
+    \uses{def:mpdo_normalized_vertical_sector_maps,
+        def:mpdo_vertical_bond_matrix_contraction}
+    For vertical BNT tensors $M_\alpha$ with simple matrix algebras
+    $M_{d_\alpha}$, define
+    \[
+        V(X)=\bigoplus_\alpha m_\alpha M_\alpha(X),
+        \qquad
+        M_\alpha(X)=\sum_{a,b}X_{ba}M_{\alpha,ab}.
+    \]
+    For each $L\geq0$, let
+    \[
+        C_L(V)=\spn_{\C}\left\{
+          V(X_1)\cdots V(X_L):X_1,\ldots,X_L\in M_D
+        \right\}
+        \subseteq \prod_\alpha M_{d_\alpha}.
+    \]
+\end{definition}
+
+\begin{theorem}[Vertical bond contractions generate the sector algebra]
+    \label{thm:mpdo_vertical_bond_contractions_generate_sector_algebra}
+    \lean{MPSTensor.contractBondMatrix_single_transpose}
+    \lean{MPSTensor.contractBondMatrix_single_mod_div}
+    \lean{MPOTensor.verticalSectorScaleEquiv}
+    \lean{MPOTensor.weightedVerticalBondContractionProduct_single}
+    \lean{MPOTensor.%
+        weightedVerticalBondContractionProductSpanTop_of_wordTupleSpanTop}
+    \lean{MPOTensor.%
+        exists_positive_weightedVerticalBondContractionProductSpanTop_of_bnt}
+    \lean{MPOTensor.%
+        exists_positive_verticalMultiplicityTraceBondContractionProductSpanTop_of_bnt}
+    \leanok
+    \uses{def:bnt_cpsv, def:mpdo_weighted_vertical_contraction_products,
+        thm:cpsv_bnt_blocked_simultaneous_span}
+    Suppose that $(M_\alpha)_\alpha$ is a basis of normal tensors, every
+    multiplicity space is nonzero, and every diagonal entry of $\mu_\alpha$
+    is positive.  Then there is a positive integer $L$ such that
+    \[
+        C_L(V)=\prod_\alpha M_{d_\alpha}=: \mathcal A_1.
+    \]
+    This is the spanning assertion used in
+    \cite[Appendix~C.4, lines~1980--1990]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:mpdo_vertical_sector_retraction,
+        thm:cpsv_bnt_blocked_simultaneous_span}
+    For the matrix unit $E_{ba}\in M_D$, contraction of the horizontal bond
+    gives $M_\alpha(E_{ba})=M_{\alpha,ab}$.  Hence, for a word
+    $w=((a_1,b_1),\ldots,(a_L,b_L))$,
+    \[
+        V(E_{b_1a_1})\cdots V(E_{b_La_L})
+        =\bigoplus_\alpha m_\alpha^L M_\alpha^w.
+    \]
+    Choose $L>0$ for which the simultaneous word tuples
+    $(M_\alpha^w)_\alpha$ span $\prod_\alpha M_{d_\alpha}$.  Positivity gives
+    $m_\alpha\ne0$ for every $\alpha$, so multiplication of the $\alpha$-th
+    sector by $m_\alpha^L$ is an invertible linear transformation of the
+    product algebra.  The displayed contraction products therefore span the
+    same product algebra.
+\end{proof}
+
 \begin{definition}[Retained coordinates for the vertical-sector algebra]
     \label{def:mpdo_retained_vertical_sector_coordinates}
     \lean{MPOTensor.verticalSectorFinEquiv}


### PR DESCRIPTION
### Motivation
- Formalize the sector-generation assertion used in arXiv:1606.00608, Appendix C.4, lines 1980--1990.
- The local source `Papers/1606.00608/MPDO-22-12-17-2.tex:1980` states: “Proposition `propblockinj` guarantees that for some `L`, `C_L(V)=A₁`.”
- Isolate this algebraic consequence before the later fixed-point and inverse-map arguments.

### Description
- Define the weighted vertical bond contraction `V(X)`, its length-`L` products, and the assertion that their span is the full direct product of sector matrix algebras.
- Prove that a transposed horizontal matrix unit selects one vertical tensor letter, so matrix-unit products are the simultaneous word tuples scaled in sector `α` by `(m α)^L`.
- Use the simultaneous word-tuple span of a CPSV basis of normal tensors and invertible sectorwise scaling to prove `C_L(V)=∏_α M_{d_α}` for some positive `L`.
- Specialize to positive multiplicity weights, where `m_α=tr(μ_α)` is nonzero, and add the corresponding blueprint statement and proof.
- This PR does not assert the later fixed-point classification, inverse identities, complete positivity, trace preservation, relabeling, or unitary conjugation conclusions. Parent tracker #3949 remains open.

### Testing
- `lake env lean TNLean/MPS/MPDO/VerticalSectorGeneration.lean`
- `lake build` (9,538 jobs)
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `git diff origin/main...HEAD --check`
- integrity and 100-character line-length scans on the new Lean file

Closes #4121

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization and blueprint sync on the MPDO proof track; no runtime, auth, or data-path changes. Risk is limited to proof maintenance if upstream BNT/word-span APIs shift.
> 
> **Overview**
> Adds **`VerticalSectorGeneration.lean`** and wires it into the library import surface, formalizing the CPSV Appendix C.4 claim that length-`L` products of weighted vertical bond contractions span the full vertical sector algebra (**`C_L(V) = 𝒜₁`**).
> 
> The new layer defines **`weightedVerticalBondContraction`**, **`weightedVerticalBondContractionProduct`**, and **`WeightedVerticalBondContractionProductSpanTop`**, proves matrix-unit bond contractions pick encoded tensor letters, and shows matrix-unit word products equal **`m_α^L`**-scaled simultaneous word tuples. **Sectorwise scaling** (`verticalSectorScaleEquiv`) transfers existing **word-tuple spanning** from a BNT basis into spanning of contraction products when all **`m_α ≠ 0`**, with existence theorems for general weights and for **`verticalMultiplicityTrace`** under positive multiplicities.
> 
> **`ch21_mpdo_rfp_blocked_rfp.tex`** gains matching definitions, lemmas, and the main generation theorem linked to the new Lean names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a88211e1f95ed04f49d97e18d9eaabd0c1a420c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->