### PR TITLE
fix(MPS/MPDO): resolve four-sector inverse-map provenance

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -527,6 +527,7 @@ import TNLean.MPS.MPDO.PhysicalSectorPhysicalTransport
 import TNLean.MPS.MPDO.SectorPairingTransfer
 import TNLean.MPS.MPDO.InverseMapActiveSectorZCL
 import TNLean.MPS.MPDO.ActiveSectorSpanningCounterexample
+import TNLean.MPS.MPDO.ActiveSectorInverseMapProvenance
 import TNLean.MPS.MPDO.SectorEtaContraction
 import TNLean.MPS.MPDO.SectorEtaOperator
 import TNLean.MPS.MPDO.SectorEtaPositivity

--- a/TNLean/MPS/MPDO/ActiveSectorInverseMapProvenance.lean
+++ b/TNLean/MPS/MPDO/ActiveSectorInverseMapProvenance.lean
@@ -1,0 +1,282 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.ActiveSectorSpanningCounterexample
+import TNLean.MPS.MPDO.InverseMapPhysicalSectorFactorization
+
+/-!
+# Inverse-map provenance of the four-sector classical tensor
+
+This file supplies the explicit three-site Hayashi decomposition needed to
+compare the inverse-map construction in Appendix C.2 of arXiv:1606.00608 with
+the four-sector classical tensor in
+`TNLean.MPS.MPDO.ActiveSectorSpanningCounterexample`.
+
+The source uses the inverse map only through its contraction identity at lines
+1415--1438.  It does not derive linear independence of the closed sector
+tensors or the rectangular vanishing used after Lemma C.4.
+
+## References
+
+* arXiv:1606.00608, Appendix C.2, Lemma C.4, lines 1406--1471.
+* arXiv:1606.00608, Appendix C.2, Lemma C.5, lines 1473--1499.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+namespace MPOTensor.ActiveSectorSpanningCounterexample
+
+private noncomputable abbrev traceMatrix : Matrix (Fin 4) (Fin 4) ℂ :=
+  rightPairing * leftPairing
+
+/-- The left conditional density in the classical Markov decomposition. -/
+noncomputable def markovLeft (k : Fin 4) :
+    Matrix (Fin 4 × Fin 1) (Fin 4 × Fin 1) ℂ :=
+  Matrix.diagonal fun x => traceMatrix x.1 k
+
+/-- The right conditional density in the classical Markov decomposition. -/
+noncomputable def markovRight (k : Fin 4) :
+    Matrix (Fin 1 × Fin 4) (Fin 1 × Fin 4) ℂ :=
+  Matrix.diagonal fun x => traceMatrix k x.2
+
+/-- The normalized three-site classical Markov state. -/
+noncomputable def threeSiteState :
+    Matrix (Fin 4 × Fin 4 × Fin 4) (Fin 4 × Fin 4 × Fin 4) ℂ :=
+  Matrix.diagonal fun x =>
+    (1 / 4 : ℂ) * traceMatrix x.1 x.2.1 * traceMatrix x.2.1 x.2.2
+
+private lemma right_dot_left (i j : Fin 4) :
+    (fun alpha => rightPairing i alpha) ⬝ᵥ (fun beta => leftPairing beta j) =
+      traceMatrix i j := by
+  rfl
+
+private lemma tail_contraction (i k : Fin 4) :
+    (fun beta => leftPairing beta i) ⬝ᵥ
+        Matrix.vecMul (fun alpha => rightPairing k alpha)
+          (leftPairing * rightPairing) =
+      (1 / 4 : ℂ) := by
+  fin_cases i <;> fin_cases k <;>
+    norm_num [leftPairing, rightPairing, dotProduct, Matrix.vecMul,
+      Matrix.mul_apply, Fin.sum_univ_two, Fin.sum_univ_four,
+      Matrix.cons_val_two, Matrix.cons_val_three]
+
+private lemma trace_sectorMatrix_product (i j k : Fin 4) :
+    Matrix.trace
+        (sectorMatrix i * sectorMatrix j * sectorMatrix k *
+          (leftPairing * rightPairing)) =
+      (1 / 4 : ℂ) * traceMatrix i j * traceMatrix j k := by
+  rw [sectorMatrix, sectorMatrix, sectorMatrix]
+  rw [Matrix.vecMulVec_mul_vecMulVec, Matrix.vecMulVec_mul_vecMulVec,
+    Matrix.vecMulVec_mul, Matrix.trace_vecMulVec]
+  simp only [smul_dotProduct, right_dot_left]
+  rw [Matrix.smul_vecMul, dotProduct_smul, tail_contraction]
+  simp only [smul_eq_mul]
+  ring
+
+lemma markovLeft_posSemidef (k : Fin 4) : (markovLeft k).PosSemidef := by
+  apply Matrix.PosSemidef.diagonal
+  intro x
+  obtain ⟨i, u⟩ := x
+  fin_cases u
+  change 0 ≤ (rightPairing * leftPairing) i k
+  rw [rightPairing_mul_leftPairing]
+  fin_cases i <;> fin_cases k <;> norm_num [Complex.nonneg_iff]
+
+lemma markovRight_posSemidef (k : Fin 4) : (markovRight k).PosSemidef := by
+  apply Matrix.PosSemidef.diagonal
+  intro x
+  obtain ⟨u, i⟩ := x
+  fin_cases u
+  change 0 ≤ (rightPairing * leftPairing) k i
+  rw [rightPairing_mul_leftPairing]
+  fin_cases k <;> fin_cases i <;> norm_num [Complex.nonneg_iff]
+
+lemma trace_markovLeft (k : Fin 4) : (markovLeft k).trace = 1 := by
+  rw [Matrix.trace, Fintype.sum_prod_type]
+  simp only [markovLeft, Fin.sum_univ_one]
+  change (∑ i : Fin 4, (rightPairing * leftPairing) i k) = 1
+  rw [rightPairing_mul_leftPairing]
+  fin_cases k <;>
+    norm_num [Fin.sum_univ_four, Matrix.cons_val_two, Matrix.cons_val_three]
+
+lemma trace_markovRight (k : Fin 4) : (markovRight k).trace = 1 := by
+  rw [Matrix.trace, Fintype.sum_prod_type]
+  simp only [markovRight, Fin.sum_univ_one]
+  change (∑ i : Fin 4, (rightPairing * leftPairing) k i) = 1
+  rw [rightPairing_mul_leftPairing]
+  fin_cases k <;>
+    norm_num [Fin.sum_univ_four, Matrix.cons_val_two, Matrix.cons_val_three]
+
+/-- The classical three-site state has the four one-dimensional middle
+sectors dictated by the four physical symbols. -/
+noncomputable def etaStructure : EtaStructure threeSiteState where
+  m := 4
+  dL := fun _ => 1
+  dR := fun _ => 1
+  decompB := sectorEquiv
+  U_B := ⟨1, one_mem _⟩
+  p := p
+  hp_nonneg := p_nonneg
+  hp_sum := sum_p
+  ρ_left := markovLeft
+  ρ_right := markovRight
+  hρ_left_dm := fun k => ⟨markovLeft_posSemidef k, trace_markovLeft k⟩
+  hρ_right_dm := fun k => ⟨markovRight_posSemidef k, trace_markovRight k⟩
+  h_state := by
+    ext x y
+    obtain ⟨a, ⟨⟨k, ⟨l, r⟩⟩, c⟩⟩ := x
+    obtain ⟨a', ⟨⟨k', ⟨l', r'⟩⟩, c'⟩⟩ := y
+    fin_cases l
+    fin_cases r
+    fin_cases l'
+    fin_cases r'
+    simp [HayashiMarkov.abcEquiv, HayashiMarkov.liftB, threeSiteState,
+      HayashiMarkov.blockState_apply, sectorEquiv, markovLeft, markovRight]
+    by_cases haa : a = a' <;> by_cases hkk : k = k' <;> by_cases hcc : c = c'
+    all_goals simp [haa, hkk, hcc, p]
+
+/-- The classical Markov state is the three-site closure of the tensor against
+the idempotent virtual tail `LQ`. -/
+lemma isThreeSiteClosure_threeSiteState :
+    IsThreeSiteClosure tensor (leftPairing * rightPairing) threeSiteState := by
+  intro i₁ i₂ i₃ j₁ j₂ j₃
+  by_cases h₁ : i₁ = j₁
+  · subst j₁
+    by_cases h₂ : i₂ = j₂
+    · subst j₂
+      by_cases h₃ : i₃ = j₃
+      · subst j₃
+        simp only [threeSiteState, Matrix.diagonal_apply_eq]
+        rw [tensor, if_pos rfl, tensor, if_pos rfl, tensor, if_pos rfl]
+        exact trace_sectorMatrix_product i₁ i₂ i₃ |>.symm
+      · rw [threeSiteState, Matrix.diagonal_apply_ne]
+        · simp [tensor, h₃]
+        · exact fun h => h₃ (congrArg (fun x => x.2.2) h)
+    · rw [threeSiteState, Matrix.diagonal_apply_ne]
+      · simp [tensor, h₂]
+      · exact fun h => h₂ (congrArg (fun x => x.2.1) h)
+  · rw [threeSiteState, Matrix.diagonal_apply_ne]
+    · simp [tensor, h₁]
+    · exact fun h => h₁ (congrArg Prod.fst h)
+
+private lemma inverseTensor_diagonal_expansion (alpha beta : Fin 2) :
+    ∑ i : Fin 4,
+        inverseTensor tensor tensor_isInjective (finProdFinEquiv (i, i)) alpha beta •
+          sectorMatrix i =
+      Matrix.single alpha beta (1 : ℂ) := by
+  have h := inverseTensor_spec tensor tensor_isInjective alpha beta
+  rw [← Equiv.sum_comp finProdFinEquiv] at h
+  rw [Fintype.sum_prod_type] at h
+  simpa only [MPOTensor.toMPSTensor, tensor, MPSTensor.finProdFinEquiv_divNat,
+    MPSTensor.finProdFinEquiv_modNat, smul_ite, smul_zero, Finset.sum_ite_eq,
+    Finset.mem_univ, if_pos] using h
+
+private lemma hayashiInverseLeft_eq (beta : Fin 2) (k : Fin 4)
+    (l l' : Fin (etaStructure.dL k)) :
+    hayashiInverseLeft tensor tensor_isInjective etaStructure 0 beta k l l' =
+      4 * leftPairing beta k := by
+  change Fin 1 at l l'
+  fin_cases l
+  fin_cases l'
+  have h := inverseTensor_diagonal_expansion 0 beta
+  have h00 := congrFun (congrFun h 0) 0
+  have h01 := congrFun (congrFun h 0) 1
+  fin_cases beta <;> fin_cases k
+  all_goals
+    norm_num [sectorMatrix, leftPairing, rightPairing, Fin.sum_univ_four,
+      Matrix.vecMulVec_apply, Matrix.cons_val_two, Matrix.cons_val_three] at h00 h01
+    simp [hayashiInverseLeft, etaStructure, markovLeft, traceMatrix,
+      leftPairing, rightPairing, Matrix.mul_apply, Fin.sum_univ_two,
+      Fin.sum_univ_four, Matrix.cons_val_two,
+      Matrix.cons_val_three];
+      first | linear_combination h00 + 4 * h01 | linear_combination h00 - 4 * h01
+
+private lemma hayashiInverseRight_eq (alpha : Fin 2) (k : Fin 4)
+    (r r' : Fin (etaStructure.dR k)) :
+    hayashiInverseRight tensor tensor_isInjective etaStructure alpha 0 k r r' =
+      rightPairing k alpha := by
+  change Fin 1 at r r'
+  fin_cases r
+  fin_cases r'
+  have h := inverseTensor_diagonal_expansion alpha 0
+  have h00 := congrFun (congrFun h 0) 0
+  have h10 := congrFun (congrFun h 1) 0
+  fin_cases alpha <;> fin_cases k
+  all_goals
+    norm_num [sectorMatrix, leftPairing, rightPairing, Fin.sum_univ_four,
+      Matrix.vecMulVec_apply, Matrix.cons_val_two, Matrix.cons_val_three] at h00 h10
+    simp [hayashiInverseRight, etaStructure, markovRight, traceMatrix,
+      leftPairing, rightPairing, Matrix.mul_apply, Fin.sum_univ_two,
+      Fin.sum_univ_four, Matrix.cons_val_two,
+      Matrix.cons_val_three];
+      first | linear_combination h00 + (1 / 8) * h10 |
+        linear_combination h00 - (1 / 8) * h10
+
+private lemma selectedTail_ne_zero :
+    (leftPairing * rightPairing) 0 0 ≠ 0 := by
+  rw [leftPairing_mul_rightPairing]
+  norm_num
+
+/-- For the four-sector tensor, the left factor constructed by the arbitrary
+right inverse in Appendix C.2 is exactly the displayed left sector vector.
+
+This is a provenance statement for this explicit tensor.  It does not assert
+the general rank-one conclusion printed in Lemma C.5.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `Qketc`, lines 1415--1428,
+and equation `formK`, lines 1434--1439. -/
+theorem inverseMap_sectorTensorL_eq (k : Fin 4) (beta : Fin 2) :
+    sectorTensorL tensor tensor_isInjective etaStructure
+        (leftPairing * rightPairing) 0 0 k beta =
+      factorization.leftTensor k beta := by
+  ext l l'
+  rw [sectorTensorL]
+  simp only [Matrix.of_apply]
+  rw [hayashiInverseLeft_eq]
+  rw [leftPairing_mul_rightPairing]
+  simp [etaStructure, p, factorization]
+
+/-- For the four-sector tensor, the right factor constructed by the arbitrary
+right inverse in Appendix C.2 is exactly the displayed right sector vector.
+
+This is a provenance statement for this explicit tensor.  It does not assert
+the general rank-one conclusion printed in Lemma C.5.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `Qketc`, lines 1415--1428,
+and equation `formK`, lines 1434--1439. -/
+theorem inverseMap_sectorTensorR_eq (k : Fin 4) (alpha : Fin 2) :
+    sectorTensorR tensor tensor_isInjective etaStructure 0 k alpha =
+      factorization.rightTensor k alpha := by
+  ext r r'
+  rw [sectorTensorR]
+  simp only [Matrix.of_apply]
+  rw [hayashiInverseRight_eq]
+  rfl
+
+/-- The inverse-map physical-sector factorization has exactly the displayed
+left and right sector tensors for the four-sector classical example.
+
+Thus the arbitrary choice of right inverse does not remove this example: the
+inverse-map construction recovers its non-idempotent active-sector trace
+matrix.  The theorem is deliberately restricted to the explicit tensor and
+does not prove the paper's general rank-one inference.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1415--1445. -/
+theorem inverseMap_factorization_recovers_displayed_tensors :
+    (∀ k beta,
+      (inverseMapPhysicalSectorFactorization tensor tensor_isInjective
+          (leftPairing * rightPairing) isThreeSiteClosure_threeSiteState
+          etaStructure 0 0 selectedTail_ne_zero).leftTensor k beta =
+        factorization.leftTensor k beta) ∧
+    (∀ k alpha,
+      (inverseMapPhysicalSectorFactorization tensor tensor_isInjective
+          (leftPairing * rightPairing) isThreeSiteClosure_threeSiteState
+          etaStructure 0 0 selectedTail_ne_zero).rightTensor k alpha =
+        factorization.rightTensor k alpha) := by
+  constructor
+  · exact inverseMap_sectorTensorL_eq
+  · exact inverseMap_sectorTensorR_eq
+
+end MPOTensor.ActiveSectorSpanningCounterexample

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity.tex
@@ -489,6 +489,45 @@
     $Q(1-LQ)L=QL-(QL)^2\ne0$.
 \end{proof}
 
+\begin{theorem}[Inverse-map provenance of the four-sector example]
+    \label{thm:mpdo_four_sector_inverse_map_provenance}
+    \lean{MPOTensor.ActiveSectorSpanningCounterexample.%
+      inverseMap_factorization_recovers_displayed_tensors}
+    \leanok
+    \uses{thm:mpdo_virtual_spanning_active_trace_counterexample,
+      def:mpdo_inverse_map_physical_sector_factorization}
+    The four-sector classical tensor admits a four-block Hayashi decomposition
+    of its normalized three-site state such that, with virtual tail $LQ$ and
+    outer indices both equal to zero, the inverse-map construction recovers
+    exactly the displayed left factors $L_{\beta,k}$ and right factors
+    $Q_{k,\alpha}$.
+
+    Thus the freedom in choosing a right inverse of the injective tensor map
+    does not remove the non-idempotent active-sector trace matrix $QL$ in this
+    example. This assertion is restricted to the explicit four-sector tensor;
+    it does not assert the general rank-one conclusion printed in Lemma~C.5.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The three-site state is the diagonal classical Markov state
+    \[
+      \rho(i,j,k)=\frac14(QL)_{i,j}(QL)_{j,k}.
+    \]
+    Its middle sector is the symbol $j$, with weight $1/4$, left conditional
+    density $\operatorname{diag}((QL)_{i,j})_i$, and right conditional density
+    $\operatorname{diag}((QL)_{j,k})_k$. The identity
+    $(QL)^2=\frac14\mathbf 1\mathbf 1^{\mathsf T}$ shows that this state is the
+    three-site closure against $LQ$.
+
+    Apply the arbitrary right inverse only through its defining contraction
+    with the four diagonal physical slices. Evaluating the resulting matrix
+    unit identity in the first row gives the left inverse factors, and
+    evaluating it in the first column gives the right inverse factors. Since
+    $(LQ)_{0,0}=1$, the normalization in the left factor cancels the sector
+    weight, leaving precisely $L$ and $Q$.
+\end{proof}
+
 \begin{theorem}[Positivity of bipartite partial traces]
     \label{thm:matrix_possemidef_partial_traces}
     \lean{Matrix.PosSemidef.traceLeft}

--- a/docs/paper-gaps/cpgsv17_pf_rank_one.tex
+++ b/docs/paper-gaps/cpgsv17_pf_rank_one.tex
@@ -26,9 +26,11 @@ underlying question was isolated in
 counterexample was added in
 \href{https://github.com/LionSR/TNLean/pull/849}{pull request \#849}; and the
 positive-semidefinite replacement theorem was added in
-\href{https://github.com/LionSR/TNLean/pull/917}{pull request \#917}. The open
-final inverse-map provenance audit and the obstruction verdict are recorded in
-\href{https://github.com/LionSR/TNLean/issues/3593}{issue \#3593}. The
+\href{https://github.com/LionSR/TNLean/pull/917}{pull request \#917}. The
+source audit and obstruction verdict are recorded in
+\href{https://github.com/LionSR/TNLean/issues/3593}{issue \#3593}; the explicit
+inverse-map provenance question is recorded in
+\href{https://github.com/LionSR/TNLean/issues/4270}{issue \#4270}. The
 source passage is
 \path{Papers/1606.00608/MPDO-22-12-17-2.tex:1394--1499}.}
 
@@ -399,21 +401,21 @@ nilpotent remainder, are proved in
 \footnote{\sloppy Combined formal declaration:
 {\scriptsize\leanid{TNLean.Archive.PerronFrobeniusVirtualSpanningCounterexample.injective_sourceZCL_tensor_with_nilpotent_sector_pairing}}.}
 
-The construction does not yet identify $L$ and $Q$ with the particular closed
-tensors selected from a Hayashi decomposition by
-\leanid{MPOTensor.zeroWeightReparameterizedInverseMapPhysicalSectorFactorization}.
-This distinction is essential.  The theorem above supplies a directly chosen
-rectangular realization; it does not supply the Hayashi structure, normalized
-tail entry, inverse-map indices, and rephasing data from which the source
-factorization is constructed.  Thus it is not a counterexample to the full
-statement of Lemma~C.5.
+The explicit three-site Hayashi decomposition now identifies $L$ and $Q$ with
+the closed tensors selected by
+\leanid{MPOTensor.inverseMapPhysicalSectorFactorization}.  The Hayashi sectors
+are the four classical symbols, the tail is $LQ$, and both selected outer
+indices are zero.  The theorem
+{\scriptsize\leanid{MPOTensor.ActiveSectorSpanningCounterexample.inverseMap_factorization_recovers_displayed_tensors}}
+proves that the arbitrary inverse-map tensor recovers precisely the directly
+displayed rectangular realization.
 
 The obstruction instead proves that every presently exported algebraic
 consequence---source ZCL, injectivity, primitivity, trace normalization,
 rectangular pairing idempotence, constant positive-power traces, and full
-virtual spanning---is insufficient.  A source-faithful completion must derive
-an additional identity from SAL and from the provenance of the inverse-map
-tensors.  In the notation above, the needed assertion is precisely
+virtual spanning---is insufficient.  The inverse-map provenance supplies no
+additional identity.  In the notation above, the missing assertion is
+precisely
 \[
  Q(1-LQ)L=0,
 \]
@@ -494,22 +496,22 @@ is not yet a theorem about
 the formal counterexample theorem does not contain an \leanid{IsSAL}
 conjunct.
 
-The remaining boundary is solely one of provenance.  The displayed
-\leanid{MPOTensor.ActiveSectorSpanningCounterexample.factorization} satisfies
-the exact fields of \leanid{MPOTensor.PhysicalSectorFactorization}, hence the
-direct-sum factorization conclusion displayed in Lemma~C.4, and it has the
-recorded positivity and primitivity properties.  It is nevertheless built
-directly, rather than as an instance of
-\leanid{MPOTensor.zeroWeightReparameterizedInverseMapPhysicalSectorFactorization}.
-The source-minimal structure deliberately forgets the Hayashi decomposition,
-tail choice, inverse-map indices, and rephasing which produced it.  No theorem
-presently identifies the chosen factorization with the source-selected one.
-The example is therefore a counterexample to the printed universal matrix
-inference from the displayed Lemma~C.4 conclusions and ZCL, but is not yet a
-genuine counterexample to Lemma~C.5.  Deciding that last point requires either
-realizing this factorization from explicit source provenance, or proving that
-such provenance forces $Q(1-LQ)L=0$; this focused provenance question is
-tracked in \ghissue{4270}.
+The inverse-map provenance is now explicit.  The normalized three-site state
+has the four-sector Hayashi decomposition with weights $1/4$, left conditional
+densities $\operatorname{diag}((QL)_{i,k})_i$, and right conditional densities
+$\operatorname{diag}((QL)_{k,j})_j$.  Closing three tensor copies against the
+tail $LQ$ gives this state because $(QL)^2$ is the matrix with every entry
+$1/4$.  Applying the arbitrary right inverse through its defining matrix-unit
+contraction then recovers exactly the displayed columns of $L$ and rows of
+$Q$; the selected tail entry is $(LQ)_{0,0}=1$.
+\footnote{The formal construction and comparison theorem are in
+\doclink{TNLean/MPS/MPDO/ActiveSectorInverseMapProvenance}; see
+{\scriptsize\leanid{MPOTensor.ActiveSectorSpanningCounterexample.inverseMap_factorization_recovers_displayed_tensors}}.}
+Thus inverse-map provenance does not force $Q(1-LQ)L=0$ and does not remove
+the example.  The remaining formal step toward a theorem-level counterexample
+to Lemma~C.5 is the entropy proof that the induced cyclic family satisfies
+\leanid{IsSAL}; the calculation above already establishes this mathematical
+fact.
 
 \section{A positive-semidefinite route}
 
@@ -638,14 +640,12 @@ Consequently the strongest source-faithful common-matrix conclusion remains
 together with entrywise nonnegativity and primitivity.  The formal
 counterexample shows that these conclusions, even supplemented by injectivity,
 full virtual spanning, and positivity of every neighboring operator, do not
-imply the missing vanishing.  Its induced classical cyclic family does satisfy
-the strong area law by the entropy calculation above.  However, the directly
-chosen \leanid{PhysicalSectorFactorization} has not been identified with the
-particular inverse-map factorization produced from the Hayashi decomposition.
-The example therefore refutes the printed matrix inference but does not yet
-refute Lemma~C.5 itself.  The source proof remains obstructed because it
-derives no identity from the inverse-map provenance that excludes the
-nilpotent remainder.
+imply the missing vanishing.  Its induced classical cyclic family satisfies
+the strong area law by the entropy calculation above, and the explicit
+Hayashi decomposition together with the inverse-map contraction recovers the
+same displayed factorization.  Hence the inverse-map provenance supplies no
+identity excluding the nilpotent remainder.  A fully formal counterexample to
+Lemma~C.5 now requires only the remaining entropy-to-\leanid{IsSAL} theorem.
 
 This obstruction propagates to every source statement whose proof invokes the
 rank-one factorization from Lemma~C.5.  In particular, the structural
@@ -676,13 +676,16 @@ For the unconditional matrix product density operator argument, it would
 suffice to derive positive semidefiniteness, linear independence, or any
 equivalent exclusion of the generalized zero-eigenspace from the stated SAL
 and ZCL hypotheses.  The source and inverse-map provenance audit provides no
-such derivation.  Lemma~C.5 is therefore classified as obstructed, rather than
-formalized or refuted.  The same status applies to its structural corollary and
+such derivation; in the explicit four-sector family it recovers exactly the
+factorization with nonzero remainder.  Lemma~C.5 is therefore mathematically
+refuted by the four-sector SAL family, while its fully formal counterexample
+awaits the entropy-to-\leanid{IsSAL} theorem.  The same source gap applies to
+its structural corollary and
 to the source implications (ii)$\Rightarrow$(iv) and (ii)$\Rightarrow$(v) of
 Theorem~4.9.  Their corrected conditional forms remain available, but the
 additional conditions must not be attributed to the source theorem.  The
-remaining decision whether the four-sector SAL example is realized by the
-source-selected inverse-map factorization is isolated in \ghissue{4270}.
+inverse-map provenance question isolated in \ghissue{4270} is settled by the
+explicit construction above.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

- construct the explicit four-sector Hayashi decomposition of the normalized three-site classical state
- prove that it is the three-site closure of the counterexample tensor against the tail `LQ`
- use only the defining matrix-unit identity of the arbitrary right inverse to prove that the inverse-map construction recovers exactly the displayed factors `L` and `Q`
- update the blueprint and the Perron--Frobenius paper-gap audit: inverse-map provenance does not remove the non-idempotent remainder; the remaining formal step is the entropy-to-`IsSAL` theorem

This result is deliberately restricted to the explicit four-sector family. It settles the provenance question in #4270 and does not assert the general rank-one inference printed in CPSV16 Lemma C.5.

Closes #4270.

## Source

CPSV16, Appendix C.2, lines 1406--1499, especially the inverse-map contraction at lines 1415--1438 and Lemma C.5 at lines 1473--1499.

## Validation

- `lake env lean TNLean/MPS/MPDO/ActiveSectorInverseMapProvenance.lean`
- `lake build`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/MPS/MPDO/ActiveSectorInverseMapProvenance.lean`
- `git diff --check`

`leanblueprint checkdecls` was attempted, but this environment could not generate `blueprint/lean_decls`: the local plasTeX process could not import the installed `leanblueprint` Python module. The new Lean declaration itself is built and exported from `TNLean.lean`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new formal proofs in a specialized MPDO/paper-gap track; scope is explicit to one tensor and does not change general inverse-map APIs, but misstatement in the audit doc could mislead reviewers on Lemma C.5 status.
> 
> **Overview**
> Adds **`ActiveSectorInverseMapProvenance.lean`** for the four-sector classical counterexample: a four-block Hayashi decomposition of the normalized three-site Markov state, three-site closure against tail **`LQ`**, and proofs (via the inverse map’s matrix-unit contraction only) that **`inverseMapPhysicalSectorFactorization`** matches the already displayed **`factorization`** left/right tensors — **`inverseMap_factorization_recovers_displayed_tensors`**.
> 
> Wires the module into **`TNLean.lean`**, adds blueprint theorem **`thm:mpdo_four_sector_inverse_map_provenance`**, and revises **`cpgsv17_pf_rank_one.tex`** so issue **#4270** is settled: inverse-map provenance does not force **`Q(1-LQ)L=0`** or remove the non-idempotent example; a fully formal Lemma C.5 counterexample still needs the entropy-to-**`IsSAL`** step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7fa12df1ef9ddcc1170e1f26c6bb7b948298247. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->