### PR TITLE
ci: audit Petz support theorem axioms

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -169,6 +169,7 @@ import TNLean.Channel.Schwarz.RelativeEntropyConvexity
 import TNLean.Channel.Schwarz.RelativeEntropyUnitaryInvariance
 import TNLean.Channel.Schwarz.RelativeEntropyAncillaAdditivity
 import TNLean.Channel.Schwarz.RelativeEntropyDataProcessing
+import TNLean.Channel.Schwarz.PetzRecoverySupport
 import TNLean.Channel.Schwarz.StrongSubadditivityPosDef
 import TNLean.Channel.Schwarz.SSAEqualityDPI
 import TNLean.Channel.Schwarz.WeylTwirl

--- a/TNLean/Channel/Schwarz/PetzRecoverySupport.lean
+++ b/TNLean/Channel/Schwarz/PetzRecoverySupport.lean
@@ -95,3 +95,6 @@ theorem partialTraceRightPetzChannel_apply_partialTraceRight_of_support
     (fun _ hw => partialTraceRight_support hσ hsupp hw)
 
 end Matrix
+
+#print axioms Matrix.IsHermitian.supportProj_mul_mul_supportProj_of_mulVec_kernel_le
+#print axioms Matrix.partialTraceRightPetzChannel_apply_partialTraceRight_of_support

--- a/TNLean/Channel/Schwarz/PetzRecoverySupport.lean
+++ b/TNLean/Channel/Schwarz/PetzRecoverySupport.lean
@@ -1,0 +1,97 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.PetzRecovery
+import TNLean.Channel.Schwarz.RelativeEntropyDataProcessing
+
+/-!
+# Support-domain input for partial-trace Petz recovery
+
+This file verifies that the marginal of a positive semidefinite matrix lies in
+the support domain on which the completed partial-trace Petz channel agrees
+with the support formula, provided the joint matrices satisfy the corresponding
+kernel inclusion.
+
+## Main result
+
+* `Matrix.partialTraceRightPetzChannel_apply_partialTraceRight_of_support`:
+  the completed channel and the support Petz map agree on the first marginal.
+
+## References
+
+* P. Hayden, R. Jozsa, D. Petz, and A. Winter, *Structure of States Which
+  Satisfy Strong Subadditivity of Quantum Entropy with Equality*, Theorem 3,
+  equation (8), arXiv:quant-ph/0304007v2.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder
+
+namespace Matrix
+
+namespace IsHermitian
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+  {A B : Matrix n n ℂ}
+
+/-- If the kernel of a Hermitian matrix `A` is contained in the kernel of a
+Hermitian matrix `B`, then the support projection of `A` absorbs `B` on both
+sides.
+
+This is the support-domain linear-algebra step in the singular Petz transpose
+formula of Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2, Theorem 3,
+equation (8). -/
+theorem supportProj_mul_mul_supportProj_of_mulVec_kernel_le
+    (hA : A.IsHermitian) (hB : B.IsHermitian)
+    (hker : ∀ v : n → ℂ, A.mulVec v = 0 → B.mulVec v = 0) :
+    hA.supportProj * B * hA.supportProj = B := by
+  classical
+  have hAcomp : A * (1 - hA.supportProj) = 0 := by
+    rw [Matrix.mul_sub, Matrix.mul_one, hA.mul_supportProj_self, sub_self]
+  have hBcomp : B * (1 - hA.supportProj) = 0 := by
+    rw [Matrix.ext_iff_mulVec]
+    intro v
+    rw [Matrix.zero_mulVec, ← Matrix.mulVec_mulVec]
+    apply hker
+    rw [Matrix.mulVec_mulVec, hAcomp, Matrix.zero_mulVec]
+  have hBright : B = B * hA.supportProj := by
+    rw [Matrix.mul_sub, Matrix.mul_one, sub_eq_zero] at hBcomp
+    exact hBcomp
+  have hBcompLeft : (1 - hA.supportProj) * B = 0 := by
+    simpa [Matrix.conjTranspose_mul, hA.supportProj_isHermitian.eq, hB.eq] using
+      congrArg Matrix.conjTranspose hBcomp
+  have hBleft : B = hA.supportProj * B := by
+    rw [Matrix.sub_mul, Matrix.one_mul, sub_eq_zero] at hBcompLeft
+    exact hBcompLeft
+  calc
+    hA.supportProj * B * hA.supportProj = B * hA.supportProj := by rw [← hBleft]
+    _ = B := hBright.symm
+
+end IsHermitian
+
+variable {L R : Type*} [Fintype L] [DecidableEq L]
+  [Fintype R] [DecidableEq R]
+
+/-- If positive semidefinite matrices `ρ` and `σ` satisfy
+`ker σ ⊆ ker ρ`, then the completed Petz channel associated with `σ` agrees
+with its support formula when applied to `partialTraceRight ρ`.
+
+The support inclusion transfers to the two marginals, so the first marginal is
+absorbed on both sides by the support projection of the reference marginal.
+Thus the complementary preparation term vanishes. This isolates the support
+domain of the singular Petz transpose formula in Hayden--Jozsa--Petz--Winter,
+arXiv:quant-ph/0304007v2, Theorem 3, equation (8). -/
+theorem partialTraceRightPetzChannel_apply_partialTraceRight_of_support
+    {ρ σ : Matrix (L × R) (L × R) ℂ}
+    (hρ : ρ.PosSemidef) (hσ : σ.PosSemidef)
+    (hsupp : ∀ v : L × R → ℂ, σ.mulVec v = 0 → ρ.mulVec v = 0) :
+    partialTraceRightPetzChannel σ hσ (partialTraceRight ρ) =
+      partialTraceRightPetzMap σ hσ (partialTraceRight ρ) := by
+  apply partialTraceRightPetzChannel_apply_of_supported
+  exact IsHermitian.supportProj_mul_mul_supportProj_of_mulVec_kernel_le
+    (PosSemidef.partialTraceRight hσ).isHermitian
+    (PosSemidef.partialTraceRight hρ).isHermitian
+    (fun _ hw => partialTraceRight_support hσ hsupp hw)
+
+end Matrix

--- a/blueprint/src/chapter/ch16_channel_representations.tex
+++ b/blueprint/src/chapter/ch16_channel_representations.tex
@@ -18,7 +18,8 @@ The following definitions support the Choi--Jamiol\-kowski isomorphism
 of~\cite[Chapter~2]{Wolf2012Quantum}.
 
 \begin{definition}[Partial traces]\label{def:partial_trace}
-    \lean{Matrix.traceLeft, Matrix.traceRight}
+    \lean{Matrix.traceLeft, Matrix.traceRight, Matrix.partialTraceRight,
+        Matrix.partialTraceRight_apply}
     \leanok
     Let $X \in \MN{d \cdot d'}$ be a bipartite matrix indexed by
     \[

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -1522,6 +1522,139 @@ Theorem~\ref{thm:trace_norm_abs}.
     $\mathcal R_\sigma(X)$ does not change its value.
 \end{proof}
 
+\begin{definition}[Support projection of a Hermitian matrix]
+    \label{def:hermitian_support_projection}
+    \lean{Matrix.IsHermitian.supportProj,
+        Matrix.IsHermitian.supportProj_isHermitian,
+        Matrix.IsHermitian.mul_supportProj_self}
+    \leanok
+    Let $A$ be Hermitian, with spectral decomposition
+    $A=U\operatorname{diag}(\lambda_i)U^\dagger$. Its support projection is
+    \[
+        P_A=U\operatorname{diag}(\mathbf 1_{\lambda_i\ne 0})U^\dagger.
+    \]
+\end{definition}
+
+\begin{theorem}[Support projection absorption under kernel inclusion]
+    \label{thm:support_projection_absorption_kernel_inclusion}
+    \lean{Matrix.IsHermitian.supportProj_mul_mul_supportProj_of_mulVec_kernel_le}
+    \leanok
+    \uses{def:hermitian_support_projection}
+    Let $A$ and $B$ be Hermitian matrices such that
+    $\ker A\subseteq\ker B$. If $P_A$ is the support projection of $A$, then
+    \[
+        P_A B P_A=B.
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:hermitian_support_projection}
+    The complementary projection $\mathbf 1-P_A$ has range contained in
+    $\ker A$, and hence in $\ker B$. Thus
+    $B(\mathbf 1-P_A)=0$. Taking adjoints gives
+    $(\mathbf 1-P_A)B=0$, and the result follows.
+\end{proof}
+
+\begin{definition}[Lift along one basis vector]
+    \label{def:single_basis_vector_lift}
+    \lean{Matrix.liftVec}
+    \leanok
+    For $w\in H_L$ and a distinguished basis vector $e_r\in H_R$, define the
+    lift $J_r w=w\otimes e_r\in H_L\otimes H_R$.
+\end{definition}
+
+\begin{theorem}[Matrix action on a basis-vector lift]
+    \label{thm:matrix_action_single_basis_vector_lift}
+    \lean{Matrix.mulVec_liftVec_apply}
+    \leanok
+    \uses{def:single_basis_vector_lift}
+    Let $X$ be a matrix on $H_L\otimes H_R$. For basis indices $i,s$ and $r$,
+    \[
+        [XJ_r w]_{(i,s)}=\sum_j X_{(i,s),(j,r)}w_j.
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:single_basis_vector_lift}
+    Expand the matrix-vector product. The factor $e_r$ is zero away from the
+    index $r$, so the sum over the second index has only one nonzero term.
+\end{proof}
+
+\begin{theorem}[Quadratic form of a right marginal]
+    \label{thm:partial_trace_quadratic_form_split}
+    \lean{Matrix.qform_partialTraceRight_split}
+    \leanok
+    \uses{def:partial_trace, def:single_basis_vector_lift}
+    Let $X$ be a matrix on $H_L\otimes H_R$, let $w\in H_L$, and let
+    $(e_r)_r$ be the distinguished orthonormal basis of $H_R$. Then
+    \[
+        \langle w,(\operatorname{tr}_R X)w\rangle
+        =\sum_r\langle w\otimes e_r,X(w\otimes e_r)\rangle.
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:matrix_action_single_basis_vector_lift, def:partial_trace}
+    Expanding the matrix products and the partial trace gives
+    \[
+        \sum_{i,j,r}\overline{w_i}X_{(i,r),(j,r)}w_j
+    \]
+    on both sides.
+\end{proof}
+
+\begin{theorem}[Kernel inclusion descends under partial trace]
+    \label{thm:partial_trace_kernel_inclusion}
+    \lean{Matrix.partialTraceRight_support}
+    \leanok
+    \uses{def:partial_trace}
+    Let $\sigma$ be positive semidefinite on $H_L\otimes H_R$, and let $\rho$
+    be any matrix on the same space such that
+    $\ker\sigma\subseteq\ker\rho$. Then
+    \[
+        \ker(\operatorname{tr}_R\sigma)
+        \subseteq\ker(\operatorname{tr}_R\rho).
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:partial_trace_quadratic_form_split}
+    If $w\in\ker(\operatorname{tr}_R\sigma)$, the quadratic form of this
+    marginal at $w$ is the sum, over an orthonormal basis $(e_r)_r$ of $H_R$,
+    of the nonnegative quadratic forms of $\sigma$ at $w\otimes e_r$.
+    Each summand therefore vanishes. Positive semidefiniteness shows that
+    $\sigma(w\otimes e_r)=0$ for every $r$, so the joint kernel inclusion gives
+    $\rho(w\otimes e_r)=0$. Summing the diagonal components over $r$ yields
+    $(\operatorname{tr}_R\rho)w=0$.
+\end{proof}
+
+\begin{theorem}[The first marginal lies in the Petz support domain]
+    \label{thm:partial_trace_petz_channel_first_marginal_agreement}
+    \lean{Matrix.partialTraceRightPetzChannel_apply_partialTraceRight_of_support}
+    \leanok
+    \uses{def:partial_trace_petz_channel,
+        def:partial_trace_support_petz_map, def:partial_trace}
+    Let $\rho$ and $\sigma$ be positive semidefinite matrices on
+    $H_L\otimes H_R$ such that $\ker\sigma\subseteq\ker\rho$. Then
+    \[
+        \widehat{\mathcal R}_\sigma(\operatorname{tr}_R\rho)
+        =\mathcal R_\sigma(\operatorname{tr}_R\rho).
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:partial_trace_kernel_inclusion,
+        thm:support_projection_absorption_kernel_inclusion,
+        thm:partial_trace_petz_channel_supported_agreement}
+    Kernel inclusion descends through the partial trace, giving
+    $\ker(\operatorname{tr}_R\sigma)\subseteq
+    \ker(\operatorname{tr}_R\rho)$. The preceding absorption lemma therefore
+    yields
+    $P_\tau(\operatorname{tr}_R\rho)P_\tau
+      =\operatorname{tr}_R\rho$, where
+    $\tau=\operatorname{tr}_R\sigma$. Agreement of the completed channel with
+    the support Petz map now applies.
+\end{proof}
+
 \begin{theorem}[The support Petz map recovers its reference]
     \label{thm:partial_trace_support_petz_map_reference_recovery}
     \lean{Matrix.partialTraceRightPetzMap_partialTraceRight}

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -194,11 +194,46 @@ marginal.
 \leanid{Matrix.partialTraceRightPetzChannel_partialTraceRight} in
 \path{TNLean/Channel/PetzRecovery.lean}.}
 
-This leaf still does not supply the full recovery theorem needed by the
-forward strong-subadditivity characterization.  It does not prove that
-saturation of relative-entropy data processing forces recovery of the first
-argument.  That step, followed by the structural analysis of the recovered
-tripartite state, remains necessary before the forward axiom can be removed.
+The source support condition is also now connected to this completed channel.
+If positive semidefinite matrices $\rho$ and $\sigma$ satisfy
+$\ker\sigma\subseteq\ker\rho$, then the same inclusion holds after the right
+partial trace.  If $P_\tau$ is the support projection of
+$\tau=\operatorname{tr}_R\sigma$, this gives
+\begin{align}
+  P_\tau(\operatorname{tr}_R\rho)P_\tau
+    =\operatorname{tr}_R\rho.
+\end{align}
+Consequently the complementary term vanishes on
+$\operatorname{tr}_R\rho$, and
+\begin{align}
+  \widehat{\mathcal R}_\sigma(\operatorname{tr}_R\rho)
+    =\mathcal R_\sigma(\operatorname{tr}_R\rho).
+\end{align}
+\footnote{Formal declarations:
+\leanid{Matrix.IsHermitian.supportProj_mul_mul_supportProj_of_mulVec_kernel_le}
+and
+\leanid{Matrix.partialTraceRightPetzChannel_apply_partialTraceRight_of_support}
+in \path{TNLean/Channel/Schwarz/PetzRecoverySupport.lean}.}
+Thus the choice of trace-preserving extension away from the support is no
+longer part of the forward equality gap.
+
+The exact remaining analytic implication is the equality case of data
+processing on this support domain:
+\begin{align}
+  D(\rho\Vert\sigma)
+    =D(\operatorname{tr}_R\rho\Vert\operatorname{tr}_R\sigma)
+  \quad\Longrightarrow\quad
+  \mathcal R_\sigma(\operatorname{tr}_R\rho)=\rho.
+\end{align}
+This is the forward implication of
+\cite[Theorem~3]{HaydenJozsaPetzWinter2004}.  The present proof of data
+processing establishes the inequality by regularization, unitary averaging,
+and joint convexity, but it does not yet analyze equality in those steps.
+After this analytic implication, the proof of the block decomposition still
+requires the invariant-state decomposition used in
+\cite[Theorem~6]{HaydenJozsaPetzWinter2004}; that is the
+Koashi--Imoto structural step.  Both steps remain necessary before the forward
+axiom can be removed.
 
 \section{Verdict}
 


### PR DESCRIPTION
### Motivation

- Obtain kernel `#print axioms` output for the two new public theorems in PR #4310 without changing its exact reviewed head.

### Description

- Temporarily print the axiom dependencies of the support-projection absorption theorem and the marginal Petz-channel agreement theorem.
- This draft PR is diagnostic only and will be closed without merge after the build log is recorded.

### Testing

- Remote Lean build output is the object of this audit.

Addresses #784

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formal proofs and documentation only; diagnostic `#print axioms` is build-output noise but does not change proof content.
> 
> **Overview**
> Adds **`TNLean/Channel/Schwarz/PetzRecoverySupport.lean`** and wires it into the root import list so the library loads the new Schwarz/Petz support lemmas.
> 
> **Lean:** Under `ker σ ⊆ ker ρ`, proves Hermitian **support-projection absorption** (`P_A B P_A = B`) and that the completed **partial-trace Petz channel** matches the support Petz map on `partialTraceRight ρ`. The file ends with **`#print axioms`** on both public theorems for CI axiom auditing (per PR intent).
> 
> **Blueprint (`ch19_entropy.tex`):** Documents support projections, kernel descent under partial trace, and the first-marginal Petz-channel agreement theorem, with Lean tags.
> 
> **Docs:** Updates the CPSV16 SSA equality gap note to record that the trace-preserving Petz extension is no longer a forward gap; the remaining work is DPI **equality** (Hayden–Jozsa–Petz–Winter Thm. 3) plus Koashi–Imoto structure.
> 
> **Minor:** Extends partial-trace blueprint lean refs in `ch16_channel_representations.tex`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25286c9520c1d5e1d28f031ff2740cf3abc1100c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->