### PR TITLE
feat(Channel/FixedPoint): classify finite direct-sum fixed points

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -204,6 +204,7 @@ import TNLean.Channel.FixedPoint.MeanErgodicAdjoint
 import TNLean.Channel.FixedPoint.DirectSumExtension
 import TNLean.Channel.FixedPoint.FullSupportBlockRetraction
 import TNLean.Channel.FixedPoint.TraceAdjointDensityBlocks
+import TNLean.Channel.FixedPoint.DirectSumBlockRetraction
 import TNLean.Channel.FixedPoint.CornerAlgebra
 import TNLean.Channel.FixedPoint.CornerBlockForm
 import TNLean.Channel.FixedPoint.CornerFixedPoints

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -201,6 +201,7 @@ import TNLean.Channel.FixedPoint.ChoiEffros
 import TNLean.Channel.FixedPoint.Cesaro
 import TNLean.Channel.FixedPoint.MeanErgodicProjection
 import TNLean.Channel.FixedPoint.MeanErgodicAdjoint
+import TNLean.Channel.FixedPoint.DirectSumExtension
 import TNLean.Channel.FixedPoint.FullSupportBlockRetraction
 import TNLean.Channel.FixedPoint.TraceAdjointDensityBlocks
 import TNLean.Channel.FixedPoint.CornerAlgebra

--- a/TNLean/Channel/FixedPoint/DirectSumBlockRetraction.lean
+++ b/TNLean/Channel/FixedPoint/DirectSumBlockRetraction.lean
@@ -1,0 +1,328 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.FixedPoint.DirectSumExtension
+import TNLean.Channel.FixedPoint.TraceAdjointDensityBlocks
+
+/-!
+# Density-block form for fixed points on finite sums of matrix algebras
+
+The canonical full-matrix extension of a map on a finite direct sum may be
+reindexed by a finite equivalence and then classified by the full-support
+fixed-point theorem. This file carries out that last change of coordinates and
+returns the density-block description to the original direct-sum index space.
+
+This is the fixed-point step used in arXiv:1606.00608, Appendix C.4,
+lines 1980--1995. The channel hypotheses for the particular transported sector
+maps are separate from the result proved here.
+-/
+
+open scoped Matrix MatrixOrder ComplexOrder BigOperators Kronecker
+
+noncomputable section
+
+namespace Matrix
+
+variable {α β : Type*} [Fintype α] [DecidableEq α]
+variable [Fintype β] [DecidableEq β]
+
+/-- Conjugate a matrix endomorphism by the simultaneous reindexing of its row
+and column coordinates. -/
+noncomputable def reindexEndomorphism (e : α ≃ β)
+    (T : Matrix α α ℂ →ₗ[ℂ] Matrix α α ℂ) :
+    Matrix β β ℂ →ₗ[ℂ] Matrix β β ℂ :=
+  (Matrix.reindexLinearEquiv ℂ ℂ e e).conj T
+
+omit [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β] in
+@[simp]
+theorem reindexEndomorphism_apply (e : α ≃ β)
+    (T : Matrix α α ℂ →ₗ[ℂ] Matrix α α ℂ) (A : Matrix β β ℂ) :
+    reindexEndomorphism e T A =
+      Matrix.reindex e e (T (Matrix.reindex e.symm e.symm A)) := by
+  rfl
+
+omit [DecidableEq α] [DecidableEq β] in
+private theorem trace_reindex (e : α ≃ β) (A : Matrix α α ℂ) :
+    (Matrix.reindex e e A).trace = A.trace := by
+  simpa only [Matrix.reindex_apply] using Matrix.trace_submatrix_equiv e.symm A
+
+omit [DecidableEq α] [DecidableEq β] in
+private theorem trace_reindex_mul (e : α ≃ β) (A : Matrix α α ℂ)
+    (B : Matrix β β ℂ) :
+    (Matrix.reindex e e A * B).trace =
+      (A * Matrix.reindex e.symm e.symm B).trace := by
+  have hB : B = Matrix.reindex e e (Matrix.reindex e.symm e.symm B) := by
+    simpa only [Matrix.coe_reindexLinearEquiv,
+      Matrix.symm_reindexLinearEquiv] using
+      (Matrix.reindexLinearEquiv ℂ ℂ e e).apply_symm_apply B |>.symm
+  have hmul : Matrix.reindex e e A *
+      Matrix.reindex e e (Matrix.reindex e.symm e.symm B) =
+      Matrix.reindex e e (A * Matrix.reindex e.symm e.symm B) := by
+    exact Matrix.reindexLinearEquiv_mul ℂ ℂ e e e A _
+  calc
+    (Matrix.reindex e e A * B).trace =
+        (Matrix.reindex e e A *
+          Matrix.reindex e e (Matrix.reindex e.symm e.symm B)).trace := by
+      exact congrArg Matrix.trace (congrArg (Matrix.reindex e e A * ·) hB)
+    _ = (Matrix.reindex e e
+          (A * Matrix.reindex e.symm e.symm B)).trace := by rw [hmul]
+    _ = (A * Matrix.reindex e.symm e.symm B).trace := trace_reindex e _
+
+omit [DecidableEq α] [DecidableEq β] in
+private theorem reindex_conjugation (e : α ≃ β)
+    (U A : Matrix α α ℂ) :
+    Matrix.reindex e e (star U * A * U) =
+      star (Matrix.reindex e e U) * Matrix.reindex e e A *
+        Matrix.reindex e e U := by
+  have hstar : Matrix.reindex e e (star U) =
+      star (Matrix.reindex e e U) := by
+    simp only [Matrix.star_eq_conjTranspose, Matrix.conjTranspose_reindex]
+  calc
+    Matrix.reindex e e (star U * A * U) =
+        Matrix.reindex e e (star U * A) * Matrix.reindex e e U :=
+      (Matrix.reindexLinearEquiv_mul ℂ ℂ e e e (star U * A) U).symm
+    _ = (Matrix.reindex e e (star U) * Matrix.reindex e e A) *
+        Matrix.reindex e e U := by
+      exact congrArg (· * Matrix.reindex e e U)
+        (Matrix.reindexLinearEquiv_mul ℂ ℂ e e e (star U) A).symm
+    _ = _ := by rw [hstar]
+
+omit [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β] in
+private theorem reindex_symm_reindex (e : α ≃ β) (A : Matrix α α ℂ) :
+    Matrix.reindex e.symm e.symm (Matrix.reindex e e A) = A := by
+  simpa only [Matrix.coe_reindexLinearEquiv,
+    Matrix.symm_reindexLinearEquiv] using
+    (Matrix.reindexLinearEquiv ℂ ℂ e e).symm_apply_apply A
+
+omit [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β] in
+private theorem reindex_reindex {γ : Type*} (e : α ≃ β) (f : β ≃ γ)
+    (A : Matrix α α ℂ) :
+    Matrix.reindex f f (Matrix.reindex e e A) =
+      Matrix.reindex (e.trans f) (e.trans f) A := by
+  rfl
+
+omit [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β] in
+/-- Positivity is invariant under a simultaneous change of the matrix index
+set. -/
+theorem IsPositiveMap.reindexEndomorphism
+    {T : Matrix α α ℂ →ₗ[ℂ] Matrix α α ℂ} (hT : IsPositiveMap T)
+    (e : α ≃ β) : IsPositiveMap (reindexEndomorphism e T) := by
+  intro A hA
+  rw [reindexEndomorphism_apply]
+  exact (hT _ (hA.submatrix e)).submatrix e.symm
+
+omit [DecidableEq α] [DecidableEq β] in
+/-- Trace preservation is invariant under a simultaneous change of the matrix
+index set. -/
+theorem IsTracePreservingMap.reindexEndomorphism
+    {T : Matrix α α ℂ →ₗ[ℂ] Matrix α α ℂ}
+    (hT : IsTracePreservingMap T) (e : α ≃ β) :
+    IsTracePreservingMap (reindexEndomorphism e T) := by
+  intro A
+  rw [reindexEndomorphism_apply, trace_reindex, hT, trace_reindex]
+
+omit [DecidableEq α] [DecidableEq β] in
+/-- The trace adjoint commutes with simultaneous reindexing of matrix
+coordinates. -/
+theorem traceAdjointMap_reindexEndomorphism (e : α ≃ β)
+    (T : Matrix α α ℂ →ₗ[ℂ] Matrix α α ℂ) :
+    Matrix.traceAdjointMap (reindexEndomorphism e T) =
+      reindexEndomorphism e (Matrix.traceAdjointMap T) := by
+  apply LinearMap.ext
+  intro A
+  apply Matrix.ext_iff_trace_mul_right.mpr
+  intro B
+  calc
+    (Matrix.traceAdjointMap (reindexEndomorphism e T) A * B).trace =
+        (A * reindexEndomorphism e T B).trace :=
+      Matrix.trace_traceAdjointMap_mul _ _ _
+    _ = (Matrix.reindex e.symm e.symm A *
+          T (Matrix.reindex e.symm e.symm B)).trace := by
+      rw [reindexEndomorphism_apply]
+      rw [Matrix.trace_mul_comm, trace_reindex_mul, Matrix.trace_mul_comm]
+    _ = (Matrix.traceAdjointMap T (Matrix.reindex e.symm e.symm A) *
+          Matrix.reindex e.symm e.symm B).trace :=
+      (Matrix.trace_traceAdjointMap_mul _ _ _).symm
+    _ = (reindexEndomorphism e (Matrix.traceAdjointMap T) A * B).trace := by
+      rw [reindexEndomorphism_apply]
+      rw [trace_reindex_mul]
+
+omit [DecidableEq α] [DecidableEq β] in
+/-- The Schwarz inequality is invariant under a simultaneous change of the
+matrix index set. -/
+theorem IsSchwarzMap.reindexEndomorphism
+    {T : Matrix α α ℂ →ₗ[ℂ] Matrix α α ℂ} (hT : IsSchwarzMap T)
+    (e : α ≃ β) : IsSchwarzMap (reindexEndomorphism e T) := by
+  intro A
+  let Φ := Matrix.reindexLinearEquiv ℂ ℂ e e
+  have h := hT (Φ.symm A)
+  have h' : (Φ (T ((Φ.symm A)ᴴ * Φ.symm A) -
+      T (Φ.symm A)ᴴ * T (Φ.symm A))).PosSemidef := by
+    exact h.submatrix e.symm
+  have hstar : Φ.symm Aᴴ = (Φ.symm A)ᴴ := by
+    simp only [Φ, Matrix.symm_reindexLinearEquiv,
+      Matrix.coe_reindexLinearEquiv, Matrix.conjTranspose_reindex]
+  have hmul : Φ.symm (Aᴴ * A) = (Φ.symm A)ᴴ * Φ.symm A := by
+    calc
+      Φ.symm (Aᴴ * A) = Φ.symm Aᴴ * Φ.symm A := by
+        exact (Matrix.reindexLinearEquiv_mul ℂ ℂ
+          e.symm e.symm e.symm Aᴴ A).symm
+      _ = (Φ.symm A)ᴴ * Φ.symm A := by rw [hstar]
+  change (Φ (T (Φ.symm (Aᴴ * A))) -
+    Φ (T (Φ.symm Aᴴ)) * Φ (T (Φ.symm A))).PosSemidef
+  rw [hmul, hstar]
+  have hprod : Φ (T (Φ.symm A)ᴴ * T (Φ.symm A)) =
+      Φ (T (Φ.symm A)ᴴ) * Φ (T (Φ.symm A)) := by
+    exact (Matrix.reindexLinearEquiv_mul ℂ ℂ e e e _ _).symm
+  rw [map_sub, hprod] at h'
+  exact h'
+
+omit [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β] in
+/-- Positive definiteness is invariant under a simultaneous change of the
+matrix index set. -/
+theorem PosDef.reindex (e : α ≃ β) {A : Matrix α α ℂ} (hA : A.PosDef) :
+    (Matrix.reindex e e A).PosDef :=
+  hA.submatrix e.symm.injective
+
+end Matrix
+
+namespace Matrix
+
+variable {ι : Type*} [Fintype ι] [DecidableEq ι]
+variable {n : ι → Type*} [∀ k, Fintype (n k)] [∀ k, DecidableEq (n k)]
+
+/-- **Density-block form for fixed points on a finite direct sum.**
+
+Let `T` be a positive map of a finite sum of full matrix algebras that
+preserves the total trace. If the direct-sum trace adjoint satisfies the
+Schwarz inequality and `T` has a positive-definite fixed family, then its
+fixed points have the density-block form obtained from Wolf's Theorem 6.14.
+
+This is the finite-index classification step used in arXiv:1606.00608,
+Appendix C.4, lines 1980--1995. The hypotheses for the particular sector map
+in that argument are not asserted here. -/
+theorem IsPositiveDirectSumMap.exists_block_densities_of_fixedPoints
+    {T : (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ]
+      (∀ k, Matrix (n k) (n k) ℂ)}
+    (hT : IsPositiveDirectSumMap T)
+    (hTP : IsTracePreservingDirectSumMap T)
+    (hSchwarz : IsSchwarzDirectSumMap (Matrix.directSumTraceAdjointMap T))
+    {ρ : ∀ k, Matrix (n k) (n k) ℂ} (hρ : ∀ k, (ρ k).PosDef)
+    (hρfix : T ρ = ρ) :
+    ∃ (K : ℕ) (d m : Fin K → ℕ)
+      (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ ((k : ι) × n k))
+      (U : Matrix ((k : ι) × n k) ((k : ι) × n k) ℂ)
+      (σ : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ),
+      U ∈ Matrix.unitaryGroup ((k : ι) × n k) ℂ ∧
+        (∀ k, 0 < d k) ∧ (∀ k, 0 < m k) ∧
+        (∀ k, (σ k).PosSemidef) ∧ (∀ k, (σ k).trace = 1) ∧
+        ∀ A, T A = A ↔
+          ∃ X : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ,
+            star U * directSumDiagonalEmbedding A * U =
+              Matrix.reindex e e
+                (Matrix.blockDiagonal' fun k ↦ σ k ⊗ₖ X k) := by
+  let s := (k : ι) × n k
+  let efin : s ≃ Fin (Fintype.card s) := Fintype.equivFin s
+  let TExt := directSumExtension T
+  let TFin := reindexEndomorphism efin TExt
+  let ρExt := directSumDiagonalEmbedding ρ
+  let ρFin := Matrix.reindex efin efin ρExt
+  have hTFin : IsPositiveMap TFin := by
+    exact IsPositiveMap.reindexEndomorphism
+      hT.directSumExtension_isPositiveMap efin
+  have hTPFin : IsTracePreservingMap TFin := by
+    exact IsTracePreservingMap.reindexEndomorphism
+      hTP.directSumExtension_isTracePreservingMap efin
+  have hSchwarzExt : IsSchwarzMap (Matrix.traceAdjointMap TExt) := by
+    exact hSchwarz.traceAdjointMap_directSumExtension_isSchwarzMap hT
+  have hSchwarzFin : IsSchwarzMap (Matrix.traceAdjointMap TFin) := by
+    rw [traceAdjointMap_reindexEndomorphism]
+    exact IsSchwarzMap.reindexEndomorphism hSchwarzExt efin
+  have hρExt : ρExt.PosDef := directSumDiagonalEmbedding_posDef hρ
+  have hρFin : ρFin.PosDef := hρExt.reindex efin
+  have hρExtFix : TExt ρExt = ρExt := by
+    exact (directSumExtension_embedding_eq_self_iff T ρ).2 hρfix
+  have hρFinFix : TFin ρFin = ρFin := by
+    let Φ := Matrix.reindexLinearEquiv ℂ ℂ efin efin
+    change Φ (TExt (Φ.symm (Φ ρExt))) = Φ ρExt
+    rw [Φ.symm_apply_apply, hρExtFix]
+  obtain ⟨K, d, m, eClass, UFin, σ, hUFin, hd, hm, hσpos, hσtrace,
+      _, hfixed⟩ :=
+    hTFin.exists_block_densities_of_meanErgodicProjection
+      hTPFin hSchwarzFin hρFin hρFinFix
+  let U := Matrix.reindex efin.symm efin.symm UFin
+  let e := eClass.trans efin.symm
+  have hU : U ∈ Matrix.unitaryGroup s ℂ := by
+    rw [Matrix.mem_unitaryGroup_iff'] at hUFin ⊢
+    have hstar : star U = Matrix.reindex efin.symm efin.symm (star UFin) := by
+      simp only [U, Matrix.star_eq_conjTranspose, Matrix.conjTranspose_reindex]
+    rw [hstar]
+    have hmul : Matrix.reindex efin.symm efin.symm (star UFin) *
+        Matrix.reindex efin.symm efin.symm UFin =
+        Matrix.reindex efin.symm efin.symm (star UFin * UFin) := by
+      exact Matrix.reindexLinearEquiv_mul ℂ ℂ
+        efin.symm efin.symm efin.symm _ _
+    rw [hmul, hUFin]
+    ext i j
+    by_cases hij : i = j
+    · subst j
+      simp
+    · have heij : efin i ≠ efin j := fun h ↦ hij (efin.injective h)
+      simp [hij, heij]
+  refine ⟨K, d, m, e, U, σ, hU, hd, hm, hσpos, hσtrace, ?_⟩
+  intro A
+  rw [← directSumExtension_embedding_eq_self_iff T A]
+  have hcoord : TExt (directSumDiagonalEmbedding A) =
+        directSumDiagonalEmbedding A ↔
+      TFin (Matrix.reindex efin efin (directSumDiagonalEmbedding A)) =
+        Matrix.reindex efin efin (directSumDiagonalEmbedding A) := by
+    let Φ := Matrix.reindexLinearEquiv ℂ ℂ efin efin
+    change TExt (directSumDiagonalEmbedding A) = directSumDiagonalEmbedding A ↔
+      Φ (TExt (Φ.symm (Φ (directSumDiagonalEmbedding A)))) =
+        Φ (directSumDiagonalEmbedding A)
+    rw [Φ.symm_apply_apply]
+    exact Φ.injective.eq_iff.symm
+  rw [hcoord, hfixed]
+  constructor
+  · rintro ⟨X, hX⟩
+    refine ⟨X, ?_⟩
+    calc
+      star U * directSumDiagonalEmbedding A * U =
+          Matrix.reindex efin.symm efin.symm
+            (star UFin * Matrix.reindex efin efin
+              (directSumDiagonalEmbedding A) * UFin) := by
+        dsimp only [U]
+        rw [reindex_conjugation]
+        rw [reindex_symm_reindex]
+      _ = Matrix.reindex efin.symm efin.symm
+          (Matrix.reindex eClass eClass
+            (Matrix.blockDiagonal' fun k ↦ σ k ⊗ₖ X k)) := by rw [hX]
+      _ = Matrix.reindex e e
+          (Matrix.blockDiagonal' fun k ↦ σ k ⊗ₖ X k) := by
+        exact reindex_reindex eClass efin.symm _
+  · rintro ⟨X, hX⟩
+    refine ⟨X, ?_⟩
+    have hUback : Matrix.reindex efin efin U = UFin := by
+      dsimp only [U]
+      simpa only [Equiv.symm_symm] using
+        reindex_symm_reindex efin.symm UFin
+    calc
+      star UFin * Matrix.reindex efin efin
+          (directSumDiagonalEmbedding A) * UFin =
+          Matrix.reindex efin efin
+            (star U * directSumDiagonalEmbedding A * U) := by
+        rw [reindex_conjugation]
+        rw [hUback]
+      _ = Matrix.reindex efin efin
+          (Matrix.reindex e e
+            (Matrix.blockDiagonal' fun k ↦ σ k ⊗ₖ X k)) := by rw [hX]
+      _ = Matrix.reindex eClass eClass
+          (Matrix.blockDiagonal' fun k ↦ σ k ⊗ₖ X k) := by
+        rw [reindex_reindex]
+        congr 1
+        ext x
+        simp [e]
+
+end Matrix

--- a/TNLean/Channel/FixedPoint/DirectSumBlockRetraction.lean
+++ b/TNLean/Channel/FixedPoint/DirectSumBlockRetraction.lean
@@ -202,7 +202,12 @@ fixed points have the density-block form obtained from Wolf's Theorem 6.14.
 
 This is the finite-index classification step used in arXiv:1606.00608,
 Appendix C.4, lines 1980--1995. The hypotheses for the particular sector map
-in that argument are not asserted here. -/
+in that argument are not asserted here.
+
+**Scope restriction (full support):** The fixed family is positive definite on
+every summand. The support reduction and complementary zero summand of the
+general theorem remain open in
+`docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex`. -/
 theorem IsPositiveDirectSumMap.exists_block_densities_of_fixedPoints
     {T : (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ]
       (∀ k, Matrix (n k) (n k) ℂ)}

--- a/TNLean/Channel/FixedPoint/DirectSumExtension.lean
+++ b/TNLean/Channel/FixedPoint/DirectSumExtension.lean
@@ -1,0 +1,570 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.TracePairing
+import TNLean.Analysis.MatrixSqrt
+import TNLean.Channel.Schwarz.AbstractMultiplicativeDomain
+import TNLean.Channel.Schwarz.TwoPositive
+
+/-!
+# Extension of maps on finite sums of matrix algebras
+
+A linear map on a finite direct sum of full matrix algebras has a canonical
+extension to the full matrix algebra on the direct sum of the underlying
+spaces: first retain the diagonal blocks, apply the original map, and then
+embed the resulting family as a block-diagonal matrix.
+
+This file proves that the construction preserves positivity and the total
+trace, identifies its fixed points in both directions, and computes its
+trace-pairing adjoint. These are the algebraic ingredients of the
+block-diagonal-embedding route from Wolf's Theorem 6.14 to the sector algebras
+in arXiv:1606.00608, Appendix C.4, lines 1980--1995.
+
+## Main definitions
+
+* `Matrix.directSumDiagonalEmbedding`: block-diagonal embedding of a finite
+  family of matrices.
+* `Matrix.directSumDiagonalCompression`: family of diagonal blocks of a matrix.
+* `Matrix.directSumExtension`: canonical full-matrix extension of a map on the
+  finite direct sum.
+* `Matrix.directSumTraceAdjointMap`: adjoint for the sum of the block traces.
+
+## References
+
+* M. Wolf, *Quantum Channels & Operations: Guided Tour*, Theorem 6.14.
+* arXiv:1606.00608, Appendix C.4, lines 1980--1995.
+-/
+
+open scoped Matrix MatrixOrder ComplexOrder BigOperators
+
+noncomputable section
+
+namespace Matrix
+
+variable {ι : Type*} [Fintype ι] [DecidableEq ι]
+variable {n : ι → Type*} [∀ k, Fintype (n k)] [∀ k, DecidableEq (n k)]
+
+/-- Embed a finite dependent family of square matrices as a block-diagonal
+matrix on the direct sum of their index spaces. -/
+noncomputable def directSumDiagonalEmbedding :
+    (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ]
+      Matrix ((k : ι) × n k) ((k : ι) × n k) ℂ where
+  toFun := Matrix.blockDiagonal'
+  map_add' A B := Matrix.blockDiagonal'_add A B
+  map_smul' c A := Matrix.blockDiagonal'_smul c A
+
+omit [Fintype ι] [(k : ι) → Fintype (n k)] [(k : ι) → DecidableEq (n k)] in
+@[simp]
+theorem directSumDiagonalEmbedding_apply
+    (A : ∀ k, Matrix (n k) (n k) ℂ) :
+    directSumDiagonalEmbedding A = Matrix.blockDiagonal' A :=
+  rfl
+
+/-- Retain the diagonal blocks of a matrix on a finite dependent direct sum. -/
+noncomputable def directSumDiagonalCompression :
+    Matrix ((k : ι) × n k) ((k : ι) × n k) ℂ →ₗ[ℂ]
+      (∀ k, Matrix (n k) (n k) ℂ) where
+  toFun A k := A.submatrix (Sigma.mk k) (Sigma.mk k)
+  map_add' A B := by
+    funext k i j
+    rfl
+  map_smul' c A := by
+    funext k i j
+    rfl
+
+omit [Fintype ι] [DecidableEq ι] [(k : ι) → Fintype (n k)]
+    [(k : ι) → DecidableEq (n k)] in
+@[simp]
+theorem directSumDiagonalCompression_apply
+    (A : Matrix ((k : ι) × n k) ((k : ι) × n k) ℂ) (k : ι) :
+    directSumDiagonalCompression A k = A.submatrix (Sigma.mk k) (Sigma.mk k) :=
+  rfl
+
+omit [Fintype ι] [(k : ι) → Fintype (n k)] [(k : ι) → DecidableEq (n k)] in
+/-- Diagonal compression is a left inverse of block-diagonal embedding. -/
+@[simp]
+theorem directSumDiagonalCompression_embedding
+    (A : ∀ k, Matrix (n k) (n k) ℂ) :
+    directSumDiagonalCompression (directSumDiagonalEmbedding A) = A := by
+  funext k i j
+  simp [directSumDiagonalCompression, directSumDiagonalEmbedding,
+    Matrix.blockDiagonal'_apply_eq]
+
+omit [(k : ι) → DecidableEq (n k)] in
+/-- The trace of a finite block-diagonal matrix is the sum of the block traces. -/
+theorem trace_directSumDiagonalEmbedding
+    (A : ∀ k, Matrix (n k) (n k) ℂ) :
+    (directSumDiagonalEmbedding A).trace = ∑ k, (A k).trace := by
+  exact Matrix.trace_blockDiagonal' A
+
+omit [DecidableEq ι] [(k : ι) → DecidableEq (n k)] in
+/-- The sum of the traces of all diagonal compressions is the full trace. -/
+theorem sum_trace_directSumDiagonalCompression
+    (A : Matrix ((k : ι) × n k) ((k : ι) × n k) ℂ) :
+    ∑ k, (directSumDiagonalCompression A k).trace = A.trace := by
+  simp only [directSumDiagonalCompression_apply, Matrix.trace, Matrix.diag,
+    Matrix.submatrix_apply]
+  exact (Fintype.sum_sigma' fun k i ↦ A ⟨k, i⟩ ⟨k, i⟩).symm
+
+omit [(k : ι) → DecidableEq (n k)] in
+/-- The trace pairing of block-diagonal matrices is the sum of the trace
+pairings of their blocks. -/
+theorem trace_directSumDiagonalEmbedding_mul
+    (A B : ∀ k, Matrix (n k) (n k) ℂ) :
+    (directSumDiagonalEmbedding A * directSumDiagonalEmbedding B).trace =
+      ∑ k, (A k * B k).trace := by
+  change (Matrix.blockDiagonal' A * Matrix.blockDiagonal' B).trace = _
+  rw [← Matrix.blockDiagonal'_mul, Matrix.trace_blockDiagonal']
+
+omit [(k : ι) → DecidableEq (n k)] in
+/-- Compressing after left multiplication by a block-diagonal matrix gives
+left multiplication by the corresponding block. -/
+theorem directSumDiagonalCompression_embedding_mul
+    (B : ∀ k, Matrix (n k) (n k) ℂ)
+    (A : Matrix ((k : ι) × n k) ((k : ι) × n k) ℂ) (k : ι) :
+    directSumDiagonalCompression (directSumDiagonalEmbedding B * A) k =
+      B k * directSumDiagonalCompression A k := by
+  ext i j
+  simp only [directSumDiagonalCompression_apply, Matrix.submatrix_apply,
+    Matrix.mul_apply, directSumDiagonalEmbedding_apply]
+  rw [Fintype.sum_sigma fun q : (l : ι) × n l ↦
+    Matrix.blockDiagonal' B ⟨k, i⟩ q * A q ⟨k, j⟩]
+  rw [Finset.sum_eq_single k]
+  · simp only [Matrix.blockDiagonal'_apply_eq]
+  · intro l _ hl
+    apply Finset.sum_eq_zero
+    intro y _
+    rw [Matrix.blockDiagonal'_apply_ne _ _ _ (Ne.symm hl)]
+    simp
+  · simp
+
+omit [(k : ι) → DecidableEq (n k)] in
+/-- In a trace pairing against a block-diagonal matrix, only the diagonal
+blocks of the other matrix contribute. -/
+theorem trace_embedding_compression_mul_embedding
+    (A : Matrix ((k : ι) × n k) ((k : ι) × n k) ℂ)
+    (B : ∀ k, Matrix (n k) (n k) ℂ) :
+    (directSumDiagonalEmbedding (directSumDiagonalCompression A) *
+        directSumDiagonalEmbedding B).trace =
+      (A * directSumDiagonalEmbedding B).trace := by
+  calc
+    (directSumDiagonalEmbedding (directSumDiagonalCompression A) *
+          directSumDiagonalEmbedding B).trace =
+        ∑ k, (directSumDiagonalCompression A k * B k).trace :=
+      trace_directSumDiagonalEmbedding_mul _ _
+    _ = ∑ k, (B k * directSumDiagonalCompression A k).trace := by
+      apply Finset.sum_congr rfl
+      intro k _
+      exact Matrix.trace_mul_comm _ _
+    _ = ∑ k, (directSumDiagonalCompression
+          (directSumDiagonalEmbedding B * A) k).trace := by
+      apply Finset.sum_congr rfl
+      intro k _
+      rw [directSumDiagonalCompression_embedding_mul]
+    _ = (directSumDiagonalEmbedding B * A).trace :=
+      sum_trace_directSumDiagonalCompression _
+    _ = (A * directSumDiagonalEmbedding B).trace :=
+      Matrix.trace_mul_comm _ _
+
+omit [(k : ι) → DecidableEq (n k)] in
+/-- Block-diagonal embedding preserves multiplication. -/
+theorem directSumDiagonalEmbedding_mul
+    (A B : ∀ k, Matrix (n k) (n k) ℂ) :
+    directSumDiagonalEmbedding (A * B) =
+      directSumDiagonalEmbedding A * directSumDiagonalEmbedding B := by
+  change Matrix.blockDiagonal' (fun k ↦ A k * B k) =
+    Matrix.blockDiagonal' A * Matrix.blockDiagonal' B
+  exact Matrix.blockDiagonal'_mul A B
+
+omit [Fintype ι] [(k : ι) → Fintype (n k)] [(k : ι) → DecidableEq (n k)] in
+/-- Block-diagonal embedding preserves conjugate transpose. -/
+theorem directSumDiagonalEmbedding_conjTranspose
+    (A : ∀ k, Matrix (n k) (n k) ℂ) :
+    directSumDiagonalEmbedding (fun k ↦ (A k)ᴴ) =
+      (directSumDiagonalEmbedding A)ᴴ := by
+  exact (Matrix.blockDiagonal'_conjTranspose A).symm
+
+omit [Fintype ι] [(k : ι) → Fintype (n k)] [(k : ι) → DecidableEq (n k)] in
+/-- Block-diagonal embedding preserves positive semidefiniteness. -/
+theorem directSumDiagonalEmbedding_posSemidef
+    [Finite ι] [∀ k, Finite (n k)]
+    {A : ∀ k, Matrix (n k) (n k) ℂ} (hA : ∀ k, (A k).PosSemidef) :
+    (directSumDiagonalEmbedding A).PosSemidef := by
+  exact Matrix.PosSemidef.blockDiagonal' A hA
+
+omit [Fintype ι] [(k : ι) → Fintype (n k)] [(k : ι) → DecidableEq (n k)] in
+/-- Block-diagonal embedding preserves positive definiteness. -/
+theorem directSumDiagonalEmbedding_posDef
+    [Finite ι] [∀ k, Finite (n k)]
+    {A : ∀ k, Matrix (n k) (n k) ℂ} (hA : ∀ k, (A k).PosDef) :
+    (directSumDiagonalEmbedding A).PosDef := by
+  classical
+  letI := Fintype.ofFinite ι
+  letI (k : ι) := Fintype.ofFinite (n k)
+  have hpsd : (directSumDiagonalEmbedding A).PosSemidef :=
+    directSumDiagonalEmbedding_posSemidef fun k ↦ (hA k).posSemidef
+  apply hpsd.posDef_iff_isUnit.mpr
+  rw [isUnit_iff_exists_inv]
+  choose B hAB using fun k ↦ isUnit_iff_exists_inv.mp (hA k).isUnit
+  refine ⟨directSumDiagonalEmbedding B, ?_⟩
+  rw [← directSumDiagonalEmbedding_mul]
+  have hAB' : A * B = (1 : ∀ k, Matrix (n k) (n k) ℂ) := by
+    funext k
+    exact hAB k
+  rw [hAB']
+  exact Matrix.blockDiagonal'_one
+
+omit [Fintype ι] [DecidableEq ι] [(k : ι) → Fintype (n k)]
+    [(k : ι) → DecidableEq (n k)] in
+/-- Diagonal compression preserves positive semidefiniteness in every summand. -/
+theorem directSumDiagonalCompression_posSemidef
+    {A : Matrix ((k : ι) × n k) ((k : ι) × n k) ℂ} (hA : A.PosSemidef)
+    (k : ι) :
+    (directSumDiagonalCompression A k).PosSemidef := by
+  exact hA.submatrix (Sigma.mk k)
+
+omit [Fintype ι] [DecidableEq ι] [(k : ι) → Fintype (n k)]
+    [(k : ι) → DecidableEq (n k)] in
+/-- Diagonal compression commutes with conjugate transpose. -/
+theorem directSumDiagonalCompression_conjTranspose
+    (A : Matrix ((k : ι) × n k) ((k : ι) × n k) ℂ) (k : ι) :
+    directSumDiagonalCompression Aᴴ k =
+      (directSumDiagonalCompression A k)ᴴ := by
+  ext i j
+  rfl
+
+omit [DecidableEq ι] [(k : ι) → DecidableEq (n k)] in
+/-- The defect in the Schwarz inequality for diagonal compression is the Gram
+matrix of the column blocks lying outside the retained summand. -/
+theorem directSumDiagonalCompression_schwarz
+    (A : Matrix ((k : ι) × n k) ((k : ι) × n k) ℂ) (k : ι) :
+    (directSumDiagonalCompression (Aᴴ * A) k -
+      (directSumDiagonalCompression A k)ᴴ *
+        directSumDiagonalCompression A k).PosSemidef := by
+  classical
+  let R : Matrix ((l : ι) × n l) (n k) ℂ := fun q i ↦
+    if q.1 = k then 0 else A q ⟨k, i⟩
+  have hgap : directSumDiagonalCompression (Aᴴ * A) k -
+      (directSumDiagonalCompression A k)ᴴ *
+        directSumDiagonalCompression A k = Rᴴ * R := by
+    ext i j
+    simp only [directSumDiagonalCompression_apply, Matrix.submatrix_apply,
+      Matrix.sub_apply, Matrix.mul_apply, Matrix.conjTranspose_apply]
+    rw [Fintype.sum_sigma fun q : (l : ι) × n l ↦
+      star (A q ⟨k, i⟩) * A q ⟨k, j⟩]
+    rw [Fintype.sum_sigma fun q : (l : ι) × n l ↦ star (R q i) * R q j]
+    let f : ι → ℂ := fun l ↦
+      ∑ q : n l, star (A ⟨l, q⟩ ⟨k, i⟩) * A ⟨l, q⟩ ⟨k, j⟩
+    change (∑ l, f l) - f k =
+      ∑ l, ∑ q : n l, star (R ⟨l, q⟩ i) * R ⟨l, q⟩ j
+    rw [← Finset.sum_erase_add Finset.univ f (Finset.mem_univ k)]
+    ring_nf
+    let g : ι → ℂ := fun l ↦
+      ∑ q : n l, star (R ⟨l, q⟩ i) * R ⟨l, q⟩ j
+    change ∑ l ∈ Finset.univ.erase k, f l = ∑ l, g l
+    rw [← Finset.sum_erase_add Finset.univ g (Finset.mem_univ k)]
+    have hgk : g k = 0 := by
+      simp [g, R]
+    rw [hgk, add_zero]
+    apply Finset.sum_congr rfl
+    intro l hl
+    have hlk : l ≠ k := Finset.ne_of_mem_erase hl
+    simp [g, R, f, hlk]
+  rw [hgap]
+  exact Matrix.posSemidef_conjTranspose_mul_self R
+
+/-- A linear map of a finite direct sum is positive when it sends a family of
+positive-semidefinite matrices to such a family. -/
+def IsPositiveDirectSumMap
+    (T : (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ]
+      (∀ k, Matrix (n k) (n k) ℂ)) : Prop :=
+  ∀ A, (∀ k, (A k).PosSemidef) → ∀ k, (T A k).PosSemidef
+
+/-- A map on a finite direct sum satisfies the Schwarz inequality when the
+inequality holds in every summand. -/
+def IsSchwarzDirectSumMap
+    (T : (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ]
+      (∀ k, Matrix (n k) (n k) ℂ)) : Prop :=
+  ∀ A k,
+    (T (fun l ↦ (A l)ᴴ * A l) k - T (fun l ↦ (A l)ᴴ) k * T A k).PosSemidef
+
+/-- A linear map of a finite direct sum preserves the total trace when it
+preserves the sum of the ordinary traces on its summands. -/
+def IsTracePreservingDirectSumMap
+    (T : (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ]
+      (∀ k, Matrix (n k) (n k) ℂ)) : Prop :=
+  ∀ A, ∑ k, (T A k).trace = ∑ k, (A k).trace
+
+/-- Extend a map on a finite direct sum to the full matrix algebra by diagonal
+compression followed by block-diagonal embedding. -/
+noncomputable def directSumExtension
+    (T : (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ]
+      (∀ k, Matrix (n k) (n k) ℂ)) :
+    Matrix ((k : ι) × n k) ((k : ι) × n k) ℂ →ₗ[ℂ]
+      Matrix ((k : ι) × n k) ((k : ι) × n k) ℂ :=
+  directSumDiagonalEmbedding.comp (T.comp directSumDiagonalCompression)
+
+omit [Fintype ι] [(k : ι) → Fintype (n k)] [(k : ι) → DecidableEq (n k)] in
+@[simp]
+theorem directSumExtension_apply
+    (T : (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ]
+      (∀ k, Matrix (n k) (n k) ℂ))
+    (A : Matrix ((k : ι) × n k) ((k : ι) × n k) ℂ) :
+    directSumExtension T A =
+      directSumDiagonalEmbedding (T (directSumDiagonalCompression A)) :=
+  rfl
+
+omit [Fintype ι] [(k : ι) → Fintype (n k)] [(k : ι) → DecidableEq (n k)] in
+/-- Positivity of a map on the finite direct sum implies positivity of its
+canonical full-matrix extension. -/
+theorem IsPositiveDirectSumMap.directSumExtension_isPositiveMap
+    [Finite ι] [∀ k, Finite (n k)]
+    {T : (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ]
+      (∀ k, Matrix (n k) (n k) ℂ)}
+    (hT : IsPositiveDirectSumMap T) :
+    IsPositiveMap (directSumExtension T) := by
+  intro A hA
+  exact directSumDiagonalEmbedding_posSemidef
+    (hT (directSumDiagonalCompression A) fun k ↦
+      directSumDiagonalCompression_posSemidef hA k)
+
+omit [(k : ι) → DecidableEq (n k)] in
+/-- Positivity and the summandwise Schwarz inequality imply the Schwarz
+inequality for the canonical full-matrix extension. -/
+theorem IsSchwarzDirectSumMap.directSumExtension_isSchwarzMap
+    {T : (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ]
+      (∀ k, Matrix (n k) (n k) ℂ)}
+    (hTpos : IsPositiveDirectSumMap T) (hT : IsSchwarzDirectSumMap T) :
+    IsSchwarzMap (directSumExtension T) := by
+  intro A
+  let X := directSumDiagonalCompression A
+  let Y := directSumDiagonalCompression (Aᴴ * A)
+  let Xstar : ∀ k, Matrix (n k) (n k) ℂ := fun k ↦ (X k)ᴴ
+  let XstarX : ∀ k, Matrix (n k) (n k) ℂ := fun k ↦ (X k)ᴴ * X k
+  have hinput (k : ι) : (Y k - XstarX k).PosSemidef := by
+    exact directSumDiagonalCompression_schwarz A k
+  have hmonotone (k : ι) : (T Y k - T XstarX k).PosSemidef := by
+    have hpos := hTpos (Y - XstarX) fun l ↦ hinput l
+    have hk := hpos k
+    simpa only [map_sub, Pi.sub_apply] using hk
+  have hblock (k : ι) :
+      (T Y k - T Xstar k * T X k).PosSemidef := by
+    have hschwarz :
+        (T XstarX k - T Xstar k * T X k).PosSemidef := by
+      simpa only [XstarX, Xstar] using hT X k
+    have hadd := (hmonotone k).add hschwarz
+    rw [show T Y k - T Xstar k * T X k =
+      (T Y k - T XstarX k) +
+        (T XstarX k - T Xstar k * T X k) by abel]
+    exact hadd
+  have hXstar : directSumDiagonalCompression Aᴴ = Xstar := by
+    funext k
+    exact directSumDiagonalCompression_conjTranspose A k
+  have hgap : directSumExtension T (Aᴴ * A) -
+      directSumExtension T Aᴴ * directSumExtension T A =
+        directSumDiagonalEmbedding
+          (fun k ↦ T Y k - T Xstar k * T X k) := by
+    rw [directSumExtension_apply, directSumExtension_apply,
+      directSumExtension_apply]
+    change directSumDiagonalEmbedding (T Y) -
+      directSumDiagonalEmbedding (T (directSumDiagonalCompression Aᴴ)) *
+        directSumDiagonalEmbedding (T X) = _
+    rw [hXstar, ← directSumDiagonalEmbedding_mul, ← map_sub]
+    congr 1
+  rw [hgap]
+  exact directSumDiagonalEmbedding_posSemidef hblock
+
+omit [(k : ι) → DecidableEq (n k)] in
+/-- Preservation of the total block trace implies ordinary trace preservation
+for the canonical full-matrix extension. -/
+theorem IsTracePreservingDirectSumMap.directSumExtension_isTracePreservingMap
+    {T : (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ]
+      (∀ k, Matrix (n k) (n k) ℂ)}
+    (hT : IsTracePreservingDirectSumMap T) :
+    IsTracePreservingMap (directSumExtension T) := by
+  intro A
+  rw [directSumExtension_apply, trace_directSumDiagonalEmbedding, hT,
+    sum_trace_directSumDiagonalCompression]
+
+omit [Fintype ι] [(k : ι) → Fintype (n k)] [(k : ι) → DecidableEq (n k)] in
+/-- A fixed family gives a fixed block-diagonal matrix under the extension. -/
+theorem directSumExtension_embedding_eq_self_iff
+    (T : (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ]
+      (∀ k, Matrix (n k) (n k) ℂ))
+    (A : ∀ k, Matrix (n k) (n k) ℂ) :
+    directSumExtension T (directSumDiagonalEmbedding A) =
+        directSumDiagonalEmbedding A ↔
+      T A = A := by
+  rw [directSumExtension_apply, directSumDiagonalCompression_embedding]
+  constructor
+  · intro h
+    have := congrArg directSumDiagonalCompression h
+    rw [directSumDiagonalCompression_embedding,
+      directSumDiagonalCompression_embedding] at this
+    exact this
+  · intro h
+    rw [h]
+
+omit [Fintype ι] [(k : ι) → Fintype (n k)] [(k : ι) → DecidableEq (n k)] in
+/-- The fixed points of the extension are exactly the embedded fixed families.
+This includes both directions of the fixed-point identification required in
+the block-diagonal-embedding argument. -/
+theorem directSumExtension_apply_eq_self_iff
+    (T : (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ]
+      (∀ k, Matrix (n k) (n k) ℂ))
+    (A : Matrix ((k : ι) × n k) ((k : ι) × n k) ℂ) :
+    directSumExtension T A = A ↔
+      ∃ B : ∀ k, Matrix (n k) (n k) ℂ,
+        T B = B ∧ A = directSumDiagonalEmbedding B := by
+  constructor
+  · intro hA
+    have hfixed : T (directSumDiagonalCompression A) =
+        directSumDiagonalCompression A := by
+      have h := congrArg directSumDiagonalCompression hA
+      simpa only [directSumExtension_apply,
+        directSumDiagonalCompression_embedding] using h
+    refine ⟨directSumDiagonalCompression A, hfixed, ?_⟩
+    calc
+      A = directSumDiagonalEmbedding (T (directSumDiagonalCompression A)) :=
+        hA.symm
+      _ = directSumDiagonalEmbedding (directSumDiagonalCompression A) := by
+        rw [hfixed]
+  · rintro ⟨B, hB, rfl⟩
+    exact (directSumExtension_embedding_eq_self_iff T B).2 hB
+
+/-! ## Trace-pairing adjoints -/
+
+/-- The adjoint of a map on a finite direct sum for the bilinear pairing
+
+\[
+  \langle A,B\rangle=\sum_k\operatorname{tr}(A_kB_k).
+\]
+
+It is obtained by taking the full-matrix trace adjoint of the canonical
+extension and then restricting it to diagonal input and output blocks. -/
+noncomputable def directSumTraceAdjointMap
+    (T : (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ]
+      (∀ k, Matrix (n k) (n k) ℂ)) :
+    (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ]
+      (∀ k, Matrix (n k) (n k) ℂ) :=
+  directSumDiagonalCompression.comp
+    ((Matrix.traceAdjointMap (directSumExtension T)).comp
+      directSumDiagonalEmbedding)
+
+omit [(k : ι) → DecidableEq (n k)] in
+@[simp]
+theorem directSumTraceAdjointMap_apply
+    (T : (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ]
+      (∀ k, Matrix (n k) (n k) ℂ))
+    (A : ∀ k, Matrix (n k) (n k) ℂ) :
+    directSumTraceAdjointMap T A =
+      directSumDiagonalCompression
+        (Matrix.traceAdjointMap (directSumExtension T)
+          (directSumDiagonalEmbedding A)) :=
+  rfl
+
+omit [(k : ι) → DecidableEq (n k)] in
+/-- The direct-sum trace adjoint satisfies its defining trace-pairing
+identity. -/
+theorem sum_trace_directSumTraceAdjointMap_mul
+    (T : (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ]
+      (∀ k, Matrix (n k) (n k) ℂ))
+    (A B : ∀ k, Matrix (n k) (n k) ℂ) :
+    ∑ k, (directSumTraceAdjointMap T A k * B k).trace =
+      ∑ k, (A k * T B k).trace := by
+  calc
+    ∑ k, (directSumTraceAdjointMap T A k * B k).trace =
+        (directSumDiagonalEmbedding (directSumTraceAdjointMap T A) *
+          directSumDiagonalEmbedding B).trace :=
+      (trace_directSumDiagonalEmbedding_mul _ _).symm
+    _ = (Matrix.traceAdjointMap (directSumExtension T)
+          (directSumDiagonalEmbedding A) * directSumDiagonalEmbedding B).trace := by
+      rw [directSumTraceAdjointMap_apply]
+      exact trace_embedding_compression_mul_embedding _ _
+    _ = (directSumDiagonalEmbedding A *
+          directSumExtension T (directSumDiagonalEmbedding B)).trace :=
+      Matrix.trace_traceAdjointMap_mul _ _ _
+    _ = (directSumDiagonalEmbedding A *
+          directSumDiagonalEmbedding (T B)).trace := by
+      rw [directSumExtension_apply, directSumDiagonalCompression_embedding]
+    _ = ∑ k, (A k * T B k).trace :=
+      trace_directSumDiagonalEmbedding_mul _ _
+
+omit [(k : ι) → DecidableEq (n k)] in
+/-- Taking the full-matrix trace adjoint commutes with canonical extension.
+Equivalently, block-diagonal embedding and diagonal compression are adjoint
+to one another for the trace pairing. -/
+theorem traceAdjointMap_directSumExtension
+    (T : (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ]
+      (∀ k, Matrix (n k) (n k) ℂ)) :
+    Matrix.traceAdjointMap (directSumExtension T) =
+      directSumExtension (directSumTraceAdjointMap T) := by
+  apply LinearMap.ext
+  intro A
+  apply Matrix.ext_iff_trace_mul_right.mpr
+  intro B
+  calc
+    (Matrix.traceAdjointMap (directSumExtension T) A * B).trace =
+        (A * directSumExtension T B).trace :=
+      Matrix.trace_traceAdjointMap_mul _ _ _
+    _ = (A * directSumDiagonalEmbedding
+          (T (directSumDiagonalCompression B))).trace := rfl
+    _ = (directSumDiagonalEmbedding (directSumDiagonalCompression A) *
+          directSumDiagonalEmbedding
+            (T (directSumDiagonalCompression B))).trace :=
+      (trace_embedding_compression_mul_embedding _ _).symm
+    _ = ∑ k, (directSumDiagonalCompression A k *
+          T (directSumDiagonalCompression B) k).trace :=
+      trace_directSumDiagonalEmbedding_mul _ _
+    _ = ∑ k, (directSumTraceAdjointMap T
+          (directSumDiagonalCompression A) k *
+            directSumDiagonalCompression B k).trace :=
+      (sum_trace_directSumTraceAdjointMap_mul T _ _).symm
+    _ = ∑ k, (directSumDiagonalCompression B k *
+          directSumTraceAdjointMap T
+            (directSumDiagonalCompression A) k).trace := by
+      apply Finset.sum_congr rfl
+      intro k _
+      exact Matrix.trace_mul_comm _ _
+    _ = (directSumDiagonalEmbedding (directSumDiagonalCompression B) *
+          directSumDiagonalEmbedding
+            (directSumTraceAdjointMap T
+              (directSumDiagonalCompression A))).trace :=
+      (trace_directSumDiagonalEmbedding_mul _ _).symm
+    _ = (B * directSumDiagonalEmbedding
+          (directSumTraceAdjointMap T
+            (directSumDiagonalCompression A))).trace :=
+      trace_embedding_compression_mul_embedding _ _
+    _ = (directSumDiagonalEmbedding
+          (directSumTraceAdjointMap T
+            (directSumDiagonalCompression A)) * B).trace :=
+      Matrix.trace_mul_comm _ _
+    _ = (directSumExtension (directSumTraceAdjointMap T) A * B).trace := rfl
+
+omit [(k : ι) → DecidableEq (n k)] in
+/-- The trace adjoint of a positive direct-sum map is positive. -/
+theorem IsPositiveDirectSumMap.directSumTraceAdjointMap
+    {T : (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ]
+      (∀ k, Matrix (n k) (n k) ℂ)}
+    (hT : IsPositiveDirectSumMap T) :
+    IsPositiveDirectSumMap (directSumTraceAdjointMap T) := by
+  intro A hA k
+  apply directSumDiagonalCompression_posSemidef
+  exact IsPositiveMap.traceAdjointMap hT.directSumExtension_isPositiveMap _
+    (directSumDiagonalEmbedding_posSemidef hA)
+
+omit [(k : ι) → DecidableEq (n k)] in
+/-- A summandwise Schwarz trace adjoint yields the Schwarz trace adjoint of
+the canonical full-matrix extension. -/
+theorem IsSchwarzDirectSumMap.traceAdjointMap_directSumExtension_isSchwarzMap
+    {T : (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ]
+      (∀ k, Matrix (n k) (n k) ℂ)}
+    (hTpos : IsPositiveDirectSumMap T)
+    (hTstar : IsSchwarzDirectSumMap (directSumTraceAdjointMap T)) :
+    IsSchwarzMap (Matrix.traceAdjointMap (directSumExtension T)) := by
+  rw [traceAdjointMap_directSumExtension]
+  exact hTstar.directSumExtension_isSchwarzMap hTpos.directSumTraceAdjointMap
+
+end Matrix

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2583,7 +2583,9 @@ $\bigoplus_k \Id_{m_k} \otimes \MN{d_k}$.
     \[
       \widehat T(X)=X
       \ \Longrightarrow\
-      T(\pi(X))=\pi(\widehat T(X))=\pi(X)
+      T(\pi(X))=\pi(\widehat T(X))=\pi(X),
+      \qquad
+      X=\widehat T(X)=\iota(T(\pi(X)))=\iota(\pi(X))
     \]
     and
     \[
@@ -2688,6 +2690,8 @@ $\bigoplus_k \Id_{m_k} \otimes \MN{d_k}$.
     $\operatorname{tr}_{m_k}(\sigma_k\otimes X)=X$.
 \end{proof}
 
+% Scope restriction documented in
+% docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex.
 \begin{theorem}[Density-block form of fixed points on a finite direct sum]%
     \label{thm:direct_sum_fixed_points_density_block_form}
     \lean{Matrix.IsPositiveDirectSumMap.exists_block_densities_of_fixedPoints}
@@ -2714,7 +2718,9 @@ $\bigoplus_k \Id_{m_k} \otimes \MN{d_k}$.
     block-diagonal embedding.  This is the finite-direct-sum fixed-point step
     used in \cite[Appendix~C.4, lines~1980--1995]{Cirac2016MPDO_arXiv}; it
     does not assert the channel hypotheses for the particular sector maps in
-    that argument.
+    that argument.  This is the full-support restriction: the support
+    reduction and complementary zero summand of the general theorem remain
+    open.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2494,6 +2494,70 @@ $\bigoplus_k \Id_{m_k} \otimes \MN{d_k}$.
     supplies the unitary and the equivalence.
 \end{proof}
 
+\begin{definition}[Canonical full-matrix extension of a direct-sum map]%
+    \label{def:direct_sum_full_matrix_extension}
+    \lean{Matrix.directSumDiagonalEmbedding}
+    \lean{Matrix.directSumDiagonalCompression}
+    \lean{Matrix.directSumExtension}
+    \leanok
+    Let
+    \[
+        \mathcal A=\bigoplus_{k\in I}M_{n_k}(\mathbb C),
+        \qquad
+        \mathcal H=\bigoplus_{k\in I}\mathbb C^{n_k}.
+    \]
+    Write $\iota:\mathcal A\to\operatorname{End}(\mathcal H)$ for the
+    block-diagonal embedding and $\pi:\operatorname{End}(\mathcal H)\to
+    \mathcal A$ for diagonal-block compression.  For a linear map
+    $T:\mathcal A\to\mathcal A$, its canonical full-matrix extension is
+    \[
+        \widehat T=\iota\circ T\circ\pi.
+    \]
+    This is the block-diagonal realization needed when the fixed-point
+    argument in \cite[Appendix~C.4, lines~1980--1995]{Cirac2016MPDO_arXiv}
+    is applied to finite direct sums of matrix algebras.
+\end{definition}
+
+\begin{theorem}[Channel and fixed-point compatibility of the canonical extension]%
+    \label{thm:direct_sum_full_matrix_extension_compatibility}
+    \lean{Matrix.IsPositiveDirectSumMap.directSumExtension_isPositiveMap}
+    \lean{Matrix.IsSchwarzDirectSumMap.directSumExtension_isSchwarzMap}
+    \lean{Matrix.IsTracePreservingDirectSumMap.directSumExtension_isTracePreservingMap}
+    \lean{Matrix.traceAdjointMap_directSumExtension}
+    \lean{Matrix.directSumExtension_apply_eq_self_iff}
+    \leanok
+    \uses{def:direct_sum_full_matrix_extension}
+    If $T$ is positive and satisfies the Schwarz inequality on
+    $\mathcal A$, then $\widehat T$ is positive and satisfies the Schwarz
+    inequality on $\operatorname{End}(\mathcal H)$.  If $T$ preserves the
+    total trace $\sum_k\operatorname{tr}(A_k)$, then $\widehat T$ preserves
+    the ordinary trace.  Moreover, extension commutes with the trace adjoint,
+    and
+    \[
+        \operatorname{Fix}(\widehat T)=\iota(\operatorname{Fix}(T)).
+    \]
+    Equivalently, for every $X\in\operatorname{End}(\mathcal H)$,
+    \[
+        \widehat T(X)=X
+        \quad\Longleftrightarrow\quad
+        \exists A\in\mathcal A,\quad T(A)=A\ \text{ and }\ X=\iota(A).
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:direct_sum_full_matrix_extension}
+    Diagonal compression is positive and its Schwarz defect is the Gram
+    matrix of the off-diagonal column blocks.  Block-diagonal embedding is a
+    positive algebra homomorphism and converts the sum of the block traces
+    into the full trace.  It follows that positivity, the Schwarz inequality,
+    and trace preservation pass to $\widehat T$.  The embedding and
+    compression are adjoint for the trace pairing, which gives the adjoint
+    identity.  Finally, the image of $\widehat T$ is block diagonal;
+    compressing a fixed-point equation gives a fixed point of $T$, while
+    embedding a fixed point of $T$ gives a fixed point of $\widehat T$.
+\end{proof}
+
 % Scope restriction documented in
 % docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex.
 \begin{theorem}[Weighted block form of the adjoint Ces\`aro projection on full support]%

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2524,6 +2524,7 @@ $\bigoplus_k \Id_{m_k} \otimes \MN{d_k}$.
     \lean{Matrix.IsSchwarzDirectSumMap.directSumExtension_isSchwarzMap}
     \lean{Matrix.IsTracePreservingDirectSumMap.directSumExtension_isTracePreservingMap}
     \lean{Matrix.traceAdjointMap_directSumExtension}
+    \lean{Matrix.IsSchwarzDirectSumMap.traceAdjointMap_directSumExtension_isSchwarzMap}
     \lean{Matrix.directSumExtension_apply_eq_self_iff}
     \leanok
     \uses{def:direct_sum_full_matrix_extension}
@@ -2531,8 +2532,10 @@ $\bigoplus_k \Id_{m_k} \otimes \MN{d_k}$.
     $\mathcal A$, then $\widehat T$ is positive and satisfies the Schwarz
     inequality on $\operatorname{End}(\mathcal H)$.  If $T$ preserves the
     total trace $\sum_k\operatorname{tr}(A_k)$, then $\widehat T$ preserves
-    the ordinary trace.  Moreover, extension commutes with the trace adjoint,
-    and
+    the ordinary trace.  Moreover, extension commutes with the trace adjoint.
+    If $T$ is positive and its direct-sum trace adjoint satisfies the Schwarz
+    inequality, then the trace adjoint of $\widehat T$ satisfies the Schwarz
+    inequality on $\operatorname{End}(\mathcal H)$.  Finally,
     \[
         \operatorname{Fix}(\widehat T)=\iota(\operatorname{Fix}(T)).
     \]
@@ -2547,15 +2550,30 @@ $\bigoplus_k \Id_{m_k} \otimes \MN{d_k}$.
 \begin{proof}
     \leanok
     \uses{def:direct_sum_full_matrix_extension}
-    Diagonal compression is positive and its Schwarz defect is the Gram
-    matrix of the off-diagonal column blocks.  Block-diagonal embedding is a
-    positive algebra homomorphism and converts the sum of the block traces
-    into the full trace.  It follows that positivity, the Schwarz inequality,
-    and trace preservation pass to $\widehat T$.  The embedding and
+    For the matrix $R_k$ formed from the column blocks of $A$ outside the
+    $k$th diagonal block, diagonal compression satisfies
+    \[
+        \pi(A^*A)_k-\pi(A)_k^*\pi(A)_k=R_k^*R_k\succeq0.
+    \]
+    Block-diagonal embedding is a positive algebra homomorphism and converts
+    the sum of the block traces into the full trace.  It follows that
+    positivity, both stated Schwarz implications, and trace preservation pass
+    to $\widehat T$.  The embedding and
     compression are adjoint for the trace pairing, which gives the adjoint
-    identity.  Finally, the image of $\widehat T$ is block diagonal;
-    compressing a fixed-point equation gives a fixed point of $T$, while
-    embedding a fixed point of $T$ gives a fixed point of $\widehat T$.
+    identity.  Since $\pi\circ\iota=\operatorname{id}$, the two fixed-point
+    implications are
+    \[
+      \widehat T(X)=X
+      \ \Longrightarrow\
+      T(\pi(X))=\pi(\widehat T(X))=\pi(X)
+    \]
+    and
+    \[
+      T(A)=A
+      \ \Longrightarrow\
+      \widehat T(\iota(A))
+      =\iota(T(\pi(\iota(A))))=\iota(T(A))=\iota(A).
+    \]
 \end{proof}
 
 % Scope restriction documented in
@@ -2650,6 +2668,50 @@ $\bigoplus_k \Id_{m_k} \otimes \MN{d_k}$.
     basis proves the displayed formula by nondegeneracy of the trace pairing.
     Its range consists of the stated density blocks because
     $\operatorname{tr}_{m_k}(\sigma_k\otimes X)=X$.
+\end{proof}
+
+\begin{theorem}[Density-block form of fixed points on a finite direct sum]%
+    \label{thm:direct_sum_fixed_points_density_block_form}
+    \lean{Matrix.IsPositiveDirectSumMap.exists_block_densities_of_fixedPoints}
+    \leanok
+    \uses{thm:direct_sum_full_matrix_extension_compatibility,
+        thm:mean_ergodic_projection_density_block_form}
+    Let
+    \[
+        \mathcal A=\bigoplus_{i\in I}M_{n_i}(\mathbb C)
+    \]
+    be a finite direct sum.  Suppose that $T:\mathcal A\to\mathcal A$ is
+    positive and preserves the total trace, that its trace adjoint satisfies
+    the Schwarz inequality, and that $T$ fixes a family $\rho=(\rho_i)_i$
+    with every $\rho_i$ positive definite.  Then there are positive integers
+    $d_k,m_k$, density matrices $\sigma_k\in M_{m_k}(\mathbb C)$, a unitary
+    $U$ on $\bigoplus_i\mathbb C^{n_i}$, and a reindexing of this space by
+    $\bigoplus_k(\mathbb C^{m_k}\otimes\mathbb C^{d_k})$ such that
+    \[
+        T(A)=A
+        \quad\Longleftrightarrow\quad
+        U^*\iota(A)U=\bigoplus_k \sigma_k\otimes X_k
+    \]
+    for some $X_k\in M_{d_k}(\mathbb C)$.  Here $\iota$ is the
+    block-diagonal embedding.  This is the finite-direct-sum fixed-point step
+    used in \cite[Appendix~C.4, lines~1980--1995]{Cirac2016MPDO_arXiv}; it
+    does not assert the channel hypotheses for the particular sector maps in
+    that argument.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:direct_sum_full_matrix_extension_compatibility,
+        thm:mean_ergodic_projection_density_block_form}
+    Extend $T$ by diagonal compression and block-diagonal embedding.  The
+    canonical extension is positive and trace preserving, its trace adjoint
+    satisfies the Schwarz inequality, and the embedded family $\iota(\rho)$
+    is a positive-definite fixed point.  After choosing a numbered basis of
+    the finite-dimensional ambient space, apply the full-support
+    density-block theorem.  Simultaneous reindexing preserves positivity,
+    trace preservation, the Schwarz inequality, the trace adjoint, and
+    positive definiteness.  Reindexing the resulting unitary and block
+    decomposition back to $\mathcal H$ gives the displayed equivalence.
 \end{proof}
 
 Without a full-rank hypothesis on the fixed point, the corner-restricted fixed-point

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2499,6 +2499,7 @@ $\bigoplus_k \Id_{m_k} \otimes \MN{d_k}$.
     \lean{Matrix.directSumDiagonalEmbedding}
     \lean{Matrix.directSumDiagonalCompression}
     \lean{Matrix.directSumExtension}
+    \lean{Matrix.directSumTraceAdjointMap}
     \leanok
     Let
     \[
@@ -2512,6 +2513,12 @@ $\bigoplus_k \Id_{m_k} \otimes \MN{d_k}$.
     $T:\mathcal A\to\mathcal A$, its canonical full-matrix extension is
     \[
         \widehat T=\iota\circ T\circ\pi.
+    \]
+    The trace adjoint $T^*:\mathcal A\to\mathcal A$ is defined by
+    \[
+      \sum_k\operatorname{tr}(T^*(A)_kB_k)
+      =\sum_k\operatorname{tr}(A_kT(B)_k)
+      \qquad(A,B\in\mathcal A).
     \]
     This is the block-diagonal realization needed when the fixed-point
     argument in \cite[Appendix~C.4, lines~1980--1995]{Cirac2016MPDO_arXiv}
@@ -2532,7 +2539,10 @@ $\bigoplus_k \Id_{m_k} \otimes \MN{d_k}$.
     $\mathcal A$, then $\widehat T$ is positive and satisfies the Schwarz
     inequality on $\operatorname{End}(\mathcal H)$.  If $T$ preserves the
     total trace $\sum_k\operatorname{tr}(A_k)$, then $\widehat T$ preserves
-    the ordinary trace.  Moreover, extension commutes with the trace adjoint.
+    the ordinary trace.  Moreover,
+    \[
+        (\widehat T)^*=\widehat{T^*}.
+    \]
     If $T$ is positive and its direct-sum trace adjoint satisfies the Schwarz
     inequality, then the trace adjoint of $\widehat T$ satisfies the Schwarz
     inequality on $\operatorname{End}(\mathcal H)$.  Finally,
@@ -2558,9 +2568,17 @@ $\bigoplus_k \Id_{m_k} \otimes \MN{d_k}$.
     Block-diagonal embedding is a positive algebra homomorphism and converts
     the sum of the block traces into the full trace.  It follows that
     positivity, both stated Schwarz implications, and trace preservation pass
-    to $\widehat T$.  The embedding and
-    compression are adjoint for the trace pairing, which gives the adjoint
-    identity.  Since $\pi\circ\iota=\operatorname{id}$, the two fixed-point
+    to $\widehat T$.  The embedding and compression satisfy
+    \[
+      \operatorname{tr}(\iota(A)X)
+      =\sum_k\operatorname{tr}(A_k\pi(X)_k).
+    \]
+    Substitution of $\widehat T=\iota\circ T\circ\pi$ and the defining
+    pairing for $T^*$ gives
+    \[
+        (\widehat T)^*=\widehat{T^*}.
+    \]
+    Since $\pi\circ\iota=\operatorname{id}$, the two fixed-point
     implications are
     \[
       \widehat T(X)=X

--- a/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
+++ b/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
@@ -126,14 +126,18 @@ trace preserving precisely when the precompression output lies in its active
 image.  The established image identity is restricted to the source-generated
 contractions.
 
-There is also a domain bridge between the two results.  The present
-full-support theorem concerns an endomorphism of one full matrix algebra,
-whereas the transported composites act on dependent direct sums of matrix
-algebras.  Applying the theorem therefore requires either a trace-preserving
-Schwarz extension through the block-diagonal embedding and block projection,
-with its fixed-point space identified with that of the direct-sum map, or a
-direct-sum version of the fixed-point theorem.  Neither bridge is currently
-formalized.
+There is also a difference between the domains of the two results.  The
+present full-support theorem concerns an endomorphism of one full matrix
+algebra, whereas the transported composites act on dependent direct sums of
+matrix algebras.  The canonical full-matrix extension is now formalized: one
+first compresses to the diagonal blocks, applies the direct-sum map, and then
+embeds the output block diagonally.  Positivity, total-trace preservation, and
+the Schwarz inequality pass to this extension, its trace adjoint is the
+extension of the direct-sum trace adjoint, and its fixed points are exactly the
+block-diagonal images of the direct-sum fixed points.  What remains is to apply
+the full-matrix density-block theorem after a finite change of index and to
+verify the required channel hypotheses for the transported sector maps on the
+whole direct sums.
 
 \section{Sector relabelling uses positivity, not linear isomorphism}
 

--- a/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
+++ b/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
@@ -138,7 +138,11 @@ block-diagonal images of the direct-sum fixed points.  Reindexing the extension
 by a finite equivalence and applying the full-support theorem now gives the
 density-block form of the fixed families on the original direct sum.  What
 remains is to verify the required channel hypotheses for the transported
-sector maps on the whole direct sums.
+sector maps on the whole direct sums and to supply a blockwise
+positive-definite fixed family.  Alternatively, the support reduction and
+complementary zero summand still open in
+\path{docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex} would
+remove the latter full-support hypothesis.
 
 \section{Sector relabelling uses positivity, not linear isomorphism}
 

--- a/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
+++ b/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
@@ -134,10 +134,11 @@ first compresses to the diagonal blocks, applies the direct-sum map, and then
 embeds the output block diagonally.  Positivity, total-trace preservation, and
 the Schwarz inequality pass to this extension, its trace adjoint is the
 extension of the direct-sum trace adjoint, and its fixed points are exactly the
-block-diagonal images of the direct-sum fixed points.  What remains is to apply
-the full-matrix density-block theorem after a finite change of index and to
-verify the required channel hypotheses for the transported sector maps on the
-whole direct sums.
+block-diagonal images of the direct-sum fixed points.  Reindexing the extension
+by a finite equivalence and applying the full-support theorem now gives the
+density-block form of the fixed families on the original direct sum.  What
+remains is to verify the required channel hypotheses for the transported
+sector maps on the whole direct sums.
 
 \section{Sector relabelling uses positivity, not linear isomorphism}
 


### PR DESCRIPTION
## Summary

- define the block-diagonal embedding, diagonal compression, and canonical extension of a map on a finite direct sum of full matrix algebras;
- prove transport of positivity, total-trace preservation, Schwarz inequalities, and trace adjoints;
- identify the extension's fixed points exactly with embedded direct-sum fixed points;
- reindex the canonical extension by a finite equivalence, invoke the full-support classifier once, and return its density-block fixed-point form to the original dependent direct sum.

## Mathematical source and scope

CPSV16 Appendix C.4 (arXiv:1606.00608, lines 1980–1995) invokes Wolf, Theorem 6.14, for finite direct sums of matrix algebras. `DirectSumExtension` establishes the canonical full-matrix extension and its channel and fixed-point properties. `DirectSumBlockRetraction` applies the full-support theorem from #4287 after a finite change of coordinates and transports the resulting unitary density-block form back to the direct sum.

The result is the full-support finite-index classification needed by the cited passage: it assumes a blockwise positive-definite fixed family. It does not assert that the particular transported sector maps in CPSV16 satisfy positivity, total-trace preservation, the adjoint Schwarz inequality, or this positive-definite fixed-family hypothesis. Alternatively, the support reduction and complementary zero summand documented in `docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex` would remove the full-support restriction.

## Principal declarations

- `Matrix.directSumDiagonalEmbedding`
- `Matrix.directSumDiagonalCompression`
- `Matrix.directSumDiagonalCompression_schwarz`
- `Matrix.directSumExtension`
- `Matrix.IsPositiveDirectSumMap.directSumExtension_isPositiveMap`
- `Matrix.IsSchwarzDirectSumMap.directSumExtension_isSchwarzMap`
- `Matrix.IsTracePreservingDirectSumMap.directSumExtension_isTracePreservingMap`
- `Matrix.directSumExtension_apply_eq_self_iff`
- `Matrix.directSumTraceAdjointMap`
- `Matrix.traceAdjointMap_directSumExtension`
- `Matrix.IsSchwarzDirectSumMap.traceAdjointMap_directSumExtension_isSchwarzMap`
- `Matrix.reindexEndomorphism`
- `Matrix.IsPositiveDirectSumMap.exists_block_densities_of_fixedPoints`

## Verification

- `lake build` (9584 jobs)
- `lake build TNLean.Channel.FixedPoint.DirectSumBlockRetraction`
- `lake env lean TNLean.lean`
- `lake exe lint_style`
- proof-integrity token scan of the changed Lean files
- `python3 scripts/check_oversized_lean_files.py --root .`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `leanblueprint web` completed locally; the local installation lacks the optional `leanblueprint` Python package, so CI remains the authoritative rendered-blueprint gate
- `git diff --check`

The full repository build reports only pre-existing warnings in unrelated files, including the known `sorry` in `MPS/Periodic/Overlap/Case3.lean`.

Closes #4297.
Closes #4282.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New Mathlib-style proofs in fixed-point theory with no auth, security, or runtime impact; remaining application-specific hypotheses for CPSV16 sector maps are explicitly out of scope.
> 
> **Overview**
> Adds Lean infrastructure to classify fixed points of positive, total-trace-preserving maps on **finite direct sums of matrix algebras**, matching the CPSV16 Appendix C.4 / Wolf 6.14 finite-index step.
> 
> **`DirectSumExtension`** introduces block-diagonal embedding/compression and the canonical full-matrix extension `ι ∘ T ∘ π`. It proves positivity, total-trace preservation, Schwarz inequalities, trace-adjoint compatibility (`(widehat T)* = widehat{T*}`), and that extension fixed points are exactly embedded direct-sum fixed points.
> 
> **`DirectSumBlockRetraction`** reindexes that extension to `Fin n`, invokes the existing full-support density-block classifier, and pulls the unitary / σ⊗X block form back to the original dependent direct-sum indexing via `exists_block_densities_of_fixedPoints`. The result is stated under a **full-support** positive-definite fixed family; general support reduction remains documented as open.
> 
> Blueprint chapter 7 and `docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex` are updated to record the formalized extension bridge; verifying channel hypotheses for the concrete transported sector maps is still separate work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9d38631efd02ae1ca1e58f5c5315d133471bfd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
