### PR TITLE
doc(mpdo): mark SAL-ZCL rank-one scope

### DIFF
--- a/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
+++ b/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
@@ -106,10 +106,11 @@ hypotheses and the PSD-corrected Lemma C.5 rank-one criterion.
 Source: arXiv:1606.00608, Appendix C.2, Lemmas C.4 and C.5 and the corollary
 after them, lines 1406--1505.
 
-**Local fix (PSD rank-one criterion):** the source's primitive
-nonnegative-matrix inference at lines 1490--1498 is not valid as stated. This
+**Scope restriction (positive-semidefinite trace matrix):** the source neither
+assumes nor derives positive semidefiniteness of the trace matrix. This
 constructor uses the positive-semidefinite sufficient condition documented in
-`docs/paper-gaps/cpgsv17_pf_rank_one.tex`. -/
+`docs/paper-gaps/cpgsv17_pf_rank_one.tex`; it is not the corollary from the
+source hypotheses of SAL and ZCL alone. -/
 def ofSALZCLOfPosSemidef
     {dA dB dC n : ℕ}
     (rhoABC : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ)

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels.tex
@@ -980,6 +980,12 @@ $\widehat{\cal K}$.
 % (iii) implies (v), but the theorem statement and the local structure used
 % here give (iv) implies (v). Documented in
 % docs/paper-gaps/cpgsv17_mpdo_theorem_4_9_implication_label.tex.
+% **Scope restriction (SAL and ZCL):** the theorem starts from a neighboring
+% trace factorization, including the rank-one identity
+% tr(eta_{k,h}) = a_k b_h. It proves the conditional implication (iv) => (v),
+% not Proposition prop2to5 from SAL and ZCL alone. The missing rank-one step is
+% documented in docs/paper-gaps/cpgsv17_pf_rank_one.tex and tracked in issue
+% #3593.
 \begin{theorem}[Two-site blocking of the original tensor is a renormalization fixed point]
     \label{thm:mpdo_blocked_original_tensor_is_rfp_via_ts}
     \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.blockTwo_isRFPViaTS}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -20,6 +20,12 @@
     \]
 \end{definition}
 
+% **Scope restriction (rank-one trace matrix):** the two constructors below
+% require respectively positive semidefiniteness or linear independence, neither
+% of which is supplied by the source hypotheses of SAL and ZCL. Thus this entry
+% does not formalize Lemma SALZCL, its structural corollary, or Proposition
+% prop2to3 from those hypotheses alone. Documented in
+% docs/paper-gaps/cpgsv17_pf_rank_one.tex; tracked in issue #3593.
 \begin{theorem}[Local simple-MPDO structure from corrected rank-one criteria]
     \label{thm:simple_mpdo_local_structure_data_of_sal_zcl}
     \lean{MPOTensor.SimpleMPDOLocalStructureData.ofSALZCLOfPairingIdempotent}


### PR DESCRIPTION
## Summary

- classify the positive-semidefinite local-structure constructor as a scope-restricted theorem rather than a local correction
- record that the corrected capstone does not prove `SALZCL`, its structural corollary, or `prop2to3` from SAL and ZCL alone
- distinguish the faithful conditional channel construction `(iv) → (v)` from the unproved direct implication `prop2to5`

No Lean statement, proof, or blueprint `\\leanok` status changes. The conditional channel construction remains fully proved; the unresolved implication is the derivation of its rank-one neighboring-trace hypothesis from SAL and source ZCL.

Closes #4188.
Advances #3593.

## Validation

- `lake env lean TNLean/MPS/MPDO/BlockedRFPConstruction.lean`
- `lake build` (9,554 jobs)
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls --ci`
- `leanblueprint checkdecls`
- `git diff --check`
- changed-file proof-integrity scan

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and blueprint prose only; no executable or proof changes.
> 
> **Overview**
> **Documentation-only:** reframes several MPDO rank-one and blocking entries as **scope restrictions**, not “local fixes,” and states explicitly what is **not** derived from SAL and ZCL alone. No Lean statements, proofs, or `\leanok` flags change.
> 
> In `BlockedRFPConstruction.lean`, the `ofSALZCLOfPosSemidef` docstring now says the Cirac et al. source does not assume PSD of the trace matrix, so that constructor is a **PSD-assisted sufficient condition** (`docs/paper-gaps/cpgsv17_pf_rank_one.tex`), not the paper’s corollary from SAL+ZCL only.
> 
> The blueprint capstone (`ch21_mpdo_rfp_simple_local_structure_capstone.tex`) notes that the two local-structure constructors need **extra hypotheses** (PSD or linear independence), so the entry does **not** formalize Lemma SALZCL, its structural corollary, or `prop2to3` from SAL+ZCL alone (issue #3593).
> 
> The blocked-RFP channel chapter (`ch21_mpdo_rfp_simple_local_refinement_channels.tex`) clarifies that two-site blocking proves the **conditional** Theorem 4.9 implication **(iv) ⇒ (v)** from a neighboring trace factorization including `tr(η_{k,h}) = a_k b_h`, not **`prop2to5`** from SAL+ZCL without that rank-one step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8eebd21bb2c87268fb180333669522159bf5bf2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->