### PR TITLE
feat(MPS/RFP): prove single-normal NNCPH ground-space spanning

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -612,6 +612,7 @@ import TNLean.MPS.RFP.KroneckerTransport
 import TNLean.MPS.RFP.AppendixBSupport
 import TNLean.MPS.RFP.AppendixBCommutation
 import TNLean.MPS.RFP.AppendixBChainCommutation
+import TNLean.MPS.RFP.NNCPHGroundSpace
 import TNLean.MPS.RFP.Convergence
 import TNLean.MPS.RFP.Assembly
 import TNLean.MPS.RFP.Decorrelation

--- a/TNLean/MPS/RFP/NNCPHGroundSpace.lean
+++ b/TNLean/MPS/RFP/NNCPHGroundSpace.lean
@@ -1,0 +1,67 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.KernelChainGroundSpace
+import TNLean.MPS.ParentHamiltonian.UniqueGroundState
+import TNLean.MPS.RFP.AppendixBChainCommutation
+
+/-!
+# Ground spaces of nearest-neighbor parent Hamiltonians at a renormalization fixed point
+
+For a single normal renormalization fixed-point tensor, the kernel of the
+nearest-neighbor parent Hamiltonian on every periodic chain of length greater
+than two is the line spanned by the corresponding matrix product vector.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608, Theorem 3.10,
+  lines 534--541.
+-/
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- For a single CPSV normal renormalization fixed-point tensor, the kernel of
+the nearest-neighbor parent Hamiltonian is spanned, on every periodic chain of
+length greater than two, by its matrix product vector.
+
+Source: arXiv:1606.00608, Definition 3.9, lines 517--524, and Theorem 3.10,
+lines 534--541.
+
+**Scope restriction (single normal tensor):** The source theorem allows a
+canonical-form tensor with several normal sectors and repeated copies. This
+result treats the singleton family consisting of one normal tensor. See
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
+theorem rfp_hasParentHamiltonianGroundSpaceSpanning_single
+    (A : MPSTensor d D) [NeZero D]
+    (hRFP : IsTransferIdempotent A) (hNT : IsNormalTensor A) :
+    HasParentHamiltonianGroundSpaceSpanning A 2 (fun _ : Fin 1 ↦ A) := by
+  intro N hN
+  have hInj : IsInjective A := rfp_nt_structural A hNT.isNormal hRFP
+  rw [ker_parentHamiltonian_eq_chainGroundSpace A (by omega) (by omega),
+    chainGroundSpace_eq_mpvSubmodule hInj (by omega) (by omega) (by omega),
+    ← iSup_mpvSubmodule_eq_bntMPSVectorSpan (fun _ : Fin 1 ↦ A) N]
+  simp
+
+/-- A single CPSV normal renormalization fixed-point tensor satisfies the
+all-chain nearest-neighbor commuting parent-Hamiltonian ground-space condition.
+
+Source: arXiv:1606.00608, Theorem 3.10, lines 534--541.
+
+**Scope restriction (single normal tensor):** The source theorem allows a
+canonical-form tensor with several normal sectors and repeated copies. This
+result treats the singleton family consisting of one normal tensor. See
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
+theorem rfp_implies_hasNNCPHGroundSpaces_single
+    (A : MPSTensor d D) [NeZero D]
+    (hRFP : IsTransferIdempotent A) (hNT : IsNormalTensor A) :
+    HasNNCPHGroundSpaces A (fun _ : Fin 1 ↦ A) := by
+  rw [hasNNCPHGroundSpaces_iff_forall_isNNCPHGroundState_and_groundSpaceSpanning]
+  exact
+    ⟨rfp_implies_nncph_ground_state A hRFP hNT,
+      rfp_hasParentHamiltonianGroundSpaceSpanning_single A hRFP hNT⟩
+
+end MPSTensor

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -1058,6 +1058,51 @@ specialization of that Appendix~D definition.
     Lemma~\ref{lem:parent_hamiltonian_ff} with $L=2$.
 \end{proof}
 
+\begin{theorem}[Nearest-neighbor parent ground spaces for a single normal RFP tensor]%
+    \label{thm:rfp_single_normal_nncph_ground_spaces}
+    \lean{MPSTensor.rfp_hasParentHamiltonianGroundSpaceSpanning_single}
+    \lean{MPSTensor.rfp_implies_hasNNCPHGroundSpaces_single}
+    \leanok
+    \uses{def:mps_transfer_idempotence, def:nt_cpsv,
+        def:parent_hamiltonian_ground_space_spanning,
+        def:has_nncph_ground_spaces}
+    Let $A$ have positive bond dimension and be a normal renormalization
+    fixed-point tensor in the sense of \cite{Cirac2016MPDO_arXiv}. If the
+    canonical-form tensor consists of the single normal sector $A$, then for
+    every $N>2$,
+    \[
+        \ker H_2^{(N)}(A)=\spn\bigl\{V^{(N)}(A)\bigr\}.
+    \]
+    Its translated two-site interactions also commute and annihilate
+    $V^{(N)}(A)$. Hence the singleton family satisfies the all-chain
+    nearest-neighbor commuting parent-Hamiltonian ground-space condition.
+
+    This statement is restricted to one normal sector. It does not assert the
+    corresponding result for canonical-form tensors with several sectors or
+    repeated copies.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:cpsv_normal_eventually_injective, thm:rfp_nt_injective,
+        thm:parent_hamiltonian_kernel_eq_chain_ground_space,
+        thm:chain_ground_space_eq_mpv_blk,
+        lem:bnt_span_eq_sum_mpv_submodules,
+        thm:rfp_implies_nncph_ground_state}
+    Spectral normality gives eventual block injectivity. The fixed-point
+    equation then implies that the one-site matrices already span the full
+    matrix algebra. Thus $A$ is injective. For $N>2$, the finite-volume kernel
+    identity and injective periodic-chain theorem give
+    \[
+        \ker H_2^{(N)}(A)
+        =\mathcal G_{N,2}(A)
+        =\spn\bigl\{V^{(N)}(A)\bigr\}.
+    \]
+    The span of the matrix product vectors of the singleton family is the last
+    space in this equality. Theorem~\ref{thm:rfp_implies_nncph_ground_state}
+    supplies commutation and zero energy on every chain of length greater than
+    two.
+\end{proof}
+
 \begin{theorem}[Cyclic trace expansion for a closed MPS chain]\label{thm:trace_eval_word_eq_sum_cyclic}
     \lean{MPSTensor.trace_evalWord_eq_sum_cyclic}
     \leanok

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -108,10 +108,11 @@ states the all-chain condition as translated two-site commutation together with
 the same reverse containment for every \(N>2\).  The reverse containment itself
 is not proved here.
 
-This still does not prove the full source theorem.  The present declarations do
-not yet prove the named ground-space spanning condition, the three-way
-equivalence with ZCL, the complete canonical-form hypotheses from the source
-statement, or the Beigi ground-space characterization as an internal theorem.
+These reductions alone do not prove the full source theorem.  The
+canonical-form ground-space spanning condition for several sectors, the
+three-way equivalence with ZCL, the complete canonical-form hypotheses from the
+source statement, and the Beigi ground-space characterization as an internal
+theorem remain open.
 For the forward RFP-to-NNCPH direction, the three-site \(AX/XB\) support maps
 are now represented in \leanid{MPSTensor.HasOverlappingTwoSiteCommutation};
 Appendix~B supplies the basic-vector form.  The local projectors in
@@ -205,6 +206,16 @@ the canonical parent interactions transports the preceding result to
 \leanid{MPSTensor.rfp_implies_nncph_ground_state}.  Hence these declarations
 prove the commutation and zero-energy equations for a single CPSV normal
 tensor without an external axiom.
+For the same single tensor, transfer idempotence and normality imply one-site
+injectivity.  The injective periodic-chain theorem therefore identifies the
+kernel of the two-site parent Hamiltonian with the line spanned by the matrix
+product vector for every \(N>2\).  This is recorded by
+\leanid{MPSTensor.rfp_hasParentHamiltonianGroundSpaceSpanning_single}.
+Combining this equality with the commutation and zero-energy equations gives
+\leanid{MPSTensor.rfp_implies_hasNNCPHGroundSpaces_single}.  Thus the full
+forward NNCPH ground-space condition is proved for one normal sector.  The
+extension to canonical-form tensors with several sectors or repeated copies
+is not included in these declarations.
 The reverse theorem requires both the explicit BNT relation
 \leanid{MPSTensor.IsBNT} and the named all-chain condition
 \leanid{MPSTensor.HasNNCPHGroundSpaces}, but the implication still depends on
@@ -246,8 +257,9 @@ normal tensor. The even-chain physical-pair factorization remains a
 separate conditional construction and is not needed for the proved chain
 commutator. Extending from one normal tensor to the full repeated-sector
 canonical form is subject to the source obstruction recorded in
-\path{docs/paper-gaps/cpsv16_rfp_isometry_scope.tex}. The full source
-implication also still requires the ground-space spanning clause.
+\path{docs/paper-gaps/cpsv16_rfp_isometry_scope.tex}. The single-normal-sector
+ground-space spanning clause is proved, while its several-sector and
+repeated-copy extension remains open.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

- prove that a single CPSV normal renormalization fixed-point tensor has nearest-neighbor parent-Hamiltonian kernel equal to the line spanned by its periodic matrix product vector for every chain length greater than two;
- combine this equality with the existing commutation and zero-energy theorem to obtain the all-chain singleton-sector NNCPH ground-space condition;
- add the root import, a scope-restricted blueprint theorem, and a paper-gap update that retains the several-sector and repeated-copy cases.

The proof derives one-site injectivity internally from normality and transfer idempotence, then applies the existing finite-volume kernel and injective periodic-chain ground-space theorems. It assumes neither the spanning conclusion nor a reverse kernel inclusion.

This closes only the single-normal-sector part of item 4 in #2633. The corrected family-level theorem and the reverse Beigi implication remain open.

## Verification

- `lake build TNLean.MPS.RFP.NNCPHGroundSpace`
- `lake env lean TNLean/MPS/RFP/NNCPHGroundSpace.lean`
- blueprint--Lean declaration synchronization, including reverse coverage for the new declarations
- merge-base reader-facing prose check
- proof-integrity scan for `sorry`, `admit`, new axioms, and kernel bypasses
- `#print axioms` reports only `propext`, `Classical.choice`, and `Quot.sound`

Closes #4338.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal math and documentation only; no runtime, auth, or data-path changes. Scope is explicitly limited to a single normal sector.
> 
> **Overview**
> Adds **`TNLean.MPS.RFP.NNCPHGroundSpace`** and wires it into the root import. For one CPSV normal tensor with transfer idempotence, the proof derives **one-site injectivity** from existing structural lemmas, then chains **kernel = chain ground space = MPV span** for every periodic length **N > 2**.
> 
> **`rfp_implies_hasNNCPHGroundSpaces_single`** packages that spanning result with the already-proved commutation and zero-energy theorems into the all-chain **`HasNNCPHGroundSpaces`** predicate for the singleton family `(fun _ ↦ A)`.
> 
> Blueprint **Theorem 3.10** ground-space clause and **`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`** are updated to record this as proved only for **one normal sector**; multi-sector and repeated-copy cases stay open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe243352c2fa380332c6a1f8c66c45413d63d9ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->