### PR TITLE
doc(blueprint/MPDO): record the Lemma C.5 consequence obstruction

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels.tex
@@ -991,9 +991,15 @@ $\widehat{\cal K}$.
     to ${\cal K}^{[2]}$.
 \end{proof}
 
-% **Obstruction (dependence on Lemma C.5):** the source construction begins
-% with the neighboring trace factorization supplied through prop2to3.  Its
-% derivation from SAL and ZCL is obstructed by the rank-one step in Lemma C.5.
+% **Refuted prerequisite (Lemma C.5):**
+% lem:mpdo_sal_zcl_rank_one_trace_matrix is formally refuted under its printed
+% SAL and ZCL hypotheses by thm:mpdo_sal_zcl_rank_one_counterexample. Hence the
+% printed proof through prop2to3 does not establish implication (ii) => (v),
+% which remains unformalized rather than refuted. A conditional construction of
+% rank-one and local-structure data under positive semidefiniteness or linear
+% independence is given by thm:simple_mpdo_local_structure_data_of_sal_zcl. The
+% conditional blocking theorem thm:mpdo_blocked_original_tensor_is_rfp_via_ts
+% instead assumes a neighboring trace factorization.
 % Documented in docs/paper-gaps/cpgsv17_pf_rank_one.tex.
 \begin{theorem}[SAL and ZCL give the two blocking channels]
     \label{thm:mpdo_sal_zcl_blocking_channels}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -159,8 +159,14 @@
     $Q$, and direct multiplication gives $Q(1-LQ)L\ne0$.
 \end{proof}
 
-% **Obstruction (dependence on Lemma C.5):** the source corollary includes the
-% unavailable rank-one trace factorization.  Documented in
+% **Refuted prerequisite (Lemma C.5):**
+% lem:mpdo_sal_zcl_rank_one_trace_matrix is formally refuted under its printed
+% SAL and ZCL hypotheses by thm:mpdo_sal_zcl_rank_one_counterexample. Hence its
+% use in the printed derivation of the source corollary fails, and that
+% corollary remains unformalized under the source hypotheses. A conditional
+% construction of rank-one and local-structure data under positive
+% semidefiniteness or linear independence is given by
+% thm:simple_mpdo_local_structure_data_of_sal_zcl. Documented in
 % docs/paper-gaps/cpgsv17_pf_rank_one.tex.
 \begin{corollary}[Local sector structure from SAL and ZCL]
     \label{cor:mpdo_sal_zcl_local_sector_structure}
@@ -259,9 +265,14 @@ $\mathcal K_i=P_i\mathcal K_i=\mathcal K_iP_i$.
 This is the calculation in
 \cite[Appendix~C.2, lines~1745--1751]{Cirac2016MPDO_arXiv}.
 
-% **Obstruction (dependence on Lemma C.5):** the rank-one trace factorization
-% in this proposition is exactly the unavailable conclusion of
-% lem:mpdo_sal_zcl_rank_one_trace_matrix.  Documented in
+% **Refuted prerequisite (Lemma C.5):**
+% lem:mpdo_sal_zcl_rank_one_trace_matrix is formally refuted under its printed
+% SAL and ZCL hypotheses by thm:mpdo_sal_zcl_rank_one_counterexample. Hence its
+% use in the printed derivation of this proposition fails, and the proposition
+% remains unformalized under the source hypotheses. A conditional construction
+% of rank-one and local-structure data under positive semidefiniteness or linear
+% independence is given by
+% thm:simple_mpdo_local_structure_data_of_sal_zcl. Documented in
 % docs/paper-gaps/cpgsv17_pf_rank_one.tex.
 \begin{theorem}[SAL and ZCL give the BNT sector structure]
     \label{thm:mpdo_sal_zcl_bnt_sector_structure}


### PR DESCRIPTION
## Historical change

This documentation pull request updated the blueprint comments for the local-sector corollary, the BNT sector theorem, and the SAL--ZCL blocking-channel theorem. It made explicit that all three printed derivations pass through the unresolved rank-one step in Appendix C.2, Lemma C.5, while the downstream conclusions themselves remained unformalized.

It also cross-referenced the valid restricted rank-one criteria and `docs/paper-gaps/cpgsv17_pf_rank_one.tex`.

## Retrospective normalization correction (2026-08-03)

The original description said that Lemma C.5 was formally refuted. PR #5389 established that this was too strong. The raw four-sector tensor satisfies SAL and literal fixed-tensor ZCL but is not the normal unit-weight representative used in Case I; its normal rescaling has unit weight but fails literal fixed-tensor ZCL.

The durable conclusion is therefore an obstruction at the normalization boundary. Lemma C.5, its structural corollary, `prop2to3`, and `prop2to5` remain unformalized rather than refuted. The current blueprint and paper-gap record carry this corrected classification.

No Lean declaration changed in this historical pull request.

Closes the documentation task #4298; corrected by #5389.