### PR TITLE
feat(MPS/MPDO): bound diagonal cut rank

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -414,6 +414,7 @@ import TNLean.MPS.MPDO.ThermodynamicLimitCounterexample
 import TNLean.MPS.MPDO.MutualInfoBridge
 import TNLean.MPS.MPDO.PureAreaLaw
 import TNLean.MPS.MPDO.LocalPurificationAreaLaw
+import TNLean.MPS.MPDO.DiagonalCutRank
 import TNLean.MPS.MPDO.PureRFPSAL
 import TNLean.MPS.MPDO.VerticalCF
 import TNLean.MPS.MPDO.VerticalCoisometry

--- a/TNLean/MPS/MPDO/DiagonalCutRank.lean
+++ b/TNLean/MPS/MPDO/DiagonalCutRank.lean
@@ -1,0 +1,106 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.Defs
+import Mathlib.LinearAlgebra.Matrix.Rank
+
+/-!
+# Rank of a diagonal matrix-product-operator cut
+
+For a periodic matrix product operator, split a diagonal physical word into two
+consecutive blocks.  The resulting matrix of diagonal coefficients factors
+through the space of pairs of virtual indices.  Its ordinary complex rank is
+therefore at most the square of the bond dimension.
+
+This is the algebraic part of the classical-diagonal analysis of the estimate
+in Proposition 4.5 of arXiv:1606.00608.  Combined with Theorem 4.1 of
+arXiv:1704.06507, it gives the stronger classical estimate
+$I(X:Y) \leq 2\log D$.  The information-theoretic implication is not proved in
+this file.
+
+## Main definitions
+
+* `MPOTensor.diagonalCutMatrix`: the matrix whose rows and columns are physical
+  words on the two sides of a periodic cut and whose entries are the diagonal
+  coefficients of the full MPO.
+
+## Main results
+
+* `MPOTensor.diagonalCutMatrix_rank_le`: the diagonal cut matrix of a periodic
+  MPO has rank at most $D^2$.
+-/
+
+open scoped Matrix ComplexOrder BigOperators
+open Matrix
+
+namespace Matrix
+
+variable {D : ℕ} {r c : Type*} [Fintype c]
+
+/-- The matrix of trace pairings $(x,y) \mapsto \operatorname{tr}(A_xB_y)$
+between two finite families of square matrices. -/
+private noncomputable def traceMulMatrix
+    (A : r → Matrix (Fin D) (Fin D) ℂ)
+    (B : c → Matrix (Fin D) (Fin D) ℂ) : Matrix r c ℂ :=
+  fun x y ↦ trace (A x * B y)
+
+/-- A matrix of trace pairings of two families of $D\times D$ matrices has
+ordinary complex rank at most $D^2$.
+
+This is the finite-dimensional factorization
+$\operatorname{tr}(A_xB_y)=\sum_{a,b}(A_x)_{ab}(B_y)_{ba}$. -/
+private theorem rank_traceMulMatrix_le
+    (A : r → Matrix (Fin D) (Fin D) ℂ)
+    (B : c → Matrix (Fin D) (Fin D) ℂ) :
+    (traceMulMatrix A B).rank ≤ D * D := by
+  classical
+  let X : Matrix r (Fin D × Fin D) ℂ := fun x ab ↦ A x ab.1 ab.2
+  let Y : Matrix (Fin D × Fin D) c ℂ := fun ab y ↦ B y ab.2 ab.1
+  have hfactor : traceMulMatrix A B = X * Y := by
+    ext x y
+    simp [traceMulMatrix, X, Y, Matrix.mul_apply, Matrix.trace, Fintype.sum_prod_type]
+  rw [hfactor]
+  refine (Matrix.rank_mul_le_left X Y).trans ?_
+  simpa using Matrix.rank_le_card_width X
+
+end Matrix
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- The matrix of diagonal coefficients across a cut of a periodic MPO.  A row
+is a word of length $L$, a column is a word of length $R$, and the corresponding
+entry is
+$\operatorname{tr}(M^{x_0x_0}\cdots M^{x_{L-1}x_{L-1}}
+M^{y_0y_0}\cdots M^{y_{R-1}y_{R-1}})$.
+
+This is the joint-probability matrix when the generated operator on $L+R$
+sites is diagonal, positive semidefinite, and normalized. -/
+noncomputable def diagonalCutMatrix (M : MPOTensor d D) (L R : ℕ) :
+    Matrix (Fin L → Fin d) (Fin R → Fin d) ℂ :=
+  fun x y ↦ Matrix.trace
+    (evalWord M (List.ofFn x ++ List.ofFn y) (List.ofFn x ++ List.ofFn y))
+
+/-- The ordinary complex rank of the diagonal coefficient matrix across a
+periodic MPO cut is at most $D^2$.
+
+This is the virtual-pair factorization used in the classical-diagonal analysis
+of Proposition 4.5 of arXiv:1606.00608; see
+`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+theorem diagonalCutMatrix_rank_le (M : MPOTensor d D) (L R : ℕ) :
+    (diagonalCutMatrix M L R).rank ≤ D * D := by
+  classical
+  let A : (Fin L → Fin d) → Matrix (Fin D) (Fin D) ℂ :=
+    fun x ↦ evalWord M (List.ofFn x) (List.ofFn x)
+  let B : (Fin R → Fin d) → Matrix (Fin D) (Fin D) ℂ :=
+    fun y ↦ evalWord M (List.ofFn y) (List.ofFn y)
+  have hfactor : diagonalCutMatrix M L R = Matrix.traceMulMatrix A B := by
+    ext x y
+    simp [diagonalCutMatrix, Matrix.traceMulMatrix, A, B, evalWord_append]
+  rw [hfactor]
+  exact Matrix.rank_traceMulMatrix_le A B
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
@@ -910,8 +910,8 @@
     hypothesis to the purifying pure state.
 \end{proof}
 
-\begin{lemma}[Rank of diagonal coefficients across a periodic cut]
-    \label{lem:mpo_diagonal_cut_rank}
+\begin{theorem}[Rank of diagonal coefficients across a periodic cut]
+    \label{thm:mpo_diagonal_cut_rank}
     \lean{MPOTensor.diagonalCutMatrix,
       MPOTensor.diagonalCutMatrix_rank_le}
     \leanok
@@ -930,8 +930,9 @@
     \[
       \operatorname{rank}_{\C} P\le D^2.
     \]
-\end{lemma}
+\end{theorem}
 \begin{proof}\leanok
+    \uses{lem:mpo_eval_word_append}
     For each word, write $A_x=M^{x_0x_0}\cdots M^{x_{L-1}x_{L-1}}$
     and $B_y=M^{y_0y_0}\cdots M^{y_{R-1}y_{R-1}}$.  The identity
     \[
@@ -965,12 +966,19 @@
     unrestricted estimate therefore requires a direct operator-Schmidt
     argument not supplied by the cited proof.
 
-    Diagonal operators cannot violate the estimate.  If the normalized
-    finite-chain operator is diagonal, the matrix $P$ in
-    Lemma~\ref{lem:mpo_diagonal_cut_rank} is a joint probability distribution.
-    Theorem~4.1 of \cite{Riazanov2017PSDRank} gives
-    $I(X:Y)\leq\log\operatorname{rank}_{\R}P$.  Since a real matrix has the
-    same rank over $\R$ and $\C$, Lemma~\ref{lem:mpo_diagonal_cut_rank} yields
+    Diagonal operators cannot violate the estimate.  Suppose that the
+    finite-chain operator is diagonal and positive semidefinite, with positive
+    trace $Z$.  If $P$ is the diagonal coefficient matrix in
+    Theorem~\ref{thm:mpo_diagonal_cut_rank}, then
+    \[
+        \widehat P=Z^{-1}P
+    \]
+    is a joint probability distribution.  Multiplication by the nonzero real
+    scalar $Z^{-1}$ does not change rank, and the real matrix $\widehat P$ has
+    the same rank over $\R$ and $\C$.  Theorem~4.1 of
+    \cite{Riazanov2017PSDRank} gives
+    $I(X:Y)\leq\log\operatorname{rank}_{\R}\widehat P$.  Therefore
+    Theorem~\ref{thm:mpo_diagonal_cut_rank} yields
     \[
       I_L^{(L+R)}\leq 2\log D.
     \]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
@@ -910,6 +910,37 @@
     hypothesis to the purifying pure state.
 \end{proof}
 
+\begin{lemma}[Rank of diagonal coefficients across a periodic cut]
+    \label{lem:mpo_diagonal_cut_rank}
+    \lean{MPOTensor.diagonalCutMatrix,
+      MPOTensor.diagonalCutMatrix_rank_le}
+    \leanok
+    \uses{def:mpo_tensor}
+    Split a periodic chain into consecutive blocks of lengths $L$ and $R$.
+    For words $x\in\{0,\ldots,d-1\}^L$ and
+    $y\in\{0,\ldots,d-1\}^R$, set
+    \[
+      P_{x,y}
+      =\tr\!\left(
+        M^{x_0x_0}\cdots M^{x_{L-1}x_{L-1}}
+        M^{y_0y_0}\cdots M^{y_{R-1}y_{R-1}}
+      \right).
+    \]
+    Then the ordinary complex rank of $P$ satisfies
+    \[
+      \operatorname{rank}_{\C} P\le D^2.
+    \]
+\end{lemma}
+\begin{proof}\leanok
+    For each word, write $A_x=M^{x_0x_0}\cdots M^{x_{L-1}x_{L-1}}$
+    and $B_y=M^{y_0y_0}\cdots M^{y_{R-1}y_{R-1}}$.  The identity
+    \[
+      P_{x,y}=\tr(A_xB_y)
+      =\sum_{a,b=0}^{D-1}(A_x)_{ab}(B_y)_{ba}
+    \]
+    factors $P$ through the $D^2$-dimensional space indexed by pairs $(a,b)$.
+\end{proof}
+
 \begin{remark}[Boundedness of the mutual information]
     Proposition~4.5 of \cite{Cirac2016MPDO_arXiv} asserts the uniform estimate
     $I_L \le 4\log D$ for every MPDO. Its cited proof, however, treats mixed
@@ -932,7 +963,19 @@
     one-site density matrix $q$. Thus its $L$-site marginal has rank
     $\operatorname{rank}(q)^L$, although its mutual information vanishes. The
     unrestricted estimate therefore requires a direct operator-Schmidt
-    argument not supplied by the cited proof. The bound remains open. The
+    argument not supplied by the cited proof.
+
+    Diagonal operators cannot violate the estimate.  If the normalized
+    finite-chain operator is diagonal, the matrix $P$ in
+    Lemma~\ref{lem:mpo_diagonal_cut_rank} is a joint probability distribution.
+    Theorem~4.1 of \cite{Riazanov2017PSDRank} gives
+    $I(X:Y)\leq\log\operatorname{rank}_{\R}P$.  Since a real matrix has the
+    same rank over $\R$ and $\C$, Lemma~\ref{lem:mpo_diagonal_cut_rank} yields
+    \[
+      I_L^{(L+R)}\leq 2\log D.
+    \]
+    Thus any counterexample must have genuine quantum coherences.  The
+    unrestricted quantum estimate remains open. The
     same example as Theorem~\ref{thm:parity_mpdo_no_thermodynamic_limit} also
     makes the iterated mutual-information limit false; see
     \path{docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex}. The

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -552,4 +552,5 @@
   year         = {2017},
   eprint       = {1704.06507},
   archiveprefix = {arXiv},
+  note         = {Preprint, arXiv:1704.06507},
 }

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -545,3 +545,11 @@
   eprint       = {1105.1019},
   archiveprefix = {arXiv},
 }
+
+@unpublished{Riazanov2017PSDRank,
+  author       = {Riazanov, Andrii and Vyalyi, Mikhail},
+  title        = {Exploring the Bounds on the Positive Semidefinite Rank},
+  year         = {2017},
+  eprint       = {1704.06507},
+  archiveprefix = {arXiv},
+}

--- a/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
@@ -116,6 +116,55 @@ of the unrestricted estimate is consequently unresolved: the cited argument
 does not prove it, while the observations above do not furnish a
 counterexample.
 
+\section{Diagonal matrix product operators}
+
+No diagonal tensor can violate the proposed estimate.  Fix a chain of length
+$N=L+R$ and write the normalized diagonal entries as the joint probability
+matrix
+\[
+  P_{x,y}
+  =\tr\!\left(
+    M^{x_0x_0}\cdots M^{x_{L-1}x_{L-1}}
+    M^{y_0y_0}\cdots M^{y_{R-1}y_{R-1}}
+  \right),
+\]
+where $x$ and $y$ label configurations on the two consecutive blocks.  Set
+$A_x=M^{x_0x_0}\cdots M^{x_{L-1}x_{L-1}}$ and
+$B_y=M^{y_0y_0}\cdots M^{y_{R-1}y_{R-1}}$.  Then
+\[
+  P_{x,y}=\tr(A_xB_y)
+  =\sum_{a,b=0}^{D-1}(A_x)_{ab}(B_y)_{ba}.
+\]
+Consequently $P$ factors through a complex vector space of dimension $D^2$,
+so $\operatorname{rank}_{\mathbb C}P\leq D^2$.  Since $P$ is real,
+$\operatorname{rank}_{\mathbb R}P=\operatorname{rank}_{\mathbb C}P$.
+
+Riazanov--Vyalyi prove for every finite joint probability matrix that
+\cite[Theorem~4.1]{Riazanov2017PSDRank}
+\[
+  I(X:Y)\leq\log\operatorname{rank}_{\mathbb R}P.
+\]
+Their rank is the ordinary real matrix rank, not the nonnegative rank.  Their
+proof eliminates linearly dependent rows while preserving nonnegativity and
+the column marginals, choosing at each step the endpoint at which mutual
+information does not decrease.  The final distribution has at most
+$\operatorname{rank}_{\mathbb R}P$ nonzero rows.  It follows that every
+diagonal periodic MPO satisfies the stronger finite-chain estimate
+\[
+  I_L^{(N)}\leq2\log D.
+\]
+This conclusion needs positivity and normalization only at the chain length
+under consideration; positivity at all other lengths is unnecessary.  Hence a
+counterexample to the unrestricted estimate, if one exists, must be genuinely
+quantum rather than a classical hidden-state construction.
+
+The rank factorization is formalized.
+\footnote{Formal declarations:
+\leanid{MPOTensor.diagonalCutMatrix} and
+\leanid{MPOTensor.diagonalCutMatrix_rank_le} in
+\doclink{TNLean/MPS/MPDO/DiagonalCutRank}.}
+The information-versus-rank theorem of Riazanov--Vyalyi is not yet formalized.
+
 \section{What the rank-three separation establishes}
 
 De las Cuevas--Schuch--P\'erez-Garc\'ia--Cirac give a rank-three separation in

--- a/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
@@ -119,8 +119,7 @@ counterexample.
 \section{Diagonal matrix product operators}
 
 No diagonal tensor can violate the proposed estimate.  Fix a chain of length
-$N=L+R$ and write the normalized diagonal entries as the joint probability
-matrix
+$N=L+R$ and write its diagonal coefficient matrix as
 \[
   P_{x,y}
   =\tr\!\left(
@@ -136,13 +135,21 @@ $B_y=M^{y_0y_0}\cdots M^{y_{R-1}y_{R-1}}$.  Then
   =\sum_{a,b=0}^{D-1}(A_x)_{ab}(B_y)_{ba}.
 \]
 Consequently $P$ factors through a complex vector space of dimension $D^2$,
-so $\operatorname{rank}_{\mathbb C}P\leq D^2$.  Since $P$ is real,
-$\operatorname{rank}_{\mathbb R}P=\operatorname{rank}_{\mathbb C}P$.
+so $\operatorname{rank}_{\mathbb C}P\leq D^2$.  Suppose that the finite-chain
+operator is positive semidefinite and diagonal, with positive trace
+$Z=\operatorname{tr}\rho^{(N)}(M)$.  Then the joint probability matrix is
+\[
+  \widehat P=Z^{-1}P.
+\]
+Multiplication by the nonzero real scalar $Z^{-1}$ does not change either
+rank.  Since $\widehat P$ is real,
+$\operatorname{rank}_{\mathbb R}\widehat P
+=\operatorname{rank}_{\mathbb C}\widehat P\leq D^2$.
 
 Riazanov--Vyalyi prove for every finite joint probability matrix that
 \cite[Theorem~4.1]{Riazanov2017PSDRank}
 \[
-  I(X:Y)\leq\log\operatorname{rank}_{\mathbb R}P.
+  I(X:Y)\leq\log\operatorname{rank}_{\mathbb R}\widehat P.
 \]
 Their rank is the ordinary real matrix rank, not the nonnegative rank.  Their
 proof eliminates linearly dependent rows while preserving nonnegativity and


### PR DESCRIPTION
## Summary

This advances #4242 by excluding every diagonal periodic MPO from the search for a counterexample to the proposed mutual-information bound.

For a cut into blocks of lengths $L$ and $R$, the diagonal coefficient matrix satisfies

$$
P_{x,y}=\operatorname{tr}(A_xB_y)
=\sum_{a,b}(A_x)_{ab}(B_y)_{ba},
$$

and hence has ordinary complex rank at most $D^2$. The new Lean theorem `MPOTensor.diagonalCutMatrix_rank_le` formalizes this factorization without additional positivity assumptions.

For a normalized diagonal positive operator, $P$ is a joint probability matrix. Riazanov--Vyalyi, Theorem 4.1 (arXiv:1704.06507), then gives $I(X:Y)\leq\log\operatorname{rank}_{\mathbb R}P$, so every diagonal periodic MPO obeys the stronger estimate $I_L^{(N)}\leq2\log D$. Their information-versus-rank theorem is cited and explained but is not claimed as formalized here.

The unrestricted quantum estimate remains open; any counterexample must contain genuine quantum coherences. This PR does not close #4242.

## Validation

- `lake build` — passed, 9579 jobs
- `python3 scripts/blueprint_lean_sync.py --root . --ci` — passed
- changed-declaration reverse blueprint coverage — passed
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci` — passed
- proof-integrity scan of `TNLean/MPS/MPDO/DiagonalCutRank.lean` — no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast`
- `git diff --check` — passed
- blueprint PDF — generated successfully

The local `leanblueprint web` installation has the known Python-path defect: its plasTeX process reports `ModuleNotFoundError: No module named 'leanblueprint'`, so it did not generate `blueprint/lean_decls` for a local `leanblueprint checkdecls` run. The repository's static blueprint synchronization and reverse-coverage checks both pass; configured CI should generate and check the declaration list in its managed environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Self-contained Mathlib linear-algebra proofs and documentation; no changes to auth, runtime behavior, or existing MPDO proof obligations beyond a new import.
> 
> **Overview**
> **Formalizes the algebraic step** that diagonal MPO cut coefficients factor through virtual index pairs, so the cut matrix has complex rank at most **D²**.
> 
> Adds `TNLean/MPS/MPDO/DiagonalCutRank.lean` with `MPOTensor.diagonalCutMatrix` and `MPOTensor.diagonalCutMatrix_rank_le`, wired into the root import and blueprint Theorem `thm:mpo_diagonal_cut_rank`. Documentation now explains that **diagonal** periodic MPOs cannot violate the mutual-information bound via a classical joint distribution: normalization gives a probability matrix, and Riazanov–Vyalyi (cited, not formalized) yields **I ≤ 2 log D**, so any counterexample to the unrestricted quantum estimate must use **genuine coherences**.
> 
> The paper-gap note `docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex` gains a dedicated diagonal-MPO section; `references.bib` adds `Riazanov2017PSDRank`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5ce127a1030c55c66507ee7a378c32428f85950. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->