### PR TITLE
feat(MPS/MPDO): restrict BNT tensors to physical sectors

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -450,6 +450,7 @@ import TNLean.MPS.MPDO.BNTThreeSiteReducedClosure
 import TNLean.MPS.MPDO.BNTSourceSectorProjectors
 import TNLean.MPS.MPDO.SitewisePhysicalMatrix
 import TNLean.MPS.MPDO.BNTProjectorSelection
+import TNLean.MPS.MPDO.PhysicalSupportRestriction
 import TNLean.MPS.MPDO.BNTSectorAnalyticProperties
 import TNLean.MPS.MPDO.BNTSectorAreaLaw
 import TNLean.MPS.MPDO.HayashiSectorProjector

--- a/TNLean/MPS/Defs.lean
+++ b/TNLean/MPS/Defs.lean
@@ -322,6 +322,28 @@ def IsInjective (A : MPSTensor d D) : Prop :=
 lemma IsInjective.span_eq_top {A : MPSTensor d D} (hA : IsInjective A) :
     Submodule.span ℂ (Set.range A) = ⊤ := hA
 
+/-- Multiplication of every physical letter by a nonzero scalar preserves
+injectivity. -/
+theorem IsInjective.smul
+    {c : ℂ} {A : MPSTensor d D} (hA : IsInjective A) (hc : c ≠ 0) :
+    IsInjective (fun i ↦ c • A i) := by
+  unfold IsInjective at hA ⊢
+  calc
+    Submodule.span ℂ (Set.range fun i ↦ c • A i) =
+        Submodule.span ℂ (Set.range A) := by
+      apply le_antisymm
+      · apply Submodule.span_le.mpr
+        rintro X ⟨i, rfl⟩
+        exact Submodule.smul_mem _ c (Submodule.subset_span ⟨i, rfl⟩)
+      · apply Submodule.span_le.mpr
+        rintro X ⟨i, rfl⟩
+        have hmem : c • A i ∈
+            Submodule.span ℂ (Set.range fun i ↦ c • A i) :=
+          Submodule.subset_span ⟨i, rfl⟩
+        convert Submodule.smul_mem _ c⁻¹ hmem using 1
+        simp [hc]
+    _ = ⊤ := hA
+
 /-- An injective MPS tensor on `D ≥ 1` bond dimension implies `d ≥ 1`. -/
 theorem neZero_d_of_isInjective {A : MPSTensor d D} [NeZero D]
     (hA : IsInjective A) : NeZero d := by

--- a/TNLean/MPS/MPDO/PhysicalSectorCoordinateTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorCoordinateTransport.lean
@@ -78,6 +78,36 @@ noncomputable def changePhysicalBasis {e : ℕ}
     (V : Matrix (Fin e) (Fin d) ℂ) (M : MPOTensor d D) : MPOTensor e D :=
   fun i j beta alpha ↦ (V * physicalSlice M beta alpha * Vᴴ) i j
 
+/-- Successive changes of physical coordinates multiply their coordinate
+matrices. -/
+theorem changePhysicalBasis_changePhysicalBasis
+    {a b : ℕ} (U : Matrix (Fin a) (Fin b) ℂ)
+    (V : Matrix (Fin b) (Fin d) ℂ) (M : MPOTensor d D) :
+    changePhysicalBasis U (changePhysicalBasis V M) =
+      changePhysicalBasis (U * V) M := by
+  ext i j beta alpha
+  change (U * (V * physicalSlice M beta alpha * Vᴴ) * Uᴴ) i j =
+    ((U * V) * physicalSlice M beta alpha * (U * V)ᴴ) i j
+  rw [Matrix.conjTranspose_mul]
+  simp only [Matrix.mul_assoc]
+
+/-- A physical coordinate change commutes with a scalar multiplying every
+local MPO matrix. -/
+theorem changePhysicalBasis_smul
+    {e : ℕ} (V : Matrix (Fin e) (Fin d) ℂ) (c : ℂ) (M : MPOTensor d D) :
+    changePhysicalBasis V (c • M) = c • changePhysicalBasis V M := by
+  ext i j beta alpha
+  simp only [changePhysicalBasis, physicalSlice, Pi.smul_apply,
+    Matrix.smul_apply, smul_eq_mul, Matrix.mul_apply,
+    Matrix.conjTranspose_apply]
+  simp_rw [Finset.mul_sum, Finset.sum_mul]
+  apply Finset.sum_congr rfl
+  intro x _
+  rw [Finset.mul_sum]
+  apply Finset.sum_congr rfl
+  intro y _
+  ring
+
 theorem sectorCoordinateTensor_eq_changePhysicalBasis
     (F : PhysicalSectorFactorization K) :
     F.sectorCoordinateTensor = changePhysicalBasis F.physicalCoordinateMatrix K := by

--- a/TNLean/MPS/MPDO/PhysicalSupportRestriction.lean
+++ b/TNLean/MPS/MPDO/PhysicalSupportRestriction.lean
@@ -1,0 +1,162 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.CanonicalForm.ProjectorClosureDecomposition
+import TNLean.MPS.MPDO.BNTProjectorSelection
+import TNLean.MPS.MPDO.SimpleLocalStructure
+
+/-!
+# Restriction to an orthogonal physical sector
+
+An MPO tensor supported on an orthogonal one-site projection may be regarded
+as a tensor on the range of that projection.  This file records the finite
+dimensional support isometry, the exact reconstruction in the ambient
+physical space, and preservation of injectivity under restriction.
+
+The construction is the range restriction used before applying the injective
+part of Proposition C.8 to each BNT sector in Appendix C.2.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, equations `PjKiPj` and `generateMPDO`, lines 1733--1770
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPOTensor
+
+variable {d e D : ℕ}
+
+open PhysicalSectorFactorization
+
+/-- If an ambient tensor is obtained from a smaller tensor by a physical
+coordinate change, then injectivity of the ambient tensor implies injectivity
+of the smaller tensor. -/
+theorem isInjective_of_eq_changePhysicalBasis
+    (V : Matrix (Fin d) (Fin e) ℂ) (K : MPOTensor e D) (M : MPOTensor d D)
+    (hM : M = changePhysicalBasis V K) (hInjective : M.IsInjective) :
+    K.IsInjective := by
+  rw [IsInjective, MPSTensor.IsInjective, eq_top_iff]
+  rw [← hInjective]
+  apply Submodule.span_le.mpr
+  rintro X ⟨ij, rfl⟩
+  rw [hM]
+  change changePhysicalBasis V K ij.divNat ij.modNat ∈
+    Submodule.span ℂ (Set.range K.toMPSTensor)
+  rw [changePhysicalBasis_apply_eq_sum]
+  apply Submodule.sum_mem
+  intro p _
+  apply Submodule.smul_mem
+  exact Submodule.subset_span ⟨finProdFinEquiv (p.1, p.2), by
+    simp only [toMPSTensor, MPSTensor.finProdFinEquiv_divNat,
+      MPSTensor.finProdFinEquiv_modNat]⟩
+
+/-- Data identifying an MPO tensor with its restriction to the range of an
+orthogonal one-site projection. -/
+structure PhysicalSupportRestrictionData
+    (P : Matrix (Fin d) (Fin d) ℂ) (K : MPOTensor d D) where
+  /-- Dimension of the physical sector. -/
+  supportDim : ℕ
+  /-- Isometric inclusion of the physical sector into the ambient space. -/
+  inclusion : Matrix (Fin d) (Fin supportDim) ℂ
+  /-- The columns of the inclusion are orthonormal. -/
+  inclusion_isometry : inclusionᴴ * inclusion = 1
+  /-- The range projection of the inclusion is the prescribed sector
+  projection. -/
+  inclusion_range : inclusion * inclusionᴴ = P
+  /-- The tensor restricted to the sector range is injective. -/
+  restricted_injective :
+    (changePhysicalBasis inclusionᴴ K).IsInjective
+  /-- Restriction followed by inclusion recovers the ambient tensor exactly. -/
+  reembed :
+    changePhysicalBasis inclusion (changePhysicalBasis inclusionᴴ K) = K
+
+/-- An injective tensor fixed by an orthogonal physical projection admits an
+injective restriction to the range of that projection.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `PjKiPj` and
+`generateMPDO`, lines 1733--1770. -/
+theorem exists_physicalSupportRestrictionData
+    (P : Matrix (Fin d) (Fin d) ℂ) (K : MPOTensor d D)
+    (hP : IsOrthogonalProjection P) (hSupport : changePhysicalBasis P K = K)
+    (hInjective : K.IsInjective) :
+    Nonempty (PhysicalSupportRestrictionData P K) := by
+  obtain ⟨n, V, _hn, hV, hRange⟩ := hP.exists_support_isometry
+  have hreembed : changePhysicalBasis V (changePhysicalBasis Vᴴ K) = K := by
+    rw [changePhysicalBasis_changePhysicalBasis]
+    rw [hRange, hSupport]
+  exact ⟨{
+    supportDim := n
+    inclusion := V
+    inclusion_isometry := hV
+    inclusion_range := hRange
+    restricted_injective :=
+      isInjective_of_eq_changePhysicalBasis V
+        (changePhysicalBasis Vᴴ K) K hreembed.symm hInjective
+    reembed := hreembed }⟩
+
+/-- The common-weight-absorbed BNT representative is injective after the
+source's common blocking.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `CFK`, lines 1660--1665. -/
+theorem commonWeightAbsorbedBasisMPOTensor_isInjective
+    (S : MPSTensor.SectorDecomposition (d * d))
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q')
+    (hSpan : MPSTensor.WordTupleSpanTop S.basis 1)
+    (s : Fin S.basisCount) :
+    (commonWeightAbsorbedBasisMPOTensor S hWeight s).IsInjective := by
+  rw [IsInjective, commonWeightAbsorbedBasisMPOTensor_toMPSTensor]
+  exact (hSpan.isInjective_one s).smul (S.commonWeight_ne_zero hWeight s)
+
+/-- Each common-weight-absorbed BNT representative has an injective
+realization on the range of its matching physical-sector projector.
+
+This is the range restriction used before applying Proposition C.8 inside
+each outer BNT sector.  The theorem introduces no nonvanishing or positivity
+hypothesis beyond the data already used to construct the source projector.
+
+**Scope restriction (closing matrices):** the generic statement retains the
+nonzero-closing hypothesis used to construct the sector projectors.  The
+source specialization derives this hypothesis in
+`BNTThreeSiteReducedClosure.lean`.  This intermediate restriction is recorded
+in `docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `PjKiPj`, `generateMPDO`,
+and `CFK`, lines 1660--1665 and 1733--1770. -/
+theorem nonempty_physicalSupportRestrictionData_commonWeightAbsorbedBasis
+    (S : MPSTensor.SectorDecomposition (d * d))
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q')
+    {R : (s : Fin S.basisCount) →
+      Matrix (Fin (S.basisDim s)) (Fin (S.basisDim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex S.basisDim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse
+      (fun j ↦ S.basisMPOTensor j) C)
+    (hρ : IsThreeSiteFamilyClosure (fun j ↦ S.basisMPOTensor j) R ρ)
+    (hη : EtaStructure ρ) (hR : ∀ s : Fin S.basisCount, R s ≠ 0)
+    (hSpan : MPSTensor.WordTupleSpanTop S.basis 1)
+    (s : Fin S.basisCount) :
+    Nonempty (PhysicalSupportRestrictionData
+      (bntSectorProjection hC hρ hη hR s)
+      (commonWeightAbsorbedBasisMPOTensor S hWeight s)) := by
+  let P := bntSectorProjection hC hρ hη hR s
+  let K := commonWeightAbsorbedBasisMPOTensor S hWeight s
+  have hBasis : changePhysicalBasis P (S.basisMPOTensor s) =
+      S.basisMPOTensor s := by
+    simpa [P] using
+      changePhysicalBasis_bntSectorProjection_basis hC hρ hη hR s s
+  have hSupport : changePhysicalBasis P K = K := by
+    change changePhysicalBasis P
+        (S.commonWeight hWeight s • S.basisMPOTensor s) =
+      S.commonWeight hWeight s • S.basisMPOTensor s
+    rw [changePhysicalBasis_smul, hBasis]
+  exact exists_physicalSupportRestrictionData P K
+    (bntSectorProjection_isOrthogonal hC hρ hη hR s) hSupport
+    (commonWeightAbsorbedBasisMPOTensor_isInjective S hWeight hSpan s)
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
@@ -151,6 +151,63 @@ Definition~\ref{def:mpdo_source_gsnnch}; the converse comparison is not used.
     multiplicity to be one, and its bond to be the given bond.
 \end{proof}
 
+\begin{definition}[Restriction to an orthogonal physical sector]
+    \label{def:mpdo_physical_support_restriction}
+    \lean{MPOTensor.PhysicalSupportRestrictionData}
+    \leanok
+    \uses{def:mpdo_source_gsnnch}
+    Let $P$ be an orthogonal one-site projection and let $K$ be an MPO tensor
+    fixed by compression with $P$ on its two physical indices.  A physical
+    support restriction consists of a dimension $e$ and an isometry
+    $V:\C^e\longrightarrow\C^d$ such that
+    \[
+        V^*V=1,
+        \qquad VV^*=P,
+    \]
+    for which the restricted tensor $K_P=V^*KV$ is injective and its
+    inclusion into the ambient physical space recovers $K$ exactly.
+\end{definition}
+
+\begin{theorem}[Injective restriction to a BNT projector range]
+    \label{thm:mpdo_bnt_physical_support_restriction}
+    \lean{MPOTensor.exists_physicalSupportRestrictionData}
+    \lean{MPOTensor.commonWeightAbsorbedBasisMPOTensor_isInjective}
+    \lean{MPOTensor.nonempty_physicalSupportRestrictionData_commonWeightAbsorbedBasis}
+    \leanok
+    \uses{def:mpdo_physical_support_restriction}
+    Suppose that the source BNT projectors have been constructed after the
+    common physical blocking, and let $\mathcal K_s$ be the normal
+    representative with its common copy weight absorbed.  Then
+    $\mathcal K_s$ admits a physical support restriction to the range of
+    $P_s$.  In particular, for some isometry $V_s$,
+    \[
+        V_sV_s^*=P_s,
+        \qquad
+        \mathcal K_s=V_s(V_s^*\mathcal K_sV_s)V_s^*,
+    \]
+    and the restricted tensor $V_s^*\mathcal K_sV_s$ is injective.
+\end{theorem}
+
+\begin{proof}\leanok
+    The projector identity $P_s\mathcal K_sP_s=\mathcal K_s$ gives an
+    isometric inclusion of its range.  The simultaneous one-site spanning
+    condition makes each normal representative injective, and multiplication
+    by its nonzero common weight preserves injectivity.  Write
+    $K_{P_s}=V_s^*\mathcal K_sV_s$.  Each ambient matrix slice satisfies
+    \[
+        (\mathcal K_s)_{ij}
+        =\sum_{p,q}(V_s)_{ip}\,\overline{(V_s)_{jq}}\,(K_{P_s})_{pq}.
+    \]
+    Hence
+    \[
+        \operatorname{span}\{(\mathcal K_s)_{ij}\}_{i,j}
+        \subseteq
+        \operatorname{span}\{(K_{P_s})_{pq}\}_{p,q}.
+    \]
+    The left-hand side is the full virtual matrix algebra, so $K_{P_s}$ is
+    injective.  The two isometry identities give the exact reconstruction.
+\end{proof}
+
 \begin{definition}[Orthogonally supported commuting sector products]
     \label{def:mpdo_orthogonal_commuting_sector_family}
     \lean{MPOTensor.OrthogonalCommutingSectorFamily}

--- a/docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex
+++ b/docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex
@@ -104,12 +104,19 @@ sector product identities give the source GSNNCH form with the prescribed
 natural multiplicities.
 \footnote{\raggedright Formal declaration:
 {\scriptsize\leanid{MPOTensor.hasGSNNCHForm_of_orthogonalCommutingSectorFamily}}.}
+The first part of the support-preserving sector argument is also complete.
+Every absorbed BNT representative has an exact isometric restriction to the
+range of its matching projector, and the restricted tensor is injective.
+\footnote{\raggedright Formal declarations:
+{\scriptsize\leanid{MPOTensor.PhysicalSupportRestrictionData}} and
+{\scriptsize\leanid{MPOTensor.nonempty_physicalSupportRestrictionData_commonWeightAbsorbedBasis}}.}
 The remaining comparison has two parts:
 
 \begin{enumerate}
-  \item apply the injective commuting-product theorem inside the range of each
-        BNT projector and transport its positive bond back to the ambient
-        one-site space, proving
+  \item transport the sectorwise saturated area law through the support
+        isometry, apply the injective commuting-product theorem to the
+        restricted tensor, and transport its positive bond back to the
+        ambient one-site space, proving
         $(P_j\otimes P_j)B^{(j)}(P_j\otimes P_j)=B^{(j)}$;
   \item determine whether the reverse comparison with a single bond is needed
         in the simple-MPDO equivalence, and prove it only in that form.
@@ -129,8 +136,9 @@ area law is proved GSNNCH through a one-sector witness.  For a general simple
 tensor, the BNT projectors, their positive-length compression formula, and the
 sectorwise MPDO, SAL, and ZCL conclusions are formalized.  The abstract
 construction of the outer sector sum with its natural multiplicities is
-formalized.  The open gap is the support-preserving application of the
-injective commuting-product theorem within each BNT projector range, together
-with any reverse comparison actually needed by the simple-MPDO equivalence.
+formalized, as is the injective restriction of every representative to its
+projector range.  The open gap is the isometric transport of SAL and of the
+resulting positive commuting bond, together with any reverse comparison
+actually needed by the simple-MPDO equivalence.
 
 \end{document}


### PR DESCRIPTION
## Summary

- define the isometric restriction of an MPO tensor to an orthogonal physical-sector range;
- prove exact reconstruction in the ambient physical space and preservation of injectivity under restriction;
- construct this restriction for every common-weight-absorbed BNT representative using the existing source projectors and simultaneous one-site spanning condition;
- update the blueprint and GSNNCH gap note with the precise remaining SAL and bond-transport step.

## Mathematical scope

This is the range-restriction step at arXiv:1606.00608, Appendix C.2, equations PjKiPj and generateMPDO, lines 1733–1770. The construction uses the proved projector-support equation and common-block injectivity. The generic theorem retains the documented nonzero closing-matrix hypothesis used to construct the sector projectors; the source specialization derives that hypothesis from the normalized three-site reduced state. This scope restriction is marked in the theorem docstring and recorded in docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex. No additional positivity, SAL, ZCL, or sector-ownership hypothesis is introduced. There is no zero-chain or zero-bond-dimension case split.

The pull request advances #4003 but does not complete it. The remaining step is to transport the sectorwise saturated area law through the support isometry, apply Proposition C.8 to the restricted tensor, and embed the positive commuting bond while proving its two-site support identity.

## Validation

- lake build TNLean.MPS.MPDO.PhysicalSupportRestriction TNLean
- lake exe lint_style
- blueprint and Lean synchronization check
- declaration checker
- reader-facing prose check
- proof-integrity scan and kernel axiom audit
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes extend a long formal proof chain in MPS/MPDO GSNNCH formalization; incorrect restriction or injectivity lemmas could block downstream bond-transport theorems, but the diff is localized linear-algebra with no runtime or security impact.
> 
> **Overview**
> Formalizes **isometric restriction** of projector-supported MPO tensors to an orthogonal physical-sector range (CPSV Appendix C.2), as the step before applying the injective commuting-product theorem inside each BNT sector.
> 
> Adds `PhysicalSupportRestrictionData` with an inclusion isometry `V` (`V*V = 1`, `VV* = P`), **exact ambient reconstruction** `K = V(V*KV)V*`, and **injectivity** of the restricted tensor `V*KV`. Supporting lemmas include `MPSTensor.IsInjective.smul`, `changePhysicalBasis` composition and compatibility with global scalars, and pullback of injectivity from `changePhysicalBasis`.
> 
> Instantiates this for every **common-weight-absorbed BNT representative** on its matching `bntSectorProjection`, using existing projector-support and one-site spanning hypotheses. The blueprint and GSNNCH gap note record this as done and reframe the remaining work as **SAL and positive-bond transport** through the support isometry (not yet proving sectorwise Proposition C.8 in ambient coordinates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc8b001fba06cf158f6f2a62af20ac1039afa0a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->