### PR TITLE
doc(Entropy): display Weyl-saturation formulas

### DIFF
--- a/TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean
+++ b/TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean
@@ -86,11 +86,15 @@ theorem quantumRelativeEntropy_kronecker_support
 entropy is unchanged by the right partial trace, then the relative entropy of
 the finite Weyl average equals that of each Weyl-conjugated pair.
 
-The Weyl average is first identified with the marginal pair tensored with the
-maximally mixed ancilla. Singular-support ancilla additivity reduces its
-relative entropy to that of the marginals, while unitary invariance reduces the
-chosen summand to `D(ρ ‖ σ)`. The saturation hypothesis identifies these two
-values.
+The Weyl average is first identified by the normalized identity
+\[
+d_C^{-2}\sum_{c,e}(\mathbf 1_S\otimes W(c,e))X
+  (\mathbf 1_S\otimes W(c,e))^\dagger
+  = (\operatorname{tr}_C X)\otimes(d_C^{-1}\mathbf 1_C).
+\]
+Singular-support ancilla additivity reduces its relative entropy to that of the
+marginals, while unitary invariance reduces the chosen summand to
+\(D(\rho\Vert\sigma)\). The saturation hypothesis identifies these two values.
 
 This is an equality-propagation prerequisite for Hayden--Jozsa--Petz--Winter,
 arXiv:quant-ph/0304007v2, Theorem 3 and equation (8); it does not assert the

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -2300,8 +2300,13 @@ Theorem~\ref{thm:trace_norm_abs}.
         thm:maximally_mixed_ancilla}
     Let $\tau_C=d_C^{-1}\mathbf 1_C$.  The twirl identity gives
     $\overline X=(\tr_C X)\otimes\tau_C$.  The support inclusion passes to the
-    partial traces, so support-domain ancilla additivity and the saturation
-    hypothesis give
+    partial traces:
+    \[
+        \ker\sigma\subseteq\ker\rho
+        \Longrightarrow
+        \ker(\tr_C\sigma)\subseteq\ker(\tr_C\rho).
+    \]
+    Hence support-domain ancilla additivity and the saturation hypothesis give
     \[
         D(\overline\rho\Vert\overline\sigma)
           =D(\tr_C\rho\Vert\tr_C\sigma)


### PR DESCRIPTION
## Summary

- display the kernel-inclusion implication inherited by the partial traces;
- display the normalized Weyl-twirl identity in the saturation theorem docstring;
- typeset the relative entropy of the original pair as mathematics rather than code.

No theorem statement, proof, hypothesis, or blueprint coverage status changes.

Closes #4334.
Advances #4228; the Petz recovery implication remains open.

## Checks

- `lake build TNLean.Channel.Schwarz.PetzEqualityPrerequisites`
- proof-integrity token scan of the changed Lean file
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci --diff-base origin/main --diff-head HEAD`
- `leanblueprint web`
- `git diff --check` and Lean line-length check

Local `leanblueprint checkdecls` requires the root `TNLean.olean`, which the focused build does not produce. The PR blueprint job runs after the full root build and supplies this check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prose and LaTeX/docstring formatting only; no formal statements or proof logic changed.
> 
> **Overview**
> **Documentation-only** updates to the Weyl partial-trace saturation story in `PetzEqualityPrerequisites.lean` and the matching blueprint proof in `ch19_entropy.tex`. No theorem statements, Lean proofs, or `\leanok` coverage change.
> 
> The Lean docstring for `quantumRelativeEntropy_weyl_average_eq_summand_of_partialTraceRight_eq` now shows the normalized Weyl-twirl identity as a displayed equation and typesets the summand relative entropy as \(D(\rho\Vert\sigma)\) instead of inline code.
> 
> The blueprint proof of `thm:relative_entropy_weyl_average_eq_summand` now **displays** the implication \(\ker\sigma\subseteq\ker\rho \Rightarrow \ker(\tr_C\sigma)\subseteq\ker(\tr_C\rho)\) before invoking support-domain ancilla additivity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9448d89eae2491275ed591bb87cb893f81a7087d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->