### PR TITLE
doc(blueprint/entropy): state support inverse identities

### DIFF
--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -1376,6 +1376,11 @@ Theorem~\ref{thm:trace_norm_abs}.
         (c\tau)^{-1/2}_{\mathrm{supp}}
           =c^{-1/2}\tau^{-1/2}_{\mathrm{supp}}.
     \]
+    The unital tensor embedding satisfies
+    \[
+        \bigl(\tau\otimes\mathbf 1_R\bigr)^{-1/2}_{\mathrm{supp}}
+          =\tau^{-1/2}_{\mathrm{supp}}\otimes\mathbf 1_R.
+    \]
     Consequently, for $d_R>0$,
     \[
         \bigl(\tau\otimes d_R^{-1}\mathbf 1_R\bigr)^{-1/2}_{\mathrm{supp}}
@@ -1386,9 +1391,13 @@ Theorem~\ref{thm:trace_norm_abs}.
 
 \begin{proof}\leanok
     The scalar identity follows from the functional calculus and
-    $\sqrt{cx}=\sqrt c\sqrt x$ for $c>0$.  The unital tensor embedding commutes
-    with the functional calculus, and substituting $c=d_R^{-1}$ gives the
-    second identity.
+    $\sqrt{cx}=\sqrt c\sqrt x$ for $c>0$.  For the function
+    $f(x)=x^{-1/2}$ when $x>0$ and $f(0)=0$, the tensor functional calculus gives
+    \[
+        f(\tau\otimes\mathbf 1_R)=f(\tau)\otimes\mathbf 1_R.
+    \]
+    This is the unscaled tensor identity in the statement.  Substituting
+    $c=d_R^{-1}$ then gives the maximally mixed identity.
 \end{proof}
 
 \begin{definition}[Support Petz transpose map for a partial trace]
@@ -2420,8 +2429,12 @@ Theorem~\ref{thm:trace_norm_abs}.
 
 \begin{proof}\leanok
     By the preceding support inverse formula, each outer factor contributes
-    $\sqrt{d_C}$.  These two factors cancel the coefficient $d_C^{-1}$ in
-    the middle tensor factor, leaving the asserted unital tensor embedding.
+    $\sqrt{d_C}$, and
+    \[
+        \sqrt{d_C}\,d_C^{-1}\sqrt{d_C}=1.
+    \]
+    Thus the two outer factors cancel the coefficient $d_C^{-1}$ in the middle
+    tensor factor, leaving the asserted unital tensor embedding.
 \end{proof}
 
 \begin{theorem}[Identity Weyl sandwich implies raw Petz recovery]


### PR DESCRIPTION
## Summary

- state the unscaled support-inverse tensor identity linked by the entropy blueprint
- display the tensor functional-calculus identity and the dimension-factor cancellation used by the proof sketches
- preserve the conditional boundary of the identity-Weyl-sandwich Petz theorem

## Validation

- python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci
- python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls
- python3 scripts/blueprint_lean_sync.py --root . --ci
- leanblueprint pdf
- lake exe cache get
- lake build TNLean
- cd blueprint && leanblueprint checkdecls
- git diff --check

No Lean declarations or proofs change. This PR does not claim that scalar relative-entropy equality yields the operator sandwich; LionSR/QICLean#233 remains the analytic equality step.

Closes LionSR/QICLean#239

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prose and proof sketches in the entropy blueprint only; no executable Lean or runtime behavior changes.
> 
> **Overview**
> Documentation-only updates in **`ch19_entropy.tex`** make the support-inverse-square-root lemmas easier to read and tie them to the existing Lean blueprint links.
> 
> **Lemma on scaling / maximally mixed factors** now states the **unscaled** identity \((\tau\otimes\mathbf 1_R)^{-1/2}_{\mathrm{supp}}=\tau^{-1/2}_{\mathrm{supp}}\otimes\mathbf 1_R\) explicitly before the \(\sqrt{d_R}\) maximally-mixed case. The proof sketch spells out tensor functional calculus for \(f(x)=x^{-1/2}\) (zero on the kernel) instead of a one-line “commutes with functional calculus” remark.
> 
> **Maximally mixed support-sandwich** proof adds the displayed cancellation \(\sqrt{d_C}\,d_C^{-1}\sqrt{d_C}=1\) so the middle \(d_C^{-1}\) factor is seen to cancel the two \(\sqrt{d_C}\) contributions from the outer support inverses.
> 
> No Lean declarations or proofs change; theorem boundaries (e.g. identity Weyl sandwich → Petz recovery still does not derive the sandwich from relative-entropy equality) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e10dc38fbdd48846594328c4ea80324f1f9c2578. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->