### PR TITLE
feat(MPS/MPDO): expose cut-uniform LPDO witness

### DIFF
--- a/TNLean/MPS/MPDO/LocalPurificationAreaLaw.lean
+++ b/TNLean/MPS/MPDO/LocalPurificationAreaLaw.lean
@@ -277,8 +277,8 @@ theorem bipartitionedNormalizedMPO_eq_tensorMapBoth_blockAncillaryTraceMap
   rw [hjoin i x κ, hjoin j y κ]
 
 /-- An LPDO admits a local-purification representation for which the normalized
-finite-chain operator across every cut is obtained from the purifying operator by
-the ancillary trace on each block.
+finite-chain operator across a prescribed cut is obtained from the purifying
+operator by the ancillary trace on each block.
 
 This is the existential form of the finite-chain channel identity in the
 mixed-PEPS purification argument preceding equation (4) of arXiv:0704.3906,

--- a/TNLean/MPS/MPDO/LocalPurificationAreaLaw.lean
+++ b/TNLean/MPS/MPDO/LocalPurificationAreaLaw.lean
@@ -39,6 +39,8 @@ from the cited argument and is false without further hypotheses.
   across every cut.
 * `MPOTensor.IsLPDO.exists_bipartitionedNormalizedMPO_eq_blockAncillaryTrace`:
   an LPDO admits purifying data realizing this block-channel identity.
+* `MPOTensor.IsLPDO.exists_forall_bipartitionedNormalizedMPO_eq_blockAncillaryTrace`:
+  one choice of purifying data realizes the identity across every cut.
 * `MPOTensor.mutualInfoChain_le_of_bipartitioned_channel_image`: a matrix product
   density operator obtained by local channels from a pure matrix product state
   satisfies the bound determined by the purifying bond dimension.
@@ -300,6 +302,34 @@ theorem IsLPDO.exists_bipartitionedNormalizedMPO_eq_blockAncillaryTrace
             (doubledTensor (purificationTensor A)) N L K h) := by
   obtain ⟨dK, D', A, e, hcoeff⟩ := hLPDO
   exact ⟨dK, D', A,
+    bipartitionedNormalizedMPO_eq_tensorMapBoth_blockAncillaryTraceMap
+      M A e hcoeff N L K h⟩
+
+/-- An LPDO admits a single local-purification representation whose normalized
+finite-chain operator is obtained by ancillary traces across every cut.
+
+This is the cut-uniform form of the finite-chain channel identity in the
+mixed-PEPS purification argument preceding equation (4) of arXiv:0704.3906,
+using the local purification of arXiv:1606.00608, Section 4.3.
+
+**Scope restriction:** the conclusion remains restricted to LPDOs and exposes
+the purifying bond dimension. It is not the unrestricted finite-chain estimate
+in the MPO bond dimension asserted for every positive MPDO in arXiv:1606.00608,
+Proposition 4.5; see
+`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+theorem IsLPDO.exists_forall_bipartitionedNormalizedMPO_eq_blockAncillaryTrace
+    {M : MPOTensor d D} (hLPDO : IsLPDO M) :
+    ∃ (dK D' : ℕ)
+      (A : Fin d → Fin dK → Matrix (Fin D') (Fin D') ℂ),
+      ∀ (N L K : ℕ) (h : N = L + K),
+        bipartitionedNormalizedMPO M N L K h =
+          Matrix.tensorMapBoth
+            (blockAncillaryTraceMap d dK L)
+            (blockAncillaryTraceMap d dK K)
+            (bipartitionedNormalizedMPO
+              (doubledTensor (purificationTensor A)) N L K h) := by
+  obtain ⟨dK, D', A, e, hcoeff⟩ := hLPDO
+  exact ⟨dK, D', A, fun N L K h ↦
     bipartitionedNormalizedMPO_eq_tensorMapBoth_blockAncillaryTraceMap
       M A e hcoeff N L K h⟩
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
@@ -734,6 +734,31 @@
     Theorem~\ref{thm:lpdo_block_channel_image} to its purifying tensor.
 \end{proof}
 
+\begin{theorem}[LPDOs admit a cut-uniform block-channel representation]
+    \label{thm:lpdo_exists_cut_uniform_block_channel_image}
+    \lean{MPOTensor.IsLPDO.%
+      exists_forall_bipartitionedNormalizedMPO_eq_blockAncillaryTrace}
+    \leanok
+    \uses{def:lpdo, thm:lpdo_block_channel_image}
+    Let $M$ be an LPDO.  There exist an ancillary dimension $d_K$, a
+    purifying bond dimension $D'$, and a local-purification family $A$, all
+    independent of the cut, such that for every decomposition $N=L+K$,
+    \[
+      \sigma^{(N)}_{L:K}(M)
+      =\left(\operatorname{Tr}_{\mathrm{anc},L}\otimes
+        \operatorname{Tr}_{\mathrm{anc},K}\right)
+        \left(\left(\pi_{\widetilde A}^{(N)}\right)_{L:K}\right),
+    \]
+    where $\widetilde A$ is the purifying MPS tensor associated with $A$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:lpdo, thm:lpdo_block_channel_image}
+    Choose one local-purification representation of $M$.  For an arbitrary
+    decomposition $N=L+K$, apply
+    Theorem~\ref{thm:lpdo_block_channel_image} to the same purifying tensor.
+\end{proof}
+
 \begin{theorem}[Mutual-information bound for a local-channel image]
     \label{thm:local_channel_image_mutual_info_bound}
     \lean{MPOTensor.mutualInfoChain_le_of_bipartitioned_channel_image}


### PR DESCRIPTION
This PR exposes the cut-uniform local-purification witness carried by an LPDO. The ancillary dimension, purifying bond dimension, and local-purification family are chosen once, before quantifying over decompositions N = L + K.

The proof destructs the single `IsLPDO` witness and applies the established block ancillary-trace identity to each cut. The companion blueprint theorem states the same quantifier order and records the exact dependencies.

Verification:
- `lake env lean TNLean/MPS/MPDO/LocalPurificationAreaLaw.lean`
- `lake build TNLean`
- `lake exe checkdecls blueprint/lean_decls`
- `leanblueprint web`
- blueprint sync and reader-facing prose checks
- proof-integrity and diff checks

Closes #4255. Parent #4169 and coverage tracker #2380 remain open.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Lean and blueprint documentation with a one-line proof wrapper; no changes to core channel identities or mutual-information bounds.
> 
> **Overview**
> Exposes **`IsLPDO.exists_forall_bipartitionedNormalizedMPO_eq_blockAncillaryTrace`**: from an LPDO witness, the same ancillary dimension, purifying bond dimension, and local-purification family work for **every** decomposition `N = L + K`, with the normalized bipartitioned MPO equal to block ancillary traces on the purifying doubled tensor. The proof is the existing `IsLPDO` destruct followed by `bipartitionedNormalizedMPO_eq_tensorMapBoth_blockAncillaryTraceMap` on each cut.
> 
> The module doc lists the new result; the older **`exists_bipartitionedNormalizedMPO_eq_blockAncillaryTrace`** docstring now says the identity holds for a **prescribed** cut (not “every cut”). Blueprint **ch21** adds **Theorem** `thm:lpdo_exists_cut_uniform_block_channel_image` with the same quantifier order and a short proof citing the per-cut block-channel theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cab1d41788f6112fb3dabce34155d201d3d3d352. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->