### PR TITLE
fix(MPS/CanonicalForm): record BNT uniqueness counterexample

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -381,6 +381,7 @@ import TNLean.MPS.CanonicalForm.BNTGrouping
 import TNLean.MPS.CanonicalForm.PhaseCover
 import TNLean.MPS.CanonicalForm.PhaseClassSectorData
 import TNLean.MPS.CanonicalForm.BNTCharacterization
+import TNLean.MPS.CanonicalForm.BNTUniqueness
 import TNLean.MPS.Overlap.NormalTensorDichotomy
 import TNLean.MPS.Core.BlockingInfrastructure
 import TNLean.MPS.Irreducible.FormII

--- a/TNLean/MPS/CanonicalForm/BNTUniqueness.lean
+++ b/TNLean/MPS/CanonicalForm/BNTUniqueness.lean
@@ -1,0 +1,211 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.CanonicalForm.BNTCharacterization
+
+/-!
+# Uniqueness boundary for bases of normal tensors
+
+This module examines the uniqueness sentence following the characterization of
+a basis of normal tensors in arXiv:1606.00608, Appendix A, line 1148.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+/-- The bond-dimension-one tensor supported on one physical symbol. -/
+private def symbolTensor (a : Fin 2) : MPSTensor 2 1 :=
+  fun i => if i = a then 1 else 0
+
+private lemma symbolTensor_isIrreducibleTensor (a : Fin 2) :
+    IsIrreducibleTensor (symbolTensor a) := by
+  rintro ⟨P, ⟨_, hIdem⟩, hP0, hP1, _⟩
+  have h00 := congrFun (congrFun hIdem (0 : Fin 1)) (0 : Fin 1)
+  simp only [Matrix.mul_apply, Finset.univ_unique, Fin.default_eq_zero,
+    Fin.isValue, Finset.sum_singleton] at h00
+  have hfactor : P 0 0 * (P 0 0 - 1) = 0 := by
+    linear_combination h00
+  rcases mul_eq_zero.mp hfactor with hzero | hone
+  · apply hP0
+    ext x y
+    fin_cases x
+    fin_cases y
+    simpa using hzero
+  · apply hP1
+    ext x y
+    fin_cases x
+    fin_cases y
+    simpa using sub_eq_zero.mp hone
+
+private lemma symbolTensor_transferMap (a : Fin 2) :
+    transferMap (symbolTensor a) = LinearMap.id := by
+  apply LinearMap.ext
+  intro X
+  ext x y
+  fin_cases x
+  fin_cases y
+  simp [transferMap_apply, symbolTensor]
+
+private theorem symbolTensor_isNormalTensor (a : Fin 2) :
+    IsNormalTensor (symbolTensor a) := by
+  refine ⟨symbolTensor_isIrreducibleTensor a, ?_, ?_⟩
+  · rw [symbolTensor_transferMap]
+    change spectralRadius ℂ
+      (1 : Matrix (Fin 1) (Fin 1) ℂ →L[ℂ] Matrix (Fin 1) (Fin 1) ℂ) = 1
+    exact spectrum.spectralRadius_one
+  · rw [symbolTensor_transferMap]
+    apply isPrimitive_of_unique_norm_one LinearMap.id
+      (1 : Matrix (Fin 1) (Fin 1) ℂ)
+    · rfl
+    · exact one_ne_zero
+    · intro μ hμ _hμnorm
+      obtain ⟨X, hX⟩ := hμ.exists_hasEigenvector
+      have hEq := hX.apply_eq_smul
+      have hX00 : X 0 0 ≠ 0 := by
+        intro hzero
+        apply hX.2
+        ext x y
+        fin_cases x
+        fin_cases y
+        simpa using hzero
+      have hEq00 := congrFun (congrFun hEq (0 : Fin 1)) (0 : Fin 1)
+      simp only [LinearMap.id_apply, Matrix.smul_apply, smul_eq_mul] at hEq00
+      apply mul_right_cancel₀ hX00
+      simpa using hEq00.symm
+
+private lemma symbolTensor_evalWord_self (a : Fin 2) (N : ℕ) :
+    evalWord (symbolTensor a) (List.replicate N a) = 1 := by
+  induction N with
+  | zero => rfl
+  | succ N ih =>
+      rw [List.replicate_succ, evalWord_cons, ih]
+      simp [symbolTensor]
+
+private lemma symbolTensor_evalWord_other {a b : Fin 2} (hab : a ≠ b) (N : ℕ) :
+    evalWord (symbolTensor a) (List.replicate (N + 1) b) = 0 := by
+  rw [List.replicate_succ, evalWord_cons]
+  simp [symbolTensor, Ne.symm hab]
+
+private lemma symbolTensor_mpv_self (a : Fin 2) (N : ℕ) :
+    mpv (symbolTensor a) (fun _ : Fin N => a) = 1 := by
+  rw [mpv_const_eq_trace_pow]
+  simp [symbolTensor, Matrix.trace]
+
+private lemma symbolTensor_mpv_other {a b : Fin 2} (hab : a ≠ b)
+    (N : ℕ) (hN : 0 < N) :
+    mpv (symbolTensor a) (fun _ : Fin N => b) = 0 := by
+  rw [mpv_const_eq_trace_pow]
+  simp [symbolTensor, Ne.symm hab, Matrix.trace, Nat.ne_of_gt hN]
+
+private lemma symbolTensor_pair_linearIndependent (N : ℕ) (hN : 0 < N) :
+    LinearIndependent ℂ (fun j : Fin 2 => mpvState (symbolTensor j) N) := by
+  rw [Fintype.linearIndependent_iff]
+  intro c hsum j
+  fin_cases j
+  · have hzero := congrArg
+      (fun v : MPVSpace 2 N => v (fun _ : Fin N => (0 : Fin 2))) hsum
+    have h00 : mpv (symbolTensor 0) (fun _ : Fin N => (0 : Fin 2)) = 1 :=
+      symbolTensor_mpv_self 0 N
+    have h10 : mpv (symbolTensor 1) (fun _ : Fin N => (0 : Fin 2)) = 0 :=
+      symbolTensor_mpv_other (by decide) N hN
+    have hc0 : c (0 : Fin 2) = 0 := by
+      simpa only [Fin.sum_univ_two, PiLp.add_apply, PiLp.smul_apply,
+        mpvState_apply, smul_eq_mul, h00, h10, mul_one, mul_zero, add_zero,
+        PiLp.zero_apply] using hzero
+    simpa using hc0
+  · have hone := congrArg
+      (fun v : MPVSpace 2 N => v (fun _ : Fin N => (1 : Fin 2))) hsum
+    have h01 : mpv (symbolTensor 0) (fun _ : Fin N => (1 : Fin 2)) = 0 :=
+      symbolTensor_mpv_other (by decide) N hN
+    have h11 : mpv (symbolTensor 1) (fun _ : Fin N => (1 : Fin 2)) = 1 :=
+      symbolTensor_mpv_self 1 N
+    have hc1 : c (1 : Fin 2) = 0 := by
+      simpa only [Fin.sum_univ_two, PiLp.add_apply, PiLp.smul_apply,
+        mpvState_apply, smul_eq_mul, h01, h11, mul_zero, mul_one, zero_add,
+        PiLp.zero_apply] using hone
+    simpa using hc1
+
+private def singletonSymbolFamily : Fin 1 → Σ D : ℕ, MPSTensor 2 D :=
+  fun _ => ⟨1, symbolTensor 0⟩
+
+private def pairSymbolFamily : Fin 2 → Σ D : ℕ, MPSTensor 2 D :=
+  fun j => ⟨1, symbolTensor j⟩
+
+private theorem singletonSymbolFamily_isCPSVBasisOfNormalTensors :
+    IsCPSVBasisOfNormalTensors (symbolTensor 0) singletonSymbolFamily := by
+  refine {
+    blocks_normal := fun _ => symbolTensor_isNormalTensor 0
+    spans_mpv := ?_
+    eventually_li := ?_
+  }
+  · intro N _hN
+    refine ⟨fun _ => 1, ?_⟩
+    intro σ
+    simp [singletonSymbolFamily]
+  · refine ⟨0, ?_⟩
+    intro N hN
+    apply LinearIndependent.of_subsingleton (i := (0 : Fin 1))
+    intro hzero
+    have hcomponent := congrArg
+      (fun v : MPVSpace 2 N => v (fun _ : Fin N => (0 : Fin 2))) hzero
+    have hself : mpv (symbolTensor 0) (fun _ : Fin N => (0 : Fin 2)) = 1 :=
+      symbolTensor_mpv_self 0 N
+    have hone : (1 : ℂ) = 0 := by
+      simpa only [singletonSymbolFamily, mpvState_apply, hself, PiLp.zero_apply]
+        using hcomponent
+    exact one_ne_zero hone
+
+private theorem pairSymbolFamily_isCPSVBasisOfNormalTensors :
+    IsCPSVBasisOfNormalTensors (symbolTensor 0) pairSymbolFamily := by
+  refine {
+    blocks_normal := fun j => symbolTensor_isNormalTensor j
+    spans_mpv := ?_
+    eventually_li := ?_
+  }
+  · intro N _hN
+    refine ⟨fun j => if j = 0 then 1 else 0, ?_⟩
+    intro σ
+    simp [pairSymbolFamily]
+  · refine ⟨0, ?_⟩
+    intro N hN
+    exact symbolTensor_pair_linearIndependent N (by omega)
+
+/-- Two bases of normal tensors for one fixed canonical-form family need not
+have equivalent index types under the literal CPSV16 definition.
+
+This is a counterexample to the unrestricted uniqueness sentence in
+arXiv:1606.00608, Appendix A, line 1148. Take the bond-dimension-one tensor
+supported on physical symbol zero. Its singleton family is a basis of normal
+tensors. Adjoining the tensor supported on physical symbol one gives a second
+basis: its coefficient is identically zero, while the two matrix product
+vectors are orthogonal and hence linearly independent at every positive
+length. The two index types have cardinalities one and two.
+
+See `docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex`. -/
+theorem exists_isCPSVBasisOfNormalTensors_unequal_card :
+    ∃ (A : MPSTensor 2 1)
+      (basis₁ : Fin 1 → Σ D : ℕ, MPSTensor 2 D)
+      (basis₂ : Fin 2 → Σ D : ℕ, MPSTensor 2 D),
+      IsNormalTensor A ∧
+      SameMPV₂Pos A
+        (toTensorFromBlocks (fun _ : Fin 1 => 1) (fun _ : Fin 1 => A)) ∧
+      IsCPSVBasisOfNormalTensors A basis₁ ∧
+      IsCPSVBasisOfNormalTensors A basis₂ ∧
+      Fintype.card (Fin 1) ≠ Fintype.card (Fin 2) ∧
+      ¬ Nonempty (Fin 1 ≃ Fin 2) := by
+  refine ⟨symbolTensor 0, singletonSymbolFamily, pairSymbolFamily,
+    symbolTensor_isNormalTensor 0, ?_,
+    singletonSymbolFamily_isCPSVBasisOfNormalTensors,
+    pairSymbolFamily_isCPSVBasisOfNormalTensors, ?_, ?_⟩
+  · intro N _hN σ
+    rw [mpv_toTensorFromBlocks_eq_sum]
+    simp
+  · norm_num
+  · rintro ⟨e⟩
+    have hcard := Fintype.card_congr e
+    norm_num at hcard
+
+end MPSTensor

--- a/TNLean/MPS/CanonicalForm/BNTUniqueness.lean
+++ b/TNLean/MPS/CanonicalForm/BNTUniqueness.lean
@@ -20,26 +20,6 @@ namespace MPSTensor
 private def symbolTensor (a : Fin 2) : MPSTensor 2 1 :=
   fun i => if i = a then 1 else 0
 
-private lemma symbolTensor_isIrreducibleTensor (a : Fin 2) :
-    IsIrreducibleTensor (symbolTensor a) := by
-  rintro ⟨P, ⟨_, hIdem⟩, hP0, hP1, _⟩
-  have h00 := congrFun (congrFun hIdem (0 : Fin 1)) (0 : Fin 1)
-  simp only [Matrix.mul_apply, Finset.univ_unique, Fin.default_eq_zero,
-    Fin.isValue, Finset.sum_singleton] at h00
-  have hfactor : P 0 0 * (P 0 0 - 1) = 0 := by
-    linear_combination h00
-  rcases mul_eq_zero.mp hfactor with hzero | hone
-  · apply hP0
-    ext x y
-    fin_cases x
-    fin_cases y
-    simpa using hzero
-  · apply hP1
-    ext x y
-    fin_cases x
-    fin_cases y
-    simpa using sub_eq_zero.mp hone
-
 private lemma symbolTensor_transferMap (a : Fin 2) :
     transferMap (symbolTensor a) = LinearMap.id := by
   apply LinearMap.ext
@@ -50,31 +30,9 @@ private lemma symbolTensor_transferMap (a : Fin 2) :
   simp [transferMap_apply, symbolTensor]
 
 private theorem symbolTensor_isNormalTensor (a : Fin 2) :
-    IsNormalTensor (symbolTensor a) := by
-  refine ⟨symbolTensor_isIrreducibleTensor a, ?_, ?_⟩
-  · rw [symbolTensor_transferMap]
-    change spectralRadius ℂ
-      (1 : Matrix (Fin 1) (Fin 1) ℂ →L[ℂ] Matrix (Fin 1) (Fin 1) ℂ) = 1
-    exact spectrum.spectralRadius_one
-  · rw [symbolTensor_transferMap]
-    apply isPrimitive_of_unique_norm_one LinearMap.id
-      (1 : Matrix (Fin 1) (Fin 1) ℂ)
-    · rfl
-    · exact one_ne_zero
-    · intro μ hμ _hμnorm
-      obtain ⟨X, hX⟩ := hμ.exists_hasEigenvector
-      have hEq := hX.apply_eq_smul
-      have hX00 : X 0 0 ≠ 0 := by
-        intro hzero
-        apply hX.2
-        ext x y
-        fin_cases x
-        fin_cases y
-        simpa using hzero
-      have hEq00 := congrFun (congrFun hEq (0 : Fin 1)) (0 : Fin 1)
-      simp only [LinearMap.id_apply, Matrix.smul_apply, smul_eq_mul] at hEq00
-      apply mul_right_cancel₀ hX00
-      simpa using hEq00.symm
+    IsNormalTensor (symbolTensor a) :=
+  isNormalTensor_of_bondDim_one_of_transferMap_eq_id
+    (symbolTensor a) (symbolTensor_transferMap a)
 
 private lemma symbolTensor_evalWord_self (a : Fin 2) (N : ℕ) :
     evalWord (symbolTensor a) (List.replicate N a) = 1 := by

--- a/TNLean/MPS/CanonicalForm/BNTUniqueness.lean
+++ b/TNLean/MPS/CanonicalForm/BNTUniqueness.lean
@@ -34,19 +34,6 @@ private theorem symbolTensor_isNormalTensor (a : Fin 2) :
   isNormalTensor_of_bondDim_one_of_transferMap_eq_id
     (symbolTensor a) (symbolTensor_transferMap a)
 
-private lemma symbolTensor_evalWord_self (a : Fin 2) (N : ℕ) :
-    evalWord (symbolTensor a) (List.replicate N a) = 1 := by
-  induction N with
-  | zero => rfl
-  | succ N ih =>
-      rw [List.replicate_succ, evalWord_cons, ih]
-      simp [symbolTensor]
-
-private lemma symbolTensor_evalWord_other {a b : Fin 2} (hab : a ≠ b) (N : ℕ) :
-    evalWord (symbolTensor a) (List.replicate (N + 1) b) = 0 := by
-  rw [List.replicate_succ, evalWord_cons]
-  simp [symbolTensor, Ne.symm hab]
-
 private lemma symbolTensor_mpv_self (a : Fin 2) (N : ℕ) :
     mpv (symbolTensor a) (fun _ : Fin N => a) = 1 := by
   rw [mpv_const_eq_trace_pow]

--- a/TNLean/MPS/CanonicalForm/BNTUniqueness.lean
+++ b/TNLean/MPS/CanonicalForm/BNTUniqueness.lean
@@ -174,7 +174,7 @@ private theorem pairSymbolFamily_isCPSVBasisOfNormalTensors :
     exact symbolTensor_pair_linearIndependent N (by omega)
 
 /-- Two bases of normal tensors for one fixed canonical-form family need not
-have equivalent index types under the literal CPSV16 definition.
+have equivalent index types under the literal definition of arXiv:1606.00608.
 
 This is a counterexample to the unrestricted uniqueness sentence in
 arXiv:1606.00608, Appendix A, line 1148. Take the bond-dimension-one tensor

--- a/TNLean/MPS/CanonicalForm/Definitions.lean
+++ b/TNLean/MPS/CanonicalForm/Definitions.lean
@@ -110,6 +110,58 @@ structure IsNormalTensor (A : MPSTensor d D) : Prop where
   /-- (ii-b) the associated CPM has no unit-modulus eigenvalue other than one. -/
   primitive_transfer : _root_.IsPrimitive (transferMap (d := d) (D := D) A)
 
+/-- Every tensor of bond dimension one is irreducible: the only orthogonal
+projections on its one-dimensional bond space are zero and the identity. -/
+theorem isIrreducibleTensor_of_bondDim_one (A : MPSTensor d 1) :
+    IsIrreducibleTensor A := by
+  rintro ⟨P, ⟨_, hIdem⟩, hP0, hP1, _⟩
+  have h00 := congrFun (congrFun hIdem (0 : Fin 1)) (0 : Fin 1)
+  simp only [Matrix.mul_apply, Finset.univ_unique, Fin.default_eq_zero,
+    Fin.isValue, Finset.sum_singleton] at h00
+  have hfactor : P 0 0 * (P 0 0 - 1) = 0 := by
+    linear_combination h00
+  rcases mul_eq_zero.mp hfactor with hzero | hone
+  · apply hP0
+    ext x y
+    fin_cases x
+    fin_cases y
+    simpa using hzero
+  · apply hP1
+    ext x y
+    fin_cases x
+    fin_cases y
+    simpa using sub_eq_zero.mp hone
+
+/-- A bond-dimension-one tensor whose transfer map is the identity is a normal
+tensor. -/
+theorem isNormalTensor_of_bondDim_one_of_transferMap_eq_id
+    (A : MPSTensor d 1) (hA : transferMap A = LinearMap.id) :
+    IsNormalTensor A := by
+  refine ⟨isIrreducibleTensor_of_bondDim_one A, ?_, ?_⟩
+  · rw [hA]
+    change spectralRadius ℂ
+      (1 : Matrix (Fin 1) (Fin 1) ℂ →L[ℂ] Matrix (Fin 1) (Fin 1) ℂ) = 1
+    exact spectrum.spectralRadius_one
+  · rw [hA]
+    apply isPrimitive_of_unique_norm_one LinearMap.id
+      (1 : Matrix (Fin 1) (Fin 1) ℂ)
+    · rfl
+    · exact one_ne_zero
+    · intro μ hμ _hμnorm
+      obtain ⟨X, hX⟩ := hμ.exists_hasEigenvector
+      have hEq := hX.apply_eq_smul
+      have hX00 : X 0 0 ≠ 0 := by
+        intro hzero
+        apply hX.2
+        ext x y
+        fin_cases x
+        fin_cases y
+        simpa using hzero
+      have hEq00 := congrFun (congrFun hEq (0 : Fin 1)) (0 : Fin 1)
+      simp only [LinearMap.id_apply, Matrix.smul_apply, smul_eq_mul] at hEq00
+      apply mul_right_cancel₀ hX00
+      simpa using hEq00.symm
+
 /-! ## Basis of normal tensors (BNT) -/
 
 /--

--- a/TNLean/MPS/RFP/BNTWeightCounterexample.lean
+++ b/TNLean/MPS/RFP/BNTWeightCounterexample.lean
@@ -48,26 +48,6 @@ theorem halvedWeightTensor_eq_halvedDecomp_toTensor :
     halvedWeightTensor =
       (SectorBNT.Examples.halvedDecomp scalarUnitTensor).toTensor := rfl
 
-private lemma scalarUnitTensor_isIrreducibleTensor :
-    IsIrreducibleTensor scalarUnitTensor := by
-  rintro ⟨P, ⟨_, hIdem⟩, hP0, hP1, _⟩
-  have h00 := congrFun (congrFun hIdem (0 : Fin 1)) (0 : Fin 1)
-  simp only [Matrix.mul_apply, Finset.univ_unique, Fin.default_eq_zero,
-    Fin.isValue, Finset.sum_singleton] at h00
-  have hfactor : P 0 0 * (P 0 0 - 1) = 0 := by
-    linear_combination h00
-  rcases mul_eq_zero.mp hfactor with hzero | hone
-  · apply hP0
-    ext a b
-    fin_cases a
-    fin_cases b
-    simpa using hzero
-  · apply hP1
-    ext a b
-    fin_cases a
-    fin_cases b
-    simpa using sub_eq_zero.mp hone
-
 private lemma scalarUnitTensor_evalWord (w : List (Fin 1)) :
     evalWord scalarUnitTensor w = 1 := by
   induction w with
@@ -133,32 +113,9 @@ private theorem scalarUnitTensor_transferMap :
   simp [transferMap_apply, scalarUnitTensor]
 
 private theorem scalarUnitTensor_isNormalTensor :
-    IsNormalTensor scalarUnitTensor := by
-  refine ⟨scalarUnitTensor_isIrreducibleTensor, ?_, ?_⟩
-  · rw [scalarUnitTensor_transferMap]
-    change spectralRadius ℂ
-      (1 : Matrix (Fin 1) (Fin 1) ℂ →L[ℂ] Matrix (Fin 1) (Fin 1) ℂ) = 1
-    exact spectrum.spectralRadius_one
-  · rw [scalarUnitTensor_transferMap]
-    apply isPrimitive_of_unique_norm_one LinearMap.id
-      (1 : Matrix (Fin 1) (Fin 1) ℂ)
-    · rfl
-    · exact one_ne_zero
-    · intro μ hμ hμnorm
-      obtain ⟨X, hX⟩ := hμ.exists_hasEigenvector
-      have hEq := hX.apply_eq_smul
-      have hX00 : X 0 0 ≠ 0 := by
-        intro hzero
-        apply hX.2
-        ext a b
-        fin_cases a
-        fin_cases b
-        simpa using hzero
-      have hEq00 := congrFun (congrFun hEq (0 : Fin 1)) (0 : Fin 1)
-      simp only [LinearMap.id_apply, Matrix.smul_apply] at hEq00
-      simp only [smul_eq_mul] at hEq00
-      apply mul_right_cancel₀ hX00
-      simpa using hEq00.symm
+    IsNormalTensor scalarUnitTensor :=
+  isNormalTensor_of_bondDim_one_of_transferMap_eq_id
+    scalarUnitTensor scalarUnitTensor_transferMap
 
 /-- The raw-weight decomposition of `halvedWeightTensor` is a BNT canonical
 form in the line-246 normalization of arXiv:1606.00608. -/
@@ -170,7 +127,7 @@ theorem halvedWeightTensor_isBNTCanonicalForm :
       simp
     basis_irreducible := by
       intro j
-      exact scalarUnitTensor_isIrreducibleTensor
+      exact isIrreducibleTensor_of_bondDim_one scalarUnitTensor
     basis_left_canonical := by
       intro j
       simp [IsLeftCanonical, scalarUnitTensor]

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -189,9 +189,9 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
     Thus $(A_0)$ and $(A_0,A_1)$ are both bases of normal tensors for $A_0$:
     in the second expansion the coefficient of $A_1$ is identically zero.
     Their index sets have cardinalities one and two, so they cannot be related
-    by a bijection. This gap and the missing converse-coverage condition are
-    recorded in
-    \path{docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex}.
+    by a bijection.
+    % The missing converse-coverage condition is documented in
+    % docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex.
 \end{proof}
 
 \begin{lemma}[Perron gauges preserve primitivity]

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -40,6 +40,33 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
     block MPVs $\{\ket{V^{(N)}(A_j)}\}$ are eventually linearly independent.
 \end{definition}
 
+\begin{lemma}[Bond dimension one implies irreducibility]
+    \label{lem:bond_dimension_one_irreducible}
+    \lean{MPSTensor.isIrreducibleTensor_of_bondDim_one}
+    \leanok
+    \uses{def:irreducible_tensor}
+    Every tensor with a one-dimensional bond space is irreducible.
+\end{lemma}
+
+\begin{proof}\leanok
+    The only orthogonal projections on a one-dimensional complex vector space
+    are zero and the identity.
+\end{proof}
+
+\begin{lemma}[Normality in bond dimension one]
+    \label{lem:bond_dimension_one_identity_transfer_normal}
+    \lean{MPSTensor.isNormalTensor_of_bondDim_one_of_transferMap_eq_id}
+    \leanok
+    \uses{def:nt_cpsv, lem:bond_dimension_one_irreducible}
+    A tensor with one-dimensional bond space and identity transfer map is a
+    normal tensor.
+\end{lemma}
+
+\begin{proof}\leanok
+    Irreducibility follows from the preceding lemma. The identity transfer map
+    has spectral radius one, and its only eigenvalue is one.
+\end{proof}
+
 \begin{theorem}[Distinct BNT members are not gauge-phase equivalent]
     \label{thm:cpsv_bnt_blocks_not_gaugePhaseEquiv}
     \lean{MPSTensor.IsCPSVBasisOfNormalTensors.blocks_not_gaugePhaseEquiv}

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -190,7 +190,8 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
     \label{thm:cpsv_bnt_uniqueness_counterexample}
     \lean{MPSTensor.exists_isCPSVBasisOfNormalTensors_unequal_card}
     \leanok
-    \uses{def:bnt_cpsv, def:nt_cpsv, def:same_mpv2_pos}
+    \uses{def:bnt_cpsv, def:nt_cpsv, def:same_mpv2_pos,
+        def:block_diagonal_tensor}
     There is a normal tensor with a one-block canonical-form expansion which
     admits two bases of normal tensors of different cardinalities. Hence the
     unrestricted uniqueness sentence of
@@ -199,6 +200,7 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:mpv_decomposition}
     Take physical dimension two and bond dimension one. Let $A_0$ be supported
     on physical symbol zero and let $A_1$ be supported on physical symbol one:
     \[
@@ -206,15 +208,22 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
         \qquad
         A_1^0=0,\quad A_1^1=1.
     \]
-    Both transfer maps are the identity on the one-dimensional matrix algebra,
-    so both tensors are normal. At every positive length,
+    Both transfer maps are the identity on the one-dimensional matrix algebra:
+    \[
+        \mathcal E_{A_j}(X)=X \qquad (j=0,1).
+    \]
+    Hence both tensors are normal. At every positive length,
     \[
         \ket{V^{(N)}(A_0)}=\ket{0\cdots0},
         \qquad
         \ket{V^{(N)}(A_1)}=\ket{1\cdots1}.
     \]
-    Thus $(A_0)$ and $(A_0,A_1)$ are both bases of normal tensors for $A_0$:
-    in the second expansion the coefficient of $A_1$ is identically zero.
+    Thus $(A_0)$ and $(A_0,A_1)$ are both bases of normal tensors for $A_0$.
+    Indeed, for every $N\geq 1$, the second expansion is
+    \[
+        \ket{V^{(N)}(A_0)}
+        =1\cdot\ket{V^{(N)}(A_0)}+0\cdot\ket{V^{(N)}(A_1)}.
+    \]
     Their index sets have cardinalities one and two, so they cannot be related
     by a bijection.
     % The missing converse-coverage condition is documented in

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -159,6 +159,41 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
     completing the converse.
 \end{proof}
 
+\begin{theorem}[Failure of literal BNT uniqueness]
+    \label{thm:cpsv_bnt_uniqueness_counterexample}
+    \lean{MPSTensor.exists_isCPSVBasisOfNormalTensors_unequal_card}
+    \leanok
+    \uses{def:bnt_cpsv, def:nt_cpsv, def:same_mpv2_pos}
+    There is a normal tensor with a one-block canonical-form expansion which
+    admits two bases of normal tensors of different cardinalities. Hence the
+    unrestricted uniqueness sentence of
+    \cite[Appendix~A, line~1148]{Cirac2016MPDO_arXiv} does not follow from the
+    literal definition of a basis of normal tensors.
+\end{theorem}
+
+\begin{proof}\leanok
+    Take physical dimension two and bond dimension one. Let $A_0$ be supported
+    on physical symbol zero and let $A_1$ be supported on physical symbol one:
+    \[
+        A_0^0=1,\quad A_0^1=0,
+        \qquad
+        A_1^0=0,\quad A_1^1=1.
+    \]
+    Both transfer maps are the identity on the one-dimensional matrix algebra,
+    so both tensors are normal. At every positive length,
+    \[
+        \ket{V^{(N)}(A_0)}=\ket{0\cdots0},
+        \qquad
+        \ket{V^{(N)}(A_1)}=\ket{1\cdots1}.
+    \]
+    Thus $(A_0)$ and $(A_0,A_1)$ are both bases of normal tensors for $A_0$:
+    in the second expansion the coefficient of $A_1$ is identically zero.
+    Their index sets have cardinalities one and two, so they cannot be related
+    by a bijection. This gap and the missing converse-coverage condition are
+    recorded in
+    \path{docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex}.
+\end{proof}
+
 \begin{lemma}[Perron gauges preserve primitivity]
     \label{lem:perron_gauge_primitive_iff}
     \lean{MPSTensor.isPrimitive_transferMap_tpGauge_iff}

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -109,6 +109,12 @@ For the non-periodic MPS Fundamental Theorem background:
   to the BNT characterization: coverage concerns precisely the nonzero-weight
   canonical-form blocks, while candidate normality from Definition 2.4 appears
   explicitly on the characterized side of the equivalence.
+- `cpsv16_bnt_uniqueness_zero_coefficient.tex` records that the uniqueness
+  sentence at CPSV16 line 1148 is false under the literal BNT definition: an
+  unrelated normal tensor may be adjoined with coefficient identically zero.
+  It gives a bond-dimension-one, two-symbol counterexample and identifies
+  converse coverage of candidates by active canonical-form blocks as the
+  missing condition for a restricted uniqueness theorem.
 - `canonical_bnt_ft_theorem_surface.tex` separates paper-level theorem
   statements from auxiliary formal declarations.
 - `nonperiodic_mps_bnt_comparison_inputs.tex` compares the current

--- a/docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex
+++ b/docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex
@@ -1,0 +1,85 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{BNT Uniqueness and Zero Coefficients in CPSV16}
+\author{}
+\date{2026-07-18}
+
+\begin{document}
+\maketitle
+
+\section{The source claim}
+
+Cirac--P\'erez-Garc\'ia--Schuch--Verstraete define a basis of normal tensors
+for a tensor $A$ to be a finite family of normal tensors $(A_j)_{j=1}^g$ such
+that, at each positive length, $V^{(N)}(A)$ is a linear combination of the
+$V^{(N)}(A_j)$, and these vectors are linearly independent for all sufficiently
+large $N$ \cite[lines 271--274]{Cirac2016MPDO_arXiv}. Proposition~2.7
+characterizes such a family by coverage of the normal blocks of a canonical
+form and pairwise distinction up to a phase and an invertible gauge
+\cite[lines 278--280 and 1135--1146]{Cirac2016MPDO_arXiv}.
+
+Immediately afterwards, the source asserts that any two bases of normal
+tensors corresponding to the same canonical form coincide up to phases and
+gauge transformations \cite[line 1148]{Cirac2016MPDO_arXiv}. Read literally,
+this would in particular imply equality of the two cardinalities.
+
+\section{A two-symbol counterexample}
+
+Let the physical alphabet be $\{0,1\}$ and let the bond dimension be one.
+Define two tensors by
+\begin{align}
+    A_0^0=1,\qquad A_0^1=0,
+    \qquad
+    A_1^0=0,\qquad A_1^1=1.
+\end{align}
+Both tensors are normal. Their transfer maps are the identity on the
+one-dimensional matrix algebra. Moreover,
+\begin{align}
+    V^{(N)}(A_0)&=|0\cdots0\rangle,
+    &V^{(N)}(A_1)&=|1\cdots1\rangle
+\end{align}
+for every $N\geq1$. These two vectors are orthogonal and hence linearly
+independent.
+
+The singleton family $(A_0)$ is therefore a basis of normal tensors for
+$A_0$. The two-element family $(A_0,A_1)$ is also a basis of normal tensors
+for $A_0$: take the coefficient of $A_0$ to be one and the coefficient of
+$A_1$ to be zero at every length. Both families correspond to the same
+one-block canonical-form display
+\begin{align}
+    V^{(N)}(A_0)=1^N V^{(N)}(A_0).
+\end{align}
+Their index sets have cardinalities one and two, so no bijection, and hence no
+bijective gauge-phase matching, can exist.
+
+The formal counterexample is
+\path{MPSTensor.exists_isCPSVBasisOfNormalTensors_unequal_card} in
+\path{TNLean/MPS/CanonicalForm/BNTUniqueness.lean}.
+
+\section{The missing condition}
+
+The obstruction is the identically zero coefficient. Coverage of the active
+canonical-form blocks gives a map from their gauge-phase classes into the
+candidate family. Pairwise distinction makes this map injective, but neither
+the definition nor Proposition~2.7 says that every candidate represents an
+active canonical-form block. Thus the map need not be surjective.
+
+A valid uniqueness theorem may be obtained by adding the converse coverage
+condition: every candidate must be gauge-phase equivalent to an active block
+of the displayed canonical form. Under this condition, the coverage maps are
+bijections and their composition gives the desired matching. This is a
+mathematically correct scope restriction, but it is not part of the literal
+hypotheses at lines 271--280 or 1135--1148. Accordingly, the unrestricted
+line-1148 sentence is not marked as formalized.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex
+++ b/docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex
@@ -59,9 +59,10 @@ one-block canonical-form display
 Their index sets have cardinalities one and two, so no bijection, and hence no
 bijective gauge-phase matching, can exist.
 
-The formal counterexample is
-\path{MPSTensor.exists_isCPSVBasisOfNormalTensors_unequal_card} in
-\path{TNLean/MPS/CanonicalForm/BNTUniqueness.lean}.
+The formal counterexample records both bases of normal tensors and the
+cardinality obstruction explicitly.\footnote{The declaration is
+\leanid{MPSTensor.exists_isCPSVBasisOfNormalTensors_unequal_card} in
+\doclink{TNLean/MPS/CanonicalForm/BNTUniqueness.lean}.}
 
 \section{The missing condition}
 


### PR DESCRIPTION
## Summary

- formalize a bond-dimension-one, two-symbol counterexample to the unrestricted BNT uniqueness sentence at CPSV16 Appendix A, line 1148;
- show explicitly that one fixed one-block canonical form admits CPSV bases of normal tensors indexed by `Fin 1` and `Fin 2`, so no bijection can exist;
- add the corresponding Chapter 10 theorem and a paper-gap note identifying converse coverage as the missing hypothesis.

## Mathematical reason

The literal CPSV definition only requires the matrix product vector of the total tensor to lie in the span of the candidate family, together with eventual linear independence. It does not require every candidate coefficient to be nonzero or every candidate to represent an active canonical-form block.

For the scalar tensors

\[
A_0^0=1,\quad A_0^1=0,
\qquad
A_1^0=0,\quad A_1^1=1,
\]

both `(A₀)` and `(A₀,A₁)` are bases of normal tensors for `A₀`: in the second family, the coefficient of `A₁` is zero at every length, while the two MPV states are orthogonal at every positive length. Their cardinalities differ. Thus the desired unrestricted permutation theorem is false under Definition 2.4, exactly as anticipated by the active-block characterization note from #4197.

The blueprint records the negative theorem rather than assigning an unqualified `leanok` to the source sentence. The new paper-gap note explains that a valid restricted corollary would require converse coverage of every candidate by an active canonical-form block.

## Validation

- `lake build` — 9,562/9,562 jobs passed
- `lake build TNLean.MPS.CanonicalForm.BNTUniqueness TNLean` — passed after rebasing onto current `origin/main`
- `python3 scripts/blueprint_lean_sync.py --update-lean-decls --ci --warn-missing-blueprint --changed-files TNLean/MPS/CanonicalForm/BNTUniqueness.lean --diff-base origin/main` — passed; no changed declaration lacks a blueprint entry
- standalone `latexmk` build of `docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex` — passed without unresolved references
- `git diff --check` and proof-integrity token scan — passed

The local full blueprint web rendering exhausted the host's remaining temporary disk space in the pre-existing diagram cache. Exact-head GitHub CI is therefore the authoritative blueprint/checkdecls validation.

Closes #4196.

Parent audit: #2380. Paper tracker: #232.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lean formalization and documentation only; no runtime, auth, or data-path changes. Risk is limited to mathematical scope (a paper claim is marked false under the literal definition).
> 
> **Overview**
> Formalizes a **counterexample** to the unrestricted BNT uniqueness sentence at CPSV16 Appendix A, line 1148: for bond-dimension-one symbol tensors on a two-letter alphabet, the singleton family and a two-block family (with **zero coefficient** on the extra block) are both valid `IsCPSVBasisOfNormalTensors`, so index cardinalities `Fin 1` and `Fin 2` cannot match by any bijection (`exists_isCPSVBasisOfNormalTensors_unequal_card`).
> 
> Shared lemmas **`isIrreducibleTensor_of_bondDim_one`** and **`isNormalTensor_of_bondDim_one_of_transferMap_eq_id`** are added in `Definitions.lean` and reused in `BNTWeightCounterexample.lean` instead of duplicated proofs. Blueprint Chapter 10 and **`docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex`** record the negative theorem and identify **converse coverage** (every candidate represents an active canonical-form block) as the missing hypothesis for a restricted uniqueness result.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb174b7b2771a015c28f55bce3952e36cdfc7e7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->