### PR TITLE
feat(MPS/MPDO): formalize parity mutual-information alternation

### DIFF
--- a/TNLean/MPS/MPDO/ThermodynamicLimitCounterexample.lean
+++ b/TNLean/MPS/MPDO/ThermodynamicLimitCounterexample.lean
@@ -4,8 +4,11 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.AreaLaw
+import TNLean.MPS.MPDO.MutualInfoMonotone
 import TNLean.MPS.MPDO.SectorTrace
+import TNLean.Analysis.EntropyDecomposition
 import Mathlib.Algebra.BigOperators.Fin
+import Mathlib.Analysis.SpecialFunctions.BinaryEntropy
 import Mathlib.Topology.MetricSpace.Pseudo.Defs
 
 /-!
@@ -37,6 +40,12 @@ even lengths it is the mixture with weights \(1/3\) and \(2/3\).
 * `parityTensor_isMPDO`: positivity at every positive chain length.
 * `not_exists_tendsto_reducedBlockState_one_zero_zero`: the all-zero entry of
   the one-site reduced state has no thermodynamic limit.
+* `mutualInfoChain_parityTensor_of_odd`: the mutual information is zero at odd
+  chain lengths.
+* `mutualInfoChain_parityTensor_of_even`: the mutual information is
+  \(h_2(1/3)\) at positive even chain lengths.
+* `not_exists_tendsto_parityMutualInfoAfterCut`: the mutual information has no
+  thermodynamic limit at any fixed nonempty cut.
 
 ## Reference
 
@@ -295,5 +304,370 @@ theorem not_exists_tendsto_reducedBlockState_one_zero_zero :
   norm_num [Real.dist_eq] at hOddLengthIndex hEvenLengthIndex
   rw [abs_lt] at hOddLengthIndex hEvenLengthIndex
   linarith
+
+/-! ## Mutual-information alternation -/
+
+private def oddWeight {N : ℕ} (sigma : Fin N → Fin 2) : ℝ :=
+  if ∀ k, sigma k = 0 then 1 else 0
+
+private noncomputable def evenWeight {N : ℕ} (sigma : Fin N → Fin 2) : ℝ :=
+  if ∀ k, sigma k = 0 then 1 / 3 else if ∀ k, sigma k = 1 then 2 / 3 else 0
+
+private lemma forall_append_comp_cast_iff {L K N : ℕ} (u : Fin L → Fin 2)
+    (w : Fin K → Fin 2) (h : N = L + K) (j : Fin 2) :
+    (∀ k, (Fin.append u w ∘ Fin.cast h) k = j) ↔
+      (∀ k, u k = j) ∧ (∀ k, w k = j) := by
+  constructor
+  · intro hall
+    constructor
+    · intro k
+      simpa using hall (Fin.cast h.symm (Fin.castAdd K k))
+    · intro k
+      simpa using hall (Fin.cast h.symm (Fin.natAdd L k))
+  · rintro ⟨hu, hw⟩ k
+    change Fin.append u w (Fin.cast h k) = j
+    refine Fin.addCases (fun i ↦ ?_) (fun i ↦ ?_) (Fin.cast h k)
+    · simp [hu]
+    · simp [hw]
+
+private lemma normalizedMPO_eq_diagonal_of_odd {N : ℕ} (hN : Odd N) :
+    normalizedMPO parityTensor N =
+      Matrix.diagonal fun sigma ↦ (oddWeight sigma : ℂ) := by
+  rw [normalizedMPO, trace_mpo_parityTensor, hN.neg_one_pow,
+    mpo_parityTensor_eq_diagonal N hN.pos]
+  ext sigma tau
+  by_cases hst : sigma = tau
+  · subst tau
+    rw [Matrix.smul_apply, Matrix.diagonal_apply_eq, Matrix.diagonal_apply_eq]
+    simp only [smul_eq_mul, oddWeight]
+    split_ifs <;> norm_num [hN.neg_one_pow]
+  · rw [Matrix.smul_apply, Matrix.diagonal_apply_ne _ hst,
+      Matrix.diagonal_apply_ne _ hst, smul_zero]
+
+private lemma normalizedMPO_eq_diagonal_of_even {N : ℕ} (hN : Even N)
+    (hNpos : 0 < N) :
+    normalizedMPO parityTensor N =
+      Matrix.diagonal fun sigma ↦ (evenWeight sigma : ℂ) := by
+  rw [normalizedMPO, trace_mpo_parityTensor, hN.neg_one_pow,
+    mpo_parityTensor_eq_diagonal N hNpos]
+  ext sigma tau
+  by_cases hst : sigma = tau
+  · subst tau
+    rw [Matrix.smul_apply, Matrix.diagonal_apply_eq, Matrix.diagonal_apply_eq]
+    simp only [smul_eq_mul, evenWeight]
+    split_ifs <;> norm_num [hN.neg_one_pow]
+  · rw [Matrix.smul_apply, Matrix.diagonal_apply_ne _ hst,
+      Matrix.diagonal_apply_ne _ hst, smul_zero]
+
+private lemma reducedBlockState_eq_diagonal_of_odd {N L : ℕ} (hN : Odd N)
+    (hLN : L ≤ N) :
+    reducedBlockState parityTensor N L hLN =
+      Matrix.diagonal fun sigma ↦ (oddWeight sigma : ℂ) := by
+  ext u v
+  rw [reducedBlockState_eq_sum]
+  by_cases huv : u = v
+  · subst v
+    rw [Matrix.diagonal_apply_eq]
+    simp_rw [normalizedMPO_eq_diagonal_of_odd hN,
+      Matrix.diagonal_apply_eq, oddWeight, forall_append_comp_cast_iff]
+    by_cases hu0 : ∀ k, u k = 0
+    · have hu0eq : (∀ k, u k = 0) = True := propext (iff_true_intro hu0)
+      rw [if_pos hu0]
+      simp only [hu0eq, true_and]
+      rw [Fintype.sum_eq_single (fun _ ↦ 0)]
+      · simp
+      · intro w hw
+        have hnotzero : ¬∀ k, w k = 0 := fun h ↦ hw (funext h)
+        simp [hnotzero]
+    · have hu0eq : (∀ k, u k = 0) = False := propext (iff_false_intro hu0)
+      rw [if_neg hu0]
+      apply Finset.sum_eq_zero
+      intro w _
+      simp [hu0eq]
+  · rw [Matrix.diagonal_apply_ne _ huv]
+    apply Finset.sum_eq_zero
+    intro w _
+    rw [normalizedMPO_eq_diagonal_of_odd hN]
+    apply Matrix.diagonal_apply_ne
+    intro hfull
+    apply huv
+    funext k
+    have hk := congrFun hfull
+      (Fin.cast (show N = L + (N - L) by omega).symm (Fin.castAdd (N - L) k))
+    simpa using hk
+
+private lemma reducedBlockState_eq_diagonal_of_even {N L : ℕ} (hN : Even N)
+    (hNpos : 0 < N) (hLpos : 0 < L) (hLN : L ≤ N) :
+    reducedBlockState parityTensor N L hLN =
+      Matrix.diagonal fun sigma ↦ (evenWeight sigma : ℂ) := by
+  ext u v
+  rw [reducedBlockState_eq_sum]
+  by_cases huv : u = v
+  · subst v
+    rw [Matrix.diagonal_apply_eq]
+    simp_rw [normalizedMPO_eq_diagonal_of_even hN hNpos,
+      Matrix.diagonal_apply_eq, evenWeight, forall_append_comp_cast_iff]
+    by_cases hu0 : ∀ k, u k = 0
+    · have hu1 : ¬∀ k, u k = 1 := by
+        intro h
+        have h01 := (hu0 ⟨0, hLpos⟩).symm.trans (h ⟨0, hLpos⟩)
+        norm_num at h01
+      have hu0eq : (∀ k, u k = 0) = True := propext (iff_true_intro hu0)
+      have hu1eq : (∀ k, u k = 1) = False := propext (iff_false_intro hu1)
+      rw [if_pos hu0]
+      simp only [hu0eq, hu1eq, true_and, false_and, if_false]
+      rw [Fintype.sum_eq_single (fun _ ↦ 0)]
+      · simp
+      · intro w hw
+        have hnotzero : ¬∀ k, w k = 0 := fun h ↦ hw (funext h)
+        simp [hnotzero]
+    · by_cases hu1 : ∀ k, u k = 1
+      · have hu0eq : (∀ k, u k = 0) = False := propext (iff_false_intro hu0)
+        have hu1eq : (∀ k, u k = 1) = True := propext (iff_true_intro hu1)
+        rw [if_neg hu0, if_pos hu1]
+        simp only [hu0eq, hu1eq, false_and, true_and, if_false]
+        rw [Fintype.sum_eq_single (fun _ ↦ 1)]
+        · simp
+        · intro w hw
+          have hnotone : ¬∀ k, w k = 1 := fun h ↦ hw (funext h)
+          simp [hnotone]
+      · have hu0eq : (∀ k, u k = 0) = False := propext (iff_false_intro hu0)
+        have hu1eq : (∀ k, u k = 1) = False := propext (iff_false_intro hu1)
+        rw [if_neg hu0, if_neg hu1]
+        apply Finset.sum_eq_zero
+        intro w _
+        simp [hu0eq, hu1eq]
+  · rw [Matrix.diagonal_apply_ne _ huv]
+    apply Finset.sum_eq_zero
+    intro w _
+    rw [normalizedMPO_eq_diagonal_of_even hN hNpos]
+    apply Matrix.diagonal_apply_ne
+    intro hfull
+    apply huv
+    funext k
+    have hk := congrFun hfull
+      (Fin.cast (show N = L + (N - L) by omega).symm (Fin.castAdd (N - L) k))
+    simpa using hk
+
+/-- At odd length the normalized chain is the pure all-zero state.
+
+This is the odd-length state used to test the inner limit in
+arXiv:1606.00608, Proposition 4.5, lines 801--806. -/
+theorem normalizedMPO_parityTensor_of_odd {N : ℕ} (hN : Odd N) :
+    normalizedMPO parityTensor N = Matrix.diagonal fun sigma ↦
+      ((if ∀ k, sigma k = 0 then (1 : ℝ) else 0 : ℝ) : ℂ) := by
+  simpa [oddWeight] using normalizedMPO_eq_diagonal_of_odd hN
+
+/-- At positive even length the normalized chain has precisely the two
+constant configurations, with weights one third and two thirds.
+
+This is the even-length state used to test the inner limit in
+arXiv:1606.00608, Proposition 4.5, lines 801--806. -/
+theorem normalizedMPO_parityTensor_of_even {N : ℕ} (hN : Even N)
+    (hNpos : 0 < N) :
+    normalizedMPO parityTensor N = Matrix.diagonal fun sigma ↦
+      ((if ∀ k, sigma k = 0 then (1 / 3 : ℝ)
+        else if ∀ k, sigma k = 1 then 2 / 3 else 0 : ℝ) : ℂ) := by
+  simpa [evenWeight] using normalizedMPO_eq_diagonal_of_even hN hNpos
+
+/-- Every reduced block of an odd-length chain is the pure all-zero state.
+
+This is the odd-length marginal in the counterexample to the inner limit of
+arXiv:1606.00608, Proposition 4.5, lines 801--806. -/
+theorem reducedBlockState_parityTensor_of_odd {N L : ℕ} (hN : Odd N)
+    (hLN : L ≤ N) :
+    reducedBlockState parityTensor N L hLN = Matrix.diagonal fun sigma ↦
+      ((if ∀ k, sigma k = 0 then (1 : ℝ) else 0 : ℝ) : ℂ) := by
+  simpa [oddWeight] using reducedBlockState_eq_diagonal_of_odd hN hLN
+
+/-- Every nonempty reduced block of a positive even-length chain has the same
+two nonzero eigenvalues, one third and two thirds, as the full state.
+
+This is the even-length marginal in the counterexample to the inner limit of
+arXiv:1606.00608, Proposition 4.5, lines 801--806. -/
+theorem reducedBlockState_parityTensor_of_even {N L : ℕ} (hN : Even N)
+    (hNpos : 0 < N) (hLpos : 0 < L) (hLN : L ≤ N) :
+    reducedBlockState parityTensor N L hLN = Matrix.diagonal fun sigma ↦
+      ((if ∀ k, sigma k = 0 then (1 / 3 : ℝ)
+        else if ∀ k, sigma k = 1 then 2 / 3 else 0 : ℝ) : ℂ) := by
+  simpa [evenWeight] using
+    reducedBlockState_eq_diagonal_of_even hN hNpos hLpos hLN
+
+private lemma vonNeumannEntropy_oddWeight {N : ℕ}
+    (hd : (Matrix.diagonal fun sigma : Fin N → Fin 2 =>
+      (oddWeight sigma : ℂ)).IsHermitian) :
+    vonNeumannEntropy (Matrix.diagonal fun sigma : Fin N → Fin 2 =>
+      (oddWeight sigma : ℂ)) hd = 0 := by
+  rw [Matrix.vonNeumannEntropy_diagonal]
+  apply Finset.sum_eq_zero
+  intro sigma _
+  by_cases hzero : ∀ k, sigma k = 0
+  · simp [oddWeight, hzero, Real.negMulLog_one]
+  · simp [oddWeight, hzero, Real.negMulLog_zero]
+
+private lemma vonNeumannEntropy_evenWeight {N : ℕ} (hNpos : 0 < N)
+    (hd : (Matrix.diagonal fun sigma : Fin N → Fin 2 =>
+      (evenWeight sigma : ℂ)).IsHermitian) :
+    vonNeumannEntropy (Matrix.diagonal fun sigma : Fin N → Fin 2 =>
+      (evenWeight sigma : ℂ)) hd = Real.binEntropy (1 / 3) := by
+  rw [Matrix.vonNeumannEntropy_diagonal]
+  let zeroConfig : Fin N → Fin 2 := fun _ ↦ 0
+  let oneConfig : Fin N → Fin 2 := fun _ ↦ 1
+  have hzero_one : zeroConfig ≠ oneConfig := by
+    intro h
+    have := congrFun h ⟨0, hNpos⟩
+    norm_num [zeroConfig, oneConfig] at this
+  let f : (Fin N → Fin 2) → ℝ := fun sigma ↦ Real.negMulLog (evenWeight sigma)
+  rw [show (∑ sigma, Real.negMulLog (evenWeight sigma)) = ∑ sigma, f sigma from rfl]
+  rw [← Finset.add_sum_erase _ _ (Finset.mem_univ zeroConfig)]
+  rw [← Finset.add_sum_erase _ _
+    (Finset.mem_erase.mpr ⟨hzero_one.symm, Finset.mem_univ oneConfig⟩)]
+  have hremaining :
+      ∑ sigma ∈ (Finset.univ.erase zeroConfig).erase oneConfig, f sigma = 0 := by
+    apply Finset.sum_eq_zero
+    intro sigma hsigma
+    simp only [Finset.mem_erase, Finset.mem_univ, and_true] at hsigma
+    have hnotzero : ¬∀ k, sigma k = 0 := fun h ↦ hsigma.2 (funext h)
+    have hnotone : ¬∀ k, sigma k = 1 := fun h ↦ hsigma.1 (funext h)
+    simp [f, evenWeight, hnotzero, hnotone, Real.negMulLog_zero]
+  rw [hremaining, add_zero]
+  have hfzero : f zeroConfig = Real.negMulLog (1 / 3) := by
+    norm_num [f, evenWeight, zeroConfig]
+  have hfone : f oneConfig = Real.negMulLog (2 / 3) := by
+    simp only [f, evenWeight, oneConfig]
+    rw [if_neg]
+    · norm_num
+    · intro h
+      have := h ⟨0, hNpos⟩
+      norm_num at this
+  rw [hfzero, hfone, Real.binEntropy_eq_negMulLog_add_negMulLog_one_sub]
+  norm_num
+
+/-- Every reduced block of an odd-length chain has zero von Neumann entropy.
+
+This is the entropy calculation underlying the odd-length mutual information
+in the counterexample to arXiv:1606.00608, Proposition 4.5, lines 801--806. -/
+theorem blockEntropy_parityTensor_of_odd {N L : ℕ} (hN : Odd N)
+    (hLN : L ≤ N) :
+    blockEntropy parityTensor N L hLN (parityTensor_isMPDO N hN.pos) = 0 := by
+  let hd : (Matrix.diagonal fun sigma : Fin L → Fin 2 =>
+      (oddWeight sigma : ℂ)).IsHermitian :=
+    Matrix.isHermitian_diagonal_of_self_adjoint _ (by
+      rw [isSelfAdjoint_iff]
+      ext sigma
+      simp [Complex.conj_ofReal])
+  calc
+    blockEntropy parityTensor N L hLN (parityTensor_isMPDO N hN.pos) =
+        vonNeumannEntropy (Matrix.diagonal fun sigma : Fin L → Fin 2 =>
+          (oddWeight sigma : ℂ)) hd :=
+      vonNeumannEntropy_congr (reducedBlockState_eq_diagonal_of_odd hN hLN) _ _
+    _ = 0 := vonNeumannEntropy_oddWeight hd
+
+/-- Every nonempty reduced block of a positive even-length chain has von
+Neumann entropy \(h_2(1/3)\).
+
+This is the entropy calculation underlying the even-length mutual information
+in the counterexample to arXiv:1606.00608, Proposition 4.5, lines 801--806. -/
+theorem blockEntropy_parityTensor_of_even {N L : ℕ} (hN : Even N)
+    (hNpos : 0 < N) (hLpos : 0 < L) (hLN : L ≤ N) :
+    blockEntropy parityTensor N L hLN (parityTensor_isMPDO N hNpos) =
+      Real.binEntropy (1 / 3) := by
+  let hd : (Matrix.diagonal fun sigma : Fin L → Fin 2 =>
+      (evenWeight sigma : ℂ)).IsHermitian :=
+    Matrix.isHermitian_diagonal_of_self_adjoint _ (by
+      rw [isSelfAdjoint_iff]
+      ext sigma
+      simp [Complex.conj_ofReal])
+  calc
+    blockEntropy parityTensor N L hLN (parityTensor_isMPDO N hNpos) =
+        vonNeumannEntropy (Matrix.diagonal fun sigma : Fin L → Fin 2 =>
+          (evenWeight sigma : ℂ)) hd :=
+      vonNeumannEntropy_congr
+        (reducedBlockState_eq_diagonal_of_even hN hNpos hLpos hLN) _ _
+    _ = Real.binEntropy (1 / 3) := vonNeumannEntropy_evenWeight hLpos hd
+
+/-- At odd total length, the mutual information across every proper cut is
+zero.
+
+This is the odd-length value of the quantity in arXiv:1606.00608,
+Proposition 4.5, lines 795--806. -/
+theorem mutualInfoChain_parityTensor_of_odd {N L : ℕ} (hN : Odd N)
+    (hLN : L < N) :
+    mutualInfoChain parityTensor N L (Nat.le_of_lt hLN)
+      (parityTensor_isMPDO N hN.pos) = 0 := by
+  rw [mutualInfoChain_eq,
+    blockEntropy_parityTensor_of_odd hN (Nat.le_of_lt hLN),
+    blockEntropy_parityTensor_of_odd hN (Nat.sub_le N L),
+    blockEntropy_parityTensor_of_odd hN (le_refl N)]
+  ring
+
+/-- At positive even total length, the mutual information across every
+nonempty proper cut is \(h_2(1/3)\).
+
+This is the even-length value of the quantity in arXiv:1606.00608,
+Proposition 4.5, lines 795--806. -/
+theorem mutualInfoChain_parityTensor_of_even {N L : ℕ} (hN : Even N)
+    (hLpos : 0 < L) (hLN : L < N) :
+    mutualInfoChain parityTensor N L (Nat.le_of_lt hLN)
+      (parityTensor_isMPDO N (by omega)) = Real.binEntropy (1 / 3) := by
+  rw [mutualInfoChain_eq,
+    blockEntropy_parityTensor_of_even hN (by omega) hLpos (Nat.le_of_lt hLN),
+    blockEntropy_parityTensor_of_even hN (by omega) (by omega) (Nat.sub_le N L),
+    blockEntropy_parityTensor_of_even hN (by omega) (by omega) (le_refl N)]
+  ring
+
+/-- For fixed block length \(L\), the mutual-information tail whose chain
+length is \(N=L+K+1\).
+
+This is exactly the inner sequence \(I_L^{(N)}\) from arXiv:1606.00608,
+Proposition 4.5, lines 801--806, restricted to its natural range \(N>L\). -/
+noncomputable def parityMutualInfoAfterCut (L K : ℕ) : ℝ :=
+  mutualInfoChain parityTensor (L + K + 1) L (by omega)
+    (parityTensor_isMPDO (L + K + 1) (by omega))
+
+private lemma parityMutualInfoAfterCut_of_odd {L K : ℕ} (hN : Odd (L + K + 1)) :
+    parityMutualInfoAfterCut L K = 0 := by
+  rw [parityMutualInfoAfterCut, mutualInfoChain_parityTensor_of_odd hN (by omega)]
+
+private lemma parityMutualInfoAfterCut_of_even {L K : ℕ} (hN : Even (L + K + 1))
+    (hLpos : 0 < L) :
+    parityMutualInfoAfterCut L K = Real.binEntropy (1 / 3) := by
+  rw [parityMutualInfoAfterCut,
+    mutualInfoChain_parityTensor_of_even hN hLpos (by omega)]
+
+/-- The binary entropy \(h_2(1/3)\) appearing in the counterexample of
+arXiv:1606.00608, lines 801--806, is strictly positive. -/
+theorem binEntropy_one_div_three_pos : 0 < Real.binEntropy (1 / 3) :=
+  Real.binEntropy_pos (by norm_num) (by norm_num)
+
+/-- At every fixed nonempty cut, the mutual information has no thermodynamic
+limit: its odd-length subsequence is zero, while its even-length subsequence is
+the strictly positive value \(h_2(1/3)\).
+
+This disproves the unrestricted inner-limit assertion in arXiv:1606.00608,
+Proposition 4.5, lines 801--806. -/
+theorem not_exists_tendsto_parityMutualInfoAfterCut (L : ℕ) (hLpos : 0 < L) :
+    ¬∃ x : ℝ, Tendsto (parityMutualInfoAfterCut L) atTop (nhds x) := by
+  rintro ⟨x, hx⟩
+  obtain ⟨K, hK⟩ := (Metric.tendsto_atTop.1 hx)
+    (Real.binEntropy (1 / 3) / 3) (by positivity [binEntropy_one_div_three_pos])
+  let J := 2 * (K + L) + 1 - L - 1
+  have hKJ : K ≤ J := by
+    dsimp [J]
+    omega
+  have hOddLength : Odd (L + J + 1) := by
+    refine ⟨K + L, ?_⟩
+    dsimp [J]
+    omega
+  have hEvenLength : Even (L + (J + 1) + 1) := by
+    refine ⟨K + L + 1, ?_⟩
+    dsimp [J]
+    omega
+  have hOddIndex := hK J hKJ
+  have hEvenIndex := hK (J + 1) (by omega)
+  rw [parityMutualInfoAfterCut_of_odd hOddLength] at hOddIndex
+  rw [parityMutualInfoAfterCut_of_even hEvenLength hLpos] at hEvenIndex
+  rw [Real.dist_eq, abs_lt] at hOddIndex hEvenIndex
+  linarith [binEntropy_one_div_three_pos]
 
 end MPOTensor.ThermodynamicLimitCounterexample

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
@@ -202,6 +202,51 @@
     entries, so the sequence cannot converge.
 \end{proof}
 
+\begin{theorem}[Mutual information without a thermodynamic limit]
+    \label{thm:parity_mpdo_no_mutual_info_limit}
+    \lean{MPOTensor.ThermodynamicLimitCounterexample.normalizedMPO_parityTensor_of_odd,
+      MPOTensor.ThermodynamicLimitCounterexample.normalizedMPO_parityTensor_of_even,
+      MPOTensor.ThermodynamicLimitCounterexample.reducedBlockState_parityTensor_of_odd,
+      MPOTensor.ThermodynamicLimitCounterexample.reducedBlockState_parityTensor_of_even,
+      MPOTensor.ThermodynamicLimitCounterexample.blockEntropy_parityTensor_of_odd,
+      MPOTensor.ThermodynamicLimitCounterexample.blockEntropy_parityTensor_of_even,
+      MPOTensor.ThermodynamicLimitCounterexample.mutualInfoChain_parityTensor_of_odd,
+      MPOTensor.ThermodynamicLimitCounterexample.mutualInfoChain_parityTensor_of_even,
+      MPOTensor.ThermodynamicLimitCounterexample.binEntropy_one_div_three_pos,
+      MPOTensor.ThermodynamicLimitCounterexample.parityMutualInfoAfterCut,
+      MPOTensor.ThermodynamicLimitCounterexample.not_exists_tendsto_parityMutualInfoAfterCut}
+    \leanok
+    \uses{def:mutual_info_chain, def:parity_mpdo_counterexample}
+    Fix $L\geq1$.  For every $N>L$, the tensor in
+    Definition~\ref{def:parity_mpdo_counterexample} satisfies
+    \[
+        I_L^{(N)}=
+        \begin{cases}
+            0, & N \text{ odd},\\
+            h_2(1/3), & N \text{ even},
+        \end{cases}
+        \qquad
+        h_2(1/3)
+        =-\frac13\log\frac13-\frac23\log\frac23>0.
+    \]
+    Consequently the sequence $K\mapsto I_L^{(L+K+1)}$ does not converge,
+    giving the counterexample described in
+    \cite[Proposition~4.5, lines~801--806]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    At odd $N$, the normalized state and both of its nonempty marginals are
+    pure, so all three terms in $I_L^{(N)}=S_L+S_{N-L}-S_N$ vanish.  At even
+    $N$, the full state and both marginals have the same two nonzero
+    eigenvalues $1/3$ and $2/3$.  Each of their entropies is therefore
+    $h_2(1/3)$, and hence
+    \[
+        I_L^{(N)}=h_2(1/3)+h_2(1/3)-h_2(1/3)=h_2(1/3).
+    \]
+    The binary entropy is strictly positive at $1/3$.  Thus the odd and even
+    subsequences have distinct constant values.
+\end{proof}
+
 \begin{definition}[Map on the second tensor factor]
     \label{def:mpdo_id_tensor_map}
     \lean{Matrix.idTensorMap}

--- a/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
@@ -272,16 +272,22 @@ oscillation.  Primitivity or another aperiodicity assumption would exclude
 this example, but no such assumption occurs in Proposition~4.5.
 
 The finite-chain form, positivity, trace formula, alternating normalized
-entries, alternating one-site reduced entries, and nonconvergence of the
-one-site entry are formalized.
+states and marginals, their exact entropies and mutual informations, and the
+nonconvergence of both the one-site entry and mutual information are
+formalized.
 \footnote{Formal declarations:
 \leanid{MPOTensor.ThermodynamicLimitCounterexample.mpo_parityTensor_eq_diagonal},
 \leanid{MPOTensor.ThermodynamicLimitCounterexample.parityTensor_isMPDO},
 \leanid{MPOTensor.ThermodynamicLimitCounterexample.trace_mpo_parityTensor},
 \leanid{MPOTensor.ThermodynamicLimitCounterexample.reducedBlockState_one_zero_zero_of_odd},
 \leanid{MPOTensor.ThermodynamicLimitCounterexample.reducedBlockState_one_zero_zero_of_even},
+\leanid{MPOTensor.ThermodynamicLimitCounterexample.reducedBlockState_parityTensor_of_even},
+\leanid{MPOTensor.ThermodynamicLimitCounterexample.blockEntropy_parityTensor_of_even},
+\leanid{MPOTensor.ThermodynamicLimitCounterexample.mutualInfoChain_parityTensor_of_odd},
+\leanid{MPOTensor.ThermodynamicLimitCounterexample.mutualInfoChain_parityTensor_of_even},
+\leanid{MPOTensor.ThermodynamicLimitCounterexample.not_exists_tendsto_reducedBlockState_one_zero_zero},
 and
-\leanid{MPOTensor.ThermodynamicLimitCounterexample.not_exists_tendsto_reducedBlockState_one_zero_zero}
+\leanid{MPOTensor.ThermodynamicLimitCounterexample.not_exists_tendsto_parityMutualInfoAfterCut}
 in \doclink{TNLean/MPS/MPDO/ThermodynamicLimitCounterexample}.}
 
 Accordingly, the precise unconditional result that remains from the cited


### PR DESCRIPTION
## Summary

This formalizes the parity-sensitive mutual-information counterexample from arXiv:1606.00608, Proposition 4.5, lines 795–806.

- It determines the normalized odd- and even-length states exactly.
- It determines every relevant reduced-block state exactly.
- It proves that the block entropies and mutual information alternate between 0 and the positive value h₂(1/3).
- It proves directly that, for every fixed nonempty cut, the natural tail K ↦ I_L^(L+K+1) does not converge.
- It records the result as a separate blueprint theorem and updates the corresponding paper-gap note.

No general entropy infrastructure is changed.

## Verification

- `lake build TNLean.MPS.MPDO.ThermodynamicLimitCounterexample` (8956/8956)
- `lake build` (9588/9588 on current main)
- `lake exe checkdecls blueprint/lean_decls`
- Blueprint–Lean sync: Chapter 21 area-law entries 110/110
- Axiom audit of the exact state, marginal, entropy, mutual-information, and nonconvergence theorems: only `propext`, `Classical.choice`, and `Quot.sound`
- No `sorry`, `axiom`, proof bypass, or overlong Lean line in the changed Lean file

Closes #4288

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additions are localized to one counterexample file and documentation; no changes to general entropy or mutual-information infrastructure.
> 
> **Overview**
> Extends the **parity MPDO thermodynamic-limit counterexample** with a full mutual-information story, not just the alternating one-site marginal.
> 
> In Lean (`ThermodynamicLimitCounterexample.lean`), the PR adds exact **odd/even** descriptions of normalized states and **reduced block** marginals, computes **block entropies** (0 vs \(h_2(1/3)\)), and proves **mutual information** is **0** at odd chain length and **\(h_2(1/3)\)** at even length. It defines **`parityMutualInfoAfterCut`** and proves **`not_exists_tendsto_parityMutualInfoAfterCut`**, so for any fixed nonempty cut the inner sequence \(K \mapsto I_L^{(L+K+1)}\) **does not converge**. New imports wire in mutual-info monotonicity, entropy decomposition, and binary entropy; module docs list the new main results.
> 
> **Blueprint** Chapter 21 gains theorem **“Mutual information without a thermodynamic limit”** with `\lean` links to the new declarations. The **paper-gap** note `cpgsv17_mpdo_mutual_information_bound.tex` is updated to state that entropies, mutual informations, and nonconvergence of mutual information are formalized, with additional `\leanid` references.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 447218edb6c5ca6cc14b3a196d46587a9eca33f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->