### PR TITLE
feat(MPS/MPDO): transport supported bond products

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -499,6 +499,7 @@ import TNLean.MPS.MPDO.PhysicalSectorBondCommutativity
 import TNLean.MPS.MPDO.PhysicalSectorBondTransport
 import TNLean.MPS.MPDO.IsometricAdjacentBondTransport
 import TNLean.MPS.MPDO.PhysicalSupportBondCommutativity
+import TNLean.MPS.MPDO.PhysicalSupportProductTransport
 import TNLean.MPS.MPDO.PhysicalSectorBondTwoSite
 import TNLean.MPS.MPDO.PhysicalSectorBondPairwise
 import TNLean.MPS.MPDO.PhysicalSectorChainDecomposition

--- a/TNLean/MPS/MPDO/PhysicalSupportProductTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSupportProductTransport.lean
@@ -1,0 +1,725 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.KroneckerFactorPositivity
+import TNLean.MPS.MPDO.PhysicalSupportBondCommutativity
+
+/-!
+# Finite-chain products on an isometric physical support
+
+This file transports the complete periodic product of a restricted two-site
+bond through its physical-support isometry.  All statements concern chains of
+length at least two.  In particular, multiplicativity is needed only for a
+nonempty bond list; the single-Kraus map of a rectangular isometry is not
+incorrectly treated as unital.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, Proposition C.8 and equation `generateMPDO`, lines 1571--1593
+  and 1733--1770
+-/
+
+open scoped Matrix BigOperators ComplexOrder Kronecker
+
+namespace MPOTensor
+
+variable {d e D : ℕ}
+
+open PhysicalSectorFactorization
+
+private theorem singleKrausMap_kronecker
+    {a b c f : Type*} [Fintype a] [Fintype b] [Fintype c] [Fintype f]
+    (A : Matrix a b ℂ) (C : Matrix c f ℂ)
+    (X : Matrix b b ℂ) (Y : Matrix f f ℂ) :
+    singleKrausMap (A ⊗ₖ C) (X ⊗ₖ Y) =
+      singleKrausMap A X ⊗ₖ singleKrausMap C Y := by
+  simp only [singleKrausMap_apply, Matrix.conjTranspose_kronecker]
+  rw [← Matrix.mul_kronecker_mul, ← Matrix.mul_kronecker_mul]
+
+private theorem singleKrausMap_mul_isometry
+    {a b : Type*} [Fintype a] [Fintype b] [DecidableEq b]
+    (V : Matrix a b ℂ) (hV : Vᴴ * V = 1)
+    (X Y : Matrix b b ℂ) :
+    singleKrausMap V (X * Y) =
+      singleKrausMap V X * singleKrausMap V Y := by
+  simp only [singleKrausMap_apply, Matrix.mul_assoc]
+  rw [← Matrix.mul_assoc Vᴴ V, hV]
+  simp
+
+private theorem finKronecker_mul {N : ℕ}
+    (A B : Fin N → Matrix (Fin d) (Fin d) ℂ) :
+    Matrix.finKronecker A * Matrix.finKronecker B =
+      Matrix.finKronecker (fun n ↦ A n * B n) := by
+  classical
+  ext x y
+  simp only [Matrix.mul_apply, Matrix.finKronecker_apply]
+  simp_rw [← Finset.prod_mul_distrib]
+  rw [← Fintype.piFinset_univ]
+  rw [← Finset.prod_univ_sum
+    (fun _ : Fin N ↦ (Finset.univ : Finset (Fin d)))
+    (fun n z ↦ A n (x n) z * B n z (y n))]
+
+/-- Isometric conjugation preserves the product of a nonempty list.  No
+coisometry, and hence no unitality assertion, is used. -/
+theorem singleKrausMap_list_prod_of_ne_nil
+    {a b : Type*} [Fintype a] [Fintype b]
+    [DecidableEq a] [DecidableEq b]
+    (V : Matrix a b ℂ) (hV : Vᴴ * V = 1)
+    (l : List (Matrix b b ℂ)) (hl : l ≠ []) :
+    singleKrausMap V l.prod = (l.map (singleKrausMap V)).prod := by
+  induction l with
+  | nil => exact (hl rfl).elim
+  | cons X l ih =>
+      cases l with
+      | nil => simp
+      | cons Y l =>
+          rw [List.prod_cons, List.map_cons, List.prod_cons,
+            singleKrausMap_mul_isometry V hV]
+          exact congrArg (singleKrausMap V X * ·)
+            (ih (by simp))
+
+private def cyclicShiftEquiv (N : ℕ) (i : Fin N) : Fin N ≃ Fin N where
+  toFun k := ⟨(i.val + k.val) % N, Nat.mod_lt _ (Fin.pos i)⟩
+  invFun k := ⟨(k.val + N - i.val) % N, Nat.mod_lt _ (Fin.pos i)⟩
+  left_inv k := by
+    apply Fin.ext
+    exact MPSTensor.offset_mod_eq i.isLt k.isLt
+  right_inv k := by
+    apply Fin.ext
+    change (i.val + ((k.val + N - i.val) % N)) % N = k.val
+    let offset := (k.val + N - i.val) % N
+    have hsite : (i.val + offset) % N = k.val := by
+      rcases lt_or_ge k.val i.val with hki | hik
+      · have hmod : offset = k.val + N - i.val := by
+          simp only [offset]
+          rw [Nat.mod_eq_of_lt (by omega)]
+        rw [hmod, show i.val + (k.val + N - i.val) = k.val + N by omega,
+          Nat.add_mod_right, Nat.mod_eq_of_lt k.isLt]
+      · have hmod : offset = k.val - i.val := by
+          simp only [offset]
+          have heq : k.val + N - i.val = N + (k.val - i.val) := by omega
+          rw [heq, Nat.add_mod_left,
+            Nat.mod_eq_of_lt (lt_of_le_of_lt (Nat.sub_le _ _) k.isLt)]
+        rw [hmod, Nat.add_sub_of_le hik, Nat.mod_eq_of_lt k.isLt]
+    exact hsite
+
+private def cyclicWindowIndexEquiv (L N : ℕ) (hLN : L ≤ N) (i : Fin N) :
+    Fin L ⊕ Fin (N - L) ≃ Fin N :=
+  finSumFinEquiv |>.trans (finCongr (Nat.add_sub_of_le hLN)) |>.trans
+    (cyclicShiftEquiv N i)
+
+@[simp] private theorem cyclicWindowIndexEquiv_inl
+    (L N : ℕ) (hLN : L ≤ N) (i : Fin N) (r : Fin L) :
+    cyclicWindowIndexEquiv L N hLN i (Sum.inl r) =
+      ⟨(i.val + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩ := rfl
+
+@[simp] private theorem cyclicWindowIndexEquiv_inr
+    (L N : ℕ) (hLN : L ≤ N) (i : Fin N) (r : Fin (N - L)) :
+    cyclicWindowIndexEquiv L N hLN i (Sum.inr r) =
+      ⟨(i.val + L + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩ := by
+  apply Fin.ext
+  change (i.val + (L + r.val)) % N = (i.val + L + r.val) % N
+  congr 1
+  omega
+
+private theorem prod_cyclicWindow_complement
+    (L N : ℕ) (hLN : L ≤ N) (i : Fin N) (f : Fin N → ℂ) :
+    (∏ n : Fin N, f n) =
+      (∏ r : Fin L,
+        f ⟨(i.val + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩) *
+        (∏ r : Fin (N - L),
+          f ⟨(i.val + L + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩) := by
+  rw [Fintype.prod_equiv
+    (cyclicWindowIndexEquiv L N hLN i).symm f
+    (fun x ↦ f (cyclicWindowIndexEquiv L N hLN i x))
+    (fun n ↦ by simp)]
+  rw [Fintype.prod_sum_type]
+  simp only [cyclicWindowIndexEquiv_inl, cyclicWindowIndexEquiv_inr]
+
+private theorem reindex_sitewisePhysicalMatrix_windowComplement
+    (V : Matrix (Fin d) (Fin e) ℂ) {N : ℕ} (hN : 2 ≤ N) (i : Fin N) :
+    Matrix.reindex (windowComplementEquiv (d := d) 2 N hN i)
+        (windowComplementEquiv (d := e) 2 N hN i)
+        (sitewisePhysicalMatrix V N) =
+      sitewisePhysicalMatrix V 2 ⊗ₖ sitewisePhysicalMatrix V (N - 2) := by
+  ext ⟨x, u⟩ ⟨y, v⟩
+  let ed := windowComplementEquiv (d := d) 2 N hN i
+  let ee := windowComplementEquiv (d := e) 2 N hN i
+  let s := ed.symm (x, u)
+  let t := ee.symm (y, v)
+  have hx : MPSTensor.extractWindow 2 i s = x :=
+    congrArg Prod.fst (ed.apply_symm_apply (x, u))
+  have hy : MPSTensor.extractWindow 2 i t = y :=
+    congrArg Prod.fst (ee.apply_symm_apply (y, v))
+  have hu : (fun r ↦ s ⟨(i.val + 2 + r.val) % N,
+      Nat.mod_lt _ (Fin.pos i)⟩) = u :=
+    congrArg Prod.snd (ed.apply_symm_apply (x, u))
+  have hv : (fun r ↦ t ⟨(i.val + 2 + r.val) % N,
+      Nat.mod_lt _ (Fin.pos i)⟩) = v :=
+    congrArg Prod.snd (ee.apply_symm_apply (y, v))
+  change (∏ n : Fin N, V (s n) (t n)) = _
+  rw [prod_cyclicWindow_complement 2 N hN i]
+  simp only [MPSTensor.extractWindow] at hx hy
+  simp only [sitewisePhysicalMatrix, Matrix.kroneckerMap_apply]
+  apply congrArg₂ (fun a b : ℂ ↦ a * b)
+  · apply Finset.prod_congr rfl
+    intro r _
+    rw [congrFun hx r, congrFun hy r]
+  · apply Finset.prod_congr rfl
+    intro r _
+    rw [congrFun hu r, congrFun hv r]
+
+private noncomputable def cyclicBondProjectionFactor
+    (P : Matrix (Fin d) (Fin d) ℂ) {N : ℕ} (i n : Fin N) :
+    Matrix (Fin d) (Fin d) ℂ :=
+  if (n.val + N - i.val) % N < 2 then P else 1
+
+private theorem embed_twoSiteSectorProjection_eq_finKronecker
+    (P : Matrix (Fin d) (Fin d) ℂ) {N : ℕ} (hN : 2 ≤ N) (i : Fin N) :
+    embedLocalOperator (d := d) 2 N hN i (twoSiteSectorProjection P) =
+      Matrix.finKronecker (fun n ↦ cyclicBondProjectionFactor P i n) := by
+  rw [← sitewisePhysicalMatrix_two_eq_twoSiteSectorProjection]
+  ext σ τ
+  simp only [embedLocalOperator_apply, sitewisePhysicalMatrix,
+    Matrix.finKronecker_apply]
+  by_cases hAgree : AgreesOutsideWindow (d := d) 2 hN i σ τ
+  · rw [if_pos hAgree, prod_cyclicWindow_complement 2 N hN i]
+    rw [agreesOutsideWindow_iff] at hAgree
+    apply Eq.symm
+    calc
+      (∏ r : Fin 2,
+          cyclicBondProjectionFactor P i
+            ⟨(i.val + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩
+            (σ ⟨(i.val + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩)
+            (τ ⟨(i.val + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩)) *
+          (∏ r : Fin (N - 2),
+            cyclicBondProjectionFactor P i
+              ⟨(i.val + 2 + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩
+              (σ ⟨(i.val + 2 + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩)
+              (τ ⟨(i.val + 2 + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩)) =
+          (∏ r : Fin 2,
+            P (σ ⟨(i.val + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩)
+              (τ ⟨(i.val + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩)) * 1 := by
+        congr 1
+        · apply Finset.prod_congr rfl
+          intro r _
+          simp only [cyclicBondProjectionFactor]
+          rw [MPSTensor.offset_mod_eq i.isLt
+            (Nat.lt_of_lt_of_le r.isLt hN)]
+          simp [r.isLt]
+        · apply Finset.prod_eq_one
+          intro r _
+          simp only [cyclicBondProjectionFactor]
+          have hoff :
+              (((i.val + 2 + r.val) % N + N - i.val) % N) =
+                2 + r.val := by
+            simpa [Nat.add_assoc] using MPSTensor.offset_mod_eq i.isLt
+              (by omega : 2 + r.val < N)
+          rw [hoff]
+          rw [if_neg (by omega)]
+          simp only [Matrix.one_apply]
+          rw [if_pos]
+          exact (hAgree
+            ⟨(i.val + 2 + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩
+            (by rw [hoff]; omega)).symm
+      _ = _ := by simp [MPSTensor.extractWindow]
+  · rw [if_neg hAgree]
+    rw [agreesOutsideWindow_iff] at hAgree
+    push Not at hAgree
+    obtain ⟨n, hn, hστ⟩ := hAgree
+    apply Eq.symm
+    apply Finset.prod_eq_zero (i := n) (Finset.mem_univ n)
+    simp only [cyclicBondProjectionFactor]
+    rw [if_neg (by omega), Matrix.one_apply, if_neg (Ne.symm hστ)]
+
+private theorem finKronecker_list_prod_of_ne_nil {N : ℕ}
+    (l : List (Fin N → Matrix (Fin d) (Fin d) ℂ)) (hl : l ≠ []) :
+    (l.map Matrix.finKronecker).prod =
+      Matrix.finKronecker (fun n ↦ (l.map fun A ↦ A n).prod) := by
+  classical
+  induction l with
+  | nil => exact (hl rfl).elim
+  | cons A l ih =>
+      cases l with
+      | nil => simp
+      | cons B l =>
+          rw [List.map_cons, List.prod_cons]
+          rw [ih (by simp)]
+          rw [finKronecker_mul]
+          simp only [List.map_cons, List.prod_cons]
+
+private theorem list_prod_eq_one_of_forall
+    (l : List (Matrix (Fin d) (Fin d) ℂ)) (h : ∀ X ∈ l, X = 1) : l.prod = 1 := by
+  induction l with
+  | nil => simp
+  | cons X l ih =>
+      rw [List.prod_cons, h X (by simp), Matrix.one_mul]
+      exact ih (fun Y hY ↦ h Y (by simp [hY]))
+
+private theorem list_prod_eq_of_mem_idempotent
+    (P : Matrix (Fin d) (Fin d) ℂ) (hP : P * P = P)
+    (l : List (Matrix (Fin d) (Fin d) ℂ))
+    (hvalues : ∀ X ∈ l, X = 1 ∨ X = P) (hmem : P ∈ l) :
+    l.prod = P := by
+  classical
+  by_cases hPone : P = 1
+  · subst P
+    apply list_prod_eq_one_of_forall l
+    intro X hX
+    rcases hvalues X hX with hX1 | hX1 <;> exact hX1
+  induction l with
+  | nil => simp at hmem
+  | cons X l ih =>
+      have hX := hvalues X (by simp)
+      rcases hX with hX | hX
+      · subst X
+        simp only [List.prod_cons, Matrix.one_mul]
+        apply ih (fun Y hY ↦ hvalues Y (by simp [hY]))
+        simpa [hPone] using hmem
+      · subst X
+        simp only [List.prod_cons]
+        by_cases hPl : P ∈ l
+        · rw [ih (fun Y hY ↦ hvalues Y (by simp [hY])) hPl, hP]
+        · have hall : ∀ Y ∈ l, Y = 1 := by
+            intro Y hY
+            rcases hvalues Y (by simp [hY]) with hY1 | hYP
+            · exact hY1
+            · exact (hPl (hYP ▸ hY)).elim
+          have hprod : l.prod = 1 := list_prod_eq_one_of_forall l hall
+          rw [hprod, Matrix.mul_one]
+
+private noncomputable def openBondProjectionProduct
+    (P : Matrix (Fin d) (Fin d) ℂ) {N : ℕ} (hN : 2 ≤ N) :
+    Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ :=
+  (List.ofFn fun i : Fin (N - 1) ↦
+    embedLocalOperator (d := d) 2 N hN ⟨i.val, by omega⟩
+      (twoSiteSectorProjection P)).prod
+
+private theorem openBondProjectionProduct_eq_sitewise
+    (P : Matrix (Fin d) (Fin d) ℂ) (hP : P * P = P)
+    {N : ℕ} (hN : 2 ≤ N) :
+    openBondProjectionProduct P hN = sitewisePhysicalMatrix P N := by
+  classical
+  let factors : Fin (N - 1) → Fin N → Matrix (Fin d) (Fin d) ℂ :=
+    fun i n ↦ cyclicBondProjectionFactor P ⟨i.val, by omega⟩ n
+  have hlist :
+      (List.ofFn fun i : Fin (N - 1) ↦
+        embedLocalOperator (d := d) 2 N hN ⟨i.val, by omega⟩
+          (twoSiteSectorProjection P)) =
+        (List.ofFn factors).map Matrix.finKronecker := by
+    rw [List.map_ofFn]
+    apply congrArg List.ofFn
+    funext i
+    exact embed_twoSiteSectorProjection_eq_finKronecker P hN ⟨i.val, by omega⟩
+  rw [openBondProjectionProduct, hlist]
+  have hne : List.ofFn factors ≠ [] := by
+    rw [List.ne_nil_iff_length_pos, List.length_ofFn]
+    omega
+  rw [finKronecker_list_prod_of_ne_nil _ hne]
+  simp only [List.map_ofFn]
+  change Matrix.finKronecker
+      (fun n ↦ (List.ofFn fun i : Fin (N - 1) ↦ factors i n).prod) =
+    Matrix.finKronecker (fun _ ↦ P)
+  congr 1
+  funext n
+  apply list_prod_eq_of_mem_idempotent P hP
+  · intro X hX
+    rw [List.mem_ofFn] at hX
+    obtain ⟨i, rfl⟩ := hX
+    simp only [factors, cyclicBondProjectionFactor]
+    split_ifs <;> simp
+  · rw [List.mem_ofFn]
+    by_cases hnlast : n.val < N - 1
+    · refine ⟨⟨n.val, hnlast⟩, ?_⟩
+      simp only [factors, cyclicBondProjectionFactor]
+      have hoff : (n.val + N - n.val) % N = 0 := by
+        rw [show n.val + N - n.val = N by omega, Nat.mod_self]
+      rw [if_pos (by rw [hoff]; omega)]
+    · refine ⟨⟨N - 2, by omega⟩, ?_⟩
+      simp only [factors, cyclicBondProjectionFactor]
+      have hn : n.val = N - 1 := by omega
+      have hoff : (n.val + N - (N - 2)) % N = 1 := by
+        rw [hn]
+        rw [show N - 1 + N - (N - 2) = N + 1 by omega,
+          Nat.add_mod_left, Nat.mod_eq_of_lt (by omega : 1 < N)]
+      rw [hoff, if_pos (by omega)]
+
+private theorem list_prod_mul_eq_of_forall
+    {n : Type*} [Fintype n] [DecidableEq n]
+    (l : List (Matrix n n ℂ)) (X : Matrix n n ℂ)
+    (h : ∀ A ∈ l, A * X = X) : l.prod * X = X := by
+  induction l with
+  | nil => simp
+  | cons A l ih =>
+      rw [List.prod_cons, Matrix.mul_assoc, ih (fun B hB ↦ h B (by simp [hB])),
+        h A (by simp)]
+
+private theorem list_prod_range_mul
+    {n : Type*} [Fintype n] [DecidableEq n]
+    (Q : Matrix n n ℂ) (hQ : Q * Q = Q)
+    (l : List (Matrix n n ℂ)) (hl : l ≠ [])
+    (hcomm : ∀ A ∈ l, Q * A = A * Q) :
+    (l.map fun A ↦ Q * A).prod = Q * l.prod := by
+  induction l with
+  | nil => exact (hl rfl).elim
+  | cons A l ih =>
+      cases l with
+      | nil => simp
+      | cons B l =>
+          rw [List.map_cons, List.prod_cons, ih (by simp)
+            (fun C hC ↦ hcomm C (by simp [hC]))]
+          calc
+            (Q * A) * (Q * (B :: l).prod) =
+                Q * (A * Q) * (B :: l).prod := by
+              simp only [Matrix.mul_assoc]
+            _ = Q * (Q * A) * (B :: l).prod := by
+              rw [hcomm A (by simp)]
+            _ = (Q * Q) * A * (B :: l).prod := by
+              simp only [Matrix.mul_assoc]
+            _ = Q * (A :: B :: l).prod := by
+              rw [hQ]
+              simp only [List.prod_cons, Matrix.mul_assoc]
+
+namespace PhysicalSupportRestrictionData
+
+variable {P : Matrix (Fin d) (Fin d) ℂ} {K : MPOTensor d D}
+
+private theorem twoSiteSectorProjection_mul_liftedBond
+    (F : PhysicalSupportRestrictionData P K)
+    (B : Matrix (Fin 2 → Fin F.supportDim)
+      (Fin 2 → Fin F.supportDim) ℂ) :
+    twoSiteSectorProjection P * F.liftedBond B = F.liftedBond B := by
+  rw [F.twoSiteSectorProjection_eq_lifted_range]
+  simp only [liftedBond, singleKrausMap_apply, Matrix.mul_assoc]
+  rw [← Matrix.mul_assoc
+      (sitewisePhysicalMatrix F.inclusion 2)ᴴ
+      (sitewisePhysicalMatrix F.inclusion 2),
+    sitewisePhysicalMatrix_isometry F.inclusion F.inclusion_isometry 2,
+    Matrix.one_mul]
+
+private theorem liftedBond_mul_twoSiteSectorProjection
+    (F : PhysicalSupportRestrictionData P K)
+    (B : Matrix (Fin 2 → Fin F.supportDim)
+      (Fin 2 → Fin F.supportDim) ℂ) :
+    F.liftedBond B * twoSiteSectorProjection P = F.liftedBond B := by
+  rw [F.twoSiteSectorProjection_eq_lifted_range]
+  simp only [liftedBond, singleKrausMap_apply, Matrix.mul_assoc]
+  rw [← Matrix.mul_assoc
+      (sitewisePhysicalMatrix F.inclusion 2)ᴴ
+      (sitewisePhysicalMatrix F.inclusion 2),
+    sitewisePhysicalMatrix_isometry F.inclusion F.inclusion_isometry 2,
+    Matrix.one_mul]
+
+private theorem liftedBondProduct_left_supported
+    (F : PhysicalSupportRestrictionData P K)
+    (data : TranslationInvariantBondData F.supportDim)
+    {N : ℕ} (hN : 2 ≤ N) :
+    sitewisePhysicalMatrix P N *
+        (List.ofFn fun i : Fin N ↦
+          embedLocalOperator (d := d) 2 N hN i
+            (F.liftedBond data.bond)).prod =
+      (List.ofFn fun i : Fin N ↦
+        embedLocalOperator (d := d) 2 N hN i
+          (F.liftedBond data.bond)).prod := by
+  let A : Fin N → Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ :=
+    fun i ↦ embedLocalOperator (d := d) 2 N hN i
+      (F.liftedBond data.bond)
+  let R : Fin (N - 1) → Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ :=
+    fun i ↦ embedLocalOperator (d := d) 2 N hN ⟨i.val, by omega⟩
+      (twoSiteSectorProjection P)
+  have hpair : (List.ofFn A).Pairwise Commute := by
+    rw [List.pairwise_ofFn]
+    intro i j _
+    exact F.liftedTranslationInvariantBondData data |>.bond_comm
+      hN ⟨i.val, by omega⟩ ⟨j.val, by omega⟩
+  have hRiAi (i : Fin (N - 1)) :
+      R i * A ⟨i.val, by omega⟩ = A ⟨i.val, by omega⟩ := by
+    simp only [R, A]
+    rw [← embedLocalOperator_mul,
+      F.twoSiteSectorProjection_mul_liftedBond]
+  have hRiProduct (i : Fin (N - 1)) : R i * (List.ofFn A).prod =
+      (List.ofFn A).prod := by
+    let j : Fin N := ⟨i.val, by omega⟩
+    have hmem : A j ∈ List.ofFn A := by
+      rw [List.mem_ofFn]
+      exact ⟨j, rfl⟩
+    have hperm : List.Perm (List.ofFn A)
+        (A j :: (List.ofFn A).erase (A j)) :=
+      List.perm_cons_erase hmem
+    have hprod := hperm.prod_eq' hpair
+    rw [hprod]
+    simp only [List.prod_cons]
+    rw [← Matrix.mul_assoc, show R i * A j = A j from hRiAi i]
+  have hRprod : (List.ofFn R).prod * (List.ofFn A).prod =
+      (List.ofFn A).prod :=
+    list_prod_mul_eq_of_forall _ _ (by
+      intro X hX
+      rw [List.mem_ofFn] at hX
+      obtain ⟨i, rfl⟩ := hX
+      exact hRiProduct i)
+  have hP : P * P = P := by
+    rw [← F.inclusion_range]
+    simp only [Matrix.mul_assoc]
+    rw [← Matrix.mul_assoc F.inclusionᴴ F.inclusion,
+      F.inclusion_isometry, Matrix.one_mul]
+  have hR : (List.ofFn R).prod = sitewisePhysicalMatrix P N := by
+    simpa [R, openBondProjectionProduct] using
+      openBondProjectionProduct_eq_sitewise P hP hN
+  simpa [A, hR] using hRprod
+
+end PhysicalSupportRestrictionData
+
+
+/-- The isometric image of one embedded restricted bond is its ambient lift
+multiplied by the range projection on the complete chain.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 and equation
+`generateMPDO`, lines 1571--1593 and 1733--1770. -/
+theorem singleKrausMap_embedLocalOperator_eq_range_mul_lift
+    (V : Matrix (Fin d) (Fin e) ℂ) (hV : Vᴴ * V = 1)
+    {N : ℕ} (hN : 2 ≤ N) (i : Fin N)
+    (B : Matrix (Fin 2 → Fin e) (Fin 2 → Fin e) ℂ) :
+    singleKrausMap (sitewisePhysicalMatrix V N)
+        (embedLocalOperator (d := e) 2 N hN i B) =
+      singleKrausMap (sitewisePhysicalMatrix V N) 1 *
+        embedLocalOperator (d := d) 2 N hN i
+          (singleKrausMap (sitewisePhysicalMatrix V 2) B) := by
+  let ed := windowComplementEquiv (d := d) 2 N hN i
+  let ee := windowComplementEquiv (d := e) 2 N hN i
+  apply (Matrix.reindex ed ed).injective
+  change (Matrix.reindexLinearEquiv ℂ ℂ ed ed)
+      (singleKrausMap (sitewisePhysicalMatrix V N)
+        (embedLocalOperator (d := e) 2 N hN i B)) =
+    (Matrix.reindexLinearEquiv ℂ ℂ ed ed)
+      (singleKrausMap (sitewisePhysicalMatrix V N) 1 *
+        embedLocalOperator (d := d) 2 N hN i
+          (singleKrausMap (sitewisePhysicalMatrix V 2) B))
+  rw [← Matrix.reindexLinearEquiv_mul ℂ ℂ ed ed ed]
+  simp only [Matrix.coe_reindexLinearEquiv]
+  rw [Matrix.reindex_singleKrausMap ee ed,
+    reindex_sitewisePhysicalMatrix_windowComplement,
+    reindex_embedLocalOperator_windowComplement]
+  change singleKrausMap
+      (sitewisePhysicalMatrix V 2 ⊗ₖ sitewisePhysicalMatrix V (N - 2))
+        (B ⊗ₖ (1 : Matrix (Fin (N - 2) → Fin e)
+          (Fin (N - 2) → Fin e) ℂ)) = _
+  rw [singleKrausMap_kronecker]
+  have hone : Matrix.reindex ee ee
+      (1 : Matrix (Fin N → Fin e) (Fin N → Fin e) ℂ) = 1 := by
+    ext x y
+    by_cases hxy : x = y
+    · subst y
+      simp [Matrix.reindex_apply]
+    · have hne : ee.symm x ≠ ee.symm y := fun h ↦ hxy (ee.symm.injective h)
+      simp [Matrix.reindex_apply, hxy, hne]
+  rw [Matrix.reindex_singleKrausMap ee ed,
+    reindex_sitewisePhysicalMatrix_windowComplement,
+    reindex_embedLocalOperator_windowComplement, hone]
+  simp only [singleKrausMap_apply, Matrix.mul_one,
+    Matrix.conjTranspose_kronecker]
+  rw [← Matrix.mul_kronecker_mul, ← Matrix.mul_kronecker_mul]
+  have htwo := sitewisePhysicalMatrix_isometry V hV 2
+  simp only [Matrix.mul_assoc]
+  rw [← Matrix.mul_assoc
+      (sitewisePhysicalMatrix V 2)ᴴ (sitewisePhysicalMatrix V 2),
+    htwo, Matrix.one_mul]
+  simp
+
+private theorem sitewisePhysicalMatrix_mul_conjTranspose
+    (V : Matrix (Fin d) (Fin e) ℂ) (N : ℕ) :
+    sitewisePhysicalMatrix V N * (sitewisePhysicalMatrix V N)ᴴ =
+      sitewisePhysicalMatrix (V * Vᴴ) N := by
+  classical
+  ext s t
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply,
+    sitewisePhysicalMatrix, star_prod]
+  simp_rw [← Finset.prod_mul_distrib]
+  rw [← Fintype.piFinset_univ]
+  rw [← Finset.prod_univ_sum
+    (fun _ : Fin N ↦ (Finset.univ : Finset (Fin e)))
+    (fun n a ↦ V (s n) a * star (V (t n) a))]
+
+namespace PhysicalSupportRestrictionData
+
+variable {P : Matrix (Fin d) (Fin d) ℂ} {K : MPOTensor d D}
+
+/-- Isometric conjugation carries the complete restricted periodic bond
+product to the complete product of the lifted ambient bond, for every chain
+length at least two.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 and equation
+`generateMPDO`, lines 1571--1593 and 1733--1770. -/
+theorem singleKrausMap_bondProduct_eq_liftedBondProduct
+    (F : PhysicalSupportRestrictionData P K)
+    (data : TranslationInvariantBondData F.supportDim)
+    {N : ℕ} (hN : 2 ≤ N) :
+    singleKrausMap (sitewisePhysicalMatrix F.inclusion N)
+        (List.ofFn fun i : Fin N ↦
+          embedLocalOperator (d := F.supportDim) 2 N hN i data.bond).prod =
+      (List.ofFn fun i : Fin N ↦
+        embedLocalOperator (d := d) 2 N hN i
+          (F.liftedBond data.bond)).prod := by
+  let W := sitewisePhysicalMatrix F.inclusion N
+  let Q := singleKrausMap W 1
+  let X : Fin N → Matrix (Fin N → Fin F.supportDim)
+      (Fin N → Fin F.supportDim) ℂ :=
+    fun i ↦ embedLocalOperator (d := F.supportDim) 2 N hN i data.bond
+  let A : Fin N → Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ :=
+    fun i ↦ embedLocalOperator (d := d) 2 N hN i
+      (F.liftedBond data.bond)
+  have hW : Wᴴ * W = 1 :=
+    sitewisePhysicalMatrix_isometry F.inclusion F.inclusion_isometry N
+  have hQ : Q * Q = Q := by
+    calc
+      Q * Q = singleKrausMap W (1 * 1) :=
+        (singleKrausMap_mul_isometry W hW 1 1).symm
+      _ = Q := by simp [Q]
+  have hmap : (List.ofFn X).map (singleKrausMap W) =
+      List.ofFn (fun i ↦ Q * A i) := by
+    rw [List.map_ofFn]
+    apply congrArg List.ofFn
+    funext i
+    exact singleKrausMap_embedLocalOperator_eq_range_mul_lift
+      F.inclusion F.inclusion_isometry hN i data.bond
+  have hQherm : Q.IsHermitian :=
+    (Matrix.PosSemidef.one.mul_mul_conjTranspose_same W).1
+  have hcommQ : ∀ C ∈ List.ofFn A, Q * C = C * Q := by
+    intro C hC
+    rw [List.mem_ofFn] at hC
+    obtain ⟨i, rfl⟩ := hC
+    have hleft := singleKrausMap_embedLocalOperator_eq_range_mul_lift
+      F.inclusion F.inclusion_isometry hN i data.bond
+    have hXpos : (X i).PosSemidef :=
+      embedLocalOperator_posSemidef 2 hN i data.bond_pos
+    have hφherm : (singleKrausMap W (X i)).IsHermitian :=
+      (hXpos.mul_mul_conjTranspose_same W).1
+    have hAherm : (A i).IsHermitian :=
+      (embedLocalOperator_posSemidef 2 hN i
+        (F.liftedBond_pos data.bond_pos)).1
+    calc
+      Q * A i = singleKrausMap W (X i) := hleft.symm
+      _ = (singleKrausMap W (X i))ᴴ := hφherm.eq.symm
+      _ = (Q * A i)ᴴ := congrArg Matrix.conjTranspose hleft
+      _ = A i * Q := by
+        rw [Matrix.conjTranspose_mul, hAherm.eq, hQherm.eq]
+  have hQrange : Q = sitewisePhysicalMatrix P N := by
+    simp only [Q, singleKrausMap_apply, Matrix.mul_one, W]
+    rw [sitewisePhysicalMatrix_mul_conjTranspose, F.inclusion_range]
+  have hne : List.ofFn X ≠ [] := by
+    rw [List.ne_nil_iff_length_pos, List.length_ofFn]
+    omega
+  have hAne : List.ofFn A ≠ [] := by
+    rw [List.ne_nil_iff_length_pos, List.length_ofFn]
+    omega
+  calc
+    singleKrausMap W (List.ofFn X).prod =
+        ((List.ofFn X).map (singleKrausMap W)).prod :=
+      singleKrausMap_list_prod_of_ne_nil W hW _ hne
+    _ = (List.ofFn fun i ↦ Q * A i).prod := congrArg List.prod hmap
+    _ = Q * (List.ofFn A).prod := by
+      have hm : (List.ofFn A).map (fun C ↦ Q * C) =
+          List.ofFn (fun i ↦ Q * A i) := by
+        rw [List.map_ofFn]
+        apply congrArg List.ofFn
+        funext i
+        rfl
+      rw [← hm]
+      exact list_prod_range_mul Q hQ _ hAne hcommQ
+    _ = (List.ofFn A).prod := by
+      rw [hQrange]
+      exact F.liftedBondProduct_left_supported data hN
+
+/-- Eta-local structure on the restricted physical space extends through the
+support isometry to eta-local structure on the ambient tensor.  The same
+positive normalization scalar is retained at every chain length.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 and equation
+`generateMPDO`, lines 1571--1593 and 1733--1770. -/
+noncomputable def liftedEtaLocalStructureData
+    (F : PhysicalSupportRestrictionData P K)
+    (data : EtaLocalStructureData
+      (PhysicalSectorFactorization.changePhysicalBasis F.inclusionᴴ K)) :
+    EtaLocalStructureData K where
+  bondData := F.liftedTranslationInvariantBondData data.bondData
+  realizes_mpo := by
+    intro N hN
+    obtain ⟨c, hc, hreal⟩ := data.realizes_mpo N hN
+    refine ⟨c, hc, ?_⟩
+    change mpo K N = (c : ℂ) •
+      (List.ofFn fun i : Fin N ↦
+        embedLocalOperator (d := d) 2 N hN i
+          (F.liftedBond data.bondData.bond)).prod
+    have hmpo : mpo K N =
+        singleKrausMap (sitewisePhysicalMatrix F.inclusion N)
+          (mpo (PhysicalSectorFactorization.changePhysicalBasis
+            F.inclusionᴴ K) N) := by
+      rw [singleKrausMap_sitewisePhysicalMatrix_mpo, F.reembed]
+    change mpo (PhysicalSectorFactorization.changePhysicalBasis
+      F.inclusionᴴ K) N = (c : ℂ) •
+        (List.ofFn fun i : Fin N ↦
+          embedLocalOperator (d := F.supportDim) 2 N hN i
+            data.bondData.bond).prod at hreal
+    rw [hmpo, hreal]
+    rw [(singleKrausMap
+      (sitewisePhysicalMatrix F.inclusion N)).map_smul]
+    rw [F.singleKrausMap_bondProduct_eq_liftedBondProduct data.bondData hN]
+
+/-- The lifted eta-local structure has the isometrically included restricted
+bond as its local bond. -/
+@[simp] theorem liftedEtaLocalStructureData_bond
+    (F : PhysicalSupportRestrictionData P K)
+    (data : EtaLocalStructureData
+      (PhysicalSectorFactorization.changePhysicalBasis F.inclusionᴴ K)) :
+    (F.liftedEtaLocalStructureData data).bondData.bond =
+      F.liftedBond data.bondData.bond := rfl
+
+/-- Proposition C.8 on the injective physical support gives an eta-local
+commuting-product realization of the ambient tensor whose bond remains in the
+prescribed two-site sector.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`) and
+equations `PjKiPj` and `generateMPDO`, lines 1571--1593 and 1733--1770. -/
+theorem exists_etaLocalStructureData_lifted_supported
+    (F : PhysicalSupportRestrictionData P K) (hSAL : IsSAL K) :
+    ∃ data : EtaLocalStructureData K,
+      twoSiteSectorProjection P * data.bondData.bond *
+          twoSiteSectorProjection P = data.bondData.bond ∧
+      ∀ N (hN : 2 ≤ N),
+        mpo K N = (data.bondData.toCommutingFormData hN).product := by
+  obtain ⟨G, hG⟩ := exists_positive_physicalSectorFactorization_of_isSAL
+    (PhysicalSectorFactorization.changePhysicalBasis F.inclusionᴴ K)
+    F.restricted_injective (F.restricted_isSAL hSAL)
+  let restrictedData := G.etaLocalStructureData hG
+  let data := F.liftedEtaLocalStructureData restrictedData
+  refine ⟨data, F.liftedBond_supported restrictedData.bondData.bond, ?_⟩
+  intro N hN
+  change mpo K N =
+    ((F.liftedTranslationInvariantBondData restrictedData.bondData).toCommutingFormData
+      hN).product
+  have hmpo : mpo K N =
+      singleKrausMap (sitewisePhysicalMatrix F.inclusion N)
+        (mpo (PhysicalSectorFactorization.changePhysicalBasis
+          F.inclusionᴴ K) N) := by
+    rw [singleKrausMap_sitewisePhysicalMatrix_mpo, F.reembed]
+  rw [hmpo]
+  change singleKrausMap (sitewisePhysicalMatrix F.inclusion N)
+      (mpo (PhysicalSectorFactorization.changePhysicalBasis
+        F.inclusionᴴ K) N) =
+    (List.ofFn fun i : Fin N ↦
+      embedLocalOperator (d := d) 2 N hN i
+        (F.liftedBond restrictedData.bondData.bond)).prod
+  rw [show mpo (PhysicalSectorFactorization.changePhysicalBasis
+      F.inclusionᴴ K) N =
+      (List.ofFn fun i : Fin N ↦
+        embedLocalOperator (d := F.supportDim) 2 N hN i
+          restrictedData.bondData.bond).prod by
+    exact G.mpo_eq_product_physicalBond hN]
+  exact F.singleKrausMap_bondProduct_eq_liftedBondProduct
+    restrictedData.bondData hN
+
+end PhysicalSupportRestrictionData
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
@@ -234,9 +234,9 @@ Definition~\ref{def:mpdo_source_gsnnch}; the converse comparison is not used.
     $K$ consequently give those for $K_P$.
 \end{proof}
 
-\begin{theorem}[The restricted commuting bond has a supported commuting lift]
+\begin{theorem}[The restricted commuting product has a supported ambient realization]
     \label{thm:mpdo_physical_support_restriction_bond}
-    \lean{MPOTensor.PhysicalSupportRestrictionData.exists_etaLocalStructureData_liftedTranslationInvariantBondData}
+    \lean{MPOTensor.PhysicalSupportRestrictionData.exists_etaLocalStructureData_lifted_supported}
     \leanok
     \uses{thm:mpdo_physical_support_restriction_sal}
     Let $K=V K_P V^*$ be a physical support restriction of an MPO tensor
@@ -247,6 +247,10 @@ Definition~\ref{def:mpdo_source_gsnnch}; the converse comparison is not used.
     commute pairwise on every such ambient chain, and
     \[
         (P\otimes P)B(P\otimes P)=B.
+    \]
+    Moreover, for every $N\geq2$ one has the exact identity
+    \[
+        \rho^{(N)}(K)=\prod_{i=0}^{N-1}B_{i,i+1}.
     \]
 \end{theorem}
 
@@ -265,6 +269,15 @@ Definition~\ref{def:mpdo_source_gsnnch}; the converse comparison is not used.
     the product in the reverse order.  The two-site periodic chain is handled
     by the same argument with the two oppositely oriented bonds.  Locality and
     cyclic translation then give pairwise commutativity for every $N\geq 2$.
+
+    Finally, isometric conjugation preserves every nonempty product of
+    restricted bonds.  The image of each restricted bond is the corresponding
+    lifted bond multiplied by the projection onto the range of
+    $V^{\otimes N}$.  The support projections contributed by the first
+    $N-1$ bonds cover all sites and leave the full commuting product fixed.
+    Hence the range projection disappears, and the restricted finite-chain
+    product identity becomes the asserted ambient identity, still with
+    normalization scalar one.
 \end{proof}
 
 \begin{definition}[Orthogonally supported commuting sector products]

--- a/docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex
+++ b/docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex
@@ -104,30 +104,25 @@ sector product identities give the source GSNNCH form with the prescribed
 natural multiplicities.
 \footnote{\raggedright Formal declaration:
 {\scriptsize\leanid{MPOTensor.hasGSNNCHForm_of_orthogonalCommutingSectorFamily}}.}
-The first part of the support-preserving sector argument is also complete.
+The support-preserving sector argument is also complete.
 Every absorbed BNT representative has an exact isometric restriction to the
 range of its matching projector, the restricted tensor is injective, SAL
 passes from the ambient representative to this restriction through the
 sitewise support isometry, and the positive Proposition~C.8 bond lifts to a
 positive two-site operator supported on the tensor square of that projector.
 The cyclic translates of this lifted bond commute pairwise on every periodic
-chain of length at least two.
+chain of length at least two, and their full periodic product gives the
+ambient finite-chain operator exactly, with normalization scalar one as in the
+restricted product.
 \footnote{\raggedright Formal declarations:
 {\scriptsize\leanid{MPOTensor.PhysicalSupportRestrictionData}},
 {\scriptsize\leanid{MPOTensor.nonempty_physicalSupportRestrictionData_commonWeightAbsorbedBasis}},
 {\scriptsize\leanid{MPOTensor.PhysicalSupportRestrictionData.restricted_isSAL}},
 and
-{\scriptsize\leanid{MPOTensor.PhysicalSupportRestrictionData.exists_etaLocalStructureData_liftedTranslationInvariantBondData}}.}
-The remaining comparison has two parts:
-
-\begin{enumerate}
-  \item transport the exact finite-chain product identity of the restricted
-        bond through the support isometry; positivity, pairwise commutativity
-        for every chain length at least two, and the identity
-        $(P_j\otimes P_j)B^{(j)}(P_j\otimes P_j)=B^{(j)}$ are formalized;
-  \item determine whether the reverse comparison with a single bond is needed
-        in the simple-MPDO equivalence, and prove it only in that form.
-\end{enumerate}
+{\scriptsize\leanid{MPOTensor.PhysicalSupportRestrictionData.exists_etaLocalStructureData_lifted_supported}}.}
+The remaining comparison is to determine whether the reverse comparison with
+a single bond is needed in the simple-MPDO equivalence, and to prove it only
+in that form.
 
 The local Markov labels in Appendix C.2 belong inside one injective BNT
 component.  They are not the outer labels $x$ of Definition~4.8 and must not
@@ -147,8 +142,9 @@ formalized, as is the injective restriction of every representative to its
 projector range.  SAL is invariant under the support isometry, and the
 resulting positive bond has a positive ambient lift supported on the matching
 two-site sector, and all cyclic translates of that lift commute pairwise on
-every periodic chain of length at least two.  The open gap is the exact
-finite-chain product identity, together with any reverse comparison actually
-needed by the simple-MPDO equivalence.
+every periodic chain of length at least two.  Their product realizes the
+ambient finite-chain operator exactly, with normalization scalar one.  The
+remaining question is whether the simple-MPDO equivalence requires a reverse
+comparison with a single bond.
 
 \end{document}


### PR DESCRIPTION
## Mathematical content

This proves that the complete periodic product supplied by Proposition C.8 survives the isometric inclusion of an injective physical support.

For every chain length N at least two, isometric conjugation transports the nonempty restricted bond product to the product of the ambient lifted bonds. The apparent range projection is removed using the two-site support identity and the open path formed by the first N minus one bonds, whose support projections cover every site. The resulting ambient bond is positive, supported on the prescribed two-site sector, has pairwise commuting cyclic translates, and realizes the ambient MPO exactly with normalization scalar one.

The proof deliberately makes no empty-chain or one-site statement. In particular, it does not assert that conjugation by a rectangular isometry is unital.

The blueprint statement and the GSNNCH paper-gap record are updated to include the exact finite-chain identity.

Advances #4126.

## Source

- arXiv:1606.00608, Appendix C.2, Proposition C.8 and equation generateMPDO, lines 1571–1593 and 1733–1770
- docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex

## Verification

- lake build TNLean.MPS.MPDO.PhysicalSupportProductTransport
- lake build TNLean
- leanblueprint pdf
- axiom audit: the transport declarations use only standard logical axioms; the final existence theorem inherits the existing Hayashi equality-characterization axiom and introduces no new axiom

Local leanblueprint declaration extraction remains unavailable because the installed plasTeX environment cannot import leanblueprint; the hosted blueprint check is therefore required.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style formal proofs and documentation; no runtime, auth, or data-path changes. Mathematical risk is localized to MPDO/GSNNCH theory already covered by related modules.
> 
> **Overview**
> Adds **`PhysicalSupportProductTransport.lean`** (~725 lines) and wires it into the root import list. The new proofs show that for chain length **N ≥ 2**, isometric conjugation by the sitewise physical support carries the **full periodic restricted bond product** to the product of **ambient lifted** bonds—without treating rectangular isometries as unital on empty lists.
> 
> The capstone is **`exists_etaLocalStructureData_lifted_supported`**: from SAL on the ambient MPO, it builds eta-local structure on **K** with a sector-supported bond and **`mpo K N` equal to the commuting bond product** for every **N ≥ 2**. Supporting lemmas include per-bond range-projection factorization, removal of the global range projection via the first **N−1** support bonds, and **`liftedEtaLocalStructureData`** lifting restricted eta-local data through the inclusion.
> 
> **Blueprint** theorem `thm:mpdo_physical_support_restriction_bond` is retitled, points at the new Lean name, and now states the exact identity ρ^(N)(K) = ∏ B_{i,i+1}. **`docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex`** marks the finite-chain product transport gap closed and narrows the remaining work to a possible reverse single-bond comparison.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ef207ccceeb45ac97f113e1d29b6bd553840e24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->