### PR TITLE
feat(MPS/MPDO): expose LPDO block-channel witnesses

### DIFF
--- a/TNLean/MPS/MPDO/LocalPurificationAreaLaw.lean
+++ b/TNLean/MPS/MPDO/LocalPurificationAreaLaw.lean
@@ -34,9 +34,10 @@ from the cited argument and is false without further hypotheses.
 * `MPOTensor.blockAncillaryTraceMap_apply` and
   `MPOTensor.tensorMapBoth_blockAncillaryTraceMap_apply`: coefficient formulas
   for one block and for the two sides of a cut.
-* `MPOTensor.bipartitionedNormalizedMPO_eq_tensorMapBoth_blockAncillaryTraceMap`:
-  an explicit local purification gives the normalized block-channel image
-  across every cut.
+* `MPOTensor.bipartitionedNormalizedMPO_eq_tensorMapBoth_blockAncillaryTraceMap`
+  and `MPOTensor.IsLPDO.exists_bipartitionedNormalizedMPO_eq_blockAncillaryTrace`:
+  an explicit local purification, or an LPDO witness, gives the normalized
+  block-channel image across every cut.
 * `MPOTensor.mutualInfoChain_le_of_bipartitioned_channel_image`: a matrix product
   density operator obtained by local channels from a pure matrix product state
   satisfies the bound determined by the purifying bond dimension.
@@ -271,6 +272,33 @@ theorem bipartitionedNormalizedMPO_eq_tensorMapBoth_blockAncillaryTraceMap
       congr 1
   refine Finset.sum_congr rfl (fun κ _ ↦ ?_)
   rw [hjoin i x κ, hjoin j y κ]
+
+/-- The existential `IsLPDO` form of
+`bipartitionedNormalizedMPO_eq_tensorMapBoth_blockAncillaryTraceMap`.
+It chooses the ancillary dimension, purifying bond dimension, and purifying
+tensor, then identifies the normalized finite-chain state with the two
+blockwise ancillary traces. This is the identity used by the mixed-PEPS
+channel argument preceding equation (4) of arXiv:0704.3906.
+
+**Scope restriction:** the hypothesis is a local purification in the sense of
+arXiv:1606.00608, Section 4.3. A general positive matrix product operator need
+not have one, so this theorem is not the unrestricted boundedness clause of
+Proposition 4.5, lines 801--806 and 1316--1320. See
+`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+theorem IsLPDO.exists_bipartitionedNormalizedMPO_eq_blockAncillaryTrace
+    {M : MPOTensor d D} (hLPDO : IsLPDO M)
+    (N L K : ℕ) (h : N = L + K) :
+    ∃ (dK D' : ℕ)
+      (A : Fin d → Fin dK → Matrix (Fin D') (Fin D') ℂ),
+      bipartitionedNormalizedMPO M N L K h =
+        Matrix.tensorMapBoth (blockAncillaryTraceMap d dK L)
+          (blockAncillaryTraceMap d dK K)
+          (bipartitionedNormalizedMPO
+            (doubledTensor (purificationTensor A)) N L K h) := by
+  obtain ⟨dK, D', A, e, hM⟩ := hLPDO
+  exact ⟨dK, D', A,
+    bipartitionedNormalizedMPO_eq_tensorMapBoth_blockAncillaryTraceMap
+      M A e hM N L K h⟩
 
 /-- **Mutual-information bound for a local-channel image of a pure matrix
 product state.** Let the normalized density operator across the cut

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
@@ -634,7 +634,8 @@
     \label{thm:lpdo_block_channel_image}
     \lean{MPOTensor.blockAncillaryTraceMap_pureState_purificationTensor,
       MPOTensor.trace_purificationDensity_eq_pureState,
-      MPOTensor.bipartitionedNormalizedMPO_eq_tensorMapBoth_blockAncillaryTraceMap}
+      MPOTensor.bipartitionedNormalizedMPO_eq_tensorMapBoth_blockAncillaryTraceMap,
+      MPOTensor.IsLPDO.exists_bipartitionedNormalizedMPO_eq_blockAncillaryTrace}
     \leanok
     \uses{def:block_ancillary_trace,
       def:mpdo_purification_tensor, def:mpdo_purification_density,
@@ -681,6 +682,10 @@
 
     This identity also holds when the common trace vanishes, in which case both
     normalized-form operators are zero.
+
+    In particular, the local-purification representation of an LPDO supplies
+    an ancillary dimension, a purifying bond dimension, and a purifying tensor
+    for which the same identity holds.
 
     This is the finite-chain channel identity from the purification preceding
     equation~(4) of \cite{Wolf2008AreaLaws}, under the explicit local


### PR DESCRIPTION
## Motivation

PR #4240 now provides the substantive explicit local-purification channel identity and the LPDO mutual-information corollary. Issue #4219 still requests the corresponding existential block-identity API directly from `MPOTensor.IsLPDO M`.

## Description

- unpack the existential `IsLPDO M` witness;
- apply the merged `bipartitionedNormalizedMPO_eq_tensorMapBoth_blockAncillaryTraceMap` theorem;
- expose the ancillary dimension, purifying bond dimension, and purifying tensor existentially;
- add the declaration to the existing scope-restricted blueprint theorem.

This remains an LPDO-only result. It does not claim the unrestricted MPDO bound in arXiv:1606.00608, Proposition `PropILILp1`; that source is an MPDO/MPS/RFP paper, not a PEPS paper. The mixed-PEPS wording applies only to the separate arXiv:0704.3906 argument.

## Testing

- `lake env lean TNLean/MPS/MPDO/LocalPurificationAreaLaw.lean`
- `lake build TNLean.MPS.MPDO.LocalPurificationAreaLaw`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- changed-declaration blueprint coverage check
- `lake exe checkdecls blueprint/lean_decls`
- proof-integrity token scan and `git diff origin/main...HEAD --check`

Closes #4219.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Thin wrapper over an existing proof plus documentation and blueprint sync; no changes to auth, runtime behavior, or general MPDO bounds.
> 
> **Overview**
> Adds **`MPOTensor.IsLPDO.exists_bipartitionedNormalizedMPO_eq_blockAncillaryTrace`**, which from `IsLPDO M` existentially supplies ancillary dimension, purifying bond dimension, and purifying tensor `A`, then reuses **`bipartitionedNormalizedMPO_eq_tensorMapBoth_blockAncillaryTraceMap`** to equate the normalized cut state with the two block ancillary traces on the doubled purification MPO.
> 
> The module header and blueprint **Theorem (Local purification as a block-channel image)** now cite this existential API and note that an LPDO witness yields the same finite-chain channel identity without spelling out purification data upfront. The result remains **LPDO-only** (explicit local purification); it is not the unrestricted MPDO mutual-information bound.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1970b0b042083cfd5e9e880ab8ca37f14365997b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->