### PR TITLE
fix(tenkz): validate pairlegs against face ports

### DIFF
--- a/scripts/tenkz_audit.py
+++ b/scripts/tenkz_audit.py
@@ -117,15 +117,6 @@ def _is_cell(v: str) -> bool:
     return re.fullmatch(r"\d+-\d+", v) is not None
 
 
-def _is_nonnegative_int(v: str) -> bool:
-    if not _is_int(v):
-        return False
-    try:
-        return int(v) >= 0
-    except ValueError:
-        return False
-
-
 def _is_pairleg_port(v: str) -> bool:
     """A contraction starts at the centred face or a positive face slot."""
     if v == "center":

--- a/scripts/tenkz_audit.py
+++ b/scripts/tenkz_audit.py
@@ -18,6 +18,10 @@ Hard errors (exit 1):
                        leaf and vertex counts.
   duplicate-picture    Two `picture` lines share one id: picture identity
                        is the key of every back-reference.
+  conflicting-faceports
+                       Two faceports records declare different slots for the
+                       same cell face.  The first valid declaration remains
+                       authoritative; identical retries are idempotent.
   dangling-picture-ref An event references an undeclared picture.
   empty-picture        A grid/lattice/free picture emitted no content
                        events.  A tensor diagram with no atoms and no
@@ -113,6 +117,15 @@ def _is_cell(v: str) -> bool:
     return re.fullmatch(r"\d+-\d+", v) is not None
 
 
+def _is_nonnegative_int(v: str) -> bool:
+    if not _is_int(v):
+        return False
+    try:
+        return int(v) >= 0
+    except ValueError:
+        return False
+
+
 def _is_pairleg_port(v: str) -> bool:
     """A contraction starts at the centred face or a positive face slot."""
     if v == "center":
@@ -142,7 +155,7 @@ FIELD_VALIDATORS: dict[str, dict[str, Callable[[str], bool]]] = {
     "atom": {"picture": _is_int, "cell": _is_cell, "name": _any, "kind": _any},
     "faceports": {"picture": _is_int, "cell": _is_cell,
                   "face": _enum("up", "down", "west", "east"),
-                  "arity": _is_int, "at": _any},
+                  "arity": _is_nonnegative_int, "at": _any},
     "pairleg": {"picture": _is_int, "upper": _is_cell, "lower": _is_cell,
                 "upper-port": _is_pairleg_port,
                 "column": _is_int},
@@ -375,25 +388,25 @@ class Audit:
                                  f"{want}=")
 
     @staticmethod
-    def _declared_face_ports(event: Event) -> Optional[set[str]]:
-        """Resolve one well-formed faceports event to its contraction slots."""
+    def _declared_face_ports(
+            event: Event) -> Optional[tuple[set[str], Optional[int]]]:
+        """Resolve explicit slots and an optional inclusive `rows` bound."""
         at = event.attrs.get("at", "").strip()
         if at == "center":
-            return {"center"}
+            return {"center"}, None
         if at == "none":
-            return set()
+            return set(), None
         if at == "rows":
             arity = event.attrs.get("arity", "")
-            if not _is_int(arity):
+            if not _is_nonnegative_int(arity):
                 return None
             count = int(arity)
-            if count < 0:
-                return None
-            return {str(slot) for slot in range(1, count + 1)}
+            # A one-row physical face emits its unique contraction as `center`.
+            return ({"center"} if count == 1 else set()), count
         slots = [slot.strip() for slot in at.split(",")]
         if slots and all(
                 _is_pairleg_port(slot) and slot != "center" for slot in slots):
-            return set(slots)
+            return set(slots), None
         return None
 
     def check_pairleg_faceports(self) -> None:
@@ -406,26 +419,90 @@ class Audit:
         for pic in self.pictures:
             if pic.lang != "grid":
                 continue
-            declared: dict[str, set[str]] = {}
+            declared: dict[
+                tuple[str, str], tuple[set[str], Optional[int], int]
+            ] = {}
             for event in pic.events:
-                if event.kind != "faceports" or event.attrs.get("face") != "down":
+                if event.kind != "faceports":
                     continue
                 cell = event.attrs.get("cell", "")
-                ports = self._declared_face_ports(event)
-                if not _is_cell(cell) or ports is None:
+                face = event.attrs.get("face", "")
+                if (not _is_cell(cell)
+                        or face not in {"up", "down", "west", "east"}):
                     continue
-                declared.setdefault(cell, set()).update(ports)
+                missing = [
+                    field for field in ("arity", "at")
+                    if field not in event.attrs
+                ]
+                if missing:
+                    fields = ",".join(f"{field}=" for field in missing)
+                    self.hard(
+                        "malformed-event",
+                        f"{self.log_path.name}:{event.line}",
+                        f"picture {pic.ident} faceports cell={cell} face={face} "
+                        f"lacks required {fields}",
+                    )
+                    continue
+                at = event.attrs["at"]
+                arity = event.attrs["arity"]
+                if not at or not _is_nonnegative_int(arity):
+                    continue  # FIELD_VALIDATORS already emitted malformed-event.
+                declaration = self._declared_face_ports(event)
+                if declaration is None:
+                    self.hard(
+                        "malformed-event",
+                        f"{self.log_path.name}:{event.line}",
+                        f"picture {pic.ident} faceports cell={cell} "
+                        f"face={face} has invalid at={at!r}",
+                    )
+                    continue
+                ports, row_count = declaration
+                expected_arity = row_count if row_count is not None else len(ports)
+                if int(arity) != expected_arity:
+                    self.hard(
+                        "malformed-event",
+                        f"{self.log_path.name}:{event.line}",
+                        f"picture {pic.ident} faceports cell={cell} face={face} "
+                        f"declares arity={arity} but at={at!r} resolves to "
+                        f"{expected_arity} port(s)",
+                    )
+                    continue
+                key = cell, face
+                previous = declared.get(key)
+                if previous is None:
+                    declared[key] = ports, row_count, event.line
+                    continue
+                previous_ports, previous_rows, previous_line = previous
+                if previous_ports == ports and previous_rows == row_count:
+                    continue
+                self.hard(
+                    "conflicting-faceports",
+                    f"{self.log_path.name}:{event.line}",
+                    f"picture {pic.ident} cell={cell} face={face} conflicts "
+                    f"with its declaration on line {previous_line}",
+                )
             for event in pic.events:
                 if event.kind != "pairleg":
                     continue
                 upper = event.attrs.get("upper", "")
                 port = event.attrs.get("upper-port", "")
+                down_key = upper, "down"
                 if (not _is_cell(upper) or not _is_pairleg_port(port)
-                        or upper not in declared):
+                        or down_key not in declared):
                     continue
-                if port in declared[upper]:
+                ports, row_count, _ = declared[down_key]
+                matches = port in ports
+                if not matches and row_count is not None and port != "center":
+                    matches = int(port) <= row_count
+                if matches:
                     continue
-                available = ",".join(sorted(declared[upper])) or "none"
+                available_parts = sorted(
+                    ports,
+                    key=lambda slot: -1 if slot == "center" else int(slot),
+                )
+                if row_count is not None:
+                    available_parts.append(f"rows 1..{row_count}")
+                available = ",".join(available_parts) or "none"
                 self.hard(
                     "pairleg-faceport-mismatch",
                     f"{self.log_path.name}:{event.line}",

--- a/scripts/tenkz_audit.py
+++ b/scripts/tenkz_audit.py
@@ -484,7 +484,7 @@ class Audit:
                 ports, row_count, _ = declared[down_key]
                 matches = port in ports
                 if not matches and row_count is not None and port != "center":
-                    matches = int(port) <= row_count
+                    matches = row_count != 1 and int(port) <= row_count
                 if matches:
                     continue
                 available_parts = sorted(

--- a/scripts/tenkz_audit.py
+++ b/scripts/tenkz_audit.py
@@ -23,6 +23,13 @@ Hard errors (exit 1):
                        events.  A tensor diagram with no atoms and no
                        regions denotes no tensor network -- historically
                        the "34 fake diagrams" class.
+  pairleg-faceport-mismatch
+                       A grid pairleg names a contraction slot absent from the
+                       upper cell's declared down face.  Explicit declarations
+                       resolve `center`, comma-separated slots, `rows`, and
+                       `none`.  If no faceports event exists, the check is
+                       skipped for compatibility with legacy logs, including
+                       simple centred faces.
 
 Advisories (never affect the exit code):
   eq-boundary-mismatch Consecutive grid pictures joined by `=` in the
@@ -367,6 +374,65 @@ class Audit:
                                  f"atom in {pic.lang} picture {pic.ident} lacks "
                                  f"{want}=")
 
+    @staticmethod
+    def _declared_face_ports(event: Event) -> Optional[set[str]]:
+        """Resolve one well-formed faceports event to its contraction slots."""
+        at = event.attrs.get("at", "").strip()
+        if at == "center":
+            return {"center"}
+        if at == "none":
+            return set()
+        if at == "rows":
+            arity = event.attrs.get("arity", "")
+            if not _is_int(arity):
+                return None
+            count = int(arity)
+            if count < 0:
+                return None
+            return {str(slot) for slot in range(1, count + 1)}
+        slots = [slot.strip() for slot in at.split(",")]
+        if slots and all(
+                _is_pairleg_port(slot) and slot != "center" for slot in slots):
+            return set(slots)
+        return None
+
+    def check_pairleg_faceports(self) -> None:
+        """Cross-check pairleg slots against explicit upper down-face declarations.
+
+        Older event streams did not always emit faceports records.  Absence is
+        therefore deliberately not an error; an explicit declaration is the
+        authority whenever one is present.
+        """
+        for pic in self.pictures:
+            if pic.lang != "grid":
+                continue
+            declared: dict[str, set[str]] = {}
+            for event in pic.events:
+                if event.kind != "faceports" or event.attrs.get("face") != "down":
+                    continue
+                cell = event.attrs.get("cell", "")
+                ports = self._declared_face_ports(event)
+                if not _is_cell(cell) or ports is None:
+                    continue
+                declared.setdefault(cell, set()).update(ports)
+            for event in pic.events:
+                if event.kind != "pairleg":
+                    continue
+                upper = event.attrs.get("upper", "")
+                port = event.attrs.get("upper-port", "")
+                if (not _is_cell(upper) or not _is_pairleg_port(port)
+                        or upper not in declared):
+                    continue
+                if port in declared[upper]:
+                    continue
+                available = ",".join(sorted(declared[upper])) or "none"
+                self.hard(
+                    "pairleg-faceport-mismatch",
+                    f"{self.log_path.name}:{event.line}",
+                    f"picture {pic.ident} pairleg upper={upper} names upper-port={port!r}, "
+                    f"but its declared down face has ports {available}",
+                )
+
     def check_repeated_topology(self) -> None:
         groups: dict[tuple[str, str], list[Picture]] = {}
         for pic in self.pictures:
@@ -487,6 +553,7 @@ class Audit:
         self.link_tex()
         self.check_empty_pictures()
         self.check_dialects()
+        self.check_pairleg_faceports()
         self.check_equation_boundaries()
         self.check_periodic_dots()
         self.check_repeated_topology()

--- a/scripts/test_tenkz_face_ports.py
+++ b/scripts/test_tenkz_face_ports.py
@@ -97,7 +97,7 @@ SOURCE = r"""
   &
 \end{tenkz}
 \begin{tenkz}[rows={op, ket}, tensor style=box]
-  \tn[down at=center]{U} & \\
+  \tn[down at={1}]{U} & \\
   \tn[pill, wide=2, up at={1,2}, down at=center]{L} &
 \end{tenkz}
 \begin{tenkz}[rows={wire, wire}]
@@ -383,6 +383,10 @@ SOURCE = r"""
   \tnfuse[span=2, west at=center, east at=none]{V}\\
   &
 \end{tenkz}
+\begin{tenkz}[rows={op, ket}, tensor style=box]
+  \tn[wires=1, physical=down]{U}\\
+  \tn{L}
+\end{tenkz}
 \end{document}
 """
 
@@ -448,8 +452,13 @@ def main() -> int:
         audit = Audit(work / "face-ports.tnlog", None)
         audit.parse_log()
         audit.check_dialects()
+        audit.check_pairleg_faceports()
         hooks_findings = [
             finding for finding in audit.findings if "hooks" in finding.msg
+        ]
+        pairleg_faceport_findings = [
+            finding for finding in audit.findings
+            if finding.rule == "pairleg-faceport-mismatch"
         ]
         topology_hashes = {
             picture.ident: canonical_hash(picture) for picture in audit.pictures
@@ -495,6 +504,8 @@ def main() -> int:
             if finding.rule == "malformed-event" and "upper-port=" in finding.msg
         ]
         pairleg_faceports_log = work / "pairleg-faceports.tnlog"
+        overlong_arity = "9" * 5000
+        huge_arity = 1_000_000_000
         pairleg_faceports_log.write_text(
             "picture|id=1|lang=grid\n"
             "faceports|picture=1|cell=1-1|face=down|arity=1|at=center\n"
@@ -519,7 +530,58 @@ def main() -> int:
             "picture|id=6|lang=grid\n"
             "faceports|picture=6|cell=1-1|face=down|arity=3|at=rows\n"
             "pairleg|picture=6|upper=1-1|lower=2-3|upper-port=3|column=3\n"
-            "pairleg|picture=6|upper=1-1|lower=2-4|upper-port=4|column=4\n",
+            "pairleg|picture=6|upper=1-1|lower=2-4|upper-port=4|column=4\n"
+            "picture|id=7|lang=grid\n"
+            f"faceports|picture=7|cell=1-1|face=down|arity={overlong_arity}|at=rows\n"
+            "pairleg|picture=7|upper=1-1|lower=2-1|upper-port=1|column=1\n"
+            "picture|id=8|lang=grid\n"
+            f"faceports|picture=8|cell=1-1|face=down|arity={huge_arity}|at=rows\n"
+            f"pairleg|picture=8|upper=1-1|lower=2-1|upper-port={huge_arity}|"
+            "column=1\n"
+            f"pairleg|picture=8|upper=1-1|lower=2-2|upper-port={huge_arity + 1}|"
+            "column=2\n"
+            "picture|id=9|lang=grid\n"
+            "faceports|picture=9|cell=1-1|face=down|arity=1|at=1\n"
+            "pairleg|picture=9|upper=1-1|lower=2-1|upper-port=center|column=1\n"
+            "picture|id=10|lang=grid\n"
+            "faceports|picture=10|cell=1-1|face=down|arity=1|at=rows\n"
+            "pairleg|picture=10|upper=1-1|lower=2-1|upper-port=center|column=1\n"
+            "picture|id=11|lang=grid\n"
+            "faceports|picture=11|cell=1-1|face=down|arity=1|at=1\n"
+            "faceports|picture=11|cell=1-1|face=down|arity=1|at=2\n"
+            "pairleg|picture=11|upper=1-1|lower=2-2|upper-port=2|column=2\n"
+            "picture|id=12|lang=grid\n"
+            "faceports|picture=12|cell=1-1|face=down|arity=1|at=1\n"
+            "faceports|picture=12|cell=1-1|face=down|arity=1|at=1\n"
+            "pairleg|picture=12|upper=1-1|lower=2-1|upper-port=1|column=1\n"
+            "picture|id=13|lang=grid\n"
+            "faceports|picture=13|cell=1-1|face=down|arity=1|at=cetner\n"
+            "pairleg|picture=13|upper=1-1|lower=2-1|upper-port=center|column=1\n"
+            "picture|id=14|lang=grid\n"
+            "faceports|picture=14|cell=1-1|face=down|arity=2|at=1;2\n"
+            "pairleg|picture=14|upper=1-1|lower=2-1|upper-port=1|column=1\n"
+            "picture|id=15|lang=grid\n"
+            "faceports|picture=15|cell=1-1|face=up|arity=1|at=1\n"
+            "faceports|picture=15|cell=1-1|face=up|arity=1|at=2\n"
+            "faceports|picture=15|cell=1-1|face=west|arity=1|at=center\n"
+            "faceports|picture=15|cell=1-1|face=west|arity=0|at=none\n"
+            "faceports|picture=15|cell=1-1|face=east|arity=1|at=1\n"
+            "faceports|picture=15|cell=1-1|face=east|arity=1|at=2\n"
+            "picture|id=16|lang=grid\n"
+            "faceports|picture=16|cell=1-1|face=down|at=rows\n"
+            "pairleg|picture=16|upper=1-1|lower=2-1|upper-port=1|column=1\n"
+            "picture|id=17|lang=grid\n"
+            "faceports|picture=17|cell=1-1|face=down|arity=1\n"
+            "pairleg|picture=17|upper=1-1|lower=2-1|upper-port=1|column=1\n"
+            "picture|id=18|lang=grid\n"
+            "faceports|picture=18|cell=1-1|face=down|arity=-1|at=rows\n"
+            "pairleg|picture=18|upper=1-1|lower=2-1|upper-port=1|column=1\n"
+            "picture|id=19|lang=grid\n"
+            "faceports|picture=19|cell=1-1|face=down|arity=1|at=1,2\n"
+            "pairleg|picture=19|upper=1-1|lower=2-2|upper-port=2|column=2\n"
+            "picture|id=20|lang=grid\n"
+            "faceports|picture=20|cell=1-1|face=down|arity=0|at=center\n"
+            "pairleg|picture=20|upper=1-1|lower=2-1|upper-port=center|column=1\n",
             encoding="utf-8",
         )
         pairleg_faceports_audit = Audit(pairleg_faceports_log, None)
@@ -528,6 +590,31 @@ def main() -> int:
         pairleg_faceport_mismatches = [
             finding for finding in pairleg_faceports_audit.findings
             if finding.rule == "pairleg-faceport-mismatch"
+        ]
+        conflicting_faceports = [
+            finding for finding in pairleg_faceports_audit.findings
+            if finding.rule == "conflicting-faceports"
+        ]
+        malformed_faceports_at = [
+            finding.msg for finding in pairleg_faceports_audit.findings
+            if finding.rule == "malformed-event"
+            and "faceports cell=1-1 face=down has invalid at=" in finding.msg
+        ]
+        incomplete_faceports = [
+            finding.msg for finding in pairleg_faceports_audit.findings
+            if finding.rule == "malformed-event"
+            and "faceports cell=1-1 face=down lacks required" in finding.msg
+        ]
+        inconsistent_faceport_arities = [
+            finding.msg for finding in pairleg_faceports_audit.findings
+            if finding.rule == "malformed-event"
+            and "faceports cell=1-1 face=down declares arity=" in finding.msg
+        ]
+        malformed_rows_arities = [
+            finding.msg
+            for finding in pairleg_faceports_audit.findings
+            if finding.rule == "malformed-event"
+            and "faceports field arity=" in finding.msg
         ]
         warning_only_log = work / "warning-only.tnlog"
         warning_only_log.write_text(
@@ -554,6 +641,9 @@ def main() -> int:
         (3, "upper-port='2'"),
         (4, "upper-port='center'"),
         (6, "upper-port='4'"),
+        (8, f"upper-port='{huge_arity + 1}'"),
+        (9, "upper-port='center'"),
+        (11, "upper-port='2'"),
     }
     actual_pairleg_mismatches = {
         (picture, port)
@@ -566,6 +656,49 @@ def main() -> int:
         raise AssertionError(
             "pairleg face-port correlation missed a mismatch or rejected a declared/legacy slot"
         )
+    expected_conflicts = {
+        (11, "face=down"),
+        (15, "face=up"),
+        (15, "face=west"),
+        (15, "face=east"),
+    }
+    actual_conflicts = {
+        (picture, face)
+        for finding in conflicting_faceports
+        for picture, face in expected_conflicts
+        if f"picture {picture} " in finding.msg and face in finding.msg
+    }
+    if (len(conflicting_faceports) != len(expected_conflicts)
+            or actual_conflicts != expected_conflicts):
+        raise AssertionError(
+            "audit accepted a conflicting duplicate face declaration"
+        )
+    if len(malformed_faceports_at) != 2 or not all(
+        any(f"invalid at={value!r}" in msg for msg in malformed_faceports_at)
+        for value in ("cetner", "1;2")
+    ):
+        raise AssertionError(
+            "audit silently skipped a malformed face declaration: "
+            f"{malformed_faceports_at!r}"
+        )
+    if len(incomplete_faceports) != 2 or not all(
+        any(required in msg for msg in incomplete_faceports)
+        for required in ("required arity=", "required at=")
+    ):
+        raise AssertionError("audit silently skipped an incomplete face declaration")
+    if len(inconsistent_faceport_arities) != 2 or not all(
+        any(fragment in msg for msg in inconsistent_faceport_arities)
+        for fragment in (
+            "declares arity=1 but at='1,2' resolves to 2 port(s)",
+            "declares arity=0 but at='center' resolves to 1 port(s)",
+        )
+    ):
+        raise AssertionError("audit accepted an inconsistent face arity")
+    if len(malformed_rows_arities) != 2 or not all(
+        any(value in msg for msg in malformed_rows_arities)
+        for value in (overlong_arity, "arity='-1'")
+    ):
+        raise AssertionError("audit accepted or crashed on an overlong rows arity")
     if warning_only_status != 1 or not any(
         finding.rule == "empty-picture" and finding.severity == "HARD"
         for finding in warning_only_audit.findings
@@ -573,6 +706,8 @@ def main() -> int:
         raise AssertionError("warning-only grid picture counted as mathematical content")
     if hooks_findings:
         raise AssertionError("audit rejected a grid hooks event")
+    if pairleg_faceport_findings:
+        raise AssertionError("audit rejected a rendered pairleg declared by its upper face")
     inverse = pictures[1]
     require(
         inverse,
@@ -710,6 +845,15 @@ def main() -> int:
         "tall brick physical signature disagrees with its declared faces",
     )
     lower_surplus = pictures[16]
+    require(
+        lower_surplus,
+        "faceports|picture=16|cell=1-1|face=down|arity=1|at=1",
+        "explicit one-column face was not recorded as slot 1",
+    )
+    if paired_ports(lower_surplus) != [("1", "1")]:
+        raise AssertionError(
+            "explicit one-column face did not emit contraction slot 1"
+        )
     require(
         lower_surplus,
         "boundary|picture=16|virtual-west=2|virtual-east=2|physical-up=2|physical-down=0",
@@ -1327,6 +1471,17 @@ def main() -> int:
             "physical-up=0|physical-down=0",
             f"picture {picture} counted its unmatched centered face twice",
         )
+    physical_rows_one = pictures[81]
+    require(
+        physical_rows_one,
+        "faceports|picture=81|cell=1-1|face=down|arity=1|at=rows",
+        "one-row physical face was not declared through rows",
+    )
+    require(
+        physical_rows_one,
+        "pairleg|picture=81|upper=1-1|lower=2-1|upper-port=center|column=1",
+        "one-row physical face lost its unique centered contraction",
+    )
     print("PASS: physical faces, compatibility aliases, and virtual face arity")
     return 0
 

--- a/scripts/test_tenkz_face_ports.py
+++ b/scripts/test_tenkz_face_ports.py
@@ -494,6 +494,41 @@ def main() -> int:
             for finding in pairleg_ports_audit.findings
             if finding.rule == "malformed-event" and "upper-port=" in finding.msg
         ]
+        pairleg_faceports_log = work / "pairleg-faceports.tnlog"
+        pairleg_faceports_log.write_text(
+            "picture|id=1|lang=grid\n"
+            "faceports|picture=1|cell=1-1|face=down|arity=1|at=center\n"
+            "pairleg|picture=1|upper=1-1|lower=2-1|upper-port=center|column=1\n"
+            "pairleg|picture=1|upper=1-1|lower=2-1|upper-port=1|column=1\n"
+            "picture|id=2|lang=grid\n"
+            "faceports|picture=2|cell=1-1|face=down|arity=2|at=1,2\n"
+            "pairleg|picture=2|upper=1-1|lower=2-1|upper-port=1|column=1\n"
+            "pairleg|picture=2|upper=1-1|lower=2-2|upper-port=2|column=2\n"
+            "pairleg|picture=2|upper=1-1|lower=2-3|upper-port=3|column=3\n"
+            "picture|id=3|lang=grid\n"
+            "faceports|picture=3|cell=1-1|face=down|arity=2|at=1,3\n"
+            "pairleg|picture=3|upper=1-1|lower=2-1|upper-port=1|column=1\n"
+            "pairleg|picture=3|upper=1-1|lower=2-3|upper-port=3|column=3\n"
+            "pairleg|picture=3|upper=1-1|lower=2-2|upper-port=2|column=2\n"
+            "picture|id=4|lang=grid\n"
+            "faceports|picture=4|cell=1-1|face=down|arity=0|at=none\n"
+            "pairleg|picture=4|upper=1-1|lower=2-1|upper-port=center|column=1\n"
+            "picture|id=5|lang=grid\n"
+            "pairleg|picture=5|upper=1-1|lower=2-1|upper-port=center|column=1\n"
+            "pairleg|picture=5|upper=1-2|lower=2-2|upper-port=2|column=2\n"
+            "picture|id=6|lang=grid\n"
+            "faceports|picture=6|cell=1-1|face=down|arity=3|at=rows\n"
+            "pairleg|picture=6|upper=1-1|lower=2-3|upper-port=3|column=3\n"
+            "pairleg|picture=6|upper=1-1|lower=2-4|upper-port=4|column=4\n",
+            encoding="utf-8",
+        )
+        pairleg_faceports_audit = Audit(pairleg_faceports_log, None)
+        pairleg_faceports_audit.parse_log()
+        pairleg_faceports_audit.check_pairleg_faceports()
+        pairleg_faceport_mismatches = [
+            finding for finding in pairleg_faceports_audit.findings
+            if finding.rule == "pairleg-faceport-mismatch"
+        ]
         warning_only_log = work / "warning-only.tnlog"
         warning_only_log.write_text(
             "picture|id=1|lang=grid\n"
@@ -513,6 +548,24 @@ def main() -> int:
         for value in ("0", "-1", "bogus", overlong_port)
     ):
         raise AssertionError("audit accepted a non-contraction pairleg upper-port")
+    expected_pairleg_mismatches = {
+        (1, "upper-port='1'"),
+        (2, "upper-port='3'"),
+        (3, "upper-port='2'"),
+        (4, "upper-port='center'"),
+        (6, "upper-port='4'"),
+    }
+    actual_pairleg_mismatches = {
+        (picture, port)
+        for finding in pairleg_faceport_mismatches
+        for picture, port in expected_pairleg_mismatches
+        if f"picture {picture} " in finding.msg and port in finding.msg
+    }
+    if (len(pairleg_faceport_mismatches) != len(expected_pairleg_mismatches)
+            or actual_pairleg_mismatches != expected_pairleg_mismatches):
+        raise AssertionError(
+            "pairleg face-port correlation missed a mismatch or rejected a declared/legacy slot"
+        )
     if warning_only_status != 1 or not any(
         finding.rule == "empty-picture" and finding.severity == "HARD"
         for finding in warning_only_audit.findings

--- a/scripts/test_tenkz_face_ports.py
+++ b/scripts/test_tenkz_face_ports.py
@@ -546,6 +546,7 @@ def main() -> int:
             "picture|id=10|lang=grid\n"
             "faceports|picture=10|cell=1-1|face=down|arity=1|at=rows\n"
             "pairleg|picture=10|upper=1-1|lower=2-1|upper-port=center|column=1\n"
+            "pairleg|picture=10|upper=1-1|lower=2-1|upper-port=1|column=1\n"
             "picture|id=11|lang=grid\n"
             "faceports|picture=11|cell=1-1|face=down|arity=1|at=1\n"
             "faceports|picture=11|cell=1-1|face=down|arity=1|at=2\n"
@@ -643,6 +644,7 @@ def main() -> int:
         (6, "upper-port='4'"),
         (8, f"upper-port='{huge_arity + 1}'"),
         (9, "upper-port='center'"),
+        (10, "upper-port='1'"),
         (11, "upper-port='2'"),
     }
     actual_pairleg_mismatches = {


### PR DESCRIPTION
## Summary

- resolve explicit upper-cell down-face declarations for center, explicit lists, rows, and none
- reject pairleg contraction slots outside the declared face-port set
- retain compatibility for legacy logs without faceports events, including simple centered faces
- cover centered, contiguous, sparse, absent, missing, and rows declarations without false positives

## Validation

- python3 scripts/test_tenkz_face_ports.py (80 pictures, including periodic endpoints)
- all tex/tenkz/examples acceptance sources compile and audit without hard errors
- python3 scripts/test_tenkz_pic.py
- tenkz lint: 113 files, 0 findings
- python3 -m py_compile on the touched audit/test and pipeline/lint scripts
- git diff --check

Closes LionSR/tenkz#37

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the optional audit script and its regression tests; legacy logs without faceports are explicitly skipped, limiting breakage risk.
> 
> **Overview**
> Extends **tenkz** `.tnlog` auditing so grid **pairleg** `upper-port` values are checked against explicit **faceports** on the upper cell’s **down** face, with new hard rules **`pairleg-faceport-mismatch`** and **`conflicting-faceports`**.
> 
> The auditor resolves `at=` as `center`, `none`, comma-separated slots, or **`rows`** (with arity consistency), treats duplicate identical declarations as idempotent, and **skips** the pairleg check when no faceports exist (legacy logs). **`faceports` `arity`** must now be a non-negative integer.
> 
> **`test_tenkz_face_ports.py`** adds a synthetic log matrix for these cases, runs the new check on the compiled fixture (no false positives), and adjusts a few LaTeX examples (e.g. single-slot `down at={1}`, one-row physical `rows` + centered pairleg).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99044a255007a72650043c88033cba284256e597. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->