### PR TITLE
docs(Channel/FixedPoint): synchronize support correspondence

### DIFF
--- a/TNLean/Channel/FixedPoint/SupportCompressedDensityBlocks.lean
+++ b/TNLean/Channel/FixedPoint/SupportCompressedDensityBlocks.lean
@@ -168,8 +168,8 @@ is the full-support step in the proof of Wolf, Theorem 6.14; local source
 **Scope restriction (maximal-support compression):** This theorem describes
 the fixed points of the compressed map with positive definite density blocks.
 The transport to the original space with its complementary zero summand is
-completed in `TNLean.Channel.FixedPoint.WolfTheorem614`.  This restriction is
-documented in `docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex`.
+completed in `TNLean.Channel.FixedPoint.WolfTheorem614`.  That completion is
+recorded in `docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex`.
 
 The theorem records only the fixed-point description.  The corresponding
 formula for the mean ergodic projection is supplied by

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -3271,7 +3271,7 @@ positive maps, fixed points, or Theorem~6.14 of~\cite{Wolf2012Quantum}.
     Rescaling by the positive number $\tr(B)^{-1}$ proves $A>0$.
 \end{proof}
 
-% Scope restriction documented in
+% Completed support transport recorded in
 % docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex.
 \begin{theorem}[Density blocks after restriction to maximal stationary support]%
     \label{thm:maximal_support_compression_density_blocks}
@@ -3289,7 +3289,9 @@ positive maps, fixed points, or Theorem~6.14 of~\cite{Wolf2012Quantum}.
     \[
         \widetilde T(Y)=V^*T(VYV^*)V
     \]
-    has a positive definite fixed point.  There are positive integers
+    has a positive definite fixed point.  Moreover, $T(B)=B$ if and only if
+    there is a fixed point $Y$ of $\widetilde T$ such that $B=VYV^*$.
+    There are positive integers
     $d_k,m_k$, a unitary $U$ on $\mathcal H$, and positive definite
     density matrices $\sigma_k\in\MN{m_k}$ such that
     \[
@@ -3309,7 +3311,8 @@ positive maps, fixed points, or Theorem~6.14 of~\cite{Wolf2012Quantum}.
         thm:mean_ergodic_projection_density_block_form,
         thm:posdef_left_kronecker_trace_one}
     Theorem~\ref{thm:stationarySupport_compression} gives positivity, trace
-    preservation, and a positive definite fixed point for $\widetilde T$.
+    preservation, a positive definite fixed point for $\widetilde T$, and the
+    stated correspondence between the original and compressed fixed points.
     Directly from the trace pairing,
     \[
         \widetilde T^*(A)=V^*T^*(VAV^*)V.


### PR DESCRIPTION
## Summary\n\n- state the ambient/compressed fixed-point correspondence in the blueprint theorem whose Lean existential carries it\n- mention that correspondence in the blueprint proof dependency narrative\n- replace the stale scope-restriction wording with completion-record language\n\nFollow-up to #4363 and its final exact-head style-sync review. This changes documentation only.\n\n## Verification\n\n- `python3 scripts/blueprint_lean_sync.py --ci --diff-base origin/main`\n- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main --ci`\n- `git diff --check origin/main..HEAD`\n\n@codex review\n@claude review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prose and comment updates only; no changes to proofs, APIs, or runtime behavior.
> 
> **Overview**
> **Documentation-only** sync between the Lean module doc, the blueprint theorem `maximal_support_compression_density_blocks`, and the paper-gaps note on Wolf Theorem 6.14.
> 
> The blueprint now states explicitly that **$T(B)=B$ iff there is a compressed fixed point $Y$ with $B=VYV^*$**, matching what the Lean existential already encodes via `hambientFixed`. The proof narrative cites **stationary support compression** for that correspondence, not only positivity and density blocks.
> 
> Wording around `wolf_theorem6_14_fixed_point_projection_gap.tex` shifts from **scope restriction** to **completed support transport recorded** in both Lean and TeX comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0eecb604bc5b1052ea4f0a89b5c3002e03cb9ec8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->