### PR TITLE
feat(Channel): identify the adjoint Cesàro projection

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -197,6 +197,7 @@ import TNLean.Channel.FixedPoint.BlockForm
 import TNLean.Channel.FixedPoint.ChoiEffros
 import TNLean.Channel.FixedPoint.Cesaro
 import TNLean.Channel.FixedPoint.MeanErgodicProjection
+import TNLean.Channel.FixedPoint.MeanErgodicAdjoint
 import TNLean.Channel.FixedPoint.CornerAlgebra
 import TNLean.Channel.FixedPoint.CornerBlockForm
 import TNLean.Channel.FixedPoint.CornerFixedPoints

--- a/TNLean/Channel/FixedPoint/MeanErgodicAdjoint.lean
+++ b/TNLean/Channel/FixedPoint/MeanErgodicAdjoint.lean
@@ -1,0 +1,198 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.FixedPoint.MeanErgodicProjection
+import TNLean.Channel.Schwarz.TwoPositive
+
+/-!
+# Trace adjoints of mean-ergodic projections
+
+This module identifies the trace-pairing adjoint of a finite-dimensional
+mean-ergodic projection.  Its range is the fixed-point space of the adjoint
+endomorphism.  For a positive trace-preserving matrix endomorphism, this
+adjoint projection is a positive unital retraction.
+
+## References
+
+* M. Wolf, *Quantum Channels & Operations: Guided Tour*, Proposition 6.3 and
+  Equation (6.14); local source
+  `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 226--269.
+* M. Wolf, Theorem 6.14, proof; local source
+  `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1488--1492.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder Matrix.Norms.Frobenius
+
+variable {D : ℕ}
+
+/-- A matrix endomorphism is trace-preserving if and only if its trace-pairing
+adjoint fixes the identity.
+
+Source: Wolf, Chapter 3 trace-pairing duality and Proposition 6.3; local
+sources `Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`, lines
+723--737, and `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines
+226--256. -/
+theorem isTracePreservingMap_iff_traceAdjointMap_one
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ} :
+    IsTracePreservingMap T ↔ Matrix.traceAdjointMap T 1 = 1 := by
+  constructor
+  · intro hTP
+    refine sub_eq_zero.mp ((Matrix.trace_mul_right_eq_zero_iff
+      (M := Matrix.traceAdjointMap T 1 - 1)).1 ?_)
+    intro X
+    simp only [Matrix.sub_mul, Matrix.trace_sub,
+      Matrix.trace_traceAdjointMap_mul, one_mul]
+    exact sub_eq_zero.mpr (hTP X)
+  · intro hOne X
+    calc
+      Matrix.trace (T X) = Matrix.trace (1 * T X) := by simp
+      _ = Matrix.trace (Matrix.traceAdjointMap T 1 * X) :=
+        (Matrix.trace_traceAdjointMap_mul T 1 X).symm
+      _ = Matrix.trace X := by rw [hOne]; simp
+
+/-- The trace adjoint of the mean-ergodic projection fixes exactly the fixed
+points of the trace adjoint of the original endomorphism.
+
+The proof uses the complementary decomposition
+`X - P(X) ∈ range(T - 1)`.  A fixed point of `T*` annihilates this range under
+the trace pairing, so it is fixed by `P*`.  This avoids any bounded-orbit or
+spectral hypothesis on `T*`.
+
+Source: Wolf, Proposition 6.3 and Equation (6.14), local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 226--269; this is
+the adjoint projection used in the proof of Theorem 6.14, lines 1488--1492. -/
+theorem LinearMap.HasBoundedOrbits.traceAdjointMap_meanErgodicProjection_apply_eq_self_iff
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hbounded : T.HasBoundedOrbits) (Y : Matrix (Fin D) (Fin D) ℂ) :
+    Matrix.traceAdjointMap (LinearMap.meanErgodicProjection T hbounded) Y = Y ↔
+      Matrix.traceAdjointMap T Y = Y := by
+  let P := LinearMap.meanErgodicProjection T hbounded
+  constructor
+  · intro hPfixed
+    refine sub_eq_zero.mp ((Matrix.trace_mul_right_eq_zero_iff
+      (M := Matrix.traceAdjointMap T Y - Y)).1 ?_)
+    intro X
+    rw [Matrix.sub_mul, Matrix.trace_sub, Matrix.trace_traceAdjointMap_mul]
+    have hpairTX := Matrix.trace_traceAdjointMap_mul P Y (T X)
+    change Matrix.trace (Matrix.traceAdjointMap P Y * T X) =
+      Matrix.trace (Y * P (T X)) at hpairTX
+    rw [hPfixed] at hpairTX
+    have hpairX := Matrix.trace_traceAdjointMap_mul P Y X
+    change Matrix.trace (Matrix.traceAdjointMap P Y * X) =
+      Matrix.trace (Y * P X) at hpairX
+    rw [hPfixed] at hpairX
+    have hPT := congrArg
+      (fun F : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ ↦ F X)
+      hbounded.meanErgodicProjection_comp
+    change P (T X) = P X at hPT
+    rw [hPT] at hpairTX
+    exact sub_eq_zero.mpr (hpairTX.trans hpairX.symm)
+  · intro hfixed
+    refine sub_eq_zero.mp ((Matrix.trace_mul_right_eq_zero_iff
+      (M := Matrix.traceAdjointMap P Y - Y)).1 ?_)
+    intro X
+    rw [Matrix.sub_mul, Matrix.trace_sub, Matrix.trace_traceAdjointMap_mul]
+    have hrem : X - P X ∈ LinearMap.range (T - 1) := by
+      change X - LinearMap.meanErgodicProjection T hbounded X ∈
+        LinearMap.range (T - 1)
+      exact Submodule.sub_projection_mem
+        hbounded.isCompl_ker_sub_one_range_sub_one X
+    obtain ⟨Z, hZ⟩ := hrem
+    have hpair := Matrix.trace_traceAdjointMap_mul T Y Z
+    rw [hfixed] at hpair
+    have hzero : Matrix.trace (Y * (X - P X)) = 0 := by
+      rw [← hZ]
+      simp only [LinearMap.sub_apply, Module.End.one_apply, Matrix.mul_sub,
+        Matrix.trace_sub]
+      exact sub_eq_zero.mpr hpair.symm
+    rw [Matrix.mul_sub, Matrix.trace_sub] at hzero
+    exact sub_eq_zero.mpr (sub_eq_zero.mp hzero).symm
+
+/-- The trace adjoint of a mean-ergodic projection is idempotent.
+
+Source: Wolf, Proposition 6.3 and Equation (6.14), local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 226--269; this is
+the adjoint projection used in the proof of Theorem 6.14, lines 1488--1492. -/
+theorem LinearMap.HasBoundedOrbits.traceAdjointMap_meanErgodicProjection_apply_self
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hbounded : T.HasBoundedOrbits) (Y : Matrix (Fin D) (Fin D) ℂ) :
+    Matrix.traceAdjointMap (LinearMap.meanErgodicProjection T hbounded)
+        (Matrix.traceAdjointMap (LinearMap.meanErgodicProjection T hbounded) Y) =
+      Matrix.traceAdjointMap (LinearMap.meanErgodicProjection T hbounded) Y := by
+  let P := LinearMap.meanErgodicProjection T hbounded
+  refine sub_eq_zero.mp ((Matrix.trace_mul_right_eq_zero_iff
+    (M := Matrix.traceAdjointMap P (Matrix.traceAdjointMap P Y) -
+      Matrix.traceAdjointMap P Y)).1 ?_)
+  intro X
+  rw [Matrix.sub_mul, Matrix.trace_sub, Matrix.trace_traceAdjointMap_mul,
+    Matrix.trace_traceAdjointMap_mul]
+  rw [Matrix.trace_traceAdjointMap_mul]
+  rw [show P (P X) = P X from
+    hbounded.meanErgodicProjection_apply_meanErgodicProjection X]
+  exact sub_self _
+
+/-- The range of the trace adjoint of a mean-ergodic projection is exactly the
+fixed-point space of the trace adjoint of the original endomorphism.
+
+Source: Wolf, Proposition 6.3 and Equation (6.14), local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 226--269; this is
+the adjoint projection used in the proof of Theorem 6.14, lines 1488--1492. -/
+@[simp]
+theorem LinearMap.HasBoundedOrbits.range_traceAdjointMap_meanErgodicProjection
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hbounded : T.HasBoundedOrbits) :
+    LinearMap.range
+        (Matrix.traceAdjointMap (LinearMap.meanErgodicProjection T hbounded)) =
+      LinearMap.ker (Matrix.traceAdjointMap T - 1) := by
+  ext Y
+  constructor
+  · rintro ⟨Z, rfl⟩
+    rw [LinearMap.mem_ker]
+    apply sub_eq_zero.mpr
+    simpa only [Module.End.one_apply] using
+      (hbounded.traceAdjointMap_meanErgodicProjection_apply_eq_self_iff
+        (Matrix.traceAdjointMap (LinearMap.meanErgodicProjection T hbounded) Z)).1
+        (hbounded.traceAdjointMap_meanErgodicProjection_apply_self Z)
+  · intro hY
+    rw [LinearMap.mem_ker] at hY
+    have hfixed : Matrix.traceAdjointMap T Y = Y := by
+      simpa only [LinearMap.sub_apply, Module.End.one_apply] using sub_eq_zero.mp hY
+    refine ⟨Y, ?_⟩
+    exact
+      (hbounded.traceAdjointMap_meanErgodicProjection_apply_eq_self_iff Y).2 hfixed
+
+/-- For a positive trace-preserving matrix endomorphism, the trace adjoint of
+the mean-ergodic projection is a positive unital idempotent retraction onto the
+fixed-point space of the adjoint endomorphism.
+
+Source: Wolf, Proposition 6.3 and Equation (6.14), local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 226--269; this is
+the positive unital adjoint projection used in the proof of Theorem 6.14,
+lines 1488--1492. -/
+theorem IsPositiveMap.traceAdjoint_meanErgodicProjection_isPositiveUnitalRetraction
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT : IsPositiveMap T) (hTP : IsTracePreservingMap T) :
+    let Pstar := Matrix.traceAdjointMap
+      (LinearMap.meanErgodicProjection T (hT.hasBoundedOrbits_of_tracePreserving hTP))
+    IsPositiveMap Pstar ∧
+      Pstar 1 = 1 ∧
+      (∀ Y, Pstar (Pstar Y) = Pstar Y) ∧
+      LinearMap.range Pstar = LinearMap.ker (Matrix.traceAdjointMap T - 1) ∧
+      (∀ Y, Pstar Y = Y ↔ Matrix.traceAdjointMap T Y = Y) := by
+  dsimp only
+  refine ⟨?_, ?_, ?_, ?_, ?_⟩
+  · exact (hT.meanErgodicProjection_isPositiveMap
+      (hT.hasBoundedOrbits_of_tracePreserving hTP)).traceAdjointMap
+  · exact isTracePreservingMap_iff_traceAdjointMap_one.mp
+      (hTP.meanErgodicProjection_isTracePreservingMap
+        (hT.hasBoundedOrbits_of_tracePreserving hTP))
+  · intro Y
+    exact (hT.hasBoundedOrbits_of_tracePreserving hTP)
+      |>.traceAdjointMap_meanErgodicProjection_apply_self Y
+  · exact (hT.hasBoundedOrbits_of_tracePreserving hTP)
+      |>.range_traceAdjointMap_meanErgodicProjection
+  · intro Y
+    exact (hT.hasBoundedOrbits_of_tracePreserving hTP)
+      |>.traceAdjointMap_meanErgodicProjection_apply_eq_self_iff Y

--- a/TNLean/Channel/FixedPoint/MeanErgodicAdjoint.lean
+++ b/TNLean/Channel/FixedPoint/MeanErgodicAdjoint.lean
@@ -56,9 +56,9 @@ theorem isTracePreservingMap_iff_traceAdjointMap_one
 points of the trace adjoint of the original endomorphism.
 
 The proof uses the complementary decomposition
-`X - P(X) ∈ range(T - 1)`.  A fixed point of `T*` annihilates this range under
-the trace pairing, so it is fixed by `P*`.  This avoids any bounded-orbit or
-spectral hypothesis on `T*`.
+\(X - P(X) \in \operatorname{range}(T - \mathrm{id})\).  A fixed point of
+\(T^*\) annihilates this range under the trace pairing, so it is fixed by
+\(P^*\).  This avoids any bounded-orbit or spectral hypothesis on \(T^*\).
 
 Source: Wolf, Proposition 6.3 and Equation (6.14), local source
 `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 226--269; this is

--- a/TNLean/Channel/FixedPoint/MeanErgodicAdjoint.lean
+++ b/TNLean/Channel/FixedPoint/MeanErgodicAdjoint.lean
@@ -23,7 +23,7 @@ adjoint projection is a positive unital retraction.
   `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1488--1492.
 -/
 
-open scoped Matrix ComplexOrder MatrixOrder Matrix.Norms.Frobenius
+open scoped Matrix Matrix.Norms.Frobenius
 
 variable {D : ℕ}
 

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -7,6 +7,7 @@ import TNLean.Analysis.MeanErgodic
 import TNLean.Channel.FixedPoint.Algebra
 import TNLean.Channel.FixedPoint.Cesaro
 import TNLean.Channel.FixedPoint.MeanErgodicProjection
+import TNLean.Channel.FixedPoint.MeanErgodicAdjoint
 import TNLean.Channel.FixedPoint.ConditionalExpectation
 import TNLean.Channel.FixedPoint.StationarySupport
 import TNLean.Channel.FixedPoint.CornerFixedPoints
@@ -283,10 +284,13 @@ projection is a positive trace-preserving retraction onto its fixed-point
 space. If the original endomorphism is unital, the projection is unital as
 well.
 
-The remaining mean-ergodic step for Theorem 6.14 is to identify the
-trace-pairing adjoint of this projection with the corresponding retraction on
-the adjoint fixed-point space and to combine it with the full-support
-star-algebra description.
+The trace-pairing adjoint step is provided by
+`LinearMap.HasBoundedOrbits.range_traceAdjointMap_meanErgodicProjection` and
+`IsPositiveMap.traceAdjoint_meanErgodicProjection_isPositiveUnitalRetraction`.
+The adjoint of the mean-ergodic projection is a positive unital idempotent
+retraction onto the fixed-point space of the adjoint endomorphism.  The
+remaining step for Theorem 6.14 is to combine this retraction with the
+full-support star-algebra description.
 
 In `TNLean.Channel.FixedPoint.WedderburnDecomp`:
 

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -284,13 +284,11 @@ projection is a positive trace-preserving retraction onto its fixed-point
 space. If the original endomorphism is unital, the projection is unital as
 well.
 
-The trace-pairing adjoint step is provided by
-`LinearMap.HasBoundedOrbits.range_traceAdjointMap_meanErgodicProjection` and
-`IsPositiveMap.traceAdjoint_meanErgodicProjection_isPositiveUnitalRetraction`.
-The adjoint of the mean-ergodic projection is a positive unital idempotent
-retraction onto the fixed-point space of the adjoint endomorphism.  The
-remaining step for Theorem 6.14 is to combine this retraction with the
-full-support star-algebra description.
+The trace-pairing adjoint step is now complete.  The adjoint of the
+mean-ergodic projection is a positive unital idempotent retraction onto the
+fixed-point space of the adjoint endomorphism.  The remaining step for
+Theorem 6.14 is to combine this retraction with the full-support star-algebra
+description.
 
 In `TNLean.Channel.FixedPoint.WedderburnDecomp`:
 

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -1072,18 +1072,18 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     \label{thm:trace_preserving_iff_trace_adjoint_unital}
     \lean{isTracePreservingMap_iff_traceAdjointMap_one}
     \leanok
-    \uses{def:trace_preserving}
+    \uses{def:trace_preserving, def:trace_pairing_adjoint}
     A linear map $S:\MN{D}\to\MN{D}$ is trace-preserving if and only if its
     trace-pairing adjoint fixes the identity:
     \[
-        \tr(S(X))=\tr(X)\quad\text{for every }X
+        (\forall X,\; \tr(S(X))=\tr(X))
         \quad\Longleftrightarrow\quad
         S^*(\Id)=\Id.
     \]
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:trace_pairing_adjoint_identity}
+    \uses{thm:trace_pairing_adjoint_identity, thm:trace_nondeg}
     The trace-pairing identity gives
     \[
         \tr(S^*(\Id)X)=\tr(S(X)).
@@ -1113,7 +1113,7 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:trace_pairing_adjoint_identity,
+    \uses{thm:trace_pairing_adjoint_identity, thm:trace_nondeg,
         thm:mean_ergodic_bounded_orbits}
     Since $P_T^2=P_T$, the trace-pairing identity gives
     $(P_T^*)^2=P_T^*$.  If $T^*(Y)=Y$, decompose

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -1127,8 +1127,21 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     \]
     Nondegeneracy of the trace pairing gives $P_T^*(Y)=Y$.  Conversely,
     $P_TT=P_T$ implies $T^*P_T^*=P_T^*$, so every fixed point of $P_T^*$ is a
-    fixed point of $T^*$.  The fixed-point equivalence and idempotence give the
-    range identity.
+    fixed point of $T^*$:
+    \[
+        P_T^*(Y)=Y
+        \quad\Longrightarrow\quad
+        T^*(Y)=T^*(P_T^*(Y))=P_T^*(Y)=Y.
+    \]
+    Hence
+    \[
+        Y\in\operatorname{range}(P_T^*)
+        \quad\Longleftrightarrow\quad P_T^*(Y)=Y
+        \quad\Longleftrightarrow\quad T^*(Y)=Y
+        \quad\Longleftrightarrow\quad Y\in\ker(T^*-\Id).
+    \]
+    The first equivalence uses idempotence, and the second is the fixed-point
+    equivalence proved above.
 \end{proof}
 
 \begin{theorem}[Positive unital adjoint Ces\`aro retraction]

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -1068,6 +1068,99 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     preceding theorems.
 \end{proof}
 
+\begin{theorem}[Trace preservation and the trace adjoint]
+    \label{thm:trace_preserving_iff_trace_adjoint_unital}
+    \lean{isTracePreservingMap_iff_traceAdjointMap_one}
+    \leanok
+    \uses{def:trace_preserving}
+    A linear map $S:\MN{D}\to\MN{D}$ is trace-preserving if and only if its
+    trace-pairing adjoint fixes the identity:
+    \[
+        \tr(S(X))=\tr(X)\quad\text{for every }X
+        \quad\Longleftrightarrow\quad
+        S^*(\Id)=\Id.
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:trace_pairing_adjoint_identity}
+    The trace-pairing identity gives
+    \[
+        \tr(S^*(\Id)X)=\tr(S(X)).
+    \]
+    The equivalence follows from nondegeneracy of the trace pairing.
+\end{proof}
+
+\begin{theorem}[Adjoint mean-ergodic projection]
+    \label{thm:adjoint_mean_ergodic_projection}
+    \lean{LinearMap.HasBoundedOrbits.traceAdjointMap_meanErgodicProjection_apply_eq_self_iff,
+        LinearMap.HasBoundedOrbits.traceAdjointMap_meanErgodicProjection_apply_self,
+        LinearMap.HasBoundedOrbits.range_traceAdjointMap_meanErgodicProjection}
+    \leanok
+    \uses{def:mean_ergodic_projection, thm:mean_ergodic_bounded_orbits}
+    Let $T:\MN{D}\to\MN{D}$ have bounded orbits, let $P_T$ be its
+    mean-ergodic projection, and let $P_T^*$ be the trace-pairing adjoint of
+    $P_T$. Then
+    \[
+        (P_T^*)^2=P_T^*,
+        \qquad
+        \operatorname{range}(P_T^*)=\ker(T^*-\Id),
+    \]
+    and
+    \[
+        P_T^*(Y)=Y\quad\Longleftrightarrow\quad T^*(Y)=Y.
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:trace_pairing_adjoint_identity,
+        thm:mean_ergodic_bounded_orbits}
+    Since $P_T^2=P_T$, the trace-pairing identity gives
+    $(P_T^*)^2=P_T^*$.  If $T^*(Y)=Y$, decompose
+    \[
+        X-P_T(X)=(T-\Id)(Z).
+    \]
+    Then
+    \[
+        \tr\bigl(Y(X-P_T(X))\bigr)
+        =\tr\bigl((T^*(Y)-Y)Z\bigr)=0.
+    \]
+    Nondegeneracy of the trace pairing gives $P_T^*(Y)=Y$.  Conversely,
+    $P_TT=P_T$ implies $T^*P_T^*=P_T^*$, so every fixed point of $P_T^*$ is a
+    fixed point of $T^*$.  The fixed-point equivalence and idempotence give the
+    range identity.
+\end{proof}
+
+\begin{theorem}[Positive unital adjoint Ces\`aro retraction]
+    \label{thm:positive_unital_adjoint_mean_ergodic_retraction}
+    \lean{IsPositiveMap.traceAdjoint_meanErgodicProjection_isPositiveUnitalRetraction}
+    \leanok
+    \uses{thm:positive_trace_preserving_mean_ergodic_projection,
+        thm:trace_preserving_iff_trace_adjoint_unital,
+        thm:adjoint_mean_ergodic_projection,
+        thm:trace_pairing_adjoint_positive}
+    Let $T:\MN{D}\to\MN{D}$ be positive and trace-preserving.  The trace
+    adjoint $P_T^*$ of its mean-ergodic projection is positive, unital, and
+    idempotent.  It is a retraction onto the adjoint fixed-point space:
+    \[
+        P_T^*(\Id)=\Id,
+        \qquad (P_T^*)^2=P_T^*,
+        \qquad \operatorname{range}(P_T^*)=\ker(T^*-\Id),
+    \]
+    and $P_T^*(Y)=Y$ if and only if $T^*(Y)=Y$.
+    This is the adjoint projection used in the proof of
+    \cite[Theorem~6.14]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}\leanok
+    Theorem~\ref{thm:positive_trace_preserving_mean_ergodic_projection} makes
+    $P_T$ positive and trace-preserving.  Positivity passes to its trace
+    adjoint, while
+    Theorem~\ref{thm:trace_preserving_iff_trace_adjoint_unital} gives
+    $P_T^*(\Id)=\Id$.  The remaining assertions are
+    Theorem~\ref{thm:adjoint_mean_ergodic_projection}.
+\end{proof}
+
 \begin{theorem}[Hermitian fixed-point decomposition]\label{thm:hermitian_fixedpoint_parts}
     \lean{IsChannel.posSemidef_parts_of_hermitian_fixedPoint}
     \leanok

--- a/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
+++ b/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
@@ -96,7 +96,9 @@ instead obtains the identity from the density-weighted structure of the
 fixed-point space.
 
 The positive trace-preserving mean-ergodic retraction on a full matrix algebra
-is formalized, but the general density-weighted form of Wolf's Theorem~6.14 in
+and its positive unital trace-adjoint retraction onto the adjoint fixed-point
+space are formalized.  Their construction uses no bounded-orbit hypothesis on
+the adjoint map.  The general density-weighted form of Wolf's Theorem~6.14 in
 the Schr\"odinger picture is not yet assembled.  Its precise boundary is
 recorded in
 \path{docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex}.  For

--- a/docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex
+++ b/docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex
@@ -33,7 +33,8 @@ complete positivity, trace preservation, or a Schwarz inequality is added.
 \section{The remaining fixed-point theorem}
 
 Let $T:M_D(\mathbb C)\to M_D(\mathbb C)$ be positive and trace preserving,
-and suppose that its trace-pairing adjoint satisfies the Schwarz inequality.
+write $T^*$ for its trace-pairing adjoint, and suppose that $T^*$ satisfies the
+Schwarz inequality.
 Wolf's Theorem~6.14 asserts that there are a unitary $U$, a decomposition
 \begin{align}
     \mathbb C^D

--- a/docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex
+++ b/docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex
@@ -63,21 +63,30 @@ is exactly $\operatorname{Fix}(T)$.
 \leanid{IsTracePreservingMap.meanErgodicProjection_isTracePreservingMap}.}
 If the original map is unital, this projection is also unital.
 
-Three arguments remain to obtain the fixed-point statement above.  First,
-the trace-pairing adjoint of the mean-ergodic projection must be identified
-with the corresponding retraction on $\operatorname{Fix}(T^*)$, and the
-Schwarz hypothesis must be used to identify its full-support range with a
-unital $*$-algebra.  Second, the positive semidefinite density matrices
-supplied by Proposition~1.5 must be restricted to their supports; this
-produces the positive definite matrices in Theorem~6.14.  Third, the
+The trace-pairing adjoint of this projection is now identified as a positive
+unital idempotent retraction onto $\operatorname{Fix}(T^*)$.
+\footnote{Formal declarations:
+\leanid{LinearMap.HasBoundedOrbits.range_traceAdjointMap_meanErgodicProjection}
+and
+\leanid{IsPositiveMap.traceAdjoint_meanErgodicProjection_isPositiveUnitalRetraction}.}
+The proof uses the complementary decomposition for the original
+mean-ergodic projection and trace-pairing nondegeneracy; it requires no
+bounded-orbit or spectral hypothesis for $T^*$.
+
+Three arguments remain to obtain the fixed-point statement above.  First, the
+Schwarz hypothesis must be used to identify the full-support adjoint
+fixed-point range with a unital $*$-algebra.  Second, the positive
+semidefinite density matrices supplied by Proposition~1.5 must be restricted
+to their supports; this produces the positive definite matrices in
+Theorem~6.14.  Third, the
 discarded kernels must be assembled with the subspace on which every fixed
 point vanishes, thereby recovering the zero summand $\mathcal H_0$.
 
 Thus Proposition~1.5 is fully formalized, while Theorem~6.14 remains an open
-gap.  The missing work is not another classification of a given retraction:
-it is the adjoint and full-support algebra identification for the completed
-fixed-point retraction, the positive-definite support reduction, and the
-recovery of the zero block from the kernels.
+gap.  The missing work is not another construction of a fixed-point
+retraction: it is the full-support algebra identification for the completed
+adjoint retraction, the positive-definite support reduction, and the recovery
+of the zero block from the kernels.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Motivation

Wolf Theorem 6.14 uses the trace-pairing adjoint of the Cesàro projection as a retraction onto the adjoint fixed-point space. The primal mean-ergodic projection was already available, but this adjoint identification remained an explicit boundary in LionSR/QICLean#219.

## Description

- prove that trace preservation is equivalent to unitality of the trace adjoint;
- identify the fixed points and range of the trace adjoint of the mean-ergodic projection;
- prove its idempotence without assuming bounded orbits for the adjoint map;
- bundle positivity, unitality, idempotence, range, and the fixed-point equivalence for a positive trace-preserving endomorphism;
- update the Wolf Chapter 6 index, blueprint, and paper-gap notes to record the narrower remaining boundary.

The proof follows Wolf Proposition 6.3 and Equation (6.14), with the adjoint use in the proof of Theorem 6.14; see `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 226–269 and 1488–1492.

## Testing

- `lake build TNLean.Channel.FixedPoint.MeanErgodicAdjoint TNLean.Channel.WolfChapter6Index` (passed on the final declaration set before a conflict-free rebase over unrelated main changes)
- `python3 scripts/blueprint_lean_sync.py --root . --ci` (passed)
- axiom audit of all five new declarations: only `propext`, `Classical.choice`, and `Quot.sound`
- proof-integrity and line-length checks on the new module (passed)
- `git diff --check` (passed on the exact rebased head)

A root build passed before the final declaration-name shortening. A later local root rebuild was not usable because parallel worktrees shared `.lake` build objects and removed objects during the run; an isolated duplicate build then exhausted the host disk. The GitHub workflows therefore provide the authoritative clean root build for this exact head.

Addresses LionSR/QICLean#219. Advances LionSR/QICLean#39 and LionSR/TNLean#4120. Does not close LionSR/QICLean#219, LionSR/QICLean#39, LionSR/TNLean#4120, LionSR/TNLean#3949, or LionSR/TNLean#232.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style formalization and documentation sync; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **`TNLean.Channel.FixedPoint.MeanErgodicAdjoint`**, formalizing Wolf’s adjoint Cesàro projection (Prop. 6.3 / Eq. (6.14)) used toward Theorem 6.14.
> 
> The new Lean layer proves trace preservation is equivalent to **`S^*(1) = 1`**, identifies the trace adjoint of the mean-ergodic projection as an idempotent whose range and fixed points match **`Fix(T^*)`** (via the complementary **`X - P(X)`** decomposition, without assuming bounded orbits for **`T^*`**), and bundles **positivity, unitality, idempotence, and range** for positive trace-preserving **`T`**.
> 
> Root and Wolf Chapter 6 index imports are wired; the blueprint gains matching theorems, and paper-gap notes now treat the adjoint retraction as done while listing Schwarz/full-support algebra identification, support reduction of densities, and the zero block as what remains for Theorem 6.14.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb0a0cf90245158fdc335a0273d0ac1b3270a021. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->