### PR TITLE
feat(Channel/Schwarz): prove the Weyl resolvent defect identity

### DIFF
--- a/TNLean/Analysis/SuperoperatorResolvent.lean
+++ b/TNLean/Analysis/SuperoperatorResolvent.lean
@@ -29,6 +29,9 @@ here.
   matrix `[[A⁻¹, 1], [1, B]]` has Schur complement `B - A` of its first block
   and Schur complement `A⁻¹ - B⁻¹` of its second block, so the two differences
   are positive semidefinite together.
+* `superop_leftRight_posDef`: the Kronecker matrix representing
+  `X ↦ A * X + t • (X * B)` is positive definite when `A`, `B`, and `t` are
+  positive definite, positive definite, and positive, respectively.
 * `superop_resolvent_antitone`: for `t > 0` and positive-definite `A₁ ≤ A₂`,
   `B₁ ≤ B₂`, the resolvent of the commuting-multiplication model is antitone:
   `(A₂ ⊗ₖ 1 + t • (1 ⊗ₖ B₂ᵀ))⁻¹` is at most `(A₁ ⊗ₖ 1 + t • (1 ⊗ₖ B₁ᵀ))⁻¹`.
@@ -82,6 +85,26 @@ lemma inv_le_inv_of_le {A B : Matrix n n ℂ}
 
 end Matrix.PosDef
 
+/-- The commuting-Kronecker matrix representing the positive left-right
+multiplication operator `X ↦ A * X + t • (X * B)` is positive definite when
+`A` and `B` are positive definite and `t > 0`.
+
+Under the vectorization `X ↦ Matrix.vec Xᵀ`, the displayed matrix acts as that
+left-right multiplication operator.  This is the fixed-resolvent positivity
+input in Jenčová--Ruskai, arXiv:0903.2895, §4 and Appendix. -/
+theorem superop_leftRight_posDef
+    {n : Type*} [Fintype n] [DecidableEq n]
+    {t : ℝ} (ht : 0 < t) {A B : Matrix n n ℂ}
+    (hA : A.PosDef) (hB : B.PosDef) :
+    (A ⊗ₖ (1 : Matrix n n ℂ) +
+      t • ((1 : Matrix n n ℂ) ⊗ₖ Bᵀ)).PosDef := by
+  have hI : (1 : Matrix n n ℂ).PosDef := Matrix.PosDef.one
+  have hleft : (A ⊗ₖ (1 : Matrix n n ℂ)).PosDef :=
+    Matrix.PosDef.kronecker hA hI
+  have hright : ((1 : Matrix n n ℂ) ⊗ₖ Bᵀ).PosSemidef :=
+    Matrix.PosSemidef.kronecker hI.posSemidef hB.posSemidef.transpose
+  exact hleft.add_posSemidef (hright.smul ht.le)
+
 variable {D : ℕ}
 
 /-- **Joint Loewner-antitonicity of the commuting-multiplication resolvent.**
@@ -110,15 +133,10 @@ lemma superop_resolvent_antitone
   -- summand is positive definite and the second is positive semidefinite.
   have hIpd : I.PosDef := hI ▸ Matrix.PosDef.one
   have hIps : I.PosSemidef := hIpd.posSemidef
-  have hXposDef : ∀ {A B : Matrix (Fin D) (Fin D) ℂ}, A.PosDef → B.PosDef →
-      (A ⊗ₖ I + t • (I ⊗ₖ Bᵀ)).PosDef := by
-    intro A B hA hB
-    have h1 : (A ⊗ₖ I).PosDef := Matrix.PosDef.kronecker hA hIpd
-    have h2 : (I ⊗ₖ Bᵀ).PosSemidef :=
-      Matrix.PosSemidef.kronecker hIps hB.posSemidef.transpose
-    exact h1.add_posSemidef (h2.smul ht.le)
-  have hX₁ : X₁.PosDef := hXposDef hA₁ hB₁
-  have hX₂ : X₂.PosDef := hXposDef hA₂ hB₂
+  have hX₁ : X₁.PosDef := by
+    simpa only [hI] using superop_leftRight_posDef ht hA₁ hB₁
+  have hX₂ : X₂.PosDef := by
+    simpa only [hI] using superop_leftRight_posDef ht hA₂ hB₂
   -- `X₁ ≤ X₂`, because `X₂ - X₁ = (A₂ - A₁) ⊗ₖ I + t • (I ⊗ₖ (B₂ - B₁)ᵀ) ≥ 0`.
   have hXle : X₁ ≤ X₂ := by
     rw [Matrix.le_iff]

--- a/TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean
+++ b/TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean
@@ -5,6 +5,10 @@ Authors: TNLean contributors
 -/
 import TNLean.Channel.Schwarz.PetzRecoverySupport
 import TNLean.Channel.Schwarz.SSAEqualityDPI
+import TNLean.Analysis.SuperoperatorResolvent
+import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.Basic
+import Mathlib.Data.Complex.BigOperators
+import Mathlib.LinearAlgebra.Matrix.Vec
 
 /-!
 # Singular-support prerequisites for equality in data processing
@@ -28,6 +32,10 @@ the positive semidefinite matrices.
   saturation of the finite Jensen inequality in the Weyl proof.
 * `Matrix.partialTraceRightPetzMap_eq_of_weyl_identity_sandwich` reduces the
   identity-summand support sandwich to the native raw partial-trace Petz map.
+* `Matrix.weyl_resolvent_defect_identity` proves the positive-definite,
+  fixed-`t` squared-defect identity for the finite Weyl family.
+* `Matrix.weyl_resolvent_eq_of_defect_eq_zero` shows that zero defect gives
+  the common resolvent solution for every Weyl summand.
 
 ## References
 
@@ -36,7 +44,7 @@ the positive semidefinite matrices.
   arXiv:quant-ph/0304007v2.
 -/
 
-open scoped Matrix Kronecker ComplexOrder Matrix.Norms.L2Operator
+open scoped Matrix Kronecker ComplexOrder MatrixOrder Matrix.Norms.L2Operator
 open Matrix
 
 namespace Matrix
@@ -310,3 +318,448 @@ theorem quantumRelativeEntropy_weyl_jensen_eq_of_partialTraceRight_eq
     smul_eq_mul]
   have hdC : (dC : ℝ) ≠ 0 := by exact_mod_cast NeZero.ne dC
   field_simp [hdC]
+
+namespace Matrix
+
+variable {n : Type*} [Fintype n]
+
+private lemma star_mulVec_dotProduct (S : Matrix n n ℂ) (hS : S.IsHermitian)
+    (x y : n → ℂ) :
+    star (S *ᵥ x) ⬝ᵥ y = star x ⬝ᵥ (S *ᵥ y) := by
+  rw [star_mulVec, ← Matrix.dotProduct_mulVec, hS.eq]
+
+variable [DecidableEq n]
+
+private lemma resolvent_residual_expand (S : Matrix n n ℂ) (hS : S.PosDef)
+    (b x : n → ℂ) :
+    dotProduct (star (b - S *ᵥ x)) (S⁻¹ *ᵥ (b - S *ᵥ x)) =
+      dotProduct (star b) (S⁻¹ *ᵥ b) - dotProduct (star b) x -
+        dotProduct (star x) b + dotProduct (star x) (S *ᵥ x) := by
+  letI : Invertible S := hS.isUnit.invertible
+  have hinv (y : n → ℂ) : S⁻¹ *ᵥ (S *ᵥ y) = y := by
+    rw [mulVec_mulVec, inv_mul_of_invertible, one_mulVec]
+  have hinv' (y : n → ℂ) : S *ᵥ (S⁻¹ *ᵥ y) = y := by
+    rw [mulVec_mulVec, mul_inv_of_invertible, one_mulVec]
+  simp only [star_sub, sub_dotProduct, mulVec_sub, dotProduct_sub, hinv]
+  rw [star_mulVec_dotProduct S hS.isHermitian]
+  rw [hinv']
+  rw [star_mulVec_dotProduct S hS.isHermitian]
+  ring
+
+private theorem resolvent_residual_identity
+    {ι : Type*} [Fintype ι] [Nonempty ι]
+    (S : ι → Matrix n n ℂ) (b : ι → n → ℂ)
+    (hS : ∀ i, (S i).PosDef) :
+    let Sbar := ∑ i, S i
+    let bbar := ∑ i, b i
+    let x := Sbar⁻¹ *ᵥ bbar
+    ∑ i, dotProduct (star (b i - S i *ᵥ x))
+      ((S i)⁻¹ *ᵥ (b i - S i *ᵥ x)) =
+      (∑ i, dotProduct (star (b i)) ((S i)⁻¹ *ᵥ b i)) -
+        dotProduct (star bbar) (Sbar⁻¹ *ᵥ bbar) := by
+  classical
+  dsimp only
+  let Sbar : Matrix n n ℂ := ∑ i, S i
+  let bbar : n → ℂ := ∑ i, b i
+  let x : n → ℂ := Sbar⁻¹ *ᵥ bbar
+  have hSbar : Sbar.PosDef := by
+    exact Matrix.posDef_sum Finset.univ_nonempty (fun i _ ↦ hS i)
+  letI : Invertible Sbar := hSbar.isUnit.invertible
+  have hx : Sbar *ᵥ x = bbar := by
+    simp only [x, mulVec_mulVec, mul_inv_of_invertible, one_mulVec]
+  have hsumStarB : ∑ i, star (b i) = star bbar := by
+    ext j
+    simp [bbar]
+  have hsumB : ∑ i, b i = bbar := rfl
+  have hsumSx : ∑ i, S i *ᵥ x = Sbar *ᵥ x := by
+    simpa [Sbar] using (Matrix.sum_mulVec Finset.univ S x).symm
+  change (∑ i, dotProduct (star (b i - S i *ᵥ x))
+      ((S i)⁻¹ *ᵥ (b i - S i *ᵥ x))) =
+    (∑ i, dotProduct (star (b i)) ((S i)⁻¹ *ᵥ b i)) -
+      dotProduct (star bbar) x
+  simp_rw [resolvent_residual_expand (hS := hS _)]
+  rw [Finset.sum_add_distrib, Finset.sum_sub_distrib, Finset.sum_sub_distrib]
+  have hleft : ∑ i, dotProduct (star (b i)) x = dotProduct (star bbar) x := by
+    rw [← hsumStarB]
+    simpa using (sum_dotProduct Finset.univ (fun i ↦ star (b i)) x).symm
+  have hright : ∑ i, dotProduct (star x) (b i) = dotProduct (star x) bbar := by
+    rw [← hsumB]
+    simpa using (dotProduct_sum (star x) Finset.univ b).symm
+  have hlast : ∑ i, dotProduct (star x) (S i *ᵥ x) =
+      dotProduct (star x) (Sbar *ᵥ x) := by
+    rw [← hsumSx]
+    simpa using (dotProduct_sum (star x) Finset.univ (fun i ↦ S i *ᵥ x)).symm
+  rw [hleft, hright, hlast, hx]
+  ring
+
+private lemma sum_norm_sq_eq_re_dotProduct (y : n → ℂ) :
+    ∑ p, ‖y p‖ ^ 2 = (dotProduct (star y) y).re := by
+  simp [dotProduct, Complex.sq_norm, ← Complex.normSq_eq_conj_mul_self]
+
+private lemma sqrt_inv_mulVec_normSq (S : Matrix n n ℂ) (hS : S.PosDef)
+    (r : n → ℂ) :
+    ∑ p, ‖((CFC.sqrt S)⁻¹ *ᵥ r) p‖ ^ 2 =
+      (dotProduct (star r) (S⁻¹ *ᵥ r)).re := by
+  let Q : Matrix n n ℂ := CFC.sqrt S
+  have hSnonneg : 0 ≤ S := hS.posSemidef.nonneg
+  have hQQ : Q * Q = S := by
+    simpa [Q] using CFC.sqrt_mul_sqrt_self S hSnonneg
+  have hQunit : IsUnit Q := by
+    change IsUnit (CFC.sqrt S)
+    rw [CFC.isUnit_sqrt_iff_isStrictlyPositive,
+      Matrix.isStrictlyPositive_iff_posDef]
+    exact hS
+  letI : Invertible Q := hQunit.invertible
+  letI : Invertible S := hS.isUnit.invertible
+  have hQherm : Q.IsHermitian := by
+    show Qᴴ = Q
+    simpa only [Q, star_eq_conjTranspose] using
+      (CFC.sqrt_nonneg (a := S)).isSelfAdjoint.star_eq
+  let y : n → ℂ := Q⁻¹ *ᵥ r
+  have hy : Q *ᵥ y = r := by
+    simp only [y, mulVec_mulVec, mul_inv_of_invertible, one_mulVec]
+  have hSinv : S⁻¹ = Q⁻¹ * Q⁻¹ := by
+    rw [← hQQ, Matrix.mul_inv_rev]
+  have hcancel : (Q⁻¹ * Q⁻¹) *ᵥ (Q *ᵥ y) = Q⁻¹ *ᵥ y := by
+    rw [mulVec_mulVec, Matrix.mul_assoc, inv_mul_of_invertible,
+      Matrix.mul_one]
+  have hquad : dotProduct (star r) (S⁻¹ *ᵥ r) =
+      dotProduct (star y) y := by
+    rw [← hy, hSinv, hcancel, star_mulVec_dotProduct Q hQherm]
+    rw [mulVec_mulVec, mul_inv_of_invertible, one_mulVec]
+  calc
+    ∑ p, ‖((CFC.sqrt S)⁻¹ *ᵥ r) p‖ ^ 2 =
+        (dotProduct (star y) y).re := by
+          simpa only [Q, y] using sum_norm_sq_eq_re_dotProduct y
+    _ = (dotProduct (star r) (S⁻¹ *ᵥ r)).re := congrArg Complex.re hquad.symm
+
+private lemma sqrt_defect_eq_sqrt_inv_residual
+    (S : Matrix n n ℂ) (hS : S.PosDef) (b x : n → ℂ) :
+    (CFC.sqrt S)⁻¹ *ᵥ b - CFC.sqrt S *ᵥ x =
+      (CFC.sqrt S)⁻¹ *ᵥ (b - S *ᵥ x) := by
+  let Q : Matrix n n ℂ := CFC.sqrt S
+  have hQunit : IsUnit Q := by
+    change IsUnit (CFC.sqrt S)
+    rw [CFC.isUnit_sqrt_iff_isStrictlyPositive,
+      Matrix.isStrictlyPositive_iff_posDef]
+    exact hS
+  letI : Invertible Q := hQunit.invertible
+  have hQQ : Q * Q = S := by
+    simpa [Q] using CFC.sqrt_mul_sqrt_self S hS.posSemidef.nonneg
+  change Q⁻¹ *ᵥ b - Q *ᵥ x = Q⁻¹ *ᵥ (b - S *ᵥ x)
+  rw [mulVec_sub]
+  congr 1
+  rw [← hQQ, mulVec_mulVec, ← Matrix.mul_assoc,
+    inv_mul_of_invertible, Matrix.one_mul]
+
+private theorem resolvent_sqrt_defect_identity
+    {ι : Type*} [Fintype ι] [Nonempty ι]
+    (S : ι → Matrix n n ℂ) (b : ι → n → ℂ)
+    (hS : ∀ i, (S i).PosDef) :
+    let Sbar := ∑ i, S i
+    let bbar := ∑ i, b i
+    let x := Sbar⁻¹ *ᵥ bbar
+    ∑ i, ∑ p, ‖((CFC.sqrt (S i))⁻¹ *ᵥ b i -
+      CFC.sqrt (S i) *ᵥ x) p‖ ^ 2 =
+      ∑ i, (dotProduct (star (b i)) ((S i)⁻¹ *ᵥ b i)).re -
+        (dotProduct (star bbar) (Sbar⁻¹ *ᵥ bbar)).re := by
+  classical
+  dsimp only
+  let Sbar : Matrix n n ℂ := ∑ i, S i
+  let bbar : n → ℂ := ∑ i, b i
+  let x : n → ℂ := Sbar⁻¹ *ᵥ bbar
+  have hresComplex :
+      ∑ i, dotProduct (star (b i - S i *ᵥ x))
+          ((S i)⁻¹ *ᵥ (b i - S i *ᵥ x)) =
+        (∑ i, dotProduct (star (b i)) ((S i)⁻¹ *ᵥ b i)) -
+          dotProduct (star bbar) (Sbar⁻¹ *ᵥ bbar) := by
+    simpa only [x, bbar, Sbar] using resolvent_residual_identity S b hS
+  have hres := congrArg Complex.re hresComplex
+  change (∑ i, ∑ p, ‖((CFC.sqrt (S i))⁻¹ *ᵥ b i -
+      CFC.sqrt (S i) *ᵥ x) p‖ ^ 2) = _
+  calc
+    ∑ i, ∑ p, ‖((CFC.sqrt (S i))⁻¹ *ᵥ b i -
+        CFC.sqrt (S i) *ᵥ x) p‖ ^ 2 =
+        ∑ i, (dotProduct (star (b i - S i *ᵥ x))
+          ((S i)⁻¹ *ᵥ (b i - S i *ᵥ x))).re := by
+            apply Finset.sum_congr rfl
+            intro i _
+            rw [sqrt_defect_eq_sqrt_inv_residual (S i) (hS i),
+              sqrt_inv_mulVec_normSq (S i) (hS i)]
+    _ = ∑ i, (dotProduct (star (b i)) ((S i)⁻¹ *ᵥ b i)).re -
+        (dotProduct (star bbar) (Sbar⁻¹ *ᵥ bbar)).re := by
+          simpa only [Complex.re_sum, Complex.sub_re] using hres
+
+private theorem resolvent_eq_of_sqrt_defect_sum_eq_zero
+    {ι : Type*} [Fintype ι] [Nonempty ι]
+    (S : ι → Matrix n n ℂ) (b : ι → n → ℂ)
+    (hS : ∀ i, (S i).PosDef)
+    (hzero :
+      let Sbar := ∑ i, S i
+      let bbar := ∑ i, b i
+      let x := Sbar⁻¹ *ᵥ bbar
+      ∑ i, ∑ p, ‖((CFC.sqrt (S i))⁻¹ *ᵥ b i -
+        CFC.sqrt (S i) *ᵥ x) p‖ ^ 2 = 0) :
+    ∀ i, (S i)⁻¹ *ᵥ b i = (∑ j, S j)⁻¹ *ᵥ (∑ j, b j) := by
+  classical
+  let Sbar : Matrix n n ℂ := ∑ i, S i
+  let bbar : n → ℂ := ∑ i, b i
+  let x : n → ℂ := Sbar⁻¹ *ᵥ bbar
+  change (∑ i, ∑ p, ‖((CFC.sqrt (S i))⁻¹ *ᵥ b i -
+      CFC.sqrt (S i) *ᵥ x) p‖ ^ 2) = 0 at hzero
+  have hi (i : ι) : ∑ p, ‖((CFC.sqrt (S i))⁻¹ *ᵥ b i -
+      CFC.sqrt (S i) *ᵥ x) p‖ ^ 2 = 0 := by
+    exact (Finset.sum_eq_zero_iff_of_nonneg
+      (fun j _ ↦ Finset.sum_nonneg (fun p _ ↦ sq_nonneg _))).mp hzero i
+      (Finset.mem_univ i)
+  intro i
+  have hm : (CFC.sqrt (S i))⁻¹ *ᵥ b i -
+      CFC.sqrt (S i) *ᵥ x = 0 := by
+    funext p
+    have hp : ‖((CFC.sqrt (S i))⁻¹ *ᵥ b i -
+        CFC.sqrt (S i) *ᵥ x) p‖ ^ 2 = 0 :=
+      (Finset.sum_eq_zero_iff_of_nonneg (fun q _ ↦ sq_nonneg _)).mp (hi i) p
+        (Finset.mem_univ p)
+    exact norm_eq_zero.mp (sq_eq_zero_iff.mp hp)
+  let Q : Matrix n n ℂ := CFC.sqrt (S i)
+  have hQunit : IsUnit Q := by
+    change IsUnit (CFC.sqrt (S i))
+    rw [CFC.isUnit_sqrt_iff_isStrictlyPositive,
+      Matrix.isStrictlyPositive_iff_posDef]
+    exact hS i
+  letI : Invertible Q := hQunit.invertible
+  letI : Invertible (S i) := (hS i).isUnit.invertible
+  have hresInv : Q⁻¹ *ᵥ (b i - S i *ᵥ x) = 0 := by
+    rw [← sqrt_defect_eq_sqrt_inv_residual (S i) (hS i) (b i) x]
+    exact hm
+  have hres : b i - S i *ᵥ x = 0 := by
+    have hcancel : Q *ᵥ (Q⁻¹ *ᵥ (b i - S i *ᵥ x)) = b i - S i *ᵥ x := by
+      calc
+        Q *ᵥ (Q⁻¹ *ᵥ (b i - S i *ᵥ x)) =
+            (Q * Q⁻¹) *ᵥ (b i - S i *ᵥ x) := mulVec_mulVec _ _ _
+        _ = b i - S i *ᵥ x := by rw [mul_inv_of_invertible, one_mulVec]
+    calc
+      b i - S i *ᵥ x = Q *ᵥ (Q⁻¹ *ᵥ (b i - S i *ᵥ x)) := hcancel.symm
+      _ = 0 := by rw [hresInv, Matrix.mulVec_zero]
+  have hb : b i = S i *ᵥ x := sub_eq_zero.mp hres
+  change (S i)⁻¹ *ᵥ b i = x
+  rw [hb, mulVec_mulVec, inv_mul_of_invertible, one_mulVec]
+
+end Matrix
+
+namespace Matrix
+
+/-- **The fixed-resolvent defect identity for the finite Weyl family.**
+Let `A g` and `B g` be the uniformly weighted Weyl conjugates of positive
+definite matrices `ρ` and `σ`. For `t > 0`, the squared norm of the
+square-root resolvent defect is the difference between the sum of the
+summand quadratic forms and the quadratic form of their average.
+
+The vectorization is `X ↦ Matrix.vec Xᵀ`; hence
+`A ⊗ₖ 1 + t • (1 ⊗ₖ Bᵀ)` represents `X ↦ A * X + t • (X * B)`.
+This is the finite-Weyl specialization of Jenčová--Ruskai,
+arXiv:0903.2895, §4 and Appendix, equations `Mj` and `basiceq`. It is a
+fixed-`t`, positive-definite statement and does not derive vanishing of the
+defect from relative-entropy equality.
+
+**Scope restriction (positive definite, fixed `t`):** The source equality
+analysis also uses integration in `t` and limiting arguments for singular
+matrices. Those steps are not asserted here. Documented in
+`docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex`. -/
+theorem weyl_resolvent_defect_identity
+    {dS dC : ℕ} [NeZero dC]
+    {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
+    (hρ : ρ.PosDef) (hσ : σ.PosDef)
+    {ζ : ℂ} (hζ : IsPrimitiveRoot ζ dC) {t : ℝ} (ht : 0 < t) :
+    let U := fun g : ZMod dC × ZMod dC ↦
+      (1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ g.1 g.2
+    let q : ℝ := ((dC : ℝ) ^ 2)⁻¹
+    let A := fun g ↦ q • (U g * ρ * (U g)ᴴ)
+    let B := fun g ↦ q • (U g * σ * (U g)ᴴ)
+    let Abar := ∑ g, A g
+    let Bbar := ∑ g, B g
+    let S := fun g ↦ A g ⊗ₖ (1 : Matrix (Fin dS × ZMod dC)
+        (Fin dS × ZMod dC) ℂ) +
+      t • ((1 : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ) ⊗ₖ (B g)ᵀ)
+    let Sbar := Abar ⊗ₖ (1 : Matrix (Fin dS × ZMod dC)
+        (Fin dS × ZMod dC) ℂ) +
+      t • ((1 : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ) ⊗ₖ Bbarᵀ)
+    let b := fun g ↦ Matrix.vec (B g)ᵀ
+    let bbar := Matrix.vec Bbarᵀ
+    let x := Sbar⁻¹ *ᵥ bbar
+    ∑ g, ∑ p, ‖((CFC.sqrt (S g))⁻¹ *ᵥ b g -
+      CFC.sqrt (S g) *ᵥ x) p‖ ^ 2 =
+      ∑ g, (dotProduct (star (b g)) ((S g)⁻¹ *ᵥ b g)).re -
+        (dotProduct (star bbar) (Sbar⁻¹ *ᵥ bbar)).re := by
+  classical
+  dsimp only
+  let N := Fin dS × ZMod dC
+  let G := ZMod dC × ZMod dC
+  let U : G → Matrix N N ℂ := fun g ↦
+    (1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ g.1 g.2
+  let q : ℝ := ((dC : ℝ) ^ 2)⁻¹
+  let A : G → Matrix N N ℂ := fun g ↦ q • (U g * ρ * (U g)ᴴ)
+  let B : G → Matrix N N ℂ := fun g ↦ q • (U g * σ * (U g)ᴴ)
+  let Abar : Matrix N N ℂ := ∑ g, A g
+  let Bbar : Matrix N N ℂ := ∑ g, B g
+  let S : G → Matrix (N × N) (N × N) ℂ := fun g ↦
+    A g ⊗ₖ (1 : Matrix N N ℂ) +
+      t • ((1 : Matrix N N ℂ) ⊗ₖ (B g)ᵀ)
+  let Sbar : Matrix (N × N) (N × N) ℂ :=
+    Abar ⊗ₖ (1 : Matrix N N ℂ) +
+      t • ((1 : Matrix N N ℂ) ⊗ₖ Bbarᵀ)
+  let b : G → N × N → ℂ := fun g ↦ Matrix.vec (B g)ᵀ
+  let bbar : N × N → ℂ := Matrix.vec Bbarᵀ
+  let x : N × N → ℂ := Sbar⁻¹ *ᵥ bbar
+  have hdCpos : (0 : ℝ) < dC := by
+    exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne dC)
+  have hqpos : 0 < q := by
+    simp only [q]
+    positivity
+  have hU (g : G) : U g ∈ unitary (Matrix N N ℂ) := by
+    exact Matrix.kronecker_mem_unitary (Submonoid.one_mem _)
+      (weyl_mem_unitary hζ g.1 g.2)
+  have hA (g : G) : (A g).PosDef := by
+    have hc := posDef_conj_unitary hρ ⟨U g, hU g⟩
+    simpa only [A, star_eq_conjTranspose] using hc.smul hqpos
+  have hB (g : G) : (B g).PosDef := by
+    have hc := posDef_conj_unitary hσ ⟨U g, hU g⟩
+    simpa only [B, star_eq_conjTranspose] using hc.smul hqpos
+  have hS (g : G) : (S g).PosDef :=
+    superop_leftRight_posDef ht (hA g) (hB g)
+  have hsumS : ∑ g, S g = Sbar := by
+    ext ⟨a, b⟩ ⟨c, d⟩
+    simp only [S, Sbar, Abar, Bbar, Matrix.sum_apply, Matrix.add_apply,
+      Matrix.smul_apply, Matrix.kroneckerMap_apply, Matrix.transpose_apply,
+      Finset.sum_add_distrib, Finset.sum_mul, Finset.mul_sum]
+    rw [Finset.smul_sum]
+  have hsumb : ∑ g, b g = bbar := by
+    ext ⟨a, c⟩
+    simp only [b, bbar, Bbar, Matrix.vec, Matrix.transpose_apply,
+      Matrix.sum_apply, Finset.sum_apply]
+  have hdef := resolvent_sqrt_defect_identity S b hS
+  change (∑ g, ∑ p, ‖((CFC.sqrt (S g))⁻¹ *ᵥ b g -
+      CFC.sqrt (S g) *ᵥ x) p‖ ^ 2) =
+    ∑ g, (dotProduct (star (b g)) ((S g)⁻¹ *ᵥ b g)).re -
+      (dotProduct (star bbar) (Sbar⁻¹ *ᵥ bbar)).re
+  simpa only [hsumS, hsumb, x] using hdef
+
+/-- **Zero Weyl defect gives the common fixed-resolvent solution.**
+In the positive-definite finite Weyl family, if the difference of resolvent
+quadratic forms in `weyl_resolvent_defect_identity` vanishes at a fixed
+`t > 0`, then every summand has the same resolvent solution as the average.
+Taking `g = (0, 0)` gives the identity-Weyl summand required in the
+partial-trace equality argument.
+
+This is the zero-defect conclusion of Jenčová--Ruskai,
+arXiv:0903.2895, §4 and Appendix, equations `Mj` and `basiceq` and Theorem
+`thm:eqJp`. It does not assert that equality of relative entropies makes the
+displayed defect vanish.
+
+**Scope restriction (positive definite, fixed `t`):** The implication from
+relative-entropy equality to zero defect, integration in `t`, and singular
+supports remain outside this theorem. Documented in
+`docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex`. -/
+theorem weyl_resolvent_eq_of_defect_eq_zero
+    {dS dC : ℕ} [NeZero dC]
+    {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
+    (hρ : ρ.PosDef) (hσ : σ.PosDef)
+    {ζ : ℂ} (hζ : IsPrimitiveRoot ζ dC) {t : ℝ} (ht : 0 < t)
+    (hzero :
+      let U := fun g : ZMod dC × ZMod dC ↦
+        (1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ g.1 g.2
+      let q : ℝ := ((dC : ℝ) ^ 2)⁻¹
+      let A := fun g ↦ q • (U g * ρ * (U g)ᴴ)
+      let B := fun g ↦ q • (U g * σ * (U g)ᴴ)
+      let Abar := ∑ g, A g
+      let Bbar := ∑ g, B g
+      let S := fun g ↦ A g ⊗ₖ (1 : Matrix (Fin dS × ZMod dC)
+          (Fin dS × ZMod dC) ℂ) +
+        t • ((1 : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ) ⊗ₖ (B g)ᵀ)
+      let Sbar := Abar ⊗ₖ (1 : Matrix (Fin dS × ZMod dC)
+          (Fin dS × ZMod dC) ℂ) +
+        t • ((1 : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ) ⊗ₖ Bbarᵀ)
+      let b := fun g ↦ Matrix.vec (B g)ᵀ
+      let bbar := Matrix.vec Bbarᵀ
+      ∑ g, (dotProduct (star (b g)) ((S g)⁻¹ *ᵥ b g)).re -
+        (dotProduct (star bbar) (Sbar⁻¹ *ᵥ bbar)).re = 0) :
+    let U := fun g : ZMod dC × ZMod dC ↦
+      (1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ g.1 g.2
+    let q : ℝ := ((dC : ℝ) ^ 2)⁻¹
+    let A := fun g ↦ q • (U g * ρ * (U g)ᴴ)
+    let B := fun g ↦ q • (U g * σ * (U g)ᴴ)
+    let Abar := ∑ g, A g
+    let Bbar := ∑ g, B g
+    let S := fun g ↦ A g ⊗ₖ (1 : Matrix (Fin dS × ZMod dC)
+        (Fin dS × ZMod dC) ℂ) +
+      t • ((1 : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ) ⊗ₖ (B g)ᵀ)
+    let Sbar := Abar ⊗ₖ (1 : Matrix (Fin dS × ZMod dC)
+        (Fin dS × ZMod dC) ℂ) +
+      t • ((1 : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ) ⊗ₖ Bbarᵀ)
+    let b := fun g ↦ Matrix.vec (B g)ᵀ
+    let bbar := Matrix.vec Bbarᵀ
+    ∀ g, (S g)⁻¹ *ᵥ b g = Sbar⁻¹ *ᵥ bbar := by
+  classical
+  dsimp only at hzero ⊢
+  let N := Fin dS × ZMod dC
+  let G := ZMod dC × ZMod dC
+  let U : G → Matrix N N ℂ := fun g ↦
+    (1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ g.1 g.2
+  let q : ℝ := ((dC : ℝ) ^ 2)⁻¹
+  let A : G → Matrix N N ℂ := fun g ↦ q • (U g * ρ * (U g)ᴴ)
+  let B : G → Matrix N N ℂ := fun g ↦ q • (U g * σ * (U g)ᴴ)
+  let Abar : Matrix N N ℂ := ∑ g, A g
+  let Bbar : Matrix N N ℂ := ∑ g, B g
+  let S : G → Matrix (N × N) (N × N) ℂ := fun g ↦
+    A g ⊗ₖ (1 : Matrix N N ℂ) +
+      t • ((1 : Matrix N N ℂ) ⊗ₖ (B g)ᵀ)
+  let Sbar : Matrix (N × N) (N × N) ℂ :=
+    Abar ⊗ₖ (1 : Matrix N N ℂ) +
+      t • ((1 : Matrix N N ℂ) ⊗ₖ Bbarᵀ)
+  let b : G → N × N → ℂ := fun g ↦ Matrix.vec (B g)ᵀ
+  let bbar : N × N → ℂ := Matrix.vec Bbarᵀ
+  let x : N × N → ℂ := Sbar⁻¹ *ᵥ bbar
+  change (∑ g, (dotProduct (star (b g)) ((S g)⁻¹ *ᵥ b g)).re -
+      (dotProduct (star bbar) (Sbar⁻¹ *ᵥ bbar)).re) = 0 at hzero
+  change ∀ g, (S g)⁻¹ *ᵥ b g = Sbar⁻¹ *ᵥ bbar
+  have hdCpos : (0 : ℝ) < dC := by
+    exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne dC)
+  have hqpos : 0 < q := by
+    simp only [q]
+    positivity
+  have hU (g : G) : U g ∈ unitary (Matrix N N ℂ) := by
+    exact Matrix.kronecker_mem_unitary (Submonoid.one_mem _)
+      (weyl_mem_unitary hζ g.1 g.2)
+  have hA (g : G) : (A g).PosDef := by
+    have hc := posDef_conj_unitary hρ ⟨U g, hU g⟩
+    simpa only [A, star_eq_conjTranspose] using hc.smul hqpos
+  have hB (g : G) : (B g).PosDef := by
+    have hc := posDef_conj_unitary hσ ⟨U g, hU g⟩
+    simpa only [B, star_eq_conjTranspose] using hc.smul hqpos
+  have hS (g : G) : (S g).PosDef :=
+    superop_leftRight_posDef ht (hA g) (hB g)
+  have hsumS : ∑ g, S g = Sbar := by
+    ext ⟨a, b⟩ ⟨c, d⟩
+    simp only [S, Sbar, Abar, Bbar, Matrix.sum_apply, Matrix.add_apply,
+      Matrix.smul_apply, Matrix.kroneckerMap_apply, Matrix.transpose_apply,
+      Finset.sum_add_distrib, Finset.sum_mul, Finset.mul_sum]
+    rw [Finset.smul_sum]
+  have hsumb : ∑ g, b g = bbar := by
+    ext ⟨a, c⟩
+    simp only [b, bbar, Bbar, Matrix.vec, Matrix.transpose_apply,
+      Matrix.sum_apply, Finset.sum_apply]
+  have hdef := resolvent_sqrt_defect_identity S b hS
+  have hnormZero :
+      ∑ g, ∑ p, ‖((CFC.sqrt (S g))⁻¹ *ᵥ b g -
+        CFC.sqrt (S g) *ᵥ x) p‖ ^ 2 = 0 := by
+    calc
+      _ = ∑ g, (dotProduct (star (b g)) ((S g)⁻¹ *ᵥ b g)).re -
+          (dotProduct (star bbar) (Sbar⁻¹ *ᵥ bbar)).re := by
+            simpa only [hsumS, hsumb, x] using hdef
+      _ = 0 := hzero
+  have hall := resolvent_eq_of_sqrt_defect_sum_eq_zero S b hS
+    (by simpa only [hsumS, hsumb, x] using hnormZero)
+  intro g
+  simpa only [hsumS, hsumb] using hall g
+
+end Matrix

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -2401,6 +2401,91 @@ Theorem~\ref{thm:trace_norm_abs}.
     \]
 \end{proof}
 
+\begin{theorem}[Fixed-resolvent defect identity for the Weyl family]
+    \label{thm:weyl_resolvent_defect_identity}
+    \lean{Matrix.weyl_resolvent_defect_identity}
+    \leanok
+    \uses{thm:weyl_operator_unitary}
+    Let $\rho$ and $\sigma$ be positive definite on
+    $\mathcal H_S\otimes\mathbb C^{d_C}$, let
+    $q=d_C^{-2}$, and put
+    \[
+        A_g=qU_g\rho U_g^{\dagger},\qquad
+        B_g=qU_g\sigma U_g^{\dagger},\qquad
+        A=\sum_g A_g,\qquad B=\sum_g B_g,
+    \]
+    where $U_g=\mathbf 1_S\otimes W_g$.  For $t>0$, let
+    \[
+        T_g(X)=A_gX+tXB_g,\qquad T(X)=AX+tXB,
+        \qquad \Lambda_t=T^{-1}(B).
+    \]
+    Then
+    \[
+        \sum_g\left\|
+          T_g^{-1/2}(B_g)-T_g^{1/2}(\Lambda_t)
+        \right\|_{\mathrm{HS}}^2
+        =\sum_g\operatorname{Re}
+          \langle B_g,T_g^{-1}(B_g)\rangle_{\mathrm{HS}}
+          -\operatorname{Re}
+          \langle B,T^{-1}(B)\rangle_{\mathrm{HS}}.
+    \]
+    This is the positive-definite, fixed-$t$ identity in
+    Jen\v{c}ov\'a--Ruskai, arXiv:0903.2895, \S4 and Appendix, equations
+    \texttt{Mj} and \texttt{basiceq}.  It does not infer zero defect from
+    equality of relative entropies and makes no assertion about singular
+    supports.
+\end{theorem}
+
+\begin{proof}\leanok
+    Write $S_g$ for the positive definite matrix representing $T_g$ under
+    the vectorization $X\mapsto\operatorname{vec}(X^{\mathsf T})$, and put
+    $b_g=\operatorname{vec}(B_g^{\mathsf T})$ and
+    $x=S^{-1}\sum_g b_g$.  For the residual $r_g=b_g-S_gx$, direct expansion
+    gives
+    \[
+      \sum_g\langle r_g,S_g^{-1}r_g\rangle
+        =\sum_g\langle b_g,S_g^{-1}b_g\rangle
+          -\left\langle\sum_gb_g,
+            S^{-1}\sum_gb_g\right\rangle.
+    \]
+    Since $S_g^{1/2}$ is invertible,
+    \[
+      \|S_g^{-1/2}b_g-S_g^{1/2}x\|^2
+        =\|S_g^{-1/2}r_g\|^2
+        =\operatorname{Re}\langle r_g,S_g^{-1}r_g\rangle.
+    \]
+    Summing proves the identity.
+\end{proof}
+
+\begin{theorem}[Zero Weyl defect gives the common resolvent solution]
+    \label{thm:weyl_resolvent_zero_defect}
+    \lean{Matrix.weyl_resolvent_eq_of_defect_eq_zero}
+    \leanok
+    \uses{thm:weyl_resolvent_defect_identity}
+    Under the hypotheses and notation of the preceding theorem, suppose that
+    \[
+        \sum_g\operatorname{Re}
+          \langle B_g,T_g^{-1}(B_g)\rangle_{\mathrm{HS}}
+          -\operatorname{Re}
+          \langle B,T^{-1}(B)\rangle_{\mathrm{HS}}=0.
+    \]
+    Then, for every Weyl index $g$,
+    \[
+        T_g^{-1}(B_g)=T^{-1}(B).
+    \]
+    In particular this holds for the identity Weyl element $g=(0,0)$.
+    This fixed-$t$, positive-definite conclusion does not assert that equality
+    of relative entropies implies the displayed scalar hypothesis.
+\end{theorem}
+
+\begin{proof}\leanok
+    The preceding identity writes the hypothesis as a finite sum of squared
+    norms.  Each term is nonnegative, so every term vanishes.  Thus
+    $S_g^{-1/2}(b_g-S_gx)=0$ for every $g$.  Invertibility of
+    $S_g^{-1/2}$ gives $b_g=S_gx$, and hence
+    $S_g^{-1}b_g=x=S^{-1}\sum_hb_h$.
+\end{proof}
+
 \begin{lemma}[Maximally mixed support-sandwich normalization]
     \label{lem:maximally_mixed_support_sandwich}
     \lean{Matrix.PosSemidef.supportInvSqrt_kronecker_maximallyMixed_mul_mul}

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -308,10 +308,10 @@ arXiv:0903.2895, \S4 and Appendix, equations \texttt{Mj} and
 This result is deliberately restricted to positive definite inputs and one
 fixed value of $t$.  The missing analytic bridge is to rewrite the scalar
 equality in the preceding finite Weyl Jensen step as the integral of a
-nonnegative sum containing this defect, deduce the vanishing of this summand
-for every $t>0$, and then pass to singular supports.  Thus the new identity
-advances the saturation analysis but does not by itself imply the Petz
-sandwich below.
+nonnegative sum whose summands include a positive multiple of this defect,
+deduce its vanishing for every $t>0$, and then pass to singular supports.
+Thus the new identity advances the saturation analysis but does not by itself
+imply the Petz sandwich below.
 
 There is nevertheless a useful algebraic reduction for the identity summand.
 Write

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -278,6 +278,40 @@ value on the left.  The $d_R^2$ weights sum to one.
 This statement does not characterize equality in joint convexity and does not
 imply an operator intertwining or Petz recovery identity.
 
+For positive definite inputs, the fixed-resolvent algebra of the equality
+case is now available for the Weyl family.  With
+$A_g=d_R^{-2}U_g\rho U_g^\dagger$, $B_g=d_R^{-2}U_g\sigma U_g^\dagger$,
+and
+\[
+  T_g(X)=A_gX+tXB_g,\qquad
+  T(X)=\Bigl(\sum_gA_g\Bigr)X+tX\Bigl(\sum_gB_g\Bigr),
+\]
+put $\Lambda_t=T^{-1}(\sum_gB_g)$.  For every $t>0$, direct expansion of
+the residuals $R_g=B_g-T_g(\Lambda_t)$ gives the exact identity
+\begin{align}
+  \sum_g\left\|T_g^{-1/2}(B_g)-T_g^{1/2}(\Lambda_t)\right\|_{\rm HS}^2
+  &={}
+  \sum_g\operatorname{Re}\langle B_g,T_g^{-1}(B_g)\rangle_{\rm HS}\notag\\
+  &\quad-
+  \operatorname{Re}\left\langle\sum_gB_g,
+    T^{-1}\Bigl(\sum_gB_g\Bigr)\right\rangle_{\rm HS}.
+\end{align}
+Consequently, if the right-hand side vanishes, then
+$T_g^{-1}(B_g)=\Lambda_t$ for every $g$, in particular for the identity Weyl
+element.  This is the fixed-$t$ calculation of Jen\v{c}ov\'a--Ruskai,
+arXiv:0903.2895, \S4 and Appendix, equations \texttt{Mj} and
+\texttt{basiceq}.
+\footnote{Formal declarations:
+\leanid{Matrix.weyl_resolvent_defect_identity} and
+\leanid{Matrix.weyl_resolvent_eq_of_defect_eq_zero} in
+\path{TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean}.}
+This result is deliberately restricted to positive definite inputs and one
+fixed value of $t$.  The missing analytic bridge is to rewrite the scalar
+equality in the preceding finite Weyl Jensen step as the integral of this
+nonnegative defect, deduce its vanishing for every $t>0$, and then pass to
+singular supports.  Thus the new identity advances the saturation analysis
+but does not by itself imply the Petz sandwich below.
+
 There is nevertheless a useful algebraic reduction for the identity summand.
 Write
 \[

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -307,10 +307,11 @@ arXiv:0903.2895, \S4 and Appendix, equations \texttt{Mj} and
 \path{TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean}.}
 This result is deliberately restricted to positive definite inputs and one
 fixed value of $t$.  The missing analytic bridge is to rewrite the scalar
-equality in the preceding finite Weyl Jensen step as the integral of this
-nonnegative defect, deduce its vanishing for every $t>0$, and then pass to
-singular supports.  Thus the new identity advances the saturation analysis
-but does not by itself imply the Petz sandwich below.
+equality in the preceding finite Weyl Jensen step as the integral of a
+nonnegative sum containing this defect, deduce the vanishing of this summand
+for every $t>0$, and then pass to singular supports.  Thus the new identity
+advances the saturation analysis but does not by itself imply the Petz
+sandwich below.
 
 There is nevertheless a useful algebraic reduction for the identity summand.
 Write


### PR DESCRIPTION
Closes LionSR/QICLean#237.

Advances LionSR/QICLean#233 and LionSR/TNLean#4228; does not close either parent issue.

## Mathematical content

- promotes the positive-definiteness of the Kronecker matrix representing `X ↦ A X + t X B` to a reusable finite-index lemma;
- proves the exact positive-definite, fixed-`t` squared-resolvent-defect identity for the uniformly weighted finite Weyl family;
- proves that zero defect forces `T_g⁻¹(B_g) = T⁻¹(B)` for every Weyl summand, hence in particular for the identity element;
- records the theorem and proof in the entropy blueprint and sharpens the existing equality-case gap note.

The public results are deliberately Weyl-specialized. They do not state an equality theorem for arbitrary convex ensembles, derive zero defect from relative-entropy equality, integrate in `t`, prove the Petz sandwich, or treat singular supports.

## Verification

- `lake env lean TNLean/Analysis/SuperoperatorResolvent.lean`
- Mathlib-only scratch check of the complete private residual expansion, square-root identity, and zero-defect argument
- Mathlib-only scratch checks of the aggregate-superoperator specialization and zero-defect specialization used by the public proofs
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- line-length and proof-integrity searches on the changed Lean files

A direct check of `PetzEqualityPrerequisites.lean` and `leanblueprint checkdecls` could not be completed locally because a shared cache cleanup removed the generated TNLean oleans. I did not rebuild the repository, following the parent-agent resource constraint; PR CI is therefore the authoritative check of the two public declarations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new formal proofs in Petz equality prerequisites with subtle matrix/CFC and vectorization assumptions; incorrect lemmas could mislead downstream SSA equality work, though the PR explicitly avoids claiming the full Petz recovery chain.
> 
> **Overview**
> This PR formalizes the **fixed-`t`, positive-definite** resolvent defect algebra used in the Weyl route toward SSA equality (Jenčová–Ruskai), without claiming recovery from relative-entropy equality.
> 
> **`SuperoperatorResolvent.lean`** extracts **`superop_leftRight_posDef`**: the Kronecker matrix for `X ↦ A X + t X B` is positive definite when `A`, `B` are positive definite and `t > 0`. **`superop_resolvent_antitone`** is refactored to call this lemma instead of an inline proof.
> 
> **`PetzEqualityPrerequisites.lean`** adds private matrix lemmas (residual expansion, square-root defect norms, zero-defect ⇒ common resolvent solution) and two public theorems: **`Matrix.weyl_resolvent_defect_identity`** (sum of squared square-root defects equals the difference of resolvent quadratic forms) and **`Matrix.weyl_resolvent_eq_of_defect_eq_zero`** (vanishing of that difference forces every Weyl summand to share the average resolvent). Docstrings stress scope: positive definite inputs, fixed `t` only—no integral in `t`, no singular supports, no implication from DPI equality to zero defect.
> 
> **Blueprint** (`ch19_entropy.tex`) and **`docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex`** record the new results and clarify that the remaining gap is bridging finite Weyl Jensen equality to this defect via integration and singular limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83f815fd6625247afc692871a0e316dde99e27b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->