### PR TITLE
feat(Algebra): prove commuting-overlap spatial decomposition

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -53,6 +53,7 @@ import TNLean.Algebra.SpinCover
 import TNLean.Algebra.MatrixRankClosed
 import TNLean.Algebra.StarSubalgebraBlockDiagonal
 import TNLean.Algebra.StarSubalgebraBlockForm
+import TNLean.Algebra.CommutingOverlappingDecomp
 import TNLean.Algebra.StarSubalgebraIntertwinerIsometry
 import TNLean.Algebra.StarSubalgebraIrreducibleDecomp
 import TNLean.Algebra.StarSubalgebraIsotypic

--- a/TNLean/Algebra/CommutingOverlappingDecomp.lean
+++ b/TNLean/Algebra/CommutingOverlappingDecomp.lean
@@ -1,0 +1,158 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.StarSubalgebraBlockForm
+
+/-!
+# Commuting overlapping operators
+
+This file begins the matrix passage in the Bravyi--Vyalyi spatial decomposition for two
+commuting overlapping Hermitian operators. It defines their natural embeddings on a
+three-factor space and the middle-factor coefficient matrices obtained by fixing the outer
+indices.
+
+## Main results
+
+* `Matrix.middleSlices_commute_of_overlappingLifts_commute` -- commutation of the two
+  overlapping operators implies pairwise commutation of all their middle-factor coefficient
+  matrices.
+* `Matrix.exists_middle_spatial_decomposition_of_overlappingLifts_commute` -- one
+  orthonormal decomposition of the middle space puts the coefficient families of the two
+  overlapping operators on complementary tensor factors.
+
+## References
+
+* S. Beigi, *Classification of the phases of 1D spin chains with commuting Hamiltonians*,
+  arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`) and its proof on pages 2--3.
+-/
+
+namespace Matrix
+
+variable {a b c : Type*}
+variable [Fintype a] [Fintype b] [Fintype c]
+variable [DecidableEq a] [DecidableEq b] [DecidableEq c]
+
+/-- The natural embedding of an operator on the first two factors into the three-factor
+space.
+
+Source: Beigi, arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`). -/
+def leftOverlappingLift (X : Matrix (a × b) (a × b) ℂ) :
+    Matrix ((a × b) × c) ((a × b) × c) ℂ :=
+  fun p q ↦ X p.1 q.1 * (1 : Matrix c c ℂ) p.2 q.2
+
+/-- The natural embedding of an operator on the last two factors into the three-factor
+space.
+
+Source: Beigi, arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`). -/
+def rightOverlappingLift (Y : Matrix (b × c) (b × c) ℂ) :
+    Matrix ((a × b) × c) ((a × b) × c) ℂ :=
+  fun p q ↦ (1 : Matrix a a ℂ) p.1.1 q.1.1 * Y (p.1.2, p.2) (q.1.2, q.2)
+
+/-- The middle-factor coefficient matrix of an operator on the first two factors, with
+the two first-factor indices fixed.
+
+Source: Beigi, arXiv:1105.1019v2, proof of Lemma 2.1 (`lem:comm`). -/
+def leftMiddleSlice (X : Matrix (a × b) (a × b) ℂ) (i i' : a) : Matrix b b ℂ :=
+  fun j j' ↦ X (i, j) (i', j')
+
+/-- The middle-factor coefficient matrix of an operator on the last two factors, with
+the two last-factor indices fixed.
+
+Source: Beigi, arXiv:1105.1019v2, proof of Lemma 2.1 (`lem:comm`). -/
+def rightMiddleSlice (Y : Matrix (b × c) (b × c) ℂ) (k k' : c) : Matrix b b ℂ :=
+  fun j j' ↦ Y (j, k) (j', k')
+
+omit [Fintype b] [Fintype c] [DecidableEq b] [DecidableEq c] in
+/-- Hermiticity exchanges the two outer indices of a middle-factor coefficient matrix.
+
+Source: Beigi, arXiv:1105.1019v2, proof of Lemma 2.1 (`lem:comm`). -/
+theorem star_rightMiddleSlice (Y : Matrix (b × c) (b × c) ℂ) (hY : Y.IsHermitian)
+    (k k' : c) : star (rightMiddleSlice Y k k') = rightMiddleSlice Y k' k := by
+  ext i j
+  change star (Y (j, k) (i, k')) = Y (i, k') (j, k)
+  exact hY.apply (i, k') (j, k)
+
+omit [DecidableEq b] in
+/-- If two operators on the first--middle and middle--last tensor factors commute after
+their natural embeddings, then every middle-factor coefficient matrix of the first
+operator commutes with every middle-factor coefficient matrix of the second operator.
+
+This is the coefficientwise consequence of
+`[X_{AB} \otimes \mathbf 1_C, \mathbf 1_A \otimes Y_{BC}] = 0` used before the
+finite-dimensional star-algebra decomposition in S. Beigi, arXiv:1105.1019v2,
+proof of Lemma 2.1 (`lem:comm`), pages 2--3. Hermiticity is not needed for this
+coefficientwise implication. -/
+theorem middleSlices_commute_of_overlappingLifts_commute
+    (X : Matrix (a × b) (a × b) ℂ) (Y : Matrix (b × c) (b × c) ℂ)
+    (hComm : leftOverlappingLift X * rightOverlappingLift Y =
+      rightOverlappingLift Y * leftOverlappingLift X) (i i' : a) (k k' : c) :
+    leftMiddleSlice X i i' * rightMiddleSlice Y k k' =
+      rightMiddleSlice Y k k' * leftMiddleSlice X i i' := by
+  ext j j'
+  have h := congrFun (congrFun hComm ((i, j), k)) ((i', j'), k')
+  simpa [leftOverlappingLift, rightOverlappingLift, leftMiddleSlice, rightMiddleSlice,
+    Matrix.mul_apply, Matrix.one_apply, Fintype.sum_prod_type] using h
+
+/-- **Middle-space spatial decomposition for commuting overlapping operators.** Suppose
+operators `X` on the first--middle factors and `Y` on the middle--last factors commute after
+their natural embeddings, and suppose `Y` is Hermitian. There is an orthonormal basis
+`(e_{q,r,s})` of the middle space such that every coefficient matrix of `X` acts on the
+`s` index, identically across `r`, and every coefficient matrix of `Y` acts on the
+complementary `r` index, identically across `s`:
+$$
+ X_{ii'}e_{q,r,s}=\sum_{s'}(B^{ii'}_q)_{s's}e_{q,r,s'},\qquad
+ Y_{kk'}e_{q,r,s}=\sum_{r'}(C^{kk'}_q)_{r'r}e_{q,r',s}.
+$$
+The dimensions of both factors in every summand are positive. Thus, up to the order of the
+two tensor factors, the basis realizes
+`H_B \cong \bigoplus_q H_{q,l}\otimes H_{q,r}` with complementary actions of the two
+operator families.
+
+This is the middle-space conclusion of the Bravyi--Vyalyi decomposition in S. Beigi,
+arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`). The source assumes both `X` and `Y` Hermitian;
+the proof below uses Hermiticity only for `Y`, because it applies the star-subalgebra
+decomposition to the commutant of the coefficient matrices of `Y`. -/
+theorem exists_middle_spatial_decomposition_of_overlappingLifts_commute
+    (X : Matrix (a × b) (a × b) ℂ) (Y : Matrix (b × c) (b × c) ℂ)
+    (hY : Y.IsHermitian)
+    (hComm : leftOverlappingLift X * rightOverlappingLift Y =
+      rightOverlappingLift Y * leftOverlappingLift X) :
+    ∃ (K : ℕ) (d m : Fin K → ℕ)
+      (e : OrthonormalBasis ((q : Fin K) × (Fin (m q) × Fin (d q))) ℂ
+        (EuclideanSpace ℂ b)),
+      (∀ q, 0 < d q) ∧ (∀ q, 0 < m q) ∧
+        (∀ i i' : a, ∃ B : ∀ q, Matrix (Fin (d q)) (Fin (d q)) ℂ,
+          ∀ (q : Fin K) (r : Fin (m q)) (s : Fin (d q)),
+            Matrix.toEuclideanLin (leftMiddleSlice X i i') (e ⟨q, (r, s)⟩) =
+              ∑ s', B q s' s • e ⟨q, (r, s')⟩) ∧
+        ∀ k k' : c, ∃ C : ∀ q, Matrix (Fin (m q)) (Fin (m q)) ℂ,
+          ∀ (q : Fin K) (r : Fin (m q)) (s : Fin (d q)),
+            Matrix.toEuclideanLin (rightMiddleSlice Y k k') (e ⟨q, (r, s)⟩) =
+              ∑ r', C q r' r • e ⟨q, (r', s)⟩ := by
+  let S : StarSubalgebra ℂ (Matrix b b ℂ) :=
+    StarSubalgebra.centralizer ℂ
+      (Set.range fun p : c × c ↦ rightMiddleSlice Y p.1 p.2)
+  obtain ⟨K, d, m, e, hd, hm, hS, hScomm⟩ :=
+    S.exists_complementary_action_orthonormalBasis
+  refine ⟨K, d, m, e, hd, hm, ?_, ?_⟩
+  · intro i i'
+    apply hS
+    change leftMiddleSlice X i i' ∈ StarSubalgebra.centralizer ℂ
+      (Set.range fun p : c × c ↦ rightMiddleSlice Y p.1 p.2)
+    rw [StarSubalgebra.mem_centralizer_iff]
+    rintro g ⟨⟨k, k'⟩, rfl⟩
+    dsimp
+    constructor
+    · exact (middleSlices_commute_of_overlappingLifts_commute X Y hComm i i' k k').symm
+    · rw [star_rightMiddleSlice Y hY]
+      exact (middleSlices_commute_of_overlappingLifts_commute X Y hComm i i' k' k).symm
+  · intro k k'
+    apply hScomm
+    intro A hA
+    change A ∈ StarSubalgebra.centralizer ℂ
+      (Set.range fun p : c × c ↦ rightMiddleSlice Y p.1 p.2) at hA
+    exact ((StarSubalgebra.mem_centralizer_iff ℂ).mp hA _ ⟨(k, k'), rfl⟩).1
+
+end Matrix

--- a/TNLean/Algebra/StarSubalgebraBlockForm.lean
+++ b/TNLean/Algebra/StarSubalgebraBlockForm.lean
@@ -33,6 +33,9 @@ all such operators, hence lies in $S$.
 * `StarSubalgebra.mem_of_forall_comm` -- membership through the double commutant: a matrix
   whose operator commutes with every endomorphism commuting with the subalgebra is a member
   of the subalgebra.
+* `StarSubalgebra.exists_complementary_action_orthonormalBasis` -- one adapted orthonormal
+  basis simultaneously puts a star-subalgebra on the irreducible tensor factors and its
+  commutant on the complementary multiplicity factors.
 * `StarSubalgebra.exists_unitary_conj_blockDiagonal_iff` -- the full block form: a unitary
   $U$ such that membership in $S$ is equivalent to $U^{\dagger} A U$ being block diagonal
   with blocks $\mathbf{1}_{m_k} \otimes B_k$.
@@ -259,6 +262,44 @@ private theorem exists_commutant_coeff
   rw [Finset.sum_eq_single_of_mem k (Finset.mem_univ k) houter]
   refine Finset.sum_congr rfl fun i' _ => ?_
   simp only [hγ, ite_smul, zero_smul, Finset.sum_ite_eq', Finset.mem_univ, if_true]
+
+/-- **Complementary spatial actions of a star-subalgebra and its commutant.** Let `S` be a
+star-subalgebra of complex matrices. There is an orthonormal basis
+`(f_{k,i,j})`, with positive multiplicity dimensions `m k` and irreducible dimensions
+`d k`, such that every member of `S` acts on the `j` index, identically across `i`, while
+every matrix commuting with all members of `S` acts on the `i` index, identically across
+`j`:
+$$
+ A f_{k,i,j} = \sum_{j'} (B_k)_{j'j} f_{k,i,j'}, \qquad
+ T f_{k,i,j} = \sum_{i'} (C_k)_{i'i} f_{k,i',j}.
+$$
+Thus the same orthonormal identification realizes the complementary block algebras
+`\bigoplus_k (\mathbf 1_{m_k} \otimes M_{d_k})` and
+`\bigoplus_k (M_{m_k} \otimes \mathbf 1_{d_k})`.
+
+This is the finite-dimensional star-algebra step in the proof of the Bravyi--Vyalyi
+spatial decomposition; see S. Beigi, arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`), proof on
+pages 2--3. -/
+theorem exists_complementary_action_orthonormalBasis :
+    ∃ (K : ℕ) (d m : Fin K → ℕ)
+      (b : OrthonormalBasis ((k : Fin K) × (Fin (m k) × Fin (d k))) ℂ
+        (EuclideanSpace ℂ n)),
+      (∀ k, 0 < d k) ∧ (∀ k, 0 < m k) ∧
+        (∀ A ∈ S, ∃ B : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ,
+          ∀ (k : Fin K) (i : Fin (m k)) (j : Fin (d k)),
+            Matrix.toEuclideanLin A (b ⟨k, (i, j)⟩) =
+              ∑ j', B k j' j • b ⟨k, (i, j')⟩) ∧
+        ∀ T : Matrix n n ℂ, (∀ A ∈ S, T * A = A * T) →
+          ∃ C : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ,
+            ∀ (k : Fin K) (i : Fin (m k)) (j : Fin (d k)),
+              Matrix.toEuclideanLin T (b ⟨k, (i, j)⟩) =
+                ∑ i', C k i' i • b ⟨k, (i', j)⟩ := by
+  classical
+  obtain ⟨K, d, m, b, hd, hm, hirr, hcross, hact⟩ := S.exists_adapted_orthonormalBasis
+  refine ⟨K, d, m, b, hd, hm, hact, fun T hT ↦ ?_⟩
+  apply exists_commutant_coeff S hirr hcross hact
+  intro A hA x
+  simp only [Matrix.toEuclideanLin, Matrix.toLpLin_apply, Matrix.mulVec_mulVec, hT A hA]
 
 end RowTransport
 

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2013,6 +2013,124 @@ module over the subalgebra.
     action agrees with $T$ on a basis, hence equals $T$.
 \end{proof}
 
+\begin{theorem}[Middle-factor coefficients of commuting overlapping operators]%
+    \label{thm:commuting_overlapping_middle_coefficients}
+    \lean{Matrix.middleSlices_commute_of_overlappingLifts_commute}
+    \lean{Matrix.leftOverlappingLift}
+    \lean{Matrix.rightOverlappingLift}
+    \lean{Matrix.leftMiddleSlice}
+    \lean{Matrix.rightMiddleSlice}
+    \leanok
+    Let $X_{AB}\in\mathbf L(H_A\otimes H_B)$ and
+    $Y_{BC}\in\mathbf L(H_B\otimes H_C)$. For fixed outer indices define their
+    middle-factor coefficient matrices by
+    \[
+        (X_{aa'})_{bb'}=(X_{AB})_{(a,b),(a',b')},\qquad
+        (Y_{cc'})_{bb'}=(Y_{BC})_{(b,c),(b',c')}.
+    \]
+    If
+    \[
+        (X_{AB}\otimes\Id_C)(\Id_A\otimes Y_{BC})
+        =(\Id_A\otimes Y_{BC})(X_{AB}\otimes\Id_C),
+    \]
+    then $X_{aa'}Y_{cc'}=Y_{cc'}X_{aa'}$ for every $a,a',c,c'$. This is the
+    coefficientwise commutation step in the proof of
+    \cite[Lemma~2.1]{Beigi2012Classification}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Evaluate the commutation identity between the basis vectors
+    $\lvert a,b,c\rangle$ and $\lvert a',b',c'\rangle$. The identity matrices
+    collapse the sums over the first and third intermediate indices, leaving
+    \[
+        \sum_{r}(X_{aa'})_{br}(Y_{cc'})_{rb'}
+        =\sum_{r}(Y_{cc'})_{br}(X_{aa'})_{rb'}.
+    \]
+    This is precisely the $(b,b')$ entry of
+    $X_{aa'}Y_{cc'}=Y_{cc'}X_{aa'}$.
+\end{proof}
+
+\begin{theorem}[Complementary spatial actions of a $*$-subalgebra and its commutant]%
+    \label{thm:starSubalgebra_complementary_spatial_actions}
+    \lean{StarSubalgebra.exists_complementary_action_orthonormalBasis}
+    \leanok
+    Let $S$ be a $*$-subalgebra of $\MN{D}$. There are positive integers
+    $d_k,m_k$ and an orthonormal basis
+    $(f_{k,i,j})_{k<K,\,i<m_k,\,j<d_k}$ of $\C^D$ such that every $A\in S$ acts by
+    \[
+        A f_{k,i,j}=\sum_{j'=0}^{d_k-1}(B_k)_{j'j}f_{k,i,j'},
+    \]
+    while every $T\in\MN{D}$ commuting with all members of $S$ acts by
+    \[
+        T f_{k,i,j}=\sum_{i'=0}^{m_k-1}(C_k)_{i'i}f_{k,i',j}.
+    \]
+    Thus the same orthonormal identification realizes $S$ on the second tensor factor
+    and its commutant on the complementary first tensor factor. This is the
+    finite-dimensional $C^*$-algebra step used in the proof of
+    \cite[Lemma~2.1]{Beigi2012Classification}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:starSubalgebra_global_adapted_orthonormal_basis}
+    Choose the adapted orthonormal basis $(f_{k,i,j})$ for $S$. The first displayed
+    identity is its defining action property. If $T$ commutes with $S$, the row transport
+    \[
+        \tau_{k,i',i}(v)
+        =\sum_j\langle f_{k,i',j},v\rangle f_{k,i,j}
+    \]
+    also commutes with $S$, and so does $\tau_{k,i',i}T$. Schur's lemma makes this
+    composite scalar on each irreducible row and makes its matrix coefficients vanish
+    between different isotypic components. Expanding $T f_{k,i,j}$ in the orthonormal
+    basis therefore gives the second displayed identity, with coefficients
+    $(C_k)_{i'i}$ independent of $j$.
+\end{proof}
+
+\begin{theorem}[Coefficient form of the commuting-overlap spatial decomposition]%
+    \label{thm:commuting_overlapping_coefficient_spatial_decomposition}
+    \lean{Matrix.exists_middle_spatial_decomposition_of_overlappingLifts_commute}
+    \lean{Matrix.star_rightMiddleSlice}
+    \leanok
+    Let $X_{AB}\in\mathbf L(H_A\otimes H_B)$ and
+    $Y_{BC}\in\mathbf L(H_B\otimes H_C)$, with $Y_{BC}$ Hermitian, and suppose
+    \[
+        [X_{AB}\otimes\Id_C,\Id_A\otimes Y_{BC}]=0.
+    \]
+    There is an orthonormal decomposition
+    \[
+        H_B\cong\bigoplus_{q=0}^{K-1} H_{q,r}\otimes H_{q,l}
+    \]
+    such that all middle-factor coefficients $X_{aa'}$ act only on $H_{q,l}$,
+    while all middle-factor coefficients $Y_{cc'}$ act only on $H_{q,r}$. More
+    precisely, in an orthonormal basis $(e_{q,r,s})$ adapted to this decomposition,
+    \[
+        X_{aa'}e_{q,r,s}
+        =\sum_{s'}(B^{aa'}_q)_{s's}e_{q,r,s'},\qquad
+        Y_{cc'}e_{q,r,s}
+        =\sum_{r'}(C^{cc'}_q)_{r'r}e_{q,r',s}.
+    \]
+    The source lemma assumes that both overlapping operators are Hermitian; the
+    coefficient conclusion requires Hermiticity only for $Y_{BC}$. This is the
+    middle-space coefficient form of
+    \cite[Lemma~2.1]{Beigi2012Classification}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:commuting_overlapping_middle_coefficients,
+        thm:starSubalgebra_complementary_spatial_actions}
+    Let $S$ be the commutant of the family $(Y_{cc'})_{c,c'}$ together with its
+    adjoints. Hermiticity gives $Y_{cc'}^*=Y_{c'c}$.
+    Theorem~\ref{thm:commuting_overlapping_middle_coefficients} therefore places
+    every $X_{aa'}$ in $S$. Conversely, every $Y_{cc'}$ commutes with all members
+    of $S$. Apply
+    Theorem~\ref{thm:starSubalgebra_complementary_spatial_actions} to $S$: its
+    members act on one tensor factor of each summand, and matrices commuting with
+    $S$ act on the complementary factor. Specializing these two actions to
+    $X_{aa'}$ and $Y_{cc'}$ gives the displayed formulas.
+\end{proof}
+
 Combining the containment direction with the double-commutant criterion yields the full
 block representation of a finite-dimensional $*$-subalgebra, the unital case of
 Eq.~(1.39) of~\cite{Wolf2012Quantum} invoked by~\cite[Theorem~6.14]{Wolf2012Quantum}: up

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -531,3 +531,17 @@
   year         = {1949},
   doi          = {10.1073/pnas.35.11.652},
 }
+
+@article{Beigi2012Classification,
+  author       = {Beigi, Salman},
+  title        = {Classification of the Phases of {1D} Spin Chains with Commuting
+                  Hamiltonians},
+  journal      = {Journal of Physics A: Mathematical and Theoretical},
+  volume       = {45},
+  number       = {2},
+  pages        = {025306},
+  year         = {2012},
+  doi          = {10.1088/1751-8113/45/2/025306},
+  eprint       = {1105.1019},
+  archiveprefix = {arXiv},
+}

--- a/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
+++ b/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
@@ -87,12 +87,36 @@ substitute for the proposition labelled \emph{4to2}.
 
 \section{Unformalized implication}
 
-The abstract Wedderburn--Artin decomposition already available in
-\leanid{StarSubalgebra.exists_algEquiv_pi_matrix} does not provide the spatial
-unitary tensor-factor decomposition required by the Bravyi--Vyalyi lemma.
-The file \path{TNLean/Algebra/StarSubalgebraSpatial.lean} proves orthogonal
-reducibility, but explicitly records the remaining isotypic tensor
-identification and unitary construction.
+The finite-dimensional $C^*$-algebra part of the Bravyi--Vyalyi argument is
+now available.  For a star-subalgebra $S\subseteq\mathbf L(H_B)$, one
+orthonormal identification
+\[
+  H_B\cong\bigoplus_{\beta}
+  H_{\beta_l}\otimes H_{\beta_r}
+\]
+simultaneously puts $S$ in
+$\bigoplus_\beta\mathbf 1_{\beta_l}\otimes
+\mathbf L(H_{\beta_r})$ and its commutant in
+$\bigoplus_\beta\mathbf L(H_{\beta_l})\otimes
+\mathbf 1_{\beta_r}$.
+This complementary action is
+\leanid{StarSubalgebra.exists_complementary_action_orthonormalBasis}.
+
+The coefficient passage in Beigi's proof is now also available.  Fixing the
+outer indices produces middle-site matrices $X_{aa'}$ and $Y_{cc'}$;
+commutation of the two overlapping operators implies
+$[X_{aa'},Y_{cc'}]=0$ for all outer indices.  Applying the complementary-action
+theorem to the star-commutant of the $Y_{cc'}$ gives one orthonormal
+decomposition on which all $X_{aa'}$ and $Y_{cc'}$ act on complementary
+factors.  This is
+\leanid{Matrix.exists_middle_spatial_decomposition_of_overlappingLifts_commute}.
+
+The remaining part of the exact statement of Beigi's Lemma~2.1 is the final
+assembly: construct the unitary from this orthonormal basis, combine the
+coefficient matrices into the operators $R_{A\beta_l}$ and
+$S_{\beta_rC}$, and prove the two block-sum equalities printed in the source.
+No additional mathematical hypothesis is needed for this assembly, but those
+operator equalities have not yet been stated in the formal development.
 
 Consequently the source implication
 \[
@@ -114,15 +138,12 @@ restriction that isolates only its final entropy-theoretic step.
 
 \section{Elimination plan}
 
-The gap can be removed in three stages.
+The gap can be removed in the following stages.
 
 \begin{enumerate}
-\item Complete the spatial finite-dimensional $C^*$-algebra theorem: construct
-the unitary decomposition
-$\mathcal H_B\cong\bigoplus_\beta
-\mathcal H_{\beta_l}\otimes\mathcal H_{\beta_r}$ and prove the complementary
-actions of a star-subalgebra and its commutant.
-\item Apply it to the two overlapping translates of the single bond in
+\item Assemble the completed coefficient decomposition into the unitary
+block-sum equalities for $X_{AB}$ and $Y_{BC}$ printed in Beigi's Lemma~2.1.
+\item Apply that lemma to the two overlapping translates of the single bond in
 \leanid{MPOTensor.EtaLocalStructureData}, obtaining the translation-invariant
 neighboring operators $\eta_{k,h}$ without assuming a Hayashi decomposition.
 Use \leanid{MPOTensor.IsSourceZCL} to prove the rank-one trace factorization


### PR DESCRIPTION
This PR formalizes the coefficientwise and complementary-action milestone in the Bravyi--Vyalyi spatial decomposition, following Beigi, arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`), pages 2--3. It advances #4191; it does not close the issue.

The new algebra module defines the two natural overlapping lifts and their middle-factor coefficient matrices. It proves that commutation of the lifted operators implies pairwise commutation of all middle coefficients. A new public star-subalgebra theorem then supplies one orthonormal basis in which a finite-dimensional star-subalgebra and its commutant act on complementary factors. Combining these results gives a common middle-space decomposition for the two coefficient families. The formal result needs Hermiticity only for the right operator, whereas Beigi assumes both operators are Hermitian, so it introduces no additional hypothesis.

The blueprint records these three results and the paper-gap note now separates the completed coefficient decomposition from the remaining source-level assembly. The work still required for #4191 is to construct the explicit unitary and the operators in Beigi's two block-sum identities, prove the three-site reindexing bridge from adjacent cyclic `bondAt` operators to the abstract overlapping lifts, and apply that result in the CPSV16 Proposition `4to2` argument.

Validated by the full `lake build TNLean`, direct checks of both affected Lean files, `leanblueprint checkdecls`, blueprint declaration synchronization and reverse coverage, the reader-facing prose check, and an axiom audit. The new theorems use only `propext`, `Classical.choice`, and `Quot.sound`; no proof placeholders or kernel bypasses are introduced.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New core algebra theorems on which future CPSV16/4to2 assembly depends; errors would propagate to the commuting-form track, but changes are localized and reuse existing star-subalgebra infrastructure.
> 
> **Overview**
> Formalizes the **Bravyi–Vyalyi / Beigi Lemma 2.1** coefficient step: overlapping lifts on three factors, middle slices, and the fact that lifted commutation forces all middle coefficient matrices to commute.
> 
> Adds **`StarSubalgebra.exists_complementary_action_orthonormalBasis`**, exposing one adapted orthonormal basis where a star-subalgebra and its commutant act on complementary tensor indices. **`Matrix.exists_middle_spatial_decomposition_of_overlappingLifts_commute`** combines that with the commutant of the `Y` slices; only **Hermiticity of `Y`** is required (weaker than Beigi’s both-Hermitian assumption).
> 
> Blueprint chapter 7 gains matching theorems and a **Beigi** bibliography entry; the CPSV16 paper-gap note marks the \(C^*\)-algebra and coefficient parts done and leaves the unitary block-sum assembly open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49824d179228e07e2bb01490680006c5487b37c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->