### PR TITLE
feat(MPS/ParentHamiltonian): recover PGVWC07 source range

### DIFF
--- a/TNLean/MPS/MPDO/BiCFDerivation/Selectors.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/Selectors.lean
@@ -217,6 +217,68 @@ theorem wordTupleSpanTop_add_of_wordTupleSpanTop
   rw [hSpanS]
   exact Submodule.mem_top
 
+/-- Right-canonical normalization propagates a full simultaneous word-tuple
+span by one site.
+
+If the length-$L$ word tuples span the full product matrix algebra, represent
+the tuple $j\mapsto (A^j_a)^\dagger M_j$ at that length, prepend $A^j_a$, and
+sum over $a$. The normalization
+$$
+  \sum_a A^j_a(A^j_a)^\dagger=I
+$$
+then recovers the arbitrary target tuple $M$ at length $L+1$.
+
+This is the homogeneous form of the padding used after the direct-sum lemma in
+arXiv:quant-ph/0608197, lines 1346--1421. -/
+theorem wordTupleSpanTop_succ_of_unital
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    {L : ℕ} (hSpan : WordTupleSpanTop A L)
+    (hUnital : ∀ k : Fin r, ∑ a : Fin d, A k a * (A k a)ᴴ = 1) :
+    WordTupleSpanTop A (L + 1) := by
+  classical
+  unfold WordTupleSpanTop at hSpan ⊢
+  apply top_unique
+  intro M _
+  have hN : ∀ a : Fin d,
+      (fun k : Fin r ↦ (A k a)ᴴ * M k) ∈
+        Submodule.span ℂ (Set.range (wordTuple A L)) := by
+    simp [hSpan]
+  have hLetter : ∀ a : Fin d,
+      wordTuple A 1 (fun _ ↦ a) ∈
+        Submodule.span ℂ (Set.range (wordTuple A 1)) :=
+    fun a ↦ Submodule.subset_span ⟨fun _ ↦ a, rfl⟩
+  have hProduct : ∀ a : Fin d,
+      (fun k : Fin r ↦
+        wordTuple A 1 (fun _ ↦ a) k * ((A k a)ᴴ * M k)) ∈
+          Submodule.span ℂ (Set.range (wordTuple A (1 + L))) :=
+    fun a ↦ pointwise_mul_mem_span_wordTuple_add A (hLetter a) (hN a)
+  have hSum : (∑ a : Fin d, fun k : Fin r ↦
+      wordTuple A 1 (fun _ ↦ a) k * ((A k a)ᴴ * M k)) ∈
+        Submodule.span ℂ (Set.range (wordTuple A (1 + L))) :=
+    Submodule.sum_mem _ fun a _ ↦ hProduct a
+  have hSumEq : (∑ a : Fin d, fun k : Fin r ↦
+      wordTuple A 1 (fun _ ↦ a) k * ((A k a)ᴴ * M k)) = M := by
+    funext k
+    rw [Finset.sum_apply]
+    simp only [wordTuple, List.ofFn_succ, List.ofFn_zero, evalWord_cons,
+      evalWord_nil, mul_one]
+    simp_rw [← Matrix.mul_assoc]
+    rw [← Finset.sum_mul, hUnital k, one_mul]
+  rw [hSumEq] at hSum
+  rw [Nat.add_comm 1 L] at hSum
+  exact hSum
+
+/-- Right-canonical normalization propagates a full simultaneous word-tuple
+span to every larger length. -/
+theorem wordTupleSpanTop_of_ge_of_unital
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    {L n : ℕ} (hSpan : WordTupleSpanTop A L)
+    (hUnital : ∀ k : Fin r, ∑ a : Fin d, A k a * (A k a)ᴴ = 1)
+    (hLn : L ≤ n) :
+    WordTupleSpanTop A n := by
+  exact Nat.le_induction hSpan
+    (fun m _ h ↦ wordTupleSpanTop_succ_of_unital A h hUnital) n hLn
+
 /-- A full homogeneous word-tuple span at one period extends any full base
 length along the arithmetic progression obtained by adding that period. -/
 theorem wordTupleSpanTop_add_mul_of_wordTupleSpanTop

--- a/TNLean/MPS/MPDO/BiCFDerivation/Selectors.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/Selectors.lean
@@ -269,7 +269,8 @@ theorem wordTupleSpanTop_succ_of_unital
   exact hSum
 
 /-- Right-canonical normalization propagates a full simultaneous word-tuple
-span to every larger length. -/
+span to every larger length. This is the induction wrapper for the one-step
+propagation used in arXiv:quant-ph/0608197, lines 1346--1421. -/
 theorem wordTupleSpanTop_of_ge_of_unital
     (A : (k : Fin r) → MPSTensor d (dim k))
     {L n : ℕ} (hSpan : WordTupleSpanTop A L)

--- a/TNLean/MPS/MPDO/BiCFDerivation/Selectors.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/Selectors.lean
@@ -228,8 +228,8 @@ $$
 $$
 then recovers the arbitrary target tuple $M$ at length $L+1$.
 
-This is the homogeneous form of the padding used after the direct-sum lemma in
-arXiv:quant-ph/0608197, lines 1346--1421. -/
+This is the simultaneous-tuple form of the unital propagation in
+arXiv:quant-ph/0608197, lines 893--898. -/
 theorem wordTupleSpanTop_succ_of_unital
     (A : (k : Fin r) → MPSTensor d (dim k))
     {L : ℕ} (hSpan : WordTupleSpanTop A L)
@@ -270,7 +270,7 @@ theorem wordTupleSpanTop_succ_of_unital
 
 /-- Right-canonical normalization propagates a full simultaneous word-tuple
 span to every larger length. This is the induction-based extension of the one-step
-propagation used in arXiv:quant-ph/0608197, lines 1346--1421. -/
+propagation in arXiv:quant-ph/0608197, lines 893--898. -/
 theorem wordTupleSpanTop_of_ge_of_unital
     (A : (k : Fin r) → MPSTensor d (dim k))
     {L n : ℕ} (hSpan : WordTupleSpanTop A L)

--- a/TNLean/MPS/MPDO/BiCFDerivation/Selectors.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/Selectors.lean
@@ -269,7 +269,7 @@ theorem wordTupleSpanTop_succ_of_unital
   exact hSum
 
 /-- Right-canonical normalization propagates a full simultaneous word-tuple
-span to every larger length. This is the induction wrapper for the one-step
+span to every larger length. This is the induction-based extension of the one-step
 propagation used in arXiv:quant-ph/0608197, lines 1346--1421. -/
 theorem wordTupleSpanTop_of_ge_of_unital
     (A : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalBoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalBoundaryClosing.lean
@@ -285,9 +285,9 @@ theorem exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1
 /-- A global change of cut closes the block-diagonal boundary conditions in
 the sharp PGVWC07 source range.
 
-Let $r\ge2$, let every block be injective at length $L_0>0$, and assume
-$L\ge3(r-1)(L_0+1)+1$ and $N\ge L+L_0$. The source-range simultaneous span
-on the complementary segment $N-L_0$ identifies the boundary matrices before
+Let \(r\ge2\), let every block be injective at length \(L_0>0\), and assume
+\(L\ge3(r-1)(L_0+1)+1\) and \(N\ge L+L_0\). The source-range simultaneous span
+on the complementary segment \(N-L_0\) identifies the boundary matrices before
 and after moving the cut. Each block component therefore satisfies every
 periodic local constraint. This is arXiv:quant-ph/0608197, Theorem 12, proof
 lines 1424--1456. -/
@@ -391,8 +391,8 @@ theorem exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvw
   exact hCommWord j (List.ofFn β)
 
 /-- At the length bound of Perez-Garcia, Verstraete, Wolf, and Cirac, the
-periodic chain space of a normalized BNT block sum is the internal sum of the
-periodic chain spaces of its blocks.
+periodic chain space of a normalized BNT block sum is the sum of the periodic
+chain spaces of its blocks, while the open-boundary block spaces are independent.
 
 This is arXiv:quant-ph/0608197, Theorem 12, proof lines 1424--1456. The required
 interaction length is

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalBoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalBoundaryClosing.lean
@@ -180,12 +180,11 @@ argument of arXiv:quant-ph/0608197, Theorem 12, proof lines 1276--1289 and
 1454--1456, with the block-diagonal boundary restriction of arXiv:2011.12127,
 Section IV.C, lines 2126--2128.
 
-**Scope restriction (finite Condition C1 range):** The moved-cut comparison is
-unconditional within the repository's existing normalized BNT separation range
-\((L_0+1)+3(r-1)(L_0+1)+1\le L\). The source theorem uses the sharper bound
-\(3(r-1)(L_0+1)+1\le L\). Thus the length-\(L_0\) injectivity range remains
-stronger than the source constant. This independent mismatch is documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+This earlier variant is retained with the sufficient range
+\((L_0+1)+3(r-1)(L_0+1)+1\le L\). The theorem
+`exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07`
+below proves the same conclusion at the source bound
+\(3(r-1)(L_0+1)+1\le L\).
 -/
 theorem exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -283,6 +282,227 @@ theorem exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1
   intro β
   exact hCommWord j (List.ofFn β)
 
+/-- A global change of cut closes the block-diagonal boundary conditions in
+the sharp PGVWC07 source range.
+
+Let $r\ge2$, let every block be injective at length $L_0>0$, and assume
+$L\ge3(r-1)(L_0+1)+1$ and $N\ge L+L_0$. The source-range simultaneous span
+on the complementary segment $N-L_0$ identifies the boundary matrices before
+and after moving the cut. Each block component therefore satisfies every
+periodic local constraint. This is arXiv:quant-ph/0608197, Theorem 12, proof
+lines 1424--1456. -/
+theorem exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hr : 2 ≤ r) (hμ : ∀ k : Fin r, μ k ≠ 0)
+    {L₀ L N : ℕ}
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    [NeZero d]
+    (hRange :
+      (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) + 1 ≤ L)
+    (hNlarge : L + L₀ ≤ N)
+    {ψ : NSiteSpace d N}
+    (hψ : ψ ∈ chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N) :
+    ∃ X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+      ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+        ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X)) ∧
+      ∀ j : Fin r,
+        groundSpaceMap (A j) N ((μ j) ^ N • X j) ∈ chainGroundSpace (A j) L N := by
+  classical
+  have hN : 0 < N := by omega
+  have hL : 0 < L := by omega
+  have hLN : L ≤ N := by omega
+  obtain ⟨X, hψX, _⟩ :=
+    exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1_pgvwc07
+      μ A hr hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange hψ
+  let s : Fin N := ⟨N - L₀, by omega⟩
+  have hTranslate :
+      cyclicTranslateState s ψ ∈
+        chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N :=
+    cyclicTranslateState_mem_chainGroundSpace
+      (toTensorFromBlocks (d := d) (μ := μ) A) hN hLN s hψ
+  obtain ⟨Y, hψY, _⟩ :=
+    exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1_pgvwc07
+      μ A hr hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange hTranslate
+  have hXsum :
+      ψ = ∑ j : Fin r, groundSpaceMap (A j) N ((μ j) ^ N • X j) := by
+    calc
+      ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+          ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv)
+            (Matrix.blockDiagonal' X)) := hψX
+      _ = ∑ j : Fin r, groundSpaceMap (A j) N ((μ j) ^ N • X j) := by
+        rw [BlockSumGroundSpace.groundSpaceMap_toTensorFromBlocks_eq_sum_blockDiagonal]
+  have hYsum :
+      cyclicTranslateState s ψ =
+        ∑ j : Fin r, groundSpaceMap (A j) N ((μ j) ^ N • Y j) := by
+    calc
+      cyclicTranslateState s ψ =
+          groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+            ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv)
+              (Matrix.blockDiagonal' Y)) := hψY
+      _ = ∑ j : Fin r, groundSpaceMap (A j) N ((μ j) ^ N • Y j) := by
+        rw [BlockSumGroundSpace.groundSpaceMap_toTensorFromBlocks_eq_sum_blockDiagonal]
+  have hSplit : N - L₀ + L₀ = N := by omega
+  have hSumTranslate :
+      cyclicTranslateState s
+          (∑ j : Fin r, groundSpaceMap (A j) N ((μ j) ^ N • X j)) =
+        ∑ j : Fin r, groundSpaceMap (A j) N ((μ j) ^ N • Y j) := by
+    rw [← hXsum]
+    exact hYsum
+  have hLongSpan : WordTupleSpanTop A (N - L₀) := by
+    apply wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1_pgvwc07
+      A hr hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital
+    omega
+  have hIntertwine :
+      ∀ (α : Fin L₀ → Fin d) (j : Fin r),
+        ((μ j) ^ N • X j) * evalWord (A j) (List.ofFn α) =
+          evalWord (A j) (List.ofFn α) * ((μ j) ^ N • Y j) := by
+    apply block_boundary_intertwines_of_cyclicTranslate_sum_groundSpaceMap_eq_of_add_eq
+      A hSplit hL₀ hLongSpan
+        (fun j ↦ (μ j) ^ N • X j) (fun j ↦ (μ j) ^ N • Y j)
+    simpa only [s] using hSumTranslate
+  have hComm : ∀ j : Fin r, ∀ a : Fin d,
+      ((μ j) ^ N • X j) * A j a = A j a * ((μ j) ^ N • X j) := by
+    intro j
+    exact (boundary_eq_and_commutes_of_isNBlkInjective_of_intertwines
+      (hBlk j) hL₀ ((μ j) ^ N • X j) ((μ j) ^ N • Y j)
+      (fun α ↦ hIntertwine α j)).2
+  have hCommWord : ∀ j : Fin r, ∀ w : List (Fin d),
+      ((μ j) ^ N • X j) * evalWord (A j) w =
+        evalWord (A j) w * ((μ j) ^ N • X j) := by
+    intro j w
+    induction w with
+    | nil => simp [evalWord_nil]
+    | cons a w ih =>
+        rw [evalWord_cons, ← Matrix.mul_assoc, hComm j a, Matrix.mul_assoc, ih,
+          ← Matrix.mul_assoc]
+  refine ⟨X, hψX, ?_⟩
+  apply blockDiagonal_boundary_component_chainGroundSpace_of_boundary_identities
+    μ A hN hLN X
+  intro j i _τ _hi
+  refine ⟨(μ j) ^ N • X j, ?_⟩
+  intro β
+  exact hCommWord j (List.ofFn β)
+
+/-- At the length bound of Perez-Garcia, Verstraete, Wolf, and Cirac, the
+periodic chain space of a normalized BNT block sum is the internal sum of the
+periodic chain spaces of its blocks.
+
+This is arXiv:quant-ph/0608197, Theorem 12, proof lines 1424--1456. The required
+interaction length is
+\[
+  3(r-1)(L_0+1)+1 \leq L,
+\]
+and the chain length satisfies \(L+L_0\leq N\). -/
+theorem
+    chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_global_cut_bnt_c1_pgvwc07
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    {L₀ L N : ℕ}
+    (hr : 2 ≤ r)
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    [NeZero d]
+    (hRange :
+      (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) + 1 ≤ L)
+    (hNlarge : L + L₀ ≤ N) :
+    chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N =
+        ⨆ j : Fin r, chainGroundSpace (A j) L N ∧
+      iSupIndep (fun j : Fin r ↦ groundSpace (A j) N) := by
+  have hN : 0 < N := by omega
+  have hL : 0 < L := by omega
+  have hLN : L ≤ N := by omega
+  have hClose :
+      chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N ≤
+        ⨆ j : Fin r, chainGroundSpace (A j) L N :=
+    chainGroundSpace_toTensorFromBlocks_le_iSup_of_blockDiagonal_boundary_groundSpaceMap
+      μ A (fun ψ hψ ↦
+        exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07
+          μ A hr hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hRange hNlarge hψ)
+  refine ⟨?_, ?_⟩
+  · exact
+      chainGroundSpace_toTensorFromBlocks_eq_iSup_chainGroundSpace_of_boundary_closing
+        μ A hμ hN hLN hClose
+  · exact
+      groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1_pgvwc07
+        A hr hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital (by omega)
+
+/-- At the source length bound, the normalized BNT block-diagonal periodic
+chain space is the sum of the periodic chain spaces of its blocks.
+
+This is the equality in arXiv:quant-ph/0608197, Theorem 12, proof lines
+1424--1456. -/
+theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_of_global_cut_bnt_c1_pgvwc07
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    {L₀ L N : ℕ}
+    (hr : 2 ≤ r)
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    [NeZero d]
+    (hRange :
+      (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) + 1 ≤ L)
+    (hNlarge : L + L₀ ≤ N) :
+    chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N =
+      ⨆ j : Fin r, chainGroundSpace (A j) L N := by
+  exact
+    (chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_global_cut_bnt_c1_pgvwc07
+      μ A hμ hr hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hRange hNlarge).1
+
+/-- At the source length bound, blockwise periodic uniqueness gives containment
+of the block-diagonal parent-Hamiltonian kernel in the span of the BNT matrix
+product vectors.
+
+This is the final conditional step in arXiv:quant-ph/0608197, Theorem 12, proof
+lines 1424--1456. -/
+theorem ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan_of_global_cut_bnt_c1_pgvwc07
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    {L₀ L N : ℕ}
+    (hr : 2 ≤ r)
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    [NeZero d]
+    (hRange :
+      (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) + 1 ≤ L)
+    (hNlarge : L + L₀ ≤ N)
+    (hBlock : ∀ j : Fin r,
+      chainGroundSpace (A j) L N ≤ mpvSubmodule (A j) N) :
+    LinearMap.ker (parentHamiltonian
+      (toTensorFromBlocks (d := d) (μ := μ) A) L N) ≤
+      bntMPSVectorSpan A N := by
+  have hN : 0 < N := by omega
+  have hLN : L ≤ N := by omega
+  refine ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan
+    μ A hN hLN ?_ hBlock
+  exact le_of_eq
+    (chainGroundSpace_toTensorFromBlocks_eq_iSup_of_global_cut_bnt_c1_pgvwc07
+      μ A hμ hr hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hRange hNlarge)
+
 /-- The normalized BNT block-diagonal periodic chain space is the sum of the
 single-block periodic chain spaces in the finite Condition C1 range, and the
 corresponding open-boundary block spaces are independent.
@@ -292,11 +512,10 @@ Theorem 12, proof lines 1430--1456, in the finite Condition C1 range. The
 boundary closing is supplied by the global change-of-cut comparison above, so
 there is no short crossing-tail span hypothesis.
 
-**Scope restriction (finite Condition C1 range):** The conclusion is proved in
-the repository's existing normalized BNT separation range derived from
-length-\(L_0\) injectivity. Recovering the sharper length bound of
-arXiv:quant-ph/0608197, Theorem 12, is documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+This earlier variant is retained with the sufficient range containing the extra
+summand \(L_0+1\). The theorem
+`chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_global_cut_bnt_c1_pgvwc07`
+above proves the source bound from arXiv:quant-ph/0608197, Theorem 12.
 -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_global_cut_bnt_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -108,8 +108,8 @@ boundary-crossing windows. The periodic-boundary upgrade — replacing the
 open-boundary span \(\bigvee_jG_N(A_j)\) by
 \(\sum_j\mathcal G_{N,L}(A_j)\) — is the separate comparison of
 arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and
-arXiv:2011.12127, Section IV.C, lines 2126--2128, recorded in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
+arXiv:2011.12127, Section IV.C, lines 2126--2128. It is proved by the global
+change-of-cut theorem in `BNTBlockDiagonalBoundaryClosing`. -/
 theorem chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_directSum_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -139,6 +139,47 @@ theorem chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_dir
   have hstep :=
     pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1
       (d := d) (L₀ := L₀) A hIrr hLeft hOverlap hBlocks hBlk hL₀
+      hUnital (n := M - 1) hbound
+  have hM1 : M - 1 + 1 = M := Nat.sub_add_cancel (Nat.succ_le_iff.mpr hMpos)
+  rw [← hM1]
+  simpa [Nat.add_assoc] using hstep
+
+/-- In the PGVWC07 source range, every block-diagonal periodic vector belongs
+to the sum of the open-boundary block spaces.
+
+For $r\ge2$, injectivity at the common length $L_0>0$, and
+$L\ge3(r-1)(L_0+1)+1$, the one-step intersection identity propagates the
+local constraints to the full chain. This is arXiv:quant-ph/0608197,
+Theorem 12, proof lines 1424--1452. -/
+theorem
+    chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_directSum_unital_c1_pgvwc07
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hr : 2 ≤ r) (hμ : ∀ k : Fin r, μ k ≠ 0)
+    {L₀ L N : ℕ}
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    [NeZero d] (hN : 0 < N) (hL : 0 < L) (hLN : L ≤ N)
+    (hRange :
+      (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) + 1 ≤ L) :
+    chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N ≤
+      ⨆ j : Fin r, groundSpace (A j) N := by
+  classical
+  apply chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace
+    (μ := μ) (A := A) hμ hN hL hLN
+  intro M hM
+  have hMpos : 0 < M := lt_of_lt_of_le hL hM
+  have hbound :
+      (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) ≤ M - 1 := by
+    omega
+  have hstep :=
+    pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1_pgvwc07
+      (d := d) (L₀ := L₀) A hr hIrr hLeft hOverlap hBlocks hBlk hL₀
       hUnital (n := M - 1) hbound
   have hM1 : M - 1 + 1 = M := Nat.sub_add_cancel (Nat.succ_le_iff.mpr hMpos)
   rw [← hM1]
@@ -192,8 +233,8 @@ both independent of the boundary-condition comparison at boundary-crossing
 windows. The periodic-boundary upgrade replacing \(S_N\) by
 \(\sum_j\mathcal G_{N,L}(A_j)\) is the separate comparison of
 arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and
-arXiv:2011.12127, Section IV.C, lines 2126--2128, recorded in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
+arXiv:2011.12127, Section IV.C, lines 2126--2128. It is proved by the global
+change-of-cut theorem in `BNTBlockDiagonalBoundaryClosing`. -/
 theorem chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -242,8 +283,8 @@ The decomposition uses only the span-based open-boundary inclusion and
 block-separation independence, both independent of the boundary-condition
 comparison at boundary-crossing windows. That periodic-boundary comparison
 (arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456;
-arXiv:2011.12127, Section IV.C, lines 2126--2128) is recorded in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
+arXiv:2011.12127, Section IV.C, lines 2126--2128) is proved by the global
+change-of-cut theorem in `BNTBlockDiagonalBoundaryClosing`. -/
 theorem exists_unique_sum_groundSpace_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -325,8 +366,8 @@ membership use only the span-based open-boundary inclusion, independently of
 the boundary-condition comparison at boundary-crossing windows. The
 periodic-boundary upgrade to \(\mathcal G_{N,L}(A_j)\) (arXiv:quant-ph/0608197,
 Theorem 12, proof lines 1446--1456; arXiv:2011.12127, Section IV.C, lines
-2126--2128) is the separate step recorded in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
+2126--2128) is proved by the global change-of-cut theorem in
+`BNTBlockDiagonalBoundaryClosing`. -/
 theorem
     exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -354,6 +395,67 @@ theorem
   obtain ⟨φ, hφ, hψφ, _huniq⟩ :=
     exists_unique_sum_groundSpace_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1
       μ A hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange hψ
+  have hφRange : ∀ j : Fin r, φ j ∈ (groundSpaceMap (A j) N).range := by
+    intro j
+    simpa [groundSpace] using hφ j
+  choose Y hY using hφRange
+  let X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ :=
+    fun j => ((μ j) ^ N)⁻¹ • Y j
+  refine ⟨X, ?_, ?_⟩
+  · rw [BlockSumGroundSpace.groundSpaceMap_toTensorFromBlocks_eq_sum_blockDiagonal]
+    calc
+      ψ = ∑ j : Fin r, φ j := hψφ
+      _ = ∑ j : Fin r, groundSpaceMap (A j) N ((μ j) ^ N • X j) := by
+            refine Finset.sum_congr rfl ?_
+            intro j _
+            have hpow : (μ j) ^ N ≠ 0 := pow_ne_zero N (hμ j)
+            simp [X, hY j, hpow]
+  · intro j
+    have hpow : (μ j) ^ N ≠ 0 := pow_ne_zero N (hμ j)
+    simpa [X, hY j, hpow] using hφ j
+
+/-- In the PGVWC07 source range, a block-diagonal periodic vector has
+block-diagonal open-boundary matrices.
+
+For $r\ge2$ and $L\ge3(r-1)(L_0+1)+1$, every vector in the periodic chain
+space of $\bigoplus_j\mu_jA_j$ is a sum of vectors in the open-boundary spaces
+$G_N(A_j)$. Choosing boundary matrices for these summands gives a single
+block-diagonal boundary matrix. This is the open-boundary part of
+arXiv:quant-ph/0608197, Theorem 12, proof lines 1424--1452. -/
+theorem
+    exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1_pgvwc07
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hr : 2 ≤ r) (hμ : ∀ k : Fin r, μ k ≠ 0)
+    {L₀ L N : ℕ}
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    [NeZero d] (hN : 0 < N) (hL : 0 < L) (hLN : L ≤ N)
+    (hRange :
+      (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) + 1 ≤ L)
+    {ψ : NSiteSpace d N}
+    (hψ : ψ ∈ chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N) :
+    ∃ X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+      ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+        ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X)) ∧
+      ∀ j : Fin r,
+        groundSpaceMap (A j) N ((μ j) ^ N • X j) ∈ groundSpace (A j) N := by
+  classical
+  have hLe :
+      chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N ≤
+        ⨆ j : Fin r, groundSpace (A j) N :=
+    chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_directSum_unital_c1_pgvwc07
+      μ A hr hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange
+  obtain ⟨φ, hφ, hφsum⟩ :=
+    (Submodule.mem_iSup_iff_exists_finsupp
+      (fun j : Fin r => groundSpace (A j) N) ψ).mp (hLe hψ)
+  have hψφ : ψ = ∑ j : Fin r, φ j := by
+    simpa [Finsupp.sum_fintype] using hφsum.symm
   have hφRange : ∀ j : Fin r, φ j ∈ (groundSpaceMap (A j) N).range := by
     intro j
     simpa [groundSpace] using hφ j
@@ -442,8 +544,8 @@ span-based open-boundary results, independently of the boundary-condition
 comparison at boundary-crossing windows. The periodic-boundary upgrade
 replacing \(\bigvee_jG_N(A_j)\) by \(\sum_j\mathcal G_{N,L}(A_j)\)
 (arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456;
-arXiv:2011.12127, Section IV.C, lines 2126--2128) is recorded in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
+arXiv:2011.12127, Section IV.C, lines 2126--2128) is proved by the global
+change-of-cut theorem in `BNTBlockDiagonalBoundaryClosing`. -/
 theorem chainGroundSpace_toTensorFromBlocks_two_inclusions_and_iSupIndep_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -850,15 +952,15 @@ inverting-and-re-growing argument in Perez-Garcia, Verstraete, Wolf, and Cirac
 (arXiv:quant-ph/0608197) and Cirac, Perez-Garcia, Schuch, and Verstraete
 (arXiv:2011.12127), with block-diagonal boundary conditions.
 
-**Scope restriction (periodic-boundary comparison):** The block-diagonal boundary
+**Explicit hypothesis (periodic-boundary comparison):** The block-diagonal boundary
 representation whose block components already satisfy the periodic constraints
 \(\Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j)\) is the explicit hypothesis
 `hBoundary` here. The span-based open-boundary version of this representation is
 proved (its components lie in \(G_N(A_j)\)); the periodic-boundary upgrade is the
 boundary-condition comparison of arXiv:quant-ph/0608197, Theorem 12, proof lines
-1446--1456, and arXiv:2011.12127, Section IV.C, lines 2126--2128, not yet derived
-from the periodic ground-space constraint. Documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
+1446--1456, and arXiv:2011.12127, Section IV.C, lines 2126--2128. It is supplied
+by the global change-of-cut theorem in `BNTBlockDiagonalBoundaryClosing`; this
+theorem retains it as an explicit hypothesis for reuse. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_blockBoundary
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -143,6 +143,7 @@ theorem chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_dir
   have hM1 : M - 1 + 1 = M := Nat.sub_add_cancel (Nat.succ_le_iff.mpr hMpos)
   rw [← hM1]
   simpa [Nat.add_assoc] using hstep
+
 /-- In the PGVWC07 source range, every block-diagonal periodic vector belongs
 to the sum of the open-boundary block spaces.
 For $r\ge2$, injectivity at the common length $L_0>0$, and

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -143,14 +143,12 @@ theorem chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_dir
   have hM1 : M - 1 + 1 = M := Nat.sub_add_cancel (Nat.succ_le_iff.mpr hMpos)
   rw [← hM1]
   simpa [Nat.add_assoc] using hstep
-
 /-- In the PGVWC07 source range, every block-diagonal periodic vector belongs
 to the sum of the open-boundary block spaces.
-
 For $r\ge2$, injectivity at the common length $L_0>0$, and
-$L\ge3(r-1)(L_0+1)+1$, the one-step intersection identity propagates the
-local constraints to the full chain. This is arXiv:quant-ph/0608197,
-Theorem 12, proof lines 1424--1452. -/
+$L\ge3(r-1)(L_0+1)+1$, the one-step intersection identity propagates the local
+constraints to the full chain. This is arXiv:quant-ph/0608197, Theorem 12,
+proof lines 1424--1452. -/
 theorem
     chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_directSum_unital_c1_pgvwc07
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -416,12 +414,11 @@ theorem
 
 /-- In the PGVWC07 source range, a block-diagonal periodic vector has
 block-diagonal open-boundary matrices.
-
 For $r\ge2$ and $L\ge3(r-1)(L_0+1)+1$, every vector in the periodic chain
 space of $\bigoplus_j\mu_jA_j$ is a sum of vectors in the open-boundary spaces
 $G_N(A_j)$. Choosing boundary matrices for these summands gives a single
-block-diagonal boundary matrix. This is the open-boundary part of
-arXiv:quant-ph/0608197, Theorem 12, proof lines 1424--1452. -/
+block-diagonal boundary matrix, as in arXiv:quant-ph/0608197, Theorem 12,
+proof lines 1424--1452. -/
 theorem
     exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1_pgvwc07
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -146,8 +146,8 @@ theorem chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_dir
 
 /-- In the PGVWC07 source range, every block-diagonal periodic vector belongs
 to the sum of the open-boundary block spaces.
-For $r\ge2$, injectivity at the common length $L_0>0$, and
-$L\ge3(r-1)(L_0+1)+1$, the one-step intersection identity propagates the local
+For \(r\ge2\), injectivity at the common length \(L_0>0\), and
+\(L\ge3(r-1)(L_0+1)+1\), the one-step intersection identity propagates the local
 constraints to the full chain. This is arXiv:quant-ph/0608197, Theorem 12,
 proof lines 1424--1452. -/
 theorem
@@ -415,9 +415,9 @@ theorem
 
 /-- In the PGVWC07 source range, a block-diagonal periodic vector has
 block-diagonal open-boundary matrices.
-For $r\ge2$ and $L\ge3(r-1)(L_0+1)+1$, every vector in the periodic chain
-space of $\bigoplus_j\mu_jA_j$ is a sum of vectors in the open-boundary spaces
-$G_N(A_j)$. Choosing boundary matrices for these summands gives a single
+For \(r\ge2\) and \(L\ge3(r-1)(L_0+1)+1\), every vector in the periodic chain
+space of \(\bigoplus_j\mu_jA_j\) is a sum of vectors in the open-boundary spaces
+\(G_N(A_j)\). Choosing boundary matrices for these summands gives a single
 block-diagonal boundary matrix, as in arXiv:quant-ph/0608197, Theorem 12,
 proof lines 1424--1452. -/
 theorem

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
@@ -214,7 +214,8 @@ source range of PGVWC07, Theorem 12.
 For at least two blocks, the sharp direct-sum argument gives the full tuple
 span at length \(3(r-1)(L_0+1)\). Right-canonical normalization then propagates
 that span to every larger length. Thus no additional injective prefix is
-needed. This is arXiv:quant-ph/0608197, lines 1346--1421. -/
+needed. The base span is arXiv:quant-ph/0608197, lines 1346--1421; the unital
+propagation is lines 893--898. -/
 theorem wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1_pgvwc07
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
@@ -208,6 +208,41 @@ theorem wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1
   exact wordTupleSpanTop_of_ge_of_common_blockInjective_of_unital_of_pairBlockSeparatingWords
     A hBlk1 hUnital hPair (by simpa [S] using hn)
 
+/-- The normalized BNT hypotheses give the simultaneous product span in the
+source range of PGVWC07, Theorem 12.
+
+For at least two blocks, the sharp direct-sum argument gives the full tuple
+span at length $3(r-1)(L_0+1)$. Right-canonical normalization then propagates
+that span to every larger length. Thus no additional injective prefix is
+needed. This is arXiv:quant-ph/0608197, lines 1346--1421. -/
+theorem wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1_pgvwc07
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hr : 2 ≤ r)
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    {L₀ : ℕ}
+    (hBlk0 : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    {n : ℕ}
+    (hn : (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) ≤ n) :
+    WordTupleSpanTop A n := by
+  have hBlk1 : ∀ k : Fin r, IsNBlkInjective (A k) (L₀ + 1) := by
+    intro k
+    exact isNBlkInjective_of_ge_of_unital (A k) (hUnital k) (hBlk0 k) (by omega)
+  have hBlk3 : ∀ k : Fin r,
+      IsNBlkInjective (A k) ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) := by
+    intro k
+    exact isNBlkInjective_of_ge_of_unital (A k) (hUnital k) (hBlk0 k) (by omega)
+  have hBase : WordTupleSpanTop A
+      ((r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1)))) :=
+    wordTupleSpanTop_threeBlock_mul_pred_of_blocksNotGaugePhaseEquiv_c1
+      A hIrr hLeft hOverlap hBlocks hBlk0 hBlk1 hBlk3 hL₀ hr
+  exact wordTupleSpanTop_of_ge_of_unital A hBase hUnital hn
+
 /-- Under the normalized BNT block-separation hypotheses, the local spaces
 \(G_n(A^j)\) form an internal direct sum.
 
@@ -254,6 +289,29 @@ theorem groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1
   groundSpace_iSupIndep_of_wordTupleSpanTop A
     (wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1
       A hIrr hLeft hOverlap hBlocks hBlk0 hL₀ hUnital hn)
+
+/-- In the PGVWC07 source range, the normalized BNT local spaces form an
+internal direct sum.
+
+This is the direct-sum lemma in arXiv:quant-ph/0608197, lines 1346--1421. -/
+theorem groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1_pgvwc07
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hr : 2 ≤ r)
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    {L₀ : ℕ}
+    (hBlk0 : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    {n : ℕ}
+    (hn : (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) ≤ n) :
+    iSupIndep fun j : Fin r => groundSpace (A j) n :=
+  groundSpace_iSupIndep_of_wordTupleSpanTop A
+    (wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1_pgvwc07
+      A hr hIrr hLeft hOverlap hBlocks hBlk0 hL₀ hUnital hn)
 
 /-- BNT block-separation conditions and PGVWC07 normalization give the one-step
 block-intersection identity at every length above the BNT block-separation
@@ -317,6 +375,35 @@ theorem pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1
   exact pgvwc07_iSup_groundSpace_eq_restriction_intersection A
     (wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1
       A hIrr hLeft hOverlap hBlocks hBlk0 hL₀ hUnital hn)
+    hUnital
+
+/-- The one-step block-intersection identity holds throughout the sharp length
+range in PGVWC07, Theorem 12.
+
+The internal middle-word length is at least $3(r-1)(L_0+1)$. This is the
+intersection step in arXiv:quant-ph/0608197, lines 1424--1452. -/
+theorem pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1_pgvwc07
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hr : 2 ≤ r)
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    {L₀ : ℕ}
+    (hBlk0 : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    {n : ℕ}
+    (hn : (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) ≤ n) :
+    ((⨅ b : Fin d,
+        (⨆ j : Fin r, groundSpace (A j) (n + 1)).comap (restrictLastₗ b)) ⊓
+      (⨅ a : Fin d,
+        (⨆ j : Fin r, groundSpace (A j) (n + 1)).comap (restrictFirstₗ a))) =
+      ⨆ j : Fin r, groundSpace (A j) (n + 2) := by
+  exact pgvwc07_iSup_groundSpace_eq_restriction_intersection A
+    (wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1_pgvwc07
+      A hr hIrr hLeft hOverlap hBlocks hBlk0 hL₀ hUnital hn)
     hUnital
 
 /-- Normalized BNT block-separation hypotheses give the large-length block

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
@@ -212,7 +212,7 @@ theorem wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1
 source range of PGVWC07, Theorem 12.
 
 For at least two blocks, the sharp direct-sum argument gives the full tuple
-span at length $3(r-1)(L_0+1)$. Right-canonical normalization then propagates
+span at length \(3(r-1)(L_0+1)\). Right-canonical normalization then propagates
 that span to every larger length. Thus no additional injective prefix is
 needed. This is arXiv:quant-ph/0608197, lines 1346--1421. -/
 theorem wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1_pgvwc07
@@ -380,7 +380,7 @@ theorem pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1
 /-- The one-step block-intersection identity holds throughout the sharp length
 range in PGVWC07, Theorem 12.
 
-The internal middle-word length is at least $3(r-1)(L_0+1)$. This is the
+The internal middle-word length is at least \(3(r-1)(L_0+1)\). This is the
 intersection step in arXiv:quant-ph/0608197, lines 1424--1452. -/
 theorem pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1_pgvwc07
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
@@ -457,7 +457,9 @@ by \cite[Theorem~IV.16]{Cirac2021Matrix}.
 
 \begin{proof}
     \leanok
-    \uses{thm:pgvwc_direct_sum_intersection_source_length}
+    \uses{thm:pgvwc_direct_sum_intersection_source_length,
+        lem:block_diagonal_periodic_constraints_propagated_sum,
+        lem:block_diagonal_boundary_condition_sum}
     Put $S_M=\sum_jG_M(A_j)$. For every $M$ with $L\le M<N$,
     Theorem~\ref{thm:pgvwc_direct_sum_intersection_source_length} gives
     \[

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
@@ -458,8 +458,18 @@ by \cite[Theorem~IV.16]{Cirac2021Matrix}.
 \begin{proof}
     \leanok
     \uses{thm:pgvwc_direct_sum_intersection_source_length}
-    Iterating the direct-sum restriction intersection from length $L$ to
-    length $N$ places every periodic vector in $\bigoplus_jG_N(A_j)$.
+    Put $S_M=\sum_jG_M(A_j)$. For every $M$ with $L\le M<N$,
+    Theorem~\ref{thm:pgvwc_direct_sum_intersection_source_length} gives
+    \[
+        \left(\bigcap_b\operatorname{Res}_{-,b}^{-1}S_M\right)
+        \cap
+        \left(\bigcap_a\operatorname{Res}_{a,-}^{-1}S_M\right)
+        =S_{M+1}.
+    \]
+    Induction through the cyclic local constraints therefore gives
+    \[
+        \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right)\subseteq S_N.
+    \]
     Decompose the vector into its block components, choose one boundary matrix
     for each component, and absorb the nonzero factor $\mu_j^N$ into that
     matrix.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
@@ -423,6 +423,48 @@ by \cite[Theorem~IV.16]{Cirac2021Matrix}.
     \]
 \end{proof}
 
+\begin{lemma}[Block-diagonal boundary conditions at the source length]
+    \label{lem:bnt_block_diagonal_open_boundary_matrices_source_length}
+    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_directSum_unital_c1_pgvwc07}
+    \lean{MPSTensor.exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1_pgvwc07}
+    \leanok
+    \uses{thm:pgvwc_direct_sum_intersection_source_length}
+    Let $g\ge2$. Let $A_j$ be irreducible left-canonical blocks with normalized
+    self-overlap, pairwise inequivalent up to gauge and phase, injective at the
+    common length $L_0>0$, and satisfying
+    \[
+        \sum_aA^j_aA^{j\,\dagger}_a=I.
+    \]
+    Let every weight $\mu_j$ be nonzero. If $0<L\le N$ and
+    \[
+        L\ge3(g-1)(L_0+1)+1,
+    \]
+    then
+    \[
+        \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right)
+        \subseteq\bigoplus_jG_N(A_j).
+    \]
+    In particular, every vector $\psi$ in the left-hand side admits matrices
+    $X_j$ such that
+    \[
+        \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right),
+        \qquad
+        \Gamma_N^{A_j}(\mu_j^NX_j)\in G_N(A_j).
+    \]
+    This is the open-boundary decomposition used in
+    \cite[Theorem~12, proof lines~1424--1456]{PerezGarcia2007Matrix}.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{thm:pgvwc_direct_sum_intersection_source_length}
+    Iterating the direct-sum restriction intersection from length $L$ to
+    length $N$ places every periodic vector in $\bigoplus_jG_N(A_j)$.
+    Decompose the vector into its block components, choose one boundary matrix
+    for each component, and absorb the nonzero factor $\mu_j^N$ into that
+    matrix.
+\end{proof}
+
 The lemma gives
 \[
     \Gamma_N^{A_j}(\mu_j^NX_j)\in G_N(A_j).

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
@@ -1542,23 +1542,24 @@ in both cases.
 
 \begin{theorem}[A global change of cut gives periodic single-block states]
     \label{thm:block_diagonal_boundary_periodic_components_from_global_cut}
-    \lean{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1}
+    \lean{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07}
     \leanok
-    \uses{lem:bnt_block_diagonal_open_boundary_matrices,
-        lem:unital_block_separating_product_span,
+    \uses{lem:bnt_block_diagonal_open_boundary_matrices_source_length,
+        lem:pgvwc_product_span_source_length,
         lem:parent_cyclic_translate_preserves_chain_space,
         lem:block_boundary_intertwiner_from_global_cut,
         lem:block_diagonal_boundary_component_right_boundary_matrices}
     With the hypotheses and notation of
-    Lemma~\ref{lem:bnt_block_diagonal_open_boundary_matrices}, assume in
-    addition that $L+L_0\le N$. Thus this statement is in the currently proved
-    block-separation range
+    Lemma~\ref{lem:bnt_block_diagonal_open_boundary_matrices_source_length},
+    assume in addition that $L+L_0\le N$. Thus
     \[
-        (L_0+1)+3(g-1)(L_0+1)+1\le L,
+        g\ge2,
+        \qquad
+        L\ge3(g-1)(L_0+1)+1,
+        \qquad
+        N\ge L+L_0.
     \]
-    rather than the sharper length range in the source theorem. Let
-    % Scope restriction documented in
-    % docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex; issue #4195.
+    Let
     \[
         \psi\in
         \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right).
@@ -1577,17 +1578,17 @@ in both cases.
 
 \begin{proof}
     \leanok
-    \uses{lem:bnt_block_diagonal_open_boundary_matrices,
-        lem:unital_block_separating_product_span,
+    \uses{lem:bnt_block_diagonal_open_boundary_matrices_source_length,
+        lem:pgvwc_product_span_source_length,
         lem:parent_cyclic_translate_preserves_chain_space,
         lem:block_boundary_intertwiner_from_global_cut,
         lem:block_diagonal_boundary_component_right_boundary_matrices}
-    Lemma~\ref{lem:bnt_block_diagonal_open_boundary_matrices} gives boundary
-    matrices $X_j$. Translate the periodic state so that the cut moves past
-    the final $L_0$ sites, and apply the same lemma again to obtain boundary
-    matrices $Y_j$ for the translated state. For a word $\alpha$ of length
-    $L_0$, comparison of the two decompositions against every complementary
-    word $w$ of length $N-L_0$ gives
+    Lemma~\ref{lem:bnt_block_diagonal_open_boundary_matrices_source_length}
+    gives boundary matrices $X_j$. Translate the periodic state so that the
+    cut moves past the final $L_0$ sites, and apply the same lemma again to
+    obtain boundary matrices $Y_j$ for the translated state. For a word
+    $\alpha$ of length $L_0$, comparison of the two decompositions against
+    every complementary word $w$ of length $N-L_0$ gives
     \[
         \sum_j\operatorname{tr}
         \bigl((\mu_j^NX_j)A^j_\alpha A^j_w\bigr)
@@ -1596,7 +1597,7 @@ in both cases.
         \bigl(A^j_\alpha(\mu_j^NY_j)A^j_w\bigr).
     \]
     The length bound and
-    Lemma~\ref{lem:unital_block_separating_product_span} imply that the
+    Lemma~\ref{lem:pgvwc_product_span_source_length} imply that the
     simultaneous products of length $N-L_0$ span the product algebra.
     Hence, block by block,
     \[
@@ -1618,19 +1619,29 @@ in both cases.
 
 \begin{theorem}[Periodic block decomposition from a global cut]
     \label{thm:block_diagonal_chain_space_global_cut}
-    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_global_cut_bnt_c1}
+    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_of_global_cut_bnt_c1_pgvwc07}
     \leanok
     \uses{thm:block_diagonal_boundary_periodic_components_from_global_cut,
         lem:bnt_block_diagonal_boundary_representation_equality}
-    Under the hypotheses of
-    Theorem~\ref{thm:block_diagonal_boundary_periodic_components_from_global_cut},
+    Let $g\ge2$. Let $A_j$ be irreducible left-canonical blocks with normalized
+    self-overlap, pairwise inequivalent up to gauge and phase, injective at a
+    common length $L_0>0$, and satisfying
+    \[
+        \sum_aA^j_aA^{j\,\dagger}_a=I.
+    \]
+    Let $\mu_j\ne0$ for every $j$, and assume
+    \[
+        L\ge3(g-1)(L_0+1)+1,
+        \qquad
+        N\ge L+L_0.
+    \]
+    Then
     \[
         \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right)
         =\sum_j\mathcal G_{N,L}(A_j),
     \]
-    and the open-boundary spaces $G_N(A_j)$ form an internal sum.
-    This statement uses the block-separation range displayed in that
-    theorem.
+    as asserted in
+    \cite[Theorem~12, proof lines~1424--1456]{PerezGarcia2007Matrix}.
 \end{theorem}
 
 \begin{proof}
@@ -1638,12 +1649,12 @@ in both cases.
     The preceding theorem decomposes every vector on the left into periodic
     single-block components. The reverse inclusion follows because every
     periodic single-block vector is a periodic vector for the block-diagonal
-    tensor. Block separation gives independence of the open-boundary spaces.
+    tensor.
 \end{proof}
 
-\begin{corollary}[Periodic block-diagonal chain-space equality]
-    \label{cor:block_diagonal_chain_space_global_cut}
-    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_of_global_cut_bnt_c1}
+\begin{theorem}[Periodic block decomposition and block-space independence]
+    \label{thm:block_diagonal_chain_space_global_cut_independent}
+    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_global_cut_bnt_c1_pgvwc07}
     \leanok
     \uses{thm:block_diagonal_chain_space_global_cut}
     Under the same hypotheses,
@@ -1651,22 +1662,25 @@ in both cases.
         \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right)
         =\sum_j\mathcal G_{N,L}(A_j).
     \]
-\end{corollary}
+    The open-boundary spaces $G_N(A_j)$ also form an internal sum.
+\end{theorem}
 
 \begin{proof}
     \leanok
-    This is the equality part of
-    Theorem~\ref{thm:block_diagonal_chain_space_global_cut}.
+    The equality is Theorem~\ref{thm:block_diagonal_chain_space_global_cut}.
+    The simultaneous product span at length $N$ separates the blockwise trace
+    representations and gives independence.
 \end{proof}
 
 \begin{corollary}[Kernel containment from the global cut]
     \label{cor:block_diagonal_kernel_global_cut}
-    \lean{MPSTensor.ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan_of_global_cut_bnt_c1}
+    \lean{MPSTensor.ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan_of_global_cut_bnt_c1_pgvwc07}
     \leanok
-    \uses{cor:block_diagonal_chain_space_global_cut,
+    \uses{thm:block_diagonal_chain_space_global_cut,
         lem:block_diagonal_kernel_to_bnt_span_from_chain_splitting}
     Under the same hypotheses, suppose additionally that every periodic
-    single-block chain space is contained in its matrix-product-vector line.
+    single-block chain space is
+    contained in its matrix-product-vector line.
     Then
     \[
         \ker H_L^{(N)}\!\left(\bigoplus_j\mu_jA_j\right)

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
@@ -1710,6 +1710,8 @@ in both cases.
 
 \begin{proof}
     \leanok
+    \uses{thm:block_diagonal_chain_space_global_cut,
+        lem:block_diagonal_kernel_to_bnt_span_from_chain_splitting}
     The parent-Hamiltonian kernel is the periodic chain space. Apply the
     preceding block decomposition and then the assumed single-block
     containments.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
@@ -1621,8 +1621,7 @@ in both cases.
     \label{thm:block_diagonal_chain_space_global_cut}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_of_global_cut_bnt_c1_pgvwc07}
     \leanok
-    \uses{thm:block_diagonal_boundary_periodic_components_from_global_cut,
-        lem:bnt_block_diagonal_boundary_representation_equality}
+    \uses{thm:block_diagonal_chain_space_global_cut_independent}
     Let $g\ge2$. Let $A_j$ be irreducible left-canonical blocks with normalized
     self-overlap, pairwise inequivalent up to gauge and phase, injective at a
     common length $L_0>0$, and satisfying
@@ -1646,17 +1645,16 @@ in both cases.
 
 \begin{proof}
     \leanok
-    The preceding theorem decomposes every vector on the left into periodic
-    single-block components. The reverse inclusion follows because every
-    periodic single-block vector is a periodic vector for the block-diagonal
-    tensor.
+    \uses{thm:block_diagonal_chain_space_global_cut_independent}
+    This is the equality component of
+    Theorem~\ref{thm:block_diagonal_chain_space_global_cut_independent}.
 \end{proof}
 
 \begin{theorem}[Periodic block decomposition and block-space independence]
     \label{thm:block_diagonal_chain_space_global_cut_independent}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_global_cut_bnt_c1_pgvwc07}
     \leanok
-    \uses{thm:block_diagonal_chain_space_global_cut,
+    \uses{thm:block_diagonal_boundary_periodic_components_from_global_cut,
         lem:pgvwc_product_span_source_length}
     Under the same hypotheses,
     \[
@@ -1668,9 +1666,12 @@ in both cases.
 
 \begin{proof}
     \leanok
-    \uses{thm:block_diagonal_chain_space_global_cut,
+    \uses{thm:block_diagonal_boundary_periodic_components_from_global_cut,
         lem:pgvwc_product_span_source_length}
-    The equality is Theorem~\ref{thm:block_diagonal_chain_space_global_cut}.
+    Theorem~\ref{thm:block_diagonal_boundary_periodic_components_from_global_cut}
+    gives the forward inclusion in the displayed equality. Every periodic
+    single-block vector is a periodic vector for the block-diagonal tensor,
+    which gives the reverse inclusion.
     For independence, write $\phi_j=\Gamma_N^{A^j}(X_j)$ and suppose that
     $\sum_j\phi_j=0$. Lemma~\ref{lem:pgvwc_product_span_source_length} and
     nondegeneracy of the trace pairing give

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
@@ -1656,7 +1656,8 @@ in both cases.
     \label{thm:block_diagonal_chain_space_global_cut_independent}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_global_cut_bnt_c1_pgvwc07}
     \leanok
-    \uses{thm:block_diagonal_chain_space_global_cut}
+    \uses{thm:block_diagonal_chain_space_global_cut,
+        lem:pgvwc_product_span_source_length}
     Under the same hypotheses,
     \[
         \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right)
@@ -1667,9 +1668,22 @@ in both cases.
 
 \begin{proof}
     \leanok
+    \uses{thm:block_diagonal_chain_space_global_cut,
+        lem:pgvwc_product_span_source_length}
     The equality is Theorem~\ref{thm:block_diagonal_chain_space_global_cut}.
-    The simultaneous product span at length $N$ separates the blockwise trace
-    representations and gives independence.
+    For independence, write $\phi_j=\Gamma_N^{A^j}(X_j)$ and suppose that
+    $\sum_j\phi_j=0$. Lemma~\ref{lem:pgvwc_product_span_source_length} and
+    nondegeneracy of the trace pairing give
+    \[
+        \sum_j \Gamma_N^{A^j}(X_j)=0
+        \quad\Longrightarrow\quad
+        \left(\forall (M_j)_j,\ \sum_j\tr(X_jM_j)=0\right)
+        \quad\Longrightarrow\quad
+        X_j=0 \text{ for every }j.
+    \]
+    The last implication follows by choosing a tuple supported in one block.
+    Thus every $\phi_j$ vanishes, and the open-boundary spaces form an internal
+    sum.
 \end{proof}
 
 \begin{corollary}[Kernel containment from the global cut]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
@@ -1655,6 +1655,8 @@ in both cases.
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_global_cut_bnt_c1_pgvwc07}
     \leanok
     \uses{thm:block_diagonal_boundary_periodic_components_from_global_cut,
+        lem:block_diagonal_boundary_representation_inclusion,
+        lem:block_diagonal_boundary_closing_equality,
         lem:pgvwc_product_span_source_length}
     Under the same hypotheses,
     \[
@@ -1667,6 +1669,8 @@ in both cases.
 \begin{proof}
     \leanok
     \uses{thm:block_diagonal_boundary_periodic_components_from_global_cut,
+        lem:block_diagonal_boundary_representation_inclusion,
+        lem:block_diagonal_boundary_closing_equality,
         lem:pgvwc_product_span_source_length}
     Theorem~\ref{thm:block_diagonal_boundary_periodic_components_from_global_cut}
     gives the forward inclusion in the displayed equality. Every periodic
@@ -1680,7 +1684,7 @@ in both cases.
         \quad\Longrightarrow\quad
         \left(\forall (M_j)_j,\ \sum_j\tr(X_jM_j)=0\right)
         \quad\Longrightarrow\quad
-        X_j=0 \text{ for every }j.
+        \forall j,\ X_j=0.
     \]
     The last implication follows by choosing a tuple supported in one block.
     Thus every $\phi_j$ vanishes, and the open-boundary spaces form an internal

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
@@ -1282,7 +1282,8 @@ length $n$ also makes the sum of the local spaces $G_n(A^j)$ direct.
     \lean{MPSTensor.groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1_pgvwc07}
     \leanok
     \uses{lem:unital_simultaneous_product_span_propagation,
-        lem:bnt_direct_sum_block_separation_word_span}
+        lem:bnt_direct_sum_block_separation_word_span,
+        lem:product_span_block_image_direct_sum}
     Let $r\ge2$. Suppose that the normalized BNT blocks are injective at the
     common length $L_0>0$ and satisfy
     \[

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
@@ -1207,9 +1207,8 @@ length $n$ also makes the sum of the local spaces $G_n(A^j)$ direct.
         \sum_a A^j_aA^{j\,\dagger}_a=I.
     \]
     Then the simultaneous products span the product algebra at every length
-    $n\ge q$. This homogeneous-length propagation packages the normalization
-    used in the direct-sum argument of
-    \cite[proof lines~1346--1421]{PerezGarcia2007Matrix}.
+    $n\ge q$. This is the simultaneous-tuple form of the unital propagation in
+    \cite[lines~893--898]{PerezGarcia2007Matrix}.
 \end{lemma}
 
 \begin{proof}
@@ -1282,8 +1281,7 @@ length $n$ also makes the sum of the local spaces $G_n(A^j)$ direct.
     \lean{MPSTensor.groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1_pgvwc07}
     \leanok
     \uses{lem:unital_simultaneous_product_span_propagation,
-        lem:bnt_direct_sum_block_separation_word_span,
-        lem:product_span_block_image_direct_sum}
+        lem:bnt_direct_sum_block_separation_word_span}
     Let $r\ge2$. Suppose that the normalized BNT blocks are injective at the
     common length $L_0>0$ and satisfy
     \[
@@ -1306,7 +1304,8 @@ length $n$ also makes the sum of the local spaces $G_n(A^j)$ direct.
 \begin{proof}
     \leanok
     \uses{lem:unital_simultaneous_product_span_propagation,
-        lem:bnt_direct_sum_block_separation_word_span}
+        lem:bnt_direct_sum_block_separation_word_span,
+        lem:product_span_block_image_direct_sum}
     The block-separation argument gives the full simultaneous span at
     $q=3(r-1)(L_0+1)$. Lemma~\ref{lem:unital_simultaneous_product_span_propagation}
     propagates this equality to every $n\ge q$. To prove independence, write

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
@@ -1214,6 +1214,7 @@ length $n$ also makes the sum of the local spaces $G_n(A^j)$ direct.
 
 \begin{proof}
     \leanok
+    \uses{lem:block_separating_equations_from_pairwise_separation}
     Given matrices $M_j$, first represent the tuple
     $((A^j_a)^\dagger M_j)_j$ by words of length $q$. Prefixing the letter $a$
     and summing over $a$ gives
@@ -1316,7 +1317,7 @@ length $n$ also makes the sum of the local spaces $G_n(A^j)$ direct.
         \quad\Longrightarrow\quad
         \left(\forall (M_j)_j,\ \sum_j\tr(X_jM_j)=0\right)
         \quad\Longrightarrow\quad
-        X_j=0 \text{ for every }j.
+        \forall j,\ X_j=0.
     \]
     Indeed, in the last implication one takes a tuple supported in one block
     and uses nondegeneracy of the trace pairing. Hence every $\phi_j$ vanishes,
@@ -1327,7 +1328,8 @@ length $n$ also makes the sum of the local spaces $G_n(A^j)$ direct.
     \label{thm:pgvwc_direct_sum_intersection_source_length}
     \lean{MPSTensor.pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1_pgvwc07}
     \leanok
-    \uses{lem:pgvwc_product_span_source_length}
+    \uses{lem:pgvwc_product_span_source_length,
+        lem:block_restriction_intersection_subspace}
     Under the hypotheses of
     Lemma~\ref{lem:pgvwc_product_span_source_length}, let
     $m\ge3(r-1)(L_0+1)+1$. Then
@@ -1346,7 +1348,8 @@ length $n$ also makes the sum of the local spaces $G_n(A^j)$ direct.
 
 \begin{proof}
     \leanok
-    \uses{lem:pgvwc_product_span_source_length}
+    \uses{lem:pgvwc_product_span_source_length,
+        lem:block_restriction_intersection_subspace}
     Let a vector belong to both restricted spaces. The two endpoint
     decompositions give boundary matrices $C_a^j$ and $D_b^j$. For every pair
     of physical indices $a,b$ and every middle word $w$ of length $m-1$, their

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
@@ -1332,12 +1332,14 @@ length $n$ also makes the sum of the local spaces $G_n(A^j)$ direct.
     Lemma~\ref{lem:pgvwc_product_span_source_length}, let
     $m\ge3(r-1)(L_0+1)+1$. Then
     \[
-        \C^d\otimes\left(\bigoplus_jG_m(A^j)\right)
+        \C^d\otimes\left(\sum_jG_m(A^j)\right)
         \cap
-        \left(\bigoplus_jG_m(A^j)\right)\otimes\C^d
+        \left(\sum_jG_m(A^j)\right)\otimes\C^d
         =
-        \bigoplus_jG_{m+1}(A^j).
+        \sum_jG_{m+1}(A^j).
     \]
+    Lemma~\ref{lem:pgvwc_product_span_source_length} also shows that the sums
+    at lengths $m$ and $m+1$ are internal.
     This is the direct-sum lemma in the proof of
     \cite[Theorem~12, proof lines~1346--1456]{PerezGarcia2007Matrix}.
 \end{theorem}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
@@ -1192,6 +1192,37 @@ length $n$ also makes the sum of the local spaces $G_n(A^j)$ direct.
     the displayed equality for all sufficiently large $n$.
 \end{proof}
 
+\begin{lemma}[Unitality propagates simultaneous product spans]
+    \label{lem:unital_simultaneous_product_span_propagation}
+    \lean{MPSTensor.wordTupleSpanTop_succ_of_unital}
+    \lean{MPSTensor.wordTupleSpanTop_of_ge_of_unital}
+    \leanok
+    Suppose that the length-$q$ simultaneous products span the product algebra,
+    \[
+        \spn\{(A^1_w,\ldots,A^r_w):|w|=q\}
+        =\prod_j\MN{D_j},
+    \]
+    and that every block satisfies
+    \[
+        \sum_a A^j_aA^{j\,\dagger}_a=I.
+    \]
+    Then the simultaneous products span the product algebra at every length
+    $n\ge q$. This homogeneous-length propagation is the normalization step
+    used in the direct-sum argument of
+    \cite[Lemma~3]{PerezGarcia2007Matrix}.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Given matrices $M_j$, first represent the tuple
+    $((A^j_a)^\dagger M_j)_j$ by words of length $q$. Prefixing the letter $a$
+    and summing over $a$ gives
+    \[
+        \left(\sum_aA^j_aA^{j\,\dagger}_aM_j\right)_j=(M_j)_j.
+    \]
+    This proves the step from $q$ to $q+1$; induction gives every $n\ge q$.
+\end{proof}
+
 \begin{lemma}[Normalized block-separating equations give all large product spans]
     \label{lem:unital_block_separating_product_span}
     \lean{MPSTensor.wordTupleSpanTop_of_ge_of_common_blockInjective_of_unital_of_pairBlockSeparatingWords}
@@ -1242,6 +1273,70 @@ length $n$ also makes the sum of the local spaces $G_n(A^j)$ direct.
     normalization propagates it to the lengths $L_0+1$ and $3(L_0+1)$.
     Lemma~\ref{lem:bnt_direct_sum_block_separation_word_span} then supplies the
     block-separating equations with $S=3(L_0+1)$.
+\end{proof}
+
+\begin{lemma}[Simultaneous product span at the source length]
+    \label{lem:pgvwc_product_span_source_length}
+    \lean{MPSTensor.wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1_pgvwc07}
+    \lean{MPSTensor.groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1_pgvwc07}
+    \leanok
+    \uses{lem:unital_simultaneous_product_span_propagation,
+        lem:bnt_direct_sum_block_separation_word_span}
+    Let $r\ge2$. Suppose that the normalized BNT blocks are injective at the
+    common length $L_0>0$ and satisfy
+    \[
+        \sum_aA^j_aA^{j\,\dagger}_a=I.
+    \]
+    For every
+    \[
+        n\ge 3(r-1)(L_0+1),
+    \]
+    one has
+    \[
+        \spn\{(A^1_w,\ldots,A^r_w):|w|=n\}
+        =\prod_j\MN{D_j}.
+    \]
+    Consequently the spaces $G_n(A^j)$ form an internal sum. This is the
+    simultaneous spanning estimate used in
+    \cite[Theorem~12, proof lines~1424--1456]{PerezGarcia2007Matrix}.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:unital_simultaneous_product_span_propagation,
+        lem:bnt_direct_sum_block_separation_word_span}
+    The block-separation argument gives the full simultaneous span at
+    $q=3(r-1)(L_0+1)$. Lemma~\ref{lem:unital_simultaneous_product_span_propagation}
+    propagates this equality to every $n\ge q$. Nondegeneracy of the trace
+    pairing then separates the spaces $G_n(A^j)$.
+\end{proof}
+
+\begin{theorem}[Direct-sum restriction intersection at the source length]
+    \label{thm:pgvwc_direct_sum_intersection_source_length}
+    \lean{MPSTensor.pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1_pgvwc07}
+    \leanok
+    \uses{lem:pgvwc_product_span_source_length}
+    Under the hypotheses of
+    Lemma~\ref{lem:pgvwc_product_span_source_length}, let
+    $m\ge3(r-1)(L_0+1)+1$. Then
+    \[
+        \C^d\otimes\left(\bigoplus_jG_m(A^j)\right)
+        \cap
+        \left(\bigoplus_jG_m(A^j)\right)\otimes\C^d
+        =
+        \bigoplus_jG_{m+1}(A^j).
+    \]
+    This is the direct-sum lemma in the proof of
+    \cite[Theorem~12, proof lines~1346--1456]{PerezGarcia2007Matrix}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:pgvwc_product_span_source_length}
+    The simultaneous product span at length $m-1$ separates the blockwise trace
+    identities. The resulting boundary-matrix equations give membership in
+    $G_{m+1}(A^j)$ for each block. The reverse inclusion follows by splitting
+    a word of length $m+1$ at either endpoint.
 \end{proof}
 
 \begin{lemma}[Product span makes the sum of local spaces direct]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
@@ -1307,8 +1307,20 @@ length $n$ also makes the sum of the local spaces $G_n(A^j)$ direct.
         lem:bnt_direct_sum_block_separation_word_span}
     The block-separation argument gives the full simultaneous span at
     $q=3(r-1)(L_0+1)$. Lemma~\ref{lem:unital_simultaneous_product_span_propagation}
-    propagates this equality to every $n\ge q$. Nondegeneracy of the trace
-    pairing then separates the spaces $G_n(A^j)$.
+    propagates this equality to every $n\ge q$. To prove independence, write
+    $\phi_j=\Gamma_n^{A^j}(X_j)$ and suppose that $\sum_j\phi_j=0$.
+    Comparison of the coefficient of each word, followed by the simultaneous
+    spanning equality, gives
+    \[
+        \sum_j \Gamma_n^{A^j}(X_j)=0
+        \quad\Longrightarrow\quad
+        \left(\forall (M_j)_j,\ \sum_j\tr(X_jM_j)=0\right)
+        \quad\Longrightarrow\quad
+        X_j=0 \text{ for every }j.
+    \]
+    Indeed, in the last implication one takes a tuple supported in one block
+    and uses nondegeneracy of the trace pairing. Hence every $\phi_j$ vanishes,
+    so the spaces $G_n(A^j)$ form an internal sum.
 \end{proof}
 
 \begin{theorem}[Direct-sum restriction intersection at the source length]
@@ -1333,10 +1345,27 @@ length $n$ also makes the sum of the local spaces $G_n(A^j)$ direct.
 \begin{proof}
     \leanok
     \uses{lem:pgvwc_product_span_source_length}
-    The simultaneous product span at length $m-1$ separates the blockwise trace
-    identities. The resulting boundary-matrix equations give membership in
-    $G_{m+1}(A^j)$ for each block. The reverse inclusion follows by splitting
-    a word of length $m+1$ at either endpoint.
+    Let a vector belong to both restricted spaces. The two endpoint
+    decompositions give boundary matrices $C_a^j$ and $D_b^j$. For every pair
+    of physical indices $a,b$ and every middle word $w$ of length $m-1$, their
+    coefficients obey
+    \[
+        \sum_j\tr\!\left((A_b^jC_a^j)A_w^j\right)
+        =
+        \sum_j\tr\!\left((D_b^jA_a^j)A_w^j\right).
+    \]
+    The simultaneous product span at length $m-1$ and nondegeneracy of the
+    trace pairing therefore give, block by block,
+    \[
+        A_b^jC_a^j=D_b^jA_a^j.
+    \]
+    Set $E^j=\sum_a C_a^jA_a^{j\,\dagger}$. The preceding identities and the
+    right-unital normalization imply
+    \[
+        A_b^jC_a^j=A_b^jE^jA_a^j.
+    \]
+    Thus the component in block $j$ lies in $G_{m+1}(A^j)$. The reverse
+    inclusion follows by splitting a word of length $m+1$ at either endpoint.
 \end{proof}
 
 \begin{lemma}[Product span makes the sum of local spaces direct]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
@@ -1207,9 +1207,9 @@ length $n$ also makes the sum of the local spaces $G_n(A^j)$ direct.
         \sum_a A^j_aA^{j\,\dagger}_a=I.
     \]
     Then the simultaneous products span the product algebra at every length
-    $n\ge q$. This homogeneous-length propagation is the normalization step
+    $n\ge q$. This homogeneous-length propagation packages the normalization
     used in the direct-sum argument of
-    \cite[Lemma~3]{PerezGarcia2007Matrix}.
+    \cite[proof lines~1346--1421]{PerezGarcia2007Matrix}.
 \end{lemma}
 
 \begin{proof}

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -245,7 +245,8 @@ local constraints to
   S_N:=\bigvee_{j=1}^b\mathcal G_N^{A_j},
 \end{align}
 and make the sum defining $S_N$ internal.\footnote{Lean declarations:
-\leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_directSum_unital_c1_pgvwc07}
+\leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_directSum_unital_c1_pgvwc07},
+\leanid{MPSTensor.groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1_pgvwc07},
 and
 \leanid{MPSTensor.exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1_pgvwc07}.}
 The former residual was the source boundary-condition comparison: starting with a

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -61,11 +61,11 @@ of \cite{Cirac2021Matrix}.\footnote{For
 	\path{TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean}).
 		The short crossing-tail span hypothesis is removed by the global change-of-cut
 		comparison in
-		\leanid{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1};
+		\leanid{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07};
 		this resolves
-		\href{https://github.com/LionSR/TNLean/issues/3597}{issue \#3597} in the
-		finite Condition C1 range. The sharper source length bound is tracked
-		separately by
+		\href{https://github.com/LionSR/TNLean/issues/3597}{issue \#3597} at the
+		length bound of the source. The removal of the former extra $(L_0+1)$ in
+		the separation constant resolves
 		\href{https://github.com/LionSR/TNLean/issues/4195}{issue \#4195} (the earlier
 		tracker \href{https://github.com/LionSR/TNLean/issues/2971}{issue \#2971}, which
 		tracked proving the boundary-crossing comparison itself, is now closed). Pull
@@ -96,17 +96,19 @@ After blocking, the corresponding word-span statement is
   \prod_{j=1}^g M_{D_j}(\mathbb C).
 \end{align}
 
-The current Lean development separates the product-span input from
+The Lean development separates the product-span input from
 the finite blocking hypothesis.  First, it proves the one-step intersection
 identity from \cite[Theorem~12]{PerezGarcia2007MPSReps} under the displayed
 product-span equation.  Then the
-normalized basis-of-normal-tensors (BNT) theorems derive that product span in
-the finite Condition C1 range from the injectivity of
+normalized basis-of-normal-tensors (BNT) theorems derive that product span from
+the injectivity of
 \begin{align}
   \Gamma_{L_0}^{A_j}:M_{D_j}(\mathbb C)
     \to(\mathbb C^d)^{\otimes L_0},
 \end{align}
-together with the separated normalized block hypotheses. Thus the current
+together with the separated normalized block hypotheses. For $b\ge2$, the
+simultaneous products span the product algebra at every length
+$n\ge3(b-1)(L_0+1)$. Thus the
 Lean statements no longer replace Condition C1 by a length-one span condition
 in the boundary-decomposition path. The boundary conditions are compared after
 a global change of cut, using only the simultaneous product span on the long
@@ -235,24 +237,22 @@ for all sufficiently large $m$ satisfying the product-span hypotheses.\footnote{
 Lean declarations:
 \leanid{MPSTensor.pgvwc07_directSum_restriction_intersection_of_wordTupleSpanTop},
 \leanid{MPSTensor.groundSpace_iSupIndep_of_wordTupleSpanTop}, and
-\leanid{MPSTensor.pgvwc07_directSum_restriction_intersection_of_ge_of_bnt_directSum_unital}.}
-The corresponding finite-Condition-C1 declarations then propagate the cyclic
+\leanid{MPSTensor.pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1_pgvwc07}.}
+The corresponding source-range declarations then propagate the cyclic
 local constraints to
 \begin{align}
   \mathcal K_{N,L}(\widehat A)\subseteq
   S_N:=\bigvee_{j=1}^b\mathcal G_N^{A_j},
 \end{align}
 and make the sum defining $S_N$ internal.\footnote{Lean declarations:
-\leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_directSum_unital_c1},
-\leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital_c1},
-\leanid{MPSTensor.exists_unique_sum_groundSpace_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1},
+\leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_directSum_unital_c1_pgvwc07}
 and
-\leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_two_inclusions_and_iSupIndep_of_bnt_unital_c1}.}
+\leanid{MPSTensor.exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1_pgvwc07}.}
 The former residual was the source boundary-condition comparison: starting with a
 vector in the periodic-boundary space $\mathcal K_{N,L}(\widehat A)$, produce
 block-diagonal boundary matrices whose block components again belong to the
 blockwise periodic-boundary spaces. The global change-of-cut theorem now proves
-this conclusion in the finite Condition C1 range.
+this conclusion at the source length bound.
 
 Earlier conditional reductions isolated the source comparison in the coordinates
 obtained by opening the periodic boundary for boundary-crossing windows. Suppose
@@ -287,9 +287,9 @@ assuming those identities separately: it translates the whole periodic state
 past the final \(L_0\) sites and compares the two open-boundary decompositions
 against the long complementary segment.\footnote{Formal declarations:
 \leanid{MPSTensor.block_boundary_intertwines_of_cyclicTranslate_sum_groundSpaceMap_eq},
-\leanid{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1},
+\leanid{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07},
 and
-\leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_of_global_cut_bnt_c1}.
+\leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_of_global_cut_bnt_c1_pgvwc07}.
 The earlier conditional declarations are
 \leanid{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_complementary_word_identities},
 \leanid{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_complementary_word_identities_of_injective},
@@ -302,8 +302,7 @@ the forward inclusion, the block-diagonal intersection identity from
 \cite[Theorem~12]{PerezGarcia2007MPSReps}, the parent-ground-space
 containment, and the final span statement with explicit citations. It also
 separates these opened-boundary coordinates from the paper's boundary indices,
-and records the unconditional global-cut conclusion in the finite Condition C1
-range. It does not identify this stricter range with the source range.
+and records the unconditional global-cut conclusion at the source length bound.
 % Blueprint labels: def:parent_hamiltonian_ground_space_bnt,
 % lem:isup_chain_ground_space_block_le_assembled,
 % thm:block_diagonal_ground_space_intersection,
@@ -317,8 +316,7 @@ With this notation,
     \psi_j\in\mathcal K_{N,L}(A_j)
   \right\}.
 \end{align}
-The source-range strengthening not yet obtained from the finite Condition C1
-bound is
+The source-range conclusion now proved is
 \begin{align}
   \left[
     b\ge2
@@ -380,11 +378,13 @@ $L\ge 3L_0+4>L_0$; the inequality $L_0<L$ is displayed separately because the
 one-block uniqueness input is used in that range.
 The one-block case is the injective parent-Hamiltonian theorem rather than the
 degenerate block-injective boundary theorem.
-The finite-Condition-C1 propagation theorem currently proved in Lean is stated
-in the more conservative range
-\begin{align}
-  L\ge (L_0+1)+3(b-1)(L_0+1)+1.
-\end{align}
+The former proof required the more conservative range
+$L\ge (L_0+1)+3(b-1)(L_0+1)+1$. This extra $(L_0+1)$ is no longer present.
+Once the simultaneous tuples span at
+$q=3(b-1)(L_0+1)$, the unital normalization propagates the homogeneous tuple
+span from $q$ to every larger length: a target tuple $(M_j)_j$ is obtained at
+length $q+1$ by representing $((A^j_a)^\dagger M_j)_j$ at length $q$, prefixing
+$A^j_a$, and summing over $a$.
 The periodic-boundary comparison reductions now separate into three forms: a
 decomposition into blockwise vectors with periodic boundary conditions, a
 block-diagonal boundary representation whose components already belong to the
@@ -397,8 +397,7 @@ coordinate formulation displayed above.\footnote{Lean declarations:
 and
 \leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_complementary_identities}.}
 The global change-of-cut theorem discharges the boundary-crossing comparison
-hypothesis in the finite Condition C1 range. The source theorem itself remains
-stronger only through its sharper length constant.
+hypothesis at the source length constant.
 For
 \begin{align}
   X=\bigoplus_j X_j,
@@ -460,10 +459,15 @@ The composition gives
 
 This is not a source-error claim. The formal development proves the
 block-diagonal periodic-boundary comparison without a short-tail span or an
-external boundary-comparison hypothesis in the
-finite-Condition-C1 Lean range
+external boundary-comparison hypothesis in the source range
 \begin{align}
-  L\ge (L_0+1)+3(b-1)(L_0+1)+1.
+  b\ge2,
+  \qquad
+  L_0\ge1,
+  \qquad
+  L\ge3(b-1)(L_0+1)+1,
+  \qquad
+  N\ge L+L_0.
 \end{align}
 For every block $j$ one has
 \begin{align}
@@ -517,10 +521,10 @@ product-spanning length: the fixed cyclic window gives the wrapped tail length
 \(N-i\), whereas the separating trace-decomposition implication is stated at a
 common product-span length \(m\).
 
-In the normalized BNT finite range, this common middle-word span is no longer an
+In the normalized BNT source range, this common middle-word span is no longer an
 external assumption. If
 \begin{align}
-  m=(L_0+1)+(b-1)\bigl((L_0+1)+((L_0+1)+(L_0+1))\bigr),
+  m=3(b-1)(L_0+1),
   \qquad
   L\ge m+1,
 \end{align}
@@ -590,26 +594,21 @@ the lower bound on \(L\) alone.
 
 The block-diagonal boundary representation itself is not an instance of the
 boundary-crossing comparison. The Lean theorem
-\leanid{MPSTensor.exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1}
+\leanid{MPSTensor.exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1_pgvwc07}
 derives it from the span-based one-step intersection identity
-\leanid{MPSTensor.pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1};
+\leanid{MPSTensor.pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1_pgvwc07};
 its block components lie in the open-boundary ground spaces $\mathcal G_N^{A_j}$,
 and its proof does not use the periodic-boundary comparison at boundary-crossing
 windows. The earlier conditional block-diagonal parent-space statements retain
 the periodic-boundary comparison as an explicit hypothesis, while the global
-change-of-cut theorem discharges it. The residual source-faithfulness gap is the
-normalized BNT product-span range, whose derivation is recorded in
-\path{docs/paper-gaps/cpgsv21_normal_range_reduction.tex} (lines 2078--2079 of
-\path{Papers/2011.12127/TN-Review-main.tex}); that gap is independent of the
-periodic-boundary comparison tracked here.
+change-of-cut theorem discharges it. Homogeneous tuple-span propagation removes
+the former extra $(L_0+1)$ from the normalized BNT product-span range.
 
 The periodic-boundary comparison target of
 \href{https://github.com/LionSR/TNLean/issues/3597}{issue \#3597} is therefore
-complete in the finite Condition C1 range. The remaining source-range
-strengthening, tracked by
-\href{https://github.com/LionSR/TNLean/issues/4195}{issue \#4195}, is to replace
-the present separation constant by the sharper bound from
-\cite[Theorem~12]{PerezGarcia2007MPSReps}:
+complete at the source range. The length-constant strengthening tracked by
+\href{https://github.com/LionSR/TNLean/issues/4195}{issue \#4195} is also
+complete: the hypotheses are exactly
 \begin{align}
   b\ge2,
   \qquad
@@ -619,7 +618,7 @@ the present separation constant by the sharper bound from
   \qquad
   N\ge L+L_0.
 \end{align}
-The global-cut theorem already gives, in the current finite Condition C1 range,
+The global-cut theorem gives
 \begin{align}
   \mathcal K_{N,L}(\widehat A)
   =


### PR DESCRIPTION
### Motivation

The block-diagonal periodic parent-space theorem was proved only with the sufficient bound containing an extra additive summand L₀ + 1. PGVWC07 Theorem 12 uses the sharper range 3(r - 1)(L₀ + 1) + 1 ≤ L and L + L₀ ≤ N.

### Description

This PR propagates an exact simultaneous homogeneous tuple span by right-unitality, obtains the direct-sum restriction intersection at the source length, and applies the global change-of-cut boundary comparison. For at least two normalized separated BNT blocks with common injectivity length L₀ > 0 and nonzero weights, the equality-only headline theorem now assumes exactly the source bounds and proves

K_{N,L}(⊕ⱼ μⱼ Aⱼ) = ⨆ⱼ K_{N,L}(Aⱼ).

The source wrapper derives positivity and L ≤ N internally, so its signature has no hypotheses absent from the source statement. The blueprint and docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex now record the former extra summand as removed.

Source: Papers/quant-ph_0608197/MPSarchive.tex, lines 1346–1421 and 1424–1456.

This does not address the Beigi-to-eta implication, Schwarz fixed-point algebra, RFP-to-fusion transport, or the full parent-Hamiltonian claim beyond the stated decomposition and its conditional kernel consequence.

Closes #4195.

### Testing

- lake build
- focused builds of the four changed Lean modules
- blueprint Lean synchronization and reverse declaration coverage
- reader-facing prose check
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large formal proof surface in parent-Hamiltonian/BNT chain logic with many new theorem names and doc cross-links; math is localized to length bounds and span propagation rather than auth or runtime, but reviewers should check hypothesis alignment with PGVWC07 and that older C1-range callers still compile.
> 
> **Overview**
> **Recovers the sharper PGVWC07 Theorem 12 length bound** \(L \ge 3(r-1)(L_0+1)+1\) (and \(N \ge L+L_0\)) for block-diagonal parent periodic ground spaces, removing the former extra \((L_0+1)\) in the separation constant (closes #4195).
> 
> **New unital propagation** in `Selectors.lean`: right-canonical \(\sum_a A_a A_a^\dagger = I\) lifts a full simultaneous word-tuple span from length \(L\) to every \(n \ge L\), so the BNT base span at \(3(r-1)(L_0+1)\) extends without an additional injective prefix.
> 
> **Source-range Lean API** (`*_pgvwc07`): product span, open-boundary direct sum, one-step restriction intersection, open-boundary block-diagonal matrices, global change-of-cut boundary closing, and \(\mathcal K_{N,L}(\oplus \mu_j A_j) = \bigsqcup_j \mathcal K_{N,L}(A_j)\) (plus conditional kernel \(\subseteq\) BNT span). Older finite C1-range theorems remain with pointers to the sharp variants.
> 
> **Blueprint and** `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex` **updated** to cite the new declarations and record the gap as closed at the source bound.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 014962007d0f7cdd4cf175315f4a59b5692b6715. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->