### PR TITLE
doc(MPS/MPDO): list active-sector weight conditions

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity.tex
@@ -417,11 +417,18 @@
     \leanok
     \uses{def:mpdo_physical_sector_factorization,
       def:mpdo_active_sector_trace_matrix}
-    There is an injective tensor of bond dimension two with four one-dimensional
-    physical sectors, carrying equal positive weights $p_k=1/4$ summing to one,
-    such that the following statements hold simultaneously: it has source zero
-    correlation length; its sector virtual matrices span $\MN{2}$; its
-    physical-trace transfer is idempotent; every neighboring operator is
+    There is a tensor of bond dimension two with four one-dimensional physical
+    sectors and weights $p_k$ such that the following statements hold
+    simultaneously: the tensor is injective and has source zero correlation
+    length; its physical-trace transfer is idempotent; the weights satisfy
+    \[
+        \forall k\in\{0,1,2,3\},\quad p_k=\frac14,
+        \qquad
+        \forall k\in\{0,1,2,3\},\quad 0\leq p_k,
+        \qquad
+        \sum_{k=0}^{3}p_k=1;
+    \]
+    its sector virtual matrices span $\MN{2}$; every neighboring operator is
     positive semidefinite; and its active trace matrix is primitive and has
     trace one.  Nevertheless, if
     $S=LQ$ is the physical-trace transfer and $T=QL$ is the active trace matrix,


### PR DESCRIPTION
## Summary

- list equal sector weights as an explicit simultaneous conclusion;
- list sector-weight nonnegativity and normalization separately, matching the Lean conjunction;
- keep the theorem framed as the corrected local virtual-spanning counterexample.

## Scope

This documents the scope-restricted counterexample proved by `virtual_spanning_does_not_force_rectangular_remainder_zero`. It is not a formalization or refutation of CPSV16 Lemma C.5, and it does not resolve the rank-one boundary in #3593.

## Validation

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity.tex`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

Local `checkdecls` was invoked, but the shared root build cache was incomplete after current-main churn (`Existence.olean` absent). Pull-request CI provides the authoritative clean render and declaration check.

Closes #4208

Does not close #3593.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX edit to a theorem statement; no Lean or runtime behavior changes.
> 
> **Overview**
> Updates the statement of **Theorem** (virtual spanning active trace counterexample) in `ch21_mpdo_rfp_simple_local_primitivity.tex` so reader-facing prose matches `virtual_spanning_does_not_force_rectangular_remainder_zero`.
> 
> The opening no longer folds equal weights into a single “carrying equal positive weights $p_k=1/4$ summing to one” phrase. It introduces weights $p_k$, reorders simultaneous conclusions (injectivity, source ZCL, idempotent physical-trace transfer before spanning/PSD/primitivity), and adds a displayed block with three separate conditions: $p_k=\frac14$ for $k\in\{0,1,2,3\}$, $0\leq p_k$, and $\sum_{k=0}^3 p_k=1$—the same split as in Lean. The counterexample conclusion ($Q(1-S)L=T-T^2\ne0$) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5db10c3ef7119ee161c75da830577e4a23c1e38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->