### PR TITLE
feat(MPS/MPDO): isolate commuting-form SAL conclusion

### DIFF
--- a/TNLean/MPS/MPDO/CommutingForm.lean
+++ b/TNLean/MPS/MPDO/CommutingForm.lean
@@ -431,9 +431,16 @@ def Realizes (data : CommutingFormData d N) (ρ : ChainOperator d N) : Prop :=
 
 end CommutingFormData
 
-/-- Global commuting-form property for an MPO tensor: each finite chain of
+/-- Chainwise commuting-form property for an MPO tensor: each finite chain of
 length at least `2` admits a commuting-form witness for the corresponding MPO
-operator. -/
+operator. The bond may depend on the chain length.
+
+This is weaker than the hypothesis of Proposition `4to2` in
+arXiv:1606.00608, lines 1597--1619, which refers back to the single
+translation-invariant bond family in equation `expression`. That source
+hypothesis is represented by `EtaLocalStructureData`: one bond realizes every
+finite chain. The distinction and the missing Bravyi--Vyalyi decomposition are
+recorded in `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 def HasCommutingForm (M : MPOTensor d D) : Prop :=
   ∀ N : ℕ, 2 ≤ N →
     ∃ data : CommutingFormData d N, data.Realizes (mpo M N)

--- a/TNLean/MPS/MPDO/CommutingForm.lean
+++ b/TNLean/MPS/MPDO/CommutingForm.lean
@@ -435,9 +435,10 @@ end CommutingFormData
 length at least `2` admits a commuting-form witness for the corresponding MPO
 operator. The bond may depend on the chain length.
 
-This is weaker than the hypothesis of Proposition 4to2 in
+This is weaker than the hypothesis of source Proposition 4to2 in
 arXiv:1606.00608, lines 1597--1619, which refers back to the single
-translation-invariant bond family in equation expression. That source
+translation-invariant bond family in the equation carrying the source label
+expression. That source
 hypothesis is represented by `EtaLocalStructureData`: one bond realizes every
 finite chain. The distinction and the missing Bravyi--Vyalyi decomposition are
 recorded in `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/

--- a/TNLean/MPS/MPDO/CommutingForm.lean
+++ b/TNLean/MPS/MPDO/CommutingForm.lean
@@ -435,9 +435,9 @@ end CommutingFormData
 length at least `2` admits a commuting-form witness for the corresponding MPO
 operator. The bond may depend on the chain length.
 
-This is weaker than the hypothesis of Proposition `4to2` in
+This is weaker than the hypothesis of Proposition 4to2 in
 arXiv:1606.00608, lines 1597--1619, which refers back to the single
-translation-invariant bond family in equation `expression`. That source
+translation-invariant bond family in equation expression. That source
 hypothesis is represented by `EtaLocalStructureData`: one bond realizes every
 finite chain. The distinction and the missing Bravyi--Vyalyi decomposition are
 recorded in `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/

--- a/TNLean/MPS/MPDO/SALArbitraryCut.lean
+++ b/TNLean/MPS/MPDO/SALArbitraryCut.lean
@@ -162,8 +162,8 @@ theorem isSAL_of_isSSAEquality_tripartite_m (M : MPOTensor d D)
 imply saturation of the area law, provided the periodic operators are positive
 and have nonzero trace.
 
-This isolates the entropy-theoretic conclusion used in the proof of the
-proposition labelled 4to2: the direct-sum tensor-factor decomposition on the
+This isolates the entropy-theoretic conclusion used in the proof of source
+Proposition 4to2: the direct-sum tensor-factor decomposition on the
 middle site implies equality in strong subadditivity, and the latter equalities
 give SAL.
 
@@ -175,7 +175,7 @@ and the subsequent ZCL trace factorization. This missing implication is document
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.
 
 Source: arXiv:1606.00608, Appendix C.2, Proposition 4to2, lines
-1597--1619. -/
+1606--1612. -/
 theorem isSAL_of_quantumMarkovDecomposition_tripartite_m
     (M : MPOTensor d D) (hMpdo : IsMPDO M)
     (htrace : ∀ N, 0 < N → (mpo M N).trace ≠ 0)

--- a/TNLean/MPS/MPDO/SALArbitraryCut.lean
+++ b/TNLean/MPS/MPDO/SALArbitraryCut.lean
@@ -163,18 +163,18 @@ imply saturation of the area law, provided the periodic operators are positive
 and have nonzero trace.
 
 This isolates the entropy-theoretic conclusion used in the proof of the
-proposition labelled `4to2`: the direct-sum tensor-factor decomposition on the
+proposition labelled 4to2: the direct-sum tensor-factor decomposition on the
 middle site implies equality in strong subadditivity, and the latter equalities
 give SAL.
 
-**Scope restriction (Markov decomposition assumed):** Proposition `4to2` of
+**Scope restriction (Markov decomposition assumed):** Proposition 4to2 of
 arXiv:1606.00608 assumes instead a single translation-invariant commuting bond
 and ZCL. Deriving the decompositions below from those hypotheses requires the
 Bravyi--Vyalyi spatial decomposition (Beigi, arXiv:1105.1019v2, Lemma 2.1),
 and the subsequent ZCL trace factorization. This missing implication is documented in
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.
 
-Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+Source: arXiv:1606.00608, Appendix C.2, Proposition 4to2, lines
 1597--1619. -/
 theorem isSAL_of_quantumMarkovDecomposition_tripartite_m
     (M : MPOTensor d D) (hMpdo : IsMPDO M)

--- a/TNLean/MPS/MPDO/SALArbitraryCut.lean
+++ b/TNLean/MPS/MPDO/SALArbitraryCut.lean
@@ -22,6 +22,8 @@ first three regions.  The converse is stated for all admissible cuts.
   equality gives \(I_1=I_m\).
 - `MPOTensor.isSAL_of_isSSAEquality_tripartite_m`: the equalities at all
   admissible cuts recover SAL.
+- `MPOTensor.isSAL_of_quantumMarkovDecomposition_tripartite_m`: quantum
+  Markov decompositions at all admissible cuts recover SAL.
 -/
 
 open scoped Matrix ComplexOrder BigOperators
@@ -155,5 +157,46 @@ theorem isSAL_of_isSSAEquality_tripartite_m (M : MPOTensor d D)
     M hMpdo (m := L + 1) (by omega) (by omega)
       (hSSA N (L + 1) (by omega) (by omega))
   exact hEqL.symm.trans hEqSucc
+
+/-- Quantum-Markov decompositions for every admissible three-region marginal
+imply saturation of the area law, provided the periodic operators are positive
+and have nonzero trace.
+
+This isolates the entropy-theoretic conclusion used in the proof of the
+proposition labelled `4to2`: the direct-sum tensor-factor decomposition on the
+middle site implies equality in strong subadditivity, and the latter equalities
+give SAL.
+
+**Scope restriction (Markov decomposition assumed):** Proposition `4to2` of
+arXiv:1606.00608 assumes instead a single translation-invariant commuting bond
+and ZCL. Deriving the decompositions below from those hypotheses requires the
+Bravyi--Vyalyi spatial decomposition (Beigi, arXiv:1105.1019v2, Lemma 2.1),
+and the subsequent ZCL trace factorization. This missing implication is documented in
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1597--1619. -/
+theorem isSAL_of_quantumMarkovDecomposition_tripartite_m
+    (M : MPOTensor d D) (hMpdo : IsMPDO M)
+    (htrace : ∀ N, 0 < N → (mpo M N).trace ≠ 0)
+    (hMarkov : ∀ (N m : ℕ) (hm1 : 1 ≤ m) (hmN : m ≤ N / 2),
+      let h3 : (m - 1) + 1 + (N - m - 1) ≤ N := by omega
+      let ρ_ABC :=
+        (M.reducedBlockState N ((m - 1) + 1 + (N - m - 1)) h3).submatrix
+          (tripartiteSplitEquiv d (m - 1) 1 (N - m - 1)).symm
+          (tripartiteSplitEquiv d (m - 1) 1 (N - m - 1)).symm
+      Nonempty (Entropy.QuantumMarkovDecomposition ρ_ABC)) :
+    IsSAL M := by
+  apply isSAL_of_isSSAEquality_tripartite_m M hMpdo htrace
+  intro N m hm1 hmN
+  dsimp only
+  apply Entropy.isSSAEquality_of_quantumMarkovDecomposition
+  · constructor
+    · exact (reducedBlockState_posSemidef M N
+        ((m - 1) + 1 + (N - m - 1)) (by omega) (hMpdo N (by omega))).submatrix _
+    · rw [Matrix.trace_submatrix_equiv]
+      exact reducedBlockState_trace M N ((m - 1) + 1 + (N - m - 1))
+        (by omega) (htrace N (by omega))
+  · exact hMarkov N m hm1 hmN
 
 end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -106,6 +106,27 @@
     combine it with the doubled-index transfer hypothesis.
 \end{proof}
 
+\begin{theorem}[A translation-invariant commuting bond and ZCL imply SAL]
+    \label{thm:mpdo_translation_invariant_commuting_form_zcl_sal}
+    \notready
+    \uses{def:mpdo_eta_local_structure_data, def:mpo_source_zcl,
+        def:is_sal, def:mpdo, def:mpdo_injective_inverse_layer}
+    Let $\mathcal K$ be a normal MPDO block.  Suppose that there is one
+    positive two-site bond $B$ whose translates commute and, for every
+    $N\geq2$, a constant $c_N>0$ such that
+    \[
+        \rho^{(N)}(\mathcal K)=c_N\prod_{i=0}^{N-1}B_{i,i+1}.
+    \]
+    If the physical-trace transfer of $\mathcal K$ has zero correlation
+    length, then $\mathcal K$ saturates the area law.
+
+    This is the proposition at
+    \cite[Appendix~C.2, lines~1597--1619]{Cirac2016MPDO_arXiv}.
+    % The Bravyi--Vyalyi spatial decomposition and the subsequent source-ZCL
+    % trace factorization remain open. Gap documented in
+    % docs/paper-gaps/cpsv16_commuting_form_to_sal.tex.
+\end{theorem}
+
 \begin{theorem}[$\eta$-local structure gives the one-sector GSNNCH form]
     \label{thm:mpdo_eta_local_structure_has_gsnnch_form}
     \lean{MPOTensor.EtaLocalStructureData.hasGSNNCHForm}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -111,11 +111,12 @@
     \notready
     \uses{def:mpdo_eta_local_structure_data, def:mpo_source_zcl,
         def:is_sal, def:mpdo, def:mpdo_injective_inverse_layer}
-    Let $\mathcal K$ be a normal MPDO block.  Suppose that there is one
+    Let $\mathcal K$ be an injective normal tensor generating MPDOs.  Suppose
+    that there is one
     positive two-site bond $B$ whose translates commute and, for every
     $N\geq2$, a constant $c_N>0$ such that
     \[
-        \rho^{(N)}(\mathcal K)=c_N\prod_{i=0}^{N-1}B_{i,i+1}.
+        \sigma^{(N)}(\mathcal K)=c_N\prod_{i=0}^{N-1}B_{i,i+1}.
     \]
     If the physical-trace transfer of $\mathcal K$ has zero correlation
     length, then $\mathcal K$ saturates the area law.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
@@ -44,6 +44,7 @@ Definition~\ref{def:mpdo_source_gsnnch}; the converse comparison is not used.
 \begin{definition}[Single-bond commuting-form data for an MPDO]
     \label{def:mpdo_commuting_form_data}
     \lean{MPOTensor.CommutingFormData}
+    \lean{MPOTensor.CommutingFormData.Realizes}
     \leanok
     \uses{def:mpo_tensor}
     For a fixed chain length $N \ge 2$, this consists of one positive
@@ -66,6 +67,11 @@ Definition~\ref{def:mpdo_source_gsnnch}; the converse comparison is not used.
     \[
         \rho^{(N)}(M)=c\prod_{i=0}^{N-1}B_{i,i+1}.
     \]
+    The bond in this chainwise condition may depend on $N$.  It is therefore
+    weaker than the single translation-invariant bond family used in the
+    proposition at
+    \cite[Appendix~C.2, lines~1597--1619]{Cirac2016MPDO_arXiv}.
+    % See docs/paper-gaps/cpsv16_commuting_form_to_sal.tex.
 \end{definition}
 
 \begin{definition}[Single-bond product predicate]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
@@ -44,7 +44,6 @@ Definition~\ref{def:mpdo_source_gsnnch}; the converse comparison is not used.
 \begin{definition}[Single-bond commuting-form data for an MPDO]
     \label{def:mpdo_commuting_form_data}
     \lean{MPOTensor.CommutingFormData}
-    \lean{MPOTensor.CommutingFormData.Realizes}
     \leanok
     \uses{def:mpo_tensor}
     For a fixed chain length $N \ge 2$, this consists of one positive

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
@@ -384,8 +384,8 @@ strong subadditivity for a normalized three-site reduced state.
     \[
         S(\rho_{ABC})+S(\rho_B)=S(\rho_{AB})+S(\rho_{BC}).
     \]
-    Apply the converse direction of
-    Theorem~\ref{thm:mpdo_sal_ssa_equality}.
+    These equalities at every admissible cut imply saturation of the area law
+    by Theorem~\ref{thm:mpdo_sal_ssa_equality}.
 \end{proof}
 
 \begin{theorem}[SAL implies local $\eta$-structure]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
@@ -359,6 +359,31 @@ strong subadditivity for a normalized three-site reduced state.
     admissible $m$, comparing the cases $m=L$ and $m=L+1$ gives
     $I_L=I_{L+1}$ and hence saturation of the area law.
 \end{proof}
+
+\begin{theorem}[All-cut quantum Markov structure implies SAL]
+    \label{thm:mpdo_all_cut_markov_implies_sal}
+    \lean{MPOTensor.isSAL_of_quantumMarkovDecomposition_tripartite_m}
+    \leanok
+    \uses{def:is_sal, def:entropy_quantum_markov_decomposition}
+    Suppose that the periodic operators are positive semidefinite and have
+    nonzero trace at every positive chain length.  For every $N$ and every
+    $1\leq m\leq\lfloor N/2\rfloor$, divide the chain into four consecutive
+    regions of lengths $m-1,1,N-m-1,1$.  If the marginal on the first three
+    regions admits a quantum Markov decomposition on its one-site middle
+    system, then the tensor saturates the area law.
+    % This is the final entropy step at source lines 1606--1619. The missing
+    % implication from its commuting-bond and source-ZCL hypotheses is recorded in
+    % docs/paper-gaps/cpsv16_commuting_form_to_sal.tex.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_sal_ssa_equality,
+        thm:entropy_ssa_equality_quantum_markov}
+    The quantum Markov decomposition gives equality in strong subadditivity
+    at every admissible cut.  Apply the converse direction of
+    Theorem~\ref{thm:mpdo_sal_ssa_equality}.
+\end{proof}
+
 \begin{theorem}[SAL implies local $\eta$-structure]
     \label{thm:sal_implies_eta_structure}
     \lean{MPOTensor.sal_implies_eta_structure}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
@@ -364,7 +364,7 @@ strong subadditivity for a normalized three-site reduced state.
     \label{thm:mpdo_all_cut_markov_implies_sal}
     \lean{MPOTensor.isSAL_of_quantumMarkovDecomposition_tripartite_m}
     \leanok
-    \uses{def:is_sal, def:entropy_quantum_markov_decomposition}
+    \uses{def:is_sal, def:mpdo, def:entropy_quantum_markov_decomposition}
     Suppose that the periodic operators are positive semidefinite and have
     nonzero trace at every positive chain length.  For every $N$ and every
     $1\leq m\leq\lfloor N/2\rfloor$, divide the chain into four consecutive
@@ -380,7 +380,11 @@ strong subadditivity for a normalized three-site reduced state.
     \uses{thm:mpdo_sal_ssa_equality,
         thm:entropy_ssa_equality_quantum_markov}
     The quantum Markov decomposition gives equality in strong subadditivity
-    at every admissible cut.  Apply the converse direction of
+    at every admissible cut:
+    \[
+        S(\rho_{ABC})+S(\rho_B)=S(\rho_{AB})+S(\rho_{BC}).
+    \]
+    Apply the converse direction of
     Theorem~\ref{thm:mpdo_sal_ssa_equality}.
 \end{proof}
 

--- a/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
+++ b/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
@@ -107,6 +107,11 @@ Markov decompositions at all admissible cuts imply SAL.\footnote{This is
 direct-sum hypothesis is a marked scope restriction, not an additional
 hypothesis on the source proposition.
 
+\paragraph{Verdict.}
+Proposition~\emph{4to2} is classified as an open gap.  The proved implication
+from quantum Markov decompositions at every admissible cut to SAL is a scope
+restriction that isolates only its final entropy-theoretic step.
+
 \section{Elimination plan}
 
 The gap can be removed in three stages.

--- a/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
+++ b/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
@@ -1,0 +1,141 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+
+\input{command}
+
+\title{The Commuting-Form-to-SAL Implication for Simple MPDOs}
+\author{}
+\date{2026-07-18}
+
+\begin{document}
+\maketitle
+
+\section{Source statement}
+
+The proposition labelled \emph{4to2} in
+\cite[Appendix~C.2, lines~1597--1619]{Cirac2016MPDO_arXiv} considers a normal
+MPDO block $\mathcal K$.  Its finite-chain operators are positive scalar
+multiples of products of translates of one positive two-site bond,
+\[
+  \sigma^{(N)}(\mathcal K)
+  =c_N\prod_{i=0}^{N-1}B_{i,i+1},
+  \qquad c_N>0,
+  \qquad [B_{i,i+1},B_{j,j+1}]=0.
+\]
+Together with zero correlation length, this hypothesis is asserted to imply
+saturation of the area law.
+
+The phrase ``of the form'' refers back to the single bond in equation
+\emph{expression} at source lines~1571--1578.  It is therefore a statement
+about one translation-invariant bond family, not a separate existence
+statement at each chain length.
+
+\section{The theorem cited through Beigi}
+
+The reference denoted by \emph{Beigi} is Salman Beigi,
+\emph{Classification of the phases of 1D spin chains with commuting
+Hamiltonians}, arXiv:1105.1019v2, J. Phys. A \textbf{45} (2012) 025306,
+\href{https://doi.org/10.1088/1751-8113/45/2/025306}
+{doi:10.1088/1751-8113/45/2/025306}.
+
+The relevant assertion is Lemma~2.1, labelled \emph{lem:comm} in the arXiv
+source and credited there to Bravyi and Vyalyi.  If Hermitian operators
+$X_{AB}$ and $Y_{BC}$ commute after their natural embeddings, then
+\[
+  \mathcal H_B
+  \cong \bigoplus_{\beta\in V}
+  \mathcal H_{\beta_l}\otimes\mathcal H_{\beta_r},
+\]
+such that $X_{AB}$ acts trivially on every $\mathcal H_{\beta_r}$ and
+$Y_{BC}$ acts trivially on every $\mathcal H_{\beta_l}$.  Beigi applies this
+lemma to neighboring translates of one local interaction.  Translation
+invariance permits the same one-site decomposition at every site; the local
+decomposition is independent of the system size.
+
+The proof uses the representation theory of finite-dimensional
+$C^*$-algebras.  It first forms the commutant of the operator-Schmidt factors
+of $X_{AB}$ and then identifies that algebra, after a unitary change of basis,
+with
+\[
+  \bigoplus_{\beta\in V}
+  \mathbf 1_{\beta_l}\otimes
+  \mathbf L(\mathcal H_{\beta_r}).
+\]
+The commutant has the complementary action on the left tensor factors.
+
+\section{Present formal distinction}
+
+The predicate
+\leanid{MPOTensor.HasCommutingForm} is chainwise: for every $N\geq2$ it
+allows a new two-site bond $B_N$.  It is weaker than the source hypothesis and
+does not support the comparison of the $N$, $N+1$, and $N+2$ chains used by
+the source trace-factorization argument.
+
+The source family is represented by the bond in
+\begin{center}
+\path{MPOTensor.TranslationInvariantBondData}
+\end{center}
+together with the realization equalities in
+\begin{center}
+\path{MPOTensor.EtaLocalStructureData}.
+\end{center}
+These declarations fix one bond whose commuting translates realize every
+finite chain.
+
+The source ZCL hypothesis is
+\leanid{MPOTensor.IsSourceZCL}, the scale-invariant idempotence condition for
+the physical-trace transfer.  The predicate \leanid{MPOTensor.IsZCL} concerns
+the doubled-index completely positive transfer map and is not a faithful
+substitute for the proposition labelled \emph{4to2}.
+
+\section{Unformalized implication}
+
+The abstract Wedderburn--Artin decomposition already available in
+\leanid{StarSubalgebra.exists_algEquiv_pi_matrix} does not provide the spatial
+unitary tensor-factor decomposition required by the Bravyi--Vyalyi lemma.
+The file \path{TNLean/Algebra/StarSubalgebraSpatial.lean} proves orthogonal
+reducibility, but explicitly records the remaining isotypic tensor
+identification and unitary construction.
+
+Consequently the source implication
+\[
+  \text{one translation-invariant commuting bond}
+  +\text{source ZCL}
+  \Longrightarrow \text{SAL}
+\]
+is not yet formalized and must not carry a \texttt{\string\leanok} marker.
+The formal development proves only the final entropy-theoretic step:
+\path{MPOTensor.isSAL_of_quantumMarkovDecomposition_tripartite_m} shows that
+quantum Markov decompositions at all admissible cuts imply SAL.  Its direct-sum
+hypothesis is a marked scope restriction, not an additional hypothesis on the
+source proposition.
+
+\section{Elimination plan}
+
+The gap can be removed in three stages.
+
+\begin{enumerate}
+\item Complete the spatial finite-dimensional $C^*$-algebra theorem: construct
+the unitary decomposition
+$\mathcal H_B\cong\bigoplus_\beta
+\mathcal H_{\beta_l}\otimes\mathcal H_{\beta_r}$ and prove the complementary
+actions of a star-subalgebra and its commutant.
+\item Apply it to the two overlapping translates of the single bond in
+\leanid{MPOTensor.EtaLocalStructureData}, obtaining the translation-invariant
+neighboring operators $\eta_{k,h}$ without assuming a Hayashi decomposition.
+Use \leanid{MPOTensor.IsSourceZCL} to prove the rank-one trace factorization
+$\operatorname{tr}(\eta_{k,h})=a_kb_h$ appearing at source lines~1610--1616.
+\item Trace the fourth region, construct the quantum Markov decomposition at
+each admissible cut, and apply
+\path{MPOTensor.isSAL_of_quantumMarkovDecomposition_tripartite_m}.
+Only then may the source proposition receive a formal declaration and a
+\texttt{\string\leanok} marker.
+\end{enumerate}
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
+++ b/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
@@ -4,7 +4,7 @@
 \usepackage{xurl}
 \usepackage[hidelinks]{hyperref}
 
-\input{command}
+\input{./command}
 
 \title{The Commuting-Form-to-SAL Implication for Simple MPDOs}
 \author{}
@@ -74,16 +74,10 @@ allows a new two-site bond $B_N$.  It is weaker than the source hypothesis and
 does not support the comparison of the $N$, $N+1$, and $N+2$ chains used by
 the source trace-factorization argument.
 
-The source family is represented by the bond in
-\begin{center}
-\path{MPOTensor.TranslationInvariantBondData}
-\end{center}
-together with the realization equalities in
-\begin{center}
-\path{MPOTensor.EtaLocalStructureData}.
-\end{center}
-These declarations fix one bond whose commuting translates realize every
-finite chain.
+The formal model fixes one bond whose commuting translates realize every
+finite chain.\footnote{The bond family is
+\leanid{MPOTensor.TranslationInvariantBondData}; the realization equalities
+are fields of \leanid{MPOTensor.EtaLocalStructureData}.}
 
 The source ZCL hypothesis is
 \leanid{MPOTensor.IsSourceZCL}, the scale-invariant idempotence condition for
@@ -107,11 +101,11 @@ Consequently the source implication
   \Longrightarrow \text{SAL}
 \]
 is not yet formalized and must not carry a \texttt{\string\leanok} marker.
-The formal development proves only the final entropy-theoretic step:
-\path{MPOTensor.isSAL_of_quantumMarkovDecomposition_tripartite_m} shows that
-quantum Markov decompositions at all admissible cuts imply SAL.  Its direct-sum
-hypothesis is a marked scope restriction, not an additional hypothesis on the
-source proposition.
+The formal development proves only the final entropy-theoretic step: quantum
+Markov decompositions at all admissible cuts imply SAL.\footnote{This is
+\leanid{MPOTensor.isSAL_of_quantumMarkovDecomposition_tripartite_m}.} Its
+direct-sum hypothesis is a marked scope restriction, not an additional
+hypothesis on the source proposition.
 
 \section{Elimination plan}
 
@@ -129,8 +123,7 @@ neighboring operators $\eta_{k,h}$ without assuming a Hayashi decomposition.
 Use \leanid{MPOTensor.IsSourceZCL} to prove the rank-one trace factorization
 $\operatorname{tr}(\eta_{k,h})=a_kb_h$ appearing at source lines~1610--1616.
 \item Trace the fourth region, construct the quantum Markov decomposition at
-each admissible cut, and apply
-\path{MPOTensor.isSAL_of_quantumMarkovDecomposition_tripartite_m}.
+each admissible cut, and apply the all-cut Markov theorem above.
 Only then may the source proposition receive a formal declaration and a
 \texttt{\string\leanok} marker.
 \end{enumerate}


### PR DESCRIPTION
## Mathematical content

This audits the commuting-nearest-neighbor-form implication in CPSV16, Proposition 4to2. The cited Beigi result is Lemma 2.1 of arXiv:1105.1019v2, credited there to Bravyi and Vyalyi. It gives the spatial direct-sum tensor-factor decomposition of the middle site for overlapping commuting Hermitian operators.

The audit identifies two distinctions that prevent the source proposition from being marked complete:

- the paper uses one translation-invariant bond family for every chain length, whereas HasCommutingForm may choose a new bond for each length;
- the paper uses physical-trace ZCL, not the doubled-index completely positive transfer condition.

The missing spatial finite-dimensional C-star-algebra decomposition and the subsequent ZCL trace factorization are recorded explicitly. The source proposition remains not ready.

The PR proves the final entropy theorem that is valid independently: if every admissible three-region marginal has a quantum Markov decomposition on its one-site middle region, then the tensor saturates the area law.

## Verification

- direct Lean checks for both modified modules
- no prohibited proof tokens
- reader-facing prose check
- blueprint-to-Lean synchronization and changed-declaration coverage
- full 617-page blueprint PDF
- standalone three-page gap-note PDF with no final warnings or overfull lines
- clean diff and worktree

Documents #4175

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new SAL theorem under a strong assumed hypothesis and reclassifies a major paper implication as an explicit gap; no auth or runtime changes, but readers must not treat the full 4to2 route as proved.
> 
> **Overview**
> This PR **separates** what is formalized from what Cirac–Pérez-García–Schuch–Verstraete (CPSV16) Appendix C.2 Proposition 4to2 still requires. **`HasCommutingForm`** is clarified as **chainwise** (the bond may depend on chain length \(N\)), which is **weaker** than the paper’s **single translation-invariant** commuting bond plus **physical-trace ZCL** (`IsSourceZCL`, not doubled-index `IsZCL`).
> 
> A new Lean theorem **`MPOTensor.isSAL_of_quantumMarkovDecomposition_tripartite_m`** proves the **entropy-only closing step**: if every admissible three-region marginal has a **quantum Markov decomposition** on the one-site middle, then the MPO **saturates the area law** (via SSA equality and existing SAL↔SSA machinery). The blueprint adds a matching **leanok** theorem and marks the full **commuting bond + ZCL ⇒ SAL** statement **not ready**.
> 
> **`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`** records the open implication (Bravyi–Vyalyi spatial decomposition and ZCL trace factorization) and a three-stage elimination plan.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c45b2f9f51ce3b9289cf6773108a0411299a6745. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->