### PR TITLE
feat(MPS/MPDO): transport SAL through physical support

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -453,6 +453,7 @@ import TNLean.MPS.MPDO.BNTSourceSectorProjectors
 import TNLean.MPS.MPDO.SitewisePhysicalMatrix
 import TNLean.MPS.MPDO.BNTProjectorSelection
 import TNLean.MPS.MPDO.PhysicalSupportRestriction
+import TNLean.MPS.MPDO.PhysicalSupportSALTransport
 import TNLean.MPS.MPDO.BNTSectorAnalyticProperties
 import TNLean.MPS.MPDO.BNTSectorAreaLaw
 import TNLean.MPS.MPDO.HayashiSectorProjector

--- a/TNLean/MPS/MPDO/PhysicalSupportSALTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSupportSALTransport.lean
@@ -1,0 +1,386 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.AreaLaw
+import TNLean.MPS.MPDO.PhysicalSupportRestriction
+import TNLean.MPS.MPDO.SitewisePhysicalMatrix
+
+/-!
+# Saturated-area-law transport through a physical support
+
+Restricting an MPO tensor to an orthogonal one-site support does not change
+the nonzero spectrum of any chain state or contiguous marginal.  Consequently,
+saturation of the area law passes from the ambient tensor to its injective
+restriction.
+
+This is the range-restriction step preceding the injective application of
+Proposition C.8 in each BNT sector.
+
+No hypothesis or conclusion concerns the empty periodic chain.  The case
+`L = N` does leave a zero-site *complement* in the definition of a marginal;
+there `Fin 0` is only the one-dimensional tensor unit for the partial trace,
+not an MPO state of length zero.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, equations `PjKiPj` and `generateMPDO`, lines 1733--1770
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+namespace Matrix
+
+/-- Tracing out the output of an isometry on the discarded factor leaves the
+retained single-Kraus action. -/
+theorem partialTraceRight_singleKraus_kronecker_isometry
+    {α β γ δ : Type*} [Fintype α]
+    [Fintype β] [DecidableEq β] [Fintype γ] [Fintype δ]
+    (A : Matrix γ α ℂ) (B : Matrix δ β ℂ) (hB : Bᴴ * B = 1)
+    (X : Matrix (α × β) (α × β) ℂ) :
+    partialTraceRight
+        (singleKrausMap (kroneckerMap (· * ·) A B) X) =
+      singleKrausMap A (partialTraceRight X) := by
+  classical
+  ext i j
+  have horth (x y : β) :
+      (∑ k : δ, B k x * star (B k y)) = if x = y then 1 else 0 := by
+    simpa only [Matrix.mul_apply, Matrix.conjTranspose_apply,
+      Matrix.one_apply, mul_comm, eq_comm] using
+      congrFun (congrFun hB y) x
+  simp only [partialTraceRight_apply, singleKrausMap_apply,
+    Matrix.mul_apply, Matrix.conjTranspose_apply, kroneckerMap_apply,
+    Fintype.sum_prod_type, star_mul]
+  simp_rw [Finset.mul_sum, Finset.sum_mul]
+  rw [Finset.sum_comm (s := (Finset.univ : Finset δ))
+    (t := (Finset.univ : Finset α))]
+  simp_rw [Finset.sum_comm (s := (Finset.univ : Finset δ))
+    (t := (Finset.univ : Finset β))]
+  simp_rw [Finset.sum_comm (s := (Finset.univ : Finset δ))
+    (t := (Finset.univ : Finset α))]
+  simp_rw [Finset.sum_comm (s := (Finset.univ : Finset δ))
+    (t := (Finset.univ : Finset β))]
+  simp_rw [show ∀ (q : α) (b : β) (p : α) (a : β),
+      (∑ k : δ,
+        A i p * B k a * X (p, a) (q, b) *
+          (star (B k b) * star (A j q))) =
+        A i p * X (p, a) (q, b) *
+          (∑ k : δ, B k a * star (B k b)) * star (A j q) by
+    intro q b p a
+    calc
+      _ = ∑ k : δ,
+          (A i p * X (p, a) (q, b) * star (A j q)) *
+            (B k a * star (B k b)) := by
+        apply Finset.sum_congr rfl
+        intro k _
+        ring
+      _ = (A i p * X (p, a) (q, b) * star (A j q)) *
+          ∑ k : δ, B k a * star (B k b) := by
+        rw [Finset.mul_sum]
+      _ = _ := by ring]
+  simp_rw [horth]
+  simp only [mul_ite, mul_one, mul_zero, RCLike.star_def, ite_mul,
+    zero_mul, Finset.sum_ite_eq', Finset.mem_univ, ↓reduceIte]
+  apply Finset.sum_congr rfl
+  intro q _
+  exact Finset.sum_comm
+
+/-- Reindexing the input and output bases commutes with a single-Kraus
+conjugation. -/
+theorem reindex_singleKrausMap
+    {α α' β β' : Type*} [Fintype α] [Fintype α']
+    [Fintype β] [Fintype β']
+    (eα : α ≃ α') (eβ : β ≃ β')
+    (V : Matrix β α ℂ) (X : Matrix α α ℂ) :
+    reindex eβ eβ (singleKrausMap V X) =
+      singleKrausMap (reindex eβ eα V) (reindex eα eα X) := by
+  simp only [singleKrausMap_apply]
+  change reindexLinearEquiv ℂ ℂ eβ eβ (V * X * Vᴴ) = _
+  rw [← reindexLinearEquiv_mul ℂ ℂ eβ eα eβ,
+    ← reindexLinearEquiv_mul ℂ ℂ eβ eα eα]
+  simp only [Matrix.coe_reindexLinearEquiv, Matrix.conjTranspose_reindex]
+
+end Matrix
+
+/-- Conjugating a Hermitian matrix by a rectangular isometry preserves its von
+Neumann entropy; the additional eigenvalues are zero. -/
+theorem vonNeumannEntropy_singleKraus_isometry
+    {α β : Type*} [Fintype α] [DecidableEq α]
+    [Fintype β] [DecidableEq β]
+    (V : Matrix β α ℂ) (hV : Vᴴ * V = 1)
+    (ρ : Matrix α α ℂ) (hρ : ρ.IsHermitian) :
+    vonNeumannEntropy (singleKrausMap V ρ)
+        (Matrix.isHermitian_mul_mul_conjTranspose V hρ) =
+      vonNeumannEntropy ρ hρ := by
+  have hABeq : V * ρ * Vᴴ = V * (ρ * Vᴴ) := Matrix.mul_assoc V ρ Vᴴ
+  have hAB : (V * (ρ * Vᴴ)).IsHermitian := hABeq ▸
+    Matrix.isHermitian_mul_mul_conjTranspose V hρ
+  have hBAeq : (ρ * Vᴴ) * V = ρ := by
+    rw [Matrix.mul_assoc, hV, Matrix.mul_one]
+  have hBA : ((ρ * Vᴴ) * V).IsHermitian := hBAeq.symm ▸ hρ
+  calc
+    vonNeumannEntropy (singleKrausMap V ρ)
+        (Matrix.isHermitian_mul_mul_conjTranspose V hρ) =
+        vonNeumannEntropy (V * (ρ * Vᴴ)) hAB :=
+      vonNeumannEntropy_congr hABeq
+        (Matrix.isHermitian_mul_mul_conjTranspose V hρ) hAB
+    _ = vonNeumannEntropy ((ρ * Vᴴ) * V) hBA :=
+      vonNeumannEntropy_mul_comm V (ρ * Vᴴ) hAB hBA
+    _ = vonNeumannEntropy ρ hρ :=
+      vonNeumannEntropy_congr hBAeq hBA hρ
+
+namespace Matrix
+
+/-- Positivity can be read back through an isometric single-Kraus
+conjugation. -/
+theorem posSemidef_of_singleKraus_isometry
+    {α β : Type*} [Fintype α] [DecidableEq α]
+    [Fintype β]
+    (V : Matrix β α ℂ) (hV : Vᴴ * V = 1) {X : Matrix α α ℂ}
+    (hX : (singleKrausMap V X).PosSemidef) : X.PosSemidef := by
+  classical
+  have hback := hX.mul_mul_conjTranspose_same Vᴴ
+  simp only [singleKrausMap_apply,
+    Matrix.conjTranspose_conjTranspose] at hback
+  have heq : Vᴴ * (V * X * Vᴴ) * V = X := by
+    calc
+      _ = (Vᴴ * V) * X * (Vᴴ * V) := by
+        simp only [← Matrix.mul_assoc]
+      _ = X := by rw [hV, Matrix.one_mul, Matrix.mul_one]
+  rw [heq] at hback
+  exact hback
+
+end Matrix
+
+namespace MPOTensor
+
+variable {d e D : ℕ}
+
+open PhysicalSectorFactorization
+
+/-- The sitewise tensor power of a one-site isometry is an isometry. -/
+theorem sitewisePhysicalMatrix_isometry
+    (V : Matrix (Fin e) (Fin d) ℂ) (hV : Vᴴ * V = 1) (N : ℕ) :
+    (sitewisePhysicalMatrix V N)ᴴ * sitewisePhysicalMatrix V N = 1 := by
+  classical
+  ext x y
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply,
+    sitewisePhysicalMatrix]
+  simp_rw [star_prod, ← Finset.prod_mul_distrib]
+  rw [← Fintype.piFinset_univ]
+  rw [← Finset.prod_univ_sum
+    (fun _ : Fin N ↦ (Finset.univ : Finset (Fin e)))
+    (fun n a ↦ star (V a (x n)) * V a (y n))]
+  have hentry : ∀ n : Fin N,
+      (∑ a : Fin e, star (V a (x n)) * V a (y n)) =
+        if x n = y n then 1 else 0 := by
+    intro n
+    simpa only [Matrix.mul_apply, Matrix.conjTranspose_apply,
+      Matrix.one_apply] using congrFun (congrFun hV (x n)) (y n)
+  simp_rw [hentry]
+  rw [Fintype.prod_boole]
+  congr 1
+  exact propext funext_iff.symm
+
+/-- An isometric physical inclusion preserves the trace of every periodic
+MPO, including every positive-length chain used by SAL. -/
+theorem trace_mpo_changePhysicalBasis_of_isometry
+    (V : Matrix (Fin e) (Fin d) ℂ) (hV : Vᴴ * V = 1)
+    (M : MPOTensor d D) (N : ℕ) :
+    Matrix.trace (mpo (changePhysicalBasis V M) N) =
+      Matrix.trace (mpo M N) := by
+  rw [← singleKrausMap_sitewisePhysicalMatrix_mpo]
+  exact (singleKrausMap_isKrausCPTP (sitewisePhysicalMatrix V N)
+    (sitewisePhysicalMatrix_isometry V hV N)).trace_map (mpo M N)
+
+/-- Normalization commutes with an isometric physical inclusion. -/
+theorem normalizedMPO_changePhysicalBasis_of_isometry
+    (V : Matrix (Fin e) (Fin d) ℂ) (hV : Vᴴ * V = 1)
+    (M : MPOTensor d D) (N : ℕ) :
+    normalizedMPO (changePhysicalBasis V M) N =
+      singleKrausMap (sitewisePhysicalMatrix V N) (normalizedMPO M N) := by
+  rw [normalizedMPO, normalizedMPO,
+    trace_mpo_changePhysicalBasis_of_isometry V hV M N,
+    ← singleKrausMap_sitewisePhysicalMatrix_mpo]
+  exact ((singleKrausMap (sitewisePhysicalMatrix V N)).map_smul _ _).symm
+
+/-- After splitting a chain into a prefix and suffix, the sitewise physical
+matrix is the Kronecker product of the corresponding prefix and suffix
+matrices. -/
+theorem reindex_sitewisePhysicalMatrix_blockSplit
+    (V : Matrix (Fin e) (Fin d) ℂ) (L K : ℕ) :
+    Matrix.reindex (blockSplitEquiv e L K)
+        (blockSplitEquiv d L K)
+        (sitewisePhysicalMatrix V (L + K)) =
+      Matrix.kroneckerMap (· * ·)
+        (sitewisePhysicalMatrix V L) (sitewisePhysicalMatrix V K) := by
+  ext ⟨a, b⟩ ⟨x, y⟩
+  simp only [Matrix.reindex_apply, Matrix.submatrix_apply, sitewisePhysicalMatrix,
+    Matrix.kroneckerMap_apply, blockSplitEquiv_symm_apply]
+  rw [Fin.prod_univ_add]
+  simp
+
+/-- Reassociating the chain length from `N` to `L + (N - L)` does not alter
+the sitewise physical matrix. -/
+theorem reindex_sitewisePhysicalMatrix_blockReindex
+    (V : Matrix (Fin e) (Fin d) ℂ) (N L : ℕ) (hL : L ≤ N) :
+    Matrix.reindex (blockReindexEquiv e N L hL)
+        (blockReindexEquiv d N L hL) (sitewisePhysicalMatrix V N) =
+      sitewisePhysicalMatrix V (L + (N - L)) := by
+  ext s t
+  simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
+    sitewisePhysicalMatrix, blockReindexEquiv, Equiv.arrowCongr_symm,
+    Equiv.refl_symm, Equiv.arrowCongr_apply, Equiv.coe_refl,
+    finCongr_symm]
+  exact Fintype.prod_equiv (finCongr (Nat.add_sub_cancel' hL)).symm
+    (fun i : Fin N ↦ V (s ((finCongr (Nat.add_sub_cancel' hL)).symm i))
+      (t ((finCongr (Nat.add_sub_cancel' hL)).symm i)))
+    (fun i : Fin (L + (N - L)) ↦ V (s i) (t i)) (fun _ ↦ rfl)
+
+/-- A sitewise isometry commutes with taking a contiguous prefix marginal.
+The isometry on the discarded suffix disappears under the partial trace. -/
+theorem blockReducedState_singleKraus_sitewise
+    (V : Matrix (Fin e) (Fin d) ℂ) (hV : Vᴴ * V = 1)
+    (L K : ℕ)
+    (X : Matrix (Fin (L + K) → Fin d) (Fin (L + K) → Fin d) ℂ) :
+    blockReducedState e L K
+        (singleKrausMap (sitewisePhysicalMatrix V (L + K)) X) =
+      singleKrausMap (sitewisePhysicalMatrix V L)
+        (blockReducedState d L K X) := by
+  change Matrix.partialTraceRight
+      (Matrix.reindex (blockSplitEquiv e L K) (blockSplitEquiv e L K)
+        (singleKrausMap (sitewisePhysicalMatrix V (L + K)) X)) = _
+  rw [Matrix.reindex_singleKrausMap
+      (blockSplitEquiv d L K) (blockSplitEquiv e L K),
+    reindex_sitewisePhysicalMatrix_blockSplit]
+  exact Matrix.partialTraceRight_singleKraus_kronecker_isometry
+    (sitewisePhysicalMatrix V L) (sitewisePhysicalMatrix V K)
+    (sitewisePhysicalMatrix_isometry V hV K)
+    (Matrix.reindex (blockSplitEquiv d L K) (blockSplitEquiv d L K) X)
+
+/-- Every contiguous marginal of a physically included MPO is the isometric
+conjugate of the corresponding marginal before inclusion. -/
+theorem reducedBlockState_changePhysicalBasis_of_isometry
+    (V : Matrix (Fin e) (Fin d) ℂ) (hV : Vᴴ * V = 1)
+    (M : MPOTensor d D) (N L : ℕ) (hL : L ≤ N) :
+    reducedBlockState (changePhysicalBasis V M) N L hL =
+      singleKrausMap (sitewisePhysicalMatrix V L)
+        (reducedBlockState M N L hL) := by
+  rw [reducedBlockState, reducedBlockState,
+    normalizedMPO_changePhysicalBasis_of_isometry V hV]
+  change blockReducedState e L (N - L)
+      (Matrix.reindex (blockReindexEquiv e N L hL)
+        (blockReindexEquiv e N L hL)
+        (singleKrausMap (sitewisePhysicalMatrix V N)
+          (normalizedMPO M N))) = _
+  rw [Matrix.reindex_singleKrausMap
+      (blockReindexEquiv d N L hL) (blockReindexEquiv e N L hL),
+    reindex_sitewisePhysicalMatrix_blockReindex]
+  exact blockReducedState_singleKraus_sitewise V hV L (N - L)
+    (Matrix.reindex (blockReindexEquiv d N L hL)
+      (blockReindexEquiv d N L hL) (normalizedMPO M N))
+
+/-- If an MPO is positive after an isometric physical inclusion, then it was
+already positive before inclusion. -/
+theorem isMPDO_of_changePhysicalBasis_isMPDO_of_isometry
+    (V : Matrix (Fin e) (Fin d) ℂ) (hV : Vᴴ * V = 1)
+    (M : MPOTensor d D) (hM : IsMPDO (changePhysicalBasis V M)) :
+    IsMPDO M := by
+  intro N hN
+  apply Matrix.posSemidef_of_singleKraus_isometry
+    (sitewisePhysicalMatrix V N) (sitewisePhysicalMatrix_isometry V hV N)
+  rw [singleKrausMap_sitewisePhysicalMatrix_mpo]
+  exact hM N hN
+
+/-- An isometric physical inclusion does not change a contiguous block
+entropy. -/
+theorem blockEntropy_changePhysicalBasis_of_isometry
+    (V : Matrix (Fin e) (Fin d) ℂ) (hV : Vᴴ * V = 1)
+    (M : MPOTensor d D) (N L : ℕ) (hL : L ≤ N)
+    (hM : (mpo M N).PosSemidef) :
+    blockEntropy (changePhysicalBasis V M) N L hL
+        (by
+          rw [← singleKrausMap_sitewisePhysicalMatrix_mpo]
+          exact hM.mul_mul_conjTranspose_same
+            (sitewisePhysicalMatrix V N)) =
+      blockEntropy M N L hL hM := by
+  let hM' : (mpo (changePhysicalBasis V M) N).PosSemidef := by
+    rw [← singleKrausMap_sitewisePhysicalMatrix_mpo]
+    exact hM.mul_mul_conjTranspose_same (sitewisePhysicalMatrix V N)
+  let hρ := reducedBlockState_isHermitian M N L hL hM
+  let hρ' := Matrix.isHermitian_mul_mul_conjTranspose
+    (sitewisePhysicalMatrix V L) hρ
+  change vonNeumannEntropy
+      (reducedBlockState (changePhysicalBasis V M) N L hL)
+        (reducedBlockState_isHermitian
+          (changePhysicalBasis V M) N L hL hM') =
+    vonNeumannEntropy (reducedBlockState M N L hL) hρ
+  have hred := reducedBlockState_changePhysicalBasis_of_isometry
+    V hV M N L hL
+  calc
+    _ = vonNeumannEntropy
+        (singleKrausMap (sitewisePhysicalMatrix V L)
+          (reducedBlockState M N L hL)) hρ' :=
+      vonNeumannEntropy_congr hred _ _
+    _ = _ := vonNeumannEntropy_singleKraus_isometry
+      (sitewisePhysicalMatrix V L) (sitewisePhysicalMatrix_isometry V hV L)
+      (reducedBlockState M N L hL) hρ
+
+/-- An isometric physical inclusion does not change the mutual information
+between a contiguous block and its complement. -/
+theorem mutualInfoChain_changePhysicalBasis_of_isometry
+    (V : Matrix (Fin e) (Fin d) ℂ) (hV : Vᴴ * V = 1)
+    (M : MPOTensor d D) (N L : ℕ) (hL : L ≤ N)
+    (hM : (mpo M N).PosSemidef) :
+    mutualInfoChain (changePhysicalBasis V M) N L hL
+        (by
+          rw [← singleKrausMap_sitewisePhysicalMatrix_mpo]
+          exact hM.mul_mul_conjTranspose_same
+            (sitewisePhysicalMatrix V N)) =
+      mutualInfoChain M N L hL hM := by
+  simp only [mutualInfoChain]
+  rw [blockEntropy_changePhysicalBasis_of_isometry V hV,
+    blockEntropy_changePhysicalBasis_of_isometry V hV,
+    blockEntropy_changePhysicalBasis_of_isometry V hV]
+
+/-- Saturation of the area law descends through an isometric physical
+inclusion.  Only positive chain lengths occur, as in Definition 4.6.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `PjKiPj` and
+`generateMPDO`, lines 1733--1770. -/
+theorem isSAL_of_changePhysicalBasis_isSAL_of_isometry
+    (V : Matrix (Fin e) (Fin d) ℂ) (hV : Vᴴ * V = 1)
+    (M : MPOTensor d D) (hSAL : IsSAL (changePhysicalBasis V M)) :
+    IsSAL M := by
+  obtain ⟨hAmbientMpdo, hAmbientTrace, hAmbientStep⟩ := hSAL
+  let hMpdo := isMPDO_of_changePhysicalBasis_isMPDO_of_isometry
+    V hV M hAmbientMpdo
+  refine ⟨hMpdo, ?_, ?_⟩
+  · intro N hN
+    rw [← trace_mpo_changePhysicalBasis_of_isometry V hV]
+    exact hAmbientTrace N hN
+  · intro N L hL hLN
+    have hstep := hAmbientStep N L hL hLN
+    rw [mutualInfoChain_changePhysicalBasis_of_isometry V hV M N L
+        (Nat.le_of_lt (hLN.trans_le (Nat.div_le_self N 2))) (hMpdo N (by omega)),
+      mutualInfoChain_changePhysicalBasis_of_isometry V hV M N (L + 1)
+        (hLN.trans_le (Nat.div_le_self N 2)) (hMpdo N (by omega))] at hstep
+    exact hstep
+
+/-- The injective tensor obtained by restricting to an orthogonal physical
+support inherits saturation of the area law from the ambient tensor.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `PjKiPj` and
+`generateMPDO`, lines 1733--1770. -/
+theorem PhysicalSupportRestrictionData.restricted_isSAL
+    {P : Matrix (Fin d) (Fin d) ℂ} {K : MPOTensor d D}
+    (F : PhysicalSupportRestrictionData P K) (hSAL : IsSAL K) :
+    IsSAL (changePhysicalBasis F.inclusionᴴ K) := by
+  apply isSAL_of_changePhysicalBasis_isSAL_of_isometry
+    F.inclusion F.inclusion_isometry
+  rw [F.reembed]
+  exact hSAL
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
@@ -208,6 +208,32 @@ Definition~\ref{def:mpdo_source_gsnnch}; the converse comparison is not used.
     injective.  The two isometry identities give the exact reconstruction.
 \end{proof}
 
+\begin{theorem}[SAL passes to the physical support restriction]
+    \label{thm:mpdo_physical_support_restriction_sal}
+    \lean{MPOTensor.PhysicalSupportRestrictionData.restricted_isSAL}
+    \leanok
+    \uses{def:mpdo_physical_support_restriction}
+    If $K$ satisfies saturation of the area law and
+    $K=V K_P V^*$ is a physical support restriction, then the injective
+    restricted tensor $K_P$ also satisfies saturation of the area law.
+\end{theorem}
+
+\begin{proof}\leanok
+    On a chain of every positive length, the sitewise inclusion
+    $V^{\otimes N}$ is an isometry and
+    \[
+        \rho^{(N)}(K)
+        =V^{\otimes N}\rho^{(N)}(K_P)(V^{\otimes N})^*.
+    \]
+    The trace is therefore unchanged.  After a contiguous marginal is
+    taken, the isometry on the traced-out sites disappears, while the
+    isometry on the retained sites remains.  Thus every block marginal of
+    $K$ is an isometric conjugate of the corresponding marginal of $K_P$.
+    Their nonzero spectra, and hence their entropies and mutual
+    informations, coincide.  The consecutive equalities defining SAL for
+    $K$ consequently give those for $K_P$.
+\end{proof}
+
 \begin{definition}[Orthogonally supported commuting sector products]
     \label{def:mpdo_orthogonal_commuting_sector_family}
     \lean{MPOTensor.OrthogonalCommutingSectorFamily}

--- a/docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex
+++ b/docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex
@@ -106,17 +106,20 @@ natural multiplicities.
 {\scriptsize\leanid{MPOTensor.hasGSNNCHForm_of_orthogonalCommutingSectorFamily}}.}
 The first part of the support-preserving sector argument is also complete.
 Every absorbed BNT representative has an exact isometric restriction to the
-range of its matching projector, and the restricted tensor is injective.
+range of its matching projector, the restricted tensor is injective, and SAL
+passes from the ambient representative to this restriction through the
+sitewise support isometry.
 \footnote{\raggedright Formal declarations:
-{\scriptsize\leanid{MPOTensor.PhysicalSupportRestrictionData}} and
-{\scriptsize\leanid{MPOTensor.nonempty_physicalSupportRestrictionData_commonWeightAbsorbedBasis}}.}
+{\scriptsize\leanid{MPOTensor.PhysicalSupportRestrictionData}},
+{\scriptsize\leanid{MPOTensor.nonempty_physicalSupportRestrictionData_commonWeightAbsorbedBasis}},
+and
+{\scriptsize\leanid{MPOTensor.PhysicalSupportRestrictionData.restricted_isSAL}}.}
 The remaining comparison has two parts:
 
 \begin{enumerate}
-  \item transport the sectorwise saturated area law through the support
-        isometry, apply the injective commuting-product theorem to the
-        restricted tensor, and transport its positive bond back to the
-        ambient one-site space, proving
+  \item apply the injective commuting-product theorem to the restricted
+        tensor and transport its positive bond back to the ambient one-site
+        space, proving
         $(P_j\otimes P_j)B^{(j)}(P_j\otimes P_j)=B^{(j)}$;
   \item determine whether the reverse comparison with a single bond is needed
         in the simple-MPDO equivalence, and prove it only in that form.
@@ -137,8 +140,8 @@ tensor, the BNT projectors, their positive-length compression formula, and the
 sectorwise MPDO, SAL, and ZCL conclusions are formalized.  The abstract
 construction of the outer sector sum with its natural multiplicities is
 formalized, as is the injective restriction of every representative to its
-projector range.  The open gap is the isometric transport of SAL and of the
-resulting positive commuting bond, together with any reverse comparison
-actually needed by the simple-MPDO equivalence.
+projector range.  SAL is invariant under the support isometry.  The open gap
+is the transport of the resulting positive commuting bond, together with any
+reverse comparison actually needed by the simple-MPDO equivalence.
 
 \end{document}


### PR DESCRIPTION
## Summary

This proves that saturation of the area law passes from an MPO tensor to its injective restriction on an orthogonal one-site support. It supplies the missing prerequisite for applying the injective commuting-product theorem inside each BNT sector in #4126.

For an isometry V, the proof establishes that:

- the periodic MPO and its normalized state are conjugated by the sitewise isometry V^{⊗N};
- every contiguous marginal is conjugated by the retained tensor power of V, because the isometry on the discarded factor disappears under partial trace;
- von Neumann entropy and mutual information are therefore unchanged;
- MPDO positivity, trace nonvanishing, and SAL descend to the restricted tensor.

The new theorem is recorded in the blueprint, and the CPSV16 sector-decomposition gap note now identifies positive-bond transport as the remaining part of #4126.

No empty periodic chain is introduced. All physical MPO and SAL uses have N > 0; the zero-site complement at L = N is only the tensor unit of the partial trace.

## Source

- arXiv:1606.00608, Appendix C.2, equations `PjKiPj` and `generateMPDO`, lines 1733–1770
- `docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex`

## Verification

- `lake build TNLean.MPS.MPDO.PhysicalSupportSALTransport` with Lean/mathlib 4.32
- `lake build TNLean` with Lean/mathlib 4.32
- `leanblueprint pdf`
- declaration check for `MPOTensor.PhysicalSupportRestrictionData.restricted_isSAL`
- kernel axiom audit: only `propext`, `Classical.choice`, and `Quot.sound`
- no `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast` in the new module

Advances #4126. Tracking: #4003.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal mathematics (new Lean proofs and documentation); no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **`PhysicalSupportSALTransport.lean`** and wires it into the root import list so saturated area law (**SAL**) is proved to survive restricting an MPO to an orthogonal one-site physical support via the sitewise isometry **V^⊗N**.
> 
> The proof chain shows periodic states and contiguous marginals are isometric conjugates (partial trace drops the discarded factor), so **trace**, **MPDO positivity**, **block entropy**, **mutual information**, and **IsSAL** match before and after `changePhysicalBasis`. The capstone is **`PhysicalSupportRestrictionData.restricted_isSAL`**, closing the range-restriction step before injective Proposition C.8 in each BNT sector.
> 
> **Blueprint** records theorem `thm:mpdo_physical_support_restriction_sal`; the **CPSV16 sector-decomposition gap note** now treats SAL transport as done and leaves positive-bond transport (and any needed reverse comparison) as the remaining work for #4126.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 377430c9e00245b5aec946c8ea67de111ebf150e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->