### PR TITLE
fix(MPS/MPDO): align SAL counterexample proof and blueprint

### DIFF
--- a/TNLean/MPS/MPDO/ActiveSectorInverseMapProvenance.lean
+++ b/TNLean/MPS/MPDO/ActiveSectorInverseMapProvenance.lean
@@ -224,14 +224,26 @@ noncomputable def threeSiteState :
       (rightPairing * leftPairing) x.2.1 x.2.2
     else 0
 
-private noncomputable def crossSectorMatrix (i j : Fin 4) :
+/-- The rank-one open sector matrix with left physical label `i` and right
+physical label `j`.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1413--1455. -/
+noncomputable def crossSectorMatrix (i j : Fin 4) :
     Matrix (Fin 2) (Fin 2) ℂ :=
   Matrix.vecMulVec (fun beta => leftPairing beta i) (fun alpha => rightPairing j alpha)
 
-private lemma sectorMatrix_eq_crossSectorMatrix (i : Fin 4) :
+/-- A closed scalar sector is the open sector matrix with equal endpoint
+labels.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1413--1455. -/
+lemma sectorMatrix_eq_crossSectorMatrix (i : Fin 4) :
     sectorMatrix i = crossSectorMatrix i i := rfl
 
-private lemma crossSectorMatrix_mul (i j k h : Fin 4) :
+/-- Concatenating two open sector matrices contributes the neighboring
+transition weight at their common boundary.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1413--1455. -/
+lemma crossSectorMatrix_mul (i j k h : Fin 4) :
     crossSectorMatrix i j * crossSectorMatrix k h =
       (rightPairing * leftPairing) j k • crossSectorMatrix i h := by
   ext x y
@@ -239,7 +251,11 @@ private lemma crossSectorMatrix_mul (i j k h : Fin 4) :
     simp [crossSectorMatrix, Matrix.vecMulVec_apply, Matrix.mul_apply,
       Fin.sum_univ_two] <;> ring
 
-private lemma trace_crossSectorMatrix_mul_transfer (i k : Fin 4) :
+/-- Closing an open sector matrix against the normalized physical-trace
+transfer gives the uniform sector weight `1 / 4`.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1413--1455. -/
+lemma trace_crossSectorMatrix_mul_transfer (i k : Fin 4) :
     Matrix.trace (crossSectorMatrix i k * (leftPairing * rightPairing)) = 1 / 4 := by
   fin_cases i <;> fin_cases k <;>
     norm_num [crossSectorMatrix, leftPairing, rightPairing, Matrix.trace,

--- a/TNLean/MPS/MPDO/ActiveSectorSpanningAreaLaw.lean
+++ b/TNLean/MPS/MPDO/ActiveSectorSpanningAreaLaw.lean
@@ -170,28 +170,10 @@ private lemma sum_pathWeight_to (n : ℕ) (k : Fin 4) :
                     rw [transition_column_sum, one_mul]
             _ = 1 := ih
 
-private noncomputable def crossSectorMatrix (i j : Fin 4) :
-    Matrix (Fin 2) (Fin 2) ℂ :=
-  Matrix.vecMulVec (fun beta => leftPairing beta i) (fun alpha => rightPairing j alpha)
-
-private lemma sectorMatrix_eq_crossSectorMatrix (i : Fin 4) :
-    sectorMatrix i = crossSectorMatrix i i := rfl
-
-private lemma crossSectorMatrix_mul (i j k h : Fin 4) :
-    crossSectorMatrix i j * crossSectorMatrix k h =
-      (transition j k : ℂ) • crossSectorMatrix i h := by
-  rw [← pairing_eq_transition]
-  ext x y
-  fin_cases x <;> fin_cases y <;>
-    simp [crossSectorMatrix, Matrix.vecMulVec_apply, Matrix.mul_apply,
-      Fin.sum_univ_two] <;> ring
-
 private lemma trace_crossSectorMatrix_mul_loop (i k : Fin 4) :
     Matrix.trace (crossSectorMatrix i k * physTraceTransfer tensor) = 1 / 4 := by
-  rw [physTraceTransfer_tensor, leftPairing_mul_rightPairing]
-  fin_cases i <;> fin_cases k <;>
-    norm_num [crossSectorMatrix, leftPairing, rightPairing, Matrix.trace,
-      Matrix.mul_apply, Fin.sum_univ_two]
+  rw [physTraceTransfer_tensor]
+  exact trace_crossSectorMatrix_mul_transfer i k
 
 private lemma trace_crossSectorMatrix (i k : Fin 4) :
     Matrix.trace (crossSectorMatrix i k) = transition k i := by
@@ -212,7 +194,7 @@ private lemma evalWord_same_eq (i : Fin 4) (w : List (Fin 4)) :
       simp [evalWord, tensor, sectorMatrix_eq_crossSectorMatrix, lastFrom]
   | cons j w ih =>
       rw [evalWord_cons, tensor, if_pos rfl, sectorMatrix_eq_crossSectorMatrix,
-        ih j, Matrix.mul_smul, crossSectorMatrix_mul]
+        ih j, Matrix.mul_smul, crossSectorMatrix_mul, pairing_eq_transition]
       simp only [pathWeight_cons_cons, lastFrom, smul_smul]
       push_cast
       ring_nf

--- a/TNLean/MPS/MPDO/ActiveSectorSpanningCounterexample.lean
+++ b/TNLean/MPS/MPDO/ActiveSectorSpanningCounterexample.lean
@@ -307,6 +307,17 @@ lemma activeSectorTraceMatrix_isPrimitive :
   rw [happ]
   exact rightPairing_mul_leftPairing_re_pos (activeEquiv k) (activeEquiv h)
 
+/-- The rectangular remainder is exactly the failure of the opposite product
+`rightPairing * leftPairing` to be idempotent.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma C.5, lines 1484--1499. -/
+lemma rectangular_remainder_eq_mul_sub_sq :
+    rightPairing * (1 - leftPairing * rightPairing) * leftPairing =
+      rightPairing * leftPairing -
+        (rightPairing * leftPairing) * (rightPairing * leftPairing) := by
+  rw [Matrix.mul_sub, Matrix.mul_one, Matrix.sub_mul]
+  simp only [Matrix.mul_assoc]
+
 /-- The rectangular remainder from CPSV16, Appendix C.2, does not vanish for
 this factorization. -/
 lemma rectangular_remainder_ne_zero :
@@ -316,13 +327,8 @@ lemma rectangular_remainder_ne_zero :
   have hdiff :
       rightPairing * leftPairing -
           (rightPairing * leftPairing) * (rightPairing * leftPairing) = 0 := by
-    calc
-      rightPairing * leftPairing -
-          (rightPairing * leftPairing) * (rightPairing * leftPairing) =
-          rightPairing * (1 - leftPairing * rightPairing) * leftPairing := by
-        rw [Matrix.mul_sub, Matrix.mul_one, Matrix.sub_mul]
-        simp only [Matrix.mul_assoc]
-      _ = 0 := hzero
+    rw [← rectangular_remainder_eq_mul_sub_sq]
+    exact hzero
   exact (sub_eq_zero.mp hdiff).symm
 
 /-- Full virtual-matrix spanning does not force the rectangular remainder

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -54,6 +54,8 @@
       activeSectorTraceMatrix_not_rankOne}
     \lean{MPOTensor.ActiveSectorSpanningCounterexample.%
       tensor_refutes_printed_sal_zcl_rank_one_inference}
+    \lean{MPOTensor.ActiveSectorSpanningCounterexample.%
+      rectangular_remainder_eq_mul_sub_sq}
     \leanok
     \uses{def:is_sal, def:mpo_source_zcl,
       thm:mpdo_all_cut_markov_implies_sal,
@@ -77,19 +79,35 @@
 \begin{proof}
     \leanok
     The four physical sectors are one-dimensional.  Their cyclic transition
-    law is doubly stochastic, and conditioning on the middle physical label
-    gives a four-sector quantum-Markov decomposition at every admissible cut;
-    hence the tensor satisfies the strong area law.  Its physical-trace
+    law is doubly stochastic.  After tracing one site, conditioning on the
+    middle physical label gives, at every admissible cut,
+    \[
+      \rho_{ABC}
+      =\bigoplus_{k=0}^{3}\frac14\,
+        \rho^{L}_{A,k}\otimes\rho^{R}_{k,C}.
+    \]
+    Thus the reduced state has a four-sector quantum-Markov decomposition and
+    the tensor satisfies the strong area law.  Its physical-trace
     transfer is the idempotent matrix \(LQ\), so it has source zero correlation
     length.  The explicit Hayashi decomposition and inverse map recover the
     displayed tensors \(L,Q\).  The active trace matrix is primitive and has
-    trace one, but direct multiplication gives \(T^2\ne T\).  Any outer product
-    of trace one is idempotent, so \(T\) has no rank-one factorization.
+    trace one, but direct multiplication gives \(T^2\ne T\).  If
+    \(T=ab^{\mathsf T}\), then
+    \[
+      T^2=a(b^{\mathsf T}a)b^{\mathsf T}
+         =\left(\sum_k a_kb_k\right)T=T,
+    \]
+    where the last equality uses \(\tr(T)=1\).  Hence \(T\) has no rank-one
+    factorization.
 \end{proof}
 
 \begin{theorem}[Inverse-map factorization with a nonzero rectangular remainder]
     \label{thm:mpdo_inverse_map_nonzero_rectangular_remainder}
     \lean{MPOTensor.ActiveSectorSpanningCounterexample.normalizedFourSiteTail_tensor}
+    \lean{MPOTensor.ActiveSectorSpanningCounterexample.crossSectorMatrix}
+    \lean{MPOTensor.ActiveSectorSpanningCounterexample.sectorMatrix_eq_crossSectorMatrix}
+    \lean{MPOTensor.ActiveSectorSpanningCounterexample.crossSectorMatrix_mul}
+    \lean{MPOTensor.ActiveSectorSpanningCounterexample.trace_crossSectorMatrix_mul_transfer}
     \lean{MPOTensor.ActiveSectorSpanningCounterexample.threeSiteState}
     \lean{MPOTensor.ActiveSectorSpanningCounterexample.hayashiData}
     \lean{MPOTensor.ActiveSectorSpanningCounterexample.sectorTensorL_hayashiData}


### PR DESCRIPTION
## Summary

This corrective follow-up addresses the post-merge review findings on #4296 after the axiom remediation in #4300.

- exports the four cross-sector matrix lemmas from the inverse-map provenance module and reuses them in the area-law proof, removing the duplicate local algebra;
- proves the exact identity Q(1 - LQ)L = QL - (QL)^2 as a public Lean declaration and attaches it to the counterexample blueprint theorem;
- displays the four-sector quantum-Markov decomposition and the trace-one outer-product idempotency calculation in the blueprint proof;
- preserves the public strong-area-law theorem and packaged counterexample conclusion.

This is a narrow correction for the completed work associated with #4270. It does not modify the tracking issues #232 or #2380.

## Verification

- lake env lean TNLean/MPS/MPDO/ActiveSectorSpanningCounterexample.lean
- lake env lean TNLean/MPS/MPDO/ActiveSectorInverseMapProvenance.lean
- lake env lean TNLean/MPS/MPDO/ActiveSectorSpanningAreaLaw.lean
- lake build
- python3 scripts/blueprint_lean_sync.py --root . --ci
- lake exe checkdecls blueprint/lean_decls
- leanblueprint checkdecls
- git diff --check
- 100-character line-length check on every changed file

The axiom audit reports only [propext, Classical.choice, Quot.sound] for both MPOTensor.ActiveSectorSpanningCounterexample.tensor_isSAL and MPOTensor.ActiveSectorSpanningCounterexample.tensor_refutes_printed_sal_zcl_rank_one_inference.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof and documentation-only changes in MPDO counterexample files; no runtime or security impact, with behavior preserved by reusing existing lemmas.
> 
> **Overview**
> **Refactors the four-sector MPDO counterexample proofs** by centralizing `crossSectorMatrix` and its multiplication/trace lemmas in `ActiveSectorInverseMapProvenance` (now public with docstrings) and **deleting the duplicate private copies** in `ActiveSectorSpanningAreaLaw`, which instead calls `trace_crossSectorMatrix_mul_transfer` and the shared `crossSectorMatrix_mul`.
> 
> Adds a named Lean lemma **`rectangular_remainder_eq_mul_sub_sq`** (`Q(1-LQ)L = QL - (QL)²`) and uses it to shorten `rectangular_remainder_ne_zero`.
> 
> The **blueprint** (`ch21_mpdo_rfp_simple_local_structure_capstone.tex`) now links those declarations, states the four-sector quantum-Markov marginal after tracing one site, and gives the trace-one outer-product argument that rank one would force `T² = T`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0f430d6eca3e94a1234d194eab29fb27822c8a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->