### PR TITLE
feat(MPS/RFP): split distinct-sector parent ground spaces

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -623,6 +623,7 @@ import TNLean.MPS.RFP.Decorrelation
 import TNLean.MPS.RFP.BNTOrthogonality
 import TNLean.MPS.RFP.ResidualIsometry
 import TNLean.MPS.RFP.ResidualWordSpan
+import TNLean.MPS.RFP.NNCPHMultiSector
 import TNLean.MPS.RFP.PhaseMultiplicityCounterexample
 import TNLean.MPS.RFP.BNTWeightCounterexample
 

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -622,6 +622,7 @@ import TNLean.MPS.RFP.Assembly
 import TNLean.MPS.RFP.Decorrelation
 import TNLean.MPS.RFP.BNTOrthogonality
 import TNLean.MPS.RFP.ResidualIsometry
+import TNLean.MPS.RFP.ResidualWordSpan
 import TNLean.MPS.RFP.PhaseMultiplicityCounterexample
 import TNLean.MPS.RFP.BNTWeightCounterexample
 

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalBoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalBoundaryClosing.lean
@@ -29,8 +29,9 @@ variable {d : ℕ}
 
 /-- A length at which a tensor is block injective identifies the two boundary
 matrices in a word intertwiner and promotes the relation to one-site
-commutation. -/
-private theorem boundary_eq_and_commutes_of_isNBlkInjective_of_intertwines
+commutation. This is the boundary-identification step in
+arXiv:quant-ph/0608197, Theorem 12, proof lines 1454--1456. -/
+theorem boundary_eq_and_commutes_of_isNBlkInjective_of_intertwines
     {D S : ℕ} {A : MPSTensor d D}
     (hBlk : IsNBlkInjective A S) (hS : 0 < S)
     (X Y : Matrix (Fin D) (Fin D) ℂ)
@@ -139,8 +140,9 @@ theorem block_boundary_intertwines_of_cyclicTranslate_sum_groundSpaceMap_eq
       exact Matrix.trace_mul_comm _ _
 
 /-- Length-indexed form of the global-cut comparison, with the chain length
-kept as a separate variable. -/
-private theorem block_boundary_intertwines_of_cyclicTranslate_sum_groundSpaceMap_eq_of_add_eq
+kept as a separate variable. This is the change-of-cut comparison in
+arXiv:quant-ph/0608197, Theorem 12, proof lines 1454--1456. -/
+theorem block_boundary_intertwines_of_cyclicTranslate_sum_groundSpaceMap_eq_of_add_eq
     {r : ℕ} {dim : Fin r → ℕ}
     (A : (j : Fin r) → MPSTensor d (dim j))
     {N K S : ℕ} (hKS : K + S = N) (hS : 0 < S)

--- a/TNLean/MPS/RFP/NNCPHMultiSector.lean
+++ b/TNLean/MPS/RFP/NNCPHMultiSector.lean
@@ -1,0 +1,406 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalBoundaryClosing
+import TNLean.MPS.ParentHamiltonian.GroundSpaceSpanning
+import TNLean.MPS.RFP.ResidualWordSpan
+
+/-!
+# Nearest-neighbor ground spaces for multiplicity-one RFP sectors
+
+This file proves the periodic-chain splitting and parent-Hamiltonian
+ground-space spanning statements for a multiplicity-one family of distinct
+normal sectors whose direct sum is a renormalization fixed point.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d r : ℕ} {dim : Fin r → ℕ}
+
+/-- A full simultaneous one-site span propagates to every positive word
+length by concatenation. -/
+theorem WordTupleSpanTop.of_one_of_pos
+    {A : (j : Fin r) → MPSTensor d (dim j)}
+    (hOne : WordTupleSpanTop A 1) {n : ℕ} (hn : 0 < n) :
+    WordTupleSpanTop A n := by
+  have h := wordTupleSpanTop_add_mul_of_wordTupleSpanTop A hOne hOne (n - 1)
+  convert h using 1
+  all_goals omega
+
+/-- A full simultaneous one-site span gives a common linear expression for
+the identity matrix in every block. -/
+theorem WordTupleSpanTop.exists_one_letter_identity_coefficients
+    {A : (j : Fin r) → MPSTensor d (dim j)}
+    (hOne : WordTupleSpanTop A 1) :
+    ∃ c : (Fin 1 → Fin d) → ℂ, ∀ j : Fin r,
+      ∑ w, c w • A j (w 0) = 1 := by
+  classical
+  let I : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ := fun _ ↦ 1
+  have hI : I ∈ Submodule.span ℂ (Set.range (wordTuple A 1)) := by
+    rw [hOne]
+    exact Submodule.mem_top
+  obtain ⟨c, hc⟩ := (Submodule.mem_span_range_iff_exists_fun ℂ).mp hI
+  refine ⟨c, ?_⟩
+  intro j
+  have hj := congrArg (fun M ↦ M j) hc
+  simpa [I, wordTuple, Fintype.linearCombination_apply, List.ofFn_succ] using hj
+
+/-- A common one-letter expression for the block identities replaces the
+right-canonical normalization in the restriction argument of
+arXiv:quant-ph/0608197, Theorem 12, proof lines 1442--1452. -/
+theorem pgvwc07_mem_iSup_groundSpace_of_trace_decomposition_of_identity_coefficients
+    (A : (j : Fin r) → MPSTensor d (dim j))
+    {n : ℕ} (hSpan : WordTupleSpanTop A n)
+    (c : (Fin 1 → Fin d) → ℂ)
+    (hId : ∀ j : Fin r, ∑ w, c w • A j (w 0) = 1)
+    (C Dmat : (j : Fin r) → Fin d → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (hCoeff : ∀ a b : Fin d, ∀ w : Fin n → Fin d,
+      (∑ j : Fin r,
+        Matrix.trace ((A j b * C j a) * evalWord (A j) (List.ofFn w))) =
+      (∑ j : Fin r,
+        Matrix.trace ((Dmat j b * A j a) * evalWord (A j) (List.ofFn w))))
+    (ψ : NSiteSpace d (n + 2))
+    (hψ : ψ = ∑ j : Fin r, pgvwc07LeftBoundaryComponent (A j) (C j) n) :
+    ψ ∈ ⨆ j : Fin r, groundSpace (A j) (n + 2) := by
+  classical
+  rw [hψ]
+  let E : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ :=
+    fun j ↦ ∑ w, c w • C j (w 0)
+  have hCompat : ∀ j : Fin r, ∀ a b : Fin d,
+      A j b * C j a = Dmat j b * A j a :=
+    pgvwc07_blockwise_compatibility_of_trace_decomposition A hSpan C Dmat hCoeff
+  have hDE : ∀ j : Fin r, ∀ b : Fin d, A j b * E j = Dmat j b := by
+    intro j b
+    calc
+      A j b * E j = ∑ w, c w • (A j b * C j (w 0)) := by
+        simp [E, Matrix.mul_sum]
+      _ = ∑ w, c w • (Dmat j b * A j (w 0)) := by
+        apply Finset.sum_congr rfl
+        intro w _
+        rw [hCompat j (w 0) b]
+      _ = Dmat j b * (∑ w, c w • A j (w 0)) := by
+        simp [Matrix.mul_sum]
+      _ = Dmat j b := by rw [hId j, Matrix.mul_one]
+  have hACE : ∀ j : Fin r, ∀ a b : Fin d,
+      A j b * C j a = A j b * E j * A j a := by
+    intro j a b
+    rw [hCompat j a b, hDE j b]
+  exact pgvwc07_sum_leftBoundaryComponents_mem_iSup_groundSpace A C E n hACE
+
+/-- The two one-boundary restrictions imply membership in the next block
+ground-space sum when the identity tuple has a common one-letter expansion.
+This is arXiv:quant-ph/0608197, Theorem 12, proof lines 1442--1452. -/
+theorem pgvwc07_mem_iSup_groundSpace_of_iSup_restrictions_of_identity_coefficients
+    (A : (j : Fin r) → MPSTensor d (dim j))
+    {n : ℕ} (hSpan : WordTupleSpanTop A n)
+    (c : (Fin 1 → Fin d) → ℂ)
+    (hId : ∀ j : Fin r, ∑ w, c w • A j (w 0) = 1)
+    (ψ : NSiteSpace d (n + 2))
+    (hLeft : ∀ b : Fin d,
+      restrictLast ψ b ∈ ⨆ j : Fin r, groundSpace (A j) (n + 1))
+    (hRight : ∀ a : Fin d,
+      restrictFirst ψ a ∈ ⨆ j : Fin r, groundSpace (A j) (n + 1)) :
+    ψ ∈ ⨆ j : Fin r, groundSpace (A j) (n + 2) := by
+  rcases pgvwc07_trace_decompositions_of_iSup_restrictions A ψ hLeft hRight with
+    ⟨C, Dmat, hψ, hCoeff⟩
+  exact pgvwc07_mem_iSup_groundSpace_of_trace_decomposition_of_identity_coefficients
+    A hSpan c hId C Dmat hCoeff ψ hψ
+
+/-- The PGVWC one-step restriction intersection needs only a common
+one-letter expansion of the block identities, rather than right-canonical
+normalization. This is the local intersection step in
+arXiv:quant-ph/0608197, Theorem 12, proof lines 1442--1452. -/
+theorem pgvwc07_iSup_groundSpace_eq_restriction_intersection_of_identity_coefficients
+    (A : (j : Fin r) → MPSTensor d (dim j))
+    {n : ℕ} (hSpan : WordTupleSpanTop A n)
+    (c : (Fin 1 → Fin d) → ℂ)
+    (hId : ∀ j : Fin r, ∑ w, c w • A j (w 0) = 1) :
+    ((⨅ b : Fin d,
+        (⨆ j : Fin r, groundSpace (A j) (n + 1)).comap (restrictLastₗ b)) ⊓
+      (⨅ a : Fin d,
+        (⨆ j : Fin r, groundSpace (A j) (n + 1)).comap (restrictFirstₗ a))) =
+      ⨆ j : Fin r, groundSpace (A j) (n + 2) := by
+  classical
+  ext ψ
+  simp only [Submodule.mem_inf, Submodule.mem_iInf, Submodule.mem_comap]
+  constructor
+  · intro hRestrict
+    exact
+      pgvwc07_mem_iSup_groundSpace_of_iSup_restrictions_of_identity_coefficients
+        A hSpan c hId ψ
+          (by simpa [restrictLast] using hRestrict.1)
+          (by simpa [restrictFirst] using hRestrict.2)
+  · intro hψ
+    constructor
+    · intro b
+      refine Submodule.iSup_induction
+        (p := fun j : Fin r ↦ groundSpace (A j) (n + 2))
+        (motive := fun φ ↦ restrictLast φ b ∈
+          ⨆ j : Fin r, groundSpace (A j) (n + 1))
+        (x := ψ) hψ ?_ ?_ ?_
+      · intro j φ hφ
+        exact Submodule.mem_iSup_of_mem j
+          (groundSpace_inLeftGround (A j) (n + 1) hφ b)
+      · exact Submodule.zero_mem _
+      · intro φ ξ hφ hξ
+        exact Submodule.add_mem _ hφ hξ
+    · intro a
+      refine Submodule.iSup_induction
+        (p := fun j : Fin r ↦ groundSpace (A j) (n + 2))
+        (motive := fun φ ↦ restrictFirst φ a ∈
+          ⨆ j : Fin r, groundSpace (A j) (n + 1))
+        (x := ψ) hψ ?_ ?_ ?_
+      · intro j φ hφ
+        exact Submodule.mem_iSup_of_mem j
+          (groundSpace_inRightGround (A j) (n + 1) hφ a)
+      · exact Submodule.zero_mem _
+      · intro φ ξ hφ hξ
+        exact Submodule.add_mem _ hφ hξ
+
+/-- A simultaneous one-site span propagates nearest-neighbor periodic
+constraints into the sum of the open-boundary block spaces. This is the
+restriction-intersection propagation in arXiv:quant-ph/0608197, Theorem 12,
+proof lines 1430--1452. -/
+theorem chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_wordTupleSpanTop_one
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    (hμ : ∀ j : Fin r, μ j ≠ 0)
+    (hOne : WordTupleSpanTop A 1) [NeZero d]
+    {N : ℕ} (hN : 2 < N) :
+    chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) 2 N ≤
+      ⨆ j : Fin r, groundSpace (A j) N := by
+  classical
+  obtain ⟨c, hId⟩ := hOne.exists_one_letter_identity_coefficients
+  apply chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace
+    μ A hμ (by omega) (by omega) (by omega)
+  intro M hM
+  obtain ⟨q, hq⟩ := Nat.exists_eq_add_of_le hM
+  have hMq : M = q + 2 := by omega
+  clear hq
+  subst M
+  have hSpan : WordTupleSpanTop A (q + 1) :=
+    hOne.of_one_of_pos (by omega)
+  have hstep :=
+    pgvwc07_iSup_groundSpace_eq_restriction_intersection_of_identity_coefficients
+      A hSpan c hId
+  simpa [Nat.add_assoc] using hstep
+
+/-- A nearest-neighbor chain vector has block-diagonal open-boundary matrices
+when the simultaneous one-site word tuples span the product algebra. This is
+the block-boundary decomposition in arXiv:quant-ph/0608197, Theorem 12, proof
+lines 1430--1452. -/
+theorem exists_blockDiagonal_boundary_of_chainGroundSpace_of_wordTupleSpanTop_one
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    (hμ : ∀ j : Fin r, μ j ≠ 0)
+    (hOne : WordTupleSpanTop A 1) [NeZero d]
+    {N : ℕ} (hN : 2 < N) {ψ : NSiteSpace d N}
+    (hψ : ψ ∈ chainGroundSpace
+      (toTensorFromBlocks (d := d) (μ := μ) A) 2 N) :
+    ∃ X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+      ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+        ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv)
+          (Matrix.blockDiagonal' X)) := by
+  classical
+  have hOpen : ψ ∈ ⨆ j : Fin r, groundSpace (A j) N :=
+    chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_wordTupleSpanTop_one
+      μ A hμ hOne hN hψ
+  obtain ⟨φ, hφ, hφsum⟩ :=
+    (Submodule.mem_iSup_iff_exists_finsupp
+      (fun j : Fin r ↦ groundSpace (A j) N) ψ).mp hOpen
+  have hψφ : ψ = ∑ j : Fin r, φ j := by
+    simpa [Finsupp.sum_fintype] using hφsum.symm
+  have hφRange : ∀ j : Fin r, φ j ∈ (groundSpaceMap (A j) N).range := by
+    intro j
+    simpa [groundSpace] using hφ j
+  choose Y hY using hφRange
+  let X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ :=
+    fun j ↦ ((μ j) ^ N)⁻¹ • Y j
+  refine ⟨X, ?_⟩
+  rw [BlockSumGroundSpace.groundSpaceMap_toTensorFromBlocks_eq_sum_blockDiagonal]
+  calc
+    ψ = ∑ j : Fin r, φ j := hψφ
+    _ = ∑ j : Fin r, groundSpaceMap (A j) N ((μ j) ^ N • X j) := by
+      apply Finset.sum_congr rfl
+      intro j _
+      have hpow : (μ j) ^ N ≠ 0 := pow_ne_zero N (hμ j)
+      simp [X, hY j, hpow]
+
+/-- A global one-site change of cut closes the block-diagonal boundary
+matrices of a nearest-neighbor chain vector. This is the boundary-closing step
+in arXiv:quant-ph/0608197, Theorem 12, proof lines 1454--1456. -/
+theorem exists_blockDiagonal_boundary_chainGroundSpace_of_wordTupleSpanTop_one
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    (hμ : ∀ j : Fin r, μ j ≠ 0)
+    (hOne : WordTupleSpanTop A 1) [NeZero d]
+    {N : ℕ} (hN : 2 < N) {ψ : NSiteSpace d N}
+    (hψ : ψ ∈ chainGroundSpace
+      (toTensorFromBlocks (d := d) (μ := μ) A) 2 N) :
+    ∃ X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+      ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+        ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv)
+          (Matrix.blockDiagonal' X)) ∧
+      ∀ j : Fin r,
+        groundSpaceMap (A j) N ((μ j) ^ N • X j) ∈
+          chainGroundSpace (A j) 2 N := by
+  classical
+  obtain ⟨X, hψX⟩ :=
+    exists_blockDiagonal_boundary_of_chainGroundSpace_of_wordTupleSpanTop_one
+      μ A hμ hOne hN hψ
+  let s : Fin N := ⟨N - 1, by omega⟩
+  have hTranslate :
+      cyclicTranslateState s ψ ∈
+        chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) 2 N :=
+    cyclicTranslateState_mem_chainGroundSpace
+      (toTensorFromBlocks (d := d) (μ := μ) A) (by omega) (by omega) s hψ
+  obtain ⟨Y, hψY⟩ :=
+    exists_blockDiagonal_boundary_of_chainGroundSpace_of_wordTupleSpanTop_one
+      μ A hμ hOne hN hTranslate
+  have hXsum :
+      ψ = ∑ j : Fin r, groundSpaceMap (A j) N ((μ j) ^ N • X j) := by
+    calc
+      ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+          ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv)
+            (Matrix.blockDiagonal' X)) := hψX
+      _ = ∑ j : Fin r, groundSpaceMap (A j) N ((μ j) ^ N • X j) := by
+        rw [BlockSumGroundSpace.groundSpaceMap_toTensorFromBlocks_eq_sum_blockDiagonal]
+  have hYsum :
+      cyclicTranslateState s ψ =
+        ∑ j : Fin r, groundSpaceMap (A j) N ((μ j) ^ N • Y j) := by
+    calc
+      cyclicTranslateState s ψ =
+          groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+            ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv)
+              (Matrix.blockDiagonal' Y)) := hψY
+      _ = ∑ j : Fin r, groundSpaceMap (A j) N ((μ j) ^ N • Y j) := by
+        rw [BlockSumGroundSpace.groundSpaceMap_toTensorFromBlocks_eq_sum_blockDiagonal]
+  have hSplit : N - 1 + 1 = N := by omega
+  have hSumTranslate :
+      cyclicTranslateState s
+          (∑ j : Fin r, groundSpaceMap (A j) N ((μ j) ^ N • X j)) =
+        ∑ j : Fin r, groundSpaceMap (A j) N ((μ j) ^ N • Y j) := by
+    rw [← hXsum]
+    exact hYsum
+  have hLongSpan : WordTupleSpanTop A (N - 1) :=
+    hOne.of_one_of_pos (by omega)
+  have hIntertwine :
+      ∀ (α : Fin 1 → Fin d) (j : Fin r),
+        ((μ j) ^ N • X j) * evalWord (A j) (List.ofFn α) =
+          evalWord (A j) (List.ofFn α) * ((μ j) ^ N • Y j) := by
+    apply block_boundary_intertwines_of_cyclicTranslate_sum_groundSpaceMap_eq_of_add_eq
+      A hSplit (by omega) hLongSpan
+        (fun j ↦ (μ j) ^ N • X j) (fun j ↦ (μ j) ^ N • Y j)
+    simpa only [s] using hSumTranslate
+  have hBlk : ∀ j : Fin r, IsNBlkInjective (A j) 1 := fun j ↦
+    isNBlkInjective_one_of_isInjective (hOne.isInjective_one j)
+  have hComm : ∀ j : Fin r, ∀ a : Fin d,
+      ((μ j) ^ N • X j) * A j a = A j a * ((μ j) ^ N • X j) := by
+    intro j
+    exact (boundary_eq_and_commutes_of_isNBlkInjective_of_intertwines
+      (hBlk j) (by omega) ((μ j) ^ N • X j) ((μ j) ^ N • Y j)
+      (fun α ↦ hIntertwine α j)).2
+  have hCommWord : ∀ j : Fin r, ∀ w : List (Fin d),
+      ((μ j) ^ N • X j) * evalWord (A j) w =
+        evalWord (A j) w * ((μ j) ^ N • X j) := by
+    intro j w
+    induction w with
+    | nil => simp [evalWord_nil]
+    | cons a w ih =>
+        rw [evalWord_cons, ← Matrix.mul_assoc, hComm j a, Matrix.mul_assoc, ih,
+          ← Matrix.mul_assoc]
+  refine ⟨X, hψX, ?_⟩
+  apply blockDiagonal_boundary_component_chainGroundSpace_of_boundary_identities
+    μ A (by omega) (by omega) X
+  intro j i _τ _hi
+  refine ⟨(μ j) ^ N • X j, ?_⟩
+  intro β
+  exact hCommWord j (List.ofFn β)
+
+/-- A simultaneous one-site product span splits the nearest-neighbor periodic
+chain space into the periodic chain spaces of the blocks. This is the
+multiplicity-one distinct-block specialization of arXiv:quant-ph/0608197,
+Theorem 12, proof lines 1430--1456. -/
+theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_of_wordTupleSpanTop_one
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    (hμ : ∀ j : Fin r, μ j ≠ 0)
+    (hOne : WordTupleSpanTop A 1) [NeZero d]
+    {N : ℕ} (hN : 2 < N) :
+    chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) 2 N =
+      ⨆ j : Fin r, chainGroundSpace (A j) 2 N := by
+  have hClose :
+      chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) 2 N ≤
+        ⨆ j : Fin r, chainGroundSpace (A j) 2 N :=
+    chainGroundSpace_toTensorFromBlocks_le_iSup_of_blockDiagonal_boundary_groundSpaceMap
+      μ A (fun ψ hψ ↦
+        exists_blockDiagonal_boundary_chainGroundSpace_of_wordTupleSpanTop_one
+          μ A hμ hOne hN hψ)
+  exact chainGroundSpace_toTensorFromBlocks_eq_iSup_chainGroundSpace_of_boundary_closing
+    μ A hμ (by omega) (by omega) hClose
+
+/-- The unit-weight block tensor is the direct-sum tensor. -/
+theorem toTensorFromBlocks_one_eq_directSumTensor
+    (A : (j : Fin r) → MPSTensor d (dim j)) :
+    toTensorFromBlocks (d := d) (fun _ ↦ 1) A = directSumTensor A := by
+  funext i
+  simp [toTensorFromBlocks, directSumTensor]
+
+namespace IsBNTCanonicalForm
+
+variable {P : SectorDecomposition d}
+
+/-- A multiplicity-one BNT family whose direct sum is a renormalization fixed
+point has its nearest-neighbor parent-Hamiltonian ground space spanned by the
+periodic matrix product vectors of its distinct basis sectors.
+
+Source: arXiv:1606.00608, Definition 3.9, lines 517--524, and Theorem 3.10,
+lines 534--541.
+
+**Scope restriction (multiplicity-one distinct sectors):** the theorem treats
+the direct sum of the BNT basis tensors, with one copy of each distinct sector.
+Repeated copies and arbitrary raw sector weights remain outside this statement;
+see docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex. -/
+theorem rfp_hasParentHamiltonianGroundSpaceSpanning_basisDirectSum
+    (hCF : IsBNTCanonicalForm P)
+    (hRFP : IsTransferIdempotent (directSumTensor P.basis)) :
+    HasParentHamiltonianGroundSpaceSpanning
+      (directSumTensor P.basis) 2 P.basis := by
+  by_cases hd : d = 0
+  · subst d
+    intro N hN
+    ext ψ
+    have hψ : ψ = 0 := by
+      funext σ
+      exact Fin.elim0 (σ ⟨0, by omega⟩)
+    subst ψ
+    simp
+  · letI : NeZero d := ⟨hd⟩
+    letI : ∀ j : Fin P.basisCount, NeZero (P.basisDim j) :=
+      fun j ↦ ⟨(hCF.basis_dim_pos j).ne'⟩
+    have hnormal : ∀ j : Fin P.basisCount, IsNormal (P.basis j) := by
+      intro j
+      exact isNormal_of_irreducible_leftCanonical_selfOverlap_tendsto_one
+        (P.basis j) (hCF.basis_irreducible j) (hCF.basis_left_canonical j)
+          (hCF.basis_normalized_self_overlap j)
+    have hOne : WordTupleSpanTop P.basis 1 :=
+      wordTupleSpanTop_one_of_isTransferIdempotent_directSum P.basis
+        hnormal hCF.basis_irreducible hCF.basis_left_canonical
+          hCF.basis_distinct hRFP
+    rw [← toTensorFromBlocks_one_eq_directSumTensor P.basis]
+    apply hasParentHamiltonianGroundSpaceSpanning_toTensorFromBlocks_of_chain_eq_iSup_chain
+      (fun _ ↦ 1) P.basis (by simp)
+    · intro N hN
+      exact chainGroundSpace_toTensorFromBlocks_eq_iSup_of_wordTupleSpanTop_one
+        (fun _ ↦ 1) P.basis (by simp) hOne hN
+    · intro N hN j
+      have hBlockRFP : IsTransferIdempotent (P.basis j) :=
+        isTransferIdempotent_block_of_isTransferIdempotent_directSum
+          P.basis hRFP j
+      have hInj : IsInjective (P.basis j) :=
+        rfp_nt_structural (P.basis j) (hnormal j) hBlockRFP
+      exact chainGroundSpace_eq_mpvSubmodule hInj (by omega) (by omega) (by omega)
+
+end IsBNTCanonicalForm
+
+end MPSTensor

--- a/TNLean/MPS/RFP/ResidualWordSpan.lean
+++ b/TNLean/MPS/RFP/ResidualWordSpan.lean
@@ -1,0 +1,145 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.BiCFDerivation.Selectors
+import TNLean.MPS.RFP.ResidualIsometry
+
+/-!
+# One-site spans from residual isometries
+
+This file connects the residual-isometry equations for a finite family of
+matrix product tensors to the simultaneous one-site matrix span of that family.
+
+The residual equations are the statement that the scalar one-site entry
+vectors, indexed by the block label and the two virtual indices, have identity
+Gram matrix. Consequently these vectors are linearly independent, and the
+one-site word tuples span the product of the block matrix algebras.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d r : ℕ} {dim : Fin r → ℕ}
+
+private theorem IsResidualIsometryFamily.wordEntryFamily_one_gram
+    {U : (j : Fin r) → MPSTensor d (dim j)}
+    (hU : IsResidualIsometryFamily U) (x y : BlockEntryIndex dim) :
+    ∑ w : Fin 1 → Fin d,
+      wordEntryFamily U 1 x w * star (wordEntryFamily U 1 y w) =
+        if x = y then 1 else 0 := by
+  classical
+  rcases x with ⟨j, α, β⟩
+  rcases y with ⟨j', α', β'⟩
+  rw [← Equiv.sum_comp (Equiv.funUnique (Fin 1) (Fin d)).symm
+    (fun w : Fin 1 → Fin d ↦
+      wordEntryFamily U 1 ⟨j, (α, β)⟩ w *
+        star (wordEntryFamily U 1 ⟨j', (α', β')⟩ w))]
+  simp only [wordEntryFamily, blockEntryValue, wordTuple,
+    Equiv.funUnique_symm_apply, List.ofFn_succ, List.ofFn_zero,
+    evalWord_cons, evalWord_nil, mul_one, uniqueElim_const]
+  by_cases hj : j = j'
+  · subst j'
+    rw [hU.1]
+    simp
+  · rw [hU.2 j j' hj α β α' β']
+    simp [hj]
+
+/-- The one-site scalar entry vectors of a residual-isometry family are
+linearly independent. Their Gram matrix is the identity by the residual
+equations in arXiv:1606.00608, eq:III_isometry (line 551). -/
+theorem IsResidualIsometryFamily.wordEntryFamily_linearIndependent
+    {U : (j : Fin r) → MPSTensor d (dim j)}
+    (hU : IsResidualIsometryFamily U) :
+    LinearIndependent ℂ (wordEntryFamily U 1) := by
+  classical
+  rw [Fintype.linearIndependent_iff]
+  intro c hc x
+  have hcoeff (w : Fin 1 → Fin d) :
+      ∑ y : BlockEntryIndex dim, c y * wordEntryFamily U 1 y w = 0 := by
+    simpa [Finset.sum_apply, Pi.smul_apply] using congrFun hc w
+  calc
+    c x = ∑ y : BlockEntryIndex dim, c y * (if y = x then 1 else 0) := by
+      simp
+    _ = ∑ y : BlockEntryIndex dim, c y *
+        (∑ w : Fin 1 → Fin d,
+          wordEntryFamily U 1 y w * star (wordEntryFamily U 1 x w)) := by
+      apply Finset.sum_congr rfl
+      intro y _
+      rw [hU.wordEntryFamily_one_gram y x]
+    _ = 0 := by
+      simp_rw [Finset.mul_sum]
+      rw [Finset.sum_comm]
+      apply Finset.sum_eq_zero
+      intro w _
+      simp_rw [← mul_assoc]
+      rw [← Finset.sum_mul, hcoeff w, zero_mul]
+
+/-- A residual-isometry family spans the product of its block matrix algebras
+with one-site word tuples. This is the simultaneous one-site span consequence
+of arXiv:1606.00608, eq:III_isometry (line 551). -/
+theorem IsResidualIsometryFamily.wordTupleSpanTop_one
+    {U : (j : Fin r) → MPSTensor d (dim j)}
+    (hU : IsResidualIsometryFamily U) :
+    WordTupleSpanTop U 1 :=
+  wordTupleSpanTop_of_wordEntryFamily_linearIndependent U
+    hU.wordEntryFamily_linearIndependent
+
+/-- Simultaneous one-site word spanning is preserved by invertible left and
+right multiplication in each block. -/
+theorem wordTupleSpanTop_one_of_blockwise_mul
+    (A B : (j : Fin r) → MPSTensor d (dim j))
+    (L R : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (hL : ∀ j, (L j).det ≠ 0) (hR : ∀ j, (R j).det ≠ 0)
+    (hB : ∀ j i, B j i = L j * A j i * R j)
+    (hSpan : WordTupleSpanTop A 1) :
+    WordTupleSpanTop B 1 := by
+  classical
+  unfold WordTupleSpanTop at hSpan ⊢
+  apply top_unique
+  intro M _
+  let N : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ :=
+    fun j ↦ (L j)⁻¹ * M j * (R j)⁻¹
+  have hN : N ∈ Submodule.span ℂ (Set.range (wordTuple A 1)) := by
+    rw [hSpan]
+    exact Submodule.mem_top
+  have hTN : (fun j ↦ L j * N j * R j) ∈
+      Submodule.span ℂ (Set.range (wordTuple B 1)) := by
+    refine Submodule.span_induction
+      (p := fun Z _ ↦ (fun j ↦ L j * Z j * R j) ∈
+        Submodule.span ℂ (Set.range (wordTuple B 1))) ?_ ?_ ?_ ?_ hN
+    · rintro Z ⟨w, rfl⟩
+      apply Submodule.subset_span
+      refine ⟨w, ?_⟩
+      funext j
+      simp [wordTuple, hB]
+    · convert
+        (Submodule.zero_mem (Submodule.span ℂ (Set.range (wordTuple B 1)))) using 1
+      funext j
+      simp
+    · intro X Y _ _ hX hY
+      convert
+        Submodule.add_mem (Submodule.span ℂ (Set.range (wordTuple B 1))) hX hY using 1
+      funext j
+      simp [mul_add, add_mul]
+    · intro a X _ hX
+      convert
+        Submodule.smul_mem (Submodule.span ℂ (Set.range (wordTuple B 1))) a hX using 1
+      funext j
+      simp
+  convert hTN using 1
+  funext j
+  simp only [N]
+  symm
+  calc
+    L j * ((L j)⁻¹ * M j * (R j)⁻¹) * R j =
+        (L j * (L j)⁻¹) * M j * ((R j)⁻¹ * R j) := by
+      noncomm_ring
+    _ = M j := by
+      rw [Matrix.mul_nonsing_inv (L j) (Ne.isUnit (hL j)),
+        Matrix.nonsing_inv_mul (R j) (Ne.isUnit (hR j))]
+      simp
+
+end MPSTensor

--- a/TNLean/MPS/RFP/ResidualWordSpan.lean
+++ b/TNLean/MPS/RFP/ResidualWordSpan.lean
@@ -142,4 +142,49 @@ theorem wordTupleSpanTop_one_of_blockwise_mul
         Matrix.nonsing_inv_mul (R j) (Ne.isUnit (hR j))]
       simp
 
+/-- Under the whole-direct-sum renormalization-fixed-point hypotheses, the
+one-site word tuples of the normal-tensor blocks span the product of their
+matrix algebras. This is the span consequence of the residual isometry
+condition in arXiv:1606.00608, eq:III_isometry (line 551) and Corollary
+III.cor3 (line 584).
+
+**Scope restriction (whole-tensor canonical form):** the hypotheses expose
+normality, irreducibility, left canonical form, and gauge-phase distinctness
+block by block. The passage from the paper's single canonical-form predicate
+to these hypotheses is recorded in
+docs/paper-gaps/cpsv16_rfp_isometry_scope.tex. -/
+theorem wordTupleSpanTop_one_of_isTransferIdempotent_directSum
+    [∀ k, NeZero (dim k)]
+    (B : (k : Fin r) → MPSTensor d (dim k))
+    (hnormal : ∀ k, IsNormal (B k))
+    (hirr : ∀ k, IsIrreducibleTensor (B k))
+    (hleft : ∀ k, ∑ i : Fin d, (B k i)ᴴ * B k i = 1)
+    (hdist : ∀ j k : Fin r, j ≠ k → ∀ h : dim j = dim k,
+      ¬ GaugePhaseEquiv (cast (congrArg (MPSTensor d) h) (B j)) (B k))
+    (hRFP : IsTransferIdempotent (directSumTensor B)) :
+    WordTupleSpanTop B 1 := by
+  classical
+  obtain ⟨X, Λ, U, hXdet, hΛpos, _, hdecomp, hU⟩ :=
+    exists_residualIsometryFamily_of_isTransferIdempotent_directSum B
+      hnormal hirr hleft hdist hRFP
+  let D : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ :=
+    fun j ↦ Matrix.diagonal (fun k ↦ (Real.sqrt (Λ j k) : ℂ))
+  have hDdet : ∀ j, (D j).det ≠ 0 := by
+    intro j
+    rw [show D j = Matrix.diagonal
+      (fun k ↦ (Real.sqrt (Λ j k) : ℂ)) from rfl,
+      Matrix.det_diagonal, Finset.prod_ne_zero_iff]
+    intro k _
+    exact Complex.ofReal_ne_zero.mpr (Real.sqrt_pos.mpr (hΛpos j k)).ne'
+  apply wordTupleSpanTop_one_of_blockwise_mul U B
+    (fun j ↦ X j * D j) (fun j ↦ (X j)⁻¹)
+  · intro j
+    rw [Matrix.det_mul]
+    exact mul_ne_zero (hXdet j) (hDdet j)
+  · intro j
+    exact (Matrix.isUnit_nonsing_inv_det (X j) (Ne.isUnit (hXdet j))).ne_zero
+  · intro j i
+    simpa only [D, Matrix.mul_assoc] using hdecomp j i
+  · exact hU.wordTupleSpanTop_one
+
 end MPSTensor

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -1103,6 +1103,47 @@ specialization of that Appendix~D definition.
     two.
 \end{proof}
 
+\begin{theorem}[Nearest-neighbor parent ground spaces for distinct multiplicity-one RFP sectors]%
+    \label{thm:rfp_multiplicity_one_bnt_parent_ground_spaces}
+    \lean{MPSTensor.IsBNTCanonicalForm.rfp_hasParentHamiltonianGroundSpaceSpanning_basisDirectSum}
+    \leanok
+    \uses{def:sector_bnt_cf, def:mps_transfer_idempotence,
+        def:parent_hamiltonian_ground_space_spanning}
+    Let $A_1,\ldots,A_g$ be the distinct basis tensors of a BNT canonical
+    form, and let $B=\bigoplus_{j=1}^g A_j$ contain one copy of every basis
+    tensor. If $B$ is a renormalization fixed point, then for every $N>2$,
+    \[
+        \ker H_2^{(N)}(B)
+        =\spn\bigl\{V^{(N)}(A_j):j=1,\ldots,g\bigr\}.
+    \]
+    This is the multiplicity-one distinct-sector case of
+    \cite[Theorem~3.10]{Cirac2016MPDO_arXiv}. It does not include repeated
+    copies of a basis tensor or arbitrary raw sector weights.
+\end{theorem}
+
+\begin{proof}\leanok
+    The residual isometry equations imply that the simultaneous one-site
+    matrices $(A_j^i)_j$ span the product of the block matrix algebras. Hence
+    the same is true for every positive word length. The one-step restriction
+    intersection therefore gives
+    \[
+        \mathcal G_{N,2}(B)
+        \subseteq \bigvee_j G_N(A_j).
+    \]
+    Comparing this block decomposition before and after moving the periodic
+    cut by one site shows that every block boundary matrix commutes with the
+    corresponding one-site matrices. Thus each block component lies in
+    $\mathcal G_{N,2}(A_j)$, and
+    \[
+        \mathcal G_{N,2}(B)
+        =\bigvee_j\mathcal G_{N,2}(A_j).
+    \]
+    Each block is a normal renormalization fixed point, so one-site
+    injectivity and the injective periodic-chain theorem identify its chain
+    space with the line spanned by $V^{(N)}(A_j)$. The finite-volume kernel
+    identity completes the proof.
+\end{proof}
+
 \begin{theorem}[Cyclic trace expansion for a closed MPS chain]\label{thm:trace_eval_word_eq_sum_cyclic}
     \lean{MPSTensor.trace_evalWord_eq_sum_cyclic}
     \leanok

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -105,14 +105,17 @@ now reduces the source spanning equation to exactly the reverse containment,
 using this easy inclusion.  Its nearest-neighbor specialization,
 \leanid{MPSTensor.hasNNCPHGroundSpaces_toTensorFromBlocks_iff_forall_isNNCPH_and_ker_le_bntMPSVectorSpan},
 states the all-chain condition as translated two-site commutation together with
-the same reverse containment for every \(N>2\).  The reverse containment itself
-is not proved here.
+the same reverse containment for every \(N>2\).  For a direct sum containing
+one copy of every distinct BNT basis tensor, whole-tensor transfer idempotence
+now implies this reverse containment.  The resulting spanning theorem is
+\leanid{MPSTensor.IsBNTCanonicalForm.}
+\hspace{0pt}\leanid{rfp_hasParentHamiltonianGroundSpaceSpanning_basisDirectSum}.
 
 These reductions alone do not prove the full source theorem.  The
-canonical-form ground-space spanning condition for several sectors, the
-three-way equivalence with ZCL, the complete canonical-form hypotheses from the
-source statement, and the Beigi ground-space characterization as an internal
-theorem remain open.
+ground-space spanning condition for repeated copies and arbitrary raw sector
+weights, the three-way equivalence with ZCL, the complete canonical-form
+hypotheses from the source statement, and the Beigi ground-space
+characterization as an internal theorem remain open.
 For the forward RFP-to-NNCPH direction, the three-site \(AX/XB\) support maps
 are now represented in \leanid{MPSTensor.HasOverlappingTwoSiteCommutation};
 Appendix~B supplies the basic-vector form.  The local projectors in
@@ -213,9 +216,24 @@ product vector for every \(N>2\).  This is recorded by
 \leanid{MPSTensor.rfp_hasParentHamiltonianGroundSpaceSpanning_single}.
 Combining this equality with the commutation and zero-energy equations gives
 \leanid{MPSTensor.rfp_implies_hasNNCPHGroundSpaces_single}.  Thus the full
-forward NNCPH ground-space condition is proved for one normal sector.  The
-extension to canonical-form tensors with several sectors or repeated copies
-is not included in these declarations.
+forward NNCPH ground-space condition is proved for one normal sector.
+
+For a BNT canonical form with several distinct basis sectors, transfer
+idempotence of the whole direct sum gives residual tensors whose one-site entry
+vectors have identity Gram matrix.  Consequently the simultaneous one-site
+word tuples span the product
+of all block matrix algebras.  This span supplies a common one-letter
+expression for every block identity and propagates to every positive word
+length.  It replaces the right-canonical hypothesis in the local
+restriction-intersection calculation.  A global one-site change of cut then
+forces the block boundary matrices to commute with their tensors, so the
+periodic nearest-neighbor chain space splits into the sum of the single-block
+chain spaces.  Combining this splitting with the single-block injective
+periodic-chain theorem proves
+\leanid{MPSTensor.IsBNTCanonicalForm.}
+\hspace{0pt}\leanid{rfp_hasParentHamiltonianGroundSpaceSpanning_basisDirectSum}.
+This is precisely the multiplicity-one distinct-sector forward case: it does
+not assert the result for repeated copies or arbitrary raw weights.
 The reverse theorem requires both the explicit BNT relation
 \leanid{MPSTensor.IsBNT} and the named all-chain condition
 \leanid{MPSTensor.HasNNCPHGroundSpaces}, but the implication still depends on
@@ -258,8 +276,9 @@ separate conditional construction and is not needed for the proved chain
 commutator. Extending from one normal tensor to the full repeated-sector
 canonical form is subject to the source obstruction recorded in
 \path{docs/paper-gaps/cpsv16_rfp_isometry_scope.tex}. The single-normal-sector
-ground-space spanning clause is proved, while its several-sector and
-repeated-copy extension remains open.
+ground-space spanning clause and the multiplicity-one distinct-sector
+extension are proved. The repeated-copy and arbitrary-raw-weight extension
+remains open, as does the reverse Beigi implication.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

- Derives simultaneous one-site product spanning from the residual isometry equations of a transfer-idempotent direct sum.
- Propagates this span to every positive word length, proves the PGVWC restriction intersection, and closes each block boundary after a one-site change of periodic cut.
- Proves that the nearest-neighbor parent ground space of the direct sum of the distinct BNT basis tensors is spanned by their periodic matrix product vectors.
- Adds the scope-restricted blueprint theorem and updates the paper-gap account.

## Mathematical statement

For a BNT canonical form P, transfer idempotence of the tensor formed by one direct-sum copy of each basis tensor implies

HasParentHamiltonianGroundSpaceSpanning (directSumTensor P.basis) 2 P.basis.

No comparison or crossing hypothesis is assumed. The simultaneous complementary block spans needed in the proof are consequences of the residual Gram identities.

This proves only the multiplicity-one family of distinct BNT sectors. Repeated copies, arbitrary raw sector weights, the complete three-way equivalence, and the reverse Beigi implication remain open. These boundaries are recorded in docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex.

## Source comparison

The restriction and boundary-closing arguments follow arXiv:quant-ph/0608197, Theorem 12, proof lines 1430--1456. The final statement is the multiplicity-one distinct-sector specialization of arXiv:1606.00608, Definition 3.9 and Theorem 3.10, lines 517--541.

## Verification

- lake build TNLean.MPS.RFP.NNCPHMultiSector: passed, 8941 jobs
- Axiom audit of the final theorem, chain splitting, and restriction intersection: only propext, Classical.choice, and Quot.sound
- Proof-integrity scan: no sorry, admit, native_decide, unsafeCast, or declared axiom in changed Lean files
- Lean line-length and git diff checks: passed
- Repository blueprint/Lean synchronization check: passed
- Reader-facing prose check: passed

The repository-wide build is left to CI because the shared local volume was low on free space; the focused target and all declarations introduced here compile.

Closes #4343

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The change is a large, proof-critical extension on the MPS/RFP parent-Hamiltonian path, but it is additive formal mathematics with explicit scope limits and no runtime auth or data-handling surface.
> 
> **Overview**
> Adds formal proofs that when a **BNT canonical form**’s one-copy-per-distinct-sector direct sum is a **renormalization fixed point**, the nearest-neighbor parent Hamiltonian ground space is spanned by those sectors’ periodic matrix product vectors (multiplicity-one, distinct-sector scope only).
> 
> **`ResidualWordSpan`** derives **`WordTupleSpanTop` at one site** from residual-isometry Gram identities and transfer idempotence of the whole direct sum, without assuming right-canonical normalization.
> 
> **`NNCPHMultiSector`** uses that span to run the PGVWC restriction-intersection step with a common one-letter expansion of block identities, extracts block-diagonal boundaries, and **closes boundaries** after a one-site cyclic cut (reusing newly **public** lemmas in `BNTBlockDiagonalBoundaryClosing`). It concludes periodic chain-space splitting and the capstone **`IsBNTCanonicalForm.rfp_hasParentHamiltonianGroundSpaceSpanning_basisDirectSum`**.
> 
> Wires the new modules into **`TNLean.lean`**, adds the matching **blueprint** theorem in ch13, and updates **`cpsv16_nncph_ground_state_scope.tex`** to record this forward case while repeated copies, arbitrary weights, and the reverse Beigi implication stay open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f28600d3a3946ab61960bcfbdf09032f73c7ed2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->