### PR TITLE
refactor(MPS/MPDO): reuse fixed product proof

### DIFF
--- a/TNLean/MPS/MPDO/PhysicalSectorNormalProductRepresentative.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorNormalProductRepresentative.lean
@@ -87,12 +87,10 @@ theorem exists_normal_fixedProductTensorData_of_isSAL
           mpo K N =
             ((F.translationInvariantBondData hη).toCommutingFormData hN).product := by
   obtain ⟨F, hη⟩ := exists_positive_physicalSectorFactorization_of_isSAL K hK hSAL
+  let repr := F.fixedProductTensorData hη (bondDim_pos_of_isSAL K hSAL)
   refine ⟨F, hη, ?_, ?_⟩
   · exact hNormal
   · intro N hN
-    change mpo K N =
-      (List.ofFn fun i : Fin N ↦
-        embedLocalOperator (d := d) 2 N hN i F.physicalBond).prod
-    exact F.mpo_eq_product_physicalBond hN
+    exact repr.mpo_eq_product N hN
 
 end MPOTensor


### PR DESCRIPTION
## Summary

- bind the source-selected fixed product representation once in the SAL corollary
- reuse its `mpo_eq_product` field for the coefficient-free identity
- remove the duplicated unfolding and direct appeal to the physical-bond theorem

## Context

This is the focused post-merge follow-up to #4307 requested by unresolved review thread `PRRT_kwDORK8b986SCr2L`. It does not change the theorem statement or mathematical scope.

## Validation

- `lake env lean TNLean/MPS/MPDO/PhysicalSectorNormalProductRepresentative.lean`
- changed-file proof-integrity scan
- line-length scan
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local proof refactor in one Lean file with no API or statement changes.
> 
> **Overview**
> **Proof-only cleanup** in `exists_normal_fixedProductTensorData_of_isSAL`: the proof now binds `repr := F.fixedProductTensorData …` once and closes the length-`N` identity via `repr.mpo_eq_product` instead of re-unfolding `mpo K N` and calling `F.mpo_eq_product_physicalBond` directly.
> 
> The theorem statement and mathematical content are unchanged; this reuses the product identity already packaged on `fixedProductTensorData`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4f039c5a9a3817138ef221f1dd4750cec19b080. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->