### PR TITLE
doc(MPS/Overlap): format paper source labels

### DIFF
--- a/TNLean/MPS/Overlap/NormalTensorDichotomy.lean
+++ b/TNLean/MPS/Overlap/NormalTensorDichotomy.lean
@@ -141,8 +141,8 @@ rescaling needed to remove a length-dependent positive coefficient in
 the commuting-form decomposition; the missing rescaling argument is
 documented in `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.
 
-Source: CPSV16, Corollary `eqV`, lines 1121--1128, combined with the one-block
-case of the proportionality hypothesis in Theorem `thm1`, lines 1167--1182;
+Source: CPSV16, Corollary eqV, lines 1121--1128, combined with the one-block
+case of the proportionality hypothesis in Theorem thm1, lines 1167--1182;
 see also arXiv:2011.12127, Theorem IV.4. -/
 theorem EventuallyNonzeroProportionalMPV₂.exists_unit_phase_power_of_isNormalTensor
     [NeZero D₁] [NeZero D₂]
@@ -177,8 +177,8 @@ theorem EventuallyNonzeroProportionalMPV₂.exists_unit_phase_power_of_isNormalT
 /-- Positive-length nonzero proportionality is a sufficient special case of
 the eventual geometric-phase theorem for normal tensors.
 
-Source: CPSV16, Corollary `eqV`, lines 1121--1128, combined with the one-block
-case of the proportionality hypothesis in Theorem `thm1`, lines 1167--1182. -/
+Source: CPSV16, Corollary eqV, lines 1121--1128, combined with the one-block
+case of the proportionality hypothesis in Theorem thm1, lines 1167--1182. -/
 theorem NonzeroProportionalMPV₂.exists_unit_phase_power_of_isNormalTensor
     [NeZero D₁] [NeZero D₂]
     {A : MPSTensor d D₁} {B : MPSTensor d D₂}


### PR DESCRIPTION
This PR removes Lean-style code formatting from the CPSV16 paper labels eqV and thm1 in the two geometric-phase docstrings. It addresses the late post-merge prose finding on #4273 and contributes to #4253 without changing any theorem statement or proof.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only docstring edits with no executable or proof impact.
> 
> **Overview**
> **Documentation-only** update in `NormalTensorDichotomy.lean`: CPSV16 cross-references in the two geometric-phase theorem docstrings no longer wrap paper labels `eqV` and `thm1` in Lean code backticks, so they read as plain prose labels instead of inline code.
> 
> No theorem statements, proofs, or imports change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73f0eec67531711fb887c3e4ee527728eefe0568. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->