### PR TITLE
fix(blueprint): correct MPDO tensor diagrams

### DIFF
--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -471,11 +471,14 @@ $\sum_i (A^i)_{\alpha,\beta}(A^{-1,i})_{\alpha',\beta'}
 =\delta_{\alpha,\alpha'}\delta_{\beta,\beta'}$.  Thus contracting $A^{-1}$
 with $A$ through their common physical index identifies the two pairs of
 virtual indices:
+% Correct equation, not a figure: the source states the unindexed injective
+% identity in prose.  I_Injectivity.png illustrates the following, strictly
+% stronger block-injective identity with the additional j,j' index pair.
 \[
     A^{-1}A=\Id
 \]
 This is the identity used in
-\cite[Section~2.3, lines~326--331]{Cirac2016MPDO_arXiv}.
+\cite[Section~2.3, lines~324--331]{Cirac2016MPDO_arXiv}.
 
 \begin{definition}[$L$-block injectivity]\label{def:l_blk_injective}
     \lean{MPSTensor.IsNBlkInjective}

--- a/blueprint/src/chapter/ch16_channel_representations.tex
+++ b/blueprint/src/chapter/ch16_channel_representations.tex
@@ -1126,11 +1126,12 @@ a common dilation space.
 
 \begin{remark}[Relation with Wolf's Radon--Nikodym theorem]
     \label{rem:cp_radon_nikodym_scope}
-    Theorem~\ref{thm:cp_radon_nikodym_of_stinespring} is the source-faithful
-    finite-family statement relative to a supplied Stinespring dilation.
-    Theorem~\ref{thm:cp_exists_radon_nikodym} is the earlier binary
-    block-diagonal corollary in which the common dilation is constructed from
-    the Kraus families of $T_1$ and $T_2$.
+    % Source-faithful scope note: Wolf's statement is the finite-family
+    % theorem relative to a supplied Stinespring dilation.
+    Theorem~\ref{thm:cp_radon_nikodym_of_stinespring} treats a finite family
+    relative to a supplied Stinespring dilation.  The binary case in
+    Theorem~\ref{thm:cp_exists_radon_nikodym} instead constructs a common
+    dilation from the Kraus families of $T_1$ and $T_2$.
 \end{remark}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -203,7 +203,7 @@
         % physical-down=3).
         \begin{tenkz}[rows={op:none, op, op:none}, tensor style=box]
             \tn[pill, wide=3, legs at={1,2,3}]{U} & & \\
-            \tn{\widetilde M} & & \\
+            \tn[wide=3]{\widetilde M} & & \\
             \tn[pill, wide=3, legs at={1,2,3}]{U^\dagger} & &
         \end{tenkz}
         $\;=\;\displaystyle\bigoplus_\alpha\;$

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -209,10 +209,11 @@
         $\;=\;\displaystyle\bigoplus_\alpha\;$
         \begin{tenkzfree}
             \tnput[box]{mu}{(10mm,7mm)}{\mu_\alpha}
-            \tnput[box]{M}{(34mm,0mm)}{M_\alpha}
+            \tnput[box, ports={west:virtual, east:virtual, north:physical,
+                south:physical, 158:physical}]{M}{(34mm,0mm)}{M_\alpha}
             \tnput[dot]{d1}{(0mm,7mm)}{}
             \tnput[dot]{d2}{(20mm,7mm)}{}
-            \tnput[dot]{d3}{(20mm,2mm)}{}
+            \tnput[dot, ports={east:physical}]{d3}{(d2 |- M.158)}{}
             \tnjoin{$(d1)+(0mm,5mm)$}{$(d1)+(0mm,-19mm)$}
             \tnjoin{$(d2)+(0mm,5mm)$}{$(d2)+(0mm,-19mm)$}
             \tnjoin{$(M.west)+(-10mm,0mm)$}{M.west}
@@ -221,7 +222,7 @@
             \tnjoin{M.south}{$(M.south)+(0mm,-7mm)$}
             \tnjoin{d1}{mu.west}
             \tnjoin{d2}{mu.east}
-            \tnjoin{d3}{$(M.west)+(0mm,1.2mm)$}
+            \tnjoin{d3.east}{M.158}
         \end{tenkzfree}
     \caption{Vertical direct-sum form of the tensor: after the physical
     isometry $U$, each block factorizes as the positive diagonal weight

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -352,6 +352,10 @@ label $j$:
         & \tnghost{} &
     \end{tenkz}
 \]
+Consequently,
+\[
+    K^{-1}K=\bigoplus_j\Id_j.
+\]
 This is the inverse identity in
 \cite[Appendix~C.2, lines~1666--1670]{Cirac2016MPDO_arXiv}.
 

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -202,9 +202,9 @@
         % (virtual-west=1 | virtual-east=1 | physical-up=3 |
         % physical-down=3).
         \begin{tenkz}[rows={op:none, op, op:none}, tensor style=box]
-            \tn[pill, wide=3, legs at={1,2,3}]{U^\dagger} & & \\
+            \tn[pill, wide=3, legs at={1,2,3}]{U} & & \\
             \tn{\widetilde M} & & \\
-            \tn[pill, wide=3, legs at={1,2,3}]{U} & &
+            \tn[pill, wide=3, legs at={1,2,3}]{U^\dagger} & &
         \end{tenkz}
         $\;=\;\displaystyle\bigoplus_\alpha\;$
         \begin{tenkzfree}

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -192,7 +192,6 @@
 
 \begin{figure}[ht]
     \centering
-    \begin{center}
         % U \widetilde M U^dagger = bigoplus_alpha mu_alpha (x) M_alpha
         % (arXiv:1606.00608, Proposition 4.13, eq. UMU and figure
         % MPDO_UMU.png).  The physical isometry does not represent a plain
@@ -207,10 +206,10 @@
             \tn{\widetilde M} & & \\
             \tn[pill, wide=3, legs at={1,2,3}]{U} & &
         \end{tenkz}
-        $\;=\;$
+        $\;=\;\displaystyle\bigoplus_\alpha\;$
         \begin{tenkzfree}
-            \tnput[box]{mu}{(10mm,7mm)}{\mu}
-            \tnput[box]{M}{(34mm,0mm)}{M}
+            \tnput[box]{mu}{(10mm,7mm)}{\mu_\alpha}
+            \tnput[box]{M}{(34mm,0mm)}{M_\alpha}
             \tnput[dot]{d1}{(0mm,7mm)}{}
             \tnput[dot]{d2}{(20mm,7mm)}{}
             \tnput[dot]{d3}{(20mm,2mm)}{}
@@ -222,9 +221,8 @@
             \tnjoin{M.south}{$(M.south)+(0mm,-7mm)$}
             \tnjoin{d1}{mu.west}
             \tnjoin{d2}{mu.east}
-            \tnjoin{d3}{M.west}
+            \tnjoin{d3}{$(M.west)+(0mm,1.2mm)$}
         \end{tenkzfree}
-    \end{center}
     \caption{Vertical direct-sum form of the tensor: after the physical
     isometry $U$, each block factorizes as the positive diagonal weight
     $\mu_\alpha$ on the multiplicity factor times the basis tensor $M_\alpha$,
@@ -347,16 +345,16 @@ label $j$:
     $\;=\;$
     \begin{tenkz}[rows={op, op, bra:none}, compact]
         & \tn[up]{K^{-1}} & \\
-        \tn{X} & \tn{{\cal K}} & \tn{X^{-1}} \\
+        \tnX[wires=2]{X} & \tn{{\cal K}} & \tnX[wires=2]{X^{-1}} \\
         % The ghost is intentional: it carries the lower wire through the
         % column without a junction and consumes \mathcal K's spurious
         % downward pairing.
-        \tn{} & \tnghost{} & \tn{}
+        & \tnghost{} &
     \end{tenkz}
     $\;=\;$
     \begin{tenkz}[rows={ket, bra}, compact]
-        \tn{X} & \tnskip & \tn{X^{-1}} \\
-        \tn{} & \tn{} & \tn{}
+        \tnX[wires=2]{X} & \tnskip & \tnX[wires=2]{X^{-1}} \\
+        & \tnghost{} &
     \end{tenkz}
 \end{center}
 This is the inverse identity in
@@ -1328,7 +1326,6 @@ tensor.  This is the contraction in
 
 \begin{figure}[ht]
     \centering
-    \begin{center}
         % PH^{(N+1)} = PH^{(N+1)}P = H^{(N+1)}P for a projector P with
         % P\widetilde M=P\widetilde MP (arXiv:1606.00608, proof of
         % Proposition 4.13, eq. eq1:proof.IV.12, lines 1881--1887;
@@ -1354,7 +1351,6 @@ tensor.  This is the contraction in
             \tn[mpo]{\widetilde M} & \tn[mpo]{\widetilde M} & \tndots &
                 \tn[mpo]{\widetilde M}
         \end{tenkz}
-    \end{center}
     \caption{The periodic contraction representing $PH^{(N+1)}$. The
     analogous contractions with $Y_R$ and $Y_C$ place $P$ on the bra leg or
     on both legs and represent $H^{(N+1)}P$ and $PH^{(N+1)}P$. These are the

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -352,8 +352,8 @@ label $j$:
         & \tnghost{} &
     \end{tenkz}
     $\;=\;$
-    \begin{tenkz}[rows={ket, bra}, compact]
-        \tnX[wires=2]{X} & \tnskip & \tnX[wires=2]{X^{-1}} \\
+    \begin{tenkz}[rows={wire, wire}, compact]
+        \tnX[wires=2]{X} & \tnghost{} & \tnX[wires=2]{X^{-1}} \\
         & \tnghost{} &
     \end{tenkz}
 \end{center}

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -207,7 +207,23 @@
             \tn{\widetilde M} & & \\
             \tn[pill, wide=3, legs at={1,2,3}]{U} & &
         \end{tenkz}
-        $\;=\;\displaystyle\bigoplus_\alpha \mu_\alpha\otimes M_\alpha$
+        $\;=\;$
+        \begin{tenkzfree}
+            \tnput[box]{mu}{(10mm,7mm)}{\mu}
+            \tnput[box]{M}{(34mm,0mm)}{M}
+            \tnput[dot]{d1}{(0mm,7mm)}{}
+            \tnput[dot]{d2}{(20mm,7mm)}{}
+            \tnput[dot]{d3}{(20mm,2mm)}{}
+            \tnjoin{$(d1)+(0mm,5mm)$}{$(d1)+(0mm,-19mm)$}
+            \tnjoin{$(d2)+(0mm,5mm)$}{$(d2)+(0mm,-19mm)$}
+            \tnjoin{$(M.west)+(-10mm,0mm)$}{M.west}
+            \tnjoin{M.east}{$(M.east)+(10mm,0mm)$}
+            \tnjoin{M.north}{$(M.north)+(0mm,7mm)$}
+            \tnjoin{M.south}{$(M.south)+(0mm,-7mm)$}
+            \tnjoin{d1}{mu.west}
+            \tnjoin{d2}{mu.east}
+            \tnjoin{d3}{M.west}
+        \end{tenkzfree}
     \end{center}
     \caption{Vertical direct-sum form of the tensor: after the physical
     isometry $U$, each block factorizes as the positive diagonal weight

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -324,15 +324,17 @@ The inverse tensor of a block-injective canonical form satisfies
     (K^{-1,p}_{j'})_{\alpha',\beta'}
     =\delta_{\alpha,\alpha'}\delta_{\beta,\beta'}\delta_{j,j'}.
 \]
-Contracting $K^{-1}$ with the doubled physical index passes the virtual legs
-of $X$ and $X^{-1}$ to $K^{-1}$ and identifies its block index with the block
-label $j$:
+Writing $K=X(\bigoplus_j\mathcal K_j)X^{-1}$ in this contraction places the
+gauges on the virtual legs of $K$ and identifies the block index of
+$\mathcal K_j$ with the label $j$:
 \[
     % K^{-1}K in block-injective canonical form (arXiv:1606.00608,
     % eq. biCFK, Appendix C.2 lines 1666--1670; paper figure
     % MPDO_biCF.png).  Panel 1 contracts K^{-1} with K through their
     % doubled physical index.  Panel 2 substitutes
-    % K=X(bigoplus_j K_j)X^{-1}: X and X^{-1} touch both virtual rails.
+    % K=X(bigoplus_j K_j)X^{-1}: K^{-1} remains on the upper rail, while
+    % X and X^{-1} flank K_j on the lower rail and extend to the internal
+    % block-index rail beneath it.
     % Panel 3 removes the resolved K^{-1}-K pair and leaves the gauge legs
     % and block-index wires.  Every panel has boundary signature
     % (virtual-west=2 | virtual-east=2 | physical-up=0 |
@@ -342,9 +344,10 @@ label $j$:
         \tn{K}
     \end{tenkz}
     \;=\;
-    \begin{tenkz}[rows={ket, bra}, compact]
-        \tnX[wires=2]{X} & \tn{K^{-1}} & \tnX[wires=2]{X^{-1}} \\
-        & \tn{K} &
+    \begin{tenkz}[rows={ket, bra, wire:none}, compact]
+        & \tn{K^{-1}} & \\
+        \tnX[wires=2]{X} & \tn{\mathcal K} & \tnX[wires=2]{X^{-1}} \\
+        & \tnghost{} &
     \end{tenkz}
     \;=\;
     \begin{tenkz}[rows={wire, wire}, compact]

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -192,9 +192,45 @@
 
 \begin{figure}[ht]
     \centering
-    \[
-        U\mathcal K U^\dagger=\bigoplus_k\mu_k\otimes A_k
-    \]
+    \begin{center}
+        % U \widetilde M U^dagger = bigoplus_alpha mu_alpha (x) M_alpha
+        % (arXiv:1606.00608, Proposition 4.13, eq. UMU and figure
+        % MPDO_UMU.png).  The physical isometry does not represent a plain
+        % Kronecker product: two copy-tensor junctions thread one shared
+        % multiplicity index through both mu_alpha and M_alpha.  Only
+        % M_alpha carries the open virtual legs.  Both sides have boundary
+        % signature
+        % (virtual-west=1 | virtual-east=1 | physical-up=3 |
+        % physical-down=3).
+        \begin{tenkz}[rows={op:none, op, op:none}, tensor style=box]
+            \tn[pill, wide=3, legs at={1,2,3}]{U^\dagger} & & \\
+            \tn{\widetilde M} & & \\
+            \tn[pill, wide=3, legs at={1,2,3}]{U} & &
+        \end{tenkz}
+        $\;=\;$
+        \begin{tenkzfree}
+          \tnput[box]{mu}{(10mm,7mm)}{\mu}
+          \tnput[box]{M}{(34mm,0mm)}{M}
+          \tnput[dot]{d1}{(0mm,7mm)}{}
+          \tnput[dot]{d2}{(20mm,7mm)}{}
+          \tnput[dot]{d3}{(20mm,2mm)}{}
+          % tenkz-lint: allow raw-ink free-tier open copy leg
+          \draw[bond] (0mm,12mm) -- (0mm,-12mm);
+          % tenkz-lint: allow raw-ink free-tier open copy leg
+          \draw[bond] (20mm,12mm) -- (20mm,-12mm);
+          % tenkz-lint: allow raw-ink free-tier open virtual leg
+          \draw[bond] (-10mm,0mm) -- (M.west);
+          % tenkz-lint: allow raw-ink free-tier open virtual leg
+          \draw[bond] (M.east) -- ++(10mm,0mm);
+          % tenkz-lint: allow raw-ink free-tier open physical leg
+          \draw[bond] (M.north) -- ++(0mm,7mm);
+          % tenkz-lint: allow raw-ink free-tier open physical leg
+          \draw[bond] (M.south) -- ++(0mm,-7mm);
+          \tnjoin{d1}{mu.west}
+          \tnjoin{d2}{mu.east}
+          \tnjoin{d3}{M.west}
+        \end{tenkzfree}
+    \end{center}
     \caption{Vertical direct-sum form of the tensor: after the physical
     isometry $U$, each block factorizes as the positive diagonal weight
     $\mu_\alpha$ on the multiplicity factor times the basis tensor $M_\alpha$,
@@ -298,9 +334,37 @@ The inverse tensor of a block-injective canonical form satisfies
 Contracting $K^{-1}$ with the doubled physical index passes the virtual legs
 of $X$ and $X^{-1}$ to $K^{-1}$ and identifies its block index with the block
 label $j$:
-\[
-    K^{-1}K=\bigoplus_j\Id_j
-\]
+\begin{center}
+    % K^{-1}K in block-injective canonical form (arXiv:1606.00608,
+    % eq. biCFK, Appendix C.2 lines 1666--1670; paper figure
+    % MPDO_biCF.png).  Panel 1 contracts K^{-1} with K through their
+    % doubled physical index.  Panel 2 substitutes
+    % K=X(bigoplus_j K_j)X^{-1}: X and X^{-1} touch both ladder wires,
+    % whereas K touches only the upper wire and the lower wire bypasses its
+    % column.  Panel 3 removes the resolved K^{-1}-K pair and leaves the
+    % gauge legs and block-index wires.  Every panel has boundary signature
+    % (virtual-west=2 | virtual-east=2 | physical-up=1 |
+    % physical-down=0); the lower bookkeeping wire in panel 2 is sealed at
+    % X and X^{-1}, so it is not an extra boundary index.
+    \begin{tenkz}[rows={op, bra}, compact]
+        \tn[up]{K^{-1}} \\
+        \tn{K}
+    \end{tenkz}
+    $\;=\;$
+    \begin{tenkz}[rows={op, op, bra:none}, compact]
+        & \tn[up]{K^{-1}} & \\
+        \tn{X} & \tn{{\cal K}} & \tn{X^{-1}} \\
+        % The ghost is intentional: it carries the lower wire through the
+        % column without a junction and consumes \mathcal K's spurious
+        % downward pairing.
+        \tn{} & \tnghost{} & \tn{}
+    \end{tenkz}
+    $\;=\;$
+    \begin{tenkz}[rows={ket, bra}, compact]
+        \tn{X} & \tnskip & \tn{X^{-1}} \\
+        \tn{} & \tn{} & \tn{}
+    \end{tenkz}
+\end{center}
 This is the inverse identity in
 \cite[Appendix~C.2, lines~1666--1670]{Cirac2016MPDO_arXiv}.
 
@@ -1270,14 +1334,37 @@ tensor.  This is the contraction in
 
 \begin{figure}[ht]
     \centering
-    \[
-        PH^{(N+1)},\qquad H^{(N+1)}P,\qquad PH^{(N+1)}P
-    \]
-    \caption{The three first-site contractions of the horizontal operator on
-    $N+1$ sites: contracting the first doubled leg with $Y_L$, $Y_R$, or
-    $Y_C$ places $P$ on the ket leg, on the bra leg, or on both legs of the
-    first site, and represents $PH^{(N+1)}$, $H^{(N+1)}P$, and
-    $PH^{(N+1)}P$. Compare the first display in the proof of
+    \begin{center}
+        % PH^{(N+1)} = PH^{(N+1)}P = H^{(N+1)}P for a projector P with
+        % P\widetilde M=P\widetilde MP (arXiv:1606.00608, proof of
+        % Proposition 4.13, eq. eq1:proof.IV.12, lines 1881--1887;
+        % paper figure DAVID_Fig3.png).  The picture reproduces the one
+        % network drawn by the source; the two further equalities remain in
+        % this comment and in the surrounding blueprint statement.
+        %
+        % Each \widetilde M box is one site tensor.  Its up leg is the ket
+        % index, its down leg the bra index, and the horizontal ring is the
+        % traced virtual index.  P is contracted with the ket leg of the
+        % source's rightmost displayed site; its outer leg is the operator's
+        % open ket index.  The ring leaves no virtual stubs.  The schematic
+        % boundary signature is therefore (virtual-west=0 | virtual-east=0 |
+        % physical-up=N+1 | physical-down=N+1).
+        %
+        % The empty first row is structural padding: tenkz closes the first
+        % and last rows of a multi-row periodic picture, so padding keeps P's
+        % row untraced while closing the \widetilde M row exactly once.
+        $PH^{(N+1)}\;=\;$
+        \begin{tenkz}[rows={wire, op:none, op}, compact, periodic, align=3]
+            \tnskip & \tnskip & \tnskip & \tnskip \\
+            \tnskip & \tnskip & \tnskip & \tn{P} \\
+            \tn[mpo]{\widetilde M} & \tn[mpo]{\widetilde M} & \tndots &
+                \tn[mpo]{\widetilde M}
+        \end{tenkz}
+    \end{center}
+    \caption{The periodic contraction representing $PH^{(N+1)}$. The
+    analogous contractions with $Y_R$ and $Y_C$ place $P$ on the bra leg or
+    on both legs and represent $H^{(N+1)}P$ and $PH^{(N+1)}P$. These are the
+    three first-site contractions in
     \cite[Proposition~4.13, lines~1881--1887]{Cirac2016MPDO_arXiv}.}
     \label{fig:mpdo_first_site_contractions}
 \end{figure}

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -326,36 +326,31 @@ The inverse tensor of a block-injective canonical form satisfies
 Contracting $K^{-1}$ with the doubled physical index passes the virtual legs
 of $X$ and $X^{-1}$ to $K^{-1}$ and identifies its block index with the block
 label $j$:
-\begin{center}
+\[
     % K^{-1}K in block-injective canonical form (arXiv:1606.00608,
     % eq. biCFK, Appendix C.2 lines 1666--1670; paper figure
     % MPDO_biCF.png).  Panel 1 contracts K^{-1} with K through their
     % doubled physical index.  Panel 2 substitutes
-    % K=X(bigoplus_j K_j)X^{-1}: X and X^{-1} touch both ladder wires,
-    % whereas K touches only the upper wire and the lower wire bypasses its
-    % column.  Panel 3 removes the resolved K^{-1}-K pair and leaves the
-    % gauge legs and block-index wires.  Every panel has boundary signature
+    % K=X(bigoplus_j K_j)X^{-1}: X and X^{-1} touch both virtual rails.
+    % Panel 3 removes the resolved K^{-1}-K pair and leaves the gauge legs
+    % and block-index wires.  Every panel has boundary signature
     % (virtual-west=2 | virtual-east=2 | physical-up=0 |
-    % physical-down=0); the lower bookkeeping wire in panel 2 is sealed at
-    % X and X^{-1}, so it is not an extra boundary index.
-    \begin{tenkz}[rows={bra, ket}, compact]
+    % physical-down=0).
+    \begin{tenkz}[rows={ket, bra}, compact]
         \tn{K^{-1}} \\
         \tn{K}
     \end{tenkz}
-    $\;=\;$
-    \begin{tenkz}[rows={bra, ket, wire}, compact]
-        & \tn{K^{-1}} & \\
-        \tnX[wires=2]{X} & \tn{K} & \tnX[wires=2]{X^{-1}} \\
-        % The ghost carries the lower wire through the K column without a
-        % junction.
-        & \tnghost{} &
+    \;=\;
+    \begin{tenkz}[rows={ket, bra}, compact]
+        \tnX[wires=2]{X} & \tn{K^{-1}} & \tnX[wires=2]{X^{-1}} \\
+        & \tn{K} &
     \end{tenkz}
-    $\;=\;$
+    \;=\;
     \begin{tenkz}[rows={wire, wire}, compact]
         \tnX[wires=2]{X} & \tnghost{} & \tnX[wires=2]{X^{-1}} \\
         & \tnghost{} &
     \end{tenkz}
-\end{center}
+\]
 This is the inverse identity in
 \cite[Appendix~C.2, lines~1666--1670]{Cirac2016MPDO_arXiv}.
 

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -207,29 +207,7 @@
             \tn{\widetilde M} & & \\
             \tn[pill, wide=3, legs at={1,2,3}]{U} & &
         \end{tenkz}
-        $\;=\;$
-        \begin{tenkzfree}
-          \tnput[box]{mu}{(10mm,7mm)}{\mu}
-          \tnput[box]{M}{(34mm,0mm)}{M}
-          \tnput[dot]{d1}{(0mm,7mm)}{}
-          \tnput[dot]{d2}{(20mm,7mm)}{}
-          \tnput[dot]{d3}{(20mm,2mm)}{}
-          % tenkz-lint: allow raw-ink free-tier open copy leg
-          \draw[bond] (0mm,12mm) -- (0mm,-12mm);
-          % tenkz-lint: allow raw-ink free-tier open copy leg
-          \draw[bond] (20mm,12mm) -- (20mm,-12mm);
-          % tenkz-lint: allow raw-ink free-tier open virtual leg
-          \draw[bond] (-10mm,0mm) -- (M.west);
-          % tenkz-lint: allow raw-ink free-tier open virtual leg
-          \draw[bond] (M.east) -- ++(10mm,0mm);
-          % tenkz-lint: allow raw-ink free-tier open physical leg
-          \draw[bond] (M.north) -- ++(0mm,7mm);
-          % tenkz-lint: allow raw-ink free-tier open physical leg
-          \draw[bond] (M.south) -- ++(0mm,-7mm);
-          \tnjoin{d1}{mu.west}
-          \tnjoin{d2}{mu.east}
-          \tnjoin{d3}{M.west}
-        \end{tenkzfree}
+        $\;=\;\displaystyle\bigoplus_\alpha \mu_\alpha\otimes M_\alpha$
     \end{center}
     \caption{Vertical direct-sum form of the tensor: after the physical
     isometry $U$, each block factorizes as the positive diagonal weight

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -227,7 +227,7 @@
     isometry $U$, each block factorizes as the positive diagonal weight
     $\mu_\alpha$ on the multiplicity factor times the basis tensor $M_\alpha$,
     and only $M_\alpha$ carries the virtual legs. This is the decomposition
-    $U\tilde MU^\dagger=\bigoplus_\alpha\mu_\alpha\otimes M_\alpha$ of
+    $U\widetilde MU^\dagger=\bigoplus_\alpha\mu_\alpha\otimes M_\alpha$ of
     \cite[Proposition~4.13, lines~1864--1870]{Cirac2016MPDO_arXiv}.}
     \label{fig:mpdo_vertical_direct_sum}
 \end{figure}

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -335,20 +335,19 @@ label $j$:
     % whereas K touches only the upper wire and the lower wire bypasses its
     % column.  Panel 3 removes the resolved K^{-1}-K pair and leaves the
     % gauge legs and block-index wires.  Every panel has boundary signature
-    % (virtual-west=2 | virtual-east=2 | physical-up=1 |
+    % (virtual-west=2 | virtual-east=2 | physical-up=0 |
     % physical-down=0); the lower bookkeeping wire in panel 2 is sealed at
     % X and X^{-1}, so it is not an extra boundary index.
-    \begin{tenkz}[rows={op, bra}, compact]
-        \tn[up]{K^{-1}} \\
+    \begin{tenkz}[rows={bra, ket}, compact]
+        \tn{K^{-1}} \\
         \tn{K}
     \end{tenkz}
     $\;=\;$
-    \begin{tenkz}[rows={op, op, bra:none}, compact]
-        & \tn[up]{K^{-1}} & \\
-        \tnX[wires=2]{X} & \tn{{\cal K}} & \tnX[wires=2]{X^{-1}} \\
-        % The ghost is intentional: it carries the lower wire through the
-        % column without a junction and consumes \mathcal K's spurious
-        % downward pairing.
+    \begin{tenkz}[rows={bra, ket, wire}, compact]
+        & \tn{K^{-1}} & \\
+        \tnX[wires=2]{X} & \tn{K} & \tnX[wires=2]{X^{-1}} \\
+        % The ghost carries the lower wire through the K column without a
+        % junction.
         & \tnghost{} &
     \end{tenkz}
     $\;=\;$

--- a/blueprint/src/chapter/ch21_mpdo_rfp_algebra_tower.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_algebra_tower.tex
@@ -438,14 +438,15 @@ family, and the corresponding multiplication / inclusion coefficient arrays.
     $S=\widetilde R_1\widetilde S R_2$. The scalar
     Newton--Girard power-sum identity needed to obtain the trace-power form is
     already available as
-    Theorem~\ref{thm:newton_girard}.  A source-faithful completion must state
-    the BNT-label hypotheses of
-    \cite[Theorem~4.14(ii)]{Cirac2016MPDO_arXiv} as a separate condition,
-    relate them to the one-site and two-site vertical canonical forms, and
-    then construct the maps in
-    (\ref{eq:mpdo_reconstruction_maps}).  These hypotheses cannot be derived
-    from the support-algebra condition, by
-    Theorem~\ref{thm:mpdo_algebra_not_imply_fusion}.
+    Theorem~\ref{thm:newton_girard}.  To obtain the trace-power conclusion of
+    \cite[Theorem~4.14(ii)]{Cirac2016MPDO_arXiv}, one must impose the
+    BNT-label hypotheses as a separate condition, relate them to the one-site
+    and two-site vertical canonical forms, and construct the maps in
+    (\ref{eq:mpdo_reconstruction_maps}).
+    Theorem~\ref{thm:mpdo_algebra_not_imply_fusion} shows that the
+    support-algebra condition alone does not imply the BNT-label hypotheses.
+    % Source-faithful completion requires the BNT-label hypotheses as a
+    % separate condition; the support-algebra condition does not imply them.
 \end{remark}
 
 \subsection{Diagonal \texorpdfstring{$\chi$}{chi}-matrices and the trace-power formula}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
@@ -755,33 +755,7 @@ physical index identifies the corresponding virtual legs.  In components,
 this is the matrix-unit identity
 $\sum_p(K^{-1})^{\alpha,\beta}_pK^p=E_{\alpha,\beta}$:
 \begin{center}
-    % sum_p (K^{-1})^{alpha,beta}_p K^p = delta_{alpha,alpha'}
-    % delta_{beta,beta'}: K^{-1} (top) is contracted with K (bottom)
-    % through their shared doubled physical index.  Following
-    % MPDO_NotationK.png, its ket copy is solid and its bra copy dashed.
-    % The four open virtual stubs, top row then bottom row, are
-    % alpha', beta', alpha, beta.  The two bends on the right implement
-    % the corresponding pair of Kronecker deltas.  Both sides have
-    % boundary signature (virtual-west=2 | virtual-east=2 |
-    % physical-up=0 | physical-down=0).
-    \begin{tenkzfree}
-        \tnput[ports={west:virtual, east:virtual}, label pos=north]
-            {Kinv}{(0,4.4mm)}{{\cal K}^{-1}}
-        \tnput[ports={west:virtual, east:virtual}, label pos=south]
-            {K}{(0,-4.4mm)}{{\cal K}}
-        % tenkz-lint: allow raw-ink offset ket strand of doubled contraction
-        \draw[bond] ($(Kinv.south)+(-0.35mm,0)$) -- ($(K.north)+(-0.35mm,0)$);
-        % tenkz-lint: allow raw-ink offset bra strand of doubled contraction
-        \draw[bond, dashed] ($(Kinv.south)+(0.35mm,0)$) -- ($(K.north)+(0.35mm,0)$);
-        % tenkz-lint: allow raw-ink free-tier open virtual leg
-        \draw[bond] (Kinv.west) -- ++(-4.95mm,0);
-        % tenkz-lint: allow raw-ink free-tier open virtual leg
-        \draw[bond] (Kinv.east) -- ++(4.95mm,0);
-        % tenkz-lint: allow raw-ink free-tier open virtual leg
-        \draw[bond] (K.west) -- ++(-4.95mm,0);
-        % tenkz-lint: allow raw-ink free-tier open virtual leg
-        \draw[bond] (K.east) -- ++(4.95mm,0);
-    \end{tenkzfree}
+    $\displaystyle\sum_p (K^{-1})^{\alpha,\beta}_p\,K^p$
     $\;=\;$
     \begin{tenkz}[rows={wire, wire}, east=cup]
         \tnghost{} \\
@@ -799,52 +773,15 @@ This is the identity in
 Applying this inverse map to the doubled physical index and closing its
 virtual legs against a further copy of $K$ recovers $K$:
 \begin{center}
-    % \mathcal K K^{-1} K = K (arXiv:1606.00608, eq:Kidentity):
-    % the top tensor is the script-letter BNT basis element \mathcal K,
-    % not another copy of K.  Its two virtual legs close separately against
-    % K^{-1}, while the bottom K retains its virtual legs.  The fused double
-    % stroke marks the doubled physical index at the open top boundary and
-    % at the K^{-1}/K contraction.  Both sides have boundary signature
-    % (virtual-west=1 | virtual-east=1 | physical-up=1 |
-    % physical-down=0).
-    \begin{tenkzfree}
-        \tnput{Kc}{(0,9mm)}{}
-        \tnput{Kinv}{(0,0)}{}
-        \tnput[label pos=south]{Kbot}{(0,-9mm)}{K}
-        % tenkz-lint: allow raw-ink free-tier west inverse bend
-        \draw[bond] (Kc.west) to[out=180, in=180, looseness=1.6] (Kinv.west);
-        % tenkz-lint: allow raw-ink free-tier east inverse bend
-        \draw[bond] (Kc.east) to[out=0, in=0, looseness=1.6] (Kinv.east);
-        % tenkz-lint: allow raw-ink free-tier open doubled physical leg
-        \draw[fused bond] (Kc.north) -- ++(0,4.2mm);
-        % tenkz-lint: allow raw-ink free-tier internal physical contraction
-        \draw[bond] (Kc.south) -- (Kinv.north);
-        % tenkz-lint: allow raw-ink free-tier doubled physical contraction
-        \draw[fused bond] (Kinv.south) -- (Kbot.north);
-        % tenkz-lint: allow raw-ink free-tier open virtual leg
-        \draw[bond] (Kbot.west) -- ++(-5mm,0);
-        % tenkz-lint: allow raw-ink free-tier open virtual leg
-        \draw[bond] (Kbot.east) -- ++(5mm,0);
-        % tenkz-lint: allow raw-ink source-positioned script K label
-        \node[tn label, anchor=east] at ($(Kc.west)-(3mm,0)$) {$\scriptstyle\mathcal K$};
-        % tenkz-lint: allow raw-ink source-positioned inverse label
-        \node[tn label, anchor=east] at ($(Kinv.west)-(3mm,0)$) {$\scriptstyle K^{-1}$};
-    \end{tenkzfree}
-    $\;=\;$
-    \begin{tenkzfree}
-        \tnput[label pos=south]{K}{(0,0)}{K}
-        % tenkz-lint: allow raw-ink free-tier open doubled physical leg
-        \draw[fused bond] (K.north) -- ++(0,4.2mm);
-        % tenkz-lint: allow raw-ink free-tier open virtual leg
-        \draw[bond] (K.west) -- ++(-5mm,0);
-        % tenkz-lint: allow raw-ink free-tier open virtual leg
-        \draw[bond] (K.east) -- ++(5mm,0);
-    \end{tenkzfree}
+    % \mathcal K K^{-1} K = K (arXiv:1606.00608, eq:Kidentity): the
+    % script-letter BNT basis element \mathcal K closes its two virtual legs
+    % against K^{-1}, while the bottom K retains its virtual legs and the
+    % doubled physical index survives at the open boundary.
+    \[
+        {\cal K}\,{\cal K}^{-1}K = K
+    \]
 \end{center}
-The doubled physical index is represented by the fused double stroke at the
-open boundary and the lower contraction; the internal
-$\mathcal K$--$K^{-1}$ line remains single.  This is the
-single-block identity of
+This is the single-block identity of
 \cite[Appendix~C.2, lines~1671--1676]{Cirac2016MPDO_arXiv}.
 
 \begin{definition}[Normalized fourth-site virtual tail]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
@@ -763,8 +763,8 @@ Its two Kronecker factors are the two bare cups:
     % physical index p.  Their four virtual legs remain open and are
     % identified pairwise by the tensor product of the two cups on the right.
     \begin{tenkz}[rows={bra, ket}, tensor style=box]
-        \tn{\mathcal K^{-1}} \\
-        \tn{\mathcal K}
+        \tn{K^{-1}} \\
+        \tn{K}
     \end{tenkz}
     $\;=\;$
     \begin{tenkz}[rows={wire, wire}, east=cup]
@@ -783,7 +783,7 @@ This is the identity in
 Applying this inverse map to the doubled physical index and closing its
 virtual legs against a further copy of $K$ recovers $K$:
 \begin{center}
-    % \mathcal K K^{-1} K = K (arXiv:1606.00608, eq:Kidentity): the top
+    % K K^{-1} K = K (arXiv:1606.00608, eq:Kidentity): the top
     % tensor closes both virtual legs against K^{-1}; the bottom K retains
     % its virtual legs.  The vertical strand is the doubled physical index.
     % Both sides have boundary signature (virtual-west=1 | virtual-east=1 |
@@ -793,8 +793,8 @@ virtual legs against a further copy of $K$ recovers $K$:
             west=cup,
             east=cup,
             tensor style=box]
-        \tn[up=p]{\mathcal K} \\
-        \tn{\mathcal K^{-1}} \\
+        \tn[up=p]{K} \\
+        \tn{K^{-1}} \\
         \tn{K}
     \end{tenkz}
     $\;=\;$
@@ -810,12 +810,12 @@ This is the single-block identity in
     \lean{MPOTensor.normalizedFourSiteTail}
     \leanok
     \uses{def:mpo_family, def:mpo_physical_trace_transfer}
-    Let ${\cal K}$ be an MPO tensor and set
-    $Z_4=\tr[\rho^{(4)}({\cal K})]$. Its normalized fourth-site virtual tail is
+    Let $\mathcal K$ be an MPO tensor and set
+    $Z_4=\tr[\rho^{(4)}(\mathcal K)]$. Its normalized fourth-site virtual tail is
     \[
-        R_4:=Z_4^{-1}\mathcal T_{\cal K}
-        =\tr[\rho^{(4)}({\cal K})]^{-1}
-          \sum_{i_4=0}^{d-1}{\cal K}^{i_4i_4}.
+        R_4:=Z_4^{-1}\mathcal T_{\mathcal K}
+        =\tr[\rho^{(4)}(\mathcal K)]^{-1}
+          \sum_{i_4=0}^{d-1}\mathcal K^{i_4i_4}.
     \]
     Thus the contraction of the fourth ket and bra indices is incorporated into
     the virtual closing matrix. This is the $N=4$ specialization of the
@@ -832,10 +832,10 @@ This is the single-block identity in
     three. The corresponding entry of the first-three-site marginal of the
     normalized four-site periodic operator is
     \[
-        \sigma_3^{(4)}({\cal K})_{u,v}
-        =\tr\!\left({\cal K}^{u,v}R_4\right)
+        \sigma_3^{(4)}(\mathcal K)_{u,v}
+        =\tr\!\left(\mathcal K^{u,v}R_4\right)
         =\tr\!\left(
-          {\cal K}^{i_1j_1}{\cal K}^{i_2j_2}{\cal K}^{i_3j_3}R_4
+          \mathcal K^{i_1j_1}\mathcal K^{i_2j_2}\mathcal K^{i_3j_3}R_4
         \right).
     \]
 \end{theorem}
@@ -856,8 +856,8 @@ This is the single-block identity in
     \caption{Tracing the fourth site of the normalized four-site periodic MPO
     leaves the physical legs of sites $1,2,3$ open and replaces the fourth site
     by the virtual closing operator
-    $R_4=\tr[\rho^{(4)}({\cal K})]^{-1}
-    \sum_{i_4}{\cal K}^{i_4 i_4}$; compare the normalization convention and
+    $R_4=\tr[\rho^{(4)}(\mathcal K)]^{-1}
+    \sum_{i_4}\mathcal K^{i_4 i_4}$; compare the normalization convention and
     three-site marginal in
     \cite[lines~792--793 and 1343--1348]{Cirac2016MPDO_arXiv}.}
     \label{fig:mpdo_normalized_four_site_tail}
@@ -870,19 +870,19 @@ This is the single-block identity in
     Expanding the partial trace over the fourth site and factoring each
     length-four word at its last letter gives
     \[
-        \sigma_3^{(4)}({\cal K})_{u,v}
+        \sigma_3^{(4)}(\mathcal K)_{u,v}
         =Z_4^{-1}\sum_{i_4=0}^{d-1}
-          \tr\!\left({\cal K}^{u,v}{\cal K}^{i_4i_4}\right).
+          \tr\!\left(\mathcal K^{u,v}\mathcal K^{i_4i_4}\right).
     \]
     Linearity of the trace now yields
     \[
         Z_4^{-1}\sum_{i_4=0}^{d-1}
-          \tr\!\left({\cal K}^{u,v}{\cal K}^{i_4i_4}\right)
+          \tr\!\left(\mathcal K^{u,v}\mathcal K^{i_4i_4}\right)
         =\tr\!\left(
-          {\cal K}^{u,v}
-          \left(Z_4^{-1}\sum_{i_4=0}^{d-1}{\cal K}^{i_4i_4}\right)
+          \mathcal K^{u,v}
+          \left(Z_4^{-1}\sum_{i_4=0}^{d-1}\mathcal K^{i_4i_4}\right)
         \right)
-        =\tr\!\left({\cal K}^{u,v}R_4\right).
+        =\tr\!\left(\mathcal K^{u,v}R_4\right).
     \]
 \end{proof}
 
@@ -891,20 +891,20 @@ This is the single-block identity in
     \lean{MPOTensor.normalizedFourSiteTail_ne_zero}
     \leanok
     \uses{def:mpdo_normalized_four_site_tail}
-    If $Z_4=\tr[\rho^{(4)}({\cal K})]\ne0$, then $R_4\ne0$.
+    If $Z_4=\tr[\rho^{(4)}(\mathcal K)]\ne0$, then $R_4\ne0$.
 \end{theorem}
 
 \begin{proof}
     \leanok
     \uses{thm:mpdo_reduced_four_three_tail}
     If $R_4=0$, then the tail formula makes every entry of
-    $\sigma_3^{(4)}({\cal K})$ vanish, so
+    $\sigma_3^{(4)}(\mathcal K)$ vanish, so
     \[
-        \tr[\sigma_3^{(4)}({\cal K})]=0.
+        \tr[\sigma_3^{(4)}(\mathcal K)]=0.
     \]
     On the other hand, $Z_4\ne0$ implies
     \[
-        \tr[\sigma_3^{(4)}({\cal K})]=1,
+        \tr[\sigma_3^{(4)}(\mathcal K)]=1,
     \]
     a contradiction.
 \end{proof}
@@ -934,17 +934,17 @@ This is the single-block identity in
     \lean{MPOTensor.inverseMapThreeSiteContraction}
     \leanok
     \uses{def:mpdo_injective_inverse_layer}
-    Let ${\cal K}$ be an injective simple MPO tensor, and let $R\in\MN{D}$ be
+    Let $\mathcal K$ be an injective simple MPO tensor, and let $R\in\MN{D}$ be
     the virtual contraction of the sites following a three-site word. For
     virtual indices
     $\alpha_1,\beta_1,\alpha_3,\beta_3$, define
     \[
         C_{\alpha_1,\beta_1,\alpha_3,\beta_3}(p_2;R)
         =\sum_{p_1,p_3}
-        ({\cal K}^{-1})^{\alpha_1,\beta_1}_{p_1}
-        ({\cal K}^{-1})^{\alpha_3,\beta_3}_{p_3}
-        \tr\bigl({\cal K}^{p_1}{\cal K}^{p_2}
-        {\cal K}^{p_3}R\bigr).
+        (\mathcal K^{-1})^{\alpha_1,\beta_1}_{p_1}
+        (\mathcal K^{-1})^{\alpha_3,\beta_3}_{p_3}
+        \tr\bigl(\mathcal K^{p_1}\mathcal K^{p_2}
+        \mathcal K^{p_3}R\bigr).
     \]
     This is the contraction used in the proof of
     \cite[Appendix~C.2, lines~1415--1438]{Cirac2016MPDO_arXiv}.
@@ -960,7 +960,7 @@ This is the single-block identity in
     For every middle physical index $p_2$,
     \[
         C_{\alpha_1,\beta_1,\alpha_3,\beta_3}(p_2;R)
-        = {\cal K}^{p_2}_{\beta_1,\alpha_3}
+        = \mathcal K^{p_2}_{\beta_1,\alpha_3}
         R_{\beta_3,\alpha_1}.
     \]
     % Local fix (tail index): the source display repeats the third-site left
@@ -971,15 +971,15 @@ This is the single-block identity in
 
 \begin{figure}[ht]
     \centering
-        % (K^{-1} (x) Id (x) K^{-1}) K_3
-        %   = K^{p_2}_{beta_1,alpha_3} R_{beta_3,alpha_1}
+        % (\mathcal K^{-1} (x) Id (x) \mathcal K^{-1}) \mathcal K_3
+        %   = \mathcal K^{p_2}_{beta_1,alpha_3} R_{beta_3,alpha_1}
         % (arXiv:1606.00608, Appendix C.2, lines 1415--1438; paper
         % figures MPDO_Xab.png, MPDO_kappaab.png, and MPDO_mba.png).
         %
-        % LHS: the two K^{-1} boxes expose virtual pairs
+        % LHS: the two \mathcal K^{-1} boxes expose virtual pairs
         % (alpha_1,beta_1) and (alpha_3,beta_3).  Their physical indices
         % p_1,p_3 match the first and third legs of the three-site chain
-        % closed against R; p_2 remains open.  RHS: K carries beta_1 west,
+        % closed against R; p_2 remains open.  RHS: \mathcal K carries beta_1 west,
         % p_2 up, and alpha_3 east, while R carries beta_3 west and
         % alpha_1 east.  There is no surviving sum: the identity is
         % pointwise in all four virtual indices.  Both sides have aggregate
@@ -989,12 +989,12 @@ This is the single-block identity in
             \Bigl(
             \begin{tenkz}[compact, physical=down,
                           west label=$\alpha_1$, east label=$\beta_1$]
-                \tn[down=$p_1$]{{\cal K}^{-1}}
+                \tn[down=$p_1$]{\mathcal K^{-1}}
             \end{tenkz}
             \otimes\Id\otimes
             \begin{tenkz}[compact, physical=down,
                           west label=$\alpha_3$, east label=$\beta_3$]
-                \tn[down=$p_3$]{{\cal K}^{-1}}
+                \tn[down=$p_3$]{\mathcal K^{-1}}
             \end{tenkz}
             \Bigr)
             \begin{tenkz}[compact, physical=up, periodic]
@@ -1014,9 +1014,9 @@ This is the single-block identity in
                 \tnX{R}
             \end{tenkz}
         \]
-    \caption{Applying ${\cal K}^{-1}$ at the first and third sites collapses
+    \caption{Applying $\mathcal K^{-1}$ at the first and third sites collapses
     the three-site contraction to
-    ${\cal K}^{p_2}_{\beta_1,\alpha_3}R_{\beta_3,\alpha_1}$, where
+    $\mathcal K^{p_2}_{\beta_1,\alpha_3}R_{\beta_3,\alpha_1}$, where
     $p_2=(i_2,j_2)$ is the doubled physical index; compare
     \cite[Appendix~C.2, lines~1415--1438]{Cirac2016MPDO_arXiv}.}
     \label{fig:mpdo_inverse_map_three_site_contraction}
@@ -1026,14 +1026,14 @@ This is the single-block identity in
     \uses{thm:mpdo_injective_inverse_layer_spec}
     Move the two finite sums through the trace.  By the inverse-map identity
     \[
-        \sum_p({\cal K}^{-1})^{\alpha,\beta}_p\,{\cal K}^p
+        \sum_p(\mathcal K^{-1})^{\alpha,\beta}_p\,\mathcal K^p
         =E_{\alpha,\beta},
     \]
     the double sum collapses to
     \[
-        \tr\bigl(E_{\alpha_1,\beta_1}{\cal K}^{p_2}
+        \tr\bigl(E_{\alpha_1,\beta_1}\mathcal K^{p_2}
           E_{\alpha_3,\beta_3}R\bigr)
-        = {\cal K}^{p_2}_{\beta_1,\alpha_3}
+        = \mathcal K^{p_2}_{\beta_1,\alpha_3}
           R_{\beta_3,\alpha_1}.
     \]
 \end{proof}
@@ -1043,12 +1043,12 @@ This is the single-block identity in
     \lean{MPOTensor.IsThreeSiteClosure}
     \leanok
     \uses{def:mpo_tensor}
-    Let ${\cal K}$ be an MPO tensor and let $R\in\MN{D}$. A tripartite
-    operator $\rho$ is the three-site closure of ${\cal K}$ against $R$ if
+    Let $\mathcal K$ be an MPO tensor and let $R\in\MN{D}$. A tripartite
+    operator $\rho$ is the three-site closure of $\mathcal K$ against $R$ if
     \[
         \rho_{i_1i_2i_3,j_1j_2j_3}
         =\tr\!\left(
-          {\cal K}^{i_1j_1}{\cal K}^{i_2j_2}{\cal K}^{i_3j_3}R
+          \mathcal K^{i_1j_1}\mathcal K^{i_2j_2}\mathcal K^{i_3j_3}R
         \right).
     \]
     This is the algebraic form of the three-site reduced operator in
@@ -1064,17 +1064,17 @@ This is the single-block identity in
     \uses{def:mpdo_injective_inverse_layer, def:mpdo_eta_structure}
     Fix virtual indices $\beta,\alpha$ and set
     \[
-        \kappa_{\beta,\alpha}(i,j)={\cal K}^{ij}_{\beta,\alpha}.
+        \kappa_{\beta,\alpha}(i,j)=\mathcal K^{ij}_{\beta,\alpha}.
     \]
     For a Hayashi sector $k$, define the two inverse factors
     \begin{align*}
         A^{(k)}_{\alpha_1,\beta_1}(l,l')
         &:=\sum_{i_1,j_1}
-        ({\cal K}^{-1})^{\alpha_1,\beta_1}_{(i_1,j_1)}
+        (\mathcal K^{-1})^{\alpha_1,\beta_1}_{(i_1,j_1)}
         (\rho_{A b_1}^{(k)})_{(i_1,l),(j_1,l')},\\
         B^{(k)}_{\alpha_3,\beta_3}(r,r')
         &:=\sum_{i_3,j_3}
-        ({\cal K}^{-1})^{\alpha_3,\beta_3}_{(i_3,j_3)}
+        (\mathcal K^{-1})^{\alpha_3,\beta_3}_{(i_3,j_3)}
         (\rho_{b_2 C}^{(k)})_{(r,i_3),(r',j_3)}.
     \end{align*}
     These are the two factors in the sectorwise inverse-map calculation of
@@ -1087,16 +1087,16 @@ This is the single-block identity in
     \lean{MPOTensor.inverseMap_conj_physicalSlice_expansion}
     \leanok
     \uses{def:mpdo_three_site_closure, def:mpdo_hayashi_inverse_factors}
-    Let ${\cal K}$ be injective and let $\rho$ be its three-site closure
+    Let $\mathcal K$ be injective and let $\rho$ be its three-site closure
     against $R$. Applying the inverse tensor at the two outer sites collapses
     the closure to one entry of the middle physical slice and one entry of the
     tail:
     \[
         \sum_{i_1,j_1,i_3,j_3}
-        ({\cal K}^{-1})^{\alpha_1,\beta_1}_{(i_1,j_1)}
-        ({\cal K}^{-1})^{\alpha_3,\beta_3}_{(i_3,j_3)}
+        (\mathcal K^{-1})^{\alpha_1,\beta_1}_{(i_1,j_1)}
+        (\mathcal K^{-1})^{\alpha_3,\beta_3}_{(i_3,j_3)}
         \rho_{i_1i_2i_3,j_1j_2j_3}
-        ={\cal K}^{i_2j_2}_{\beta_1,\alpha_3}\,
+        =\mathcal K^{i_2j_2}_{\beta_1,\alpha_3}\,
         R_{\beta_3,\alpha_1}.
     \]
     Consequently, for any matrix $U$ on the middle site,
@@ -1104,8 +1104,8 @@ This is the single-block identity in
         R_{\beta_3,\alpha_1}
         \bigl(U\kappa_{\beta_1,\alpha_3}U^\dagger\bigr)_{b,b'}
         =\sum_{i_1,j_1,i_3,j_3}
-        ({\cal K}^{-1})^{\alpha_1,\beta_1}_{(i_1,j_1)}
-        ({\cal K}^{-1})^{\alpha_3,\beta_3}_{(i_3,j_3)}
+        (\mathcal K^{-1})^{\alpha_1,\beta_1}_{(i_1,j_1)}
+        (\mathcal K^{-1})^{\alpha_3,\beta_3}_{(i_3,j_3)}
         \sum_{i_2,j_2}
         U_{b,i_2}\,\rho_{i_1i_2i_3,j_1j_2j_3}\,
         \overline{U_{b',j_2}}.
@@ -1119,7 +1119,7 @@ This is the single-block identity in
     \[
         \rho_{i_1i_2i_3,j_1j_2j_3}
         =\tr\!\left(
-          {\cal K}^{i_1j_1}{\cal K}^{i_2j_2}{\cal K}^{i_3j_3}R
+          \mathcal K^{i_1j_1}\mathcal K^{i_2j_2}\mathcal K^{i_3j_3}R
         \right)
     \]
     converts the left-hand side of the first identity to
@@ -1127,7 +1127,7 @@ This is the single-block identity in
     Theorem~\ref{thm:mpdo_inverse_map_three_site_contraction} then gives
     \[
         C_{\alpha_1,\beta_1,\alpha_3,\beta_3}((i_2,j_2);R)
-        ={\cal K}^{i_2j_2}_{\beta_1,\alpha_3}
+        =\mathcal K^{i_2j_2}_{\beta_1,\alpha_3}
         R_{\beta_3,\alpha_1},
     \]
     which is the first identity. The second identity follows by expanding the
@@ -1144,8 +1144,8 @@ This is the single-block identity in
         R_{\beta_3,\alpha_1}\,
         \kappa_{\beta_1,\alpha_3}(i_2,j_2)
         =\sum_{i_1,j_1,i_3,j_3}
-        ({\cal K}^{-1})^{\alpha_1,\beta_1}_{(i_1,j_1)}
-        ({\cal K}^{-1})^{\alpha_3,\beta_3}_{(i_3,j_3)}
+        (\mathcal K^{-1})^{\alpha_1,\beta_1}_{(i_1,j_1)}
+        (\mathcal K^{-1})^{\alpha_3,\beta_3}_{(i_3,j_3)}
         \rho_{i_1i_2i_3,j_1j_2j_3},
     \]
     and reordering the finite sums.
@@ -1157,7 +1157,7 @@ This is the single-block identity in
     \leanok
     \uses{def:mpdo_three_site_closure,
         def:mpdo_hayashi_inverse_factors}
-    Suppose that ${\cal K}$ is injective, $\rho$ is its three-site closure
+    Suppose that $\mathcal K$ is injective, $\rho$ is its three-site closure
     against $R$, and a Hayashi decomposition of $\rho$ has been chosen. Write
     \[
         \widetilde\kappa^{(k)}_{\beta_1,\alpha_3}
@@ -1202,29 +1202,29 @@ in the basis adapted to sector $k$; compare
     For each $i_2,j_2$, the preceding theorem gives
     \[
         \sum_{i_1,j_1,i_3,j_3}
-        ({\cal K}^{-1})^{\alpha_1,\beta_1}_{(i_1,j_1)}
-        ({\cal K}^{-1})^{\alpha_3,\beta_3}_{(i_3,j_3)}
+        (\mathcal K^{-1})^{\alpha_1,\beta_1}_{(i_1,j_1)}
+        (\mathcal K^{-1})^{\alpha_3,\beta_3}_{(i_3,j_3)}
         \rho_{i_1i_2i_3,j_1j_2j_3}
-        ={\cal K}^{i_2j_2}_{\beta_1,\alpha_3}
+        =\mathcal K^{i_2j_2}_{\beta_1,\alpha_3}
           R_{\beta_3,\alpha_1}.
     \]
     Apply
     $\sum_{i_1,j_1,i_3,j_3}
-      ({\cal K}^{-1})^{\alpha_1,\beta_1}_{(i_1,j_1)}
-      ({\cal K}^{-1})^{\alpha_3,\beta_3}_{(i_3,j_3)}\,(-)$
+      (\mathcal K^{-1})^{\alpha_1,\beta_1}_{(i_1,j_1)}
+      (\mathcal K^{-1})^{\alpha_3,\beta_3}_{(i_3,j_3)}\,(-)$
     to the Hayashi block equality. Substituting the preceding display and
     interchanging the finite sums gives
     \begin{align*}
         &\sum_{i_1,j_1,i_3,j_3}
-          ({\cal K}^{-1})^{\alpha_1,\beta_1}_{(i_1,j_1)}
-          ({\cal K}^{-1})^{\alpha_3,\beta_3}_{(i_3,j_3)}\\
+          (\mathcal K^{-1})^{\alpha_1,\beta_1}_{(i_1,j_1)}
+          (\mathcal K^{-1})^{\alpha_3,\beta_3}_{(i_3,j_3)}\\
         &\quad{}\times\left(\sum_{i_2,j_2}
           [U_B]_{(k,l,r),i_2}\,
           \rho_{i_1i_2i_3,j_1j_2j_3}\,
           \overline{[U_B]_{(k,l',r'),j_2}}\right)\\
         &={}\sum_{i_2,j_2}
           [U_B]_{(k,l,r),i_2}\,
-          {\cal K}^{i_2j_2}_{\beta_1,\alpha_3}
+          \mathcal K^{i_2j_2}_{\beta_1,\alpha_3}
           R_{\beta_3,\alpha_1}\,
           \overline{[U_B]_{(k,l',r'),j_2}}.
     \end{align*}
@@ -1260,19 +1260,19 @@ in the basis adapted to sector $k$; compare
     \leanok
     \uses{def:mpdo_three_site_closure, def:mpdo_normalized_four_site_tail}
     Carried onto the tripartite site index, the three-site marginal of the
-    normalized four-site chain is the three-site closure of ${\cal K}$
+    normalized four-site chain is the three-site closure of $\mathcal K$
     against the normalized fourth-site tail $R_4$.
 \end{theorem}
 
 \begin{proof}
     \leanok
     \uses{thm:mpdo_reduced_four_three_tail}
-    The entry formula for $\sigma_3^{(4)}({\cal K})$, carried onto the
+    The entry formula for $\sigma_3^{(4)}(\mathcal K)$, carried onto the
     tripartite site index $(i_1,i_2,i_3)$, gives
     \[
         \rho_{i_1i_2i_3,j_1j_2j_3}
         =\tr\!\left(
-          {\cal K}^{i_1j_1}{\cal K}^{i_2j_2}{\cal K}^{i_3j_3}R_4
+          \mathcal K^{i_1j_1}\mathcal K^{i_2j_2}\mathcal K^{i_3j_3}R_4
         \right),
     \]
     which is the three-site closure condition of
@@ -1365,7 +1365,7 @@ in the basis adapted to sector $k$; compare
     \lean{MPOTensor.physicalSlice_sector_factorization}
     \leanok
     \uses{def:mpdo_sector_tensors}
-    Suppose that ${\cal K}$ is injective, $\rho$ is its three-site closure
+    Suppose that $\mathcal K$ is injective, $\rho$ is its three-site closure
     against $R$, a Hayashi decomposition of $\rho$ has been chosen, and the
     outer indices satisfy $R_{\beta_3,\alpha_1}\ne0$. Then for all virtual
     indices $\beta_1,\alpha_3$,
@@ -1381,7 +1381,8 @@ in the basis adapted to sector $k$; compare
 In the middle-site basis selected by $U_B$, the same factorization is
 displayed as
 \begin{center}
-    % U_B K U_B^dagger = bigoplus_k l_k (x) r_k: U_B splits K's
+    % U_B kappa U_B^dagger = bigoplus_k l_k (x) r_k: U_B splits the
+    % physical slice kappa_{beta_1,alpha_3}'s
     % physical space into the left sector factor l_k and right sector
     % factor r_k.  Each factor is an operator with one ket and one bra
     % leg.  Both sides have boundary signature
@@ -1389,7 +1390,7 @@ displayed as
     % physical-down=2).
     \begin{tenkz}[rows={op:none, op, op:none}, tensor style=box]
         \tn[pill, wide=2, legs at={1,2}]{U_B} & \\
-        \tn{\mathcal K} & \\
+        \tn{\kappa_{\beta_1,\alpha_3}} & \\
         \tn[pill, wide=2, legs at={1,2}]{U_B^\dagger} &
     \end{tenkz}
     $\;=\;\bigoplus_k$
@@ -1420,8 +1421,8 @@ displayed as
     \lean{MPOTensor.exists_physicalSlice_sector_factorization}
     \leanok
     \uses{def:mpdo_sector_tensors, def:mpdo_normalized_four_site_tail}
-    Let ${\cal K}$ be injective with nonzero four-site trace, let $\rho$ be a
-    three-site closure of ${\cal K}$ against the normalized fourth-site tail
+    Let $\mathcal K$ be injective with nonzero four-site trace, let $\rho$ be a
+    three-site closure of $\mathcal K$ against the normalized fourth-site tail
     $R_4$, and choose a Hayashi decomposition of $\rho$. Then there exist
     sector tensors $l_k$ and $r_k$ such that, for all virtual indices
     $\beta_1,\alpha_3$,

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
@@ -753,21 +753,25 @@ strong subadditivity for a normalized three-site reduced state.
 For an injective simple tensor, contracting $K^{-1}$ with $K$ through the
 physical index identifies the corresponding virtual legs.  In components,
 this is the matrix-unit identity
-$\sum_p(K^{-1})^{\alpha,\beta}_pK^p=E_{\alpha,\beta}$:
+\[
+    \sum_p(K^{-1})^{\alpha,\beta}_p(K^p)_{\alpha',\beta'}
+    =\delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
+\]
+Its two Kronecker factors are the two bare cups:
 \begin{center}
     % The upper inverse tensor and lower tensor contract through the doubled
     % physical index p.  Their four virtual legs remain open and are
-    % identified pairwise by the two cups on the right.
+    % identified pairwise by the tensor product of the two cups on the right.
     \begin{tenkz}[rows={bra, ket}, tensor style=box]
-        \tn{{\cal K}^{-1}} \\
-        \tn{{\cal K}}
+        \tn{\mathcal K^{-1}} \\
+        \tn{\mathcal K}
     \end{tenkz}
     $\;=\;$
     \begin{tenkz}[rows={wire, wire}, east=cup]
         \tnghost{} \\
         \tnghost{}
     \end{tenkz}
-    $\;$
+    $\;\otimes\;$
     \begin{tenkz}[rows={wire, wire}, west=cup]
         \tnghost{} \\
         \tnghost{}
@@ -789,8 +793,8 @@ virtual legs against a further copy of $K$ recovers $K$:
             west=cup,
             east=cup,
             tensor style=box]
-        \tn[up=p]{{\cal K}} \\
-        \tn{{\cal K}^{-1}} \\
+        \tn[up=p]{\mathcal K} \\
+        \tn{\mathcal K^{-1}} \\
         \tn{K}
     \end{tenkz}
     $\;=\;$
@@ -844,9 +848,9 @@ This is the single-block identity in
     % is (virtual-west=0 | virtual-east=0 |
     % physical-up=3 | physical-down=3).
     \begin{tenkz}[physical=updown, periodic]
-        \tn[up=$i_1$, down=$j_1$]{{\cal K}} &
-        \tn[up=$i_2$, down=$j_2$]{{\cal K}} &
-        \tn[up=$i_3$, down=$j_3$]{{\cal K}} &
+        \tn[up=$i_1$, down=$j_1$]{\mathcal K} &
+        \tn[up=$i_2$, down=$j_2$]{\mathcal K} &
+        \tn[up=$i_3$, down=$j_3$]{\mathcal K} &
         \tnX{R_4}
     \end{tenkz}
     \caption{Tracing the fourth site of the normalized four-site periodic MPO
@@ -994,15 +998,15 @@ This is the single-block identity in
             \end{tenkz}
             \Bigr)
             \begin{tenkz}[compact, physical=up, periodic]
-                \tn[up=$p_1$]{{\cal K}} &
-                \tn[up=$p_2$]{{\cal K}} &
-                \tn[up=$p_3$]{{\cal K}} &
+                \tn[up=$p_1$]{\mathcal K} &
+                \tn[up=$p_2$]{\mathcal K} &
+                \tn[up=$p_3$]{\mathcal K} &
                 \tnX{R}
             \end{tenkz}
             \;=\;
             \begin{tenkz}[compact, physical=up,
                           west label=$\beta_1$, east label=$\alpha_3$]
-                \tn[up=$p_2$]{{\cal K}}
+                \tn[up=$p_2$]{\mathcal K}
             \end{tenkz}
             \otimes
             \begin{tenkz}[compact,

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
@@ -784,12 +784,13 @@ Applying this inverse map to the doubled physical index and closing its
 virtual legs against a further copy of $K$ recovers $K$:
 \[
     % K K^{-1} K = K (arXiv:1606.00608, eq:Kidentity): the top
-    % tensor closes both virtual legs against K^{-1}; the bottom K retains
-    % its virtual legs.  The vertical strand is the doubled physical index.
+    % tensor closes both virtual legs against K^{-1} and keeps its physical
+    % leg p open; K^{-1} contracts through the doubled physical index only
+    % with the bottom K, whose virtual legs remain open.
     % Both sides have boundary signature (virtual-west=1 | virtual-east=1 |
     % physical-up=1 | physical-down=0).
     \begin{tenkz}[
-            rows={op, op, ket:open},
+            rows={ket:nopair, ket, bra},
             west=cup,
             east=cup,
             tensor style=box]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
@@ -758,31 +758,31 @@ this is the matrix-unit identity
     =\delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
 \]
 Its two Kronecker factors are the two bare cups:
-\begin{center}
+\[
     % The upper inverse tensor and lower tensor contract through the doubled
     % physical index p.  Their four virtual legs remain open and are
     % identified pairwise by the tensor product of the two cups on the right.
-    \begin{tenkz}[rows={bra, ket}, tensor style=box]
+    \begin{tenkz}[rows={ket, bra}, tensor style=box]
         \tn{K^{-1}} \\
         \tn{K}
     \end{tenkz}
-    $\;=\;$
+    \;=\;
     \begin{tenkz}[rows={wire, wire}, east=cup]
         \tnghost{} \\
         \tnghost{}
     \end{tenkz}
-    $\;\otimes\;$
+    \;\otimes\;
     \begin{tenkz}[rows={wire, wire}, west=cup]
         \tnghost{} \\
         \tnghost{}
     \end{tenkz}
-\end{center}
+\]
 This is the identity in
 \cite[Appendix~C.2, lines~1376--1380]{Cirac2016MPDO_arXiv}.
 
 Applying this inverse map to the doubled physical index and closing its
 virtual legs against a further copy of $K$ recovers $K$:
-\begin{center}
+\[
     % K K^{-1} K = K (arXiv:1606.00608, eq:Kidentity): the top
     % tensor closes both virtual legs against K^{-1}; the bottom K retains
     % its virtual legs.  The vertical strand is the doubled physical index.
@@ -797,11 +797,11 @@ virtual legs against a further copy of $K$ recovers $K$:
         \tn{K^{-1}} \\
         \tn{K}
     \end{tenkz}
-    $\;=\;$
+    \;=\;
     \begin{tenkz}[physical=up, tensor style=box]
         \tn[up=p]{K}
     \end{tenkz}
-\end{center}
+\]
 This is the single-block identity in
 \cite[Appendix~C.2, lines~1671--1676]{Cirac2016MPDO_arXiv}.
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
@@ -755,7 +755,43 @@ physical index identifies the corresponding virtual legs.  In components,
 this is the matrix-unit identity
 $\sum_p(K^{-1})^{\alpha,\beta}_pK^p=E_{\alpha,\beta}$:
 \begin{center}
-    \TNMPDOInverseContraction
+    % sum_p (K^{-1})^{alpha,beta}_p K^p = delta_{alpha,alpha'}
+    % delta_{beta,beta'}: K^{-1} (top) is contracted with K (bottom)
+    % through their shared doubled physical index.  Following
+    % MPDO_NotationK.png, its ket copy is solid and its bra copy dashed.
+    % The four open virtual stubs, top row then bottom row, are
+    % alpha', beta', alpha, beta.  The two bends on the right implement
+    % the corresponding pair of Kronecker deltas.  Both sides have
+    % boundary signature (virtual-west=2 | virtual-east=2 |
+    % physical-up=0 | physical-down=0).
+    \begin{tenkzfree}
+        \tnput[ports={west:virtual, east:virtual}, label pos=north]
+            {Kinv}{(0,4.4mm)}{{\cal K}^{-1}}
+        \tnput[ports={west:virtual, east:virtual}, label pos=south]
+            {K}{(0,-4.4mm)}{{\cal K}}
+        % tenkz-lint: allow raw-ink offset ket strand of doubled contraction
+        \draw[bond] ($(Kinv.south)+(-0.35mm,0)$) -- ($(K.north)+(-0.35mm,0)$);
+        % tenkz-lint: allow raw-ink offset bra strand of doubled contraction
+        \draw[bond, dashed] ($(Kinv.south)+(0.35mm,0)$) -- ($(K.north)+(0.35mm,0)$);
+        % tenkz-lint: allow raw-ink free-tier open virtual leg
+        \draw[bond] (Kinv.west) -- ++(-4.95mm,0);
+        % tenkz-lint: allow raw-ink free-tier open virtual leg
+        \draw[bond] (Kinv.east) -- ++(4.95mm,0);
+        % tenkz-lint: allow raw-ink free-tier open virtual leg
+        \draw[bond] (K.west) -- ++(-4.95mm,0);
+        % tenkz-lint: allow raw-ink free-tier open virtual leg
+        \draw[bond] (K.east) -- ++(4.95mm,0);
+    \end{tenkzfree}
+    $\;=\;$
+    \begin{tenkz}[rows={wire, wire}, east=cup]
+        \tnghost{} \\
+        \tnghost{}
+    \end{tenkz}
+    $\;$
+    \begin{tenkz}[rows={wire, wire}, west=cup]
+        \tnghost{} \\
+        \tnghost{}
+    \end{tenkz}
 \end{center}
 This is the identity in
 \cite[Appendix~C.2, lines~1376--1380]{Cirac2016MPDO_arXiv}.
@@ -763,10 +799,52 @@ This is the identity in
 Applying this inverse map to the doubled physical index and closing its
 virtual legs against a further copy of $K$ recovers $K$:
 \begin{center}
-    \TNMPDOInverseRecovery
+    % \mathcal K K^{-1} K = K (arXiv:1606.00608, eq:Kidentity):
+    % the top tensor is the script-letter BNT basis element \mathcal K,
+    % not another copy of K.  Its two virtual legs close separately against
+    % K^{-1}, while the bottom K retains its virtual legs.  The fused double
+    % stroke marks the doubled physical index at the open top boundary and
+    % at the K^{-1}/K contraction.  Both sides have boundary signature
+    % (virtual-west=1 | virtual-east=1 | physical-up=1 |
+    % physical-down=0).
+    \begin{tenkzfree}
+        \tnput{Kc}{(0,9mm)}{}
+        \tnput{Kinv}{(0,0)}{}
+        \tnput[label pos=south]{Kbot}{(0,-9mm)}{K}
+        % tenkz-lint: allow raw-ink free-tier west inverse bend
+        \draw[bond] (Kc.west) to[out=180, in=180, looseness=1.6] (Kinv.west);
+        % tenkz-lint: allow raw-ink free-tier east inverse bend
+        \draw[bond] (Kc.east) to[out=0, in=0, looseness=1.6] (Kinv.east);
+        % tenkz-lint: allow raw-ink free-tier open doubled physical leg
+        \draw[fused bond] (Kc.north) -- ++(0,4.2mm);
+        % tenkz-lint: allow raw-ink free-tier internal physical contraction
+        \draw[bond] (Kc.south) -- (Kinv.north);
+        % tenkz-lint: allow raw-ink free-tier doubled physical contraction
+        \draw[fused bond] (Kinv.south) -- (Kbot.north);
+        % tenkz-lint: allow raw-ink free-tier open virtual leg
+        \draw[bond] (Kbot.west) -- ++(-5mm,0);
+        % tenkz-lint: allow raw-ink free-tier open virtual leg
+        \draw[bond] (Kbot.east) -- ++(5mm,0);
+        % tenkz-lint: allow raw-ink source-positioned script K label
+        \node[tn label, anchor=east] at ($(Kc.west)-(3mm,0)$) {$\scriptstyle\mathcal K$};
+        % tenkz-lint: allow raw-ink source-positioned inverse label
+        \node[tn label, anchor=east] at ($(Kinv.west)-(3mm,0)$) {$\scriptstyle K^{-1}$};
+    \end{tenkzfree}
+    $\;=\;$
+    \begin{tenkzfree}
+        \tnput[label pos=south]{K}{(0,0)}{K}
+        % tenkz-lint: allow raw-ink free-tier open doubled physical leg
+        \draw[fused bond] (K.north) -- ++(0,4.2mm);
+        % tenkz-lint: allow raw-ink free-tier open virtual leg
+        \draw[bond] (K.west) -- ++(-5mm,0);
+        % tenkz-lint: allow raw-ink free-tier open virtual leg
+        \draw[bond] (K.east) -- ++(5mm,0);
+    \end{tenkzfree}
 \end{center}
-The doubled physical index is represented by a single physical line.  This
-is the single-block identity of
+The doubled physical index is represented by the fused double stroke at the
+open boundary and the lower contraction; the internal
+$\mathcal K$--$K^{-1}$ line remains single.  This is the
+single-block identity of
 \cite[Appendix~C.2, lines~1671--1676]{Cirac2016MPDO_arXiv}.
 
 \begin{definition}[Normalized fourth-site virtual tail]
@@ -806,7 +884,25 @@ is the single-block identity of
 
 \begin{figure}[ht]
     \centering
-    \TNMPDONormalizedFourSiteTail
+    % tr_4(K_4) = sum_alpha L_alpha (x) B_alpha (x) R_alpha: tracing
+    % the fourth physical index folds that site into R_4 and leaves the
+    % first three ket and bra legs open.  On the left, periodic closes the
+    % virtual ring through the virtual-only R_4 cell.  On the right, the
+    % outer sum over alpha reglues the sealed chain ends.  Both sides have
+    % aggregate signature (virtual-west=0 | virtual-east=0 |
+    % physical-up=3 | physical-down=3).
+    \begin{tenkz}[physical=updown, periodic]
+        \tn[up=$i_1$, down=$j_1$]{{\cal K}} &
+        \tn[up=$i_2$, down=$j_2$]{{\cal K}} &
+        \tn[up=$i_3$, down=$j_3$]{{\cal K}} &
+        \tnX{R_4}
+    \end{tenkz}
+    $\;=\;\displaystyle\sum_\alpha\;$
+    \begin{tenkz}[physical=updown, boundary=none]
+        \tn[up=$i_1$, down=$j_1$]{L_\alpha} &
+        \tn[up=$i_2$, down=$j_2$]{B_\alpha} &
+        \tn[up=$i_3$, down=$j_3$]{R_\alpha}
+    \end{tenkz}
     \caption{Tracing the fourth site of the normalized four-site periodic MPO
     leaves the physical legs of sites $1,2,3$ open and replaces the fourth site
     by the virtual closing operator
@@ -925,7 +1021,49 @@ is the single-block identity of
 
 \begin{figure}[ht]
     \centering
-    \TNMPDOInverseMapThreeSiteContraction
+    \begin{center}
+        % (K^{-1} (x) Id (x) K^{-1}) K_3
+        %   = K^{p_2}_{beta_1,alpha_3} R_{beta_3,alpha_1}
+        % (arXiv:1606.00608, Appendix C.2, lines 1415--1438; paper
+        % figures MPDO_Xab.png, MPDO_kappaab.png, and MPDO_mba.png).
+        %
+        % LHS: the two K^{-1} boxes expose virtual pairs
+        % (alpha_1,beta_1) and (alpha_3,beta_3).  Their physical indices
+        % p_1,p_3 match the first and third legs of the closed K_3
+        % contraction; p_2 remains open.  RHS: K carries beta_1 west,
+        % p_2 up, and alpha_3 east, while R carries beta_3 west and
+        % alpha_1 east.  There is no surviving sum: the identity is
+        % pointwise in all four virtual indices.  Both sides have aggregate
+        % boundary signature (virtual-west=2 | physical-up=1 |
+        % virtual-east=2).
+        \[
+            \Bigl(
+            \begin{tenkz}[compact, physical=down,
+                          west label=$\alpha_1$, east label=$\beta_1$]
+                \tn[down=$p_1$]{{\cal K}^{-1}}
+            \end{tenkz}
+            \otimes\Id\otimes
+            \begin{tenkz}[compact, physical=down,
+                          west label=$\alpha_3$, east label=$\beta_3$]
+                \tn[down=$p_3$]{{\cal K}^{-1}}
+            \end{tenkz}
+            \Bigr)
+            \begin{tenkz}[compact, physical=up, boundary=none]
+                \tn[pill, wide=3, legs at={1,2,3},
+                    up={$p_1$,$p_2$,$p_3$}]{{\cal K}_3}
+            \end{tenkz}
+            \;=\;
+            \begin{tenkz}[compact, physical=up,
+                          west label=$\beta_1$, east label=$\alpha_3$]
+                \tn[up=$p_2$]{{\cal K}}
+            \end{tenkz}
+            \otimes
+            \begin{tenkz}[compact,
+                          west label=$\beta_3$, east label=$\alpha_1$]
+                \tnX{R}
+            \end{tenkz}
+        \]
+    \end{center}
     \caption{Applying ${\cal K}^{-1}$ at the first and third sites collapses
     the three-site contraction to
     ${\cal K}^{p_2}_{\beta_1,\alpha_3}R_{\beta_3,\alpha_1}$, where
@@ -1293,7 +1431,25 @@ in the basis adapted to sector $k$; compare
 In the middle-site basis selected by $U_B$, the same factorization is
 displayed as
 \begin{center}
-    \TNMPDOSectorFactorization
+    % U_B K U_B^dagger = bigoplus_k l_k (x) r_k: U_B splits K's
+    % physical space into the left sector factor l_k and right sector
+    % factor r_k.  Each factor is an operator with one ket and one bra
+    % leg.  Both sides have boundary signature
+    % (virtual-west=1 | virtual-east=1 | physical-up=2 |
+    % physical-down=2).
+    \begin{tenkz}[rows={op:none, op, op:none}, tensor style=box]
+        \tn[pill, wide=2, legs at={1,2}]{U_B^\dagger} & \\
+        \tn{\mathcal K} & \\
+        \tn[pill, wide=2, legs at={1,2}]{U_B} &
+    \end{tenkz}
+    $\;=\;\bigoplus_k$
+    \begin{tenkz}[physical=updown, east=none, tensor style=box]
+        \tn{l_k}
+    \end{tenkz}
+    $\;\otimes\;$
+    \begin{tenkz}[physical=updown, west=none, tensor style=box]
+        \tn{r_k}
+    \end{tenkz}
 \end{center}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
@@ -755,7 +755,13 @@ physical index identifies the corresponding virtual legs.  In components,
 this is the matrix-unit identity
 $\sum_p(K^{-1})^{\alpha,\beta}_pK^p=E_{\alpha,\beta}$:
 \begin{center}
-    $\displaystyle\sum_p (K^{-1})^{\alpha,\beta}_p\,K^p$
+    % The upper inverse tensor and lower tensor contract through the doubled
+    % physical index p.  Their four virtual legs remain open and are
+    % identified pairwise by the two cups on the right.
+    \begin{tenkz}[rows={bra, ket}, tensor style=box]
+        \tn{{\cal K}^{-1}} \\
+        \tn{{\cal K}}
+    \end{tenkz}
     $\;=\;$
     \begin{tenkz}[rows={wire, wire}, east=cup]
         \tnghost{} \\
@@ -773,15 +779,26 @@ This is the identity in
 Applying this inverse map to the doubled physical index and closing its
 virtual legs against a further copy of $K$ recovers $K$:
 \begin{center}
-    % \mathcal K K^{-1} K = K (arXiv:1606.00608, eq:Kidentity): the
-    % script-letter BNT basis element \mathcal K closes its two virtual legs
-    % against K^{-1}, while the bottom K retains its virtual legs and the
-    % doubled physical index survives at the open boundary.
-    \[
-        {\cal K}\,{\cal K}^{-1}K = K
-    \]
+    % \mathcal K K^{-1} K = K (arXiv:1606.00608, eq:Kidentity): the top
+    % tensor closes both virtual legs against K^{-1}; the bottom K retains
+    % its virtual legs.  The vertical strand is the doubled physical index.
+    % Both sides have boundary signature (virtual-west=1 | virtual-east=1 |
+    % physical-up=1 | physical-down=0).
+    \begin{tenkz}[
+            rows={op, op, ket:open},
+            west=cup,
+            east=cup,
+            tensor style=box]
+        \tn[up=p]{{\cal K}} \\
+        \tn{{\cal K}^{-1}} \\
+        \tn{K}
+    \end{tenkz}
+    $\;=\;$
+    \begin{tenkz}[physical=up, tensor style=box]
+        \tn[up=p]{K}
+    \end{tenkz}
 \end{center}
-This is the single-block identity of
+This is the single-block identity in
 \cite[Appendix~C.2, lines~1671--1676]{Cirac2016MPDO_arXiv}.
 
 \begin{definition}[Normalized fourth-site virtual tail]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
@@ -1384,9 +1384,9 @@ displayed as
     % (virtual-west=1 | virtual-east=1 | physical-up=2 |
     % physical-down=2).
     \begin{tenkz}[rows={op:none, op, op:none}, tensor style=box]
-        \tn[pill, wide=2, legs at={1,2}]{U_B^\dagger} & \\
+        \tn[pill, wide=2, legs at={1,2}]{U_B} & \\
         \tn{\mathcal K} & \\
-        \tn[pill, wide=2, legs at={1,2}]{U_B} &
+        \tn[pill, wide=2, legs at={1,2}]{U_B^\dagger} &
     \end{tenkz}
     $\;=\;\bigoplus_k$
     \begin{tenkz}[physical=updown, east=none, tensor style=box]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
@@ -838,24 +838,16 @@ This is the single-block identity in
 
 \begin{figure}[ht]
     \centering
-    % tr_4(K_4) = sum_alpha L_alpha (x) B_alpha (x) R_alpha: tracing
-    % the fourth physical index folds that site into R_4 and leaves the
-    % first three ket and bra legs open.  On the left, periodic closes the
-    % virtual ring through the virtual-only R_4 cell.  On the right, the
-    % outer sum over alpha reglues the sealed chain ends.  Both sides have
-    % aggregate signature (virtual-west=0 | virtual-east=0 |
+    % Tracing the fourth physical index folds that site into R_4 and leaves
+    % the first three ket and bra legs open.  The periodic wire closes the
+    % virtual ring through the virtual-only R_4 cell.  The boundary signature
+    % is (virtual-west=0 | virtual-east=0 |
     % physical-up=3 | physical-down=3).
     \begin{tenkz}[physical=updown, periodic]
         \tn[up=$i_1$, down=$j_1$]{{\cal K}} &
         \tn[up=$i_2$, down=$j_2$]{{\cal K}} &
         \tn[up=$i_3$, down=$j_3$]{{\cal K}} &
         \tnX{R_4}
-    \end{tenkz}
-    $\;=\;\displaystyle\sum_\alpha\;$
-    \begin{tenkz}[physical=updown, boundary=none]
-        \tn[up=$i_1$, down=$j_1$]{L_\alpha} &
-        \tn[up=$i_2$, down=$j_2$]{B_\alpha} &
-        \tn[up=$i_3$, down=$j_3$]{R_\alpha}
     \end{tenkz}
     \caption{Tracing the fourth site of the normalized four-site periodic MPO
     leaves the physical legs of sites $1,2,3$ open and replaces the fourth site
@@ -975,7 +967,6 @@ This is the single-block identity in
 
 \begin{figure}[ht]
     \centering
-    \begin{center}
         % (K^{-1} (x) Id (x) K^{-1}) K_3
         %   = K^{p_2}_{beta_1,alpha_3} R_{beta_3,alpha_1}
         % (arXiv:1606.00608, Appendix C.2, lines 1415--1438; paper
@@ -983,8 +974,8 @@ This is the single-block identity in
         %
         % LHS: the two K^{-1} boxes expose virtual pairs
         % (alpha_1,beta_1) and (alpha_3,beta_3).  Their physical indices
-        % p_1,p_3 match the first and third legs of the closed K_3
-        % contraction; p_2 remains open.  RHS: K carries beta_1 west,
+        % p_1,p_3 match the first and third legs of the three-site chain
+        % closed against R; p_2 remains open.  RHS: K carries beta_1 west,
         % p_2 up, and alpha_3 east, while R carries beta_3 west and
         % alpha_1 east.  There is no surviving sum: the identity is
         % pointwise in all four virtual indices.  Both sides have aggregate
@@ -1002,9 +993,11 @@ This is the single-block identity in
                 \tn[down=$p_3$]{{\cal K}^{-1}}
             \end{tenkz}
             \Bigr)
-            \begin{tenkz}[compact, physical=up, boundary=none]
-                \tn[pill, wide=3, legs at={1,2,3},
-                    up={$p_1$,$p_2$,$p_3$}]{{\cal K}_3}
+            \begin{tenkz}[compact, physical=up, periodic]
+                \tn[up=$p_1$]{{\cal K}} &
+                \tn[up=$p_2$]{{\cal K}} &
+                \tn[up=$p_3$]{{\cal K}} &
+                \tnX{R}
             \end{tenkz}
             \;=\;
             \begin{tenkz}[compact, physical=up,
@@ -1017,7 +1010,6 @@ This is the single-block identity in
                 \tnX{R}
             \end{tenkz}
         \]
-    \end{center}
     \caption{Applying ${\cal K}^{-1}$ at the first and third sites collapses
     the three-site contraction to
     ${\cal K}^{p_2}_{\beta_1,\alpha_3}R_{\beta_3,\alpha_1}$, where

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
@@ -1390,7 +1390,7 @@ displayed as
     % physical-down=2).
     \begin{tenkz}[rows={op:none, op, op:none}, tensor style=box]
         \tn[pill, wide=2, legs at={1,2}]{U_B} & \\
-        \tn{\kappa_{\beta_1,\alpha_3}} & \\
+        \tn[wide=2]{\kappa_{\beta_1,\alpha_3}} & \\
         \tn[pill, wide=2, legs at={1,2}]{U_B^\dagger} &
     \end{tenkz}
     $\;=\;\bigoplus_k$

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels.tex
@@ -996,27 +996,25 @@ $\widehat{\cal K}$.
     \uses{thm:mpdo_blocked_sector_coordinate_tensor_is_rfp_via_ts}
     Transport the refinement and coarse-graining channels for
     $\widehat{\cal K}^{[2]}$ through the two-site and four-site tensor powers
-    of the physical isometry, as in
-    Figure~\ref{fig:mpdo_physical_isometry_transport}. These unitary
+    of the physical isometry, as in the identities below. These unitary
     congruences preserve complete positivity and trace, while the
     corresponding closure identities carry the two fixed-point equations back
     to ${\cal K}^{[2]}$.
 \end{proof}
 
-\begin{figure}[htbp]
-    \centering
-    \[
+% Correct equation, not a figure: the cited source draws the two-to-three
+% channel MPDO_TSKKK.png after explicitly suppressing U, but it does not draw
+% this tensor-power transport square.  The transport theorem is recorded in
+% docs/paper-gaps/cpgsv17_mpdo_blocked_rfp_physical_transport.tex.
+\begin{equation}
+    \label{eq:mpdo_physical_isometry_transport}
         U^{\otimes4}\widehat{\mathcal T}^{\,2}(U^\dagger)^{\otimes2}=\mathcal T,\qquad
         U^{\otimes2}\widehat{\mathcal S}^{\,2}(U^\dagger)^{\otimes4}=\mathcal S
-    \]
-    \caption{Physical-isometry transport of the blocked channels. Conjugating
-    the ket and bra indices by the tensor powers $U^{\otimes n}$ and
-    $(U^\dagger)^{\otimes n}$ carries the sector-coordinate channels to the
-    ordinary-coordinate channels. This combines Proposition~C.7 with
-    \cite[Appendix~C.2, lines~1510--1563 and 1821--1825]
-    {Cirac2016MPDO_arXiv}.}
-    \label{fig:mpdo_physical_isometry_transport}
-\end{figure}
+\end{equation}
+Conjugation by $U^{\otimes n}$ and $(U^\dagger)^{\otimes n}$ carries the
+sector-coordinate channels to the ordinary-coordinate channels. This combines
+Proposition~C.7 with
+\cite[Appendix~C.2, lines~1510--1563 and 1821--1825]{Cirac2016MPDO_arXiv}.
 
 Tracing the ket and bra indices of a sector tensor gives the bond vector
 $|l_k)$ or the bond functional $(r_k|$.  Hence a neighboring pair gives

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels.tex
@@ -996,7 +996,8 @@ $\widehat{\cal K}$.
     \uses{thm:mpdo_blocked_sector_coordinate_tensor_is_rfp_via_ts}
     Transport the refinement and coarse-graining channels for
     $\widehat{\cal K}^{[2]}$ through the two-site and four-site tensor powers
-    of the physical isometry, as in the identities below. These unitary
+    of the physical isometry, as in
+    \eqref{eq:mpdo_physical_isometry_transport}. These unitary
     congruences preserve complete positivity and trace, while the
     corresponding closure identities carry the two fixed-point equations back
     to ${\cal K}^{[2]}$.

--- a/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
@@ -189,7 +189,8 @@ product states, and the square lattice.
     Theorem~\ref{thm:peps_bondDim_eq_of_normalBlocking}.  Positive bond
     dimensions are required in the injectivity argument, while connectivity
     permits the per-vertex constants to be absorbed into the edge gauges; see
-    Theorem~\ref{thm:fundamentalTheorem_PEPS}.
+    Theorem~\ref{thm:fundamentalTheorem_PEPS}.  This is the blocking argument
+    of \cite[Section~4]{Molnar2018NormalPEPS}.
     % Source-faithful reading: Section 4 of \cite{Molnar2018NormalPEPS} uses
     % one common blocking of the two states and enlarges the endpoint regions
     % so that they meet only along the distinguished edge.

--- a/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
@@ -179,35 +179,20 @@ product states, and the square lattice.
     defining tensors are related by a local gauge: there are invertible
     matrices, one on each edge, whose endpoint actions transform $A_v$ into
     $B_v$ at every vertex, with no leftover scalar.
-    This is the general normal-PEPS theorem in
-    \cite[Section~4]{Molnar2018NormalPEPS}, following its Theorem~3
-    (Theorem~\ref{thm:fundamentalTheorem_normalPEPS}), with the source's
-    blocking hypothesis stated explicitly as its proof uses it, in two ways,
-    neither of which restricts the source statement.  First, the blockings
-    are shared between the two states, each region injective for both
-    tensors: the source blocks both states by one blocking (``\emph{they}
-    can be blocked''), its isomorphism lemma takes the two blocked chains
-    over the same tripartition with all six blocks injective, and its final
-    comparison contracts both tensors over the same one-site-different
-    regions, whose injectivity for both tensors its comparison lemma
-    requires.  Second, the single-crossing hypothesis is the explicit
-    statement of the source's blocking \emph{around} an edge: the chosen edge
-    is the entire bond between the first two parties of the three-site chain.
-    In the source, blocking around an edge groups all vertices except the two
-    endpoints of the edge, so the edge is the bond between the first two
-    parties; the regions in the proof of
-    \cite[Section~4, proof of Theorem~3]{Molnar2018NormalPEPS} enlarge those
-    parties to injective blocks meeting only along the distinguished edge,
-    and the gauge of the isomorphism lemma lives on that edge of the original
-    network. The equality of the bond dimensions is not assumed; it is derived from the
-    blocking hypotheses
-    (Theorem~\ref{thm:peps_bondDim_eq_of_normalBlocking}), as in the source's
-    isomorphism lemma. The
-    positive bond dimensions and the connectivity of the graph are the
-    counterexample-backed corrections carried over from the injective
-    Fundamental Theorem (Theorem~\ref{thm:fundamentalTheorem_PEPS}); the
-    absorption of the per-vertex constants into the gauges is exactly the step
-    that requires connectivity.
+    The shared blocking gives a common tripartition for the two tensors, with
+    all three regions injective for both.  The three-site isomorphism lemma
+    therefore applies to the two blocked chains.  For an edge $e$, the
+    single-crossing hypothesis says that $e$ is the entire bond between the
+    first two regions, so the resulting gauge acts on the original edge.
+    The equality of the bond dimensions is not assumed; it follows from the
+    blocking hypotheses by
+    Theorem~\ref{thm:peps_bondDim_eq_of_normalBlocking}.  Positive bond
+    dimensions are required in the injectivity argument, while connectivity
+    permits the per-vertex constants to be absorbed into the edge gauges; see
+    Theorem~\ref{thm:fundamentalTheorem_PEPS}.
+    % Source-faithful reading: Section 4 of \cite{Molnar2018NormalPEPS} uses
+    % one common blocking of the two states and enlarges the endpoint regions
+    % so that they meet only along the distinguished edge.
     \begin{proof}
         \leanok
         \uses{thm:peps_bondDim_eq_of_normalBlocking,

--- a/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
@@ -180,10 +180,18 @@ product states, and the square lattice.
     matrices, one on each edge, whose endpoint actions transform $A_v$ into
     $B_v$ at every vertex, with no leftover scalar.
     The shared blocking gives a common tripartition for the two tensors, with
-    all three regions injective for both.  The three-site isomorphism lemma
-    therefore applies to the two blocked chains.  For an edge $e$, the
-    single-crossing hypothesis says that $e$ is the entire bond between the
-    first two regions, so the resulting gauge acts on the original edge.
+    all three regions injective for both.  For an edge $e$ between the first
+    two regions, the coefficient transfer $T_e$ supplied by the three-site
+    isomorphism argument satisfies
+    \[
+        C_A(R_1,e,X;\sigma,\tau)
+        =C_B(R_1,e,T_e(X);\sigma,\tau),
+        \qquad
+        T_e(X)=Z_e\,\iota_e(X)\,Z_e^{-1}
+    \]
+    for an invertible $Z_e$ and every virtual insertion $X$ on $e$.
+    The single-crossing hypothesis identifies $e$ with the entire bond between
+    $R_1$ and $R_2$, so $Z_e$ acts on the original edge.
     The equality of the bond dimensions is not assumed; it follows from the
     blocking hypotheses by
     Theorem~\ref{thm:peps_bondDim_eq_of_normalBlocking}.  Positive bond

--- a/blueprint/src/chapter/ch24_peps_ft_normal_union.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_union.tex
@@ -605,9 +605,10 @@ every finite union of injective regions.
         \Longrightarrow
         \operatorname{inj}(R\cup S).
     \]
-    Unlike the vertex-injective version, this provider derives injectivity of
-    the union from injectivity of the two regions, faithful to the source
-    union-of-injective-regions lemma; it needs no single-vertex injectivity.
+    Thus injectivity of the two regions implies injectivity of their union;
+    no single-vertex injectivity hypothesis is needed.
+    % Source-faithful scope note: this is the union-of-injective-regions
+    % lemma, rather than the stronger vertex-injective specialization.
 \end{theorem}
 \begin{proof}\leanok
     The union-closure implication is the overlapping union lemma

--- a/blueprint/src/chapter/ch26_mps_rfp_core.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp_core.tex
@@ -773,21 +773,20 @@
     Apply Theorem~\ref{thm:isometry_canonical_form_of_rfp_nt} to each block.
 \end{proof}
 
-\begin{figure}[ht]
-    \centering
+% BLOCKED figure (issue #4152): II_RFP.png has one open leg above U and two
+% separately contracted legs below it, the splitting glyph absent from tenkz
+% 0.6.  The source also threads both j and q through X, the coefficient tensor,
+% and X^{-1}.  Keep the faithful formula as an equation until that general
+% primitive lands; do not substitute the coarser global-X picture.
+Across all blocks, the canonical form is
     \[
-        A=X\left(\bigoplus_j\mu_j\otimes\sqrt{\Lambda_j}U_j\right)X^{-1}
+        A^i=\bigoplus_{j=1}^g\bigoplus_{q=1}^{r_j}
+        \mu_{j,q}X_{j,q}\sqrt{\Lambda_j}\,U_j^iX_{j,q}^{-1}.
     \]
-    \caption{The per-block canonical form
-        $A^i=\bigoplus_{j,q}\mu_{j,q}\,X_{j,q}\sqrt{\Lambda_j}\,U_j^i
-            X_{j,q}^{-1}$: the block indices $j$ and $q$ label the gauge,
-        the diagonal weight, the isometry, and the coefficient tensor $\mu$.
-        The display is per-block, matching the entry above; the cross-block
-        physical orthogonality of
-        \cite[Section~3.4, lines~543--561]{Cirac2016MPDO_arXiv} is not
-        displayed.}
-    \label{fig:rfp_isometry_canonical_form_blocks}
-\end{figure}
+Here $j$ labels the normal-tensor block and $q$ its repeated representation;
+the joint residual-isometry condition includes the cross-block physical
+orthogonality of
+\cite[Section~3.4, lines~543--561]{Cirac2016MPDO_arXiv}.
 % Scope restriction: cross-block orthogonality omitted here; see
 % docs/paper-gaps/cpsv16_rfp_isometry_scope.tex.
 

--- a/blueprint/src/chapter/ch26_mps_rfp_core.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp_core.tex
@@ -784,9 +784,10 @@ Across all blocks, the canonical form is
         \mu_{j,q}X_{j,q}\sqrt{\Lambda_j}\,U_j^iX_{j,q}^{-1}.
     \]
 Here $j$ labels the normal-tensor block and $q$ its repeated representation;
-the joint residual-isometry condition includes the cross-block physical
-orthogonality of
-\cite[Section~3.4, lines~543--561]{Cirac2016MPDO_arXiv}.
+the residual isometries in
+\cite[Section~3.4, lines~543--561]{Cirac2016MPDO_arXiv} also satisfy
+cross-block physical orthogonality.  Those additional equations are not part
+of the per-block theorem above.
 % Scope restriction: cross-block orthogonality omitted here; see
 % docs/paper-gaps/cpsv16_rfp_isometry_scope.tex.
 


### PR DESCRIPTION
## Summary

- replace formula-only MPDO placeholders with native `tenkz` contractions for the vertical decomposition, block inverse, periodic first-site contraction, inverse maps, normalized tail, and sector factorization
- retain identities without diagrammatic content as equations, including the full block canonical formula
- remove four dangling tensor-network macro references exposed by the complete blueprint build
- state mathematical claims directly throughout the blueprint and keep provenance notes in `%` comments

## Why

Several blueprint figures either displayed only formulas, encoded the wrong contraction or indices, or referred to undefined macros. The revised diagrams preserve the relevant contractions, virtual boundaries, physical legs, and block indices.

The missing splitting primitive remains the separate task tracked by LionSR/tenkz#19; until it is available, the full block canonical form is stated as the exact equation rather than represented by an inaccurate diagram.

## Validation

- `leanblueprint pdf` (619 pages)
- `leanblueprint checkdecls` on the original figure commit; the later prose-only rerun was blocked by a concurrently replaced partial `.lake/packages/mathlib` clone
- exact PR-CI tensor-network audit: 0 private calls, 0 raw TikZ operations, 81 smoke-rendered diagrams
- `python3 scripts/tenkz_lint.py` on the affected diagram files (0 findings)
- `chktex` on the prose and diagram files
- rendered-page inspection of every affected diagram and rewritten passage
- `git diff --check`

Closes LionSR/tenkz#21

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are LaTeX blueprint/documentation only (diagrams and prose); no Lean proof or runtime code paths are modified in the diff.
> 
> **Overview**
> **Blueprint tensor diagrams** for MPDO canonical forms and simple/local factorization now use inline **`tenkz`** contractions instead of undefined **`TNMPDO*`** macros or bare formulas. Updated figures include the vertical **`U\widetilde M U^\dagger`** decomposition (shared multiplicity wiring, not a plain Kronecker product), the block-injective **`K^{-1}K`** panel chain, periodic **`PH^{(N+1)}`** first-site contractions, inverse/recovery/tail/three-site inverse-map, and sector factorization networks.
> 
> Identities that should stay symbolic are kept as **display equations** with `%` provenance comments—for example injective **`A^{-1}A=\Id`**, physical-isometry channel transport (new **`eq:mpdo_physical_isometry_transport`** referenced via **`\eqref`**), and the full multi-block RFP canonical form (figure deferred until tenkz splitting lands in **#4152**).
> 
> **Notation and exposition** normalize **`{\cal K}` → `\mathcal K`**, fix a Cirac injectivity citation span, and shorten Radon–Nikodym, BNT-label, PEPS normal blocking, and union-injectivity remarks so mathematical claims read in the body while source-faithful scope stays in comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bffa067148d996b08aff74e81e4c60d5cfbb7368. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->