### PR TITLE
feat(MPS/MPDO): isolate fixed-product spanning endpoint

### DIFF
--- a/TNLean/MPS/MPDO/VerticalSectorGeneration.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorGeneration.lean
@@ -191,6 +191,34 @@ theorem weightedVerticalBondContractionProductSpanTop_of_wordTupleSpanTop
   refine ⟨fun t => Matrix.single (w t).modNat (w t).divNat 1, ?_⟩
   exact weightedVerticalBondContractionProduct_single m A w
 
+/-- If the length-`L` products of weighted vertical bond contractions span the
+sector algebra, then a linear endomorphism fixing every such product is the
+identity.
+
+This isolates the final linear-spanning implication in the inverse-map argument.
+It does not prove that fixed weighted contractions have fixed products.
+
+**Scope restriction (fixed products):** Appendix C.4 does not assume that the
+products are fixed.  It obtains the stronger identity conclusion from Wolf's
+density-weighted fixed-point theorem.  Here fixedness of the products is an
+explicit hypothesis.  The missing fixed-point argument is recorded in
+`docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex`.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1980--1993. -/
+theorem eq_id_of_weightedVerticalBondContractionProducts_fixed
+    {g D L : ℕ} {dim : Fin g → ℕ}
+    (m : Fin g → ℂ)
+    (A : (α : Fin g) → MPSTensor (D * D) (dim α))
+    (F : VerticalSectorAlgebra dim →ₗ[ℂ] VerticalSectorAlgebra dim)
+    (hSpan : WeightedVerticalBondContractionProductSpanTop m A L)
+    (hFixed : ∀ X : Fin L → Matrix (Fin D) (Fin D) ℂ,
+      F (weightedVerticalBondContractionProduct m A X) =
+        weightedVerticalBondContractionProduct m A X) :
+    F = LinearMap.id := by
+  apply LinearMap.ext_on_range hSpan
+  intro X
+  simpa using hFixed X
+
 /-- A CPSV basis of normal tensors, with nonzero sector weights, admits one
 positive length at which the weighted vertical bond contractions generate the
 full direct product of its matrix algebras.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -433,6 +433,36 @@ physical indices, as in
     $c_\alpha=m_\alpha=\operatorname{tr}(\mu_\alpha)$.
 \end{proof}
 
+\begin{theorem}[Fixed spanning contraction products determine an endomorphism]
+    \label{thm:mpdo_fixed_spanning_vertical_contraction_products}
+    \lean{MPOTensor.eq_id_of_weightedVerticalBondContractionProducts_fixed}
+    \leanok
+    \uses{def:mpdo_weighted_vertical_contraction_products}
+    Let $F$ be a linear endomorphism of
+    $\prod_\alpha M_{d_\alpha}$.  Suppose that $C_L(V_c)$ is the whole
+    sector algebra and, for every choice of bond matrices
+    $X_1,\ldots,X_L$,
+    \[
+        F\bigl(V_c(X_1)\cdots V_c(X_L)\bigr)
+          =V_c(X_1)\cdots V_c(X_L).
+    \]
+    Then $F$ is the identity.
+\end{theorem}
+
+\begin{proof}\leanok
+    Since the displayed products span the domain, every
+    $Y\in\prod_\alpha M_{d_\alpha}$ has the form
+    $Y=\sum_i\lambda_iV_c(X_1^{(i)})\cdots V_c(X_L^{(i)})$.  Hence
+    \[
+      F(Y)
+        =\sum_i\lambda_i
+          F\!\left(V_c(X_1^{(i)})\cdots V_c(X_L^{(i)})\right)
+        =\sum_i\lambda_i V_c(X_1^{(i)})\cdots V_c(X_L^{(i)})
+        =Y.
+    \]
+    Thus $F$ is the identity.
+\end{proof}
+
 \begin{definition}[Retained coordinates for the vertical-sector algebra]
     \label{def:mpdo_retained_vertical_sector_coordinates}
     \lean{MPOTensor.verticalSectorFinEquiv}

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -38,6 +38,11 @@ unless they are cited by one of the current blueprint chapters above.
 
 For MPDO renormalization fixed points:
 
+- `cpsv16_vertical_sector_invertibility.tex` separates the proved fixed
+  contraction families and product-generation theorem from the missing
+  density-weighted fixed-point argument in Appendix C.4. It also records that
+  sector relabelling follows from mutually inverse positive trace-preserving
+  maps, not from a bare linear equivalence.
 - `cpsv16_simple_tensor_nilpotency.tex` identifies the source's nilpotent BNT
   elements with nilpotent physical-trace transfer matrices and records the
   positive physical blocking and chosen-BNT interpretation of the

--- a/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
+++ b/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
@@ -1,0 +1,167 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{./command}
+
+\title{CPSV16 Vertical-Sector Invertibility and Sector Relabelling}
+\author{}
+\date{2026-07-18}
+
+\begin{document}
+\maketitle
+
+\section{The source argument}
+
+In the proof of the general mixed-state renormalization fixed-point theorem,
+CPSV16 introduces the finite-dimensional $C^*$-algebras
+\[
+    \mathcal A_1=\bigoplus_\alpha M_{d^1_\alpha}(\mathbb C),
+    \qquad
+    \mathcal A_2=\bigoplus_\beta M_{d^2_\beta}(\mathbb C)
+\]
+and the transported maps
+\[
+    \widetilde T=\widetilde R_2TR_1,
+    \qquad
+    \widetilde S=\widetilde R_1SR_2.
+\]
+For every horizontal bond matrix $X$, the source proves
+\[
+    \widetilde T\!\left(\bigoplus_\alpha
+      m_\alpha M_\alpha(X)\right)
+      =\bigoplus_\beta n_\beta A_\beta(X),
+    \qquad
+    \widetilde S\!\left(\bigoplus_\beta
+      n_\beta A_\beta(X)\right)
+      =\bigoplus_\alpha m_\alpha M_\alpha(X).
+\]
+Thus the one-site contraction family belongs to
+$\operatorname{Fix}(\widetilde S\widetilde T)$, and the two-site family
+belongs to $\operatorname{Fix}(\widetilde T\widetilde S)$
+\cite[Appendix~C.4, lines~1972--1980]{Cirac2016MPDO_arXiv}.
+
+The next step is not a linear-spanning argument.  CPSV16 invokes the
+density-weighted fixed-point form of Wolf's Theorem~6.14 and writes
+\[
+    \mathcal F
+      =U\left(0_r\oplus\bigoplus_k
+        \rho_k\otimes M_{h_k}(\mathbb C)\right)U^*.
+\]
+If $C_L(V)$ denotes the span of length-$L$ products of the contraction
+family, then the basis-of-normal-tensors hypothesis gives
+$C_L(V)=\mathcal A_1$ for some $L>0$.  On the other hand,
+\[
+    C_L(\mathcal F)
+      =U\left(0_r\oplus\bigoplus_k
+        \rho_k^L\otimes M_{h_k}(\mathbb C)\right)U^*.
+\]
+Every $\rho_k$ is positive definite, so
+$\dim C_L(\mathcal F)=\dim\mathcal F$.  The inclusions
+\[
+    \mathcal A_1=C_L(V)\subseteq C_L(\mathcal F)\subseteq\mathcal A_1
+\]
+therefore force $\mathcal F=\mathcal A_1$.  This proves
+$\widetilde S\widetilde T=\operatorname{id}_{\mathcal A_1}$; the other
+composition is treated symmetrically
+\cite[Appendix~C.4, lines~1980--1995]{Cirac2016MPDO_arXiv}.
+
+\section{The present formal boundary}
+
+Three ingredients preceding the fixed-point classification are proved:
+\begin{enumerate}
+    \item the two transported composites fix their respective weighted bond
+          contraction families;
+    \item for a basis of normal tensors with nonzero weights, length-$L$
+          products of these contractions span the full sector algebra for
+          some $L>0$;
+    \item on the source-generated contraction families, the final compression
+          preserves the active image and hence preserves total trace.
+\end{enumerate}
+The third item does not establish trace preservation on the whole sector
+algebra.  The contraction family itself need not span the algebra linearly;
+only its length-$L$ products are known to span.  Since a linear map fixing
+$V(X)$ need not fix products $V(X_1)\cdots V(X_L)$, neither trace preservation
+nor the identity conclusion extends from the generators by linearity.
+
+The valid final implication is formalized: if a linear endomorphism fixes
+every length-$L$ contraction product and these products span, then it is the
+identity.\footnote{Formal declaration:
+\leanid{MPOTensor.eq_id_of_weightedVerticalBondContractionProducts_fixed}.}
+Its fixed-product hypothesis is not a hypothesis of CPSV16.  The source
+instead obtains the identity from the density-weighted structure of the
+fixed-point space.
+
+The general density-weighted form of Wolf's Theorem~6.14 in the
+Schr\"odinger picture is not yet formalized.  Its precise boundary is recorded in
+\path{docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex}.  For
+the transported sector maps one must also prove the channel hypotheses on the
+full direct sums, rather than only on the contraction families.  In the
+retained-coordinate construction, compression by the target coisometry is
+trace preserving precisely when the precompression output lies in its active
+image.  The established image identity is restricted to the source-generated
+contractions.
+
+\section{Sector relabelling uses positivity, not linear isomorphism}
+
+After proving mutual invertibility, CPSV16 cites the argument of
+Wolf--P\'erez-Garc\'ia, Theorem~8
+\cite[Appendix~C.4, lines~1995--2003]{Cirac2016MPDO_arXiv}.  The cited theorem
+concerns a trace-preserving Schwarz map.  Its proof constructs a positive,
+trace-preserving inverse on the peripheral space and uses the extreme points
+of the density-operator sections
+\[
+    \bigoplus_k M_{d_k}(\mathbb C)\otimes\rho_k.
+\]
+The map and its positive inverse send extreme density operators to extreme
+density operators.  Continuity and bijectivity then give a permutation of the
+simple summands and equality of the corresponding matrix dimensions.  On each
+matched summand, positivity of both directions gives either unitary
+conjugation or transposed unitary conjugation; the Schwarz condition excludes
+the transpose alternative
+\cite[Theorem~8 and its proof]{WolfPerezGarcia2010Inverse}.
+
+A linear equivalence between two finite products of matrix spaces does not
+determine their simple summands.  Likewise, the existing theorem that ring
+automorphisms permute simple block ideals cannot be applied until
+multiplicativity has been derived.  The sector relabelling therefore requires
+one of the following source-faithful routes:
+\begin{enumerate}
+    \item formalize the positive order-isomorphism argument on the normalized
+          density-operator sections and then exclude transposition by the
+          Schwarz inequality; or
+    \item prove that mutually inverse completely positive maps between the
+          direct sums are $*$-isomorphisms, and apply uniqueness of the simple
+          summands.
+\end{enumerate}
+
+\section{Elimination plan}
+
+The unrestricted CPSV16 conclusion should be completed in the following
+order:
+\begin{enumerate}
+    \item prove complete positivity and trace preservation of the transported
+          maps on the full sector algebras, including the required active-image
+          statement for every input;
+    \item formalize the density-weighted fixed-point theorem needed for
+          $\widetilde S\widetilde T$ and $\widetilde T\widetilde S$;
+    \item combine the fixed-point form with the already proved product
+          generation theorem to obtain both identity compositions;
+    \item derive the permutation and matching dimensions from the resulting
+          positive, trace-preserving inverse pair, retaining the Schwarz
+          hypothesis for the unitary-conjugation conclusion.
+\end{enumerate}
+
+\section{Classification}
+
+\textbf{Verdict: open gap.}  Until these steps are proved, neither
+transported-map invertibility nor sector relabelling should carry a completion
+marker in the blueprint.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/references.bib
+++ b/docs/paper-gaps/references.bib
@@ -117,6 +117,15 @@
   eprinttype   = {arxiv},
 }
 
+@unpublished{WolfPerezGarcia2010Inverse,
+  author       = {Wolf, Michael M. and P{\'e}rez-Garc{\'i}a, David},
+  title        = {The Inverse Eigenvalue Problem for Quantum Channels},
+  year         = {2010},
+  eprint       = {1005.4545},
+  eprinttype   = {arxiv},
+  note         = {Preprint},
+}
+
 @article{Fannes1992Finitely,
   author       = {Fannes, Mark and Nachtergaele, Bruno and Werner, Reinhard F.},
   title        = {Finitely Correlated States on Quantum Spin Chains},


### PR DESCRIPTION
## Summary

- prove that a linear endomorphism is the identity when it fixes a spanning family of weighted vertical contraction products
- record why fixed one-site contractions and product generation do not by themselves imply that the products are fixed
- audit the actual CPSV16 route through Wolf Theorem 6.14 and the positive trace-preserving inverse argument for sector relabelling
- add a source-faithful blueprint endpoint and an explicit elimination plan

This documents progress on #4120 but does not close it. The missing work is the density-weighted fixed-point theorem on the full transported sector algebras, followed by the positive order-isomorphism argument.

## Validation

- direct Lean check of `TNLean/MPS/MPDO/VerticalSectorGeneration.lean`
- full target build and blueprint synchronization checks
- `leanblueprint checkdecls`
- reader-facing prose and diff checks
- standalone compilation of `docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex`
- axiom audit: only `propext`, `Classical.choice`, and `Quot.sound`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a small, standard linear-algebra lemma; no changes to auth, runtime behavior, or existing proof obligations beyond clarifying an open formalization gap.
> 
> **Overview**
> Adds **`MPOTensor.eq_id_of_weightedVerticalBondContractionProducts_fixed`**: if length-`L` weighted vertical bond contraction products span the sector algebra and a linear endomorphism fixes every such product, it must be the identity (`LinearMap.ext_on_range`). The Lean doc stresses this is **not** CPSV16’s route—Appendix C.4 gets invertibility from Wolf’s density-weighted fixed-point theorem, not from assuming fixed products.
> 
> The blueprint chapter gains the matching theorem **Fixed spanning contraction products determine an endomorphism** (`thm:mpdo_fixed_spanning_vertical_contraction_products`).
> 
> New **`docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex`** (indexed in the paper-gaps README) separates what is already proved (fixed contraction families, product generation, trace on source-generated inputs) from open work: full CPTP on transported maps, Wolf Theorem 6.14, and **sector relabelling via positive trace-preserving inverses** (Wolf–Pérez-García), not bare linear equivalence. Adds **`WolfPerezGarcia2010Inverse`** to `references.bib`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e16eecf119b2680a7290f209b6230ec8cb65889. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->