### PR TITLE
feat(MPS/MPDO): fix vertical contraction generators

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -442,6 +442,7 @@ import TNLean.MPS.MPDO.VerticalSectorRetractions
 import TNLean.MPS.MPDO.VerticalBoundaryContraction
 import TNLean.MPS.MPDO.VerticalMapTransport
 import TNLean.MPS.MPDO.VerticalSectorCoordinates
+import TNLean.MPS.MPDO.VerticalSectorFixedGenerators
 import TNLean.MPS.MPDO.VerticalSectorGeneration
 import TNLean.MPS.MPDO.PRFP
 import TNLean.MPS.MPDO.LocalPurificationRFP

--- a/TNLean/MPS/MPDO/VerticalSectorFixedGenerators.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorFixedGenerators.lean
@@ -1,0 +1,144 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.VerticalSectorCoordinates
+
+/-!
+# Fixed generators of the transported vertical-sector composites
+
+The transported refinement map sends each multiplicity-trace-scaled
+one-site vertical BNT bond contraction to its two-site counterpart, and the
+transported coarse-graining map sends it back.  Thus these contractions are
+fixed by the coarse-graining--refinement composite.  The reverse composite
+fixes the two-site contractions in the same way.
+
+These conclusions concern only the two contraction families.  They do not
+assert that either composite is the identity on the full sector algebra.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Appendix C.4, lines 1974--1980.
+-/
+
+open scoped Matrix ComplexOrder
+
+noncomputable section
+
+namespace MPOTensor
+
+/-- Every multiplicity-trace-scaled one-site vertical BNT bond contraction is
+fixed by the transported coarse-graining--refinement composite.
+
+This proves only the inclusion of the one-site contraction family in the
+fixed-point space.  The conclusion that the composite is the identity uses
+the later fixed-point structure argument of Appendix C.4, lines 1980--1993.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1974--1980. -/
+theorem transportedVerticalSectorS_comp_T_fixed_contractBondMatrix_trace_smul
+    {g₁ g₂ d D : ℕ}
+    (dim₁ mult₁ : Fin g₁ → ℕ)
+    (weight₁ : (α : Fin g₁) → Fin (mult₁ α) → ℂ)
+    (dim₂ mult₂ : Fin g₂ → ℕ)
+    (weight₂ : (β : Fin g₂) → Fin (mult₂ β) → ℂ)
+    (hMult₁ : ∀ α, 0 < mult₁ α)
+    (hWeight₁ : ∀ α q, (0 : ℂ) < weight₁ α q)
+    (hMult₂ : ∀ β, 0 < mult₂ β)
+    (hWeight₂ : ∀ β q, (0 : ℂ) < weight₂ β q)
+    (M : MPOTensor d D)
+    (A₁ : (α : Fin g₁) → MPSTensor (D * D) (dim₁ α))
+    (A₂ : (β : Fin g₂) → MPSTensor (D * D) (dim₂ β))
+    (U₁ : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g₁, mult₁ α), verticalCopyDim dim₁ mult₁ q))
+      (Fin d) ℂ)
+    (U₂ : Matrix
+      (Fin (∑ q : Fin (∑ β : Fin g₂, mult₂ β), verticalCopyDim dim₂ mult₂ q))
+      (Fin (d * d)) ℂ)
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
+    (S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d) (Fin d) ℂ)
+    (hForward₁ : ∀ ab, U₁ * verticalTensor M ab * U₁ᴴ =
+      verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab)
+    (hReconstruct₁ : ∀ ab, verticalTensor M ab =
+      U₁ᴴ * verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab * U₁)
+    (hForward₂ : ∀ ab, U₂ * verticalTensor (blockTwo M) ab * U₂ᴴ =
+      verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab)
+    (hReconstruct₂ : ∀ ab, verticalTensor (blockTwo M) ab =
+      U₂ᴴ * verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab * U₂)
+    (X : Matrix (Fin D) (Fin D) ℂ)
+    (hT : T (physClose1 M X) = physClose2 M X)
+    (hS : S (physClose2 M X) = physClose1 M X) :
+    ((transportedVerticalSectorS dim₁ mult₁ dim₂ mult₂ weight₂ U₁ U₂ S).comp
+      (transportedVerticalSectorT dim₁ mult₁ weight₁ dim₂ mult₂ U₁ U₂ T))
+        (fun α => verticalMultiplicityTrace weight₁ α •
+          MPSTensor.contractBondMatrix (A₁ α) X) =
+      fun α => verticalMultiplicityTrace weight₁ α •
+        MPSTensor.contractBondMatrix (A₁ α) X := by
+  simp only [LinearMap.comp_apply]
+  rw [transportedVerticalSectorT_contractBondMatrix_trace_smul
+    dim₁ mult₁ weight₁ dim₂ mult₂ weight₂ hMult₁ hWeight₁ M A₁ A₂ U₁ U₂ T
+    hReconstruct₁ hForward₂ X hT]
+  exact transportedVerticalSectorS_contractBondMatrix_trace_smul
+    dim₁ mult₁ weight₁ dim₂ mult₂ weight₂ hMult₂ hWeight₂ M A₁ A₂ U₁ U₂ S
+    hForward₁ hReconstruct₂ X hS
+
+/-- Every multiplicity-trace-scaled two-site vertical BNT bond contraction is
+fixed by the transported refinement--coarse-graining composite.
+
+This proves only the inclusion of the two-site contraction family in the
+fixed-point space.  The conclusion that the composite is the identity uses
+the later fixed-point structure argument of Appendix C.4, lines 1980--1993.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1974--1980. -/
+theorem transportedVerticalSectorT_comp_S_fixed_contractBondMatrix_trace_smul
+    {g₁ g₂ d D : ℕ}
+    (dim₁ mult₁ : Fin g₁ → ℕ)
+    (weight₁ : (α : Fin g₁) → Fin (mult₁ α) → ℂ)
+    (dim₂ mult₂ : Fin g₂ → ℕ)
+    (weight₂ : (β : Fin g₂) → Fin (mult₂ β) → ℂ)
+    (hMult₁ : ∀ α, 0 < mult₁ α)
+    (hWeight₁ : ∀ α q, (0 : ℂ) < weight₁ α q)
+    (hMult₂ : ∀ β, 0 < mult₂ β)
+    (hWeight₂ : ∀ β q, (0 : ℂ) < weight₂ β q)
+    (M : MPOTensor d D)
+    (A₁ : (α : Fin g₁) → MPSTensor (D * D) (dim₁ α))
+    (A₂ : (β : Fin g₂) → MPSTensor (D * D) (dim₂ β))
+    (U₁ : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g₁, mult₁ α), verticalCopyDim dim₁ mult₁ q))
+      (Fin d) ℂ)
+    (U₂ : Matrix
+      (Fin (∑ q : Fin (∑ β : Fin g₂, mult₂ β), verticalCopyDim dim₂ mult₂ q))
+      (Fin (d * d)) ℂ)
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
+    (S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d) (Fin d) ℂ)
+    (hForward₁ : ∀ ab, U₁ * verticalTensor M ab * U₁ᴴ =
+      verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab)
+    (hReconstruct₁ : ∀ ab, verticalTensor M ab =
+      U₁ᴴ * verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab * U₁)
+    (hForward₂ : ∀ ab, U₂ * verticalTensor (blockTwo M) ab * U₂ᴴ =
+      verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab)
+    (hReconstruct₂ : ∀ ab, verticalTensor (blockTwo M) ab =
+      U₂ᴴ * verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab * U₂)
+    (X : Matrix (Fin D) (Fin D) ℂ)
+    (hT : T (physClose1 M X) = physClose2 M X)
+    (hS : S (physClose2 M X) = physClose1 M X) :
+    ((transportedVerticalSectorT dim₁ mult₁ weight₁ dim₂ mult₂ U₁ U₂ T).comp
+      (transportedVerticalSectorS dim₁ mult₁ dim₂ mult₂ weight₂ U₁ U₂ S))
+        (fun β => verticalMultiplicityTrace weight₂ β •
+          MPSTensor.contractBondMatrix (A₂ β) X) =
+      fun β => verticalMultiplicityTrace weight₂ β •
+        MPSTensor.contractBondMatrix (A₂ β) X := by
+  simp only [LinearMap.comp_apply]
+  rw [transportedVerticalSectorS_contractBondMatrix_trace_smul
+    dim₁ mult₁ weight₁ dim₂ mult₂ weight₂ hMult₂ hWeight₂ M A₁ A₂ U₁ U₂ S
+    hForward₁ hReconstruct₂ X hS]
+  exact transportedVerticalSectorT_contractBondMatrix_trace_smul
+    dim₁ mult₁ weight₁ dim₂ mult₂ weight₂ hMult₁ hWeight₁ M A₁ A₂ U₁ U₂ T
+    hReconstruct₁ hForward₂ X hT
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -1102,8 +1102,14 @@ physical indices, as in
 \begin{proof}\leanok
     The preceding theorem gives
     $\widetilde T(V_1(X))=V_2(X)$ and
-    $\widetilde S(V_2(X))=V_1(X)$.  Substitution gives both fixed-point
-    identities.
+    $\widetilde S(V_2(X))=V_1(X)$.  Hence
+    \[
+        (\widetilde S\circ\widetilde T)(V_1(X))
+        =\widetilde S(V_2(X))=V_1(X),
+        \qquad
+        (\widetilde T\circ\widetilde S)(V_2(X))
+        =\widetilde T(V_1(X))=V_2(X).
+    \]
 \end{proof}
 
 \begin{theorem}[Two-site closure of the two-site blocking]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -1073,6 +1073,38 @@ physical indices, as in
     \]
 \end{proof}
 
+\begin{lemma}[Fixed contraction families of the transported composites]
+    \label{lem:mpdo_transported_vertical_sector_fixed_generators}
+    \lean{MPOTensor.transportedVerticalSectorS_comp_T_fixed_contractBondMatrix_trace_smul}
+    \lean{MPOTensor.transportedVerticalSectorT_comp_S_fixed_contractBondMatrix_trace_smul}
+    \leanok
+    \uses{thm:mpdo_transported_vertical_sector_maps}
+    For every bond matrix $X$, set
+    \[
+        V_1(X)=\bigoplus_\alpha m_\alpha M_\alpha(X),
+        \qquad
+        V_2(X)=\bigoplus_\beta n_\beta A_\beta(X).
+    \]
+    Under the hypotheses of the preceding theorem, the transported
+    composites satisfy
+    \[
+        (\widetilde S\circ\widetilde T)(V_1(X))=V_1(X),
+        \qquad
+        (\widetilde T\circ\widetilde S)(V_2(X))=V_2(X).
+    \]
+    Thus the one-site and two-site contraction families lie in the respective
+    fixed-point spaces.  These equations do not assert that either composite
+    is the identity on the whole sector algebra; that conclusion requires the
+    fixed-point structure argument of Appendix~C.4, lines 1980--1993.
+\end{lemma}
+
+\begin{proof}\leanok
+    The preceding theorem gives
+    $\widetilde T(V_1(X))=V_2(X)$ and
+    $\widetilde S(V_2(X))=V_1(X)$.  Substitution gives both fixed-point
+    identities.
+\end{proof}
+
 \begin{theorem}[Two-site closure of the two-site blocking]
     \label{thm:mpdo_two_site_closure_two_site_blocking}
     \lean{MPOTensor.physClose2_blockTwo_eq_physClose4}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -1093,9 +1093,10 @@ physical indices, as in
         (\widetilde T\circ\widetilde S)(V_2(X))=V_2(X).
     \]
     Thus the one-site and two-site contraction families lie in the respective
-    fixed-point spaces.  These equations do not assert that either composite
-    is the identity on the whole sector algebra; that conclusion requires the
-    fixed-point structure argument of Appendix~C.4, lines 1980--1993.
+    fixed-point spaces, as in Appendix~C.4, lines 1974--1980.  These equations
+    do not assert that either composite is the identity on the whole sector
+    algebra; that conclusion requires the fixed-point structure argument of
+    Appendix~C.4, lines 1980--1993.
 \end{lemma}
 
 \begin{proof}\leanok


### PR DESCRIPTION
## Summary

- prove that the transported coarse-graining–refinement composite fixes every one-site multiplicity-trace-scaled BNT bond contraction;
- prove the symmetric fixed-generator statement for the two-site composite;
- record the two inclusions in the mathematical blueprint.

These statements formalize the immediate conclusion of arXiv:1606.00608, Appendix C.4, lines 1974–1980. They do not assert that either composite is the identity on the full sector algebra, and they add no complete-positivity, trace-preservation, relabelling, or unitary conclusion.

## Validation

- lake env lean TNLean/MPS/MPDO/VerticalSectorFixedGenerators.lean
- lake build TNLean.MPS.MPDO.VerticalSectorFixedGenerators
- lake build
- lake exe checkdecls blueprint/lean_decls
- blueprint/Lean synchronization and reverse-coverage check
- reader-facing prose, proof-integrity token, line-length, oversized-file, and diff checks

The full build retains the pre-existing sorry warning in TNLean/MPS/Periodic/Overlap/Case3.lean:600; this change introduces none.

Closes #4125

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization and documentation on the MPDO vertical-sector track; proofs delegate to prior lemmas with no auth, runtime, or data-path changes.
> 
> **Overview**
> Adds **`VerticalSectorFixedGenerators.lean`** with two Lean theorems showing that transported coarse-graining/refinement composites fix the multiplicity-trace-scaled one-site and two-site vertical BNT bond contractions (Appendix C.4, lines 1974–1980). Each proof is a short composition of the existing `transportedVerticalSectorT/S_contractBondMatrix_trace_smul` lemmas from `VerticalSectorCoordinates`.
> 
> Wires the module into **`TNLean.lean`** and records the matching **blueprint lemma** in `ch21_mpdo_rfp_blocked_rfp.tex`, with explicit scope that these are fixed-point *inclusions* for the contraction families only—not identity on the full sector algebra.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8b23965dbc02106ef59a30aa899016f529c0be3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->