### PR TITLE
fix(tenkz): harden face-port audit events

### DIFF
--- a/scripts/tenkz_audit.py
+++ b/scripts/tenkz_audit.py
@@ -86,7 +86,14 @@ def _is_cell(v: str) -> bool:
 
 def _is_pairleg_port(v: str) -> bool:
     """A contraction starts at the centred face or a positive face slot."""
-    return v == "center" or (_is_int(v) and int(v) > 0)
+    if v == "center":
+        return True
+    if not _is_int(v):
+        return False
+    try:
+        return int(v) > 0
+    except ValueError:
+        return False
 
 
 def _enum(*vals: str) -> Callable[[str], bool]:

--- a/scripts/tenkz_audit.py
+++ b/scripts/tenkz_audit.py
@@ -103,7 +103,8 @@ FIELD_VALIDATORS: dict[str, dict[str, Callable[[str], bool]]] = {
                   "face": _enum("up", "down", "west", "east"),
                   "arity": _is_int, "at": _any},
     "pairleg": {"picture": _is_int, "upper": _is_cell, "lower": _is_cell,
-                "upper-port": _any, "column": _is_int},
+                "upper-port": lambda v: v == "center" or (_is_int(v) and int(v) > 0),
+                "column": _is_int},
     # The emitter normalizes the user-facing `bond dir=left|right` to
     # forward/reverse (direction along the wire); accept both spellings.
     "bond": {"picture": _is_int, "row": _is_int, "from": _is_int, "to": _is_int,

--- a/scripts/tenkz_audit.py
+++ b/scripts/tenkz_audit.py
@@ -84,6 +84,11 @@ def _is_cell(v: str) -> bool:
     return re.fullmatch(r"\d+-\d+", v) is not None
 
 
+def _is_pairleg_port(v: str) -> bool:
+    """A contraction starts at the centred face or a positive face slot."""
+    return v == "center" or (_is_int(v) and int(v) > 0)
+
+
 def _enum(*vals: str) -> Callable[[str], bool]:
     allowed = set(vals)
     return lambda v: v in allowed
@@ -103,7 +108,7 @@ FIELD_VALIDATORS: dict[str, dict[str, Callable[[str], bool]]] = {
                   "face": _enum("up", "down", "west", "east"),
                   "arity": _is_int, "at": _any},
     "pairleg": {"picture": _is_int, "upper": _is_cell, "lower": _is_cell,
-                "upper-port": lambda v: v == "center" or (_is_int(v) and int(v) > 0),
+                "upper-port": _is_pairleg_port,
                 "column": _is_int},
     # The emitter normalizes the user-facing `bond dir=left|right` to
     # forward/reverse (direction along the wire); accept both spellings.

--- a/scripts/test_tenkz_face_ports.py
+++ b/scripts/test_tenkz_face_ports.py
@@ -473,9 +473,46 @@ def main() -> int:
             and "lacks required picture=" in finding.msg
             for finding in missing_picture_audit.findings
         )
+        pairleg_ports_log = work / "pairleg-upper-ports.tnlog"
+        pairleg_ports_log.write_text(
+            "picture|id=1|lang=grid\n"
+            "pairleg|picture=1|upper=1-1|lower=2-1|upper-port=center|column=1\n"
+            "pairleg|picture=1|upper=1-1|lower=2-1|upper-port=1|column=1\n"
+            "pairleg|picture=1|upper=1-1|lower=2-1|upper-port=0|column=1\n"
+            "pairleg|picture=1|upper=1-1|lower=2-1|upper-port=-1|column=1\n"
+            "pairleg|picture=1|upper=1-1|lower=2-1|upper-port=bogus|column=1\n",
+            encoding="utf-8",
+        )
+        pairleg_ports_audit = Audit(pairleg_ports_log, None)
+        pairleg_ports_audit.parse_log()
+        malformed_upper_ports = [
+            finding.msg
+            for finding in pairleg_ports_audit.findings
+            if finding.rule == "malformed-event" and "upper-port=" in finding.msg
+        ]
+        warning_only_log = work / "warning-only.tnlog"
+        warning_only_log.write_text(
+            "picture|id=1|lang=grid\n"
+            "warning|picture=1|code=deferred-feature\n"
+            "boundary|picture=1|virtual-west=0|virtual-east=0|"
+            "physical-up=0|physical-down=0\n",
+            encoding="utf-8",
+        )
+        warning_only_audit = Audit(warning_only_log, None)
+        warning_only_status = warning_only_audit.run()
 
     if not missing_picture_guard:
         raise AssertionError("audit parser silently dropped a pictureless warning")
+    if len(malformed_upper_ports) != 3 or not all(
+        any(f"upper-port={value!r}" in msg for msg in malformed_upper_ports)
+        for value in ("0", "-1", "bogus")
+    ):
+        raise AssertionError("audit accepted a non-contraction pairleg upper-port")
+    if warning_only_status != 1 or not any(
+        finding.rule == "empty-picture" and finding.severity == "HARD"
+        for finding in warning_only_audit.findings
+    ):
+        raise AssertionError("warning-only grid picture counted as mathematical content")
     if hooks_findings:
         raise AssertionError("audit rejected a grid hooks event")
     inverse = pictures[1]

--- a/scripts/test_tenkz_face_ports.py
+++ b/scripts/test_tenkz_face_ports.py
@@ -476,13 +476,15 @@ def main() -> int:
             for finding in missing_picture_audit.findings
         )
         pairleg_ports_log = work / "pairleg-upper-ports.tnlog"
+        overlong_port = "9" * 5000
         pairleg_ports_log.write_text(
             "picture|id=1|lang=grid\n"
             "pairleg|picture=1|upper=1-1|lower=2-1|upper-port=center|column=1\n"
             "pairleg|picture=1|upper=1-1|lower=2-1|upper-port=1|column=1\n"
             "pairleg|picture=1|upper=1-1|lower=2-1|upper-port=0|column=1\n"
             "pairleg|picture=1|upper=1-1|lower=2-1|upper-port=-1|column=1\n"
-            "pairleg|picture=1|upper=1-1|lower=2-1|upper-port=bogus|column=1\n",
+            "pairleg|picture=1|upper=1-1|lower=2-1|upper-port=bogus|column=1\n"
+            f"pairleg|picture=1|upper=1-1|lower=2-1|upper-port={overlong_port}|column=1\n",
             encoding="utf-8",
         )
         pairleg_ports_audit = Audit(pairleg_ports_log, None)
@@ -506,9 +508,9 @@ def main() -> int:
 
     if not missing_picture_guard:
         raise AssertionError("audit parser silently dropped a pictureless warning")
-    if len(malformed_upper_ports) != 3 or not all(
+    if len(malformed_upper_ports) != 4 or not all(
         any(f"upper-port={value!r}" in msg for msg in malformed_upper_ports)
-        for value in ("0", "-1", "bogus")
+        for value in ("0", "-1", "bogus", overlong_port)
     ):
         raise AssertionError("audit accepted a non-contraction pairleg upper-port")
     if warning_only_status != 1 or not any(

--- a/scripts/test_tenkz_face_ports.py
+++ b/scripts/test_tenkz_face_ports.py
@@ -11,10 +11,12 @@ resolution for ordinary tall glyphs and physical contractions.
 
 from __future__ import annotations
 
+import io
 import os
 import shutil
 import subprocess
 import tempfile
+from contextlib import redirect_stdout
 from pathlib import Path
 
 from tenkz_audit import Audit, canonical_hash
@@ -499,7 +501,8 @@ def main() -> int:
             encoding="utf-8",
         )
         warning_only_audit = Audit(warning_only_log, None)
-        warning_only_status = warning_only_audit.run()
+        with redirect_stdout(io.StringIO()):
+            warning_only_status = warning_only_audit.run()
 
     if not missing_picture_guard:
         raise AssertionError("audit parser silently dropped a pictureless warning")


### PR DESCRIPTION
## Mathematical invariant

A pairleg event certifies a physical contraction. Its upper-port value must therefore be either center, for a single centred face, or a positive integer naming a declared contraction slot. Arbitrary text, zero, and negative integers do not name an index and are rejected.

Likewise, a warning and a derived boundary signature are diagnostics; neither is mathematical ink. The new end-to-end fixture proves that a warning-only grid picture still raises the empty-picture hard error.

## Verification

- 80-picture face-port suite
- tenkz picture rendering and cache pipeline
- Python byte compilation
- tenkz lint: 275 files, 0 findings
- all 18 acceptance examples compile and audit
- git diff --check

Closes LionSR/tenkz#36.
Follow-up to LionSR/TNLean#4267.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to audit validation and test fixtures; they reject invalid log data and do not alter LaTeX rendering or runtime behavior.
> 
> **Overview**
> **Pairleg `upper-port` validation** is tightened in `tenkz_audit.py`: a new `_is_pairleg_port` check replaces permissive `_any`, so only `center` or a **positive integer** contraction slot is accepted; `0`, negatives, non-numeric text, and invalid integer strings fail as `malformed-event`.
> 
> **Regression coverage** in `test_tenkz_face_ports.py` adds synthetic `.tnlog` fixtures that assert those bad `upper-port` values are rejected (including a very long numeric string) and that a grid picture with only a `warning` plus `boundary` still fails **`empty-picture`** when `Audit.run()` runs—warnings and boundaries are not treated as mathematical content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abaf64cc2c4aa9109d266f9f5838e0297178c8e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->