### PR TITLE
refactor(tenkz): unify map coordinate checks

### DIFF
--- a/docs/tenkz/chapters2/ch-reference.tex
+++ b/docs/tenkz/chapters2/ch-reference.tex
@@ -381,13 +381,15 @@ arrow syntax of such matrices.
 \thumbtag{\tnkey{maps}}%
 \cmdsig{\textbackslash tnarrow[\\
 \quad from=\{(r,c)\}, to=\{(r,c+1)\},\\
-\quad \meta{line type}]\{\meta{map}\}}
+\quad \meta{line type}, fused]\{\meta{map}\}}
 
 \noindent The line type is either \tnkey{role=} or \tnkey{species=}.
 The semantic roles are \tnval{operator}, \tnval{marked}, \tnval{extra},
 and \tnval{passive}; a species is a name declared by \tncmd{tnset}.
 Exactly one of these keys supplies the edge type.  The line is headless
 because its position on the composition axis already fixes the direction.
+The independent key \tnkey{fused} uses the doubled-line convention for a
+fused bond and may accompany either line type.
 The starred form puts the map's name below the line; it does not reverse the
 map.  The whole environment is a mathematical atom, so the same spelling
 belongs directly in running mathematics or in a displayed equation.  No
@@ -571,6 +573,12 @@ widths still apply, so a free picture matches its grid neighbours.
   \texttt{ring} & --- & policy & the glyph \\
 \texttt{ports=} & \texttt{\{side:kind,\ldots\}} & --- &
   typed ports, kinds \texttt{virtual} and \texttt{physical} \\
+\texttt{role=} & \meta{role} & --- &
+  \texttt{operator}, \texttt{marked}, \texttt{extra}, or
+  \texttt{passive}; determines the atom's hue \\
+\texttt{species=} & \meta{name} & --- &
+  hue of a species declared by \tncmd{tnset}; \texttt{role=} prevails if
+  both are present \\
 \texttt{label pos=} & \texttt{north|south|} \texttt{east|west} &
   auto & label side of a bead \\
 \bottomrule
@@ -592,6 +600,12 @@ widths still apply, so a free picture matches its grid neighbours.
   tangents of a \texttt{curve} route \\
 \texttt{label=} & \meta{math} & --- &
   label at the wire's midpoint \\
+\texttt{role=} & \meta{role} & --- &
+  \texttt{operator}, \texttt{marked}, \texttt{extra}, or
+  \texttt{passive}; determines the wire's hue \\
+\texttt{species=} & \meta{name} & --- &
+  hue of a species declared by \tncmd{tnset}; \texttt{role=} prevails if
+  both are present \\
 \texttt{fused} & --- & --- &
   doubled strand \\
 \texttt{dir} & --- & --- &

--- a/tex/tenkz/tenkz-cd.code.tex
+++ b/tex/tenkz/tenkz-cd.code.tex
@@ -487,6 +487,20 @@
       }
   }
 
+% One scalar test serves rows and columns of both endpoints.  The caller
+% retains their source-row, target-row, source-column, target-column order,
+% so even a rejected map reports the same complete diagnostic sequence.
+\cs_new_protected:Npn \tenkz_cd_check_map_coordinate:nnnn #1#2#3#4
+  {
+    \bool_lazy_or:nnT
+      { \int_compare_p:nNn {#3} < {1} }
+      { \int_compare_p:nNn {#3} > {#4} }
+      {
+        \PackageError{tenkz}{Typed-map~#1=#2~is~outside~the~matrix}{}
+        \bool_set_false:N \l__tenkzcd_mapvalid_bool
+      }
+  }
+
 \cs_new_protected:Npn \tenkz_cd_map_style:nnnN #1#2#3#4
   {
     \str_if_eq:nnTF {#1} {1}
@@ -520,26 +534,14 @@
       \l__tenkzcd_torow_int \l__tenkzcd_tocol_int
     \bool_if:NT \l__tenkzcd_mapvalid_bool
       {
-        \bool_lazy_or:nnT
-          { \int_compare_p:nNn {\l__tenkzcd_fromrow_int} < {1} }
-          { \int_compare_p:nNn {\l__tenkzcd_fromrow_int} > {\l__tenkzcd_maprows_int} }
-          { \PackageError{tenkz}{Typed-map~from=#1~is~outside~the~matrix}{}
-            \bool_set_false:N \l__tenkzcd_mapvalid_bool }
-        \bool_lazy_or:nnT
-          { \int_compare_p:nNn {\l__tenkzcd_torow_int} < {1} }
-          { \int_compare_p:nNn {\l__tenkzcd_torow_int} > {\l__tenkzcd_maprows_int} }
-          { \PackageError{tenkz}{Typed-map~to=#2~is~outside~the~matrix}{}
-            \bool_set_false:N \l__tenkzcd_mapvalid_bool }
-        \bool_lazy_or:nnT
-          { \int_compare_p:nNn {\l__tenkzcd_fromcol_int} < {1} }
-          { \int_compare_p:nNn {\l__tenkzcd_fromcol_int} > {\l__tenkzcd_mapcols_int} }
-          { \PackageError{tenkz}{Typed-map~from=#1~is~outside~the~matrix}{}
-            \bool_set_false:N \l__tenkzcd_mapvalid_bool }
-        \bool_lazy_or:nnT
-          { \int_compare_p:nNn {\l__tenkzcd_tocol_int} < {1} }
-          { \int_compare_p:nNn {\l__tenkzcd_tocol_int} > {\l__tenkzcd_mapcols_int} }
-          { \PackageError{tenkz}{Typed-map~to=#2~is~outside~the~matrix}{}
-            \bool_set_false:N \l__tenkzcd_mapvalid_bool }
+        \tenkz_cd_check_map_coordinate:nnnn
+          {from}{#1}{\l__tenkzcd_fromrow_int}{\l__tenkzcd_maprows_int}
+        \tenkz_cd_check_map_coordinate:nnnn
+          {to}{#2}{\l__tenkzcd_torow_int}{\l__tenkzcd_maprows_int}
+        \tenkz_cd_check_map_coordinate:nnnn
+          {from}{#1}{\l__tenkzcd_fromcol_int}{\l__tenkzcd_mapcols_int}
+        \tenkz_cd_check_map_coordinate:nnnn
+          {to}{#2}{\l__tenkzcd_tocol_int}{\l__tenkzcd_mapcols_int}
       }
     \bool_if:NT \l__tenkzcd_mapvalid_bool
       {


### PR DESCRIPTION
Gate run for #4158 before milestone 0.6 closes.

## What grew ad hoc

Typed-map mode added four copies of the same scalar condition: whether a source or target row or column lies in the measured matrix bounds. The copies differed only in the endpoint name, coordinate register, and upper bound.

The key-surface sweep also found a documentation gap: the public `fused` arrow key and the public `role=`/`species=` options of `\tnput` and `\tnjoin` were implemented but absent from the manual reference.

## Which things were secretly one thing

Source-row, target-row, source-column, and target-column validation are one coordinate predicate. This PR extracts that predicate and retains the original diagnostic order.

The manual now presents the five public typed-map arrow keys as one surface: `from`, `to`, `fused`, `role`, and `species`. It also records role/species styling and precedence for free atoms and joins.

## What is deleted in a redesign today

The four hand-written bounds blocks are deleted. The parser, error messages, error multiplicity, diagnostic order, and valid rendering semantics remain unchanged.

No public key is deleted: each surviving key has a distinct visible or semantic effect and is now documented.

## Mechanical gate evidence

- every ratio in `tenkz-core.code.tex` has a motivation comment
- post-0.6 `cs_new` growth is confined to typed-map mode; the repeated coordinate predicate was the concrete twin found
- `rg -n 'TODO|FIXME|XXX' tex/tenkz docs/tenkz` has no result
- `/tenkz/arrow` accepts exactly `from`, `to`, `fused`, `role`, and `species`; the manual now covers all five
- `\tnput` and `\tnjoin` now document their implemented `role=` and `species=` options

## Validation

- rebased directly onto `main` after #4246
- `git diff --check`
- tenkz lint: 113 files, 0 findings
- all 18 acceptance examples compile and all 18 event streams audit without hard errors
- manual: two XeLaTeX passes, 42 pages; 76 pictures, 0 hard audit errors
- visually inspected manual pages 28–29 and 31–32 and the current typed-map example
- valid typed-map output is byte-identical to `main`: identical `.tnlog` and 200-dpi PNG
- a temporary invalid-address fixture using only `role=operator` preserves five package diagnostics exactly in text, multiplicity, and order

The change adds no public command or key and no new drawing behavior.
