### PR TITLE
feat(Channel/Schwarz): identify SSA equality with DPI saturation

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -168,6 +168,7 @@ import TNLean.Channel.Schwarz.RelativeEntropyUnitaryInvariance
 import TNLean.Channel.Schwarz.RelativeEntropyAncillaAdditivity
 import TNLean.Channel.Schwarz.RelativeEntropyDataProcessing
 import TNLean.Channel.Schwarz.StrongSubadditivityPosDef
+import TNLean.Channel.Schwarz.SSAEqualityDPI
 import TNLean.Channel.Schwarz.WeylTwirl
 import TNLean.Channel.Schwarz.PositiveOnAbelian
 import TNLean.Channel.Schwarz.SchwarzNormal

--- a/TNLean/Channel/Schwarz/SSAEqualityDPI.lean
+++ b/TNLean/Channel/Schwarz/SSAEqualityDPI.lean
@@ -22,7 +22,7 @@ $\rho_A\otimes\rho_{BC}$ and $\rho_A\otimes\rho_B$ in their equations (5)--(7).
 The maximally mixed reference used here gives the same strong-subadditivity
 deficit and is covered by the existing singular-support evaluation of relative
 entropy. The remaining product-marginal evaluation is recorded in
-`docs/paper-gaps/hjpw04_ssa_product_marginal_reference.tex`.
+docs/paper-gaps/hjpw04_ssa_product_marginal_reference.tex.
 
 ## Main results
 
@@ -67,7 +67,7 @@ supplies this singular-reference evaluation without any additional hypothesis.
 **Reference substitution:** This is the hypothesis-free maximally mixed-reference
 formulation, not the exact product-marginal formulation of HJPW. The missing
 product-marginal logarithm evaluation is recorded in
-`docs/paper-gaps/hjpw04_ssa_product_marginal_reference.tex`.
+docs/paper-gaps/hjpw04_ssa_product_marginal_reference.tex.
 
 Source: Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2, p. 3,
 equations (5)--(7) and the paragraph following equation (7). -/

--- a/TNLean/Channel/Schwarz/SSAEqualityDPI.lean
+++ b/TNLean/Channel/Schwarz/SSAEqualityDPI.lean
@@ -1,0 +1,141 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sirui Lu
+-/
+import TNLean.Channel.Schwarz.StrongSubadditivityPosDef
+
+/-!
+# Equality in strong subadditivity as equality in data processing
+
+For a positive semidefinite tripartite state $\rho_{ABC}$ of trace one, this
+file identifies equality in strong subadditivity with saturation of the
+relative-entropy data-processing inequality under the partial trace over $C$.
+The reference pair is
+\[
+  (\mathbf 1_A/d_A)\otimes\rho_{BC}, \qquad
+  (\mathbf 1_A/d_A)\otimes\rho_B.
+\]
+
+Hayden--Jozsa--Petz--Winter use the product-marginal pair
+$\rho_A\otimes\rho_{BC}$ and $\rho_A\otimes\rho_B$ in their equations (5)--(7).
+The maximally mixed reference used here gives the same strong-subadditivity
+deficit and is covered by the existing singular-support evaluation of relative
+entropy. The remaining product-marginal evaluation is recorded in
+`docs/paper-gaps/hjpw04_ssa_product_marginal_reference.tex`.
+
+## Main results
+
+* `isSSAEquality_iff_maximally_mixed_reference_data_processing_eq` gives the
+  equality criterion on the full positive semidefinite unit-trace domain.
+
+## Reference
+
+Hayden, Jozsa, Petz, Winter, "Structure of states which satisfy strong
+subadditivity of quantum entropy with equality", CMP 246, 359--374 (2004),
+arXiv:quant-ph/0304007v2, p. 3, equations (5)--(7).
+-/
+
+open scoped Matrix Kronecker ComplexOrder Matrix.Norms.L2Operator
+open Matrix
+
+section SSAEqualityDPI
+
+open SSAPosDef
+
+variable {dA dB dC : ℕ}
+
+/-- **SSA equality is saturation of partial-trace data processing for the
+maximally mixed reference.** For every tripartite density matrix
+$\rho_{ABC}$, equality in strong subadditivity is equivalent to
+\[
+  D\!\left(\rho_{ABC}\,\middle\|\,
+    (\mathbf 1_A/d_A)\otimes\rho_{BC}\right)
+  =
+  D\!\left(\rho_{AB}\,\middle\|\,
+    (\mathbf 1_A/d_A)\otimes\rho_B\right).
+\]
+The second reference is the image of the first under
+$\operatorname{tr}_C$ by `SSAPosDef.traceC_ABC_kronecker_traceA_ABC`.
+
+Hayden--Jozsa--Petz--Winter use instead the exact product-marginal pair
+$\rho_A\otimes\rho_{BC}$ and $\rho_A\otimes\rho_B$. Their equation (6) gives
+the same strong-subadditivity deficit. The present theorem uses
+the maximally mixed state on $A$ because `SSAPosDef.rel_entropy_eval_support`
+supplies this singular-reference evaluation without any additional hypothesis.
+
+**Reference substitution:** This is the hypothesis-free maximally mixed-reference
+formulation, not the exact product-marginal formulation of HJPW. The missing
+product-marginal logarithm evaluation is recorded in
+`docs/paper-gaps/hjpw04_ssa_product_marginal_reference.tex`.
+
+Source: Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2, p. 3,
+equations (5)--(7) and the paragraph following equation (7). -/
+theorem isSSAEquality_iff_maximally_mixed_reference_data_processing_eq
+    (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ)
+    (hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1) :
+    IsSSAEquality ρ_ABC hρ_dm.1.isHermitian ↔
+      quantumRelativeEntropy ρ_ABC
+          (((dA : ℂ)⁻¹ • (1 : Matrix (Fin dA) (Fin dA) ℂ)) ⊗ₖ traceA_ABC ρ_ABC)
+        = quantumRelativeEntropy (traceC_ABC ρ_ABC)
+          (traceC_ABC
+            (((dA : ℂ)⁻¹ • (1 : Matrix (Fin dA) (Fin dA) ℂ))
+              ⊗ₖ traceA_ABC ρ_ABC)) := by
+  classical
+  obtain ⟨hρ, hρtr⟩ := hρ_dm
+  have hAne : NeZero dA := by
+    refine ⟨fun h ↦ ?_⟩
+    subst h
+    rw [Matrix.trace_eq_zero_of_isEmpty] at hρtr
+    exact zero_ne_one hρtr
+  have hBne : NeZero dB := by
+    refine ⟨fun h ↦ ?_⟩
+    subst h
+    rw [Matrix.trace_eq_zero_of_isEmpty] at hρtr
+    exact zero_ne_one hρtr
+  have hCne : NeZero dC := by
+    refine ⟨fun h ↦ ?_⟩
+    subst h
+    rw [Matrix.trace_eq_zero_of_isEmpty] at hρtr
+    exact zero_ne_one hρtr
+  have : Nonempty (Fin dB × Fin dC) := ⟨⟨⟨0, Nat.pos_of_ne_zero (NeZero.ne dB)⟩,
+    ⟨0, Nat.pos_of_ne_zero (NeZero.ne dC)⟩⟩⟩
+  have : Nonempty (Fin dB) := ⟨⟨0, Nat.pos_of_ne_zero (NeZero.ne dB)⟩⟩
+  have hfull := rel_entropy_eval_support (ρ := ρ_ABC) hρ hρtr (kron_marginal_support hρ)
+  set ρAB := traceC_ABC ρ_ABC with hρAB
+  have hρAB_psd : ρAB.PosSemidef := traceC_ABC_posSemidef hρ
+  have hρABtr : ρAB.trace = 1 := by
+    rw [hρAB, ← Matrix.trace_eq_trace_traceC_ABC]
+    exact hρtr
+  have himg := rel_entropy_eval_support (ρ := ρAB) hρAB_psd hρABtr
+    (kron_marginal_support hρAB_psd)
+  have hρB : traceLeftA ρAB = traceAC_ABC ρ_ABC := by
+    ext b₁ b₂
+    simp only [hρAB, traceLeftA, traceC_ABC, traceAC_ABC]
+  have hSρBC :
+      vonNeumannEntropy (traceLeftA ρ_ABC) (traceLeftA_posSemidef hρ).isHermitian
+        = vonNeumannEntropy (traceA_ABC ρ_ABC)
+          (traceA_ABC_isHermitian hρ.isHermitian) :=
+    vonNeumannEntropy_congr rfl _ _
+  have hSρB : vonNeumannEntropy (traceLeftA ρAB)
+      (traceLeftA_posSemidef hρAB_psd).isHermitian
+        = vonNeumannEntropy (traceAC_ABC ρ_ABC)
+          (traceAC_ABC_isHermitian hρ.isHermitian) :=
+    vonNeumannEntropy_congr hρB _ _
+  have hSρAB : vonNeumannEntropy ρAB hρAB_psd.isHermitian
+      = vonNeumannEntropy (traceC_ABC ρ_ABC)
+          (traceC_ABC_isHermitian hρ.isHermitian) :=
+    vonNeumannEntropy_congr hρAB _ _
+  rw [traceC_ABC_kronecker_traceA_ABC]
+  rw [← hρB]
+  change IsSSAEquality ρ_ABC hρ.isHermitian ↔
+    quantumRelativeEntropy ρ_ABC
+        (((dA : ℂ)⁻¹ • (1 : Matrix (Fin dA) (Fin dA) ℂ)) ⊗ₖ traceLeftA ρ_ABC)
+      = quantumRelativeEntropy ρAB
+        (((dA : ℂ)⁻¹ • (1 : Matrix (Fin dA) (Fin dA) ℂ)) ⊗ₖ traceLeftA ρAB)
+  simp only [hfull, himg]
+  rw [IsSSAEquality]
+  rw [hSρBC, hSρB, hSρAB]
+  constructor <;> intro h <;> linarith
+
+end SSAEqualityDPI

--- a/TNLean/Channel/Schwarz/StrongSubadditivityPosDef.lean
+++ b/TNLean/Channel/Schwarz/StrongSubadditivityPosDef.lean
@@ -43,6 +43,9 @@ maximally mixed reference state can fail to be invertible.
 * `SSAPosDef.kron_marginal_support` — the marginal support condition placing the
   singular reference state $(\mathbf 1_A / d_A) \otimes \rho_{BC}$ in the domain
   of the relative entropy.
+* `SSAPosDef.traceC_ABC_kronecker_traceA_ABC` — the partial trace over $C$
+  sends the maximally mixed reference on $A \otimes BC$ to its counterpart on
+  $A \otimes B$.
 * `strong_subadditivity_posDef` — strong subadditivity for a positive definite
   tripartite density matrix.
 * `strong_subadditivity_general` — strong subadditivity for an arbitrary
@@ -79,6 +82,9 @@ on the full density-matrix domain. The development is recorded in
 
 * Lieb, Ruskai, "Proof of the strong subadditivity of quantum-mechanical
   entropy", JMP 14, 1938 (1973) — source of strong subadditivity.
+* Hayden, Jozsa, Petz, Winter, "Structure of states which satisfy strong
+  subadditivity of quantum entropy with equality", CMP 246, 359–374 (2004),
+  arXiv:quant-ph/0304007v2, p. 3, equations (5)–(7).
 * Layer 6 (instantiation) of the relative-entropy elimination route for strong
   subadditivity, `docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`.
 * [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 8
@@ -504,6 +510,24 @@ theorem traceC_ABC_posSemidef
   rw [heq]
   exact Matrix.posSemidef_sum _ fun c _ => hblock c
 
+/-- **Partial trace of the maximally mixed reference.** For every tripartite
+matrix $\rho_{ABC}$, tracing out $C$ from
+$(\mathbf 1_A/d_A)\otimes\rho_{BC}$ gives
+$(\mathbf 1_A/d_A)\otimes\rho_B$.
+
+Source: Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2, p. 3,
+equations (6) and (7) and the paragraph following equation (7), where the
+data-processing map is $T=\operatorname{tr}_C$. -/
+theorem traceC_ABC_kronecker_traceA_ABC
+    (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ) :
+    traceC_ABC
+        (((dA : ℂ)⁻¹ • (1 : Matrix (Fin dA) (Fin dA) ℂ)) ⊗ₖ traceA_ABC ρ_ABC)
+      = ((dA : ℂ)⁻¹ • (1 : Matrix (Fin dA) (Fin dA) ℂ)) ⊗ₖ traceAC_ABC ρ_ABC := by
+  ext ab₁ ab₂
+  simp only [traceC_ABC, kroneckerMap_apply, Matrix.smul_apply, Matrix.one_apply,
+    traceA_ABC, traceAC_ABC, Finset.mul_sum]
+  conv_lhs => rw [Finset.sum_comm]
+
 /-- **Data processing for the partial trace over the third factor, support
 domain.** For positive semidefinite matrices on the tripartite index with
 $\ker\sigma \subseteq \ker\rho$, the relative entropy of the partial traces over
@@ -742,17 +766,8 @@ theorem strong_subadditivity_posDef
   -- The reference state of the image pair is the partial trace of the full one.
   have hσtrace : traceC_ABC (((dA : ℂ)⁻¹ • (1 : Matrix (Fin dA) (Fin dA) ℂ)) ⊗ₖ traceLeftA ρ_ABC)
       = ((dA : ℂ)⁻¹ • (1 : Matrix (Fin dA) (Fin dA) ℂ)) ⊗ₖ traceLeftA ρAB := by
-    have hkron : traceC_ABC
-        (((dA : ℂ)⁻¹ • (1 : Matrix (Fin dA) (Fin dA) ℂ)) ⊗ₖ traceLeftA ρ_ABC)
-        = ((dA : ℂ)⁻¹ • (1 : Matrix (Fin dA) (Fin dA) ℂ))
-          ⊗ₖ partialTraceRight (traceLeftA ρ_ABC) := by
-      ext ab₁ ab₂
-      simp only [traceC_ABC, kroneckerMap_apply, partialTraceRight_apply, Finset.mul_sum]
-    rw [hkron]
-    congr 1
-    ext b₁ b₂
-    simp only [partialTraceRight_apply, traceLeftA, hρAB, traceC_ABC]
-    rw [Finset.sum_comm]
+    rw [← hρB_eq]
+    exact traceC_ABC_kronecker_traceA_ABC ρ_ABC
   set σfull : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ :=
     ((dA : ℂ)⁻¹ • (1 : Matrix (Fin dA) (Fin dA) ℂ)) ⊗ₖ traceLeftA ρ_ABC with hσfull
   have hσfull_pd : σfull.PosDef := by
@@ -844,16 +859,8 @@ theorem strong_subadditivity_general
   -- The reference state of the image pair is the partial trace of the full one.
   have hσtrace : traceC_ABC (((dA : ℂ)⁻¹ • (1 : Matrix (Fin dA) (Fin dA) ℂ)) ⊗ₖ traceLeftA ρ_ABC)
       = ((dA : ℂ)⁻¹ • (1 : Matrix (Fin dA) (Fin dA) ℂ)) ⊗ₖ traceLeftA ρAB := by
-    have hkron : traceC_ABC
-        (((dA : ℂ)⁻¹ • (1 : Matrix (Fin dA) (Fin dA) ℂ)) ⊗ₖ traceLeftA ρ_ABC)
-        = ((dA : ℂ)⁻¹ • (1 : Matrix (Fin dA) (Fin dA) ℂ))
-          ⊗ₖ partialTraceRight (traceLeftA ρ_ABC) := by
-      ext ab₁ ab₂
-      simp only [traceC_ABC, kroneckerMap_apply, partialTraceRight_apply, Finset.mul_sum]
-    rw [hkron]; congr 1
-    ext b₁ b₂
-    simp only [partialTraceRight_apply, traceLeftA, hρAB, traceC_ABC]
-    rw [Finset.sum_comm]
+    rw [← hρB_eq]
+    exact traceC_ABC_kronecker_traceA_ABC ρ_ABC
   set σfull : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ :=
     ((dA : ℂ)⁻¹ • (1 : Matrix (Fin dA) (Fin dA) ℂ)) ⊗ₖ traceLeftA ρ_ABC with hσfull
   have hσA_pd : ((dA : ℂ)⁻¹ • (1 : Matrix (Fin dA) (Fin dA) ℂ)).PosDef := by

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -1607,6 +1607,23 @@ Theorem~\ref{thm:trace_norm_abs}.
     of $P$. Hence $\rho v = 0$.
 \end{proof}
 
+\begin{lemma}[Partial trace of the maximally mixed reference]
+    \label{lem:traceC_maximally_mixed_reference}
+    \lean{SSAPosDef.traceC_ABC_kronecker_traceA_ABC}
+    \leanok
+    \uses{def:traceA_ABC, def:traceC_ABC, def:traceAC_ABC}
+    For every tripartite matrix $\rho_{ABC}$,
+    \[
+        \tr_C\!\left(\frac{\mathbf 1_A}{d_A}\otimes\rho_{BC}\right)
+        =\frac{\mathbf 1_A}{d_A}\otimes\rho_B.
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    Expand both partial traces entry by entry. The two sides differ only in the
+    order of the finite sums over the $A$ and $C$ indices.
+\end{proof}
+
 \begin{theorem}[Strong subadditivity]\label{thm:strong_subadditivity}
     \lean{strong_subadditivity_general}
     \leanok
@@ -1712,6 +1729,50 @@ Theorem~\ref{thm:trace_norm_abs}.
         S(\rho_{ABC}) + S(\rho_B) = S(\rho_{AB}) + S(\rho_{BC}).
     \]
 \end{definition}
+
+\begin{theorem}[SSA equality as saturation for a maximally mixed reference]
+    \label{thm:ssa_equality_maximally_mixed_reference_dpi}
+    \lean{isSSAEquality_iff_maximally_mixed_reference_data_processing_eq}
+    \leanok
+    \uses{def:ssa_equality, def:quantum_relative_entropy,
+        def:traceA_ABC, def:traceC_ABC, def:traceAC_ABC,
+        lem:traceC_maximally_mixed_reference}
+    Let $\rho_{ABC}$ be a tripartite density matrix and set
+    \[
+        \sigma_{ABC}=\frac{\mathbf 1_A}{d_A}\otimes\rho_{BC}.
+    \]
+    Then equality holds in strong subadditivity if and only if relative-entropy
+    data processing under the partial trace over $C$ is saturated for this pair:
+    \[
+        D(\rho_{ABC}\,\|\,\sigma_{ABC})
+        =D(\tr_C\rho_{ABC}\,\|\,\tr_C\sigma_{ABC}).
+    \]
+    By Lemma~\ref{lem:traceC_maximally_mixed_reference}, the reference on the
+    right is $(\mathbf 1_A/d_A)\otimes\rho_B$.
+
+    This gives the same hypothesis-free equality criterion as the
+    product-marginal formulation in equations~(6) and~(7) of
+    \cite{Hayden2004Structure}. It is not their exact reference pair: they use
+    $\rho_A\otimes\rho_{BC}$ and $\rho_A\otimes\rho_B$. The exact
+    product-marginal identity is not asserted by this theorem.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:rel_entropy_eval_support, lem:kron_marginal_support,
+        lem:traceC_maximally_mixed_reference}
+    The two relative entropies are
+    \[
+        \log d_A+S(\rho_{BC})-S(\rho_{ABC})
+        \quad\text{and}\quad
+        \log d_A+S(\rho_B)-S(\rho_{AB}),
+    \]
+    respectively. The marginal support lemma places both singular references
+    in the relative-entropy domain. Cancelling the common $\log d_A$ shows that
+    equality of the two relative entropies is precisely
+    \[
+        S(\rho_{ABC})+S(\rho_B)=S(\rho_{AB})+S(\rho_{BC}).
+    \]
+\end{proof}
 
 \begin{theorem}[SSA equality under factor relabeling]
     \label{thm:ssa_equality_reindex_factors}

--- a/docs/paper-gaps/hjpw04_ssa_product_marginal_reference.tex
+++ b/docs/paper-gaps/hjpw04_ssa_product_marginal_reference.tex
@@ -1,0 +1,128 @@
+\documentclass[11pt]{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{./command}
+
+\title{The Product-Marginal Reference in the Relative-Entropy Form of
+Strong Subadditivity}
+\author{}
+\date{2026-07-18}
+
+\begin{document}
+\maketitle
+
+\section{The source identity}
+
+Hayden, Jozsa, Petz, and Winter write the conditional mutual information as
+the difference
+\begin{align}
+  &D(\rho_{ABC}\,\|\,\rho_A\otimes\rho_{BC})
+    -D(\rho_{AB}\,\|\,\rho_A\otimes\rho_B) \notag\\
+  &\qquad=S(\rho_{AB})+S(\rho_{BC})-S(\rho_{ABC})-S(\rho_B).
+  \label{eq:hjpw-difference}
+\end{align}
+Here the second pair is the image of the first under
+$T=\operatorname{tr}_C$.  Consequently, equality in strong subadditivity is
+equivalent to equality in relative-entropy data processing for this pair.  This
+is equation~(6) and the paragraph following equation~(7) on page~3 of
+arXiv:quant-ph/0304007v2.
+
+The statement has no strict-positivity assumption.  If one of the marginals is
+singular, the relative entropy is interpreted on its support.  The support of a
+bipartite state is contained in the tensor product of the supports of its two
+marginals, so both relative entropies in~\eqref{eq:hjpw-difference} are finite.
+
+\section{The theorem presently proved}
+
+The current relative-entropy theory proves the corresponding identity with a
+maximally mixed state on $A$:
+\begin{align}
+  &D\!\left(\rho_{ABC}\,\middle\|\,
+    \frac{\mathbf 1_A}{d_A}\otimes\rho_{BC}\right)
+    -D\!\left(\rho_{AB}\,\middle\|\,
+    \frac{\mathbf 1_A}{d_A}\otimes\rho_B\right) \notag\\
+  &\qquad=S(\rho_{AB})+S(\rho_{BC})-S(\rho_{ABC})-S(\rho_B).
+  \label{eq:mixed-difference}
+\end{align}
+Indeed, each relative entropy is respectively
+$\log d_A+S(\rho_{BC})-S(\rho_{ABC})$ and
+$\log d_A+S(\rho_B)-S(\rho_{AB})$.  The common logarithm cancels.  Thus
+\eqref{eq:mixed-difference} gives the same equality criterion as
+\eqref{eq:hjpw-difference}, without adding a hypothesis to the state.
+
+This is formalized by the maximally mixed-reference equality theorem.
+\footnote{Formal declaration:
+\leanid{isSSAEquality_iff_maximally_mixed_reference_data_processing_eq} in
+\path{TNLean/Channel/Schwarz/SSAEqualityDPI.lean}.}
+The partial-trace identity verifies that the reference on $A\otimes B$ is the
+image of the reference on $A\otimes B\otimes C$.
+\footnote{Formal declaration:
+\leanid{SSAPosDef.traceC_ABC_kronecker_traceA_ABC} in
+\path{TNLean/Channel/Schwarz/StrongSubadditivityPosDef.lean}.}
+
+This theorem is not marked as the exact Hayden--Jozsa--Petz--Winter
+formulation.  It is a hypothesis-free equivalent formulation with a different
+reference state.
+
+\section{The remaining product-marginal step}
+
+The relative entropy in the development is the total trace-log expression
+\begin{align}
+  D(\rho\,\|\,\sigma)
+  =\operatorname{Re}\operatorname{tr}
+    \bigl(\rho(\log\rho-\log\sigma)\bigr).
+\end{align}
+For positive definite tensor factors the logarithm of a tensor product splits.
+For singular tensor factors this split is not presently available.  The
+existing support-domain evaluation
+\leanid{SSAPosDef.rel_entropy_eval_support} treats the special reference
+$(\mathbf 1_A/d_A)\otimes\rho_R$ by a one-sided regularization of
+$\rho_R$.  It does not evaluate the general singular product
+$\rho_A\otimes\rho_R$.
+
+The missing source-facing lemma is the hypothesis-free bipartite identity
+\begin{align}
+  D(\omega_{XY}\,\|\,\omega_X\otimes\omega_Y)
+  =S(\omega_X)+S(\omega_Y)-S(\omega_{XY})
+  \label{eq:product-marginal-evaluation}
+\end{align}
+for every positive semidefinite unit-trace $\omega_{XY}$.  Its proof must first
+place $\omega_{XY}$ in the support of $\omega_X\otimes\omega_Y$, and then
+justify the two-factor logarithm evaluation on that singular support.  A
+simultaneous positive-definite regularization of both marginals is one direct
+route.  The existing marginal-support theorem supplies the operator-theoretic
+starting point, but not the logarithm limit for the product.
+
+Once~\eqref{eq:product-marginal-evaluation} is established, apply it to the
+bipartitions $A\,|\,BC$ and $A\,|\,B$.  The resulting two evaluations prove
+\eqref{eq:hjpw-difference}; the biconditional with equality in data processing
+then follows by elementary rearrangement.  No recovery map or Petz equality
+theorem is needed for this step.
+
+\section{Verdict}
+
+Equality in strong subadditivity has been identified with saturation of
+partial-trace data processing for a maximally mixed reference, on the full
+density-matrix domain.  The exact product-marginal formulation of
+Hayden--Jozsa--Petz--Winter remains open only at the singular
+product-marginal evaluation~\eqref{eq:product-marginal-evaluation}.  Until that
+lemma is proved, the maximally mixed-reference theorem must remain a separate
+equivalent formulation rather than being presented as the source theorem
+itself.
+
+\begin{thebibliography}{9}
+
+\bibitem{HJPW2004}
+  P.~Hayden, R.~Jozsa, D.~Petz, and A.~Winter,
+  \emph{Structure of states which satisfy strong subadditivity of quantum
+  entropy with equality},
+  Communications in Mathematical Physics \textbf{246} (2004), 359--374;
+  arXiv:quant-ph/0304007v2.
+
+\end{thebibliography}
+
+\end{document}


### PR DESCRIPTION
## Summary

- prove that partial trace over (C) sends ((\mathbf 1_A/d_A)\otimes\rho_{BC}) to ((\mathbf 1_A/d_A)\otimes\rho_B);
- prove, for every positive-semidefinite unit-trace tripartite state, that equality in strong subadditivity is equivalent to equality in relative-entropy data processing for this reference pair;
- add the corresponding blueprint theorem and a source-facing paper-gap note isolating the remaining singular product-marginal logarithm evaluation.

## Source faithfulness

Hayden--Jozsa--Petz--Winter use the exact pair
\[
  \rho_A\otimes\rho_{BC},\qquad \rho_A\otimes\rho_B
\]
in equations (4)--(7) on page 3 of arXiv:quant-ph/0304007v2. The theorem in this pull request deliberately uses the maximally mixed state on (A), as in the existing full-domain proof of strong subadditivity. Both relative-entropy differences equal the same conditional mutual information, so this gives the same equality criterion without adding any hypothesis to the state.

The theorem is not presented as the exact HJPW product-marginal statement. The paper-gap note records that the exact statement still requires a two-factor logarithm evaluation on singular marginal supports. This pull request does not prove Petz's equality theorem, construct a recovery map, or discharge the later Hayashi characterization.

## Validation

- `lake env lean TNLean/Channel/Schwarz/SSAEqualityDPI.lean`
- `lake build TNLean` (9555 jobs)
- `leanblueprint web`
- `leanblueprint checkdecls`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- proof-integrity scan of the touched Lean file
- `#print axioms` audit: only `propext`, `Classical.choice`, and `Quot.sound`
- standalone compilation of `docs/paper-gaps/hjpw04_ssa_product_marginal_reference.tex`

Closes #4177.

The exact product-marginal, Petz-recovery, and Hayashi-characterization program remains open. Parent issues #784, #239, and #232 remain open.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds formal proofs and documentation in the Schwarz/entropy layer with no runtime, auth, or data-path changes; main caveat is mathematical scope (maximally mixed reference vs. exact HJPW product-marginal statement), which is explicitly documented.
> 
> **Overview**
> Formalizes the link between **equality in strong subadditivity (SSA)** and **saturation of relative-entropy data processing** under partial trace over \(C\), using the reference \(\sigma_{ABC} = (\mathbf 1_A/d_A)\otimes\rho_{BC}\) (not HJPW’s exact \(\rho_A\otimes\rho_{BC}\) pair).
> 
> Adds `SSAPosDef.traceC_ABC_kronecker_traceA_ABC` showing \(\mathrm{tr}_C\) maps that reference to \((\mathbf 1_A/d_A)\otimes\rho_B\), and refactors existing SSA proofs to call it instead of duplicating entry-wise sums. New `isSSAEquality_iff_maximally_mixed_reference_data_processing_eq` in `SSAEqualityDPI.lean` proves, for every PSD unit-trace tripartite state, SSA equality iff the two relative entropies (full vs. \(\mathrm{tr}_C\) image) agree, via `rel_entropy_eval_support` and entropy rewrites.
> 
> Blueprint chapter 19 gets the matching lemma/theorem; `docs/paper-gaps/hjpw04_ssa_product_marginal_reference.tex` records that the maximally mixed form is hypothesis-free and equivalent for the equality criterion, while singular **product-marginal** \(D(\rho\,\|\,\rho_A\otimes\rho_R)\) evaluation remains open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25e9afc52a09418c79e93df4fd53fe0fbfd571e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

