### PR TITLE
feat(Channel): specialize the mean-ergodic projection

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -196,6 +196,7 @@ import TNLean.Channel.FixedPoint.Algebra
 import TNLean.Channel.FixedPoint.BlockForm
 import TNLean.Channel.FixedPoint.ChoiEffros
 import TNLean.Channel.FixedPoint.Cesaro
+import TNLean.Channel.FixedPoint.MeanErgodicProjection
 import TNLean.Channel.FixedPoint.CornerAlgebra
 import TNLean.Channel.FixedPoint.CornerBlockForm
 import TNLean.Channel.FixedPoint.CornerFixedPoints

--- a/TNLean/Channel/FixedPoint/MeanErgodicProjection.lean
+++ b/TNLean/Channel/FixedPoint/MeanErgodicProjection.lean
@@ -52,7 +52,7 @@ the orbit lies in a bounded trace section of the positive cone.
 
 Source: Wolf, Proposition 6.3 and Equation (6.14), local source
 `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 226--256. -/
-theorem IsPositiveMap.isBounded_orbit_of_posSemidef_of_tracePreserving
+private theorem IsPositiveMap.isBounded_orbit_of_posSemidef_of_tracePreserving
     {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
     (hT : IsPositiveMap T) (hTP : IsTracePreservingMap T)
     {X : Matrix (Fin D) (Fin D) ℂ} (hX : X.PosSemidef) :
@@ -84,7 +84,7 @@ bound.
 
 Source: Wolf, Proposition 6.3 and Equation (6.14), local source
 `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 226--256. -/
-theorem IsPositiveMap.isBounded_orbit_of_isHermitian_of_tracePreserving
+private theorem IsPositiveMap.isBounded_orbit_of_isHermitian_of_tracePreserving
     {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
     (hT : IsPositiveMap T) (hTP : IsTracePreservingMap T)
     {X : Matrix (Fin D) (Fin D) ℂ} (hX : X.IsHermitian) :

--- a/TNLean/Channel/FixedPoint/MeanErgodicProjection.lean
+++ b/TNLean/Channel/FixedPoint/MeanErgodicProjection.lean
@@ -1,0 +1,281 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Analysis.MeanErgodic
+import TNLean.Channel.Basic
+
+/-!
+# Positive trace-preserving mean-ergodic projections
+
+A positive trace-preserving endomorphism of a finite-dimensional complex matrix
+algebra has bounded forward orbits.  Its finite-dimensional mean-ergodic
+projection is therefore defined, is positive and trace-preserving, and fixes the
+identity whenever the original map fixes the identity.
+
+The bounded-orbit estimate is proved directly.  A positive semidefinite orbit
+remains in a bounded trace section of the positive cone.  Hermitian matrices are
+differences of their positive and negative parts, and arbitrary matrices are
+complex linear combinations of two Hermitian matrices.
+
+## Main statements
+
+* `IsPositiveMap.hasBoundedOrbits_of_tracePreserving`: positivity and trace
+  preservation imply bounded forward orbits on every matrix.
+* `IsPositiveMap.meanErgodicProjection_isPositiveMap`: the mean-ergodic
+  projection of a positive map is positive.
+* `IsTracePreservingMap.meanErgodicProjection_isTracePreservingMap`: the
+  mean-ergodic projection of a trace-preserving map is trace-preserving.
+* `LinearMap.HasBoundedOrbits.meanErgodicProjection_one`: a fixed identity is
+  fixed by the mean-ergodic projection.
+* `IsPositiveMap.range_meanErgodicProjection_of_tracePreserving`: the range of
+  the resulting projection is exactly the fixed-point space.
+
+## References
+
+* M. Wolf, *Quantum Channels & Operations: Guided Tour*, Proposition 6.3 and
+  Equation (6.14); local source
+  `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 226--256.
+-/
+
+open Filter Function Set
+open scoped Matrix ComplexOrder MatrixOrder Matrix.Norms.Frobenius Topology
+
+variable {D : ℕ}
+
+/-- The forward orbit of a positive semidefinite matrix under a positive
+trace-preserving endomorphism is bounded.
+
+Indeed, every iterate remains positive semidefinite and has the same trace, so
+the orbit lies in a bounded trace section of the positive cone.
+
+Source: Wolf, Proposition 6.3 and Equation (6.14), local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 226--256. -/
+theorem IsPositiveMap.isBounded_orbit_of_posSemidef_of_tracePreserving
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT : IsPositiveMap T) (hTP : IsTracePreservingMap T)
+    {X : Matrix (Fin D) (Fin D) ℂ} (hX : X.PosSemidef) :
+    Bornology.IsBounded (Set.range fun n : ℕ ↦ T^[n] X) := by
+  have hiter_pos : ∀ n : ℕ, (T^[n] X).PosSemidef := by
+    intro n
+    induction n with
+    | zero => simpa using hX
+    | succ n ih =>
+        rw [Function.iterate_succ_apply']
+        exact hT _ ih
+  have hiter_trace : ∀ n : ℕ, Matrix.trace (T^[n] X) = Matrix.trace X := by
+    intro n
+    induction n with
+    | zero => rfl
+    | succ n ih =>
+        rw [Function.iterate_succ_apply', hTP, ih]
+  apply (posSemidef_trace_bounded_isBounded ‖Matrix.trace X‖).subset
+  intro Y hY
+  obtain ⟨n, rfl⟩ := hY
+  exact ⟨hiter_pos n, by rw [hiter_trace n]⟩
+
+/-- The forward orbit of a Hermitian matrix under a positive
+trace-preserving endomorphism is bounded.
+
+The matrix is the difference of its positive and negative parts.  Each part
+has a bounded positive semidefinite orbit, and linearity gives the stated
+bound.
+
+Source: Wolf, Proposition 6.3 and Equation (6.14), local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 226--256. -/
+theorem IsPositiveMap.isBounded_orbit_of_isHermitian_of_tracePreserving
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT : IsPositiveMap T) (hTP : IsTracePreservingMap T)
+    {X : Matrix (Fin D) (Fin D) ℂ} (hX : X.IsHermitian) :
+    Bornology.IsBounded (Set.range fun n : ℕ ↦ T^[n] X) := by
+  let Q₁ : Matrix (Fin D) (Fin D) ℂ := X⁺
+  let Q₂ : Matrix (Fin D) (Fin D) ℂ := X⁻
+  have hQ₁ : Q₁.PosSemidef :=
+    Matrix.nonneg_iff_posSemidef.mp (CFC.posPart_nonneg X)
+  have hQ₂ : Q₂.PosSemidef :=
+    Matrix.nonneg_iff_posSemidef.mp (CFC.negPart_nonneg X)
+  have hdecomp : X = Q₁ - Q₂ := by
+    simpa only [Q₁, Q₂] using
+      (CFC.posPart_sub_negPart X (isSelfAdjoint_iff.mpr hX)).symm
+  have hb₁ := hT.isBounded_orbit_of_posSemidef_of_tracePreserving hTP hQ₁
+  have hb₂ := hT.isBounded_orbit_of_posSemidef_of_tracePreserving hTP hQ₂
+  rw [isBounded_iff_forall_norm_le] at hb₁ hb₂ ⊢
+  obtain ⟨C₁, hC₁⟩ := hb₁
+  obtain ⟨C₂, hC₂⟩ := hb₂
+  refine ⟨C₁ + C₂, ?_⟩
+  intro Y hY
+  obtain ⟨n, rfl⟩ := hY
+  change ‖T^[n] X‖ ≤ C₁ + C₂
+  rw [hdecomp, iterate_map_sub]
+  calc
+    ‖T^[n] Q₁ - T^[n] Q₂‖ ≤ ‖T^[n] Q₁‖ + ‖T^[n] Q₂‖ := norm_sub_le _ _
+    _ ≤ C₁ + C₂ := add_le_add (hC₁ _ ⟨n, rfl⟩) (hC₂ _ ⟨n, rfl⟩)
+
+/-- A positive trace-preserving endomorphism of a finite-dimensional complex
+matrix algebra has bounded forward orbits on every matrix.
+
+For an arbitrary matrix (X), the matrices (X+X^*) and
+\(i(X-X^*)\) are Hermitian and
+\[
+  X=\frac12\bigl((X+X^*)-i\,i(X-X^*)\bigr).
+\]
+The Hermitian-orbit estimate and linearity then give a uniform bound for the
+orbit of (X).  No contractivity hypothesis is used.
+
+Source: Wolf, Proposition 6.3 and Equation (6.14), local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 226--256. -/
+theorem IsPositiveMap.hasBoundedOrbits_of_tracePreserving
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT : IsPositiveMap T) (hTP : IsTracePreservingMap T) :
+    T.HasBoundedOrbits := by
+  intro X
+  let H₁ : Matrix (Fin D) (Fin D) ℂ := X + Xᴴ
+  let H₂ : Matrix (Fin D) (Fin D) ℂ := Complex.I • (X - Xᴴ)
+  have hH₁ : H₁.IsHermitian := by
+    ext i j
+    simp [H₁, add_comm]
+  have hH₂ : H₂.IsHermitian := by
+    ext i j
+    simp [H₂, sub_eq_add_neg, add_comm]
+  have hdecomp : X = (2 : ℂ)⁻¹ • (H₁ - Complex.I • H₂) := by
+    ext i j
+    simp only [H₁, H₂, Matrix.add_apply, Matrix.sub_apply, Matrix.smul_apply,
+      smul_eq_mul]
+    ring_nf
+    rw [Complex.I_sq]
+    ring
+  have hb₁ := hT.isBounded_orbit_of_isHermitian_of_tracePreserving hTP hH₁
+  have hb₂ := hT.isBounded_orbit_of_isHermitian_of_tracePreserving hTP hH₂
+  rw [isBounded_iff_forall_norm_le] at hb₁ hb₂ ⊢
+  obtain ⟨C₁, hC₁⟩ := hb₁
+  obtain ⟨C₂, hC₂⟩ := hb₂
+  refine ⟨‖(2 : ℂ)⁻¹‖ * (C₁ + C₂), ?_⟩
+  intro Y hY
+  obtain ⟨n, rfl⟩ := hY
+  change ‖T^[n] X‖ ≤ ‖(2 : ℂ)⁻¹‖ * (C₁ + C₂)
+  rw [hdecomp, ← Module.End.coe_pow]
+  simp only [map_smul, map_sub]
+  rw [norm_smul]
+  apply mul_le_mul_of_nonneg_left _ (norm_nonneg _)
+  calc
+    ‖(T ^ n) H₁ - Complex.I • (T ^ n) H₂‖ ≤
+        ‖(T ^ n) H₁‖ + ‖Complex.I • (T ^ n) H₂‖ := norm_sub_le _ _
+    _ = ‖T^[n] H₁‖ + ‖T^[n] H₂‖ := by
+      simp only [norm_smul, Complex.norm_I, one_mul, Module.End.coe_pow]
+    _ ≤ C₁ + C₂ := add_le_add (hC₁ _ ⟨n, rfl⟩) (hC₂ _ ⟨n, rfl⟩)
+
+/-- The finite-dimensional mean-ergodic projection of a positive matrix
+endomorphism is positive.
+
+Every Cesàro average is positive on a positive semidefinite input.  The
+positive semidefinite cone is closed, so the pointwise mean-ergodic limit is
+positive as well.
+
+Source: Wolf, Proposition 6.3(iii) and Equation (6.14), local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 226--256. -/
+theorem IsPositiveMap.meanErgodicProjection_isPositiveMap
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT : IsPositiveMap T) (hbounded : T.HasBoundedOrbits) :
+    IsPositiveMap (LinearMap.meanErgodicProjection T hbounded) := by
+  intro X hX
+  have hiter_pos : ∀ n : ℕ, (T^[n] X).PosSemidef := by
+    intro n
+    induction n with
+    | zero => simpa using hX
+    | succ n ih =>
+        rw [Function.iterate_succ_apply']
+        exact hT _ ih
+  have havg_pos : ∀ n : ℕ,
+      (birkhoffAverage ℂ T _root_.id n X).PosSemidef := by
+    intro n
+    rw [birkhoffAverage, birkhoffSum]
+    exact (Matrix.posSemidef_sum _ fun k _ ↦ hiter_pos k).smul (by positivity)
+  exact isClosed_posSemidef.mem_of_tendsto
+    (hbounded.tendsto_birkhoffAverage_meanErgodicProjection X)
+    (Filter.Eventually.of_forall havg_pos)
+
+/-- The finite-dimensional mean-ergodic projection of a trace-preserving
+matrix endomorphism is trace-preserving.
+
+The trace of every nonempty Cesàro average equals the trace of the input.
+Continuity of the trace and pointwise mean-ergodic convergence pass this
+identity to the limit.
+
+Source: Wolf, Proposition 6.3(iii) and Equation (6.14), local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 226--256. -/
+theorem IsTracePreservingMap.meanErgodicProjection_isTracePreservingMap
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hTP : IsTracePreservingMap T) (hbounded : T.HasBoundedOrbits) :
+    IsTracePreservingMap (LinearMap.meanErgodicProjection T hbounded) := by
+  intro X
+  have hiter_trace : ∀ n : ℕ, Matrix.trace (T^[n] X) = Matrix.trace X := by
+    intro n
+    induction n with
+    | zero => rfl
+    | succ n ih =>
+        rw [Function.iterate_succ_apply', hTP, ih]
+  have havg_trace : ∀ n : ℕ, n ≠ 0 →
+      Matrix.trace (birkhoffAverage ℂ T _root_.id n X) = Matrix.trace X := by
+    intro n hn
+    simp only [birkhoffAverage, birkhoffSum, id_eq, Matrix.trace_smul,
+      Matrix.trace_sum, hiter_trace, Finset.sum_const, Finset.card_range,
+      nsmul_eq_mul, smul_eq_mul]
+    rw [← mul_assoc, inv_mul_cancel₀ (show (n : ℂ) ≠ 0 by exact_mod_cast hn),
+      one_mul]
+  have hlimit := hbounded.tendsto_birkhoffAverage_meanErgodicProjection X
+  have htrace_limit : Tendsto
+      (fun n ↦ Matrix.trace (birkhoffAverage ℂ T _root_.id n X)) atTop
+      (𝓝 (Matrix.trace (LinearMap.meanErgodicProjection T hbounded X))) :=
+    ((Matrix.traceLinearMap (Fin D) ℂ ℂ).continuous_of_finiteDimensional.tendsto
+      (LinearMap.meanErgodicProjection T hbounded X)).comp hlimit
+  have heventually : ∀ᶠ n : ℕ in atTop,
+      Matrix.trace (birkhoffAverage ℂ T _root_.id n X) = Matrix.trace X :=
+    (Filter.eventually_ne_atTop 0).mono fun n hn ↦ havg_trace n hn
+  have htrace_constant : Tendsto
+      (fun n : ℕ ↦ Matrix.trace (birkhoffAverage ℂ T _root_.id n X)) atTop
+      (𝓝 (Matrix.trace X)) :=
+    tendsto_const_nhds.congr' (heventually.mono fun _ h ↦ h.symm)
+  exact tendsto_nhds_unique htrace_limit htrace_constant
+
+/-- If a matrix endomorphism fixes the identity, then its mean-ergodic
+projection fixes the identity.
+
+Source: Wolf, Proposition 6.3(iii) and Equation (6.14), local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 226--256. -/
+theorem LinearMap.HasBoundedOrbits.meanErgodicProjection_one
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hbounded : T.HasBoundedOrbits) (hOne : T 1 = 1) :
+    LinearMap.meanErgodicProjection T hbounded 1 = 1 := by
+  exact hbounded.meanErgodicProjection_apply_eq_self_iff 1 |>.2 hOne
+
+/-- The range of the mean-ergodic projection of a positive trace-preserving
+matrix endomorphism is exactly its fixed-point space.
+
+Source: Wolf, Proposition 6.3 and Equation (6.14), local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 226--269. -/
+@[simp]
+theorem IsPositiveMap.range_meanErgodicProjection_of_tracePreserving
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT : IsPositiveMap T) (hTP : IsTracePreservingMap T) :
+    LinearMap.range
+        (LinearMap.meanErgodicProjection T
+          (hT.hasBoundedOrbits_of_tracePreserving hTP)) =
+      LinearMap.ker (T - 1) := by
+  exact (hT.hasBoundedOrbits_of_tracePreserving hTP).range_meanErgodicProjection
+
+/-- The mean-ergodic projection of a positive trace-preserving matrix
+endomorphism fixes precisely the fixed points of the original endomorphism.
+
+Source: Wolf, Proposition 6.3 and Equation (6.14), local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 226--269. -/
+@[simp]
+theorem IsPositiveMap.meanErgodicProjection_apply_eq_self_iff_of_tracePreserving
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT : IsPositiveMap T) (hTP : IsTracePreservingMap T)
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    LinearMap.meanErgodicProjection T
+        (hT.hasBoundedOrbits_of_tracePreserving hTP) X = X ↔
+      T X = X := by
+  exact (hT.hasBoundedOrbits_of_tracePreserving hTP)
+    |>.meanErgodicProjection_apply_eq_self_iff X

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -6,6 +6,7 @@ Authors: TNLean contributors
 import TNLean.Analysis.MeanErgodic
 import TNLean.Channel.FixedPoint.Algebra
 import TNLean.Channel.FixedPoint.Cesaro
+import TNLean.Channel.FixedPoint.MeanErgodicProjection
 import TNLean.Channel.FixedPoint.ConditionalExpectation
 import TNLean.Channel.FixedPoint.StationarySupport
 import TNLean.Channel.FixedPoint.CornerFixedPoints
@@ -272,9 +273,20 @@ the `*`-algebra structure back along the compression isomorphism.
 The general finite-dimensional convergence argument is provided by
 `LinearMap.HasBoundedOrbits.tendsto_birkhoffAverage_meanErgodicProjection` in
 `TNLean.Analysis.MeanErgodic`. It constructs the Cesàro projection onto the
-fixed-point space for an endomorphism with bounded orbits. The proof that this
-projection is positive and unital for matrix maps remains open here, as does its
-application to the full statement of Theorem 6.14.
+fixed-point space for an endomorphism with bounded orbits. The matrix
+specialization is provided by
+`IsPositiveMap.hasBoundedOrbits_of_tracePreserving`,
+`IsPositiveMap.meanErgodicProjection_isPositiveMap`, and
+`IsTracePreservingMap.meanErgodicProjection_isTracePreservingMap`: a positive
+trace-preserving matrix endomorphism has bounded orbits, and its mean-ergodic
+projection is a positive trace-preserving retraction onto its fixed-point
+space. If the original endomorphism is unital, the projection is unital as
+well.
+
+The remaining mean-ergodic step for Theorem 6.14 is to identify the
+trace-pairing adjoint of this projection with the corresponding retraction on
+the adjoint fixed-point space and to combine it with the full-support
+star-algebra description.
 
 In `TNLean.Channel.FixedPoint.WedderburnDecomp`:
 

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -951,9 +951,8 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
         P_f^2=P_f,\qquad fP_f=P_f=P_f f,
     \]
     and $P_f x=x$ if and only if $f x=x$.
-    The complex matrix specialization gives the convergence step underlying
-    \cite[Equation~(6.14)]{Wolf2012Quantum}; positivity and unitality of the
-    limiting projection are separate assertions.
+    The complex matrix specialization underlying
+    \cite[Equation~(6.14)]{Wolf2012Quantum} is given below.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -979,6 +978,50 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     \]
     so $P_f(fx)=P_f x$ and hence $P_f f=P_f$. The range and idempotence
     identities follow directly from the projection construction.
+\end{proof}
+
+\begin{theorem}[Positive trace-preserving mean-ergodic projection]
+    \label{thm:positive_trace_preserving_mean_ergodic_projection}
+    \lean{IsPositiveMap.isBounded_orbit_of_posSemidef_of_tracePreserving,
+        IsPositiveMap.isBounded_orbit_of_isHermitian_of_tracePreserving,
+        IsPositiveMap.hasBoundedOrbits_of_tracePreserving,
+        IsPositiveMap.meanErgodicProjection_isPositiveMap,
+        IsTracePreservingMap.meanErgodicProjection_isTracePreservingMap,
+        LinearMap.HasBoundedOrbits.meanErgodicProjection_one,
+        IsPositiveMap.range_meanErgodicProjection_of_tracePreserving,
+        IsPositiveMap.meanErgodicProjection_apply_eq_self_iff_of_tracePreserving}
+    \leanok
+    \uses{def:positive_map, def:trace_preserving,
+        def:mean_ergodic_projection}
+    Let $T:\MN{D}\to\MN{D}$ be positive and trace-preserving. Then $T$ has
+    bounded orbits, and its mean-ergodic projection $P_T$ is positive and
+    trace-preserving. Its range is precisely the fixed-point space of $T$:
+    \[
+        \operatorname{range}(P_T)=\ker(T-\Id),
+        \qquad
+        P_T(X)=X \iff T(X)=X.
+    \]
+    If $T(\Id)=\Id$, then $P_T(\Id)=\Id$.
+    This is the Ces\`aro projection $T_\infty$ of
+    \cite[Proposition~6.3 and Equation~(6.14)]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mean_ergodic_bounded_orbits}
+    If $X\ge 0$, then $T^n(X)\ge 0$ and
+    $\tr(T^n(X))=\tr(X)$. Hence the orbit of $X$ lies in a bounded trace
+    section of the positive cone. For Hermitian $X$, write
+    $X=X_+-X_-$, and for arbitrary $X$ use the two Hermitian matrices
+    \[
+        H_1=X+X^*,\qquad H_2=i(X-X^*),\qquad
+        X=\frac12(H_1-iH_2).
+    \]
+    Thus every orbit is bounded. Theorem~\ref{thm:mean_ergodic_bounded_orbits}
+    gives the projection and its fixed-point characterization. Every Ces\`aro
+    average is positive, so closedness of the positive cone makes $P_T$
+    positive. Trace preservation passes to the limit by continuity of the
+    trace. Finally, if $T(\Id)=\Id$, the fixed-point characterization gives
+    $P_T(\Id)=\Id$.
 \end{proof}
 
 \begin{theorem}[Hermitian fixed-point decomposition]\label{thm:hermitian_fixedpoint_parts}

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -980,19 +980,62 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     identities follow directly from the projection construction.
 \end{proof}
 
+\begin{theorem}[Positive mean-ergodic projection]
+    \label{thm:positive_mean_ergodic_projection}
+    \lean{IsPositiveMap.meanErgodicProjection_isPositiveMap}
+    \leanok
+    \uses{def:positive_map, def:mean_ergodic_projection,
+        thm:mean_ergodic_bounded_orbits}
+    Let $T:\MN{D}\to\MN{D}$ be positive and have bounded orbits. Then its
+    mean-ergodic projection $P_T$ is positive.
+\end{theorem}
+
+\begin{proof}\leanok
+    Every Ces\`aro average is positive. Therefore, for $X\ge 0$, closedness of
+    the positive cone and convergence of the averages give $P_T(X)\ge 0$.
+\end{proof}
+
+\begin{theorem}[Trace-preserving mean-ergodic projection]
+    \label{thm:trace_preserving_mean_ergodic_projection}
+    \lean{IsTracePreservingMap.meanErgodicProjection_isTracePreservingMap}
+    \leanok
+    \uses{def:trace_preserving, def:mean_ergodic_projection,
+        thm:mean_ergodic_bounded_orbits}
+    Let $T:\MN{D}\to\MN{D}$ be trace-preserving and have bounded orbits.
+    Then its mean-ergodic projection $P_T$ is trace-preserving.
+\end{theorem}
+
+\begin{proof}\leanok
+    Every nonempty Ces\`aro average preserves the trace. Convergence of the
+    averages and continuity of the trace therefore give
+    $\tr(P_T(X))=\tr(X)$.
+\end{proof}
+
+\begin{theorem}[Identity under the mean-ergodic projection]
+    \label{thm:unital_mean_ergodic_projection}
+    \lean{LinearMap.HasBoundedOrbits.meanErgodicProjection_one}
+    \leanok
+    \uses{def:mean_ergodic_projection, thm:mean_ergodic_bounded_orbits}
+    Let $T:\MN{D}\to\MN{D}$ have bounded orbits. If $T(\Id)=\Id$, then
+    $P_T(\Id)=\Id$.
+\end{theorem}
+
+\begin{proof}\leanok
+    The identity is a fixed point of $T$, so the fixed-point characterization
+    of the mean-ergodic projection gives the conclusion.
+\end{proof}
+
 \begin{theorem}[Positive trace-preserving mean-ergodic projection]
     \label{thm:positive_trace_preserving_mean_ergodic_projection}
-    \lean{IsPositiveMap.isBounded_orbit_of_posSemidef_of_tracePreserving,
-        IsPositiveMap.isBounded_orbit_of_isHermitian_of_tracePreserving,
-        IsPositiveMap.hasBoundedOrbits_of_tracePreserving,
-        IsPositiveMap.meanErgodicProjection_isPositiveMap,
-        IsTracePreservingMap.meanErgodicProjection_isTracePreservingMap,
-        LinearMap.HasBoundedOrbits.meanErgodicProjection_one,
+    \lean{IsPositiveMap.hasBoundedOrbits_of_tracePreserving,
         IsPositiveMap.range_meanErgodicProjection_of_tracePreserving,
         IsPositiveMap.meanErgodicProjection_apply_eq_self_iff_of_tracePreserving}
     \leanok
     \uses{def:positive_map, def:trace_preserving,
-        def:mean_ergodic_projection}
+        def:mean_ergodic_projection,
+        thm:positive_mean_ergodic_projection,
+        thm:trace_preserving_mean_ergodic_projection,
+        thm:unital_mean_ergodic_projection}
     Let $T:\MN{D}\to\MN{D}$ be positive and trace-preserving. Then $T$ has
     bounded orbits, and its mean-ergodic projection $P_T$ is positive and
     trace-preserving. Its range is precisely the fixed-point space of $T$:
@@ -1007,7 +1050,10 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mean_ergodic_bounded_orbits}
+    \uses{thm:mean_ergodic_bounded_orbits,
+        thm:positive_mean_ergodic_projection,
+        thm:trace_preserving_mean_ergodic_projection,
+        thm:unital_mean_ergodic_projection}
     If $X\ge 0$, then $T^n(X)\ge 0$ and
     $\tr(T^n(X))=\tr(X)$. Hence the orbit of $X$ lies in a bounded trace
     section of the positive cone. For Hermitian $X$, write
@@ -1017,11 +1063,9 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
         X=\frac12(H_1-iH_2).
     \]
     Thus every orbit is bounded. Theorem~\ref{thm:mean_ergodic_bounded_orbits}
-    gives the projection and its fixed-point characterization. Every Ces\`aro
-    average is positive, so closedness of the positive cone makes $P_T$
-    positive. Trace preservation passes to the limit by continuity of the
-    trace. Finally, if $T(\Id)=\Id$, the fixed-point characterization gives
-    $P_T(\Id)=\Id$.
+    gives the projection and its fixed-point characterization. Its positivity,
+    trace preservation, and behavior on the identity follow from the three
+    preceding theorems.
 \end{proof}
 
 \begin{theorem}[Hermitian fixed-point decomposition]\label{thm:hermitian_fixedpoint_parts}

--- a/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
+++ b/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
@@ -95,8 +95,10 @@ Its fixed-product hypothesis is not a hypothesis of CPSV16.  The source
 instead obtains the identity from the density-weighted structure of the
 fixed-point space.
 
-The general density-weighted form of Wolf's Theorem~6.14 in the
-Schr\"odinger picture is not yet formalized.  Its precise boundary is recorded in
+The positive trace-preserving mean-ergodic retraction on a full matrix algebra
+is formalized, but the general density-weighted form of Wolf's Theorem~6.14 in
+the Schr\"odinger picture is not yet assembled.  Its precise boundary is
+recorded in
 \path{docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex}.  For
 the transported sector maps one must also prove the channel hypotheses on the
 full direct sums, rather than only on the contraction families.  In the

--- a/docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex
+++ b/docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex
@@ -53,21 +53,31 @@ this subspace.  This is the statement in
 \cite[Theorem~6.14]{Wolf2012Quantum}; the local source is
 \path{Notes/WolfNotePDF/wolf_ch6_sections.txt}, lines~896--905.
 
-The completed formal theorem classifies a given positive retraction onto a
-unital $*$-subalgebra.  Three further arguments are needed to obtain the
-fixed-point statement above.  First, the hypotheses on $T$ must be used to
-construct a positive retraction onto $\operatorname{Fix}(T)$, for example by
-Ces\`aro means, and to identify the full-support part of this fixed-point
-space with a unital $*$-algebra.  Second, the positive semidefinite density
-matrices supplied by Proposition~1.5 must be restricted to their supports;
-this produces the positive definite matrices in Theorem~6.14.  Third, the
+The mean-ergodic part is now formalized.  A positive trace-preserving
+endomorphism has bounded forward orbits on every matrix, and its
+mean-ergodic projection is a positive trace-preserving retraction whose range
+is exactly $\operatorname{Fix}(T)$.
+\footnote{Formal declarations:
+\leanid{IsPositiveMap.hasBoundedOrbits_of_tracePreserving},
+\leanid{IsPositiveMap.meanErgodicProjection_isPositiveMap}, and
+\leanid{IsTracePreservingMap.meanErgodicProjection_isTracePreservingMap}.}
+If the original map is unital, this projection is also unital.
+
+Three arguments remain to obtain the fixed-point statement above.  First,
+the trace-pairing adjoint of the mean-ergodic projection must be identified
+with the corresponding retraction on $\operatorname{Fix}(T^*)$, and the
+Schwarz hypothesis must be used to identify its full-support range with a
+unital $*$-algebra.  Second, the positive semidefinite density matrices
+supplied by Proposition~1.5 must be restricted to their supports; this
+produces the positive definite matrices in Theorem~6.14.  Third, the
 discarded kernels must be assembled with the subspace on which every fixed
 point vanishes, thereby recovering the zero summand $\mathcal H_0$.
 
 Thus Proposition~1.5 is fully formalized, while Theorem~6.14 remains an open
 gap.  The missing work is not another classification of a given retraction:
-it is the construction of the fixed-point retraction, the full-support
-reduction, and the recovery of the zero block from the kernels.
+it is the adjoint and full-support algebra identification for the completed
+fixed-point retraction, the positive-definite support reduction, and the
+recovery of the zero block from the kernels.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Motivation

Wolf Proposition 6.3 gives the Cesàro projection for a positive trace-preserving matrix endomorphism. This is the analytic retraction needed before the density-weighted fixed-point decomposition in Wolf Theorem 6.14 and the vertical-sector argument of CPSV16 Appendix C.4.

The exact local source is `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 226--256. In particular, Proposition 6.3(iii) states that the Cesàro limit is positive and trace-preserving, and unital when the original map is unital.

## Description

- prove directly that positive trace-preserving matrix endomorphisms have bounded forward orbits;
- prove that the finite-dimensional mean-ergodic projection is positive and trace-preserving;
- prove that it fixes the identity when the original endomorphism does;
- specialize the range and fixed-point characterizations;
- update the Wolf Chapter 6 index, blueprint, and the two relevant paper-gap notes.

This supplies the mean-ergodic increment of LionSR/QICLean#219. The density-weighted block decomposition, adjoint/full-support algebra identification, support reduction, and zero-block assembly remain open, so this PR does not close LionSR/QICLean#219, LionSR/QICLean#39, or LionSR/TNLean#4120.

## Testing

- `lake env lean TNLean/Channel/FixedPoint/MeanErgodicProjection.lean`
- `lake build TNLean.Channel.FixedPoint.MeanErgodicProjection TNLean.Channel.WolfChapter6Index TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check origin/main...HEAD`
- axiom audit: only `propext`, `Classical.choice`, and `Quot.sound`

Addresses LionSR/QICLean#219
Advances LionSR/QICLean#39 and LionSR/TNLean#4120

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style proofs and documentation; no runtime or security-sensitive paths. Remaining Wolf 6.14 work is explicitly out of scope.
> 
> **Overview**
> Adds **`TNLean.Channel.FixedPoint.MeanErgodicProjection`**, formalizing Wolf Proposition 6.3 / Equation (6.14): positive trace-preserving endomorphisms on `M_D(ℂ)` have **bounded forward orbits** (via PSD → Hermitian → general decomposition, without contractivity), and their **mean-ergodic projection** is **positive**, **trace-preserving**, fixes **1** when `T 1 = 1`, and has **range** `ker(T - 1)` with the usual fixed-point iff.
> 
> The module is exported from **`TNLean.lean`** and **`WolfChapter6Index`**, which now records Theorem 6.14’s mean-ergodic step as done while adjoint/full-support assembly remains open. The **blueprint** (`ch04_channels.tex`) gains linked theorems for positivity, trace preservation, unitality on the identity, and the combined PT statement. **Paper-gap** notes (`wolf_theorem6_14_*`, `cpsv16_vertical_sector_*`) are updated to cite the new declarations and narrow what is still missing for Wolf 6.14 and CPSV16.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34bb4d9fac3caf348149e0f23c0060ef73fc9c52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->