### PR TITLE
feat(MPS/MPDO): assemble conditional diagonal cut estimate

### DIFF
--- a/TNLean/MPS/MPDO/DiagonalCutRank.lean
+++ b/TNLean/MPS/MPDO/DiagonalCutRank.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.Defs
+import TNLean.Entropy.ClassicalMutualInformation
 import Mathlib.LinearAlgebra.Matrix.Rank
 
 /-!
@@ -19,8 +20,8 @@ in Proposition 4.5 of arXiv:1606.00608.  Combined with Theorem 4.1 of
 arXiv:1704.06507, it gives the stronger classical estimate
 $I(X:Y) \leq 2\log D$.  The information-versus-rank theorem is formalized in
 `TNLean.Entropy.ClassicalMutualInformation`; the scalar normalization and
-real-to-complex rank comparison needed for the MPO corollary are not proved in
-this file.
+real-to-complex rank comparison needed for the MPO corollary are handled below,
+with the latter retained as an explicit hypothesis.
 
 ## Main definitions
 
@@ -32,6 +33,9 @@ this file.
 
 * `MPOTensor.diagonalCutMatrix_rank_le`: the diagonal cut matrix of a periodic
   MPO has rank at most $D^2$.
+* `MPOTensor.diagonalCut_classicalMutualInformation_le_two_log`: normalized
+  real diagonal cut data has mutual information at most $2\log D$ once its
+  real rank is identified with the complex rank of the cut matrix.
 -/
 
 open scoped Matrix ComplexOrder BigOperators
@@ -40,6 +44,19 @@ open Matrix
 namespace Matrix
 
 variable {D : ℕ} {r c : Type*} [Fintype c]
+
+/-- Multiplication by a nonzero real scalar does not change matrix rank. -/
+theorem rank_smul_of_ne_zero_real {a : ℝ} (ha : a ≠ 0) (A : Matrix r c ℝ) :
+    (a • A).rank = A.rank := by
+  have hrange :
+      LinearMap.range (a • A).mulVecLin = LinearMap.range A.mulVecLin := by
+    ext v
+    constructor
+    · rintro ⟨x, rfl⟩
+      exact ⟨a • x, by simp⟩
+    · rintro ⟨x, rfl⟩
+      exact ⟨a⁻¹ • x, by simp [ha]⟩
+  rw [Matrix.rank, Matrix.rank, hrange]
 
 /-- The matrix of trace pairings $(x,y) \mapsto \operatorname{tr}(A_xB_y)$
 between two finite families of square matrices. -/
@@ -104,5 +121,62 @@ theorem diagonalCutMatrix_rank_le (M : MPOTensor d D) (L R : ℕ) :
     simp [diagonalCutMatrix, Matrix.traceMulMatrix, A, B, evalWord_append]
   rw [hfactor]
   exact Matrix.rank_traceMulMatrix_le A B
+
+/-- **Classical diagonal-MPO cut estimate.** Let `W` be the real diagonal
+coefficient matrix of a periodic MPO cut, let `Z > 0` be its total mass, and
+let `P = Z⁻¹ • W` be the normalized joint distribution. If real scalar
+extension preserves the rank of `W`, then the classical mutual information of
+`P` is at most `2 * log D`.
+
+This is the formal assembly of Riazanov--Vyalyi, Theorem 4.1
+(arXiv:1704.06507), with the diagonal cut factorization supporting
+arXiv:1606.00608, Proposition 4.5. The hypotheses `hcut` and `hrank_map` make
+the currently unavailable real-to-complex cut-data bridge explicit; this
+statement does not concern unrestricted quantum mutual information.
+
+**Scope restriction (real-to-complex rank bridge):** The equality of real and
+complex ranks is an explicit hypothesis rather than a consequence of the
+current MPDO API. This remaining bridge is documented in
+`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+theorem diagonalCut_classicalMutualInformation_le_two_log [NeZero D]
+    (M : MPOTensor d D) (L R : ℕ)
+    (W P : Matrix (Fin L → Fin d) (Fin R → Fin d) ℝ) (Z : ℝ)
+    (hP : P.IsJointDistribution) (hZ : 0 < Z)
+    (hnorm : P = Z⁻¹ • W)
+    (hcut : W.map Complex.ofReal = diagonalCutMatrix M L R)
+    (hrank_map : W.rank = (W.map Complex.ofReal).rank) :
+    Entropy.classicalMutualInformation P ≤ 2 * Real.log D := by
+  have hD : (D : ℝ) ≠ 0 := by exact_mod_cast NeZero.ne D
+  have hPrank : P.rank = W.rank := by
+    rw [hnorm, Matrix.rank_smul_of_ne_zero_real (inv_ne_zero hZ.ne')]
+  have hWrank : W.rank ≤ D * D := by
+    rw [hrank_map, hcut]
+    exact diagonalCutMatrix_rank_le M L R
+  have hPrank_pos : 0 < P.rank := by
+    rw [Matrix.rank, Module.finrank_pos_iff_exists_ne_zero]
+    by_contra h
+    push Not at h
+    have hrange : LinearMap.range P.mulVecLin = ⊥ := by
+      ext v
+      simp only [Submodule.mem_bot]
+      constructor
+      · intro hv
+        exact congrArg Subtype.val (h ⟨v, hv⟩)
+      · rintro rfl
+        exact Submodule.zero_mem _
+    have hlin : P.mulVecLin = 0 := LinearMap.range_eq_bot.mp hrange
+    have hPzero : P = 0 := by
+      apply Matrix.toLin'.injective
+      rw [Matrix.toLin'_apply', hlin, map_zero]
+    rw [hPzero] at hP
+    simpa using hP.2
+  calc
+    Entropy.classicalMutualInformation P ≤ Real.log P.rank :=
+      Entropy.classicalMutualInformation_le_log_rank P hP
+    _ ≤ Real.log (D * D) :=
+      Real.log_le_log (by exact_mod_cast hPrank_pos) (by exact_mod_cast hPrank ▸ hWrank)
+    _ = 2 * Real.log D := by
+      rw [Real.log_mul hD hD]
+      ring
 
 end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
@@ -987,6 +987,20 @@
     factors $P$ through the $D^2$-dimensional space indexed by pairs $(a,b)$.
 \end{proof}
 
+\begin{lemma}[Rank under real normalization]
+    \label{lem:matrix_rank_real_smul}
+    \lean{Matrix.rank_smul_of_ne_zero_real}
+    \leanok
+    Let $A$ be a finite real matrix and let $a\neq0$.  Then
+    \[
+      \operatorname{rank}_{\R}(aA)=\operatorname{rank}_{\R}A.
+    \]
+\end{lemma}
+\begin{proof}\leanok
+    Multiplication by $a$ identifies the column spaces, with inverse given by
+    multiplication by $a^{-1}$.
+\end{proof}
+
 \begin{definition}[Joint probability distribution and marginals]
     \label{def:finite_joint_distribution_marginals}
     \lean{Matrix.IsJointDistribution,
@@ -1103,6 +1117,39 @@
     $\operatorname{rank}_{\R}P$ nonzero rows.  Finally,
     $I(X:Y)\leq H(X)$, and the entropy of a distribution supported on $k$
     points is at most $\log k$.
+\end{proof}
+
+\begin{theorem}[Classical estimate with an explicit rank bridge]
+    \label{thm:mpo_diagonal_cut_classical_mutual_information}
+    \lean{MPOTensor.diagonalCut_classicalMutualInformation_le_two_log}
+    \leanok
+    \uses{thm:mpo_diagonal_cut_rank,
+      thm:classical_mutual_information_le_log_rank,
+      lem:matrix_rank_real_smul}
+    Let $D\geq1$, and let $W$ be a real diagonal coefficient matrix across a
+    periodic cut of an MPO with bond dimension $D$.  Suppose its
+    complexification is the cut matrix $P^{\C}$ from
+    Theorem~\ref{thm:mpo_diagonal_cut_rank} and
+    \[
+      \operatorname{rank}_{\R}W=\operatorname{rank}_{\C}P^{\C}.
+    \]
+    If $Z>0$ and $P=Z^{-1}W$ is a joint probability distribution, then
+    \[
+      I(X:Y)_P\leq2\log D.
+    \]
+    The rank equality is an explicit scope restriction; its derivation from
+    the current diagonal-cut data remains open.
+\end{theorem}
+\begin{proof}\leanok
+    Normalization does not change real rank by
+    Lemma~\ref{lem:matrix_rank_real_smul}.  The explicit rank bridge and
+    Theorem~\ref{thm:mpo_diagonal_cut_rank} therefore give
+    \[
+      \operatorname{rank}_{\R}P\leq D^2.
+    \]
+    Theorem~\ref{thm:classical_mutual_information_le_log_rank} gives
+    $I(X:Y)_P\leq\log\operatorname{rank}_{\R}P$, and monotonicity of the
+    logarithm gives the result.
 \end{proof}
 
 \begin{remark}[Boundedness of the mutual information]

--- a/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
@@ -203,9 +203,15 @@ The rank factorization is formalized.
 \doclink{TNLean/MPS/MPDO/DiagonalCutRank}.}
 The information-versus-rank theorem of Riazanov--Vyalyi is formalized by
 \leanid{Entropy.classicalMutualInformation_le_log_rank} in
-\doclink{TNLean/Entropy/ClassicalMutualInformation}.  The remaining formal
-assembly of the diagonal-MPO estimate requires the scalar-normalization step
-and the comparison between real and complex matrix rank.
+\doclink{TNLean/Entropy/ClassicalMutualInformation}.  Real scalar normalization
+preserves rank by \leanid{Matrix.rank_smul_of_ne_zero_real}.  The conditional
+assembly, with the real-to-complex rank equality stated explicitly, is
+\leanid{MPOTensor.diagonalCut_classicalMutualInformation_le_two_log}; both are
+in \doclink{TNLean/MPS/MPDO/DiagonalCutRank}.  The remaining unconditional
+diagonal-MPO step is to construct the real cut matrix from positivity and
+diagonality and prove that its real rank equals the complex rank of its scalar
+extension.  The conditional theorem does not assert that this bridge follows
+from the current MPDO interface.
 
 \section{What the rank-three separation establishes}
 


### PR DESCRIPTION
## Summary

- prove that nonzero real scalar normalization preserves ordinary matrix rank
- assemble the classical diagonal-cut estimate `I(X:Y) ≤ 2 log D` from the Riazanov--Vyalyi rank bound and the existing complex cut-rank bound
- keep the unavailable real-to-complex rank bridge explicit in the Lean signature, blueprint, and paper-gap verdict

## Mathematical scope

This is a conditional milestone toward #4348, not the unrestricted diagonal-MPDO corollary and not the quantum claim in #4242.

The theorem takes explicit data:

- a real unnormalized cut matrix `W`
- a joint distribution `P` with `P = Z⁻¹ • W` and `Z > 0`
- an equality identifying `W.map Complex.ofReal` with `MPOTensor.diagonalCutMatrix`
- the explicit bridge `rankℝ W = rankℂ (W.map Complex.ofReal)`

It proves `Entropy.classicalMutualInformation P ≤ 2 * Real.log D`. The real scalar-normalization step is discharged internally. Constructing `W` from diagonal positive MPDO data and proving the real-to-complex rank equality remain open, so this PR deliberately does not close #4348.

## Source and faithfulness

- arXiv:1704.06507, Theorem 4.1
- arXiv:1606.00608, Proposition 4.5 and lines 801–806
- `docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`

The blueprint calls the result a classical estimate with an explicit rank bridge and states the restriction verbatim. The Lean docstring carries a matching scope-restriction marker.

## Validation

- `lake build TNLean.MPS.MPDO.DiagonalCutRank` — passed (2443 jobs)
- `lake env lean TNLean/MPS/MPDO/DiagonalCutRank.lean` — passed on the rebased head
- blueprint sync and changed-declaration reverse coverage — passed
- `leanblueprint web` — passed
- reader-facing prose and `git diff --check` — passed
- proof-integrity scan — no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast`
- merge-tree against current `origin/main` — conflict-free

A cold isolated `lake build TNLean` reached 8837/9600 jobs with the changed module already built, then was stopped in unrelated late PEPS imports. Local `checkdecls` could not load a complete coherent root import from the isolated or primary caches; required CI is the clean full-build and declaration-check gate.

Advances #4348.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to formal Lean proofs and documentation for a conditional result; no runtime, auth, or data-path behavior is affected. Residual risk is mathematical scope only (the theorem does not close the unconditional diagonal-MPDO corollary until the rank bridge is proved).
> 
> **Overview**
> This PR completes the **conditional** classical diagonal-MPO mutual-information estimate: for normalized real cut data `P = Z⁻¹ • W` tied to `diagonalCutMatrix`, it proves `I(X:Y) ≤ 2 log D` once real rank matches complex rank after `Complex.ofReal`.
> 
> **Lean:** New `Matrix.rank_smul_of_ne_zero_real` shows nonzero real scaling does not change matrix rank. New `MPOTensor.diagonalCut_classicalMutualInformation_le_two_log` chains Riazanov–Vyalyi (`classicalMutualInformation_le_log_rank`), normalization rank invariance, and the existing `diagonalCutMatrix_rank_le` bound; hypotheses `hcut` and `hrank_map` keep the real-to-complex cut bridge explicit rather than derived from the current MPDO API.
> 
> **Docs:** Blueprint adds the normalization rank lemma and the conditional classical estimate theorem; the paper-gap note records that scalar normalization is formalized and that constructing `W` from diagonal positive data plus proving rank equality remains open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f72001d7fe5b25b1f0164e3593331e41e5f69e2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->