### PR TITLE
feat(Channel/FixedPoint): classify the full-support adjoint projection

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -201,6 +201,7 @@ import TNLean.Channel.FixedPoint.ChoiEffros
 import TNLean.Channel.FixedPoint.Cesaro
 import TNLean.Channel.FixedPoint.MeanErgodicProjection
 import TNLean.Channel.FixedPoint.MeanErgodicAdjoint
+import TNLean.Channel.FixedPoint.FullSupportBlockRetraction
 import TNLean.Channel.FixedPoint.CornerAlgebra
 import TNLean.Channel.FixedPoint.CornerBlockForm
 import TNLean.Channel.FixedPoint.CornerFixedPoints

--- a/TNLean/Channel/FixedPoint/FullSupportBlockRetraction.lean
+++ b/TNLean/Channel/FixedPoint/FullSupportBlockRetraction.lean
@@ -1,0 +1,123 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.FixedPoint.AbstractAlgebra
+import TNLean.Channel.FixedPoint.MeanErgodicAdjoint
+import TNLean.Channel.PositiveConditionalExpectationDirectSum
+
+/-!
+# Block form of the adjoint fixed-point projection on full support
+
+Let $T$ be positive and trace preserving, suppose that $T^*$ satisfies the
+Schwarz inequality, and suppose that $T$ has a positive-definite fixed point.
+The trace adjoint of the mean-ergodic projection of $T$ is then a positive
+retraction onto the fixed-point star-algebra of $T^*$.  Wolf's classification
+of positive retractions therefore gives its weighted partial-trace block form.
+
+This is the full-support part of the proof of Wolf's Theorem 6.14.  Taking the
+trace adjoint of the resulting formula identifies the fixed points of $T$;
+the general theorem also requires restriction to the support of a
+maximum-rank fixed point and the adjoining of the complementary zero block.
+
+## References
+
+* M. Wolf, *Quantum Channels & Operations: Guided Tour*, Theorem 6.14 and
+  Equations (1.40), (6.63); local source
+  `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1483--1494.
+-/
+
+open scoped Matrix Matrix.Norms.Frobenius ComplexOrder MatrixOrder Kronecker
+
+noncomputable section
+
+variable {D : ℕ}
+
+/-- **Weighted block form of the adjoint Cesàro projection on full support.**
+
+Let $T:M_D(\mathbb C)\to M_D(\mathbb C)$ be positive and trace preserving,
+suppose that $T^*$ satisfies the Schwarz inequality, and let $\rho>0$ satisfy
+$T(\rho)=\rho$.  Then the trace adjoint $P_T^*$ of the mean-ergodic projection
+is a positive retraction onto $\operatorname{Fix}(T^*)$, and hence has the
+weighted partial-trace form of Wolf, Equation (1.40).
+
+This is the full-support retraction step in the proof of Wolf's Theorem 6.14,
+local source `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines
+1483--1492.
+
+**Scope restriction (full support):** The general theorem first restricts to
+the support of a maximum-rank fixed point and later adjoins its orthogonal
+complement as the zero block.  Here the fixed point is assumed positive
+definite on the ambient space.  The support reduction and zero-block
+construction are documented in
+`docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex`. -/
+theorem IsPositiveMap.exists_block_densities_of_adjoint_meanErgodicProjection
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT : IsPositiveMap T) (hTP : IsTracePreservingMap T)
+    (hSchwarz : IsSchwarzMap (Matrix.traceAdjointMap T))
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (hρ : ρ.PosDef) (hρfix : T ρ = ρ) :
+    let Pstar := Matrix.traceAdjointMap
+      (LinearMap.meanErgodicProjection (𝕜 := ℂ)
+        (E := Matrix (Fin D) (Fin D) ℂ) T
+        (hT.hasBoundedOrbits_of_tracePreserving hTP))
+    ∃ (K : ℕ) (d m : Fin K → ℕ)
+      (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin D)
+      (U : Matrix (Fin D) (Fin D) ℂ)
+      (σ : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ),
+      U ∈ Matrix.unitaryGroup (Fin D) ℂ ∧
+        (∀ k, 0 < d k) ∧ (∀ k, 0 < m k) ∧
+        (∀ A : Matrix (Fin D) (Fin D) ℂ,
+          Matrix.traceAdjointMap T A = A ↔
+            ∃ B : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ,
+              star U * A * U = Matrix.reindex e e
+                (Matrix.blockDiagonal' fun k ↦
+                  (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ B k)) ∧
+        (∀ k, (σ k).PosSemidef) ∧ (∀ k, (σ k).trace = 1) ∧
+        ∀ A, Pstar A = U * Matrix.reindex e e
+          (Matrix.blockDiagonal' fun k ↦
+            (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ
+              Matrix.partialTraceLeft
+                (((σ k) ⊗ₖ (1 : Matrix (Fin (d k)) (Fin (d k)) ℂ)) *
+                  Matrix.directSumBlockCompression (m := m) (d := d) k
+                    (Matrix.reindex e.symm e.symm (star U * A * U)))) * star U := by
+  dsimp only
+  let E := Matrix.traceAdjointMap T
+  have hEpos : IsPositiveMap E := hT.traceAdjointMap
+  have hEone : E 1 = 1 := by
+    simpa only [E] using isTracePreservingMap_iff_traceAdjointMap_one.mp hTP
+  have hEschwarz : IsSchwarzMap E := by
+    simpa only [E] using hSchwarz
+  have hρfix' : Matrix.traceAdjointMap E ρ = ρ := by
+    dsimp only [E]
+    rw [Matrix.traceAdjointMap_traceAdjointMap, hρfix]
+  let S := SchwarzMap.fixedPointsStarSubalgebra E hEpos hEone hEschwarz hρ hρfix'
+  have hRetraction :=
+    hT.traceAdjoint_meanErgodicProjection_isPositiveUnitalRetraction hTP
+  dsimp only at hRetraction
+  obtain ⟨hPpos, _, hPidemp, _, hPfixed⟩ := hRetraction
+  have hRange (A : Matrix (Fin D) (Fin D) ℂ) :
+      Matrix.traceAdjointMap
+          (LinearMap.meanErgodicProjection T
+            (hT.hasBoundedOrbits_of_tracePreserving hTP)) A ∈ S := by
+    dsimp only [S]
+    rw [SchwarzMap.mem_fixedPointsStarSubalgebra]
+    exact (hPfixed _).mp (hPidemp A)
+  have hFix (A : Matrix (Fin D) (Fin D) ℂ) (hA : A ∈ S) :
+      Matrix.traceAdjointMap
+          (LinearMap.meanErgodicProjection T
+            (hT.hasBoundedOrbits_of_tracePreserving hTP)) A = A := by
+    dsimp only [S] at hA
+    rw [SchwarzMap.mem_fixedPointsStarSubalgebra] at hA
+    exact (hPfixed A).mpr hA
+  obtain ⟨K, d, m, e, U, σ, hU, hd, hm, hBlock, hσpos, hσtrace, hFormula⟩ :=
+    S.exists_block_densities_of_positive_retraction
+      (Matrix.traceAdjointMap
+        (LinearMap.meanErgodicProjection T
+          (hT.hasBoundedOrbits_of_tracePreserving hTP)))
+      hPpos hRange hFix
+  refine ⟨K, d, m, e, U, σ, hU, hd, hm, ?_, hσpos, hσtrace, hFormula⟩
+  intro A
+  rw [← hBlock A]
+  dsimp only [S]
+  rw [SchwarzMap.mem_fixedPointsStarSubalgebra]

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -8,6 +8,7 @@ import TNLean.Channel.FixedPoint.Algebra
 import TNLean.Channel.FixedPoint.Cesaro
 import TNLean.Channel.FixedPoint.MeanErgodicProjection
 import TNLean.Channel.FixedPoint.MeanErgodicAdjoint
+import TNLean.Channel.FixedPoint.FullSupportBlockRetraction
 import TNLean.Channel.FixedPoint.ConditionalExpectation
 import TNLean.Channel.FixedPoint.StationarySupport
 import TNLean.Channel.FixedPoint.CornerFixedPoints
@@ -301,8 +302,17 @@ well.
 The trace-pairing adjoint step is now complete.  The adjoint of the
 mean-ergodic projection is a positive unital idempotent retraction onto the
 fixed-point space of the adjoint endomorphism.  The remaining step for
-Theorem 6.14 is to combine this retraction with the full-support star-algebra
-description.
+Theorem 6.14 begins by combining this retraction with the full-support
+star-algebra description.
+
+In `TNLean.Channel.FixedPoint.FullSupportBlockRetraction`:
+
+* `IsPositiveMap.exists_block_densities_of_adjoint_meanErgodicProjection` —
+  when the positive trace-preserving map has a positive definite fixed point
+  and its trace adjoint satisfies the Schwarz inequality, the adjoint
+  mean-ergodic projection is a positive retraction onto the adjoint
+  fixed-point star-algebra and has the weighted partial-trace block form of
+  Wolf Equation (1.40).
 
 In `TNLean.Channel.FixedPoint.WedderburnDecomp`:
 
@@ -339,9 +349,10 @@ positive semidefinite fixed point):
   corner-restricted set only; extending by zero on the complement does not
   produce ambient fixed points in general.
 
-What is still missing for the full Wolf statement is the identification of
-the ambient fixed-point space with the zero-block form and the density-block
-refinement with matrices `ρ_k` for the Schrödinger-picture fixed points.
+What is still missing for the full Wolf statement is to take the trace adjoint
+of the weighted retraction formula, identify the Schrödinger-picture fixed
+points with the resulting density blocks, and transport the support-sector
+formula back to the ambient space with the complementary zero block.
 
 ### Wolf Corollary 6.7 (faithful fixed-point conjugation) — FORMALIZED (Kraus case)
 

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2494,6 +2494,48 @@ $\bigoplus_k \Id_{m_k} \otimes \MN{d_k}$.
     supplies the unitary and the equivalence.
 \end{proof}
 
+% Scope restriction documented in
+% docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex.
+\begin{theorem}[Weighted block form of the adjoint Ces\`aro projection on full support]%
+    \label{thm:adjoint_mean_ergodic_projection_weighted_block_form}
+    \lean{IsPositiveMap.exists_block_densities_of_adjoint_meanErgodicProjection}
+    \leanok
+    \uses{thm:positive_unital_adjoint_mean_ergodic_retraction,
+        thm:fixedPointsStarSubalgebra,
+        thm:positive_retraction_finite_star_algebra}
+    Let $T:\MN{D}\to\MN{D}$ be positive and trace preserving, suppose that
+    $T^*$ satisfies the Schwarz inequality, and suppose that there is a
+    positive definite matrix $\rho$ satisfying $T(\rho)=\rho$.  Let $P_T$ be
+    the mean-ergodic projection of $T$.  There are positive integers $d_k,m_k$,
+    a unitary $U$, and density matrices $\sigma_k\in\MN{m_k}$ such that
+    \[
+        U^*\operatorname{Fix}(T^*)U
+        =\bigoplus_k\Id_{m_k}\otimes\MN{d_k}
+    \]
+    and, for every $A\in\MN{D}$,
+    \[
+        P_T^*(A)=U\left(\bigoplus_k\Id_{m_k}\otimes
+        \operatorname{tr}_{m_k}\!\left(
+          (\sigma_k\otimes\Id_{d_k})(U^*AU)_{kk}\right)\right)U^*.
+    \]
+    This is the full-support conditional-expectation step in the proof of
+    \cite[Theorem~6.14]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:positive_unital_adjoint_mean_ergodic_retraction,
+        thm:fixedPointsStarSubalgebra,
+        thm:positive_retraction_finite_star_algebra}
+    The map $P_T^*$ is a positive unital idempotent map whose range is
+    $\operatorname{Fix}(T^*)$.  The positive definite fixed point of $T$ is a
+    faithful invariant weight for $T^*$, so the Schwarz equality argument
+    makes $\operatorname{Fix}(T^*)$ a $*$-subalgebra.  Thus $P_T^*$ is a
+    positive retraction onto this subalgebra.  The blockwise classification of
+    positive retractions gives the unitary, the matrix dimensions, the
+    density matrices $\sigma_k$, and the displayed formula.
+\end{proof}
+
 Without a full-rank hypothesis on the fixed point, the corner-restricted fixed-point
 $*$-algebra of Theorem~\ref{thm:cornerFixedPointsStarSubalgebra} still carries the block
 structure through the compression onto the support sector; this is the

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2528,12 +2528,19 @@ $\bigoplus_k \Id_{m_k} \otimes \MN{d_k}$.
         thm:fixedPointsStarSubalgebra,
         thm:positive_retraction_finite_star_algebra}
     The map $P_T^*$ is a positive unital idempotent map whose range is
-    $\operatorname{Fix}(T^*)$.  The positive definite fixed point of $T$ is a
-    faithful invariant weight for $T^*$, so the Schwarz equality argument
-    makes $\operatorname{Fix}(T^*)$ a $*$-subalgebra.  Thus $P_T^*$ is a
-    positive retraction onto this subalgebra.  The blockwise classification of
-    positive retractions gives the unitary, the matrix dimensions, the
-    density matrices $\sigma_k$, and the displayed formula.
+    $\operatorname{Fix}(T^*)$.  For $A\in\operatorname{Fix}(T^*)$, the
+    Schwarz inequality gives
+    $T^*(A^*A)\geq T^*(A)^*T^*(A)=A^*A$, while
+    \[
+        \operatorname{tr}\!\left(\rho T^*(A^*A)\right)
+        =\operatorname{tr}\!\left(T(\rho)A^*A\right)
+        =\operatorname{tr}(\rho A^*A).
+    \]
+    Since $\rho$ is positive definite, these relations imply
+    $T^*(A^*A)=A^*A$.  Hence $\operatorname{Fix}(T^*)$ is a $*$-subalgebra,
+    and $P_T^*$ is a positive retraction onto it.  The blockwise
+    classification of positive retractions gives the unitary, the matrix
+    dimensions, the density matrices $\sigma_k$, and the displayed formula.
 \end{proof}
 
 Without a full-rank hypothesis on the fixed point, the corner-restricted fixed-point

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -49,9 +49,12 @@ For MPDO renormalization fixed points:
   density-weighted fixed-point argument in Appendix C.4. The full-support
   adjoint Cesàro projection now has Wolf's weighted partial-trace block form;
   taking its trace adjoint, reducing to support, and proving the transported
-  maps trace preserving on the full sector algebras remain open. The note also
-  records that sector relabelling follows from mutually inverse positive
-  trace-preserving maps, not from a bare linear equivalence.
+  maps trace preserving on the full sector algebras remain open. Since those
+  algebras are direct sums rather than full matrix algebras, the application
+  also needs a block-diagonal full-matrix extension or a direct-sum version of
+  the fixed-point theorem. The note also records that sector relabelling
+  follows from mutually inverse positive trace-preserving maps, not from a
+  bare linear equivalence.
 - `cpsv16_simple_tensor_nilpotency.tex` identifies the source's nilpotent BNT
   elements with nilpotent physical-trace transfer matrices and records the
   positive physical blocking and chosen-BNT interpretation of the

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -45,10 +45,13 @@ unless they are cited by one of the current blueprint chapters above.
 For MPDO renormalization fixed points:
 
 - `cpsv16_vertical_sector_invertibility.tex` separates the proved fixed
-  contraction families and product-generation theorem from the missing
-  density-weighted fixed-point argument in Appendix C.4. It also records that
-  sector relabelling follows from mutually inverse positive trace-preserving
-  maps, not from a bare linear equivalence.
+  contraction families and product-generation theorem from the remaining
+  density-weighted fixed-point argument in Appendix C.4. The full-support
+  adjoint Cesàro projection now has Wolf's weighted partial-trace block form;
+  taking its trace adjoint, reducing to support, and proving the transported
+  maps trace preserving on the full sector algebras remain open. The note also
+  records that sector relabelling follows from mutually inverse positive
+  trace-preserving maps, not from a bare linear equivalence.
 - `cpsv16_simple_tensor_nilpotency.tex` identifies the source's nilpotent BNT
   elements with nilpotent physical-trace transfer matrices and records the
   positive physical blocking and chosen-BNT interpretation of the

--- a/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
+++ b/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
@@ -113,9 +113,11 @@ density-weighted form of $\mathcal F$.
 The positive trace-preserving mean-ergodic retraction on a full matrix algebra
 and its positive unital trace-adjoint retraction onto the adjoint fixed-point
 space are formalized.  Their construction uses no bounded-orbit hypothesis on
-the adjoint map.  The general density-weighted form of Wolf's Theorem~6.14 in
-the Schr\"odinger picture is not yet assembled.  Its precise boundary is
-recorded in
+the adjoint map.  On full support, the adjoint retraction is now identified
+with the weighted partial-trace block form of Wolf's Proposition~1.5.  The
+trace-adjoint calculation giving the Schr\"odinger-picture density blocks and
+the support reduction producing the zero summand of Wolf's Theorem~6.14 are
+not yet assembled.  Their precise boundary is recorded in
 \path{docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex}.  For
 the transported sector maps one must also prove the channel hypotheses on the
 full direct sums, rather than only on the contraction families.  In the

--- a/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
+++ b/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
@@ -126,6 +126,15 @@ trace preserving precisely when the precompression output lies in its active
 image.  The established image identity is restricted to the source-generated
 contractions.
 
+There is also a domain bridge between the two results.  The present
+full-support theorem concerns an endomorphism of one full matrix algebra,
+whereas the transported composites act on dependent direct sums of matrix
+algebras.  Applying the theorem therefore requires either a trace-preserving
+Schwarz extension through the block-diagonal embedding and block projection,
+with its fixed-point space identified with that of the direct-sum map, or a
+direct-sum version of the fixed-point theorem.  Neither bridge is currently
+formalized.
+
 \section{Sector relabelling uses positivity, not linear isomorphism}
 
 After proving mutual invertibility, CPSV16 cites the argument of
@@ -167,7 +176,9 @@ order:
     \item prove complete positivity and trace preservation of the transported
           maps on the full sector algebras, including the required active-image
           statement for every input;
-    \item formalize the density-weighted fixed-point theorem needed to prove
+    \item complete the density-weighted fixed-point theorem and transfer it to
+          the sector direct sums, either through a block-diagonal full-matrix
+          extension or through a direct-sum theorem, to prove
           $\dim C_L(\mathcal F)\leq\dim\mathcal F$ for the fixed-point spaces
           of $\widetilde S\widetilde T$ and $\widetilde T\widetilde S$;
     \item combine this dimension bound with the fixed contraction families,

--- a/docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex
+++ b/docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex
@@ -74,20 +74,32 @@ The proof uses the complementary decomposition for the original
 mean-ergodic projection and trace-pairing nondegeneracy; it requires no
 bounded-orbit or spectral hypothesis for $T^*$.
 
-Three arguments remain to obtain the fixed-point statement above.  First, the
-Schwarz hypothesis must be used to identify the full-support adjoint
-fixed-point range with a unital $*$-algebra.  Second, the positive
-semidefinite density matrices supplied by Proposition~1.5 must be restricted
-to their supports; this produces the positive definite matrices in
-Theorem~6.14.  Third, the
-discarded kernels must be assembled with the subspace on which every fixed
-point vanishes, thereby recovering the zero summand $\mathcal H_0$.
+The full-support retraction step is also formalized.  If $T$ has a positive
+definite fixed point and $T^*$ satisfies the Schwarz inequality, then the
+Schwarz equality argument makes $\operatorname{Fix}(T^*)$ a unital
+$*$-algebra, and the adjoint mean-ergodic projection is a positive retraction
+onto it.  Applying Proposition~1.5 gives the weighted partial-trace block
+form of this projection.\footnote{Formal declaration:
+\leanid{IsPositiveMap.exists_block_densities_of_adjoint_meanErgodicProjection}
+in
+\doclink{TNLean/Channel/FixedPoint/FullSupportBlockRetraction}.}
+This is the conditional-expectation step in the proof of Theorem~6.14,
+local source lines~1483--1492.
 
-Thus Proposition~1.5 is fully formalized, while Theorem~6.14 remains an open
-gap.  The missing work is not another construction of a fixed-point
-retraction: it is the full-support algebra identification for the completed
-adjoint retraction, the positive-definite support reduction, and the recovery
-of the zero block from the kernels.
+Three arguments remain to obtain the fixed-point statement above.  First, the
+trace adjoint of the weighted partial-trace formula must be calculated and its
+range identified with the Schr\"odinger-picture density blocks.  Second, the
+positive semidefinite density matrices supplied by Proposition~1.5 must be
+restricted to their supports; this produces the positive definite matrices
+in Theorem~6.14.  Third, the discarded kernels must be assembled with the
+subspace on which every fixed point vanishes, thereby recovering the zero
+summand $\mathcal H_0$.
+
+Thus Proposition~1.5 and its application to the full-support adjoint
+mean-ergodic projection are formalized, while Theorem~6.14 remains an open
+gap.  The missing work is the trace-adjoint density-block calculation, the
+positive-definite support reduction, and the recovery of the zero block from
+the kernels.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
### Motivation
- Wolf, *Quantum Channels & Operations*, Theorem 6.14 identifies the fixed points of a positive trace-preserving map satisfying the Schwarz inequality. The local source is `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1467–1494: “The same structure prevails for the fixed point set of any positive trace-preserving map.”
- The proof at lines 1483–1492 first restricts to full support, identifies the adjoint fixed points as a star algebra, and applies the positive-retraction form of Equation (1.40). This is the next unresolved leaf of LionSR/QICLean#219.
- CPSV16 Appendix C.4 invokes this structure at `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 1980–1995, but the transported-map hypotheses required for LionSR/TNLean#4120 remain separate.

### Description
- Adds `IsPositiveMap.exists_block_densities_of_adjoint_meanErgodicProjection`: for a positive trace-preserving map `T`, assuming `T*` is Schwarz and `T` has a positive-definite fixed point, the adjoint Cesàro projection is a positive retraction onto `Fix(T*)` and has Wolf’s weighted partial-trace block form.
- Marks this result explicitly as the full-support step, rather than as the general statement of Wolf Theorem 6.14. It does not assert invertibility or relabelling for the CPSV16 transported sector maps.
- Adds the corresponding blueprint theorem and records the remaining trace-adjoint density-block calculation, support reduction, zero block, and transported-sector channel hypotheses in the paper-gap notes.

### Testing
- `lake env lean TNLean/Channel/FixedPoint/FullSupportBlockRetraction.lean`
- `lake build TNLean.Channel.FixedPoint.FullSupportBlockRetraction`
- `lake build`
- `lake exe lint_style`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast|unsafeCoerce" TNLean/Channel/FixedPoint/FullSupportBlockRetraction.lean || true`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `leanblueprint web`
- `leanblueprint checkdecls`
- `leanblueprint pdf`
- `git diff --check`

---
Addresses LionSR/QICLean#219
Addresses LionSR/TNLean#4120

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formal theorem and documentation only; no changes to auth, runtime behavior, or existing API contracts beyond new imports and index text.
> 
> **Overview**
> Formalizes the **full-support** step toward Wolf Theorem 6.14: when a positive trace-preserving map `T` has a positive-definite fixed point and `T*` is Schwarz, the trace adjoint of the mean-ergodic projection is a positive retraction onto `Fix(T*)` with Wolf’s weighted partial-trace block form (`IsPositiveMap.exists_block_densities_of_adjoint_meanErgodicProjection` in `FullSupportBlockRetraction.lean`).
> 
> The proof uses the existing adjoint mean-ergodic retraction, Schwarz fixed-point star-algebra, and `exists_block_densities_of_positive_retraction`; it is explicitly **not** the general 6.14 statement (support reduction, zero block, Schrödinger density blocks).
> 
> Blueprint `ch07_spectral.tex` gets the matching theorem; `WolfChapter6Index`, root imports, and paper-gap notes are updated to mark this step done and list what remains (trace-adjoint density blocks, support/zero summand, sector direct-sum bridge).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c6df2e23fe86b2ff2ea522d710132855294f3f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->