### PR TITLE
feat(MPS/MPDO): complete projectors under copy-independent weights

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -479,6 +479,7 @@ import TNLean.MPS.MPDO.BNTThreeSiteReducedClosure
 import TNLean.MPS.MPDO.BNTSourceSectorProjectors
 import TNLean.MPS.MPDO.SitewisePhysicalMatrix
 import TNLean.MPS.MPDO.BNTProjectorSelection
+import TNLean.MPS.MPDO.BNTSeparatingProjectors
 import TNLean.MPS.MPDO.PhysicalSupportRestriction
 import TNLean.MPS.MPDO.PhysicalSupportSALTransport
 import TNLean.MPS.MPDO.PhysicalSupportBondTransport

--- a/TNLean/MPS/MPDO/BNTSeparatingProjectors.lean
+++ b/TNLean/MPS/MPDO/BNTSeparatingProjectors.lean
@@ -243,7 +243,8 @@ There is no independent closing-matrix hypothesis.
 **Scope restriction (copy-independent weights):** This theorem takes copy
 independence as the explicit hypothesis `hWeight`. The source obtains it from
 ZCL before the separating-projector lemma. A source-faithful standing-context
-wrapper must instead derive `hWeight` from the ZCL and canonical-form data; see
+formulation must instead derive `hWeight` from the ZCL and canonical-form data;
+see
 `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
 
 **Local fix (inactive sectors):** The source discards zero-weight Markov

--- a/TNLean/MPS/MPDO/BNTSeparatingProjectors.lean
+++ b/TNLean/MPS/MPDO/BNTSeparatingProjectors.lean
@@ -23,8 +23,8 @@ retains them and assigns them to one BNT label, as documented in
 
 * `completedBntSectorProjection`: the BNT projector after assigning every
   zero-weight Markov summand to a distinguished BNT label.
-* `exists_bntSeparatingProjectors_of_sameMPV₂Pos_isSAL`: the separating
-  projectors selected by SAL for a simple tensor in biCF.
+* `exists_bntSeparatingProjectors_of_sameMPV₂Pos_isSAL_of_weight_copy_independent`:
+  the separating projectors selected by SAL after copy independence is supplied.
 
 ## References
 
@@ -85,7 +85,9 @@ noncomputable def completedBntSectorProjection
       hη.sectorProjection k
     else 0
 
-/-- Each completed BNT-sector matrix is an orthogonal projection. -/
+/-- Each completed BNT-sector matrix is an orthogonal projection.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `Pis`, lines 1680--1712. -/
 theorem completedBntSectorProjection_isOrthogonal
     {K : (s : Fin g) → MPOTensor d (dim s)}
     {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
@@ -111,7 +113,9 @@ theorem completedBntSectorProjection_isOrthogonal
       · simp [hl]
     · simp [hk]
 
-/-- Completed projectors with distinct BNT labels are mutually orthogonal. -/
+/-- Completed projectors with distinct BNT labels are mutually orthogonal.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `Pis`, lines 1680--1712. -/
 theorem completedBntSectorProjection_mul_eq_zero
     {K : (s : Fin g) → MPOTensor d (dim s)}
     {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
@@ -216,8 +220,8 @@ theorem completedBntSectorProjection_mul_physicalSlice_mul_eq_zero
     · simp [hlt]
   · simp [hks]
 
-/-- A simple tensor in biCF which satisfies SAL has separating projectors for
-its BNT representatives.
+/-- Under copy-independent BNT weights, a simple tensor in biCF which satisfies
+SAL has separating projectors for its BNT representatives.
 
 More precisely, there is a distinguished BNT label $s_0$ and a family of
 orthogonal projectors $P_s$ which resolves the physical identity. Whenever
@@ -236,6 +240,12 @@ simplicity, copy independence is the conclusion immediately preceding the
 projector lemma, and SAL supplies the four-site quantum-Markov decomposition.
 There is no independent closing-matrix hypothesis.
 
+**Scope restriction (copy-independent weights):** This theorem takes copy
+independence as the explicit hypothesis `hWeight`. The source obtains it from
+ZCL before the separating-projector lemma. A source-faithful standing-context
+wrapper must instead derive `hWeight` from the ZCL and canonical-form data; see
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+
 **Local fix (inactive sectors):** The source discards zero-weight Markov
 summands. Here they are assigned to the distinguished label $s_0$, which
 restores the ambient identity resolution without changing any physical slice;
@@ -243,7 +253,7 @@ see `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
 
 Source: arXiv:1606.00608, Appendix C.2, equations `CFK`, `biCFK`, `Pis`, and
 `PjKiPj`, lines 1626--1737. -/
-theorem exists_bntSeparatingProjectors_of_sameMPV₂Pos_isSAL
+theorem exists_bntSeparatingProjectors_of_sameMPV₂Pos_isSAL_of_weight_copy_independent
     {D : ℕ} (M : MPOTensor d D)
     (S : MPSTensor.SectorDecomposition (d * d))
     (hM : MPSTensor.SameMPV₂Pos M.toMPSTensor S.toTensor)

--- a/TNLean/MPS/MPDO/BNTSeparatingProjectors.lean
+++ b/TNLean/MPS/MPDO/BNTSeparatingProjectors.lean
@@ -1,0 +1,288 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.BNTProjectorSelection
+
+/-!
+# Separating projectors for a simple tensor satisfying the strong area law
+
+For the four-site quantum-Markov decomposition, the BNT projectors resolve the
+positive-weight Markov support. The remaining zero-weight Markov summands
+annihilate every physical slice. Assigning them to one BNT label therefore
+gives orthogonal projectors which resolve the full physical identity and retain
+the local separation relation.
+
+## Main declarations
+
+* `completedBntSectorProjection`: the BNT projector after assigning every
+  zero-weight Markov summand to a distinguished BNT label.
+* `exists_bntSeparatingProjectors_of_sameMPV₂Pos_isSAL`: the separating
+  projectors selected by SAL for a simple tensor in biCF.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, equations `Pis` and `PjKiPj`, lines 1680--1737
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPOTensor
+
+variable {d g : ℕ} {dim : Fin g → ℕ}
+
+/-- The BNT label of a Markov sector, with every zero-weight sector assigned
+to a fixed label.
+
+The source removes zero-weight Markov summands before defining the sets
+$S_j$. Retaining the summands and assigning them to one label gives the same
+separation relation on every physical slice.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `QkKjs` and `Pis`, lines
+1698--1737. -/
+noncomputable def completedBntSectorLabel
+    {K : (s : Fin g) → MPOTensor d (dim s)}
+    {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse K C)
+    (hρ : IsThreeSiteFamilyClosure K R ρ) (hη : EtaStructure ρ)
+    (hR : ∀ s : Fin g, R s ≠ 0) (s₀ : Fin g) (k : Fin hη.m) : Fin g :=
+  if hk : hη.p k ≠ 0 then
+    bntSectorLabel hC hρ hη hR ⟨k, hk⟩
+  else s₀
+
+/-- The projector obtained by summing all Markov-sector projections carrying
+one completed BNT label.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `Pis`, lines 1680--1712. -/
+noncomputable def completedBntSectorProjection
+    {K : (s : Fin g) → MPOTensor d (dim s)}
+    {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse K C)
+    (hρ : IsThreeSiteFamilyClosure K R ρ) (hη : EtaStructure ρ)
+    (hR : ∀ s : Fin g, R s ≠ 0) (s₀ s : Fin g) :
+    Matrix (Fin d) (Fin d) ℂ :=
+  ∑ k : Fin hη.m,
+    if completedBntSectorLabel hC hρ hη hR s₀ k = s then
+      hη.sectorProjection k
+    else 0
+
+/-- Each completed BNT-sector matrix is an orthogonal projection. -/
+theorem completedBntSectorProjection_isOrthogonal
+    {K : (s : Fin g) → MPOTensor d (dim s)}
+    {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse K C)
+    (hρ : IsThreeSiteFamilyClosure K R ρ) (hη : EtaStructure ρ)
+    (hR : ∀ s : Fin g, R s ≠ 0) (s₀ s : Fin g) :
+    IsOrthogonalProjection
+      (completedBntSectorProjection hC hρ hη hR s₀ s) := by
+  classical
+  apply isOrthogonalProjection_sum_of_pairwise_mul_eq_zero
+  · intro k
+    by_cases hk : completedBntSectorLabel hC hρ hη hR s₀ k = s
+    · simpa [completedBntSectorProjection, hk] using
+        hη.sectorProjection_isOrthogonal k
+    · simp [hk, IsOrthogonalProjection]
+  · intro k l hkl
+    by_cases hk : completedBntSectorLabel hC hρ hη hR s₀ k = s
+    · by_cases hl : completedBntSectorLabel hC hρ hη hR s₀ l = s
+      · simp only [hk, hl, if_pos]
+        exact hη.sectorProjection_mul_eq_zero hkl
+      · simp [hl]
+    · simp [hk]
+
+/-- Completed projectors with distinct BNT labels are mutually orthogonal. -/
+theorem completedBntSectorProjection_mul_eq_zero
+    {K : (s : Fin g) → MPOTensor d (dim s)}
+    {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse K C)
+    (hρ : IsThreeSiteFamilyClosure K R ρ) (hη : EtaStructure ρ)
+    (hR : ∀ s : Fin g, R s ≠ 0) (s₀ : Fin g)
+    {s t : Fin g} (hst : s ≠ t) :
+    completedBntSectorProjection hC hρ hη hR s₀ s *
+        completedBntSectorProjection hC hρ hη hR s₀ t = 0 := by
+  classical
+  rw [completedBntSectorProjection, completedBntSectorProjection, Finset.sum_mul]
+  apply Finset.sum_eq_zero
+  intro k _
+  rw [Finset.mul_sum]
+  apply Finset.sum_eq_zero
+  intro l _
+  by_cases hk : completedBntSectorLabel hC hρ hη hR s₀ k = s
+  · by_cases hl : completedBntSectorLabel hC hρ hη hR s₀ l = t
+    · simp only [hk, hl, if_pos]
+      apply hη.sectorProjection_mul_eq_zero
+      intro hkl
+      apply hst
+      rw [← hk, ← hl, hkl]
+    · simp [hl]
+  · simp [hk]
+
+/-- The completed BNT-sector projectors resolve the full physical identity.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `Pis`, lines 1680--1696. -/
+theorem sum_completedBntSectorProjection
+    {K : (s : Fin g) → MPOTensor d (dim s)}
+    {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse K C)
+    (hρ : IsThreeSiteFamilyClosure K R ρ) (hη : EtaStructure ρ)
+    (hR : ∀ s : Fin g, R s ≠ 0) (s₀ : Fin g) :
+    ∑ s : Fin g, completedBntSectorProjection hC hρ hη hR s₀ s = 1 := by
+  classical
+  simp only [completedBntSectorProjection]
+  rw [Finset.sum_comm]
+  simpa using hη.sum_sectorProjection
+
+/-- The completed BNT projectors separate the physical slices of distinct
+normal representatives. Whenever $s\ne t$ or $i\ne s$,
+\[
+  P_s K_i^{\beta\alpha} P_t=0.
+\]
+
+Zero-weight Markov sectors are assigned to the distinguished label `s₀`.
+Their diagonal corners vanish for every physical slice, so this assignment
+does not change the separation relation.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `PjKiPj`, lines
+1680--1737. -/
+theorem completedBntSectorProjection_mul_physicalSlice_mul_eq_zero
+    {K : (s : Fin g) → MPOTensor d (dim s)}
+    {R : (s : Fin g) → Matrix (Fin (dim s)) (Fin (dim s)) ℂ}
+    {ρ : Matrix (Fin d × Fin d × Fin d) (Fin d × Fin d × Fin d) ℂ}
+    {C : Matrix (MPSTensor.BlockEntryIndex dim) (Fin d × Fin d) ℂ}
+    (hC : MPSTensor.IsMPOBlockLeftInverse K C)
+    (hρ : IsThreeSiteFamilyClosure K R ρ) (hη : EtaStructure ρ)
+    (hR : ∀ s : Fin g, R s ≠ 0) (s₀ i s t : Fin g)
+    (hst : s ≠ t ∨ i ≠ s) (β α : Fin (dim i)) :
+    completedBntSectorProjection hC hρ hη hR s₀ s *
+        physicalSlice (K i) β α *
+          completedBntSectorProjection hC hρ hη hR s₀ t = 0 := by
+  classical
+  rw [completedBntSectorProjection, completedBntSectorProjection,
+    Finset.sum_mul, Finset.sum_mul]
+  apply Finset.sum_eq_zero
+  intro k _
+  rw [Finset.mul_sum]
+  apply Finset.sum_eq_zero
+  intro l _
+  by_cases hks : completedBntSectorLabel hC hρ hη hR s₀ k = s
+  · by_cases hlt : completedBntSectorLabel hC hρ hη hR s₀ l = t
+    · simp only [hks, hlt, if_pos]
+      by_cases hkl : k = l
+      · subst l
+        have hst_eq : s = t := hks.symm.trans hlt
+        have hi : i ≠ s := by
+          rcases hst with hst | hi
+          · exact False.elim (hst hst_eq)
+          · exact hi
+        by_cases hk : hη.p k ≠ 0
+        · have hlabel :
+              bntSectorLabel hC hρ hη hR ⟨k, hk⟩ = s := by
+            simpa [completedBntSectorLabel, hk] using hks
+          apply sectorProjection_mul_physicalSlice_mul_self_eq_zero_of_ne_label
+            hC hρ hη hR ⟨k, hk⟩ i
+          · intro hilabel
+            exact hi (hilabel.trans hlabel)
+        · exact
+            sectorProjection_mul_physicalSlice_mul_self_eq_zero_of_probability_eq_zero
+              hC hρ hη hR i β α k (not_ne_iff.mp hk)
+      · exact
+          sectorProjection_mul_physicalSlice_mul_sectorProjection_eq_zero_of_ne
+            hC hρ hη hR i β α hkl
+    · simp [hlt]
+  · simp [hks]
+
+/-- A simple tensor in biCF which satisfies SAL has separating projectors for
+its BNT representatives.
+
+More precisely, there is a distinguished BNT label $s_0$ and a family of
+orthogonal projectors $P_s$ which resolves the physical identity. Whenever
+$s\ne t$ or $i\ne s$,
+\[
+  P_s K_i^{\beta\alpha}P_t=0.
+\]
+The distinguished label exists because a BNT canonical form has a copy with
+unit-modulus weight. Every zero-weight Markov summand is assigned to this
+label. Such summands annihilate all physical slices, so the assignment restores
+$\sum_sP_s=\mathbf 1$ without changing the displayed relation.
+
+The hypotheses are the source context at the beginning of Case II: the BNT
+canonical form and simultaneous span express biCF, nonnilpotence expresses
+simplicity, copy independence is the conclusion immediately preceding the
+projector lemma, and SAL supplies the four-site quantum-Markov decomposition.
+There is no independent closing-matrix hypothesis.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `CFK`, `biCFK`, `Pis`, and
+`PjKiPj`, lines 1626--1737. -/
+theorem exists_bntSeparatingProjectors_of_sameMPV₂Pos_isSAL
+    {D : ℕ} (M : MPOTensor d D)
+    (S : MPSTensor.SectorDecomposition (d * d))
+    (hM : MPSTensor.SameMPV₂Pos M.toMPSTensor S.toTensor)
+    (hCF : MPSTensor.IsBNTCanonicalForm S)
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q')
+    (hnonNil : ∀ j,
+      ¬ IsNilpotent (doubledPhysTraceTransfer d (S.basis j)))
+    (hSpan : MPSTensor.WordTupleSpanTop S.basis 1)
+    (hSAL : IsSAL M) :
+    let ρ := Matrix.reindex (_root_.finThreeArrowEquiv (Fin d))
+      (_root_.finThreeArrowEquiv (Fin d))
+      (M.reducedBlockState 4 3 (by omega))
+    ∃ (C : Matrix (MPSTensor.BlockEntryIndex S.basisDim)
+        (Fin d × Fin d) ℂ),
+      ∃ hC : MPSTensor.IsMPOBlockLeftInverse
+          (fun j ↦ S.basisMPOTensor j) C,
+        ∃ hη : EtaStructure ρ,
+          let hρ : IsThreeSiteFamilyClosure
+              (fun j ↦ S.basisMPOTensor j)
+              (S.normalizedThreeSiteClosingMatrix M 1) ρ :=
+            (reducedBlockState_four_threeSiteFamilyClosure_nonzero_closing
+              M S hM hWeight hnonNil hSAL).1
+          let hR : ∀ j : Fin S.basisCount,
+              S.normalizedThreeSiteClosingMatrix M 1 j ≠ 0 :=
+            (reducedBlockState_four_threeSiteFamilyClosure_nonzero_closing
+              M S hM hWeight hnonNil hSAL).2
+          ∃ s₀ : Fin S.basisCount,
+            (∀ s, IsOrthogonalProjection
+              (completedBntSectorProjection hC hρ hη hR s₀ s)) ∧
+            (∀ s t, s ≠ t →
+              completedBntSectorProjection hC hρ hη hR s₀ s *
+                completedBntSectorProjection hC hρ hη hR s₀ t = 0) ∧
+            (∑ s, completedBntSectorProjection hC hρ hη hR s₀ s) = 1 ∧
+            ∀ (i s t : Fin S.basisCount), s ≠ t ∨ i ≠ s →
+              ∀ (β α : Fin (S.basisDim i)),
+                completedBntSectorProjection hC hρ hη hR s₀ s *
+                    physicalSlice (S.basisMPOTensor i) β α *
+                  completedBntSectorProjection hC hρ hη hR s₀ t = 0 := by
+  dsimp only
+  obtain ⟨s₀, _q₀, _hs₀⟩ := hCF.weight_unit_exists
+  obtain ⟨C, hC, hη, _hunique, _hproj, _horth, _hsum⟩ :=
+    exists_bntSectorProjectors_four_of_sameMPV₂Pos_isSAL
+      M S hM hWeight hnonNil hSpan hSAL
+  let hClosure :=
+    reducedBlockState_four_threeSiteFamilyClosure_nonzero_closing
+      M S hM hWeight hnonNil hSAL
+  let hρ := hClosure.1
+  let hR := hClosure.2
+  refine ⟨C, hC, hη, s₀, ?_, ?_, ?_, ?_⟩
+  · intro s
+    exact completedBntSectorProjection_isOrthogonal hC hρ hη hR s₀ s
+  · intro s t hst
+    exact completedBntSectorProjection_mul_eq_zero hC hρ hη hR s₀ hst
+  · exact sum_completedBntSectorProjection hC hρ hη hR s₀
+  · intro i s t hst β α
+    exact completedBntSectorProjection_mul_physicalSlice_mul_eq_zero
+      hC hρ hη hR s₀ i s t hst β α
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/BNTSeparatingProjectors.lean
+++ b/TNLean/MPS/MPDO/BNTSeparatingProjectors.lean
@@ -243,8 +243,8 @@ There is no independent closing-matrix hypothesis.
 **Scope restriction (copy-independent weights):** This theorem takes copy
 independence as the explicit hypothesis `hWeight`. The source obtains it from
 ZCL before the separating-projector lemma. A source-faithful standing-context
-formulation must instead derive `hWeight` from the ZCL hypothesis and the BNT
-canonical-form hypotheses; see
+formulation must instead derive `hWeight` from the source ZCL equation and the
+canonical-form gauge identity; see
 `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
 
 **Local fix (inactive sectors):** The source discards zero-weight Markov

--- a/TNLean/MPS/MPDO/BNTSeparatingProjectors.lean
+++ b/TNLean/MPS/MPDO/BNTSeparatingProjectors.lean
@@ -14,6 +14,11 @@ annihilate every physical slice. Assigning them to one BNT label therefore
 gives orthogonal projectors which resolve the full physical identity and retain
 the local separation relation.
 
+**Local fix (inactive sectors):** The source removes zero-weight Markov
+summands before defining the separating projectors. The formal decomposition
+retains them and assigns them to one BNT label, as documented in
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+
 ## Main declarations
 
 * `completedBntSectorProjection`: the BNT projector after assigning every
@@ -40,6 +45,10 @@ The source removes zero-weight Markov summands before defining the sets
 $S_j$. Retaining the summands and assigning them to one label gives the same
 separation relation on every physical slice.
 
+**Local fix (inactive sectors):** This total assignment replaces the source's
+implicit removal of zero-weight summands; see
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+
 Source: arXiv:1606.00608, Appendix C.2, equations `QkKjs` and `Pis`, lines
 1698--1737. -/
 noncomputable def completedBntSectorLabel
@@ -56,6 +65,10 @@ noncomputable def completedBntSectorLabel
 
 /-- The projector obtained by summing all Markov-sector projections carrying
 one completed BNT label.
+
+**Local fix (inactive sectors):** The completed label assigns the retained
+zero-weight summands to one BNT sector; see
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
 
 Source: arXiv:1606.00608, Appendix C.2, equation `Pis`, lines 1680--1712. -/
 noncomputable def completedBntSectorProjection
@@ -222,6 +235,11 @@ canonical form and simultaneous span express biCF, nonnilpotence expresses
 simplicity, copy independence is the conclusion immediately preceding the
 projector lemma, and SAL supplies the four-site quantum-Markov decomposition.
 There is no independent closing-matrix hypothesis.
+
+**Local fix (inactive sectors):** The source discards zero-weight Markov
+summands. Here they are assigned to the distinguished label $s_0$, which
+restores the ambient identity resolution without changing any physical slice;
+see `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
 
 Source: arXiv:1606.00608, Appendix C.2, equations `CFK`, `biCFK`, `Pis`, and
 `PjKiPj`, lines 1626--1737. -/

--- a/TNLean/MPS/MPDO/BNTSeparatingProjectors.lean
+++ b/TNLean/MPS/MPDO/BNTSeparatingProjectors.lean
@@ -243,8 +243,8 @@ There is no independent closing-matrix hypothesis.
 **Scope restriction (copy-independent weights):** This theorem takes copy
 independence as the explicit hypothesis `hWeight`. The source obtains it from
 ZCL before the separating-projector lemma. A source-faithful standing-context
-formulation must instead derive `hWeight` from the ZCL and canonical-form data;
-see
+formulation must instead derive `hWeight` from the ZCL hypothesis and the BNT
+canonical-form hypotheses; see
 `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
 
 **Local fix (inactive sectors):** The source discards zero-weight Markov

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
@@ -700,8 +700,8 @@ strong subadditivity for a normalized three-site reduced state.
     \cite[Appendix~C.2, lines~1680--1737]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 % Scope restriction: the source-faithful standing-context implication from the
-% ZCL and BNT canonical-form hypotheses is not asserted here; it must first
-% derive copy independence as in lines 1646--1665.
+% source ZCL equation and canonical-form gauge identity is not asserted here;
+% it must first derive copy independence as in lines 1646--1665.
 
 \begin{proof}
     \leanok

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
@@ -668,7 +668,7 @@ strong subadditivity for a normalized three-site reduced state.
     \]
 \end{definition}
 
-\begin{theorem}[Separating projectors for a simple tensor satisfying SAL]
+\begin{theorem}[Separating projectors with copy-independent weights]
     \label{thm:mpdo_sal_bnt_separating_projectors}
     \lean{MPOTensor.completedBntSectorProjection_isOrthogonal}
     \lean{MPOTensor.completedBntSectorProjection_mul_eq_zero}
@@ -676,15 +676,15 @@ strong subadditivity for a normalized three-site reduced state.
     \lean{MPOTensor.%
       completedBntSectorProjection_mul_physicalSlice_mul_eq_zero}
     \lean{MPOTensor.%
-      exists_bntSeparatingProjectors_of_sameMPV₂Pos_isSAL}
+      exists_bntSeparatingProjectors_of_sameMPV₂Pos_isSAL_of_weight_copy_independent}
     \leanok
     \uses{def:mpdo_completed_bnt_sector_projection,
       thm:mpdo_bnt_projector_local_selection}
-    Let $K$ be simple, in biCF, and satisfy SAL.  Suppose that the common
-    blocking has been performed, the copy weights over each BNT representative
-    agree, and the representatives have a simultaneous one-site span.  There
-    is a distinguished BNT label $s_0$ such that the completed projectors are
-    orthogonal and, for distinct labels $s$ and $t$,
+    Let $K$ be simple, in biCF, and satisfy SAL.  Assume in addition that the
+    common blocking has been performed, the copy weights over each BNT
+    representative agree, and the representatives have a simultaneous
+    one-site span.  There is a distinguished BNT label $s_0$ such that the
+    completed projectors are orthogonal and, for distinct labels $s$ and $t$,
     \[
         \widehat P_s\widehat P_t=0,
         \qquad
@@ -695,8 +695,12 @@ strong subadditivity for a normalized three-site reduced state.
     \[
         \widehat P_sK_i^{\beta\alpha}\widehat P_t=0.
     \]
-    This is the separating-projector lemma in
-    \cite[Appendix~C.2, lines~1680--1737]{Cirac2016MPDO_arXiv}.
+    This is the copy-independent-weight specialization of the
+    separating-projector lemma in
+    \cite[Appendix~C.2, lines~1680--1737]{Cirac2016MPDO_arXiv}.  The
+    source-faithful standing-context implication from ZCL and canonical-form
+    data is not asserted here; it must first derive copy independence as in
+    lines~1646--1665.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
@@ -653,6 +653,66 @@ strong subadditivity for a normalized three-site reduced state.
     over the Hayashi sectors gives the asserted $P_sA_iP_t$ identities.
 \end{proof}
 
+\begin{definition}[Completion on the zero-weight Markov sectors]
+    \label{def:mpdo_completed_bnt_sector_projection}
+    \lean{MPOTensor.completedBntSectorLabel}
+    \lean{MPOTensor.completedBntSectorProjection}
+    \leanok
+    \uses{def:mpdo_bnt_sector_projection}
+    Fix a BNT label $s_0$.  Each positive-weight Markov sector retains its
+    unique BNT label, while every zero-weight Markov sector is assigned the
+    label $s_0$.  If $\widehat S_s$ is the set of Markov sectors with completed
+    label $s$, define
+    \[
+        \widehat P_s=\sum_{k\in\widehat S_s}Q_k.
+    \]
+\end{definition}
+
+\begin{theorem}[Separating projectors for a simple tensor satisfying SAL]
+    \label{thm:mpdo_sal_bnt_separating_projectors}
+    \lean{MPOTensor.completedBntSectorProjection_isOrthogonal}
+    \lean{MPOTensor.completedBntSectorProjection_mul_eq_zero}
+    \lean{MPOTensor.sum_completedBntSectorProjection}
+    \lean{MPOTensor.%
+      completedBntSectorProjection_mul_physicalSlice_mul_eq_zero}
+    \lean{MPOTensor.%
+      exists_bntSeparatingProjectors_of_sameMPV₂Pos_isSAL}
+    \leanok
+    \uses{def:mpdo_completed_bnt_sector_projection,
+      thm:mpdo_bnt_projector_local_selection}
+    Let $K$ be simple, in biCF, and satisfy SAL.  Suppose that the common
+    blocking has been performed, the copy weights over each BNT representative
+    agree, and the representatives have a simultaneous one-site span.  There
+    is a distinguished BNT label $s_0$ such that the completed projectors are
+    orthogonal and, for distinct labels $s$ and $t$,
+    \[
+        \widehat P_s\widehat P_t=0,
+        \qquad
+        \sum_s\widehat P_s=\Id.
+    \]
+    For every physical slice of the $i$-th BNT representative, whenever
+    $s\ne t$ or $i\ne s$,
+    \[
+        \widehat P_sK_i^{\beta\alpha}\widehat P_t=0.
+    \]
+    This is the separating-projector lemma in
+    \cite[Appendix~C.2, lines~1680--1737]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_four_site_sal_bnt_sector_projectors,
+      thm:mpdo_bnt_projector_local_selection}
+    A unit-modulus BNT weight supplies the label $s_0$.  The Markov-sector
+    projections $Q_k$ are mutually orthogonal and sum to the identity, so
+    partitioning all labels by $\widehat S_s$ proves orthogonality and the
+    identity resolution.  If $p_k=0$, then
+    $Q_kK_i^{\beta\alpha}Q_k=0$ for every $i,\beta,\alpha$; if $p_k\ne0$, the
+    unique-label relation gives the same vanishing unless the label is $i$.
+    Distinct Markov sectors give zero off-diagonal corners.  Summing these
+    three cases proves the separating relation.
+\end{proof}
+
 \begin{theorem}[Positive-length BNT-sector compression]
     \label{thm:mpdo_bnt_projector_positive_length_compression}
     \lean{MPOTensor.singleKrausMap_sitewise_bntSectorProjection_mpo}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
@@ -697,11 +697,11 @@ strong subadditivity for a normalized three-site reduced state.
     \]
     This is the copy-independent-weight specialization of the
     separating-projector lemma in
-    \cite[Appendix~C.2, lines~1680--1737]{Cirac2016MPDO_arXiv}.  The
-    source-faithful standing-context implication from ZCL and canonical-form
-    data is not asserted here; it must first derive copy independence as in
-    lines~1646--1665.
+    \cite[Appendix~C.2, lines~1680--1737]{Cirac2016MPDO_arXiv}.
 \end{theorem}
+% Scope restriction: the source-faithful standing-context implication from the
+% ZCL and BNT canonical-form hypotheses is not asserted here; it must first
+% derive copy independence as in lines 1646--1665.
 
 \begin{proof}
     \leanok

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
@@ -711,10 +711,24 @@ strong subadditivity for a normalized three-site reduced state.
     projections $Q_k$ are mutually orthogonal and sum to the identity, so
     partitioning all labels by $\widehat S_s$ proves orthogonality and the
     identity resolution.  If $p_k=0$, then
-    $Q_kK_i^{\beta\alpha}Q_k=0$ for every $i,\beta,\alpha$; if $p_k\ne0$, the
-    unique-label relation gives the same vanishing unless the label is $i$.
-    Distinct Markov sectors give zero off-diagonal corners.  Summing these
-    three cases proves the separating relation.
+    $Q_kK_i^{\beta\alpha}Q_k=0$ for every $i,\beta,\alpha$.  If $p_k\ne0$,
+    then
+    \[
+      Q_kK_i^{\beta\alpha}Q_k=0
+      \quad\text{whenever the BNT label of sector $k$ is not $i$}.
+    \]
+    For distinct Markov sectors,
+    \[
+      Q_kK_i^{\beta\alpha}Q_l=0 \qquad (k\ne l).
+    \]
+    Hence, whenever $s\ne t$ or $i\ne s$,
+    \[
+      \widehat P_sK_i^{\beta\alpha}\widehat P_t
+      =\sum_{k\in\widehat S_s}\sum_{l\in\widehat S_t}
+        Q_kK_i^{\beta\alpha}Q_l
+      =0,
+    \]
+    since every summand vanishes by one of the three preceding cases.
 \end{proof}
 
 \begin{theorem}[Positive-length BNT-sector compression]

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -300,6 +300,32 @@ with the common copy weight absorbed into $\mathcal K_s$.
 \leanid{MPOTensor.changePhysicalBasis_bntSectorProjection_basis},
 \leanid{MPOTensor.sitewise_bntSectorProjection_mul_mpo_mul_self}, and
 \leanid{MPOTensor.exists_bntProjectorSelection_positiveLength_of_sameMPV₂Pos_isSAL}.}
+
+The literal identity resolution in equation \emph{Pis} is recovered in the
+ambient physical space by choosing a BNT label $s_0$ from a copy with
+unit-modulus weight.  Assign every zero-weight Markov summand to $s_0$, while
+retaining the unique source label on each positive-weight summand.  The
+completed projections
+\[
+  \widehat P_s=\sum_{k:\widehat j_k=s}Q_k
+\]
+then satisfy
+\[
+  \sum_s\widehat P_s=\Id,
+  \qquad
+  \widehat P_s\widehat P_t=0\quad(s\ne t).
+\]
+Since a zero-weight $Q_k$ annihilates every physical slice, this reassignment
+preserves, whenever $s\ne t$ or $i\ne s$,
+\[
+  \widehat P_s K_i^{\beta\alpha}\widehat P_t=0.
+\]
+Thus the retained zero-weight summands account exactly for the difference
+between the active-support resolution and the source's equation \emph{Pis}.
+The construction and its SAL specialization are
+\leanid{MPOTensor.completedBntSectorProjection} and
+\leanid{MPOTensor.exists_bntSeparatingProjectors_of_sameMPV₂Pos_isSAL}.
+
 The empty-word value $N=0$ is excluded because its closed virtual trace records
 the bond dimension and is not a physical chain.  Positivity and ZCL of every
 selected absorbed BNT representative are now formalized.  Positivity follows

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -324,7 +324,18 @@ Thus the retained zero-weight summands account exactly for the difference
 between the active-support resolution and the source's equation \emph{Pis}.
 The construction and its SAL specialization are
 \leanid{MPOTensor.completedBntSectorProjection} and
-\leanid{MPOTensor.exists_bntSeparatingProjectors_of_sameMPV₂Pos_isSAL}.
+\leanid{MPOTensor.%
+exists_bntSeparatingProjectors_of_sameMPV₂Pos_isSAL_of_weight_copy_independent}.
+
+\paragraph{Scope restriction (copy-independent weights).}
+The latter theorem assumes explicitly that the copy weights of each BNT
+representative agree.  The paper obtains this equality from ZCL immediately
+before the separating-projector argument (lines 1646--1665).  Thus the present
+theorem proves the projector conclusion after that equality is supplied, but
+does not yet establish the source's standing-context implication from simple
+biCF, ZCL, and SAL alone.  A source-faithful theorem must derive the required
+copy independence from the ZCL and canonical-form data before invoking the
+completed-projector construction.
 
 The empty-word value $N=0$ is excluded because its closed virtual trace records
 the bond dimension and is not a physical chain.  Positivity and ZCL of every

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -334,8 +334,8 @@ before the separating-projector argument (lines 1646--1665).  Thus the present
 theorem proves the projector conclusion after that equality is supplied, but
 does not yet establish the source's standing-context implication from simple
 biCF, ZCL, and SAL alone.  A source-faithful theorem must derive the required
-copy independence from the ZCL hypothesis and the BNT canonical-form
-hypotheses before invoking the completed-projector construction.
+copy independence from the source ZCL equation and the canonical-form gauge
+identity before invoking the completed-projector construction.
 
 The empty-word value $N=0$ is excluded because its closed virtual trace records
 the bond dimension and is not a physical chain.  Positivity and ZCL of every

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -334,8 +334,8 @@ before the separating-projector argument (lines 1646--1665).  Thus the present
 theorem proves the projector conclusion after that equality is supplied, but
 does not yet establish the source's standing-context implication from simple
 biCF, ZCL, and SAL alone.  A source-faithful theorem must derive the required
-copy independence from the ZCL and canonical-form data before invoking the
-completed-projector construction.
+copy independence from the ZCL hypothesis and the BNT canonical-form
+hypotheses before invoking the completed-projector construction.
 
 The empty-word value $N=0$ is excluded because its closed virtual trace records
 the bond dimension and is not a physical chain.  Positivity and ZCL of every


### PR DESCRIPTION
## Motivation

Appendix C.2 of arXiv:1606.00608, lines 1680--1737 constructs orthogonal
one-site projectors which resolve the identity and separate the BNT physical
slices. The paper has already derived copy-independent BNT weights from ZCL at
lines 1646--1665 before it states this lemma.

The repository already constructs the corresponding projectors on the
positive-weight Markov support and proves the local separation relation. The
formal Hayashi decomposition retains zero-weight summands which the source
discards, so the existing projectors sum only to the active support.

## Scope

This PR proves the projector conclusion under an explicit copy-independent
weight hypothesis. It does not yet prove the source-faithful standing-context
implication from simple biCF, ZCL, and SAL: that wrapper must first derive copy
independence from the ZCL and canonical-form data. Therefore this PR advances,
but does not close, #4309.

## Description

- assign every positive-weight Markov sector its existing unique BNT label;
- assign every zero-weight Markov sector to a distinguished BNT label supplied
  by the unit-modulus weight in the BNT canonical form;
- prove that the resulting projectors are orthogonal, mutually disjoint, and
  sum to the full physical identity;
- prove that zero-weight reassignment preserves the separating relation because
  those Markov projectors annihilate every physical slice;
- state the SAL specialization with copy-independent weights supplied
  explicitly;
- record the scope restriction in the Lean docstring, blueprint, and paper-gap
  note.

The proof composes the existing four-site SAL projector theorem and the
active-sector and inactive-sector corner-vanishing results. It does not use
Lemma C.5 or any result depending on its false rank-one assertion.

## Verification

- direct elaboration of `TNLean/MPS/MPDO/BNTSeparatingProjectors.lean` against
  the shared compiled library after rebasing onto current main;
- direct elaboration of the public `TNLean.lean` import surface before the
  rebase; the rebase was clean, and remote CI checks the current-main root;
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`;
- `python3 scripts/blueprint_lean_sync.py --root . --ci`;
- `git diff --check`;
- proof-integrity scan of the new module;
- `#print axioms` for the final theorem: only
  `hayashi_ssa_equality_characterization_forward` and Lean's standard logical
  axioms occur.

No local `.lake/build` cache or broad local build was created because disk
space is constrained. Remote CI is the authoritative full build and blueprint
check.

Progress toward #4309; does not close it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization and documentation on the MPDO/BNT projector track; no auth, runtime, or data-path changes, with scope limits called out in docstrings and the paper-gap note.
> 
> **Overview**
> Adds **completed BNT sector projectors** (`completedBntSectorLabel`, `completedBntSectorProjection`) that keep zero-weight Markov summands in the decomposition but route them to a distinguished label `s₀` (from a unit-modulus BNT copy), restoring **∑ₛ P̂ₛ = Id** while preserving the physical-slice separation **P̂ₛ Kᵢ^{βα} P̂ₜ = 0** when `s ≠ t` or `i ≠ s`.
> 
> The new module `BNTSeparatingProjectors.lean` proves orthogonality, mutual disjointness, full identity resolution, and the separation identity, then packages a SAL theorem **`exists_bntSeparatingProjectors_of_sameMPV₂Pos_isSAL_of_weight_copy_independent`** by composing the existing four-site SAL projector construction with these completed projectors. The root import and blueprint chapter gain matching definitions, theorem, and proof; the paper-gap note documents the inactive-sector fix and states that **copy-independent weights are still assumed explicitly** rather than derived from ZCL in standing context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b39100003464957c86bda7a5a5a96e78eb54fd2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->