### PR TITLE
doc(MPS/MPDO): classify Lemma C.5 obstruction

### DIFF
--- a/TNLean/MPS/MPDO/ActiveSectorSpanningCounterexample.lean
+++ b/TNLean/MPS/MPDO/ActiveSectorSpanningCounterexample.lean
@@ -334,9 +334,9 @@ This is a counterexample only to the proposed intermediate implication.  The
 formal statement does not assert the strong area law, although the induced
 classical cyclic family satisfies it by a direct entropy calculation.  What
 prevents this theorem from refuting Lemma C.5 of arXiv:1606.00608 is instead
-the unproved identification of `factorization` with the source-selected
-inverse-map factorization.  A proof of that lemma must use information beyond
-the concrete spanning and rectangular identities presently extracted from
+the unproved identification of the chosen direct-sum decomposition with the
+source-selected inverse-map factorization.  A proof of that lemma must use
+information beyond the concrete spanning and rectangular identities presently extracted from
 Appendix C.2, lines 1406--1499. -/
 theorem virtual_spanning_does_not_force_rectangular_remainder_zero :
     tensor.IsInjective ∧ tensor.IsSourceZCL ∧

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -385,7 +385,7 @@
     This is the proposition at
     \cite[Appendix~C.2, lines~1597--1619]{Cirac2016MPDO_arXiv}.
     % The local positive neighboring operators are constructed.  The printed
-    % rank-one inference at source line 1613 remains obstructed by #3593. Gap
+    % rank-one inference at source line 1613 is obstructed by Lemma C.5. Gap
     % documented in
     % docs/paper-gaps/cpsv16_commuting_form_to_sal.tex.
 \end{theorem}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels.tex
@@ -965,8 +965,7 @@ $\widehat{\cal K}$.
 % trace factorization, including the rank-one identity
 % tr(eta_{k,h}) = a_k b_h. It proves the conditional implication (iv) => (v),
 % not Proposition prop2to5 from SAL and ZCL alone. The missing rank-one step is
-% documented in docs/paper-gaps/cpgsv17_pf_rank_one.tex and tracked in issue
-% #3593.
+% documented in docs/paper-gaps/cpgsv17_pf_rank_one.tex.
 \begin{theorem}[Two-site blocking of the original tensor is a renormalization fixed point]
     \label{thm:mpdo_blocked_original_tensor_is_rfp_via_ts}
     \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.blockTwo_isRFPViaTS}
@@ -989,6 +988,26 @@ $\widehat{\cal K}$.
     corresponding closure identities carry the two fixed-point equations back
     to ${\cal K}^{[2]}$.
 \end{proof}
+
+% **Obstruction (dependence on Lemma C.5):** the source construction begins
+% with the neighboring trace factorization supplied through prop2to3.  Its
+% derivation from SAL and ZCL is obstructed by the rank-one step in Lemma C.5.
+% Documented in docs/paper-gaps/cpgsv17_pf_rank_one.tex.
+\begin{proposition}[SAL and ZCL give the two blocking channels]
+    \label{prop:mpdo_sal_zcl_blocking_channels}
+    \notready
+    \uses{def:is_sal, def:mpo_source_zcl, def:is_rfp_via_ts,
+        def:mpdo_two_site_blocking,
+        prop:mpdo_sal_zcl_bnt_sector_structure}
+    Let $K$ be a simple tensor satisfying the strong area law and zero
+    correlation length, and let $M=K^{[2]}$ be its two-site blocking. Then
+    there are trace-preserving completely positive maps in both directions
+    between the one-site and two-site closures of $M$. Equivalently, $M$ is a
+    renormalization fixed point via these two maps. This is implication
+    (ii)$\Rightarrow$(v) of
+    \cite[Theorem~4.9 and Appendix~C.2, lines~1810--1817]
+      {Cirac2016MPDO_arXiv}.
+\end{proposition}
 
 % Correct equation, not a figure: the cited source draws the two-to-three
 % channel MPDO_TSKKK.png after explicitly suppressing U, but it does not draw

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels.tex
@@ -993,12 +993,12 @@ $\widehat{\cal K}$.
 % with the neighboring trace factorization supplied through prop2to3.  Its
 % derivation from SAL and ZCL is obstructed by the rank-one step in Lemma C.5.
 % Documented in docs/paper-gaps/cpgsv17_pf_rank_one.tex.
-\begin{proposition}[SAL and ZCL give the two blocking channels]
-    \label{prop:mpdo_sal_zcl_blocking_channels}
+\begin{theorem}[SAL and ZCL give the two blocking channels]
+    \label{thm:mpdo_sal_zcl_blocking_channels}
     \notready
     \uses{def:is_sal, def:mpo_source_zcl, def:is_rfp_via_ts,
         def:mpdo_two_site_blocking,
-        prop:mpdo_sal_zcl_bnt_sector_structure}
+        thm:mpdo_sal_zcl_bnt_sector_structure}
     Let $K$ be a simple tensor satisfying the strong area law and zero
     correlation length, and let $M=K^{[2]}$ be its two-site blocking. Then
     there are trace-preserving completely positive maps in both directions
@@ -1007,7 +1007,7 @@ $\widehat{\cal K}$.
     (ii)$\Rightarrow$(v) of
     \cite[Theorem~4.9 and Appendix~C.2, lines~1810--1817]
       {Cirac2016MPDO_arXiv}.
-\end{proposition}
+\end{theorem}
 
 % Correct equation, not a figure: the cited source draws the two-to-three
 % channel MPDO_TSKKK.png after explicitly suppressing U, but it does not draw

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels.tex
@@ -999,15 +999,17 @@ $\widehat{\cal K}$.
     \uses{def:is_sal, def:mpo_source_zcl, def:is_rfp_via_ts,
         def:mpdo_two_site_blocking,
         thm:mpdo_sal_zcl_bnt_sector_structure}
-    Let $K$ be a simple tensor in basis-of-normal-tensors canonical form
-    satisfying the strong area law and zero correlation length, and let
-    $M=K^{[2]}$ be its two-site blocking. Then
+    Let $K$ be a simple tensor in block-injective canonical form (biCF),
+    equipped with a basis-of-normal-tensors decomposition and satisfying the
+    strong area law and zero correlation length. Let $M=K^{[2]}$ be its
+    two-site blocking. Then
     there are trace-preserving completely positive maps in both directions
     between the one-site and two-site closures of $M$. Equivalently, $M$ is a
     renormalization fixed point via these two maps. This is implication
     (ii)$\Rightarrow$(v) of
     \cite[Theorem~4.9 and Appendix~C.2, lines~1810--1825]
-      {Cirac2016MPDO_arXiv}.
+      {Cirac2016MPDO_arXiv}. The separate standing biCF and BNT hypotheses are
+    imposed at lines~849--850 and restated at line~1628 of the same source.
 \end{theorem}
 
 % Correct equation, not a figure: the cited source draws the two-to-three

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -20,12 +20,60 @@
     \]
 \end{definition}
 
+% **Obstruction (rank-one trace matrix):** SAL and ZCL presently give only
+% \widehat T^2=\widehat T^3 and constant positive-power traces.  The missing
+% condition Q(1-LQ)L=0 is not obtained from the inverse-map construction.
+% Documented in docs/paper-gaps/cpgsv17_pf_rank_one.tex.
+\begin{theorem}[SAL and ZCL give a rank-one sector trace matrix]
+    \label{thm:mpdo_sal_zcl_rank_one_trace_matrix}
+    \notready
+    \uses{def:is_sal, def:mpo_source_zcl,
+        thm:mpdo_active_trace_matrix_zcl_relations}
+    Let ${\cal K}$ be an injective matrix product density operator tensor
+    satisfying the strong area law and zero correlation length. For the
+    neighboring operators obtained from its inverse-map sector decomposition,
+    define
+    \[
+        T_{k,h}=\tr(\eta_{k,h}).
+    \]
+    Then there are real families $(a_k)_k$ and $(b_k)_k$ such that
+    \[
+        T_{k,h}=a_kb_h,
+        \qquad
+        \sum_k a_kb_k=1.
+    \]
+    This is Lemma~C.5 at
+    \cite[Appendix~C.2, lines~1473--1499]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+% **Obstruction (dependence on Lemma C.5):** the source corollary includes the
+% unavailable rank-one trace factorization.  Documented in
+% docs/paper-gaps/cpgsv17_pf_rank_one.tex.
+\begin{corollary}[Local sector structure from SAL and ZCL]
+    \label{cor:mpdo_sal_zcl_local_sector_structure}
+    \notready
+    \uses{thm:mpdo_sal_zcl_rank_one_trace_matrix,
+        thm:mpdo_active_trace_matrix_zcl_relations}
+    Let ${\cal K}$ be an injective matrix product density operator tensor
+    satisfying the strong area law and zero correlation length. Then there are
+    an isometry, closed sector tensors, positive neighboring operators
+    $\eta_{k,h}$, and real families $(a_k)_k,(b_k)_k$ such that the inverse-map
+    sector decomposition holds and
+    \[
+        \tr(\eta_{k,h})=a_kb_h,
+        \qquad
+        \sum_k a_kb_k=1.
+    \]
+    This is the structural corollary at
+    \cite[Appendix~C.2, lines~1501--1505]{Cirac2016MPDO_arXiv}.
+\end{corollary}
+
 % **Scope restriction (rank-one trace matrix):** the two constructors below
 % require respectively positive semidefiniteness or linear independence, neither
 % of which is supplied by the source hypotheses of SAL and ZCL. Thus this entry
 % does not formalize Lemma SALZCL, its structural corollary, or Proposition
 % prop2to3 from those hypotheses alone. Documented in
-% docs/paper-gaps/cpgsv17_pf_rank_one.tex; tracked in issue #3593.
+% docs/paper-gaps/cpgsv17_pf_rank_one.tex.
 \begin{theorem}[Local simple-MPDO structure from corrected rank-one criteria]
     \label{thm:simple_mpdo_local_structure_data_of_sal_zcl}
     \lean{MPOTensor.SimpleMPDOLocalStructureData.ofSALZCLOfPairingIdempotent}
@@ -97,3 +145,28 @@ Equivalently, each local tensor is supported on its own sector:
 $\mathcal K_i=P_i\mathcal K_i=\mathcal K_iP_i$.
 This is the calculation in
 \cite[Appendix~C.2, lines~1745--1751]{Cirac2016MPDO_arXiv}.
+
+% **Obstruction (dependence on Lemma C.5):** the rank-one trace factorization
+% in this proposition is exactly the unavailable conclusion of
+% thm:mpdo_sal_zcl_rank_one_trace_matrix.  Documented in
+% docs/paper-gaps/cpgsv17_pf_rank_one.tex.
+\begin{proposition}[SAL and ZCL give the BNT sector structure]
+    \label{prop:mpdo_sal_zcl_bnt_sector_structure}
+    \notready
+    \uses{def:is_sal, def:mpo_source_zcl,
+        cor:mpdo_sal_zcl_local_sector_structure}
+    Let $K$ be a simple tensor in basis-of-normal-tensors canonical form. If
+    $K$ satisfies the strong area law and zero correlation length, then its
+    basis tensors have mutually orthogonal physical supports. Moreover, each
+    basis tensor has an inverse-map sector decomposition with positive
+    neighboring operators $\eta_{k,h}$ and real families $(a_k)_k,(b_k)_k$
+    satisfying
+    \[
+        \tr(\eta_{k,h})=a_kb_h,
+        \qquad
+        \sum_k a_kb_k=1.
+    \]
+    This is implication (ii)$\Rightarrow$(iv) of
+    \cite[Theorem~4.9 and Appendix~C.2, lines~1740--1788]
+      {Cirac2016MPDO_arXiv}.
+\end{proposition}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -150,8 +150,8 @@ This is the calculation in
 % in this proposition is exactly the unavailable conclusion of
 % thm:mpdo_sal_zcl_rank_one_trace_matrix.  Documented in
 % docs/paper-gaps/cpgsv17_pf_rank_one.tex.
-\begin{proposition}[SAL and ZCL give the BNT sector structure]
-    \label{prop:mpdo_sal_zcl_bnt_sector_structure}
+\begin{theorem}[SAL and ZCL give the BNT sector structure]
+    \label{thm:mpdo_sal_zcl_bnt_sector_structure}
     \notready
     \uses{def:is_sal, def:mpo_source_zcl,
         cor:mpdo_sal_zcl_local_sector_structure}
@@ -169,4 +169,4 @@ This is the calculation in
     This is implication (ii)$\Rightarrow$(iv) of
     \cite[Theorem~4.9 and Appendix~C.2, lines~1740--1788]
       {Cirac2016MPDO_arXiv}.
-\end{proposition}
+\end{theorem}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -24,8 +24,8 @@
 % \widehat T^2=\widehat T^3 and constant positive-power traces.  The missing
 % condition Q(1-LQ)L=0 is not obtained from the inverse-map construction.
 % Documented in docs/paper-gaps/cpgsv17_pf_rank_one.tex.
-\begin{theorem}[SAL and ZCL give a rank-one sector trace matrix]
-    \label{thm:mpdo_sal_zcl_rank_one_trace_matrix}
+\begin{lemma}[SAL and ZCL give a rank-one sector trace matrix]
+    \label{lem:mpdo_sal_zcl_rank_one_trace_matrix}
     \notready
     \uses{def:is_sal, def:mpo_source_zcl,
         thm:mpdo_active_trace_matrix_zcl_relations}
@@ -44,7 +44,7 @@
     \]
     This is Lemma~C.5 at
     \cite[Appendix~C.2, lines~1473--1499]{Cirac2016MPDO_arXiv}.
-\end{theorem}
+\end{lemma}
 
 % **Obstruction (dependence on Lemma C.5):** the source corollary includes the
 % unavailable rank-one trace factorization.  Documented in
@@ -52,7 +52,7 @@
 \begin{corollary}[Local sector structure from SAL and ZCL]
     \label{cor:mpdo_sal_zcl_local_sector_structure}
     \notready
-    \uses{thm:mpdo_sal_zcl_rank_one_trace_matrix,
+    \uses{lem:mpdo_sal_zcl_rank_one_trace_matrix,
         thm:mpdo_active_trace_matrix_zcl_relations}
     Let ${\cal K}$ be an injective matrix product density operator tensor
     satisfying the strong area law and zero correlation length. Then there are
@@ -148,19 +148,19 @@ This is the calculation in
 
 % **Obstruction (dependence on Lemma C.5):** the rank-one trace factorization
 % in this proposition is exactly the unavailable conclusion of
-% thm:mpdo_sal_zcl_rank_one_trace_matrix.  Documented in
+% lem:mpdo_sal_zcl_rank_one_trace_matrix.  Documented in
 % docs/paper-gaps/cpgsv17_pf_rank_one.tex.
 \begin{theorem}[SAL and ZCL give the BNT sector structure]
     \label{thm:mpdo_sal_zcl_bnt_sector_structure}
     \notready
     \uses{def:is_sal, def:mpo_source_zcl,
         cor:mpdo_sal_zcl_local_sector_structure}
-    Let $K$ be a simple tensor in basis-of-normal-tensors canonical form. If
-    $K$ satisfies the strong area law and zero correlation length, then its
-    basis tensors have mutually orthogonal physical supports. Moreover, each
-    basis tensor has an inverse-map sector decomposition with positive
-    neighboring operators $\eta_{k,h}$ and real families $(a_k)_k,(b_k)_k$
-    satisfying
+    Let $K$ be a simple tensor in block-injective canonical form (biCF),
+    equipped with a basis-of-normal-tensors decomposition. If $K$ satisfies
+    the strong area law and zero correlation length, then its basis tensors
+    have mutually orthogonal physical supports. Moreover, each basis tensor
+    has an inverse-map sector decomposition with positive neighboring
+    operators $\eta_{k,h}$ and real families $(a_k)_k,(b_k)_k$ satisfying
     \[
         \tr(\eta_{k,h})=a_kb_h,
         \qquad
@@ -168,5 +168,6 @@ This is the calculation in
     \]
     This is implication (ii)$\Rightarrow$(iv) of
     \cite[Theorem~4.9 and Appendix~C.2, lines~1740--1788]
-      {Cirac2016MPDO_arXiv}.
+      {Cirac2016MPDO_arXiv}. The separate standing biCF and BNT hypotheses are
+    imposed at lines~849--850 and restated at line~1628 of the same source.
 \end{theorem}

--- a/docs/paper-gaps/cpgsv17_pf_rank_one.tex
+++ b/docs/paper-gaps/cpgsv17_pf_rank_one.tex
@@ -27,9 +27,7 @@ counterexample was added in
 \href{https://github.com/LionSR/TNLean/pull/849}{pull request \#849}; and the
 positive-semidefinite replacement theorem was added in
 \href{https://github.com/LionSR/TNLean/pull/917}{pull request \#917}. The open
-follow-up --- either supplying matrix-level positive semidefiniteness of the
-sector trace matrix, or completing the sector-pairing and linear-independence
-route described below --- is tracked in
+final inverse-map provenance audit and the obstruction verdict are recorded in
 \href{https://github.com/LionSR/TNLean/issues/3593}{issue \#3593}. The
 source passage is
 \path{Papers/1606.00608/MPDO-22-12-17-2.tex:1394--1499}.}
@@ -569,6 +567,65 @@ blueprint entries have labels
 \texttt{\detokenize{thm:psd_trace_powers_rank_one_t}} in
 \path{blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity.tex}.}
 
+\section{Audit of the inverse-map provenance}
+
+The remaining possibility was that the particular inverse-map tensors used in
+Appendix~C.2 might satisfy an additional identity which is not visible in the
+rectangular pairing equation.  An audit of the complete source passage does
+not reveal such an identity.
+
+In the proof of Lemma~C.4, at lines~1406--1471, the strong area law
+is used to obtain the physical-sector factorization, positive neighboring
+operators, and primitivity of the trace matrix.  The last point uses
+injectivity to rule out more than one primitive block.  This argument does not
+prove an adjoint relation between the closed left and right tensors, their
+linear independence, or the vanishing
+\[
+    Q(1-LQ)L=0.
+\]
+The physical direct sum separates the uncontracted physical sector spaces.
+After the physical legs are closed at lines~1473--1482, the vectors $l_h$ and
+functionals $r_k$ lie in common bond spaces, and the source gives only
+$T_{k,h}=(r_k\mid l_h)$.
+
+The proof of Lemma~C.5, at lines~1489--1499, then uses zero
+correlation length to obtain the pairing-operator identity and its trace-power
+consequence.  No further property of the inverse map occurs between this
+identity and the rank-one conclusion.  Thus the printed proof has precisely
+the matrix gap described above.
+
+The cyclic finite-chain form at lines~1581--1593 does not repair this step. It
+is obtained later from the same positive neighboring family and states a
+direct sum of cyclic products.  Its formal, scalar-preserving version is
+\leanid{MPOTensor.EtaLocalStructureData.%
+exists_positive_cyclic_eta_block_decomposition}.  Neither the source formula
+nor this theorem asserts independence, a Gram relation, kernel stabilization,
+or rectangular vanishing for the closed tensors.  Taking traces of cyclic
+products returns the already established positive-power trace identities.
+
+Consequently the strongest source-faithful common-matrix conclusion remains
+\[
+    \widehat T^2=\widehat T^3,
+    \qquad
+    \tr(\widehat T^N)=\tr(\widehat T)\quad(N\geq1),
+\]
+together with entrywise nonnegativity and primitivity.  The formal counterexample
+shows that these conclusions, even supplemented by injectivity, full virtual
+spanning, and positivity of every neighboring operator, do not imply the
+missing vanishing.  The counterexample does not satisfy the strong area law,
+so it does not disprove Lemma~C.5; rather, the source proof is obstructed
+because the printed argument derives no identity from its stated premises that
+excludes the nilpotent remainder.
+
+This obstruction propagates to every source statement whose proof invokes the
+rank-one factorization from Lemma~C.5.  In particular, the structural
+corollary at lines~1501--1505, the proposition proving Theorem~4.9
+(ii)$\Rightarrow$(iv) at lines~1740--1788, and the proposition proving
+Theorem~4.9 (ii)$\Rightarrow$(v) at lines~1810--1817 are not formalized from
+their stated SAL and ZCL hypotheses.  The constructions from an explicitly
+supplied rank-one neighboring trace factorization remain valid restricted
+results, but they do not establish these three source statements.
+
 \section{Conclusion}
 
 The proof in Appendix C.2 contains an unjustified matrix step as written: a
@@ -585,13 +642,15 @@ The local simple-MPDO structure is constructed only through these two corrected
 criteria; the former constructor with an abstract assumption asserting the
 false primitive trace-power implication has been removed.
 
-For the unconditional matrix product density operator argument, it therefore
-suffices either to prove the required positive-semidefinite structure of the
-trace matrix, or to derive the needed linear independence (or an equivalent
-exclusion of the generalized zero-eigenspace) for the concrete source sector
-pairing.  The source proof has a genuine unsupported intermediate assertion,
-while the intended matrix product density operator theorem itself has not been
-disproved.
+For the unconditional matrix product density operator argument, it would
+suffice to derive positive semidefiniteness, linear independence, or any
+equivalent exclusion of the generalized zero-eigenspace from the stated SAL
+and ZCL hypotheses.  The source and inverse-map provenance audit provides no
+such derivation.  Lemma~C.5 is therefore classified as obstructed, rather than
+formalized or refuted.  The same status applies to its structural corollary and
+to the source implications (ii)$\Rightarrow$(iv) and (ii)$\Rightarrow$(v) of
+Theorem~4.9.  Their corrected conditional forms remain available, but the
+additional conditions must not be attributed to the source theorem.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpgsv17_pf_rank_one.tex
+++ b/docs/paper-gaps/cpgsv17_pf_rank_one.tex
@@ -631,9 +631,9 @@ products returns the already established positive-power trace identities.
 
 Consequently the strongest source-faithful common-matrix conclusion remains
 \[
-    \widehat T^2=\widehat T^3,
+    T^2=T^3,
     \qquad
-    \tr(\widehat T^N)=\tr(\widehat T)\quad(N\geq1),
+    \tr(T^N)=\tr(T)\quad(N\geq1),
 \]
 together with entrywise nonnegativity and primitivity.  The formal
 counterexample shows that these conclusions, even supplemented by injectivity,

--- a/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
+++ b/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
@@ -232,7 +232,7 @@ primitivity from SAL, which is the conclusion being proved in Proposition
 trace-power-to-rank-one inference recorded in
 \path{docs/paper-gaps/cpgsv17_pf_rank_one.tex}.  Formally, source ZCL yields an
 idempotent normalized pairing operator, but for the opposite product it yields
-only $\widehat T^2=\widehat T^3$ and constant positive-power traces.  The
+only a square--cube identity and constant positive-power traces.  The
 four-sector example
 \leanid{MPOTensor.ActiveSectorSpanningCounterexample.%
 virtual_spanning_does_not_force_rectangular_remainder_zero}

--- a/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
+++ b/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
@@ -215,8 +215,9 @@ four-sector example
 virtual_spanning_does_not_force_rectangular_remainder_zero}
 satisfies the recorded
 positivity, primitivity, trace-one, and spanning conditions while its trace
-matrix is not idempotent.  The source-faithful rank-one question remains
-\ghissue{3593}.
+matrix is not idempotent.  The source-faithful audit in \ghissue{3593}
+classifies this rank-one step as obstructed: neither the inverse-map provenance
+nor the finite-chain cyclic form supplies the missing rectangular vanishing.
 
 Consequently the source implication
 \[
@@ -244,11 +245,11 @@ The gap can be removed in the following stages.
 \item Determine whether the source normalization removes $c_N$ or permits its
 absorption into one neighboring family independent of $N$.  Until this is
 proved, the coefficient-free equation \emph{sigmaNK2} remains open.
-\item Resolve \ghissue{3593} by finding a source-faithful property of the
-actual neighboring family which excludes the nilpotent zero-eigenspace, or
-replace the printed line-1613 argument by a direct Markov decomposition which
-does not require the rank-one trace matrix.  Source ZCL alone must not be
-presented as giving the factorization.
+\item Replace the obstructed line-1613 argument by a direct Markov
+decomposition which does not require the rank-one trace matrix, or prove from
+the stated hypotheses a new identity excluding the nilpotent zero-eigenspace.
+Source ZCL alone must not be presented as giving the factorization; the
+inverse-map and finite-chain audits in \ghissue{3593} do not supply it.
 \item Trace the fourth region, construct the quantum Markov decomposition at
 each admissible cut, and apply the all-cut Markov theorem.  Only then may the
 source proposition receive a formal declaration and a


### PR DESCRIPTION
## Mathematical conclusion

The complete Appendix C.2 provenance audit supplies no identity in the printed argument that eliminates the nilpotent generalized zero-eigenspace of the normalized sector trace matrix.

Writing
\[
S=\widehat LQ,\qquad T=Q\widehat L,
\]
source zero correlation length gives \(S^2=S\), while the exact missing conclusion is
\[
Q(1-S)\widehat L=T-T^2=0.
\]

The strong area law is used in Lemma C.4 to obtain the physical-sector factorization, positivity, and primitivity. After the physical indices are closed, the source derives no linear independence, Gram relation, kernel stabilization, or equivalent rectangular vanishing. The later cyclic finite-chain form returns the already known trace identities and adds no such relation.

The four-sector classical cyclic family does satisfy SAL: \(H_L=2+(L-1)h\), \(H_N=Nh\), hence \(I_L=4-2h\). It therefore refutes the printed universal matrix inference from the displayed trace identities to rank one. It does **not yet refute Lemma C.5 itself**, because the remaining question is whether that family arises with the inverse-map physical-sector factorization required by the source construction. That provenance question is isolated in #4270.

Thus this PR classifies the current formalization boundary as: the printed matrix step is refuted; Lemma C.5 is obstructed, not formalized or refuted; and no source-absent hypothesis may be inserted to mark it as formalized.

## Blueprint status

The following source-hypothesis statements are explicit `\notready` entries:

- Lemma C.5, the rank-one sector trace factorization;
- its immediate structural corollary;
- Theorem 4.9, implication (ii) to (iv), under the source's standing BNT/biCF hypothesis and Appendix C.2 lines 1740–1788;
- Theorem 4.9, implication (ii) to (v), under the same standing hypothesis and Appendix C.2 lines 1810–1825, including the blocking and squared-channel step.

No existing `\leanok` marker is removed. The existing marked theorems are explicitly restricted statements: they assume positive semidefiniteness, linear independence, or a supplied rank-one neighboring trace factorization.

The paper-gap note `docs/paper-gaps/cpgsv17_pf_rank_one.tex` records the source audit, exact obstruction, SAL calculation, and propagation. The separate commuting-form-to-SAL note is updated consistently.

## Validation

- full `lake build` on the implementation head before the final notation-only correction
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `leanblueprint checkdecls`
- `leanblueprint web`
- `leanblueprint pdf`
- `git diff --check`
- proof-integrity scan on the changed Lean file

The four obstruction entries intentionally carry no `\lean{...}` tag.

Closes #3593. The remaining source-provenance question is tracked in #4270.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and blueprint `\notready` markers only; no change to proved Lean APIs or runtime behavior beyond clarified module docstrings.
> 
> **Overview**
> **Classifies the formalization boundary** around Cirac et al. Appendix C.2 Lemma C.5: the printed inference from primitivity, ZCL trace identities, and virtual spanning to a rank-one sector trace matrix is **refuted** by the existing four-sector counterexample, while **Lemma C.5 itself is obstructed—not formalized or refuted**—because the example’s `PhysicalSectorFactorization` is built directly and is not yet tied to `zeroWeightReparameterizedInverseMapPhysicalSectorFactorization`.
> 
> The **Lean** change is documentation only on `virtual_spanning_does_not_force_rectangular_remainder_zero`: it notes the induced classical cyclic family **satisfies SAL** by entropy, and that the gap is **provenance** (inverse-map factorization), not absence of SAL in the formal theorem.
> 
> **Blueprint** adds explicit `\notready` entries for Lemma C.5, its structural corollary, SAL+ZCL ⇒ BNT sector structure (Theorem 4.9 (ii)⇒(iv)), and SAL+ZCL ⇒ blocking channels ((ii)⇒(v)); comments now point at Lemma C.5 obstruction instead of open issue #3593 for the rank-one step.
> 
> **Gap notes** (`cpgsv17_pf_rank_one.tex`, `cpsv16_commuting_form_to_sal.tex`) record the full inverse-map and finite-chain audit, propagation to downstream source implications, and isolate the remaining factorization-identification question in **#4270**; **#3593** is treated as closed by this classification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9396831ca5205f7dd3f53eca10c0cc1b0f2586d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->