### PR TITLE
doc(Entropy): complete Petz support proof formulas

### DIFF
--- a/TNLean/Channel/Schwarz/PetzRecoverySupport.lean
+++ b/TNLean/Channel/Schwarz/PetzRecoverySupport.lean
@@ -74,7 +74,7 @@ variable {L R : Type*} [Fintype L] [DecidableEq L]
   [Fintype R] [DecidableEq R]
 
 /-- If positive semidefinite matrices `ρ` and `σ` satisfy
-`ker σ ⊆ ker ρ`, then the completed Petz channel associated with `σ` agrees
+$\ker σ \subseteq \ker ρ$, then the completed Petz channel associated with `σ` agrees
 with its support formula when applied to `partialTraceRight ρ`.
 
 The support inclusion transfers to the two marginals, so the first marginal is

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -1552,7 +1552,10 @@ Theorem~\ref{thm:trace_norm_abs}.
     The complementary projection $\mathbf 1-P_A$ has range contained in
     $\ker A$, and hence in $\ker B$. Thus
     $B(\mathbf 1-P_A)=0$. Taking adjoints gives
-    $(\mathbf 1-P_A)B=0$, and the result follows.
+    $(\mathbf 1-P_A)B=0$, so $B=P_A B$, and therefore
+    \[
+        P_A B P_A=P_A B=B.
+    \]
 \end{proof}
 
 \begin{definition}[Lift along one basis vector]
@@ -1576,8 +1579,13 @@ Theorem~\ref{thm:trace_norm_abs}.
 
 \begin{proof}\leanok
     \uses{def:single_basis_vector_lift}
-    Expand the matrix-vector product. The factor $e_r$ is zero away from the
-    index $r$, so the sum over the second index has only one nonzero term.
+    Since $(J_r w)_{(j,c)}=w_j\mathbf 1_{c=r}$, expansion of the
+    matrix-vector product gives
+    \[
+        [XJ_r w]_{(i,s)}
+        =\sum_{j,c}X_{(i,s),(j,c)}[J_r w]_{(j,c)}
+        =\sum_j X_{(i,s),(j,r)}w_j.
+    \]
 \end{proof}
 
 \begin{theorem}[Quadratic form of a right marginal]
@@ -1617,7 +1625,8 @@ Theorem~\ref{thm:trace_norm_abs}.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:partial_trace_quadratic_form_split}
+    \uses{thm:partial_trace_quadratic_form_split,
+        thm:matrix_action_single_basis_vector_lift}
     If $w\in\ker(\operatorname{tr}_R\sigma)$, then
     \[
         0=\langle w,(\operatorname{tr}_R\sigma)w\rangle
@@ -1654,8 +1663,14 @@ Theorem~\ref{thm:trace_norm_abs}.
     yields
     $P_\tau(\operatorname{tr}_R\rho)P_\tau
       =\operatorname{tr}_R\rho$, where
-    $\tau=\operatorname{tr}_R\sigma$. Agreement of the completed channel with
-    the support Petz map now applies.
+    $\tau=\operatorname{tr}_R\sigma$. The supported-agreement theorem gives
+    \[
+        P_\tau(\operatorname{tr}_R\rho)P_\tau
+        =\operatorname{tr}_R\rho
+        \;\Longrightarrow\;
+        \widehat{\mathcal R}_\sigma(\operatorname{tr}_R\rho)
+        =\mathcal R_\sigma(\operatorname{tr}_R\rho).
+    \]
 \end{proof}
 
 \begin{theorem}[The support Petz map recovers its reference]


### PR DESCRIPTION
### Motivation

- The exact-head review of LionSR/TNLean#4310 found one missing blueprint dependency and three proof calculations that were stated only verbally.
- The mathematical scope is the support-domain input for the partial-trace Petz formula in Hayden--Jozsa--Petz--Winter, Theorem 3, equation (8). No recovery theorem or theorem statement changes.

### Description

- Add the basis-vector lift theorem to the proof dependencies of marginal kernel inclusion.
- Display the support-projection absorption calculation, the basis-lift double-sum collapse, and the supported-agreement implication.
- Typeset the kernel inclusion in the Lean docstring as mathematics rather than as a code span.

### Testing

- `lake build TNLean.Channel.Schwarz.PetzRecoverySupport`
- `lake env lean TNLean/Channel/Schwarz/PetzRecoverySupport.lean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci --diff-base origin/main --diff-head HEAD`
- `leanblueprint web`
- `leanblueprint pdf`
- `leanblueprint checkdecls` was invoked after the focused build; it requires the project root object file produced by the full Lean build, so the exact full declaration check is left to PR CI.
- `git diff --check origin/main...HEAD`

Closes LionSR/QICLean#229

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Blueprint and docstring edits only; no changes to Lean proof terms, definitions, or theorem statements.
> 
> **Overview**
> Documentation-only follow-up for the partial-trace Petz **support-domain** chain (HJPW Theorem 3, eq. (8)): theorem statements and Lean proofs are unchanged.
> 
> In **ch19_entropy.tex**, three blueprint proofs now show intermediate algebra instead of one-line verbal steps: support-projection absorption (`P_A B P_A = B`), the basis-lift matrix–vector product (Kronecker delta collapse in the double sum), and the implication from marginal support to completed vs. support Petz channel agreement. The marginal kernel-inclusion proof **`\uses`** list now cites `thm:matrix_action_single_basis_vector_lift`, matching the Lean dependency graph.
> 
> In **`PetzRecoverySupport.lean`**, the main theorem docstring typesets \(\ker\sigma \subseteq \ker\rho\) as mathematics instead of a code span.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0abd540f692c91d99dc3c9435dafffdd17ca293d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->