### PR TITLE
feat(MPS/MPDO): preserve generated vertical-sector images

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -449,6 +449,7 @@ import TNLean.MPS.MPDO.VerticalMapTransport
 import TNLean.MPS.MPDO.VerticalSectorCoordinates
 import TNLean.MPS.MPDO.VerticalSectorFixedGenerators
 import TNLean.MPS.MPDO.VerticalSectorTraceLoss
+import TNLean.MPS.MPDO.VerticalSectorImagePreservation
 import TNLean.MPS.MPDO.VerticalSectorGeneration
 import TNLean.MPS.MPDO.PRFP
 import TNLean.MPS.MPDO.LocalPurificationRFP

--- a/TNLean/MPS/MPDO/VerticalSectorImagePreservation.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorImagePreservation.lean
@@ -1,0 +1,227 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.VerticalSectorTraceLoss
+
+/-!
+# Image preservation for transported vertical-sector maps
+
+The precompression outputs of the transported refinement and coarse-graining
+maps lie in the active vertical sectors when their inputs are the bond
+contractions of the corresponding vertical canonical forms.  Consequently
+the transported maps preserve total sector trace on these source-generated
+families.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Appendix C.4, lines 1955--1980.
+-/
+
+open scoped Matrix ComplexOrder
+
+noncomputable section
+
+namespace MPOTensor
+
+/-- The matrix before the final two-site compression lies in the active
+two-site sector for every one-site BNT bond contraction.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1955--1980. -/
+lemma precompressionVerticalSectorT_image_preservation
+    {g₁ g₂ d D : ℕ}
+    (dim₁ mult₁ : Fin g₁ → ℕ)
+    (weight₁ : (α : Fin g₁) → Fin (mult₁ α) → ℂ)
+    (dim₂ mult₂ : Fin g₂ → ℕ)
+    (weight₂ : (β : Fin g₂) → Fin (mult₂ β) → ℂ)
+    (hMult₁ : ∀ α, 0 < mult₁ α)
+    (hWeight₁ : ∀ α q, (0 : ℂ) < weight₁ α q)
+    (M : MPOTensor d D)
+    (A₁ : (α : Fin g₁) → MPSTensor (D * D) (dim₁ α))
+    (A₂ : (β : Fin g₂) → MPSTensor (D * D) (dim₂ β))
+    (U₁ : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g₁, mult₁ α), verticalCopyDim dim₁ mult₁ q))
+      (Fin d) ℂ)
+    (U₂ : Matrix
+      (Fin (∑ q : Fin (∑ β : Fin g₂, mult₂ β), verticalCopyDim dim₂ mult₂ q))
+      (Fin (d * d)) ℂ)
+    (hU₂ : U₂ * U₂ᴴ = 1)
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
+    (hReconstruct₁ : ∀ ab, verticalTensor M ab =
+      U₁ᴴ * verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab * U₁)
+    (hReconstruct₂ : ∀ ab, verticalTensor (blockTwo M) ab =
+      U₂ᴴ * verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab * U₂)
+    (X : Matrix (Fin D) (Fin D) ℂ)
+    (hT : T (physClose1 M X) = physClose2 M X) :
+    U₂ᴴ * U₂ * precompressionVerticalSectorT dim₁ mult₁ weight₁ U₁ T
+        (fun α => verticalMultiplicityTrace weight₁ α •
+          MPSTensor.contractBondMatrix (A₁ α) X) =
+      precompressionVerticalSectorT dim₁ mult₁ weight₁ U₁ T
+        (fun α => verticalMultiplicityTrace weight₁ α •
+          MPSTensor.contractBondMatrix (A₁ α) X) := by
+  unfold precompressionVerticalSectorT
+  rw [normalizedRetainedVerticalSectorEmbedding_trace_smul
+    dim₁ mult₁ weight₁ hMult₁ hWeight₁]
+  rw [← contractBondMatrix_verticalAssembledTensor_eq_sectorBlockDiagonal]
+  rw [singleKrausMap_apply, Matrix.conjTranspose_conjTranspose]
+  rw [← physClose1_eq_of_vertical_reconstruction M
+    (verticalAssembledTensor dim₁ mult₁ weight₁ A₁) U₁ hReconstruct₁ X]
+  rw [hT]
+  rw [physClose2_eq_physClose1_blockTwo_apply]
+  rw [physClose1_eq_of_vertical_reconstruction (blockTwo M)
+    (verticalAssembledTensor dim₂ mult₂ weight₂ A₂) U₂ hReconstruct₂ X]
+  simp only [Matrix.mul_assoc]
+  rw [← Matrix.mul_assoc U₂ U₂ᴴ]
+  rw [hU₂]
+  simp
+
+/-- The matrix before the final one-site compression lies in the active
+one-site sector for every two-site BNT bond contraction.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1955--1980. -/
+lemma precompressionVerticalSectorS_image_preservation
+    {g₁ g₂ d D : ℕ}
+    (dim₁ mult₁ : Fin g₁ → ℕ)
+    (weight₁ : (α : Fin g₁) → Fin (mult₁ α) → ℂ)
+    (dim₂ mult₂ : Fin g₂ → ℕ)
+    (weight₂ : (β : Fin g₂) → Fin (mult₂ β) → ℂ)
+    (hMult₂ : ∀ β, 0 < mult₂ β)
+    (hWeight₂ : ∀ β q, (0 : ℂ) < weight₂ β q)
+    (M : MPOTensor d D)
+    (A₁ : (α : Fin g₁) → MPSTensor (D * D) (dim₁ α))
+    (A₂ : (β : Fin g₂) → MPSTensor (D * D) (dim₂ β))
+    (U₁ : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g₁, mult₁ α), verticalCopyDim dim₁ mult₁ q))
+      (Fin d) ℂ)
+    (hU₁ : U₁ * U₁ᴴ = 1)
+    (U₂ : Matrix
+      (Fin (∑ q : Fin (∑ β : Fin g₂, mult₂ β), verticalCopyDim dim₂ mult₂ q))
+      (Fin (d * d)) ℂ)
+    (S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d) (Fin d) ℂ)
+    (hReconstruct₁ : ∀ ab, verticalTensor M ab =
+      U₁ᴴ * verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab * U₁)
+    (hReconstruct₂ : ∀ ab, verticalTensor (blockTwo M) ab =
+      U₂ᴴ * verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab * U₂)
+    (X : Matrix (Fin D) (Fin D) ℂ)
+    (hS : S (physClose2 M X) = physClose1 M X) :
+    U₁ᴴ * U₁ * precompressionVerticalSectorS dim₂ mult₂ weight₂ U₂ S
+        (fun β => verticalMultiplicityTrace weight₂ β •
+          MPSTensor.contractBondMatrix (A₂ β) X) =
+      precompressionVerticalSectorS dim₂ mult₂ weight₂ U₂ S
+        (fun β => verticalMultiplicityTrace weight₂ β •
+          MPSTensor.contractBondMatrix (A₂ β) X) := by
+  unfold precompressionVerticalSectorS
+  rw [normalizedRetainedVerticalSectorEmbedding_trace_smul
+    dim₂ mult₂ weight₂ hMult₂ hWeight₂]
+  rw [← contractBondMatrix_verticalAssembledTensor_eq_sectorBlockDiagonal]
+  rw [singleKrausMap_apply, Matrix.conjTranspose_conjTranspose]
+  rw [← physClose1_eq_of_vertical_reconstruction (blockTwo M)
+    (verticalAssembledTensor dim₂ mult₂ weight₂ A₂) U₂ hReconstruct₂ X]
+  rw [physClose1_blockTwo_eq_physClose2_apply]
+  rw [hS]
+  rw [physClose1_eq_of_vertical_reconstruction M
+    (verticalAssembledTensor dim₁ mult₁ weight₁ A₁) U₁ hReconstruct₁ X]
+  simp only [Matrix.mul_assoc]
+  rw [← Matrix.mul_assoc U₁ U₁ᴴ]
+  rw [hU₁]
+  simp
+
+/-- Transported refinement preserves the total sector trace of every
+one-site BNT bond contraction.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1955--1980. -/
+lemma transportedVerticalSectorT_trace_of_source_generated
+    {g₁ g₂ d D : ℕ}
+    (dim₁ mult₁ : Fin g₁ → ℕ)
+    (weight₁ : (α : Fin g₁) → Fin (mult₁ α) → ℂ)
+    (dim₂ mult₂ : Fin g₂ → ℕ)
+    (weight₂ : (β : Fin g₂) → Fin (mult₂ β) → ℂ)
+    (hMult₁ : ∀ α, 0 < mult₁ α)
+    (hWeight₁ : ∀ α q, (0 : ℂ) < weight₁ α q)
+    (M : MPOTensor d D)
+    (A₁ : (α : Fin g₁) → MPSTensor (D * D) (dim₁ α))
+    (A₂ : (β : Fin g₂) → MPSTensor (D * D) (dim₂ β))
+    (U₁ : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g₁, mult₁ α), verticalCopyDim dim₁ mult₁ q))
+      (Fin d) ℂ)
+    (hU₁ : U₁ * U₁ᴴ = 1)
+    (U₂ : Matrix
+      (Fin (∑ q : Fin (∑ β : Fin g₂, mult₂ β), verticalCopyDim dim₂ mult₂ q))
+      (Fin (d * d)) ℂ)
+    (hU₂ : U₂ * U₂ᴴ = 1)
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
+    (hTTP : IsKrausCPTP T)
+    (hReconstruct₁ : ∀ ab, verticalTensor M ab =
+      U₁ᴴ * verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab * U₁)
+    (hReconstruct₂ : ∀ ab, verticalTensor (blockTwo M) ab =
+      U₂ᴴ * verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab * U₂)
+    (X : Matrix (Fin D) (Fin D) ℂ)
+    (hT : T (physClose1 M X) = physClose2 M X) :
+    verticalSectorTrace
+        (transportedVerticalSectorT dim₁ mult₁ weight₁ dim₂ mult₂ U₁ U₂ T
+          (fun α => verticalMultiplicityTrace weight₁ α •
+            MPSTensor.contractBondMatrix (A₁ α) X)) =
+      verticalSectorTrace
+        (fun α => verticalMultiplicityTrace weight₁ α •
+          MPSTensor.contractBondMatrix (A₁ α) X) := by
+  rw [verticalSectorTrace_transportedVerticalSectorT]
+  rw [Matrix.trace_mul_cycle]
+  rw [precompressionVerticalSectorT_image_preservation
+    dim₁ mult₁ weight₁ dim₂ mult₂ weight₂ hMult₁ hWeight₁ M A₁ A₂ U₁ U₂
+      hU₂ T hReconstruct₁ hReconstruct₂ X hT]
+  exact trace_precompressionVerticalSectorT dim₁ mult₁ weight₁ hMult₁ hWeight₁
+    U₁ hU₁ T hTTP _
+
+/-- Transported coarse-graining preserves the total sector trace of every
+two-site BNT bond contraction.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1955--1980. -/
+lemma transportedVerticalSectorS_trace_of_source_generated
+    {g₁ g₂ d D : ℕ}
+    (dim₁ mult₁ : Fin g₁ → ℕ)
+    (weight₁ : (α : Fin g₁) → Fin (mult₁ α) → ℂ)
+    (dim₂ mult₂ : Fin g₂ → ℕ)
+    (weight₂ : (β : Fin g₂) → Fin (mult₂ β) → ℂ)
+    (hMult₂ : ∀ β, 0 < mult₂ β)
+    (hWeight₂ : ∀ β q, (0 : ℂ) < weight₂ β q)
+    (M : MPOTensor d D)
+    (A₁ : (α : Fin g₁) → MPSTensor (D * D) (dim₁ α))
+    (A₂ : (β : Fin g₂) → MPSTensor (D * D) (dim₂ β))
+    (U₁ : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g₁, mult₁ α), verticalCopyDim dim₁ mult₁ q))
+      (Fin d) ℂ)
+    (hU₁ : U₁ * U₁ᴴ = 1)
+    (U₂ : Matrix
+      (Fin (∑ q : Fin (∑ β : Fin g₂, mult₂ β), verticalCopyDim dim₂ mult₂ q))
+      (Fin (d * d)) ℂ)
+    (hU₂ : U₂ * U₂ᴴ = 1)
+    (S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d) (Fin d) ℂ)
+    (hSTP : IsKrausCPTP S)
+    (hReconstruct₁ : ∀ ab, verticalTensor M ab =
+      U₁ᴴ * verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab * U₁)
+    (hReconstruct₂ : ∀ ab, verticalTensor (blockTwo M) ab =
+      U₂ᴴ * verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab * U₂)
+    (X : Matrix (Fin D) (Fin D) ℂ)
+    (hS : S (physClose2 M X) = physClose1 M X) :
+    verticalSectorTrace
+        (transportedVerticalSectorS dim₁ mult₁ dim₂ mult₂ weight₂ U₁ U₂ S
+          (fun β => verticalMultiplicityTrace weight₂ β •
+            MPSTensor.contractBondMatrix (A₂ β) X)) =
+      verticalSectorTrace
+        (fun β => verticalMultiplicityTrace weight₂ β •
+          MPSTensor.contractBondMatrix (A₂ β) X) := by
+  rw [verticalSectorTrace_transportedVerticalSectorS]
+  rw [Matrix.trace_mul_cycle]
+  rw [precompressionVerticalSectorS_image_preservation
+    dim₁ mult₁ weight₁ dim₂ mult₂ weight₂ hMult₂ hWeight₂ M A₁ A₂ U₁
+      hU₁ U₂ S hReconstruct₁ hReconstruct₂ X hS]
+  exact trace_precompressionVerticalSectorS dim₂ mult₂ weight₂ hMult₂ hWeight₂
+    U₂ hU₂ S hSTP _
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/VerticalSectorTraceLoss.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorTraceLoss.lean
@@ -467,13 +467,7 @@ theorem transportedVerticalSectorT_trace_le
 exactly when its precompression output is supported on `U₂ᴴ * U₂`.
 
 Appendix C.4, lines 1955--1980 of arXiv:1606.00608 supplies the transported
-map used here.
-
-**Local fix (zero-sector complement):** Rectangular vertical coordinates may
-discard a zero-sector complement.  The support criterion below identifies
-exactly when no trace is lost.  This obstruction and the image-preservation
-condition that eliminates it are recorded in
-`docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex`. -/
+map used here. -/
 theorem transportedVerticalSectorT_trace_eq_iff
     {g₁ g₂ d : ℕ}
     (dim₁ mult₁ : Fin g₁ → ℕ)
@@ -554,13 +548,7 @@ theorem transportedVerticalSectorS_trace_le
 family exactly when its precompression output is supported on `U₁ᴴ * U₁`.
 
 Appendix C.4, lines 1955--1980 of arXiv:1606.00608 supplies the transported
-map used here.
-
-**Local fix (zero-sector complement):** Rectangular vertical coordinates may
-discard a zero-sector complement.  The support criterion below identifies
-exactly when no trace is lost.  This obstruction and the image-preservation
-condition that eliminates it are recorded in
-`docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex`. -/
+map used here. -/
 theorem transportedVerticalSectorS_trace_eq_iff
     {g₁ g₂ d : ℕ}
     (dim₁ mult₁ : Fin g₁ → ℕ)

--- a/TNLean/MPS/MPDO/VerticalSectorTraceLoss.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorTraceLoss.lean
@@ -467,7 +467,14 @@ theorem transportedVerticalSectorT_trace_le
 exactly when its precompression output is supported on `U₂ᴴ * U₂`.
 
 Appendix C.4, lines 1955--1980 of arXiv:1606.00608 supplies the transported
-map used here. -/
+map used here.
+
+**Local fix (zero-sector complement):** Rectangular vertical coordinates may
+discard a zero-sector complement.  The support criterion below identifies
+exactly when no trace is lost for an arbitrary positive sector family.  The
+obstruction is eliminated for the source-generated family in
+`VerticalSectorImagePreservation.lean` and is documented in
+`docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex`. -/
 theorem transportedVerticalSectorT_trace_eq_iff
     {g₁ g₂ d : ℕ}
     (dim₁ mult₁ : Fin g₁ → ℕ)
@@ -548,7 +555,14 @@ theorem transportedVerticalSectorS_trace_le
 family exactly when its precompression output is supported on `U₁ᴴ * U₁`.
 
 Appendix C.4, lines 1955--1980 of arXiv:1606.00608 supplies the transported
-map used here. -/
+map used here.
+
+**Local fix (zero-sector complement):** Rectangular vertical coordinates may
+discard a zero-sector complement.  The support criterion below identifies
+exactly when no trace is lost for an arbitrary positive sector family.  The
+obstruction is eliminated for the source-generated family in
+`VerticalSectorImagePreservation.lean` and is documented in
+`docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex`. -/
 theorem transportedVerticalSectorS_trace_eq_iff
     {g₁ g₂ d : ℕ}
     (dim₁ mult₁ : Fin g₁ → ℕ)

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -1209,6 +1209,136 @@ physical indices, as in
     $\operatorname{tr}((1-P)Z)=0$, hence to $(1-P)Z=0$.
 \end{proof}
 
+\begin{lemma}[Two-site support after refinement]
+    \label{lem:mpdo_vertical_sector_t_image_preservation}
+    \lean{MPOTensor.precompressionVerticalSectorT_image_preservation}
+    \leanok
+    \uses{def:mpdo_vertical_sector_precompression,
+      lem:mpdo_normalized_retained_vertical_sector_embedding,
+      lem:mpdo_retained_vertical_weighted_contraction,
+      lem:mpdo_vertical_bond_contraction_reconstruction,
+      thm:mpdo_one_site_closure_two_site_blocking}
+    For a bond matrix $X$, set
+    \[
+        V_1(X)=\bigoplus_\alpha m_\alpha M_\alpha(X).
+    \]
+    Suppose that both vertical canonical forms satisfy their exact
+    reconstruction identities, the one-site multiplicity spaces are nonzero,
+    their diagonal weights are positive,
+    $T(\mathcal M^{(1)}(X))=\mathcal M^{(2)}(X)$, and
+    $U_2U_2^\dagger=1$, then
+    \[
+        U_2^\dagger U_2 Z_T(V_1(X))=Z_T(V_1(X)).
+    \]
+    This is the refinement support identity used in
+    \cite[Appendix~C.4, lines~1955--1980]{Cirac2016MPDO_arXiv}.
+\end{lemma}
+
+\begin{proof}\leanok
+    The normalized embedding sends $V_1(X)$ to $B_1(X)$.  The one-site
+    reconstruction, the refinement identity, the blocked-index relabelling,
+    and the two-site reconstruction give
+    \[
+        Z_T(V_1(X))=U_2^\dagger B_2(X)U_2.
+    \]
+    Therefore
+    \[
+        U_2^\dagger U_2Z_T(V_1(X))
+        =U_2^\dagger(U_2U_2^\dagger)B_2(X)U_2
+        =Z_T(V_1(X)).
+    \]
+\end{proof}
+
+\begin{lemma}[One-site support after coarse-graining]
+    \label{lem:mpdo_vertical_sector_s_image_preservation}
+    \lean{MPOTensor.precompressionVerticalSectorS_image_preservation}
+    \leanok
+    \uses{def:mpdo_vertical_sector_precompression,
+      lem:mpdo_normalized_retained_vertical_sector_embedding,
+      lem:mpdo_retained_vertical_weighted_contraction,
+      lem:mpdo_vertical_bond_contraction_reconstruction,
+      thm:mpdo_one_site_closure_two_site_blocking}
+    For a bond matrix $X$, set
+    \[
+        V_2(X)=\bigoplus_\beta n_\beta A_\beta(X).
+    \]
+    Suppose that both vertical canonical forms satisfy their exact
+    reconstruction identities, the two-site multiplicity spaces are nonzero,
+    their diagonal weights are positive,
+    $S(\mathcal M^{(2)}(X))=\mathcal M^{(1)}(X)$, and
+    $U_1U_1^\dagger=1$, then
+    \[
+        U_1^\dagger U_1 Z_S(V_2(X))=Z_S(V_2(X)).
+    \]
+    This is the coarse-graining support identity used in
+    \cite[Appendix~C.4, lines~1955--1980]{Cirac2016MPDO_arXiv}.
+\end{lemma}
+
+\begin{proof}\leanok
+    The normalized embedding sends $V_2(X)$ to $B_2(X)$.  The two-site
+    reconstruction, the blocked-index relabelling, the coarse-graining
+    identity, and the one-site reconstruction give
+    \[
+        Z_S(V_2(X))=U_1^\dagger B_1(X)U_1.
+    \]
+    Therefore
+    \[
+        U_1^\dagger U_1Z_S(V_2(X))
+        =U_1^\dagger(U_1U_1^\dagger)B_1(X)U_1
+        =Z_S(V_2(X)).
+    \]
+\end{proof}
+
+\begin{lemma}[Trace preservation on one-site canonical-form contractions]
+    \label{lem:mpdo_vertical_sector_t_source_generated_trace}
+    \lean{MPOTensor.transportedVerticalSectorT_trace_of_source_generated}
+    \leanok
+    \uses{lem:mpdo_vertical_sector_t_image_preservation,
+      lem:mpdo_vertical_sector_precompression_positive_trace,
+      thm:mpdo_transported_vertical_sector_trace_loss}
+    Under the hypotheses of Lemma~\ref{lem:mpdo_vertical_sector_t_image_preservation},
+    suppose in addition that $U_1U_1^\dagger=1$ and that $T$ is completely
+    positive and trace preserving.  Then
+    \[
+        \Trsec(\widetilde T(V_1(X)))=\Trsec(V_1(X)).
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    Cyclicity of trace and the preceding support identity give
+    \[
+        \Trsec(\widetilde T(V_1(X)))
+        =\operatorname{tr}(U_2^\dagger U_2Z_T(V_1(X)))
+        =\operatorname{tr}(Z_T(V_1(X)))
+        =\Trsec(V_1(X)).
+    \]
+\end{proof}
+
+\begin{lemma}[Trace preservation on two-site canonical-form contractions]
+    \label{lem:mpdo_vertical_sector_s_source_generated_trace}
+    \lean{MPOTensor.transportedVerticalSectorS_trace_of_source_generated}
+    \leanok
+    \uses{lem:mpdo_vertical_sector_s_image_preservation,
+      lem:mpdo_vertical_sector_precompression_positive_trace,
+      thm:mpdo_transported_vertical_sector_trace_loss}
+    Under the hypotheses of Lemma~\ref{lem:mpdo_vertical_sector_s_image_preservation},
+    suppose in addition that $U_2U_2^\dagger=1$ and that $S$ is completely
+    positive and trace preserving.  Then
+    \[
+        \Trsec(\widetilde S(V_2(X)))=\Trsec(V_2(X)).
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    Cyclicity of trace and the preceding support identity give
+    \[
+        \Trsec(\widetilde S(V_2(X)))
+        =\operatorname{tr}(U_1^\dagger U_1Z_S(V_2(X)))
+        =\operatorname{tr}(Z_S(V_2(X)))
+        =\Trsec(V_2(X)).
+    \]
+\end{proof}
+
 \begin{theorem}[Action of the normalized vertical-sector maps]
     \label{thm:mpdo_transported_vertical_sector_maps}
     \lean{MPOTensor.transportedVerticalSectorT_trace_smul}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -1235,16 +1235,21 @@ physical indices, as in
 \end{lemma}
 
 \begin{proof}\leanok
+    Let $\mathcal R^{-1}$ relabel a matrix indexed by two one-site indices as
+    a matrix indexed by the blocked two-site index.  Then
     \[
         Z_T(V_1(X))
-        =T\!\left(U_1^\dagger B_1(X)U_1\right)
-        =T\!\left(\mathcal M^{(1)}(X)\right)
-        =\mathcal M^{(2)}(X)
+        =\mathcal R^{-1}\!\left[
+          T\!\left(U_1^\dagger B_1(X)U_1\right)\right]
+        =\mathcal R^{-1}\!\left[
+          T\!\left(\mathcal M^{(1)}(X)\right)\right]
+        =\mathcal R^{-1}\!\left[\mathcal M^{(2)}(X)\right]
         =U_2^\dagger B_2(X)U_2.
     \]
-    Here the first equality is the normalized embedding, the second and fourth
+    Here the first equality is the normalized embedding, the second and last
     are the two reconstruction identities, and the middle equality is the
-    refinement identity after the blocked-index relabelling.
+    refinement identity.  The equality before the last is precisely the
+    blocked-index relabelling theorem.
     Therefore
     \[
         U_2^\dagger U_2Z_T(V_1(X))
@@ -1279,16 +1284,19 @@ physical indices, as in
 \end{lemma}
 
 \begin{proof}\leanok
+    Let $\mathcal R$ decode a matrix indexed by the blocked two-site index as a
+    matrix indexed by two one-site indices.  Then
     \[
         Z_S(V_2(X))
-        =S\!\left(U_2^\dagger B_2(X)U_2\right)
+        =S\!\left(\mathcal R\!\left[
+          U_2^\dagger B_2(X)U_2\right]\right)
         =S\!\left(\mathcal M^{(2)}(X)\right)
         =\mathcal M^{(1)}(X)
         =U_1^\dagger B_1(X)U_1.
     \]
-    Here the first equality is the normalized embedding, the second and fourth
-    are the two reconstruction identities, and the middle equality is the
-    coarse-graining identity after the blocked-index relabelling.
+    Here the first equality is the normalized embedding, the next equality is
+    the blocked-index relabelling theorem, the middle equality is the
+    coarse-graining identity, and the last is the one-site reconstruction.
     Therefore
     \[
         U_1^\dagger U_1Z_S(V_2(X))

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -1294,8 +1294,7 @@ physical indices, as in
     \lean{MPOTensor.transportedVerticalSectorT_trace_of_source_generated}
     \leanok
     \uses{lem:mpdo_vertical_sector_t_image_preservation,
-      lem:mpdo_vertical_sector_precompression_positive_trace,
-      thm:mpdo_transported_vertical_sector_trace_loss}
+      lem:mpdo_vertical_sector_precompression_positive_trace}
     Under the hypotheses of Lemma~\ref{lem:mpdo_vertical_sector_t_image_preservation},
     suppose in addition that $U_1U_1^\dagger=1$ and that $T$ is completely
     positive and trace preserving.  Then
@@ -1319,8 +1318,7 @@ physical indices, as in
     \lean{MPOTensor.transportedVerticalSectorS_trace_of_source_generated}
     \leanok
     \uses{lem:mpdo_vertical_sector_s_image_preservation,
-      lem:mpdo_vertical_sector_precompression_positive_trace,
-      thm:mpdo_transported_vertical_sector_trace_loss}
+      lem:mpdo_vertical_sector_precompression_positive_trace}
     Under the hypotheses of Lemma~\ref{lem:mpdo_vertical_sector_s_image_preservation},
     suppose in addition that $U_2U_2^\dagger=1$ and that $S$ is completely
     positive and trace preserving.  Then

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -1235,12 +1235,16 @@ physical indices, as in
 \end{lemma}
 
 \begin{proof}\leanok
-    The normalized embedding sends $V_1(X)$ to $B_1(X)$.  The one-site
-    reconstruction, the refinement identity, the blocked-index relabelling,
-    and the two-site reconstruction give
     \[
-        Z_T(V_1(X))=U_2^\dagger B_2(X)U_2.
+        Z_T(V_1(X))
+        =T\!\left(U_1^\dagger B_1(X)U_1\right)
+        =T\!\left(\mathcal M^{(1)}(X)\right)
+        =\mathcal M^{(2)}(X)
+        =U_2^\dagger B_2(X)U_2.
     \]
+    Here the first equality is the normalized embedding, the second and fourth
+    are the two reconstruction identities, and the middle equality is the
+    refinement identity after the blocked-index relabelling.
     Therefore
     \[
         U_2^\dagger U_2Z_T(V_1(X))
@@ -1275,12 +1279,16 @@ physical indices, as in
 \end{lemma}
 
 \begin{proof}\leanok
-    The normalized embedding sends $V_2(X)$ to $B_2(X)$.  The two-site
-    reconstruction, the blocked-index relabelling, the coarse-graining
-    identity, and the one-site reconstruction give
     \[
-        Z_S(V_2(X))=U_1^\dagger B_1(X)U_1.
+        Z_S(V_2(X))
+        =S\!\left(U_2^\dagger B_2(X)U_2\right)
+        =S\!\left(\mathcal M^{(2)}(X)\right)
+        =\mathcal M^{(1)}(X)
+        =U_1^\dagger B_1(X)U_1.
     \]
+    Here the first equality is the normalized embedding, the second and fourth
+    are the two reconstruction identities, and the middle equality is the
+    coarse-graining identity after the blocked-index relabelling.
     Therefore
     \[
         U_1^\dagger U_1Z_S(V_2(X))

--- a/docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex
@@ -5,7 +5,7 @@
 \usepackage[hidelinks]{hyperref}
 \setlength{\emergencystretch}{2em}
 
-\input{command}
+\input{./command}
 
 \title{The Vertical Canonical Form Retains Only the Nonzero Physical Sectors}
 \author{}
@@ -169,16 +169,21 @@ orientation of \eqref{eq:vertical-form}, together with
 with \eqref{eq:dimension-bound}: the retained part is represented
 rectangularly, while the omitted part is required to be zero. No full-support
 assumption is added to Proposition~4.13.  The construction of the canonical
-form from horizontal canonical form is proved by
-\path{MPOTensor.verticalCF_of_horizontalCF} in
-\path{TNLean/MPS/MPDO/VerticalCanonicalForm.lean}.  It uses this corrected
-coisometry condition.  The correction itself is tracked in \ghissue{3869}.
+form from horizontal canonical form is proved in
+\path{TNLean/MPS/MPDO/VerticalCanonicalForm.lean}.\footnote{The corresponding
+declaration is \leanid{MPOTensor.verticalCF_of_horizontalCF}.}  It uses this
+corrected coisometry condition.  The correction itself is tracked in
+\ghissue{3869}.
 
 The source-generated support identities and their trace consequences are
-proved by \path{MPOTensor.precompressionVerticalSectorT_image_preservation},
-\path{MPOTensor.precompressionVerticalSectorS_image_preservation}, and the
-two corresponding trace lemmas in
-\path{TNLean/MPS/MPDO/VerticalSectorImagePreservation.lean}.
+proved in
+\path{TNLean/MPS/MPDO/VerticalSectorImagePreservation.lean}.\footnote{The image
+identities are
+\leanid{MPOTensor.precompressionVerticalSectorT_image_preservation} and
+\leanid{MPOTensor.precompressionVerticalSectorS_image_preservation}; their
+trace consequences are
+\leanid{MPOTensor.transportedVerticalSectorT_trace_of_source_generated} and
+\leanid{MPOTensor.transportedVerticalSectorS_trace_of_source_generated}.}
 
 \paragraph{Verdict.}
 The earlier two-sided-unitary condition was a stronger statement absent from

--- a/docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex
@@ -151,12 +151,15 @@ image-preservation statements
 The displayed identities of Appendix~C.4 establish the required action on
 the weighted sector operators arising from the canonical forms; they do not,
 by themselves, establish \eqref{eq:transported-image-preservation} for every
-element of the finite products.  The elimination plan is therefore to prove
-\eqref{eq:transported-image-preservation} for each source-generated family
-where trace preservation is used.  The support criterion above then yields
-trace equality on precisely that family.  No global trace-preserving
-extension, complete-positivity assertion for the finite products, or inverse
-relation is needed for this step.
+element of the finite products.  For every virtual bond matrix~$X$, the
+source-generated families now satisfy
+\eqref{eq:transported-image-preservation}: the normalized embedding gives the
+contracted weighted direct sum, the two reconstruction identities identify
+the precompression matrix with $U_i^\dagger B_i(X)U_i$, and
+$U_iU_i^\dagger=1$ gives the support equation.  Cyclicity of trace then yields
+trace equality on these families.  No global trace-preserving extension,
+complete-positivity assertion for the finite products, or inverse relation is
+asserted.
 
 \section{Formal correction}
 
@@ -170,6 +173,12 @@ form from horizontal canonical form is proved by
 \path{MPOTensor.verticalCF_of_horizontalCF} in
 \path{TNLean/MPS/MPDO/VerticalCanonicalForm.lean}.  It uses this corrected
 coisometry condition.  The correction itself is tracked in \ghissue{3869}.
+
+The source-generated support identities and their trace consequences are
+proved by \path{MPOTensor.precompressionVerticalSectorT_image_preservation},
+\path{MPOTensor.precompressionVerticalSectorS_image_preservation}, and the
+two corresponding trace lemmas in
+\path{TNLean/MPS/MPDO/VerticalSectorImagePreservation.lean}.
 
 \paragraph{Verdict.}
 The earlier two-sided-unitary condition was a stronger statement absent from


### PR DESCRIPTION
## Mathematical content

This proves the support identities needed in Appendix C.4 of arXiv:1606.00608 for the source-generated vertical-sector families. For every virtual bond matrix, the precompression outputs of transported refinement and coarse-graining lie in the active vertical sectors. Cyclicity of trace then gives sector-trace preservation on those families.

The result avoids asserting trace preservation on arbitrary elements of the ambient product algebra. The zero-sector paper-gap note now records precisely which source-generated image-preservation statement closes the local obstruction.

## Changes

- add four sorry-free image-preservation and trace-preservation lemmas
- import the new module from the root
- add four exact-hypothesis blueprint entries
- update the zero-sector paper-gap resolution
- remove obsolete local-fix wording from the generic equality criteria

## Verification

- direct Lean checks for both changed MPDO modules
- full lake build TNLean twice after substantive rebases (9,554 targets)
- leanblueprint checkdecls
- reader-facing prose, diff-integrity, and proof-integrity scans
- axiom audit: only propext, Classical.choice, and Quot.sound

Closes #4136

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions in formal Lean and documentation; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **formal proofs** that transported refinement/coarse-graining precompression outputs stay in the active vertical sector when inputs are **bond contractions** from the one- and two-site vertical canonical forms (Appendix C.4, arXiv:1606.00608). That closes the local “zero-sector complement” gap for those **source-generated** families: support identities `U₂†U₂ Z_T = Z_T` and `U₁†U₁ Z_S = Z_S`, then **sector-trace preservation** via trace cyclicity—not a claim of trace preservation on arbitrary sector algebra elements.
> 
> **Lean:** new `VerticalSectorImagePreservation.lean` with four sorry-free lemmas; root import; `VerticalSectorTraceLoss` docstrings now defer the generic iff criteria to this module for the canonical-form case.
> 
> **Docs:** four matching blueprint lemmas in `ch21_mpdo_rfp_blocked_rfp.tex`; the zero-sector paper-gap note records the proved image-preservation step and Lean cross-refs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1141c76ad1f9b2e95cf3b899ecb8e48dcd35cc52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->