### PR TITLE
feat(MPS/MPDO): transport commuting support bonds

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -497,6 +497,8 @@ import TNLean.MPS.MPDO.InverseMapActiveSectorPrimitivity
 import TNLean.MPS.MPDO.PhysicalSectorPositiveBond
 import TNLean.MPS.MPDO.PhysicalSectorBondCommutativity
 import TNLean.MPS.MPDO.PhysicalSectorBondTransport
+import TNLean.MPS.MPDO.IsometricAdjacentBondTransport
+import TNLean.MPS.MPDO.PhysicalSupportBondCommutativity
 import TNLean.MPS.MPDO.PhysicalSectorBondTwoSite
 import TNLean.MPS.MPDO.PhysicalSectorBondPairwise
 import TNLean.MPS.MPDO.PhysicalSectorChainDecomposition

--- a/TNLean/MPS/MPDO/IsometricAdjacentBondTransport.lean
+++ b/TNLean/MPS/MPDO/IsometricAdjacentBondTransport.lean
@@ -1,0 +1,594 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalSupportBondTransport
+
+/-!
+# Isometric transport of adjacent two-site bonds
+
+If a one-site isometry includes a physical subspace into an ambient physical
+space, conjugation of a product of two adjacent restricted bonds is exactly
+the product of their two ambient lifts.  The shared physical index contracts
+through the isometry identity.  No coisometry is used.
+
+The calculation takes place on a three-site chain.  Thus it has no empty-chain
+case and is the local input for transporting neighboring commutativity through
+an orthogonal physical support.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, equations `PjKiPj` and `generateMPDO`, lines 1733--1770
+-/
+
+open scoped Matrix BigOperators ComplexOrder Kronecker
+
+open MPOTensor
+
+namespace MPOTensor
+
+variable {d e : ℕ}
+
+open MPOTensor.PhysicalSectorFactorization
+
+private theorem singleKrausMap_kronecker
+    {a b c f : Type*} [Fintype a] [Fintype b] [Fintype c] [Fintype f]
+    (A : Matrix a b ℂ) (C : Matrix c f ℂ)
+    (X : Matrix b b ℂ) (Y : Matrix f f ℂ) :
+    singleKrausMap (A ⊗ₖ C) (X ⊗ₖ Y) =
+      singleKrausMap A X ⊗ₖ singleKrausMap C Y := by
+  simp only [singleKrausMap_apply, Matrix.conjTranspose_kronecker]
+  rw [← Matrix.mul_kronecker_mul, ← Matrix.mul_kronecker_mul]
+
+private theorem reindex_kronecker_assoc
+    (V : Matrix (Fin d) (Fin e) ℂ) :
+    Matrix.reindex (Equiv.prodAssoc (Fin d) (Fin d) (Fin d)).symm
+        (Equiv.prodAssoc (Fin e) (Fin e) (Fin e)).symm
+        (V ⊗ₖ (V ⊗ₖ V)) = (V ⊗ₖ V) ⊗ₖ V := by
+  ext ⟨⟨i, j⟩, k⟩ ⟨⟨a, b⟩, c⟩
+  simp [Matrix.reindex_apply, Matrix.kroneckerMap_apply]
+  ring
+
+private theorem reindex_leftPairMatrix
+    (B : Matrix (Fin e × Fin e) (Fin e × Fin e) ℂ) :
+    Matrix.reindex (Equiv.prodAssoc (Fin e) (Fin e) (Fin e)).symm
+        (Equiv.prodAssoc (Fin e) (Fin e) (Fin e)).symm
+        (leftPairMatrix B) =
+      B ⊗ₖ (1 : Matrix (Fin e) (Fin e) ℂ) := by
+  ext ⟨⟨i, j⟩, k⟩ ⟨⟨a, b⟩, c⟩
+  simp [leftPairMatrix, Matrix.reindex_apply,
+    Matrix.kroneckerMap_apply]
+
+private theorem lift_leftPairMatrix
+    (V : Matrix (Fin d) (Fin e) ℂ)
+    (B : Matrix (Fin e × Fin e) (Fin e × Fin e) ℂ) :
+    singleKrausMap (V ⊗ₖ (V ⊗ₖ V)) (leftPairMatrix B) =
+      Matrix.reindex (Equiv.prodAssoc (Fin d) (Fin d) (Fin d))
+        (Equiv.prodAssoc (Fin d) (Fin d) (Fin d))
+        (singleKrausMap (V ⊗ₖ V) B ⊗ₖ singleKrausMap V 1) := by
+  apply (Matrix.reindex
+    (Equiv.prodAssoc (Fin d) (Fin d) (Fin d)).symm
+    (Equiv.prodAssoc (Fin d) (Fin d) (Fin d)).symm).injective
+  rw [Matrix.reindex_singleKrausMap
+      (Equiv.prodAssoc (Fin e) (Fin e) (Fin e)).symm
+      (Equiv.prodAssoc (Fin d) (Fin d) (Fin d)).symm,
+    reindex_kronecker_assoc, reindex_leftPairMatrix,
+    singleKrausMap_kronecker]
+  ext
+  simp [Matrix.reindex_apply]
+
+private theorem singleKrausMap_mul
+    {a b : Type*} [Fintype a] [Fintype b] [DecidableEq b]
+    (V : Matrix a b ℂ) (hV : Vᴴ * V = 1)
+    (X Y : Matrix b b ℂ) :
+    singleKrausMap V (X * Y) =
+      singleKrausMap V X * singleKrausMap V Y := by
+  simp only [singleKrausMap_apply, Matrix.mul_assoc]
+  rw [← Matrix.mul_assoc Vᴴ V, hV]
+  simp
+
+private theorem kronecker_isometry
+    {a b c f : Type*} [Fintype a] [Fintype c]
+    [DecidableEq b] [DecidableEq f]
+    (V : Matrix a b ℂ) (W : Matrix c f ℂ)
+    (hV : Vᴴ * V = 1) (hW : Wᴴ * W = 1) :
+    (V ⊗ₖ W)ᴴ * (V ⊗ₖ W) = 1 := by
+  rw [Matrix.conjTranspose_kronecker, ← Matrix.mul_kronecker_mul,
+    hV, hW]
+  exact Matrix.one_kronecker_one
+
+private theorem lift_pair_mul_firstProjection
+    (V : Matrix (Fin d) (Fin e) ℂ) (hV : Vᴴ * V = 1)
+    (B : Matrix (Fin e × Fin e) (Fin e × Fin e) ℂ) :
+    singleKrausMap (V ⊗ₖ V) B *
+        (singleKrausMap V 1 ⊗ₖ (1 : Matrix (Fin d) (Fin d) ℂ)) =
+      singleKrausMap (V ⊗ₖ V) B := by
+  simp only [singleKrausMap_apply, Matrix.conjTranspose_kronecker,
+    Matrix.mul_assoc]
+  rw [← Matrix.mul_kronecker_mul]
+  simp only [Matrix.mul_one]
+  rw [← Matrix.mul_assoc Vᴴ V, hV]
+  simp
+
+private theorem secondProjection_mul_lift_pair
+    (V : Matrix (Fin d) (Fin e) ℂ) (hV : Vᴴ * V = 1)
+    (B : Matrix (Fin e × Fin e) (Fin e × Fin e) ℂ) :
+    ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ singleKrausMap V 1) *
+        singleKrausMap (V ⊗ₖ V) B =
+      singleKrausMap (V ⊗ₖ V) B := by
+  have hPV : (V * Vᴴ) * V = V := by
+    simp only [Matrix.mul_assoc]
+    rw [hV]
+    simp
+  have hQW :
+      ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ (V * Vᴴ)) *
+          (V ⊗ₖ V) = V ⊗ₖ V := by
+    rw [← Matrix.mul_kronecker_mul, Matrix.one_mul, hPV]
+  have hP : singleKrausMap V 1 = V * Vᴴ := by
+    simp [singleKrausMap_apply]
+  rw [hP]
+  simp only [singleKrausMap_apply]
+  calc
+    _ = (((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ
+          (V * Vᴴ)) * (V ⊗ₖ V)) * B *
+            (V ⊗ₖ V)ᴴ := by simp only [Matrix.mul_assoc]
+    _ = _ := by rw [hQW]
+
+private theorem lift_rightPairMatrix
+    (V : Matrix (Fin d) (Fin e) ℂ)
+    (B : Matrix (Fin e × Fin e) (Fin e × Fin e) ℂ) :
+    singleKrausMap (V ⊗ₖ (V ⊗ₖ V)) (rightPairMatrix B) =
+      singleKrausMap V 1 ⊗ₖ singleKrausMap (V ⊗ₖ V) B := by
+  rw [rightPairMatrix, singleKrausMap_kronecker]
+
+private theorem leftPair_mul_lastProjection
+    (A : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
+    (P : Matrix (Fin d) (Fin d) ℂ) :
+    leftPairMatrix A *
+        ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ
+          ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ P)) =
+      Matrix.reindex (Equiv.prodAssoc (Fin d) (Fin d) (Fin d))
+        (Equiv.prodAssoc (Fin d) (Fin d) (Fin d))
+        (A ⊗ₖ P) := by
+  let e := Equiv.prodAssoc (Fin d) (Fin d) (Fin d)
+  apply (Matrix.reindex e.symm e.symm).injective
+  change Matrix.reindexLinearEquiv ℂ ℂ e.symm e.symm
+      (leftPairMatrix A *
+        ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ
+          ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ P))) = _
+  rw [← Matrix.reindexLinearEquiv_mul ℂ ℂ e.symm e.symm e.symm]
+  simp only [Matrix.coe_reindexLinearEquiv]
+  rw [reindex_leftPairMatrix]
+  have hQ :
+      Matrix.reindex e.symm e.symm
+          ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ
+            ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ P)) =
+        ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ
+          (1 : Matrix (Fin d) (Fin d) ℂ)) ⊗ₖ P := by
+    ext ⟨⟨i, j⟩, k⟩ ⟨⟨i', j'⟩, k'⟩
+    simp [e, Matrix.reindex_apply, Matrix.kroneckerMap_apply,
+      Matrix.one_apply]
+    by_cases hi : i = i' <;> by_cases hj : j = j' <;> simp_all
+  rw [hQ, ← Matrix.mul_kronecker_mul]
+  ext
+  simp [e, Matrix.reindex_apply, Matrix.kroneckerMap_apply]
+
+private theorem firstProjection_mul_rightPair
+    (P : Matrix (Fin d) (Fin d) ℂ)
+    (A : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ) :
+    (P ⊗ₖ ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ
+        (1 : Matrix (Fin d) (Fin d) ℂ))) * rightPairMatrix A =
+      P ⊗ₖ A := by
+  rw [rightPairMatrix, ← Matrix.mul_kronecker_mul,
+    Matrix.mul_one, Matrix.one_kronecker_one, Matrix.one_mul]
+
+private theorem first_lastProjection_comm
+    (P : Matrix (Fin d) (Fin d) ℂ) :
+    ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ
+        ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ P)) *
+        (P ⊗ₖ ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ
+          (1 : Matrix (Fin d) (Fin d) ℂ))) =
+      (P ⊗ₖ ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ
+          (1 : Matrix (Fin d) (Fin d) ℂ))) *
+        ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ
+          ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ P)) := by
+  repeat' rw [← Matrix.mul_kronecker_mul]
+  simp
+
+private theorem leftPair_mul_firstProjection
+    (A : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
+    (P : Matrix (Fin d) (Fin d) ℂ)
+    (hA : A * (P ⊗ₖ (1 : Matrix (Fin d) (Fin d) ℂ)) = A) :
+    leftPairMatrix A *
+        (P ⊗ₖ ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ
+          (1 : Matrix (Fin d) (Fin d) ℂ))) =
+      leftPairMatrix A := by
+  apply (Matrix.reindex
+    (Equiv.prodAssoc (Fin d) (Fin d) (Fin d)).symm
+    (Equiv.prodAssoc (Fin d) (Fin d) (Fin d)).symm).injective
+  change Matrix.reindexLinearEquiv ℂ ℂ
+      (Equiv.prodAssoc (Fin d) (Fin d) (Fin d)).symm
+      (Equiv.prodAssoc (Fin d) (Fin d) (Fin d)).symm
+      (leftPairMatrix A *
+        (P ⊗ₖ ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ
+          (1 : Matrix (Fin d) (Fin d) ℂ)))) = _
+  rw [← Matrix.reindexLinearEquiv_mul ℂ ℂ
+      (Equiv.prodAssoc (Fin d) (Fin d) (Fin d)).symm
+      (Equiv.prodAssoc (Fin d) (Fin d) (Fin d)).symm
+      (Equiv.prodAssoc (Fin d) (Fin d) (Fin d)).symm]
+  simp only [Matrix.coe_reindexLinearEquiv]
+  rw [reindex_leftPairMatrix]
+  have hQ :
+      Matrix.reindex (Equiv.prodAssoc (Fin d) (Fin d) (Fin d)).symm
+          (Equiv.prodAssoc (Fin d) (Fin d) (Fin d)).symm
+          (P ⊗ₖ ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ
+            (1 : Matrix (Fin d) (Fin d) ℂ))) =
+        (P ⊗ₖ (1 : Matrix (Fin d) (Fin d) ℂ)) ⊗ₖ
+          (1 : Matrix (Fin d) (Fin d) ℂ) := by
+    ext
+    simp [Matrix.reindex_apply, Matrix.kroneckerMap_apply,
+      Matrix.one_apply]
+    split_ifs <;> simp_all
+  rw [hQ, ← Matrix.mul_kronecker_mul, hA, Matrix.one_mul]
+
+private theorem lastProjection_mul_rightPair
+    (P : Matrix (Fin d) (Fin d) ℂ)
+    (A : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
+    (hA : ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ P) * A = A) :
+    ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ
+        ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ P)) *
+        rightPairMatrix A = rightPairMatrix A := by
+  rw [rightPairMatrix, ← Matrix.mul_kronecker_mul,
+    Matrix.one_mul, hA]
+
+private theorem pair_product_transport
+    (V : Matrix (Fin d) (Fin e) ℂ) (hV : Vᴴ * V = 1)
+    (B C : Matrix (Fin e × Fin e) (Fin e × Fin e) ℂ) :
+    singleKrausMap (V ⊗ₖ (V ⊗ₖ V))
+        (leftPairMatrix B * rightPairMatrix C) =
+      leftPairMatrix (singleKrausMap (V ⊗ₖ V) B) *
+        rightPairMatrix (singleKrausMap (V ⊗ₖ V) C) := by
+  let W₂ := V ⊗ₖ V
+  let W₃ := V ⊗ₖ W₂
+  let P := singleKrausMap V 1
+  let B' := singleKrausMap W₂ B
+  let C' := singleKrausMap W₂ C
+  have hW₂ : W₂ᴴ * W₂ = 1 := kronecker_isometry V V hV hV
+  have hW₃ : W₃ᴴ * W₃ = 1 := kronecker_isometry V W₂ hV hW₂
+  have hB' : B' * (P ⊗ₖ (1 : Matrix (Fin d) (Fin d) ℂ)) = B' :=
+    lift_pair_mul_firstProjection V hV B
+  have hC' : ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ P) * C' = C' :=
+    secondProjection_mul_lift_pair V hV C
+  let Q₀ := P ⊗ₖ ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ
+    (1 : Matrix (Fin d) (Fin d) ℂ))
+  let Q₂ := (1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ
+    ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ P)
+  have hleft :
+      singleKrausMap W₃ (leftPairMatrix B) = leftPairMatrix B' * Q₂ := by
+    rw [lift_leftPairMatrix]
+    exact (leftPair_mul_lastProjection B' P).symm
+  have hright :
+      singleKrausMap W₃ (rightPairMatrix C) = Q₀ * rightPairMatrix C' := by
+    rw [lift_rightPairMatrix]
+    exact (firstProjection_mul_rightPair P C').symm
+  calc
+    singleKrausMap W₃ (leftPairMatrix B * rightPairMatrix C) =
+        singleKrausMap W₃ (leftPairMatrix B) *
+          singleKrausMap W₃ (rightPairMatrix C) :=
+      singleKrausMap_mul W₃ hW₃ _ _
+    _ = (leftPairMatrix B' * Q₂) * (Q₀ * rightPairMatrix C') := by
+      rw [hleft, hright]
+    _ = leftPairMatrix B' * (Q₂ * Q₀) * rightPairMatrix C' := by
+      simp only [Matrix.mul_assoc]
+    _ = leftPairMatrix B' * (Q₀ * Q₂) * rightPairMatrix C' := by
+      rw [first_lastProjection_comm]
+    _ = (leftPairMatrix B' * Q₀) *
+        (Q₂ * rightPairMatrix C') := by
+      simp only [Matrix.mul_assoc]
+    _ = leftPairMatrix B' * rightPairMatrix C' := by
+      rw [leftPair_mul_firstProjection B' P hB',
+        lastProjection_mul_rightPair P C' hC']
+
+private theorem reindex_sitewisePhysicalMatrix_two
+    (V : Matrix (Fin d) (Fin e) ℂ) :
+    Matrix.reindex (_root_.finTwoArrowEquiv (Fin d))
+        (_root_.finTwoArrowEquiv (Fin e))
+        (sitewisePhysicalMatrix V 2) = V ⊗ₖ V := by
+  ext ⟨i, j⟩ ⟨a, b⟩
+  simp [Matrix.reindex_apply, sitewisePhysicalMatrix,
+    Matrix.kroneckerMap_apply, _root_.finTwoArrowEquiv]
+
+private theorem reindex_sitewisePhysicalMatrix_three
+    (V : Matrix (Fin d) (Fin e) ℂ) :
+    Matrix.reindex (_root_.finThreeArrowEquiv (Fin d))
+        (_root_.finThreeArrowEquiv (Fin e))
+        (sitewisePhysicalMatrix V 3) = V ⊗ₖ (V ⊗ₖ V) := by
+  ext ⟨i, j, k⟩ ⟨a, b, c⟩
+  simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
+    finThreeArrowEquiv_symm_apply, Nat.succ_eq_add_one, Nat.reduceAdd,
+    Matrix.kroneckerMap_apply]
+  change (∏ n : Fin 3, V (![i, j, k] n) (![a, b, c] n)) =
+    V i a * (V j b * V k c)
+  rw [Fin.prod_univ_succ, Fin.prod_univ_succ, Fin.prod_univ_succ]
+  simp
+
+private theorem reindex_embedLocalOperator_three_zero
+    (B : Matrix (Fin 2 → Fin e) (Fin 2 → Fin e) ℂ) :
+    Matrix.reindex (_root_.finThreeArrowEquiv (Fin e))
+        (_root_.finThreeArrowEquiv (Fin e))
+        (embedLocalOperator (d := e) 2 3 (by decide) (0 : Fin 3) B) =
+      leftPairMatrix
+        (Matrix.reindex (_root_.finTwoArrowEquiv (Fin e))
+          (_root_.finTwoArrowEquiv (Fin e)) B) := by
+  ext σ τ
+  have hAgree :
+      AgreesOutsideWindow (d := e) 2 (by decide) (0 : Fin 3)
+          ((_root_.finThreeArrowEquiv (Fin e)).symm σ)
+          ((_root_.finThreeArrowEquiv (Fin e)).symm τ) ↔
+        τ.2.2 = σ.2.2 := by
+    constructor
+    · intro ha
+      have h := congrFun ha (2 : Fin 3)
+      simpa [AgreesOutsideWindow, MPSTensor.replaceWindow,
+        MPSTensor.extractWindow] using h
+    · intro ha
+      funext i
+      fin_cases i <;>
+        simp [MPSTensor.replaceWindow, MPSTensor.extractWindow, ha]
+  have hσ :
+      MPSTensor.extractWindow 2 (0 : Fin 3)
+          ((_root_.finThreeArrowEquiv (Fin e)).symm σ) =
+        (_root_.finTwoArrowEquiv (Fin e)).symm (σ.1, σ.2.1) := by
+    funext r
+    fin_cases r <;> rfl
+  have hτ :
+      MPSTensor.extractWindow 2 (0 : Fin 3)
+          ((_root_.finThreeArrowEquiv (Fin e)).symm τ) =
+        (_root_.finTwoArrowEquiv (Fin e)).symm (τ.1, τ.2.1) := by
+    funext r
+    fin_cases r <;> rfl
+  by_cases h : τ.2.2 = σ.2.2
+  · have ha := hAgree.mpr h
+    simp only [Fin.isValue, Matrix.reindex_apply, Matrix.submatrix_apply,
+      embedLocalOperator_apply]
+    rw [if_pos ha]
+    simp only [leftPairMatrix]
+    rw [hσ, hτ]
+    change
+      B ((_root_.finTwoArrowEquiv (Fin e)).symm (σ.1, σ.2.1))
+          ((_root_.finTwoArrowEquiv (Fin e)).symm (τ.1, τ.2.1)) =
+        B ((_root_.finTwoArrowEquiv (Fin e)).symm (σ.1, σ.2.1))
+            ((_root_.finTwoArrowEquiv (Fin e)).symm (τ.1, τ.2.1)) *
+          (if σ.2.2 = τ.2.2 then 1 else 0)
+    rw [if_pos h.symm, mul_one]
+  · have ha : ¬ AgreesOutsideWindow (d := e) 2 (by decide) (0 : Fin 3)
+        ((_root_.finThreeArrowEquiv (Fin e)).symm σ)
+        ((_root_.finThreeArrowEquiv (Fin e)).symm τ) :=
+      fun ha ↦ h (hAgree.mp ha)
+    simp only [Fin.isValue, Matrix.reindex_apply, Matrix.submatrix_apply,
+      embedLocalOperator_apply]
+    rw [if_neg ha]
+    simp only [leftPairMatrix]
+    change 0 = B _ _ * (if σ.2.2 = τ.2.2 then 1 else 0)
+    rw [if_neg (fun hs ↦ h hs.symm), mul_zero]
+
+private theorem reindex_embedLocalOperator_three_one
+    (B : Matrix (Fin 2 → Fin e) (Fin 2 → Fin e) ℂ) :
+    Matrix.reindex (_root_.finThreeArrowEquiv (Fin e))
+        (_root_.finThreeArrowEquiv (Fin e))
+        (embedLocalOperator (d := e) 2 3 (by decide) (1 : Fin 3) B) =
+      rightPairMatrix
+        (Matrix.reindex (_root_.finTwoArrowEquiv (Fin e))
+          (_root_.finTwoArrowEquiv (Fin e)) B) := by
+  ext σ τ
+  have hAgree :
+      AgreesOutsideWindow (d := e) 2 (by decide) (1 : Fin 3)
+          ((_root_.finThreeArrowEquiv (Fin e)).symm σ)
+          ((_root_.finThreeArrowEquiv (Fin e)).symm τ) ↔
+        τ.1 = σ.1 := by
+    constructor
+    · intro ha
+      have h := congrFun ha (0 : Fin 3)
+      simpa [MPSTensor.replaceWindow, MPSTensor.extractWindow] using h
+    · intro ha
+      funext i
+      fin_cases i <;>
+        simp [MPSTensor.replaceWindow, MPSTensor.extractWindow, ha]
+  have hσ :
+      MPSTensor.extractWindow 2 (1 : Fin 3)
+          ((_root_.finThreeArrowEquiv (Fin e)).symm σ) =
+        (_root_.finTwoArrowEquiv (Fin e)).symm σ.2 := by
+    funext r
+    fin_cases r <;> rfl
+  have hτ :
+      MPSTensor.extractWindow 2 (1 : Fin 3)
+          ((_root_.finThreeArrowEquiv (Fin e)).symm τ) =
+        (_root_.finTwoArrowEquiv (Fin e)).symm τ.2 := by
+    funext r
+    fin_cases r <;> rfl
+  by_cases h : τ.1 = σ.1
+  · have ha := hAgree.mpr h
+    simp only [Fin.isValue, Matrix.reindex_apply, Matrix.submatrix_apply,
+      embedLocalOperator_apply]
+    rw [if_pos ha]
+    rw [hσ, hτ]
+    change B _ _ = (if σ.1 = τ.1 then 1 else 0) * B _ _
+    rw [if_pos h.symm, one_mul]
+  · have ha : ¬ AgreesOutsideWindow (d := e) 2 (by decide) (1 : Fin 3)
+        ((_root_.finThreeArrowEquiv (Fin e)).symm σ)
+        ((_root_.finThreeArrowEquiv (Fin e)).symm τ) :=
+      fun ha ↦ h (hAgree.mp ha)
+    simp only [Fin.isValue, Matrix.reindex_apply, Matrix.submatrix_apply,
+      embedLocalOperator_apply]
+    rw [if_neg ha]
+    simp only [rightPairMatrix, Matrix.kroneckerMap_apply,
+      Matrix.one_apply]
+    change 0 = (if σ.1 = τ.1 then 1 else 0) * B _ _
+    rw [if_neg (fun hs ↦ h hs.symm), zero_mul]
+
+private theorem reindex_embedLocalOperator_two_zero
+    (B : Matrix (Fin 2 → Fin e) (Fin 2 → Fin e) ℂ) :
+    Matrix.reindex (_root_.finTwoArrowEquiv (Fin e))
+        (_root_.finTwoArrowEquiv (Fin e))
+        (embedLocalOperator (d := e) 2 2 (by decide) (0 : Fin 2) B) =
+      Matrix.reindex (_root_.finTwoArrowEquiv (Fin e))
+        (_root_.finTwoArrowEquiv (Fin e)) B := by
+  ext σ τ
+  have hAgree : AgreesOutsideWindow (d := e) 2 (by decide) (0 : Fin 2)
+      ((_root_.finTwoArrowEquiv (Fin e)).symm σ)
+      ((_root_.finTwoArrowEquiv (Fin e)).symm τ) := by
+    funext i
+    fin_cases i <;>
+      simp [MPSTensor.replaceWindow, MPSTensor.extractWindow,
+        _root_.finTwoArrowEquiv]
+  simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
+    embedLocalOperator_apply]
+  rw [if_pos hAgree]
+  simp only [Fin.isValue, finTwoArrowEquiv_symm_apply]
+  congr 1 <;> funext j <;> fin_cases j <;> rfl
+
+private theorem reindex_embedLocalOperator_two_one
+    (B : Matrix (Fin 2 → Fin e) (Fin 2 → Fin e) ℂ) :
+    Matrix.reindex (_root_.finTwoArrowEquiv (Fin e))
+        (_root_.finTwoArrowEquiv (Fin e))
+        (embedLocalOperator (d := e) 2 2 (by decide) (1 : Fin 2) B) =
+      swapPairMatrix
+        (Matrix.reindex (_root_.finTwoArrowEquiv (Fin e))
+          (_root_.finTwoArrowEquiv (Fin e)) B) := by
+  ext σ τ
+  have hAgree : AgreesOutsideWindow (d := e) 2 (by decide) (1 : Fin 2)
+      ((_root_.finTwoArrowEquiv (Fin e)).symm σ)
+      ((_root_.finTwoArrowEquiv (Fin e)).symm τ) := by
+    funext i
+    fin_cases i <;>
+      simp [MPSTensor.replaceWindow, MPSTensor.extractWindow,
+        _root_.finTwoArrowEquiv]
+  simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
+    embedLocalOperator_apply]
+  rw [if_pos hAgree]
+  simp only [Fin.isValue, finTwoArrowEquiv_symm_apply]
+  congr 1 <;> funext j <;> fin_cases j <;> rfl
+
+/-- On a two-site periodic chain, isometric conjugation carries the product
+of the two oppositely oriented restricted bonds to the product of their
+ambient lifts.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `PjKiPj` and
+`generateMPDO`, lines 1733--1770. -/
+theorem singleKrausMap_crossedTwoSiteBondProduct
+    (V : Matrix (Fin d) (Fin e) ℂ) (hV : Vᴴ * V = 1)
+    (B C : Matrix (Fin 2 → Fin e) (Fin 2 → Fin e) ℂ) :
+    singleKrausMap (sitewisePhysicalMatrix V 2)
+        (embedLocalOperator (d := e) 2 2 (by decide) (0 : Fin 2) B *
+          embedLocalOperator (d := e) 2 2 (by decide) (1 : Fin 2) C) =
+      embedLocalOperator (d := d) 2 2 (by decide) (0 : Fin 2)
+          (singleKrausMap (sitewisePhysicalMatrix V 2) B) *
+        embedLocalOperator (d := d) 2 2 (by decide) (1 : Fin 2)
+          (singleKrausMap (sitewisePhysicalMatrix V 2) C) := by
+  apply (Matrix.reindex (_root_.finTwoArrowEquiv (Fin d))
+    (_root_.finTwoArrowEquiv (Fin d))).injective
+  rw [Matrix.reindex_singleKrausMap
+      (_root_.finTwoArrowEquiv (Fin e))
+      (_root_.finTwoArrowEquiv (Fin d)),
+    reindex_sitewisePhysicalMatrix_two]
+  have hrestricted := Matrix.reindexLinearEquiv_mul ℂ ℂ
+      (_root_.finTwoArrowEquiv (Fin e))
+      (_root_.finTwoArrowEquiv (Fin e))
+      (_root_.finTwoArrowEquiv (Fin e))
+      (embedLocalOperator (d := e) 2 2 (by decide) (0 : Fin 2) B)
+      (embedLocalOperator (d := e) 2 2 (by decide) (1 : Fin 2) C)
+  simp only [Matrix.coe_reindexLinearEquiv] at hrestricted
+  rw [← hrestricted, reindex_embedLocalOperator_two_zero,
+    reindex_embedLocalOperator_two_one]
+  have hambient := Matrix.reindexLinearEquiv_mul ℂ ℂ
+      (_root_.finTwoArrowEquiv (Fin d))
+      (_root_.finTwoArrowEquiv (Fin d))
+      (_root_.finTwoArrowEquiv (Fin d))
+      (embedLocalOperator (d := d) 2 2 (by decide) (0 : Fin 2)
+        (singleKrausMap (sitewisePhysicalMatrix V 2) B))
+      (embedLocalOperator (d := d) 2 2 (by decide) (1 : Fin 2)
+        (singleKrausMap (sitewisePhysicalMatrix V 2) C))
+  simp only [Matrix.coe_reindexLinearEquiv] at hambient
+  rw [← hambient, reindex_embedLocalOperator_two_zero,
+    reindex_embedLocalOperator_two_one,
+    Matrix.reindex_singleKrausMap
+      (_root_.finTwoArrowEquiv (Fin e))
+      (_root_.finTwoArrowEquiv (Fin d)),
+    Matrix.reindex_singleKrausMap
+      (_root_.finTwoArrowEquiv (Fin e))
+      (_root_.finTwoArrowEquiv (Fin d)),
+    reindex_sitewisePhysicalMatrix_two]
+  rw [singleKrausMap_mul _ (kronecker_isometry V V hV hV)]
+  have hswap := swapPairMatrix_singleKraus_kronecker_self Vᴴ
+    (Matrix.reindex (_root_.finTwoArrowEquiv (Fin e))
+      (_root_.finTwoArrowEquiv (Fin e)) C)
+  have hswap' :
+      singleKrausMap (V ⊗ₖ V)
+          (swapPairMatrix (Matrix.reindex
+            (_root_.finTwoArrowEquiv (Fin e))
+            (_root_.finTwoArrowEquiv (Fin e)) C)) =
+        swapPairMatrix (singleKrausMap (V ⊗ₖ V)
+          (Matrix.reindex (_root_.finTwoArrowEquiv (Fin e))
+            (_root_.finTwoArrowEquiv (Fin e)) C)) := by
+    simpa only [Matrix.conjTranspose_kronecker,
+      Matrix.conjTranspose_conjTranspose] using hswap.symm
+  rw [hswap']
+
+/-- Isometric conjugation carries a product of two adjacent restricted bonds
+to the product of their ambient two-site lifts.
+
+Only the isometry identity is used.  In particular, the statement concerns a
+three-site chain and requires neither a coisometry nor an empty-chain case.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `PjKiPj` and
+`generateMPDO`, lines 1733--1770. -/
+theorem singleKrausMap_adjacentBondProduct
+    (V : Matrix (Fin d) (Fin e) ℂ) (hV : Vᴴ * V = 1)
+    (B C : Matrix (Fin 2 → Fin e) (Fin 2 → Fin e) ℂ) :
+    singleKrausMap (sitewisePhysicalMatrix V 3)
+        (embedLocalOperator (d := e) 2 3 (by decide) (0 : Fin 3) B *
+          embedLocalOperator (d := e) 2 3 (by decide) (1 : Fin 3) C) =
+      embedLocalOperator (d := d) 2 3 (by decide) (0 : Fin 3)
+          (singleKrausMap (sitewisePhysicalMatrix V 2) B) *
+        embedLocalOperator (d := d) 2 3 (by decide) (1 : Fin 3)
+          (singleKrausMap (sitewisePhysicalMatrix V 2) C) := by
+  apply (Matrix.reindex (_root_.finThreeArrowEquiv (Fin d))
+    (_root_.finThreeArrowEquiv (Fin d))).injective
+  rw [Matrix.reindex_singleKrausMap
+      (_root_.finThreeArrowEquiv (Fin e))
+      (_root_.finThreeArrowEquiv (Fin d)),
+    reindex_sitewisePhysicalMatrix_three]
+  have hrestricted := Matrix.reindexLinearEquiv_mul ℂ ℂ
+      (_root_.finThreeArrowEquiv (Fin e))
+      (_root_.finThreeArrowEquiv (Fin e))
+      (_root_.finThreeArrowEquiv (Fin e))
+      (embedLocalOperator (d := e) 2 3 (by decide) (0 : Fin 3) B)
+      (embedLocalOperator (d := e) 2 3 (by decide) (1 : Fin 3) C)
+  simp only [Matrix.coe_reindexLinearEquiv] at hrestricted
+  rw [← hrestricted]
+  rw [reindex_embedLocalOperator_three_zero,
+    reindex_embedLocalOperator_three_one]
+  have hambient := Matrix.reindexLinearEquiv_mul ℂ ℂ
+      (_root_.finThreeArrowEquiv (Fin d))
+      (_root_.finThreeArrowEquiv (Fin d))
+      (_root_.finThreeArrowEquiv (Fin d))
+      (embedLocalOperator (d := d) 2 3 (by decide) (0 : Fin 3)
+        (singleKrausMap (sitewisePhysicalMatrix V 2) B))
+      (embedLocalOperator (d := d) 2 3 (by decide) (1 : Fin 3)
+        (singleKrausMap (sitewisePhysicalMatrix V 2) C))
+  simp only [Matrix.coe_reindexLinearEquiv] at hambient
+  rw [← hambient]
+  rw [reindex_embedLocalOperator_three_zero,
+    reindex_embedLocalOperator_three_one,
+    Matrix.reindex_singleKrausMap
+      (_root_.finTwoArrowEquiv (Fin e))
+      (_root_.finTwoArrowEquiv (Fin d)),
+    Matrix.reindex_singleKrausMap
+      (_root_.finTwoArrowEquiv (Fin e))
+      (_root_.finTwoArrowEquiv (Fin d)),
+    reindex_sitewisePhysicalMatrix_two]
+  exact pair_product_transport V hV _ _
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/PhysicalSectorBondTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorBondTransport.lean
@@ -111,7 +111,9 @@ private theorem offset_from_finRotate {N : ℕ} (hN : 2 ≤ N) (i k : Fin N) :
         _ = ((finRotate N i).val + (r - 1)) % N := by rw [hrot]
     rw [hk, MPSTensor.offset_mod_eq (finRotate N i).isLt (by omega : r - 1 < N)]
 
-private theorem embedLocalOperator_two_zero_nested {N : ℕ} (hN : 3 ≤ N)
+/-- Embedding the first bond of a three-site window agrees with embedding that
+bond directly in the ambient periodic chain. -/
+theorem embedLocalOperator_two_zero_nested {N : ℕ} (hN : 3 ≤ N)
     (i : Fin N) (B : Matrix (Fin 2 → Fin d) (Fin 2 → Fin d) ℂ) :
     embedLocalOperator (d := d) 3 N (by omega) i
         (embedLocalOperator (d := d) 2 3 (by decide) (0 : Fin 3) B) =
@@ -154,7 +156,9 @@ private theorem embedLocalOperator_two_zero_nested {N : ℕ} (hN : 3 ≤ N)
     · rw [if_neg h2, if_neg (fun h ↦ h2 (hAgree.mpr h).2)]
   · rw [if_neg h3, if_neg (fun h ↦ h3 (hAgree.mpr h).1)]
 
-private theorem embedLocalOperator_two_one_nested {N : ℕ} (hN : 3 ≤ N)
+/-- Embedding the second bond of a three-site window agrees with embedding the
+translated bond directly in the ambient periodic chain. -/
+theorem embedLocalOperator_two_one_nested {N : ℕ} (hN : 3 ≤ N)
     (i : Fin N) (B : Matrix (Fin 2 → Fin d) (Fin 2 → Fin d) ℂ) :
     embedLocalOperator (d := d) 3 N (by omega) i
         (embedLocalOperator (d := d) 2 3 (by decide) (1 : Fin 3) B) =

--- a/TNLean/MPS/MPDO/PhysicalSupportBondCommutativity.lean
+++ b/TNLean/MPS/MPDO/PhysicalSupportBondCommutativity.lean
@@ -1,0 +1,238 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.IsometricAdjacentBondTransport
+
+/-!
+# Commuting bonds on an isometric physical support
+
+The positive commuting bond on an injective physical support is included into
+the ambient physical space.  Its neighboring translates commute on every
+periodic chain of length at least two.  The two-site crossed chain is treated
+separately; every longer chain reduces by locality to the three-site
+calculation.
+
+No zero-length or one-site nearest-neighbor chain occurs.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, equations `PjKiPj` and `generateMPDO`, lines 1733--1770
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+namespace MPOTensor.PhysicalSupportRestrictionData
+
+variable {d D : ℕ} {P : Matrix (Fin d) (Fin d) ℂ} {K : MPOTensor d D}
+
+open MPOTensor.PhysicalSectorFactorization
+
+private theorem product_isHermitian_of_comm
+    {n : Type*} [Fintype n]
+    {A B : Matrix n n ℂ} (hA : A.IsHermitian) (hB : B.IsHermitian)
+    (hcomm : A * B = B * A) : (A * B).IsHermitian := by
+  change (A * B)ᴴ = A * B
+  rw [Matrix.conjTranspose_mul, hA.eq, hB.eq, hcomm]
+
+private theorem commute_of_product_isHermitian
+    {n : Type*} [Fintype n]
+    {A B : Matrix n n ℂ} (hA : A.IsHermitian) (hB : B.IsHermitian)
+    (hprod : (A * B).IsHermitian) : A * B = B * A := by
+  change (A * B)ᴴ = A * B at hprod
+  rw [Matrix.conjTranspose_mul, hA.eq, hB.eq] at hprod
+  exact hprod.symm
+
+/-- The two lifted neighboring bonds commute on a three-site chain.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `PjKiPj` and
+`generateMPDO`, lines 1733--1770. -/
+theorem liftedBond_three_zero_one_comm
+    (F : PhysicalSupportRestrictionData P K)
+    (data : TranslationInvariantBondData F.supportDim) :
+    embedLocalOperator (d := d) 2 3 (by decide) (0 : Fin 3)
+          (F.liftedBond data.bond) *
+        embedLocalOperator (d := d) 2 3 (by decide) (1 : Fin 3)
+          (F.liftedBond data.bond) =
+      embedLocalOperator (d := d) 2 3 (by decide) (1 : Fin 3)
+          (F.liftedBond data.bond) *
+        embedLocalOperator (d := d) 2 3 (by decide) (0 : Fin 3)
+          (F.liftedBond data.bond) := by
+  let A := embedLocalOperator (d := F.supportDim) 2 3 (by decide)
+    (0 : Fin 3) data.bond
+  let B := embedLocalOperator (d := F.supportDim) 2 3 (by decide)
+    (1 : Fin 3) data.bond
+  have hcomm : A * B = B * A := data.bond_comm (by decide) 0 1
+  have hA : A.IsHermitian :=
+    (embedLocalOperator_posSemidef 2 (by decide) 0 data.bond_pos).1
+  have hB : B.IsHermitian :=
+    (embedLocalOperator_posSemidef 2 (by decide) 1 data.bond_pos).1
+  have hrestricted : (A * B).IsHermitian :=
+    product_isHermitian_of_comm hA hB hcomm
+  have hambient :
+      (singleKrausMap (sitewisePhysicalMatrix F.inclusion 3) (A * B)).IsHermitian :=
+    Matrix.isHermitian_mul_mul_conjTranspose
+      (sitewisePhysicalMatrix F.inclusion 3) hrestricted
+  rw [singleKrausMap_adjacentBondProduct
+    F.inclusion F.inclusion_isometry data.bond data.bond] at hambient
+  apply commute_of_product_isHermitian
+  · exact (embedLocalOperator_posSemidef 2 (by decide) 0
+      (F.liftedBond_pos data.bond_pos)).1
+  · exact (embedLocalOperator_posSemidef 2 (by decide) 1
+      (F.liftedBond_pos data.bond_pos)).1
+  · exact hambient
+
+/-- The two oppositely oriented lifted bonds commute on the two-site periodic
+chain.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `PjKiPj` and
+`generateMPDO`, lines 1733--1770. -/
+theorem liftedBond_two_zero_one_comm
+    (F : PhysicalSupportRestrictionData P K)
+    (data : TranslationInvariantBondData F.supportDim) :
+    embedLocalOperator (d := d) 2 2 (by decide) (0 : Fin 2)
+          (F.liftedBond data.bond) *
+        embedLocalOperator (d := d) 2 2 (by decide) (1 : Fin 2)
+          (F.liftedBond data.bond) =
+      embedLocalOperator (d := d) 2 2 (by decide) (1 : Fin 2)
+          (F.liftedBond data.bond) *
+        embedLocalOperator (d := d) 2 2 (by decide) (0 : Fin 2)
+          (F.liftedBond data.bond) := by
+  let A := embedLocalOperator (d := F.supportDim) 2 2 (by decide)
+    (0 : Fin 2) data.bond
+  let B := embedLocalOperator (d := F.supportDim) 2 2 (by decide)
+    (1 : Fin 2) data.bond
+  have hcomm : A * B = B * A := data.bond_comm (by decide) 0 1
+  have hA : A.IsHermitian :=
+    (embedLocalOperator_posSemidef 2 (by decide) 0 data.bond_pos).1
+  have hB : B.IsHermitian :=
+    (embedLocalOperator_posSemidef 2 (by decide) 1 data.bond_pos).1
+  have hrestricted : (A * B).IsHermitian :=
+    product_isHermitian_of_comm hA hB hcomm
+  have hambient :
+      (singleKrausMap (sitewisePhysicalMatrix F.inclusion 2) (A * B)).IsHermitian :=
+    Matrix.isHermitian_mul_mul_conjTranspose
+      (sitewisePhysicalMatrix F.inclusion 2) hrestricted
+  rw [singleKrausMap_crossedTwoSiteBondProduct
+    F.inclusion F.inclusion_isometry data.bond data.bond] at hambient
+  apply commute_of_product_isHermitian
+  · exact (embedLocalOperator_posSemidef 2 (by decide) 0
+      (F.liftedBond_pos data.bond_pos)).1
+  · exact (embedLocalOperator_posSemidef 2 (by decide) 1
+      (F.liftedBond_pos data.bond_pos)).1
+  · exact hambient
+
+/-- The lifted bond commutes with its translate by one site on every periodic
+chain of length at least two.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `PjKiPj` and
+`generateMPDO`, lines 1733--1770. -/
+theorem liftedBond_zero_one_comm
+    (F : PhysicalSupportRestrictionData P K)
+    (data : TranslationInvariantBondData F.supportDim)
+    {N : ℕ} (hN : 2 ≤ N) :
+    embedLocalOperator (d := d) 2 N hN ⟨0, by omega⟩
+          (F.liftedBond data.bond) *
+        embedLocalOperator (d := d) 2 N hN ⟨1, by omega⟩
+          (F.liftedBond data.bond) =
+      embedLocalOperator (d := d) 2 N hN ⟨1, by omega⟩
+          (F.liftedBond data.bond) *
+        embedLocalOperator (d := d) 2 N hN ⟨0, by omega⟩
+          (F.liftedBond data.bond) := by
+  by_cases htwo : N = 2
+  · subst N
+    exact F.liftedBond_two_zero_one_comm data
+  · have hthree : 3 ≤ N := by omega
+    let B := F.liftedBond data.bond
+    have hzero := embedLocalOperator_two_zero_nested (d := d)
+      hthree ⟨0, by omega⟩ B
+    have hone := embedLocalOperator_two_one_nested (d := d)
+      hthree ⟨0, by omega⟩ B
+    have hsite : finRotate N ⟨0, by omega⟩ = ⟨1, by omega⟩ := by
+      apply Fin.ext
+      rw [coe_finRotate_mod]
+      change 1 % N = 1
+      exact Nat.mod_eq_of_lt (by omega)
+    rw [hsite] at hone
+    have hone' :
+        embedLocalOperator (d := d) 3 N (by omega) ⟨0, by omega⟩
+            (embedLocalOperator (d := d) 2 3 (by decide) (1 : Fin 3) B) =
+          embedLocalOperator (d := d) 2 N (by omega) ⟨1, by omega⟩ B := by
+      exact hone
+    rw [← hzero, ← hone']
+    rw [← embedLocalOperator_mul, ← embedLocalOperator_mul]
+    exact congrArg
+      (embedLocalOperator (d := d) 3 N (by omega) ⟨0, by omega⟩)
+      (F.liftedBond_three_zero_one_comm data)
+
+private theorem supportProjection_isOrthogonal
+    (F : PhysicalSupportRestrictionData P K) : IsOrthogonalProjection P := by
+  rw [← F.inclusion_range]
+  constructor
+  · exact Matrix.isHermitian_mul_conjTranspose_self F.inclusion
+  · calc
+      (F.inclusion * F.inclusionᴴ) *
+          (F.inclusion * F.inclusionᴴ) =
+        F.inclusion * (F.inclusionᴴ * F.inclusion) * F.inclusionᴴ := by
+          simp only [Matrix.mul_assoc]
+      _ = F.inclusion * F.inclusionᴴ := by
+        rw [F.inclusion_isometry, Matrix.mul_one]
+
+/-- A translation-invariant commuting bond on the restricted physical space
+has a positive translation-invariant commuting lift to the ambient physical
+space.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `PjKiPj` and
+`generateMPDO`, lines 1733--1770. -/
+noncomputable def liftedTranslationInvariantBondData
+    (F : PhysicalSupportRestrictionData P K)
+    (data : TranslationInvariantBondData F.supportDim) :
+    TranslationInvariantBondData d where
+  bond := F.liftedBond data.bond
+  bond_pos := F.liftedBond_pos data.bond_pos
+  bond_comm := by
+    intro N hN i j
+    let G : GSNNCHData d N := {
+      hN := hN
+      sectorCount := 1
+      multiplicity := fun _ ↦ 1
+      sectorProjection := fun _ ↦ P
+      sectorProjection_isOrthogonal := fun _ ↦ F.supportProjection_isOrthogonal
+      sectorProjection_orthogonal := by
+        intro x y hxy
+        exact (hxy (Subsingleton.elim x y)).elim
+      bond := fun _ ↦ F.liftedBond data.bond
+      bond_pos := fun _ ↦ F.liftedBond_pos data.bond_pos
+      bond_supported := fun _ ↦ F.liftedBond_supported data.bond
+      neighboring_comm := fun _ ↦ F.liftedBond_zero_one_comm data hN }
+    simpa [G, GSNNCHData.bondAt] using G.bondAt_comm (0 : Fin 1) i j
+
+/-- The local bond of the lifted translation-invariant data is the isometric
+conjugate of the restricted bond. -/
+@[simp] theorem liftedTranslationInvariantBondData_bond
+    (F : PhysicalSupportRestrictionData P K)
+    (data : TranslationInvariantBondData F.supportDim) :
+    (F.liftedTranslationInvariantBondData data).bond =
+      F.liftedBond data.bond := rfl
+
+/-- Proposition C.8 on the injective physical support supplies a positive
+translation-invariant commuting bond whose ambient lift remains supported on
+the prescribed two-site sector.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`) and
+equations `PjKiPj` and `generateMPDO`, lines 1571--1593 and 1733--1770. -/
+theorem exists_etaLocalStructureData_liftedTranslationInvariantBondData
+    (F : PhysicalSupportRestrictionData P K) (hSAL : IsSAL K) :
+    ∃ data : EtaLocalStructureData
+        (PhysicalSectorFactorization.changePhysicalBasis F.inclusionᴴ K),
+      twoSiteSectorProjection P *
+          (F.liftedTranslationInvariantBondData data.bondData).bond *
+          twoSiteSectorProjection P =
+        (F.liftedTranslationInvariantBondData data.bondData).bond := by
+  obtain ⟨data, _, hsupported⟩ :=
+    F.exists_etaLocalStructureData_liftedBond_supported hSAL
+  exact ⟨data, hsupported⟩
+
+end MPOTensor.PhysicalSupportRestrictionData

--- a/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
@@ -234,15 +234,17 @@ Definition~\ref{def:mpdo_source_gsnnch}; the converse comparison is not used.
     $K$ consequently give those for $K_P$.
 \end{proof}
 
-\begin{theorem}[The restricted commuting bond has a supported lift]
+\begin{theorem}[The restricted commuting bond has a supported commuting lift]
     \label{thm:mpdo_physical_support_restriction_bond}
-    \lean{MPOTensor.PhysicalSupportRestrictionData.exists_etaLocalStructureData_liftedBond_supported}
+    \lean{MPOTensor.PhysicalSupportRestrictionData.exists_etaLocalStructureData_liftedTranslationInvariantBondData}
     \leanok
     \uses{thm:mpdo_physical_support_restriction_sal}
     Let $K=V K_P V^*$ be a physical support restriction of an MPO tensor
     satisfying SAL.  Proposition~C.8 applied to the injective tensor $K_P$
-    gives a positive two-site bond $B_P$.  Its lift
-    $B=V^{\otimes 2}B_P(V^{\otimes 2})^*$ is positive and satisfies
+    gives a positive two-site bond $B_P$ whose cyclic translates commute
+    pairwise on every periodic chain of length $N\geq 2$.  Its lift
+    $B=V^{\otimes 2}B_P(V^{\otimes 2})^*$ is positive, its cyclic translates
+    commute pairwise on every such ambient chain, and
     \[
         (P\otimes P)B(P\otimes P)=B.
     \]
@@ -254,6 +256,15 @@ Definition~\ref{def:mpdo_source_gsnnch}; the converse comparison is not used.
     is preserved under conjugation by $V^{\otimes 2}$.  Moreover,
     $V^{\otimes 2}(V^{\otimes 2})^*=P\otimes P$; multiplying the lifted bond
     by this projection on either side therefore leaves it unchanged.
+
+    It remains to prove commutativity after the lift.  On a three-site chain,
+    isometric conjugation carries the product of two adjacent restricted bonds
+    to the product of their lifted bonds.  The restricted product is Hermitian
+    because its positive factors commute.  Its conjugate is therefore
+    Hermitian; since the lifted factors are Hermitian, their product equals
+    the product in the reverse order.  The two-site periodic chain is handled
+    by the same argument with the two oppositely oriented bonds.  Locality and
+    cyclic translation then give pairwise commutativity for every $N\geq 2$.
 \end{proof}
 
 \begin{definition}[Orthogonally supported commuting sector products]

--- a/docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex
+++ b/docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex
@@ -110,18 +110,20 @@ range of its matching projector, the restricted tensor is injective, SAL
 passes from the ambient representative to this restriction through the
 sitewise support isometry, and the positive Proposition~C.8 bond lifts to a
 positive two-site operator supported on the tensor square of that projector.
+The cyclic translates of this lifted bond commute pairwise on every periodic
+chain of length at least two.
 \footnote{\raggedright Formal declarations:
 {\scriptsize\leanid{MPOTensor.PhysicalSupportRestrictionData}},
 {\scriptsize\leanid{MPOTensor.nonempty_physicalSupportRestrictionData_commonWeightAbsorbedBasis}},
 {\scriptsize\leanid{MPOTensor.PhysicalSupportRestrictionData.restricted_isSAL}},
 and
-{\scriptsize\leanid{MPOTensor.PhysicalSupportRestrictionData.exists_etaLocalStructureData_liftedBond_supported}}.}
+{\scriptsize\leanid{MPOTensor.PhysicalSupportRestrictionData.exists_etaLocalStructureData_liftedTranslationInvariantBondData}}.}
 The remaining comparison has two parts:
 
 \begin{enumerate}
-  \item transport commutativity and the exact finite-chain product identity
-        of the restricted bond through the support isometry; its positive
-        ambient lift and the identity
+  \item transport the exact finite-chain product identity of the restricted
+        bond through the support isometry; positivity, pairwise commutativity
+        for every chain length at least two, and the identity
         $(P_j\otimes P_j)B^{(j)}(P_j\otimes P_j)=B^{(j)}$ are formalized;
   \item determine whether the reverse comparison with a single bond is needed
         in the simple-MPDO equivalence, and prove it only in that form.
@@ -144,7 +146,8 @@ construction of the outer sector sum with its natural multiplicities is
 formalized, as is the injective restriction of every representative to its
 projector range.  SAL is invariant under the support isometry, and the
 resulting positive bond has a positive ambient lift supported on the matching
-two-site sector.  The open gap is the transport of commutativity and the exact
+two-site sector, and all cyclic translates of that lift commute pairwise on
+every periodic chain of length at least two.  The open gap is the exact
 finite-chain product identity, together with any reverse comparison actually
 needed by the simple-MPDO equivalence.
 


### PR DESCRIPTION
## Summary

- prove that sitewise isometric conjugation transports products of adjacent two-site bonds on three sites
- treat the crossed orientation of the two bonds on a periodic chain of length two separately
- lift the restricted Proposition C.8 bond to positive translation-invariant bond data on the ambient physical space, with pairwise commuting cyclic translates for every chain length N >= 2
- retain the two-site support identity and update the blueprint and paper-gap note accordingly

The exact finite-chain product identity remains a separate step. This pull request advances #4126 without closing it.

## Verification

- `lake build TNLean`
- `lake build TNLean.MPS.MPDO.PhysicalSupportBondCommutativity`
- `leanblueprint pdf` (613 pages)
- direct `#check` and `#print axioms` audit of the new public declarations

The transport and commutativity declarations depend only on `propext`, `Classical.choice`, and `Quot.sound`. The final existence theorem additionally inherits the existing `hayashi_ssa_equality_characterization_forward` axiom through Proposition C.8; no axiom is introduced here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new formal proofs on the GSNNCH/physical-support path; errors would block downstream MPDO formalization but there is no runtime or security surface.
> 
> **Overview**
> Formalizes **isometric conjugation** of products of adjacent two-site bonds: on a three-site chain, `singleKrausMap_adjacentBondProduct` shows restricted bond products map to products of ambient lifts; `singleKrausMap_crossedTwoSiteBondProduct` handles the length-2 periodic crossed orientation.
> 
> **Physical support:** `PhysicalSupportBondCommutativity` proves lifted Proposition C.8 bonds commute on 2- and 3-site windows, extends to all `N ≥ 2` via nested `embedLocalOperator` lemmas (now public in `PhysicalSectorBondTransport`), and packages **`liftedTranslationInvariantBondData`** plus **`exists_etaLocalStructureData_liftedTranslationInvariantBondData`** (replacing the blueprint link from supported lift only).
> 
> Blueprint **Theorem** on the restricted commuting bond and the **paper-gap** note now record pairwise commutativity of cyclic translates; the exact finite-chain product identity remains open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4eec0bfd3d6f499df60ab96b3c6801b5bf3a9265. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->