### PR TITLE
feat(Algebra): prove Beigi block-sum equalities

### DIFF
--- a/TNLean/Algebra/CommutingOverlappingDecomp.lean
+++ b/TNLean/Algebra/CommutingOverlappingDecomp.lean
@@ -24,6 +24,8 @@ indices.
 * `Matrix.exists_unitary_blockActions_of_overlappingLifts_commute` -- the corresponding
   explicit unitary direct-sum representation, with Hermitian operators on the two
   complementary factors and the two block identities of Beigi's lemma.
+* `Matrix.exists_unitary_blockSum_equalities_of_overlappingLifts_commute` -- the same
+  identities solved for the original two overlapping operators.
 
 ## References
 
@@ -460,5 +462,103 @@ theorem exists_unitary_blockActions_of_overlappingLifts_commute
     simpa [S,
       Matrix.blockDiagonal'_apply_eq, Matrix.kroneckerMap_apply,
       Matrix.one_apply] using hEntry
+
+/-- **Beigi's block-sum equalities for the original overlapping operators.** Let
+$X_{AB}$ and $Y_{BC}$ be Hermitian, and suppose that their natural three-factor lifts
+commute. There are positive dimensions $d_q,m_q$, a unitary $U$ on the middle space,
+and Hermitian operators $R_q$ on $H_A\otimes H_{q,l}$ and $S_q$ on
+$H_{q,r}\otimes H_C$ such that
+$$
+ X_{AB}=(\mathbf 1_A\otimes U)
+   \left(\bigoplus_q R_q\otimes\mathbf 1_{q,r}\right)
+   (\mathbf 1_A\otimes U^*),
+ \qquad
+ Y_{BC}=(U\otimes\mathbf 1_C)
+   \left(\bigoplus_q \mathbf 1_{q,l}\otimes S_q\right)
+   (U^*\otimes\mathbf 1_C).
+$$
+The reindexings in the formal statement express the two dependent direct sums in the
+original product coordinates. The block operators are Hermitian; no unitarity assertion
+is made about them.
+
+Source: Beigi, arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`), TeX lines 398--422,
+especially the two displayed equalities on page 3. -/
+theorem exists_unitary_blockSum_equalities_of_overlappingLifts_commute
+    (X : Matrix (a × b) (a × b) ℂ) (Y : Matrix (b × c) (b × c) ℂ)
+    (hX : X.IsHermitian) (hY : Y.IsHermitian)
+    (hComm : leftOverlappingLift X * rightOverlappingLift Y =
+      rightOverlappingLift Y * leftOverlappingLift X) :
+    ∃ (K : ℕ) (d m : Fin K → ℕ)
+      (e : ((q : Fin K) × (Fin (m q) × Fin (d q))) ≃ b)
+      (U : Matrix b b ℂ)
+      (R : ∀ q, Matrix (a × Fin (d q)) (a × Fin (d q)) ℂ)
+      (S : ∀ q, Matrix (Fin (m q) × c) (Fin (m q) × c) ℂ),
+      U ∈ Matrix.unitaryGroup b ℂ ∧
+        (∀ q, 0 < d q) ∧ (∀ q, 0 < m q) ∧
+        (∀ q, (R q).IsHermitian) ∧ (∀ q, (S q).IsHermitian) ∧
+        X = ((1 : Matrix a a ℂ) ⊗ₖ U) *
+          Matrix.reindex (leftSpatialBlockEquiv e) (leftSpatialBlockEquiv e)
+            (Matrix.blockDiagonal' fun q =>
+              R q ⊗ₖ (1 : Matrix (Fin (m q)) (Fin (m q)) ℂ)) *
+          star ((1 : Matrix a a ℂ) ⊗ₖ U) ∧
+        Y = (U ⊗ₖ (1 : Matrix c c ℂ)) *
+          Matrix.reindex (rightSpatialBlockEquiv e) (rightSpatialBlockEquiv e)
+            (Matrix.blockDiagonal' fun q =>
+              (1 : Matrix (Fin (d q)) (Fin (d q)) ℂ) ⊗ₖ S q) *
+          star (U ⊗ₖ (1 : Matrix c c ℂ)) := by
+  classical
+  obtain ⟨K, d, m, e, U, R, S, hU, hd, hm, hR, hS, hXblock, hYblock⟩ :=
+    exists_unitary_blockActions_of_overlappingLifts_commute X Y hX hY hComm
+  have hXcoord : star ((1 : Matrix a a ℂ) ⊗ₖ U) * X *
+        ((1 : Matrix a a ℂ) ⊗ₖ U) =
+      Matrix.reindex (leftSpatialBlockEquiv e) (leftSpatialBlockEquiv e)
+        (Matrix.blockDiagonal' fun q =>
+          R q ⊗ₖ (1 : Matrix (Fin (m q)) (Fin (m q)) ℂ)) := by
+    have h := congrArg
+      (Matrix.reindex (leftSpatialBlockEquiv e) (leftSpatialBlockEquiv e)) hXblock
+    simpa using h
+  have hYcoord : star (U ⊗ₖ (1 : Matrix c c ℂ)) * Y *
+        (U ⊗ₖ (1 : Matrix c c ℂ)) =
+      Matrix.reindex (rightSpatialBlockEquiv e) (rightSpatialBlockEquiv e)
+        (Matrix.blockDiagonal' fun q =>
+          (1 : Matrix (Fin (d q)) (Fin (d q)) ℂ) ⊗ₖ S q) := by
+    have h := congrArg
+      (Matrix.reindex (rightSpatialBlockEquiv e) (rightSpatialBlockEquiv e)) hYblock
+    simpa using h
+  have hUleft : ((1 : Matrix a a ℂ) ⊗ₖ U) ∈ Matrix.unitaryGroup (a × b) ℂ :=
+    Matrix.kronecker_mem_unitary (one_mem _) hU
+  have hUright : (U ⊗ₖ (1 : Matrix c c ℂ)) ∈ Matrix.unitaryGroup (b × c) ℂ :=
+    Matrix.kronecker_mem_unitary hU (one_mem _)
+  have hUleft_mul : ((1 : Matrix a a ℂ) ⊗ₖ U) *
+      star ((1 : Matrix a a ℂ) ⊗ₖ U) = 1 :=
+    Matrix.mem_unitaryGroup_iff.mp hUleft
+  have hUright_mul : (U ⊗ₖ (1 : Matrix c c ℂ)) *
+      star (U ⊗ₖ (1 : Matrix c c ℂ)) = 1 :=
+    Matrix.mem_unitaryGroup_iff.mp hUright
+  have hXeq : X = ((1 : Matrix a a ℂ) ⊗ₖ U) *
+        Matrix.reindex (leftSpatialBlockEquiv e) (leftSpatialBlockEquiv e)
+          (Matrix.blockDiagonal' fun q =>
+            R q ⊗ₖ (1 : Matrix (Fin (m q)) (Fin (m q)) ℂ)) *
+        star ((1 : Matrix a a ℂ) ⊗ₖ U) := by
+    rw [← hXcoord,
+      ← mul_assoc ((1 : Matrix a a ℂ) ⊗ₖ U)
+        (star ((1 : Matrix a a ℂ) ⊗ₖ U) * X)
+        ((1 : Matrix a a ℂ) ⊗ₖ U),
+      ← mul_assoc ((1 : Matrix a a ℂ) ⊗ₖ U)
+        (star ((1 : Matrix a a ℂ) ⊗ₖ U)) X,
+      hUleft_mul, one_mul, mul_assoc, hUleft_mul, mul_one]
+  have hYeq : Y = (U ⊗ₖ (1 : Matrix c c ℂ)) *
+        Matrix.reindex (rightSpatialBlockEquiv e) (rightSpatialBlockEquiv e)
+          (Matrix.blockDiagonal' fun q =>
+            (1 : Matrix (Fin (d q)) (Fin (d q)) ℂ) ⊗ₖ S q) *
+        star (U ⊗ₖ (1 : Matrix c c ℂ)) := by
+    rw [← hYcoord,
+      ← mul_assoc (U ⊗ₖ (1 : Matrix c c ℂ))
+        (star (U ⊗ₖ (1 : Matrix c c ℂ)) * Y)
+        (U ⊗ₖ (1 : Matrix c c ℂ)),
+      ← mul_assoc (U ⊗ₖ (1 : Matrix c c ℂ))
+        (star (U ⊗ₖ (1 : Matrix c c ℂ))) Y,
+      hUright_mul, one_mul, mul_assoc, hUright_mul, mul_one]
+  exact ⟨K, d, m, e, U, R, S, hU, hd, hm, hR, hS, hXeq, hYeq⟩
 
 end Matrix

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2177,6 +2177,62 @@ module over the subalgebra.
     complementary factor, shows that every $R_q$ and every $S_q$ is Hermitian.
 \end{proof}
 
+\begin{theorem}[Block-sum equalities for commuting overlapping operators]%
+    \label{thm:commuting_overlapping_block_sum_equalities}
+    \lean{Matrix.exists_unitary_blockSum_equalities_of_overlappingLifts_commute}
+    \leanok
+    \uses{thm:commuting_overlapping_unitary_block_actions}
+    Let $X_{AB}\in\mathbf L(H_A\otimes H_B)$ and
+    $Y_{BC}\in\mathbf L(H_B\otimes H_C)$ be Hermitian, and suppose
+    \[
+        [X_{AB}\otimes\Id_C,\Id_A\otimes Y_{BC}]=0.
+    \]
+    There are positive integers $d_q,m_q$, an identification
+    \[
+        H_B\cong\bigoplus_{q=0}^{K-1}H_{q,l}\otimes H_{q,r},
+    \]
+    a unitary $U\in\mathbf L(H_B)$, and Hermitian operators
+    $R_q\in\mathbf L(H_A\otimes H_{q,l})$ and
+    $S_q\in\mathbf L(H_{q,r}\otimes H_C)$ such that
+    \[
+        X_{AB}=(\Id_A\otimes U)
+        \left(\bigoplus_{q=0}^{K-1}R_q\otimes\Id_{H_{q,r}}\right)
+        (\Id_A\otimes U^*),
+    \]
+    and
+    \[
+        Y_{BC}=(U\otimes\Id_C)
+        \left(\bigoplus_{q=0}^{K-1}\Id_{H_{q,l}}\otimes S_q\right)
+        (U^*\otimes\Id_C).
+    \]
+    In these formulas the two direct sums are transported to the original
+    product coordinates through the displayed identification.
+    These are the two equalities in
+    \cite[Lemma~2.1]{Beigi2012Classification}. The operators $R_q$ and $S_q$
+    are Hermitian; they are not asserted to be unitary.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Let $V_A=\Id_A\otimes U$ and $V_C=U\otimes\Id_C$. The preceding theorem
+    gives the two conjugated operators in the direct-sum coordinates. Applying
+    the inverse coordinate identifications yields
+    \[
+        V_A^*X_{AB}V_A
+        =\bigoplus_q R_q\otimes\Id_{H_{q,r}},
+        \qquad
+        V_C^*Y_{BC}V_C
+        =\bigoplus_q\Id_{H_{q,l}}\otimes S_q.
+    \]
+    Since $V_AV_A^*=\Id$ and $V_CV_C^*=\Id$,
+    \[
+        X_{AB}=V_A(V_A^*X_{AB}V_A)V_A^*,
+        \qquad
+        Y_{BC}=V_C(V_C^*Y_{BC}V_C)V_C^*,
+    \]
+    which are the stated equalities.
+\end{proof}
+
 Combining the containment direction with the double-commutant criterion yields the full
 block representation of a finite-dimensional $*$-subalgebra, the unital case of
 Eq.~(1.39) of~\cite{Wolf2012Quantum} invoked by~\cite[Theorem~6.14]{Wolf2012Quantum}: up

--- a/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
+++ b/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
@@ -111,14 +111,18 @@ decomposition on which all $X_{aa'}$ and $Y_{cc'}$ act on complementary
 factors.  This is
 \leanid{Matrix.exists_middle_spatial_decomposition_of_overlappingLifts_commute}.
 
-The unitary assembly in Beigi's Lemma~2.1 is now available as well.  The
-theorem
-\leanid{Matrix.exists_unitary_blockActions_of_overlappingLifts_commute}
-constructs one unitary identification of the middle space, combines the
+The conjugated coordinate form of Beigi's Lemma~2.1 is
+\leanid{Matrix.exists_unitary_blockActions_of_overlappingLifts_commute}.
+It constructs one unitary identification of the middle space and combines the
 coefficient matrices into Hermitian operators $R_{A\beta_l}$ and
-$S_{\beta_rC}$, and proves the two direct-sum block identities printed in the
-source.  Its hypotheses are exactly the source hypotheses: Hermiticity of both
-overlapping operators and commutation of their natural three-factor lifts.
+$S_{\beta_rC}$.  Applying the inverse coordinate identifications and cancelling
+the unitary factors gives the two equalities for the original operators in
+Beigi's statement.  This is
+\leanid{Matrix.exists_unitary_blockSum_equalities_of_overlappingLifts_commute}.
+Its hypotheses are exactly the source hypotheses: Hermiticity of both
+overlapping operators and commutation of their natural three-factor lifts.  The
+block operators are Hermitian, as in the source; no unitarity property is
+asserted for them.
 
 The cyclic three-site coordinate identification is now available.  The
 equivalence


### PR DESCRIPTION
This PR proves the explicit block-sum equalities for the two original Hermitian overlapping operators in Beigi, arXiv:1105.1019v2, Lemma 2.1, TeX lines 398–422.

The preceding coordinate theorem supplies the unitary decomposition after conjugation and reindexing. The new theorem applies the inverse coordinate identifications and cancels the unitary factors, yielding equalities for the original operators. Its hypotheses are exactly Hermiticity and commutation of the natural overlapping lifts. The resulting block operators are Hermitian; no unsupported unitarity assertion is made.

A separate blueprint theorem and proof record this step, and the commuting-form paper-gap note is updated only for this closed boundary. The downstream problems tracked by #4191, #4175, #2380, and #232 remain open.

Validation:
- focused Lean check and focused Lake build
- full lake build
- axiom audit: propext, Classical.choice, Quot.sound only
- blueprint declaration synchronization and checkdecls
- leanblueprint web
- style, prose, oversized-file, integrity, line-length, and diff checks

Closes #4202

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal mathematics and documentation on an existing commuting-overlap chain; no auth, runtime, or data-path changes.
> 
> **Overview**
> Adds **`Matrix.exists_unitary_blockSum_equalities_of_overlappingLifts_commute`**, which states Beigi Lemma 2.1’s two equalities for the **original** Hermitian overlapping operators \(X_{AB}\), \(Y_{BC}\) (unitary sandwich around block direct sums), not only after conjugation.
> 
> The proof is a short algebraic step on top of **`exists_unitary_blockActions_of_overlappingLifts_commute`**: reindex the conjugated identities, then cancel Kronecker–unitary factors using unitary-group identities.
> 
> The blueprint gains **Theorem `thm:commuting_overlapping_block_sum_equalities`** with a matching proof sketch, and the commuting-form paper-gap note now separates the conjugated block-action theorem from this solved-for-\(X,Y\) form (Hermitian block operators; no extra unitarity claim).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb1db0c96979a5ef61cf71d9f297feb2282e95f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->