### PR TITLE
feat(MPS/MPDO): isolate fixed-space dimension argument

### DIFF
--- a/TNLean/MPS/MPDO/VerticalSectorGeneration.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorGeneration.lean
@@ -18,7 +18,7 @@ from simultaneous word-tuple span of the vertical BNT representatives.
 ## References
 
 * Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
-  Appendix C.4, lines 1980--1990.
+  Appendix C.4, lines 1980--1993.
 -/
 
 open scoped Matrix BigOperators ComplexOrder

--- a/TNLean/MPS/MPDO/VerticalSectorGeneration.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorGeneration.lean
@@ -111,7 +111,7 @@ general MPDO renormalization fixed-point theorem.
 
 Source: arXiv:1606.00608, Appendix C.4, lines 1980--1993. -/
 def fixedPointProductSpan
-    {g L : ℕ} {dim : Fin g → ℕ}
+    {g : ℕ} {dim : Fin g → ℕ} (L : ℕ)
     (F : VerticalSectorAlgebra dim →ₗ[ℂ] VerticalSectorAlgebra dim) :
     Submodule ℂ (VerticalSectorAlgebra dim) :=
   Submodule.span ℂ (Set.range fun X : Fin L → F.fixedSubmodule =>
@@ -246,7 +246,7 @@ products force \(C_L(\mathcal F)\) to be the whole sector algebra.
 The dimension bound then forces the fixed-point space itself to be the whole
 sector algebra.
 
-**Interface to the open fixed-point theorem:** The source obtains the
+**Scope restriction (fixed-point dimension):** The source obtains the
 dimension bound from Wolf's density-weighted description of the fixed-point
 space.  Its derivation from positivity and trace preservation remains recorded
 in `docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex`; the bound is
@@ -262,16 +262,16 @@ theorem eq_id_of_weightedVerticalBondContractions_fixed_of_productSpan_finrank_l
     (hFixed : ∀ X : Matrix (Fin D) (Fin D) ℂ,
       F (weightedVerticalBondContraction m A X) =
         weightedVerticalBondContraction m A X)
-    (hFinrank : Module.finrank ℂ (fixedPointProductSpan (L := L) F) ≤
+    (hFinrank : Module.finrank ℂ (fixedPointProductSpan L F) ≤
       Module.finrank ℂ F.fixedSubmodule) :
     F = LinearMap.id := by
   have hProductMem (X : Fin L → Matrix (Fin D) (Fin D) ℂ) :
       weightedVerticalBondContractionProduct m A X ∈
-        fixedPointProductSpan (L := L) F := by
+        fixedPointProductSpan L F := by
     apply Submodule.subset_span
     refine ⟨fun t => ⟨weightedVerticalBondContraction m A (X t), ?_⟩, rfl⟩
     exact LinearMap.mem_fixedSubmodule_iff.mpr (hFixed (X t))
-  have hProductSpanTop : fixedPointProductSpan (L := L) F = ⊤ := by
+  have hProductSpanTop : fixedPointProductSpan L F = ⊤ := by
     apply top_unique
     rw [← hSpan]
     apply Submodule.span_le.mpr

--- a/TNLean/MPS/MPDO/VerticalSectorGeneration.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorGeneration.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.SourceBNTBlocking
 import TNLean.MPS.MPDO.VerticalSectorCoordinates
+import Mathlib.LinearAlgebra.FixedSubmodule
 
 /-!
 # Generation of vertical BNT sector algebras
@@ -101,6 +102,20 @@ def WeightedVerticalBondContractionProductSpanTop
     (L : ℕ) : Prop :=
   Submodule.span ℂ
     (Set.range (weightedVerticalBondContractionProduct (L := L) m A)) = ⊤
+
+/-- The span of all \(L\)-fold products of fixed points of a linear
+endomorphism of the vertical-sector algebra.
+
+This is the space denoted by \(C_L(\mathcal F)\) in the dimension argument of the
+general MPDO renormalization fixed-point theorem.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1980--1993. -/
+def fixedPointProductSpan
+    {g L : ℕ} {dim : Fin g → ℕ}
+    (F : VerticalSectorAlgebra dim →ₗ[ℂ] VerticalSectorAlgebra dim) :
+    Submodule ℂ (VerticalSectorAlgebra dim) :=
+  Submodule.span ℂ (Set.range fun X : Fin L → F.fixedSubmodule =>
+    fun α => (List.ofFn fun t => (X t : VerticalSectorAlgebra dim) α).prod)
 
 /-- Sectorwise multiplication by nonzero scalars is a linear equivalence of
 the direct product of the BNT matrix algebras. -/
@@ -218,6 +233,59 @@ theorem eq_id_of_weightedVerticalBondContractionProducts_fixed
   apply LinearMap.ext_on_range hSpan
   intro X
   simpa using hFixed X
+
+/-- Fixed weighted contractions determine an endomorphism once the products
+of arbitrary fixed points have no larger dimension than the fixed-point
+space.
+
+This is the finite-dimensional step in the inverse-map argument of Appendix
+C.4.  Unlike `eq_id_of_weightedVerticalBondContractionProducts_fixed`, it
+does not assume that products of the distinguished contractions are fixed.
+The contractions themselves lie in the fixed-point space, so their spanning
+products force \(C_L(\mathcal F)\) to be the whole sector algebra.
+The dimension bound then forces the fixed-point space itself to be the whole
+sector algebra.
+
+**Interface to the open fixed-point theorem:** The source obtains the
+dimension bound from Wolf's density-weighted description of the fixed-point
+space.  Its derivation from positivity and trace preservation remains recorded
+in `docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex`; the bound is
+therefore an explicit hypothesis here.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1980--1993. -/
+theorem eq_id_of_weightedVerticalBondContractions_fixed_of_productSpan_finrank_le
+    {g D L : ℕ} {dim : Fin g → ℕ}
+    (m : Fin g → ℂ)
+    (A : (α : Fin g) → MPSTensor (D * D) (dim α))
+    (F : VerticalSectorAlgebra dim →ₗ[ℂ] VerticalSectorAlgebra dim)
+    (hSpan : WeightedVerticalBondContractionProductSpanTop m A L)
+    (hFixed : ∀ X : Matrix (Fin D) (Fin D) ℂ,
+      F (weightedVerticalBondContraction m A X) =
+        weightedVerticalBondContraction m A X)
+    (hFinrank : Module.finrank ℂ (fixedPointProductSpan (L := L) F) ≤
+      Module.finrank ℂ F.fixedSubmodule) :
+    F = LinearMap.id := by
+  have hProductMem (X : Fin L → Matrix (Fin D) (Fin D) ℂ) :
+      weightedVerticalBondContractionProduct m A X ∈
+        fixedPointProductSpan (L := L) F := by
+    apply Submodule.subset_span
+    refine ⟨fun t => ⟨weightedVerticalBondContraction m A (X t), ?_⟩, rfl⟩
+    exact LinearMap.mem_fixedSubmodule_iff.mpr (hFixed (X t))
+  have hProductSpanTop : fixedPointProductSpan (L := L) F = ⊤ := by
+    apply top_unique
+    rw [← hSpan]
+    apply Submodule.span_le.mpr
+    rintro _ ⟨X, rfl⟩
+    exact hProductMem X
+  have hAmbientFinrankLe :
+      Module.finrank ℂ (VerticalSectorAlgebra dim) ≤
+        Module.finrank ℂ F.fixedSubmodule := by
+    rw [hProductSpanTop] at hFinrank
+    simpa using hFinrank
+  have hFixedTop : F.fixedSubmodule = ⊤ :=
+    Submodule.eq_top_of_finrank_eq
+      ((Submodule.finrank_le F.fixedSubmodule).antisymm hAmbientFinrankLe)
+  exact LinearMap.fixedSubmodule_eq_top_iff.mp hFixedTop
 
 /-- A CPSV basis of normal tensors, with nonzero sector weights, admits one
 positive length at which the weighted vertical bond contractions generate the

--- a/TNLean/MPS/MPDO/VerticalSectorGeneration.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorGeneration.lean
@@ -103,10 +103,10 @@ def WeightedVerticalBondContractionProductSpanTop
   Submodule.span ℂ
     (Set.range (weightedVerticalBondContractionProduct (L := L) m A)) = ⊤
 
-/-- The span of all \(L\)-fold products of fixed points of a linear
+/-- The span of all $L$-fold products of fixed points of a linear
 endomorphism of the vertical-sector algebra.
 
-This is the space denoted by \(C_L(\mathcal F)\) in the dimension argument of the
+This is the space denoted by $C_L(\mathcal F)$ in the dimension argument of the
 general MPDO renormalization fixed-point theorem.
 
 Source: arXiv:1606.00608, Appendix C.4, lines 1980--1993. -/
@@ -242,7 +242,7 @@ This is the finite-dimensional step in the inverse-map argument of Appendix
 C.4.  Unlike `eq_id_of_weightedVerticalBondContractionProducts_fixed`, it
 does not assume that products of the distinguished contractions are fixed.
 The contractions themselves lie in the fixed-point space, so their spanning
-products force \(C_L(\mathcal F)\) to be the whole sector algebra.
+products force $C_L(\mathcal F)$ to be the whole sector algebra.
 The dimension bound then forces the fixed-point space itself to be the whole
 sector algebra.
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -500,10 +500,9 @@ physical indices, as in
 
     This is the finite-dimensional conclusion in
     \cite[Appendix~C.4, lines~1980--1993]{Cirac2016MPDO_arXiv}.  It does not
-    assume that the products $V_c(X_1)\cdots V_c(X_L)$ are fixed.  The
-    displayed dimension inequality is the part supplied there by the
-    density-weighted description of the fixed-point space; its derivation for
-    the transported maps remains separate.
+    assume that the products $V_c(X_1)\cdots V_c(X_L)$ are fixed.
+    % The displayed dimension inequality is the remaining consequence of the
+    % density-weighted fixed-point theorem for the transported maps.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -463,6 +463,63 @@ physical indices, as in
     Thus $F$ is the identity.
 \end{proof}
 
+\begin{definition}[Products of fixed points]
+    \label{def:mpdo_vertical_fixed_point_products}
+    \lean{MPOTensor.fixedPointProductSpan}
+    \leanok
+    Let $F$ be a linear endomorphism of
+    $\mathcal A=\prod_\alpha M_{d_\alpha}$, and write
+    $\mathcal F=\{X\in\mathcal A:F(X)=X\}$.  For $L\geq0$, define
+    \[
+        C_L(\mathcal F)
+        =\spn_{\C}\{X_1\cdots X_L:X_1,\ldots,X_L\in\mathcal F\}.
+    \]
+    This is the product space used in the dimension argument of
+    \cite[Appendix~C.4, lines~1980--1993]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{theorem}[Fixed contractions and the dimension of their fixed-point space]
+    \label{thm:mpdo_fixed_contractions_product_dimension}
+    \lean{MPOTensor.%
+        eq_id_of_weightedVerticalBondContractions_fixed_of_productSpan_finrank_le}
+    \leanok
+    \uses{def:mpdo_weighted_vertical_contraction_products,
+        def:mpdo_vertical_fixed_point_products}
+    Let $F$ be a linear endomorphism of
+    $\mathcal A=\prod_\alpha M_{d_\alpha}$.  Suppose that
+    \[
+        C_L(V_c)=\mathcal A,
+        \qquad \forall X,\quad F(V_c(X))=V_c(X),
+    \]
+    and that
+    \[
+        \dim C_L(\mathcal F)\leq\dim\mathcal F,
+        \qquad \mathcal F=\{Y\in\mathcal A:F(Y)=Y\}.
+    \]
+    Then $F=\operatorname{id}_{\mathcal A}$.
+
+    This is the finite-dimensional conclusion in
+    \cite[Appendix~C.4, lines~1980--1993]{Cirac2016MPDO_arXiv}.  It does not
+    assume that the products $V_c(X_1)\cdots V_c(X_L)$ are fixed.  The
+    displayed dimension inequality is the part supplied there by the
+    density-weighted description of the fixed-point space; its derivation for
+    the transported maps remains separate.
+\end{theorem}
+
+\begin{proof}\leanok
+    Since every $V_c(X)$ belongs to $\mathcal F$, every product occurring in
+    $C_L(V_c)$ belongs to $C_L(\mathcal F)$.  Hence
+    \[
+        \mathcal A=C_L(V_c)\subseteq C_L(\mathcal F)\subseteq\mathcal A,
+    \]
+    so $C_L(\mathcal F)=\mathcal A$.  Therefore
+    \[
+        \dim\mathcal A=\dim C_L(\mathcal F)
+        \leq\dim\mathcal F\leq\dim\mathcal A.
+    \]
+    Thus $\mathcal F=\mathcal A$, and $F$ is the identity.
+\end{proof}
+
 \begin{definition}[Retained coordinates for the vertical-sector algebra]
     \label{def:mpdo_retained_vertical_sector_coordinates}
     \lean{MPOTensor.verticalSectorFinEquiv}

--- a/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
+++ b/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
@@ -90,7 +90,8 @@ nor the identity conclusion extends from the generators by linearity.
 Two finite-dimensional final implications are formalized.  First, if a linear
 endomorphism fixes every length-$L$ contraction product and these products
 span, then it is the identity.\footnote{Formal declaration:
-\leanid{MPOTensor.eq_id_of_weightedVerticalBondContractionProducts_fixed}.}
+\leanid{MPOTensor.eq_id_of_weightedVerticalBondContractionProducts_fixed}
+in \doclink{TNLean/MPS/MPDO/VerticalSectorGeneration}.}
 Its fixed-product hypothesis is not a hypothesis of CPSV16.
 
 Second, let $\mathcal F$ be the fixed-point space of the endomorphism and let
@@ -102,7 +103,8 @@ sector algebra, and
 \]
 then the endomorphism is the identity.\footnote{Formal declarations:
 \leanid{MPOTensor.fixedPointProductSpan} and
-\leanid{MPOTensor.eq_id_of_weightedVerticalBondContractions_fixed_of_productSpan_finrank_le}.}
+\leanid{MPOTensor.eq_id_of_weightedVerticalBondContractions_fixed_of_productSpan_finrank_le}
+in \doclink{TNLean/MPS/MPDO/VerticalSectorGeneration}.}
 This second implication does not assume that products of distinguished
 contractions are fixed.  It isolates the source's dimension argument.  The
 remaining fixed-point theorem must supply the displayed inequality from the

--- a/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
+++ b/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
@@ -87,13 +87,26 @@ only its length-$L$ products are known to span.  Since a linear map fixing
 $V(X)$ need not fix products $V(X_1)\cdots V(X_L)$, neither trace preservation
 nor the identity conclusion extends from the generators by linearity.
 
-The valid final implication is formalized: if a linear endomorphism fixes
-every length-$L$ contraction product and these products span, then it is the
-identity.\footnote{Formal declaration:
+Two finite-dimensional final implications are formalized.  First, if a linear
+endomorphism fixes every length-$L$ contraction product and these products
+span, then it is the identity.\footnote{Formal declaration:
 \leanid{MPOTensor.eq_id_of_weightedVerticalBondContractionProducts_fixed}.}
-Its fixed-product hypothesis is not a hypothesis of CPSV16.  The source
-instead obtains the identity from the density-weighted structure of the
-fixed-point space.
+Its fixed-product hypothesis is not a hypothesis of CPSV16.
+
+Second, let $\mathcal F$ be the fixed-point space of the endomorphism and let
+$C_L(\mathcal F)$ be the span of its length-$L$ products.  If the distinguished
+contractions themselves are fixed, their length-$L$ products span the ambient
+sector algebra, and
+\[
+    \dim C_L(\mathcal F)\leq\dim\mathcal F,
+\]
+then the endomorphism is the identity.\footnote{Formal declarations:
+\leanid{MPOTensor.fixedPointProductSpan} and
+\leanid{MPOTensor.eq_id_of_weightedVerticalBondContractions_fixed_of_productSpan_finrank_le}.}
+This second implication does not assume that products of distinguished
+contractions are fixed.  It isolates the source's dimension argument.  The
+remaining fixed-point theorem must supply the displayed inequality from the
+density-weighted form of $\mathcal F$.
 
 The positive trace-preserving mean-ergodic retraction on a full matrix algebra
 and its positive unital trace-adjoint retraction onto the adjoint fixed-point
@@ -150,10 +163,13 @@ order:
     \item prove complete positivity and trace preservation of the transported
           maps on the full sector algebras, including the required active-image
           statement for every input;
-    \item formalize the density-weighted fixed-point theorem needed for
-          $\widetilde S\widetilde T$ and $\widetilde T\widetilde S$;
-    \item combine the fixed-point form with the already proved product
-          generation theorem to obtain both identity compositions;
+    \item formalize the density-weighted fixed-point theorem needed to prove
+          $\dim C_L(\mathcal F)\leq\dim\mathcal F$ for the fixed-point spaces
+          of $\widetilde S\widetilde T$ and $\widetilde T\widetilde S$;
+    \item combine this dimension bound with the fixed contraction families,
+          the already proved product-generation theorem, and the
+          finite-dimensional implication above to obtain both identity
+          compositions;
     \item derive the permutation and matching dimensions from the resulting
           positive, trace-preserving inverse pair, retaining the Schwarz
           hypothesis for the unitary-conjugation conclusion.


### PR DESCRIPTION
## Mathematical change

Formalizes the finite-dimensional step in CPSV16 Appendix C.4, lines 1980–1993. For a vertical-sector endomorphism `F`, the new subspace `fixedPointProductSpan F` is the span of products of fixed points. The new theorem proves `F = id` from:

- fixedness of each weighted vertical contraction;
- spanning of the sector algebra by their length-`L` products; and
- the dimension inequality `dim C_L(Fix F) ≤ dim Fix F`.

This avoids the stronger hypothesis that every distinguished contraction product is itself fixed. The remaining dimension inequality is exactly the consequence that must later be derived from Wolf’s density-weighted fixed-point theorem, as documented in `docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex`.

The blueprint records the definition, theorem, and dimension proof. This is an intermediate result toward #3949 and #4120; it does not mark the unrestricted Theorem 4.14 direction complete and does not close either tracker.

## Verification

- `lake env lean TNLean/MPS/MPDO/VerticalSectorGeneration.lean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check`
- proof-integrity scan of the changed Lean file

`leanblueprint checkdecls` could not be completed in the shared local build directory because it intentionally lacks the root `TNLean.olean`; the pull-request build supplies that root-level check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds formal Lean proofs and documentation only; no runtime, auth, or data-path changes. The dimension inequality remains an explicit open hypothesis.
> 
> **Overview**
> Adds the **finite-dimensional identity step** from CPSV16 Appendix C.4 (lines 1980–1993) without assuming distinguished contraction *products* are fixed.
> 
> Lean introduces **`fixedPointProductSpan`** ($C_L(\mathcal F)$): the span of length-$L$ products of fixed points of a vertical-sector endomorphism. **`eq_id_of_weightedVerticalBondContractions_fixed_of_productSpan_finrank_le`** proves $F = \mathrm{id}$ when each weighted vertical contraction is fixed, their length-$L$ products span the sector algebra, and $\dim C_L(\mathrm{Fix}\,F) \le \dim \mathrm{Fix}\,F$—with the last inequality left as an explicit hypothesis pending Wolf's density-weighted fixed-point theorem.
> 
> The blueprint chapter records the definition, theorem, and proof sketch; **`cpsv16_vertical_sector_invertibility.tex`** documents this as the second formalized final implication and updates the elimination plan to combine the dimension bound with product generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 825e608d04cf6261924b49344705a0474aeff859. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->