### PR TITLE
doc(MPS/MPDO): resolve single-bond comparison audit

### DIFF
--- a/docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex
+++ b/docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex
@@ -127,9 +127,12 @@ numbers therefore has the source GSNNCH form.
 {\scriptsize\leanid{MPOTensor.nonempty_orthogonalCommutingSectorFamily_of_bntSectorSAL}}
 and
 {\scriptsize\leanid{MPOTensor.hasGSNNCHForm_of_bntSectorSAL}}.}
-The remaining comparison is to determine whether the reverse comparison with
-a single bond is needed in the simple-MPDO equivalence, and to prove it only
-in that form.
+No reverse comparison with a single-bond predicate is needed for this
+implication.  The construction chooses one supported bond for each absorbed
+BNT representative, assembles these bonds into the orthogonal outer sectors,
+and concludes the source GSNNCH form directly from the positive-length BNT
+sum.  Thus a theorem extracting one bond from arbitrary GSNNCH sector data
+would not enter the proof of the simple-MPDO implication.
 
 The local Markov labels in Appendix C.2 belong inside one injective BNT
 component.  They are not the outer labels $x$ of Definition~4.8 and must not
@@ -152,7 +155,8 @@ two-site sector, and all cyclic translates of that lift commute pairwise on
 every periodic chain of length at least two.  Their product realizes the
 ambient finite-chain operator exactly, with normalization scalar one.  The
 supported products are assembled into the BNT outer sectors with their
-natural multiplicities.  The remaining question is whether the simple-MPDO
-equivalence requires a reverse comparison with a single bond.
+natural multiplicities.  This direct construction proves the GSNNCH
+implication without a reverse comparison with the auxiliary single-bond
+predicate.
 
 \end{document}


### PR DESCRIPTION
### Motivation

- Issue #4145 asks whether the simple-MPDO implication requires a reverse map from the source GSNNCH sector form to the auxiliary single-bond predicate.
- In arXiv:1606.00608, Appendix C.2, Proposition `prop3to4`, lines 1783–1792, the source writes the finite-chain operator as the direct sum of the absorbed BNT representatives with their natural multiplicities and applies the commuting-product result separately in each sector.
- The proved declarations `MPOTensor.nonempty_orthogonalCommutingSectorFamily_of_bntSectorSAL` and `MPOTensor.hasGSNNCHForm_of_bntSectorSAL` follow this source argument directly. No reverse single-bond extraction occurs.

### Description

- Update `docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex`.
- Record that the supported bond for each absorbed BNT representative is assembled directly into the orthogonal outer-sector sum.
- Remove the obsolete open question about extracting one auxiliary bond from arbitrary GSNNCH sector data.
- Leave the broader tracker #4003 open; separate blueprint-faithfulness corrections remain under #4148 and #4149.

### Testing

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check origin/main...HEAD`
- `TEXINPUTS="docs/paper-gaps:" latexmk -pdf -interaction=nonstopmode -halt-on-error -outdir=<temporary-directory> docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex`
- GitHub PR CI: changed-file classification and blueprint compilation pass at `cbd60eddfbbd1065e547ef728c3e8b99a0c1d9d4`.

---
Closes #4145