### PR TITLE
feat(MPS/Overlap): control geometric proportionality phase

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/Proportional.lean
+++ b/TNLean/MPS/FundamentalTheorem/Proportional.lean
@@ -34,19 +34,23 @@ section Main
 
 variable [NeZero D]
 
-omit [NeZero D] in
-private theorem gaugePhaseEquiv_of_eventually_proportionalMPV₂_of_overlap_decay
-    (A B : MPSTensor d D)
+/-- Eventual proportionality and normalized self-overlaps force the rectangular
+cross-overlap to have asymptotic norm one.
+
+This is the scalar-control argument used in the primitive single-block branch
+of Cirac et al., arXiv:2011.12127, Theorem 4.4.  No common bond dimension is
+required. -/
+theorem mpvOverlap_norm_tendsto_one_of_eventually_proportionalMPV₂
+    {D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (hA_self :
       Filter.Tendsto (fun N => mpvOverlap (d := d) A A N) Filter.atTop (nhds (1 : ℂ)))
     (hB_self :
       Filter.Tendsto (fun N => mpvOverlap (d := d) B B N) Filter.atTop (nhds (1 : ℂ)))
     (hProp :
       ∀ᶠ N in Filter.atTop, ∃ c : ℂ, ∀ σ : Fin N → Fin d,
-        mpv A σ = c * mpv B σ)
-    (hZero : ¬ GaugePhaseEquiv A B →
-      Filter.Tendsto (fun N => mpvOverlap (d := d) A B N) Filter.atTop (nhds 0)) :
-    GaugePhaseEquiv A B := by
+        mpv A σ = c * mpv B σ) :
+    Filter.Tendsto (fun N => ‖mpvOverlap (d := d) A B N‖) Filter.atTop
+      (nhds (1 : ℝ)) := by
   classical
   let proportionalAt : ℕ → Prop := fun N =>
     ∃ c : ℂ, ∀ σ : Fin N → Fin d,
@@ -145,11 +149,7 @@ private theorem gaugePhaseEquiv_of_eventually_proportionalMPV₂_of_overlap_deca
       filter_upwards [hOverlapAB] with N hAB
       simp [hAB]
     exact Filter.Tendsto.congr' hCross_eq.symm hmul
-  by_contra hNot
-  have hto0 :
-      Filter.Tendsto (fun N => mpvOverlap (d := d) A B N) Filter.atTop (nhds 0) :=
-    hZero hNot
-  exact one_ne_zero (tendsto_nhds_unique hCrossNorm (by simpa using hto0.norm))
+  exact hCrossNorm
 
 
 /-! ## Gauge-phase equivalence from unit-modulus overlap -/
@@ -299,12 +299,12 @@ theorem exists_ge_not_forall_mpv_eq_mul_of_not_gaugePhaseEquiv_of_irreducible_TP
     exact Filter.eventually_atTop.2 ⟨Nmin, fun N hN => by
       by_contra hNprop
       exact hNo ⟨N, hN, hNprop⟩⟩
-  exact hNot
-    (gaugePhaseEquiv_of_eventually_proportionalMPV₂_of_overlap_decay
+  have hCrossNorm :=
+    mpvOverlap_norm_tendsto_one_of_eventually_proportionalMPV₂
       A B hA_self hB_self hProp
-      (fun hNot' =>
-        mpvOverlap_tendsto_zero_of_irreducible_TP
-          (A := A) (B := B) hA_irr hB_irr hA_norm hB_norm hNot'))
+  have hto0 := mpvOverlap_tendsto_zero_of_irreducible_TP
+    (A := A) (B := B) hA_irr hB_irr hA_norm hB_norm hNot
+  exact one_ne_zero (tendsto_nhds_unique hCrossNorm (by simpa using hto0.norm))
 
 end Main
 

--- a/TNLean/MPS/FundamentalTheorem/Proportional.lean
+++ b/TNLean/MPS/FundamentalTheorem/Proportional.lean
@@ -10,7 +10,7 @@ import TNLean.MPS.SharedInfra.GaugePhase
 
 This file contains a lightweight “proportional” variant of the single-block Fundamental Theorem,
 aligned with the **primitive/aperiodic** branch of Cirac et al., Rev. Mod. Phys. 93 (2021),
-Theorem 4.4 (arXiv:2011.12127).
+Theorem IV.4 (arXiv:2011.12127).
 
 * If `A` and `B` are related by a gauge transform up to a scalar `ζ` (`GaugePhaseEquiv A B`), then
   their Matrix Product Vectors are proportional for each system size `N`.
@@ -38,7 +38,7 @@ variable [NeZero D]
 cross-overlap to have asymptotic norm one.
 
 This is the scalar-control argument used in the primitive single-block branch
-of Cirac et al., arXiv:2011.12127, Theorem 4.4.  No common bond dimension is
+of Cirac et al., arXiv:2011.12127, Theorem IV.4. No common bond dimension is
 required. -/
 theorem mpvOverlap_norm_tendsto_one_of_eventually_proportionalMPV₂
     {D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂)

--- a/TNLean/MPS/Overlap/NormalTensorDichotomy.lean
+++ b/TNLean/MPS/Overlap/NormalTensorDichotomy.lean
@@ -138,8 +138,8 @@ bond dimensions may differ.
 This theorem concerns the unit-phase part of the proportionality between
 normalized normal blocks. It does not construct the positive geometric
 rescaling needed to remove a length-dependent positive coefficient in
-CPSV16 equation `sigmaNK2`; the missing rescaling argument is documented in
-`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.
+the commuting-form decomposition; the missing rescaling argument is
+documented in `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.
 
 Source: CPSV16, Corollary `eqV`, lines 1121--1128, combined with the one-block
 case of the proportionality hypothesis in Theorem `thm1`, lines 1167--1182;

--- a/TNLean/MPS/Overlap/NormalTensorDichotomy.lean
+++ b/TNLean/MPS/Overlap/NormalTensorDichotomy.lean
@@ -138,7 +138,8 @@ bond dimensions may differ.
 This theorem concerns the unit-phase part of the proportionality between
 normalized normal blocks. It does not construct the positive geometric
 rescaling needed to remove a length-dependent positive coefficient in
-CPSV16 equation `sigmaNK2`; that separate construction is tracked in #4253.
+CPSV16 equation `sigmaNK2`; the missing rescaling argument is documented in
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.
 
 Source: CPSV16, Corollary `eqV`, lines 1121--1128, combined with the one-block
 case of the proportionality hypothesis in Theorem `thm1`, lines 1167--1182;

--- a/TNLean/MPS/Overlap/NormalTensorDichotomy.lean
+++ b/TNLean/MPS/Overlap/NormalTensorDichotomy.lean
@@ -143,7 +143,7 @@ CPSV16 equation `sigmaNK2`; the missing rescaling argument is documented in
 
 Source: CPSV16, Corollary `eqV`, lines 1121--1128, combined with the one-block
 case of the proportionality hypothesis in Theorem `thm1`, lines 1167--1182;
-see also arXiv:2011.12127, Theorem 4.4. -/
+see also arXiv:2011.12127, Theorem IV.4. -/
 theorem EventuallyNonzeroProportionalMPV₂.exists_unit_phase_power_of_isNormalTensor
     [NeZero D₁] [NeZero D₂]
     {A : MPSTensor d D₁} {B : MPSTensor d D₂}

--- a/TNLean/MPS/Overlap/NormalTensorDichotomy.lean
+++ b/TNLean/MPS/Overlap/NormalTensorDichotomy.lean
@@ -19,8 +19,8 @@ matrix product vectors differ by the corresponding power of the phase at every l
   to zero or has modulus tending to one with gauge-phase equivalence by a unit phase.
 * `IsNormalTensor.mpv_phase_alternative`: the overlap tends to zero, or the matrix product vectors
   differ by a unit phase raised to each chain length.
-* `NonzeroProportionalMPV₂.exists_unit_phase_power_of_isNormalTensor`: proportional normal
-  matrix product vectors differ by the powers of one unit phase.
+* `EventuallyNonzeroProportionalMPV₂.exists_unit_phase_power_of_isNormalTensor`: eventually
+  proportional normal matrix product vectors differ by the powers of one unit phase.
 
 ## References
 
@@ -130,23 +130,29 @@ theorem IsNormalTensor.mpv_phase_alternative
 
 /-- **Geometric proportionality scalar for two normal blocks.**
 
-If two CPSV16 normal tensors generate nonzero proportional matrix product
-vectors at every positive length, then the proportionality may be chosen as
-the powers of one fixed unit phase.  The bond dimensions may differ.
+If two CPSV16 normal tensors generate matrix product vectors that are
+eventually proportional by a nonzero scalar, then at every positive length
+their proportionality may be chosen as the power of one fixed unit phase. The
+bond dimensions may differ.
+
+This theorem concerns the unit-phase part of the proportionality between
+normalized normal blocks. It does not construct the positive geometric
+rescaling needed to remove a length-dependent positive coefficient in
+CPSV16 equation `sigmaNK2`; that separate construction is tracked in #4253.
 
 Source: CPSV16, Corollary `eqV`, lines 1121--1128, combined with the one-block
 case of the proportionality hypothesis in Theorem `thm1`, lines 1167--1182;
 see also arXiv:2011.12127, Theorem 4.4. -/
-theorem NonzeroProportionalMPV₂.exists_unit_phase_power_of_isNormalTensor
+theorem EventuallyNonzeroProportionalMPV₂.exists_unit_phase_power_of_isNormalTensor
     [NeZero D₁] [NeZero D₂]
     {A : MPSTensor d D₁} {B : MPSTensor d D₂}
-    (hProp : NonzeroProportionalMPV₂ A B)
+    (hProp : EventuallyNonzeroProportionalMPV₂ A B)
     (hA : IsNormalTensor A) (hB : IsNormalTensor B) :
     ∃ a : ℂ, ‖a‖ = 1 ∧ ∀ N : ℕ, 0 < N → ∀ σ : Fin N → Fin d,
       mpv A σ = a ^ N * mpv B σ := by
   have hEvent : ∀ᶠ N in atTop, ∃ c : ℂ, ∀ σ : Fin N → Fin d,
       mpv A σ = c * mpv B σ := by
-    exact hProp.eventually.mono fun _ hN ↦ ⟨hN.choose, hN.choose_spec.2⟩
+    exact hProp.mono fun _ hN ↦ ⟨hN.choose, hN.choose_spec.2⟩
   have hCrossNorm : Tendsto (fun N ↦ ‖mpvOverlap (d := d) A B N‖)
       atTop (nhds (1 : ℝ)) :=
     mpvOverlap_norm_tendsto_one_of_eventually_proportionalMPV₂
@@ -166,5 +172,19 @@ theorem NonzeroProportionalMPV₂.exists_unit_phase_power_of_isNormalTensor
       have hComponent := congrArg (fun v : MPVSpace d N ↦ v σ) (hState N)
       simp only [mpvState_apply, PiLp.smul_apply, smul_eq_mul] at hComponent
       rw [hComponent, ← mul_assoc, ← mul_pow, inv_mul_cancel₀ hζ0, one_pow, one_mul]
+
+/-- Positive-length nonzero proportionality is a sufficient special case of
+the eventual geometric-phase theorem for normal tensors.
+
+Source: CPSV16, Corollary `eqV`, lines 1121--1128, combined with the one-block
+case of the proportionality hypothesis in Theorem `thm1`, lines 1167--1182. -/
+theorem NonzeroProportionalMPV₂.exists_unit_phase_power_of_isNormalTensor
+    [NeZero D₁] [NeZero D₂]
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂}
+    (hProp : NonzeroProportionalMPV₂ A B)
+    (hA : IsNormalTensor A) (hB : IsNormalTensor B) :
+    ∃ a : ℂ, ‖a‖ = 1 ∧ ∀ N : ℕ, 0 < N → ∀ σ : Fin N → Fin d,
+      mpv A σ = a ^ N * mpv B σ :=
+  hProp.eventually.exists_unit_phase_power_of_isNormalTensor hA hB
 
 end MPSTensor

--- a/TNLean/MPS/Overlap/NormalTensorDichotomy.lean
+++ b/TNLean/MPS/Overlap/NormalTensorDichotomy.lean
@@ -19,6 +19,8 @@ matrix product vectors differ by the corresponding power of the phase at every l
   to zero or has modulus tending to one with gauge-phase equivalence by a unit phase.
 * `IsNormalTensor.mpv_phase_alternative`: the overlap tends to zero, or the matrix product vectors
   differ by a unit phase raised to each chain length.
+* `NonzeroProportionalMPV₂.exists_unit_phase_power_of_isNormalTensor`: proportional normal
+  matrix product vectors differ by the powers of one unit phase.
 
 ## References
 
@@ -125,5 +127,44 @@ theorem IsNormalTensor.mpv_phase_alternative
     rw [mpv_eq_pow_mul_of_gaugePhase
       (A := cast (congr_arg (MPSTensor d) hdim) A) (B := B) X ζ hrel N w,
       mpv_cast_dim hdim A N w]
+
+/-- **Geometric proportionality scalar for two normal blocks.**
+
+If two CPSV16 normal tensors generate nonzero proportional matrix product
+vectors at every positive length, then the proportionality may be chosen as
+the powers of one fixed unit phase.  The bond dimensions may differ.
+
+Source: CPSV16, Corollary `eqV`, lines 1121--1128, combined with the one-block
+case of the proportionality hypothesis in Theorem `thm1`, lines 1167--1182;
+see also arXiv:2011.12127, Theorem 4.4. -/
+theorem NonzeroProportionalMPV₂.exists_unit_phase_power_of_isNormalTensor
+    [NeZero D₁] [NeZero D₂]
+    {A : MPSTensor d D₁} {B : MPSTensor d D₂}
+    (hProp : NonzeroProportionalMPV₂ A B)
+    (hA : IsNormalTensor A) (hB : IsNormalTensor B) :
+    ∃ a : ℂ, ‖a‖ = 1 ∧ ∀ N : ℕ, 0 < N → ∀ σ : Fin N → Fin d,
+      mpv A σ = a ^ N * mpv B σ := by
+  have hEvent : ∀ᶠ N in atTop, ∃ c : ℂ, ∀ σ : Fin N → Fin d,
+      mpv A σ = c * mpv B σ := by
+    exact hProp.eventually.mono fun _ hN ↦ ⟨hN.choose, hN.choose_spec.2⟩
+  have hCrossNorm : Tendsto (fun N ↦ ‖mpvOverlap (d := d) A B N‖)
+      atTop (nhds (1 : ℝ)) :=
+    mpvOverlap_norm_tendsto_one_of_eventually_proportionalMPV₂
+      A B hA.selfOverlap_tendsto_one hB.selfOverlap_tendsto_one hEvent
+  rcases hA.mpv_phase_alternative hB with hZero | ⟨ζ, hζ, hState⟩
+  · exfalso
+    have hZeroNorm : Tendsto (fun N ↦ ‖mpvOverlap (d := d) A B N‖)
+        atTop (nhds (0 : ℝ)) := by
+      simpa using hZero.norm
+    exact one_ne_zero (tendsto_nhds_unique hCrossNorm hZeroNorm)
+  · refine ⟨ζ⁻¹, ?_, ?_⟩
+    · rw [norm_inv, hζ, inv_one]
+    · intro N _hN σ
+      have hζ0 : ζ ≠ 0 := by
+        intro h
+        simp [h] at hζ
+      have hComponent := congrArg (fun v : MPVSpace d N ↦ v σ) (hState N)
+      simp only [mpvState_apply, PiLp.smul_apply, smul_eq_mul] at hComponent
+      rw [hComponent, ← mul_assoc, ← mul_pow, inv_mul_cancel₀ hζ0, one_pow, one_mul]
 
 end MPSTensor

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -525,12 +525,9 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
     \label{thm:normal_proportional_mpv_geometric_phase}
     \lean{MPSTensor.EventuallyNonzeroProportionalMPV₂.%
         exists_unit_phase_power_of_isNormalTensor}
-    \lean{MPSTensor.NonzeroProportionalMPV₂.%
-        exists_unit_phase_power_of_isNormalTensor}
     \leanok
     \uses{def:nt_cpsv, def:mpv_state,
-        def:eventually_nonzero_proportional_mpv,
-        def:nonzero_proportional_mpv}
+        def:eventually_nonzero_proportional_mpv}
     Let $A$ and $B$ be normal tensors of positive, possibly different, bond
     dimensions. Suppose that, for all sufficiently large $N$, their matrix
     product vectors are proportional by a nonzero scalar. Then there is
@@ -540,21 +537,48 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
     \]
     This is the one-normal-block consequence of
     \cite[Corollary~A.3 and the proof of Theorem~2.10]{Cirac2016MPDO_arXiv}.
-    It determines the unit-phase part for normalized normal blocks; it does
-    not supply the positive geometric rescaling needed to eliminate the
-    positive finite-chain coefficient in equation \texttt{sigmaNK2}.
+    % Maintainer note: this determines only the unit-phase part for normalized
+    % normal blocks. The distinct positive-rescaling problem is recorded in
+    % docs/paper-gaps/cpsv16_commuting_form_to_sal.tex.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{thm:eventual_proportional_normalized_overlap_norm_one,
-        thm:cpsv_normal_mpv_phase_alternative}
-    Normality gives self-overlap limits equal to one, so
+        thm:cpsv_normal_mpv_phase_alternative,
+        thm:cpsv_normal_mpv_phase_gauge}
+    Normality gives $O_{AA}(N)\to1$ and $O_{BB}(N)\to1$, so
     Theorem~\ref{thm:eventual_proportional_normalized_overlap_norm_one} gives
     $|O_{AB}(N)|\to1$. The decaying alternative in
     Theorem~\ref{thm:cpsv_normal_mpv_phase_alternative} is therefore
     impossible. In the remaining alternative,
     $\ket{V^{(N)}(B)}=\zeta^N\ket{V^{(N)}(A)}$ with $|\zeta|=1$; take
     $a=\zeta^{-1}$.
+\end{proof}
+
+\begin{corollary}[Positive-length geometric proportionality phase]
+    \label{cor:normal_positive_proportional_mpv_geometric_phase}
+    \lean{MPSTensor.NonzeroProportionalMPV₂.%
+        exists_unit_phase_power_of_isNormalTensor}
+    \leanok
+    \uses{def:nt_cpsv, def:mpv_state,
+        def:nonzero_proportional_mpv}
+    Let $A$ and $B$ be normal tensors of positive, possibly different, bond
+    dimensions. Suppose that, for every positive $N$, their matrix product
+    vectors are proportional by a nonzero scalar. Then there is $a\in\C$,
+    with $|a|=1$, such that, for every positive $N$,
+    \[
+        \ket{V^{(N)}(A)}=a^N\ket{V^{(N)}(B)}.
+    \]
+    This is the positive-length one-normal-block consequence of
+    \cite[Corollary~A.3 and Theorem~2.10]{Cirac2016MPDO_arXiv}.
+\end{corollary}
+
+\begin{proof}\leanok
+    \uses{lem:nonzero_proportional_mpv_basic,
+        thm:normal_proportional_mpv_geometric_phase}
+    Positive-length nonzero proportionality implies eventual nonzero
+    proportionality. Apply
+    Theorem~\ref{thm:normal_proportional_mpv_geometric_phase}.
 \end{proof}
 
 \begin{theorem}[Separated normal tensors are eventually independent]

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -523,19 +523,23 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
 
 \begin{theorem}[Geometric proportionality phase for normal tensors]
     \label{thm:normal_proportional_mpv_geometric_phase}
-    \lean{MPSTensor.NonzeroProportionalMPV₂.%
+    \lean{MPSTensor.EventuallyNonzeroProportionalMPV₂.%
         exists_unit_phase_power_of_isNormalTensor}
     \leanok
-    \uses{def:nt_cpsv, def:mpv_state}
+    \uses{def:nt_cpsv, def:mpv_state,
+        def:eventually_nonzero_proportional_mpv}
     Let $A$ and $B$ be normal tensors of positive, possibly different, bond
-    dimensions. Suppose that for every positive $N$ their matrix product
-    vectors are nonzero and proportional. Then there is $a\in\C$, with
-    $|a|=1$, such that, for every positive $N$,
+    dimensions. Suppose that, for all sufficiently large $N$, their matrix
+    product vectors are proportional by a nonzero scalar. Then there is
+    $a\in\C$, with $|a|=1$, such that, for every positive $N$,
     \[
         \ket{V^{(N)}(A)}=a^N\ket{V^{(N)}(B)}.
     \]
     This is the one-normal-block consequence of
     \cite[Corollary~A.3 and the proof of Theorem~2.10]{Cirac2016MPDO_arXiv}.
+    It determines the unit-phase part for normalized normal blocks; it does
+    not supply the positive geometric rescaling needed to eliminate the
+    positive finite-chain coefficient in equation \texttt{sigmaNK2}.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -497,6 +497,59 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
     $\sigma$, and hence the asserted equality of vectors.
 \end{proof}
 
+\begin{theorem}[Unit overlap from eventual proportionality]
+    \label{thm:eventual_proportional_normalized_overlap_norm_one}
+    \lean{MPSTensor.mpvOverlap_norm_tendsto_one_of_eventually_proportionalMPV₂}
+    \leanok
+    \uses{def:mpv_overlap}
+    Let $A$ and $B$ be tensors, possibly with different bond dimensions, whose
+    self-overlaps tend to one. Suppose that, for all sufficiently large $N$,
+    there is $c_N\in\C$ such that
+    \[
+        \ket{V^{(N)}(A)}=c_N\ket{V^{(N)}(B)}.
+    \]
+    Then $|O_{AB}(N)|\to1$.
+\end{theorem}
+
+\begin{proof}\leanok
+    The proportionality relation gives
+    \[
+        O_{AB}(N)=c_NO_{BB}(N),
+        \qquad O_{AA}(N)=|c_N|^2O_{BB}(N).
+    \]
+    Hence $|c_N|^2\to1$ and therefore $|c_N|\to1$.  The first identity now
+    gives $|O_{AB}(N)|\to1$.
+\end{proof}
+
+\begin{theorem}[Geometric proportionality phase for normal tensors]
+    \label{thm:normal_proportional_mpv_geometric_phase}
+    \lean{MPSTensor.NonzeroProportionalMPV₂.%
+        exists_unit_phase_power_of_isNormalTensor}
+    \leanok
+    \uses{def:nt_cpsv, def:mpv_state}
+    Let $A$ and $B$ be normal tensors of positive, possibly different, bond
+    dimensions. Suppose that for every positive $N$ their matrix product
+    vectors are nonzero and proportional. Then there is $a\in\C$, with
+    $|a|=1$, such that, for every positive $N$,
+    \[
+        \ket{V^{(N)}(A)}=a^N\ket{V^{(N)}(B)}.
+    \]
+    This is the one-normal-block consequence of
+    \cite[Corollary~A.3 and the proof of Theorem~2.10]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:eventual_proportional_normalized_overlap_norm_one,
+        thm:cpsv_normal_mpv_phase_alternative}
+    Normality gives self-overlap limits equal to one, so
+    Theorem~\ref{thm:eventual_proportional_normalized_overlap_norm_one} gives
+    $|O_{AB}(N)|\to1$. The decaying alternative in
+    Theorem~\ref{thm:cpsv_normal_mpv_phase_alternative} is therefore
+    impossible. In the remaining alternative,
+    $\ket{V^{(N)}(B)}=\zeta^N\ket{V^{(N)}(A)}$ with $|\zeta|=1$; take
+    $a=\zeta^{-1}$.
+\end{proof}
+
 \begin{theorem}[Separated normal tensors are eventually independent]
     \label{thm:cpsv_normal_separated_eventually_li}
     \lean{MPSTensor.exists_eventually_linearIndependent_of_normalTensor_blocks_not_gaugePhaseEquiv}

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -525,9 +525,12 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
     \label{thm:normal_proportional_mpv_geometric_phase}
     \lean{MPSTensor.EventuallyNonzeroProportionalMPV₂.%
         exists_unit_phase_power_of_isNormalTensor}
+    \lean{MPSTensor.NonzeroProportionalMPV₂.%
+        exists_unit_phase_power_of_isNormalTensor}
     \leanok
     \uses{def:nt_cpsv, def:mpv_state,
-        def:eventually_nonzero_proportional_mpv}
+        def:eventually_nonzero_proportional_mpv,
+        def:nonzero_proportional_mpv}
     Let $A$ and $B$ be normal tensors of positive, possibly different, bond
     dimensions. Suppose that, for all sufficiently large $N$, their matrix
     product vectors are proportional by a nonzero scalar. Then there is

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -548,9 +548,10 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
         thm:cpsv_normal_mpv_phase_gauge}
     Normality gives $O_{AA}(N)\to1$ and $O_{BB}(N)\to1$, so
     Theorem~\ref{thm:eventual_proportional_normalized_overlap_norm_one} gives
-    $|O_{AB}(N)|\to1$. The decaying alternative in
-    Theorem~\ref{thm:cpsv_normal_mpv_phase_alternative} is therefore
-    impossible. In the remaining alternative,
+    $|O_{AB}(N)|\to1$. The first alternative in
+    Theorem~\ref{thm:cpsv_normal_mpv_phase_alternative} gives
+    $O_{AB}(N)\to0$, hence $|O_{AB}(N)|\to0$, a contradiction. In the
+    remaining alternative,
     $\ket{V^{(N)}(B)}=\zeta^N\ket{V^{(N)}(A)}$ with $|\zeta|=1$; take
     $a=\zeta^{-1}$.
 \end{proof}


### PR DESCRIPTION
### Motivation

- The normal single-block part of #4253 requires a theorem showing that the proportionality coefficients of two normal matrix-product families are powers of one phase.
- The source is `Papers/1606.00608/MPDO-22-12-17-2.tex`: Corollary `eqV`, lines 1121--1128, states that two normal tensors either have decaying overlap or satisfy `|V_B^(N)> = exp(i phi N) |V_A^(N)>`; the proof of Theorem `thm1`, lines 1167--1182, uses proportionality to exclude the decaying alternative.

### Description

- Expose the rectangular scalar calculation as `mpvOverlap_norm_tendsto_one_of_eventually_proportionalMPV₂`: eventual proportionality together with the two normalized self-overlap limits forces the cross-overlap norm to tend to one.
- Prove `EventuallyNonzeroProportionalMPV₂.exists_unit_phase_power_of_isNormalTensor` for two normal tensors of possibly different positive bond dimensions. The proof excludes the decaying branch by uniqueness of limits and inverts the phase supplied by the exact normal-tensor phase alternative.
- Re-express the existing irreducible trace-preserving contradiction through the new rectangular overlap theorem, without changing its statement.
- Add matching statements and proofs to Chapter 10 of the blueprint.
- The distinct construction needed to represent the fixed commuting-bond product by a normal matrix-product tensor is recorded in #4271 and is not assumed here.
- This unit-phase theorem does not derive the positive geometric magnitude or the rescaling needed to make CPSV16 equation `sigmaNK2` coefficient-free; those remain part of #4253.

### Testing

- `lake env lean TNLean/MPS/FundamentalTheorem/Proportional.lean`
- `lake env lean TNLean/MPS/Overlap/NormalTensorDichotomy.lean`
- `lake build` (9573 jobs after rebasing onto `a540f68485`)
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch10_bnt.tex`
- `latexindent -k -s -l blueprint/latexindent.yaml blueprint/src/chapter/ch10_bnt.tex > /dev/null`
- `rg -n "sorry|admit|native_decide|unsafeCast|unsafeCoerce|axiom" TNLean/MPS/FundamentalTheorem/Proportional.lean TNLean/MPS/Overlap/NormalTensorDichotomy.lean || true`
- `git diff --check HEAD^ HEAD`

---
Contributes to #4253
Related #4271

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive formal proofs and blueprint text for MPS overlap theory; no auth, I/O, or runtime behavior is affected.
> 
> **Overview**
> Adds **`mpvOverlap_norm_tendsto_one_of_eventually_proportionalMPV₂`**, showing that eventual MPV proportionality plus self-overlaps tending to 1 forces the rectangular cross-overlap modulus to tend to 1, without requiring equal bond dimension. The irreducible trace-preserving “eventually not proportional” argument is refactored to call this lemma and then contradict overlap decay, instead of folding the scalar calculation into a private gauge-phase proof.
> 
> For two **normal** tensors with eventually (or everywhere) nonzero proportional MPVs, new results prove the proportionality scalar is **`a^N`** for a fixed unit phase `a`, by ruling out the decaying overlap branch via the new overlap-norm lemma and inverting the phase from **`mpv_phase_alternative`**. Chapter 10 of the blueprint documents the overlap-norm and geometric-phase statements (with a note that positive rescaling in the commuting-form story remains out of scope).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe6e5ef04a873b0f667ac951774b657aac9c2bae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

