### PR TITLE
doc(MPS/MPDO): display inverse-map contractions

### DIFF
--- a/TNLean/MPS/MPDO/ActiveSectorInverseMapProvenance.lean
+++ b/TNLean/MPS/MPDO/ActiveSectorInverseMapProvenance.lean
@@ -81,6 +81,9 @@ private lemma sectorMatrix_linearIndependent : LinearIndependent ℂ sectorMatri
   · change c 3 = 0
     linear_combination h00 - 8 * h01 - (1 / 4) * h10 + 2 * h11
 
+/-- The coefficient table dual to the four sector matrices.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1415--1439. -/
 private noncomputable def dualCoefficient (i : Fin 4) : Matrix (Fin 2) (Fin 2) ℂ :=
   match i with
   | 0 => !![1, 8; 1 / 4, 2]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -84,11 +84,21 @@
 
 \begin{proof}
     \leanok
-    The four physical slices form a basis of the $2\times2$ matrices.  Computing
-    their dual basis and applying it to the two outer density matrices gives the
-    left and right inverse-map factors.  The factor four in the left contraction
-    is cancelled by the sector weight $1/4$.  Direct multiplication then gives
-    $Q(1-LQ)L\ne0$.
+    Write $S_i=L_{\mathord\bullet i}Q_{i\mathord\bullet}$ for the four physical
+    slices, and let $f_i(a,b)$ be their dual coefficients, so that
+    \[
+        \sum_{i=0}^{3}f_i(a,b)S_i=E_{ab}.
+    \]
+    With $T=QL$, $p_k=1/4$, and $(LQ)_{00}=1$, the two inverse-map contractions
+    are
+    \[
+        (LQ)_{00}^{-1}p_k\sum_{i=0}^{3}f_i(0,\beta)T_{ik}
+        =\frac14\bigl(4L_{\beta k}\bigr)=L_{\beta k},
+        \qquad
+        \sum_{i=0}^{3}f_i(\alpha,0)T_{ki}=Q_{k\alpha}.
+    \]
+    Hence the neighboring operators are those obtained directly from $L$ and
+    $Q$, and direct multiplication gives $Q(1-LQ)L\ne0$.
 \end{proof}
 
 % **Obstruction (dependence on Lemma C.5):** the source corollary includes the


### PR DESCRIPTION
### Motivation

The exact-head prose review of #4286 found that the blueprint proof stated the load-bearing dual-basis contraction only in words. The project prose guide requires the contraction identity itself to carry this argument.

### Description

- Define the four physical slices and their dual coefficients in the blueprint proof.
- Display the left and right inverse-map contractions explicitly, including the cancellation of the factor four by the sector weight `1/4`.
- Add a source-cited docstring identifying the private coefficient table as the dual table.
- Leave the mathematical statements and Lean proofs unchanged.

### Testing

- `lake env lean TNLean/MPS/MPDO/ActiveSectorInverseMapProvenance.lean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/MPDO/ActiveSectorInverseMapProvenance.lean`
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex`
- `latexindent -k -s -l blueprint/latexindent.yaml blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex`

---
Follow-up to #4286 and #4270.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prose and comment changes only; no formal proof or API behavior changes.
> 
> **Overview**
> Documentation-only follow-up to prose review: the blueprint proof for the inverse-map factorization theorem now carries the **load-bearing contraction argument** instead of summarizing it in words.
> 
> The proof introduces the four physical slices \(S_i\), dual coefficients \(f_i\) with \(\sum_i f_i(a,b) S_i = E_{ab}\), and **displays** the left and right inverse-map contractions under \(T=QL\), \(p_k=1/4\), and \((LQ)_{00}=1\), including how the sector weight **cancels the factor four** in the left contraction. **Lean statements and proofs are unchanged**; `dualCoefficient` only gains a source-cited docstring identifying it as the dual coefficient table (arXiv:1606.00608, Appendix C.2).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96eb6fc7fe23dea8a0563773f92a1c23b67fcd7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->