### PR TITLE
doc(MPS/MPDO): distinguish the scaled cyclic eta identity

### DIFF
--- a/TNLean/MPS/MPDO/CommutingBondEtaCyclicTransport.lean
+++ b/TNLean/MPS/MPDO/CommutingBondEtaCyclicTransport.lean
@@ -21,7 +21,8 @@ trace factorization, a Markov decomposition, nor saturation of the area law.
 
 ## References
 
-* arXiv:1606.00608, Appendix C.2, equation sigmaNK2, lines 1581--1605.
+* arXiv:1606.00608, Appendix C.2, equation expression, lines 1571--1576,
+  and equation sigmaNK2, lines 1581--1605.
 -/
 
 open scoped BigOperators ComplexOrder Kronecker Matrix
@@ -656,18 +657,26 @@ theorem reindex_product_embedLocalOperator_two_of_etaPair_decomposition
   exact reindex_product_embedLocalOperator_of_etaPair_decomposition
     (N := 2) (by omega) dl dr e η B hB
 
-/-- **Finite-chain cyclic neighboring-operator identity.** A positive
+/-- **Scaled finite-chain cyclic neighboring-operator identity.** A positive
 translation-invariant commuting bond admits one chain-independent unitary,
 one collection of sector dimensions, and one positive neighboring family such
 that, at every length at least two, conjugation by the sitewise tensor power
 and cyclic regrouping give the direct sum of cyclic neighboring products, up
 to the positive realization scalar.
 
-This is precisely the finite-chain equation `sigmaNK2`.  It uses neither zero
-correlation length, rank-one trace factorization, a Markov decomposition, nor
-saturation of the area law, and it does not prove Proposition `4to2`.
+**Local fix (proportionality scalar):** The converse argument in
+arXiv:1606.00608, lines 1603--1605, passes from a matrix proportional to a
+commuting-bond product to the coefficient-free equation sigmaNK2 without
+retaining the proportionality scalar.  The statement below preserves the
+positive scalar at each chain length.  This discrepancy is recorded in
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.
 
-Source: arXiv:1606.00608, Appendix C.2, equation `sigmaNK2`, lines 1581--1605.
+This result uses neither zero correlation length, rank-one trace factorization,
+a Markov decomposition, nor saturation of the area law, and it does not prove
+Proposition `4to2`.
+
+Source: arXiv:1606.00608, Appendix C.2, equation expression, lines 1571--1576,
+and equation sigmaNK2 as invoked at lines 1603--1605.
 Documented in `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem EtaLocalStructureData.exists_positive_cyclic_eta_block_decomposition
     {D : ℕ} {M : MPOTensor d D} (data : EtaLocalStructureData M) :

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -316,7 +316,11 @@
     direct sum of tensor products.
 \end{proof}
 
-\begin{theorem}[Finite-chain cyclic neighboring-operator form]
+% **Local fix (proportionality scalar):** The converse at source lines
+% 1603--1605 invokes the coefficient-free equation sigmaNK2 after assuming
+% only proportionality to the commuting-bond product.  The statement below
+% retains that scalar.  See docs/paper-gaps/cpsv16_commuting_form_to_sal.tex.
+\begin{theorem}[Scaled finite-chain cyclic neighboring-operator form]
     \label{thm:mpdo_eta_local_sigma_nk2}
     \lean{MPOTensor.sitewisePhysicalMatrix_conjTranspose}
     \lean{MPOTensor.reindex_sitewisePhysicalMatrix_two}
@@ -343,9 +347,12 @@
     \]
     Here $E_N$ is the cyclic regrouping from the edge factors
     $H_{k_n,r}\otimes H_{k_{n+1},l}$ to the site factors
-    $H_{k_n,r}\otimes H_{k_n,l}$.  This is the finite-chain equation
-    \emph{sigmaNK2} in
-    \cite[Appendix~C.2, lines~1581--1593]{Cirac2016MPDO_arXiv}.
+    $H_{k_n,r}\otimes H_{k_n,l}$.  The factor $c_N$ is retained from the
+    proportionality relation in
+    \cite[Appendix~C.2, lines~1571--1576]{Cirac2016MPDO_arXiv}.  The passage at
+    \cite[Appendix~C.2, lines~1603--1605]{Cirac2016MPDO_arXiv} suppresses this
+    factor when invoking the coefficient-free equation \emph{sigmaNK2}; the
+    coefficient-free assertion is not part of the present theorem.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
+++ b/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
@@ -173,8 +173,8 @@ and proves that the product of the translated, locally decomposed bond is
 \), with $k_N=k_0$.  The length-two specialization is included: its two
 windows have the opposite cyclic orders $(0,1)$ and $(1,0)$.
 
-The tensor-power conjugation and positive realization scalar are now combined
-with this cyclic product.  The theorem
+The tensor-power conjugation and positive realization scalar are combined with
+this cyclic product.  The theorem
 \leanid{MPOTensor.EtaLocalStructureData.%
 exists_positive_cyclic_eta_block_decomposition}
 chooses the unitary, sector dimensions, and positive neighboring family once,
@@ -185,11 +185,20 @@ independently of the chain length, and proves for every $N\geq2$ that
     \bigotimes_{n=0}^{N-1}\eta_{k_n,k_{n+1}},
   \qquad c_N>0,\qquad k_N=k_0.
 \]
-Thus the finite-chain equation \emph{sigmaNK2} is formalized.  This identity
-uses only the fixed commuting bond and its positive realization scalar.  It
-does not assert zero correlation length, rank-one trace factorization, a
-quantum Markov decomposition, saturation of the area law, or the proposition
-labelled \emph{4to2}.
+
+\paragraph{Local fix (proportionality scalar).}
+The converse argument at source lines~1603--1605 starts from the relation
+$\sigma^{(N)}(\mathcal K)\propto\prod_n B_{n,n+1}$ but invokes the
+coefficient-free equation \emph{sigmaNK2} without retaining the corresponding
+constant.  The formal theorem proves the proportionality-preserving identity
+displayed above.  It does not prove the coefficient-free equation printed at
+source lines~1581--1588.  Removing or absorbing $c_N$ into one neighboring
+family independent of $N$ requires a further normalization argument.
+
+The scaled identity uses only the fixed commuting bond and its positive
+realization scalar.  It does not assert zero correlation length, rank-one trace
+factorization, a quantum Markov decomposition, saturation of the area law, or
+the proposition labelled \emph{4to2}.
 
 There is a separate obstruction at source line~1613.  The phrase ``arguing as
 in Lemmas \emph{propSN} and \emph{SALZCL}'' does not show that source ZCL alone
@@ -232,6 +241,9 @@ restriction that isolates only its final entropy-theoretic step.
 The gap can be removed in the following stages.
 
 \begin{enumerate}
+\item Determine whether the source normalization removes $c_N$ or permits its
+absorption into one neighboring family independent of $N$.  Until this is
+proved, the coefficient-free equation \emph{sigmaNK2} remains open.
 \item Resolve \ghissue{3593} by finding a source-faithful property of the
 actual neighboring family which excludes the nilpotent zero-eigenspace, or
 replace the printed line-1613 argument by a direct Markov decomposition which


### PR DESCRIPTION
## Motivation

PR #4256 merged before its source-faithfulness correction could be included.
The Lean theorem proved there is mathematically valid, but its conclusion is
scaled by a positive chain-length-dependent factor $c_N$. The coefficient-free
equation `sigmaNK2` printed in arXiv:1606.00608 is therefore not yet
formalized.

## Description

- Rename the blueprint and Lean documentation to identify the result as the
  scaled finite-chain cyclic neighboring-operator identity.
- Add the required **Local fix (proportionality scalar):** marker, citing the
  paper-gap note and the source passage at lines 1603--1605 where the scalar is
  suppressed.
- Update the paper-gap note to state that eliminating or uniformly absorbing
  $c_N$ remains open before the coefficient-free `sigmaNK2` equation can be
  claimed.

This changes documentation and source attribution only; the Lean theorem and
proof are unchanged.

## Testing

- `lake env lean TNLean/MPS/MPDO/CommutingBondEtaCyclicTransport.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base 04d0beaa0a97d70b5f7ad5024e05f9f02159388b --ci`
- diff whitespace, line-length, and proof-integrity checks
- blueprint PDF build on the byte-identical correction before rebasing to the
  latest main

Advances #4253

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment, blueprint, and paper-gap text only; no changes to Lean proofs or theorem statements.
> 
> **Overview**
> **Documentation and source-faithfulness only** — the Lean theorem `EtaLocalStructureData.exists_positive_cyclic_eta_block_decomposition` and its proof are unchanged.
> 
> The blueprint, Lean module doc, and `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex` now name the result the **scaled finite-chain cyclic neighboring-operator identity** and state explicitly that the conclusion keeps the positive chain-length factor **c_N**, matching the proportionality relation at arXiv:1606.00608 lines 1571–1576.
> 
> A **Local fix (proportionality scalar)** note records that the paper’s converse (lines 1603–1605) invokes coefficient-free **sigmaNK2** without retaining that scalar, so the formalization does **not** claim the coefficient-free equation at lines 1581–1588. The gap note’s elimination plan adds an open step: show source normalization removes or absorbs **c_N** before **sigmaNK2** can be claimed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 819240d8e380b747fbf9edb4ca64d927d2252b73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->