### PR TITLE
feat(MPS/MPDO): extract positive neighboring operators

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -562,6 +562,7 @@ import TNLean.MPS.MPDO.CommutingForm
 import TNLean.MPS.MPDO.CommutingFormBridge
 import TNLean.MPS.MPDO.CommutingOverlappingCoordinates
 import TNLean.MPS.MPDO.CommutingFormSpatialBridge
+import TNLean.MPS.MPDO.CommutingBondEtaDecomposition
 import TNLean.MPS.MPDO.GSNNCHSectorSum
 import TNLean.MPS.MPDO.GSNNCHOrthogonalSectors
 import TNLean.MPS.MPDO.BNTSectorCommutingFamily

--- a/TNLean/MPS/MPDO/CommutingBondEtaDecomposition.lean
+++ b/TNLean/MPS/MPDO/CommutingBondEtaDecomposition.lean
@@ -15,7 +15,7 @@ finite chain.
 
 ## Main declarations
 
-* `MPOTensor.etaPairSpatialBlockEquiv`
+* `Matrix.etaPairSpatialBlockEquiv`
 * `MPOTensor.EtaLocalStructureData.exists_positive_eta_pairBond_decomposition`
 
 ## References
@@ -26,9 +26,9 @@ finite chain.
 
 open scoped ComplexOrder Kronecker Matrix
 
-namespace MPOTensor
+namespace Matrix
 
-variable {d D : ℕ}
+variable {d : ℕ}
 
 /-- The index equivalence which orders a pair of spatially decomposed sites as
 \[
@@ -58,9 +58,11 @@ def etaPairSpatialBlockEquiv {K : ℕ} {dl dr : Fin K → ℕ}
     simp only
     rw [e.apply_symm_apply, e.apply_symm_apply]
 
-namespace EtaLocalStructureData
+end Matrix
 
-variable {M : MPOTensor d D}
+namespace MPOTensor.EtaLocalStructureData
+
+variable {d D : ℕ} {M : MPOTensor d D}
 
 /-- A positive translation-invariant commuting bond has one spatial decomposition and a
 positive neighboring operator \(\eta_{q,h}\) for each ordered pair of sectors such that
@@ -88,8 +90,8 @@ theorem exists_positive_eta_pairBond_decomposition
       U ∈ Matrix.unitaryGroup (Fin d) ℂ ∧
         (∀ q, 0 < dl q) ∧ (∀ q, 0 < dr q) ∧
         (∀ q h, (η q h).PosSemidef) ∧
-        Matrix.reindex (etaPairSpatialBlockEquiv e).symm
-            (etaPairSpatialBlockEquiv e).symm
+        Matrix.reindex (Matrix.etaPairSpatialBlockEquiv e).symm
+            (Matrix.etaPairSpatialBlockEquiv e).symm
             (star (U ⊗ₖ U) * data.pairBond * (U ⊗ₖ U)) =
           Matrix.blockDiagonal' fun qh : Fin K × Fin K ↦
             ((1 : Matrix (Fin (dl qh.1)) (Fin (dl qh.1)) ℂ) ⊗ₖ
@@ -263,8 +265,8 @@ theorem exists_positive_eta_pairBond_decomposition
     have hsub := hBpos.submatrix f
     change (B'.submatrix f f).PosSemidef
     exact hsub
-  · change Matrix.reindex (etaPairSpatialBlockEquiv e).symm
-        (etaPairSpatialBlockEquiv e).symm B' = _
+  · change Matrix.reindex (Matrix.etaPairSpatialBlockEquiv e).symm
+        (Matrix.etaPairSpatialBlockEquiv e).symm B' = _
     ext ⟨⟨q, h⟩, ⟨⟨lq, ⟨rq, lh⟩⟩, rh⟩⟩
       ⟨⟨q', h'⟩, ⟨⟨lq', ⟨rq', lh'⟩⟩, rh'⟩⟩
     change B' (e ⟨q, (rq, lq)⟩, e ⟨h, (rh, lh)⟩)
@@ -281,6 +283,4 @@ theorem exists_positive_eta_pairBond_decomposition
     · rw [Matrix.blockDiagonal'_apply_ne _ _ _ (fun hp ↦ hq (Prod.mk.inj hp).1)]
       exact hB'_left_sector_ne q q' h h' hq lq lq' rq rq' lh lh' rh rh'
 
-end EtaLocalStructureData
-
-end MPOTensor
+end MPOTensor.EtaLocalStructureData

--- a/TNLean/MPS/MPDO/CommutingBondEtaDecomposition.lean
+++ b/TNLean/MPS/MPDO/CommutingBondEtaDecomposition.lean
@@ -21,7 +21,7 @@ finite chain.
 ## References
 
 * S. Beigi, arXiv:1105.1019v2, Lemma 2.1.
-* arXiv:1606.00608, Appendix C.2, equation `sigmaNK2`, lines 1581--1605.
+* arXiv:1606.00608, Appendix C.2, equation sigmaNK2, lines 1581--1605.
 -/
 
 open scoped ComplexOrder Kronecker Matrix
@@ -36,7 +36,7 @@ variable {d D : ℕ}
 \]
 
 This is the order in which a neighboring operator acts between sectors \(q\) and \(h\) in
-arXiv:1606.00608, Appendix C.2, equation `sigmaNK2`, lines 1581--1589. -/
+arXiv:1606.00608, Appendix C.2, equation sigmaNK2, lines 1581--1589. -/
 def etaPairSpatialBlockEquiv {K : ℕ} {dl dr : Fin K → ℕ}
     (e : ((q : Fin K) × (Fin (dr q) × Fin (dl q))) ≃ Fin d) :
     ((qh : Fin K × Fin K) ×
@@ -71,12 +71,12 @@ positive neighboring operator \(\eta_{q,h}\) for each ordered pair of sectors su
 
 The unitary and the family \(\eta\) depend only on the fixed two-site bond, not on a chain
 length or a bond position.  Thus this is the local transport from Beigi's block actions to
-the neighboring operators in equation `sigmaNK2`.
+the neighboring operators in equation sigmaNK2.
 
 No zero-correlation-length or area-law hypothesis is used.  In particular, this theorem
-does not assert the rank-one trace factorization invoked later in Proposition `4to2`.
+does not assert the rank-one trace factorization invoked later in Proposition 4to2.
 
-Source: arXiv:1606.00608, Appendix C.2, equation `sigmaNK2` and Proposition `4to2`,
+Source: arXiv:1606.00608, Appendix C.2, equation sigmaNK2 and Proposition 4to2,
 lines 1581--1605; Beigi, arXiv:1105.1019v2, Lemma 2.1. -/
 theorem exists_positive_eta_pairBond_decomposition
     (data : EtaLocalStructureData M) :

--- a/TNLean/MPS/MPDO/CommutingBondEtaDecomposition.lean
+++ b/TNLean/MPS/MPDO/CommutingBondEtaDecomposition.lean
@@ -1,0 +1,286 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.CommutingFormSpatialBridge
+
+/-!
+# Neighboring operators from a translation-invariant commuting bond
+
+This file extracts the positive neighboring operators in the spatial decomposition of a
+single translation-invariant commuting bond.  The same one-site unitary is used at both
+ends of the bond, so the resulting family is independent of the position of the bond in a
+finite chain.
+
+## Main declarations
+
+* `MPOTensor.etaPairSpatialBlockEquiv`
+* `MPOTensor.EtaLocalStructureData.exists_positive_eta_pairBond_decomposition`
+
+## References
+
+* S. Beigi, arXiv:1105.1019v2, Lemma 2.1.
+* arXiv:1606.00608, Appendix C.2, equation `sigmaNK2`, lines 1581--1605.
+-/
+
+open scoped ComplexOrder Kronecker Matrix
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- The index equivalence which orders a pair of spatially decomposed sites as
+\[
+  H_{q,l}\otimes(H_{q,r}\otimes H_{h,l})\otimes H_{h,r}.
+\]
+
+This is the order in which a neighboring operator acts between sectors \(q\) and \(h\) in
+arXiv:1606.00608, Appendix C.2, equation `sigmaNK2`, lines 1581--1589. -/
+def etaPairSpatialBlockEquiv {K : ℕ} {dl dr : Fin K → ℕ}
+    (e : ((q : Fin K) × (Fin (dr q) × Fin (dl q))) ≃ Fin d) :
+    ((qh : Fin K × Fin K) ×
+      ((Fin (dl qh.1) × (Fin (dr qh.1) × Fin (dl qh.2))) × Fin (dr qh.2))) ≃
+      (Fin d × Fin d) where
+  toFun x :=
+    (e ⟨x.1.1, (x.2.1.2.1, x.2.1.1)⟩,
+      e ⟨x.1.2, (x.2.2, x.2.1.2.2)⟩)
+  invFun y :=
+    let x := e.symm y.1
+    let z := e.symm y.2
+    ⟨(x.1, z.1), ((x.2.2, (x.2.1, z.2.2)), z.2.1)⟩
+  left_inv x := by
+    obtain ⟨⟨q, h⟩, ⟨⟨lq, rq, lh⟩, rh⟩⟩ := x
+    simp only
+    rw [e.symm_apply_apply, e.symm_apply_apply]
+  right_inv y := by
+    obtain ⟨i, j⟩ := y
+    simp only
+    rw [e.apply_symm_apply, e.apply_symm_apply]
+
+namespace EtaLocalStructureData
+
+variable {M : MPOTensor d D}
+
+/-- A positive translation-invariant commuting bond has one spatial decomposition and a
+positive neighboring operator \(\eta_{q,h}\) for each ordered pair of sectors such that
+\[
+  (U^*\otimes U^*)B(U\otimes U)
+    =\bigoplus_{q,h}\mathbf 1_{q,l}\otimes\eta_{q,h}\otimes\mathbf 1_{h,r}.
+\]
+
+The unitary and the family \(\eta\) depend only on the fixed two-site bond, not on a chain
+length or a bond position.  Thus this is the local transport from Beigi's block actions to
+the neighboring operators in equation `sigmaNK2`.
+
+No zero-correlation-length or area-law hypothesis is used.  In particular, this theorem
+does not assert the rank-one trace factorization invoked later in Proposition `4to2`.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `sigmaNK2` and Proposition `4to2`,
+lines 1581--1605; Beigi, arXiv:1105.1019v2, Lemma 2.1. -/
+theorem exists_positive_eta_pairBond_decomposition
+    (data : EtaLocalStructureData M) :
+    ∃ (K : ℕ) (dl dr : Fin K → ℕ)
+      (e : ((q : Fin K) × (Fin (dr q) × Fin (dl q))) ≃ Fin d)
+      (U : Matrix (Fin d) (Fin d) ℂ)
+      (η : (q h : Fin K) →
+        Matrix (Fin (dr q) × Fin (dl h)) (Fin (dr q) × Fin (dl h)) ℂ),
+      U ∈ Matrix.unitaryGroup (Fin d) ℂ ∧
+        (∀ q, 0 < dl q) ∧ (∀ q, 0 < dr q) ∧
+        (∀ q h, (η q h).PosSemidef) ∧
+        Matrix.reindex (etaPairSpatialBlockEquiv e).symm
+            (etaPairSpatialBlockEquiv e).symm
+            (star (U ⊗ₖ U) * data.pairBond * (U ⊗ₖ U)) =
+          Matrix.blockDiagonal' fun qh : Fin K × Fin K ↦
+            ((1 : Matrix (Fin (dl qh.1)) (Fin (dl qh.1)) ℂ) ⊗ₖ
+              η qh.1 qh.2) ⊗ₖ
+                (1 : Matrix (Fin (dr qh.2)) (Fin (dr qh.2)) ℂ) := by
+  classical
+  obtain ⟨K, dl, dr, e, U, R, S, hU, hdl, hdr, _, _, hR, hS⟩ :=
+    data.exists_unitary_blockActions_of_pairBond
+  let B' := star (U ⊗ₖ U) * data.pairBond * (U ⊗ₖ U)
+  let BR := star ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ U) * data.pairBond *
+    ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ U)
+  let BS := star (U ⊗ₖ (1 : Matrix (Fin d) (Fin d) ℂ)) * data.pairBond *
+    (U ⊗ₖ (1 : Matrix (Fin d) (Fin d) ℂ))
+  let η : (q h : Fin K) →
+      Matrix (Fin (dr q) × Fin (dl h)) (Fin (dr q) × Fin (dl h)) ℂ :=
+    fun q h x y ↦
+      B' (e ⟨q, (x.1, ⟨0, hdl q⟩)⟩, e ⟨h, (⟨0, hdr h⟩, x.2)⟩)
+        (e ⟨q, (y.1, ⟨0, hdl q⟩)⟩, e ⟨h, (⟨0, hdr h⟩, y.2)⟩)
+  have hUU_left : U ⊗ₖ U =
+      ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ U) *
+        (U ⊗ₖ (1 : Matrix (Fin d) (Fin d) ℂ)) := by
+    rw [← Matrix.mul_kronecker_mul]
+    simp
+  have hUU_right : U ⊗ₖ U =
+      (U ⊗ₖ (1 : Matrix (Fin d) (Fin d) ℂ)) *
+        ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ U) := by
+    rw [← Matrix.mul_kronecker_mul]
+    simp
+  have hB'_left : B' =
+      star (U ⊗ₖ (1 : Matrix (Fin d) (Fin d) ℂ)) * BR *
+        (U ⊗ₖ (1 : Matrix (Fin d) (Fin d) ℂ)) := by
+    dsimp only [B', BR]
+    rw [hUU_left, star_mul]
+    noncomm_ring
+  have hB'_right : B' =
+      star ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ U) * BS *
+        ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ U) := by
+    dsimp only [B', BS]
+    rw [hUU_right, star_mul]
+    noncomm_ring
+  have hR_entry (i i' : Fin d) (h : Fin K) (lh lh' : Fin (dl h))
+      (rh rh' : Fin (dr h)) :
+      BR (i, e ⟨h, (rh, lh)⟩) (i', e ⟨h, (rh', lh')⟩) =
+        R h (i, lh) (i', lh') *
+          (1 : Matrix (Fin (dr h)) (Fin (dr h)) ℂ) rh rh' := by
+    have hEntry := congrFun (congrFun hR ⟨h, ((i, lh), rh)⟩)
+      ⟨h, ((i', lh'), rh')⟩
+    simpa [BR, Matrix.reindex_apply, Matrix.leftSpatialBlockEquiv,
+      Matrix.blockDiagonal'_apply_eq, Matrix.kroneckerMap_apply] using hEntry
+  have hR_entry_ne (i i' : Fin d) (h h' : Fin K) (hh : h ≠ h')
+      (lh : Fin (dl h)) (lh' : Fin (dl h')) (rh : Fin (dr h)) (rh' : Fin (dr h')) :
+      BR (i, e ⟨h, (rh, lh)⟩) (i', e ⟨h', (rh', lh')⟩) = 0 := by
+    have hEntry := congrFun (congrFun hR ⟨h, ((i, lh), rh)⟩)
+      ⟨h', ((i', lh'), rh')⟩
+    simpa [BR, Matrix.reindex_apply, Matrix.leftSpatialBlockEquiv,
+      Matrix.blockDiagonal'_apply_ne _ _ _ hh] using hEntry
+  have hS_entry (q : Fin K) (lq lq' : Fin (dl q)) (rq rq' : Fin (dr q))
+      (j j' : Fin d) :
+      BS (e ⟨q, (rq, lq)⟩, j) (e ⟨q, (rq', lq')⟩, j') =
+        (1 : Matrix (Fin (dl q)) (Fin (dl q)) ℂ) lq lq' *
+          S q (rq, j) (rq', j') := by
+    have hEntry := congrFun (congrFun hS ⟨q, (lq, (rq, j))⟩)
+      ⟨q, (lq', (rq', j'))⟩
+    simpa [BS, Matrix.reindex_apply, Matrix.rightSpatialBlockEquiv,
+      Matrix.blockDiagonal'_apply_eq, Matrix.kroneckerMap_apply] using hEntry
+  have hS_entry_ne (q q' : Fin K) (hq : q ≠ q')
+      (lq : Fin (dl q)) (lq' : Fin (dl q')) (rq : Fin (dr q)) (rq' : Fin (dr q'))
+      (j j' : Fin d) :
+      BS (e ⟨q, (rq, lq)⟩, j) (e ⟨q', (rq', lq')⟩, j') = 0 := by
+    have hEntry := congrFun (congrFun hS ⟨q, (lq, (rq, j))⟩)
+      ⟨q', (lq', (rq', j'))⟩
+    simpa [BS, Matrix.reindex_apply, Matrix.rightSpatialBlockEquiv,
+      Matrix.blockDiagonal'_apply_ne _ _ _ hq] using hEntry
+  have hB'_right_sector_ne (q q' h h' : Fin K) (hh : h ≠ h')
+      (lq : Fin (dl q)) (lq' : Fin (dl q'))
+      (rq : Fin (dr q)) (rq' : Fin (dr q'))
+      (lh : Fin (dl h)) (lh' : Fin (dl h'))
+      (rh : Fin (dr h)) (rh' : Fin (dr h')) :
+      B' (e ⟨q, (rq, lq)⟩, e ⟨h, (rh, lh)⟩)
+          (e ⟨q', (rq', lq')⟩, e ⟨h', (rh', lh')⟩) = 0 := by
+    rw [hB'_left]
+    simp only [Matrix.mul_apply, Matrix.kroneckerMap_apply, Matrix.one_apply,
+      Matrix.star_eq_conjTranspose, Matrix.conjTranspose_kronecker,
+      Matrix.conjTranspose_one, Fintype.sum_prod_type]
+    simp only [mul_ite, ite_mul, mul_one, mul_zero, zero_mul,
+      Finset.sum_ite_eq, Finset.sum_ite_eq', Finset.mem_univ, if_true]
+    simp_rw [hR_entry_ne _ _ h h' hh]
+    simp only [mul_zero, zero_mul, Finset.sum_const_zero]
+  have hB'_left_sector_ne (q q' h h' : Fin K) (hq : q ≠ q')
+      (lq : Fin (dl q)) (lq' : Fin (dl q'))
+      (rq : Fin (dr q)) (rq' : Fin (dr q'))
+      (lh : Fin (dl h)) (lh' : Fin (dl h'))
+      (rh : Fin (dr h)) (rh' : Fin (dr h')) :
+      B' (e ⟨q, (rq, lq)⟩, e ⟨h, (rh, lh)⟩)
+          (e ⟨q', (rq', lq')⟩, e ⟨h', (rh', lh')⟩) = 0 := by
+    rw [hB'_right]
+    simp only [Matrix.mul_apply, Matrix.kroneckerMap_apply, Matrix.one_apply,
+      Matrix.star_eq_conjTranspose, Matrix.conjTranspose_kronecker,
+      Matrix.conjTranspose_one, Fintype.sum_prod_type]
+    simp only [mul_ite, ite_mul, mul_zero, zero_mul]
+    simp [hS_entry_ne q q' hq]
+  have hB'_from_R (q q' h : Fin K)
+      (lq : Fin (dl q)) (lq' : Fin (dl q'))
+      (rq : Fin (dr q)) (rq' : Fin (dr q'))
+      (lh lh' : Fin (dl h)) (rh rh' : Fin (dr h)) :
+      B' (e ⟨q, (rq, lq)⟩, e ⟨h, (rh, lh)⟩)
+          (e ⟨q', (rq', lq')⟩, e ⟨h, (rh', lh')⟩) =
+        (1 : Matrix (Fin (dr h)) (Fin (dr h)) ℂ) rh rh' *
+          ∑ i', (∑ i, star U (e ⟨q, (rq, lq)⟩) i *
+            R h (i, lh) (i', lh')) * U i' (e ⟨q', (rq', lq')⟩) := by
+    rw [hB'_left]
+    simp only [Matrix.mul_apply, Matrix.kroneckerMap_apply, Matrix.one_apply,
+      Matrix.star_eq_conjTranspose, Matrix.conjTranspose_kronecker,
+      Matrix.conjTranspose_one, Fintype.sum_prod_type]
+    simp only [mul_ite, ite_mul, mul_one, mul_zero, zero_mul,
+      Finset.sum_ite_eq, Finset.sum_ite_eq', Finset.mem_univ, if_true]
+    simp_rw [hR_entry]
+    simp [Matrix.one_apply]
+  have hB'_from_S (q h h' : Fin K)
+      (lq lq' : Fin (dl q)) (rq rq' : Fin (dr q))
+      (lh : Fin (dl h)) (lh' : Fin (dl h'))
+      (rh : Fin (dr h)) (rh' : Fin (dr h')) :
+      B' (e ⟨q, (rq, lq)⟩, e ⟨h, (rh, lh)⟩)
+          (e ⟨q, (rq', lq')⟩, e ⟨h', (rh', lh')⟩) =
+        (1 : Matrix (Fin (dl q)) (Fin (dl q)) ℂ) lq lq' *
+          ∑ j', (∑ j, star U (e ⟨h, (rh, lh)⟩) j *
+            S q (rq, j) (rq', j')) * U j' (e ⟨h', (rh', lh')⟩) := by
+    rw [hB'_right]
+    simp only [Matrix.mul_apply, Matrix.kroneckerMap_apply, Matrix.one_apply,
+      Matrix.star_eq_conjTranspose, Matrix.conjTranspose_kronecker,
+      Matrix.conjTranspose_one, Fintype.sum_prod_type]
+    simp only [mul_ite, ite_mul, mul_zero, zero_mul]
+    simp [hS_entry, Matrix.one_apply]
+  have hB'_same_sector (q h : Fin K)
+      (lq lq' : Fin (dl q)) (rq rq' : Fin (dr q))
+      (lh lh' : Fin (dl h)) (rh rh' : Fin (dr h)) :
+      B' (e ⟨q, (rq, lq)⟩, e ⟨h, (rh, lh)⟩)
+          (e ⟨q, (rq', lq')⟩, e ⟨h, (rh', lh')⟩) =
+        (1 : Matrix (Fin (dl q)) (Fin (dl q)) ℂ) lq lq' *
+          η q h (rq, lh) (rq', lh') *
+            (1 : Matrix (Fin (dr h)) (Fin (dr h)) ℂ) rh rh' := by
+    by_cases hl : lq = lq'
+    · subst lq'
+      by_cases hr : rh = rh'
+      · subst rh'
+        let l0 : Fin (dl q) := ⟨0, hdl q⟩
+        let r0 : Fin (dr h) := ⟨0, hdr h⟩
+        have hleft := hB'_from_S q h h lq lq rq rq' lh lh' rh rh
+        have hleft0 := hB'_from_S q h h l0 l0 rq rq' lh lh' rh rh
+        have hright := hB'_from_R q q h l0 l0 rq rq' lh lh' rh rh
+        have hright0 := hB'_from_R q q h l0 l0 rq rq' lh lh' r0 r0
+        simp at hleft hleft0 hright hright0
+        rw [hleft, ← hleft0, hright, ← hright0]
+        simp [η, l0, r0]
+      · rw [hB'_from_R]
+        simp [hr]
+    · rw [hB'_from_S]
+      simp [Matrix.one_apply, hl]
+  refine ⟨K, dl, dr, e, U, η, hU, hdl, hdr, ?_, ?_⟩
+  · intro q h
+    have hpair : data.pairBond.PosSemidef := by
+      have hsub := data.bondData.bond_pos.submatrix
+        (finTwoArrowEquiv (Fin d)).symm
+      simpa [EtaLocalStructureData.pairBond, pairBondMatrix,
+        Matrix.reindex_apply] using hsub
+    have hBpos : B'.PosSemidef := by
+      have hconj := hpair.mul_mul_conjTranspose_same (B := star (U ⊗ₖ U))
+      simpa [B', Matrix.star_eq_conjTranspose] using hconj
+    let f : Fin (dr q) × Fin (dl h) → Fin d × Fin d := fun x ↦
+      (e ⟨q, (x.1, ⟨0, hdl q⟩)⟩, e ⟨h, (⟨0, hdr h⟩, x.2)⟩)
+    have hsub := hBpos.submatrix f
+    change (B'.submatrix f f).PosSemidef
+    exact hsub
+  · change Matrix.reindex (etaPairSpatialBlockEquiv e).symm
+        (etaPairSpatialBlockEquiv e).symm B' = _
+    ext ⟨⟨q, h⟩, ⟨⟨lq, ⟨rq, lh⟩⟩, rh⟩⟩
+      ⟨⟨q', h'⟩, ⟨⟨lq', ⟨rq', lh'⟩⟩, rh'⟩⟩
+    change B' (e ⟨q, (rq, lq)⟩, e ⟨h, (rh, lh)⟩)
+        (e ⟨q', (rq', lq')⟩, e ⟨h', (rh', lh')⟩) = _
+    by_cases hq : q = q'
+    · subst q'
+      by_cases hh : h = h'
+      · subst h'
+        rw [Matrix.blockDiagonal'_apply_eq]
+        simpa [Matrix.kroneckerMap_apply] using
+          hB'_same_sector q h lq lq' rq rq' lh lh' rh rh'
+      · rw [Matrix.blockDiagonal'_apply_ne _ _ _ (fun hp ↦ hh (Prod.mk.inj hp).2)]
+        exact hB'_right_sector_ne q q h h' hh lq lq' rq rq' lh lh' rh rh'
+    · rw [Matrix.blockDiagonal'_apply_ne _ _ _ (fun hp ↦ hq (Prod.mk.inj hp).1)]
+      exact hB'_left_sector_ne q q' h h' hq lq lq' rq rq' lh lh' rh rh'
+
+end EtaLocalStructureData
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -231,6 +231,37 @@
     Theorem~\ref{thm:commuting_overlapping_unitary_block_actions}.
 \end{proof}
 
+\begin{theorem}[Positive neighboring operators from the commuting bond]
+    \label{thm:mpdo_commuting_bond_positive_eta_decomposition}
+    \lean{MPOTensor.EtaLocalStructureData.%
+      exists_positive_eta_pairBond_decomposition}
+    \leanok
+    \uses{thm:mpdo_eta_local_pair_bond_unitary_block_actions}
+    Let $B$ be the pair-indexed positive bond of an $\eta$-local structure.
+    There are a unitary decomposition
+    \[
+        H\cong\bigoplus_q H_{q,l}\otimes H_{q,r}
+    \]
+    and positive semidefinite operators
+    $\eta_{q,h}$ on $H_{q,r}\otimes H_{h,l}$ such that
+    \[
+        (U^*\otimes U^*)B(U\otimes U)
+        =\bigoplus_{q,h}
+          \Id_{H_{q,l}}\otimes\eta_{q,h}\otimes\Id_{H_{h,r}}.
+    \]
+    The unitary and the neighboring operators depend only on the fixed bond,
+    and hence are independent of a chain length or bond position.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_eta_local_pair_bond_unitary_block_actions}
+    Apply the same unitary block decomposition at both ends of $B$.  One
+    block identity gives the identity action on $H_{q,l}$ and the other gives
+    the identity action on $H_{h,r}$.  Their common matrix coefficients define
+    $\eta_{q,h}$.  It is a principal compression of the positive doubly
+    conjugated bond, and is therefore positive semidefinite.
+\end{proof}
+
 \begin{theorem}[A translation-invariant commuting bond and ZCL imply SAL]
     \label{thm:mpdo_translation_invariant_commuting_form_zcl_sal}
     \notready
@@ -248,8 +279,9 @@
 
     This is the proposition at
     \cite[Appendix~C.2, lines~1597--1619]{Cirac2016MPDO_arXiv}.
-    % The Bravyi--Vyalyi spatial decomposition and the subsequent source-ZCL
-    % trace factorization remain open. Gap documented in
+    % The local positive neighboring operators are constructed.  The printed
+    % rank-one inference at source line 1613 remains obstructed by #3593. Gap
+    % documented in
     % docs/paper-gaps/cpsv16_commuting_form_to_sal.tex.
 \end{theorem}
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -260,11 +260,18 @@
 
 \begin{proof}\leanok
     \uses{thm:mpdo_eta_local_pair_bond_unitary_block_actions}
-    Apply the same unitary block decomposition at both ends of $B$.  One
-    block identity gives the identity action on $H_{q,l}$ and the other gives
-    the identity action on $H_{h,r}$.  Their common matrix coefficients define
-    $\eta_{q,h}$.  It is a principal compression of the positive doubly
-    conjugated bond, and is therefore positive semidefinite.
+    The same unitary block decomposition at both ends of $B$ gives identity
+    action on $H_{q,l}$ through one block identity and on $H_{h,r}$ through
+    the other.  For fixed basis indices
+    $l_q^0\in H_{q,l}$ and $r_h^0\in H_{h,r}$, let
+    $B'=(U^*\otimes U^*)B(U\otimes U)$.  The neighboring operator has entries
+    \[
+        (\eta_{q,h})_{(r,l),(r',l')}
+        =(B'_{q,h})_{(l_q^0,(r,l),r_h^0),
+          (l_q^0,(r',l'),r_h^0)}.
+    \]
+    Thus $\eta_{q,h}$ is a principal compression of the positive operator
+    $B'$, and is therefore positive semidefinite.
 \end{proof}
 
 \begin{theorem}[A translation-invariant commuting bond and ZCL imply SAL]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -238,12 +238,17 @@
     \leanok
     \uses{thm:mpdo_eta_local_pair_bond_unitary_block_actions}
     Let $B$ be the pair-indexed positive bond of an $\eta$-local structure.
-    There are a unitary decomposition
+    There are a unitary coordinate decomposition
     \[
-        H\cong\bigoplus_q H_{q,l}\otimes H_{q,r}
+        H\cong\bigoplus_q H_{q,r}\otimes H_{q,l}
     \]
     and positive semidefinite operators
-    $\eta_{q,h}$ on $H_{q,r}\otimes H_{h,l}$ such that
+    $\eta_{q,h}$ on $H_{q,r}\otimes H_{h,l}$.  After regrouping the
+    two-site coordinates, the $(q,h)$-sector is
+    \[
+        H_{q,l}\otimes(H_{q,r}\otimes H_{h,l})\otimes H_{h,r},
+    \]
+    and in these regrouped coordinates
     \[
         (U^*\otimes U^*)B(U\otimes U)
         =\bigoplus_{q,h}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -263,12 +263,12 @@
     The same unitary block decomposition at both ends of $B$ gives identity
     action on $H_{q,l}$ through one block identity and on $H_{h,r}$ through
     the other.  For fixed basis indices
-    $l_q^0\in H_{q,l}$ and $r_h^0\in H_{h,r}$, let
+    $\ell_q^0\in H_{q,l}$ and $r_h^0\in H_{h,r}$, let
     $B'=(U^*\otimes U^*)B(U\otimes U)$.  The neighboring operator has entries
     \[
-        (\eta_{q,h})_{(r,l),(r',l')}
-        =(B'_{q,h})_{(l_q^0,(r,l),r_h^0),
-          (l_q^0,(r',l'),r_h^0)}.
+        (\eta_{q,h})_{(r,\ell),(r',\ell')}
+        =B'_{(q,r,\ell_q^0;h,r_h^0,\ell),
+          (q,r',\ell_q^0;h,r_h^0,\ell')}.
     \]
     Thus $\eta_{q,h}$ is a principal compression of the positive operator
     $B'$, and is therefore positive semidefinite.

--- a/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
+++ b/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
@@ -143,11 +143,36 @@ in \doclink{TNLean/MPS/MPDO/CommutingFormSpatialBridge}; its coordinate and
 commutation hypotheses are supplied by
 \doclink{TNLean/MPS/MPDO/CommutingOverlappingCoordinates}.}
 
-What remains is to transport the resulting direct-sum decomposition through
-the translation-invariant family and derive the neighboring operators
-$\eta_{k,h}$ without assuming a Hayashi decomposition.  The source ZCL
-hypothesis must then yield the rank-one trace factorization
-$\operatorname{tr}(\eta_{k,h})=a_kb_h$ at source lines~1610--1616.
+The local neighboring operators have now been extracted without assuming a
+Hayashi decomposition.  The theorem
+\leanid{MPOTensor.EtaLocalStructureData.exists_positive_eta_pairBond_decomposition}
+uses the same one-site unitary at both ends of the fixed bond and proves
+\[
+ (U^*\otimes U^*)B(U\otimes U)
+ =\bigoplus_{k,h}\Id_{H_{k,l}}\otimes\eta_{k,h}\otimes\Id_{H_{h,r}},
+ \qquad \eta_{k,h}\succeq0.
+\]
+Since the bond and unitary are chain-independent, this is one neighboring
+family for every translate.  The remaining transport task is the finite-chain
+direct-sum product formula and its use in the Markov decomposition.
+
+There is a separate obstruction at source line~1613.  The phrase ``arguing as
+in Lemmas \emph{propSN} and \emph{SALZCL}'' does not show that source ZCL alone
+gives
+$\operatorname{tr}(\eta_{k,h})=a_kb_h$.  Lemma \emph{propSN} obtains
+primitivity from SAL, which is the conclusion being proved in Proposition
+\emph{4to2}; Lemma \emph{SALZCL} then uses the invalid
+trace-power-to-rank-one inference recorded in
+\path{docs/paper-gaps/cpgsv17_pf_rank_one.tex}.  Formally, source ZCL yields an
+idempotent normalized pairing operator, but for the opposite product it yields
+only $\widehat T^2=\widehat T^3$ and constant positive-power traces.  The
+four-sector example
+\leanid{MPOTensor.ActiveSectorSpanningCounterexample.%
+virtual_spanning_does_not_force_rectangular_remainder_zero}
+satisfies the recorded
+positivity, primitivity, trace-one, and spanning conditions while its trace
+matrix is not idempotent.  The source-faithful rank-one question remains
+\ghissue{3593}.
 
 Consequently the source implication
 \[
@@ -172,14 +197,16 @@ restriction that isolates only its final entropy-theoretic step.
 The gap can be removed in the following stages.
 
 \begin{enumerate}
-\item Transport the Beigi block actions through the translation-invariant bond
-family, obtaining the neighboring operators $\eta_{k,h}$ without assuming a
-Hayashi decomposition.  Use \leanid{MPOTensor.IsSourceZCL} to prove the
-rank-one trace factorization
-$\operatorname{tr}(\eta_{k,h})=a_kb_h$ appearing at source lines~1610--1616.
-Then trace the fourth region and construct the quantum Markov decomposition at
-each admissible cut, and apply the all-cut Markov theorem above.
-Only then may the source proposition receive a formal declaration and a
+\item Derive the finite-chain form of equation \emph{sigmaNK2} from the proved
+local positive neighboring-operator decomposition.
+\item Resolve \ghissue{3593} by finding a source-faithful property of the
+actual neighboring family which excludes the nilpotent zero-eigenspace, or
+replace the printed line-1613 argument by a direct Markov decomposition which
+does not require the rank-one trace matrix.  Source ZCL alone must not be
+presented as giving the factorization.
+\item Trace the fourth region, construct the quantum Markov decomposition at
+each admissible cut, and apply the all-cut Markov theorem.  Only then may the
+source proposition receive a formal declaration and a
 \texttt{\string\leanok} marker.
 \end{enumerate}
 


### PR DESCRIPTION
## Summary

- extracts positive neighboring operators from the unitary Beigi block actions of one translation-invariant commuting bond;
- proves the dependent direct-sum identity
  $$
  (U^*\otimes U^*)B(U\otimes U)
  =\bigoplus_{q,h}\mathbf 1_{H_{q,l}}\otimes\eta_{q,h}\otimes\mathbf 1_{H_{h,r}},
  \qquad \eta_{q,h}\succeq0;
  $$
- records the theorem in the blueprint and narrows the commuting-form paper-gap note;
- corrects the line-1613 audit: source ZCL yields the normalized rectangular-pairing relations, not the requested rank-one trace factorization.

## Mathematical scope

The construction uses the same one-site unitary at both ends of the fixed bond. The two block-action identities force identity action on the outer complementary factors, and their common coefficients define $\eta_{q,h}$ on $H_{q,r}\otimes H_{h,l}$. Positivity follows because each $\eta_{q,h}$ is a principal compression of the positive doubly conjugated bond.

No ZCL or SAL hypothesis is used. This PR does not assert the rank-one factorization $\operatorname{tr}(\eta_{q,h})=a_qb_h$. The printed appeal to `propSN` and `SALZCL` at CPSV16 line 1613 is circular for Proposition `4to2` and inherits the invalid Perron--Frobenius inference documented in `docs/paper-gaps/cpgsv17_pf_rank_one.tex`. The source-faithful rank-one question remains #3593.

## Verification

- `lake env lean TNLean/MPS/MPDO/CommutingBondEtaDecomposition.lean`
- `lake build TNLean.MPS.MPDO.CommutingBondEtaDecomposition`
- `lake build`
- `cd blueprint && leanblueprint checkdecls`
- forbidden-token scan of the new Lean file

Closes #4211.

Related: #3593, #4191, #4175, #2380, #232.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formalization and documentation only; no runtime, auth, or data-path changes. Risk is mainly proof maintenance in specialized MPDO Lean code.
> 
> **Overview**
> Adds **`CommutingBondEtaDecomposition.lean`**, which defines `Matrix.etaPairSpatialBlockEquiv` and proves `exists_positive_eta_pairBond_decomposition`: from existing Beigi block actions on `EtaLocalStructureData.pairBond`, the same one-site unitary at both ends yields PSD **η_{q,h}** with the direct-sum identity matching CPSV16 σNK2. Positivity is via principal compression; **no ZCL/SAL** and **no** rank-one trace factorization.
> 
> Registers the module in **`TNLean.lean`**, adds blueprint **Theorem** `thm:mpdo_commuting_bond_positive_eta_decomposition`, and updates **`cpsv16_commuting_form_to_sal.tex`**: local η extraction is done; the line-1613 rank-one step stays open (**#3593**), with a revised elimination plan.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e85eafd6382e0f27527cebfa7f78a3fd9abf202. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->