### PR TITLE
feat(MPS/MPDO): prove source-ZCL marginal stability

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -440,6 +440,7 @@ import TNLean.MPS.MPDO.VerticalBNT
 import TNLean.MPS.MPDO.RetainedClass
 import TNLean.MPS.MPDO.VerticalBNTConstruction
 import TNLean.MPS.MPDO.SectorTrace
+import TNLean.MPS.MPDO.SourceZCLMarginal
 import TNLean.MPS.MPDO.ReflectedMarkedChain
 import TNLean.MPS.MPDO.FigureEightPairwise
 import TNLean.MPS.MPDO.GroupedFigure8

--- a/TNLean/MPS/MPDO/SourceZCLMarginal.lean
+++ b/TNLean/MPS/MPDO/SourceZCLMarginal.lean
@@ -1,0 +1,113 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.MutualInfoMonotone
+import TNLean.MPS.MPDO.SectorTrace
+
+/-!
+# Marginal stability from source zero correlation length
+
+This file isolates the finite-chain consequence of source zero correlation
+length used in the converse commuting-form argument of Appendix C.2 of
+arXiv:1606.00608.  If the physical-trace transfer satisfies
+`E * E = lambda * E`, then tracing two sites from a chain of length `N + 2`
+gives the same normalized `N`-site marginal as tracing one site from a chain
+of length `N + 1`.
+
+This statement does not assert the rank-one trace factorization printed later
+at source line 1613 and does not construct a quantum Markov decomposition.
+
+## Main results
+
+* `MPOTensor.reducedBlockState_apply_eq_trace_evalWord_mul_verticalLoop_pow`
+* `MPOTensor.reducedBlockState_succ_succ_eq_succ_of_isSourceZCL`
+
+## Reference
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, line 1613
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- A contiguous reduced-state entry is the normalized trace of the retained
+word followed by the appropriate power of the physical-trace transfer.
+
+Source: arXiv:1606.00608, Appendix C.2, line 1613. -/
+theorem reducedBlockState_apply_eq_trace_evalWord_mul_verticalLoop_pow
+    (M : MPOTensor d D) {N L : ℕ} (hL : L ≤ N)
+    (u v : Fin L → Fin d) :
+    M.reducedBlockState N L hL u v =
+      (mpo M N).trace⁻¹ *
+        Matrix.trace
+          (M.evalWord (List.ofFn u) (List.ofFn v) * M.verticalLoop ^ (N - L)) := by
+  rw [reducedBlockState_eq_sum]
+  simp only [normalizedMPO, Matrix.smul_apply, smul_eq_mul, mpo_apply, mpoMatrixEntry]
+  rw [← Finset.mul_sum]
+  congr 1
+  have hwords (a : Fin L → Fin d) (w : Fin (N - L) → Fin d) :
+      List.ofFn
+          (Fin.append a w ∘ Fin.cast (show N = L + (N - L) by omega)) =
+        List.ofFn a ++ List.ofFn w := by
+    rw [← List.ofFn_fin_append]
+    exact (List.ofFn_congr (Nat.add_sub_of_le hL) (Fin.append a w)).symm
+  simp_rw [hwords]
+  have heval (w : Fin (N - L) → Fin d) :
+      M.evalWord (List.ofFn u ++ List.ofFn w) (List.ofFn v ++ List.ofFn w) =
+        M.evalWord (List.ofFn u) (List.ofFn v) *
+          M.evalWord (List.ofFn w) (List.ofFn w) := by
+    exact M.evalWord_append _ _ _ _ (by simp)
+  simp_rw [heval]
+  rw [← Matrix.trace_sum]
+  congr 1
+  rw [← Finset.mul_sum, M.sum_evalWord_diag_eq_verticalLoop_pow]
+
+/-- Under source zero correlation length, tracing two sites from length
+`N + 2` gives the same normalized `N`-site marginal as tracing one site from
+length `N + 1`.
+
+This is the valid ZCL replacement at the beginning of the argument at source
+line 1613.  It does not imply that the neighboring trace matrix has rank one.
+
+Source: arXiv:1606.00608, Appendix C.2, line 1613. -/
+theorem reducedBlockState_succ_succ_eq_succ_of_isSourceZCL
+    (M : MPOTensor d D) (hZCL : IsSourceZCL M) (N : ℕ) :
+    M.reducedBlockState (N + 2) N (by omega) =
+      M.reducedBlockState (N + 1) N (by omega) := by
+  ext u v
+  rw [reducedBlockState_apply_eq_trace_evalWord_mul_verticalLoop_pow,
+    reducedBlockState_apply_eq_trace_evalWord_mul_verticalLoop_pow]
+  rw [show N + 2 - N = 2 by omega, show N + 1 - N = 1 by omega, pow_one]
+  obtain ⟨hE0, lam, hlam, hsq⟩ := hZCL
+  have hsq' : M.verticalLoop ^ 2 = (lam : ℂ) • M.verticalLoop := by
+    rw [pow_two, verticalLoop_eq_physTraceTransfer, hsq]
+  have hnum :
+      Matrix.trace
+          (M.evalWord (List.ofFn u) (List.ofFn v) * M.verticalLoop ^ 2) =
+        (lam : ℂ) *
+          Matrix.trace (M.evalWord (List.ofFn u) (List.ofFn v) * M.verticalLoop) := by
+    rw [hsq', Matrix.mul_smul, Matrix.trace_smul, smul_eq_mul]
+  have hsplit : M.verticalLoop ^ (N + 2) =
+      M.verticalLoop ^ N * M.verticalLoop ^ 2 := by
+    rw [pow_add]
+  have hpow : M.verticalLoop ^ (N + 2) =
+      (lam : ℂ) • M.verticalLoop ^ (N + 1) := by
+    rw [hsplit, hsq', Matrix.mul_smul, ← pow_succ]
+  have htrace : (mpo M (N + 2)).trace =
+      (lam : ℂ) * (mpo M (N + 1)).trace := by
+    rw [trace_mpo_eq_trace_verticalLoop_pow,
+      trace_mpo_eq_trace_verticalLoop_pow, hpow, Matrix.trace_smul, smul_eq_mul]
+  have htr : (mpo M (N + 1)).trace ≠ 0 := by
+    exact trace_mpo_ne_zero_of_isSourceZCL M ⟨hE0, lam, hlam, hsq⟩ (by omega)
+  have hlamC : (lam : ℂ) ≠ 0 := by
+    exact_mod_cast ne_of_gt hlam
+  rw [htrace, hnum]
+  field_simp
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -622,6 +622,38 @@
     $\zeta=1$.
 \end{proof}
 
+\begin{lemma}[Marginal stability under source zero correlation length]
+    \label{lem:mpdo_source_zcl_marginal_stability}
+    \lean{MPOTensor.%
+      reducedBlockState_apply_eq_trace_evalWord_mul_verticalLoop_pow}
+    \lean{MPOTensor.%
+      reducedBlockState_succ_succ_eq_succ_of_isSourceZCL}
+    \leanok
+    \uses{def:mpo_source_zcl, lem:mpdo_trace_loop_chain}
+    Let $M$ have source zero correlation length.  For every $N\geq0$, the
+    normalized $N$-site marginal obtained by tracing two sites from
+    $\sigma^{(N+2)}(M)$ equals the normalized $N$-site marginal obtained by
+    tracing one site from $\sigma^{(N+1)}(M)$.
+
+    This is the first replacement at
+    \cite[Appendix~C.2, line~1613]{Cirac2016MPDO_arXiv}.  It does not imply
+    the rank-one trace factorization asserted later on that line.
+\end{lemma}
+
+\begin{proof}\leanok
+    Write $E=\mathcal T_M$ and choose $\lambda>0$ such that
+    $E^2=\lambda E$.  For physical configurations $u,v$ of length $N$, the
+    two marginal matrix elements are
+    \[
+        \frac{\tr(M^{u,v}E^2)}{\tr(E^{N+2})}
+        \quad\text{and}\quad
+        \frac{\tr(M^{u,v}E)}{\tr(E^{N+1})}.
+    \]
+    The numerator and denominator on the left are respectively $\lambda$
+    times those on the right, and source zero correlation length makes the
+    denominator on the right nonzero.
+\end{proof}
+
 \begin{definition}[Rank-one trace factorization for neighboring operators]
     \label{def:mpdo_generic_eta_rank_one_trace_factorization}
     \lean{Matrix.EtaRankOneTraceFactorization}

--- a/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
+++ b/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
@@ -319,6 +319,24 @@ It does not prove the ZCL replacement of the one-site marginal, derive the
 rank-one factorization, construct a quantum Markov decomposition, or prove
 SAL.
 
+The ZCL replacement itself is now formalized.  If $E$ is the physical-trace
+transfer and $E^2=\lambda E$ with $\lambda>0$, then for every $N\geq0$ the
+normalized $N$-site marginal obtained by tracing two sites from the
+length-$(N+2)$ chain equals the one obtained by tracing one site from the
+length-$(N+1)$ chain.  Entrywise, the two expressions are
+\[
+  \frac{\operatorname{tr}(M^{u,v}E^2)}
+       {\operatorname{tr}(E^{N+2})}
+  \quad\text{and}\quad
+  \frac{\operatorname{tr}(M^{u,v}E)}
+       {\operatorname{tr}(E^{N+1})},
+\]
+and the numerator and denominator of the first are both multiplied by
+$\lambda$.  This is
+\leanid{MPOTensor.reducedBlockState_succ_succ_eq_succ_of_isSourceZCL}.
+It proves the first sentence of the source's line~1613 argument, but it does
+not separate the two boundary sector sums.
+
 There is a separate obstruction at source line~1613.  The phrase ``arguing as
 in Lemmas \emph{propSN} and \emph{SALZCL}'' does not show that source ZCL alone
 gives
@@ -367,6 +385,15 @@ replace the printed line-1613 argument by a direct Markov decomposition which
 does not require the rank-one trace matrix.  Source ZCL alone must not be
 presented as giving the factorization; the inverse-map and finite-chain audits
 in \ghissue{3593} do not supply it.
+One possible corrected route is to use the square of the trace matrix.  If a
+primitive nonnegative trace matrix $T$ satisfies $T^2=T^3$, then all powers
+from the second onward equal $T^2$, so $T^2$ is an idempotent Perron
+projection of rank one.  This is compatible with the four-sector example,
+where $T$ is not rank one but $T^2$ is.  What remains absent is a derivation of
+primitivity for the Beigi trace matrix from the normal source block and its
+fixed proportional commuting-bond presentation; the existing primitivity
+theorem starts from the SAL-derived inverse-map factorization and is therefore
+circular at this call site.
 \item Trace the fourth region, construct the quantum Markov decomposition at
 each admissible cut, and apply the all-cut Markov theorem.  Only then may the
 source proposition receive a formal declaration and a


### PR DESCRIPTION
### Motivation

CPSV16 Appendix C.2, line 1613 begins the commuting-form-to-SAL argument by using zero correlation length to replace a two-site partial trace by a one-site partial trace. This is a valid consequence of the source condition
\(E^2=\lambda E\), independently of the later rank-one factorization asserted on the same line.

The printed rank-one conclusion does not follow from source ZCL alone, as recorded in `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. This pull request therefore isolates only the valid marginal identity and does not claim Proposition C.8 (`4to2`).

### Description

- Proves an entrywise formula for a contiguous normalized marginal:
  \[
  \rho^{(N)}_{L}(u,v)
  = \operatorname{tr}(\rho^{(N)})^{-1}
    \operatorname{tr}\!\left(M^{u,v}E^{N-L}\right).
  \]
- Proves that source ZCL implies, for every \(N\geq0\),
  \[
  \operatorname{tr}_{N+1,N+2}\sigma^{(N+2)}
  = \operatorname{tr}_{N+1}\sigma^{(N+1)}.
  \]
  The numerator and denominator on the left both acquire the factor \(\lambda\).
- Adds the corresponding blueprint lemma and updates the paper-gap note with the remaining primitivity/Markov obstruction.
- Leaves #4175 open: deriving SAL from the fixed commuting-bond presentation still requires a non-circular primitivity theorem for the Beigi trace matrix, or a direct Markov decomposition.

### Testing

- `lake env lean -DwarningAsError=true TNLean/MPS/MPDO/SourceZCLMarginal.lean`
- `lake build TNLean.MPS.MPDO.SourceZCLMarginal`
- `lake build TNLean` (9586 jobs)
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` (chapter 21: 65/65)
- `lake exe checkdecls blueprint/lean_decls`
- No `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast` occurs in the new Lean file.

Addresses #4175.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds proved Lean theorems and documentation only; no changes to auth, runtime, or critical infrastructure. Scope is intentionally narrow relative to the full commuting-form-to-SAL argument.
> 
> **Overview**
> Formalizes the **valid** first step of CPSV16 Appendix C.2 line 1613: under **source zero correlation length** (`E² = λE`), normalized **N**-site marginals from tracing **two** sites on a length **(N+2)** chain match those from tracing **one** site on length **(N+1)**.
> 
> Adds `TNLean/MPS/MPDO/SourceZCLMarginal.lean` with an entrywise trace formula for `reducedBlockState` via `evalWord` and powers of `verticalLoop`, and `reducedBlockState_succ_succ_eq_succ_of_isSourceZCL`, which cancels the common **λ** factor in numerator and denominator. Registers the module in `TNLean.lean`, adds blueprint Lemma **marginal stability under source ZCL**, and updates `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex` to mark this ZCL replacement as proved while **not** claiming rank-one trace factorization, SAL, or Proposition **4to2** (notes a possible **T²** idempotent route and remaining primitivity circularity).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d333f128f8cb869e1eab72d1fc98d78718c8c4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

