### PR TITLE
doc(docs): add tactic self-improvement loop, pattern ledger, and scanner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,7 +134,8 @@ process is in `docs/tactic_development.md`; the pattern ledger is
 3. **Record** noticed repetition as a candidate entry in the ledger — in the
    same PR; recording is cheap and needs no design decision.
 4. **Promote** when a pattern hits ≥ 3 occurrences across ≥ 2 files (rule of
-   three): prefer a lemma, then a simp set, then a macro, then an elab tactic
+   three): prefer a lemma, then a simp set, then `@[grind]` annotations +
+   `grind` for goal-closing patterns, then a macro, then an elab tactic
    (weakest mechanism that removes the duplication). Refactor the known call
    sites and update the ledger entry.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,8 @@ Detailed conventions live in `docs/`. Read the relevant file before working in t
 | [`docs/blueprint_style_guide.md`](docs/blueprint_style_guide.md) | LaTeX conventions, `\lean{}`/`\leanok` tags, notation table, `\uses` rules, blueprint build commands |
 | [`docs/prose_style.md`](docs/prose_style.md) | Prose conventions: no Lean jargon in the leanblueprint, banned software-engineering terms, banned LLM writing patterns (applies to `.tex` AND Lean docstrings/comments) |
 | [`docs/ci-automation.md`](docs/ci-automation.md) | CI workflows, auto-fix loops, iteration caps, commit message conventions |
+| [`docs/tactic_development.md`](docs/tactic_development.md) | Tactic self-improvement loop: detecting repeated proof patterns, promotion criteria, design rules for custom tactics/simp sets |
+| [`docs/tactic_patterns.md`](docs/tactic_patterns.md) | Living pattern ledger: promoted tactics, candidate patterns awaiting abstraction |
 
 ### Quick Reference (from the docs above)
 
@@ -111,6 +113,30 @@ When writing new proofs or closing sorrys, scout Mathlib first:
 - Grep Mathlib source: `.lake/packages/mathlib/Mathlib/` for related definitions/theorems
 - Reuse Mathlib lemmas rather than reproving from scratch
 - Not needed for cosmetic fixes, docstrings, imports, or renaming
+
+### Tactic Self-Improvement Loop
+
+Proof text must grow sublinearly with mathematical content: a tactic pattern
+paid for three times gets abstracted, not copied a fourth time. The full
+process is in `docs/tactic_development.md`; the pattern ledger is
+`docs/tactic_patterns.md`. In every proof-writing session:
+
+1. **Consult** the ledger's promoted section first and use existing custom
+   tactics/simp sets (`mpv_ext`, `block_words`, `transfer_simp` in
+   `TNLean/MPS/Tactic/Basic.lean`) where they apply — hand-writing a pattern
+   that has a promoted tactic is a review-blocking style issue.
+2. **Detect** repetition while writing, and in proof-heavy PRs run:
+
+   ```bash
+   python3 scripts/tactic_pattern_scan.py
+   ```
+
+3. **Record** noticed repetition as a candidate entry in the ledger — in the
+   same PR; recording is cheap and needs no design decision.
+4. **Promote** when a pattern hits ≥ 3 occurrences across ≥ 2 files (rule of
+   three): prefer a lemma, then a simp set, then a macro, then an elab tactic
+   (weakest mechanism that removes the duplication). Refactor the known call
+   sites and update the ledger entry.
 
 ### Blueprint Updates
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,8 @@ source-faithfulness requirements.
 - `pr_review_management.md`
 - `prose_style.md`
 - `stale_issue_audit.md`
+- `tactic_development.md`
+- `tactic_patterns.md`
 - `tn_diagram_grammar.md`
 - `upgrade_4_29.md`
 

--- a/docs/tactic_development.md
+++ b/docs/tactic_development.md
@@ -69,13 +69,59 @@ Prefer the weakest mechanism that removes the duplication, in this order:
    rewrites (`simp only [a, b, c, ...]` repeated verbatim), tag the lemmas
    with a custom attribute and replace the list with the set. Existing sets:
    `mps_block_words`, `mps_transfer`.
-3. **A macro** (`macro "name" : tactic => ...`). Thin sugar over a fixed
+3. **`@[grind]` annotations + `grind`.** When the block *closes* a goal
+   (rather than normalizing it) by combining hypotheses, case-splitting, and
+   arithmetic, try the core `grind` tactic before writing any custom tactic.
+   Like a simp set, its power is declarative and cumulative: tagging project
+   lemmas `@[grind]` / `@[grind =]` / `@[grind →]` teaches it a theory once
+   and every later leaf goal in that theory benefits. See
+   [Using `grind`](#using-grind) below.
+4. **A macro** (`macro "name" : tactic => ...`). Thin sugar over a fixed
    tactic sequence. Cheap to write, transparent to review, easy to inline
    away if it ages badly.
-4. **An elab tactic** (`elab "name" : tactic => ...`). Only when the pattern
+5. **An elab tactic** (`elab "name" : tactic => ...`). Only when the pattern
    needs goal inspection or branching (like `mpv_ext`). These cost the most
    to review and maintain; the ledger entry must say why a macro is not
    enough.
+
+## Using `grind`
+
+The core `grind` tactic (congruence closure, E-matching over annotated
+lemmas, case splitting, linear-arithmetic and commutative-ring solvers) is
+available on this toolchain and already used in the codebase
+(`TNLean/Channel/Schwarz/OperatorJensenAux.lean`,
+`TNLean/Axioms/OperatorConvexity.lean`) — chiefly as a side-condition
+discharger, e.g. `fun_prop (disch := grind)` and spectrum-membership
+arithmetic. It produces ordinary kernel-checked proofs, so none of the
+`docs/PROOF_INTEGRITY.md` blocker concerns apply (it is *not* in the
+`native_decide` class).
+
+Where it fits in this project:
+
+- **Leaf goals, not normalization.** `grind` either closes a goal or fails;
+  it does not leave a usable normal form. Use it as a terminal discharger
+  after the structural steps (`ext`, `mpv_ext`, `block_words`, …) have
+  exposed a first-order goal. The "no search" rule below therefore also
+  means: never wrap `grind` inside a promoted normalization tactic; call it
+  explicitly at the leaf so failures are local and visible.
+- **Annotate theories, not proofs.** The sustainable win is tagging the
+  project's characterizing lemmas (`@[grind =]` for defining equations,
+  `@[grind →]` for implications) in the file that proves them, exactly as
+  simp-set membership is declared. A candidate ledger entry whose block is
+  "combine these three lemmas and split cases" is often better discharged by
+  annotating those lemmas than by a macro.
+- **Known limits.** Binder-heavy goals (`Finset.sum`/`prod` congruence with
+  function arguments), noncommutative-ring identities (matrix algebra — its
+  ring solver is commutative), and instance-synthesis problems are outside
+  its reach; those stay on the lemma/simp-set/macro path.
+- **Budget.** `grind` searches, so it costs elaboration time. If a call
+  needs a `maxHeartbeats` bump (a `docs/PROOF_INTEGRITY.md` warning), write
+  the explicit proof instead. When an explicit 2-3 line proof is stable and
+  fast, prefer it; `grind` earns its keep on goals whose explicit proofs are
+  long, brittle, or repeated.
+- **Record it.** When `grind` closes a ledger candidate outright, resolve
+  the entry as *promoted* with abstraction "`grind` (+ the annotations
+  added)" so the pattern is not re-proposed as a macro later.
 
 ## Design rules for promoted tactics
 

--- a/docs/tactic_development.md
+++ b/docs/tactic_development.md
@@ -1,0 +1,124 @@
+# Tactic Self-Improvement Loop
+
+This document defines the process by which repeated proof patterns are
+detected, recorded, and promoted into reusable lemmas, simp sets, and custom
+tactics. The goal is that **proof text grows sublinearly with the mathematical
+content**: a pattern paid for once should never be paid for a fourth time.
+
+The process has two artifacts:
+
+- **This document** — the process rules (stable).
+- [`docs/tactic_patterns.md`](tactic_patterns.md) — the *pattern ledger*, a
+  living registry of observed patterns and their status (updated continuously).
+
+Promoted tactics live in the source tree:
+
+- `TNLean/MPS/Tactic/Basic.lean` — MPS/channel/overlap-specific simp sets and
+  tactic macros (`mpv_ext`, `block_words`, `transfer_simp`).
+- `TNLean/Tactic/` — cross-cutting tactics not tied to MPS (create the
+  directory when the first such tactic is promoted).
+
+## The loop
+
+Every proof-writing session (closing a `sorry`, adding a theorem, refactoring
+a proof) follows this loop:
+
+1. **Consult** — before writing a proof, skim the ledger's *promoted* section
+   and use existing tactics/simp sets where they apply. Writing out by hand a
+   pattern that already has a promoted tactic is a review-blocking style issue.
+2. **Detect** — while writing, notice when you copy-paste or re-derive a
+   tactic block you have seen before. Periodically (and in any PR that touches
+   many proofs) run the scanner:
+
+   ```bash
+   python3 scripts/tactic_pattern_scan.py                 # default report
+   python3 scripts/tactic_pattern_scan.py --min-count 5   # stricter
+   ```
+
+3. **Record** — add newly noticed repetition to the ledger as a *candidate*
+   entry (see the entry format in `docs/tactic_patterns.md`). Recording is
+   cheap and requires no design decision; do it in the same PR.
+4. **Promote** — when a candidate meets the promotion criteria below, implement
+   the abstraction, mark the ledger entry *promoted*, and link the declaration.
+5. **Refactor** — rewrite the call sites the scanner found to use the
+   abstraction, in the same PR as the promotion or an immediately-following
+   `refactor(...)` PR. Record the net line delta in the ledger entry.
+6. **Retire** — if a promoted tactic loses all call sites (e.g. the underlying
+   API changed), mark it *retired* in the ledger and deprecate or delete it.
+
+## Promotion criteria
+
+Promote a candidate when **either**:
+
+- it occurs **>= 3 times across >= 2 files** (rule of three), or
+- it is **>= 5 lines and occurs >= 2 times** with more occurrences clearly
+  coming (e.g. an in-progress multi-file development).
+
+Below these thresholds, leave the entry as a candidate — premature
+abstraction is its own maintenance cost.
+
+## Choosing the abstraction
+
+Prefer the weakest mechanism that removes the duplication, in this order:
+
+1. **A lemma.** Most "repeated tactic blocks" are a missing lemma. If the
+   block proves the same *statement shape* each time, state that shape once
+   and `exact`/`apply` it. Scout Mathlib first (`exact?`, `rw?`, grep
+   `.lake/packages/mathlib/Mathlib/`) — the lemma may already exist.
+2. **A simp set** (`register_simp_attr`). When the block is a fixed list of
+   rewrites (`simp only [a, b, c, ...]` repeated verbatim), tag the lemmas
+   with a custom attribute and replace the list with the set. Existing sets:
+   `mps_block_words`, `mps_transfer`.
+3. **A macro** (`macro "name" : tactic => ...`). Thin sugar over a fixed
+   tactic sequence. Cheap to write, transparent to review, easy to inline
+   away if it ages badly.
+4. **An elab tactic** (`elab "name" : tactic => ...`). Only when the pattern
+   needs goal inspection or branching (like `mpv_ext`). These cost the most
+   to review and maintain; the ledger entry must say why a macro is not
+   enough.
+
+## Design rules for promoted tactics
+
+These extend the design notes in `TNLean/MPS/Tactic/Basic.lean`:
+
+- **No search.** Promoted tactics normalize or discharge a *known* pattern.
+  When the pattern does not apply they must fail fast or leave clear unsolved
+  goals — never silently try alternatives. (Search belongs in interactive
+  scouting with `exact?`/`apply?`, not in committed proofs.)
+- **Docstring states the pattern.** Every promoted tactic's docstring shows
+  the tactic block it replaces, so `grep` on the old pattern leads to the
+  replacement.
+- **Named per Mathlib conventions** (`docs/MATHLIB_naming.md`): tactics and
+  simp attributes are `snake_case`; MPS-specific sets carry the `mps_` prefix.
+- **One file per topic.** Keep MPS-specific tactics in `TNLean/MPS/Tactic/`,
+  cross-cutting ones in `TNLean/Tactic/`; do not scatter `register_simp_attr`
+  calls through content files.
+- **Simp-set hygiene.** A lemma enters a custom simp set via
+  `attribute [mps_foo] lemma_name` next to the lemma (or `@[mps_foo]` at the
+  declaration), and the set's registration docstring lists its intended
+  normal form.
+
+## Scanner notes
+
+`scripts/tactic_pattern_scan.py` is a heuristic line-based n-gram scanner,
+not a Lean parser:
+
+- It only sees lines starting with a known tactic keyword; extend its
+  `TACTIC_HEADS` list when a promoted tactic introduces a new head symbol
+  (e.g. `mpv_ext` is already listed).
+- It excludes `Archive/` and `Scratch/`.
+- Its ranking weight is `lines x occurrences` — an estimate of removable
+  lines, not a proof of semantic equivalence. Always confirm that the
+  occurrences really are the same pattern (same goal shape, not just the
+  same text) before promoting.
+- It is a reporting tool, not a lint gate: it never fails CI.
+
+## Interaction with other rules
+
+- Promotion refactors are `refactor(scope):` PRs (`docs/CONTRIBUTING.md`)
+  and must not change theorem statements — only proof text.
+- A promotion PR must keep `lake build` clean; there is no
+  paper-realignment relaxation here since statements are untouched.
+- Ledger updates (`docs/tactic_patterns.md`) do not require blueprint
+  changes; the ledger is engineering metadata, not mathematics, and the
+  prose rules of `docs/prose_style.md` do not apply to it.

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -1,0 +1,157 @@
+# Tactic Pattern Ledger
+
+Living registry of repeated proof patterns, maintained under the process in
+[`docs/tactic_development.md`](tactic_development.md). Agents and contributors:
+**consult the promoted section before writing proofs; append candidates when
+you meet repetition; promote when the criteria are met.**
+
+Entry format:
+
+```markdown
+### <short-name> — <status>
+- **Pattern:** the repeated tactic block (fenced code)
+- **Seen:** N occurrences (representative `file:line` list, or scanner output date)
+- **Abstraction:** the promoted declaration, or the proposed one for candidates
+- **Notes:** goal shape, caveats, line delta after refactor
+```
+
+Statuses: `candidate` (recorded, below promotion threshold or not yet
+implemented), `promoted` (abstraction exists; call sites refactored),
+`retired` (abstraction removed), `rejected` (examined and deliberately not
+abstracted — record why, so it is not re-proposed).
+
+---
+
+## Promoted
+
+### mpv_ext — promoted
+- **Pattern:** `intro N σ` / `intro N hN σ` prelude for `SameMPV₂` /
+  `SameMPV₂Pos` goals.
+- **Abstraction:** `mpv_ext` (elab tactic, `TNLean/MPS/Tactic/Basic.lean`).
+- **Notes:** elab rather than macro because it inspects the goal to
+  distinguish the two predicate forms.
+
+### block_words — promoted
+- **Pattern:** repeated `simp only [...]` lists normalizing direct/iterated
+  blocking maps and `wordOfBlock` expressions.
+- **Abstraction:** `@[mps_block_words]` simp set + `block_words` macro
+  (`TNLean/MPS/Tactic/Basic.lean`).
+- **Notes:** used across `MPS/Core/Blocking.lean`,
+  `MPS/Core/BlockingInfrastructure.lean`, `MPS/ParentHamiltonian/BlockStrip.lean`.
+
+### transfer_simp — promoted
+- **Pattern:** unfolding `transferMap A X` to `∑ i, A i * X * (A i)ᴴ`.
+- **Abstraction:** `@[mps_transfer]` simp set + `transfer_simp` macro
+  (`TNLean/MPS/Tactic/Basic.lean`).
+
+---
+
+## Candidates
+
+Seeded from `scripts/tactic_pattern_scan.py` (2026-07-18 scan; re-run for
+current counts and full location lists).
+
+### matrix_entry_cases — candidate
+- **Pattern:**
+  ```
+  ext i j
+  by_cases hij : i = j
+  · subst hij
+    ...
+  ```
+- **Seen:** 10 occurrences across >= 4 files
+  (`TNLean/Algebra/HermitianHelpers.lean:115`,
+  `TNLean/Algebra/HermitianHelpers.lean:144`,
+  `TNLean/Channel/ChoiJamiolkowski.lean:407`,
+  `TNLean/Channel/ChoiTypeMap.lean:308`, +6 more).
+- **Abstraction (proposed):** cross-cutting macro `matrix_entry_cases`
+  (in a new `TNLean/Tactic/Basic.lean`) that performs the entrywise
+  extensionality plus diagonal/off-diagonal split, leaving the two goals
+  named. Check first whether the diagonal-matrix Mathlib API
+  (`Matrix.diagonal_apply_ne` etc.) turns specific call sites into lemmas
+  instead.
+
+### clm_norm_instances — candidate
+- **Pattern:**
+  ```
+  letI : NormedAddCommGroup (V →L[ℂ] V) := ContinuousLinearMap.toNormedAddCommGroup
+  letI : SeminormedRing (V →L[ℂ] V) := ContinuousLinearMap.toSeminormedRing
+  letI : NormedRing (V →L[ℂ] V) := ContinuousLinearMap.toNormedRing
+  letI : NormedSpace ℂ (V →L[ℂ] V) := ContinuousLinearMap.toNormedSpace
+  letI : NormedAlgebra ℂ (V →L[ℂ] V) := ContinuousLinearMap.toNormedAlgebra
+  ```
+- **Seen:** 5 occurrences (`TNLean/MPS/RFP/BNTOrthogonality.lean:423`,
+  `TNLean/Spectral/MPVOverlapDecay.lean:174`,
+  `TNLean/Spectral/PrimitiveOverlap.lean:101`,
+  `TNLean/Spectral/TransferOperatorGap.lean:459`, +1).
+- **Abstraction (proposed):** not a tactic — investigate why these instances
+  need `letI` at all (likely an instance-resolution gap); either fix the
+  underlying instance visibility once in a shared file, or provide a
+  `clm_norm_instances` macro expanding to the block.
+
+### peps_prod_entry_congr — candidate
+- **Pattern:**
+  ```
+  refine Finset.prod_congr rfl (fun w _ => ?_)
+  congr 1
+  funext ie
+  ```
+- **Seen:** 12 occurrences across PEPS files
+  (`TNLean/PEPS/NormalFundamentalTheorem.lean:106`,
+  `TNLean/PEPS/RegionBlock/InsertResidual.lean:468`,
+  `TNLean/PEPS/RegionBlock/Recovery.lean:239`, +9 more).
+- **Abstraction (proposed):** likely a missing congruence lemma for
+  PEPS region products rather than a tactic; state it once in
+  `TNLean/PEPS/RegionBlock/` and `apply` it.
+
+### filter_sum_split — candidate
+- **Pattern:**
+  ```
+  · refine Finset.sum_congr rfl (fun η hη => ?_)
+    rw [Finset.mem_filter] at hη
+    rw [if_pos hη.2]
+  · refine Finset.sum_eq_zero (fun η hη => ?_)
+    rw [Finset.mem_filter] at hη
+    rw [if_neg hη.2, smul_zero]
+  ```
+- **Seen:** 5 occurrences in `TNLean/PEPS/RegionBlock/`
+  (`ThreeBlockResonate.lean:682`, `ThreeBlockResonate2.lean:452`,
+  `UnionInjectivityGeneral.lean:505`, +2).
+- **Abstraction (proposed):** a lemma of the shape
+  `∑ η in s.filter p, (if p η then f η else 0) • g η = ...` — scout
+  Mathlib's `Finset.sum_filter` / `Finset.sum_ite_of_true` family first.
+
+### two_positive_bilinear_checks — candidate
+- **Pattern:** alternating `· intro i / simp` and
+  `· intro i u v / simp [mul_assoc, mul_add]` blocks discharging
+  bilinearity side goals.
+- **Seen:** 9 occurrences, all in `TNLean/Channel/Schwarz/TwoPositive.lean`
+  (lines 359-396).
+- **Abstraction (proposed):** single-file duplication — restructure the
+  underlying definition to take a bundled bilinear map, or a local
+  `macro`/`have` inside the file. Below cross-file threshold; promote only
+  if the pattern escapes `TwoPositive.lean`.
+
+### region_cover_union_cases — candidate
+- **Pattern:**
+  ```
+  rcases Finset.mem_union.mp hcover with hrb | hc
+  · rcases Finset.mem_union.mp hrb with hr | hbl
+  · exact absurd hr hwnotred
+  ```
+- **Seen:** 9 occurrences in `TNLean/PEPS/RegionBlock/`
+  (`CoarseThreeSite3.lean:89`, `ThreeBlockReconcile.lean:244`,
+  `ThreeBlockResonate.lean:96`, +6).
+- **Abstraction (proposed):** a case-elimination lemma on the three-region
+  cover (membership in red/blue/crossing regions) stated once in the
+  RegionBlock development.
+
+---
+
+## Rejected
+
+(none yet)
+
+## Retired
+
+(none yet)

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -69,7 +69,10 @@ current counts and full location lists).
   extensionality plus diagonal/off-diagonal split, leaving the two goals
   named. Check first whether the diagonal-matrix Mathlib API
   (`Matrix.diagonal_apply_ne` etc.) turns specific call sites into lemmas
-  instead.
+  instead. Also try `ext i j <;> grind` at a few call sites (with
+  `Matrix.diagonal_apply`-family lemmas `@[grind =]`-tagged if needed) —
+  the case split and entry arithmetic are squarely in `grind`'s scope;
+  unverified pending a build-capable session.
 
 ### clm_norm_instances — candidate
 - **Pattern:**
@@ -130,7 +133,10 @@ current counts and full location lists).
 - **Abstraction (proposed):** single-file duplication — restructure the
   underlying definition to take a bundled bilinear map, or a local
   `macro`/`have` inside the file. Below cross-file threshold; promote only
-  if the pattern escapes `TwoPositive.lean`.
+  if the pattern escapes `TwoPositive.lean`. Note: `grind` is unlikely to
+  close these directly (matrix multiplication is noncommutative and its
+  ring solver is commutative); the bundled-bilinear-map restructuring is
+  the better bet.
 
 ### region_cover_union_cases — candidate
 - **Pattern:**

--- a/scripts/tactic_pattern_scan.py
+++ b/scripts/tactic_pattern_scan.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Detect repeated tactic-block patterns across the Lean corpus.
+
+Purpose
+-------
+Supports the tactic self-improvement loop (docs/tactic_development.md):
+find tactic-line sequences that recur across ``TNLean/``, so they can be
+recorded in the pattern ledger (docs/tactic_patterns.md) and eventually
+promoted to a custom tactic, macro, or simp set.
+
+Method
+------
+* Walk ``TNLean/**/*.lean`` (excluding ``Archive/`` and ``Scratch/``).
+* Keep only lines that look like tactic invocations (leading keyword from
+  ``TACTIC_HEADS``, or a focus-dot line).  Comments and string literals are
+  not parsed; this is a heuristic scanner, not a Lean parser.
+* Normalize each line (strip indentation, collapse whitespace).
+* Slide windows of ``--min-window`` .. ``--max-window`` consecutive tactic
+  lines over each file and count identical windows across the corpus.
+* Report windows seen at least ``--min-count`` times, largest
+  ``lines x occurrences`` savings first.  Sub-windows of a reported window
+  are suppressed so each pattern is reported once, maximally.
+
+Usage
+-----
+    python3 scripts/tactic_pattern_scan.py                # default scan
+    python3 scripts/tactic_pattern_scan.py --min-count 5  # stricter
+    python3 scripts/tactic_pattern_scan.py --top 10 --show-locations 5
+
+Exit code is always 0; this is a reporting tool, not a lint gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from collections import defaultdict
+from pathlib import Path
+
+# Keywords that begin a tactic invocation line.  Deliberately conservative:
+# missing a tactic keyword only means some duplication goes unreported.
+TACTIC_HEADS = (
+    "simp",
+    "simpa",
+    "rw",
+    "rewrite",
+    "exact",
+    "apply",
+    "refine",
+    "intro",
+    "intros",
+    "rintro",
+    "obtain",
+    "rcases",
+    "cases",
+    "constructor",
+    "ext",
+    "funext",
+    "subst",
+    "unfold",
+    "change",
+    "show",
+    "calc",
+    "have",
+    "haveI",
+    "letI",
+    "set",
+    "norm_num",
+    "ring",
+    "ring_nf",
+    "field_simp",
+    "positivity",
+    "omega",
+    "decide",
+    "trivial",
+    "rfl",
+    "symm",
+    "push_cast",
+    "norm_cast",
+    "congr",
+    "gcongr",
+    "convert",
+    "conv",
+    "dsimp",
+    "delta",
+    "specialize",
+    "use",
+    "exists",
+    "left",
+    "right",
+    "induction",
+    "injection",
+    "contradiction",
+    "absurd",
+    "by_cases",
+    "by_contra",
+    "push_neg",
+    "nlinarith",
+    "linarith",
+    "linear_combination",
+    "aesop",
+    "tauto",
+    "fun_prop",
+    "measurability",
+    "continuity",
+    "bound",
+    "mpv_ext",
+    "block_words",
+    "transfer_simp",
+)
+
+TACTIC_LINE_RE = re.compile(
+    r"^\s*(?:·\s*)?(?:" + "|".join(re.escape(t) for t in sorted(set(TACTIC_HEADS))) + r")\b"
+)
+
+EXCLUDED_DIRS = {"Archive", "Scratch"}
+
+
+def tactic_lines(path: Path) -> list[tuple[int, str]]:
+    """Return (line-number, normalized-text) for tactic-looking lines."""
+    out: list[tuple[int, str]] = []
+    for lineno, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("--") or stripped.startswith("/-"):
+            continue
+        if TACTIC_LINE_RE.match(raw):
+            out.append((lineno, re.sub(r"\s+", " ", stripped)))
+    return out
+
+
+def consecutive_runs(lines: list[tuple[int, str]]) -> list[list[tuple[int, str]]]:
+    """Split tactic lines into runs of consecutive source lines."""
+    runs: list[list[tuple[int, str]]] = []
+    current: list[tuple[int, str]] = []
+    for item in lines:
+        if current and item[0] != current[-1][0] + 1:
+            runs.append(current)
+            current = []
+        current.append(item)
+    if current:
+        runs.append(current)
+    return runs
+
+
+def scan(root: Path, min_window: int, max_window: int, min_count: int):
+    windows: dict[tuple[str, ...], list[tuple[str, int]]] = defaultdict(list)
+    for path in sorted(root.rglob("*.lean")):
+        rel = path.relative_to(root.parent)
+        if any(part in EXCLUDED_DIRS for part in rel.parts):
+            continue
+        for run in consecutive_runs(tactic_lines(path)):
+            for size in range(min_window, max_window + 1):
+                for i in range(len(run) - size + 1):
+                    chunk = run[i : i + size]
+                    key = tuple(text for _, text in chunk)
+                    windows[key].append((str(rel), chunk[0][0]))
+
+    hits = {k: v for k, v in windows.items() if len(v) >= min_count}
+
+    # Suppress windows that are sub-sequences of a larger reported window
+    # with the same occurrence count (they carry no extra information).
+    keys_by_size = sorted(hits, key=len, reverse=True)
+    kept: list[tuple[str, ...]] = []
+    for key in keys_by_size:
+        joined = "\n".join(key)
+        redundant = any(
+            joined in "\n".join(big) and len(hits[big]) >= len(hits[key]) for big in kept
+        )
+        if not redundant:
+            kept.append(key)
+    return {k: hits[k] for k in kept}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--root", default="TNLean", help="source root to scan")
+    parser.add_argument("--min-window", type=int, default=3, help="minimum lines per pattern")
+    parser.add_argument("--max-window", type=int, default=8, help="maximum lines per pattern")
+    parser.add_argument("--min-count", type=int, default=3, help="minimum occurrences to report")
+    parser.add_argument("--top", type=int, default=20, help="number of patterns to print")
+    parser.add_argument(
+        "--show-locations", type=int, default=3, help="locations to print per pattern"
+    )
+    args = parser.parse_args()
+
+    results = scan(Path(args.root), args.min_window, args.max_window, args.min_count)
+    ranked = sorted(
+        results.items(), key=lambda kv: len(kv[0]) * len(kv[1]), reverse=True
+    )
+
+    if not ranked:
+        print("No repeated tactic patterns found at the current thresholds.")
+        return
+
+    print(f"# Repeated tactic patterns (>= {args.min_count} occurrences)")
+    print(f"# Ranked by lines x occurrences; showing top {args.top}\n")
+    for key, locs in ranked[: args.top]:
+        savings = len(key) * len(locs)
+        print(f"## {len(locs)} occurrences x {len(key)} lines (weight {savings})")
+        for line in key:
+            print(f"    {line}")
+        shown = locs[: args.show_locations]
+        print("  at: " + ", ".join(f"{f}:{n}" for f, n in shown), end="")
+        if len(locs) > len(shown):
+            print(f" (+{len(locs) - len(shown)} more)")
+        else:
+            print()
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tactic_pattern_scan.py
+++ b/scripts/tactic_pattern_scan.py
@@ -104,6 +104,7 @@ TACTIC_HEADS = (
     "measurability",
     "continuity",
     "bound",
+    "grind",
     "mpv_ext",
     "block_words",
     "transfer_simp",


### PR DESCRIPTION
Introduce a mechanism so proof text grows sublinearly with mathematical
content instead of paying for the same tactic pattern repeatedly:

- docs/tactic_development.md: the process — consult/detect/record/promote/
  refactor/retire, rule-of-three promotion criteria, abstraction ordering
  (lemma > simp set > macro > elab tactic), design rules for promoted
  tactics.
- docs/tactic_patterns.md: living pattern ledger, seeded with the three
  existing promoted tactics (mpv_ext, block_words, transfer_simp) and six
  candidate patterns found by scanning the corpus (10x matrix entrywise
  case split, 12x PEPS product congruence block, 5x continuous-linear-map
  norm instance boilerplate, and others).
- scripts/tactic_pattern_scan.py: heuristic n-gram scanner that reports
  repeated tactic-line blocks across TNLean/ ranked by removable lines.
- CLAUDE.md: wire the loop into the proof-writing workflow and register
  the new docs in the documentation table.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SSUwS35cPdWPDQsSoEw2tk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and an optional reporting script only; no theorem statements, proofs, or CI enforcement changes.
> 
> **Overview**
> Adds a **tactic self-improvement** workflow so repeated proof blocks get detected, logged, and promoted instead of copied across the corpus.
> 
> **`docs/tactic_development.md`** defines the loop (consult → detect → record → promote → refactor → retire), rule-of-three promotion thresholds, abstraction preference (lemma → simp set → `grind` → macro → elab), design rules for promoted tactics, and how the scanner fits in.
> 
> **`docs/tactic_patterns.md`** is a living ledger: documents existing promoted patterns (`mpv_ext`, `block_words`, `transfer_simp`) and seeds **six candidate** repetitions from an initial corpus scan (matrix entry cases, CLM norm `letI` blocks, PEPS product congruence, filter-sum splits, etc.).
> 
> **`scripts/tactic_pattern_scan.py`** walks `TNLean/**/*.lean` (skipping `Archive/`/`Scratch/`), finds repeated consecutive tactic-line n-grams, ranks by `lines × occurrences`, and always exits 0 (report-only, not a CI gate).
> 
> **`CLAUDE.md`** and **`docs/README.md`** wire contributors and assistants to use the loop and run `python3 scripts/tactic_pattern_scan.py` on proof-heavy PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9a5fa0d3191ff3f377b543294b7dd968d293122. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->