### PR TITLE
feat(Channel/FixedPoint): identify full-support density blocks

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -202,6 +202,7 @@ import TNLean.Channel.FixedPoint.Cesaro
 import TNLean.Channel.FixedPoint.MeanErgodicProjection
 import TNLean.Channel.FixedPoint.MeanErgodicAdjoint
 import TNLean.Channel.FixedPoint.FullSupportBlockRetraction
+import TNLean.Channel.FixedPoint.TraceAdjointDensityBlocks
 import TNLean.Channel.FixedPoint.CornerAlgebra
 import TNLean.Channel.FixedPoint.CornerBlockForm
 import TNLean.Channel.FixedPoint.CornerFixedPoints

--- a/TNLean/Algebra/MatrixAux.lean
+++ b/TNLean/Algebra/MatrixAux.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import Mathlib.Data.Matrix.Basic
+import Mathlib.Data.Matrix.Block
 import Mathlib.LinearAlgebra.Matrix.PosDef
 import Mathlib.Analysis.Matrix.Normed
 import Mathlib.Analysis.Matrix.PosDef
@@ -28,6 +29,8 @@ Extracted from various files for reusability.
   trace form of the Frobenius norm
 - `Matrix.trace_conjTranspose_mul_self_kronecker`: Hilbert--Schmidt trace-form
   multiplicativity for Kronecker products
+- `Matrix.trace_blockDiagonal'_mul`: the trace pairing with a dependent
+  block-diagonal matrix is the sum over diagonal block compressions
 - `Matrix.card_le_trace_conjTranspose_mul_self_re_of_det_norm_eq_one`: determinant
   AM--GM lower bound for the Hilbert--Schmidt trace form
 - `Matrix.PosSemidef.trace_mul_nonneg`: the trace product of two positive
@@ -56,6 +59,38 @@ Extracted from various files for reusability.
 open scoped Matrix BigOperators ComplexOrder Kronecker Matrix.Norms.Frobenius MatrixOrder
 
 namespace Matrix
+
+/-! ## Dependent block-diagonal matrices -/
+
+/-- A dependent block-diagonal matrix pairs under the trace only with the
+diagonal block compressions of the other factor:
+$\operatorname{tr}((\bigoplus_i M_i)X)=\sum_i\operatorname{tr}(M_iX_{ii})$. -/
+theorem trace_blockDiagonal'_mul
+    {ι R : Type*} [Fintype ι] [DecidableEq ι]
+    {n : ι → Type*} [(i : ι) → Fintype (n i)] [Semiring R]
+    (M : (i : ι) → Matrix (n i) (n i) R)
+    (X : Matrix (Σ i, n i) (Σ i, n i) R) :
+    Matrix.trace (Matrix.blockDiagonal' M * X) =
+      ∑ i : ι, Matrix.trace
+        (M i * X.submatrix (fun a => ⟨i, a⟩) (fun a => ⟨i, a⟩)) := by
+  classical
+  simp only [Matrix.trace, Matrix.diag, Matrix.mul_apply, Matrix.submatrix_apply]
+  rw [Fintype.sum_sigma]
+  refine Finset.sum_congr rfl ?_
+  intro i _
+  refine Finset.sum_congr rfl ?_
+  intro a _
+  rw [Fintype.sum_sigma]
+  rw [Finset.sum_eq_single i]
+  · simp
+  · intro j _ hji
+    apply Finset.sum_eq_zero
+    intro b _
+    have hij : i ≠ j := fun h ↦ hji h.symm
+    rw [Matrix.blockDiagonal'_apply_ne M a b hij]
+    simp
+  · intro hi
+    exact (hi (Finset.mem_univ _)).elim
 
 /-! ## Uniform density matrices -/
 

--- a/TNLean/Channel/FixedPoint/TraceAdjointDensityBlocks.lean
+++ b/TNLean/Channel/FixedPoint/TraceAdjointDensityBlocks.lean
@@ -1,0 +1,369 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.FixedPoint.FullSupportBlockRetraction
+
+/-!
+# Density-block form of the full-support fixed points
+
+Suppose that a positive trace-preserving map has a positive-definite fixed
+point and that its trace adjoint satisfies the Schwarz inequality.  The
+adjoint Cesàro projection has the weighted partial-trace form proved in
+`FullSupportBlockRetraction`.  Taking its adjoint with respect to the trace
+pairing gives the density-block formula for the original Cesàro projection
+and identifies its range with the fixed points of the original map.
+
+TNLean indexes a summand by the product of the multiplicity index and the
+matrix-factor index.  Thus the left partial trace is over the multiplicity
+factor, and the Schrödinger-picture summand has the form
+$\sigma_k\otimes M_{d_k}(\mathbb C)$.
+
+## Main result
+
+* `IsPositiveMap.exists_block_densities_of_meanErgodicProjection`: the
+  full-support density-block form of the Cesàro projection and of the fixed
+  points.
+
+## References
+
+* M. Wolf, *Quantum Channels & Operations: Guided Tour*, Proposition 1.5,
+  Equation (1.40), Theorem 6.14, and Equation (6.63); local sources
+  `Notes/WolfNoteTexSource/ch01_deconstructing_quantum.tex`, lines 536--570,
+  and `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1483--1494.
+-/
+
+open scoped Matrix Matrix.Norms.Frobenius ComplexOrder MatrixOrder Kronecker
+open Matrix Finset BigOperators
+
+noncomputable section
+
+namespace Matrix
+
+private theorem trace_reindex_equiv
+    {m n : Type*} [Fintype m] [Fintype n]
+    (e : m ≃ n) (M : Matrix m m ℂ) :
+    Matrix.trace (Matrix.reindex e e M) = Matrix.trace M := by
+  classical
+  simpa [Matrix.trace, Matrix.reindex_apply] using
+    Fintype.sum_equiv e.symm _ _ (by intro; simp)
+
+private theorem trace_partialTraceLeft_mul
+    {α β : Type*} [Fintype α] [Fintype β] [DecidableEq α] [DecidableEq β]
+    (X : Matrix β β ℂ) (Y : Matrix (α × β) (α × β) ℂ) :
+    Matrix.trace (Matrix.partialTraceLeft Y * X) =
+      Matrix.trace (Y * ((1 : Matrix α α ℂ) ⊗ₖ X)) := by
+  classical
+  simp only [Matrix.trace, Matrix.diag, Matrix.mul_apply,
+    Matrix.partialTraceLeft_apply, Matrix.kroneckerMap_apply, Matrix.one_apply]
+  simp only [Finset.sum_mul]
+  simp_rw [Fintype.sum_prod_type]
+  simp
+  calc
+    (∑ x : β, ∑ y : β, ∑ i : α, Y (i, x) (i, y) * X y x) =
+        ∑ x : β, ∑ i : α, ∑ y : β, Y (i, x) (i, y) * X y x := by
+      apply Finset.sum_congr rfl
+      intro x _
+      rw [Finset.sum_comm]
+    _ = ∑ i : α, ∑ x : β, ∑ y : β, Y (i, x) (i, y) * X y x := by
+      rw [Finset.sum_comm]
+
+private theorem partialTraceLeft_kronecker
+    {α β : Type*} [Fintype α]
+    (A : Matrix α α ℂ) (B : Matrix β β ℂ) :
+    Matrix.partialTraceLeft (A ⊗ₖ B) = Matrix.trace A • B := by
+  classical
+  ext i j
+  simp only [Matrix.partialTraceLeft_apply, Matrix.kroneckerMap_apply,
+    Matrix.smul_apply, Matrix.trace, Matrix.diag]
+  rw [← Finset.sum_mul]
+  rfl
+
+private theorem trace_kronecker_partialTraceLeft_mul_eq
+    {α β : Type*} [Fintype α] [Fintype β] [DecidableEq α] [DecidableEq β]
+    (σ : Matrix α α ℂ) (A B : Matrix (α × β) (α × β) ℂ) :
+    Matrix.trace ((σ ⊗ₖ Matrix.partialTraceLeft B) * A) =
+      Matrix.trace
+        (B * ((1 : Matrix α α ℂ) ⊗ₖ
+          Matrix.partialTraceLeft (((σ ⊗ₖ (1 : Matrix β β ℂ)) * A)))) := by
+  classical
+  let X := Matrix.partialTraceLeft B
+  let Y := (σ ⊗ₖ (1 : Matrix β β ℂ)) * A
+  calc
+    Matrix.trace ((σ ⊗ₖ X) * A) =
+        Matrix.trace (((σ ⊗ₖ (1 : Matrix β β ℂ)) *
+          ((1 : Matrix α α ℂ) ⊗ₖ X)) * A) := by
+      rw [← Matrix.mul_kronecker_mul, Matrix.mul_one, Matrix.one_mul]
+    _ = Matrix.trace (((1 : Matrix α α ℂ) ⊗ₖ X) * Y) := by
+      simp only [Y, ← Matrix.mul_assoc]
+      rw [← Matrix.mul_kronecker_mul, ← Matrix.mul_kronecker_mul,
+        Matrix.mul_one, Matrix.one_mul]
+      simp
+    _ = Matrix.trace (Y * ((1 : Matrix α α ℂ) ⊗ₖ X)) :=
+      Matrix.trace_mul_comm _ _
+    _ = Matrix.trace (Matrix.partialTraceLeft Y * X) := by
+      rw [trace_partialTraceLeft_mul]
+    _ = Matrix.trace (X * Matrix.partialTraceLeft Y) :=
+      Matrix.trace_mul_comm _ _
+    _ = Matrix.trace
+        (B * ((1 : Matrix α α ℂ) ⊗ₖ Matrix.partialTraceLeft Y)) := by
+      rw [← trace_partialTraceLeft_mul]
+
+private theorem trace_blockDiagonal'_mul
+    {K : ℕ} {m d : Fin K → ℕ}
+    (M : (k : Fin K) →
+      Matrix (Fin (m k) × Fin (d k)) (Fin (m k) × Fin (d k)) ℂ)
+    (X : Matrix ((k : Fin K) × (Fin (m k) × Fin (d k)))
+      ((k : Fin K) × (Fin (m k) × Fin (d k))) ℂ) :
+    Matrix.trace (Matrix.blockDiagonal' M * X) =
+      ∑ k : Fin K, Matrix.trace
+        (M k * Matrix.directSumBlockCompression (m := m) (d := d) k X) := by
+  classical
+  simp only [Matrix.trace, Matrix.diag, Matrix.mul_apply,
+    Matrix.directSumBlockCompression]
+  rw [Fintype.sum_sigma]
+  refine Finset.sum_congr rfl ?_
+  intro k _
+  refine Finset.sum_congr rfl ?_
+  intro a _
+  rw [Fintype.sum_sigma]
+  rw [Finset.sum_eq_single k]
+  · simp
+  · intro j _ hjk
+    apply Finset.sum_eq_zero
+    intro b _
+    have hkj : k ≠ j := fun h ↦ hjk h.symm
+    rw [Matrix.blockDiagonal'_apply_ne M a b hkj]
+    simp
+  · intro hk
+    exact (hk (Finset.mem_univ _)).elim
+
+private theorem trace_density_blockMap_mul_eq
+    {K : ℕ} {m d : Fin K → ℕ}
+    (σ : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ)
+    (A B : Matrix ((k : Fin K) × (Fin (m k) × Fin (d k)))
+      ((k : Fin K) × (Fin (m k) × Fin (d k))) ℂ) :
+    Matrix.trace
+        ((Matrix.blockDiagonal' fun k ↦
+          σ k ⊗ₖ Matrix.partialTraceLeft
+            (Matrix.directSumBlockCompression (m := m) (d := d) k B)) * A) =
+      Matrix.trace
+        (B * (Matrix.blockDiagonal' fun k ↦
+          (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ
+            Matrix.partialTraceLeft
+              (((σ k) ⊗ₖ (1 : Matrix (Fin (d k)) (Fin (d k)) ℂ)) *
+                Matrix.directSumBlockCompression (m := m) (d := d) k A))) := by
+  classical
+  rw [trace_blockDiagonal'_mul]
+  rw [Matrix.trace_mul_comm, trace_blockDiagonal'_mul]
+  apply Finset.sum_congr rfl
+  intro k _
+  calc
+    _ = Matrix.trace
+        (Matrix.directSumBlockCompression (m := m) (d := d) k B *
+          ((1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ
+            Matrix.partialTraceLeft
+              (((σ k) ⊗ₖ (1 : Matrix (Fin (d k)) (Fin (d k)) ℂ)) *
+                Matrix.directSumBlockCompression (m := m) (d := d) k A))) :=
+      trace_kronecker_partialTraceLeft_mul_eq (σ k)
+        (Matrix.directSumBlockCompression (m := m) (d := d) k A)
+        (Matrix.directSumBlockCompression (m := m) (d := d) k B)
+    _ = _ := Matrix.trace_mul_comm _ _
+
+private theorem trace_unitaryReindexLinearEquiv_symm_mul
+    {n H : Type*} [Fintype n] [DecidableEq n] [Fintype H] [DecidableEq H]
+    (e : H ≃ n) (U : Matrix n n ℂ) (hU : U ∈ Matrix.unitaryGroup n ℂ)
+    (X : Matrix H H ℂ) (A : Matrix n n ℂ) :
+    Matrix.trace ((Matrix.unitaryReindexLinearEquiv e U hU).symm X * A) =
+      Matrix.trace (X * Matrix.unitaryReindexLinearEquiv e U hU A) := by
+  classical
+  rw [Matrix.unitaryReindexLinearEquiv_symm_apply,
+    Matrix.unitaryReindexLinearEquiv_apply]
+  let Ahat := Matrix.reindex e.symm e.symm (star U * A * U)
+  have hreindex : Matrix.reindex e e Ahat = star U * A * U := by
+    ext i j
+    simp [Ahat]
+  calc
+    Matrix.trace ((U * Matrix.reindex e e X * star U) * A) =
+        Matrix.trace (U * (Matrix.reindex e e X * star U * A)) := by
+      simp only [Matrix.mul_assoc]
+    _ = Matrix.trace ((Matrix.reindex e e X * star U * A) * U) :=
+      Matrix.trace_mul_comm _ _
+    _ = Matrix.trace (Matrix.reindex e e X * (star U * A * U)) := by
+      simp only [Matrix.mul_assoc]
+    _ = Matrix.trace
+        (Matrix.reindex e e X * Matrix.reindex e e Ahat) := by rw [hreindex]
+    _ = Matrix.trace (Matrix.reindex e e (X * Ahat)) := by
+      exact congrArg Matrix.trace
+        (Matrix.reindexLinearEquiv_mul ℂ ℂ e e e X Ahat)
+    _ = Matrix.trace (X * Ahat) := trace_reindex_equiv e (X * Ahat)
+
+end Matrix
+
+variable {D : ℕ}
+
+/-- **Density-block form of the Cesàro projection on full support.**
+
+Let $T:M_D(\mathbb C)\to M_D(\mathbb C)$ be positive and trace preserving,
+suppose that $T^*$ satisfies the Schwarz inequality, and let $\rho>0$ satisfy
+$T(\rho)=\rho$.  Then the mean-ergodic projection has the block form
+\[
+  P_T(B)=U\left(\bigoplus_k
+    \sigma_k\otimes\operatorname{tr}_{m_k}((U^*BU)_{kk})\right)U^*,
+\]
+and its range, which equals $\operatorname{Fix}(T)$, is
+$U(\bigoplus_k \sigma_k\otimes M_{d_k}(\mathbb C))U^*$.
+
+This is the trace-adjoint calculation in Wolf, Equation (1.40), used in the
+proof of Theorem 6.14 and Equation (6.63); local sources
+`Notes/WolfNoteTexSource/ch01_deconstructing_quantum.tex`, lines 536--570,
+and `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1483--1494.
+
+**Scope restriction (full support):** The fixed point is positive definite on
+the ambient space.  The positive-definite reduction of the block densities
+and the complementary zero summand required for the general theorem remain
+open in `docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex`.
+
+**Convention (factor order):** Wolf writes the algebra and density factors in
+the opposite order.  TNLean indexes each summand by
+`Fin (m k) × Fin (d k)`, so `Matrix.partialTraceLeft` traces the multiplicity
+factor and the density block is $\sigma_k\otimes M_{d_k}(\mathbb C)$. -/
+theorem IsPositiveMap.exists_block_densities_of_meanErgodicProjection
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT : IsPositiveMap T) (hTP : IsTracePreservingMap T)
+    (hSchwarz : IsSchwarzMap (Matrix.traceAdjointMap T))
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (hρ : ρ.PosDef) (hρfix : T ρ = ρ) :
+    let P := LinearMap.meanErgodicProjection (𝕜 := ℂ)
+      (E := Matrix (Fin D) (Fin D) ℂ) T
+      (hT.hasBoundedOrbits_of_tracePreserving hTP)
+    ∃ (K : ℕ) (d m : Fin K → ℕ)
+      (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin D)
+      (U : Matrix (Fin D) (Fin D) ℂ)
+      (σ : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ),
+      U ∈ Matrix.unitaryGroup (Fin D) ℂ ∧
+        (∀ k, 0 < d k) ∧ (∀ k, 0 < m k) ∧
+        (∀ k, (σ k).PosSemidef) ∧ (∀ k, (σ k).trace = 1) ∧
+        (∀ B, P B = U * Matrix.reindex e e
+          (Matrix.blockDiagonal' fun k ↦
+            σ k ⊗ₖ Matrix.partialTraceLeft
+              (Matrix.directSumBlockCompression (m := m) (d := d) k
+                (Matrix.reindex e.symm e.symm (star U * B * U)))) * star U) ∧
+        ∀ B, T B = B ↔
+          ∃ X : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ,
+            star U * B * U = Matrix.reindex e e
+              (Matrix.blockDiagonal' fun k ↦ σ k ⊗ₖ X k) := by
+  dsimp only
+  let P := LinearMap.meanErgodicProjection (𝕜 := ℂ)
+    (E := Matrix (Fin D) (Fin D) ℂ) T
+    (hT.hasBoundedOrbits_of_tracePreserving hTP)
+  obtain ⟨K, d, m, e, U, σ, hU, hd, hm, _, hσpos, hσtrace, hFormula⟩ :=
+    hT.exists_block_densities_of_adjoint_meanErgodicProjection hTP hSchwarz hρ hρfix
+  have hPFormula : ∀ B, P B = U * Matrix.reindex e e
+      (Matrix.blockDiagonal' fun k ↦
+        σ k ⊗ₖ Matrix.partialTraceLeft
+          (Matrix.directSumBlockCompression (m := m) (d := d) k
+            (Matrix.reindex e.symm e.symm (star U * B * U)))) * star U := by
+    intro B
+    let Φ := Matrix.unitaryReindexLinearEquiv e U hU
+    let F : Matrix ((k : Fin K) × (Fin (m k) × Fin (d k)))
+          ((k : Fin K) × (Fin (m k) × Fin (d k))) ℂ →
+        Matrix ((k : Fin K) × (Fin (m k) × Fin (d k)))
+          ((k : Fin K) × (Fin (m k) × Fin (d k))) ℂ :=
+      fun A ↦ Matrix.blockDiagonal' fun k ↦
+        (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ
+          Matrix.partialTraceLeft
+            (((σ k) ⊗ₖ (1 : Matrix (Fin (d k)) (Fin (d k)) ℂ)) *
+              Matrix.directSumBlockCompression (m := m) (d := d) k A)
+    let G : Matrix ((k : Fin K) × (Fin (m k) × Fin (d k)))
+          ((k : Fin K) × (Fin (m k) × Fin (d k))) ℂ →
+        Matrix ((k : Fin K) × (Fin (m k) × Fin (d k)))
+          ((k : Fin K) × (Fin (m k) × Fin (d k))) ℂ :=
+      fun B ↦ Matrix.blockDiagonal' fun k ↦
+        σ k ⊗ₖ Matrix.partialTraceLeft
+          (Matrix.directSumBlockCompression (m := m) (d := d) k B)
+    change P B = _
+    rw [show U * Matrix.reindex e e
+          (Matrix.blockDiagonal' fun k ↦
+            σ k ⊗ₖ Matrix.partialTraceLeft
+              (Matrix.directSumBlockCompression (m := m) (d := d) k
+                (Matrix.reindex e.symm e.symm (star U * B * U)))) * star U =
+        Φ.symm (G (Φ B)) by
+      simp only [Φ, G, Matrix.unitaryReindexLinearEquiv_apply,
+        Matrix.unitaryReindexLinearEquiv_symm_apply]]
+    refine sub_eq_zero.mp ((Matrix.trace_mul_right_eq_zero_iff
+      (M := P B - Φ.symm (G (Φ B)))).1 ?_)
+    intro A
+    rw [Matrix.sub_mul, Matrix.trace_sub]
+    apply sub_eq_zero.mpr
+    have hPdouble : Matrix.traceAdjointMap (Matrix.traceAdjointMap P) B = P B :=
+      LinearMap.congr_fun (Matrix.traceAdjointMap_traceAdjointMap P) B
+    calc
+      Matrix.trace (P B * A) =
+          Matrix.trace (Matrix.traceAdjointMap (Matrix.traceAdjointMap P) B * A) := by
+        rw [hPdouble]
+      _ = Matrix.trace (B * Matrix.traceAdjointMap P A) :=
+        Matrix.trace_traceAdjointMap_mul (Matrix.traceAdjointMap P) B A
+      _ = Matrix.trace (B * Φ.symm (F (Φ A))) := by
+        rw [hFormula A]
+        simp only [Φ, F, Matrix.unitaryReindexLinearEquiv_apply,
+          Matrix.unitaryReindexLinearEquiv_symm_apply]
+      _ = Matrix.trace (Φ.symm (F (Φ A)) * B) :=
+        Matrix.trace_mul_comm _ _
+      _ = Matrix.trace (F (Φ A) * Φ B) :=
+        Matrix.trace_unitaryReindexLinearEquiv_symm_mul e U hU _ _
+      _ = Matrix.trace (Φ B * F (Φ A)) := Matrix.trace_mul_comm _ _
+      _ = Matrix.trace (G (Φ B) * Φ A) := by
+        exact (Matrix.trace_density_blockMap_mul_eq σ (Φ A) (Φ B)).symm
+      _ = Matrix.trace (Φ.symm (G (Φ B)) * A) :=
+        (Matrix.trace_unitaryReindexLinearEquiv_symm_mul e U hU _ _).symm
+  refine ⟨K, d, m, e, U, σ, hU, hd, hm, hσpos, hσtrace, hPFormula, ?_⟩
+  intro B
+  let Φ := Matrix.unitaryReindexLinearEquiv e U hU
+  let G : Matrix ((k : Fin K) × (Fin (m k) × Fin (d k)))
+        ((k : Fin K) × (Fin (m k) × Fin (d k))) ℂ →
+      Matrix ((k : Fin K) × (Fin (m k) × Fin (d k)))
+        ((k : Fin K) × (Fin (m k) × Fin (d k))) ℂ :=
+    fun B ↦ Matrix.blockDiagonal' fun k ↦
+      σ k ⊗ₖ Matrix.partialTraceLeft
+        (Matrix.directSumBlockCompression (m := m) (d := d) k B)
+  rw [← hT.meanErgodicProjection_apply_eq_self_iff_of_tracePreserving hTP B]
+  constructor
+  · intro hPB
+    refine ⟨fun k ↦ Matrix.partialTraceLeft
+      (Matrix.directSumBlockCompression (m := m) (d := d) k (Φ B)), ?_⟩
+    have hpcoord : P B = Φ.symm (G (Φ B)) := by
+      simpa only [Φ, G, Matrix.unitaryReindexLinearEquiv_apply,
+        Matrix.unitaryReindexLinearEquiv_symm_apply] using hPFormula B
+    have hcoord : Φ B = G (Φ B) := by
+      apply Φ.symm.injective
+      rw [LinearEquiv.symm_apply_apply]
+      exact hPB.symm.trans hpcoord
+    calc
+      star U * B * U = Matrix.reindex e e (Φ B) := by
+        ext i j
+        simp [Φ]
+      _ = Matrix.reindex e e (G (Φ B)) := congrArg (Matrix.reindex e e) hcoord
+      _ = _ := by rfl
+  · rintro ⟨X, hX⟩
+    have hcoord : Φ B = Matrix.blockDiagonal' (fun k ↦ σ k ⊗ₖ X k) := by
+      rw [Matrix.unitaryReindexLinearEquiv_apply, hX]
+      ext i j
+      simp
+    have hG : G (Φ B) = Φ B := by
+      rw [hcoord]
+      simp only [G]
+      congr 1
+      funext k
+      have hcomp : Matrix.directSumBlockCompression (m := m) (d := d) k
+            (Matrix.blockDiagonal' fun j ↦ σ j ⊗ₖ X j) = σ k ⊗ₖ X k := by
+        ext i j
+        simp [Matrix.directSumBlockCompression, Matrix.blockDiagonal'_apply_eq]
+      rw [hcomp, Matrix.partialTraceLeft_kronecker, hσtrace]
+      simp
+    calc
+      P B = Φ.symm (G (Φ B)) := by
+        simpa only [Φ, G, Matrix.unitaryReindexLinearEquiv_apply,
+          Matrix.unitaryReindexLinearEquiv_symm_apply] using hPFormula B
+      _ = Φ.symm (Φ B) := by rw [hG]
+      _ = B := Φ.symm_apply_apply B

--- a/TNLean/Channel/FixedPoint/TraceAdjointDensityBlocks.lean
+++ b/TNLean/Channel/FixedPoint/TraceAdjointDensityBlocks.lean
@@ -10,10 +10,11 @@ import TNLean.Channel.FixedPoint.FullSupportBlockRetraction
 
 Suppose that a positive trace-preserving map has a positive-definite fixed
 point and that its trace adjoint satisfies the Schwarz inequality.  The
-adjoint Cesàro projection has the weighted partial-trace form proved in
-`FullSupportBlockRetraction`.  Taking its adjoint with respect to the trace
-pairing gives the density-block formula for the original Cesàro projection
-and identifies its range with the fixed points of the original map.
+adjoint Cesàro projection has the weighted partial-trace form supplied by the
+preceding full-support fixed-point decomposition.  Taking its adjoint with
+respect to the trace pairing gives the density-block formula for the original
+Cesàro projection and identifies its range with the fixed points of the
+original map.
 
 TNLean indexes a summand by the product of the multiplicity index and the
 matrix-factor index.  Thus the left partial trace is over the multiplicity

--- a/TNLean/Channel/FixedPoint/TraceAdjointDensityBlocks.lean
+++ b/TNLean/Channel/FixedPoint/TraceAdjointDensityBlocks.lean
@@ -101,7 +101,7 @@ and the complementary zero summand required for the general theorem remain
 open in `docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex`.
 
 **Convention (factor order):** Wolf writes the algebra and density factors in
-the opposite order.  TNLean indexes each summand by
+the opposite order.  Each summand is indexed by
 `Fin (m k) × Fin (d k)`, so `Matrix.partialTraceLeft` traces the multiplicity
 factor and the density block is $\sigma_k\otimes M_{d_k}(\mathbb C)$. -/
 theorem IsPositiveMap.exists_block_densities_of_meanErgodicProjection

--- a/TNLean/Channel/FixedPoint/TraceAdjointDensityBlocks.lean
+++ b/TNLean/Channel/FixedPoint/TraceAdjointDensityBlocks.lean
@@ -41,75 +41,6 @@ noncomputable section
 
 namespace Matrix
 
-private theorem trace_reindex_equiv
-    {m n : Type*} [Fintype m] [Fintype n]
-    (e : m ≃ n) (M : Matrix m m ℂ) :
-    Matrix.trace (Matrix.reindex e e M) = Matrix.trace M := by
-  classical
-  simpa [Matrix.trace, Matrix.reindex_apply] using
-    Fintype.sum_equiv e.symm _ _ (by intro; simp)
-
-private theorem trace_partialTraceLeft_mul
-    {α β : Type*} [Fintype α] [Fintype β] [DecidableEq α] [DecidableEq β]
-    (X : Matrix β β ℂ) (Y : Matrix (α × β) (α × β) ℂ) :
-    Matrix.trace (Matrix.partialTraceLeft Y * X) =
-      Matrix.trace (Y * ((1 : Matrix α α ℂ) ⊗ₖ X)) := by
-  classical
-  simp only [Matrix.trace, Matrix.diag, Matrix.mul_apply,
-    Matrix.partialTraceLeft_apply, Matrix.kroneckerMap_apply, Matrix.one_apply]
-  simp only [Finset.sum_mul]
-  simp_rw [Fintype.sum_prod_type]
-  simp
-  calc
-    (∑ x : β, ∑ y : β, ∑ i : α, Y (i, x) (i, y) * X y x) =
-        ∑ x : β, ∑ i : α, ∑ y : β, Y (i, x) (i, y) * X y x := by
-      apply Finset.sum_congr rfl
-      intro x _
-      rw [Finset.sum_comm]
-    _ = ∑ i : α, ∑ x : β, ∑ y : β, Y (i, x) (i, y) * X y x := by
-      rw [Finset.sum_comm]
-
-private theorem partialTraceLeft_kronecker
-    {α β : Type*} [Fintype α]
-    (A : Matrix α α ℂ) (B : Matrix β β ℂ) :
-    Matrix.partialTraceLeft (A ⊗ₖ B) = Matrix.trace A • B := by
-  classical
-  ext i j
-  simp only [Matrix.partialTraceLeft_apply, Matrix.kroneckerMap_apply,
-    Matrix.smul_apply, Matrix.trace, Matrix.diag]
-  rw [← Finset.sum_mul]
-  rfl
-
-private theorem trace_kronecker_partialTraceLeft_mul_eq
-    {α β : Type*} [Fintype α] [Fintype β] [DecidableEq α] [DecidableEq β]
-    (σ : Matrix α α ℂ) (A B : Matrix (α × β) (α × β) ℂ) :
-    Matrix.trace ((σ ⊗ₖ Matrix.partialTraceLeft B) * A) =
-      Matrix.trace
-        (B * ((1 : Matrix α α ℂ) ⊗ₖ
-          Matrix.partialTraceLeft (((σ ⊗ₖ (1 : Matrix β β ℂ)) * A)))) := by
-  classical
-  let X := Matrix.partialTraceLeft B
-  let Y := (σ ⊗ₖ (1 : Matrix β β ℂ)) * A
-  calc
-    Matrix.trace ((σ ⊗ₖ X) * A) =
-        Matrix.trace (((σ ⊗ₖ (1 : Matrix β β ℂ)) *
-          ((1 : Matrix α α ℂ) ⊗ₖ X)) * A) := by
-      rw [← Matrix.mul_kronecker_mul, Matrix.mul_one, Matrix.one_mul]
-    _ = Matrix.trace (((1 : Matrix α α ℂ) ⊗ₖ X) * Y) := by
-      simp only [Y, ← Matrix.mul_assoc]
-      rw [← Matrix.mul_kronecker_mul, ← Matrix.mul_kronecker_mul,
-        Matrix.mul_one, Matrix.one_mul]
-      simp
-    _ = Matrix.trace (Y * ((1 : Matrix α α ℂ) ⊗ₖ X)) :=
-      Matrix.trace_mul_comm _ _
-    _ = Matrix.trace (Matrix.partialTraceLeft Y * X) := by
-      rw [trace_partialTraceLeft_mul]
-    _ = Matrix.trace (X * Matrix.partialTraceLeft Y) :=
-      Matrix.trace_mul_comm _ _
-    _ = Matrix.trace
-        (B * ((1 : Matrix α α ℂ) ⊗ₖ Matrix.partialTraceLeft Y)) := by
-      rw [← trace_partialTraceLeft_mul]
-
 private theorem trace_blockDiagonal'_mul
     {K : ℕ} {m d : Fin K → ℕ}
     (M : (k : Fin K) →
@@ -197,7 +128,7 @@ private theorem trace_unitaryReindexLinearEquiv_symm_mul
     _ = Matrix.trace (Matrix.reindex e e (X * Ahat)) := by
       exact congrArg Matrix.trace
         (Matrix.reindexLinearEquiv_mul ℂ ℂ e e e X Ahat)
-    _ = Matrix.trace (X * Ahat) := trace_reindex_equiv e (X * Ahat)
+    _ = Matrix.trace (X * Ahat) := Matrix.trace_submatrix_equiv e.symm (X * Ahat)
 
 end Matrix
 

--- a/TNLean/Channel/FixedPoint/TraceAdjointDensityBlocks.lean
+++ b/TNLean/Channel/FixedPoint/TraceAdjointDensityBlocks.lean
@@ -42,35 +42,6 @@ noncomputable section
 
 namespace Matrix
 
-private theorem trace_blockDiagonal'_mul
-    {K : ℕ} {m d : Fin K → ℕ}
-    (M : (k : Fin K) →
-      Matrix (Fin (m k) × Fin (d k)) (Fin (m k) × Fin (d k)) ℂ)
-    (X : Matrix ((k : Fin K) × (Fin (m k) × Fin (d k)))
-      ((k : Fin K) × (Fin (m k) × Fin (d k))) ℂ) :
-    Matrix.trace (Matrix.blockDiagonal' M * X) =
-      ∑ k : Fin K, Matrix.trace
-        (M k * Matrix.directSumBlockCompression (m := m) (d := d) k X) := by
-  classical
-  simp only [Matrix.trace, Matrix.diag, Matrix.mul_apply,
-    Matrix.directSumBlockCompression]
-  rw [Fintype.sum_sigma]
-  refine Finset.sum_congr rfl ?_
-  intro k _
-  refine Finset.sum_congr rfl ?_
-  intro a _
-  rw [Fintype.sum_sigma]
-  rw [Finset.sum_eq_single k]
-  · simp
-  · intro j _ hjk
-    apply Finset.sum_eq_zero
-    intro b _
-    have hkj : k ≠ j := fun h ↦ hjk h.symm
-    rw [Matrix.blockDiagonal'_apply_ne M a b hkj]
-    simp
-  · intro hk
-    exact (hk (Finset.mem_univ _)).elim
-
 private theorem trace_density_blockMap_mul_eq
     {K : ℕ} {m d : Fin K → ℕ}
     (σ : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ)
@@ -87,8 +58,8 @@ private theorem trace_density_blockMap_mul_eq
               (((σ k) ⊗ₖ (1 : Matrix (Fin (d k)) (Fin (d k)) ℂ)) *
                 Matrix.directSumBlockCompression (m := m) (d := d) k A))) := by
   classical
-  rw [trace_blockDiagonal'_mul]
-  rw [Matrix.trace_mul_comm, trace_blockDiagonal'_mul]
+  rw [Matrix.trace_blockDiagonal'_mul]
+  rw [Matrix.trace_mul_comm, Matrix.trace_blockDiagonal'_mul]
   apply Finset.sum_congr rfl
   intro k _
   calc

--- a/TNLean/Channel/FixedPoint/TraceAdjointDensityBlocks.lean
+++ b/TNLean/Channel/FixedPoint/TraceAdjointDensityBlocks.lean
@@ -16,7 +16,7 @@ respect to the trace pairing gives the density-block formula for the original
 Cesàro projection and identifies its range with the fixed points of the
 original map.
 
-TNLean indexes a summand by the product of the multiplicity index and the
+Each summand is indexed by the product of the multiplicity index and the
 matrix-factor index.  Thus the left partial trace is over the multiplicity
 factor, and the Schrödinger-picture summand has the form
 $\sigma_k\otimes M_{d_k}(\mathbb C)$.

--- a/TNLean/Channel/FixedPoint/TraceAdjointDensityBlocks.lean
+++ b/TNLean/Channel/FixedPoint/TraceAdjointDensityBlocks.lean
@@ -103,34 +103,6 @@ private theorem trace_density_blockMap_mul_eq
         (Matrix.directSumBlockCompression (m := m) (d := d) k B)
     _ = _ := Matrix.trace_mul_comm _ _
 
-private theorem trace_unitaryReindexLinearEquiv_symm_mul
-    {n H : Type*} [Fintype n] [DecidableEq n] [Fintype H] [DecidableEq H]
-    (e : H ≃ n) (U : Matrix n n ℂ) (hU : U ∈ Matrix.unitaryGroup n ℂ)
-    (X : Matrix H H ℂ) (A : Matrix n n ℂ) :
-    Matrix.trace ((Matrix.unitaryReindexLinearEquiv e U hU).symm X * A) =
-      Matrix.trace (X * Matrix.unitaryReindexLinearEquiv e U hU A) := by
-  classical
-  rw [Matrix.unitaryReindexLinearEquiv_symm_apply,
-    Matrix.unitaryReindexLinearEquiv_apply]
-  let Ahat := Matrix.reindex e.symm e.symm (star U * A * U)
-  have hreindex : Matrix.reindex e e Ahat = star U * A * U := by
-    ext i j
-    simp [Ahat]
-  calc
-    Matrix.trace ((U * Matrix.reindex e e X * star U) * A) =
-        Matrix.trace (U * (Matrix.reindex e e X * star U * A)) := by
-      simp only [Matrix.mul_assoc]
-    _ = Matrix.trace ((Matrix.reindex e e X * star U * A) * U) :=
-      Matrix.trace_mul_comm _ _
-    _ = Matrix.trace (Matrix.reindex e e X * (star U * A * U)) := by
-      simp only [Matrix.mul_assoc]
-    _ = Matrix.trace
-        (Matrix.reindex e e X * Matrix.reindex e e Ahat) := by rw [hreindex]
-    _ = Matrix.trace (Matrix.reindex e e (X * Ahat)) := by
-      exact congrArg Matrix.trace
-        (Matrix.reindexLinearEquiv_mul ℂ ℂ e e e X Ahat)
-    _ = Matrix.trace (X * Ahat) := Matrix.trace_submatrix_equiv e.symm (X * Ahat)
-
 end Matrix
 
 variable {D : ℕ}

--- a/TNLean/Channel/PartialTrace.lean
+++ b/TNLean/Channel/PartialTrace.lean
@@ -40,6 +40,10 @@ Proposition 2.1) and for reduced states on contiguous tensor factors.
   left partial trace
 * `Matrix.partialTraceRight_kronecker`: the right partial trace of a Kronecker
   product
+* `Matrix.partialTraceLeft_kronecker`: the left partial trace of a Kronecker
+  product
+* `Matrix.trace_partialTraceLeft_mul`: the defining trace-pairing identity for
+  the left partial trace
 * `Matrix.partialTraceRightAlong`: the partial trace after choosing a product
   decomposition of the right factor
 * `Matrix.trace_eq_trace_traceLeft`: `tr(X) = tr(tr_A(X))`
@@ -54,7 +58,7 @@ Proposition 2.1) and for reduced states on contiguous tensor factors.
 * arXiv:1606.00608, Appendix D.2, lines 2225--2229: tripartite marginals.
 -/
 
-open scoped Matrix ComplexOrder
+open scoped Matrix ComplexOrder Kronecker
 open Matrix Finset BigOperators
 
 namespace Matrix
@@ -226,6 +230,77 @@ theorem trace_partialTraceLeft [Fintype β] (X : Matrix (α × β) (α × β) �
   simp only [Matrix.trace, Matrix.diag, partialTraceLeft_apply]
   rw [Finset.sum_comm, Fintype.sum_prod_type]
 
+/-- The partial trace over the left factor of a Kronecker product is the
+retained matrix multiplied by the trace of the discarded matrix. -/
+theorem partialTraceLeft_kronecker (A : Matrix α α ℂ) (B : Matrix β β ℂ) :
+    partialTraceLeft (kroneckerMap (· * ·) A B) = A.trace • B := by
+  classical
+  ext i j
+  simp only [partialTraceLeft_apply, kroneckerMap_apply, Matrix.smul_apply,
+    Matrix.trace, Matrix.diag]
+  rw [← Finset.sum_mul]
+  rfl
+
+/-- The left partial trace is adjoint to tensoring with the identity under the
+bilinear trace pairing:
+$\operatorname{tr}(\operatorname{tr}_\alpha(Y)X)
+=\operatorname{tr}(Y(1_\alpha\otimes X))$. -/
+theorem trace_partialTraceLeft_mul [Fintype β] [DecidableEq α]
+    (X : Matrix β β ℂ) (Y : Matrix (α × β) (α × β) ℂ) :
+    Matrix.trace (Matrix.partialTraceLeft Y * X) =
+      Matrix.trace (Y * ((1 : Matrix α α ℂ) ⊗ₖ X)) := by
+  classical
+  simp only [Matrix.trace, Matrix.diag, Matrix.mul_apply,
+    Matrix.partialTraceLeft_apply, Matrix.kroneckerMap_apply, Matrix.one_apply]
+  simp only [Finset.sum_mul]
+  simp_rw [Fintype.sum_prod_type]
+  simp only [ite_mul, one_mul, zero_mul, mul_ite, mul_zero, Finset.sum_ite_irrel,
+    Finset.sum_const_zero, Finset.sum_ite_eq', Finset.mem_univ, ↓reduceIte]
+  calc
+    (∑ x : β, ∑ y : β, ∑ i : α, Y (i, x) (i, y) * X y x) =
+        ∑ x : β, ∑ i : α, ∑ y : β, Y (i, x) (i, y) * X y x := by
+      apply Finset.sum_congr rfl
+      intro x _
+      rw [Finset.sum_comm]
+    _ = ∑ i : α, ∑ x : β, ∑ y : β, Y (i, x) (i, y) * X y x := by
+      rw [Finset.sum_comm]
+
+/-- The trace adjoint of the weighted left partial trace sends $B$ to
+$\sigma\otimes\operatorname{tr}_\alpha(B)$.
+
+This is the one-summand trace calculation in Wolf, Equation (1.40); local
+source `Notes/WolfNoteTexSource/ch01_deconstructing_quantum.tex`, lines
+536--570. -/
+theorem trace_kronecker_partialTraceLeft_mul_eq
+    [Fintype β] [DecidableEq α] [DecidableEq β]
+    (σ : Matrix α α ℂ) (A B : Matrix (α × β) (α × β) ℂ) :
+    Matrix.trace ((σ ⊗ₖ Matrix.partialTraceLeft B) * A) =
+      Matrix.trace
+        (B * ((1 : Matrix α α ℂ) ⊗ₖ
+          Matrix.partialTraceLeft (((σ ⊗ₖ (1 : Matrix β β ℂ)) * A)))) := by
+  classical
+  let X := Matrix.partialTraceLeft B
+  let Y := (σ ⊗ₖ (1 : Matrix β β ℂ)) * A
+  calc
+    Matrix.trace ((σ ⊗ₖ X) * A) =
+        Matrix.trace (((σ ⊗ₖ (1 : Matrix β β ℂ)) *
+          ((1 : Matrix α α ℂ) ⊗ₖ X)) * A) := by
+      rw [← Matrix.mul_kronecker_mul, Matrix.mul_one, Matrix.one_mul]
+    _ = Matrix.trace (((1 : Matrix α α ℂ) ⊗ₖ X) * Y) := by
+      simp only [Y, ← Matrix.mul_assoc]
+      rw [← Matrix.mul_kronecker_mul, ← Matrix.mul_kronecker_mul,
+        Matrix.mul_one, Matrix.one_mul]
+      simp
+    _ = Matrix.trace (Y * ((1 : Matrix α α ℂ) ⊗ₖ X)) :=
+      Matrix.trace_mul_comm _ _
+    _ = Matrix.trace (Matrix.partialTraceLeft Y * X) := by
+      rw [trace_partialTraceLeft_mul]
+    _ = Matrix.trace (X * Matrix.partialTraceLeft Y) :=
+      Matrix.trace_mul_comm _ _
+    _ = Matrix.trace
+        (B * ((1 : Matrix α α ℂ) ⊗ₖ Matrix.partialTraceLeft Y)) := by
+      rw [← trace_partialTraceLeft_mul]
+
 /-- The partial trace over the first factor preserves Hermiticity. -/
 theorem partialTraceLeft_isHermitian {X : Matrix (α × β) (α × β) ℂ}
     (hX : X.IsHermitian) : (partialTraceLeft X).IsHermitian := by
@@ -362,9 +437,7 @@ noncomputable def traceRightLM (d d' : ℕ) :
 /-- Left partial trace of a Kronecker product: `tr_A(A ⊗ B) = tr(A) • B`. -/
 theorem traceLeft_kronecker (A : Matrix (Fin d) (Fin d) ℂ) (B : Matrix (Fin d') (Fin d') ℂ) :
     traceLeft (kroneckerMap (· * ·) A B) = A.trace • B := by
-  ext i j
-  simp only [traceLeft_apply, kroneckerMap_apply, Matrix.smul_apply, Matrix.trace,
-    Matrix.diag, smul_eq_mul, Finset.sum_mul]
+  exact partialTraceLeft_kronecker A B
 
 /-- Right partial trace of a Kronecker product: `tr_B(A ⊗ B) = tr(B) • A`. -/
 theorem traceRight_kronecker (A : Matrix (Fin d) (Fin d) ℂ) (B : Matrix (Fin d') (Fin d') ℂ) :

--- a/TNLean/Channel/PartialTrace.lean
+++ b/TNLean/Channel/PartialTrace.lean
@@ -44,6 +44,8 @@ Proposition 2.1) and for reduced states on contiguous tensor factors.
   product
 * `Matrix.trace_partialTraceLeft_mul`: the defining trace-pairing identity for
   the left partial trace
+* `Matrix.trace_kronecker_partialTraceLeft_mul_eq`: the weighted one-summand
+  trace-adjoint identity
 * `Matrix.partialTraceRightAlong`: the partial trace after choosing a product
   decomposition of the right factor
 * `Matrix.trace_eq_trace_traceLeft`: `tr(X) = tr(tr_A(X))`

--- a/TNLean/Channel/PositiveConditionalExpectationDirectSum.lean
+++ b/TNLean/Channel/PositiveConditionalExpectationDirectSum.lean
@@ -24,6 +24,8 @@ star-subalgebra
   coordinate direct-sum classification.
 * `StarSubalgebra.exists_block_densities_of_positive_retraction`: the classification for
   an arbitrary star-subalgebra.
+* `Matrix.trace_unitaryReindexLinearEquiv_symm_mul`: the trace-pairing identity
+  for unitary block coordinates.
 
 ## References
 

--- a/TNLean/Channel/PositiveConditionalExpectationDirectSum.lean
+++ b/TNLean/Channel/PositiveConditionalExpectationDirectSum.lean
@@ -72,6 +72,36 @@ theorem unitaryReindexLinearEquiv_symm_apply
   simp [unitaryReindexLinearEquiv, Unitary.toUnits,
     Matrix.symm_reindexLinearEquiv, Matrix.coe_reindexLinearEquiv, Matrix.mul_assoc]
 
+/-- The inverse unitary block-coordinate change is adjoint to the forward
+change under the bilinear trace pairing:
+$\operatorname{tr}(\Phi^{-1}(X)A)=\operatorname{tr}(X\Phi(A))$. -/
+theorem trace_unitaryReindexLinearEquiv_symm_mul
+    {n H : Type*} [Fintype n] [DecidableEq n] [Fintype H] [DecidableEq H]
+    (e : H ≃ n) (U : Matrix n n ℂ) (hU : U ∈ Matrix.unitaryGroup n ℂ)
+    (X : Matrix H H ℂ) (A : Matrix n n ℂ) :
+    Matrix.trace ((unitaryReindexLinearEquiv e U hU).symm X * A) =
+      Matrix.trace (X * unitaryReindexLinearEquiv e U hU A) := by
+  classical
+  rw [unitaryReindexLinearEquiv_symm_apply, unitaryReindexLinearEquiv_apply]
+  let Ahat := Matrix.reindex e.symm e.symm (star U * A * U)
+  have hreindex : Matrix.reindex e e Ahat = star U * A * U := by
+    ext i j
+    simp [Ahat]
+  calc
+    Matrix.trace ((U * Matrix.reindex e e X * star U) * A) =
+        Matrix.trace (U * (Matrix.reindex e e X * star U * A)) := by
+      simp only [Matrix.mul_assoc]
+    _ = Matrix.trace ((Matrix.reindex e e X * star U * A) * U) :=
+      Matrix.trace_mul_comm _ _
+    _ = Matrix.trace (Matrix.reindex e e X * (star U * A * U)) := by
+      simp only [Matrix.mul_assoc]
+    _ = Matrix.trace
+        (Matrix.reindex e e X * Matrix.reindex e e Ahat) := by rw [hreindex]
+    _ = Matrix.trace (Matrix.reindex e e (X * Ahat)) := by
+      exact congrArg Matrix.trace
+        (Matrix.reindexLinearEquiv_mul ℂ ℂ e e e X Ahat)
+    _ = Matrix.trace (X * Ahat) := Matrix.trace_submatrix_equiv e.symm (X * Ahat)
+
 /-- Unitary change of basis and reindexing preserve positive semidefiniteness. -/
 theorem unitaryReindexLinearEquiv_posSemidef
     {n H : Type*} [Fintype n] [DecidableEq n] [Fintype H] [DecidableEq H]

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -9,6 +9,7 @@ import TNLean.Channel.FixedPoint.Cesaro
 import TNLean.Channel.FixedPoint.MeanErgodicProjection
 import TNLean.Channel.FixedPoint.MeanErgodicAdjoint
 import TNLean.Channel.FixedPoint.FullSupportBlockRetraction
+import TNLean.Channel.FixedPoint.TraceAdjointDensityBlocks
 import TNLean.Channel.FixedPoint.ConditionalExpectation
 import TNLean.Channel.FixedPoint.StationarySupport
 import TNLean.Channel.FixedPoint.CornerFixedPoints
@@ -314,6 +315,14 @@ In `TNLean.Channel.FixedPoint.FullSupportBlockRetraction`:
   fixed-point star-algebra and has the weighted partial-trace block form of
   Wolf Equation (1.40).
 
+In `TNLean.Channel.FixedPoint.TraceAdjointDensityBlocks`:
+
+* `IsPositiveMap.exists_block_densities_of_meanErgodicProjection` — under the
+  same full-support hypotheses, the mean-ergodic projection has the
+  Schrödinger-picture density-block form
+  `U (⊕_k σ_k ⊗ tr_{m_k}((U† B U)_{kk})) U†`, and the fixed-point space is
+  `U (⊕_k σ_k ⊗ M_{d_k}(ℂ)) U†`.
+
 In `TNLean.Channel.FixedPoint.WedderburnDecomp`:
 
 * `Kraus.starSubalgebra_isSemisimpleRing` — every finite-dimensional
@@ -349,10 +358,12 @@ positive semidefinite fixed point):
   corner-restricted set only; extending by zero on the complement does not
   produce ambient fixed points in general.
 
-What is still missing for the full Wolf statement is to take the trace adjoint
-of the weighted retraction formula, identify the Schrödinger-picture fixed
-points with the resulting density blocks, and transport the support-sector
-formula back to the ambient space with the complementary zero block.
+What is still missing for the full Wolf statement is the reduction to the
+support of a maximum-rank fixed point, including positive definiteness of the
+supported density blocks, and transport back to the ambient space with the
+complementary zero block.  Applying the full-support theorem to the transported
+sector channels of arXiv:1606.00608 additionally requires a direct-sum version
+or an extension through the block-diagonal embedding.
 
 ### Wolf Corollary 6.7 (faithful fixed-point conjugation) — FORMALIZED (Kraus case)
 

--- a/TNLean/MPS/ParentHamiltonian/BlockSumGroundSpace.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockSumGroundSpace.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.MatrixAux
 import TNLean.MPS.ParentHamiltonian.GroundSpace
 import TNLean.MPS.SharedInfra.BlockAssembly
 
@@ -49,25 +50,7 @@ theorem trace_blockDiagonal'_mul
     (X : Matrix ((j : Fin r) × Fin (dim j)) ((j : Fin r) × Fin (dim j)) ℂ) :
     Matrix.trace (Matrix.blockDiagonal' M * X) =
       ∑ j : Fin r, Matrix.trace (M j * sigmaDiagonalBlock X j) := by
-  classical
-  simp only [Matrix.trace, Matrix.diag, Matrix.mul_apply, sigmaDiagonalBlock,
-    Matrix.submatrix_apply]
-  rw [Fintype.sum_sigma]
-  refine Finset.sum_congr rfl ?_
-  intro j _
-  refine Finset.sum_congr rfl ?_
-  intro a _
-  rw [Fintype.sum_sigma]
-  rw [Finset.sum_eq_single j]
-  · simp
-  · intro k _ hkj
-    apply Finset.sum_eq_zero
-    intro b _
-    have hjk : j ≠ k := fun h => hkj h.symm
-    rw [Matrix.blockDiagonal'_apply_ne M a b hjk]
-    simp
-  · intro hj
-    exact (hj (Finset.mem_univ _)).elim
+  simpa only [sigmaDiagonalBlock] using Matrix.trace_blockDiagonal'_mul M X
 
 /-- The boundary parametrization of a block-diagonal tensor is the sum of the block
 boundary parametrizations applied to the diagonal boundary blocks. -/

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2543,6 +2543,51 @@ $\bigoplus_k \Id_{m_k} \otimes \MN{d_k}$.
     dimensions, the density matrices $\sigma_k$, and the displayed formula.
 \end{proof}
 
+% Scope restriction and factor-order convention documented in
+% docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex.
+\begin{theorem}[Density-block form of the Ces\`aro projection on full support]%
+    \label{thm:mean_ergodic_projection_density_block_form}
+    \lean{IsPositiveMap.exists_block_densities_of_meanErgodicProjection}
+    \leanok
+    \uses{thm:adjoint_mean_ergodic_projection_weighted_block_form}
+    Under the hypotheses of
+    Theorem~\ref{thm:adjoint_mean_ergodic_projection_weighted_block_form},
+    the mean-ergodic projection of $T$ satisfies
+    \[
+        P_T(B)=U\left(\bigoplus_k \sigma_k\otimes
+          \operatorname{tr}_{m_k}((U^*BU)_{kk})\right)U^*.
+    \]
+    Consequently,
+    \[
+        \operatorname{Fix}(T)
+        =U\left(\bigoplus_k \sigma_k\otimes\MN{d_k}\right)U^*.
+    \]
+    Here each summand is written on
+    $\mathbb C^{m_k}\otimes\mathbb C^{d_k}$, so
+    $\operatorname{tr}_{m_k}$ traces the first factor.  This is the
+    full-support part of Equation~(6.63) in
+    \cite[Theorem~6.14]{Wolf2012Quantum}; the density matrices are not yet
+    asserted to be positive definite.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:adjoint_mean_ergodic_projection_weighted_block_form}
+    For one summand, cyclicity of the trace and the defining property of the
+    partial trace give
+    \[
+      \operatorname{tr}\!\left(
+        (\sigma_k\otimes\operatorname{tr}_{m_k}B)A\right)
+      =\operatorname{tr}\!\left(
+        B\bigl(\Id_{m_k}\otimes
+          \operatorname{tr}_{m_k}((\sigma_k\otimes\Id_{d_k})A)\bigr)\right).
+    \]
+    Summing over the diagonal summands and applying the unitary change of
+    basis proves the displayed formula by nondegeneracy of the trace pairing.
+    Its range consists of the stated density blocks because
+    $\operatorname{tr}_{m_k}(\sigma_k\otimes X)=X$.
+\end{proof}
+
 Without a full-rank hypothesis on the fixed point, the corner-restricted fixed-point
 $*$-algebra of Theorem~\ref{thm:cornerFixedPointsStarSubalgebra} still carries the block
 structure through the compression onto the support sector; this is the

--- a/docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex
+++ b/docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex
@@ -86,20 +86,37 @@ in
 This is the conditional-expectation step in the proof of Theorem~6.14,
 local source lines~1483--1492.
 
-Three arguments remain to obtain the fixed-point statement above.  First, the
-trace adjoint of the weighted partial-trace formula must be calculated and its
-range identified with the Schr\"odinger-picture density blocks.  Second, the
+The trace-adjoint calculation is also formalized.  In the convention used by
+the formalization, each summand is ordered as
+$\mathbb C^{m_k}\otimes\mathbb C^{d_k}$ and the adjoint fixed-point algebra is
+$\Id_{m_k}\otimes M_{d_k}(\mathbb C)$.  Consequently, the partial trace is
+over the first, multiplicity factor and
+\begin{align}
+  P_T(B)
+    =U\left(\bigoplus_k \sigma_k\otimes
+      \operatorname{tr}_{m_k}((U^*BU)_{kk})\right)U^*.
+\end{align}
+Writing $\operatorname{tr}_{d_k}$ here would reverse the factor convention
+and would be dimensionally inconsistent.  The range of this projection is
+$U(\bigoplus_k\sigma_k\otimes M_{d_k}(\mathbb C))U^*$, hence this is also
+$\operatorname{Fix}(T)$ under the full-support hypothesis.
+\footnote{Formal declaration:
+\leanid{IsPositiveMap.exists_block_densities_of_meanErgodicProjection}
+in
+\doclink{TNLean/Channel/FixedPoint/TraceAdjointDensityBlocks}.}
+
+Two arguments remain to obtain the general fixed-point statement above.  First, the
 positive semidefinite density matrices supplied by Proposition~1.5 must be
 restricted to their supports; this produces the positive definite matrices
-in Theorem~6.14.  Third, the discarded kernels must be assembled with the
+in Theorem~6.14.  Second, the discarded kernels must be combined with the
 subspace on which every fixed point vanishes, thereby recovering the zero
 summand $\mathcal H_0$.
 
-Thus Proposition~1.5 and its application to the full-support adjoint
-mean-ergodic projection are formalized, while Theorem~6.14 remains an open
-gap.  The missing work is the trace-adjoint density-block calculation, the
-positive-definite support reduction, and the recovery of the zero block from
-the kernels.
+Thus Proposition~1.5, its application to the full-support adjoint
+mean-ergodic projection, and the full-support Schr\"odinger-picture fixed-point
+formula are formalized, while Theorem~6.14 remains open.  The missing work is
+the positive-definite support reduction and the recovery of the zero block
+from the kernels.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

- Prove IsPositiveMap.exists_block_densities_of_meanErgodicProjection from the adjoint Cesàro block form established in LionSR/TNLean#4276.
- Compute the trace-pairing adjoint first on one tensor factor, then over the finite direct sum, and transport the identity through the unitary basis change.
- Identify the range of the Cesàro projection, hence Fix(T), with the full-support density-block space.
- Synchronize the spectral blueprint and the Wolf Theorem 6.14 paper-gap note.

## Factor-order convention

TNLean stores each summand as Fin (m k) × Fin (d k), and writes the adjoint fixed-point algebra as Id_(m k) tensor M_(d k). Therefore Matrix.partialTraceLeft traces the left multiplicity factor m k, and the Schrödinger-picture block is sigma_k tensor M_(d k). This is the repository translation of Wolf Equations (1.40) and (6.63). A trace over d k would be dimensionally inconsistent in this ordering.

## Scope

This is the full-support intermediate in Wolf Theorem 6.14. The block densities are positive semidefinite and trace one; their positive-definite support reduction and the complementary zero summand remain open in LionSR/QICLean#219.

The PR does not assert the direct-sum/full-matrix connection tracked by LionSR/TNLean#4282 and does not import or assume CPSV16 transported-map invertibility.

## Sources

- Wolf, Proposition 1.5 and Equation (1.40), Notes/WolfNoteTexSource/ch01_deconstructing_quantum.tex, lines 536–570.
- Wolf, Theorem 6.14 and Equation (6.63), Notes/WolfNoteTexSource/ch06_spectral_properties.tex, lines 1483–1494.
- docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex.

## Verification

- lake env lean TNLean/Channel/FixedPoint/TraceAdjointDensityBlocks.lean
- lake build (9,577 jobs)
- python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls
- python3 scripts/blueprint_lean_sync.py --root . --ci
- lake exe checkdecls blueprint/lean_decls
- python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci
- leanblueprint web
- proof-integrity scan and git diff --check

Closes LionSR/QICLean#223.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal Lean proofs and documentation only; no runtime, auth, or data-path changes. Risk is limited to proof maintenance and factor-order conventions already documented in the PR.
> 
> **Overview**
> **Full-support Wolf Theorem 6.14 (Schrödinger picture):** Under positive trace-preserving `T`, Schwarz on `T*`, and a positive-definite fixed point, the PR proves `IsPositiveMap.exists_block_densities_of_meanErgodicProjection`—the Cesàro projection as `U (⊕_k σ_k ⊗ tr_{m_k}(…)) U†` and `Fix(T) = U (⊕_k σ_k ⊗ M_{d_k}) U†`, building on the adjoint Cesàro block form from prior work.
> 
> The proof is trace-adjoint transport: new lemmas for left partial trace (`partialTraceLeft_kronecker`, `trace_partialTraceLeft_mul`, `trace_kronecker_partialTraceLeft_mul_eq`), shared `Matrix.trace_blockDiagonal'_mul`, unitary reindex trace pairing, and the capstone file `TraceAdjointDensityBlocks.lean`. MPS `BlockSumGroundSpace` deduplicates the block-diagonal trace identity; blueprint ch07 and `wolf_theorem6_14_fixed_point_projection_gap.tex` mark this step done and narrow remaining gaps (support reduction, zero block).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f5d8d561de1582d76fa94f0aa6362309482e3d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->