### PR TITLE
docs(tenkz): migrate core MPS figures

### DIFF
--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -19,7 +19,13 @@ boundary conditions (PBC).
     indexed by a physical index $i \in \{0, \ldots, d{-}1\}$.
     Such a tensor defines an MPV family. Diagrammatically,
     \begin{center}
-        \TNMPSLocal{A}{i}
+        % A^i \in \MN{D}: the node is A, its upper leg is the physical
+        % index i, and the open west/east legs are the two virtual
+        % matrix indices.  Boundary signature: (virtual-west=1 |
+        % virtual-east=1 | physical-up=1 | physical-down=0).
+        \begin{tenkz}[physical=up]
+            \tn[up=$i$]{A}
+        \end{tenkz}
     \end{center}
     The black node denotes the tensor $A$, the horizontal legs are virtual,
     and the upper leg is the physical index $i$.
@@ -37,7 +43,18 @@ boundary conditions (PBC).
     with the convention that the empty word evaluates to the identity:
     $A^\varnothing = \Id_D$. In tensor-network notation,
     \begin{center}
-        \TNMPSWord{A}{i_1}{i_L}{L}
+        % A^w = A^{i_1} A^{i_2} \cdots A^{i_L}: horizontal bonds are
+        % contracted matrix indices, the two outer virtual legs remain
+        % open, and the upper legs carry the letters of w.  The ellipsis
+        % and brace make the L-site word schematic.  The ink therefore
+        % displays three representative physical legs; the ellipsis carries
+        % the remaining L-3 factors.  Emitted boundary signature of this
+        % finite schematic: (virtual-west=1 | virtual-east=1 |
+        % physical-up=3 | physical-down=0).
+        \begin{tenkz}[physical=up]
+            \tn[up=$i_1$]{A}\tnspan[brace below]{4}{$L\text{ copies}$} &
+            \tn{A} & \tndots & \tn[up=$i_L$]{A}
+        \end{tenkz}
     \end{center}
     in which each black node denotes the same local tensor $A$, the virtual
     legs remain open, and the physical legs are labelled by the word
@@ -149,7 +166,19 @@ boundary conditions (PBC).
     $\mc{V}(A) = \bigl\{\ket{V^{(N)}(A)}\bigr\}_{N \ge 1}$. The coefficient
     $V^{(N)}(A)_\sigma$ is the periodic contraction
     \begin{center}
-        \TNMPV{A}{i_1}{i_N}{N}
+        % V^{(N)}(A)_{i_1,\ldots,i_N}
+        % = \tr(A^{i_1} \cdots A^{i_N}):
+        % the periodic return closes the two outer virtual legs into the
+        % trace, while the upper legs carry the physical configuration.
+        % The ellipsis and brace make the N-site ring schematic.  The ink
+        % displays three representative physical legs; the ellipsis carries
+        % the remaining N-3 factors.  Emitted boundary signature of this
+        % finite schematic: (virtual-west=0 | virtual-east=0 |
+        % physical-up=3 | physical-down=0).
+        \begin{tenkz}[periodic, physical=up]
+            \tn[up=$i_1$]{A}\tnspan[brace below]{4}{$N\text{ copies}$} &
+            \tn{A} & \tndots & \tn[up=$i_N$]{A}
+        \end{tenkz}
     \end{center}
     of $N$ copies of the local tensor $A$, with the outer virtual legs closed
     by the trace.
@@ -166,20 +195,18 @@ boundary conditions (PBC).
     \]
     Diagrammatically, the transfer map is the double-layer contraction
     \begin{center}
-        \TNTransferMap{A}
+        % \E_A(X) = \sum_i A^i X (A^i)^\dagger: the upper and starred
+        % lower nodes are A and its conjugate, their paired physical
+        % legs sum i, and X rides the east cup (the input).  Traversing
+        % the lower wire in the opposite direction supplies the transpose
+        % in the adjoint.  The west pair remains open as the matrix output.
+        % Boundary signature: (virtual-west=2 | virtual-east=0 |
+        % physical-up=0 | physical-down=0).
+        \begin{tenkz}[sandwich, east={cup=$X$}]
+            \tn{A} \\
+            \tn*{A}
+        \end{tenkz}
     \end{center}
-    % TODO-tenkz (Phase-1 migration batch): this \TNTransferMap motif
-    % draws the input X at the WEST end of the double layer.  Under the
-    % tenkz 0.6 index conventions (manual2, east-cup ruling) a west-side
-    % input reads as the ADJOINT map E*_A(X); the applied form of E_A
-    % must ride X on the EAST cup, with the west ket/bra pair left open
-    % because the output is a matrix.  Corrected tenkz spelling:
-    %   % E_A(X) = sum_i A^i X (A^i)^dagger : X rides the east cup (the
-    %   % input side); the west pair stays open -- the output is a matrix
-    %   \begin{tenkz}[sandwich, east={cup=$X$}]
-    %     \tn{A} \\
-    %     \tn*{A}
-    %   \end{tenkz}
     in which the upper node denotes $A$, the lower node denotes $A^\dagger$,
     and the physical index is summed over between them.
 \end{definition}
@@ -877,10 +904,21 @@ This is the identity used in
     conjugate ring of $B$ along their shared physical indices, both virtual
     rings closed by the trace:
     \begin{center}
-        \TNMPVOverlap{A}{B}{N}
+        % O_{AB}(N) = \sum_\sigma V^{(N)}(A)_\sigma
+        % \overline{V^{(N)}(B)_\sigma}: the ket row is the A ring and the
+        % starred bra row is the conjugate B ring.  Each vertical pairing
+        % sums one shared physical index; periodic closes both virtual
+        % rings.  Hence every index is contracted and the network is a
+        % scalar.  The brace makes the N-site contraction schematic.
+        % Boundary signature: (virtual-west=0 | virtual-east=0 |
+        % physical-up=0 | physical-down=0).
+        \begin{tenkz}[rows={ket, bra}, periodic]
+            \tn{A} & \tndots & \tn{A} \\
+            \tn*{B}\tnspan[brace below]{3}{$N\text{ sites}$} & \tndots & \tn*{B}
+        \end{tenkz}
     \end{center}
-    This is the bilinear overlap (without complex conjugation) used later. By
-    Lemma~\ref{lem:overlap_eq_inner}, it is the complex conjugate of
+    This pairing is linear in the first MPV coefficient and conjugate-linear
+    in the second. By Lemma~\ref{lem:overlap_eq_inner}, it is the complex conjugate of
     the Hilbert-space inner product from Definition~\ref{def:mpv_inner}.
 \end{definition}
 

--- a/scripts/build_blueprint_ch01_12.sh
+++ b/scripts/build_blueprint_ch01_12.sh
@@ -21,6 +21,7 @@ mkdir -p "$WORK_DIR/blueprint/src" "$WORK_DIR/tex"
 rsync -a --exclude='.tn_svg_cache/' \
   "$REPO_ROOT/blueprint/src/" "$WORK_DIR/blueprint/src/"
 cp -R "$REPO_ROOT/tex/tn" "$WORK_DIR/tex/tn"
+cp -R "$REPO_ROOT/tex/tenkz" "$WORK_DIR/tex/tenkz"
 
 # Verify that the dedicated router contains exactly ch01_* through ch12_*.
 echo "==> Checking the FT--MPS chapter router..."

--- a/tex/tn/tn_catalogue.tex
+++ b/tex/tn/tn_catalogue.tex
@@ -101,75 +101,6 @@
 
 \input{tn_motifs_mpdo.tex} % chktex 27 (resolved within the TikZ library directory)
 
-\TNDeclareDiagram
-    {TNMPSLocal}
-    {tensor,label}
-    {display}
-    {compact}
-    {\TNMPSLocal{A}{i}}
-    {chapter/ch02_mps.tex}{%
-    \begin{TNDiagram}[compact]
-        \TNMPSSite{tnA}{at=origin}{#1}
-        \TNOpenVirtualWest{tnAWest}
-        \TNOpenVirtualEast{tnAEast}
-        \TNOpenPhysicalNorth{tnAKet}
-        \TNLabelAbove{tnAKetOpen}{#2}
-    \end{TNDiagram}%
-}
-
-\TNDeclareDiagram
-    {TNMPSWord}
-    {tensor,left,right,length}
-    {display}
-    {compact}
-    {\TNMPSWord{A}{i}{k}{L}}
-    {chapter/ch02_mps.tex}{%
-    \begin{TNDiagram}[compact]
-        \TNMPSSite{tnL}{at=origin}{}
-        \TNMPSSite{tnM}{right=of tnL}{}
-        \TNOmission{tnWordOmission}{right=of tnM}
-        \TNMPSSite{tnR}{right=of tnWordOmission}{}
-        \TNConnectVirtual{tnLEast}{tnMWest}
-        \TNOpenVirtualWest{tnLWest}
-        \TNOpenVirtualEast{tnMEast}
-        \TNOpenVirtualWest{tnRWest}
-        \TNOpenVirtualEast{tnREast}
-        \TNOpenPhysicalNorth{tnLKet}
-        \TNOpenPhysicalNorth{tnMKet}
-        \TNOpenPhysicalNorth{tnRKet}
-        \TNLabelAbove{tnLKetOpen}{#2}
-        \TNLabelAbove{tnRKetOpen}{#3}
-        \TNLabelBelow{tnWordOmission}{#4}
-        \TNLabelLeft{tnL}{#1}
-    \end{TNDiagram}%
-}
-
-\TNDeclareDiagram
-    {TNMPV}
-    {tensor,left,right,length}
-    {display}
-    {compact}
-    {\TNMPV{A}{i}{k}{L}}
-    {chapter/ch02_mps.tex}{%
-    \begin{TNDiagram}[compact]
-        \TNMPSSite{tnL}{at=origin}{}
-        \TNMPSSite{tnM}{right=of tnL}{}
-        \TNOmission{tnMPVOmission}{right=of tnM}
-        \TNMPSSite{tnR}{right=of tnMPVOmission}{}
-        \TNConnectVirtual{tnLEast}{tnMWest}
-        \TNOpenVirtualEast{tnMEast}
-        \TNOpenVirtualWest{tnRWest}
-        \TNOpenPhysicalNorth{tnLKet}
-        \TNOpenPhysicalNorth{tnMKet}
-        \TNOpenPhysicalNorth{tnRKet}
-        \TNTraceVirtualBelow{tnLWest}{tnREast}
-        \TNLabelAbove{tnLKetOpen}{#2}
-        \TNLabelAbove{tnRKetOpen}{#3}
-        \TNLabelLeft{tnL}{#1}
-        \TNLabelBelow{tnMPVOmission}{#4}
-    \end{TNDiagram}%
-}
-
 % Blocking: L neighbouring local tensors grouped (dashed box) into one
 % blocked tensor; physical legs poke out the top, the outer virtual legs
 % become the blocked bond.
@@ -199,40 +130,6 @@
         \TNGroupFit{tnBlockingBoundary}
             {(tnL)(tnM)(tnBlockingOmission)(tnR)}
         \TNLabelLeft{tnBlockingBoundary}{#1}
-    \end{TNDiagram}%
-}
-
-% MPV overlap: the top row carries copies of #1, the bottom row the conjugate
-% copies of #2; the shared physical indices are contracted between the rows and
-% both virtual rings are closed by the trace (the boxes above and below).
-\TNDeclareDiagram
-    {TNMPVOverlap}
-    {left,right,length}
-    {display}
-    {compact}
-    {\TNMPVOverlap{i}{k}{L}}
-    {chapter/ch02_mps.tex}{%
-    \begin{TNDiagram}[compact]
-        \TNMPDOOverlapWord{ovu}{at=origin}{#1}{#2}{#3}
-    \end{TNDiagram}%
-}
-
-\TNDeclareDiagram
-    {TNTransferMap}
-    {tensor}
-    {display}
-    {compact}
-    {\TNTransferMap{A}}
-    {chapter/ch02_mps.tex}{%
-    \begin{TNDiagram}[compact]
-        \TNStackedMPOProduct{tn}{at=origin}{}{\overline{#1}}{}
-        \TNOpenVirtualWest{tnUpperWest}
-        \TNOpenVirtualWest{tnLowerWest}
-        \TNOpenVirtualEast{tnUpperEast}
-        \TNOpenVirtualEast{tnLowerEast}
-        \TNLabelLeft{tnCentre}{X}
-        \TNLabelRight{tnCentre}{\E_{#1}(X)}
-        \TNLabelRight{tnUpperBra}{i}
     \end{TNDiagram}%
 }
 


### PR DESCRIPTION
## Mathematical content

This replaces five legacy catalogue calls by inline tenkz descriptions of the same tensor networks:

- A^i has one physical index and two virtual boundary indices.
- A^{i_1}\cdots A^{i_L} contracts adjacent virtual indices and retains the two boundary indices.
- The periodic MPV coefficient closes the virtual word into a ring while leaving its physical indices open.
- E_A(X) contracts the physical index between A and A^dagger, places X on the east cup, and leaves the west pair as the output matrix indices.
- The MPV overlap contracts the physical indices between two closed virtual rings, hence represents a scalar.

The nearby prose now records the correct sesquilinearity convention: the overlap is linear in the first MPV coefficient and conjugate-linear in the second. Formula-to-ink correspondences remain in percent comments.

## Scope

Only the five now-unused catalogue entries are removed. This PR introduces no typed morphism diagram, fusion tree, or Cartesian reassociation.

The isolated Chapter 1 through Chapter 12 build script now copies tex/tenkz as well as tex/tn, so the build boundary contains the package actually imported by the migrated chapter.

## Verification

- exact isolated Chapter 1 through Chapter 12 XeLaTeX build: 197 pages
- visual inspection of the fresh Chapter 2 pages containing all five diagrams
- focused tenkz lint: 2 files, 0 findings
- prior isolated five-picture semantic audit: 5 pictures, 0 hard errors, 0 advisories
- all 18 tenkz acceptance examples compile and audit
- tenkz picture pipeline and legacy smoke render pass
- git diff --check
- forbidden phrase and issue4152_proto scans: 0 matches

Closes LionSR/tenkz#35.
Tracks LionSR/tenkz#20 and LionSR/tenkz#10.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and diagram-rendering only; no Lean or runtime logic. Build risk is limited to LaTeX packaging for the isolated blueprint volume.
> 
> **Overview**
> **Chapter 2** replaces five legacy `\TN…` catalogue diagrams with inline **`tenkz`** environments (local MPS site, word product, periodic MPV ring, transfer map with **`east={cup=$X$}`**, and ket/bra MPV overlap). Percent comments document formula-to-ink boundary signatures; the transfer-map TODO about west vs east cup is removed because the new spelling matches the applied map \(\mathcal{E}_A\).
> 
> **`tn_catalogue.tex`** drops the unused declarations **`TNMPSLocal`**, **`TNMPSWord`**, **`TNMPV`**, **`TNMPVOverlap`**, and **`TNTransferMap`** (e.g. **`TNBlocking`** and gauge diagrams stay).
> 
> Overlap prose now states **linear in the first MPV coefficient and conjugate-linear in the second**, aligned with the inner product definition.
> 
> **`build_blueprint_ch01_12.sh`** copies **`tex/tenkz`** into the isolated ch01–ch12 build tree alongside **`tex/tn`**, so migrated chapters resolve the package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a353350a6dbf7e8c605b4fb85546a9af73d54ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->