### PR TITLE
feat(MPS/MPDO): lift bonds through physical support

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -457,6 +457,7 @@ import TNLean.MPS.MPDO.SitewisePhysicalMatrix
 import TNLean.MPS.MPDO.BNTProjectorSelection
 import TNLean.MPS.MPDO.PhysicalSupportRestriction
 import TNLean.MPS.MPDO.PhysicalSupportSALTransport
+import TNLean.MPS.MPDO.PhysicalSupportBondTransport
 import TNLean.MPS.MPDO.BNTSectorAnalyticProperties
 import TNLean.MPS.MPDO.BNTSectorAreaLaw
 import TNLean.MPS.MPDO.HayashiSectorProjector

--- a/TNLean/MPS/MPDO/PhysicalSupportBondTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSupportBondTransport.lean
@@ -1,0 +1,172 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.GSNNCHOrthogonalSectors
+import TNLean.MPS.MPDO.PhysicalSupportSALTransport
+
+/-!
+# Two-site bonds on a physical support
+
+The positive commuting bond obtained from Proposition C.8 after restricting an
+MPO tensor to an orthogonal one-site support is carried back to the ambient
+physical space by the tensor square of the support inclusion.  The resulting
+bond is positive and acts entirely within the prescribed two-site sector.
+
+All chain statements used in this construction concern positive lengths.
+In particular, saturation of the area law itself excludes zero physical and
+virtual dimensions.  No empty periodic chain is introduced.
+
+The support transport is purely algebraic.  The final existence theorem uses
+the already formalized Proposition C.8 and hence inherits its sanctioned
+dependence on `hayashi_ssa_equality_characterization_forward`; it introduces
+no further axiom.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, equations `PjKiPj` and `generateMPDO`, lines 1733--1770
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+namespace MPOTensor
+
+variable {d e D : ℕ}
+
+/-- Saturation of the area law excludes a zero-dimensional physical space.
+Only the one-site chain is used.
+
+Source: arXiv:1606.00608, Definition 4.6, line 811. -/
+theorem physicalDim_pos_of_isSAL (M : MPOTensor d D) (hSAL : IsSAL M) :
+    0 < d := by
+  by_contra hd
+  have hd0 : d = 0 := Nat.eq_zero_of_not_pos hd
+  subst d
+  obtain ⟨_, htrace, _⟩ := hSAL
+  simpa [mpo, mpoMatrixEntry] using htrace 1 (by omega)
+
+/-- Saturation of the area law excludes a zero-dimensional virtual space.
+Only the one-site chain is used.
+
+Source: arXiv:1606.00608, Definition 4.6, line 811. -/
+theorem bondDim_pos_of_isSAL (M : MPOTensor d D) (hSAL : IsSAL M) :
+    0 < D := by
+  by_contra hD
+  have hD0 : D = 0 := Nat.eq_zero_of_not_pos hD
+  subst D
+  obtain ⟨_, htrace, _⟩ := hSAL
+  have hzero : mpo M 1 = 0 := by
+    ext s t
+    simp [mpo, mpoMatrixEntry, evalWord]
+  exact htrace 1 (by omega) (by rw [hzero, Matrix.trace_zero])
+
+/-- On two sites, the sitewise matrix of a one-site operator is its Kronecker
+square in configuration coordinates. -/
+theorem sitewisePhysicalMatrix_two_eq_twoSiteSectorProjection
+    (P : Matrix (Fin d) (Fin d) ℂ) :
+    sitewisePhysicalMatrix P 2 = twoSiteSectorProjection P := by
+  ext s t
+  simp [sitewisePhysicalMatrix, twoSiteSectorProjection,
+    finTwoArrowEquiv, Matrix.reindex_apply]
+
+/-- The sitewise tensor square of an isometry has the corresponding tensor
+square of its range projection as its range projection. -/
+theorem sitewisePhysicalMatrix_two_mul_conjTranspose
+    (V : Matrix (Fin d) (Fin e) ℂ) :
+    sitewisePhysicalMatrix V 2 * (sitewisePhysicalMatrix V 2)ᴴ =
+      twoSiteSectorProjection (V * Vᴴ) := by
+  rw [← sitewisePhysicalMatrix_two_eq_twoSiteSectorProjection]
+  classical
+  ext s t
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply,
+    sitewisePhysicalMatrix, star_prod]
+  simp_rw [← Finset.prod_mul_distrib]
+  rw [← Fintype.piFinset_univ]
+  rw [← Finset.prod_univ_sum
+    (fun _ : Fin 2 ↦ (Finset.univ : Finset (Fin e)))
+    (fun n a ↦ V (s n) a * star (V (t n) a))]
+
+namespace PhysicalSupportRestrictionData
+
+variable {P : Matrix (Fin d) (Fin d) ℂ} {K : MPOTensor d D}
+
+/-- A two-site bond on the restricted physical space, included into the
+ambient physical space. -/
+noncomputable def liftedBond (F : PhysicalSupportRestrictionData P K)
+    (B : Matrix (Fin 2 → Fin F.supportDim)
+      (Fin 2 → Fin F.supportDim) ℂ) :
+    Matrix (Fin 2 → Fin d) (Fin 2 → Fin d) ℂ :=
+  singleKrausMap (sitewisePhysicalMatrix F.inclusion 2) B
+
+/-- Positivity of a restricted two-site bond is preserved by its inclusion
+into the ambient physical space. -/
+theorem liftedBond_pos (F : PhysicalSupportRestrictionData P K)
+    {B : Matrix (Fin 2 → Fin F.supportDim)
+      (Fin 2 → Fin F.supportDim) ℂ} (hB : B.PosSemidef) :
+    (F.liftedBond B).PosSemidef :=
+  hB.mul_mul_conjTranspose_same (sitewisePhysicalMatrix F.inclusion 2)
+
+/-- The tensor square of the support inclusion has the prescribed two-site
+sector as its range. -/
+theorem twoSiteSectorProjection_eq_lifted_range
+    (F : PhysicalSupportRestrictionData P K) :
+    twoSiteSectorProjection P =
+      sitewisePhysicalMatrix F.inclusion 2 *
+        (sitewisePhysicalMatrix F.inclusion 2)ᴴ := by
+  rw [sitewisePhysicalMatrix_two_mul_conjTranspose, F.inclusion_range]
+
+/-- A lifted bond acts entirely within the tensor square of the prescribed
+one-site support.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `PjKiPj` and
+`generateMPDO`, lines 1733--1770. -/
+theorem liftedBond_supported (F : PhysicalSupportRestrictionData P K)
+    (B : Matrix (Fin 2 → Fin F.supportDim)
+      (Fin 2 → Fin F.supportDim) ℂ) :
+    twoSiteSectorProjection P * F.liftedBond B *
+      twoSiteSectorProjection P = F.liftedBond B := by
+  rw [F.twoSiteSectorProjection_eq_lifted_range]
+  simp only [liftedBond, singleKrausMap_apply, Matrix.mul_assoc]
+  rw [← Matrix.mul_assoc
+      (sitewisePhysicalMatrix F.inclusion 2)ᴴ
+      (sitewisePhysicalMatrix F.inclusion 2),
+    sitewisePhysicalMatrix_isometry F.inclusion F.inclusion_isometry 2,
+    Matrix.one_mul]
+  rw [← Matrix.mul_assoc
+      (sitewisePhysicalMatrix F.inclusion 2)ᴴ
+      (sitewisePhysicalMatrix F.inclusion 2),
+    sitewisePhysicalMatrix_isometry F.inclusion F.inclusion_isometry 2,
+    Matrix.one_mul]
+
+/-- The physical support obtained from an SAL tensor has positive dimension.
+Thus no zero-dimensional restricted physical space occurs in the application
+of Proposition C.8. -/
+theorem supportDim_pos (F : PhysicalSupportRestrictionData P K)
+    (hSAL : IsSAL K) : 0 < F.supportDim :=
+  physicalDim_pos_of_isSAL _ (F.restricted_isSAL hSAL)
+
+/-- Proposition C.8 applied on the injective physical support supplies a
+positive two-site bond whose lift to the ambient physical space is supported
+on the prescribed two-site sector.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`) and
+equations `PjKiPj` and `generateMPDO`, lines 1571--1593 and 1733--1770. -/
+theorem exists_etaLocalStructureData_liftedBond_supported
+    (F : PhysicalSupportRestrictionData P K) (hSAL : IsSAL K) :
+    ∃ data : EtaLocalStructureData
+        (PhysicalSectorFactorization.changePhysicalBasis F.inclusionᴴ K),
+      (F.liftedBond data.bondData.bond).PosSemidef ∧
+        twoSiteSectorProjection P * F.liftedBond data.bondData.bond *
+          twoSiteSectorProjection P = F.liftedBond data.bondData.bond := by
+  obtain ⟨data⟩ := nonempty_etaLocalStructureData_of_isSAL
+    (PhysicalSectorFactorization.changePhysicalBasis F.inclusionᴴ K)
+    F.restricted_injective
+    (F.restricted_isSAL hSAL)
+  exact ⟨data, F.liftedBond_pos data.bondData.bond_pos,
+    F.liftedBond_supported data.bondData.bond⟩
+
+end PhysicalSupportRestrictionData
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
@@ -234,6 +234,28 @@ Definition~\ref{def:mpdo_source_gsnnch}; the converse comparison is not used.
     $K$ consequently give those for $K_P$.
 \end{proof}
 
+\begin{theorem}[The restricted commuting bond has a supported lift]
+    \label{thm:mpdo_physical_support_restriction_bond}
+    \lean{MPOTensor.PhysicalSupportRestrictionData.exists_etaLocalStructureData_liftedBond_supported}
+    \leanok
+    \uses{thm:mpdo_physical_support_restriction_sal}
+    Let $K=V K_P V^*$ be a physical support restriction of an MPO tensor
+    satisfying SAL.  Proposition~C.8 applied to the injective tensor $K_P$
+    gives a positive two-site bond $B_P$.  Its lift
+    $B=V^{\otimes 2}B_P(V^{\otimes 2})^*$ is positive and satisfies
+    \[
+        (P\otimes P)B(P\otimes P)=B.
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    The preceding theorem gives SAL for the injective restricted tensor, so
+    Proposition~C.8 supplies its positive bond.  Since $V^*V=1$, positivity
+    is preserved under conjugation by $V^{\otimes 2}$.  Moreover,
+    $V^{\otimes 2}(V^{\otimes 2})^*=P\otimes P$; multiplying the lifted bond
+    by this projection on either side therefore leaves it unchanged.
+\end{proof}
+
 \begin{definition}[Orthogonally supported commuting sector products]
     \label{def:mpdo_orthogonal_commuting_sector_family}
     \lean{MPOTensor.OrthogonalCommutingSectorFamily}

--- a/docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex
+++ b/docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex
@@ -106,21 +106,23 @@ natural multiplicities.
 {\scriptsize\leanid{MPOTensor.hasGSNNCHForm_of_orthogonalCommutingSectorFamily}}.}
 The first part of the support-preserving sector argument is also complete.
 Every absorbed BNT representative has an exact isometric restriction to the
-range of its matching projector, the restricted tensor is injective, and SAL
+range of its matching projector, the restricted tensor is injective, SAL
 passes from the ambient representative to this restriction through the
-sitewise support isometry.
+sitewise support isometry, and the positive Proposition~C.8 bond lifts to a
+positive two-site operator supported on the tensor square of that projector.
 \footnote{\raggedright Formal declarations:
 {\scriptsize\leanid{MPOTensor.PhysicalSupportRestrictionData}},
 {\scriptsize\leanid{MPOTensor.nonempty_physicalSupportRestrictionData_commonWeightAbsorbedBasis}},
+{\scriptsize\leanid{MPOTensor.PhysicalSupportRestrictionData.restricted_isSAL}},
 and
-{\scriptsize\leanid{MPOTensor.PhysicalSupportRestrictionData.restricted_isSAL}}.}
+{\scriptsize\leanid{MPOTensor.PhysicalSupportRestrictionData.exists_etaLocalStructureData_liftedBond_supported}}.}
 The remaining comparison has two parts:
 
 \begin{enumerate}
-  \item apply the injective commuting-product theorem to the restricted
-        tensor and transport its positive bond back to the ambient one-site
-        space, proving
-        $(P_j\otimes P_j)B^{(j)}(P_j\otimes P_j)=B^{(j)}$;
+  \item transport commutativity and the exact finite-chain product identity
+        of the restricted bond through the support isometry; its positive
+        ambient lift and the identity
+        $(P_j\otimes P_j)B^{(j)}(P_j\otimes P_j)=B^{(j)}$ are formalized;
   \item determine whether the reverse comparison with a single bond is needed
         in the simple-MPDO equivalence, and prove it only in that form.
 \end{enumerate}
@@ -140,8 +142,10 @@ tensor, the BNT projectors, their positive-length compression formula, and the
 sectorwise MPDO, SAL, and ZCL conclusions are formalized.  The abstract
 construction of the outer sector sum with its natural multiplicities is
 formalized, as is the injective restriction of every representative to its
-projector range.  SAL is invariant under the support isometry.  The open gap
-is the transport of the resulting positive commuting bond, together with any
-reverse comparison actually needed by the simple-MPDO equivalence.
+projector range.  SAL is invariant under the support isometry, and the
+resulting positive bond has a positive ambient lift supported on the matching
+two-site sector.  The open gap is the transport of commutativity and the exact
+finite-chain product identity, together with any reverse comparison actually
+needed by the simple-MPDO equivalence.
 
 \end{document}


### PR DESCRIPTION
## Summary

- prove that SAL excludes zero physical and virtual dimensions using the one-site chain
- lift the positive Proposition C.8 bond from an injective physical support to the ambient two-site space
- prove positivity and the exact support identity `(P ⊗ P) B (P ⊗ P) = B`
- record the completed support-lift step and the remaining commutativity/product transport in the paper-gap note

## Source faithfulness

This follows arXiv:1606.00608, Appendix C.2, especially Proposition C.8 and equations `PjKiPj` and `generateMPDO`. It introduces no empty periodic chain and no new axiom. The final existence theorem inherits the already sanctioned Hayashi equality-characterization axiom through the existing Proposition C.8 formalization.

Advances #4126.

## Validation

- `lake env lean TNLean/MPS/MPDO/PhysicalSupportBondTransport.lean`
- `lake build TNLean.MPS.MPDO.PhysicalSupportBondTransport`
- `lake build TNLean`
- `leanblueprint pdf`
- forbidden-token, line-length, and `git diff --check` audits

The local `leanblueprint checkdecls` wrapper could not generate its declaration list because the installed Python environment could not import the repository leanblueprint package hooks. The tagged declaration is nevertheless checked by the module and full Lean builds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style formalization and documentation on an existing MPDO/GSNNCH track; no runtime, auth, or data-path changes. Residual proof risk is confined to downstream Lean obligations that still depend on the Hayashi axiom chain already used by Proposition C.8.
> 
> **Overview**
> Adds **`PhysicalSupportBondTransport`**, which lifts the positive two-site bond from Proposition C.8 on an injective **physical-support restriction** back to the ambient space via the sitewise inclusion \(V^{\otimes 2}\), and proves **positivity** and the sector support identity \((P \otimes P) B (P \otimes P) = B\).
> 
> Also shows **SAL** forces **positive physical and virtual dimensions** (so restricted supports are nonempty in this pipeline), and packages existence of **`EtaLocalStructureData`** with a lifted bond satisfying those properties. The blueprint and GSNNCH paper-gap note mark this support-lift step as done; **commutativity** and the **exact finite-chain product identity** through the isometry remain open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 836207317ea216183ff189ac4395e12a61027d87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->