### PR TITLE
feat(MPS/MPDO): attach fusion clause to vertical form

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -538,6 +538,7 @@ import TNLean.MPS.MPDO.BNTMultiplicityNormalization
 import TNLean.MPS.MPDO.BNTTheoremWitness
 import TNLean.MPS.MPDO.BNTTheoremWitnessConsequences
 import TNLean.MPS.MPDO.BNTFusionIsometries
+import TNLean.MPS.MPDO.BNTFusionTensorClause
 import TNLean.MPS.MPDO.BlockedBNTFusionIsometries
 import TNLean.MPS.MPDO.BNTAssociativity
 import TNLean.MPS.MPDO.BNTLeftTripleFusion

--- a/TNLean/MPS/MPDO/BNTFusionTensorClause.lean
+++ b/TNLean/MPS/MPDO/BNTFusionTensorClause.lean
@@ -188,7 +188,7 @@ noncomputable def toBNTAlgebraTensorClause : BNTAlgebraTensorClause M where
 /-- The chosen decomposition in a tensor-attached fusion clause is a vertical
 canonical form of the underlying MPO tensor. -/
 theorem isVerticalCF : IsVerticalCF M :=
-  H.toBNTAlgebraTensorClause.isVerticalCF
+  BNTAlgebraTensorClause.isVerticalCF H.toBNTAlgebraTensorClause
 
 end BNTFusionTensorClause
 

--- a/TNLean/MPS/MPDO/BNTFusionTensorClause.lean
+++ b/TNLean/MPS/MPDO/BNTFusionTensorClause.lean
@@ -154,14 +154,6 @@ def toBNTFusionIsometryFamily : BNTFusionIsometryFamily (Fin H.labelCount) D whe
   isometry := H.isometry
   fusion := H.fusion
 
-/-- The chosen decomposition in a tensor-attached fusion clause is a vertical
-canonical form of the underlying MPO tensor. -/
-theorem isVerticalCF {N : MPOTensor d D} (G : BNTFusionTensorClause N) :
-    IsVerticalCF N :=
-  ⟨G.labelCount, G.bondDim, G.multiplicity, G.weight, G.tensor,
-    G.verticalCoisometry, G.multiplicity_pos, G.weight_pos, G.coisometry,
-    G.isBNT, G.forward, G.reconstruction⟩
-
 /-- **Tensor-attached implication (iii) to (ii) of Theorem 4.14.**
 
 The fusion isometries for the BNT tensors in a chosen vertical canonical
@@ -192,6 +184,11 @@ noncomputable def toBNTAlgebraTensorClause : BNTAlgebraTensorClause M where
   coeffs := BNTLabelCoefficientFamily.ofChi H.chi
   algebraClause := H.toBNTFusionIsometryFamily.toBNTAlgebraClause
     (verticalBNTTraceScalarFamily H.weight) H.idempotent
+
+/-- The chosen decomposition in a tensor-attached fusion clause is a vertical
+canonical form of the underlying MPO tensor. -/
+theorem isVerticalCF : IsVerticalCF M :=
+  H.toBNTAlgebraTensorClause.isVerticalCF
 
 end BNTFusionTensorClause
 

--- a/TNLean/MPS/MPDO/BNTFusionTensorClause.lean
+++ b/TNLean/MPS/MPDO/BNTFusionTensorClause.lean
@@ -142,10 +142,11 @@ structure BNTFusionTensorClause (M : MPOTensor d D) where
 
 namespace BNTFusionTensorClause
 
-variable {M : MPOTensor d D} (H : BNTFusionTensorClause M)
+variable {M : MPOTensor d D}
 
 /-- The fusion-isometry family carried by a tensor-attached fusion clause. -/
-def toBNTFusionIsometryFamily : BNTFusionIsometryFamily (Fin H.labelCount) D where
+def toBNTFusionIsometryFamily (H : BNTFusionTensorClause M) :
+    BNTFusionIsometryFamily (Fin H.labelCount) D where
   bondDim := H.bondDim
   tensor := fun γ => verticalBNTMPO (H.tensor γ)
   chi := H.chi
@@ -168,7 +169,8 @@ no assertion about the renormalization fixed-point condition.
 Source: arXiv:1606.00608, Theorem 4.14(ii)--(iii), lines 972--993, and
 Appendix C.4, lines 1929--1947 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
-noncomputable def toBNTAlgebraTensorClause : BNTAlgebraTensorClause M where
+noncomputable def toBNTAlgebraTensorClause (H : BNTFusionTensorClause M) :
+    BNTAlgebraTensorClause M where
   labelCount := H.labelCount
   bondDim := H.bondDim
   multiplicity := H.multiplicity
@@ -187,8 +189,9 @@ noncomputable def toBNTAlgebraTensorClause : BNTAlgebraTensorClause M where
 
 /-- The chosen decomposition in a tensor-attached fusion clause is a vertical
 canonical form of the underlying MPO tensor. -/
-theorem isVerticalCF : IsVerticalCF M :=
-  BNTAlgebraTensorClause.isVerticalCF H.toBNTAlgebraTensorClause
+theorem isVerticalCF (H : BNTFusionTensorClause M) : IsVerticalCF M :=
+  BNTAlgebraTensorClause.isVerticalCF
+    (BNTFusionTensorClause.toBNTAlgebraTensorClause H)
 
 end BNTFusionTensorClause
 

--- a/TNLean/MPS/MPDO/BNTFusionTensorClause.lean
+++ b/TNLean/MPS/MPDO/BNTFusionTensorClause.lean
@@ -1,0 +1,220 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.BNTAlgebraTensorClause
+import TNLean.MPS.MPDO.BNTFusionIsometries
+
+/-!
+# Fusion isometries attached to an MPO tensor
+
+This file attaches the fusion-isometry clause of arXiv:1606.00608,
+Theorem 4.14(iii), to the basis of normal tensors in a chosen vertical
+canonical decomposition of the original MPO tensor. The positive diagonal
+matrices in the fusion identity determine the coefficients in the algebra
+clause, while the trace scalars are the traces of the multiplicity matrices
+in the same vertical decomposition.
+
+## Main results
+
+* `BNTFusionTensorClause` is the tensor-attached form of Theorem 4.14(iii).
+* `BNTFusionTensorClause.toBNTAlgebraTensorClause` proves the tensor-attached
+  implication from statement (iii) to statement (ii).
+* `HasBNTFusionTensorClause.to_hasBNTAlgebraTensorClause` gives the
+  corresponding existential implication.
+
+This is one implication of Theorem 4.14. No assertion involving the
+renormalization fixed-point condition is made here.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Theorem 4.14(ii)--(iii), lines 972--993, and Appendix C.4, lines 1929--1947
+-/
+
+open scoped BigOperators ComplexOrder Kronecker Matrix
+
+noncomputable section
+
+namespace MPOTensor
+
+/-- The fusion-isometry clause of Theorem 4.14(iii), attached to a chosen
+vertical canonical decomposition of the MPO tensor \(M\).
+
+The tensors in the fusion identity are precisely the basis of normal tensors
+\(M_\alpha\) in
+\[
+  U\widetilde M U^\dagger
+    = \bigoplus_\alpha \mu_\alpha\otimes M_\alpha.
+\]
+The same positive diagonal matrices \(\chi_{\alpha,\beta,\gamma}\) occur in
+the fusion identity and in the length-one idempotent law for
+\(m_\alpha=\operatorname{tr}(\mu_\alpha)\).
+
+Source: arXiv:1606.00608, Proposition 4.13, lines 943--951;
+Theorem 4.14(iii), lines 986--993; and Appendix C.4, lines 1929--1947 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+structure BNTFusionTensorClause (M : MPOTensor d D) where
+  /-- Number of BNT labels in the chosen vertical decomposition. -/
+  labelCount : ℕ
+  /-- Bond dimension of each vertical BNT tensor. -/
+  bondDim : Fin labelCount → ℕ
+  /-- Dimension of the positive diagonal matrix \(\mu_\alpha\). -/
+  multiplicity : Fin labelCount → ℕ
+  /-- Positive diagonal entries of \(\mu_\alpha\). -/
+  weight : (α : Fin labelCount) → Fin (multiplicity α) → ℂ
+  /-- The chosen vertical basis of normal tensors \(M_\alpha\). -/
+  tensor : (α : Fin labelCount) → MPSTensor (D * D) (bondDim α)
+  /-- The coisometry from the original physical space onto the retained
+  vertical sectors. -/
+  verticalCoisometry :
+    Matrix
+      (Fin (∑ q : Fin (∑ α : Fin labelCount, multiplicity α),
+        verticalCopyDim bondDim multiplicity q)) (Fin d) ℂ
+  /-- Every BNT label occurs with a nonempty multiplicity space.
+
+  Source: arXiv:1606.00608, Proposition 4.13, lines 948--951. -/
+  multiplicity_pos : ∀ α, 0 < multiplicity α
+  /-- Every diagonal entry of \(\mu_\alpha\) is positive.
+
+  Source: arXiv:1606.00608, Proposition 4.13, lines 948--951. -/
+  weight_pos : ∀ α q, (0 : ℂ) < weight α q
+  /-- The vertical change of basis is a coisometry onto the retained sectors.
+
+  Source: arXiv:1606.00608, Proposition 4.13, lines 948--951. -/
+  coisometry : verticalCoisometry * (verticalCoisometry)ᴴ = 1
+  /-- The chosen tensors form a basis of normal tensors of the vertical tensor.
+
+  Source: arXiv:1606.00608, Proposition 4.13, lines 948--951. -/
+  isBNT : MPSTensor.IsBNT (verticalTensor M) labelCount bondDim tensor
+  /-- Conjugating the vertical tensor gives the weighted BNT direct sum.
+
+  Source: arXiv:1606.00608, Proposition 4.13, lines 948--951. -/
+  forward : ∀ v : Fin (D * D),
+    verticalCoisometry * verticalTensor M v * (verticalCoisometry)ᴴ =
+      verticalAssembledTensor bondDim multiplicity weight tensor v
+  /-- The weighted BNT direct sum reconstructs the vertical tensor, including
+  the possible zero-sector complement.
+
+  Source: arXiv:1606.00608, Proposition 4.13, lines 948--951. -/
+  reconstruction : ∀ v : Fin (D * D),
+    verticalTensor M v = (verticalCoisometry)ᴴ *
+      verticalAssembledTensor bondDim multiplicity weight tensor v *
+        verticalCoisometry
+  /-- The positive diagonal matrices \(\chi_{\alpha,\beta,\gamma}\).
+
+  Source: arXiv:1606.00608, Theorem 4.14(ii)--(iii), lines 976--993. -/
+  chi : DiagonalChiFamily (Fin labelCount)
+  /-- Every diagonal entry of \(\chi_{\alpha,\beta,\gamma}\) is positive.
+
+  Source: arXiv:1606.00608, Theorem 4.14(ii)--(iii), lines 976--993. -/
+  chi_pos : chi.PosEntries
+  /-- The fusion isometry \(U_{\alpha,\beta}\) for each pair of BNT labels.
+
+  Source: arXiv:1606.00608, Theorem 4.14(iii), lines 986--993. -/
+  fusionIsometry : ∀ α β : Fin labelCount,
+    Matrix ((γ : Fin labelCount) × (Fin (chi.dim α β γ) × Fin (bondDim γ)))
+      (Fin (bondDim α * bondDim β)) ℂ
+  /-- Each fusion map is an isometry.
+
+  Source: arXiv:1606.00608, Theorem 4.14(iii), lines 986--993. -/
+  isometry : ∀ α β : Fin labelCount,
+    (fusionIsometry α β)ᴴ * fusionIsometry α β = 1
+  /-- The sitewise fusion identity for the concrete vertical BNT tensors.
+
+  Source: arXiv:1606.00608, Theorem 4.14(iii), label `Ualphabeta`,
+  lines 986--993. -/
+  fusion : ∀ (α β : Fin labelCount) (i j : Fin D),
+    fusionIsometry α β *
+        (mulTensor (verticalBNTMPO (tensor α)) (verticalBNTMPO (tensor β))) i j *
+          (fusionIsometry α β)ᴴ =
+      Matrix.blockDiagonal' fun γ =>
+        chi.matrix α β γ ⊗ₖ (verticalBNTMPO (tensor γ)) i j
+  /-- The length-one idempotent identity for
+  \(m_\alpha=\operatorname{tr}(\mu_\alpha)\).
+
+  Source: arXiv:1606.00608, Theorem 4.14(iii), lines 986--993, referring to
+  the identity in lines 981--985. -/
+  idempotent :
+    (verticalBNTTraceScalarFamily weight).HasIdempotentCoefficientForm
+      (BNTLabelCoefficientFamily.ofChi chi)
+
+namespace BNTFusionTensorClause
+
+variable {M : MPOTensor d D} (H : BNTFusionTensorClause M)
+
+/-- The fusion-isometry family carried by a tensor-attached fusion clause. -/
+def toBNTFusionIsometryFamily : BNTFusionIsometryFamily (Fin H.labelCount) D where
+  bondDim := H.bondDim
+  tensor := fun γ => verticalBNTMPO (H.tensor γ)
+  chi := H.chi
+  posEntries := H.chi_pos
+  fusionIsometry := H.fusionIsometry
+  isometry := H.isometry
+  fusion := H.fusion
+
+/-- The chosen decomposition in a tensor-attached fusion clause is a vertical
+canonical form of the underlying MPO tensor. -/
+theorem isVerticalCF {N : MPOTensor d D} (G : BNTFusionTensorClause N) :
+    IsVerticalCF N :=
+  ⟨G.labelCount, G.bondDim, G.multiplicity, G.weight, G.tensor,
+    G.verticalCoisometry, G.multiplicity_pos, G.weight_pos, G.coisometry,
+    G.isBNT, G.forward, G.reconstruction⟩
+
+/-- **Tensor-attached implication (iii) to (ii) of Theorem 4.14.**
+
+The fusion isometries for the BNT tensors in a chosen vertical canonical
+decomposition give the algebra clause for the same decomposition. Its
+coefficients are the trace powers of the same positive diagonal matrices
+\(\chi_{\alpha,\beta,\gamma}\), and its trace scalars are
+\(m_\alpha=\operatorname{tr}(\mu_\alpha)\) from that decomposition.
+
+This is only the implication from statement (iii) to statement (ii); it makes
+no assertion about the renormalization fixed-point condition.
+
+Source: arXiv:1606.00608, Theorem 4.14(ii)--(iii), lines 972--993, and
+Appendix C.4, lines 1929--1947 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+noncomputable def toBNTAlgebraTensorClause : BNTAlgebraTensorClause M where
+  labelCount := H.labelCount
+  bondDim := H.bondDim
+  multiplicity := H.multiplicity
+  weight := H.weight
+  tensor := H.tensor
+  verticalCoisometry := H.verticalCoisometry
+  multiplicity_pos := H.multiplicity_pos
+  weight_pos := H.weight_pos
+  coisometry := H.coisometry
+  isBNT := H.isBNT
+  forward := H.forward
+  reconstruction := H.reconstruction
+  coeffs := BNTLabelCoefficientFamily.ofChi H.chi
+  algebraClause := H.toBNTFusionIsometryFamily.toBNTAlgebraClause
+    (verticalBNTTraceScalarFamily H.weight) H.idempotent
+
+end BNTFusionTensorClause
+
+/-- Existence of the fusion-isometry clause for a chosen vertical canonical
+decomposition of \(M\).
+
+Source: arXiv:1606.00608, Theorem 4.14(iii), lines 986--993, and
+Appendix C.4, lines 1929--1947. -/
+def HasBNTFusionTensorClause (M : MPOTensor d D) : Prop :=
+  Nonempty (BNTFusionTensorClause M)
+
+namespace HasBNTFusionTensorClause
+
+/-- The tensor-attached fusion-isometry clause implies the tensor-attached
+algebra clause, using the same vertical decomposition and the same positive
+diagonal chi matrices.
+
+This is only implication (iii) to (ii) of arXiv:1606.00608, Theorem 4.14;
+Appendix C.4, lines 1929--1947. -/
+theorem to_hasBNTAlgebraTensorClause {M : MPOTensor d D}
+    (h : HasBNTFusionTensorClause M) : HasBNTAlgebraTensorClause M :=
+  h.map BNTFusionTensorClause.toBNTAlgebraTensorClause
+
+end HasBNTFusionTensorClause
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -645,11 +645,10 @@ weights in the length-independent case at
         def:mpdo_bnt_fusion_tensor_clause}
     Suppose the fusion-isometry clause holds for a chosen vertical canonical
     decomposition.  Then the algebra clause holds for the same decomposition,
-    with coefficients
+    with coefficients, for every positive chain length $L$,
     \[
         c^{(L)}_{\alpha,\beta,\gamma}
-        =\operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{L})
-        \qquad (L>0)
+        =\operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{L}),
     \]
     determined by the same diagonal matrices.  Thus statement (iii) implies
     statement (ii) of
@@ -657,13 +656,22 @@ weights in the length-independent case at
     concerning the renormalization fixed-point condition is made here.
 \end{theorem}
 \begin{proof}\leanok
-    The fusion isometries for the vertical BNT tensors $M_\alpha$ satisfy the
-    fusion identity by assumption, while the trace scalars
-    $m_\alpha=\operatorname{tr}(\mu_\alpha)$ satisfy the length-one idempotent
-    identity.  These two identities give the algebra clause for the tensors
-    $M_\alpha$.  Retaining the chosen vertical decomposition and the same
-    diagonal matrices $\chi_{\alpha,\beta,\gamma}$ gives the tensor-attached
-    algebra clause.
+    Iterating the fusion identity along $L$ sites and taking the closed trace
+    gives
+    \[
+        O_L(M_\alpha)O_L(M_\beta)
+        =\sum_\gamma
+        \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{L})O_L(M_\gamma).
+    \]
+    Writing $m_\alpha=\operatorname{tr}(\mu_\alpha)$, the assumed length-one
+    idempotent identity is
+    \[
+        m_\gamma=\sum_{\alpha,\beta}
+        \operatorname{tr}(\chi_{\alpha,\beta,\gamma})m_\alpha m_\beta.
+    \]
+    These are the product and idempotent identities of the algebra clause.
+    Retaining the chosen vertical decomposition and the same diagonal matrices
+    gives the tensor-attached algebra clause.
 \end{proof}
 
 \begin{figure}[ht]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -657,10 +657,12 @@ weights in the length-independent case at
     concerning the renormalization fixed-point condition is made here.
 \end{theorem}
 \begin{proof}\leanok
-    Apply the object-level implication to the basis of normal tensors in the
-    chosen vertical canonical decomposition.  Its trace-scalar hypothesis is
-    exactly the assumed length-one idempotent identity.  Retaining the chosen
-    decomposition and the same diagonal matrices gives the tensor-attached
+    The fusion isometries for the vertical BNT tensors $M_\alpha$ satisfy the
+    fusion identity by assumption, while the trace scalars
+    $m_\alpha=\operatorname{tr}(\mu_\alpha)$ satisfy the length-one idempotent
+    identity.  These two identities give the algebra clause for the tensors
+    $M_\alpha$.  Retaining the chosen vertical decomposition and the same
+    diagonal matrices $\chi_{\alpha,\beta,\gamma}$ gives the tensor-attached
     algebra clause.
 \end{proof}
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -605,6 +605,65 @@ weights in the length-independent case at
     implications involving the renormalization fixed-point condition.
 \end{definition}
 
+\begin{definition}[Fusion isometries for a vertical canonical decomposition]%
+    \label{def:mpdo_bnt_fusion_tensor_clause}
+    \lean{MPOTensor.BNTFusionTensorClause}
+    \lean{MPOTensor.HasBNTFusionTensorClause}
+    \leanok
+    \uses{def:vertical_cf_mpdo,
+        def:mpdo_bnt_fusion_isometry_family,
+        def:mpdo_bnt_label_idempotent_coefficient_form}
+    Choose a vertical canonical decomposition
+    \[
+        U\widetilde M U^\dagger
+        =\bigoplus_\alpha \mu_\alpha\otimes M_\alpha.
+    \]
+    The fusion-isometry clause for this decomposition consists of positive
+    diagonal matrices $\chi_{\alpha,\beta,\gamma}$ and isometries
+    $U_{\alpha,\beta}$ satisfying
+    \[
+        U_{\alpha,\beta}(M_\alpha M_\beta)^{ij}
+        U_{\alpha,\beta}^\dagger
+        =\bigoplus_\gamma
+        \chi_{\alpha,\beta,\gamma}\otimes M_\gamma^{ij}.
+    \]
+    The trace scalars $m_\alpha=\operatorname{tr}(\mu_\alpha)$ satisfy the
+    length-one idempotent identity for the coefficients determined by these
+    same diagonal matrices.  This is statement (iii) of
+    \cite[Theorem~4.14, lines~986--993]{Cirac2016MPDO_arXiv}, attached to the
+    chosen decomposition of
+    \cite[Proposition~4.13, lines~943--951]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{theorem}[Fusion isometries imply the tensor-attached algebra clause]%
+    \label{thm:mpdo_bnt_fusion_tensor_to_algebra_tensor}
+    \lean{MPOTensor.BNTFusionTensorClause.toBNTAlgebraTensorClause}
+    \lean{MPOTensor.HasBNTFusionTensorClause.to_hasBNTAlgebraTensorClause}
+    \leanok
+    \uses{def:mpdo_bnt_algebra_tensor_clause,
+        def:mpdo_bnt_fusion_algebra_clause,
+        def:mpdo_bnt_fusion_tensor_clause}
+    Suppose the fusion-isometry clause holds for a chosen vertical canonical
+    decomposition.  Then the algebra clause holds for the same decomposition,
+    with coefficients
+    \[
+        c^{(L)}_{\alpha,\beta,\gamma}
+        =\operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{L})
+        \qquad (L>0)
+    \]
+    determined by the same diagonal matrices.  Thus statement (iii) implies
+    statement (ii) of
+    \cite[Theorem~4.14, lines~972--993]{Cirac2016MPDO_arXiv}.  No assertion
+    concerning the renormalization fixed-point condition is made here.
+\end{theorem}
+\begin{proof}\leanok
+    Apply the object-level implication to the basis of normal tensors in the
+    chosen vertical canonical decomposition.  Its trace-scalar hypothesis is
+    exactly the assumed length-one idempotent identity.  Retaining the chosen
+    decomposition and the same diagonal matrices gives the tensor-attached
+    algebra clause.
+\end{proof}
+
 \begin{figure}[ht]
     \centering
     \TNMPDORecursiveStructureOperator


### PR DESCRIPTION
## Summary

- attach Theorem 4.14(iii) fusion isometries to a chosen vertical canonical decomposition of an MPO tensor
- derive the tensor-attached algebra clause of Theorem 4.14(ii) using the identical decomposition, diagonal chi matrices, and trace scalars
- record the statement and implication in the blueprint

## Source faithfulness

The new clause follows arXiv:1606.00608, Proposition 4.13, lines 943–951; Theorem 4.14(ii)–(iii), lines 972–993; and Appendix C.4, lines 1929–1947. The length-one idempotent identity is part of source statement (iii). This pull request proves only (iii) implies (ii); it does not assert either implication involving the renormalization fixed-point condition.

Progress on #3949.

## Validation

- `lake env lean TNLean/MPS/MPDO/BNTFusionTensorClause.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- reverse blueprint coverage for the new declarations
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex`
- `git diff --check`
- no proof-integrity blockers in the new module

The complete repository build and declaration check are left to CI because the local shared cache was deliberately kept bounded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formal definitions and a thin composition proof over existing fusion/algebra machinery; no auth, runtime, or data-path changes.
> 
> **Overview**
> Introduces **`MPOTensor.BNTFusionTensorClause`**, packaging Cirac et al. Theorem 4.14(iii) fusion isometries together with the vertical canonical decomposition data (BNT tensors, \(\mu_\alpha\) weights, coisometry, \(\chi\) matrices, and the length-one idempotent on trace scalars).
> 
> **`toBNTAlgebraTensorClause`** and **`HasBNTFusionTensorClause.to_hasBNTAlgebraTensorClause`** derive the existing **`BNTAlgebraTensorClause`** from the same decomposition via **`BNTFusionIsometryFamily.toBNTAlgebraClause`**—only implication (iii)→(ii); no renormalization fixed-point claims.
> 
> Registers the module in **`TNLean.lean`** and adds blueprint definition **`def:mpdo_bnt_fusion_tensor_clause`** plus theorem **`thm:mpdo_bnt_fusion_tensor_to_algebra_tensor`** in **`ch21_mpdo_rfp_fusion_isometries.tex`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e34bfa8f8c6102686883131c6fe7d024a7262202. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->