### PR TITLE
feat(MPS/RFP): decompose the two-site parent interaction

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -627,6 +627,7 @@ import TNLean.MPS.RFP.ResidualIsometry
 import TNLean.MPS.RFP.ResidualWordSpan
 import TNLean.MPS.RFP.NNCPHMultiSector
 import TNLean.MPS.RFP.BeigiGroundSpaceDimension
+import TNLean.MPS.RFP.BeigiSpatialDecomposition
 import TNLean.MPS.RFP.PhaseMultiplicityCounterexample
 import TNLean.MPS.RFP.BNTWeightCounterexample
 

--- a/TNLean/MPS/RFP/BeigiSpatialDecomposition.lean
+++ b/TNLean/MPS/RFP/BeigiSpatialDecomposition.lean
@@ -1,0 +1,219 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.CommutingOverlappingDecomp
+import TNLean.MPS.ParentHamiltonian.Commuting
+import TNLean.MPS.ParentHamiltonian.Martingale.Transport
+import TNLean.MPS.RFP.AppendixBCommutation
+
+/-!
+# Spatial decomposition of the two-site parent interaction
+
+This file places the canonical two-site parent interaction in the coordinates
+used by the Bravyi--Vyalyi decomposition.  On three sites, nearest-neighbor
+commutation says that the two overlapping lifts of this Hermitian matrix
+commute.  Beigi's spatial decomposition therefore applies directly.
+
+## Main declarations
+
+* `twoSiteParentInteractionMatrix`: the canonical two-site parent interaction
+  in ordered-pair coordinates;
+* `IsNNCPH.twoSiteParentInteractionMatrix_isHermitian_and_overlappingLifts_commute`:
+  the Hermitian commuting-overlap input to the spatial decomposition;
+* `IsNNCPH.exists_unitary_blockActions_of_twoSiteParentInteractionMatrix`:
+  the resulting unitary block actions on the middle physical site.
+
+## References
+
+* S. Beigi, *Classification of the phases of 1D spin chains with commuting
+  Hamiltonians*, arXiv:1105.1019v2, Lemma 2.1 and Sections II--IV.
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Theorem 3.10, lines 534--540.
+-/
+
+open scoped Matrix Kronecker
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-! ### Coordinate transport -/
+
+/-- The common left-associated coordinates for three consecutive physical sites.
+The equivalence sends a configuration `x` to `((x 0, x 1), x 2)`.
+
+Source: Beigi, arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`), pages 2--3. -/
+def threeSiteParentInteractionEquiv (n : Type*) :
+    (Fin 3 → n) ≃ ((n × n) × n) :=
+  (finThreeArrowEquiv n).trans (Equiv.prodAssoc n n n).symm
+
+/-- In common left-associated three-site coordinates, the first-pair lift of a
+two-site operator is its left overlapping matrix lift.
+
+Source: Beigi, arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`), pages 2--3. -/
+theorem leftPairLift_toMatrix_reindex_leftAssociated
+    (Q : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2) :
+    Matrix.reindex (threeSiteParentInteractionEquiv (Fin d))
+        (threeSiteParentInteractionEquiv (Fin d))
+        (LinearMap.toMatrix' (leftPairLift Q)) =
+      Matrix.leftOverlappingLift
+        (Matrix.reindex (finTwoArrowEquiv (Fin d))
+          (finTwoArrowEquiv (Fin d)) (LinearMap.toMatrix' Q)) := by
+  classical
+  rw [threeSiteParentInteractionEquiv]
+  change Matrix.reindex (Equiv.prodAssoc (Fin d) (Fin d) (Fin d)).symm
+      (Equiv.prodAssoc (Fin d) (Fin d) (Fin d)).symm
+      (Matrix.reindex (finThreeArrowEquiv (Fin d))
+        (finThreeArrowEquiv (Fin d))
+        (LinearMap.toMatrix' (leftPairLift Q))) = _
+  rw [leftPairLift_toMatrix_reindex]
+  ext p q
+  simp [appendixBLeftPairMatrixAux, Matrix.leftOverlappingLift,
+    Matrix.reindex_apply, Matrix.kroneckerMap_apply]
+
+/-- In common left-associated three-site coordinates, the final-pair lift of a
+two-site operator is its right overlapping matrix lift.
+
+Source: Beigi, arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`), pages 2--3. -/
+theorem rightPairLift_toMatrix_reindex_leftAssociated
+    (Q : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2) :
+    Matrix.reindex (threeSiteParentInteractionEquiv (Fin d))
+        (threeSiteParentInteractionEquiv (Fin d))
+        (LinearMap.toMatrix' (rightPairLift Q)) =
+      Matrix.rightOverlappingLift
+        (Matrix.reindex (finTwoArrowEquiv (Fin d))
+          (finTwoArrowEquiv (Fin d)) (LinearMap.toMatrix' Q)) := by
+  classical
+  rw [threeSiteParentInteractionEquiv]
+  change Matrix.reindex (Equiv.prodAssoc (Fin d) (Fin d) (Fin d)).symm
+      (Equiv.prodAssoc (Fin d) (Fin d) (Fin d)).symm
+      (Matrix.reindex (finThreeArrowEquiv (Fin d))
+        (finThreeArrowEquiv (Fin d))
+        (LinearMap.toMatrix' (rightPairLift Q))) = _
+  rw [rightPairLift_toMatrix_reindex]
+  ext p q
+  simp [appendixBRightPairMatrixAux, Matrix.rightOverlappingLift,
+    Matrix.reindex_apply, Matrix.kroneckerMap_apply]
+
+/-- The matrix of the parent interaction agrees with the matrix of its
+Euclidean-space representative in the canonical orthonormal basis. -/
+private theorem parentInteraction_toMatrix'_eq_parentInteractionES_toMatrix
+    (A : MPSTensor d D) (L : ℕ) :
+    LinearMap.toMatrix' (parentInteraction A L) =
+      LinearMap.toMatrix (EuclideanSpace.basisFun (Cfg d L) ℂ).toBasis
+        (EuclideanSpace.basisFun (Cfg d L) ℂ).toBasis
+        (parentInteractionES A L) := by
+  classical
+  ext i j
+  simp [LinearMap.toMatrix'_apply, LinearMap.toMatrix_apply,
+    EuclideanSpace.basisFun_toBasis, PiLp.basisFun_apply,
+    parentInteraction, parentInteractionES]
+
+/-! ### The canonical interaction and its overlapping lifts -/
+
+/-- The canonical two-site parent interaction in ordered-pair coordinates.
+
+Source: arXiv:1606.00608, Definition 3.9 and Theorem 3.10, lines 517--540. -/
+noncomputable def twoSiteParentInteractionMatrix (A : MPSTensor d D) :
+    Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ :=
+  Matrix.reindex (finTwoArrowEquiv (Fin d)) (finTwoArrowEquiv (Fin d))
+    (LinearMap.toMatrix' (parentInteraction A 2))
+
+/-- The canonical two-site parent interaction matrix is Hermitian.
+
+Source: arXiv:1606.00608, Definition 3.9, lines 517--525. -/
+theorem twoSiteParentInteractionMatrix_isHermitian (A : MPSTensor d D) :
+    (twoSiteParentInteractionMatrix A).IsHermitian := by
+  apply Matrix.IsHermitian.reindex
+  rw [parentInteraction_toMatrix'_eq_parentInteractionES_toMatrix]
+  exact (LinearMap.isHermitian_toMatrix_iff
+    (EuclideanSpace.basisFun (Cfg d 2) ℂ)).2
+      (parentInteractionES_isSymmetricProjection A 2).isSymmetric
+
+/-- On three sites, nearest-neighbor parent commutation becomes commutation of
+the two natural overlapping lifts of the canonical two-site interaction.
+
+Source: arXiv:1606.00608, Theorem 3.10, lines 534--540; Beigi,
+arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`), pages 2--3. -/
+theorem IsNNCPH.twoSiteParentInteractionMatrix_overlappingLifts_commute
+    {A : MPSTensor d D} (hNNCPH : IsNNCPH A 3) :
+    Matrix.leftOverlappingLift (twoSiteParentInteractionMatrix A) *
+        Matrix.rightOverlappingLift (twoSiteParentInteractionMatrix A) =
+      Matrix.rightOverlappingLift (twoSiteParentInteractionMatrix A) *
+        Matrix.leftOverlappingLift (twoSiteParentInteractionMatrix A) := by
+  have hComm := hNNCPH (0 : Fin 3) (1 : Fin 3)
+  rw [localTerm_two_three_zero_eq_leftPairLift_parentInteraction,
+    localTerm_two_three_one_eq_rightPairLift_parentInteraction] at hComm
+  have hMatrix := congrArg LinearMap.toMatrix' hComm
+  simp only [LinearMap.toMatrix'_mul] at hMatrix
+  let e := threeSiteParentInteractionEquiv (Fin d)
+  rw [twoSiteParentInteractionMatrix,
+    ← leftPairLift_toMatrix_reindex_leftAssociated,
+    ← rightPairLift_toMatrix_reindex_leftAssociated]
+  change (Matrix.reindexLinearEquiv ℂ ℂ e e)
+        (LinearMap.toMatrix' (leftPairLift (parentInteraction A 2))) *
+      (Matrix.reindexLinearEquiv ℂ ℂ e e)
+        (LinearMap.toMatrix' (rightPairLift (parentInteraction A 2))) =
+    (Matrix.reindexLinearEquiv ℂ ℂ e e)
+        (LinearMap.toMatrix' (rightPairLift (parentInteraction A 2))) *
+      (Matrix.reindexLinearEquiv ℂ ℂ e e)
+        (LinearMap.toMatrix' (leftPairLift (parentInteraction A 2)))
+  rw [Matrix.reindexLinearEquiv_mul ℂ ℂ e e e,
+    Matrix.reindexLinearEquiv_mul ℂ ℂ e e e]
+  exact congrArg (Matrix.reindex e e) hMatrix
+
+/-- The canonical two-site interaction is Hermitian, and its two overlapping
+lifts commute on three sites.
+
+This is exactly the local input to the spatial decomposition of Beigi,
+arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`), pages 2--3. -/
+theorem IsNNCPH.twoSiteParentInteractionMatrix_isHermitian_and_overlappingLifts_commute
+    {A : MPSTensor d D} (hNNCPH : IsNNCPH A 3) :
+    (twoSiteParentInteractionMatrix A).IsHermitian ∧
+      Matrix.leftOverlappingLift (twoSiteParentInteractionMatrix A) *
+          Matrix.rightOverlappingLift (twoSiteParentInteractionMatrix A) =
+        Matrix.rightOverlappingLift (twoSiteParentInteractionMatrix A) *
+          Matrix.leftOverlappingLift (twoSiteParentInteractionMatrix A) :=
+  ⟨twoSiteParentInteractionMatrix_isHermitian A,
+    hNNCPH.twoSiteParentInteractionMatrix_overlappingLifts_commute⟩
+
+/-! ### Bravyi--Vyalyi spatial block actions -/
+
+/-- The canonical two-site parent interaction admits Beigi's explicit unitary
+block-action decomposition on the middle physical site.
+
+Source: Beigi, arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`), pages 2--3;
+arXiv:1606.00608, Theorem 3.10, lines 534--540. -/
+theorem IsNNCPH.exists_unitary_blockActions_of_twoSiteParentInteractionMatrix
+    {A : MPSTensor d D} (hNNCPH : IsNNCPH A 3) :
+    ∃ (K : ℕ) (dl dr : Fin K → ℕ)
+      (e : ((q : Fin K) × (Fin (dr q) × Fin (dl q))) ≃ Fin d)
+      (U : Matrix (Fin d) (Fin d) ℂ)
+      (R : ∀ q, Matrix (Fin d × Fin (dl q)) (Fin d × Fin (dl q)) ℂ)
+      (S : ∀ q, Matrix (Fin (dr q) × Fin d) (Fin (dr q) × Fin d) ℂ),
+      U ∈ Matrix.unitaryGroup (Fin d) ℂ ∧
+        (∀ q, 0 < dl q) ∧ (∀ q, 0 < dr q) ∧
+        (∀ q, (R q).IsHermitian) ∧ (∀ q, (S q).IsHermitian) ∧
+        Matrix.reindex (Matrix.leftSpatialBlockEquiv e).symm
+            (Matrix.leftSpatialBlockEquiv e).symm
+            (star ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ U) *
+              twoSiteParentInteractionMatrix A *
+              ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ U)) =
+          (Matrix.blockDiagonal' fun q =>
+            R q ⊗ₖ (1 : Matrix (Fin (dr q)) (Fin (dr q)) ℂ)) ∧
+        Matrix.reindex (Matrix.rightSpatialBlockEquiv e).symm
+            (Matrix.rightSpatialBlockEquiv e).symm
+            (star (U ⊗ₖ (1 : Matrix (Fin d) (Fin d) ℂ)) *
+              twoSiteParentInteractionMatrix A *
+              (U ⊗ₖ (1 : Matrix (Fin d) (Fin d) ℂ))) =
+          (Matrix.blockDiagonal' fun q =>
+            (1 : Matrix (Fin (dl q)) (Fin (dl q)) ℂ) ⊗ₖ S q) := by
+  rcases hNNCPH.twoSiteParentInteractionMatrix_isHermitian_and_overlappingLifts_commute
+    with ⟨hHermitian, hComm⟩
+  exact Matrix.exists_unitary_blockActions_of_overlappingLifts_commute
+    (twoSiteParentInteractionMatrix A) (twoSiteParentInteractionMatrix A)
+    hHermitian hHermitian hComm
+
+end MPSTensor

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -2292,6 +2292,72 @@ specialization of that Appendix~D definition.
     linear independence. The dimension of their span is therefore $g$.
 \end{proof}
 
+\begin{definition}[Two-site parent-interaction matrix]%
+    \label{def:two_site_parent_interaction_matrix}
+    \lean{MPSTensor.twoSiteParentInteractionMatrix}
+    \leanok
+    Let $A$ be a matrix product tensor.  Write its canonical two-site parent
+    interaction in the ordered-pair basis of the two-site physical Hilbert
+    space, and denote the resulting matrix by $Q_A$.
+\end{definition}
+
+\begin{theorem}[Hermitian commuting overlapping parent interactions]%
+    \label{thm:two_site_parent_interaction_commuting_overlaps}
+    \lean{MPSTensor.IsNNCPH.twoSiteParentInteractionMatrix_isHermitian_and_overlappingLifts_commute}
+    \leanok
+    \uses{def:two_site_parent_interaction_matrix}
+    Suppose that the canonical length-two parent terms of $A$ commute on a
+    three-site chain.  Then $Q_A$ is Hermitian, and its natural placements on
+    the first and last pairs of a three-fold tensor product commute:
+    \[
+        (Q_A\otimes\mathbf 1)(\mathbf 1\otimes Q_A)
+        =
+        (\mathbf 1\otimes Q_A)(Q_A\otimes\mathbf 1).
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    The parent interaction is the orthogonal projector onto the orthogonal
+    complement of the local matrix product space, hence is Hermitian.
+    Transporting the adjacent three-site parent-term commutator to the common
+    left-associated tensor-product basis gives the displayed identity.
+\end{proof}
+
+\begin{theorem}[Spatial block actions of the two-site parent interaction]%
+    \label{thm:two_site_parent_interaction_spatial_blocks}
+    \lean{MPSTensor.IsNNCPH.exists_unitary_blockActions_of_twoSiteParentInteractionMatrix}
+    \leanok
+    \uses{thm:two_site_parent_interaction_commuting_overlaps}
+    Under the preceding hypothesis, there are positive integers
+    $d_q,m_q$, a unitary identification
+    \[
+        \mathcal H\cong\bigoplus_q
+        \mathcal H_{q,l}\otimes\mathcal H_{q,r},
+    \]
+    and Hermitian matrices $R_q$ on
+    $\mathcal H\otimes\mathcal H_{q,l}$ and $S_q$ on
+    $\mathcal H_{q,r}\otimes\mathcal H$ such that, after conjugating the
+    middle site by this unitary,
+    \[
+        Q_A=\bigoplus_q(R_q\otimes\mathbf 1_{q,r})
+        \qquad\text{on the first pair},
+    \]
+    and
+    \[
+        Q_A=\bigoplus_q(\mathbf 1_{q,l}\otimes S_q)
+        \qquad\text{on the last pair}.
+    \]
+    This is the spatial decomposition of
+    \cite[Lemma~2.1]{Beigi2012Classification} for the canonical parent
+    interaction.
+\end{theorem}
+
+\begin{proof}\leanok
+    Apply the finite-dimensional spatial decomposition for two Hermitian
+    overlapping operators to $Q_A$ in both positions, using
+    Theorem~\ref{thm:two_site_parent_interaction_commuting_overlaps}.
+\end{proof}
+
 \begin{theorem}[All-chain nearest-neighbor commuting parent-Hamiltonian ground spaces imply a renormalization fixed point]\label{thm:nncph_implies_rfp}
     \lean{MPSTensor.nncph_implies_rfp}
     \lean{Axioms.beigi_nncph_to_rfp}

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -253,6 +253,23 @@ The proof uses only the ground-space spanning equation and the dimension of the
 span of a finite linearly independent family.  It does not use the commuting
 interaction classification.
 
+The local spatial-decomposition input is also now internal.  The canonical
+two-site parent interaction, written in ordered-pair coordinates as
+\leanid{MPSTensor.twoSiteParentInteractionMatrix}, is Hermitian because it is
+the transport of an orthogonal projector.  If the nearest-neighbor parent
+terms commute on three sites, their common left-associated coordinates are
+the two natural overlapping lifts of this matrix.  Therefore
+\leanid{MPSTensor.IsNNCPH.}
+\hspace{0pt}\leanid{twoSiteParentInteractionMatrix_isHermitian_and_overlappingLifts_commute}
+supplies exactly the hypotheses of Beigi's spatial decomposition, with no
+canonical-form or ground-space-spanning assumption.  Its direct consequence
+\leanid{MPSTensor.IsNNCPH.}
+\hspace{0pt}\leanid{exists_unitary_blockActions_of_twoSiteParentInteractionMatrix}
+decomposes the middle physical space into a finite direct sum of left and
+right tensor factors on which the two adjacent interactions act separately.
+This completes the local Bravyi--Vyalyi step.  It does not yet construct the
+finite sector graph or analyze its cyclic ground spaces.
+
 \section{Elimination plan}
 
 A source-faithful formalization should replace the remaining axiom-backed
@@ -295,8 +312,9 @@ canonical form is subject to the source obstruction recorded in
 ground-space spanning clause and the multiplicity-one distinct-sector
 extension are proved. The repeated-copy and arbitrary-raw-weight extension
 remains open.  In the reverse direction, eventual ground-space dimension
-stability is proved; the sector-graph classification and its identification
-with the basis of normal tensors remain open.
+stability and the local spatial decomposition are proved; the sector-graph
+classification and its identification with the basis of normal tensors remain
+open.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

This pull request closes #4362 and advances #2633 by placing the canonical two-site MPS parent interaction in the matrix coordinates required by the existing Bravyi--Vyalyi spatial decomposition.

It adds:

- the ordered-pair matrix `twoSiteParentInteractionMatrix`;
- left-associated coordinate identities for the two adjacent pair lifts;
- Hermiticity, transported from the Euclidean orthogonal parent projector;
- the overlapping-lift commutator derived from `IsNNCPH A 3`, with no stronger hypothesis;
- the direct unitary block-action decomposition obtained from `Matrix.exists_unitary_blockActions_of_overlappingLifts_commute`.

The parent-Hamiltonian blueprint and the NNCPH paper-gap note record the completed local spatial-decomposition step and retain the finite sector graph and cyclic-ground-space classification as the remaining Beigi reverse work.

## Source-faithful boundary

The main local theorem assumes only `IsNNCPH A 3`. It does not add BNT data, normality, canonical-form hypotheses, ground-space spanning, or eventual degeneracy. The result therefore supplies exactly the Hermitian commuting-overlap input of Beigi, arXiv:1105.1019v2, Lemma 2.1.

This pull request does not construct the finite sector graph, prove its cyclic ground-space dimension formula, or remove `Axioms.beigi_nncph_to_rfp`.

## Verification

- The new Lean module was checked directly against an existing TNLean/Mathlib object cache.
- Both main theorems have axiom dependencies `[propext, Classical.choice, Quot.sound]` only.
- `scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci` passes.
- `scripts/blueprint_lean_sync.py --root . --ci --warn-missing-blueprint --changed-files TNLean/MPS/RFP/BeigiSpatialDecomposition.lean --diff-base origin/main` passes with no missing declarations.
- The proof-integrity scan finds no `sorry`, `admit`, `native_decide`, `unsafeCast`, or declared axiom.
- `git diff --check` passes, and the new Lean file has no line longer than 100 characters.

A repository rebuild was deliberately not run because the shared TNLean object cache had been cleaned; the full target and blueprint compilation are left to pull-request CI.

Closes #4362.
Advances #2633.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New proved Lean theorems on an existing RFP path with no auth, axiom additions, or changes to runtime behavior; remaining Beigi reverse work stays behind the existing axiom.
> 
> **Overview**
> Adds **`TNLean/MPS/RFP/BeigiSpatialDecomposition.lean`** and wires it into the root import list. The new module defines **`twoSiteParentInteractionMatrix`** in ordered-pair coordinates, proves left-associated reindexing identities linking adjacent pair lifts to **`Matrix.leftOverlappingLift`** / **`rightOverlappingLift`**, and shows that **`IsNNCPH A 3`** alone yields Hermiticity plus commuting overlapping lifts of that matrix.
> 
> The capstone **`exists_unitary_blockActions_of_twoSiteParentInteractionMatrix`** is obtained by instantiating the existing algebra lemma **`Matrix.exists_unitary_blockActions_of_overlappingLifts_commute`**—no BNT, canonical form, or ground-space spanning is assumed.
> 
> **Blueprint** (`ch13_parent_hamiltonian_commuting_gap.tex`) gains matching definitions/theorems for the matrix, commuting overlaps, and unitary block actions. **`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`** records that the local Bravyi–Vyalyi step is internal while the sector graph and **`Axioms.beigi_nncph_to_rfp`** remain open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d38362fcb974cc0357ab5d7c8a3d12a1bb90618. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->