### PR TITLE
feat(Channel/FixedPoint): restrict maps to stationary support

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -215,6 +215,7 @@ import TNLean.Channel.FixedPoint.CornerFixedPoints
 import TNLean.Channel.FixedPoint.MaximalRank
 import TNLean.Channel.FixedPoint.MaximalSupportBasic
 import TNLean.Channel.FixedPoint.MaximalSupport
+import TNLean.Channel.FixedPoint.StationarySupportRestriction
 import TNLean.Channel.FixedPoint.StationarySupport
 import TNLean.Channel.FixedPoint.WedderburnDecomp
 import TNLean.Channel.FixedPoint.WeightedCornerFixedPoints

--- a/TNLean/Algebra/OrthogonalProjection.lean
+++ b/TNLean/Algebra/OrthogonalProjection.lean
@@ -18,6 +18,7 @@ channels and irreducibility.
 
 * `IsOrthogonalProjection`
 * `IsOrthogonalProjection.one_sub`
+* `IsOrthogonalProjection.exists_range_isometry`
 * `IsStarProjection.conjTranspose_mul_mul_of_mul_conjTranspose_eq_one`
 * `isOrthogonalProjection_posSemidef`
 * `isOrthogonalProjection_sum_of_pairwise_mul_eq_zero`
@@ -78,6 +79,96 @@ theorem isOrthogonalProjection_posSemidef {P : Matrix (Fin D) (Fin D) ℂ}
     (hP : IsOrthogonalProjection P) :
     P.PosSemidef :=
   Matrix.nonneg_iff_posSemidef.mp hP.isStarProjection.nonneg
+
+/-- An orthogonal projection is the range projection of an isometry from a
+finite coordinate space. -/
+theorem IsOrthogonalProjection.exists_range_isometry
+    {P : Matrix (Fin D) (Fin D) ℂ} (hP : IsOrthogonalProjection P) :
+    ∃ (n : ℕ) (V : Matrix (Fin D) (Fin n) ℂ),
+      Vᴴ * V = 1 ∧ V * Vᴴ = P := by
+  classical
+  have hHerm : P.IsHermitian := hP.1
+  let U := hHerm.eigenvectorUnitary
+  let Umat : Matrix (Fin D) (Fin D) ℂ := (U : Matrix (Fin D) (Fin D) ℂ)
+  have hUU : Umat * Umatᴴ = 1 := by
+    simpa [Matrix.star_eq_conjTranspose] using Unitary.mul_star_self_of_mem U.prop
+  have hU'U : Umatᴴ * Umat = 1 := by
+    simpa [Matrix.star_eq_conjTranspose] using Matrix.UnitaryGroup.star_mul_self U
+  let f : Fin D → ℂ := fun j ↦ (↑(hHerm.eigenvalues j) : ℂ)
+  have hdiag : Umatᴴ * P * Umat = Matrix.diagonal f := by
+    have h := hHerm.conjStarAlgAut_star_eigenvectorUnitary
+    simpa [f, Umat, Matrix.star_eq_conjTranspose, Function.comp_def,
+      Unitary.conjStarAlgAut_star_apply] using h
+  have hdiag_idem : Matrix.diagonal f * Matrix.diagonal f = Matrix.diagonal f := by
+    rw [← hdiag]
+    calc
+      Umatᴴ * P * Umat * (Umatᴴ * P * Umat)
+          = Umatᴴ * (P * (Umat * Umatᴴ) * P) * Umat := by
+              simp only [Matrix.mul_assoc]
+      _ = Umatᴴ * (P * P) * Umat := by rw [hUU, Matrix.mul_one]
+      _ = Umatᴴ * P * Umat := by rw [hP.2]
+  have hf01 : ∀ j : Fin D, f j = 0 ∨ f j = 1 := by
+    intro j
+    have hfun : (fun k ↦ f k * f k) = f := by
+      apply Matrix.diagonal_injective
+      simpa [Matrix.diagonal_mul_diagonal] using hdiag_idem
+    exact IsIdempotentElem.iff_eq_zero_or_one.mp (congrFun hfun j)
+  let p : Fin D → Prop := fun j ↦ f j = 1
+  haveI : DecidablePred p := fun _ ↦ inferInstance
+  let S := {j : Fin D // p j}
+  let n := Fintype.card S
+  let eS : S ≃ Fin n := Fintype.equivFin S
+  let V : Matrix (Fin D) (Fin n) ℂ := fun i j ↦ Umat i (eS.symm j).1
+  refine ⟨n, V, ?_, ?_⟩
+  · ext j k
+    have hentry := congrFun (congrFun hU'U (eS.symm j).1) (eS.symm k).1
+    have heq : (eS.symm j).1 = (eS.symm k).1 ↔ j = k := by
+      constructor
+      · intro h
+        apply eS.symm.injective
+        exact Subtype.ext h
+      · intro h
+        subst k
+        rfl
+    simpa [V, Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.one_apply, heq]
+      using hentry
+  · have hPdecomp : P = Umat * Matrix.diagonal f * Umatᴴ := by
+      calc
+        P = (Umat * Umatᴴ) * P * (Umat * Umatᴴ) := by rw [hUU]; simp
+        _ = Umat * (Umatᴴ * P * Umat) * Umatᴴ := by simp [Matrix.mul_assoc]
+        _ = Umat * Matrix.diagonal f * Umatᴴ := by rw [hdiag]
+    rw [hPdecomp]
+    ext i k
+    change (∑ j : Fin n, Umat i ↑(eS.symm j) *
+        starRingEnd ℂ (Umat k ↑(eS.symm j))) =
+      (Umat * Matrix.diagonal f * Umatᴴ) i k
+    rw [Matrix.mul_apply]
+    simp only [Matrix.conjTranspose_apply]
+    have hmuldiag : ∀ j : Fin D,
+        (Umat * Matrix.diagonal f) i j = Umat i j * f j := by
+      intro j
+      rw [Matrix.mul_apply, Finset.sum_eq_single j]
+      · simp
+      · intro b _ hb
+        simp [hb]
+      · simp
+    simp_rw [hmuldiag]
+    calc
+      ∑ j : Fin n, Umat i ↑(eS.symm j) * starRingEnd ℂ (Umat k ↑(eS.symm j)) =
+          ∑ s : S, Umat i s.1 * starRingEnd ℂ (Umat k s.1) := by
+            exact Fintype.sum_equiv eS.symm _ _ (fun _ ↦ rfl)
+      _ = ∑ j : Fin D, if p j then
+            Umat i j * starRingEnd ℂ (Umat k j) else 0 := by
+          rw [← Finset.sum_filter]
+          simpa [S] using (Finset.sum_subtype_eq_sum_filter
+            (s := Finset.univ) (fun j : Fin D ↦
+              Umat i j * starRingEnd ℂ (Umat k j)) (p := p))
+      _ = ∑ j : Fin D, Umat i j * f j * starRingEnd ℂ (Umat k j) := by
+          apply Finset.sum_congr rfl
+          intro j _
+          by_cases hp : p j
+          · simp [hp, show f j = 1 from hp]
+          · simp [hp, show f j = 0 from (hf01 j).resolve_right hp]
 
 /-- A finite sum of pairwise orthogonal projections is an orthogonal
 projection. -/

--- a/TNLean/Channel/FixedPoint/StationarySupportRestriction.lean
+++ b/TNLean/Channel/FixedPoint/StationarySupportRestriction.lean
@@ -1,0 +1,491 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.HermitianHelpers
+import TNLean.Algebra.OrthogonalProjection
+import TNLean.Channel.FixedPoint.MaximalSupportBasic
+import TNLean.Channel.FixedPoint.StationaryProjection
+import TNLean.Channel.Spectral.Support
+
+/-!
+# Restriction to the support of a stationary positive matrix
+
+Let `T` be a positive trace-preserving endomorphism of a full matrix algebra and let
+`ρ` be a positive semidefinite fixed point.  The support of `ρ` is a stationary
+subspace: every matrix supported on this subspace is mapped to another matrix supported
+there.  Consequently, compression along an isometry onto this support is again positive
+and trace-preserving, and extension by zero intertwines the compressed and ambient maps.
+
+Maximality of the support of `ρ` is not needed here.  Taking
+`ρ = T∞(1)` from `IsPositiveMap.exists_maximalSupport_fixedPoint` gives the support used
+in Wolf's subsequent fixed-space reduction.
+
+## References
+
+* M. Wolf, *Quantum Channels & Operations: Guided Tour*, Proposition 6.10 and
+  “Restriction to full rank fixed points,” local source
+  `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1241--1258 and
+  1306--1336, especially Eqs. (6.51)--(6.52).
+-/
+
+open scoped Matrix Matrix.Norms.Frobenius ComplexOrder MatrixOrder BigOperators
+open Matrix
+
+namespace IsPositiveMap
+
+variable {D n : ℕ}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+/-- The support projection of a positive semidefinite matrix is dominated by a
+positive scalar multiple of the matrix.
+
+This is the finite-dimensional order estimate used in Wolf, Proposition 6.10:
+after compression to the support, the matrix is positive definite, so its least
+eigenvalue gives the required scalar. -/
+private theorem exists_supportProj_le_smul {ρ : Mat} (hρ : ρ.PosSemidef) :
+    ∃ c : ℂ, Kraus.stationaryProj hρ ≤ c • ρ := by
+  classical
+  let Q : Mat := Kraus.stationaryProj hρ
+  have hQproj : IsOrthogonalProjection Q :=
+    Kraus.isOrthogonalProjection_stationaryProj hρ
+  obtain ⟨n, V, hV, hVrange⟩ :=
+    IsOrthogonalProjection.exists_range_isometry hQproj
+  cases isEmpty_or_nonempty (Fin n) with
+  | inl hn =>
+      letI := hn
+      have hVzero : V = 0 := Subsingleton.elim _ _
+      have hQzero : Q = 0 := by simpa [hVzero] using hVrange.symm
+      exact ⟨0, by simp [Q, hQzero]⟩
+  | inr hn =>
+      letI := hn
+      let σ : Matrix (Fin n) (Fin n) ℂ := Vᴴ * ρ * V
+      have hσpd : σ.PosDef := by
+        have h := Matrix.PosSemidef.compression_on_support_posDef
+          (D := D) (ρ := ρ) hρ (k := n) (V := Vᴴ)
+          (by simpa [Matrix.conjTranspose_conjTranspose] using hV)
+          (by simpa [Q, Kraus.stationaryProj, Matrix.conjTranspose_conjTranspose]
+            using hVrange)
+        simpa [σ, Matrix.conjTranspose_conjTranspose] using h
+      let μ : ℝ := minEigenvalue hσpd.isHermitian
+      have hμpos : 0 < μ := minEigenvalue_pos_of_posDef hσpd.isHermitian hσpd
+      have hσgap : (σ - (μ : ℂ) • (1 : Matrix (Fin n) (Fin n) ℂ)).PosSemidef := by
+        simpa [μ] using sub_minEigenvalue_smul_one_posSemidef hσpd.isHermitian
+      have hambient := hσgap.mul_mul_conjTranspose_same V
+      have hρsupport : Q * ρ * Q = ρ := by
+        have hQρ : Q * ρ = ρ := by
+          simpa [Q] using Kraus.stationaryProj_mul hρ
+        have hρQ : ρ * Q = ρ := by
+          simpa [Q] using Kraus.mul_stationaryProj hρ
+        rw [hQρ, hρQ]
+      have hσexpand : V * σ * Vᴴ = Q * ρ * Q := by
+        calc
+          V * σ * Vᴴ = (V * Vᴴ) * ρ * (V * Vᴴ) := by
+            simp only [σ, Matrix.mul_assoc]
+          _ = Q * ρ * Q := by rw [hVrange]
+      have honeexpand :
+          V * (1 : Matrix (Fin n) (Fin n) ℂ) * Vᴴ = Q := by
+        rw [Matrix.mul_one, hVrange]
+      have hgap : (ρ - (μ : ℂ) • Q).PosSemidef := by
+        have heq :
+            V * (σ - (μ : ℂ) • (1 : Matrix (Fin n) (Fin n) ℂ)) * Vᴴ =
+              ρ - (μ : ℂ) • Q := by
+          calc
+            V * (σ - (μ : ℂ) • (1 : Matrix (Fin n) (Fin n) ℂ)) * Vᴴ =
+                V * σ * Vᴴ - (μ : ℂ) •
+                  (V * (1 : Matrix (Fin n) (Fin n) ℂ) * Vᴴ) := by
+              rw [Matrix.mul_sub, Matrix.sub_mul, Matrix.mul_smul, Matrix.smul_mul]
+            _ = Q * ρ * Q - (μ : ℂ) • Q := by rw [hσexpand, honeexpand]
+            _ = ρ - (μ : ℂ) • Q := by rw [hρsupport]
+        rw [← heq]
+        exact hambient
+      let c : ℂ := ((μ⁻¹ : ℝ) : ℂ)
+      have hc_nonneg : (0 : ℂ) ≤ c := by
+        dsimp [c]
+        positivity
+      have hscaled := hgap.smul hc_nonneg
+      have hscaled_eq : c • (ρ - (μ : ℂ) • Q) = c • ρ - Q := by
+        rw [smul_sub, smul_smul]
+        have hcμ : c * (μ : ℂ) = 1 := by
+          change (((μ⁻¹ : ℝ) : ℂ) * (μ : ℂ)) = 1
+          exact_mod_cast inv_mul_cancel₀ hμpos.ne'
+        rw [hcμ, one_smul]
+      rw [hscaled_eq] at hscaled
+      exact ⟨c, sub_nonneg.mp hscaled.nonneg⟩
+
+/-- **Wolf Proposition 6.10, positive-input form.** Let `ρ` be a positive
+semidefinite fixed point of a positive map `T`, and let `Q` be
+the support projection of `ρ`.  If a positive semidefinite matrix `A` is
+supported on `Q`, then `T A` is supported on `Q`.
+
+The proof is purely an order argument.  One has `A ≤ tr(A) Q`, while `Q` is
+bounded above by a positive scalar multiple of `ρ`.  Positivity and `T ρ = ρ`
+therefore place `T A` below a scalar multiple of `ρ`, so the support projection
+of `ρ` absorbs `T A`. Trace preservation is not used in this support
+invariance step.
+
+Source: Wolf, Proposition 6.10; local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1241--1258. -/
+theorem map_posSemidef_supported_on_fixedPoint_support
+    {T : Mat →ₗ[ℂ] Mat} (hT : IsPositiveMap T)
+    {ρ A : Mat} (hρ : ρ.PosSemidef) (hρfix : T ρ = ρ)
+    (hA : A.PosSemidef)
+    (hAsupport : Kraus.stationaryProj hρ * A * Kraus.stationaryProj hρ = A) :
+    Kraus.stationaryProj hρ * T A * Kraus.stationaryProj hρ = T A := by
+  classical
+  cases isEmpty_or_nonempty (Fin D) with
+  | inl hD =>
+      letI := hD
+      have hAzero : A = 0 := Subsingleton.elim _ _
+      simp [hAzero]
+  | inr hD =>
+      letI := hD
+      let Q : Mat := Kraus.stationaryProj hρ
+      have hQproj : IsOrthogonalProjection Q :=
+        Kraus.isOrthogonalProjection_stationaryProj hρ
+      obtain ⟨c, hQcρ⟩ := exists_supportProj_le_smul hρ
+      have htrQ_sub_A : (A.trace • Q - A).PosSemidef := by
+        have hbase := hA.trace_smul_one_sub_self_posSemidef
+        have hcorner := hbase.conjTranspose_mul_mul_same Q
+        have heq : Qᴴ * (A.trace • (1 : Mat) - A) * Q = A.trace • Q - A := by
+          rw [hQproj.1.eq, Matrix.mul_sub, Matrix.sub_mul, Matrix.mul_smul,
+            Matrix.smul_mul, Matrix.mul_one, hQproj.2, hAsupport]
+        rwa [heq] at hcorner
+      have hcρ_sub_Q : (c • ρ - Q).PosSemidef := by
+        have hQcρ' : Q ≤ c • ρ := by simpa [Q] using hQcρ
+        exact (sub_nonneg.mpr hQcρ').posSemidef
+      have htr_nonneg : (0 : ℂ) ≤ A.trace := hA.trace_nonneg
+      have hscaled := hcρ_sub_Q.smul htr_nonneg
+      have hbound : ((A.trace * c) • ρ - A).PosSemidef := by
+        have heq : A.trace • (c • ρ - Q) + (A.trace • Q - A) =
+            (A.trace * c) • ρ - A := by module
+        rw [← heq]
+        exact hscaled.add htrQ_sub_A
+      have himage := hT _ hbound
+      have hTbound : T A ≤ (A.trace * c) • ρ := by
+        rw [T.map_sub, T.map_smul, hρfix] at himage
+        exact sub_nonneg.mp himage.nonneg
+      have hTA := hT A hA
+      obtain ⟨hQTA, hTAQ⟩ := Kraus.stationaryProj_absorb_of_le_smul
+        hρ hTA (A.trace * c) hTbound
+      simpa [Q] using (show Q * T A * Q = T A by rw [Matrix.mul_assoc, hTAQ, hQTA])
+
+/-- **Wolf Eq. (6.52), support form.** Under the hypotheses of
+`map_posSemidef_supported_on_fixedPoint_support`, every matrix supported on the
+support projection of `ρ` is mapped to another matrix supported there.
+
+The positive-input order argument is extended linearly by writing an arbitrary
+matrix as a complex linear combination of four positive matrices.  No complete
+positivity, Schwarz inequality, or multiplicative property is used.
+
+Source: Wolf, “Restriction to full rank fixed points,” Eq. (6.52); local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1321--1333. -/
+theorem map_supported_on_fixedPoint_support
+    {T : Mat →ₗ[ℂ] Mat} (hT : IsPositiveMap T)
+    {ρ X : Mat} (hρ : ρ.PosSemidef) (hρfix : T ρ = ρ)
+    (hXsupport : Kraus.stationaryProj hρ * X * Kraus.stationaryProj hρ = X) :
+    Kraus.stationaryProj hρ * T X * Kraus.stationaryProj hρ = T X := by
+  classical
+  let Q : Mat := Kraus.stationaryProj hρ
+  have hQproj : IsOrthogonalProjection Q :=
+    Kraus.isOrthogonalProjection_stationaryProj hρ
+  obtain ⟨H₁, H₂, -, -, hH₁herm, hH₂herm, hXherm_decomp⟩ :=
+    Matrix.exists_isHermitian_decomposition X
+  let A₁p : Mat := Q * H₁⁺ * Q
+  let A₁m : Mat := Q * H₁⁻ * Q
+  let A₂p : Mat := Q * H₂⁺ * Q
+  let A₂m : Mat := Q * H₂⁻ * Q
+  have hcorner_psd {B : Mat} (hB : B.PosSemidef) :
+      (Q * B * Q).PosSemidef := by
+    have := hB.conjTranspose_mul_mul_same Q
+    rwa [hQproj.1.eq] at this
+  have hA₁p : A₁p.PosSemidef := hcorner_psd
+    (Matrix.nonneg_iff_posSemidef.mp (CFC.posPart_nonneg H₁))
+  have hA₁m : A₁m.PosSemidef := hcorner_psd
+    (Matrix.nonneg_iff_posSemidef.mp (CFC.negPart_nonneg H₁))
+  have hA₂p : A₂p.PosSemidef := hcorner_psd
+    (Matrix.nonneg_iff_posSemidef.mp (CFC.posPart_nonneg H₂))
+  have hA₂m : A₂m.PosSemidef := hcorner_psd
+    (Matrix.nonneg_iff_posSemidef.mp (CFC.negPart_nonneg H₂))
+  have hcorner_support (B : Mat) : Q * (Q * B * Q) * Q = Q * B * Q := by
+    rw [show Q * (Q * B * Q) * Q = (Q * Q) * B * (Q * Q) by
+      simp only [Matrix.mul_assoc], hQproj.2]
+  have hA₁ps : Q * A₁p * Q = A₁p := by simpa [A₁p] using hcorner_support H₁⁺
+  have hA₁ms : Q * A₁m * Q = A₁m := by simpa [A₁m] using hcorner_support H₁⁻
+  have hA₂ps : Q * A₂p * Q = A₂p := by simpa [A₂p] using hcorner_support H₂⁺
+  have hA₂ms : Q * A₂m * Q = A₂m := by simpa [A₂m] using hcorner_support H₂⁻
+  have hmap (A : Mat) (hA : A.PosSemidef) (hAs : Q * A * Q = A) :
+      Q * T A * Q = T A := by
+    simpa [Q] using map_posSemidef_supported_on_fixedPoint_support
+      hT hρ hρfix hA (by simpa [Q] using hAs)
+  have hmA₁p := hmap A₁p hA₁p hA₁ps
+  have hmA₁m := hmap A₁m hA₁m hA₁ms
+  have hmA₂p := hmap A₂p hA₂p hA₂ps
+  have hmA₂m := hmap A₂m hA₂m hA₂ms
+  have hH₁decomp : H₁ = H₁⁺ - H₁⁻ :=
+    (CFC.posPart_sub_negPart H₁ (isSelfAdjoint_iff.mpr hH₁herm)).symm
+  have hH₂decomp : H₂ = H₂⁺ - H₂⁻ :=
+    (CFC.posPart_sub_negPart H₂ (isSelfAdjoint_iff.mpr hH₂herm)).symm
+  have hXeq :
+      X = (2⁻¹ : ℂ) • (A₁p - A₁m) -
+        ((2⁻¹ : ℂ) * Complex.I) • (A₂p - A₂m) := by
+    calc
+      X = Q * X * Q := by simpa [Q] using hXsupport.symm
+      _ = Q * ((2⁻¹ : ℂ) • H₁ - ((2⁻¹ : ℂ) * Complex.I) • H₂) * Q := by
+        rw [← hXherm_decomp]
+      _ = (2⁻¹ : ℂ) • (A₁p - A₁m) -
+          ((2⁻¹ : ℂ) * Complex.I) • (A₂p - A₂m) := by
+        rw [hH₁decomp, hH₂decomp]
+        simp only [A₁p, A₁m, A₂p, A₂m, Matrix.mul_sub, Matrix.sub_mul,
+          Matrix.mul_smul, Matrix.smul_mul]
+  rw [hXeq, T.map_sub, T.map_smul, T.map_smul, T.map_sub, T.map_sub]
+  simp only [Matrix.mul_sub, Matrix.sub_mul, Matrix.mul_smul, Matrix.smul_mul]
+  rw [hmA₁p, hmA₁m, hmA₂p, hmA₂m]
+
+/-- Compression of a linear map along an isometric inclusion. -/
+noncomputable def stationarySupportCompression
+    (T : Mat →ₗ[ℂ] Mat) (V : Matrix (Fin D) (Fin n) ℂ) :
+    Matrix (Fin n) (Fin n) ℂ →ₗ[ℂ] Matrix (Fin n) (Fin n) ℂ where
+  toFun Y := Vᴴ * T (V * Y * Vᴴ) * V
+  map_add' X Y := by
+    rw [Matrix.mul_add, Matrix.add_mul, T.map_add, Matrix.mul_add, Matrix.add_mul]
+  map_smul' c X := by
+    simp [Matrix.mul_smul, Matrix.smul_mul]
+
+@[simp]
+theorem stationarySupportCompression_apply
+    (T : Mat →ₗ[ℂ] Mat) (V : Matrix (Fin D) (Fin n) ℂ)
+    (Y : Matrix (Fin n) (Fin n) ℂ) :
+    stationarySupportCompression T V Y = Vᴴ * T (V * Y * Vᴴ) * V := by
+  rfl
+
+/-- **Wolf Eq. (6.52), isometric form.** Extension by zero intertwines the
+compression of `T` to the support of a stationary positive matrix with `T`.
+
+Source: Wolf, “Restriction to full rank fixed points,” Eq. (6.52); local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1321--1333. -/
+theorem stationarySupportCompression_intertwine
+    {T : Mat →ₗ[ℂ] Mat} (hT : IsPositiveMap T)
+    {ρ : Mat} (hρ : ρ.PosSemidef) (hρfix : T ρ = ρ)
+    (V : Matrix (Fin D) (Fin n) ℂ) (hV : Vᴴ * V = 1)
+    (hVrange : V * Vᴴ = Kraus.stationaryProj hρ)
+    (Y : Matrix (Fin n) (Fin n) ℂ) :
+    T (V * Y * Vᴴ) = V * stationarySupportCompression T V Y * Vᴴ := by
+  let Q : Mat := Kraus.stationaryProj hρ
+  have hZsupport : Q * (V * Y * Vᴴ) * Q = V * Y * Vᴴ := by
+    dsimp [Q]
+    rw [← hVrange]
+    calc
+      (V * Vᴴ) * (V * Y * Vᴴ) * (V * Vᴴ) =
+          V * ((Vᴴ * V) * Y * (Vᴴ * V)) * Vᴴ := by
+            simp only [Matrix.mul_assoc]
+      _ = V * Y * Vᴴ := by rw [hV, Matrix.one_mul, Matrix.mul_one]
+  have hTZsupport := map_supported_on_fixedPoint_support hT hρ hρfix
+    (by simpa [Q] using hZsupport)
+  calc
+    T (V * Y * Vᴴ) = Q * T (V * Y * Vᴴ) * Q := by
+      simpa [Q] using hTZsupport.symm
+    _ = (V * Vᴴ) * T (V * Y * Vᴴ) * (V * Vᴴ) := by rw [hVrange]
+    _ = V * (Vᴴ * T (V * Y * Vᴴ) * V) * Vᴴ := by
+      simp only [Matrix.mul_assoc]
+    _ = V * stationarySupportCompression T V Y * Vᴴ := rfl
+
+/-- The compression of a positive map to the support of a stationary positive
+matrix is positive.
+
+Source: Wolf, “Restriction to full rank fixed points”; local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1321--1326. -/
+theorem stationarySupportCompression_isPositiveMap
+    {T : Mat →ₗ[ℂ] Mat} (hT : IsPositiveMap T)
+    (V : Matrix (Fin D) (Fin n) ℂ) :
+    IsPositiveMap (stationarySupportCompression T V) := by
+  intro Y hY
+  have hVY : (V * Y * Vᴴ).PosSemidef := hY.mul_mul_conjTranspose_same V
+  have hTVY : (T (V * Y * Vᴴ)).PosSemidef := hT _ hVY
+  have hcompressed := hTVY.mul_mul_conjTranspose_same Vᴴ
+  simpa [stationarySupportCompression, Matrix.conjTranspose_conjTranspose] using hcompressed
+
+/-- The compression of a positive trace-preserving map to the support of a
+stationary positive matrix is trace-preserving.
+
+Source: Wolf, “Restriction to full rank fixed points”; local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1326--1333. -/
+theorem stationarySupportCompression_isTracePreservingMap
+    {T : Mat →ₗ[ℂ] Mat} (hT : IsPositiveMap T) (hTP : IsTracePreservingMap T)
+    {ρ : Mat} (hρ : ρ.PosSemidef) (hρfix : T ρ = ρ)
+    (V : Matrix (Fin D) (Fin n) ℂ) (hV : Vᴴ * V = 1)
+    (hVrange : V * Vᴴ = Kraus.stationaryProj hρ) :
+    IsTracePreservingMap (stationarySupportCompression T V) := by
+  intro Y
+  let T' := stationarySupportCompression T V
+  have hintertwine :=
+    stationarySupportCompression_intertwine
+      hT hρ hρfix V hV hVrange Y
+  have hext_trace (Z : Matrix (Fin n) (Fin n) ℂ) :
+      Matrix.trace (V * Z * Vᴴ) = Matrix.trace Z := by
+    calc
+      Matrix.trace (V * Z * Vᴴ) = Matrix.trace (Vᴴ * (V * Z)) :=
+        Matrix.trace_mul_comm (V * Z) Vᴴ
+      _ = Matrix.trace Z := by rw [← Matrix.mul_assoc, hV, Matrix.one_mul]
+  calc
+    Matrix.trace (T' Y) = Matrix.trace (V * T' Y * Vᴴ) := (hext_trace (T' Y)).symm
+    _ = Matrix.trace (T (V * Y * Vᴴ)) := by rw [hintertwine]
+    _ = Matrix.trace (V * Y * Vᴴ) := hTP _
+    _ = Matrix.trace Y := hext_trace Y
+
+/-- Compression to the support of a stationary positive matrix preserves both
+positivity and trace preservation, and extension by zero intertwines it with
+the ambient map.
+
+Source: Wolf, “Restriction to full rank fixed points”; local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1306--1333. -/
+theorem stationarySupportCompression_isPositiveMap_and_isTracePreservingMap
+    {T : Mat →ₗ[ℂ] Mat} (hT : IsPositiveMap T) (hTP : IsTracePreservingMap T)
+    {ρ : Mat} (hρ : ρ.PosSemidef) (hρfix : T ρ = ρ)
+    (V : Matrix (Fin D) (Fin n) ℂ) (hV : Vᴴ * V = 1)
+    (hVrange : V * Vᴴ = Kraus.stationaryProj hρ) :
+    IsPositiveMap (stationarySupportCompression T V) ∧
+      IsTracePreservingMap (stationarySupportCompression T V) ∧
+      ∀ Y : Matrix (Fin n) (Fin n) ℂ,
+        T (V * Y * Vᴴ) = V * stationarySupportCompression T V Y * Vᴴ :=
+  ⟨stationarySupportCompression_isPositiveMap hT V,
+    stationarySupportCompression_isTracePreservingMap
+      hT hTP hρ hρfix V hV hVrange,
+    stationarySupportCompression_intertwine
+      hT hρ hρfix V hV hVrange⟩
+
+/-- The compression to the support of a positive stationary matrix has a
+positive-definite fixed point, namely the compression of that matrix.
+
+Source: Wolf, “Restriction to full rank fixed points”; local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1333--1336. -/
+theorem exists_posDef_fixedPoint_stationarySupportCompression
+    {T : Mat →ₗ[ℂ] Mat} {ρ : Mat} (hρ : ρ.PosSemidef) (hρfix : T ρ = ρ)
+    (V : Matrix (Fin D) (Fin n) ℂ) (hV : Vᴴ * V = 1)
+    (hVrange : V * Vᴴ = Kraus.stationaryProj hρ) :
+    ∃ σ : Matrix (Fin n) (Fin n) ℂ,
+      σ.PosDef ∧ stationarySupportCompression T V σ = σ := by
+  let σ : Matrix (Fin n) (Fin n) ℂ := Vᴴ * ρ * V
+  have hσpd : σ.PosDef := by
+    have h := Matrix.PosSemidef.compression_on_support_posDef
+      (D := D) (ρ := ρ) hρ (k := n) (V := Vᴴ)
+      (by simpa [Matrix.conjTranspose_conjTranspose] using hV)
+      (by simpa [Kraus.stationaryProj, Matrix.conjTranspose_conjTranspose]
+        using hVrange)
+    simpa [σ, Matrix.conjTranspose_conjTranspose] using h
+  refine ⟨σ, hσpd, ?_⟩
+  have hρsupport : Kraus.stationaryProj hρ * ρ * Kraus.stationaryProj hρ = ρ := by
+    rw [Kraus.stationaryProj_mul hρ, Kraus.mul_stationaryProj hρ]
+  change Vᴴ * T (V * (Vᴴ * ρ * V) * Vᴴ) * V = Vᴴ * ρ * V
+  rw [show V * (Vᴴ * ρ * V) * Vᴴ = ρ by
+    calc
+      V * (Vᴴ * ρ * V) * Vᴴ = (V * Vᴴ) * ρ * (V * Vᴴ) := by
+        simp only [Matrix.mul_assoc]
+      _ = Kraus.stationaryProj hρ * ρ * Kraus.stationaryProj hρ := by rw [hVrange]
+      _ = ρ := hρsupport, hρfix]
+
+/-- **Wolf Eq. (6.51).** Suppose the support projection `Q` of the stationary
+positive matrix `ρ` carries every fixed point of `T`.  Then the fixed points of
+`T` are exactly the fixed points of the compressed map, extended by zero on
+the orthogonal complement of `Q`.
+
+For the canonical choice `ρ = T∞(1)`, the support hypothesis is supplied by
+`IsPositiveMap.exists_maximalSupport_fixedPoint`.  Thus the theorem states the
+complementary zero summand without imposing an additional property on `T`.
+
+Source: Wolf, “Restriction to full rank fixed points,” Eq. (6.51); local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1306--1336.
+
+**Scope restriction (supported fixed space):** this auxiliary statement takes
+the support property of every fixed point as a hypothesis. The source-faithful
+choice `ρ = T∞(1)` and the derivation of that property are packaged in
+`exists_maximalSupportCompression`. The distinction is recorded in
+`docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex`. -/
+theorem fixedPoint_iff_exists_fixedPoint_stationarySupportCompression
+    {T : Mat →ₗ[ℂ] Mat} (hT : IsPositiveMap T)
+    {ρ : Mat} (hρ : ρ.PosSemidef) (hρfix : T ρ = ρ)
+    (hmax : ∀ X : Mat, T X = X →
+      Kraus.stationaryProj hρ * X * Kraus.stationaryProj hρ = X)
+    (V : Matrix (Fin D) (Fin n) ℂ) (hV : Vᴴ * V = 1)
+    (hVrange : V * Vᴴ = Kraus.stationaryProj hρ) (X : Mat) :
+    T X = X ↔ ∃ Y : Matrix (Fin n) (Fin n) ℂ,
+      stationarySupportCompression T V Y = Y ∧ X = V * Y * Vᴴ := by
+  constructor
+  · intro hXfix
+    let Y : Matrix (Fin n) (Fin n) ℂ := Vᴴ * X * V
+    have hXsupport := hmax X hXfix
+    have hXeq : X = V * Y * Vᴴ := by
+      calc
+        X = Kraus.stationaryProj hρ * X * Kraus.stationaryProj hρ := hXsupport.symm
+        _ = (V * Vᴴ) * X * (V * Vᴴ) := by rw [hVrange]
+        _ = V * (Vᴴ * X * V) * Vᴴ := by simp only [Matrix.mul_assoc]
+        _ = V * Y * Vᴴ := rfl
+    refine ⟨Y, ?_, hXeq⟩
+    change Vᴴ * T (V * (Vᴴ * X * V) * Vᴴ) * V = Vᴴ * X * V
+    rw [← hXeq, hXfix]
+  · rintro ⟨Y, hYfix, rfl⟩
+    rw [stationarySupportCompression_intertwine
+      hT hρ hρfix V hV hVrange Y, hYfix]
+
+/-- The canonical maximal-support stationary point `T∞(1)`. -/
+noncomputable def maximalSupportPoint
+    (T : Mat →ₗ[ℂ] Mat) (hT : IsPositiveMap T) (hTP : IsTracePreservingMap T) : Mat :=
+  LinearMap.meanErgodicProjection (𝕜 := ℂ)
+    (E := Matrix (Fin D) (Fin D) ℂ) T
+    (hT.hasBoundedOrbits_of_tracePreserving hTP) 1
+
+/-- **Wolf restriction to full-rank fixed points, Eqs. (6.51)--(6.52).**
+Let `T` be positive and trace preserving, set `ρ₀ = T∞(1)`, and restrict `T`
+to the support of `ρ₀`. There is an isometric support coordinate map `V` for
+which the compressed endomorphism is positive and trace preserving, extension
+by zero intertwines it with `T`, and the compressed endomorphism has a
+positive-definite fixed point. Moreover, every fixed point of `T` is uniquely
+represented by extension of a compressed fixed point, so the complementary
+summand vanishes.
+
+No complete positivity, Schwarz inequality, multiplicativity, or unitality is
+assumed.
+
+Source: Wolf, “Restriction to full rank fixed points”; local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1306--1336,
+especially Eqs. (6.51)--(6.52). -/
+theorem exists_maximalSupportCompression
+    {T : Mat →ₗ[ℂ] Mat} (hT : IsPositiveMap T) (hTP : IsTracePreservingMap T) :
+    let ρ₀ := maximalSupportPoint T hT hTP
+    ∃ (hρ₀ : ρ₀.PosSemidef) (n : ℕ) (V : Matrix (Fin D) (Fin n) ℂ),
+      T ρ₀ = ρ₀ ∧ Vᴴ * V = 1 ∧ V * Vᴴ = Kraus.stationaryProj hρ₀ ∧
+      IsPositiveMap (stationarySupportCompression T V) ∧
+      IsTracePreservingMap (stationarySupportCompression T V) ∧
+      (∀ Y : Matrix (Fin n) (Fin n) ℂ,
+        T (V * Y * Vᴴ) = V * stationarySupportCompression T V Y * Vᴴ) ∧
+      (∃ σ : Matrix (Fin n) (Fin n) ℂ,
+        σ.PosDef ∧ stationarySupportCompression T V σ = σ) ∧
+      ∀ X : Mat, T X = X ↔ ∃ Y : Matrix (Fin n) (Fin n) ℂ,
+        stationarySupportCompression T V Y = Y ∧ X = V * Y * Vᴴ := by
+  classical
+  dsimp only
+  let hbounded : LinearMap.HasBoundedOrbits T :=
+    hT.hasBoundedOrbits_of_tracePreserving hTP
+  let ρ₀ : Mat := maximalSupportPoint T hT hTP
+  have hmaximal : ∃ hρ₀ : ρ₀.PosSemidef, T ρ₀ = ρ₀ ∧
+      ∀ X : Mat, T X = X →
+        Kraus.stationaryProj hρ₀ * X * Kraus.stationaryProj hρ₀ = X := by
+    simpa only [ρ₀, maximalSupportPoint, hbounded] using
+      hT.exists_maximalSupport_fixedPoint hTP
+  obtain ⟨hρ₀, hρ₀fix, hmax⟩ := hmaximal
+  obtain ⟨n, V, hV, hVrange⟩ :=
+    IsOrthogonalProjection.exists_range_isometry
+      (Kraus.isOrthogonalProjection_stationaryProj hρ₀)
+  obtain ⟨hpositive, htrace, hintertwine⟩ :=
+    stationarySupportCompression_isPositiveMap_and_isTracePreservingMap
+      hT hTP hρ₀ hρ₀fix V hV hVrange
+  have hfaithful := exists_posDef_fixedPoint_stationarySupportCompression
+    hρ₀ hρ₀fix V hV hVrange
+  have hfixed := fixedPoint_iff_exists_fixedPoint_stationarySupportCompression
+    hT hρ₀ hρ₀fix hmax V hV hVrange
+  exact ⟨hρ₀, n, V, hρ₀fix, hV, hVrange, hpositive, htrace,
+    hintertwine, hfaithful, hfixed⟩
+
+end IsPositiveMap

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -311,6 +311,27 @@ fixed-point space of the adjoint endomorphism.  The remaining step for
 Theorem 6.14 begins by combining this retraction with the full-support
 star-algebra description.
 
+In `TNLean.Channel.FixedPoint.StationarySupportRestriction`:
+
+* `IsPositiveMap.map_posSemidef_supported_on_fixedPoint_support` — the order
+  argument of Wolf Proposition 6.10 for a positive matrix supported on the
+  support of an arbitrary stationary positive matrix.
+* `IsPositiveMap.map_supported_on_fixedPoint_support` — the extension to every
+  supported matrix by decomposition into four positive matrices.
+* `IsPositiveMap.stationarySupportCompression_isPositiveMap` and
+  `IsPositiveMap.stationarySupportCompression_isTracePreservingMap` — the
+  supported compression is positive and trace-preserving.
+* `IsPositiveMap.exists_posDef_fixedPoint_stationarySupportCompression` — the
+  compressed stationary matrix is positive definite.
+* `IsPositiveMap.fixedPoint_iff_exists_fixedPoint_stationarySupportCompression`
+  — the scope-restricted auxiliary form of Wolf Equation (6.51), conditional
+  on a fixed-point space already known to be supported in the chosen corner.
+* `IsPositiveMap.exists_maximalSupportCompression` — the source-faithful
+  restriction theorem: it chooses $T_\infty(\mathbf 1)$ through
+  `IsPositiveMap.exists_maximalSupport_fixedPoint` and packages positivity,
+  trace preservation, a positive-definite compressed fixed point,
+  Equation (6.52), and the complementary zero summand of Equation (6.51).
+
 In `TNLean.Channel.FixedPoint.FullSupportBlockRetraction`:
 
 * `IsPositiveMap.exists_block_densities_of_adjoint_meanErgodicProjection` —
@@ -363,12 +384,12 @@ positive semidefinite fixed point):
   corner-restricted set only; extending by zero on the complement does not
   produce ambient fixed points in general.
 
-What is still missing for the full Wolf statement is the reduction to the
-support of a maximum-rank fixed point, including positive definiteness of the
-supported density blocks, and transport back to the ambient space with the
-complementary zero block.  Applying the full-support theorem to the transported
-sector channels of arXiv:1606.00608 additionally requires a direct-sum version
-or an extension through the block-diagonal embedding.
+What is still missing for the full Wolf statement is to apply the full-support
+block theorem to the positive trace-preserving support compression, transport
+the result back to the ambient space, and combine the discarded density
+kernels with the complementary zero block.  Applying the full-support theorem
+to the transported sector channels of arXiv:1606.00608 additionally requires a
+direct-sum version or an extension through the block-diagonal embedding.
 
 ### Wolf Corollary 6.7 (faithful fixed-point conjugation) — FORMALIZED (Kraus case)
 

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -3078,6 +3078,125 @@ transfers the support.
     \]
 \end{proof}
 
+\begin{theorem}[Restriction to the support of a stationary positive matrix]%
+    \label{thm:stationarySupport_restriction}
+    \lean{IsPositiveMap.map_supported_on_fixedPoint_support}
+    \leanok
+    \uses{def:positive_map, def:support_proj,
+        lem:stationaryProj_absorb_of_le}
+    Let $T:\MN{D}\to\MN{D}$ be positive, and let
+    $\rho\succeq0$ satisfy $T(\rho)=\rho$. If $Q$ is the support projection of
+    $\rho$, then for every $X\in\MN{D}$,
+    \[
+        QXQ=X \quad\Longrightarrow\quad QT(X)Q=T(X).
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:stationaryProj_absorb_of_le}
+    First suppose $A\succeq0$ and $QAQ=A$.  On the support of $\rho$, the
+    matrix $\rho$ is positive definite, so $Q\preceq c\rho$ for some positive
+    scalar $c$.  Moreover,
+    \[
+        A\preceq\tr(A)Q,
+    \]
+    because this follows by compressing
+    $\tr(A)\Id-A\succeq0$ with $Q$.  Positivity and $T(\rho)=\rho$ therefore give
+    \[
+        0\preceq T(A)\preceq c\tr(A)\rho.
+    \]
+    Scalar domination transfers the support, hence $QT(A)Q=T(A)$.
+    Write $H_1=X+X^*$ and $H_2=\mathrm{i}(X-X^*)$, so that both matrices are
+    Hermitian and
+    \[
+        X=\tfrac{1}{2}H_1-\tfrac{\mathrm{i}}{2}H_2.
+    \]
+    Setting $A_j^\pm=QH_j^\pm Q$ gives positive matrices with
+    $QA_j^\pm Q=A_j^\pm$ and
+    \[
+        X=\tfrac{1}{2}(A_1^+-A_1^-)-\tfrac{\mathrm{i}}{2}(A_2^+-A_2^-).
+    \]
+    Applying the positive-input conclusion to these four matrices and using
+    linearity of $T$ gives the assertion.
+\end{proof}
+
+\begin{theorem}[Restriction to full-rank fixed points]%
+    \label{thm:stationarySupport_compression}
+    \lean{IsPositiveMap.exists_maximalSupportCompression}
+    \leanok
+    \uses{thm:maximalSupport_fixedPoint, thm:stationarySupport_restriction}
+    Let $T:\MN{D}\to\MN{D}$ be positive and trace preserving, set
+    $\rho_0=T_\infty(\Id)$, and let $Q_0$ be the support projection of
+    $\rho_0$. There are a finite-dimensional Hilbert space $\mathcal H$ and an
+    isometry $V:\mathcal H\to\mathbb C^D$ with
+    $V^*V=\Id_{\mathcal H}$ and $VV^*=Q_0$ such that
+    \[
+        \widetilde T(Y)=V^*T(VYV^*)V
+    \]
+    is positive and trace preserving and has a positive definite fixed point.
+    Moreover,
+    \[
+        T(VYV^*)=V\widetilde T(Y)V^*,
+    \]
+    and
+    \[
+        T(X)=X
+        \quad\Longleftrightarrow\quad
+        \exists\,Y:\widetilde T(Y)=Y,\quad X=VYV^*.
+    \]
+    These are Equations~(6.52) and~(6.51), respectively,
+    of~\cite{Wolf2012Quantum}. Thus the complementary fixed-point summand
+    vanishes.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:maximalSupport_fixedPoint, thm:stationarySupport_restriction}
+    Theorem~\ref{thm:maximalSupport_fixedPoint} gives $\rho_0$ and shows that
+    $Q_0XQ_0=X$ for every fixed point $X$ of $T$. Choose an isometry onto the
+    range of $Q_0$.
+    Positivity follows from positivity of conjugation and of $T$.  The matrix
+    $VYV^*$ is supported on $Q_0$, so the preceding theorem shows that its
+    image is also supported there. Inserting $Q_0=VV^*$ gives
+    \[
+        T(VYV^*)
+        =Q_0T(VYV^*)Q_0
+        =VV^*T(VYV^*)VV^*
+        =V\widetilde T(Y)V^*.
+    \]
+    By cyclicity of the trace, the isometry identity, and trace preservation of
+    $T$,
+    \[
+        \tr(\widetilde T(Y))
+        =\tr(V\widetilde T(Y)V^*)
+        =\tr(T(VYV^*))
+        =\tr(VYV^*)
+        =\tr(Y).
+    \]
+    Thus $\widetilde T$ is trace preserving. The compressed point
+    $\sigma_0=V^*\rho_0V$ is positive definite. Since
+    $V\sigma_0V^*=Q_0\rho_0Q_0=\rho_0$,
+    \[
+        \widetilde T(\sigma_0)
+        =V^*T(\rho_0)V
+        =V^*\rho_0V
+        =\sigma_0.
+    \]
+    If $T(X)=X$, then $Q_0XQ_0=X$, and hence
+    $X=V(V^*XV)V^*$. Moreover,
+    \[
+        \widetilde T(V^*XV)
+        =V^*T\bigl(V(V^*XV)V^*\bigr)V
+        =V^*T(X)V
+        =V^*XV.
+    \]
+    Conversely, if $\widetilde T(Y)=Y$, then the intertwining identity gives
+    \[
+        T(VYV^*)=V\widetilde T(Y)V^*=VYV^*.
+    \]
+\end{proof}
+
 \begin{theorem}[Conjugation by the square root at a fixed point of maximal support]%
     \label{thm:maximalSupport_weightedCorner}
     \lean{Kraus.exists_maximalSupport_weightedCorner_sqrt_eq}

--- a/docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex
+++ b/docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex
@@ -113,19 +113,55 @@ support and range of every fixed point.
 \leanid{IsPositiveMap.exists_maximalSupport_fixedPoint} in
 \doclink{TNLean/Channel/FixedPoint/MaximalSupportBasic}.}
 
-Two arguments remain to obtain the general fixed-point statement above.  First, the
-positive semidefinite density matrices supplied by Proposition~1.5 must be
-restricted to their supports; this produces the positive definite matrices
-in Theorem~6.14.  Second, the discarded kernels must be combined with the
-subspace on which every fixed point vanishes, thereby recovering the zero
-summand $\mathcal H_0$.
+The restriction to this support is also formalized in the same generality.
+If $\rho\succeq0$ is any fixed point and $Q$ is its support projection, then
+every positive matrix in $Q M_D(\mathbb C)Q$ is mapped back into that corner.
+Decomposition into four positive matrices extends the conclusion to every
+matrix in the corner.  Hence, for an isometry $V$ with $V^*V=\mathbf 1$ and
+$VV^*=Q$, the map
+\begin{align}
+  \widetilde T(X)=V^*T(VXV^*)V
+\end{align}
+is positive and trace preserving, has a positive definite fixed point, and
+satisfies
+\begin{align}
+  T(VXV^*)=V\widetilde T(X)V^*.
+  \tag{Wolf, Equation (6.52)}
+\end{align}
+When $\rho=T_\infty(\mathbf 1)$, maximal support further gives
+\begin{align}
+  \operatorname{Fix}(T)=V\operatorname{Fix}(\widetilde T)V^*.
+  \tag{Wolf, Equation (6.51)}
+\end{align}
+Thus every ambient fixed point has zero complementary block.
+The auxiliary fixed-space equivalence is also retained in conditional form:
+for a general stationary $\rho$, it assumes
+$QXQ=X$ for every $X\in\operatorname{Fix}(T)$.  This is the hypothesis named
+\texttt{hmax} in
+\leanid{IsPositiveMap.fixedPoint_iff_exists_fixedPoint_stationarySupportCompression}.
+The source-faithful theorem
+\leanid{IsPositiveMap.exists_maximalSupportCompression} has no such exposed
+hypothesis: it takes $\rho_0=T_\infty(\mathbf 1)$ and derives the support property
+from \leanid{IsPositiveMap.exists_maximalSupport_fixedPoint}.
+\footnote{Formal declarations:
+\leanid{IsPositiveMap.map_supported_on_fixedPoint_support},
+and
+\leanid{IsPositiveMap.exists_maximalSupportCompression}
+in
+\doclink{TNLean/Channel/FixedPoint/StationarySupportRestriction}.}
+
+It remains to apply the full-support fixed-point theorem to $\widetilde T$,
+transport its density-block form through $V$, and combine the complement of
+$Q$ with the kernels discarded when each density matrix is restricted to its
+support.  This last combination produces the single zero summand
+$\mathcal H_0$ of Theorem~6.14.
 
 Thus Proposition~1.5, its application to the full-support adjoint
 mean-ergodic projection, and the full-support Schr\"odinger-picture fixed-point
-formula, together with the maximal-support witness, are formalized, while
-Theorem~6.14 remains open.  The missing work is to construct the supported
-endomorphism, apply the full-support formula there, and recover the zero block
-from the discarded kernels.
+formula, together with the maximal-support witness and the positive
+trace-preserving restriction to its support, are formalized, while
+Theorem~6.14 remains open.  The missing work is the application and transport
+of the full-support formula and the final assembly of the discarded kernels.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
Closes LionSR/QICLean#228. Advances LionSR/TNLean#4120.

## Mathematical content

This proves Wolf's restriction to full-rank fixed points for an arbitrary positive trace-preserving endomorphism, without assuming complete positivity, a Kraus representation, a Schwarz inequality, multiplicativity, unitality, or irreducibility.

For a positive semidefinite stationary point `ρ`, the proof first shows that every positive matrix supported on `supp(ρ)` is mapped back into that support. The order argument is the one in Wolf Proposition 6.10: the support projection is dominated by a scalar multiple of `ρ`, while a supported positive matrix `A` is dominated by `tr(A)` times the support projection. The conclusion is then extended to an arbitrary supported matrix through four positive supported parts.

For the canonical maximal-support point `ρ₀ = T∞(1)` supplied by LionSR/TNLean#4314, the new source-faithful wrapper chooses a support isometry `V` and proves:

- the compression `T̃(Y) = V† T(V Y V†) V` is positive and trace preserving;
- `T(V Y V†) = V T̃(Y) V†`, Wolf Eq. (6.52);
- `T̃` has a positive-definite fixed point;
- `Fix(T) = V Fix(T̃) V†`, equivalently `Fix(T) = Fix(T̃) ⊕ 0`, Wolf Eq. (6.51).

The conditional fixed-space lemma remains available as an explicitly scope-restricted auxiliary. The blueprint source label points only to the maximal-support wrapper.

The Wolf Chapter 6 index, spectral blueprint, and `docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex` are updated. Wolf Theorem 6.14 remains open: the full-support density-block theorem must still be applied to `T̃`, transported through `V`, and combined with the discarded density kernels.

## Verification

- `lake env lean TNLean/Channel/FixedPoint/StationarySupportRestriction.lean`
- `lake build TNLean.Channel.FixedPoint.StationarySupportRestriction`
- proof-integrity scan: no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast`
- `#print axioms` for the positive-input theorem, arbitrary-input theorem, compressed-map theorem, positive-definite fixed-point theorem, conditional fixed-space theorem, and source-faithful wrapper: exactly `[propext, Classical.choice, Quot.sound]`

Local `leanblueprint web` could not generate `blueprint/lean_decls`: its Python 3.14 plasTeX process could not import the Python 3.9 `leanblueprint` package. A focused `checkdecls` invocation also requires `TNLean.olean`, which is absent from the fresh targeted-build worktree. Blueprint declaration validation is therefore left to CI.

## Source

- Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 6, local source `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1241–1258 and 1306–1336, especially Eqs. (6.51)–(6.52).
- `docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style formalization and documentation with no runtime or security surface; main risk is proof maintenance and downstream theorem wiring, not production behavior.
> 
> **Overview**
> Formalizes **Wolf’s restriction to full-rank fixed points** for positive trace-preserving maps on matrix algebras, without extra hypotheses (CP, Kraus, Schwarz, etc.).
> 
> **Algebra:** `IsOrthogonalProjection.exists_range_isometry` realizes an orthogonal projection as `V V†` from an isometry `V†V = 1`.
> 
> **New `StationarySupportRestriction`:** For stationary PSD `ρ`, shows maps preserve the support corner (`map_supported_on_fixedPoint_support`), defines `stationarySupportCompression`, and proves positivity, trace preservation, intertwining (Eq. 6.52), a positive-definite compressed fixed point, and fixed-space identification (Eq. 6.51) via `exists_maximalSupportCompression` using `ρ₀ = T∞(1)` from prior maximal-support work.
> 
> **Docs:** Root import, Wolf Ch. 6 index, blueprint theorems, and the Theorem 6.14 gap note now treat this restriction step as done; remaining work is applying the full-support block theorem to the compressed map and assembling discarded kernels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d085434098fa681aeb1513370c4ea950752992e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->