### PR TITLE
feat(Channel/FixedPoint): formalize maximal support for positive maps

### DIFF
--- a/TNLean/Channel/FixedPoint/Cesaro.lean
+++ b/TNLean/Channel/FixedPoint/Cesaro.lean
@@ -12,15 +12,20 @@ This file proves that every quantum channel (CPTP map) on `M_D(ℂ)` has a nonze
 PSD fixed point, using the Cesàro mean / Markov-Kakutani argument. It also states
 the decomposition of Hermitian fixed points (Wolf Proposition 6.8).
 
-Note: the proofs only use positivity + trace-preservation (not full CP), but the
-statements are for channels (`IsChannel`) which carry a CP hypothesis.
+The decomposition theorem uses only positivity and trace preservation. The fixed-point
+existence theorem is stated for channels.
 
 ## Main results
 
 * `cesaroMean`: the Cesàro mean of iterates of a linear map
 * `cesaroMean_telescope`: telescoping identity for Cesàro means
 * `IsChannel.exists_posSemidef_fixedPoint`: existence of PSD fixed point
-* `IsChannel.posSemidef_parts_of_hermitian_fixedPoint`: Wolf Proposition 6.8
+* `IsPositiveMap.posPart_negPart_fixed_of_hermitian_fixedPoint`: Wolf Proposition 6.8
+  for positive trace-preserving maps, stated for the canonical positive and negative
+  parts.
+* `IsPositiveMap.posSemidef_parts_of_hermitian_fixedPoint`: existential compatibility
+  form of the preceding theorem.
+* `IsChannel.posSemidef_parts_of_hermitian_fixedPoint`: the channel specialization.
 
 ## References
 
@@ -129,19 +134,19 @@ private theorem psd_orthogonal_difference_eq_zero
     _ = Y * V * star V := (mul_assoc Y V (star V)).symm
     _ = 0 := by rw [hYV_zero, zero_mul]
 
-/-- **Wolf Proposition 6.8** (Hermitian part):
-If `E` is trace-preserving and positive, and `X` is a Hermitian fixed point,
-then the positive and negative parts of `X` are also fixed points.
+/-- **Wolf Proposition 6.8** (Hermitian part). If `E` is positive and
+trace-preserving, and `X` is a Hermitian fixed point, then the positive and
+negative parts of `X` are also fixed points.
 
-More precisely: there exist PSD `Q₁`, `Q₂` (the CFC positive and negative parts)
-with `X = Q₁ - Q₂` and `E(Q₁) = Q₁` and `E(Q₂) = Q₂`. -/
-theorem IsChannel.posSemidef_parts_of_hermitian_fixedPoint
-    (hE : IsChannel E)
+More precisely, the canonical CFC parts satisfy `E(X⁺) = X⁺` and `E(X⁻) = X⁻`.
+
+Source: Wolf, *Quantum Channels & Operations*, Proposition 6.8; local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1155--1201. -/
+theorem IsPositiveMap.posPart_negPart_fixed_of_hermitian_fixedPoint
+    (hE : IsPositiveMap E) (hTP : IsTracePreservingMap E)
     {X : Matrix (Fin D) (Fin D) ℂ} (hX_herm : X.IsHermitian)
     (hX_fix : E X = X) :
-    ∃ Q₁ Q₂ : Matrix (Fin D) (Fin D) ℂ,
-      Q₁.PosSemidef ∧ Q₂.PosSemidef ∧
-      X = Q₁ - Q₂ ∧ E Q₁ = Q₁ ∧ E Q₂ = Q₂ := by
+    E X⁺ = X⁺ ∧ E X⁻ = X⁻ := by
   -- Use CFC positive and negative parts
   set Q₁ := X⁺ with hQ₁_def
   set Q₂ := X⁻ with hQ₂_def
@@ -157,10 +162,10 @@ theorem IsChannel.posSemidef_parts_of_hermitian_fixedPoint
   have hQ₁Q₂ : Q₁ * Q₂ = 0 := CFC.posPart_mul_negPart X
   have hQ₂Q₁ : Q₂ * Q₁ = 0 := CFC.negPart_mul_posPart X
   -- E preserves PSD (positivity)
-  have hEQ₁_psd : (E Q₁).PosSemidef := hE.pos Q₁ hQ₁_psd
-  have hEQ₂_psd : (E Q₂).PosSemidef := hE.pos Q₂ hQ₂_psd
+  have hEQ₁_psd : (E Q₁).PosSemidef := hE Q₁ hQ₁_psd
+  have hEQ₂_psd : (E Q₂).PosSemidef := hE Q₂ hQ₂_psd
   -- E is trace-preserving
-  have hEQ₁_tr : trace (E Q₁) = trace Q₁ := hE.tp Q₁
+  have hEQ₁_tr : trace (E Q₁) = trace Q₁ := hTP Q₁
   -- From E(X) = X and X = Q₁ - Q₂: E(Q₁) - E(Q₂) = Q₁ - Q₂
   have hE_diff : E Q₁ - E Q₂ = Q₁ - Q₂ := by
     rw [← map_sub]; rw [← hX_decomp]; exact hX_fix
@@ -191,7 +196,37 @@ theorem IsChannel.posSemidef_parts_of_hermitian_fixedPoint
   -- Therefore E(Q₁) = Q₁ and E(Q₂) = Q₂
   have hEQ₁ : E Q₁ = Q₁ := by rw [hEQ₁_eq, hY_zero, add_zero]
   have hEQ₂ : E Q₂ = Q₂ := by rw [hEQ₂_eq, hY_zero, add_zero]
-  exact ⟨Q₁, Q₂, hQ₁_psd, hQ₂_psd, hX_decomp, hEQ₁, hEQ₂⟩
+  simpa [hQ₁_def, hQ₂_def] using And.intro hEQ₁ hEQ₂
+
+/-- Existential compatibility form of Wolf Proposition 6.8. The witnesses are the
+canonical positive and negative parts of the Hermitian fixed point. -/
+theorem IsPositiveMap.posSemidef_parts_of_hermitian_fixedPoint
+    (hE : IsPositiveMap E) (hTP : IsTracePreservingMap E)
+    {X : Matrix (Fin D) (Fin D) ℂ} (hX_herm : X.IsHermitian)
+    (hX_fix : E X = X) :
+    ∃ Q₁ Q₂ : Matrix (Fin D) (Fin D) ℂ,
+      Q₁.PosSemidef ∧ Q₂.PosSemidef ∧
+      X = Q₁ - Q₂ ∧ E Q₁ = Q₁ ∧ E Q₂ = Q₂ := by
+  have hX_sa : IsSelfAdjoint X := isSelfAdjoint_iff.mpr hX_herm
+  obtain ⟨hpos, hneg⟩ :=
+    IsPositiveMap.posPart_negPart_fixed_of_hermitian_fixedPoint
+      E hE hTP hX_herm hX_fix
+  exact ⟨X⁺, X⁻,
+    Matrix.nonneg_iff_posSemidef.mp (CFC.posPart_nonneg X),
+    Matrix.nonneg_iff_posSemidef.mp (CFC.negPart_nonneg X),
+    (CFC.posPart_sub_negPart X hX_sa).symm, hpos, hneg⟩
+
+/-- Wolf Proposition 6.8 specialized to a completely positive
+trace-preserving map. -/
+theorem IsChannel.posSemidef_parts_of_hermitian_fixedPoint
+    (hE : IsChannel E)
+    {X : Matrix (Fin D) (Fin D) ℂ} (hX_herm : X.IsHermitian)
+    (hX_fix : E X = X) :
+    ∃ Q₁ Q₂ : Matrix (Fin D) (Fin D) ℂ,
+      Q₁.PosSemidef ∧ Q₂.PosSemidef ∧
+      X = Q₁ - Q₂ ∧ E Q₁ = Q₁ ∧ E Q₂ = Q₂ :=
+  IsPositiveMap.posSemidef_parts_of_hermitian_fixedPoint
+    E hE.cp.isPositiveMap hE.tp hX_herm hX_fix
 
 end FixedPointDecomposition
 

--- a/TNLean/Channel/FixedPoint/MaximalSupport.lean
+++ b/TNLean/Channel/FixedPoint/MaximalSupport.lean
@@ -4,22 +4,23 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Channel.FixedPoint.WeightedCornerFixedPoints
+import TNLean.Channel.FixedPoint.MeanErgodicProjection
 import TNLean.MPS.Core.CPPrimitive
 import TNLean.Channel.FixedPoint.Cesaro
 
 /-!
 # A fixed point of maximal support
 
-For a trace-preserving Kraus map $T$ there is a positive semidefinite fixed point
-$\rho_0$ whose support carries every fixed point: $Q_0 X Q_0 = X$ for every fixed point
-$X$ of $T$, where $Q_0$ is the support projection of $\rho_0$. This is the maximal-support
-property of fixed points stated in Section 6.4 of *Quantum Channels & Operations*
-(Wolf 2012), there in terms of the fixed point obtained by applying the projection onto
-the fixed-point space to the identity; the construction here instead sums the positive
-parts of a basis of the fixed-point space, so that every fixed point is a linear
-combination of positive fixed points dominated by $\rho_0$, and domination transfers the
-support: for $Q$ the support projection of $\rho$,
-$$0 \preceq P \preceq \rho \;\Longrightarrow\; Q\,P = P = P\,Q.$$
+For a positive trace-preserving map $T$, the mean-ergodic image
+$\rho_0=T_\infty(\mathbf 1)$ is a positive semidefinite fixed point whose support carries
+every fixed point: $Q_0XQ_0=X$. This is the maximal-support proposition in Section 6.4
+of *Quantum Channels & Operations* (Wolf 2012). The proof first decomposes every fixed
+point into positive fixed points and then uses positivity of $T_\infty$ to dominate each
+positive fixed point by a scalar multiple of $\rho_0$.
+
+The preceding statement is proved for arbitrary positive trace-preserving maps. The
+existing trace-preserving Kraus theorem is retained as its completely positive
+specialization.
 
 Instantiating the weighted corner fixed points at $\rho_0$ removes the corner-support
 restriction: conjugation by $\sqrt{\rho_0}$ maps the weighted corner star-algebra
@@ -30,8 +31,12 @@ support of $\rho_0$.
 
 ## Main results
 
+* `Kraus.stationaryProj_absorb_of_le_smul` -- domination by a scalar multiple transfers
+  the support.
 * `Kraus.stationaryProj_absorb_of_le` -- Loewner domination transfers the support: for
   positive semidefinite $P \preceq \rho$, the support projection of $\rho$ absorbs $P$.
+* `IsPositiveMap.exists_maximalSupport_fixedPoint` -- $T_\infty(\mathbf 1)$ has support
+  carrying every fixed point of a positive trace-preserving map.
 * `Kraus.exists_maximalSupport_fixedPoint` -- a positive semidefinite fixed point whose
   support carries every fixed point.
 * `Kraus.exists_maximalSupport_weightedCorner_sqrt_eq` -- at such a fixed point,
@@ -39,7 +44,7 @@ support of $\rho_0$.
   fixed-point set.
 -/
 
-open scoped Matrix ComplexOrder MatrixOrder BigOperators
+open scoped Matrix Matrix.Norms.Frobenius ComplexOrder MatrixOrder BigOperators
 open Matrix Finset Complex
 
 namespace Kraus
@@ -48,14 +53,16 @@ variable {d D : ℕ}
 
 local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
 
-/-- **Loewner domination transfers the support.** For positive semidefinite matrices
-$P \preceq \rho$, the support projection $Q$ of $\rho$ absorbs $P$:
+/-- **Domination by a scalar multiple transfers the support.** For positive semidefinite
+matrices $P$ and $\rho$, if $P \preceq c\rho$, then the support projection $Q$ of $\rho$
+absorbs $P$:
 $Q P = P$ and $P Q = P$. From $(\mathbf 1 - Q)\rho = 0$ and
-$0 \preceq (\mathbf 1 - Q) P (\mathbf 1 - Q) \preceq (\mathbf 1 - Q) \rho (\mathbf 1 - Q)
+$0 \preceq (\mathbf 1 - Q) P (\mathbf 1 - Q) \preceq
+(\mathbf 1 - Q)c\rho(\mathbf 1 - Q)
 = 0$ one gets $(\mathbf 1 - Q)\sqrt{P}\,\bigl((\mathbf 1 - Q)\sqrt{P}\bigr)^{\dagger} = 0$,
 hence $(\mathbf 1 - Q)\sqrt{P} = 0$ and $(\mathbf 1 - Q)P = 0$. -/
-theorem stationaryProj_absorb_of_le {ρ P : Mat} (hρ_psd : ρ.PosSemidef)
-    (hP_psd : P.PosSemidef) (hle : P ≤ ρ) :
+theorem stationaryProj_absorb_of_le_smul {ρ P : Mat} (hρ_psd : ρ.PosSemidef)
+    (hP_psd : P.PosSemidef) (c : ℂ) (hle : P ≤ c • ρ) :
     stationaryProj hρ_psd * P = P ∧ P * stationaryProj hρ_psd = P := by
   set Q : Mat := stationaryProj hρ_psd
   have hQproj : IsOrthogonalProjection Q := isOrthogonalProjection_stationaryProj hρ_psd
@@ -63,25 +70,26 @@ theorem stationaryProj_absorb_of_le {ρ P : Mat} (hρ_psd : ρ.PosSemidef)
   have h1Q : (1 - Q)ᴴ = 1 - Q := by
     rw [Matrix.conjTranspose_sub, Matrix.conjTranspose_one, hQherm]
   have hQρ : Q * ρ = ρ := MPSTensor.supportProj_mul (D := D) (ρ := ρ) hρ_psd
-  -- The corner of `ρ` on the complement of the support vanishes.
-  have hρ0 : (1 - Q) * ρ * (1 - Q) = 0 := by
+  -- The corner of `cρ` on the complement of the support vanishes.
+  have hρ0 : (1 - Q) * (c • ρ) * (1 - Q) = 0 := by
     have h : (1 - Q) * ρ = 0 := by
       rw [Matrix.sub_mul, Matrix.one_mul, hQρ, sub_self]
-    rw [h, Matrix.zero_mul]
+    rw [Matrix.mul_smul, h, smul_zero, Matrix.zero_mul]
   -- Hence so does the corner of the dominated `P`.
   have hP0 : (1 - Q) * P * (1 - Q) = 0 := by
     have hupper : (1 - Q) * P * (1 - Q) ≤ 0 := by
-      have hconj : (1 - Q) * P * (1 - Q) ≤ (1 - Q) * ρ * (1 - Q) := by
+      have hconj : (1 - Q) * P * (1 - Q) ≤ (1 - Q) * (c • ρ) * (1 - Q) := by
         rw [← sub_nonneg] at hle ⊢
-        have hpsd : ((1 - Q)ᴴ * (ρ - P) * (1 - Q)).PosSemidef :=
+        have hpsd : ((1 - Q)ᴴ * (c • ρ - P) * (1 - Q)).PosSemidef :=
           (hle.posSemidef).conjTranspose_mul_mul_same (1 - Q)
         rw [h1Q] at hpsd
-        have heq : (1 - Q) * ρ * (1 - Q) - (1 - Q) * P * (1 - Q) =
-            (1 - Q) * (ρ - P) * (1 - Q) := by
-          rw [mul_sub (1 - Q) ρ P, sub_mul ((1 - Q) * ρ) ((1 - Q) * P) (1 - Q)]
+        have heq : (1 - Q) * (c • ρ) * (1 - Q) - (1 - Q) * P * (1 - Q) =
+            (1 - Q) * (c • ρ - P) * (1 - Q) := by
+          rw [mul_sub (1 - Q) (c • ρ) P,
+            sub_mul ((1 - Q) * (c • ρ)) ((1 - Q) * P) (1 - Q)]
         rw [heq]
         exact hpsd.nonneg
-      calc (1 - Q) * P * (1 - Q) ≤ (1 - Q) * ρ * (1 - Q) := hconj
+      calc (1 - Q) * P * (1 - Q) ≤ (1 - Q) * (c • ρ) * (1 - Q) := hconj
         _ = 0 := hρ0
     have hlower : (0 : Mat) ≤ (1 - Q) * P * (1 - Q) := by
       have : ((1 - Q)ᴴ * P * (1 - Q)).PosSemidef :=
@@ -110,6 +118,137 @@ theorem stationaryProj_absorb_of_le {ρ P : Mat} (hρ_psd : ρ.PosSemidef)
   have h := congrArg Matrix.conjTranspose hQP
   rwa [Matrix.conjTranspose_mul, hQherm, hP_psd.isHermitian.eq] at h
 
+/-- **Loewner domination transfers the support.** For positive semidefinite matrices
+$P \preceq \rho$, the support projection of $\rho$ absorbs $P$. -/
+theorem stationaryProj_absorb_of_le {ρ P : Mat} (hρ_psd : ρ.PosSemidef)
+    (hP_psd : P.PosSemidef) (hle : P ≤ ρ) :
+    stationaryProj hρ_psd * P = P ∧ P * stationaryProj hρ_psd = P := by
+  simpa using stationaryProj_absorb_of_le_smul hρ_psd hP_psd 1 (by simpa using hle)
+
+end Kraus
+
+namespace IsPositiveMap
+
+open Kraus
+
+variable {D : ℕ}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+/-- **Maximal support of fixed points.** Let $T$ be a positive trace-preserving
+endomorphism of a full matrix algebra, and let $T_\infty$ be its mean-ergodic
+projection. Then $\rho_0=T_\infty(\mathbf 1)$ is a positive semidefinite fixed point,
+and its support projection $Q_0$ satisfies $Q_0XQ_0=X$ for every fixed point $X$ of
+$T$.
+
+This is Wolf, Proposition 6.9, “Maximal support of fixed points”; local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1214--1235. The proof
+uses Proposition 6.8 to decompose an arbitrary fixed point into positive fixed points.
+For a positive fixed point $A$, positivity of $T_\infty$ applied to
+$\operatorname{tr}(A)\mathbf 1-A$ gives
+$A\preceq\operatorname{tr}(A)\rho_0$, so the support of $\rho_0$ absorbs $A$.
+
+The restriction of $T$ to this support and the complementary zero summand required
+by Wolf Theorem 6.14 are not asserted here; their remaining construction is recorded
+in `docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex`. -/
+theorem exists_maximalSupport_fixedPoint
+    {T : Mat →ₗ[ℂ] Mat} (hT : IsPositiveMap T) (hTP : IsTracePreservingMap T) :
+    let hbounded := hT.hasBoundedOrbits_of_tracePreserving hTP
+    let ρ₀ := LinearMap.meanErgodicProjection (𝕜 := ℂ)
+      (E := Matrix (Fin D) (Fin D) ℂ) T hbounded 1
+    ∃ hρ₀ : ρ₀.PosSemidef, T ρ₀ = ρ₀ ∧
+      ∀ X : Mat, T X = X →
+        stationaryProj hρ₀ * X * stationaryProj hρ₀ = X := by
+  classical
+  dsimp only
+  let hbounded := hT.hasBoundedOrbits_of_tracePreserving hTP
+  let P := LinearMap.meanErgodicProjection (𝕜 := ℂ)
+    (E := Matrix (Fin D) (Fin D) ℂ) T hbounded
+  let ρ₀ : Mat := P 1
+  have hPpos : IsPositiveMap P := hT.meanErgodicProjection_isPositiveMap hbounded
+  have hρ₀psd : ρ₀.PosSemidef := hPpos 1 Matrix.PosSemidef.one
+  have hPfixed (A : Mat) (hA : T A = A) : P A = A := by
+    exact (hT.meanErgodicProjection_apply_eq_self_iff_of_tracePreserving hTP A).2 hA
+  have hρ₀fix : T ρ₀ = ρ₀ := by
+    apply (hT.meanErgodicProjection_apply_eq_self_iff_of_tracePreserving hTP ρ₀).1
+    exact hbounded.meanErgodicProjection_apply_meanErgodicProjection 1
+  refine ⟨hρ₀psd, hρ₀fix, ?_⟩
+  intro X hXfix
+  cases isEmpty_or_nonempty (Fin D) with
+  | inl hD =>
+      letI := hD
+      have hXzero : X = 0 := Subsingleton.elim _ _
+      rw [hXzero, Matrix.mul_zero, Matrix.zero_mul]
+  | inr hD =>
+      letI := hD
+      let H₁ : Mat := X + Xᴴ
+      let H₂ : Mat := Complex.I • (X - Xᴴ)
+      have hXstar : T Xᴴ = Xᴴ := by
+        rw [hT.map_conjTranspose, hXfix]
+      have hH₁herm : H₁.IsHermitian := by
+        change (X + Xᴴ)ᴴ = X + Xᴴ
+        rw [Matrix.conjTranspose_add, Matrix.conjTranspose_conjTranspose]
+        exact add_comm _ _
+      have hH₂herm : H₂.IsHermitian := by
+        change (Complex.I • (X - Xᴴ))ᴴ = Complex.I • (X - Xᴴ)
+        rw [Matrix.conjTranspose_smul, Matrix.conjTranspose_sub,
+          Matrix.conjTranspose_conjTranspose]
+        rw [show star Complex.I = -Complex.I by simp]
+        rw [neg_smul, ← smul_neg, neg_sub]
+      have hH₁fix : T H₁ = H₁ := by
+        change T (X + Xᴴ) = X + Xᴴ
+        rw [T.map_add, hXfix, hXstar]
+      have hH₂fix : T H₂ = H₂ := by
+        change T (Complex.I • (X - Xᴴ)) = Complex.I • (X - Xᴴ)
+        rw [T.map_smul, T.map_sub, hXfix, hXstar]
+      obtain ⟨P₁p, P₁m, hP₁p, hP₁m, hH₁eq, hf₁p, hf₁m⟩ :=
+        IsPositiveMap.posSemidef_parts_of_hermitian_fixedPoint
+          T hT hTP hH₁herm hH₁fix
+      obtain ⟨P₂p, P₂m, hP₂p, hP₂m, hH₂eq, hf₂p, hf₂m⟩ :=
+        IsPositiveMap.posSemidef_parts_of_hermitian_fixedPoint
+          T hT hTP hH₂herm hH₂fix
+      have hbound (A : Mat) (hA : A.PosSemidef) (hAfix : T A = A) :
+          A ≤ A.trace • ρ₀ := by
+        have hshift : (A.trace • (1 : Mat) - A).PosSemidef :=
+          hA.trace_smul_one_sub_self_posSemidef
+        have himage := hPpos _ hshift
+        change (P (A.trace • (1 : Mat) - A)).PosSemidef at himage
+        rw [P.map_sub, P.map_smul, hPfixed A hAfix] at himage
+        change (A.trace • ρ₀ - A).PosSemidef at himage
+        exact sub_nonneg.mp himage.nonneg
+      have hsupported (A : Mat) (hA : A.PosSemidef) (hAfix : T A = A) :
+          stationaryProj hρ₀psd * A * stationaryProj hρ₀psd = A := by
+        obtain ⟨hQA, hAQ⟩ := stationaryProj_absorb_of_le_smul
+          hρ₀psd hA A.trace (hbound A hA hAfix)
+        rw [Matrix.mul_assoc, hAQ, hQA]
+      have hH₁support :
+          stationaryProj hρ₀psd * H₁ * stationaryProj hρ₀psd = H₁ := by
+        rw [hH₁eq, Matrix.mul_sub, Matrix.sub_mul,
+          hsupported P₁p hP₁p hf₁p, hsupported P₁m hP₁m hf₁m]
+      have hH₂support :
+          stationaryProj hρ₀psd * H₂ * stationaryProj hρ₀psd = H₂ := by
+        rw [hH₂eq, Matrix.mul_sub, Matrix.sub_mul,
+          hsupported P₂p hP₂p hf₂p, hsupported P₂m hP₂m hf₂m]
+      have hXeq : X = (2⁻¹ : ℂ) • H₁ - ((2⁻¹ : ℂ) * Complex.I) • H₂ := by
+        change X = (2⁻¹ : ℂ) • (X + Xᴴ) -
+          ((2⁻¹ : ℂ) * Complex.I) • (Complex.I • (X - Xᴴ))
+        rw [smul_smul,
+          show ((2⁻¹ : ℂ) * Complex.I) * Complex.I = -(2⁻¹ : ℂ) by
+            rw [mul_assoc, Complex.I_mul_I]
+            ring]
+        module
+      conv_lhs => rw [hXeq]
+      rw [Matrix.mul_sub, Matrix.sub_mul, Matrix.mul_smul, Matrix.smul_mul,
+        Matrix.mul_smul, Matrix.smul_mul, hH₁support, hH₂support, ← hXeq]
+
+end IsPositiveMap
+
+namespace Kraus
+
+variable {d D : ℕ}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
 /-- The transfer map of a trace-preserving Kraus family is a quantum channel; the
 trace-preservation hypothesis is the normalization of the channel form of the transfer
 map (`MPSTensor.transferMap_isChannel`). -/
@@ -117,160 +256,30 @@ theorem isChannel_transferMap (K : Fin d → Mat) (h_tp : IsTP K) :
     IsChannel (MPSTensor.transferMap (d := d) (D := D) K) :=
   MPSTensor.transferMap_isChannel K h_tp
 
-/-- **A fixed point of maximal support.** For a trace-preserving Kraus map $T$ there is a
-positive semidefinite fixed point $\rho_0$ whose support carries every fixed point:
-$Q_0 X Q_0 = X$ for every $X$ with $T(X) = X$, where $Q_0$ is the support projection of
-$\rho_0$. This is the maximal-support property of fixed points stated in Section 6.4 of
-*Quantum Channels & Operations* (Wolf 2012); the reference exhibits the witness as the
-image of the identity under the projection onto the fixed-point space, while here
-$\rho_0$ is the sum of the positive parts of the Hermitian and anti-Hermitian components
-of a basis of the fixed-point space. Every fixed point is then a linear combination of
-positive semidefinite fixed points dominated by $\rho_0$ in the Loewner order, and
-domination transfers the support (`Kraus.stationaryProj_absorb_of_le`). -/
+/-- **A fixed point of maximal support for a Kraus map.** The mean-ergodic image
+of the identity is a positive semidefinite fixed point whose support carries every fixed
+point of the trace-preserving Kraus map. This is the completely positive specialization
+of Wolf, Proposition 6.9, formalized for arbitrary positive trace-preserving maps by
+`IsPositiveMap.exists_maximalSupport_fixedPoint`. -/
 theorem exists_maximalSupport_fixedPoint (K : Fin d → Mat) (h_tp : IsTP K) :
     ∃ (ρ₀ : Mat) (hρ₀ : ρ₀.PosSemidef), map K ρ₀ = ρ₀ ∧
       ∀ X : Mat, map K X = X →
         stationaryProj hρ₀ * X * stationaryProj hρ₀ = X := by
-  classical
-  set E : Mat →ₗ[ℂ] Mat := MPSTensor.transferMap (d := d) (D := D) K with hEdef
-  have hEK : ∀ X : Mat, E X = map K X := by
-    intro X
-    simp [hEdef, MPSTensor.transferMap_apply, map]
+  let E : Mat →ₗ[ℂ] Mat := MPSTensor.transferMap (d := d) (D := D) K
   have hE : IsChannel E := isChannel_transferMap K h_tp
-  -- Positive parts of a Hermitian fixed point are fixed (Proposition 6.8 of the source).
-  have hpos : ∀ H : Mat, H.IsHermitian → map K H = H →
-      ∃ P₁ P₂ : Mat, P₁.PosSemidef ∧ P₂.PosSemidef ∧ H = P₁ - P₂ ∧
-        map K P₁ = P₁ ∧ map K P₂ = P₂ := by
-    intro H hH hHfix
-    obtain ⟨P₁, P₂, h₁, h₂, hdiff, hf₁, hf₂⟩ :=
-      IsChannel.posSemidef_parts_of_hermitian_fixedPoint E hE hH
-        (by rw [hEK]; exact hHfix)
-    exact ⟨P₁, P₂, h₁, h₂, hdiff, by rw [← hEK]; exact hf₁, by rw [← hEK]; exact hf₂⟩
-  -- A basis of the fixed-point space, the eigenspace of the transfer map at one.
-  set S : Submodule ℂ Mat := Module.End.eigenspace E 1 with hSdef
-  have hSmem : ∀ X : Mat, X ∈ S ↔ map K X = X := by
-    intro X
-    rw [hSdef, Module.End.mem_eigenspace_iff, one_smul, hEK]
-  set m : ℕ := Module.finrank ℂ ↥S
-  set b : Module.Basis (Fin m) ℂ ↥S := Module.finBasis ℂ ↥S
-  -- The Hermitian and anti-Hermitian components of the basis vectors are fixed.
-  have hbfix : ∀ j : Fin m, map K ((b j : Mat)) = (b j : Mat) := fun j => (hSmem _).mp (b j).2
-  have hbHfix : ∀ j : Fin m, map K ((b j : Mat))ᴴ = ((b j : Mat))ᴴ := fun j =>
-    conjTranspose_mem_fixedPoints (K := K) (hbfix j)
-  set H₁ : Fin m → Mat := fun j => (b j : Mat) + (b j : Mat)ᴴ
-  set H₂ : Fin m → Mat := fun j => Complex.I • ((b j : Mat) - (b j : Mat)ᴴ)
-  have hH₁herm : ∀ j, (H₁ j).IsHermitian := by
-    intro j
-    change ((b j : Mat) + (b j : Mat)ᴴ)ᴴ = (b j : Mat) + (b j : Mat)ᴴ
-    rw [Matrix.conjTranspose_add, Matrix.conjTranspose_conjTranspose]
-    exact add_comm _ _
-  have hH₂herm : ∀ j, (H₂ j).IsHermitian := by
-    intro j
-    change (Complex.I • ((b j : Mat) - (b j : Mat)ᴴ))ᴴ =
-      Complex.I • ((b j : Mat) - (b j : Mat)ᴴ)
-    rw [Matrix.conjTranspose_smul, Matrix.conjTranspose_sub,
-      Matrix.conjTranspose_conjTranspose]
-    rw [show star Complex.I = -Complex.I by simp]
-    rw [neg_smul, ← smul_neg, neg_sub]
-  have hH₁fix : ∀ j, map K (H₁ j) = H₁ j := by
-    intro j
-    change map K ((b j : Mat) + (b j : Mat)ᴴ) = (b j : Mat) + (b j : Mat)ᴴ
-    rw [← hEK, E.map_add, hEK, hEK, hbfix j, hbHfix j]
-  have hH₂fix : ∀ j, map K (H₂ j) = H₂ j := by
-    intro j
-    change map K (Complex.I • ((b j : Mat) - (b j : Mat)ᴴ)) =
-      Complex.I • ((b j : Mat) - (b j : Mat)ᴴ)
-    rw [← hEK, E.map_smul, E.map_sub, hEK, hEK, hbfix j, hbHfix j]
-  -- Each basis vector is a combination of its Hermitian and anti-Hermitian components.
-  have hXj : ∀ j, (b j : Mat) = (2⁻¹ : ℂ) • H₁ j - ((2⁻¹ : ℂ) * Complex.I) • H₂ j := by
-    intro j
-    change (b j : Mat) = (2⁻¹ : ℂ) • ((b j : Mat) + (b j : Mat)ᴴ) -
-      ((2⁻¹ : ℂ) * Complex.I) • (Complex.I • ((b j : Mat) - (b j : Mat)ᴴ))
-    rw [smul_smul,
-      show ((2⁻¹ : ℂ) * Complex.I) * Complex.I = -(2⁻¹ : ℂ) by
-        rw [mul_assoc, Complex.I_mul_I]; ring]
-    module
-  -- Positive parts of the components, all of them fixed points.
-  choose P₁p P₁m hP₁p hP₁m hH₁eq hf₁p hf₁m using fun j => hpos (H₁ j) (hH₁herm j) (hH₁fix j)
-  choose P₂p P₂m hP₂p hP₂m hH₂eq hf₂p hf₂m using fun j => hpos (H₂ j) (hH₂herm j) (hH₂fix j)
-  -- The maximal fixed point: the sum of all the positive parts.
-  set g : Fin m → Mat := fun j => P₁p j + P₁m j + P₂p j + P₂m j
-  have hg_nonneg : ∀ j, (0 : Mat) ≤ g j := by
-    intro j
-    change (0 : Mat) ≤ P₁p j + P₁m j + P₂p j + P₂m j
-    exact add_nonneg (add_nonneg (add_nonneg (hP₁p j).nonneg (hP₁m j).nonneg)
-      (hP₂p j).nonneg) (hP₂m j).nonneg
-  set ρ₀ : Mat := ∑ j : Fin m, g j with hρ₀def
-  have hρ₀psd : ρ₀.PosSemidef :=
-    (Finset.sum_nonneg fun j _ => hg_nonneg j).posSemidef
-  have hρ₀fix : map K ρ₀ = ρ₀ := by
-    rw [hρ₀def, ← hEK, _root_.map_sum]
-    refine Finset.sum_congr rfl fun j _ => ?_
-    change E (P₁p j + P₁m j + P₂p j + P₂m j) = g j
-    rw [E.map_add, E.map_add, E.map_add, hEK, hEK, hEK, hEK,
-      hf₁p j, hf₁m j, hf₂p j, hf₂m j]
-  refine ⟨ρ₀, hρ₀psd, hρ₀fix, ?_⟩
-  set Q₀ : Mat := stationaryProj hρ₀psd
-  -- Every positive part is dominated by the sum, so the support projection absorbs it.
-  have hg_le : ∀ j, g j ≤ ρ₀ := fun j =>
-    Finset.single_le_sum (fun i _ => hg_nonneg i) (Finset.mem_univ j)
-  have habsorb : ∀ (P : Mat), P.PosSemidef → P ≤ ρ₀ → Q₀ * P * Q₀ = P := by
-    intro P hP hle
-    obtain ⟨hQP, hPQ⟩ := stationaryProj_absorb_of_le hρ₀psd hP hle
-    rw [Matrix.mul_assoc, hPQ, hQP]
-  have hle₁p : ∀ j, P₁p j ≤ ρ₀ := by
-    intro j
-    refine le_trans (show P₁p j ≤ g j from ?_) (hg_le j)
-    calc P₁p j ≤ P₁p j + P₁m j := le_add_of_nonneg_right (hP₁m j).nonneg
-      _ ≤ P₁p j + P₁m j + P₂p j := le_add_of_nonneg_right (hP₂p j).nonneg
-      _ ≤ P₁p j + P₁m j + P₂p j + P₂m j := le_add_of_nonneg_right (hP₂m j).nonneg
-  have hle₁m : ∀ j, P₁m j ≤ ρ₀ := by
-    intro j
-    refine le_trans (show P₁m j ≤ g j from ?_) (hg_le j)
-    calc P₁m j ≤ P₁p j + P₁m j := le_add_of_nonneg_left (hP₁p j).nonneg
-      _ ≤ P₁p j + P₁m j + P₂p j := le_add_of_nonneg_right (hP₂p j).nonneg
-      _ ≤ P₁p j + P₁m j + P₂p j + P₂m j := le_add_of_nonneg_right (hP₂m j).nonneg
-  have hle₂p : ∀ j, P₂p j ≤ ρ₀ := by
-    intro j
-    refine le_trans (show P₂p j ≤ g j from ?_) (hg_le j)
-    calc P₂p j ≤ P₁p j + P₁m j + P₂p j := le_add_of_nonneg_left
-          (add_nonneg (hP₁p j).nonneg (hP₁m j).nonneg)
-      _ ≤ P₁p j + P₁m j + P₂p j + P₂m j := le_add_of_nonneg_right (hP₂m j).nonneg
-  have hle₂m : ∀ j, P₂m j ≤ ρ₀ := by
-    intro j
-    refine le_trans (show P₂m j ≤ g j from ?_) (hg_le j)
-    exact le_add_of_nonneg_left (add_nonneg (add_nonneg (hP₁p j).nonneg (hP₁m j).nonneg)
-      (hP₂p j).nonneg)
-  -- The support projection absorbs the components, hence the basis vectors.
-  have habsorbH₁ : ∀ j, Q₀ * H₁ j * Q₀ = H₁ j := by
-    intro j
-    rw [hH₁eq j, Matrix.mul_sub, Matrix.sub_mul,
-      habsorb _ (hP₁p j) (hle₁p j), habsorb _ (hP₁m j) (hle₁m j)]
-  have habsorbH₂ : ∀ j, Q₀ * H₂ j * Q₀ = H₂ j := by
-    intro j
-    rw [hH₂eq j, Matrix.mul_sub, Matrix.sub_mul,
-      habsorb _ (hP₂p j) (hle₂p j), habsorb _ (hP₂m j) (hle₂m j)]
-  have hQb : ∀ j, Q₀ * (b j : Mat) * Q₀ = (b j : Mat) := by
-    intro j
-    conv_lhs => rw [hXj j]
-    rw [Matrix.mul_sub, Matrix.sub_mul, Matrix.mul_smul, Matrix.smul_mul,
-      Matrix.mul_smul, Matrix.smul_mul, habsorbH₁ j, habsorbH₂ j, ← hXj j]
-  -- Every fixed point is a combination of the basis vectors, all carried by the support.
-  intro X hX
-  have hXS : X ∈ S := (hSmem X).mpr hX
-  have hrepr : ∑ j : Fin m, b.repr ⟨X, hXS⟩ j • (b j : Mat) = X := by
-    have h := congrArg (Subtype.val) (b.sum_repr ⟨X, hXS⟩)
-    simp only [AddSubmonoidClass.coe_finsetSum, SetLike.val_smul] at h
-    exact h
-  calc Q₀ * X * Q₀
-      = ∑ j : Fin m, b.repr ⟨X, hXS⟩ j • (Q₀ * (b j : Mat) * Q₀) := by
-        conv_lhs => rw [← hrepr]
-        rw [Matrix.mul_sum, Matrix.sum_mul]
-        exact Finset.sum_congr rfl fun j _ => by
-          rw [Matrix.mul_smul, Matrix.smul_mul]
-    _ = ∑ j : Fin m, b.repr ⟨X, hXS⟩ j • (b j : Mat) := by
-        exact Finset.sum_congr rfl fun j _ => by rw [hQb j]
-    _ = X := hrepr
+  let hbounded := hE.cp.isPositiveMap.hasBoundedOrbits_of_tracePreserving hE.tp
+  let ρ₀ : Mat := LinearMap.meanErgodicProjection (𝕜 := ℂ) (E := Mat)
+    E hbounded 1
+  have hgeneric : ∃ hρ₀ : ρ₀.PosSemidef, E ρ₀ = ρ₀ ∧
+      ∀ X : Mat, E X = X → stationaryProj hρ₀ * X * stationaryProj hρ₀ = X := by
+    simpa only [ρ₀, hbounded] using
+      hE.cp.isPositiveMap.exists_maximalSupport_fixedPoint hE.tp
+  obtain ⟨hρ₀, hfix, hmax⟩ := hgeneric
+  refine ⟨ρ₀, hρ₀, ?_, ?_⟩
+  · simpa [E, MPSTensor.transferMap_apply, map] using hfix
+  · intro X hX
+    apply hmax X
+    simpa [E, MPSTensor.transferMap_apply, map] using hX
 
 /-- **Conjugation by the square root at a fixed point of maximal support.** For a
 trace-preserving Kraus map $T$ there is a positive semidefinite fixed point $\rho_0$ such

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -264,7 +264,12 @@ In `TNLean.Channel.FixedPoint.Algebra`:
 
 ### Wolf Proposition 6.8 (Positive fixed-points)
 
-* `IsChannel.posSemidef_parts_of_hermitian_fixedPoint` — `TNLean.Channel.FixedPoint.Cesaro`
+* `IsPositiveMap.posPart_negPart_fixed_of_hermitian_fixedPoint` — the source-faithful
+  positive trace-preserving statement for the canonical positive and negative parts in
+  `TNLean.Channel.FixedPoint.Cesaro`.
+* `IsPositiveMap.posSemidef_parts_of_hermitian_fixedPoint` — the existential
+  compatibility form.
+* `IsChannel.posSemidef_parts_of_hermitian_fixedPoint` — the channel specialization.
 * Numbered theorem: `IsChannel.wolf_prop_6_8` — `TNLean.Channel.WolfChapter6Wrappers`
 
 ### Wolf Corollary 6.6 (projected support corner) — FORMALIZED
@@ -391,6 +396,9 @@ and the removal of the corner restriction):
 
 * `Kraus.stationaryProj_absorb_of_le` — for positive semidefinite $P \preceq \rho$
   the support projection of $\rho$ absorbs $P$.
+* `IsPositiveMap.exists_maximalSupport_fixedPoint` — for an arbitrary positive
+  trace-preserving map, the fixed point $T_\infty(\mathbf 1)$ has support carrying every
+  fixed point, as in Wolf Proposition 6.9.
 * `Kraus.exists_maximalSupport_fixedPoint` — a positive semidefinite fixed point
   $\rho_0$ whose
   support projection $Q_0$ satisfies $Q_0 X Q_0 = X$ for every fixed point $X$.

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -310,6 +310,22 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     $\rho\mapsto T(X\rho X^\dagger)$ is positive and trace-preserving.
 \end{proof}
 
+\begin{theorem}[The trace bounds a positive matrix]
+    \label{thm:psd_le_trace_smul_one}
+    \lean{Matrix.PosSemidef.trace_smul_one_sub_self_posSemidef}
+    \leanok
+    Let $D\geq 1$ and let $P\in\MN{D}$ be positive semidefinite. Then
+    \[
+        P\preceq \tr(P)\Id.
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    Diagonalize $P$ with nonnegative eigenvalues $\lambda_1,\ldots,\lambda_D$.
+    Each eigenvalue is bounded above by their sum $\tr(P)$, so every eigenvalue
+    of $\tr(P)\Id-P$ is nonnegative.
+\end{proof}
+
 \begin{theorem}[Forward Lorentz-cone trace inequality]
     \label{thm:psd_trace_square_le_square_trace}
     \lean{Matrix.PosSemidef.trace_sq_re_le_trace_re_sq}
@@ -1175,25 +1191,32 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
 \end{proof}
 
 \begin{theorem}[Hermitian fixed-point decomposition]\label{thm:hermitian_fixedpoint_parts}
-    \lean{IsChannel.posSemidef_parts_of_hermitian_fixedPoint}
+    \lean{IsPositiveMap.posPart_negPart_fixed_of_hermitian_fixedPoint}
     \leanok
-    \uses{def:channel}
-    Let $E$ be a quantum channel and $X = E(X)$ a Hermitian
-    fixed point with decomposition $X = P_+ - P_-$ into orthogonal
-    positive and negative parts ($P_\pm \ge 0$, $\tr(P_+ P_-) = 0$).
+    \uses{def:positive_map, def:trace_preserving}
+    Let $E$ be a positive trace-preserving linear map and let $X = E(X)$ be a Hermitian
+    fixed point. Let $P_+=X^+$ and $P_-=X^-$ be its canonical positive and negative
+    parts. Thus $X=P_+-P_-$, $P_\pm\geq0$, and $P_+P_-=P_-P_+=0$.
     Then $E(P_+) = P_+$ and $E(P_-) = P_-$.
     This is \cite[Proposition~6.8]{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    Let $Q$ be the support projection of $P_+$.
-    Trace preservation and positivity give
-    $\tr(Q E(P_-)) = 0$
-    and $E(P_-) \ge 0$, so $Q E(P_-) = 0$.
-    The fixed-point equation
-    $E(P_+) - E(P_-) = P_+ - P_-$ then identifies
-    $E(P_\pm) = P_\pm$.
+    The fixed-point equation gives a common difference
+    \[
+        Y=E(P_+)-P_+=E(P_-)-P_-.
+    \]
+    Hence $P_++Y$ and $P_-+Y$ are positive semidefinite, while trace
+    preservation gives $\tr(Y)=0$. Diagonalize $P_+$. Since
+    $P_+P_-=P_-P_+=0$, each eigenvector belongs to the kernel of $P_+$ or to
+    the kernel of $P_-$. Positivity of the corresponding matrix $P_++Y$ or
+    $P_-+Y$ shows that every diagonal coefficient of $Y$ in this basis is
+    nonnegative. Their sum is $\tr(Y)=0$, so every such coefficient vanishes.
+    A positive semidefinite matrix with a zero diagonal coefficient annihilates
+    the corresponding basis vector. Applying this to $P_++Y$ or $P_-+Y$ shows
+    that $Y$ annihilates the entire eigenbasis. Thus $Y=0$, and consequently
+    $E(P_\pm)=P_\pm$.
 \end{proof}
 
 \begin{theorem}[Ces\`aro fixed-point theorem]\label{thm:cesaro_fixedpoint}

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2982,13 +2982,13 @@ transfers the support.
     (Theorem~\ref{thm:transfer_channel}).
 \end{proof}
 
-\begin{lemma}[Loewner domination transfers the support]%
+\begin{lemma}[Scalar Loewner domination transfers the support]%
     \label{lem:stationaryProj_absorb_of_le}
-    \lean{Kraus.stationaryProj_absorb_of_le}
+    \lean{Kraus.stationaryProj_absorb_of_le_smul}
     \leanok
     \uses{def:support_proj}
-    Let $\rho, P \succeq 0$ with $P \preceq \rho$, and let $Q$ be the support projection
-    of $\rho$. Then
+    Let $\rho, P \succeq 0$ and $c\in\C$ with $P \preceq c\rho$, and let $Q$ be the
+    support projection of $\rho$. Then
     \[
         Q\,P = P, \qquad P\,Q = P.
     \]
@@ -3000,7 +3000,7 @@ transfers the support.
     The support projection absorbs $\rho$, so $(\Id - Q)\rho = 0$ and
     \[
         0 \;\preceq\; (\Id - Q)\,P\,(\Id - Q)
-        \;\preceq\; (\Id - Q)\,\rho\,(\Id - Q) \;=\; 0,
+        \;\preceq\; (\Id - Q)\,(c\rho)\,(\Id - Q) \;=\; 0,
     \]
     the middle inequality because conjugation by $\Id - Q$ preserves the Loewner order.
     Hence
@@ -3018,69 +3018,64 @@ transfers the support.
 
 \begin{theorem}[A fixed point of maximal support]%
     \label{thm:maximalSupport_fixedPoint}
-    \lean{Kraus.exists_maximalSupport_fixedPoint}
+    \lean{IsPositiveMap.exists_maximalSupport_fixedPoint}
     \leanok
-    \uses{def:tp_kraus, def:support_proj}
-    Let $T(X) = \sum_i K_i X K_i^\dagger$ be trace-preserving. There is a positive
-    semidefinite fixed point $\rho_0$ of $T$ such that, with $Q_0$ the support projection
-    of $\rho_0$, every fixed point $X$ of $T$ satisfies
+    \uses{def:positive_map, def:trace_preserving, def:mean_ergodic_projection,
+        def:support_proj}
+    Let $T:\MN{D}\to\MN{D}$ be positive and trace-preserving, and let $T_\infty$ be its
+    mean-ergodic projection. Then $\rho_0=T_\infty(\Id)$ is positive semidefinite and
+    fixed by $T$. With $Q_0$ the support projection of $\rho_0$, every fixed point $X$
+    of $T$ satisfies
     \[
         Q_0\, X\, Q_0 = X.
     \]
     This is the maximal-support property of fixed points in Section~6.4
-    of~\cite{Wolf2012Quantum}; there the witness is the image of the identity under the
-    projection onto the fixed-point space, while here it is a sum of positive fixed
-    points.
+    of~\cite{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    \uses{lem:isChannel_transferMap, thm:hermitian_fixedpoint_parts,
-        lem:stationaryProj_absorb_of_le}
-    Let $X_0, \ldots, X_{m-1}$ be a basis of the fixed-point space of $T$. Each $X_j$ splits
-    into fixed Hermitian components: with
+    \uses{thm:positive_trace_preserving_mean_ergodic_projection,
+        thm:positive_map_conjTranspose, thm:hermitian_fixedpoint_parts,
+        thm:psd_le_trace_smul_one, lem:stationaryProj_absorb_of_le}
+    Positivity of the mean-ergodic projection gives $\rho_0\succeq 0$, while its range
+    and idempotence give $T(\rho_0)=\rho_0$.  Each fixed point $X$ splits into fixed
+    Hermitian components:
     \[
-        H_{1,j} = X_j + X_j^{\dagger},
+        H_1 = X + X^{\dagger},
         \qquad
-        H_{2,j} = i\,\bigl(X_j - X_j^{\dagger}\bigr),
+        H_2 = i\,\bigl(X - X^{\dagger}\bigr),
     \]
-    both are Hermitian fixed points (the conjugate transpose of a fixed point is fixed),
+    Both are Hermitian fixed points (the conjugate transpose of a fixed point is fixed),
     and
     \[
-        X_j \;=\; \tfrac{1}{2}\,H_{1,j} - \tfrac{i}{2}\,H_{2,j}.
+        X \;=\; \tfrac{1}{2}\,H_1 - \tfrac{i}{2}\,H_2.
     \]
     By the decomposition of Hermitian fixed points into positive parts
     (Theorem~\ref{thm:hermitian_fixedpoint_parts}) there are positive semidefinite fixed
     points with
     \[
-        H_{1,j} = P^{+}_{1,j} - P^{-}_{1,j},
+        H_1 = P^{+}_1 - P^{-}_1,
         \qquad
-        H_{2,j} = P^{+}_{2,j} - P^{-}_{2,j}.
+        H_2 = P^{+}_2 - P^{-}_2.
     \]
-    Set
+    If $P\succeq0$ is any of these positive fixed points, then
+    $\tr(P)\Id-P\succeq0$. Positivity of $T_\infty$ and
+    $T_\infty(P)=P$ give
     \[
-        \rho_0 \;=\; \sum_{j=0}^{m-1}
-            \bigl(P^{+}_{1,j} + P^{-}_{1,j} + P^{+}_{2,j} + P^{-}_{2,j}\bigr),
+        \tr(P)\rho_0-P
+        =T_\infty\!\left(\tr(P)\Id-P\right)\succeq0.
     \]
-    a positive semidefinite fixed point. Every summand is dominated by $\rho_0$ in the
-    Loewner order, because the remaining summands are positive semidefinite, so the
-    support projection $Q_0$ of $\rho_0$ absorbs each of them
-    (Lemma~\ref{lem:stationaryProj_absorb_of_le}):
+    Thus $P\preceq\tr(P)\rho_0$, and scalar domination transfers the support, so
+    $Q_0P Q_0=P$. Substituting this identity into the two positive-part decompositions
+    gives
     \[
-        Q_0\, P^{\pm}_{k,j}\, Q_0 = P^{\pm}_{k,j}.
-    \]
-    Substituting into the two displayed decompositions gives
-    \[
-        Q_0\, H_{k,j}\, Q_0
-        \;=\; Q_0\,\bigl(P^{+}_{k,j} - P^{-}_{k,j}\bigr)\,Q_0
-        \;=\; H_{k,j},
+        Q_0\, H_k\, Q_0 = H_k,
         \qquad
-        Q_0\, X_j\, Q_0
-        \;=\; \tfrac{1}{2}\,Q_0 H_{1,j} Q_0 - \tfrac{i}{2}\,Q_0 H_{2,j} Q_0
-        \;=\; X_j.
+        Q_0\, X\, Q_0
+        = \tfrac{1}{2}\,Q_0 H_1 Q_0 - \tfrac{i}{2}\,Q_0 H_2 Q_0
+        = X.
     \]
-    A fixed point $X$ of $T$ is a
-    linear combination of the basis $X_0, \ldots, X_{m-1}$, so $Q_0\, X\, Q_0 = X$.
 \end{proof}
 
 \begin{theorem}[Conjugation by the square root at a fixed point of maximal support]%

--- a/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
+++ b/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
@@ -139,9 +139,11 @@ by a finite equivalence and applying the full-support theorem now gives the
 density-block form of the fixed families on the original direct sum.  What
 remains is to verify the required channel hypotheses for the transported
 sector maps on the whole direct sums and to supply a blockwise
-positive-definite fixed family.  Alternatively, the support reduction and
-complementary zero summand still open in
-\path{docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex} would
+positive-definite fixed family.  Alternatively, the maximal-support witness
+$T_\infty(\mathbf 1)$ is now available for an arbitrary positive
+trace-preserving map.  The construction of the supported endomorphism and its
+complementary zero summand, still open in
+\path{docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex}, would
 remove the latter full-support hypothesis.
 
 \section{Sector relabelling uses positivity, not linear isomorphism}

--- a/docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex
+++ b/docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex
@@ -105,6 +105,14 @@ $\operatorname{Fix}(T)$ under the full-support hypothesis.
 in
 \doclink{TNLean/Channel/FixedPoint/TraceAdjointDensityBlocks}.}
 
+The maximal-support witness required for the reduction is now formalized for the
+source's full generality: for every positive trace-preserving map,
+$\rho_0=T_\infty(\mathbf 1)$ is positive semidefinite and its support contains the
+support and range of every fixed point.
+\footnote{Formal declaration:
+\leanid{IsPositiveMap.exists_maximalSupport_fixedPoint} in
+\doclink{TNLean/Channel/FixedPoint/MaximalSupport}.}
+
 Two arguments remain to obtain the general fixed-point statement above.  First, the
 positive semidefinite density matrices supplied by Proposition~1.5 must be
 restricted to their supports; this produces the positive definite matrices
@@ -114,9 +122,10 @@ summand $\mathcal H_0$.
 
 Thus Proposition~1.5, its application to the full-support adjoint
 mean-ergodic projection, and the full-support Schr\"odinger-picture fixed-point
-formula are formalized, while Theorem~6.14 remains open.  The missing work is
-the positive-definite support reduction and the recovery of the zero block
-from the kernels.
+formula, together with the maximal-support witness, are formalized, while
+Theorem~6.14 remains open.  The missing work is to construct the supported
+endomorphism, apply the full-support formula there, and recover the zero block
+from the discarded kernels.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Motivation

Wolf Chapter 6 proves that, for a positive trace-preserving map, every fixed point has support and range inside the support of the exact state $T_\infty(\mathbf 1)$. This is the first support-reduction step needed after LionSR/TNLean#4299 for the unrestricted fixed-point structure theorem tracked in LionSR/TNLean#4120.

Source: Wolf, *Quantum Channels & Operations*, Proposition “Maximal support of fixed points”; local source `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1214–1235.

## Description

- generalize the Hermitian fixed-point decomposition (Wolf Proposition 6.8) from channels to positive trace-preserving maps, retaining the channel specialization;
- prove that the exact mean-ergodic witness $T_\infty(\mathbf 1)$ is positive semidefinite, fixed, and has support carrying every fixed point;
- generalize support absorption from $P \preceq \rho$ to scalar domination $P \preceq c\rho$, and retain the previous lemma as a specialization;
- derive the existing trace-preserving Kraus theorem from the general statement;
- align the Chapter 6 index, blueprint entries, and paper-gap records with the source-faithful result and its remaining boundary.

## Verification

- `lake env lean TNLean/Channel/FixedPoint/Cesaro.lean`
- `lake env lean TNLean/Channel/FixedPoint/MaximalSupport.lean`
- `lake env lean TNLean/Channel/FixedPoint/MaximalRank.lean`
- `lake env lean TNLean/Channel/WolfChapter6Index.lean`
- `git diff --check origin/main...HEAD`
- proof-integrity scan of the changed Lean files

The Lean checks used an external read-only olean cache because the local volume cannot hold a second Mathlib build. Full repository and blueprint validation are left to the pull-request checks.

Closes LionSR/QICLean#226.
Addresses LionSR/TNLean#4120.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Core fixed-point theory and Wolf Chapter 6 documentation change proof strategy and API surface (`IsPositiveMap` vs `IsChannel`); incorrect domination or projection lemmas would break downstream maximal-support and gap-tracking claims.
> 
> **Overview**
> **Wolf Proposition 6.8** is now proved for **positive trace-preserving** maps (`IsPositiveMap`), not only channels: the canonical CFC positive/negative parts of a Hermitian fixed point are fixed, with an existential wrapper and `IsChannel` recovered as a thin specialization.
> 
> **Maximal support (Wolf Prop. 6.9)** is proved for the same class: \(\rho_0 = T_\infty(\mathbf 1)\) is PSD, fixed, and its support projection carries every fixed point. The old Kraus proof (basis sum of positive parts) is replaced by Hermitian decomposition, domination \(P \preceq \mathrm{tr}(P)\rho_0\) from positivity of \(T_\infty\), and a new lemma **`stationaryProj_absorb_of_le_smul`** (\(P \preceq c\rho\)); `Kraus.exists_maximalSupport_fixedPoint` delegates to the general theorem.
> 
> Blueprint and index entries now point at the generalized Lean names; ch04 adds **`P \preceq \mathrm{tr}(P)\Id`** and rewrites the Hermitian fixed-point proof; paper-gap notes record that the \(T_\infty(\mathbf 1)\) witness is formalized while Wolf Theorem 6.14 construction remains open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35443ed24ae7396dc60fe52117087257774e8cac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->