### PR TITLE
fix(MPS/MPDO): record inactive sector obstruction

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -679,7 +679,6 @@ import TNLean.Wielandt.SpanGrowth.CumulativeToWordSpan
 import TNLean.Channel.Peripheral.CyclicDecomposition
 import TNLean.Channel.Peripheral.Cycles
 import TNLean.Channel.Peripheral.MultiCycleDecomposition
-
 -- Chapter 2 §2.3 normal-form existence (SVD + Lorentz)
 import TNLean.Channel.NormalForm
 

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -584,6 +584,7 @@ import TNLean.MPS.MPDO.CommutingOverlappingCoordinates
 import TNLean.MPS.MPDO.CommutingFormSpatialBridge
 import TNLean.MPS.MPDO.CommutingBondEtaDecomposition
 import TNLean.MPS.MPDO.CommutingBondEtaCyclicTransport
+import TNLean.MPS.MPDO.CommutingBondTraceMatrixObstruction
 import TNLean.MPS.MPDO.CyclicEdgeWeightTensor
 import TNLean.MPS.MPDO.FixedBondProductTensor
 import TNLean.MPS.MPDO.FixedBondProductEtaTensor

--- a/TNLean/MPS/MPDO/CommutingBondTraceMatrixObstruction.lean
+++ b/TNLean/MPS/MPDO/CommutingBondTraceMatrixObstruction.lean
@@ -20,8 +20,8 @@ vanishes.  Its trace matrix is then not primitive.
 
 The example is the pure product MPDO on a two-dimensional physical space.  Its
 bond dimension is one and its only nonzero tensor entry is
-$\mathcal K^{0,0}=1$.  The two one-dimensional Beigi sectors give neighboring
-operators with trace matrix
+$\mathcal K^{0,0}=1$.  In the chosen two-sector Beigi-style factorization, the
+neighboring operators have trace matrix
 \[
   T=\begin{pmatrix}1&0\\0&0\end{pmatrix}.
 \]
@@ -64,8 +64,8 @@ noncomputable def sectorEquiv :
     subst y
     rfl
 
-/-- The sector factorization used in arXiv:1606.00608, Appendix C.2,
-lines 1603--1605, specialized to the product tensor. -/
+/-- A two-sector factorization of the kind invoked in arXiv:1606.00608,
+Appendix C.2, lines 1603--1605, specialized to the product tensor. -/
 noncomputable def factorization : PhysicalSectorFactorization tensor where
   sectorCount := 2
   leftDim := fun _ => 1

--- a/TNLean/MPS/MPDO/CommutingBondTraceMatrixObstruction.lean
+++ b/TNLean/MPS/MPDO/CommutingBondTraceMatrixObstruction.lean
@@ -1,0 +1,276 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.CanonicalForm.Definitions
+import TNLean.MPS.MPDO.PhysicalSectorEtaLocalStructure
+import TNLean.MPS.MPDO.ZCL
+
+/-!
+# Inactive-sector obstruction to primitivity of a commuting-bond trace matrix
+
+This file records the inactive-sector obstruction in the converse argument of
+arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines 1603--1613.  A normal
+source block with source zero correlation length and one exact positive
+translation-invariant commuting-bond presentation need not make the full Beigi
+trace matrix primitive: the middle-space decomposition can retain a physical
+summand on which the bond vanishes.
+
+The example is the pure product MPDO on a two-dimensional physical space.  Its
+bond dimension is one and its only nonzero tensor entry is
+`K^{0,0} = 1`.  The two one-dimensional Beigi sectors give neighboring
+operators with trace matrix
+\[
+  T=\begin{pmatrix}1&0\\0&0\end{pmatrix}.
+\]
+Thus the source hypotheses do not imply primitivity before inactive sectors
+are removed.  This does not refute a theorem about a source-faithfully defined
+active restriction of `T`; constructing that restriction and proving its
+primitivity remain separate obligations.
+
+## References
+
+* arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines 1597--1619.
+* Beigi, arXiv:1105.1019v2, Lemma 2.1.
+-/
+
+open scoped BigOperators ComplexOrder Matrix
+
+namespace MPOTensor.CommutingBondTraceMatrixObstruction
+
+/-- The indicator of the retained physical sector. -/
+noncomputable def sectorWeight (k : Fin 2) : ℂ := if k = 0 then 1 else 0
+
+/-- The bond-dimension-one pure product MPDO with only `K^{0,0}` nonzero. -/
+noncomputable def tensor : MPOTensor 2 1 :=
+  fun i j => if i = j then Matrix.of fun _ _ => sectorWeight i else 0
+
+/-- The two-dimensional physical space as two one-dimensional sectors in the
+decomposition of Beigi, arXiv:1105.1019v2, Lemma 2.1. -/
+noncomputable def sectorEquiv :
+    Fin 2 ≃ Sigma fun _k : Fin 2 => Fin 1 × Fin 1 where
+  toFun k := ⟨k, (0, 0)⟩
+  invFun q := q.1
+  left_inv _ := rfl
+  right_inv := by
+    rintro ⟨k, x, y⟩
+    have hx : x = 0 := Subsingleton.elim _ _
+    have hy : y = 0 := Subsingleton.elim _ _
+    subst x
+    subst y
+    rfl
+
+/-- The sector factorization used in arXiv:1606.00608, Appendix C.2,
+lines 1603--1605, specialized to the product tensor. -/
+noncomputable def factorization : PhysicalSectorFactorization tensor where
+  sectorCount := 2
+  leftDim := fun _ => 1
+  rightDim := fun _ => 1
+  leftDim_pos := fun _ => by omega
+  rightDim_pos := fun _ => by omega
+  sectorEquiv := sectorEquiv
+  physicalIsometry := 1
+  physicalIsometry_isometry := by simp
+  leftTensor := fun k _ => Matrix.of fun _ _ => sectorWeight k
+  rightTensor := fun k _ => Matrix.of fun _ _ => sectorWeight k
+  factorization := by
+    intro beta alpha
+    ext q r
+    obtain ⟨k, x, y⟩ := q
+    obtain ⟨h, u, v⟩ := r
+    fin_cases x
+    fin_cases y
+    fin_cases u
+    fin_cases v
+    by_cases hkh : k = h
+    · subst h
+      simp only [Matrix.reindex_apply, Matrix.conjTranspose_one, Matrix.one_mul,
+        Matrix.mul_one]
+      rw [Matrix.blockDiagonal'_apply_eq]
+      simp [Matrix.submatrix_apply, sectorEquiv, physicalSlice, tensor]
+      simp [sectorWeight]
+    · simp only [Matrix.reindex_apply, Matrix.conjTranspose_one, Matrix.one_mul,
+        Matrix.mul_one]
+      change tensor k h beta alpha =
+        Matrix.blockDiagonal'
+          (fun q => Matrix.kroneckerMap (· * ·)
+            (Matrix.of fun _ _ => sectorWeight q)
+            (Matrix.of fun _ _ => sectorWeight q))
+          ⟨k, (0, 0)⟩ ⟨h, (0, 0)⟩
+      rw [Matrix.blockDiagonal'_apply_ne _ _ _ hkh]
+      simp [tensor, hkh]
+
+/-- The real trace matrix of the neighboring operators considered in
+arXiv:1606.00608, Appendix C.2, line 1613. -/
+noncomputable def traceMatrix : Matrix (Fin 2) (Fin 2) ℝ :=
+  fun k h => (Matrix.trace (factorization.neighboringOperator k h)).re
+
+/-- The neighboring operator is the scalar product of the two sector
+indicators. -/
+lemma neighboringOperator_eq (k h : Fin 2) :
+    factorization.neighboringOperator k h =
+      Matrix.diagonal (fun _ : Fin 1 × Fin 1 => sectorWeight k * sectorWeight h) := by
+  ext x y
+  obtain ⟨x₁, x₂⟩ := x
+  obtain ⟨y₁, y₂⟩ := y
+  fin_cases x₁
+  fin_cases x₂
+  fin_cases y₁
+  fin_cases y₂
+  simp [PhysicalSectorFactorization.neighboringOperator_apply,
+    factorization]
+
+/-- Every neighboring operator in the displayed decomposition is positive
+semidefinite. -/
+lemma neighboringOperator_posSemidef (k h : Fin 2) :
+    (factorization.neighboringOperator k h).PosSemidef := by
+  rw [neighboringOperator_eq]
+  apply Matrix.PosSemidef.diagonal
+  intro i
+  fin_cases k <;> fin_cases h <;> norm_num [sectorWeight, Complex.nonneg_iff]
+
+/-- The full two-sector trace matrix is `diag(1, 0)`. -/
+lemma traceMatrix_eq : traceMatrix = !![1, 0; 0, 0] := by
+  have huniv : (Finset.univ : Finset (Fin 1 × Fin 1)) = {(0, 0)} := by
+    ext x
+    simp [Subsingleton.elim x (0, 0)]
+  ext k h
+  rw [traceMatrix, neighboringOperator_eq]
+  change (∑ _i : Fin 1 × Fin 1, sectorWeight k * sectorWeight h).re =
+    !![1, 0; 0, 0] k h
+  rw [huniv]
+  fin_cases k <;> fin_cases h <;> norm_num [sectorWeight]
+
+/-- The unused physical summand makes the full Beigi trace matrix
+nonprimitive. -/
+lemma traceMatrix_not_isPrimitive : ¬ Matrix.IsPrimitive traceMatrix := by
+  intro h
+  obtain ⟨n, hn, hpos⟩ := h.exists_pos_pow
+  have h11 := hpos (1 : Fin 2) (1 : Fin 2)
+  rw [traceMatrix_eq] at h11
+  have hdiag : (!![1, 0; 0, 0] : Matrix (Fin 2) (Fin 2) ℝ) =
+      Matrix.diagonal ![1, 0] := by
+    ext i j
+    fin_cases i <;> fin_cases j <;> simp
+  rw [hdiag, Matrix.diagonal_pow] at h11
+  norm_num [hn.ne'] at h11
+
+/-- The doubled-index transfer map of the product tensor is the identity on its
+one-dimensional bond algebra. -/
+lemma transferMap_toMPSTensor :
+    MPSTensor.transferMap tensor.toMPSTensor = LinearMap.id := by
+  rw [← transferMap_eq_toMPSTensor]
+  apply LinearMap.ext
+  intro X
+  rw [transferMap_apply]
+  ext a b
+  fin_cases a
+  fin_cases b
+  simp [tensor, sectorWeight, Fin.sum_univ_two, Matrix.mul_apply]
+
+/-- The source tensor is normal. -/
+lemma tensor_isNormalTensor : MPSTensor.IsNormalTensor tensor.toMPSTensor :=
+  MPSTensor.isNormalTensor_of_bondDim_one_of_transferMap_eq_id
+    tensor.toMPSTensor transferMap_toMPSTensor
+
+/-- The product tensor is already injective before blocking. -/
+lemma tensor_isInjective : MPSTensor.IsInjective tensor.toMPSTensor := by
+  apply top_unique
+  intro X _hX
+  have hdiv : (0 : Fin (2 * 2)).divNat = (0 : Fin 2) := by decide
+  have hmod : (0 : Fin (2 * 2)).modNat = (0 : Fin 2) := by decide
+  have hone : tensor.toMPSTensor (0 : Fin (2 * 2)) = 1 := by
+    change tensor (0 : Fin (2 * 2)).divNat (0 : Fin (2 * 2)).modNat = 1
+    rw [hdiv, hmod]
+    ext a b
+    fin_cases a
+    fin_cases b
+    simp [tensor, sectorWeight]
+  have hone_mem : (1 : Matrix (Fin 1) (Fin 1) ℂ) ∈
+      Submodule.span ℂ (Set.range tensor.toMPSTensor) := by
+    rw [← hone]
+    exact Submodule.subset_span (Set.mem_range_self _)
+  have hX : X = (X 0 0) • (1 : Matrix (Fin 1) (Fin 1) ℂ) := by
+    ext a b
+    fin_cases a
+    fin_cases b
+    simp
+  rw [hX]
+  exact Submodule.smul_mem _ _ hone_mem
+
+/-- The physical-trace transfer is the identity matrix. -/
+lemma physTraceTransfer_tensor : physTraceTransfer tensor = 1 := by
+  ext a b
+  fin_cases a
+  fin_cases b
+  simp [physTraceTransfer, tensor, sectorWeight, Fin.sum_univ_two]
+
+/-- The product tensor has source zero correlation length. -/
+lemma tensor_isSourceZCL : tensor.IsSourceZCL := by
+  apply isSourceZCL_of_physTraceTransfer_sq tensor
+  · rw [physTraceTransfer_tensor]
+    exact one_ne_zero
+  · rw [physTraceTransfer_tensor, one_mul]
+
+/-- The unique bond index as a pair of unique purification indices. -/
+noncomputable def singletonPairEquiv : Fin 1 ≃ Fin 1 × Fin 1 where
+  toFun _ := (0, 0)
+  invFun _ := 0
+  left_inv _ := Subsingleton.elim _ _
+  right_inv _ := Subsingleton.elim _ _
+
+/-- A local purification of the product tensor. -/
+noncomputable def purification (i : Fin 2) (_k : Fin 1) :
+    Matrix (Fin 1) (Fin 1) ℂ :=
+  Matrix.of fun _ _ => sectorWeight i
+
+/-- The product tensor is locally purifiable. -/
+lemma tensor_isLPDO : tensor.IsLPDO := by
+  refine ⟨1, 1, purification, singletonPairEquiv, ?_⟩
+  intro i j
+  ext a b
+  fin_cases a
+  fin_cases b
+  fin_cases i <;> fin_cases j <;>
+    norm_num [tensor, purification, singletonPairEquiv, sectorWeight,
+      Matrix.kroneckerMap_apply]
+
+/-- The product tensor generates positive semidefinite operators on every
+nonempty chain. -/
+lemma tensor_isMPDO : tensor.IsMPDO := tensor_isLPDO.isMPDO
+
+/-- The exact fixed commuting-bond presentation assembled from the displayed
+Beigi neighboring operators. -/
+noncomputable def commutingBondData : EtaLocalStructureData tensor :=
+  factorization.etaLocalStructureData neighboringOperator_posSemidef
+
+/-- The fixed commuting-bond product equals the source MPO with coefficient
+one at every length in the source range. -/
+lemma mpo_eq_commutingBondProduct (N : ℕ) (hN : 2 ≤ N) :
+    mpo tensor N =
+      (commutingBondData.bondData.toCommutingFormData hN).product := by
+  exact factorization.mpo_eq_product_physicalBond hN
+
+/-- A normal MPDO block with source zero correlation length and an exact fixed
+positive commuting-bond presentation need not have a primitive full Beigi
+trace matrix.
+
+This formally obstructs the raw primitivity target suggested after
+arXiv:1606.00608, Appendix C.2, line 1613.  The example does not address a
+trace matrix restricted to a source-faithfully defined active sector set. -/
+theorem normal_sourceZCL_fixed_commutingBond_does_not_force_traceMatrix_primitive :
+    tensor.IsMPDO ∧
+      MPSTensor.IsInjective tensor.toMPSTensor ∧
+      MPSTensor.IsNormalTensor tensor.toMPSTensor ∧
+      tensor.IsSourceZCL ∧
+      (∀ k h, (factorization.neighboringOperator k h).PosSemidef) ∧
+      (∀ (N : ℕ) (hN : 2 ≤ N),
+        mpo tensor N =
+          (commutingBondData.bondData.toCommutingFormData hN).product) ∧
+      ¬ Matrix.IsPrimitive traceMatrix := by
+  exact ⟨tensor_isMPDO, tensor_isInjective, tensor_isNormalTensor, tensor_isSourceZCL,
+    neighboringOperator_posSemidef, mpo_eq_commutingBondProduct,
+    traceMatrix_not_isPrimitive⟩
+
+end MPOTensor.CommutingBondTraceMatrixObstruction

--- a/TNLean/MPS/MPDO/CommutingBondTraceMatrixObstruction.lean
+++ b/TNLean/MPS/MPDO/CommutingBondTraceMatrixObstruction.lean
@@ -178,7 +178,7 @@ lemma tensor_isNormalTensor : MPSTensor.IsNormalTensor tensor.toMPSTensor :=
     tensor.toMPSTensor transferMap_toMPSTensor
 
 /-- The product tensor is already injective before blocking. -/
-lemma tensor_isInjective : MPSTensor.IsInjective tensor.toMPSTensor := by
+lemma tensor_isInjective : tensor.IsInjective := by
   apply top_unique
   intro X _hX
   have hdiv : (0 : Fin (2 * 2)).divNat = (0 : Fin 2) := by decide
@@ -264,7 +264,7 @@ line 1613, must be selected or pruned by a separate argument.  The example does
 not rule out another factorization with primitive trace matrix. -/
 theorem normal_sourceZCL_fixed_commutingBond_does_not_force_traceMatrix_primitive :
     tensor.IsMPDO ∧
-      MPSTensor.IsInjective tensor.toMPSTensor ∧
+      tensor.IsInjective ∧
       MPSTensor.IsNormalTensor tensor.toMPSTensor ∧
       tensor.IsSourceZCL ∧
       (∀ k h, (factorization.neighboringOperator k h).PosSemidef) ∧

--- a/TNLean/MPS/MPDO/CommutingBondTraceMatrixObstruction.lean
+++ b/TNLean/MPS/MPDO/CommutingBondTraceMatrixObstruction.lean
@@ -8,14 +8,14 @@ import TNLean.MPS.MPDO.PhysicalSectorEtaLocalStructure
 import TNLean.MPS.MPDO.ZCL
 
 /-!
-# Inactive-sector obstruction to primitivity of a commuting-bond trace matrix
+# A nonminimal sector factorization with nonprimitive trace matrix
 
 This file records the inactive-sector obstruction in the converse argument of
-arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines 1603--1613.  A normal
-source block with source zero correlation length and one exact positive
-translation-invariant commuting-bond presentation need not make the full Beigi
-trace matrix primitive: the middle-space decomposition can retain a physical
-summand on which the bond vanishes.
+arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines 1603--1613.  Even for
+a normal source block with source zero correlation length and one exact positive
+translation-invariant commuting-bond presentation, a chosen nonminimal
+middle-space decomposition can retain a physical summand on which the bond
+vanishes.  Its trace matrix is then not primitive.
 
 The example is the pure product MPDO on a two-dimensional physical space.  Its
 bond dimension is one and its only nonzero tensor entry is
@@ -24,10 +24,11 @@ operators with trace matrix
 \[
   T=\begin{pmatrix}1&0\\0&0\end{pmatrix}.
 \]
-Thus the source hypotheses do not imply primitivity before inactive sectors
-are removed.  This does not refute a theorem about a source-faithfully defined
-active restriction of `T`; constructing that restriction and proving its
-primitivity remain separate obligations.
+This does not exclude another factorization with primitive trace matrix: the
+same product tensor has a one-sector factorization.  Thus an existential
+repair of the source proof requires a source-faithful minimal or visible-sector
+selection theorem; primitivity cannot be inferred for an arbitrary selected
+factorization merely from the displayed commuting product.
 
 ## References
 
@@ -252,13 +253,13 @@ lemma mpo_eq_commutingBondProduct (N : ℕ) (hN : 2 ≤ N) :
       (commutingBondData.bondData.toCommutingFormData hN).product := by
   exact factorization.mpo_eq_product_physicalBond hN
 
-/-- A normal MPDO block with source zero correlation length and an exact fixed
-positive commuting-bond presentation need not have a primitive full Beigi
-trace matrix.
+/-- A chosen nonminimal factorization of a normal source-ZCL MPDO with an exact
+fixed positive commuting-bond presentation need not have a primitive trace
+matrix.
 
-This formally obstructs the raw primitivity target suggested after
-arXiv:1606.00608, Appendix C.2, line 1613.  The example does not address a
-trace matrix restricted to a source-faithfully defined active sector set. -/
+This shows that the factorization needed after arXiv:1606.00608, Appendix C.2,
+line 1613, must be selected or pruned by a separate argument.  The example does
+not rule out another factorization with primitive trace matrix. -/
 theorem normal_sourceZCL_fixed_commutingBond_does_not_force_traceMatrix_primitive :
     tensor.IsMPDO ∧
       MPSTensor.IsInjective tensor.toMPSTensor ∧

--- a/TNLean/MPS/MPDO/CommutingBondTraceMatrixObstruction.lean
+++ b/TNLean/MPS/MPDO/CommutingBondTraceMatrixObstruction.lean
@@ -104,10 +104,121 @@ noncomputable def factorization : PhysicalSectorFactorization tensor where
       rw [Matrix.blockDiagonal'_apply_ne _ _ _ hkh]
       simp [tensor, hkh]
 
+/-- The two physical basis vectors as one sector with a two-dimensional left
+factor and a one-dimensional right factor.
+
+Source: Beigi, arXiv:1105.1019v2, Lemma 2.1; arXiv:1606.00608,
+Appendix C.2, lines 1603--1605. -/
+noncomputable def oneSectorEquiv :
+    Fin 2 ≃ Sigma fun _k : Fin 1 => Fin 2 × Fin 1 where
+  toFun i := ⟨0, (i, 0)⟩
+  invFun q := q.2.1
+  left_inv _ := rfl
+  right_inv := by
+    rintro ⟨k, i, j⟩
+    have hk : k = 0 := Subsingleton.elim _ _
+    have hj : j = 0 := Subsingleton.elim _ _
+    subst k
+    subst j
+    rfl
+
+/-- A one-sector factorization of the product tensor, with the sector weight
+placed entirely in its two-dimensional left factor.
+
+Source: Beigi, arXiv:1105.1019v2, Lemma 2.1; arXiv:1606.00608,
+Appendix C.2, lines 1603--1605. -/
+noncomputable def oneSectorFactorization : PhysicalSectorFactorization tensor where
+  sectorCount := 1
+  leftDim := fun _ => 2
+  rightDim := fun _ => 1
+  leftDim_pos := fun _ => by omega
+  rightDim_pos := fun _ => by omega
+  sectorEquiv := oneSectorEquiv
+  physicalIsometry := 1
+  physicalIsometry_isometry := by simp
+  leftTensor := fun _ _ => Matrix.diagonal sectorWeight
+  rightTensor := fun _ _ => 1
+  factorization := by
+    intro beta alpha
+    ext q r
+    obtain ⟨k, x, y⟩ := q
+    obtain ⟨h, u, v⟩ := r
+    fin_cases k
+    fin_cases h
+    fin_cases y
+    fin_cases v
+    fin_cases beta
+    fin_cases alpha
+    simp [Matrix.reindex_apply, oneSectorEquiv, physicalSlice, tensor,
+      Matrix.blockDiagonal'_apply_eq, Matrix.kroneckerMap_apply, Matrix.diagonal_apply]
+    by_cases hxu : x = u
+    all_goals simp [hxu]
+
 /-- The real trace matrix of the neighboring operators considered in
 arXiv:1606.00608, Appendix C.2, line 1613. -/
 noncomputable def traceMatrix : Matrix (Fin 2) (Fin 2) ℝ :=
   fun k h => (Matrix.trace (factorization.neighboringOperator k h)).re
+
+/-- The real trace matrix of the one-sector neighboring family.
+
+Source: arXiv:1606.00608, Appendix C.2, line 1613. -/
+noncomputable def oneSectorTraceMatrix : Matrix (Fin 1) (Fin 1) ℝ :=
+  fun k h => (Matrix.trace (oneSectorFactorization.neighboringOperator k h)).re
+
+/-- The sole neighboring operator in the one-sector factorization is the
+rank-one diagonal matrix with diagonal $(1,0)$.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `etarl`, lines 1441--1445. -/
+lemma oneSector_neighboringOperator_eq
+    (k h : Fin oneSectorFactorization.sectorCount) :
+    oneSectorFactorization.neighboringOperator k h =
+      Matrix.diagonal (fun x : Fin 1 × Fin 2 => sectorWeight x.2) := by
+  ext x y
+  obtain ⟨x₁, x₂⟩ := x
+  obtain ⟨y₁, y₂⟩ := y
+  simp only [PhysicalSectorFactorization.neighboringOperator_apply, Finset.univ_unique,
+    Fin.default_eq_zero, Fin.isValue, Finset.sum_singleton]
+  fin_cases x₁
+  fin_cases y₁
+  simp only [oneSectorFactorization, Matrix.one_apply, Matrix.diagonal_apply]
+  simp only [if_true, one_mul, Prod.mk.injEq, true_and]
+
+/-- Every neighboring operator in the one-sector factorization is positive
+semidefinite.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `etarl`, lines 1441--1445. -/
+lemma oneSector_neighboringOperator_posSemidef
+    (k h : Fin oneSectorFactorization.sectorCount) :
+    (oneSectorFactorization.neighboringOperator k h).PosSemidef := by
+  rw [oneSector_neighboringOperator_eq]
+  apply Matrix.PosSemidef.diagonal
+  intro i
+  change (0 : ℂ) ≤ sectorWeight (show Fin 2 from i.2)
+  by_cases hi : (show Fin 2 from i.2) = 0
+  all_goals simp [sectorWeight, hi]
+
+/-- The one-sector trace matrix is the positive one-by-one matrix $(1)$.
+
+Source: arXiv:1606.00608, Appendix C.2, line 1613. -/
+lemma oneSectorTraceMatrix_eq : oneSectorTraceMatrix = 1 := by
+  ext k h
+  fin_cases k
+  fin_cases h
+  rw [oneSectorTraceMatrix, oneSector_neighboringOperator_eq]
+  norm_num [Matrix.trace, sectorWeight]
+  decide
+
+/-- The trace matrix of the one-sector factorization is primitive.
+
+Source: arXiv:1606.00608, Appendix C.2, line 1613. -/
+lemma oneSectorTraceMatrix_isPrimitive :
+    Matrix.IsPrimitive oneSectorTraceMatrix := by
+  rw [oneSectorTraceMatrix_eq]
+  refine ⟨?_, ⟨1, by norm_num, ?_⟩⟩
+  all_goals intro i j
+  all_goals fin_cases i
+  all_goals fin_cases j
+  all_goals norm_num
 
 /-- The neighboring operator is the scalar product of the two sector
 indicators. -/
@@ -261,7 +372,8 @@ matrix.
 
 This shows that the factorization needed after arXiv:1606.00608, Appendix C.2,
 line 1613, must be selected or pruned by a separate argument.  The example does
-not rule out another factorization with primitive trace matrix. -/
+not rule out another factorization with primitive trace matrix: the explicit
+one-sector factorization above has trace matrix $(1)$. -/
 theorem normal_sourceZCL_fixed_commutingBond_does_not_force_traceMatrix_primitive :
     tensor.IsMPDO ∧
       tensor.IsInjective ∧
@@ -271,9 +383,14 @@ theorem normal_sourceZCL_fixed_commutingBond_does_not_force_traceMatrix_primitiv
       (∀ (N : ℕ) (hN : 2 ≤ N),
         mpo tensor N =
           (commutingBondData.bondData.toCommutingFormData hN).product) ∧
-      ¬ Matrix.IsPrimitive traceMatrix := by
+      ¬ Matrix.IsPrimitive traceMatrix ∧
+      oneSectorFactorization.sectorCount = 1 ∧
+      (∀ k h,
+        (oneSectorFactorization.neighboringOperator k h).PosSemidef) ∧
+      Matrix.IsPrimitive oneSectorTraceMatrix := by
   exact ⟨tensor_isMPDO, tensor_isInjective, tensor_isNormalTensor, tensor_isSourceZCL,
     neighboringOperator_posSemidef, mpo_eq_commutingBondProduct,
-    traceMatrix_not_isPrimitive⟩
+    traceMatrix_not_isPrimitive, rfl, oneSector_neighboringOperator_posSemidef,
+    oneSectorTraceMatrix_isPrimitive⟩
 
 end MPOTensor.CommutingBondTraceMatrixObstruction

--- a/TNLean/MPS/MPDO/CommutingBondTraceMatrixObstruction.lean
+++ b/TNLean/MPS/MPDO/CommutingBondTraceMatrixObstruction.lean
@@ -11,7 +11,8 @@ import TNLean.MPS.MPDO.ZCL
 # A nonminimal sector factorization with nonprimitive trace matrix
 
 This file records the inactive-sector obstruction in the converse argument of
-arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines 1603--1613.  Even for
+arXiv:1606.00608, Appendix C.2, the converse implication, lines 1603--1613.
+Even for
 a normal source block with source zero correlation length and one exact positive
 translation-invariant commuting-bond presentation, a chosen nonminimal
 middle-space decomposition can retain a physical summand on which the bond
@@ -19,7 +20,7 @@ vanishes.  Its trace matrix is then not primitive.
 
 The example is the pure product MPDO on a two-dimensional physical space.  Its
 bond dimension is one and its only nonzero tensor entry is
-`K^{0,0} = 1`.  The two one-dimensional Beigi sectors give neighboring
+$\mathcal K^{0,0}=1$.  The two one-dimensional Beigi sectors give neighboring
 operators with trace matrix
 \[
   T=\begin{pmatrix}1&0\\0&0\end{pmatrix}.
@@ -32,7 +33,7 @@ factorization merely from the displayed commuting product.
 
 ## References
 
-* arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines 1597--1619.
+* arXiv:1606.00608, Appendix C.2, converse implication, lines 1597--1619.
 * Beigi, arXiv:1105.1019v2, Lemma 2.1.
 -/
 
@@ -43,7 +44,8 @@ namespace MPOTensor.CommutingBondTraceMatrixObstruction
 /-- The indicator of the retained physical sector. -/
 noncomputable def sectorWeight (k : Fin 2) : ℂ := if k = 0 then 1 else 0
 
-/-- The bond-dimension-one pure product MPDO with only `K^{0,0}` nonzero. -/
+/-- The bond-dimension-one pure product MPDO with only
+$\mathcal K^{0,0}$ nonzero. -/
 noncomputable def tensor : MPOTensor 2 1 :=
   fun i j => if i = j then Matrix.of fun _ _ => sectorWeight i else 0
 
@@ -131,7 +133,7 @@ lemma neighboringOperator_posSemidef (k h : Fin 2) :
   intro i
   fin_cases k <;> fin_cases h <;> norm_num [sectorWeight, Complex.nonneg_iff]
 
-/-- The full two-sector trace matrix is `diag(1, 0)`. -/
+/-- The full two-sector trace matrix is $\operatorname{diag}(1,0)$. -/
 lemma traceMatrix_eq : traceMatrix = !![1, 0; 0, 0] := by
   have huniv : (Finset.univ : Finset (Fin 1 × Fin 1)) = {(0, 0)} := by
     ext x

--- a/TNLean/MPS/MPDO/CommutingBondTraceMatrixObstruction.lean
+++ b/TNLean/MPS/MPDO/CommutingBondTraceMatrixObstruction.lean
@@ -371,9 +371,10 @@ fixed positive commuting-bond presentation need not have a primitive trace
 matrix.
 
 This shows that the factorization needed after arXiv:1606.00608, Appendix C.2,
-line 1613, must be selected or pruned by a separate argument.  The example does
-not rule out another factorization with primitive trace matrix: the explicit
-one-sector factorization above has trace matrix $(1)$. -/
+line 1613, must be selected after deleting inactive summands by a separate
+argument.  The example does not rule out another factorization with primitive
+trace matrix: the explicit one-sector factorization above has trace matrix
+$(1)$. -/
 theorem normal_sourceZCL_fixed_commutingBond_does_not_force_traceMatrix_primitive :
     tensor.IsMPDO ∧
       tensor.IsInjective ∧
@@ -383,6 +384,7 @@ theorem normal_sourceZCL_fixed_commutingBond_does_not_force_traceMatrix_primitiv
       (∀ (N : ℕ) (hN : 2 ≤ N),
         mpo tensor N =
           (commutingBondData.bondData.toCommutingFormData hN).product) ∧
+      traceMatrix = !![1, 0; 0, 0] ∧
       ¬ Matrix.IsPrimitive traceMatrix ∧
       oneSectorFactorization.sectorCount = 1 ∧
       (∀ k h,
@@ -390,7 +392,7 @@ theorem normal_sourceZCL_fixed_commutingBond_does_not_force_traceMatrix_primitiv
       Matrix.IsPrimitive oneSectorTraceMatrix := by
   exact ⟨tensor_isMPDO, tensor_isInjective, tensor_isNormalTensor, tensor_isSourceZCL,
     neighboringOperator_posSemidef, mpo_eq_commutingBondProduct,
-    traceMatrix_not_isPrimitive, rfl, oneSector_neighboringOperator_posSemidef,
-    oneSectorTraceMatrix_isPrimitive⟩
+    traceMatrix_eq, traceMatrix_not_isPrimitive, rfl,
+    oneSector_neighboringOperator_posSemidef, oneSectorTraceMatrix_isPrimitive⟩
 
 end MPOTensor.CommutingBondTraceMatrixObstruction

--- a/TNLean/MPS/MPDO/PhysicalSectorFactorization.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorFactorization.lean
@@ -38,13 +38,15 @@ namespace MPOTensor
 
 variable {d D : ℕ}
 
-/-- A source-minimal physical-sector factorization of an MPO tensor.
+/-- A physical-sector factorization of an MPO tensor.
 
 The physical space is decomposed as
 $\bigoplus_k B_k^L\otimes B_k^R$.  The matrices `leftTensor k beta` and
 `rightTensor k alpha` are the factors $(l_k)_\beta$ and $(r_k)_\alpha$ in
-the transformed physical slice.  The only compatibility imposed on these
-data is the displayed direct-sum factorization from the source.
+the transformed physical slice.  Positivity of the left and right factor
+dimensions does not impose minimality under coarsening the direct sum or
+deleting inactive summands.  The only compatibility imposed on these data is
+the displayed direct-sum factorization from the source.
 
 Source: arXiv:1606.00608, Appendix C.2, equation `AppUkU=rl`, lines
 1381--1388; the explicit slice factorization is derived at lines 1435--1448. -/

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -779,10 +779,10 @@
     This shows that primitivity cannot be inferred for an arbitrary selected
     factorization in the step suggested at
     \cite[Appendix~C.2, line~1613]{Cirac2016MPDO_arXiv}.  The same tensor also
-    has a one-sector factorization with primitive trace matrix.  Hence the
-    example does not exclude a source-faithful minimal or visible-sector
-    selection, and it does not disprove the stated commuting-form-to-SAL
-    implication.
+    has a one-sector factorization with positive semidefinite neighboring
+    operator and primitive trace matrix.  Hence the example does not exclude a
+    source-faithful minimal or visible-sector selection, and it does not
+    disprove the stated commuting-form-to-SAL implication.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -813,7 +813,21 @@
         T^n=\begin{pmatrix}1&0\\0&0\end{pmatrix}.
     \]
     Thus no positive power has all entries strictly positive, so $T$ is not
-    primitive.
+    primitive.  For the alternative factorization, take one sector
+    $B^L=\mathbb C^2$ and $B^R=\mathbb C$, with
+
+    \[
+        l=\begin{pmatrix}1&0\\0&0\end{pmatrix},
+        \qquad r=(1).
+    \]
+    Its sole neighboring operator is
+    $\widehat\eta_{0,0}=\operatorname{diag}(1,0)\succeq0$, and hence its trace
+    matrix is
+    \[
+        \widehat T=\bigl(\tr(\widehat\eta_{0,0})\bigr)=(1).
+    \]
+    Every positive power of $\widehat T$ equals $(1)$, so this one-sector
+    trace matrix is primitive.
 \end{proof}
 
 \begin{theorem}[A translation-invariant commuting bond and ZCL imply SAL]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -756,6 +756,45 @@
     decomposition or saturation of the area law.
 \end{remark}
 
+\begin{theorem}[Inactive-sector obstruction to full trace-matrix primitivity]
+    \label{thm:mpdo_commuting_bond_trace_matrix_primitivity_obstruction}
+    \lean{MPOTensor.CommutingBondTraceMatrixObstruction.%
+      normal_sourceZCL_fixed_commutingBond_does_not_force_traceMatrix_primitive}
+    \leanok
+    \uses{def:mpdo_eta_local_structure_data, def:mpo_source_zcl, def:mpdo}
+    There is an injective normal tensor $\mathcal K$, of physical dimension two
+    and bond dimension one, which generates MPDOs and has source zero
+    correlation length, together with one positive two-site bond $B$ whose
+    translates commute.  For every $N\geq2$,
+    \[
+        \sigma^{(N)}(\mathcal K)=\prod_{i=0}^{N-1}B_{i,i+1},
+    \]
+    while the full trace matrix of its two Beigi sectors is
+    \[
+        T=\begin{pmatrix}1&0\\0&0\end{pmatrix}.
+    \]
+    In particular, $T$ is not primitive.
+
+    This obstructs the unqualified primitivity step suggested at
+    \cite[Appendix~C.2, line~1613]{Cirac2016MPDO_arXiv}.  It does not obstruct
+    primitivity after a mathematically specified removal of inactive sectors,
+    and it does not disprove the stated commuting-form-to-SAL implication.
+\end{theorem}
+
+\begin{proof}\leanok
+    Let $\mathcal K^{0,0}=1$ and let all other physical entries vanish.  The
+    doubled-index transfer and the physical-trace transfer are both the
+    identity on the one-dimensional bond algebra, so $\mathcal K$ is injective
+    and normal and has source zero correlation length.  Decompose the physical
+    space as $\mathbb C\oplus\mathbb C$ and take the left and right sector
+    factors to be $1$ on the first summand and $0$ on the second.  The resulting
+    neighboring operators are positive scalar matrices and give a single bond
+    whose commuting translates have exactly the required product at every
+    length.  Their traces are $1$ only for the ordered pair of first sectors,
+    giving the displayed matrix.  Its second row remains zero under every
+    positive power, so it is not primitive.
+\end{proof}
+
 \begin{theorem}[A translation-invariant commuting bond and ZCL imply SAL]
     \label{thm:mpdo_translation_invariant_commuting_form_zcl_sal}
     \notready

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -761,7 +761,8 @@
     \lean{MPOTensor.CommutingBondTraceMatrixObstruction.%
       normal_sourceZCL_fixed_commutingBond_does_not_force_traceMatrix_primitive}
     \leanok
-    \uses{def:mpdo_eta_local_structure_data, def:mpo_source_zcl, def:mpdo}
+    \uses{def:mpdo_eta_local_structure_data, def:mpo_source_zcl, def:mpdo,
+      def:injective, def:normal}
     There is an injective normal tensor $\mathcal K$, of physical dimension two
     and bond dimension one, which generates MPDOs and has source zero
     correlation length, together with one positive two-site bond $B$ whose

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -803,10 +803,23 @@
     \[
         \eta_{k,h}=w_kw_h I_1=\delta_{k,0}\delta_{h,0}I_1\succeq0.
     \]
-    They give a single bond whose commuting translates have exactly the
-    required product at every length.  Consequently,
+    In the sector coordinates the corresponding physical bond is
     \[
-        T_{k,h}=\tr(\eta_{k,h})=\delta_{k,0}\delta_{h,0}.
+        B=\sum_{k,h} I_{H_L^{(k)}}\otimes\eta_{k,h}\otimes
+        I_{H_R^{(h)}}
+        =I_{H_L^{(0)}}\otimes I_1\otimes I_{H_R^{(0)}}.
+    \]
+    Since only the all-zero physical-index word contributes, the
+    factorization identity is
+    \[
+        \sigma^{(N)}(\mathcal K)=\prod_{i=0}^{N-1}B_{i,i+1}
+        \qquad (N\geq2).
+    \]
+    Consequently,
+    \[
+        T_{k,h}=\tr(\eta_{k,h})=\delta_{k,0}\delta_{h,0},
+        \qquad
+        T=\begin{pmatrix}1&0\\0&0\end{pmatrix}.
     \]
     For every $n\geq1$,
     \[

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -756,7 +756,7 @@
     decomposition or saturation of the area law.
 \end{remark}
 
-\begin{theorem}[Inactive-sector obstruction to full trace-matrix primitivity]
+\begin{theorem}[A nonminimal sector factorization need not be primitive]
     \label{thm:mpdo_commuting_bond_trace_matrix_primitivity_obstruction}
     \lean{MPOTensor.CommutingBondTraceMatrixObstruction.%
       normal_sourceZCL_fixed_commutingBond_does_not_force_traceMatrix_primitive}
@@ -770,16 +770,19 @@
     \[
         \sigma^{(N)}(\mathcal K)=\prod_{i=0}^{N-1}B_{i,i+1},
     \]
-    while the full trace matrix of its two Beigi sectors is
+    while the trace matrix of a chosen two-sector Beigi factorization is
     \[
         T=\begin{pmatrix}1&0\\0&0\end{pmatrix}.
     \]
     In particular, $T$ is not primitive.
 
-    This obstructs the unqualified primitivity step suggested at
-    \cite[Appendix~C.2, line~1613]{Cirac2016MPDO_arXiv}.  It does not obstruct
-    primitivity after a mathematically specified removal of inactive sectors,
-    and it does not disprove the stated commuting-form-to-SAL implication.
+    This shows that primitivity cannot be inferred for an arbitrary selected
+    factorization in the step suggested at
+    \cite[Appendix~C.2, line~1613]{Cirac2016MPDO_arXiv}.  The same tensor also
+    has a one-sector factorization with primitive trace matrix.  Hence the
+    example does not exclude a source-faithful minimal or visible-sector
+    selection, and it does not disprove the stated commuting-form-to-SAL
+    implication.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -787,9 +790,9 @@
     doubled-index transfer and the physical-trace transfer are both the
     identity on the one-dimensional bond algebra, so $\mathcal K$ is injective
     and normal and has source zero correlation length.  Decompose the physical
-    space as $\mathbb C\oplus\mathbb C$ and take the left and right sector
-    factors to be $1$ on the first summand and $0$ on the second.  The resulting
-    neighboring operators are positive scalar matrices and give a single bond
+    space nonminimally as $\mathbb C\oplus\mathbb C$ and take the left and right
+    sector factors to be $1$ on the first summand and $0$ on the second.  The
+    resulting neighboring operators are positive scalar matrices and give a single bond
     whose commuting translates have exactly the required product at every
     length.  Their traces are $1$ only for the ordered pair of first sectors,
     giving the displayed matrix.  Its second row remains zero under every

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -787,16 +787,33 @@
 
 \begin{proof}\leanok
     Let $\mathcal K^{0,0}=1$ and let all other physical entries vanish.  The
-    doubled-index transfer and the physical-trace transfer are both the
-    identity on the one-dimensional bond algebra, so $\mathcal K$ is injective
-    and normal and has source zero correlation length.  Decompose the physical
-    space nonminimally as $\mathbb C\oplus\mathbb C$ and take the left and right
-    sector factors to be $1$ on the first summand and $0$ on the second.  The
-    resulting neighboring operators are positive scalar matrices and give a single bond
-    whose commuting translates have exactly the required product at every
-    length.  Their traces are $1$ only for the ordered pair of first sectors,
-    giving the displayed matrix.  Its second row remains zero under every
-    positive power, so it is not primitive.
+    matrices $\{\mathcal K^{i,j}\}_{i,j=0}^1$ span $M_1(\mathbb C)$.  For every
+    $X\in M_1(\mathbb C)$, the doubled-index transfer $\mathcal E_{\mathcal K}$
+    and the physical-trace transfer $P_{\mathcal K}$ satisfy
+    \[
+        \mathcal E_{\mathcal K}(X)=X,
+        \qquad P_{\mathcal K}=I_1,
+        \qquad P_{\mathcal K}^2=P_{\mathcal K}.
+    \]
+    Hence $\mathcal K$ is injective and normal and has source zero correlation
+    length.  Decompose the physical space nonminimally as
+    $\mathbb C\oplus\mathbb C$.  With $w_0=1$ and $w_1=0$, take both sector
+    factors to be the scalar $w_k$ in sector $k$.  The neighboring operators
+    are
+    \[
+        \eta_{k,h}=w_kw_h I_1=\delta_{k,0}\delta_{h,0}I_1\succeq0.
+    \]
+    They give a single bond whose commuting translates have exactly the
+    required product at every length.  Consequently,
+    \[
+        T_{k,h}=\tr(\eta_{k,h})=\delta_{k,0}\delta_{h,0}.
+    \]
+    For every $n\geq1$,
+    \[
+        T^n=\begin{pmatrix}1&0\\0&0\end{pmatrix}.
+    \]
+    Thus no positive power has all entries strictly positive, so $T$ is not
+    primitive.
 \end{proof}
 
 \begin{theorem}[A translation-invariant commuting bond and ZCL imply SAL]

--- a/docs/audits/2026-05-08-mps-ft-paper-coverage.md
+++ b/docs/audits/2026-05-08-mps-ft-paper-coverage.md
@@ -119,17 +119,17 @@ Listed for completeness; detailed MPDO coverage audit is out of scope.
 |---|---|---|---|---|
 | Prop `propsimple` (l.1333) | 1333–1341 | RFP ⇒ ZCL + SAL | `TNLean/MPS/MPDO/` | **needs verification** |
 | Lemma `Lsigma3` (l.1351) | 1351–1359 | SAL ⇒ direct sum structure for 3-spin reduced state | **out of scope** | — |
-| Lemma `propSN` (l.1406) | 1406–1411 | SAL ⇒ isometry U + r_k, l_k with primitive T | **out of scope** | — |
+| Lemma `propSN` (l.1406) | 1406–1411 | SAL ⇒ isometry U + r_k, l_k with primitive T | `TNLean/MPS/MPDO/InverseMapActiveSectorPrimitivity.lean` | **partial** — primitivity is proved on the nonzero-weight inverse-map sectors; the source's unqualified full-sector wording requires removal of inactive summands |
 | Lemma `SALZCL` (l.1484) | 1484–1487 | SAL + ZCL ⇒ T rank-1 (factorized) | **out of scope** | — |
 | Corollary (l.1503) | 1503–1506 | SAL + ZCL ⇒ structural form | **out of scope** | — |
 | Prop `3to5` (l.1510) | 1510–1517 | Structural form ⇒ tpCPM T,S exist (RFP) | **out of scope** | — |
 | Prop `3to4` (l.1569) | 1569–1577 | SAL ⇒ GSNNCH form | **out of scope** | — |
-| Prop `4to2` (l.1597) | 1597–1601 | GSNNCH + ZCL ⇒ SAL | **out of scope** | — |
+| Prop `4to2` (l.1597) | 1597–1601 | GSNNCH + ZCL ⇒ SAL | `TNLean/MPS/MPDO/CommutingBondTraceMatrixObstruction.lean`; `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex` | **open** — Beigi's decomposition is formalized, but the source invokes the SAL-dependent `propSN`; the raw full-trace-matrix primitivity repair is formally false because inactive sectors may remain.  A SAL-independent active restriction or a direct Markov argument is still required |
 | Lemma `lemmus` (l.1647) | 1647–1649 | ZCL ⇒ μ_j,q independent of q | **out of scope** | — |
 | Lemma (l.1680) | 1680–1691 | SAL ⇒ orthogonal projectors P_j | **out of scope** | — |
 | Prop `prop2to3` (l.1740) | 1740–1743 | SAL + ZCL ⇒ BNTs satisfy (iv) of Theorem 4.9 | **out of scope** | — |
 | Prop `prop3to4` (l.1786) | 1786–1789 | (iv) ⇒ GSNNCH | **out of scope** | — |
-| Prop `prop4to2` (l.1801) | 1801–1804 | GSNNCH ⇒ SAL | **out of scope** | — |
+| Prop `prop4to2` (l.1801) | 1801–1804 | GSNNCH ⇒ SAL | `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex` | **open** — downstream of the unresolved single-block implication at line 1597; the inactive-sector obstruction prevents using primitivity of the full Beigi trace matrix |
 | Prop `prop2to5` (l.1810) | 1810–1813 | SAL + ZCL ⇒ tpCPM T,S exist | **out of scope** | — |
 
 ### 2.7 Appendix D — Proofs of IV.12 / IV.13

--- a/docs/audits/2026-05-08-mps-ft-paper-coverage.md
+++ b/docs/audits/2026-05-08-mps-ft-paper-coverage.md
@@ -119,17 +119,17 @@ Listed for completeness; detailed MPDO coverage audit is out of scope.
 |---|---|---|---|---|
 | Prop `propsimple` (l.1333) | 1333–1341 | RFP ⇒ ZCL + SAL | `TNLean/MPS/MPDO/` | **needs verification** |
 | Lemma `Lsigma3` (l.1351) | 1351–1359 | SAL ⇒ direct sum structure for 3-spin reduced state | **out of scope** | — |
-| Lemma `propSN` (l.1406) | 1406–1411 | SAL ⇒ isometry U + r_k, l_k with primitive T | `TNLean/MPS/MPDO/InverseMapActiveSectorPrimitivity.lean` | **partial** — primitivity is proved on the nonzero-weight inverse-map sectors; the source's unqualified full-sector wording requires removal of inactive summands |
+| Lemma `propSN` (l.1406) | 1406–1411 | SAL ⇒ isometry U + r_k, l_k with primitive T | `TNLean/MPS/MPDO/InverseMapActiveSectorPrimitivity.lean` | **partial** — primitivity is proved on the nonzero-weight inverse-map sectors; an explicit comparison with the source's sector selection remains required |
 | Lemma `SALZCL` (l.1484) | 1484–1487 | SAL + ZCL ⇒ T rank-1 (factorized) | **out of scope** | — |
 | Corollary (l.1503) | 1503–1506 | SAL + ZCL ⇒ structural form | **out of scope** | — |
 | Prop `3to5` (l.1510) | 1510–1517 | Structural form ⇒ tpCPM T,S exist (RFP) | **out of scope** | — |
 | Prop `3to4` (l.1569) | 1569–1577 | SAL ⇒ GSNNCH form | **out of scope** | — |
-| Prop `4to2` (l.1597) | 1597–1601 | GSNNCH + ZCL ⇒ SAL | `TNLean/MPS/MPDO/CommutingBondTraceMatrixObstruction.lean`; `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex` | **open** — Beigi's decomposition is formalized, but the source invokes the SAL-dependent `propSN`; the raw full-trace-matrix primitivity repair is formally false because inactive sectors may remain.  A SAL-independent active restriction or a direct Markov argument is still required |
+| Prop `4to2` (l.1597) | 1597–1601 | GSNNCH + ZCL ⇒ SAL | `TNLean/MPS/MPDO/CommutingBondTraceMatrixObstruction.lean`; `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex` | **open** — Beigi's decomposition is formalized, but the source invokes the SAL-dependent `propSN`.  A chosen nonminimal factorization can retain inactive sectors and have a nonprimitive trace matrix, although the same tensor may have a primitive factorization.  A SAL-independent minimal or visible-sector selection, or a direct Markov argument, is still required |
 | Lemma `lemmus` (l.1647) | 1647–1649 | ZCL ⇒ μ_j,q independent of q | **out of scope** | — |
 | Lemma (l.1680) | 1680–1691 | SAL ⇒ orthogonal projectors P_j | **out of scope** | — |
 | Prop `prop2to3` (l.1740) | 1740–1743 | SAL + ZCL ⇒ BNTs satisfy (iv) of Theorem 4.9 | **out of scope** | — |
 | Prop `prop3to4` (l.1786) | 1786–1789 | (iv) ⇒ GSNNCH | **out of scope** | — |
-| Prop `prop4to2` (l.1801) | 1801–1804 | GSNNCH ⇒ SAL | `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex` | **open** — downstream of the unresolved single-block implication at line 1597; the inactive-sector obstruction prevents using primitivity of the full Beigi trace matrix |
+| Prop `prop4to2` (l.1801) | 1801–1804 | GSNNCH ⇒ SAL | `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex` | **open** — downstream of the unresolved single-block implication at line 1597; primitivity requires a source-faithful selection rather than an arbitrary nonminimal Beigi factorization |
 | Prop `prop2to5` (l.1810) | 1810–1813 | SAL + ZCL ⇒ tpCPM T,S exist | **out of scope** | — |
 
 ### 2.7 Appendix D — Proofs of IV.12 / IV.13

--- a/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
+++ b/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
@@ -363,8 +363,8 @@ The theorem
 \leanid{MPOTensor.CommutingBondTraceMatrixObstruction.%
 normal_sourceZCL_fixed_commutingBond_does_not_force_traceMatrix_primitive}
 gives an injective normal bond-dimension-one product MPDO with source ZCL and
-one exact fixed positive commuting-bond presentation.  Beigi's two
-one-dimensional sectors have positive neighboring operators and trace matrix
+one exact fixed positive commuting-bond presentation.  The chosen two-sector
+Beigi-style factorization has positive neighboring operators and trace matrix
 \[
   T=\begin{pmatrix}1&0\\0&0\end{pmatrix}.
 \]

--- a/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
+++ b/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
@@ -358,8 +358,8 @@ tensor has SAL and source ZCL, yet its trace matrix is not rank one.  Thus
 neither inverse-map provenance nor the finite-chain cyclic form supplies the
 missing rectangular vanishing.
 
-Primitivity of the full Beigi trace matrix cannot repair this argument under
-the raw hypotheses either.  The theorem
+Primitivity cannot be assumed for an arbitrary selected Beigi factorization.
+The theorem
 \leanid{MPOTensor.CommutingBondTraceMatrixObstruction.%
 normal_sourceZCL_fixed_commutingBond_does_not_force_traceMatrix_primitive}
 gives an injective normal bond-dimension-one product MPDO with source ZCL and
@@ -368,10 +368,14 @@ one-dimensional sectors have positive neighboring operators and trace matrix
 \[
   T=\begin{pmatrix}1&0\\0&0\end{pmatrix}.
 \]
-The second physical summand is inactive, but it is retained by the middle-space
-decomposition, so the full matrix is not primitive.  Beigi's Lemma~2.1 supplies
-only the direct-sum tensor-factor decomposition; it contains no assertion of
-primitivity or removal of inactive summands.
+The second physical summand is inactive, but it is retained by this nonminimal
+middle-space decomposition, so its full matrix is not primitive.  The same
+product tensor also has a one-sector factorization with the primitive
+$1\times1$ trace matrix $(1)$.  Thus this example does not exclude the
+existence of a primitive Beigi factorization.  It shows instead that Beigi's
+Lemma~2.1, which supplies only the direct-sum tensor-factor decomposition,
+must be supplemented by a source-faithful minimal or visible-sector selection
+before primitivity can be used.
 
 Consequently the source implication
 \[
@@ -398,10 +402,11 @@ The gap can be removed in the following stages.
 \begin{enumerate}
 \item Replace the full Beigi sector set by a source-faithfully defined active
 restriction, formed without using SAL, and prove that normality leaves one
-aperiodic recurrent component.  The raw full-matrix assertion is false by the
-inactive-sector example above.  The active-sector construction presently used
-for the inverse-map factorization depends on SAL-derived sector weights and
-therefore cannot be invoked at this call site.
+aperiodic recurrent component.  The inactive-sector example above shows that
+an arbitrary nonminimal factorization is insufficient; it does not rule out an
+appropriate existential selection.  The active-sector construction presently
+used for the inverse-map factorization depends on SAL-derived sector weights
+and therefore cannot be invoked at this call site.
 
 For such an active restriction, one possible corrected route is to use the
 square of its trace matrix.  If a primitive nonnegative matrix $T$ satisfies

--- a/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
+++ b/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
@@ -352,11 +352,13 @@ four-sector example
 virtual_spanning_does_not_force_rectangular_remainder_zero}
 satisfies the recorded
 positivity, primitivity, trace-one, and spanning conditions while its trace
-matrix is not idempotent.  The source-faithful audit in \ghissue{3593}
-formally refutes the printed rank-one conclusion: the same source-selected
-tensor has SAL and source ZCL, yet its trace matrix is not rank one.  Thus
-neither inverse-map provenance nor the finite-chain cyclic form supplies the
-missing rectangular vanishing.
+matrix is not idempotent.  The capstone theorem
+\leanid{MPOTensor.ActiveSectorSpanningCounterexample.%
+tensor_refutes_printed_sal_zcl_rank_one_inference}
+adds SAL, source ZCL, and the source-selected inverse-map factorization, and
+proves that its active trace matrix is not rank one.  Thus neither inverse-map
+provenance nor the finite-chain cyclic form supplies the missing rectangular
+vanishing.
 
 Primitivity cannot be assumed for an arbitrary selected Beigi factorization.
 The theorem

--- a/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
+++ b/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
@@ -353,8 +353,25 @@ virtual_spanning_does_not_force_rectangular_remainder_zero}
 satisfies the recorded
 positivity, primitivity, trace-one, and spanning conditions while its trace
 matrix is not idempotent.  The source-faithful audit in \ghissue{3593}
-classifies this rank-one step as obstructed: neither the inverse-map provenance
-nor the finite-chain cyclic form supplies the missing rectangular vanishing.
+formally refutes the printed rank-one conclusion: the same source-selected
+tensor has SAL and source ZCL, yet its trace matrix is not rank one.  Thus
+neither inverse-map provenance nor the finite-chain cyclic form supplies the
+missing rectangular vanishing.
+
+Primitivity of the full Beigi trace matrix cannot repair this argument under
+the raw hypotheses either.  The theorem
+\leanid{MPOTensor.CommutingBondTraceMatrixObstruction.%
+normal_sourceZCL_fixed_commutingBond_does_not_force_traceMatrix_primitive}
+gives an injective normal bond-dimension-one product MPDO with source ZCL and
+one exact fixed positive commuting-bond presentation.  Beigi's two
+one-dimensional sectors have positive neighboring operators and trace matrix
+\[
+  T=\begin{pmatrix}1&0\\0&0\end{pmatrix}.
+\]
+The second physical summand is inactive, but it is retained by the middle-space
+decomposition, so the full matrix is not primitive.  Beigi's Lemma~2.1 supplies
+only the direct-sum tensor-factor decomposition; it contains no assertion of
+primitivity or removal of inactive summands.
 
 Consequently the source implication
 \[
@@ -379,25 +396,23 @@ restriction that isolates only its final entropy-theoretic step.
 The gap can be removed in the following stages.
 
 \begin{enumerate}
-\item Find a source-faithful property of the actual inverse-map neighboring
-family which excludes the nilpotent zero-eigenspace, or
-replace the printed line-1613 argument by a direct Markov decomposition which
-does not require the rank-one trace matrix.  Source ZCL alone must not be
-presented as giving the factorization; the inverse-map and finite-chain audits
-in \ghissue{3593} do not supply it.
-One possible corrected route is to use the square of the trace matrix.  If a
-primitive nonnegative trace matrix $T$ satisfies $T^2=T^3$, then all powers
-from the second onward equal $T^2$, so $T^2$ is an idempotent Perron
-projection of rank one.  This is compatible with the four-sector example,
-where $T$ is not rank one but $T^2$ is.  This finite-dimensional implication is
+\item Replace the full Beigi sector set by a source-faithfully defined active
+restriction, formed without using SAL, and prove that normality leaves one
+aperiodic recurrent component.  The raw full-matrix assertion is false by the
+inactive-sector example above.  The active-sector construction presently used
+for the inverse-map factorization depends on SAL-derived sector weights and
+therefore cannot be invoked at this call site.
+
+For such an active restriction, one possible corrected route is to use the
+square of its trace matrix.  If a primitive nonnegative matrix $T$ satisfies
+$T^2=T^3$, then $T^2$ is an idempotent Perron projection of rank one.  This is
 formalized by
 \leanid{Matrix.IsPrimitive.rank_pow_two_eq_one_of_pow_two_eq_pow_three}; the
 nonempty matrix convention is explicit, since primitivity is vacuous for the
-zero-dimensional matrix under the library definition.  What remains absent is a derivation of
-primitivity for the Beigi trace matrix from the normal source block and its
-fixed proportional commuting-bond presentation; the existing primitivity
-theorem starts from the SAL-derived inverse-map factorization and is therefore
-circular at this call site.
+zero-dimensional matrix under the library definition.  The construction and
+primitivity of the required SAL-independent active restriction remain absent.
+Alternatively, replace the printed line-1613 argument by a direct Markov
+decomposition which does not require any rank-one trace matrix.
 \item Trace the fourth region, construct the quantum Markov decomposition at
 each admissible cut, and apply the all-cut Markov theorem.  Only then may the
 source proposition receive a formal declaration and a


### PR DESCRIPTION
This PR records the precise inactive-sector phenomenon in CPSV16 Appendix C.2 without treating it as an obstruction to an existential primitive factorization.

### Mathematical result

- Construct an explicit physical-dimension-two, bond-dimension-one product MPDO with only $K^{0,0}=1$.
- Prove that it is locally purifiable, injective before blocking, normal, source-ZCL, and represented exactly by one positive translation-invariant commuting bond at every length $N\ge 2$.
- Construct a chosen nonminimal two-sector physical factorization whose neighboring operators are positive semidefinite and whose trace matrix is proved explicitly equal to $\operatorname{diag}(1,0)$, hence nonprimitive.
- Formalize a second one-sector factorization of the same tensor. Its neighboring operator is $\operatorname{diag}(1,0)\succeq0$, its trace matrix is $(1)$, and that trace matrix is primitive.
- Include both factorizations and both explicit trace-matrix conclusions in the checked capstone theorem, matching the blueprint statement and proof.
- Correct `PhysicalSectorFactorization` documentation: positive factor dimensions do not imply minimality under coarsening the direct sum or deleting inactive summands.
- Cite the SAL counterexample capstone for the source-selected inverse-map rank-one refutation, while retaining the lower-level theorem only for its precise subclaim.

Thus primitivity is not automatic for an arbitrary selected decomposition. The remaining positive task is the source-faithful minimal or visible/recurrent-sector selection theorem owned by #4364; this PR does not overlap that work and does not refute Proposition `4to2`.

### Testing

- Exact head `475e1f88397871f5ad267ba8f451f3a80697d9e8` is rebased on main `7666fe99d50a2a1693253ee51efa241ea00b615b`; merge-base equality was verified.
- Focused Lean check for `CommutingBondTraceMatrixObstruction.lean` passed on the exact head.
- Full `lake build` passed with 9604 jobs on an earlier main-based head; CI is rebuilding the exact rebased head.
- The capstone and one-sector declarations depend only on `propext`, `Classical.choice`, and `Quot.sound`.
- Reader-facing prose, forbidden-token, diff, and 1000-line guards passed. `TNLean.lean` remains exactly 1000 lines.

---
Closes #4315
Advances #4175
Follow-up: #4364