### PR TITLE
feat(Channel): classify positive retractions onto matrix sums

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -175,6 +175,7 @@ import TNLean.Channel.Schwarz.SchwarzNotCP
 import TNLean.Channel.Schwarz.TwoPositive
 import TNLean.Channel.PositiveFunctional
 import TNLean.Channel.PositiveConditionalExpectation
+import TNLean.Channel.PositiveConditionalExpectationDirectSum
 import TNLean.Channel.Schwarz.ChoiCompression
 import TNLean.Channel.NPositivityChainStrict
 import TNLean.Channel.ReductionCriterion

--- a/TNLean/Algebra/ScalarCommutant.lean
+++ b/TNLean/Algebra/ScalarCommutant.lean
@@ -3,9 +3,10 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import Mathlib.Data.Complex.Basic
 import Mathlib.Data.Matrix.Basis
 import Mathlib.Data.Matrix.Block
-import Mathlib.Analysis.Matrix.PosDef
+import Mathlib.LinearAlgebra.Matrix.Hermitian
 import Mathlib.LinearAlgebra.Matrix.Kronecker
 
 /-!

--- a/TNLean/Algebra/ScalarCommutant.lean
+++ b/TNLean/Algebra/ScalarCommutant.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import Mathlib.Data.Matrix.Basis
 import Mathlib.Data.Matrix.Block
+import Mathlib.Analysis.Matrix.PosDef
 import Mathlib.LinearAlgebra.Matrix.Kronecker
 
 /-!
@@ -136,6 +137,30 @@ theorem isBlockDiagonal'_iff_offBlock_zero {R : Type*} [Zero R]
 section Semiring
 
 variable {R : Type*} [Semiring R]
+
+/-- A block projection is idempotent. -/
+theorem blockProjection_isIdempotentElem
+    [Fintype ι] [(i : ι) → Fintype (n i)] [(i : ι) → DecidableEq (n i)]
+    (k : ι) : IsIdempotentElem (blockProjection (n := n) (R := R) k) := by
+  rw [IsIdempotentElem, blockProjection, ← Matrix.blockDiagonal'_mul]
+  congr 1
+  funext i
+  by_cases hik : i = k
+  · simp [hik]
+  · simp [hik]
+
+/-- A complex block projection is Hermitian. -/
+theorem blockProjection_isHermitian
+    [(i : ι) → DecidableEq (n i)]
+    (k : ι) :
+    (blockProjection (n := n) (R := ℂ) k).IsHermitian := by
+  simp only [Matrix.IsHermitian, blockProjection,
+    Matrix.blockDiagonal'_conjTranspose]
+  congr 1
+  funext i
+  by_cases hik : i = k
+  · simp [hik]
+  · simp [hik]
 
 /-- Left multiplication by a block projection fixes entries whose row belongs
 to the selected block. -/

--- a/TNLean/Channel/Basic.lean
+++ b/TNLean/Channel/Basic.lean
@@ -54,11 +54,11 @@ open Matrix Finset
 
 section PositiveMap
 
-variable {n : Type*} [Fintype n] [DecidableEq n]
+variable {m n : Type*} [Fintype n] [DecidableEq n]
 
-/-- A linear map `E : M_n(ℂ) →ₗ[ℂ] M_n(ℂ)` is **positive** if it maps
+/-- A linear map `E : M_n(ℂ) →ₗ[ℂ] M_m(ℂ)` is **positive** if it maps
 positive semidefinite matrices to positive semidefinite matrices. -/
-def IsPositiveMap (E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ) : Prop :=
+def IsPositiveMap (E : Matrix n n ℂ →ₗ[ℂ] Matrix m m ℂ) : Prop :=
   ∀ X : Matrix n n ℂ, X.PosSemidef → (E X).PosSemidef
 
 /-- A linear map is **trace-preserving** if `Tr(E(X)) = Tr(X)` for all `X`. -/
@@ -182,13 +182,14 @@ end PositiveMap
 
 section PositiveMapHermitian
 
-variable {n : Type*} [Finite n]
+variable {m n : Type*} [Finite m] [Finite n]
 
 /-- A positive matrix map is a positive linear map: if `A ≤ B`, then `E A ≤ E B`. -/
 def IsPositiveMap.toPositiveLinearMap
-    {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ} (hE : IsPositiveMap E) :
-    Matrix n n ℂ →ₚ[ℂ] Matrix n n ℂ := by
+    {E : Matrix n n ℂ →ₗ[ℂ] Matrix m m ℂ} (hE : IsPositiveMap E) :
+    Matrix n n ℂ →ₚ[ℂ] Matrix m m ℂ := by
   classical
+  letI := Fintype.ofFinite m
   letI := Fintype.ofFinite n
   exact
     { toLinearMap := E
@@ -199,10 +200,11 @@ def IsPositiveMap.toPositiveLinearMap
 
 /-- Positive maps preserve Hermiticity. -/
 theorem IsPositiveMap.map_isHermitian
-    {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
+    {E : Matrix n n ℂ →ₗ[ℂ] Matrix m m ℂ}
     (hE : IsPositiveMap E) {X : Matrix n n ℂ} (hX : X.IsHermitian) :
     (E X).IsHermitian := by
   classical
+  letI := Fintype.ofFinite m
   letI := Fintype.ofFinite n
   exact IsSelfAdjoint.isHermitian
     (hX.isSelfAdjoint.map' hE.toPositiveLinearMap)

--- a/TNLean/Channel/PositiveConditionalExpectation.lean
+++ b/TNLean/Channel/PositiveConditionalExpectation.lean
@@ -410,7 +410,8 @@ arbitrary direct sum of matrix factors, whereas this theorem treats one factor
 $1_m\otimes M_d(\mathbb C)$. Documented in
 `docs/paper-gaps/wolf_prop1_5_one_factor_scope.tex`. Elimination: conjugate and reindex
 by the finite-dimensional block decomposition, remove cross-block inputs and outputs by
-positivity, and apply this theorem to each diagonal factor. -/
+positivity, and apply this theorem to each diagonal factor, as carried out in
+`StarSubalgebra.exists_block_densities_of_positive_retraction`. -/
 theorem exists_density_of_positive_retraction_onto_right_factor [NeZero d]
     (E : Matrix (Fin m × Fin d) (Fin m × Fin d) ℂ →ₗ[ℂ]
       Matrix (Fin m × Fin d) (Fin m × Fin d) ℂ)

--- a/TNLean/Channel/PositiveConditionalExpectationDirectSum.lean
+++ b/TNLean/Channel/PositiveConditionalExpectationDirectSum.lean
@@ -100,7 +100,7 @@ partial trace.
 This is the finite-dimensional cyclicity used to pass between the two orders in Wolf,
 Equation (1.40): the displayed equation uses $A_{kk}(\rho_k\otimes 1)$, while the
 one-factor functional representation naturally gives $(\rho_k\otimes 1)A_{kk}$. -/
-theorem partialTraceLeft_kronecker_one_mul_eq_mul_kronecker_one
+private theorem partialTraceLeft_kronecker_one_mul_eq_mul_kronecker_one
     {α β : Type*} [Fintype α] [Fintype β] [DecidableEq β]
     (ρ : Matrix α α ℂ) (A : Matrix (α × β) (α × β) ℂ) :
     Matrix.partialTraceLeft ((ρ ⊗ₖ (1 : Matrix β β ℂ)) * A) =
@@ -466,10 +466,15 @@ theorem exists_density_of_positive_retraction_onto_direct_sum_right_factors
             directSumDiagonalBlockMap E k A =
               (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ
                 Matrix.partialTraceLeft
-                  ((ρ ⊗ₖ (1 : Matrix (Fin (d k)) (Fin (d k)) ℂ)) * A) :=
-    Matrix.exists_density_of_positive_retraction_onto_right_factor
+                  (A * (ρ ⊗ₖ (1 : Matrix (Fin (d k)) (Fin (d k)) ℂ))) := by
+    obtain ⟨ρ, hρpos, hρtrace, hρformula⟩ :=
+      Matrix.exists_density_of_positive_retraction_onto_right_factor
       (directSumDiagonalBlockMap E k)
       (directSumDiagonalBlockMap_isPositiveMap E hE k) (hLocalRange k) (hLocalFix k)
+    refine ⟨ρ, hρpos, hρtrace, fun A ↦ ?_⟩
+    rw [hρformula]
+    congr 1
+    exact partialTraceLeft_kronecker_one_mul_eq_mul_kronecker_one ρ A
   choose ρ hρpos hρtrace hρformula using hLocal
   refine ⟨ρ, hρpos, hρtrace, fun A ↦ ?_⟩
   obtain ⟨B, hB⟩ := hRange A
@@ -485,7 +490,14 @@ theorem exists_density_of_positive_retraction_onto_direct_sum_right_factors
     _ = directSumDiagonalBlockMap E k
           (directSumBlockCompression (m := m) (d := d) k A) :=
       directSumOutputBlockMap_eq_diagonalBlockMap_compression E hE hFix A k
-    _ = _ := hρformula k _
+    _ = (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ
+          Matrix.partialTraceLeft
+            (directSumBlockCompression (m := m) (d := d) k A *
+              ((ρ k) ⊗ₖ (1 : Matrix (Fin (d k)) (Fin (d k)) ℂ))) := hρformula k _
+    _ = _ := by
+      congr 1
+      exact (partialTraceLeft_kronecker_one_mul_eq_mul_kronecker_one
+        (ρ k) (directSumBlockCompression (m := m) (d := d) k A)).symm
 
 end Matrix
 

--- a/TNLean/Channel/PositiveConditionalExpectationDirectSum.lean
+++ b/TNLean/Channel/PositiveConditionalExpectationDirectSum.lean
@@ -38,15 +38,6 @@ namespace Matrix
 
 variable {K : ℕ} {m d : Fin K → ℕ}
 
-/-- A unitary matrix, regarded as a unit whose inverse is its adjoint. -/
-noncomputable def unitaryMatrixUnit {n : Type*} [Fintype n] [DecidableEq n]
-    (U : Matrix n n ℂ) (hU : U ∈ Matrix.unitaryGroup n ℂ) :
-    (Matrix n n ℂ)ˣ where
-  val := U
-  inv := star U
-  val_inv := Matrix.mem_unitaryGroup_iff.mp hU
-  inv_val := Matrix.mem_unitaryGroup_iff'.mp hU
-
 /-- Change from an original matrix basis to unitary block coordinates.
 
 For an equivalence `e : H ≃ n`, this sends $A$ to
@@ -57,8 +48,9 @@ noncomputable def unitaryReindexLinearEquiv
     {n H : Type*} [Fintype n] [DecidableEq n] [Fintype H] [DecidableEq H]
     (e : H ≃ n) (U : Matrix n n ℂ) (hU : U ∈ Matrix.unitaryGroup n ℂ) :
     Matrix n n ℂ ≃ₗ[ℂ] Matrix H H ℂ :=
-  (((unitaryMatrixUnit U hU)⁻¹).mulLeftLinearEquiv ℂ (Matrix n n ℂ)).trans
-    ((unitaryMatrixUnit U hU).mulRightLinearEquiv ℂ) |>.trans
+  ((((Unitary.toUnits (⟨U, hU⟩ : unitary (Matrix n n ℂ)))⁻¹).mulLeftLinearEquiv
+    ℂ (Matrix n n ℂ)).trans
+    ((Unitary.toUnits (⟨U, hU⟩ : unitary (Matrix n n ℂ))).mulRightLinearEquiv ℂ)) |>.trans
       (Matrix.reindexLinearEquiv ℂ ℂ e.symm e.symm)
 
 @[simp]
@@ -77,7 +69,7 @@ theorem unitaryReindexLinearEquiv_symm_apply
     (A : Matrix H H ℂ) :
     (unitaryReindexLinearEquiv e U hU).symm A =
       U * Matrix.reindex e e A * star U := by
-  simp [unitaryReindexLinearEquiv, unitaryMatrixUnit,
+  simp [unitaryReindexLinearEquiv, Unitary.toUnits,
     Matrix.symm_reindexLinearEquiv, Matrix.coe_reindexLinearEquiv, Matrix.mul_assoc]
 
 /-- Unitary change of basis and reindexing preserve positive semidefiniteness. -/

--- a/TNLean/Channel/PositiveConditionalExpectationDirectSum.lean
+++ b/TNLean/Channel/PositiveConditionalExpectationDirectSum.lean
@@ -1,0 +1,613 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.ScalarCommutant
+import TNLean.Algebra.StarSubalgebraBlockForm
+import TNLean.Analysis.MatrixSqrt
+import TNLean.Channel.PositiveConditionalExpectation
+import TNLean.Channel.Schwarz.PositiveMapProperties
+
+/-!
+# Positive conditional expectations onto finite sums of matrix factors
+
+This file determines the form of a positive linear retraction onto the coordinate
+star-subalgebra
+\[
+  \bigoplus_k \bigl(1_{m_k}\otimes M_{d_k}(\mathbb C)\bigr).
+\]
+
+## Main result
+
+* `Matrix.exists_density_of_positive_retraction_onto_direct_sum_right_factors`: the
+  coordinate direct-sum classification.
+* `StarSubalgebra.exists_block_densities_of_positive_retraction`: the classification for
+  an arbitrary star-subalgebra.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Proposition 1.5 and
+  Equation (1.40)][Wolf2012QChannels]
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder Kronecker
+open Matrix
+
+namespace Matrix
+
+variable {K : ℕ} {m d : Fin K → ℕ}
+
+/-- A unitary matrix, regarded as a unit whose inverse is its adjoint. -/
+noncomputable def unitaryMatrixUnit {n : Type*} [Fintype n] [DecidableEq n]
+    (U : Matrix n n ℂ) (hU : U ∈ Matrix.unitaryGroup n ℂ) :
+    (Matrix n n ℂ)ˣ where
+  val := U
+  inv := star U
+  val_inv := Matrix.mem_unitaryGroup_iff.mp hU
+  inv_val := Matrix.mem_unitaryGroup_iff'.mp hU
+
+/-- Change from an original matrix basis to unitary block coordinates.
+
+For an equivalence `e : H ≃ n`, this sends $A$ to
+$\operatorname{reindex}_{e^{-1}}(U^*AU)$. Its inverse sends $X$ to
+$U\operatorname{reindex}_e(X)U^*$. These are the coordinate changes in Wolf,
+Equation (1.39). -/
+noncomputable def unitaryReindexLinearEquiv
+    {n H : Type*} [Fintype n] [DecidableEq n] [Fintype H] [DecidableEq H]
+    (e : H ≃ n) (U : Matrix n n ℂ) (hU : U ∈ Matrix.unitaryGroup n ℂ) :
+    Matrix n n ℂ ≃ₗ[ℂ] Matrix H H ℂ :=
+  (((unitaryMatrixUnit U hU)⁻¹).mulLeftLinearEquiv ℂ (Matrix n n ℂ)).trans
+    ((unitaryMatrixUnit U hU).mulRightLinearEquiv ℂ) |>.trans
+      (Matrix.reindexLinearEquiv ℂ ℂ e.symm e.symm)
+
+@[simp]
+theorem unitaryReindexLinearEquiv_apply
+    {n H : Type*} [Fintype n] [DecidableEq n] [Fintype H] [DecidableEq H]
+    (e : H ≃ n) (U : Matrix n n ℂ) (hU : U ∈ Matrix.unitaryGroup n ℂ)
+    (A : Matrix n n ℂ) :
+    unitaryReindexLinearEquiv e U hU A =
+      Matrix.reindex e.symm e.symm (star U * A * U) := by
+  rfl
+
+@[simp]
+theorem unitaryReindexLinearEquiv_symm_apply
+    {n H : Type*} [Fintype n] [DecidableEq n] [Fintype H] [DecidableEq H]
+    (e : H ≃ n) (U : Matrix n n ℂ) (hU : U ∈ Matrix.unitaryGroup n ℂ)
+    (A : Matrix H H ℂ) :
+    (unitaryReindexLinearEquiv e U hU).symm A =
+      U * Matrix.reindex e e A * star U := by
+  simp [unitaryReindexLinearEquiv, unitaryMatrixUnit,
+    Matrix.symm_reindexLinearEquiv, Matrix.coe_reindexLinearEquiv, Matrix.mul_assoc]
+
+/-- Unitary change of basis and reindexing preserve positive semidefiniteness. -/
+theorem unitaryReindexLinearEquiv_posSemidef
+    {n H : Type*} [Fintype n] [DecidableEq n] [Fintype H] [DecidableEq H]
+    (e : H ≃ n) (U : Matrix n n ℂ) (hU : U ∈ Matrix.unitaryGroup n ℂ)
+    {A : Matrix n n ℂ} (hA : A.PosSemidef) :
+    (unitaryReindexLinearEquiv e U hU A).PosSemidef := by
+  rw [unitaryReindexLinearEquiv_apply]
+  have hConj : (star U * A * U).PosSemidef := by
+    simpa only [Matrix.star_eq_conjTranspose, Matrix.conjTranspose_conjTranspose] using
+      hA.mul_mul_conjTranspose_same (B := star U)
+  exact hConj.submatrix e
+
+/-- The inverse unitary change of basis and reindexing preserve positive
+semidefiniteness. -/
+theorem unitaryReindexLinearEquiv_symm_posSemidef
+    {n H : Type*} [Fintype n] [DecidableEq n] [Fintype H] [DecidableEq H]
+    (e : H ≃ n) (U : Matrix n n ℂ) (hU : U ∈ Matrix.unitaryGroup n ℂ)
+    {A : Matrix H H ℂ} (hA : A.PosSemidef) :
+    ((unitaryReindexLinearEquiv e U hU).symm A).PosSemidef := by
+  rw [unitaryReindexLinearEquiv_symm_apply]
+  exact (hA.submatrix e.symm).mul_mul_conjTranspose_same (B := U)
+
+/-- A matrix acting on the traced factor may be moved across an input before taking the
+partial trace.
+
+This is the finite-dimensional cyclicity used to pass between the two orders in Wolf,
+Equation (1.40): the displayed equation uses $A_{kk}(\rho_k\otimes 1)$, while the
+one-factor functional representation naturally gives $(\rho_k\otimes 1)A_{kk}$. -/
+theorem partialTraceLeft_kronecker_one_mul_eq_mul_kronecker_one
+    {α β : Type*} [Fintype α] [Fintype β] [DecidableEq β]
+    (ρ : Matrix α α ℂ) (A : Matrix (α × β) (α × β) ℂ) :
+    Matrix.partialTraceLeft ((ρ ⊗ₖ (1 : Matrix β β ℂ)) * A) =
+      Matrix.partialTraceLeft (A * (ρ ⊗ₖ (1 : Matrix β β ℂ))) := by
+  classical
+  ext i j
+  simp only [Matrix.partialTraceLeft_apply, Matrix.mul_apply]
+  simp_rw [Fintype.sum_prod_type]
+  simp only [Matrix.kroneckerMap_apply, Matrix.one_apply]
+  simp only [mul_ite, mul_one, mul_zero, ite_mul, zero_mul, Finset.sum_ite_eq,
+    Finset.mem_univ, if_true, Finset.sum_ite_eq']
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro a _
+  apply Finset.sum_congr rfl
+  intro b _
+  ring
+
+/-- The diagonal block of a matrix on a finite dependent direct sum.
+
+This is the block restriction used in Wolf, Proposition 1.5 and Equation (1.40). -/
+noncomputable def directSumBlockCompression (k : Fin K) :
+    Matrix ((j : Fin K) × (Fin (m j) × Fin (d j)))
+        ((j : Fin K) × (Fin (m j) × Fin (d j))) ℂ →ₗ[ℂ]
+      Matrix (Fin (m k) × Fin (d k)) (Fin (m k) × Fin (d k)) ℂ where
+  toFun A := A.submatrix (fun i ↦ ⟨k, i⟩) (fun i ↦ ⟨k, i⟩)
+  map_add' A B := by
+    ext i j
+    rfl
+  map_smul' c A := by
+    ext i j
+    rfl
+
+@[simp]
+theorem directSumBlockCompression_apply (k : Fin K)
+    (A : Matrix ((j : Fin K) × (Fin (m j) × Fin (d j)))
+      ((j : Fin K) × (Fin (m j) × Fin (d j))) ℂ)
+    (i j : Fin (m k) × Fin (d k)) :
+    directSumBlockCompression (m := m) (d := d) k A i j = A ⟨k, i⟩ ⟨k, j⟩ :=
+  rfl
+
+/-- Embed a matrix as one diagonal block of a finite dependent direct sum.
+
+This is the inclusion of a single summand in Wolf, Proposition 1.5 and
+Equation (1.40). -/
+noncomputable def directSumBlockEmbedding (k : Fin K) :
+    Matrix (Fin (m k) × Fin (d k)) (Fin (m k) × Fin (d k)) ℂ →ₗ[ℂ]
+      Matrix ((j : Fin K) × (Fin (m j) × Fin (d j)))
+        ((j : Fin K) × (Fin (m j) × Fin (d j))) ℂ where
+  toFun A := Matrix.blockDiagonal' (Pi.single k A)
+  map_add' A B := by
+    rw [Pi.single_add, Matrix.blockDiagonal'_add]
+  map_smul' c A := by
+    rw [Pi.single_smul, Matrix.blockDiagonal'_smul]
+    rfl
+
+@[simp]
+theorem directSumBlockCompression_embedding (k : Fin K)
+    (A : Matrix (Fin (m k) × Fin (d k)) (Fin (m k) × Fin (d k)) ℂ) :
+    directSumBlockCompression (m := m) (d := d) k
+      (directSumBlockEmbedding (m := m) (d := d) k A) = A := by
+  ext i j
+  simp [directSumBlockCompression, directSumBlockEmbedding,
+    Matrix.blockDiagonal'_apply_eq]
+
+/-- Compression to a diagonal summand preserves positive semidefiniteness. -/
+theorem directSumBlockCompression_isPositiveMap (k : Fin K) :
+    IsPositiveMap (directSumBlockCompression (m := m) (d := d) k) := by
+  intro A hA
+  exact hA.submatrix (fun i ↦ ⟨k, i⟩)
+
+/-- Embedding in a diagonal summand preserves positive semidefiniteness. -/
+theorem directSumBlockEmbedding_isPositiveMap (k : Fin K) :
+    IsPositiveMap (directSumBlockEmbedding (m := m) (d := d) k) := by
+  intro A hA
+  apply Matrix.PosSemidef.blockDiagonal'
+  intro j
+  by_cases hjk : j = k
+  · subst j
+    simpa using hA
+  · simpa [hjk] using
+      (Matrix.PosSemidef.zero :
+        (0 : Matrix (Fin (m j) × Fin (d j)) (Fin (m j) × Fin (d j)) ℂ).PosSemidef)
+
+/-- The image of a map, restricted to one diagonal output block. -/
+noncomputable def directSumOutputBlockMap
+    (E : Matrix ((j : Fin K) × (Fin (m j) × Fin (d j)))
+        ((j : Fin K) × (Fin (m j) × Fin (d j))) ℂ →ₗ[ℂ]
+      Matrix ((j : Fin K) × (Fin (m j) × Fin (d j)))
+        ((j : Fin K) × (Fin (m j) × Fin (d j))) ℂ)
+    (k : Fin K) :
+    Matrix ((j : Fin K) × (Fin (m j) × Fin (d j)))
+        ((j : Fin K) × (Fin (m j) × Fin (d j))) ℂ →ₗ[ℂ]
+      Matrix (Fin (m k) × Fin (d k)) (Fin (m k) × Fin (d k)) ℂ :=
+  (directSumBlockCompression (m := m) (d := d) k).comp E
+
+/-- Restrict a map to one diagonal input block and one diagonal output block. -/
+noncomputable def directSumDiagonalBlockMap
+    (E : Matrix ((j : Fin K) × (Fin (m j) × Fin (d j)))
+        ((j : Fin K) × (Fin (m j) × Fin (d j))) ℂ →ₗ[ℂ]
+      Matrix ((j : Fin K) × (Fin (m j) × Fin (d j)))
+        ((j : Fin K) × (Fin (m j) × Fin (d j))) ℂ)
+    (k : Fin K) :
+    Matrix (Fin (m k) × Fin (d k)) (Fin (m k) × Fin (d k)) ℂ →ₗ[ℂ]
+      Matrix (Fin (m k) × Fin (d k)) (Fin (m k) × Fin (d k)) ℂ :=
+  (directSumOutputBlockMap E k).comp
+    (directSumBlockEmbedding (m := m) (d := d) k)
+
+/-- Restricting a positive map to one diagonal output block preserves positivity. -/
+theorem directSumOutputBlockMap_isPositiveMap
+    (E : Matrix ((j : Fin K) × (Fin (m j) × Fin (d j)))
+        ((j : Fin K) × (Fin (m j) × Fin (d j))) ℂ →ₗ[ℂ]
+      Matrix ((j : Fin K) × (Fin (m j) × Fin (d j)))
+        ((j : Fin K) × (Fin (m j) × Fin (d j))) ℂ)
+    (hE : IsPositiveMap E) (k : Fin K) :
+    IsPositiveMap (directSumOutputBlockMap E k) := by
+  intro A hA
+  exact directSumBlockCompression_isPositiveMap k (E A) (hE A hA)
+
+/-- Restricting a positive map to one diagonal input and output block preserves
+positivity. -/
+theorem directSumDiagonalBlockMap_isPositiveMap
+    (E : Matrix ((j : Fin K) × (Fin (m j) × Fin (d j)))
+        ((j : Fin K) × (Fin (m j) × Fin (d j))) ℂ →ₗ[ℂ]
+      Matrix ((j : Fin K) × (Fin (m j) × Fin (d j)))
+        ((j : Fin K) × (Fin (m j) × Fin (d j))) ℂ)
+    (hE : IsPositiveMap E) (k : Fin K) :
+    IsPositiveMap (directSumDiagonalBlockMap E k) := by
+  intro A hA
+  exact directSumOutputBlockMap_isPositiveMap E hE k _
+    (directSumBlockEmbedding_isPositiveMap k A hA)
+
+/-- The identity embedded in one summand is its central block projection. -/
+theorem directSumBlockEmbedding_one (k : Fin K) :
+    directSumBlockEmbedding (m := m) (d := d) k 1 =
+      Matrix.blockProjection
+        (n := fun j : Fin K ↦ Fin (m j) × Fin (d j)) (R := ℂ) k := by
+  classical
+  change Matrix.blockDiagonal' (Pi.single k 1) =
+    Matrix.blockDiagonal' (fun i => if i = k then 1 else 0)
+  congr 1
+  funext i
+  by_cases hik : i = k
+  · subst i
+    simp
+  · simp [hik]
+
+/-- Embedding a right-factor matrix in one summand agrees with its coordinate factor
+family. -/
+theorem directSumBlockEmbedding_one_kronecker (k : Fin K)
+    (X : Matrix (Fin (d k)) (Fin (d k)) ℂ) :
+    directSumBlockEmbedding (m := m) (d := d) k
+        ((1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ X) =
+      Matrix.blockDiagonal' fun j =>
+        (1 : Matrix (Fin (m j)) (Fin (m j)) ℂ) ⊗ₖ
+          (Pi.single k X : ∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) j := by
+  classical
+  change Matrix.blockDiagonal'
+      (Pi.single k ((1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ X) :
+        ∀ i, Matrix (Fin (m i) × Fin (d i)) (Fin (m i) × Fin (d i)) ℂ) = _
+  congr 1
+  funext j
+  by_cases hjk : j = k
+  · subst j
+    simp
+  · simp [hjk]
+
+/-- The identity matrix is the coordinate factor family of identity matrices. -/
+theorem blockDiagonal_one_kronecker_one :
+    Matrix.blockDiagonal' (fun j : Fin K =>
+        (1 : Matrix (Fin (m j)) (Fin (m j)) ℂ) ⊗ₖ
+          (1 : Matrix (Fin (d j)) (Fin (d j)) ℂ)) =
+      (1 : Matrix ((j : Fin K) × (Fin (m j) × Fin (d j)))
+        ((j : Fin K) × (Fin (m j) × Fin (d j))) ℂ) := by
+  rw [← Matrix.blockDiagonal'_one]
+  congr 1
+  funext j
+  simp
+
+/-- Compressing a coordinate factor decomposition selects the corresponding factor. -/
+@[simp]
+theorem directSumBlockCompression_blockDiagonal_one_kronecker
+    (B : ∀ j, Matrix (Fin (d j)) (Fin (d j)) ℂ) (k : Fin K) :
+    directSumBlockCompression (m := m) (d := d) k
+        (Matrix.blockDiagonal' fun j =>
+          (1 : Matrix (Fin (m j)) (Fin (m j)) ℂ) ⊗ₖ B j) =
+      (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ B k := by
+  ext i j
+  simp [directSumBlockCompression, Matrix.blockDiagonal'_apply_eq]
+
+/-- Compression by a central block projection retains exactly one diagonal block. -/
+theorem blockProjection_mul_mul_eq_directSumBlockEmbedding
+    (A : Matrix ((j : Fin K) × (Fin (m j) × Fin (d j)))
+      ((j : Fin K) × (Fin (m j) × Fin (d j))) ℂ)
+    (k : Fin K) :
+    Matrix.blockProjection
+          (n := fun j : Fin K ↦ Fin (m j) × Fin (d j)) (R := ℂ) k * A *
+        Matrix.blockProjection
+          (n := fun j : Fin K ↦ Fin (m j) × Fin (d j)) (R := ℂ) k =
+      directSumBlockEmbedding (m := m) (d := d) k
+        (directSumBlockCompression (m := m) (d := d) k A) := by
+  classical
+  ext ⟨i, a⟩ ⟨j, b⟩
+  by_cases hik : i = k
+  · subst i
+    by_cases hjk : j = k
+    · subst j
+      simp [directSumBlockEmbedding, directSumBlockCompression]
+    · rw [Matrix.mul_blockProjection_apply_ne _ k hjk]
+      have hkj : k ≠ j := Ne.symm hjk
+      simp [directSumBlockEmbedding, Matrix.blockDiagonal'_apply, hkj]
+  · have hright :
+        directSumBlockEmbedding (m := m) (d := d) k
+            (directSumBlockCompression (m := m) (d := d) k A) ⟨i, a⟩ ⟨j, b⟩ = 0 := by
+      simp [directSumBlockEmbedding, Matrix.blockDiagonal'_apply, hik]
+    rw [hright, Matrix.mul_apply]
+    apply Finset.sum_eq_zero
+    rintro x _
+    rw [Matrix.blockProjection_mul_apply_ne A k hik, zero_mul]
+
+/-- A coordinate positive retraction sees only the corresponding diagonal input block
+when one restricts its output to a fixed summand.
+
+The complementary central projection is annihilated by the restricted output map, so
+positivity annihilates both its left and right corners. This is the cross-block removal
+in Wolf, Proposition 1.5, lines 548--560. -/
+theorem directSumOutputBlockMap_eq_diagonalBlockMap_compression
+    (E : Matrix ((j : Fin K) × (Fin (m j) × Fin (d j)))
+        ((j : Fin K) × (Fin (m j) × Fin (d j))) ℂ →ₗ[ℂ]
+      Matrix ((j : Fin K) × (Fin (m j) × Fin (d j)))
+        ((j : Fin K) × (Fin (m j) × Fin (d j))) ℂ)
+    (hE : IsPositiveMap E)
+    (hFix : ∀ B : ∀ j, Matrix (Fin (d j)) (Fin (d j)) ℂ,
+      E (Matrix.blockDiagonal' fun j =>
+          (1 : Matrix (Fin (m j)) (Fin (m j)) ℂ) ⊗ₖ B j) =
+        Matrix.blockDiagonal' fun j =>
+          (1 : Matrix (Fin (m j)) (Fin (m j)) ℂ) ⊗ₖ B j)
+    (A : Matrix ((j : Fin K) × (Fin (m j) × Fin (d j)))
+      ((j : Fin K) × (Fin (m j) × Fin (d j))) ℂ)
+    (k : Fin K) :
+    directSumOutputBlockMap E k A =
+      directSumDiagonalBlockMap E k
+        (directSumBlockCompression (m := m) (d := d) k A) := by
+  let P := Matrix.blockProjection
+    (n := fun j : Fin K ↦ Fin (m j) × Fin (d j)) (R := ℂ) k
+  let T := directSumOutputBlockMap E k
+  have hTP : T P = 1 := by
+    dsimp only [T, P]
+    rw [← directSumBlockEmbedding_one (m := m) (d := d) k]
+    have hOneKron :
+        (1 : Matrix (Fin (m k) × Fin (d k)) (Fin (m k) × Fin (d k)) ℂ) =
+          (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ
+            (1 : Matrix (Fin (d k)) (Fin (d k)) ℂ) := by
+      simp
+    conv_lhs => rw [hOneKron, directSumBlockEmbedding_one_kronecker]
+    change directSumBlockCompression (m := m) (d := d) k
+      (E (Matrix.blockDiagonal' fun j =>
+        (1 : Matrix (Fin (m j)) (Fin (m j)) ℂ) ⊗ₖ
+          (Pi.single k (1 : Matrix (Fin (d k)) (Fin (d k)) ℂ) :
+            ∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) j)) = 1
+    rw [hFix]
+    simp
+  have hTOne : T 1 = 1 := by
+    dsimp only [T]
+    rw [← blockDiagonal_one_kronecker_one (m := m) (d := d)]
+    change directSumBlockCompression (m := m) (d := d) k
+      (E (Matrix.blockDiagonal' fun j =>
+        (1 : Matrix (Fin (m j)) (Fin (m j)) ℂ) ⊗ₖ
+          (1 : Matrix (Fin (d j)) (Fin (d j)) ℂ))) = 1
+    rw [hFix]
+    exact directSumBlockCompression_blockDiagonal_one_kronecker
+      (m := m) (d := d) (fun j => 1) k |>.trans (by simp)
+  have hTComplement : T (1 - P) = 0 := by
+    rw [map_sub, hTOne, hTP, sub_self]
+  have hPherm : P.IsHermitian := by
+    exact Matrix.blockProjection_isHermitian k
+  have hPidem : IsIdempotentElem P := by
+    exact Matrix.blockProjection_isIdempotentElem k
+  have hQherm : (1 - P).IsHermitian := Matrix.isHermitian_one.sub hPherm
+  have hQidem : IsIdempotentElem (1 - P) := hPidem.one_sub
+  have hCorners :=
+    (directSumOutputBlockMap_isPositiveMap E hE k).map_mul_eq_zero_of_map_projection_eq_zero
+      hQherm hQidem hTComplement
+  have hLeft : T A = T (P * A) := by
+    have hDecomp : A = P * A + (1 - P) * A := by
+      rw [Matrix.sub_mul, Matrix.one_mul]
+      abel
+    calc
+      T A = T (P * A + (1 - P) * A) := congrArg T hDecomp
+      _ = T (P * A) := by rw [map_add, (hCorners A).1, add_zero]
+  have hRight : T (P * A) = T (P * A * P) := by
+    have hDecomp : P * A = P * A * P + P * A * (1 - P) := by
+      rw [Matrix.mul_sub, Matrix.mul_one]
+      abel
+    calc
+      T (P * A) = T (P * A * P + P * A * (1 - P)) := congrArg T hDecomp
+      _ = T (P * A * P) := by
+        rw [map_add, (hCorners (P * A)).2, add_zero]
+  rw [hLeft, hRight,
+    blockProjection_mul_mul_eq_directSumBlockEmbedding (m := m) (d := d)]
+  rfl
+
+/-- A positive linear retraction onto
+$\bigoplus_k(1_{m_k}\otimes M_{d_k}(\mathbb C))$ is a weighted partial trace on each
+diagonal summand.
+
+More precisely, there are positive semidefinite matrices $\rho_k$ of trace one such that
+\[
+  E(A)=\bigoplus_k\left[1_{m_k}\otimes
+    \operatorname{tr}_{m_k}\bigl((\rho_k\otimes 1_{d_k})A_{kk}\bigr)\right].
+\]
+This is the coordinate direct-sum form of Wolf, Proposition 1.5 and Equation (1.40),
+lines 536--570. The theorem assumes a given positive retraction; it does not construct
+such a retraction from a fixed-point space. -/
+theorem exists_density_of_positive_retraction_onto_direct_sum_right_factors
+    [∀ k, NeZero (m k)] [∀ k, NeZero (d k)]
+    (E : Matrix ((j : Fin K) × (Fin (m j) × Fin (d j)))
+        ((j : Fin K) × (Fin (m j) × Fin (d j))) ℂ →ₗ[ℂ]
+      Matrix ((j : Fin K) × (Fin (m j) × Fin (d j)))
+        ((j : Fin K) × (Fin (m j) × Fin (d j))) ℂ)
+    (hE : IsPositiveMap E)
+    (hRange : ∀ A, ∃ B : ∀ j, Matrix (Fin (d j)) (Fin (d j)) ℂ,
+      E A = Matrix.blockDiagonal' fun j =>
+        (1 : Matrix (Fin (m j)) (Fin (m j)) ℂ) ⊗ₖ B j)
+    (hFix : ∀ B : ∀ j, Matrix (Fin (d j)) (Fin (d j)) ℂ,
+      E (Matrix.blockDiagonal' fun j =>
+          (1 : Matrix (Fin (m j)) (Fin (m j)) ℂ) ⊗ₖ B j) =
+        Matrix.blockDiagonal' fun j =>
+          (1 : Matrix (Fin (m j)) (Fin (m j)) ℂ) ⊗ₖ B j) :
+    ∃ ρ : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ,
+      (∀ k, (ρ k).PosSemidef) ∧ (∀ k, (ρ k).trace = 1) ∧
+        ∀ A, E A = Matrix.blockDiagonal' fun k =>
+          (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ
+            Matrix.partialTraceLeft
+              (((ρ k) ⊗ₖ (1 : Matrix (Fin (d k)) (Fin (d k)) ℂ)) *
+                directSumBlockCompression (m := m) (d := d) k A) := by
+  have hLocalRange (k : Fin K)
+      (A : Matrix (Fin (m k) × Fin (d k)) (Fin (m k) × Fin (d k)) ℂ) :
+      ∃ B : Matrix (Fin (d k)) (Fin (d k)) ℂ,
+        directSumDiagonalBlockMap E k A =
+          (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ B := by
+    obtain ⟨B, hB⟩ := hRange (directSumBlockEmbedding (m := m) (d := d) k A)
+    refine ⟨B k, ?_⟩
+    change directSumBlockCompression (m := m) (d := d) k
+      (E (directSumBlockEmbedding (m := m) (d := d) k A)) = _
+    rw [hB]
+    exact directSumBlockCompression_blockDiagonal_one_kronecker B k
+  have hLocalFix (k : Fin K) (X : Matrix (Fin (d k)) (Fin (d k)) ℂ) :
+      directSumDiagonalBlockMap E k
+          ((1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ X) =
+        (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ X := by
+    change directSumBlockCompression (m := m) (d := d) k
+      (E (directSumBlockEmbedding (m := m) (d := d) k
+        ((1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ X))) = _
+    rw [directSumBlockEmbedding_one_kronecker, hFix]
+    exact (directSumBlockCompression_blockDiagonal_one_kronecker
+      (m := m) (d := d)
+      (Pi.single k X : ∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) k).trans (by simp)
+  have hLocal (k : Fin K) :
+      ∃ ρ : Matrix (Fin (m k)) (Fin (m k)) ℂ,
+        ρ.PosSemidef ∧ ρ.trace = 1 ∧
+          ∀ A : Matrix (Fin (m k) × Fin (d k)) (Fin (m k) × Fin (d k)) ℂ,
+            directSumDiagonalBlockMap E k A =
+              (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ
+                Matrix.partialTraceLeft
+                  ((ρ ⊗ₖ (1 : Matrix (Fin (d k)) (Fin (d k)) ℂ)) * A) :=
+    Matrix.exists_density_of_positive_retraction_onto_right_factor
+      (directSumDiagonalBlockMap E k)
+      (directSumDiagonalBlockMap_isPositiveMap E hE k) (hLocalRange k) (hLocalFix k)
+  choose ρ hρpos hρtrace hρformula using hLocal
+  refine ⟨ρ, hρpos, hρtrace, fun A ↦ ?_⟩
+  obtain ⟨B, hB⟩ := hRange A
+  rw [hB]
+  congr 1
+  funext k
+  calc
+    (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ B k =
+        directSumOutputBlockMap E k A := by
+      change _ = directSumBlockCompression (m := m) (d := d) k (E A)
+      rw [hB]
+      exact (directSumBlockCompression_blockDiagonal_one_kronecker B k).symm
+    _ = directSumDiagonalBlockMap E k
+          (directSumBlockCompression (m := m) (d := d) k A) :=
+      directSumOutputBlockMap_eq_diagonalBlockMap_compression E hE hFix A k
+    _ = _ := hρformula k _
+
+end Matrix
+
+namespace StarSubalgebra
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- A positive linear retraction onto a star-subalgebra of a full complex matrix algebra
+has the blockwise weighted-partial-trace form.
+
+Thus, after the unitary and index change of Wolf, Equation (1.39), there are positive
+semidefinite matrices $\rho_k$ of trace one such that
+\[
+ E(A)=U\left(\bigoplus_k 1_{m_k}\otimes
+   \operatorname{tr}_{m_k}\bigl((\rho_k\otimes1_{d_k})
+     (U^*AU)_{kk}\bigr)\right)U^*.
+\]
+This is Wolf, Proposition 1.5 and Equation (1.40), lines 536--570.
+
+Proposition 1.5 itself assumes the positive retraction. The separate construction of a
+fixed-point projection required for Wolf, Theorem 6.14 is documented in
+`docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex`. -/
+theorem exists_block_densities_of_positive_retraction
+    (S : StarSubalgebra ℂ (Matrix n n ℂ))
+    (E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ)
+    (hE : IsPositiveMap E) (hRange : ∀ A, E A ∈ S)
+    (hFix : ∀ A ∈ S, E A = A) :
+    ∃ (K : ℕ) (d m : Fin K → ℕ)
+      (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ n)
+      (U : Matrix n n ℂ) (ρ : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ),
+      U ∈ Matrix.unitaryGroup n ℂ ∧ (∀ k, 0 < d k) ∧ (∀ k, 0 < m k) ∧
+        (∀ A : Matrix n n ℂ,
+          A ∈ S ↔ ∃ B : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ,
+            star U * A * U = Matrix.reindex e e
+              (Matrix.blockDiagonal' fun k =>
+                (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ B k)) ∧
+        (∀ k, (ρ k).PosSemidef) ∧ (∀ k, (ρ k).trace = 1) ∧
+          ∀ A, E A = U * Matrix.reindex e e
+            (Matrix.blockDiagonal' fun k =>
+              (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ
+                Matrix.partialTraceLeft
+                  (((ρ k) ⊗ₖ (1 : Matrix (Fin (d k)) (Fin (d k)) ℂ)) *
+                    Matrix.directSumBlockCompression (m := m) (d := d) k
+                      (Matrix.reindex e.symm e.symm (star U * A * U)))) * star U := by
+  classical
+  obtain ⟨K, d, m, e, U, hU, hd, hm, hBlock⟩ :=
+    S.exists_unitary_conj_blockDiagonal_iff
+  letI : ∀ k, NeZero (m k) := fun k => ⟨Nat.ne_of_gt (hm k)⟩
+  letI : ∀ k, NeZero (d k) := fun k => ⟨Nat.ne_of_gt (hd k)⟩
+  let Φ := Matrix.unitaryReindexLinearEquiv e U hU
+  let Ehat : Matrix ((k : Fin K) × (Fin (m k) × Fin (d k)))
+      ((k : Fin K) × (Fin (m k) × Fin (d k))) ℂ →ₗ[ℂ]
+        Matrix ((k : Fin K) × (Fin (m k) × Fin (d k)))
+          ((k : Fin K) × (Fin (m k) × Fin (d k))) ℂ := Φ.conj E
+  have hEhat : IsPositiveMap Ehat := by
+    intro A hA
+    exact Matrix.unitaryReindexLinearEquiv_posSemidef e U hU
+      (hE _ (Matrix.unitaryReindexLinearEquiv_symm_posSemidef e U hU hA))
+  have hRangeHat (A : Matrix ((k : Fin K) × (Fin (m k) × Fin (d k)))
+      ((k : Fin K) × (Fin (m k) × Fin (d k))) ℂ) :
+      ∃ B : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ,
+        Ehat A = Matrix.blockDiagonal' fun k =>
+          (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ B k := by
+    obtain ⟨B, hB⟩ := (hBlock (E (Φ.symm A))).mp (hRange (Φ.symm A))
+    refine ⟨B, ?_⟩
+    change Φ (E (Φ.symm A)) = _
+    rw [Matrix.unitaryReindexLinearEquiv_apply, hB]
+    simpa only [Matrix.symm_reindexLinearEquiv, Matrix.coe_reindexLinearEquiv] using
+      (Matrix.reindexLinearEquiv ℂ ℂ e e).symm_apply_apply
+        (Matrix.blockDiagonal' fun k =>
+          (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ B k)
+  have hFixHat (B : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ) :
+      Ehat (Matrix.blockDiagonal' fun k =>
+          (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ B k) =
+        Matrix.blockDiagonal' fun k =>
+          (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ B k := by
+    let X := Matrix.blockDiagonal' fun k =>
+      (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ B k
+    have hXmem : Φ.symm X ∈ S := by
+      apply (hBlock (Φ.symm X)).mpr
+      refine ⟨B, ?_⟩
+      rw [show star U * Φ.symm X * U = Matrix.reindex e e X by
+        rw [Matrix.unitaryReindexLinearEquiv_symm_apply]
+        have hUstarU : star U * U = 1 := Matrix.mem_unitaryGroup_iff'.mp hU
+        calc
+          star U * (U * Matrix.reindex e e X * star U) * U =
+              (star U * U) * Matrix.reindex e e X * (star U * U) := by
+            simp only [Matrix.mul_assoc]
+          _ = Matrix.reindex e e X := by rw [hUstarU, Matrix.one_mul, Matrix.mul_one]]
+    change Φ (E (Φ.symm X)) = X
+    rw [hFix _ hXmem, Φ.apply_symm_apply]
+  obtain ⟨ρ, hρpos, hρtrace, hEhatFormula⟩ :=
+    Matrix.exists_density_of_positive_retraction_onto_direct_sum_right_factors
+      Ehat hEhat hRangeHat hFixHat
+  refine ⟨K, d, m, e, U, ρ, hU, hd, hm, hBlock, hρpos, hρtrace, fun A ↦ ?_⟩
+  have hFormula :
+      Φ (E A) = Matrix.blockDiagonal' fun k =>
+        (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ
+          Matrix.partialTraceLeft
+            (((ρ k) ⊗ₖ (1 : Matrix (Fin (d k)) (Fin (d k)) ℂ)) *
+              Matrix.directSumBlockCompression (m := m) (d := d) k (Φ A)) := by
+    simpa only [Ehat, LinearEquiv.conj_apply_apply, LinearEquiv.symm_apply_apply] using
+      hEhatFormula (Φ A)
+  have hFormulaBack := congrArg Φ.symm hFormula
+  calc
+    E A = Φ.symm (Φ (E A)) := (Φ.symm_apply_apply (E A)).symm
+    _ = Φ.symm (Matrix.blockDiagonal' fun k =>
+          (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ
+            Matrix.partialTraceLeft
+              (((ρ k) ⊗ₖ (1 : Matrix (Fin (d k)) (Fin (d k)) ℂ)) *
+                Matrix.directSumBlockCompression (m := m) (d := d) k (Φ A))) := hFormulaBack
+    _ = _ := by
+      rw [show Φ.symm = (Matrix.unitaryReindexLinearEquiv e U hU).symm from rfl]
+      simp only [Matrix.unitaryReindexLinearEquiv_symm_apply,
+        Φ, Matrix.unitaryReindexLinearEquiv_apply]
+
+end StarSubalgebra

--- a/TNLean/Channel/Schwarz/PositiveMapProperties.lean
+++ b/TNLean/Channel/Schwarz/PositiveMapProperties.lean
@@ -3,6 +3,7 @@ Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.KroneckerFactorPositivity
 import TNLean.Algebra.MatrixOperatorSpace
 import TNLean.Channel.Basic
 import Mathlib.Analysis.CStarAlgebra.Matrix
@@ -16,6 +17,8 @@ of Schwarz inequalities:
 
 * `IsPositiveMap.map_le_map`: positivity implies monotonicity for the matrix
   Loewner order;
+* `IsPositiveMap.map_mul_eq_zero_of_map_projection_eq_zero`: a positive map that
+  annihilates an orthogonal projection also annihilates both products with that projection;
 * `IsPositiveMap.image_bounded`: if `T(1) ≤ 1` and `0 ∈ [a,b]`, then order bounds
   `a • 1 ≤ A ≤ b • 1` are preserved by `T`;
 * `IsPositiveMap.spectrum_contractivity`: the corresponding real-spectrum interval
@@ -47,24 +50,110 @@ noncomputable local instance matrixCStarAlgebra (m : Type*) [Fintype m] [Decidab
 
 /-- A positive map is monotone for the matrix Loewner order. -/
 theorem IsPositiveMap.map_le_map
-    {m : Type*} [Finite m]
-    {T : Matrix m m ℂ →ₗ[ℂ] Matrix m m ℂ} {A B : Matrix m m ℂ}
+    {m n : Type*} [Finite m] [Finite n]
+    {T : Matrix n n ℂ →ₗ[ℂ] Matrix m m ℂ} {A B : Matrix n n ℂ}
     (hT : IsPositiveMap T) (hAB : A ≤ B) : T A ≤ T B := by
   classical
   letI := Fintype.ofFinite m
+  letI := Fintype.ofFinite n
   exact hT.toPositiveLinearMap.monotone hAB
 
 /-- Positive maps preserve adjoints. -/
 theorem IsPositiveMap.map_conjTranspose
-    {m : Type*} [Finite m]
-    {T : Matrix m m ℂ →ₗ[ℂ] Matrix m m ℂ} (hT : IsPositiveMap T) (A : Matrix m m ℂ) :
+    {m n : Type*} [Finite m] [Finite n]
+    {T : Matrix n n ℂ →ₗ[ℂ] Matrix m m ℂ} (hT : IsPositiveMap T) (A : Matrix n n ℂ) :
     T Aᴴ = (T A)ᴴ := by
   classical
   letI := Fintype.ofFinite m
+  letI := Fintype.ofFinite n
   letI := Classical.decEq m
+  letI := Classical.decEq n
   letI : CStarAlgebra (Matrix m m ℂ) := matrixCStarAlgebra m
+  letI : CStarAlgebra (Matrix n n ℂ) := matrixCStarAlgebra n
   change hT.toPositiveLinearMap Aᴴ = (hT.toPositiveLinearMap A)ᴴ
   simpa [Matrix.star_eq_conjTranspose] using map_star hT.toPositiveLinearMap A
+
+/-- If `d` is nonnegative and `2tb + t²d` is nonnegative for every real `t`, then
+`b` vanishes. -/
+private theorem linear_eq_zero_of_quadratic_nonneg
+    (b d : ℝ) (hd : 0 ≤ d)
+    (h : ∀ t : ℝ, 0 ≤ 2 * t * b + t ^ 2 * d) :
+    b = 0 := by
+  have hd1 : 0 < d + 1 := by linarith
+  have hspecial := h (-b / (d + 1))
+  field_simp [ne_of_gt hd1] at hspecial
+  nlinarith [sq_nonneg b]
+
+/-- One-sided form of null-projection corner annihilation. -/
+private theorem IsPositiveMap.map_projection_mul_eq_zero
+    {m n : Type*} [Finite m] [Fintype n]
+    {T : Matrix n n ℂ →ₗ[ℂ] Matrix m m ℂ} (hT : IsPositiveMap T)
+    {P : Matrix n n ℂ} (hP : P.IsHermitian) (hP2 : IsIdempotentElem P)
+    (hTP : T P = 0) (A : Matrix n n ℂ) :
+    T (P * A) = 0 := by
+  classical
+  letI := Fintype.ofFinite m
+  apply Matrix.eq_zero_of_forall_star_dotProduct_mulVec_eq_zero
+  intro x
+  let b : ℂ := star x ⬝ᵥ T (P * A) *ᵥ x
+  let d : ℂ := star x ⬝ᵥ T (Aᴴ * A) *ᵥ x
+  have hd : 0 ≤ d := by
+    exact
+      (hT (Aᴴ * A) (Matrix.posSemidef_conjTranspose_mul_self A)).dotProduct_mulVec_nonneg x
+  have hAdj : T (Aᴴ * P) = (T (P * A))ᴴ := by
+    rw [← hT.map_conjTranspose (P * A), Matrix.conjTranspose_mul, hP.eq]
+  have hAdjQ : star x ⬝ᵥ T (Aᴴ * P) *ᵥ x = star b := by
+    rw [hAdj, star_dotProduct, Matrix.star_mulVec,
+      Matrix.conjTranspose_conjTranspose, ← Matrix.dotProduct_mulVec]
+  have hinput (z : ℂ) :
+      (P + z • A)ᴴ * (P + z • A) =
+        P + z • (P * A) + star z • (Aᴴ * P) + (star z * z) • (Aᴴ * A) := by
+    simp only [Matrix.conjTranspose_add, Matrix.conjTranspose_smul, hP.eq,
+      Matrix.add_mul, Matrix.mul_add, hP2.eq, Matrix.mul_smul, Matrix.smul_mul]
+    rw [smul_add, smul_smul, mul_comm z (star z)]
+    abel
+  have hq (z : ℂ) : 0 ≤ z * b + star z * star b + (star z * z) * d := by
+    have hz := hT ((P + z • A)ᴴ * (P + z • A))
+      (Matrix.posSemidef_conjTranspose_mul_self (P + z • A))
+    rw [hinput z] at hz
+    have hx := hz.dotProduct_mulVec_nonneg x
+    simp only [map_add, map_smul, hTP, zero_add, Matrix.add_mulVec,
+      Matrix.smul_mulVec, dotProduct_add, dotProduct_smul, smul_eq_mul] at hx
+    rw [hAdjQ] at hx
+    exact hx
+  have hdre : 0 ≤ d.re := (Complex.nonneg_iff.mp hd).1
+  have hreal : ∀ t : ℝ, 0 ≤ 2 * t * b.re + t ^ 2 * d.re := by
+    intro t
+    have ht := (Complex.nonneg_iff.mp (hq (t : ℂ))).1
+    simp [Complex.mul_re] at ht
+    nlinarith
+  have hbre : b.re = 0 := linear_eq_zero_of_quadratic_nonneg b.re d.re hdre hreal
+  have himag : ∀ t : ℝ, 0 ≤ 2 * t * (-b.im) + t ^ 2 * d.re := by
+    intro t
+    have ht := (Complex.nonneg_iff.mp (hq ((t : ℂ) * Complex.I))).1
+    simp [Complex.mul_re] at ht
+    nlinarith
+  have hbim : b.im = 0 := by
+    have := linear_eq_zero_of_quadratic_nonneg (-b.im) d.re hdre himag
+    linarith
+  change b = 0
+  exact Complex.ext hbre hbim
+
+/-- If a positive matrix map annihilates an orthogonal projection `P`, then it
+annihilates both `P * A` and `A * P` for every matrix `A`. -/
+theorem IsPositiveMap.map_mul_eq_zero_of_map_projection_eq_zero
+    {m n : Type*} [Finite m] [Fintype n]
+    {T : Matrix n n ℂ →ₗ[ℂ] Matrix m m ℂ} (hT : IsPositiveMap T)
+    {P : Matrix n n ℂ} (hP : P.IsHermitian) (hP2 : IsIdempotentElem P)
+    (hTP : T P = 0) (A : Matrix n n ℂ) :
+    T (P * A) = 0 ∧ T (A * P) = 0 := by
+  refine ⟨hT.map_projection_mul_eq_zero hP hP2 hTP A, ?_⟩
+  calc
+    T (A * P) = T ((P * Aᴴ)ᴴ) := by rw [Matrix.conjTranspose_mul,
+      Matrix.conjTranspose_conjTranspose, hP.eq]
+    _ = (T (P * Aᴴ))ᴴ := hT.map_conjTranspose (P * Aᴴ)
+    _ = 0 := by rw [hT.map_projection_mul_eq_zero hP hP2 hTP Aᴴ,
+      Matrix.conjTranspose_zero]
 
 /-- A block diagonal matrix with PSD diagonal blocks is PSD. -/
 theorem Matrix.PosSemidef.fromBlocks_diag

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -599,7 +599,9 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     \lean{IsPositiveMap.map_isHermitian}
     \leanok
     \uses{def:positive_map_is_positive_linear_map}
-    If $E$ is positive and $X = X^\dagger$, then $E(X) = E(X)^\dagger$.
+    If $E:\MN{n}\to\MN{m}$ is positive and
+    $X\in\MN{n}$ satisfies $X = X^\dagger$, then
+    $E(X) = E(X)^\dagger$ in $\MN{m}$.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -8,7 +8,7 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
 \begin{definition}[Positive map]\label{def:positive_map}
     \lean{IsPositiveMap}
     \leanok
-    A linear map $E : \MN{D} \to \MN{D}$ is \emph{positive}
+    A linear map $E : \MN{n} \to \MN{m}$ is \emph{positive}
     if $E(X) \ge 0$ whenever $X \ge 0$, where $X \ge 0$
     means that $X$ is positive semidefinite.
 \end{definition}
@@ -23,9 +23,9 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     \lean{IsPositiveMap.toPositiveLinearMap}
     \leanok
     \uses{def:positive_map}
-    A positive matrix map $E : \MN{D} \to \MN{D}$ determines the same
-    linear map regarded as a positive linear map: if $A \le B$, then
-    $E(A) \le E(B)$.
+    A positive matrix map $E : \MN{n} \to \MN{m}$ determines the same
+    linear map regarded as a positive linear map: if
+    $A,B\in\MN{n}$ and $A \le B$, then $E(A) \le E(B)$ in $\MN{m}$.
 \end{definition}
 
 \begin{definition}[Trace-preserving map]\label{def:trace_preserving}

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -2204,8 +2204,8 @@ adjacent cones.
     \lean{IsPositiveMap.map_le_map}
     \leanok
     \uses{def:positive_map}
-    If $T : \MN{D} \to \MN{D}$ is positive and $A \le B$, then
-    $T(A) \le T(B)$.
+    If $T : \MN{n} \to \MN{m}$ is positive and
+    $A,B\in\MN{n}$ satisfy $A \le B$, then $T(A) \le T(B)$ in $\MN{m}$.
 \end{theorem}
 
 \begin{proof}
@@ -2218,8 +2218,8 @@ adjacent cones.
     \lean{IsPositiveMap.map_conjTranspose}
     \leanok
     \uses{def:positive_map_is_positive_linear_map}
-    If $T : \MN{D} \to \MN{D}$ is positive, then
-    $T(A^\dagger) = T(A)^\dagger$ for all $A \in \MN{D}$.
+    If $T : \MN{n} \to \MN{m}$ is positive, then
+    $T(A^\dagger) = T(A)^\dagger$ for all $A \in \MN{n}$.
 \end{theorem}
 
 \begin{proof}
@@ -2227,7 +2227,7 @@ adjacent cones.
     Regard $T$ as the associated positive linear map
     (Definition~\ref{def:positive_map_is_positive_linear_map}). For positive
     linear maps between matrix $C^*$-algebras, $T(A^\ast)=T(A)^\ast$.
-    Since the star on $\MN{D}$ is the conjugate transpose,
+    Since the star on each matrix algebra is the conjugate transpose,
     $T(A^\dagger)=T(A^\ast)=T(A)^\ast=T(A)^\dagger$.
 \end{proof}
 

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -1387,6 +1387,53 @@ maps.
     every $A\in\MN{md}$.
 \end{proof}
 
+% The remaining fixed-point-projection application is documented in
+% docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex.
+\begin{theorem}[Positive retractions onto finite-dimensional star-algebras]
+    \label{thm:positive_retraction_finite_star_algebra}
+    \lean{StarSubalgebra.exists_block_densities_of_positive_retraction}
+    \leanok
+    Let $S\subseteq\MN{D}$ be a unital $*$-subalgebra, and let
+    $E:\MN{D}\to\MN{D}$ be a positive complex-linear map whose image lies in
+    $S$ and whose restriction to $S$ is the identity.  There are positive
+    integers $d_k,m_k$, a unitary $U$, and density matrices
+    $\rho_k\in\MN{m_k}$ such that
+    \[
+        U^*SU=\bigoplus_k \Id_{m_k}\otimes\MN{d_k}
+    \]
+    and, for every $A\in\MN{D}$,
+    \[
+        E(A)=U\left(\bigoplus_k \Id_{m_k}\otimes
+        \operatorname{tr}_{m_k}\!\left(
+          (\rho_k\otimes\Id_{d_k})(U^*AU)_{kk}\right)\right)U^*.
+    \]
+    Equivalently, cyclicity of the partial trace permits the factor
+    $\rho_k\otimes\Id_{d_k}$ to be placed on the right of $(U^*AU)_{kk}$.
+    This is \cite[Proposition~1.5 and Equation~(1.40)]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:positive_retraction_one_matrix_factor,
+      thm:starSubalgebra_unitary_block_diagonal_iff}
+    Conjugate by $U$ and identify the ambient space with
+    $\bigoplus_k\C^{m_k}\otimes\C^{d_k}$.  Let $P_k$ be the central projection
+    onto the $k$-th summand and let $T_k$ be the $k$-th diagonal block of the
+    conjugated map.  Since $T_k(\Id-P_k)=0$, positivity implies
+    \[
+        T_k((\Id-P_k)A)=T_k(A(\Id-P_k))=0.
+    \]
+    Hence $T_k(A)=T_k(P_kAP_k)$.  The restriction to the $k$-th diagonal
+    summand is a positive retraction onto
+    $\Id_{m_k}\otimes\MN{d_k}$, so the one-factor theorem gives the density
+    matrix $\rho_k$.  Taking the direct sum and conjugating back proves the
+    formula.  Entrywise expansion of the partial trace gives
+    \[
+      \operatorname{tr}_{m_k}((\rho_k\otimes\Id)A_{kk})
+      =\operatorname{tr}_{m_k}(A_{kk}(\rho_k\otimes\Id)).
+    \]
+\end{proof}
+
 \begin{theorem}[Trace-pairing adjoints preserve positivity exactly]\label{thm:trace_pairing_adjoint_positive_iff}
     \lean{isPositiveMap_traceAdjointMap_iff}
     \leanok

--- a/docs/paper-gaps/wolf_prop1_5_one_factor_scope.tex
+++ b/docs/paper-gaps/wolf_prop1_5_one_factor_scope.tex
@@ -43,10 +43,12 @@ to be positive semidefinite and to have trace one.  Thus the theorem is a
 faithful scope-restricted case, but it is not the full direct-sum
 classification of Proposition~1.5.
 
-\section{Missing direct-sum argument}
+\section{Resolution of the direct-sum argument}
 
-The remaining result must combine the one-factor theorem with the existing
-finite-dimensional block description.  More precisely, it must:
+The theorem
+\leanid{StarSubalgebra.exists_block_densities_of_positive_retraction} combines
+the one-factor theorem with the finite-dimensional block description.  Its
+proof:
 \begin{enumerate}
     \item conjugate and reindex the ambient matrices by the unitary block data;
     \item prove that the positive retraction annihilates inputs between
@@ -58,9 +60,11 @@ finite-dimensional block description.  More precisely, it must:
           the original subalgebra.
 \end{enumerate}
 The second and third items are the off-diagonal positivity arguments in Wolf's
-proof preceding Equation~(1.42).  Once these are formalized, the present
-one-factor theorem supplies the remaining factorwise classification without
-additional assumptions.
+proof preceding Equation~(1.42).  They are now proved using the complementary
+central projection of each summand.  The remaining distinction between the
+classification of a given retraction and the later construction of a
+fixed-point projection is recorded in
+\path{docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex}.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex
+++ b/docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex
@@ -1,0 +1,49 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+
+\input{command}
+
+\title{Wolf Theorem~6.14: Fixed-Point Projection Gap}
+\author{}
+\date{2026-07-18}
+
+\begin{document}
+\maketitle
+
+\section{The completed classification theorem}
+
+Wolf's Proposition~1.5 assumes a positive linear retraction onto a unital
+finite-dimensional $*$-subalgebra and classifies that retraction
+\cite[Proposition~1.5 and Equation~(1.40)]{Wolf2012Quantum}.  The local source
+is \path{Notes/WolfNoteTexSource/ch01_deconstructing_quantum.tex},
+lines~536--570.
+
+The theorem
+\leanid{StarSubalgebra.exists_block_densities_of_positive_retraction} proves
+the full proposition.  It assumes exactly that the given linear map is
+positive, that its image is contained in the subalgebra, and that it fixes
+every member of the subalgebra.  It obtains the unitary direct-sum
+representation, removes off-diagonal inputs by positivity, and gives a
+positive semidefinite trace-one matrix for each summand.  No assumption of
+complete positivity, trace preservation, or a Schwarz inequality is added.
+
+\section{The remaining application to fixed points}
+
+The application surrounding \cite[Theorem~6.14]{Wolf2012Quantum} requires a
+positive retraction onto the relevant fixed-point space.  This retraction must
+first be constructed, for example as an appropriate Ces\`aro limit, and its
+range must be identified with the fixed-point space to which Proposition~1.5
+is applied.
+
+Thus Proposition~1.5 is fully formalized.  The remaining work toward
+Theorem~6.14 is the construction and identification of this fixed-point
+projection in the intended channel-theoretic setting, together with the
+additional hypotheses and zero-block conclusions of that theorem.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex
+++ b/docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex
@@ -30,18 +30,44 @@ representation, removes off-diagonal inputs by positivity, and gives a
 positive semidefinite trace-one matrix for each summand.  No assumption of
 complete positivity, trace preservation, or a Schwarz inequality is added.
 
-\section{The remaining application to fixed points}
+\section{The remaining fixed-point theorem}
 
-The application surrounding \cite[Theorem~6.14]{Wolf2012Quantum} requires a
-positive retraction onto the relevant fixed-point space.  This retraction must
-first be constructed, for example as an appropriate Ces\`aro limit, and its
-range must be identified with the fixed-point space to which Proposition~1.5
-is applied.
+Let $T:M_D(\mathbb C)\to M_D(\mathbb C)$ be positive and trace preserving,
+and suppose that its trace-pairing adjoint satisfies the Schwarz inequality.
+Wolf's Theorem~6.14 asserts that there are a unitary $U$, a decomposition
+\begin{align}
+    \mathbb C^D
+      &= \mathcal H_0\oplus
+        \bigoplus_{k=1}^K\mathbb C^{d_k}\otimes\mathbb C^{m_k},
+\end{align}
+and positive definite density matrices $\rho_k\in M_{m_k}(\mathbb C)$ such
+that
+\begin{align}
+    \operatorname{Fix}(T)
+      &= U\left(0\oplus\bigoplus_{k=1}^K
+          M_{d_k}(\mathbb C)\otimes\rho_k\right)U^*.
+    \tag{Wolf, Theorem 6.14 and Equation (6.63)}
+\end{align}
+Here $\mathcal H_0$ is a genuine zero summand: every fixed point vanishes on
+this subspace.  This is the statement in
+\cite[Theorem~6.14]{Wolf2012Quantum}; the local source is
+\path{Notes/WolfNotePDF/wolf_ch6_sections.txt}, lines~896--905.
 
-Thus Proposition~1.5 is fully formalized.  The remaining work toward
-Theorem~6.14 is the construction and identification of this fixed-point
-projection in the intended channel-theoretic setting, together with the
-additional hypotheses and zero-block conclusions of that theorem.
+The completed formal theorem classifies a given positive retraction onto a
+unital $*$-subalgebra.  Three further arguments are needed to obtain the
+fixed-point statement above.  First, the hypotheses on $T$ must be used to
+construct a positive retraction onto $\operatorname{Fix}(T)$, for example by
+Ces\`aro means, and to identify the full-support part of this fixed-point
+space with a unital $*$-algebra.  Second, the positive semidefinite density
+matrices supplied by Proposition~1.5 must be restricted to their supports;
+this produces the positive definite matrices in Theorem~6.14.  Third, the
+discarded kernels must be assembled with the subspace on which every fixed
+point vanishes, thereby recovering the zero summand $\mathcal H_0$.
+
+Thus Proposition~1.5 is fully formalized, while Theorem~6.14 remains an open
+gap.  The missing work is not another classification of a given retraction:
+it is the construction of the fixed-point retraction, the full-support
+reduction, and the recovery of the zero block from the kernels.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
Closes LionSR/QICLean#217.

## Mathematical result

This pull request proves the full finite-dimensional classification in Wolf, Proposition 1.5, for a given positive linear retraction onto a unital star-subalgebra of a complex matrix algebra. After unitary block decomposition, the retraction is shown to be a weighted partial trace on each diagonal summand, with a positive semidefinite trace-one density matrix on every multiplicity factor.

The proof removes all cross-block inputs using the complementary central projection and positivity, applies the established one-factor theorem to each diagonal block, and transports the coordinate formula back through the unitary equivalence. It also records cyclicity of the partial trace, which identifies the two multiplication orders in Wolf Equation (1.40).

The pull request includes the rectangular positive-map generalization and the null-projection corner lemma supplied by the auxiliary branch.

## Source faithfulness and scope

The global theorem assumes precisely a positive map whose image lies in the subalgebra and whose restriction to the subalgebra is the identity. No complete-positivity, trace-preservation, or Schwarz hypothesis is added. The blueprint therefore marks Wolf Proposition 1.5 as proved.

The work does not construct the positive fixed-point projection used later in Wolf Theorem 6.14 and does not close parent issue LionSR/QICLean#39. That remaining application is documented in docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex.

## Validation

- lake build
- lake build TNLean.Channel.PositiveConditionalExpectationDirectSum TNLean
- python3 scripts/blueprint_lean_sync.py --root . --ci
- lake exe checkdecls blueprint/lean_decls
- python3 scripts/check_reader_facing_prose.py --root . --diff-base 7b43e391359560da9838165db44033b129c32e51
- both changed paper-gap documents compiled with latexmk
- integrity scan found no sorry, admit, axiom, native_decide, or unsafeCast in changed Lean files
- kernel axiom audit found only propext, Classical.choice, and Quot.sound

The full build emits only warnings already present on the base branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new formal proof in channel/positive-map theory with broad API generalization (`IsPositiveMap` codomain); mathematical risk is moderate but localized to positivity/retraction classification, not auth or runtime systems.
> 
> **Overview**
> Formalizes **Wolf Proposition 1.5**: a positive linear retraction onto a unital star-subalgebra of `M_n(ℂ)` is, after unitary block coordinates, a **direct sum of weighted partial traces** with PSD trace-one density matrices `ρ_k` on each multiplicity factor.
> 
> Adds `TNLean/Channel/PositiveConditionalExpectationDirectSum.lean` with the coordinate direct-sum theorem and `StarSubalgebra.exists_block_densities_of_positive_retraction`, built from block compression/embedding, unitary reindexing, cross-block removal via central projections, and the existing one-factor result.
> 
> **Supporting changes:** `IsPositiveMap` and related lemmas are generalized to rectangular maps `M_n → M_m`; new `IsPositiveMap.map_mul_eq_zero_of_map_projection_eq_zero` (and block projection idempotent/Hermitian facts in `ScalarCommutant`) power the off-diagonal positivity argument. Blueprint ch04/ch05 and paper-gap docs are updated to mark Prop 1.5 resolved and to separate the remaining Wolf Theorem 6.14 fixed-point projection gap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dad67e1d8f857f1775d3399bf65c86c49ec15c10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->