### PR TITLE
feat(MPS/MPDO): identify inverse-map counterexample factors

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -528,6 +528,7 @@ import TNLean.MPS.MPDO.PhysicalSectorPhysicalTransport
 import TNLean.MPS.MPDO.SectorPairingTransfer
 import TNLean.MPS.MPDO.InverseMapActiveSectorZCL
 import TNLean.MPS.MPDO.ActiveSectorSpanningCounterexample
+import TNLean.MPS.MPDO.ActiveSectorInverseMapProvenance
 import TNLean.MPS.MPDO.SectorEtaContraction
 import TNLean.MPS.MPDO.SectorEtaOperator
 import TNLean.MPS.MPDO.SectorEtaPositivity

--- a/TNLean/MPS/MPDO/ActiveSectorInverseMapProvenance.lean
+++ b/TNLean/MPS/MPDO/ActiveSectorInverseMapProvenance.lean
@@ -27,7 +27,7 @@ namespace MPOTensor.ActiveSectorSpanningCounterexample
 unit from the four nonzero physical slices.
 
 Source: arXiv:1606.00608, Appendix C.2, lines 1413--1428. -/
-lemma sum_inverseTensor_diagonal (alpha beta : Fin 2) :
+private lemma sum_inverseTensor_diagonal (alpha beta : Fin 2) :
     (∑ i : Fin 4,
         inverseTensor tensor tensor_isInjective (finProdFinEquiv (i, i)) alpha beta •
           sectorMatrix i) = Matrix.single alpha beta (1 : ℂ) := by
@@ -62,7 +62,7 @@ lemma sum_inverseTensor_diagonal (alpha beta : Fin 2) :
 /-- The four nonzero physical slices form a basis of the virtual matrix
 space, not merely a spanning family.  This is a property of the explicit
 counterexample tensor. -/
-lemma sectorMatrix_linearIndependent : LinearIndependent ℂ sectorMatrix := by
+private lemma sectorMatrix_linearIndependent : LinearIndependent ℂ sectorMatrix := by
   rw [Fintype.linearIndependent_iff]
   intro c hzero k
   have h00 := congrFun (congrFun hzero 0) 0
@@ -92,7 +92,7 @@ private noncomputable def dualCoefficient (i : Fin 4) : Matrix (Fin 2) (Fin 2) �
 four sector matrices.
 
 Source: arXiv:1606.00608, Appendix C.2, lines 1415--1439. -/
-lemma inverseTensor_diagonal_eq_dualCoefficient (i : Fin 4) :
+private lemma inverseTensor_diagonal_eq_dualCoefficient (i : Fin 4) :
     inverseTensor tensor tensor_isInjective (finProdFinEquiv (i, i)) =
       dualCoefficient i := by
   ext alpha beta
@@ -165,14 +165,14 @@ lemma normalizedFourSiteTail_tensor :
 /-- The left density matrix in the four one-dimensional Hayashi sectors.
 
 Source: arXiv:1606.00608, Appendix C.2, Lemma C.3, lines 1351--1363. -/
-noncomputable def hayashiLeftDensity (k : Fin 4) :
+private noncomputable def hayashiLeftDensity (k : Fin 4) :
     Matrix (Fin 4 × Fin 1) (Fin 4 × Fin 1) ℂ :=
   Matrix.diagonal fun x => (rightPairing * leftPairing) x.1 k
 
 /-- The right density matrix in the four one-dimensional Hayashi sectors.
 
 Source: arXiv:1606.00608, Appendix C.2, Lemma C.3, lines 1351--1363. -/
-noncomputable def hayashiRightDensity (k : Fin 4) :
+private noncomputable def hayashiRightDensity (k : Fin 4) :
     Matrix (Fin 1 × Fin 4) (Fin 1 × Fin 4) ℂ :=
   Matrix.diagonal fun x => (rightPairing * leftPairing) k x.2
 
@@ -259,7 +259,7 @@ private lemma trace_three_sectorMatrices_mul_transfer (i j k : Fin 4) :
 four-site tail selected in Appendix C.2.
 
 Source: arXiv:1606.00608, Appendix C.2, lines 1413--1418. -/
-lemma isThreeSiteClosure_threeSiteState :
+private lemma isThreeSiteClosure_threeSiteState :
     IsThreeSiteClosure tensor (normalizedFourSiteTail tensor) threeSiteState := by
   intro i₁ i₂ i₃ j₁ j₂ j₃
   rw [normalizedFourSiteTail_tensor]

--- a/TNLean/MPS/MPDO/ActiveSectorInverseMapProvenance.lean
+++ b/TNLean/MPS/MPDO/ActiveSectorInverseMapProvenance.lean
@@ -91,8 +91,7 @@ private noncomputable def dualCoefficient (i : Fin 4) : Matrix (Fin 2) (Fin 2) �
 /-- The inverse tensor on a diagonal physical slice is the dual basis to the
 four sector matrices.
 
-Source: arXiv:1606.00608, Appendix C.2, equations `Qketc` and `formK`, lines
-1415--1439. -/
+Source: arXiv:1606.00608, Appendix C.2, lines 1415--1439. -/
 lemma inverseTensor_diagonal_eq_dualCoefficient (i : Fin 4) :
     inverseTensor tensor tensor_isInjective (finProdFinEquiv (i, i)) =
       dualCoefficient i := by
@@ -165,16 +164,14 @@ lemma normalizedFourSiteTail_tensor :
 
 /-- The left density matrix in the four one-dimensional Hayashi sectors.
 
-Source: arXiv:1606.00608, Appendix C.2, Lemma C.3 (`Lsigma3`), lines
-1351--1363. -/
+Source: arXiv:1606.00608, Appendix C.2, Lemma C.3, lines 1351--1363. -/
 noncomputable def hayashiLeftDensity (k : Fin 4) :
     Matrix (Fin 4 × Fin 1) (Fin 4 × Fin 1) ℂ :=
   Matrix.diagonal fun x => (rightPairing * leftPairing) x.1 k
 
 /-- The right density matrix in the four one-dimensional Hayashi sectors.
 
-Source: arXiv:1606.00608, Appendix C.2, Lemma C.3 (`Lsigma3`), lines
-1351--1363. -/
+Source: arXiv:1606.00608, Appendix C.2, Lemma C.3, lines 1351--1363. -/
 noncomputable def hayashiRightDensity (k : Fin 4) :
     Matrix (Fin 1 × Fin 4) (Fin 1 × Fin 4) ℂ :=
   Matrix.diagonal fun x => (rightPairing * leftPairing) k x.2
@@ -216,8 +213,7 @@ private lemma trace_hayashiRightDensity (k : Fin 4) :
 /-- The explicit classical three-site state used in the refined Hayashi
 decomposition.
 
-Source: arXiv:1606.00608, Appendix C.2, Lemma C.3 (`Lsigma3`), lines
-1351--1363. -/
+Source: arXiv:1606.00608, Appendix C.2, Lemma C.3, lines 1351--1363. -/
 noncomputable def threeSiteState :
     Matrix (Fin 4 × Fin 4 × Fin 4) (Fin 4 × Fin 4 × Fin 4) ℂ :=
   fun x y => if x = y then
@@ -296,8 +292,8 @@ lemma isThreeSiteClosure_threeSiteState :
 state. Each middle-site classical label is retained as a one-dimensional
 direct-sum sector.
 
-Source: arXiv:1606.00608, Appendix C.2, Lemma C.3 (`Lsigma3`), lines
-1351--1363, used in Lemma C.4 at lines 1413--1455. -/
+Source: arXiv:1606.00608, Appendix C.2, Lemma C.3, lines 1351--1363,
+used in Lemma C.4 at lines 1413--1455. -/
 noncomputable def hayashiData : EtaStructure threeSiteState where
   m := 4
   dL := fun _ => 1
@@ -356,8 +352,7 @@ private lemma sum_mul_hayashiRightDensity (f : Fin 4 → Fin 4 → ℂ) (k : Fin
 the chosen left sector tensor exactly. The factor `p_k = 1/4` cancels the
 factor four in the left inverse contraction.
 
-Source: arXiv:1606.00608, Appendix C.2, equations `Qketc` and `formK`,
-lines 1415--1439. -/
+Source: arXiv:1606.00608, Appendix C.2, lines 1415--1439. -/
 lemma sectorTensorL_hayashiData (k : Fin 4) (beta : Fin 2) :
     sectorTensorL tensor tensor_isInjective hayashiData
         (normalizedFourSiteTail tensor) 0 0 k beta =
@@ -381,8 +376,7 @@ lemma sectorTensorL_hayashiData (k : Fin 4) (beta : Fin 2) :
 /-- For the refined Hayashi decomposition, the source inverse map recovers
 the chosen right sector tensor exactly.
 
-Source: arXiv:1606.00608, Appendix C.2, equations `Qketc` and `formK`,
-lines 1415--1439. -/
+Source: arXiv:1606.00608, Appendix C.2, lines 1415--1439. -/
 lemma sectorTensorR_hayashiData (k : Fin 4) (alpha : Fin 2) :
     sectorTensorR tensor tensor_isInjective hayashiData 0 k alpha =
       factorization.rightTensor k alpha := by
@@ -418,8 +412,7 @@ noncomputable def inverseMapFactorization : PhysicalSectorFactorization tensor :
 /-- The neighboring operators selected by the explicit inverse-map provenance
 are exactly those of the directly written factorization.
 
-Source: arXiv:1606.00608, Appendix C.2, equation `etarl`, lines
-1441--1455. -/
+Source: arXiv:1606.00608, Appendix C.2, lines 1441--1455. -/
 lemma inverseMapFactorization_neighboringOperator (k h : Fin 4) :
     inverseMapFactorization.neighboringOperator k h =
       factorization.neighboringOperator k h := by
@@ -445,8 +438,7 @@ provenance. Thus the arbitrary-factorization boundary isolated previously is
 removed for this witness; the separate formalization of SAL is not asserted
 here.
 
-Source: arXiv:1606.00608, Appendix C.2, Lemma C.5 (`SALZCL`), lines
-1484--1499. -/
+Source: arXiv:1606.00608, Appendix C.2, Lemma C.5, lines 1484--1499. -/
 theorem inverseMap_provenance_preserves_rectangular_remainder :
     (∀ k h, inverseMapFactorization.neighboringOperator k h =
       factorization.neighboringOperator k h) ∧

--- a/TNLean/MPS/MPDO/ActiveSectorInverseMapProvenance.lean
+++ b/TNLean/MPS/MPDO/ActiveSectorInverseMapProvenance.lean
@@ -1,0 +1,456 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.ActiveSectorSpanningCounterexample
+import TNLean.MPS.MPDO.PhysicalSectorPruning
+
+/-!
+# Inverse-map provenance of the four-sector example
+
+This file computes the inverse-map tensors selected from an explicit Hayashi
+decomposition of the three-site marginal of the four-sector classical tensor
+in `ActiveSectorSpanningCounterexample`.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, lines 1413--1499
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+namespace MPOTensor.ActiveSectorSpanningCounterexample
+
+/-- The diagonal inverse-tensor coefficients reconstruct each virtual matrix
+unit from the four nonzero physical slices.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1413--1428. -/
+lemma sum_inverseTensor_diagonal (alpha beta : Fin 2) :
+    (∑ i : Fin 4,
+        inverseTensor tensor tensor_isInjective (finProdFinEquiv (i, i)) alpha beta •
+          sectorMatrix i) = Matrix.single alpha beta (1 : ℂ) := by
+  calc
+    _ = ∑ q : Fin 4 × Fin 4,
+        inverseTensor tensor tensor_isInjective (finProdFinEquiv q) alpha beta •
+          tensor.toMPSTensor (finProdFinEquiv q) := by
+      rw [Fintype.sum_prod_type]
+      apply Finset.sum_congr rfl
+      intro i _
+      rw [Finset.sum_eq_single i]
+      · have hdiv : (finProdFinEquiv (i, i)).divNat = i :=
+          MPSTensor.finProdFinEquiv_divNat i i
+        have hmod : (finProdFinEquiv (i, i)).modNat = i :=
+          MPSTensor.finProdFinEquiv_modNat i i
+        simp [MPOTensor.toMPSTensor, tensor, hdiv, hmod]
+      · intro j _ hji
+        have hdiv : (finProdFinEquiv (i, j)).divNat = i :=
+          MPSTensor.finProdFinEquiv_divNat i j
+        have hmod : (finProdFinEquiv (i, j)).modNat = j :=
+          MPSTensor.finProdFinEquiv_modNat i j
+        have hij : i ≠ j := Ne.symm hji
+        simp [MPOTensor.toMPSTensor, tensor, hij, hdiv, hmod]
+      · simp
+    _ = ∑ q : Fin (4 * 4),
+        inverseTensor tensor tensor_isInjective q alpha beta • tensor.toMPSTensor q := by
+      exact (Equiv.sum_comp finProdFinEquiv (fun q =>
+        inverseTensor tensor tensor_isInjective q alpha beta • tensor.toMPSTensor q)).symm
+    _ = Matrix.single alpha beta (1 : ℂ) :=
+      inverseTensor_spec tensor tensor_isInjective alpha beta
+
+/-- The four nonzero physical slices form a basis of the virtual matrix
+space, not merely a spanning family.  This is a property of the explicit
+counterexample tensor. -/
+lemma sectorMatrix_linearIndependent : LinearIndependent ℂ sectorMatrix := by
+  rw [Fintype.linearIndependent_iff]
+  intro c hzero k
+  have h00 := congrFun (congrFun hzero 0) 0
+  have h01 := congrFun (congrFun hzero 0) 1
+  have h10 := congrFun (congrFun hzero 1) 0
+  have h11 := congrFun (congrFun hzero 1) 1
+  simp [sectorMatrix, leftPairing, rightPairing, Matrix.sum_apply,
+    Fin.sum_univ_four] at h00 h01 h10 h11
+  fin_cases k
+  · change c 0 = 0
+    linear_combination h00 + 8 * h01 + (1 / 4) * h10 + 2 * h11
+  · change c 1 = 0
+    linear_combination h00 + 8 * h01 - (1 / 4) * h10 - 2 * h11
+  · change c 2 = 0
+    linear_combination h00 - 8 * h01 + (1 / 4) * h10 - 2 * h11
+  · change c 3 = 0
+    linear_combination h00 - 8 * h01 - (1 / 4) * h10 + 2 * h11
+
+private noncomputable def dualCoefficient (i : Fin 4) : Matrix (Fin 2) (Fin 2) ℂ :=
+  match i with
+  | 0 => !![1, 8; 1 / 4, 2]
+  | 1 => !![1, 8; -1 / 4, -2]
+  | 2 => !![1, -8; 1 / 4, -2]
+  | 3 => !![1, -8; -1 / 4, 2]
+
+/-- The inverse tensor on a diagonal physical slice is the dual basis to the
+four sector matrices.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `Qketc` and `formK`, lines
+1415--1439. -/
+lemma inverseTensor_diagonal_eq_dualCoefficient (i : Fin 4) :
+    inverseTensor tensor tensor_isInjective (finProdFinEquiv (i, i)) =
+      dualCoefficient i := by
+  ext alpha beta
+  apply sub_eq_zero.mp
+  apply Fintype.linearIndependent_iff.mp sectorMatrix_linearIndependent
+    (fun j =>
+      inverseTensor tensor tensor_isInjective (finProdFinEquiv (j, j)) alpha beta -
+        dualCoefficient j alpha beta)
+  have hinv := sum_inverseTensor_diagonal alpha beta
+  have hdual :
+      (∑ j : Fin 4, dualCoefficient j alpha beta • sectorMatrix j) =
+        Matrix.single alpha beta (1 : ℂ) := by
+    ext x y
+    fin_cases alpha <;> fin_cases beta <;> fin_cases x <;> fin_cases y <;>
+      simp [dualCoefficient, sectorMatrix, leftPairing, rightPairing,
+        Fin.sum_univ_four, Matrix.single] <;> norm_num
+  simp only [sub_smul]
+  rw [Finset.sum_sub_distrib, hinv, hdual, sub_self]
+
+private lemma inverseTensor_diagonal_apply (i : Fin 4) (alpha beta : Fin 2) :
+    inverseTensor tensor tensor_isInjective (finProdFinEquiv (i, i)) alpha beta =
+      dualCoefficient i alpha beta :=
+  congrFun (congrFun (inverseTensor_diagonal_eq_dualCoefficient i) alpha) beta
+
+private lemma sum_evalWord_diagonal (N : ℕ) :
+    ∑ sigma : Fin N → Fin 4,
+        evalWord tensor (List.ofFn sigma) (List.ofFn sigma) =
+      physTraceTransfer tensor ^ N := by
+  induction N with
+  | zero => simp [evalWord_nil]
+  | succ N ih =>
+      rw [← (Fin.consEquiv (fun _ : Fin (N + 1) => Fin 4)).sum_comp,
+        Fintype.sum_prod_type]
+      have hlist : ∀ (a : Fin 4) (rho : Fin N → Fin 4),
+          List.ofFn (Fin.cons a rho : Fin (N + 1) → Fin 4) = a :: List.ofFn rho := by
+        intro a rho
+        simp [List.ofFn_succ, Fin.cons_zero, Fin.cons_succ]
+      calc
+        _ = ∑ a : Fin 4, ∑ rho : Fin N → Fin 4,
+            tensor a a * evalWord tensor (List.ofFn rho) (List.ofFn rho) := by
+              refine Finset.sum_congr rfl fun a _ => Finset.sum_congr rfl fun rho _ => ?_
+              change evalWord tensor (List.ofFn (Fin.cons a rho))
+                  (List.ofFn (Fin.cons a rho)) =
+                tensor a a * evalWord tensor (List.ofFn rho) (List.ofFn rho)
+              rw [hlist a rho, evalWord_cons]
+        _ = (∑ a : Fin 4, tensor a a) *
+              ∑ rho : Fin N → Fin 4,
+                evalWord tensor (List.ofFn rho) (List.ofFn rho) :=
+          (Finset.sum_mul_sum _ _ _ _).symm
+        _ = physTraceTransfer tensor ^ (N + 1) := by
+          rw [ih, pow_succ']
+          rfl
+
+private lemma trace_mpo_four :
+    (mpo tensor 4).trace = Matrix.trace (physTraceTransfer tensor ^ 4) := by
+  rw [← sum_evalWord_diagonal 4, Matrix.trace_sum]
+  simp only [Matrix.trace, Matrix.diag, mpo_apply, mpoMatrixEntry]
+
+/-- The source-normalized four-site tail is the idempotent physical-trace
+transfer of the example.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1413--1418. -/
+lemma normalizedFourSiteTail_tensor :
+    normalizedFourSiteTail tensor = leftPairing * rightPairing := by
+  have htrace : (mpo tensor 4).trace = 1 := by
+    rw [trace_mpo_four, physTraceTransfer_tensor, leftPairing_mul_rightPairing]
+    norm_num [Matrix.trace, pow_succ, Matrix.mul_apply, Fin.sum_univ_two]
+  rw [normalizedFourSiteTail, htrace, inv_one, one_smul, physTraceTransfer_tensor]
+
+/-- The left density matrix in the four one-dimensional Hayashi sectors.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma C.3 (`Lsigma3`), lines
+1351--1363. -/
+noncomputable def hayashiLeftDensity (k : Fin 4) :
+    Matrix (Fin 4 × Fin 1) (Fin 4 × Fin 1) ℂ :=
+  Matrix.diagonal fun x => (rightPairing * leftPairing) x.1 k
+
+/-- The right density matrix in the four one-dimensional Hayashi sectors.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma C.3 (`Lsigma3`), lines
+1351--1363. -/
+noncomputable def hayashiRightDensity (k : Fin 4) :
+    Matrix (Fin 1 × Fin 4) (Fin 1 × Fin 4) ℂ :=
+  Matrix.diagonal fun x => (rightPairing * leftPairing) k x.2
+
+private lemma hayashiLeftDensity_posSemidef (k : Fin 4) :
+    (hayashiLeftDensity k).PosSemidef := by
+  apply Matrix.PosSemidef.diagonal
+  rintro ⟨i, u⟩
+  fin_cases u
+  rw [rightPairing_mul_leftPairing]
+  fin_cases i <;> fin_cases k <;> norm_num [Complex.nonneg_iff]
+
+private lemma trace_hayashiLeftDensity (k : Fin 4) :
+    (hayashiLeftDensity k).trace = 1 := by
+  rw [Matrix.trace]
+  change (∑ x : Fin 4 × Fin 1, (rightPairing * leftPairing) x.1 k) = 1
+  rw [Fintype.sum_prod_type]
+  rw [rightPairing_mul_leftPairing]
+  fin_cases k <;> norm_num [Fin.sum_univ_four, Fin.sum_univ_one,
+    Matrix.cons_val_two, Matrix.cons_val_three]
+
+private lemma hayashiRightDensity_posSemidef (k : Fin 4) :
+    (hayashiRightDensity k).PosSemidef := by
+  apply Matrix.PosSemidef.diagonal
+  rintro ⟨u, i⟩
+  fin_cases u
+  rw [rightPairing_mul_leftPairing]
+  fin_cases k <;> fin_cases i <;> norm_num [Complex.nonneg_iff]
+
+private lemma trace_hayashiRightDensity (k : Fin 4) :
+    (hayashiRightDensity k).trace = 1 := by
+  rw [Matrix.trace]
+  change (∑ x : Fin 1 × Fin 4, (rightPairing * leftPairing) k x.2) = 1
+  rw [Fintype.sum_prod_type]
+  rw [rightPairing_mul_leftPairing]
+  fin_cases k <;> norm_num [Fin.sum_univ_four, Fin.sum_univ_one,
+    Matrix.cons_val_two, Matrix.cons_val_three]
+
+/-- The explicit classical three-site state used in the refined Hayashi
+decomposition.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma C.3 (`Lsigma3`), lines
+1351--1363. -/
+noncomputable def threeSiteState :
+    Matrix (Fin 4 × Fin 4 × Fin 4) (Fin 4 × Fin 4 × Fin 4) ℂ :=
+  fun x y => if x = y then
+    (1 / 4 : ℂ) * (rightPairing * leftPairing) x.1 x.2.1 *
+      (rightPairing * leftPairing) x.2.1 x.2.2
+    else 0
+
+private noncomputable def crossSectorMatrix (i j : Fin 4) :
+    Matrix (Fin 2) (Fin 2) ℂ :=
+  Matrix.vecMulVec (fun beta => leftPairing beta i) (fun alpha => rightPairing j alpha)
+
+private lemma sectorMatrix_eq_crossSectorMatrix (i : Fin 4) :
+    sectorMatrix i = crossSectorMatrix i i := rfl
+
+private lemma crossSectorMatrix_mul (i j k h : Fin 4) :
+    crossSectorMatrix i j * crossSectorMatrix k h =
+      (rightPairing * leftPairing) j k • crossSectorMatrix i h := by
+  ext x y
+  fin_cases x <;> fin_cases y <;>
+    simp [crossSectorMatrix, Matrix.vecMulVec_apply, Matrix.mul_apply,
+      Fin.sum_univ_two] <;> ring
+
+private lemma trace_crossSectorMatrix_mul_transfer (i k : Fin 4) :
+    Matrix.trace (crossSectorMatrix i k * (leftPairing * rightPairing)) = 1 / 4 := by
+  fin_cases i <;> fin_cases k <;>
+    norm_num [crossSectorMatrix, leftPairing, rightPairing, Matrix.trace,
+      Matrix.mul_apply, Fin.sum_univ_two]
+
+private lemma trace_three_sectorMatrices_mul_transfer (i j k : Fin 4) :
+    Matrix.trace
+        (sectorMatrix i * sectorMatrix j * sectorMatrix k *
+          (leftPairing * rightPairing)) =
+      (1 / 4 : ℂ) * (rightPairing * leftPairing) i j *
+        (rightPairing * leftPairing) j k := by
+  rw [sectorMatrix_eq_crossSectorMatrix, sectorMatrix_eq_crossSectorMatrix,
+    sectorMatrix_eq_crossSectorMatrix, crossSectorMatrix_mul,
+    Matrix.smul_mul, crossSectorMatrix_mul]
+  simp only [Matrix.smul_mul, Matrix.trace_smul, smul_smul]
+  rw [trace_crossSectorMatrix_mul_transfer]
+  ring
+
+/-- The explicit three-site state is the closure against the normalized
+four-site tail selected in Appendix C.2.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1413--1418. -/
+lemma isThreeSiteClosure_threeSiteState :
+    IsThreeSiteClosure tensor (normalizedFourSiteTail tensor) threeSiteState := by
+  intro i₁ i₂ i₃ j₁ j₂ j₃
+  rw [normalizedFourSiteTail_tensor]
+  by_cases h₁ : i₁ = j₁
+  · subst j₁
+    by_cases h₂ : i₂ = j₂
+    · subst j₂
+      by_cases h₃ : i₃ = j₃
+      · subst j₃
+        simp only [threeSiteState, if_pos]
+        simp only [tensor, if_pos]
+        exact (trace_three_sectorMatrices_mul_transfer i₁ i₂ i₃).symm
+      · have htuple : (i₁, i₂, i₃) ≠ (i₁, i₂, j₃) := by
+          intro h
+          exact h₃ (congrArg (fun x => x.2.2) h)
+        rw [threeSiteState, if_neg htuple]
+        simp [tensor, h₃]
+    · have htuple : (i₁, i₂, i₃) ≠ (i₁, j₂, j₃) := by
+        intro h
+        exact h₂ (congrArg (fun x => x.2.1) h)
+      rw [threeSiteState, if_neg htuple]
+      simp [tensor, h₂]
+  · have htuple : (i₁, i₂, i₃) ≠ (j₁, j₂, j₃) := by
+      intro h
+      exact h₁ (congrArg Prod.fst h)
+    rw [threeSiteState, if_neg htuple]
+    simp [tensor, h₁]
+
+/-- The refined four-sector Hayashi decomposition of the explicit three-site
+state. Each middle-site classical label is retained as a one-dimensional
+direct-sum sector.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma C.3 (`Lsigma3`), lines
+1351--1363, used in Lemma C.4 at lines 1413--1455. -/
+noncomputable def hayashiData : EtaStructure threeSiteState where
+  m := 4
+  dL := fun _ => 1
+  dR := fun _ => 1
+  decompB := sectorEquiv
+  U_B := ⟨1, by simp⟩
+  p := p
+  hp_nonneg := p_nonneg
+  hp_sum := sum_p
+  ρ_left := hayashiLeftDensity
+  ρ_right := hayashiRightDensity
+  hρ_left_dm := fun k => ⟨hayashiLeftDensity_posSemidef k,
+    trace_hayashiLeftDensity k⟩
+  hρ_right_dm := fun k => ⟨hayashiRightDensity_posSemidef k,
+    trace_hayashiRightDensity k⟩
+  h_state := by
+    ext x y
+    obtain ⟨i, ⟨⟨k, ⟨l, r⟩⟩, j⟩⟩ := x
+    obtain ⟨i', ⟨⟨k', ⟨l', r'⟩⟩, j'⟩⟩ := y
+    fin_cases l
+    fin_cases r
+    fin_cases l'
+    fin_cases r'
+    rw [HayashiMarkov.blockState_apply]
+    simp [Matrix.reindex_apply, Matrix.submatrix_apply, HayashiMarkov.liftB,
+      HayashiMarkov.abcEquiv, sectorEquiv, threeSiteState, p,
+      hayashiLeftDensity, hayashiRightDensity]
+    by_cases hii : i = i' <;> by_cases hkk : k = k' <;> by_cases hjj : j = j' <;>
+      simp [hii, hkk, hjj]
+
+private lemma sum_mul_hayashiLeftDensity (f : Fin 4 → Fin 4 → ℂ) (k : Fin 4) :
+    (∑ i : Fin 4, ∑ j : Fin 4, f i j * hayashiLeftDensity k (i, 0) (j, 0)) =
+      ∑ i : Fin 4, f i i * (rightPairing * leftPairing) i k := by
+  apply Finset.sum_congr rfl
+  intro i _
+  rw [Finset.sum_eq_single i]
+  · simp [hayashiLeftDensity]
+  · intro j _ hji
+    have hij : i ≠ j := Ne.symm hji
+    simp [hayashiLeftDensity, hij]
+  · simp
+
+private lemma sum_mul_hayashiRightDensity (f : Fin 4 → Fin 4 → ℂ) (k : Fin 4) :
+    (∑ i : Fin 4, ∑ j : Fin 4, f i j * hayashiRightDensity k (0, i) (0, j)) =
+      ∑ i : Fin 4, f i i * (rightPairing * leftPairing) k i := by
+  apply Finset.sum_congr rfl
+  intro i _
+  rw [Finset.sum_eq_single i]
+  · simp [hayashiRightDensity]
+  · intro j _ hji
+    have hij : i ≠ j := Ne.symm hji
+    simp [hayashiRightDensity, hij]
+  · simp
+
+/-- For the refined Hayashi decomposition, the source inverse map recovers
+the chosen left sector tensor exactly. The factor `p_k = 1/4` cancels the
+factor four in the left inverse contraction.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `Qketc` and `formK`,
+lines 1415--1439. -/
+lemma sectorTensorL_hayashiData (k : Fin 4) (beta : Fin 2) :
+    sectorTensorL tensor tensor_isInjective hayashiData
+        (normalizedFourSiteTail tensor) 0 0 k beta =
+      factorization.leftTensor k beta := by
+  ext x y
+  fin_cases x
+  fin_cases y
+  change ((normalizedFourSiteTail tensor 0 0)⁻¹ * (p k : ℂ) *
+      (∑ i : Fin 4, ∑ j : Fin 4,
+        inverseTensor tensor tensor_isInjective (finProdFinEquiv (i, j)) 0 beta *
+          hayashiLeftDensity k (i, 0) (j, 0))) = leftPairing beta k
+  rw [normalizedFourSiteTail_tensor, leftPairing_mul_rightPairing]
+  norm_num [p]
+  rw [sum_mul_hayashiLeftDensity]
+  simp_rw [inverseTensor_diagonal_apply]
+  rw [rightPairing_mul_leftPairing]
+  fin_cases k <;> fin_cases beta <;>
+    norm_num [dualCoefficient, leftPairing, Fin.sum_univ_four,
+      Matrix.cons_val_two, Matrix.cons_val_three]
+
+/-- For the refined Hayashi decomposition, the source inverse map recovers
+the chosen right sector tensor exactly.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `Qketc` and `formK`,
+lines 1415--1439. -/
+lemma sectorTensorR_hayashiData (k : Fin 4) (alpha : Fin 2) :
+    sectorTensorR tensor tensor_isInjective hayashiData 0 k alpha =
+      factorization.rightTensor k alpha := by
+  ext x y
+  fin_cases x
+  fin_cases y
+  change (∑ i : Fin 4, ∑ j : Fin 4,
+      inverseTensor tensor tensor_isInjective (finProdFinEquiv (i, j)) alpha 0 *
+        hayashiRightDensity k (0, i) (0, j)) = rightPairing k alpha
+  rw [sum_mul_hayashiRightDensity]
+  simp_rw [inverseTensor_diagonal_apply]
+  rw [rightPairing_mul_leftPairing]
+  fin_cases k <;> fin_cases alpha <;>
+    norm_num [dualCoefficient, rightPairing, Fin.sum_univ_four,
+      Matrix.cons_val_two, Matrix.cons_val_three]
+
+private lemma normalizedFourSiteTail_tensor_zero_zero_ne :
+    normalizedFourSiteTail tensor 0 0 ≠ 0 := by
+  rw [normalizedFourSiteTail_tensor, leftPairing_mul_rightPairing]
+  norm_num
+
+/-- The source-selected inverse-map factorization, including the inactive-sector
+reparameterization. In this example every Hayashi weight is `1/4`, so no
+sector is removed.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1413--1455. -/
+noncomputable def inverseMapFactorization : PhysicalSectorFactorization tensor :=
+  zeroWeightReparameterizedInverseMapPhysicalSectorFactorization
+    tensor tensor_isInjective (normalizedFourSiteTail tensor)
+      isThreeSiteClosure_threeSiteState hayashiData 0 0
+      normalizedFourSiteTail_tensor_zero_zero_ne
+
+/-- The neighboring operators selected by the explicit inverse-map provenance
+are exactly those of the directly written factorization.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `etarl`, lines
+1441--1455. -/
+lemma inverseMapFactorization_neighboringOperator (k h : Fin 4) :
+    inverseMapFactorization.neighboringOperator k h =
+      factorization.neighboringOperator k h := by
+  unfold inverseMapFactorization
+  rw [zeroWeightReparameterizedInverseMapPhysicalSectorFactorization_neighboringOperator]
+  have hk : hayashiData.p k ≠ 0 := by
+    change p k ≠ 0
+    norm_num [p]
+  rw [if_pos hk]
+  ext x y
+  obtain ⟨xR, xL⟩ := x
+  obtain ⟨yR, yL⟩ := y
+  fin_cases xR
+  fin_cases xL
+  fin_cases yR
+  fin_cases yL
+  simp only [sectorEta, Matrix.sum_apply, Matrix.kroneckerMap_apply,
+    PhysicalSectorFactorization.neighboringOperator_apply]
+  simp_rw [sectorTensorL_hayashiData, sectorTensorR_hayashiData]
+
+/-- The nonzero rectangular remainder survives the exact Hayashi/tail/inverse-map
+provenance. Thus the arbitrary-factorization boundary isolated previously is
+removed for this witness; the separate formalization of SAL is not asserted
+here.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma C.5 (`SALZCL`), lines
+1484--1499. -/
+theorem inverseMap_provenance_preserves_rectangular_remainder :
+    (∀ k h, inverseMapFactorization.neighboringOperator k h =
+      factorization.neighboringOperator k h) ∧
+    rightPairing * (1 - leftPairing * rightPairing) * leftPairing ≠ 0 :=
+  ⟨inverseMapFactorization_neighboringOperator, rectangular_remainder_ne_zero⟩
+
+end MPOTensor.ActiveSectorSpanningCounterexample

--- a/TNLean/MPS/MPDO/ActiveSectorSpanningCounterexample.lean
+++ b/TNLean/MPS/MPDO/ActiveSectorSpanningCounterexample.lean
@@ -24,9 +24,10 @@ while
 
 Thus spanning by the full virtual matrix algebra does not, by itself, prove
 the missing vanishing in the proof of Lemma C.5.  The induced classical cyclic
-family satisfies the strong area law mathematically, but the factorization
-below is chosen directly and has not been identified with the particular
-inverse-map factorization selected from the source Hayashi decomposition.
+family satisfies the strong area law mathematically.  The companion
+`ActiveSectorInverseMapProvenance` calculation identifies the factorization
+below with one selected by an explicit Hayashi decomposition, normalized tail,
+and inverse map.
 
 ## Main result
 
@@ -332,12 +333,11 @@ matrix is non-idempotent and the rectangular remainder is nonzero.
 
 This is a counterexample only to the proposed intermediate implication.  The
 formal statement does not assert the strong area law, although the induced
-classical cyclic family satisfies it by a direct entropy calculation.  What
-prevents this theorem from refuting Lemma C.5 of arXiv:1606.00608 is instead
-the unproved identification of the chosen direct-sum decomposition with the
-source-selected inverse-map factorization.  A proof of that lemma must use
-information beyond the concrete spanning and rectangular identities presently extracted from
-Appendix C.2, lines 1406--1499. -/
+classical cyclic family satisfies it by a direct entropy calculation.  The
+source-selected inverse-map identification is proved separately in
+`inverseMap_provenance_preserves_rectangular_remainder`.  A formal
+counterexample to Lemma C.5 of arXiv:1606.00608 still requires a theorem that
+the same tensor satisfies the strong area law. -/
 theorem virtual_spanning_does_not_force_rectangular_remainder_zero :
     tensor.IsInjective ∧ tensor.IsSourceZCL ∧
       physTraceTransfer tensor * physTraceTransfer tensor = physTraceTransfer tensor ∧

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -20,10 +20,11 @@
     \]
 \end{definition}
 
-% **Obstruction (rank-one trace matrix):** SAL and ZCL presently give only
-% \widehat T^2=\widehat T^3 and constant positive-power traces.  The missing
-% condition Q(1-LQ)L=0 is not obtained from the inverse-map construction.
-% Documented in docs/paper-gaps/cpgsv17_pf_rank_one.tex.
+% **Obstruction (strong area law for the explicit witness):** the source-selected
+% inverse-map construction does not force Q(1-LQ)L=0, as shown by
+% thm:mpdo_inverse_map_nonzero_rectangular_remainder below.  The same explicit
+% tensor has not yet been proved to satisfy SAL.  Documented in
+% docs/paper-gaps/cpgsv17_pf_rank_one.tex.
 \begin{lemma}[SAL and ZCL give a rank-one sector trace matrix]
     \label{lem:mpdo_sal_zcl_rank_one_trace_matrix}
     \notready
@@ -45,6 +46,37 @@
     This is Lemma~C.5 at
     \cite[Appendix~C.2, lines~1473--1499]{Cirac2016MPDO_arXiv}.
 \end{lemma}
+
+\begin{theorem}[Inverse-map factorization with a nonzero rectangular remainder]
+    \label{thm:mpdo_inverse_map_nonzero_rectangular_remainder}
+    \lean{MPOTensor.ActiveSectorSpanningCounterexample.sectorTensorL_hayashiData}
+    \lean{MPOTensor.ActiveSectorSpanningCounterexample.sectorTensorR_hayashiData}
+    \lean{MPOTensor.ActiveSectorSpanningCounterexample.%
+      inverseMap_provenance_preserves_rectangular_remainder}
+    \leanok
+    \uses{def:mpdo_zero_weight_reparameterized_inverse_map_factorization,
+        thm:mpdo_inverse_map_hayashi_sector_comparison}
+    There is a four-sector, bond-dimension-two tensor with a refined Hayashi
+    decomposition whose four sectors are one-dimensional and have weight
+    $1/4$.  For the normalized four-site tail $LQ$, the inverse-map
+    construction recovers the closed sector tensors $L$ and $Q$ exactly.  Its
+    neighboring operators therefore coincide with those obtained directly
+    from $L$ and $Q$, while
+    \[
+        Q(1-LQ)L\ne0.
+    \]
+    The inverse-map construction is the one in
+    \cite[Appendix~C.2, lines~1413--1455]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The four physical slices form a basis of the $2\times2$ matrices.  Computing
+    their dual basis and applying it to the two outer density matrices gives the
+    left and right inverse-map factors.  The factor four in the left contraction
+    is cancelled by the sector weight $1/4$.  Direct multiplication then gives
+    $Q(1-LQ)L\ne0$.
+\end{proof}
 
 % **Obstruction (dependence on Lemma C.5):** the source corollary includes the
 % unavailable rank-one trace factorization.  Documented in

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -50,13 +50,14 @@
 \begin{theorem}[Inverse-map factorization with a nonzero rectangular remainder]
     \label{thm:mpdo_inverse_map_nonzero_rectangular_remainder}
     \lean{MPOTensor.ActiveSectorSpanningCounterexample.normalizedFourSiteTail_tensor}
-    \lean{MPOTensor.ActiveSectorSpanningCounterexample.isThreeSiteClosure_threeSiteState}
+    \lean{MPOTensor.ActiveSectorSpanningCounterexample.threeSiteState}
     \lean{MPOTensor.ActiveSectorSpanningCounterexample.hayashiData}
     \lean{MPOTensor.ActiveSectorSpanningCounterexample.sectorTensorL_hayashiData}
     \lean{MPOTensor.ActiveSectorSpanningCounterexample.sectorTensorR_hayashiData}
     \lean{MPOTensor.ActiveSectorSpanningCounterexample.inverseMapFactorization}
     \lean{MPOTensor.ActiveSectorSpanningCounterexample.%
       inverseMapFactorization_neighboringOperator}
+    \lean{MPOTensor.ActiveSectorSpanningCounterexample.rectangular_remainder_ne_zero}
     \lean{MPOTensor.ActiveSectorSpanningCounterexample.%
       inverseMap_provenance_preserves_rectangular_remainder}
     \leanok
@@ -64,7 +65,13 @@
         thm:mpdo_inverse_map_hayashi_sector_comparison}
     There is a four-sector, bond-dimension-two tensor with a refined Hayashi
     decomposition whose four sectors are one-dimensional and have weight
-    $1/4$.  For the normalized four-site tail $LQ$, the inverse-map
+    $1/4$.  Its three-site state is diagonal, with
+    \[
+        \rho(i,j,k;i',j',k')
+        =\delta_{(i,j,k),(i',j',k')}\,
+          \frac14(QL)_{i,j}(QL)_{j,k}.
+    \]
+    The normalized four-site tail is $LQ$.  For this tail, the inverse-map
     construction recovers the closed sector tensors $L$ and $Q$ exactly.  Its
     neighboring operators therefore coincide with those obtained directly
     from $L$ and $Q$, while

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -49,8 +49,14 @@
 
 \begin{theorem}[Inverse-map factorization with a nonzero rectangular remainder]
     \label{thm:mpdo_inverse_map_nonzero_rectangular_remainder}
+    \lean{MPOTensor.ActiveSectorSpanningCounterexample.normalizedFourSiteTail_tensor}
+    \lean{MPOTensor.ActiveSectorSpanningCounterexample.isThreeSiteClosure_threeSiteState}
+    \lean{MPOTensor.ActiveSectorSpanningCounterexample.hayashiData}
     \lean{MPOTensor.ActiveSectorSpanningCounterexample.sectorTensorL_hayashiData}
     \lean{MPOTensor.ActiveSectorSpanningCounterexample.sectorTensorR_hayashiData}
+    \lean{MPOTensor.ActiveSectorSpanningCounterexample.inverseMapFactorization}
+    \lean{MPOTensor.ActiveSectorSpanningCounterexample.%
+      inverseMapFactorization_neighboringOperator}
     \lean{MPOTensor.ActiveSectorSpanningCounterexample.%
       inverseMap_provenance_preserves_rectangular_remainder}
     \leanok

--- a/docs/paper-gaps/cpgsv17_pf_rank_one.tex
+++ b/docs/paper-gaps/cpgsv17_pf_rank_one.tex
@@ -26,10 +26,11 @@ underlying question was isolated in
 counterexample was added in
 \href{https://github.com/LionSR/TNLean/pull/849}{pull request \#849}; and the
 positive-semidefinite replacement theorem was added in
-\href{https://github.com/LionSR/TNLean/pull/917}{pull request \#917}. The open
-final inverse-map provenance audit and the obstruction verdict are recorded in
-\href{https://github.com/LionSR/TNLean/issues/3593}{issue \#3593}. The
-source passage is
+\href{https://github.com/LionSR/TNLean/pull/917}{pull request \#917}. The
+inverse-map provenance question is recorded in
+\href{https://github.com/LionSR/TNLean/issues/4270}{issue \#4270}; the preceding
+audit and obstruction verdict are recorded in
+\href{https://github.com/LionSR/TNLean/issues/3593}{issue \#3593}. The source passage is
 \path{Papers/1606.00608/MPDO-22-12-17-2.tex:1394--1499}.}
 
 The paper constructs positive semidefinite neighboring operators $\eta_{k,h}$ and defines
@@ -494,21 +495,26 @@ is not yet a theorem about
 the formal counterexample theorem does not contain an \leanid{IsSAL}
 conjunct.
 
-The remaining boundary is solely one of provenance.  The displayed
-\leanid{MPOTensor.ActiveSectorSpanningCounterexample.factorization} satisfies
-the exact fields of \leanid{MPOTensor.PhysicalSectorFactorization}, hence the
-direct-sum factorization conclusion displayed in Lemma~C.4, and it has the
-recorded positivity and primitivity properties.  It is nevertheless built
-directly, rather than as an instance of
-\leanid{MPOTensor.zeroWeightReparameterizedInverseMapPhysicalSectorFactorization}.
-The source-minimal structure deliberately forgets the Hayashi decomposition,
-tail choice, inverse-map indices, and rephasing which produced it.  No theorem
-presently identifies the chosen factorization with the source-selected one.
-The example is therefore a counterexample to the printed universal matrix
-inference from the displayed Lemma~C.4 conclusions and ZCL, but is not yet a
-genuine counterexample to Lemma~C.5.  Deciding that last point requires either
-realizing this factorization from explicit source provenance, or proving that
-such provenance forces $Q(1-LQ)L=0$; this focused provenance question is
+The inverse-map provenance is now explicit.  The refined Hayashi decomposition
+has four one-dimensional sectors of weight $1/4$, with diagonal left and right
+density matrices determined by $QL$.  Its normalized four-site tail is $LQ$.
+The four nonzero physical slices form a basis of the virtual matrix algebra;
+computing the dual basis shows that the source inverse map recovers the
+displayed closed tensors $L$ and $Q$ exactly.  Consequently its neighboring
+operators agree with those of
+\leanid{MPOTensor.ActiveSectorSpanningCounterexample.factorization}, and the
+same source-selected construction satisfies
+\[
+  Q(1-LQ)L\ne0.
+\]
+These statements are proved in
+\leanid{MPOTensor.ActiveSectorSpanningCounterexample.%
+inverseMap_provenance_preserves_rectangular_remainder}.  Thus provenance does
+not supply the missing vanishing.  The remaining formal boundary is the strong
+area law: the entropy calculation above has not yet been expressed as an
+\leanid{IsSAL} theorem for this tensor.  Until that hypothesis is checked for
+the same witness, the example is not classified here as a formal counterexample
+to Lemma~C.5.  The provenance calculation and this remaining boundary are
 tracked in \ghissue{4270}.
 
 \section{A positive-semidefinite route}
@@ -638,14 +644,14 @@ Consequently the strongest source-faithful common-matrix conclusion remains
 together with entrywise nonnegativity and primitivity.  The formal
 counterexample shows that these conclusions, even supplemented by injectivity,
 full virtual spanning, and positivity of every neighboring operator, do not
-imply the missing vanishing.  Its induced classical cyclic family does satisfy
-the strong area law by the entropy calculation above.  However, the directly
-chosen \leanid{PhysicalSectorFactorization} has not been identified with the
-particular inverse-map factorization produced from the Hayashi decomposition.
-The example therefore refutes the printed matrix inference but does not yet
-refute Lemma~C.5 itself.  The source proof remains obstructed because it
-derives no identity from the inverse-map provenance that excludes the
-nilpotent remainder.
+imply the missing vanishing.  The explicit Hayashi decomposition and inverse-map
+calculation now show that the same nonzero nilpotent remainder occurs for the
+source-selected factorization.  Its induced classical cyclic family satisfies
+the strong area law by the entropy calculation above, but that last hypothesis
+has not yet been formalized for this tensor.  The example therefore refutes the
+printed matrix inference and rules out inverse-map provenance as its missing
+input, while the formal status of Lemma~C.5 itself awaits the strong-area-law
+theorem.
 
 This obstruction propagates to every source statement whose proof invokes the
 rank-one factorization from Lemma~C.5.  In particular, the structural
@@ -675,14 +681,15 @@ false primitive trace-power implication has been removed.
 For the unconditional matrix product density operator argument, it would
 suffice to derive positive semidefiniteness, linear independence, or any
 equivalent exclusion of the generalized zero-eigenspace from the stated SAL
-and ZCL hypotheses.  The source and inverse-map provenance audit provides no
-such derivation.  Lemma~C.5 is therefore classified as obstructed, rather than
-formalized or refuted.  The same status applies to its structural corollary and
-to the source implications (ii)$\Rightarrow$(iv) and (ii)$\Rightarrow$(v) of
+and ZCL hypotheses.  The source audit provides no such derivation, and the
+explicit inverse-map calculation shows that provenance alone does not supply
+one.  Lemma~C.5 is therefore still classified as obstructed, rather than
+formalized or refuted, until the strong area law is formalized for the same
+four-sector tensor.  The same status applies to its structural corollary and to
+the source implications (ii)$\Rightarrow$(iv) and (ii)$\Rightarrow$(v) of
 Theorem~4.9.  Their corrected conditional forms remain available, but the
 additional conditions must not be attributed to the source theorem.  The
-remaining decision whether the four-sector SAL example is realized by the
-source-selected inverse-map factorization is isolated in \ghissue{4270}.
+remaining strong-area-law verification is recorded in \ghissue{4270}.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
### Motivation

- Issue #4270 asks whether the four-sector rectangular counterexample is merely an arbitrary factorization, or whether it is selected by the inverse-map construction in CPSV16 Appendix C.2.
- The source is `Papers/1606.00608/MPDO-22-12-17-2.tex:1413--1455`, equations `Qketc`, `formK`, and `etarl`: after applying the inverse map to the outer sites, “we can write ... for some tensors `r_k` and `l_k`.” Lemma C.5 uses these tensors at lines 1484--1499, and the rank-one conclusion is used again at line 1613.

### Description

- Construct the explicit refined Hayashi decomposition with four one-dimensional sectors of weight `1/4` and prove that its three-site state is the closure against the normalized tail `LQ`.
- Compute the dual basis of the four physical slices and prove that the source inverse map recovers the previously displayed left and right sector tensors exactly.
- Prove that every source-selected neighboring operator agrees with the directly written one, while `Q(1 - LQ)L ≠ 0`.
- Add the result to the blueprint and update the paper-gap record. Lemma C.5 remains `\notready`: this PR does not assert `IsSAL` for the explicit tensor and therefore does not classify the full source lemma as formally refuted.
- Introduce no `sorry`, axioms, or kernel bypasses.

### Testing

- `lake env lean TNLean/MPS/MPDO/ActiveSectorInverseMapProvenance.lean`
- `lake build TNLean.MPS.MPDO.ActiveSectorInverseMapProvenance`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/MPDO/ActiveSectorInverseMapProvenance.lean TNLean/MPS/MPDO/ActiveSectorSpanningCounterexample.lean TNLean.lean`
- `rg -n "sorry|admit|axiom|native_decide|unsafeCast" TNLean/MPS/MPDO/ActiveSectorInverseMapProvenance.lean`

---
Addresses #4270

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formal proofs and documentation only; no changes to core APIs or runtime behavior. Mathematical content is localized to the existing counterexample namespace.
> 
> **Overview**
> Adds **`ActiveSectorInverseMapProvenance`**, which builds an explicit four-sector Hayashi decomposition (weight **1/4**, diagonal three-site state, tail **LQ**) and proves the **source inverse map** recovers the same closed **L**/**Q** tensors as the hand-written factorization—via dual-basis coefficients on the four physical slices and cancellation of the left-contraction factor by **p_k = 1/4**.
> 
> Introduces **`inverseMapFactorization`** from `zeroWeightReparameterizedInverseMapPhysicalSectorFactorization` and **`inverseMap_provenance_preserves_rectangular_remainder`**: neighboring operators agree with the direct factorization and **Q(1−LQ)L ≠ 0** still holds, so the “arbitrary factorization” gap for issue **#4270** is closed on the provenance side.
> 
> **`ActiveSectorSpanningCounterexample`** docstrings now point to that theorem; the blueprint gains **`thm:mpdo_inverse_map_nonzero_rectangular_remainder`**; **`cpgsv17_pf_rank_one.tex`** records that provenance does not force the rectangular vanishing and that a formal **Lemma C.5** refutation still needs **`IsSAL`** for this tensor. Root import **`TNLean.lean`** wires the new module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c3e6309e939fd5d63ae98d330bdf3c514373f82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->