### PR TITLE
feat(tenkz): add ribbon fusion-tree skin

### DIFF
--- a/docs/tenkz/chapters2/ch-reference.tex
+++ b/docs/tenkz/chapters2/ch-reference.tex
@@ -406,13 +406,21 @@ belongs directly in running mathematics or in a displayed equation.  No
 floating or numbered figure is part of the grammar.
 
 \thumbtag{\tncmd{tntree}}%
-\cmdsig{\textbackslash tntree\{\meta{bracketed word}\}\\
+\cmdsig{\textbackslash tntree[tree style=wire|ribbon,\\
+\hspace*{2em}role=\meta{role}, species=\meta{name}]%
+\{\meta{bracketed word}\}\\
 \textbackslash tnarrow*[from=\meta{i}, to=\meta{j}]\{\meta{label}\}}
 
 \noindent \tncmd{tntree} draws the fusion tree of a bracketed word,
 innermost pairs first: in
 \tnval{((a\textbackslash,b)\_x\textbackslash,c)\_y} the pair
 $(a,b)$ fuses into the internal charge $x$, then with $c$ into $y$.
+The default \tnkey{tree style=wire} draws the tree as trivalent lines;
+\tnkey{tree style=ribbon} draws the regular ribbon neighbourhood of the
+same parsed tree, with a nonsingular vertex patch and three attached bands
+at each trivalent vertex.  A declared \tnkey{species=} or a semantic
+\tnkey{role=} colours either skin, with the role prevailing when both are
+present.
 \tncmd{tnarrow} labels the arrow from slot $i$ to slot $j$; the
 starred form sets the label on the other side of the shaft.  The
 five-slot pentagon, trees and all, is Example~\ref{ex:tut-pentagon}.

--- a/docs/tenkz/chapters2/ch-tutorial.tex
+++ b/docs/tenkz/chapters2/ch-tutorial.tex
@@ -264,13 +264,16 @@ whether in a sentence or between the delimiters of a displayed equation.
 % ---------------------------------------------------------------------
 \subsection{Fusion trees and the pentagon}\label{sec:tut-cd}
 
-Commutative diagrams are not contractions, so they live in their own
-environment.  In \tnenv{tenkzcd}'s polygon mode, \tnkey{polygon=5}
-sets five cells on a circle, vertex $1$ on top, clockwise;
-\tncmd{tntree} builds a fusion tree from a parenthesised word whose
-subscripts are the internal charges; \tncmd{tnarrow} draws a labelled
-arrow between vertices, and the starred form sets its label on the
-arrow's other side.
+The pentagon expresses equality of two composites of associativity
+isomorphisms.  After choosing bases in the fusion spaces, and either in
+the multiplicity-free case or with multiplicity labels suppressed, each
+vertex is the basis morphism represented by one parenthesised fusion
+tree for $a\otimes b\otimes c\otimes d$; each edge is an $F$-move.  In
+\tnenv{tenkzcd}'s polygon mode, \tnkey{polygon=5} sets five
+cells on a circle, vertex $1$ on top, clockwise.  The command
+\tncmd{tntree} builds a tree from a parenthesised word whose subscripts
+are the internal charges; \tncmd{tnarrow} draws a labelled arrow between
+vertices, and the starred form sets its label on the arrow's other side.
 
 \begin{tnexample}[
     formula   = {\begin{aligned}[t]
@@ -282,24 +285,70 @@ arrow's other side.
                    &=\bigl[F^{xcd}_{e}\bigr]_{yv}
                      \bigl[F^{abv}_{e}\bigr]_{xw}
                  \end{aligned}},
-    caption   = {the pentagon},
+    caption   = {the multiplicity-free pentagon in the wire skin},
     index     = {Each \tncmd{tntree} word is one association of
-                 $a,b,c,d$ fusing to $e$; the subscripts $x=ab$,
-                 $y=abc$, $u=bc$, $w=bcd$, $v=cd$ are the internal
-                 charges.  The two arrow paths from vertex $1$ to
+                 $a,b,c,d$ fusing to $e$.  The subscripts $x,u,v,w,y$
+                 are intermediate simple channels allowed by the
+                 corresponding fusion coefficients (for example,
+                 $N_{ab}^{x}>0$ and $N_{bc}^{u}>0$).  The two arrow
+                 paths from vertex $1$ to
                  vertex $4$ compose to the same map, with the sum
                  over $u$ running along the three-move path.},
     label     = {ex:tut-pentagon},
   ]
-% pentagon for a,b,c,d -> e; internal charges x=ab, y=abc,
-% u=bc, w=bcd, v=cd; the two F-move paths from vertex 1 to
-% vertex 4 agree, with a sum over u on the three-move path
+% Multiplicity-free specialization of arXiv:1511.08090, Eq. (33), for
+% a,b,c,d -> e.  The labels x,u,v,w,y are intermediate simple channels:
+% e.g. N_{ab}^x>0, N_{bc}^u>0, and N_{cd}^v>0; they are not composites.
+% The two F-move paths from vertex 1 to vertex 4 agree, with a sum over u.
+% Each simple object is a wire, and each trivalent point is fusion.
 \begin{tenkzcd}[polygon=5, radius=32mm]
-  \tntree{(((a\,b)_x\,c)_y\,d)_e} &
-  \tntree{((a\,(b\,c)_u)_y\,d)_e} &
-  \tntree{(a\,((b\,c)_u\,d)_w)_e} &
-  \tntree{(a\,(b\,(c\,d)_v)_w)_e} &
-  \tntree{((a\,b)_x\,(c\,d)_v)_e}
+  \tntree[tree style=wire]{(((a\,b)_x\,c)_y\,d)_e} &
+  \tntree[tree style=wire]{((a\,(b\,c)_u)_y\,d)_e} &
+  \tntree[tree style=wire]{(a\,((b\,c)_u\,d)_w)_e} &
+  \tntree[tree style=wire]{(a\,(b\,(c\,d)_v)_w)_e} &
+  \tntree[tree style=wire]{((a\,b)_x\,(c\,d)_v)_e}
+  \tnarrow[from=1, to=2]{F^{abc}_y}
+  \tnarrow[from=2, to=3]{F^{aud}_e}
+  \tnarrow[from=3, to=4]{F^{bcd}_w}
+  \tnarrow*[from=1, to=5]{F^{xcd}_e}
+  \tnarrow*[from=5, to=4]{F^{abv}_e}
+\end{tenkzcd}
+\end{tnexample}
+
+The ribbon skin changes the representation of each fusion tree, not the
+morphism it denotes.  It draws the regular ribbon neighbourhood of the
+tree: three bands meet in a nonsingular vertex patch, without a tensor
+bead or a doubled-wire convention.
+
+\vspace*{8mm}
+\begin{tnexample}[
+    formula   = {\begin{aligned}[t]
+                   &\textstyle\sum_{u}
+                    \bigl[F^{abc}_{y}\bigr]_{xu}
+                    \bigl[F^{aud}_{e}\bigr]_{yw}
+                    \bigl[F^{bcd}_{w}\bigr]_{uv}\\
+                   &=\bigl[F^{xcd}_{e}\bigr]_{yv}
+                     \bigl[F^{abv}_{e}\bigr]_{xw}
+                 \end{aligned}},
+    caption   = {the same multiplicity-free pentagon in the ribbon skin},
+    index     = {The five parenthesised words and five $F$-moves are
+                 exactly those of Example~\ref{ex:tut-pentagon}; only
+                 \tnkey{tree style=ribbon} changes.  Thus the polygon
+                 again compares the three-move and two-move composites,
+                 now using ribbon-neighbourhood representatives for its
+                 basis morphisms.},
+  ]
+% This is the same multiplicity-free specialization of equation (33),
+% with the same chosen fusion bases and suppressed multiplicity labels.
+% Each parenthesised word is identical to the wire example; tree style
+% changes only its ink.  Every trivalent fusion has a nonsingular vertex
+% patch, and the three incident simple objects are its three labelled bands.
+\begin{tenkzcd}[polygon=5, radius=32mm]
+  \tntree[tree style=ribbon]{(((a\,b)_x\,c)_y\,d)_e} &
+  \tntree[tree style=ribbon]{((a\,(b\,c)_u)_y\,d)_e} &
+  \tntree[tree style=ribbon]{(a\,((b\,c)_u\,d)_w)_e} &
+  \tntree[tree style=ribbon]{(a\,(b\,(c\,d)_v)_w)_e} &
+  \tntree[tree style=ribbon]{((a\,b)_x\,(c\,d)_v)_e}
   \tnarrow[from=1, to=2]{F^{abc}_y}
   \tnarrow[from=2, to=3]{F^{aud}_e}
   \tnarrow[from=3, to=4]{F^{bcd}_w}
@@ -312,9 +361,10 @@ The tree is its word: \verb|(((a\,b)_x\,c)_y\,d)_e| says fuse $a$ with
 $b$ into $x$, then with $c$ into $y$, then with $d$ into the total
 charge $e$.  Every $F$-symbol slot holds a simple charge --- the mixed
 slots carry $x$, $u$, $v$, never a composite label like
-$bc$.\sidenote{Conventions of arXiv:1511.08090, eq.~(33): fused
-charges up, total charge down, the $F$-move mapping the
-left-associated tree to the right-associated one.}
+$bc$.\sidenote{Multiplicity-free specialization of the conventions of
+arXiv:1511.08090, eq.~(33): intermediate simple channels up, total charge
+down, and the $F$-move mapping the left-associated tree to the
+right-associated one.}
 
 % ---------------------------------------------------------------------
 \subsection{A picture in a sentence}\label{sec:tut-inline}

--- a/scripts/tenkz_audit.py
+++ b/scripts/tenkz_audit.py
@@ -13,6 +13,9 @@ Hard errors (exit 1):
                        slot).  The stream is the contraction record; a
                        non-numeric coordinate names no cell, so the event
                        describes no drawable ink.
+  malformed-tree       A tree's canonical numeric bracketing is not a
+                       rooted binary tree, or disagrees with its declared
+                       leaf and vertex counts.
   duplicate-picture    Two `picture` lines share one id: picture identity
                        is the key of every back-reference.
   dangling-picture-ref An event references an undeclared picture.
@@ -76,8 +79,27 @@ DIALECT_KINDS = {
 }
 
 
+def _parse_int(v: str) -> Optional[int]:
+    if INT_RE.fullmatch(v) is None:
+        return None
+    try:
+        return int(v)
+    except ValueError:  # Python's configured decimal-digit safety limit
+        return None
+
+
 def _is_int(v: str) -> bool:
-    return INT_RE.fullmatch(v) is not None
+    return _parse_int(v) is not None
+
+
+def _is_positive_int(v: str) -> bool:
+    parsed = _parse_int(v)
+    return parsed is not None and parsed > 0
+
+
+def _is_nonnegative_int(v: str) -> bool:
+    parsed = _parse_int(v)
+    return parsed is not None and parsed >= 0
 
 
 def _is_cell(v: str) -> bool:
@@ -138,7 +160,12 @@ FIELD_VALIDATORS: dict[str, dict[str, Callable[[str], bool]]] = {
               "fused": _enum("0", "1"),
               "role": _enum("none", "operator", "marked", "extra", "passive"),
               "species": _any},
-    "tree": {"picture": _is_int, "leaves": _is_int},
+    "tree": {"picture": _is_int, "id": _is_positive_int,
+             "style": _enum("wire", "ribbon"),
+             "leaves": _is_positive_int, "vertices": _is_nonnegative_int,
+             "topology": _any,
+             "role": _enum("none", "operator", "marked", "extra", "passive"),
+             "species": _any},
     "join": {"picture": _is_int, "from": _any, "to": _any},
 }
 
@@ -267,6 +294,8 @@ class Audit:
                 self.by_id[pid] = pic
                 self.pictures.append(pic)
                 continue
+            if kind == "tree":
+                self.check_tree_event(ev)
             ref = attrs.get("picture", "")
             if not _is_int(ref):
                 continue
@@ -278,6 +307,31 @@ class Audit:
                           f"{kind} references undeclared picture {pid}")
                 continue
             self.by_id[pid].events.append(ev)
+
+    def check_tree_event(self, event: Event) -> None:
+        """Validate the tree event as structural data, not display text."""
+        where = f"{self.log_path.name}:{event.line}"
+        required = {"id", "style", "leaves", "vertices", "topology",
+                    "role", "species"}
+        missing = sorted(required - event.attrs.keys())
+        if missing:
+            self.hard("malformed-tree", where,
+                      f"tree event lacks required field(s): {', '.join(missing)}")
+            return
+        shape = parse_tree_topology(event.attrs["topology"])
+        if shape is None:
+            self.hard("malformed-tree", where,
+                      f"invalid canonical topology {event.attrs['topology']!r}")
+            return
+        leaves, vertices = shape
+        if not (_is_positive_int(event.attrs["leaves"])
+                and _is_nonnegative_int(event.attrs["vertices"])):
+            return  # generic field validation already reports these values
+        declared = (int(event.attrs["leaves"]), int(event.attrs["vertices"]))
+        if declared != (leaves, vertices):
+            self.hard("malformed-tree", where,
+                      f"topology has {leaves} leaves and {vertices} vertices, "
+                      f"but event declares {declared[0]} and {declared[1]}")
 
     # ---------------- log-only checks ----------------
 
@@ -456,6 +510,52 @@ class Audit:
 
 
 # ---------------- canonical topology ----------------
+
+def parse_tree_topology(value: str) -> Optional[tuple[int, int]]:
+    """Return (leaves, internal vertices) for canonical numeric bracketing.
+
+    A canonical tree is either the next positive leaf number or a pair of
+    canonical trees.  Consequently the leaf sequence must be exactly
+    1,2,...,n; labels and TeX never enter this structural field.
+    """
+    pos = 0
+    leaf_numbers: list[int] = []
+
+    def parse_node() -> Optional[int]:
+        nonlocal pos
+        if pos >= len(value):
+            return None
+        if value[pos].isdigit():
+            start = pos
+            while pos < len(value) and value[pos].isdigit():
+                pos += 1
+            leaf = int(value[start:pos])
+            if leaf <= 0:
+                return None
+            leaf_numbers.append(leaf)
+            return 0
+        if value[pos] != "(":
+            return None
+        pos += 1
+        left = parse_node()
+        if left is None or pos >= len(value) or value[pos] != ",":
+            return None
+        pos += 1
+        right = parse_node()
+        if right is None or pos >= len(value) or value[pos] != ")":
+            return None
+        pos += 1
+        return left + right + 1
+
+    try:
+        vertices = parse_node()
+    except (RecursionError, ValueError):
+        return None
+    if (vertices is None or pos != len(value)
+            or leaf_numbers != list(range(1, len(leaf_numbers) + 1))):
+        return None
+    return len(leaf_numbers), vertices
+
 
 def canonical_hash(pic: Picture) -> str:
     """Order-free digest of a picture's content.  Attributes are sorted,

--- a/scripts/test_tenkz_tree.py
+++ b/scripts/test_tenkz_tree.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Regression checks for wire/ribbon fusion-tree skins and tree audit data."""
+
+from __future__ import annotations
+
+import io
+import os
+import shutil
+import subprocess
+import tempfile
+from contextlib import redirect_stdout
+from pathlib import Path
+
+from tenkz_audit import Audit
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = r"""
+\documentclass{article}
+\usepackage{tenkz}
+\pagestyle{empty}
+\begin{document}
+\tnset{species={anyon}}
+% With fusion bases chosen and multiplicity labels suppressed, both calls
+% denote the same basis morphism; only the skin changes.
+\tntree[tree style=wire, species=anyon]{((a\,b)_x\,c)_e}
+\tntree[tree style=ribbon, species=anyon]{((a\,b)_x\,c)_e}
+\tntree[tree style=ribbon, species=anyon, role=marked]{(a\,(b\,c)_u)_e}
+\end{document}
+"""
+
+
+def main() -> int:
+    engine = shutil.which("xelatex")
+    if engine is None:
+        print("SKIP: xelatex not found")
+        return 0
+    with tempfile.TemporaryDirectory(prefix="tenkz-tree-") as tmp:
+        work = Path(tmp)
+        tex = work / "trees.tex"
+        tex.write_text(SOURCE, encoding="utf-8")
+        env = os.environ.copy()
+        env["TEXINPUTS"] = f"{ROOT / 'tex/tenkz'}//:" + env.get("TEXINPUTS", "")
+        try:
+            run = subprocess.run(
+                [engine, "-interaction=nonstopmode", "-halt-on-error", tex.name],
+                cwd=work,
+                env=env,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                timeout=120,
+            )
+        except subprocess.TimeoutExpired as exc:
+            print(exc.stdout or "")
+            print("FAIL: wire/ribbon tree fixture timed out after 120 seconds")
+            return 1
+        if run.returncode:
+            print(run.stdout)
+            print("FAIL: wire/ribbon tree fixture did not compile")
+            return 1
+
+        log = work / "trees.tnlog"
+        audit = Audit(log, tex)
+        with redirect_stdout(io.StringIO()):
+            status = audit.run()
+        if status:
+            raise AssertionError("audit rejected valid wire/ribbon tree events")
+        lines = log.read_text(encoding="utf-8").splitlines()
+        if len(lines) != 3:
+            raise AssertionError(f"expected three tree events, got {len(lines)}")
+        if "style=wire" not in lines[0] or "style=ribbon" not in lines[1]:
+            raise AssertionError("tree style was not recorded")
+        topology = "topology=((1,2),3)"
+        if topology not in lines[0] or topology not in lines[1]:
+            raise AssertionError("the two skins did not preserve one topology")
+        if "role=marked|species=anyon" not in lines[2]:
+            raise AssertionError("tree role/species semantics were not recorded")
+
+        malformed = work / "malformed.tnlog"
+        overlong = "9" * 5000
+        deep = "(" * 1500 + "1" + ",2)" * 1500
+        malformed.write_text(
+            "tree|picture=0|id=1|style=ribbon|leaves=3|vertices=2|"
+            "topology=((1,3),2)|role=none|species=none\n"
+            "tree|picture=0|id=2|style=wire|leaves=2|vertices=1|"
+            "topology=(1,{a})|role=none|species=none\n"
+            f"tree|picture=0|id=3|style=wire|leaves=2|vertices=1|"
+            f"topology=({overlong},2)|role=none|species=none\n"
+            f"tree|picture=0|id=4|style=ribbon|leaves=1501|vertices=1500|"
+            f"topology={deep}|role=none|species=none\n"
+            f"tree|picture=0|id={overlong}|style=wire|leaves=2|vertices=1|"
+            f"topology=(1,2)|role=none|species=none\n",
+            encoding="utf-8",
+        )
+        malformed_audit = Audit(malformed, None)
+        malformed_audit.parse_log()
+        failures = [
+            finding for finding in malformed_audit.findings
+            if finding.rule == "malformed-tree"
+        ]
+        if len(failures) != 4:
+            raise AssertionError("audit accepted noncanonical tree topology")
+        numeric_failures = [
+            finding for finding in malformed_audit.findings
+            if finding.rule == "malformed-event"
+            and "tree field id=" in finding.msg
+        ]
+        if len(numeric_failures) != 1:
+            raise AssertionError("audit integer validator accepted an overlong tree id")
+
+    print("PASS: wire/ribbon trees share topology and emit structural audit data")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tex/tenkz/examples/cd-pentagon.tex
+++ b/tex/tenkz/examples/cd-pentagon.tex
@@ -1,19 +1,30 @@
 \documentclass[varwidth=20cm, border=6pt]{standalone}
 \usepackage{amsmath, amssymb}
 \usepackage{tenkz}
+% Multiplicity-free specialization of Eq. (33) of arXiv:1511.08090:
+% sum_u [F^{abc}_y]_{xu}[F^{aud}_e]_{yw}[F^{bcd}_w]_{uv}
+%   = [F^{xcd}_e]_{yv}[F^{abv}_e]_{xw}.
+% After fusion bases are chosen, each polygon vertex below is one
+% parenthesized fusion-basis morphism, with multiplicity labels suppressed;
+% each polygon edge is the corresponding F-move.  The parameter changes
+% only the ink: both pentagons parse these same five tree words.
+\newcommand{\Pentagon}[1]{%
+  \begin{tenkzcd}[polygon=5, radius=34mm]
+    \tntree[tree style=#1]{(((a\,b)_x\,c)_y\,d)_e} &
+    \tntree[tree style=#1]{((a\,(b\,c)_u)_y\,d)_e} &
+    \tntree[tree style=#1]{(a\,((b\,c)_u\,d)_w)_e} &
+    \tntree[tree style=#1]{(a\,(b\,(c\,d)_v)_w)_e} &
+    \tntree[tree style=#1]{((a\,b)_x\,(c\,d)_v)_e}
+    \tnarrow[from=1, to=2]{F^{abc}_y}
+    \tnarrow[from=2, to=3]{F^{aud}_e}
+    \tnarrow[from=3, to=4]{F^{bcd}_w}
+    \tnarrow*[from=1, to=5]{F^{xcd}_e}
+    \tnarrow*[from=5, to=4]{F^{abv}_e}
+  \end{tenkzcd}}
 \begin{document}
-Tree: \tntree{(((a\,b)_x\,c)_y\,d)_e}
+\Pentagon{wire}
 
-\begin{tenkzcd}[polygon=5, radius=34mm]
-  \tntree{(((a\,b)_x\,c)_y\,d)_e} &
-  \tntree{((a\,(b\,c)_u)_y\,d)_e} &
-  \tntree{(a\,((b\,c)_u\,d)_w)_e} &
-  \tntree{(a\,(b\,(c\,d)_v)_w)_e} &
-  \tntree{((a\,b)_x\,(c\,d)_v)_e}
-  \tnarrow[from=1, to=2]{F^{abc}_y}
-  \tnarrow[from=2, to=3]{F^{a,bc,d}_e}
-  \tnarrow[from=3, to=4]{F^{bcd}_w}
-  \tnarrow*[from=1, to=5]{F^{ab,c,d}_e}
-  \tnarrow*[from=5, to=4]{F^{a,b,cd}_e}
-\end{tenkzcd}
+\medskip
+
+\Pentagon{ribbon}
 \end{document}

--- a/tex/tenkz/examples/gallery.tex
+++ b/tex/tenkz/examples/gallery.tex
@@ -4,6 +4,27 @@
 \usepackage{amsmath, amssymb}
 \usepackage{tenkz}
 \newcommand{\head}[1]{\par\medskip\noindent\textbf{#1}\par\smallskip}
+% Multiplicity-free specialization of Eq. (33) of arXiv:1511.08090:
+% sum_u [F^{abc}_y]_{xu}[F^{aud}_e]_{yw}[F^{bcd}_w]_{uv}
+%   = [F^{xcd}_e]_{yv}[F^{abv}_e]_{xw}.
+% After choosing fusion bases, the five parenthesized words are its five
+% fusion-basis morphisms, with multiplicity labels suppressed, and the
+% arrows are its F-moves; #1 selects only how each already-parsed tree is
+% drawn.  In the wire skin a simple object is a line; in the ribbon skin
+% it is a band and each fusion vertex has a nonsingular vertex patch.
+\newcommand{\gallerypentagon}[1]{%
+  \begin{tenkzcd}[polygon=5, radius=34mm]
+    \tntree[tree style=#1]{(((a\,b)_x\,c)_y\,d)_e} &
+    \tntree[tree style=#1]{((a\,(b\,c)_u)_y\,d)_e} &
+    \tntree[tree style=#1]{(a\,((b\,c)_u\,d)_w)_e} &
+    \tntree[tree style=#1]{(a\,(b\,(c\,d)_v)_w)_e} &
+    \tntree[tree style=#1]{((a\,b)_x\,(c\,d)_v)_e}
+    \tnarrow[from=1, to=2]{F^{abc}_y}
+    \tnarrow[from=2, to=3]{F^{aud}_e}
+    \tnarrow[from=3, to=4]{F^{bcd}_w}
+    \tnarrow*[from=1, to=5]{F^{xcd}_e}
+    \tnarrow*[from=5, to=4]{F^{abv}_e}
+  \end{tenkzcd}}
 \begin{document}
 
 \head{B1 — periodic MPS word}
@@ -53,19 +74,11 @@
   \end{tenkz}
 \]
 
-\head{B5 — fusion-tree pentagon (tenkzcd, polygon mode)}
-\begin{tenkzcd}[polygon=5, radius=34mm]
-  \tntree{(((a\,b)_x\,c)_y\,d)_e} &
-  \tntree{((a\,(b\,c)_u)_y\,d)_e} &
-  \tntree{(a\,((b\,c)_u\,d)_w)_e} &
-  \tntree{(a\,(b\,(c\,d)_v)_w)_e} &
-  \tntree{((a\,b)_x\,(c\,d)_v)_e}
-  \tnarrow[from=1, to=2]{F^{abc}_y}
-  \tnarrow[from=2, to=3]{F^{a,bc,d}_e}
-  \tnarrow[from=3, to=4]{F^{bcd}_w}
-  \tnarrow*[from=1, to=5]{F^{ab,c,d}_e}
-  \tnarrow*[from=5, to=4]{F^{a,b,cd}_e}
-\end{tenkzcd}
+\head{B5 — fusion-tree pentagon, wire skin (tenkzcd, polygon mode)}
+\gallerypentagon{wire}
+
+\head{B5r — the same fusion-tree pentagon, ribbon skin}
+\gallerypentagon{ribbon}
 
 \head{B6 — PEPS window with regions (tenkzlattice)}
 \begin{tenkzlattice}[rows=4, cols=4, boundary legs]

--- a/tex/tenkz/examples/tree-ribbon.tex
+++ b/tex/tenkz/examples/tree-ribbon.tex
@@ -1,0 +1,19 @@
+\documentclass[varwidth=16cm, border=6pt]{standalone}
+\usepackage{amsmath, amssymb}
+\usepackage{tenkz}
+\begin{document}
+% In the multiplicity-free case, both pictures are the chosen fusion
+% morphism m_{ab}^{x}:a\otimes b\to x, where N_{ab}^{x}>0.
+% The wire skin draws its three incident simple objects as lines meeting at
+% one trivalent vertex.  The ribbon skin draws the same parsed tree as a
+% regular ribbon neighbourhood, with one labelled band for each simple
+% object and a nonsingular vertex patch joining the three bands.
+\tnset{species={anyon}}
+\[
+  \tntree[tree style=wire, species=anyon]{(a\,b)_x}
+  \qquad
+  \tntree[tree style=ribbon, species=anyon]{(a\,b)_x}
+  \qquad
+  \tntree[tree style=ribbon, role=marked]{(a\,b)_x}
+\]
+\end{document}

--- a/tex/tenkz/tenkz-cd.code.tex
+++ b/tex/tenkz/tenkz-cd.code.tex
@@ -30,6 +30,21 @@
 % rooted, not as one more leaf.
 \def\tenkz@r@treestep{0.55}
 \def\tenkz@r@treeleg{0.35}
+% One ribbon is a band, not a fused wire: 0.13 pitch gives its two
+% wire-weight boundary curves visible daylight at compact scale.  The
+% vertex-patch reach exceeds the half-width so its three sector arcs
+% remain distinct at the most acute junctions in a four-leaf tree; 0.72
+% measures how far each cubic control travels from its mouth toward the
+% vertex, leaving a rounded nonzero waist between the three sectors.
+\def\tenkz@r@treeribbonhalf{0.065}
+\def\tenkz@r@treepatchreach{0.16}
+\def\tenkz@r@treepatchcontrol{0.72}
+% TikZ's rotated calc-coordinate delimiter must have the ordinary colon
+% catcode, so keep this tiny coordinate primitive outside expl3 syntax.
+\ExplSyntaxOff
+\def\tenkz@ribbonoffset#1#2#3#4#5{%
+  \coordinate (#1) at ($(#2)!#4!#5:(#3)$);}
+\ExplSyntaxOn
 % Typed-map rows are mathematical objects joined by named maps.  One
 % third-pitch column air keeps adjacent object names distinct without
 % turning a short composition into a display-width commutative diagram;
@@ -39,7 +54,10 @@
 
 % ---------- state ----------
 \seq_new:N \l__tenkzcd_items_seq     % parenthesization word, one item each
-\seq_new:N \l__tenkzcd_stack_seq     % parsed subtrees: {x}{level}{charge}
+\seq_new:N \l__tenkzcd_stack_seq     % {x}{level}{charge}{node}{topology}
+\seq_new:N \l__tenkzcd_vertices_seq  % postorder {node}{left}{right}
+\prop_new:N \l__tenkzcd_parent_prop  % node id -> parent node id or root
+\prop_new:N \l__tenkzcd_internal_prop % node id -> marker
 \tl_new:N  \l__tenkzcd_word_tl
 \tl_new:N  \l__tenkzcd_item_tl
 \tl_new:N  \l__tenkzcd_charge_tl
@@ -48,7 +66,24 @@
 \tl_new:N  \l__tenkzcd_cha_tl
 \tl_new:N  \l__tenkzcd_chb_tl
 \tl_new:N  \l__tenkzcd_anchor_tl
+\tl_new:N  \l__tenkzcd_tree_skin_tl
+\tl_new:N  \l__tenkzcd_tree_role_tl
+\tl_new:N  \l__tenkzcd_tree_species_tl
+\tl_new:N  \l__tenkzcd_tree_path_tl
+\tl_new:N  \l__tenkzcd_tree_fill_tl
+\tl_new:N  \l__tenkzcd_tree_junction_tl
+\tl_new:N  \l__tenkzcd_parent_tl
+\tl_new:N  \l__tenkzcd_topoa_tl
+\tl_new:N  \l__tenkzcd_topob_tl
+\tl_new:N  \l__tenkzcd_topop_tl
 \int_new:N \l__tenkzcd_leaf_int
+\int_new:N \l__tenkzcd_node_int
+\int_new:N \l__tenkzcd_nodea_int
+\int_new:N \l__tenkzcd_nodeb_int
+\int_new:N \l__tenkzcd_nodep_int
+% Picture ids cannot distinguish several standalone trees, so tree ids
+% are document-global and also keep every TikZ coordinate name unique.
+\int_new:N \g__tenkzcd_tree_int
 \int_new:N \l__tenkzcd_la_int
 \int_new:N \l__tenkzcd_lb_int
 \int_new:N \l__tenkzcd_lp_int
@@ -113,6 +148,24 @@
           { \exp_not:o \pgfkeyscurrentname =
             \exp_not:o \pgfkeyscurrentvalue , } }
   },
+}
+\pgfkeys{
+  /tenkz/tree/.is~family,
+  /tenkz/tree/tree~style/.is~choice,
+  /tenkz/tree/tree~style/wire/.code={\tl_set:Nn \l__tenkzcd_tree_skin_tl {wire}},
+  /tenkz/tree/tree~style/ribbon/.code={\tl_set:Nn \l__tenkzcd_tree_skin_tl {ribbon}},
+  /tenkz/tree/role/.is~choice,
+  /tenkz/tree/role/operator/.code={\tl_set:Nn \l__tenkzcd_tree_role_tl {operator}},
+  /tenkz/tree/role/marked/.code={\tl_set:Nn \l__tenkzcd_tree_role_tl {marked}},
+  /tenkz/tree/role/extra/.code={\tl_set:Nn \l__tenkzcd_tree_role_tl {extra}},
+  /tenkz/tree/role/passive/.code={\tl_set:Nn \l__tenkzcd_tree_role_tl {passive}},
+  /tenkz/tree/species/.code={
+    \tenkz_species_check:n {#1}
+    \tl_set:Nn \l__tenkzcd_tree_species_tl {#1}
+  },
+  /tenkz/tree/pitch/.code={\pgfqkeys{/tenkz}{pitch=#1}},
+  /tenkz/tree/compact/.code={\pgfqkeys{/tenkz}{compact}},
+  /tenkz/tree/inline/.code={\pgfqkeys{/tenkz}{inline}},
 }
 \pgfkeys{
   /tenkz/arrow/.is~family,
@@ -191,11 +244,18 @@
     \dim_set:Nn \l__tenkzcd_xa_dim
       { \tenkz@r@treestep\tenkz@pitch * \l__tenkzcd_leaf_int }
     \int_incr:N \l__tenkzcd_leaf_int
+    \int_incr:N \l__tenkzcd_node_int
+    \coordinate
+      (tenkztree-\int_use:N\g__tenkzcd_tree_int-
+       \int_use:N\l__tenkzcd_node_int) at
+      (\dim_use:N \l__tenkzcd_xa_dim, 0pt);
     \node[tn~label, anchor=south] at
       (\dim_use:N \l__tenkzcd_xa_dim, \tenkz@dim{\tenkz@r@labelclear})
       { $\tenkz@labelsize \tl_use:N \l__tenkzcd_item_tl$ };
     \seq_put_right:Ne \l__tenkzcd_stack_seq
-      { { \dim_use:N \l__tenkzcd_xa_dim }{ 0 }{ } }
+      { { \dim_use:N \l__tenkzcd_xa_dim }{ 0 }{ }
+        { \int_use:N \l__tenkzcd_node_int }
+        { \int_use:N \l__tenkzcd_leaf_int } }
   }
 
 % ( node node ) [_ charge]
@@ -228,56 +288,71 @@
     % pop the two children and fuse them
     \seq_pop_right:NN \l__tenkzcd_stack_seq \l__tenkzcd_cb_tl
     \seq_pop_right:NN \l__tenkzcd_stack_seq \l__tenkzcd_ca_tl
-    \exp_last_unbraced:NV \tenkz_cd_unpack_a:nnn \l__tenkzcd_ca_tl
-    \exp_last_unbraced:NV \tenkz_cd_unpack_b:nnn \l__tenkzcd_cb_tl
+    \exp_last_unbraced:NV \tenkz_cd_unpack_a:nnnnn \l__tenkzcd_ca_tl
+    \exp_last_unbraced:NV \tenkz_cd_unpack_b:nnnnn \l__tenkzcd_cb_tl
     \tenkz_cd_tree_fuse:
   }
 
-\cs_new_protected:Npn \tenkz_cd_unpack_a:nnn #1#2#3
+\cs_new_protected:Npn \tenkz_cd_unpack_a:nnnnn #1#2#3#4#5
   {
     \dim_set:Nn \l__tenkzcd_xa_dim {#1}
     \int_set:Nn \l__tenkzcd_la_int {#2}
     \tl_set:Nn  \l__tenkzcd_cha_tl {#3}
+    \int_set:Nn \l__tenkzcd_nodea_int {#4}
+    \tl_set:Nn \l__tenkzcd_topoa_tl {#5}
   }
-\cs_new_protected:Npn \tenkz_cd_unpack_b:nnn #1#2#3
+\cs_new_protected:Npn \tenkz_cd_unpack_b:nnnnn #1#2#3#4#5
   {
     \dim_set:Nn \l__tenkzcd_xb_dim {#1}
     \int_set:Nn \l__tenkzcd_lb_int {#2}
     \tl_set:Nn  \l__tenkzcd_chb_tl {#3}
+    \int_set:Nn \l__tenkzcd_nodeb_int {#4}
+    \tl_set:Nn \l__tenkzcd_topob_tl {#5}
   }
 
-% one child edge: from (x register #1, level #2) up to the shared junction
-% at (xp, lp), which the caller has already set
-\cs_new_protected:Npn \tenkz_cd_childedge:Nn #1#2
-  {
-    \draw[bond]
-      (\dim_use:N #1, \tenkz_cd_levely:n {#2}) --
-      (\dim_use:N \l__tenkzcd_xp_dim, \tenkz_cd_levely:n {\l__tenkzcd_lp_int});
-  }
-
-% join the two children on the stack: edges, junction dot, the
-% children's charges (their downward edges are now known), push the
-% joint carrying this vertex's own charge
+% Join the two children on the stack.  Parsing records one abstract
+% trivalent vertex; the selected skin draws that same record only after
+% the full word has been parsed, when the third (parent) direction is
+% known.  This separation is what lets the ribbon skin draw a regular
+% ribbon neighbourhood instead of guessing a vertical output at
+% every vertex.
 \cs_new_protected:Npn \tenkz_cd_tree_fuse:
   {
     \int_set:Nn \l__tenkzcd_lp_int
       { 1 + \int_max:nn { \l__tenkzcd_la_int } { \l__tenkzcd_lb_int } }
     \dim_set:Nn \l__tenkzcd_xp_dim
       { ( \l__tenkzcd_xa_dim + \l__tenkzcd_xb_dim ) / 2 }
-    \tenkz_cd_childedge:Nn \l__tenkzcd_xa_dim {\l__tenkzcd_la_int}
-    \tenkz_cd_childedge:Nn \l__tenkzcd_xb_dim {\l__tenkzcd_lb_int}
-    \node[tree~junction] at
+    \int_incr:N \l__tenkzcd_node_int
+    \int_set_eq:NN \l__tenkzcd_nodep_int \l__tenkzcd_node_int
+    \coordinate
+      (tenkztree-\int_use:N\g__tenkzcd_tree_int-
+       \int_use:N\l__tenkzcd_nodep_int) at
       (\dim_use:N \l__tenkzcd_xp_dim,
-       \tenkz_cd_levely:n {\l__tenkzcd_lp_int}) {};
+       \tenkz_cd_levely:n {\l__tenkzcd_lp_int});
+    \prop_put:Nee \l__tenkzcd_parent_prop
+      { \int_use:N \l__tenkzcd_nodea_int }
+      { \int_use:N \l__tenkzcd_nodep_int }
+    \prop_put:Nee \l__tenkzcd_parent_prop
+      { \int_use:N \l__tenkzcd_nodeb_int }
+      { \int_use:N \l__tenkzcd_nodep_int }
+    \prop_put:Nee \l__tenkzcd_internal_prop
+      { \int_use:N \l__tenkzcd_nodep_int } {1}
     \tl_if_blank:VF \l__tenkzcd_cha_tl
       { \tenkz_cd_edge_charge:NnN \l__tenkzcd_xa_dim
           {\l__tenkzcd_la_int} \l__tenkzcd_cha_tl }
     \tl_if_blank:VF \l__tenkzcd_chb_tl
       { \tenkz_cd_edge_charge:NnN \l__tenkzcd_xb_dim
           {\l__tenkzcd_lb_int} \l__tenkzcd_chb_tl }
+    \seq_put_right:Ne \l__tenkzcd_vertices_seq
+      { { \int_use:N \l__tenkzcd_nodep_int }
+        { \int_use:N \l__tenkzcd_nodea_int }
+        { \int_use:N \l__tenkzcd_nodeb_int } }
     \seq_put_right:Ne \l__tenkzcd_stack_seq
       { { \dim_use:N \l__tenkzcd_xp_dim }{ \int_use:N \l__tenkzcd_lp_int }
-        { \exp_not:V \l__tenkzcd_charge_tl } }
+        { \exp_not:V \l__tenkzcd_charge_tl }
+        { \int_use:N \l__tenkzcd_nodep_int }
+        { (\exp_not:V\l__tenkzcd_topoa_tl,
+           \exp_not:V\l__tenkzcd_topob_tl) } }
   }
 
 % A charge labels its vertex's downward edge, half a fusion level below
@@ -303,14 +378,207 @@
       { $\tenkz@labelsize \tl_use:N #3$ };
   }
 
-% the root: a short downward leg; the total charge sits right of the
-% leg's midpoint
-\cs_new_protected:Npn \tenkz_cd_tree_root:nnn #1#2#3
+% Resolve the semantic ink once per tree.  Species is the first
+% indirection and role wins, matching every other tenkz element.
+\cs_new_protected:Npn \tenkz_cd_tree_resolve_style:
   {
-    \draw[bond]
-      (#1, \tenkz_cd_levely:n {#2}) --
+    \tl_set:Nn \l__tenkzcd_tree_path_tl {bond}
+    \tl_set:Nn \l__tenkzcd_tree_fill_tl {tree~ribbon~fill}
+    \tl_set:Nn \l__tenkzcd_tree_junction_tl {tree~junction}
+    \tl_if_blank:VF \l__tenkzcd_tree_species_tl
+      {
+        \tl_set:Ne \l__tenkzcd_tree_path_tl
+          {species~\tl_use:N\l__tenkzcd_tree_species_tl\c_space_tl bond}
+        \tl_set:Ne \l__tenkzcd_tree_fill_tl
+          {species~\tl_use:N\l__tenkzcd_tree_species_tl\c_space_tl ribbon~fill}
+        \tl_set:Ne \l__tenkzcd_tree_junction_tl
+          {species~\tl_use:N\l__tenkzcd_tree_species_tl
+            \c_space_tl tree~junction}
+      }
+    \tl_if_blank:VF \l__tenkzcd_tree_role_tl
+      {
+        \tl_set:Ne \l__tenkzcd_tree_path_tl
+          {\tl_use:N\l__tenkzcd_tree_role_tl\c_space_tl bond}
+        \tl_set:Ne \l__tenkzcd_tree_fill_tl
+          {\tl_use:N\l__tenkzcd_tree_role_tl\c_space_tl ribbon~fill}
+        \tl_set:Ne \l__tenkzcd_tree_junction_tl
+          {\tl_use:N\l__tenkzcd_tree_role_tl\c_space_tl tree~junction}
+      }
+    \str_if_eq:VnT \l__tenkzcd_tree_skin_tl {ribbon}
+      {
+        \tl_if_blank:VTF \l__tenkzcd_tree_role_tl
+          {
+            \tl_if_blank:VTF \l__tenkzcd_tree_species_tl
+              { \tl_set:Nn \l__tenkzcd_tree_path_tl {tree~ribbon} }
+              { \tl_set:Ne \l__tenkzcd_tree_path_tl
+                  {species~\tl_use:N\l__tenkzcd_tree_species_tl
+                    \c_space_tl ribbon} }
+          }
+          { \tl_set:Ne \l__tenkzcd_tree_path_tl
+              {\tl_use:N\l__tenkzcd_tree_role_tl\c_space_tl ribbon} }
+      }
+  }
+
+\cs_new:Npn \tenkz_cd_tree_name:n #1
+  { tenkztree-\int_use:N\g__tenkzcd_tree_int-#1 }
+
+\cs_new_protected:Npn \tenkz_cd_wire_vertex:nnn #1#2#3
+  {
+    \draw[\l__tenkzcd_tree_path_tl]
+      (\tenkz_cd_tree_name:n {#2}) -- (\tenkz_cd_tree_name:n {#1});
+    \draw[\l__tenkzcd_tree_path_tl]
+      (\tenkz_cd_tree_name:n {#3}) -- (\tenkz_cd_tree_name:n {#1});
+    \node[\l__tenkzcd_tree_junction_tl] at
+      (\tenkz_cd_tree_name:n {#1}) {};
+  }
+
+% One band owns the filled strip and its two boundaries between leaf/root
+% endpoints or vertex-patch mouths.  It is deliberately not TikZ's
+% `double' stroke: the two curves bound a surface, while the disjoint
+% vertex patch owns all ink inside each trivalent neighbourhood.
+\cs_new_protected:Npn \tenkz_cd_ribbon_band:nn #1#2
+  {
+    % Each internal endpoint is trimmed to its patch mouth.  The patch,
+    % not a center-to-center contour hidden underneath it, owns every
+    % junction.  Leaves and the root remain untrimmed.
+    \coordinate (tenkzearaw) at (\tenkz_cd_tree_name:n {#1});
+    \coordinate (tenkzebraw) at (\tenkz_cd_tree_name:n {#2});
+    \prop_if_in:NnTF \l__tenkzcd_internal_prop {#1}
+      { \coordinate (tenkzea) at
+          ($(tenkzearaw)!\tenkz@r@treepatchreach\tenkz@pitch!
+            (tenkzebraw)$); }
+      { \coordinate (tenkzea) at (tenkzearaw); }
+    \prop_if_in:NnTF \l__tenkzcd_internal_prop {#2}
+      { \coordinate (tenkzeb) at
+          ($(tenkzebraw)!\tenkz@r@treepatchreach\tenkz@pitch!
+            (tenkzearaw)$); }
+      { \coordinate (tenkzeb) at (tenkzebraw); }
+    \draw[\l__tenkzcd_tree_fill_tl, line~cap=butt,
+      line~width=\dim_eval:n {2\tenkz@dim{\tenkz@r@treeribbonhalf}}]
+      (tenkzea) -- (tenkzeb);
+    % Calc's rotated-coordinate scanner is deliberately fed plain names;
+    % expl3 function tokens inside the rotated target are not scan-safe.
+    \tenkz@ribbonoffset{tenkzeaL}{tenkzea}{tenkzeb}
+      {\tenkz@r@treeribbonhalf\tenkz@pitch}{90}
+    \tenkz@ribbonoffset{tenkzeaR}{tenkzea}{tenkzeb}
+      {\tenkz@r@treeribbonhalf\tenkz@pitch}{-90}
+    \tenkz@ribbonoffset{tenkzebL}{tenkzeb}{tenkzea}
+      {\tenkz@r@treeribbonhalf\tenkz@pitch}{90}
+    \tenkz@ribbonoffset{tenkzebR}{tenkzeb}{tenkzea}
+      {\tenkz@r@treeribbonhalf\tenkz@pitch}{-90}
+    \draw[\l__tenkzcd_tree_path_tl]
+      (tenkzeaL) -- (tenkzebR);
+    \draw[\l__tenkzcd_tree_path_tl]
+      (tenkzeaR) -- (tenkzebL);
+  }
+\cs_new_protected:Npn \tenkz_cd_ribbon_vertex_bands:nnn #1#2#3
+  {
+    \tenkz_cd_ribbon_band:nn {#1}{#2}
+    \tenkz_cd_ribbon_band:nn {#1}{#3}
+  }
+
+% The central patch is the regular ribbon neighbourhood of a trivalent
+% vertex: a disc with three attached bands.  Each sector arc has two
+% distinct controls, so the patch retains a nonzero waist and its boundary
+% never pinches or crosses.  No tensor bead or fused-bond glyph is inserted.
+\cs_new_protected:Npn \tenkz_cd_ribbon_patch:nnnn #1#2#3#4
+  {
+    \coordinate (tenkzvc) at (\tenkz_cd_tree_name:n {#1});
+    \coordinate (tenkzva) at (\tenkz_cd_tree_name:n {#2});
+    \coordinate (tenkzvb) at (\tenkz_cd_tree_name:n {#3});
+    \coordinate (tenkzvp) at (#4);
+    \coordinate (tenkzpa) at
+      ($(tenkzvc)!\tenkz@r@treepatchreach\tenkz@pitch!(tenkzva)$);
+    \coordinate (tenkzpb) at
+      ($(tenkzvc)!\tenkz@r@treepatchreach\tenkz@pitch!(tenkzvb)$);
+    \coordinate (tenkzpp) at
+      ($(tenkzvc)!\tenkz@r@treepatchreach\tenkz@pitch!(tenkzvp)$);
+    \tenkz@ribbonoffset{tenkzpaL}{tenkzpa}{tenkzva}
+      {\tenkz@r@treeribbonhalf\tenkz@pitch}{90}
+    \tenkz@ribbonoffset{tenkzpaR}{tenkzpa}{tenkzva}
+      {\tenkz@r@treeribbonhalf\tenkz@pitch}{-90}
+    \tenkz@ribbonoffset{tenkzpbL}{tenkzpb}{tenkzvb}
+      {\tenkz@r@treeribbonhalf\tenkz@pitch}{90}
+    \tenkz@ribbonoffset{tenkzpbR}{tenkzpb}{tenkzvb}
+      {\tenkz@r@treeribbonhalf\tenkz@pitch}{-90}
+    \tenkz@ribbonoffset{tenkzppL}{tenkzpp}{tenkzvp}
+      {\tenkz@r@treeribbonhalf\tenkz@pitch}{90}
+    \tenkz@ribbonoffset{tenkzppR}{tenkzpp}{tenkzvp}
+      {\tenkz@r@treeribbonhalf\tenkz@pitch}{-90}
+    \path[\l__tenkzcd_tree_fill_tl, draw=none]
+      (tenkzpbL)
+        .. controls ($(tenkzpbL)!\tenkz@r@treepatchcontrol!(tenkzvc)$)
+        and ($(tenkzpaR)!\tenkz@r@treepatchcontrol!(tenkzvc)$)
+        .. (tenkzpaR) --
+      (tenkzpaL)
+        .. controls ($(tenkzpaL)!\tenkz@r@treepatchcontrol!(tenkzvc)$)
+        and ($(tenkzppR)!\tenkz@r@treepatchcontrol!(tenkzvc)$)
+        .. (tenkzppR) --
+      (tenkzppL)
+        .. controls ($(tenkzppL)!\tenkz@r@treepatchcontrol!(tenkzvc)$)
+        and ($(tenkzpbR)!\tenkz@r@treepatchcontrol!(tenkzvc)$)
+        .. (tenkzpbR) -- cycle;
+    \draw[\l__tenkzcd_tree_path_tl]
+      (tenkzpbL)
+        .. controls ($(tenkzpbL)!\tenkz@r@treepatchcontrol!(tenkzvc)$)
+        and ($(tenkzpaR)!\tenkz@r@treepatchcontrol!(tenkzvc)$)
+        .. (tenkzpaR);
+    \draw[\l__tenkzcd_tree_path_tl]
+      (tenkzpaL)
+        .. controls ($(tenkzpaL)!\tenkz@r@treepatchcontrol!(tenkzvc)$)
+        and ($(tenkzppR)!\tenkz@r@treepatchcontrol!(tenkzvc)$)
+        .. (tenkzppR);
+    \draw[\l__tenkzcd_tree_path_tl]
+      (tenkzppL)
+        .. controls ($(tenkzppL)!\tenkz@r@treepatchcontrol!(tenkzvc)$)
+        and ($(tenkzpbR)!\tenkz@r@treepatchcontrol!(tenkzvc)$)
+        .. (tenkzpbR);
+  }
+
+\cs_new_protected:Npn \tenkz_cd_ribbon_vertex_patch:nnn #1#2#3
+  {
+    \prop_get:NnNTF \l__tenkzcd_parent_prop {#1} \l__tenkzcd_parent_tl
+      {
+        \str_if_eq:VnTF \l__tenkzcd_parent_tl {root}
+          { \tenkz_cd_ribbon_patch:nnnn {#1}{#2}{#3}
+              {tenkztree-\int_use:N\g__tenkzcd_tree_int-root} }
+          { \tenkz_cd_ribbon_patch:nnnn {#1}{#2}{#3}
+              {\tenkz_cd_tree_name:n {\l__tenkzcd_parent_tl}} }
+      }
+      { \PackageError{tenkz}{Internal~tree~vertex~#1~has~no~parent}{} }
+  }
+
+\cs_new_protected:Npn \tenkz_cd_tree_geometry:n #1
+  {
+    \begin{pgfonlayer}{background}
+      \str_if_eq:VnTF \l__tenkzcd_tree_skin_tl {wire}
+        {
+          \seq_map_inline:Nn \l__tenkzcd_vertices_seq
+            { \tenkz_cd_wire_vertex:nnn ##1 }
+          \draw[\l__tenkzcd_tree_path_tl]
+            (\tenkz_cd_tree_name:n {#1}) --
+            (tenkztree-\int_use:N\g__tenkzcd_tree_int-root);
+        }
+        {
+          \seq_map_inline:Nn \l__tenkzcd_vertices_seq
+            { \tenkz_cd_ribbon_vertex_bands:nnn ##1 }
+          \tenkz_cd_ribbon_band:nn {#1}{root}
+          \seq_map_inline:Nn \l__tenkzcd_vertices_seq
+            { \tenkz_cd_ribbon_vertex_patch:nnn ##1 }
+        }
+    \end{pgfonlayer}
+  }
+
+% The root creates the third direction of its vertex, renders the selected
+% skin from the recorded topology, and finally places the total charge.
+\cs_new_protected:Npn \tenkz_cd_tree_root:nnnnn #1#2#3#4#5
+  {
+    \tl_set:Nn \l__tenkzcd_topop_tl {#5}
+    \coordinate (tenkztree-\int_use:N\g__tenkzcd_tree_int-root) at
       (#1, \dim_eval:n{ \tenkz_cd_levely:n {#2}
                         - \tenkz@r@treeleg\tenkz@pitch });
+    \prop_put:Nnn \l__tenkzcd_parent_prop {#4} {root}
+    \tenkz_cd_tree_geometry:n {#4}
     \tl_if_blank:nF {#3}
       {
         \node[tn~label, anchor=west] at
@@ -327,7 +595,12 @@
 \cs_new_protected:Npn \tenkz_cd_tree:nn #1#2
   {
     \group_begin:
-    \tl_if_empty:nF {#1} { \pgfqkeys{/tenkz}{#1} }
+    \tl_set:Nn \l__tenkzcd_tree_skin_tl {wire}
+    \tl_clear:N \l__tenkzcd_tree_role_tl
+    \tl_clear:N \l__tenkzcd_tree_species_tl
+    \tl_if_empty:nF {#1} { \pgfqkeys{/tenkz/tree}{#1} }
+    \tenkz_cd_tree_resolve_style:
+    \int_gincr:N \g__tenkzcd_tree_int
     % \, and spaces are separators, not syntax; flatten to items
     % (spaces never form items, so only \, needs stripping)
     \tl_set:Nn \l__tenkzcd_word_tl {#2}
@@ -336,7 +609,11 @@
     \tl_map_inline:Nn \l__tenkzcd_word_tl
       { \seq_put_right:Nn \l__tenkzcd_items_seq {##1} }
     \seq_clear:N \l__tenkzcd_stack_seq
+    \seq_clear:N \l__tenkzcd_vertices_seq
+    \prop_clear:N \l__tenkzcd_parent_prop
+    \prop_clear:N \l__tenkzcd_internal_prop
     \int_zero:N \l__tenkzcd_leaf_int
+    \int_zero:N \l__tenkzcd_node_int
     \tenkz_cd_read_axis:
     \begin{tikzpicture}[ tenkz~every~picture, tenkz~cd~baseline ]
       \tenkz_cd_tree_node:
@@ -347,9 +624,19 @@
         { \PackageError{tenkz}{Malformed~tree:~trailing~material~after~
             the~root~--~a~word~denotes~exactly~one~tree}{} }
       \seq_pop_right:NNT \l__tenkzcd_stack_seq \l__tenkzcd_ca_tl
-        { \exp_last_unbraced:NV \tenkz_cd_tree_root:nnn \l__tenkzcd_ca_tl }
-      % inside the picture group, where the leaf count is still live
-      \tenkz@event{tree|picture=\the\tenkz@pictureid|leaves=\int_use:N \l__tenkzcd_leaf_int}
+        { \exp_last_unbraced:NV \tenkz_cd_tree_root:nnnnn \l__tenkzcd_ca_tl }
+      % The canonical numeric bracketing reconstructs the rooted binary
+      % tree without writing arbitrary TeX labels into structural fields.
+      \tenkz@event{tree|picture=\the\tenkz@pictureid|
+        id=\int_use:N\g__tenkzcd_tree_int|
+        style=\tl_use:N\l__tenkzcd_tree_skin_tl|
+        leaves=\int_use:N\l__tenkzcd_leaf_int|
+        vertices=\int_eval:n{\seq_count:N\l__tenkzcd_vertices_seq}|
+        topology=\tl_use:N\l__tenkzcd_topop_tl|
+        role=\tl_if_blank:VTF\l__tenkzcd_tree_role_tl{none}
+          {\tl_use:N\l__tenkzcd_tree_role_tl}|
+        species=\tl_if_blank:VTF\l__tenkzcd_tree_species_tl{none}
+          {\tl_use:N\l__tenkzcd_tree_species_tl}}
     \end{tikzpicture}
     \group_end:
   }

--- a/tex/tenkz/tenkz-core.code.tex
+++ b/tex/tenkz/tenkz-core.code.tex
@@ -206,6 +206,12 @@
       line width=\tenkz@dim{\tenkz@r@fusionwidth}},
   tree junction/.style={draw=tenkzInk, fill=tenkzInk, circle, inner sep=0pt,
       minimum size=\tenkz@junctionfloor},
+  % A ribbon tree is a filled surface with two boundary curves, not a
+  % doubled wire.  The cd renderer draws the strip fills and their two
+  % boundaries separately, then joins three strips through a nonsingular
+  % vertex patch.  This style supplies only the semantic boundary/fill colours.
+  tree ribbon/.style={draw=tenkzInk, line width=\tenkz@wirewidth},
+  tree ribbon fill/.style={draw=tenkzPaper, fill=tenkzPaper},
   % wires
   bond/.style={draw=tenkzInk, line width=\tenkz@wirewidth},
   tenkz combined stub/.style={},
@@ -224,10 +230,30 @@
   marked bond/.style={bond, draw=tenkzMarked},
   extra bond/.style={bond, draw=tenkzExtra},
   passive bond/.style={bond, draw=tenkzPassive},
+  operator ribbon/.style={tree ribbon, draw=tenkzOperator,
+      fill=tenkzOperator!12!tenkzPaper},
+  operator ribbon fill/.style={draw=tenkzOperator!12!tenkzPaper,
+      fill=tenkzOperator!12!tenkzPaper},
+  marked ribbon/.style={tree ribbon, draw=tenkzMarked,
+      fill=tenkzMarked!12!tenkzPaper},
+  marked ribbon fill/.style={draw=tenkzMarked!12!tenkzPaper,
+      fill=tenkzMarked!12!tenkzPaper},
+  extra ribbon/.style={tree ribbon, draw=tenkzExtra,
+      fill=tenkzExtra!12!tenkzPaper},
+  extra ribbon fill/.style={draw=tenkzExtra!12!tenkzPaper,
+      fill=tenkzExtra!12!tenkzPaper},
+  passive ribbon/.style={tree ribbon, draw=tenkzPassive,
+      fill=tenkzPassive!12!tenkzPaper},
+  passive ribbon fill/.style={draw=tenkzPassive!12!tenkzPaper,
+      fill=tenkzPassive!12!tenkzPaper},
   operator tensor/.style={draw=tenkzOperator, fill=tenkzOperator},
   marked tensor/.style={draw=tenkzMarked, fill=tenkzMarked},
   extra tensor/.style={draw=tenkzExtra, fill=tenkzExtra},
   passive tensor/.style={draw=tenkzPassive, fill=tenkzPassive},
+  operator tree junction/.style={tree junction, operator tensor},
+  marked tree junction/.style={tree junction, marked tensor},
+  extra tree junction/.style={tree junction, extra tensor},
+  passive tree junction/.style={tree junction, passive tensor},
   operator outline/.style={draw=tenkzOperator, text=tenkzOperator},
   marked outline/.style={draw=tenkzMarked, text=tenkzMarked},
   extra outline/.style={draw=tenkzExtra, text=tenkzExtra},
@@ -367,7 +393,14 @@
       {
         species~#1~bond/.style={bond, draw=\l_tmpb_tl},
         species~#1~tensor/.style={draw=\l_tmpb_tl, fill=\l_tmpb_tl},
-        species~#1~outline/.style={draw=\l_tmpb_tl, text=\l_tmpb_tl}
+        species~#1~tree~junction/.style={tree~junction,
+          species~#1~tensor},
+        species~#1~outline/.style={draw=\l_tmpb_tl, text=\l_tmpb_tl},
+        species~#1~ribbon/.style={tree~ribbon, draw=\l_tmpb_tl,
+          fill=\l_tmpb_tl!12!tenkzPaper},
+        species~#1~ribbon~fill/.style={
+          draw=\l_tmpb_tl!12!tenkzPaper,
+          fill=\l_tmpb_tl!12!tenkzPaper}
       }
     \exp_args:NV \tikzset \l_tmpa_tl
   }


### PR DESCRIPTION
## Summary

- extend `\tntree` with `tree style=wire|ribbon` while retaining one parser and one `tenkzcd` polygon layout
- render the ribbon skin as the regular planar ribbon neighbourhood of the parsed trivalent tree: each edge is a band, and a nonsingular vertex patch owns each junction
- carry semantic `role=` and declared `species=` hues through both skins, with role precedence and wire-weight ribbon boundaries
- emit canonical numeric tree topology, skin, counts, and semantic metadata for audit validation
- render the explicit F-pentagon in both skins in the acceptance example, gallery, and manual; each standalone source locally parameterizes its wire/ribbon pair

## Mathematical and source scope

The ribbon skin is a fat-graph representation of a fusion tree, not a tensor-network brick diagram and not a doubled/fused bond. Its local model is a vertex disc with three attached bands. Band contours stop at vertex-patch mouths, so every junction has one geometric owner and an embedded, nonsingular boundary.

The displayed identity is the multiplicity-free specialization of Eq. (33) of arXiv:1511.08090, after choosing fusion bases and suppressing multiplicity labels:

\[
\sum_u [F^{abc}_y]_{xu}[F^{aud}_e]_{yw}[F^{bcd}_w]_{uv}
= [F^{xcd}_e]_{yv}[F^{abv}_e]_{xw}.
\]

Here `x,u,v,w,y` are intermediate simple channels allowed by the relevant fusion coefficients, not composite labels. Each polygon vertex is the chosen fusion-basis morphism for one parenthesization, and each polygon edge is the corresponding F-move.

The source review also keeps two distinct objects distinct: arXiv:2011.12127 Fig. 3 contains a shaded MPO-fusion surface and does not justify importing a pair-of-pants cobordism into generic `\tntree`. The implementation therefore claims only the regular ribbon neighbourhood of the trivalent tree. No braiding hexagon or new layout engine is introduced.

## Audit contract

Each tree emits one structural event with a document-unique id, `wire|ribbon` skin, leaf and internal-vertex counts, semantic role/species, and canonical numeric bracketing such as `((1,2),(3,4))`. Arbitrary TeX labels and charges stay out of structural fields. The audit rejects malformed, count-inconsistent, overlong-numeric, and excessively deep topology data without crashing.

## Validation

- compiled every `tex/tenkz/examples/*.tex` file with the canonical timeout/XeLaTeX invocation
- compiled `docs/tenkz/manual2.tex` twice with XeLaTeX
- `python3 scripts/test_tenkz_tree.py`
- `python3 scripts/test_tenkz_face_ports.py`
- `python3 scripts/test_tenkz_pic.py`
- full tenkz source lint: 114 files, zero findings
- audited the gallery and manual event streams with no hard errors
- rendered and visually inspected the standalone tree, gallery, and both pentagons; independent 600-dpi review passed all 15 nested ribbon junctions with no seam, crossing, pinch, lens, or sliver
- `git diff --check`
- forbidden-phrase and `issue4152_proto` scope scans

## Simplification gate

The LionSR/TNLean#4158 gate was run over `tenkz-cd.code.tex` and polygon mode. It collapsed separate fill/boundary passes into one band owner, made the vertex patch the sole owner of junction ink, removed shallow pentagon wrappers and unused records, and kept wire/ribbon as two renderers of one parsed topology. No deferred kept-because exception remains for `DESIGN.md`; the detailed three-answer result is recorded on LionSR/tenkz#10.

Closes LionSR/tenkz#24
