### PR TITLE
feat(MPS/MPDO): construct orthogonal GSNNCH sectors

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -533,6 +533,7 @@ import TNLean.MPS.MPDO.BlockedCompleteZipper
 import TNLean.MPS.MPDO.CommutingForm
 import TNLean.MPS.MPDO.CommutingFormBridge
 import TNLean.MPS.MPDO.GSNNCHSectorSum
+import TNLean.MPS.MPDO.GSNNCHOrthogonalSectors
 import TNLean.MPS.MPDO.BlockedRFPConstruction
 
 -- MPS examples

--- a/TNLean/MPS/MPDO/GSNNCHOrthogonalSectors.lean
+++ b/TNLean/MPS/MPDO/GSNNCHOrthogonalSectors.lean
@@ -1,0 +1,160 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.BNTProjectorSelection
+import TNLean.MPS.MPDO.GSNNCHSectorSum
+
+/-!
+# Orthogonal sector construction of the GSNNCH form
+
+The GSNNCH form of Definition 4.8 is obtained by combining positive commuting
+bond products supported on pairwise orthogonal one-site subspaces.  The natural
+multiplicity of each sector remains outside its bond product.
+
+## Main declarations
+
+* `MPOTensor.OrthogonalCommutingSectorFamily`: orthogonally supported commuting
+  bond products for a finite family of MPO tensors.
+* `MPOTensor.OrthogonalCommutingSectorFamily.toGSNNCHData`: the corresponding
+  finite-chain GSNNCH sector decomposition.
+* `MPOTensor.hasGSNNCHForm_of_orthogonalCommutingSectorFamily`: the outer-sector
+  sum has the source GSNNCH form at every chain length at least two.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Definition 4.8 and Appendix C.2, Proposition `prop3to4`, lines 1783--1792
+-/
+
+open scoped ComplexOrder
+
+namespace MPOTensor
+
+variable {d g : ℕ} {dim : Fin g → ℕ}
+
+/-- A finite family of positive commuting bond products supported on pairwise
+orthogonal one-site subspaces.
+
+The equality in `realizes_mpo` has scalar one.  Hence the natural
+multiplicities in an outer direct sum are not absorbed into chain-length
+dependent rescalings of the bonds.
+
+Source: arXiv:1606.00608, Definition 4.8, lines 829--850, and Appendix C.2,
+Proposition `prop3to4`, lines 1783--1792. -/
+structure OrthogonalCommutingSectorFamily
+    (K : (s : Fin g) → MPOTensor d (dim s)) where
+  /-- The one-site projection of each outer sector.
+  Source: arXiv:1606.00608, lines 838--842 and 1783--1792. -/
+  projection : Fin g → Matrix (Fin d) (Fin d) ℂ
+  /-- Every outer-sector projection is orthogonal.
+  Source: arXiv:1606.00608, lines 838--842. -/
+  projection_isOrthogonal : ∀ s, IsOrthogonalProjection (projection s)
+  /-- Distinct outer sectors have orthogonal one-site spaces.
+  Source: arXiv:1606.00608, lines 838--842. -/
+  projection_orthogonal : ∀ {s t}, s ≠ t → projection s * projection t = 0
+  /-- The positive translation-invariant bond of each sector.
+  Source: arXiv:1606.00608, lines 843--850 and 1783--1792. -/
+  bondData : Fin g → TranslationInvariantBondData d
+  /-- Each bond acts on the tensor square of its one-site sector.
+  Source: arXiv:1606.00608, lines 838--850. -/
+  bond_supported : ∀ s,
+    twoSiteSectorProjection (projection s) * (bondData s).bond *
+      twoSiteSectorProjection (projection s) = (bondData s).bond
+  /-- Every sector MPO is exactly the periodic product of its translated bond.
+  Source: arXiv:1606.00608, Appendix C.2, Proposition `prop3to4`, lines
+  1783--1792. -/
+  realizes_mpo : ∀ s N (hN : 2 ≤ N),
+    mpo (K s) N = ((bondData s).toCommutingFormData hN).product
+
+namespace OrthogonalCommutingSectorFamily
+
+variable {K : (s : Fin g) → MPOTensor d (dim s)}
+
+/-- The finite-chain GSNNCH decomposition determined by orthogonally supported
+commuting sector bonds and their natural multiplicities.
+
+Source: arXiv:1606.00608, Definition 4.8, lines 829--850, and Appendix C.2,
+Proposition `prop3to4`, lines 1783--1792. -/
+noncomputable def toGSNNCHData (F : OrthogonalCommutingSectorFamily K)
+    (multiplicity : Fin g → ℕ) (N : ℕ) (hN : 2 ≤ N) : GSNNCHData d N where
+  hN := hN
+  sectorCount := g
+  multiplicity := multiplicity
+  sectorProjection := F.projection
+  sectorProjection_isOrthogonal := F.projection_isOrthogonal
+  sectorProjection_orthogonal := fun hst ↦ F.projection_orthogonal hst
+  bond := fun s ↦ (F.bondData s).bond
+  bond_pos := fun s ↦ (F.bondData s).bond_pos
+  bond_supported := F.bond_supported
+  neighboring_comm := fun s ↦
+    (F.bondData s).bond_comm hN ⟨0, by omega⟩ ⟨1, by omega⟩
+
+/-- The sector product in the induced GSNNCH decomposition is the prescribed
+commuting bond product.
+
+Source: arXiv:1606.00608, equation `rhoNCommv2`, lines 843--850. -/
+@[simp] theorem toGSNNCHData_sectorProduct
+    (F : OrthogonalCommutingSectorFamily K) (multiplicity : Fin g → ℕ)
+    (N : ℕ) (hN : 2 ≤ N) (s : Fin g) :
+    (F.toGSNNCHData multiplicity N hN).sectorProduct s =
+      ((F.bondData s).toCommutingFormData hN).product := by
+  rfl
+
+/-- The unnormalized state of the induced GSNNCH decomposition is the
+multiplicity-weighted sum of the sector MPOs.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `prop3to4`, lines
+1783--1792. -/
+theorem toGSNNCHData_unnormalizedState
+    (F : OrthogonalCommutingSectorFamily K) (multiplicity : Fin g → ℕ)
+    (N : ℕ) (hN : 2 ≤ N) :
+    (F.toGSNNCHData multiplicity N hN).unnormalizedState =
+      ∑ s : Fin g, (multiplicity s : ℂ) • mpo (K s) N := by
+  change (∑ s : Fin g, (multiplicity s : ℂ) •
+      ((F.bondData s).toCommutingFormData hN).product) =
+    ∑ s : Fin g, (multiplicity s : ℂ) • mpo (K s) N
+  apply Finset.sum_congr rfl
+  intro s _
+  rw [F.realizes_mpo s N hN]
+
+end OrthogonalCommutingSectorFamily
+
+/-- A multiplicity-weighted sum of orthogonally supported commuting sector
+products has the source GSNNCH form at every chain length at least two.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `prop3to4`, lines
+1783--1792, and Definition 4.8, lines 829--850. -/
+theorem hasGSNNCHForm_of_orthogonalCommutingSectorFamily
+    {D : ℕ} (M : MPOTensor d D) (K : (s : Fin g) → MPOTensor d (dim s))
+    (multiplicity : Fin g → ℕ) (F : OrthogonalCommutingSectorFamily K)
+    (hM : ∀ N : ℕ, 2 ≤ N →
+      mpo M N = ∑ s : Fin g, (multiplicity s : ℂ) • mpo (K s) N) :
+    HasGSNNCHForm M := by
+  intro N hN
+  refine ⟨F.toGSNNCHData multiplicity N hN, 1, by norm_num, ?_⟩
+  rw [show ((1 : ℝ) : ℂ) = 1 by norm_num, one_smul]
+  rw [F.toGSNNCHData_unnormalizedState, hM N hN]
+
+/-- Once the absorbed BNT representatives have orthogonally supported
+commuting bond products, the original tensor has the source GSNNCH form with
+the BNT copy numbers as its natural multiplicities.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `CFK` and Proposition
+`prop3to4`, lines 1660--1665 and 1783--1792. -/
+theorem hasGSNNCHForm_of_commonWeightAbsorbedBasisMPOTensor
+    {D : ℕ} (M : MPOTensor d D)
+    (S : MPSTensor.SectorDecomposition (d * d))
+    (hM : MPSTensor.SameMPV₂Pos M.toMPSTensor S.toTensor)
+    (hWeight : ∀ (s : Fin S.basisCount) (q q' : Fin (S.copies s)),
+      S.weight s q = S.weight s q')
+    (F : OrthogonalCommutingSectorFamily
+      (fun s ↦ commonWeightAbsorbedBasisMPOTensor S hWeight s)) :
+    HasGSNNCHForm M := by
+  apply hasGSNNCHForm_of_orthogonalCommutingSectorFamily M _ S.copies F
+  intro N hN
+  exact mpo_eq_sum_copies_smul_commonWeightAbsorbedBasisMPOTensor
+    M S hM hWeight (by omega)
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
@@ -151,6 +151,82 @@ Definition~\ref{def:mpdo_source_gsnnch}; the converse comparison is not used.
     multiplicity to be one, and its bond to be the given bond.
 \end{proof}
 
+\begin{definition}[Orthogonally supported commuting sector products]
+    \label{def:mpdo_orthogonal_commuting_sector_family}
+    \lean{MPOTensor.OrthogonalCommutingSectorFamily}
+    \lean{MPOTensor.OrthogonalCommutingSectorFamily.toGSNNCHData}
+    \leanok
+    \uses{def:mpdo_source_gsnnch, def:mpdo_commuting_form_data}
+    Let $\{K_x\}_{x=0}^{g-1}$ be MPO tensors on a common one-site space.
+    An orthogonally supported family of commuting sector products consists of
+    pairwise orthogonal one-site projections $P_x$ and positive two-site
+    operators $B^{(x)}$ such that
+    \[
+        (P_x\otimes P_x)B^{(x)}(P_x\otimes P_x)=B^{(x)},
+        \qquad
+        [\tau_i(B^{(x)}),\tau_j(B^{(x)})]=0,
+    \]
+    and, for every $N\geq2$,
+    \[
+        \rho^{(N)}(K_x)=\prod_{i=0}^{N-1}\tau_i(B^{(x)}).
+    \]
+    Together with natural multiplicities $n_x$, these objects determine the
+    corresponding finite-chain sector decomposition in
+    Definition~\ref{def:mpdo_source_gsnnch}.
+\end{definition}
+
+\begin{theorem}[Orthogonal commuting sector products give the GSNNCH form]
+    \label{thm:mpdo_orthogonal_commuting_sectors_gsnnch}
+    \lean{MPOTensor.OrthogonalCommutingSectorFamily.toGSNNCHData_sectorProduct}
+    \lean{MPOTensor.OrthogonalCommutingSectorFamily.toGSNNCHData_unnormalizedState}
+    \lean{MPOTensor.hasGSNNCHForm_of_orthogonalCommutingSectorFamily}
+    \leanok
+    \uses{def:mpdo_source_gsnnch,
+        def:mpdo_orthogonal_commuting_sector_family}
+    Suppose that $\{K_x\}_{x=0}^{g-1}$ has an orthogonally supported family
+    of commuting sector products and that, for every $N\geq2$,
+    \[
+        \rho^{(N)}(M)=\sum_{x=0}^{g-1}n_x\rho^{(N)}(K_x),
+        \qquad n_x\in\N.
+    \]
+    Then $M$ has the explicit GSNNCH sector form with outer sectors $x$ and
+    natural multiplicities $n_x$.
+\end{theorem}
+
+\begin{proof}\leanok
+    For each $N\geq2$, the represented unnormalized sector sum is
+    \[
+        \sum_{x=0}^{g-1}n_x
+          \prod_{i=0}^{N-1}\tau_i(B^{(x)})
+        =\sum_{x=0}^{g-1}n_x\rho^{(N)}(K_x)
+        =\rho^{(N)}(M).
+    \]
+    Thus the positive proportionality constant in
+    Definition~\ref{def:mpdo_source_gsnnch} is one.
+\end{proof}
+
+\begin{corollary}[Orthogonal BNT sector products give the GSNNCH form]
+    \label{cor:mpdo_bnt_orthogonal_commuting_sectors_gsnnch}
+    \lean{MPOTensor.hasGSNNCHForm_of_commonWeightAbsorbedBasisMPOTensor}
+    \leanok
+    \uses{thm:mpdo_orthogonal_commuting_sectors_gsnnch}
+    Suppose that the common weight has been absorbed into each BNT
+    representative $\mathcal K_x$, and that these representatives have
+    orthogonally supported commuting sector products.  Then
+    \[
+        \rho^{(N)}(M)=\sum_x n_x\rho^{(N)}(\mathcal K_x)
+    \]
+    gives the explicit GSNNCH form with the BNT copy numbers $n_x$ as its
+    natural multiplicities.
+\end{corollary}
+
+\begin{proof}\leanok
+    Apply
+    Theorem~\ref{thm:mpdo_orthogonal_commuting_sectors_gsnnch} to the
+    positive-length BNT decomposition.  Its coefficients are exactly the
+    copy numbers $n_x$ after the common weights have been absorbed.
+\end{proof}
+
 \begin{lemma}[Cyclic-shift transport of an embedded local operator]
     \label{lem:mpdo_gsnnch_shift_transport}
     \lean{MPOTensor.embedLocalOperator_submatrix_rotateConfig}

--- a/docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex
+++ b/docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex
@@ -90,24 +90,30 @@ of the represented finite-chain sector sum from the stored sector data---is
 complete.  Appendix C.2 has also been followed through the BNT projector
 selection formula: the natural multiplicities are retained, positive-length
 compression proves that each absorbed BNT representative generates MPDOs,
-and the canonical block equation proves ZCL for each representative.
+the direct-sum entropy identity proves SAL for each representative, and the
+canonical block equation proves ZCL for each representative.
 \footnote{\raggedright Formal declarations:
 {\scriptsize\leanid{MPOTensor.exists_bntProjectorSelection_positiveLength_of_sameMPV₂Pos_isSAL}},
 {\scriptsize\leanid{MPOTensor.commonWeightAbsorbedBasisMPOTensor_isMPDO_of_sameMPV₂Pos_isSAL}},
+{\scriptsize\leanid{MPOTensor.commonWeightAbsorbedBasisMPOTensor_isSAL_of_sameMPV₂Pos}},
 and
 {\scriptsize\leanid{MPOTensor.commonWeightAbsorbedBasisMPOTensor_isSourceZCL}}.}
-The remaining comparison and assembly work has two parts:
+The general outer-sector construction is also complete: pairwise orthogonal
+one-site projections, supported positive commuting bonds, and the exact
+sector product identities give the source GSNNCH form with the prescribed
+natural multiplicities.
+\footnote{\raggedright Formal declaration:
+{\scriptsize\leanid{MPOTensor.hasGSNNCHForm_of_orthogonalCommutingSectorFamily}}.}
+The remaining comparison has two parts:
 
 \begin{enumerate}
-  \item prove SAL for every absorbed BNT representative from the direct-sum
-        entropy identity and strong subadditivity, then
-        apply the injective one-sector theorem to those representatives and
-        assemble the outer GSNNCH sectors with their natural multiplicities;
+  \item apply the injective commuting-product theorem inside the range of each
+        BNT projector and transport its positive bond back to the ambient
+        one-site space, proving
+        $(P_j\otimes P_j)B^{(j)}(P_j\otimes P_j)=B^{(j)}$;
   \item determine whether the reverse comparison with a single bond is needed
         in the simple-MPDO equivalence, and prove it only in that form.
 \end{enumerate}
-\footnote{The direct-sum entropy identity is labelled
-\texttt{entropiesj} in the source.}
 
 The local Markov labels in Appendix C.2 belong inside one injective BNT
 component.  They are not the outer labels $x$ of Definition~4.8 and must not
@@ -121,9 +127,10 @@ pairwise commuting translates, and the single-bond presentation is proved to
 give the one-sector case; every injective tensor satisfying the saturated
 area law is proved GSNNCH through a one-sector witness.  For a general simple
 tensor, the BNT projectors, their positive-length compression formula, and the
-sectorwise MPDO and ZCL conclusions are formalized.  The open gap is the
-sectorwise SAL argument and the ensuing assembly of the outer sectors and
-multiplicities, together with any reverse comparison actually needed by that
-argument.
+sectorwise MPDO, SAL, and ZCL conclusions are formalized.  The abstract
+construction of the outer sector sum with its natural multiplicities is
+formalized.  The open gap is the support-preserving application of the
+injective commuting-product theorem within each BNT projector range, together
+with any reverse comparison actually needed by the simple-MPDO equivalence.
 
 \end{document}


### PR DESCRIPTION
## Summary

- define finite families of positive commuting bond products supported on pairwise orthogonal one-site sectors
- construct the corresponding GSNNCH sector decomposition with prescribed natural multiplicities
- prove that an exact multiplicity-weighted sector sum has the source GSNNCH form
- specialize the construction to the common-weight-absorbed BNT decomposition
- update the blueprint and the source-faithfulness note

## Mathematical source

This formalizes the outer direct-sum step in arXiv:1606.00608, Appendix C.2, Proposition prop3to4, lines 1783–1792, together with Definition 4.8, lines 829–850.

The construction keeps each natural multiplicity outside the sector bond product. It concerns only chain lengths N ≥ 2, so it introduces no empty-chain convention. The remaining source step is to apply the injective commuting-product theorem inside each BNT projector range and transport the resulting positive bond back to the ambient one-site space while proving its two-site support equation. This PR does not assume that equation for the source tensor and does not close #4003.

## Validation

- lake build TNLean.MPS.MPDO.GSNNCHOrthogonalSectors TNLean
- lake exe lint_style
- Python line-length, reader-prose, and blueprint synchronization checks
- leanblueprint checkdecls
- git diff --check
- proof-integrity scan of the new Lean file
- kernel axiom audit: only propext, Classical.choice, and Quot.sound

Advances #4003.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New Lean proofs and blueprint/docs only; no runtime, auth, or data-path changes. Remaining GSNNCH closure still depends on future BNT-range bond construction.
> 
> **Overview**
> Adds **`MPOTensor.OrthogonalCommutingSectorFamily`** and maps it to **`GSNNCHData`** via **`toGSNNCHData`**, keeping natural multiplicities outside each sector’s commuting bond product. Proves that an exact multiplicity-weighted sum of sector MPOs has **`HasGSNNCHForm`**, and specializes this to common-weight-absorbed BNT representatives when copy-weighted **`mpo`** decomposition holds.
> 
> Blueprint chapter 21 gains the orthogonal-sector definition, the GSNNCH assembly theorem, and the BNT corollary. The CPSV16 gap note is updated: outer-sector construction is marked done; the remaining work is applying the injective commuting-product theorem inside each BNT projector range (with two-site support), not sectorwise SAL assembly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5ed034a9d4770d6204a790f3d6ac9a4ecdb9a05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->