### PR TITLE
feat(MPS/CanonicalForm): prove restricted BNT uniqueness

### DIFF
--- a/TNLean/MPS/CanonicalForm/BNTUniqueness.lean
+++ b/TNLean/MPS/CanonicalForm/BNTUniqueness.lean
@@ -10,6 +10,9 @@ import TNLean.MPS.CanonicalForm.BNTCharacterization
 
 This module examines the uniqueness sentence following the characterization of
 a basis of normal tensors in arXiv:1606.00608, Appendix A, line 1148.
+
+It also proves the uniqueness statement after adding converse coverage of every
+candidate by an active canonical-form block.
 -/
 
 open scoped Matrix BigOperators
@@ -152,5 +155,142 @@ theorem exists_isCPSVBasisOfNormalTensors_unequal_card :
   · rintro ⟨e⟩
     have hcard := Fintype.card_congr e
     norm_num at hcard
+
+/-- Two bases of normal tensors are equivalent when every member of each basis
+is represented by an active block of the same canonical-form expansion.
+
+This is the restricted uniqueness statement described after the counterexample
+to arXiv:1606.00608, Appendix A, line 1148. Proposition 2.7 (`prop:char-BNT`,
+lines 1135--1146) supplies coverage of every active block by each basis. The
+additional converse hypotheses supply coverage in the other direction.
+
+**Scope restriction (converse coverage):** unlike the literal uniqueness
+sentence at line 1148, this theorem assumes that every candidate tensor in
+both bases is gauge-phase equivalent to a nonzero-weight canonical-form block.
+See `docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex`. -/
+theorem IsCPSVBasisOfNormalTensors.equiv_of_converse_coverage
+    {r g₁ g₂ : ℕ}
+    {dimCF : Fin r → ℕ} {dim₁ : Fin g₁ → ℕ} {dim₂ : Fin g₂ → ℕ}
+    [∀ k, NeZero (dimCF k)] [∀ j, NeZero (dim₁ j)] [∀ j, NeZero (dim₂ j)]
+    {A : MPSTensor d D} {μ : Fin r → ℂ}
+    {blocks : (k : Fin r) → MPSTensor d (dimCF k)}
+    {basis₁ : (j : Fin g₁) → MPSTensor d (dim₁ j)}
+    {basis₂ : (j : Fin g₂) → MPSTensor d (dim₂ j)}
+    (hBlocksNormal : ∀ k, IsNormalTensor (blocks k))
+    (hCF : SameMPV₂Pos A (toTensorFromBlocks (d := d) μ blocks))
+    (hBNT₁ : IsCPSVBasisOfNormalTensors A (fun j => ⟨dim₁ j, basis₁ j⟩))
+    (hBNT₂ : IsCPSVBasisOfNormalTensors A (fun j => ⟨dim₂ j, basis₂ j⟩))
+    (hConverse₁ : ∀ j : Fin g₁,
+      ∃ k : Fin r, μ k ≠ 0 ∧
+        ∃ hdim : dim₁ j = dimCF k,
+        ∃ X : GL (Fin (dimCF k)) ℂ, ∃ ζ : ℂ, ‖ζ‖ = 1 ∧
+          ∀ i, blocks k i = ζ •
+            ((X : Matrix (Fin (dimCF k)) (Fin (dimCF k)) ℂ) *
+              (cast (congr_arg (MPSTensor d) hdim) (basis₁ j)) i *
+              (↑(X⁻¹) : Matrix (Fin (dimCF k)) (Fin (dimCF k)) ℂ)))
+    (hConverse₂ : ∀ j : Fin g₂,
+      ∃ k : Fin r, μ k ≠ 0 ∧
+        ∃ hdim : dim₂ j = dimCF k,
+        ∃ X : GL (Fin (dimCF k)) ℂ, ∃ ζ : ℂ, ‖ζ‖ = 1 ∧
+          ∀ i, blocks k i = ζ •
+            ((X : Matrix (Fin (dimCF k)) (Fin (dimCF k)) ℂ) *
+              (cast (congr_arg (MPSTensor d) hdim) (basis₂ j)) i *
+              (↑(X⁻¹) : Matrix (Fin (dimCF k)) (Fin (dimCF k)) ℂ))) :
+    ∃ e : Fin g₁ ≃ Fin g₂, ∀ j : Fin g₁,
+      ∃ hdim : dim₁ j = dim₂ (e j),
+      ∃ X : GL (Fin (dim₂ (e j))) ℂ, ∃ ζ : ℂ, ‖ζ‖ = 1 ∧
+        ∀ i, basis₂ (e j) i = ζ •
+          ((X : Matrix (Fin (dim₂ (e j))) (Fin (dim₂ (e j))) ℂ) *
+            (cast (congr_arg (MPSTensor d) hdim) (basis₁ j)) i *
+            (↑(X⁻¹) : Matrix (Fin (dim₂ (e j))) (Fin (dim₂ (e j))) ℂ)) := by
+  classical
+  have hCover₁ :=
+    (isCPSVBasisOfNormalTensors_iff_canonicalForm_covered_and_minimal
+      A μ blocks basis₁ hBlocksNormal hCF).mp hBNT₁ |>.2.1
+  have hCover₂ :=
+    (isCPSVBasisOfNormalTensors_iff_canonicalForm_covered_and_minimal
+      A μ blocks basis₂ hBlocksNormal hCF).mp hBNT₂ |>.2.1
+  have hMatch₁ : ∀ j : Fin g₁,
+      ∃ k : Fin g₂, ∃ hdim : dim₁ j = dim₂ k,
+        GaugePhaseEquiv
+          (cast (congr_arg (MPSTensor d) hdim) (basis₁ j)) (basis₂ k) := by
+    intro j
+    obtain ⟨l, hl, hdim₁, X₁, ζ₁, hζ₁, hrel₁⟩ := hConverse₁ j
+    obtain ⟨k, hdim₂, X₂, ζ₂, hζ₂, hrel₂⟩ := hCover₂ l hl
+    have hGE₁ : GaugePhaseEquiv
+        (cast (congr_arg (MPSTensor d) hdim₁) (basis₁ j)) (blocks l) :=
+      ⟨X₁, ζ₁, norm_ne_zero_iff.mp (by rw [hζ₁]; exact one_ne_zero), hrel₁⟩
+    have hGE₂ : GaugePhaseEquiv
+        (cast (congr_arg (MPSTensor d) hdim₂) (basis₂ k)) (blocks l) :=
+      ⟨X₂, ζ₂, norm_ne_zero_iff.mp (by rw [hζ₂]; exact one_ne_zero), hrel₂⟩
+    refine ⟨k, hdim₁.trans hdim₂.symm, ?_⟩
+    simpa using gaugePhaseEquiv_cast_compose_via_centre
+      hdim₁.symm hdim₂.symm
+      (gaugePhaseEquiv_swap_cast hdim₁.symm hGE₁)
+      (gaugePhaseEquiv_swap_cast hdim₂.symm hGE₂)
+  choose f hdimF hGEF using hMatch₁
+  have hf : Function.Injective f := by
+    intro j k hjk
+    by_contra hne
+    have hTransport (l : Fin g₂) (hkl : f k = l) :
+        ∃ hdim : dim₁ k = dim₂ l,
+          GaugePhaseEquiv
+            (cast (congr_arg (MPSTensor d) hdim) (basis₁ k)) (basis₂ l) := by
+      subst l
+      exact ⟨hdimF k, hGEF k⟩
+    obtain ⟨hdimK, hGEK⟩ := hTransport (f j) hjk.symm
+    apply hBNT₁.blocks_not_gaugePhaseEquiv j k hne
+      ((hdimF j).trans hdimK.symm)
+    simpa using gaugePhaseEquiv_cast_compose_via_centre
+      (hdimF j).symm hdimK.symm
+      (gaugePhaseEquiv_swap_cast (hdimF j).symm (hGEF j))
+      (gaugePhaseEquiv_swap_cast hdimK.symm hGEK)
+  have hMatch₂ : ∀ j : Fin g₂,
+      ∃ k : Fin g₁, ∃ hdim : dim₂ j = dim₁ k,
+        GaugePhaseEquiv
+          (cast (congr_arg (MPSTensor d) hdim) (basis₂ j)) (basis₁ k) := by
+    intro j
+    obtain ⟨l, hl, hdim₂, X₂, ζ₂, hζ₂, hrel₂⟩ := hConverse₂ j
+    obtain ⟨k, hdim₁, X₁, ζ₁, hζ₁, hrel₁⟩ := hCover₁ l hl
+    have hGE₂ : GaugePhaseEquiv
+        (cast (congr_arg (MPSTensor d) hdim₂) (basis₂ j)) (blocks l) :=
+      ⟨X₂, ζ₂, norm_ne_zero_iff.mp (by rw [hζ₂]; exact one_ne_zero), hrel₂⟩
+    have hGE₁ : GaugePhaseEquiv
+        (cast (congr_arg (MPSTensor d) hdim₁) (basis₁ k)) (blocks l) :=
+      ⟨X₁, ζ₁, norm_ne_zero_iff.mp (by rw [hζ₁]; exact one_ne_zero), hrel₁⟩
+    refine ⟨k, hdim₂.trans hdim₁.symm, ?_⟩
+    simpa using gaugePhaseEquiv_cast_compose_via_centre
+      hdim₂.symm hdim₁.symm
+      (gaugePhaseEquiv_swap_cast hdim₂.symm hGE₂)
+      (gaugePhaseEquiv_swap_cast hdim₁.symm hGE₁)
+  choose q hdimQ hGEQ using hMatch₂
+  have hq : Function.Injective q := by
+    intro j k hjk
+    by_contra hne
+    have hTransport (l : Fin g₁) (hkl : q k = l) :
+        ∃ hdim : dim₂ k = dim₁ l,
+          GaugePhaseEquiv
+            (cast (congr_arg (MPSTensor d) hdim) (basis₂ k)) (basis₁ l) := by
+      subst l
+      exact ⟨hdimQ k, hGEQ k⟩
+    obtain ⟨hdimK, hGEK⟩ := hTransport (q j) hjk.symm
+    apply hBNT₂.blocks_not_gaugePhaseEquiv j k hne
+      ((hdimQ j).trans hdimK.symm)
+    simpa using gaugePhaseEquiv_cast_compose_via_centre
+      (hdimQ j).symm hdimK.symm
+      (gaugePhaseEquiv_swap_cast (hdimQ j).symm (hGEQ j))
+      (gaugePhaseEquiv_swap_cast hdimK.symm hGEK)
+  have hcard : Fintype.card (Fin g₁) = Fintype.card (Fin g₂) :=
+    Nat.le_antisymm (Fintype.card_le_of_injective f hf)
+      (Fintype.card_le_of_injective q hq)
+  have hfBij : Function.Bijective f :=
+    (Fintype.bijective_iff_injective_and_card f).2 ⟨hf, hcard⟩
+  let e : Fin g₁ ≃ Fin g₂ := Equiv.ofBijective f hfBij
+  refine ⟨e, fun j => ?_⟩
+  obtain ⟨X, ζ, hζ, hrel⟩ := hGEF j
+  have hζnorm : ‖ζ‖ = 1 :=
+    norm_eq_one_of_gaugePhase_cast_of_isNormalTensor
+      (hBNT₁.blocks_normal j) (hBNT₂.blocks_normal (f j)) (hdimF j) hrel
+  exact ⟨hdimF j, X, ζ, hζnorm, hrel⟩
 
 end MPSTensor

--- a/TNLean/MPS/CanonicalForm/BNTUniqueness.lean
+++ b/TNLean/MPS/CanonicalForm/BNTUniqueness.lean
@@ -229,16 +229,21 @@ theorem IsCPSVBasisOfNormalTensors.equiv_of_converse_coverage
       (gaugePhaseEquiv_swap_cast hdim₁.symm hGE₁)
       (gaugePhaseEquiv_swap_cast hdim₂.symm hGE₂)
   choose f hdimF hGEF using hMatch₁
+  have rebase₂ :
+      ∀ (l l' : Fin g₂) (_hll : l = l') {j : Fin g₁}
+        (hdim : dim₁ j = dim₂ l')
+        (hGE : GaugePhaseEquiv
+          (cast (congr_arg (MPSTensor d) hdim) (basis₁ j)) (basis₂ l')),
+        ∃ hdim' : dim₁ j = dim₂ l,
+          GaugePhaseEquiv
+            (cast (congr_arg (MPSTensor d) hdim') (basis₁ j)) (basis₂ l) := by
+    rintro _ _ rfl _ hdim hGE
+    exact ⟨hdim, hGE⟩
   have hf : Function.Injective f := by
     intro j k hjk
     by_contra hne
-    have hTransport (l : Fin g₂) (hkl : f k = l) :
-        ∃ hdim : dim₁ k = dim₂ l,
-          GaugePhaseEquiv
-            (cast (congr_arg (MPSTensor d) hdim) (basis₁ k)) (basis₂ l) := by
-      subst l
-      exact ⟨hdimF k, hGEF k⟩
-    obtain ⟨hdimK, hGEK⟩ := hTransport (f j) hjk.symm
+    obtain ⟨hdimK, hGEK⟩ :=
+      rebase₂ (f j) (f k) hjk (hdimF k) (hGEF k)
     apply hBNT₁.blocks_not_gaugePhaseEquiv j k hne
       ((hdimF j).trans hdimK.symm)
     simpa using gaugePhaseEquiv_cast_compose_via_centre
@@ -264,16 +269,21 @@ theorem IsCPSVBasisOfNormalTensors.equiv_of_converse_coverage
       (gaugePhaseEquiv_swap_cast hdim₂.symm hGE₂)
       (gaugePhaseEquiv_swap_cast hdim₁.symm hGE₁)
   choose q hdimQ hGEQ using hMatch₂
+  have rebase₁ :
+      ∀ (l l' : Fin g₁) (_hll : l = l') {j : Fin g₂}
+        (hdim : dim₂ j = dim₁ l')
+        (hGE : GaugePhaseEquiv
+          (cast (congr_arg (MPSTensor d) hdim) (basis₂ j)) (basis₁ l')),
+        ∃ hdim' : dim₂ j = dim₁ l,
+          GaugePhaseEquiv
+            (cast (congr_arg (MPSTensor d) hdim') (basis₂ j)) (basis₁ l) := by
+    rintro _ _ rfl _ hdim hGE
+    exact ⟨hdim, hGE⟩
   have hq : Function.Injective q := by
     intro j k hjk
     by_contra hne
-    have hTransport (l : Fin g₁) (hkl : q k = l) :
-        ∃ hdim : dim₂ k = dim₁ l,
-          GaugePhaseEquiv
-            (cast (congr_arg (MPSTensor d) hdim) (basis₂ k)) (basis₁ l) := by
-      subst l
-      exact ⟨hdimQ k, hGEQ k⟩
-    obtain ⟨hdimK, hGEK⟩ := hTransport (q j) hjk.symm
+    obtain ⟨hdimK, hGEK⟩ :=
+      rebase₁ (q j) (q k) hjk (hdimQ k) (hGEQ k)
     apply hBNT₂.blocks_not_gaugePhaseEquiv j k hne
       ((hdimQ j).trans hdimK.symm)
     simpa using gaugePhaseEquiv_cast_compose_via_centre

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -411,7 +411,8 @@ boundary conditions (PBC).
     \uses{def:gauge_phase_equiv}
     Gauge-phase equivalence is symmetric after identifying equal bond
     dimensions. Moreover, suppose that $A$, $B$, and $C$ have identified bond
-    dimensions and
+    dimensions, that $X_1$ and $X_2$ are invertible, that
+    $\zeta_1,\zeta_2\ne0$, and that
     \[
         B^i=\zeta_1X_1A^iX_1^{-1},
         \qquad

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -403,6 +403,35 @@ boundary conditions (PBC).
     statements keep the block-scaling factors explicit.
 \end{remark}
 
+\begin{lemma}[Gauge-phase equivalence across equal bond dimensions]
+    \label{lem:gauge_phase_equiv_cast_compose}
+    \lean{MPSTensor.gaugePhaseEquiv_swap_cast,
+        MPSTensor.gaugePhaseEquiv_cast_compose_via_centre}
+    \leanok
+    \uses{def:gauge_phase_equiv}
+    Gauge-phase equivalence is symmetric after identifying equal bond
+    dimensions. Moreover, suppose that $A$, $B$, and $C$ have identified bond
+    dimensions and
+    \[
+        B^i=\zeta_1X_1A^iX_1^{-1},
+        \qquad
+        C^i=\zeta_2X_2A^iX_2^{-1}
+    \]
+    for every physical index $i$. Then
+    \[
+        C^i=(\zeta_2\zeta_1^{-1})(X_2X_1^{-1})
+            B^i(X_1X_2^{-1}),
+    \]
+    so $B$ and $C$ are gauge-phase equivalent after the corresponding
+    identification of their bond dimensions.
+\end{lemma}
+
+\begin{proof}\leanok
+    Symmetry follows by replacing $(X,\zeta)$ with
+    $(X^{-1},\zeta^{-1})$. The displayed identity follows by substituting the
+    first gauge formula into the second.
+\end{proof}
+
 \begin{lemma}[Gauge covariance of word evaluation]\label{lem:eval_word_gauge}
     \lean{MPSTensor.evalWord_gauge}
     \leanok

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -241,6 +241,47 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
     % docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex.
 \end{proof}
 
+\begin{theorem}[Restricted BNT uniqueness under converse coverage]
+    \label{thm:cpsv_bnt_uniqueness_converse_coverage}
+    \lean{MPSTensor.IsCPSVBasisOfNormalTensors.equiv_of_converse_coverage}
+    \leanok
+    \uses{thm:cpsv_bnt_characterization,
+        thm:cpsv_bnt_blocks_not_gaugePhaseEquiv}
+    Let $A$ have a canonical-form MPV expansion
+    \[
+        \ket{V^{(N)}(A)}
+        =\sum_{k=1}^{r}\mu_k^N\ket{V^{(N)}(\widetilde A_k)}
+    \]
+    at every positive length, where the tensors $\widetilde A_k$ are normal.
+    Let $(A_j)_{j=1}^{g_1}$ and $(B_l)_{l=1}^{g_2}$ be two bases of normal
+    tensors for $A$. Assume that every $A_j$ and every $B_l$ is related by a
+    phase and an invertible gauge to a block $\widetilde A_k$ with
+    $\mu_k\ne0$. Then there is a bijection
+    $e:\{1,\ldots,g_1\}\to\{1,\ldots,g_2\}$ such that the bond dimensions of
+    $A_j$ and $B_{e(j)}$ agree and
+    \[
+        B_{e(j)}^i=\zeta_jX_jA_j^iX_j^{-1},
+        \qquad |\zeta_j|=1,
+    \]
+    for every $j$ and every physical index $i$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:cpsv_bnt_characterization,
+        thm:cpsv_bnt_blocks_not_gaugePhaseEquiv}
+    For each $A_j$, choose an active canonical-form block representing it,
+    and then choose a member $B_{f(j)}$ representing that block. If
+    $f(j)=f(j')$, composition through the common tensor $B_{f(j)}$ makes
+    $A_j$ and $A_{j'}$ gauge-phase equivalent. Minimality of the first basis
+    gives $j=j'$, so $f$ is injective. Reversing the roles of the two bases
+    gives an injection in the other direction. Since both index sets are
+    finite, $f$ is bijective. Composition of the two gauges supplies the
+    displayed relation, and normality forces the scalar to have modulus one.
+    % This is the converse-coverage restriction documented in
+    % docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex, not the
+    % unrestricted sentence at arXiv:1606.00608, Appendix A, line 1148.
+\end{proof}
+
 \begin{lemma}[Perron gauges preserve primitivity]
     \label{lem:perron_gauge_primitive_iff}
     \lean{MPSTensor.isPrimitive_transferMap_tpGauge_iff}

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -252,11 +252,13 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
         \ket{V^{(N)}(A)}
         =\sum_{k=0}^{r-1}\mu_k^N\ket{V^{(N)}(\widetilde A_k)}
     \]
-    at every positive length, where the tensors $\widetilde A_k$ are normal.
+    at every positive length, where the tensors $\widetilde A_k$ are normal
+    and have positive bond dimensions.
     Let $(A_j)_{j=0}^{g_1-1}$ and $(B_l)_{l=0}^{g_2-1}$ be two bases of normal
-    tensors for $A$. Assume that every $A_j$ and every $B_l$ is related by a
-    phase and an invertible gauge to a block $\widetilde A_k$ with
-    $\mu_k\ne0$. Then there is a bijection
+    tensors for $A$, all of whose members have positive bond dimensions.
+    Assume that every $A_j$ and every $B_l$ is related by a phase and an
+    invertible gauge to a block $\widetilde A_k$ with $\mu_k\ne0$. Then there
+    is a bijection
     $e:\{0,\ldots,g_1-1\}\to\{0,\ldots,g_2-1\}$ such that the bond dimensions of
     $A_j$ and $B_{e(j)}$ agree and
     \[

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -245,9 +245,8 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
     \label{thm:cpsv_bnt_uniqueness_converse_coverage}
     \lean{MPSTensor.IsCPSVBasisOfNormalTensors.equiv_of_converse_coverage}
     \leanok
-    \uses{thm:cpsv_bnt_characterization,
-        thm:cpsv_bnt_blocks_not_gaugePhaseEquiv,
-        thm:cpsv_normal_mpv_phase_gauge}
+    \uses{def:bnt_cpsv, def:nt_cpsv, def:same_mpv2_pos,
+        def:block_diagonal_tensor, def:gauge_phase_equiv}
     Let $A$ have a canonical-form MPV expansion
     \[
         \ket{V^{(N)}(A)}
@@ -270,7 +269,8 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
 \begin{proof}\leanok
     \uses{thm:cpsv_bnt_characterization,
         thm:cpsv_bnt_blocks_not_gaugePhaseEquiv,
-        thm:cpsv_normal_mpv_phase_gauge}
+        thm:cpsv_normal_mpv_phase_gauge,
+        lem:gauge_phase_equiv_cast_compose, def:gauge_phase_equiv}
     For each $A_j$, choose an active canonical-form block
     $\widetilde A_{\ell(j)}$ representing it, and then choose a member
     $B_{f(j)}$ representing that block. If $f(j)=f(j')$, then

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -246,18 +246,19 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
     \lean{MPSTensor.IsCPSVBasisOfNormalTensors.equiv_of_converse_coverage}
     \leanok
     \uses{thm:cpsv_bnt_characterization,
-        thm:cpsv_bnt_blocks_not_gaugePhaseEquiv}
+        thm:cpsv_bnt_blocks_not_gaugePhaseEquiv,
+        thm:cpsv_normal_mpv_phase_gauge}
     Let $A$ have a canonical-form MPV expansion
     \[
         \ket{V^{(N)}(A)}
-        =\sum_{k=1}^{r}\mu_k^N\ket{V^{(N)}(\widetilde A_k)}
+        =\sum_{k=0}^{r-1}\mu_k^N\ket{V^{(N)}(\widetilde A_k)}
     \]
     at every positive length, where the tensors $\widetilde A_k$ are normal.
-    Let $(A_j)_{j=1}^{g_1}$ and $(B_l)_{l=1}^{g_2}$ be two bases of normal
+    Let $(A_j)_{j=0}^{g_1-1}$ and $(B_l)_{l=0}^{g_2-1}$ be two bases of normal
     tensors for $A$. Assume that every $A_j$ and every $B_l$ is related by a
     phase and an invertible gauge to a block $\widetilde A_k$ with
     $\mu_k\ne0$. Then there is a bijection
-    $e:\{1,\ldots,g_1\}\to\{1,\ldots,g_2\}$ such that the bond dimensions of
+    $e:\{0,\ldots,g_1-1\}\to\{0,\ldots,g_2-1\}$ such that the bond dimensions of
     $A_j$ and $B_{e(j)}$ agree and
     \[
         B_{e(j)}^i=\zeta_jX_jA_j^iX_j^{-1},
@@ -268,7 +269,8 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
 
 \begin{proof}\leanok
     \uses{thm:cpsv_bnt_characterization,
-        thm:cpsv_bnt_blocks_not_gaugePhaseEquiv}
+        thm:cpsv_bnt_blocks_not_gaugePhaseEquiv,
+        thm:cpsv_normal_mpv_phase_gauge}
     For each $A_j$, choose an active canonical-form block
     $\widetilde A_{\ell(j)}$ representing it, and then choose a member
     $B_{f(j)}$ representing that block. If $f(j)=f(j')$, then

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -269,32 +269,42 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
 \begin{proof}\leanok
     \uses{thm:cpsv_bnt_characterization,
         thm:cpsv_bnt_blocks_not_gaugePhaseEquiv}
-    For each $A_j$, choose an active canonical-form block representing it,
-    and then choose a member $B_{f(j)}$ representing that block. If
-    $f(j)=f(j')$, the chosen relations give
+    For each $A_j$, choose an active canonical-form block
+    $\widetilde A_{\ell(j)}$ representing it, and then choose a member
+    $B_{f(j)}$ representing that block. If $f(j)=f(j')$, then
     \[
-        A_j\sim_{\mathrm{gp}}B_{f(j)}
-        =B_{f(j')}\sim_{\mathrm{gp}}A_{j'}.
+        A_j\sim_{\mathrm{gp}}\widetilde A_{\ell(j)}
+        \sim_{\mathrm{gp}}B_{f(j)}
+        =B_{f(j')}\sim_{\mathrm{gp}}\widetilde A_{\ell(j')}
+        \sim_{\mathrm{gp}}A_{j'}.
     \]
-    Hence $A_j\sim_{\mathrm{gp}}A_{j'}$. Minimality of the first basis gives
-    $j=j'$, so $f$ is injective. Reversing the roles of the two bases gives an
-    injection in the other direction. Since both index sets are finite, $f$
-    is bijective. More explicitly, if the common active block satisfies
+    Minimality of the first basis gives $j=j'$, so $f$ is injective.
+    Reversing the roles of the two bases gives an injection in the other
+    direction. Since both index sets are finite, $f$ is bijective; set $e=f$.
+    Write the two relations through the chosen active block as
     \[
-        \widetilde A_k^i=\alpha P A_j^iP^{-1},
+        \widetilde A_{\ell(j)}^i
+        =\zeta_{1,j}X_{1,j}A_j^iX_{1,j}^{-1},
         \qquad
-        \widetilde A_k^i=\beta Q B_{f(j)}^iQ^{-1},
+        \widetilde A_{\ell(j)}^i
+        =\zeta_{2,j}X_{2,j}B_{e(j)}^iX_{2,j}^{-1}.
     \]
-    then
+    Solving the second identity for $B_{e(j)}^i$ and using the first gives
     \[
-        B_{f(j)}^i=(\beta^{-1}\alpha)(Q^{-1}P)
-          A_j^i(P^{-1}Q).
+        B_{e(j)}^i
+        =(\zeta_{2,j}^{-1}\zeta_{1,j})
+        (X_{2,j}^{-1}X_{1,j})A_j^i(X_{1,j}^{-1}X_{2,j}).
     \]
-    Finally, for normal tensors the gauge-phase relation used here satisfies
+    Denote the scalar and gauge in this identity by $\zeta_j$ and $X_j$.
+    The gauge-phase relation gives
     \[
-        B_{f(j)}^i=\zeta X A_j^iX^{-1}\quad\text{for every }i
-        \quad\Longrightarrow\quad |\zeta|=1.
+        O_{B_{e(j)}B_{e(j)}}(N)
+        =(\zeta_j\overline{\zeta_j})^N O_{A_jA_j}(N)
+        =|\zeta_j|^{2N}O_{A_jA_j}(N).
     \]
+    Normality gives
+    $O_{A_jA_j}(N)\to1$ and $O_{B_{e(j)}B_{e(j)}}(N)\to1$; hence the last
+    identity forces $|\zeta_j|=1$.
     % This is the converse-coverage restriction documented in
     % docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex, not the
     % unrestricted sentence at arXiv:1606.00608, Appendix A, line 1148.

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -271,12 +271,30 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
         thm:cpsv_bnt_blocks_not_gaugePhaseEquiv}
     For each $A_j$, choose an active canonical-form block representing it,
     and then choose a member $B_{f(j)}$ representing that block. If
-    $f(j)=f(j')$, composition through the common tensor $B_{f(j)}$ makes
-    $A_j$ and $A_{j'}$ gauge-phase equivalent. Minimality of the first basis
-    gives $j=j'$, so $f$ is injective. Reversing the roles of the two bases
-    gives an injection in the other direction. Since both index sets are
-    finite, $f$ is bijective. Composition of the two gauges supplies the
-    displayed relation, and normality forces the scalar to have modulus one.
+    $f(j)=f(j')$, the chosen relations give
+    \[
+        A_j\sim_{\mathrm{gp}}B_{f(j)}
+        =B_{f(j')}\sim_{\mathrm{gp}}A_{j'}.
+    \]
+    Hence $A_j\sim_{\mathrm{gp}}A_{j'}$. Minimality of the first basis gives
+    $j=j'$, so $f$ is injective. Reversing the roles of the two bases gives an
+    injection in the other direction. Since both index sets are finite, $f$
+    is bijective. More explicitly, if the common active block satisfies
+    \[
+        \widetilde A_k^i=\alpha P A_j^iP^{-1},
+        \qquad
+        \widetilde A_k^i=\beta Q B_{f(j)}^iQ^{-1},
+    \]
+    then
+    \[
+        B_{f(j)}^i=(\beta^{-1}\alpha)(Q^{-1}P)
+          A_j^i(P^{-1}Q).
+    \]
+    Finally, for normal tensors the gauge-phase relation used here satisfies
+    \[
+        B_{f(j)}^i=\zeta X A_j^iX^{-1}\quad\text{for every }i
+        \quad\Longrightarrow\quad |\zeta|=1.
+    \]
     % This is the converse-coverage restriction documented in
     % docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex, not the
     % unrestricted sentence at arXiv:1606.00608, Appendix A, line 1148.

--- a/docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex
+++ b/docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex
@@ -80,6 +80,15 @@ mathematically correct scope restriction, but it is not part of the literal
 hypotheses at lines 271--280 or 1135--1148. Accordingly, the unrestricted
 line-1148 sentence is not marked as formalized.
 
+The converse-coverage restriction has been formalized: two such bases have
+equivalent index types, and the matched tensors have equal bond dimension and
+are related by an invertible gauge and a scalar of modulus one.\footnote{The
+declaration is
+\leanid{MPSTensor.IsCPSVBasisOfNormalTensors.equiv_of_converse_coverage} in
+\doclink{TNLean/MPS/CanonicalForm/BNTUniqueness.lean}.} This restricted result
+does not alter the counterexample above or validate the unrestricted source
+sentence.
+
 \bibliographystyle{alpha}
 \bibliography{references}
 


### PR DESCRIPTION
## Summary

- prove converse-coverage restricted uniqueness for two CPSV bases of normal tensors over one canonical-form expansion
- construct injections in both directions through active canonical-form representatives, then obtain the index equivalence by finite cardinality
- return explicit bond-dimension equalities, invertible gauges, and unit-modulus phase scalars
- add a separate blueprint theorem and update the existing gap note while retaining the unrestricted Appendix A line-1148 claim as false/open

## Scope

This proves only the converse-coverage restriction documented in `docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex`. It does not formalize the literal unrestricted uniqueness sentence of arXiv:1606.00608, Appendix A, line 1148.

## Validation

- `lake env lean TNLean/MPS/CanonicalForm/BNTUniqueness.lean`
- `lake build`
- `leanblueprint web`
- `leanblueprint checkdecls`
- reader-facing prose check
- proof-integrity, 100-column, and diff checks

Closes #4218

Related #2380
Related #232

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds formal proofs and blueprint/gap documentation only; no runtime, auth, or API behavior changes. Mathematical scope is explicitly restricted and does not replace the known false unrestricted uniqueness sentence.
> 
> **Overview**
> Formalizes **restricted** uniqueness of two CPSV bases of normal tensors when every basis element is gauge-phase equivalent to a **nonzero-weight** canonical-form block (converse coverage). The unrestricted Appendix A line-1148 claim remains excluded; the existing unequal-cardinality counterexample is unchanged.
> 
> Adds `IsCPSVBasisOfNormalTensors.equiv_of_converse_coverage` in `BNTUniqueness.lean`: match each basis tensor to the other basis through a shared active block, prove injectivity of the forward maps via `blocks_not_gaugePhaseEquiv`, then promote to a bijection and read off bond dimensions, invertible gauges, and **unit-modulus** phases (`norm_eq_one_of_gaugePhase_cast_of_isNormalTensor`).
> 
> Blueprint: new gauge-phase cast/compose lemma in ch02; new **Restricted BNT uniqueness under converse coverage** theorem in ch10 linked to the Lean declaration. Gap note `cpsv16_bnt_uniqueness_zero_coefficient.tex` now records that this restricted result is formalized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c10809f983bb662f03dcf609c500f78c83a95a57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->