### PR TITLE
feat(Channel/Schwarz): reduce Weyl sandwich to Petz recovery

### DIFF
--- a/TNLean/Channel/PetzRecovery.lean
+++ b/TNLean/Channel/PetzRecovery.lean
@@ -21,6 +21,9 @@ reference matrix.
 ## Main declarations
 
 * `Matrix.PosSemidef.supportInvSqrt`: the inverse square root on the support.
+* `Matrix.PosSemidef.supportInvSqrt_smul`: scaling by a positive real scalar.
+* `Matrix.PosSemidef.supportInvSqrt_kronecker_one`: compatibility with the
+  unital left tensor embedding.
 * `Matrix.partialTraceRightPetzMap`: the raw Petz transpose map for the right
   partial trace.
 * `Matrix.partialTraceRightPetzMap_isKrausCP`: complete positivity.
@@ -72,6 +75,48 @@ theorem PosSemidef.supportInvSqrt_isHermitian {ρ : Matrix n n ℂ}
   rw [PosSemidef.supportInvSqrt, ← hρ.isHermitian.cfc_eq]
   exact Matrix.isHermitian_iff_isSelfAdjoint.mpr
     (cfc_predicate (fun x : ℝ ↦ if x ≠ 0 then (Real.sqrt x)⁻¹ else 0) ρ)
+
+/-- The support inverse square root of a positive real multiple scales by the
+inverse square root of that multiple. This is the scalar normalization in the
+support inverse appearing in Hayden--Jozsa--Petz--Winter,
+arXiv:quant-ph/0304007v2, Theorem 3, equation (8). -/
+theorem PosSemidef.supportInvSqrt_smul {ρ : Matrix n n ℂ}
+    (hρ : ρ.PosSemidef) {c : ℝ} (hc : 0 < c) :
+    (hρ.smul hc.le).supportInvSqrt = (Real.sqrt c)⁻¹ • hρ.supportInvSqrt := by
+  unfold PosSemidef.supportInvSqrt
+  rw [← (hρ.smul hc.le).isHermitian.cfc_eq, ← hρ.isHermitian.cfc_eq]
+  refine (cfc_comp_smul (p := IsSelfAdjoint) c
+    (fun x : ℝ ↦ if x ≠ 0 then (Real.sqrt x)⁻¹ else 0) ρ
+    (hf := (ρ.finite_real_spectrum.image (fun x : ℝ ↦ c • x)).continuousOn _)
+    (ha := hρ.isHermitian.isSelfAdjoint)).symm.trans ?_
+  have hfun :
+      (fun x : ℝ ↦ if c • x ≠ 0 then (Real.sqrt (c • x))⁻¹ else 0) =
+        fun x : ℝ ↦ (Real.sqrt c)⁻¹ •
+          (if x ≠ 0 then (Real.sqrt x)⁻¹ else 0) := by
+    funext x
+    simp only [smul_eq_mul]
+    by_cases hx : x = 0
+    · simp [hx]
+    · rw [if_pos (mul_ne_zero hc.ne' hx), if_pos hx, Real.sqrt_mul hc.le,
+        mul_inv]
+  rw [hfun, cfc_smul (p := IsSelfAdjoint) (Real.sqrt c)⁻¹
+    (fun x : ℝ ↦ if x ≠ 0 then (Real.sqrt x)⁻¹ else 0) ρ
+    (hf := ρ.finite_real_spectrum.continuousOn _)]
+
+/-- The support inverse square root commutes with the unital left tensor
+embedding. This is the tensor functional-calculus identity for the support
+inverse in Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2, Theorem 3,
+equation (8). -/
+theorem PosSemidef.supportInvSqrt_kronecker_one
+    {m : Type*} [Fintype m] [DecidableEq m]
+    {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) :
+    (hρ.kronecker (Matrix.PosSemidef.one (n := m))).supportInvSqrt =
+      hρ.supportInvSqrt ⊗ₖ (1 : Matrix m m ℂ) := by
+  unfold PosSemidef.supportInvSqrt
+  rw [← (hρ.kronecker (Matrix.PosSemidef.one (n := m))).isHermitian.cfc_eq,
+    ← hρ.isHermitian.cfc_eq]
+  exact Matrix.cfc_kronecker_one hρ.isHermitian
+    (fun x : ℝ ↦ if x ≠ 0 then (Real.sqrt x)⁻¹ else 0)
 
 /-- Sandwiching a positive-semidefinite matrix by its support inverse square
 root gives its support projection.  This is the spectral support identity

--- a/TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean
+++ b/TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean
@@ -39,6 +39,8 @@ the positive semidefinite matrices.
 open scoped Matrix Kronecker ComplexOrder Matrix.Norms.L2Operator
 open Matrix
 
+namespace Matrix
+
 /-- The support inverse square root of a positive semidefinite left factor
 tensored with the maximally mixed right factor is the lifted support inverse
 square root multiplied by the square root of the right dimension.
@@ -46,7 +48,7 @@ square root multiplied by the square root of the right dimension.
 This is the functional-calculus normalization in the identity-summand
 specialization of Hayden--Jozsa--Petz--Winter,
 arXiv:quant-ph/0304007v2, Theorem 3, equation (8). -/
-theorem Matrix.PosSemidef.supportInvSqrt_kronecker_maximallyMixed
+theorem PosSemidef.supportInvSqrt_kronecker_maximallyMixed
     {m : Type*} [Fintype m] [DecidableEq m] {dC : ℕ} [NeZero dC]
     {σ : Matrix m m ℂ} (hσ : σ.PosSemidef) :
     (hσ.kronecker maximallyMixed_posDef.posSemidef).supportInvSqrt =
@@ -70,7 +72,7 @@ left tensor embedding.
 This is the tensor normalization needed to reduce the identity Weyl summand to
 the support Petz formula in Hayden--Jozsa--Petz--Winter,
 arXiv:quant-ph/0304007v2, Theorem 3, equation (8). -/
-theorem Matrix.PosSemidef.supportInvSqrt_kronecker_maximallyMixed_mul_mul
+theorem PosSemidef.supportInvSqrt_kronecker_maximallyMixed_mul_mul
     {m : Type*} [Fintype m] [DecidableEq m] {dC : ℕ} [NeZero dC]
     {σ X : Matrix m m ℂ} (hσ : σ.PosSemidef) :
     let hbarσ := hσ.kronecker maximallyMixed_posDef.posSemidef
@@ -102,7 +104,7 @@ algebraic reduction of that hypothesis to the support formula in
 Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2, Theorem 3,
 equation (8); it does not derive the hypothesis from scalar relative-entropy
 equality. -/
-theorem Matrix.partialTraceRightPetzMap_eq_of_weyl_identity_sandwich
+theorem partialTraceRightPetzMap_eq_of_weyl_identity_sandwich
     {dS dC : ℕ} [NeZero dC]
     {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
     (hσ : σ.PosSemidef)
@@ -120,6 +122,8 @@ theorem Matrix.partialTraceRightPetzMap_eq_of_weyl_identity_sandwich
   rw [← Matrix.PosSemidef.supportInvSqrt_kronecker_maximallyMixed_mul_mul
     (X := partialTraceRight ρ) (PosSemidef.partialTraceRight hσ)]
   exact hSandwich
+
+end Matrix
 
 /-- **Ancilla additivity on the singular support domain.** Let `ρ` and `σ` be
 positive semidefinite matrices with `ker σ ⊆ ker ρ`, and let `τ` be a positive

--- a/TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean
+++ b/TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean
@@ -15,6 +15,10 @@ the positive semidefinite matrices.
 
 ## Main result
 
+* `Matrix.PosSemidef.supportInvSqrt_kronecker_maximallyMixed` computes the
+  support inverse square root of a maximally mixed extension.
+* `Matrix.PosSemidef.supportInvSqrt_kronecker_maximallyMixed_mul_mul` cancels
+  the dimension factors in the corresponding support sandwich.
 * `quantumRelativeEntropy_kronecker_support` proves ancilla additivity on the
   finite-relative-entropy support domain.
 * `quantumRelativeEntropy_weyl_average_eq_summand_of_partialTraceRight_eq`

--- a/TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean
+++ b/TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean
@@ -22,6 +22,8 @@ the positive semidefinite matrices.
   finite Weyl average.
 * `quantumRelativeEntropy_weyl_jensen_eq_of_partialTraceRight_eq` identifies
   saturation of the finite Jensen inequality in the Weyl proof.
+* `Matrix.partialTraceRightPetzMap_eq_of_weyl_identity_sandwich` reduces the
+  identity-summand support sandwich to the native raw partial-trace Petz map.
 
 ## References
 
@@ -32,6 +34,88 @@ the positive semidefinite matrices.
 
 open scoped Matrix Kronecker ComplexOrder Matrix.Norms.L2Operator
 open Matrix
+
+/-- The support inverse square root of a positive semidefinite left factor
+tensored with the maximally mixed right factor is the lifted support inverse
+square root multiplied by the square root of the right dimension.
+
+This is the functional-calculus normalization in the identity-summand
+specialization of Hayden--Jozsa--Petz--Winter,
+arXiv:quant-ph/0304007v2, Theorem 3, equation (8). -/
+theorem Matrix.PosSemidef.supportInvSqrt_kronecker_maximallyMixed
+    {m : Type*} [Fintype m] [DecidableEq m] {dC : ℕ} [NeZero dC]
+    {σ : Matrix m m ℂ} (hσ : σ.PosSemidef) :
+    (hσ.kronecker maximallyMixed_posDef.posSemidef).supportInvSqrt =
+      (Real.sqrt dC : ℂ) •
+        (hσ.supportInvSqrt ⊗ₖ (1 : Matrix (ZMod dC) (ZMod dC) ℂ)) := by
+  have hdCpos : (0 : ℝ) < dC := by
+    exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne dC)
+  have hbase := Matrix.PosSemidef.supportInvSqrt_smul
+    (hσ.kronecker (Matrix.PosSemidef.one (n := ZMod dC))) (inv_pos.mpr hdCpos)
+  convert hbase using 1
+  · congr 1
+    rw [Matrix.kronecker_smul, ← Complex.coe_smul, Complex.ofReal_inv,
+      Complex.ofReal_natCast]
+  · rw [Matrix.PosSemidef.supportInvSqrt_kronecker_one, Real.sqrt_inv, inv_inv]
+    · rw [Complex.coe_smul]
+
+/-- Sandwiching a left-tensored matrix by the support inverse square root of a
+maximally-mixed extension cancels the dimension factors and gives the unital
+left tensor embedding.
+
+This is the tensor normalization needed to reduce the identity Weyl summand to
+the support Petz formula in Hayden--Jozsa--Petz--Winter,
+arXiv:quant-ph/0304007v2, Theorem 3, equation (8). -/
+theorem Matrix.PosSemidef.supportInvSqrt_kronecker_maximallyMixed_mul_mul
+    {m : Type*} [Fintype m] [DecidableEq m] {dC : ℕ} [NeZero dC]
+    {σ X : Matrix m m ℂ} (hσ : σ.PosSemidef) :
+    let hbarσ := hσ.kronecker maximallyMixed_posDef.posSemidef
+    hbarσ.supportInvSqrt *
+        (X ⊗ₖ ((dC : ℂ)⁻¹ • (1 : Matrix (ZMod dC) (ZMod dC) ℂ))) *
+        hbarσ.supportInvSqrt =
+      leftKroneckerEmbed (n := ZMod dC)
+        (hσ.supportInvSqrt * X * hσ.supportInvSqrt) := by
+  dsimp only
+  rw [Matrix.PosSemidef.supportInvSqrt_kronecker_maximallyMixed hσ,
+    Matrix.kronecker_smul]
+  simp only [Matrix.smul_mul, Matrix.mul_smul, smul_smul,
+    Matrix.leftKroneckerEmbed_apply]
+  rw [← Matrix.mul_kronecker_mul, ← Matrix.mul_kronecker_mul]
+  simp only [Matrix.mul_one]
+  have hdC : (dC : ℂ) ≠ 0 := by exact_mod_cast NeZero.ne dC
+  have hsqrt : ((Real.sqrt dC : ℝ) : ℂ) * ((dC : ℂ)⁻¹ * Real.sqrt dC) = 1 := by
+    rw [mul_comm (dC : ℂ)⁻¹, ← mul_assoc, ← Complex.ofReal_mul,
+      Real.mul_self_sqrt (by positivity), Complex.ofReal_natCast, mul_inv_cancel₀ hdC]
+  rw [hsqrt, one_smul]
+
+/-- If the identity summand of the finite Weyl mixture satisfies the support
+Petz sandwich identity, then the native raw partial-trace Petz map recovers the
+original matrix.
+
+The sandwich hypothesis is the operator equality that must still be obtained
+from equality in the finite Weyl Jensen step. This theorem performs only the
+algebraic reduction of that hypothesis to the support formula in
+Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2, Theorem 3,
+equation (8); it does not derive the hypothesis from scalar relative-entropy
+equality. -/
+theorem Matrix.partialTraceRightPetzMap_eq_of_weyl_identity_sandwich
+    {dS dC : ℕ} [NeZero dC]
+    {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
+    (hσ : σ.PosSemidef)
+    (hSandwich :
+      let hbarσ := (PosSemidef.partialTraceRight hσ).kronecker
+        maximallyMixed_posDef.posSemidef
+      hσ.isHermitian.cfc Real.sqrt *
+          (hbarσ.supportInvSqrt *
+            (partialTraceRight ρ ⊗ₖ
+              ((dC : ℂ)⁻¹ • (1 : Matrix (ZMod dC) (ZMod dC) ℂ))) *
+            hbarσ.supportInvSqrt) *
+          hσ.isHermitian.cfc Real.sqrt = ρ) :
+    partialTraceRightPetzMap σ hσ (partialTraceRight ρ) = ρ := by
+  rw [partialTraceRightPetzMap_apply]
+  rw [← Matrix.PosSemidef.supportInvSqrt_kronecker_maximallyMixed_mul_mul
+    (X := partialTraceRight ρ) (PosSemidef.partialTraceRight hσ)]
+  exact hSandwich
 
 /-- **Ancilla additivity on the singular support domain.** Let `ρ` and `σ` be
 positive semidefinite matrices with `ker σ ⊆ ker ρ`, and let `τ` be a positive

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -1364,6 +1364,33 @@ Theorem~\ref{thm:trace_norm_abs}.
     $\lambda_i^{-1/2}\lambda_i\lambda_i^{-1/2}=1$ otherwise.
 \end{proof}
 
+\begin{lemma}[Support inverse square root under scaling and a maximally mixed factor]
+    \label{lem:support_inverse_square_root_maximally_mixed}
+    \lean{Matrix.PosSemidef.supportInvSqrt_smul}
+    \lean{Matrix.PosSemidef.supportInvSqrt_kronecker_one}
+    \lean{Matrix.PosSemidef.supportInvSqrt_kronecker_maximallyMixed}
+    \leanok
+    \uses{def:support_inverse_square_root}
+    Let $\tau$ be positive semidefinite and let $c>0$. Then
+    \[
+        (c\tau)^{-1/2}_{\mathrm{supp}}
+          =c^{-1/2}\tau^{-1/2}_{\mathrm{supp}}.
+    \]
+    Consequently, for $d_R>0$,
+    \[
+        \bigl(\tau\otimes d_R^{-1}\mathbf 1_R\bigr)^{-1/2}_{\mathrm{supp}}
+          =\sqrt{d_R}\,
+            \bigl(\tau^{-1/2}_{\mathrm{supp}}\otimes\mathbf 1_R\bigr).
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    The scalar identity follows from the functional calculus and
+    $\sqrt{cx}=\sqrt c\sqrt x$ for $c>0$.  The unital tensor embedding commutes
+    with the functional calculus, and substituting $c=d_R^{-1}$ gives the
+    second identity.
+\end{proof}
+
 \begin{definition}[Support Petz transpose map for a partial trace]
     \label{def:partial_trace_support_petz_map}
     \lean{Matrix.partialTraceRightPetzMap}
@@ -2372,6 +2399,71 @@ Theorem~\ref{thm:trace_norm_abs}.
           =\frac{d_C^2}{d_C^2}D(\rho\Vert\sigma)
           =D(\overline\rho\Vert\overline\sigma).
     \]
+\end{proof}
+
+\begin{lemma}[Maximally mixed support-sandwich normalization]
+    \label{lem:maximally_mixed_support_sandwich}
+    \lean{Matrix.PosSemidef.supportInvSqrt_kronecker_maximallyMixed_mul_mul}
+    \leanok
+    \uses{lem:support_inverse_square_root_maximally_mixed}
+    Let $\tau$ be positive semidefinite on $\mathcal H_S$, let $X$ be a
+    matrix on $\mathcal H_S$, and let
+    $\overline\tau=\tau\otimes d_C^{-1}\mathbf 1_C$.  Then
+    \[
+        \overline\tau^{-1/2}_{\mathrm{supp}}
+        \bigl(X\otimes d_C^{-1}\mathbf 1_C\bigr)
+        \overline\tau^{-1/2}_{\mathrm{supp}}
+        =\bigl(\tau^{-1/2}_{\mathrm{supp}}X
+          \tau^{-1/2}_{\mathrm{supp}}\bigr)\otimes\mathbf 1_C.
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    By the preceding support inverse formula, each outer factor contributes
+    $\sqrt{d_C}$.  These two factors cancel the coefficient $d_C^{-1}$ in
+    the middle tensor factor, leaving the asserted unital tensor embedding.
+\end{proof}
+
+\begin{theorem}[Identity Weyl sandwich implies raw Petz recovery]
+    \label{thm:weyl_identity_sandwich_petz_recovery}
+    \lean{Matrix.partialTraceRightPetzMap_eq_of_weyl_identity_sandwich}
+    \leanok
+    \uses{def:partial_trace_support_petz_map,
+        lem:partial_trace_support_petz_map_apply,
+        lem:maximally_mixed_support_sandwich}
+    Let $\rho$ and $\sigma$ be matrices on
+    $\mathcal H_S\otimes\mathbb C^{d_C}$, with $\sigma$ positive semidefinite,
+    and set
+    \[
+        \overline\sigma=(\tr_C\sigma)\otimes d_C^{-1}\mathbf 1_C.
+    \]
+    If the identity summand obeys the support sandwich identity
+    \[
+        \sqrt\sigma\,
+        \overline\sigma^{-1/2}_{\mathrm{supp}}
+        \bigl((\tr_C\rho)\otimes d_C^{-1}\mathbf 1_C\bigr)
+        \overline\sigma^{-1/2}_{\mathrm{supp}}\,
+        \sqrt\sigma=\rho,
+    \]
+    then the raw support Petz map recovers $\rho$:
+    \[
+        \mathcal R_\sigma(\tr_C\rho)=\rho.
+    \]
+    This is the algebraic reduction in
+    \cite[Theorem~3, equation~(8)]{Hayden2004Structure}.  It does not derive
+    the displayed sandwich identity from equality of relative entropies.
+\end{theorem}
+
+\begin{proof}\leanok
+    The preceding normalization rewrites the middle three factors as
+    \[
+        \bigl((\tr_C\sigma)^{-1/2}_{\mathrm{supp}}
+          (\tr_C\rho)
+          (\tr_C\sigma)^{-1/2}_{\mathrm{supp}}\bigr)
+          \otimes\mathbf 1_C.
+    \]
+    The support Petz formula therefore identifies the left-hand side of the
+    assumed sandwich identity with $\mathcal R_\sigma(\tr_C\rho)$.
 \end{proof}
 
 \begin{theorem}[Relative entropy against the product of the marginals]

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -278,6 +278,42 @@ value on the left.  The $d_R^2$ weights sum to one.
 This statement does not characterize equality in joint convexity and does not
 imply an operator intertwining or Petz recovery identity.
 
+There is nevertheless a useful algebraic reduction for the identity summand.
+Write
+\[
+  \overline X=(\operatorname{tr}_R X)\otimes d_R^{-1}\mathbf 1_R.
+\]
+For every positive semidefinite $\tau$ on the left factor,
+\begin{align}
+  (\tau\otimes d_R^{-1}\mathbf 1_R)^{-1/2}_{\mathrm{supp}}
+    &=\sqrt{d_R}\,
+      (\tau^{-1/2}_{\mathrm{supp}}\otimes\mathbf 1_R),\\
+  \overline\sigma^{-1/2}_{\mathrm{supp}}\,\overline\rho\,
+  \overline\sigma^{-1/2}_{\mathrm{supp}}
+    &=\bigl((\operatorname{tr}_R\sigma)^{-1/2}_{\mathrm{supp}}
+       (\operatorname{tr}_R\rho)
+       (\operatorname{tr}_R\sigma)^{-1/2}_{\mathrm{supp}}\bigr)
+       \otimes\mathbf 1_R.
+\end{align}
+The second identity follows because the two factors $\sqrt{d_R}$ cancel the
+coefficient $d_R^{-1}$ in $\overline\rho$.  Hence the operator identity
+\[
+  \sqrt\sigma\,\overline\sigma^{-1/2}_{\mathrm{supp}}\,
+  \overline\rho\,\overline\sigma^{-1/2}_{\mathrm{supp}}\,
+  \sqrt\sigma=\rho
+\]
+implies
+$\mathcal R_\sigma(\operatorname{tr}_R\rho)=\rho$ by the support Petz formula
+of \cite[Theorem~3, equation~(8)]{HaydenJozsaPetzWinter2004}.
+\footnote{Formal declarations:
+\leanid{Matrix.PosSemidef.supportInvSqrt_kronecker_maximallyMixed},
+\leanid{Matrix.PosSemidef.supportInvSqrt_kronecker_maximallyMixed_mul_mul}, and
+\leanid{Matrix.partialTraceRightPetzMap_eq_of_weyl_identity_sandwich} in
+\path{TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean}.}
+This implication is conditional on the displayed operator identity.  It does
+not infer that identity from the scalar equality in the finite Weyl Jensen
+step, and it makes no assertion for an arbitrary convex ensemble.
+
 The exact remaining analytic implication is the equality case of data
 processing on this support domain:
 \begin{align}


### PR DESCRIPTION
Closes LionSR/QICLean#236.

Advances LionSR/QICLean#233 and LionSR/TNLean#4228; it does not close either issue.

## Mathematical content

This pull request isolates the algebraic identity-summand step in the finite Weyl route to Petz recovery.

- It proves that the support inverse square root commutes with positive scaling and with tensoring by an identity matrix.
- It computes the support inverse square root of a maximally mixed extension and proves that the two dimension factors cancel in the middle Petz sandwich.
- It proves conditionally that the identity-summand support sandwich is exactly the raw partial-trace Petz recovery identity.

The public statements cite Hayden--Jozsa--Petz--Winter, Theorem 3, equation (8). The blueprint and the paper-gap note record the same scope.

## Deliberate boundary

This pull request does not derive the operator sandwich identity from equality of scalar relative entropies. That analytic equality condition remains open in LionSR/QICLean#233. In particular, no equality characterization for an arbitrary convex ensemble is asserted here.

## Verification

- `lake env lean TNLean/Channel/PetzRecovery.lean`
- `lake env lean TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean`
- `lake build TNLean.Channel.Schwarz.PetzEqualityPrerequisites`
- `lake build`
- `python3 scripts/blueprint_lean_sync.py --update-lean-decls --ci`
- `python3 scripts/blueprint_lean_sync.py --ci --warn-missing-blueprint --changed-files TNLean/Channel/PetzRecovery.lean TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean --diff-base origin/main`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check`

All five new declarations depend only on `propext`, `Classical.choice`, and `Quot.sound`. The changed Lean files contain no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely algebraic Lean proofs on existing Petz/support machinery plus documentation; no auth, runtime, or API surface changes.
> 
> **Overview**
> Adds **support inverse square root** identities used in the finite Weyl route to Petz recovery (Hayden–Jozsa–Petz–Winter, Thm. 3, eq. (8)): positive scaling (`supportInvSqrt_smul`), tensoring with identity (`supportInvSqrt_kronecker_one`), and the maximally mixed extension with dimension cancellation in the middle sandwich.
> 
> Proves **conditionally** that the identity Weyl summand’s support sandwich operator equality is equivalent to raw partial-trace Petz recovery (`partialTraceRightPetzMap_eq_of_weyl_identity_sandwich`). The PR does **not** derive that sandwich from scalar relative-entropy equality; that analytic step remains open.
> 
> Blueprint (`ch19_entropy`) and the SSA-equality paper-gap note are updated to match this scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e267a19f4194c85b02898573601424672c2f003f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->