### PR TITLE
feat(MPS/MPDO): select the SAL normal product representative

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -574,6 +574,7 @@ import TNLean.MPS.MPDO.CommutingBondEtaCyclicTransport
 import TNLean.MPS.MPDO.CyclicEdgeWeightTensor
 import TNLean.MPS.MPDO.FixedBondProductTensor
 import TNLean.MPS.MPDO.FixedBondProductEtaTensor
+import TNLean.MPS.MPDO.PhysicalSectorNormalProductRepresentative
 import TNLean.MPS.MPDO.CommutingBondEtaBoundaryTrace
 import TNLean.MPS.MPDO.GSNNCHSectorSum
 import TNLean.MPS.MPDO.GSNNCHOrthogonalSectors

--- a/TNLean/MPS/MPDO/FixedBondProductTensor.lean
+++ b/TNLean/MPS/MPDO/FixedBondProductTensor.lean
@@ -18,9 +18,11 @@ written as a cyclic nearest-neighbor scalar weight, and transports the source
 positive realization from lengths at least two to eventual nonzero MPV
 proportionality.
 
-Normality is deliberately not included in the representation datum.  The
-passage from this finite tensor to a normal representative is a separate
-canonical-form problem; it is not asserted in Proposition C.8 of the source.
+Normality is deliberately not included in the representation datum. An
+arbitrary representation may contain an additional all-zero virtual summand,
+which cannot be removed by a nonzero scalar. Proposition C.8 instead selects
+its bond from the physical-sector factorization of the source tensor; that
+selected product family has the source tensor itself as a representative.
 
 ## Main declarations
 
@@ -173,19 +175,20 @@ theorem eventuallyNonzeroProportionalMPV₂_fixedProductTensor
 comparison with a normal source tensor already has one geometric coefficient:
 a unit phase times the positive rescaling, raised to the chain length.
 
-Thus the construction of a rescaled normal representative is not independent
-of the geometric-scalar problem.  This statement does not assert that the
+Thus the existence of a rescaled normal representative is not independent of
+the geometric-scalar problem. This statement does not assert that the
 fixed product tensor, or any rescaling of it, is normal.
 
 Source context: arXiv:1606.00608, Appendix C.2, Proposition C.8 (label:
-3to4), lines 1570--1593, together with Corollary eqV, lines 1121--1128.  The
-remaining normal-representative problem is documented in
+3to4), lines 1570--1593, together with Corollary eqV, lines 1121--1128. The
+distinction between source-selected and arbitrary presentations is documented in
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.
 
 **Scope restriction (positive normal rescaling):** The hypothesis `hRepr`
-assumes that the positively rescaled fixed-product tensor is normal.  This
-hypothesis is absent from Proposition C.8 (label: 3to4), and its derivation
-remains open; see
+assumes that the positively rescaled fixed-product tensor is normal. This
+hypothesis is absent from Proposition C.8 (label: 3to4). It is false for an
+arbitrary supplied representation after adjoining an all-zero virtual summand;
+the source-selected bond instead uses the source tensor itself. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem exists_unit_phase_power_mpo_eq_product_of_normal_smul
     [NeZero D]
@@ -230,14 +233,15 @@ two.  Normality of the source makes its self-overlap, and hence the fixed bond
 product, nonzero at those lengths.
 
 Source context: arXiv:1606.00608, Appendix C.2, Proposition C.8 (label:
-3to4), lines 1570--1593, together with Corollary eqV, lines 1121--1128.  The
-normal-representative hypothesis is precisely the remaining condition recorded
-in `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.
+3to4), lines 1570--1593, together with Corollary eqV, lines 1121--1128. The
+arbitrary-presentation hypothesis is discussed in
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.
 
 **Scope restriction (positive normal rescaling):** The hypothesis `hRepr`
-assumes that the positively rescaled fixed-product tensor is normal.  This
-hypothesis is absent from Proposition C.8 (label: 3to4), and its derivation
-remains open; see
+assumes that the positively rescaled fixed-product tensor is normal. This
+hypothesis is absent from Proposition C.8 (label: 3to4). It is false for an
+arbitrary supplied representation after adjoining an all-zero virtual summand;
+the source-selected bond instead uses the source tensor itself. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem mpo_eq_positive_power_product_of_normal_smul
     [NeZero D]

--- a/TNLean/MPS/MPDO/PhysicalSectorNormalProductRepresentative.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorNormalProductRepresentative.lean
@@ -1,0 +1,98 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.FixedBondProductTensor
+import TNLean.MPS.MPDO.InverseMapActiveSectorRecurrence
+import TNLean.MPS.MPDO.PhysicalSupportBondTransport
+
+/-!
+# Normal representative for the SAL-selected commuting-bond product
+
+The positive physical-sector factorization of an injective tensor satisfying
+the strong area law selects a particular commuting bond. The tensor itself
+represents the products of this bond exactly, with scalar one. If its
+doubled-index tensor is normal, it is therefore already a normal representative
+of the selected product family.
+
+This is the forward construction in Proposition C.8. It does not assert that
+an arbitrary proportional commuting-bond presentation, or an arbitrary
+matrix-product representation of its products, has a normal rescaling.
+
+## Main declarations
+
+* `PhysicalSectorFactorization.fixedProductTensorData`
+* `MPOTensor.exists_normal_fixedProductTensorData_of_isSAL`
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, Lemma C.4 and Proposition C.8, lines 1435--1450 and
+  1570--1593
+-/
+
+open scoped ComplexOrder
+
+namespace MPOTensor
+
+namespace PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D}
+
+/-- The bond selected by a positive physical-sector factorization is represented
+exactly by the source tensor itself.
+
+Unlike an arbitrary finite-state representation of the same closed operators,
+this representation has no additional virtual summand: its tensor is the
+original `K`. The coefficient in the periodic bond-product identity is one at
+every length at least two.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `sigmaNK2` and Proposition
+C.8 (`3to4`), lines 1581--1593. -/
+noncomputable def fixedProductTensorData
+    (F : PhysicalSectorFactorization K)
+    (hη : ∀ k h, (F.neighboringOperator k h).PosSemidef)
+    (hD : 0 < D) :
+    TranslationInvariantBondData.FixedProductTensorData
+      (F.translationInvariantBondData hη) where
+  bondDim := D
+  bondDim_pos := hD
+  tensor := K
+  mpo_eq_product := by
+    intro N hN
+    change mpo K N =
+      (List.ofFn fun i : Fin N ↦
+        embedLocalOperator (d := d) 2 N hN i F.physicalBond).prod
+    exact F.mpo_eq_product_physicalBond hN
+
+end PhysicalSectorFactorization
+
+/-- An injective normal MPO tensor satisfying SAL is itself a normal
+matrix-product representative of the commuting-bond product selected in the
+proof of Proposition C.8. The local scalar is one; no assertion is made about
+an arbitrary proportional commuting-bond presentation.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`), lines
+1570--1593. The positive physical-sector factorization is constructed in
+Lemma C.4 (`propSN`), lines 1406--1450. -/
+theorem exists_normal_fixedProductTensorData_of_isSAL
+    {d D : ℕ} (K : MPOTensor d D) (hK : K.IsInjective) (hSAL : IsSAL K)
+    (hNormal : MPSTensor.IsNormalTensor K.toMPSTensor) :
+    ∃ (F : PhysicalSectorFactorization K)
+      (hη : ∀ k h, (F.neighboringOperator k h).PosSemidef),
+      let repr := F.fixedProductTensorData hη (bondDim_pos_of_isSAL K hSAL)
+      MPSTensor.IsNormalTensor repr.tensor.toMPSTensor ∧
+        ∀ (N : ℕ) (hN : 2 ≤ N),
+          mpo K N =
+            ((F.translationInvariantBondData hη).toCommutingFormData hN).product := by
+  obtain ⟨F, hη⟩ := exists_positive_physicalSectorFactorization_of_isSAL K hK hSAL
+  refine ⟨F, hη, ?_, ?_⟩
+  · exact hNormal
+  · intro N hN
+    change mpo K N =
+      (List.ofFn fun i : Fin N ↦
+        embedLocalOperator (d := d) 2 N hN i F.physicalBond).prod
+    exact F.mpo_eq_product_physicalBond hN
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -379,7 +379,7 @@
     positive scalar $c_N$.
 \end{proof}
 
-\begin{remark}[The finite-chain scalar requires a normal-block argument]
+\begin{remark}[An arbitrary proportional presentation need not have unit scalar]
     The proportional commuting-bond form alone does not permit one common
     local normalization.  Indeed, take physical dimension $d=1$ and bond
     dimension $D=2$, with sole matrix-product letter $M^{00}=I_2$, and take
@@ -392,13 +392,17 @@
     Any positive neighboring decomposition of the one-dimensional physical
     space has one sector and one scalar $a\geq0$.  A coefficient-free identity
     at lengths two and four would give $a^2=2$ and $a^4=2$, a contradiction.
-    This example is not a normal injective block.  In the normal single-block
-    setting, the missing assertion is the geometric law $c_N=a^N$ for one
-    $a>0$; it is precisely this law that permits one fixed rescaling.  This
-    distinguishes the proportionality at
+    This example is not a normal injective block.  More generally, the source
+    does not claim that every proportional commuting-bond presentation can be
+    made coefficient-free by one local rescaling.  In the SAL-to-commuting-form
+    direction, the proof chooses the neighboring operators from the source
+    tensor and obtains scalar one directly.  This distinguishes the
+    proportionality at
     \cite[Appendix~C.2, lines~1571--1576]{Cirac2016MPDO_arXiv} from the
     coefficient-free invocation at
-    \cite[Appendix~C.2, lines~1603--1605]{Cirac2016MPDO_arXiv}.
+    \cite[Appendix~C.2, lines~1603--1605]{Cirac2016MPDO_arXiv}. The
+    source-selected normal representative is
+    Corollary~\ref{cor:mpdo_normal_fixed_product_tensor_of_is_sal}.
 \end{remark}
 
 \begin{definition}[Cyclic edge-weight tensor]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_bond_products.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_bond_products.tex
@@ -1277,6 +1277,7 @@ commutativity is therefore the local identity
 \begin{theorem}[$\eta$-local structure from a positive physical-sector factorization]
     \label{thm:mpdo_eta_local_structure_of_positive_physical_sector_factorization}
     \lean{MPOTensor.PhysicalSectorFactorization.etaLocalStructureData}
+    \lean{MPOTensor.PhysicalSectorFactorization.fixedProductTensorData}
     \leanok
     \uses{thm:mpdo_exact_physical_sector_bond_product,
       thm:mpdo_positive_translation_invariant_bond_data,
@@ -1288,9 +1289,11 @@ commutativity is therefore the local identity
     \[
       \rho_N=B_0B_1\cdots B_{N-1}.
     \]
-    Thus the positive normalization scalar may be chosen to be $1$. This is
-    Proposition~C.8 conditional on the coherently positive physical-sector
-    factorization that the source derives from SAL.
+    If the virtual dimension of $K$ is positive, then $K$ itself is a fixed
+    tensor representation of this product family, with the same virtual
+    dimension. Thus the positive normalization scalar may be chosen to be
+    $1$. This is Proposition~C.8 conditional on the coherently positive
+    physical-sector factorization that the source derives from SAL.
 \end{theorem}
 
 \begin{proof}
@@ -1319,4 +1322,36 @@ commutativity is therefore the local identity
     Theorem~\ref{thm:mpdo_eta_coherent_positive_choice} supplies the positive
     physical-sector factorization. Apply
     Theorem~\ref{thm:mpdo_eta_local_structure_of_positive_physical_sector_factorization}.
+\end{proof}
+
+\begin{corollary}[Normal representative for the SAL-selected bond]%
+    \label{cor:mpdo_normal_fixed_product_tensor_of_is_sal}
+    \lean{MPOTensor.exists_normal_fixedProductTensorData_of_isSAL}
+    \leanok
+    \uses{def:mpdo_fixed_bond_product_tensor,
+      def:mpdo_physical_sector_factorization, def:nt_cpsv}
+    Let $K$ be injective and satisfy SAL, and suppose that its doubled-index
+    matrix-product tensor is normal. There is a positive physical-sector
+    factorization whose selected two-site bond $B$ has $K$ itself as a normal
+    fixed tensor representation. Its virtual dimension is the virtual
+    dimension of $K$, and for every $N\geq2$,
+    \[
+      \rho_N(K)=B_0B_1\cdots B_{N-1}.
+    \]
+    In particular, the scalar is one. This is an existential statement about
+    the bond selected in the proof of Proposition~C.8; it does not assert
+    uniqueness or normal rescalability for an arbitrary proportional
+    commuting-bond presentation.
+\end{corollary}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_exact_physical_sector_bond_product,
+      thm:mpdo_eta_coherent_positive_choice}
+    SAL implies that the virtual dimension is positive. The positive
+    physical-sector factorization is supplied by
+    Theorem~\ref{thm:mpdo_eta_coherent_positive_choice}. For its selected
+    bond, use $K$ as the fixed tensor. The exact product identity is
+    Theorem~\ref{thm:mpdo_exact_physical_sector_bond_product}, and normality
+    is the given hypothesis on the doubled-index tensor.
 \end{proof}

--- a/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
+++ b/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
@@ -254,13 +254,25 @@ $a^2=2$ and $a^3=2$.  Thus an arbitrary fixed bond does not carry
 original coordinates.  Equation \emph{sigmaNK2} gives that scalar form only
 after the one-site unitary coordinate change.
 
-The constructed tensor is not yet known to become normal after one positive
-rescaling.  Obtaining such a representative requires a normal-block
-canonical-form argument that rules out additional canonical summands; a
-general BNT direct sum does not supply a single normal block.
+An arbitrary tensor representing the products need not become normal after one
+positive rescaling.  Indeed, adjoining a zero virtual direct-sum block changes
+neither the closed operator at any positive length nor the product identity,
+but no nonzero rescaling removes that invariant summand.  Proposition
+\emph{3to4} does not assert normality or uniqueness for such an arbitrary
+representation.
 
-The normal-representative and geometric-scalar questions are not independent.
-The theorem
+For the bond selected in the SAL proof, no canonical-form reduction is needed.
+The source physical-sector factorization gives the coefficient-one identity
+directly, so the original source tensor itself represents the bond product.
+This is
+\leanid{MPOTensor.PhysicalSectorFactorization.fixedProductTensorData}.  Under
+the normal single-block hypothesis, its normality and the exact all-length
+identity are recorded by
+\leanid{MPOTensor.exists_normal_fixedProductTensorData_of_isSAL}.  Thus the
+source-selected presentation has rescaling $s=1$.
+
+For a different proportional commuting-bond presentation, the conditional
+theorem
 \leanid{MPOTensor.EtaLocalStructureData.%
 mpo_eq_positive_power_product_of_normal_smul}
 shows that if $sC$ is normal for one $s>0$, then
@@ -271,11 +283,11 @@ shows that if $sC$ is normal for one $s>0$, then
 First, the normal-tensor fundamental theorem gives a possible unit phase
 $\zeta^N$.  The self-overlap of the normal source tends to one, so the fixed
 product is nonzero at two sufficiently large consecutive lengths.  The
-positive realization constants at those lengths force $\zeta=1$.  Thus any
-solution of the remaining positive normal-rescaling problem simultaneously
-proves the law $c_N=s^N$ and permits its absorption into one local
-normalization.  This joint remaining problem is tracked in \ghissue{4271};
-\ghissue{4253} records the same dependency from the scalar-law side.
+positive realization constants at those lengths force $\zeta=1$.  This is a
+valid strengthening for a presentation already known to have a normal
+rescaling.  The existence of such a rescaling for every proportional
+commuting-bond presentation is not claimed in Appendix~C.2 and is not needed
+for the source-selected SAL-to-commuting-form implication.
 
 The scaled identity uses only the fixed commuting bond and its positive
 realization scalar.  It does not assert zero correlation length, rank-one trace
@@ -349,15 +361,6 @@ restriction that isolates only its final entropy-theoretic step.
 The gap can be removed in the following stages.
 
 \begin{enumerate}
-\item Prove that the exact fixed-product tensor has a single normal
-representative after one positive rescaling, or identify the weakest faithful
-replacement if canonical multiplicities cannot be removed.  The theorem
-\leanid{MPOTensor.EtaLocalStructureData.%
-mpo_eq_positive_power_product_of_normal_smul}
-then gives the positive geometric scalar law and its absorption automatically.
-The counterexample above shows that generic proportional commuting-bond data
-without the normal single-block input cannot supply this conclusion.  This
-joint normalization problem is tracked in \ghissue{4271} and \ghissue{4253}.
 \item Find a source-faithful property of the actual inverse-map neighboring
 family which excludes the nilpotent zero-eigenspace, or
 replace the printed line-1613 argument by a direct Markov decomposition which


### PR DESCRIPTION
## Motivation

Issue #4271 asked for a normal matrix-product representative of the fixed
commuting-bond product used in Appendix C.2 of arXiv:1606.00608. A source audit
shows that a canonical-form reduction of an arbitrary representation is neither
needed nor valid in this generality: adjoining an all-zero virtual summand leaves
all positive-length closed operators unchanged, but no nonzero scalar rescaling
removes that summand.

The source instead selects its bond from the physical-sector factorization of
the original SAL tensor. In `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines
1435--1450 construct the neighboring operators from the tensor, while lines
1581--1593 give the coefficient-one product identity. Thus the original tensor
itself is the required representative, with scalar one.

## Description

- construct `PhysicalSectorFactorization.fixedProductTensorData` with the
  original tensor and its original virtual dimension;
- prove `MPOTensor.exists_normal_fixedProductTensorData_of_isSAL`, using the
  positive physical-sector factorization supplied by SAL and the given
  normality of the doubled-index tensor;
- record explicitly that this is an existential statement for the
  source-selected bond, not a uniqueness or rescaling theorem for an arbitrary
  proportional presentation;
- align the blueprint and the paper-gap note with this distinction.

No proof-integrity exception is introduced.

## Testing

- `lake env lean TNLean/MPS/MPDO/PhysicalSectorNormalProductRepresentative.lean`
- `lake env lean TNLean/MPS/MPDO/FixedBondProductTensor.lean`
- `lake build TNLean.MPS.MPDO.PhysicalSectorNormalProductRepresentative`
- `lake env lean TNLean.lean -o .lake/build/lib/lean/TNLean.olean -i .lake/build/lib/lean/TNLean.ilean`
- `cd blueprint && leanblueprint checkdecls`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

An initial full `lake build TNLean` completed 9510 of 9583 jobs and then stopped
because the temporary worktree ran out of disk space while writing unrelated
PEPS and periodic-MPS object files. No changed source file failed. The targeted
build, public root-import check, and blueprint declaration check above all pass;
the remote full build remains the authoritative complete check.

Closes #4271.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal additions are small, documentation-heavy, and reuse existing SAL factorization and product identities; no changes to auth, runtime, or critical infrastructure.
> 
> **Overview**
> Closes the **#4271** reading of Proposition C.8 by proving that the **SAL-selected** commuting bond is represented by the **original MPO tensor** with scalar **one**, not by a generic canonical-form rescaling of an arbitrary matrix-product presentation.
> 
> **Lean:** Adds `PhysicalSectorFactorization.fixedProductTensorData` (tensor `K`, bond dim `D`, product identity from `mpo_eq_product_physicalBond`) and `exists_normal_fixedProductTensorData_of_isSAL` (positive physical-sector factorization from SAL + given doubled-index normality). Wires the module into `TNLean.lean`. **`FixedBondProductTensor`** docstrings now state that an arbitrary `FixedProductTensorData` may carry an **all-zero virtual summand** that no positive rescaling removes, and that the conditional `mpo_eq_positive_power_product_of_normal_smul` hypotheses are **false** for such presentations—not claimed for every proportional bond.
> 
> **Blueprint / gaps:** New corollary `cor:mpdo_normal_fixed_product_tensor_of_is_sal`; η-local structure theorem notes `K` as fixed tensor when virtual dimension is positive. Remark reframed from “normal-block scalar law” to **source-selected vs arbitrary** presentations. **`cpsv16_commuting_form_to_sal.tex`** documents the forward construction and demotes the “prove normal rescaling for every presentation” elimination step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4a119e1288a5cc37390e8fcc6a70fd3f9603539. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->