### PR TITLE
fix(MPS/CanonicalForm): address BNT review findings

### DIFF
--- a/TNLean/MPS/CanonicalForm/BNTCharacterization.lean
+++ b/TNLean/MPS/CanonicalForm/BNTCharacterization.lean
@@ -34,35 +34,6 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-- Eventual linear independence excludes gauge-phase-equivalent duplicate
-members of a basis of normal tensors.
-
-This is condition (ii) in the characterization of arXiv:1606.00608,
-Proposition 2.7 (`prop:char-BNT`, lines 278--280 and 1137--1142). -/
-theorem IsCPSVBasisOfNormalTensors.blocks_not_gaugePhaseEquiv
-    {g : ℕ} {dim : Fin g → ℕ}
-    {A : MPSTensor d D} {B : (j : Fin g) → MPSTensor d (dim j)}
-    (hBNT : IsCPSVBasisOfNormalTensors A (fun j => ⟨dim j, B j⟩)) :
-    BlocksNotGaugePhaseEquiv (d := d) B := by
-  intro j k hjk hdim hGPE
-  obtain ⟨N₀, hLI⟩ := hBNT.eventually_li
-  have hN := hLI (N₀ + 1) (by omega)
-  obtain ⟨X, ζ, _hζ, hConj⟩ := hGPE
-  have hState : ζ ^ (N₀ + 1) • mpvState (d := d) (B j) (N₀ + 1) =
-      mpvState (d := d) (B k) (N₀ + 1) := by
-    apply PiLp.ext
-    intro σ
-    simp only [PiLp.smul_apply, mpvState_apply, smul_eq_mul]
-    rw [mpv_eq_pow_mul_of_gaugePhase
-      (A := cast (congr_arg (MPSTensor d) hdim) (B j))
-      (B := B k) X ζ hConj (N₀ + 1) σ,
-      mpv_cast_dim hdim (B j) (N₀ + 1) σ]
-  have hPair : LinearIndepOn ℂ
-      (fun l : Fin g => mpvState (d := d) (B l) (N₀ + 1)) {j, k} :=
-    hN.linearIndepOn {j, k}
-  have hNot := (linearIndepOn_pair_iff _ hjk (hN.ne_zero j)).mp hPair
-  exact hNot (ζ ^ (N₀ + 1)) hState
-
 /-- Normal tensors which are not MPV-phase equivalent have asymptotically
 vanishing overlap.
 

--- a/TNLean/MPS/CanonicalForm/NormalTensorGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalTensorGauge.lean
@@ -34,6 +34,8 @@ tensor.
   injectivity.
 * `MPVBlockPhaseEquiv.dim_eq_and_gaugePhaseEquiv_of_isNormalTensor`: exact MPV
   phase equivalence between normal tensors is realized by an invertible gauge.
+* `IsCPSVBasisOfNormalTensors.blocks_not_gaugePhaseEquiv`: distinct members of
+  a basis of normal tensors are not gauge-phase equivalent.
 * `exists_eventually_linearIndependent_of_normalTensor_blocks_not_gaugePhaseEquiv`:
   a separated finite family of normal tensors is eventually linearly
   independent.
@@ -292,6 +294,35 @@ theorem MPVBlockPhaseEquiv.dim_eq_and_gaugePhaseEquiv_of_isNormalTensor
       X' Y' hIrrX hIrrY hTPX hTPY hCrossNorm
   refine ⟨rfl, ?_⟩
   exact gaugePhaseEquiv_of_gaugeEquiv_left_right hGaugeX hGaugePhase hGaugeY
+
+/-- Eventual linear independence excludes gauge-phase-equivalent duplicate
+members of a basis of normal tensors.
+
+This is condition (ii) in the characterization of arXiv:1606.00608,
+Proposition 2.7 (`prop:char-BNT`, lines 278--280 and 1137--1142). -/
+theorem IsCPSVBasisOfNormalTensors.blocks_not_gaugePhaseEquiv
+    {g : ℕ} {dim : Fin g → ℕ}
+    {A : MPSTensor d D} {B : (j : Fin g) → MPSTensor d (dim j)}
+    (hBNT : IsCPSVBasisOfNormalTensors A (fun j => ⟨dim j, B j⟩)) :
+    BlocksNotGaugePhaseEquiv (d := d) B := by
+  intro j k hjk hdim hGPE
+  obtain ⟨N₀, hLI⟩ := hBNT.eventually_li
+  have hN := hLI (N₀ + 1) (by omega)
+  obtain ⟨X, ζ, _hζ, hConj⟩ := hGPE
+  have hState : ζ ^ (N₀ + 1) • mpvState (d := d) (B j) (N₀ + 1) =
+      mpvState (d := d) (B k) (N₀ + 1) := by
+    apply PiLp.ext
+    intro σ
+    simp only [PiLp.smul_apply, mpvState_apply, smul_eq_mul]
+    rw [mpv_eq_pow_mul_of_gaugePhase
+      (A := cast (congr_arg (MPSTensor d) hdim) (B j))
+      (B := B k) X ζ hConj (N₀ + 1) σ,
+      mpv_cast_dim hdim (B j) (N₀ + 1) σ]
+  have hPair : LinearIndepOn ℂ
+      (fun l : Fin g => mpvState (d := d) (B l) (N₀ + 1)) {j, k} :=
+    hN.linearIndepOn {j, k}
+  have hNot := (linearIndepOn_pair_iff _ hjk (hN.ne_zero j)).mp hPair
+  exact hNot (ζ ^ (N₀ + 1)) hState
 
 /-- A finite gauge-phase-separated family of normal tensors is eventually
 linearly independent at the level of matrix product vectors.

--- a/TNLean/MPS/MPDO/SourceBNTBlocking.lean
+++ b/TNLean/MPS/MPDO/SourceBNTBlocking.lean
@@ -50,30 +50,6 @@ theorem IsCPSVBasisOfNormalTensors.blocks_dim_pos
     (hLI (N₀ + 1) hN).ne_zero j
   exact bondDim_pos_of_mpvState_ne_zero hne
 
-private theorem IsCPSVBasisOfNormalTensors.blocks_not_gaugePhaseEquiv
-    {g : ℕ} {dim : Fin g → ℕ}
-    {A : MPSTensor d D} {B : (j : Fin g) → MPSTensor d (dim j)}
-    (hBNT : IsCPSVBasisOfNormalTensors A (fun j => ⟨dim j, B j⟩)) :
-    BlocksNotGaugePhaseEquiv (d := d) B := by
-  intro j k hjk hdim hGPE
-  obtain ⟨N₀, hLI⟩ := hBNT.eventually_li
-  have hN := hLI (N₀ + 1) (by omega)
-  obtain ⟨X, ζ, _hζ, hConj⟩ := hGPE
-  have hState : ζ ^ (N₀ + 1) • mpvState (d := d) (B j) (N₀ + 1) =
-      mpvState (d := d) (B k) (N₀ + 1) := by
-    apply PiLp.ext
-    intro σ
-    simp only [PiLp.smul_apply, mpvState_apply, smul_eq_mul]
-    rw [mpv_eq_pow_mul_of_gaugePhase
-      (A := cast (congr_arg (MPSTensor d) hdim) (B j))
-      (B := B k) X ζ hConj (N₀ + 1) σ,
-      mpv_cast_dim hdim (B j) (N₀ + 1) σ]
-  have hPair : LinearIndepOn ℂ
-      (fun l : Fin g => mpvState (d := d) (B l) (N₀ + 1)) {j, k} :=
-    hN.linearIndepOn {j, k}
-  have hNot := (linearIndepOn_pair_iff _ hjk (hN.ne_zero j)).mp hPair
-  exact hNot (ζ ^ (N₀ + 1)) hState
-
 /-- A simultaneous length-`L` word span becomes a simultaneous one-letter
 span after blocking `L` physical sites. -/
 theorem wordTupleSpanTop_blockTensor_one

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -52,8 +52,13 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
 \begin{proof}\leanok
     At every sufficiently large length the matrix product vectors of the basis
     members are linearly independent. A gauge-phase equivalence between two
-    distinct members would make one of these vectors a nonzero scalar multiple
-    of the other, a contradiction.
+    distinct members would give, for a nonzero scalar $\zeta$,
+    \[
+        \ket{V^{(N)}(A_k)}
+        = \zeta^N\ket{V^{(N)}(A_j)}.
+    \]
+    Thus one vector would be a scalar multiple of the other, contradicting
+    linear independence.
 \end{proof}
 
 \begin{theorem}[Characterization by canonical-form representatives]
@@ -85,8 +90,9 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
               way.
     \end{enumerate}
     This is \cite[Proposition~2.7]{Cirac2016MPDO_arXiv}, with the literal
-    canonical-form display restricted to its active blocks as explained in
-    \path{docs/paper-gaps/cpsv16_bnt_characterization_active_blocks.tex}.
+    canonical-form display restricted to its active blocks.
+    % Local correction documented in
+    % docs/paper-gaps/cpsv16_bnt_characterization_active_blocks.tex.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -100,8 +106,9 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
         thm:cpsv_normal_separated_eventually_li,
         thm:mpv_decomposition}
     First discard the zero-weight summands; they contribute zero at every
-    positive length. Reindex the remaining summands, group them into MPV phase
-    classes, and choose one representative from each class. By
+    positive length. Reindex the remaining summands, group them into the MPV
+    phase classes of Definition~\ref{def:mpv_phase_class_data}, and choose one
+    representative from each class. By
     Theorem~\ref{thm:cpsv_bnt_blocks_not_gaugePhaseEquiv}, eventual linear
     independence of a BNT excludes gauge-phase equivalence between two
     distinct $A_j$.
@@ -118,12 +125,13 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
         \qquad
         O_{\widetilde A_t A_j}(N)\longrightarrow0.
     \]
-    The Gram-matrix criterion therefore makes the combined family
+    By Lemma~\ref{lem:bnt_finite_index_overlap_orthonormal_li}, the combined
+    family
     \[
         \{\ket{V^{(N)}(\widetilde A_t)}:t\in T\}
         \cup \{\ket{V^{(N)}(A_j)}:1\leq j\leq g\}
     \]
-    linearly independent for all sufficiently large $N$. Comparing the
+    is linearly independent for all sufficiently large $N$. Comparing the
     canonical-form expansion with the BNT expansion gives a relation
     \[
         \sum_{t\in T}c_{N,t}\ket{V^{(N)}(\widetilde A_t)}
@@ -132,9 +140,12 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
     Linear independence forces every $c_{N,t}$ to vanish. Hence the
     coefficient of every unmatched phase class vanishes for all sufficiently
     large $N$.
-    Such a coefficient has the form
+    For an unmatched class $t$, let $q$ range over its active canonical-form
+    summands, write $\mu_q$ for the corresponding canonical-form weight, and
+    write $\zeta_q$ for the phase relating that summand to the chosen
+    representative. Then
     \[
-        \sum_q (\zeta_q\mu_q)^N.
+        c_{N,t}=\sum_{q\in t}(\zeta_q\mu_q)^N.
     \]
     Every base $\zeta_q\mu_q$ is nonzero because only active summands occur.
     Eventual vanishing of this finite geometric sum would imply vanishing at
@@ -1962,9 +1973,12 @@ projection.
 
 \begin{proof}\leanok
     If the coefficient vanished for every $N\geq M$, the finite geometric-sum
-    extrapolation would make it vanish at every nonnegative exponent. At
-    exponent zero it is the positive number of copies in sector $j$, which is
-    impossible.
+    extrapolation would make it vanish at every nonnegative exponent. However,
+    at exponent zero,
+    \[
+        c_{P,j}^{(0)}=\sum_q\mu_{j,q}^0=\operatorname{copies}(j)>0,
+    \]
+    which is impossible.
 \end{proof}
 
 \begin{lemma}[Sector coefficient is not eventually zero]

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -1976,7 +1976,7 @@ projection.
     extrapolation would make it vanish at every nonnegative exponent. However,
     at exponent zero,
     \[
-        c_{P,j}^{(0)}=\sum_q\mu_{j,q}^0=\operatorname{copies}(j)>0,
+        c_{P,j}^{(0)}=\sum_q\mu_{j,q}^0=r_j>0,
     \]
     which is impossible.
 \end{proof}

--- a/docs/paper-gaps/cpsv16_bnt_characterization_active_blocks.tex
+++ b/docs/paper-gaps/cpsv16_bnt_characterization_active_blocks.tex
@@ -66,8 +66,9 @@ condition is added: Definition~2.4 permits an additional normal representative
 whose coefficient is identically zero, provided the full candidate family is
 eventually linearly independent.
 
-This correction is recorded in the declaration
-\path{MPSTensor.isCPSVBasisOfNormalTensors_iff_canonicalForm_covered_and_minimal}.
+This correction is recorded in the formal characterization.\footnote{Formal
+declaration:
+\leanid{MPSTensor.isCPSVBasisOfNormalTensors_iff_canonicalForm_covered_and_minimal}.}
 It reconciles the literal canonical-form display with the constructive
 nonzero-block reading and makes the normality condition from Definition~2.4
 visible in the equivalence. It does not strengthen or weaken the mathematical


### PR DESCRIPTION
## Summary

- centralize `IsCPSVBasisOfNormalTensors.blocks_not_gaugePhaseEquiv` in `NormalTensorGauge.lean` so the canonical-form and source-blocking developments share one theorem without an import cycle
- make the Chapter 10 proof equations and dependencies explicit, including the gauge-phase scalar relation, overlap criterion, phase-class coefficients, and exponent-zero contradiction
- move the paper-gap declaration traceability to the required footnoted `\leanid{...}` form

## Context

Post-merge recovery for the exact-head review findings on #4197.

## Validation

- `lake build TNLean.MPS.CanonicalForm.BNTCharacterization TNLean.MPS.MPDO.SourceBNTBlocking`
- `lake build` (9561 jobs)
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `cd blueprint && leanblueprint checkdecls`
- changed-file proof-integrity scan
- `#print axioms` for the shared theorem, main characterization, and downstream blocking theorem (only `propext`, `Classical.choice`, `Quot.sound`)
- standalone paper-gap PDF build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-preserving refactor and documentation-only blueprint/paper-gap edits; no change to mathematical statements or runtime behavior.
> 
> **Overview**
> **Centralizes** `IsCPSVBasisOfNormalTensors.blocks_not_gaugePhaseEquiv` in `NormalTensorGauge.lean` as the single shared theorem, removing duplicate/private copies from `BNTCharacterization.lean` and `SourceBNTBlocking.lean` so canonical-form and MPDO blocking developments can both use it without an import cycle.
> 
> **Blueprint Chapter 10** proofs are made more explicit: the distinct-BNT-members argument states the gauge-phase scalar relation \(\ket{V^{(N)}(A_k)}=\zeta^N\ket{V^{(N)}(A_j)}\); the main characterization cites MPV phase classes, the overlap orthonormality lemma by name, and the unmatched-class coefficient \(c_{N,t}=\sum_{q\in t}(\zeta_q\mu_q)^N\); sector coefficient non-vanishing uses the \(N=0\) identity \(c_{P,j}^{(0)}=r_j>0\).
> 
> **Paper-gap note** `cpsv16_bnt_characterization_active_blocks.tex` now points to the formal characterization via a footnoted `\leanid{...}` instead of an inline `\path{...}` declaration path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae906415b86dc346b6f7d8c6cd5cb1bd0fa6f795. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->