### PR TITLE
feat(Algebra/PerronFrobenius): prove rank-one stationary primitive square

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -47,6 +47,7 @@ import TNLean.Algebra.BurnsideMatrix
 import TNLean.Algebra.IrreducibleTensorAction
 import TNLean.Algebra.PerronFrobenius.PrimitiveAperiodic
 import TNLean.Algebra.PerronFrobenius.RankOne
+import TNLean.Algebra.PerronFrobenius.Idempotent
 import TNLean.Algebra.ProjectiveRepresentation
 import TNLean.Algebra.ScalarCommutant
 import TNLean.Algebra.CocycleCohomology

--- a/TNLean/Algebra/PerronFrobenius/Idempotent.lean
+++ b/TNLean/Algebra/PerronFrobenius/Idempotent.lean
@@ -1,0 +1,123 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.PerronFrobenius.RankOne
+import Mathlib.LinearAlgebra.Matrix.Rank
+
+/-!
+# Primitive matrices with stationary powers
+
+This module proves a finite-dimensional Perron--Frobenius lemma for a primitive
+nonnegative real matrix whose second and third powers agree. Its square is a
+strictly positive idempotent, and the fixed space of such an idempotent is
+one-dimensional. Consequently the square has rank one.
+
+The result supports the rank-one trace factorization sought at
+arXiv:1606.00608, Appendix C.2, line 1613. It is a source-independent matrix
+lemma, not a statement asserted in that paper: applying it to the sector trace
+matrix still requires a separate, non-circular proof of primitivity.
+-/
+
+open scoped BigOperators Matrix
+
+namespace Matrix
+
+variable {n : Type*} [Fintype n]
+
+/-- A strictly positive idempotent real matrix on a nonempty finite index set
+has rank one. -/
+theorem rank_eq_one_of_pos_of_mul_self_eq_self [Nonempty n]
+    {P : Matrix n n ℝ} (hP : ∀ i j, 0 < P i j) (hidem : P * P = P) :
+    P.rank = 1 := by
+  classical
+  let f : (n → ℝ) →ₗ[ℝ] (n → ℝ) := Matrix.toLin' P
+  let u : n → ℝ := f 1
+  have hu_pos (i : n) : 0 < u i := by
+    simp only [u, f, Matrix.toLin'_apply, Matrix.mulVec, dotProduct, Pi.one_apply,
+      mul_one]
+    exact Finset.sum_pos (fun j _ ↦ hP i j) Finset.univ_nonempty
+  have hf : f ∘ₗ f = f := by
+    change Matrix.toLin' P ∘ₗ Matrix.toLin' P = Matrix.toLin' P
+    rw [← Matrix.toLin'_mul, hidem]
+  have hu_fix : f u = u := by
+    simpa only [u, LinearMap.comp_apply] using LinearMap.congr_fun hf 1
+  have hfixed (x : n → ℝ) (hx : f x = x) : ∃ c : ℝ, c • u = x := by
+    obtain ⟨k, _, hk⟩ := Finset.exists_max_image Finset.univ
+      (fun i ↦ x i / u i) Finset.univ_nonempty
+    let c : ℝ := x k / u k
+    let y : n → ℝ := c • u - x
+    have hy_nonneg (i : n) : 0 ≤ y i := by
+      have hratio : x i / u i ≤ c := hk i (Finset.mem_univ i)
+      have hxi : x i ≤ c * u i := (div_le_iff₀ (hu_pos i)).mp hratio
+      exact sub_nonneg.mpr hxi
+    have hyk : y k = 0 := by
+      simp only [y, Pi.smul_apply, smul_eq_mul, Pi.sub_apply, c]
+      rw [div_mul_cancel₀ (x k) (ne_of_gt (hu_pos k)), sub_self]
+    have hy_fix : f y = y := by
+      simp only [y, map_sub, map_smul, hu_fix, hx]
+    have hsum : ∑ j, P k j * y j = 0 := by
+      have hky := congrFun hy_fix k
+      rw [hyk] at hky
+      simpa only [f, Matrix.toLin'_apply, Matrix.mulVec, dotProduct] using hky
+    have hy_zero : y = 0 := by
+      funext i
+      have hterm : P k i * y i = 0 := congrFun
+        ((Fintype.sum_eq_zero_iff_of_nonneg fun j ↦
+          mul_nonneg (hP k j).le (hy_nonneg j)).mp hsum) i
+      exact (mul_eq_zero.mp hterm).resolve_left (ne_of_gt (hP k i))
+    refine ⟨c, sub_eq_zero.mp ?_⟩
+    simpa only [y] using hy_zero
+  have hu_mem : u ∈ LinearMap.range f := ⟨1, rfl⟩
+  have hu_ne : u ≠ 0 := by
+    intro hu
+    have := hu_pos (Classical.choice inferInstance)
+    rw [hu, Pi.zero_apply] at this
+    exact lt_irrefl 0 this
+  have hrank_le : Module.finrank ℝ (LinearMap.range f) ≤ 1 := by
+    refine finrank_le_one ⟨u, hu_mem⟩ fun x ↦ ?_
+    rcases x.property with ⟨z, hz⟩
+    have hx : f x.1 = x.1 := by
+      rw [← hz]
+      exact LinearMap.congr_fun hf z
+    obtain ⟨c, hc⟩ := hfixed x.1 hx
+    refine ⟨c, Subtype.ext ?_⟩
+    exact hc
+  have hrank_pos : 0 < Module.finrank ℝ (LinearMap.range f) := by
+    apply Module.finrank_pos_iff_exists_ne_zero.mpr
+    refine ⟨⟨u, hu_mem⟩, ?_⟩
+    intro hzero
+    apply hu_ne
+    exact congrArg Subtype.val hzero
+  have hrange : Module.finrank ℝ (LinearMap.range f) = 1 := by omega
+  rw [Matrix.rank_eq_finrank_range_toLin P (Pi.basisFun ℝ n) (Pi.basisFun ℝ n),
+    Matrix.toLin_eq_toLin']
+  simpa only [f] using hrange
+
+/-- If a primitive nonnegative real matrix has equal second and third powers,
+then its square has rank one.
+
+This is the finite-dimensional Perron-projection lemma supporting the proposed
+argument at arXiv:1606.00608, Appendix C.2, line 1613; it is not itself a
+claim of that source. The nonempty-index assumption is necessary for
+the library definition of primitivity: on the empty index set, strict
+positivity of a matrix power is vacuous and the square has rank zero. -/
+theorem IsPrimitive.rank_pow_two_eq_one_of_pow_two_eq_pow_three
+    {N : ℕ} [NeZero N] {T : Matrix (Fin N) (Fin N) ℝ}
+    (hT : T.IsPrimitive) (h : T ^ 2 = T ^ 3) :
+    (T ^ 2).rank = 1 := by
+  obtain ⟨m, hm, hpos⟩ := hT.exists_pos_pow
+  have htwom_pos (i j : Fin N) : 0 < (T ^ (m + m)) i j := by
+    rw [pow_add, Matrix.mul_apply]
+    exact Finset.sum_pos (fun k _ ↦ mul_pos (hpos i k) (hpos k j))
+      Finset.univ_nonempty
+  have hsq_pos (i j : Fin N) : 0 < (T ^ 2) i j := by
+    rw [← pow_eq_pow_two_of_pow_two_eq_pow_three h (m + m) (by omega)]
+    exact htwom_pos i j
+  have hsq_idem : T ^ 2 * T ^ 2 = T ^ 2 := by
+    rw [← pow_add]
+    exact pow_eq_pow_two_of_pow_two_eq_pow_three h 4 (by omega)
+  exact rank_eq_one_of_pos_of_mul_self_eq_self hsq_pos hsq_idem
+
+end Matrix

--- a/TNLean/Algebra/PerronFrobenius/Idempotent.lean
+++ b/TNLean/Algebra/PerronFrobenius/Idempotent.lean
@@ -100,9 +100,8 @@ then its square has rank one.
 
 This is the finite-dimensional Perron-projection lemma supporting the proposed
 argument at arXiv:1606.00608, Appendix C.2, line 1613; it is not itself a
-claim of that source. The nonempty-index assumption is necessary for
-the library definition of primitivity: on the empty index set, strict
-positivity of a matrix power is vacuous and the square has rank zero. -/
+claim of that source. The assumption N ≥ 1 is necessary: for N = 0,
+primitivity is vacuous and the square has rank zero. -/
 theorem IsPrimitive.rank_pow_two_eq_one_of_pow_two_eq_pow_three
     {N : ℕ} [NeZero N] {T : Matrix (Fin N) (Fin N) ℝ}
     (hT : T.IsPrimitive) (h : T ^ 2 = T ^ 3) :

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity.tex
@@ -749,7 +749,7 @@
     \label{thm:matrix_primitive_pow_two_rank_one}
     \lean{Matrix.IsPrimitive.rank_pow_two_eq_one_of_pow_two_eq_pow_three}
     \leanok
-    Let $T$ be a primitive non-negative real $N\times N$ matrix, where
+    Let $T$ be a primitive real $N\times N$ matrix, where
     $N\geq 1$. If
     \[
         T^2=T^3,
@@ -767,9 +767,13 @@
     \leanok
     \uses{thm:matrix_positive_idempotent_rank_one,
         thm:matrix_pairing_sq_eq_cube}
-    The identity $T^2=T^3$ gives $T^m=T^2$ for every $m\geq 2$. Some positive
-    power of $T$ has strictly positive entries. Squaring that power shows that
-    $T^2$ is strictly positive, and the same identity gives $(T^2)^2=T^2$.
+    Primitivity gives $m\geq 1$ such that $(T^m)_{i,j}>0$ for every $i,j$.
+    Stabilization gives $T^{2m}=T^2$. Thus, for every $i,j$,
+    \[
+        (T^2)_{i,j}=(T^{2m})_{i,j}
+        =\sum_k (T^m)_{i,k}(T^m)_{k,j}>0.
+    \]
+    The same stabilization identity gives $(T^2)^2=T^2$.
     The preceding theorem applied to $P=T^2$ now gives the conclusion.
 \end{proof}
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity.tex
@@ -716,21 +716,20 @@
     again contradicting the strict positivity of some power of $T$.
 \end{proof}
 
-\begin{lemma}[Rank of a strictly positive idempotent]
+\begin{theorem}[Rank of a strictly positive idempotent]
     \label{thm:matrix_positive_idempotent_rank_one}
     \lean{Matrix.rank_eq_one_of_pos_of_mul_self_eq_self}
     \leanok
     Let $I$ be a nonempty finite index set, and let $P$ be a real matrix
-    indexed by $I\times I$. If
+    indexed by $I\times I$. Suppose that $P^2=P$ and, for every $i,j\in I$,
     \[
-        P_{i,j}>0 \quad\text{for all }i,j\in I,
-        \qquad P^2=P,
+        P_{i,j}>0.
     \]
     then
     \[
         \operatorname{rank}(P)=1.
     \]
-\end{lemma}
+\end{theorem}
 
 \begin{proof}
     \leanok

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity.tex
@@ -716,9 +716,38 @@
     again contradicting the strict positivity of some power of $T$.
 \end{proof}
 
+\begin{lemma}[Rank of a strictly positive idempotent]
+    \label{thm:matrix_positive_idempotent_rank_one}
+    \lean{Matrix.rank_eq_one_of_pos_of_mul_self_eq_self}
+    \leanok
+    Let $I$ be a nonempty finite index set, and let $P$ be a real matrix
+    indexed by $I\times I$. If
+    \[
+        P_{i,j}>0 \quad\text{for all }i,j\in I,
+        \qquad P^2=P,
+    \]
+    then
+    \[
+        \operatorname{rank}(P)=1.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Put $u=P\mathbf 1$, so every coordinate of $u$ is positive and $Pu=u$.
+    For a fixed vector $x$ satisfying $Px=x$, choose an index $k$ at which
+    $x_i/u_i$ is maximal and put $c=x_k/u_k$. Then $y=cu-x$ is non-negative,
+    $y_k=0$, and $Py=y$. Hence
+    \[
+        0=y_k=(Py)_k=\sum_j P_{k,j}y_j.
+    \]
+    Since every $P_{k,j}$ is strictly positive, all coordinates of $y$ vanish.
+    Thus every fixed vector is proportional to $u$. The range of an idempotent
+    is its fixed space, so it is one-dimensional.
+\end{proof}
+
 \begin{theorem}[Rank of a stationary primitive square]
     \label{thm:matrix_primitive_pow_two_rank_one}
-    \lean{Matrix.rank_eq_one_of_pos_of_mul_self_eq_self}
     \lean{Matrix.IsPrimitive.rank_pow_two_eq_one_of_pow_two_eq_pow_three}
     \leanok
     Let $T$ be a primitive non-negative real $N\times N$ matrix, where
@@ -737,20 +766,12 @@
 
 \begin{proof}
     \leanok
+    \uses{thm:matrix_positive_idempotent_rank_one,
+        thm:matrix_pairing_sq_eq_cube}
     The identity $T^2=T^3$ gives $T^m=T^2$ for every $m\geq 2$. Some positive
     power of $T$ has strictly positive entries. Squaring that power shows that
     $T^2$ is strictly positive, and the same identity gives $(T^2)^2=T^2$.
-
-    Put $P=T^2$ and $u=P\mathbf 1$, so every coordinate of $u$ is positive and
-    $Pu=u$. For a fixed vector $x$, choose an index $k$ at which $x_i/u_i$ is
-    maximal and put $c=x_k/u_k$. Then $y=cu-x$ is non-negative, $y_k=0$, and
-    $Py=y$. Hence
-    \[
-        0=y_k=(Py)_k=\sum_j P_{k,j}y_j.
-    \]
-    Since every $P_{k,j}$ is strictly positive, all coordinates of $y$ vanish.
-    Thus every fixed vector is proportional to $u$. The range of an idempotent
-    is its fixed space, so it is one-dimensional.
+    The preceding lemma applied to $P=T^2$ now gives the conclusion.
 \end{proof}
 
 \begin{theorem}[Idempotence of the sector trace matrix]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity.tex
@@ -770,7 +770,7 @@
     The identity $T^2=T^3$ gives $T^m=T^2$ for every $m\geq 2$. Some positive
     power of $T$ has strictly positive entries. Squaring that power shows that
     $T^2$ is strictly positive, and the same identity gives $(T^2)^2=T^2$.
-    The preceding lemma applied to $P=T^2$ now gives the conclusion.
+    The preceding theorem applied to $P=T^2$ now gives the conclusion.
 \end{proof}
 
 \begin{theorem}[Idempotence of the sector trace matrix]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity.tex
@@ -725,7 +725,7 @@
     \[
         P_{i,j}>0.
     \]
-    then
+    Then
     \[
         \operatorname{rank}(P)=1.
     \]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity.tex
@@ -716,6 +716,43 @@
     again contradicting the strict positivity of some power of $T$.
 \end{proof}
 
+\begin{theorem}[Rank of a stationary primitive square]
+    \label{thm:matrix_primitive_pow_two_rank_one}
+    \lean{Matrix.rank_eq_one_of_pos_of_mul_self_eq_self}
+    \lean{Matrix.IsPrimitive.rank_pow_two_eq_one_of_pow_two_eq_pow_three}
+    \leanok
+    Let $T$ be a primitive non-negative real $N\times N$ matrix, where
+    $N\geq 1$. If
+    \[
+        T^2=T^3,
+    \]
+    then
+    \[
+        \operatorname{rank}(T^2)=1.
+    \]
+    This finite-dimensional matrix lemma supports the argument sought at
+    \cite[Appendix~C.2, line~1613]{Cirac2016MPDO_arXiv}; it is not a theorem
+    asserted there.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The identity $T^2=T^3$ gives $T^m=T^2$ for every $m\geq 2$. Some positive
+    power of $T$ has strictly positive entries. Squaring that power shows that
+    $T^2$ is strictly positive, and the same identity gives $(T^2)^2=T^2$.
+
+    Put $P=T^2$ and $u=P\mathbf 1$, so every coordinate of $u$ is positive and
+    $Pu=u$. For a fixed vector $x$, choose an index $k$ at which $x_i/u_i$ is
+    maximal and put $c=x_k/u_k$. Then $y=cu-x$ is non-negative, $y_k=0$, and
+    $Py=y$. Hence
+    \[
+        0=y_k=(Py)_k=\sum_j P_{k,j}y_j.
+    \]
+    Since every $P_{k,j}$ is strictly positive, all coordinates of $y$ vanish.
+    Thus every fixed vector is proportional to $u$. The range of an idempotent
+    is its fixed space, so it is one-dimensional.
+\end{proof}
+
 \begin{theorem}[Idempotence of the sector trace matrix]
     \label{thm:matrix_pairing_idempotent}
     \lean{Matrix.mul_self_eq_self_of_pairing_idempotent}

--- a/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
+++ b/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
@@ -389,7 +389,11 @@ One possible corrected route is to use the square of the trace matrix.  If a
 primitive nonnegative trace matrix $T$ satisfies $T^2=T^3$, then all powers
 from the second onward equal $T^2$, so $T^2$ is an idempotent Perron
 projection of rank one.  This is compatible with the four-sector example,
-where $T$ is not rank one but $T^2$ is.  What remains absent is a derivation of
+where $T$ is not rank one but $T^2$ is.  This finite-dimensional implication is
+formalized by
+\leanid{Matrix.IsPrimitive.rank_pow_two_eq_one_of_pow_two_eq_pow_three}; the
+nonempty matrix convention is explicit, since primitivity is vacuous for the
+zero-dimensional matrix under the library definition.  What remains absent is a derivation of
 primitivity for the Beigi trace matrix from the normal source block and its
 fixed proportional commuting-bond presentation; the existing primitivity
 theorem starts from the SAL-derived inverse-map factorization and is therefore


### PR DESCRIPTION
## Mathematical result

This proves the finite-dimensional implication needed in the proposed Perron--Frobenius route for the mixed-state trace matrix:

```lean
theorem Matrix.IsPrimitive.rank_pow_two_eq_one_of_pow_two_eq_pow_three
    {N : ℕ} [NeZero N] {T : Matrix (Fin N) (Fin N) ℝ}
    (hT : T.IsPrimitive) (h : T ^ 2 = T ^ 3) :
    (T ^ 2).rank = 1
```

The proof first shows that `T²` is a strictly positive idempotent. It then proves directly, by the maximum-ratio argument, that every fixed vector of a strictly positive idempotent is proportional to its positive fixed vector. Thus its range is one-dimensional.

The explicit `NeZero N` condition is necessary: under the library definition, primitivity is vacuous on the empty index type, while the empty matrix has rank zero.

## Source boundary

The new lemma supports the rank-one step sought near CPSV16 Appendix C.2, line 1613, but it is not asserted as a theorem in that source. The blueprint and the existing paper-gap note record this distinction. The remaining non-circular task is to prove primitivity of the actual Beigi sector trace matrix; this PR does not claim that step.

## Verification

- `lake build TNLean.Algebra.PerronFrobenius.Idempotent`
- `lake env lean TNLean/Algebra/PerronFrobenius/Idempotent.lean`
- no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast` in the new module
- axiom audit: only `propext`, `Classical.choice`, and `Quot.sound`
- blueprint synchronization, reverse coverage, and reader-facing prose checks
- `leanblueprint web`
- `git diff --check`

A clean aggregate build reached 9317/9590 jobs with no failures, including `TNLean.Spectral.MixedTransfer` and the relevant MPS targets. It was stopped in unrelated PEPS recovery modules after the focused checks passed; full remote CI is authoritative for aggregate completion.

Closes #4316.
Advances #4175 without closing it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Self-contained linear algebra on a new module; no auth, data, or runtime behavior changes. Remaining application risk is mathematical (proving primitivity at call sites), not introduced by this PR’s code paths.
> 
> **Overview**
> Adds **`TNLean.Algebra.PerronFrobenius.Idempotent`** with two matrix lemmas: strictly positive idempotents have rank one (maximum-ratio fixed-vector argument), and **primitive** real matrices with **`T² = T³`** have **`rank(T²) = 1`**, using existing power-stabilization from `RankOne` plus primitivity to make **`T²`** strictly positive and idempotent. The module is wired into **`TNLean.lean`**.
> 
> Blueprint ch.21 gains matching theorems (`matrix_positive_idempotent_rank_one`, `matrix_primitive_pow_two_rank_one`) with `\leanok` proofs; the paper-gap note records that the square-of-trace-matrix route is now formalized via **`Matrix.IsPrimitive.rank_pow_two_eq_one_of_pow_two_eq_pow_three`**, with **`NeZero N`** called out and **non-circular primitivity of the Beigi trace matrix** still open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a10012547edaad6fc0ff34751ecf298168e8489e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->