### PR TITLE
feat(Channel): represent positive functionals by densities

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -172,6 +172,7 @@ import TNLean.Channel.Schwarz.SchwarzNormal
 import TNLean.Channel.Schwarz.SchwarzSubnormal
 import TNLean.Channel.Schwarz.SchwarzNotCP
 import TNLean.Channel.Schwarz.TwoPositive
+import TNLean.Channel.PositiveFunctional
 import TNLean.Channel.Schwarz.ChoiCompression
 import TNLean.Channel.NPositivityChainStrict
 import TNLean.Channel.ReductionCriterion

--- a/TNLean/Channel/PositiveFunctional.lean
+++ b/TNLean/Channel/PositiveFunctional.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.MatrixAux
+import TNLean.Algebra.TracePairing
+import TNLean.Channel.Schwarz.TwoPositive
+
+/-!
+# Density representation of positive matrix functionals
+
+A positive normalized complex-linear functional on a finite matrix algebra is the trace
+pairing with a density matrix.  The representing density is obtained by applying the
+trace-pairing adjoint of the associated scalar-range positive map to the faithful uniform
+density.
+
+## Main results
+
+* `Matrix.exists_density_of_positive_functional`: a positive normalized linear functional
+  on a finite matrix algebra is represented by a density matrix.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 1, the discussion
+  following Proposition 1.5 and Equation (1.40)][Wolf2012QChannels]
+-/
+
+open scoped Matrix ComplexOrder
+
+namespace Matrix
+
+variable {n : Type*} [Fintype n] [DecidableEq n] [Nonempty n]
+
+/-- A positive normalized complex-linear functional on a finite matrix algebra is the
+trace pairing with a density matrix.
+
+This is the finite-dimensional representation of positive functionals used in Wolf,
+Chapter 1, in the discussion following Proposition 1.5 and Equation (1.40). -/
+theorem exists_density_of_positive_functional
+    (f : Matrix n n ℂ →ₗ[ℂ] ℂ)
+    (hpos : ∀ X : Matrix n n ℂ, X.PosSemidef → (0 : ℂ) ≤ f X)
+    (hone : f 1 = 1) :
+    ∃ ρ : Matrix n n ℂ, ρ.PosSemidef ∧ ρ.trace = 1 ∧
+      ∀ X : Matrix n n ℂ, f X = (ρ * X).trace := by
+  classical
+  let F : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ :=
+    { toFun := fun X ↦ f X • (1 : Matrix n n ℂ)
+      map_add' := by
+        intro X Y
+        simp [add_smul]
+      map_smul' := by
+        intro c X
+        simp [smul_smul] }
+  have hF : IsPositiveMap F := by
+    intro X hX
+    exact Matrix.PosSemidef.one.smul (hpos X hX)
+  let σ : Matrix n n ℂ := Matrix.faithfulDensity n
+  let ρ : Matrix n n ℂ := Matrix.traceAdjointMap F σ
+  have hσ : σ.PosSemidef := (Matrix.faithfulDensity_posDef n).posSemidef
+  have hρ : ρ.PosSemidef := hF.traceAdjointMap σ hσ
+  have hpair (X : Matrix n n ℂ) : (ρ * X).trace = f X := by
+    rw [show ρ = Matrix.traceAdjointMap F σ from rfl,
+      Matrix.trace_traceAdjointMap_mul]
+    simp [F, σ, Matrix.trace_smul, Matrix.faithfulDensity_trace]
+  refine ⟨ρ, hρ, ?_, fun X ↦ (hpair X).symm⟩
+  simpa [hone] using hpair (1 : Matrix n n ℂ)
+
+end Matrix

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -1264,17 +1264,18 @@ maps.
     \leanok
     Let $f : \MN{D} \to \C$ be a complex-linear functional, where $D>0$.  If
     $f(X) \geq 0$ for every $X \geq 0$ and $f(\Id)=1$, then there is a density
-    matrix $\rho \in \MN{D}$ such that
+    matrix $\rho \in \MN{D}$ such that, for every $X \in \MN{D}$,
     \[
-        f(X) = \tr(\rho X)
+        f(X) = \tr(\rho X).
     \]
-    for every $X \in \MN{D}$.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    \uses{thm:trace_pairing_adjoint_identity, thm:trace_pairing_adjoint_positive}
-    Define $F : \MN{D} \to \MN{D}$ by $F(X) = f(X)\Id$.  This map is positive.
+    \uses{thm:trace_pairing_adjoint_identity, thm:trace_pairing_adjoint_positive,
+      def:mpdo_faithful_uniform_density, thm:mpdo_faithful_uniform_density}
+    Define $F : \MN{D} \to \MN{D}$ by $F(X) = f(X)\Id$; for $X \geq 0$ one has
+    $f(X) \geq 0$, so $F(X) = f(X)\Id \geq 0$ and $F$ is positive.
     Set $\sigma = D^{-1}\Id$ and $\rho = F^*(\sigma)$.  Positivity of the
     trace-pairing adjoint gives $\rho \geq 0$, while the adjoint identity gives
     \[

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -1258,6 +1258,31 @@ maps.
     positive semidefinite cone therefore gives $E^*(\rho)\geq 0$.
 \end{proof}
 
+\begin{theorem}[Density representation of positive matrix functionals]
+    \label{thm:positive_functional_density_representation}
+    \lean{Matrix.exists_density_of_positive_functional}
+    \leanok
+    Let $f : \MN{D} \to \C$ be a complex-linear functional, where $D>0$.  If
+    $f(X) \geq 0$ for every $X \geq 0$ and $f(\Id)=1$, then there is a density
+    matrix $\rho \in \MN{D}$ such that
+    \[
+        f(X) = \tr(\rho X)
+    \]
+    for every $X \in \MN{D}$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:trace_pairing_adjoint_identity, thm:trace_pairing_adjoint_positive}
+    Define $F : \MN{D} \to \MN{D}$ by $F(X) = f(X)\Id$.  This map is positive.
+    Set $\sigma = D^{-1}\Id$ and $\rho = F^*(\sigma)$.  Positivity of the
+    trace-pairing adjoint gives $\rho \geq 0$, while the adjoint identity gives
+    \[
+        \tr(\rho X) = \tr(\sigma F(X)) = f(X).
+    \]
+    Taking $X = \Id$ yields $\tr(\rho) = 1$.
+\end{proof}
+
 \begin{theorem}[Trace-pairing adjoints preserve positivity exactly]\label{thm:trace_pairing_adjoint_positive_iff}
     \lean{isPositiveMap_traceAdjointMap_iff}
     \leanok


### PR DESCRIPTION
### Motivation

- The one-factor conditional-expectation classification in LionSR/QICLean#215 requires the finite-dimensional representation of positive normalized functionals by density matrices.
- Wolf states the underlying trace-pairing representation in `Notes/WolfNoteTexSource/ch01_deconstructing_quantum.tex`, lines 578--585, in the discussion following Proposition 1.5 and Equation (1.40): a finite-dimensional linear functional is a trace pairing, while positivity and normalization make its representative a density operator.
- This pull request isolates that prerequisite without asserting the one-factor form of Proposition 1.5 or the density-weighted fixed-point form of Theorem 6.14.

### Description

- Add `Matrix.exists_density_of_positive_functional`: if a complex-linear functional on a nonzero finite matrix algebra is nonnegative on positive semidefinite matrices and maps the identity to one, then it has the form `X ↦ tr(ρ X)` for a positive semidefinite trace-one matrix `ρ`.
- Construct `ρ` as the trace-pairing adjoint of the positive scalar-range map `X ↦ f(X) 1`, evaluated at the faithful uniform density. Positivity of trace-pairing adjoints gives `ρ ≥ 0`; the adjoint trace identity gives the representation formula and trace normalization.
- Import the new module from `TNLean.lean` and add the source-faithful blueprint theorem `thm:positive_functional_density_representation` with a proof matching the formal construction.
- This result is a prerequisite only. Issues LionSR/QICLean#215 and LionSR/QICLean#39 remain open for the rank-one order argument, weighted partial-trace formula, finite direct-product classification, and Wolf Theorem 6.14.

### Testing

- `lake env lean TNLean/Channel/PositiveFunctional.lean`
- `lake build TNLean.Channel.PositiveFunctional`
- `lake env lean TNLean.lean`
- `lake build` (9541 jobs; pre-existing warnings only)
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `leanblueprint checkdecls`
- `git diff --check`
- proof-integrity and 100-column scans on `TNLean/Channel/PositiveFunctional.lean`

---
Closes LionSR/QICLean#216
Addresses LionSR/QICLean#215
Addresses LionSR/QICLean#39

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Self-contained Mathlib-style theorem plus blueprint sync; no changes to auth, runtime behavior, or existing channel APIs beyond a new import.
> 
> **Overview**
> Adds **`Matrix.exists_density_of_positive_functional`**: a complex-linear functional on a finite matrix algebra that is nonnegative on positive semidefinite inputs and normalized (`f 1 = 1`) equals **`X ↦ tr(ρ X)`** for some trace-one positive semidefinite **`ρ`**. The proof builds the positive map **`F(X) = f(X) • 1`**, sets **`ρ = traceAdjointMap F σ`** at the faithful uniform density **`σ`**, and uses trace-adjoint positivity and the pairing identity.
> 
> The new module is wired into **`TNLean.lean`**, and blueprint **`thm:positive_functional_density_representation`** in **`ch05_schwarz.tex`** documents the same construction (Wolf Ch. 1 / Eq. 1.40 style).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02d31ab38a954a17c3e39b9ee180a81922d8bdba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->