### PR TITLE
feat(Channel/FixedPoint): prove Wolf Theorem 6.14

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -673,7 +673,6 @@ import TNLean.Wielandt.RectangularSpan.Universality
 import TNLean.Wielandt.RankOne.BoundedWord
 import TNLean.Wielandt.RankOne.ExtractionFull
 import TNLean.Wielandt.SpanGrowth.CumulativeToWordSpan
-
 import TNLean.Channel.Peripheral.CyclicDecomposition
 import TNLean.Channel.Peripheral.Cycles
 import TNLean.Channel.Peripheral.MultiCycleDecomposition

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -218,6 +218,7 @@ import TNLean.Channel.FixedPoint.MaximalSupportBasic
 import TNLean.Channel.FixedPoint.MaximalSupport
 import TNLean.Channel.FixedPoint.StationarySupportRestriction
 import TNLean.Channel.FixedPoint.SupportCompressedDensityBlocks
+import TNLean.Channel.FixedPoint.WolfTheorem614
 import TNLean.Channel.FixedPoint.StationarySupport
 import TNLean.Channel.FixedPoint.WedderburnDecomp
 import TNLean.Channel.FixedPoint.WeightedCornerFixedPoints

--- a/TNLean/Algebra/MatrixGramUnitary.lean
+++ b/TNLean/Algebra/MatrixGramUnitary.lean
@@ -5,6 +5,8 @@ Authors: Sirui Lu
 -/
 import Mathlib.Analysis.InnerProductSpace.Adjoint
 import Mathlib.Analysis.InnerProductSpace.PiL2
+import Mathlib.Data.Matrix.Block
+import Mathlib.Logic.Equiv.Fin.Basic
 
 /-!
 # Gram equality and unitary extension for rectangular matrices
@@ -102,6 +104,70 @@ theorem exists_unitary_mul_eq_of_conjTranspose_mul_eq
     exact hU_eq v
   refine ⟨⟨U_mat, Matrix.mem_unitaryGroup_iff'.2 hU_unitary⟩, ?_⟩
   exact hU_mat_eq.symm
+
+/-- An isometric inclusion can be completed to an ambient unitary so that its
+matrix sandwich is a single complementary zero block followed by the original
+matrix.
+
+This is the finite-dimensional unitary-extension step used in Wolf,
+Theorem 6.14 and Equation (6.63); local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1483--1494. -/
+theorem exists_unitary_zero_extension_eq
+    {D n : ℕ} (W : Matrix (Fin D) (Fin n) ℂ) (hW : Wᴴ * W = 1) :
+    ∃ (e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D)
+      (U : Matrix.unitaryGroup (Fin D) ℂ),
+      ∀ A : Matrix (Fin n) (Fin n) ℂ,
+        W * A * Wᴴ =
+          (U : Matrix (Fin D) (Fin D) ℂ) *
+            Matrix.reindex e₀ e₀ (Matrix.fromBlocks 0 0 0 A) *
+              star (U : Matrix (Fin D) (Fin D) ℂ) := by
+  classical
+  have hinj : Function.Injective (Matrix.mulVecLin W) := by
+    intro x y hxy
+    have hxy' : W.mulVec x = W.mulVec y := hxy
+    have h1 : (Wᴴ * W).mulVec x = (Wᴴ * W).mulVec y := by
+      rw [← Matrix.mulVec_mulVec, ← Matrix.mulVec_mulVec]
+      exact congrArg _ hxy'
+    simpa [hW] using h1
+  have hnD : n ≤ D := by
+    simpa using LinearMap.finrank_le_finrank_of_injective hinj
+  let e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D :=
+    finSumFinEquiv |>.trans (finCongr (Nat.sub_add_cancel hnD))
+  let j : Fin n → Fin D := fun i ↦ e₀ (Sum.inr i)
+  let J : Matrix (Fin D) (Fin n) ℂ :=
+    (1 : Matrix (Fin D) (Fin D) ℂ).submatrix id j
+  have hJ : Jᴴ * J = 1 := by
+    rw [show Jᴴ = (1 : Matrix (Fin D) (Fin D) ℂ).submatrix j id by
+      simp [J]]
+    change
+      (1 : Matrix (Fin D) (Fin D) ℂ).submatrix j (Equiv.refl (Fin D)) *
+          (1 : Matrix (Fin D) (Fin D) ℂ).submatrix (Equiv.refl (Fin D)) j = 1
+    rw [Matrix.submatrix_mul_equiv]
+    simpa only [Matrix.one_mul] using
+      Matrix.submatrix_one (α := ℂ) j fun x y h ↦ by
+        have h' : Sum.inr x = Sum.inr y := e₀.injective (by simpa [j] using h)
+        exact Sum.inr.inj h'
+  obtain ⟨U, hWU⟩ :=
+    Matrix.exists_unitary_mul_eq_of_conjTranspose_mul_eq W J (hW.trans hJ.symm)
+  have hJAJ (A : Matrix (Fin n) (Fin n) ℂ) :
+      J * A * Jᴴ =
+        Matrix.reindex e₀ e₀ (Matrix.fromBlocks 0 0 0 A) := by
+    ext i k
+    rw [← e₀.apply_symm_apply i, ← e₀.apply_symm_apply k]
+    generalize e₀.symm i = i'
+    generalize e₀.symm k = k'
+    rcases i' with i' | i' <;> rcases k' with k' | k' <;>
+      simp [J, j, Matrix.mul_apply, Matrix.reindex_apply, Matrix.one_apply]
+  refine ⟨e₀, U, fun A ↦ ?_⟩
+  rw [hWU, Matrix.conjTranspose_mul]
+  simp only [Matrix.star_eq_conjTranspose, Matrix.mul_assoc]
+  calc
+    (U : Matrix (Fin D) (Fin D) ℂ) *
+          (J * (A * (Jᴴ * (U : Matrix (Fin D) (Fin D) ℂ)ᴴ))) =
+        (U : Matrix (Fin D) (Fin D) ℂ) *
+          ((J * A * Jᴴ) * (U : Matrix (Fin D) (Fin D) ℂ)ᴴ) := by
+      simp only [Matrix.mul_assoc]
+    _ = _ := by rw [hJAJ]
 
 /-- A matrix whose Gram matrix is a positive multiple of the identity becomes
 unitary after dividing by the square root of the multiple.  This is the

--- a/TNLean/Algebra/MatrixGramUnitary.lean
+++ b/TNLean/Algebra/MatrixGramUnitary.lean
@@ -16,6 +16,10 @@ matrices: two rectangular matrices with the same Gram matrix differ by a
 unitary matrix on the codomain.  The proof passes through the corresponding
 linear maps on Euclidean spaces and extends the induced isometry between their
 ranges to the ambient finite-dimensional Hilbert space.
+
+It also applies this extension to an isometric rectangular matrix, realizing
+its compression as a unitary conjugate of the corresponding square matrix
+with one complementary zero block.
 -/
 
 open scoped Matrix InnerProductSpace

--- a/TNLean/Channel/FixedPoint/DirectSumBlockRetraction.lean
+++ b/TNLean/Channel/FixedPoint/DirectSumBlockRetraction.lean
@@ -205,8 +205,10 @@ Appendix C.4, lines 1980--1995. The hypotheses for the particular sector map
 in that argument are not asserted here.
 
 **Scope restriction (full support):** The fixed family is positive definite on
-every summand. The support reduction and complementary zero summand of the
-general theorem remain open in
+every summand. The maximal-support reduction and complementary zero summand
+for a full matrix algebra are completed in
+`TNLean.Channel.FixedPoint.WolfTheorem614`; the present direct-sum theorem
+retains its explicit full-support hypothesis. See
 `docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex`. -/
 theorem IsPositiveDirectSumMap.exists_block_densities_of_fixedPoints
     {T : (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ]

--- a/TNLean/Channel/FixedPoint/SupportCompressedDensityBlocks.lean
+++ b/TNLean/Channel/FixedPoint/SupportCompressedDensityBlocks.lean
@@ -167,8 +167,8 @@ is the full-support step in the proof of Wolf, Theorem 6.14; local source
 
 **Scope restriction (maximal-support compression):** This theorem describes
 the fixed points of the compressed map with positive definite density blocks.
-It does not yet transport the description to the original space with its
-complementary zero summand.  This restriction is documented in
+The transport to the original space with its complementary zero summand is
+completed in `TNLean.Channel.FixedPoint.WolfTheorem614`.  This restriction is documented in
 `docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex`.
 
 The theorem records only the fixed-point description.  The corresponding

--- a/TNLean/Channel/FixedPoint/SupportCompressedDensityBlocks.lean
+++ b/TNLean/Channel/FixedPoint/SupportCompressedDensityBlocks.lean
@@ -186,6 +186,10 @@ theorem IsPositiveMap.exists_block_densities_of_maximalSupportCompression
         (∃ ρfull : Matrix (Fin n) (Fin n) ℂ,
           ρfull.PosDef ∧
             IsPositiveMap.stationarySupportCompression T V ρfull = ρfull) ∧
+        (∀ B : MatD, T B = B ↔
+          ∃ X : Matrix (Fin n) (Fin n) ℂ,
+            IsPositiveMap.stationarySupportCompression T V X = X ∧
+              B = V * X * Vᴴ) ∧
         ∃ (K : ℕ) (d m : Fin K → ℕ)
           (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
           (U : Matrix (Fin n) (Fin n) ℂ)
@@ -199,7 +203,8 @@ theorem IsPositiveMap.exists_block_densities_of_maximalSupportCompression
                   (Matrix.blockDiagonal' fun k ↦ σ k ⊗ₖ X k) := by
   dsimp only
   obtain ⟨hρ₀, n, V, hρ₀fix, hV, hVrange, hpositive, htrace, _,
-      ⟨ρfull, hρfull, hρfullFix⟩, _⟩ := hT.exists_maximalSupportCompression hTP
+      ⟨ρfull, hρfull, hρfullFix⟩, hambientFixed⟩ :=
+    hT.exists_maximalSupportCompression hTP
   have hcompressedSchwarz :
       IsSchwarzMap (Matrix.traceAdjointMap
         (IsPositiveMap.stationarySupportCompression T V)) :=
@@ -242,5 +247,5 @@ theorem IsPositiveMap.exists_block_densities_of_maximalSupportCompression
       exact hprincipal
     exact hblock.left_of_kronecker_of_trace_eq_one (hσtrace k)
   exact ⟨hρ₀, n, V, hρ₀fix, hV, hVrange,
-    ⟨ρfull, hρfull, hρfullFix⟩,
+    ⟨ρfull, hρfull, hρfullFix⟩, hambientFixed,
     K, d, m, e, U, σ, hU, hd, hm, hσ, hσtrace, hfixed⟩

--- a/TNLean/Channel/FixedPoint/SupportCompressedDensityBlocks.lean
+++ b/TNLean/Channel/FixedPoint/SupportCompressedDensityBlocks.lean
@@ -168,8 +168,8 @@ is the full-support step in the proof of Wolf, Theorem 6.14; local source
 **Scope restriction (maximal-support compression):** This theorem describes
 the fixed points of the compressed map with positive definite density blocks.
 The transport to the original space with its complementary zero summand is
-completed in `TNLean.Channel.FixedPoint.WolfTheorem614`.  This restriction is documented in
-`docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex`.
+completed in `TNLean.Channel.FixedPoint.WolfTheorem614`.  This restriction is
+documented in `docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex`.
 
 The theorem records only the fixed-point description.  The corresponding
 formula for the mean ergodic projection is supplied by

--- a/TNLean/Channel/FixedPoint/TraceAdjointDensityBlocks.lean
+++ b/TNLean/Channel/FixedPoint/TraceAdjointDensityBlocks.lean
@@ -96,9 +96,10 @@ proof of Theorem 6.14 and Equation (6.63); local sources
 and `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1483--1494.
 
 **Scope restriction (full support):** The fixed point is positive definite on
-the ambient space.  The positive-definite reduction of the block densities
-and the complementary zero summand required for the general theorem remain
-open in `docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex`.
+the ambient space.  The subsequent maximal-support reduction and the
+complementary zero summand are completed in
+`TNLean.Channel.FixedPoint.WolfTheorem614`; their construction is recorded in
+`docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex`.
 
 **Convention (factor order):** Wolf writes the algebra and density factors in
 the opposite order.  Each summand is indexed by

--- a/TNLean/Channel/FixedPoint/WolfTheorem614.lean
+++ b/TNLean/Channel/FixedPoint/WolfTheorem614.lean
@@ -71,7 +71,7 @@ theorem IsPositiveMap.exists_fixedPoints_densityBlocks_with_zero
   have hUcRight : Uc * star Uc = 1 := Matrix.mem_unitaryGroup_iff.mp hUc
   let W : Matrix (Fin D) (Fin n) ℂ := V * Uc
   have hWH : Wᴴ = star Uc * Vᴴ := by
-    simp [W, Matrix.conjTranspose_mul]
+    simp only [W, Matrix.conjTranspose_mul, Matrix.star_eq_conjTranspose]
   have hW : Wᴴ * W = 1 := by
     rw [hWH]
     dsimp only [W]
@@ -103,19 +103,37 @@ theorem IsPositiveMap.exists_fixedPoints_densityBlocks_with_zero
         B = U * Matrix.reindex e₀ e₀ (Matrix.fromBlocks 0 0 0 A) * star U := by
       calc
         B = V * Y * Vᴴ := hBY
-        _ = W * A * Wᴴ := by rw [hYeq, W, hWH]; simp [Matrix.mul_assoc]
+        _ = W * A * Wᴴ := by
+          rw [hYeq]
+          dsimp only [W]
+          simp only [Matrix.conjTranspose_mul, Matrix.star_eq_conjTranspose,
+            Matrix.mul_assoc]
         _ = U * Matrix.reindex e₀ e₀ (Matrix.fromBlocks 0 0 0 A) * star U := by
           simpa only [U] using hzeroExtension A
     refine ⟨X, ?_⟩
-    rw [hBzero]
-    simp [hULeft, Matrix.mul_assoc]
+    change star U * B * U = Matrix.reindex e₀ e₀ (Matrix.fromBlocks 0 0 0 A)
+    calc
+      star U * B * U =
+          star U *
+            (U * Matrix.reindex e₀ e₀ (Matrix.fromBlocks 0 0 0 A) * star U) * U := by
+        rw [hBzero]
+      _ = (star U * U) * Matrix.reindex e₀ e₀
+            (Matrix.fromBlocks 0 0 0 A) * (star U * U) := by
+        simp only [Matrix.mul_assoc]
+      _ = Matrix.reindex e₀ e₀ (Matrix.fromBlocks 0 0 0 A) := by
+        rw [hULeft]
+        simp
   · rintro ⟨X, hBcoord⟩
     let A : Matrix (Fin n) (Fin n) ℂ :=
       Matrix.reindex e e (Matrix.blockDiagonal' fun k ↦ σ k ⊗ₖ X k)
     let Y : Matrix (Fin n) (Fin n) ℂ := Uc * A * star Uc
     have hYcoord : star Uc * Y * Uc = A := by
       dsimp only [Y]
-      simp [hUcLeft, Matrix.mul_assoc]
+      calc
+        star Uc * (Uc * A * star Uc) * Uc =
+            (star Uc * Uc) * A * (star Uc * Uc) := by
+          simp only [Matrix.mul_assoc]
+        _ = A := by rw [hUcLeft]; simp
     have hYfix : IsPositiveMap.stationarySupportCompression T V Y = Y :=
       (hcompressedFixed Y).mpr ⟨X, hYcoord⟩
     have hBeq : B = V * Y * Vᴴ := by
@@ -131,5 +149,8 @@ theorem IsPositiveMap.exists_fixedPoints_densityBlocks_with_zero
         B = U * Matrix.reindex e₀ e₀ (Matrix.fromBlocks 0 0 0 A) * star U := hBzero
         _ = W * A * Wᴴ := by
           simpa only [U] using (hzeroExtension A).symm
-        _ = V * Y * Vᴴ := by rw [Y, W, hWH]; simp [Matrix.mul_assoc]
+        _ = V * Y * Vᴴ := by
+          dsimp only [Y, W]
+          simp only [Matrix.conjTranspose_mul, Matrix.star_eq_conjTranspose,
+            Matrix.mul_assoc]
     exact (hambientFixed B).mpr ⟨Y, hYfix, hBeq⟩

--- a/TNLean/Channel/FixedPoint/WolfTheorem614.lean
+++ b/TNLean/Channel/FixedPoint/WolfTheorem614.lean
@@ -1,0 +1,135 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.MatrixGramUnitary
+import TNLean.Channel.FixedPoint.SupportCompressedDensityBlocks
+
+/-!
+# Fixed points of positive trace-preserving maps
+
+This file proves the density-block classification of the fixed points of a
+positive trace-preserving map whose trace adjoint satisfies the Schwarz
+inequality.  Restriction to maximal stationary support gives the full-support
+density blocks.  A unitary extension of the support isometry places the
+orthogonal complement in one zero summand.
+
+## Reference
+
+* M. Wolf, *Quantum Channels & Operations: Guided Tour*, Theorem 6.14 and
+  Equation (6.63); local source
+  `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1469--1494.
+-/
+
+open scoped Matrix Matrix.Norms.Frobenius ComplexOrder MatrixOrder Kronecker
+open Matrix
+
+noncomputable section
+
+variable {D : ℕ}
+
+local notation "MatD" => Matrix (Fin D) (Fin D) ℂ
+
+/-- **Wolf Theorem 6.14, Equation (6.63).** Let `T` be positive and trace
+preserving, and suppose that its trace adjoint satisfies the Schwarz
+inequality.  Then, after a unitary change of basis, the fixed-point space is
+one zero summand followed by density-weighted full matrix blocks.  Every
+density matrix is positive definite and has trace one.
+
+The formalization orders each nonzero summand as
+`ℂ^{m k} ⊗ ℂ^{d k}`, so its matrices are `σ k ⊗ₖ X k`.  This differs from
+Wolf's displayed order only by the canonical interchange of the two tensor
+factors.
+
+Source: Wolf, *Quantum Channels & Operations: Guided Tour*, Theorem 6.14 and
+Equation (6.63); local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1469--1494. -/
+theorem IsPositiveMap.exists_fixedPoints_densityBlocks_with_zero
+    {T : MatD →ₗ[ℂ] MatD} (hT : IsPositiveMap T)
+    (hTP : IsTracePreservingMap T)
+    (hSchwarz : IsSchwarzMap (Matrix.traceAdjointMap T)) :
+    ∃ (n K : ℕ) (d m : Fin K → ℕ)
+      (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin n)
+      (e₀ : (Fin (D - n) ⊕ Fin n) ≃ Fin D)
+      (U : Matrix (Fin D) (Fin D) ℂ)
+      (σ : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ),
+      U ∈ Matrix.unitaryGroup (Fin D) ℂ ∧
+        (∀ k, 0 < d k) ∧ (∀ k, 0 < m k) ∧
+        (∀ k, (σ k).PosDef) ∧ (∀ k, (σ k).trace = 1) ∧
+        ∀ B : MatD, T B = B ↔
+          ∃ X : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ,
+            star U * B * U = Matrix.reindex e₀ e₀
+              (Matrix.fromBlocks 0 0 0
+                (Matrix.reindex e e
+                  (Matrix.blockDiagonal' fun k ↦ σ k ⊗ₖ X k))) := by
+  obtain ⟨_, n, V, _, hV, _, _, hambientFixed, hblocks⟩ :=
+    hT.exists_block_densities_of_maximalSupportCompression hTP hSchwarz
+  obtain ⟨K, d, m, e, Uc, σ, hUc, hd, hm, hσ, hσtrace, hcompressedFixed⟩ :=
+    hblocks
+  have hUcLeft : star Uc * Uc = 1 := Matrix.mem_unitaryGroup_iff'.mp hUc
+  have hUcRight : Uc * star Uc = 1 := Matrix.mem_unitaryGroup_iff.mp hUc
+  let W : Matrix (Fin D) (Fin n) ℂ := V * Uc
+  have hWH : Wᴴ = star Uc * Vᴴ := by
+    simp [W, Matrix.conjTranspose_mul]
+  have hW : Wᴴ * W = 1 := by
+    rw [hWH]
+    dsimp only [W]
+    calc
+      star Uc * Vᴴ * (V * Uc) = star Uc * (Vᴴ * V) * Uc := by
+        simp only [Matrix.mul_assoc]
+      _ = star Uc * Uc := by rw [hV]; simp
+      _ = 1 := hUcLeft
+  obtain ⟨e₀, Uunitary, hzeroExtension⟩ :=
+    Matrix.exists_unitary_zero_extension_eq W hW
+  let U : Matrix (Fin D) (Fin D) ℂ := Uunitary
+  have hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ := Uunitary.property
+  have hULeft : star U * U = 1 := Matrix.mem_unitaryGroup_iff'.mp hU
+  have hURight : U * star U = 1 := Matrix.mem_unitaryGroup_iff.mp hU
+  refine ⟨n, K, d, m, e, e₀, U, σ, hU, hd, hm, hσ, hσtrace, fun B ↦ ?_⟩
+  constructor
+  · intro hBfix
+    obtain ⟨Y, hYfix, hBY⟩ := (hambientFixed B).mp hBfix
+    obtain ⟨X, hYcoord⟩ := (hcompressedFixed Y).mp hYfix
+    let A : Matrix (Fin n) (Fin n) ℂ :=
+      Matrix.reindex e e (Matrix.blockDiagonal' fun k ↦ σ k ⊗ₖ X k)
+    have hYeq : Y = Uc * A * star Uc := by
+      calc
+        Y = (Uc * star Uc) * Y * (Uc * star Uc) := by rw [hUcRight]; simp
+        _ = Uc * (star Uc * Y * Uc) * star Uc := by
+          simp only [Matrix.mul_assoc]
+        _ = Uc * A * star Uc := by rw [hYcoord]
+    have hBzero :
+        B = U * Matrix.reindex e₀ e₀ (Matrix.fromBlocks 0 0 0 A) * star U := by
+      calc
+        B = V * Y * Vᴴ := hBY
+        _ = W * A * Wᴴ := by rw [hYeq, W, hWH]; simp [Matrix.mul_assoc]
+        _ = U * Matrix.reindex e₀ e₀ (Matrix.fromBlocks 0 0 0 A) * star U := by
+          simpa only [U] using hzeroExtension A
+    refine ⟨X, ?_⟩
+    rw [hBzero]
+    simp [hULeft, Matrix.mul_assoc]
+  · rintro ⟨X, hBcoord⟩
+    let A : Matrix (Fin n) (Fin n) ℂ :=
+      Matrix.reindex e e (Matrix.blockDiagonal' fun k ↦ σ k ⊗ₖ X k)
+    let Y : Matrix (Fin n) (Fin n) ℂ := Uc * A * star Uc
+    have hYcoord : star Uc * Y * Uc = A := by
+      dsimp only [Y]
+      simp [hUcLeft, Matrix.mul_assoc]
+    have hYfix : IsPositiveMap.stationarySupportCompression T V Y = Y :=
+      (hcompressedFixed Y).mpr ⟨X, hYcoord⟩
+    have hBeq : B = V * Y * Vᴴ := by
+      have hBzero :
+          B = U * Matrix.reindex e₀ e₀ (Matrix.fromBlocks 0 0 0 A) * star U := by
+        calc
+          B = (U * star U) * B * (U * star U) := by rw [hURight]; simp
+          _ = U * (star U * B * U) * star U := by
+            simp only [Matrix.mul_assoc]
+          _ = U * Matrix.reindex e₀ e₀ (Matrix.fromBlocks 0 0 0 A) * star U := by
+            rw [hBcoord]
+      calc
+        B = U * Matrix.reindex e₀ e₀ (Matrix.fromBlocks 0 0 0 A) * star U := hBzero
+        _ = W * A * Wᴴ := by
+          simpa only [U] using (hzeroExtension A).symm
+        _ = V * Y * Vᴴ := by rw [Y, W, hWH]; simp [Matrix.mul_assoc]
+    exact (hambientFixed B).mpr ⟨Y, hYfix, hBeq⟩

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -220,8 +220,10 @@ This is the algebra step after the faithful invariant weight has been chosen.
 The source theorem begins with an arbitrary full-rank fixed point and invokes
 its proposition on positive fixed points to obtain that weight.  The
 full-rank-to-positive-definite reduction theorem remains open.  The explicit
-block realization from Equation (1.39), including the complementary zero
-summand, is completed in `TNLean.Channel.FixedPoint.WolfTheorem614`.
+trace-adjoint block realization from Equation (1.39) also remains open at this
+level of generality.  The downstream Schrödinger-picture density-block
+classification and its complementary zero summand are completed in
+`TNLean.Channel.FixedPoint.WolfTheorem614`.
 
 In `TNLean.Channel.FixedPoint.Algebra`:
 

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -293,7 +293,7 @@ where the compressed map is unital with a positive-definite fixed point, applies
 Wolf Theorem 6.12 there (`Kraus.adjointFixedPointsStarSubalgebra`), and transports
 the `*`-algebra structure back along the compression isomorphism.
 
-### Wolf Theorem 6.14 (Wedderburn decomposition of fixed-point algebra) — PARTIALLY FORMALIZED
+### Wolf Theorem 6.14 (density-block form of fixed points) — FORMALIZED
 
 The general finite-dimensional convergence argument is provided by
 `LinearMap.HasBoundedOrbits.tendsto_birkhoffAverage_meanErgodicProjection` in
@@ -310,9 +310,10 @@ well.
 
 The trace-pairing adjoint step is now complete.  The adjoint of the
 mean-ergodic projection is a positive unital idempotent retraction onto the
-fixed-point space of the adjoint endomorphism.  The remaining step for
-Theorem 6.14 begins by combining this retraction with the full-support
-star-algebra description.
+fixed-point space of the adjoint endomorphism.  Combining this retraction with
+the full-support star-algebra description, restricting to maximal stationary
+support, and adjoining the complementary zero summand gives the full statement
+of Theorem 6.14 and Equation (6.63).
 
 In `TNLean.Channel.FixedPoint.StationarySupportRestriction`:
 
@@ -352,6 +353,32 @@ In `TNLean.Channel.FixedPoint.TraceAdjointDensityBlocks`:
   `U (⊕_k σ_k ⊗ tr_{m_k}((U† B U)_{kk})) U†`, and the fixed-point space is
   `U (⊕_k σ_k ⊗ M_{d_k}(ℂ)) U†`.
 
+In `TNLean.Channel.FixedPoint.SupportCompressedDensityBlocks`:
+
+* `IsPositiveMap.exists_block_densities_of_maximalSupportCompression` — the
+  maximal-support compression has positive-definite density blocks, and its
+  fixed points correspond exactly to the ambient fixed points carried by the
+  support isometry.
+
+In `TNLean.Algebra.MatrixGramUnitary`:
+
+* `Matrix.exists_unitary_zero_extension_eq` — an isometric inclusion extends
+  to an ambient unitary that identifies every compressed matrix with one
+  complementary zero block followed by that matrix.
+
+In `TNLean.Channel.FixedPoint.WolfTheorem614`:
+
+* `IsPositiveMap.exists_fixedPoints_densityBlocks_with_zero` — for every
+  positive trace-preserving matrix endomorphism whose trace adjoint satisfies
+  the Schwarz inequality, the fixed-point space is the unitary conjugate of
+  one complementary zero summand followed by positive-definite trace-one
+  density blocks, exactly as in Wolf Equation (6.63).
+
+In `TNLean.Channel.FixedPoint.DirectSumBlockRetraction`:
+
+* `Matrix.IsPositiveDirectSumMap.exists_block_densities_of_fixedPoints` — the
+  full-support consequence for a finite direct sum of full matrix algebras.
+
 In `TNLean.Channel.FixedPoint.WedderburnDecomp`:
 
 * `Kraus.starSubalgebra_isSemisimpleRing` — every finite-dimensional
@@ -387,12 +414,11 @@ positive semidefinite fixed point):
   corner-restricted set only; extending by zero on the complement does not
   produce ambient fixed points in general.
 
-What is still missing for the full Wolf statement is to apply the full-support
-block theorem to the positive trace-preserving support compression, transport
-the result back to the ambient space, and combine the discarded density
-kernels with the complementary zero block.  Applying the full-support theorem
-to the transported sector channels of arXiv:1606.00608 additionally requires a
-direct-sum version or an extension through the block-diagonal embedding.
+The full Wolf statement is therefore complete.  Its application to the
+transported sector maps of arXiv:1606.00608 is a separate tensor-attached
+problem: one must still prove the channel hypotheses for those maps on the
+whole direct-sum algebras.  This remaining boundary is recorded in
+`docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex`.
 
 ### Wolf Corollary 6.7 (faithful fixed-point conjugation) — FORMALIZED (Kraus case)
 
@@ -475,8 +501,9 @@ In `TNLean.Channel.FixedPoint.ConditionalExpectation`:
 * Numbered theorem: `Kraus.wolf_theorem_6_15_scalar` —
   `TNLean.Channel.WolfChapter6Wrappers`.
 
-The general irreducible case with period `h > 1` requires Wedderburn blocks
-(Wolf Theorem 6.14, issue #27).
+The density-block decomposition required for the general irreducible case with
+period `h > 1` is now supplied by Wolf Theorem 6.14.  The corresponding
+conditional-expectation construction remains to be assembled.
 
 ---
 
@@ -518,8 +545,8 @@ The general irreducible case with period `h > 1` requires Wedderburn blocks
 
 * The remaining **existence direction** — that every trace-preserving positive
   Schwarz map admits a `MultiCycleDecomposition` on its asymptotic image, with
-  the cycles coming from the Wedderburn decomposition of the fixed-point algebra
-  — depends on Wolf Theorem 6.14 (issues #27 / #360) and is left to future work.
+  the cycles coming from the now-formalized density-block decomposition of the
+  fixed-point space — is left to future work.
 
 ---
 

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -219,8 +219,9 @@ In `TNLean.Channel.FixedPoint.AbstractAlgebra`:
 This is the algebra step after the faithful invariant weight has been chosen.
 The source theorem begins with an arbitrary full-rank fixed point and invokes
 its proposition on positive fixed points to obtain that weight.  The
-full-rank-to-positive-definite reduction theorem and the explicit block
-realization from Equation (1.39) remain open.
+full-rank-to-positive-definite reduction theorem remains open.  The explicit
+block realization from Equation (1.39), including the complementary zero
+summand, is completed in `TNLean.Channel.FixedPoint.WolfTheorem614`.
 
 In `TNLean.Channel.FixedPoint.Algebra`:
 

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -3269,6 +3269,60 @@ transfers the support.
     $\operatorname{tr}(X_k)>0$, it follows that $\sigma_k>0$.
 \end{proof}
 
+\begin{theorem}[Fixed points of trace-preserving maps]%
+    \label{thm:wolf_6_14}
+    \lean{IsPositiveMap.exists_fixedPoints_densityBlocks_with_zero,
+        Matrix.exists_unitary_zero_extension_eq}
+    \leanok
+    \uses{thm:maximal_support_compression_density_blocks}
+    Let $T:\MN{D}\to\MN{D}$ be positive and trace preserving, and suppose
+    that $T^*$ satisfies the Schwarz inequality.  There are positive integers
+    $d_k,m_k$, positive definite density matrices
+    $\sigma_k\in\MN{m_k}$, a nonnegative integer $d_0$, and a unitary $U$
+    associated with a decomposition
+    \[
+        \mathbb C^D=\mathbb C^{d_0}\oplus
+          \bigoplus_k\mathbb C^{m_k}\otimes\mathbb C^{d_k}
+    \]
+    such that
+    \[
+        \operatorname{Fix}(T)
+          =U\left(0_{d_0}\oplus
+            \bigoplus_k\sigma_k\otimes\MN{d_k}\right)U^*.
+    \]
+    This is \cite[Theorem~6.14 and Equation~(6.63)]{Wolf2012Quantum}.
+    The two tensor factors are interchanged from the displayed convention in
+    the reference; the interchange is a unitary change of basis on each
+    summand.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:maximal_support_compression_density_blocks}
+    Let $V:\mathbb C^n\to\mathbb C^D$ be the maximal-support isometry and
+    let $U_c$ be the unitary in the density-block description of the
+    compressed fixed points.  The fixed-space equivalence gives
+    \[
+        \operatorname{Fix}(T)
+          =VU_c\left(\bigoplus_k
+              \sigma_k\otimes\MN{d_k}\right)U_c^*V^*.
+    \]
+    Put $W=VU_c$.  Then $W^*W=\Id_n$.  Compare $W$ with the canonical
+    inclusion of $\mathbb C^n$ as the second summand of
+    $\mathbb C^{D-n}\oplus\mathbb C^n$.  The two inclusions have the same
+    Gram matrix, so the finite-dimensional unitary extension theorem gives
+    an ambient unitary $U$ carrying the canonical inclusion to $W$.  Hence,
+    for every $A\in\MN{n}$,
+    \[
+        WAW^*=U(0_{D-n}\oplus A)U^*.
+    \]
+    Substituting the compressed density-block description for $A$ proves the
+    assertion.  The first block is the whole orthogonal complement of the
+    maximal stationary support, and is therefore one zero summand.  Positive
+    definiteness and trace one for every $\sigma_k$ are supplied by
+    Theorem~\ref{thm:maximal_support_compression_density_blocks}.
+\end{proof}
+
 \begin{theorem}[Conjugation by the square root at a fixed point of maximal support]%
     \label{thm:maximalSupport_weightedCorner}
     \lean{Kraus.exists_maximalSupport_weightedCorner_sqrt_eq}

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -3271,8 +3271,7 @@ transfers the support.
 
 \begin{theorem}[Fixed points of trace-preserving maps]%
     \label{thm:wolf_6_14}
-    \lean{IsPositiveMap.exists_fixedPoints_densityBlocks_with_zero,
-        Matrix.exists_unitary_zero_extension_eq}
+    \lean{IsPositiveMap.exists_fixedPoints_densityBlocks_with_zero}
     \leanok
     \uses{thm:maximal_support_compression_density_blocks}
     Let $T:\MN{D}\to\MN{D}$ be positive and trace preserving, and suppose
@@ -3298,7 +3297,8 @@ transfers the support.
 
 \begin{proof}
     \leanok
-    \uses{thm:maximal_support_compression_density_blocks}
+    \uses{thm:maximal_support_compression_density_blocks,
+        lem:isometric_inclusion_zero_extension}
     Let $V:\mathbb C^n\to\mathbb C^D$ be the maximal-support isometry and
     let $U_c$ be the unitary in the density-block description of the
     compressed fixed points.  The fixed-space equivalence gives

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -3298,7 +3298,7 @@ transfers the support.
 \begin{proof}
     \leanok
     \uses{thm:maximal_support_compression_density_blocks,
-        lem:isometric_inclusion_zero_extension}
+        thm:isometric_inclusion_zero_extension}
     Let $V:\mathbb C^n\to\mathbb C^D$ be the maximal-support isometry and
     let $U_c$ be the unitary in the density-block description of the
     compressed fixed points.  The fixed-space equivalence gives

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -3226,10 +3226,10 @@ transfers the support.
         =U\left(\bigoplus_k \sigma_k\otimes\MN{d_k}\right)U^*.
     \]
     This is the maximal-support application of the full-support step in the
-    proof of \cite[Theorem~6.14]{Wolf2012Quantum}.  This is not the full
-    statement of that theorem: it does not yet transport the displayed
-    decomposition back to the original space and adjoin the complementary
-    zero summand.
+    proof of \cite[Theorem~6.14]{Wolf2012Quantum}.  This intermediate theorem
+    does not itself transport the displayed decomposition back to the original
+    space and adjoin the complementary zero summand; that final step is
+    Theorem~\ref{thm:wolf_6_14}.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch16_channel_representations.tex
+++ b/blueprint/src/chapter/ch16_channel_representations.tex
@@ -1203,8 +1203,8 @@ a common dilation space.
 \begin{proof}\leanok
 \end{proof}
 
-\begin{lemma}[Unitary completion of an isometric inclusion]
-    \label{lem:isometric_inclusion_zero_extension}
+\begin{theorem}[Unitary completion of an isometric inclusion]
+    \label{thm:isometric_inclusion_zero_extension}
     \lean{Matrix.exists_unitary_zero_extension_eq}
     \leanok
     \uses{lem:exists_unitary_mul_eq_of_gram_eq}
@@ -1214,7 +1214,7 @@ a common dilation space.
     \[
         WAW^*=U(0_{D-n}\oplus A)U^*.
     \]
-\end{lemma}
+\end{theorem}
 
 \begin{proof}
     \leanok

--- a/blueprint/src/chapter/ch16_channel_representations.tex
+++ b/blueprint/src/chapter/ch16_channel_representations.tex
@@ -1203,6 +1203,29 @@ a common dilation space.
 \begin{proof}\leanok
 \end{proof}
 
+\begin{lemma}[Unitary completion of an isometric inclusion]
+    \label{lem:isometric_inclusion_zero_extension}
+    \lean{Matrix.exists_unitary_zero_extension_eq}
+    \leanok
+    \uses{lem:exists_unitary_mul_eq_of_gram_eq}
+    Let $W:\C^n\to\C^D$ satisfy $W^*W=\Id_n$.  There are an identification
+    $\C^D\simeq\C^{D-n}\oplus\C^n$ and a unitary $U$ on $\C^D$ such that,
+    for every $A\in\MN{n}$,
+    \[
+        WAW^*=U(0_{D-n}\oplus A)U^*.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:exists_unitary_mul_eq_of_gram_eq}
+    The isometry $W$ implies $n\leq D$.  Let $J:\C^n\to
+    \C^{D-n}\oplus\C^n$ be the canonical inclusion into the second summand.
+    Since $W^*W=J^*J=\Id_n$, Lemma~\ref{lem:exists_unitary_mul_eq_of_gram_eq}
+    gives a unitary $U$ with $W=UJ$.  The identity follows from
+    $JAJ^*=0_{D-n}\oplus A$.
+\end{proof}
+
 \begin{definition}[First environment embedding]
     \label{def:first_env_embedding}
     \lean{Matrix.firstEnvEmbedding}

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -46,13 +46,12 @@ For MPDO renormalization fixed points:
 
 - `cpsv16_vertical_sector_invertibility.tex` separates the proved fixed
   contraction families and product-generation theorem from the remaining
-  density-weighted fixed-point argument in Appendix C.4. The full-support
-  adjoint Cesàro projection now has Wolf's weighted partial-trace block form;
-  taking its trace adjoint, reducing to support, and proving the transported
-  maps trace preserving on the full sector algebras remain open. Since those
-  algebras are direct sums rather than full matrix algebras, the application
-  also needs a block-diagonal full-matrix extension or a direct-sum version of
-  the fixed-point theorem. The note also records that sector relabelling
+  density-weighted fixed-point argument in Appendix C.4. Wolf's full
+  fixed-point theorem, including maximal-support reduction and the
+  complementary zero summand, and its full-support direct-sum consequence are
+  now formalized. For the transported sector maps it remains to prove the
+  channel hypotheses on the full sector algebras. The note also records that
+  sector relabelling
   follows from mutually inverse positive trace-preserving maps, not from a
   bare linear equivalence.
 - `cpsv16_simple_tensor_nilpotency.tex` identifies the source's nilpotent BNT

--- a/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
+++ b/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
@@ -107,8 +107,8 @@ then the endomorphism is the identity.\footnote{Formal declarations:
 in \doclink{TNLean/MPS/MPDO/VerticalSectorGeneration}.}
 This second implication does not assume that products of distinguished
 contractions are fixed.  It isolates the source's dimension argument.  The
-remaining fixed-point theorem must supply the displayed inequality from the
-density-weighted form of $\mathcal F$.
+formalized fixed-point theorem supplies the displayed inequality from the
+density-weighted form of $\mathcal F$ once its channel hypotheses are known.
 
 The positive trace-preserving mean-ergodic retraction on a full matrix algebra
 and its positive unital trace-adjoint retraction onto the adjoint fixed-point
@@ -117,7 +117,7 @@ the adjoint map.  On full support, the adjoint retraction is now identified
 with the weighted partial-trace block form of Wolf's Proposition~1.5.  The
 trace-adjoint calculation giving the Schr\"odinger-picture density blocks and
 the support reduction producing the zero summand of Wolf's Theorem~6.14 are
-not yet assembled.  Their precise boundary is recorded in
+now assembled.  Their construction is recorded in
 \path{docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex}.  For
 the transported sector maps one must also prove the channel hypotheses on the
 full direct sums, rather than only on the contraction families.  In the
@@ -142,9 +142,10 @@ sector maps on the whole direct sums and to supply a blockwise
 positive-definite fixed family.  Alternatively, the maximal-support witness
 $T_\infty(\mathbf 1)$ is now available for an arbitrary positive
 trace-preserving map.  The construction of the supported endomorphism and its
-complementary zero summand, still open in
-\path{docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex}, would
-remove the latter full-support hypothesis.
+complementary zero summand is now completed in the full-matrix theorem recorded
+in \path{docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex}; it
+removes the need to assume a positive-definite fixed point before applying the
+full-matrix classification.
 
 \section{Sector relabelling uses positivity, not linear isomorphism}
 

--- a/docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex
+++ b/docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex
@@ -6,9 +6,9 @@
 
 \input{command}
 
-\title{Wolf Theorem~6.14: Fixed-Point Projection Gap}
+\title{Wolf Theorem~6.14: Fixed-Point Classification Completion Record}
 \author{}
-\date{2026-07-18}
+\date{2026-07-19}
 
 \begin{document}
 \maketitle
@@ -30,7 +30,7 @@ representation, removes off-diagonal inputs by positivity, and gives a
 positive semidefinite trace-one matrix for each summand.  No assumption of
 complete positivity, trace preservation, or a Schwarz inequality is added.
 
-\section{The remaining fixed-point theorem}
+\section{The fixed-point theorem}
 
 Let $T:M_D(\mathbb C)\to M_D(\mathbb C)$ be positive and trace preserving,
 write $T^*$ for its trace-pairing adjoint, and suppose that $T^*$ satisfies the
@@ -193,15 +193,37 @@ positive-definite partial-trace facts are
 \leanid{Matrix.PosDef.left_of_kronecker_of_trace_eq_one} in
 \doclink{TNLean/Channel/PartialTrace}.}
 
-It remains to transport the density-block form through $V$ and write the
-complement of $Q$ as the single zero summand $\mathcal H_0$ of Theorem~6.14.
+The ambient transport is now formalized.  If $U_c$ is the compressed block
+unitary, then $W=VU_c$ is an isometry from the compressed space into the
+original space.  Compare it with the canonical inclusion of
+$\mathbb C^n$ into
+$\mathbb C^{D-n}\oplus\mathbb C^n$.  The two inclusions have the same Gram
+matrix.  The finite-dimensional unitary extension theorem therefore gives an
+ambient unitary $U$ satisfying
+\begin{align}
+    WAW^*=U(0_{D-n}\oplus A)U^*
+\end{align}
+for every $A\in M_n(\mathbb C)$.  Applying the retained fixed-space
+equivalence and substituting the compressed density-block formula yields
+\begin{align}
+    \operatorname{Fix}(T)
+      =U\left(0_{D-n}\oplus\bigoplus_k
+        \sigma_k\otimes M_{d_k}(\mathbb C)\right)U^*.
+\end{align}
+The first block is exactly the orthogonal complement of maximal stationary
+support, so it is one zero summand.  There are no further kernel blocks,
+because every $\sigma_k$ is positive definite.
+\footnote{Formal declarations:
+\leanid{Matrix.exists_unitary_zero_extension_eq} in
+\doclink{TNLean/Algebra/MatrixGramUnitary}, and
+\leanid{IsPositiveMap.exists_fixedPoints_densityBlocks_with_zero} in
+\doclink{TNLean/Channel/FixedPoint/WolfTheorem614}.}
 
-Thus Proposition~1.5, its application to the full-support adjoint
-mean-ergodic projection, and the full-support Schr\"odinger-picture fixed-point
-formula, together with the maximal-support witness and the positive
-trace-preserving restriction to its support, are formalized, while
-Theorem~6.14 remains open.  The missing work is transport to the original
-space and assembly of the complementary zero summand.
+Consequently, the statement and hypotheses of Wolf's Theorem~6.14 are now
+formalized in full.  The theorem assumes precisely positivity and trace
+preservation of $T$ and the Schwarz inequality for $T^*$; the fixed-point
+space has exactly the single complementary zero summand asserted in
+Equation~(6.63).  This document therefore records a closed paper gap.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/wolf_thm6_12_abstract_schwarz_fixed_points.tex
+++ b/docs/paper-gaps/wolf_thm6_12_abstract_schwarz_fixed_points.tex
@@ -96,9 +96,11 @@ the literal formalization of Theorem~6.12.
 
 The elimination plan is to formalize the positive-fixed-parts proposition for
 the abstract positive trace-preserving trace adjoint, derive a positive-definite
-fixed point from the full-rank witness, and wrap the present lemma.  The explicit
-Equation~(1.39) block realization, the subsequent support reduction, and the
-zero-block assembly required for Theorem~6.14 are now complete; see
+fixed point from the full-rank witness, and wrap the present lemma.  The
+explicit trace-adjoint Equation~(1.39) realization remains open at this level
+of generality.  The downstream Schrödinger-picture density-block
+classification, support reduction, and zero-block assembly required for
+Theorem~6.14 are complete; see
 \path{docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex}.
 
 \bibliographystyle{alpha}

--- a/docs/paper-gaps/wolf_thm6_12_abstract_schwarz_fixed_points.tex
+++ b/docs/paper-gaps/wolf_thm6_12_abstract_schwarz_fixed_points.tex
@@ -98,7 +98,8 @@ The elimination plan is to formalize the positive-fixed-parts proposition for
 the abstract positive trace-preserving trace adjoint, derive a positive-definite
 fixed point from the full-rank witness, and wrap the present lemma.  The explicit
 Equation~(1.39) block realization, the subsequent support reduction, and the
-zero-block assembly required for Theorem~6.14 also remain open gaps.
+zero-block assembly required for Theorem~6.14 are now complete; see
+\path{docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex}.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

- retain the maximal-support fixed-space equivalence alongside the positive-definite compressed density blocks
- complete an arbitrary support isometry to an ambient unitary and identify its matrix sandwich with one complementary zero block
- prove the source-facing fixed-point classification under exactly positivity, trace preservation, and the Schwarz inequality for the trace adjoint
- add the blueprint theorem thm:wolf_6_14 and convert the paper-gap note into a completion record dated 2026-07-19

## Mathematical source

Wolf, Quantum Channels & Operations: Guided Tour, Theorem 6.14 and Equation (6.63); local source Notes/WolfNoteTexSource/ch06_spectral_properties.tex, lines 1469--1494.

The formal coordinates order each nonzero summand as C^{m_k} tensor C^{d_k}; this is the canonical tensor-factor interchange of the order displayed by Wolf.

## Verification

Current local evidence:

- a Mathlib-only scratch reproducing the four matrix normalization and unitary-cancellation identities in the capstone proof passes
- the changed-declaration reverse blueprint synchronization check reports no missing entries
- Matrix.exists_unitary_zero_extension_eq has only propext, Classical.choice, and Quot.sound as axioms
- proof-integrity scan, 100-column scan, and git diff --check pass

The earlier focused direct checks preceded the clean Linux CI diagnosis and are not evidence for the repaired capstone proof. At exact head 04951baaea6e3b1fa4df4db034a32825a33e4ec1, GitHub Actions run 29680757544 passes the full Lean build, blueprint compilation and synchronization, file-length gate, and changed-file gate.

Closes LionSR/QICLean#225.
Closes LionSR/QICLean#219.
Advances LionSR/TNLean#4120.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal mathematics (Lean proofs and blueprint/docs); no runtime services, auth, or data handling. Risk is mainly proof correctness and maintenance of a large fixed-point dependency chain.
> 
> **Overview**
> **Completes Wolf Theorem 6.14** (density-block fixed points with one complementary zero summand) for positive trace-preserving maps whose trace adjoint satisfies the Schwarz inequality.
> 
> Adds `Matrix.exists_unitary_zero_extension_eq` so an isometric inclusion `W` realizes `W A W‴` as conjugation by an ambient unitary with a single `0 ⊕ A` block. New `IsPositiveMap.exists_fixedPoints_densityBlocks_with_zero` in `WolfTheorem614.lean` chains maximal-support compression, compressed density blocks, and that unitary extension.
> 
> **Maximal-support API:** `exists_block_densities_of_maximalSupportCompression` now also states that ambient fixed points are exactly `V X V‴` with compressed fixed `X` (`hambientFixed`), which the capstone proof uses for transport.
> 
> Blueprint gains `thm:wolf_6_14` and `thm:isometric_inclusion_zero_extension`; Wolf Chapter 6 index and paper-gap notes are updated from “partial / open” to **formalized** for this theorem (CPSV16 sector application still needs channel hypotheses on direct sums).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04951baaea6e3b1fa4df4db034a32825a33e4ec1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

