### PR TITLE
doc(MPS/MPDO): display coupled boundary sum

### DIFF
--- a/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
+++ b/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
@@ -226,8 +226,15 @@ the proposition labelled \emph{4to2}.
 The fourth-region calculation after the cyclic identity requires a coordinate
 clarification.  Tracing one physical site of the length-$N$ cyclic eta product
 leaves a coupled sum of the right partial trace of
-$\eta_{k_{N-1},q}$ and the left partial trace of $\eta_{q,k_1}$; rank-one
-factorization does not separate this sum.  Source line~1613 instead invokes
+$\eta_{k_{N-1},q}$ and the left partial trace of $\eta_{q,k_1}$:
+\[
+  \sum_q
+    \tr_{H_{q,l}}\!\left(\eta_{k_{N-1},q}\right)
+    \otimes
+    \tr_{H_{q,r}}\!\left(\eta_{q,k_1}\right).
+\]
+The same sector $q$ occurs in both factors, so rank-one factorization does not
+separate this into two independent sums.  Source line~1613 instead invokes
 ZCL to replace this marginal by a trace of two boundary sites on the
 length-$(N+1)$ chain.  In edge coordinates the middle operator
 $\eta_{q,h}$ is then fully traced, while the two adjacent operators retain


### PR DESCRIPTION
## Summary

- display the shared-sector partial-trace sum left by tracing one site of the cyclic eta product;
- state explicitly that the common sector index prevents factorization into two independent sums;
- retain the existing distinction between this one-site marginal and the two-boundary contraction used after the ZCL replacement.

This is the nonblocking notation clarification suggested in the final review of #4265. The conditional fourth-region theorem itself is already merged and is unchanged.

## Validation

- `git diff --check`
- the parent PR's full Lean, blueprint, and PDF validation remains applicable because this change is mathematical prose only

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mathematical prose only in a paper-gap document; no code or proof behavior changes.
> 
> **Overview**
> **Documentation-only** clarification in `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex` for the fourth-region / one-site marginal step in the commuting-form-to-SAL gap narrative.
> 
> The prose now **shows the coupled sector sum** left after tracing one physical site of the cyclic η product: a sum over shared index \(q\) of right partial trace of \(\eta_{k_{N-1},q}\) tensored with left partial trace of \(\eta_{q,k_1}\). It **states explicitly** that the common \(q\) prevents splitting this into two independent sums (so rank-one factorization does not apply here). The existing story is unchanged: ZCL still replaces this marginal with a two-boundary contraction on the length-\((N+1)\) chain, and the conditional `Matrix.eta_fourth_region_trace_formula` discussion is untouched.
> 
> No Lean, blueprint, or formal proof changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49b135f57718715b0c07b2a4e6709cccacf9a81a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->