### PR TITLE
doc(MPS/MPDO): record cyclic scalar countermodel

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -367,6 +367,28 @@
     positive scalar $c_N$.
 \end{proof}
 
+\begin{remark}[The finite-chain scalar requires a normal-block argument]
+    The proportional commuting-bond form alone does not permit one common
+    local normalization.  Indeed, take physical dimension $d=1$ and bond
+    dimension $D=2$, with sole matrix-product letter $M^{00}=I_2$, and take
+    the two-site bond to be the scalar $B=1$.  Then
+    \[
+        \sigma^{(N)}=\operatorname{tr}(I_2^N)=2
+        =c_N\prod_{n=0}^{N-1}B_{n,n+1},
+        \qquad c_N=2.
+    \]
+    Any positive neighboring decomposition of the one-dimensional physical
+    space has one sector and one scalar $a\geq0$.  A coefficient-free identity
+    at lengths two and four would give $a^2=2$ and $a^4=2$, a contradiction.
+    This example is not a normal injective block.  In the normal single-block
+    setting, the missing assertion is the geometric law $c_N=a^N$ for one
+    $a>0$; it is precisely this law that permits one fixed rescaling.  This
+    distinguishes the proportionality at
+    \cite[Appendix~C.2, lines~1571--1576]{Cirac2016MPDO_arXiv} from the
+    coefficient-free invocation at
+    \cite[Appendix~C.2, lines~1603--1605]{Cirac2016MPDO_arXiv}.
+\end{remark}
+
 \begin{theorem}[A translation-invariant commuting bond and ZCL imply SAL]
     \label{thm:mpdo_translation_invariant_commuting_form_zcl_sal}
     \notready

--- a/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
+++ b/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
@@ -192,8 +192,31 @@ $\sigma^{(N)}(\mathcal K)\propto\prod_n B_{n,n+1}$ but invokes the
 coefficient-free equation \emph{sigmaNK2} without retaining the corresponding
 constant.  The formal theorem proves the proportionality-preserving identity
 displayed above.  It does not prove the coefficient-free equation printed at
-source lines~1581--1588.  Removing or absorbing $c_N$ into one neighboring
-family independent of $N$ requires a further normalization argument.
+source lines~1581--1588.
+
+This omission cannot be repaired from the proportional commuting-bond form
+alone.  Take physical dimension $d=1$ and bond dimension $D=2$, with sole
+matrix-product letter $M^{00}=I_2$.  Then
+\[
+  \sigma^{(N)}=\operatorname{tr}(I_2^N)=2.
+\]
+The scalar two-site bond $B=1$ realizes this family with $c_N=2$ for every
+$N$.  Since the physical space is one-dimensional, any positive neighboring
+decomposition has a single one-dimensional sector and a single scalar
+$a\geq0$.  A coefficient-free identity for all $N\geq2$ would therefore give
+$a^2=2$ and $a^4=2$, which is impossible.  Thus a fixed local rescaling does
+not follow from the displayed proportionality data.
+
+The example is not a normal injective block.  It therefore does not contradict
+the source setting, but shows exactly which source hypothesis the missing
+argument must use.  For a normal injective single block, one must compare the
+matrix-product family with the fixed bond-product family and prove that its
+proportionality constants have the form
+\[
+  c_N=a^N
+\]
+for one $a>0$.  Only then can $a$ be absorbed once into the bond, or
+equivalently into the neighboring operators, independently of $N$.
 
 The scaled identity uses only the fixed commuting bond and its positive
 realization scalar.  It does not assert zero correlation length, rank-one trace
@@ -241,9 +264,12 @@ restriction that isolates only its final entropy-theoretic step.
 The gap can be removed in the following stages.
 
 \begin{enumerate}
-\item Determine whether the source normalization removes $c_N$ or permits its
-absorption into one neighboring family independent of $N$.  Until this is
-proved, the coefficient-free equation \emph{sigmaNK2} remains open.
+\item Restore the normal injective single-block hypothesis in the comparison
+between the matrix-product family and the fixed bond-product family.  Prove the
+proportional fundamental-theorem scalar law $c_N=a^N$ for one $a>0$, and absorb
+$a$ into the bond or neighboring operators.  The counterexample above shows
+that the generic proportional commuting-bond data cannot supply this law; this
+normalization problem is tracked in \ghissue{4253}.
 \item Resolve \ghissue{3593} by finding a source-faithful property of the
 actual neighboring family which excludes the nilpotent zero-eigenspace, or
 replace the printed line-1613 argument by a direct Markov decomposition which


### PR DESCRIPTION
## Summary

- records the explicit $d=1$, $D=2$ identity-letter counterexample showing that a proportional commuting-bond realization does not by itself admit one coefficient-free neighboring family;
- identifies the missing source-faithful step as a normal injective single-block comparison proving the geometric scalar law $c_N=a^N$;
- places the counterexample beside the scaled cyclic theorem in the blueprint and replaces the open-ended normalization question in the paper-gap elimination plan.

No Lean declaration or hypothesis is added. The mathematical distinction is between the proportionality at CPSV16 Appendix C.2, lines 1571--1576, and the coefficient-free invocation at lines 1603--1605.

Refs #4253.

## Validation

- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`
- `latexmk -pdf -interaction=nonstopmode -halt-on-error cpsv16_commuting_form_to_sal.tex`
- `leanblueprint pdf`

The full PDF and the standalone paper-gap report compile successfully. The local web renderer parses and renders every chapter, but its mixed Python 3.9/3.14 installation reports a `pygraphviz` binary-import error while loading the `leanblueprint` plasTeX package; the clean CI environment remains the authoritative web-render check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and paper-gap prose only; no runtime, auth, or Lean proof changes.
> 
> **Overview**
> Documents that **proportional commuting-bond data alone** cannot justify absorbing the length-dependent scalar into one coefficient-free neighboring family.
> 
> Adds the same **$d=1$, $D=2$, $M^{00}=I_2$, $B=1$** counterexample beside the scaled cyclic theorem in the blueprint (`remark` after `thm:mpdo_eta_local_sigma_nk2`) and in the paper-gap note on CPSV16 Appendix C.2. The example realizes $\sigma^{(N)}=2=c_N\prod_n B_{n,n+1}$ with constant $c_N=2$, while any one-dimensional positive neighboring decomposition would force $a^2=2$ and $a^4=2$ if a coefficient-free identity held for all $N$.
> 
> Clarifies the **missing source-faithful step**: under a **normal injective single block**, prove the geometric law $c_N=a^N$ for one $a>0$, then absorb $a$ once—distinguishing proportionality at source lines 1571–1576 from the coefficient-free step at 1603–1605. The elimination plan’s first item is rewritten to require that comparison and points to **#4253** instead of an open-ended “remove $c_N$?” question.
> 
> No Lean declarations or hypotheses are added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit decdf42a357e1bdbd82b8175ce64d316c7a22b57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->