### PR TITLE
feat(Channel/Schwarz): prove singular ancilla additivity

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -172,6 +172,7 @@ import TNLean.Channel.Schwarz.RelativeEntropyDataProcessing
 import TNLean.Channel.Schwarz.PetzRecoverySupport
 import TNLean.Channel.Schwarz.StrongSubadditivityPosDef
 import TNLean.Channel.Schwarz.SSAEqualityDPI
+import TNLean.Channel.Schwarz.PetzEqualityPrerequisites
 import TNLean.Channel.Schwarz.WeylTwirl
 import TNLean.Channel.Schwarz.PositiveOnAbelian
 import TNLean.Channel.Schwarz.SchwarzNormal

--- a/TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean
+++ b/TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean
@@ -1,0 +1,79 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.Schwarz.PetzRecoverySupport
+import TNLean.Channel.Schwarz.SSAEqualityDPI
+
+/-!
+# Singular-support prerequisites for equality in data processing
+
+This file records analytic identities needed to study equality in the
+relative-entropy data-processing inequality without imposing invertibility on
+the positive semidefinite matrices.
+
+## Main result
+
+* `quantumRelativeEntropy_kronecker_support` proves ancilla additivity on the
+  finite-relative-entropy support domain.
+
+## References
+
+* P. Hayden, R. Jozsa, D. Petz, and A. Winter, *Structure of States Which
+  Satisfy Strong Subadditivity of Quantum Entropy with Equality*, Theorem 3,
+  arXiv:quant-ph/0304007v2.
+-/
+
+open scoped Matrix Kronecker ComplexOrder Matrix.Norms.L2Operator
+open Matrix
+
+/-- **Ancilla additivity on the singular support domain.** Let `ρ` and `σ` be
+positive semidefinite matrices with `ker σ ⊆ ker ρ`, and let `τ` be a positive
+semidefinite matrix of unit trace. Then
+`D(ρ ⊗ τ ‖ σ ⊗ τ) = D(ρ ‖ σ)`.
+
+The singular tensor-logarithm formula introduces the support projections of
+`ρ`, `σ`, and `τ`. The common ancilla-logarithm contribution cancels because
+the kernel inclusion makes both system support projections absorb `ρ`; the
+remaining factor is multiplied by `trace τ = 1`.
+
+This removes the positive-definite scope restriction from the ancilla identity
+used in the Weyl-twirl route to partial-trace data processing. It is an analytic
+prerequisite for the equality implication in Hayden--Jozsa--Petz--Winter,
+arXiv:quant-ph/0304007v2, Theorem 3; it does not itself assert recovery. -/
+theorem quantumRelativeEntropy_kronecker_support
+    {m n : Type*} [Fintype m] [DecidableEq m] [Fintype n] [DecidableEq n]
+    {ρ σ : Matrix m m ℂ} {τ : Matrix n n ℂ}
+    (hρ : ρ.PosSemidef) (hσ : σ.PosSemidef) (hτ : τ.PosSemidef)
+    (hτtrace : τ.trace = 1)
+    (hsupp : ∀ v : m → ℂ, σ.mulVec v = 0 → ρ.mulVec v = 0) :
+    quantumRelativeEntropy (ρ ⊗ₖ τ) (σ ⊗ₖ τ) =
+      quantumRelativeEntropy ρ σ := by
+  have hσabsorb :
+      hσ.isHermitian.supportProj * ρ * hσ.isHermitian.supportProj = ρ :=
+    Matrix.IsHermitian.supportProj_mul_mul_supportProj_of_mulVec_kernel_le
+      hσ.isHermitian hρ.isHermitian hsupp
+  have hρPσ : ρ * hσ.isHermitian.supportProj = ρ := by
+    calc
+      ρ * hσ.isHermitian.supportProj =
+          (hσ.isHermitian.supportProj * ρ * hσ.isHermitian.supportProj) *
+            hσ.isHermitian.supportProj := by rw [hσabsorb]
+      _ = hσ.isHermitian.supportProj * ρ *
+          (hσ.isHermitian.supportProj * hσ.isHermitian.supportProj) := by
+            simp only [Matrix.mul_assoc]
+      _ = hσ.isHermitian.supportProj * ρ * hσ.isHermitian.supportProj := by
+            rw [hσ.isHermitian.supportProj_idem]
+      _ = ρ := hσabsorb
+  have hρPρ : ρ * hρ.isHermitian.supportProj = ρ :=
+    hρ.isHermitian.mul_supportProj_self
+  have hτPτ : τ * hτ.isHermitian.supportProj = τ :=
+    hτ.isHermitian.mul_supportProj_self
+  rw [quantumRelativeEntropy, quantumRelativeEntropy,
+    Matrix.log_kronecker_posSemidef hρ hτ,
+    Matrix.log_kronecker_posSemidef hσ hτ]
+  simp only [Matrix.mul_sub, Matrix.mul_add, ← Matrix.mul_kronecker_mul,
+    Matrix.trace_sub, Matrix.trace_add, Matrix.trace_kronecker,
+    Complex.sub_re, Complex.add_re]
+  rw [hρPρ, hρPσ, hτPτ, hτtrace]
+  ring_nf

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -2180,6 +2180,41 @@ Theorem~\ref{thm:trace_norm_abs}.
     eigenvalue is zero.
 \end{proof}
 
+\begin{theorem}[Ancilla additivity on the support domain]
+    \label{thm:relative_entropy_ancilla_additivity_support}
+    \lean{quantumRelativeEntropy_kronecker_support}
+    \leanok
+    \uses{def:quantum_relative_entropy}
+    Let $\rho$ and $\sigma$ be positive semidefinite matrices such that
+    $\ker\sigma\subseteq\ker\rho$, and let $\tau$ be positive semidefinite with
+    $\operatorname{tr}\tau=1$.  Then
+    \[
+        D(\rho\otimes\tau\,\Vert\,\sigma\otimes\tau)
+        =D(\rho\,\Vert\,\sigma).
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:hermitian_support_projection,
+        lem:log_kronecker_possemidef,
+        thm:support_projection_absorption_kernel_inclusion}
+    Write $P_\rho$, $P_\sigma$, and $P_\tau$ for the support projections.  The
+    kernel inclusion gives
+    \[
+        P_\sigma\rho P_\sigma=\rho,
+        \qquad \rho P_\sigma=\rho,
+    \]
+    while $\rho P_\rho=\rho$ and $\tau P_\tau=\tau$.  Substituting the singular
+    tensor-logarithm formulas into the relative entropy and using these four
+    identities cancels the two contributions containing $\log\tau$.  Factoring
+    the trace of the remaining tensor product gives
+    \[
+        D(\rho\otimes\tau\,\Vert\,\sigma\otimes\tau)
+        =D(\rho\,\Vert\,\sigma)\operatorname{tr}\tau
+        =D(\rho\,\Vert\,\sigma).
+    \]
+\end{proof}
+
 \begin{theorem}[Relative entropy against the product of the marginals]
     \label{thm:relative_entropy_product_marginals}
     \lean{quantumRelativeEntropy_product_marginals}

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -217,6 +217,23 @@ in \path{TNLean/Channel/Schwarz/PetzRecoverySupport.lean}.}
 Thus the choice of trace-preserving extension away from the support is no
 longer part of the forward equality gap.
 
+The tensor-product identity required to identify the pre-twirl pair is also
+available without invertibility.  If $\rho$ and $\sigma$ are positive
+semidefinite, $\ker\sigma\subseteq\ker\rho$, and $\tau$ is positive
+semidefinite with $\operatorname{tr}\tau=1$, then
+\begin{align}
+  D(\rho\otimes\tau\Vert\sigma\otimes\tau)=D(\rho\Vert\sigma).
+\end{align}
+The proof expands the logarithm of a singular tensor product through the three
+support projections; support absorption and $\operatorname{tr}\tau=1$ remove
+the projection and ancilla terms.
+\footnote{Formal declaration:
+\leanid{quantumRelativeEntropy_kronecker_support} in
+\path{TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean}.}
+This identity is a prerequisite for transporting equality through the
+Weyl-twirl proof of data processing.  It does not prove that equality yields
+recovery.
+
 The exact remaining analytic implication is the equality case of data
 processing on this support domain:
 \begin{align}

--- a/docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex
+++ b/docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex
@@ -263,8 +263,7 @@ in place. Concretely:
     conjugation (\leanid{Matrix.log_conj_unitary}, itself the $f=\log$ case of the
     functional-calculus covariance \leanid{Matrix.cfc_conj_unitary}) followed by
     trace cyclicity. This ingredient needs no Lieb input. The
-    ancilla-additivity ingredient is now formalized as well, on the
-    positive-definite domain:
+    ancilla-additivity ingredient is formalized on the positive-definite domain:
     \leanid{quantumRelativeEntropy_kronecker} in
     \doclink{TNLean/Channel/Schwarz/RelativeEntropyAncillaAdditivity}
     (\path{TNLean/Channel/Schwarz/RelativeEntropyAncillaAdditivity.lean}) proves
@@ -284,8 +283,15 @@ in place. Concretely:
     \path{TNLean/Analysis/CfcLogAdditive.lean}). The difference of tensor
     logarithms then cancels the $\mathbf 1\otimes\log\tau$ terms, the trace of the
     Kronecker product factors as a product of traces, and the unit trace of $\tau$
-    leaves $D(\rho\,\|\,\sigma)$. These results depend only on the standard Lean
-    axioms and need no Lieb input. The third ingredient of layer (5) is the
+    leaves $D(\rho\,\|\,\sigma)$.  The corresponding singular-support identity
+    is \leanid{quantumRelativeEntropy_kronecker_support} in
+    \doclink{TNLean/Channel/Schwarz/PetzEqualityPrerequisites}
+    (\path{TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean}): it assumes
+    positive semidefiniteness, $\ker\sigma\subseteq\ker\rho$, and unit trace of
+    $\tau$, but no normalization of $\rho$ or $\sigma$.  Its proof uses the
+    tensor-logarithm formula on support projections and support absorption.
+    These results depend only on the standard Lean axioms and need no Lieb
+    input. The third ingredient of layer (5) is the
     twirling identity, which writes
     $\tr_C\rho\otimes(\mathbf 1_C/d_C)$ as a uniform average of conjugations by a
     unitary $1$-design on $C$. Because the current dependency carries no Haar


### PR DESCRIPTION
## Summary

- prove ancilla additivity of quantum relative entropy for positive semidefinite matrices on the finite-relative-entropy support domain
- use support-projection absorption to remove the projections in the singular tensor-logarithm formula
- record the exact theorem in the entropy blueprint and update the two paper-gap accounts

The new theorem assumes

$$
\rho,\sigma,\tau\ge 0,\qquad
\ker\sigma\subseteq\ker\rho,\qquad
\operatorname{tr}\tau=1,
$$

and proves

$$
D(\rho\otimes\tau\mathbin\|\sigma\otimes\tau)
=D(\rho\mathbin\|\sigma).
$$

There is no normalization assumption on $\rho$ or $\sigma$, and no invertibility assumption on any matrix.

## Source and scope

This is the first singular-support equality prerequisite under LionSR/TNLean#4228. Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2, Theorem 3, state the equality/recovery criterion and refer to Petz for its proof. The result here only identifies the relative entropy of the system after adjoining a normalized ancilla. It does not prove the remaining implication

$$
D(\rho\mathbin\|\sigma)
=D(\operatorname{tr}_R\rho\mathbin\|\operatorname{tr}_R\sigma)
\Longrightarrow
\mathcal R_\sigma(\operatorname{tr}_R\rho)=\rho.
$$

Thus LionSR/TNLean#4228 remains open.

## Verification

- `lake build TNLean.Channel.Schwarz.PetzEqualityPrerequisites`
- `lake env lean TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean`
- exact axiom audit: `[propext, Classical.choice, Quot.sound]`
- proof-integrity scan: no `sorry`, `admit`, `native_decide`, `unsafeCast`, or new `axiom`
- reader-facing prose check and `git diff --check`
- `scripts/blueprint_lean_sync.py`: blueprint and Lean declarations agree; Chapter 19 is 131/131

The local `leanblueprint checkdecls` invocation could not run because this fresh worktree does not contain the root `TNLean.olean`. The focused module build and source-level blueprint synchronization succeeded; remote CI will run the repository-wide declaration check.

Closes LionSR/QICLean#227.
Progress toward LionSR/TNLean#4228.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formal theorem and documentation only; no changes to auth, runtime behavior, or existing DPI proofs beyond registering the module in the root import.
> 
> **Overview**
> Adds **`quantumRelativeEntropy_kronecker_support`**, showing that for positive semidefinite `ρ`, `σ`, and unit-trace `τ` with **`ker σ ⊆ ker ρ`**, adjoining the ancilla does not change relative entropy: **`D(ρ ⊗ τ ‖ σ ⊗ τ) = D(ρ ‖ σ)`**. The proof uses the singular Kronecker logarithm with support projections and kernel-based absorption lemmas already in the Petz recovery stack—not the positive-definite **`quantumRelativeEntropy_kronecker`** split.
> 
> The result is exposed via **`TNLean.Channel.Schwarz.PetzEqualityPrerequisites`**, recorded in **Chapter 19** of the entropy blueprint, and noted in the **Hayashi–Markov** and **SSA-from-Lieb** gap documents as a prerequisite for equality in data processing (Weyl-twirl / HJPW Theorem 3), **without** proving Petz recovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41572570461c2a0c806cb9ff65dc721a38bf51d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->