### PR TITLE
feat(MPS/MPDO): expose LPDO block-channel witness

### DIFF
--- a/TNLean/MPS/MPDO/LocalPurificationAreaLaw.lean
+++ b/TNLean/MPS/MPDO/LocalPurificationAreaLaw.lean
@@ -37,6 +37,8 @@ from the cited argument and is false without further hypotheses.
 * `MPOTensor.bipartitionedNormalizedMPO_eq_tensorMapBoth_blockAncillaryTraceMap`:
   an explicit local purification gives the normalized block-channel image
   across every cut.
+* `MPOTensor.IsLPDO.exists_bipartitionedNormalizedMPO_eq_blockAncillaryTrace`:
+  an LPDO admits purifying data realizing this block-channel identity.
 * `MPOTensor.mutualInfoChain_le_of_bipartitioned_channel_image`: a matrix product
   density operator obtained by local channels from a pure matrix product state
   satisfies the bound determined by the purifying bond dimension.
@@ -271,6 +273,35 @@ theorem bipartitionedNormalizedMPO_eq_tensorMapBoth_blockAncillaryTraceMap
       congr 1
   refine Finset.sum_congr rfl (fun κ _ ↦ ?_)
   rw [hjoin i x κ, hjoin j y κ]
+
+/-- An LPDO admits a local-purification representation for which the normalized
+finite-chain operator across every cut is obtained from the purifying operator by
+the ancillary trace on each block.
+
+This is the existential form of the finite-chain channel identity in the
+mixed-PEPS purification argument preceding equation (4) of arXiv:0704.3906,
+using the local purification of arXiv:1606.00608, Section 4.3.
+
+**Scope restriction:** the conclusion remains restricted to LPDOs and exposes
+the purifying bond dimension. It is not the unrestricted finite-chain estimate
+in the MPO bond dimension asserted for every positive MPDO in arXiv:1606.00608,
+Proposition 4.5; see
+`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+theorem IsLPDO.exists_bipartitionedNormalizedMPO_eq_blockAncillaryTrace
+    {M : MPOTensor d D} (hLPDO : IsLPDO M)
+    (N L K : ℕ) (h : N = L + K) :
+    ∃ (dK D' : ℕ)
+      (A : Fin d → Fin dK → Matrix (Fin D') (Fin D') ℂ),
+      bipartitionedNormalizedMPO M N L K h =
+        Matrix.tensorMapBoth
+          (blockAncillaryTraceMap d dK L)
+          (blockAncillaryTraceMap d dK K)
+          (bipartitionedNormalizedMPO
+            (doubledTensor (purificationTensor A)) N L K h) := by
+  obtain ⟨dK, D', A, e, hcoeff⟩ := hLPDO
+  exact ⟨dK, D', A,
+    bipartitionedNormalizedMPO_eq_tensorMapBoth_blockAncillaryTraceMap
+      M A e hcoeff N L K h⟩
 
 /-- **Mutual-information bound for a local-channel image of a pure matrix
 product state.** Let the normalized density operator across the cut

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
@@ -718,16 +718,14 @@
     \uses{def:lpdo, thm:lpdo_block_channel_image}
     Let $M$ be an LPDO.  For every decomposition $N=L+K$, there exist an
     ancillary dimension $d_K$, a purifying bond dimension $D'$, and a
-    purifying tensor $A$ such that
+    local-purification family $A$.  Let $\widetilde A$ be its associated
+    purifying MPS tensor.  Then
     \[
       \sigma^{(N)}_{L:K}(M)
       =\left(\operatorname{Tr}_{\mathrm{anc},L}\otimes
         \operatorname{Tr}_{\mathrm{anc},K}\right)
         \left(\left(\pi_{\widetilde A}^{(N)}\right)_{L:K}\right).
     \]
-    This is restricted to LPDOs and exposes the purifying bond dimension
-    $D'$.  It does not assert a bound in terms of the MPO bond dimension for
-    every positive MPDO.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
@@ -710,6 +710,32 @@
     normalized identity across $L\mid K$.
 \end{proof}
 
+\begin{theorem}[LPDOs admit a block-channel representation]
+    \label{thm:lpdo_exists_block_channel_image}
+    \lean{MPOTensor.IsLPDO.%
+      exists_bipartitionedNormalizedMPO_eq_blockAncillaryTrace}
+    \leanok
+    \uses{def:lpdo, thm:lpdo_block_channel_image}
+    Let $M$ be an LPDO.  For every decomposition $N=L+K$, there exist an
+    ancillary dimension $d_K$, a purifying bond dimension $D'$, and a
+    purifying tensor $A$ such that
+    \[
+      \sigma^{(N)}_{L:K}(M)
+      =\left(\operatorname{Tr}_{\mathrm{anc},L}\otimes
+        \operatorname{Tr}_{\mathrm{anc},K}\right)
+        \left(\left(\pi_{\widetilde A}^{(N)}\right)_{L:K}\right).
+    \]
+    This is restricted to LPDOs and exposes the purifying bond dimension
+    $D'$.  It does not assert a bound in terms of the MPO bond dimension for
+    every positive MPDO.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:lpdo, thm:lpdo_block_channel_image}
+    Choose a local-purification representation of $M$ and apply
+    Theorem~\ref{thm:lpdo_block_channel_image} to its purifying tensor.
+\end{proof}
+
 \begin{theorem}[Mutual-information bound for a local-channel image]
     \label{thm:local_channel_image_mutual_info_bound}
     \lean{MPOTensor.mutualInfoChain_le_of_bipartitioned_channel_image}


### PR DESCRIPTION
This PR adds the public existential block-channel identity for `MPOTensor.IsLPDO`. It unpacks the ancillary dimension, purifying bond dimension, purifying tensor, and bond equivalence from the LPDO witness, then applies the explicit finite-chain identity merged in #4240.

The blueprint now states the existential LPDO theorem separately from the explicit-witness theorem. The conclusion remains restricted to LPDOs and exposes the purifying bond dimension; it does not assert the unrestricted MPO-bond-dimension bound for every positive MPDO in arXiv:1606.00608, Proposition 4.5.

Verified with:
- `lake env lean TNLean/MPS/MPDO/LocalPurificationAreaLaw.lean`
- `lake build`
- `leanblueprint web`
- `leanblueprint checkdecls`
- proof-integrity, line-length, and whitespace scans

Closes #4219.
Related: #4169, #2380, #232.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formalization and blueprint text only; the Lean proof is a direct application of an existing theorem with no changes to runtime or security-sensitive code.
> 
> **Overview**
> Adds **`MPOTensor.IsLPDO.exists_bipartitionedNormalizedMPO_eq_blockAncillaryTrace`**, the existential form of the finite-chain block-channel identity: for any LPDO and cut `N = L + K`, there exist ancillary dimension, purifying bond dimension `D'`, and a local-purification family such that the normalized operator across the cut equals independent block ancillary traces applied to the normalized purifying operator.
> 
> The proof **unpacks the LPDO witness** (`dK`, `D'`, `A`, bond equivalence) and invokes the already-merged explicit identity `bipartitionedNormalizedMPO_eq_tensorMapBoth_blockAncillaryTraceMap`. Docstrings and the module header record that the statement is **scoped to LPDOs** and the **purifying** bond dimension—not the unrestricted MPO-bond bound in Cirac et al. Prop. 4.5.
> 
> The **blueprint** (`ch21`) adds **Theorem `lpdo_exists_block_channel_image`**, linked to the new Lean name, stated separately from the explicit-witness theorem, with a one-step proof via local purification plus `thm:lpdo_block_channel_image`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3caa3add6c4c8dfc62340cfbaf798f17eab662b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->