### PR TITLE
doc(tenkz): distinguish carrier spaces from densities

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_normalized_preparations.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_normalized_preparations.tex
@@ -389,14 +389,14 @@
       def:mpdo_faithful_uniform_density}
     For every sector pair define
     \[
-        \mathcal H_{k,h}^{\Omega}
+        \mathcal H^{\Omega}_{k,h}
         =\bigoplus_l
           (B_k^R\otimes B_l^L)\otimes(B_l^R\otimes B_h^L),
         \qquad
         \overline\Omega_{k,h}=
         \begin{cases}
           \widehat\Omega_{k,h},&a_kb_h\ne0,\\
-          \tau_{\mathcal H_{k,h}^{\Omega}},&a_kb_h=0,
+          \tau_{\mathcal H^{\Omega}_{k,h}},&a_kb_h=0,
         \end{cases}
         \qquad
         \overline{\mathcal T}_{k,h}(X)
@@ -437,7 +437,7 @@
     while on the inactive branch,
     \[
       a_kb_h=0\Longrightarrow
-      \overline\Omega_{k,h}=\tau_{\mathcal H_{k,h}^{\Omega}}\succ0,
+      \overline\Omega_{k,h}=\tau_{\mathcal H^{\Omega}_{k,h}}\succ0,
       \quad \tr(\overline\Omega_{k,h})=1.
     \]
     The state-preparation result therefore applies to
@@ -985,7 +985,8 @@ $\mathcal S_0$ discard coherences between distinct outer summands and take the
 displayed partial trace in each diagonal summand. In particular,
 $\mathcal S_0$ traces the whole space
 \[
-  \bigoplus_l
+  \mathcal H^{\Omega}_{k,h}
+  =\bigoplus_l
   \bigl[(R_k\otimes L_l)\otimes(R_l\otimes L_h)\bigr].
 \]
 The shifts $\mathcal S_2$ and $\mathcal T_2$ are global reindexings, with all
@@ -996,8 +997,8 @@ For every $(k,h)$, the four fiberwise maps are
 % T_0 : R_2 -> L_k tensor R_h traces R_k tensor L_h.
 % S_2 : (L_k tensor R_h) tensor (R_k tensor L_h) -> R_2 is the inverse
 % regrouping.  S_0 : R_3 -> L_k tensor R_h traces the whole middle block
-% Omega_{k,h} = bigoplus_l (R_k tensor L_l) tensor (R_l tensor L_h).
-% T_2 : (L_k tensor R_h) tensor Omega_{k,h} -> R_3 restores the ordered
+% H^Omega_{k,h} = bigoplus_l (R_k tensor L_l) tensor (R_l tensor L_h).
+% T_2 : (L_k tensor R_h) tensor H^Omega_{k,h} -> R_3 restores the ordered
 % three-site sector factors.  Blue line ink denotes a channel; labels
 % distinguish the four maps.  The endpoints are sector spaces, so these
 % strokes are maps between objects rather than contracted tensor indices.
@@ -1006,7 +1007,7 @@ For every $(k,h)$, the four fiberwise maps are
     \mathfrak R_2 & L_k\otimes R_h \\
     (L_k\otimes R_h)\otimes(R_k\otimes L_h) & \mathfrak R_2 \\
     \mathfrak R_3 & L_k\otimes R_h \\
-    (L_k\otimes R_h)\otimes\Omega_{k,h} & \mathfrak R_3
+    (L_k\otimes R_h)\otimes\mathcal H^{\Omega}_{k,h} & \mathfrak R_3
     \tnarrow[from={(1,1)}, to={(1,2)}, species=channel]{\mathcal T_0}
     \tnarrow[from={(2,1)}, to={(2,2)}, species=channel]{\mathcal S_2}
     \tnarrow[from={(3,1)}, to={(3,2)}, species=channel]{\mathcal S_0}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels.tex
@@ -144,6 +144,16 @@ The refinement uses the sitewise sector coordinates $\mathfrak R_2$ and
 $\mathfrak R_3$
 \cite[Appendix~C.2, lines~1510--1516 and~1522--1545]
   {Cirac2016MPDO_arXiv}.
+For each outer pair, write
+\[
+  \mathcal H^{\Omega}_{k,h}
+  =\bigoplus_l(R_k\otimes L_l)\otimes(R_l\otimes L_h)
+\]
+for the Hilbert space carrying both $\widehat\Omega_{k,h}$ and its completed
+form $\overline\Omega_{k,h}$. Thus the third object below is the carrier
+space $(L_k\otimes R_h)\otimes\mathcal H^{\Omega}_{k,h}$, while
+$\mathcal T_1$ adjoins the density $\overline\Omega_{k,h}$ on its second
+factor.
 
 % T = T_2 T_1 T_0 maps R_2 through the retained outer factors and the
 % completed neighboring density to R_3.  Each blue stroke has channel
@@ -153,7 +163,7 @@ $\mathfrak R_3$
   \begin{tenkzcd}[maps, species={channel}]
     \mathfrak R_2 &
     L_k\otimes R_h &
-    (L_k\otimes R_h)\otimes\overline\Omega_{k,h} &
+    (L_k\otimes R_h)\otimes\mathcal H^{\Omega}_{k,h} &
     \mathfrak R_3
     \tnarrow[from={(1,1)}, to={(1,2)}, species=channel]{\mathcal T_0}
     \tnarrow[from={(1,2)}, to={(1,3)}, species=channel]{\mathcal T_1}

--- a/docs/tenkz/DESIGN.md
+++ b/docs/tenkz/DESIGN.md
@@ -170,8 +170,8 @@ For the CPSV refinement, the middle-subspin Hilbert space is
   =\bigoplus_l(R_k\otimes L_l)\otimes(R_l\otimes L_h).
 \]
 
-The normalized active density and the completed density are distinct operators
-on this space. On an active pair,
+The notation distinguishes the normalized active density from its total
+completion on this space. On an active pair,
 
 \[
   \widehat\Omega_{k,h}

--- a/docs/tenkz/DESIGN.md
+++ b/docs/tenkz/DESIGN.md
@@ -163,13 +163,27 @@ Typed-map rows belong to the categorical diagram language, not to the tensor-net
 
 A family is written as small multiples: one complete domain--codomain row for each member, with the same number of object columns in every row. A finite family is displayed in full, rather than by selected representatives. Parameters may remain symbolic when the displayed row asserts a formula uniformly over all their values. The matrix is a math object and may occur directly in displayed or running mathematics; it requires neither a figure wrapper nor a separate sizing mode.
 
-For the CPSV refinement, let
+For the CPSV refinement, the middle-subspin Hilbert space is
+
+\[
+  \mathcal H^{\Omega}_{k,h}
+  =\bigoplus_l(R_k\otimes L_l)\otimes(R_l\otimes L_h).
+\]
+
+The normalized active density and the completed density are distinct operators
+on this space. On an active pair,
 
 \[
   \widehat\Omega_{k,h}
-  = \frac{1}{a_k b_h}
-    \bigoplus_l \bigl(\eta_{k,l}\otimes\eta_{l,h}\bigr).
+  =\frac{1}{a_kb_h}\bigoplus_l
+    (\eta_{k,l}\otimes\eta_{l,h}),
+  \qquad
+  \overline\Omega_{k,h}=\widehat\Omega_{k,h}.
 \]
+
+On an inactive pair, $\overline\Omega_{k,h}$ denotes the chosen positive
+trace-one completion on $\mathcal H^{\Omega}_{k,h}$. A typed-map vertex records
+the carrier Hilbert space, not the density acting on it.
 
 The fiberwise refinement is the composition
 
@@ -178,19 +192,23 @@ The fiberwise refinement is the composition
   \xrightarrow{\mathcal T_0}
   L_k\otimes R_h
   \xrightarrow{\mathcal T_1}
-  (L_k\otimes R_h)\otimes\widehat\Omega_{k,h}
+  (L_k\otimes R_h)\otimes\mathcal H^{\Omega}_{k,h}
   \xrightarrow{\mathcal T_2}
   \mathfrak R_3.
 \]
 
-On an active $(k,h)$-summand, $\mathcal T_0$ traces out the factors $R_k\otimes L_h$, $\mathcal T_1$ sends $X$ to $X\otimes\widehat\Omega_{k,h}$, and $\mathcal T_2$ reorders the subspin factors into the three output sites. Consequently $\mathcal T=\mathcal T_2\mathcal T_1\mathcal T_0$. In `tenkzcd` this is written as follows.
+On a $(k,h)$-summand, $\mathcal T_0$ traces out the factors $R_k\otimes L_h$,
+$\mathcal T_1$ sends $X$ to $X\otimes\overline\Omega_{k,h}$, and
+$\mathcal T_2$ reorders the subspin factors into the three output sites.
+Consequently $\mathcal T=\mathcal T_2\mathcal T_1\mathcal T_0$. In `tenkzcd`
+this is written as follows.
 
 ```latex
 \[
 \begin{tenkzcd}[maps, species={channel}]
   \mathfrak R_2 &
   L_k\otimes R_h &
-  (L_k\otimes R_h)\otimes\widehat\Omega_{k,h} &
+  (L_k\otimes R_h)\otimes\mathcal H^{\Omega}_{k,h} &
   \mathfrak R_3
   \tnarrow[from={(1,1)}, to={(1,2)}, species=channel]{\mathcal T_0}
   \tnarrow[from={(1,2)}, to={(1,3)}, species=channel]{\mathcal T_1}

--- a/tex/tenkz/examples/typed-maps.tex
+++ b/tex/tenkz/examples/typed-maps.tex
@@ -28,12 +28,23 @@
   \end{tenkzcd}
 \]
 
-% H^Omega_{k,h} is the middle-subspin Hilbert space.  The completed
-% density overline Omega_{k,h} acts on this space and is adjoined by T_1.
+% H^Omega_{k,h} is the middle-subspin Hilbert space.  The normalized active
+% density and its completed extension act on this space and are adjoined by T_1.
 \[
   \mathcal H^{\Omega}_{k,h}
-  =\bigoplus_l(R_k\otimes L_l)\otimes(R_l\otimes L_h),
+  =\bigoplus_l(R_k\otimes L_l)\otimes(R_l\otimes L_h).
+\]
+On an active pair, let
+\[
+  \widehat\Omega_{k,h}
+  =\frac{1}{a_kb_h}\bigoplus_l
+    (\eta_{k,l}\otimes\eta_{l,h}),
   \qquad
+  \overline\Omega_{k,h}=\widehat\Omega_{k,h}.
+\]
+On an inactive pair, $\overline\Omega_{k,h}$ denotes a chosen positive
+trace-one density on $\mathcal H^{\Omega}_{k,h}$.  Thus, in every case,
+\[
   \overline\Omega_{k,h}\in
     \operatorname{End}(\mathcal H^{\Omega}_{k,h}),
   \quad

--- a/tex/tenkz/examples/typed-maps.tex
+++ b/tex/tenkz/examples/typed-maps.tex
@@ -28,6 +28,18 @@
   \end{tenkzcd}
 \]
 
+% H^Omega_{k,h} is the middle-subspin Hilbert space.  The completed
+% density overline Omega_{k,h} acts on this space and is adjoined by T_1.
+\[
+  \mathcal H^{\Omega}_{k,h}
+  =\bigoplus_l(R_k\otimes L_l)\otimes(R_l\otimes L_h),
+  \qquad
+  \overline\Omega_{k,h}\in
+    \operatorname{End}(\mathcal H^{\Omega}_{k,h}),
+  \quad
+  \operatorname{tr}(\overline\Omega_{k,h})=1.
+\]
+
 % T = T_2 T_1 T_0 maps the two-site sector coordinates R_2 to the
 % three-site sector coordinates R_3.  Composition runs left-to-right.
 % Every line has species=channel, so line ink records the common CPTP
@@ -36,7 +48,7 @@
   \begin{tenkzcd}[maps, species={channel}]
     \mathfrak R_2 &
     L_k\otimes R_h &
-    (L_k\otimes R_h)\otimes\widehat\Omega_{k,h} &
+    (L_k\otimes R_h)\otimes\mathcal H^{\Omega}_{k,h} &
     \mathfrak R_3
     \tnarrow[from={(1,1)}, to={(1,2)}, species=channel]{\mathcal T_0}
     \tnarrow[from={(1,2)}, to={(1,3)}, species=channel]{\mathcal T_1}
@@ -51,7 +63,7 @@
     \mathfrak R_2 & L_k\otimes R_h \\
     (L_k\otimes R_h)\otimes(R_k\otimes L_h) & \mathfrak R_2 \\
     \mathfrak R_3 & L_k\otimes R_h \\
-    (L_k\otimes R_h)\otimes\widehat\Omega_{k,h} & \mathfrak R_3
+    (L_k\otimes R_h)\otimes\mathcal H^{\Omega}_{k,h} & \mathfrak R_3
     \tnarrow[from={(1,1)}, to={(1,2)}, species=channel]{\mathcal T_0}
     \tnarrow[from={(2,1)}, to={(2,2)}, species=channel]{\mathcal S_2}
     \tnarrow[from={(3,1)}, to={(3,2)}, species=channel]{\mathcal S_0}


### PR DESCRIPTION
### Motivation
- Appendix C.2 defines the refinement preparation by adjoining the operator `(a_k b_h)^{-1} ⊕_l (η_{k,l} ⊗ η_{l,h})`; it does not identify that operator with its carrier Hilbert space.
- Source: `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 1510–1545, especially the formula for `T_{k,h}` at lines 1528–1530.
- The typed-map examples used decorated density symbols as categorical vertices, although the corresponding Lean maps are indexed by the middle-subspin carrier type.

### Description
- Write `H^Ω_{k,h}` for the direct-sum middle-subspin Hilbert space at typed-map vertices.
- Retain `Ω_{k,h}` for the raw neighboring operator, `widehat Ω_{k,h}` for its normalized active form, and `overline Ω_{k,h}` for the completed density used by the total preparation.
- Align both affected blueprint chapters, the standalone typed-map example, and the tenkz design account. The channel labels `T_0`, `T_1`, and `T_2` already have the correct domains and codomains and therefore remain unchanged.
- This change does not close or narrow LionSR/TNLean#2380 or LionSR/TNLean#232.

### Testing
- `lake build TNLean`
- `lake exe checkdecls blueprint/lean_decls`
- blueprint–Lean synchronization in update and CI modes
- `leanblueprint web`
- tensor-network semantic audit and 76-diagram smoke render
- `python3 scripts/test_tenkz_pic.py`
- standalone `typed-maps.tex` XeLaTeX compilation with `-no-pdf`
- ChkTeX, reader-facing prose, and `git diff --check`

Closes LionSR/tenkz#30

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prose, LaTeX notation, and diagram labels only; no Lean or runtime tenkz grammar changes.
> 
> **Overview**
> **Documentation-only** alignment so CPSV refinement typed-map diagrams treat **middle-subspin carrier spaces** and **neighboring densities** as separate mathematical objects, matching Appendix C.2 and the Lean carrier types.
> 
> Introduces **`mathcal H^{Omega}_{k,h}`** as the direct-sum Hilbert space `oplus_l (R_k otimes L_l) otimes (R_l otimes L_h)`, with **`widehat Omega_{k,h}`** / **`overline Omega_{k,h}`** reserved for normalized active and completed trace-one densities on that space. **Inactive** completions use `tau_{mathcal H^{Omega}_{k,h}}` instead of older `mathcal H_{k,h}^{Omega}` subscript ordering.
> 
> **`tenkzcd[maps]`** third columns change from decorated density symbols (e.g. `widehat Omega` or `overline Omega` as vertices) to **`(L_k otimes R_h) otimes mathcal H^{Omega}_{k,h}`**; **`mathcal T_1`** is described as adjoining **`overline Omega_{k,h}`** on the second factor, not the density as the vertex label. Channel labels **`mathcal T_0`**, **`mathcal T_1`**, **`mathcal T_2`** are unchanged.
> 
> Touches two blueprint ch.21 sections, **`docs/tenkz/DESIGN.md`**, and **`tex/tenkz/examples/typed-maps.tex`** (plus prose tying **`overline Omega_{k,h} in operatorname{End}(mathcal H^{Omega}_{k,h})`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a88cf9c64225482ce51cbf642a229a35477af6a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->