### PR TITLE
feat(tenkz): draw RFP block-multiplicity routing

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -33,6 +33,7 @@ on:
       - 'scripts/tenkz_lint.py'
       - 'scripts/test_tenkz_pic.py'
       - 'scripts/test_tenkz_face_ports.py'
+      - 'scripts/test_tenkz_index_routing.py'
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
@@ -59,6 +60,7 @@ on:
       - 'scripts/tenkz_lint.py'
       - 'scripts/test_tenkz_pic.py'
       - 'scripts/test_tenkz_face_ports.py'
+      - 'scripts/test_tenkz_index_routing.py'
   workflow_dispatch:
 
 concurrency:
@@ -117,6 +119,7 @@ jobs:
               - 'scripts/tenkz_lint.py'
               - 'scripts/test_tenkz_pic.py'
               - 'scripts/test_tenkz_face_ports.py'
+              - 'scripts/test_tenkz_index_routing.py'
             workflow:
               - '.github/workflows/pr-ci.yml'
 
@@ -312,6 +315,10 @@ jobs:
       - name: Test asymmetric tenkz face ports
         if: env.TEX_CHANGED == 'true'
         run: python3 scripts/test_tenkz_face_ports.py
+
+      - name: Test tenkz coefficient-index routing
+        if: env.TEX_CHANGED == 'true'
+        run: python3 scripts/test_tenkz_index_routing.py
 
       - name: Lint LaTeX (chktex)
         if: env.TEX_CHANGED == 'true'

--- a/blueprint/src/chapter/ch26_mps_rfp_core.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp_core.tex
@@ -792,16 +792,104 @@
     Apply Theorem~\ref{thm:isometry_canonical_form_of_rfp_nt} to each block.
 \end{proof}
 
-% BLOCKED figure (issue #4152): the source threads both j and q through X,
-% the coefficient tensor, and X^{-1}.  Face-specific splitting ports can now
-% represent the local U geometry, but not this block-and-multiplicity threading.
-% Keep the faithful formula as an equation until that general primitive lands;
-% do not substitute the coarser global-X picture.
-Across all blocks, the canonical form is
-    \[
-        A^i=\bigoplus_{j=1}^g\bigoplus_{q=1}^{r_j}
-        \mu_{j,q}X_{j,q}\sqrt{\Lambda_j}\,U_j^iX_{j,q}^{-1}.
-    \]
+Across all blocks, the canonical form has the following routed representation.
+\begin{figure}[ht]
+    \centering
+    \begin{center}
+        \begin{tenkz}[physical=up, tensor style=box]
+            \tn{A}
+        \end{tenkz}
+        $\;=\;$
+        % TENKZ-II-RFP-BEGIN
+        \begin{tenkzfree}[tensor style=box]
+            \tnput[boundary, ports={east:virtual}]
+                {rfpWest}{(-8mm,0)}{}
+            \tnput[box, ports={west:virtual,east:virtual,south:virtual}]
+                {rfpX}{(0,0)}{X}
+            \tnput[box, ports={west:virtual,east:virtual,south:virtual}]
+                {rfpLambda}{(14mm,0)}{\sqrt\Lambda}
+            \tnput[box,
+                ports={south west:virtual,south:virtual,
+                    south east:virtual,north:physical}]
+                {rfpU}{(31mm,11mm)}{\quad U\quad}
+            \tnput[dot, ports={north:virtual,south:virtual,east:virtual}]
+                {rfpMain}{(31mm,0)}{}
+            \tnput[box, ports={west:virtual,east:virtual,south:virtual}]
+                {rfpM}{(40mm,0)}{M}
+            \tnput[box,
+                ports={west:virtual,east:virtual,north west:virtual,
+                    south:virtual}]
+                {rfpXinv}{(54mm,0)}{X^{-1}}
+            \tnput[boundary, ports={west:virtual}]
+                {rfpEast}{(63mm,0)}{}
+            \tnput[boundary, ports={south:physical}]
+                {rfpPhysical}{(31mm,20mm)}{}
+
+            \tnput[boundary, label pos=west, ports={east:virtual}]
+                {rfpJwest}{(-8mm,-9mm)}{j}
+            \tnput[dot, ports={west:virtual,east:virtual,
+                    north:virtual,south:virtual}]
+                {rfpXj}{(0,-9mm)}{}
+            \tnput[dot, ports={west:virtual,east:virtual,north:virtual}]
+                {rfpLambdaj}{(14mm,-9mm)}{}
+            \tnput[dot, ports={west:virtual,east:virtual,north:virtual}]
+                {rfpUj}{(31mm,-9mm)}{}
+            \tnput[dot, ports={west:virtual,east:virtual,
+                    north:virtual,south:virtual}]
+                {rfpXinvj}{(54mm,-9mm)}{}
+            \tnput[boundary, ports={west:virtual}]
+                {rfpJeast}{(63mm,-9mm)}{}
+
+            \tnput[boundary, label pos=west, ports={east:virtual}]
+                {rfpQwest}{(-8mm,-16mm)}{q}
+            \tnput[dot, ports={west:virtual,east:virtual,north:virtual}]
+                {rfpXq}{(0,-16mm)}{}
+            \tnput[dot, ports={west:virtual,east:virtual,north:virtual}]
+                {rfpMq}{(40mm,-16mm)}{}
+            \tnput[dot, ports={west:virtual,east:virtual,north:virtual}]
+                {rfpXinvq}{(54mm,-16mm)}{}
+            \tnput[boundary, ports={west:virtual}]
+                {rfpQeast}{(63mm,-16mm)}{}
+
+            \tnjoin{rfpWest.east}{rfpX.west}
+            \tnjoin{rfpX.east}{rfpLambda.west}
+            \tnjoin[route=hv]{rfpLambda.east}{rfpU.south west}
+            \tnjoin[route=vh]{rfpU.south east}{rfpXinv.north west}
+            \tnjoin{rfpU.south}{rfpMain.north}
+            \tnjoin{rfpMain.east}{rfpM.west}
+            \tnjoin{rfpM.east}{rfpXinv.west}
+            \tnjoin{rfpXinv.east}{rfpEast.west}
+            \tnjoin{rfpPhysical.south}{rfpU.north}
+
+            \tnjoin{rfpX.south}{rfpXj.north}
+            \tnjoin{rfpXj.south}{rfpXq.north}
+            \tnjoin{rfpLambda.south}{rfpLambdaj.north}
+            \tnjoin{rfpMain.south}{rfpUj.north}
+            \tnjoin{rfpM.south}{rfpMq.north}
+            \tnjoin{rfpXinv.south}{rfpXinvj.north}
+            \tnjoin{rfpXinvj.south}{rfpXinvq.north}
+
+            \tnjoin{rfpJwest.east}{rfpXj.west}
+            \tnjoin{rfpXj.east}{rfpLambdaj.west}
+            \tnjoin{rfpLambdaj.east}{rfpUj.west}
+            \tnjoin{rfpUj.east}{rfpXinvj.west}
+            \tnjoin{rfpXinvj.east}{rfpJeast.west}
+            \tnjoin{rfpQwest.east}{rfpXq.west}
+            \tnjoin{rfpXq.east}{rfpMq.west}
+            \tnjoin{rfpMq.east}{rfpXinvq.west}
+            \tnjoin{rfpXinvq.east}{rfpQeast.west}
+        \end{tenkzfree}
+        % TENKZ-II-RFP-END
+    \end{center}
+    \caption{Block-and-multiplicity routing in the isometry canonical form.
+        The independent rails $j$ and $q$ pass through the coefficient
+        network without being fused: $X$ and $X^{-1}$ depend on both,
+        $\sqrt\Lambda$ and $U$ carry the block label $j$, and $M$ carries
+        the multiplicity label $q$.  The upper leg of $U$ is the physical
+        index, as in the source figure
+        \cite[Section~3.4, lines~543--563]{Cirac2016MPDO_arXiv}.}
+    \label{fig:rfp_block_multiplicity_routing}
+\end{figure}
 Here $j$ labels the normal-tensor block and $q$ its repeated representation;
 the residual isometries in
 \cite[Section~3.4, lines~543--561]{Cirac2016MPDO_arXiv} also satisfy

--- a/docs/tenkz/DESIGN.md
+++ b/docs/tenkz/DESIGN.md
@@ -996,3 +996,20 @@ inside the resolver.
   cells' silhouette toward each edge plus daylight, so outlines hug
   bare beads and step out around legs and labels instead of carrying
   one worst-case margin.
+
+## 19. Named coefficient routing (recorded 2026-07-19)
+
+Several coefficient tensors may depend on the same direct-sum labels without
+turning those labels into one fused wire.  The free tier records this as an
+explicit typed graph: each coefficient glyph declares one port per incident
+index, each junction is a dot atom, and each labelled rail is a chain of
+`\tnjoin` edges.  Sharing a glyph therefore never collapses two names into one
+unlabelled strand.  This is the native spelling of the $j,q$ routing in
+`II_RFP.png` from arXiv:1606.00608.
+
+No routing command is added.  `\tnput` and `\tnjoin` already form the required
+grammatical class, and a dedicated command would only abbreviate one graph.
+The `boundary` skin of `\tnput` places an inkless typed endpoint, so open rails
+and their labels enter the event graph without acquiring a spurious tensor
+dot.  A regression should compare the complete join set and the degree of
+every coefficient, junction, and boundary node.

--- a/docs/tenkz/chapters2/ch-reference.tex
+++ b/docs/tenkz/chapters2/ch-reference.tex
@@ -580,7 +580,8 @@ widths still apply, so a free picture matches its grid neighbours.
 \toprule
 \keyhead
 \texttt{dot}, \texttt{box}, \texttt{pill}, \texttt{mpo},
-  \texttt{ring} & --- & policy & the glyph \\
+  \texttt{ring}, \texttt{boundary} & --- & policy & the glyph;
+  \texttt{boundary} is an inkless typed endpoint \\
 \texttt{ports=} & \texttt{\{side:kind,\ldots\}} & --- &
   typed ports, kinds \texttt{virtual} and \texttt{physical} \\
 \texttt{role=} & \meta{role} & --- &

--- a/docs/tenkz/manual2.tex
+++ b/docs/tenkz/manual2.tex
@@ -286,7 +286,7 @@ whole language.
 
   \qrsection{Free placement (tenkzfree)}
   \qritem{\textbackslash tnput[shape, ports=]\{name\}\{(x,y)\}\{A\}}{%
-    typed node; shapes dot|box|pill|mpo|ring}
+    typed node; shapes dot|box|pill|mpo|ring|boundary}
   \qritem{\textbackslash tnjoin[route=, dir, fused, label=, out=,
     in=]\{a.east\}\{b.west\}}{wire; \texttt{route=}
     straight|hv|vh|curve; \texttt{dir}: argument order = direction}

--- a/scripts/test_tenkz_index_routing.py
+++ b/scripts/test_tenkz_index_routing.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Regression check for the II_RFP block-and-multiplicity routing graph."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+from collections import Counter
+from pathlib import Path
+
+from tenkz_audit import Audit
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CHAPTER = ROOT / "blueprint/src/chapter/ch26_mps_rfp_core.tex"
+BEGIN = "% TENKZ-II-RFP-BEGIN"
+END = "% TENKZ-II-RFP-END"
+
+
+def attrs(line: str) -> tuple[str, dict[str, str]]:
+    fields = line.split("|")
+    return fields[0], dict(field.split("=", 1) for field in fields[1:])
+
+
+def main() -> int:
+    engine = shutil.which("xelatex")
+    if engine is None:
+        print("FAIL: xelatex is required")
+        return 1
+
+    chapter = CHAPTER.read_text(encoding="utf-8")
+    if chapter.count(BEGIN) != 1 or chapter.count(END) != 1:
+        raise AssertionError("II_RFP routing markers must occur exactly once")
+    body = chapter.split(BEGIN, 1)[1].split(END, 1)[0]
+    source = (
+        "\\documentclass{article}\n"
+        "\\usepackage{tenkz}\n"
+        "\\pagestyle{empty}\n"
+        "\\begin{document}\n"
+        f"{body}\n"
+        "\\end{document}\n"
+    )
+
+    with tempfile.TemporaryDirectory(prefix="tenkz_index_routing_") as tmp:
+        work = Path(tmp)
+        tex = work / "ii-rfp-routing.tex"
+        tex.write_text(source, encoding="utf-8")
+        env = os.environ.copy()
+        env["TEXINPUTS"] = f"{ROOT / 'tex/tenkz'}//:" + env.get("TEXINPUTS", "")
+        run = subprocess.run(
+            [engine, "-interaction=nonstopmode", "-halt-on-error", tex.name],
+            cwd=work,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+        if run.returncode:
+            print(run.stdout)
+            print("FAIL: II_RFP routing fixture did not compile")
+            return 1
+        log_path = work / "ii-rfp-routing.tnlog"
+        lines = log_path.read_text(encoding="utf-8").splitlines()
+        audit = Audit(log_path, tex)
+        audit.parse_log()
+        audit.check_dialects()
+        hard = [finding for finding in audit.findings if finding.severity == "HARD"]
+        if hard:
+            raise AssertionError(f"II_RFP event stream has hard findings: {hard}")
+
+    parsed = [attrs(line) for line in lines]
+    atoms = {
+        event["name"]: event["kind"]
+        for kind, event in parsed
+        if kind == "atom"
+    }
+    expected_atoms = {
+        "rfpWest": "boundary", "rfpX": "box", "rfpLambda": "box",
+        "rfpU": "box", "rfpMain": "dot", "rfpM": "box",
+        "rfpXinv": "box", "rfpEast": "boundary",
+        "rfpPhysical": "boundary", "rfpJwest": "boundary",
+        "rfpXj": "dot", "rfpLambdaj": "dot", "rfpUj": "dot",
+        "rfpXinvj": "dot", "rfpJeast": "boundary",
+        "rfpQwest": "boundary", "rfpXq": "dot", "rfpMq": "dot",
+        "rfpXinvq": "dot", "rfpQeast": "boundary",
+    }
+    if atoms != expected_atoms:
+        raise AssertionError(f"II_RFP atoms changed: {atoms}")
+
+    joins = [
+        frozenset((event["from"], event["to"]))
+        for kind, event in parsed
+        if kind == "join"
+    ]
+    expected_joins = {
+        frozenset(edge)
+        for edge in (
+            ("rfpWest.east", "rfpX.west"),
+            ("rfpX.east", "rfpLambda.west"),
+            ("rfpLambda.east", "rfpU.south west"),
+            ("rfpU.south east", "rfpXinv.north west"),
+            ("rfpU.south", "rfpMain.north"),
+            ("rfpMain.east", "rfpM.west"),
+            ("rfpM.east", "rfpXinv.west"),
+            ("rfpXinv.east", "rfpEast.west"),
+            ("rfpPhysical.south", "rfpU.north"),
+            ("rfpX.south", "rfpXj.north"),
+            ("rfpXj.south", "rfpXq.north"),
+            ("rfpLambda.south", "rfpLambdaj.north"),
+            ("rfpMain.south", "rfpUj.north"),
+            ("rfpM.south", "rfpMq.north"),
+            ("rfpXinv.south", "rfpXinvj.north"),
+            ("rfpXinvj.south", "rfpXinvq.north"),
+            ("rfpJwest.east", "rfpXj.west"),
+            ("rfpXj.east", "rfpLambdaj.west"),
+            ("rfpLambdaj.east", "rfpUj.west"),
+            ("rfpUj.east", "rfpXinvj.west"),
+            ("rfpXinvj.east", "rfpJeast.west"),
+            ("rfpQwest.east", "rfpXq.west"),
+            ("rfpXq.east", "rfpMq.west"),
+            ("rfpMq.east", "rfpXinvq.west"),
+            ("rfpXinvq.east", "rfpQeast.west"),
+        )
+    }
+    if len(joins) != len(expected_joins) or set(joins) != expected_joins:
+        raise AssertionError("II_RFP join graph changed")
+
+    degree: Counter[str] = Counter()
+    for edge in joins:
+        for endpoint in edge:
+            degree[endpoint.split(".", 1)[0]] += 1
+    boundary_names = {name for name, kind in atoms.items() if kind == "boundary"}
+    if any(degree[name] != 1 for name in boundary_names):
+        raise AssertionError(f"II_RFP boundary is not open exactly once: {degree}")
+    expected_coeff_degrees = {
+        "rfpX": 3, "rfpLambda": 3, "rfpU": 4,
+        "rfpM": 3, "rfpXinv": 4,
+    }
+    if any(degree[name] != value for name, value in expected_coeff_degrees.items()):
+        raise AssertionError(f"II_RFP coefficient arity changed: {degree}")
+
+    print("PASS: II_RFP block and multiplicity rails retain their routed arities")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_tenkz_index_routing.py
+++ b/scripts/test_tenkz_index_routing.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import subprocess
 import tempfile
@@ -34,6 +35,34 @@ def main() -> int:
     if chapter.count(BEGIN) != 1 or chapter.count(END) != 1:
         raise AssertionError("II_RFP routing markers must occur exactly once")
     body = chapter.split(BEGIN, 1)[1].split(END, 1)[0]
+    declared_ports: dict[str, dict[str, str]] = {}
+    for match in re.finditer(
+        r"\\tnput\[(?P<options>.*?)\]\s*\{(?P<name>[^}]+)\}", body, re.DOTALL
+    ):
+        ports = re.search(r"ports=\{(?P<ports>[^}]*)\}", match["options"], re.DOTALL)
+        if ports is None:
+            continue
+        declared_ports[match["name"]] = {
+            anchor.strip(): port_type.strip()
+            for item in ports["ports"].split(",")
+            for anchor, port_type in [item.rsplit(":", 1)]
+        }
+    expected_boundary_ports = {
+        "rfpWest": {"east": "virtual"},
+        "rfpEast": {"west": "virtual"},
+        "rfpPhysical": {"south": "physical"},
+        "rfpJwest": {"east": "virtual"},
+        "rfpJeast": {"west": "virtual"},
+        "rfpQwest": {"east": "virtual"},
+        "rfpQeast": {"west": "virtual"},
+    }
+    actual_boundary_ports = {
+        name: declared_ports.get(name) for name in expected_boundary_ports
+    }
+    if actual_boundary_ports != expected_boundary_ports:
+        raise AssertionError(
+            f"II_RFP boundary port declarations changed: {actual_boundary_ports}"
+        )
     source = (
         "\\documentclass{article}\n"
         "\\usepackage{tenkz}\n"

--- a/tex/tenkz/tenkz-free.code.tex
+++ b/tex/tenkz/tenkz-free.code.tex
@@ -22,7 +22,8 @@
   { \end{tikzpicture} }
 
 % \tnput[<glyph keys>]{<name>}{<coordinate>}{<label>}
-%   glyph keys: dot|box|pill|mpo (skin), ports={e:virtual, ph:physical, ...},
+%   glyph keys: dot|box|pill|mpo|ring|boundary (skin),
+%   ports={e:virtual, ph:physical, ...},
 %   label pos=north|south|east|west (dot skin only)
 \tl_new:N \l__tenkz_fshape_tl    % \tnput skin word (free-owned: the tiers
                                  % share only L0/L1, never each other's locals)
@@ -38,6 +39,7 @@
   /tenkz/put/pill/.code={\tl_set:Nn \l__tenkz_fshape_tl {pill}},
   /tenkz/put/mpo/.code={\tl_set:Nn \l__tenkz_fshape_tl {mpo}},
   /tenkz/put/ring/.code={\tl_set:Nn \l__tenkz_fshape_tl {ring}},
+  /tenkz/put/boundary/.code={\tl_set:Nn \l__tenkz_fshape_tl {boundary}},
   /tenkz/put/ports/.store~in=\l__tenkz_fports_tl,
   % role= / species=: the semantic hue interface (see tenkz-core) —
   % the language's invariants cross the free-tier border.  Resolution
@@ -144,6 +146,13 @@
                    { $\tenkz@labelsize \tenkz@glyphstrut #4$ }; }
         {ring} { \node[on-wire~matrix, \l__tenkz_frolesty_tl] (#2) at #3
                    { $\tenkz@labelsize \tenkz@glyphstrut #4$ }; }
+        {boundary}
+          {
+            \coordinate (#2) at #3;
+            \tl_if_blank:nF {#4}
+              { \exp_args:NV \tenkz_free_dot_label:nnn
+                  \l__tenkz_flpos_tl {#2} {#4} }
+          }
       }
     % register declared port types:  ports={east:virtual, north:physical}
     % (str-normalized so the document's catcode-12 colon parses)


### PR DESCRIPTION
Closes LionSR/tenkz#34.

## Summary

- replace the `II_RFP.png` placeholder with a native tenkz figure whose independent `j` and `q` rails reproduce the source coefficient routing
- add an inkless typed `boundary` skin for explicit open endpoints in free-form diagrams
- document the routing pattern and add a regression that checks the exact join set and coefficient-node arities

This is the pure-state MPS renormalization-fixed-point construction embedded in the MPDO/RFP paper, not a PEPS result. The figure follows `Papers/1606.00608/MPDO-22-12-17-2.tex`, Section 3.4, lines 543-563. It retains the chapter's documented `sqrt(Lambda)` correction in place of the source image's bare `Lambda`.

## Validation

- `python3 scripts/test_tenkz_index_routing.py`
- `python3 scripts/test_tenkz_face_ports.py`
- `python3 scripts/test_tenkz_pic.py`
- `python3 scripts/tenkz_lint.py 'blueprint/src/chapter/*.tex' 'docs/tenkz/manual2.tex' 'docs/tenkz/chapters2/*.tex' 'tex/tenkz/examples/*.tex'`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `leanblueprint pdf` (670 pages; affected page 492 rendered and visually inspected)
- `leanblueprint web` (grid and free-form diagrams emitted as native SVG image nodes)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to tenkz free-tier rendering, one blueprint figure, documentation, and a regression test; no Lean or runtime security impact.
> 
> **Overview**
> Replaces the blocked **II_RFP** placeholder in `ch26_mps_rfp_core.tex` with a **`tenkzfree`** diagram whose separate **$j$** and **$q$** rails route through $X$, $\sqrt\Lambda$, $U$, $M$, and $X^{-1}$ without fusing labels into one wire.
> 
> **tenkz:** New **`boundary`** skin on `\tnput` — coordinate plus optional label, typed ports, no bead ink — for open typed endpoints in free-form graphs.
> 
> **Docs:** DESIGN §19 (named coefficient routing), manual/quick-ref updates for `boundary`.
> 
> **CI:** `scripts/test_tenkz_index_routing.py` compiles the marked figure slice, audits `.tnlog`, and locks atoms, joins, boundary degrees, and coefficient arities; wired into `pr-ci.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 583bf56aa1f045293fbc64419cad44ce90178f83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->