### PR TITLE
doc(tenkz): correct refinement map types

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_normalized_preparations.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_normalized_preparations.tex
@@ -980,37 +980,97 @@
 \end{proof}
 \end{samepage}
 
-On each fixed $(k,h)$-summand, the controlled maps $\mathcal T_0$ and
-$\mathcal S_0$ discard coherences between distinct outer summands and take the
-displayed partial trace in each diagonal summand. In particular,
-$\mathcal S_0$ traces the whole space
+To record the domains and codomains, set
 \[
   \mathcal H^{\Omega}_{k,h}
   =\bigoplus_l
-  \bigl[(R_k\otimes L_l)\otimes(R_l\otimes L_h)\bigr].
+    (B_k^R\otimes B_l^L)\otimes(B_l^R\otimes B_h^L)
 \]
-The shifts $\mathcal S_2$ and $\mathcal T_2$ are global reindexings, with all
-displayed tensor factors present at their inputs
+and introduce the matrix algebras
+\[
+\begin{aligned}
+  \mathcal A_2
+  &=\operatorname{End}\!\left(
+      \left[\bigoplus_j(B_j^L\otimes B_j^R)\right]^{\!\otimes2}\right),
+  &
+  \mathcal A_{\partial}
+  &=\operatorname{End}\!\left(\bigoplus_{k,h}B_k^L\otimes B_h^R\right),\\
+  \mathcal A_{\eta}
+  &=\operatorname{End}\!\left(
+      \bigoplus_{k,h}\bigl[(B_k^L\otimes B_h^R)\otimes
+        (B_k^R\otimes B_h^L)\bigr]\right),
+  &
+  \mathcal A_{\Omega}
+  &=\operatorname{End}\!\left(
+      \bigoplus_{k,h}\bigl[(B_k^L\otimes B_h^R)\otimes
+        \mathcal H^{\Omega}_{k,h}\bigr]\right),\\
+  \mathcal A_3
+  &=\operatorname{End}\!\left(
+      \left[\bigoplus_j(B_j^L\otimes B_j^R)\right]^{\!\otimes3}\right).
+\end{aligned}
+\]
+Thus the global maps have types
+\[
+  \mathcal T_0:\mathcal A_2\to\mathcal A_{\partial},
+  \qquad
+  \mathcal S_2:\mathcal A_{\eta}\to\mathcal A_2,
+  \qquad
+  \mathcal S_0:\mathcal A_3\to\mathcal A_{\partial},
+  \qquad
+  \mathcal T_2:\mathcal A_{\Omega}\to\mathcal A_3.
+\]
+The controlled maps $\mathcal T_0$ and $\mathcal S_0$ discard coherences
+between distinct outer-sector pairs. For fixed $(k,h)$, the global map
+$\mathcal S_0$ traces the entire carrier $\mathcal H^{\Omega}_{k,h}$, including
+its direct sum over $l$. The shifts $\mathcal S_2$ and $\mathcal T_2$ are
+global reindexings, with all displayed tensor factors present at their inputs
 \cite[Appendix~C.2, lines~1521--1559]{Cirac2016MPDO_arXiv}.
 
-For every $(k,h)$, the four fiberwise maps are
-% T_0 : R_2 -> L_k tensor R_h traces R_k tensor L_h.
-% S_2 : (L_k tensor R_h) tensor (R_k tensor L_h) -> R_2 is the inverse
-% regrouping.  S_0 : R_3 -> L_k tensor R_h traces the whole middle block
-% H^Omega_{k,h} = bigoplus_l (R_k tensor L_l) tensor (R_l tensor L_h).
-% T_2 : (L_k tensor R_h) tensor H^Omega_{k,h} -> R_3 restores the ordered
-% three-site sector factors.  Blue line ink denotes a channel; labels
-% distinguish the four maps.  The endpoints are sector spaces, so these
-% strokes are maps between objects rather than contracted tensor indices.
+For the fiberwise maps, write
+\[
+\begin{aligned}
+  \mathcal A_2^{k,h}
+  &=\operatorname{End}\!\left(
+      (B_k^L\otimes B_k^R)\otimes(B_h^L\otimes B_h^R)\right),
+  &
+  \mathcal A_{\partial}^{k,h}
+  &=\operatorname{End}(B_k^L\otimes B_h^R),\\
+  \mathcal A_{\eta}^{k,h}
+  &=\operatorname{End}\!\left(
+      (B_k^L\otimes B_h^R)\otimes(B_k^R\otimes B_h^L)\right),
+  &
+  \mathcal A_{\Omega}^{k,h}
+  &=\operatorname{End}\!\left(
+      (B_k^L\otimes B_h^R)\otimes\mathcal H^{\Omega}_{k,h}\right),\\
+  \mathcal A_3^{k,l,h}
+  &=\operatorname{End}\!\left(
+      (B_k^L\otimes B_k^R)\otimes(B_l^L\otimes B_l^R)
+        \otimes(B_h^L\otimes B_h^R)\right),&\\
+  \mathcal A_3^{k,\bullet,h}
+  &=\operatorname{End}\!\left(\bigoplus_l
+      \bigl[(B_k^L\otimes B_k^R)\otimes(B_l^L\otimes B_l^R)
+        \otimes(B_h^L\otimes B_h^R)\bigr]\right).&
+\end{aligned}
+\]
+The map $\mathcal S_0^{(k,l,h)}$ fixes the middle sector $l$ before taking the
+partial trace; it is therefore distinct from the fixed-$(k,h)$ restriction of
+the global controlled map $\mathcal S_0$. The four fiberwise types are
+% Formula: T_0^(k,h), S_2^(k,h), S_0^(k,l,h), and T_2^(k,h) have the displayed
+% matrix-algebra domains and codomains. Ink: every blue stroke denotes a
+% trace-preserving completely positive map, and its label specifies the map.
 \[
   \begin{tenkzcd}[maps, species={channel}, row sep=6mm]
-    \mathfrak R_2 & L_k\otimes R_h \\
-    (L_k\otimes R_h)\otimes(R_k\otimes L_h) & \mathfrak R_2 \\
-    \mathfrak R_3 & L_k\otimes R_h \\
-    (L_k\otimes R_h)\otimes\mathcal H^{\Omega}_{k,h} & \mathfrak R_3
-    \tnarrow[from={(1,1)}, to={(1,2)}, species=channel]{\mathcal T_0}
-    \tnarrow[from={(2,1)}, to={(2,2)}, species=channel]{\mathcal S_2}
-    \tnarrow[from={(3,1)}, to={(3,2)}, species=channel]{\mathcal S_0}
-    \tnarrow[from={(4,1)}, to={(4,2)}, species=channel]{\mathcal T_2}
+    \mathcal A_2^{k,h} & \mathcal A_{\partial}^{k,h} \\
+    \mathcal A_{\eta}^{k,h} & \mathcal A_2^{k,h} \\
+    \mathcal A_3^{k,l,h} & \mathcal A_{\partial}^{k,h} \\
+    \mathcal A_{\Omega}^{k,h} & \mathcal A_3^{k,\bullet,h}
+    \tnarrow[from={(1,1)}, to={(1,2)}, species=channel]
+      {\mathcal T_0^{(k,h)}}
+    \tnarrow[from={(2,1)}, to={(2,2)}, species=channel]
+      {\mathcal S_2^{(k,h)}}
+    \tnarrow[from={(3,1)}, to={(3,2)}, species=channel]
+      {\mathcal S_0^{(k,l,h)}}
+    \tnarrow[from={(4,1)}, to={(4,2)}, species=channel]
+      {\mathcal T_2^{(k,h)}}
   \end{tenkzcd}
 \]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels.tex
@@ -129,8 +129,8 @@
     this property is preserved under composition.
 \end{proof}
 
-On the active $(k,h)$-sector, $\mathcal T_0$ traces $R_k\otimes L_h$, leaving
-$a_kb_h$ times the operator on $L_k\otimes R_h$. The preparation
+On the active $(k,h)$-sector, $\mathcal T_0$ traces $B_k^R\otimes B_h^L$,
+leaving $a_kb_h$ times the operator on $B_k^L\otimes B_h^R$. The preparation
 $\mathcal T_1$ then adjoins
 \[
   \widehat\Omega_{k,h}
@@ -138,7 +138,8 @@ $\mathcal T_1$ then adjoins
 \]
 and $\mathcal T_2$ orders the result as
 \[
-  (L_k\otimes R_k)\otimes(L_l\otimes R_l)\otimes(L_h\otimes R_h).
+  (B_k^L\otimes B_k^R)\otimes(B_l^L\otimes B_l^R)
+    \otimes(B_h^L\otimes B_h^R).
 \]
 The refinement uses the sitewise sector coordinates $\mathfrak R_2$ and
 $\mathfrak R_3$
@@ -147,35 +148,33 @@ $\mathfrak R_3$
 For each outer pair, write
 \[
   \mathcal H^{\Omega}_{k,h}
-  =\bigoplus_l(R_k\otimes L_l)\otimes(R_l\otimes L_h)
+  =\bigoplus_l(B_k^R\otimes B_l^L)\otimes(B_l^R\otimes B_h^L)
 \]
 for the Hilbert space carrying both $\widehat\Omega_{k,h}$ and its completed
-form $\overline\Omega_{k,h}$. Thus the third object below is the carrier
-space $(L_k\otimes R_h)\otimes\mathcal H^{\Omega}_{k,h}$, while
-$\mathcal T_1$ adjoins the density $\overline\Omega_{k,h}$ on its second
-factor.
+form $\overline\Omega_{k,h}$. With the matrix algebras introduced above, the
+refinement stages have type
 
-% T = T_2 T_1 T_0 maps R_2 through the retained outer factors and the
-% completed neighboring density to R_3.  Each blue stroke has channel
-% species; the labels T_0, T_1, T_2 name the constituent maps.  The fixed
-% left-to-right axis records composition without arrowheads.
+% Formula: T_0 : A_2 -> A_partial, T_1 : A_partial -> A_Omega, and
+% T_2 : A_Omega -> A_3. Ink: each blue stroke denotes a channel, its label
+% names the stage, and the fixed left-to-right axis records composition.
 \[
   \begin{tenkzcd}[maps, species={channel}]
-    \mathfrak R_2 &
-    L_k\otimes R_h &
-    (L_k\otimes R_h)\otimes\mathcal H^{\Omega}_{k,h} &
-    \mathfrak R_3
+    \mathcal A_2 &
+    \mathcal A_{\partial} &
+    \mathcal A_{\Omega} &
+    \mathcal A_3
     \tnarrow[from={(1,1)}, to={(1,2)}, species=channel]{\mathcal T_0}
     \tnarrow[from={(1,2)}, to={(1,3)}, species=channel]{\mathcal T_1}
     \tnarrow[from={(1,3)}, to={(1,4)}, species=channel]{\mathcal T_2}
   \end{tenkzcd}
 \]
-The closure identity is
-% T(R_2(K_2(X))) = R_3(K_3(X)).  Both endpoints are closed sector-coordinate
-% matrices; the blue line is the channel T, not a contracted tensor index.
+Here $\mathcal T_1$ adjoins $\overline\Omega_{k,h}$ on each diagonal
+outer-sector summand. The composite channel has type
+% Formula: T = T_2 T_1 T_0 : A_2 -> A_3. Ink: the blue stroke denotes the
+% composite channel T; its endpoints are matrix algebras, not matrices.
 \[
   \begin{tenkzcd}[maps, species={channel}]
-    \mathfrak R_2(\mathcal K_2(X)) & \mathfrak R_3(\mathcal K_3(X))
+    \mathcal A_2 & \mathcal A_3
     \tnarrow[from={(1,1)}, to={(1,2)}, species=channel]{\mathcal T}
   \end{tenkzcd}
 \]

--- a/docs/tenkz/DESIGN.md
+++ b/docs/tenkz/DESIGN.md
@@ -167,49 +167,89 @@ For the CPSV refinement, the middle-subspin Hilbert space is
 
 \[
   \mathcal H^{\Omega}_{k,h}
-  =\bigoplus_l(R_k\otimes L_l)\otimes(R_l\otimes L_h).
+  =\bigoplus_l(B_k^R\otimes B_l^L)\otimes(B_l^R\otimes B_h^L).
 \]
 
-The notation distinguishes the normalized active density from its total
-completion on this space. On an active pair,
+The neighboring operator and the normalized active density on this space are
 
 \[
-  \widehat\Omega_{k,h}
-  =\frac{1}{a_kb_h}\bigoplus_l
+  \Omega_{k,h}=\bigoplus_l
     (\eta_{k,l}\otimes\eta_{l,h}),
   \qquad
+  \widehat\Omega_{k,h}=\frac{1}{a_kb_h}\Omega_{k,h}.
+\]
+
+On an active pair, the total completion agrees with the normalized density:
+
+\[
   \overline\Omega_{k,h}=\widehat\Omega_{k,h}.
 \]
 
 On an inactive pair, $\overline\Omega_{k,h}$ denotes the chosen positive
 trace-one completion on $\mathcal H^{\Omega}_{k,h}$. A typed-map vertex records
-the carrier Hilbert space, not the density acting on it.
-
-The fiberwise refinement is the composition
+an operator space in the refinement displays below, not a coordinate
+expression, a carrier Hilbert space, or a density acting on that space.
+Introduce the five matrix algebras
 
 \[
-  \mathfrak R_2
-  \xrightarrow{\mathcal T_0}
-  L_k\otimes R_h
-  \xrightarrow{\mathcal T_1}
-  (L_k\otimes R_h)\otimes\mathcal H^{\Omega}_{k,h}
-  \xrightarrow{\mathcal T_2}
-  \mathfrak R_3.
+\begin{aligned}
+  \mathcal A_2
+  &=\operatorname{End}\!\left(
+      \left[\bigoplus_j(B_j^L\otimes B_j^R)\right]^{\!\otimes2}\right),
+  &
+  \mathcal A_{\partial}
+  &=\operatorname{End}\!\left(\bigoplus_{k,h}B_k^L\otimes B_h^R\right),\\
+  \mathcal A_{\eta}
+  &=\operatorname{End}\!\left(
+      \bigoplus_{k,h}\bigl[(B_k^L\otimes B_h^R)\otimes
+        (B_k^R\otimes B_h^L)\bigr]\right),
+  &
+  \mathcal A_{\Omega}
+  &=\operatorname{End}\!\left(
+      \bigoplus_{k,h}\bigl[(B_k^L\otimes B_h^R)\otimes
+        \mathcal H^{\Omega}_{k,h}\bigr]\right),\\
+  \mathcal A_3
+  &=\operatorname{End}\!\left(
+      \left[\bigoplus_j(B_j^L\otimes B_j^R)\right]^{\!\otimes3}\right).
+\end{aligned}
 \]
 
-On a $(k,h)$-summand, $\mathcal T_0$ traces out the factors $R_k\otimes L_h$,
+The global refinement is the composition
+
+\[
+  \mathcal A_2
+  \xrightarrow{\mathcal T_0}
+  \mathcal A_{\partial}
+  \xrightarrow{\mathcal T_1}
+  \mathcal A_{\Omega}
+  \xrightarrow{\mathcal T_2}
+  \mathcal A_3.
+\]
+
+On a $(k,h)$-summand, $\mathcal T_0$ traces out the factors
+$B_k^R\otimes B_h^L$,
 $\mathcal T_1$ sends $X$ to $X\otimes\overline\Omega_{k,h}$, and
 $\mathcal T_2$ reorders the subspin factors into the three output sites.
 Consequently $\mathcal T=\mathcal T_2\mathcal T_1\mathcal T_0$. In `tenkzcd`
 this is written as follows.
 
+The companion global maps have types
+$\mathcal S_0:\mathcal A_3\to\mathcal A_{\partial}$ and
+$\mathcal S_2:\mathcal A_{\eta}\to\mathcal A_2$. On a fixed outer pair,
+$\mathcal S_0$ traces the full direct sum $\mathcal H^{\Omega}_{k,h}$; the
+sectorwise map $\mathcal S_0^{(k,l,h)}$ instead fixes $l$ before taking the
+partial trace.
+
 ```latex
+% Formula: T_0 : A_2 -> A_partial, T_1 : A_partial -> A_Omega, and
+% T_2 : A_Omega -> A_3. Ink: every blue stroke denotes a channel, its label
+% names the stage, and composition runs left-to-right.
 \[
 \begin{tenkzcd}[maps, species={channel}]
-  \mathfrak R_2 &
-  L_k\otimes R_h &
-  (L_k\otimes R_h)\otimes\mathcal H^{\Omega}_{k,h} &
-  \mathfrak R_3
+  \mathcal A_2 &
+  \mathcal A_{\partial} &
+  \mathcal A_{\Omega} &
+  \mathcal A_3
   \tnarrow[from={(1,1)}, to={(1,2)}, species=channel]{\mathcal T_0}
   \tnarrow[from={(1,2)}, to={(1,3)}, species=channel]{\mathcal T_1}
   \tnarrow[from={(1,3)}, to={(1,4)}, species=channel]{\mathcal T_2}

--- a/tex/tenkz/examples/typed-maps.tex
+++ b/tex/tenkz/examples/typed-maps.tex
@@ -4,11 +4,11 @@
 
 \begin{document}
 
-% T maps the open two-site MPDO tensor network to the open three-site
-% MPDO tensor network, while S maps the three-site network back to the
-% two-site network.  Each K has one virtual index on each horizontal side
-% and one ket/bra pair vertically.  Each blue channel line lies between
-% two complete tensor-network objects; it is not an additional contraction.
+% Formula: T maps the open two-site MPDO network to the open three-site
+% network, while S maps the three-site network back to the two-site network.
+% Ink: each K has one virtual index on each horizontal side and one ket/bra
+% pair vertically; each blue line is a channel between complete networks,
+% not an additional tensor contraction.
 \[
   \begin{tenkzcd}[maps, species={channel}, column sep=10mm, row sep=8mm]
     \tnpic[inline, physical=updown]{
@@ -28,17 +28,17 @@
   \end{tenkzcd}
 \]
 
-% H^Omega_{k,h} is the middle-subspin Hilbert space.  The normalized active
-% density and its completed extension act on this space and are adjoined by T_1.
+% H^Omega_{k,h} is the middle-subspin Hilbert space. Omega_{k,h}, its
+% normalized active density, and its completed density are operators on it.
 \[
   \mathcal H^{\Omega}_{k,h}
-  =\bigoplus_l(R_k\otimes L_l)\otimes(R_l\otimes L_h).
+  =\bigoplus_l(B_k^R\otimes B_l^L)\otimes(B_l^R\otimes B_h^L),
+  \qquad
+  \Omega_{k,h}=\bigoplus_l(\eta_{k,l}\otimes\eta_{l,h}).
 \]
 On an active pair, let
 \[
-  \widehat\Omega_{k,h}
-  =\frac{1}{a_kb_h}\bigoplus_l
-    (\eta_{k,l}\otimes\eta_{l,h}),
+  \widehat\Omega_{k,h}=\frac{1}{a_kb_h}\Omega_{k,h},
   \qquad
   \overline\Omega_{k,h}=\widehat\Omega_{k,h}.
 \]
@@ -51,45 +51,110 @@ trace-one density on $\mathcal H^{\Omega}_{k,h}$.  Thus, in every case,
   \operatorname{tr}(\overline\Omega_{k,h})=1.
 \]
 
-% T = T_2 T_1 T_0 maps the two-site sector coordinates R_2 to the
-% three-site sector coordinates R_3.  Composition runs left-to-right.
-% Every line has species=channel, so line ink records the common CPTP
-% type; T_0, T_1, and T_2 name the constituent maps.
+Define the matrix algebras
+\[
+\begin{aligned}
+  \mathcal A_2
+  &=\operatorname{End}\!\left(
+      \left[\bigoplus_j(B_j^L\otimes B_j^R)\right]^{\!\otimes2}\right),
+  &
+  \mathcal A_{\partial}
+  &=\operatorname{End}\!\left(\bigoplus_{k,h}B_k^L\otimes B_h^R\right),\\
+  \mathcal A_{\eta}
+  &=\operatorname{End}\!\left(
+      \bigoplus_{k,h}\bigl[(B_k^L\otimes B_h^R)\otimes
+        (B_k^R\otimes B_h^L)\bigr]\right),
+  &
+  \mathcal A_{\Omega}
+  &=\operatorname{End}\!\left(
+      \bigoplus_{k,h}\bigl[(B_k^L\otimes B_h^R)\otimes
+        \mathcal H^{\Omega}_{k,h}\bigr]\right),\\
+  \mathcal A_3
+  &=\operatorname{End}\!\left(
+      \left[\bigoplus_j(B_j^L\otimes B_j^R)\right]^{\!\otimes3}\right).
+\end{aligned}
+\]
+
+% Formula: T_0 : A_2 -> A_partial, T_1 : A_partial -> A_Omega, and
+% T_2 : A_Omega -> A_3. Ink: every blue stroke denotes a CPTP map, its label
+% names the stage, and composition runs left-to-right.
 \[
   \begin{tenkzcd}[maps, species={channel}]
-    \mathfrak R_2 &
-    L_k\otimes R_h &
-    (L_k\otimes R_h)\otimes\mathcal H^{\Omega}_{k,h} &
-    \mathfrak R_3
+    \mathcal A_2 &
+    \mathcal A_{\partial} &
+    \mathcal A_{\Omega} &
+    \mathcal A_3
     \tnarrow[from={(1,1)}, to={(1,2)}, species=channel]{\mathcal T_0}
     \tnarrow[from={(1,2)}, to={(1,3)}, species=channel]{\mathcal T_1}
     \tnarrow[from={(1,3)}, to={(1,4)}, species=channel]{\mathcal T_2}
   \end{tenkzcd}
 \]
 
-% Four fiberwise maps, one map per row.  Each row spells its complete
-% domain and codomain; the parameters k and h remain symbolic.
+For the fiberwise maps, write
+\[
+\begin{aligned}
+  \mathcal A_2^{k,h}
+  &=\operatorname{End}\!\left(
+      (B_k^L\otimes B_k^R)\otimes(B_h^L\otimes B_h^R)\right),
+  &
+  \mathcal A_{\partial}^{k,h}
+  &=\operatorname{End}(B_k^L\otimes B_h^R),\\
+  \mathcal A_{\eta}^{k,h}
+  &=\operatorname{End}\!\left(
+      (B_k^L\otimes B_h^R)\otimes(B_k^R\otimes B_h^L)\right),
+  &
+  \mathcal A_{\Omega}^{k,h}
+  &=\operatorname{End}\!\left(
+      (B_k^L\otimes B_h^R)\otimes\mathcal H^{\Omega}_{k,h}\right),\\
+  \mathcal A_3^{k,l,h}
+  &=\operatorname{End}\!\left(
+      (B_k^L\otimes B_k^R)\otimes(B_l^L\otimes B_l^R)
+        \otimes(B_h^L\otimes B_h^R)\right),&\\
+  \mathcal A_3^{k,\bullet,h}
+  &=\operatorname{End}\!\left(\bigoplus_l
+      \bigl[(B_k^L\otimes B_k^R)\otimes(B_l^L\otimes B_l^R)
+        \otimes(B_h^L\otimes B_h^R)\bigr]\right).&
+\end{aligned}
+\]
+
+The global controlled map
+$\mathcal S_0:\mathcal A_3\to\mathcal A_{\partial}$ traces the whole direct
+sum $\mathcal H^{\Omega}_{k,h}$ on a fixed outer pair. The sectorwise map
+$\mathcal S_0^{(k,l,h)}$ in the third row below fixes the middle sector $l$.
+
+% Formula: the four rows give the exact types of T_0^(k,h), S_2^(k,h),
+% S_0^(k,l,h), and T_2^(k,h). Ink: every blue stroke denotes a CPTP map,
+% and its label records which fixed sectors define that map.
 \[
   \begin{tenkzcd}[maps, species={channel}]
-    \mathfrak R_2 & L_k\otimes R_h \\
-    (L_k\otimes R_h)\otimes(R_k\otimes L_h) & \mathfrak R_2 \\
-    \mathfrak R_3 & L_k\otimes R_h \\
-    (L_k\otimes R_h)\otimes\mathcal H^{\Omega}_{k,h} & \mathfrak R_3
-    \tnarrow[from={(1,1)}, to={(1,2)}, species=channel]{\mathcal T_0}
-    \tnarrow[from={(2,1)}, to={(2,2)}, species=channel]{\mathcal S_2}
-    \tnarrow[from={(3,1)}, to={(3,2)}, species=channel]{\mathcal S_0}
-    \tnarrow[from={(4,1)}, to={(4,2)}, species=channel]{\mathcal T_2}
+    \mathcal A_2^{k,h} & \mathcal A_{\partial}^{k,h} \\
+    \mathcal A_{\eta}^{k,h} & \mathcal A_2^{k,h} \\
+    \mathcal A_3^{k,l,h} & \mathcal A_{\partial}^{k,h} \\
+    \mathcal A_{\Omega}^{k,h} & \mathcal A_3^{k,\bullet,h}
+    \tnarrow[from={(1,1)}, to={(1,2)}, species=channel]
+      {\mathcal T_0^{(k,h)}}
+    \tnarrow[from={(2,1)}, to={(2,2)}, species=channel]
+      {\mathcal S_2^{(k,h)}}
+    \tnarrow[from={(3,1)}, to={(3,2)}, species=channel]
+      {\mathcal S_0^{(k,l,h)}}
+    \tnarrow[from={(4,1)}, to={(4,2)}, species=channel]
+      {\mathcal T_2^{(k,h)}}
   \end{tenkzcd}
 \]
 
-% T(R_2(K_2(X))) = R_3(K_3(X)); the channel line is the map T and the
-% two endpoints are closed sector-coordinate matrices.
-The refinement identity is
-\(
-  \begin{tenkzcd}[maps, inline, species={channel}]
-    \mathfrak R_2({\cal K}_2(X)) & \mathfrak R_3({\cal K}_3(X))
+% Formula: T = T_2 T_1 T_0 : A_2 -> A_3. Ink: the blue stroke denotes the
+% composite channel T, and its endpoints are the two matrix algebras.
+The composite channel has type
+\[
+  \begin{tenkzcd}[maps, species={channel}]
+    \mathcal A_2 & \mathcal A_3
     \tnarrow[from={(1,1)}, to={(1,2)}, species=channel]{\mathcal T}
   \end{tenkzcd}
-\).
+\]
+and the refinement identity is the equality
+\[
+  \mathcal T\bigl(\mathfrak R_2({\cal K}_2(X))\bigr)
+  =\mathfrak R_3({\cal K}_3(X)).
+\]
 
 \end{document}


### PR DESCRIPTION
## Summary

- correct the refinement displays so their vertices are matrix algebras rather than coordinate expressions, Hilbert-space carriers, or density operators
- state the global chain A₂ → A∂ → AΩ → A₃ and the exact fibrewise domains and codomains of T₀, S₂, S₀, and T₂
- separate the fixed-l map S₀^(k,l,h) from the fixed-(k,h) restriction of the global controlled S₀, which traces the full direct sum over l
- distinguish Ω, its normalized active form, its completed trace-one form, and the carrier HΩ
- state the composite type A₂ → A₃ separately from the refinement equality T(R₂(K₂(X))) = R₃(K₃(X))

The correction follows CPSV16 Appendix C.2, lines 1510–1559, and the established Lean types for the boundary, preparation, and regrouping indices. It changes only the two blueprint chapters, the tenkz design note, and the standalone typed-map example; no rendering convention or implementation is changed.

## Verification

- standalone XeLaTeX compilation and tenkz audit: 8 pictures, no errors or advisories
- affected blueprint pages rendered and inspected in the complete 650-page PDF
- blueprint web generation
- tenkz lint and reader-facing prose check
- full tensor-network audit and smoke render
- lake build TNLean
- blueprint declaration synchronization and checkdecls

Closes LionSR/tenkz#33

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> LaTeX and design-doc edits only; no runtime, API, or build logic changes.
> 
> **Overview**
> **Documentation-only fix** for CPSV MPDO refinement **typed-map** (`tenkzcd[maps]`) figures: diagram **vertices are matrix algebras** (`\mathcal A_2`, `\mathcal A_{\partial}`, `\mathcal A_{\Omega}`, `\mathcal A_3`, and fiberwise variants), not sector coordinates (`\mathfrak R_2`), raw tensor factors (`L_k\otimes R_h`), carriers, or density operators.
> 
> The prose now **defines** `\mathcal H^{\Omega}_{k,h}` and the five global algebras, states **global map types** (`\mathcal T_0`, `\mathcal S_2`, `\mathcal S_0`, `\mathcal T_2`) and the **refinement chain** `\mathcal A_2 \to \mathcal A_{\partial} \to \mathcal A_{\Omega} \to \mathcal A_3`, and rewrites fiberwise rows with superscripts and **`\mathcal S_0^{(k,l,h)}` vs global `\mathcal S_0`** (full sum over `l` vs fixed middle sector). Notation shifts from `R_k`/`L_h` to **`B_k^R`/`B_h^L`** where those diagrams are updated.
> 
> **`\Omega_{k,h}`**, **`\widehat\Omega_{k,h}`**, and **`\overline\Omega_{k,h}`** are separated from the Hilbert carrier. The composite type **`\mathcal T:\mathcal A_2\to\mathcal A_3`** is shown apart from the refinement identity **`T(R_2(K_2(X)))=R_3(K_3(X))`**.
> 
> Touches two blueprint chapters, `docs/tenkz/DESIGN.md`, and `tex/tenkz/examples/typed-maps.tex`; **no tenkz rendering or implementation changes**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b46b66bf6f1b787347238ffb916d599cf29cab85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->