### PR TITLE
feat(MPS/MPDO): prove finite-chain cyclic eta identity

### DIFF
--- a/TNLean/MPS/MPDO/CommutingBondEtaCyclicTransport.lean
+++ b/TNLean/MPS/MPDO/CommutingBondEtaCyclicTransport.lean
@@ -17,6 +17,7 @@ trace factorization, a Markov decomposition, nor saturation of the area law.
 
 * `Matrix.etaCyclicEdgeEquiv`
 * `MPOTensor.reindex_product_embedLocalOperator_of_etaPair_decomposition`
+* `MPOTensor.EtaLocalStructureData.exists_positive_cyclic_eta_block_decomposition`
 
 ## References
 

--- a/TNLean/MPS/MPDO/CommutingBondEtaCyclicTransport.lean
+++ b/TNLean/MPS/MPDO/CommutingBondEtaCyclicTransport.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.CommutingBondEtaDecomposition
+import TNLean.MPS.MPDO.PhysicalSupportProductTransport
 
 /-!
 # Cyclic transport of neighboring operators
@@ -22,7 +23,7 @@ trace factorization, a Markov decomposition, nor saturation of the area law.
 * arXiv:1606.00608, Appendix C.2, equation sigmaNK2, lines 1581--1605.
 -/
 
-open scoped BigOperators Kronecker Matrix
+open scoped BigOperators ComplexOrder Kronecker Matrix
 
 namespace Matrix
 
@@ -109,6 +110,35 @@ end Matrix
 namespace MPOTensor
 
 variable {d : ℕ}
+
+/-- In pair coordinates, conjugating a two-site operator by the tensor square
+of a conjugate-transposed one-site matrix is the corresponding Kronecker
+conjugation. -/
+private theorem singleKrausMap_sitewise_conjTranspose_two_eq
+    (U : Matrix (Fin d) (Fin d) ℂ)
+    (B : Matrix (Fin 2 → Fin d) (Fin 2 → Fin d) ℂ) :
+    singleKrausMap (sitewisePhysicalMatrix Uᴴ 2) B =
+      Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+        (finTwoArrowEquiv (Fin d)).symm
+        (star (U ⊗ₖ U) * pairBondMatrix B * (U ⊗ₖ U)) := by
+  apply (Matrix.reindex (finTwoArrowEquiv (Fin d))
+    (finTwoArrowEquiv (Fin d))).injective
+  rw [Matrix.reindex_singleKrausMap
+      (finTwoArrowEquiv (Fin d)) (finTwoArrowEquiv (Fin d)),
+    reindex_sitewisePhysicalMatrix_two]
+  rw [show Matrix.reindex (finTwoArrowEquiv (Fin d))
+      (finTwoArrowEquiv (Fin d))
+      (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+        (finTwoArrowEquiv (Fin d)).symm
+        (star (U ⊗ₖ U) * pairBondMatrix B * (U ⊗ₖ U))) =
+      star (U ⊗ₖ U) * pairBondMatrix B * (U ⊗ₖ U) by
+    exact (Matrix.reindex (finTwoArrowEquiv (Fin d))
+      (finTwoArrowEquiv (Fin d))).apply_symm_apply _]
+  simp only [singleKrausMap_apply, Matrix.conjTranspose_kronecker,
+    Matrix.conjTranspose_conjTranspose]
+  change (Uᴴ ⊗ₖ Uᴴ) * pairBondMatrix B * (U ⊗ₖ U) =
+    star (U ⊗ₖ U) * pairBondMatrix B * (U ⊗ₖ U)
+  simp [Matrix.conjTranspose_kronecker, Matrix.star_eq_conjTranspose]
 
 /-- The product on a chosen set of cyclic edges.  Edges outside the set carry the
 identity matrix. -/
@@ -624,5 +654,114 @@ theorem reindex_product_embedLocalOperator_two_of_etaPair_decomposition
         fun x y ↦ ∏ n : Fin 2, η (k n) (k (n + 1)) (x n) (y n) := by
   exact reindex_product_embedLocalOperator_of_etaPair_decomposition
     (N := 2) (by omega) dl dr e η B hB
+
+/-- **Finite-chain cyclic neighboring-operator identity.** A positive
+translation-invariant commuting bond admits one chain-independent unitary,
+one collection of sector dimensions, and one positive neighboring family such
+that, at every length at least two, conjugation by the sitewise tensor power
+and cyclic regrouping give the direct sum of cyclic neighboring products, up
+to the positive realization scalar.
+
+This is precisely the finite-chain equation `sigmaNK2`.  It uses neither zero
+correlation length, rank-one trace factorization, a Markov decomposition, nor
+saturation of the area law, and it does not prove Proposition `4to2`.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `sigmaNK2`, lines 1581--1605.
+Documented in `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem EtaLocalStructureData.exists_positive_cyclic_eta_block_decomposition
+    {D : ℕ} {M : MPOTensor d D} (data : EtaLocalStructureData M) :
+    ∃ (K : ℕ) (dl dr : Fin K → ℕ)
+      (e : Matrix.EtaSiteIndex K dl dr ≃ Fin d)
+      (U : Matrix (Fin d) (Fin d) ℂ)
+      (η : (q h : Fin K) →
+        Matrix (Matrix.EtaEdgeIndex dl dr q h)
+          (Matrix.EtaEdgeIndex dl dr q h) ℂ),
+      U ∈ Matrix.unitaryGroup (Fin d) ℂ ∧
+        (∀ q, 0 < dl q) ∧ (∀ q, 0 < dr q) ∧
+        (∀ q h, (η q h).PosSemidef) ∧
+        ∀ (N : ℕ) (hN : 2 ≤ N),
+          letI : NeZero N := ⟨by omega⟩
+          ∃ c : ℝ, 0 < c ∧
+          Matrix.reindex
+              (Matrix.etaCyclicEdgeEquiv dl dr e)
+              (Matrix.etaCyclicEdgeEquiv dl dr e)
+              (star (sitewisePhysicalMatrix U N) * mpo M N *
+                sitewisePhysicalMatrix U N) =
+            (c : ℂ) • Matrix.blockDiagonal' fun k : Fin N → Fin K ↦
+              fun x y ↦ ∏ n : Fin N, η (k n) (k (n + 1)) (x n) (y n) := by
+  classical
+  obtain ⟨K, dl, dr, e, U, η, hU, hdl, hdr, hη, hB⟩ :=
+    data.exists_positive_eta_pairBond_decomposition
+  refine ⟨K, dl, dr, e, U, η, hU, hdl, hdr, hη, ?_⟩
+  intro N hN
+  letI : NeZero N := ⟨by omega⟩
+  obtain ⟨c, hc, hreal⟩ := data.exists_positive_scalar_mpo_eq_product N hN
+  refine ⟨c, hc, ?_⟩
+  have hUco : U * Uᴴ = 1 := by
+    simpa only [Matrix.star_eq_conjTranspose] using
+      (Matrix.mem_unitaryGroup_iff.mp hU)
+  have hUiso : Uᴴ * U = 1 := by
+    simpa only [Matrix.star_eq_conjTranspose] using
+      (Matrix.mem_unitaryGroup_iff'.mp hU)
+  have hV : (Uᴴ)ᴴ * Uᴴ = 1 := by
+    simpa only [Matrix.conjTranspose_conjTranspose] using hUco
+  have hV' : Uᴴ * (Uᴴ)ᴴ = 1 := by
+    simpa only [Matrix.conjTranspose_conjTranspose] using hUiso
+  change mpo M N = (c : ℂ) •
+    (List.ofFn fun i : Fin N ↦
+      embedLocalOperator 2 N hN i data.bondData.bond).prod at hreal
+  have hconj :
+      singleKrausMap (sitewisePhysicalMatrix Uᴴ N) (mpo M N) =
+        (c : ℂ) • (List.ofFn fun i : Fin N ↦
+          embedLocalOperator 2 N hN i
+            (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+              (finTwoArrowEquiv (Fin d)).symm
+              (star (U ⊗ₖ U) * data.pairBond * (U ⊗ₖ U)))).prod := by
+    rw [hreal, (singleKrausMap (sitewisePhysicalMatrix Uᴴ N)).map_smul,
+      singleKrausMap_bondProduct_of_unitary Uᴴ hV hV' hN]
+    congr 1
+    apply congrArg List.prod
+    apply congrArg List.ofFn
+    funext i
+    rw [singleKrausMap_sitewise_conjTranspose_two_eq]
+    rfl
+  have hglobal :
+      singleKrausMap (sitewisePhysicalMatrix Uᴴ N) (mpo M N) =
+        star (sitewisePhysicalMatrix U N) * mpo M N *
+          sitewisePhysicalMatrix U N := by
+    simp only [singleKrausMap_apply, ← sitewisePhysicalMatrix_conjTranspose,
+      Matrix.conjTranspose_conjTranspose, Matrix.star_eq_conjTranspose]
+  have hcyclic := reindex_product_embedLocalOperator_of_etaPair_decomposition
+    hN dl dr e η (star (U ⊗ₖ U) * data.pairBond * (U ⊗ₖ U)) hB
+  calc
+    Matrix.reindex (Matrix.etaCyclicEdgeEquiv dl dr e)
+        (Matrix.etaCyclicEdgeEquiv dl dr e)
+        (star (sitewisePhysicalMatrix U N) * mpo M N *
+          sitewisePhysicalMatrix U N) =
+      Matrix.reindex (Matrix.etaCyclicEdgeEquiv dl dr e)
+        (Matrix.etaCyclicEdgeEquiv dl dr e)
+        (singleKrausMap (sitewisePhysicalMatrix Uᴴ N) (mpo M N)) :=
+          congrArg (Matrix.reindex (Matrix.etaCyclicEdgeEquiv dl dr e)
+            (Matrix.etaCyclicEdgeEquiv dl dr e)) hglobal.symm
+    _ = Matrix.reindex (Matrix.etaCyclicEdgeEquiv dl dr e)
+        (Matrix.etaCyclicEdgeEquiv dl dr e)
+        ((c : ℂ) • (List.ofFn fun i : Fin N ↦
+          embedLocalOperator 2 N hN i
+            (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+              (finTwoArrowEquiv (Fin d)).symm
+              (star (U ⊗ₖ U) * data.pairBond * (U ⊗ₖ U)))).prod) :=
+          congrArg (Matrix.reindex (Matrix.etaCyclicEdgeEquiv dl dr e)
+            (Matrix.etaCyclicEdgeEquiv dl dr e)) hconj
+    _ = (c : ℂ) • Matrix.reindex (Matrix.etaCyclicEdgeEquiv dl dr e)
+        (Matrix.etaCyclicEdgeEquiv dl dr e)
+        (List.ofFn fun i : Fin N ↦
+          embedLocalOperator 2 N hN i
+            (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+              (finTwoArrowEquiv (Fin d)).symm
+              (star (U ⊗ₖ U) * data.pairBond * (U ⊗ₖ U)))).prod := by
+          rfl
+    _ = (c : ℂ) • Matrix.blockDiagonal' fun k : Fin N → Fin K ↦
+        fun x y ↦ ∏ n : Fin N, η (k n) (k (n + 1)) (x n) (y n) :=
+          congrArg ((c : ℂ) • ·) hcyclic
 
 end MPOTensor

--- a/TNLean/MPS/MPDO/IsometricAdjacentBondTransport.lean
+++ b/TNLean/MPS/MPDO/IsometricAdjacentBondTransport.lean
@@ -291,15 +291,6 @@ private theorem pair_product_transport
       rw [leftPair_mul_firstProjection B' P hB',
         lastProjection_mul_rightPair P C' hC']
 
-private theorem reindex_sitewisePhysicalMatrix_two
-    (V : Matrix (Fin d) (Fin e) ℂ) :
-    Matrix.reindex (_root_.finTwoArrowEquiv (Fin d))
-        (_root_.finTwoArrowEquiv (Fin e))
-        (sitewisePhysicalMatrix V 2) = V ⊗ₖ V := by
-  ext ⟨i, j⟩ ⟨a, b⟩
-  simp [Matrix.reindex_apply, sitewisePhysicalMatrix,
-    Matrix.kroneckerMap_apply, _root_.finTwoArrowEquiv]
-
 private theorem reindex_sitewisePhysicalMatrix_three
     (V : Matrix (Fin d) (Fin e) ℂ) :
     Matrix.reindex (_root_.finThreeArrowEquiv (Fin d))

--- a/TNLean/MPS/MPDO/PhysicalSupportBondTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSupportBondTransport.lean
@@ -77,16 +77,8 @@ theorem sitewisePhysicalMatrix_two_mul_conjTranspose
     (V : Matrix (Fin d) (Fin e) ℂ) :
     sitewisePhysicalMatrix V 2 * (sitewisePhysicalMatrix V 2)ᴴ =
       twoSiteSectorProjection (V * Vᴴ) := by
-  rw [← sitewisePhysicalMatrix_two_eq_twoSiteSectorProjection]
-  classical
-  ext s t
-  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply,
-    sitewisePhysicalMatrix, star_prod]
-  simp_rw [← Finset.prod_mul_distrib]
-  rw [← Fintype.piFinset_univ]
-  rw [← Finset.prod_univ_sum
-    (fun _ : Fin 2 ↦ (Finset.univ : Finset (Fin e)))
-    (fun n a ↦ V (s n) a * star (V (t n) a))]
+  rw [sitewisePhysicalMatrix_mul_conjTranspose,
+    sitewisePhysicalMatrix_two_eq_twoSiteSectorProjection]
 
 namespace PhysicalSupportRestrictionData
 

--- a/TNLean/MPS/MPDO/PhysicalSupportProductTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSupportProductTransport.lean
@@ -528,7 +528,9 @@ theorem singleKrausMap_embedLocalOperator_eq_range_mul_lift
     htwo, Matrix.one_mul]
   simp
 
-private theorem sitewisePhysicalMatrix_mul_conjTranspose
+/-- The product of a sitewise tensor power with its conjugate transpose is the
+sitewise tensor power of the corresponding one-site product. -/
+theorem sitewisePhysicalMatrix_mul_conjTranspose
     (V : Matrix (Fin d) (Fin e) ℂ) (N : ℕ) :
     sitewisePhysicalMatrix V N * (sitewisePhysicalMatrix V N)ᴴ =
       sitewisePhysicalMatrix (V * Vᴴ) N := by
@@ -541,6 +543,36 @@ private theorem sitewisePhysicalMatrix_mul_conjTranspose
   rw [← Finset.prod_univ_sum
     (fun _ : Fin N ↦ (Finset.univ : Finset (Fin e)))
     (fun n a ↦ V (s n) a * star (V (t n) a))]
+
+/-- Conjugation by a one-site unitary tensor power carries a complete periodic
+bond product to the product of the conjugated two-site bonds.
+
+Both unitary identities are stated explicitly: the first makes single-Kraus
+conjugation multiplicative, while the second removes its range projection.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `sigmaNK2`, lines 1581--1593. -/
+theorem singleKrausMap_bondProduct_of_unitary
+    (V : Matrix (Fin d) (Fin d) ℂ) (hV : Vᴴ * V = 1) (hV' : V * Vᴴ = 1)
+    {N : ℕ} (hN : 2 ≤ N) (B : Matrix (Fin 2 → Fin d) (Fin 2 → Fin d) ℂ) :
+    singleKrausMap (sitewisePhysicalMatrix V N)
+        (List.ofFn fun i : Fin N ↦ embedLocalOperator 2 N hN i B).prod =
+      (List.ofFn fun i : Fin N ↦ embedLocalOperator 2 N hN i
+        (singleKrausMap (sitewisePhysicalMatrix V 2) B)).prod := by
+  have hW : (sitewisePhysicalMatrix V N)ᴴ * sitewisePhysicalMatrix V N = 1 :=
+    sitewisePhysicalMatrix_isometry V hV N
+  have hne : (List.ofFn fun i : Fin N ↦ embedLocalOperator 2 N hN i B) ≠ [] := by
+    rw [List.ne_nil_iff_length_pos, List.length_ofFn]
+    omega
+  rw [singleKrausMap_list_prod_of_ne_nil _ hW _ hne, List.map_ofFn]
+  apply congrArg List.prod
+  apply congrArg List.ofFn
+  funext i
+  change singleKrausMap (sitewisePhysicalMatrix V N)
+      (embedLocalOperator 2 N hN i B) = _
+  rw [singleKrausMap_embedLocalOperator_eq_range_mul_lift V hV hN i B]
+  simp only [singleKrausMap_apply, Matrix.mul_one]
+  rw [sitewisePhysicalMatrix_mul_conjTranspose, hV']
+  rw [sitewisePhysicalMatrix_one, Matrix.one_mul]
 
 namespace PhysicalSupportRestrictionData
 

--- a/TNLean/MPS/MPDO/PhysicalSupportProductTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSupportProductTransport.lean
@@ -528,22 +528,6 @@ theorem singleKrausMap_embedLocalOperator_eq_range_mul_lift
     htwo, Matrix.one_mul]
   simp
 
-/-- The product of a sitewise tensor power with its conjugate transpose is the
-sitewise tensor power of the corresponding one-site product. -/
-theorem sitewisePhysicalMatrix_mul_conjTranspose
-    (V : Matrix (Fin d) (Fin e) ℂ) (N : ℕ) :
-    sitewisePhysicalMatrix V N * (sitewisePhysicalMatrix V N)ᴴ =
-      sitewisePhysicalMatrix (V * Vᴴ) N := by
-  classical
-  ext s t
-  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply,
-    sitewisePhysicalMatrix, star_prod]
-  simp_rw [← Finset.prod_mul_distrib]
-  rw [← Fintype.piFinset_univ]
-  rw [← Finset.prod_univ_sum
-    (fun _ : Fin N ↦ (Finset.univ : Finset (Fin e)))
-    (fun n a ↦ V (s n) a * star (V (t n) a))]
-
 /-- Conjugation by a one-site unitary tensor power carries a complete periodic
 bond product to the product of the conjugated two-site bonds.
 

--- a/TNLean/MPS/MPDO/SitewisePhysicalMatrix.lean
+++ b/TNLean/MPS/MPDO/SitewisePhysicalMatrix.lean
@@ -39,6 +39,22 @@ theorem sitewisePhysicalMatrix_conjTranspose
   ext s t
   simp [Matrix.conjTranspose_apply, sitewisePhysicalMatrix, star_prod]
 
+/-- The product of a sitewise tensor power with its conjugate transpose is the
+sitewise tensor power of the corresponding one-site product. -/
+theorem sitewisePhysicalMatrix_mul_conjTranspose
+    (V : Matrix (Fin d) (Fin e) ℂ) (N : ℕ) :
+    sitewisePhysicalMatrix V N * (sitewisePhysicalMatrix V N)ᴴ =
+      sitewisePhysicalMatrix (V * Vᴴ) N := by
+  classical
+  ext s t
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply,
+    sitewisePhysicalMatrix, star_prod]
+  simp_rw [← Finset.prod_mul_distrib]
+  rw [← Fintype.piFinset_univ]
+  rw [← Finset.prod_univ_sum
+    (fun _ : Fin N ↦ (Finset.univ : Finset (Fin e)))
+    (fun n a ↦ V (s n) a * star (V (t n) a))]
+
 /-- On two sites, the configuration-indexed tensor power is the Kronecker square. -/
 theorem reindex_sitewisePhysicalMatrix_two
     (V : Matrix (Fin e) (Fin d) ℂ) :

--- a/TNLean/MPS/MPDO/SitewisePhysicalMatrix.lean
+++ b/TNLean/MPS/MPDO/SitewisePhysicalMatrix.lean
@@ -17,7 +17,7 @@ below with the BNT physical-sector projections of arXiv:1606.00608,
 Appendix C.2, equations `generateMPDO` and `sigmaNKj`.
 -/
 
-open scoped Matrix BigOperators
+open scoped Matrix BigOperators Kronecker
 
 namespace MPOTensor
 
@@ -31,6 +31,33 @@ noncomputable def sitewisePhysicalMatrix
     (V : Matrix (Fin e) (Fin d) ℂ) (N : ℕ) :
     Matrix (Fin N → Fin e) (Fin N → Fin d) ℂ :=
   fun s t ↦ ∏ n : Fin N, V (s n) (t n)
+
+/-- Conjugate transpose commutes with the sitewise tensor power. -/
+theorem sitewisePhysicalMatrix_conjTranspose
+    (V : Matrix (Fin e) (Fin d) ℂ) (N : ℕ) :
+    (sitewisePhysicalMatrix V N)ᴴ = sitewisePhysicalMatrix Vᴴ N := by
+  ext s t
+  simp [Matrix.conjTranspose_apply, sitewisePhysicalMatrix, star_prod]
+
+/-- On two sites, the configuration-indexed tensor power is the Kronecker square. -/
+theorem reindex_sitewisePhysicalMatrix_two
+    (V : Matrix (Fin e) (Fin d) ℂ) :
+    Matrix.reindex (_root_.finTwoArrowEquiv (Fin e))
+        (_root_.finTwoArrowEquiv (Fin d))
+        (sitewisePhysicalMatrix V 2) = V ⊗ₖ V := by
+  ext ⟨i, j⟩ ⟨a, b⟩
+  simp [Matrix.reindex_apply, sitewisePhysicalMatrix,
+    Matrix.kroneckerMap_apply, _root_.finTwoArrowEquiv]
+
+/-- The sitewise tensor power of the identity matrix is the identity matrix. -/
+@[simp] theorem sitewisePhysicalMatrix_one (d N : ℕ) :
+    sitewisePhysicalMatrix (1 : Matrix (Fin d) (Fin d) ℂ) N = 1 := by
+  classical
+  ext x y
+  simp only [sitewisePhysicalMatrix, Matrix.one_apply]
+  rw [Fintype.prod_boole]
+  congr 1
+  exact propext funext_iff.symm
 
 private theorem list_prod_sum_ofFn {a n : Type*} [Fintype a]
     [Fintype n] [DecidableEq n] {N : ℕ}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -316,6 +316,50 @@
     direct sum of tensor products.
 \end{proof}
 
+\begin{theorem}[Finite-chain cyclic neighboring-operator form]
+    \label{thm:mpdo_eta_local_sigma_nk2}
+    \lean{MPOTensor.sitewisePhysicalMatrix_conjTranspose}
+    \lean{MPOTensor.reindex_sitewisePhysicalMatrix_two}
+    \lean{MPOTensor.sitewisePhysicalMatrix_one}
+    \lean{MPOTensor.sitewisePhysicalMatrix_mul_conjTranspose}
+    \lean{MPOTensor.singleKrausMap_bondProduct_of_unitary}
+    \lean{MPOTensor.EtaLocalStructureData.%
+      exists_positive_cyclic_eta_block_decomposition}
+    \leanok
+    \uses{def:mpdo_eta_local_structure_data,
+        thm:mpdo_commuting_bond_positive_eta_decomposition,
+        thm:mpdo_eta_pair_bond_cyclic_product_transport}
+    Let $\sigma^{(N)}(\mathcal K)$ be realized, for every $N\geq2$, by
+    translates of one positive commuting bond.  There are one unitary $U$,
+    positive sector dimensions, and positive semidefinite operators
+    $\eta_{q,h}$, all independent of $N$, such that for every $N\geq2$ there
+    is a constant $c_N>0$ satisfying
+    \[
+        E_N^*(U^*)^{\otimes N}\sigma^{(N)}(\mathcal K)
+          U^{\otimes N}E_N
+        =c_N\bigoplus_{k_0,\ldots,k_{N-1}}
+          \bigotimes_{n=0}^{N-1}\eta_{k_n,k_{n+1}},
+        \qquad k_N=k_0.
+    \]
+    Here $E_N$ is the cyclic regrouping from the edge factors
+    $H_{k_n,r}\otimes H_{k_{n+1},l}$ to the site factors
+    $H_{k_n,r}\otimes H_{k_n,l}$.  This is the finite-chain equation
+    \emph{sigmaNK2} in
+    \cite[Appendix~C.2, lines~1581--1593]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_commuting_bond_positive_eta_decomposition,
+        thm:mpdo_eta_pair_bond_cyclic_product_transport}
+    Choose the unitary and the neighboring operators from the decomposition
+    of the fixed bond.  Conjugation by $(U^*)^{\otimes N}$ carries the product
+    of its translates to the product of the conjugated two-site bonds.  The
+    cyclic regrouping theorem changes this product into the displayed direct
+    sum.  Applying both transformations to
+    $\sigma^{(N)}(\mathcal K)=c_N\prod_n B_{n,n+1}$ preserves the same
+    positive scalar $c_N$.
+\end{proof}
+
 \begin{theorem}[A translation-invariant commuting bond and ZCL imply SAL]
     \label{thm:mpdo_translation_invariant_commuting_form_zcl_sal}
     \notready

--- a/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
+++ b/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
@@ -159,8 +159,7 @@ uses the same one-site unitary at both ends of the fixed bond and proves
 Since the bond and unitary are chain-independent, this is one neighboring
 family for every translate.
 
-The bond-local cyclic product is now formalized for every $N\geq2$.  The
-theorem
+The bond-local cyclic product is formalized for every $N\geq2$.  The theorem
 \leanid{MPOTensor.reindex_product_embedLocalOperator_of_etaPair_decomposition}
 constructs the dependent cyclic regrouping
 \[
@@ -174,12 +173,23 @@ and proves that the product of the translated, locally decomposed bond is
 \), with $k_N=k_0$.  The length-two specialization is included: its two
 windows have the opposite cyclic orders $(0,1)$ and $(1,0)$.
 
-This theorem begins with the locally transformed bond.  It does not yet
-identify the product with the conjugation of the original chain product by
-the tensor power of the one-site unitary, nor combine that identity with the
-positive realization scalar.  Those two transport statements are the
-remaining algebraic steps before the full finite-chain equation
-\emph{sigmaNK2} may be claimed.
+The tensor-power conjugation and positive realization scalar are now combined
+with this cyclic product.  The theorem
+\leanid{MPOTensor.EtaLocalStructureData.%
+exists_positive_cyclic_eta_block_decomposition}
+chooses the unitary, sector dimensions, and positive neighboring family once,
+independently of the chain length, and proves for every $N\geq2$ that
+\[
+  E_N^*(U^*)^{\otimes N}\sigma^{(N)}(\mathcal K)U^{\otimes N}E_N
+  =c_N\bigoplus_{k_0,\ldots,k_{N-1}}
+    \bigotimes_{n=0}^{N-1}\eta_{k_n,k_{n+1}},
+  \qquad c_N>0,\qquad k_N=k_0.
+\]
+Thus the finite-chain equation \emph{sigmaNK2} is formalized.  This identity
+uses only the fixed commuting bond and its positive realization scalar.  It
+does not assert zero correlation length, rank-one trace factorization, a
+quantum Markov decomposition, saturation of the area law, or the proposition
+labelled \emph{4to2}.
 
 There is a separate obstruction at source line~1613.  The phrase ``arguing as
 in Lemmas \emph{propSN} and \emph{SALZCL}'' does not show that source ZCL alone
@@ -222,11 +232,6 @@ restriction that isolates only its final entropy-theoretic step.
 The gap can be removed in the following stages.
 
 \begin{enumerate}
-\item Complete the tensor-power conjugation of the original cyclic bond
-product and combine it with the positive realization scalar.  The intervening
-bond-local cyclic direct-sum product is proved for every $N\geq2$; only after
-these two remaining identities may the full finite-chain equation
-\emph{sigmaNK2} be claimed.
 \item Resolve \ghissue{3593} by finding a source-faithful property of the
 actual neighboring family which excludes the nilpotent zero-eigenspace, or
 replace the printed line-1613 argument by a direct Markov decomposition which


### PR DESCRIPTION
### Motivation

- Formalize the finite-chain neighboring-operator decomposition used in
  arXiv:1606.00608, Appendix C.2.  The source states
  `sigma^(N)(K) proportional to product B_(n,n+1)` in equation `expression`,
  lines 1571--1576, and says at lines 1603--1605 that this form implies
  equation `sigmaNK2`.
- Preserve the positive proportionality constant suppressed in that converse
  passage.  No normalization removing this constant is assumed.

### Description

- Expose the sitewise tensor-power adjoint, identity, product, and two-site
  Kronecker identities, with the general product identity in
  `SitewisePhysicalMatrix.lean`.
- Prove that conjugation by a one-site unitary tensor power carries a complete
  periodic bond product to the product of the conjugated two-site bonds.
- Combine this identity with the fixed-bond positive realization scalar and
  cyclic neighboring-operator regrouping for every chain length `N >= 2`.
  The unitary, sector dimensions, and positive neighboring family are
  independent of `N`; only `c_N > 0` may vary.
- Mark the result as the scaled, proportionality-preserving variant of the
  source display.  Eliminating or uniformly absorbing `c_N` to obtain the
  coefficient-free equation `sigmaNK2` remains open.
- Keep zero correlation length, rank-one trace factorization, quantum Markov
  decomposition, saturation of the area law, and Proposition `4to2` outside
  the proved scope.

### Testing

- Focused Lean elaboration of `SitewisePhysicalMatrix.lean`,
  `PhysicalSupportBondTransport.lean`, `PhysicalSupportProductTransport.lean`,
  `IsometricAdjacentBondTransport.lean`, and
  `CommutingBondEtaCyclicTransport.lean` against the exact-base dependencies.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base 12ceae28817076ec6238c6a1df1984ae96903867 --ci`
- Proof-integrity scan of the added Lean lines.
- `git diff --check`

---
Advances #4253
