### PR TITLE
feat(MPS/MPDO): apply eta-local bond block actions

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -558,6 +558,7 @@ import TNLean.MPS.MPDO.BlockedCompleteZipper
 import TNLean.MPS.MPDO.CommutingForm
 import TNLean.MPS.MPDO.CommutingFormBridge
 import TNLean.MPS.MPDO.CommutingOverlappingCoordinates
+import TNLean.MPS.MPDO.CommutingFormSpatialBridge
 import TNLean.MPS.MPDO.GSNNCHSectorSum
 import TNLean.MPS.MPDO.GSNNCHOrthogonalSectors
 import TNLean.MPS.MPDO.BNTSectorCommutingFamily

--- a/TNLean/MPS/MPDO/CommutingFormSpatialBridge.lean
+++ b/TNLean/MPS/MPDO/CommutingFormSpatialBridge.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.CommutingOverlappingCoordinates
+
+/-!
+# Unitary block actions for an eta-local bond
+
+This file applies the spatial decomposition of Beigi's lemma to the pair-indexed bond
+carried by an eta-local structure.
+
+## Main declarations
+
+* `MPOTensor.EtaLocalStructureData.exists_unitary_blockActions_of_pairBond`
+
+## References
+
+* S. Beigi, arXiv:1105.1019v2, Lemma 2.1.
+* arXiv:1606.00608, Appendix C.2, lines 1597--1610.
+-/
+
+open scoped ComplexOrder Kronecker Matrix
+
+namespace MPOTensor.EtaLocalStructureData
+
+variable {d D : ℕ} {M : MPOTensor d D}
+
+/-- The pair-indexed bond carried by an eta-local structure admits the explicit unitary
+block-action decomposition of Beigi's lemma.
+
+Under the common three-site identification, the two abstract overlapping lifts are
+precisely the first two adjacent translates of the original bond.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1597--1610; Beigi,
+arXiv:1105.1019v2, Lemma 2.1. -/
+theorem exists_unitary_blockActions_of_pairBond
+    (data : EtaLocalStructureData M) :
+    ∃ (K : ℕ) (dl dr : Fin K → ℕ)
+      (e : ((q : Fin K) × (Fin (dr q) × Fin (dl q))) ≃ Fin d)
+      (U : Matrix (Fin d) (Fin d) ℂ)
+      (R : ∀ q, Matrix (Fin d × Fin (dl q)) (Fin d × Fin (dl q)) ℂ)
+      (S : ∀ q, Matrix (Fin (dr q) × Fin d) (Fin (dr q) × Fin d) ℂ),
+      U ∈ Matrix.unitaryGroup (Fin d) ℂ ∧
+        (∀ q, 0 < dl q) ∧ (∀ q, 0 < dr q) ∧
+        (∀ q, (R q).IsHermitian) ∧ (∀ q, (S q).IsHermitian) ∧
+        Matrix.reindex (Matrix.leftSpatialBlockEquiv e).symm
+            (Matrix.leftSpatialBlockEquiv e).symm
+            (star ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ U) * data.pairBond *
+              ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ U)) =
+          (Matrix.blockDiagonal' fun q =>
+            R q ⊗ₖ (1 : Matrix (Fin (dr q)) (Fin (dr q)) ℂ)) ∧
+        Matrix.reindex (Matrix.rightSpatialBlockEquiv e).symm
+            (Matrix.rightSpatialBlockEquiv e).symm
+            (star (U ⊗ₖ (1 : Matrix (Fin d) (Fin d) ℂ)) * data.pairBond *
+              (U ⊗ₖ (1 : Matrix (Fin d) (Fin d) ℂ))) =
+          (Matrix.blockDiagonal' fun q =>
+            (1 : Matrix (Fin (dl q)) (Fin (dl q)) ℂ) ⊗ₖ S q) := by
+  apply Matrix.exists_unitary_blockActions_of_overlappingLifts_commute
+  · exact data.pairBond_isHermitian
+  · exact data.pairBond_isHermitian
+  · exact data.overlappingLifts_pairBond_comm
+
+end MPOTensor.EtaLocalStructureData

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -182,6 +182,55 @@
     combine it with the doubled-index transfer hypothesis.
 \end{proof}
 
+\begin{theorem}[$\eta$-local bond admits unitary block actions]
+    \label{thm:mpdo_eta_local_pair_bond_unitary_block_actions}
+    \lean{MPOTensor.EtaLocalStructureData.exists_unitary_blockActions_of_pairBond}
+    \leanok
+    \uses{def:mpdo_three_site_overlapping_coordinates,
+        thm:mpdo_eta_bond_overlapping_lifts,
+        thm:commuting_overlapping_unitary_block_actions}
+    Let $\widehat B$ be the pair-indexed positive two-site bond of an
+    $\eta$-local structure.  There are positive dimensions
+    $d_{l,q}=\dim H_{q,l}$ and $d_{r,q}=\dim H_{q,r}$, a unitary decomposition
+    \[
+        H\cong\bigoplus_{q=0}^{K-1}H_{q,l}\otimes H_{q,r},
+    \]
+    and Hermitian operators $R_q$ on $H\otimes H_{q,l}$ and $S_q$ on
+    $H_{q,r}\otimes H$ such that
+    \[
+        (\Id_H\otimes U^*)\widehat B(\Id_H\otimes U)
+        =\bigoplus_{q=0}^{K-1}(R_q\otimes\Id_{H_{q,r}}),
+    \]
+    \[
+        (U^*\otimes\Id_H)\widehat B(U\otimes\Id_H)
+        =\bigoplus_{q=0}^{K-1}(\Id_{H_{q,l}}\otimes S_q).
+    \]
+    The basis bijection for each sector enumerates the numerical indices in
+    right--left order,
+    \[
+        \bigsqcup_q\bigl(\{0,\ldots,d_{r,q}-1\}
+            \times\{0,\ldots,d_{l,q}-1\}\bigr)
+        \cong\{0,\ldots,d-1\}.
+    \]
+    Writing $e(q,(r,s))$ for this basis bijection, the left and right spatial
+    coordinates are respectively
+    \[
+        (q,((i,s),r))\longmapsto(i,e(q,(r,s))),
+        \qquad
+        (q,(s,(r,k)))\longmapsto(e(q,(r,s)),k).
+    \]
+    Hence the tensor factors in the displayed block actions occur in
+    left--right order.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_eta_bond_overlapping_lifts,
+        thm:commuting_overlapping_unitary_block_actions}
+    The pair-indexed bond is Hermitian by positivity, and its two overlapping
+    lifts commute by the common three-site identification.  Apply
+    Theorem~\ref{thm:commuting_overlapping_unitary_block_actions}.
+\end{proof}
+
 \begin{theorem}[A translation-invariant commuting bond and ZCL imply SAL]
     \label{thm:mpdo_translation_invariant_commuting_form_zcl_sal}
     \notready

--- a/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
+++ b/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
@@ -135,10 +135,19 @@ transports their length-three commutation to the abstract lifts.  Hence the
 formal hypotheses of Beigi's lemma are obtained without an additional
 assumption.
 
-What remains is to use the resulting unitary block actions to construct the
-translation-invariant neighboring operators $\eta_{k,h}$ and the global form
-\emph{sigmaNK2}, and then to perform the source-ZCL trace factorization and
-Markov decomposition at an arbitrary cut.
+The application of the finite-matrix theorem to this pair-indexed bond is
+\leanid{MPOTensor.EtaLocalStructureData.exists_unitary_blockActions_of_pairBond}.
+It supplies one unitary middle-space identification and the two Hermitian
+block actions required by Beigi's lemma.\footnote{The application theorem is
+in \doclink{TNLean/MPS/MPDO/CommutingFormSpatialBridge}; its coordinate and
+commutation hypotheses are supplied by
+\doclink{TNLean/MPS/MPDO/CommutingOverlappingCoordinates}.}
+
+What remains is to transport the resulting direct-sum decomposition through
+the translation-invariant family and derive the neighboring operators
+$\eta_{k,h}$ without assuming a Hayashi decomposition.  The source ZCL
+hypothesis must then yield the rank-one trace factorization
+$\operatorname{tr}(\eta_{k,h})=a_kb_h$ at source lines~1610--1616.
 
 Consequently the source implication
 \[
@@ -163,15 +172,10 @@ restriction that isolates only its final entropy-theoretic step.
 The gap can be removed in the following stages.
 
 \begin{enumerate}
-\item Apply
-\leanid{Matrix.exists_unitary_blockActions_of_overlappingLifts_commute} to the
-pair-indexed bond through the proved three-site coordinate identification, and
-transport its
-single-site direct-sum decomposition through the translation-invariant bond
-family.  This must produce the neighboring operators $\eta_{k,h}$ and the
-global form \emph{sigmaNK2} without assuming a Hayashi decomposition.
-\item Use \leanid{MPOTensor.IsSourceZCL} to prove the rank-one trace
-factorization
+\item Transport the Beigi block actions through the translation-invariant bond
+family, obtaining the neighboring operators $\eta_{k,h}$ without assuming a
+Hayashi decomposition.  Use \leanid{MPOTensor.IsSourceZCL} to prove the
+rank-one trace factorization
 $\operatorname{tr}(\eta_{k,h})=a_kb_h$ appearing at source lines~1610--1616.
 Then trace the fourth region and construct the quantum Markov decomposition at
 each admissible cut, and apply the all-cut Markov theorem above.


### PR DESCRIPTION
## Summary

This applies the completed Bravyi–Vyalyi/Beigi unitary block-action theorem directly to the pair-indexed bond of an eta-local MPDO structure.

While this PR was under review, #4221 merged the common three-site coordinate bridge and the Hermiticity/commutation hypotheses. The branch has therefore been rebased and all parallel coordinate definitions and window proofs have been removed. The new theorem
`MPOTensor.EtaLocalStructureData.exists_unitary_blockActions_of_pairBond`
now reuses those results and constructs the explicit unitary direct-sum block actions:
$
R_q\otimes \mathbf 1_{q,r},
\qquad
\mathbf 1_{q,l}\otimes S_q.
$

Chapter 21 records the application theorem with `\leanok` and explicitly distinguishes the raw right-before-left basis enumeration from the left-before-right tensor grouping in the block actions. The paper-gap note credits the coordinate bridge already on `main` and narrows the remaining gap to translation-invariant transport of the block actions and the source-ZCL rank-one trace factorization tracked in #4211.

## Validation

- `lake env lean TNLean/MPS/MPDO/CommutingFormSpatialBridge.lean`
- `lake build TNLean.MPS.MPDO.CommutingFormSpatialBridge` (3,319 jobs)
- `lake build` (9,566 jobs)
- reader-facing prose check
- `git diff --check origin/main...HEAD`
- proof-integrity scan: no `sorry`, `admit`, `axiom`, `native_decide`, or kernel bypass

The exact-head blueprint compilation and declaration check run in PR CI.

Closes #4203

Parent trackers #4191, #4175, #2380, and #232 remain open.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, proof-only addition that composes existing lemmas; no auth, runtime, or behavioral changes beyond formal documentation.
> 
> **Overview**
> Adds **`CommutingFormSpatialBridge`** with `MPOTensor.EtaLocalStructureData.exists_unitary_blockActions_of_pairBond`, which instantiates the general **`Matrix.exists_unitary_blockActions_of_overlappingLifts_commute`** on the η-local **pair-indexed bond** using Hermiticity and overlapping-lift commutation from **`CommutingOverlappingCoordinates`** (no new coordinate proofs).
> 
> **Chapter 21** gains a `\leanok` theorem stating the unitary direct-sum block actions \(R_q \otimes \mathbf{1}\) and \(\mathbf{1} \otimes S_q\), including the right–left basis enumeration vs left–right tensor grouping. The **commuting-form-to-SAL gap note** records this application as proved and reframes the open work as transporting block actions through the translation-invariant family and the source-ZCL rank-one trace step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca485fb3272a933341e38bd46099f8400eb246f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->