### PR TITLE
feat(MPS/MPDO): prove all-length SAL Markov decomposition

### DIFF
--- a/TNLean/Channel/PartialTrace.lean
+++ b/TNLean/Channel/PartialTrace.lean
@@ -38,6 +38,8 @@ Proposition 2.1) and for reduced states on contiguous tensor factors.
   right partial trace
 * `Matrix.partialTraceRight_kronecker`: the right partial trace of a Kronecker
   product
+* `Matrix.partialTraceRightAlong`: the partial trace after choosing a product
+  decomposition of the right factor
 * `Matrix.trace_eq_trace_traceLeft`: `tr(X) = tr(tr_A(X))`
 * `Matrix.traceLeft_kronecker`: `tr_A(A ⊗ B) = tr(A) • B`
 * `Matrix.traceRight_kronecker`: `tr_B(A ⊗ B) = A • tr(B)`
@@ -114,6 +116,44 @@ theorem partialTraceRight_kronecker (A : Matrix α α ℂ) (B : Matrix β β ℂ
   simp only [partialTraceRight_apply, kroneckerMap_apply, Matrix.smul_apply, Matrix.trace,
     Matrix.diag, smul_eq_mul, ← Finset.mul_sum]
   ring
+
+/-- Reindex the right tensor factor as `β' × γ`, keeping the left factor fixed. -/
+def rightSplitEquiv {α β β' γ : Type*} (e : β ≃ β' × γ) :
+    α × β ≃ (α × β') × γ :=
+  (Equiv.prodCongr (Equiv.refl α) e).trans (Equiv.prodAssoc α β' γ).symm
+
+/-- Trace the second component of a chosen product decomposition of the right
+tensor factor. -/
+noncomputable def partialTraceRightAlong {α β β' γ : Type*}
+    [Fintype γ] (e : β ≃ β' × γ) (X : Matrix (α × β) (α × β) ℂ) :
+    Matrix (α × β') (α × β') ℂ :=
+  partialTraceRight
+    (X.submatrix (rightSplitEquiv e).symm (rightSplitEquiv e).symm)
+
+@[simp]
+theorem partialTraceRightAlong_apply {α β β' γ : Type*}
+    [Fintype γ] (e : β ≃ β' × γ) (X : Matrix (α × β) (α × β) ℂ)
+    (a a' : α) (b b' : β') :
+    partialTraceRightAlong e X (a, b) (a', b') =
+      ∑ c : γ, X (a, e.symm (b, c)) (a', e.symm (b', c)) := by
+  rfl
+
+/-- The partial trace along a product decomposition preserves positive
+semidefiniteness. -/
+theorem PosSemidef.partialTraceRightAlong {α β β' γ : Type*}
+    [Finite α] [Finite β'] [Fintype γ] {X : Matrix (α × β) (α × β) ℂ}
+    (hX : X.PosSemidef) (e : β ≃ β' × γ) :
+    (partialTraceRightAlong e X).PosSemidef := by
+  exact (hX.submatrix (rightSplitEquiv e).symm).partialTraceRight
+
+/-- The partial trace along a product decomposition preserves the full trace. -/
+theorem trace_partialTraceRightAlong {α β β' γ : Type*}
+    [Fintype α] [Fintype β] [Fintype β'] [Fintype γ] (e : β ≃ β' × γ)
+    (X : Matrix (α × β) (α × β) ℂ) :
+    (partialTraceRightAlong e X).trace = X.trace := by
+  rw [partialTraceRightAlong, trace_partialTraceRight]
+  simp only [Matrix.trace, Matrix.diag, Matrix.submatrix_apply]
+  exact (rightSplitEquiv e).symm.sum_comp fun x ↦ X x x
 
 /-- The partial trace over the second factor is additive. -/
 theorem partialTraceRight_add (X Y : Matrix (α × β) (α × β) ℂ) :

--- a/TNLean/Entropy/MarkovChain.lean
+++ b/TNLean/Entropy/MarkovChain.lean
@@ -35,6 +35,8 @@ the namespace abbreviation for the quantum-Markov-chain decomposition.
 * `Entropy.exists_quantumMarkovDecomposition_of_ssaEquality` — forward
   direction.
 * `Entropy.isSSAEquality_of_quantumMarkovDecomposition` — reverse direction.
+* `Entropy.exists_quantumMarkovDecomposition_rightMarginalAlong` — tracing
+  part of the right subsystem preserves the decomposition.
 
 ## References
 
@@ -100,6 +102,102 @@ theorem isSSAEquality_of_quantumMarkovDecomposition
     (hMarkov : Nonempty (QuantumMarkovDecomposition ρ_ABC)) :
     IsSSAEquality ρ_ABC hρ_dm.1.isHermitian :=
   (ssaEquality_iff_exists_quantumMarkovDecomposition ρ_ABC hρ_dm).mpr hMarkov
+
+/-- Trace a chosen factor of the right subsystem of a tripartite state.
+
+If `eC` identifies (C) with (C' \otimes E), this is the marginal on
+(A \otimes B \otimes C') obtained by tracing out (E). -/
+noncomputable def rightMarginalAlong {dA dB dC dC' : ℕ} {γ : Type*} [Fintype γ]
+    (eC : Fin dC ≃ Fin dC' × γ)
+    (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ) :
+    Matrix (Fin dA × Fin dB × Fin dC') (Fin dA × Fin dB × Fin dC') ℂ :=
+  fun (a, b, c) (a', b', c') ↦
+    ∑ x : γ, ρ_ABC (a, b, eC.symm (c, x)) (a', b', eC.symm (c', x))
+
+/-- A quantum-Markov decomposition on the middle subsystem is preserved when
+part of the right subsystem is traced out.
+
+This is the partial-trace step in arXiv:1606.00608, Appendix C.2, Lemma
+Lsigma3, lines 1360--1369. -/
+theorem exists_quantumMarkovDecomposition_rightMarginalAlong
+    {dA dB dC dC' : ℕ} {γ : Type*} [Fintype γ]
+    (eC : Fin dC ≃ Fin dC' × γ)
+    (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ)
+    (hMarkov : Nonempty (QuantumMarkovDecomposition ρ_ABC)) :
+    Nonempty (QuantumMarkovDecomposition (rightMarginalAlong eC ρ_ABC)) := by
+  obtain ⟨H⟩ := hMarkov
+  refine ⟨{
+    m := H.m
+    dL := H.dL
+    dR := H.dR
+    decompB := H.decompB
+    U_B := H.U_B
+    p := H.p
+    hp_nonneg := H.hp_nonneg
+    hp_sum := H.hp_sum
+    ρ_left := H.ρ_left
+    ρ_right := fun j ↦ Matrix.partialTraceRightAlong eC (H.ρ_right j)
+    hρ_left_dm := H.hρ_left_dm
+    hρ_right_dm := by
+      intro j
+      constructor
+      · exact (H.hρ_right_dm j).1.partialTraceRightAlong eC
+      · rw [Matrix.trace_partialTraceRightAlong]
+        exact (H.hρ_right_dm j).2
+    h_state := ?_ }⟩
+  classical
+  ext x y
+  rcases x with ⟨a, ⟨⟨j, lr⟩, c⟩⟩
+  rcases y with ⟨a', ⟨⟨j', lr'⟩, c'⟩⟩
+  rw [HayashiMarkov.blockState_apply]
+  rw [Matrix.reindex_apply]
+  rw [Matrix.submatrix_apply]
+  change
+    (HayashiMarkov.liftB (dA := dA) (dC := dC')
+        (H.U_B : Matrix (Fin dB) (Fin dB) ℂ) *
+        rightMarginalAlong eC ρ_ABC *
+        (HayashiMarkov.liftB (dA := dA) (dC := dC')
+          (H.U_B : Matrix (Fin dB) (Fin dB) ℂ))ᴴ)
+      (a, H.decompB.symm ⟨j, lr⟩, c) (a', H.decompB.symm ⟨j', lr'⟩, c') = _
+  rw [HayashiMarkov.liftB_conj_apply]
+  simp only [rightMarginalAlong]
+  simp_rw [Finset.mul_sum]
+  simp_rw [Finset.sum_mul]
+  let F (b b' : Fin dB) (x : γ) :=
+    (H.U_B : Matrix (Fin dB) (Fin dB) ℂ) (H.decompB.symm ⟨j, lr⟩) b *
+      ρ_ABC (a, b, eC.symm (c, x)) (a', b', eC.symm (c', x)) *
+      star ((H.U_B : Matrix (Fin dB) (Fin dB) ℂ) (H.decompB.symm ⟨j', lr'⟩) b')
+  change (∑ b : Fin dB, ∑ b' : Fin dB, ∑ x : γ, F b b' x) = _
+  have hsum : (∑ b : Fin dB, ∑ b' : Fin dB, ∑ x : γ, F b b' x) =
+      ∑ x : γ, ∑ b : Fin dB, ∑ b' : Fin dB, F b b' x := by
+    calc
+      _ = ∑ b : Fin dB, ∑ x : γ, ∑ b' : Fin dB, F b b' x :=
+        Finset.sum_congr rfl fun _ _ ↦ Finset.sum_comm
+      _ = _ := Finset.sum_comm
+  rw [hsum]
+  have hstate (x : γ) : (∑ b : Fin dB, ∑ b' : Fin dB, F b b' x) =
+      if h : j = j' then
+        (H.p j : ℂ) * H.ρ_left j (a, lr.1) (a', h ▸ lr'.1) *
+          H.ρ_right j (lr.2, eC.symm (c, x)) (h ▸ lr'.2, eC.symm (c', x))
+      else 0 := by
+    have hx := congrArg
+      (fun M ↦ M (a, ⟨j, lr⟩, eC.symm (c, x))
+        (a', ⟨j', lr'⟩, eC.symm (c', x))) H.h_state
+    rw [Matrix.reindex_apply, Matrix.submatrix_apply] at hx
+    change
+      (HayashiMarkov.liftB (dA := dA) (dC := dC)
+          (H.U_B : Matrix (Fin dB) (Fin dB) ℂ) * ρ_ABC *
+          (HayashiMarkov.liftB (dA := dA) (dC := dC)
+            (H.U_B : Matrix (Fin dB) (Fin dB) ℂ))ᴴ)
+        (a, H.decompB.symm ⟨j, lr⟩, eC.symm (c, x))
+        (a', H.decompB.symm ⟨j', lr'⟩, eC.symm (c', x)) = _ at hx
+    rw [HayashiMarkov.liftB_conj_apply, HayashiMarkov.blockState_apply] at hx
+    simpa [F] using hx
+  simp_rw [hstate]
+  by_cases hj : j = j'
+  all_goals simp [hj, Matrix.partialTraceRightAlong_apply, Finset.mul_sum]
 
 end MarkovChain
 

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -47,8 +47,11 @@ arXiv:1606.00608 (Cirac–Pérez-García–Schuch–Verstraete).
   its three-site specialization.
 - `MPOTensor.sal_implies_eta_structure`: equality in strong subadditivity gives
   the local structure by the Hayashi equality characterization.
-- `MPOTensor.exists_etaStructure_reducedBlockState_of_isSAL`: the three-site
-  marginal of the normalized four-site periodic state has this local structure.
+- `MPOTensor.exists_etaStructure_reducedBlockState_three_of_isSAL`: the
+  first-three-site marginal of every chain of length at least four has this
+  local structure.
+- `MPOTensor.exists_etaStructure_reducedBlockState_of_isSAL`: the four-site
+  specialization retained for subsequent arguments.
 - `MPOTensor.etaOperators`: the dependent type of explicit neighboring operator
   families over a fixed Hayashi decomposition.
 - `MPOTensor.ExplicitEtaOperators`: the explicit neighboring operators
@@ -511,6 +514,109 @@ theorem sal_implies_eta_structure
     Nonempty (EtaStructure ρ_ABC) :=
   Entropy.exists_quantumMarkovDecomposition_of_ssaEquality ρ_ABC hρ_dm hSAL
 
+/-- **Lemma Lsigma3.** If `K` satisfies the strong area law, then the first-three-site
+marginal of every periodic chain of length at least four admits a quantum Markov
+decomposition on the middle site.
+
+The decomposition is obtained first for the marginal on the first (N-1) sites,
+with consecutive regions of lengths (1), (1), and (N-3), and is then
+preserved while the last (N-4) sites of the third region are traced out.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma Lsigma3, lines 1351--1371. -/
+theorem exists_etaStructure_reducedBlockState_three_of_isSAL
+    {d D : ℕ} (K : MPOTensor d D) (hSAL : IsSAL K) {N : ℕ} (hN : 4 ≤ N) :
+    Nonempty
+      (EtaStructure
+        ((K.reducedBlockState N 3 (by omega)).submatrix
+          (fun p : Fin d × Fin d × Fin d ↦ ![p.1, p.2.1, p.2.2])
+          (fun p : Fin d × Fin d × Fin d ↦ ![p.1, p.2.1, p.2.2]))) := by
+  obtain ⟨n, rfl⟩ := Nat.exists_eq_add_of_le hN
+  let N := 4 + n
+  let hM : (mpo K N).PosSemidef := (Classical.choose hSAL) N (by omega)
+  let hNm1 : 1 + 1 + (N - 3) ≤ N := by omega
+  let ρflat :=
+    (K.reducedBlockState N (1 + 1 + (N - 3)) hNm1).submatrix
+      (tripartiteSplitEquiv d 1 1 (N - 3)).symm
+      (tripartiteSplitEquiv d 1 1 (N - 3)).symm
+  let eSite : Fin d ≃ Fin (d ^ 1) :=
+    (Equiv.funUnique (Fin 1) (Fin d)).symm.trans finFunctionFinEquiv
+  let E := eSite.prodCongr (eSite.prodCongr (Equiv.refl (Fin (d ^ (N - 3)))))
+  have hρflatPos : ρflat.PosSemidef := by
+    exact (reducedBlockState_posSemidef K N (1 + 1 + (N - 3)) hNm1 hM).submatrix _
+  have hρflatTrace : ρflat.trace = 1 := by
+    dsimp only [ρflat]
+    rw [Matrix.trace_submatrix_equiv]
+    exact reducedBlockState_trace K N (1 + 1 + (N - 3)) hNm1
+      ((Classical.choose_spec hSAL).1 N (by omega))
+  have hEqFlat : IsSSAEquality ρflat hρflatPos.isHermitian := by
+    simpa [ρflat, hM] using isSSAEquality_tripartite_of_isSAL K hSAL hN
+  have hEqSite :
+      IsSSAEquality (ρflat.submatrix E E) (hρflatPos.isHermitian.submatrix E) :=
+    isSSAEquality_submatrix_prodEquiv ρflat hρflatPos.isHermitian
+      eSite eSite (Equiv.refl _) hEqFlat
+  have hρsiteTrace : (ρflat.submatrix E E).trace = 1 := by
+    rw [Matrix.trace_submatrix_equiv]
+    exact hρflatTrace
+  have hηLarge : Nonempty (EtaStructure (ρflat.submatrix E E)) :=
+    sal_implies_eta_structure (ρflat.submatrix E E)
+      ⟨hρflatPos.submatrix E, hρsiteTrace⟩ hEqSite
+  let eC : Fin (d ^ (N - 3)) ≃ Fin d × (Fin (N - 4) → Fin d) :=
+    finFunctionFinEquiv.symm |>.trans
+      (Equiv.arrowCongr (finCongr (show N - 3 = 1 + (N - 4) by omega)) (Equiv.refl _)) |>.trans
+      (blockSplitEquiv d 1 (N - 4)) |>.trans
+      (finFunctionFinEquiv.prodCongr (Equiv.refl _)) |>.trans
+      (eSite.symm.prodCongr (Equiv.refl _))
+  have hηSmall := Entropy.exists_quantumMarkovDecomposition_rightMarginalAlong
+    eC (ρflat.submatrix E E) hηLarge
+  have hstate : Entropy.rightMarginalAlong eC (ρflat.submatrix E E) =
+      (K.reducedBlockState N 3 (by omega)).submatrix
+        (fun p : Fin d × Fin d × Fin d ↦ ![p.1, p.2.1, p.2.2])
+        (fun p : Fin d × Fin d × Fin d ↦ ![p.1, p.2.1, p.2.2]) := by
+    ext p q
+    simp only [Entropy.rightMarginalAlong, Matrix.submatrix_apply]
+    simp only [ρflat, Matrix.submatrix_apply]
+    have hconfig (r : Fin d × Fin d × Fin d) (x : Fin (N - 4) → Fin d) :
+        (tripartiteSplitEquiv d 1 1 (N - 3)).symm
+              (E (r.1, r.2.1, eC.symm (r.2.2, x))) ∘
+            Fin.cast (show 3 + (N - 4) = 1 + 1 + (N - 3) by omega) =
+          Fin.append ![r.1, r.2.1, r.2.2] x := by
+      dsimp only [tripartiteSplitEquiv, E, eC, eSite, N]
+      simp only [Equiv.symm_trans, Equiv.prodCongr_symm, Equiv.refl_symm,
+        Equiv.prodCongr_apply, Equiv.coe_trans, Equiv.funUnique_symm_apply,
+        Equiv.trans_apply, Equiv.prodAssoc_symm_apply, Function.comp_apply,
+        Equiv.symm_apply_apply, Equiv.symm_symm, Equiv.coe_refl, Prod.map_apply,
+        id_eq, Nat.succ_eq_add_one]
+      rw [blockSplitEquiv_symm_apply, blockSplitEquiv_symm_apply,
+        blockSplitEquiv_symm_apply]
+      funext i
+      refine Fin.addCases (fun j : Fin 3 ↦ ?_) (fun j : Fin (N - 4) ↦ ?_) i
+      · fin_cases j <;>
+          simp [Fin.append, Fin.addCases, Equiv.arrowCongr, Function.comp_def]
+      · simp only [Nat.reduceAdd, Fin.append, Equiv.arrowCongr, Equiv.coe_refl,
+          finCongr_symm, Function.comp_def, finCongr_apply,
+          Equiv.refl_symm, Equiv.symm_mk, Equiv.coe_fn_mk, Fin.addCases,
+          Fin.val_cast, Order.lt_one_iff, uniqueElim_const, Fin.cast_cast,
+          eq_rec_constant, Function.comp_apply, Fin.val_natAdd, Order.lt_two_iff,
+          Fin.val_castLT, Nat.add_eq_zero_iff, OfNat.ofNat_ne_zero, false_and,
+          ↓reduceDIte, Fin.cast_eq_self, Fin.val_subNat, add_lt_iff_neg_left,
+          not_lt_zero, Fin.cast_natAdd, Fin.subNat_addNat]
+        split
+        · omega
+        · split
+          · omega
+          · apply congrArg x
+            apply Fin.ext
+            simp only [Fin.val_subNat, Fin.val_cast, Fin.val_natAdd]
+            omega
+    simp_rw [reducedBlockState_cast K
+      (show 3 + (N - 4) = 1 + 1 + (N - 3) by omega) hNm1]
+    simp_rw [hconfig]
+    simpa only [Nat.add_zero] using
+      (collapse_last K (N := N) (a := 3) (b := 0) (c := N - 4)
+        (show 3 + 0 + (N - 4) ≤ N by omega)
+        ![p.1, p.2.1, p.2.2] ![q.1, q.2.1, q.2.2])
+  rwa [hstate] at hηSmall
+
 /-- **Four-site specialization of Lemma Lsigma3.** If `K` satisfies the strong
 area law, then the three-site marginal of its normalized four-site periodic
 state admits a quantum Markov decomposition on the middle site.
@@ -518,10 +624,8 @@ state admits a quantum Markov decomposition on the middle site.
 Source: arXiv:1606.00608, Appendix C.2, Lemma Lsigma3, lines 1351--1363;
 normalization convention at lines 792--793.
 
-**Scope restriction (four-site chain):** Lemma Lsigma3 treats the three-site
-marginal of every chain to which its four-region argument applies. This theorem
-is its $N=4$ specialization. The remaining all-length construction is recorded
-in `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`. -/
+This is the (N=4) specialization of
+`exists_etaStructure_reducedBlockState_three_of_isSAL`. -/
 theorem exists_etaStructure_reducedBlockState_of_isSAL
     {d D : ℕ} (K : MPOTensor d D) (hSAL : IsSAL K) :
     Nonempty
@@ -529,53 +633,7 @@ theorem exists_etaStructure_reducedBlockState_of_isSAL
         ((K.reducedBlockState 4 3 (by omega)).submatrix
           (fun p : Fin d × Fin d × Fin d ↦ ![p.1, p.2.1, p.2.2])
           (fun p : Fin d × Fin d × Fin d ↦ ![p.1, p.2.1, p.2.2]))) := by
-  let hM : (mpo K 4).PosSemidef := (Classical.choose hSAL) 4 (by omega)
-  let ρflat :=
-    (K.reducedBlockState 4 3 (by omega)).submatrix
-      (tripartiteSplitEquiv d 1 1 1).symm
-      (tripartiteSplitEquiv d 1 1 1).symm
-  let eSite : Fin d ≃ Fin (d ^ 1) :=
-    (Equiv.funUnique (Fin 1) (Fin d)).symm.trans finFunctionFinEquiv
-  let E := eSite.prodCongr (eSite.prodCongr eSite)
-  have hρflatPos : ρflat.PosSemidef := by
-    exact (reducedBlockState_posSemidef K 4 3 (by omega) hM).submatrix _
-  have hρflatTrace : ρflat.trace = 1 := by
-    dsimp only [ρflat]
-    rw [Matrix.trace_submatrix_equiv]
-    exact reducedBlockState_trace K 4 3 (by omega)
-      ((Classical.choose_spec hSAL).1 4 (by omega))
-  have hEqFlat : IsSSAEquality ρflat hρflatPos.isHermitian := by
-    simpa [ρflat, hM] using isSSAEquality_threeSite_of_isSAL K hSAL
-  have hEqSite :
-      IsSSAEquality (ρflat.submatrix E E) (hρflatPos.isHermitian.submatrix E) :=
-    isSSAEquality_submatrix_prodEquiv ρflat hρflatPos.isHermitian
-      eSite eSite eSite hEqFlat
-  have hρsiteTrace : (ρflat.submatrix E E).trace = 1 := by
-    rw [Matrix.trace_submatrix_equiv]
-    exact hρflatTrace
-  have hη : Nonempty (EtaStructure (ρflat.submatrix E E)) :=
-    sal_implies_eta_structure (ρflat.submatrix E E)
-      ⟨hρflatPos.submatrix E, hρsiteTrace⟩ hEqSite
-  have hsplit (p : Fin d × Fin d × Fin d) :
-      (tripartiteSplitEquiv d 1 1 1).symm (E p) = ![p.1, p.2.1, p.2.2] := by
-    dsimp only [tripartiteSplitEquiv, E, eSite]
-    simp only [Nat.reduceAdd, Equiv.symm_trans, Equiv.prodCongr_symm,
-      Equiv.refl_symm, Equiv.prodCongr_apply, Equiv.coe_trans,
-      Equiv.funUnique_symm_apply, Equiv.trans_apply, Equiv.prodAssoc_symm_apply,
-      Prod.map_fst, Function.comp_apply, Equiv.symm_apply_apply, Prod.map_snd,
-      Equiv.coe_refl, Prod.map_apply, id_eq, Nat.succ_eq_add_one]
-    rw [blockSplitEquiv_symm_apply, blockSplitEquiv_symm_apply]
-    funext i
-    fin_cases i <;> rfl
-  have hstate :
-      ρflat.submatrix E E =
-        (K.reducedBlockState 4 3 (by omega)).submatrix
-          (fun p : Fin d × Fin d × Fin d ↦ ![p.1, p.2.1, p.2.2])
-          (fun p : Fin d × Fin d × Fin d ↦ ![p.1, p.2.1, p.2.2]) := by
-    ext p q
-    simp only [ρflat, Matrix.submatrix_apply]
-    rw [hsplit p, hsplit q]
-  rwa [hstate] at hη
+  exact exists_etaStructure_reducedBlockState_three_of_isSAL K hSAL (N := 4) (by omega)
 
 /-- The type of explicit neighboring operator families `η_{k,h}` over a fixed
 Hayashi decomposition.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
@@ -407,46 +407,150 @@ strong subadditivity for a normalized three-site reduced state.
     decomposition on the middle subsystem.
 \end{proof}
 
-\begin{theorem}[Four-site SAL marginal has a Hayashi decomposition]
-    \label{thm:mpdo_four_site_sal_eta_structure}
-    \lean{MPOTensor.exists_etaStructure_reducedBlockState_of_isSAL}
+\begin{lemma}[Partial trace along a right tensor factor]
+    \label{lem:partial_trace_right_along}
+    \lean{Matrix.partialTraceRightAlong,
+      Matrix.partialTraceRightAlong_apply,
+      Matrix.PosSemidef.partialTraceRightAlong,
+      Matrix.trace_partialTraceRightAlong}
+    \leanok
+    Suppose that $C\simeq C'\otimes E$.  The partial trace over $E$ is given
+    entrywise by
+    \[
+        \bigl(\tr_E X\bigr)_{(a,c'),(a',d')}
+        =\sum_e X_{(a,c',e),(a',d',e)}.
+    \]
+    It preserves positivity and trace.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:mpdo_right_partial_trace_cptp}
+    Reindex $C$ as $C'\otimes E$ and apply the ordinary right partial trace.
+    Its entry formula gives the displayed sum, while complete positivity and
+    trace preservation give the final assertions.
+\end{proof}
+
+\begin{theorem}[Right marginals preserve a quantum Markov decomposition]
+    \label{thm:quantum_markov_right_marginal}
+    \lean{Entropy.rightMarginalAlong,
+      Entropy.exists_quantumMarkovDecomposition_rightMarginalAlong}
+    \leanok
+    \uses{def:entropy_quantum_markov_decomposition,
+      lem:partial_trace_right_along}
+    Suppose that $C\simeq C'\otimes E$ and
+    \[
+        \rho_{ABC}
+        =\bigoplus_k p_k\rho_{A b_1}^{(k)}\otimes
+          \rho_{b_2 C}^{(k)}
+    \]
+    is a quantum Markov decomposition on $B$. Then the marginal
+    $\rho_{ABC'}=\tr_E(\rho_{ABC})$ has the decomposition
+    \[
+        \rho_{ABC'}
+        =\bigoplus_k p_k\rho_{A b_1}^{(k)}\otimes
+          \tr_E\!\left(\rho_{b_2 C}^{(k)}\right).
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:partial_trace_right_along}
+    The middle-system decomposition, its unitary change of basis, and the
+    probabilities $p_k$ are unchanged.  Partial trace preserves positivity and
+    trace, so each $\tr_E(\rho_{b_2 C}^{(k)})$ is a density operator.  Applying
+    $\tr_E$ to the block-diagonal identity gives the displayed formula.
+\end{proof}
+
+\begin{lemma}[Tracing a terminal block]
+    \label{lem:mpdo_reduced_state_collapse_last}
+    \lean{collapse_last, collapse_last', reducedBlockState_cast}
+    \leanok
+    Let $a,b,c,N\in\mathbb N$ satisfy $a+b+c\leq N$.  For configurations
+    $u,v$ on the first $a+b$ sites,
+    \[
+      \sum_y \sigma_{a+b+c}^{(N)}(K)_{u\mathbin\Vert y,\,
+        v\mathbin\Vert y}
+      =\sigma_{a+b}^{(N)}(K)_{u,v},
+    \]
+    where the sum ranges over configurations on the last $c$ sites.  The same
+    identity holds after replacing an arithmetically equal block length by its
+    canonical identification.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Expand both reduced states as partial traces of the normalized periodic
+    state.  The left-hand side first traces the complement of the
+    $(a+b+c)$-site block and then its last $c$ sites; combining the two sums
+    gives the partial trace onto the first $a+b$ sites.
+\end{proof}
+
+\begin{theorem}[SAL three-site marginals have Hayashi decompositions]
+    \label{thm:mpdo_sal_three_site_eta_structure}
+    \lean{MPOTensor.exists_etaStructure_reducedBlockState_three_of_isSAL}
     \leanok
     \uses{def:is_sal, def:mpdo_eta_structure}
-    Let $K$ satisfy the strong area law, and let
-    $\sigma_3^{(4)}(K)=\tr_4\sigma^{(4)}(K)$ be the three-site marginal of its
-    normalized four-site periodic state. Then $\sigma_3^{(4)}(K)$ admits a
-    quantum-Markov decomposition on its middle site.
-
-    This assertion is restricted to the four-site chain. It is the $N=4$
-    specialization of the three-site decomposition in
-    \cite[Appendix~C.2, lines~1351--1363]{Cirac2016MPDO_arXiv}, which treats all
-    chain lengths in the range of its four-region argument.
+    Let $K$ satisfy the strong area law and let $N\geq4$.  If
+    $\sigma_3^{(N)}(K)$ is obtained from the normalized $N$-site periodic state
+    by tracing out all but its first three sites, then
+    $\sigma_3^{(N)}(K)$ admits a quantum Markov decomposition on its middle
+    site.  This is the result proved in
+    \cite[Appendix~C.2, lines~1351--1371]{Cirac2016MPDO_arXiv}.  The
+    decomposition may depend on $N$.
 \end{theorem}
 
 \begin{proof}
     \leanok
     \uses{thm:mpdo_sal_ssa_equality, thm:ssa_equality_reindex_factors,
-        thm:sal_implies_eta_structure}
-    Let $\rho^{\mathrm{flat}}$ denote the three-site marginal with index set
-    $(\Fin{d^1})^3$.
+        thm:sal_implies_eta_structure,
+        thm:quantum_markov_right_marginal,
+        lem:mpdo_reduced_state_collapse_last}
+    Divide the first $N-1$ sites into consecutive regions of lengths $1$, $1$,
+    and $N-3$.  Let $\rho^{\mathrm{flat}}_{ABC}$ denote this marginal in the
+    corresponding index set
+    $\Fin{d^1}\times\Fin{d^1}\times\Fin{d^{N-3}}$.
     By Theorem~\ref{thm:mpdo_sal_ssa_equality},
     \[
         S(\rho^{\mathrm{flat}}_{ABC})+S(\rho^{\mathrm{flat}}_B)
         =S(\rho^{\mathrm{flat}}_{AB})+S(\rho^{\mathrm{flat}}_{BC}).
     \]
-    Each singleton block has the canonical identification
+    The first two singleton blocks have the canonical identification
     \[
         e_{\mathrm{site}}:\Fin{d}\simeq\Fin{d^1},
-        \qquad
-        E=e_{\mathrm{site}}\times e_{\mathrm{site}}\times e_{\mathrm{site}},
     \]
-    and reindexing $\rho^{\mathrm{flat}}$ along $E$ gives
-    $\sigma_3^{(4)}(K)$. Hence
-    Theorem~\ref{thm:ssa_equality_reindex_factors} preserves the displayed
-    equality. Positivity and unit trace follow from the normalized reduced
-    state, so
-    Theorem~\ref{thm:sal_implies_eta_structure} gives the required quantum
-    Markov decomposition.
+    and reindexing these factors preserves the displayed equality.  Positivity
+    and unit trace follow from the normalized reduced state, so the Hayashi
+    characterization gives a quantum Markov decomposition of the $(N-1)$-site
+    marginal.  Finally split the third region as
+    $C\simeq c\otimes E$, where $c$ is its first site and $E$ contains the
+    remaining $N-4$ sites.  Theorem~\ref{thm:quantum_markov_right_marginal} gives
+    the same middle-site direct sum after tracing out $E$.  The contiguous-block
+    partial-trace identity gives
+    \[
+      \tr_{4,\ldots,N-1}\!\left(\sigma_{N-1}^{(N)}(K)\right)
+        =\sigma_3^{(N)}(K),
+    \]
+    which identifies the resulting operator with the required three-site
+    marginal.
+\end{proof}
+
+\begin{theorem}[Four-site SAL marginals have Hayashi decompositions]
+    \label{thm:mpdo_four_site_sal_eta_structure}
+    \lean{MPOTensor.exists_etaStructure_reducedBlockState_of_isSAL}
+    \leanok
+    \uses{def:is_sal, def:mpdo_eta_structure}
+    Let $K$ satisfy the strong area law.  If $\sigma_3^{(4)}(K)$ is obtained
+    from its normalized four-site periodic state by tracing out the fourth
+    site, then $\sigma_3^{(4)}(K)$ admits a quantum Markov decomposition on its
+    middle site.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_sal_three_site_eta_structure}
+    This is the case $N=4$ of
+    Theorem~\ref{thm:mpdo_sal_three_site_eta_structure}.
 \end{proof}
 
 \begin{theorem}[BNT sector projectors for the four-site SAL marginal]

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -5,7 +5,7 @@
 \usepackage[hidelinks]{hyperref}
 \setlength{\emergencystretch}{2em}
 
-\input{command}
+\input{./command}
 
 \title{The SAL to Eta-Local Structure Step in
 Cirac--Perez-Garcia--Schuch--Verstraete 2017 Appendix C.2}
@@ -63,10 +63,17 @@ $N\geq 4$, saturation gives $I_1=I_2$, and hence
 \]
 This is equality in strong subadditivity for the normalized $(N-1)$-site
 marginal divided into three consecutive regions of lengths $1$, $1$, and
-$N-3$.  The literal three-site statement is obtained by taking $N=4$.
+$N-3$.  The Hayashi characterization gives a direct-sum tensor-product
+decomposition on the middle site.  Splitting the third region into its first
+site and its remaining $N-4$ sites and tracing the latter preserves this
+decomposition.  Consequently the first-three-site marginal has the form
+asserted in Lemma~\texttt{Lsigma3} for every $N\geq4$; the decomposition is
+chosen separately for each $N$.
 \footnote{The formal statements are
 \leanid{MPOTensor.isSSAEquality_tripartite_of_isSAL} and
-\leanid{MPOTensor.isSSAEquality_threeSite_of_isSAL}.}
+\leanid{MPOTensor.exists_etaStructure_reducedBlockState_three_of_isSAL};
+the partial-trace preservation result is
+\leanid{Entropy.exists_quantumMarkovDecomposition_rightMarginalAlong}.}
 
 The desired commuting product form is currently recorded as an eta-local
 structure for $K$.\footnote{The formal structure is
@@ -213,10 +220,10 @@ projections
 \]
 These projections are mutually orthogonal.\footnote{The relevant declarations
 are
-\path{MPOTensor.exists_bntMarkovBlockNonzero_of_probability_ne_zero},
-\path{MPOTensor.existsUnique_bntMarkovBlockNonzero_of_probability_ne_zero},
-\path{MPOTensor.bntSectorProjection}, and
-\path{MPOTensor.sum_bntSectorProjection}.}
+\leanid{MPOTensor.exists_bntMarkovBlockNonzero_of_probability_ne_zero},
+\leanid{MPOTensor.existsUnique_bntMarkovBlockNonzero_of_probability_ne_zero},
+\leanid{MPOTensor.bntSectorProjection}, and
+\leanid{MPOTensor.sum_bntSectorProjection}.}
 
 Both factors in the closing-scalar choice are now selected.  Once the copy
 weights agree, the distinguished common weight is nonzero and
@@ -225,8 +232,8 @@ weights agree, the distinguished common weight is nonzero and
 \]
 for every chain length $N$.
 \footnote{The relevant declarations are
-\path{MPSTensor.SectorDecomposition.commonWeight_ne_zero} and
-\path{MPSTensor.SectorDecomposition.coeff_ne_zero_of_weight_copy_independent}.}
+\leanid{MPSTensor.SectorDecomposition.commonWeight_ne_zero} and
+\leanid{MPSTensor.SectorDecomposition.coeff_ne_zero_of_weight_copy_independent}.}
 Simplicity says that the physical-trace transfer
 $\mathcal B_j=\sum_iA_j^{ii}$ is not nilpotent.  Hence one positive tail
 length $L$ has, for every representative, a nonzero entry
@@ -239,11 +246,11 @@ with nonzero entry
 $(R_j)_{\alpha_j,\beta_j}=q_j\widetilde m_j\ne0$, as in Appendix~C.2,
 lines 1714--1718.
 \footnote{The relevant declarations are
-\path{MPSTensor.SectorDecomposition.exists_common_nonzero_physicalTraceTail_entry}
+\leanid{MPSTensor.SectorDecomposition.exists_common_nonzero_physicalTraceTail_entry}
 and
-\path{MPSTensor.SectorDecomposition.exists_common_nonzero_threeSiteClosingMatrix_entry};
+\leanid{MPSTensor.SectorDecomposition.exists_common_nonzero_threeSiteClosingMatrix_entry};
 the matrix form is
-\path{MPSTensor.SectorDecomposition.exists_common_threeSiteClosingMatrix_ne_zero}.}
+\leanid{MPSTensor.SectorDecomposition.exists_common_threeSiteClosingMatrix_ne_zero}.}
 This closing-matrix bridge is now formalized with the normalization included.
 Equality of the complete matrix-product-vector families transports the
 original tensor to its horizontal BNT representation, and the normalized
@@ -251,14 +258,14 @@ three-site reduced state has closing matrices
 \[
   \widehat R_j=\tr(\rho^{(L+3)})^{-1}q_j\mathcal B_j^L.
 \]
-At the four-site length used by the formal SAL-to-Markov theorem, one takes
-$L=1$.  SAL makes the normalization scalar nonzero, so every
+At the four-site specialization used by the subsequent closing-matrix
+argument, one takes $L=1$.  SAL makes the normalization scalar nonzero, so every
 $\widehat R_j$ is nonzero.
 \footnote{The relevant declarations are
-\path{MPSTensor.SectorDecomposition.normalizedThreeSiteClosingMatrix},
-\path{MPOTensor.reducedBlockState_reindex_isThreeSiteFamilyClosure_of_sameMPV₂},
+\leanid{MPSTensor.SectorDecomposition.normalizedThreeSiteClosingMatrix},
+\leanid{MPOTensor.reducedBlockState_reindex_isThreeSiteFamilyClosure_of_sameMPV₂},
 and
-\path{MPOTensor.reducedBlockState_four_threeSiteFamilyClosure_nonzero_closing}.}
+\leanid{MPOTensor.reducedBlockState_four_threeSiteFamilyClosure_nonzero_closing}.}
 Thus the explicit nonzero-closing hypothesis of the generic cancellation
 theorem is derived for the family closure used by the source.  The simultaneous
 specialization is now formalized as well.  After the common blocking has made
@@ -268,7 +275,7 @@ Markov sector then has a unique BNT label, and the resulting BNT-labelled sums
 of Hayashi projections are orthogonal, mutually disjoint, and resolve the
 active Markov support.
 \footnote{The relevant declaration is
-\path{MPOTensor.exists_bntSectorProjectors_four_of_sameMPV₂Pos_isSAL}.}
+\leanid{MPOTensor.exists_bntSectorProjectors_four_of_sameMPV₂Pos_isSAL}.}
 No further closing-matrix assumption is needed for this specialization.
 
 The remaining projector passage is now formalized as well.  For every physical
@@ -288,11 +295,11 @@ sitewise on every nonempty periodic chain then gives
 \]
 with the common copy weight absorbed into $\mathcal K_s$.
 \footnote{The relevant declarations are
-\path{MPOTensor.bntSectorProjection_mul_physicalSlice_mul_eq_zero},
-\path{MPOTensor.sum_bntSectorProjection_mul_physicalSlice_mul_self},
-\path{MPOTensor.changePhysicalBasis_bntSectorProjection_basis},
-\path{MPOTensor.sitewise_bntSectorProjection_mul_mpo_mul_self}, and
-\path{MPOTensor.exists_bntProjectorSelection_positiveLength_of_sameMPV₂Pos_isSAL}.}
+\leanid{MPOTensor.bntSectorProjection_mul_physicalSlice_mul_eq_zero},
+\leanid{MPOTensor.sum_bntSectorProjection_mul_physicalSlice_mul_self},
+\leanid{MPOTensor.changePhysicalBasis_bntSectorProjection_basis},
+\leanid{MPOTensor.sitewise_bntSectorProjection_mul_mpo_mul_self}, and
+\leanid{MPOTensor.exists_bntProjectorSelection_positiveLength_of_sameMPV₂Pos_isSAL}.}
 The empty-word value $N=0$ is excluded because its closed virtual trace records
 the bond dimension and is not a physical chain.  Positivity and ZCL of every
 selected absorbed BNT representative are now formalized.  Positivity follows
@@ -300,10 +307,10 @@ by compressing the positive full-chain operator and dividing by the positive
 integer $n_s$.  ZCL follows by restricting the full transfer equation to the
 $s$-th canonical block and using nonnilpotence to exclude the zero transfer.
 \footnote{The relevant declarations are
-\path{MPOTensor.commonWeightAbsorbedBasisMPOTensor_isMPDO_of_projectorSelection},
-\path{MPOTensor.commonWeightAbsorbedBasisMPOTensor_isMPDO_of_sameMPV₂Pos_isSAL},
+\leanid{MPOTensor.commonWeightAbsorbedBasisMPOTensor_isMPDO_of_projectorSelection},
+\leanid{MPOTensor.commonWeightAbsorbedBasisMPOTensor_isMPDO_of_sameMPV₂Pos_isSAL},
 and
-\path{MPOTensor.commonWeightAbsorbedBasisMPOTensor_isSourceZCL}.}
+\leanid{MPOTensor.commonWeightAbsorbedBasisMPOTensor_isSourceZCL}.}
 The strict normalization needed in the sector entropy identity is now
 formalized: an MPDO tensor with source ZCL has positive trace at every
 nonempty chain length, since its normalized physical-trace transfer is a
@@ -311,24 +318,24 @@ nonzero idempotent.  Applied to the absorbed BNT sectors above, this proves
 $p_j^{(N)}>0$ rather than silently inferring it from the weaker displayed
 inequality $p_j\geq0$.
 \footnote{The general declarations are
-\path{MPOTensor.trace_mpo_ne_zero_of_isSourceZCL} and
-\path{MPOTensor.trace_mpo_pos_of_isMPDO_isSourceZCL}; their specialization to
+\leanid{MPOTensor.trace_mpo_ne_zero_of_isSourceZCL} and
+\leanid{MPOTensor.trace_mpo_pos_of_isMPDO_isSourceZCL}; their specialization to
 the absorbed BNT representative is
-\path{MPOTensor.trace_mpo_commonWeightAbsorbedBasisMPOTensor_pos}.}
+\leanid{MPOTensor.trace_mpo_commonWeightAbsorbedBasisMPOTensor_pos}.}
 The weighted orthogonal-direct-sum entropy formula used in Appendix~C.2,
 lines~1760--1770, is also formalized as
-\path{vonNeumannEntropy_blockDiagonal_smul}, together with the form for
+\leanid{vonNeumannEntropy_blockDiagonal_smul}, together with the form for
 pairwise-annihilating support operators
-\path{vonNeumannEntropy_eq_sum_of_pairwise_annihilating_supports}.  The remaining source
+\leanid{vonNeumannEntropy_eq_sum_of_pairwise_annihilating_supports}.  The remaining source
 step after the sector-compression identity is now formalized: the same sector
 probabilities occur in all four marginals, the Shannon terms cancel, and
 strict positivity together with strong subadditivity forces equality in every
 sector.  Thus every absorbed BNT representative satisfies SAL under the biCF
 hypothesis imposed at the start of Case II in the source.
 \footnote{The principal declarations are
-\path{MPOTensor.blockEntropy_eq_sum_bntSectorProbability},
-\path{MPOTensor.blockEntropy_add_blockEntropy_eq_bntSector}, and
-\path{MPOTensor.commonWeightAbsorbedBasisMPOTensor_isSAL_of_sameMPV₂Pos}.}
+\leanid{MPOTensor.blockEntropy_eq_sum_bntSectorProbability},
+\leanid{MPOTensor.blockEntropy_add_blockEntropy_eq_bntSector}, and
+\leanid{MPOTensor.commonWeightAbsorbedBasisMPOTensor_isSAL_of_sameMPV₂Pos}.}
 This completes the entropy argument of
 \cite[Appendix~C.2, lines~1748--1781]{Cirac2016MPDO_arXiv} with the source's
 stated biCF hypothesis.
@@ -368,23 +375,25 @@ $\eta_{k,l}\otimes\eta_{l,h}$ in Proposition \texttt{3to5} consistently fix
 the intended convention as $\eta_{k,h}=r_k l_h$.  The formalization follows
 this later consistent convention; the earlier figure is an index-swap typo.
 
-The Hayashi decomposition of the concrete closure state is now formalized for
-the four-site chain.  Independent bijections on the three tensor factors
-preserve equality in strong subadditivity: each marginal is carried to the
-corresponding reindexed marginal, and the four entropies are unchanged.  The
-canonical bijection between a singleton block and one physical-site index
+The Hayashi decomposition of the concrete three-site marginal is now
+formalized for every $N\geq4$.  Independent bijections on the first two tensor
+factors preserve equality in strong subadditivity: each marginal is carried to
+the corresponding reindexed marginal, and the four entropies are unchanged.
+The canonical bijection between a singleton block and one physical-site index
 therefore carries the SAL equality from flattened block coordinates to the
-tripartite site coordinates of the closure state.  Applying the forward
-Hayashi characterization gives a decomposition of the literal three-site
-marginal
+tripartite coordinates of the $(N-1)$-site state.  Applying the forward Hayashi
+characterization gives a decomposition before the last $N-4$ sites of the
+third region are traced out.  Partial trace preserves the same middle-site
+direct sum, and the contiguous-block reduction identity gives
 \[
-  \sigma_3^{(4)}({\cal K})=\tr_4\sigma^{(4)}({\cal K}).
+  \sigma_3^{(N)}({\cal K})
+  =\tr_{4,\ldots,N}\!\left[\sigma_{N-1}^{(N)}({\cal K})\right].
 \]
-This is the $N=4$ specialization of Lemma \texttt{Lsigma3}; it does not assert
-the source statement simultaneously for arbitrary chain length.
+This proves Lemma~\texttt{Lsigma3} at every admissible chain length, with no
+claim that the decomposition is common to different values of $N$.
 \footnote{The formal declarations are
 \leanid{isSSAEquality_submatrix_prodEquiv} and
-\leanid{MPOTensor.exists_etaStructure_reducedBlockState_of_isSAL}.}
+\leanid{MPOTensor.exists_etaStructure_reducedBlockState_three_of_isSAL}.}
 
 The neighboring operators and their all-length algebraic identity are now
 formalized.  The inverse-map tensors also determine a source-minimal
@@ -397,20 +406,20 @@ For one such factorization, every complete nonempty cyclic neighboring
 product is positive semidefinite as a diagonal sector compression of the
 corresponding finite-chain operator.
 \footnote{The formal declarations are
-\path{MPOTensor.inverseMapPhysicalSectorFactorization},
-\path{MPOTensor.inverseMapPhysicalSectorFactorization_neighboringOperator_eq_sectorEta},
-\path{MPOTensor.nonempty_physicalSectorFactorization_of_isSAL},
-\path{MPOTensor.exists_physicalSectorFactorization_with_cyclicNeighboringProduct_posSemidef_of_isSAL},
-\path{MPOTensor.etaOfSectorTensors},
-\path{MPOTensor.sum_cyclic_sectorTensor_eq_prod_etaOfSectorTensors},
-\path{MPOTensor.trace_sector_word_eq_prod_etaOfSectorTensors},
-\path{MPOTensor.mpo_submatrix_sector_eq_cyclicEtaTensorProduct}, and
-\path{MPOTensor.mpo_reindex_sectorChainEquiv_eq_blockDiagonal_cyclicEta}.
+\leanid{MPOTensor.inverseMapPhysicalSectorFactorization},
+\leanid{MPOTensor.inverseMapPhysicalSectorFactorization_neighboringOperator_eq_sectorEta},
+\leanid{MPOTensor.nonempty_physicalSectorFactorization_of_isSAL},
+\leanid{MPOTensor.exists_physicalSectorFactorization_with_cyclicNeighboringProduct_posSemidef_of_isSAL},
+\leanid{MPOTensor.etaOfSectorTensors},
+\leanid{MPOTensor.sum_cyclic_sectorTensor_eq_prod_etaOfSectorTensors},
+\leanid{MPOTensor.trace_sector_word_eq_prod_etaOfSectorTensors},
+\leanid{MPOTensor.mpo_submatrix_sector_eq_cyclicEtaTensorProduct}, and
+\leanid{MPOTensor.mpo_reindex_sectorChainEquiv_eq_blockDiagonal_cyclicEta}.
 For the source-minimal physical-sector factorization, the corresponding direct
 statements are
-\path{MPOTensor.PhysicalSectorFactorization.mpo_submatrix_sector_eq_cyclicNeighboringProduct}
+\leanid{MPOTensor.PhysicalSectorFactorization.mpo_submatrix_sector_eq_cyclicNeighboringProduct}
 and
-\path{MPOTensor.PhysicalSectorFactorization.mpo_reindex_sectorChainEquiv_eq_blockDiagonal}.}
+\leanid{MPOTensor.PhysicalSectorFactorization.mpo_reindex_sectorChainEquiv_eq_blockDiagonal}.}
 The positive choice of the individual $\eta_{k,h}$ and primitivity of the
 active sector trace matrix are now obtained from this factorization.
 Positivity of a complete cyclic product alone would not supply coherent
@@ -437,13 +446,13 @@ $\eta_{h,k}=0$), choosing one scalar per unordered pair produces a positive
 semidefinite family which agrees with the raw family on the diagonal and
 preserves every two-site block
 $\eta_{k,h}\otimes\eta_{h,k}$.\footnote{The formal declarations are
-\path{Matrix.exists_smul_posSemidef_of_kronecker_posSemidef},
-\path{MPOTensor.mpo_conjugatePhysical_eq},
-\path{MPOTensor.cyclicEtaTensorProduct_posSemidef},
-\path{MPOTensor.sectorEta_self_posSemidef},
-\path{MPOTensor.sectorEta_kronecker_posSemidef},
-\path{MPOTensor.exists_smul_posSemidef_sectorEta}, and
-\path{MPOTensor.exists_explicitEtaOperators_sectorEta}.}
+\leanid{Matrix.exists_smul_posSemidef_of_kronecker_posSemidef},
+\leanid{MPOTensor.mpo_conjugatePhysical_eq},
+\leanid{MPOTensor.cyclicEtaTensorProduct_posSemidef},
+\leanid{MPOTensor.sectorEta_self_posSemidef},
+\leanid{MPOTensor.sectorEta_kronecker_posSemidef},
+\leanid{MPOTensor.exists_smul_posSemidef_sectorEta}, and
+\leanid{MPOTensor.exists_explicitEtaOperators_sectorEta}.}
 
 The pairwise construction has two limitations.  Its symmetric-support
 hypothesis is not stated in the source, and it preserves only the chain blocks
@@ -692,7 +701,7 @@ The graph-theoretic coboundary step is now formalized: for a recurrent
 directed relation, any group-valued edge assignment with trivial
 product around every closed directed walk is a vertex coboundary.
 \footnote{The formal declaration is
-\path{TNLean.Algebra.DirectedWalk.exists_vertex_of_closedWalk_weight_eq_one}.}
+\leanid{TNLean.Algebra.DirectedWalk.exists_vertex_of_closedWalk_weight_eq_one}.}
 The proof chooses one representative of each reachability component and
 defines the vertex weight by multiplication along a path from that
 representative; a common return path proves independence of the chosen path.


### PR DESCRIPTION
## Summary

- prove that the first-three-site marginal of every periodic chain of length at least four has a quantum Markov decomposition when the tensor satisfies SAL
- prove that tracing a chosen factor of the right subsystem preserves a Hayashi quantum Markov decomposition
- retain the former four-site result as the N = 4 corollary
- align the blueprint and the Appendix C.2 paper-gap note with the source statement

This closes the four-site scope restriction in CPSV16 Appendix C.2, Lemma Lsigma3, lines 1351–1379.

Closes #4167.

## Validation

- `lake env lean TNLean/Channel/PartialTrace.lean`
- `lake env lean TNLean/Entropy/MarkovChain.lean`
- `lake env lean TNLean/MPS/MPDO/SimpleLocalStructure.lean`
- `lake build TNLean.MPS.MPDO.SimpleLocalStructure`
- `lake build TNLean`
- `cd blueprint && leanblueprint checkdecls`
- blueprint synchronization and reader-facing prose checks
- standalone compilation of `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`
- proof-integrity and diff checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new Lean proofs in the SAL→Markov pipeline; errors would undermine downstream MPDO formalization, but changes are additive with the prior N=4 result kept as a corollary.
> 
> **Overview**
> Closes the **four-site-only** scope on Appendix C.2 Lemma Lsigma3: under SAL, the **first-three-site marginal** of an **N≥4** periodic chain now gets a Hayashi quantum-Markov decomposition on the middle site (decomposition may depend on **N**).
> 
> **Matrix layer:** adds `Matrix.partialTraceRightAlong` (partial trace after splitting the right factor as **C' ⊗ E**), with entry formula, PSD, and trace preservation.
> 
> **Entropy layer:** defines tripartite `Entropy.rightMarginalAlong` and proves `exists_quantumMarkovDecomposition_rightMarginalAlong`—tracing out **E** keeps the same middle-site direct-sum structure (block probabilities and **U_B** unchanged; right sector states are partially traced).
> 
> **MPDO proof:** `exists_etaStructure_reducedBlockState_three_of_isSAL` builds SSA equality on the **(N−1)**-site marginal (regions **1 | 1 | N−3**), applies Hayashi, then traces the last **N−4** sites of the third region and identifies the result with `reducedBlockState N 3` via `collapse_last`. The old four-site theorem is retained as **`exists_etaStructure_reducedBlockState_of_isSAL`** (N=4 corollary).
> 
> Blueprint chapter 21 and `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex` are updated to match the source lines **1351–1371** and the new Lean names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f035d18213cf6e0b2a3ebafac6084a89bc6ed2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->