### PR TITLE
feat(tenkz): add typed map diagrams

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_normalized_preparations.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_normalized_preparations.tex
@@ -992,68 +992,24 @@ The shifts $\mathcal S_2$ and $\mathcal T_2$ are global reindexings, with all
 displayed tensor factors present at their inputs
 \cite[Appendix~C.2, lines~1521--1559]{Cirac2016MPDO_arXiv}.
 
-\begin{figure}[ht]
-    \centering
-    $\displaystyle\bigoplus_{k,h}$; one $(k,h)$-fiber is displayed
-
-    \smallskip
-    \[
-        \mathcal T_0:\mathfrak R_2\to L_k\otimes R_h,\qquad
-        \mathcal S_2:(L_k\otimes R_h)\otimes(R_k\otimes L_h)\to\mathfrak R_2
-    \]
-
-    \begin{center}
-        % T_0 : R_2 -> L_k tensor R_h,  S_2 : (L_k tensor R_h) tensor
-        % (R_k tensor L_h) -> R_2.  One (k,h)-summand of the family
-        % bigoplus_{k,h} is drawn; objects are the typed sector spaces of
-        % Appendix C.2 (arXiv:1606.00608, lines 1521-1522 and 1555-1559),
-        % not tensor legs, so this is a commutative-diagram (cd) picture,
-        % not a tensor-network contraction.  Top row: T_0 is the two-site
-        % regrouping followed by the partial trace over R_k tensor L_h,
-        % landing on the retained outer factors L_k tensor R_h.  Bottom
-        % row: S_2 starts from the outer AND neighbouring factors already
-        % supplied and applies only the inverse regrouping back to R_2 --
-        % no trace, no preparation map.
-        \begin{tenkzcd}[column sep=large, row sep=large]
-            \mathfrak R_2 \arrow[r, "\mathcal T_0"] & L_k\otimes R_h \\
-            (L_k\otimes R_h)\otimes(R_k\otimes L_h)
-              \arrow[r, "\mathcal S_2"] & \mathfrak R_2
-        \end{tenkzcd}
-    \end{center}
-
-    \medskip
-    $\displaystyle\bigoplus_{k,h}$; one $(k,h)$-fiber and one $l$-summand are displayed
-
-    \smallskip
-    \[
-        \mathcal S_0:\mathfrak R_3\to L_k\otimes R_h,\qquad
-        \mathcal T_2:(L_k\otimes R_h)\otimes\Omega_{k,h}\to\mathfrak R_3
-    \]
-
-    \begin{center}
-        % S_0 : R_3 -> L_k tensor R_h,  T_2 : (L_k tensor R_h) tensor
-        % Omega_{k,h} -> R_3.  The three-site analogue of the two-site
-        % T_0/S_2 pair: one (k,h)-fiber and one l-summand of
-        % bigoplus_{k,h} (bigoplus_l ...) is drawn; objects are the typed
-        % sector spaces of Appendix C.2 (arXiv:1606.00608, lines
-        % 1521-1522, 1524-1530, 1535-1540 and 1547), not tensor legs, so
-        % this is a commutative-diagram (cd) picture, not a tensor-network
-        % contraction.  Top row: S_0 is just the partial trace over the
-        % whole middle block Omega_{k,h} = bigoplus_l (R_k tensor L_l)
-        % tensor (R_l tensor L_h) -- already the four contiguous middle
-        % subspins of R_3's fixed ordering -- landing on the retained
-        % outer factors L_k tensor R_h; no permutation of tensor factors
-        % is needed.  Bottom row: T_2 starts from the outer factor AND
-        % the entire traced block Omega_{k,h} already supplied and
-        % applies the inverse regrouping -- the genuine subspin
-        % permutation -- back to R_3; no trace, no preparation map.
-        \begin{tenkzcd}[column sep=large, row sep=large]
-            \mathfrak R_3 \arrow[r, "\mathcal S_0"] & L_k\otimes R_h \\
-            (L_k\otimes R_h)\otimes\Omega_{k,h}
-              \arrow[r, "\mathcal T_2"] & \mathfrak R_3
-        \end{tenkzcd}
-    \end{center}
-    \caption{Fiberwise partial traces and regrouping maps on two and three
-    physical sites. One $(k,h)$-summand and one $l$-summand are displayed.}
-    \label{fig:mpdo_regrouping_partial_trace_maps}
-\end{figure}
+For every $(k,h)$, the four fiberwise maps are
+% T_0 : R_2 -> L_k tensor R_h traces R_k tensor L_h.
+% S_2 : (L_k tensor R_h) tensor (R_k tensor L_h) -> R_2 is the inverse
+% regrouping.  S_0 : R_3 -> L_k tensor R_h traces the whole middle block
+% Omega_{k,h} = bigoplus_l (R_k tensor L_l) tensor (R_l tensor L_h).
+% T_2 : (L_k tensor R_h) tensor Omega_{k,h} -> R_3 restores the ordered
+% three-site sector factors.  Blue line ink denotes a channel; labels
+% distinguish the four maps.  The endpoints are sector spaces, so these
+% strokes are maps between objects rather than contracted tensor indices.
+\[
+  \begin{tenkzcd}[maps, species={channel}, row sep=6mm]
+    \mathfrak R_2 & L_k\otimes R_h \\
+    (L_k\otimes R_h)\otimes(R_k\otimes L_h) & \mathfrak R_2 \\
+    \mathfrak R_3 & L_k\otimes R_h \\
+    (L_k\otimes R_h)\otimes\Omega_{k,h} & \mathfrak R_3
+    \tnarrow[from={(1,1)}, to={(1,2)}, species=channel]{\mathcal T_0}
+    \tnarrow[from={(2,1)}, to={(2,2)}, species=channel]{\mathcal S_2}
+    \tnarrow[from={(3,1)}, to={(3,2)}, species=channel]{\mathcal S_0}
+    \tnarrow[from={(4,1)}, to={(4,2)}, species=channel]{\mathcal T_2}
+  \end{tenkzcd}
+\]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels.tex
@@ -140,64 +140,35 @@ and $\mathcal T_2$ orders the result as
 \[
   (L_k\otimes R_k)\otimes(L_l\otimes R_l)\otimes(L_h\otimes R_h).
 \]
-The two rows in Figure~\ref{fig:mpdo_physical_sector_refinement_channel} use
-the sitewise sector coordinates $\mathfrak R_2$ and $\mathfrak R_3$
+The refinement uses the sitewise sector coordinates $\mathfrak R_2$ and
+$\mathfrak R_3$
 \cite[Appendix~C.2, lines~1510--1516 and~1522--1545]
   {Cirac2016MPDO_arXiv}.
 
-\begin{figure}[ht]
-    \centering
-    \[
-        \mathfrak R_2\xrightarrow{\mathcal T_0}L_k\otimes R_h
-        \xrightarrow{\mathcal T_1}(L_k\otimes R_h)\otimes\Omega_{k,h}
-        \xrightarrow{\mathcal T_2}\mathfrak R_3
-    \]
-    \begin{center}
-        % R_2 --T_0--> L_k tensor R_h --T_1--> (L_k tensor R_h) tensor
-        % Omega_{k,h} --T_2--> R_3.  Objects are the typed sector spaces of
-        % Appendix C.2 (arXiv:1606.00608, lines 1510-1516 and 1522-1545),
-        % not tensor legs, so this is a commutative-diagram (cd) picture,
-        % not a tensor-network contraction -- matching the abstract
-        % composite T = T_2 T_1 T_0 of MPDO_TMatrix.png, not the tensor
-        % rows it also draws.  T_0 traces the neighbouring subspins R_k
-        % tensor L_h from the two-site sector space, landing on the
-        % retained outer factors L_k tensor R_h.  T_1 adjoins the
-        % completed three-site neighbouring density Omega_{k,h} on the
-        % active/zero-weight sector.  T_2 reorders the six subspins into
-        % the three-site sector space R_3.
-        \begin{tenkzcd}[column sep=large]
-            \mathfrak R_2 \arrow[r, "\mathcal T_0"] &
-            L_k\otimes R_h \arrow[r, "\mathcal T_1"] &
-            (L_k\otimes R_h)\otimes\Omega_{k,h} \arrow[r, "\mathcal T_2"] &
-            \mathfrak R_3
-        \end{tenkzcd}
-    \end{center}
-
-    \medskip
-    \[
-        \mathfrak R_2({\cal K}_2(X))\xrightarrow{\mathcal T}\mathfrak R_3({\cal K}_3(X))
-    \]
-    \begin{center}
-        % R_2(K_2(X)) --T--> R_3(K_3(X)): the refinement half of
-        % MPDO_TSKKK.png (arXiv:1606.00608 / CPSV16, Appendix C.2, eq.
-        % (3to5tcpm), lines~1510--1516, and Prop. C.7). Genre: cd -- both
-        % R_2(K_2(X)) and R_3(K_3(X)) are already-closed matrices (no
-        % open legs survive the sector-coordinate embedding), so the
-        % identity is a labelled arrow between two objects, not a tensor
-        % contraction. The arrow label T is the refinement channel
-        % T = T_2 T_1 T_0 of Definition~\ref{def:mpdo_physical_sector_t_map};
-        % the closure identity itself (T applied equals the closure) is
-        % Theorem~\ref{thm:mpdo_physical_sector_t_closure_identity}.
-        \begin{tenkzcd}
-            \mathfrak R_2({\cal K}_2(X)) \arrow[r, "\mathcal T"] &
-            \mathfrak R_3({\cal K}_3(X))
-        \end{tenkzcd}
-    \end{center}
-    \caption{The refinement channel
-    $\mathcal T=\mathcal T_2\mathcal T_1\mathcal T_0$ in physical-sector
-    coordinates.}
-    \label{fig:mpdo_physical_sector_refinement_channel}
-\end{figure}
+% T = T_2 T_1 T_0 maps R_2 through the retained outer factors and the
+% completed neighboring density to R_3.  Each blue stroke has channel
+% species; the labels T_0, T_1, T_2 name the constituent maps.  The fixed
+% left-to-right axis records composition without arrowheads.
+\[
+  \begin{tenkzcd}[maps, species={channel}]
+    \mathfrak R_2 &
+    L_k\otimes R_h &
+    (L_k\otimes R_h)\otimes\overline\Omega_{k,h} &
+    \mathfrak R_3
+    \tnarrow[from={(1,1)}, to={(1,2)}, species=channel]{\mathcal T_0}
+    \tnarrow[from={(1,2)}, to={(1,3)}, species=channel]{\mathcal T_1}
+    \tnarrow[from={(1,3)}, to={(1,4)}, species=channel]{\mathcal T_2}
+  \end{tenkzcd}
+\]
+The closure identity is
+% T(R_2(K_2(X))) = R_3(K_3(X)).  Both endpoints are closed sector-coordinate
+% matrices; the blue line is the channel T, not a contracted tensor index.
+\[
+  \begin{tenkzcd}[maps, species={channel}]
+    \mathfrak R_2(\mathcal K_2(X)) & \mathfrak R_3(\mathcal K_3(X))
+    \tnarrow[from={(1,1)}, to={(1,2)}, species=channel]{\mathcal T}
+  \end{tenkzcd}
+\]
 
 \begin{definition}[The neighboring-state preparation $\mathcal S_1$]
     \label{def:mpdo_physical_sector_s1_map}

--- a/docs/tenkz/DESIGN.md
+++ b/docs/tenkz/DESIGN.md
@@ -154,6 +154,50 @@ Cell commands (expandable; legal only inside `tenkz`/`\tnpic`):
 
 - **Grid mode** (default): *is* tikz-cd — all its keys and the full `\arrow` grammar pass through — plus house arrow/label styles (`cd arrow`: 0.40pt, open head, boundary-clipped with named standoff) and TN objects via `\tnpic`/`\tntree`.
 - **Polygon mode** (`polygon=⟨n⟩, radius=⟨dim⟩`): n `&`-separated cells placed as named nodes on a regular n-gon (vertex 1 on top, clockwise); `\tnarrow[from=⟨i⟩, to=⟨j⟩]{⟨label⟩}` between vertex names (`\tnarrow*` puts the label on the other side; the spec first wrote this in tikz-cd's `\arrow` grammar — the shipped grammar is `\tnarrow`). **Honesty clause (fixes the judge-author flag):** polygon mode implements node *placement* only; arrow drawing, shortening, and label sides reuse tikz-cd's arrow-style vocabulary — it does not reimplement an arrow engine. **Documented first-class fallback (G25):** a raw `tikzcd` grid with `\tnpic`/`\tntree` objects is sanctioned whenever a layout exceeds polygon mode; the manual shows the pentagon both ways.
+- **Typed-map mode** (`maps`): a matrix of objects joined along the fixed left-to-right composition axis. A map has the form
+  `\tnarrow[from={(r,c)}, to={(r,c+1)}, role=⟨role⟩]{⟨name⟩}` or
+  `\tnarrow[from={(r,c)}, to={(r,c+1)}, species=⟨species⟩]{⟨name⟩}`;
+  `fused` selects the fused line type, and `\tnarrow*` places the name on the opposite side. Every map must have either a role or a declared species. The line style records the map's type; the label records only the map itself. There are no arrowheads: the order of the objects determines the order of composition. Vertical maps, reverse maps, and maps that skip an object column lie outside this grammar.
+
+Typed-map rows belong to the categorical diagram language, not to the tensor-network language. Their vertices are mathematical objects and their joining strokes are maps, not contracted indices. A `\tnpic` occurring in an object cell remains an opaque mathematical object; the adjacent typed-map stroke does not acquire tensor ports or enter its contraction graph. The modes `maps` and `polygon` are disjoint, while ordinary grid mode retains the complete tikz-cd arrow grammar.
+
+A family is written as small multiples: one complete domain--codomain row for each member, with the same number of object columns in every row. A finite family is displayed in full, rather than by selected representatives. Parameters may remain symbolic when the displayed row asserts a formula uniformly over all their values. The matrix is a math object and may occur directly in displayed or running mathematics; it requires neither a figure wrapper nor a separate sizing mode.
+
+For the CPSV refinement, let
+
+\[
+  \widehat\Omega_{k,h}
+  = \frac{1}{a_k b_h}
+    \bigoplus_l \bigl(\eta_{k,l}\otimes\eta_{l,h}\bigr).
+\]
+
+The fiberwise refinement is the composition
+
+\[
+  \mathfrak R_2
+  \xrightarrow{\mathcal T_0}
+  L_k\otimes R_h
+  \xrightarrow{\mathcal T_1}
+  (L_k\otimes R_h)\otimes\widehat\Omega_{k,h}
+  \xrightarrow{\mathcal T_2}
+  \mathfrak R_3.
+\]
+
+On an active $(k,h)$-summand, $\mathcal T_0$ traces out the factors $R_k\otimes L_h$, $\mathcal T_1$ sends $X$ to $X\otimes\widehat\Omega_{k,h}$, and $\mathcal T_2$ reorders the subspin factors into the three output sites. Consequently $\mathcal T=\mathcal T_2\mathcal T_1\mathcal T_0$. In `tenkzcd` this is written as follows.
+
+```latex
+\[
+\begin{tenkzcd}[maps, species={channel}]
+  \mathfrak R_2 &
+  L_k\otimes R_h &
+  (L_k\otimes R_h)\otimes\widehat\Omega_{k,h} &
+  \mathfrak R_3
+  \tnarrow[from={(1,1)}, to={(1,2)}, species=channel]{\mathcal T_0}
+  \tnarrow[from={(1,2)}, to={(1,3)}, species=channel]{\mathcal T_1}
+  \tnarrow[from={(1,3)}, to={(1,4)}, species=channel]{\mathcal T_2}
+\end{tenkzcd}
+\]
+```
 
 ### 2.3 Math / CD objects
 
@@ -331,6 +375,7 @@ Two-layer split: **semantic styles** (what a mark means) bind to **theme slots**
 | `region collar` | `slot=collar` | 0.80pt | |
 | `distinguished edge` | `\tnedge` | 0.80pt accent | own layer |
 | `distinguished vertex` | `\tnsite` | accent | |
+| `typed map` | `tenkzcd[maps]` edges | role/species bond style, headless | the label names the map; order is the fixed axis |
 | `cd arrow` | tenkzcd arrows | 0.40pt, open head | never confusable with 0.55pt wires |
 
 ### 4.3 Semantic hue table (document-wide meanings)
@@ -351,6 +396,8 @@ One base: `pitch = 11mm` (display). Derived constants (name, value, motivation):
 | `junction diameter` | 3.2 × wire width (≥ 0.9mm) | below 3×, a junction is indistinguishable from a wire crossing at 600 dpi |
 | `region margin` | 0.36·pitch | strictly < pitch/2 so single-site notches read; > glyph radius so hulls never clip glyphs |
 | `compact` / `inline` | 0.8 scale / em-based scale on pitch | profiles are one scale factor, not parallel constant lists — literals cannot bypass them |
+| `map column gap` | 0.34·pitch | a short composition remains a mathematical atom rather than expanding to display width; wider labels override it with `column sep=` |
+| `map row gap` | 0.50·pitch | adjacent small multiples remain distinct without figure-scale leading; `row sep=` overrides it |
 
 ---
 
@@ -358,7 +405,7 @@ One base: `pitch = 11mm` (display). Derived constants (name, value, motivation):
 
 ### 5.1 Event stream v2 (`.tnlog`)
 
-Every environment emits `picture|id|lang=grid|cd|lattice|free|src=⟨file:line⟩` (via currfile — identity without a registry), then dialect events: grid → `atom`, `bond` (with `fused`/`dir` attributes), `leg`, `pairleg`, `trace`, `fuse`, `span`; cd → `object`, `arrow`; lattice → `lattice`, `region|slot|cellset-normal-form`, `edge`, `site`; free → `put`, `join`. `\tndefine`/use emit `def|name|hash` / `use|name`. plasTeX compiles bodies standalone, so identical events flow in web builds.
+Every environment emits `picture|id|lang=grid|cd|lattice|free|src=⟨file:line⟩` (via currfile — identity without a registry), then dialect events: grid → `atom`, `bond` (with `fused`/`dir` attributes), `leg`, `pairleg`, `trace`, `fuse`, `span`; cd → `cdcell`, `cdobject`, `cdarrow`, `cdmap`, `tree`; lattice → `lattice`, `region|slot|cellset-normal-form`, `edge`, `site`; free → `put`, `join`. `\tndefine`/use emit `def|name|hash` / `use|name`. plasTeX compiles bodies standalone, so identical events flow in web builds.
 
 ### 5.2 The sugar contract (G21)
 
@@ -366,7 +413,7 @@ Every environment emits `picture|id|lang=grid|cd|lattice|free|src=⟨file:line�
 
 ### 5.3 Type checks
 
-Structural in the grid: bonds are virtual–virtual and pairings physical–physical **by construction** — mismatches are inexpressible, so checks move from runtime to parser. Runtime assertions fire exactly where free composition exists: `\tnjoin` in `tenkzfree`. The `morphism` port type is deleted; cd arrows are their own event species and never enter the contraction graph.
+Structural in the grid: bonds are virtual–virtual and pairings physical–physical **by construction** — mismatches are inexpressible, so checks move from runtime to parser. Runtime assertions fire exactly where free composition exists: `\tnjoin` in `tenkzfree`. The `morphism` port type is deleted; `cdmap` and `cdarrow` are their own event species and never enter the contraction graph.
 
 ### 5.4 Invariants
 

--- a/docs/tenkz/USAGE.md
+++ b/docs/tenkz/USAGE.md
@@ -105,6 +105,38 @@ the metric system; bead labels pick a free compass quadrant automatically.
 When you disagree with a choice: `label pos=south west`,
 `label shift={2pt,0pt}`.
 
+## Typed maps: `tenkzcd[maps]`
+
+A typed map joins two mathematical objects along the fixed left-to-right
+composition axis. Its line style gives the map type, and its label gives the
+map's name. For example, the MPDO refinement and coarsening channels act
+between the open two-site and three-site tensor networks:
+
+```latex
+\begin{tenkzcd}[maps, species={channel}, column sep=10mm, row sep=8mm]
+  \tnpic[inline, physical=updown]{
+    \tn[box]{\mathcal K} & \tn[box]{\mathcal K}
+  } &
+  \tnpic[inline, physical=updown]{
+    \tn[box]{\mathcal K} & \tn[box]{\mathcal K} & \tn[box]{\mathcal K}
+  } \\
+  \tnpic[inline, physical=updown]{
+    \tn[box]{\mathcal K} & \tn[box]{\mathcal K} & \tn[box]{\mathcal K}
+  } &
+  \tnpic[inline, physical=updown]{
+    \tn[box]{\mathcal K} & \tn[box]{\mathcal K}
+  }
+  \tnarrow[from={(1,1)}, to={(1,2)}, species=channel]{\mathcal T}
+  \tnarrow[from={(2,1)}, to={(2,2)}, species=channel]{\mathcal S}
+\end{tenkzcd}
+```
+
+The channel strokes are headless because their direction is the composition
+axis: the second row reverses the objects rather than reversing the stroke.
+Each stroke lies between two complete tensor-network objects and is not an
+additional contraction. A finite family is written with one complete
+domain--codomain row per member.
+
 ## Commutative diagrams: `tenkzcd` and `\tntree`
 
 Pentagon equations are commutative diagrams, not contractions:

--- a/docs/tenkz/chapters2/ch-reference.tex
+++ b/docs/tenkz/chapters2/ch-reference.tex
@@ -337,16 +337,27 @@ window under both policies; \S\ref{ch:house} states which school a
 document should pick, and why.
 
 % =====================================================================
-\subsection{Trees and arrows: \tnenv{tenkzcd}}
+\subsection{Maps, trees, and arrows: \tnenv{tenkzcd}}
 
 \thumbtag{\tnenv{tenkzcd}}%
 \cmdsig{\textbackslash begin\{tenkzcd\}[\meta{keys}]\ \meta{slots}\
 \textbackslash end\{tenkzcd\}}
 
+The environment has three mathematical readings.  With \tnkey{maps},
+its cells are objects and its edges are maps.  Composition runs from
+left to right, so a map joins $(r,c)$ only to $(r,c+1)$ and needs no
+arrowhead.  This is not a tensor-network contraction: the cells denote
+spaces or other mathematical objects, the joining line denotes a
+morphism, and no tensor index is contracted.  Every edge carries either
+\tnkey{role=} or \tnkey{species=}; that line style states its type, while
+the argument of \tncmd{tnarrow} states only the map's name.  A family
+is written as explicit rows, one member per row, with no selected
+examples standing for the rest.
+
 With \tnkey{polygon=}$n$ the \texttt{\&}-separated slots sit on an
 $n$-gon, first slot at the top, and \tncmd{tnarrow} joins them by
 slot number; each slot holds a fusion tree, a \tncmd{tnpic}, or plain
-mathematics.  Without \tnkey{polygon=} the body is a
+mathematics.  Without \tnkey{maps} or \tnkey{polygon=}, the body is a
 commutative-diagram matrix in rows and columns, with the standard
 arrow syntax of such matrices.
 
@@ -355,6 +366,8 @@ arrow syntax of such matrices.
 \noindent\begin{tabularx}{\linewidth}{@{}p{29mm}p{23mm}p{11mm}>{\raggedright\arraybackslash}X@{}}
 \toprule
 \keyhead
+\texttt{maps} & --- & --- &
+  typed-map rows on the fixed left-to-right composition axis \\
 \texttt{polygon=} & \meta{n} & --- &
   slots on an $n$-gon; unset = matrix mode \\
 \texttt{radius=} & \meta{length} & \texttt{30mm} &
@@ -364,6 +377,21 @@ arrow syntax of such matrices.
 \bottomrule
 \end{tabularx}\par}
 \medskip
+
+\thumbtag{\tnkey{maps}}%
+\cmdsig{\textbackslash tnarrow[\\
+\quad from=\{(r,c)\}, to=\{(r,c+1)\},\\
+\quad \meta{line type}]\{\meta{map}\}}
+
+\noindent The line type is either \tnkey{role=} or \tnkey{species=}.
+The semantic roles are \tnval{operator}, \tnval{marked}, \tnval{extra},
+and \tnval{passive}; a species is a name declared by \tncmd{tnset}.
+Exactly one of these keys supplies the edge type.  The line is headless
+because its position on the composition axis already fixes the direction.
+The starred form puts the map's name below the line; it does not reverse the
+map.  The whole environment is a mathematical atom, so the same spelling
+belongs directly in running mathematics or in a displayed equation.  No
+floating or numbered figure is part of the grammar.
 
 \thumbtag{\tncmd{tntree}}%
 \cmdsig{\textbackslash tntree\{\meta{bracketed word}\}\\

--- a/docs/tenkz/chapters2/ch-tutorial.tex
+++ b/docs/tenkz/chapters2/ch-tutorial.tex
@@ -227,6 +227,44 @@ selected region'' looks the same in every figure.
 \end{tnexample}
 
 % ---------------------------------------------------------------------
+\subsection{Typed maps compose along one axis}\label{sec:tut-maps}
+
+A typed-map diagram records morphisms between mathematical objects.  It
+does not contract tensor indices.  In \tnenv{tenkzcd} with
+\tnkey{maps}, objects occupy matrix cells and every map runs from a cell
+to its eastern neighbour.  The fixed left-to-right order carries the
+direction, so the edge has no arrowhead.  Its line style gives the map's
+type; its label gives the map's name.
+
+Declare paper-specific edge types once, then enumerate a finite family
+as aligned rows.  Here the two channels are the two members of the
+family, not representatives chosen from a larger collection:
+
+\begin{tnexample}[
+    formula   = {\Phi_a:V_a\longrightarrow W_a},
+    caption   = {an enumerated family of typed maps},
+    index     = {Each row is one map $\Phi_a:V_a\to W_a$.  The common
+                 line style states that both maps are channels; the
+                 labels $\Phi_0$ and $\Phi_1$ distinguish them.},
+    label     = {ex:tut-typed-maps},
+  ]
+% Phi_a : V_a -> W_a for a=0,1; every family member is a row.
+% The channel species is line data; Phi_0 and Phi_1 name the two maps.
+\begin{tenkzcd}[maps, species={channel}, column sep=12mm]
+  V_0 & W_0 \\
+  V_1 & W_1
+  \tnarrow[from={(1,1)}, to={(1,2)}, species=channel]{\Phi_0}
+  \tnarrow[from={(2,1)}, to={(2,2)}, species=channel]{\Phi_1}
+\end{tenkzcd}
+\end{tnexample}
+
+Longer compositions use further columns on the same axis.  Reverse the
+order of the objects when the domain changes; never reverse an edge or
+add a head.  Since \tnenv{tenkzcd} is already a mathematical atom, this
+construction sits wherever the corresponding expression belongs,
+whether in a sentence or between the delimiters of a displayed equation.
+
+% ---------------------------------------------------------------------
 \subsection{Fusion trees and the pentagon}\label{sec:tut-cd}
 
 Commutative diagrams are not contractions, so they live in their own

--- a/docs/tenkz/manual2.tex
+++ b/docs/tenkz/manual2.tex
@@ -187,7 +187,7 @@ whole language.
   \qrsection{Environments}
   \qritem{tenkz}{the contraction grid: rows are layers, columns are
     sites; bonds implicit}
-  \qritem{tenkzcd}{commutative diagrams and fusion trees}
+  \qritem{tenkzcd}{typed maps, commutative diagrams, and fusion trees}
   \qritem{tenkzlattice}{lattice windows and regions}
   \qritem{tenkzplanes}{ket-over-bra double layer}
   \qritem{tenkzfree}{typed free placement}
@@ -270,7 +270,12 @@ whole language.
   \qritem{open=\{(1-4, 2)\}}{cells keeping dangling stubs}
   \qritem{sheet sep=, trace=}{the gap; traced cells}
 
-  \qrsection{Trees and arrows (tenkzcd)}
+  \qrsection{Maps, trees, and arrows (tenkzcd)}
+  \qritem{maps}{headless typed maps composed from left to right;
+    one family member per row}
+  \qritem{\textbackslash tnarrow[from=\{(r,c)\},
+    to=\{(r,c+1)\}, species=s]\{T\}}{map $T$ of species $s$;
+    use \texttt{role=} instead for a semantic role}
   \qritem{\textbackslash tntree\{(((a\,b)\_x\,c)\_y\,d)\_e\}}{fusion
     tree from a bracketed word}
   \qritem{\textbackslash tnarrow[from=1, to=2]\{F\}}{arrow between

--- a/scripts/tenkz_audit.py
+++ b/scripts/tenkz_audit.py
@@ -72,7 +72,7 @@ EMPTY_CHECK_LANGS = {"grid", "lattice", "free"}
 DIALECT_KINDS = {
     "grid": {"atom", "bond", "trace", "pairtrace", "phtrace", "cup", "hole", "boundary"},
     "free": {"atom", "join", "boundary"},
-    "cd": {"cdcell", "cdarrow", "tree"},
+    "cd": {"cdcell", "cdobject", "cdarrow", "cdmap", "tree"},
 }
 
 
@@ -112,7 +112,12 @@ FIELD_VALIDATORS: dict[str, dict[str, Callable[[str], bool]]] = {
     "boundary": {"picture": _is_int, "virtual-west": _is_int, "virtual-east": _is_int,
                  "physical-up": _is_int, "physical-down": _is_int},
     "cdcell": {"picture": _is_int, "index": _is_int},
+    "cdobject": {"picture": _is_int, "cell": _is_cell},
     "cdarrow": {"picture": _is_int, "from": _any, "to": _any},
+    "cdmap": {"picture": _is_int, "from": _is_cell, "to": _is_cell,
+              "fused": _enum("0", "1"),
+              "role": _enum("none", "operator", "marked", "extra", "passive"),
+              "species": _any},
     "tree": {"picture": _is_int, "leaves": _is_int},
     "join": {"picture": _is_int, "from": _any, "to": _any},
 }
@@ -294,6 +299,28 @@ class Audit:
         for (lang, digest), pics in sorted(groups.items(),
                                            key=lambda kv: kv[1][0].ident):
             if len(pics) < 2:
+                continue
+            # A cd parent emits its final addressed edges after all object
+            # cells have been typeset.  Grid pictures declared inside that
+            # line interval are therefore nested object cells.  Repeating an
+            # object in several rows of one map family is the point of a
+            # small-multiple diagram, not a candidate for a global named
+            # figure definition.
+            parents = []
+            for pic in pics:
+                containing = [
+                    parent for parent in self.pictures
+                    if parent.lang == "cd"
+                    and parent.line < pic.line
+                    and parent.content()
+                    and pic.line < max(e.line for e in parent.content())
+                ]
+                parents.append(max(containing, key=lambda p: p.line,
+                                   default=None))
+            if parents[0] is not None and all(
+                    parent is not None
+                    and parent.ident == parents[0].ident
+                    for parent in parents):
                 continue
             ids = ", ".join(str(p.ident) for p in pics)
             self.adv("repeated-topology", self.log_path.name,

--- a/tex/tenkz/examples/typed-maps.tex
+++ b/tex/tenkz/examples/typed-maps.tex
@@ -1,0 +1,72 @@
+\documentclass[varwidth=18cm, border=6pt]{standalone}
+\usepackage{amsmath, amssymb}
+\usepackage{tenkz}
+
+\begin{document}
+
+% T maps the open two-site MPDO tensor network to the open three-site
+% MPDO tensor network, while S maps the three-site network back to the
+% two-site network.  Each K has one virtual index on each horizontal side
+% and one ket/bra pair vertically.  Each blue channel line lies between
+% two complete tensor-network objects; it is not an additional contraction.
+\[
+  \begin{tenkzcd}[maps, species={channel}, column sep=10mm, row sep=8mm]
+    \tnpic[inline, physical=updown]{
+      \tn[box]{\mathcal K} & \tn[box]{\mathcal K}
+    } &
+    \tnpic[inline, physical=updown]{
+      \tn[box]{\mathcal K} & \tn[box]{\mathcal K} & \tn[box]{\mathcal K}
+    } \\
+    \tnpic[inline, physical=updown]{
+      \tn[box]{\mathcal K} & \tn[box]{\mathcal K} & \tn[box]{\mathcal K}
+    } &
+    \tnpic[inline, physical=updown]{
+      \tn[box]{\mathcal K} & \tn[box]{\mathcal K}
+    }
+    \tnarrow[from={(1,1)}, to={(1,2)}, species=channel]{\mathcal T}
+    \tnarrow[from={(2,1)}, to={(2,2)}, species=channel]{\mathcal S}
+  \end{tenkzcd}
+\]
+
+% T = T_2 T_1 T_0 maps the two-site sector coordinates R_2 to the
+% three-site sector coordinates R_3.  Composition runs left-to-right.
+% Every line has species=channel, so line ink records the common CPTP
+% type; T_0, T_1, and T_2 name the constituent maps.
+\[
+  \begin{tenkzcd}[maps, species={channel}]
+    \mathfrak R_2 &
+    L_k\otimes R_h &
+    (L_k\otimes R_h)\otimes\widehat\Omega_{k,h} &
+    \mathfrak R_3
+    \tnarrow[from={(1,1)}, to={(1,2)}, species=channel]{\mathcal T_0}
+    \tnarrow[from={(1,2)}, to={(1,3)}, species=channel]{\mathcal T_1}
+    \tnarrow[from={(1,3)}, to={(1,4)}, species=channel]{\mathcal T_2}
+  \end{tenkzcd}
+\]
+
+% Four fiberwise maps, one map per row.  Each row spells its complete
+% domain and codomain; the parameters k and h remain symbolic.
+\[
+  \begin{tenkzcd}[maps, species={channel}]
+    \mathfrak R_2 & L_k\otimes R_h \\
+    (L_k\otimes R_h)\otimes(R_k\otimes L_h) & \mathfrak R_2 \\
+    \mathfrak R_3 & L_k\otimes R_h \\
+    (L_k\otimes R_h)\otimes\widehat\Omega_{k,h} & \mathfrak R_3
+    \tnarrow[from={(1,1)}, to={(1,2)}, species=channel]{\mathcal T_0}
+    \tnarrow[from={(2,1)}, to={(2,2)}, species=channel]{\mathcal S_2}
+    \tnarrow[from={(3,1)}, to={(3,2)}, species=channel]{\mathcal S_0}
+    \tnarrow[from={(4,1)}, to={(4,2)}, species=channel]{\mathcal T_2}
+  \end{tenkzcd}
+\]
+
+% T(R_2(K_2(X))) = R_3(K_3(X)); the channel line is the map T and the
+% two endpoints are closed sector-coordinate matrices.
+The refinement identity is
+\(
+  \begin{tenkzcd}[maps, inline, species={channel}]
+    \mathfrak R_2({\cal K}_2(X)) & \mathfrak R_3({\cal K}_3(X))
+    \tnarrow[from={(1,1)}, to={(1,2)}, species=channel]{\mathcal T}
+  \end{tenkzcd}
+\).
+
+\end{document}

--- a/tex/tenkz/tenkz-cd.code.tex
+++ b/tex/tenkz/tenkz-cd.code.tex
@@ -30,6 +30,12 @@
 % rooted, not as one more leaf.
 \def\tenkz@r@treestep{0.55}
 \def\tenkz@r@treeleg{0.35}
+% Typed-map rows are mathematical objects joined by named maps.  One
+% third-pitch column air keeps adjacent object names distinct without
+% turning a short composition into a display-width commutative diagram;
+% half a pitch separates family members as small multiples.
+\def\tenkz@r@mapgap{0.34}
+\def\tenkz@r@maprowsep{0.50}
 
 % ---------- state ----------
 \seq_new:N \l__tenkzcd_items_seq     % parenthesization word, one item each
@@ -62,19 +68,39 @@
 \fp_new:N  \l__tenkzcd_angle_fp
 \seq_new:N \l__tenkzcd_cells_seq
 \seq_new:N \g__tenkzcd_arrows_seq    % {from}{to}{side keys}{label}
+\seq_new:N \g__tenkzcd_maps_seq      % {from}{to}{side}{fused}{role}{species}{label}
 \bool_new:N \g__tenkzcd_inpoly_bool  % a polygon body is being typeset
+\bool_new:N \g__tenkzcd_inmaps_bool  % a typed-map matrix is being typeset
 \tl_new:N  \l__tenkzcd_afrom_tl
 \tl_new:N  \l__tenkzcd_ato_tl
+\tl_new:N  \l__tenkzcd_arole_tl
+\tl_new:N  \l__tenkzcd_aspecies_tl
 \tl_new:N  \l__tenkzcd_body_tl
+\tl_new:N  \l__tenkzcd_mapstyle_tl
+\bool_new:N \l__tenkzcd_afused_bool
+\bool_new:N \l__tenkzcd_maps_bool
+\bool_new:N \l__tenkzcd_mapvalid_bool
+\bool_new:N \l__tenkzcd_mapmatrixvalid_bool
+\seq_new:N \l__tenkzcd_maprows_seq
+\seq_new:N \l__tenkzcd_mapcells_seq
+\int_new:N \l__tenkzcd_maprows_int
+\int_new:N \l__tenkzcd_mapcols_int
+\int_new:N \l__tenkzcd_fromrow_int
+\int_new:N \l__tenkzcd_fromcol_int
+\int_new:N \l__tenkzcd_torow_int
+\int_new:N \l__tenkzcd_tocol_int
+\seq_new:N \l__tenkzcd_addr_seq
 
 % ---------- keys ----------
 \pgfkeys{
   /tenkz/cd/.is~family,
   /tenkz/cd/polygon/.code={\int_set:Nn \l__tenkzcd_ngon_int {#1}},
+  /tenkz/cd/maps/.code={\bool_set_true:N \l__tenkzcd_maps_bool},
   /tenkz/cd/radius/.store~in=\l__tenkzcd_radius_tl,
   /tenkz/cd/pitch/.code={\pgfkeys{/tenkz/pitch=#1}},
   /tenkz/cd/compact/.code={\pgfkeys{/tenkz/compact}},
   /tenkz/cd/inline/.code={\pgfkeys{/tenkz/inline}},
+  /tenkz/cd/species/.code={\pgfqkeys{/tenkz}{species={#1}}},
   % the shared forward-to-core plumbing: the glyph policy reads the same
   % in every family, so \tnpic cells inside a cd picture obey it
   /tenkz/cd/tensor~style/.code={\pgfqkeys{/tenkz}{tensor~style=#1}},
@@ -92,6 +118,16 @@
   /tenkz/arrow/.is~family,
   /tenkz/arrow/from/.store~in=\l__tenkzcd_afrom_tl,
   /tenkz/arrow/to/.store~in=\l__tenkzcd_ato_tl,
+  /tenkz/arrow/fused/.code={\bool_set_true:N \l__tenkzcd_afused_bool},
+  /tenkz/arrow/role/.is~choice,
+  /tenkz/arrow/role/operator/.code={\tl_set:Nn \l__tenkzcd_arole_tl {operator}},
+  /tenkz/arrow/role/marked/.code={\tl_set:Nn \l__tenkzcd_arole_tl {marked}},
+  /tenkz/arrow/role/extra/.code={\tl_set:Nn \l__tenkzcd_arole_tl {extra}},
+  /tenkz/arrow/role/passive/.code={\tl_set:Nn \l__tenkzcd_arole_tl {passive}},
+  /tenkz/arrow/species/.code={
+    \tenkz_species_check:n {#1}
+    \tl_set:Nn \l__tenkzcd_aspecies_tl {#1}
+  },
 }
 
 % ---------- the fusion tree ----------
@@ -326,25 +362,66 @@
 \NewDocumentCommand \tnarrow { s O{} m }
   {
     \unskip
-    % polygon-body syntax only: in grid mode the natural mixed-dialect
-    % mistake (tikz-cd's \arrow vs polygon's \tnarrow) used to record an
-    % arrow nothing ever drained -- a silent no-op -- and in running
-    % prose there are no vertices at all.  Both now stop here.
+    % One addressed edge command serves the two declarative cd modes.
+    % Polygon mode draws annotation arrows.  Maps mode admits only the
+    % fixed left-to-right composition edge and draws it as a headless
+    % typed wire.  Raw grid mode keeps tikz-cd's own arrow grammar.
     \bool_if:NTF \g__tenkzcd_inpoly_bool
       {
         \group_begin:
         \tl_clear:N \l__tenkzcd_afrom_tl
         \tl_clear:N \l__tenkzcd_ato_tl
+        \tl_clear:N \l__tenkzcd_arole_tl
+        \tl_clear:N \l__tenkzcd_aspecies_tl
+        \bool_set_false:N \l__tenkzcd_afused_bool
+        \bool_set_true:N \l__tenkzcd_mapvalid_bool
         \tl_if_empty:nF {#2} { \pgfqkeys{/tenkz/arrow}{#2} }
-        \seq_gput_right:Ne \g__tenkzcd_arrows_seq
-          { { \tl_use:N \l__tenkzcd_afrom_tl }{ \tl_use:N \l__tenkzcd_ato_tl }
-            { auto \IfBooleanT {#1} { , swap } }{ \exp_not:n {#3} } }
+        \bool_lazy_or:nnT
+          { ! \tl_if_blank_p:V \l__tenkzcd_arole_tl }
+          {
+            \bool_lazy_or_p:nn
+              { ! \tl_if_blank_p:V \l__tenkzcd_aspecies_tl }
+              { \bool_if_p:N \l__tenkzcd_afused_bool }
+          }
+          {
+            \PackageError{tenkz}{Typed-line~keys~are~not~polygon~arrow~keys}
+              {Use~role,~species,~and~fused~only~in~tenkzcd[maps].}
+            \bool_set_false:N \l__tenkzcd_mapvalid_bool
+          }
+        \bool_if:NT \l__tenkzcd_mapvalid_bool
+          {
+            \seq_gput_right:Ne \g__tenkzcd_arrows_seq
+              { { \tl_use:N \l__tenkzcd_afrom_tl }{ \tl_use:N \l__tenkzcd_ato_tl }
+                { auto \IfBooleanT {#1} { , swap } }{ \exp_not:n {#3} } }
+          }
         \group_end:
       }
       {
-        \PackageError{tenkz}{\string\tnarrow\space outside~a~polygon~
-          body:~it~draws~between~polygon~vertices.~Grid~mode~takes~
-          tikz-cd's~\string\arrow;~prose~has~no~vertices}{}
+        \bool_if:NTF \g__tenkzcd_inmaps_bool
+          {
+            \group_begin:
+            \tl_clear:N \l__tenkzcd_afrom_tl
+            \tl_clear:N \l__tenkzcd_ato_tl
+            \tl_clear:N \l__tenkzcd_arole_tl
+            \tl_clear:N \l__tenkzcd_aspecies_tl
+            \bool_set_false:N \l__tenkzcd_afused_bool
+            \tl_if_empty:nF {#2} { \pgfqkeys{/tenkz/arrow}{#2} }
+            \seq_gput_right:Ne \g__tenkzcd_maps_seq
+              { { \tl_use:N \l__tenkzcd_afrom_tl }
+                { \tl_use:N \l__tenkzcd_ato_tl }
+                { auto \IfBooleanT {#1} { , swap } }
+                { \bool_if:NTF \l__tenkzcd_afused_bool {1}{0} }
+                { \tl_use:N \l__tenkzcd_arole_tl }
+                { \tl_use:N \l__tenkzcd_aspecies_tl }
+                { \exp_not:n {#3} } }
+            \group_end:
+          }
+          {
+            \PackageError{tenkz}{\string\tnarrow\space outside~a~
+              polygon~or~maps~body}{Polygon~mode~addresses~vertices;~
+              maps~mode~addresses~adjacent~matrix~cells;~raw~grid~mode~
+              takes~tikz-cd's~\string\arrow.}
+          }
       }
     \ignorespaces
   }
@@ -384,6 +461,186 @@
       }
   }
 
+% ---------- typed-map rows ----------
+% The matrix supplies object placement.  \tnarrow records maps while the
+% cells are typeset; the deferred pass then joins adjacent objects with
+% the existing wire styles, never an arrow tip.  Requiring (r,c)->(r,c+1)
+% makes composition left-to-right by grammar, not by a decorative head.
+
+\cs_new_protected:Npn \tenkz_cd_map_address:nnNN #1#2#3#4
+  {
+    \tl_set:Ne \l_tmpa_tl { \tl_to_str:n {#2} }
+    \tl_remove_all:Nn \l_tmpa_tl { ~ }
+    \regex_extract_once:nVNTF
+      { \A \( ([0-9]+) , ([0-9]+) \) \Z }
+      \l_tmpa_tl \l__tenkzcd_addr_seq
+      {
+        \int_set:Nn #3 { \seq_item:Nn \l__tenkzcd_addr_seq {2} }
+        \int_set:Nn #4 { \seq_item:Nn \l__tenkzcd_addr_seq {3} }
+      }
+      {
+        \PackageError{tenkz}{Typed-map~#1~address~'#2'~is~not~(row,col)}
+          {Use~from={(1,1)}~and~to={(1,2)}.}
+        \bool_set_false:N \l__tenkzcd_mapvalid_bool
+        \int_zero:N #3
+        \int_zero:N #4
+      }
+  }
+
+\cs_new_protected:Npn \tenkz_cd_map_style:nnnN #1#2#3#4
+  {
+    \str_if_eq:nnTF {#1} {1}
+      { \tl_set:Nn #4 {fused~bond} }
+      { \tl_set:Nn #4 {bond} }
+    \tl_if_blank:nTF {#2}
+      {
+        \tl_if_blank:nF {#3}
+          { \tl_put_right:Nn #4 {, species~#3~bond} }
+      }
+      { \tl_put_right:Nn #4 {, #2~bond} }
+  }
+
+\cs_new_protected:Npn \tenkz_cd_map_path:nnn #1#2#3
+  {
+    \draw[#1]
+      (tenkzmap-\int_use:N\l__tenkzcd_fromrow_int-
+        \int_use:N\l__tenkzcd_fromcol_int.base~east) --
+      node[tn~label, fill=tenkzPaper, #2]
+        {$\tenkz@labelsize #3$}
+      (tenkzmap-\int_use:N\l__tenkzcd_torow_int-
+        \int_use:N\l__tenkzcd_tocol_int.base~west);
+  }
+
+\cs_new_protected:Npn \tenkz_cd_draw_map:nnnnnnn #1#2#3#4#5#6#7
+  {
+    \bool_set_true:N \l__tenkzcd_mapvalid_bool
+    \tenkz_cd_map_address:nnNN {from}{#1}
+      \l__tenkzcd_fromrow_int \l__tenkzcd_fromcol_int
+    \tenkz_cd_map_address:nnNN {to}{#2}
+      \l__tenkzcd_torow_int \l__tenkzcd_tocol_int
+    \bool_if:NT \l__tenkzcd_mapvalid_bool
+      {
+        \bool_lazy_or:nnT
+          { \int_compare_p:nNn {\l__tenkzcd_fromrow_int} < {1} }
+          { \int_compare_p:nNn {\l__tenkzcd_fromrow_int} > {\l__tenkzcd_maprows_int} }
+          { \PackageError{tenkz}{Typed-map~from=#1~is~outside~the~matrix}{}
+            \bool_set_false:N \l__tenkzcd_mapvalid_bool }
+        \bool_lazy_or:nnT
+          { \int_compare_p:nNn {\l__tenkzcd_torow_int} < {1} }
+          { \int_compare_p:nNn {\l__tenkzcd_torow_int} > {\l__tenkzcd_maprows_int} }
+          { \PackageError{tenkz}{Typed-map~to=#2~is~outside~the~matrix}{}
+            \bool_set_false:N \l__tenkzcd_mapvalid_bool }
+        \bool_lazy_or:nnT
+          { \int_compare_p:nNn {\l__tenkzcd_fromcol_int} < {1} }
+          { \int_compare_p:nNn {\l__tenkzcd_fromcol_int} > {\l__tenkzcd_mapcols_int} }
+          { \PackageError{tenkz}{Typed-map~from=#1~is~outside~the~matrix}{}
+            \bool_set_false:N \l__tenkzcd_mapvalid_bool }
+        \bool_lazy_or:nnT
+          { \int_compare_p:nNn {\l__tenkzcd_tocol_int} < {1} }
+          { \int_compare_p:nNn {\l__tenkzcd_tocol_int} > {\l__tenkzcd_mapcols_int} }
+          { \PackageError{tenkz}{Typed-map~to=#2~is~outside~the~matrix}{}
+            \bool_set_false:N \l__tenkzcd_mapvalid_bool }
+      }
+    \bool_if:NT \l__tenkzcd_mapvalid_bool
+      {
+        \bool_lazy_or:nnT
+          { ! \int_compare_p:nNn {\l__tenkzcd_fromrow_int} = {\l__tenkzcd_torow_int} }
+          { ! \int_compare_p:nNn {\l__tenkzcd_tocol_int} =
+              {\l__tenkzcd_fromcol_int + 1} }
+          {
+            \PackageError{tenkz}{Typed-map~#1~to~#2~does~not~follow~the~
+              composition~axis}{A~map~must~run~from~(r,c)~to~(r,c+1).~
+              Use~another~row~for~another~map.}
+            \bool_set_false:N \l__tenkzcd_mapvalid_bool
+          }
+        \bool_lazy_and:nnT
+          { \tl_if_blank_p:n {#5} }
+          { \tl_if_blank_p:n {#6} }
+          {
+            \PackageError{tenkz}{Typed-map~#1~to~#2~has~no~line~type}
+              {Give~the~map~a~role=...~or~a~declared~species=....}
+            \bool_set_false:N \l__tenkzcd_mapvalid_bool
+          }
+        \bool_lazy_and:nnT
+          { ! \tl_if_blank_p:n {#5} }
+          { ! \tl_if_blank_p:n {#6} }
+          {
+            \PackageError{tenkz}{Typed-map~#1~to~#2~has~two~line~types}
+              {Choose~exactly~one~of~role=...~and~species=....}
+            \bool_set_false:N \l__tenkzcd_mapvalid_bool
+          }
+      }
+    \bool_if:NT \l__tenkzcd_mapvalid_bool
+      {
+        \tenkz_cd_map_style:nnnN {#4}{#5}{#6} \l__tenkzcd_mapstyle_tl
+        \exp_args:NV \tenkz_cd_map_path:nnn
+          \l__tenkzcd_mapstyle_tl {#3}{#7}
+        \tenkz@event{cdmap|picture=\the\tenkz@pictureid|
+          from=\int_use:N\l__tenkzcd_fromrow_int-
+               \int_use:N\l__tenkzcd_fromcol_int|
+          to=\int_use:N\l__tenkzcd_torow_int-
+             \int_use:N\l__tenkzcd_tocol_int|
+          fused=#4|
+          role=\tl_if_blank:nTF {#5}{none}{#5}|
+          species=\tl_if_blank:nTF {#6}{none}{#6}}
+      }
+  }
+
+\cs_new_protected:Npn \tenkz_cd_measure_map:n #1
+  {
+    \bool_set_true:N \l__tenkzcd_mapmatrixvalid_bool
+    \seq_set_split:Nnn \l__tenkzcd_maprows_seq { \\ } {#1}
+    \seq_get_right:NNT \l__tenkzcd_maprows_seq \l_tmpa_tl
+      { \tl_if_blank:VT \l_tmpa_tl
+          { \seq_pop_right:NN \l__tenkzcd_maprows_seq \l_tmpa_tl } }
+    \int_set:Nn \l__tenkzcd_maprows_int
+      { \seq_count:N \l__tenkzcd_maprows_seq }
+    \int_zero:N \l__tenkzcd_mapcols_int
+    \seq_map_indexed_inline:Nn \l__tenkzcd_maprows_seq
+      {
+        \seq_set_split:Nnn \l__tenkzcd_mapcells_seq { & } {##2}
+        \seq_map_indexed_inline:Nn \l__tenkzcd_mapcells_seq
+          { \tenkz@event{cdobject|picture=\the\tenkz@pictureid|
+              cell=##1-####1} }
+        \int_compare:nNnTF {##1} = {1}
+          { \int_set:Nn \l__tenkzcd_mapcols_int
+              { \seq_count:N \l__tenkzcd_mapcells_seq } }
+          {
+            \int_compare:nNnF { \seq_count:N \l__tenkzcd_mapcells_seq }
+              = { \l__tenkzcd_mapcols_int }
+              {
+                \PackageError{tenkz}{Typed-map~rows~have~unequal~object~
+                  counts}{Every~small~multiple~uses~the~same~object~columns.}
+                \bool_set_false:N \l__tenkzcd_mapmatrixvalid_bool
+              }
+          }
+      }
+  }
+
+\cs_new_protected:Npn \tenkz_cd_maps:nn #1#2
+  {
+    \tenkz_cd_measure_map:n {#2}
+    \seq_gclear:N \g__tenkzcd_maps_seq
+    \bool_if:NT \l__tenkzcd_mapmatrixvalid_bool
+      {
+        \tl_set:Nn \l__tenkzcd_body_tl {#2}
+        \tl_replace_all:Nnn \l__tenkzcd_body_tl { & } { \pgfmatrixnextcell }
+        \tl_put_right:Nn \l__tenkzcd_body_tl { \\ }
+        \bool_gset_true:N \g__tenkzcd_inmaps_bool
+        \begin{tikzpicture}[tenkz~every~picture, tenkz~cd~baseline]
+          \matrix (tenkzmap)
+            [matrix~of~math~nodes,
+             column~sep=\tenkz@dim{\tenkz@r@mapgap},
+             row~sep=\tenkz@dim{\tenkz@r@maprowsep},
+             nodes={inner~sep=1pt}, #1]
+            { \tl_use:N \l__tenkzcd_body_tl };
+          \seq_map_inline:Nn \g__tenkzcd_maps_seq
+            { \tenkz_cd_draw_map:nnnnnnn ##1 }
+        \end{tikzpicture}
+        \bool_gset_false:N \g__tenkzcd_inmaps_bool
+      }
+  }
+
 % ---------- the environment ----------
 \NewDocumentEnvironment { tenkzcd } { O{} +b }
   { \tenkz_cd_render:nn {#1} {#2} } { }
@@ -392,15 +649,28 @@
   {
     \group_begin:
     \int_zero:N \l__tenkzcd_ngon_int
+    \bool_set_false:N \l__tenkzcd_maps_bool
     \tl_set:Nn \l__tenkzcd_radius_tl {30mm}
     \tl_clear:N \l__tenkzcd_pass_tl
     \tl_if_empty:nF {#1} { \pgfqkeys{/tenkz/cd}{#1} }
     \seq_gclear:N \g__tenkzcd_arrows_seq
     \tenkz@beginpicture{cd}
     \tenkz_cd_read_axis:
-    \int_compare:nNnTF { \l__tenkzcd_ngon_int } > {0}
-      { \exp_args:NV \tenkz_cd_polygon:nn \l__tenkzcd_pass_tl {#2} }
-      { \exp_args:NV \tenkz_cd_grid:nn    \l__tenkzcd_pass_tl {#2} }
+    \bool_if:NTF \l__tenkzcd_maps_bool
+      {
+        \int_compare:nNnTF { \l__tenkzcd_ngon_int } > {0}
+          {
+            \PackageError{tenkz}{tenkzcd~cannot~be~both~maps~and~polygon}
+              {Maps~have~one~fixed~composition~axis;~polygon~edges~are~
+               annotation~arrows.}
+          }
+          { \exp_args:NV \tenkz_cd_maps:nn \l__tenkzcd_pass_tl {#2} }
+      }
+      {
+        \int_compare:nNnTF { \l__tenkzcd_ngon_int } > {0}
+          { \exp_args:NV \tenkz_cd_polygon:nn \l__tenkzcd_pass_tl {#2} }
+          { \exp_args:NV \tenkz_cd_grid:nn    \l__tenkzcd_pass_tl {#2} }
+      }
     \group_end:
   }
 


### PR DESCRIPTION
## Summary

- add `tenkzcd[maps]`, a modeless typed-map grammar with a fixed left-to-right composition axis, headless strokes, and role- or species-typed line ink
- keep map strokes outside the tensor contraction graph while allowing complete `\tnpic` networks as domain and codomain objects
- document and render the CPSV16 refinement/coarsening examples, including the two-site/three-site `\mathcal T` and `\mathcal S` network pair
- replace the numbered regrouping/refinement arrow figures with compact mathematical displays
- audit `cdobject` and `cdmap` events, including intentional object reuse within a small-multiple family

## Why

The existing `tenkzcd` tier provided ordinary commutative-diagram arrows, but it could not express the typed families used in the MPDO refinement argument without introducing a visually foreign arrow language. This adds the missing genre while preserving the tensor-network wire dictionary and making the distinction between a morphism and a contraction explicit.

## Validation

- all 18 `tex/tenkz/examples/*.tex` files compile
- all example audits report 0 hard errors; `typed-maps.tex` reports 0 advisories
- `python3 scripts/tenkz_lint.py` on all changed TeX sources: 0 findings
- `docs/tenkz/manual2.tex`: two-pass XeLaTeX build, 41 pages
- `leanblueprint pdf`: 632 pages
- malformed direction, missing/double line type, unequal rows, out-of-range addresses, and mixed map/polygon mode fail with curated package errors
- rendered comparison against `MPDO_TSKKK.png`, plus inspection of blueprint pages 573 and 583
- `git diff --check`

Closes LionSR/tenkz#19

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `tenkzcd` rendering and audit semantics; blueprint figure removals change published layout but math content is preserved in a new visual form.
> 
> **Overview**
> Introduces **`tenkzcd[maps]`**, a new commutative-diagram mode where objects sit in a matrix and **headless** `\tnarrow` strokes (with `role=` or `species=`) denote maps along a fixed **left-to-right** composition axis—distinct from tensor contractions and from tikz-cd arrowheads. Implementation in `tenkz-cd.code.tex` validates addresses `(r,c)→(r,c+1)`, line types, and row widths; emits **`cdobject`** / **`cdmap`** events; **`maps`** is mutually exclusive with **`polygon`**.
> 
> **Blueprint** chapters drop numbered `figure`/`tikzcd` panels for MPDO regrouping, refinement \(\mathcal T=\mathcal T_2\mathcal T_1\mathcal T_0\), and closure identities in favor of displayed **`tenkzcd[maps, species={channel}]`** math.
> 
> **Docs** (`DESIGN.md`, `USAGE.md`, manual/tutorial/reference) document the grammar, CPSV examples, and map spacing metrics. **`scripts/tenkz_audit.py`** learns the new CD events and skips false “repeated topology” advisories when the same object repeats across map-family rows inside one parent `tenkzcd`. New **`tex/tenkz/examples/typed-maps.tex`** demonstrates refinement/coarsening between `\tnpic` tensor objects and sector coordinates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba3b67053f2297cda9a77b03d74d34b1b818c269. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->