### PR TITLE
feat(MPS/MPDO): prove conditional fourth-region trace

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -565,6 +565,7 @@ import TNLean.MPS.MPDO.CommutingOverlappingCoordinates
 import TNLean.MPS.MPDO.CommutingFormSpatialBridge
 import TNLean.MPS.MPDO.CommutingBondEtaDecomposition
 import TNLean.MPS.MPDO.CommutingBondEtaCyclicTransport
+import TNLean.MPS.MPDO.CommutingBondEtaBoundaryTrace
 import TNLean.MPS.MPDO.GSNNCHSectorSum
 import TNLean.MPS.MPDO.GSNNCHOrthogonalSectors
 import TNLean.MPS.MPDO.BNTSectorCommutingFamily

--- a/TNLean/MPS/MPDO/CommutingBondEtaBoundaryTrace.lean
+++ b/TNLean/MPS/MPDO/CommutingBondEtaBoundaryTrace.lean
@@ -36,7 +36,7 @@ namespace Matrix
 /-- An explicit rank-one trace factorization of a cyclic neighboring family:
 $\operatorname{tr}(\eta_{q,h})=a_qb_h$ and $\sum_q a_qb_q=1$.
 
-**Scope restriction (#3593):** this structure records the factorization as an
+**Scope restriction:** this structure records the factorization as an
 assumption; it does not derive it from zero correlation length.  This
 restriction is documented in
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.
@@ -133,7 +133,7 @@ noncomputable def etaSeparatedBoundary {K : ℕ} (dl dr : Fin K → ℕ)
 \left(\sum_h b_h\operatorname{tr}_{R_h}(\eta_{h,l})\right).
 \]
 
-**Scope restriction (#3593):** the rank-one trace factorization is assumed.
+**Scope restriction:** the rank-one trace factorization is assumed.
 This theorem does not derive it from zero correlation length and does not
 assert a Markov decomposition or saturation of the area law.  This restriction
 is documented in `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.
@@ -193,7 +193,7 @@ $\eta_{q,h}$ and retains `Matrix.partialTraceRight` and
 `Matrix.partialTraceLeft` on the adjacent operators.  The notation at source
 line 1616 suppresses these two partial-trace symbols.
 
-**Scope restriction (#3593):** the theorem assumes
+**Scope restriction:** the theorem assumes
 $\operatorname{tr}(\eta_{q,h})=a_qb_h$ explicitly.  It neither proves the
 source replacement of a one-site marginal using zero correlation length nor
 formalizes Proposition `4to2`, a Markov decomposition, or saturation of the

--- a/TNLean/MPS/MPDO/CommutingBondEtaBoundaryTrace.lean
+++ b/TNLean/MPS/MPDO/CommutingBondEtaBoundaryTrace.lean
@@ -1,0 +1,223 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.CommutingBondEtaCyclicTransport
+
+/-!
+# Boundary trace of cyclic neighboring operators
+
+This file computes the two-boundary edge contraction used after the cyclic
+neighboring-operator identity.  Tracing two adjacent boundary sites fully
+traces the neighboring operator on the middle edge and leaves one partial
+trace on each adjacent edge.  An explicit rank-one factorization of the middle
+trace separates the two boundary sector sums.
+
+## Main declarations
+
+* `Matrix.EtaRankOneTraceFactorization`: an explicit factorization
+  $\operatorname{tr}(\eta_{q,h})=a_qb_h$ for the neighboring family.
+* `Matrix.etaTwoBoundaryContraction_eq_separated`: separation of the two
+  boundary sector sums.
+* `Matrix.eta_fourth_region_trace_formula`: the direct-sum formula with the
+  untouched bulk neighboring product.
+
+## References
+
+* arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines 1606 and
+  1613--1617.
+-/
+
+open scoped BigOperators Kronecker Matrix
+
+namespace Matrix
+
+/-- An explicit rank-one trace factorization of a cyclic neighboring family:
+$\operatorname{tr}(\eta_{q,h})=a_qb_h$ and $\sum_q a_qb_q=1$.
+
+**Scope restriction (#3593):** this structure records the factorization as an
+assumption; it does not derive it from zero correlation length.  This
+restriction is documented in
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, line 1613. -/
+structure EtaRankOneTraceFactorization {K : ℕ} (dl dr : Fin K → ℕ)
+    (η : (q h : Fin K) →
+      Matrix (EtaEdgeIndex dl dr q h) (EtaEdgeIndex dl dr q h) ℂ) where
+  /-- The left factors $a_q$ in
+  $\operatorname{tr}(\eta_{q,h})=a_qb_h$.
+
+  Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, line 1613. -/
+  a : Fin K → ℝ
+  /-- The right factors $b_h$ in
+  $\operatorname{tr}(\eta_{q,h})=a_qb_h$.
+
+  Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, line 1613. -/
+  b : Fin K → ℝ
+  /-- The trace factorization
+  $\operatorname{tr}(\eta_{q,h})=a_qb_h$.
+
+  Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, line 1613. -/
+  trace_eta : ∀ q h, (η q h).trace = ((a q * b h : ℝ) : ℂ)
+  /-- The normalization $\sum_q a_qb_q=1$ accompanying the source
+  factorization.
+
+  Source: arXiv:1606.00608, Appendix C.2, lines 1395--1402. -/
+  sum_mul : ∑ q, a q * b q = 1
+
+/-- The indices on the untouched neighboring edges of a nonempty open chain.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1615--1617. -/
+abbrev EtaRetainedBulkIndex {K L : ℕ} (dl dr : Fin K → ℕ)
+    (hL : 1 ≤ L) (k : Fin L → Fin K) :=
+  (n : Fin (L - 1)) →
+    EtaEdgeIndex dl dr
+      (k ⟨(n : ℕ), by omega⟩) (k ⟨(n : ℕ) + 1, by omega⟩)
+
+/-- The tensor product of the neighboring operators on the untouched bulk
+edges.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1615--1617. -/
+noncomputable def etaRetainedBulkProduct {K L : ℕ} (dl dr : Fin K → ℕ)
+    (η : (q h : Fin K) →
+      Matrix (EtaEdgeIndex dl dr q h) (EtaEdgeIndex dl dr q h) ℂ)
+    (hL : 1 ≤ L) (k : Fin L → Fin K) :
+    Matrix (EtaRetainedBulkIndex dl dr hL k)
+      (EtaRetainedBulkIndex dl dr hL k) ℂ :=
+  fun x y ↦ ∏ n : Fin (L - 1),
+    η (k ⟨(n : ℕ), by omega⟩) (k ⟨(n : ℕ) + 1, by omega⟩) (x n) (y n)
+
+/-- The contraction obtained by tracing two adjacent boundary sites: the
+middle neighboring operator is fully traced, while the two adjacent operators
+retain their right and left partial traces.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1613--1617. -/
+noncomputable def etaTwoBoundaryContraction {K : ℕ} (dl dr : Fin K → ℕ)
+    (η : (q h : Fin K) →
+      Matrix (EtaEdgeIndex dl dr q h) (EtaEdgeIndex dl dr q h) ℂ)
+    (kFirst kLast : Fin K) :
+    Matrix (Fin (dr kLast) × Fin (dl kFirst))
+      (Fin (dr kLast) × Fin (dl kFirst)) ℂ :=
+  ∑ q, ∑ h, (η q h).trace •
+    (partialTraceRight (η kLast q) ⊗ₖ partialTraceLeft (η h kFirst))
+
+/-- The separated right and left boundary sums appearing in the source
+fourth-region formula.  The right partial trace acts on the last retained
+right factor, and the left partial trace acts on the first retained left
+factor.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1615--1617. -/
+noncomputable def etaSeparatedBoundary {K : ℕ} (dl dr : Fin K → ℕ)
+    (η : (q h : Fin K) →
+      Matrix (EtaEdgeIndex dl dr q h) (EtaEdgeIndex dl dr q h) ℂ)
+    (factor : EtaRankOneTraceFactorization dl dr η)
+    (kFirst kLast : Fin K) :
+    Matrix (Fin (dr kLast) × Fin (dl kFirst))
+      (Fin (dr kLast) × Fin (dl kFirst)) ℂ :=
+  (∑ q, ((factor.a q : ℂ) • partialTraceRight (η kLast q))) ⊗ₖ
+    (∑ h, ((factor.b h : ℂ) • partialTraceLeft (η h kFirst)))
+
+/-- The rank-one trace identity separates the double boundary contraction:
+\[
+\sum_{q,h}\operatorname{tr}(\eta_{q,h})
+  \bigl(\operatorname{tr}_{L_q}(\eta_{k,q})\otimes
+        \operatorname{tr}_{R_h}(\eta_{h,l})\bigr)
+=
+\left(\sum_q a_q\operatorname{tr}_{L_q}(\eta_{k,q})\right)
+\otimes
+\left(\sum_h b_h\operatorname{tr}_{R_h}(\eta_{h,l})\right).
+\]
+
+**Scope restriction (#3593):** the rank-one trace factorization is assumed.
+This theorem does not derive it from zero correlation length and does not
+assert a Markov decomposition or saturation of the area law.  This restriction
+is documented in `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1613--1617. -/
+theorem etaTwoBoundaryContraction_eq_separated
+    {K : ℕ} (dl dr : Fin K → ℕ)
+    (η : (q h : Fin K) →
+      Matrix (EtaEdgeIndex dl dr q h) (EtaEdgeIndex dl dr q h) ℂ)
+    (factor : EtaRankOneTraceFactorization dl dr η)
+    (kFirst kLast : Fin K) :
+    etaTwoBoundaryContraction dl dr η kFirst kLast =
+      etaSeparatedBoundary dl dr η factor kFirst kLast := by
+  classical
+  change (∑ q, ∑ h, (η q h).trace •
+      (partialTraceRight (η kLast q) ⊗ₖ partialTraceLeft (η h kFirst))) =
+    (∑ q, ((factor.a q : ℂ) • partialTraceRight (η kLast q))) ⊗ₖ
+      (∑ h, ((factor.b h : ℂ) • partialTraceLeft (η h kFirst)))
+  ext x y
+  simp only [Matrix.sum_apply, Matrix.kroneckerMap_apply, Matrix.smul_apply,
+    factor.trace_eta, smul_eq_mul]
+  rw [Finset.sum_mul]
+  apply Finset.sum_congr rfl
+  intro q _
+  rw [Finset.mul_sum]
+  apply Finset.sum_congr rfl
+  intro h _
+  rw [Complex.ofReal_mul]
+  ring
+
+/-- The first retained sector of a nonempty open chain.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1615--1617. -/
+def etaRetainedFirstSector {K L : ℕ} (hL : 1 ≤ L)
+    (k : Fin L → Fin K) : Fin K :=
+  k ⟨0, by omega⟩
+
+/-- The last retained sector of a nonempty open chain.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1615--1617. -/
+def etaRetainedLastSector {K L : ℕ} (hL : 1 ≤ L)
+    (k : Fin L → Fin K) : Fin K :=
+  k ⟨L - 1, by omega⟩
+
+/-- **Conditional fourth-region trace formula.**  For every retained sector
+configuration, the untouched bulk neighboring product tensored with the
+two-boundary contraction equals the same bulk product tensored with the
+separated $a$- and $b$-weighted boundary sums.  Taking the dependent direct
+sum gives the displayed formula for $\widetilde\sigma_{ABC}$.
+
+The contraction is the edge-coordinate form of tracing two boundary sites of
+the longer cyclic chain used at source line 1613.  It fully traces the middle
+$\eta_{q,h}$ and retains `Matrix.partialTraceRight` and
+`Matrix.partialTraceLeft` on the adjacent operators.  The notation at source
+line 1616 suppresses these two partial-trace symbols.
+
+**Scope restriction (#3593):** the theorem assumes
+$\operatorname{tr}(\eta_{q,h})=a_qb_h$ explicitly.  It neither proves the
+source replacement of a one-site marginal using zero correlation length nor
+formalizes Proposition `4to2`, a Markov decomposition, or saturation of the
+area law.  This restriction is documented in
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines 1606 and
+1613--1617. -/
+theorem eta_fourth_region_trace_formula
+    {K L : ℕ} (dl dr : Fin K → ℕ)
+    (η : (q h : Fin K) →
+      Matrix (EtaEdgeIndex dl dr q h) (EtaEdgeIndex dl dr q h) ℂ)
+    (factor : EtaRankOneTraceFactorization dl dr η) (hL : 1 ≤ L) :
+    (Matrix.blockDiagonal' fun k : Fin L → Fin K ↦
+      etaRetainedBulkProduct dl dr η hL k ⊗ₖ
+        etaTwoBoundaryContraction dl dr η
+          (etaRetainedFirstSector hL k) (etaRetainedLastSector hL k)) =
+      Matrix.blockDiagonal' fun k : Fin L → Fin K ↦
+        etaRetainedBulkProduct dl dr η hL k ⊗ₖ
+          etaSeparatedBoundary dl dr η factor
+            (etaRetainedFirstSector hL k) (etaRetainedLastSector hL k) := by
+  classical
+  apply congrArg Matrix.blockDiagonal'
+  funext k
+  rw [etaTwoBoundaryContraction_eq_separated]
+
+end Matrix

--- a/TNLean/MPS/MPDO/CommutingBondEtaBoundaryTrace.lean
+++ b/TNLean/MPS/MPDO/CommutingBondEtaBoundaryTrace.lean
@@ -36,9 +36,9 @@ namespace Matrix
 /-- An explicit rank-one trace factorization of a cyclic neighboring family:
 $\operatorname{tr}(\eta_{q,h})=a_qb_h$ and $\sum_q a_qb_q=1$.
 
-**Scope restriction:** this structure records the factorization as an
-assumption; it does not derive it from zero correlation length.  This
-restriction is documented in
+**Scope restriction (rank-one trace factorization):** this structure records
+the factorization as an assumption; it does not derive it from zero
+correlation length.  This restriction is documented in
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.
 
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, line 1613. -/
@@ -133,10 +133,11 @@ noncomputable def etaSeparatedBoundary {K : ℕ} (dl dr : Fin K → ℕ)
 \left(\sum_h b_h\operatorname{tr}_{R_h}(\eta_{h,l})\right).
 \]
 
-**Scope restriction:** the rank-one trace factorization is assumed.
-This theorem does not derive it from zero correlation length and does not
-assert a Markov decomposition or saturation of the area law.  This restriction
-is documented in `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.
+**Scope restriction (rank-one trace factorization):** the factorization is
+assumed.  This theorem does not derive it from zero correlation length and
+does not assert a Markov decomposition or saturation of the area law.  This
+restriction is documented in
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.
 
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1613--1617. -/
@@ -189,11 +190,11 @@ sum gives the displayed formula for $\widetilde\sigma_{ABC}$.
 
 The contraction is the edge-coordinate form of tracing two boundary sites of
 the longer cyclic chain used at source line 1613.  It fully traces the middle
-$\eta_{q,h}$ and retains `Matrix.partialTraceRight` and
-`Matrix.partialTraceLeft` on the adjacent operators.  The notation at source
-line 1616 suppresses these two partial-trace symbols.
+$\eta_{q,h}$ and retains the right and left partial traces of the adjacent
+operators.  The notation at source line 1616 suppresses these two
+partial-trace symbols.
 
-**Scope restriction:** the theorem assumes
+**Scope restriction (rank-one trace factorization):** the theorem assumes
 $\operatorname{tr}(\eta_{q,h})=a_qb_h$ explicitly.  It neither proves the
 source replacement of a one-site marginal using zero correlation length nor
 formalizes Proposition `4to2`, a Markov decomposition, or saturation of the

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -389,6 +389,73 @@
     \cite[Appendix~C.2, lines~1603--1605]{Cirac2016MPDO_arXiv}.
 \end{remark}
 
+% **Scope restriction (#3593):** the theorem below assumes the rank-one
+% factorization tr(eta_{q,h}) = a_q b_h.  It does not derive that identity
+% from zero correlation length and does not prove Proposition 4to2, a Markov
+% decomposition, or saturation of the area law.  The source line 1616
+% suppresses the partial traces on the two surviving boundary operators.
+% Documented in docs/paper-gaps/cpsv16_commuting_form_to_sal.tex.
+\begin{definition}[Rank-one trace factorization of the neighboring family]
+    \label{def:mpdo_eta_rank_one_trace_factorization}
+    \lean{Matrix.EtaRankOneTraceFactorization}
+    \leanok
+    \uses{thm:mpdo_eta_local_sigma_nk2}
+    For the positive neighboring family $\eta_{q,h}$ in
+    Theorem~\ref{thm:mpdo_eta_local_sigma_nk2}, a rank-one trace
+    factorization consists of real numbers $a_q,b_h$ satisfying
+    \[
+        \tr(\eta_{q,h})=a_qb_h,
+        \qquad
+        \sum_q a_qb_q=1.
+    \]
+\end{definition}
+
+\begin{theorem}[Conditional fourth-region boundary trace]
+    \label{thm:mpdo_eta_fourth_region_trace_formula}
+    \lean{Matrix.etaTwoBoundaryContraction_eq_separated}
+    \lean{Matrix.eta_fourth_region_trace_formula}
+    \leanok
+    \uses{thm:mpdo_eta_local_sigma_nk2,
+        def:mpdo_eta_rank_one_trace_factorization}
+    Let $\eta_{q,h}$ be the positive neighboring family in
+    Theorem~\ref{thm:mpdo_eta_local_sigma_nk2}, equipped with a rank-one
+    trace factorization as in
+    Definition~\ref{def:mpdo_eta_rank_one_trace_factorization}.
+    For a nonempty retained sector word
+    $k=(k_0,\ldots,k_{L-1})$, write
+    \[
+        P_k=\bigotimes_{n=0}^{L-2}\eta_{k_n,k_{n+1}},
+        \qquad
+        R_{u,q}=\tr_{H_{q,l}}(\eta_{u,q}),
+        \qquad
+        L_{h,v}=\tr_{H_{h,r}}(\eta_{h,v}).
+    \]
+    The edge contraction corresponding to tracing the two boundary sites of
+    the longer cyclic chain is
+    \[
+    \begin{aligned}
+        &\bigoplus_k P_k\otimes
+          \sum_{q,h}\tr(\eta_{q,h})
+            \bigl(R_{k_{L-1},q}\otimes L_{h,k_0}\bigr)\\
+        &\quad=
+          \bigoplus_k P_k\otimes
+          \left(\sum_q a_qR_{k_{L-1},q}\right)\otimes
+          \left(\sum_h b_hL_{h,k_0}\right).
+    \end{aligned}
+    \]
+    This is the edge-coordinate interpretation of the displayed
+    fourth-region trace in
+    \cite[Appendix~C.2, lines~1606 and 1613--1617]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpdo_eta_rank_one_trace_factorization}
+    Substitute $\tr(\eta_{q,h})=a_qb_h$ into the double boundary sum.
+    Distributivity separates the sums over $q$ and $h$.  Tensoring with the
+    unchanged product $P_k$ and taking the direct sum over $k$ gives the
+    stated identity.
+\end{proof}
+
 \begin{theorem}[A translation-invariant commuting bond and ZCL imply SAL]
     \label{thm:mpdo_translation_invariant_commuting_form_zcl_sal}
     \notready

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -395,8 +395,8 @@
 % decomposition, or saturation of the area law.  The source line 1616
 % suppresses the partial traces on the two surviving boundary operators.
 % Documented in docs/paper-gaps/cpsv16_commuting_form_to_sal.tex.
-\begin{definition}[Rank-one trace factorization of the neighboring family]
-    \label{def:mpdo_eta_rank_one_trace_factorization}
+\begin{definition}[Rank-one trace factorization of the cyclic neighboring family]
+    \label{def:mpdo_cyclic_eta_rank_one_trace_factorization}
     \lean{Matrix.EtaRankOneTraceFactorization}
     \leanok
     \uses{thm:mpdo_eta_local_sigma_nk2}
@@ -416,11 +416,11 @@
     \lean{Matrix.eta_fourth_region_trace_formula}
     \leanok
     \uses{thm:mpdo_eta_local_sigma_nk2,
-        def:mpdo_eta_rank_one_trace_factorization}
+        def:mpdo_cyclic_eta_rank_one_trace_factorization}
     Let $\eta_{q,h}$ be the positive neighboring family in
     Theorem~\ref{thm:mpdo_eta_local_sigma_nk2}, equipped with a rank-one
     trace factorization as in
-    Definition~\ref{def:mpdo_eta_rank_one_trace_factorization}.
+    Definition~\ref{def:mpdo_cyclic_eta_rank_one_trace_factorization}.
     For a nonempty retained sector word
     $k=(k_0,\ldots,k_{L-1})$, write
     \[
@@ -449,7 +449,7 @@
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{def:mpdo_eta_rank_one_trace_factorization}
+    \uses{def:mpdo_cyclic_eta_rank_one_trace_factorization}
     Substitute $\tr(\eta_{q,h})=a_qb_h$ into the double boundary sum.
     Distributivity separates the sums over $q$ and $h$.  Tensoring with the
     unchanged product $P_k$ and taking the direct sum over $k$ gives the

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -389,40 +389,67 @@
     \cite[Appendix~C.2, lines~1603--1605]{Cirac2016MPDO_arXiv}.
 \end{remark}
 
-% **Scope restriction (#3593):** the theorem below assumes the rank-one
-% factorization tr(eta_{q,h}) = a_q b_h.  It does not derive that identity
-% from zero correlation length and does not prove Proposition 4to2, a Markov
-% decomposition, or saturation of the area law.  The source line 1616
-% suppresses the partial traces on the two surviving boundary operators.
-% Documented in docs/paper-gaps/cpsv16_commuting_form_to_sal.tex.
-\begin{definition}[Rank-one trace factorization of the cyclic neighboring family]
-    \label{def:mpdo_cyclic_eta_rank_one_trace_factorization}
+\begin{definition}[Rank-one trace factorization for neighboring operators]
+    \label{def:mpdo_generic_eta_rank_one_trace_factorization}
     \lean{Matrix.EtaRankOneTraceFactorization}
     \leanok
-    \uses{thm:mpdo_eta_local_sigma_nk2}
-    For the positive neighboring family $\eta_{q,h}$ in
-    Theorem~\ref{thm:mpdo_eta_local_sigma_nk2}, a rank-one trace
-    factorization consists of real numbers $a_q,b_h$ satisfying
+    A rank-one trace factorization of neighboring matrices $\eta_{q,h}$
+    consists of real numbers $a_q,b_h$ such that
     \[
         \tr(\eta_{q,h})=a_qb_h,
         \qquad
         \sum_q a_qb_q=1.
     \]
+    The factorization is an explicit assumption; it is not deduced from zero
+    correlation length.  It is the factorization invoked at
+    \cite[Appendix~C.2, line~1613]{Cirac2016MPDO_arXiv}.
+    % Scope restriction documented in
+    % docs/paper-gaps/cpsv16_commuting_form_to_sal.tex.
 \end{definition}
 
+\begin{lemma}[Separation of the two-boundary edge contraction]
+    \label{lem:mpdo_eta_two_boundary_contraction_separated}
+    \lean{Matrix.etaTwoBoundaryContraction_eq_separated}
+    \leanok
+    \uses{def:mpdo_generic_eta_rank_one_trace_factorization,
+        def:mpdo_right_partial_trace_map, def:partial_trace_left}
+    Suppose $\eta_{q,h}$ has a rank-one trace factorization.  For fixed
+    boundary sectors $u,v$, set
+    \[
+        R_{u,q}=\tr_{H_{q,l}}(\eta_{u,q}),
+        \qquad
+        L_{h,v}=\tr_{H_{h,r}}(\eta_{h,v}).
+    \]
+    Then
+    \[
+        \sum_{q,h}\tr(\eta_{q,h})(R_{u,q}\otimes L_{h,v})
+        =\left(\sum_q a_qR_{u,q}\right)\otimes
+          \left(\sum_h b_hL_{h,v}\right).
+    \]
+    This is the corrected edge contraction at
+    \cite[Appendix~C.2, lines~1613--1617]{Cirac2016MPDO_arXiv}.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{def:mpdo_generic_eta_rank_one_trace_factorization}
+    Substitute $\tr(\eta_{q,h})=a_qb_h$ and distribute the two finite sums.
+\end{proof}
+
+% **Scope restriction (rank-one trace factorization):** the theorem below
+% assumes tr(eta_{q,h}) = a_q b_h.  It does not derive that identity from zero
+% correlation length and does not prove Proposition 4to2, a Markov
+% decomposition, or saturation of the area law.  Source line 1616 suppresses
+% the partial traces on the two surviving boundary operators.  Documented in
+% docs/paper-gaps/cpsv16_commuting_form_to_sal.tex.
 \begin{theorem}[Conditional fourth-region boundary trace]
     \label{thm:mpdo_eta_fourth_region_trace_formula}
-    \lean{Matrix.etaTwoBoundaryContraction_eq_separated}
     \lean{Matrix.eta_fourth_region_trace_formula}
     \leanok
-    \uses{thm:mpdo_eta_local_sigma_nk2,
-        def:mpdo_cyclic_eta_rank_one_trace_factorization}
-    Let $\eta_{q,h}$ be the positive neighboring family in
-    Theorem~\ref{thm:mpdo_eta_local_sigma_nk2}, equipped with a rank-one
-    trace factorization as in
-    Definition~\ref{def:mpdo_cyclic_eta_rank_one_trace_factorization}.
-    For a nonempty retained sector word
-    $k=(k_0,\ldots,k_{L-1})$, write
+    \uses{def:mpdo_generic_eta_rank_one_trace_factorization,
+        def:mpdo_right_partial_trace_map, def:partial_trace_left}
+    Let $\eta_{q,h}$ be arbitrary matrices on
+    $H_{q,r}\otimes H_{h,l}$ with a rank-one trace factorization.  For a
+    nonempty retained sector word $k=(k_0,\ldots,k_{L-1})$, write
     \[
         P_k=\bigotimes_{n=0}^{L-2}\eta_{k_n,k_{n+1}},
         \qquad
@@ -449,12 +476,20 @@
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{def:mpdo_cyclic_eta_rank_one_trace_factorization}
-    Substitute $\tr(\eta_{q,h})=a_qb_h$ into the double boundary sum.
-    Distributivity separates the sums over $q$ and $h$.  Tensoring with the
-    unchanged product $P_k$ and taking the direct sum over $k$ gives the
-    stated identity.
+    \uses{lem:mpdo_eta_two_boundary_contraction_separated}
+    Apply Lemma~\ref{lem:mpdo_eta_two_boundary_contraction_separated} for
+    each retained sector word.  Tensor with the unchanged product $P_k$ and
+    take the direct sum over $k$.
 \end{proof}
+
+\begin{remark}
+    The theorem applies, in particular, to the positive chain-independent
+    neighboring family supplied by
+    Theorem~\ref{thm:mpdo_eta_local_sigma_nk2}, once the rank-one trace
+    factorization is given.  It does not derive that factorization, identify
+    this two-boundary contraction with a one-site marginal, or prove a Markov
+    decomposition or saturation of the area law.
+\end{remark}
 
 \begin{theorem}[A translation-invariant commuting bond and ZCL imply SAL]
     \label{thm:mpdo_translation_invariant_commuting_form_zcl_sal}

--- a/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
+++ b/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
@@ -223,6 +223,24 @@ realization scalar.  It does not assert zero correlation length, rank-one trace
 factorization, a quantum Markov decomposition, saturation of the area law, or
 the proposition labelled \emph{4to2}.
 
+The fourth-region calculation after the cyclic identity requires a coordinate
+clarification.  Tracing one physical site of the length-$N$ cyclic eta product
+leaves a coupled sum of the right partial trace of
+$\eta_{k_{N-1},q}$ and the left partial trace of $\eta_{q,k_1}$; rank-one
+factorization does not separate this sum.  Source line~1613 instead invokes
+ZCL to replace this marginal by a trace of two boundary sites on the
+length-$(N+1)$ chain.  In edge coordinates the middle operator
+$\eta_{q,h}$ is then fully traced, while the two adjacent operators retain
+their right and left partial traces.  The displayed formula at source
+line~1616 suppresses these partial-trace symbols.
+
+The conditional algebraic identity after this replacement is formalized by
+\leanid{Matrix.eta_fourth_region_trace_formula}.  It assumes
+$\operatorname{tr}(\eta_{q,h})=a_qb_h$ and separates the two boundary sums.
+It does not prove the ZCL replacement of the one-site marginal, derive the
+rank-one factorization, construct a quantum Markov decomposition, or prove
+SAL.
+
 There is a separate obstruction at source line~1613.  The phrase ``arguing as
 in Lemmas \emph{propSN} and \emph{SALZCL}'' does not show that source ZCL alone
 gives


### PR DESCRIPTION
## Motivation

Issue #4263 tracks the fourth-region boundary calculation in arXiv:1606.00608,
Appendix C.2, lines 1606 and 1613--1617. A direct one-site trace of the
length-$N$ cyclic eta product leaves a coupled sector sum, so the source-faithful
conditional statement must instead use the two-boundary contraction of the
longer cyclic chain invoked at line 1613.

## Description

- add an explicit rank-one trace-factorization witness
  `Matrix.EtaRankOneTraceFactorization`;
- prove that the two-boundary edge contraction separates into the
  $a$-weighted right boundary and $b$-weighted left boundary sums;
- lift the identity through the untouched bulk product and dependent direct
  sum in `Matrix.eta_fourth_region_trace_formula`;
- add a `\leanok` blueprint entry between the finite-chain eta identity and
  the still-unformalized Proposition `4to2` implication;
- record the exact coordinate correction and retained scope boundary in
  `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.

The result is deliberately conditional: it assumes
$\operatorname{tr}(\eta_{q,h})=a_qb_h$. It does not prove the ZCL replacement,
derive rank-one factorization, construct a Markov decomposition, or establish
SAL/Proposition `4to2`.

## Testing

- `lake env lean TNLean/MPS/MPDO/CommutingBondEtaBoundaryTrace.lean`
- `lake build` (9573 jobs)
- `lake exe lint_style`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `leanblueprint pdf` (649 pages)
- `git diff --check`
- proof-integrity pattern audit of the new Lean module

Closes #4263

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New self-contained Lean proofs and documentation/blueprint sync only; no changes to runtime services, auth, or existing proof obligations beyond adding an import and clearly bounded conditional assumptions.
> 
> **Overview**
> Formalizes the **conditional** fourth-region boundary trace step from Cirac et al. Appendix C.2 (Proposition 4to2, lines 1606 and 1613–1617), using the **two-boundary** edge contraction (trace two adjacent boundary sites on the longer cyclic chain) rather than a single-site trace that leaves coupled sector sums.
> 
> Adds `TNLean/MPS/MPDO/CommutingBondEtaBoundaryTrace.lean` with `Matrix.EtaRankOneTraceFactorization` (assumed \(\mathrm{tr}(\eta_{q,h})=a_q b_h\)), definitions for bulk product and two-boundary contraction, **`etaTwoBoundaryContraction_eq_separated`** (rank-one factorization splits the double sum into \(a\)- and \(b\)-weighted Kronecker boundary terms), and **`eta_fourth_region_trace_formula`** lifted over retained sector words via `blockDiagonal'`. Wires the module into `TNLean.lean`.
> 
> The blueprint chapter gains `\leanok` definition, lemma, and theorem entries between the finite-chain \(\eta\) identity and the still-unformalized SAL implication. **`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`** documents the coordinate fix (middle \(\eta_{q,h}\) fully traced; adjacent edges keep partial traces; source line 1616 notation) and states explicitly that ZCL replacement, derivation of rank-one factorization, Markov decomposition, and SAL are **out of scope**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5801e2929d301463227297d45fee7060cc4d6ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
