### PR TITLE
feat(MPS/CanonicalForm): characterize bases of normal tensors

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -377,6 +377,7 @@ import TNLean.MPS.CanonicalForm.SectorComparison.CyclicSectorRelation
 import TNLean.MPS.CanonicalForm.BNTGrouping
 import TNLean.MPS.CanonicalForm.PhaseCover
 import TNLean.MPS.CanonicalForm.PhaseClassSectorData
+import TNLean.MPS.CanonicalForm.BNTCharacterization
 import TNLean.MPS.Overlap.NormalTensorDichotomy
 import TNLean.MPS.Core.BlockingInfrastructure
 import TNLean.MPS.Irreducible.FormII

--- a/TNLean/MPS/BNT/Basic.lean
+++ b/TNLean/MPS/BNT/Basic.lean
@@ -88,6 +88,32 @@ structure IsBNT {d Dtot : ℕ} (A_total : MPSTensor d Dtot)
   eventually_li : ∃ N0 : ℕ, ∀ N > N0,
       LinearIndependent ℂ (fun j : Fin g => mpvState (d := d) (A_bnt j) N)
 
+/-- Re-index a sum over a finite family by collecting coefficients in the fibres
+of a finite map. -/
+lemma sum_fiber_smul
+    {ι κ V : Type*} [Fintype ι] [Fintype κ] [DecidableEq κ]
+    [AddCommMonoid V] [Module ℂ V]
+    (φ : ι → κ) (a : ι → ℂ) (v : κ → V) :
+    (∑ i : ι, a i • v (φ i)) =
+      ∑ k : κ, (∑ i : ι, if φ i = k then a i else 0) • v k := by
+  classical
+  calc
+    (∑ i : ι, a i • v (φ i))
+        = ∑ i : ι, ∑ k : κ, (if φ i = k then a i else 0) • v k := by
+          refine Finset.sum_congr rfl ?_
+          intro i _
+          have hinner :
+              (∑ k : κ, (if φ i = k then a i else 0) • v k)
+                = a i • v (φ i) := by
+            simp [ite_smul, eq_comm]
+          exact hinner.symm
+    _ = ∑ k : κ, ∑ i : ι, (if φ i = k then a i else 0) • v k := by
+          rw [Finset.sum_comm]
+    _ = ∑ k : κ, (∑ i : ι, if φ i = k then a i else 0) • v k := by
+          refine Finset.sum_congr rfl ?_
+          intro k _
+          rw [Finset.sum_smul]
+
 /--
 If the MPV overlaps of a finite index family `A j` converge to an orthonormal
 Gram matrix, then the MPV states `mpvState (A j) N` are eventually linearly

--- a/TNLean/MPS/CanonicalForm/BNTCharacterization.lean
+++ b/TNLean/MPS/CanonicalForm/BNTCharacterization.lean
@@ -1,0 +1,563 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.CanonicalForm.NormalTensorGauge
+import TNLean.MPS.CanonicalForm.PhaseClassSectorData
+import TNLean.MPS.FundamentalTheorem.SectorWeightComparison
+import TNLean.MPS.Overlap.NormalTensorDichotomy
+
+/-!
+# Characterization of a basis of normal tensors
+
+This module proves the characterization of a basis of normal tensors from
+arXiv:1606.00608, Proposition 2.7 (`prop:char-BNT`, lines 271--280 and
+1135--1146). For a tensor in canonical form, a finite candidate family is a
+basis of normal tensors if and only if every candidate is normal, every active
+canonical-form summand is gauge-phase equivalent to one member of the family,
+and distinct members are not gauge-phase equivalent.
+
+The canonical-form hypotheses below record the context of the source
+proposition: the displayed summands are normal and their weighted direct sum
+generates the same positive-length matrix product vectors as the original
+tensor. Coverage is restricted to nonzero-weight summands, as explained in
+`docs/paper-gaps/cpsv16_bnt_characterization_active_blocks.tex`. Positive bond
+dimensions are implicit in the source's matrix algebras and are made explicit
+through typeclass assumptions.
+-/
+
+open scoped Matrix BigOperators
+open Filter Topology
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- Eventual linear independence excludes gauge-phase-equivalent duplicate
+members of a basis of normal tensors.
+
+This is condition (ii) in the characterization of arXiv:1606.00608,
+Proposition 2.7 (`prop:char-BNT`, lines 278--280 and 1137--1142). -/
+theorem IsCPSVBasisOfNormalTensors.blocks_not_gaugePhaseEquiv
+    {g : ℕ} {dim : Fin g → ℕ}
+    {A : MPSTensor d D} {B : (j : Fin g) → MPSTensor d (dim j)}
+    (hBNT : IsCPSVBasisOfNormalTensors A (fun j => ⟨dim j, B j⟩)) :
+    BlocksNotGaugePhaseEquiv (d := d) B := by
+  intro j k hjk hdim hGPE
+  obtain ⟨N₀, hLI⟩ := hBNT.eventually_li
+  have hN := hLI (N₀ + 1) (by omega)
+  obtain ⟨X, ζ, _hζ, hConj⟩ := hGPE
+  have hState : ζ ^ (N₀ + 1) • mpvState (d := d) (B j) (N₀ + 1) =
+      mpvState (d := d) (B k) (N₀ + 1) := by
+    apply PiLp.ext
+    intro σ
+    simp only [PiLp.smul_apply, mpvState_apply, smul_eq_mul]
+    rw [mpv_eq_pow_mul_of_gaugePhase
+      (A := cast (congr_arg (MPSTensor d) hdim) (B j))
+      (B := B k) X ζ hConj (N₀ + 1) σ,
+      mpv_cast_dim hdim (B j) (N₀ + 1) σ]
+  have hPair : LinearIndepOn ℂ
+      (fun l : Fin g => mpvState (d := d) (B l) (N₀ + 1)) {j, k} :=
+    hN.linearIndepOn {j, k}
+  have hNot := (linearIndepOn_pair_iff _ hjk (hN.ne_zero j)).mp hPair
+  exact hNot (ζ ^ (N₀ + 1)) hState
+
+/-- Normal tensors which are not MPV-phase equivalent have asymptotically
+vanishing overlap.
+
+This is the contrapositive form of arXiv:1606.00608, Corollary `eqV`, lines
+1121--1128. -/
+private lemma overlap_tendsto_zero_of_not_mpvBlockPhaseEquiv
+    {D₁ D₂ : ℕ} [NeZero D₁] [NeZero D₂]
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂}
+    (hA : IsNormalTensor A) (hB : IsNormalTensor B)
+    (hNot : ¬ MPVBlockPhaseEquiv A B) :
+    Tendsto (fun N => mpvOverlap (d := d) A B N) atTop (𝓝 0) := by
+  rcases hA.mpv_phase_alternative hB with hZero | ⟨ζ, hζ, hState⟩
+  · exact hZero
+  · exfalso
+    apply hNot
+    refine ⟨ζ, ?_, ?_⟩
+    · exact norm_ne_zero_iff.mp (by rw [hζ]; exact one_ne_zero)
+    · intro N _hN σ
+      have hEq := congrArg (fun v : MPVSpace d N => v σ) (hState N)
+      simpa [mpvState_apply, PiLp.smul_apply, smul_eq_mul] using hEq
+
+/-- A canonical-form phase class must occur among any basis of normal tensors
+spanning the same matrix product vectors.
+
+This is the forward implication of CPSV16, Proposition `prop:char-BNT`,
+lines 1135–1146. -/
+private theorem exists_phase_match_of_isCPSVBasisOfNormalTensors
+    {g : ℕ} {dimB : Fin g → ℕ} [∀ j, NeZero (dimB j)]
+    {P : SectorDecomposition d} [∀ j, NeZero (P.basisDim j)]
+    (B : (j : Fin g) → MPSTensor d (dimB j))
+    (hPNormal : ∀ j, IsNormalTensor (P.basis j))
+    (hPDistinct : BlocksNotGaugePhaseEquiv (d := d) P.basis)
+    (hBNormal : ∀ j, IsNormalTensor (B j))
+    (hBNT : IsCPSVBasisOfNormalTensors P.toTensor (fun j => ⟨dimB j, B j⟩))
+    (j₀ : Fin P.basisCount) :
+    ∃ k : Fin g, MPVBlockPhaseEquiv (P.basis j₀) (B k) := by
+  classical
+  have hBDistinct : BlocksNotGaugePhaseEquiv (d := d) B :=
+    hBNT.blocks_not_gaugePhaseEquiv
+  have hPPhaseDistinct : ∀ i j : Fin P.basisCount, i ≠ j →
+      ¬ MPVBlockPhaseEquiv (P.basis i) (P.basis j) := by
+    intro i j hij hPhase
+    obtain ⟨hdim, hGPE⟩ :=
+      hPhase.dim_eq_and_gaugePhaseEquiv_of_isNormalTensor
+        (hPNormal i) (hPNormal j)
+    exact hPDistinct i j hij hdim hGPE
+  have hBPhaseDistinct : ∀ i j : Fin g, i ≠ j →
+      ¬ MPVBlockPhaseEquiv (B i) (B j) := by
+    intro i j hij hPhase
+    obtain ⟨hdim, hGPE⟩ :=
+      hPhase.dim_eq_and_gaugePhaseEquiv_of_isNormalTensor
+        (hBNormal i) (hBNormal j)
+    exact hBDistinct i j hij hdim hGPE
+  by_contra hNo
+  push Not at hNo
+  let T : Finset (Fin P.basisCount) :=
+    Finset.univ.filter fun j : Fin P.basisCount =>
+      ∀ k : Fin g, ¬ MPVBlockPhaseEquiv (P.basis j) (B k)
+  have hj₀T : j₀ ∈ T := by
+    simp [T, hNo]
+  have hTNotPhase : ∀ (j : Fin P.basisCount), j ∈ T → ∀ k : Fin g,
+      ¬ MPVBlockPhaseEquiv (P.basis j) (B k) := by
+    intro j hj k
+    exact (Finset.mem_filter.mp hj).2 k
+  have hNotTPhase : ∀ j : Fin P.basisCount, j ∉ T →
+      ∃ k : Fin g, MPVBlockPhaseEquiv (P.basis j) (B k) := by
+    intro j hj
+    have hnot : ¬ (∀ k : Fin g, ¬ MPVBlockPhaseEquiv (P.basis j) (B k)) := by
+      intro hall
+      exact hj (by simp [T, hall])
+    push Not at hnot
+    exact hnot
+  have hScalar : ∀ c : {j : Fin P.basisCount // j ∉ T},
+      ∃ k : Fin g, ∃ α : ℕ → ℂ, ∀ N : ℕ, 0 < N →
+        mpvState (d := d) (P.basis c.1) N =
+          α N • mpvState (d := d) (B k) N := by
+    intro c
+    obtain ⟨k, ζ, hζ, hmpv⟩ := hNotTPhase c.1 c.2
+    refine ⟨k, fun N => (ζ ^ N)⁻¹, ?_⟩
+    intro N hN
+    apply PiLp.ext
+    intro σ
+    have hB_mpv : mpv (B k) σ = ζ ^ N * mpv (P.basis c.1) σ :=
+      hmpv N hN σ
+    have hζN : ζ ^ N ≠ 0 := pow_ne_zero N hζ
+    simp only [mpvState_apply, PiLp.smul_apply, smul_eq_mul]
+    calc
+      mpv (P.basis c.1) σ = (ζ ^ N)⁻¹ * (ζ ^ N * mpv (P.basis c.1) σ) := by
+        rw [inv_mul_cancel_left₀ hζN]
+      _ = (ζ ^ N)⁻¹ * mpv (B k) σ := by rw [← hB_mpv]
+  choose kOf αOf hStateOf using hScalar
+  letI : Fintype {j : Fin P.basisCount // j ∈ T} := Subtype.fintype (fun j => j ∈ T)
+  letI : Fintype {j : Fin P.basisCount // j ∉ T} := Subtype.fintype (fun j => j ∉ T)
+  let C :
+      (x : Sum {j : Fin P.basisCount // j ∈ T} (Fin g)) →
+        MPSTensor d
+          (Sum.elim
+            (fun j : {j : Fin P.basisCount // j ∈ T} => P.basisDim j.1)
+            dimB x) :=
+    Sum.rec
+      (motive := fun x => MPSTensor d
+        (Sum.elim
+          (fun j : {j : Fin P.basisCount // j ∈ T} => P.basisDim j.1)
+          dimB x))
+      (fun j => P.basis j.1) B
+  have hSelf : ∀ x,
+      Tendsto (fun N => mpvOverlap (d := d) (C x) (C x) N) atTop
+        (𝓝 (1 : ℂ)) := by
+    intro x
+    cases x with
+    | inl j => simpa [C] using (hPNormal j.1).selfOverlap_tendsto_one
+    | inr k => simpa [C] using (hBNormal k).selfOverlap_tendsto_one
+  have hCross : ∀ x y, x ≠ y →
+      Tendsto (fun N => mpvOverlap (d := d) (C x) (C y) N) atTop
+        (𝓝 (0 : ℂ)) := by
+    intro x y hxy
+    cases x with
+    | inl i =>
+        cases y with
+        | inl j =>
+            have hij : i.1 ≠ j.1 := by
+              intro h
+              exact hxy (congrArg Sum.inl (Subtype.ext h))
+            simpa [C] using
+              overlap_tendsto_zero_of_not_mpvBlockPhaseEquiv
+                (hPNormal i.1) (hPNormal j.1) (hPPhaseDistinct i.1 j.1 hij)
+        | inr k =>
+            simpa [C] using
+              overlap_tendsto_zero_of_not_mpvBlockPhaseEquiv
+                (hPNormal i.1) (hBNormal k) (hTNotPhase i.1 i.2 k)
+    | inr k =>
+        cases y with
+        | inl i =>
+            simpa [C] using tendsto_mpvOverlap_zero_swap
+              (P.basis i.1) (B k)
+              (overlap_tendsto_zero_of_not_mpvBlockPhaseEquiv
+                (hPNormal i.1) (hBNormal k) (hTNotPhase i.1 i.2 k))
+        | inr l =>
+            have hkl : k ≠ l := by
+              intro h
+              exact hxy (congrArg Sum.inr h)
+            simpa [C] using
+              overlap_tendsto_zero_of_not_mpvBlockPhaseEquiv
+                (hBNormal k) (hBNormal l) (hBPhaseDistinct k l hkl)
+  have hLI : ∀ᶠ N in atTop,
+      LinearIndependent ℂ
+        (Sum.elim
+          (fun j : {j : Fin P.basisCount // j ∈ T} =>
+            mpvState (d := d) (P.basis j.1) N)
+          (fun k : Fin g => mpvState (d := d) (B k) N)) :=
+    (eventually_linearIndependent_of_finite_overlap_tendsto_orthonormal
+      C hSelf hCross).mono (fun N hN => by
+        have key :
+            (fun x : Sum {j : Fin P.basisCount // j ∈ T} (Fin g) =>
+              mpvState (d := d) (C x) N) =
+              Sum.elim
+                (fun j : {j : Fin P.basisCount // j ∈ T} =>
+                  mpvState (d := d) (P.basis j.1) N)
+                (fun k : Fin g => mpvState (d := d) (B k) N) := by
+          funext x
+          cases x <;> rfl
+        rw [← key]
+        exact hN)
+  have hCoeffEventuallyZero : ∀ᶠ N : ℕ in atTop, P.coeff N j₀ = 0 := by
+    refine (hLI.and (Filter.eventually_atTop.mpr ⟨1, fun N hN => hN⟩)).mono ?_
+    intro N hN
+    rcases hN with ⟨hLIN, hNpos⟩
+    obtain ⟨cB, hcB⟩ := hBNT.spans_mpv N hNpos
+    have hPstate :
+        mpvState (d := d) P.toTensor N =
+          ∑ j : Fin P.basisCount, P.coeff N j •
+            mpvState (d := d) (P.basis j) N := by
+      refine mpvState_eq_sum_of_decomp (d := d) P.toTensor P.basis
+        (N := N) (fun j => P.coeff N j) ?_
+      intro σ
+      simpa [smul_eq_mul] using P.mpv_toTensor_eq_sum_coeff (N := N) σ
+    have hBstate :
+        mpvState (d := d) P.toTensor N =
+          ∑ k : Fin g, cB k • mpvState (d := d) (B k) N :=
+      mpvState_eq_sum_of_decomp (d := d) P.toTensor B cB (hcB)
+    have hPBsum :
+        (∑ j : Fin P.basisCount, P.coeff N j •
+            mpvState (d := d) (P.basis j) N) =
+          ∑ k : Fin g, cB k • mpvState (d := d) (B k) N :=
+      hPstate.symm.trans hBstate
+    let sumT : MPVSpace d N :=
+      ∑ t : {j : Fin P.basisCount // j ∈ T}, P.coeff N t.1 •
+        mpvState (d := d) (P.basis t.1) N
+    let sumC : MPVSpace d N :=
+      ∑ c : {j : Fin P.basisCount // j ∉ T}, P.coeff N c.1 •
+        mpvState (d := d) (P.basis c.1) N
+    let sumB : MPVSpace d N :=
+      ∑ k : Fin g, cB k • mpvState (d := d) (B k) N
+    let agg : Fin g → ℂ := fun k =>
+      ∑ c : {j : Fin P.basisCount // j ∉ T},
+        if kOf c = k then P.coeff N c.1 * αOf c N else 0
+    let sumAgg : MPVSpace d N :=
+      ∑ k : Fin g, agg k • mpvState (d := d) (B k) N
+    have hSplitP : sumT + sumC = sumB := by
+      have hsplit :=
+        Fintype.sum_subtype_add_sum_subtype
+          (p := fun j : Fin P.basisCount => j ∈ T)
+          (f := fun j : Fin P.basisCount =>
+            P.coeff N j • mpvState (d := d) (P.basis j) N)
+      exact hsplit.trans hPBsum
+    have hCSubst :
+        sumC = ∑ c : {j : Fin P.basisCount // j ∉ T},
+          (P.coeff N c.1 * αOf c N) •
+            mpvState (d := d) (B (kOf c)) N := by
+      refine Finset.sum_congr rfl ?_
+      intro c _
+      calc
+        P.coeff N c.1 • mpvState (d := d) (P.basis c.1) N =
+            P.coeff N c.1 •
+              (αOf c N • mpvState (d := d) (B (kOf c)) N) := by
+                rw [hStateOf c N hNpos]
+        _ = (P.coeff N c.1 * αOf c N) •
+              mpvState (d := d) (B (kOf c)) N := by
+                rw [smul_smul]
+    have hCGroup :
+        (∑ c : {j : Fin P.basisCount // j ∉ T},
+          (P.coeff N c.1 * αOf c N) •
+            mpvState (d := d) (B (kOf c)) N) = sumAgg := by
+      simpa [sumAgg, agg] using
+        (sum_fiber_smul (φ := kOf)
+          (a := fun c : {j : Fin P.basisCount // j ∉ T} =>
+            P.coeff N c.1 * αOf c N)
+          (v := fun k : Fin g => mpvState (d := d) (B k) N))
+    have hMain : sumT + sumAgg = sumB := by
+      calc
+        sumT + sumAgg = sumT + sumC := by rw [← hCGroup, ← hCSubst]
+        _ = sumB := hSplitP
+    let coeff : Sum {j : Fin P.basisCount // j ∈ T} (Fin g) → ℂ :=
+      Sum.elim (fun t => P.coeff N t.1) (fun k => agg k - cB k)
+    have hZeroCombined :
+        ∑ x : Sum {j : Fin P.basisCount // j ∈ T} (Fin g),
+          coeff x •
+            Sum.elim
+              (fun t : {j : Fin P.basisCount // j ∈ T} =>
+                mpvState (d := d) (P.basis t.1) N)
+              (fun k : Fin g => mpvState (d := d) (B k) N) x = 0 := by
+      have hBsub :
+          (∑ k : Fin g, (agg k - cB k) • mpvState (d := d) (B k) N) =
+            sumAgg - sumB := by
+        simp [sumAgg, sumB, sub_smul, Finset.sum_sub_distrib]
+      have hZero :
+          sumT +
+            (∑ k : Fin g, (agg k - cB k) • mpvState (d := d) (B k) N) = 0 := by
+        calc
+          sumT +
+              (∑ k : Fin g, (agg k - cB k) • mpvState (d := d) (B k) N) =
+              sumT + (sumAgg - sumB) := by rw [hBsub]
+          _ = (sumT + sumAgg) - sumB := by abel
+          _ = 0 := sub_eq_zero.mpr hMain
+      simpa [coeff, sumT] using hZero
+    have hcoeff :=
+      Fintype.linearIndependent_iff.mp hLIN coeff hZeroCombined
+        (Sum.inl ⟨j₀, hj₀T⟩)
+    simpa [coeff] using hcoeff
+  exact (P.coeff_not_eventually_zero j₀) hCoeffEventuallyZero
+
+/-- The all-active-block form of the CPSV16 basis characterization. -/
+private theorem isCPSVBasisOfNormalTensors_iff_active_blocks_covered_and_minimal
+    {r g : ℕ} {dimCF : Fin r → ℕ} {dimB : Fin g → ℕ}
+    [∀ k, NeZero (dimCF k)] [∀ j, NeZero (dimB j)]
+    (A : MPSTensor d D) (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dimCF k))
+    (basis : (j : Fin g) → MPSTensor d (dimB j))
+    (hBlocksNormal : ∀ k, IsNormalTensor (blocks k))
+    (hμne : ∀ k, μ k ≠ 0)
+    (hCF : SameMPV₂Pos A (toTensorFromBlocks (d := d) μ blocks)) :
+    IsCPSVBasisOfNormalTensors A (fun j => ⟨dimB j, basis j⟩) ↔
+      (∀ j, IsNormalTensor (basis j)) ∧
+      (∀ k : Fin r, ∃ j : Fin g, ∃ hdim : dimB j = dimCF k,
+        ∃ X : GL (Fin (dimCF k)) ℂ, ∃ ζ : ℂ, ‖ζ‖ = 1 ∧
+          ∀ i, blocks k i = ζ •
+            ((X : Matrix (Fin (dimCF k)) (Fin (dimCF k)) ℂ) *
+              (cast (congr_arg (MPSTensor d) hdim) (basis j)) i *
+              (↑(X⁻¹) : Matrix (Fin (dimCF k)) (Fin (dimCF k)) ℂ))) ∧
+      (∀ j k : Fin g, j ≠ k → ∀ hdim : dimB j = dimB k,
+        ¬ ∃ X : GL (Fin (dimB k)) ℂ, ∃ ζ : ℂ, ‖ζ‖ = 1 ∧
+          ∀ i, basis k i = ζ •
+            ((X : Matrix (Fin (dimB k)) (Fin (dimB k)) ℂ) *
+              (cast (congr_arg (MPSTensor d) hdim) (basis j)) i *
+              (↑(X⁻¹) : Matrix (Fin (dimB k)) (Fin (dimB k)) ℂ))) := by
+  classical
+  constructor
+  · intro hBNT
+    have hBasisNormal := hBNT.blocks_normal
+    have hBasisDistinct := hBNT.blocks_not_gaugePhaseEquiv
+    refine ⟨hBasisNormal, ?_, ?_⟩
+    · let classes := mpvPhaseClassData blocks
+      let P := collapsedBntSectorDecomp (d := d) μ blocks hμne
+      have hPBasis : ∀ j : Fin P.basisCount,
+          P.basis j = blocks (classes.repr j) := by
+        intro j
+        rfl
+      have hPBasisDim : ∀ j : Fin P.basisCount,
+          P.basisDim j = dimCF (classes.repr j) := by
+        intro j
+        rfl
+      letI : ∀ j : Fin P.basisCount, NeZero (P.basisDim j) := fun j => by
+        rw [hPBasisDim j]
+        infer_instance
+      have hPNormal : ∀ j : Fin P.basisCount, IsNormalTensor (P.basis j) := by
+        intro j
+        rw [hPBasis j]
+        exact hBlocksNormal (classes.repr j)
+      have hPDistinct : BlocksNotGaugePhaseEquiv (d := d) P.basis := by
+        simpa [P, classes, collapsedBntSectorDecomp] using classes.blocks_not_equiv
+      have hPA : SameMPV₂Pos P.toTensor A :=
+        (collapsedBntSectorDecomp_sameMPV₂Pos (d := d) μ blocks hμne).trans hCF.symm
+      have hPBNT :
+          IsCPSVBasisOfNormalTensors P.toTensor
+            (fun j => ⟨dimB j, basis j⟩) := by
+        refine {
+          blocks_normal := hBNT.blocks_normal
+          spans_mpv := ?_
+          eventually_li := hBNT.eventually_li
+        }
+        · intro N hN
+          obtain ⟨c, hc⟩ := hBNT.spans_mpv N hN
+          refine ⟨c, fun σ => ?_⟩
+          rw [hPA N hN σ]
+          exact hc σ
+      intro k
+      obtain ⟨jClass, q, hEnum⟩ := classes.exists_enum_eq k
+      obtain ⟨jBasis, hRepBasis⟩ :=
+        exists_phase_match_of_isCPSVBasisOfNormalTensors basis
+          hPNormal hPDistinct hBasisNormal hPBNT jClass
+      have hBasisRep : MPVBlockPhaseEquiv (basis jBasis) (blocks (classes.repr jClass)) := by
+        rw [← hPBasis jClass]
+        exact hRepBasis.symm
+      have hRepBlock : MPVBlockPhaseEquiv (blocks (classes.repr jClass)) (blocks k) := by
+        rw [← hEnum]
+        exact classes.enum_phase jClass q
+      have hBasisBlock : MPVBlockPhaseEquiv (basis jBasis) (blocks k) :=
+        hBasisRep.trans hRepBlock
+      obtain ⟨hdim, hGPE⟩ :=
+        hBasisBlock.dim_eq_and_gaugePhaseEquiv_of_isNormalTensor
+          (hBasisNormal jBasis) (hBlocksNormal k)
+      obtain ⟨X, ζ, hζ, hrel⟩ := hGPE
+      have hζnorm : ‖ζ‖ = 1 :=
+        norm_eq_one_of_gaugePhase_cast_of_isNormalTensor
+          (hBasisNormal jBasis) (hBlocksNormal k) hdim hrel
+      exact ⟨jBasis, hdim, X, ζ, hζnorm, hrel⟩
+    · intro j k hjk hdim hUnit
+      obtain ⟨X, ζ, hζnorm, hrel⟩ := hUnit
+      exact hBasisDistinct j k hjk hdim
+        ⟨X, ζ, norm_ne_zero_iff.mp (by rw [hζnorm]; exact one_ne_zero), hrel⟩
+  · rintro ⟨hBasisNormal, hCover, hUnitDistinct⟩
+    have hDistinct : BlocksNotGaugePhaseEquiv (d := d) basis := by
+      intro j k hjk hdim hGPE
+      obtain ⟨X, ζ, _hζ, hrel⟩ := hGPE
+      apply hUnitDistinct j k hjk hdim
+      exact ⟨X, ζ,
+        norm_eq_one_of_gaugePhase_cast_of_isNormalTensor
+          (hBasisNormal j) (hBasisNormal k) hdim hrel,
+        hrel⟩
+    choose jOf hdimOf XOf ζOf hζnormOf hrelOf using hCover
+    have hGPE : ∀ k : Fin r,
+        GaugePhaseEquiv
+          (cast (congr_arg (MPSTensor d) (hdimOf k)) (basis (jOf k)))
+          (blocks k) := fun k =>
+      ⟨XOf k, ζOf k,
+        norm_ne_zero_iff.mp (by rw [hζnormOf k]; exact one_ne_zero), hrelOf k⟩
+    have hPhase : ∀ k : Fin r,
+        MPVBlockPhaseEquiv (basis (jOf k)) (blocks k) := fun k =>
+      MPVBlockPhaseEquiv.of_gaugePhaseEquiv_cast
+        (basis (jOf k)) (blocks k) (hdimOf k) (hGPE k)
+    choose ζ hζ hmpv using hPhase
+    refine {
+      blocks_normal := hBasisNormal
+      spans_mpv := ?_
+      eventually_li :=
+        exists_eventually_linearIndependent_of_normalTensor_blocks_not_gaugePhaseEquiv
+          basis hBasisNormal hDistinct
+    }
+    intro N hN
+    let c : Fin g → ℂ := fun j =>
+      ∑ k : Fin r, if jOf k = j then (μ k * ζ k) ^ N else 0
+    refine ⟨c, ?_⟩
+    intro σ
+    calc
+      mpv A σ = mpv (toTensorFromBlocks (d := d) μ blocks) σ := hCF N hN σ
+      _ = ∑ k : Fin r, (μ k) ^ N * mpv (blocks k) σ := by
+        simpa [smul_eq_mul] using mpv_toTensorFromBlocks_eq_sum μ blocks σ
+      _ = ∑ k : Fin r, (μ k * ζ k) ^ N * mpv (basis (jOf k)) σ := by
+        refine Finset.sum_congr rfl ?_
+        intro k _
+        rw [hmpv k N hN σ, mul_pow]
+        ring
+      _ = ∑ j : Fin g, c j * mpv (basis j) σ := by
+        have hGroup :=
+          sum_fiber_smul (φ := jOf)
+            (a := fun k : Fin r => (μ k * ζ k) ^ N)
+            (v := fun j : Fin g => mpvState (d := d) (basis j) N)
+        have hComponent := congrArg (fun v : MPVSpace d N => v σ) hGroup
+        simpa [c, mpvState_apply, PiLp.smul_apply, smul_eq_mul] using hComponent
+
+/-- Characterization of a basis of normal tensors by coverage of the active
+normal canonical-form summands and minimality under gauge-phase equivalence.
+
+This is arXiv:1606.00608, Proposition 2.7 (`prop:char-BNT`, lines 271--280
+and 1135--1146).
+
+**Local fix (active CF blocks and candidate normality):** Definition
+`eq:II_CF1` at lines 238--244 permits zero weights syntactically, although the
+construction at lines 214--225 lists the nonzero blocks and normalizes their
+completely positive maps. Accordingly, coverage is required precisely when
+the displayed weight is nonzero. Candidate normality, which is part of the BNT
+definition at lines 271--274, is stated on the characterized side of the iff.
+See `docs/paper-gaps/cpsv16_bnt_characterization_active_blocks.tex`. -/
+theorem isCPSVBasisOfNormalTensors_iff_canonicalForm_covered_and_minimal
+    {r g : ℕ} {dimCF : Fin r → ℕ} {dimB : Fin g → ℕ}
+    [∀ k, NeZero (dimCF k)] [∀ j, NeZero (dimB j)]
+    (A : MPSTensor d D) (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dimCF k))
+    (basis : (j : Fin g) → MPSTensor d (dimB j))
+    (hBlocksNormal : ∀ k, IsNormalTensor (blocks k))
+    (hCF : SameMPV₂Pos A (toTensorFromBlocks (d := d) μ blocks)) :
+    IsCPSVBasisOfNormalTensors A (fun j ↦ ⟨dimB j, basis j⟩) ↔
+      (∀ j, IsNormalTensor (basis j)) ∧
+      (∀ k : Fin r, μ k ≠ 0 →
+        ∃ j : Fin g, ∃ hdim : dimB j = dimCF k,
+        ∃ X : GL (Fin (dimCF k)) ℂ, ∃ ζ : ℂ, ‖ζ‖ = 1 ∧
+          ∀ i, blocks k i = ζ •
+            ((X : Matrix (Fin (dimCF k)) (Fin (dimCF k)) ℂ) *
+              (cast (congr_arg (MPSTensor d) hdim) (basis j)) i *
+              (↑(X⁻¹) : Matrix (Fin (dimCF k)) (Fin (dimCF k)) ℂ))) ∧
+      (∀ j k : Fin g, j ≠ k → ∀ hdim : dimB j = dimB k,
+        ¬ ∃ X : GL (Fin (dimB k)) ℂ, ∃ ζ : ℂ, ‖ζ‖ = 1 ∧
+          ∀ i, basis k i = ζ •
+            ((X : Matrix (Fin (dimB k)) (Fin (dimB k)) ℂ) *
+              (cast (congr_arg (MPSTensor d) hdim) (basis j)) i *
+              (↑(X⁻¹) : Matrix (Fin (dimB k)) (Fin (dimB k)) ℂ))) := by
+  classical
+  let Active := {k : Fin r // μ k ≠ 0}
+  let activeEquiv : Fin (Fintype.card Active) ≃ Active :=
+    (Fintype.equivFin Active).symm
+  let dimActive : Fin (Fintype.card Active) → ℕ :=
+    fun k ↦ dimCF (activeEquiv k)
+  let μActive : Fin (Fintype.card Active) → ℂ :=
+    fun k ↦ μ (activeEquiv k)
+  let blocksActive : (k : Fin (Fintype.card Active)) → MPSTensor d (dimActive k) :=
+    fun k ↦ blocks (activeEquiv k)
+  letI : ∀ k, NeZero (dimActive k) := fun k ↦ by
+    simp only [dimActive]
+    infer_instance
+  have hActiveNormal : ∀ k, IsNormalTensor (blocksActive k) := by
+    intro k
+    exact hBlocksNormal (activeEquiv k)
+  have hμActive : ∀ k, μActive k ≠ 0 := by
+    intro k
+    exact (activeEquiv k).property
+  have hActiveCF :
+      SameMPV₂Pos A (toTensorFromBlocks (d := d) μActive blocksActive) := by
+    intro N hN σ
+    rw [hCF N hN σ]
+    rw [mpv_toTensorFromBlocks_eq_sum, mpv_toTensorFromBlocks_eq_sum]
+    simp only [smul_eq_mul]
+    let f : Fin r → ℂ := fun k ↦ μ k ^ N * mpv (blocks k) σ
+    have hInactive : ∑ k : {k : Fin r // ¬ μ k ≠ 0}, f k = 0 := by
+      apply Fintype.sum_eq_zero
+      intro k
+      simp [f, not_ne_iff.mp k.property, Nat.ne_of_gt hN]
+    have hSplit :=
+      Fintype.sum_subtype_add_sum_subtype (fun k : Fin r ↦ μ k ≠ 0) f
+    have hActiveSum : (∑ k : Fin r, f k) = ∑ k : Active, f k := by
+      rw [hInactive, add_zero] at hSplit
+      exact hSplit.symm
+    change (∑ k : Fin r, f k) =
+      ∑ k : Fin (Fintype.card Active), f (activeEquiv k)
+    rw [hActiveSum]
+    exact (activeEquiv.sum_comp (fun k : Active ↦ f k)).symm
+  have hCharacterization :=
+    isCPSVBasisOfNormalTensors_iff_active_blocks_covered_and_minimal
+      A μActive blocksActive basis hActiveNormal hμActive hActiveCF
+  constructor
+  · intro hBNT
+    obtain ⟨hBasisNormal, hCover, hDistinct⟩ := hCharacterization.mp hBNT
+    refine ⟨hBasisNormal, ?_, hDistinct⟩
+    intro k hk
+    let kActive : Active := ⟨k, hk⟩
+    let l : Fin (Fintype.card Active) := activeEquiv.symm kActive
+    have hkIndex : k = (activeEquiv l : Fin r) := by
+      change k = (activeEquiv (activeEquiv.symm kActive) : Fin r)
+      exact (congrArg Subtype.val (activeEquiv.apply_symm_apply kActive)).symm
+    rw [hkIndex]
+    simpa only [dimActive, blocksActive] using hCover l
+  · rintro ⟨hBasisNormal, hCover, hDistinct⟩
+    apply hCharacterization.mpr
+    refine ⟨hBasisNormal, ?_, hDistinct⟩
+    intro k
+    simpa [dimActive, blocksActive] using
+      hCover (activeEquiv k) (activeEquiv k).property
+
+end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Basic.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Basic.lean
@@ -182,33 +182,8 @@ positivity of `P.copies j` (i.e. `∑_q 1 = P.copies j ≠ 0`).
 -/
 lemma coeff_not_eventually_zero
     (_h : IsBNTCanonicalForm P) (j : Fin P.basisCount) :
-    ¬ (∀ᶠ N in Filter.atTop, P.coeff N j = 0) := by
-  classical
-  intro hEv
-  -- Extract an explicit threshold `M` past which the power sum vanishes.
-  rw [Filter.eventually_atTop] at hEv
-  obtain ⟨M, hM⟩ := hEv
-  -- Apply `geom_sum_eventually_zero` with weights `P.weight j` (all nonzero)
-  -- and constants `c q = 1`, to conclude vanishing at every exponent.
-  have hwne : ∀ q : Fin (P.copies j), P.weight j q ≠ 0 :=
-    fun q => P.weight_ne_zero j q
-  have hAll : ∀ k, ∑ q : Fin (P.copies j), (1 : ℂ) * (P.weight j q) ^ k = 0 := by
-    refine SectorWeightData.geom_sum_eventually_zero
-      (w := P.weight j) (c := fun _ => 1) hwne (M := M) ?_
-    intro N hN
-    have hzero : P.coeff N j = 0 := hM N hN
-    -- `∑ q, 1 * w^N = ∑ q, w^N = coeff`.
-    simpa [SectorDecomposition.coeff, SectorWeightData.coeff, one_mul] using hzero
-  -- Specialize at `k = 0` to get `(P.copies j : ℂ) = 0`, contradicting positivity.
-  have h0 := hAll 0
-  -- `∑ q, 1 * w^0 = ∑ q, 1 = P.copies j`.
-  have hcard : (∑ _q : Fin (P.copies j), (1 : ℂ) * (P.weight j _q) ^ 0)
-      = (P.copies j : ℂ) := by
-    simp
-  rw [hcard] at h0
-  -- But `0 < P.copies j` rules out `(P.copies j : ℂ) = 0`.
-  have hpos : 0 < P.copies j := P.copies_pos j
-  exact (Nat.cast_ne_zero.mpr hpos.ne') h0
+    ¬ (∀ᶠ N in Filter.atTop, P.coeff N j = 0) :=
+  P.coeff_not_eventually_zero j
 
 end IsBNTCanonicalForm
 

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/ExactMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/ExactMatch.lean
@@ -24,32 +24,6 @@ namespace MPSTensor
 
 variable {d : ℕ}
 
-/-- Re-index a sum over a finite family through a finite map by collecting the
-coefficients in the fibres of the map. -/
-lemma sum_fiber_smul
-    {ι κ V : Type*} [Fintype ι] [Fintype κ] [DecidableEq κ]
-    [AddCommMonoid V] [Module ℂ V]
-    (φ : ι → κ) (a : ι → ℂ) (v : κ → V) :
-    (∑ i : ι, a i • v (φ i)) =
-      ∑ k : κ, (∑ i : ι, if φ i = k then a i else 0) • v k := by
-  classical
-  calc
-    (∑ i : ι, a i • v (φ i))
-        = ∑ i : ι, ∑ k : κ, (if φ i = k then a i else 0) • v k := by
-          refine Finset.sum_congr rfl ?_
-          intro i _
-          have hinner :
-              (∑ k : κ, (if φ i = k then a i else 0) • v k)
-                = a i • v (φ i) := by
-            simp [ite_smul, eq_comm]
-          exact hinner.symm
-    _ = ∑ k : κ, ∑ i : ι, (if φ i = k then a i else 0) • v k := by
-          rw [Finset.sum_comm]
-    _ = ∑ k : κ, (∑ i : ι, if φ i = k then a i else 0) • v k := by
-          refine Finset.sum_congr rfl ?_
-          intro k _
-          rw [Finset.sum_smul]
-
 /-- If the overlap of two irreducible normalized BNT blocks does not decay,
 then the left MPV state is an exact scalar multiple of the right MPV state at
 every length. -/

--- a/TNLean/MPS/FundamentalTheorem/SectorWeightComparison.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorWeightComparison.lean
@@ -169,4 +169,36 @@ lemma power_sums_eq_of_eventually_eq_hetero
 
 end SectorWeightData
 
+namespace SectorDecomposition
+
+/-- A sector coefficient with nonzero copy weights cannot vanish at all
+sufficiently large exponents.
+
+This is the coefficient nonvanishing used in the CPSV16 Appendix MPV argument,
+lines 1182--1188. If the coefficient vanished eventually, geometric
+extrapolation would make it vanish at exponent zero, where it equals the
+positive number of copies in the sector. -/
+lemma coeff_not_eventually_zero (P : SectorDecomposition d)
+    (j : Fin P.basisCount) :
+    ¬ (∀ᶠ N in Filter.atTop, P.coeff N j = 0) := by
+  classical
+  intro hEv
+  rw [Filter.eventually_atTop] at hEv
+  obtain ⟨M, hM⟩ := hEv
+  have hAll : ∀ k,
+      ∑ q : Fin (P.copies j), (1 : ℂ) * (P.weight j q) ^ k = 0 := by
+    refine SectorWeightData.geom_sum_eventually_zero
+      (w := P.weight j) (c := fun _ ↦ 1) (P.weight_ne_zero j) (M := M) ?_
+    intro N hN
+    simpa [SectorDecomposition.coeff, SectorWeightData.coeff] using hM N hN
+  have h0 := hAll 0
+  have hcard :
+      (∑ q : Fin (P.copies j), (1 : ℂ) * (P.weight j q) ^ 0) =
+        (P.copies j : ℂ) := by
+    simp
+  rw [hcard] at h0
+  exact (Nat.cast_ne_zero.mpr (P.copies_pos j).ne') h0
+
+end SectorDecomposition
+
 end MPSTensor

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -40,6 +40,125 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
     block MPVs $\{\ket{V^{(N)}(A_j)}\}$ are eventually linearly independent.
 \end{definition}
 
+\begin{theorem}[Distinct BNT members are not gauge-phase equivalent]
+    \label{thm:cpsv_bnt_blocks_not_gaugePhaseEquiv}
+    \lean{MPSTensor.IsCPSVBasisOfNormalTensors.blocks_not_gaugePhaseEquiv}
+    \leanok
+    \uses{def:bnt_cpsv, def:blocks_not_gauge_phase_equiv}
+    Distinct members of a basis of normal tensors are not gauge-phase
+    equivalent after identifying equal bond dimensions.
+\end{theorem}
+
+\begin{proof}\leanok
+    At every sufficiently large length the matrix product vectors of the basis
+    members are linearly independent. A gauge-phase equivalence between two
+    distinct members would make one of these vectors a nonzero scalar multiple
+    of the other, a contradiction.
+\end{proof}
+
+\begin{theorem}[Characterization by canonical-form representatives]
+    \label{thm:cpsv_bnt_characterization}
+    \lean{MPSTensor.isCPSVBasisOfNormalTensors_iff_canonicalForm_covered_and_minimal}
+    \leanok
+    \uses{def:bnt_cpsv, def:nt_cpsv, def:block_diagonal_tensor,
+        def:same_mpv2_pos, def:blocks_not_gauge_phase_equiv}
+    Let $A$ have a canonical-form MPV expansion
+    \[
+        \ket{V^{(N)}(A)}
+        = \sum_{k=1}^{r}\mu_k^N\ket{V^{(N)}(\widetilde A_k)}
+    \]
+    at every positive length, where the tensors $\widetilde A_k$ are normal
+    tensors of positive bond dimension. Set
+    $K_{\mathrm{act}}=\{k:\mu_k\ne0\}$. Let $(A_j)_{j=1}^{g}$ be tensors of
+    positive bond dimension. Then
+    $(A_j)_{j=1}^{g}$ is a basis of normal tensors for $A$ if and only if:
+    \begin{enumerate}
+        \item every $A_j$ is normal;
+        \item for every $k\in K_{\mathrm{act}}$ there are an index $j$, an
+              invertible matrix $X_k$, and a phase $e^{i\phi_k}$ such that
+              \[
+                  \widetilde A_k^i
+                  = e^{i\phi_k}X_kA_j^iX_k^{-1}
+              \]
+              for every physical index $i$;
+        \item no two distinct tensors $A_j$ and $A_{j'}$ are related in this
+              way.
+    \end{enumerate}
+    This is \cite[Proposition~2.7]{Cirac2016MPDO_arXiv}, with the literal
+    canonical-form display restricted to its active blocks as explained in
+    \path{docs/paper-gaps/cpsv16_bnt_characterization_active_blocks.tex}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:cpsv_normal_mpv_phase_gauge,
+        thm:cpsv_normal_mpv_phase_alternative,
+        thm:cpsv_bnt_blocks_not_gaugePhaseEquiv,
+        lem:bnt_finite_index_overlap_orthonormal_li,
+        lem:finite_geometric_sum_eventual_vanishing,
+        lem:sector_decomposition_coeff_not_eventually_zero,
+        def:mpv_phase_class_data,
+        thm:cpsv_normal_separated_eventually_li,
+        thm:mpv_decomposition}
+    First discard the zero-weight summands; they contribute zero at every
+    positive length. Reindex the remaining summands, group them into MPV phase
+    classes, and choose one representative from each class. By
+    Theorem~\ref{thm:cpsv_bnt_blocks_not_gaugePhaseEquiv}, eventual linear
+    independence of a BNT excludes gauge-phase equivalence between two
+    distinct $A_j$.
+
+    Suppose that some phase-class representative is not gauge-phase equivalent
+    to any $A_j$. Partition all phase classes into the unmatched classes $T$
+    and the remaining classes. Every remaining representative is a nonzero
+    scalar multiple of some $\ket{V^{(N)}(A_j)}$ at each positive length.
+    Distinct unmatched representatives have vanishing mutual overlaps, and
+    their overlaps with every $A_j$ also vanish. Explicitly, for $t\ne t'$ in
+    $T$ and every $j$,
+    \[
+        O_{\widetilde A_t\widetilde A_{t'}}(N)\longrightarrow0,
+        \qquad
+        O_{\widetilde A_t A_j}(N)\longrightarrow0.
+    \]
+    The Gram-matrix criterion therefore makes the combined family
+    \[
+        \{\ket{V^{(N)}(\widetilde A_t)}:t\in T\}
+        \cup \{\ket{V^{(N)}(A_j)}:1\leq j\leq g\}
+    \]
+    linearly independent for all sufficiently large $N$. Comparing the
+    canonical-form expansion with the BNT expansion gives a relation
+    \[
+        \sum_{t\in T}c_{N,t}\ket{V^{(N)}(\widetilde A_t)}
+        +\sum_{j=1}^{g}\alpha_{N,j}\ket{V^{(N)}(A_j)}=0.
+    \]
+    Linear independence forces every $c_{N,t}$ to vanish. Hence the
+    coefficient of every unmatched phase class vanishes for all sufficiently
+    large $N$.
+    Such a coefficient has the form
+    \[
+        \sum_q (\zeta_q\mu_q)^N.
+    \]
+    Every base $\zeta_q\mu_q$ is nonzero because only active summands occur.
+    Eventual vanishing of this finite geometric sum would imply vanishing at
+    $N=0$, where its value is the positive number of summands in the class.
+    This contradiction proves coverage. The normal-tensor phase theorem turns
+    the resulting MPV phase relation into the stated gauge-phase relation.
+
+    Conversely, coverage gives, for each canonical-form summand,
+    \[
+        \ket{V^{(N)}(\widetilde A_k)}
+        = \zeta_k^N\ket{V^{(N)}(A_{j(k)})}.
+    \]
+    Hence
+    \[
+        \ket{V^{(N)}(A)}
+        = \sum_j
+            \left(\sum_{k:j(k)=j}(\mu_k\zeta_k)^N\right)
+            \ket{V^{(N)}(A_j)},
+    \]
+    which is the required BNT span at every positive length. Pairwise
+    gauge-phase distinction and normality give eventual linear independence,
+    completing the converse.
+\end{proof}
+
 \begin{lemma}[Perron gauges preserve primitivity]
     \label{lem:perron_gauge_primitive_iff}
     \lean{MPSTensor.isPrimitive_transferMap_tpGauge_iff}
@@ -1831,22 +1950,37 @@ with a basis sector of the other. The non-vanishing of the sector coefficients
 isolates the matched sector exactly, with no limit of a single-sector
 projection.
 
+\begin{lemma}[Sector-decomposition coefficient is not eventually zero]
+    \label{lem:sector_decomposition_coeff_not_eventually_zero}
+    \lean{MPSTensor.SectorDecomposition.coeff_not_eventually_zero}
+    \leanok
+    \uses{def:sector_weight_data,
+        lem:finite_geometric_sum_eventual_vanishing}
+    For any sector decomposition $P$ and any sector $j$, the coefficient
+    $c_{P,j}^{(N)}=\sum_q\mu_{j,q}^N$ is not eventually zero in $N$.
+\end{lemma}
+
+\begin{proof}\leanok
+    If the coefficient vanished for every $N\geq M$, the finite geometric-sum
+    extrapolation would make it vanish at every nonnegative exponent. At
+    exponent zero it is the positive number of copies in sector $j$, which is
+    impossible.
+\end{proof}
+
 \begin{lemma}[Sector coefficient is not eventually zero]
     \label{lem:sector_bnt_coeff_not_eventually_zero}
     \lean{MPSTensor.IsBNTCanonicalForm.coeff_not_eventually_zero}
     \leanok
-    \uses{def:sector_bnt_cf}
+    \uses{def:sector_bnt_cf,
+        lem:sector_decomposition_coeff_not_eventually_zero}
     For a BNT canonical form $P$ and any sector $j$, the sector coefficient
     $c_{P,j}^{(N)} = \sum_q \mu_{j,q}^N$ is not eventually zero in $N$. Only
     nonvanishing of the copy weights is used, not any modulus condition.
 \end{lemma}
 
 \begin{proof}\leanok
-    If $c_{P,j}^{(N)} = 0$ for all $N \ge M$, the signed geometric-sequence
-    vanishing lemma forces $\sum_q \mu_{j,q}^k = 0$ at every exponent $k$, in
-    particular $\sum_q 1 = r_j = 0$ at $k=0$, contradicting $r_j > 0$. Repeated
-    ratios are handled by the same extrapolation, so distinct weights are not
-    needed.
+    Apply Lemma~\ref{lem:sector_decomposition_coeff_not_eventually_zero}; its
+    conclusion does not require the canonical-form assumptions.
 \end{proof}
 
 \begin{theorem}[Exact single-sector matching]

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -105,6 +105,10 @@ For MPDO renormalization fixed points:
 
 For the non-periodic MPS Fundamental Theorem background:
 
+- `cpsv16_bnt_characterization_active_blocks.tex` records the local correction
+  to the BNT characterization: coverage concerns precisely the nonzero-weight
+  canonical-form blocks, while candidate normality from Definition 2.4 appears
+  explicitly on the characterized side of the equivalence.
 - `canonical_bnt_ft_theorem_surface.tex` separates paper-level theorem
   statements from auxiliary formal declarations.
 - `nonperiodic_mps_bnt_comparison_inputs.tex` compares the current

--- a/docs/paper-gaps/cpsv16_bnt_characterization_active_blocks.tex
+++ b/docs/paper-gaps/cpsv16_bnt_characterization_active_blocks.tex
@@ -1,0 +1,79 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Active Canonical-Form Blocks in the BNT Characterization}
+\author{}
+\date{2026-07-18}
+
+\begin{document}
+\maketitle
+
+\section{The two source formulations}
+
+Cirac--P\'erez-Garc\'ia--Schuch--Verstraete construct the canonical form by
+listing the invariant blocks of the completely positive map and normalizing
+each block separately \cite[lines 214--225]{Cirac2016MPDO_arXiv}. Thus the
+blocks produced by the construction are precisely the blocks which occur in
+the tensor. The subsequent displayed definition
+\cite[lines 238--244]{Cirac2016MPDO_arXiv}, however, writes
+\begin{align}
+    A^i=\bigoplus_{k=1}^r \mu_k A_k^i
+    \tag{\path{eq:II_CF1}}
+\end{align}
+without explicitly requiring every $\mu_k$ to be nonzero. Read literally, this
+display also permits a listed block with zero weight. Such a block contributes
+nothing to any positive-length matrix product vector.
+
+The source definition of a basis of normal tensors
+\cite[lines 271--274]{Cirac2016MPDO_arXiv} requires, as its first condition,
+that every candidate representative $A_j$ is normal. Proposition~2.7 then
+characterizes the basis by coverage of the canonical-form blocks and pairwise
+gauge-phase distinction \cite[lines 278--280 and 1135--1146]
+{Cirac2016MPDO_arXiv}. Its displayed right-hand side does not repeat candidate
+normality, because that condition is already part of the term ``basis of
+normal tensors.''
+
+\section{The local correction}
+
+To state an equivalence which is valid under the literal displayed
+canonical-form hypothesis, let
+\begin{align}
+    K_{\mathrm{act}}=\{k:\mu_k\ne0\}.
+\end{align}
+Coverage is required exactly for $k\in K_{\mathrm{act}}$. Removing the other
+indices leaves every positive-length matrix product vector unchanged, since
+$\mu_k^N=0$ whenever $N>0$ and $\mu_k=0$. The active family has nonzero
+weights and therefore satisfies the hypothesis needed by the source
+phase-class argument.
+
+Candidate normality is placed explicitly on the characterized side of the
+equivalence. The resulting statement says that a candidate family is a basis
+of normal tensors if and only if
+\begin{enumerate}
+    \item every candidate representative is normal;
+    \item every active canonical-form block is gauge-phase equivalent to a
+          candidate representative; and
+    \item distinct candidate representatives are not gauge-phase equivalent.
+\end{enumerate}
+The third condition is the source notion of minimality. No converse coverage
+condition is added: Definition~2.4 permits an additional normal representative
+whose coefficient is identically zero, provided the full candidate family is
+eventually linearly independent.
+
+This correction is recorded in the declaration
+\path{MPSTensor.isCPSVBasisOfNormalTensors_iff_canonicalForm_covered_and_minimal}.
+It reconciles the literal canonical-form display with the constructive
+nonzero-block reading and makes the normality condition from Definition~2.4
+visible in the equivalence. It does not strengthen or weaken the mathematical
+characterization of the active canonical-form blocks.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
### Motivation

- CPSV16 Proposition `prop:char-BNT` characterizes a basis of normal tensors by coverage of every normal canonical-form summand and minimality under unit-phase gauge equivalence (`Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 271--280 and 1135--1146).
- TNLean already contained the normal-overlap dichotomy, phase-class decomposition, and eventual linear-independence results, but it did not state the source proposition as an iff for an arbitrary displayed canonical-form expansion.

### Description

- Add `MPSTensor.isCPSVBasisOfNormalTensors_iff_canonicalForm_covered_and_minimal`. For arbitrary canonical-form weights and normal positive-dimensional summands, it proves that a candidate family is a CPSV basis of normal tensors exactly when every candidate is normal, every nonzero-weight summand is related to a candidate by an invertible gauge and a scalar of modulus one, and distinct candidates are not related in this way. The proof restricts internally to the active support `{k // μ k ≠ 0}`; the paper-gap note records the literal displayed-CF versus constructed-CF distinction.
- Prove the forward coverage statement by collapsing canonical-form phase classes, adjoining an assumed unmatched class to the candidate family, and using the normal-overlap dichotomy to obtain eventual linear independence. Equality of the two MPV expansions would then force the unmatched class coefficient to vanish eventually; the finite geometric-sum identity at exponent zero gives the contradiction.
- Prove the converse by transporting each covered summand to its representative, collecting coefficients over the fibres of the representative map, and applying eventual linear independence to the pairwise distinct normal candidates.
- Move the general finite fibre-sum lemma `MPSTensor.sum_fiber_smul` from `SectorBNT/ExactMatch.lean` to `MPS/BNT/Basic.lean`, where both arguments can use it.
- Add the source-faithful Chapter 10 theorem and proof entry, with dependencies on CPSV normality, the displayed block tensor, and positive-length MPV equality.

The sentence at source line 1148 comparing two BNTs for the same canonical form is a separate uniqueness corollary, not part of Proposition `prop:char-BNT`. It remains explicitly tracked in #4196.

This completes the proposition target in #4184 and advances the audits in #2380 and #232 without closing either tracker.

### Testing

- `lake build TNLean.MPS.CanonicalForm.BNTCharacterization TNLean`
- `lake build TNLean` (9,558 jobs)
- `lake exe checkdecls blueprint/lean_decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- Added-line proof-integrity scan for `sorry`, `admit`, `axiom`, `native_decide`, kernel bypasses, and `maxHeartbeats`
- `#print axioms MPSTensor.isCPSVBasisOfNormalTensors_iff_canonicalForm_covered_and_minimal` reports only `propext`, `Classical.choice`, and `Quot.sound`

---
Closes #4184

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new formal proof in core MPS canonical-form/BNT theory with refactors to shared lemmas; mathematical content is additive but touches fundamental theorem infrastructure used downstream.
> 
> **Overview**
> Adds **`TNLean/MPS/CanonicalForm/BNTCharacterization.lean`** and wires it into the root import list. The main result is **`isCPSVBasisOfNormalTensors_iff_canonicalForm_covered_and_minimal`**: a candidate family is a CPSV basis of normal tensors exactly when candidates are normal, every **nonzero-weight** canonical-form block is gauge-phase equivalent to some candidate, and distinct candidates are not gauge-related. The proof follows the paper’s coverage argument (unmatched phase classes + eventual linear independence force vanishing sector coefficients, contradicted by geometric-sum nonvanishing) and the converse (phase transport + **`sum_fiber_smul`** grouping of MPV coefficients).
> 
> Also proves **`IsCPSVBasisOfNormalTensors.blocks_not_gaugePhaseEquiv`** from eventual linear independence.
> 
> **Refactors:** moves **`sum_fiber_smul`** from `SectorBNT/ExactMatch.lean` to **`MPS/BNT/Basic.lean`** for shared use; lifts **`coeff_not_eventually_zero`** to **`SectorDecomposition`** (BNT canonical form delegates to it).
> 
> **Docs:** Chapter 10 blueprint entries for distinct BNT members, the characterization theorem, and sector coefficient nonvanishing; new gap note **`cpsv16_bnt_characterization_active_blocks.tex`** (active blocks + explicit candidate normality).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba3a003d81f17fb6430cdd874353a7479f0d38f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
