### PR TITLE
feat(Channel/PetzRecovery): add support Petz recovery

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -132,6 +132,7 @@ import TNLean.Analysis.KleinInequality
 import TNLean.Analysis.MarginalSupport
 import TNLean.Analysis.CoisometricCompression
 import TNLean.Channel.MarginalSupportAbsorption
+import TNLean.Channel.PetzRecovery
 
 -- Layer 2a: Density-matrix Brouwer fixed-point theorem used in Perron--Frobenius existence
 import TNLean.Axioms.BrouwerFixedPoint

--- a/TNLean/Channel/KrausCPTP.lean
+++ b/TNLean/Channel/KrausCPTP.lean
@@ -20,6 +20,7 @@ dimensions.
 
 ## Main declarations
 
+* `IsKrausCP`: a completely positive map in rectangular Kraus form.
 * `IsKrausCPTP`: a trace-preserving completely positive map in rectangular
   Kraus form.
 * `IsKrausCPTP.trace_map`: a map satisfying `IsKrausCPTP` preserves trace.
@@ -59,6 +60,19 @@ dimensions.
 
 open scoped Matrix BigOperators ComplexOrder
 
+/-- A **completely positive map** in rectangular Kraus form
+`S(X) = ∑ᵢ Aᵢ X Aᵢ†`.  Rectangular Kraus operators
+`Aᵢ : Matrix β α ℂ` allow different input and output dimensions.
+
+This is the dimension-changing Kraus notion used for the support formula of
+the Petz transpose map in Hayden--Jozsa--Petz--Winter,
+arXiv:quant-ph/0304007v2, Theorem `thm:petz`, equation
+`eq:transpose:channel`.  No trace-preservation condition is included. -/
+def IsKrausCP {α β : Type*} [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]
+    (S : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ) : Prop :=
+  ∃ (r : ℕ) (A : Fin r → Matrix β α ℂ),
+    ∀ X, S X = ∑ i, A i * X * (A i)ᴴ
+
 /-- A **trace-preserving completely positive map** in Kraus form
 `S(X) = ∑ᵢ Aᵢ X Aᵢ†` with `∑ᵢ Aᵢ† Aᵢ = I`; rectangular Kraus operators
 `Aᵢ : β × α` allow different in/out dimensions. The Kraus form itself gives
@@ -69,6 +83,24 @@ def IsKrausCPTP {α β : Type*} [Fintype α] [DecidableEq α] [Fintype β] [Deci
     (S : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ) : Prop :=
   ∃ (r : ℕ) (A : Fin r → Matrix β α ℂ),
     (∀ X, S X = ∑ i, A i * X * (A i)ᴴ) ∧ (∑ i, (A i)ᴴ * A i = (1 : Matrix α α ℂ))
+
+/-- A trace-preserving completely positive map is completely positive after
+forgetting the resolution-of-identity condition. -/
+theorem IsKrausCPTP.isKrausCP
+    {α β : Type*} [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]
+    {S : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ} (hS : IsKrausCPTP S) : IsKrausCP S := by
+  obtain ⟨r, A, hA, _⟩ := hS
+  exact ⟨r, A, hA⟩
+
+/-- A completely positive map in rectangular Kraus form sends positive
+semidefinite matrices to positive semidefinite matrices. -/
+theorem IsKrausCP.map_posSemidef
+    {α β : Type*} [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]
+    {S : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ} (hS : IsKrausCP S)
+    {X : Matrix α α ℂ} (hX : X.PosSemidef) : (S X).PosSemidef := by
+  obtain ⟨r, A, hA⟩ := hS
+  rw [hA]
+  exact Matrix.posSemidef_sum _ fun i _ => hX.mul_mul_conjTranspose_same (A i)
 
 /-- A completely positive map in rectangular Kraus form sends positive
 semidefinite matrices to positive semidefinite matrices. -/
@@ -129,6 +161,14 @@ noncomputable alias sandwichMap := singleKrausMap
     singleKrausMap V X = V * X * Vᴴ :=
   rfl
 
+/-- Conjugation by one rectangular matrix is completely positive. -/
+theorem singleKrausMap_isKrausCP {α β : Type*}
+    [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]
+    (V : Matrix β α ℂ) : IsKrausCP (singleKrausMap V) := by
+  refine ⟨1, fun _ ↦ V, ?_⟩
+  intro X
+  simp
+
 @[deprecated singleKrausMap_apply (since := "2026-07-16")]
 alias sandwichMap_apply := singleKrausMap_apply
 
@@ -175,6 +215,25 @@ theorem isKrausCPTP_comp {α β γ : Type*} [Fintype α] [DecidableEq α] [Finty
         = (B j)ᴴ * ((∑ i : Fin r, (A i)ᴴ * A i) * B j) := by
       simp only [Matrix.sum_mul, Matrix.mul_sum, Matrix.mul_assoc]
     rw [step, hA_tp, Matrix.one_mul]
+
+/-- Composition preserves complete positivity for rectangular Kraus maps. -/
+theorem isKrausCP_comp {α β γ : Type*} [Fintype α] [DecidableEq α] [Fintype β]
+    [DecidableEq β] [Fintype γ] [DecidableEq γ]
+    {T : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ}
+    {S : Matrix β β ℂ →ₗ[ℂ] Matrix γ γ ℂ}
+    (hT : IsKrausCP T) (hS : IsKrausCP S) : IsKrausCP (S ∘ₗ T) := by
+  obtain ⟨r, A, hA_form⟩ := hS
+  obtain ⟨s, B, hB_form⟩ := hT
+  refine ⟨r * s, fun k ↦ A (finProdFinEquiv.symm k).1 *
+    B (finProdFinEquiv.symm k).2, ?_⟩
+  intro X
+  rw [LinearMap.comp_apply, hB_form X, hA_form,
+    ← finProdFinEquiv.sum_comp (fun k ↦ (A (finProdFinEquiv.symm k).1 *
+      B (finProdFinEquiv.symm k).2) * X *
+      (A (finProdFinEquiv.symm k).1 * B (finProdFinEquiv.symm k).2)ᴴ)]
+  simp only [Equiv.symm_apply_apply, Fintype.sum_prod_type]
+  refine Finset.sum_congr rfl fun i _ ↦ ?_
+  simp only [Matrix.mul_sum, Matrix.sum_mul, Matrix.conjTranspose_mul, Matrix.mul_assoc]
 
 namespace Matrix
 
@@ -270,6 +329,17 @@ theorem rectangularKrausMap_isKrausCPTP
   · intro X
     exact DFunLike.congr_fun (rectangularKrausMap_equiv e A).symm X
   · exact (e.symm.sum_comp fun i => (A i)ᴴ * A i).trans hA
+
+/-- Every finite rectangular Kraus family defines a completely positive map;
+no resolution-of-identity condition is required. -/
+theorem rectangularKrausMap_isKrausCP
+    {κ α β : Type*} [Fintype κ] [Fintype α] [DecidableEq α]
+    [Fintype β] [DecidableEq β] (A : κ → Matrix β α ℂ) :
+    IsKrausCP (rectangularKrausMap A) := by
+  let e := Fintype.equivFin κ
+  refine ⟨Fintype.card κ, fun i ↦ A (e.symm i), ?_⟩
+  intro X
+  exact DFunLike.congr_fun (rectangularKrausMap_equiv e A).symm X
 
 section ControlledDirectSum
 
@@ -708,6 +778,15 @@ theorem rectangularKrausMap_preparationKraus_eq
   rw [hRRentry, Matrix.mul_apply, Finset.mul_sum]
   refine Finset.sum_congr rfl fun j _ => ?_
   rw [preparationKraus_mul_conjTranspose_apply, hRherm.apply]
+
+/-- Adjoining a positive-semidefinite matrix is completely positive, without
+any normalization assumption on the matrix being adjoined. -/
+theorem preparationMap_isKrausCP
+    {α β : Type*} [Fintype α] [DecidableEq α]
+    [Fintype β] [DecidableEq β] (ρ : Matrix β β ℂ) (hρ : ρ.PosSemidef) :
+    IsKrausCP (preparationMap (α := α) ρ) := by
+  rw [← rectangularKrausMap_preparationKraus_eq ρ hρ]
+  exact rectangularKrausMap_isKrausCP _
 
 private theorem preparationKraus_sum_conjTranspose_mul
     {α β : Type*} [Fintype α] [DecidableEq α]

--- a/TNLean/Channel/KrausCPTP.lean
+++ b/TNLean/Channel/KrausCPTP.lean
@@ -21,8 +21,13 @@ dimensions.
 ## Main declarations
 
 * `IsKrausCP`: a completely positive map in rectangular Kraus form.
+* `isKrausCP_iff_isCPMap`: the rectangular and square CP predicates agree for
+  square maps.
 * `IsKrausCPTP`: a trace-preserving completely positive map in rectangular
   Kraus form.
+* `IsKrausCPTP.isKrausCP`: a trace-preserving Kraus map is a Kraus CP map.
+* `IsKrausCP.map_posSemidef`: a Kraus CP map preserves positive
+  semidefiniteness.
 * `IsKrausCPTP.trace_map`: a map satisfying `IsKrausCPTP` preserves trace.
 * `IsKrausCPTP.map_posSemidef`: a map satisfying `IsKrausCPTP` preserves
   positive semidefiniteness.
@@ -31,14 +36,18 @@ dimensions.
   completely positive.
 * `singleKrausMap`: the linear map `X ↦ V X V†` associated with one rectangular
   matrix `V`.
+* `singleKrausMap_isKrausCP`: a single-Kraus map is completely positive.
 * `singleKrausMap_isKrausCPTP`: an isometric single-Kraus map is trace-preserving
   completely positive.
+* `isKrausCP_comp`: composition preserves complete positivity.
 * `isKrausCPTP_comp`: composition preserves the trace-preserving completely
   positive property.
 * `Matrix.equivReindexMap_isKrausCPTP`: reindexing by an equivalence is
   trace-preserving completely positive.
 * `Matrix.rectangularKrausMap_isKrausCPTP`: any finite Kraus family resolving
   the identity defines a trace-preserving completely positive map.
+* `Matrix.rectangularKrausMap_isKrausCP`: any finite rectangular Kraus family
+  defines a completely positive map.
 * `Matrix.controlledKrausMap_sameBlock_apply`: the action on each diagonal
   summand of an orthogonally controlled Kraus map.
 * `Matrix.controlledKrausMap_apply_of_ne`: the vanishing of its off-diagonal
@@ -53,6 +62,8 @@ dimensions.
   each diagonal summand.
 * `Matrix.preparationMap_isKrausCPTP`: adjoining a density matrix is a
   trace-preserving completely positive map.
+* `Matrix.preparationMap_isKrausCP`: adjoining a positive semidefinite matrix is
+  completely positive.
 * `Matrix.preparationKraus`: the explicit Kraus family for state preparation.
 * `Matrix.rectangularKrausMap_preparationKraus_eq`: the Kraus action of state
   preparation.
@@ -66,8 +77,8 @@ open scoped Matrix BigOperators ComplexOrder
 
 This is the dimension-changing Kraus notion used for the support formula of
 the Petz transpose map in Hayden--Jozsa--Petz--Winter,
-arXiv:quant-ph/0304007v2, Theorem `thm:petz`, equation
-`eq:transpose:channel`.  No trace-preservation condition is included. -/
+arXiv:quant-ph/0304007v2, Theorem 3, equation (8).  No trace-preservation
+condition is included. -/
 def IsKrausCP {α β : Type*} [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]
     (S : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ) : Prop :=
   ∃ (r : ℕ) (A : Fin r → Matrix β α ℂ),
@@ -114,10 +125,8 @@ semidefinite matrices to positive semidefinite matrices. -/
 theorem IsKrausCPTP.map_posSemidef
     {α β : Type*} [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]
     {S : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ} (hS : IsKrausCPTP S)
-    {X : Matrix α α ℂ} (hX : X.PosSemidef) : (S X).PosSemidef := by
-  obtain ⟨r, A, hA, _⟩ := hS
-  rw [hA]
-  exact Matrix.posSemidef_sum _ fun i _ => hX.mul_mul_conjTranspose_same (A i)
+    {X : Matrix α α ℂ} (hX : X.PosSemidef) : (S X).PosSemidef :=
+  hS.isKrausCP.map_posSemidef hX
 
 /-- A rectangular Kraus map whose Kraus operators resolve the identity
 preserves the matrix trace. This is the trace-preservation property used for

--- a/TNLean/Channel/KrausCPTP.lean
+++ b/TNLean/Channel/KrausCPTP.lean
@@ -73,6 +73,13 @@ def IsKrausCP {α β : Type*} [Fintype α] [DecidableEq α] [Fintype β] [Decida
   ∃ (r : ℕ) (A : Fin r → Matrix β α ℂ),
     ∀ X, S X = ∑ i, A i * X * (A i)ᴴ
 
+/-- For maps between the same matrix algebra, rectangular Kraus complete
+positivity is exactly the existing square-map predicate `IsCPMap`. -/
+theorem isKrausCP_iff_isCPMap
+    {α : Type*} [Fintype α] [DecidableEq α]
+    {S : Matrix α α ℂ →ₗ[ℂ] Matrix α α ℂ} : IsKrausCP S ↔ IsCPMap S :=
+  Iff.rfl
+
 /-- A **trace-preserving completely positive map** in Kraus form
 `S(X) = ∑ᵢ Aᵢ X Aᵢ†` with `∑ᵢ Aᵢ† Aᵢ = I`; rectangular Kraus operators
 `Aᵢ : β × α` allow different in/out dimensions. The Kraus form itself gives

--- a/TNLean/Channel/PetzRecovery.lean
+++ b/TNLean/Channel/PetzRecovery.lean
@@ -1,0 +1,237 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Analysis.CfcKronecker
+import TNLean.Channel.KrausCPTP
+import TNLean.Channel.MarginalSupportAbsorption
+
+/-!
+# The support Petz transpose map for a partial trace
+
+This file constructs the raw Petz transpose map associated with a positive
+semidefinite reference matrix and the partial trace over a right tensor factor.
+The source formula is defined on the support of the partial trace of the
+reference.  Accordingly, the map here is proved completely positive and is
+proved to recover its reference matrix, but no global trace-preservation claim
+is made.
+
+## Main declarations
+
+* `Matrix.PosSemidef.supportInvSqrt`: the inverse square root on the support.
+* `Matrix.partialTraceRightPetzMap`: the raw Petz transpose map for the right
+  partial trace.
+* `Matrix.partialTraceRightPetzMap_isKrausCP`: complete positivity.
+* `Matrix.partialTraceRightPetzMap_partialTraceRight`: recovery of the
+  reference matrix.
+
+## References
+
+* Hayden, Jozsa, Petz, and Winter, arXiv:quant-ph/0304007v2,
+  Theorem `thm:petz`, equation `eq:transpose:channel` and the specialization
+  following equation `eq:RE:mono`.
+-/
+
+open scoped Matrix BigOperators ComplexOrder Kronecker
+
+namespace Matrix
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- The inverse square root of a positive-semidefinite matrix on its support:
+the zero eigenspace is sent to zero and every positive eigenvalue `x` is sent
+to `(sqrt x)⁻¹`.
+
+This is the singular inverse square root in the support formula of
+Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2,
+equation `eq:transpose:channel`. -/
+noncomputable def PosSemidef.supportInvSqrt {ρ : Matrix n n ℂ}
+    (hρ : ρ.PosSemidef) : Matrix n n ℂ :=
+  hρ.isHermitian.cfc fun x ↦ if x ≠ 0 then (Real.sqrt x)⁻¹ else 0
+
+/-- The support inverse square root is Hermitian. -/
+theorem PosSemidef.supportInvSqrt_isHermitian {ρ : Matrix n n ℂ}
+    (hρ : ρ.PosSemidef) : hρ.supportInvSqrt.IsHermitian := by
+  rw [PosSemidef.supportInvSqrt, hρ.isHermitian.cfc_form,
+    Matrix.star_eq_conjTranspose]
+  have hD : (Matrix.diagonal (fun i ↦
+      (((if hρ.isHermitian.eigenvalues i ≠ 0 then
+        (Real.sqrt (hρ.isHermitian.eigenvalues i))⁻¹ else 0) : ℝ) : ℂ))).IsHermitian := by
+    apply Matrix.IsHermitian.ext
+    intro i j
+    by_cases hij : i = j
+    · subst hij
+      simp
+    · simp [Matrix.diagonal_apply_ne _ hij,
+        Matrix.diagonal_apply_ne _ (Ne.symm hij)]
+  exact Matrix.isHermitian_mul_mul_conjTranspose _ hD
+
+/-- Sandwiching a positive-semidefinite matrix by its support inverse square
+root gives its support projection.  This is the spectral support identity
+underlying the singular Petz formula in arXiv:quant-ph/0304007v2,
+equation `eq:transpose:channel`. -/
+theorem PosSemidef.supportInvSqrt_mul_self_mul_supportInvSqrt
+    {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) :
+    hρ.supportInvSqrt * ρ * hρ.supportInvSqrt =
+      hρ.isHermitian.supportProj := by
+  let f : ℝ → ℝ := fun x ↦ if x ≠ 0 then (Real.sqrt x)⁻¹ else 0
+  change hρ.isHermitian.cfc f * ρ * hρ.isHermitian.cfc f =
+    hρ.isHermitian.supportProj
+  calc
+    hρ.isHermitian.cfc f * ρ * hρ.isHermitian.cfc f =
+        hρ.isHermitian.cfc f * hρ.isHermitian.cfc id *
+          hρ.isHermitian.cfc f := by rw [hρ.isHermitian.cfc_id]
+    _ = hρ.isHermitian.cfc (fun x ↦ f x * id x) *
+          hρ.isHermitian.cfc f := by
+      rw [← hρ.isHermitian.cfc_mul]
+    _ = hρ.isHermitian.cfc (fun x ↦ (f x * id x) * f x) := by
+      rw [← hρ.isHermitian.cfc_mul]
+    _ = hρ.isHermitian.supportProj := by
+      have hdiag :
+          Matrix.diagonal ((RCLike.ofReal : ℝ → ℂ) ∘
+              (fun x ↦ (f x * id x) * f x) ∘ hρ.isHermitian.eigenvalues) =
+            Matrix.diagonal (fun i ↦
+              if hρ.isHermitian.eigenvalues i ≠ 0 then (1 : ℂ) else 0) := by
+        congr 1
+        funext i
+        simp only [Function.comp_apply, id_eq]
+        by_cases hi : hρ.isHermitian.eigenvalues i = 0
+        · simp [f, hi]
+        · have hpos : 0 < hρ.isHermitian.eigenvalues i :=
+            lt_of_le_of_ne (hρ.eigenvalues_nonneg i) (Ne.symm hi)
+          have hsqrt : Real.sqrt (hρ.isHermitian.eigenvalues i) ≠ 0 :=
+            ne_of_gt (Real.sqrt_pos.2 hpos)
+          have hreal :
+              (Real.sqrt (hρ.isHermitian.eigenvalues i))⁻¹ *
+                  hρ.isHermitian.eigenvalues i *
+                (Real.sqrt (hρ.isHermitian.eigenvalues i))⁻¹ = 1 := by
+            nth_rewrite 2 [← Real.mul_self_sqrt hpos.le]
+            field_simp
+          simpa [f, hi] using congrArg Complex.ofReal hreal
+      unfold Matrix.IsHermitian.supportProj
+      rw [Matrix.IsHermitian.cfc, Unitary.conjStarAlgAut_apply, hdiag]
+
+section PartialTrace
+
+variable {L R : Type*} [Fintype L] [DecidableEq L]
+  [Fintype R] [DecidableEq R]
+
+/-- The raw Petz transpose map for the right partial trace with reference
+`σ`.  It is the support formula
+`X ↦ sqrt(σ) ((tr_R σ)⁻¹/² X (tr_R σ)⁻¹/² ⊗ 1_R) sqrt(σ)` from
+Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2,
+Theorem `thm:petz`, equation `eq:transpose:channel`.
+
+The source states this formula on the support of `tr_R σ`; this definition does
+not extend it to a trace-preserving map on the complementary subspace. -/
+noncomputable def partialTraceRightPetzMap
+    (σ : Matrix (L × R) (L × R) ℂ) (hσ : σ.PosSemidef) :
+    Matrix L L ℂ →ₗ[ℂ] Matrix (L × R) (L × R) ℂ :=
+  singleKrausMap (hσ.isHermitian.cfc Real.sqrt) ∘ₗ
+    preparationMap (1 : Matrix R R ℂ) ∘ₗ
+      singleKrausMap (PosSemidef.supportInvSqrt
+        (PosSemidef.partialTraceRight hσ))
+
+/-- The raw partial-trace Petz map has the displayed support formula from
+arXiv:quant-ph/0304007v2, equation `eq:transpose:channel`. -/
+theorem partialTraceRightPetzMap_apply
+    (σ : Matrix (L × R) (L × R) ℂ) (hσ : σ.PosSemidef)
+    (X : Matrix L L ℂ) :
+    partialTraceRightPetzMap σ hσ X =
+      hσ.isHermitian.cfc Real.sqrt *
+        leftKroneckerEmbed (n := R)
+          ((PosSemidef.partialTraceRight hσ).supportInvSqrt * X *
+            (PosSemidef.partialTraceRight hσ).supportInvSqrt) *
+        hσ.isHermitian.cfc Real.sqrt := by
+  simp [partialTraceRightPetzMap, preparationMap,
+    leftKroneckerEmbed_apply,
+    hσ.cfc_sqrt_isHermitian.eq,
+    (PosSemidef.partialTraceRight hσ).supportInvSqrt_isHermitian.eq,
+    Matrix.mul_assoc]
+
+/-- The raw partial-trace Petz map is completely positive in rectangular Kraus
+form.  This is the complete-positivity part of the support formula in
+Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2,
+Theorem `thm:petz`.  No global trace-preservation claim is made. -/
+theorem partialTraceRightPetzMap_isKrausCP
+    (σ : Matrix (L × R) (L × R) ℂ) (hσ : σ.PosSemidef) :
+    IsKrausCP (partialTraceRightPetzMap σ hσ) := by
+  apply isKrausCP_comp
+  · apply isKrausCP_comp
+    · exact singleKrausMap_isKrausCP _
+    · exact preparationMap_isKrausCP _ Matrix.PosSemidef.one
+  · exact singleKrausMap_isKrausCP _
+
+/-- The raw partial-trace Petz map recovers its positive-semidefinite reference
+matrix:
+`R_σ (tr_R σ) = σ`.
+
+This is the automatic reference-recovery identity following
+Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2,
+equation `eq:transpose:channel`.  It uses only the source's support formula and
+does not assert trace preservation away from that support. -/
+theorem partialTraceRightPetzMap_partialTraceRight
+    (σ : Matrix (L × R) (L × R) ℂ) (hσ : σ.PosSemidef) :
+    partialTraceRightPetzMap σ hσ (partialTraceRight σ) = σ := by
+  rw [partialTraceRightPetzMap_apply]
+  have hInv := PosSemidef.supportInvSqrt_mul_self_mul_supportInvSqrt
+    (PosSemidef.partialTraceRight hσ)
+  rw [hInv]
+  set S := hσ.isHermitian.cfc Real.sqrt with hS
+  set P := leftKroneckerEmbed (n := R)
+    (PosSemidef.partialTraceRight hσ).isHermitian.supportProj with hP
+  set Q : Matrix (L × R) (L × R) ℂ := 1 - P with hQ
+  have hS_sq : S * S = σ := by
+    rw [hS]
+    exact hσ.cfc_sqrt_mul_self
+  have hS_herm : S.IsHermitian := by
+    rw [hS]
+    exact hσ.cfc_sqrt_isHermitian
+  have hPσ : P * σ = σ := by
+    rw [hP]
+    exact hσ.leftKroneckerEmbed_supportProj_mul_self
+  have hPherm : P.IsHermitian := by
+    rw [hP]
+    change (leftKroneckerEmbed (n := R)
+      (PosSemidef.partialTraceRight hσ).isHermitian.supportProj)ᴴ = _
+    rw [← star_eq_conjTranspose, ← map_star, star_eq_conjTranspose,
+      (PosSemidef.partialTraceRight hσ).isHermitian.supportProj_isHermitian.eq]
+  have hPidem : P * P = P := by
+    rw [hP, ← map_mul,
+      (PosSemidef.partialTraceRight hσ).isHermitian.supportProj_idem]
+  have hQherm : Q.IsHermitian := by
+    rw [hQ]
+    exact Matrix.isHermitian_one.sub hPherm
+  have hQidem : Q * Q = Q := by
+    rw [hQ]
+    calc
+      (1 - P) * (1 - P) = 1 - P - P + P * P := by noncomm_ring
+      _ = 1 - P := by rw [hPidem]; abel
+  have hQσ : Q * σ = 0 := by
+    rw [hQ, Matrix.sub_mul, Matrix.one_mul, hPσ, sub_self]
+  have hQSQ_pos : (S * Q * S).PosSemidef := by
+    have hQpos : Q.PosSemidef := by
+      rw [hQherm.posSemidef_iff_eigenvalues_nonneg]
+      intro i
+      rcases hQherm.eigenvalues_idem_eq_zero_or_one hQidem i with hi | hi
+      · simp [hi]
+      · simp [hi]
+    simpa [hS_herm.eq] using hQpos.mul_mul_conjTranspose_same (Sᴴ)
+  have hQSQ_trace : (S * Q * S).trace = 0 := by
+    calc
+      (S * Q * S).trace = (S * (Q * S)).trace := by
+        rw [Matrix.mul_assoc]
+      _ = ((Q * S) * S).trace := Matrix.trace_mul_comm _ _
+      _ = (Q * (S * S)).trace := by rw [Matrix.mul_assoc]
+      _ = (Q * σ).trace := by rw [hS_sq]
+      _ = 0 := by rw [hQσ, Matrix.trace_zero]
+  have hQSQ : S * Q * S = 0 := hQSQ_pos.trace_eq_zero_iff.mp hQSQ_trace
+  calc
+    S * P * S = S * (1 - Q) * S := by rw [hQ]; congr 2; abel
+    _ = S * S - S * Q * S := by noncomm_ring
+    _ = σ := by rw [hQSQ, sub_zero, hS_sq]
+
+end PartialTrace
+
+end Matrix

--- a/TNLean/Channel/PetzRecovery.lean
+++ b/TNLean/Channel/PetzRecovery.lean
@@ -29,8 +29,8 @@ is made.
 ## References
 
 * Hayden, Jozsa, Petz, and Winter, arXiv:quant-ph/0304007v2,
-  Theorem `thm:petz`, equation `eq:transpose:channel` and the specialization
-  following equation `eq:RE:mono`.
+  Theorem 3, equation (8), and the specialization following their
+  relative-entropy monotonicity equation.
 -/
 
 open scoped Matrix BigOperators ComplexOrder Kronecker
@@ -45,7 +45,7 @@ to `(sqrt x)⁻¹`.
 
 This is the singular inverse square root in the support formula of
 Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2,
-equation `eq:transpose:channel`. -/
+equation (8). -/
 noncomputable def PosSemidef.supportInvSqrt {ρ : Matrix n n ℂ}
     (hρ : ρ.PosSemidef) : Matrix n n ℂ :=
   hρ.isHermitian.cfc fun x ↦ if x ≠ 0 then (Real.sqrt x)⁻¹ else 0
@@ -70,7 +70,7 @@ theorem PosSemidef.supportInvSqrt_isHermitian {ρ : Matrix n n ℂ}
 /-- Sandwiching a positive-semidefinite matrix by its support inverse square
 root gives its support projection.  This is the spectral support identity
 underlying the singular Petz formula in arXiv:quant-ph/0304007v2,
-equation `eq:transpose:channel`. -/
+equation (8). -/
 theorem PosSemidef.supportInvSqrt_mul_self_mul_supportInvSqrt
     {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) :
     hρ.supportInvSqrt * ρ * hρ.supportInvSqrt =
@@ -121,7 +121,7 @@ variable {L R : Type*} [Fintype L] [DecidableEq L]
 `σ`.  It is the support formula
 `X ↦ sqrt(σ) ((tr_R σ)⁻¹/² X (tr_R σ)⁻¹/² ⊗ 1_R) sqrt(σ)` from
 Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2,
-Theorem `thm:petz`, equation `eq:transpose:channel`.
+Theorem 3, equation (8).
 
 The source states this formula on the support of `tr_R σ`; this definition does
 not extend it to a trace-preserving map on the complementary subspace. -/
@@ -134,7 +134,7 @@ noncomputable def partialTraceRightPetzMap
         (PosSemidef.partialTraceRight hσ))
 
 /-- The raw partial-trace Petz map has the displayed support formula from
-arXiv:quant-ph/0304007v2, equation `eq:transpose:channel`. -/
+arXiv:quant-ph/0304007v2, equation (8). -/
 theorem partialTraceRightPetzMap_apply
     (σ : Matrix (L × R) (L × R) ℂ) (hσ : σ.PosSemidef)
     (X : Matrix L L ℂ) :
@@ -153,7 +153,7 @@ theorem partialTraceRightPetzMap_apply
 /-- The raw partial-trace Petz map is completely positive in rectangular Kraus
 form.  This is the complete-positivity part of the support formula in
 Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2,
-Theorem `thm:petz`.  No global trace-preservation claim is made. -/
+Theorem 3.  No global trace-preservation claim is made. -/
 theorem partialTraceRightPetzMap_isKrausCP
     (σ : Matrix (L × R) (L × R) ℂ) (hσ : σ.PosSemidef) :
     IsKrausCP (partialTraceRightPetzMap σ hσ) := by
@@ -169,7 +169,7 @@ matrix:
 
 This is the automatic reference-recovery identity following
 Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2,
-equation `eq:transpose:channel`.  It uses only the source's support formula and
+equation (8).  It uses only the source's support formula and
 does not assert trace preservation away from that support. -/
 theorem partialTraceRightPetzMap_partialTraceRight
     (σ : Matrix (L × R) (L × R) ℂ) (hσ : σ.PosSemidef) :

--- a/TNLean/Channel/PetzRecovery.lean
+++ b/TNLean/Channel/PetzRecovery.lean
@@ -53,19 +53,9 @@ noncomputable def PosSemidef.supportInvSqrt {ρ : Matrix n n ℂ}
 /-- The support inverse square root is Hermitian. -/
 theorem PosSemidef.supportInvSqrt_isHermitian {ρ : Matrix n n ℂ}
     (hρ : ρ.PosSemidef) : hρ.supportInvSqrt.IsHermitian := by
-  rw [PosSemidef.supportInvSqrt, hρ.isHermitian.cfc_form,
-    Matrix.star_eq_conjTranspose]
-  have hD : (Matrix.diagonal (fun i ↦
-      (((if hρ.isHermitian.eigenvalues i ≠ 0 then
-        (Real.sqrt (hρ.isHermitian.eigenvalues i))⁻¹ else 0) : ℝ) : ℂ))).IsHermitian := by
-    apply Matrix.IsHermitian.ext
-    intro i j
-    by_cases hij : i = j
-    · subst hij
-      simp
-    · simp [Matrix.diagonal_apply_ne _ hij,
-        Matrix.diagonal_apply_ne _ (Ne.symm hij)]
-  exact Matrix.isHermitian_mul_mul_conjTranspose _ hD
+  rw [PosSemidef.supportInvSqrt, ← hρ.isHermitian.cfc_eq]
+  exact Matrix.isHermitian_iff_isSelfAdjoint.mpr
+    (cfc_predicate (fun x : ℝ ↦ if x ≠ 0 then (Real.sqrt x)⁻¹ else 0) ρ)
 
 /-- Sandwiching a positive-semidefinite matrix by its support inverse square
 root gives its support projection.  This is the spectral support identity

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -1368,11 +1368,14 @@ Theorem~\ref{thm:trace_norm_abs}.
 \begin{proof}\leanok
     \uses{lem:is_kraus_cp_comp, lem:mpdo_single_kraus_map_cp,
         lem:mpdo_state_preparation_cp}
-    The map is the composition of conjugation by
-    $\tau^{-1/2}_{\mathrm{supp}}$, adjoining the identity on $H_R$, and
-    conjugation by $\sqrt\sigma$.  Each operation has a rectangular Kraus
-    representation, and compositions of such representations remain in
-    Kraus form.
+    For an orthonormal basis $(e_r)_r$ of $H_R$, let
+    $J_r:H_L\to H_L\otimes H_R$ be given by $J_r(v)=v\otimes e_r$.  Then
+    \[
+        \mathcal R_\sigma(X)=\sum_r K_rXK_r^\dagger,
+        \qquad
+        K_r=\sqrt\sigma\,J_r\tau^{-1/2}_{\mathrm{supp}}.
+    \]
+    Thus the support Petz map has a rectangular Kraus representation.
 \end{proof}
 
 \begin{theorem}[The support Petz map recovers its reference]
@@ -1392,9 +1395,11 @@ Theorem~\ref{thm:trace_norm_abs}.
 \begin{proof}\leanok
     The support inverse-square-root identity reduces the middle factor to
     $P_\tau\otimes\mathbf 1_R$.  Marginal-support absorption gives
-    $(1-P_\tau\otimes\mathbf 1_R)\sigma=0$.  Sandwiching that complementary
-    projection by $\sqrt\sigma$ gives a positive semidefinite matrix of trace
-    zero, hence zero.  Therefore
+    $(\mathbf 1_{LR}-P_\tau\otimes\mathbf 1_R)\sigma=0$, so
+    \[
+        \sqrt\sigma(\mathbf 1_{LR}-P_\tau\otimes\mathbf 1_R)\sqrt\sigma=0
+    \]
+    because that matrix is positive semidefinite of trace zero.  Therefore
     $\sqrt\sigma(P_\tau\otimes\mathbf 1_R)\sqrt\sigma=\sigma$.
 \end{proof}
 

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -1290,6 +1290,113 @@ Theorem~\ref{thm:trace_norm_abs}.
     Passing the inequality through the two limits gives the support-domain bound.
 \end{proof}
 
+\begin{definition}[Inverse square root on the support]
+    \label{def:support_inverse_square_root}
+    \lean{Matrix.PosSemidef.supportInvSqrt}
+    \leanok
+    Let $\tau=\sum_i\lambda_i |i\rangle\!\langle i|$ be positive semidefinite.
+    Its inverse square root on the support is
+    \[
+        \tau^{-1/2}_{\mathrm{supp}}
+        =\sum_{\lambda_i>0}\lambda_i^{-1/2}|i\rangle\!\langle i|.
+    \]
+\end{definition}
+
+\begin{lemma}[Hermiticity of the support inverse square root]
+    \label{lem:support_inverse_square_root_hermitian}
+    \lean{Matrix.PosSemidef.supportInvSqrt_isHermitian}
+    \leanok
+    \uses{def:support_inverse_square_root}
+    The inverse square root of a positive semidefinite matrix on its support is
+    Hermitian.
+\end{lemma}
+
+\begin{lemma}[Support inverse-square-root identity]
+    \label{lem:support_inverse_square_root_sandwich}
+    \lean{Matrix.PosSemidef.supportInvSqrt_mul_self_mul_supportInvSqrt}
+    \leanok
+    \uses{def:support_inverse_square_root}
+    If $P_\tau$ is the orthogonal projector onto the support of a positive
+    semidefinite matrix $\tau$, then
+    \[
+        \tau^{-1/2}_{\mathrm{supp}}\,\tau\,
+        \tau^{-1/2}_{\mathrm{supp}}=P_\tau.
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    In an eigenbasis of $\tau$, the left-hand side has eigenvalue zero when
+    $\lambda_i=0$ and eigenvalue
+    $\lambda_i^{-1/2}\lambda_i\lambda_i^{-1/2}=1$ otherwise.
+\end{proof}
+
+\begin{definition}[Support Petz transpose map for a partial trace]
+    \label{def:partial_trace_support_petz_map}
+    \lean{Matrix.partialTraceRightPetzMap}
+    \leanok
+    \uses{def:support_inverse_square_root}
+    Let $\sigma$ be positive semidefinite on $H_L\otimes H_R$, and set
+    $\tau=\operatorname{tr}_R\sigma$.  The Petz transpose formula on the
+    support of $\tau$ is
+    \[
+        \mathcal R_\sigma(X)=\sqrt\sigma\,
+        \bigl(\tau^{-1/2}_{\mathrm{supp}}X
+        \tau^{-1/2}_{\mathrm{supp}}\otimes\mathbf 1_R\bigr)\sqrt\sigma.
+    \]
+    This is the support formula of
+    \cite[Theorem~3, equation~(8)]{Hayden2004Structure}.  It is not asserted to
+    be trace preserving on operators outside the support of $\tau$.
+\end{definition}
+
+\begin{lemma}[Support Petz formula]
+    \label{lem:partial_trace_support_petz_map_apply}
+    \lean{Matrix.partialTraceRightPetzMap_apply}
+    \leanok
+    \uses{def:partial_trace_support_petz_map}
+    For every matrix $X$, the support Petz map is given by the displayed
+    support formula.
+\end{lemma}
+
+\begin{theorem}[Complete positivity of the support Petz map]
+    \label{thm:partial_trace_support_petz_map_cp}
+    \lean{Matrix.partialTraceRightPetzMap_isKrausCP}
+    \leanok
+    \uses{def:partial_trace_support_petz_map, def:is_kraus_cp}
+    The support Petz transpose map $\mathcal R_\sigma$ is completely positive.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:is_kraus_cp_comp, lem:mpdo_single_kraus_map_cp,
+        lem:mpdo_state_preparation_cp}
+    The map is the composition of conjugation by
+    $\tau^{-1/2}_{\mathrm{supp}}$, adjoining the identity on $H_R$, and
+    conjugation by $\sqrt\sigma$.  Each operation has a rectangular Kraus
+    representation, and compositions of such representations remain in
+    Kraus form.
+\end{proof}
+
+\begin{theorem}[The support Petz map recovers its reference]
+    \label{thm:partial_trace_support_petz_map_reference_recovery}
+    \lean{Matrix.partialTraceRightPetzMap_partialTraceRight}
+    \leanok
+    \uses{def:partial_trace_support_petz_map,
+        lem:support_inverse_square_root_sandwich,
+        thm:marginal_support_left_absorption}
+    For every positive semidefinite $\sigma$,
+    \[
+        \mathcal R_\sigma(\operatorname{tr}_R\sigma)=\sigma.
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    The support inverse-square-root identity reduces the middle factor to
+    $P_\tau\otimes\mathbf 1_R$.  Marginal-support absorption shows that its
+    complement annihilates $\sigma$.  Sandwiching that complementary
+    projection by $\sqrt\sigma$ gives a positive semidefinite matrix of trace
+    zero, hence zero.  Therefore
+    $\sqrt\sigma(P_\tau\otimes\mathbf 1_R)\sqrt\sigma=\sigma$.
+\end{proof}
+
 \begin{theorem}[Entropy is invariant under reindexing]
     \label{thm:entropy_submatrix_equiv}
     \lean{vonNeumannEntropy_submatrix_equiv}

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -1380,6 +1380,7 @@ Theorem~\ref{thm:trace_norm_abs}.
     \lean{Matrix.partialTraceRightPetzMap_partialTraceRight}
     \leanok
     \uses{def:partial_trace_support_petz_map,
+        lem:partial_trace_support_petz_map_apply,
         lem:support_inverse_square_root_sandwich,
         thm:marginal_support_left_absorption}
     For every positive semidefinite $\sigma$,
@@ -1390,8 +1391,8 @@ Theorem~\ref{thm:trace_norm_abs}.
 
 \begin{proof}\leanok
     The support inverse-square-root identity reduces the middle factor to
-    $P_\tau\otimes\mathbf 1_R$.  Marginal-support absorption shows that its
-    complement annihilates $\sigma$.  Sandwiching that complementary
+    $P_\tau\otimes\mathbf 1_R$.  Marginal-support absorption gives
+    $(1-P_\tau\otimes\mathbf 1_R)\sigma=0$.  Sandwiching that complementary
     projection by $\sqrt\sigma$ gives a positive semidefinite matrix of trace
     zero, hence zero.  Therefore
     $\sqrt\sigma(P_\tau\otimes\mathbf 1_R)\sqrt\sigma=\sigma$.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
@@ -18,6 +18,30 @@ section.
 % The definition above is transfer-map idempotence, distinct from the paper's
 % Definition 4.1 (`RFPMixedTS`); the latter is stated below as def:is_rfp_via_ts.
 
+\begin{definition}[Completely positive map in rectangular Kraus form]
+    \label{def:is_kraus_cp}
+    \lean{IsKrausCP}
+    \leanok
+    A linear map $\mathcal S$ between matrix algebras is \emph{completely
+    positive in rectangular Kraus form} if there are finitely many operators
+    $A_i:H\to K$ such that
+    \[
+        \mathcal S(X)=\sum_i A_iXA_i^\dagger.
+    \]
+    No trace-preservation normalization is imposed.
+\end{definition}
+
+\begin{lemma}[Basic properties of rectangular Kraus complete positivity]
+    \label{lem:is_kraus_cp_basic}
+    \lean{IsKrausCP.map_posSemidef, IsKrausCPTP.isKrausCP}
+    \leanok
+    \uses{def:is_kraus_cp, def:is_kraus_cptp}
+    A map in rectangular Kraus form sends positive semidefinite matrices to
+    positive semidefinite matrices.  Every trace-preserving completely positive
+    map in rectangular Kraus form has this property after its normalization
+    condition is forgotten.
+\end{lemma}
+
 \begin{definition}[Trace-preserving completely positive map]
     \label{def:is_kraus_cptp}
     \lean{IsKrausCPTP}
@@ -122,6 +146,15 @@ section.
     positive.
 \end{theorem}
 
+\begin{lemma}[A single-Kraus map is completely positive]
+    \label{lem:mpdo_single_kraus_map_cp}
+    \lean{singleKrausMap_isKrausCP}
+    \leanok
+    \uses{def:is_kraus_cp, def:mpdo_single_kraus_map}
+    For every rectangular operator $V:H\to K$, the map
+    $X\mapsto VXV^\dagger$ is completely positive.
+\end{lemma}
+
 \begin{definition}[Matrix reindexing along an equivalence]
     \label{def:mpdo_equiv_reindex_map}
     \lean{Matrix.equivReindexMap}
@@ -177,6 +210,16 @@ section.
         = \sum_{j} B_j^\dagger B_j = I.
     \]
 \end{proof}
+
+\begin{lemma}[Composition of completely positive rectangular Kraus maps]
+    \label{lem:is_kraus_cp_comp}
+    \lean{isKrausCP_comp}
+    \leanok
+    \uses{def:is_kraus_cp}
+    The composition of two completely positive rectangular Kraus maps is
+    completely positive.  If the two families are $(A_i)_i$ and $(B_j)_j$,
+    the composite family is $(A_iB_j)_{i,j}$.
+\end{lemma}
 
 \begin{theorem}[Tensor extension preserves trace-preserving complete positivity]
     \label{thm:mpdo_tensor_map_id_cptp}
@@ -238,6 +281,15 @@ section.
     The displayed family is already a Kraus representation, and the assumed
     identity is precisely its trace-preserving normalization.
 \end{proof}
+
+\begin{lemma}[A rectangular Kraus family is completely positive]
+    \label{lem:mpdo_rectangular_kraus_map_cp}
+    \lean{Matrix.rectangularKrausMap_isKrausCP}
+    \leanok
+    \uses{def:is_kraus_cp, def:mpdo_rectangular_kraus_map}
+    Every finite rectangular Kraus family defines a completely positive map,
+    without a resolution-of-identity assumption.
+\end{lemma}
 
 \begin{theorem}[Relabeling a rectangular Kraus family]
     \label{thm:mpdo_rectangular_kraus_map_equiv}
@@ -476,6 +528,16 @@ section.
     \]
     while its off-diagonal entries vanish.
 \end{proof}
+
+\begin{lemma}[Positive state preparation is completely positive]
+    \label{lem:mpdo_state_preparation_cp}
+    \lean{Matrix.preparationMap_isKrausCP}
+    \leanok
+    \uses{def:is_kraus_cp, def:mpdo_state_preparation_map,
+      thm:mpdo_state_preparation_kraus_action}
+    If $\rho\geq0$, then the map $X\mapsto X\otimes\rho$ is completely
+    positive.  No trace normalization is required.
+\end{lemma}
 
 \begin{lemma}[State preparation is trace-preserving completely positive]
     \label{lem:mpdo_state_preparation_cptp}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
@@ -47,8 +47,7 @@ section.
     \uses{def:is_kraus_cp, def:is_kraus_cptp}
     A map in rectangular Kraus form sends positive semidefinite matrices to
     positive semidefinite matrices.  Every trace-preserving completely positive
-    map in rectangular Kraus form has this property after its normalization
-    condition is forgotten.
+    Kraus map is a completely positive Kraus map.
 \end{lemma}
 
 \begin{definition}[Trace-preserving completely positive map]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
@@ -31,6 +31,15 @@ section.
     No trace-preservation normalization is imposed.
 \end{definition}
 
+\begin{lemma}[Agreement with square-map complete positivity]
+    \label{lem:is_kraus_cp_iff_is_cp_map}
+    \lean{isKrausCP_iff_isCPMap}
+    \leanok
+    \uses{def:is_kraus_cp, def:cp_map}
+    When the input and output matrix algebras agree, rectangular Kraus complete
+    positivity is equivalent to the square-map notion of complete positivity.
+\end{lemma}
+
 \begin{lemma}[Basic properties of rectangular Kraus complete positivity]
     \label{lem:is_kraus_cp_basic}
     \lean{IsKrausCP.map_posSemidef, IsKrausCPTP.isKrausCP}

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -60,8 +60,10 @@ finite decomposition, the unitary basis change, the weights $p_j$, the component
 density operators, and the block-diagonal equality.} The forward direction is an
 external stand-in: that implication is a theorem of Ruskai, of
 Hayden--Jozsa--Petz--Winter, and of Hayashi, but its proof rests on
-recovery-map and Petz theory not formalized here. The reverse direction is now
-proved from the entropy-additivity sub-lemmas listed below.
+the full saturation-to-recovery theorem, a trace-preserving extension of the
+support Petz map, and the structural analysis of recovered states, none of
+which is yet formalized here. The reverse direction is now proved from the
+entropy-additivity sub-lemmas listed below.
 
 \section{The point at issue: only the forward direction is consumed}
 
@@ -75,8 +77,10 @@ downstream. Its proof is the deep part of the characterization: it requires
 recovery-map theory and the Petz transpose channel, that is, the analysis of
 when the data-processing inequality for relative entropy is saturated and the
 reconstruction of the discarded subsystem from a recovery map. This recovery-map
-and Petz machinery is absent from the underlying library, which is why the
-forward direction is axiomatized rather than proved.
+argument still lacks the saturation-to-recovery theorem, the complementary
+trace-preserving extension of the support Petz map, and the subsequent
+structural analysis, which is why the forward direction is axiomatized rather
+than proved.
 
 \paragraph{Reverse direction (tractable, currently unused).}
 The implication \eqref{eq:qmc} $\Rightarrow$~\eqref{eq:ssa-eq} --- a state of the
@@ -145,20 +149,51 @@ The reverse half uses the following entropy-additivity sub-lemmas, all proved in
 
 With these five facts the reverse implication is a finite computation, now
 carried out in \path{TNLean/Analysis/EntropyMarkovReverse.lean}; the
-forward implication remains an axiom until recovery-map and Petz theory are
-available.
+forward implication remains an axiom until the full saturation-to-recovery
+theorem, the complementary trace-preserving extension, and the structural
+analysis are available.
+
+\section{Support-level Petz infrastructure now available}
+
+The support formula for the Petz transpose map associated with a right partial
+trace is now formalized for every positive semidefinite reference $\sigma$.
+Writing $\tau=\operatorname{tr}_R\sigma$, the map is
+\begin{align}
+  \mathcal R_\sigma(X)
+  =\sqrt\sigma\,
+    (\tau^{-1/2}_{\mathrm{supp}}X
+      \tau^{-1/2}_{\mathrm{supp}}\otimes\mathbf 1_R)\sqrt\sigma.
+\end{align}
+It is proved completely positive in rectangular Kraus form and satisfies
+$\mathcal R_\sigma(\tau)=\sigma$.
+\footnote{Formal declarations:
+\leanid{Matrix.partialTraceRightPetzMap},
+\leanid{Matrix.partialTraceRightPetzMap_isKrausCP}, and
+\leanid{Matrix.partialTraceRightPetzMap_partialTraceRight} in
+\path{TNLean/Channel/PetzRecovery.lean}.}
+This is exactly the formula stated on the support in
+\cite[Theorem~3, equation~(8)]{HaydenJozsaPetzWinter2004}.
+
+This leaf does not yet supply the full recovery theorem needed by the forward
+strong-subadditivity characterization.  In particular, it neither extends the
+singular formula to a trace-preserving channel on the complementary output
+subspace nor proves that saturation of relative-entropy data processing forces
+recovery of the first argument.  Those two steps, followed by the structural
+analysis of the recovered tripartite state, remain necessary before the
+forward axiom can be removed.
 
 \section{Verdict}
 
 The strong-subadditivity equality characterization is now split into a proved
 reverse direction and an axiomatic forward direction. Only the forward
-direction, equality implies quantum-Markov-chain structure, needs recovery-map
-and Petz theory not present in the library, and it alone is axiomatized. The
-reverse direction, a block-diagonal product state attains equality, is proved
-from entropy additivity over weighted direct sums and tensor factors together
-with unitary and reindexing invariance. Until the recovery-map theory is
-formalized, the forward direction remains the irreducible axiomatic content of
-this characterization.
+direction, equality implies quantum-Markov-chain structure, still needs the
+full saturation-to-recovery theorem, the complementary trace-preserving
+extension of the support Petz map, and the structural analysis of recovered
+states, and it alone is axiomatized. The reverse direction, a block-diagonal
+product state attains equality, is proved from entropy additivity over weighted
+direct sums and tensor factors together with unitary and reindexing invariance.
+Until those remaining steps are formalized, the forward direction remains the
+irreducible axiomatic content of this characterization.
 
 \begin{thebibliography}{9}
 


### PR DESCRIPTION
Closes #4198.

Child of #784; contributes to #239.

## Summary

- add a dimension-changing `IsKrausCP` predicate and the composition,
  single-Kraus, rectangular-family, and positive-preparation closure lemmas
  needed by the recovery map
- define the inverse square root on the support of a positive semidefinite
  matrix and prove its support-projector sandwich identity
- define the raw Petz transpose map for a right partial trace, prove complete
  positivity, and prove recovery of its positive semidefinite reference
- document the declarations in the entropy/RFP blueprint and update the Hayashi
  paper-gap note to identify the remaining recovery and structural steps

## Source and faithfulness boundary

The construction follows Hayden--Jozsa--Petz--Winter,
arXiv:quant-ph/0304007v2, Theorem `thm:petz`, equation
`eq:transpose:channel`, specialized to the right partial trace. The singular
formula is used exactly on the support of the reference marginal.

This PR deliberately does **not** claim that the raw singular formula is
globally trace preserving. It also does not formalize the full
data-processing-equality iff recovery theorem, recovery of an arbitrary state
saturating the inequality, or the Hayashi/HJPW structural decomposition. Those
remain the follow-up steps recorded in
`docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex`.

## Validation

- `lake build TNLean.Channel.KrausCPTP TNLean.Channel.PetzRecovery`
- `lake build TNLean`
- `lake exe lint_style TNLean/Channel/KrausCPTP.lean TNLean/Channel/PetzRecovery.lean TNLean.lean`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --ci --diff-base origin/main`
- `cd blueprint && leanblueprint checkdecls`
- `cd blueprint && leanblueprint web` (exit 0; local environment emitted its
  existing missing-bibliography/plugin warnings)
- focused proof-integrity scan: no `sorry`, `admit`, `axiom`, `native_decide`,
  or `unsafeCast` in the changed Lean files
- axiom audit of the new core theorems: only `propext`, `Classical.choice`, and
  `Quot.sound`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New quantum-channel and spectral-calculus lemmas on positive semidefinite matrices; scope is bounded and the PR avoids claiming full recovery or trace preservation, but mistakes here would affect downstream entropy/recovery formalization.
> 
> **Overview**
> Introduces **rectangular Kraus complete positivity** (`IsKrausCP`) for dimension-changing maps, with composition, single-Kraus, rectangular-family, and preparation closures layered on existing `IsKrausCPTP` infrastructure in `KrausCPTP.lean`.
> 
> Adds **`TNLean/Channel/PetzRecovery`**: support inverse square root, the raw right partial-trace **Petz transpose** map (Hayden–Jozsa–Petz–Winter support formula), proofs of **complete positivity** and **`R_σ(tr_R σ) = σ`**, explicitly **without** claiming global trace preservation off the marginal support.
> 
> Wires the module into **`TNLean.lean`**, extends entropy and MPDO-RFP **blueprint** entries, and revises the Hayashi SSA **paper-gap** note to record what is now formalized versus still missing (saturation-to-recovery, trace-preserving extension, structural decomposition).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85fa499a11fac38620fd32088e4cc44b53c8327b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->