### PR TITLE
feat(Channel/PetzRecovery): complete the support Petz map

### DIFF
--- a/TNLean/Channel/KrausCPTP.lean
+++ b/TNLean/Channel/KrausCPTP.lean
@@ -140,6 +140,41 @@ theorem IsKrausCPTP.trace_map
   rw [hA]
   exact kraus_tp_of_sum_conjTranspose_mul A hA_norm X
 
+/-- A completely positive Kraus map that preserves the matrix trace is
+trace-preserving completely positive. -/
+theorem isKrausCPTP_of_isKrausCP_trace_preserving
+    {α β : Type*} [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]
+    {S : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ} (hS : IsKrausCP S)
+    (htrace : ∀ X, Matrix.trace (S X) = Matrix.trace X) : IsKrausCPTP S := by
+  obtain ⟨r, A, hA⟩ := hS
+  refine ⟨r, A, hA, ?_⟩
+  apply (Matrix.ext_iff_trace_mul_right).2
+  intro X
+  rw [Matrix.one_mul]
+  calc
+    Matrix.trace ((∑ i, (A i)ᴴ * A i) * X) =
+        ∑ i, Matrix.trace ((A i)ᴴ * A i * X) := by
+      rw [Matrix.sum_mul, Matrix.trace_sum]
+    _ = ∑ i, Matrix.trace (A i * X * (A i)ᴴ) := by
+      apply Finset.sum_congr rfl
+      intro i _
+      exact (Matrix.trace_mul_cycle (A i) X (A i)ᴴ).symm
+    _ = Matrix.trace (S X) := by rw [hA X, Matrix.trace_sum]
+    _ = Matrix.trace X := htrace X
+
+/-- The sum of two completely positive maps in rectangular Kraus form is
+completely positive. -/
+theorem isKrausCP_add
+    {α β : Type*} [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]
+    {S T : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ}
+    (hS : IsKrausCP S) (hT : IsKrausCP T) : IsKrausCP (S + T) := by
+  obtain ⟨r, A, hA⟩ := hS
+  obtain ⟨s, B, hB⟩ := hT
+  refine ⟨r + s, Fin.append A B, ?_⟩
+  intro X
+  rw [LinearMap.add_apply, hA X, hB X, Fin.sum_univ_add]
+  simp
+
 /-- The identity map is trace-preserving completely positive; the single Kraus
 operator is the identity matrix. -/
 theorem isKrausCPTP_id {α : Type*} [Fintype α] [DecidableEq α] :

--- a/TNLean/Channel/KrausCPTP.lean
+++ b/TNLean/Channel/KrausCPTP.lean
@@ -29,8 +29,11 @@ dimensions.
 * `IsKrausCP.map_posSemidef`: a Kraus CP map preserves positive
   semidefiniteness.
 * `IsKrausCPTP.trace_map`: a map satisfying `IsKrausCPTP` preserves trace.
+* `isKrausCPTP_of_isKrausCP_trace_preserving`: a Kraus CP map that preserves
+  trace is Kraus CPTP.
 * `IsKrausCPTP.map_posSemidef`: a map satisfying `IsKrausCPTP` preserves
   positive semidefiniteness.
+* `isKrausCP_add`: sums of rectangular Kraus CP maps are Kraus CP.
 * `isKrausCPTP_id`: the identity map is trace-preserving completely positive.
 * `isKrausCPTP_of_singleKraus`: conjugation by an isometry is trace-preserving
   completely positive.
@@ -163,7 +166,9 @@ theorem isKrausCPTP_of_isKrausCP_trace_preserving
     _ = Matrix.trace X := htrace X
 
 /-- The sum of two completely positive maps in rectangular Kraus form is
-completely positive. -/
+completely positive.  This is the dimension-changing counterpart of
+`IsCPMap.add`; concatenating the two rectangular Kraus families makes the
+codomain dimensions explicit. -/
 theorem isKrausCP_add
     {α β : Type*} [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]
     {S T : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ}

--- a/TNLean/Channel/KrausCPTP.lean
+++ b/TNLean/Channel/KrausCPTP.lean
@@ -33,7 +33,7 @@ dimensions.
   trace is Kraus CPTP.
 * `IsKrausCPTP.map_posSemidef`: a map satisfying `IsKrausCPTP` preserves
   positive semidefiniteness.
-* `isKrausCP_add`: sums of rectangular Kraus CP maps are Kraus CP.
+* `IsKrausCP.add`: sums of rectangular Kraus CP maps are Kraus CP.
 * `isKrausCPTP_id`: the identity map is trace-preserving completely positive.
 * `isKrausCPTP_of_singleKraus`: conjugation by an isometry is trace-preserving
   completely positive.
@@ -169,7 +169,7 @@ theorem isKrausCPTP_of_isKrausCP_trace_preserving
 completely positive.  This is the dimension-changing counterpart of
 `IsCPMap.add`; concatenating the two rectangular Kraus families makes the
 codomain dimensions explicit. -/
-theorem isKrausCP_add
+theorem IsKrausCP.add
     {α β : Type*} [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]
     {S T : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ}
     (hS : IsKrausCP S) (hT : IsKrausCP T) : IsKrausCP (S + T) := by

--- a/TNLean/Channel/PartialTrace.lean
+++ b/TNLean/Channel/PartialTrace.lean
@@ -36,6 +36,8 @@ Proposition 2.1) and for reduced states on contiguous tensor factors.
 * `Matrix.traceRight_apply`: elementwise formula for `tr_B`
 * `Matrix.trace_partialTraceRight`: the full trace is preserved by the general
   right partial trace
+* `Matrix.trace_partialTraceLeft`: the full trace is preserved by the general
+  left partial trace
 * `Matrix.partialTraceRight_kronecker`: the right partial trace of a Kronecker
   product
 * `Matrix.partialTraceRightAlong`: the partial trace after choosing a product
@@ -217,6 +219,12 @@ noncomputable def partialTraceLeft (X : Matrix (α × β) (α × β) ℂ) :
 @[simp]
 theorem partialTraceLeft_apply (X : Matrix (α × β) (α × β) ℂ) (i j : β) :
     partialTraceLeft X i j = ∑ k : α, X (k, i) (k, j) := rfl
+
+/-- The trace is invariant under the partial trace over the first factor. -/
+theorem trace_partialTraceLeft [Fintype β] (X : Matrix (α × β) (α × β) ℂ) :
+    (partialTraceLeft X).trace = X.trace := by
+  simp only [Matrix.trace, Matrix.diag, partialTraceLeft_apply]
+  rw [Finset.sum_comm, Fintype.sum_prod_type]
 
 /-- The partial trace over the first factor preserves Hermiticity. -/
 theorem partialTraceLeft_isHermitian {X : Matrix (α × β) (α × β) ℂ}

--- a/TNLean/Channel/PetzRecovery.lean
+++ b/TNLean/Channel/PetzRecovery.lean
@@ -8,7 +8,7 @@ import TNLean.Channel.KrausCPTP
 import TNLean.Channel.MarginalSupportAbsorption
 
 /-!
-# The support Petz transpose map for a partial trace
+# A trace-preserving Petz transpose channel for a partial trace
 
 This file constructs the Petz transpose map associated with a positive
 semidefinite reference matrix and the partial trace over a right tensor factor.
@@ -24,8 +24,19 @@ reference matrix.
 * `Matrix.partialTraceRightPetzMap`: the raw Petz transpose map for the right
   partial trace.
 * `Matrix.partialTraceRightPetzMap_isKrausCP`: complete positivity.
+* `Matrix.partialTraceRightPetzMap_trace`: the support trace identity.
+* `Matrix.partialTraceRightPetzComplementMap`: the complementary
+  measure-and-prepare term.
+* `Matrix.partialTraceRightPetzComplementMap_isKrausCP`: complete positivity
+  of the complementary term.
+* `Matrix.partialTraceRightPetzComplementMap_trace`: the complementary trace
+  identity.
 * `Matrix.partialTraceRightPetzChannel`: a trace-preserving completely positive
   extension of the support formula.
+* `Matrix.partialTraceRightPetzChannel_isKrausCPTP`: the completed map is a
+  channel for a normalized reference.
+* `Matrix.partialTraceRightPetzChannel_apply_of_supported`: agreement with the
+  support formula on supported inputs.
 * `Matrix.partialTraceRightPetzMap_partialTraceRight`: recovery of the
   reference matrix.
 * `Matrix.partialTraceRightPetzChannel_partialTraceRight`: recovery by the

--- a/TNLean/Channel/PetzRecovery.lean
+++ b/TNLean/Channel/PetzRecovery.lean
@@ -10,12 +10,13 @@ import TNLean.Channel.MarginalSupportAbsorption
 /-!
 # The support Petz transpose map for a partial trace
 
-This file constructs the raw Petz transpose map associated with a positive
+This file constructs the Petz transpose map associated with a positive
 semidefinite reference matrix and the partial trace over a right tensor factor.
-The source formula is defined on the support of the partial trace of the
-reference.  Accordingly, the map here is proved completely positive and is
-proved to recover its reference matrix, but no global trace-preservation claim
-is made.
+It first proves the source formula on the support of the reference marginal,
+then completes it on the orthogonal complement by a measure-and-prepare term.
+For a normalized reference, the completed map is trace-preserving completely
+positive, agrees with the source formula on supported inputs, and recovers the
+reference matrix.
 
 ## Main declarations
 
@@ -23,8 +24,12 @@ is made.
 * `Matrix.partialTraceRightPetzMap`: the raw Petz transpose map for the right
   partial trace.
 * `Matrix.partialTraceRightPetzMap_isKrausCP`: complete positivity.
+* `Matrix.partialTraceRightPetzChannel`: a trace-preserving completely positive
+  extension of the support formula.
 * `Matrix.partialTraceRightPetzMap_partialTraceRight`: recovery of the
   reference matrix.
+* `Matrix.partialTraceRightPetzChannel_partialTraceRight`: recovery by the
+  completed channel.
 
 ## References
 
@@ -153,6 +158,186 @@ theorem partialTraceRightPetzMap_isKrausCP
     · exact preparationMap_isKrausCP _ Matrix.PosSemidef.one
   · exact singleKrausMap_isKrausCP _
 
+/-- The raw partial-trace Petz map preserves the trace on the support of the
+reference marginal:
+\[
+  \operatorname{tr}(\mathcal R_\sigma(X))
+    =\operatorname{tr}(P_{\operatorname{tr}_R\sigma}X).
+\]
+
+This is the support trace identity for the transpose channel in
+Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2,
+Theorem 3 and equation (8).  It does not assert trace preservation on the
+orthogonal complement of the marginal support. -/
+theorem partialTraceRightPetzMap_trace
+    (σ : Matrix (L × R) (L × R) ℂ) (hσ : σ.PosSemidef)
+    (X : Matrix L L ℂ) :
+    Matrix.trace (partialTraceRightPetzMap σ hσ X) =
+      Matrix.trace
+        ((PosSemidef.partialTraceRight hσ).isHermitian.supportProj * X) := by
+  let hτ := PosSemidef.partialTraceRight hσ
+  let I := hτ.supportInvSqrt
+  let S := hσ.isHermitian.cfc Real.sqrt
+  have hS_sq : S * S = σ := hσ.cfc_sqrt_mul_self
+  have hInv : I * partialTraceRight σ * I = hτ.isHermitian.supportProj :=
+    hτ.supportInvSqrt_mul_self_mul_supportInvSqrt
+  rw [partialTraceRightPetzMap_apply]
+  change Matrix.trace (S * leftKroneckerEmbed (n := R) (I * X * I) * S) =
+    Matrix.trace (hτ.isHermitian.supportProj * X)
+  calc
+    Matrix.trace (S * leftKroneckerEmbed (n := R) (I * X * I) * S) =
+        Matrix.trace (leftKroneckerEmbed (n := R) (I * X * I) * (S * S)) := by
+      simpa only [Matrix.mul_assoc] using
+        (Matrix.trace_mul_cycle (leftKroneckerEmbed (n := R) (I * X * I)) S S).symm
+    _ = Matrix.trace
+        (leftKroneckerEmbed (n := R) (I * X * I) * σ) := by rw [hS_sq]
+    _ = Matrix.trace ((I * X * I) * partialTraceRight σ) := by
+      rw [trace_leftKroneckerEmbed_mul]
+    _ = Matrix.trace (hτ.isHermitian.supportProj * X) := by
+      calc
+        Matrix.trace ((I * X * I) * partialTraceRight σ) =
+            Matrix.trace ((I * partialTraceRight σ) * I * X) := by
+          simpa only [Matrix.mul_assoc] using
+            Matrix.trace_mul_cycle I X (I * partialTraceRight σ)
+        _ = Matrix.trace (hτ.isHermitian.supportProj * X) := by rw [← hInv]
+
+/-- The complementary measure-and-prepare term for the partial-trace Petz
+map.  It measures the input on the orthogonal complement of the reference
+marginal support and prepares the other marginal of the reference matrix.
+
+This is the standard trace-preserving completion of the support transpose
+channel from Hayden--Jozsa--Petz--Winter,
+arXiv:quant-ph/0304007v2, Theorem 3 and equation (8). -/
+noncomputable def partialTraceRightPetzComplementMap
+    (σ : Matrix (L × R) (L × R) ℂ) (hσ : σ.PosSemidef) :
+    Matrix L L ℂ →ₗ[ℂ] Matrix (L × R) (L × R) ℂ :=
+  preparationMap (partialTraceLeft σ) ∘ₗ
+    singleKrausMap
+      (1 - (PosSemidef.partialTraceRight hσ).isHermitian.supportProj)
+
+/-- The complementary term has the expected measure-and-prepare formula for
+the trace-preserving completion of Hayden--Jozsa--Petz--Winter,
+arXiv:quant-ph/0304007v2, Theorem 3 and equation (8). -/
+theorem partialTraceRightPetzComplementMap_apply
+    (σ : Matrix (L × R) (L × R) ℂ) (hσ : σ.PosSemidef)
+    (X : Matrix L L ℂ) :
+    partialTraceRightPetzComplementMap σ hσ X =
+      ((1 - (PosSemidef.partialTraceRight hσ).isHermitian.supportProj) * X *
+          (1 - (PosSemidef.partialTraceRight hσ).isHermitian.supportProj)) ⊗ₖ
+        partialTraceLeft σ := by
+  simp [partialTraceRightPetzComplementMap, preparationMap,
+    (PosSemidef.partialTraceRight hσ).isHermitian.one_sub_supportProj_isHermitian.eq]
+
+/-- The complementary measure-and-prepare term in the trace-preserving
+completion of Hayden--Jozsa--Petz--Winter,
+arXiv:quant-ph/0304007v2, Theorem 3, is completely positive. -/
+theorem partialTraceRightPetzComplementMap_isKrausCP
+    (σ : Matrix (L × R) (L × R) ℂ) (hσ : σ.PosSemidef) :
+    IsKrausCP (partialTraceRightPetzComplementMap σ hσ) := by
+  apply isKrausCP_comp
+  · exact singleKrausMap_isKrausCP _
+  · exact preparationMap_isKrausCP _ hσ.partialTraceLeft
+
+/-- The complementary term contributes the trace on the orthogonal complement
+of the reference marginal support when the reference matrix has trace one.
+
+This is the trace bookkeeping for the trace-preserving completion of the
+support transpose channel in Hayden--Jozsa--Petz--Winter,
+arXiv:quant-ph/0304007v2, Theorem 3. -/
+theorem partialTraceRightPetzComplementMap_trace
+    (σ : Matrix (L × R) (L × R) ℂ) (hσ : σ.PosSemidef)
+    (hσtrace : Matrix.trace σ = 1) (X : Matrix L L ℂ) :
+    Matrix.trace (partialTraceRightPetzComplementMap σ hσ X) =
+      Matrix.trace
+        ((1 - (PosSemidef.partialTraceRight hσ).isHermitian.supportProj) * X) := by
+  let Q := 1 - (PosSemidef.partialTraceRight hσ).isHermitian.supportProj
+  have hQidem : Q * Q = Q :=
+    (PosSemidef.partialTraceRight hσ).isHermitian.one_sub_supportProj_idem
+  rw [partialTraceRightPetzComplementMap_apply, Matrix.trace_kronecker,
+    trace_partialTraceLeft, hσtrace, mul_one]
+  change Matrix.trace (Q * X * Q) = Matrix.trace (Q * X)
+  calc
+    Matrix.trace (Q * X * Q) = Matrix.trace ((Q * Q) * X) := by
+      simpa only [Matrix.mul_assoc] using Matrix.trace_mul_cycle Q X Q
+    _ = Matrix.trace (Q * X) := by rw [hQidem]
+
+/-- A trace-preserving completion of the partial-trace Petz transpose map.
+It agrees with the support formula on inputs supported on the reference
+marginal and sends the complementary weight to a fixed prepared state.
+
+This is the channel extension of the transpose map used in
+Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2,
+Theorem 3 and equation (8). -/
+noncomputable def partialTraceRightPetzChannel
+    (σ : Matrix (L × R) (L × R) ℂ) (hσ : σ.PosSemidef) :
+    Matrix L L ℂ →ₗ[ℂ] Matrix (L × R) (L × R) ℂ :=
+  partialTraceRightPetzMap σ hσ + partialTraceRightPetzComplementMap σ hσ
+
+/-- The completed partial-trace Petz map is trace-preserving and completely
+positive when the reference matrix has trace one.
+
+This is the channel completion of the support transpose map in
+Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2,
+Theorem 3 and equation (8). -/
+theorem partialTraceRightPetzChannel_isKrausCPTP
+    (σ : Matrix (L × R) (L × R) ℂ) (hσ : σ.PosSemidef)
+    (hσtrace : Matrix.trace σ = 1) :
+    IsKrausCPTP (partialTraceRightPetzChannel σ hσ) := by
+  apply isKrausCPTP_of_isKrausCP_trace_preserving
+  · exact isKrausCP_add
+      (partialTraceRightPetzMap_isKrausCP σ hσ)
+      (partialTraceRightPetzComplementMap_isKrausCP σ hσ)
+  · intro X
+    rw [partialTraceRightPetzChannel, LinearMap.add_apply, Matrix.trace_add,
+      partialTraceRightPetzMap_trace,
+      partialTraceRightPetzComplementMap_trace σ hσ hσtrace]
+    let P := (PosSemidef.partialTraceRight hσ).isHermitian.supportProj
+    change Matrix.trace (P * X) + Matrix.trace ((1 - P) * X) = Matrix.trace X
+    calc
+      Matrix.trace (P * X) + Matrix.trace ((1 - P) * X) =
+          Matrix.trace (P * X + (1 - P) * X) := by rw [Matrix.trace_add]
+      _ = Matrix.trace ((P + (1 - P)) * X) := by rw [Matrix.add_mul]
+      _ = Matrix.trace X := by simp
+
+/-- On an input supported on the reference marginal, the completed channel
+agrees with the raw support Petz formula.
+
+This is the support restriction in Hayden--Jozsa--Petz--Winter,
+arXiv:quant-ph/0304007v2, Theorem 3 and equation (8). -/
+theorem partialTraceRightPetzChannel_apply_of_supported
+    (σ : Matrix (L × R) (L × R) ℂ) (hσ : σ.PosSemidef)
+    (X : Matrix L L ℂ)
+    (hX :
+      (PosSemidef.partialTraceRight hσ).isHermitian.supportProj * X *
+        (PosSemidef.partialTraceRight hσ).isHermitian.supportProj = X) :
+    partialTraceRightPetzChannel σ hσ X = partialTraceRightPetzMap σ hσ X := by
+  let P := (PosSemidef.partialTraceRight hσ).isHermitian.supportProj
+  let Q : Matrix L L ℂ := 1 - P
+  have hPidem : P * P = P :=
+    (PosSemidef.partialTraceRight hσ).isHermitian.supportProj_idem
+  have hPX : P * X = X := by
+    calc
+      P * X = P * (P * X * P) := by rw [hX]
+      _ = (P * P) * X * P := by simp only [Matrix.mul_assoc]
+      _ = P * X * P := by rw [hPidem]
+      _ = X := hX
+  have hXP : X * P = X := by
+    calc
+      X * P = (P * X * P) * P := by rw [hX]
+      _ = P * X * (P * P) := by simp only [Matrix.mul_assoc]
+      _ = P * X * P := by rw [hPidem]
+      _ = X := hX
+  have hQXQ : Q * X * Q = 0 := by
+    rw [show Q = 1 - P from rfl]
+    calc
+      (1 - P) * X * (1 - P) = X - P * X - X * P + P * X * P := by
+        noncomm_ring
+      _ = 0 := by rw [hPX, hXP]; abel
+  rw [partialTraceRightPetzChannel, LinearMap.add_apply,
+    partialTraceRightPetzComplementMap_apply]
+  change partialTraceRightPetzMap σ hσ X + (Q * X * Q) ⊗ₖ partialTraceLeft σ = _
+  rw [hQXQ, zero_kronecker, add_zero]
+
 /-- The raw partial-trace Petz map recovers its positive-semidefinite reference
 matrix:
 `R_σ (tr_R σ) = σ`.
@@ -221,6 +406,25 @@ theorem partialTraceRightPetzMap_partialTraceRight
     S * P * S = S * (1 - Q) * S := by rw [hQ]; congr 2; abel
     _ = S * S - S * Q * S := by noncomm_ring
     _ = σ := by rw [hQSQ, sub_zero, hS_sq]
+
+/-- The completed partial-trace Petz channel recovers its reference matrix
+from the reference marginal.
+
+This is the reference-recovery identity for the transpose channel in
+Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2,
+Theorem 3 and equation (8). -/
+theorem partialTraceRightPetzChannel_partialTraceRight
+    (σ : Matrix (L × R) (L × R) ℂ) (hσ : σ.PosSemidef) :
+    partialTraceRightPetzChannel σ hσ (partialTraceRight σ) = σ := by
+  rw [partialTraceRightPetzChannel_apply_of_supported]
+  · exact partialTraceRightPetzMap_partialTraceRight σ hσ
+  · let hτ := PosSemidef.partialTraceRight hσ
+    calc
+      hτ.isHermitian.supportProj * partialTraceRight σ *
+          hτ.isHermitian.supportProj =
+          partialTraceRight σ * hτ.isHermitian.supportProj := by
+            rw [hτ.isHermitian.supportProj_mul_self]
+      _ = partialTraceRight σ := hτ.isHermitian.mul_supportProj_self
 
 end PartialTrace
 

--- a/TNLean/Channel/PetzRecovery.lean
+++ b/TNLean/Channel/PetzRecovery.lean
@@ -216,9 +216,10 @@ theorem partialTraceRightPetzMap_trace
 map.  It measures the input on the orthogonal complement of the reference
 marginal support and prepares the other marginal of the reference matrix.
 
-This is the standard trace-preserving completion of the support transpose
-channel from Hayden--Jozsa--Petz--Winter,
-arXiv:quant-ph/0304007v2, Theorem 3 and equation (8). -/
+This file chooses this measure-and-prepare term to complete the support
+transpose formula of Hayden--Jozsa--Petz--Winter,
+arXiv:quant-ph/0304007v2, Theorem 3 and equation (8).  The cited equation gives
+the support formula, not this particular complementary extension. -/
 noncomputable def partialTraceRightPetzComplementMap
     (σ : Matrix (L × R) (L × R) ℂ) (hσ : σ.PosSemidef) :
     Matrix L L ℂ →ₗ[ℂ] Matrix (L × R) (L × R) ℂ :=
@@ -226,9 +227,10 @@ noncomputable def partialTraceRightPetzComplementMap
     singleKrausMap
       (1 - (PosSemidef.partialTraceRight hσ).isHermitian.supportProj)
 
-/-- The complementary term has the expected measure-and-prepare formula for
-the trace-preserving completion of Hayden--Jozsa--Petz--Winter,
-arXiv:quant-ph/0304007v2, Theorem 3 and equation (8). -/
+/-- The complementary term has the measure-and-prepare formula chosen here to
+complete the support formula of Hayden--Jozsa--Petz--Winter,
+arXiv:quant-ph/0304007v2, Theorem 3 and equation (8).  The complementary term
+itself is not part of the cited equation. -/
 theorem partialTraceRightPetzComplementMap_apply
     (σ : Matrix (L × R) (L × R) ℂ) (hσ : σ.PosSemidef)
     (X : Matrix L L ℂ) :
@@ -239,9 +241,10 @@ theorem partialTraceRightPetzComplementMap_apply
   simp [partialTraceRightPetzComplementMap, preparationMap,
     (PosSemidef.partialTraceRight hσ).isHermitian.one_sub_supportProj_isHermitian.eq]
 
-/-- The complementary measure-and-prepare term in the trace-preserving
-completion of Hayden--Jozsa--Petz--Winter,
-arXiv:quant-ph/0304007v2, Theorem 3, is completely positive. -/
+/-- The complementary measure-and-prepare term chosen here to complete the
+support formula of Hayden--Jozsa--Petz--Winter,
+arXiv:quant-ph/0304007v2, Theorem 3, is completely positive.  The cited theorem
+supplies the support formula rather than this particular completion. -/
 theorem partialTraceRightPetzComplementMap_isKrausCP
     (σ : Matrix (L × R) (L × R) ℂ) (hσ : σ.PosSemidef) :
     IsKrausCP (partialTraceRightPetzComplementMap σ hσ) := by
@@ -252,9 +255,10 @@ theorem partialTraceRightPetzComplementMap_isKrausCP
 /-- The complementary term contributes the trace on the orthogonal complement
 of the reference marginal support when the reference matrix has trace one.
 
-This is the trace bookkeeping for the trace-preserving completion of the
-support transpose channel in Hayden--Jozsa--Petz--Winter,
-arXiv:quant-ph/0304007v2, Theorem 3. -/
+This is the trace bookkeeping for the complementary extension chosen here for
+the support transpose formula in Hayden--Jozsa--Petz--Winter,
+arXiv:quant-ph/0304007v2, Theorem 3.  The cited theorem does not specify this
+particular extension. -/
 theorem partialTraceRightPetzComplementMap_trace
     (σ : Matrix (L × R) (L × R) ℂ) (hσ : σ.PosSemidef)
     (hσtrace : Matrix.trace σ = 1) (X : Matrix L L ℂ) :
@@ -276,9 +280,10 @@ theorem partialTraceRightPetzComplementMap_trace
 It agrees with the support formula on inputs supported on the reference
 marginal and sends the complementary weight to a fixed prepared state.
 
-This is the channel extension of the transpose map used in
-Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2,
-Theorem 3 and equation (8). -/
+This definition adds the complementary extension chosen here to the transpose
+map used in Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2,
+Theorem 3 and equation (8).  The cited equation supplies only the support
+formula. -/
 noncomputable def partialTraceRightPetzChannel
     (σ : Matrix (L × R) (L × R) ℂ) (hσ : σ.PosSemidef) :
     Matrix L L ℂ →ₗ[ℂ] Matrix (L × R) (L × R) ℂ :=
@@ -287,9 +292,10 @@ noncomputable def partialTraceRightPetzChannel
 /-- The completed partial-trace Petz map is trace-preserving and completely
 positive when the reference matrix has trace one.
 
-This is the channel completion of the support transpose map in
-Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2,
-Theorem 3 and equation (8). -/
+This is the trace-preserving property of the completion chosen here for the
+support transpose map in Hayden--Jozsa--Petz--Winter,
+arXiv:quant-ph/0304007v2, Theorem 3 and equation (8).  The cited source gives
+the support formula rather than this particular completion. -/
 theorem partialTraceRightPetzChannel_isKrausCPTP
     (σ : Matrix (L × R) (L × R) ℂ) (hσ : σ.PosSemidef)
     (hσtrace : Matrix.trace σ = 1) :
@@ -312,8 +318,9 @@ theorem partialTraceRightPetzChannel_isKrausCPTP
 /-- On an input supported on the reference marginal, the completed channel
 agrees with the raw support Petz formula.
 
-This is the support restriction in Hayden--Jozsa--Petz--Winter,
-arXiv:quant-ph/0304007v2, Theorem 3 and equation (8). -/
+This proves that the completion chosen here restricts to the support formula
+of Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2,
+Theorem 3 and equation (8). -/
 theorem partialTraceRightPetzChannel_apply_of_supported
     (σ : Matrix (L × R) (L × R) ℂ) (hσ : σ.PosSemidef)
     (X : Matrix L L ℂ)
@@ -421,9 +428,9 @@ theorem partialTraceRightPetzMap_partialTraceRight
 /-- The completed partial-trace Petz channel recovers its reference matrix
 from the reference marginal.
 
-This is the reference-recovery identity for the transpose channel in
+This lifts the reference-recovery identity for the support formula of
 Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2,
-Theorem 3 and equation (8). -/
+Theorem 3 and equation (8), to the completion chosen here. -/
 theorem partialTraceRightPetzChannel_partialTraceRight
     (σ : Matrix (L × R) (L × R) ℂ) (hσ : σ.PosSemidef) :
     partialTraceRightPetzChannel σ hσ (partialTraceRight σ) = σ := by

--- a/TNLean/Channel/PetzRecovery.lean
+++ b/TNLean/Channel/PetzRecovery.lean
@@ -31,8 +31,8 @@ reference matrix.
   of the complementary term.
 * `Matrix.partialTraceRightPetzComplementMap_trace`: the complementary trace
   identity.
-* `Matrix.partialTraceRightPetzChannel`: a trace-preserving completely positive
-  extension of the support formula.
+* `Matrix.partialTraceRightPetzChannel`: the support formula completed by the
+  complementary measure-and-prepare term.
 * `Matrix.partialTraceRightPetzChannel_isKrausCPTP`: the completed map is a
   channel for a normalized reference.
 * `Matrix.partialTraceRightPetzChannel_apply_of_supported`: agreement with the
@@ -227,7 +227,7 @@ noncomputable def partialTraceRightPetzComplementMap
     singleKrausMap
       (1 - (PosSemidef.partialTraceRight hσ).isHermitian.supportProj)
 
-/-- The complementary term has the measure-and-prepare formula chosen here to
+/-- The complementary term has the measure-and-prepare formula used to
 complete the support formula of Hayden--Jozsa--Petz--Winter,
 arXiv:quant-ph/0304007v2, Theorem 3 and equation (8).  The complementary term
 itself is not part of the cited equation. -/
@@ -241,10 +241,9 @@ theorem partialTraceRightPetzComplementMap_apply
   simp [partialTraceRightPetzComplementMap, preparationMap,
     (PosSemidef.partialTraceRight hσ).isHermitian.one_sub_supportProj_isHermitian.eq]
 
-/-- The complementary measure-and-prepare term chosen here to complete the
-support formula of Hayden--Jozsa--Petz--Winter,
-arXiv:quant-ph/0304007v2, Theorem 3, is completely positive.  The cited theorem
-supplies the support formula rather than this particular completion. -/
+/-- The local complementary measure-and-prepare term accompanying the support
+formula of Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2, Theorem 3,
+is completely positive. -/
 theorem partialTraceRightPetzComplementMap_isKrausCP
     (σ : Matrix (L × R) (L × R) ℂ) (hσ : σ.PosSemidef) :
     IsKrausCP (partialTraceRightPetzComplementMap σ hσ) := by
@@ -255,10 +254,9 @@ theorem partialTraceRightPetzComplementMap_isKrausCP
 /-- The complementary term contributes the trace on the orthogonal complement
 of the reference marginal support when the reference matrix has trace one.
 
-This is the trace bookkeeping for the complementary extension chosen here for
-the support transpose formula in Hayden--Jozsa--Petz--Winter,
-arXiv:quant-ph/0304007v2, Theorem 3.  The cited theorem does not specify this
-particular extension. -/
+This is the trace bookkeeping for the local complementary extension of the
+support transpose formula in Hayden--Jozsa--Petz--Winter,
+arXiv:quant-ph/0304007v2, Theorem 3. -/
 theorem partialTraceRightPetzComplementMap_trace
     (σ : Matrix (L × R) (L × R) ℂ) (hσ : σ.PosSemidef)
     (hσtrace : Matrix.trace σ = 1) (X : Matrix L L ℂ) :
@@ -276,12 +274,13 @@ theorem partialTraceRightPetzComplementMap_trace
       simpa only [Matrix.mul_assoc] using Matrix.trace_mul_cycle Q X Q
     _ = Matrix.trace (Q * X) := by rw [hQidem]
 
-/-- A trace-preserving completion of the partial-trace Petz transpose map.
-It agrees with the support formula on inputs supported on the reference
-marginal and sends the complementary weight to a fixed prepared state.
+/-- A completion of the partial-trace Petz transpose map that is trace
+preserving when the reference matrix has trace one.  It agrees with the
+support formula on inputs supported on the reference marginal and sends the
+complementary weight to a fixed prepared state.
 
-This definition adds the complementary extension chosen here to the transpose
-map used in Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2,
+This definition adds the local complementary extension to the transpose map
+used in Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2,
 Theorem 3 and equation (8).  The cited equation supplies only the support
 formula. -/
 noncomputable def partialTraceRightPetzChannel
@@ -292,10 +291,9 @@ noncomputable def partialTraceRightPetzChannel
 /-- The completed partial-trace Petz map is trace-preserving and completely
 positive when the reference matrix has trace one.
 
-This is the trace-preserving property of the completion chosen here for the
-support transpose map in Hayden--Jozsa--Petz--Winter,
-arXiv:quant-ph/0304007v2, Theorem 3 and equation (8).  The cited source gives
-the support formula rather than this particular completion. -/
+This is the trace-preserving property of the completed support transpose map
+associated with Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2,
+Theorem 3 and equation (8). -/
 theorem partialTraceRightPetzChannel_isKrausCPTP
     (σ : Matrix (L × R) (L × R) ℂ) (hσ : σ.PosSemidef)
     (hσtrace : Matrix.trace σ = 1) :
@@ -318,8 +316,8 @@ theorem partialTraceRightPetzChannel_isKrausCPTP
 /-- On an input supported on the reference marginal, the completed channel
 agrees with the raw support Petz formula.
 
-This proves that the completion chosen here restricts to the support formula
-of Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2,
+This proves that the completed map restricts to the support formula of
+Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2,
 Theorem 3 and equation (8). -/
 theorem partialTraceRightPetzChannel_apply_of_supported
     (σ : Matrix (L × R) (L × R) ℂ) (hσ : σ.PosSemidef)
@@ -430,7 +428,7 @@ from the reference marginal.
 
 This lifts the reference-recovery identity for the support formula of
 Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2,
-Theorem 3 and equation (8), to the completion chosen here. -/
+Theorem 3 and equation (8), to the completed map. -/
 theorem partialTraceRightPetzChannel_partialTraceRight
     (σ : Matrix (L × R) (L × R) ℂ) (hσ : σ.PosSemidef) :
     partialTraceRightPetzChannel σ hσ (partialTraceRight σ) = σ := by

--- a/TNLean/Channel/PetzRecovery.lean
+++ b/TNLean/Channel/PetzRecovery.lean
@@ -232,10 +232,10 @@ arXiv:quant-ph/0304007v2, Theorem 3 and equation (8). -/
 theorem partialTraceRightPetzComplementMap_apply
     (σ : Matrix (L × R) (L × R) ℂ) (hσ : σ.PosSemidef)
     (X : Matrix L L ℂ) :
+    let Q := 1 - (PosSemidef.partialTraceRight hσ).isHermitian.supportProj
     partialTraceRightPetzComplementMap σ hσ X =
-      ((1 - (PosSemidef.partialTraceRight hσ).isHermitian.supportProj) * X *
-          (1 - (PosSemidef.partialTraceRight hσ).isHermitian.supportProj)) ⊗ₖ
-        partialTraceLeft σ := by
+      (Q * X * Q) ⊗ₖ partialTraceLeft σ := by
+  dsimp only
   simp [partialTraceRightPetzComplementMap, preparationMap,
     (PosSemidef.partialTraceRight hσ).isHermitian.one_sub_supportProj_isHermitian.eq]
 
@@ -258,9 +258,9 @@ arXiv:quant-ph/0304007v2, Theorem 3. -/
 theorem partialTraceRightPetzComplementMap_trace
     (σ : Matrix (L × R) (L × R) ℂ) (hσ : σ.PosSemidef)
     (hσtrace : Matrix.trace σ = 1) (X : Matrix L L ℂ) :
+    let Q := 1 - (PosSemidef.partialTraceRight hσ).isHermitian.supportProj
     Matrix.trace (partialTraceRightPetzComplementMap σ hσ X) =
-      Matrix.trace
-        ((1 - (PosSemidef.partialTraceRight hσ).isHermitian.supportProj) * X) := by
+      Matrix.trace (Q * X) := by
   let Q := 1 - (PosSemidef.partialTraceRight hσ).isHermitian.supportProj
   have hQidem : Q * Q = Q :=
     (PosSemidef.partialTraceRight hσ).isHermitian.one_sub_supportProj_idem
@@ -295,8 +295,7 @@ theorem partialTraceRightPetzChannel_isKrausCPTP
     (hσtrace : Matrix.trace σ = 1) :
     IsKrausCPTP (partialTraceRightPetzChannel σ hσ) := by
   apply isKrausCPTP_of_isKrausCP_trace_preserving
-  · exact isKrausCP_add
-      (partialTraceRightPetzMap_isKrausCP σ hσ)
+  · exact (partialTraceRightPetzMap_isKrausCP σ hσ).add
       (partialTraceRightPetzComplementMap_isKrausCP σ hσ)
   · intro X
     rw [partialTraceRightPetzChannel, LinearMap.add_apply, Matrix.trace_add,
@@ -319,11 +318,12 @@ theorem partialTraceRightPetzChannel_apply_of_supported
     (σ : Matrix (L × R) (L × R) ℂ) (hσ : σ.PosSemidef)
     (X : Matrix L L ℂ)
     (hX :
-      (PosSemidef.partialTraceRight hσ).isHermitian.supportProj * X *
-        (PosSemidef.partialTraceRight hσ).isHermitian.supportProj = X) :
+      let P := (PosSemidef.partialTraceRight hσ).isHermitian.supportProj
+      P * X * P = X) :
     partialTraceRightPetzChannel σ hσ X = partialTraceRightPetzMap σ hσ X := by
   let P := (PosSemidef.partialTraceRight hσ).isHermitian.supportProj
   let Q : Matrix L L ℂ := 1 - P
+  change P * X * P = X at hX
   have hPidem : P * P = P :=
     (PosSemidef.partialTraceRight hσ).isHermitian.supportProj_idem
   have hPX : P * X = X := by

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -1404,6 +1404,27 @@ Theorem~\ref{thm:trace_norm_abs}.
     \]
 \end{definition}
 
+\begin{theorem}[Complete positivity of the complementary term]
+    \label{thm:partial_trace_petz_complement_cp}
+    \lean{Matrix.partialTraceRightPetzComplementMap_isKrausCP}
+    \leanok
+    \uses{def:partial_trace_petz_complement, def:is_kraus_cp}
+    The complementary preparation term $\mathcal C_\sigma$ is completely
+    positive.
+\end{theorem}
+
+\begin{lemma}[Trace of the complementary term]
+    \label{lem:partial_trace_petz_complement_trace}
+    \lean{Matrix.partialTraceRightPetzComplementMap_trace}
+    \leanok
+    \uses{def:partial_trace_petz_complement}
+    If $\sigma$ has trace one, then
+    \[
+        \operatorname{tr}(\mathcal C_\sigma(X))
+        =\operatorname{tr}(Q_\tau X).
+    \]
+\end{lemma}
+
 \begin{definition}[Trace-preserving Petz channel for a partial trace]
     \label{def:partial_trace_petz_channel}
     \lean{Matrix.partialTraceRightPetzChannel}
@@ -1422,7 +1443,10 @@ Theorem~\ref{thm:trace_norm_abs}.
     \lean{Matrix.partialTraceRightPetzChannel_isKrausCPTP}
     \leanok
     \uses{def:partial_trace_petz_channel,
-        lem:partial_trace_support_petz_map_trace, def:is_kraus_cptp}
+        thm:partial_trace_support_petz_map_cp,
+        lem:partial_trace_support_petz_map_trace,
+        thm:partial_trace_petz_complement_cp,
+        lem:partial_trace_petz_complement_trace, def:is_kraus_cptp}
     If $\sigma$ is positive semidefinite with trace one, then
     $\widehat{\mathcal R}_\sigma$ is completely positive and trace preserving.
 \end{theorem}

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -1416,6 +1416,14 @@ Theorem~\ref{thm:trace_norm_abs}.
     positive.
 \end{theorem}
 
+\begin{proof}\leanok
+    \uses{lem:is_kraus_cp_comp, lem:mpdo_single_kraus_map_cp,
+        lem:mpdo_state_preparation_cp}
+    The map $X\mapsto Q_\tau XQ_\tau$ has the single Kraus operator $Q_\tau$.
+    Adjoining the positive semidefinite matrix $\omega_R$ is completely
+    positive, and the composition of these two maps is completely positive.
+\end{proof}
+
 \begin{lemma}[Trace of the complementary term]
     \label{lem:partial_trace_petz_complement_trace}
     \lean{Matrix.partialTraceRightPetzComplementMap_trace}

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -1396,7 +1396,8 @@ Theorem~\ref{thm:trace_norm_abs}.
     \label{def:partial_trace_petz_complement}
     \lean{Matrix.partialTraceRightPetzComplementMap}
     \leanok
-    \uses{def:partial_trace_support_petz_map}
+    \uses{def:support_proj, def:partial_trace_left,
+        def:mpdo_state_preparation_map}
     Put $Q_\tau=\mathbf 1_L-P_\tau$ and
     $\omega_R=\operatorname{tr}_L\sigma$.  The complementary term is
     \[

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -1378,6 +1378,78 @@ Theorem~\ref{thm:trace_norm_abs}.
     Thus the support Petz map has a rectangular Kraus representation.
 \end{proof}
 
+\begin{lemma}[Trace of the support Petz map]
+    \label{lem:partial_trace_support_petz_map_trace}
+    \lean{Matrix.partialTraceRightPetzMap_trace}
+    \leanok
+    \uses{def:partial_trace_support_petz_map,
+        lem:support_inverse_square_root_sandwich}
+    Let $P_\tau$ be the orthogonal projector onto the support of
+    $\tau=\operatorname{tr}_R\sigma$.  Then, for every matrix $X$,
+    \[
+        \operatorname{tr}(\mathcal R_\sigma(X))
+        =\operatorname{tr}(P_\tau X).
+    \]
+\end{lemma}
+
+\begin{definition}[Complementary preparation term]
+    \label{def:partial_trace_petz_complement}
+    \lean{Matrix.partialTraceRightPetzComplementMap}
+    \leanok
+    \uses{def:partial_trace_support_petz_map}
+    Put $Q_\tau=\mathbf 1_L-P_\tau$ and
+    $\omega_R=\operatorname{tr}_L\sigma$.  The complementary term is
+    \[
+        \mathcal C_\sigma(X)=Q_\tau XQ_\tau\otimes\omega_R.
+    \]
+\end{definition}
+
+\begin{definition}[Trace-preserving Petz channel for a partial trace]
+    \label{def:partial_trace_petz_channel}
+    \lean{Matrix.partialTraceRightPetzChannel}
+    \leanok
+    \uses{def:partial_trace_support_petz_map,
+        def:partial_trace_petz_complement}
+    The completed Petz map is
+    \[
+        \widehat{\mathcal R}_\sigma
+        =\mathcal R_\sigma+\mathcal C_\sigma.
+    \]
+\end{definition}
+
+\begin{theorem}[The completed Petz map is a channel]
+    \label{thm:partial_trace_petz_channel_cptp}
+    \lean{Matrix.partialTraceRightPetzChannel_isKrausCPTP}
+    \leanok
+    \uses{def:partial_trace_petz_channel,
+        lem:partial_trace_support_petz_map_trace, def:is_kraus_cptp}
+    If $\sigma$ is positive semidefinite with trace one, then
+    $\widehat{\mathcal R}_\sigma$ is completely positive and trace preserving.
+\end{theorem}
+
+\begin{proof}\leanok
+    The two summands are completely positive.  Since
+    $\operatorname{tr}(\omega_R)=1$, the complementary term satisfies
+    \[
+        \operatorname{tr}(\mathcal C_\sigma(X))
+        =\operatorname{tr}(Q_\tau X).
+    \]
+    Adding this identity to
+    $\operatorname{tr}(\mathcal R_\sigma(X))
+      =\operatorname{tr}(P_\tau X)$ gives trace preservation.
+\end{proof}
+
+\begin{theorem}[Agreement on the marginal support]
+    \label{thm:partial_trace_petz_channel_supported_agreement}
+    \lean{Matrix.partialTraceRightPetzChannel_apply_of_supported}
+    \leanok
+    \uses{def:partial_trace_petz_channel}
+    If $P_\tau XP_\tau=X$, then
+    \[
+        \widehat{\mathcal R}_\sigma(X)=\mathcal R_\sigma(X).
+    \]
+\end{theorem}
+
 \begin{theorem}[The support Petz map recovers its reference]
     \label{thm:partial_trace_support_petz_map_reference_recovery}
     \lean{Matrix.partialTraceRightPetzMap_partialTraceRight}
@@ -1402,6 +1474,18 @@ Theorem~\ref{thm:trace_norm_abs}.
     because that matrix is positive semidefinite of trace zero.  Therefore
     $\sqrt\sigma(P_\tau\otimes\mathbf 1_R)\sqrt\sigma=\sigma$.
 \end{proof}
+
+\begin{theorem}[The completed Petz channel recovers its reference]
+    \label{thm:partial_trace_petz_channel_reference_recovery}
+    \lean{Matrix.partialTraceRightPetzChannel_partialTraceRight}
+    \leanok
+    \uses{thm:partial_trace_support_petz_map_reference_recovery,
+        thm:partial_trace_petz_channel_supported_agreement}
+    For every positive semidefinite $\sigma$,
+    \[
+        \widehat{\mathcal R}_\sigma(\operatorname{tr}_R\sigma)=\sigma.
+    \]
+\end{theorem}
 
 \begin{theorem}[Entropy is invariant under reindexing]
     \label{thm:entropy_submatrix_equiv}

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -1488,6 +1488,10 @@ Theorem~\ref{thm:trace_norm_abs}.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{lem:is_kraus_cp_add,
+        thm:is_kraus_cptp_of_is_kraus_cp_trace_preserving,
+        lem:partial_trace_support_petz_map_trace,
+        lem:partial_trace_petz_complement_trace}
     The two summands are completely positive.  Since
     $\operatorname{tr}(\omega_R)=1$, the complementary term satisfies
     \[

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -1392,6 +1392,19 @@ Theorem~\ref{thm:trace_norm_abs}.
     \]
 \end{lemma}
 
+\begin{proof}\leanok
+    \uses{lem:support_inverse_square_root_sandwich}
+    Cyclicity of the trace and the defining property of the partial trace give
+    \[
+        \operatorname{tr}(\mathcal R_\sigma(X))
+        =\operatorname{tr}(\tau^{-1/2}_{\mathrm{supp}}
+          X\tau^{-1/2}_{\mathrm{supp}}\tau)
+        =\operatorname{tr}((\tau^{-1/2}_{\mathrm{supp}}
+          \tau\tau^{-1/2}_{\mathrm{supp}})X).
+    \]
+    The factor in parentheses is $P_\tau$.
+\end{proof}
+
 \begin{definition}[Complementary preparation term]
     \label{def:partial_trace_petz_complement}
     \lean{Matrix.partialTraceRightPetzComplementMap}
@@ -1435,6 +1448,18 @@ Theorem~\ref{thm:trace_norm_abs}.
         =\operatorname{tr}(Q_\tau X).
     \]
 \end{lemma}
+
+\begin{proof}\leanok
+    \uses{def:partial_trace_petz_complement}
+    Since $\operatorname{tr}(\omega_R)=\operatorname{tr}(\sigma)=1$ and
+    $Q_\tau^2=Q_\tau$, factorization and cyclicity of the trace give
+    \[
+        \operatorname{tr}(\mathcal C_\sigma(X))
+        =\operatorname{tr}(Q_\tau XQ_\tau)
+        =\operatorname{tr}(Q_\tau^2X)
+        =\operatorname{tr}(Q_\tau X).
+    \]
+\end{proof}
 
 \begin{definition}[Trace-preserving Petz channel for a partial trace]
     \label{def:partial_trace_petz_channel}
@@ -1485,6 +1510,14 @@ Theorem~\ref{thm:trace_norm_abs}.
     \]
 \end{theorem}
 
+\begin{proof}\leanok
+    \uses{def:partial_trace_petz_channel,
+        def:partial_trace_petz_complement}
+    The assumption implies $Q_\tau XQ_\tau=0$.  Hence
+    $\mathcal C_\sigma(X)=0$, and adding the complementary term to
+    $\mathcal R_\sigma(X)$ does not change its value.
+\end{proof}
+
 \begin{theorem}[The support Petz map recovers its reference]
     \label{thm:partial_trace_support_petz_map_reference_recovery}
     \lean{Matrix.partialTraceRightPetzMap_partialTraceRight}
@@ -1521,6 +1554,15 @@ Theorem~\ref{thm:trace_norm_abs}.
         \widehat{\mathcal R}_\sigma(\operatorname{tr}_R\sigma)=\sigma.
     \]
 \end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:partial_trace_support_petz_map_reference_recovery,
+        thm:partial_trace_petz_channel_supported_agreement}
+    The marginal satisfies
+    $P_\tau\tau P_\tau=\tau$.  Therefore the completed channel agrees with
+    the support Petz map at $\tau$, and the preceding recovery theorem gives
+    $\widehat{\mathcal R}_\sigma(\tau)=\sigma$.
+\end{proof}
 
 \begin{theorem}[Entropy is invariant under reindexing]
     \label{thm:entropy_submatrix_equiv}

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -1403,8 +1403,8 @@ Theorem~\ref{thm:trace_norm_abs}.
     \[
         \mathcal C_\sigma(X)=Q_\tau XQ_\tau\otimes\omega_R.
     \]
-    This is a chosen complementary extension of the cited support formula;
-    it is not part of equation~(8).
+    % Source-faithfulness note: equation (8) supplies the support formula;
+    % this complementary extension is the local completion chosen here.
 \end{definition}
 
 \begin{theorem}[Complete positivity of the complementary term]

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -1403,6 +1403,8 @@ Theorem~\ref{thm:trace_norm_abs}.
     \[
         \mathcal C_\sigma(X)=Q_\tau XQ_\tau\otimes\omega_R.
     \]
+    This is a chosen complementary extension of the cited support formula;
+    it is not part of equation~(8).
 \end{definition}
 
 \begin{theorem}[Complete positivity of the complementary term]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
@@ -50,6 +50,20 @@ section.
     Kraus map is a completely positive Kraus map.
 \end{lemma}
 
+\begin{lemma}[Sum of rectangular Kraus maps]
+    \label{lem:is_kraus_cp_add}
+    \lean{IsKrausCP.add}
+    \leanok
+    \uses{def:is_kraus_cp}
+    The sum of two completely positive maps in rectangular Kraus form is
+    completely positive in rectangular Kraus form.
+\end{lemma}
+
+\begin{proof}\leanok
+    Concatenating Kraus families for the two summands gives a Kraus family for
+    their sum.
+\end{proof}
+
 \begin{definition}[Trace-preserving completely positive map]
     \label{def:is_kraus_cptp}
     \lean{IsKrausCPTP}
@@ -60,6 +74,25 @@ section.
     The Kraus operators may be rectangular, so the input and output dimensions
     need not agree.
 \end{definition}
+
+\begin{theorem}[Trace preservation completes a Kraus channel]
+    \label{thm:is_kraus_cptp_of_is_kraus_cp_trace_preserving}
+    \lean{isKrausCPTP_of_isKrausCP_trace_preserving}
+    \leanok
+    \uses{def:is_kraus_cp, def:is_kraus_cptp}
+    A completely positive map in rectangular Kraus form that preserves the
+    matrix trace is trace-preserving completely positive.
+\end{theorem}
+
+\begin{proof}\leanok
+    If $(A_i)_i$ is a Kraus family, trace preservation and cyclicity give
+    \[
+        \operatorname{tr}\left(\left(\sum_i A_i^\dagger A_i\right)X\right)
+        =\operatorname{tr}(X)
+    \]
+    for every $X$.  Nondegeneracy of the trace pairing implies
+    $\sum_i A_i^\dagger A_i=\mathbf 1$.
+\end{proof}
 
 \begin{theorem}[Trace preservation from a Kraus resolution]
     \label{thm:is_kraus_cptp_trace_map}

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -10,7 +10,7 @@
 \title{The Strong-Subadditivity Equality Characterization as an External
 Stand-In, and Its One-Directional Hygiene Split}
 \author{}
-\date{2026-06-22}
+\date{2026-07-18}
 
 \begin{document}
 \maketitle
@@ -60,10 +60,10 @@ finite decomposition, the unitary basis change, the weights $p_j$, the component
 density operators, and the block-diagonal equality.} The forward direction is an
 external stand-in: that implication is a theorem of Ruskai, of
 Hayden--Jozsa--Petz--Winter, and of Hayashi, but its proof rests on
-the full saturation-to-recovery theorem, a trace-preserving extension of the
-support Petz map, and the structural analysis of recovered states, none of
-which is yet formalized here. The reverse direction is now proved from the
-entropy-additivity sub-lemmas listed below.
+the full saturation-to-recovery theorem and the structural analysis of
+recovered states.  The trace-preserving extension of the support Petz map is
+now available, but those two later steps are not.  The reverse direction is
+proved from the entropy-additivity sub-lemmas listed below.
 
 \section{The point at issue: only the forward direction is consumed}
 
@@ -77,10 +77,10 @@ downstream. Its proof is the deep part of the characterization: it requires
 recovery-map theory and the Petz transpose channel, that is, the analysis of
 when the data-processing inequality for relative entropy is saturated and the
 reconstruction of the discarded subsystem from a recovery map. This recovery-map
-argument still lacks the saturation-to-recovery theorem, the complementary
-trace-preserving extension of the support Petz map, and the subsequent
+argument still lacks the saturation-to-recovery theorem and the subsequent
 structural analysis, which is why the forward direction is axiomatized rather
-than proved.
+than proved.  The complementary trace-preserving extension of the support
+Petz map has now been supplied and is no longer part of this gap.
 
 \paragraph{Reverse direction (tractable, currently unused).}
 The implication \eqref{eq:qmc} $\Rightarrow$~\eqref{eq:ssa-eq} --- a state of the
@@ -150,10 +150,9 @@ The reverse half uses the following entropy-additivity sub-lemmas, all proved in
 With these five facts the reverse implication is a finite computation, now
 carried out in \path{TNLean/Analysis/EntropyMarkovReverse.lean}; the
 forward implication remains an axiom until the full saturation-to-recovery
-theorem, the complementary trace-preserving extension, and the structural
-analysis are available.
+theorem and the structural analysis are available.
 
-\section{Support-level Petz infrastructure now available}
+\section{Trace-preserving Petz channel now available}
 
 The support formula for the Petz transpose map associated with a right partial
 trace is now formalized for every positive semidefinite reference $\sigma$.
@@ -164,32 +163,51 @@ Writing $\tau=\operatorname{tr}_R\sigma$, the map is
     (\tau^{-1/2}_{\mathrm{supp}}X
       \tau^{-1/2}_{\mathrm{supp}}\otimes\mathbf 1_R)\sqrt\sigma.
 \end{align}
-It is proved completely positive in rectangular Kraus form and satisfies
-$\mathcal R_\sigma(\tau)=\sigma$.
+It is proved completely positive in rectangular Kraus form, satisfies
+$\mathcal R_\sigma(\tau)=\sigma$, and obeys the support trace identity
+$\operatorname{tr}(\mathcal R_\sigma(X))=\operatorname{tr}(P_\tau X)$.
 \footnote{Formal declarations:
 \leanid{Matrix.partialTraceRightPetzMap},
-\leanid{Matrix.partialTraceRightPetzMap_isKrausCP}, and
+\leanid{Matrix.partialTraceRightPetzMap_isKrausCP},
+\leanid{Matrix.partialTraceRightPetzMap_trace}, and
 \leanid{Matrix.partialTraceRightPetzMap_partialTraceRight} in
 \path{TNLean/Channel/PetzRecovery.lean}.}
 This is exactly the formula stated on the support in
 \cite[Theorem~3, equation~(8)]{HaydenJozsaPetzWinter2004}.
 
-This leaf does not yet supply the full recovery theorem needed by the forward
-strong-subadditivity characterization.  In particular, it neither extends the
-singular formula to a trace-preserving channel on the complementary output
-subspace nor proves that saturation of relative-entropy data processing forces
-recovery of the first argument.  Those two steps, followed by the structural
-analysis of the recovered tripartite state, remain necessary before the
-forward axiom can be removed.
+For a normalized reference, let $Q_\tau=\mathbf 1-P_\tau$ and
+$\omega_R=\operatorname{tr}_L\sigma$.  The complementary term
+\begin{align}
+  \mathcal C_\sigma(X)=Q_\tau XQ_\tau\otimes\omega_R
+\end{align}
+is completely positive and contributes trace
+$\operatorname{tr}(Q_\tau X)$.  Hence
+$\widehat{\mathcal R}_\sigma=\mathcal R_\sigma+\mathcal C_\sigma$ is a
+trace-preserving completely positive map.  It agrees with the support formula
+when $P_\tau XP_\tau=X$ and still recovers the reference matrix from its
+marginal.
+\footnote{Formal declarations:
+\leanid{Matrix.partialTraceRightPetzComplementMap},
+\leanid{Matrix.partialTraceRightPetzChannel},
+\leanid{Matrix.partialTraceRightPetzChannel_isKrausCPTP},
+\leanid{Matrix.partialTraceRightPetzChannel_apply_of_supported}, and
+\leanid{Matrix.partialTraceRightPetzChannel_partialTraceRight} in
+\path{TNLean/Channel/PetzRecovery.lean}.}
+
+This leaf still does not supply the full recovery theorem needed by the
+forward strong-subadditivity characterization.  It does not prove that
+saturation of relative-entropy data processing forces recovery of the first
+argument.  That step, followed by the structural analysis of the recovered
+tripartite state, remains necessary before the forward axiom can be removed.
 
 \section{Verdict}
 
 The strong-subadditivity equality characterization is now split into a proved
 reverse direction and an axiomatic forward direction. Only the forward
 direction, equality implies quantum-Markov-chain structure, still needs the
-full saturation-to-recovery theorem, the complementary trace-preserving
-extension of the support Petz map, and the structural analysis of recovered
-states, and it alone is axiomatized. The reverse direction, a block-diagonal
+full saturation-to-recovery theorem and the structural analysis of recovered
+states; the trace-preserving Petz channel is now available.  The forward
+direction alone is axiomatized. The reverse direction, a block-diagonal
 product state attains equality, is proved from entropy additivity over weighted
 direct sums and tensor factors together with unitary and reindexing invariance.
 Until those remaining steps are formalized, the forward direction remains the


### PR DESCRIPTION
## Summary

- prove the support-trace identity for the raw partial-trace Petz map
- add the complementary measure-and-prepare term and assemble a globally trace-preserving completely positive map
- prove agreement with the raw formula on inputs satisfying `P * X * P = X`
- prove recovery of the reference matrix from its right marginal
- add the supporting Kraus and partial-trace lemmas, blueprint entries, and paper-gap status update

## Mathematical scope

For `τ = partialTraceRight σ`, let `P` be the support projection of `τ` and `Q = 1 - P`. The raw Petz term has trace `trace (P * X)`. The complementary term

```text
(Q * X * Q) ⊗ partialTraceLeft σ
```

has trace `trace (Q * X)` when `σ` is normalized. Their sum is therefore CPTP. The complement vanishes when `P * X * P = X`, so the completed map agrees with the support formula on supported inputs.

This PR intentionally excludes data-processing saturation implies recovery (#4228), the Hayashi structural decomposition (#4229), and removal of the forward equality axiom.

## Validation

- `lake build TNLean.Channel.PetzRecovery`
- direct Lean checks of the three changed Lean files during development
- no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast` in the changed Lean files
- `git diff origin/main...HEAD --check`
- rebased onto `origin/main` at `8fccb1dc`

`leanblueprint checkdecls` could not run locally because the installed command could not import its own `leanblueprint` Python module and consequently did not generate `blueprint/lean_decls`; CI should exercise the declaration check in the repository environment.

Closes #4227.
Parent tracker: #784.
Entropy tracker: #239.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal mathematics and documentation in channel/entropy infrastructure; no auth, runtime, or production code paths.
> 
> **Overview**
> **Completes the partial-trace support Petz map** into a globally trace-preserving channel for normalized references, by adding a complementary measure-and-prepare term and proving the combined map is Kraus CPTP.
> 
> The raw support formula only preserves trace on the marginal support (`tr(R_σ(X)) = tr(P_τ X)`). The new term `C_σ(X) = Q_τ X Q_τ ⊗ tr_L σ` accounts for the orthogonal complement when `tr(σ)=1`, so `R̂_σ = R_σ + C_σ` is CPTP, agrees with `R_σ` when `P_τ X P_τ = X`, and still recovers `σ` from `tr_R σ`.
> 
> **Supporting lemmas:** `IsKrausCP.add`, `isKrausCPTP_of_isKrausCP_trace_preserving`, and `trace_partialTraceLeft` enable the channel proof and complement trace bookkeeping.
> 
> Blueprint (`ch19_entropy`, `ch21_mpdo_rfp_renormalization`) and the Hayashi SSA paper-gap note are updated to record the new formalizations and that the trace-preserving Petz extension is no longer a gap (saturation-to-recovery and structural analysis still are).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d6715b89e3a70cddb4072a168877cd5ad32806e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->