### PR TITLE
fix(MPS/MPDO): disprove unrestricted thermodynamic limit

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -435,6 +435,7 @@ import TNLean.MPS.MPDO.VerticalBNT
 import TNLean.MPS.MPDO.RetainedClass
 import TNLean.MPS.MPDO.VerticalBNTConstruction
 import TNLean.MPS.MPDO.SectorTrace
+import TNLean.MPS.MPDO.ThermodynamicLimitCounterexample
 import TNLean.MPS.MPDO.ReflectedMarkedChain
 import TNLean.MPS.MPDO.FigureEightPairwise
 import TNLean.MPS.MPDO.GroupedFigure8

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -410,6 +410,7 @@ import TNLean.PiAlgebra.GlobalSymmetry
 import TNLean.MPS.MPDO.Defs
 import TNLean.MPS.MPDO.AreaLaw
 import TNLean.MPS.MPDO.MutualInfoMonotone
+import TNLean.MPS.MPDO.ThermodynamicLimitCounterexample
 import TNLean.MPS.MPDO.MutualInfoBridge
 import TNLean.MPS.MPDO.PureAreaLaw
 import TNLean.MPS.MPDO.LocalPurificationAreaLaw
@@ -435,7 +436,6 @@ import TNLean.MPS.MPDO.VerticalBNT
 import TNLean.MPS.MPDO.RetainedClass
 import TNLean.MPS.MPDO.VerticalBNTConstruction
 import TNLean.MPS.MPDO.SectorTrace
-import TNLean.MPS.MPDO.ThermodynamicLimitCounterexample
 import TNLean.MPS.MPDO.ReflectedMarkedChain
 import TNLean.MPS.MPDO.FigureEightPairwise
 import TNLean.MPS.MPDO.GroupedFigure8

--- a/TNLean/MPS/MPDO/ThermodynamicLimitCounterexample.lean
+++ b/TNLean/MPS/MPDO/ThermodynamicLimitCounterexample.lean
@@ -3,8 +3,9 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.MPDO.MutualInfoMonotone
+import TNLean.MPS.MPDO.AreaLaw
 import TNLean.MPS.MPDO.SectorTrace
+import Mathlib.Algebra.BigOperators.Fin
 import Mathlib.Topology.MetricSpace.Pseudo.Defs
 
 /-!
@@ -44,7 +45,7 @@ even lengths it is the mixture with weights \(1/3\) and \(2/3\).
 -/
 
 open scoped Matrix BigOperators ComplexOrder
-open Matrix Finset
+open Matrix Finset Filter
 
 namespace MPOTensor.ThermodynamicLimitCounterexample
 
@@ -91,34 +92,6 @@ private lemma mpo_off_diagonal {N : ℕ} {σ τ : Fin N → Fin 2} (hστ : σ �
   intro a _
   apply Finset.prod_eq_zero (Finset.mem_univ k)
   simp [virtualWeight, hk]
-
-private lemma diagonalWeight_nonneg {N : ℕ} (hN : 0 < N) (σ : Fin N → Fin 2) :
-    0 ≤ ∑ a : Fin 3, ∏ k, virtualWeight a (σ k) (σ k) := by
-  by_cases hzero : ∀ k, σ k = 0
-  · simp [Fin.sum_univ_three, virtualWeight, hzero, hN.ne']
-  · by_cases hone : ∀ k, σ k = 1
-    · rcases Nat.even_or_odd N with hEven | hOdd
-      · simp [Fin.sum_univ_three, virtualWeight, hone, hN.ne', hEven.neg_one_pow,
-          Complex.nonneg_iff]
-      · simp [Fin.sum_univ_three, virtualWeight, hone, hN.ne', hOdd.neg_one_pow]
-    · push Not at hzero hone
-      obtain ⟨kzero, hkzero⟩ := hzero
-      obtain ⟨kone, hkone⟩ := hone
-      have hσkzero : σ kzero = 1 := Fin.eq_one_of_ne_zero _ hkzero
-      have hσkone : σ kone = 0 := by
-        by_contra hne
-        exact hkone (Fin.eq_one_of_ne_zero _ hne)
-      have h0 : ∏ k, virtualWeight 0 (σ k) (σ k) = 0 := by
-        apply Finset.prod_eq_zero (Finset.mem_univ kzero)
-        simp [virtualWeight, hσkzero]
-      have h1 : ∏ k, virtualWeight 1 (σ k) (σ k) = 0 := by
-        apply Finset.prod_eq_zero (Finset.mem_univ kone)
-        simp [virtualWeight, hσkone]
-      have h2 : ∏ k, virtualWeight 2 (σ k) (σ k) = 0 := by
-        apply Finset.prod_eq_zero (Finset.mem_univ kone)
-        simp [virtualWeight, hσkone]
-      rw [Fin.sum_univ_three, h0, h1, h2]
-      simp
 
 private lemma diagonalWeight_eq {N : ℕ} (hN : 0 < N) (σ : Fin N → Fin 2) :
     (∑ a : Fin 3, ∏ k, virtualWeight a (σ k) (σ k)) =
@@ -170,17 +143,17 @@ This gives a positive translationally invariant MPDO satisfying exactly the
 hypotheses of arXiv:1606.00608, Proposition 4.5, lines 801--806. -/
 theorem parityTensor_isMPDO : IsMPDO parityTensor := by
   intro N hN
-  rw [show mpo parityTensor N = Matrix.diagonal fun σ => mpo parityTensor N σ σ by
-    ext σ τ
-    by_cases hστ : σ = τ
-    · subst τ
-      simp
-    · rw [Matrix.diagonal_apply_ne _ hστ, mpo_off_diagonal hστ]]
+  rw [mpo_parityTensor_eq_diagonal N hN]
   apply Matrix.PosSemidef.diagonal
-  exact fun σ => by
-    change 0 ≤ (mpo parityTensor N) σ σ
-    rw [mpo_apply, mpoMatrixEntry_eq_sum_prod]
-    exact diagonalWeight_nonneg hN σ
+  intro σ
+  change 0 ≤ (if (∀ k, σ k = 0) then 1 else if (∀ k, σ k = 1) then
+    1 + (-1 : ℂ) ^ N else 0)
+  split_ifs with hzero hone
+  · norm_num
+  · rcases Nat.even_or_odd N with hEven | hOdd
+    · simp [hEven.neg_one_pow, Complex.nonneg_iff]
+    · simp [hOdd.neg_one_pow]
+  · norm_num
 
 private lemma verticalLoop_parityTensor :
     verticalLoop parityTensor = Matrix.diagonal ![(1 : ℂ), 1, -1] := by
@@ -231,12 +204,53 @@ private def zeroSite : Fin 1 → Fin 2 := fun _ => 0
 private theorem reducedBlockState_one_zero_zero (K : ℕ) :
     reducedBlockState parityTensor (K + 1) 1 (by omega) zeroSite zeroSite =
       normalizedMPO parityTensor (K + 1) (fun _ => 0) (fun _ => 0) := by
+  classical
+  let e := (blockReindexEquiv 2 (K + 1) 1 (by omega)).symm
+  have e_const (j : Fin 2) : e (fun _ => j) = fun _ => j := by
+    funext k
+    simp only [e, blockReindexEquiv, Equiv.arrowCongr_symm, Equiv.refl_symm,
+      Equiv.arrowCongr_apply, Equiv.coe_refl, id_eq, Function.comp_apply]
+  have append_zero : Fin.append zeroSite (fun _ : Fin (K + 1 - 1) => (0 : Fin 2)) =
+      (fun _ : Fin (1 + (K + 1 - 1)) => (0 : Fin 2)) := by
+    funext k
+    refine Fin.addCases (fun i => ?_) (fun i => ?_) k <;> simp [zeroSite]
+  have reindexed_zero :
+      e (Fin.append zeroSite (fun _ : Fin (K + 1 - 1) => (0 : Fin 2))) = fun _ => 0 := by
+    rw [append_zero, e_const]
   simp only [reducedBlockState, blockReducedState, Matrix.partialTraceRight_apply,
-    Matrix.submatrix_apply, blockSplitEquiv_symm_apply, blockReindexEquiv,
-    Equiv.arrowCongr_symm, Equiv.refl_symm, finCongr_symm]
+    Matrix.submatrix_apply, blockSplitEquiv_symm_apply]
   simp_rw [normalizedMPO, Matrix.smul_apply, smul_eq_mul,
     mpo_parityTensor_eq_diagonal (K + 1) (by omega), Matrix.diagonal_apply_eq]
-  simp [zeroSite]
+  rw [Fintype.sum_eq_single (fun _ => 0)]
+  · rw [show (blockReindexEquiv 2 (K + 1) 1 (by omega)).symm
+        (Fin.append zeroSite (fun _ => 0)) = (fun _ => 0) from reindexed_zero]
+    simp
+  · intro x hx
+    have append_ne_zero : Fin.append zeroSite x ≠ (fun _ => 0) := by
+      intro h
+      apply hx
+      funext i
+      have hi := congrFun h (Fin.natAdd 1 i)
+      simpa using hi
+    have append_ne_one : Fin.append zeroSite x ≠ (fun _ => 1) := by
+      intro h
+      have hi := congrFun h (Fin.castAdd (K + 1 - 1) (0 : Fin 1))
+      norm_num [zeroSite] at hi
+    have reindexed_ne_zero : e (Fin.append zeroSite x) ≠ (fun _ => 0) := by
+      intro h
+      apply append_ne_zero
+      exact e.injective (h.trans (e_const 0).symm)
+    have reindexed_ne_one : e (Fin.append zeroSite x) ≠ (fun _ => 1) := by
+      intro h
+      apply append_ne_one
+      exact e.injective (h.trans (e_const 1).symm)
+    have hnotzero : ¬∀ k, e (Fin.append zeroSite x) k = 0 := fun h =>
+      reindexed_ne_zero (funext h)
+    have hnotone : ¬∀ k, e (Fin.append zeroSite x) k = 1 := fun h =>
+      reindexed_ne_one (funext h)
+    rw [show (blockReindexEquiv 2 (K + 1) 1 (by omega)).symm
+        (Fin.append zeroSite x) = e (Fin.append zeroSite x) from rfl]
+    simp only [if_neg hnotzero, if_neg hnotone, mul_zero]
 
 /-- The all-zero entry of the one-site reduced state is one at odd total
 lengths.
@@ -272,13 +286,14 @@ theorem not_exists_tendsto_reducedBlockState_one_zero_zero :
         zeroSite zeroSite).re) atTop (nhds x) := by
   rintro ⟨x, hx⟩
   obtain ⟨K, hK⟩ := (Metric.tendsto_atTop.1 hx) (1 / 4) (by norm_num)
-  have hEvenIndex := hK (2 * K) (by omega)
-  have hOddIndex := hK (2 * K + 1) (by omega)
+  have hOddLengthIndex := hK (2 * K) (by omega)
+  have hEvenLengthIndex := hK (2 * K + 1) (by omega)
   rw [reducedBlockState_one_zero_zero_of_odd (show Odd (2 * K + 1) from ⟨K, by omega⟩)]
-    at hEvenIndex
+    at hOddLengthIndex
   rw [reducedBlockState_one_zero_zero_of_even
-      (show Even (2 * K + 1 + 1) from ⟨K + 1, by omega⟩) (by omega)] at hOddIndex
-  norm_num [Real.dist_eq] at hEvenIndex hOddIndex
+      (show Even (2 * K + 1 + 1) from ⟨K + 1, by omega⟩) (by omega)] at hEvenLengthIndex
+  norm_num [Real.dist_eq] at hOddLengthIndex hEvenLengthIndex
+  rw [abs_lt] at hOddLengthIndex hEvenLengthIndex
   linarith
 
 end MPOTensor.ThermodynamicLimitCounterexample

--- a/TNLean/MPS/MPDO/ThermodynamicLimitCounterexample.lean
+++ b/TNLean/MPS/MPDO/ThermodynamicLimitCounterexample.lean
@@ -1,0 +1,284 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.MutualInfoMonotone
+import TNLean.MPS.MPDO.SectorTrace
+import Mathlib.Topology.MetricSpace.Pseudo.Defs
+
+/-!
+# A periodic MPDO without a thermodynamic limit
+
+This file gives a classical translationally invariant MPDO whose normalized
+periodic states alternate with the parity of the chain length.  It disproves
+the unrestricted thermodynamic-limit assertion in Proposition 4.5 of
+arXiv:1606.00608, lines 801--806.
+
+The tensor has physical dimension two and bond dimension three.  Its only
+nonzero physical slices are
+\[
+  M^{00}=\operatorname{diag}(1,0,0),\qquad
+  M^{11}=\operatorname{diag}(0,1,-1).
+\]
+Consequently, the unnormalized operator on a chain of length~\(N\) is
+\[
+  \lvert 0^N\rangle\!\langle 0^N\rvert
+  +\bigl(1+(-1)^N\bigr)\lvert 1^N\rangle\!\langle 1^N\rvert.
+\]
+It is positive semidefinite and has nonzero trace at every positive length.
+For odd lengths its normalization is the first pure product state, whereas for
+even lengths it is the mixture with weights \(1/3\) and \(2/3\).
+
+## Main results
+
+* `mpo_parityTensor_eq_diagonal`: the exact finite-chain operator.
+* `parityTensor_isMPDO`: positivity at every positive chain length.
+* `not_exists_tendsto_reducedBlockState_one_zero_zero`: the all-zero entry of
+  the one-site reduced state has no thermodynamic limit.
+
+## Reference
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Proposition 4.5, lines 801--806
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+open Matrix Finset
+
+namespace MPOTensor.ThermodynamicLimitCounterexample
+
+private noncomputable def virtualWeight (a : Fin 3) (i j : Fin 2) : ℂ :=
+  if i = j then
+    ![if i = 0 then 1 else 0, if i = 1 then 1 else 0, if i = 1 then -1 else 0] a
+  else 0
+
+/-- The diagonal classical tensor whose all-one sector cancels at odd lengths.
+
+This is the counterexample to the unrestricted thermodynamic-limit clause of
+arXiv:1606.00608, Proposition 4.5, lines 801--806. -/
+noncomputable def parityTensor : MPOTensor 2 3 :=
+  fun i j => Matrix.diagonal fun a => virtualWeight a i j
+
+@[simp] private lemma parityTensor_apply (i j : Fin 2) :
+    parityTensor i j = Matrix.diagonal fun a => virtualWeight a i j :=
+  rfl
+
+private lemma prod_parityTensor {N : ℕ} (σ τ : Fin N → Fin 2) :
+    (List.ofFn fun k => parityTensor (σ k) (τ k)).prod =
+      Matrix.diagonal fun a => ∏ k, virtualWeight a (σ k) (τ k) := by
+  induction N with
+  | zero =>
+      simp only [List.ofFn_zero, List.prod_nil, Fin.prod_univ_zero]
+      exact (Matrix.diagonal_one (n := Fin 3)).symm
+  | succ N ih =>
+      rw [List.ofFn_succ, List.prod_cons, parityTensor_apply, ih,
+        Matrix.diagonal_mul_diagonal]
+      congr 1
+      funext a
+      rw [Fin.prod_univ_succ]
+
+private lemma mpoMatrixEntry_eq_sum_prod {N : ℕ} (σ τ : Fin N → Fin 2) :
+    mpoMatrixEntry parityTensor σ τ =
+      ∑ a : Fin 3, ∏ k, virtualWeight a (σ k) (τ k) := by
+  rw [mpoMatrixEntry, evalWord_ofFn, prod_parityTensor, Matrix.trace_diagonal]
+
+private lemma mpo_off_diagonal {N : ℕ} {σ τ : Fin N → Fin 2} (hστ : σ ≠ τ) :
+    mpo parityTensor N σ τ = 0 := by
+  rw [mpo_apply, mpoMatrixEntry_eq_sum_prod]
+  obtain ⟨k, hk⟩ := Function.ne_iff.mp hστ
+  apply Finset.sum_eq_zero
+  intro a _
+  apply Finset.prod_eq_zero (Finset.mem_univ k)
+  simp [virtualWeight, hk]
+
+private lemma diagonalWeight_nonneg {N : ℕ} (hN : 0 < N) (σ : Fin N → Fin 2) :
+    0 ≤ ∑ a : Fin 3, ∏ k, virtualWeight a (σ k) (σ k) := by
+  by_cases hzero : ∀ k, σ k = 0
+  · simp [Fin.sum_univ_three, virtualWeight, hzero, hN.ne']
+  · by_cases hone : ∀ k, σ k = 1
+    · rcases Nat.even_or_odd N with hEven | hOdd
+      · simp [Fin.sum_univ_three, virtualWeight, hone, hN.ne', hEven.neg_one_pow,
+          Complex.nonneg_iff]
+      · simp [Fin.sum_univ_three, virtualWeight, hone, hN.ne', hOdd.neg_one_pow]
+    · push Not at hzero hone
+      obtain ⟨kzero, hkzero⟩ := hzero
+      obtain ⟨kone, hkone⟩ := hone
+      have hσkzero : σ kzero = 1 := Fin.eq_one_of_ne_zero _ hkzero
+      have hσkone : σ kone = 0 := by
+        by_contra hne
+        exact hkone (Fin.eq_one_of_ne_zero _ hne)
+      have h0 : ∏ k, virtualWeight 0 (σ k) (σ k) = 0 := by
+        apply Finset.prod_eq_zero (Finset.mem_univ kzero)
+        simp [virtualWeight, hσkzero]
+      have h1 : ∏ k, virtualWeight 1 (σ k) (σ k) = 0 := by
+        apply Finset.prod_eq_zero (Finset.mem_univ kone)
+        simp [virtualWeight, hσkone]
+      have h2 : ∏ k, virtualWeight 2 (σ k) (σ k) = 0 := by
+        apply Finset.prod_eq_zero (Finset.mem_univ kone)
+        simp [virtualWeight, hσkone]
+      rw [Fin.sum_univ_three, h0, h1, h2]
+      simp
+
+private lemma diagonalWeight_eq {N : ℕ} (hN : 0 < N) (σ : Fin N → Fin 2) :
+    (∑ a : Fin 3, ∏ k, virtualWeight a (σ k) (σ k)) =
+      if (∀ k, σ k = 0) then 1 else if (∀ k, σ k = 1) then 1 + (-1 : ℂ) ^ N else 0 := by
+  by_cases hzero : ∀ k, σ k = 0
+  · simp [hzero, Fin.sum_univ_three, virtualWeight, hN.ne']
+  · by_cases hone : ∀ k, σ k = 1
+    · letI : Nonempty (Fin N) := ⟨⟨0, hN⟩⟩
+      simp [hone, Fin.sum_univ_three, virtualWeight, hN.ne']
+    · push Not at hzero hone
+      obtain ⟨kzero, hkzero⟩ := hzero
+      obtain ⟨kone, hkone⟩ := hone
+      have hσkzero : σ kzero = 1 := Fin.eq_one_of_ne_zero _ hkzero
+      have hσkone : σ kone = 0 := by
+        by_contra hne
+        exact hkone (Fin.eq_one_of_ne_zero _ hne)
+      have h0 : ∏ k, virtualWeight 0 (σ k) (σ k) = 0 := by
+        apply Finset.prod_eq_zero (Finset.mem_univ kzero)
+        simp [virtualWeight, hσkzero]
+      have h1 : ∏ k, virtualWeight 1 (σ k) (σ k) = 0 := by
+        apply Finset.prod_eq_zero (Finset.mem_univ kone)
+        simp [virtualWeight, hσkone]
+      have h2 : ∏ k, virtualWeight 2 (σ k) (σ k) = 0 := by
+        apply Finset.prod_eq_zero (Finset.mem_univ kone)
+        simp [virtualWeight, hσkone]
+      rw [if_neg (not_forall.mpr ⟨kzero, hkzero⟩),
+        if_neg (not_forall.mpr ⟨kone, hkone⟩)]
+      simp [Fin.sum_univ_three, h0, h1, h2]
+
+/-- The finite-chain operator has support only on the two constant
+configurations.  Its all-one weight is \(1+(-1)^N\).
+
+This is the explicit finite-chain form of the counterexample to
+arXiv:1606.00608, Proposition 4.5, lines 801--806. -/
+theorem mpo_parityTensor_eq_diagonal (N : ℕ) (hN : 0 < N) :
+    mpo parityTensor N = Matrix.diagonal fun σ =>
+      if (∀ k, σ k = 0) then 1 else if (∀ k, σ k = 1) then 1 + (-1 : ℂ) ^ N else 0 := by
+  ext σ τ
+  by_cases hστ : σ = τ
+  · subst τ
+    rw [Matrix.diagonal_apply_eq, mpo_apply, mpoMatrixEntry_eq_sum_prod,
+      diagonalWeight_eq hN]
+  · rw [Matrix.diagonal_apply_ne _ hστ, mpo_off_diagonal hστ]
+
+/-- The parity tensor generates positive semidefinite operators at every
+positive chain length.
+
+This gives a positive translationally invariant MPDO satisfying exactly the
+hypotheses of arXiv:1606.00608, Proposition 4.5, lines 801--806. -/
+theorem parityTensor_isMPDO : IsMPDO parityTensor := by
+  intro N hN
+  rw [show mpo parityTensor N = Matrix.diagonal fun σ => mpo parityTensor N σ σ by
+    ext σ τ
+    by_cases hστ : σ = τ
+    · subst τ
+      simp
+    · rw [Matrix.diagonal_apply_ne _ hστ, mpo_off_diagonal hστ]]
+  apply Matrix.PosSemidef.diagonal
+  exact fun σ => by
+    change 0 ≤ (mpo parityTensor N) σ σ
+    rw [mpo_apply, mpoMatrixEntry_eq_sum_prod]
+    exact diagonalWeight_nonneg hN σ
+
+private lemma verticalLoop_parityTensor :
+    verticalLoop parityTensor = Matrix.diagonal ![(1 : ℂ), 1, -1] := by
+  rw [verticalLoop_eq_physTraceTransfer]
+  ext a b
+  fin_cases a <;> fin_cases b <;>
+    simp [physTraceTransfer, parityTensor, virtualWeight, Fin.sum_univ_two]
+
+/-- The trace of the finite-chain counterexample is \(2+(-1)^N\).
+
+This is the normalization factor for the counterexample to arXiv:1606.00608,
+Proposition 4.5, lines 801--806. -/
+theorem trace_mpo_parityTensor (N : ℕ) :
+    (mpo parityTensor N).trace = 2 + (-1 : ℂ) ^ N := by
+  rw [trace_mpo_eq_trace_verticalLoop_pow, verticalLoop_parityTensor,
+    Matrix.diagonal_pow, Matrix.trace_diagonal]
+  simp [Fin.sum_univ_three]
+  ring
+
+/-- The all-zero configuration has unnormalized weight one at every length. -/
+private lemma mpo_zeroConfig (N : ℕ) (hN : 0 < N) :
+    mpo parityTensor N (fun _ => 0) (fun _ => 0) = 1 := by
+  rw [mpo_apply, mpoMatrixEntry_eq_sum_prod]
+  simp [Fin.sum_univ_three, virtualWeight, hN.ne']
+
+/-- At every odd length, the normalized all-zero diagonal entry is one.
+
+This is the odd-length half of the counterexample to arXiv:1606.00608,
+Proposition 4.5, lines 801--806. -/
+theorem normalizedMPO_zeroConfig_of_odd {N : ℕ} (hN : Odd N) :
+    normalizedMPO parityTensor N (fun _ => 0) (fun _ => 0) = 1 := by
+  rw [normalizedMPO, Matrix.smul_apply, smul_eq_mul, trace_mpo_parityTensor,
+    hN.neg_one_pow, mpo_zeroConfig N hN.pos]
+  norm_num
+
+/-- At every even length, the normalized all-zero diagonal entry is one third.
+
+This is the even-length half of the counterexample to arXiv:1606.00608,
+Proposition 4.5, lines 801--806. -/
+theorem normalizedMPO_zeroConfig_of_even {N : ℕ} (hN : Even N) (hNpos : 0 < N) :
+    normalizedMPO parityTensor N (fun _ => 0) (fun _ => 0) = 1 / 3 := by
+  rw [normalizedMPO, Matrix.smul_apply, smul_eq_mul, trace_mpo_parityTensor,
+    hN.neg_one_pow, mpo_zeroConfig N hNpos]
+  norm_num
+
+private def zeroSite : Fin 1 → Fin 2 := fun _ => 0
+
+private theorem reducedBlockState_one_zero_zero (K : ℕ) :
+    reducedBlockState parityTensor (K + 1) 1 (by omega) zeroSite zeroSite =
+      normalizedMPO parityTensor (K + 1) (fun _ => 0) (fun _ => 0) := by
+  simp only [reducedBlockState, blockReducedState, Matrix.partialTraceRight_apply,
+    Matrix.submatrix_apply, blockSplitEquiv_symm_apply, blockReindexEquiv,
+    Equiv.arrowCongr_symm, Equiv.refl_symm, finCongr_symm]
+  simp_rw [normalizedMPO, Matrix.smul_apply, smul_eq_mul,
+    mpo_parityTensor_eq_diagonal (K + 1) (by omega), Matrix.diagonal_apply_eq]
+  simp [zeroSite]
+
+/-- The all-zero entry of the one-site reduced state is one at odd total
+lengths.
+
+This is the odd-length local marginal in the counterexample to
+arXiv:1606.00608, Proposition 4.5, lines 801--806. -/
+theorem reducedBlockState_one_zero_zero_of_odd {N : ℕ} (hN : Odd N) :
+    reducedBlockState parityTensor N 1 (by exact hN.pos) zeroSite zeroSite = 1 := by
+  obtain ⟨K, rfl⟩ := Nat.exists_eq_succ_of_ne_zero hN.pos.ne'
+  rw [reducedBlockState_one_zero_zero, normalizedMPO_zeroConfig_of_odd hN]
+
+/-- The all-zero entry of the one-site reduced state is one third at positive
+even total lengths.
+
+This is the even-length local marginal in the counterexample to
+arXiv:1606.00608, Proposition 4.5, lines 801--806. -/
+theorem reducedBlockState_one_zero_zero_of_even {N : ℕ} (hN : Even N)
+    (hNpos : 0 < N) :
+    reducedBlockState parityTensor N 1 (by exact hNpos) zeroSite zeroSite = 1 / 3 := by
+  obtain ⟨K, rfl⟩ := Nat.exists_eq_succ_of_ne_zero hNpos.ne'
+  rw [reducedBlockState_one_zero_zero,
+    normalizedMPO_zeroConfig_of_even hN hNpos]
+
+/-- The one-site reduced states of the normalized periodic MPDO do not have a
+thermodynamic limit: their all-zero diagonal entry alternates between one and
+one third.
+
+This is a formal obstruction to the inner limit asserted without further
+hypotheses in arXiv:1606.00608, Proposition 4.5, lines 801--806. -/
+theorem not_exists_tendsto_reducedBlockState_one_zero_zero :
+    ¬∃ x : ℝ, Tendsto
+      (fun K => (reducedBlockState parityTensor (K + 1) 1 (by omega)
+        zeroSite zeroSite).re) atTop (nhds x) := by
+  rintro ⟨x, hx⟩
+  obtain ⟨K, hK⟩ := (Metric.tendsto_atTop.1 hx) (1 / 4) (by norm_num)
+  have hEvenIndex := hK (2 * K) (by omega)
+  have hOddIndex := hK (2 * K + 1) (by omega)
+  rw [reducedBlockState_one_zero_zero_of_odd (show Odd (2 * K + 1) from ⟨K, by omega⟩)]
+    at hEvenIndex
+  rw [reducedBlockState_one_zero_zero_of_even
+      (show Even (2 * K + 1 + 1) from ⟨K + 1, by omega⟩) (by omega)] at hOddIndex
+  norm_num [Real.dist_eq] at hEvenIndex hOddIndex
+  linarith
+
+end MPOTensor.ThermodynamicLimitCounterexample

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
@@ -184,6 +184,24 @@
     \path{docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex}.
 \end{theorem}
 
+\begin{proof}\leanok
+    A contraction around the virtual loop vanishes unless the bra and ket
+    configurations agree and are both constant.  The all-zero configuration
+    receives weight one.  The all-one configuration receives the sum of the
+    two virtual-sector weights, namely $1+(-1)^N$.  This gives the displayed
+    diagonal form.  Its coefficients are nonnegative: the second coefficient
+    is zero for odd $N$ and two for even $N$.  Hence every positive-length
+    operator is positive semidefinite, and summing its two possible diagonal
+    entries gives the trace $2+(-1)^N$.
+
+    After normalization, the all-zero weight is consequently one at odd
+    lengths and $1/3$ at positive even lengths.  Tracing out all but the first
+    site does not change this entry, since among the configurations beginning
+    with zero only the all-zero configuration has nonzero weight.  The two
+    subsequences of one-site marginals therefore have distinct all-zero
+    entries, so the sequence cannot converge.
+\end{proof}
+
 \begin{definition}[Map on the second tensor factor]
     \label{def:mpdo_id_tensor_map}
     \lean{Matrix.idTensorMap}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
@@ -140,6 +140,50 @@
     $I_L \le I_{L+1}$ after subtracting $S_N$.
 \end{proof}
 
+\begin{definition}[Parity-sensitive classical MPDO]
+    \label{def:parity_mpdo_counterexample}
+    \lean{MPOTensor.ThermodynamicLimitCounterexample.parityTensor}
+    \leanok
+    \uses{def:mpo_tensor}
+    Let $M$ have physical dimension two and bond dimension three, with
+    \[
+        M^{00}=\operatorname{diag}(1,0,0),\qquad
+        M^{11}=\operatorname{diag}(0,1,-1),\qquad
+        M^{01}=M^{10}=0.
+    \]
+\end{definition}
+
+\begin{theorem}[A periodic MPDO without a thermodynamic limit]
+    \label{thm:parity_mpdo_no_thermodynamic_limit}
+    \lean{MPOTensor.ThermodynamicLimitCounterexample.mpo_parityTensor_eq_diagonal,
+      MPOTensor.ThermodynamicLimitCounterexample.parityTensor_isMPDO,
+      MPOTensor.ThermodynamicLimitCounterexample.trace_mpo_parityTensor,
+      MPOTensor.ThermodynamicLimitCounterexample.normalizedMPO_zeroConfig_of_odd,
+      MPOTensor.ThermodynamicLimitCounterexample.normalizedMPO_zeroConfig_of_even,
+      MPOTensor.ThermodynamicLimitCounterexample.reducedBlockState_one_zero_zero_of_odd,
+      MPOTensor.ThermodynamicLimitCounterexample.reducedBlockState_one_zero_zero_of_even,
+      MPOTensor.ThermodynamicLimitCounterexample.not_exists_tendsto_reducedBlockState_one_zero_zero}
+    \leanok
+    \uses{def:mpdo, def:parity_mpdo_counterexample}
+    The tensor in Definition~\ref{def:parity_mpdo_counterexample} generates the
+    positive operators
+    \[
+        \rho^{(N)}
+        =\lvert 0^N\rangle\!\langle 0^N\rvert
+        +\bigl(1+(-1)^N\bigr)
+          \lvert 1^N\rangle\!\langle 1^N\rvert.
+    \]
+    Their traces are $2+(-1)^N$.  The all-zero diagonal entry of the normalized
+    one-site reduced state is therefore one for odd $N$ and $1/3$ for positive
+    even $N$.  In particular, the normalized periodic one-site reduced states
+    do not converge as $N\to\infty$.
+
+    Thus normalized periodic marginals need not converge under the hypotheses
+    of \cite[Proposition~4.5, lines~801--806]{Cirac2016MPDO_arXiv}.  The mutual
+    information of this same family is computed in
+    \path{docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex}.
+\end{theorem}
+
 \begin{definition}[Map on the second tensor factor]
     \label{def:mpdo_id_tensor_map}
     \lean{Matrix.idTensorMap}
@@ -870,8 +914,9 @@
     one-site density matrix $q$. Thus its $L$-site marginal has rank
     $\operatorname{rank}(q)^L$, although its mutual information vanishes. The
     unrestricted estimate therefore requires a direct operator-Schmidt
-    argument not supplied by the cited proof. The bound and the iterated
-    thermodynamic limit remain open; see
+    argument not supplied by the cited proof. The bound remains open. The
+    same example as Theorem~\ref{thm:parity_mpdo_no_thermodynamic_limit} also
+    makes the iterated mutual-information limit false; see
     \path{docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex}. The
     channel-image implication is
     Theorem~\ref{thm:local_channel_image_mutual_info_bound}, and the pure-state

--- a/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
@@ -157,25 +157,83 @@ show that a small MPO bond does not control the bond dimension of an exact local
 purification; they neither prove nor disprove the unrestricted
 $4\log D$ mutual-information estimate.
 
-\section{The iterated limit}
+\section{The iterated limit is false without an aperiodicity hypothesis}
 
-Even a uniform finite-chain estimate does not by itself define the inner limit
+The normalized periodic states need not converge on local algebras.  Consider
+the physical dimension two, bond dimension three tensor whose only nonzero
+physical slices are
 \[
-  \lim_{N\to\infty} I_L^{(N)}.
+  M^{00}=\operatorname{diag}(1,0,0),\qquad
+  M^{11}=\operatorname{diag}(0,1,-1).
 \]
-For fixed $L$, one must first specify an infinite-chain state or prove
-convergence of the normalized periodic density operators on every local
-algebra.  Monotonicity in $L$ at each fixed finite $N$ does not supply this
-thermodynamic-limit construction.
+For every positive chain length, contraction of the virtual trace gives
+\[
+  \rho^{(N)}(M)
+  =\lvert 0^N\rangle\!\langle 0^N\rvert
+  +\bigl(1+(-1)^N\bigr)
+    \lvert 1^N\rangle\!\langle 1^N\rvert.
+\]
+Thus the operator is positive semidefinite for every $N\geq1$, including odd
+lengths, and
+\[
+  \tr\rho^{(N)}(M)=2+(-1)^N\ne0.
+\]
+This is therefore an MPDO at exactly the hypothesis set of Proposition~4.5.
 
-Accordingly, the precise finite-chain result currently available for arbitrary
-MPDOs is only the monotonicity
+At odd lengths the normalized state is
+\[
+  \widehat\rho^{(N)}(M)
+  =\lvert0^N\rangle\!\langle0^N\rvert,
+\]
+whereas at positive even lengths it is
+\[
+  \widehat\rho^{(N)}(M)
+  =\frac13\lvert0^N\rangle\!\langle0^N\rvert
+   +\frac23\lvert1^N\rangle\!\langle1^N\rvert.
+\]
+In particular, the all-zero entry of the one-site reduced state alternates
+between $1$ and $1/3$, so the normalized local states have no thermodynamic
+limit.
+
+The mutual information itself also oscillates.  For any fixed $L\geq1$ and
+all $N>L$, the odd-length state is a product state and hence
+\[
+  I_L^{(N)}=0.
+\]
+For even $N$, both nonempty marginals and the full state have the two nonzero
+eigenvalues $1/3$ and $2/3$.  Writing
+\[
+  h_2(1/3)
+  =-\frac13\log\frac13-\frac23\log\frac23>0,
+\]
+one obtains
+\[
+  I_L^{(N)}=h_2(1/3)+h_2(1/3)-h_2(1/3)=h_2(1/3).
+\]
+Hence $\lim_{N\to\infty}I_L^{(N)}$ does not exist.  The eigenvalue $-1$ of the
+physical-trace transfer is the peripheral sector responsible for the parity
+oscillation.  Primitivity or another aperiodicity assumption would exclude
+this example, but no such assumption occurs in Proposition~4.5.
+
+The finite-chain form, positivity, trace formula, alternating normalized
+entries, alternating one-site reduced entries, and nonconvergence of the
+one-site entry are formalized.
+\footnote{Formal declarations:
+\leanid{MPOTensor.ThermodynamicLimitCounterexample.mpo_parityTensor_eq_diagonal},
+\leanid{MPOTensor.ThermodynamicLimitCounterexample.parityTensor_isMPDO},
+\leanid{MPOTensor.ThermodynamicLimitCounterexample.trace_mpo_parityTensor},
+\leanid{MPOTensor.ThermodynamicLimitCounterexample.reducedBlockState_one_zero_zero_of_odd},
+\leanid{MPOTensor.ThermodynamicLimitCounterexample.reducedBlockState_one_zero_zero_of_even},
+and
+\leanid{MPOTensor.ThermodynamicLimitCounterexample.not_exists_tendsto_reducedBlockState_one_zero_zero}
+in \doclink{TNLean/MPS/MPDO/ThermodynamicLimitCounterexample}.}
+
+Accordingly, the precise unconditional result that remains from the cited
+argument is the finite-chain monotonicity
 \[
   I_L^{(N)}\leq I_{L+1}^{(N)}
   \qquad (2L+1\leq N).
 \]
-The bound and the iterated limit are not established at the source hypothesis
-set by the cited arguments or by the present development.
 
 \section{Resolution}
 
@@ -211,20 +269,17 @@ This result does not supply a local purification for an arbitrary positive
 MPO.  The source itself warns at the purification step that such a
 representation need not exist, and the no-go results above show that this
 missing representation cannot be recovered uniformly from MPO positivity and
-bond dimension.  Two questions therefore remain for the full statement of
-Proposition~4.5.
-\begin{enumerate}
-  \item Determine whether the finite-chain estimate is true for arbitrary
-    positive periodic MPO families of bond dimension $D$.  A proof must use
-    only the hypotheses of Proposition~4.5, and a counterexample must satisfy
-    positivity for every chain length.  No operator-Schmidt-rank implication is
-    assumed here.
-  \item Construct the thermodynamic limit required for the inner limit in the
-    proposition.
-\end{enumerate}
+bond dimension.
 
-Until both tasks are completed, the unrestricted bound and limit clauses of
-Proposition~4.5 remain unformalized.  This obstruction is tracked by issue
+The remaining unresolved question is whether the finite-chain estimate is true
+for arbitrary positive periodic MPO families of bond dimension $D$.  A proof
+must use only the hypotheses of Proposition~4.5, and a counterexample must
+satisfy positivity for every chain length.  No operator-Schmidt-rank
+implication is assumed here.
+
+The thermodynamic-limit clause of Proposition~4.5 is false at its stated
+hypothesis set, while the unrestricted finite-chain bound remains
+unformalized.  These two conclusions are tracked by issue
 \href{https://github.com/LionSR/TNLean/issues/4169}{\#4169} under the MPDO
 coverage audit
 \href{https://github.com/LionSR/TNLean/issues/2380}{\#2380}.


### PR DESCRIPTION
This PR gives a positive translationally invariant MPDO for which the normalized periodic states oscillate with the parity of the chain length, disproving the unrestricted thermodynamic-limit clause of arXiv:1606.00608, Proposition 4.5.

The tensor has physical dimension two and bond dimension three, with nonzero slices M^{00} = diag(1,0,0) and M^{11} = diag(0,1,-1). Its N-site operator is the all-zero projector plus (1+(-1)^N) times the all-one projector. The formalization proves the exact finite-chain formula, positivity at every positive length, the trace formula, the alternating one-site marginal entries, and nonconvergence of that local entry.

The blueprint and the paper-gap analysis now distinguish the false thermodynamic-limit clause from the still-open unrestricted finite-chain mutual-information bound. The paper-gap note also computes the mutual information explicitly: it is zero at odd lengths and the positive binary entropy h_2(1/3) at even lengths.

Closes #4243.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds proved Lean theory and documentation only; no runtime, auth, or data-path changes. Main risk is mathematical/narrative scope in a large formalization track, not production breakage.
> 
> **Overview**
> **Adds a formal counterexample** showing that normalized periodic MPDO marginals need not have a thermodynamic limit under the hypotheses of Cirac et al. Proposition 4.5, without extra aperiodicity.
> 
> The new Lean module `ThermodynamicLimitCounterexample` defines `parityTensor` (physical dim 2, bond dim 3) and proves the finite-chain operator is projectors on all-0 and all-1 strings with weight \(1+(−1)^N\) on the latter, **`IsMPDO`** at every positive length, alternating normalized one-site entries (1 vs \(1/3\)), and **`not_exists_tendsto_reducedBlockState_one_zero_zero`**. The module is wired into the root import list.
> 
> The **blueprint** gains Definition `parity_mpdo_counterexample` and Theorem `parity_mpdo_no_thermodynamic_limit`, with lean links to the new declarations. A remark now states the iterated mutual-information limit fails for this family while the unrestricted \(4\log D\) bound stays open.
> 
> The **paper-gap note** rewrites the iterated-limit section: the same tensor is worked out analytically (nonconverging \(I_L^{(N)}\), parity from a \(-1\) peripheral sector), and resolution text separates **false thermodynamic-limit clause** from the **still-open finite-chain bound**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4446ed31d5e90c6a325f57d2e477995eeb41b89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->