### PR TITLE
fix(MPS/MPDO/BNTSeparatingProjectors): derive projector weights from ZCL

### DIFF
--- a/TNLean/MPS/MPDO/BNTSeparatingProjectors.lean
+++ b/TNLean/MPS/MPDO/BNTSeparatingProjectors.lean
@@ -25,6 +25,9 @@ retains them and assigns them to one BNT label, as documented in
   zero-weight Markov summand to a distinguished BNT label.
 * `exists_bntSeparatingProjectors_of_sameMPV₂Pos_isSAL_of_weight_copy_independent`:
   the separating projectors selected by SAL after copy independence is supplied.
+* `exists_bntSeparatingProjectors_of_horizontalCF_isSourceZCL_isSAL`:
+  the source-faithful standing-context theorem, with copy independence derived
+  from ZCL.
 
 ## References
 
@@ -240,11 +243,11 @@ simplicity, copy independence is the conclusion immediately preceding the
 projector lemma, and SAL supplies the four-site quantum-Markov decomposition.
 There is no independent closing-matrix hypothesis.
 
-**Scope restriction (copy-independent weights):** This theorem takes copy
-independence as the explicit hypothesis `hWeight`. The source obtains it from
-ZCL before the separating-projector lemma. A source-faithful standing-context
-formulation must instead derive `hWeight` from the source ZCL equation and the
-canonical-form gauge identity; see
+**Scope restriction (copy-independent weights):** This theorem assumes copy
+independence explicitly, while the source obtains it from ZCL before the
+separating-projector lemma. The standing-context theorem
+`exists_bntSeparatingProjectors_of_horizontalCF_isSourceZCL_isSAL` derives this
+equality from the source ZCL equation and the canonical-form gauge identity; see
 `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
 
 **Local fix (inactive sectors):** The source discards zero-weight Markov
@@ -313,5 +316,70 @@ theorem exists_bntSeparatingProjectors_of_sameMPV₂Pos_isSAL_of_weight_copy_ind
   · intro i s t hst β α
     exact completedBntSectorProjection_mul_physicalSlice_mul_eq_zero
       hC hρ hη hR s₀ i s t hst β α
+
+/-- **Separating projectors in the source standing context.**
+
+Let $M$ be a simple tensor in block-injective canonical form which satisfies
+ZCL and SAL. Its horizontal canonical form is presented through the direct
+sum of the weighted BNT copies and their block-diagonal gauge. Simplicity says
+that no representative has nilpotent physical-trace transfer, while biCF gives
+the simultaneous one-site span after the common blocking. Then the BNT
+representatives admit orthogonal projectors $P_s$ such that
+\[
+  \sum_s P_s=\mathbf 1,
+  \qquad
+  P_sK_i^{\beta\alpha}P_t=0
+  \quad\text{whenever }s\ne t\text{ or }i\ne s.
+\]
+
+Unlike the preceding specialization, this theorem does not assume that the
+copy weights agree. It derives their equality from the source ZCL equation
+and the horizontal canonical-form gauge identity.
+
+Source: arXiv:1606.00608, Appendix C.2, Case II and Lemma `lemmus`, lines
+1626--1691; the projector argument continues through line 1737. -/
+theorem exists_bntSeparatingProjectors_of_horizontalCF_isSourceZCL_isSAL
+    {D : ℕ} (M : MPOTensor d D)
+    (S : MPSTensor.SectorDecomposition (d * d))
+    (hCF : MPSTensor.IsBNTCanonicalForm S)
+    (hTotal : S.totalDim = D)
+    (X : (s : Fin S.totalCopies) → GL (Fin (S.flatDim s)) ℂ)
+    (hEq : ∀ i : Fin (d * d),
+      M.toMPSTensor i =
+        cast (by rw [hTotal] :
+            Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ =
+              Matrix (Fin D) (Fin D) ℂ)
+          ((MPSTensor.globalGaugeOfBlocks X :
+                Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ) *
+            S.toTensor i *
+            (((MPSTensor.globalGaugeOfBlocks X)⁻¹ :
+                GL (Fin S.totalDim) ℂ) :
+              Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ)))
+    (hnonNil : ∀ j,
+      ¬ IsNilpotent (doubledPhysTraceTransfer d (S.basis j)))
+    (hSpan : MPSTensor.WordTupleSpanTop S.basis 1)
+    (hZCL : IsSourceZCL M)
+    (hSAL : IsSAL M) :
+    ∃ P : Fin S.basisCount → Matrix (Fin d) (Fin d) ℂ,
+      (∀ s, IsOrthogonalProjection (P s)) ∧
+      (∀ s t, s ≠ t → P s * P t = 0) ∧
+      (∑ s, P s) = 1 ∧
+      ∀ (i s t : Fin S.basisCount), s ≠ t ∨ i ≠ s →
+        ∀ (β α : Fin (S.basisDim i)),
+          P s * physicalSlice (S.basisMPOTensor i) β α * P t = 0 := by
+  subst D
+  have hGauge : MPSTensor.GaugeEquiv S.toTensor M.toMPSTensor := by
+    refine ⟨MPSTensor.globalGaugeOfBlocks X, ?_⟩
+    intro i
+    simpa using hEq i
+  have hM : MPSTensor.SameMPV₂Pos M.toMPSTensor S.toTensor :=
+    fun N _hN σ ↦ (hGauge.sameMPV N σ).symm
+  have hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q' :=
+    weight_copy_independent_of_isSourceZCL S rfl X hEq hZCL hnonNil
+  obtain ⟨_, _, _, _, hProj, hOrth, hSum, hSeparate⟩ :=
+    exists_bntSeparatingProjectors_of_sameMPV₂Pos_isSAL_of_weight_copy_independent
+      M S hM hCF hWeight hnonNil hSpan hSAL
+  exact ⟨_, hProj, hOrth, hSum, hSeparate⟩
 
 end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
@@ -669,7 +669,7 @@ strong subadditivity for a normalized three-site reduced state.
 \end{definition}
 
 \begin{theorem}[Separating projectors with copy-independent weights]
-    \label{thm:mpdo_sal_bnt_separating_projectors}
+    \label{thm:mpdo_sal_bnt_separating_projectors_copy_independent}
     \lean{MPOTensor.completedBntSectorProjection_isOrthogonal}
     \lean{MPOTensor.completedBntSectorProjection_mul_eq_zero}
     \lean{MPOTensor.sum_completedBntSectorProjection}
@@ -699,9 +699,6 @@ strong subadditivity for a normalized three-site reduced state.
     separating-projector lemma in
     \cite[Appendix~C.2, lines~1680--1737]{Cirac2016MPDO_arXiv}.
 \end{theorem}
-% Scope restriction: the source-faithful standing-context implication from the
-% source ZCL equation and canonical-form gauge identity is not asserted here;
-% it must first derive copy independence as in lines 1646--1665.
 
 \begin{proof}
     \leanok
@@ -729,6 +726,41 @@ strong subadditivity for a normalized three-site reduced state.
       =0,
     \]
     since every summand vanishes by one of the three preceding cases.
+\end{proof}
+
+\begin{theorem}[Separating projectors for a simple tensor satisfying ZCL and SAL]
+    \label{thm:mpdo_sal_bnt_separating_projectors}
+    \lean{MPOTensor.%
+      exists_bntSeparatingProjectors_of_horizontalCF_isSourceZCL_isSAL}
+    \leanok
+    \uses{thm:mpdo_simple_weight_copy_independent,
+      thm:mpdo_sal_bnt_separating_projectors_copy_independent}
+    Let $K$ be a simple tensor in block-injective canonical form which satisfies
+    ZCL and SAL.  For the representatives $\mathcal K_i$ of its BNT, there are
+    orthogonal projectors $P_s$ such that
+    \[
+      \sum_sP_s=\Id,
+      \qquad
+      P_sK_i^{\beta\alpha}P_t=0
+      \quad\text{whenever }s\ne t\text{ or }i\ne s.
+    \]
+    This is the separating-projector lemma in
+    \cite[Appendix~C.2, lines~1626--1691]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Write the horizontal canonical form as
+    $K=G(\bigoplus_{j,q}\mu_{j,q}\mathcal K_j)G^{-1}$.  Restricting the ZCL
+    equation to the $(j,q)$-th block and using the non-nilpotence supplied by
+    simplicity gives
+    \[
+      \mu_{j,q}=\mu_{j,q'}
+      \qquad\text{for all }j,q,q'.
+    \]
+    The block-diagonal gauge preserves every positive-length periodic state,
+    so the canonical-form tensor and $K$ generate the same such states.  The
+    preceding copy-independent-weight theorem now supplies the projectors.
 \end{proof}
 
 \begin{theorem}[Positive-length BNT-sector compression]

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -327,15 +327,15 @@ The construction and its SAL specialization are
 \leanid{MPOTensor.%
 exists_bntSeparatingProjectors_of_sameMPV₂Pos_isSAL_of_weight_copy_independent}.
 
-\paragraph{Scope restriction (copy-independent weights).}
-The latter theorem assumes explicitly that the copy weights of each BNT
-representative agree.  The paper obtains this equality from ZCL immediately
-before the separating-projector argument (lines 1646--1665).  Thus the present
-theorem proves the projector conclusion after that equality is supplied, but
-does not yet establish the source's standing-context implication from simple
-biCF, ZCL, and SAL alone.  A source-faithful theorem must derive the required
-copy independence from the source ZCL equation and the canonical-form gauge
-identity before invoking the completed-projector construction.
+The source standing context is recovered by
+\leanid{MPOTensor.%
+exists_bntSeparatingProjectors_of_horizontalCF_isSourceZCL_isSAL}.
+It applies the ZCL equation to the horizontal canonical-form gauge identity,
+uses simplicity to exclude a zero physical-trace transfer, and thereby derives
+the equality of the copy weights proved at lines 1646--1665.  It then invokes
+the copy-independent specialization above.  Consequently the final theorem
+assumes only the simple biCF, ZCL, and SAL context of Appendix~C.2, rather than
+assuming copy independence separately.
 
 The empty-word value $N=0$ is excluded because its closed virtual trace records
 the bond dimension and is not a physical chain.  Positivity and ZCL of every


### PR DESCRIPTION
## Summary

- Prove the separating-projector lemma in the simple biCF, ZCL, and SAL
  standing context of arXiv:1606.00608, Appendix C.2.
- Derive equality of the copy weights from ZCL and the horizontal
  canonical-form gauge identity, rather than assuming that equality.
- Retain the copy-independent theorem as a separately labelled restriction and
  point the source-labelled blueprint entry only to the unrestricted theorem.
- Record the completed source-faithful implication in the corresponding
  paper-gap note.

## Mathematical argument

The horizontal canonical-form identity gives a gauge equivalence between the
doubled-index tensor and the direct sum of weighted BNT copies. Hence they
generate the same positive-length periodic states. Applying the ZCL equation to
the canonical-form display and using simplicity to exclude a nilpotent
physical-trace transfer shows that, for each BNT representative,
$\mu_{j,q}=\mu_{j,q'}$ for all copies $q,q'$.

The completed-projector theorem then supplies mutually orthogonal one-site
projectors whose sum is the ambient identity and which satisfy

$$
P_sK_i^{\beta\alpha}P_t=0
\quad\text{if }s\ne t\text{ or }i\ne s.
$$

This uses the argument at lines 1626--1737 of Appendix C.2 and does not invoke
Lemma C.5 or any result depending on its rank-one assertion.

## Source faithfulness

The final theorem assumes the paper's simple biCF, ZCL, and SAL context. Copy
independence and the nonzero closing contractions are derived rather than added
as separate hypotheses. The restricted copy-independent theorem remains under
its own blueprint label.

## Verification

- `lake env lean TNLean/MPS/MPDO/BNTSeparatingProjectors.lean`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --ci`
- `git diff --check origin/main...HEAD`
- Kernel audit of the new theorem:
  `[hayashi_ssa_equality_characterization_forward, propext,
  Classical.choice, Quot.sound]`

The Hayashi forward axiom is the sanctioned dependency inherited from the SAL
projector theorem. This change introduces no axiom, proof placeholder,
`native_decide`, or kernel bypass.

Closes #4309.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal proof is a thin composition of existing lemmas (gauge equivalence, ZCL weight independence, copy-independent projectors); documentation and blueprint label changes only, no auth or runtime impact.
> 
> **Overview**
> Adds **`exists_bntSeparatingProjectors_of_horizontalCF_isSourceZCL_isSAL`**, which proves the Appendix C.2 separating-projector lemma assuming only **simple biCF, source ZCL, and SAL**. Copy-weight equality is derived via **`weight_copy_independent_of_isSourceZCL`** from the horizontal canonical-form gauge identity and ZCL, then the existing copy-independent theorem is applied.
> 
> The copy-independent result stays as **`exists_bntSeparatingProjectors_of_sameMPV₂Pos_isSAL_of_weight_copy_independent`**; blueprint label **`thm:mpdo_sal_bnt_separating_projectors_copy_independent`** is introduced, and **`thm:mpdo_sal_bnt_separating_projectors`** now points only at the unrestricted theorem. The paper-gap note records that the source standing context is closed by the new implication.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ae64212d98be0b6b15a1982d6ecd95d69703987. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->