### PR TITLE
feat(Analysis): add bounded-orbit mean-ergodic projection

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -65,6 +65,7 @@ import TNLean.Algebra.StarSubalgebraSpatial
 import TNLean.Algebra.StarSubalgebraUnitaryIntertwiner
 
 -- Layer 0b: General analysis
+import TNLean.Analysis.MeanErgodic
 import TNLean.Analysis.ProjectionGeometry
 -- Layer 0b: Hermitian functional calculus for finite-dimensional matrices
 import TNLean.Analysis.TraceCFC

--- a/TNLean/Analysis/MeanErgodic.lean
+++ b/TNLean/Analysis/MeanErgodic.lean
@@ -52,7 +52,7 @@ result does not by itself establish the fixed-point structure in Wolf's Theorem 
 mean ergodic theorem, Cesàro average, fixed point, bounded orbit
 -/
 
-open Filter Function Set
+open Filter Function
 open scoped Topology
 
 namespace LinearMap

--- a/TNLean/Analysis/MeanErgodic.lean
+++ b/TNLean/Analysis/MeanErgodic.lean
@@ -1,0 +1,222 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Analysis.Complex.Basic
+import Mathlib.Dynamics.BirkhoffSum.NormedSpace
+import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
+import Mathlib.LinearAlgebra.Projection
+
+/-!
+# Finite-dimensional mean-ergodic projection
+
+Let $f$ be a linear endomorphism of a finite-dimensional complex normed space. If every
+forward orbit of $f$ is bounded, then
+$$
+  \ker(f-1) \oplus \operatorname{range}(f-1)
+$$
+is the whole space. Projection onto the first summand is the pointwise limit of the
+Cesàro averages of the iterates of $f$.
+
+The proof first uses the telescoping identity for Cesàro averages to show that the two
+summands have zero intersection. Rank-nullity makes them complementary. The algebraic
+projection associated with this decomposition then gives the limiting map.
+
+## Main definitions
+
+* `LinearMap.HasBoundedOrbits`: every forward orbit has bounded range.
+* `LinearMap.meanErgodicProjection`: projection onto the fixed-point space along
+  the range of $f-1$.
+
+## Main statements
+
+* `LinearMap.HasBoundedOrbits.tendsto_birkhoffAverage_meanErgodicProjection`:
+  pointwise convergence of the Cesàro averages.
+* `LinearMap.HasBoundedOrbits.range_meanErgodicProjection`: the range is the
+  fixed-point space.
+* `LinearMap.HasBoundedOrbits.comp_meanErgodicProjection` and
+  `LinearMap.HasBoundedOrbits.meanErgodicProjection_comp`: the limiting projection
+  absorbs $f$ on both sides.
+
+This theorem supplies the finite-dimensional mean-ergodic argument used in the
+construction of fixed-point projections for positive maps. The positivity and unitality
+of those projections are separate matrix-algebra statements. In particular, the present
+result does not by itself establish the fixed-point structure in Wolf's Theorem 6.14.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Equation 6.14][Wolf2012QChannels]
+
+## Tags
+
+mean ergodic theorem, Cesàro average, fixed point, bounded orbit
+-/
+
+open Filter Function Set
+open scoped Topology
+
+namespace LinearMap
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
+
+/-- A linear endomorphism has bounded orbits if the range of
+$n \mapsto f^n x$ is bounded for every vector $x$. -/
+def HasBoundedOrbits (f : E →ₗ[ℂ] E) : Prop :=
+  ∀ x : E, Bornology.IsBounded (Set.range fun n : ℕ ↦ f^[n] x)
+
+/-- The Cesàro averages of a vector in the range of $f-1$ tend to zero when the
+forward orbit of every vector is bounded. -/
+theorem HasBoundedOrbits.tendsto_birkhoffAverage_of_mem_range_sub_one
+    {f : E →ₗ[ℂ] E} (hf : f.HasBoundedOrbits) {x : E}
+    (hx : x ∈ LinearMap.range (f - 1)) :
+    Tendsto (birkhoffAverage ℂ f _root_.id · x) atTop (nhds 0) := by
+  obtain ⟨y, rfl⟩ := hx
+  have hsub : ∀ n : ℕ, f^[n] (f y - y) = f^[n] (f y) - f^[n] y :=
+    fun n ↦ iterate_map_sub (f : E →+ E) n (f y) y
+  have hseq :
+      (fun n ↦ birkhoffAverage ℂ f _root_.id n ((f - 1) y)) =
+        fun n ↦ birkhoffAverage ℂ f _root_.id n (f y) -
+          birkhoffAverage ℂ f _root_.id n y := by
+    funext n
+    change birkhoffAverage ℂ f _root_.id n (f y - y) = _
+    simp only [birkhoffAverage, birkhoffSum, id_eq, hsub, Finset.sum_sub_distrib,
+      smul_sub]
+  rw [hseq]
+  exact tendsto_birkhoffAverage_apply_sub_birkhoffAverage ℂ (hf y)
+
+/-- If every orbit of $f$ is bounded, then the fixed-point space and the range
+of $f-1$ have zero intersection. -/
+theorem HasBoundedOrbits.disjoint_ker_sub_one_range_sub_one
+    {f : E →ₗ[ℂ] E} (hf : f.HasBoundedOrbits) :
+    Disjoint (LinearMap.ker (f - 1)) (LinearMap.range (f - 1)) := by
+  rw [Submodule.disjoint_def]
+  intro x hxker hxrange
+  have hxfix : IsFixedPt f x := by
+    rw [LinearMap.mem_ker] at hxker
+    change f x = x
+    simpa only [LinearMap.sub_apply, Module.End.one_apply] using sub_eq_zero.mp hxker
+  exact tendsto_nhds_unique (hxfix.tendsto_birkhoffAverage ℂ _root_.id)
+    (hf.tendsto_birkhoffAverage_of_mem_range_sub_one hxrange)
+
+variable [FiniteDimensional ℂ E]
+
+/-- In finite dimension, bounded orbits imply that the fixed-point space and the
+range of $f-1$ are complementary. -/
+theorem HasBoundedOrbits.isCompl_ker_sub_one_range_sub_one
+    {f : E →ₗ[ℂ] E} (hf : f.HasBoundedOrbits) :
+    IsCompl (LinearMap.ker (f - 1)) (LinearMap.range (f - 1)) := by
+  apply (Submodule.isCompl_iff_disjoint _ _ ?_).2
+  · exact hf.disjoint_ker_sub_one_range_sub_one
+  · rw [← (f - 1).finrank_range_add_finrank_ker]
+    omega
+
+/-- The mean-ergodic projection of a finite-dimensional linear endomorphism with
+bounded orbits is the projection onto $\ker(f-1)$ along $\operatorname{range}(f-1)$. -/
+noncomputable def meanErgodicProjection (f : E →ₗ[ℂ] E) (hf : f.HasBoundedOrbits) :
+    E →ₗ[ℂ] E :=
+  (LinearMap.ker (f - 1)).projection (LinearMap.range (f - 1))
+    hf.isCompl_ker_sub_one_range_sub_one
+
+/-- **Finite-dimensional mean-ergodic theorem for bounded orbits.** The Cesàro averages
+of the iterates of $f$ converge pointwise to the projection onto $\ker(f-1)$ along
+$\operatorname{range}(f-1)$.
+
+This is the abstract convergence argument underlying Equation 6.14 of Wolf's
+*Quantum Channels & Operations*. The matrix specialization must separately prove
+that the limiting projection is positive and unital. -/
+theorem HasBoundedOrbits.tendsto_birkhoffAverage_meanErgodicProjection
+    {f : E →ₗ[ℂ] E} (hf : f.HasBoundedOrbits) (x : E) :
+    Tendsto (birkhoffAverage ℂ f _root_.id · x) atTop
+      (nhds (meanErgodicProjection f hf x)) := by
+  let P := meanErgodicProjection f hf
+  change Tendsto (birkhoffAverage ℂ f _root_.id · x) atTop (nhds (P x))
+  have hcompl := hf.isCompl_ker_sub_one_range_sub_one
+  have hPker : P x ∈ LinearMap.ker (f - 1) := by
+    exact Submodule.projection_apply_mem hcompl x
+  have hPfix : IsFixedPt f (P x) := by
+    rw [LinearMap.mem_ker] at hPker
+    change f (P x) = P x
+    simpa only [LinearMap.sub_apply, Module.End.one_apply] using sub_eq_zero.mp hPker
+  have hrem : x - P x ∈ LinearMap.range (f - 1) := by
+    exact Submodule.sub_projection_mem hcompl x
+  have hrem_lim := hf.tendsto_birkhoffAverage_of_mem_range_sub_one hrem
+  have hsum := (hPfix.tendsto_birkhoffAverage ℂ _root_.id).add hrem_lim
+  have hadd : ∀ n : ℕ, f^[n] (P x + (x - P x)) =
+      f^[n] (P x) + f^[n] (x - P x) :=
+    fun n ↦ iterate_map_add (f : E →+ E) n (P x) (x - P x)
+  have hseq :
+      (fun n ↦ birkhoffAverage ℂ f _root_.id n x) =
+        fun n ↦ birkhoffAverage ℂ f _root_.id n (P x) +
+          birkhoffAverage ℂ f _root_.id n (x - P x) := by
+    funext n
+    have hdecomp : x = P x + (x - P x) := by abel
+    conv_lhs => rw [hdecomp]
+    simp only [birkhoffAverage, birkhoffSum, id_eq, hadd, Finset.sum_add_distrib,
+      smul_add]
+  rw [hseq]
+  simpa only [id_eq, add_zero] using hsum
+
+/-- The range of the mean-ergodic projection is exactly the fixed-point space
+$\ker(f-1)$. -/
+@[simp]
+theorem HasBoundedOrbits.range_meanErgodicProjection
+    {f : E →ₗ[ℂ] E} (hf : f.HasBoundedOrbits) :
+    LinearMap.range (meanErgodicProjection f hf) = LinearMap.ker (f - 1) := by
+  exact Submodule.range_projection hf.isCompl_ker_sub_one_range_sub_one
+
+/-- The mean-ergodic projection fixes exactly the fixed points of $f$. -/
+@[simp]
+theorem HasBoundedOrbits.meanErgodicProjection_apply_eq_self_iff
+    {f : E →ₗ[ℂ] E} (hf : f.HasBoundedOrbits) (x : E) :
+    meanErgodicProjection f hf x = x ↔ f x = x := by
+  change
+    (LinearMap.ker (f - 1)).projection (LinearMap.range (f - 1))
+        hf.isCompl_ker_sub_one_range_sub_one x = x ↔ _
+  rw [Submodule.projection_eq_self_iff, LinearMap.mem_ker]
+  simp only [LinearMap.sub_apply, Module.End.one_apply, sub_eq_zero]
+
+/-- The mean-ergodic projection is idempotent. -/
+theorem HasBoundedOrbits.isIdempotentElem_meanErgodicProjection
+    {f : E →ₗ[ℂ] E} (hf : f.HasBoundedOrbits) :
+    IsIdempotentElem (meanErgodicProjection f hf) := by
+  exact Submodule.isIdempotentElem_projection hf.isCompl_ker_sub_one_range_sub_one
+
+/-- Applying the mean-ergodic projection twice is the same as applying it once. -/
+@[simp]
+theorem HasBoundedOrbits.meanErgodicProjection_apply_meanErgodicProjection
+    {f : E →ₗ[ℂ] E} (hf : f.HasBoundedOrbits) (x : E) :
+    meanErgodicProjection f hf (meanErgodicProjection f hf x) =
+      meanErgodicProjection f hf x := by
+  have h := congrArg (fun g : E →ₗ[ℂ] E ↦ g x)
+    hf.isIdempotentElem_meanErgodicProjection.eq
+  simpa only [Module.End.mul_apply] using h
+
+/-- The endomorphism fixes the range of its mean-ergodic projection. -/
+theorem HasBoundedOrbits.comp_meanErgodicProjection
+    {f : E →ₗ[ℂ] E} (hf : f.HasBoundedOrbits) :
+    f.comp (meanErgodicProjection f hf) = meanErgodicProjection f hf := by
+  apply LinearMap.ext
+  intro x
+  have hmem : meanErgodicProjection f hf x ∈ LinearMap.ker (f - 1) := by
+    exact Submodule.projection_apply_mem hf.isCompl_ker_sub_one_range_sub_one x
+  rw [LinearMap.mem_ker] at hmem
+  simpa only [LinearMap.comp_apply, LinearMap.sub_apply, Module.End.one_apply]
+    using sub_eq_zero.mp hmem
+
+/-- The mean-ergodic projection is unchanged after precomposition with the
+endomorphism. -/
+theorem HasBoundedOrbits.meanErgodicProjection_comp
+    {f : E →ₗ[ℂ] E} (hf : f.HasBoundedOrbits) :
+    (meanErgodicProjection f hf).comp f = meanErgodicProjection f hf := by
+  apply LinearMap.ext
+  intro x
+  have hdiff : f x - x ∈ LinearMap.range (f - 1) := by
+    refine ⟨x, ?_⟩
+    simp only [LinearMap.sub_apply, Module.End.one_apply]
+  have hzero := Submodule.projection_apply_of_mem_right
+    hf.isCompl_ker_sub_one_range_sub_one hdiff
+  change meanErgodicProjection f hf (f x - x) = 0 at hzero
+  simpa only [LinearMap.comp_apply, map_sub, sub_eq_zero] using hzero
+
+end LinearMap

--- a/TNLean/Analysis/MeanErgodic.lean
+++ b/TNLean/Analysis/MeanErgodic.lean
@@ -3,7 +3,6 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import Mathlib.Analysis.Complex.Basic
 import Mathlib.Dynamics.BirkhoffSum.NormedSpace
 import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
 import Mathlib.LinearAlgebra.Projection
@@ -11,8 +10,8 @@ import Mathlib.LinearAlgebra.Projection
 /-!
 # Finite-dimensional mean-ergodic projection
 
-Let $f$ be a linear endomorphism of a finite-dimensional complex normed space. If every
-forward orbit of $f$ is bounded, then
+Let $f$ be a linear endomorphism of a finite-dimensional real or complex normed space.
+If every forward orbit of $f$ is bounded, then
 $$
   \ker(f-1) \oplus \operatorname{range}(f-1)
 $$
@@ -58,37 +57,37 @@ open scoped Topology
 
 namespace LinearMap
 
-variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
+variable {𝕜 E : Type*} [RCLike 𝕜] [NormedAddCommGroup E] [NormedSpace 𝕜 E]
 
 /-- A linear endomorphism has bounded orbits if the range of
 $n \mapsto f^n x$ is bounded for every vector $x$. -/
-def HasBoundedOrbits (f : E →ₗ[ℂ] E) : Prop :=
+def HasBoundedOrbits (f : E →ₗ[𝕜] E) : Prop :=
   ∀ x : E, Bornology.IsBounded (Set.range fun n : ℕ ↦ f^[n] x)
 
 /-- The Cesàro averages of a vector in the range of $f-1$ tend to zero when the
 forward orbit of every vector is bounded. -/
 theorem HasBoundedOrbits.tendsto_birkhoffAverage_of_mem_range_sub_one
-    {f : E →ₗ[ℂ] E} (hf : f.HasBoundedOrbits) {x : E}
+    {f : E →ₗ[𝕜] E} (hf : f.HasBoundedOrbits) {x : E}
     (hx : x ∈ LinearMap.range (f - 1)) :
-    Tendsto (birkhoffAverage ℂ f _root_.id · x) atTop (nhds 0) := by
+    Tendsto (birkhoffAverage 𝕜 f _root_.id · x) atTop (nhds 0) := by
   obtain ⟨y, rfl⟩ := hx
   have hsub : ∀ n : ℕ, f^[n] (f y - y) = f^[n] (f y) - f^[n] y :=
     fun n ↦ iterate_map_sub (f : E →+ E) n (f y) y
   have hseq :
-      (fun n ↦ birkhoffAverage ℂ f _root_.id n ((f - 1) y)) =
-        fun n ↦ birkhoffAverage ℂ f _root_.id n (f y) -
-          birkhoffAverage ℂ f _root_.id n y := by
+      (fun n ↦ birkhoffAverage 𝕜 f _root_.id n ((f - 1) y)) =
+        fun n ↦ birkhoffAverage 𝕜 f _root_.id n (f y) -
+          birkhoffAverage 𝕜 f _root_.id n y := by
     funext n
-    change birkhoffAverage ℂ f _root_.id n (f y - y) = _
+    change birkhoffAverage 𝕜 f _root_.id n (f y - y) = _
     simp only [birkhoffAverage, birkhoffSum, id_eq, hsub, Finset.sum_sub_distrib,
       smul_sub]
   rw [hseq]
-  exact tendsto_birkhoffAverage_apply_sub_birkhoffAverage ℂ (hf y)
+  exact tendsto_birkhoffAverage_apply_sub_birkhoffAverage 𝕜 (hf y)
 
 /-- If every orbit of $f$ is bounded, then the fixed-point space and the range
 of $f-1$ have zero intersection. -/
 theorem HasBoundedOrbits.disjoint_ker_sub_one_range_sub_one
-    {f : E →ₗ[ℂ] E} (hf : f.HasBoundedOrbits) :
+    {f : E →ₗ[𝕜] E} (hf : f.HasBoundedOrbits) :
     Disjoint (LinearMap.ker (f - 1)) (LinearMap.range (f - 1)) := by
   rw [Submodule.disjoint_def]
   intro x hxker hxrange
@@ -96,15 +95,15 @@ theorem HasBoundedOrbits.disjoint_ker_sub_one_range_sub_one
     rw [LinearMap.mem_ker] at hxker
     change f x = x
     simpa only [LinearMap.sub_apply, Module.End.one_apply] using sub_eq_zero.mp hxker
-  exact tendsto_nhds_unique (hxfix.tendsto_birkhoffAverage ℂ _root_.id)
+  exact tendsto_nhds_unique (hxfix.tendsto_birkhoffAverage 𝕜 _root_.id)
     (hf.tendsto_birkhoffAverage_of_mem_range_sub_one hxrange)
 
-variable [FiniteDimensional ℂ E]
+variable [FiniteDimensional 𝕜 E]
 
 /-- In finite dimension, bounded orbits imply that the fixed-point space and the
 range of $f-1$ are complementary. -/
 theorem HasBoundedOrbits.isCompl_ker_sub_one_range_sub_one
-    {f : E →ₗ[ℂ] E} (hf : f.HasBoundedOrbits) :
+    {f : E →ₗ[𝕜] E} (hf : f.HasBoundedOrbits) :
     IsCompl (LinearMap.ker (f - 1)) (LinearMap.range (f - 1)) := by
   apply (Submodule.isCompl_iff_disjoint _ _ ?_).2
   · exact hf.disjoint_ker_sub_one_range_sub_one
@@ -113,8 +112,8 @@ theorem HasBoundedOrbits.isCompl_ker_sub_one_range_sub_one
 
 /-- The mean-ergodic projection of a finite-dimensional linear endomorphism with
 bounded orbits is the projection onto $\ker(f-1)$ along $\operatorname{range}(f-1)$. -/
-noncomputable def meanErgodicProjection (f : E →ₗ[ℂ] E) (hf : f.HasBoundedOrbits) :
-    E →ₗ[ℂ] E :=
+noncomputable def meanErgodicProjection (f : E →ₗ[𝕜] E) (hf : f.HasBoundedOrbits) :
+    E →ₗ[𝕜] E :=
   (LinearMap.ker (f - 1)).projection (LinearMap.range (f - 1))
     hf.isCompl_ker_sub_one_range_sub_one
 
@@ -126,11 +125,11 @@ This is the abstract convergence argument underlying Equation 6.14 of Wolf's
 *Quantum Channels & Operations*. The matrix specialization must separately prove
 that the limiting projection is positive and unital. -/
 theorem HasBoundedOrbits.tendsto_birkhoffAverage_meanErgodicProjection
-    {f : E →ₗ[ℂ] E} (hf : f.HasBoundedOrbits) (x : E) :
-    Tendsto (birkhoffAverage ℂ f _root_.id · x) atTop
+    {f : E →ₗ[𝕜] E} (hf : f.HasBoundedOrbits) (x : E) :
+    Tendsto (birkhoffAverage 𝕜 f _root_.id · x) atTop
       (nhds (meanErgodicProjection f hf x)) := by
   let P := meanErgodicProjection f hf
-  change Tendsto (birkhoffAverage ℂ f _root_.id · x) atTop (nhds (P x))
+  change Tendsto (birkhoffAverage 𝕜 f _root_.id · x) atTop (nhds (P x))
   have hcompl := hf.isCompl_ker_sub_one_range_sub_one
   have hPker : P x ∈ LinearMap.ker (f - 1) := by
     exact Submodule.projection_apply_mem hcompl x
@@ -141,14 +140,14 @@ theorem HasBoundedOrbits.tendsto_birkhoffAverage_meanErgodicProjection
   have hrem : x - P x ∈ LinearMap.range (f - 1) := by
     exact Submodule.sub_projection_mem hcompl x
   have hrem_lim := hf.tendsto_birkhoffAverage_of_mem_range_sub_one hrem
-  have hsum := (hPfix.tendsto_birkhoffAverage ℂ _root_.id).add hrem_lim
+  have hsum := (hPfix.tendsto_birkhoffAverage 𝕜 _root_.id).add hrem_lim
   have hadd : ∀ n : ℕ, f^[n] (P x + (x - P x)) =
       f^[n] (P x) + f^[n] (x - P x) :=
     fun n ↦ iterate_map_add (f : E →+ E) n (P x) (x - P x)
   have hseq :
-      (fun n ↦ birkhoffAverage ℂ f _root_.id n x) =
-        fun n ↦ birkhoffAverage ℂ f _root_.id n (P x) +
-          birkhoffAverage ℂ f _root_.id n (x - P x) := by
+      (fun n ↦ birkhoffAverage 𝕜 f _root_.id n x) =
+        fun n ↦ birkhoffAverage 𝕜 f _root_.id n (P x) +
+          birkhoffAverage 𝕜 f _root_.id n (x - P x) := by
     funext n
     have hdecomp : x = P x + (x - P x) := by abel
     conv_lhs => rw [hdecomp]
@@ -161,14 +160,14 @@ theorem HasBoundedOrbits.tendsto_birkhoffAverage_meanErgodicProjection
 $\ker(f-1)$. -/
 @[simp]
 theorem HasBoundedOrbits.range_meanErgodicProjection
-    {f : E →ₗ[ℂ] E} (hf : f.HasBoundedOrbits) :
+    {f : E →ₗ[𝕜] E} (hf : f.HasBoundedOrbits) :
     LinearMap.range (meanErgodicProjection f hf) = LinearMap.ker (f - 1) := by
   exact Submodule.range_projection hf.isCompl_ker_sub_one_range_sub_one
 
 /-- The mean-ergodic projection fixes exactly the fixed points of $f$. -/
 @[simp]
 theorem HasBoundedOrbits.meanErgodicProjection_apply_eq_self_iff
-    {f : E →ₗ[ℂ] E} (hf : f.HasBoundedOrbits) (x : E) :
+    {f : E →ₗ[𝕜] E} (hf : f.HasBoundedOrbits) (x : E) :
     meanErgodicProjection f hf x = x ↔ f x = x := by
   change
     (LinearMap.ker (f - 1)).projection (LinearMap.range (f - 1))
@@ -178,23 +177,23 @@ theorem HasBoundedOrbits.meanErgodicProjection_apply_eq_self_iff
 
 /-- The mean-ergodic projection is idempotent. -/
 theorem HasBoundedOrbits.isIdempotentElem_meanErgodicProjection
-    {f : E →ₗ[ℂ] E} (hf : f.HasBoundedOrbits) :
+    {f : E →ₗ[𝕜] E} (hf : f.HasBoundedOrbits) :
     IsIdempotentElem (meanErgodicProjection f hf) := by
   exact Submodule.isIdempotentElem_projection hf.isCompl_ker_sub_one_range_sub_one
 
 /-- Applying the mean-ergodic projection twice is the same as applying it once. -/
 @[simp]
 theorem HasBoundedOrbits.meanErgodicProjection_apply_meanErgodicProjection
-    {f : E →ₗ[ℂ] E} (hf : f.HasBoundedOrbits) (x : E) :
+    {f : E →ₗ[𝕜] E} (hf : f.HasBoundedOrbits) (x : E) :
     meanErgodicProjection f hf (meanErgodicProjection f hf x) =
       meanErgodicProjection f hf x := by
-  have h := congrArg (fun g : E →ₗ[ℂ] E ↦ g x)
+  have h := congrArg (fun g : E →ₗ[𝕜] E ↦ g x)
     hf.isIdempotentElem_meanErgodicProjection.eq
   simpa only [Module.End.mul_apply] using h
 
 /-- The endomorphism fixes the range of its mean-ergodic projection. -/
 theorem HasBoundedOrbits.comp_meanErgodicProjection
-    {f : E →ₗ[ℂ] E} (hf : f.HasBoundedOrbits) :
+    {f : E →ₗ[𝕜] E} (hf : f.HasBoundedOrbits) :
     f.comp (meanErgodicProjection f hf) = meanErgodicProjection f hf := by
   apply LinearMap.ext
   intro x
@@ -207,7 +206,7 @@ theorem HasBoundedOrbits.comp_meanErgodicProjection
 /-- The mean-ergodic projection is unchanged after precomposition with the
 endomorphism. -/
 theorem HasBoundedOrbits.meanErgodicProjection_comp
-    {f : E →ₗ[ℂ] E} (hf : f.HasBoundedOrbits) :
+    {f : E →ₗ[𝕜] E} (hf : f.HasBoundedOrbits) :
     (meanErgodicProjection f hf).comp f = meanErgodicProjection f hf := by
   apply LinearMap.ext
   intro x

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Analysis.MeanErgodic
 import TNLean.Channel.FixedPoint.Algebra
 import TNLean.Channel.FixedPoint.Cesaro
 import TNLean.Channel.FixedPoint.ConditionalExpectation
@@ -267,6 +268,13 @@ Wolf Theorem 6.12 there (`Kraus.adjointFixedPointsStarSubalgebra`), and transpor
 the `*`-algebra structure back along the compression isomorphism.
 
 ### Wolf Theorem 6.14 (Wedderburn decomposition of fixed-point algebra) — PARTIALLY FORMALIZED
+
+The general finite-dimensional convergence argument is provided by
+`LinearMap.HasBoundedOrbits.tendsto_birkhoffAverage_meanErgodicProjection` in
+`TNLean.Analysis.MeanErgodic`. It constructs the Cesàro projection onto the
+fixed-point space for an endomorphism with bounded orbits. The proof that this
+projection is positive and unital for matrix maps remains open here, as does its
+application to the full statement of Theorem 6.14.
 
 In `TNLean.Channel.FixedPoint.WedderburnDecomp`:
 

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -874,11 +874,11 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     is bounded.
 \end{definition}
 
-\begin{definition}[Mean-ergodic projection]
-    \label{def:mean_ergodic_projection}
-    \lean{LinearMap.HasBoundedOrbits.disjoint_ker_sub_one_range_sub_one,
-        LinearMap.HasBoundedOrbits.isCompl_ker_sub_one_range_sub_one,
-        LinearMap.meanErgodicProjection}
+\begin{lemma}[Complementarity of the fixed-point space]
+    \label{lem:mean_ergodic_complementarity}
+    \lean{LinearMap.HasBoundedOrbits.tendsto_birkhoffAverage_of_mem_range_sub_one,
+        LinearMap.HasBoundedOrbits.disjoint_ker_sub_one_range_sub_one,
+        LinearMap.HasBoundedOrbits.isCompl_ker_sub_one_range_sub_one}
     \leanok
     \uses{def:has_bounded_orbits}
     Let $V$ be finite-dimensional and let $f:V\to V$ have bounded orbits.
@@ -886,14 +886,32 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     \[
         V=\ker(f-\Id_V)\oplus\operatorname{range}(f-\Id_V).
     \]
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{def:has_bounded_orbits}
+    If $y\in V$, telescoping and boundedness of its orbit give
+    \[
+        A_N\bigl((f-\Id_V)y\bigr)
+        =\frac{f^N y-y}{N}\longrightarrow 0.
+    \]
+    Since $A_N(z)=z$ for $z\in\ker(f-\Id_V)$, the two summands have zero
+    intersection. Rank--nullity then gives the asserted complementarity.
+\end{proof}
+
+\begin{definition}[Mean-ergodic projection]
+    \label{def:mean_ergodic_projection}
+    \lean{LinearMap.meanErgodicProjection}
+    \leanok
+    \uses{def:has_bounded_orbits, lem:mean_ergodic_complementarity}
+    Let $V$ be finite-dimensional and let $f:V\to V$ have bounded orbits.
     The \emph{mean-ergodic projection} $P_f:V\to V$ is the projection onto
     $\ker(f-\Id_V)$ along $\operatorname{range}(f-\Id_V)$.
 \end{definition}
 
 \begin{theorem}[Finite-dimensional mean-ergodic theorem]
     \label{thm:mean_ergodic_bounded_orbits}
-    \lean{LinearMap.HasBoundedOrbits.tendsto_birkhoffAverage_of_mem_range_sub_one,
-        LinearMap.HasBoundedOrbits.tendsto_birkhoffAverage_meanErgodicProjection,
+    \lean{LinearMap.HasBoundedOrbits.tendsto_birkhoffAverage_meanErgodicProjection,
         LinearMap.HasBoundedOrbits.range_meanErgodicProjection,
         LinearMap.HasBoundedOrbits.meanErgodicProjection_apply_eq_self_iff,
         LinearMap.HasBoundedOrbits.isIdempotentElem_meanErgodicProjection,
@@ -919,22 +937,28 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{def:has_bounded_orbits, def:mean_ergodic_projection}
-    If $y\in V$, telescoping and boundedness of its orbit give
-    \[
-        A_N\bigl((f-\Id_V)y\bigr)
-        =\frac{f^N y-y}{N}\longrightarrow 0.
-    \]
-    On the other hand, $A_N(z)=z$ whenever $z\in\ker(f-\Id_V)$.
-    Hence the kernel and range in Definition~\ref{def:mean_ergodic_projection}
-    have zero intersection; rank--nullity makes them complementary. Decompose
+    \uses{def:has_bounded_orbits, lem:mean_ergodic_complementarity,
+        def:mean_ergodic_projection}
+    By Lemma~\ref{lem:mean_ergodic_complementarity}, decompose
     \[
         x=P_f x+(x-P_f x),\qquad
         P_f x\in\ker(f-\Id_V),\qquad
         x-P_f x\in\operatorname{range}(f-\Id_V).
     \]
-    The two preceding limits give $A_N(x)\to P_f x$. The remaining identities
-    follow from the kernel, range, and idempotence of this projection.
+    The fixed component has constant Ces\`aro averages, whereas the averages of
+    the second component tend to zero by the telescoping calculation in the
+    lemma. Thus $A_N(x)\to P_f x$. Since
+    \[
+        P_f x\in\ker(f-\Id_V),
+        \qquad f(P_f x)=P_f x,
+    \]
+    we have $fP_f=P_f$. Moreover,
+    \[
+        (f-\Id_V)x\in\operatorname{range}(f-\Id_V),
+        \qquad P_f\bigl((f-\Id_V)x\bigr)=0,
+    \]
+    so $P_f(fx)=P_f x$ and hence $P_f f=P_f$. The range and idempotence
+    identities follow directly from the projection construction.
 \end{proof}
 
 \begin{theorem}[Hermitian fixed-point decomposition]\label{thm:hermitian_fixedpoint_parts}

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -874,13 +874,34 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     is bounded.
 \end{definition}
 
-\begin{lemma}[Complementarity of the fixed-point space]
-    \label{lem:mean_ergodic_complementarity}
-    \lean{LinearMap.HasBoundedOrbits.tendsto_birkhoffAverage_of_mem_range_sub_one,
-        LinearMap.HasBoundedOrbits.disjoint_ker_sub_one_range_sub_one,
-        LinearMap.HasBoundedOrbits.isCompl_ker_sub_one_range_sub_one}
+\begin{lemma}[Ces\`aro averages of range elements]
+    \label{lem:mean_ergodic_range_limit}
+    \lean{LinearMap.HasBoundedOrbits.tendsto_birkhoffAverage_of_mem_range_sub_one}
     \leanok
     \uses{def:has_bounded_orbits}
+    Let $f:V\to V$ have bounded orbits. If
+    $x\in\operatorname{range}(f-\Id_V)$, then
+    \[
+        A_N(x)\longrightarrow 0.
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{def:has_bounded_orbits}
+    Write $x=(f-\Id_V)y$. Telescoping gives
+    \[
+        A_N(x)=\frac{f^N y-y}{N}.
+    \]
+    Boundedness of the orbit of $y$ makes the numerator bounded, so the
+    right-hand side tends to zero.
+\end{proof}
+
+\begin{lemma}[Complementarity of the fixed-point space]
+    \label{lem:mean_ergodic_complementarity}
+    \lean{LinearMap.HasBoundedOrbits.disjoint_ker_sub_one_range_sub_one,
+        LinearMap.HasBoundedOrbits.isCompl_ker_sub_one_range_sub_one}
+    \leanok
+    \uses{def:has_bounded_orbits, lem:mean_ergodic_range_limit}
     Let $V$ be finite-dimensional and let $f:V\to V$ have bounded orbits.
     Then
     \[
@@ -889,14 +910,11 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
 \end{lemma}
 
 \begin{proof}\leanok
-    \uses{def:has_bounded_orbits}
-    If $y\in V$, telescoping and boundedness of its orbit give
-    \[
-        A_N\bigl((f-\Id_V)y\bigr)
-        =\frac{f^N y-y}{N}\longrightarrow 0.
-    \]
-    Since $A_N(z)=z$ for $z\in\ker(f-\Id_V)$, the two summands have zero
-    intersection. Rank--nullity then gives the asserted complementarity.
+    \uses{def:has_bounded_orbits, lem:mean_ergodic_range_limit}
+    If $z$ belongs to both summands, then $A_N(z)=z$ because
+    $z\in\ker(f-\Id_V)$, while Lemma~\ref{lem:mean_ergodic_range_limit} gives
+    $A_N(z)\to 0$. Hence $z=0$. Rank--nullity then gives the asserted
+    complementarity.
 \end{proof}
 
 \begin{definition}[Mean-ergodic projection]
@@ -937,8 +955,8 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{def:has_bounded_orbits, lem:mean_ergodic_complementarity,
-        def:mean_ergodic_projection}
+    \uses{def:has_bounded_orbits, lem:mean_ergodic_range_limit,
+        lem:mean_ergodic_complementarity, def:mean_ergodic_projection}
     By Lemma~\ref{lem:mean_ergodic_complementarity}, decompose
     \[
         x=P_f x+(x-P_f x),\qquad
@@ -946,8 +964,8 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
         x-P_f x\in\operatorname{range}(f-\Id_V).
     \]
     The fixed component has constant Ces\`aro averages, whereas the averages of
-    the second component tend to zero by the telescoping calculation in the
-    lemma. Thus $A_N(x)\to P_f x$. Since
+    the second component tend to zero by
+    Lemma~\ref{lem:mean_ergodic_range_limit}. Thus $A_N(x)\to P_f x$. Since
     \[
         P_f x\in\ker(f-\Id_V),
         \qquad f(P_f x)=P_f x,

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -861,6 +861,82 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     and subtracting $\sigma_N$ cancels all but the first and last terms.
 \end{proof}
 
+\begin{definition}[Bounded-orbit endomorphism]
+    \label{def:has_bounded_orbits}
+    \lean{LinearMap.HasBoundedOrbits}
+    \leanok
+    Let $\mathbb K$ denote either $\R$ or $\C$, and let $V$ be a normed
+    vector space over $\mathbb K$. A linear endomorphism $f:V\to V$ has
+    \emph{bounded orbits} if, for every $x\in V$, the set
+    \[
+        \{f^n x:n\in\N\}
+    \]
+    is bounded.
+\end{definition}
+
+\begin{definition}[Mean-ergodic projection]
+    \label{def:mean_ergodic_projection}
+    \lean{LinearMap.HasBoundedOrbits.disjoint_ker_sub_one_range_sub_one,
+        LinearMap.HasBoundedOrbits.isCompl_ker_sub_one_range_sub_one,
+        LinearMap.meanErgodicProjection}
+    \leanok
+    \uses{def:has_bounded_orbits}
+    Let $V$ be finite-dimensional and let $f:V\to V$ have bounded orbits.
+    Then
+    \[
+        V=\ker(f-\Id_V)\oplus\operatorname{range}(f-\Id_V).
+    \]
+    The \emph{mean-ergodic projection} $P_f:V\to V$ is the projection onto
+    $\ker(f-\Id_V)$ along $\operatorname{range}(f-\Id_V)$.
+\end{definition}
+
+\begin{theorem}[Finite-dimensional mean-ergodic theorem]
+    \label{thm:mean_ergodic_bounded_orbits}
+    \lean{LinearMap.HasBoundedOrbits.tendsto_birkhoffAverage_of_mem_range_sub_one,
+        LinearMap.HasBoundedOrbits.tendsto_birkhoffAverage_meanErgodicProjection,
+        LinearMap.HasBoundedOrbits.range_meanErgodicProjection,
+        LinearMap.HasBoundedOrbits.meanErgodicProjection_apply_eq_self_iff,
+        LinearMap.HasBoundedOrbits.isIdempotentElem_meanErgodicProjection,
+        LinearMap.HasBoundedOrbits.meanErgodicProjection_apply_meanErgodicProjection,
+        LinearMap.HasBoundedOrbits.comp_meanErgodicProjection,
+        LinearMap.HasBoundedOrbits.meanErgodicProjection_comp}
+    \leanok
+    \uses{def:has_bounded_orbits, def:mean_ergodic_projection}
+    Let $V$ be finite-dimensional and let $f:V\to V$ have bounded orbits.
+    For every $x\in V$, the Ces\`aro averages
+    \[
+        A_N(x)=\frac{1}{N}\sum_{n=0}^{N-1}f^n x
+    \]
+    converge to $P_f x$. Moreover,
+    \[
+        \operatorname{range}(P_f)=\ker(f-\Id_V),\qquad
+        P_f^2=P_f,\qquad fP_f=P_f=P_f f,
+    \]
+    and $P_f x=x$ if and only if $f x=x$.
+    The complex matrix specialization gives the convergence step underlying
+    \cite[Equation~(6.14)]{Wolf2012Quantum}; positivity and unitality of the
+    limiting projection are separate assertions.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:has_bounded_orbits, def:mean_ergodic_projection}
+    If $y\in V$, telescoping and boundedness of its orbit give
+    \[
+        A_N\bigl((f-\Id_V)y\bigr)
+        =\frac{f^N y-y}{N}\longrightarrow 0.
+    \]
+    On the other hand, $A_N(z)=z$ whenever $z\in\ker(f-\Id_V)$.
+    Hence the kernel and range in Definition~\ref{def:mean_ergodic_projection}
+    have zero intersection; rank--nullity makes them complementary. Decompose
+    \[
+        x=P_f x+(x-P_f x),\qquad
+        P_f x\in\ker(f-\Id_V),\qquad
+        x-P_f x\in\operatorname{range}(f-\Id_V).
+    \]
+    The two preceding limits give $A_N(x)\to P_f x$. The remaining identities
+    follow from the kernel, range, and idempotence of this projection.
+\end{proof}
+
 \begin{theorem}[Hermitian fixed-point decomposition]\label{thm:hermitian_fixedpoint_parts}
     \lean{IsChannel.posSemidef_parts_of_hermitian_fixedPoint}
     \leanok


### PR DESCRIPTION
### Motivation
- Wolf Equation 6.14 uses Cesàro averages to construct a projection onto a fixed-point space.
- Issue LionSR/QICLean#218 isolates the finite-dimensional linear argument needed before the positive-unital matrix specialization in parent issue LionSR/QICLean#39.
- The required hypothesis is boundedness of every forward orbit; no contraction hypothesis is introduced.

### Description
- Add `TNLean.Analysis.MeanErgodic` over real or complex scalars (`RCLike`).
- Prove that `ker (f - 1)` and `range (f - 1)` are complementary when every orbit of `f` is bounded.
- Define the projection onto `ker (f - 1)` along `range (f - 1)` and prove pointwise Cesàro convergence, its range and fixed-vector characterization, idempotence, and both absorption identities.
- Add the module to the root import and record the complex specialization as an abstract prerequisite in the Wolf Chapter 6 index.
- Add faithful Chapter 4 blueprint entries for the bounded-orbit condition, the projection, and the finite-dimensional theorem with its telescoping proof.
- Positivity, unitality, the matrix-map specialization, and the full statement of Wolf Theorem 6.14 remain open in LionSR/QICLean#39; this pull request does not close LionSR/QICLean#39.

### Testing
- `lake env lean TNLean/Analysis/MeanErgodic.lean`
- `lake build` (9552 jobs)
- `latexmk -lualatex -interaction=nonstopmode -halt-on-error print.tex` (613-page blueprint)
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `#print axioms` on convergence, range, idempotence, and both absorption theorems; only `propext`, `Classical.choice`, and `Quot.sound` are used.
- Independent audit of the initial exact commit `bebf708cf89d12abcbfd7d656d1bc58fa98f9cfb`; subsequent review corrections were revalidated with the same applicable local checks.

---
Closes LionSR/QICLean#218

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive analysis library and documentation only; no changes to channel auth, data paths, or existing proof obligations beyond new imports.
> 
> **Overview**
> Adds **`TNLean.Analysis.MeanErgodic`**, a finite-dimensional linear mean-ergodic layer for real/complex normed spaces under **`LinearMap.HasBoundedOrbits`** (every forward orbit bounded). It proves **`ker(f−1) ⊕ range(f−1)`**, defines **`meanErgodicProjection`**, and shows Cesàro (Birkhoff) averages converge to that projection, with range, idempotence, and **`fP = P = Pf`** identities.
> 
> The module is wired into the root import and the Wolf Chapter 6 index; **positivity and unitality of the limiting projection for matrix maps** and the full Wolf Theorem 6.14 remain explicit follow-ups. Chapter 4 blueprint entries document the bounded-orbit condition, complementarity lemmas, projection definition, and main theorem with `\lean` links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca1933ded3b2767d966d5c09aba4d6f201a9e9df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->