### PR TITLE
feat(Channel/FixedPoint): prove the abstract fixed-point algebra lemma

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -194,6 +194,7 @@ import TNLean.Channel.Schwarz.MultiplicativeDomain
 import TNLean.Channel.Schwarz.AbstractMultiplicativeDomain
 import TNLean.Channel.Schwarz.MultiplicativeDomainPowers
 import TNLean.Channel.Schwarz.MultiplicativeDomainFull
+import TNLean.Channel.FixedPoint.AbstractAlgebra
 import TNLean.Channel.FixedPoint.Algebra
 import TNLean.Channel.FixedPoint.BlockForm
 import TNLean.Channel.FixedPoint.ChoiEffros

--- a/TNLean/Algebra/MatrixAux.lean
+++ b/TNLean/Algebra/MatrixAux.lean
@@ -34,6 +34,8 @@ Extracted from various files for reusability.
   semidefinite matrices is nonnegative
 - `Matrix.PosSemidef.of_forall_trace_mul_nonneg`: self-duality of the positive
   semidefinite cone for the trace pairing
+- `Matrix.posSemidef_eq_zero_of_posDef_trace_mul_eq_zero`: faithfulness of a
+  positive-definite weighted trace on the positive semidefinite cone
 - `Matrix.eq_zero_of_sum_mul_conjTranspose_eq_zero`: a positive sum of squares
   vanishes only if every summand vanishes
 - `Matrix.eq_zero_of_sum_conjTranspose_mul_self_eq_zero`: the conjugate-transpose
@@ -564,6 +566,36 @@ theorem of_forall_trace_mul_nonneg {A : Matrix n n ℂ}
   simpa [Matrix.mul_vecMulVec, Matrix.trace_vecMulVec, dotProduct_comm] using htrace
 
 end PosSemidef
+
+/-- If `M` is positive semidefinite, `ρ` is positive definite, and
+`tr(ρ * M) = 0`, then `M = 0`.
+
+This is faithfulness of the positive-definite weighted trace. -/
+theorem posSemidef_eq_zero_of_posDef_trace_mul_eq_zero
+    {ρ M : Matrix n n ℂ} (hM : M.PosSemidef) (hρ : ρ.PosDef)
+    (htr : trace (ρ * M) = 0) : M = 0 := by
+  classical
+  rcases CStarAlgebra.isStrictlyPositive_iff_eq_star_mul_self.mp
+      (Matrix.isStrictlyPositive_iff_posDef.mpr hρ) with ⟨S, hS_unit, hρ_eq⟩
+  have hSMS_psd : (S * M * Sᴴ).PosSemidef :=
+    hM.mul_mul_conjTranspose_same (B := S)
+  have htr' : trace (S * M * Sᴴ) = 0 := by
+    have hcycle : trace (S * M * Sᴴ) = trace (Sᴴ * S * M) :=
+      trace_mul_cycle S M Sᴴ
+    have htr'' : trace (Sᴴ * S * M) = 0 := by
+      simpa [hρ_eq, mul_assoc, ← star_eq_conjTranspose] using htr
+    exact hcycle.trans htr''
+  have hSMS_zero : S * M * Sᴴ = 0 :=
+    hSMS_psd.trace_eq_zero_iff.mp htr'
+  have hMS_zero : M * Sᴴ = 0 := by
+    have : S * (M * Sᴴ) = S * 0 := by
+      simpa [mul_assoc] using hSMS_zero
+    exact IsUnit.mul_left_cancel hS_unit this
+  have hSstar_unit : IsUnit (Sᴴ) := by
+    simpa [star_eq_conjTranspose] using hS_unit.star
+  have : M * Sᴴ = 0 * Sᴴ := by
+    simpa [zero_mul] using hMS_zero
+  exact IsUnit.mul_right_cancel hSstar_unit this
 
 end PosSemidefTrace
 

--- a/TNLean/Channel/FixedPoint/AbstractAlgebra.lean
+++ b/TNLean/Channel/FixedPoint/AbstractAlgebra.lean
@@ -1,0 +1,176 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.Schwarz.AbstractMultiplicativeDomain
+import TNLean.Algebra.MatrixAux
+import TNLean.Algebra.TracePairing
+
+/-!
+# Fixed points of abstract unital Schwarz maps
+
+This file proves the algebraic step in Wolf's structure theorem after a
+positive-definite invariant weight has been chosen.  The map is not assumed to
+admit a Kraus representation.
+
+## Main results
+
+* `SchwarzMap.schwarz_equality_of_mem_fixedPoints`: a fixed point attains equality in
+  the Schwarz inequality when the trace adjoint has a positive-definite fixed point.
+* `SchwarzMap.mem_multiplicativeDomain_of_mem_fixedPoints`: every fixed point belongs
+  to the abstract multiplicative domain.
+* `SchwarzMap.fixedPointsStarSubalgebra`: the fixed points form a star-subalgebra.
+
+## References
+
+* M. Wolf, *Quantum Channels & Operations: Guided Tour*, Theorem 6.12 and
+  Equation (6.60); local source
+  `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1395--1417.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder
+open Matrix
+
+namespace SchwarzMap
+
+variable {n : Type*}
+
+local notation "Mat" => Matrix n n ℂ
+
+/-- The fixed-point set of a complex-linear matrix map. -/
+def fixedPoints (E : Mat →ₗ[ℂ] Mat) : Set Mat :=
+  {X | E X = X}
+
+@[simp] theorem mem_fixedPoints (E : Mat →ₗ[ℂ] Mat) (X : Mat) :
+    X ∈ fixedPoints E ↔ E X = X :=
+  Iff.rfl
+
+section
+
+variable [Finite n]
+
+/-- Fixed points of a positive map are closed under conjugate transpose. -/
+theorem conjTranspose_mem_fixedPoints
+    (E : Mat →ₗ[ℂ] Mat) (hEpos : IsPositiveMap E)
+    {X : Mat} (hX : X ∈ fixedPoints E) :
+    Xᴴ ∈ fixedPoints E := by
+  change E Xᴴ = Xᴴ
+  rw [hEpos.map_conjTranspose, hX]
+
+end
+
+
+variable [Fintype n]
+
+/-- A fixed point attains equality in the Schwarz inequality when the trace adjoint
+has a positive-definite fixed point.
+
+This is the weighted-trace step in Wolf, Equation (6.60), local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1404--1413. -/
+theorem schwarz_equality_of_mem_fixedPoints
+    (E : Mat →ₗ[ℂ] Mat) (hEpos : IsPositiveMap E) (hE : IsSchwarzMap E)
+    {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : Matrix.traceAdjointMap E ρ = ρ)
+    {X : Mat} (hX : X ∈ fixedPoints E) :
+    E (Xᴴ * X) = E Xᴴ * E X := by
+  have hgap : (E (Xᴴ * X) - E Xᴴ * E X).PosSemidef := hE X
+  have hXstar : E Xᴴ = Xᴴ := by
+    rw [hEpos.map_conjTranspose, hX]
+  have htrace_first :
+      Matrix.trace (ρ * E (Xᴴ * X)) = Matrix.trace (ρ * (Xᴴ * X)) := by
+    calc
+      Matrix.trace (ρ * E (Xᴴ * X)) =
+          Matrix.trace (Matrix.traceAdjointMap E ρ * (Xᴴ * X)) :=
+        (Matrix.trace_traceAdjointMap_mul E ρ (Xᴴ * X)).symm
+      _ = Matrix.trace (ρ * (Xᴴ * X)) := by rw [hρ_fix]
+  have htrace_gap :
+      Matrix.trace (ρ * (E (Xᴴ * X) - E Xᴴ * E X)) = 0 := by
+    rw [Matrix.mul_sub, Matrix.trace_sub, htrace_first, hXstar, hX]
+    simp
+  exact sub_eq_zero.mp
+    (Matrix.posSemidef_eq_zero_of_posDef_trace_mul_eq_zero hgap hρ htrace_gap)
+
+/-- Every fixed point belongs to the full abstract multiplicative domain.
+
+The second one-sided equality is obtained by applying the weighted-trace argument to
+the adjoint fixed point.  This is the multiplicative-domain step in Wolf Theorem 6.12,
+local source `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1404--1415. -/
+theorem mem_multiplicativeDomain_of_mem_fixedPoints
+    (E : Mat →ₗ[ℂ] Mat) (hEpos : IsPositiveMap E) (hE : IsSchwarzMap E)
+    {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : Matrix.traceAdjointMap E ρ = ρ)
+    {X : Mat} (hX : X ∈ fixedPoints E) :
+    X ∈ multiplicativeDomain E := by
+  rw [mem_multiplicativeDomain_iff E hE X]
+  refine ⟨schwarz_equality_of_mem_fixedPoints E hEpos hE hρ hρ_fix hX, ?_⟩
+  have hXstar : Xᴴ ∈ fixedPoints E :=
+    conjTranspose_mem_fixedPoints E hEpos hX
+  simpa using
+    (schwarz_equality_of_mem_fixedPoints E hEpos hE hρ hρ_fix hXstar)
+
+/-- Fixed points are closed under multiplication under the hypotheses of Wolf
+Theorem 6.12. -/
+theorem mul_mem_fixedPoints
+    (E : Mat →ₗ[ℂ] Mat) (hEpos : IsPositiveMap E) (hE : IsSchwarzMap E)
+    {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : Matrix.traceAdjointMap E ρ = ρ)
+    {X Y : Mat} (hX : X ∈ fixedPoints E) (hY : Y ∈ fixedPoints E) :
+    X * Y ∈ fixedPoints E := by
+  have hXmd : X ∈ multiplicativeDomain E :=
+    mem_multiplicativeDomain_of_mem_fixedPoints E hEpos hE hρ hρ_fix hX
+  change E (X * Y) = X * Y
+  rw [hXmd.2 Y, hX, hY]
+
+variable [DecidableEq n]
+
+/-- **Full-support fixed-point algebra after choosing a faithful invariant weight.**
+
+Let `E` be a positive unital complex-linear map satisfying the Schwarz inequality.
+If the trace-pairing adjoint of `E` has a positive-definite fixed point, then the
+fixed points of `E` form a star-subalgebra.
+
+Wolf uses the term *Schwarz map* for a positive unital map satisfying Equation (5.2);
+the three properties are separate hypotheses here because they are separate predicates
+in the formal library.  Source: Wolf Theorem 6.12 and Equation (6.60), local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1395--1417.  The explicit
+block realization from Wolf Equation (1.39) is not asserted here.
+
+**Scope restriction (positive-definite witness):** Wolf Theorem 6.12 assumes an
+arbitrary full-rank fixed point and invokes the proposition on positive fixed
+points to choose a positive-definite one (local source lines 1161--1192 and
+1404--1405).  This declaration takes the positive-definite witness explicitly.
+Documented in `docs/paper-gaps/wolf_thm6_12_abstract_schwarz_fixed_points.tex`.
+Elimination: formalize that source reduction for abstract positive
+trace-preserving maps and use it to wrap this lemma with the literal theorem
+hypothesis. -/
+noncomputable def fixedPointsStarSubalgebra
+    (E : Mat →ₗ[ℂ] Mat) (hEpos : IsPositiveMap E) (hE_one : E 1 = 1)
+    (hE : IsSchwarzMap E) {ρ : Mat} (hρ : ρ.PosDef)
+    (hρ_fix : Matrix.traceAdjointMap E ρ = ρ) :
+    StarSubalgebra ℂ Mat where
+  carrier := fixedPoints E
+  zero_mem' := E.map_zero
+  add_mem' := by
+    intro X Y hX hY
+    change E (X + Y) = X + Y
+    rw [E.map_add, hX, hY]
+  one_mem' := hE_one
+  mul_mem' := by
+    intro X Y hX hY
+    exact mul_mem_fixedPoints E hEpos hE hρ hρ_fix hX hY
+  algebraMap_mem' := by
+    intro c
+    change E (algebraMap ℂ Mat c) = algebraMap ℂ Mat c
+    simp [Algebra.algebraMap_eq_smul_one, hE_one]
+  star_mem' := by
+    intro X hX
+    change Xᴴ ∈ fixedPoints E
+    exact conjTranspose_mem_fixedPoints E hEpos hX
+
+@[simp] theorem mem_fixedPointsStarSubalgebra
+    (E : Mat →ₗ[ℂ] Mat) (hEpos : IsPositiveMap E) (hE_one : E 1 = 1)
+    (hE : IsSchwarzMap E) {ρ : Mat} (hρ : ρ.PosDef)
+    (hρ_fix : Matrix.traceAdjointMap E ρ = ρ) (X : Mat) :
+    X ∈ fixedPointsStarSubalgebra E hEpos hE_one hE hρ hρ_fix ↔
+      E X = X :=
+  Iff.rfl
+
+end SchwarzMap

--- a/TNLean/Channel/FixedPoint/Algebra.lean
+++ b/TNLean/Channel/FixedPoint/Algebra.lean
@@ -11,7 +11,10 @@ import TNLean.Channel.Schwarz.MultiplicativeDomainFull
 /-!
 # Fixed points of unital Schwarz maps form a `*`-algebra
 
-This file formalizes Wolf Theorems 6.12 and 6.13.
+This file gives the Kraus specialization of the full-support algebra step in
+Wolf Theorem 6.12 and formalizes Wolf Theorem 6.13.  The abstract Schwarz-map
+version after choosing a positive-definite invariant weight is in
+`TNLean.Channel.FixedPoint.AbstractAlgebra`.
 
 ## Main results
 
@@ -160,7 +163,7 @@ theorem mul_mem_fixedPoints
   change map K (X * Y) = X * Y
   rw [h_mul_map, hX, hY]
 
-/-- **Wolf Theorem 6.12** for `map K`.
+/-- **Kraus specialization of the algebra conclusion of Wolf Theorem 6.12** for `map K`.
 
 If `map K` is unital and `adjointMap K` has a positive definite fixed point,
 then the fixed points of `map K` form a `StarSubalgebra`. -/

--- a/TNLean/Channel/Schwarz/Basic.lean
+++ b/TNLean/Channel/Schwarz/Basic.lean
@@ -193,41 +193,12 @@ theorem trace_mul_map_eq_trace_adjointMap_mul
             simp [Matrix.mul_assoc]
 
 omit [DecidableEq n] in
-/-- If `M` is PSD, `ρ` is PD, and `tr(ρ·M)=0`, then `M=0`.
-
-This is the standard “faithfulness of the weighted trace”. -/
+/-- Equivalent Kraus-namespace formulation of faithfulness of the
+positive-definite weighted trace. -/
 theorem posSemidef_eq_zero_of_posDef_trace_mul_eq_zero
     {ρ M : Matrix n n ℂ} (hM : M.PosSemidef) (hρ : ρ.PosDef)
-    (htr : Matrix.trace (ρ * M) = 0) : M = 0 := by
-  classical
-  -- Factor `ρ = S†S` with `S` a unit.
-  rcases CStarAlgebra.isStrictlyPositive_iff_eq_star_mul_self.mp
-      (Matrix.isStrictlyPositive_iff_posDef.mpr hρ) with ⟨S, hS_unit, hρ_eq⟩
-  -- Consider `S M S†`, which is PSD.
-  have hSMS_psd : (S * M * Sᴴ).PosSemidef :=
-    hM.mul_mul_conjTranspose_same (B := S)
-  -- Its trace is `tr(ρ M)` by cyclicity.
-  have htr' : Matrix.trace (S * M * Sᴴ) = 0 := by
-    -- `tr(S M S†) = tr(S† S M)` by cyclicity, and `S†S = ρ`.
-    have hcycle : Matrix.trace (S * M * Sᴴ) = Matrix.trace (Sᴴ * S * M) :=
-      Matrix.trace_mul_cycle S M Sᴴ
-    have htr'' : Matrix.trace (Sᴴ * S * M) = 0 := by
-      -- Rewrite `tr(ρ M)=0` using `ρ = S†S`.
-      simpa [hρ_eq, Matrix.mul_assoc, ← Matrix.star_eq_conjTranspose] using htr
-    exact hcycle.trans htr''
-  -- PSD + trace 0 ⇒ zero.
-  have hSMS_zero : S * M * Sᴴ = 0 := (hSMS_psd.trace_eq_zero_iff.mp htr')
-  -- Cancel the unit factors.
-  have hMS_zero : M * Sᴴ = 0 := by
-    have : S * (M * Sᴴ) = S * 0 := by
-      simpa [Matrix.mul_assoc] using hSMS_zero
-    exact IsUnit.mul_left_cancel hS_unit this
-  have hSstar_unit : IsUnit (Sᴴ) := by
-    -- `Sᴴ = star S`.
-    simpa [Matrix.star_eq_conjTranspose] using (IsUnit.star hS_unit)
-  have : M * Sᴴ = 0 * Sᴴ := by
-    simpa [zero_mul] using hMS_zero
-  exact IsUnit.mul_right_cancel hSstar_unit this
+    (htr : Matrix.trace (ρ * M) = 0) : M = 0 :=
+  Matrix.posSemidef_eq_zero_of_posDef_trace_mul_eq_zero hM hρ htr
 
 /-- **Weighted KS equality for peripheral eigenvectors**.
 

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -206,14 +206,28 @@ In `TNLean.Channel.FixedPoint.StationarySupport`:
   (`irreducible_iff_support_full`, `stationary_support_minimal`) remain to be
   reinstated.
 
-### Wolf Theorem 6.12 (Fixed points form a *-algebra) — FORMALIZED
+### Wolf Theorem 6.12 (Fixed points form a *-algebra) — PARTIALLY FORMALIZED
+
+In `TNLean.Channel.FixedPoint.AbstractAlgebra`:
+
+* `SchwarzMap.fixedPointsStarSubalgebra` — for a positive unital Schwarz map
+  whose trace adjoint has an explicitly chosen positive definite fixed point,
+  the fixed points form a `StarSubalgebra`.
+
+This is the algebra step after the faithful invariant weight has been chosen.
+The source theorem begins with an arbitrary full-rank fixed point and invokes
+its proposition on positive fixed points to obtain that weight.  The
+full-rank-to-positive-definite reduction theorem and the explicit block
+realization from Equation (1.39) remain open.
 
 In `TNLean.Channel.FixedPoint.Algebra`:
 
-* `Kraus.fixedPointsStarSubalgebra` — Schrödinger-picture form:
+* `Kraus.fixedPointsStarSubalgebra` — Kraus specialization in the
+  Schrödinger picture:
   if `map K` is unital and `adjointMap K` has a positive definite fixed point,
   the fixed points of `map K` form a `StarSubalgebra`.
-* `Kraus.adjointFixedPointsStarSubalgebra` — Heisenberg-picture form:
+* `Kraus.adjointFixedPointsStarSubalgebra` — Kraus specialization in the
+  Heisenberg picture:
   if `adjointMap K` is unital (`IsTP K`) and `map K` has a positive definite
   fixed point, the fixed points of `adjointMap K` form a `StarSubalgebra`.
 * `Kraus.fixedPoints_in_multiplicativeDomain` — the key intermediate step:

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -1778,6 +1778,35 @@ matching the weighted-trace argument in
     $\mathrm{Fix}(E) = \{X \in \MN{D} : E(X) = X\}$.
 \end{definition}
 
+\begin{definition}[Fixed points of a linear map]\label{def:abstract_fixed_points}
+    \lean{SchwarzMap.fixedPoints}\leanok
+    The fixed-point set of a complex-linear map
+    $E:\MN{D}\to\MN{D}$ is
+    \[
+        \operatorname{Fix}(E)=\{X\in\MN{D}:E(X)=X\}.
+    \]
+\end{definition}
+
+\begin{lemma}[Faithfulness of a positive-definite weighted trace]
+    \label{lem:posDef_weighted_trace_faithful}
+    \lean{Matrix.posSemidef_eq_zero_of_posDef_trace_mul_eq_zero}\leanok
+    If $M\succeq0$, $\rho>0$, and
+    \[
+        \tr(\rho M)=0,
+    \]
+    then $M=0$.
+\end{lemma}
+
+\begin{proof}\leanok
+    Write $\rho=S^\dagger S$ with $S$ invertible.  The matrix
+    $SMS^\dagger$ is positive semidefinite and
+    \[
+        \tr(SMS^\dagger)=\tr(S^\dagger SM)=\tr(\rho M)=0.
+    \]
+    A positive semidefinite matrix of trace zero vanishes.  Cancelling $S$
+    and $S^\dagger$ gives $M=0$.
+\end{proof}
+
 \begin{theorem}[Fixed points lie in the multiplicative domain]
     \label{thm:fixedPoints_in_multiplicativeDomain}
     \lean{Kraus.fixedPoints_in_multiplicativeDomain}
@@ -1796,29 +1825,62 @@ matching the weighted-trace argument in
     multiplicative domain.
 \end{proof}
 
-\begin{theorem}[Fixed points form a $*$-subalgebra]
+\begin{theorem}[Fixed-point algebra after choosing a faithful invariant weight]
     \label{thm:fixedPointsStarSubalgebra}
-    \lean{Kraus.fixedPointsStarSubalgebra}\leanok
-    \uses{def:kraus_fixed_points, def:kraus_map_channels}
-    Let $E$ be a unital Kraus map whose adjoint map $E^*$ has a positive
-    definite fixed point $\rho > 0$.
-    Then $\mathrm{Fix}(E)$ is a $*$-subalgebra of $\MN{D}$.
-    This is \cite[Theorem~6.12]{Wolf2012Quantum}.
+    \lean{SchwarzMap.fixedPointsStarSubalgebra}\leanok
+    \uses{def:abstract_fixed_points, def:abstract_schwarz_inequality,
+        lem:posDef_weighted_trace_faithful}
+    Let $E:\MN{D}\to\MN{D}$ be positive and unital, and suppose that
+    it satisfies the Schwarz inequality
+    \[
+        E(A^\dagger A)-E(A^\dagger)E(A)\succeq0
+        \qquad(A\in\MN{D}).
+    \]
+    If the trace-pairing adjoint $E^*$ has a positive definite fixed point
+    $\rho>0$, then $\operatorname{Fix}(E)$ is a $*$-subalgebra of $\MN{D}$.
+
+    In the terminology introduced immediately before
+    \cite[Example~5.3]{Wolf2012Quantum}, a \emph{Schwarz map} is precisely a
+    positive unital map satisfying the displayed inequality.  Thus the three
+    displayed assumptions reproduce the source's Schwarz-map convention.
+    In \cite[Theorem~6.12]{Wolf2012Quantum}, the trace adjoint is initially
+    assumed to have an arbitrary full-rank fixed point.  The proposition on
+    positive fixed points then produces a positive definite fixed point
+    $\rho$, to which the theorem above applies.  Equation~(1.39) gives the
+    resulting explicit block form of the algebra.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:kadison_schwarz_channels, thm:left_multiplicative_identity_channels}
-    Closure under addition and scalar multiplication follows from
-    linearity.
-    Closure under $\dagger$: if $E(X) = X$ then $E(X^\dagger) = X^\dagger$
-    because fixed points are stable under adjoint.
-    Closure under multiplication: if $E(X) = X$ and $E(Y) = Y$, the weighted
-    Kadison--Schwarz argument gives
-    $E(X^\dagger X) = E(X)^\dagger E(X)$ and, applied to $X^\dagger$,
-    also $E(X X^\dagger) = E(X) E(X)^\dagger$. Thus $X$ lies in the
-    multiplicative domain, and Theorem~\ref{thm:left_multiplicative_identity_channels}
-    yields $E(XY) = E(X) E(Y) = XY$.
+    \uses{thm:abstract_md_characterization}
+    Positivity gives $E(X^\dagger)=E(X)^\dagger$, so fixed points are closed
+    under adjoints.  For a fixed point $X$, set
+    \[
+        \Delta_X=E(X^\dagger X)-E(X^\dagger)E(X)\succeq0.
+    \]
+    The trace-pairing identity, $E^*(\rho)=\rho$, and $E(X)=X$ give
+    \begin{align*}
+        \tr(\rho\Delta_X)
+          &=\tr\!\left(E^*(\rho)X^\dagger X\right)
+            -\tr\!\left(\rho X^\dagger X\right)\\
+          &=0.
+    \end{align*}
+    Since $\rho>0$, faithfulness of the weighted trace forces
+    $\Delta_X=0$.  Applying the same argument to $X^\dagger$ gives equality
+    in the other one-sided Schwarz inequality.  Hence
+    Theorem~\ref{thm:abstract_md_characterization} places $X$ in the full
+    multiplicative domain.  Consequently, for fixed points $X,Y$,
+    \[
+        E(XY)=E(X)E(Y)=XY.
+    \]
+    Linearity and unitality supply the remaining subalgebra axioms.
 \end{proof}
+
+\begin{remark}[Kraus specialization]
+    \lean{Kraus.fixedPointsStarSubalgebra}\leanok
+    Every unital Kraus map is a positive Schwarz map.  Hence, if its adjoint
+    has a positive definite fixed point, its fixed points form a
+    $*$-subalgebra by the preceding theorem.
+\end{remark}
 
 \begin{remark}\leanok
     Theorem~\ref{thm:fixedPoints_in_multiplicativeDomain} is the

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -1880,9 +1880,9 @@ matching the weighted-trace argument in
 
 \begin{remark}[Kraus specialization]
     \lean{Kraus.fixedPointsStarSubalgebra}\leanok
-    Every unital Kraus map is a positive Schwarz map.  Hence, if its adjoint
-    has a positive definite fixed point, its fixed points form a
-    $*$-subalgebra by the preceding theorem.
+    For a unital Kraus map whose adjoint has a positive definite fixed point,
+    the weighted Kadison--Schwarz equality gives directly that its fixed
+    points form a $*$-subalgebra.
 \end{remark}
 
 \begin{remark}\leanok

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -1803,8 +1803,11 @@ matching the weighted-trace argument in
     \[
         \tr(SMS^\dagger)=\tr(S^\dagger SM)=\tr(\rho M)=0.
     \]
-    A positive semidefinite matrix of trace zero vanishes.  Cancelling $S$
-    and $S^\dagger$ gives $M=0$.
+    A positive semidefinite matrix of trace zero vanishes, so
+    $SMS^\dagger=0$.  Since $S$ and $S^\dagger$ are invertible,
+    \[
+        SMS^\dagger=0 \implies MS^\dagger=0 \implies M=0.
+    \]
 \end{proof}
 
 \begin{theorem}[Fixed points lie in the multiplicative domain]

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -5,6 +5,12 @@ than the cited source paper states locally. A note should identify the exact
 source passage, state the mathematical input in paper notation, and then name
 the current formal boundary.
 
+- `wolf_thm6_12_abstract_schwarz_fixed_points.tex` records the former
+  Kraus-only scope restriction in the source-labelled fixed-point algebra
+  theorem, its resolution by an abstract positive unital Schwarz-map lemma,
+  and the remaining reduction from a full-rank fixed point to an explicitly
+  chosen positive-definite invariant weight.
+
 For the present non-periodic MPS Fundamental Theorem work, the repeated-copy and
 equal-modulus comparison has these current reference points.
 

--- a/docs/paper-gaps/wolf_thm6_12_abstract_schwarz_fixed_points.tex
+++ b/docs/paper-gaps/wolf_thm6_12_abstract_schwarz_fixed_points.tex
@@ -1,0 +1,106 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{The Abstract Schwarz-Map Hypotheses in Wolf Theorem 6.12}
+\author{}
+\date{2026-07-18}
+
+\begin{document}
+\maketitle
+
+\section{Source statement}
+
+Wolf introduces a Schwarz map as a positive unital matrix map satisfying
+\begin{align}
+  E(A^\dagger A)-E(A^\dagger)E(A)&\succeq0
+  \qquad\text{for every }A.
+  \tag{5.2}
+\end{align}
+This terminology is stated in Chapter~5 immediately before Example~5.3
+(local source lines 347--352).  Theorem~6.12 then assumes a unital map satisfying
+this Schwarz inequality and an arbitrary full-rank fixed point of its
+trace-pairing adjoint.  Its algebraic conclusion is
+\begin{align}
+  \operatorname{Fix}(E)&=\{X:E(X)=X\}
+  \quad\text{is a unital $*$-subalgebra.}
+  \tag{6.12}
+\end{align}
+The proof is at local source lines 1395--1417.  It invokes the proposition on
+positive fixed points (local lines 1161--1192, cited there as Proposition~6.9)
+to replace the full-rank witness by a positive-definite fixed point before
+performing the weighted-trace argument.
+The complete theorem also invokes the explicit block realization in
+Equation~(1.39); the present increment concerns only the displayed
+$*$-algebra conclusion.
+
+The word ``positive'' is not repeated in the theorem statement because it is
+part of the Chapter~5 definition of a Schwarz map.  Exposing positivity as a
+separate formal hypothesis therefore does not strengthen the source theorem.
+
+\section{The weighted equality}
+
+Let $\rho>0$ satisfy $E^*(\rho)=\rho$, and let $E(X)=X$.  Positivity implies
+$E(X^\dagger)=X^\dagger$.  For the Schwarz gap
+\begin{align}
+  \Delta_X&=E(X^\dagger X)-E(X^\dagger)E(X)\succeq0,
+\end{align}
+the trace-pairing identity gives Wolf's Equation~(6.60):
+\begin{align}
+  \tr(\rho\Delta_X)
+    &=\tr\!\left(E^*(\rho)X^\dagger X\right)
+      -\tr\!\left(\rho X^\dagger X\right)\\
+    &=0.
+\end{align}
+Faithfulness of the positive-definite weight forces $\Delta_X=0$.  Repeating
+the calculation for $X^\dagger$ gives equality in both one-sided Schwarz
+inequalities.  The abstract multiplicative-domain theorem then yields
+\begin{align}
+  E(XY)&=E(X)E(Y)=XY
+\end{align}
+for fixed points $X$ and $Y$.
+
+This argument is formalized for arbitrary positive unital Schwarz maps once a
+positive-definite invariant weight has been supplied explicitly.
+\footnote{Formal declarations:
+  \leanid{SchwarzMap.schwarz_equality_of_mem_fixedPoints},
+  \leanid{SchwarzMap.mem_multiplicativeDomain_of_mem_fixedPoints}, and
+  \leanid{SchwarzMap.fixedPointsStarSubalgebra} in
+  \doclink{TNLean/Channel/FixedPoint/AbstractAlgebra}.}
+
+\section{Comparison with the Kraus specialization}
+
+The earlier declaration assumed a Kraus representation.
+\footnote{Formal declaration:
+  \leanid{Kraus.fixedPointsStarSubalgebra} in
+  \doclink{TNLean/Channel/FixedPoint/Algebra}.}
+That result is mathematically correct, but complete positivity is stronger than
+the Schwarz-map hypothesis in Theorem~6.12.  It is retained as a useful
+specialization of the post-reduction lemma and is not presented as the literal
+formalization of the theorem.
+
+\section{Verdict}
+
+The earlier Kraus-only attribution was a \emph{scope restriction}, and the
+abstract lemma removes that restriction.  A second scope restriction remains:
+the formal signature assumes a positive-definite fixed point, while Wolf
+Theorem~6.12 assumes only a full-rank fixed point and derives the faithful
+positive witness from its proposition on positive fixed points.  Consequently,
+the present result is the source-faithful post-reduction algebra lemma, not yet
+the literal formalization of Theorem~6.12.
+
+The elimination plan is to formalize the positive-fixed-parts proposition for
+the abstract positive trace-preserving trace adjoint, derive a positive-definite
+fixed point from the full-rank witness, and wrap the present lemma.  The explicit
+Equation~(1.39) block realization, the subsequent support reduction, and the
+zero-block assembly required for Theorem~6.14 also remain open gaps.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
This PR proves the abstract full-support fixed-point algebra lemma used after a positive-definite invariant weight has been chosen in Wolf Theorem 6.12. For an arbitrary positive unital complex-linear map satisfying the Schwarz inequality, whose trace-pairing adjoint fixes a positive-definite matrix, the fixed points form a star-subalgebra. The existing Kraus theorem remains as a completely positive specialization.

The proof follows Wolf Equation (6.60): the invariant positive-definite weight makes the Schwarz gap have zero weighted trace, faithfulness forces the gap to vanish, and the abstract multiplicative-domain theorem from LionSR/TNLean#4223 gives multiplication closure. Positivity gives closure under conjugate transpose, while unitality supplies the identity.

Source correspondence: `Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`, lines 347--352, defines Schwarz maps as positive unital maps satisfying Equation (5.2); `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1395--1417, proves the algebra step through Equation (6.60). The separate positivity hypothesis is definitional unpacking, not a strengthening of the source.

This is a scope-restricted post-reduction lemma, not the literal formalization of Theorem 6.12. Wolf begins with an arbitrary full-rank fixed point and invokes its proposition on positive fixed points, local lines 1161--1192 and 1404--1405, to choose the positive-definite witness. The Lean declaration takes that witness explicitly. The gap note `docs/paper-gaps/wolf_thm6_12_abstract_schwarz_fixed_points.tex` records the restriction and elimination plan. The explicit Equation (1.39) block realization also remains downstream.

Focused verification: `lake build TNLean.Channel.FixedPoint.AbstractAlgebra TNLean.Channel.FixedPoint.Algebra` passes without warnings. The changed Lean files contain no `sorry`, `axiom`, `native_decide`, `unsafeCast`, or `admit` proof tokens. Local blueprint rendering was not run because the isolated worktree lacks the required Python package; GitHub blueprint CI is the validation gate.

This is a bounded increment of LionSR/QICLean#219. The full-rank-to-positive-definite wrapper, Equation (1.39) block realization, support reduction, zero-block assembly of Theorem 6.14, and the applications in LionSR/QICLean#39, LionSR/TNLean#4120, LionSR/TNLean#3949, and LionSR/TNLean#232 remain open.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formal proofs and documentation in channel fixed-point theory; no auth, runtime, or data-path changes. Kraus results are preserved via thin wrappers.
> 
> **Overview**
> **Abstract Wolf Theorem 6.12 (post-reduction).** New `TNLean.Channel.FixedPoint.AbstractAlgebra` proves that for a **positive unital** complex-linear map satisfying the Schwarz inequality, if the trace-pairing adjoint fixes a **positive-definite** weight `ρ`, then fixed points form a `StarSubalgebra`. The proof is Wolf’s weighted trace on the Schwarz gap (`schwarz_equality_of_mem_fixedPoints`), membership in the abstract multiplicative domain, then multiplication closure—**without** assuming a Kraus/CP representation.
> 
> **Shared algebra.** `Matrix.posSemidef_eq_zero_of_posDef_trace_mul_eq_zero` moves to `TNLean.Algebra.MatrixAux`; `TNLean.Channel.Schwarz.Basic` now delegates to it.
> 
> **Docs and scope.** Blueprint chapter 4, `WolfChapter6Index`, and `docs/paper-gaps/wolf_thm6_12_abstract_schwarz_fixed_points.tex` record that this is the algebra step **after** choosing a faithful invariant weight; the Kraus `fixedPointsStarSubalgebra` is relabeled as a specialization. Full-rank → positive-definite witness and Equation (1.39) block form remain open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84eae9a438d78574a0988528c84da2b48e8a4fc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->