### PR TITLE
ci(workflows): save only complete Lean caches

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -134,10 +134,10 @@ jobs:
       - name: Run text-based style linter
         run: lake exe lint_style --github
 
-      # Save even when the build failed: a partial cache still spares the
-      # next run the modules that did compile.
+      # A cancelled or failed build can leave partially written `.olean` files.
+      # Restore only caches saved after the complete build and style checks pass.
       - name: Save Lean build cache (main only)
-        if: always() && github.ref == 'refs/heads/main'
+        if: success() && github.ref == 'refs/heads/main'
         uses: actions/cache/save@v4
         with:
           path: ${{ env.BUILD_CACHE_PATHS }}


### PR DESCRIPTION
## Summary

The main-branch build cache is now saved only after the Lean build and style checks succeed. Cancelled or failed builds can leave partially written `.olean` files; restoring such files causes unrelated downstream modules to fail with `invalid header`.

The corrupted generated cache entries associated with the cancelled/failed main builds at `d5c27980`, `15f33e2f`, and `b16ebca4` have also been removed from GitHub Actions. The next run will fall back to the earlier complete cache and rebuild the changed modules.

## Evidence

The failed main run at `b16ebca4` and the subsequent #4256 run both failed only while reading malformed cached objects such as `Transfer.olean`, `Basic.olean`, `BlockGauge.olean`, `GroundSpace.olean`, and `Blocking.olean`. The listed target failures were downstream consequences; no Lean source error was reported.

## Validation

- `actionlint .github/workflows/pr-ci.yml` (or YAML parsing fallback)
- `git diff --check`

Closes #4260

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to cache save gating; no application or auth logic affected.
> 
> **Overview**
> **Main-branch Lean build caches are no longer saved when the job fails or is cancelled.** The save step’s condition changes from `always()` to `success()`, so partial `.olean` artifacts from interrupted runs are not published for later restores.
> 
> The inline comment now documents that incomplete builds can corrupt cache entries and cause downstream `invalid header` failures when those objects are restored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c929a264c34297f1996c3c6926305f3f9554cf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->