### PR TITLE
feat(MPS/ParentHamiltonian): add one-step cyclic segment lemma

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
@@ -85,6 +85,7 @@ theorem
     cyclicRestrictₗ hN (L + 1) i τ ψ ∈
       ⨆ j : Fin r, groundSpace (A j) (L + 1) := by
   classical
+  obtain ⟨n, rfl⟩ : ∃ n, L = n + 1 := ⟨L - 1, by omega⟩
   let S : Submodule ℂ (NSiteSpace d L) :=
     ⨆ j : Fin r, groundSpace (A j) L
   have hLocal : ∀ (k : Fin N) (ρ : Fin N → Fin d),
@@ -93,18 +94,10 @@ theorem
     simp only [Submodule.mem_iInf, Submodule.mem_comap] at hψ
     intro k ρ
     simpa [S, groundSpace_toTensorFromBlocks_eq_iSup μ A hμ L] using hψ k ρ
-  have hLpred : L - 1 + 1 = L := by omega
-  have hLpredSucc : L - 1 + 2 = L + 1 := by omega
-  have hStep :
-      ((⨅ b : Fin d,
-          (⨆ j : Fin r, groundSpace (A j) L).comap (restrictLastₗ b)) ⊓
-        (⨅ a : Fin d,
-          (⨆ j : Fin r, groundSpace (A j) L).comap (restrictFirstₗ a))) =
-        ⨆ j : Fin r, groundSpace (A j) (L + 1) := by
-    simpa only [hLpred, hLpredSucc] using
-      (pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1_pgvwc07
-        (d := d) (L₀ := L₀) A hr hIrr hLeft hOverlap hBlocks hBlk hL₀
-        hUnital (n := L - 1) (by omega))
+  have hStep :=
+    pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1_pgvwc07
+      (d := d) (L₀ := L₀) A hr hIrr hLeft hOverlap hBlocks hBlk hL₀
+      hUnital (n := n) (by omega)
   rw [← hStep]
   constructor
   · simp only [Submodule.mem_iInf, Submodule.mem_comap]

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
@@ -43,6 +43,74 @@ namespace MPSTensor
 
 variable {d : ℕ}
 
+/-- A cyclic segment one site longer than the interaction range belongs to the
+sum of the block ground spaces.
+
+Let
+\[
+  B=\bigoplus_j\mu_jA_j,
+  \qquad S_M=\bigvee_jG_M(A_j).
+\]
+For a vector in the periodic chain space of \(B\), the two restrictions of an
+\((L+1)\)-site cyclic segment obtained by fixing its first or last site belong
+to \(S_L\).  The one-step intersection identity therefore places the segment
+itself in \(S_{L+1}\).
+
+This is the local \((L+1)\)-site form of the intersection argument in
+arXiv:quant-ph/0608197, Theorem 12, proof lines 1431--1452.  Its interior word
+has length \(L-1\), where the normalized BNT block-separation theorem applies
+under the source bound
+\(L\ge 3(r-1)(L_0+1)+1\).  Thus it does not assume that the wrapped tail of a
+boundary-crossing length-\(L\) window spans the product algebra; that tail may
+have length one. -/
+theorem
+    blockDiagonal_cyclicRestrict_succ_mem_iSup_groundSpace_of_chainGroundSpace_bnt_c1_pgvwc07
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hr : 2 ≤ r) (hμ : ∀ k : Fin r, μ k ≠ 0)
+    {L₀ L N : ℕ}
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    (hN : 0 < N) (hLsuccN : L + 1 ≤ N)
+    (hRange :
+      (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) + 1 ≤ L)
+    {ψ : NSiteSpace d N}
+    (hψ : ψ ∈ chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N)
+    (i : Fin N) (τ : Fin N → Fin d) :
+    cyclicRestrictₗ hN (L + 1) i τ ψ ∈
+      ⨆ j : Fin r, groundSpace (A j) (L + 1) := by
+  classical
+  let S : Submodule ℂ (NSiteSpace d L) :=
+    ⨆ j : Fin r, groundSpace (A j) L
+  have hLocal : ∀ (k : Fin N) (ρ : Fin N → Fin d),
+      cyclicRestrictₗ hN L k ρ ψ ∈ S := by
+    rw [chainGroundSpace, dif_pos ⟨hN, by omega⟩] at hψ
+    simp only [Submodule.mem_iInf, Submodule.mem_comap] at hψ
+    intro k ρ
+    simpa [S, groundSpace_toTensorFromBlocks_eq_iSup μ A hμ L] using hψ k ρ
+  have hStep :=
+    pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1_pgvwc07
+      (d := d) (L₀ := L₀) A hr hIrr hLeft hOverlap hBlocks hBlk hL₀
+      hUnital (n := L - 1) (by omega)
+  have hLpred : L - 1 + 1 = L := by omega
+  have hLpredSucc : L - 1 + 2 = L + 1 := by omega
+  rw [hLpred, hLpredSucc] at hStep
+  rw [← hStep]
+  constructor
+  · simp only [Submodule.mem_iInf, Submodule.mem_comap]
+    intro b
+    rw [cyclicRestrictₗ_restrictLast]
+    exact hLocal i _
+  · simp only [Submodule.mem_iInf, Submodule.mem_comap]
+    intro a
+    rw [cyclicRestrictₗ_restrictFirst hN hLsuccN]
+    exact hLocal (cyclicForwardSite i 1) _
+
 /-- Boundary-crossing local constraints give the \(C^j,D^j\) comparison for a
 fixed block-diagonal boundary representation.
 

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
@@ -93,13 +93,18 @@ theorem
     simp only [Submodule.mem_iInf, Submodule.mem_comap] at hψ
     intro k ρ
     simpa [S, groundSpace_toTensorFromBlocks_eq_iSup μ A hμ L] using hψ k ρ
-  have hStep :=
-    pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1_pgvwc07
-      (d := d) (L₀ := L₀) A hr hIrr hLeft hOverlap hBlocks hBlk hL₀
-      hUnital (n := L - 1) (by omega)
   have hLpred : L - 1 + 1 = L := by omega
   have hLpredSucc : L - 1 + 2 = L + 1 := by omega
-  rw [hLpred, hLpredSucc] at hStep
+  have hStep :
+      ((⨅ b : Fin d,
+          (⨆ j : Fin r, groundSpace (A j) L).comap (restrictLastₗ b)) ⊓
+        (⨅ a : Fin d,
+          (⨆ j : Fin r, groundSpace (A j) L).comap (restrictFirstₗ a))) =
+        ⨆ j : Fin r, groundSpace (A j) (L + 1) := by
+    simpa only [hLpred, hLpredSucc] using
+      (pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1_pgvwc07
+        (d := d) (L₀ := L₀) A hr hIrr hLeft hOverlap hBlocks hBlk hL₀
+        hUnital (n := L - 1) (by omega))
   rw [← hStep]
   constructor
   · simp only [Submodule.mem_iInf, Submodule.mem_comap]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
@@ -1348,8 +1348,8 @@ in both cases.
     \]
 \end{proof}
 
-\begin{lemma}[One-step cyclic segments lie in the block ground-space sum]
-    \label{lem:block_diagonal_cyclic_segment_succ}
+\begin{theorem}[One-step cyclic segments lie in the block ground-space sum]
+    \label{thm:block_diagonal_cyclic_segment_succ}
     \lean{MPSTensor.blockDiagonal_cyclicRestrict_succ_mem_iSup_groundSpace_of_chainGroundSpace_bnt_c1_pgvwc07}
     \leanok
     \uses{thm:pgvwc_direct_sum_intersection_source_length}
@@ -1373,7 +1373,7 @@ in both cases.
     \cite[Theorem~12, proof lines~1431--1452]{PerezGarcia2007Matrix}. It uses
     the middle-word length $L-1$ and makes no spanning assumption on a short
     tail produced by opening a boundary-crossing interval.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}
     \leanok

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
@@ -1348,6 +1348,50 @@ in both cases.
     \]
 \end{proof}
 
+\begin{lemma}[One-step cyclic segments lie in the block ground-space sum]
+    \label{lem:block_diagonal_cyclic_segment_succ}
+    \lean{MPSTensor.blockDiagonal_cyclicRestrict_succ_mem_iSup_groundSpace_of_chainGroundSpace_bnt_c1_pgvwc07}
+    \leanok
+    \uses{thm:pgvwc_direct_sum_intersection_source_length}
+    Let $g\ge2$, and let $A^1,\ldots,A^g$ be separated normalized BNT blocks
+    that are injective at the common length $L_0>0$. Let every $\mu_j$ be
+    nonzero, and suppose that
+    \[
+        L\ge 3(g-1)(L_0+1)+1,
+        \qquad L+1\le N.
+    \]
+    If
+    \[
+        \psi\in
+        \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA^j\right),
+    \]
+    then every cyclic segment of $\psi$ on $L+1$ consecutive sites belongs to
+    \[
+        \sum_jG_{L+1}(A^j).
+    \]
+    This is the one-step intersection argument in
+    \cite[Theorem~12, proof lines~1431--1452]{PerezGarcia2007Matrix}. It uses
+    the middle-word length $L-1$ and makes no spanning assumption on a short
+    tail produced by opening a boundary-crossing interval.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{thm:pgvwc_direct_sum_intersection_source_length}
+    Fix an $(L+1)$-site cyclic segment. After fixing its last site, the
+    remaining length-$L$ segment satisfies the corresponding local constraint,
+    so it belongs to $\sum_jG_L(A^j)$. The same conclusion follows after
+    fixing its first site, using the adjacent cyclic constraint. Hence the
+    original segment belongs to
+    \[
+        \C^d\otimes\left(\sum_jG_L(A^j)\right)
+        \cap
+        \left(\sum_jG_L(A^j)\right)\otimes\C^d.
+    \]
+    Theorem~\ref{thm:pgvwc_direct_sum_intersection_source_length} identifies
+    this intersection with $\sum_jG_{L+1}(A^j)$.
+\end{proof}
+
 \begin{theorem}[Crossing-tail spans give periodic single-block states]
     \label{thm:block_diagonal_boundary_periodic_components_from_crossing_span}
     \lean{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_crossing_pgvwc_comparison_bnt_c1}


### PR DESCRIPTION
## Mathematical statement

For separated normalized BNT blocks in the sharp PGVWC source range, every cyclic segment of length `L + 1` of a block-diagonal periodic chain-ground-space vector belongs to the sum of the length-`L + 1` open-boundary block ground spaces.

The proof fixes the last or first endpoint of the segment, applies the two adjacent length-`L` cyclic constraints, and invokes the one-step direct-sum intersection identity. Its separating middle word has length `L - 1`; no span is assumed for the short wrapped tail of a boundary-crossing length-`L` window.

Source: arXiv:quant-ph/0608197, Theorem 12, proof lines 1431--1452. This is a bounded step toward the local residual discussed in #3597; it does not claim to discharge the full periodic-boundary comparison.

## Changes

- add `blockDiagonal_cyclicRestrict_succ_mem_iSup_groundSpace_of_chainGroundSpace_bnt_c1_pgvwc07`;
- add the corresponding blueprint lemma and proof.

## Checks

- focused Lean elaboration of `BNTBlockDiagonalPGVWCComparison.lean` passed before the fresh-worktree dependency cache was regenerated;
- blueprint/Lean synchronization passed;
- reader-facing prose check passed;
- `git diff --check` passed.

A full post-rebase build is deferred because concurrent repository builds exhausted the shared disk allowance; no proof or statement depends on that environmental limitation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style formal proof and blueprint sync; no runtime, auth, or data-path changes. Residual periodic-boundary comparison gaps elsewhere are unchanged.
> 
> **Overview**
> Adds a **formalized one-step cyclic-segment lemma** for block-diagonal periodic chain ground spaces in the sharp PGVWC/BNT range: vectors in \(\mathcal G_{N,L}(\bigoplus_j \mu_j A^j)\) have every length-\(L+1\) cyclic segment in \(\bigvee_j G_{L+1}(A^j)\).
> 
> The Lean proof is `blockDiagonal_cyclicRestrict_succ_mem_iSup_groundSpace_of_chainGroundSpace_bnt_c1_pgvwc07` in `BNTBlockDiagonalPGVWCComparison.lean`. It rewrites \(L\) as \(n+1\), pulls length-\(L\) restrictions from periodic membership into the block ground-space sum, then applies the existing one-step direct-sum intersection identity `pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1_pgvwc07` via fixing the segment’s first and last sites.
> 
> Blueprint chapter 13 gains matching **Theorem** `thm:block_diagonal_cyclic_segment_succ` (PGVWC Theorem 12, proof lines 1431–1452), stressing middle-word length \(L-1\) and **no** short tail-span hypothesis for boundary-crossing windows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f25df2bf4a959fd5713288d0209127f24dc7151. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->