### PR TITLE
feat(Channel/Schwarz): identify Weyl Jensen saturation

### DIFF
--- a/TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean
+++ b/TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean
@@ -20,6 +20,8 @@ the positive semidefinite matrices.
 * `quantumRelativeEntropy_weyl_average_eq_summand_of_partialTraceRight_eq`
   propagates saturation of partial-trace data processing to each summand in the
   finite Weyl average.
+* `quantumRelativeEntropy_weyl_jensen_eq_of_partialTraceRight_eq` identifies
+  saturation of the finite Jensen inequality in the Weyl proof.
 
 ## References
 
@@ -153,3 +155,75 @@ theorem quantumRelativeEntropy_weyl_average_eq_summand_of_partialTraceRight_eq
           ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ a b)ᴴ) := by
             simpa only [Unitary.coe_star, star_eq_conjTranspose, U] using
               (quantumRelativeEntropy_conj_unitary hρ.isHermitian hσ.isHermitian U).symm
+
+/-- **Partial-trace saturation saturates the finite Weyl Jensen inequality.**
+Let `ρ` and `σ` be positive semidefinite matrices with `ker σ ⊆ ker ρ`. If their
+relative entropy is unchanged by the right partial trace, then the relative
+entropy of the finite Weyl average equals the uniform average of the relative
+entropies of the Weyl-conjugated pairs.
+
+This is the first equality-sensitive inequality in the finite Weyl proof of
+partial-trace data processing. It is a scalar equality-propagation prerequisite
+for Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2, Theorem 3 and equation
+(8); it does not characterize equality in joint convexity or assert an operator
+intertwining or Petz recovery identity. -/
+theorem quantumRelativeEntropy_weyl_jensen_eq_of_partialTraceRight_eq
+    {dS dC : ℕ} [NeZero dC]
+    {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
+    (hρ : ρ.PosSemidef) (hσ : σ.PosSemidef)
+    (hsupp : ∀ v : Fin dS × ZMod dC → ℂ, σ.mulVec v = 0 → ρ.mulVec v = 0)
+    (heq : quantumRelativeEntropy ρ σ =
+      quantumRelativeEntropy (partialTraceRight ρ) (partialTraceRight σ))
+    {ζ : ℂ} (hζ : IsPrimitiveRoot ζ dC) :
+    quantumRelativeEntropy
+        (((dC : ℂ) ^ 2)⁻¹ • ∑ c : ZMod dC, ∑ e : ZMod dC,
+          ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ c e) * ρ *
+            ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ c e)ᴴ)
+        (((dC : ℂ) ^ 2)⁻¹ • ∑ c : ZMod dC, ∑ e : ZMod dC,
+          ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ c e) * σ *
+            ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ c e)ᴴ) =
+      ∑ c : ZMod dC, ∑ e : ZMod dC, ((dC : ℝ) ^ 2)⁻¹ •
+        quantumRelativeEntropy
+          (((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ c e) * ρ *
+            ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ c e)ᴴ)
+          (((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ c e) * σ *
+            ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ c e)ᴴ) := by
+  classical
+  have hterm (c e : ZMod dC) :
+      quantumRelativeEntropy
+          (((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ c e) * ρ *
+            ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ c e)ᴴ)
+          (((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ c e) * σ *
+            ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ c e)ᴴ) =
+        quantumRelativeEntropy ρ σ := by
+    let U : unitary
+        (Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ) :=
+      ⟨(1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ c e,
+        Matrix.kronecker_mem_unitary (Submonoid.one_mem _)
+          (weyl_mem_unitary hζ c e)⟩
+    simpa only [Unitary.coe_star, star_eq_conjTranspose, U] using
+      quantumRelativeEntropy_conj_unitary hρ.isHermitian hσ.isHermitian U
+  have haverage :
+      quantumRelativeEntropy
+          (((dC : ℂ) ^ 2)⁻¹ • ∑ c : ZMod dC, ∑ e : ZMod dC,
+            ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ c e) * ρ *
+              ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ c e)ᴴ)
+          (((dC : ℂ) ^ 2)⁻¹ • ∑ c : ZMod dC, ∑ e : ZMod dC,
+            ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ c e) * σ *
+              ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ c e)ᴴ) =
+        quantumRelativeEntropy ρ σ := by
+    calc
+      _ = quantumRelativeEntropy
+          (((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ 0 0) * ρ *
+            ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ 0 0)ᴴ)
+          (((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ 0 0) * σ *
+            ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ 0 0)ᴴ) :=
+        quantumRelativeEntropy_weyl_average_eq_summand_of_partialTraceRight_eq
+          hρ hσ hsupp heq hζ 0 0
+      _ = quantumRelativeEntropy ρ σ := hterm 0 0
+  rw [haverage]
+  simp_rw [hterm]
+  simp only [Finset.sum_const, Finset.card_univ, ZMod.card, nsmul_eq_mul,
+    smul_eq_mul]
+  have hdC : (dC : ℝ) ≠ 0 := by exact_mod_cast NeZero.ne dC
+  field_simp [hdC]

--- a/TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean
+++ b/TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean
@@ -125,10 +125,6 @@ theorem quantumRelativeEntropy_weyl_average_eq_summand_of_partialTraceRight_eq
   have hsuppM : ∀ w : Fin dS → ℂ,
       (partialTraceRight σ).mulVec w = 0 → (partialTraceRight ρ).mulVec w = 0 :=
     fun _ hw => partialTraceRight_support hσ hsupp hw
-  let U : unitary
-      (Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ) :=
-    ⟨(1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ a b,
-      Matrix.kronecker_mem_unitary (Submonoid.one_mem _) (weyl_mem_unitary hζ a b)⟩
   calc
     quantumRelativeEntropy
         (((dC : ℂ) ^ 2)⁻¹ • ∑ c : ZMod dC, ∑ e : ZMod dC,
@@ -153,8 +149,8 @@ theorem quantumRelativeEntropy_weyl_average_eq_summand_of_partialTraceRight_eq
           ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ a b)ᴴ)
         (((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ a b) * σ *
           ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ a b)ᴴ) := by
-            simpa only [Unitary.coe_star, star_eq_conjTranspose, U] using
-              (quantumRelativeEntropy_conj_unitary hρ.isHermitian hσ.isHermitian U).symm
+            exact (quantumRelativeEntropy_weyl_conj_eq hρ.isHermitian
+              hσ.isHermitian hζ a b).symm
 
 /-- **Partial-trace saturation saturates the finite Weyl Jensen inequality.**
 Let ρ and σ be positive semidefinite matrices with ker σ ⊆ ker ρ. If their
@@ -196,13 +192,8 @@ theorem quantumRelativeEntropy_weyl_jensen_eq_of_partialTraceRight_eq
           (((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ c e) * σ *
             ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ c e)ᴴ) =
         quantumRelativeEntropy ρ σ := by
-    let U : unitary
-        (Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ) :=
-      ⟨(1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ c e,
-        Matrix.kronecker_mem_unitary (Submonoid.one_mem _)
-          (weyl_mem_unitary hζ c e)⟩
-    simpa only [Unitary.coe_star, star_eq_conjTranspose, U] using
-      quantumRelativeEntropy_conj_unitary hρ.isHermitian hσ.isHermitian U
+    exact quantumRelativeEntropy_weyl_conj_eq hρ.isHermitian hσ.isHermitian
+      hζ c e
   have haverage :
       quantumRelativeEntropy
           (((dC : ℂ) ^ 2)⁻¹ • ∑ c : ZMod dC, ∑ e : ZMod dC,

--- a/TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean
+++ b/TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean
@@ -157,7 +157,7 @@ theorem quantumRelativeEntropy_weyl_average_eq_summand_of_partialTraceRight_eq
               (quantumRelativeEntropy_conj_unitary hρ.isHermitian hσ.isHermitian U).symm
 
 /-- **Partial-trace saturation saturates the finite Weyl Jensen inequality.**
-Let `ρ` and `σ` be positive semidefinite matrices with `ker σ ⊆ ker ρ`. If their
+Let ρ and σ be positive semidefinite matrices with ker σ ⊆ ker ρ. If their
 relative entropy is unchanged by the right partial trace, then the relative
 entropy of the finite Weyl average equals the uniform average of the relative
 entropies of the Weyl-conjugated pairs.

--- a/TNLean/Channel/Schwarz/RelativeEntropyDataProcessing.lean
+++ b/TNLean/Channel/Schwarz/RelativeEntropyDataProcessing.lean
@@ -383,6 +383,30 @@ theorem weyl_mem_unitary {ζ : ℂ} (hζ : IsPrimitiveRoot ζ d) (a b : ZMod d) 
 
 end WeylUnitary
 
+section WeylRelativeEntropy
+
+variable {S : Type*} [Fintype S] [DecidableEq S] {dC : ℕ} [NeZero dC]
+
+/-- Conjugation by an identity-on-system lift of a Weyl operator preserves
+quantum relative entropy. -/
+theorem quantumRelativeEntropy_weyl_conj_eq
+    {ρ σ : Matrix (S × ZMod dC) (S × ZMod dC) ℂ}
+    (hρ : ρ.IsHermitian) (hσ : σ.IsHermitian)
+    {ζ : ℂ} (hζ : IsPrimitiveRoot ζ dC) (a b : ZMod dC) :
+    quantumRelativeEntropy
+        (((1 : Matrix S S ℂ) ⊗ₖ weyl ζ a b) * ρ *
+          ((1 : Matrix S S ℂ) ⊗ₖ weyl ζ a b)ᴴ)
+        (((1 : Matrix S S ℂ) ⊗ₖ weyl ζ a b) * σ *
+          ((1 : Matrix S S ℂ) ⊗ₖ weyl ζ a b)ᴴ) =
+      quantumRelativeEntropy ρ σ := by
+  let U : unitary (Matrix (S × ZMod dC) (S × ZMod dC) ℂ) :=
+    ⟨(1 : Matrix S S ℂ) ⊗ₖ weyl ζ a b,
+      Matrix.kronecker_mem_unitary (Submonoid.one_mem _) (weyl_mem_unitary hζ a b)⟩
+  simpa only [Unitary.coe_star, star_eq_conjTranspose, U] using
+    quantumRelativeEntropy_conj_unitary hρ hσ U
+
+end WeylRelativeEntropy
+
 /-! ## The twirl as partial trace tensored with the maximally mixed ancilla -/
 
 section Twirl
@@ -605,8 +629,9 @@ theorem quantumRelativeEntropy_partialTraceRight_le
           × Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ =>
           quantumRelativeEntropy q.1 q.2) (P p) = quantumRelativeEntropy ρ σ := by
       intro p
-      simp only [hPdef]
-      exact quantumRelativeEntropy_conj_unitary hρ.isHermitian hσ.isHermitian (U p.1 p.2)
+      simpa only [hPdef, hUcoe, Unitary.coe_star, star_eq_conjTranspose] using
+        quantumRelativeEntropy_weyl_conj_eq hρ.isHermitian hσ.isHermitian
+          hζ p.1 p.2
     simp_rw [hterm]
     rw [← Finset.sum_smul, hwsum, one_smul]
   rw [← hLHS, ← hRHS]

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -1010,6 +1010,7 @@ Theorem~\ref{thm:trace_norm_abs}.
 \begin{theorem}[Unitary invariance of the quantum relative entropy]
     \label{thm:relative_entropy_unitary_invariance}
     \lean{quantumRelativeEntropy_conj_unitary}
+    \lean{Matrix.quantumRelativeEntropy_weyl_conj_eq}
     \leanok
     \uses{def:quantum_relative_entropy}
     For Hermitian matrices $\rho, \sigma$ and a unitary $U$,

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -2320,6 +2320,51 @@ Theorem~\ref{thm:trace_norm_abs}.
     The two displayed identities prove the assertion.
 \end{proof}
 
+\begin{theorem}[Saturation of the finite Weyl Jensen inequality]
+    \label{thm:relative_entropy_weyl_jensen_eq}
+    \lean{quantumRelativeEntropy_weyl_jensen_eq_of_partialTraceRight_eq}
+    \leanok
+    \uses{def:quantum_relative_entropy, def:partial_trace}
+    Let $\rho$ and $\sigma$ be positive semidefinite matrices on
+    $\mathcal H_S\otimes\mathbb C^{d_C}$ such that
+    $\ker\sigma\subseteq\ker\rho$, and suppose that
+    \[
+        D(\rho\Vert\sigma)
+          =D(\tr_C\rho\Vert\tr_C\sigma).
+    \]
+    For a primitive $d_C$-th root of unity, put
+    $U_{ce}=\mathbf 1_S\otimes W(c,e)$ and
+    \[
+        \overline X=\frac{1}{d_C^2}\sum_{c,e}U_{ce}XU_{ce}^{\dagger}.
+    \]
+    Then
+    \[
+        D(\overline\rho\Vert\overline\sigma)
+          =\frac{1}{d_C^2}\sum_{c,e}
+            D(U_{ce}\rho U_{ce}^{\dagger}\Vert
+              U_{ce}\sigma U_{ce}^{\dagger}).
+    \]
+    This scalar identity is associated with the finite Jensen step in the
+    Weyl proof of data processing.  It is a prerequisite for
+    \cite[Theorem~3 and equation~(8)]{Hayden2004Structure}; it neither
+    characterizes equality in joint convexity nor asserts recovery.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:relative_entropy_weyl_average_eq_summand,
+        thm:relative_entropy_unitary_invariance,
+        thm:weyl_operator_unitary}
+    Unitary invariance gives, for every $c,e$,
+    \[
+        D(U_{ce}\rho U_{ce}^{\dagger}\Vert
+          U_{ce}\sigma U_{ce}^{\dagger})=D(\rho\Vert\sigma).
+    \]
+    The preceding theorem identifies
+    $D(\overline\rho\Vert\overline\sigma)$ with the same value.  Since the
+    $d_C^2$ summands have uniform weight $d_C^{-2}$, the asserted equality
+    follows.
+\end{proof}
+
 \begin{theorem}[Relative entropy against the product of the marginals]
     \label{thm:relative_entropy_product_marginals}
     \lean{quantumRelativeEntropy_product_marginals}

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -2359,10 +2359,18 @@ Theorem~\ref{thm:trace_norm_abs}.
         D(U_{ce}\rho U_{ce}^{\dagger}\Vert
           U_{ce}\sigma U_{ce}^{\dagger})=D(\rho\Vert\sigma).
     \]
-    The preceding theorem identifies
-    $D(\overline\rho\Vert\overline\sigma)$ with the same value.  Since the
-    $d_C^2$ summands have uniform weight $d_C^{-2}$, the asserted equality
-    follows.
+    The preceding theorem gives
+    \[
+        D(\overline\rho\Vert\overline\sigma)=D(\rho\Vert\sigma).
+    \]
+    Substituting into the right-hand side gives
+    \[
+        \frac{1}{d_C^2}\sum_{c,e}
+          D(U_{ce}\rho U_{ce}^{\dagger}\Vert
+            U_{ce}\sigma U_{ce}^{\dagger})
+          =\frac{d_C^2}{d_C^2}D(\rho\Vert\sigma)
+          =D(\overline\rho\Vert\overline\sigma).
+    \]
 \end{proof}
 
 \begin{theorem}[Relative entropy against the product of the marginals]

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -261,6 +261,23 @@ This is only equality of the scalar relative entropies.  It neither
 characterizes equality in the joint-convexity inequality nor supplies a Petz
 intertwining or recovery identity.
 
+Summing the preceding equality with the uniform Weyl weights gives the scalar
+equality associated with the finite Jensen step:
+\begin{align}
+  D(\overline\rho\Vert\overline\sigma)
+    =\frac{1}{d_R^2}\sum_{c,e}
+      D(U_{ce}\rho U_{ce}^{\dagger}\Vert
+        U_{ce}\sigma U_{ce}^{\dagger}).
+\end{align}
+Indeed, unitary invariance makes every summand equal to
+$D(\rho\Vert\sigma)$, while the preceding Weyl-summand equality gives the same
+value on the left.  The $d_R^2$ weights sum to one.
+\footnote{Formal declaration:
+\leanid{quantumRelativeEntropy_weyl_jensen_eq_of_partialTraceRight_eq} in
+\path{TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean}.}
+This statement does not characterize equality in joint convexity and does not
+imply an operator intertwining or Petz recovery identity.
+
 The exact remaining analytic implication is the equality case of data
 processing on this support domain:
 \begin{align}


### PR DESCRIPTION
## Summary

- prove that partial-trace relative-entropy saturation forces equality in the finite Weyl Jensen step on the singular support domain
- record the theorem in the entropy blueprint and the HJPW equality-gap account
- build on LionSR/TNLean#4336, which completed LionSR/TNLean#4334, retaining its inherited-kernel and Weyl-twirl formulas after rebasing onto current main

The new theorem assumes positive semidefiniteness and ker sigma contained in ker rho. It adds neither invertibility nor normalization. It is only a scalar equality statement: it does not characterize equality in joint convexity, prove an operator intertwining identity, or establish Petz recovery.

The proof uses unitary invariance to identify every Weyl summand with D(rho || sigma), uses the preceding average-to-summand theorem for the left side, and sums the uniform weights.

Closes LionSR/QICLean#231.
Related documentation issue: LionSR/TNLean#4334, completed by LionSR/TNLean#4336 and inherited from current main.

Parent LionSR/TNLean#4228 remains open: the source-faithful recovery implication of HJPW Theorem 3 and equation (8) is not proved here.

## Checks

- lake env lean TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean
- python3 scripts/blueprint_lean_sync.py --update-lean-decls --ci
- changed-declaration blueprint coverage check
- exact axiom report: propext, Classical.choice, Quot.sound
- placeholder, line-length, prose, and git diff checks
- exact-head CI and blueprint generation pending after rebase

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds formal lemmas and documentation along an existing Petz-equality proof line; no auth, I/O, or runtime behavior changes.
> 
> **Overview**
> When partial-trace data processing is **saturated** on the singular support domain (`ker σ ⊆ ker ρ`), this PR adds the scalar identity that the relative entropy of the **finite Weyl twirl** equals the uniform average of relative entropies over all Weyl-conjugated pairs—i.e. equality in the finite Jensen step of the Weyl proof route.
> 
> **Lean:** New `quantumRelativeEntropy_weyl_jensen_eq_of_partialTraceRight_eq` in `PetzEqualityPrerequisites.lean`, proved via per-summand unitary invariance and the existing average-to-summand theorem. Shared helper `quantumRelativeEntropy_weyl_conj_eq` is extracted in `RelativeEntropyDataProcessing.lean` and wired into the Weyl-average summand proof and the DPI Jensen argument.
> 
> **Docs:** The entropy blueprint (`ch19_entropy.tex`) and the HJPW equality-gap note (`cpsv16_ssa_equality_hayashi_markov.tex`) record the theorem and clarify it is **not** joint-convexity equality, intertwining, or Petz recovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94faedfcb1d75922ad2c20b6d359031900d53c31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->