### PR TITLE
doc(MPS/MPDO): state BNT relations in GSNNCH corollaries

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
@@ -373,10 +373,14 @@ Definition~\ref{def:mpdo_source_gsnnch}; the converse comparison is not used.
     \label{cor:mpdo_bnt_orthogonal_commuting_sectors_gsnnch}
     \lean{MPOTensor.hasGSNNCHForm_of_commonWeightAbsorbedBasisMPOTensor}
     \leanok
-    \uses{thm:mpdo_orthogonal_commuting_sectors_gsnnch}
-    Suppose that the common weight has been absorbed into each BNT
-    representative $\mathcal K_x$, and that these representatives have
-    orthogonally supported commuting sector products.  Then
+    \uses{def:same_mpv2_pos,
+        thm:mpdo_orthogonal_commuting_sectors_gsnnch}
+    Let $M$ be an MPO tensor and let its BNT canonical form have normal
+    representatives $A_x$, copy numbers $n_x$, and copy-independent weights
+    $\mu_x$.  Put $\mathcal K_x=\mu_xA_x$, and assume that this canonical form
+    generates the same matrix product vectors as $M$ at every positive length.
+    If the representatives $\mathcal K_x$ have orthogonally supported
+    commuting sector products, then
     \[
         \rho^{(N)}(M)=\sum_x n_x\rho^{(N)}(\mathcal K_x)
     \]
@@ -395,12 +399,20 @@ Definition~\ref{def:mpdo_source_gsnnch}; the converse comparison is not used.
     \label{cor:mpdo_bnt_sector_sal_gsnnch}
     \lean{MPOTensor.hasGSNNCHForm_of_bntSectorSAL}
     \leanok
-    \uses{thm:mpdo_bnt_sector_sal_commuting_family,
+    \uses{def:same_mpv2_pos,
+        thm:mpdo_bnt_sector_sal_commuting_family,
         cor:mpdo_bnt_orthogonal_commuting_sectors_gsnnch}
-    Under the BNT projector-selection hypotheses, if every absorbed BNT
-    representative satisfies SAL, then the original tensor has the source
-    GSNNCH form.  Its outer sectors are the BNT sectors and its natural
-    multiplicities are the BNT copy numbers.
+    Let $M$ be an MPO tensor and let its BNT canonical form have normal
+    representatives $A_x$, copy numbers $n_x$, and copy-independent weights
+    $\mu_x$.  Put $\mathcal K_x=\mu_xA_x$, and assume that this canonical form
+    generates the same matrix product vectors as $M$ at every positive length.
+    Equivalently, for every $N>0$,
+    \[
+        \rho^{(N)}(M)=\sum_x n_x\rho^{(N)}(\mathcal K_x).
+    \]
+    Under the BNT projector-selection hypotheses, if every $\mathcal K_x$
+    satisfies SAL, then $M$ has the source GSNNCH form.  Its outer sectors are
+    the BNT sectors and its natural multiplicities are the copy numbers $n_x$.
 \end{corollary}
 
 \begin{proof}\leanok


### PR DESCRIPTION
## Mathematical correction

The two adjacent BNT-to-GSNNCH corollaries now state the positive-length relation connecting the original MPO tensor to its BNT sector decomposition. For normal representatives Aₓ, copy numbers nₓ, and copy-independent weights μₓ, put Kₓ = μₓ Aₓ. The BNT canonical form is required to generate the same matrix-product family as M at every positive length; equivalently,

ρ⁽ᴺ⁾(M) = ∑ₓ nₓ ρ⁽ᴺ⁾(Kₓ)

for every N > 0. This is precisely the mathematical content of the SameMPV₂Pos hypothesis in both Lean theorems. Without it, M and the displayed sector decomposition would be unrelated.

Both corollaries now cite the positive-length equality definition, so their Lean correspondence tags match their theorem signatures. The statements follow arXiv:1606.00608, Appendix C.2, Proposition prop3to4.

## Verification

- lake build: 9551 jobs completed successfully
- leanblueprint web
- leanblueprint checkdecls
- python3 scripts/blueprint_lean_sync.py --root . --ci --diff-base origin/main
- python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci
- git diff origin/main...HEAD --check

Closes #4149.