### PR TITLE
feat(MPS/MPDO): derive geometric law from normal rescaling

### DIFF
--- a/TNLean/MPS/MPDO/FixedBondProductTensor.lean
+++ b/TNLean/MPS/MPDO/FixedBondProductTensor.lean
@@ -180,6 +180,12 @@ fixed product tensor, or any rescaling of it, is normal.
 Source context: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`),
 lines 1570--1593, together with Corollary `eqV`, lines 1121--1128.  The
 remaining normal-representative problem is documented in
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.
+
+**Scope restriction (positive normal rescaling):** The hypothesis `hRepr`
+assumes that the positively rescaled fixed-product tensor is normal.  This
+hypothesis is absent from Proposition C.8 (`3to4`) and its derivation remains
+open in issue #4271; see
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem exists_unit_phase_power_mpo_eq_product_of_normal_smul
     [NeZero D]
@@ -226,7 +232,13 @@ product, nonzero at those lengths.
 Source context: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`),
 lines 1570--1593, together with Corollary `eqV`, lines 1121--1128.  The
 normal-representative hypothesis is precisely the remaining condition recorded
-in `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+in `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.
+
+**Scope restriction (positive normal rescaling):** The hypothesis `hRepr`
+assumes that the positively rescaled fixed-product tensor is normal.  This
+hypothesis is absent from Proposition C.8 (`3to4`) and its derivation remains
+open in issue #4271; see
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem mpo_eq_positive_power_product_of_normal_smul
     [NeZero D]
     (data : EtaLocalStructureData M)

--- a/TNLean/MPS/MPDO/FixedBondProductTensor.lean
+++ b/TNLean/MPS/MPDO/FixedBondProductTensor.lean
@@ -177,15 +177,15 @@ Thus the construction of a rescaled normal representative is not independent
 of the geometric-scalar problem.  This statement does not assert that the
 fixed product tensor, or any rescaling of it, is normal.
 
-Source context: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`),
-lines 1570--1593, together with Corollary `eqV`, lines 1121--1128.  The
+Source context: arXiv:1606.00608, Appendix C.2, Proposition C.8 (label:
+3to4), lines 1570--1593, together with Corollary eqV, lines 1121--1128.  The
 remaining normal-representative problem is documented in
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.
 
 **Scope restriction (positive normal rescaling):** The hypothesis `hRepr`
 assumes that the positively rescaled fixed-product tensor is normal.  This
-hypothesis is absent from Proposition C.8 (`3to4`) and its derivation remains
-open in issue #4271; see
+hypothesis is absent from Proposition C.8 (label: 3to4), and its derivation
+remains open; see
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem exists_unit_phase_power_mpo_eq_product_of_normal_smul
     [NeZero D]
@@ -229,15 +229,15 @@ The proof uses two sufficiently large consecutive lengths, not lengths one or
 two.  Normality of the source makes its self-overlap, and hence the fixed bond
 product, nonzero at those lengths.
 
-Source context: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`),
-lines 1570--1593, together with Corollary `eqV`, lines 1121--1128.  The
+Source context: arXiv:1606.00608, Appendix C.2, Proposition C.8 (label:
+3to4), lines 1570--1593, together with Corollary eqV, lines 1121--1128.  The
 normal-representative hypothesis is precisely the remaining condition recorded
 in `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.
 
 **Scope restriction (positive normal rescaling):** The hypothesis `hRepr`
 assumes that the positively rescaled fixed-product tensor is normal.  This
-hypothesis is absent from Proposition C.8 (`3to4`) and its derivation remains
-open in issue #4271; see
+hypothesis is absent from Proposition C.8 (label: 3to4), and its derivation
+remains open; see
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem mpo_eq_positive_power_product_of_normal_smul
     [NeZero D]

--- a/TNLean/MPS/MPDO/FixedBondProductTensor.lean
+++ b/TNLean/MPS/MPDO/FixedBondProductTensor.lean
@@ -6,6 +6,7 @@ Authors: TNLean contributors
 import TNLean.MPS.MPDO.CommutingFormBridge
 import TNLean.MPS.MPDO.CyclicEdgeWeightTensor
 import TNLean.MPS.MPDO.VerticalCF
+import TNLean.MPS.Overlap.NormalTensorDichotomy
 
 /-!
 # Fixed matrix-product representations of commuting-bond products
@@ -27,6 +28,8 @@ canonical-form problem; it is not asserted in Proposition C.8 of the source.
 * `MPOTensor.TranslationInvariantBondData.CyclicEdgeWeightForm`
 * `MPOTensor.TranslationInvariantBondData.CyclicEdgeWeightForm.toFixedProductTensorData`
 * `MPOTensor.EtaLocalStructureData.eventuallyNonzeroProportionalMPV₂_fixedProductTensor`
+* `MPOTensor.EtaLocalStructureData.exists_unit_phase_power_mpo_eq_product_of_normal_smul`
+* `MPOTensor.EtaLocalStructureData.mpo_eq_positive_power_product_of_normal_smul`
 
 ## References
 
@@ -107,6 +110,35 @@ namespace EtaLocalStructureData
 
 variable {M : MPOTensor d D}
 
+private theorem fixedProduct_ne_zero_of_mpvOverlap_ne_zero
+    (data : EtaLocalStructureData M)
+    {N : ℕ} (hN : 2 ≤ N)
+    (hOverlap : MPSTensor.mpvOverlap M.toMPSTensor M.toMPSTensor N ≠ 0) :
+    (data.bondData.toCommutingFormData hN).product ≠ 0 := by
+  classical
+  have hExists : ∃ ρ : Fin N → Fin (d * d),
+      MPSTensor.mpv M.toMPSTensor ρ ≠ 0 := by
+    by_contra h
+    push Not at h
+    apply hOverlap
+    simp only [MPSTensor.mpvOverlap]
+    apply Finset.sum_eq_zero
+    intro ρ _hρ
+    rw [h ρ, zero_mul]
+  obtain ⟨ρ, hρ⟩ := hExists
+  let σ : Fin N → Fin d := fun n ↦ (ρ n).divNat
+  let τ : Fin N → Fin d := fun n ↦ (ρ n).modNat
+  have hρeq : (fun n ↦ finProdFinEquiv (σ n, τ n)) = ρ := by
+    funext n
+    simpa [σ, τ] using (finProdFinEquiv.apply_symm_apply (ρ n))
+  have hMpo : mpo M N σ τ ≠ 0 := by
+    rw [← MPSTensor.mpv_toMPSTensor_pairConfig, hρeq]
+    exact hρ
+  obtain ⟨c, hc, hReal⟩ := data.realizes_mpo N hN
+  intro hProduct
+  apply hMpo
+  rw [hReal, hProduct, smul_zero, Matrix.zero_apply]
+
 /-- A fixed tensor representation of the commuting-bond product converts the
 positive source realization, which begins at length two, into eventual
 nonzero proportionality of the doubled-index matrix-product vectors.
@@ -136,6 +168,135 @@ theorem eventuallyNonzeroProportionalMPV₂_fixedProductTensor
       MPSTensor.mpv_toMPSTensor_pairConfig]
     rw [hreal, repr.mpo_eq_product N hN]
     rfl
+
+/-- If one positive rescaling of a fixed product tensor is normal, then its
+comparison with a normal source tensor already has one geometric coefficient:
+a unit phase times the positive rescaling, raised to the chain length.
+
+Thus the construction of a rescaled normal representative is not independent
+of the geometric-scalar problem.  This statement does not assert that the
+fixed product tensor, or any rescaling of it, is normal.
+
+Source context: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`),
+lines 1570--1593, together with Corollary `eqV`, lines 1121--1128.  The
+remaining normal-representative problem is documented in
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem exists_unit_phase_power_mpo_eq_product_of_normal_smul
+    [NeZero D]
+    (data : EtaLocalStructureData M)
+    (repr : TranslationInvariantBondData.FixedProductTensorData data.bondData)
+    (s : ℝ) (hs : 0 < s)
+    (hM : MPSTensor.IsNormalTensor M.toMPSTensor)
+    (hRepr : MPSTensor.IsNormalTensor
+      (fun i ↦ (s : ℂ) • repr.tensor.toMPSTensor i)) :
+    ∃ ζ : ℂ, ‖ζ‖ = 1 ∧ ∀ (N : ℕ) (hN : 2 ≤ N),
+      mpo M N = ((ζ * (s : ℂ)) ^ N) • (data.bondData.toCommutingFormData hN).product := by
+  letI : NeZero repr.bondDim := ⟨Nat.ne_of_gt repr.bondDim_pos⟩
+  have hsℂ : (s : ℂ) ≠ 0 := by
+    exact_mod_cast ne_of_gt hs
+  have hProp : MPSTensor.EventuallyNonzeroProportionalMPV₂ M.toMPSTensor
+      (fun i ↦ (s : ℂ) • repr.tensor.toMPSTensor i) := by
+    filter_upwards [data.eventuallyNonzeroProportionalMPV₂_fixedProductTensor repr]
+      with N hN
+    rcases hN with ⟨c, hc, hEq⟩
+    refine ⟨c / (s : ℂ) ^ N, div_ne_zero hc (pow_ne_zero N hsℂ), ?_⟩
+    intro σ
+    rw [MPSTensor.mpv_smul, hEq σ]
+    field_simp
+  rcases hProp.exists_unit_phase_power_of_isNormalTensor hM hRepr with
+    ⟨ζ, hζ, hPhase⟩
+  refine ⟨ζ, hζ, ?_⟩
+  intro N hN
+  ext σ τ
+  rw [← MPSTensor.mpv_toMPSTensor_pairConfig,
+    hPhase N (by omega), MPSTensor.mpv_smul,
+    MPSTensor.mpv_toMPSTensor_pairConfig, repr.mpo_eq_product N hN]
+  simp only [Matrix.smul_apply, smul_eq_mul, mul_assoc, mul_pow]
+
+/-- Under the hypotheses of
+`exists_unit_phase_power_mpo_eq_product_of_normal_smul`, positivity of the
+source realization removes the unit phase.  Consequently the same positive
+rescaling that makes the fixed product tensor normal is the base of the
+geometric realization scalar.
+
+The proof uses two sufficiently large consecutive lengths, not lengths one or
+two.  Normality of the source makes its self-overlap, and hence the fixed bond
+product, nonzero at those lengths.
+
+Source context: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`),
+lines 1570--1593, together with Corollary `eqV`, lines 1121--1128.  The
+normal-representative hypothesis is precisely the remaining condition recorded
+in `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem mpo_eq_positive_power_product_of_normal_smul
+    [NeZero D]
+    (data : EtaLocalStructureData M)
+    (repr : TranslationInvariantBondData.FixedProductTensorData data.bondData)
+    (s : ℝ) (hs : 0 < s)
+    (hM : MPSTensor.IsNormalTensor M.toMPSTensor)
+    (hRepr : MPSTensor.IsNormalTensor
+      (fun i ↦ (s : ℂ) • repr.tensor.toMPSTensor i)) :
+    ∀ (N : ℕ) (hN : 2 ≤ N),
+      mpo M N = ((s : ℂ) ^ N) • (data.bondData.toCommutingFormData hN).product := by
+  rcases data.exists_unit_phase_power_mpo_eq_product_of_normal_smul
+      repr s hs hM hRepr with ⟨ζ, hζ, hGeo⟩
+  obtain ⟨K, hK⟩ := Metric.tendsto_atTop.mp hM.selfOverlap_tendsto_one
+    (1 / 2) (by norm_num)
+  let N := max K 2
+  have hKN : K ≤ N := le_max_left K 2
+  have hN : 2 ≤ N := le_max_right K 2
+  have hOverlapN : MPSTensor.mpvOverlap M.toMPSTensor M.toMPSTensor N ≠ 0 := by
+    intro hZero
+    have hDist := hK N hKN
+    rw [hZero] at hDist
+    norm_num at hDist
+  have hOverlapSucc :
+      MPSTensor.mpvOverlap M.toMPSTensor M.toMPSTensor (N + 1) ≠ 0 := by
+    intro hZero
+    have hDist := hK (N + 1) (by omega)
+    rw [hZero] at hDist
+    norm_num at hDist
+  have hProductN : (data.bondData.toCommutingFormData hN).product ≠ 0 :=
+    fixedProduct_ne_zero_of_mpvOverlap_ne_zero data hN hOverlapN
+  have hNSucc : 2 ≤ N + 1 := by omega
+  have hProductSucc :
+      (data.bondData.toCommutingFormData hNSucc).product ≠ 0 :=
+    fixedProduct_ne_zero_of_mpvOverlap_ne_zero data hNSucc hOverlapSucc
+  obtain ⟨cN, hcN, hRealN⟩ := data.realizes_mpo N hN
+  obtain ⟨cSucc, hcSucc, hRealSucc⟩ := data.realizes_mpo (N + 1) hNSucc
+  have hScalarN : (ζ * (s : ℂ)) ^ N = (cN : ℂ) := by
+    apply sub_eq_zero.mp
+    apply (smul_eq_zero.mp ?_).resolve_right hProductN
+    rw [sub_smul, (hGeo N hN).symm.trans hRealN, sub_self]
+  have hScalarSucc : (ζ * (s : ℂ)) ^ (N + 1) = (cSucc : ℂ) := by
+    apply sub_eq_zero.mp
+    apply (smul_eq_zero.mp ?_).resolve_right hProductSucc
+    rw [sub_smul, (hGeo (N + 1) hNSucc).symm.trans hRealSucc, sub_self]
+  let x : ℂ := ζ * (s : ℂ)
+  have hxMul : x * (cN : ℂ) = (cSucc : ℂ) := by
+    rw [← hScalarN, ← hScalarSucc]
+    simp only [x, pow_succ]
+    rw [mul_comm]
+  have hcNℂ : (cN : ℂ) ≠ 0 := by
+    exact_mod_cast ne_of_gt hcN
+  have hx : x = ((cSucc / cN : ℝ) : ℂ) := by
+    calc
+      x = (cSucc : ℂ) / (cN : ℂ) := (eq_div_iff hcNℂ).2 hxMul
+      _ = ((cSucc / cN : ℝ) : ℂ) := by norm_cast
+  have hnormx : ‖x‖ = s := by
+    simp [x, hζ, Complex.norm_real, Real.norm_of_nonneg hs.le]
+  have hRatio : cSucc / cN = s := by
+    have hNorm := congrArg norm hx
+    rw [hnormx, Complex.norm_real,
+      Real.norm_of_nonneg (div_pos hcSucc hcN).le] at hNorm
+    exact hNorm.symm
+  have hxS : x = (s : ℂ) := by
+    rw [hx]
+    exact_mod_cast hRatio
+  have hζOne : ζ = 1 := by
+    apply (mul_right_cancel₀ (by exact_mod_cast ne_of_gt hs : (s : ℂ) ≠ 0))
+    simpa [x] using hxS
+  intro L hL
+  simpa [hζOne] using hGeo L hL
 
 end EtaLocalStructureData
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -540,6 +540,55 @@
     pairs as doubled physical indices.
 \end{proof}
 
+\begin{theorem}[A normal rescaling gives a geometric phase]
+    \label{thm:mpdo_eta_normal_rescaling_geometric_phase}
+    \lean{MPOTensor.EtaLocalStructureData.%
+      exists_unit_phase_power_mpo_eq_product_of_normal_smul}
+    \leanok
+    \uses{thm:mpdo_eta_fixed_product_tensor_eventual_proportionality,
+        thm:normal_proportional_mpv_geometric_phase}
+    Let $A$ be the normal doubled-index source tensor, and let $C$ be a fixed
+    tensor for its commuting-bond product.  Suppose that $sC$ is normal for
+    some $s>0$.  Then there is a complex number $\zeta$, with
+    $|\zeta|=1$, such that, for every $N\geq2$,
+    \[
+        \rho^{(N)}(A)=(\zeta s)^N\prod_{n=0}^{N-1}B_{n,n+1}.
+    \]
+    This is a conditional reduction: it does not assert that $C$, or any
+    rescaling of $C$, is normal.
+\end{theorem}
+
+\begin{proof}\leanok
+    Scaling $C$ by $s$ multiplies its length-$N$ matrix-product vector by
+    $s^N$.  Eventual nonzero proportionality and the normal-tensor overlap
+    dichotomy then give one unit phase $\zeta$ for all lengths.
+\end{proof}
+
+\begin{theorem}[A normal rescaling forces the positive geometric law]
+    \label{thm:mpdo_eta_normal_rescaling_positive_geometric_law}
+    \lean{MPOTensor.EtaLocalStructureData.%
+      mpo_eq_positive_power_product_of_normal_smul}
+    \leanok
+    \uses{thm:mpdo_eta_normal_rescaling_geometric_phase}
+    Under the preceding hypotheses, the unit phase is trivial.  For every
+    $N\geq2$,
+    \[
+        \rho^{(N)}(A)=s^N\prod_{n=0}^{N-1}B_{n,n+1}.
+    \]
+    Thus a positive normal rescaling of the fixed product tensor already
+    supplies the positive geometric realization law.
+\end{theorem}
+
+\begin{proof}\leanok
+    The self-overlap of the normal source tends to one.  Hence at two
+    sufficiently large consecutive lengths, say $N$ and $N+1$, both the
+    source vector and the fixed bond product are nonzero.  Positivity of the
+    realization gives positive numbers $c_N,c_{N+1}$ satisfying
+    $(\zeta s)^N=c_N$ and $(\zeta s)^{N+1}=c_{N+1}$.  Consequently
+    $\zeta s=c_{N+1}/c_N>0$.  Since $|\zeta|=1$ and $s>0$, one has
+    $\zeta=1$.
+\end{proof}
+
 \begin{definition}[Rank-one trace factorization for neighboring operators]
     \label{def:mpdo_generic_eta_rank_one_trace_factorization}
     \lean{Matrix.EtaRankOneTraceFactorization}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -545,8 +545,8 @@
     \lean{MPOTensor.EtaLocalStructureData.%
       exists_unit_phase_power_mpo_eq_product_of_normal_smul}
     \leanok
-    \uses{thm:mpdo_eta_fixed_product_tensor_eventual_proportionality,
-        thm:normal_proportional_mpv_geometric_phase}
+    \uses{def:mpdo_eta_local_structure_data,
+        def:mpdo_fixed_bond_product_tensor, def:nt_cpsv}
     Let $A$ be the normal doubled-index source tensor, and let $C$ be a fixed
     tensor for its commuting-bond product.  Suppose that $sC$ is normal for
     some $s>0$.  Then there is a complex number $\zeta$, with
@@ -559,6 +559,9 @@
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:mpdo_eta_fixed_product_tensor_eventual_proportionality,
+        lem:mpv_smul, thm:normal_proportional_mpv_geometric_phase,
+        lem:mpdo_three_first_site_contraction_coefficients}
     Scaling $C$ by $s$ multiplies its length-$N$ matrix-product vector by
     $s^N$.  Eventual nonzero proportionality and the normal-tensor overlap
     dichotomy then give one unit phase $\zeta$ for all lengths.
@@ -569,7 +572,8 @@
     \lean{MPOTensor.EtaLocalStructureData.%
       mpo_eq_positive_power_product_of_normal_smul}
     \leanok
-    \uses{thm:mpdo_eta_normal_rescaling_geometric_phase}
+    \uses{def:mpdo_eta_local_structure_data,
+        def:mpdo_fixed_bond_product_tensor, def:nt_cpsv}
     Under the preceding hypotheses, the unit phase is trivial.  For every
     $N\geq2$,
     \[
@@ -580,6 +584,8 @@
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:mpdo_eta_normal_rescaling_geometric_phase,
+        thm:cpsv_normal_mpv_phase_gauge}
     The self-overlap of the normal source tends to one.  Hence at two
     sufficiently large consecutive lengths, say $N$ and $N+1$, both the
     source vector and the fixed bond product are nonzero.  Positivity of the

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -547,9 +547,10 @@
     \leanok
     \uses{def:mpdo_eta_local_structure_data,
         def:mpdo_fixed_bond_product_tensor, def:nt_cpsv}
-    Let $A$ be the normal doubled-index source tensor, and let $C$ be a fixed
-    tensor for its commuting-bond product.  Suppose that $sC$ is normal for
-    some $s>0$.  Then there is a complex number $\zeta$, with
+    Let $A$ be the normal doubled-index source tensor of positive bond
+    dimension $D$, and let $C$ be a fixed tensor for its commuting-bond
+    product.  Suppose that $sC$ is normal for some $s>0$.  Then there is a
+    complex number $\zeta$, with
     $|\zeta|=1$, such that, for every $N\geq2$,
     \[
         \rho^{(N)}(A)=(\zeta s)^N\prod_{n=0}^{N-1}B_{n,n+1}.
@@ -562,9 +563,25 @@
     \uses{thm:mpdo_eta_fixed_product_tensor_eventual_proportionality,
         lem:mpv_smul, thm:normal_proportional_mpv_geometric_phase,
         lem:mpdo_three_first_site_contraction_coefficients}
-    Scaling $C$ by $s$ multiplies its length-$N$ matrix-product vector by
-    $s^N$.  Eventual nonzero proportionality and the normal-tensor overlap
-    dichotomy then give one unit phase $\zeta$ for all lengths.
+    Scaling $C$ by $s$ gives
+    \[
+        V^{(N)}(sC)_\sigma=s^N V^{(N)}(C)_\sigma.
+    \]
+    Thus, for all sufficiently large $N$, the proportionality
+    $V^{(N)}(A)_\sigma=c_NV^{(N)}(C)_\sigma$ becomes
+    \[
+        V^{(N)}(A)_\sigma
+          =\frac{c_N}{s^N}V^{(N)}(sC)_\sigma,
+        \qquad \frac{c_N}{s^N}\ne0.
+    \]
+    The normal-tensor overlap dichotomy gives one $\zeta\in\C$, with
+    $|\zeta|=1$, such that
+    \[
+        V^{(N)}(A)_\sigma
+          =\zeta^N V^{(N)}(sC)_\sigma
+          =(\zeta s)^N V^{(N)}(C)_\sigma
+    \]
+    at every positive length.
 \end{proof}
 
 \begin{theorem}[A normal rescaling forces the positive geometric law]
@@ -574,8 +591,10 @@
     \leanok
     \uses{def:mpdo_eta_local_structure_data,
         def:mpdo_fixed_bond_product_tensor, def:nt_cpsv}
-    Under the preceding hypotheses, the unit phase is trivial.  For every
-    $N\geq2$,
+    Let $A$ be the normal doubled-index source tensor of positive bond
+    dimension $D$, let $C$ be a fixed tensor for its commuting-bond product,
+    and suppose that $sC$ is normal for some $s>0$.  Then the unit phase is
+    trivial.  For every $N\geq2$,
     \[
         \rho^{(N)}(A)=s^N\prod_{n=0}^{N-1}B_{n,n+1}.
     \]
@@ -586,10 +605,14 @@
 \begin{proof}\leanok
     \uses{thm:mpdo_eta_normal_rescaling_geometric_phase,
         thm:cpsv_normal_mpv_phase_gauge}
-    The self-overlap of the normal source tends to one.  Hence at two
-    sufficiently large consecutive lengths, say $N$ and $N+1$, both the
-    source vector and the fixed bond product are nonzero.  Positivity of the
-    realization gives positive numbers $c_N,c_{N+1}$ satisfying
+    Normality gives
+    \[
+        \lim_{N\to\infty}
+          \bigl\langle V^{(N)}(A),V^{(N)}(A)\bigr\rangle=1.
+    \]
+    Hence at two sufficiently large consecutive lengths, say $N$ and $N+1$,
+    both the source vector and the fixed bond product are nonzero.  Positivity
+    of the realization gives positive numbers $c_N,c_{N+1}$ satisfying
     $(\zeta s)^N=c_N$ and $(\zeta s)^{N+1}=c_{N+1}$.  Consequently
     $\zeta s=c_{N+1}/c_N>0$.  Since $|\zeta|=1$ and $s>0$, one has
     $\zeta=1$.

--- a/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
+++ b/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
@@ -254,11 +254,28 @@ $a^2=2$ and $a^3=2$.  Thus an arbitrary fixed bond does not carry
 original coordinates.  Equation \emph{sigmaNK2} gives that scalar form only
 after the one-site unitary coordinate change.
 
-A normal representative is still not automatic.  Obtaining one requires the
-normal-block canonical-form argument that rules out additional canonical
-summands; this is the remaining part of \ghissue{4271}.  The separate
-geometric law $c_N=a^N$ for the realization scalars, and its absorption into
-one local normalization, remains tracked in \ghissue{4253}.
+The constructed tensor is not yet known to become normal after one positive
+rescaling.  Obtaining such a representative requires a normal-block
+canonical-form argument that rules out additional canonical summands; a
+general BNT direct sum does not supply a single normal block.
+
+The normal-representative and geometric-scalar questions are not independent.
+The theorem
+\leanid{MPOTensor.EtaLocalStructureData.%
+mpo_eq_positive_power_product_of_normal_smul}
+shows that if $sC$ is normal for one $s>0$, then
+\[
+  \sigma^{(N)}(\mathcal K)=s^N\prod_n B_{n,n+1}
+  \qquad (N\geq2).
+\]
+First, the normal-tensor fundamental theorem gives a possible unit phase
+$\zeta^N$.  The self-overlap of the normal source tends to one, so the fixed
+product is nonzero at two sufficiently large consecutive lengths.  The
+positive realization constants at those lengths force $\zeta=1$.  Thus any
+solution of the remaining positive normal-rescaling problem simultaneously
+proves the law $c_N=s^N$ and permits its absorption into one local
+normalization.  This joint remaining problem is tracked in \ghissue{4271};
+\ghissue{4253} records the same dependency from the scalar-law side.
 
 The scaled identity uses only the fixed commuting bond and its positive
 realization scalar.  It does not assert zero correlation length, rank-one trace
@@ -332,12 +349,15 @@ restriction that isolates only its final entropy-theoretic step.
 The gap can be removed in the following stages.
 
 \begin{enumerate}
-\item Restore the normal injective single-block hypothesis in the comparison
-between the matrix-product family and the fixed bond-product family.  Prove the
-proportional fundamental-theorem scalar law $c_N=a^N$ for one $a>0$, and absorb
-$a$ into the bond or neighboring operators.  The counterexample above shows
-that the generic proportional commuting-bond data cannot supply this law; this
-normalization problem is tracked in \ghissue{4253}.
+\item Prove that the exact fixed-product tensor has a single normal
+representative after one positive rescaling, or identify the weakest faithful
+replacement if canonical multiplicities cannot be removed.  The theorem
+\leanid{MPOTensor.EtaLocalStructureData.%
+mpo_eq_positive_power_product_of_normal_smul}
+then gives the positive geometric scalar law and its absorption automatically.
+The counterexample above shows that generic proportional commuting-bond data
+without the normal single-block input cannot supply this conclusion.  This
+joint normalization problem is tracked in \ghissue{4271} and \ghissue{4253}.
 \item Find a source-faithful property of the actual inverse-map neighboring
 family which excludes the nilpotent zero-eigenspace, or
 replace the printed line-1613 argument by a direct Markov decomposition which


### PR DESCRIPTION
### Motivation
- Issue #4271 asks whether the exact fixed-product tensor constructed for Proposition C.8 can be promoted to a normal representative without assuming the scalar law tracked in #4253.
- The relevant sources are `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 1121--1128 (Corollary `eqV`: two non-orthogonal normal tensor families differ by a phase $e^{i\phi N}$) and lines 1570--1593 (Proposition `3to4`: $\sigma^{(N)}(\mathcal K)\propto\prod_n B_{n,n+1}$ with positive commuting bonds).

### Description
- Proves that if one positive rescaling $sC$ of the exact fixed-product tensor is normal and the doubled-index source tensor is normal, then
  $$
  \rho^{(N)}(M)=(\zeta s)^N\prod_n B_{n,n+1}
  $$
  for one unit phase $\zeta$ and every $N\ge 2$.
- Uses convergence of the normal source self-overlap to find two consecutive lengths with nonzero bond products. The positive realization constants at these lengths force $\zeta=1$, hence
  $$
  \rho^{(N)}(M)=s^N\prod_n B_{n,n+1}
  $$
  for every $N\ge 2$.
- Updates the blueprint and the commuting-form paper-gap note to make explicit that the normal-representative and positive geometric-scalar questions are one remaining problem. No normality of the raw fixed-product tensor is asserted.

### Testing
- `lake env lean TNLean/MPS/MPDO/FixedBondProductTensor.lean`
- `rg -n "sorry|admit|axiom|native_decide|unsafeCast" TNLean/MPS/MPDO/FixedBondProductTensor.lean || true`
- `git diff --check`

---
Addresses #4271
Addresses #4253

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes are confined to formal Lean proofs and documentation; the new results are explicitly conditional on an open normal-rescaling hypothesis, but they alter how a central paper-gap elimination plan is stated and could mislead if the scope restriction is overlooked.
> 
> **Overview**
> Adds Lean proofs in `FixedBondProductTensor.lean` that **if** the normal source MPO and some positive rescaling \(sC\) of the exact fixed-product tensor are normal, then \(\rho^{(N)}(M) = (\zeta s)^N \prod_n B_{n,n+1}\) for a unit phase \(\zeta\), and **positive realization constants at two large consecutive lengths force \(\zeta = 1\)**, giving \(\rho^{(N)}(M) = s^N \prod_n B_{n,n+1}\) for every \(N \ge 2\). A private lemma links nonzero normal self-overlap to nonzero commuting-bond products.
> 
> The blueprint chapter gains matching theorems (`thm:mpdo_eta_normal_rescaling_geometric_phase` and `thm:mpdo_eta_normal_rescaling_positive_geometric_law`). The commuting-form paper-gap note is revised to state that **proving a single positive normal rescaling of the fixed tensor would automatically yield the geometric scalar law** \(c_N = s^N\), folding issues #4271 and #4253 into one remaining problem. **Normality of the raw fixed tensor is not claimed.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5e11f37cff0f2df9728444df9936d3baa4b78ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->