### PR TITLE
feat(ParentHamiltonian): close block boundaries by global cut

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -327,6 +327,8 @@ import TNLean.MPS.ParentHamiltonian.GroundSpaceSpanning
 import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalChain
 import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalChainBoundary
 import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossing
+import TNLean.MPS.ParentHamiltonian.CyclicTranslation
+import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalBoundaryClosing
 import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalPGVWCComparison
 import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalTraceDecomposition
 import TNLean.Algebra.BlockTriangularTrace

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalBoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalBoundaryClosing.lean
@@ -1,0 +1,382 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalChain
+import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossing
+import TNLean.MPS.ParentHamiltonian.BlockIntersectionProperty
+import TNLean.MPS.ParentHamiltonian.BoundaryMatrixBlock
+import TNLean.MPS.ParentHamiltonian.CyclicTranslation
+import TNLean.MPS.ParentHamiltonian.GroundSpaceSpanning
+
+/-!
+# Boundary closing by comparison across a cyclic cut
+
+This file formalizes the change-of-cut comparison in
+arXiv:quant-ph/0608197, Theorem 12, proof lines 1454--1456.  Two open-boundary
+decompositions of the same periodic state, with cuts separated by \(S\) sites,
+are compared against the common complementary words of length \(K\). A
+simultaneous spanning family on the complementary segment then identifies the
+boundary matrices block by block.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d : ℕ}
+
+/-- A length at which a tensor is block injective identifies the two boundary
+matrices in a word intertwiner and promotes the relation to one-site
+commutation. -/
+private theorem boundary_eq_and_commutes_of_isNBlkInjective_of_intertwines
+    {D S : ℕ} {A : MPSTensor d D}
+    (hBlk : IsNBlkInjective A S) (hS : 0 < S)
+    (X Y : Matrix (Fin D) (Fin D) ℂ)
+    (hIntertwine : ∀ α : Fin S → Fin d,
+      X * evalWord A (List.ofFn α) = evalWord A (List.ofFn α) * Y) :
+    X = Y ∧ ∀ a : Fin d, X * A a = A a * X := by
+  have hMaps : LinearMap.mulLeft ℂ X = LinearMap.mulRight ℂ Y := by
+    apply LinearMap.ext_on_range
+      (v := fun α : Fin S → Fin d ↦ evalWord A (List.ofFn α))
+    · simpa [wordSpan] using (wordSpan_eq_top_iff_isNBlkInjective A S).mpr hBlk
+    · intro α
+      simpa only [LinearMap.mulLeft_apply, LinearMap.mulRight_apply] using
+        hIntertwine α
+  have hXY := congrArg (fun f ↦ f 1) hMaps
+  simp only [LinearMap.mulLeft_apply, LinearMap.mulRight_apply, mul_one, one_mul] at hXY
+  refine ⟨hXY, ?_⟩
+  apply boundary_matrix_commutes_of_isNBlkInjective_of_long_word_commutes
+    hBlk hS (le_refl S)
+  intro α
+  rw [hIntertwine α, hXY]
+
+/-- Comparing open-boundary decompositions before and after moving the cut
+gives a blockwise boundary intertwiner.
+
+Suppose translating the cut of
+
+\[
+  \sum_j \Gamma_{K+S}^{A_j}(X_j)
+\]
+
+by \(K\) sites gives
+
+\[
+  \sum_j \Gamma_{K+S}^{A_j}(Y_j).
+\]
+
+If the simultaneous block words of length \(K\) span the product matrix
+algebra, then every word \(A^j_\alpha\) of length \(S\) satisfies
+
+\[
+  X_j A^j_\alpha=A^j_\alpha Y_j.
+\]
+
+This is the global-cut form of the boundary comparison used in
+arXiv:quant-ph/0608197, Theorem 12, proof lines 1454--1456, following the
+single-block change-of-cut argument in proof lines 1276--1289. -/
+theorem block_boundary_intertwines_of_cyclicTranslate_sum_groundSpaceMap_eq
+    {r : ℕ} {dim : Fin r → ℕ}
+    (A : (j : Fin r) → MPSTensor d (dim j))
+    {K S : ℕ} (hS : 0 < S) (hSpan : WordTupleSpanTop A K)
+    (X Y : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (hEq :
+      cyclicTranslateState (⟨K, by omega⟩ : Fin (K + S))
+          (∑ j : Fin r, groundSpaceMap (A j) (K + S) (X j)) =
+        ∑ j : Fin r, groundSpaceMap (A j) (K + S) (Y j)) :
+    ∀ (α : Fin S → Fin d) (j : Fin r),
+      X j * evalWord (A j) (List.ofFn α) =
+        evalWord (A j) (List.ofFn α) * Y j := by
+  classical
+  intro α
+  apply block_matrices_eq_of_wordTupleSpanTop_trace A hSpan
+    (fun j ↦ X j * evalWord (A j) (List.ofFn α))
+    (fun j ↦ evalWord (A j) (List.ofFn α) * Y j)
+  intro β
+  have hcoeff := congrFun hEq (Fin.append β α)
+  change
+    (∑ j : Fin r, groundSpaceMap (A j) (K + S) (X j))
+        (cyclicTranslateCfg (⟨K, by omega⟩ : Fin (K + S)) (Fin.append β α)) =
+      (∑ j : Fin r, groundSpaceMap (A j) (K + S) (Y j)) (Fin.append β α)
+    at hcoeff
+  simp only [Finset.sum_apply, groundSpaceMap_apply] at hcoeff
+  rw [cyclicTranslateCfg_fin_append hS β α] at hcoeff
+  have hswap :
+      List.ofFn ((Fin.append α β) ∘ Fin.cast (Nat.add_comm K S)) =
+        List.ofFn α ++ List.ofFn β := by
+    rw [← List.ofFn_fin_append]
+    exact (List.ofFn_congr (Nat.add_comm S K) (Fin.append α β)).symm
+  rw [hswap, List.ofFn_fin_append] at hcoeff
+  simp_rw [evalWord_append] at hcoeff
+  calc
+    (∑ j : Fin r,
+        Matrix.trace
+          ((X j * evalWord (A j) (List.ofFn α)) *
+            evalWord (A j) (List.ofFn β))) =
+        ∑ j : Fin r,
+          Matrix.trace
+            ((evalWord (A j) (List.ofFn α) *
+                evalWord (A j) (List.ofFn β)) * X j) := by
+      apply Finset.sum_congr rfl
+      intro j _
+      rw [Matrix.mul_assoc]
+      exact Matrix.trace_mul_comm _ _
+    _ =
+        ∑ j : Fin r,
+          Matrix.trace
+            ((evalWord (A j) (List.ofFn β) *
+                evalWord (A j) (List.ofFn α)) * Y j) := hcoeff
+    _ =
+        ∑ j : Fin r,
+          Matrix.trace
+            ((evalWord (A j) (List.ofFn α) * Y j) *
+              evalWord (A j) (List.ofFn β)) := by
+      apply Finset.sum_congr rfl
+      intro j _
+      rw [Matrix.mul_assoc]
+      exact Matrix.trace_mul_comm _ _
+
+/-- Length-indexed form of the global-cut comparison, with the chain length
+kept as a separate variable. -/
+private theorem block_boundary_intertwines_of_cyclicTranslate_sum_groundSpaceMap_eq_of_add_eq
+    {r : ℕ} {dim : Fin r → ℕ}
+    (A : (j : Fin r) → MPSTensor d (dim j))
+    {N K S : ℕ} (hKS : K + S = N) (hS : 0 < S)
+    (hSpan : WordTupleSpanTop A K)
+    (X Y : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (hEq :
+      cyclicTranslateState (⟨K, by omega⟩ : Fin N)
+          (∑ j : Fin r, groundSpaceMap (A j) N (X j)) =
+        ∑ j : Fin r, groundSpaceMap (A j) N (Y j)) :
+    ∀ (α : Fin S → Fin d) (j : Fin r),
+      X j * evalWord (A j) (List.ofFn α) =
+        evalWord (A j) (List.ofFn α) * Y j := by
+  subst N
+  exact block_boundary_intertwines_of_cyclicTranslate_sum_groundSpaceMap_eq
+    A hS hSpan X Y hEq
+
+/-- A global comparison of two cuts closes the block-diagonal boundary
+conditions without any short-tail simultaneous spanning hypothesis.
+
+Let \(B=\bigoplus_j\mu_jA_j\). Under the normalized BNT block-separation
+hypotheses, suppose \(N\ge L+L_0\), where every block is injective at length
+\(L_0>0\). Every vector in the periodic chain space of \(B\) has block-diagonal
+open-boundary matrices \(X_j\). Move the cut past the final \(L_0\) sites and
+apply the same open-boundary decomposition to the translated state. Comparing
+the two decompositions against the complementary words of length \(N-L_0\)
+gives
+
+\[
+  (\mu_j^N X_j)A^j_\alpha=A^j_\alpha(\mu_j^N Y_j).
+\]
+
+The simultaneous spanning hypothesis is used only at the long length
+\(N-L_0\), where it follows from the BNT separation bound. Block injectivity at
+length \(L_0\) then identifies the two boundary matrices and gives commutation,
+which closes every boundary-crossing local interval. This is the change-of-cut
+argument of arXiv:quant-ph/0608197, Theorem 12, proof lines 1276--1289 and
+1454--1456, with the block-diagonal boundary restriction of arXiv:2011.12127,
+Section IV.C, lines 2126--2128.
+
+**Scope restriction (finite Condition C1 range):** The moved-cut comparison is
+unconditional within the repository's existing normalized BNT separation range
+\((L_0+1)+3(r-1)(L_0+1)+1\le L\). The source theorem uses the sharper bound
+\(3(r-1)(L_0+1)+1\le L\). Thus the length-\(L_0\) injectivity range remains
+stronger than the source constant. This independent mismatch is documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex` and tracked by
+issue #4195.
+-/
+theorem exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    {L₀ L N : ℕ}
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    [NeZero d] (hN : 0 < N) (hL : 0 < L) (hLN : L ≤ N)
+    (hRange :
+      (L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) + 1 ≤ L)
+    (hNlarge : L + L₀ ≤ N)
+    {ψ : NSiteSpace d N}
+    (hψ : ψ ∈ chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N) :
+    ∃ X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+      ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+        ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X)) ∧
+      ∀ j : Fin r,
+        groundSpaceMap (A j) N ((μ j) ^ N • X j) ∈ chainGroundSpace (A j) L N := by
+  classical
+  obtain ⟨X, hψX, _⟩ :=
+    exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1
+      μ A hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange hψ
+  let s : Fin N := ⟨N - L₀, by omega⟩
+  have hTranslate :
+      cyclicTranslateState s ψ ∈
+        chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N :=
+    cyclicTranslateState_mem_chainGroundSpace
+      (toTensorFromBlocks (d := d) (μ := μ) A) hN hLN s hψ
+  obtain ⟨Y, hψY, _⟩ :=
+    exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1
+      μ A hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange hTranslate
+  have hXsum :
+      ψ = ∑ j : Fin r, groundSpaceMap (A j) N ((μ j) ^ N • X j) := by
+    calc
+      ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+          ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv)
+            (Matrix.blockDiagonal' X)) := hψX
+      _ = ∑ j : Fin r, groundSpaceMap (A j) N ((μ j) ^ N • X j) := by
+        rw [BlockSumGroundSpace.groundSpaceMap_toTensorFromBlocks_eq_sum_blockDiagonal]
+  have hYsum :
+      cyclicTranslateState s ψ =
+        ∑ j : Fin r, groundSpaceMap (A j) N ((μ j) ^ N • Y j) := by
+    calc
+      cyclicTranslateState s ψ =
+          groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+            ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv)
+              (Matrix.blockDiagonal' Y)) := hψY
+      _ = ∑ j : Fin r, groundSpaceMap (A j) N ((μ j) ^ N • Y j) := by
+        rw [BlockSumGroundSpace.groundSpaceMap_toTensorFromBlocks_eq_sum_blockDiagonal]
+  have hSplit : N - L₀ + L₀ = N := by omega
+  have hSumTranslate :
+      cyclicTranslateState s
+          (∑ j : Fin r, groundSpaceMap (A j) N ((μ j) ^ N • X j)) =
+        ∑ j : Fin r, groundSpaceMap (A j) N ((μ j) ^ N • Y j) := by
+    rw [← hXsum]
+    exact hYsum
+  have hLongSpan : WordTupleSpanTop A (N - L₀) := by
+    apply wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1
+      A hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital
+    omega
+  have hIntertwine :
+      ∀ (α : Fin L₀ → Fin d) (j : Fin r),
+        ((μ j) ^ N • X j) * evalWord (A j) (List.ofFn α) =
+          evalWord (A j) (List.ofFn α) * ((μ j) ^ N • Y j) := by
+    apply block_boundary_intertwines_of_cyclicTranslate_sum_groundSpaceMap_eq_of_add_eq
+      A hSplit hL₀ hLongSpan
+        (fun j ↦ (μ j) ^ N • X j) (fun j ↦ (μ j) ^ N • Y j)
+    simpa only [s] using hSumTranslate
+  have hComm : ∀ j : Fin r, ∀ a : Fin d,
+      ((μ j) ^ N • X j) * A j a = A j a * ((μ j) ^ N • X j) := by
+    intro j
+    exact (boundary_eq_and_commutes_of_isNBlkInjective_of_intertwines
+      (hBlk j) hL₀ ((μ j) ^ N • X j) ((μ j) ^ N • Y j)
+      (fun α ↦ hIntertwine α j)).2
+  have hCommWord : ∀ j : Fin r, ∀ w : List (Fin d),
+      ((μ j) ^ N • X j) * evalWord (A j) w =
+        evalWord (A j) w * ((μ j) ^ N • X j) := by
+    intro j w
+    induction w with
+    | nil => simp [evalWord_nil]
+    | cons a w ih =>
+        rw [evalWord_cons, ← Matrix.mul_assoc, hComm j a, Matrix.mul_assoc, ih,
+          ← Matrix.mul_assoc]
+  refine ⟨X, hψX, ?_⟩
+  apply blockDiagonal_boundary_component_chainGroundSpace_of_boundary_identities
+    μ A hN hLN X
+  intro j i _τ _hi
+  refine ⟨(μ j) ^ N • X j, ?_⟩
+  intro β
+  exact hCommWord j (List.ofFn β)
+
+/-- The normalized BNT block-diagonal periodic chain space is the sum of the
+single-block periodic chain spaces in the finite Condition C1 range, and the
+corresponding open-boundary block spaces are independent.
+
+This is the periodic ground-space conclusion of arXiv:quant-ph/0608197,
+Theorem 12, proof lines 1430--1456, in the finite Condition C1 range. The
+boundary closing is supplied by the global change-of-cut comparison above, so
+there is no short crossing-tail span hypothesis.
+
+**Scope restriction (finite Condition C1 range):** The conclusion is proved in
+the repository's existing normalized BNT separation range derived from
+length-\(L_0\) injectivity. Recovering the sharper length bound of
+arXiv:quant-ph/0608197, Theorem 12, is documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex` and tracked in
+issue #4195.
+-/
+theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_global_cut_bnt_c1
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    {L₀ L N : ℕ}
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    [NeZero d] (hN : 0 < N) (hL : 0 < L) (hLN : L ≤ N)
+    (hRange :
+      (L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) + 1 ≤ L)
+    (hNlarge : L + L₀ ≤ N) :
+    chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N =
+        ⨆ j : Fin r, chainGroundSpace (A j) L N ∧
+      iSupIndep (fun j : Fin r ↦ groundSpace (A j) N) := by
+  apply chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_blockBoundary
+    μ A hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange
+  intro ψ hψ
+  exact exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1
+    μ A hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange
+      hNlarge hψ
+
+/-- The normalized BNT block-diagonal periodic chain space is the sum of the
+single-block periodic chain spaces in the finite Condition C1 range. -/
+theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_of_global_cut_bnt_c1
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    {L₀ L N : ℕ}
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    [NeZero d] (hN : 0 < N) (hL : 0 < L) (hLN : L ≤ N)
+    (hRange :
+      (L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) + 1 ≤ L)
+    (hNlarge : L + L₀ ≤ N) :
+    chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N =
+      ⨆ j : Fin r, chainGroundSpace (A j) L N := by
+  exact (chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_global_cut_bnt_c1
+    μ A hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange hNlarge).1
+
+/-- The global change-of-cut comparison gives the fixed-chain kernel
+containment needed for the block-diagonal parent-Hamiltonian spanning clause,
+provided the periodic chain space of each block is contained in its MPS line. -/
+theorem ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan_of_global_cut_bnt_c1
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    {L₀ L N : ℕ}
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    [NeZero d] (hN : 0 < N) (hL : 0 < L) (hLN : L ≤ N)
+    (hRange :
+      (L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) + 1 ≤ L)
+    (hNlarge : L + L₀ ≤ N)
+    (hBlock : ∀ j : Fin r,
+      chainGroundSpace (A j) L N ≤ mpvSubmodule (A j) N) :
+    LinearMap.ker (parentHamiltonian
+      (toTensorFromBlocks (d := d) (μ := μ) A) L N) ≤
+      bntMPSVectorSpan A N := by
+  refine ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan
+    μ A hN hLN ?_ hBlock
+  exact le_of_eq
+    (chainGroundSpace_toTensorFromBlocks_eq_iSup_of_global_cut_bnt_c1
+      μ A hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange hNlarge)
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalBoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalBoundaryClosing.lean
@@ -185,8 +185,7 @@ unconditional within the repository's existing normalized BNT separation range
 \((L_0+1)+3(r-1)(L_0+1)+1\le L\). The source theorem uses the sharper bound
 \(3(r-1)(L_0+1)+1\le L\). Thus the length-\(L_0\) injectivity range remains
 stronger than the source constant. This independent mismatch is documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex` and tracked by
-issue #4195.
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
 -/
 theorem exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -297,8 +296,7 @@ there is no short crossing-tail span hypothesis.
 the repository's existing normalized BNT separation range derived from
 length-\(L_0\) injectivity. Recovering the sharper length bound of
 arXiv:quant-ph/0608197, Theorem 12, is documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex` and tracked in
-issue #4195.
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
 -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_global_cut_bnt_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/TNLean/MPS/ParentHamiltonian/CyclicTranslation.lean
+++ b/TNLean/MPS/ParentHamiltonian/CyclicTranslation.lean
@@ -1,0 +1,129 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.ChainGroundSpace
+
+/-!
+# Cyclic translation of periodic-chain states
+
+This file records covariance of cyclic-window restrictions under translation of
+the sites of a periodic chain. It supplies the change of cut used in the
+periodic boundary comparison of arXiv:quant-ph/0608197, Theorem 12, proof lines
+1276--1289 and 1454--1456.
+-/
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- Translate a periodic-chain configuration clockwise by `s` sites. -/
+def cyclicTranslateCfg {N : ℕ} (s : Fin N) (σ : Fin N → Fin d) : Fin N → Fin d :=
+  fun k ↦ σ (k + s)
+
+/-- Cyclic translation of a periodic-chain state. -/
+def cyclicTranslateState {N : ℕ} (s : Fin N) :
+    NSiteSpace d N →ₗ[ℂ] NSiteSpace d N where
+  toFun ψ σ := ψ (cyclicTranslateCfg s σ)
+  map_add' _ _ := by
+    ext
+    simp
+  map_smul' _ _ := by
+    ext
+    simp
+
+private theorem cyclic_offset_eq_sub {N : ℕ} (k i : Fin N) :
+    ((k.val + N - i.val) % N) = (k - i).val := by
+  letI : NeZero N := ⟨(Fin.pos k).ne'⟩
+  have h := offset_mod_eq i.isLt (k - i).isLt
+  have hadd : i + (k - i) = k := by
+    abel
+  have hval := congrArg Fin.val hadd
+  simp only [Fin.add_def] at hval
+  rwa [hval] at h
+
+private theorem cyclic_offset_translate {N : ℕ} (k i s : Fin N) :
+    (((k + s).val + N - i.val) % N) =
+      ((k.val + N - (i - s).val) % N) := by
+  letI : NeZero N := ⟨(Fin.pos k).ne'⟩
+  rw [cyclic_offset_eq_sub, cyclic_offset_eq_sub]
+  have hFin : k + s - i = k - (i - s) := by
+    abel
+  exact congrArg Fin.val hFin
+
+/-- Translating a filled cyclic window translates its starting site and its
+outside configuration, while leaving the ordered local word unchanged. -/
+private theorem cyclicTranslateCfg_cyclicCfg {N L : ℕ} (hN : 0 < N)
+    (s i : Fin N) (ω : Fin L → Fin d) (τ : Fin N → Fin d) :
+    cyclicTranslateCfg s (cyclicCfg hN L i ω τ) =
+      cyclicCfg hN L (i - s) ω (cyclicTranslateCfg s τ) := by
+  funext k
+  simp only [cyclicTranslateCfg, cyclicCfg]
+  rw [cyclic_offset_translate k i s]
+
+/-- A cyclic restriction of a translated state is the restriction of the
+original state at the translated starting site. -/
+private theorem cyclicRestrictₗ_cyclicTranslateState {N L : ℕ} (hN : 0 < N)
+    (s i : Fin N) (τ : Fin N → Fin d) (ψ : NSiteSpace d N) :
+    cyclicRestrictₗ hN L i τ (cyclicTranslateState s ψ) =
+      cyclicRestrictₗ hN L (i - s) (cyclicTranslateCfg s τ) ψ := by
+  ext ω
+  simp only [cyclicRestrictₗ_apply, cyclicTranslateState]
+  change ψ (cyclicTranslateCfg s (cyclicCfg hN L i ω τ)) = _
+  rw [cyclicTranslateCfg_cyclicCfg]
+
+/-- The periodic chain ground space is invariant under cyclic translation of
+the physical sites. -/
+theorem cyclicTranslateState_mem_chainGroundSpace (A : MPSTensor d D)
+    {L N : ℕ} (hN : 0 < N) (hLN : L ≤ N) (s : Fin N)
+    {ψ : NSiteSpace d N} (hψ : ψ ∈ chainGroundSpace A L N) :
+    cyclicTranslateState s ψ ∈ chainGroundSpace A L N := by
+  rw [chainGroundSpace, dif_pos ⟨hN, hLN⟩] at hψ ⊢
+  simp only [Submodule.mem_iInf, Submodule.mem_comap] at hψ ⊢
+  intro i τ
+  rw [cyclicRestrictₗ_cyclicTranslateState hN s i τ ψ]
+  exact hψ (i - s) (cyclicTranslateCfg s τ)
+
+/-! ### Translation across a specified cut -/
+
+/-- Translation by the length of the first word exchanges the two words in a
+concatenated periodic configuration. -/
+theorem cyclicTranslateCfg_fin_append {K S : ℕ} (hS : 0 < S)
+    (β : Fin K → Fin d) (α : Fin S → Fin d) :
+    cyclicTranslateCfg (⟨K, by omega⟩ : Fin (K + S)) (Fin.append β α) =
+      (Fin.append α β) ∘ Fin.cast (Nat.add_comm K S) := by
+  funext k
+  by_cases hk : k.val < S
+  · have hsite :
+        k + (⟨K, by omega⟩ : Fin (K + S)) =
+          Fin.natAdd K (⟨k.val, hk⟩ : Fin S) := by
+      apply Fin.ext
+      simp [Fin.add_def, Nat.mod_eq_of_lt (by omega : k.val + K < K + S)]
+      omega
+    have hcast :
+        Fin.cast (Nat.add_comm K S) k =
+          Fin.castAdd K (⟨k.val, hk⟩ : Fin S) := by
+      apply Fin.ext
+      rfl
+    rw [cyclicTranslateCfg, hsite, Fin.append_right, Function.comp_apply,
+      hcast, Fin.append_left]
+  · have hkS : S ≤ k.val := by omega
+    have hkK : k.val - S < K := by omega
+    have hsite :
+        k + (⟨K, by omega⟩ : Fin (K + S)) =
+          Fin.castAdd S (⟨k.val - S, hkK⟩ : Fin K) := by
+      apply Fin.ext
+      change (k.val + K) % (K + S) = k.val - S
+      have hsum : k.val + K = K + S + (k.val - S) := by omega
+      rw [hsum, Nat.add_mod_left, Nat.mod_eq_of_lt (by omega : k.val - S < K + S)]
+    have hcast :
+        Fin.cast (Nat.add_comm K S) k =
+          Fin.natAdd S (⟨k.val - S, hkK⟩ : Fin K) := by
+      apply Fin.ext
+      simp
+      omega
+    rw [cyclicTranslateCfg, hsite, Fin.append_left, Function.comp_apply,
+      hcast, Fin.append_right]
+
+end MPSTensor

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
@@ -1451,6 +1451,234 @@ in both cases.
     \]
 \end{proof}
 
+\begin{definition}[Cyclic translation of configurations]
+    \label{def:parent_cyclic_translate_configuration}
+    \lean{MPSTensor.cyclicTranslateCfg}
+    \leanok
+    For a periodic configuration $\sigma$ on $N$ sites and $s\in\mathbb Z/N\mathbb Z$,
+    define
+    \[
+        (T_s\sigma)(k)=\sigma(k+s).
+    \]
+\end{definition}
+
+\begin{definition}[Cyclic translation of states]
+    \label{def:parent_cyclic_translate_state}
+    \lean{MPSTensor.cyclicTranslateState}
+    \leanok
+    For a state $\psi$ on a periodic chain, define
+    \[
+        (T_s\psi)(\sigma)=\psi(T_s\sigma).
+    \]
+\end{definition}
+
+\begin{lemma}[Cyclic translation preserves the periodic chain space]
+    \label{lem:parent_cyclic_translate_preserves_chain_space}
+    \lean{MPSTensor.cyclicTranslateState_mem_chainGroundSpace}
+    \leanok
+    \uses{def:parent_cyclic_translate_configuration,
+        def:parent_cyclic_translate_state}
+    If $\psi\in\mathcal G_{N,L}(A)$, then
+    $T_s\psi\in\mathcal G_{N,L}(A)$ for every cyclic translation $s$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    A length-$L$ interval of $T_s\psi$ beginning at $i$ is the corresponding
+    interval of $\psi$ beginning at $i-s$, with the outside configuration
+    translated by $s$.
+\end{proof}
+
+\begin{lemma}[Translation exchanges the two words at a cut]
+    \label{lem:parent_cyclic_translate_append}
+    \lean{MPSTensor.cyclicTranslateCfg_fin_append}
+    \leanok
+    \uses{def:parent_cyclic_translate_configuration}
+    If $\beta$ has length $K$ and $\alpha$ has positive length $S$, then
+    \[
+        T_K(\beta\alpha)=\alpha\beta
+    \]
+    as configurations on the periodic chain of length $K+S$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    This is addition modulo $K+S$, separated according to whether the site
+    lies before or after the cut.
+\end{proof}
+
+\begin{lemma}[Comparison across a global cut]
+    \label{lem:block_boundary_intertwiner_from_global_cut}
+    \lean{MPSTensor.block_boundary_intertwines_of_cyclicTranslate_sum_groundSpaceMap_eq}
+    \leanok
+    \uses{def:parent_cyclic_translate_state,
+        lem:parent_cyclic_translate_append,
+        lem:block_matrices_equal_from_trace_pairings}
+    Let $X_j,Y_j\in\MN{D_j}$, and suppose
+    \[
+        T_K\!\left(\sum_j\Gamma_{K+S}^{A_j}(X_j)\right)
+        =\sum_j\Gamma_{K+S}^{A_j}(Y_j).
+    \]
+    If the simultaneous block words of length $K$ span
+    $\prod_j\MN{D_j}$, then for every word $\alpha$ of length $S$,
+    \[
+        X_jA^j_\alpha=A^j_\alpha Y_j
+        \qquad\text{for every }j.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Evaluate the translated equality on the word $\beta\alpha$, where
+    $|\beta|=K$. Cyclicity of the trace gives
+    \[
+        \sum_j\operatorname{tr}(X_jA^j_\alpha A^j_\beta)
+        =
+        \sum_j\operatorname{tr}(A^j_\alpha Y_jA^j_\beta).
+    \]
+    The simultaneous spanning hypothesis separates the blocks and gives the
+    asserted matrix identities.
+\end{proof}
+
+\begin{theorem}[A global change of cut gives periodic single-block states]
+    \label{thm:block_diagonal_boundary_periodic_components_from_global_cut}
+    \lean{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1}
+    \leanok
+    \uses{lem:bnt_block_diagonal_open_boundary_matrices,
+        lem:unital_block_separating_product_span,
+        lem:parent_cyclic_translate_preserves_chain_space,
+        lem:block_boundary_intertwiner_from_global_cut,
+        lem:block_diagonal_boundary_component_right_boundary_matrices}
+    With the hypotheses and notation of
+    Lemma~\ref{lem:bnt_block_diagonal_open_boundary_matrices}, assume in
+    addition that $L+L_0\le N$. Thus this statement is in the currently proved
+    block-separation range
+    \[
+        (L_0+1)+3(g-1)(L_0+1)+1\le L,
+    \]
+    rather than the sharper length range in the source theorem. Let
+    % Scope restriction documented in
+    % docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex; issue #4195.
+    \[
+        \psi\in
+        \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right).
+    \]
+    Then there are block-diagonal boundary conditions $X_j$ with
+    \[
+        \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right)
+    \]
+    and, for every $j$,
+    \[
+        \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j).
+    \]
+    No simultaneous spanning assumption is imposed at the short crossing
+    tails.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:bnt_block_diagonal_open_boundary_matrices,
+        lem:unital_block_separating_product_span,
+        lem:parent_cyclic_translate_preserves_chain_space,
+        lem:block_boundary_intertwiner_from_global_cut,
+        lem:block_diagonal_boundary_component_right_boundary_matrices}
+    Lemma~\ref{lem:bnt_block_diagonal_open_boundary_matrices} gives boundary
+    matrices $X_j$. Translate the periodic state so that the cut moves past
+    the final $L_0$ sites, and apply the same lemma again to obtain boundary
+    matrices $Y_j$ for the translated state. For a word $\alpha$ of length
+    $L_0$, comparison of the two decompositions against every complementary
+    word $w$ of length $N-L_0$ gives
+    \[
+        \sum_j\operatorname{tr}
+          \bigl((\mu_j^NX_j)A^j_\alpha A^j_w\bigr)
+        =
+        \sum_j\operatorname{tr}
+          \bigl(A^j_\alpha(\mu_j^NY_j)A^j_w\bigr).
+    \]
+    The length bound and
+    Lemma~\ref{lem:unital_block_separating_product_span} imply that the
+    simultaneous products of length $N-L_0$ span the product algebra.
+    Hence, block by block,
+    \[
+        (\mu_j^NX_j)A^j_\alpha
+        =A^j_\alpha(\mu_j^NY_j).
+    \]
+    Since the words of length $L_0$ span each block matrix algebra, evaluation
+    at the identity identifies the two scaled boundary matrices. The displayed
+    relation therefore says that $\mu_j^NX_j$ commutes with every word of
+    length $L_0$, and consequently with every one-site matrix. The boundary
+    condition may then be moved across every interval crossing the cut, which
+    places each block component in its periodic chain space. This is the
+    change-of-cut argument of
+    \cite[Theorem~12, proof lines~1276--1289 and 1454--1456]{PerezGarcia2007Matrix}.
+\end{proof}
+
+\begin{theorem}[Periodic block decomposition from a global cut]
+    \label{thm:block_diagonal_chain_space_global_cut}
+    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_global_cut_bnt_c1}
+    \leanok
+    \uses{thm:block_diagonal_boundary_periodic_components_from_global_cut,
+        lem:bnt_block_diagonal_boundary_representation_equality}
+    Under the hypotheses of
+    Theorem~\ref{thm:block_diagonal_boundary_periodic_components_from_global_cut},
+    \[
+        \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right)
+        =\sum_j\mathcal G_{N,L}(A_j),
+    \]
+    and the open-boundary spaces $G_N(A_j)$ form an internal sum.
+    This statement uses the block-separation range displayed in that
+    theorem.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The preceding theorem decomposes every vector on the left into periodic
+    single-block components. The reverse inclusion follows because every
+    periodic single-block vector is a periodic vector for the block-diagonal
+    tensor. Block separation gives independence of the open-boundary spaces.
+\end{proof}
+
+\begin{corollary}[Periodic block-diagonal chain-space equality]
+    \label{cor:block_diagonal_chain_space_global_cut}
+    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_of_global_cut_bnt_c1}
+    \leanok
+    \uses{thm:block_diagonal_chain_space_global_cut}
+    Under the same hypotheses,
+    \[
+        \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right)
+        =\sum_j\mathcal G_{N,L}(A_j).
+    \]
+\end{corollary}
+
+\begin{proof}
+    \leanok
+    This is the equality part of
+    Theorem~\ref{thm:block_diagonal_chain_space_global_cut}.
+\end{proof}
+
+\begin{corollary}[Kernel containment from the global cut]
+    \label{cor:block_diagonal_kernel_global_cut}
+    \lean{MPSTensor.ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan_of_global_cut_bnt_c1}
+    \leanok
+    \uses{cor:block_diagonal_chain_space_global_cut,
+        lem:block_diagonal_kernel_to_bnt_span_from_chain_splitting}
+    Under the same hypotheses, suppose additionally that every periodic
+    single-block chain space is contained in its matrix-product-vector line.
+    Then
+    \[
+        \ker H_L^{(N)}\!\left(\bigoplus_j\mu_jA_j\right)
+        \subseteq
+        \operatorname{span}\{V^{(N)}(A_j):1\le j\le g\}.
+    \]
+\end{corollary}
+
+\begin{proof}
+    \leanok
+    The parent-Hamiltonian kernel is the periodic chain space. Apply the
+    preceding block decomposition and then the assumed single-block
+    containments.
+\end{proof}
+
 \begin{lemma}[Matrix identities give periodic single-block states]
     \label{lem:block_diagonal_boundary_periodic_components_from_complementary_identities}
     \lean{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_complementary_identities_bnt_c1}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
@@ -1520,10 +1520,10 @@ in both cases.
         =\sum_j\Gamma_{K+S}^{A_j}(Y_j).
     \]
     If the simultaneous block words of length $K$ span
-    $\prod_j\MN{D_j}$, then for every word $\alpha$ of length $S$,
+    $\prod_j\MN{D_j}$, then, for every block $j$ and every word $\alpha$ of
+    length $S$,
     \[
-        X_jA^j_\alpha=A^j_\alpha Y_j
-        \qquad\text{for every }j.
+        X_jA^j_\alpha=A^j_\alpha Y_j.
     \]
 \end{lemma}
 
@@ -1590,10 +1590,10 @@ in both cases.
     word $w$ of length $N-L_0$ gives
     \[
         \sum_j\operatorname{tr}
-          \bigl((\mu_j^NX_j)A^j_\alpha A^j_w\bigr)
+        \bigl((\mu_j^NX_j)A^j_\alpha A^j_w\bigr)
         =
         \sum_j\operatorname{tr}
-          \bigl(A^j_\alpha(\mu_j^NY_j)A^j_w\bigr).
+        \bigl(A^j_\alpha(\mu_j^NY_j)A^j_w\bigr).
     \]
     The length bound and
     Lemma~\ref{lem:unital_block_separating_product_span} imply that the
@@ -1604,9 +1604,12 @@ in both cases.
         =A^j_\alpha(\mu_j^NY_j).
     \]
     Since the words of length $L_0$ span each block matrix algebra, evaluation
-    at the identity identifies the two scaled boundary matrices. The displayed
-    relation therefore says that $\mu_j^NX_j$ commutes with every word of
-    length $L_0$, and consequently with every one-site matrix. The boundary
+    at the identity gives
+    \[
+        \mu_j^NX_j=\mu_j^NY_j.
+    \]
+    The preceding relation therefore says that $\mu_j^NX_j$ commutes with every
+    word of length $L_0$, and consequently with every one-site matrix. The boundary
     condition may then be moved across every interval crossing the cut, which
     places each block component in its periodic chain space. This is the
     change-of-cut argument of

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -59,9 +59,14 @@ of \cite{Cirac2021Matrix}.\footnote{For
 	form on the main branch
 	(\path{TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossingTrace.lean} and
 	\path{TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean}).
-		The remaining step is to replace the short crossing-tail span hypothesis by
-		the source \(C^j,D^j,E^j\) boundary-condition comparison; this is tracked by
-		\href{https://github.com/LionSR/TNLean/issues/3597}{issue \#3597} (the earlier
+		The short crossing-tail span hypothesis is removed by the global change-of-cut
+		comparison in
+		\leanid{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1};
+		this resolves
+		\href{https://github.com/LionSR/TNLean/issues/3597}{issue \#3597} in the
+		finite Condition C1 range. The sharper source length bound is tracked
+		separately by
+		\href{https://github.com/LionSR/TNLean/issues/4195}{issue \#4195} (the earlier
 		tracker \href{https://github.com/LionSR/TNLean/issues/2971}{issue \#2971}, which
 		tracked proving the boundary-crossing comparison itself, is now closed). Pull
 	request~\#2724 records the earlier conditional reduction on the main branch,
@@ -101,11 +106,11 @@ the finite Condition C1 range from the injectivity of
   \Gamma_{L_0}^{A_j}:M_{D_j}(\mathbb C)
     \to(\mathbb C^d)^{\otimes L_0},
 \end{align}
-together with the separated normalized block hypotheses.  Thus the current
+together with the separated normalized block hypotheses. Thus the current
 Lean statements no longer replace Condition C1 by a length-one span condition
-in the boundary-decomposition path.  The remaining mathematical boundary lies
-later in the argument: after the cyclic constraints have been propagated into
-the trace-form sum, the boundary conditions themselves must be compared.
+in the boundary-decomposition path. The boundary conditions are compared after
+a global change of cut, using only the simultaneous product span on the long
+complementary segment of length \(N-L_0\).
 
 The resulting parent-Hamiltonian theorem in \cite[Section~IV.C]{Cirac2021Matrix}
 is
@@ -198,7 +203,7 @@ the displayed matrix identity gives
 \end{align}
 which puts the vector in $\bigoplus_j \mathcal G_{m+1}^{A_j}$.
 
-\section{The remaining boundary condition}
+\section{The boundary condition and the global change of cut}
 
 The present Lean statements prove the one-step identity under the product-span
 hypothesis
@@ -243,13 +248,14 @@ and make the sum defining $S_N$ internal.\footnote{Lean declarations:
 \leanid{MPSTensor.exists_unique_sum_groundSpace_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1},
 and
 \leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_two_inclusions_and_iSupIndep_of_bnt_unital_c1}.}
-What remains is the source boundary-condition comparison: starting with a
+The former residual was the source boundary-condition comparison: starting with a
 vector in the periodic-boundary space $\mathcal K_{N,L}(\widehat A)$, produce
 block-diagonal boundary matrices whose block components again belong to the
-blockwise periodic-boundary spaces.
+blockwise periodic-boundary spaces. The global change-of-cut theorem now proves
+this conclusion in the finite Condition C1 range.
 
-The present boundary isolates the remaining source comparison in the coordinates
-obtained by opening the periodic boundary for boundary-crossing windows.  Suppose
+Earlier conditional reductions isolated the source comparison in the coordinates
+obtained by opening the periodic boundary for boundary-crossing windows. Suppose
 \begin{align}
   \psi
   =
@@ -276,10 +282,15 @@ implies
 \end{align}
 Thus the trace representation of \(\psi\) is not the obstruction. The
 periodic component theorem proves the displayed conclusion from these
-boundary-crossing coordinate identities. The remaining source-level work in this note is
-to present the \(C^j,D^j,E^j\) comparison from
-\cite[Theorem~12]{PerezGarcia2007MPSReps}
-as an unconditional hypothesis-free equality theorem in the source range.\footnote{Formal declarations:
+boundary-crossing coordinate identities. The global change-of-cut proof avoids
+assuming those identities separately: it translates the whole periodic state
+past the final \(L_0\) sites and compares the two open-boundary decompositions
+against the long complementary segment.\footnote{Formal declarations:
+\leanid{MPSTensor.block_boundary_intertwines_of_cyclicTranslate_sum_groundSpaceMap_eq},
+\leanid{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1},
+and
+\leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_of_global_cut_bnt_c1}.
+The earlier conditional declarations are
 \leanid{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_complementary_word_identities},
 \leanid{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_complementary_word_identities_of_injective},
 \leanid{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_pgvwc_comparison_of_injective},
@@ -291,7 +302,8 @@ the forward inclusion, the block-diagonal intersection identity from
 \cite[Theorem~12]{PerezGarcia2007MPSReps}, the parent-ground-space
 containment, and the final span statement with explicit citations. It also
 separates these opened-boundary coordinates from the paper's boundary indices,
-without claiming that the source statement is proved.
+and records the unconditional global-cut conclusion in the finite Condition C1
+range. It does not identify this stricter range with the source range.
 % Blueprint labels: def:parent_hamiltonian_ground_space_bnt,
 % lem:isup_chain_ground_space_block_le_assembled,
 % thm:block_diagonal_ground_space_intersection,
@@ -305,8 +317,8 @@ With this notation,
     \psi_j\in\mathcal K_{N,L}(A_j)
   \right\}.
 \end{align}
-The source-level boundary-condition statement not yet stated without assuming
-the boundary-crossing coordinate identity is
+The source-range strengthening not yet obtained from the finite Condition C1
+bound is
 \begin{align}
   \left[
     b\ge2
@@ -384,8 +396,9 @@ coordinate formulation displayed above.\footnote{Lean declarations:
 \leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_blockBoundary},
 and
 \leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_complementary_identities}.}
-These reductions do not yet state the source theorem without assuming the
-boundary-crossing comparison.
+The global change-of-cut theorem discharges the boundary-crossing comparison
+hypothesis in the finite Condition C1 range. The source theorem itself remains
+stronger only through its sharper length constant.
 For
 \begin{align}
   X=\bigoplus_j X_j,
@@ -445,22 +458,22 @@ The composition gives
 
 \section{Conclusion}
 
-This is not a source-error claim. The formal development has proved the
-surrounding block-diagonal reductions and a conditional propagation step. In the
+This is not a source-error claim. The formal development proves the
+block-diagonal periodic-boundary comparison without a short-tail span or an
+external boundary-comparison hypothesis in the
 finite-Condition-C1 Lean range
 \begin{align}
-  L\ge (L_0+1)+3(b-1)(L_0+1)+1,
+  L\ge (L_0+1)+3(b-1)(L_0+1)+1.
 \end{align}
-assume the boundary-crossing coordinate identities displayed above. Then, for
-every block $j$,
+For every block $j$ one has
 \begin{align}
   \psi\in\mathcal K_{N,L}(\widehat A)
   \quad\Longrightarrow\quad
   \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal K_{N,L}(A_j).
 \end{align}
-This is the conditional reduction recorded by pull request~\#2724. There are
-now two proved conditional implications leading to the boundary-condition
-comparison. The boundary-trace implication records the following statement.
+The earlier conditional reduction recorded by pull request~\#2724 and the
+boundary-trace implication remain useful intermediate statements. The latter
+records the following assertion.
 Assume the common
 word-span property for the middle-word length \(m\). If, for every
 boundary-crossing interval, word
@@ -582,19 +595,21 @@ derives it from the span-based one-step intersection identity
 \leanid{MPSTensor.pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1};
 its block components lie in the open-boundary ground spaces $\mathcal G_N^{A_j}$,
 and its proof does not use the periodic-boundary comparison at boundary-crossing
-windows. The conditional block-diagonal parent-space statements therefore hold the
-periodic-boundary comparison only as an explicit hypothesis---a scope
-restriction---rather than as a smuggled dependency. The residual transitive
-source-faithfulness gap carried by those statements is the normalized BNT
-product-span input, whose derivation is the normal-range reduction recorded in
+windows. The earlier conditional block-diagonal parent-space statements retain
+the periodic-boundary comparison as an explicit hypothesis, while the global
+change-of-cut theorem discharges it. The residual source-faithfulness gap is the
+normalized BNT product-span range, whose derivation is recorded in
 \path{docs/paper-gaps/cpgsv21_normal_range_reduction.tex} (lines 2078--2079 of
 \path{Papers/2011.12127/TN-Review-main.tex}); that gap is independent of the
 periodic-boundary comparison tracked here.
 
-The remaining source-comparison target is tracked by
-\href{https://github.com/LionSR/TNLean/issues/3597}{issue \#3597}: replace the
-span-dependent short-tail statement by the \(C^j,D^j\) comparison input from
-\cite[Theorem~12]{PerezGarcia2007MPSReps} in the source range
+The periodic-boundary comparison target of
+\href{https://github.com/LionSR/TNLean/issues/3597}{issue \#3597} is therefore
+complete in the finite Condition C1 range. The remaining source-range
+strengthening, tracked by
+\href{https://github.com/LionSR/TNLean/issues/4195}{issue \#4195}, is to replace
+the present separation constant by the sharper bound from
+\cite[Theorem~12]{PerezGarcia2007MPSReps}:
 \begin{align}
   b\ge2,
   \qquad
@@ -604,16 +619,14 @@ span-dependent short-tail statement by the \(C^j,D^j\) comparison input from
   \qquad
   N\ge L+L_0.
 \end{align}
-After this boundary-condition comparison is proved, the conditional equality
-formalized in the current finite Condition C1 range gives
+The global-cut theorem already gives, in the current finite Condition C1 range,
 \begin{align}
   \mathcal K_{N,L}(\widehat A)
   =
   \sum_{j=1}^b\mathcal K_{N,L}(A_j).
 \end{align}
-The final degenerate
-parent-Hamiltonian ground-space equality follows by applying the one-block
-uniqueness theorem to each block.
+The final degenerate parent-Hamiltonian ground-space equality follows by
+applying the one-block uniqueness theorem to each block.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Mathematical content

This change proves the periodic-boundary closure required in #3597 by moving the global cut.

- It defines cyclic translation of configurations and states and proves that the periodic chain space is invariant under this translation.
- It decomposes both a state and its translate into open block-diagonal matrix-product forms.
- Translation by N - L₀ converts comparison of the two decompositions into the intertwining identity
  μⱼᴺ Xⱼ Aᵅⱼ = Aᵅⱼ μⱼᴺ Yⱼ.
- The complementary word has length N - L₀, so the existing long-word spanning theorem identifies the boundary matrices. Block injectivity at length L₀ then yields commutation and closes every boundary-crossing window.
- The resulting chain-space equality and parent-Hamiltonian kernel containment no longer require the comparison hypothesis or a short crossing-tail span hypothesis.

## Source and scope

The argument follows the change-of-cut step in Pérez-García et al., quant-ph/0608197, Theorem 12: lines 1276–1289 supply the cut comparison, reused at lines 1454–1456 for the block-diagonal theorem.

The present theorem assumes the finite local separation range already available in TNLean:
(L₀ + 1) + 3(r - 1)(L₀ + 1) + 1 ≤ L.
The sharper printed source bound
3(r - 1)(L₀ + 1) + 1 ≤ L
is isolated in #4195. The theorem and blueprint state this restriction explicitly, and the paper-gap note records it.

This result supplies part of the parent-Hamiltonian ground-space analysis used in the broader RFP and MPDO programme tracked by #232.

## Verification

- lake build: passed, 9,558 targets on current main
- lake exe checkdecls blueprint/lean_decls: passed
- changed Lean files contain no sorry, axiom, admit, native_decide, or unsafeCast
- git diff --check: passed
- independent proof review: passed

The blueprint synchronizer currently reports 21 declaration-list omissions already present on main. None is introduced by this pull request; the new declarations in this change are already present in blueprint/lean_decls.

Closes #3597

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new formal proofs in core parent-Hamiltonian / BNT ground-space theory; mathematical correctness is critical but changes are additive Lean with documented scope limits rather than refactors of unrelated infrastructure.
> 
> **Overview**
> **Closes the periodic boundary comparison for normalized BNT block-diagonal parent Hamiltonians** by comparing two open-boundary decompositions after moving the global cut by \(L_0\) sites, instead of assuming boundary-crossing identities or short-tail simultaneous spanning.
> 
> Adds **`CyclicTranslation.lean`** (`cyclicTranslateCfg`, `cyclicTranslateState`, invariance of `chainGroundSpace`, and `cyclicTranslateCfg_fin_append` for cut word exchange) and **`BNTBlockDiagonalBoundaryClosing.lean`**, which derives blockwise boundary intertwiners from trace pairings at complementary length \(N-L_0\), then uses \(L_0\)-injectivity to get commutation and feed existing right-boundary machinery.
> 
> New capstones include **`exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1`**, **`chainGroundSpace_toTensorFromBlocks_eq_iSup_of_global_cut_bnt_c1`**, and **`ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan_of_global_cut_bnt_c1`**. Blueprint chapter 13 and **`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`** are updated to record that issue #3597 is resolved in TNLean’s separation range, with the sharper source length bound left to #4195.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9aadfddc58dbd0cd6e216dfc5a3ccec2fd4fe4e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->