### PR TITLE
feat(Channel/FixedPoint): prove density blocks positive definite

### DIFF
--- a/TNLean/Channel/FixedPoint/SupportCompressedDensityBlocks.lean
+++ b/TNLean/Channel/FixedPoint/SupportCompressedDensityBlocks.lean
@@ -166,10 +166,9 @@ is the full-support step in the proof of Wolf, Theorem 6.14; local source
 1483--1494.
 
 **Scope restriction (maximal-support compression):** This theorem describes
-the fixed points of the compressed map with positive semidefinite density
-blocks.  It does not yet prove that these blocks are positive definite or
-transport the description to the original space with its complementary zero
-summand.  This restriction is documented in
+the fixed points of the compressed map with positive definite density blocks.
+It does not yet transport the description to the original space with its
+complementary zero summand.  This restriction is documented in
 `docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex`.
 
 The theorem records only the fixed-point description.  The corresponding
@@ -193,7 +192,7 @@ theorem IsPositiveMap.exists_block_densities_of_maximalSupportCompression
           (σ : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ),
           U ∈ Matrix.unitaryGroup (Fin n) ℂ ∧
             (∀ k, 0 < d k) ∧ (∀ k, 0 < m k) ∧
-            (∀ k, (σ k).PosSemidef) ∧ (∀ k, (σ k).trace = 1) ∧
+            (∀ k, (σ k).PosDef) ∧ (∀ k, (σ k).trace = 1) ∧
             ∀ B, IsPositiveMap.stationarySupportCompression T V B = B ↔
               ∃ X : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ,
                 star U * B * U = Matrix.reindex e e
@@ -205,9 +204,43 @@ theorem IsPositiveMap.exists_block_densities_of_maximalSupportCompression
       IsSchwarzMap (Matrix.traceAdjointMap
         (IsPositiveMap.stationarySupportCompression T V)) :=
     hSchwarz.traceAdjointMap_stationarySupportCompression hT V hV
-  obtain ⟨K, d, m, e, U, σ, hU, hd, hm, hσpos, hσtrace, _, hfixed⟩ :=
+  obtain ⟨K, d, m, e, U, σ, hU, hd, hm, _, hσtrace, _, hfixed⟩ :=
     hpositive.exists_block_densities_of_meanErgodicProjection
       htrace hcompressedSchwarz hρfull hρfullFix
+  obtain ⟨X, hρblocks⟩ := (hfixed ρfull).mp hρfullFix
+  let Uunitary : unitary (Matrix (Fin n) (Fin n) ℂ) := ⟨U, hU⟩
+  have hUunit : IsUnit U := ⟨Unitary.toUnits Uunitary, rfl⟩
+  have hρcoord : (star U * ρfull * U).PosDef := by
+    simpa only [star_eq_conjTranspose] using
+      hρfull.conjTranspose_mul_mul_same
+        (Matrix.mulVec_injective_iff_isUnit.mpr hUunit)
+  have hreindexed :
+      (Matrix.reindex e e
+        (Matrix.blockDiagonal' fun k ↦ σ k ⊗ₖ X k)).PosDef := by
+    rw [← hρblocks]
+    exact hρcoord
+  have hblockDiagonal :
+      (Matrix.blockDiagonal' fun k ↦ σ k ⊗ₖ X k).PosDef := by
+    have hprincipal := hreindexed.submatrix e.injective
+    simpa only [Matrix.reindex_apply, Matrix.submatrix_submatrix,
+      Equiv.symm_comp_self, Matrix.submatrix_id_id] using hprincipal
+  have hσ : ∀ k, (σ k).PosDef := by
+    intro k
+    letI : Nonempty (Fin (m k)) := Fin.pos_iff_nonempty.mp (hm k)
+    letI : Nonempty (Fin (d k)) := Fin.pos_iff_nonempty.mp (hd k)
+    have hblock : (σ k ⊗ₖ X k).PosDef := by
+      have hprincipal := hblockDiagonal.submatrix
+        (e := fun i ↦ ⟨k, i⟩)
+        (fun _ _ hij ↦ eq_of_heq (Sigma.mk.inj_iff.mp hij).2)
+      have heq :
+          (Matrix.blockDiagonal' fun j ↦ σ j ⊗ₖ X j).submatrix
+              (fun i ↦ ⟨k, i⟩) (fun i ↦ ⟨k, i⟩) = σ k ⊗ₖ X k := by
+        ext i j
+        exact Matrix.blockDiagonal'_apply_eq
+          (fun q : Fin K ↦ σ q ⊗ₖ X q) k i j
+      rw [heq] at hprincipal
+      exact hprincipal
+    exact hblock.left_of_kronecker_of_trace_eq_one (hσtrace k)
   exact ⟨hρ₀, n, V, hρ₀fix, hV, hVrange,
     ⟨ρfull, hρfull, hρfullFix⟩,
-    K, d, m, e, U, σ, hU, hd, hm, hσpos, hσtrace, hfixed⟩
+    K, d, m, e, U, σ, hU, hd, hm, hσ, hσtrace, hfixed⟩

--- a/TNLean/Channel/PartialTrace.lean
+++ b/TNLean/Channel/PartialTrace.lean
@@ -42,6 +42,10 @@ Proposition 2.1) and for reduced states on contiguous tensor factors.
   product
 * `Matrix.partialTraceLeft_kronecker`: the left partial trace of a Kronecker
   product
+* `Matrix.PosDef.partialTraceRight`: the right partial trace of a positive
+  definite matrix is positive definite when the traced factor is nonempty
+* `Matrix.PosDef.partialTraceLeft`: the analogous statement for the left
+  partial trace
 * `Matrix.trace_partialTraceLeft_mul`: the defining trace-pairing identity for
   the left partial trace
 * `Matrix.trace_kronecker_partialTraceLeft_mul_eq`: the weighted one-summand
@@ -109,6 +113,22 @@ theorem PosSemidef.partialTraceRight [Finite α] {X : Matrix (α × β) (α × �
     rfl
   rw [h_eq]
   exact Matrix.posSemidef_sum _ fun _ _ => hX.submatrix _
+
+/-- The partial trace over a nonempty second factor preserves positive
+definiteness.  It is a nonempty sum of positive-definite principal
+submatrices. -/
+theorem PosDef.partialTraceRight [Finite α] [Nonempty β]
+    {X : Matrix (α × β) (α × β) ℂ} (hX : X.PosDef) :
+    (Matrix.partialTraceRight X).PosDef := by
+  cases nonempty_fintype α
+  have h_eq : (Matrix.partialTraceRight X : Matrix α α ℂ) =
+      ∑ k : β, X.submatrix (fun a ↦ (a, k)) (fun a ↦ (a, k)) := by
+    ext i j
+    simp only [Matrix.sum_apply, Matrix.submatrix_apply]
+    rfl
+  rw [h_eq]
+  exact Matrix.posDef_sum Finset.univ_nonempty fun k _ ↦
+    hX.submatrix fun i j hij ↦ (Prod.ext_iff.mp hij).1
 
 /-- The trace is invariant under the partial trace over the second factor. -/
 theorem trace_partialTraceRight [Fintype α] (X : Matrix (α × β) (α × β) ℂ) :
@@ -323,7 +343,48 @@ theorem PosSemidef.partialTraceLeft [Finite β] {X : Matrix (α × β) (α × β
   rw [h_eq]
   exact Matrix.posSemidef_sum _ fun _ _ => hX.submatrix _
 
+/-- The partial trace over a nonempty first factor preserves positive
+definiteness.  It is a nonempty sum of positive-definite principal
+submatrices. -/
+theorem PosDef.partialTraceLeft [Finite β] [Nonempty α]
+    {X : Matrix (α × β) (α × β) ℂ} (hX : X.PosDef) :
+    (Matrix.partialTraceLeft X).PosDef := by
+  cases nonempty_fintype β
+  have h_eq : (Matrix.partialTraceLeft X : Matrix β β ℂ) =
+      ∑ k : α, X.submatrix (fun b ↦ (k, b)) (fun b ↦ (k, b)) := by
+    ext i j
+    simp only [Matrix.sum_apply, Matrix.submatrix_apply]
+    rfl
+  rw [h_eq]
+  exact Matrix.posDef_sum Finset.univ_nonempty fun k _ ↦
+    hX.submatrix fun i j hij ↦ (Prod.ext_iff.mp hij).2
+
 end GeneralLeft
+
+section KroneckerPosDef
+
+variable {α β : Type*} [Fintype α] [Finite β] [Nonempty α] [Nonempty β]
+
+/-- If a Kronecker product is positive definite and its left factor has trace
+one, then the left factor is positive definite.
+
+The first partial trace shows that the right factor is positive definite.  The
+second partial trace is then a positive scalar multiple of the left factor. -/
+theorem PosDef.left_of_kronecker_of_trace_eq_one
+    {A : Matrix α α ℂ} {B : Matrix β β ℂ}
+    (hAB : (A ⊗ₖ B).PosDef) (hAtrace : A.trace = 1) : A.PosDef := by
+  cases nonempty_fintype β
+  have hB : B.PosDef := by
+    have h := hAB.partialTraceLeft
+    rw [partialTraceLeft_kronecker, hAtrace, one_smul] at h
+    exact h
+  have hscaled : (B.trace • A).PosDef := by
+    simpa only [partialTraceRight_kronecker] using hAB.partialTraceRight
+  have htrace : 0 < B.trace := hB.trace_pos
+  have hrescaled := hscaled.smul (inv_pos.mpr htrace)
+  simpa only [smul_smul, inv_mul_cancel₀ (ne_of_gt htrace), one_smul] using hrescaled
+
+end KroneckerPosDef
 
 /-- The trace is invariant under reindexing a matrix by an equivalence of its
 index type. -/

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -3204,7 +3204,10 @@ transfers the support.
     \lean{IsPositiveMap.exists_block_densities_of_maximalSupportCompression,
         Matrix.traceAdjointMap_stationarySupportCompression,
         IsSchwarzMap.stationarySupportCompression,
-        IsSchwarzMap.traceAdjointMap_stationarySupportCompression}
+        IsSchwarzMap.traceAdjointMap_stationarySupportCompression,
+        Matrix.PosDef.partialTraceRight,
+        Matrix.PosDef.partialTraceLeft,
+        Matrix.PosDef.left_of_kronecker_of_trace_eq_one}
     \leanok
     \uses{thm:stationarySupport_compression,
         thm:mean_ergodic_projection_density_block_form}
@@ -3216,7 +3219,7 @@ transfers the support.
         \widetilde T(Y)=V^*T(VYV^*)V
     \]
     has a positive definite fixed point.  There are positive integers
-    $d_k,m_k$, a unitary $U$ on $\mathcal H$, and positive semidefinite
+    $d_k,m_k$, a unitary $U$ on $\mathcal H$, and positive definite
     density matrices $\sigma_k\in\MN{m_k}$ such that
     \[
         \operatorname{Fix}(\widetilde T)
@@ -3224,9 +3227,9 @@ transfers the support.
     \]
     This is the maximal-support application of the full-support step in the
     proof of \cite[Theorem~6.14]{Wolf2012Quantum}.  This is not the full
-    statement of that theorem: it does not yet identify the density matrices
-    as positive definite or transport the displayed decomposition back to the
-    original space.
+    statement of that theorem: it does not yet transport the displayed
+    decomposition back to the original space and adjoin the complementary
+    zero summand.
 \end{theorem}
 
 \begin{proof}
@@ -3242,7 +3245,28 @@ transfers the support.
     Compressing the Schwarz defect for $T^*$ and adding the positive term
     through $\Id-VV^*$ proves the Schwarz inequality for
     $\widetilde T^*$.  Theorem~\ref{thm:mean_ergodic_projection_density_block_form}
-    now gives the asserted fixed-point description.
+    gives the fixed-point description with positive semidefinite trace-one
+    matrices $\sigma_k$.
+
+    Apply this description to a positive definite fixed point
+    $\rho_{\mathrm{full}}$ of $\widetilde T$.  The unitary coordinate matrix
+    is positive definite and has the form
+    \[
+        U^*\rho_{\mathrm{full}}U
+          =\bigoplus_k\sigma_k\otimes X_k.
+    \]
+    Hence every principal block $\sigma_k\otimes X_k$ is positive definite.
+    Its two partial traces satisfy
+    \[
+        \operatorname{tr}_{m_k}(\sigma_k\otimes X_k)=X_k,
+        \qquad
+        \operatorname{tr}_{d_k}(\sigma_k\otimes X_k)
+          =\operatorname{tr}(X_k)\sigma_k.
+    \]
+    Both tensor factors have positive dimension.  Positive definiteness is
+    preserved by these partial traces, so $X_k>0$ and
+    $\operatorname{tr}(X_k)\sigma_k>0$.  Since
+    $\operatorname{tr}(X_k)>0$, it follows that $\sigma_k>0$.
 \end{proof}
 
 \begin{theorem}[Conjugation by the square root at a fixed point of maximal support]%

--- a/docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex
+++ b/docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex
@@ -164,28 +164,44 @@ therefore gives
   \operatorname{Fix}(\widetilde T)
     =U\left(\bigoplus_k\sigma_k\otimes M_{d_k}(\mathbb C)\right)U^*,
 \end{align}
-where every $\sigma_k$ is positive semidefinite and has trace one.
+where every $\sigma_k$ has trace one.  To see that these matrices are positive
+definite, apply this formula to the positive definite fixed point
+$\rho_{\mathrm{full}}$ retained by the compression theorem:
+\begin{align}
+  U^*\rho_{\mathrm{full}}U
+    =\bigoplus_k\sigma_k\otimes X_k.
+\end{align}
+Every principal block $\sigma_k\otimes X_k$ is positive definite.  Taking the
+two partial traces gives
+\begin{align}
+  \operatorname{tr}_{m_k}(\sigma_k\otimes X_k)&=X_k,\\
+  \operatorname{tr}_{d_k}(\sigma_k\otimes X_k)
+    &=\operatorname{tr}(X_k)\sigma_k.
+\end{align}
+Thus $X_k$ is positive definite, so $\operatorname{tr}(X_k)>0$, and the second
+identity implies that $\sigma_k$ is positive definite.  No block dimension is
+changed and no additional kernel summand is introduced.
 \footnote{Formal declarations:
 \leanid{Matrix.traceAdjointMap_stationarySupportCompression},
 \leanid{IsSchwarzMap.traceAdjointMap_stationarySupportCompression}, and
 \leanid{IsPositiveMap.exists_block_densities_of_maximalSupportCompression}
 in
-\doclink{TNLean/Channel/FixedPoint/SupportCompressedDensityBlocks}.}
+\doclink{TNLean/Channel/FixedPoint/SupportCompressedDensityBlocks}; the
+positive-definite partial-trace facts are
+\leanid{Matrix.PosDef.partialTraceRight},
+\leanid{Matrix.PosDef.partialTraceLeft}, and
+\leanid{Matrix.PosDef.left_of_kronecker_of_trace_eq_one} in
+\doclink{TNLean/Channel/PartialTrace}.}
 
-It remains to use the retained positive definite fixed point of
-$\widetilde T$ to prove that each $\sigma_k$ is positive definite, transport
-the resulting density-block form through $V$, and write the complement of
-$Q$ as the single zero summand $\mathcal H_0$ of Theorem~6.14.  In particular,
-the present reduction suggests that no second support compression of the
-individual matrices $\sigma_k$ is needed.
+It remains to transport the density-block form through $V$ and write the
+complement of $Q$ as the single zero summand $\mathcal H_0$ of Theorem~6.14.
 
 Thus Proposition~1.5, its application to the full-support adjoint
 mean-ergodic projection, and the full-support Schr\"odinger-picture fixed-point
 formula, together with the maximal-support witness and the positive
 trace-preserving restriction to its support, are formalized, while
-Theorem~6.14 remains open.  The missing work is the positive-definiteness of
-the compressed density blocks, transport to the original space, and assembly
-of the complementary zero summand.
+Theorem~6.14 remains open.  The missing work is transport to the original
+space and assembly of the complementary zero summand.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

- proves that partial traces over nonempty factors preserve positive definiteness;
- proves that a positive-definite Kronecker product with a trace-one left factor forces that left factor to be positive definite;
- applies the retained positive-definite fixed point of the maximal-support compression to upgrade every density block from positive semidefinite to positive definite;
- updates the scope-restricted blueprint theorem and the Wolf Theorem 6.14 paper-gap note.

## Mathematical argument

For the positive-definite compressed fixed point rho_full, the fixed-space formula gives

U* rho_full U = direct sum over k of sigma_k tensor X_k.

Unitary conjugation preserves positive definiteness, and every diagonal block is a positive-definite principal submatrix. The partial trace over the sigma factor equals X_k because tr(sigma_k)=1, so X_k is positive definite. The other partial trace is tr(X_k) sigma_k; since tr(X_k)>0, rescaling proves sigma_k positive definite.

All existing block dimensions, the unitary, and the density matrices themselves are retained. No support compression, kernel summand, or additional zero block is introduced.

This remains inside maximal stationary support. Transport through the support isometry and assembly of the single complementary zero summand remain in LionSR/QICLean#225 and the parent tracker LionSR/QICLean#219.

Source: Wolf, *Quantum Channels & Operations*, Theorem 6.14 and Equation (6.63), local source lines 1483--1494.

## Verification

- lake env lean TNLean/Channel/PartialTrace.lean
- lake env lean TNLean/Channel/FixedPoint/SupportCompressedDensityBlocks.lean
- lake build TNLean.Channel.FixedPoint.SupportCompressedDensityBlocks
- blueprint/Lean synchronization and reverse coverage for every changed declaration
- proof-integrity, 100-column, and diff checks
- axioms of all changed declarations: propext, Classical.choice, Quot.sound

Closes LionSR/QICLean#224.
Advances LionSR/QICLean#219.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely formal linear-algebra and fixed-point theory with doc/blueprint sync; no auth, I/O, or runtime behavior changes.
> 
> **Overview**
> Adds matrix lemmas so **partial traces over nonempty factors preserve positive definiteness**, and **`PosDef.left_of_kronecker_of_trace_eq_one`** extracts a positive-definite left Kronecker factor when the product is positive definite and that factor has trace one.
> 
> **`IsPositiveMap.exists_block_densities_of_maximalSupportCompression`** no longer stops at positive semidefinite density blocks: it instantiates the block formula on the retained positive-definite compressed fixed point `ρ_full`, uses principal submatrix and unitary invariance, then partial traces to show each `σ_k` is **positive definite** (not just PSD).
> 
> Blueprint **Theorem (density blocks after maximal stationary support)** and **`docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex`** are updated so the documented gap is only **transport through the support isometry** and the **complementary zero summand**—not positive-definiteness of the blocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 690e9086f0c0b2722af79e9c32034feb04157ff4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->