### PR TITLE
doc(mpdo): correct all-length Markov follow-up

### DIFF
--- a/TNLean/Entropy/MarkovChain.lean
+++ b/TNLean/Entropy/MarkovChain.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Axioms.Entropy
+import TNLean.Channel.PartialTrace
 import TNLean.Entropy.StrongSubadditivity
 
 /-!

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
@@ -425,10 +425,10 @@ strong subadditivity for a normalized three-site reduced state.
 
 \begin{proof}
     \leanok
-    \uses{lem:mpdo_right_partial_trace_cptp}
     Reindex $C$ as $C'\otimes E$ and apply the ordinary right partial trace.
-    Its entry formula gives the displayed sum, while complete positivity and
-    trace preservation give the final assertions.
+    Its entry formula gives the displayed sum.  Positivity follows by tracing
+    a positive matrix, and invariance of the full trace under reindexing gives
+    trace preservation.
 \end{proof}
 
 \begin{theorem}[Right marginals preserve a quantum Markov decomposition]
@@ -495,7 +495,7 @@ strong subadditivity for a normalized three-site reduced state.
     $\sigma_3^{(N)}(K)$ is obtained from the normalized $N$-site periodic state
     by tracing out all but its first three sites, then
     $\sigma_3^{(N)}(K)$ admits a quantum Markov decomposition on its middle
-    site.  This is the result proved in
+    site.  This is Lemma~Lsigma3 of
     \cite[Appendix~C.2, lines~1351--1371]{Cirac2016MPDO_arXiv}.  The
     decomposition may depend on $N$.
 \end{theorem}
@@ -526,13 +526,12 @@ strong subadditivity for a normalized three-site reduced state.
     $C\simeq c\otimes E$, where $c$ is its first site and $E$ contains the
     remaining $N-4$ sites.  Theorem~\ref{thm:quantum_markov_right_marginal} gives
     the same middle-site direct sum after tracing out $E$.  The contiguous-block
-    partial-trace identity gives
+    reduction gives
     \[
-      \tr_{4,\ldots,N-1}\!\left(\sigma_{N-1}^{(N)}(K)\right)
-        =\sigma_3^{(N)}(K),
+        \sigma_3^{(N)}(K)
+        =\tr_{4,\ldots,N-1}\!\left[\sigma_{N-1}^{(N)}(K)\right],
     \]
-    which identifies the resulting operator with the required three-site
-    marginal.
+    which identifies the resulting operator with $\sigma_3^{(N)}(K)$.
 \end{proof}
 
 \begin{theorem}[Four-site SAL marginals have Hayashi decompositions]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
@@ -495,7 +495,7 @@ strong subadditivity for a normalized three-site reduced state.
     $\sigma_3^{(N)}(K)$ is obtained from the normalized $N$-site periodic state
     by tracing out all but its first three sites, then
     $\sigma_3^{(N)}(K)$ admits a quantum Markov decomposition on its middle
-    site.  This is Lemma~Lsigma3 of
+    site.  This is the three-site marginal result proved in
     \cite[Appendix~C.2, lines~1351--1371]{Cirac2016MPDO_arXiv}.  The
     decomposition may depend on $N$.
 \end{theorem}

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -5,7 +5,7 @@
 \usepackage[hidelinks]{hyperref}
 \setlength{\emergencystretch}{2em}
 
-\input{./command}
+\input{command}
 
 \title{The SAL to Eta-Local Structure Step in
 Cirac--Perez-Garcia--Schuch--Verstraete 2017 Appendix C.2}
@@ -387,7 +387,7 @@ third region are traced out.  Partial trace preserves the same middle-site
 direct sum, and the contiguous-block reduction identity gives
 \[
   \sigma_3^{(N)}({\cal K})
-  =\tr_{4,\ldots,N}\!\left[\sigma_{N-1}^{(N)}({\cal K})\right].
+  =\tr_{4,\ldots,N-1}\!\left[\sigma_{N-1}^{(N)}({\cal K})\right].
 \]
 This proves Lemma~\texttt{Lsigma3} at every admissible chain length, with no
 claim that the decomposition is common to different values of $N$.


### PR DESCRIPTION
## Summary

- import the chosen-factor partial-trace API directly where it is used
- remove an inaccurate blueprint dependency on the Kraus-CPTP theorem and align the proof prose with the Lean helpers
- correct the terminal trace range from `4,...,N` to `4,...,N-1` in the paper-gap note
- keep the note's established shared-command input path stable

## Context

PR #4185 merged while its final review follow-through was reconciling concurrent head updates. This narrow follow-up contains only the net corrections that were not present in the merged head. It does not reopen #4167; the all-length theorem itself is already merged.

## Validation

- `lake build TNLean.MPS.MPDO.SimpleLocalStructure`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check origin/main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and import-path edits only; no changes to theorem statements or proof logic beyond aligning prose with existing Lean.
> 
> **Overview**
> Narrow documentation and import follow-up after the merged all-length Markov work (#4185).
> 
> **Lean:** `MarkovChain.lean` now imports `TNLean.Channel.PartialTrace` so `Matrix.partialTraceRightAlong` and its lemmas are pulled in where the right-marginal Markov proof uses them.
> 
> **Blueprint:** The partial-trace-along lemma no longer cites the Kraus–CPTP lemma; proof text matches the Lean entry formula plus positivity/trace arguments. The SAL three-site marginal proof uses the corrected trace range **`4,…,N−1`** (not `4,…,N`) and slightly tightened wording.
> 
> **Paper-gap note:** The same terminal trace index is fixed in the displayed identity, and `\input{command}` replaces `\input{./command}` for stable shared macros.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17ba1e8aae84871c9786d777e3ebbc057fa31e51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->