### PR TITLE
feat(Channel/FixedPoint): classify maximal-support compression

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -216,6 +216,7 @@ import TNLean.Channel.FixedPoint.MaximalRank
 import TNLean.Channel.FixedPoint.MaximalSupportBasic
 import TNLean.Channel.FixedPoint.MaximalSupport
 import TNLean.Channel.FixedPoint.StationarySupportRestriction
+import TNLean.Channel.FixedPoint.SupportCompressedDensityBlocks
 import TNLean.Channel.FixedPoint.StationarySupport
 import TNLean.Channel.FixedPoint.WedderburnDecomp
 import TNLean.Channel.FixedPoint.WeightedCornerFixedPoints

--- a/TNLean/Channel/FixedPoint/SupportCompressedDensityBlocks.lean
+++ b/TNLean/Channel/FixedPoint/SupportCompressedDensityBlocks.lean
@@ -1,0 +1,213 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.FixedPoint.StationarySupportRestriction
+import TNLean.Channel.FixedPoint.TraceAdjointDensityBlocks
+
+/-!
+# Density blocks after restriction to maximal stationary support
+
+Let $T$ be positive and trace preserving, and suppose that its trace adjoint
+satisfies the Schwarz inequality.  Restriction to the support of the maximal
+stationary point gives a positive trace-preserving map with a positive-definite
+fixed point.  The trace adjoint of this compression again satisfies the
+Schwarz inequality, so the full-support density-block classification applies.
+
+## References
+
+* M. Wolf, *Quantum Channels & Operations: Guided Tour*, Lemma 6.5 and
+  Theorem 6.14; local source
+  `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1345--1386 and
+  1483--1494.
+-/
+
+open scoped Matrix Matrix.Norms.Frobenius ComplexOrder MatrixOrder Kronecker
+open Matrix
+
+noncomputable section
+
+variable {D n : ℕ}
+
+local notation "MatD" => Matrix (Fin D) (Fin D) ℂ
+local notation "Matn" => Matrix (Fin n) (Fin n) ℂ
+
+/-- Taking the trace adjoint commutes with compression along an isometric
+inclusion.
+
+This is the trace-pairing identity used in Wolf, Lemma 6.5, especially
+Equation (6.54); local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1345--1368. -/
+theorem Matrix.traceAdjointMap_stationarySupportCompression
+    (T : MatD →ₗ[ℂ] MatD) (V : Matrix (Fin D) (Fin n) ℂ) :
+    Matrix.traceAdjointMap (IsPositiveMap.stationarySupportCompression T V) =
+      IsPositiveMap.stationarySupportCompression (Matrix.traceAdjointMap T) V := by
+  apply LinearMap.ext
+  intro A
+  apply Matrix.ext_iff_trace_mul_right.mpr
+  intro B
+  calc
+    (Matrix.traceAdjointMap (IsPositiveMap.stationarySupportCompression T V) A * B).trace =
+        (A * IsPositiveMap.stationarySupportCompression T V B).trace :=
+      Matrix.trace_traceAdjointMap_mul _ _ _
+    _ = ((A * Vᴴ) * (T (V * B * Vᴴ) * V)).trace := by
+      simp only [IsPositiveMap.stationarySupportCompression_apply, Matrix.mul_assoc]
+    _ = ((T (V * B * Vᴴ) * V) * (A * Vᴴ)).trace :=
+      Matrix.trace_mul_comm _ _
+    _ = (T (V * B * Vᴴ) * (V * A * Vᴴ)).trace := by
+      simp only [Matrix.mul_assoc]
+    _ = ((V * A * Vᴴ) * T (V * B * Vᴴ)).trace :=
+      Matrix.trace_mul_comm _ _
+    _ = (Matrix.traceAdjointMap T (V * A * Vᴴ) * (V * B * Vᴴ)).trace :=
+      (Matrix.trace_traceAdjointMap_mul _ _ _).symm
+    _ = ((Matrix.traceAdjointMap T (V * A * Vᴴ) * V) * (B * Vᴴ)).trace := by
+      simp only [Matrix.mul_assoc]
+    _ = ((B * Vᴴ) * (Matrix.traceAdjointMap T (V * A * Vᴴ) * V)).trace :=
+      Matrix.trace_mul_comm _ _
+    _ = (B * (Vᴴ * Matrix.traceAdjointMap T (V * A * Vᴴ) * V)).trace := by
+      simp only [Matrix.mul_assoc]
+    _ = ((Vᴴ * Matrix.traceAdjointMap T (V * A * Vᴴ) * V) * B).trace :=
+      Matrix.trace_mul_comm _ _
+    _ = (IsPositiveMap.stationarySupportCompression
+          (Matrix.traceAdjointMap T) V A * B).trace := rfl
+
+/-- Compression along an isometry preserves the Schwarz inequality for a
+positive map.
+
+The proof compresses the original Schwarz defect and adds the positive corner
+through $1-VV^*$.  This is Wolf, Equations (6.58)--(6.59), local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1370--1386. -/
+theorem IsSchwarzMap.stationarySupportCompression
+    {E : MatD →ₗ[ℂ] MatD} (hE : IsSchwarzMap E) (hEpos : IsPositiveMap E)
+    (V : Matrix (Fin D) (Fin n) ℂ) (hV : Vᴴ * V = 1) :
+    IsSchwarzMap (IsPositiveMap.stationarySupportCompression E V) := by
+  intro A
+  let X : MatD := V * A * Vᴴ
+  let Q : MatD := V * Vᴴ
+  have hQ : IsOrthogonalProjection Q := by
+    constructor
+    · change Qᴴ = Q
+      simp [Q]
+    · dsimp [Q]
+      calc
+        (V * Vᴴ) * (V * Vᴴ) = V * (Vᴴ * V) * Vᴴ := by
+          simp only [Matrix.mul_assoc]
+        _ = V * Vᴴ := by rw [hV, Matrix.mul_one]
+  have hcompressed :
+      (Vᴴ * (E (Xᴴ * X) - E Xᴴ * E X) * V).PosSemidef :=
+    (hE X).conjTranspose_mul_mul_same V
+  have hcomplement :
+      (Vᴴ * (E X)ᴴ * (1 - Q) * E X * V).PosSemidef := by
+    have hQcomp : (1 - Q).PosSemidef :=
+      isOrthogonalProjection_posSemidef hQ.one_sub
+    have h := hQcomp.conjTranspose_mul_mul_same (E X * V)
+    simpa [Matrix.conjTranspose_mul, Matrix.mul_assoc] using h
+  have hXstar : E Xᴴ = (E X)ᴴ := hEpos.map_conjTranspose X
+  change
+    (Vᴴ * E (V * (Aᴴ * A) * Vᴴ) * V -
+      (Vᴴ * E (V * Aᴴ * Vᴴ) * V) *
+        (Vᴴ * E (V * A * Vᴴ) * V)).PosSemidef
+  have hXsq : Xᴴ * X = V * (Aᴴ * A) * Vᴴ := by
+    dsimp only [X]
+    rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_mul,
+      Matrix.conjTranspose_conjTranspose]
+    calc
+      V * (Aᴴ * Vᴴ) * (V * A * Vᴴ) =
+          V * Aᴴ * (Vᴴ * V) * A * Vᴴ := by
+        simp only [Matrix.mul_assoc]
+      _ = V * (Aᴴ * A) * Vᴴ := by rw [hV]; simp [Matrix.mul_assoc]
+  have hXadj : Xᴴ = V * Aᴴ * Vᴴ := by
+    dsimp only [X]
+    rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_mul,
+      Matrix.conjTranspose_conjTranspose]
+    exact (Matrix.mul_assoc _ _ _).symm
+  rw [← hXsq, ← hXadj]
+  rw [show
+      Vᴴ * E (Xᴴ * X) * V -
+          (Vᴴ * E Xᴴ * V) * (Vᴴ * E X * V) =
+        Vᴴ * (E (Xᴴ * X) - E Xᴴ * E X) * V +
+          Vᴴ * (E X)ᴴ * (1 - Q) * E X * V by
+    rw [hXstar]
+    dsimp only [Q]
+    simp only [Matrix.mul_sub, Matrix.mul_one, Matrix.sub_mul]
+    have hcorner :
+        (Vᴴ * (E X)ᴴ * V) * (Vᴴ * E X * V) =
+          Vᴴ * (E X)ᴴ * (V * Vᴴ) * E X * V := by
+      simp only [Matrix.mul_assoc]
+    have hwhole :
+        Vᴴ * ((E X)ᴴ * E X) * V = Vᴴ * (E X)ᴴ * E X * V := by
+      simp only [Matrix.mul_assoc]
+    rw [hcorner]
+    rw [hwhole]
+    abel]
+  exact hcompressed.add hcomplement
+
+/-- If the trace adjoint of a positive map satisfies the Schwarz inequality,
+then so does the trace adjoint after compression along an isometry.
+
+This is Wolf, Equation (6.55), local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1369--1386. -/
+theorem IsSchwarzMap.traceAdjointMap_stationarySupportCompression
+    {T : MatD →ₗ[ℂ] MatD}
+    (hSchwarz : IsSchwarzMap (Matrix.traceAdjointMap T)) (hT : IsPositiveMap T)
+    (V : Matrix (Fin D) (Fin n) ℂ) (hV : Vᴴ * V = 1) :
+    IsSchwarzMap
+      (Matrix.traceAdjointMap (IsPositiveMap.stationarySupportCompression T V)) := by
+  rw [Matrix.traceAdjointMap_stationarySupportCompression]
+  exact hSchwarz.stationarySupportCompression hT.traceAdjointMap V hV
+
+/-- The restriction to maximal stationary support admits the density-block
+description of its fixed points.
+
+The support restriction is Wolf, Lemma 6.5, and the density-block conclusion
+is the full-support step in the proof of Wolf, Theorem 6.14; local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1345--1386 and
+1483--1494.
+
+**Scope restriction (maximal-support compression):** This theorem describes
+the fixed points of the compressed map with positive semidefinite density
+blocks.  It does not yet prove that these blocks are positive definite or
+transport the description to the original space with its complementary zero
+summand.  This restriction is documented in
+`docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex`.
+
+The theorem records only the fixed-point description.  The corresponding
+formula for the mean ergodic projection is supplied by
+`IsPositiveMap.exists_block_densities_of_meanErgodicProjection`. -/
+theorem IsPositiveMap.exists_block_densities_of_maximalSupportCompression
+    {T : MatD →ₗ[ℂ] MatD} (hT : IsPositiveMap T)
+    (hTP : IsTracePreservingMap T)
+    (hSchwarz : IsSchwarzMap (Matrix.traceAdjointMap T)) :
+    let ρ₀ := IsPositiveMap.maximalSupportPoint T hT hTP
+    ∃ (hρ₀ : ρ₀.PosSemidef) (n : ℕ)
+      (V : Matrix (Fin D) (Fin n) ℂ),
+      T ρ₀ = ρ₀ ∧ Vᴴ * V = 1 ∧
+        V * Vᴴ = Kraus.stationaryProj hρ₀ ∧
+        (∃ ρfull : Matrix (Fin n) (Fin n) ℂ,
+          ρfull.PosDef ∧
+            IsPositiveMap.stationarySupportCompression T V ρfull = ρfull) ∧
+        ∃ (K : ℕ) (d m : Fin K → ℕ)
+          (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
+          (U : Matrix (Fin n) (Fin n) ℂ)
+          (σ : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ),
+          U ∈ Matrix.unitaryGroup (Fin n) ℂ ∧
+            (∀ k, 0 < d k) ∧ (∀ k, 0 < m k) ∧
+            (∀ k, (σ k).PosSemidef) ∧ (∀ k, (σ k).trace = 1) ∧
+            ∀ B, IsPositiveMap.stationarySupportCompression T V B = B ↔
+              ∃ X : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ,
+                star U * B * U = Matrix.reindex e e
+                  (Matrix.blockDiagonal' fun k ↦ σ k ⊗ₖ X k) := by
+  dsimp only
+  obtain ⟨hρ₀, n, V, hρ₀fix, hV, hVrange, hpositive, htrace, _,
+      ⟨ρfull, hρfull, hρfullFix⟩, _⟩ := hT.exists_maximalSupportCompression hTP
+  have hcompressedSchwarz :
+      IsSchwarzMap (Matrix.traceAdjointMap
+        (IsPositiveMap.stationarySupportCompression T V)) :=
+    hSchwarz.traceAdjointMap_stationarySupportCompression hT V hV
+  obtain ⟨K, d, m, e, U, σ, hU, hd, hm, hσpos, hσtrace, _, hfixed⟩ :=
+    hpositive.exists_block_densities_of_meanErgodicProjection
+      htrace hcompressedSchwarz hρfull hρfullFix
+  exact ⟨hρ₀, n, V, hρ₀fix, hV, hVrange,
+    ⟨ρfull, hρfull, hρfullFix⟩,
+    K, d, m, e, U, σ, hU, hd, hm, hσpos, hσtrace, hfixed⟩

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -3197,6 +3197,54 @@ transfers the support.
     \]
 \end{proof}
 
+% Scope restriction documented in
+% docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex.
+\begin{theorem}[Density blocks after restriction to maximal stationary support]%
+    \label{thm:maximal_support_compression_density_blocks}
+    \lean{IsPositiveMap.exists_block_densities_of_maximalSupportCompression,
+        Matrix.traceAdjointMap_stationarySupportCompression,
+        IsSchwarzMap.stationarySupportCompression,
+        IsSchwarzMap.traceAdjointMap_stationarySupportCompression}
+    \leanok
+    \uses{thm:stationarySupport_compression,
+        thm:mean_ergodic_projection_density_block_form}
+    Let $T:\MN{D}\to\MN{D}$ be positive and trace preserving, and suppose
+    that $T^*$ satisfies the Schwarz inequality.  Set
+    $\rho_0=T_\infty(\Id)$ and let $V:\mathcal H\to\mathbb C^D$ be an
+    isometry onto the support of $\rho_0$.  Then
+    \[
+        \widetilde T(Y)=V^*T(VYV^*)V
+    \]
+    has a positive definite fixed point.  There are positive integers
+    $d_k,m_k$, a unitary $U$ on $\mathcal H$, and positive semidefinite
+    density matrices $\sigma_k\in\MN{m_k}$ such that
+    \[
+        \operatorname{Fix}(\widetilde T)
+        =U\left(\bigoplus_k \sigma_k\otimes\MN{d_k}\right)U^*.
+    \]
+    This is the maximal-support application of the full-support step in the
+    proof of \cite[Theorem~6.14]{Wolf2012Quantum}.  This is not the full
+    statement of that theorem: it does not yet identify the density matrices
+    as positive definite or transport the displayed decomposition back to the
+    original space.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:stationarySupport_compression,
+        thm:mean_ergodic_projection_density_block_form}
+    Theorem~\ref{thm:stationarySupport_compression} gives positivity, trace
+    preservation, and a positive definite fixed point for $\widetilde T$.
+    Directly from the trace pairing,
+    \[
+        \widetilde T^*(A)=V^*T^*(VAV^*)V.
+    \]
+    Compressing the Schwarz defect for $T^*$ and adding the positive term
+    through $\Id-VV^*$ proves the Schwarz inequality for
+    $\widetilde T^*$.  Theorem~\ref{thm:mean_ergodic_projection_density_block_form}
+    now gives the asserted fixed-point description.
+\end{proof}
+
 \begin{theorem}[Conjugation by the square root at a fixed point of maximal support]%
     \label{thm:maximalSupport_weightedCorner}
     \lean{Kraus.exists_maximalSupport_weightedCorner_sqrt_eq}

--- a/docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex
+++ b/docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex
@@ -150,18 +150,42 @@ and
 in
 \doclink{TNLean/Channel/FixedPoint/StationarySupportRestriction}.}
 
-It remains to apply the full-support fixed-point theorem to $\widetilde T$,
-transport its density-block form through $V$, and combine the complement of
-$Q$ with the kernels discarded when each density matrix is restricted to its
-support.  This last combination produces the single zero summand
-$\mathcal H_0$ of Theorem~6.14.
+The full-support fixed-point theorem is now applied to $\widetilde T$.  The
+trace adjoint commutes with the isometric compression,
+\begin{align}
+  \widetilde T^*(A)=V^*T^*(VAV^*)V,
+\end{align}
+and the Schwarz defect of this map is the compression of the Schwarz defect
+of $T^*$ plus a positive term supported on $\mathbf 1-VV^*$.  Hence the
+Schwarz hypothesis passes to $\widetilde T^*$ using only the positivity of
+$T$ already assumed in Theorem~6.14.  The full-support density-block theorem
+therefore gives
+\begin{align}
+  \operatorname{Fix}(\widetilde T)
+    =U\left(\bigoplus_k\sigma_k\otimes M_{d_k}(\mathbb C)\right)U^*,
+\end{align}
+where every $\sigma_k$ is positive semidefinite and has trace one.
+\footnote{Formal declarations:
+\leanid{Matrix.traceAdjointMap_stationarySupportCompression},
+\leanid{IsSchwarzMap.traceAdjointMap_stationarySupportCompression}, and
+\leanid{IsPositiveMap.exists_block_densities_of_maximalSupportCompression}
+in
+\doclink{TNLean/Channel/FixedPoint/SupportCompressedDensityBlocks}.}
+
+It remains to use the retained positive definite fixed point of
+$\widetilde T$ to prove that each $\sigma_k$ is positive definite, transport
+the resulting density-block form through $V$, and write the complement of
+$Q$ as the single zero summand $\mathcal H_0$ of Theorem~6.14.  In particular,
+the present reduction suggests that no second support compression of the
+individual matrices $\sigma_k$ is needed.
 
 Thus Proposition~1.5, its application to the full-support adjoint
 mean-ergodic projection, and the full-support Schr\"odinger-picture fixed-point
 formula, together with the maximal-support witness and the positive
 trace-preserving restriction to its support, are formalized, while
-Theorem~6.14 remains open.  The missing work is the application and transport
-of the full-support formula and the final assembly of the discarded kernels.
+Theorem~6.14 remains open.  The missing work is the positive-definiteness of
+the compressed density blocks, transport to the original space, and assembly
+of the complementary zero summand.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

- proves that the trace adjoint commutes with compression along an isometry;
- proves that the Schwarz inequality passes to the compressed trace adjoint, using positivity for preservation of conjugate transpose;
- applies the existing full-support density-block theorem to the restriction on maximal stationary support;
- adds a scope-restricted blueprint entry and updates the Wolf Theorem 6.14 paper-gap note.

## Mathematical scope

The source-facing theorem assumes exactly that T is positive and trace preserving and that its trace adjoint satisfies the Schwarz inequality. It retains the maximal stationary point, its support isometry, a positive-definite fixed point of the compressed map, and the density-block description of the compressed fixed-point space. No complete positivity, Kraus representation, unitality, irreducibility, multiplicativity, or invertibility is assumed.

This is not the full statement of Wolf Theorem 6.14. The block densities are presently positive semidefinite and trace one. Proving their positive definiteness, transporting the formula through the support isometry, and adjoining the complementary zero summand remain in LionSR/QICLean#219.

Source: Wolf, *Quantum Channels & Operations*, Lemma 6.5, Equations (6.54)--(6.59), and Theorem 6.14; local source lines 1345--1386 and 1483--1494.

## Verification

- lake env lean TNLean/Channel/FixedPoint/SupportCompressedDensityBlocks.lean
- lake build TNLean.Channel.FixedPoint.SupportCompressedDensityBlocks
- blueprint/Lean synchronization, including reverse coverage of all changed declarations
- proof-integrity and 100-column checks
- axioms of all new declarations: propext, Classical.choice, Quot.sound

Closes LionSR/QICLean#235.
Advances LionSR/QICLean#219.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style fixed-point theory with no runtime or security surface; main risk is mathematical/API surface expansion in a specialized Lean module.
> 
> **Overview**
> Adds **`SupportCompressedDensityBlocks.lean`** and wires it into the root import list, advancing Wolf Theorem 6.14 by classifying fixed points of the map compressed to **maximal stationary support**.
> 
> New lemmas show the **trace adjoint commutes** with `stationarySupportCompression`, and that **Schwarz** for the original trace adjoint passes to the compressed trace adjoint (via a defect split using `1 - VVᴴ`). Those feed **`IsPositiveMap.exists_block_densities_of_maximalSupportCompression`**, which reuses maximal-support compression and the existing full-support **`exists_block_densities_of_meanErgodicProjection`** to obtain the block-diagonal fixed-point form on the compressed Hilbert space.
> 
> The **blueprint** gains a matching theorem (explicitly **scope-restricted**: semidefinite blocks, no transport back to the full space). The **Wolf 6.14 gap note** is updated to record this step and narrows remaining work to positive-definite blocks, isometry transport, and the zero summand.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89275a0a24b799b9d23c1ea060f9f8b9eedb2bae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->