### PR TITLE
feat(MPS/MPDO): represent fixed commuting-bond products

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -567,6 +567,7 @@ import TNLean.MPS.MPDO.CommutingBondEtaDecomposition
 import TNLean.MPS.MPDO.CommutingBondEtaCyclicTransport
 import TNLean.MPS.MPDO.CyclicEdgeWeightTensor
 import TNLean.MPS.MPDO.FixedBondProductTensor
+import TNLean.MPS.MPDO.FixedBondProductEtaTensor
 import TNLean.MPS.MPDO.CommutingBondEtaBoundaryTrace
 import TNLean.MPS.MPDO.GSNNCHSectorSum
 import TNLean.MPS.MPDO.GSNNCHOrthogonalSectors

--- a/TNLean/MPS/MPDO/FixedBondProductEtaTensor.lean
+++ b/TNLean/MPS/MPDO/FixedBondProductEtaTensor.lean
@@ -1,0 +1,302 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.CommutingBondEtaCyclicTransport
+import TNLean.MPS.MPDO.FixedBondProductTensor
+
+/-!
+# Fixed matrix-product tensors from neighboring operators
+
+This file represents the cyclic neighboring-operator decomposition of a fixed
+commuting bond by one matrix-product tensor.  The virtual dimension is
+independent of the chain length.
+
+## Main definitions and statements
+
+* `etaCyclicEdgeWeight` gives the scalar neighboring-operator weight.
+* `reindex_mpo_cyclicEdgeWeightTensor_etaCyclicEdgeWeight` identifies its
+  closed operator in sector-edge coordinates.
+* `EtaLocalStructureData.nonempty_fixedProductTensorData` constructs an exact
+  fixed tensor for the commuting-bond product.
+
+## References
+
+* arXiv:1606.00608, Appendix C.2, equation `sigmaNK2`, lines 1581--1593.
+-/
+
+open scoped BigOperators Kronecker Matrix
+
+namespace MPOTensor
+
+variable {d : ℕ}
+
+open PhysicalSectorFactorization
+
+/-- The scalar edge weight obtained from a family of neighboring operators.
+
+The current site contributes its right coordinate and the following site
+contributes its left coordinate.  The block-diagonal matrix forces the ket and
+bra sector labels to agree at both endpoints of the edge.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `sigmaNK2`, lines
+1586--1593. -/
+noncomputable def etaCyclicEdgeWeight {K : ℕ} (dl dr : Fin K → ℕ)
+    (e : Matrix.EtaSiteIndex K dl dr ≃ Fin d)
+    (η : (q h : Fin K) →
+      Matrix (Matrix.EtaEdgeIndex dl dr q h)
+        (Matrix.EtaEdgeIndex dl dr q h) ℂ) :
+    Fin d → Fin d → Fin d → Fin d → ℂ :=
+  fun i j i' j' ↦
+    let x := e.symm i
+    let y := e.symm j
+    let x' := e.symm i'
+    let y' := e.symm j'
+    Matrix.blockDiagonal' (fun qh : Fin K × Fin K ↦ η qh.1 qh.2)
+      ⟨(x.1, x'.1), (x.2.1, x'.2.2)⟩
+      ⟨(y.1, y'.1), (y.2.1, y'.2.2)⟩
+
+/-- The cyclic edge-weight tensor is the direct sum of the cyclic products of
+the neighboring operators in sector-edge coordinates.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `sigmaNK2`, lines
+1581--1589. -/
+theorem reindex_mpo_cyclicEdgeWeightTensor_etaCyclicEdgeWeight
+    {K N : ℕ} [NeZero N] (dl dr : Fin K → ℕ)
+    (e : Matrix.EtaSiteIndex K dl dr ≃ Fin d)
+    (η : (q h : Fin K) →
+      Matrix (Matrix.EtaEdgeIndex dl dr q h)
+        (Matrix.EtaEdgeIndex dl dr q h) ℂ) :
+    Matrix.reindex (Matrix.etaCyclicEdgeEquiv dl dr e)
+        (Matrix.etaCyclicEdgeEquiv dl dr e)
+        (mpo (cyclicEdgeWeightTensor (etaCyclicEdgeWeight dl dr e η)) N) =
+      Matrix.blockDiagonal' fun k : Fin N → Fin K ↦
+        fun x y ↦ ∏ n : Fin N, η (k n) (k (n + 1)) (x n) (y n) := by
+  classical
+  ext ⟨k, x⟩ ⟨h, y⟩
+  rw [Matrix.reindex_apply, Matrix.submatrix_apply,
+    mpo_cyclicEdgeWeightTensor]
+  by_cases hkh : k = h
+  · subst h
+    rw [Matrix.blockDiagonal'_apply_eq]
+    apply Finset.prod_congr rfl
+    intro n _
+    have hx (m : Fin N) :
+        e.symm ((Matrix.etaCyclicEdgeEquiv dl dr e).symm ⟨k, x⟩ m) =
+          ⟨k m, (Matrix.etaFixedSectorCyclicEdgeEquiv dl dr k).symm x m⟩ := by
+      rw [Matrix.etaCyclicEdgeEquiv_symm_apply, e.symm_apply_apply]
+    have hy (m : Fin N) :
+        e.symm ((Matrix.etaCyclicEdgeEquiv dl dr e).symm ⟨k, y⟩ m) =
+          ⟨k m, (Matrix.etaFixedSectorCyclicEdgeEquiv dl dr k).symm y m⟩ := by
+      rw [Matrix.etaCyclicEdgeEquiv_symm_apply, e.symm_apply_apply]
+    rw [etaCyclicEdgeWeight]
+    rw [hx n, hx (n + 1), hy n, hy (n + 1)]
+    rw [Matrix.blockDiagonal'_apply_eq]
+    exact congrArg₂ (η (k n) (k (n + 1)))
+      (Matrix.etaFixedSectorCyclicEdgeEquiv_symm_edge dl dr k x n)
+      (Matrix.etaFixedSectorCyclicEdgeEquiv_symm_edge dl dr k y n)
+  · rw [Matrix.blockDiagonal'_apply_ne _ _ _ hkh]
+    obtain ⟨n, hn⟩ := Function.ne_iff.mp hkh
+    apply Finset.prod_eq_zero (Finset.mem_univ n)
+    have hk :
+        (e.symm ((Matrix.etaCyclicEdgeEquiv dl dr e).symm ⟨k, x⟩ n)).1 = k n := by
+      rw [Matrix.etaCyclicEdgeEquiv_symm_apply, e.symm_apply_apply]
+    have hh :
+        (e.symm ((Matrix.etaCyclicEdgeEquiv dl dr e).symm ⟨h, y⟩ n)).1 = h n := by
+      rw [Matrix.etaCyclicEdgeEquiv_symm_apply, e.symm_apply_apply]
+    rw [etaCyclicEdgeWeight]
+    rw [Matrix.blockDiagonal'_apply_ne]
+    intro hpairs
+    apply hn
+    simpa only [hk, hh] using congrArg Prod.fst hpairs
+
+/-- Conjugating a two-site bond by a sitewise conjugate-transposed matrix is
+the corresponding Kronecker conjugation in pair coordinates. -/
+private theorem singleKrausMap_sitewise_conjTranspose_pairBond
+    (U : Matrix (Fin d) (Fin d) ℂ)
+    (B : Matrix (Fin 2 → Fin d) (Fin 2 → Fin d) ℂ) :
+    singleKrausMap (sitewisePhysicalMatrix Uᴴ 2) B =
+      Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+        (finTwoArrowEquiv (Fin d)).symm
+        (star (U ⊗ₖ U) * pairBondMatrix B * (U ⊗ₖ U)) := by
+  apply (Matrix.reindex (finTwoArrowEquiv (Fin d))
+    (finTwoArrowEquiv (Fin d))).injective
+  rw [Matrix.reindex_singleKrausMap
+      (finTwoArrowEquiv (Fin d)) (finTwoArrowEquiv (Fin d)),
+    reindex_sitewisePhysicalMatrix_two]
+  rw [show Matrix.reindex (finTwoArrowEquiv (Fin d))
+      (finTwoArrowEquiv (Fin d))
+      (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+        (finTwoArrowEquiv (Fin d)).symm
+        (star (U ⊗ₖ U) * pairBondMatrix B * (U ⊗ₖ U))) =
+      star (U ⊗ₖ U) * pairBondMatrix B * (U ⊗ₖ U) by
+    exact (Matrix.reindex (finTwoArrowEquiv (Fin d))
+      (finTwoArrowEquiv (Fin d))).apply_symm_apply _]
+  simp only [singleKrausMap_apply, Matrix.conjTranspose_kronecker,
+    Matrix.conjTranspose_conjTranspose]
+  change (Uᴴ ⊗ₖ Uᴴ) * pairBondMatrix B * (U ⊗ₖ U) =
+    star (U ⊗ₖ U) * pairBondMatrix B * (U ⊗ₖ U)
+  simp [Matrix.conjTranspose_kronecker, Matrix.star_eq_conjTranspose]
+
+/-- Sitewise conjugation by a unitary carries the complete periodic bond
+product to the product of the conjugated pair-coordinate bonds. -/
+private theorem singleKrausMap_sitewise_conjTranspose_bondProduct
+    (U : Matrix (Fin d) (Fin d) ℂ) (hU : U ∈ Matrix.unitaryGroup (Fin d) ℂ)
+    {N : ℕ} (hN : 2 ≤ N)
+    (B : Matrix (Fin 2 → Fin d) (Fin 2 → Fin d) ℂ) :
+    singleKrausMap (sitewisePhysicalMatrix Uᴴ N)
+        (List.ofFn fun i : Fin N ↦ embedLocalOperator 2 N hN i B).prod =
+      (List.ofFn fun i : Fin N ↦
+        embedLocalOperator 2 N hN i
+          (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+            (finTwoArrowEquiv (Fin d)).symm
+            (star (U ⊗ₖ U) * pairBondMatrix B * (U ⊗ₖ U)))).prod := by
+  have hUco : U * Uᴴ = 1 := by
+    simpa only [Matrix.star_eq_conjTranspose] using
+      (Matrix.mem_unitaryGroup_iff.mp hU)
+  have hUiso : Uᴴ * U = 1 := by
+    simpa only [Matrix.star_eq_conjTranspose] using
+      (Matrix.mem_unitaryGroup_iff'.mp hU)
+  rw [singleKrausMap_bondProduct_of_unitary Uᴴ (by simpa) (by simpa) hN]
+  apply congrArg List.prod
+  apply congrArg List.ofFn
+  funext i
+  rw [singleKrausMap_sitewise_conjTranspose_pairBond]
+
+/-- The cyclic eta edge-weight tensor represents exactly the conjugated
+periodic bond product determined by the same local decomposition. -/
+private theorem mpo_cyclicEdgeWeightTensor_eta_eq_conjugated_bondProduct
+    {K N : ℕ} [NeZero N] (hN : 2 ≤ N) (dl dr : Fin K → ℕ)
+    (e : Matrix.EtaSiteIndex K dl dr ≃ Fin d)
+    (U : Matrix (Fin d) (Fin d) ℂ)
+    (eta : (q h : Fin K) →
+      Matrix (Matrix.EtaEdgeIndex dl dr q h)
+        (Matrix.EtaEdgeIndex dl dr q h) ℂ)
+    (B : Matrix (Fin 2 → Fin d) (Fin 2 → Fin d) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin d) ℂ)
+    (hB : Matrix.reindex (Matrix.etaPairSpatialBlockEquiv e).symm
+        (Matrix.etaPairSpatialBlockEquiv e).symm
+        (star (U ⊗ₖ U) * pairBondMatrix B * (U ⊗ₖ U)) =
+      Matrix.blockDiagonal' fun qh : Fin K × Fin K ↦
+        ((1 : Matrix (Fin (dl qh.1)) (Fin (dl qh.1)) ℂ) ⊗ₖ
+          eta qh.1 qh.2) ⊗ₖ
+            (1 : Matrix (Fin (dr qh.2)) (Fin (dr qh.2)) ℂ)) :
+    mpo (cyclicEdgeWeightTensor (etaCyclicEdgeWeight dl dr e eta)) N =
+      singleKrausMap (sitewisePhysicalMatrix Uᴴ N)
+        (List.ofFn fun i : Fin N ↦ embedLocalOperator 2 N hN i B).prod := by
+  apply (Matrix.reindex (Matrix.etaCyclicEdgeEquiv dl dr e)
+    (Matrix.etaCyclicEdgeEquiv dl dr e)).injective
+  rw [reindex_mpo_cyclicEdgeWeightTensor_etaCyclicEdgeWeight]
+  rw [singleKrausMap_sitewise_conjTranspose_bondProduct U hU hN B]
+  rw [reindex_product_embedLocalOperator_of_etaPair_decomposition
+    hN dl dr e eta (star (U ⊗ₖ U) * pairBondMatrix B * (U ⊗ₖ U)) hB]
+
+/-- Successive single-Kraus conjugations by a coisometry and its conjugate
+transpose cancel. -/
+private theorem singleKrausMap_comp_conjTranspose_of_mul_conjTranspose_eq_one
+    {alpha : Type*} [Fintype alpha] [DecidableEq alpha]
+    (V : Matrix alpha alpha ℂ) (hV : V * Vᴴ = 1) (X : Matrix alpha alpha ℂ) :
+    singleKrausMap V (singleKrausMap Vᴴ X) = X := by
+  simp only [singleKrausMap_apply, Matrix.conjTranspose_conjTranspose]
+  calc
+    V * (Vᴴ * X * V) * Vᴴ = (V * Vᴴ) * X * (V * Vᴴ) := by
+      simp only [Matrix.mul_assoc]
+    _ = X := by rw [hV, one_mul, mul_one]
+
+namespace EtaLocalStructureData
+
+variable {D : ℕ} {M : MPOTensor d D}
+
+/-- The tensor obtained from one eta decomposition realizes the corresponding
+fixed periodic bond product at every chain length at least two. -/
+private theorem mpo_changePhysicalBasis_cyclicEtaWeight_eq_product
+    (data : EtaLocalStructureData M) {K : ℕ} (dl dr : Fin K → ℕ)
+    (e : Matrix.EtaSiteIndex K dl dr ≃ Fin d)
+    (U : Matrix (Fin d) (Fin d) ℂ)
+    (eta : (q h : Fin K) →
+      Matrix (Matrix.EtaEdgeIndex dl dr q h)
+        (Matrix.EtaEdgeIndex dl dr q h) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin d) ℂ)
+    (hB : Matrix.reindex (Matrix.etaPairSpatialBlockEquiv e).symm
+        (Matrix.etaPairSpatialBlockEquiv e).symm
+        (star (U ⊗ₖ U) * data.pairBond * (U ⊗ₖ U)) =
+      Matrix.blockDiagonal' fun qh : Fin K × Fin K ↦
+        ((1 : Matrix (Fin (dl qh.1)) (Fin (dl qh.1)) ℂ) ⊗ₖ
+          eta qh.1 qh.2) ⊗ₖ
+            (1 : Matrix (Fin (dr qh.2)) (Fin (dr qh.2)) ℂ))
+    (N : ℕ) (hN : 2 ≤ N) :
+    mpo (changePhysicalBasis U
+      (cyclicEdgeWeightTensor (etaCyclicEdgeWeight dl dr e eta))) N =
+        (data.bondData.toCommutingFormData hN).product := by
+  letI : NeZero N := ⟨by omega⟩
+  let C₀ : MPOTensor d (d * d) :=
+    cyclicEdgeWeightTensor (etaCyclicEdgeWeight dl dr e eta)
+  let P : Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ :=
+    (data.bondData.toCommutingFormData hN).product
+  change mpo (changePhysicalBasis U C₀) N = P
+  rw [← singleKrausMap_sitewisePhysicalMatrix_mpo U C₀ N]
+  let V := sitewisePhysicalMatrix U N
+  change singleKrausMap V (mpo C₀ N) = P
+  change Matrix.reindex (Matrix.etaPairSpatialBlockEquiv e).symm
+      (Matrix.etaPairSpatialBlockEquiv e).symm
+      (star (U ⊗ₖ U) * pairBondMatrix data.bondData.bond * (U ⊗ₖ U)) = _ at hB
+  have hsector : mpo C₀ N =
+      singleKrausMap (sitewisePhysicalMatrix Uᴴ N) P := by
+    dsimp only [C₀, P]
+    change mpo (cyclicEdgeWeightTensor (etaCyclicEdgeWeight dl dr e eta)) N =
+      singleKrausMap (sitewisePhysicalMatrix Uᴴ N)
+        (List.ofFn fun i : Fin N ↦
+          embedLocalOperator 2 N hN i data.bondData.bond).prod
+    exact mpo_cyclicEdgeWeightTensor_eta_eq_conjugated_bondProduct
+      hN dl dr e U eta data.bondData.bond hU hB
+  have hsectorV : mpo C₀ N = singleKrausMap Vᴴ P := by
+    rw [sitewisePhysicalMatrix_conjTranspose]
+    exact hsector
+  rw [hsectorV]
+  apply singleKrausMap_comp_conjTranspose_of_mul_conjTranspose_eq_one V
+  dsimp only [V]
+  rw [sitewisePhysicalMatrix_mul_conjTranspose]
+  have hUco : U * Uᴴ = 1 := by
+    simpa only [Matrix.star_eq_conjTranspose] using
+      (Matrix.mem_unitaryGroup_iff.mp hU)
+  rw [hUco, sitewisePhysicalMatrix_one]
+
+/-- The fixed commuting-bond product carried by an eta-local structure has one
+exact matrix-product representation with positive bond dimension, independent
+of the chain length.
+
+This proves only the finite representation of the product.  It does not assert
+that the representing tensor is normal and does not constrain the positive
+realization scalar of the source MPO.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `3to4` and equation
+`sigmaNK2`, lines 1570--1593. -/
+theorem nonempty_fixedProductTensorData [NeZero d]
+    (data : EtaLocalStructureData M) :
+    Nonempty (TranslationInvariantBondData.FixedProductTensorData data.bondData) := by
+  classical
+  obtain ⟨K, dl, dr, e, U, η, hU, _hdl, _hdr, _hη, hB⟩ :=
+    data.exists_positive_eta_pairBond_decomposition
+  refine ⟨{
+    bondDim := d * d
+    bondDim_pos := Nat.mul_pos (NeZero.pos d) (NeZero.pos d)
+    tensor := changePhysicalBasis U
+      (cyclicEdgeWeightTensor (etaCyclicEdgeWeight dl dr e η))
+    mpo_eq_product := fun N hN ↦
+      data.mpo_changePhysicalBasis_cyclicEtaWeight_eq_product
+        dl dr e U η hU hB N hN }⟩
+
+/-- A chosen exact matrix-product representation of the fixed commuting-bond
+product.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `3to4` and equation
+`sigmaNK2`, lines 1570--1593. -/
+noncomputable def fixedProductTensorData [NeZero d]
+    (data : EtaLocalStructureData M) :
+    TranslationInvariantBondData.FixedProductTensorData data.bondData :=
+  Classical.choice data.nonempty_fixedProductTensorData
+
+end EtaLocalStructureData
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -393,6 +393,7 @@
     \label{def:mpdo_cyclic_edge_weight_tensor}
     \lean{MPOTensor.cyclicEdgeWeightTensor}
     \lean{MPOTensor.cyclicEdgeWeightTensor_apply_eq}
+    \lean{MPOTensor.etaCyclicEdgeWeight}
     \leanok
     A scalar weight
     \[
@@ -441,13 +442,50 @@
     product gives such a tensor with positive virtual dimension $d^2$.
 \end{definition}
 
+\begin{theorem}[Fixed tensor for an eta-local bond product]
+    \label{thm:mpdo_eta_fixed_bond_product_tensor}
+    \lean{MPOTensor.%
+      reindex_mpo_cyclicEdgeWeightTensor_etaCyclicEdgeWeight}
+    \lean{MPOTensor.EtaLocalStructureData.nonempty_fixedProductTensorData}
+    \lean{MPOTensor.EtaLocalStructureData.fixedProductTensorData}
+    \leanok
+    \uses{def:mpdo_eta_local_structure_data,
+        def:mpdo_fixed_bond_product_tensor,
+        thm:mpdo_commuting_bond_positive_eta_decomposition}
+    Suppose $d>0$.  The fixed positive commuting bond carried by an eta-local
+    structure admits one matrix-product tensor $C$, with virtual dimension
+    $d^2$ and independent of $N$, such that for every $N\geq2$,
+    \[
+        \rho^{(N)}(C)=\prod_{n=0}^{N-1}B_{n,n+1}.
+    \]
+    No normality assertion is made for $C$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_commuting_bond_positive_eta_decomposition,
+        thm:mpdo_eta_pair_bond_cyclic_product_transport,
+        thm:mpdo_cyclic_edge_weight_tensor}
+    Choose the unitary $U$, sector dimensions, and neighboring operators
+    $\eta_{q,h}$ from the fixed-bond decomposition.  In the corresponding
+    sector coordinates, the product of the conjugated bonds has entries
+    \[
+        \bigoplus_{k_0,\ldots,k_{N-1}}
+          \bigotimes_{n=0}^{N-1}\eta_{k_n,k_{n+1}},
+        \qquad k_N=k_0.
+    \]
+    The cyclic edge-weight tensor has exactly these entries.  Conjugating its
+    physical index by $U$ gives $C$; the two sitewise unitary conjugations
+    cancel, which yields the stated bond product.
+\end{proof}
+
 \begin{theorem}[Eventual proportionality from a fixed product tensor]
     \label{thm:mpdo_eta_fixed_product_tensor_eventual_proportionality}
     \lean{MPOTensor.EtaLocalStructureData.%
       eventuallyNonzeroProportionalMPV₂_fixedProductTensor}
     \leanok
     \uses{def:mpdo_eta_local_structure_data,
-        def:mpdo_fixed_bond_product_tensor}
+        def:mpdo_fixed_bond_product_tensor,
+        thm:mpdo_eta_fixed_bond_product_tensor}
     Suppose one fixed tensor $C$ generates the products of the bond carried
     by an eta-local structure.  Then the doubled-index tensors of $M$ and
     $C$ are eventually nonzero proportional.  The proof uses only lengths

--- a/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
+++ b/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
@@ -231,14 +231,20 @@ eventuallyNonzeroProportionalMPV₂_fixedProductTensor}
 derives eventual nonzero proportionality to the source tensor without adding
 a length-one hypothesis.
 
-This does not yet construct the fixed tensor directly from an arbitrary
-\leanid{MPOTensor.TranslationInvariantBondData}.  The remaining local step is
-to assemble the chain-independent Beigi sector coordinates and neighboring
-operators into the cyclic scalar weight, then transport the resulting tensor
-back through the same one-site unitary.  Even after that construction, a
-normal representative is not automatic: it requires the normal-block
-canonical-form argument that rules out additional canonical summands and
-proves the geometric law for $c_N$.
+For the fixed bond carried by an eta-local structure, this construction is now
+complete.  The theorem
+\leanid{MPOTensor.EtaLocalStructureData.nonempty_fixedProductTensorData}
+assembles the chain-independent Beigi sector coordinates and neighboring
+operators into the cyclic scalar weight, then transports the resulting tensor
+back through the same one-site unitary.  Its virtual dimension is $d^2$, and
+its operator family equals the fixed bond product for every $N\geq2$.
+
+The constructed tensor is not yet known to be normal.  Obtaining a normal
+representative requires the normal-block canonical-form argument that rules
+out additional canonical summands; this is the remaining part of
+\ghissue{4271}.  The separate geometric law $c_N=a^N$ for the realization
+scalars, and its absorption into one local normalization, remains tracked in
+\ghissue{4253}.
 
 The scaled identity uses only the fixed commuting bond and its positive
 realization scalar.  It does not assert zero correlation length, rank-one trace


### PR DESCRIPTION
### Motivation
- Address the finite-representation part of #4271 without overlapping the normality argument or #4253.
- The source is `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 1570--1593, Proposition `3to4` and equation `sigmaNK2`: after one unitary change of physical coordinates, the finite-chain operator is a direct sum of cyclic products of neighboring positive operators.

### Description
- Define the scalar cyclic edge weight associated with the neighboring operators and prove its closed matrix-product operator is the required sectorwise direct sum.
- Construct, for every eta-local structure with positive physical dimension, one tensor of virtual dimension `d^2` whose operator equals the complete product of the fixed commuting bond for every `N >= 2`.
- Keep all algebraic transport lemmas private and expose only the mathematical edge weight, its cyclic identity, the existence theorem, and a chosen exact representative.
- Add the root import and update the Chapter 21 blueprint and `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.
- This PR does not prove that the constructed tensor is normal and does not prove a geometric law `c_N = a^N`. Normality remains in #4271; scalar normalization remains separate in #4253.

### Testing
- `lake env lean TNLean/MPS/MPDO/FixedBondProductEtaTensor.lean`
- `lake build TNLean.MPS.MPDO.FixedBondProductEtaTensor`
- `lake build TNLean` (9576/9576)
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- Reverse blueprint coverage check for the changed Lean declarations
- `rg -n "sorry|admit|axiom|native_decide|unsafeCast" TNLean/MPS/MPDO/FixedBondProductEtaTensor.lean`
- `git diff --check`
- `leanblueprint web` could not be validated locally because the renderer Python process could not import its installed `leanblueprint` package; CI should run it in the configured environment.

---
Addresses #4271

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization and documentation in MPS/MPDO theory; no runtime, auth, or data-path changes. Scope is explicitly limited (no normality or scalar law).
> 
> **Overview**
> Introduces **`FixedBondProductEtaTensor.lean`**, which closes the finite-representation step for eta-local commuting bonds (arXiv:1606.00608 Appendix C.2): defines **`etaCyclicEdgeWeight`**, proves the cyclic edge-weight MPO matches sectorwise products of neighboring η operators, and shows **`EtaLocalStructureData.nonempty_fixedProductTensorData`** / **`fixedProductTensorData`** give a single **`changePhysicalBasis U`** tensor with virtual dimension **`d²`** whose MPO equals the bond product for every **`N ≥ 2`**. Transport lemmas stay private; the public API is the edge weight, reindex identity, existence, and a classical choice of representative.
> 
> Registers the module in **`TNLean.lean`**. Chapter 21 blueprint gains theorem **`thm:mpdo_eta_fixed_bond_product_tensor`** and links **`eventuallyNonzeroProportionalMPV₂_fixedProductTensor`** to it. **`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`** now records this construction as complete for eta-local bonds while **normality** (#4271) and **`c_N = a^N`** (#4253) remain open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7470e225a54af0efd48a304594b8d06a43510e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->