### PR TITLE
feat(MPS/MPDO): formalize active-sector spanning obstruction

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -514,6 +514,7 @@ import TNLean.MPS.MPDO.PhysicalSectorEtaLocalStructure
 import TNLean.MPS.MPDO.PhysicalSectorPhysicalTransport
 import TNLean.MPS.MPDO.SectorPairingTransfer
 import TNLean.MPS.MPDO.InverseMapActiveSectorZCL
+import TNLean.MPS.MPDO.ActiveSectorSpanningCounterexample
 import TNLean.MPS.MPDO.SectorEtaContraction
 import TNLean.MPS.MPDO.SectorEtaOperator
 import TNLean.MPS.MPDO.SectorEtaPositivity

--- a/TNLean/MPS/MPDO/ActiveSectorSpanningCounterexample.lean
+++ b/TNLean/MPS/MPDO/ActiveSectorSpanningCounterexample.lean
@@ -1,0 +1,357 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.InverseMapActiveSectorZCL
+
+/-!
+# Virtual spanning does not remove the active-sector nilpotent remainder
+
+This file gives a four-sector, bond-dimension-two tensor for which the virtual
+matrices of the physical sectors span the full matrix algebra, the
+physical-trace transfer is idempotent, and every neighboring operator is
+positive semidefinite.  The active sector trace matrix is primitive, but it is not
+idempotent.  In the rectangular notation of Appendix C.2 of
+arXiv:1606.00608, the tensor therefore satisfies
+\[
+  S=LQ,\qquad S^2=S,
+\]
+while
+\[
+  Q(1-S)L=T-T^2\ne0,\qquad T=QL.
+\]
+
+Thus spanning by the full virtual matrix algebra does not, by itself, prove
+the missing vanishing in the proof of Lemma C.5.  This does not disprove the
+strong-area-law statement: the example isolates the concrete algebraic inputs
+used after the physical-sector factorization, but no strong-area-law witness
+is asserted.
+
+## Main result
+
+* `virtual_spanning_does_not_force_rectangular_remainder_zero`: the combined
+  counterexample to the proposed rectangular-vanishing argument.
+
+## Reference
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, lines 1406--1499
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+namespace MPOTensor.ActiveSectorSpanningCounterexample
+
+/-- The closed left-sector vectors. -/
+noncomputable def leftPairing : Matrix (Fin 2) (Fin 4) ℂ :=
+  !![1 / 4, 1 / 4, 1 / 4, 1 / 4;
+     1, -1, 1, -1]
+
+/-- The closed right-sector functionals. -/
+noncomputable def rightPairing : Matrix (Fin 4) (Fin 2) ℂ :=
+  !![1, 1 / 8;
+     1, 1 / 8;
+     1, -1 / 8;
+     1, -1 / 8]
+
+/-- The virtual matrix belonging to a scalar physical sector. -/
+noncomputable def sectorMatrix (k : Fin 4) : Matrix (Fin 2) (Fin 2) ℂ :=
+  Matrix.vecMulVec (fun beta => leftPairing beta k) (fun alpha => rightPairing k alpha)
+
+/-- The tensor whose four diagonal physical entries are the sector matrices. -/
+noncomputable def tensor : MPOTensor 4 2 :=
+  fun i j => if i = j then sectorMatrix i else 0
+
+lemma leftPairing_mul_rightPairing : leftPairing * rightPairing = !![1, 0; 0, 0] := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [leftPairing, rightPairing, Matrix.mul_apply, Fin.sum_univ_four] <;> ring
+
+lemma rightPairing_mul_leftPairing : rightPairing * leftPairing =
+    !![3 / 8, 1 / 8, 3 / 8, 1 / 8;
+       3 / 8, 1 / 8, 3 / 8, 1 / 8;
+       1 / 8, 3 / 8, 1 / 8, 3 / 8;
+       1 / 8, 3 / 8, 1 / 8, 3 / 8] := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [leftPairing, rightPairing, Matrix.mul_apply, Fin.sum_univ_two] <;> ring
+
+lemma rightPairing_mul_leftPairing_re_pos (k h : Fin 4) :
+    0 < ((rightPairing * leftPairing) k h).re := by
+  rw [rightPairing_mul_leftPairing]
+  fin_cases k <;> fin_cases h <;> norm_num
+
+lemma rightPairing_mul_leftPairing_ne_idempotent :
+    (rightPairing * leftPairing) * (rightPairing * leftPairing) ≠
+      rightPairing * leftPairing := by
+  intro h
+  rw [rightPairing_mul_leftPairing] at h
+  have hij := congrFun (congrFun h 0) 1
+  norm_num [Matrix.mul_apply, Fin.sum_univ_four, Matrix.cons_val_two,
+    Matrix.cons_val_three] at hij
+
+lemma sectorMatrix_span_eq_top : Submodule.span ℂ (Set.range sectorMatrix) = ⊤ := by
+  rw [Submodule.eq_top_iff']
+  intro X
+  let c : Fin 4 → ℂ := ![
+    X 0 0 + 8 * X 0 1 + (1 / 4) * X 1 0 + 2 * X 1 1,
+    X 0 0 + 8 * X 0 1 - (1 / 4) * X 1 0 - 2 * X 1 1,
+    X 0 0 - 8 * X 0 1 + (1 / 4) * X 1 0 - 2 * X 1 1,
+    X 0 0 - 8 * X 0 1 - (1 / 4) * X 1 0 + 2 * X 1 1]
+  have hsum : X = ∑ k, c k • sectorMatrix k := by
+    ext i j
+    fin_cases i <;> fin_cases j <;>
+      simp [c, sectorMatrix, leftPairing, rightPairing, Fin.sum_univ_four] <;> ring
+  rw [hsum]
+  exact Submodule.sum_mem _ fun k _ =>
+    Submodule.smul_mem _ _ (Submodule.subset_span (Set.mem_range_self k))
+
+/-- The four diagonal sector matrices make the tensor injective. -/
+lemma tensor_isInjective : tensor.IsInjective := by
+  apply top_unique
+  rw [← sectorMatrix_span_eq_top]
+  apply Submodule.span_le.2
+  rintro _ ⟨k, rfl⟩
+  apply Submodule.subset_span
+  refine ⟨finProdFinEquiv (k, k), ?_⟩
+  change tensor (finProdFinEquiv (k, k)).divNat
+      (finProdFinEquiv (k, k)).modNat = sectorMatrix k
+  rw [MPSTensor.finProdFinEquiv_divNat, MPSTensor.finProdFinEquiv_modNat]
+  simp [tensor]
+
+lemma physTraceTransfer_tensor : physTraceTransfer tensor = leftPairing * rightPairing := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [physTraceTransfer, tensor, sectorMatrix, leftPairing, rightPairing,
+      Fin.sum_univ_four, Matrix.mul_apply]
+
+lemma physTraceTransfer_tensor_idempotent :
+    physTraceTransfer tensor * physTraceTransfer tensor = physTraceTransfer tensor := by
+  rw [physTraceTransfer_tensor, leftPairing_mul_rightPairing]
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [Matrix.mul_apply, Fin.sum_univ_two]
+
+/-- Idempotence of the nonzero physical-trace transfer gives source zero
+correlation length. -/
+lemma tensor_isSourceZCL : tensor.IsSourceZCL := by
+  apply isSourceZCL_of_physTraceTransfer_sq tensor
+  · rw [physTraceTransfer_tensor, leftPairing_mul_rightPairing]
+    intro h
+    have hij := congrFun (congrFun h 0) 0
+    norm_num at hij
+  · exact physTraceTransfer_tensor_idempotent
+
+/-- The identification of the four-dimensional physical space with four
+one-dimensional sectors. -/
+noncomputable def sectorEquiv :
+    Fin 4 ≃ Σ _k : Fin 4, Fin 1 × Fin 1 where
+  toFun k := ⟨k, (0, 0)⟩
+  invFun q := q.1
+  left_inv _ := rfl
+  right_inv := by
+    rintro ⟨k, ⟨x, y⟩⟩
+    have hx : x = 0 := Subsingleton.elim _ _
+    have hy : y = 0 := Subsingleton.elim _ _
+    subst x
+    subst y
+    rfl
+
+/-- The scalar physical-sector factorization of the counterexample tensor. -/
+noncomputable def factorization : PhysicalSectorFactorization tensor where
+  sectorCount := 4
+  leftDim := fun _ => 1
+  rightDim := fun _ => 1
+  leftDim_pos := fun _ => by omega
+  rightDim_pos := fun _ => by omega
+  sectorEquiv := sectorEquiv
+  physicalIsometry := 1
+  physicalIsometry_isometry := by simp
+  leftTensor := fun k beta => Matrix.of fun _ _ => leftPairing beta k
+  rightTensor := fun k alpha => Matrix.of fun _ _ => rightPairing k alpha
+  factorization := by
+    intro beta alpha
+    ext q r
+    obtain ⟨k, x, y⟩ := q
+    obtain ⟨h, u, v⟩ := r
+    fin_cases x
+    fin_cases y
+    fin_cases u
+    fin_cases v
+    by_cases hkh : k = h
+    · subst h
+      simp only [Matrix.reindex_apply, Matrix.conjTranspose_one, Matrix.one_mul,
+        Matrix.mul_one]
+      rw [Matrix.blockDiagonal'_apply_eq]
+      simp [Matrix.submatrix_apply, sectorEquiv, physicalSlice, tensor, sectorMatrix]
+      rfl
+    · simp only [Matrix.reindex_apply, Matrix.conjTranspose_one, Matrix.one_mul,
+        Matrix.mul_one]
+      change tensor k h beta alpha =
+        Matrix.blockDiagonal'
+          (fun q => Matrix.kroneckerMap (· * ·)
+            (Matrix.of fun _ _ => leftPairing beta q) (Matrix.of fun _ _ => rightPairing q alpha))
+          ⟨k, (0, 0)⟩ ⟨h, (0, 0)⟩
+      rw [Matrix.blockDiagonal'_apply_ne _ _ _ hkh]
+      simp [tensor, hkh]
+
+/-- The normalized, strictly positive weight of each sector. -/
+noncomputable def p : Fin 4 → ℝ := fun _ => 1 / 4
+
+lemma p_nonneg (k : Fin 4) : 0 ≤ p k := by norm_num [p]
+
+lemma sum_p : ∑ k, p k = 1 := by
+  simp [p]
+
+lemma neighboringOperator_eq (k h : Fin 4) :
+    factorization.neighboringOperator k h =
+      Matrix.diagonal (fun _ : Fin 1 × Fin 1 => (rightPairing * leftPairing) k h) := by
+  ext x y
+  obtain ⟨x₁, x₂⟩ := x
+  obtain ⟨y₁, y₂⟩ := y
+  fin_cases x₁
+  fin_cases x₂
+  fin_cases y₁
+  fin_cases y₂
+  simp [PhysicalSectorFactorization.neighboringOperator_apply,
+    factorization, Matrix.mul_apply]
+
+/-- Every neighboring operator is a positive semidefinite scalar matrix. -/
+lemma neighboringOperator_posSemidef (k h : Fin 4) :
+    (factorization.neighboringOperator k h).PosSemidef := by
+  rw [neighboringOperator_eq]
+  apply Matrix.PosSemidef.diagonal
+  intro i
+  rw [rightPairing_mul_leftPairing]
+  fin_cases k <;> fin_cases h <;> norm_num [Complex.nonneg_iff]
+
+lemma factorization_sectorVirtualMatrixFamily_span_eq_top :
+    Submodule.span ℂ (Set.range factorization.sectorVirtualMatrixFamily) = ⊤ :=
+  factorization.sectorVirtualMatrixFamily_span_eq_top tensor_isInjective
+
+/-- All four sectors are active because their weights are strictly positive. -/
+noncomputable def activeEquiv : factorization.ActiveSector p ≃ Fin 4 where
+  toFun k := k.1
+  invFun k := ⟨k, by norm_num [p]⟩
+  left_inv k := Subtype.ext rfl
+  right_inv _ := rfl
+
+lemma reindex_activeSectorTraceMatrix :
+    Matrix.reindex activeEquiv activeEquiv
+        (factorization.activeSectorTraceMatrix p) =
+      Matrix.map (rightPairing * leftPairing) Complex.re := by
+  ext k h
+  simp only [Matrix.reindex_apply, Matrix.map_apply]
+  change (factorization.neighboringOperator k h).trace.re = ((rightPairing * leftPairing) k h).re
+  rw [neighboringOperator_eq]
+  have hcard : Fintype.card (factorization.NeighborIndex k h) = 1 := by
+    change Fintype.card (Fin 1 × Fin 1) = 1
+    simp
+  simp [Matrix.trace, hcard]
+
+/-- The active-sector trace matrix is not idempotent. -/
+lemma activeSectorTraceMatrix_ne_idempotent :
+    factorization.activeSectorTraceMatrix p *
+        factorization.activeSectorTraceMatrix p ≠
+      factorization.activeSectorTraceMatrix p := by
+  intro hidem
+  have hmap := congrArg
+    (Matrix.reindexAlgEquiv ℝ ℝ activeEquiv) hidem
+  rw [map_mul] at hmap
+  change Matrix.reindex activeEquiv activeEquiv
+      (factorization.activeSectorTraceMatrix p) *
+        Matrix.reindex activeEquiv activeEquiv
+          (factorization.activeSectorTraceMatrix p) =
+      Matrix.reindex activeEquiv activeEquiv
+        (factorization.activeSectorTraceMatrix p) at hmap
+  rw [reindex_activeSectorTraceMatrix] at hmap
+  have h01 := congrFun (congrFun hmap 0) 1
+  rw [rightPairing_mul_leftPairing] at h01
+  norm_num [Matrix.mul_apply, Fin.sum_univ_four, Matrix.cons_val_two,
+    Matrix.cons_val_three] at h01
+
+lemma trace_activeSectorTraceMatrix :
+    Matrix.trace (factorization.activeSectorTraceMatrix p) = 1 := by
+  rw [Matrix.trace]
+  calc
+    ∑ k, factorization.activeSectorTraceMatrix p k k =
+        ∑ i : Fin 4, factorization.activeSectorTraceMatrix p
+          (activeEquiv.symm i) (activeEquiv.symm i) :=
+      (Equiv.sum_comp activeEquiv.symm
+        (fun k => factorization.activeSectorTraceMatrix p k k)).symm
+    _ = ∑ i : Fin 4, ((rightPairing * leftPairing) i i).re := by
+      apply Finset.sum_congr rfl
+      intro i _
+      have happ := congrFun (congrFun reindex_activeSectorTraceMatrix i) i
+      exact happ
+    _ = 1 := by
+      rw [rightPairing_mul_leftPairing]
+      norm_num [Fin.sum_univ_four, Matrix.cons_val_two,
+        Matrix.cons_val_three]
+
+/-- Strict positivity of all entries makes the active-sector trace matrix primitive. -/
+lemma activeSectorTraceMatrix_isPrimitive :
+    Matrix.IsPrimitive (factorization.activeSectorTraceMatrix p) := by
+  refine ⟨factorization.activeSectorTraceMatrix_nonneg p
+    neighboringOperator_posSemidef, 1, by omega, ?_⟩
+  intro k h
+  rw [pow_one]
+  have happ := congrFun (congrFun reindex_activeSectorTraceMatrix
+    (activeEquiv k)) (activeEquiv h)
+  change factorization.activeSectorTraceMatrix p
+      (activeEquiv.symm (activeEquiv k)) (activeEquiv.symm (activeEquiv h)) =
+    ((rightPairing * leftPairing) (activeEquiv k) (activeEquiv h)).re at happ
+  rw [Equiv.symm_apply_apply, Equiv.symm_apply_apply] at happ
+  rw [happ]
+  exact rightPairing_mul_leftPairing_re_pos (activeEquiv k) (activeEquiv h)
+
+/-- The rectangular remainder from CPSV16, Appendix C.2, does not vanish for
+this factorization. -/
+lemma rectangular_remainder_ne_zero :
+    rightPairing * (1 - leftPairing * rightPairing) * leftPairing ≠ 0 := by
+  intro hzero
+  apply rightPairing_mul_leftPairing_ne_idempotent
+  have hdiff :
+      rightPairing * leftPairing -
+          (rightPairing * leftPairing) * (rightPairing * leftPairing) = 0 := by
+    calc
+      rightPairing * leftPairing -
+          (rightPairing * leftPairing) * (rightPairing * leftPairing) =
+          rightPairing * (1 - leftPairing * rightPairing) * leftPairing := by
+        rw [Matrix.mul_sub, Matrix.mul_one, Matrix.sub_mul]
+        simp only [Matrix.mul_assoc]
+      _ = 0 := hzero
+  exact (sub_eq_zero.mp hdiff).symm
+
+/-- Full virtual-matrix spanning does not force the rectangular remainder
+$Q(1-LQ)L$ to vanish.  The example has normalized positive sector weights,
+positive semidefinite neighboring operators, an injective tensor with source zero
+correlation length, and a primitive trace-one active trace matrix, while that
+matrix is non-idempotent and the rectangular remainder is nonzero.
+
+This is a counterexample only to the proposed intermediate implication.  No
+strong-area-law hypothesis is asserted, so it does not refute Lemma C.5 of
+arXiv:1606.00608; it shows that a proof of that lemma must use information
+beyond the concrete spanning and rectangular identities presently extracted
+from Appendix C.2, lines 1406--1499. -/
+theorem virtual_spanning_does_not_force_rectangular_remainder_zero :
+    tensor.IsInjective ∧ tensor.IsSourceZCL ∧
+      physTraceTransfer tensor * physTraceTransfer tensor = physTraceTransfer tensor ∧
+      (∀ k, p k = 1 / 4) ∧ (∀ k, 0 ≤ p k) ∧ (∑ k, p k) = 1 ∧
+      Submodule.span ℂ (Set.range factorization.sectorVirtualMatrixFamily) = ⊤ ∧
+      (∀ k h, (factorization.neighboringOperator k h).PosSemidef) ∧
+      Matrix.IsPrimitive (factorization.activeSectorTraceMatrix p) ∧
+      Matrix.trace (factorization.activeSectorTraceMatrix p) = 1 ∧
+      factorization.activeSectorTraceMatrix p *
+          factorization.activeSectorTraceMatrix p ≠
+        factorization.activeSectorTraceMatrix p ∧
+      rightPairing * (1 - leftPairing * rightPairing) * leftPairing ≠ 0 :=
+  ⟨tensor_isInjective, tensor_isSourceZCL, physTraceTransfer_tensor_idempotent,
+    (by intro k; rfl), p_nonneg, sum_p,
+    factorization_sectorVirtualMatrixFamily_span_eq_top,
+    neighboringOperator_posSemidef, activeSectorTraceMatrix_isPrimitive,
+    trace_activeSectorTraceMatrix, activeSectorTraceMatrix_ne_idempotent,
+    rectangular_remainder_ne_zero⟩
+
+end MPOTensor.ActiveSectorSpanningCounterexample

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity.tex
@@ -306,7 +306,7 @@
         thm:mpdo_eta_coherent_positive_choice,
         thm:mpdo_sector_eta_data_trace_matrix}
     Let ${\cal K}$ be an injective tensor that generates MPDOs and
-    satisfies SAL, and choose the positive neighboring operators of
+    satisfies SAL, and choose the positive semidefinite neighboring operators of
     Theorem~\ref{thm:mpdo_eta_coherent_positive_choice}. Restrict the sector
     index to the positive-weight summands of the Hayashi decomposition. Then
     positive semidefiniteness makes every neighboring trace real and
@@ -404,6 +404,82 @@
     \]
     for every $N\geq1$. Injectivity of the real-to-complex inclusion gives
     the two real matrix identities.
+\end{proof}
+
+\begin{theorem}[Virtual spanning does not force active-sector idempotence]
+    \label{thm:mpdo_virtual_spanning_active_trace_counterexample}
+    \lean{MPOTensor.ActiveSectorSpanningCounterexample.%
+      virtual_spanning_does_not_force_rectangular_remainder_zero}
+    \lean{MPOTensor.ActiveSectorSpanningCounterexample.%
+      physTraceTransfer_tensor}
+    \lean{MPOTensor.ActiveSectorSpanningCounterexample.%
+      reindex_activeSectorTraceMatrix}
+    \leanok
+    \uses{def:mpdo_physical_sector_factorization,
+      def:mpdo_active_sector_trace_matrix}
+    There is an injective tensor of bond dimension two with four one-dimensional
+    physical sectors, carrying equal positive weights $p_k=1/4$ summing to one,
+    such that the following statements hold simultaneously: it has source zero
+    correlation length; its sector virtual matrices span $\MN{2}$; its
+    physical-trace transfer is idempotent; every neighboring operator is
+    positive semidefinite; and its active trace matrix is primitive and has
+    trace one.  Nevertheless, if
+    $S=LQ$ is the physical-trace transfer and $T=QL$ is the active trace matrix,
+    then
+    \[
+        Q(1-S)L=T-T^2\ne0.
+    \]
+    In particular, full virtual-matrix spanning does not by itself imply that
+    the active trace matrix is idempotent.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Take
+    \[
+      L=\begin{pmatrix}
+        \frac14&\frac14&\frac14&\frac14\\
+        1&-1&1&-1
+      \end{pmatrix},
+      \qquad
+      Q=\begin{pmatrix}
+        1&\frac18\\
+        1&\frac18\\
+        1&-\frac18\\
+        1&-\frac18
+      \end{pmatrix}.
+    \]
+    For each $k$, the $k$th sector virtual matrix is the outer product of the
+    $k$th column of $L$ with the $k$th row of $Q$.  Their four coordinate
+    functions are proportional to the Walsh functions $1,x,y,xy$ on four
+    points.  More explicitly, the matrix whose columns are their coordinates
+    in the order $(00,01,10,11)$ has determinant $-1/64$.  Hence they form a
+    basis of $\MN{2}$.  Placing them on the
+    diagonal physical entries gives an injective tensor and a physical-sector factorization with
+    scalar sectors.
+
+    Direct multiplication gives
+    \[
+      LQ=\begin{pmatrix}1&0\\0&0\end{pmatrix},
+      \qquad
+      QL=\begin{pmatrix}
+        \frac38&\frac18&\frac38&\frac18\\
+        \frac38&\frac18&\frac38&\frac18\\
+        \frac18&\frac38&\frac18&\frac38\\
+        \frac18&\frac38&\frac18&\frac38
+      \end{pmatrix}.
+    \]
+    Thus $LQ$ is idempotent, whereas every entry of $QL$ is strictly positive,
+    so $QL$ is primitive.  Its trace is one.  Since each sector is
+    one-dimensional, the neighboring operators are the scalar matrices
+
+    \[
+        \eta_{k,h}=\begin{pmatrix}(QL)_{k,h}\end{pmatrix}\succeq0.
+    \]
+
+    The $(0,1)$ entry of $(QL)^2$ is $1/4$, while the corresponding entry of
+    $QL$ is $1/8$.  Hence $QL$ is not idempotent, and associativity gives
+    $Q(1-LQ)L=QL-(QL)^2\ne0$.
 \end{proof}
 
 \begin{theorem}[Positivity of bipartite partial traces]

--- a/docs/counterexamples.md
+++ b/docs/counterexamples.md
@@ -22,12 +22,18 @@ mathematical obstruction.
 
 - Location:
   `TNLean/Archive/PerronFrobeniusVirtualSpanningCounterexample.lean`
+- Active physical-sector realization:
+  `TNLean/MPS/MPDO/ActiveSectorSpanningCounterexample.lean`
 - Main declaration:
   `TNLean.Archive.PerronFrobeniusVirtualSpanningCounterexample.injective_sourceZCL_tensor_with_nilpotent_sector_pairing`
-- Statement refuted: source ZCL, injectivity, primitivity, trace
-  normalization, rectangular pairing idempotence, constant positive-power
-  traces, and full spanning of the virtual matrix algebra imply that the
-  opposite rectangular product has rank one.
+- Strengthened declaration with scalar positive semidefinite neighboring operators:
+  `MPOTensor.ActiveSectorSpanningCounterexample.virtual_spanning_does_not_force_rectangular_remainder_zero`
+- Statement refuted by the strengthened active-sector realization: source ZCL,
+  injectivity, exact idempotence of the physical-trace rectangular product,
+  primitivity and trace normalization of the active trace matrix, full spanning
+  of the virtual matrix algebra, and positive semidefiniteness of every neighboring operator
+  imply that the active trace matrix is idempotent, or equivalently that the
+  rectangular remainder vanishes.
 - Witness: four rational pairs $l_k,r_k$ with $LQ$ idempotent and $T=QL$
   primitive, but $Q(1-LQ)L=T-T^2\ne0$. The matrices $l_k r_k$ span
   $M_2(\mathbb R)$ and occur as the diagonal slices of an injective

--- a/docs/paper-gaps/cpgsv17_pf_rank_one.tex
+++ b/docs/paper-gaps/cpgsv17_pf_rank_one.tex
@@ -34,7 +34,7 @@ route described below --- is tracked in
 source passage is
 \path{Papers/1606.00608/MPDO-22-12-17-2.tex:1394--1499}.}
 
-The paper constructs positive neighboring operators $\eta_{k,h}$ and defines
+The paper constructs positive semidefinite neighboring operators $\eta_{k,h}$ and defines
 \[
   T_{k,h}=\operatorname{tr}(\eta_{k,h}).
 \]
@@ -380,7 +380,7 @@ $T\ne T^2$.  Equivalently, the exact missing expression is nonzero:
  Q(1-LQ)L=T-T^2\ne0.
 \]
 Moreover, the four matrices $l_k r_k$ span $M_2(\mathbb R)$.  For example,
-after vectorizing them in the order $(11,12,21,22)$, the determinant of the
+after vectorizing them in the order $(00,01,10,11)$, the determinant of the
 resulting four-by-four matrix is $1/108$.  Consequently full virtual spanning
 does not exclude the generalized zero-eigenspace.
 
@@ -423,6 +423,69 @@ tensors.  In the notation above, the needed assertion is precisely
 \]
 or any equivalent statement excluding the nilpotent generalized
 zero-eigenspace of $QL$.
+
+\subsection{Positive semidefinite neighboring operators do not force the rectangular
+vanishing}
+
+The preceding obstruction can also be realized inside the physical-sector
+factorization with every neighboring operator positive semidefinite.  This can
+be seen from a second, independent witness with bond dimension two and four
+one-dimensional physical sectors.  Let
+\[
+  L=\begin{pmatrix}
+    \frac14&\frac14&\frac14&\frac14\\
+    1&-1&1&-1
+  \end{pmatrix},
+  \qquad
+  Q=\begin{pmatrix}
+    1&\frac18\\
+    1&\frac18\\
+    1&-\frac18\\
+    1&-\frac18
+  \end{pmatrix}.
+\]
+For each sector $k$, take the virtual matrix to be the outer product of the
+$k$th column of $L$ with the $k$th row of $Q$.  These four matrices span
+$\MN{2}$: in the coordinate order $(00,01,10,11)$, the matrix having these
+four outer products as columns has determinant $-1/64$.  Placing them on the
+four diagonal physical entries therefore gives an injective tensor with a
+scalar physical-sector factorization.
+
+The two rectangular products are
+\[
+  LQ=\begin{pmatrix}1&0\\0&0\end{pmatrix},
+  \qquad
+  QL=\begin{pmatrix}
+    \frac38&\frac18&\frac38&\frac18\\
+    \frac38&\frac18&\frac38&\frac18\\
+    \frac18&\frac38&\frac18&\frac38\\
+    \frac18&\frac38&\frac18&\frac38
+  \end{pmatrix}.
+\]
+Hence $LQ$ is a nonzero idempotent physical-trace transfer, while $QL$ is
+strictly positive, primitive, and trace one.  Its entries are the scalar
+neighboring operators and are therefore positive semidefinite.  Nevertheless
+$(QL)^2\ne QL$; for example, the $(0,1)$ entry changes from $1/8$ to $1/4$.
+Equivalently,
+\[
+  Q(1-LQ)L=QL-(QL)^2\ne0.
+\]
+Thus injectivity, full virtual-matrix spanning, positive semidefinite neighboring
+operators, primitivity, trace normalization, and the source
+zero-correlation-length rectangular identity can all hold without the missing
+vanishing.
+\footnote{The formal tensor and the combined counterexample theorem are in
+\doclink{TNLean/MPS/MPDO/ActiveSectorSpanningCounterexample}; see
+{\scriptsize\leanid{MPOTensor.ActiveSectorSpanningCounterexample.virtual_spanning_does_not_force_rectangular_remainder_zero}}.}
+
+This example does not assert the strong area law, and therefore does not
+disprove the statement of Lemma~C.5.  It instead closes the narrower question
+left after the active-sector construction: no argument using only the concrete
+spanning and rectangular identities presently extracted in the formal
+development can prove $Q(1-LQ)L=0$.  Any source-faithful completion must use an
+additional consequence of the strong area law or of the inverse-map
+construction that is not among those identities.  Such a consequence must be
+derived, rather than added as a new hypothesis to Lemma~C.5.
 
 \section{A positive-semidefinite route}
 


### PR DESCRIPTION
## Summary

- construct an explicit bond-dimension-two tensor with four scalar physical sectors;
- prove injectivity, source zero correlation length, exact idempotence of the physical-trace transfer, full virtual-matrix spanning, positivity of all neighboring operators, and primitivity and trace-one normalization of the active trace matrix;
- prove nevertheless that the active trace matrix is not idempotent and that the rectangular remainder (Q(1-LQ)L=T-T^2) is nonzero;
- record the resulting boundary in the blueprint, the CPGSV17 paper-gap note, and the counterexample index.

## Source faithfulness

This is a counterexample only to the proposed intermediate implication that the concrete spanning, positivity, and rectangular identities presently extracted from Appendix C.2 force the missing vanishing. It is **not** an SAL counterexample and does not refute CPSV16 Lemma C.5.

The result shows that a source-faithful completion must derive an additional consequence from SAL or from the provenance of the inverse-map factors. Such a consequence must not be introduced as an extra hypothesis of the source theorem.

## Validation

- `lake env lean TNLean/MPS/MPDO/ActiveSectorSpanningCounterexample.lean`
- `lake build TNLean` (9555 targets)
- `leanblueprint checkdecls`
- blueprint/Lean synchronization and coverage check
- reader-facing prose and whitespace checks
- proof-integrity scan of the new module

Advances #3593; the source-faithful SAL/inverse-provenance step remains open.

Parent tracker: #2380.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formal mathematics and documentation only; no runtime, auth, or data-path changes. Scope is explicitly bounded as a counterexample to an intermediate proof step, not a change to SAL lemmas.
> 
> **Overview**
> Introduces **`ActiveSectorSpanningCounterexample.lean`**, an explicit bond-dimension-two MPO with four scalar physical sectors and closed tensors \(L,Q\). The main theorem **`virtual_spanning_does_not_force_rectangular_remainder_zero`** proves that injectivity, source ZCL, idempotent physical-trace transfer \(LQ\), full virtual-matrix spanning, **positive semidefinite** neighboring operators, and a primitive trace-one active trace matrix can all hold while the active trace matrix is **not** idempotent and **`Q(1-LQ)L = T - T² ≠ 0`**.
> 
> The module is wired into the root **`TNLean.lean`** import list. The blueprint gains **Theorem “Virtual spanning does not force active-sector idempotence”** with a Walsh-basis spanning argument; **`docs/counterexamples.md`** and **`docs/paper-gaps/cpgsv17_pf_rank_one.tex`** record the strengthened obstruction and clarify it does **not** refute SAL or Lemma C.5—only the hoped-for implication from presently extracted Appendix C.2 identities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 236a2ba20558008405f04646594e264ca7d445ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->