### PR TITLE
feat(Channel/Schwarz): propagate Weyl-twirl saturation

### DIFF
--- a/TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean
+++ b/TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean
@@ -17,6 +17,9 @@ the positive semidefinite matrices.
 
 * `quantumRelativeEntropy_kronecker_support` proves ancilla additivity on the
   finite-relative-entropy support domain.
+* `quantumRelativeEntropy_weyl_average_eq_summand_of_partialTraceRight_eq`
+  propagates saturation of partial-trace data processing to each summand in the
+  finite Weyl average.
 
 ## References
 
@@ -77,3 +80,72 @@ theorem quantumRelativeEntropy_kronecker_support
     Complex.sub_re, Complex.add_re]
   rw [hρPρ, hρPσ, hτPτ, hτtrace]
   ring_nf
+
+/-- **Partial-trace saturation propagates to every Weyl summand.** Let `ρ` and
+`σ` be positive semidefinite matrices with `ker σ ⊆ ker ρ`. If their relative
+entropy is unchanged by the right partial trace, then the relative entropy of
+the finite Weyl average equals that of each Weyl-conjugated pair.
+
+The Weyl average is first identified with the marginal pair tensored with the
+maximally mixed ancilla. Singular-support ancilla additivity reduces its
+relative entropy to that of the marginals, while unitary invariance reduces the
+chosen summand to `D(ρ ‖ σ)`. The saturation hypothesis identifies these two
+values.
+
+This is an equality-propagation prerequisite for Hayden--Jozsa--Petz--Winter,
+arXiv:quant-ph/0304007v2, Theorem 3 and equation (8); it does not assert the
+equality condition for joint convexity or Petz recovery. -/
+theorem quantumRelativeEntropy_weyl_average_eq_summand_of_partialTraceRight_eq
+    {dS dC : ℕ} [NeZero dC]
+    {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
+    (hρ : ρ.PosSemidef) (hσ : σ.PosSemidef)
+    (hsupp : ∀ v : Fin dS × ZMod dC → ℂ, σ.mulVec v = 0 → ρ.mulVec v = 0)
+    (heq : quantumRelativeEntropy ρ σ =
+      quantumRelativeEntropy (partialTraceRight ρ) (partialTraceRight σ))
+    {ζ : ℂ} (hζ : IsPrimitiveRoot ζ dC) (a b : ZMod dC) :
+    quantumRelativeEntropy
+        (((dC : ℂ) ^ 2)⁻¹ • ∑ c : ZMod dC, ∑ e : ZMod dC,
+          ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ c e) * ρ *
+            ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ c e)ᴴ)
+        (((dC : ℂ) ^ 2)⁻¹ • ∑ c : ZMod dC, ∑ e : ZMod dC,
+          ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ c e) * σ *
+            ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ c e)ᴴ) =
+      quantumRelativeEntropy
+        (((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ a b) * ρ *
+          ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ a b)ᴴ)
+        (((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ a b) * σ *
+          ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ a b)ᴴ) := by
+  classical
+  have hsuppM : ∀ w : Fin dS → ℂ,
+      (partialTraceRight σ).mulVec w = 0 → (partialTraceRight ρ).mulVec w = 0 :=
+    fun _ hw => partialTraceRight_support hσ hsupp hw
+  let U : unitary
+      (Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ) :=
+    ⟨(1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ a b,
+      Matrix.kronecker_mem_unitary (Submonoid.one_mem _) (weyl_mem_unitary hζ a b)⟩
+  calc
+    quantumRelativeEntropy
+        (((dC : ℂ) ^ 2)⁻¹ • ∑ c : ZMod dC, ∑ e : ZMod dC,
+          ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ c e) * ρ *
+            ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ c e)ᴴ)
+        (((dC : ℂ) ^ 2)⁻¹ • ∑ c : ZMod dC, ∑ e : ZMod dC,
+          ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ c e) * σ *
+            ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ c e)ᴴ) =
+        quantumRelativeEntropy
+          (partialTraceRight ρ ⊗ₖ
+            ((dC : ℂ)⁻¹ • (1 : Matrix (ZMod dC) (ZMod dC) ℂ)))
+          (partialTraceRight σ ⊗ₖ
+            ((dC : ℂ)⁻¹ • (1 : Matrix (ZMod dC) (ZMod dC) ℂ))) := by
+              rw [sum_kronecker_one_weyl_conj hζ ρ,
+                sum_kronecker_one_weyl_conj hζ σ]
+    _ = quantumRelativeEntropy (partialTraceRight ρ) (partialTraceRight σ) :=
+      quantumRelativeEntropy_kronecker_support hρ.partialTraceRight
+        hσ.partialTraceRight maximallyMixed_posDef.posSemidef maximallyMixed_trace hsuppM
+    _ = quantumRelativeEntropy ρ σ := heq.symm
+    _ = quantumRelativeEntropy
+        (((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ a b) * ρ *
+          ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ a b)ᴴ)
+        (((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ a b) * σ *
+          ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ a b)ᴴ) := by
+            simpa only [Unitary.coe_star, star_eq_conjTranspose, U] using
+              (quantumRelativeEntropy_conj_unitary hρ.isHermitian hσ.isHermitian U).symm

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -1108,6 +1108,24 @@ Theorem~\ref{thm:trace_norm_abs}.
     the injectivity of $b \mapsto \zeta^{b}$ on residues.
 \end{proof}
 
+\begin{theorem}[Unitarity of the Weyl operators]
+    \label{thm:weyl_operator_unitary}
+    \lean{Matrix.weylShift_mem_unitary}
+    \lean{Matrix.weylClock_mem_unitary}
+    \lean{Matrix.weyl_mem_unitary}
+    \leanok
+    Fix a dimension $d\geq 1$ and a primitive $d$-th root of unity $\zeta$.
+    The cyclic shift $X$, the clock operator $Z$, and every Weyl operator
+    $W(a,b)=X^aZ^b$ are unitary.
+\end{theorem}
+
+\begin{proof}\leanok
+    The cyclic shift is the permutation matrix of a cyclic permutation.  The
+    clock operator is diagonal, and each diagonal entry is a power of $\zeta$,
+    hence has modulus one.  Thus $X$ and $Z$ are unitary, and so is every product
+    $X^aZ^b$.
+\end{proof}
+
 \begin{theorem}[Weyl-operator unitary 1-design twirl]
     \label{thm:weyl_twirl}
     \lean{Matrix.sum_weyl_conj}
@@ -1166,6 +1184,21 @@ Theorem~\ref{thm:trace_norm_abs}.
     $\mathbf 1_C / d_C$. The block trace is exactly the corresponding entry of the
     partial trace $\tr_C M$, so the average is $(\tr_C M) \otimes
     (\mathbf 1_C / d_C)$.
+\end{proof}
+
+\begin{theorem}[The maximally mixed ancilla]
+    \label{thm:maximally_mixed_ancilla}
+    \lean{Matrix.maximallyMixed_posDef}
+    \lean{Matrix.maximallyMixed_trace}
+    \leanok
+    For $d_C\geq 1$, the matrix $\tau_C=d_C^{-1}\mathbf 1_C$ is positive
+    definite and has trace one.
+\end{theorem}
+
+\begin{proof}\leanok
+    The identity is positive definite and $d_C^{-1}>0$, so $\tau_C$ is positive
+    definite.  Moreover,
+    $\operatorname{tr}\tau_C=d_C^{-1}\operatorname{tr}\mathbf 1_C=1$.
 \end{proof}
 
 \begin{lemma}[Reindexing invariance of the quantum relative entropy]
@@ -2213,6 +2246,58 @@ Theorem~\ref{thm:trace_norm_abs}.
         =D(\rho\,\Vert\,\sigma)\operatorname{tr}\tau
         =D(\rho\,\Vert\,\sigma).
     \]
+\end{proof}
+
+\begin{theorem}[Partial-trace saturation at each Weyl summand]
+    \label{thm:relative_entropy_weyl_average_eq_summand}
+    \lean{quantumRelativeEntropy_weyl_average_eq_summand_of_partialTraceRight_eq}
+    \leanok
+    \uses{def:quantum_relative_entropy, def:partial_trace}
+    Let $\rho$ and $\sigma$ be positive semidefinite matrices on
+    $\mathcal H_S\otimes\mathbb C^{d_C}$ such that
+    $\ker\sigma\subseteq\ker\rho$, and suppose that
+    \[
+        D(\rho\Vert\sigma)
+          =D(\tr_C\rho\Vert\tr_C\sigma).
+    \]
+    For a primitive $d_C$-th root of unity, put
+    $U_{ab}=\mathbf 1_S\otimes W(a,b)$ and
+    \[
+        \overline X=\frac{1}{d_C^2}\sum_{c,e}U_{ce}XU_{ce}^{\dagger}.
+    \]
+    Then, for every $a,b$,
+    \[
+        D(\overline\rho\Vert\overline\sigma)
+          =D(U_{ab}\rho U_{ab}^{\dagger}\Vert
+              U_{ab}\sigma U_{ab}^{\dagger}).
+    \]
+    This is a scalar equality-propagation prerequisite for
+    \cite[Theorem~3 and equation~(8)]{Hayden2004Structure}; it neither
+    characterizes equality in joint convexity nor asserts recovery.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:twirl_partial_trace,
+        thm:partial_trace_kernel_inclusion,
+        thm:relative_entropy_ancilla_additivity_support,
+        thm:relative_entropy_unitary_invariance,
+        thm:weyl_operator_unitary,
+        thm:maximally_mixed_ancilla}
+    Let $\tau_C=d_C^{-1}\mathbf 1_C$.  The twirl identity gives
+    $\overline X=(\tr_C X)\otimes\tau_C$.  The support inclusion passes to the
+    partial traces, so support-domain ancilla additivity and the saturation
+    hypothesis give
+    \[
+        D(\overline\rho\Vert\overline\sigma)
+          =D(\tr_C\rho\Vert\tr_C\sigma)
+          =D(\rho\Vert\sigma).
+    \]
+    Every $U_{ab}$ is unitary, and unitary invariance gives
+    \[
+        D(U_{ab}\rho U_{ab}^{\dagger}\Vert
+            U_{ab}\sigma U_{ab}^{\dagger})=D(\rho\Vert\sigma).
+    \]
+    The two displayed identities prove the assertion.
 \end{proof}
 
 \begin{theorem}[Relative entropy against the product of the marginals]

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -234,6 +234,33 @@ This identity is a prerequisite for transporting equality through the
 Weyl-twirl proof of data processing.  It does not prove that equality yields
 recovery.
 
+The scalar equality can now be transported from the partial-trace pair to every
+individual Weyl summand.  Fix a primitive $d_R$-th root of unity, put
+$U_{ab}=\mathbf 1_L\otimes W(a,b)$, and write
+\begin{align}
+  \overline X
+    =\frac{1}{d_R^2}\sum_{c,e}U_{ce}XU_{ce}^{\dagger}
+    =(\operatorname{tr}_R X)\otimes(d_R^{-1}\mathbf 1_R).
+\end{align}
+If $\rho$ and $\sigma$ are positive semidefinite,
+$\ker\sigma\subseteq\ker\rho$, and partial-trace data processing is saturated,
+then for every $a,b$,
+\begin{align}
+  D(\overline\rho\Vert\overline\sigma)
+    =D(U_{ab}\rho U_{ab}^{\dagger}\Vert
+       U_{ab}\sigma U_{ab}^{\dagger}).
+\end{align}
+Indeed, the twirl identity, support-domain ancilla additivity, and the inherited
+support inclusion for the marginals identify the left-hand side with
+$D(\operatorname{tr}_R\rho\Vert\operatorname{tr}_R\sigma)$; unitary invariance
+identifies the right-hand side with $D(\rho\Vert\sigma)$.
+\footnote{Formal declaration:
+\leanid{quantumRelativeEntropy_weyl_average_eq_summand_of_partialTraceRight_eq}
+in \path{TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean}.}
+This is only equality of the scalar relative entropies.  It neither
+characterizes equality in the joint-convexity inequality nor supplies a Petz
+intertwining or recovery identity.
+
 The exact remaining analytic implication is the equality case of data
 processing on this support domain:
 \begin{align}


### PR DESCRIPTION
## Summary

- prove that saturation of partial-trace data processing on the singular support domain identifies the relative entropy of the Weyl average with the relative entropy of every Weyl-conjugated summand
- derive the result from the explicit Weyl-twirl identity, inherited marginal support, singular ancilla additivity, and unitary invariance
- record the exact theorem and its direct ingredients in the entropy blueprint, and update the Hayashi--Markov paper-gap account

For positive semidefinite matrices with

$$
\ker\sigma\subseteq\ker\rho,
\qquad
D(\rho\mathbin\|\sigma)
 =D(\operatorname{tr}_C\rho\mathbin\|\operatorname{tr}_C\sigma),
$$

write

$$
\overline X=\frac{1}{d_C^2}\sum_{c,e}U_{ce}XU_{ce}^{\dagger},
\qquad U_{ce}=\mathbf 1_S\otimes W(c,e).
$$

The new theorem proves, for every Weyl operator $U_{ab}$,

$$
D(\overline\rho\mathbin\|\overline\sigma)
 =D(U_{ab}\rho U_{ab}^{\dagger}\mathbin\|
    U_{ab}\sigma U_{ab}^{\dagger}).
$$

There is no trace-normalization or invertibility assumption on $\rho$ or $\sigma$.

## Source and scope

This is a scalar equality-propagation prerequisite for Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2, Theorem 3 and equation (8). It does **not** characterize equality in the joint-convexity inequality, prove an operator intertwining relation, or establish Petz recovery. In particular, the implication

$$
D(\rho\mathbin\|\sigma)
 =D(\operatorname{tr}_C\rho\mathbin\|\operatorname{tr}_C\sigma)
\Longrightarrow
\mathcal R_\sigma(\operatorname{tr}_C\rho)=\rho
$$

remains open. Thus LionSR/TNLean#4228 remains open.

## Verification

- `lake build TNLean.Channel.Schwarz.PetzEqualityPrerequisites`
- `lake env lean TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean`
- exact axiom audit for the new theorem and its direct dependencies: `[propext, Classical.choice, Quot.sound]`
- proof-integrity scan: no `sorry`, `admit`, `native_decide`, `unsafeCast`, or new `axiom`
- reader-facing prose check and `git diff --check`
- `leanblueprint web`
- `scripts/blueprint_lean_sync.py --ci`: blueprint and Lean declarations agree; Chapter 19 is 137/137
- changed-declaration coverage audit: no changed Lean declaration is missing a blueprint entry

The local `leanblueprint checkdecls` invocation requires the root `TNLean.olean`, which is absent from this target-only worktree. A broad root build was not used for this focused leaf; remote CI will run the repository-wide declaration check.

Closes LionSR/QICLean#230.
Progress toward LionSR/TNLean#4228.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formal proofs and documentation in entropy/Petz prerequisites; no runtime, auth, or data-path changes. Scope is explicitly limited to scalar equality propagation, not recovery.
> 
> **Overview**
> Adds **`quantumRelativeEntropy_weyl_average_eq_summand_of_partialTraceRight_eq`**: when partial-trace data processing is **saturated** on the singular-support domain (`ker σ ⊆ ker ρ`), the relative entropy of the **finite Weyl average** equals that of **every** Weyl-conjugated summand. The proof chains the twirl identity (`sum_kronecker_one_weyl_conj`), support-domain ancilla additivity, marginal kernel inheritance, and unitary invariance.
> 
> The entropy **blueprint** gains lean-linked statements for Weyl operator unitarity, the maximally mixed ancilla, and this propagation theorem. The **Hayashi–Markov paper-gap** note records the new scalar step and clarifies it does **not** imply Petz recovery or joint-convexity equality—the saturation-to-recovery implication remains open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e4571be0c7631471e49fee350d9d1723d583b6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->