### PR TITLE
feat(MPS/MPDO): assemble supported BNT sectors

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -546,6 +546,7 @@ import TNLean.MPS.MPDO.CommutingForm
 import TNLean.MPS.MPDO.CommutingFormBridge
 import TNLean.MPS.MPDO.GSNNCHSectorSum
 import TNLean.MPS.MPDO.GSNNCHOrthogonalSectors
+import TNLean.MPS.MPDO.BNTSectorCommutingFamily
 import TNLean.MPS.MPDO.BlockedRFPConstruction
 
 -- MPS examples

--- a/TNLean/MPS/MPDO/BNTSectorCommutingFamily.lean
+++ b/TNLean/MPS/MPDO/BNTSectorCommutingFamily.lean
@@ -1,0 +1,120 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.GSNNCHOrthogonalSectors
+import TNLean.MPS.MPDO.PhysicalSupportProductTransport
+
+/-!
+# Commuting products on the BNT physical sectors
+
+The positive commuting bond of Proposition C.8 may be constructed on the
+injective restriction of each absorbed BNT representative and then included
+in the original physical space. The included bonds remain supported on their
+pairwise orthogonal BNT sectors and realize the sector MPOs exactly on every
+periodic chain of length at least two.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, equations `PjKiPj` and `generateMPDO`, and Proposition
+  `prop3to4`, lines 1733--1792
+-/
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- Saturation of the area law for every absorbed BNT representative gives a
+family of positive commuting bond products supported on the corresponding
+pairwise orthogonal BNT projectors.
+
+The hypotheses preceding `hSectorSAL` are precisely the data selecting the
+BNT physical projectors. The sectorwise SAL hypothesis is established from
+the simple-MPDO hypotheses in
+`commonWeightAbsorbedBasisMPOTensor_isSAL_of_sameMPV₂Pos`.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `PjKiPj` and
+`generateMPDO`, and Proposition `prop3to4`, lines 1733--1792. -/
+theorem nonempty_orthogonalCommutingSectorFamily_of_bntSectorSAL
+    (S : MPSTensor.SectorDecomposition (d * d))
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q')
+    {R : (s : Fin S.basisCount) →
+      Matrix (Fin (S.basisDim s)) (Fin (S.basisDim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex S.basisDim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse
+      (fun j ↦ S.basisMPOTensor j) C)
+    (hρ : IsThreeSiteFamilyClosure (fun j ↦ S.basisMPOTensor j) R ρ)
+    (hη : EtaStructure ρ) (hR : ∀ s : Fin S.basisCount, R s ≠ 0)
+    (hSpan : MPSTensor.WordTupleSpanTop S.basis 1)
+    (hSectorSAL : ∀ s : Fin S.basisCount,
+      IsSAL (commonWeightAbsorbedBasisMPOTensor S hWeight s)) :
+    Nonempty (OrthogonalCommutingSectorFamily
+      (fun s ↦ commonWeightAbsorbedBasisMPOTensor S hWeight s)) := by
+  classical
+  let restriction : (s : Fin S.basisCount) →
+      PhysicalSupportRestrictionData
+        (bntSectorProjection hC hρ hη hR s)
+        (commonWeightAbsorbedBasisMPOTensor S hWeight s) :=
+    fun s ↦ Classical.choice
+      (nonempty_physicalSupportRestrictionData_commonWeightAbsorbedBasis
+        S hWeight hC hρ hη hR hSpan s)
+  let data : (s : Fin S.basisCount) → EtaLocalStructureData
+      (commonWeightAbsorbedBasisMPOTensor S hWeight s) :=
+    fun s ↦ Classical.choose
+      ((restriction s).exists_etaLocalStructureData_lifted_supported
+        (hSectorSAL s))
+  have hdata : ∀ s : Fin S.basisCount,
+      twoSiteSectorProjection (bntSectorProjection hC hρ hη hR s) *
+          (data s).bondData.bond *
+          twoSiteSectorProjection (bntSectorProjection hC hρ hη hR s) =
+            (data s).bondData.bond ∧
+        ∀ N (hN : 2 ≤ N),
+          mpo (commonWeightAbsorbedBasisMPOTensor S hWeight s) N =
+            ((data s).bondData.toCommutingFormData hN).product :=
+    fun s ↦ Classical.choose_spec
+      ((restriction s).exists_etaLocalStructureData_lifted_supported
+        (hSectorSAL s))
+  exact ⟨{
+    projection := fun s ↦ bntSectorProjection hC hρ hη hR s
+    projection_isOrthogonal := fun s ↦
+      bntSectorProjection_isOrthogonal hC hρ hη hR s
+    projection_orthogonal := fun hst ↦
+      bntSectorProjection_mul_eq_zero hC hρ hη hR hst
+    bondData := fun s ↦ (data s).bondData
+    bond_supported := fun s ↦ (hdata s).1
+    realizes_mpo := fun s N hN ↦ (hdata s).2 N hN }⟩
+
+/-- Once the absorbed BNT representatives satisfy SAL, their supported
+commuting products assemble with the natural BNT multiplicities to give the
+source GSNNCH form of the original tensor.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `CFK` and Proposition
+`prop3to4`, lines 1660--1665 and 1733--1792. -/
+theorem hasGSNNCHForm_of_bntSectorSAL
+    (M : MPOTensor d D) (S : MPSTensor.SectorDecomposition (d * d))
+    (hM : MPSTensor.SameMPV₂Pos M.toMPSTensor S.toTensor)
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q')
+    {R : (s : Fin S.basisCount) →
+      Matrix (Fin (S.basisDim s)) (Fin (S.basisDim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex S.basisDim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse
+      (fun j ↦ S.basisMPOTensor j) C)
+    (hρ : IsThreeSiteFamilyClosure (fun j ↦ S.basisMPOTensor j) R ρ)
+    (hη : EtaStructure ρ) (hR : ∀ s : Fin S.basisCount, R s ≠ 0)
+    (hSpan : MPSTensor.WordTupleSpanTop S.basis 1)
+    (hSectorSAL : ∀ s : Fin S.basisCount,
+      IsSAL (commonWeightAbsorbedBasisMPOTensor S hWeight s)) :
+    HasGSNNCHForm M := by
+  obtain ⟨F⟩ :=
+    nonempty_orthogonalCommutingSectorFamily_of_bntSectorSAL
+      S hWeight hC hρ hη hR hSpan hSectorSAL
+  exact hasGSNNCHForm_of_commonWeightAbsorbedBasisMPOTensor
+    M S hM hWeight F
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
@@ -304,6 +304,39 @@ Definition~\ref{def:mpdo_source_gsnnch}; the converse comparison is not used.
     Definition~\ref{def:mpdo_source_gsnnch}.
 \end{definition}
 
+\begin{theorem}[SAL supplies orthogonally supported BNT sector products]
+    \label{thm:mpdo_bnt_sector_sal_commuting_family}
+    \lean{MPOTensor.nonempty_orthogonalCommutingSectorFamily_of_bntSectorSAL}
+    \leanok
+    \uses{thm:mpdo_physical_support_restriction_bond,
+        def:mpdo_orthogonal_commuting_sector_family}
+    Suppose that the BNT physical projectors $P_x$ have been selected and
+    that every common-weight-absorbed representative $\mathcal K_x$
+    satisfies SAL.  Then there are positive two-site bonds $B^{(x)}$ such
+    that the projections $P_x$ are pairwise orthogonal,
+    \[
+        (P_x\otimes P_x)B^{(x)}(P_x\otimes P_x)=B^{(x)},
+    \]
+    all cyclic translates of each $B^{(x)}$ commute pairwise, and, for every
+    $N\geq2$,
+    \[
+        \rho^{(N)}(\mathcal K_x)
+          =\prod_{i=0}^{N-1}\tau_i(B^{(x)}).
+    \]
+    Thus the absorbed BNT representatives have an orthogonally supported
+    family of commuting sector products with normalization scalar one.
+\end{theorem}
+
+\begin{proof}\leanok
+    Restrict $\mathcal K_x$ isometrically to the range of $P_x$.  The
+    restricted tensor is injective and satisfies SAL, so Proposition~C.8
+    gives its positive commuting bond product.  Apply
+    Theorem~\ref{thm:mpdo_physical_support_restriction_bond} in every sector.
+    The lifted bond is supported on $P_x\otimes P_x$ and realizes
+    $\mathcal K_x$ exactly.  The BNT projector construction gives
+    $P_xP_y=0$ for $x\ne y$, which completes the sector family.
+\end{proof}
+
 \begin{theorem}[Orthogonal commuting sector products give the GSNNCH form]
     \label{thm:mpdo_orthogonal_commuting_sectors_gsnnch}
     \lean{MPOTensor.OrthogonalCommutingSectorFamily.toGSNNCHData_sectorProduct}
@@ -354,6 +387,24 @@ Definition~\ref{def:mpdo_source_gsnnch}; the converse comparison is not used.
     Theorem~\ref{thm:mpdo_orthogonal_commuting_sectors_gsnnch} to the
     positive-length BNT decomposition.  Its coefficients are exactly the
     copy numbers $n_x$ after the common weights have been absorbed.
+\end{proof}
+
+\begin{corollary}[Sectorwise SAL gives the BNT GSNNCH form]
+    \label{cor:mpdo_bnt_sector_sal_gsnnch}
+    \lean{MPOTensor.hasGSNNCHForm_of_bntSectorSAL}
+    \leanok
+    \uses{thm:mpdo_bnt_sector_sal_commuting_family,
+        cor:mpdo_bnt_orthogonal_commuting_sectors_gsnnch}
+    Under the BNT projector-selection hypotheses, if every absorbed BNT
+    representative satisfies SAL, then the original tensor has the source
+    GSNNCH form.  Its outer sectors are the BNT sectors and its natural
+    multiplicities are the BNT copy numbers.
+\end{corollary}
+
+\begin{proof}\leanok
+    Theorem~\ref{thm:mpdo_bnt_sector_sal_commuting_family} supplies the
+    orthogonally supported commuting sector products.  Apply
+    Corollary~\ref{cor:mpdo_bnt_orthogonal_commuting_sectors_gsnnch}.
 \end{proof}
 
 \begin{lemma}[Cyclic-shift transport of an embedded local operator]

--- a/docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex
+++ b/docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex
@@ -120,6 +120,13 @@ restricted product.
 {\scriptsize\leanid{MPOTensor.PhysicalSupportRestrictionData.restricted_isSAL}},
 and
 {\scriptsize\leanid{MPOTensor.PhysicalSupportRestrictionData.exists_etaLocalStructureData_lifted_supported}}.}
+Choosing these supported products over all absorbed BNT representatives gives
+an orthogonal commuting sector family, and the BNT sum with its natural copy
+numbers therefore has the source GSNNCH form.
+\footnote{\raggedright Formal declarations:
+{\scriptsize\leanid{MPOTensor.nonempty_orthogonalCommutingSectorFamily_of_bntSectorSAL}}
+and
+{\scriptsize\leanid{MPOTensor.hasGSNNCHForm_of_bntSectorSAL}}.}
 The remaining comparison is to determine whether the reverse comparison with
 a single bond is needed in the simple-MPDO equivalence, and to prove it only
 in that form.
@@ -144,7 +151,8 @@ resulting positive bond has a positive ambient lift supported on the matching
 two-site sector, and all cyclic translates of that lift commute pairwise on
 every periodic chain of length at least two.  Their product realizes the
 ambient finite-chain operator exactly, with normalization scalar one.  The
-remaining question is whether the simple-MPDO equivalence requires a reverse
-comparison with a single bond.
+supported products are assembled into the BNT outer sectors with their
+natural multiplicities.  The remaining question is whether the simple-MPDO
+equivalence requires a reverse comparison with a single bond.
 
 \end{document}


### PR DESCRIPTION
## Mathematical content

This assembles the Proposition C.8 bond products over the absorbed BNT representatives.

For each BNT sector, the proof chooses the injective restriction to the range of the corresponding physical projector and applies the scalar-one support-product transport from #4143. The resulting two-site bond is positive, supported on the tensor square of its BNT projector, has pairwise commuting cyclic translates on every chain of length N at least two, and realizes the sector MPO exactly. Pairwise orthogonality of the BNT projectors then gives an OrthogonalCommutingSectorFamily.

The family combines with the positive-length BNT sum and the natural copy numbers to give the source GSNNCH form of the original tensor whenever the already-established sectorwise SAL hypotheses are supplied.

No empty-chain, one-site periodic-bond, zero physical-dimension, or zero virtual-dimension case enters the construction: every product statement assumes N at least two, while sectorwise SAL excludes both zero dimensions.

Closes #4126.

## Source

- arXiv:1606.00608, Appendix C.2, equations PjKiPj and generateMPDO, and Proposition prop3to4, lines 1733–1792
- docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex

## Verification

- lake env lean TNLean/MPS/MPDO/BNTSectorCommutingFamily.lean
- lake build TNLean.MPS.MPDO.BNTSectorCommutingFamily
- lake build TNLean
- leanblueprint pdf
- no sorry, axiom, admit, native_decide, or unsafeCast in the new file
- axiom audit: the new declarations inherit only the existing Hayashi equality-characterization axiom and standard logical axioms

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization and documentation on the MPDO/GSNNCH track; no runtime, auth, or data-path changes, and proofs compose existing lemmas without new axioms beyond inherited ones.
> 
> **Overview**
> Adds **`TNLean/MPS/MPDO/BNTSectorCommutingFamily.lean`** and wires it into the root import list.
> 
> **`nonempty_orthogonalCommutingSectorFamily_of_bntSectorSAL`** shows that when every common-weight-absorbed BNT representative satisfies SAL, the existing per-sector physical-support restriction and lifted Proposition C.8 bond data assemble into an **`OrthogonalCommutingSectorFamily`**: BNT sector projectors are pairwise orthogonal, bonds are supported on \(P_s \otimes P_s\), cyclic translates commute, and sector MPOs match the bond product for \(N \geq 2\).
> 
> **`hasGSNNCHForm_of_bntSectorSAL`** composes that family with **`hasGSNNCHForm_of_commonWeightAbsorbedBasisMPOTensor`**, so the original tensor has the source GSNNCH form with BNT outer sectors and copy multiplicities under the usual BNT projector-selection hypotheses plus sectorwise SAL.
> 
> The blueprint chapter gains theorem **SAL supplies orthogonally supported BNT sector products** and corollary **Sectorwise SAL gives the BNT GSNNCH form**; the CPSV16 sector-decomposition gap note records that this assembly step is now formalized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dedfcf875d75b10e81940c7bc87b2de8deede43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->