### PR TITLE
feat(MPS/MPDO): preserve trace on vertical contractions

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -449,6 +449,7 @@ import TNLean.MPS.MPDO.VerticalMapTransport
 import TNLean.MPS.MPDO.VerticalSectorCoordinates
 import TNLean.MPS.MPDO.VerticalSectorFixedGenerators
 import TNLean.MPS.MPDO.VerticalSectorTraceLoss
+import TNLean.MPS.MPDO.VerticalSectorImagePreservation
 import TNLean.MPS.MPDO.VerticalSectorGeneration
 import TNLean.MPS.MPDO.PRFP
 import TNLean.MPS.MPDO.LocalPurificationRFP

--- a/TNLean/MPS/MPDO/VerticalSectorImagePreservation.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorImagePreservation.lean
@@ -1,0 +1,242 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.VerticalSectorTraceLoss
+
+/-!
+# Image preservation for transported vertical-sector maps
+
+The matrices before the final compression of the transported refinement and
+coarse-graining maps lie in the active vertical sectors on the bond
+contractions of the corresponding vertical canonical forms.  Consequently,
+the transported maps preserve total sector trace on these contraction
+families.
+
+The mathematical scope is documented in
+`docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex`.
+
+## Main results
+
+* `precompressionVerticalSectorT_image_preservation`: the refinement
+  precompression matrix of a one-site contraction lies in the active two-site
+  sector.
+* `precompressionVerticalSectorS_image_preservation`: the corresponding
+  statement for coarse-graining.
+* `transportedVerticalSectorT_trace_of_source_generated`: refinement preserves
+  sector trace on the one-site contraction family.
+* `transportedVerticalSectorS_trace_of_source_generated`: coarse-graining
+  preserves sector trace on the two-site contraction family.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Appendix C.4, lines 1955--1980.
+-/
+
+open scoped Matrix ComplexOrder
+
+noncomputable section
+
+namespace MPOTensor
+
+/-- The matrix before the final two-site compression lies in the active
+two-site sector for every one-site BNT bond contraction.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1955--1980. -/
+theorem precompressionVerticalSectorT_image_preservation
+    {g₁ g₂ d D : ℕ}
+    (dim₁ mult₁ : Fin g₁ → ℕ)
+    (weight₁ : (α : Fin g₁) → Fin (mult₁ α) → ℂ)
+    (dim₂ mult₂ : Fin g₂ → ℕ)
+    (weight₂ : (β : Fin g₂) → Fin (mult₂ β) → ℂ)
+    (hMult₁ : ∀ α, 0 < mult₁ α)
+    (hWeight₁ : ∀ α q, (0 : ℂ) < weight₁ α q)
+    (M : MPOTensor d D)
+    (A₁ : (α : Fin g₁) → MPSTensor (D * D) (dim₁ α))
+    (A₂ : (β : Fin g₂) → MPSTensor (D * D) (dim₂ β))
+    (U₁ : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g₁, mult₁ α), verticalCopyDim dim₁ mult₁ q))
+      (Fin d) ℂ)
+    (U₂ : Matrix
+      (Fin (∑ q : Fin (∑ β : Fin g₂, mult₂ β), verticalCopyDim dim₂ mult₂ q))
+      (Fin (d * d)) ℂ)
+    (hU₂ : U₂ * U₂ᴴ = 1)
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
+    (hReconstruct₁ : ∀ ab, verticalTensor M ab =
+      U₁ᴴ * verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab * U₁)
+    (hReconstruct₂ : ∀ ab, verticalTensor (blockTwo M) ab =
+      U₂ᴴ * verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab * U₂)
+    (X : Matrix (Fin D) (Fin D) ℂ)
+    (hT : T (physClose1 M X) = physClose2 M X) :
+    U₂ᴴ * U₂ * precompressionVerticalSectorT dim₁ mult₁ weight₁ U₁ T
+        (fun α => verticalMultiplicityTrace weight₁ α •
+          MPSTensor.contractBondMatrix (A₁ α) X) =
+      precompressionVerticalSectorT dim₁ mult₁ weight₁ U₁ T
+        (fun α => verticalMultiplicityTrace weight₁ α •
+          MPSTensor.contractBondMatrix (A₁ α) X) := by
+  unfold precompressionVerticalSectorT
+  rw [normalizedRetainedVerticalSectorEmbedding_trace_smul
+    dim₁ mult₁ weight₁ hMult₁ hWeight₁]
+  rw [← contractBondMatrix_verticalAssembledTensor_eq_sectorBlockDiagonal]
+  rw [singleKrausMap_apply, Matrix.conjTranspose_conjTranspose]
+  rw [← physClose1_eq_of_vertical_reconstruction M
+    (verticalAssembledTensor dim₁ mult₁ weight₁ A₁) U₁ hReconstruct₁ X]
+  rw [hT]
+  rw [physClose2_eq_physClose1_blockTwo_apply]
+  rw [physClose1_eq_of_vertical_reconstruction (blockTwo M)
+    (verticalAssembledTensor dim₂ mult₂ weight₂ A₂) U₂ hReconstruct₂ X]
+  simp only [Matrix.mul_assoc]
+  rw [← Matrix.mul_assoc U₂ U₂ᴴ]
+  rw [hU₂]
+  simp
+
+/-- The matrix before the final one-site compression lies in the active
+one-site sector for every two-site BNT bond contraction.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1955--1980. -/
+theorem precompressionVerticalSectorS_image_preservation
+    {g₁ g₂ d D : ℕ}
+    (dim₁ mult₁ : Fin g₁ → ℕ)
+    (weight₁ : (α : Fin g₁) → Fin (mult₁ α) → ℂ)
+    (dim₂ mult₂ : Fin g₂ → ℕ)
+    (weight₂ : (β : Fin g₂) → Fin (mult₂ β) → ℂ)
+    (hMult₂ : ∀ β, 0 < mult₂ β)
+    (hWeight₂ : ∀ β q, (0 : ℂ) < weight₂ β q)
+    (M : MPOTensor d D)
+    (A₁ : (α : Fin g₁) → MPSTensor (D * D) (dim₁ α))
+    (A₂ : (β : Fin g₂) → MPSTensor (D * D) (dim₂ β))
+    (U₁ : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g₁, mult₁ α), verticalCopyDim dim₁ mult₁ q))
+      (Fin d) ℂ)
+    (hU₁ : U₁ * U₁ᴴ = 1)
+    (U₂ : Matrix
+      (Fin (∑ q : Fin (∑ β : Fin g₂, mult₂ β), verticalCopyDim dim₂ mult₂ q))
+      (Fin (d * d)) ℂ)
+    (S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d) (Fin d) ℂ)
+    (hReconstruct₁ : ∀ ab, verticalTensor M ab =
+      U₁ᴴ * verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab * U₁)
+    (hReconstruct₂ : ∀ ab, verticalTensor (blockTwo M) ab =
+      U₂ᴴ * verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab * U₂)
+    (X : Matrix (Fin D) (Fin D) ℂ)
+    (hS : S (physClose2 M X) = physClose1 M X) :
+    U₁ᴴ * U₁ * precompressionVerticalSectorS dim₂ mult₂ weight₂ U₂ S
+        (fun β => verticalMultiplicityTrace weight₂ β •
+          MPSTensor.contractBondMatrix (A₂ β) X) =
+      precompressionVerticalSectorS dim₂ mult₂ weight₂ U₂ S
+        (fun β => verticalMultiplicityTrace weight₂ β •
+          MPSTensor.contractBondMatrix (A₂ β) X) := by
+  unfold precompressionVerticalSectorS
+  rw [normalizedRetainedVerticalSectorEmbedding_trace_smul
+    dim₂ mult₂ weight₂ hMult₂ hWeight₂]
+  rw [← contractBondMatrix_verticalAssembledTensor_eq_sectorBlockDiagonal]
+  rw [singleKrausMap_apply, Matrix.conjTranspose_conjTranspose]
+  rw [← physClose1_eq_of_vertical_reconstruction (blockTwo M)
+    (verticalAssembledTensor dim₂ mult₂ weight₂ A₂) U₂ hReconstruct₂ X]
+  rw [physClose1_blockTwo_eq_physClose2_apply]
+  rw [hS]
+  rw [physClose1_eq_of_vertical_reconstruction M
+    (verticalAssembledTensor dim₁ mult₁ weight₁ A₁) U₁ hReconstruct₁ X]
+  simp only [Matrix.mul_assoc]
+  rw [← Matrix.mul_assoc U₁ U₁ᴴ]
+  rw [hU₁]
+  simp
+
+/-- Transported refinement preserves the total sector trace of every
+one-site BNT bond contraction.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1955--1980. -/
+theorem transportedVerticalSectorT_trace_of_source_generated
+    {g₁ g₂ d D : ℕ}
+    (dim₁ mult₁ : Fin g₁ → ℕ)
+    (weight₁ : (α : Fin g₁) → Fin (mult₁ α) → ℂ)
+    (dim₂ mult₂ : Fin g₂ → ℕ)
+    (weight₂ : (β : Fin g₂) → Fin (mult₂ β) → ℂ)
+    (hMult₁ : ∀ α, 0 < mult₁ α)
+    (hWeight₁ : ∀ α q, (0 : ℂ) < weight₁ α q)
+    (M : MPOTensor d D)
+    (A₁ : (α : Fin g₁) → MPSTensor (D * D) (dim₁ α))
+    (A₂ : (β : Fin g₂) → MPSTensor (D * D) (dim₂ β))
+    (U₁ : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g₁, mult₁ α), verticalCopyDim dim₁ mult₁ q))
+      (Fin d) ℂ)
+    (hU₁ : U₁ * U₁ᴴ = 1)
+    (U₂ : Matrix
+      (Fin (∑ q : Fin (∑ β : Fin g₂, mult₂ β), verticalCopyDim dim₂ mult₂ q))
+      (Fin (d * d)) ℂ)
+    (hU₂ : U₂ * U₂ᴴ = 1)
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
+    (hTTP : IsKrausCPTP T)
+    (hReconstruct₁ : ∀ ab, verticalTensor M ab =
+      U₁ᴴ * verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab * U₁)
+    (hReconstruct₂ : ∀ ab, verticalTensor (blockTwo M) ab =
+      U₂ᴴ * verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab * U₂)
+    (X : Matrix (Fin D) (Fin D) ℂ)
+    (hT : T (physClose1 M X) = physClose2 M X) :
+    verticalSectorTrace
+        (transportedVerticalSectorT dim₁ mult₁ weight₁ dim₂ mult₂ U₁ U₂ T
+          (fun α => verticalMultiplicityTrace weight₁ α •
+            MPSTensor.contractBondMatrix (A₁ α) X)) =
+      verticalSectorTrace
+        (fun α => verticalMultiplicityTrace weight₁ α •
+          MPSTensor.contractBondMatrix (A₁ α) X) := by
+  rw [verticalSectorTrace_transportedVerticalSectorT]
+  rw [Matrix.trace_mul_cycle]
+  rw [precompressionVerticalSectorT_image_preservation
+    dim₁ mult₁ weight₁ dim₂ mult₂ weight₂ hMult₁ hWeight₁ M A₁ A₂ U₁ U₂
+      hU₂ T hReconstruct₁ hReconstruct₂ X hT]
+  exact trace_precompressionVerticalSectorT dim₁ mult₁ weight₁ hMult₁ hWeight₁
+    U₁ hU₁ T hTTP _
+
+/-- Transported coarse-graining preserves the total sector trace of every
+two-site BNT bond contraction.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1955--1980. -/
+theorem transportedVerticalSectorS_trace_of_source_generated
+    {g₁ g₂ d D : ℕ}
+    (dim₁ mult₁ : Fin g₁ → ℕ)
+    (weight₁ : (α : Fin g₁) → Fin (mult₁ α) → ℂ)
+    (dim₂ mult₂ : Fin g₂ → ℕ)
+    (weight₂ : (β : Fin g₂) → Fin (mult₂ β) → ℂ)
+    (hMult₂ : ∀ β, 0 < mult₂ β)
+    (hWeight₂ : ∀ β q, (0 : ℂ) < weight₂ β q)
+    (M : MPOTensor d D)
+    (A₁ : (α : Fin g₁) → MPSTensor (D * D) (dim₁ α))
+    (A₂ : (β : Fin g₂) → MPSTensor (D * D) (dim₂ β))
+    (U₁ : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g₁, mult₁ α), verticalCopyDim dim₁ mult₁ q))
+      (Fin d) ℂ)
+    (hU₁ : U₁ * U₁ᴴ = 1)
+    (U₂ : Matrix
+      (Fin (∑ q : Fin (∑ β : Fin g₂, mult₂ β), verticalCopyDim dim₂ mult₂ q))
+      (Fin (d * d)) ℂ)
+    (hU₂ : U₂ * U₂ᴴ = 1)
+    (S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d) (Fin d) ℂ)
+    (hSTP : IsKrausCPTP S)
+    (hReconstruct₁ : ∀ ab, verticalTensor M ab =
+      U₁ᴴ * verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab * U₁)
+    (hReconstruct₂ : ∀ ab, verticalTensor (blockTwo M) ab =
+      U₂ᴴ * verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab * U₂)
+    (X : Matrix (Fin D) (Fin D) ℂ)
+    (hS : S (physClose2 M X) = physClose1 M X) :
+    verticalSectorTrace
+        (transportedVerticalSectorS dim₁ mult₁ dim₂ mult₂ weight₂ U₁ U₂ S
+          (fun β => verticalMultiplicityTrace weight₂ β •
+            MPSTensor.contractBondMatrix (A₂ β) X)) =
+      verticalSectorTrace
+        (fun β => verticalMultiplicityTrace weight₂ β •
+          MPSTensor.contractBondMatrix (A₂ β) X) := by
+  rw [verticalSectorTrace_transportedVerticalSectorS]
+  rw [Matrix.trace_mul_cycle]
+  rw [precompressionVerticalSectorS_image_preservation
+    dim₁ mult₁ weight₁ dim₂ mult₂ weight₂ hMult₂ hWeight₂ M A₁ A₂ U₁ hU₁
+      U₂ S hReconstruct₁ hReconstruct₂ X hS]
+  exact trace_precompressionVerticalSectorS dim₂ mult₂ weight₂ hMult₂ hWeight₂
+    U₂ hU₂ S hSTP _
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/VerticalSectorTraceLoss.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorTraceLoss.lean
@@ -467,12 +467,9 @@ theorem transportedVerticalSectorT_trace_le
 exactly when its precompression output is supported on `U₂ᴴ * U₂`.
 
 Appendix C.4, lines 1955--1980 of arXiv:1606.00608 supplies the transported
-map used here.
-
-**Local fix (zero-sector complement):** Rectangular vertical coordinates may
-discard a zero-sector complement.  The support criterion below identifies
-exactly when no trace is lost.  This obstruction and the image-preservation
-condition that eliminates it are recorded in
+map used here.  On the bond contractions of the vertical canonical forms, the
+source-generated image-preservation result proves that the precompression
+output is supported on the active sector.  Its scope is documented in
 `docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex`. -/
 theorem transportedVerticalSectorT_trace_eq_iff
     {g₁ g₂ d : ℕ}
@@ -554,12 +551,9 @@ theorem transportedVerticalSectorS_trace_le
 family exactly when its precompression output is supported on `U₁ᴴ * U₁`.
 
 Appendix C.4, lines 1955--1980 of arXiv:1606.00608 supplies the transported
-map used here.
-
-**Local fix (zero-sector complement):** Rectangular vertical coordinates may
-discard a zero-sector complement.  The support criterion below identifies
-exactly when no trace is lost.  This obstruction and the image-preservation
-condition that eliminates it are recorded in
+map used here.  On the bond contractions of the vertical canonical forms, the
+source-generated image-preservation result proves that the precompression
+output is supported on the active sector.  Its scope is documented in
 `docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex`. -/
 theorem transportedVerticalSectorS_trace_eq_iff
     {g₁ g₂ d : ℕ}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -1207,6 +1207,116 @@ physical indices, as in
     $\operatorname{tr}((1-P)Z)=0$, hence to $(1-P)Z=0$.
 \end{proof}
 
+\begin{theorem}[Active-sector support on vertical bond contractions]
+    \label{thm:mpdo_vertical_sector_source_image_preservation}
+    \lean{MPOTensor.precompressionVerticalSectorT_image_preservation}
+    \lean{MPOTensor.precompressionVerticalSectorS_image_preservation}
+    \lean{MPOTensor.transportedVerticalSectorT_trace_of_source_generated}
+    \lean{MPOTensor.transportedVerticalSectorS_trace_of_source_generated}
+    \leanok
+    \uses{lem:mpdo_normalized_retained_vertical_sector_embedding,
+        lem:mpdo_retained_vertical_weighted_contraction,
+        lem:mpdo_vertical_bond_contraction_reconstruction,
+        thm:mpdo_one_site_closure_two_site_blocking,
+        lem:mpdo_vertical_sector_precompression_positive_trace}
+    Suppose that the one-site and two-site vertical canonical forms have
+    diagonal multiplicity matrices $\mu_\alpha$ and $\nu_\beta$, with every
+    multiplicity space nonzero and every diagonal entry strictly positive,
+    and coordinate coisometries $U_1,U_2$.  Write
+    $m_\alpha=\operatorname{tr}(\mu_\alpha)$ and
+    $n_\beta=\operatorname{tr}(\nu_\beta)$.  For a bond matrix $X$, write
+    $\mathcal M^{(1)}(X)$ and $\mathcal M^{(2)}(X)$ for the one-site and
+    two-site physical closures, and set
+    \[
+        x(X)=\bigoplus_\alpha m_\alpha M_\alpha(X),
+        \qquad
+        y(X)=\bigoplus_\beta n_\beta A_\beta(X).
+    \]
+    If the physical refinement and coarse-graining maps satisfy
+    \[
+        T(\mathcal M^{(1)}(X))=\mathcal M^{(2)}(X),
+        \qquad
+        S(\mathcal M^{(2)}(X))=\mathcal M^{(1)}(X),
+    \]
+    then the corresponding matrices before the final compression obey
+    \[
+        U_2^\dagger U_2 Z_T(x(X))=Z_T(x(X)),
+        \qquad
+        U_1^\dagger U_1 Z_S(y(X))=Z_S(y(X)).
+    \]
+    If $T$ and $S$ are completely positive and trace preserving, then
+    \[
+        \Trsec(\widetilde T(x(X)))=\Trsec(x(X)),
+        \qquad
+        \Trsec(\widetilde S(y(X)))=\Trsec(y(X)).
+    \]
+    These assertions concern the vertical bond-contraction families in
+    \cite[Appendix~C.4, lines~1955--1980]{Cirac2016MPDO_arXiv}; they make no
+    assertion for arbitrary positive elements of the sector algebras.
+\end{theorem}
+
+\begin{proof}\leanok
+    Put
+    \[
+        B_1(X)=\bigoplus_\alpha\mu_\alpha\otimes M_\alpha(X),
+        \qquad
+        B_2(X)=\bigoplus_\beta\nu_\beta\otimes A_\beta(X).
+    \]
+    Since $m_\alpha=\operatorname{tr}(\mu_\alpha)$ and
+    $n_\beta=\operatorname{tr}(\nu_\beta)$, the normalized embeddings satisfy
+    \[
+        R_\mu(x(X))=B_1(X),
+        \qquad
+        R_\nu(y(X))=B_2(X).
+    \]
+    The two reconstruction identities are
+    \[
+        \mathcal M^{(1)}(X)=U_1^\dagger B_1(X)U_1,
+        \qquad
+        \mathcal M^{(2)}(X)=U_2^\dagger B_2(X)U_2.
+    \]
+    Applying $T$, the physical refinement identity, and the second
+    reconstruction identity gives
+    \[
+        Z_T(x(X))
+          =U_2^\dagger B_2(X)U_2.
+    \]
+    Hence
+    \[
+    \begin{aligned}
+        U_2^\dagger U_2 Z_T(x(X))
+          &=U_2^\dagger(U_2U_2^\dagger)B_2(X)U_2 \\
+          &=U_2^\dagger B_2(X)U_2
+           =Z_T(x(X)).
+    \end{aligned}
+    \]
+    Here the second equality uses $U_2U_2^\dagger=1$.  Interchanging the two
+    canonical forms gives
+    \[
+    \begin{aligned}
+        U_1^\dagger U_1 Z_S(y(X))
+          &=U_1^\dagger(U_1U_1^\dagger)B_1(X)U_1 \\
+          &=U_1^\dagger B_1(X)U_1
+           =Z_S(y(X)).
+    \end{aligned}
+    \]
+    Finally, the precompression trace identities and cyclicity give
+    \[
+    \begin{aligned}
+      \Trsec(\widetilde T(x(X)))
+        &=\operatorname{tr}(U_2 Z_T(x(X))U_2^\dagger)
+         =\operatorname{tr}(U_2^\dagger U_2 Z_T(x(X))) \\
+        &=\operatorname{tr}(Z_T(x(X)))
+         =\Trsec(x(X)), \\
+      \Trsec(\widetilde S(y(X)))
+        &=\operatorname{tr}(U_1 Z_S(y(X))U_1^\dagger)
+         =\operatorname{tr}(U_1^\dagger U_1 Z_S(y(X))) \\
+        &=\operatorname{tr}(Z_S(y(X)))
+         =\Trsec(y(X)).
+    \end{aligned}
+    \]
+\end{proof}
+
 \begin{theorem}[Action of the normalized vertical-sector maps]
     \label{thm:mpdo_transported_vertical_sector_maps}
     \lean{MPOTensor.transportedVerticalSectorT_trace_smul}

--- a/docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex
@@ -151,12 +151,46 @@ image-preservation statements
 The displayed identities of Appendix~C.4 establish the required action on
 the weighted sector operators arising from the canonical forms; they do not,
 by themselves, establish \eqref{eq:transported-image-preservation} for every
-element of the finite products.  The elimination plan is therefore to prove
-\eqref{eq:transported-image-preservation} for each source-generated family
-where trace preservation is used.  The support criterion above then yields
-trace equality on precisely that family.  No global trace-preserving
-extension, complete-positivity assertion for the finite products, or inverse
-relation is needed for this step.
+element of the finite products.  The calculation below proves
+\eqref{eq:transported-image-preservation} on precisely the vertical
+bond-contraction families used in the source.  The support criterion then
+yields trace equality on those families.  This argument requires no global
+trace-preserving extension, complete-positivity assertion for the finite
+products, or inverse relation.
+
+For a horizontal bond matrix $X$, set
+\begin{equation}
+  x(X)=\bigoplus_\alpha m_\alpha M_\alpha(X),
+  \qquad
+  y(X)=\bigoplus_\beta n_\beta A_\beta(X).
+  \label{eq:source-contraction-families}
+\end{equation}
+The physical refinement identity and the two vertical reconstruction
+identities give
+\begin{equation}
+  Z_T(x(X))
+   =U_2^\dagger\left(
+      \bigoplus_\beta\nu_\beta\otimes A_\beta(X)
+    \right)U_2.
+  \label{eq:refinement-precompression-reconstruction}
+\end{equation}
+Since $U_2U_2^\dagger=1$, equation
+\eqref{eq:refinement-precompression-reconstruction} implies
+$P_2Z_T(x(X))=Z_T(x(X))$.  The coarse-graining identity gives symmetrically
+$P_1Z_S(y(X))=Z_S(y(X))$.  Hence the trace criteria
+\eqref{eq:refinement-trace-loss} and \eqref{eq:coarse-trace-loss} yield
+\begin{equation}
+  \operatorname{Tr}_{\mathrm{sec}}(\widetilde T(x(X)))
+    =\operatorname{Tr}_{\mathrm{sec}}(x(X)),
+  \qquad
+  \operatorname{Tr}_{\mathrm{sec}}(\widetilde S(y(X)))
+    =\operatorname{Tr}_{\mathrm{sec}}(y(X)).
+  \label{eq:source-contraction-trace-preservation}
+\end{equation}
+This proves the image-preservation step used at source lines~1955--1980.
+It does not extend \eqref{eq:transported-image-preservation} to arbitrary
+positive elements, nor does it assert that the transported maps are inverse
+on the full sector algebras.
 
 \section{Formal correction}
 


### PR DESCRIPTION
## Mathematical result

For every horizontal bond matrix, the precompression output of the transported refinement map on the weighted one-site vertical BNT contraction lies in the active two-site sector. The symmetric statement holds for transported coarse-graining. The coisometric compression criteria then give preservation of total sector trace on these two contraction families.

The proof expands the normalized sector embedding, identifies it with the contracted vertical canonical form, applies the physical refinement or coarse-graining identity, and reconstructs the output as a matrix of the form `Uᴴ * B * U`. The identity `U * Uᴴ = 1` then gives active-sector support.

Source: arXiv:1606.00608, Appendix C.4, lines 1955–1980.

## Scope and faithfulness

The new statements quantify explicitly over the canonical-form bond contractions. They do not assert image preservation or trace preservation for arbitrary positive sector families, do not equip the finite products with a new complete-positivity structure, and do not assert that the transported maps are inverse. In particular, this PR does not claim #4120. Tracking issues #3949 and #232 remain open.

The paper-gap note now records the completed source-generated case and retains the distinction from the unproved full-algebra statement. The two equality-criterion docstrings no longer carry the temporary Local fix markers. The blueprint contains the source-faithful support and trace statement with `\leanok` tags.

## Validation

- `lake env lean TNLean/MPS/MPDO/VerticalSectorImagePreservation.lean`
- `lake build TNLean` — 9,554 jobs passed
- `lake exe checkdecls blueprint/lean_decls`
- blueprint–Lean synchronization and reader-facing prose checks
- changed-file proof-integrity, line-length, and diff checks
- kernel axiom audit: only `propext`, `Classical.choice`, and `Quot.sound`

Closes #4136

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formal proofs and documentation in the MPDO vertical-sector track; no auth, runtime, or data-path changes. Scope is explicitly limited to source-generated contraction families.
> 
> **Overview**
> Adds **`VerticalSectorImagePreservation.lean`** with Lean proofs that, on **vertical canonical-form bond contractions**, precompression outputs for transported refinement/coarse-graining sit in the **active sector** (`Uᴴ U` fixed point), and under CPTP physical maps the transported sector maps **preserve total sector trace** on those families—not on arbitrary positive sector elements.
> 
> The proofs chain normalized embedding, vertical reconstruction, and the physical `T`/`S` identities with coisometry `U Uᴴ = 1`. **`VerticalSectorTraceLoss`** docstrings now cite this module instead of temporary “local fix” wording. The **blueprint** gains theorem `thm:mpdo_vertical_sector_source_image_preservation` with `\leanok` links, and the **paper-gap note** records the completed source-generated case while keeping full-algebra image preservation open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3380dc8a2d5ff72dc6b7ce5a4ba05ebfea0851b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->