### PR TITLE
doc(Channel/Schwarz): restore SSA review clarifications

### DIFF
--- a/TNLean/Channel/Schwarz/SSAEqualityDPI.lean
+++ b/TNLean/Channel/Schwarz/SSAEqualityDPI.lean
@@ -56,13 +56,15 @@ $\rho_{ABC}$, equality in strong subadditivity is equivalent to
     (\mathbf 1_A/d_A)\otimes\rho_B\right).
 \]
 The second reference is the image of the first under
-$\operatorname{tr}_C$ by `SSAPosDef.traceC_ABC_kronecker_traceA_ABC`.
+$\operatorname{tr}_C$, since tracing out $C$ sends
+$(\mathbf 1_A/d_A)\otimes\rho_{BC}$ to
+$(\mathbf 1_A/d_A)\otimes\rho_B$.
 
 Hayden--Jozsa--Petz--Winter use instead the exact product-marginal pair
 $\rho_A\otimes\rho_{BC}$ and $\rho_A\otimes\rho_B$. Their equation (6) gives
-the same strong-subadditivity deficit. The present theorem uses
-the maximally mixed state on $A$ because `SSAPosDef.rel_entropy_eval_support`
-supplies this singular-reference evaluation without any additional hypothesis.
+the same strong-subadditivity deficit. The present theorem uses the maximally
+mixed state on $A$ because relative entropy against this singular reference
+evaluates on its support without any additional hypothesis.
 
 **Reference substitution:** This is the hypothesis-free maximally mixed-reference
 formulation, not the exact product-marginal formulation of HJPW. The missing

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -1620,8 +1620,16 @@ Theorem~\ref{thm:trace_norm_abs}.
 \end{lemma}
 
 \begin{proof}\leanok
-    Expand both partial traces entry by entry. The two sides differ only in the
-    order of the finite sums over the $A$ and $C$ indices.
+    For indices $(a_1,b_1)$ and $(a_2,b_2)$, the corresponding matrix entry is
+    \[
+        \left[\tr_C\!\left(\frac{\mathbf 1_A}{d_A}\otimes
+            \rho_{BC}\right)\right]_{(a_1,b_1),(a_2,b_2)}
+        =\frac{\delta_{a_1,a_2}}{d_A}
+            \sum_c (\rho_{BC})_{(b_1,c),(b_2,c)}
+        =\frac{\delta_{a_1,a_2}}{d_A}(\rho_B)_{b_1,b_2}.
+    \]
+    This is the corresponding entry of
+    $(\mathbf 1_A/d_A)\otimes\rho_B$.
 \end{proof}
 
 \begin{theorem}[Strong subadditivity]\label{thm:strong_subadditivity}


### PR DESCRIPTION
## Motivation

PR #4187 merged before its final blueprint-prose review completed. This follow-up restores the three requested post-merge clarifications without changing the theorem, proof, or source-faithfulness boundary.

## Description

- replace Lean identifiers used as mathematical justification with self-contained prose
- display the indexed partial-trace calculation in the blueprint proof
- keep the maximally mixed reference and exact HJPW product-marginal boundary unchanged

## Testing

- lake env lean TNLean/Channel/Schwarz/SSAEqualityDPI.lean
- python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main
- python3 scripts/blueprint_lean_sync.py --root . --diff-base origin/main
- lake exe lint_style
- cd blueprint and leanblueprint checkdecls

Follow-up to #4187.

Closes #4177