### PR TITLE
doc(Entropy): state support inverse identities explicitly

### DIFF
--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -1376,6 +1376,11 @@ Theorem~\ref{thm:trace_norm_abs}.
         (c\tau)^{-1/2}_{\mathrm{supp}}
           =c^{-1/2}\tau^{-1/2}_{\mathrm{supp}}.
     \]
+    For every finite-dimensional auxiliary space $\mathcal H_R$,
+    \[
+        \bigl(\tau\otimes\mathbf 1_R\bigr)^{-1/2}_{\mathrm{supp}}
+          =\tau^{-1/2}_{\mathrm{supp}}\otimes\mathbf 1_R.
+    \]
     Consequently, for $d_R>0$,
     \[
         \bigl(\tau\otimes d_R^{-1}\mathbf 1_R\bigr)^{-1/2}_{\mathrm{supp}}
@@ -1386,9 +1391,13 @@ Theorem~\ref{thm:trace_norm_abs}.
 
 \begin{proof}\leanok
     The scalar identity follows from the functional calculus and
-    $\sqrt{cx}=\sqrt c\sqrt x$ for $c>0$.  The unital tensor embedding commutes
-    with the functional calculus, and substituting $c=d_R^{-1}$ gives the
-    second identity.
+    $\sqrt{cx}=\sqrt c\sqrt x$ for $c>0$.  For the support-inverse function
+    $f(x)=x^{-1/2}$ when $x>0$ and $f(0)=0$, the functional calculus gives
+    \[
+        f(\tau\otimes\mathbf 1_R)=f(\tau)\otimes\mathbf 1_R.
+    \]
+    This is the unscaled tensor identity.  Substituting $c=d_R^{-1}$ in the
+    scaling identity then gives the maximally mixed identity.
 \end{proof}
 
 \begin{definition}[Support Petz transpose map for a partial trace]
@@ -2420,8 +2429,12 @@ Theorem~\ref{thm:trace_norm_abs}.
 
 \begin{proof}\leanok
     By the preceding support inverse formula, each outer factor contributes
-    $\sqrt{d_C}$.  These two factors cancel the coefficient $d_C^{-1}$ in
-    the middle tensor factor, leaving the asserted unital tensor embedding.
+    $\sqrt{d_C}$.  The scalar coefficient cancels because
+    \[
+        \sqrt{d_C}\,d_C^{-1}\sqrt{d_C}
+          =d_C^{-1}(\sqrt{d_C})^2=1.
+    \]
+    The remaining matrix product is the asserted unital tensor embedding.
 \end{proof}
 
 \begin{theorem}[Identity Weyl sandwich implies raw Petz recovery]


### PR DESCRIPTION
### Motivation
- The support-inverse lemma in `blueprint/src/chapter/ch19_entropy.tex`, `lem:support_inverse_square_root_maximally_mixed`, linked the unscaled tensor theorem without stating its formula.
- The source declarations `Matrix.PosSemidef.supportInvSqrt_kronecker_one` in `TNLean/Channel/PetzRecovery.lean` (lines 106–118) and `Matrix.PosSemidef.supportInvSqrt_kronecker_maximallyMixed_mul_mul` in `TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean` (lines 75–95) state tensor functional-calculus and support-sandwich identities that should be visible in the blueprint.

### Description
- State explicitly that the support inverse square root of `τ ⊗ 𝟙_R` is `τ^{-1/2}_{supp} ⊗ 𝟙_R`, so every Lean link in the lemma has a displayed formula.
- Display the functional-calculus equality `f(τ ⊗ 𝟙_R) = f(τ) ⊗ 𝟙_R` and the scalar cancellation `√d_C d_C^{-1} √d_C = 1` in the corresponding proof sketches.
- Preserve the conditional Petz boundary: the recovery theorem still assumes the operator sandwich identity and does not derive it from equality of scalar relative entropies.
- No Lean declaration or proof is changed.

### Testing
- `lake build TNLean` (9601 targets)
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base c0f529877fc7505801800360a2596778abf257dd --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `leanblueprint checkdecls`
- `git diff --check`

---
Closes LionSR/QICLean#239
Addresses LionSR/TNLean#4228
Addresses LionSR/QICLean#233
Addresses LionSR/TNLean#2380

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to blueprint prose and proof sketches; no runtime, API, or formal proof changes.
> 
> **Overview**
> **Blueprint-only** updates in `ch19_entropy.tex` so support-inverse-square-root lemmas match the linked Lean theorems; no Lean proofs or declarations change.
> 
> **Lemma `lem:support_inverse_square_root_maximally_mixed`** now states the unscaled tensor identity explicitly: \((\tau \otimes \mathbf 1_R)^{-1/2}_{\mathrm{supp}} = \tau^{-1/2}_{\mathrm{supp}} \otimes \mathbf 1_R\), aligning with `Matrix.PosSemidef.supportInvSqrt_kronecker_one`. The proof sketch cites functional calculus for \(f(x)=x^{-1/2}\) (zero on the kernel) via \(f(\tau \otimes \mathbf 1_R) = f(\tau) \otimes \mathbf 1_R\), then derives the maximally mixed case from scaling.
> 
> **Lemma `lem:maximally_mixed_support_sandwich`** spells out why the \(\sqrt{d_C}\) factors cancel: \(\sqrt{d_C}\, d_C^{-1}\sqrt{d_C} = d_C^{-1}(\sqrt{d_C})^2 = 1\), instead of only saying the factors cancel the middle coefficient.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 843a8205fa2aab244fff915d8e08f27a7a24165d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->