### PR TITLE
feat(MPS/MPDO): preserve rank under scalar extension

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -52,6 +52,7 @@ import TNLean.Algebra.ProjectiveRepresentation
 import TNLean.Algebra.ScalarCommutant
 import TNLean.Algebra.CocycleCohomology
 import TNLean.Algebra.SpinCover
+import TNLean.Algebra.MatrixRankBaseChange
 import TNLean.Algebra.MatrixRankClosed
 import TNLean.Algebra.StarSubalgebraBlockDiagonal
 import TNLean.Algebra.StarSubalgebraBlockForm
@@ -66,7 +67,6 @@ import TNLean.Algebra.StarSubalgebraSemisimple
 import TNLean.Algebra.StarSubalgebraSimpleModule
 import TNLean.Algebra.StarSubalgebraSpatial
 import TNLean.Algebra.StarSubalgebraUnitaryIntertwiner
-
 -- Layer 0b: General analysis
 import TNLean.Analysis.MeanErgodic
 import TNLean.Analysis.ProjectionGeometry

--- a/TNLean/Algebra/MatrixRankBaseChange.lean
+++ b/TNLean/Algebra/MatrixRankBaseChange.lean
@@ -1,0 +1,96 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.LinearAlgebra.LinearIndependent.BaseChange
+import Mathlib.LinearAlgebra.Matrix.Rank
+
+/-!
+# Matrix rank under scalar multiplication and scalar extension
+
+This file collects general rank invariance results for finite matrices.  It has
+only the linear-algebra imports needed by its consumers.
+
+## Main results
+
+* `Matrix.rank_smul_of_ne_zero`: multiplying a finite matrix over a field by a
+  nonzero scalar preserves its rank.
+* `Matrix.rank_map_algebraMap`: extending scalars along a faithful field
+  extension preserves the rank of a finite matrix.
+-/
+
+open Matrix Module Submodule Set
+
+namespace Matrix
+
+variable {K m n : Type*} [Field K] [Fintype n]
+
+/-- Multiplication by a nonzero field scalar does not change matrix rank. -/
+theorem rank_smul_of_ne_zero {a : K} (ha : a ≠ 0) (A : Matrix m n K) :
+    (a • A).rank = A.rank := by
+  have hrange :
+      LinearMap.range (a • A).mulVecLin = LinearMap.range A.mulVecLin := by
+    ext v
+    constructor
+    · rintro ⟨x, rfl⟩
+      exact ⟨a • x, by simp⟩
+    · rintro ⟨x, rfl⟩
+      exact ⟨a⁻¹ • x, by simp [ha]⟩
+  rw [Matrix.rank, Matrix.rank, hrange]
+
+variable [Finite m]
+
+/-- Extending scalars along a faithful field extension does not change the rank
+of a finite matrix. -/
+theorem rank_map_algebraMap {L : Type*}
+    [Field L] [Algebra K L] [FaithfulSMul K L]
+    (A : Matrix m n K) :
+    (A.map (algebraMap K L)).rank = A.rank := by
+  classical
+  have hli (s : ℕ) (j : Fin s → n) :
+      LinearIndependent L (fun i ↦ (A.map (algebraMap K L)).col (j i)) ↔
+        LinearIndependent K (fun i ↦ A.col (j i)) := by
+    have hcols :
+        (fun i ↦ (A.map (algebraMap K L)).col (j i)) =
+          (fun i ↦ (algebraMap K L) ∘ A.col (j i)) := by
+      funext i x
+      rfl
+    rw [hcols]
+    exact linearIndependent_algebraMap_comp_iff
+  apply le_antisymm
+  · rw [Matrix.rank_eq_finrank_span_cols, Matrix.rank_eq_finrank_span_cols]
+    obtain ⟨v, hv_mem, _, hv_ind⟩ :=
+      Submodule.exists_fun_fin_finrank_span_eq L
+        (Set.range (A.map (algebraMap K L)).col)
+    choose j hj using hv_mem
+    have hselectedL :
+        LinearIndependent L (fun i ↦ (A.map (algebraMap K L)).col (j i)) := by
+      rw [funext hj]
+      exact hv_ind
+    have hselectedK : LinearIndependent K (fun i ↦ A.col (j i)) :=
+      (hli _ j).mp hselectedL
+    have hrange : Set.range (fun i ↦ A.col (j i)) ⊆ Set.range A.col := by
+      rintro _ ⟨i, rfl⟩
+      exact ⟨j i, rfl⟩
+    simpa using (linearIndependent_iff_card_le_finrank_span.mp hselectedK).trans
+      (Submodule.finrank_mono (Submodule.span_mono hrange))
+  · rw [Matrix.rank_eq_finrank_span_cols, Matrix.rank_eq_finrank_span_cols]
+    obtain ⟨v, hv_mem, _, hv_ind⟩ :=
+      Submodule.exists_fun_fin_finrank_span_eq K (Set.range A.col)
+    choose j hj using hv_mem
+    have hselectedK : LinearIndependent K (fun i ↦ A.col (j i)) := by
+      rw [funext hj]
+      exact hv_ind
+    have hselectedL :
+        LinearIndependent L (fun i ↦ (A.map (algebraMap K L)).col (j i)) :=
+      (hli _ j).mpr hselectedK
+    have hrange :
+        Set.range (fun i ↦ (A.map (algebraMap K L)).col (j i)) ⊆
+          Set.range (A.map (algebraMap K L)).col := by
+      rintro _ ⟨i, rfl⟩
+      exact ⟨j i, rfl⟩
+    simpa using (linearIndependent_iff_card_le_finrank_span.mp hselectedL).trans
+      (Submodule.finrank_mono (Submodule.span_mono hrange))
+
+end Matrix

--- a/TNLean/Channel/SchmidtRank.lean
+++ b/TNLean/Channel/SchmidtRank.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 Sirui Lu and TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sirui Lu
 -/
+import TNLean.Algebra.MatrixRankBaseChange
 import Mathlib.Analysis.InnerProductSpace.PiL2
 import Mathlib.Analysis.InnerProductSpace.SingularValues
 import Mathlib.Data.Complex.Basic
@@ -39,7 +40,6 @@ bounded Schmidt rank.
   Schmidt rank is equivalent to vanishing of the corresponding singular value.
 * `Matrix.exists_mul_eq_of_rank_le`: a matrix of rank at most `k` factors
   through a `k`-dimensional coordinate space.
-* `Matrix.rank_smul_of_ne_zero`: nonzero complex rescaling preserves matrix rank.
 
 ## References
 
@@ -63,20 +63,6 @@ theorem schmidtCoeffMatrix_apply (ψ : m × n → ℂ) (i : m) (j : n) :
   rfl
 
 variable [Fintype n]
-
-/-- Multiplication by a nonzero complex scalar does not change the rank of a
-matrix. -/
-theorem rank_smul_of_ne_zero {c : ℂ} (hc : c ≠ 0) (A : Matrix m n ℂ) :
-    (c • A).rank = A.rank := by
-  have hrange :
-      LinearMap.range (c • A).mulVecLin = LinearMap.range A.mulVecLin := by
-    ext v
-    constructor
-    · rintro ⟨x, rfl⟩
-      exact ⟨c • x, by simp⟩
-    · rintro ⟨x, rfl⟩
-      exact ⟨c⁻¹ • x, by simp [hc]⟩
-  rw [Matrix.rank, Matrix.rank, hrange]
 
 /-- A matrix whose rank is at most `k` factors through `ℂ^k`. -/
 theorem exists_mul_eq_of_rank_le

--- a/TNLean/MPS/MPDO/DiagonalCutRank.lean
+++ b/TNLean/MPS/MPDO/DiagonalCutRank.lean
@@ -3,9 +3,9 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.MPDO.Defs
+import TNLean.Algebra.MatrixRankBaseChange
 import TNLean.Entropy.ClassicalMutualInformation
-import Mathlib.LinearAlgebra.Matrix.Rank
+import TNLean.MPS.MPDO.Defs
 
 /-!
 # Rank of a diagonal matrix-product-operator cut
@@ -19,9 +19,9 @@ This is the algebraic part of the classical-diagonal analysis of the estimate
 in Proposition 4.5 of arXiv:1606.00608.  Combined with Theorem 4.1 of
 arXiv:1704.06507, it gives the stronger classical estimate
 $I(X:Y) \leq 2\log D$.  The information-versus-rank theorem is formalized in
-`TNLean.Entropy.ClassicalMutualInformation`; the scalar normalization and
-real-to-complex rank comparison needed for the MPO corollary are handled below,
-with the latter retained as an explicit hypothesis.
+`TNLean.Entropy.ClassicalMutualInformation`; rank invariance under scalar
+normalization and scalar extension is proved in
+`TNLean.Algebra.MatrixRankBaseChange`.
 
 ## Main definitions
 
@@ -34,8 +34,8 @@ with the latter retained as an explicit hypothesis.
 * `MPOTensor.diagonalCutMatrix_rank_le`: the diagonal cut matrix of a periodic
   MPO has rank at most $D^2$.
 * `MPOTensor.diagonalCut_classicalMutualInformation_le_two_log`: normalized
-  real diagonal cut data has mutual information at most $2\log D$ once its
-  real rank is identified with the complex rank of the cut matrix.
+  real diagonal coefficients define a joint distribution whose mutual
+  information is at most $2\log D$.
 -/
 
 open scoped Matrix ComplexOrder BigOperators
@@ -44,19 +44,6 @@ open Matrix
 namespace Matrix
 
 variable {D : ℕ} {r c : Type*} [Fintype c]
-
-/-- Multiplication by a nonzero real scalar does not change matrix rank. -/
-theorem rank_smul_of_ne_zero_real {a : ℝ} (ha : a ≠ 0) (A : Matrix r c ℝ) :
-    (a • A).rank = A.rank := by
-  have hrange :
-      LinearMap.range (a • A).mulVecLin = LinearMap.range A.mulVecLin := by
-    ext v
-    constructor
-    · rintro ⟨x, rfl⟩
-      exact ⟨a • x, by simp⟩
-    · rintro ⟨x, rfl⟩
-      exact ⟨a⁻¹ • x, by simp [ha]⟩
-  rw [Matrix.rank, Matrix.rank, hrange]
 
 /-- The matrix of trace pairings $(x,y) \mapsto \operatorname{tr}(A_xB_y)$
 between two finite families of square matrices. -/
@@ -124,33 +111,33 @@ theorem diagonalCutMatrix_rank_le (M : MPOTensor d D) (L R : ℕ) :
 
 /-- **Classical diagonal-MPO cut estimate.** Let `W` be the real diagonal
 coefficient matrix of a periodic MPO cut, let `Z > 0` be its total mass, and
-let `P = Z⁻¹ • W` be the normalized joint distribution. If real scalar
-extension preserves the rank of `W`, then the classical mutual information of
-`P` is at most `2 * log D`.
+let `P = Z⁻¹ • W` be the normalized joint distribution. Then the classical
+mutual information of `P` is at most `2 * log D`.
 
 This is the formal assembly of Riazanov--Vyalyi, Theorem 4.1
 (arXiv:1704.06507), with the diagonal cut factorization supporting
-arXiv:1606.00608, Proposition 4.5. The hypotheses `hcut` and `hrank_map` make
-the currently unavailable real-to-complex cut-data bridge explicit; this
-statement does not concern unrestricted quantum mutual information.
+arXiv:1606.00608, Proposition 4.5. This statement does not concern unrestricted
+quantum mutual information.
 
-**Scope restriction (real-to-complex rank bridge):** The equality of real and
-complex ranks is an explicit hypothesis rather than a consequence of the
-current MPDO API. This remaining bridge is documented in
+**Scope restriction (coefficient matrix and probability distribution):** The
+real coefficient matrix `W`, the joint distribution `P`, their normalization
+relation, and the identification of the scalar extension of `W` with the
+complex cut matrix are explicit hypotheses rather than consequences of the
+current MPDO definitions. This remaining construction is documented in
 `docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
 theorem diagonalCut_classicalMutualInformation_le_two_log [NeZero D]
     (M : MPOTensor d D) (L R : ℕ)
     (W P : Matrix (Fin L → Fin d) (Fin R → Fin d) ℝ) (Z : ℝ)
     (hP : P.IsJointDistribution) (hZ : 0 < Z)
     (hnorm : P = Z⁻¹ • W)
-    (hcut : W.map Complex.ofReal = diagonalCutMatrix M L R)
-    (hrank_map : W.rank = (W.map Complex.ofReal).rank) :
+    (hcut : W.map Complex.ofReal = diagonalCutMatrix M L R) :
     Entropy.classicalMutualInformation P ≤ 2 * Real.log D := by
   have hD : (D : ℝ) ≠ 0 := by exact_mod_cast NeZero.ne D
   have hPrank : P.rank = W.rank := by
-    rw [hnorm, Matrix.rank_smul_of_ne_zero_real (inv_ne_zero hZ.ne')]
+    rw [hnorm, Matrix.rank_smul_of_ne_zero (inv_ne_zero hZ.ne')]
+  have hmap : W.map (algebraMap ℝ ℂ) = W.map Complex.ofReal := rfl
   have hWrank : W.rank ≤ D * D := by
-    rw [hrank_map, hcut]
+    rw [← Matrix.rank_map_algebraMap (L := ℂ) W, hmap, hcut]
     exact diagonalCutMatrix_rank_le M L R
   have hPrank_pos : 0 < P.rank := by
     rw [Matrix.rank, Module.finrank_pos_iff_exists_ne_zero]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
@@ -987,18 +987,38 @@
     factors $P$ through the $D^2$-dimensional space indexed by pairs $(a,b)$.
 \end{proof}
 
-\begin{lemma}[Rank under real normalization]
-    \label{lem:matrix_rank_real_smul}
-    \lean{Matrix.rank_smul_of_ne_zero_real}
+\begin{theorem}[Rank under nonzero scalar multiplication]
+    \label{thm:matrix_rank_smul}
+    \lean{Matrix.rank_smul_of_ne_zero}
     \leanok
-    Let $A$ be a finite real matrix and let $a\neq0$.  Then
+    Let $K$ be a field, let $A$ be a finite matrix over $K$, and let
+    $a\in K$ be nonzero.  Then
     \[
-      \operatorname{rank}_{\R}(aA)=\operatorname{rank}_{\R}A.
+      \operatorname{rank}_{K}(aA)=\operatorname{rank}_{K}A.
     \]
-\end{lemma}
+\end{theorem}
 \begin{proof}\leanok
     Multiplication by $a$ identifies the column spaces, with inverse given by
     multiplication by $a^{-1}$.
+\end{proof}
+
+\begin{theorem}[Rank under faithful scalar extension]
+    \label{thm:matrix_rank_scalar_extension}
+    \lean{Matrix.rank_map_algebraMap}
+    \leanok
+    Let $K\subseteq L$ be a faithful field extension, let
+    $\iota:K\hookrightarrow L$ be the inclusion, and let $A$ be a finite
+    matrix over $K$.  Then
+    \[
+      \operatorname{rank}_{L}\!\left((\iota(A_{ij}))_{ij}\right)
+      =\operatorname{rank}_{K} A.
+    \]
+\end{theorem}
+\begin{proof}\leanok
+    For every finite selection of columns, the selected columns are linearly
+    independent over $K$ if and only if their scalar extensions are linearly
+    independent over $L$.  Selecting a basis from each column space proves the
+    two rank inequalities.
 \end{proof}
 
 \begin{definition}[Joint probability distribution and marginals]
@@ -1119,31 +1139,28 @@
     points is at most $\log k$.
 \end{proof}
 
-\begin{theorem}[Classical estimate with an explicit rank bridge]
+\begin{theorem}[Classical estimate for normalized diagonal cut coefficients]
     \label{thm:mpo_diagonal_cut_classical_mutual_information}
     \lean{MPOTensor.diagonalCut_classicalMutualInformation_le_two_log}
     \leanok
     \uses{thm:mpo_diagonal_cut_rank,
       thm:classical_mutual_information_le_log_rank,
-      lem:matrix_rank_real_smul}
+      thm:matrix_rank_smul,
+      thm:matrix_rank_scalar_extension}
     Let $D\geq1$, and let $W$ be a real diagonal coefficient matrix across a
-    periodic cut of an MPO with bond dimension $D$.  Suppose its
-    complexification is the cut matrix $P^{\C}$ from
-    Theorem~\ref{thm:mpo_diagonal_cut_rank} and
-    \[
-      \operatorname{rank}_{\R}W=\operatorname{rank}_{\C}P^{\C}.
-    \]
+    periodic cut of an MPO with bond dimension $D$.  Suppose its scalar
+    extension to $\C$ is the cut matrix $P^{\C}$ from
+    Theorem~\ref{thm:mpo_diagonal_cut_rank}.
     If $Z>0$ and $P=Z^{-1}W$ is a joint probability distribution, then
     \[
       I(X:Y)_P\leq2\log D.
     \]
-    The rank equality is an explicit scope restriction; its derivation from
-    the current diagonal-cut data remains open.
 \end{theorem}
 \begin{proof}\leanok
     Normalization does not change real rank by
-    Lemma~\ref{lem:matrix_rank_real_smul}.  The explicit rank bridge and
-    Theorem~\ref{thm:mpo_diagonal_cut_rank} therefore give
+    Theorem~\ref{thm:matrix_rank_smul}.  Faithful scalar extension does
+    not change rank by Theorem~\ref{thm:matrix_rank_scalar_extension}; hence
+    Theorem~\ref{thm:mpo_diagonal_cut_rank} gives
     \[
       \operatorname{rank}_{\R}P\leq D^2.
     \]

--- a/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
@@ -204,14 +204,17 @@ The rank factorization is formalized.
 The information-versus-rank theorem of Riazanov--Vyalyi is formalized by
 \leanid{Entropy.classicalMutualInformation_le_log_rank} in
 \doclink{TNLean/Entropy/ClassicalMutualInformation}.  Real scalar normalization
-preserves rank by \leanid{Matrix.rank_smul_of_ne_zero_real}.  The conditional
-assembly, with the real-to-complex rank equality stated explicitly, is
-\leanid{MPOTensor.diagonalCut_classicalMutualInformation_le_two_log}; both are
-in \doclink{TNLean/MPS/MPDO/DiagonalCutRank}.  The remaining unconditional
-diagonal-MPO step is to construct the real cut matrix from positivity and
-diagonality and prove that its real rank equals the complex rank of its scalar
-extension.  The conditional theorem does not assert that this bridge follows
-from the current MPDO interface.
+preserves rank by \leanid{Matrix.rank_smul_of_ne_zero}, while faithful
+scalar extension preserves matrix rank by \leanid{Matrix.rank_map_algebraMap};
+both are in \doclink{TNLean/Algebra/MatrixRankBaseChange}.  The resulting
+finite-chain estimate
+\leanid{MPOTensor.diagonalCut_classicalMutualInformation_le_two_log} is in
+\doclink{TNLean/MPS/MPDO/DiagonalCutRank}.  The estimate assumes a real
+coefficient matrix, its normalized joint distribution, and an identification
+of its complex scalar extension with the diagonal cut matrix.  The remaining
+step at the MPDO level is to construct that coefficient matrix and probability
+distribution, together with the two identifications, from positivity and
+diagonality of the finite-chain operator.
 
 \section{What the rank-three separation establishes}
 


### PR DESCRIPTION
## Motivation

The finite-chain classical diagonal-MPO estimate added in #4361 retained an
explicit equality between the real rank of the coefficient matrix and the
complex rank of its scalar extension.  This equality is a general fact about
faithful field extensions and should not remain an assumption of the
information-theoretic result.

## Changes

- Add the light algebra module `TNLean.Algebra.MatrixRankBaseChange` for two
  general rank facts: invariance under nonzero field scalars and under faithful
  scalar extension.
- Prove `Matrix.rank_map_algebraMap`: extending the scalars of a finite matrix
  along a faithful field extension preserves its rank.
- Use this theorem to remove the explicit `hrank_map` hypothesis from
  `MPOTensor.diagonalCut_classicalMutualInformation_le_two_log`.
- Replace the complex-only scalar-rank lemma in `Channel.SchmidtRank` by the
  field-generic algebraic theorem.
- Record both scalar-normalization and scalar-extension rank results in the
  blueprint and paper-gap note.
- Update the mixed-state paper-gap note so that it states the exact remaining
  MPDO-level construction.

The rank proof transports linear independence for every finite selected family
of columns and obtains each rank inequality by selecting a basis of the
corresponding column space.

## Source alignment and scope

The resulting estimate combines Riazanov--Vyalyi, Theorem 4.1
(arXiv:1704.06507), with the periodic diagonal-cut factorization supporting
CPSV16 Proposition 4.5 (arXiv:1606.00608, local source lines 801--806).

This PR does not establish the unrestricted quantum mutual-information bound.
The remaining step for #4348 is to construct the real coefficient matrix, its
normalized joint distribution, and the complex cut identification directly
from positivity and diagonality of the finite-chain MPDO operator.  That
boundary is stated explicitly in the theorem docstring, blueprint, and
`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`.

## Verification

- full `lake build` (9604 jobs)
- focused builds for `TNLean.Algebra.MatrixRankBaseChange`,
  `TNLean.Channel.SchmidtRank`, and `TNLean.MPS.MPDO.DiagonalCutRank`
- `lake exe lint_style --github`
- axiom audit for both general rank theorems and the diagonal-cut
  estimate: only `propext`, `Classical.choice`, and `Quot.sound`
- forbidden-token check
- 1000-line file gate; `TNLean.lean` remains exactly 1000 lines
- reader-facing prose check
- blueprint/Lean synchronization and reverse declaration coverage
- `lake exe checkdecls blueprint/lean_decls`
- `chktex` on the changed blueprint chapter
- `git diff --check`

Advances #4348.
Closes #4366.
Related to #2380, #4169, and #4242.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure linear-algebra refactoring with localized theorem API tightening; no auth, I/O, or runtime behavior changes. Main risk is Mathlib proof correctness in the new rank extension lemma, which is standard and covered by full build verification.
> 
> **Overview**
> **Adds shared matrix rank lemmas** and **drops an explicit real/complex rank assumption** from the diagonal MPDO mutual-information estimate.
> 
> New module `TNLean.Algebra.MatrixRankBaseChange` proves **`Matrix.rank_smul_of_ne_zero`** (nonzero field scalar) and **`Matrix.rank_map_algebraMap`** (faithful scalar extension). The root import list includes it; `Channel.SchmidtRank` and `DiagonalCutRank` import it instead of local duplicate proofs (the complex-only and real-only `rank_smul` lemmas are removed).
> 
> **`MPOTensor.diagonalCut_classicalMutualInformation_le_two_log`** no longer takes **`hrank_map`**: normalization and **`rank_map_algebraMap`** (via `ℝ → ℂ`) supply real rank ≤ complex cut-matrix rank internally. Blueprint chapter 21 and `docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex` record the general theorems and narrow the stated remaining gap to constructing the coefficient matrix, joint distribution, and cut identification from MPDO data—not proving rank invariance under extension.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa21af547eeec4a2a614536eeae6cadf4a1cba39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->