### PR TITLE
feat(MPS/MPDO): represent fixed commuting-bond products

### DIFF
--- a/TNLean/MPS/MPDO/CommutingBondEtaDecomposition.lean
+++ b/TNLean/MPS/MPDO/CommutingBondEtaDecomposition.lean
@@ -16,6 +16,7 @@ finite chain.
 ## Main declarations
 
 * `Matrix.etaPairSpatialBlockEquiv`
+* `MPOTensor.TranslationInvariantBondData.exists_positive_eta_pairBond_decomposition`
 * `MPOTensor.EtaLocalStructureData.exists_positive_eta_pairBond_decomposition`
 
 ## References
@@ -60,9 +61,9 @@ def etaPairSpatialBlockEquiv {K : ℕ} {dl dr : Fin K → ℕ}
 
 end Matrix
 
-namespace MPOTensor.EtaLocalStructureData
+namespace MPOTensor.TranslationInvariantBondData
 
-variable {d D : ℕ} {M : MPOTensor d D}
+variable {d : ℕ}
 
 /-- A positive translation-invariant commuting bond has one spatial decomposition and a
 positive neighboring operator \(\eta_{q,h}\) for each ordered pair of sectors such that
@@ -81,7 +82,7 @@ does not assert the rank-one trace factorization invoked later in Proposition 4t
 Source: arXiv:1606.00608, Appendix C.2, equation sigmaNK2 and Proposition 4to2,
 lines 1581--1605; Beigi, arXiv:1105.1019v2, Lemma 2.1. -/
 theorem exists_positive_eta_pairBond_decomposition
-    (data : EtaLocalStructureData M) :
+    (data : TranslationInvariantBondData d) :
     ∃ (K : ℕ) (dl dr : Fin K → ℕ)
       (e : ((q : Fin K) × (Fin (dr q) × Fin (dl q))) ≃ Fin d)
       (U : Matrix (Fin d) (Fin d) ℂ)
@@ -243,7 +244,7 @@ theorem exists_positive_eta_pairBond_decomposition
         have hleft0 := hB'_from_S q h h l0 l0 rq rq' lh lh' rh rh
         have hright := hB'_from_R q q h l0 l0 rq rq' lh lh' rh rh
         have hright0 := hB'_from_R q q h l0 l0 rq rq' lh lh' r0 r0
-        simp at hleft hleft0 hright hright0
+        simp only [Matrix.one_apply_eq, one_mul] at hleft hleft0 hright hright0
         rw [hleft, ← hleft0, hright, ← hright0]
         simp [η, l0, r0]
       · rw [hB'_from_R]
@@ -253,9 +254,9 @@ theorem exists_positive_eta_pairBond_decomposition
   refine ⟨K, dl, dr, e, U, η, hU, hdl, hdr, ?_, ?_⟩
   · intro q h
     have hpair : data.pairBond.PosSemidef := by
-      have hsub := data.bondData.bond_pos.submatrix
+      have hsub := data.bond_pos.submatrix
         (finTwoArrowEquiv (Fin d)).symm
-      simpa [EtaLocalStructureData.pairBond, pairBondMatrix,
+      simpa [TranslationInvariantBondData.pairBond, pairBondMatrix,
         Matrix.reindex_apply] using hsub
     have hBpos : B'.PosSemidef := by
       have hconj := hpair.mul_mul_conjTranspose_same (B := star (U ⊗ₖ U))
@@ -282,5 +283,35 @@ theorem exists_positive_eta_pairBond_decomposition
         exact hB'_right_sector_ne q q h h' hh lq lq' rq rq' lh lh' rh rh'
     · rw [Matrix.blockDiagonal'_apply_ne _ _ _ (fun hp ↦ hq (Prod.mk.inj hp).1)]
       exact hB'_left_sector_ne q q' h h' hq lq lq' rq rq' lh lh' rh rh'
+
+end MPOTensor.TranslationInvariantBondData
+
+namespace MPOTensor.EtaLocalStructureData
+
+variable {d D : ℕ} {M : MPOTensor d D}
+
+/-- A positive bond carried by an eta-local structure has one chain-independent unitary
+sector decomposition with positive neighboring operators.
+
+Source: arXiv:1606.00608, Appendix C.2, equation sigmaNK2 and Proposition 4to2,
+lines 1581--1605; Beigi, arXiv:1105.1019v2, Lemma 2.1. -/
+theorem exists_positive_eta_pairBond_decomposition
+    (data : EtaLocalStructureData M) :
+    ∃ (K : ℕ) (dl dr : Fin K → ℕ)
+      (e : ((q : Fin K) × (Fin (dr q) × Fin (dl q))) ≃ Fin d)
+      (U : Matrix (Fin d) (Fin d) ℂ)
+      (η : (q h : Fin K) →
+        Matrix (Fin (dr q) × Fin (dl h)) (Fin (dr q) × Fin (dl h)) ℂ),
+      U ∈ Matrix.unitaryGroup (Fin d) ℂ ∧
+        (∀ q, 0 < dl q) ∧ (∀ q, 0 < dr q) ∧
+        (∀ q h, (η q h).PosSemidef) ∧
+        Matrix.reindex (Matrix.etaPairSpatialBlockEquiv e).symm
+            (Matrix.etaPairSpatialBlockEquiv e).symm
+            (star (U ⊗ₖ U) * data.pairBond * (U ⊗ₖ U)) =
+          Matrix.blockDiagonal' fun qh : Fin K × Fin K ↦
+            ((1 : Matrix (Fin (dl qh.1)) (Fin (dl qh.1)) ℂ) ⊗ₖ
+              η qh.1 qh.2) ⊗ₖ
+                (1 : Matrix (Fin (dr qh.2)) (Fin (dr qh.2)) ℂ) := by
+  exact data.bondData.exists_positive_eta_pairBond_decomposition
 
 end MPOTensor.EtaLocalStructureData

--- a/TNLean/MPS/MPDO/CommutingFormSpatialBridge.lean
+++ b/TNLean/MPS/MPDO/CommutingFormSpatialBridge.lean
@@ -6,13 +6,14 @@ Authors: TNLean contributors
 import TNLean.MPS.MPDO.CommutingOverlappingCoordinates
 
 /-!
-# Unitary block actions for an eta-local bond
+# Unitary block actions for a fixed commuting bond
 
 This file applies the spatial decomposition of Beigi's lemma to the pair-indexed bond
-carried by an eta-local structure.
+of a positive translation-invariant commuting family.
 
 ## Main declarations
 
+* `MPOTensor.TranslationInvariantBondData.exists_unitary_blockActions_of_pairBond`
 * `MPOTensor.EtaLocalStructureData.exists_unitary_blockActions_of_pairBond`
 
 ## References
@@ -23,11 +24,11 @@ carried by an eta-local structure.
 
 open scoped ComplexOrder Kronecker Matrix
 
-namespace MPOTensor.EtaLocalStructureData
+namespace MPOTensor.TranslationInvariantBondData
 
-variable {d D : ℕ} {M : MPOTensor d D}
+variable {d : ℕ}
 
-/-- The pair-indexed bond carried by an eta-local structure admits the explicit unitary
+/-- The pair-indexed fixed bond admits the explicit unitary
 block-action decomposition of Beigi's lemma.
 
 Under the common three-site identification, the two abstract overlapping lifts are
@@ -36,7 +37,7 @@ precisely the first two adjacent translates of the original bond.
 Source: arXiv:1606.00608, Appendix C.2, lines 1597--1610; Beigi,
 arXiv:1105.1019v2, Lemma 2.1. -/
 theorem exists_unitary_blockActions_of_pairBond
-    (data : EtaLocalStructureData M) :
+    (data : TranslationInvariantBondData d) :
     ∃ (K : ℕ) (dl dr : Fin K → ℕ)
       (e : ((q : Fin K) × (Fin (dr q) × Fin (dl q))) ≃ Fin d)
       (U : Matrix (Fin d) (Fin d) ℂ)
@@ -61,5 +62,40 @@ theorem exists_unitary_blockActions_of_pairBond
   · exact data.pairBond_isHermitian
   · exact data.pairBond_isHermitian
   · exact data.overlappingLifts_pairBond_comm
+
+end MPOTensor.TranslationInvariantBondData
+
+namespace MPOTensor.EtaLocalStructureData
+
+variable {d D : ℕ} {M : MPOTensor d D}
+
+/-- The pair-indexed bond carried by an eta-local structure admits the unitary block-action
+decomposition of Beigi's lemma.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1597--1610; Beigi,
+arXiv:1105.1019v2, Lemma 2.1. -/
+theorem exists_unitary_blockActions_of_pairBond
+    (data : EtaLocalStructureData M) :
+    ∃ (K : ℕ) (dl dr : Fin K → ℕ)
+      (e : ((q : Fin K) × (Fin (dr q) × Fin (dl q))) ≃ Fin d)
+      (U : Matrix (Fin d) (Fin d) ℂ)
+      (R : ∀ q, Matrix (Fin d × Fin (dl q)) (Fin d × Fin (dl q)) ℂ)
+      (S : ∀ q, Matrix (Fin (dr q) × Fin d) (Fin (dr q) × Fin d) ℂ),
+      U ∈ Matrix.unitaryGroup (Fin d) ℂ ∧
+        (∀ q, 0 < dl q) ∧ (∀ q, 0 < dr q) ∧
+        (∀ q, (R q).IsHermitian) ∧ (∀ q, (S q).IsHermitian) ∧
+        Matrix.reindex (Matrix.leftSpatialBlockEquiv e).symm
+            (Matrix.leftSpatialBlockEquiv e).symm
+            (star ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ U) * data.pairBond *
+              ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ U)) =
+          (Matrix.blockDiagonal' fun q ↦
+            R q ⊗ₖ (1 : Matrix (Fin (dr q)) (Fin (dr q)) ℂ)) ∧
+        Matrix.reindex (Matrix.rightSpatialBlockEquiv e).symm
+            (Matrix.rightSpatialBlockEquiv e).symm
+            (star (U ⊗ₖ (1 : Matrix (Fin d) (Fin d) ℂ)) * data.pairBond *
+              (U ⊗ₖ (1 : Matrix (Fin d) (Fin d) ℂ))) =
+          (Matrix.blockDiagonal' fun q ↦
+            (1 : Matrix (Fin (dl q)) (Fin (dl q)) ℂ) ⊗ₖ S q) := by
+  exact data.bondData.exists_unitary_blockActions_of_pairBond
 
 end MPOTensor.EtaLocalStructureData

--- a/TNLean/MPS/MPDO/CommutingOverlappingCoordinates.lean
+++ b/TNLean/MPS/MPDO/CommutingOverlappingCoordinates.lean
@@ -10,8 +10,8 @@ import TNLean.MPS.MPDO.CommutingFormBridge
 /-!
 # Three-site coordinates for overlapping translates of a commuting bond
 
-This file places the first two adjacent translates of the bond carried by
-`MPOTensor.EtaLocalStructureData` in the abstract three-factor coordinates of the
+This file places the first two adjacent translates of one fixed positive commuting bond in the
+abstract three-factor coordinates of the
 Bravyi--Vyalyi decomposition.  One common equivalence identifies a three-site physical
 configuration with a left-associated triple.  Under this equivalence, the translate on
 sites zero and one is `Matrix.leftOverlappingLift`, while the translate on sites one and
@@ -27,6 +27,7 @@ commutation through the common equivalence gives the remaining hypothesis of
 * `MPOTensor.pairBondMatrix`
 * `MPOTensor.reindex_embedLocalOperator_zero_eq_leftOverlappingLift`
 * `MPOTensor.reindex_embedLocalOperator_one_eq_rightOverlappingLift`
+* `MPOTensor.TranslationInvariantBondData.overlappingLifts_pairBond_comm`
 * `MPOTensor.EtaLocalStructureData.reindex_bondAt_zero_eq_leftOverlappingLift`
 * `MPOTensor.EtaLocalStructureData.reindex_bondAt_one_eq_rightOverlappingLift`
 * `MPOTensor.EtaLocalStructureData.overlappingLifts_pairBond_comm`
@@ -184,6 +185,85 @@ theorem reindex_embedLocalOperator_one_eq_rightOverlappingLift
     have hi : i ≠ i' := fun hi ↦ h hi.symm
     simp [Matrix.rightOverlappingLift, hi]
 
+namespace TranslationInvariantBondData
+
+variable {d : ℕ}
+
+/-- A fixed two-site bond written on an ordered pair of physical indices.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `expression` and Proposition
+`4to2`, lines 1571--1576 and 1599--1605. -/
+def pairBond (data : TranslationInvariantBondData d) :
+    Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ :=
+  pairBondMatrix data.bond
+
+/-- The pair-indexed bond is Hermitian because the fixed bond is positive semidefinite.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `expression`, lines 1571--1576. -/
+theorem pairBond_isHermitian (data : TranslationInvariantBondData d) :
+    data.pairBond.IsHermitian := by
+  exact data.bond_pos.isHermitian.reindex (finTwoArrowEquiv (Fin d))
+
+/-- The first adjacent translate is the left overlapping lift under the common three-site
+equivalence.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines 1599--1605;
+Beigi, arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`), pages 2--3. -/
+theorem reindex_bondAt_zero_eq_leftOverlappingLift
+    (data : TranslationInvariantBondData d) :
+    Matrix.reindex (threeSiteOverlappingEquiv (Fin d))
+        (threeSiteOverlappingEquiv (Fin d))
+        ((data.toCommutingFormData two_le_three).bondAt (0 : Fin 3)) =
+      Matrix.leftOverlappingLift data.pairBond := by
+  exact reindex_embedLocalOperator_zero_eq_leftOverlappingLift data.bond
+
+/-- The second adjacent translate is the right overlapping lift under the same three-site
+equivalence.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines 1599--1605;
+Beigi, arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`), pages 2--3. -/
+theorem reindex_bondAt_one_eq_rightOverlappingLift
+    (data : TranslationInvariantBondData d) :
+    Matrix.reindex (threeSiteOverlappingEquiv (Fin d))
+        (threeSiteOverlappingEquiv (Fin d))
+        ((data.toCommutingFormData two_le_three).bondAt (1 : Fin 3)) =
+      Matrix.rightOverlappingLift data.pairBond := by
+  exact reindex_embedLocalOperator_one_eq_rightOverlappingLift data.bond
+
+/-- The two abstract overlapping lifts of the pair-indexed fixed bond commute. Thus, together
+with Hermiticity, they satisfy the hypotheses of Beigi's spatial decomposition.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines 1599--1605;
+Beigi, arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`), pages 2--3. -/
+theorem overlappingLifts_pairBond_comm (data : TranslationInvariantBondData d) :
+    Matrix.leftOverlappingLift data.pairBond *
+        Matrix.rightOverlappingLift data.pairBond =
+      Matrix.rightOverlappingLift data.pairBond *
+        Matrix.leftOverlappingLift data.pairBond := by
+  rw [← data.reindex_bondAt_zero_eq_leftOverlappingLift,
+    ← data.reindex_bondAt_one_eq_rightOverlappingLift]
+  change (Matrix.reindexLinearEquiv ℂ ℂ (threeSiteOverlappingEquiv (Fin d))
+      (threeSiteOverlappingEquiv (Fin d)))
+        ((data.toCommutingFormData two_le_three).bondAt 0) *
+      (Matrix.reindexLinearEquiv ℂ ℂ (threeSiteOverlappingEquiv (Fin d))
+        (threeSiteOverlappingEquiv (Fin d)))
+          ((data.toCommutingFormData two_le_three).bondAt 1) =
+    (Matrix.reindexLinearEquiv ℂ ℂ (threeSiteOverlappingEquiv (Fin d))
+      (threeSiteOverlappingEquiv (Fin d)))
+        ((data.toCommutingFormData two_le_three).bondAt 1) *
+      (Matrix.reindexLinearEquiv ℂ ℂ (threeSiteOverlappingEquiv (Fin d))
+        (threeSiteOverlappingEquiv (Fin d)))
+          ((data.toCommutingFormData two_le_three).bondAt 0)
+  rw [Matrix.reindexLinearEquiv_mul ℂ ℂ (threeSiteOverlappingEquiv (Fin d))
+      (threeSiteOverlappingEquiv (Fin d)) (threeSiteOverlappingEquiv (Fin d)),
+    Matrix.reindexLinearEquiv_mul ℂ ℂ (threeSiteOverlappingEquiv (Fin d))
+      (threeSiteOverlappingEquiv (Fin d)) (threeSiteOverlappingEquiv (Fin d))]
+  exact congrArg (Matrix.reindex (threeSiteOverlappingEquiv (Fin d))
+    (threeSiteOverlappingEquiv (Fin d)))
+    (data.bond_comm two_le_three (0 : Fin 3) (1 : Fin 3))
+
+end TranslationInvariantBondData
+
 namespace EtaLocalStructureData
 
 variable {M : MPOTensor d D}
@@ -195,14 +275,14 @@ Source: arXiv:1606.00608, Appendix C.2, equation `expression` and Proposition
 `4to2`, lines 1571--1576 and 1599--1605. -/
 def pairBond (data : EtaLocalStructureData M) :
     Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ :=
-  pairBondMatrix data.bondData.bond
+  data.bondData.pairBond
 
 /-- The pair-indexed bond is Hermitian because the source bond is positive semidefinite.
 
 Source: arXiv:1606.00608, Appendix C.2, equation `expression`, lines 1571--1576. -/
 theorem pairBond_isHermitian (data : EtaLocalStructureData M) :
     data.pairBond.IsHermitian := by
-  exact data.bondData.bond_pos.isHermitian.reindex (finTwoArrowEquiv (Fin d))
+  exact data.bondData.pairBond_isHermitian
 
 /-- The first adjacent translate of the eta-local bond is the left overlapping lift under
 the common three-site equivalence.
@@ -215,7 +295,7 @@ theorem reindex_bondAt_zero_eq_leftOverlappingLift
         (threeSiteOverlappingEquiv (Fin d))
         ((data.formAt 3 two_le_three).bondAt (0 : Fin 3)) =
       Matrix.leftOverlappingLift data.pairBond := by
-  exact reindex_embedLocalOperator_zero_eq_leftOverlappingLift data.bondData.bond
+  exact data.bondData.reindex_bondAt_zero_eq_leftOverlappingLift
 
 /-- The second adjacent translate of the eta-local bond is the right overlapping lift
 under the same three-site equivalence.
@@ -228,7 +308,7 @@ theorem reindex_bondAt_one_eq_rightOverlappingLift
         (threeSiteOverlappingEquiv (Fin d))
         ((data.formAt 3 two_le_three).bondAt (1 : Fin 3)) =
       Matrix.rightOverlappingLift data.pairBond := by
-  exact reindex_embedLocalOperator_one_eq_rightOverlappingLift data.bondData.bond
+  exact data.bondData.reindex_bondAt_one_eq_rightOverlappingLift
 
 /-- The two abstract overlapping lifts of the pair-indexed eta-local bond commute.  Thus,
 together with `pairBond_isHermitian`, they satisfy exactly the hypotheses of
@@ -241,27 +321,7 @@ theorem overlappingLifts_pairBond_comm (data : EtaLocalStructureData M) :
         Matrix.rightOverlappingLift data.pairBond =
       Matrix.rightOverlappingLift data.pairBond *
         Matrix.leftOverlappingLift data.pairBond := by
-  rw [← data.reindex_bondAt_zero_eq_leftOverlappingLift,
-    ← data.reindex_bondAt_one_eq_rightOverlappingLift]
-  change (Matrix.reindexLinearEquiv ℂ ℂ (threeSiteOverlappingEquiv (Fin d))
-      (threeSiteOverlappingEquiv (Fin d)))
-        ((data.formAt 3 two_le_three).bondAt 0) *
-      (Matrix.reindexLinearEquiv ℂ ℂ (threeSiteOverlappingEquiv (Fin d))
-        (threeSiteOverlappingEquiv (Fin d)))
-          ((data.formAt 3 two_le_three).bondAt 1) =
-    (Matrix.reindexLinearEquiv ℂ ℂ (threeSiteOverlappingEquiv (Fin d))
-      (threeSiteOverlappingEquiv (Fin d)))
-        ((data.formAt 3 two_le_three).bondAt 1) *
-      (Matrix.reindexLinearEquiv ℂ ℂ (threeSiteOverlappingEquiv (Fin d))
-        (threeSiteOverlappingEquiv (Fin d)))
-          ((data.formAt 3 two_le_three).bondAt 0)
-  rw [Matrix.reindexLinearEquiv_mul ℂ ℂ (threeSiteOverlappingEquiv (Fin d))
-      (threeSiteOverlappingEquiv (Fin d)) (threeSiteOverlappingEquiv (Fin d)),
-    Matrix.reindexLinearEquiv_mul ℂ ℂ (threeSiteOverlappingEquiv (Fin d))
-      (threeSiteOverlappingEquiv (Fin d)) (threeSiteOverlappingEquiv (Fin d))]
-  exact congrArg (Matrix.reindex (threeSiteOverlappingEquiv (Fin d))
-    (threeSiteOverlappingEquiv (Fin d)))
-    (data.formAt_bondAt_comm 3 two_le_three (0 : Fin 3) (1 : Fin 3))
+  exact data.bondData.overlappingLifts_pairBond_comm
 
 end EtaLocalStructureData
 end MPOTensor

--- a/TNLean/MPS/MPDO/FixedBondProductEtaTensor.lean
+++ b/TNLean/MPS/MPDO/FixedBondProductEtaTensor.lean
@@ -18,8 +18,8 @@ independent of the chain length.
 * `etaCyclicEdgeWeight` gives the scalar neighboring-operator weight.
 * `reindex_mpo_cyclicEdgeWeightTensor_etaCyclicEdgeWeight` identifies its
   closed operator in sector-edge coordinates.
-* `EtaLocalStructureData.nonempty_fixedProductTensorData` constructs an exact
-  fixed tensor for the commuting-bond product.
+* `TranslationInvariantBondData.fixedProductTensorData` constructs an exact
+  fixed tensor for an arbitrary positive commuting bond.
 
 ## References
 
@@ -204,14 +204,12 @@ private theorem singleKrausMap_comp_conjTranspose_of_mul_conjTranspose_eq_one
       simp only [Matrix.mul_assoc]
     _ = X := by rw [hV, one_mul, mul_one]
 
-namespace EtaLocalStructureData
-
-variable {D : ℕ} {M : MPOTensor d D}
+namespace TranslationInvariantBondData
 
 /-- The tensor obtained from one eta decomposition realizes the corresponding
 fixed periodic bond product at every chain length at least two. -/
 private theorem mpo_changePhysicalBasis_cyclicEtaWeight_eq_product
-    (data : EtaLocalStructureData M) {K : ℕ} (dl dr : Fin K → ℕ)
+    (data : TranslationInvariantBondData d) {K : ℕ} (dl dr : Fin K → ℕ)
     (e : Matrix.EtaSiteIndex K dl dr ≃ Fin d)
     (U : Matrix (Fin d) (Fin d) ℂ)
     (eta : (q h : Fin K) →
@@ -228,28 +226,28 @@ private theorem mpo_changePhysicalBasis_cyclicEtaWeight_eq_product
     (N : ℕ) (hN : 2 ≤ N) :
     mpo (changePhysicalBasis U
       (cyclicEdgeWeightTensor (etaCyclicEdgeWeight dl dr e eta))) N =
-        (data.bondData.toCommutingFormData hN).product := by
+        (data.toCommutingFormData hN).product := by
   letI : NeZero N := ⟨by omega⟩
   let C₀ : MPOTensor d (d * d) :=
     cyclicEdgeWeightTensor (etaCyclicEdgeWeight dl dr e eta)
   let P : Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ :=
-    (data.bondData.toCommutingFormData hN).product
+    (data.toCommutingFormData hN).product
   change mpo (changePhysicalBasis U C₀) N = P
   rw [← singleKrausMap_sitewisePhysicalMatrix_mpo U C₀ N]
   let V := sitewisePhysicalMatrix U N
   change singleKrausMap V (mpo C₀ N) = P
   change Matrix.reindex (Matrix.etaPairSpatialBlockEquiv e).symm
       (Matrix.etaPairSpatialBlockEquiv e).symm
-      (star (U ⊗ₖ U) * pairBondMatrix data.bondData.bond * (U ⊗ₖ U)) = _ at hB
+      (star (U ⊗ₖ U) * pairBondMatrix data.bond * (U ⊗ₖ U)) = _ at hB
   have hsector : mpo C₀ N =
       singleKrausMap (sitewisePhysicalMatrix Uᴴ N) P := by
     dsimp only [C₀, P]
     change mpo (cyclicEdgeWeightTensor (etaCyclicEdgeWeight dl dr e eta)) N =
       singleKrausMap (sitewisePhysicalMatrix Uᴴ N)
         (List.ofFn fun i : Fin N ↦
-          embedLocalOperator 2 N hN i data.bondData.bond).prod
+          embedLocalOperator 2 N hN i data.bond).prod
     exact mpo_cyclicEdgeWeightTensor_eta_eq_conjugated_bondProduct
-      hN dl dr e U eta data.bondData.bond hU hB
+      hN dl dr e U eta data.bond hU hB
   have hsectorV : mpo C₀ N = singleKrausMap Vᴴ P := by
     rw [sitewisePhysicalMatrix_conjTranspose]
     exact hsector
@@ -262,7 +260,7 @@ private theorem mpo_changePhysicalBasis_cyclicEtaWeight_eq_product
       (Matrix.mem_unitaryGroup_iff.mp hU)
   rw [hUco, sitewisePhysicalMatrix_one]
 
-/-- The fixed commuting-bond product carried by an eta-local structure has one
+/-- Every positive fixed bond whose periodic translates commute has one
 exact matrix-product representation with positive bond dimension, independent
 of the chain length.
 
@@ -270,32 +268,65 @@ This proves only the finite representation of the product.  It does not assert
 that the representing tensor is normal and does not constrain the positive
 realization scalar of the source MPO.
 
-Source: arXiv:1606.00608, Appendix C.2, Proposition `3to4` and equation
-`sigmaNK2`, lines 1570--1593. -/
-theorem nonempty_fixedProductTensorData [NeZero d]
-    (data : EtaLocalStructureData M) :
-    Nonempty (TranslationInvariantBondData.FixedProductTensorData data.bondData) := by
+Source: arXiv:1606.00608, Appendix C.2, equation `sigmaNK2` and Proposition
+`4to2`, lines 1581--1605; Beigi, arXiv:1105.1019v2, Lemma 2.1. -/
+theorem nonempty_fixedProductTensorData (data : TranslationInvariantBondData d) :
+    Nonempty (FixedProductTensorData data) := by
   classical
-  obtain ⟨K, dl, dr, e, U, η, hU, _hdl, _hdr, _hη, hB⟩ :=
-    data.exists_positive_eta_pairBond_decomposition
-  refine ⟨{
-    bondDim := d * d
-    bondDim_pos := Nat.mul_pos (NeZero.pos d) (NeZero.pos d)
-    tensor := changePhysicalBasis U
-      (cyclicEdgeWeightTensor (etaCyclicEdgeWeight dl dr e η))
-    mpo_eq_product := fun N hN ↦
-      data.mpo_changePhysicalBasis_cyclicEtaWeight_eq_product
-        dl dr e U η hU hB N hN }⟩
+  by_cases hd : d = 0
+  · subst d
+    refine ⟨{
+      bondDim := 1
+      bondDim_pos := by omega
+      tensor := fun i ↦ Fin.elim0 i
+      mpo_eq_product := ?_ }⟩
+    intro N hN
+    ext sigma
+    exact Fin.elim0 (sigma ⟨0, by omega⟩)
+  · letI : NeZero d := ⟨hd⟩
+    obtain ⟨K, dl, dr, e, U, η, hU, _hdl, _hdr, _hη, hB⟩ :=
+      data.exists_positive_eta_pairBond_decomposition
+    refine ⟨{
+      bondDim := d * d
+      bondDim_pos := Nat.mul_pos (NeZero.pos d) (NeZero.pos d)
+      tensor := changePhysicalBasis U
+        (cyclicEdgeWeightTensor (etaCyclicEdgeWeight dl dr e η))
+      mpo_eq_product := fun N hN ↦
+        data.mpo_changePhysicalBasis_cyclicEtaWeight_eq_product
+          dl dr e U η hU hB N hN }⟩
 
 /-- A chosen exact matrix-product representation of the fixed commuting-bond
 product.
 
-Source: arXiv:1606.00608, Appendix C.2, Proposition `3to4` and equation
-`sigmaNK2`, lines 1570--1593. -/
-noncomputable def fixedProductTensorData [NeZero d]
-    (data : EtaLocalStructureData M) :
-    TranslationInvariantBondData.FixedProductTensorData data.bondData :=
+Source: arXiv:1606.00608, Appendix C.2, equation `sigmaNK2` and Proposition
+`4to2`, lines 1581--1605; Beigi, arXiv:1105.1019v2, Lemma 2.1. -/
+noncomputable def fixedProductTensorData (data : TranslationInvariantBondData d) :
+    FixedProductTensorData data :=
   Classical.choice data.nonempty_fixedProductTensorData
+
+end TranslationInvariantBondData
+
+namespace EtaLocalStructureData
+
+variable {D : ℕ} {M : MPOTensor d D}
+
+/-- The bond carried by an eta-local structure has one exact fixed matrix-product
+representation.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `sigmaNK2` and Proposition
+`4to2`, lines 1581--1605. -/
+theorem nonempty_fixedProductTensorData (data : EtaLocalStructureData M) :
+    Nonempty (TranslationInvariantBondData.FixedProductTensorData data.bondData) :=
+  data.bondData.nonempty_fixedProductTensorData
+
+/-- A chosen exact fixed matrix-product representation of the bond carried by an eta-local
+structure.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `sigmaNK2` and Proposition
+`4to2`, lines 1581--1605. -/
+noncomputable def fixedProductTensorData (data : EtaLocalStructureData M) :
+    TranslationInvariantBondData.FixedProductTensorData data.bondData :=
+  data.bondData.fixedProductTensorData
 
 end EtaLocalStructureData
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -45,9 +45,10 @@
     \label{def:mpdo_three_site_overlapping_coordinates}
     \lean{MPOTensor.threeSiteOverlappingEquiv}
     \lean{MPOTensor.pairBondMatrix}
+    \lean{MPOTensor.TranslationInvariantBondData.pairBond}
     \lean{MPOTensor.EtaLocalStructureData.pairBond}
     \leanok
-    \uses{def:mpdo_eta_local_structure_data}
+    \uses{def:mpdo_translation_invariant_bond_data}
     Write the two-site bond on the ordered pair of physical indices, and
     identify a three-site configuration $(x_0,x_1,x_2)$ with the
     left-associated triple $((x_0,x_1),x_2)$.  These are common coordinates
@@ -58,6 +59,13 @@
     \label{thm:mpdo_eta_bond_overlapping_lifts}
     \lean{MPOTensor.reindex_embedLocalOperator_zero_eq_leftOverlappingLift}
     \lean{MPOTensor.reindex_embedLocalOperator_one_eq_rightOverlappingLift}
+    \lean{MPOTensor.TranslationInvariantBondData.pairBond_isHermitian}
+    \lean{MPOTensor.TranslationInvariantBondData.%
+      reindex_bondAt_zero_eq_leftOverlappingLift}
+    \lean{MPOTensor.TranslationInvariantBondData.%
+      reindex_bondAt_one_eq_rightOverlappingLift}
+    \lean{MPOTensor.TranslationInvariantBondData.%
+      overlappingLifts_pairBond_comm}
     \lean{MPOTensor.EtaLocalStructureData.pairBond_isHermitian}
     \lean{MPOTensor.EtaLocalStructureData.reindex_bondAt_zero_eq_leftOverlappingLift}
     \lean{MPOTensor.EtaLocalStructureData.reindex_bondAt_one_eq_rightOverlappingLift}
@@ -65,8 +73,8 @@
     \leanok
     \uses{def:mpdo_three_site_overlapping_coordinates,
         def:mpdo_translation_invariant_bond_data}
-    Let $B$ be the positive two-site bond carried by the eta-local structure,
-    written as an operator $\widehat B$ on an ordered pair of physical spaces.
+    Let $B$ be a translation-invariant positive two-site bond, written as an
+    operator $\widehat B$ on an ordered pair of physical spaces.
     Under the same three-site identification for both translates,
     \[
         B_{0,1}=\widehat B\otimes\Id,
@@ -182,15 +190,17 @@
     combine it with the doubled-index transfer hypothesis.
 \end{proof}
 
-\begin{theorem}[$\eta$-local bond admits unitary block actions]
+\begin{theorem}[A commuting bond admits unitary block actions]
     \label{thm:mpdo_eta_local_pair_bond_unitary_block_actions}
+    \lean{MPOTensor.TranslationInvariantBondData.%
+      exists_unitary_blockActions_of_pairBond}
     \lean{MPOTensor.EtaLocalStructureData.exists_unitary_blockActions_of_pairBond}
     \leanok
     \uses{def:mpdo_three_site_overlapping_coordinates,
         thm:mpdo_eta_bond_overlapping_lifts,
         thm:commuting_overlapping_unitary_block_actions}
-    Let $\widehat B$ be the pair-indexed positive two-site bond of an
-    $\eta$-local structure.  There are positive dimensions
+    Let $\widehat B$ be a pair-indexed positive two-site bond whose periodic
+    translates commute.  There are positive dimensions
     $d_{l,q}=\dim H_{q,l}$ and $d_{r,q}=\dim H_{q,r}$, a unitary decomposition
     \[
         H\cong\bigoplus_{q=0}^{K-1}H_{q,l}\otimes H_{q,r},
@@ -233,11 +243,13 @@
 
 \begin{theorem}[Positive neighboring operators from the commuting bond]
     \label{thm:mpdo_commuting_bond_positive_eta_decomposition}
+    \lean{MPOTensor.TranslationInvariantBondData.%
+      exists_positive_eta_pairBond_decomposition}
     \lean{MPOTensor.EtaLocalStructureData.%
       exists_positive_eta_pairBond_decomposition}
     \leanok
     \uses{thm:mpdo_eta_local_pair_bond_unitary_block_actions}
-    Let $B$ be the pair-indexed positive bond of an $\eta$-local structure.
+    Let $B$ be a pair-indexed positive bond whose periodic translates commute.
     There are a unitary coordinate decomposition
     \[
         H\cong\bigoplus_q H_{q,r}\otimes H_{q,l}
@@ -442,41 +454,70 @@
     product gives such a tensor with positive virtual dimension $d^2$.
 \end{definition}
 
-\begin{theorem}[Fixed tensor for an eta-local bond product]
+\begin{theorem}[Fixed tensor representation of a commuting bond]
     \label{thm:mpdo_eta_fixed_bond_product_tensor}
     \lean{MPOTensor.%
       reindex_mpo_cyclicEdgeWeightTensor_etaCyclicEdgeWeight}
+    \lean{MPOTensor.TranslationInvariantBondData.%
+      nonempty_fixedProductTensorData}
+    \lean{MPOTensor.TranslationInvariantBondData.fixedProductTensorData}
     \lean{MPOTensor.EtaLocalStructureData.nonempty_fixedProductTensorData}
     \lean{MPOTensor.EtaLocalStructureData.fixedProductTensorData}
     \leanok
-    \uses{def:mpdo_eta_local_structure_data,
+    \uses{def:mpdo_translation_invariant_bond_data,
+        def:mpdo_eta_local_structure_data,
         def:mpdo_fixed_bond_product_tensor,
-        thm:mpdo_commuting_bond_positive_eta_decomposition}
-    Suppose $d>0$.  The fixed positive commuting bond carried by an eta-local
-    structure admits one matrix-product tensor $C$, with virtual dimension
-    $d^2$ and independent of $N$, such that for every $N\geq2$,
+        thm:mpdo_commuting_bond_positive_eta_decomposition,
+        thm:mpdo_eta_pair_bond_cyclic_product_transport,
+        thm:mpdo_cyclic_edge_weight_tensor}
+    Let $B\geq0$ be a two-site bond whose periodic translates commute.  There
+    is a positive integer $R$ and a matrix-product tensor $C$ of virtual
+    dimension $R$, both independent of the chain length, such that for every
+    $N\geq2$,
     \[
         \rho^{(N)}(C)=\prod_{n=0}^{N-1}B_{n,n+1}.
     \]
-    No normality assertion is made for $C$.
+    When $d>0$, the construction has $R=d^2$; when $d=0$, one may take
+    $R=1$.
+    No normality, zero-correlation-length, or scalar normalization hypothesis
+    is required.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{thm:mpdo_commuting_bond_positive_eta_decomposition,
         thm:mpdo_eta_pair_bond_cyclic_product_transport,
         thm:mpdo_cyclic_edge_weight_tensor}
-    Choose the unitary $U$, sector dimensions, and neighboring operators
-    $\eta_{q,h}$ from the fixed-bond decomposition.  In the corresponding
-    sector coordinates, the product of the conjugated bonds has entries
+    Choose Beigi's chain-independent one-site unitary and the positive
+    neighboring operators $\eta_{q,h}$.  In the resulting sector coordinates,
+    the entries of the bond product are
     \[
-        \bigoplus_{k_0,\ldots,k_{N-1}}
-          \bigotimes_{n=0}^{N-1}\eta_{k_n,k_{n+1}},
-        \qquad k_N=k_0.
+        \prod_{n=0}^{N-1}
+        (\eta_{k_n,k_{n+1}})_{(r_n,l_{n+1}),(r_n',l_{n+1}')},
     \]
-    The cyclic edge-weight tensor has exactly these entries.  Conjugating its
-    physical index by $U$ gives $C$; the two sitewise unitary conjugations
-    cancel, which yields the stated bond product.
+    with weight zero unless the ket and bra sector labels agree at each site.
+    The cyclic edge-weight tensor generates this product at every length.
+    Conjugating that tensor by the inverse one-site coordinate change gives
+    $C$ in the original physical coordinates.  Tensor-power unitary
+    conjugation carries its closed operators to the products of the original
+    translates of $B$.
 \end{proof}
+
+\begin{remark}[The scalar edge formula depends on the one-site coordinates]
+    A cyclic scalar edge formula need not hold in the original physical basis.
+    For $d=2$, let $X$ be the Pauli flip and set $B=\Id+X\otimes X$.  This bond
+    is positive semidefinite and its periodic translates commute.  For every
+    $N\geq2$,
+    \[
+        \langle 0^N,\bigl(\prod_n B_{n,n+1}\bigr)0^N\rangle=2.
+    \]
+    At $N=2$ the periodic product is $B^2=2B$; for $N\geq3$, the empty edge
+    set and the full cycle are the two terms with zero boundary.  An
+    original-coordinate scalar edge weight would make this entry equal to
+    $a^N$.  The cases $N=2$ and $N=3$ would give $a^2=2$ and $a^3=2$, a
+    contradiction.  Equation \emph{sigmaNK2} in
+    \cite[Appendix~C.2, lines~1581--1589]{Cirac2016MPDO_arXiv} is stated only
+    after the one-site unitary coordinate change, as used in the theorem.
+\end{remark}
 
 \begin{theorem}[Eventual proportionality from a fixed product tensor]
     \label{thm:mpdo_eta_fixed_product_tensor_eventual_proportionality}

--- a/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
+++ b/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
@@ -231,20 +231,34 @@ eventuallyNonzeroProportionalMPV₂_fixedProductTensor}
 derives eventual nonzero proportionality to the source tensor without adding
 a length-one hypothesis.
 
-For the fixed bond carried by an eta-local structure, this construction is now
-complete.  The theorem
-\leanid{MPOTensor.EtaLocalStructureData.nonempty_fixedProductTensorData}
+The fixed tensor is now constructed directly from an arbitrary
+\leanid{MPOTensor.TranslationInvariantBondData}.  The theorem
+\leanid{MPOTensor.TranslationInvariantBondData.fixedProductTensorData}
 assembles the chain-independent Beigi sector coordinates and neighboring
-operators into the cyclic scalar weight, then transports the resulting tensor
-back through the same one-site unitary.  Its virtual dimension is $d^2$, and
-its operator family equals the fixed bond product for every $N\geq2$.
+operators into a cyclic scalar weight in the transformed one-site coordinates,
+then conjugates the resulting tensor back through the same one-site unitary.
+It uses only positivity and commutation of the periodic translates.
 
-The constructed tensor is not yet known to be normal.  Obtaining a normal
-representative requires the normal-block canonical-form argument that rules
-out additional canonical summands; this is the remaining part of
-\ghissue{4271}.  The separate geometric law $c_N=a^N$ for the realization
-scalars, and its absorption into one local normalization, remains tracked in
-\ghissue{4253}.
+The coordinate qualification is necessary.  In physical dimension $d=2$, let
+$X$ be the Pauli flip and $B=\Id+X\otimes X$.  Then $B\succeq0$, all periodic
+translates commute, and
+\[
+  \langle 0^N,(\prod_n B_{n,n+1})0^N\rangle=2
+\]
+for every $N\geq2$.  At $N=2$ the repository's periodic product is
+$B^2=2B$; for $N\geq3$ the empty edge set and the full cycle give the two
+terms with zero boundary.  A scalar edge weight in the original coordinates
+would make this entry $a^N$, so the cases $N=2$ and $N=3$ would require both
+$a^2=2$ and $a^3=2$.  Thus an arbitrary fixed bond does not carry
+\leanid{MPOTensor.TranslationInvariantBondData.CyclicEdgeWeightForm} in the
+original coordinates.  Equation \emph{sigmaNK2} gives that scalar form only
+after the one-site unitary coordinate change.
+
+A normal representative is still not automatic.  Obtaining one requires the
+normal-block canonical-form argument that rules out additional canonical
+summands; this is the remaining part of \ghissue{4271}.  The separate
+geometric law $c_N=a^N$ for the realization scalars, and its absorption into
+one local normalization, remains tracked in \ghissue{4253}.
 
 The scaled identity uses only the fixed commuting bond and its positive
 realization scalar.  It does not assert zero correlation length, rank-one trace


### PR DESCRIPTION
## Summary

This pull request proves the fixed-tensor construction for an arbitrary positive two-site bond whose periodic translates commute. PR #4289 supplied the eta-local special case while this branch was in progress; the present change strengthens that construction to arbitrary `TranslationInvariantBondData`, including physical dimension zero, while retaining the eta-local declarations as consequences.

- It generalizes the overlapping-lift, Beigi block-action, and positive eta-pair decompositions from eta-local MPO data to `TranslationInvariantBondData`.
- It forms the chain-independent cyclic scalar weight in Beigi's sector coordinates and transports the resulting tensor back through the same one-site unitary.
- It provides `TranslationInvariantBondData.nonempty_fixedProductTensorData` and a chosen `TranslationInvariantBondData.fixedProductTensorData` for every physical dimension.
- It updates the blueprint and the CPSV16 paper-gap note with the coordinate qualification.

No normality, zero-correlation-length, multiplicativity, or scalar-magnitude normalization assumption is introduced.

## Source faithfulness

The construction follows CPSV16, arXiv:1606.00608, Appendix C.2, equation `sigmaNK2` (lines 1581–1589) and Proposition `4to2` (lines 1597–1619), together with Beigi, arXiv:1105.1019v2, Lemma 2.1.

A scalar cyclic edge formula is not generally available in the original physical basis. The paper-gap note now records the dimension-minimal counterexample
`B = I + X ⊗ X`: its all-zero diagonal bond-product entry is `2` at every length `N ≥ 2`, whereas a raw scalar edge weight would require both `a² = 2` and `a³ = 2`. The theorem therefore asserts the transported fixed tensor, exactly as the source coordinate change requires.

See `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.

## Verification

- `lake build`
- `lake env lean TNLean/MPS/MPDO/FixedBondProductEtaTensor.lean`
- `lake exe lint_style` on the four changed Lean modules
- `python3 scripts/blueprint_lean_sync.py --ci`
- `leanblueprint checkdecls`
- proof-integrity scan of the changed Lean modules: no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast`

Closes #4280.
Advances #4271.