### PR TITLE
feat(MPS/RFP): prove eventual parent-ground-space dimension

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -626,6 +626,7 @@ import TNLean.MPS.RFP.BNTOrthogonality
 import TNLean.MPS.RFP.ResidualIsometry
 import TNLean.MPS.RFP.ResidualWordSpan
 import TNLean.MPS.RFP.NNCPHMultiSector
+import TNLean.MPS.RFP.BeigiGroundSpaceDimension
 import TNLean.MPS.RFP.PhaseMultiplicityCounterexample
 import TNLean.MPS.RFP.BNTWeightCounterexample
 

--- a/TNLean/MPS/RFP/BeigiGroundSpaceDimension.lean
+++ b/TNLean/MPS/RFP/BeigiGroundSpaceDimension.lean
@@ -1,0 +1,68 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.Commuting
+import TNLean.MPS.SharedInfra.SectorDecomposition
+import Mathlib.LinearAlgebra.Dimension.Constructions
+
+/-!
+# Eventual dimension of nearest-neighbor parent ground spaces
+
+For a sector decomposition whose basis matrix product vectors are eventually
+linearly independent, the all-chain nearest-neighbor ground-space spanning
+condition makes the parent-Hamiltonian ground-space dimension eventually equal
+to the number of basis sectors. This is the scale-invariance hypothesis used in
+Beigi's classification of one-dimensional commuting Hamiltonians.
+
+## Main statement
+
+* `HasBNTSectorData.eventually_parentHamiltonian_groundSpace_finrank_eq`:
+  the parent ground-space dimension is eventually the number of distinct BNT
+  representatives.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Definition 3.9 and Theorem 3.10, lines 517--540.
+* S. Beigi, *Classification of the phases of 1D spin chains with commuting
+  Hamiltonians*, J. Phys. A 45 (2012) 025306, arXiv:1105.1019.
+-/
+
+namespace MPSTensor
+
+/-- If the basis-sector matrix product vectors are eventually linearly independent and
+span every sufficiently long nearest-neighbor parent ground space, then the dimension of
+that ground space is eventually the number of distinct basis sectors.
+
+Source: arXiv:1606.00608, Definition 3.9 and Theorem 3.10, lines 517--540.
+This supplies the eventual ground-state degeneracy used in Beigi,
+arXiv:1105.1019, Section IV. -/
+theorem HasBNTSectorData.eventually_parentHamiltonian_groundSpace_finrank_eq
+    {d : ℕ} {P : SectorDecomposition d}
+    (hBNT : HasBNTSectorData P)
+    (hNNCPH : HasNNCPHGroundSpaces P.toTensor P.basis) :
+    ∃ N₀ : ℕ, ∀ N : ℕ, N₀ < N →
+      Module.finrank ℂ (LinearMap.ker (parentHamiltonian P.toTensor 2 N)) =
+        P.basisCount := by
+  rcases hBNT with ⟨N₁, hLI⟩
+  refine ⟨max N₁ 2, ?_⟩
+  intro N hN
+  have hN₁ : N₁ < N := lt_of_le_of_lt (Nat.le_max_left _ _) hN
+  have hTwo : 2 < N := lt_of_le_of_lt (Nat.le_max_right _ _) hN
+  have hImage : LinearIndependent ℂ
+      ((WithLp.linearEquiv 2 ℂ (NSiteSpace d N)).symm.toLinearMap ∘
+        fun j : Fin P.basisCount ↦ (mpv (P.basis j) : NSiteSpace d N)) := by
+    convert hLI N hN₁ using 1
+    funext j
+    ext σ
+    simp [Function.comp_apply, mpvState_apply]
+  have hCoefficients : LinearIndependent ℂ
+      (fun j : Fin P.basisCount ↦ (mpv (P.basis j) : NSiteSpace d N)) :=
+    LinearIndependent.of_comp
+      (WithLp.linearEquiv 2 ℂ (NSiteSpace d N)).symm.toLinearMap hImage
+  rw [(hNNCPH N hTwo).groundSpaceSpanning, bntMPSVectorSpan]
+  simpa using finrank_span_eq_card hCoefficients
+
+end MPSTensor

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -2262,6 +2262,36 @@ specialization of that Appendix~D definition.
     Definition~\ref{def:has_nncph_ground_space}, uniformly in \(N\).
 \end{proof}
 
+\begin{theorem}[Eventual dimension of nearest-neighbor parent ground spaces]%
+    \label{thm:nncph_eventual_ground_space_dimension}
+    \lean{MPSTensor.HasBNTSectorData.eventually_parentHamiltonian_groundSpace_finrank_eq}
+    \leanok
+    \uses{def:sector_weight_data, def:has_nncph_ground_spaces}
+    Let $P$ be a sector decomposition with representatives
+    $A_1,\ldots,A_g$ and total tensor $B$. Suppose that the vectors
+    $\{\ket{V^{(N)}(A_j)}\}_{j=1}^g$ are linearly independent for all
+    sufficiently large $N$, and that $B$ satisfies the all-chain
+    nearest-neighbor commuting parent-Hamiltonian ground-space condition with
+    these representatives. Then there is $N_0$ such that, for every $N>N_0$,
+    \[
+        \dim_{\C}\ker H_2^{(N)}(B)=g.
+    \]
+    Thus the ground-state degeneracy is eventually constant, as required in
+    \cite[Section~IV]{Beigi2012Classification}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:bnt_span, def:has_nncph_ground_spaces}
+    Choose $N_0\geq2$ beyond the linear-independence threshold. For $N>N_0$,
+    the ground-space spanning equation gives
+    \[
+        \ker H_2^{(N)}(B)
+        =\spn\{\ket{V^{(N)}(A_j)}:j=1,\ldots,g\}.
+    \]
+    Identifying these vectors with their coefficient functions preserves
+    linear independence. The dimension of their span is therefore $g$.
+\end{proof}
+
 \begin{theorem}[All-chain nearest-neighbor commuting parent-Hamiltonian ground spaces imply a renormalization fixed point]\label{thm:nncph_implies_rfp}
     \lean{MPSTensor.nncph_implies_rfp}
     \lean{Axioms.beigi_nncph_to_rfp}

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -239,6 +239,20 @@ The reverse theorem requires both the explicit BNT relation
 \leanid{MPSTensor.HasNNCPHGroundSpaces}, but the implication still depends on
 the axiom \leanid{Axioms.beigi_nncph_to_rfp}.
 
+The eventual scale-invariance input to Beigi's classification is now proved
+without this axiom.  Let $P$ be a sector decomposition with representatives
+$A_1,\ldots,A_g$ and total tensor $B$. If the representative matrix product
+vectors are eventually linearly independent, the all-chain condition gives
+\[
+  \dim_{\mathbb C}\ker H_2^{(N)}(B)=g
+\]
+for all sufficiently large $N$.  This is
+\leanid{MPSTensor.HasBNTSectorData.}
+\hspace{0pt}\leanid{eventually_parentHamiltonian_groundSpace_finrank_eq}.
+The proof uses only the ground-space spanning equation and the dimension of the
+span of a finite linearly independent family.  It does not use the commuting
+interaction classification.
+
 \section{Elimination plan}
 
 A source-faithful formalization should replace the remaining axiom-backed
@@ -255,10 +269,12 @@ including the spanning condition in the parent-Hamiltonian ground-space clause:
 \end{align}
 The forward commutation implication uses the basic-vector form in
 Theorem~3.11 and the corresponding local projectors.  The reverse implication
-must internalize Beigi's
-one-dimensional nearest-neighbor commuting-Hamiltonian ground-space
-classification and identify the resulting locally orthogonal states with the
-basis of normal tensors of $A$.\footnote{Tracked by \ghissue{2633}.}
+must internalize the remaining part of Beigi's one-dimensional
+nearest-neighbor commuting-Hamiltonian ground-space classification: construct
+the finite sector graph, use eventual degeneracy constancy to reduce its cycles
+to loops with one-dimensional cyclic edge kernels, and identify the resulting
+locally orthogonal product-of-pairs states with the basis of normal tensors of
+$A$.\footnote{Tracked by \ghissue{2633}.}
 
 The current proof boundary is therefore: the reverse implication has the
 source ground-space hypothesis, but its proof is still the Beigi axiom; the
@@ -278,7 +294,9 @@ canonical form is subject to the source obstruction recorded in
 \path{docs/paper-gaps/cpsv16_rfp_isometry_scope.tex}. The single-normal-sector
 ground-space spanning clause and the multiplicity-one distinct-sector
 extension are proved. The repeated-copy and arbitrary-raw-weight extension
-remains open, as does the reverse Beigi implication.
+remains open.  In the reverse direction, eventual ground-space dimension
+stability is proved; the sector-graph classification and its identification
+with the basis of normal tensors remain open.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
### Motivation

- CPSV16 Definition 3.9 identifies the periodic parent ground space with the span of the basis-of-normal-tensor vectors for every sufficiently long chain; see `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 517–524: “the kernel of the parent Hamiltonian is spanned by the states associated to the BNT.”
- Beigi's classification, arXiv:1105.1019, Section IV, uses eventual constancy of the ground-state degeneracy before the sector-cycle argument.
- Issue #4353 isolates this scale-invariance consequence as the first native step toward the reverse implication in CPSV16 Theorem 3.10, tracked by #2633.

### Description

- Add `MPSTensor.HasBNTSectorData.eventually_parentHamiltonian_groundSpace_finrank_eq` in a downstream RFP module.
- Derive the equality
  \[
  \dim_{\mathbb C}\ker H_2^{(N)}(P_{\mathrm{tot}})=P.\mathrm{basisCount}
  \]
  for all sufficiently large `N`, using only eventual linear independence and the all-chain ground-space spanning equation.
- Transport linear independence from matrix product states to their coefficient functions through the canonical finite-dimensional linear equivalence, then apply the dimension formula for the span of a finite linearly independent family.
- Add the stable root import, a Chapter 13 blueprint theorem and proof, and an NNCPH paper-gap update recording that the sector graph, loop reduction, one-dimensional cyclic edge kernels, and product-of-pairs identification remain open.
- No normality assumption, Beigi axiom, or additional mathematical hypothesis is introduced.

### Testing

- Direct Lean check of `TNLean/MPS/RFP/BeigiGroundSpaceDimension.lean` against the existing TNLean dependency artifacts.
- `#print axioms MPSTensor.HasBNTSectorData.eventually_parentHamiltonian_groundSpace_finrank_eq` reports only `propext`, `Classical.choice`, and `Quot.sound`.
- `python3 scripts/blueprint_lean_sync.py --ci --warn-missing-blueprint --changed-files TNLean/MPS/RFP/BeigiGroundSpaceDimension.lean --diff-base origin/main`.
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main --ci`.
- Proof-integrity scan, line-length check, and `git diff --check` pass.
- `leanblueprint checkdecls` could not run locally because the generated `blueprint/lean_decls` file is absent; the repository-native blueprint synchronization check passes.

Closes #4353

Advances #2633

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, self-contained Lean proof on existing predicates; documentation and import wiring only, with no auth, security, or runtime behavior changes.
> 
> **Overview**
> Adds **`HasBNTSectorData.eventually_parentHamiltonian_groundSpace_finrank_eq`**, showing that for a sector decomposition with eventually linearly independent BNT matrix-product vectors and the all-chain NNCPH ground-space spanning hypothesis, **`dim ker H₂⁽ᴺ⁾` equals `basisCount` for all sufficiently large `N`**—the eventual degeneracy constancy Beigi’s classification uses.
> 
> The proof is linear algebra only: spanning identifies the kernel with the span of the basis MPVs, independence is transported through the `NSiteSpace` equivalence, then **`finrank_span_eq_card`**. It does **not** invoke **`Axioms.beigi_nncph_to_rfp`** or normality.
> 
> Also wires the new RFP module into the stable root import, adds the matching Chapter 13 blueprint theorem, and updates the NNCPH paper-gap note so eventual dimension stability is recorded as proved while sector-graph classification remains open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12397fd7b736dcf12f5e435c595ecd4b662cc5a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->