### PR TITLE
doc(Channel/Schwarz): address product-marginal review

### DIFF
--- a/TNLean/Channel/Schwarz/SSAEqualityDPI.lean
+++ b/TNLean/Channel/Schwarz/SSAEqualityDPI.lean
@@ -332,9 +332,8 @@ $\operatorname{tr}_C$, since tracing out $C$ sends
 $(\mathbf 1_A/d_A)\otimes\rho_{BC}$ to
 $(\mathbf 1_A/d_A)\otimes\rho_B$.
 
-This is an equivalent formulation of
-`isSSAEquality_iff_product_marginal_data_processing_eq`: both relative-entropy
-differences equal the strong-subadditivity deficit. The exact
+This is an equivalent criterion with a different reference state: both
+relative-entropy differences equal the strong-subadditivity deficit. The exact
 Hayden--Jozsa--Petz--Winter pair uses $\rho_A$ in place of the maximally mixed
 state on $A$.
 

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -1802,7 +1802,6 @@ Theorem~\ref{thm:trace_norm_abs}.
 \begin{theorem}[SSA equality as saturation for the product marginals]
     \label{thm:ssa_equality_product_marginal_dpi}
     \lean{isSSAEquality_iff_product_marginal_data_processing_eq}
-    \lean{SSAPosDef.partialTraceRight_traceC_ABC}
     \lean{SSAPosDef.traceC_ABC_product_marginals}
     \leanok
     \uses{def:ssa_equality, def:quantum_relative_entropy,
@@ -1836,8 +1835,13 @@ Theorem~\ref{thm:trace_norm_abs}.
     \[
         S(\rho_{ABC})+S(\rho_B)=S(\rho_{AB})+S(\rho_{BC}).
     \]
-    The partial-trace identity follows by expanding the matrix entries and
-    interchanging the finite sums over the $A$ and $C$ indices.
+    Entrywise, the partial-trace identity is
+    \[
+        \bigl[\tr_C(\rho_A\otimes\rho_{BC})\bigr]_{(a,b),(a',b')}
+        =\sum_c(\rho_A)_{a,a'}(\rho_{BC})_{(b,c),(b',c)}
+        =(\rho_A)_{a,a'}(\rho_B)_{b,b'}
+        =\bigl[\rho_A\otimes\rho_B\bigr]_{(a,b),(a',b')}.
+    \]
 \end{proof}
 
 \begin{theorem}[SSA equality as saturation for a maximally mixed reference]


### PR DESCRIPTION
## Summary

Post-merge recovery for LionSR/TNLean#4201:

- remove an auxiliary declaration incorrectly tagged as a co-formalization of the HJPW theorem;
- replace the word-only partial-trace proof sketch with the displayed entrywise calculation;
- replace a Lean identifier in reader-facing docstring prose with mathematical wording.

## Faithfulness check

The merged theorem `isSSAEquality_iff_product_marginal_data_processing_eq` remains unchanged. Its statement uses exactly the positive-semidefinite, trace-one tripartite-state domain and the HJPW product-marginal pair, with no invertibility assumption. The more general bipartite positive-semidefinite evaluation specializes faithfully to the source's density-state setting.

## Validation

- `lake build TNLean.Channel.Schwarz.SSAEqualityDPI`
- `lake env lean TNLean/Channel/Schwarz/SSAEqualityDPI.lean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- proof-integrity scan of the touched Lean file
- `git diff --check origin/main...HEAD`

Closes LionSR/QICLean#220
Closes LionSR/QICLean#221

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prose and blueprint–Lean tagging only; formal theorems including `isSSAEquality_iff_product_marginal_data_processing_eq` are untouched.
> 
> **Overview**
> **Documentation-only** follow-up on SSA equality and the Hayden–Jozsa–Petz–Winter product-marginal data-processing story. No Lean theorem statements or proofs change.
> 
> In **blueprint** `thm:ssa_equality_product_marginal_dpi`, the incorrect `\lean` link to `SSAPosDef.partialTraceRight_traceC_ABC` is removed (that lemma is not what the HJPW partial-trace identity states). The vague “expand entries and interchange sums” sketch is replaced by an **entrywise** display showing \(\tr_C(\rho_A\otimes\rho_{BC})=\rho_A\otimes\rho_B\).
> 
> In **Lean**, the docstring for `isSSAEquality_iff_maximally_mixed_reference_data_processing_eq` no longer names the product-marginal theorem as an “equivalent formulation”; it describes the maximally mixed reference as an **equivalent criterion with a different reference state**, with both relative-entropy gaps matching the SSA deficit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31c104e5241a0011cbb852357db17320619c1cfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->