### PR TITLE
feat(MPS/MPDO): transport decomposed bonds cyclically

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -564,6 +564,7 @@ import TNLean.MPS.MPDO.CommutingFormBridge
 import TNLean.MPS.MPDO.CommutingOverlappingCoordinates
 import TNLean.MPS.MPDO.CommutingFormSpatialBridge
 import TNLean.MPS.MPDO.CommutingBondEtaDecomposition
+import TNLean.MPS.MPDO.CommutingBondEtaCyclicTransport
 import TNLean.MPS.MPDO.GSNNCHSectorSum
 import TNLean.MPS.MPDO.GSNNCHOrthogonalSectors
 import TNLean.MPS.MPDO.BNTSectorCommutingFamily

--- a/TNLean/MPS/MPDO/CommutingBondEtaCyclicTransport.lean
+++ b/TNLean/MPS/MPDO/CommutingBondEtaCyclicTransport.lean
@@ -1,0 +1,625 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.CommutingBondEtaDecomposition
+
+/-!
+# Cyclic transport of neighboring operators
+
+This file transports a two-site neighboring-operator decomposition around a periodic
+finite chain.  The argument is purely algebraic: it uses neither zero correlation length,
+trace factorization, a Markov decomposition, nor saturation of the area law.
+
+## Main declarations
+
+* `Matrix.etaCyclicEdgeEquiv`
+* `MPOTensor.reindex_product_embedLocalOperator_of_etaPair_decomposition`
+
+## References
+
+* arXiv:1606.00608, Appendix C.2, equation sigmaNK2, lines 1581--1605.
+-/
+
+open scoped BigOperators Kronecker Matrix
+
+namespace Matrix
+
+/-- A one-site sector index in the coordinate order
+\(H_{q,r}\otimes H_{q,l}\). -/
+abbrev EtaSiteIndex (K : ℕ) (dl dr : Fin K → ℕ) :=
+  Σ q : Fin K, Fin (dr q) × Fin (dl q)
+
+/-- The neighboring index carried by the cyclic edge from sector \(q\) to sector \(h\). -/
+abbrev EtaEdgeIndex {K : ℕ} (dl dr : Fin K → ℕ) (q h : Fin K) :=
+  Fin (dr q) × Fin (dl h)
+
+/-- Distribute a dependent sum pointwise over a finite family. -/
+private def etaPiSigmaEquiv
+    {ι : Type*} {α : ι → Type*} {β : (i : ι) → α i → Type*} :
+    ((i : ι) → Σ a, β i a) ≃
+      Σ a : (i : ι) → α i, (i : ι) → β i (a i) where
+  toFun x := ⟨fun i ↦ (x i).1, fun i ↦ (x i).2⟩
+  invFun x i := ⟨x.1 i, x.2 i⟩
+  left_inv x := by
+    funext i
+    exact Sigma.eta (x i)
+  right_inv x := by
+    obtain ⟨a, b⟩ := x
+    rfl
+
+/-- For a fixed cyclic sector configuration, regroup the site factors
+\((R_n,L_n)\) into the edge factors \((R_n,L_{n+1})\). -/
+def etaFixedSectorCyclicEdgeEquiv {K N : ℕ} [NeZero N]
+    (dl dr : Fin K → ℕ) (k : Fin N → Fin K) :
+    ((n : Fin N) → Fin (dr (k n)) × Fin (dl (k n))) ≃
+      ((n : Fin N) → EtaEdgeIndex dl dr (k n) (k (n + 1))) :=
+  (Equiv.arrowProdEquivProdArrow _ _ _).trans <|
+    (Equiv.prodCongr (Equiv.refl _)
+      (Equiv.piCongrLeft
+        (fun n : Fin N ↦ Fin (dl (k n))) (finRotate N)).symm).trans <|
+      (Equiv.arrowProdEquivProdArrow _ _ _).symm |>.trans <|
+        Equiv.piCongrRight fun n ↦
+          Equiv.prodCongr (Equiv.refl _)
+            (finCongr (congrArg dl (congrArg k (finRotate_apply n))))
+
+@[simp] theorem etaFixedSectorCyclicEdgeEquiv_apply {K N : ℕ} [NeZero N]
+    (dl dr : Fin K → ℕ) (k : Fin N → Fin K)
+    (x : (n : Fin N) → Fin (dr (k n)) × Fin (dl (k n))) (n : Fin N) :
+    etaFixedSectorCyclicEdgeEquiv dl dr k x n = ((x n).1, (x (n + 1)).2) := by
+  apply Prod.ext
+  · rfl
+  · apply Fin.ext
+    change ((x (finRotate N n)).2 : ℕ) = ((x (n + 1)).2 : ℕ)
+    rw [finRotate_apply]
+
+@[simp] theorem etaFixedSectorCyclicEdgeEquiv_symm_edge {K N : ℕ} [NeZero N]
+    (dl dr : Fin K → ℕ) (k : Fin N → Fin K)
+    (x : (n : Fin N) → EtaEdgeIndex dl dr (k n) (k (n + 1)))
+    (n : Fin N) :
+    (((etaFixedSectorCyclicEdgeEquiv dl dr k).symm x n).1,
+        ((etaFixedSectorCyclicEdgeEquiv dl dr k).symm x (n + 1)).2) = x n := by
+  have h := congrFun ((etaFixedSectorCyclicEdgeEquiv dl dr k).apply_symm_apply x) n
+  simpa only [etaFixedSectorCyclicEdgeEquiv_apply] using h
+
+/-- Apply the one-site sector decomposition at every site and regroup the site factors into
+cyclic neighboring factors. -/
+def etaCyclicEdgeEquiv {K N d : ℕ} [NeZero N] (dl dr : Fin K → ℕ)
+    (e : EtaSiteIndex K dl dr ≃ Fin d) :
+    (Fin N → Fin d) ≃
+      Σ k : Fin N → Fin K,
+        (n : Fin N) → EtaEdgeIndex dl dr (k n) (k (n + 1)) :=
+  ((Equiv.piCongrRight fun _ : Fin N ↦ e.symm).trans etaPiSigmaEquiv).trans <|
+    Equiv.sigmaCongrRight fun k ↦ etaFixedSectorCyclicEdgeEquiv dl dr k
+
+@[simp] theorem etaCyclicEdgeEquiv_symm_apply {K N d : ℕ} [NeZero N]
+    (dl dr : Fin K → ℕ) (e : EtaSiteIndex K dl dr ≃ Fin d)
+    (k : Fin N → Fin K)
+    (x : (n : Fin N) → EtaEdgeIndex dl dr (k n) (k (n + 1)))
+    (n : Fin N) :
+    (etaCyclicEdgeEquiv dl dr e).symm ⟨k, x⟩ n =
+      e ⟨k n, (etaFixedSectorCyclicEdgeEquiv dl dr k).symm x n⟩ := by
+  apply e.symm.injective
+  simp [etaCyclicEdgeEquiv, Equiv.piCongrRight, Equiv.sigmaCongrRight,
+    etaPiSigmaEquiv]
+
+end Matrix
+
+namespace MPOTensor
+
+variable {d : ℕ}
+
+/-- The product on a chosen set of cyclic edges.  Edges outside the set carry the
+identity matrix. -/
+private noncomputable def etaEdgePartialProduct {K N : ℕ} [NeZero N]
+    (dl dr : Fin K → ℕ)
+    (η : (q h : Fin K) →
+      Matrix (Matrix.EtaEdgeIndex dl dr q h) (Matrix.EtaEdgeIndex dl dr q h) ℂ)
+    (k : Fin N → Fin K) (s : Finset (Fin N)) :
+    Matrix ((n : Fin N) → Matrix.EtaEdgeIndex dl dr (k n) (k (n + 1)))
+      ((n : Fin N) → Matrix.EtaEdgeIndex dl dr (k n) (k (n + 1))) ℂ :=
+  fun x y ↦ ∏ n : Fin N,
+    if n ∈ s then η (k n) (k (n + 1)) (x n) (y n)
+    else if x n = y n then 1 else 0
+
+@[simp] private theorem etaEdgePartialProduct_empty {K N : ℕ} [NeZero N]
+    (dl dr : Fin K → ℕ)
+    (η : (q h : Fin K) →
+      Matrix (Matrix.EtaEdgeIndex dl dr q h) (Matrix.EtaEdgeIndex dl dr q h) ℂ)
+    (k : Fin N → Fin K) :
+    etaEdgePartialProduct dl dr η k ∅ = 1 := by
+  ext x y
+  simp only [etaEdgePartialProduct, Finset.notMem_empty, ↓reduceIte,
+    Matrix.one_apply]
+  rw [Fintype.prod_boole]
+  congr 1
+  exact propext funext_iff.symm
+
+@[simp] private theorem etaEdgePartialProduct_univ {K N : ℕ} [NeZero N]
+    (dl dr : Fin K → ℕ)
+    (η : (q h : Fin K) →
+      Matrix (Matrix.EtaEdgeIndex dl dr q h) (Matrix.EtaEdgeIndex dl dr q h) ℂ)
+    (k : Fin N → Fin K) :
+    etaEdgePartialProduct dl dr η k Finset.univ =
+      fun x y ↦ ∏ n : Fin N, η (k n) (k (n + 1)) (x n) (y n) := by
+  ext x y
+  simp [etaEdgePartialProduct]
+
+/-- Multiplication by a new one-edge factor adjoins that edge to a partial product. -/
+private theorem etaEdgePartialProduct_singleton_mul {K N : ℕ} [NeZero N]
+    (dl dr : Fin K → ℕ)
+    (η : (q h : Fin K) →
+      Matrix (Matrix.EtaEdgeIndex dl dr q h) (Matrix.EtaEdgeIndex dl dr q h) ℂ)
+    (k : Fin N → Fin K) (s : Finset (Fin N)) (i : Fin N) (hi : i ∉ s) :
+    etaEdgePartialProduct dl dr η k {i} * etaEdgePartialProduct dl dr η k s =
+      etaEdgePartialProduct dl dr η k (insert i s) := by
+  classical
+  ext x y
+  simp only [Matrix.mul_apply, etaEdgePartialProduct]
+  simp_rw [← Finset.prod_mul_distrib]
+  rw [← Fintype.piFinset_univ]
+  rw [← Finset.prod_univ_sum
+    (fun n : Fin N ↦
+      (Finset.univ : Finset (Matrix.EtaEdgeIndex dl dr (k n) (k (n + 1)))))
+    (fun n z ↦
+      (if n ∈ ({i} : Finset (Fin N)) then
+        η (k n) (k (n + 1)) (x n) z
+      else if x n = z then 1 else 0) *
+      (if n ∈ s then η (k n) (k (n + 1)) z (y n)
+      else if z = y n then 1 else 0))]
+  apply Finset.prod_congr rfl
+  intro n _
+  by_cases hni : n = i
+  · subst n
+    simp [hi]
+  · by_cases hns : n ∈ s
+    · simp [hni, hns]
+    · by_cases hxy : x n = y n
+      · simp [hni, hns, hxy]
+      · simp [hni, hns, hxy]
+
+private theorem prod_etaEdgePartialProduct_singletons {K N : ℕ} [NeZero N]
+    (dl dr : Fin K → ℕ)
+    (η : (q h : Fin K) →
+      Matrix (Matrix.EtaEdgeIndex dl dr q h) (Matrix.EtaEdgeIndex dl dr q h) ℂ)
+    (k : Fin N → Fin K) (l : List (Fin N)) (hl : l.Nodup) :
+    (l.map fun i ↦ etaEdgePartialProduct dl dr η k {i}).prod =
+      etaEdgePartialProduct dl dr η k l.toFinset := by
+  induction l with
+  | nil => simp
+  | cons i l ih =>
+      rw [List.nodup_cons] at hl
+      simp only [List.map_cons, List.prod_cons, List.toFinset_cons]
+      rw [ih hl.2]
+      exact etaEdgePartialProduct_singleton_mul dl dr η k l.toFinset i (by
+        simpa only [List.mem_toFinset] using hl.1)
+
+private theorem prod_etaEdgePartialProduct_singletons_univ {K N : ℕ} [NeZero N]
+    (dl dr : Fin K → ℕ)
+    (η : (q h : Fin K) →
+      Matrix (Matrix.EtaEdgeIndex dl dr q h) (Matrix.EtaEdgeIndex dl dr q h) ℂ)
+    (k : Fin N → Fin K) :
+    (List.ofFn fun i : Fin N ↦ etaEdgePartialProduct dl dr η k {i}).prod =
+      fun x y ↦ ∏ n : Fin N, η (k n) (k (n + 1)) (x n) (y n) := by
+  have hlist : List.ofFn (fun i : Fin N ↦ etaEdgePartialProduct dl dr η k {i}) =
+      (List.ofFn id).map fun i ↦ etaEdgePartialProduct dl dr η k {i} := by
+    simp
+  rw [hlist]
+  rw [prod_etaEdgePartialProduct_singletons dl dr η k (List.ofFn id)
+    (List.nodup_ofFn.mpr Function.injective_id)]
+  have hfin : (List.ofFn id : List (Fin N)).toFinset = Finset.univ := by
+    ext i
+    simp only [List.mem_toFinset, Finset.mem_univ, iff_true]
+    exact List.mem_ofFn.mpr ⟨i, rfl⟩
+  rw [hfin]
+  exact etaEdgePartialProduct_univ dl dr η k
+
+private theorem add_one_ne_self_of_two_le {N : ℕ} [NeZero N]
+    (hN : 2 ≤ N) (i : Fin N) :
+    i + 1 ≠ i := by
+  have h1 : ((1 : Fin N) : ℕ) = 1 := by
+    change 1 % N = 1
+    rw [Nat.mod_eq_of_lt (by omega)]
+  intro h
+  have hval := congrArg Fin.val h
+  rw [Fin.val_add_eq_ite, h1] at hval
+  have := i.isLt
+  split_ifs at hval <;> omega
+
+private theorem mem_cyclicWindowSupport_two {N : ℕ} (i q : Fin N) :
+    q ∈ MPSTensor.cyclicWindowSupport N 2 i ↔
+      q = i ∨ q = MPSTensor.cyclicForwardSite i 1 := by
+  rw [MPSTensor.cyclicWindowSupport]
+  simp only [Finset.mem_image, Finset.mem_range]
+  constructor
+  · rintro ⟨r, hr, rfl⟩
+    interval_cases r
+    · simp
+    · simp
+  · rintro (rfl | rfl)
+    · exact ⟨0, by simp, by simp⟩
+    · exact ⟨1, by simp, rfl⟩
+
+/-- In cyclic edge coordinates, one translated pair bond is block diagonal in the sector
+configuration and acts only on the edge beginning at the translation site. -/
+private theorem reindex_embedLocalOperator_etaPairBond {K N : ℕ} [NeZero N]
+    (hN : 2 ≤ N) (dl dr : Fin K → ℕ)
+    (e : Matrix.EtaSiteIndex K dl dr ≃ Fin d)
+    (η : (q h : Fin K) →
+      Matrix (Matrix.EtaEdgeIndex dl dr q h) (Matrix.EtaEdgeIndex dl dr q h) ℂ)
+    (B : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
+    (hB : Matrix.reindex (Matrix.etaPairSpatialBlockEquiv e).symm
+        (Matrix.etaPairSpatialBlockEquiv e).symm B =
+      Matrix.blockDiagonal' fun qh : Fin K × Fin K ↦
+        ((1 : Matrix (Fin (dl qh.1)) (Fin (dl qh.1)) ℂ) ⊗ₖ
+          η qh.1 qh.2) ⊗ₖ
+            (1 : Matrix (Fin (dr qh.2)) (Fin (dr qh.2)) ℂ))
+    (i : Fin N) :
+    Matrix.reindex (Matrix.etaCyclicEdgeEquiv dl dr e)
+        (Matrix.etaCyclicEdgeEquiv dl dr e)
+        (embedLocalOperator (d := d) 2 N hN i
+          (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+            (finTwoArrowEquiv (Fin d)).symm B)) =
+      Matrix.blockDiagonal' fun k ↦ etaEdgePartialProduct dl dr η k {i} := by
+  classical
+  ext ⟨k, x⟩ ⟨h, y⟩
+  simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
+    embedLocalOperator_apply]
+  by_cases hkh : k = h
+  · subst h
+    rw [Matrix.blockDiagonal'_apply_eq]
+    let sx := (Matrix.etaFixedSectorCyclicEdgeEquiv dl dr k).symm x
+    let sy := (Matrix.etaFixedSectorCyclicEdgeEquiv dl dr k).symm y
+    have hxchain : (Matrix.etaCyclicEdgeEquiv dl dr e).symm ⟨k, x⟩ =
+        fun n ↦ e ⟨k n, sx n⟩ := by
+      funext n
+      exact Matrix.etaCyclicEdgeEquiv_symm_apply dl dr e k x n
+    have hychain : (Matrix.etaCyclicEdgeEquiv dl dr e).symm ⟨k, y⟩ =
+        fun n ↦ e ⟨k n, sy n⟩ := by
+      funext n
+      exact Matrix.etaCyclicEdgeEquiv_symm_apply dl dr e k y n
+    rw [hxchain, hychain]
+    simp only [Equiv.symm_symm, MPSTensor.extractWindow, finTwoArrowEquiv_apply,
+      Equiv.toFun_as_coe,
+      piFinTwoEquiv_apply, Fin.isValue, Fin.coe_ofNat_eq_mod, Nat.zero_mod,
+      Nat.add_zero, Nat.reduceMod, etaEdgePartialProduct, Finset.mem_singleton]
+    have hi0 : (⟨i.val % N, Nat.mod_lt _ (Fin.pos i)⟩ : Fin N) = i := by
+      ext
+      exact Nat.mod_eq_of_lt i.isLt
+    have hi1 : (⟨(i.val + 1) % N, Nat.mod_lt _ (Fin.pos i)⟩ : Fin N) = i + 1 := by
+      ext
+      simp [Fin.add_def]
+    rw [hi0, hi1]
+    have hlocal :
+        B (e ⟨k i, sx i⟩, e ⟨k (i + 1), sx (i + 1)⟩)
+            (e ⟨k i, sy i⟩, e ⟨k (i + 1), sy (i + 1)⟩) =
+          (1 : Matrix (Fin (dl (k i))) (Fin (dl (k i))) ℂ)
+              (sx i).2 (sy i).2 *
+            η (k i) (k (i + 1)) ((sx i).1, (sx (i + 1)).2)
+              ((sy i).1, (sy (i + 1)).2) *
+            (1 : Matrix (Fin (dr (k (i + 1)))) (Fin (dr (k (i + 1)))) ℂ)
+              (sx (i + 1)).1 (sy (i + 1)).1 := by
+      have hentry := congrFun (congrFun hB
+        ⟨(k i, k (i + 1)),
+          (((sx i).2, ((sx i).1, (sx (i + 1)).2)), (sx (i + 1)).1)⟩)
+        ⟨(k i, k (i + 1)),
+          (((sy i).2, ((sy i).1, (sy (i + 1)).2)), (sy (i + 1)).1)⟩
+      simpa [Matrix.reindex_apply, Matrix.etaPairSpatialBlockEquiv,
+        Matrix.blockDiagonal'_apply_eq, Matrix.kroneckerMap_apply] using hentry
+    rw [hlocal]
+    simp only [Matrix.one_apply]
+    have hxedge : ∀ n : Fin N,
+        x n = ((sx n).1, (sx (n + 1)).2) := by
+      intro n
+      simpa only [sx, Matrix.etaFixedSectorCyclicEdgeEquiv_apply] using
+        (congrFun
+          ((Matrix.etaFixedSectorCyclicEdgeEquiv dl dr k).apply_symm_apply x)
+          n).symm
+    have hyedge : ∀ n : Fin N,
+        y n = ((sy n).1, (sy (n + 1)).2) := by
+      intro n
+      simpa only [sy, Matrix.etaFixedSectorCyclicEdgeEquiv_apply] using
+        (congrFun
+          ((Matrix.etaFixedSectorCyclicEdgeEquiv dl dr k).apply_symm_apply y)
+          n).symm
+    have hj : MPSTensor.cyclicForwardSite i 1 = i + 1 := by
+      ext
+      simp [MPSTensor.cyclicForwardSite, Fin.add_def]
+    have hij : i + 1 ≠ i := add_one_ne_self_of_two_le hN i
+    have hcondition :
+        (AgreesOutsideWindow 2 hN i (fun n ↦ e ⟨k n, sx n⟩)
+            (fun n ↦ e ⟨k n, sy n⟩) ∧
+          ((sx i).2, (sx (i + 1)).1) = ((sy i).2, (sy (i + 1)).1)) ↔
+          ∀ n : Fin N, n ≠ i → x n = y n := by
+      constructor
+      · rintro ⟨ha, hb⟩ n hni
+        rw [hxedge, hyedge]
+        apply Prod.ext
+        · by_cases hnj : n = i + 1
+          · subst n
+            exact congrArg (fun z ↦ z.2) hb
+          · have hs := (agreesOutsideWindow_iff 2 hN i _ _).mp ha n (by
+                rw [← MPSTensor.mem_cyclicWindowSupport_iff hN,
+                  mem_cyclicWindowSupport_two, hj]
+                simp [hni, hnj])
+            have hs' := congrArg e.symm hs
+            simp only [Equiv.symm_apply_apply, Sigma.mk.injEq, true_and] at hs'
+            exact congrArg
+              (fun z : Fin (dr (k n)) × Fin (dl (k n)) ↦ z.1)
+              (eq_of_heq hs').symm
+        · by_cases hn1i : n + 1 = i
+          · rw [hn1i]
+            exact congrArg (fun z ↦ z.1) hb
+          · have hn1j : n + 1 ≠ i + 1 := by
+              intro hn
+              exact hni (add_right_cancel hn)
+            have hs := (agreesOutsideWindow_iff 2 hN i _ _).mp ha (n + 1) (by
+                rw [← MPSTensor.mem_cyclicWindowSupport_iff hN,
+                  mem_cyclicWindowSupport_two, hj]
+                simp [hn1i, hn1j])
+            have hs' := congrArg e.symm hs
+            simp only [Equiv.symm_apply_apply, Sigma.mk.injEq, true_and] at hs'
+            exact congrArg
+              (fun z : Fin (dr (k (n + 1))) × Fin (dl (k (n + 1))) ↦ z.2)
+              (eq_of_heq hs').symm
+      · intro he
+        constructor
+        · rw [agreesOutsideWindow_iff]
+          intro q hq
+          have hqi : q ≠ i := by
+            intro h
+            subst q
+            exact hq (by simp)
+          have hqj : q ≠ i + 1 := by
+            intro h
+            subst q
+            apply hq
+            rw [← MPSTensor.mem_cyclicWindowSupport_iff hN,
+              mem_cyclicWindowSupport_two, hj]
+            simp
+          congr 1
+          refine Sigma.ext rfl (heq_of_eq ?_)
+          apply Prod.ext
+          · have hqedge := congrArg Prod.fst (he q hqi).symm
+            rw [hxedge q, hyedge q] at hqedge
+            exact hqedge
+          · let p : Fin N := q - 1
+            have hpnext : p + 1 = q := by simp [p]
+            have hpne : p ≠ i := by
+              intro hp
+              have : q = i + 1 := by rw [← hpnext, hp]
+              exact hqj this
+            have hpedge := congrArg Prod.snd (he p hpne).symm
+            rw [hxedge p, hyedge p, hpnext] at hpedge
+            exact hpedge
+        · apply Prod.ext
+          · let p : Fin N := i - 1
+            have hpnext : p + 1 = i := by simp [p]
+            have hpne : p ≠ i := by
+              intro hp
+              have hpnext' := hpnext
+              rw [hp] at hpnext'
+              exact hij hpnext'
+            have hpedge := he p hpne
+            rw [hxedge p, hyedge p, hpnext] at hpedge
+            exact congrArg
+              (fun z : Matrix.EtaEdgeIndex dl dr (k p) (k i) ↦ z.2) hpedge
+          · have hedge := he (i + 1) hij
+            rw [hxedge (i + 1), hyedge (i + 1)] at hedge
+            exact (Prod.ext_iff.mp hedge).1
+    by_cases he : ∀ n : Fin N, n ≠ i → x n = y n
+    · obtain ⟨ha, hb⟩ := hcondition.mpr he
+      rw [if_pos ha]
+      simp only [Prod.ext_iff] at hb
+      rw [if_pos hb.1, if_pos hb.2, one_mul, mul_one]
+      rw [Finset.prod_eq_single i]
+      · rw [if_pos rfl, hxedge i, hyedge i]
+      · intro n _ hni
+        rw [if_neg hni, if_pos (he n hni)]
+      · simp
+    · have hnot : ¬ (AgreesOutsideWindow 2 hN i
+            (fun n ↦ e ⟨k n, sx n⟩) (fun n ↦ e ⟨k n, sy n⟩) ∧
+          ((sx i).2, (sx (i + 1)).1) = ((sy i).2, (sy (i + 1)).1)) :=
+        fun hc ↦ he (hcondition.mp hc)
+      push Not at he
+      obtain ⟨n, hni, hnxy⟩ := he
+      have hprod : (∏ q : Fin N,
+          if q = i then η (k q) (k (q + 1)) (x q) (y q)
+          else if x q = y q then 1 else 0) = 0 := by
+        apply Finset.prod_eq_zero (Finset.mem_univ n)
+        simp [hni, hnxy]
+      rw [hprod]
+      by_cases ha : AgreesOutsideWindow 2 hN i
+          (fun n ↦ e ⟨k n, sx n⟩) (fun n ↦ e ⟨k n, sy n⟩)
+      · rw [if_pos ha]
+        have hb : ((sx i).2, (sx (i + 1)).1) ≠
+            ((sy i).2, (sy (i + 1)).1) := fun hb ↦ hnot ⟨ha, hb⟩
+        by_cases hbL : (sx i).2 = (sy i).2
+        · have hbR : (sx (i + 1)).1 ≠ (sy (i + 1)).1 :=
+            fun hbR ↦ hb (Prod.ext hbL hbR)
+          rw [if_pos hbL, if_neg hbR, mul_zero]
+        · rw [if_neg hbL, zero_mul, zero_mul]
+      · rw [if_neg ha]
+  · rw [Matrix.blockDiagonal'_apply_ne _ _ _ hkh]
+    let sx := (Matrix.etaFixedSectorCyclicEdgeEquiv dl dr k).symm x
+    let ty := (Matrix.etaFixedSectorCyclicEdgeEquiv dl dr h).symm y
+    have hxchain : (Matrix.etaCyclicEdgeEquiv dl dr e).symm ⟨k, x⟩ =
+        fun n ↦ e ⟨k n, sx n⟩ := by
+      funext n
+      exact Matrix.etaCyclicEdgeEquiv_symm_apply dl dr e k x n
+    have hychain : (Matrix.etaCyclicEdgeEquiv dl dr e).symm ⟨h, y⟩ =
+        fun n ↦ e ⟨h n, ty n⟩ := by
+      funext n
+      exact Matrix.etaCyclicEdgeEquiv_symm_apply dl dr e h y n
+    rw [hxchain, hychain]
+    simp only [Equiv.symm_symm, MPSTensor.extractWindow, finTwoArrowEquiv_apply,
+      Equiv.toFun_as_coe,
+      piFinTwoEquiv_apply, Fin.isValue, Fin.coe_ofNat_eq_mod, Nat.zero_mod,
+      Nat.add_zero, Nat.reduceMod]
+    have hi0 : (⟨i.val % N, Nat.mod_lt _ (Fin.pos i)⟩ : Fin N) = i := by
+      ext
+      exact Nat.mod_eq_of_lt i.isLt
+    have hi1 : (⟨(i.val + 1) % N, Nat.mod_lt _ (Fin.pos i)⟩ : Fin N) = i + 1 := by
+      ext
+      simp [Fin.add_def]
+    rw [hi0, hi1]
+    by_cases ha : AgreesOutsideWindow 2 hN i
+        (fun n ↦ e ⟨k n, sx n⟩) (fun n ↦ e ⟨h n, ty n⟩)
+    · rw [if_pos ha]
+      have hpairs : (k i, k (i + 1)) ≠ (h i, h (i + 1)) := by
+        intro hp
+        apply hkh
+        funext q
+        by_cases hq : ((q.val + N - i.val) % N < 2)
+        · rw [← MPSTensor.mem_cyclicWindowSupport_iff hN,
+            mem_cyclicWindowSupport_two] at hq
+          rcases hq with rfl | hq
+          · exact congrArg Prod.fst hp
+          · have hj : MPSTensor.cyclicForwardSite i 1 = i + 1 := by
+              ext
+              simp [MPSTensor.cyclicForwardSite, Fin.add_def]
+            rw [hj] at hq
+            subst q
+            exact congrArg Prod.snd hp
+        · have hs := (agreesOutsideWindow_iff 2 hN i _ _).mp ha q hq
+          have hs' := congrArg e.symm hs
+          simpa only [Equiv.symm_apply_apply] using (congrArg Sigma.fst hs').symm
+      have hentry := congrFun (congrFun hB
+        ⟨(k i, k (i + 1)),
+          (((sx i).2, ((sx i).1, (sx (i + 1)).2)), (sx (i + 1)).1)⟩)
+        ⟨(h i, h (i + 1)),
+          (((ty i).2, ((ty i).1, (ty (i + 1)).2)), (ty (i + 1)).1)⟩
+      simpa [Matrix.reindex_apply, Matrix.etaPairSpatialBlockEquiv,
+        Matrix.blockDiagonal'_apply_ne _ _ _ hpairs] using hentry
+    · rw [if_neg ha]
+
+private theorem reindex_list_prod {α β : Type*} [Fintype α] [DecidableEq α]
+    [Fintype β] [DecidableEq β] (e : α ≃ β) (l : List (Matrix α α ℂ)) :
+    Matrix.reindex e e l.prod = (l.map fun A ↦ Matrix.reindex e e A).prod := by
+  induction l with
+  | nil =>
+      ext x y
+      simp [Matrix.reindex_apply, Matrix.one_apply]
+  | cons A l ih =>
+      simp only [List.prod_cons, List.map_cons]
+      change Matrix.reindexLinearEquiv ℂ ℂ e e (A * l.prod) = _
+      rw [← Matrix.reindexLinearEquiv_mul ℂ ℂ e e e]
+      simp only [Matrix.coe_reindexLinearEquiv, ih]
+
+private theorem blockDiagonal'_list_prod {ι : Type*} [Fintype ι] [DecidableEq ι]
+    {α : ι → Type*} [∀ i, Fintype (α i)] [∀ i, DecidableEq (α i)]
+    (l : List ((i : ι) → Matrix (α i) (α i) ℂ)) :
+    (l.map Matrix.blockDiagonal').prod =
+      Matrix.blockDiagonal' fun i ↦ (l.map fun A ↦ A i).prod := by
+  induction l with
+  | nil =>
+      ext ⟨i, x⟩ ⟨j, y⟩
+      by_cases hij : i = j
+      · subst j
+        simp [Matrix.one_apply, Matrix.blockDiagonal'_apply]
+      · simp [Matrix.blockDiagonal'_apply_ne _ _ _ hij, hij]
+  | cons A l ih =>
+      simp only [List.map_cons, List.prod_cons]
+      rw [ih, ← Matrix.blockDiagonal'_mul]
+
+/-- A local neighboring-operator decomposition propagates to the ordered product of all
+translated bonds on every periodic chain of length at least two.  At length two the two
+translated windows have the opposite orders \((0,1)\) and \((1,0)\); the cyclic edge
+equivalence records both orientations explicitly.
+
+Source: arXiv:1606.00608, Appendix C.2, equation sigmaNK2, lines 1581--1605.
+Documented in `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem reindex_product_embedLocalOperator_of_etaPair_decomposition
+    {K N : ℕ} [NeZero N] (hN : 2 ≤ N) (dl dr : Fin K → ℕ)
+    (e : Matrix.EtaSiteIndex K dl dr ≃ Fin d)
+    (η : (q h : Fin K) →
+      Matrix (Matrix.EtaEdgeIndex dl dr q h) (Matrix.EtaEdgeIndex dl dr q h) ℂ)
+    (B : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
+    (hB : Matrix.reindex (Matrix.etaPairSpatialBlockEquiv e).symm
+        (Matrix.etaPairSpatialBlockEquiv e).symm B =
+      Matrix.blockDiagonal' fun qh : Fin K × Fin K ↦
+        ((1 : Matrix (Fin (dl qh.1)) (Fin (dl qh.1)) ℂ) ⊗ₖ
+          η qh.1 qh.2) ⊗ₖ
+            (1 : Matrix (Fin (dr qh.2)) (Fin (dr qh.2)) ℂ)) :
+    Matrix.reindex (Matrix.etaCyclicEdgeEquiv dl dr e)
+        (Matrix.etaCyclicEdgeEquiv dl dr e)
+        (List.ofFn fun i : Fin N ↦
+          embedLocalOperator (d := d) 2 N (by omega) i
+            (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+              (finTwoArrowEquiv (Fin d)).symm B)).prod =
+      Matrix.blockDiagonal' fun k : Fin N → Fin K ↦
+        fun x y ↦ ∏ n : Fin N, η (k n) (k (n + 1)) (x n) (y n) := by
+  classical
+  rw [reindex_list_prod]
+  rw [show (List.ofFn fun i : Fin N ↦
+      embedLocalOperator (d := d) 2 N hN i
+        (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+          (finTwoArrowEquiv (Fin d)).symm B)).map
+        (fun A ↦ Matrix.reindex (Matrix.etaCyclicEdgeEquiv dl dr e)
+          (Matrix.etaCyclicEdgeEquiv dl dr e) A) =
+      List.ofFn (fun i : Fin N ↦
+        Matrix.reindex (Matrix.etaCyclicEdgeEquiv dl dr e)
+          (Matrix.etaCyclicEdgeEquiv dl dr e)
+          (embedLocalOperator (d := d) 2 N hN i
+            (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+              (finTwoArrowEquiv (Fin d)).symm B))) by
+    simp
+    rfl]
+  have hmap :
+      (List.ofFn fun i : Fin N ↦
+        Matrix.reindex (Matrix.etaCyclicEdgeEquiv dl dr e)
+          (Matrix.etaCyclicEdgeEquiv dl dr e)
+          (embedLocalOperator (d := d) 2 N hN i
+            (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+              (finTwoArrowEquiv (Fin d)).symm B))) =
+      List.ofFn (fun i : Fin N ↦
+        Matrix.blockDiagonal' fun k ↦ etaEdgePartialProduct dl dr η k {i}) := by
+    exact congrArg List.ofFn (funext fun i ↦
+      reindex_embedLocalOperator_etaPairBond hN dl dr e η B hB i)
+  rw [hmap]
+  rw [show List.ofFn (fun i : Fin N ↦
+      Matrix.blockDiagonal' fun k ↦ etaEdgePartialProduct dl dr η k {i}) =
+      (List.ofFn fun i : Fin N ↦
+        fun k ↦ etaEdgePartialProduct dl dr η k {i}).map Matrix.blockDiagonal' by
+    simp
+    rfl]
+  rw [blockDiagonal'_list_prod]
+  congr
+  funext k
+  symm
+  have hl : (List.ofFn fun i : Fin N ↦
+      fun q ↦ etaEdgePartialProduct dl dr η q {i}).map (fun A ↦ A k) =
+      List.ofFn (fun i : Fin N ↦ etaEdgePartialProduct dl dr η k {i}) := by
+    simp
+    rfl
+  rw [hl]
+  exact (prod_etaEdgePartialProduct_singletons_univ dl dr η k).symm
+
+/-- The length-two specialization of cyclic transport.  The two translated windows are
+\((0,1)\) and \((1,0)\), and hence contribute the two oriented edge factors
+\(\eta_{k_0,k_1}\) and \(\eta_{k_1,k_0}\). -/
+theorem reindex_product_embedLocalOperator_two_of_etaPair_decomposition
+    {K : ℕ} (dl dr : Fin K → ℕ)
+    (e : Matrix.EtaSiteIndex K dl dr ≃ Fin d)
+    (η : (q h : Fin K) →
+      Matrix (Matrix.EtaEdgeIndex dl dr q h) (Matrix.EtaEdgeIndex dl dr q h) ℂ)
+    (B : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
+    (hB : Matrix.reindex (Matrix.etaPairSpatialBlockEquiv e).symm
+        (Matrix.etaPairSpatialBlockEquiv e).symm B =
+      Matrix.blockDiagonal' fun qh : Fin K × Fin K ↦
+        ((1 : Matrix (Fin (dl qh.1)) (Fin (dl qh.1)) ℂ) ⊗ₖ
+          η qh.1 qh.2) ⊗ₖ
+            (1 : Matrix (Fin (dr qh.2)) (Fin (dr qh.2)) ℂ)) :
+    Matrix.reindex (Matrix.etaCyclicEdgeEquiv (N := 2) dl dr e)
+        (Matrix.etaCyclicEdgeEquiv (N := 2) dl dr e)
+        (List.ofFn fun i : Fin 2 ↦
+          embedLocalOperator (d := d) 2 2 (by omega) i
+            (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+              (finTwoArrowEquiv (Fin d)).symm B)).prod =
+      Matrix.blockDiagonal' fun k : Fin 2 → Fin K ↦
+        fun x y ↦ ∏ n : Fin 2, η (k n) (k (n + 1)) (x n) (y n) := by
+  exact reindex_product_embedLocalOperator_of_etaPair_decomposition
+    (N := 2) (by omega) dl dr e η B hB
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/CommutingBondEtaCyclicTransport.lean
+++ b/TNLean/MPS/MPDO/CommutingBondEtaCyclicTransport.lean
@@ -598,7 +598,10 @@ theorem reindex_product_embedLocalOperator_of_etaPair_decomposition
 
 /-- The length-two specialization of cyclic transport.  The two translated windows are
 \((0,1)\) and \((1,0)\), and hence contribute the two oriented edge factors
-\(\eta_{k_0,k_1}\) and \(\eta_{k_1,k_0}\). -/
+\(\eta_{k_0,k_1}\) and \(\eta_{k_1,k_0}\).
+
+Source: arXiv:1606.00608, Appendix C.2, equation sigmaNK2, lines 1581--1605.
+Documented in `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem reindex_product_embedLocalOperator_two_of_etaPair_decomposition
     {K : ℕ} (dl dr : Fin K → ℕ)
     (e : Matrix.EtaSiteIndex K dl dr ≃ Fin d)

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -283,6 +283,7 @@
     \[
         H\cong\bigoplus_q H_{q,r}\otimes H_{q,l},
     \]
+    after regrouping the two-site coordinates according to this decomposition,
     a two-site operator has the form
     \[
         B=\bigoplus_{q,h}
@@ -291,7 +292,7 @@
     For every $N\geq2$, regroup the cyclic chain as
     \[
         H^{\otimes N}\cong
-        \bigoplus_{k:\mathbb Z/N\mathbb Z\to\{1,\ldots,K\}}
+        \bigoplus_{k:\mathbb Z/N\mathbb Z\to\{0,\ldots,K-1\}}
         \bigotimes_{n\in\mathbb Z/N\mathbb Z}
           \left(H_{k_n,r}\otimes H_{k_{n+1},l}\right).
     \]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -274,6 +274,47 @@
     $B'$, and is therefore positive semidefinite.
 \end{proof}
 
+\begin{theorem}[Cyclic product of a locally decomposed bond]
+    \label{thm:mpdo_eta_pair_bond_cyclic_product_transport}
+    \lean{MPOTensor.%
+      reindex_product_embedLocalOperator_of_etaPair_decomposition}
+    \leanok
+    Suppose that, in one fixed coordinate decomposition
+    \[
+        H\cong\bigoplus_q H_{q,r}\otimes H_{q,l},
+    \]
+    a two-site operator has the form
+    \[
+        B=\bigoplus_{q,h}
+          \Id_{H_{q,l}}\otimes\eta_{q,h}\otimes\Id_{H_{h,r}}.
+    \]
+    For every $N\geq2$, regroup the cyclic chain as
+    \[
+        H^{\otimes N}\cong
+        \bigoplus_{k:\mathbb Z/N\mathbb Z\to\{1,\ldots,K\}}
+        \bigotimes_{n\in\mathbb Z/N\mathbb Z}
+          \left(H_{k_n,r}\otimes H_{k_{n+1},l}\right).
+    \]
+    Then, in these coordinates,
+    \[
+        \prod_{n=0}^{N-1}B_{n,n+1}
+        =\bigoplus_k\bigotimes_{n=0}^{N-1}\eta_{k_n,k_{n+1}},
+        \qquad k_N=k_0.
+    \]
+    At $N=2$, the two translated windows have the opposite orders $(0,1)$
+    and $(1,0)$ and give the two oriented factors
+    $\eta_{k_0,k_1}$ and $\eta_{k_1,k_0}$.
+\end{theorem}
+
+\begin{proof}\leanok
+    In a fixed sector configuration, the cyclic regrouping sends the factors
+    $(r_n,l_n)$ to the edge factors $(r_n,l_{n+1})$.  The translate beginning
+    at $n$ acts by $\eta_{k_n,k_{n+1}}$ on the $n$th edge factor and by the
+    identity on every other edge factor.  Different sector configurations do
+    not mix.  Multiplying the translated operators therefore gives the stated
+    direct sum of tensor products.
+\end{proof}
+
 \begin{theorem}[A translation-invariant commuting bond and ZCL imply SAL]
     \label{thm:mpdo_translation_invariant_commuting_form_zcl_sal}
     \notready

--- a/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
+++ b/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
@@ -153,8 +153,29 @@ uses the same one-site unitary at both ends of the fixed bond and proves
  \qquad \eta_{k,h}\succeq0.
 \]
 Since the bond and unitary are chain-independent, this is one neighboring
-family for every translate.  The remaining transport task is the finite-chain
-direct-sum product formula and its use in the Markov decomposition.
+family for every translate.
+
+The bond-local cyclic product is now formalized for every $N\geq2$.  The
+theorem
+\leanid{MPOTensor.reindex_product_embedLocalOperator_of_etaPair_decomposition}
+constructs the dependent cyclic regrouping
+\[
+  H^{\otimes N}\simeq
+  \bigoplus_{k_0,\ldots,k_{N-1}}
+  \bigotimes_{n=0}^{N-1}(H_{k_n,r}\otimes H_{k_{n+1},l})
+\]
+and proves that the product of the translated, locally decomposed bond is
+\(
+  \bigoplus_k\bigotimes_n\eta_{k_n,k_{n+1}}
+\), with $k_N=k_0$.  The length-two specialization is included: its two
+windows have the opposite cyclic orders $(0,1)$ and $(1,0)$.
+
+This theorem begins with the locally transformed bond.  It does not yet
+identify the product with the conjugation of the original chain product by
+the tensor power of the one-site unitary, nor combine that identity with the
+positive realization scalar.  Those two transport statements are the
+remaining algebraic steps before the full finite-chain equation
+\emph{sigmaNK2} may be claimed.
 
 There is a separate obstruction at source line~1613.  The phrase ``arguing as
 in Lemmas \emph{propSN} and \emph{SALZCL}'' does not show that source ZCL alone
@@ -197,8 +218,11 @@ restriction that isolates only its final entropy-theoretic step.
 The gap can be removed in the following stages.
 
 \begin{enumerate}
-\item Derive the finite-chain form of equation \emph{sigmaNK2} from the proved
-local positive neighboring-operator decomposition.
+\item Complete the tensor-power conjugation of the original cyclic bond
+product and combine it with the positive realization scalar.  The intervening
+bond-local cyclic direct-sum product is proved for every $N\geq2$; only after
+these two remaining identities may the full finite-chain equation
+\emph{sigmaNK2} be claimed.
 \item Resolve \ghissue{3593} by finding a source-faithful property of the
 actual neighboring family which excludes the nilpotent zero-eigenspace, or
 replace the printed line-1613 argument by a direct Markov decomposition which


### PR DESCRIPTION
## Summary

This pull request formalizes the all-length cyclic product of a two-site bond after its local neighboring-operator decomposition.

For every N ≥ 2, it constructs the dependent regrouping from site factors (R_n, L_n) to cyclic edge factors (R_n, L_{n+1}) and proves that the ordered product of translated bonds is block diagonal over sector configurations k : Fin N → Fin K.  The block for k has entries given by the product of η_{k_n,k_{n+1}} around the cycle.

The length-two case is included explicitly.  Its two translated windows have the opposite cyclic orders (0,1) and (1,0), producing the two oriented factors η_{k_0,k_1} and η_{k_1,k_0}.

The theorem is a conditional algebraic transport result: it assumes the local pair-bond block identity.  It does not use positivity, zero correlation length, a rank-one conclusion, a Hayashi decomposition, or saturation of the area law.  Accordingly, the blueprint entry has no logical dependency on the positive-decomposition theorem.

The paper-gap note now separates this completed bond-local product formula from the still-missing tensor-power unitary conjugation and positive realization scalar needed for the full finite-chain equation sigmaNK2.

Advances #4191.

## Checks

- Focused Lean elaboration of TNLean/MPS/MPDO/CommutingBondEtaCyclicTransport.lean in the known-good project environment
- Root import elaboration using a temporary compiled overlay, without modifying the damaged worktree-local dependency checkout
- Blueprint and Lean source synchronization
- Reader-facing prose validation
- Diff and line-length validation
- Proof-integrity scan for sorry, admit, axiom, native_decide, and unsafeCast

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formal proofs and documentation only; no runtime, auth, or data-path changes. Risk is mainly proof maintenance and import surface growth in the MPDO library.
> 
> **Overview**
> Adds **`CommutingBondEtaCyclicTransport.lean`** (~628 lines) proving that, after a local pair-bond block decomposition, the product of all translated two-site bonds on a periodic chain of length **N ≥ 2** is block diagonal over sector configurations **k**, with each block **∏ₙ η_{kₙ,k_{n+1}}** around the cycle. The proof introduces **`Matrix.etaCyclicEdgeEquiv`** (site factors **(Rₙ,Lₙ)** → cyclic edge factors **(Rₙ,L_{n+1})**) and **`MPOTensor.reindex_product_embedLocalOperator_of_etaPair_decomposition`** as the main capstone; a **N = 2** corollary covers the opposite window orientations **(0,1)** vs **(1,0)**.
> 
> The result is **purely algebraic** (assumes the local η-block identity only; no positivity, ZCL, or area law). **`TNLean.lean`** imports the new module; blueprint **ch21** gains theorem **Cyclic product of a locally decomposed bond** with a `\leanok` link; **`cpsv16_commuting_form_to_sal.tex`** records this step as done and narrows the open gap to tensor-power unitary conjugation plus the positive realization scalar before full **sigmaNK2**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 618c57b1a22bed77b0c394d95b5562a75d6be324. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->