### PR TITLE
feat(Channel/Schwarz): characterize abstract multiplicative domains

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -190,6 +190,7 @@ import TNLean.Channel.PositiveMapDetection
 import TNLean.Channel.SchmidtNumberFactors
 import TNLean.Channel.Separable
 import TNLean.Channel.Schwarz.MultiplicativeDomain
+import TNLean.Channel.Schwarz.AbstractMultiplicativeDomain
 import TNLean.Channel.Schwarz.MultiplicativeDomainPowers
 import TNLean.Channel.Schwarz.MultiplicativeDomainFull
 import TNLean.Channel.FixedPoint.Algebra

--- a/TNLean/Channel/Schwarz/AbstractMultiplicativeDomain.lean
+++ b/TNLean/Channel/Schwarz/AbstractMultiplicativeDomain.lean
@@ -1,0 +1,238 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.Schwarz.PositiveMapProperties
+
+/-!
+# Multiplicative domains of abstract Schwarz maps
+
+This file proves Wolf's multiplicative-domain characterization for an arbitrary
+complex-linear map satisfying the Schwarz inequality.  In particular, no Kraus
+representation or complete-positivity hypothesis is imposed.
+
+## Main definitions
+
+* `IsSchwarzMap`: the one-variable inequality in
+  Wolf, Equation (5.2).
+* `SchwarzMap.rightMultiplicativeDomain` and
+  `SchwarzMap.leftMultiplicativeDomain`: the domains in Wolf, Equations
+  (5.11)--(5.12).
+
+## Main results
+
+* `SchwarzMap.mem_rightMultiplicativeDomain_iff`: Wolf, Equation (5.13).
+* `SchwarzMap.mem_leftMultiplicativeDomain_iff`: Wolf, Equation (5.14).
+
+## References
+
+* M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 5,
+  Equations (5.2) and (5.11)--(5.14); local source
+  `Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`, lines 156--164 and
+  383--410.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder
+open Matrix
+
+variable {n : Type*} [Fintype n]
+
+local notation "Mat" => Matrix n n ℂ
+
+/-- A complex-linear matrix map satisfies the Schwarz inequality when
+
+\(E(A^\dagger A)-E(A^\dagger)E(A)\)
+
+is positive semidefinite for every \(A\).
+
+This is Wolf, Equation (5.2), local source
+`Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`, lines 156--164. -/
+def IsSchwarzMap (E : Mat →ₗ[ℂ] Mat) : Prop :=
+  ∀ A, (E (Aᴴ * A) - E Aᴴ * E A).PosSemidef
+
+namespace SchwarzMap
+
+/-- The right multiplicative domain of \(E\), following Wolf's convention:
+it consists of those \(A\) for which right multiplication by \(A\) is preserved.
+
+Source: Wolf, Equation (5.11), local source
+`Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`, lines 383--386. -/
+def rightMultiplicativeDomain (E : Mat →ₗ[ℂ] Mat) : Set Mat :=
+  {A | ∀ X, E (X * A) = E X * E A}
+
+/-- The left multiplicative domain of \(E\), following Wolf's convention:
+it consists of those \(A\) for which left multiplication by \(A\) is preserved.
+
+Source: Wolf, Equation (5.12), local source
+`Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`, lines 387--389. -/
+def leftMultiplicativeDomain (E : Mat →ₗ[ℂ] Mat) : Set Mat :=
+  {A | ∀ X, E (A * X) = E A * E X}
+
+/-- The multiplicative domain is the intersection of the right and left domains.
+
+Source: Wolf, local source
+`Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`, lines 391--392. -/
+def multiplicativeDomain (E : Mat →ₗ[ℂ] Mat) : Set Mat :=
+  rightMultiplicativeDomain E ∩ leftMultiplicativeDomain E
+
+private theorem linear_eq_zero_of_quadratic_nonneg
+    (b d : ℝ) (h : ∀ t : ℝ, 0 ≤ t * b + t ^ 2 * d) :
+    b = 0 := by
+  have hd : 0 ≤ d := by
+    have hpos := h 1
+    have hneg := h (-1)
+    norm_num at hpos hneg
+    linarith
+  have hd1 : 0 < d + 1 := by linarith
+  have hspecial := h (-b / (d + 1))
+  field_simp [ne_of_gt hd1] at hspecial
+  nlinarith [sq_nonneg b]
+
+/-- A matrix-valued quadratic which is positive semidefinite for every real
+parameter and has zero constant term must have zero linear coefficient. -/
+private theorem eq_zero_of_forall_quadratic_posSemidef
+    {m : Type*} [Finite m] {B D : Matrix m m ℂ}
+    (h : ∀ t : ℝ,
+      (((t : ℂ) • B) + ((t ^ 2 : ℝ) : ℂ) • D).PosSemidef) :
+    B = 0 := by
+  classical
+  letI := Fintype.ofFinite m
+  apply Matrix.eq_zero_of_forall_star_dotProduct_mulVec_eq_zero
+  intro x
+  let b : ℂ := star x ⬝ᵥ B *ᵥ x
+  let d : ℂ := star x ⬝ᵥ D *ᵥ x
+  have hq (t : ℝ) : 0 ≤ (t : ℂ) * b + ((t ^ 2 : ℝ) : ℂ) * d := by
+    have ht := (h t).dotProduct_mulVec_nonneg x
+    simpa [b, d, Matrix.add_mulVec, Matrix.smul_mulVec, dotProduct_add,
+      dotProduct_smul, smul_eq_mul] using ht
+  have hbre : b.re = 0 := by
+    apply linear_eq_zero_of_quadratic_nonneg b.re d.re
+    intro t
+    have ht := (Complex.nonneg_iff.mp (hq t)).1
+    simpa only [Complex.add_re, Complex.mul_re, Complex.ofReal_re,
+      Complex.ofReal_im, zero_mul, sub_zero] using ht
+  have hbim : b.im = 0 := by
+    have hplus := (Complex.nonneg_iff.mp (hq 1)).2
+    have hminus := (Complex.nonneg_iff.mp (hq (-1))).2
+    norm_num [Complex.mul_im] at hplus hminus
+    linarith
+  exact Complex.ext hbre hbim
+
+private theorem schwarz_cross_terms
+    (E : Mat →ₗ[ℂ] Mat) (hE : IsSchwarzMap E)
+    (A : Mat)
+    (hA : E (Aᴴ * A) = E Aᴴ * E A) (Y : Mat) :
+    E (Aᴴ * Y) = E Aᴴ * E Y ∧
+      E (Yᴴ * A) = E Yᴴ * E A := by
+  let L : Mat := E (Aᴴ * Y) - E Aᴴ * E Y
+  let R : Mat := E (Yᴴ * A) - E Yᴴ * E A
+  let Q : Mat := E (Yᴴ * Y) - E Yᴴ * E Y
+  have hreal (t : ℝ) :
+      (((t : ℂ) • (L + R)) + ((t ^ 2 : ℝ) : ℂ) • Q).PosSemidef := by
+    have hexpand :
+        E ((A + (t : ℂ) • Y)ᴴ * (A + (t : ℂ) • Y)) -
+            E (A + (t : ℂ) • Y)ᴴ * E (A + (t : ℂ) • Y) =
+          ((t : ℂ) • (L + R)) + ((t ^ 2 : ℝ) : ℂ) • Q := by
+      simp only [Matrix.conjTranspose_add, Matrix.conjTranspose_smul]
+      rw [show star (t : ℂ) = (t : ℂ) by simp]
+      simp only [Matrix.add_mul, Matrix.mul_add, Matrix.mul_smul,
+        Matrix.smul_mul, map_add, map_smul]
+      rw [hA]
+      simp only [smul_add, Complex.coe_smul, Complex.ofReal_pow]
+      module
+    rw [← hexpand]
+    exact hE (A + (t : ℂ) • Y)
+  have hsum : L + R = 0 := eq_zero_of_forall_quadratic_posSemidef hreal
+  have himag (t : ℝ) :
+      (((t : ℂ) • ((Complex.I : ℂ) • L - (Complex.I : ℂ) • R)) +
+        ((t ^ 2 : ℝ) : ℂ) • Q).PosSemidef := by
+    have hexpand :
+        E ((A + ((t : ℂ) * Complex.I) • Y)ᴴ *
+              (A + ((t : ℂ) * Complex.I) • Y)) -
+            E (A + ((t : ℂ) * Complex.I) • Y)ᴴ *
+              E (A + ((t : ℂ) * Complex.I) • Y) =
+          ((t : ℂ) • ((Complex.I : ℂ) • L - (Complex.I : ℂ) • R)) +
+            ((t ^ 2 : ℝ) : ℂ) • Q := by
+      simp only [Matrix.conjTranspose_add, Matrix.conjTranspose_smul]
+      rw [show star ((t : ℂ) * Complex.I) = -((t : ℂ) * Complex.I) by simp]
+      simp only [Matrix.add_mul, Matrix.mul_add, Matrix.mul_smul,
+        Matrix.smul_mul, map_add, map_smul]
+      rw [hA]
+      simp only [neg_smul, smul_add, smul_neg, Complex.coe_smul,
+        Complex.ofReal_pow]
+      have hz :
+          -(((t : ℂ) * Complex.I) * ((t : ℂ) * Complex.I)) =
+            ((t ^ 2 : ℝ) : ℂ) := by
+        calc
+          -(((t : ℂ) * Complex.I) * ((t : ℂ) * Complex.I)) =
+              -((t : ℂ) ^ 2 * Complex.I ^ 2) := by ring
+          _ = ((t ^ 2 : ℝ) : ℂ) := by rw [Complex.I_sq]; norm_num
+      simp only [smul_smul]
+      simp_rw [← neg_smul]
+      rw [hz]
+      module
+    rw [← hexpand]
+    exact hE (A + ((t : ℂ) * Complex.I) • Y)
+  have hdiff : (Complex.I : ℂ) • L - (Complex.I : ℂ) • R = 0 :=
+    eq_zero_of_forall_quadratic_posSemidef himag
+  have hL : L = 0 := by
+    have hR : R = -L := eq_neg_of_add_eq_zero_right hsum
+    rw [hR, smul_neg, sub_neg_eq_add, ← add_smul] at hdiff
+    exact (smul_eq_zero.mp hdiff).resolve_left (by norm_num)
+  have hR : R = 0 := by
+    rw [hL, zero_add] at hsum
+    exact hsum
+  exact ⟨sub_eq_zero.mp hL, sub_eq_zero.mp hR⟩
+
+/-- Wolf's right multiplicative-domain characterization.
+
+For an arbitrary complex-linear map satisfying the Schwarz inequality,
+equality at \(A^\dagger A\) is equivalent to preservation of every product
+\(XA\).
+
+Source: Wolf, Equation (5.13), local source
+`Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`, lines 399--410. -/
+theorem mem_rightMultiplicativeDomain_iff
+    (E : Mat →ₗ[ℂ] Mat) (hE : IsSchwarzMap E) (A : Mat) :
+    A ∈ rightMultiplicativeDomain E ↔
+      E (Aᴴ * A) = E Aᴴ * E A := by
+  constructor
+  · intro hA
+    exact hA Aᴴ
+  · intro hA X
+    simpa using (schwarz_cross_terms E hE A hA Xᴴ).2
+
+/-- Wolf's left multiplicative-domain characterization.
+
+For an arbitrary complex-linear map satisfying the Schwarz inequality,
+equality at \(AA^\dagger\) is equivalent to preservation of every product
+\(AX\).
+
+Source: Wolf, Equation (5.14), local source
+`Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`, lines 399--410. -/
+theorem mem_leftMultiplicativeDomain_iff
+    (E : Mat →ₗ[ℂ] Mat) (hE : IsSchwarzMap E) (A : Mat) :
+    A ∈ leftMultiplicativeDomain E ↔
+      E (A * Aᴴ) = E A * E Aᴴ := by
+  constructor
+  · intro hA
+    exact hA Aᴴ
+  · intro hA X
+    simpa using (schwarz_cross_terms E hE Aᴴ (by simpa) X).1
+
+/-- The full multiplicative domain consists exactly of the matrices attaining
+equality in both one-sided Schwarz inequalities.
+
+Source: Wolf, Equations (5.13)--(5.14), local source
+`Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`, lines 399--410. -/
+theorem mem_multiplicativeDomain_iff
+    (E : Mat →ₗ[ℂ] Mat) (hE : IsSchwarzMap E) (A : Mat) :
+    A ∈ multiplicativeDomain E ↔
+      E (Aᴴ * A) = E Aᴴ * E A ∧
+        E (A * Aᴴ) = E A * E Aᴴ := by
+  rw [multiplicativeDomain, Set.mem_inter_iff,
+    mem_rightMultiplicativeDomain_iff E hE A,
+    mem_leftMultiplicativeDomain_iff E hE A]
+
+end SchwarzMap

--- a/TNLean/Channel/Schwarz/MultiplicativeDomainFull.lean
+++ b/TNLean/Channel/Schwarz/MultiplicativeDomainFull.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Channel.Schwarz.MultiplicativeDomainPowers
+import TNLean.Channel.Schwarz.AbstractMultiplicativeDomain
 import Mathlib.Algebra.Star.Subalgebra
 
 /-!
@@ -370,5 +371,55 @@ theorem krausMap_star_of_mem_multiplicativeDomain (K : Fin d → Mat) {X : Mat}
   krausMap_conjTranspose K X
 
 end StarHomomorphism
+
+section AbstractSpecialization
+
+/-- A unital Kraus map satisfies Wolf's abstract Schwarz inequality.
+
+The result records that the Kraus theory in this file is a specialization of
+the source-faithful abstract theory in `AbstractMultiplicativeDomain`.
+
+Source: Wolf, Equation (5.2), local source
+`Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`, lines 156--164. -/
+theorem krausMap_isSchwarzMap
+    (K : Fin d → Mat) (h_unital : IsUnitalKraus K) :
+    IsSchwarzMap (Kraus.mapLM K) := by
+  intro X
+  change (Kraus.map K (Xᴴ * X) - Kraus.map K Xᴴ * Kraus.map K X).PosSemidef
+  rw [← Kraus.map_conjTranspose K X]
+  have h := kadison_schwarz K h_unital X
+  simpa [Kraus.map, krausMap] using h
+
+/-- Wolf's abstract right multiplicative domain is the existing Kraus left
+multiplicative domain.  The names differ because the two formulations record
+opposite multiplication conventions. -/
+theorem mem_abstractRightMultiplicativeDomain_iff
+    (K : Fin d → Mat) (X : Mat) :
+    X ∈ SchwarzMap.rightMultiplicativeDomain (Kraus.mapLM K) ↔
+      X ∈ leftMultiplicativeDomain K := by
+  simp [SchwarzMap.rightMultiplicativeDomain, leftMultiplicativeDomain,
+    Kraus.mapLM_apply, Kraus.map, krausMap]
+
+/-- Wolf's abstract left multiplicative domain is the existing Kraus right
+multiplicative domain.  The names differ because the two formulations record
+opposite multiplication conventions. -/
+theorem mem_abstractLeftMultiplicativeDomain_iff
+    (K : Fin d → Mat) (X : Mat) :
+    X ∈ SchwarzMap.leftMultiplicativeDomain (Kraus.mapLM K) ↔
+      X ∈ rightMultiplicativeDomain K := by
+  simp [SchwarzMap.leftMultiplicativeDomain, rightMultiplicativeDomain,
+    Kraus.mapLM_apply, Kraus.map, krausMap]
+
+/-- The abstract and Kraus full multiplicative domains agree. -/
+theorem mem_abstractMultiplicativeDomain_iff
+    (K : Fin d → Mat) (X : Mat) :
+    X ∈ SchwarzMap.multiplicativeDomain (Kraus.mapLM K) ↔
+      X ∈ multiplicativeDomain K := by
+  rw [SchwarzMap.multiplicativeDomain, multiplicativeDomain,
+    Set.mem_inter_iff, mem_abstractRightMultiplicativeDomain_iff,
+    mem_abstractLeftMultiplicativeDomain_iff]
+  exact and_comm
+
+end AbstractSpecialization
 
 end KadisonSchwarz

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -1939,10 +1939,124 @@ adjacent cones.
     \end{align*}
 \end{proof}
 
-\subsection{Full multiplicative-domain structure}
+\subsection{Abstract Schwarz maps and their multiplicative domains}
+
+\begin{definition}[Schwarz inequality for a linear map]
+    \label{def:abstract_schwarz_inequality}
+    \lean{IsSchwarzMap}
+    \leanok
+    A complex-linear map $E:\MN{D}\to\MN{D}$ satisfies the Schwarz
+    inequality if
+    \[
+        E(A^\dagger A)-E(A^\dagger)E(A)\succeq 0
+    \]
+    for every $A\in\MN{D}$.  This is
+    \cite[Equation~(5.2)]{Wolf2012Quantum}.
+\end{definition}
+
+\begin{definition}[Abstract one-sided multiplicative domains]
+    \label{def:abstract_one_sided_multiplicative_domains}
+    \lean{SchwarzMap.rightMultiplicativeDomain,
+        SchwarzMap.leftMultiplicativeDomain,
+        SchwarzMap.multiplicativeDomain}
+    \leanok
+    For a complex-linear map $E:\MN{D}\to\MN{D}$, set
+    \[
+        \mc{A}_R(E)
+          = \{A : E(XA)=E(X)E(A)\text{ for every }X\},
+        \qquad
+        \mc{A}_L(E)
+          = \{A : E(AX)=E(A)E(X)\text{ for every }X\},
+    \]
+    and $\mc{A}(E)=\mc{A}_R(E)\cap\mc{A}_L(E)$.
+    These are \cite[Equations~(5.11)--(5.12)]{Wolf2012Quantum}, with the
+    source's convention that the subscript records the side on which $A$
+    multiplies the varying matrix.
+\end{definition}
+
+\begin{theorem}[Abstract multiplicative-domain characterization]
+    \label{thm:abstract_md_characterization}
+    \lean{SchwarzMap.mem_rightMultiplicativeDomain_iff,
+        SchwarzMap.mem_leftMultiplicativeDomain_iff,
+        SchwarzMap.mem_multiplicativeDomain_iff}
+    \leanok
+    \uses{def:abstract_schwarz_inequality,
+        def:abstract_one_sided_multiplicative_domains}
+    If $E$ satisfies the Schwarz inequality, then
+    \[
+        A\in\mc{A}_R(E)
+          \quad\Longleftrightarrow\quad
+        E(A^\dagger A)=E(A^\dagger)E(A),
+    \]
+    and
+    \[
+        A\in\mc{A}_L(E)
+          \quad\Longleftrightarrow\quad
+        E(AA^\dagger)=E(A)E(A^\dagger).
+    \]
+    Consequently, $A\in\mc{A}(E)$ exactly when both equalities hold.
+    This is \cite[Equations~(5.13)--(5.14)]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:abstract_schwarz_inequality}
+    Suppose first that equality holds at $A^\dagger A$.  Apply the Schwarz
+    inequality to $A+tY$, first for real $t$ and then for purely imaginary
+    $t$.  Set
+    \[
+        L=E(A^\dagger Y)-E(A^\dagger)E(Y),\qquad
+        R=E(Y^\dagger A)-E(Y^\dagger)E(A),\qquad
+        Q=E(Y^\dagger Y)-E(Y^\dagger)E(Y)\succeq0.
+    \]
+    For every real $t$, expansion and the equality at $A^\dagger A$ give
+    \[
+        t(L+R)+t^2Q\succeq0,
+        \qquad
+        t\,i(L-R)+t^2Q\succeq0.
+    \]
+    Nonnegativity for both signs of every real parameter forces
+    \[
+        L+R=0,\qquad L-R=0.
+    \]
+    Hence $L=R=0$, which is precisely
+    \[
+        E(A^\dagger Y)=E(A^\dagger)E(Y),
+        \qquad
+        E(Y^\dagger A)=E(Y^\dagger)E(A).
+    \]
+    Replacing $Y$ by $X^\dagger$ yields $E(XA)=E(X)E(A)$.
+    The second characterization follows by applying the same argument to
+    $A^\dagger$.  The converse implications follow by evaluating the defining
+    product identities at $A^\dagger$.
+\end{proof}
+
+\begin{theorem}[Kraus maps satisfy the abstract Schwarz inequality]
+    \label{thm:kraus_abstract_schwarz}
+    \lean{KadisonSchwarz.krausMap_isSchwarzMap}
+    \leanok
+    \uses{def:kraus_map, def:unital_kraus,
+        def:abstract_schwarz_inequality}
+    Every unital Kraus map satisfies the abstract Schwarz inequality of
+    Definition~\ref{def:abstract_schwarz_inequality}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:kadison_schwarz}
+    A Kraus map preserves adjoints.  The Kadison--Schwarz inequality therefore
+    gives, for every $A\in\MN{D}$,
+    \[
+        E(A^\dagger A)-E(A^\dagger)E(A)
+        =E(A^\dagger A)-E(A)^\dagger E(A)\succeq0.
+    \]
+\end{proof}
+
+\subsection{Kraus specialization and full algebraic structure}
 
 \begin{definition}[Right and left multiplicative domains]\label{def:one_sided_multiplicative_domains}
-    \lean{KadisonSchwarz.rightMultiplicativeDomain, KadisonSchwarz.leftMultiplicativeDomain}
+    \lean{KadisonSchwarz.rightMultiplicativeDomain,
+        KadisonSchwarz.leftMultiplicativeDomain}
     \leanok
     \uses{def:kraus_map}
     For a Kraus map $E$, define
@@ -1955,8 +2069,10 @@ adjacent cones.
     \]
     We follow the convention that $\mc{A}_R(E)$ controls right multiplication
     and $\mc{A}_L(E)$ controls left multiplication.
-    These are the two one-sided multiplicative domains from
-    \cite[Equations~(5.11)--(5.12)]{Wolf2012Quantum}.
+    These are Kraus-map specializations of the preceding abstract domains,
+    with the names interchanged: here the subscript records the side on which
+    the varying factor is appended, whereas the preceding convention records
+    the side occupied by the fixed element.
 \end{definition}
 
 \begin{definition}[Full multiplicative domain]\label{def:full_multiplicative_domain}
@@ -1968,6 +2084,26 @@ adjacent cones.
         \mc{A}(E) := \mc{A}_R(E) \cap \mc{A}_L(E).
     \]
 \end{definition}
+
+\begin{remark}[Comparison of the two naming conventions]
+    \label{rem:abstract_kraus_multiplicative_domain_names}
+    \lean{KadisonSchwarz.mem_abstractRightMultiplicativeDomain_iff,
+        KadisonSchwarz.mem_abstractLeftMultiplicativeDomain_iff,
+        KadisonSchwarz.mem_abstractMultiplicativeDomain_iff}
+    \leanok
+    \uses{def:abstract_one_sided_multiplicative_domains,
+        def:one_sided_multiplicative_domains,
+        def:full_multiplicative_domain}
+    Write $\mc{A}_R^{\mathrm W},\mc{A}_L^{\mathrm W}$ for Wolf's
+    convention and $\mc{A}_R^{\mathrm K},\mc{A}_L^{\mathrm K}$ for the
+    Kraus convention of this subsection.  For the linear map associated with
+    a Kraus family,
+    \[
+        \mc{A}_R^{\mathrm W}=\mc{A}_L^{\mathrm K},\qquad
+        \mc{A}_L^{\mathrm W}=\mc{A}_R^{\mathrm K},\qquad
+        \mc{A}^{\mathrm W}=\mc{A}^{\mathrm K}.
+    \]
+\end{remark}
 
 \begin{theorem}[Multiplicative-domain characterization]\label{thm:md_characterization}
     \lean{KadisonSchwarz.mem_rightMultiplicativeDomain_iff, KadisonSchwarz.mem_leftMultiplicativeDomain_iff}
@@ -1981,8 +2117,8 @@ adjacent cones.
     \[
         X \in \mc{A}_L(E) \iff E(X^\dagger X) = E(X)^\dagger E(X).
     \]
-    Together these are the two one-sided characterizations from
-    \cite[Theorem~5.7]{Wolf2012Quantum}.
+    Together these are the Kraus-map specialization of
+    Theorem~\ref{thm:abstract_md_characterization}.
 \end{theorem}
 
 \begin{proof}

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -166,6 +166,15 @@ For Wolf Chapter 3 positive maps:
   Wolf Example 3.1.  The general cyclic reciprocal estimate, and hence
   positivity of \(T_C\) for the full range \(1\le n\le d-2\), remain open.
 
+For Wolf Chapter 5 Schwarz maps:
+
+- `wolf_ch5_abstract_multiplicative_domains.tex` distinguishes the
+  source-faithful multiplicative-domain theorem for an arbitrary linear map
+  satisfying the Schwarz inequality from the older unital-Kraus
+  specialization. The abstract one-variable theorem is now proved; the
+  two-variable inverse-on-range inequality and its equality criterion remain
+  open.
+
 For the periodic (irreducible-form) MPS Fundamental Theorem of
 arXiv:1708.00029, the overlap-dichotomy development has one route-alignment
 note.

--- a/docs/paper-gaps/wolf_ch5_abstract_multiplicative_domains.tex
+++ b/docs/paper-gaps/wolf_ch5_abstract_multiplicative_domains.tex
@@ -1,0 +1,91 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+
+\input{command}
+
+\title{Wolf Chapter~5: Abstract Multiplicative-Domain Hypotheses}
+\author{}
+\date{2026-07-18}
+
+\begin{document}
+\maketitle
+
+\section{Source statement}
+
+Let $E:M_D(\mathbb C)\to M_D(\mathbb C)$ be a complex-linear map satisfying
+the Schwarz inequality
+\begin{align}
+  E(A^*A)-E(A^*)E(A)\succeq 0
+  \qquad (A\in M_D(\mathbb C)).
+  \tag{Wolf, Equation (5.2)}
+\end{align}
+Wolf defines
+\begin{align}
+  \mathcal A_R
+    &=\{A:E(XA)=E(X)E(A)\text{ for every }X\},\\
+  \mathcal A_L
+    &=\{A:E(AX)=E(A)E(X)\text{ for every }X\},
+\end{align}
+and proves
+\begin{align}
+  A\in\mathcal A_R
+    &\iff E(A^*A)=E(A^*)E(A),\\
+  A\in\mathcal A_L
+    &\iff E(AA^*)=E(A)E(A^*).
+  \tag{Wolf, Equations (5.13)--(5.14)}
+\end{align}
+The local source for Equation~(5.2) is
+\path{Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex},
+lines~156--164; the local source for Equations~(5.11)--(5.14) is
+lines~383--410 of the same file.  No Kraus representation, complete
+positivity, or $2$-positivity occurs in this statement.
+
+\section{Earlier specialization}
+
+The existing one-sided characterizations use a unital Kraus family.
+\footnote{See
+\leanid{KadisonSchwarz.mem_rightMultiplicativeDomain_iff} and
+\leanid{KadisonSchwarz.mem_leftMultiplicativeDomain_iff} in
+\doclink{TNLean/Channel/Schwarz/MultiplicativeDomainFull}.}
+They are mathematically correct specializations, but the
+Kraus representation and unitality are absent from Wolf's abstract
+multiplicative-domain theorem.  Their names also use the convention that the
+subscript records the side on which the varying factor is appended; this
+interchanges the labels ``left'' and ``right'' relative to Wolf's convention,
+where the subscript records the side occupied by the fixed element.
+
+The source-faithful formulation now uses only complex linearity and the
+displayed Schwarz inequality.
+\footnote{Formal declarations:
+\leanid{IsSchwarzMap},
+\leanid{SchwarzMap.rightMultiplicativeDomain},
+\leanid{SchwarzMap.leftMultiplicativeDomain},
+\leanid{SchwarzMap.mem_rightMultiplicativeDomain_iff}, and
+\leanid{SchwarzMap.mem_leftMultiplicativeDomain_iff} in
+\doclink{TNLean/Channel/Schwarz/AbstractMultiplicativeDomain}.}
+The Kraus declarations remain available as specialized results and are no
+longer used as the blueprint witness for the unrestricted source theorem.
+
+\section{Remaining Chapter 5 boundary}
+
+Wolf's preceding two-variable operator Schwarz inequality and its equality
+criterion, involving the inverse of $E(B^*B)$ on its range, remain separate
+work.  The one-variable multiplicative-domain theorem above does not assume
+those results: its polarization proof applies the one-variable Schwarz
+inequality directly to $A+tY$.
+
+\section{Verdict}
+
+The interchange of the one-sided domain names is a notational clarification:
+the two conventions define the same pair of sets with opposite labels, and
+their full intersections agree.  The source-faithful one-variable theorem is
+complete.  The two-variable inverse-on-range inequality and its equality
+criterion remain an open gap.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
## Summary

This pull request proves the abstract multiplicative-domain characterization
from Wolf, Chapter 5, Equations (5.13)--(5.14), for an arbitrary complex-linear
matrix map satisfying the Schwarz inequality.

It adds:

- `IsSchwarzMap`, stated exactly as
  $E(A^\dagger A)-E(A^\dagger)E(A)\succeq0$;
- Wolf's right, left, and full multiplicative domains, using the source's
  naming convention;
- the two one-sided membership characterizations and the combined full-domain
  characterization;
- comparison theorems showing that the existing unital-Kraus domains are the
  corresponding specializations, with the one-sided names interchanged;
- a blueprint statement and a paper-gap note separating the unrestricted
  source theorem from the older Kraus specialization.

## Proof

For a matrix $A$ attaining equality in the Schwarz inequality, the proof
applies the inequality to $A+tY$ for real and purely imaginary $t$.
Positivity for both signs forces the matrix-valued linear coefficient to
vanish. The two polarizations give

\[
E(A^\dagger Y)=E(A^\dagger)E(Y),\qquad
E(Y^\dagger A)=E(Y^\dagger)E(A).
\]

Replacing $Y$ by $X^\dagger$ gives the right multiplicative identity;
applying the same argument to $A^\dagger$ gives the left identity. The
converse directions follow by evaluation at $A^\dagger$.

## Source and scope

Source: Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 5,
Equation (5.2), local lines 156--164, and Equations (5.11)--(5.14), local
lines 383--410, in
`Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`.

This is a bounded increment of LionSR/QICLean#206 and supplies the abstract Chapter 5 input
needed by LionSR/QICLean#219. The two-variable inverse-on-range Schwarz inequality and its
equality criterion remain open. This pull request does not close LionSR/QICLean#206, LionSR/QICLean#219,
LionSR/QICLean#39, LionSR/TNLean#4120, LionSR/TNLean#3949, or LionSR/TNLean#232.

## Verification

- `lake build TNLean.Channel.Schwarz.AbstractMultiplicativeDomain TNLean.Channel.Schwarz.MultiplicativeDomainFull`
- `#print axioms` for all three public membership characterizations: only
  `propext`, `Classical.choice`, and `Quot.sound`
- searches for `sorry`, `axiom`, `native_decide`, `unsafeCast`, and `admit`: no
  occurrences in the changed Lean files
- `git diff --check`

The full root build and blueprint declaration check are left to pull-request
CI because the shared local build cache does not yet contain an unrelated
new-main module, `TNLean.MPS.CanonicalForm.BNTUniqueness`.
