### PR TITLE
doc(MPS/MPDO): identify sector span as source biCF hypothesis

### DIFF
--- a/TNLean/MPS/MPDO/BNTProjectorSelection.lean
+++ b/TNLean/MPS/MPDO/BNTProjectorSelection.lean
@@ -752,9 +752,10 @@ Hayashi--Ruskai--Hayden--Jozsa--Petz--Winter characterization of equality in
 strong subadditivity, isolated as
 `hayashi_ssa_equality_characterization_forward`.  No further axiom is used.
 
-**Scope restriction (blocked tensor):** the simultaneous inverse is used after
-the source's common blocking, expressed here by the one-letter simultaneous
-span.  The passage to this blocked form is recorded in
+**Source hypothesis (biCF):** the one-letter simultaneous span is precisely
+the block-injective canonical-form assumption imposed at the start of Case II
+in arXiv:1606.00608, line 1628.  It supplies the simultaneous inverse used in
+the source proof.  Its relation with finite physical blocking is recorded in
 `docs/paper-gaps/cpgsv17_bicf_block_separation.tex`.
 
 Source: arXiv:1606.00608, Appendix C.2, equations `PjKiPj`, `generateMPDO`,

--- a/TNLean/MPS/MPDO/BNTSectorAnalyticProperties.lean
+++ b/TNLean/MPS/MPDO/BNTSectorAnalyticProperties.lean
@@ -152,9 +152,11 @@ theorem commonWeightAbsorbedBasisMPOTensor_isMPDO_of_projectorSelection
 /-- Under the source hypotheses used to construct the BNT projectors, every
 absorbed normal representative generates an MPDO.
 
-**Scope restriction (common blocking):** the one-letter simultaneous span is
-the blocked form used for the simultaneous inverse.  Its derivation from biCF
-is recorded in `docs/paper-gaps/cpgsv17_bicf_block_separation.tex`.
+**Source hypothesis (biCF):** the one-letter simultaneous span is precisely
+the block-injective canonical-form assumption imposed at the start of Case II
+in arXiv:1606.00608, line 1628.  It supplies the simultaneous inverse used in
+the source proof.  Its relation with finite physical blocking is recorded in
+`docs/paper-gaps/cpgsv17_bicf_block_separation.tex`.
 
 **Axiom boundary:** the projector construction uses the existing forward
 Hayashi--Ruskai--Hayden--Jozsa--Petz--Winter characterization of equality in
@@ -191,9 +193,11 @@ This supplies the strict inequality required before normalizing the sector in
 the direct-sum entropy identity.  It is not inferred from the weaker displayed
 inequality \(p_s\geq 0\).
 
-**Scope restriction (common blocking):** the one-letter simultaneous span is
-the blocked form used for the simultaneous inverse.  Its derivation from biCF
-is recorded in `docs/paper-gaps/cpgsv17_bicf_block_separation.tex`.
+**Source hypothesis (biCF):** the one-letter simultaneous span is precisely
+the block-injective canonical-form assumption imposed at the start of Case II
+in arXiv:1606.00608, line 1628.  It supplies the simultaneous inverse used in
+the source proof.  Its relation with finite physical blocking is recorded in
+`docs/paper-gaps/cpgsv17_bicf_block_separation.tex`.
 
 Source: arXiv:1606.00608, Appendix C.2, lines 1760--1780. -/
 theorem trace_mpo_commonWeightAbsorbedBasisMPOTensor_pos

--- a/TNLean/MPS/MPDO/BNTSectorAreaLaw.lean
+++ b/TNLean/MPS/MPDO/BNTSectorAreaLaw.lean
@@ -523,9 +523,10 @@ subadditivity into the same orthogonal sectors.  Their Shannon contributions
 cancel, and strict positivity of every sector probability forces equality in
 each sector separately.
 
-**Scope restriction (common blocking):** the one-letter simultaneous span is
-the blocked form used to construct the common left inverse.  Its derivation
-from the unrestricted biCF statement is recorded in
+**Source hypothesis (biCF):** the one-letter simultaneous span is precisely
+the block-injective canonical-form assumption imposed at the start of Case II
+in arXiv:1606.00608, line 1628.  It supplies the common left inverse used in
+the source proof.  The relation with finite physical blocking is recorded in
 `docs/paper-gaps/cpgsv17_bicf_block_separation.tex`.
 
 Source: arXiv:1606.00608, Appendix C.2, lines 1748--1781. -/

--- a/TNLean/MPS/MPDO/BNTSourceSectorProjectors.lean
+++ b/TNLean/MPS/MPDO/BNTSourceSectorProjectors.lean
@@ -80,9 +80,10 @@ Hayashi--Ruskai--Hayden--Jozsa--Petz--Winter characterization of equality in
 strong subadditivity, isolated as
 `hayashi_ssa_equality_characterization_forward`.  No further axiom is used.
 
-**Scope restriction (blocked tensor):** the simultaneous inverse is used after
-the source's common blocking, expressed here by the one-letter simultaneous
-span.  The passage to this blocked form is recorded in
+**Source hypothesis (biCF):** the one-letter simultaneous span is precisely
+the block-injective canonical-form assumption imposed at the start of Case II
+in arXiv:1606.00608, line 1628.  It supplies the simultaneous inverse used in
+the source proof.  Its relation with finite physical blocking is recorded in
 `docs/paper-gaps/cpgsv17_bicf_block_separation.tex`.
 
 Source: arXiv:1606.00608, Appendix C.2, lines 1666--1676 and equations

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
@@ -631,8 +631,9 @@ strong subadditivity for a normalized three-site reduced state.
     In particular, after a common blocking has made the simultaneous BNT
     word span full at one letter, the absorbed BNT elements selected in
     Theorem~\ref{thm:mpdo_absorbed_bnt_sector_zcl} have a well-defined
-    normalized state at every physical chain length.  This common-blocking
-    restriction is recorded in
+    normalized state at every physical chain length.  This is the biCF
+    hypothesis imposed at the start of Case II in the source; its relation
+    with finite physical blocking is recorded in
     \path{docs/paper-gaps/cpgsv17_bicf_block_separation.tex}.
     This supplies the strict form of the sector normalization used in
     \cite[Appendix~C.2, lines~1760--1780]{Cirac2016MPDO_arXiv}.
@@ -687,8 +688,10 @@ strong subadditivity for a normalized three-site reduced state.
     Consequently, every absorbed representative $\mathcal K_s$ saturates the
     area law.
 
-    The common-blocking assumption is a scope restriction relative to the
-    unrestricted source statement; it is recorded in
+    The one-letter simultaneous span is the block-injective canonical-form
+    hypothesis imposed at the start of Case II in
+    \cite[line~1628]{Cirac2016MPDO_arXiv}.  Its relation with finite physical
+    blocking is recorded in
     \path{docs/paper-gaps/cpgsv17_bicf_block_separation.tex}.  The entropy
     conclusion is the argument of
     \cite[Appendix~C.2, lines~1748--1781]{Cirac2016MPDO_arXiv}.

--- a/docs/paper-gaps/cpgsv17_bicf_block_separation.tex
+++ b/docs/paper-gaps/cpgsv17_bicf_block_separation.tex
@@ -277,6 +277,40 @@ to the original MPO tensor.  The older
 per-copy \texttt{HorizontalCFData} theorems remain available only as explicitly
 restricted auxiliary statements.
 
+\section{The Appendix C.2 sector entropy argument}
+
+The one-letter simultaneous-span assumption in the formal sector entropy
+theorem is not an additional hypothesis absent from the cited source.  At the
+start of Case II, the source fixes a simple tensor $K$ in block-injective
+canonical form \cite[line~1628]{Cirac2016MPDO_arXiv}.  By Definition~2.6,
+block-injective canonical form says exactly that the one-letter tuples of the
+minimal normal representatives span
+\[
+    \bigoplus_{j=1}^g M_{D_j}(\mathbb C).
+\]
+The inverse tensor used immediately afterwards, and hence the one-site
+projections in the proof of Proposition~4.13, depend on this hypothesis.  The
+formal assumption \texttt{WordTupleSpanTop S.basis 1} is therefore the direct
+algebraic form of the source's biCF assumption.
+
+It would be a strictly stronger assertion to begin with an unblocked canonical
+form and remove this hypothesis by choosing a finite blocking length.  Although
+SAL passes from a tensor to any positive physical blocking, the converse does
+not follow from the periodic block identity: an $L$-blocked chain records only
+the original chain lengths $NL$ and only cuts whose lengths are multiples of
+$L$.  In particular, SAL of $K^{[L]}$ does not by itself recover the equalities
+$I_m(K)=I_{m+1}(K)$ at arbitrary chain lengths and cuts.  The proposed reverse
+transport in issue~\#4119 is therefore unavailable without a new mathematical
+argument not present in Appendix~C.2, and it is not needed for faithfulness to
+the printed proposition.
+
+Consequently, the sector entropy theorem should retain the simultaneous
+one-letter span and identify it as the source biCF hypothesis.  The finite
+blocking theorem remains the justification that an arbitrary canonical-form
+tensor can be placed in biCF when the surrounding result is itself stated only
+up to physical blocking; it does not turn the Appendix C.2 conclusion into an
+unblocked SAL statement.
+
 This closes the multiplicity and block-separation gap in Lemma L.  It does not
 by itself complete Proposition~4.13: constructing the letterwise vertical
 decomposition from the resulting reducing projections, and proving the

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -323,15 +323,15 @@ pairwise-annihilating support operators
 step after the sector-compression identity is now formalized: the same sector
 probabilities occur in all four marginals, the Shannon terms cancel, and
 strict positivity together with strong subadditivity forces equality in every
-sector.  Thus every absorbed BNT representative satisfies SAL under the
-explicit common-blocking restriction above.
+sector.  Thus every absorbed BNT representative satisfies SAL under the biCF
+hypothesis imposed at the start of Case II in the source.
 \footnote{The principal declarations are
 \path{MPOTensor.blockEntropy_eq_sum_bntSectorProbability},
 \path{MPOTensor.blockEntropy_add_blockEntropy_eq_bntSector}, and
 \path{MPOTensor.commonWeightAbsorbedBasisMPOTensor_isSAL_of_sameMPV₂Pos}.}
 This completes the entropy argument of
-\cite[Appendix~C.2, lines~1748--1781]{Cirac2016MPDO_arXiv} within that stated
-scope.
+\cite[Appendix~C.2, lines~1748--1781]{Cirac2016MPDO_arXiv} with the source's
+stated biCF hypothesis.
 There is a local endpoint typo in this passage.  Line~1771 writes
 $m<\lfloor N/2\rfloor$, but Definition~4.6 gives the equality chain through
 $I_{\lfloor N/2\rfloor}$, and the conclusion at lines~1781--1783 compares


### PR DESCRIPTION
## Mathematical correction

CPSV16 fixes the simple tensor `K` in block-injective canonical form at the start of Appendix C.2, Case II. By the paper’s definition of biCF, the one-letter simultaneous span used in TNLean is exactly this source hypothesis; it is not a scope restriction added by the formalization.

The proposed removal in #4119 is therefore neither necessary nor justified by the suggested blocking argument. Blocking does give one-letter span for `K^[L]`, and SAL passes to that blocked tensor, but the blocked family sees only original chain lengths `NL` and cuts of length `mL`. It cannot recover `I_m(K)=I_{m+1}(K)` for arbitrary lengths and cuts.

This change corrects the main sector-SAL declaration, its analytic/projector dependencies, the blueprint, and the two relevant paper-gap notes. No theorem signature or proof changes.

## Validation

- `lake env lean TNLean/MPS/MPDO/BNTSectorAreaLaw.lean`
- reader-facing prose check
- blueprint–Lean synchronization
- standalone LaTeX builds of both gap notes, with bibliography
- `git diff --check`

Closes #4119. Contributes to #2380.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prose and documentation only; no Lean signatures, proofs, or runtime behavior change.
> 
> **Overview**
> **Documentation-only correction:** the formal one-letter simultaneous span (`WordTupleSpanTop S.basis 1`) is reframed as the **source biCF hypothesis** from CPSV16 Appendix C.2 Case II (line 1628), not an extra “scope restriction” from blocking.
> 
> Lean docstrings on BNT projector selection, sector MPDO/ZCL/trace positivity, and sector SAL theorems now use a **Source hypothesis (biCF)** block that ties the span to block-injective canonical form and points to `docs/paper-gaps/cpgsv17_bicf_block_separation.tex` for how finite physical blocking relates. The blueprint chapter `ch21_mpdo_rfp_simple_local_markov_factorization.tex` is updated the same way for strict normalization and absorbed-sector SAL.
> 
> `cpgsv17_bicf_block_separation.tex` gains a new section on Appendix C.2 sector entropy: why biCF is already in the paper, and why removing the hypothesis via blocking would not recover SAL at arbitrary chain lengths/cuts (addressing #4119). `cpgsv17_mpdo_sal_zcl_eta_local_structure.tex` now states sector SAL is proved under the source’s stated biCF hypothesis rather than a common-blocking restriction.
> 
> **No theorem statements or proofs are modified.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e94dbf911457f667164afdd10c2f733f87be3f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->