### PR TITLE
doc(MPS/MPDO): complete BNT sector dependencies

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
@@ -308,7 +308,9 @@ Definition~\ref{def:mpdo_source_gsnnch}; the converse comparison is not used.
     \label{thm:mpdo_bnt_sector_sal_commuting_family}
     \lean{MPOTensor.nonempty_orthogonalCommutingSectorFamily_of_bntSectorSAL}
     \leanok
-    \uses{thm:mpdo_physical_support_restriction_bond,
+    \uses{thm:mpdo_bnt_physical_support_restriction,
+        thm:mpdo_physical_support_restriction_bond,
+        thm:mpdo_bnt_sector_projection_resolution,
         def:mpdo_orthogonal_commuting_sector_family}
     Suppose that the BNT physical projectors $P_x$ have been selected and
     that every common-weight-absorbed representative $\mathcal K_x$


### PR DESCRIPTION
## Mathematical correction

The blueprint theorem asserting that SAL supplies orthogonally supported BNT sector products now records every formal dependency used by its Lean proof.

In addition to the supported-bond theorem and the sector-family definition, the proof uses:

- the existence of the physical support restriction for every absorbed BNT representative;
- orthogonality and pairwise disjointness of the BNT sector projections.

The corresponding blueprint labels are now included in the dependency list, so the dependency graph matches the proved argument.

## Verification

- python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci
- python3 scripts/blueprint_lean_sync.py --root . --ci --diff-base origin/main
- direct resolution of all four dependency labels
- git diff --check

Closes #4148.