### PR TITLE
feat(mpdo): formalize virtual-spanning rank-one obstruction

### DIFF
--- a/TNLean/Archive/PerronFrobeniusVirtualSpanningCounterexample.lean
+++ b/TNLean/Archive/PerronFrobeniusVirtualSpanningCounterexample.lean
@@ -1,0 +1,343 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Data.Matrix.Basis
+import Mathlib.Data.Matrix.Mul
+import Mathlib.Data.Real.Basic
+import Mathlib.LinearAlgebra.Matrix.Irreducible.Defs
+import Mathlib.LinearAlgebra.Matrix.Notation
+import Mathlib.LinearAlgebra.Matrix.Trace
+import Mathlib.Tactic.FinCases
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
+import TNLean.MPS.MPDO.ZCL
+
+/-!
+# A virtual-spanning obstruction to the rank-one step in Lemma C.5
+
+This file strengthens the rectangular-pairing counterexample for
+arXiv:1606.00608, Appendix C.2, lines 1406--1499.  It gives four pairs of
+vectors
+\[
+  l_k\in\mathbb R^2,\qquad r_k\in(\mathbb R^2)^*,
+\]
+with the following properties.
+
+* The four sector matrices `l_k r_k` span the full algebra `M₂(ℝ)`.
+* The closed pairing operator `L R` is idempotent.
+* The opposite product `T = R L` is entrywise nonnegative, primitive, and
+  trace-normalized.
+* Nevertheless `T` is not idempotent and has no rank-one factorization.
+
+Thus the virtual-matrix spanning conclusion obtained from injectivity in the
+formal inverse-map construction does not, by itself, eliminate the nilpotent
+generalized zero-eigenspace of the sector trace matrix.  The example does not
+claim to arise from the complete strong-area-law inverse-map construction;
+that additional provenance remains the precise boundary of issue #3593.
+
+This file is deliberately excluded from the root `TNLean.lean` import list.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Appendix C.2, Lemmas C.4--C.5, lines 1406--1499.
+-/
+
+namespace TNLean.Archive.PerronFrobeniusVirtualSpanningCounterexample
+
+open Matrix
+
+/-- The four closed left-sector vectors, arranged as the columns of a matrix. -/
+noncomputable def pairingL : Matrix (Fin 2) (Fin 4) ℝ :=
+  !![1 / 6, 1 / 6, 1 / 3, 1 / 3;
+     0,     1 / 6, 1 / 6, -1 / 3]
+
+/-- The four closed right-sector functionals, arranged as the rows of a matrix. -/
+noncomputable def pairingR : Matrix (Fin 4) (Fin 2) ℝ :=
+  !![1,  1;
+     1,  1;
+     1, -1;
+     1,  0]
+
+/-- The idempotent product on the two-dimensional closed-tensor space. -/
+noncomputable def pairingProjection : Matrix (Fin 2) (Fin 2) ℝ :=
+  !![1, 0; 0, 0]
+
+/-- The four-dimensional sector trace matrix `R L`. -/
+noncomputable def traceMatrix : Matrix (Fin 4) (Fin 4) ℝ :=
+  !![1 / 6, 1 / 3, 1 / 2, 0;
+     1 / 6, 1 / 3, 1 / 2, 0;
+     1 / 6, 0,     1 / 6, 2 / 3;
+     1 / 6, 1 / 6, 1 / 3, 1 / 3]
+
+/-- The rank-one Perron projection `traceMatrix ^ 2`. -/
+noncomputable def perronProjection : Matrix (Fin 4) (Fin 4) ℝ :=
+  !![1 / 6, 1 / 6, 1 / 3, 1 / 3;
+     1 / 6, 1 / 6, 1 / 3, 1 / 3;
+     1 / 6, 1 / 6, 1 / 3, 1 / 3;
+     1 / 6, 1 / 6, 1 / 3, 1 / 3]
+
+/-- The sector virtual matrix `l_k r_k`. -/
+noncomputable def virtualMatrix (k : Fin 4) : Matrix (Fin 2) (Fin 2) ℝ :=
+  Matrix.vecMulVec (fun i => pairingL i k) (fun j => pairingR k j)
+
+/-- Coefficients expressing an arbitrary two-by-two matrix in the four sector
+virtual matrices. -/
+noncomputable def reconstructionCoefficients
+    (X : Matrix (Fin 2) (Fin 2) ℝ) : Fin 4 → ℝ :=
+  ![X 0 0 + 5 * X 0 1 + X 1 0 - 7 * X 1 1,
+    X 0 0 - X 0 1 + X 1 0 + 5 * X 1 1,
+    X 0 0 - X 0 1 + X 1 0 - X 1 1,
+    X 0 0 - X 0 1 - 2 * X 1 0 + 2 * X 1 1]
+
+lemma pairingL_mul_pairingR : pairingL * pairingR = pairingProjection := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [pairingL, pairingR, pairingProjection, Matrix.mul_apply,
+      Fin.sum_univ_four] <;> ring
+
+lemma pairingR_mul_pairingL : pairingR * pairingL = traceMatrix := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [pairingL, pairingR, traceMatrix, Matrix.mul_apply,
+      Fin.sum_univ_two] <;> ring
+
+/-- The product in the closed-tensor space is idempotent, as required by the
+normalized source zero-correlation-length identity at lines 1490--1493. -/
+theorem pairingL_mul_pairingR_isIdempotent :
+    IsIdempotentElem (pairingL * pairingR) := by
+  rw [pairingL_mul_pairingR]
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [pairingProjection, Matrix.mul_apply, Fin.sum_univ_two]
+
+lemma traceMatrix_sq : traceMatrix * traceMatrix = perronProjection := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [traceMatrix, perronProjection, Matrix.mul_apply,
+      Fin.sum_univ_four] <;> ring
+
+lemma traceMatrix_mul_perronProjection :
+    traceMatrix * perronProjection = perronProjection := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [traceMatrix, perronProjection, Matrix.mul_apply,
+      Fin.sum_univ_four] <;> ring
+
+lemma perronProjection_mul_traceMatrix :
+    perronProjection * traceMatrix = perronProjection := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [traceMatrix, perronProjection, Matrix.mul_apply,
+      Fin.sum_univ_four] <;> ring
+
+lemma traceMatrix_nonneg (i j : Fin 4) : 0 ≤ traceMatrix i j := by
+  fin_cases i <;> fin_cases j <;> simp [traceMatrix]
+  norm_num
+
+lemma traceMatrix_pow_two_pos (i j : Fin 4) : 0 < (traceMatrix ^ 2) i j := by
+  rw [sq, traceMatrix_sq]
+  fin_cases i <;> fin_cases j <;> simp [perronProjection]
+
+/-- The sector trace matrix is primitive. -/
+theorem traceMatrix_isPrimitive : Matrix.IsPrimitive traceMatrix :=
+  ⟨traceMatrix_nonneg, 2, by norm_num, traceMatrix_pow_two_pos⟩
+
+lemma trace_traceMatrix : Matrix.trace traceMatrix = 1 := by
+  simp [Matrix.trace, traceMatrix, Fin.sum_univ_four]
+  ring
+
+/-- The sector trace matrix is not idempotent. -/
+theorem traceMatrix_not_idempotent : traceMatrix * traceMatrix ≠ traceMatrix := by
+  intro h
+  have hentry := congrFun (congrFun h 0) 1
+  rw [traceMatrix_sq] at hentry
+  norm_num [perronProjection, traceMatrix] at hentry
+
+/-- The nilpotent remainder is exactly the failure of the desired identity
+`R (1 - L R) L = 0`. -/
+theorem pairing_nilpotent_remainder_ne_zero :
+    pairingR * (1 - pairingL * pairingR) * pairingL ≠ 0 := by
+  intro h
+  apply traceMatrix_not_idempotent
+  rw [← pairingR_mul_pairingL]
+  have hdiff :
+      pairingR * pairingL -
+          (pairingR * pairingL) * (pairingR * pairingL) = 0 := by
+    calc
+      pairingR * pairingL -
+          (pairingR * pairingL) * (pairingR * pairingL) =
+        pairingR * (1 - pairingL * pairingR) * pairingL := by
+          simp only [Matrix.mul_sub, Matrix.mul_one, Matrix.sub_mul,
+            Matrix.mul_assoc]
+      _ = 0 := h
+  exact (sub_eq_zero.mp hdiff).symm
+
+/-- The four sector virtual matrices reconstruct every two-by-two matrix. -/
+theorem virtualMatrix_reconstruction (X : Matrix (Fin 2) (Fin 2) ℝ) :
+    ∑ k, reconstructionCoefficients X k • virtualMatrix k = X := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [reconstructionCoefficients, virtualMatrix, pairingL, pairingR,
+      Fin.sum_univ_four] <;> ring
+
+/-- The sector virtual matrices span the full two-by-two matrix algebra. -/
+theorem virtualMatrix_span_eq_top :
+    Submodule.span ℝ (Set.range virtualMatrix) =
+      (⊤ : Submodule ℝ (Matrix (Fin 2) (Fin 2) ℝ)) := by
+  rw [Submodule.eq_top_iff']
+  intro X
+  rw [← virtualMatrix_reconstruction X]
+  apply Submodule.sum_mem
+  intro k _
+  apply Submodule.smul_mem
+  exact Submodule.subset_span (Set.mem_range_self k)
+
+/-! ### An injective source-ZCL MPO tensor carrying the same sector data -/
+
+/-- The complexification of a sector virtual matrix. -/
+noncomputable def complexVirtualMatrix (k : Fin 4) :
+    Matrix (Fin 2) (Fin 2) ℂ :=
+  Matrix.map (virtualMatrix k) Complex.ofReal
+
+/-- A physical-diagonal MPO tensor whose four diagonal matrices are the sector
+virtual matrices above. -/
+noncomputable def mpoTensor : MPOTensor 4 2 :=
+  fun i j => if i = j then complexVirtualMatrix i else 0
+
+/-- Complex coefficients expressing an arbitrary two-by-two matrix in the
+four complexified sector virtual matrices. -/
+noncomputable def complexReconstructionCoefficients
+    (X : Matrix (Fin 2) (Fin 2) ℂ) : Fin 4 → ℂ :=
+  ![X 0 0 + 5 * X 0 1 + X 1 0 - 7 * X 1 1,
+    X 0 0 - X 0 1 + X 1 0 + 5 * X 1 1,
+    X 0 0 - X 0 1 + X 1 0 - X 1 1,
+    X 0 0 - X 0 1 - 2 * X 1 0 + 2 * X 1 1]
+
+theorem complexVirtualMatrix_reconstruction (X : Matrix (Fin 2) (Fin 2) ℂ) :
+    ∑ k, complexReconstructionCoefficients X k • complexVirtualMatrix k = X := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [complexReconstructionCoefficients, complexVirtualMatrix, virtualMatrix,
+      pairingL, pairingR, Fin.sum_univ_four] <;> ring
+
+lemma complexVirtualMatrix_mem_tensor_span (k : Fin 4) :
+    complexVirtualMatrix k ∈
+      Submodule.span ℂ (Set.range (MPOTensor.toMPSTensor mpoTensor)) := by
+  apply Submodule.subset_span
+  refine ⟨finProdFinEquiv (k, k), ?_⟩
+  change mpoTensor (finProdFinEquiv (k, k)).divNat
+      (finProdFinEquiv (k, k)).modNat = complexVirtualMatrix k
+  rw [MPSTensor.finProdFinEquiv_divNat, MPSTensor.finProdFinEquiv_modNat]
+  simp [mpoTensor]
+
+/-- The diagonal MPO tensor is injective: its four physical matrices span the
+full two-by-two virtual matrix algebra. -/
+theorem mpoTensor_isInjective : MPSTensor.IsInjective mpoTensor.toMPSTensor := by
+  unfold MPSTensor.IsInjective
+  rw [Submodule.eq_top_iff']
+  intro X
+  rw [← complexVirtualMatrix_reconstruction X]
+  apply Submodule.sum_mem
+  intro k _
+  exact Submodule.smul_mem _ _ (complexVirtualMatrix_mem_tensor_span k)
+
+lemma physTraceTransfer_mpoTensor :
+    MPOTensor.physTraceTransfer mpoTensor =
+      Matrix.map pairingProjection Complex.ofReal := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [MPOTensor.physTraceTransfer, mpoTensor, complexVirtualMatrix,
+      virtualMatrix, pairingL, pairingR, pairingProjection,
+      Fin.sum_univ_four] <;> ring
+
+/-- The injective diagonal tensor has source zero correlation length because
+its physical-trace transfer is the idempotent `L R`. -/
+theorem mpoTensor_isSourceZCL : MPOTensor.IsSourceZCL mpoTensor := by
+  apply MPOTensor.isSourceZCL_of_physTraceTransfer_sq mpoTensor
+  · rw [physTraceTransfer_mpoTensor]
+    intro h
+    have hentry := congrFun (congrFun h 0) 0
+    norm_num [pairingProjection] at hentry
+  · rw [physTraceTransfer_mpoTensor]
+    ext i j
+    fin_cases i <;> fin_cases j <;>
+      simp [pairingProjection, Matrix.mul_apply, Fin.sum_univ_two]
+
+/-- The four sector virtual matrices occur as the diagonal physical slices of
+the tensor. -/
+theorem mpoTensor_diagonal_slice (k : Fin 4) :
+    mpoTensor k k = complexVirtualMatrix k := by
+  simp [mpoTensor]
+
+/-- The primitive trace matrix has no rank-one factorization. -/
+theorem traceMatrix_not_rankOne :
+    ¬ ∃ a b : Fin 4 → ℝ, traceMatrix = Matrix.vecMulVec a b := by
+  rintro ⟨a, b, hT⟩
+  have h00 : a 0 * b 0 = (1 : ℝ) / 6 := by
+    have h := congrFun (congrFun hT 0) 0
+    simpa [traceMatrix, Matrix.vecMulVec_apply] using h.symm
+  have h03 : a 0 = 0 ∨ b 3 = 0 := by
+    have h := congrFun (congrFun hT 0) 3
+    simpa [traceMatrix, Matrix.vecMulVec_apply] using h
+  have h23 : a 2 * b 3 = (2 : ℝ) / 3 := by
+    have h := congrFun (congrFun hT 2) 3
+    simpa [traceMatrix, Matrix.vecMulVec_apply] using h.symm
+  have ha0 : a 0 ≠ 0 := by
+    intro ha
+    rw [ha, zero_mul] at h00
+    norm_num at h00
+  have hb3 : b 3 = 0 := h03.resolve_left ha0
+  rw [hb3, mul_zero] at h23
+  norm_num at h23
+
+/-- Virtual spanning does not repair the rank-one inference.  The same data
+satisfy the rectangular pairing identity, primitivity, trace normalization,
+and full virtual-matrix spanning, while the trace matrix is neither idempotent
+nor an outer product. -/
+theorem counterexample_with_virtual_spanning :
+    traceMatrix = pairingR * pairingL ∧
+      IsIdempotentElem (pairingL * pairingR) ∧
+      Matrix.IsPrimitive traceMatrix ∧
+      Matrix.trace traceMatrix = 1 ∧
+      Submodule.span ℝ (Set.range virtualMatrix) =
+        (⊤ : Submodule ℝ (Matrix (Fin 2) (Fin 2) ℝ)) ∧
+      traceMatrix * traceMatrix ≠ traceMatrix ∧
+      ¬ ∃ a b : Fin 4 → ℝ, traceMatrix = Matrix.vecMulVec a b :=
+  ⟨pairingR_mul_pairingL.symm, pairingL_mul_pairingR_isIdempotent,
+    traceMatrix_isPrimitive, trace_traceMatrix, virtualMatrix_span_eq_top,
+    traceMatrix_not_idempotent, traceMatrix_not_rankOne⟩
+
+/-- An injective source-ZCL tensor realizes the spanning sector matrices of
+the counterexample as its diagonal physical slices.  Its physical-trace
+transfer is the idempotent product `L R`, while the opposite product `R L`
+retains a nonzero nilpotent remainder.
+
+This statement contains every tensor-independent algebraic conclusion used in
+the present formal proof of Lemma C.5.  It does not identify `pairingL` and
+`pairingR` with the particular tensors chosen by the SAL inverse-map
+construction. -/
+theorem injective_sourceZCL_tensor_with_nilpotent_sector_pairing :
+    MPSTensor.IsInjective mpoTensor.toMPSTensor ∧
+      MPOTensor.IsSourceZCL mpoTensor ∧
+      MPOTensor.physTraceTransfer mpoTensor =
+        Matrix.map pairingProjection Complex.ofReal ∧
+      (∀ k : Fin 4, mpoTensor k k = complexVirtualMatrix k) ∧
+      Submodule.span ℝ (Set.range virtualMatrix) =
+        (⊤ : Submodule ℝ (Matrix (Fin 2) (Fin 2) ℝ)) ∧
+      IsIdempotentElem (pairingL * pairingR) ∧
+      traceMatrix = pairingR * pairingL ∧
+      Matrix.IsPrimitive traceMatrix ∧
+      Matrix.trace traceMatrix = 1 ∧
+      pairingR * (1 - pairingL * pairingR) * pairingL ≠ 0 ∧
+      ¬ ∃ a b : Fin 4 → ℝ, traceMatrix = Matrix.vecMulVec a b :=
+  ⟨mpoTensor_isInjective, mpoTensor_isSourceZCL, physTraceTransfer_mpoTensor,
+    mpoTensor_diagonal_slice, virtualMatrix_span_eq_top,
+    pairingL_mul_pairingR_isIdempotent, pairingR_mul_pairingL.symm,
+    traceMatrix_isPrimitive, trace_traceMatrix,
+    pairing_nilpotent_remainder_ne_zero, traceMatrix_not_rankOne⟩
+
+end TNLean.Archive.PerronFrobeniusVirtualSpanningCounterexample

--- a/TNLean/Archive/PerronFrobeniusVirtualSpanningCounterexample.lean
+++ b/TNLean/Archive/PerronFrobeniusVirtualSpanningCounterexample.lean
@@ -26,12 +26,12 @@ vectors
 with the following properties.
 
 * The four sector matrices `l_k r_k` span the full algebra `M₂(ℝ)`.
-* The closed pairing operator `L R` is idempotent.
-* The opposite product `T = R L` is entrywise nonnegative, primitive, and
+* The closed pairing operator `L Q` is idempotent.
+* The opposite product `T = Q L` is entrywise nonnegative, primitive, and
   trace-normalized.
 * Every positive power of `T` has the same trace, and `T ^ 2 = T ^ 3`.
 * Nevertheless `T` is not idempotent, the remainder
-  `R (1 - L R) L` is nonzero, and `T` has no rank-one factorization.
+  `Q (1 - L Q) L` is nonzero, and `T` has no rank-one factorization.
 * The matrices `l_k r_k` are the diagonal slices of an injective source-ZCL
   MPO tensor.
 
@@ -66,7 +66,7 @@ noncomputable def pairingL : Matrix (Fin 2) (Fin 4) ℝ :=
      0,     1 / 6, 1 / 6, -1 / 3]
 
 /-- The four closed right-sector functionals, arranged as the rows of a matrix. -/
-noncomputable def pairingR : Matrix (Fin 4) (Fin 2) ℝ :=
+noncomputable def pairingQ : Matrix (Fin 4) (Fin 2) ℝ :=
   !![1,  1;
      1,  1;
      1, -1;
@@ -76,7 +76,7 @@ noncomputable def pairingR : Matrix (Fin 4) (Fin 2) ℝ :=
 noncomputable def pairingProjection : Matrix (Fin 2) (Fin 2) ℝ :=
   !![1, 0; 0, 0]
 
-/-- The four-dimensional sector trace matrix `R L`. -/
+/-- The four-dimensional sector trace matrix `Q L`. -/
 noncomputable def traceMatrix : Matrix (Fin 4) (Fin 4) ℝ :=
   !![1 / 6, 1 / 3, 1 / 2, 0;
      1 / 6, 1 / 3, 1 / 2, 0;
@@ -92,34 +92,34 @@ noncomputable def perronProjection : Matrix (Fin 4) (Fin 4) ℝ :=
 
 /-- The sector virtual matrix `l_k r_k`. -/
 noncomputable def virtualMatrix (k : Fin 4) : Matrix (Fin 2) (Fin 2) ℝ :=
-  Matrix.vecMulVec (fun i => pairingL i k) (fun j => pairingR k j)
+  Matrix.vecMulVec (fun i => pairingL i k) (fun j => pairingQ k j)
 
 /-- Coefficients expressing an arbitrary two-by-two matrix in the four sector
 virtual matrices. -/
 noncomputable def reconstructionCoefficients
-    (X : Matrix (Fin 2) (Fin 2) ℝ) : Fin 4 → ℝ :=
+    {𝕜 : Type*} [Ring 𝕜] (X : Matrix (Fin 2) (Fin 2) 𝕜) : Fin 4 → 𝕜 :=
   ![X 0 0 + 5 * X 0 1 + X 1 0 - 7 * X 1 1,
     X 0 0 - X 0 1 + X 1 0 + 5 * X 1 1,
     X 0 0 - X 0 1 + X 1 0 - X 1 1,
     X 0 0 - X 0 1 - 2 * X 1 0 + 2 * X 1 1]
 
-lemma pairingL_mul_pairingR : pairingL * pairingR = pairingProjection := by
+lemma pairingL_mul_pairingQ : pairingL * pairingQ = pairingProjection := by
   ext i j
   fin_cases i <;> fin_cases j <;>
-    simp [pairingL, pairingR, pairingProjection, Matrix.mul_apply,
+    simp [pairingL, pairingQ, pairingProjection, Matrix.mul_apply,
       Fin.sum_univ_four] <;> ring
 
-lemma pairingR_mul_pairingL : pairingR * pairingL = traceMatrix := by
+lemma pairingQ_mul_pairingL : pairingQ * pairingL = traceMatrix := by
   ext i j
   fin_cases i <;> fin_cases j <;>
-    simp [pairingL, pairingR, traceMatrix, Matrix.mul_apply,
+    simp [pairingL, pairingQ, traceMatrix, Matrix.mul_apply,
       Fin.sum_univ_two] <;> ring
 
 /-- The product in the closed-tensor space is idempotent, as required by the
 normalized source zero-correlation-length identity at lines 1490--1493. -/
-theorem pairingL_mul_pairingR_isIdempotent :
-    IsIdempotentElem (pairingL * pairingR) := by
-  rw [pairingL_mul_pairingR]
+theorem pairingL_mul_pairingQ_isIdempotent :
+    IsIdempotentElem (pairingL * pairingQ) := by
+  rw [pairingL_mul_pairingQ]
   ext i j
   fin_cases i <;> fin_cases j <;>
     simp [pairingProjection, Matrix.mul_apply, Fin.sum_univ_two]
@@ -152,16 +152,16 @@ lemma trace_traceMatrix : Matrix.trace traceMatrix = 1 := by
 theorem traceMatrix_tracePowersConstant :
     ∀ N : ℕ, 0 < N →
       Matrix.trace (traceMatrix ^ N) = Matrix.trace traceMatrix := by
-  rw [← pairingR_mul_pairingL]
+  rw [← pairingQ_mul_pairingL]
   exact Matrix.trace_pow_eq_trace_of_rectangular_idempotent
-    pairingL pairingR pairingL_mul_pairingR_isIdempotent
+    pairingL pairingQ pairingL_mul_pairingQ_isIdempotent
 
 /-- The sector trace matrix satisfies the scale-invariant consequence of the
 rectangular idempotence, although it is not itself idempotent. -/
 theorem traceMatrix_sq_eq_cube : traceMatrix ^ 2 = traceMatrix ^ 3 := by
-  rw [← pairingR_mul_pairingL]
+  rw [← pairingQ_mul_pairingL]
   exact Matrix.pow_two_eq_pow_three_of_rectangular_idempotent
-    pairingL pairingR pairingL_mul_pairingR_isIdempotent
+    pairingL pairingQ pairingL_mul_pairingQ_isIdempotent
 
 /-- The sector trace matrix is not idempotent. -/
 theorem traceMatrix_not_idempotent : traceMatrix * traceMatrix ≠ traceMatrix := by
@@ -171,19 +171,19 @@ theorem traceMatrix_not_idempotent : traceMatrix * traceMatrix ≠ traceMatrix :
   norm_num [perronProjection, traceMatrix] at hentry
 
 /-- The nilpotent remainder is exactly the failure of the desired identity
-`R (1 - L R) L = 0`. -/
+`Q (1 - L Q) L = 0`. -/
 theorem pairing_nilpotent_remainder_ne_zero :
-    pairingR * (1 - pairingL * pairingR) * pairingL ≠ 0 := by
+    pairingQ * (1 - pairingL * pairingQ) * pairingL ≠ 0 := by
   intro h
   apply traceMatrix_not_idempotent
-  rw [← pairingR_mul_pairingL]
+  rw [← pairingQ_mul_pairingL]
   have hdiff :
-      pairingR * pairingL -
-          (pairingR * pairingL) * (pairingR * pairingL) = 0 := by
+      pairingQ * pairingL -
+          (pairingQ * pairingL) * (pairingQ * pairingL) = 0 := by
     calc
-      pairingR * pairingL -
-          (pairingR * pairingL) * (pairingR * pairingL) =
-        pairingR * (1 - pairingL * pairingR) * pairingL := by
+      pairingQ * pairingL -
+          (pairingQ * pairingL) * (pairingQ * pairingL) =
+        pairingQ * (1 - pairingL * pairingQ) * pairingL := by
           simp only [Matrix.mul_sub, Matrix.mul_one, Matrix.sub_mul,
             Matrix.mul_assoc]
       _ = 0 := h
@@ -194,7 +194,7 @@ theorem virtualMatrix_reconstruction (X : Matrix (Fin 2) (Fin 2) ℝ) :
     ∑ k, reconstructionCoefficients X k • virtualMatrix k = X := by
   ext i j
   fin_cases i <;> fin_cases j <;>
-    simp [reconstructionCoefficients, virtualMatrix, pairingL, pairingR,
+    simp [reconstructionCoefficients, virtualMatrix, pairingL, pairingQ,
       Fin.sum_univ_four] <;> ring
 
 /-- The sector virtual matrices span the full two-by-two matrix algebra. -/
@@ -221,21 +221,12 @@ virtual matrices above. -/
 noncomputable def mpoTensor : MPOTensor 4 2 :=
   fun i j => if i = j then complexVirtualMatrix i else 0
 
-/-- Complex coefficients expressing an arbitrary two-by-two matrix in the
-four complexified sector virtual matrices. -/
-noncomputable def complexReconstructionCoefficients
-    (X : Matrix (Fin 2) (Fin 2) ℂ) : Fin 4 → ℂ :=
-  ![X 0 0 + 5 * X 0 1 + X 1 0 - 7 * X 1 1,
-    X 0 0 - X 0 1 + X 1 0 + 5 * X 1 1,
-    X 0 0 - X 0 1 + X 1 0 - X 1 1,
-    X 0 0 - X 0 1 - 2 * X 1 0 + 2 * X 1 1]
-
 theorem complexVirtualMatrix_reconstruction (X : Matrix (Fin 2) (Fin 2) ℂ) :
-    ∑ k, complexReconstructionCoefficients X k • complexVirtualMatrix k = X := by
+    ∑ k, reconstructionCoefficients X k • complexVirtualMatrix k = X := by
   ext i j
   fin_cases i <;> fin_cases j <;>
-    simp [complexReconstructionCoefficients, complexVirtualMatrix, virtualMatrix,
-      pairingL, pairingR, Fin.sum_univ_four] <;> ring
+    simp [reconstructionCoefficients, complexVirtualMatrix, virtualMatrix,
+      pairingL, pairingQ, Fin.sum_univ_four] <;> ring
 
 lemma complexVirtualMatrix_mem_tensor_span (k : Fin 4) :
     complexVirtualMatrix k ∈
@@ -264,11 +255,11 @@ lemma physTraceTransfer_mpoTensor :
   ext i j
   fin_cases i <;> fin_cases j <;>
     simp [MPOTensor.physTraceTransfer, mpoTensor, complexVirtualMatrix,
-      virtualMatrix, pairingL, pairingR, pairingProjection,
+      virtualMatrix, pairingL, pairingQ, pairingProjection,
       Fin.sum_univ_four] <;> ring
 
 /-- The injective diagonal tensor has source zero correlation length because
-its physical-trace transfer is the idempotent `L R`. -/
+its physical-trace transfer is the idempotent `L Q`. -/
 theorem mpoTensor_isSourceZCL : MPOTensor.IsSourceZCL mpoTensor := by
   apply MPOTensor.isSourceZCL_of_physTraceTransfer_sq mpoTensor
   · rw [physTraceTransfer_mpoTensor]
@@ -312,26 +303,26 @@ satisfy the rectangular pairing identity, primitivity, trace normalization,
 and full virtual-matrix spanning, while the trace matrix is neither idempotent
 nor an outer product. -/
 theorem counterexample_with_virtual_spanning :
-    traceMatrix = pairingR * pairingL ∧
-      IsIdempotentElem (pairingL * pairingR) ∧
+    traceMatrix = pairingQ * pairingL ∧
+      IsIdempotentElem (pairingL * pairingQ) ∧
       Matrix.IsPrimitive traceMatrix ∧
       Matrix.trace traceMatrix = 1 ∧
       Submodule.span ℝ (Set.range virtualMatrix) =
         (⊤ : Submodule ℝ (Matrix (Fin 2) (Fin 2) ℝ)) ∧
       traceMatrix * traceMatrix ≠ traceMatrix ∧
       ¬ ∃ a b : Fin 4 → ℝ, traceMatrix = Matrix.vecMulVec a b :=
-  ⟨pairingR_mul_pairingL.symm, pairingL_mul_pairingR_isIdempotent,
+  ⟨pairingQ_mul_pairingL.symm, pairingL_mul_pairingQ_isIdempotent,
     traceMatrix_isPrimitive, trace_traceMatrix, virtualMatrix_span_eq_top,
     traceMatrix_not_idempotent, traceMatrix_not_rankOne⟩
 
 /-- An injective source-ZCL tensor realizes the spanning sector matrices of
 the counterexample as its diagonal physical slices.  Its physical-trace
-transfer is the idempotent product `L R`, while the opposite product `R L`
+transfer is the idempotent product `L Q`, while the opposite product `Q L`
 retains a nonzero nilpotent remainder.
 
 This statement contains every tensor-independent algebraic conclusion used in
 the present formal proof of Lemma C.5.  It does not identify `pairingL` and
-`pairingR` with the particular tensors chosen by the SAL inverse-map
+`pairingQ` with the particular tensors chosen by the SAL inverse-map
 construction. -/
 theorem injective_sourceZCL_tensor_with_nilpotent_sector_pairing :
     MPSTensor.IsInjective mpoTensor.toMPSTensor ∧
@@ -341,18 +332,18 @@ theorem injective_sourceZCL_tensor_with_nilpotent_sector_pairing :
       (∀ k : Fin 4, mpoTensor k k = complexVirtualMatrix k) ∧
       Submodule.span ℝ (Set.range virtualMatrix) =
         (⊤ : Submodule ℝ (Matrix (Fin 2) (Fin 2) ℝ)) ∧
-      IsIdempotentElem (pairingL * pairingR) ∧
-      traceMatrix = pairingR * pairingL ∧
+      IsIdempotentElem (pairingL * pairingQ) ∧
+      traceMatrix = pairingQ * pairingL ∧
       Matrix.IsPrimitive traceMatrix ∧
       Matrix.trace traceMatrix = 1 ∧
       (∀ N : ℕ, 0 < N →
         Matrix.trace (traceMatrix ^ N) = Matrix.trace traceMatrix) ∧
       traceMatrix ^ 2 = traceMatrix ^ 3 ∧
-      pairingR * (1 - pairingL * pairingR) * pairingL ≠ 0 ∧
+      pairingQ * (1 - pairingL * pairingQ) * pairingL ≠ 0 ∧
       ¬ ∃ a b : Fin 4 → ℝ, traceMatrix = Matrix.vecMulVec a b :=
   ⟨mpoTensor_isInjective, mpoTensor_isSourceZCL, physTraceTransfer_mpoTensor,
     mpoTensor_diagonal_slice, virtualMatrix_span_eq_top,
-    pairingL_mul_pairingR_isIdempotent, pairingR_mul_pairingL.symm,
+    pairingL_mul_pairingQ_isIdempotent, pairingQ_mul_pairingL.symm,
     traceMatrix_isPrimitive, trace_traceMatrix,
     traceMatrix_tracePowersConstant, traceMatrix_sq_eq_cube,
     pairing_nilpotent_remainder_ne_zero, traceMatrix_not_rankOne⟩

--- a/TNLean/Archive/PerronFrobeniusVirtualSpanningCounterexample.lean
+++ b/TNLean/Archive/PerronFrobeniusVirtualSpanningCounterexample.lean
@@ -3,16 +3,15 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import Mathlib.Data.Matrix.Basis
 import Mathlib.Data.Matrix.Mul
 import Mathlib.Data.Real.Basic
 import Mathlib.LinearAlgebra.Matrix.Irreducible.Defs
 import Mathlib.LinearAlgebra.Matrix.Notation
 import Mathlib.LinearAlgebra.Matrix.Trace
 import Mathlib.Tactic.FinCases
-import Mathlib.Tactic.Linarith
 import Mathlib.Tactic.NormNum
 import Mathlib.Tactic.Ring
+import TNLean.Algebra.PerronFrobenius.RankOne
 import TNLean.MPS.MPDO.ZCL
 
 /-!
@@ -30,7 +29,11 @@ with the following properties.
 * The closed pairing operator `L R` is idempotent.
 * The opposite product `T = R L` is entrywise nonnegative, primitive, and
   trace-normalized.
-* Nevertheless `T` is not idempotent and has no rank-one factorization.
+* Every positive power of `T` has the same trace, and `T ^ 2 = T ^ 3`.
+* Nevertheless `T` is not idempotent, the remainder
+  `R (1 - L R) L` is nonzero, and `T` has no rank-one factorization.
+* The matrices `l_k r_k` are the diagonal slices of an injective source-ZCL
+  MPO tensor.
 
 Thus the virtual-matrix spanning conclusion obtained from injectivity in the
 formal inverse-map construction does not, by itself, eliminate the nilpotent
@@ -44,6 +47,13 @@ This file is deliberately excluded from the root `TNLean.lean` import list.
 
 * Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
   Appendix C.2, Lemmas C.4--C.5, lines 1406--1499.
+
+## Main results
+
+* `counterexample_with_virtual_spanning`: the matrix-level obstruction with
+  full virtual spanning.
+* `injective_sourceZCL_tensor_with_nilpotent_sector_pairing`: the same sector
+  data realized as the diagonal slices of an injective source-ZCL MPO tensor.
 -/
 
 namespace TNLean.Archive.PerronFrobeniusVirtualSpanningCounterexample
@@ -120,23 +130,11 @@ lemma traceMatrix_sq : traceMatrix * traceMatrix = perronProjection := by
     simp [traceMatrix, perronProjection, Matrix.mul_apply,
       Fin.sum_univ_four] <;> ring
 
-lemma traceMatrix_mul_perronProjection :
-    traceMatrix * perronProjection = perronProjection := by
-  ext i j
-  fin_cases i <;> fin_cases j <;>
-    simp [traceMatrix, perronProjection, Matrix.mul_apply,
-      Fin.sum_univ_four] <;> ring
-
-lemma perronProjection_mul_traceMatrix :
-    perronProjection * traceMatrix = perronProjection := by
-  ext i j
-  fin_cases i <;> fin_cases j <;>
-    simp [traceMatrix, perronProjection, Matrix.mul_apply,
-      Fin.sum_univ_four] <;> ring
-
 lemma traceMatrix_nonneg (i j : Fin 4) : 0 ≤ traceMatrix i j := by
-  fin_cases i <;> fin_cases j <;> simp [traceMatrix]
-  norm_num
+  fin_cases i <;> fin_cases j <;>
+    first
+    | (simp [traceMatrix]; norm_num)
+    | simp [traceMatrix]
 
 lemma traceMatrix_pow_two_pos (i j : Fin 4) : 0 < (traceMatrix ^ 2) i j := by
   rw [sq, traceMatrix_sq]
@@ -149,6 +147,21 @@ theorem traceMatrix_isPrimitive : Matrix.IsPrimitive traceMatrix :=
 lemma trace_traceMatrix : Matrix.trace traceMatrix = 1 := by
   simp [Matrix.trace, traceMatrix, Fin.sum_univ_four]
   ring
+
+/-- Every positive power of the sector trace matrix has the same trace. -/
+theorem traceMatrix_tracePowersConstant :
+    ∀ N : ℕ, 0 < N →
+      Matrix.trace (traceMatrix ^ N) = Matrix.trace traceMatrix := by
+  rw [← pairingR_mul_pairingL]
+  exact Matrix.trace_pow_eq_trace_of_rectangular_idempotent
+    pairingL pairingR pairingL_mul_pairingR_isIdempotent
+
+/-- The sector trace matrix satisfies the scale-invariant consequence of the
+rectangular idempotence, although it is not itself idempotent. -/
+theorem traceMatrix_sq_eq_cube : traceMatrix ^ 2 = traceMatrix ^ 3 := by
+  rw [← pairingR_mul_pairingL]
+  exact Matrix.pow_two_eq_pow_three_of_rectangular_idempotent
+    pairingL pairingR pairingL_mul_pairingR_isIdempotent
 
 /-- The sector trace matrix is not idempotent. -/
 theorem traceMatrix_not_idempotent : traceMatrix * traceMatrix ≠ traceMatrix := by
@@ -332,12 +345,16 @@ theorem injective_sourceZCL_tensor_with_nilpotent_sector_pairing :
       traceMatrix = pairingR * pairingL ∧
       Matrix.IsPrimitive traceMatrix ∧
       Matrix.trace traceMatrix = 1 ∧
+      (∀ N : ℕ, 0 < N →
+        Matrix.trace (traceMatrix ^ N) = Matrix.trace traceMatrix) ∧
+      traceMatrix ^ 2 = traceMatrix ^ 3 ∧
       pairingR * (1 - pairingL * pairingR) * pairingL ≠ 0 ∧
       ¬ ∃ a b : Fin 4 → ℝ, traceMatrix = Matrix.vecMulVec a b :=
   ⟨mpoTensor_isInjective, mpoTensor_isSourceZCL, physTraceTransfer_mpoTensor,
     mpoTensor_diagonal_slice, virtualMatrix_span_eq_top,
     pairingL_mul_pairingR_isIdempotent, pairingR_mul_pairingL.symm,
     traceMatrix_isPrimitive, trace_traceMatrix,
+    traceMatrix_tracePowersConstant, traceMatrix_sq_eq_cube,
     pairing_nilpotent_remainder_ne_zero, traceMatrix_not_rankOne⟩
 
 end TNLean.Archive.PerronFrobeniusVirtualSpanningCounterexample

--- a/docs/counterexamples.md
+++ b/docs/counterexamples.md
@@ -18,6 +18,25 @@ mathematical obstruction.
   constant traces but not rank one. An additional condition excluding the
   generalized zero-eigenspace is required.
 
+### Virtual spanning does not eliminate the nilpotent sector pairing
+
+- Location:
+  `TNLean/Archive/PerronFrobeniusVirtualSpanningCounterexample.lean`
+- Main declaration:
+  `TNLean.Archive.PerronFrobeniusVirtualSpanningCounterexample.injective_sourceZCL_tensor_with_nilpotent_sector_pairing`
+- Statement refuted: source ZCL, injectivity, primitivity, trace
+  normalization, rectangular pairing idempotence, constant positive-power
+  traces, and full spanning of the virtual matrix algebra imply that the
+  opposite rectangular product has rank one.
+- Witness: four rational pairs $l_k,r_k$ with $LQ$ idempotent and $T=QL$
+  primitive, but $Q(1-LQ)L=T-T^2\ne0$. The matrices $l_k r_k$ span
+  $M_2(\mathbb R)$ and occur as the diagonal slices of an injective
+  source-ZCL MPO tensor.
+- Boundary: the witness is not identified with the factors selected by the
+  SAL inverse-map construction. It therefore isolates the missing
+  SAL/provenance consequence but does not refute the full statement of
+  Lemma C.5.
+
 ### BiCF does not follow from the other per-copy `HorizontalCFData` fields
 
 - Location: `TNLean/MPS/MPDO/BiCFDerivation.lean`

--- a/docs/paper-gaps/cpgsv17_pf_rank_one.tex
+++ b/docs/paper-gaps/cpgsv17_pf_rank_one.tex
@@ -337,6 +337,93 @@ common bond space.  Their membership in corresponding members of an
 independent family of subspaces --- or their independence by another argument
 --- therefore does not follow from the displayed equations alone.
 
+\subsection{Virtual spanning does not eliminate the nilpotent part}
+
+Injectivity gives more than primitivity in the present formal development:
+the sector virtual matrices span the full virtual matrix algebra.  This
+additional conclusion still does not imply the idempotence of the opposite
+product.  Consider
+\[
+ L=\begin{pmatrix}
+  \tfrac16&\tfrac16&\tfrac13&\tfrac13\\
+  0&\tfrac16&\tfrac16&-\tfrac13
+ \end{pmatrix},
+ \qquad
+ Q=\begin{pmatrix}
+  1&1\\ 1&1\\ 1&-1\\ 1&0
+ \end{pmatrix}.
+\]
+Writing $l_k$ for the $k$th column of $L$ and $r_k$ for the $k$th row of
+$Q$, direct multiplication gives
+\[
+ LQ=\begin{pmatrix}1&0\\0&0\end{pmatrix},
+ \qquad
+ T=QL=\begin{pmatrix}
+  \tfrac16&\tfrac13&\tfrac12&0\\
+  \tfrac16&\tfrac13&\tfrac12&0\\
+  \tfrac16&0&\tfrac16&\tfrac23\\
+  \tfrac16&\tfrac16&\tfrac13&\tfrac13
+ \end{pmatrix}.
+\]
+The square of $T$ is
+\[
+ T^2=\begin{pmatrix}
+  \tfrac16&\tfrac16&\tfrac13&\tfrac13\\
+  \tfrac16&\tfrac16&\tfrac13&\tfrac13\\
+  \tfrac16&\tfrac16&\tfrac13&\tfrac13\\
+  \tfrac16&\tfrac16&\tfrac13&\tfrac13
+ \end{pmatrix}.
+\]
+Thus $T$ is primitive, $\operatorname{tr}(T)=1$, $T^2=T^3$, and
+$T\ne T^2$.  Equivalently, the exact missing expression is nonzero:
+\[
+ Q(1-LQ)L=T-T^2\ne0.
+\]
+Moreover, the four matrices $l_k r_k$ span $M_2(\mathbb R)$.  For example,
+after vectorizing them in the order $(11,12,21,22)$, the determinant of the
+resulting four-by-four matrix is $1/108$.  Consequently full virtual spanning
+does not exclude the generalized zero-eigenspace.
+
+This example is realized at the level of physical slices by the diagonal
+matrix product operator tensor
+\[
+ K^{ij}=\delta_{ij}\,l_i r_i.
+\]
+Its doubled-index tensor is injective because the four nonzero slices span
+$M_2(\mathbb C)$, and its physical-trace transfer is
+\(
+ \sum_i K^{ii}=LQ
+\),
+so it satisfies source zero correlation length.  These assertions, together
+with primitivity, trace normalization, the spanning identity, and the nonzero
+nilpotent remainder, are proved in
+\path{TNLean/Archive/PerronFrobeniusVirtualSpanningCounterexample.lean}.
+\footnote{\sloppy Combined formal declaration:
+{\scriptsize\leanid{TNLean.Archive.PerronFrobeniusVirtualSpanningCounterexample.injective_sourceZCL_tensor_with_nilpotent_sector_pairing}}.}
+
+The construction does not yet identify $L$ and $Q$ with the particular closed
+tensors selected from a Hayashi decomposition by
+\leanid{MPOTensor.zeroWeightReparameterizedInverseMapPhysicalSectorFactorization}.
+This distinction is essential.  The present entropy interface derives a
+Hayashi decomposition from SAL and proves SAL from explicitly supplied local
+renormalization channels, but it does not provide a converse criterion for a
+classical diagonal tensor of the form above.  Thus neither SAL for this tensor
+nor the required inverse-map provenance is asserted by the formal
+counterexample.  It is not a counterexample to the full statement of
+Lemma~C.5.
+
+The obstruction instead proves that every presently exported algebraic
+consequence---source ZCL, injectivity, primitivity, trace normalization,
+rectangular pairing idempotence, constant positive-power traces, and full
+virtual spanning---is insufficient.  A source-faithful completion must derive
+an additional identity from SAL and from the provenance of the inverse-map
+tensors.  In the notation above, the needed assertion is precisely
+\[
+ Q(1-LQ)L=0,
+\]
+or any equivalent statement excluding the nilpotent generalized
+zero-eigenspace of $QL$.
+
 \section{A positive-semidefinite route}
 
 The formal development proves a corrected sufficient matrix theorem. Let $T$


### PR DESCRIPTION
## Summary

This pull request formalizes a four-sector obstruction to the rank-one step in arXiv:1606.00608, Appendix C.2, Lemma C.5.

For explicit rational matrices (L) and (Q), it proves:

- (LQ) is idempotent;
- (T=QL) is entrywise nonnegative, primitive, and trace-normalized;
- (T^2=T^3), but (T\ne T^2);
- the four virtual matrices (l_k r_k) span (M_2(\mathbb R));
- (Q(1-LQ)L=T-T^2\ne0);
- (T) has no outer-product factorization.

It also realizes the four virtual matrices as the diagonal physical slices of an explicit MPO tensor and proves that its doubled-index tensor is injective and that it satisfies source zero correlation length. The paper-gap note now records this stronger obstruction and identifies the remaining source-specific information.

## Mathematical consequence

The checked example shows that the currently exported algebraic consequences—source ZCL, injectivity, primitivity, trace normalization, rectangular pairing idempotence, constant positive-power traces, and full virtual spanning—do not eliminate the nilpotent generalized zero-eigenspace.

The combined formal declaration is:

`TNLean.Archive.PerronFrobeniusVirtualSpanningCounterexample.injective_sourceZCL_tensor_with_nilpotent_sector_pairing`.

## Scope boundary

This is not a counterexample to the full statement of Lemma C.5. The formal development does not yet prove SAL for the explicit tensor, nor identify its (L,Q) with the particular closed tensors selected by `zeroWeightReparameterizedInverseMapPhysicalSectorFactorization`. Those are now recorded as the exact missing ingredients.

Advances #3593. This pull request does not close #3593, #232, or #236.

## Validation

- `lake env lean TNLean/Archive/PerronFrobeniusVirtualSpanningCounterexample.lean`
- `lake build` — completed successfully, 9,553 jobs
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `TEXINPUTS=.: BIBINPUTS=.: latexmk -pdf -interaction=nonstopmode -halt-on-error -outdir=/tmp/tnlean-3593-latex-local cpgsv17_pf_rank_one.tex`
- `git diff --check origin/main...HEAD`
- integrity scan for `sorry`, `admit`, `axiom`, `native_decide`, and `unsafeCast` in the changed files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Archive-only formal mathematics and documentation; no changes to the default Lean import graph or runtime behavior.
> 
> **Overview**
> Adds a new archive Lean module **`PerronFrobeniusVirtualSpanningCounterexample`** (excluded from the root import) that proves a **stronger** obstruction than the existing rectangular-pairing rank-one counterexample: explicit rational **L**, **Q** with **LQ** idempotent, **T = QL** primitive and trace-normalized, **T² = T³** but **T ≠ T²**, **Q(1−LQ)L ≠ 0**, no rank-one factorization of **T**, and the four sector matrices **lₖrₖ** spanning **M₂(ℝ)**.
> 
> It also builds a **diagonal MPO tensor** whose diagonal slices are those virtual matrices and proves **injectivity** and **source ZCL**, packaged in **`counterexample_with_virtual_spanning`** and **`injective_sourceZCL_tensor_with_nilpotent_sector_pairing`**.
> 
> **`docs/counterexamples.md`** registers the new witness and states the refuted implication (virtual spanning does not force rank one). **`docs/paper-gaps/cpgsv17_pf_rank_one.tex`** adds a subsection documenting the example, the MPO realization, and the scope boundary (not SAL/inverse-map provenance; not a refutation of full Lemma C.5).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 869a572eae1d50da293b70fa163b7acd689ab345. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->