### PR TITLE
doc(Channel/FixedPoint): record support completion

### DIFF
--- a/TNLean/Channel/FixedPoint/SupportCompressedDensityBlocks.lean
+++ b/TNLean/Channel/FixedPoint/SupportCompressedDensityBlocks.lean
@@ -165,14 +165,15 @@ is the full-support step in the proof of Wolf, Theorem 6.14; local source
 `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1345--1386 and
 1483--1494.
 
-**Scope restriction (maximal-support compression):** This theorem describes
-the fixed points of the compressed map with positive definite density blocks.
-The transport to the original space with its complementary zero summand is
-completed in `TNLean.Channel.FixedPoint.WolfTheorem614`.  That completion is
-recorded in `docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex`.
+**Completion status:** This theorem records both the equivalence between the
+original and compressed fixed-point spaces and the positive definite
+density-block description after maximal-support compression.  The subsequent
+unitary transport with its complementary zero summand, completing Wolf,
+Theorem 6.14 and Equation (6.63), is proved in
+`TNLean.Channel.FixedPoint.WolfTheorem614`.  The completion is recorded in
+`docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex`.
 
-The theorem records only the fixed-point description.  The corresponding
-formula for the mean ergodic projection is supplied by
+The corresponding formula for the mean ergodic projection is supplied by
 `IsPositiveMap.exists_block_densities_of_meanErgodicProjection`. -/
 theorem IsPositiveMap.exists_block_densities_of_maximalSupportCompression
     {T : MatD →ₗ[ℂ] MatD} (hT : IsPositiveMap T)


### PR DESCRIPTION
PR LionSR/TNLean#4382 added the ambient/compressed fixed-point equivalence to the Section 4 blueprint. This follow-up updates the corresponding Lean docstring to describe that completed equivalence and the subsequent complementary zero-summand result accurately.

No declaration, theorem statement, or proof changes.

Checks:

- `lake env lean TNLean/Channel/FixedPoint/SupportCompressedDensityBlocks.lean` — passed
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base 0f100e9248e34e5a54275f31341136dadbe0f12a --ci` — passed
- `git diff --check` — passed

Closes LionSR/QICLean#241

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a Lean docstring; no executable or proof logic is affected.
> 
> **Overview**
> Updates the docstring on `IsPositiveMap.exists_block_densities_of_maximalSupportCompression` so it matches the current proof scope after PR LionSR/TNLean#4382’s blueprint work.
> 
> The **“Scope restriction”** note is replaced with a **“Completion status”** section that states this theorem already gives the **ambient vs. compressed fixed-point equivalence** and the **positive definite density-block** classification after maximal-support compression, while **`WolfTheorem614`** is described as the place where the later **unitary transport** and **complementary zero summand** (Wolf Theorem 6.14 / Eq. (6.63)) are proved. The pointer to `docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex` and the cross-reference to the mean ergodic projection theorem are unchanged in role.
> 
> **No** theorem statements, proofs, or declarations are modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 398cbc5813fcf51dd1abc793ec2b168b1422c057. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->