### PR TITLE
feat(Channel/Schwarz): prove the Weyl defect integral formula

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -124,7 +124,6 @@ import TNLean.Channel.OpenSystem
 import TNLean.Channel.TransferMatrix
 import TNLean.Channel.POVM
 import TNLean.Channel.POVM.Uniqueness
-
 -- Layer 2: Quantum entropy infrastructure (depends on Channel.Basic, Channel.PartialTrace)
 import TNLean.Analysis.Entropy
 import TNLean.Analysis.EntropyDecomposition
@@ -135,7 +134,6 @@ import TNLean.Analysis.MarginalSupport
 import TNLean.Analysis.CoisometricCompression
 import TNLean.Channel.MarginalSupportAbsorption
 import TNLean.Channel.PetzRecovery
-
 -- Layer 2a: Density-matrix Brouwer fixed-point theorem used in Perron--Frobenius existence
 import TNLean.Axioms.BrouwerFixedPoint
 -- Layer 2a: Axiomatized entropy inequalities (strong subadditivity)
@@ -158,6 +156,7 @@ import TNLean.Axioms.LiebSubBoundary
 import TNLean.Analysis.OperatorConvexity
 -- Layer 2b: Operator (Loewner) convexity of `a ↦ a^p` for `p ∈ [1,2]` (proved)
 import TNLean.Analysis.RpowConvexity
+import TNLean.Analysis.RelativeEntropyResolventIntegral
 -- Layer 2b: Quantum channels (general theory)
 import TNLean.Channel.Schwarz.KadisonSchwarz
 import TNLean.Channel.Schwarz.PositiveMapProperties
@@ -175,6 +174,7 @@ import TNLean.Channel.Schwarz.PetzRecoverySupport
 import TNLean.Channel.Schwarz.StrongSubadditivityPosDef
 import TNLean.Channel.Schwarz.SSAEqualityDPI
 import TNLean.Channel.Schwarz.PetzEqualityPrerequisites
+import TNLean.Channel.Schwarz.WeylRelativeEntropyIntegral
 import TNLean.Channel.Schwarz.WeylTwirl
 import TNLean.Channel.Schwarz.PositiveOnAbelian
 import TNLean.Channel.Schwarz.SchwarzNormal

--- a/TNLean/Analysis/RelativeEntropyResolventIntegral.lean
+++ b/TNLean/Analysis/RelativeEntropyResolventIntegral.lean
@@ -1,0 +1,925 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Analysis.KleinInequality
+import TNLean.Analysis.SuperoperatorResolvent
+import Mathlib.Analysis.SpecialFunctions.ImproperIntegrals
+import Mathlib.LinearAlgebra.Matrix.Vec
+
+/-!
+# Resolvent integral representation of positive-definite relative entropy
+
+This file proves the scalar logarithmic integral and the finite-dimensional
+spectral identities needed to express positive-definite quantum relative
+entropy through the resolvents of `X ↦ A * X + t • (X * B)`.
+
+## Main results
+
+* `relativeEntropyScalar_integrableOn` and `integral_relativeEntropyScalar`
+  give the coefficient-correct scalar improper integral.
+* `sourceA_resolvent_quadratic_spectral` and
+  `sourceB_resolvent_quadratic_spectral` identify the two resolvent quadratic
+  forms in eigenvalue coordinates.
+* `quantumRelativeEntropy_resolvent_integral` gives the positive-definite
+  matrix integral representation.
+
+## References
+
+* A. Jenčová and M. B. Ruskai, *A Unified Treatment of Convexity of Relative
+  Entropy and Related Trace Functions, with Conditions for Equality*,
+  arXiv:0903.2895v4, §4 and Appendix.
+-/
+
+open Filter MeasureTheory Set Topology
+open scoped Matrix ComplexOrder MatrixOrder Kronecker
+open Matrix
+
+namespace Matrix
+
+/-- The scalar integrand in the (p=1) Jenčová--Ruskai representation:
+\[
+ \frac{a^2/(a+tb)-b+t b^2/(a+tb)}{1+t}.
+\]
+The coefficient `t` in the last term is essential. -/
+noncomputable def relativeEntropyScalar (a b t : ℝ) : ℝ :=
+  (a ^ 2 / (a + t * b) - b + t * b ^ 2 / (a + t * b)) / (1 + t)
+
+private theorem relativeEntropyScalar_integrable_and_integral
+    {a b : ℝ} (ha : 0 < a) (hb : 0 < b) :
+    IntegrableOn (relativeEntropyScalar a b) (Ioi 0) ∧
+      ∫ t : ℝ in Ioi 0, relativeEntropyScalar a b t =
+        a * (Real.log a - Real.log b) := by
+  let f : ℝ → ℝ := relativeEntropyScalar a b
+  let F : ℝ → ℝ := fun t =>
+    a * (Real.log (1 + t) - Real.log (a + t * b))
+  have hf_form (t : ℝ) (h₁ : 1 + t ≠ 0) (h₂ : a + t * b ≠ 0) :
+      f t = a * (a - b) / ((a + t * b) * (1 + t)) := by
+    simp only [f, relativeEntropyScalar]
+    field_simp
+    ring
+  have hderiv : ∀ t ∈ Ici (0 : ℝ), HasDerivAt F (f t) t := by
+    intro t ht
+    have ht0 : 0 ≤ t := ht
+    have h1 : 1 + t ≠ 0 := by positivity
+    have hab : a + t * b ≠ 0 := by positivity
+    have hlog1 : HasDerivAt
+        (fun x : ℝ => Real.log (1 + x)) (1 / (1 + t)) t := by
+      simpa [one_div] using ((hasDerivAt_id t).const_add 1).log h1
+    have hlogab : HasDerivAt
+        (fun x : ℝ => Real.log (a + x * b)) (b / (a + t * b)) t := by
+      simpa [one_div, mul_comm] using
+        ((hasDerivAt_id t).mul_const b |>.const_add a).log hab
+    have h := (hlog1.sub hlogab).const_mul a
+    have hvalue : a * (1 / (1 + t) - b / (a + t * b)) = f t := by
+      rw [hf_form t h1 hab]
+      field_simp
+      ring
+    rw [show F = fun y => a *
+      ((fun x : ℝ => Real.log (1 + x)) y - Real.log (a + y * b)) from rfl]
+    exact h.congr_deriv hvalue
+  have hratio : Tendsto
+      (fun t : ℝ => (1 + t) / (a + t * b)) atTop (𝓝 (1 / b)) := by
+    have hzero : Tendsto (fun t : ℝ => (1 : ℝ) / t) atTop (𝓝 0) :=
+      tendsto_const_nhds.div_atTop tendsto_id
+    have ha0 : Tendsto (fun t : ℝ => a / t) atTop (𝓝 0) :=
+      tendsto_const_nhds.div_atTop tendsto_id
+    have hnum := hzero.add (tendsto_const_nhds (x := (1 : ℝ)))
+    have hden := ha0.add (tendsto_const_nhds (x := b))
+    have h : Tendsto (fun t : ℝ => (1 / t + 1) / (a / t + b)) atTop
+        (𝓝 ((0 + 1) / (0 + b))) :=
+      hnum.div hden (by simpa using hb.ne')
+    have heq : (fun t : ℝ => (1 + t) / (a + t * b)) =ᶠ[atTop]
+        fun t => (1 / t + 1) / (a / t + b) := by
+      filter_upwards [eventually_ne_atTop (0 : ℝ)] with t ht
+      field_simp
+    simpa only [zero_add] using h.congr' heq.symm
+  have hF : Tendsto F atTop (𝓝 (-a * Real.log b)) := by
+    have hinvb : (1 / b) ≠ 0 := one_div_ne_zero hb.ne'
+    have hlog := (Real.continuousAt_log hinvb).tendsto.comp hratio
+    have hmul := (tendsto_const_nhds (x := a)).mul hlog
+    have heq : F =ᶠ[atTop]
+        fun t => a * Real.log ((1 + t) / (a + t * b)) := by
+      filter_upwards [eventually_gt_atTop (0 : ℝ)] with t ht
+      simp only [F]
+      rw [Real.log_div (by positivity) (by positivity)]
+    have hmul' := hmul.congr' heq.symm
+    rw [show -a * Real.log b = a * (-Real.log b) by ring]
+    simpa only [Function.comp_apply, one_div, Real.log_inv] using hmul'
+  have hfint : IntegrableOn f (Ioi 0) := by
+    by_cases hab : b ≤ a
+    · exact integrableOn_Ioi_deriv_of_nonneg' hderiv
+        (fun t ht => by
+          have ht0 : 0 ≤ t := ht.le
+          have hden1 : 0 < 1 + t := by positivity
+          have hdenab : 0 < a + t * b := by positivity
+          rw [hf_form t hden1.ne' hdenab.ne']
+          exact div_nonneg (mul_nonneg ha.le (sub_nonneg.mpr hab))
+            (mul_nonneg hdenab.le hden1.le))
+        hF
+    · have hderivNeg : ∀ t ∈ Ici (0 : ℝ),
+          HasDerivAt (fun x => -F x) (-f t) t :=
+        fun t ht => (hderiv t ht).neg
+      have hFneg : Tendsto (fun x => -F x) atTop
+          (𝓝 (-(-a * Real.log b))) := hF.neg
+      have hnegint : IntegrableOn (fun t => -f t) (Ioi 0) :=
+        integrableOn_Ioi_deriv_of_nonneg' hderivNeg
+          (fun t ht => by
+            have ht0 : 0 ≤ t := ht.le
+            have hden1 : 0 < 1 + t := by positivity
+            have hdenab : 0 < a + t * b := by positivity
+            rw [hf_form t hden1.ne' hdenab.ne', neg_nonneg]
+            exact div_nonpos_of_nonpos_of_nonneg
+              (mul_nonpos_of_nonneg_of_nonpos ha.le
+                (sub_nonpos.mpr (le_of_not_ge hab)))
+              (mul_nonneg hdenab.le hden1.le))
+          hFneg
+      refine hnegint.neg.congr_fun ?_ measurableSet_Ioi
+      intro t _
+      change -(-f t) = f t
+      ring
+  refine ⟨hfint, ?_⟩
+  have hint := integral_Ioi_of_hasDerivAt_of_tendsto' hderiv hfint hF
+  calc
+    ∫ t : ℝ in Ioi 0, relativeEntropyScalar a b t =
+        -a * Real.log b - a *
+          (Real.log (1 + 0) - Real.log (a + 0 * b)) := by
+      simpa only [F, f] using hint
+    _ = a * (Real.log a - Real.log b) := by
+      norm_num
+      ring
+
+/-- The scalar (p=1) relative-entropy resolvent integrand is integrable on
+the positive half-line for positive `a` and `b`.
+
+This is the integrability part of Jenčová--Ruskai,
+arXiv:0903.2895v4, §4. -/
+theorem relativeEntropyScalar_integrableOn {a b : ℝ}
+    (ha : 0 < a) (hb : 0 < b) :
+    IntegrableOn (relativeEntropyScalar a b) (Ioi 0) :=
+  (relativeEntropyScalar_integrable_and_integral ha hb).1
+
+/-- For positive `a` and `b`,
+\[
+ a(\log a-\log b)=\int_0^\infty
+ \frac{a^2/(a+tb)-b+t b^2/(a+tb)}{1+t}\,dt.
+\]
+
+This is the case `p=1` of the spectral integral in Jenčová--Ruskai,
+arXiv:0903.2895v4, §4.
+-/
+theorem integral_relativeEntropyScalar {a b : ℝ}
+    (ha : 0 < a) (hb : 0 < b) :
+    ∫ t : ℝ in Ioi 0, relativeEntropyScalar a b t =
+      a * (Real.log a - Real.log b) :=
+  (relativeEntropyScalar_integrable_and_integral ha hb).2
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- The quadratic resolvent form with source `A` for the positive left-right
+operator `X ↦ A * X + t • (X * B)`. -/
+noncomputable def sourceAResolventQuadratic (A B : Matrix n n ℂ) (t : ℝ) : ℝ :=
+  let S := A ⊗ₖ (1 : Matrix n n ℂ) +
+    t • ((1 : Matrix n n ℂ) ⊗ₖ Bᵀ)
+  (star (vec Aᵀ) ⬝ᵥ (S⁻¹ *ᵥ vec Aᵀ)).re
+
+/-- The quadratic resolvent form with source `B` for the positive left-right
+operator `X ↦ A * X + t • (X * B)`. -/
+noncomputable def sourceBResolventQuadratic (A B : Matrix n n ℂ) (t : ℝ) : ℝ :=
+  let S := A ⊗ₖ (1 : Matrix n n ℂ) +
+    t • ((1 : Matrix n n ℂ) ⊗ₖ Bᵀ)
+  (star (vec Bᵀ) ⬝ᵥ (S⁻¹ *ᵥ vec Bᵀ)).re
+
+/-- Under `X ↦ vec Xᵀ`, the Kronecker left-right matrix represents
+`X ↦ A * X + t • (X * B)`. -/
+theorem leftRight_mulVec_vec_transpose (A B X : Matrix n n ℂ) (t : ℝ) :
+    (A ⊗ₖ (1 : Matrix n n ℂ) +
+        t • ((1 : Matrix n n ℂ) ⊗ₖ Bᵀ)) *ᵥ vec Xᵀ =
+      vec (A * X + t • (X * B))ᵀ := by
+  rw [add_mulVec, smul_mulVec, kronecker_mulVec_vec,
+    kronecker_mulVec_vec]
+  simp only [transpose_one, Matrix.one_mul, Matrix.mul_one,
+    ← vec_add, ← vec_smul, Matrix.transpose_add,
+    Matrix.transpose_smul, Matrix.transpose_mul]
+
+private lemma spectral_sourceA_solution {A B : Matrix n n ℂ}
+    (hA : A.PosDef) (hB : B.PosDef) {t : ℝ} (ht : 0 < t) :
+    let UA : Matrix n n ℂ := hA.isHermitian.eigenvectorUnitary
+    let UB : Matrix n n ℂ := hB.isHermitian.eigenvectorUnitary
+    let α : n → ℝ := hA.isHermitian.eigenvalues
+    let β : n → ℝ := hB.isHermitian.eigenvalues
+    let W := star UA * UB
+    let Y : Matrix n n ℂ := fun i j =>
+      (α i / (α i + t * β j) : ℂ) * W i j
+    let X := UA * Y * star UB
+    A * X + t • (X * B) = A := by
+  classical
+  dsimp only
+  let UA : Matrix n n ℂ := hA.isHermitian.eigenvectorUnitary
+  let UB : Matrix n n ℂ := hB.isHermitian.eigenvectorUnitary
+  let α : n → ℝ := hA.isHermitian.eigenvalues
+  let β : n → ℝ := hB.isHermitian.eigenvalues
+  let Dα : Matrix n n ℂ := diagonal fun i => (α i : ℂ)
+  let Dβ : Matrix n n ℂ := diagonal fun j => (β j : ℂ)
+  let W : Matrix n n ℂ := star UA * UB
+  let Y : Matrix n n ℂ := fun i j =>
+    (α i / (α i + t * β j) : ℂ) * W i j
+  let X : Matrix n n ℂ := UA * Y * star UB
+  have hα (i : n) : 0 < α i := hA.eigenvalues_pos i
+  have hβ (j : n) : 0 < β j := hB.eigenvalues_pos j
+  have hcore : Dα * Y + t • (Y * Dβ) = Dα * W := by
+    ext i j
+    simp only [Dα, Dβ, Y, Matrix.diagonal_mul, Matrix.mul_diagonal,
+      Matrix.add_apply, Matrix.smul_apply, Complex.real_smul]
+    have hden : (α i : ℂ) + t * β j ≠ 0 := by
+      exact_mod_cast
+        (ne_of_gt (add_pos (hα i) (mul_pos ht (hβ j))))
+    field_simp
+  have hAform : A = UA * Dα * star UA := by
+    simpa only [UA, Dα, α] using hA.isHermitian.spectral_form
+  have hBform : B = UB * Dβ * star UB := by
+    simpa only [UB, Dβ, β] using hB.isHermitian.spectral_form
+  have hUA : star UA * UA = 1 := by
+    simpa only [UA] using
+      Unitary.coe_star_mul_self hA.isHermitian.eigenvectorUnitary
+  have hUAstar : UA * star UA = 1 := by
+    simpa only [UA] using
+      Unitary.mul_star_self_of_mem hA.isHermitian.eigenvectorUnitary.prop
+  have hUBstar : UB * star UB = 1 := by
+    simpa only [UB] using
+      Unitary.mul_star_self_of_mem hB.isHermitian.eigenvectorUnitary.prop
+  have hstarUB : star UB * UB = 1 := by
+    simpa only [UB] using
+      Unitary.coe_star_mul_self hB.isHermitian.eigenvectorUnitary
+  calc
+    A * X + t • (X * B) =
+        (UA * Dα * star UA) * X +
+          t • (X * (UB * Dβ * star UB)) := by rw [hAform, hBform]
+    _ = UA * Dα * star UA := by
+      simp only [X, Matrix.mul_assoc]
+      rw [← Matrix.mul_assoc (star UA), hUA, Matrix.one_mul,
+        ← Matrix.mul_assoc (star UB) UB, hstarUB, Matrix.one_mul]
+      rw [show UA * (Dα * (Y * star UB)) +
+          t • (UA * (Y * (Dβ * star UB))) =
+          UA * (Dα * Y + t • (Y * Dβ)) * star UB by
+        simp only [Matrix.mul_add, Matrix.add_mul, Matrix.mul_assoc,
+          Matrix.mul_smul, Matrix.smul_mul], hcore]
+      simp only [W, Matrix.mul_assoc]
+      rw [hUBstar, Matrix.mul_one]
+    _ = A := hAform.symm
+
+private lemma spectral_sourceA_pairing {A B : Matrix n n ℂ}
+    (hA : A.PosDef) (hB : B.PosDef) {t : ℝ} (_ht : 0 < t) :
+    let UA : Matrix n n ℂ := hA.isHermitian.eigenvectorUnitary
+    let UB : Matrix n n ℂ := hB.isHermitian.eigenvectorUnitary
+    let α : n → ℝ := hA.isHermitian.eigenvalues
+    let β : n → ℝ := hB.isHermitian.eigenvalues
+    let W := star UA * UB
+    let Y : Matrix n n ℂ := fun i j =>
+      (α i / (α i + t * β j) : ℂ) * W i j
+    let X := UA * Y * star UB
+    (star (vec Aᵀ) ⬝ᵥ vec Xᵀ).re =
+      ∑ i, ∑ j, α i ^ 2 / (α i + t * β j) *
+        Complex.normSq (W i j) := by
+  classical
+  dsimp only
+  let UA : Matrix n n ℂ := hA.isHermitian.eigenvectorUnitary
+  let UB : Matrix n n ℂ := hB.isHermitian.eigenvectorUnitary
+  let α : n → ℝ := hA.isHermitian.eigenvalues
+  let β : n → ℝ := hB.isHermitian.eigenvalues
+  let Dα : Matrix n n ℂ := diagonal fun i => (α i : ℂ)
+  let W : Matrix n n ℂ := star UA * UB
+  let Y : Matrix n n ℂ := fun i j =>
+    (α i / (α i + t * β j) : ℂ) * W i j
+  let X : Matrix n n ℂ := UA * Y * star UB
+  have hAform : A = UA * Dα * star UA := by
+    simpa only [UA, Dα, α] using hA.isHermitian.spectral_form
+  have hUA : star UA * UA = 1 := by
+    simpa only [UA] using
+      Unitary.coe_star_mul_self hA.isHermitian.eigenvectorUnitary
+  have hstarW : star W = star UB * UA := by
+    simp only [W, star_mul, star_star]
+  have hpair : star (vec Aᵀ) ⬝ᵥ vec Xᵀ = Matrix.trace (A * X) := by
+    rw [Matrix.star_vec_dotProduct_vec]
+    rw [hA.isHermitian.transpose.eq, ← Matrix.transpose_mul,
+      Matrix.trace_transpose, Matrix.trace_mul_comm]
+  rw [hpair]
+  have htraceform : Matrix.trace (A * X) =
+      Matrix.trace ((UA * Dα * star UA) * X) := by rw [hAform]
+  rw [htraceform]
+  simp only [X, Matrix.mul_assoc]
+  rw [← Matrix.mul_assoc (star UA), hUA, Matrix.one_mul]
+  rw [Matrix.trace_mul_comm UA]
+  simp only [Matrix.mul_assoc]
+  rw [← hstarW]
+  rw [← Matrix.mul_assoc Dα Y (star W)]
+  have hDY : Dα * Y = fun i j => (α i : ℂ) * Y i j := by
+    ext i j
+    simp only [Dα, Matrix.diagonal_mul]
+  rw [hDY]
+  simp only [Matrix.trace, Matrix.diag_apply, Matrix.mul_apply, Y,
+    Matrix.star_apply, Complex.star_def,
+    Complex.re_sum]
+  apply Finset.sum_congr rfl
+  intro i _
+  apply Finset.sum_congr rfl
+  intro j _
+  change ((α i : ℂ) * ((α i : ℂ) /
+      ((α i : ℂ) + t * β j) * W i j) * star (W i j)).re =
+    α i ^ 2 / (α i + t * β j) * Complex.normSq (W i j)
+  have hnorm : W i j * star (W i j) =
+      (Complex.normSq (W i j) : ℂ) := by
+    rw [mul_comm, Complex.star_def, ← Complex.normSq_eq_conj_mul_self]
+  rw [show (α i : ℂ) * ((α i : ℂ) /
+      ((α i : ℂ) + t * β j) * W i j) * star (W i j) =
+      ((α i : ℂ) * ((α i : ℂ) /
+        ((α i : ℂ) + t * β j))) * (W i j * star (W i j)) by ring,
+    hnorm]
+  rw [← Complex.ofReal_mul t (β j),
+    ← Complex.ofReal_add (α i) (t * β j),
+    ← Complex.ofReal_div (α i) (α i + t * β j),
+    ← Complex.ofReal_mul (α i) (α i / (α i + t * β j)),
+    ← Complex.ofReal_mul
+      (α i * (α i / (α i + t * β j))) (Complex.normSq (W i j)),
+    Complex.ofReal_re]
+  ring
+
+private lemma spectral_sourceB_solution {A B : Matrix n n ℂ}
+    (hA : A.PosDef) (hB : B.PosDef) {t : ℝ} (ht : 0 < t) :
+    let UA : Matrix n n ℂ := hA.isHermitian.eigenvectorUnitary
+    let UB : Matrix n n ℂ := hB.isHermitian.eigenvectorUnitary
+    let α : n → ℝ := hA.isHermitian.eigenvalues
+    let β : n → ℝ := hB.isHermitian.eigenvalues
+    let W := star UA * UB
+    let Y : Matrix n n ℂ := fun i j =>
+      (β j / (α i + t * β j) : ℂ) * W i j
+    let X := UA * Y * star UB
+    A * X + t • (X * B) = B := by
+  classical
+  dsimp only
+  let UA : Matrix n n ℂ := hA.isHermitian.eigenvectorUnitary
+  let UB : Matrix n n ℂ := hB.isHermitian.eigenvectorUnitary
+  let α : n → ℝ := hA.isHermitian.eigenvalues
+  let β : n → ℝ := hB.isHermitian.eigenvalues
+  let Dα : Matrix n n ℂ := diagonal fun i => (α i : ℂ)
+  let Dβ : Matrix n n ℂ := diagonal fun j => (β j : ℂ)
+  let W : Matrix n n ℂ := star UA * UB
+  let Y : Matrix n n ℂ := fun i j =>
+    (β j / (α i + t * β j) : ℂ) * W i j
+  let X : Matrix n n ℂ := UA * Y * star UB
+  have hα (i : n) : 0 < α i := hA.eigenvalues_pos i
+  have hβ (j : n) : 0 < β j := hB.eigenvalues_pos j
+  have hcore : Dα * Y + t • (Y * Dβ) = W * Dβ := by
+    ext i j
+    simp only [Dα, Dβ, Y, Matrix.diagonal_mul, Matrix.mul_diagonal,
+      Matrix.add_apply, Matrix.smul_apply, Complex.real_smul]
+    have hden : (α i : ℂ) + t * β j ≠ 0 := by
+      exact_mod_cast
+        (ne_of_gt (add_pos (hα i) (mul_pos ht (hβ j))))
+    rw [div_eq_mul_inv]
+    calc
+      (α i : ℂ) * (((β j : ℂ) * ((α i : ℂ) + t * β j)⁻¹) * W i j) +
+          t * ((((β j : ℂ) * ((α i : ℂ) + t * β j)⁻¹) * W i j) * β j) =
+          W i j * β j *
+            (((α i : ℂ) + t * β j) * ((α i : ℂ) + t * β j)⁻¹) := by ring
+      _ = W i j * β j := by rw [mul_inv_cancel₀ hden, mul_one]
+  have hAform : A = UA * Dα * star UA := by
+    simpa only [UA, Dα, α] using hA.isHermitian.spectral_form
+  have hBform : B = UB * Dβ * star UB := by
+    simpa only [UB, Dβ, β] using hB.isHermitian.spectral_form
+  have hUA : star UA * UA = 1 := by
+    simpa only [UA] using
+      Unitary.coe_star_mul_self hA.isHermitian.eigenvectorUnitary
+  have hUAstar : UA * star UA = 1 := by
+    simpa only [UA] using
+      Unitary.mul_star_self_of_mem hA.isHermitian.eigenvectorUnitary.prop
+  have hUBstar : UB * star UB = 1 := by
+    simpa only [UB] using
+      Unitary.mul_star_self_of_mem hB.isHermitian.eigenvectorUnitary.prop
+  have hstarUB : star UB * UB = 1 := by
+    simpa only [UB] using
+      Unitary.coe_star_mul_self hB.isHermitian.eigenvectorUnitary
+  calc
+    A * X + t • (X * B) =
+        (UA * Dα * star UA) * X +
+          t • (X * (UB * Dβ * star UB)) := by rw [hAform, hBform]
+    _ = UB * Dβ * star UB := by
+      simp only [X, Matrix.mul_assoc]
+      rw [← Matrix.mul_assoc (star UA), hUA, Matrix.one_mul,
+        ← Matrix.mul_assoc (star UB) UB, hstarUB, Matrix.one_mul]
+      rw [show UA * (Dα * (Y * star UB)) +
+          t • (UA * (Y * (Dβ * star UB))) =
+          UA * (Dα * Y + t • (Y * Dβ)) * star UB by
+        simp only [Matrix.mul_add, Matrix.add_mul, Matrix.mul_assoc,
+          Matrix.mul_smul, Matrix.smul_mul], hcore]
+      simp only [W, Matrix.mul_assoc]
+      rw [← Matrix.mul_assoc UA (star UA) (UB * (Dβ * star UB)),
+        hUAstar, Matrix.one_mul]
+    _ = B := hBform.symm
+
+private lemma spectral_sourceB_pairing {A B : Matrix n n ℂ}
+    (hA : A.PosDef) (hB : B.PosDef) {t : ℝ} (_ht : 0 < t) :
+    let UA : Matrix n n ℂ := hA.isHermitian.eigenvectorUnitary
+    let UB : Matrix n n ℂ := hB.isHermitian.eigenvectorUnitary
+    let α : n → ℝ := hA.isHermitian.eigenvalues
+    let β : n → ℝ := hB.isHermitian.eigenvalues
+    let W := star UA * UB
+    let Y : Matrix n n ℂ := fun i j =>
+      (β j / (α i + t * β j) : ℂ) * W i j
+    let X := UA * Y * star UB
+    (star (vec Bᵀ) ⬝ᵥ vec Xᵀ).re =
+      ∑ i, ∑ j, β j ^ 2 / (α i + t * β j) *
+        Complex.normSq (W i j) := by
+  classical
+  dsimp only
+  let UA : Matrix n n ℂ := hA.isHermitian.eigenvectorUnitary
+  let UB : Matrix n n ℂ := hB.isHermitian.eigenvectorUnitary
+  let α : n → ℝ := hA.isHermitian.eigenvalues
+  let β : n → ℝ := hB.isHermitian.eigenvalues
+  let Dβ : Matrix n n ℂ := diagonal fun j => (β j : ℂ)
+  let W : Matrix n n ℂ := star UA * UB
+  let Y : Matrix n n ℂ := fun i j =>
+    (β j / (α i + t * β j) : ℂ) * W i j
+  let X : Matrix n n ℂ := UA * Y * star UB
+  have hBform : B = UB * Dβ * star UB := by
+    simpa only [UB, Dβ, β] using hB.isHermitian.spectral_form
+  have hUB : star UB * UB = 1 := by
+    simpa only [UB] using
+      Unitary.coe_star_mul_self hB.isHermitian.eigenvectorUnitary
+  have hstarW : star W = star UB * UA := by
+    simp only [W, star_mul, star_star]
+  have hpair : star (vec Bᵀ) ⬝ᵥ vec Xᵀ = Matrix.trace (B * X) := by
+    rw [Matrix.star_vec_dotProduct_vec]
+    rw [hB.isHermitian.transpose.eq, ← Matrix.transpose_mul,
+      Matrix.trace_transpose, Matrix.trace_mul_comm]
+  rw [hpair]
+  have htraceform : Matrix.trace (B * X) =
+      Matrix.trace ((UB * Dβ * star UB) * X) := by rw [hBform]
+  rw [htraceform]
+  simp only [X, Matrix.mul_assoc]
+  rw [Matrix.trace_mul_comm UB]
+  simp only [Matrix.mul_assoc]
+  rw [hUB, Matrix.mul_one]
+  rw [← Matrix.mul_assoc (star UB) UA Y, ← hstarW]
+  have hD : Dβ * (star W * Y) =
+      fun i j => (β i : ℂ) * (star W * Y) i j := by
+    ext i j
+    simp only [Dβ, Matrix.diagonal_mul]
+  rw [hD]
+  simp only [Matrix.trace, Matrix.diag_apply, Matrix.mul_apply, Y, W,
+    Matrix.star_apply, Complex.star_def,
+    Complex.re_sum]
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro j _
+  rw [Finset.mul_sum, Complex.re_sum]
+  apply Finset.sum_congr rfl
+  intro i _
+  change ((β j : ℂ) * (star (W i j) *
+      ((β j : ℂ) / ((α i : ℂ) + t * β j) * W i j))).re =
+    β j ^ 2 / (α i + t * β j) * Complex.normSq (W i j)
+  have hnorm : star (W i j) * W i j =
+      (Complex.normSq (W i j) : ℂ) := by
+    rw [Complex.star_def, ← Complex.normSq_eq_conj_mul_self]
+  rw [show (β j : ℂ) * (star (W i j) *
+      ((β j : ℂ) / ((α i : ℂ) + t * β j) * W i j)) =
+      ((β j : ℂ) * ((β j : ℂ) /
+        ((α i : ℂ) + t * β j))) * (star (W i j) * W i j) by ring,
+    hnorm]
+  rw [← Complex.ofReal_mul t (β j),
+    ← Complex.ofReal_add (α i) (t * β j),
+    ← Complex.ofReal_div (β j) (α i + t * β j),
+    ← Complex.ofReal_mul (β j) (β j / (α i + t * β j)),
+    ← Complex.ofReal_mul
+      (β j * (β j / (α i + t * β j))) (Complex.normSq (W i j)),
+    Complex.ofReal_re]
+  ring
+
+/-- The source-`A` left-right resolvent quadratic form has the spectral
+expansion
+\[
+ \sum_{i,j}\frac{\alpha_i^2}{\alpha_i+t\beta_j}|W_{ij}|^2.
+\]
+
+This is the first resolvent term of Jenčová--Ruskai,
+arXiv:0903.2895v4, §4. -/
+theorem sourceA_resolvent_quadratic_spectral {A B : Matrix n n ℂ}
+    (hA : A.PosDef) (hB : B.PosDef) {t : ℝ} (ht : 0 < t) :
+    sourceAResolventQuadratic A B t =
+      ∑ i, ∑ j,
+        hA.isHermitian.eigenvalues i ^ 2 /
+            (hA.isHermitian.eigenvalues i +
+              t * hB.isHermitian.eigenvalues j) *
+          Complex.normSq
+            ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+              (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j) := by
+  classical
+  let UA : Matrix n n ℂ := hA.isHermitian.eigenvectorUnitary
+  let UB : Matrix n n ℂ := hB.isHermitian.eigenvectorUnitary
+  let α : n → ℝ := hA.isHermitian.eigenvalues
+  let β : n → ℝ := hB.isHermitian.eigenvalues
+  let W : Matrix n n ℂ := star UA * UB
+  let Y : Matrix n n ℂ := fun i j =>
+    (α i / (α i + t * β j) : ℂ) * W i j
+  let X : Matrix n n ℂ := UA * Y * star UB
+  let S : Matrix (n × n) (n × n) ℂ :=
+    A ⊗ₖ (1 : Matrix n n ℂ) +
+      t • ((1 : Matrix n n ℂ) ⊗ₖ Bᵀ)
+  have hsolution : A * X + t • (X * B) = A := by
+    simpa only [UA, UB, α, β, W, Y, X] using
+      spectral_sourceA_solution hA hB ht
+  have hvec : S *ᵥ vec Xᵀ = vec Aᵀ := by
+    change (A ⊗ₖ (1 : Matrix n n ℂ) +
+      t • ((1 : Matrix n n ℂ) ⊗ₖ Bᵀ)) *ᵥ vec Xᵀ = vec Aᵀ
+    rw [leftRight_mulVec_vec_transpose, hsolution]
+  have hS : S.PosDef := by
+    simpa only [S] using superop_leftRight_posDef ht hA hB
+  letI : Invertible S := hS.isUnit.invertible
+  have hinv : S⁻¹ *ᵥ vec Aᵀ = vec Xᵀ := by
+    rw [← hvec, mulVec_mulVec, inv_mul_of_invertible, one_mulVec]
+  simp only [sourceAResolventQuadratic]
+  rw [hinv]
+  simpa only [UA, UB, α, β, W, Y, X] using
+    spectral_sourceA_pairing hA hB ht
+
+/-- The source-`B` left-right resolvent quadratic form has the spectral
+expansion
+\[
+ \sum_{i,j}\frac{\beta_j^2}{\alpha_i+t\beta_j}|W_{ij}|^2.
+\]
+
+This is the second resolvent term of Jenčová--Ruskai,
+arXiv:0903.2895v4, §4. -/
+theorem sourceB_resolvent_quadratic_spectral {A B : Matrix n n ℂ}
+    (hA : A.PosDef) (hB : B.PosDef) {t : ℝ} (ht : 0 < t) :
+    sourceBResolventQuadratic A B t =
+      ∑ i, ∑ j,
+        hB.isHermitian.eigenvalues j ^ 2 /
+            (hA.isHermitian.eigenvalues i +
+              t * hB.isHermitian.eigenvalues j) *
+          Complex.normSq
+            ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+              (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j) := by
+  classical
+  let UA : Matrix n n ℂ := hA.isHermitian.eigenvectorUnitary
+  let UB : Matrix n n ℂ := hB.isHermitian.eigenvectorUnitary
+  let α : n → ℝ := hA.isHermitian.eigenvalues
+  let β : n → ℝ := hB.isHermitian.eigenvalues
+  let W : Matrix n n ℂ := star UA * UB
+  let Y : Matrix n n ℂ := fun i j =>
+    (β j / (α i + t * β j) : ℂ) * W i j
+  let X : Matrix n n ℂ := UA * Y * star UB
+  let S : Matrix (n × n) (n × n) ℂ :=
+    A ⊗ₖ (1 : Matrix n n ℂ) +
+      t • ((1 : Matrix n n ℂ) ⊗ₖ Bᵀ)
+  have hsolution : A * X + t • (X * B) = B := by
+    simpa only [UA, UB, α, β, W, Y, X] using
+      spectral_sourceB_solution hA hB ht
+  have hvec : S *ᵥ vec Xᵀ = vec Bᵀ := by
+    change (A ⊗ₖ (1 : Matrix n n ℂ) +
+      t • ((1 : Matrix n n ℂ) ⊗ₖ Bᵀ)) *ᵥ vec Xᵀ = vec Bᵀ
+    rw [leftRight_mulVec_vec_transpose, hsolution]
+  have hS : S.PosDef := by
+    simpa only [S] using superop_leftRight_posDef ht hA hB
+  letI : Invertible S := hS.isUnit.invertible
+  have hinv : S⁻¹ *ᵥ vec Bᵀ = vec Xᵀ := by
+    rw [← hvec, mulVec_mulVec, inv_mul_of_invertible, one_mulVec]
+  simp only [sourceBResolventQuadratic]
+  rw [hinv]
+  simpa only [UA, UB, α, β, W, Y, X] using
+    spectral_sourceB_pairing hA hB ht
+
+/-- The source-`A` resolvent quadratic form is continuous for positive
+resolvent parameter. -/
+theorem sourceAResolventQuadratic_continuousOn {A B : Matrix n n ℂ}
+    (hA : A.PosDef) (hB : B.PosDef) :
+    ContinuousOn (sourceAResolventQuadratic A B) (Ioi 0) := by
+  classical
+  let α : n → ℝ := hA.isHermitian.eigenvalues
+  let β : n → ℝ := hB.isHermitian.eigenvalues
+  let W : Matrix n n ℂ :=
+    star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+      (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)
+  let P : n → n → ℝ := fun i j => Complex.normSq (W i j)
+  have hspectral : ContinuousOn
+      (fun t : ℝ => ∑ i, ∑ j,
+        α i ^ 2 / (α i + t * β j) * P i j) (Ioi 0) := by
+    apply continuousOn_finsetSum Finset.univ
+    intro i _
+    apply continuousOn_finsetSum Finset.univ
+    intro j _ t ht
+    have ht0 : 0 < t := ht
+    have hα : 0 < α i := hA.eigenvalues_pos i
+    have hβ : 0 < β j := hB.eigenvalues_pos j
+    have hden : α i + t * β j ≠ 0 := by positivity
+    apply ContinuousAt.continuousWithinAt
+    fun_prop
+  refine hspectral.congr (fun t ht => ?_)
+  simpa only [α, β, W, P] using
+    sourceA_resolvent_quadratic_spectral hA hB ht
+
+/-- The source-`B` resolvent quadratic form is continuous for positive
+resolvent parameter. -/
+theorem sourceBResolventQuadratic_continuousOn {A B : Matrix n n ℂ}
+    (hA : A.PosDef) (hB : B.PosDef) :
+    ContinuousOn (sourceBResolventQuadratic A B) (Ioi 0) := by
+  classical
+  let α : n → ℝ := hA.isHermitian.eigenvalues
+  let β : n → ℝ := hB.isHermitian.eigenvalues
+  let W : Matrix n n ℂ :=
+    star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+      (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)
+  let P : n → n → ℝ := fun i j => Complex.normSq (W i j)
+  have hspectral : ContinuousOn
+      (fun t : ℝ => ∑ i, ∑ j,
+        β j ^ 2 / (α i + t * β j) * P i j) (Ioi 0) := by
+    apply continuousOn_finsetSum Finset.univ
+    intro i _
+    apply continuousOn_finsetSum Finset.univ
+    intro j _ t ht
+    have ht0 : 0 < t := ht
+    have hα : 0 < α i := hA.eigenvalues_pos i
+    have hβ : 0 < β j := hB.eigenvalues_pos j
+    have hden : α i + t * β j ≠ 0 := by positivity
+    apply ContinuousAt.continuousWithinAt
+    fun_prop
+  refine hspectral.congr (fun t ht => ?_)
+  simpa only [α, β, W, P] using
+    sourceB_resolvent_quadratic_spectral hA hB ht
+
+open scoped Matrix.Norms.L2Operator in
+/-- For positive-definite matrices, relative entropy is the spectral double
+sum
+\[
+ D(A\Vert B)=\sum_{i,j}\alpha_i
+   (\log\alpha_i-\log\beta_j)|W_{ij}|^2.
+\]
+
+This is the finite-dimensional spectral form of Jenčová--Ruskai,
+arXiv:0903.2895v4, §4, specialized to `p=1`. -/
+theorem quantumRelativeEntropy_posDef_spectral {A B : Matrix n n ℂ}
+    (hA : A.PosDef) (hB : B.PosDef) :
+    quantumRelativeEntropy A B =
+      ∑ i, ∑ j,
+        hA.isHermitian.eigenvalues i *
+          (Real.log (hA.isHermitian.eigenvalues i) -
+            Real.log (hB.isHermitian.eigenvalues j)) *
+          Complex.normSq
+            ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+              (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j) := by
+  classical
+  let α : n → ℝ := hA.isHermitian.eigenvalues
+  let β : n → ℝ := hB.isHermitian.eigenvalues
+  let W : Matrix n n ℂ :=
+    star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+      (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)
+  let P : n → n → ℝ := fun i j => Complex.normSq (W i j)
+  have hWrow : W * star W = 1 := by
+    simp only [W, star_mul, star_star, Matrix.mul_assoc]
+    rw [← Matrix.mul_assoc
+      (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)]
+    rw [Unitary.mul_star_self_of_mem
+      hB.isHermitian.eigenvectorUnitary.prop, Matrix.one_mul]
+    exact Unitary.coe_star_mul_self hA.isHermitian.eigenvectorUnitary
+  have hrow (i : n) : ∑ j, P i j = 1 := by
+    exact TNLean.Klein.row_sum_normSq_eq_one hWrow i
+  rw [quantumRelativeEntropy_eq_trace_mul_log_sub]
+  have hlogB : CFC.log B = hB.isHermitian.cfc Real.log := by
+    rw [CFC.log]
+    exact Matrix.IsHermitian.cfc_eq hB.isHermitian Real.log
+  have hself : (Matrix.trace (A * CFC.log A)).re =
+      ∑ i, ∑ j, α i * Real.log (α i) * P i j := by
+    have h := vonNeumannEntropy_eq_neg_trace_mul_log hA.isHermitian
+    rw [vonNeumannEntropy] at h
+    have hre : (Matrix.trace (A * CFC.log A)).re =
+        ∑ i, α i * Real.log (α i) := by
+      rw [show (Matrix.trace (A * CFC.log A)).re =
+          -(-(Matrix.trace (A * CFC.log A)).re) by ring,
+        ← h, ← Finset.sum_neg_distrib]
+      exact Finset.sum_congr rfl fun i _ => by
+        rw [Real.negMulLog]
+        ring
+    rw [hre]
+    refine Finset.sum_congr rfl fun i _ => ?_
+    conv_lhs => rw [← mul_one (α i * Real.log (α i)), ← hrow i]
+    rw [Finset.mul_sum]
+  have hcross : (Matrix.trace (A * CFC.log B)).re =
+      ∑ i, ∑ j, α i * Real.log (β j) * P i j := by
+    rw [hlogB, TNLean.Klein.re_trace_mul_cfc_eq_double_sum
+      hA.isHermitian hB.isHermitian Real.log]
+  rw [hself, hcross, ← Finset.sum_sub_distrib]
+  refine Finset.sum_congr rfl fun i _ => ?_
+  rw [← Finset.sum_sub_distrib]
+  refine Finset.sum_congr rfl fun j _ => ?_
+  simp only [α, β, W, P]
+  ring
+
+open scoped Matrix.Norms.L2Operator in
+/-- Simultaneous multiplication of two positive-definite arguments by a
+positive scalar multiplies their relative entropy by the same scalar.
+
+This is the positive-definite homogeneity of finite-dimensional Umegaki
+relative entropy. It follows from the trace-log formula and the identity
+`log(c A) = (log c) 1 + log A` for `c > 0`. -/
+theorem quantumRelativeEntropy_smul_posDef {A B : Matrix n n ℂ}
+    (hA : A.PosDef) (hB : B.PosDef) {c : ℝ} (hc : 0 < c) :
+    quantumRelativeEntropy (c • A) (c • B) =
+      c * quantumRelativeEntropy A B := by
+  rw [quantumRelativeEntropy]
+  rw [CFC.log_smul A (fun x hx hx0 =>
+      spectrum.zero_notMem ℝ hA.isUnit (hx0 ▸ hx)) (ne_of_gt hc) hA.isHermitian,
+    CFC.log_smul B (fun x hx hx0 =>
+      spectrum.zero_notMem ℝ hB.isUnit (hx0 ▸ hx)) (ne_of_gt hc) hB.isHermitian]
+  simp only [add_sub_add_left_eq_sub]
+  rw [smul_mul]
+  simp [Matrix.trace_smul, quantumRelativeEntropy]
+
+/-- The two-source resolvent integrand for positive-definite relative entropy.
+The source-`B` term carries the coefficient `t` required by the scalar
+representation. -/
+noncomputable def relativeEntropyResolventIntegrand
+    (A B : Matrix n n ℂ) (t : ℝ) : ℝ :=
+  (sourceAResolventQuadratic A B t - (Matrix.trace B).re +
+      t * sourceBResolventQuadratic A B t) / (1 + t)
+
+private lemma relativeEntropyResolventIntegrand_eq_spectral
+    {A B : Matrix n n ℂ} (hA : A.PosDef) (hB : B.PosDef)
+    {t : ℝ} (ht : 0 < t) :
+    relativeEntropyResolventIntegrand A B t =
+      ∑ i, ∑ j,
+        relativeEntropyScalar
+            (hA.isHermitian.eigenvalues i)
+            (hB.isHermitian.eigenvalues j) t *
+          Complex.normSq
+            ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+              (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j) := by
+  classical
+  let α : n → ℝ := hA.isHermitian.eigenvalues
+  let β : n → ℝ := hB.isHermitian.eigenvalues
+  let W : Matrix n n ℂ :=
+    star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+      (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)
+  let P : n → n → ℝ := fun i j => Complex.normSq (W i j)
+  have hWcol : star W * W = 1 := by
+    simp only [W, star_mul, star_star, Matrix.mul_assoc]
+    rw [← Matrix.mul_assoc
+      (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ)]
+    rw [Unitary.mul_star_self_of_mem
+      hA.isHermitian.eigenvectorUnitary.prop, Matrix.one_mul]
+    exact Unitary.coe_star_mul_self hB.isHermitian.eigenvectorUnitary
+  have hcol (j : n) : ∑ i, P i j = 1 := by
+    exact TNLean.Klein.col_sum_normSq_eq_one hWcol j
+  have htrace : (Matrix.trace B).re = ∑ i, ∑ j, β j * P i j := by
+    have htr : (Matrix.trace B).re = ∑ j, β j := by
+      rw [hB.isHermitian.trace_eq_sum_eigenvalues, Complex.re_sum]
+      exact Finset.sum_congr rfl fun j _ => Complex.ofReal_re _
+    rw [htr, Finset.sum_comm]
+    refine Finset.sum_congr rfl fun j _ => ?_
+    conv_lhs => rw [← mul_one (β j), ← hcol j]
+    rw [Finset.mul_sum]
+  rw [relativeEntropyResolventIntegrand,
+    sourceA_resolvent_quadratic_spectral hA hB ht,
+    sourceB_resolvent_quadratic_spectral hA hB ht]
+  change ((∑ i, ∑ j, α i ^ 2 / (α i + t * β j) * P i j) -
+      (Matrix.trace B).re +
+      t * (∑ i, ∑ j, β j ^ 2 / (α i + t * β j) * P i j)) /
+      (1 + t) = _
+  rw [htrace, ← Finset.sum_sub_distrib]
+  simp_rw [← Finset.sum_sub_distrib]
+  rw [Finset.mul_sum, ← Finset.sum_add_distrib, Finset.sum_div]
+  simp_rw [Finset.mul_sum, ← Finset.sum_add_distrib, Finset.sum_div]
+  apply Finset.sum_congr rfl
+  intro i _
+  apply Finset.sum_congr rfl
+  intro j _
+  simp only [relativeEntropyScalar, α, β, W, P]
+  ring
+
+/-- The coefficient-correct positive-definite relative-entropy resolvent
+integrand is integrable on `(0, ∞)`.
+
+This is the integrability assertion accompanying Jenčová--Ruskai,
+arXiv:0903.2895v4, §4. -/
+theorem relativeEntropyResolventIntegrand_integrableOn
+    {A B : Matrix n n ℂ} (hA : A.PosDef) (hB : B.PosDef) :
+    IntegrableOn (relativeEntropyResolventIntegrand A B) (Ioi 0) := by
+  classical
+  let α : n → ℝ := hA.isHermitian.eigenvalues
+  let β : n → ℝ := hB.isHermitian.eigenvalues
+  let W : Matrix n n ℂ :=
+    star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+      (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)
+  let P : n → n → ℝ := fun i j => Complex.normSq (W i j)
+  have hspectral : IntegrableOn
+      (fun t : ℝ => ∑ i, ∑ j,
+        relativeEntropyScalar (α i) (β j) t * P i j) (Ioi 0) := by
+    apply integrable_finsetSum Finset.univ
+    intro i _
+    apply integrable_finsetSum Finset.univ
+    intro j _
+    exact (relativeEntropyScalar_integrableOn
+      (hA.eigenvalues_pos i) (hB.eigenvalues_pos j)).mul_const (P i j)
+  refine hspectral.congr_fun (fun t ht => ?_) measurableSet_Ioi
+  symm
+  simpa only [α, β, W, P] using
+    relativeEntropyResolventIntegrand_eq_spectral hA hB ht
+
+/-- The coefficient-correct positive-definite relative-entropy resolvent
+integrand is continuous on `(0, ∞)`.
+
+This is the continuity input needed to pass from almost-everywhere vanishing
+of the Jenčová--Ruskai integrand to pointwise vanishing. -/
+theorem relativeEntropyResolventIntegrand_continuousOn
+    {A B : Matrix n n ℂ} (hA : A.PosDef) (hB : B.PosDef) :
+    ContinuousOn (relativeEntropyResolventIntegrand A B) (Ioi 0) := by
+  classical
+  let α : n → ℝ := hA.isHermitian.eigenvalues
+  let β : n → ℝ := hB.isHermitian.eigenvalues
+  let W : Matrix n n ℂ :=
+    star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+      (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)
+  let P : n → n → ℝ := fun i j => Complex.normSq (W i j)
+  have hspectral : ContinuousOn
+      (fun t : ℝ => ∑ i, ∑ j,
+        relativeEntropyScalar (α i) (β j) t * P i j) (Ioi 0) := by
+    apply continuousOn_finsetSum Finset.univ
+    intro i _
+    apply continuousOn_finsetSum Finset.univ
+    intro j _ t ht
+    have ht0 : 0 < t := ht
+    have hα : 0 < α i := hA.eigenvalues_pos i
+    have hβ : 0 < β j := hB.eigenvalues_pos j
+    have hden : α i + t * β j ≠ 0 := by positivity
+    have h1 : 1 + t ≠ 0 := by positivity
+    apply ContinuousAt.continuousWithinAt
+    unfold relativeEntropyScalar
+    fun_prop
+  refine hspectral.congr (fun t ht => ?_)
+  simpa only [α, β, W, P] using
+    relativeEntropyResolventIntegrand_eq_spectral hA hB ht
+
+/-- **Positive-definite relative entropy as a two-source resolvent integral.**
+For positive-definite `A` and `B`,
+\[
+ D(A\Vert B)=\int_0^\infty
+ \frac{Q_A(t)-\operatorname{tr}B+tQ_B(t)}{1+t}\,dt.
+\]
+Both source families, and the coefficient `t` on the source-`B` family, are
+part of the statement.
+
+This is the finite-dimensional specialization of Jenčová--Ruskai,
+arXiv:0903.2895v4, §4, specialized to `p=1`. -/
+theorem quantumRelativeEntropy_resolvent_integral
+    {A B : Matrix n n ℂ} (hA : A.PosDef) (hB : B.PosDef) :
+    quantumRelativeEntropy A B =
+      ∫ t : ℝ in Ioi 0, relativeEntropyResolventIntegrand A B t := by
+  classical
+  let α : n → ℝ := hA.isHermitian.eigenvalues
+  let β : n → ℝ := hB.isHermitian.eigenvalues
+  let W : Matrix n n ℂ :=
+    star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+      (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)
+  let P : n → n → ℝ := fun i j => Complex.normSq (W i j)
+  have hterm (i j : n) :
+      IntegrableOn (fun t : ℝ =>
+        relativeEntropyScalar (α i) (β j) t * P i j) (Ioi 0) :=
+    (relativeEntropyScalar_integrableOn
+      (hA.eigenvalues_pos i) (hB.eigenvalues_pos j)).mul_const (P i j)
+  rw [quantumRelativeEntropy_posDef_spectral hA hB]
+  change (∑ i, ∑ j,
+      α i * (Real.log (α i) - Real.log (β j)) * P i j) = _
+  calc
+    (∑ i, ∑ j,
+        α i * (Real.log (α i) - Real.log (β j)) * P i j) =
+        ∑ i, ∑ j,
+          (∫ t : ℝ in Ioi 0,
+            relativeEntropyScalar (α i) (β j) t) * P i j := by
+      apply Finset.sum_congr rfl
+      intro i _
+      apply Finset.sum_congr rfl
+      intro j _
+      rw [integral_relativeEntropyScalar
+        (hA.eigenvalues_pos i) (hB.eigenvalues_pos j)]
+    _ = ∫ t : ℝ in Ioi 0,
+        ∑ i, ∑ j,
+          relativeEntropyScalar (α i) (β j) t * P i j := by
+      rw [integral_finsetSum Finset.univ]
+      · apply Finset.sum_congr rfl
+        intro i _
+        rw [integral_finsetSum Finset.univ]
+        · apply Finset.sum_congr rfl
+          intro j _
+          rw [integral_mul_const]
+        · exact fun j _ => hterm i j
+      · intro i _
+        apply integrable_finsetSum Finset.univ
+        exact fun j _ => hterm i j
+    _ = ∫ t : ℝ in Ioi 0, relativeEntropyResolventIntegrand A B t := by
+      apply integral_congr_ae
+      filter_upwards [ae_restrict_mem measurableSet_Ioi] with t ht
+      symm
+      simpa only [α, β, W, P] using
+        relativeEntropyResolventIntegrand_eq_spectral hA hB ht
+
+end Matrix

--- a/TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean
+++ b/TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean
@@ -558,7 +558,7 @@ summand quadratic forms and the quadratic form of their average.
 The vectorization is `X ↦ Matrix.vec Xᵀ`; hence
 `A ⊗ₖ 1 + t • (1 ⊗ₖ Bᵀ)` represents `X ↦ A * X + t • (X * B)`.
 This is the finite-Weyl specialization of Jenčová--Ruskai,
-arXiv:0903.2895, §4 and Appendix, equations `Mj` and `basiceq`. It is a
+arXiv:0903.2895, §4 and Appendix. It is a
 fixed-`t`, positive-definite statement and does not derive vanishing of the
 defect from relative-entropy equality.
 
@@ -644,6 +644,92 @@ theorem weyl_resolvent_defect_identity
       (dotProduct (star bbar) (Sbar⁻¹ *ᵥ bbar)).re
   simpa only [hsumS, hsumb, x] using hdef
 
+/-- **The source-`A` fixed-resolvent defect identity for the finite Weyl
+family.** Under the notation of `weyl_resolvent_defect_identity`, replacing
+the source vectors `vec (B g)ᵀ` by `vec (A g)ᵀ` gives the second nonnegative
+defect family needed in the relative-entropy integral representation.
+
+This is the source `X_j = A_j K`, with `K = 1`, in Jenčová--Ruskai,
+arXiv:0903.2895v4, §4 and Appendix. It remains a positive-definite,
+fixed-`t` statement. -/
+theorem weyl_sourceA_resolvent_defect_identity
+    {dS dC : ℕ} [NeZero dC]
+    {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
+    (hρ : ρ.PosDef) (hσ : σ.PosDef)
+    {ζ : ℂ} (hζ : IsPrimitiveRoot ζ dC) {t : ℝ} (ht : 0 < t) :
+    let U := fun g : ZMod dC × ZMod dC ↦
+      (1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ g.1 g.2
+    let q : ℝ := ((dC : ℝ) ^ 2)⁻¹
+    let A := fun g ↦ q • (U g * ρ * (U g)ᴴ)
+    let B := fun g ↦ q • (U g * σ * (U g)ᴴ)
+    let Abar := ∑ g, A g
+    let Bbar := ∑ g, B g
+    let S := fun g ↦ A g ⊗ₖ (1 : Matrix (Fin dS × ZMod dC)
+        (Fin dS × ZMod dC) ℂ) +
+      t • ((1 : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ) ⊗ₖ (B g)ᵀ)
+    let Sbar := Abar ⊗ₖ (1 : Matrix (Fin dS × ZMod dC)
+        (Fin dS × ZMod dC) ℂ) +
+      t • ((1 : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ) ⊗ₖ Bbarᵀ)
+    let a := fun g ↦ Matrix.vec (A g)ᵀ
+    let abar := Matrix.vec Abarᵀ
+    let x := Sbar⁻¹ *ᵥ abar
+    ∑ g, ∑ p, ‖((CFC.sqrt (S g))⁻¹ *ᵥ a g -
+      CFC.sqrt (S g) *ᵥ x) p‖ ^ 2 =
+      ∑ g, (dotProduct (star (a g)) ((S g)⁻¹ *ᵥ a g)).re -
+        (dotProduct (star abar) (Sbar⁻¹ *ᵥ abar)).re := by
+  classical
+  dsimp only
+  let N := Fin dS × ZMod dC
+  let G := ZMod dC × ZMod dC
+  let U : G → Matrix N N ℂ := fun g ↦
+    (1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ g.1 g.2
+  let q : ℝ := ((dC : ℝ) ^ 2)⁻¹
+  let A : G → Matrix N N ℂ := fun g ↦ q • (U g * ρ * (U g)ᴴ)
+  let B : G → Matrix N N ℂ := fun g ↦ q • (U g * σ * (U g)ᴴ)
+  let Abar : Matrix N N ℂ := ∑ g, A g
+  let Bbar : Matrix N N ℂ := ∑ g, B g
+  let S : G → Matrix (N × N) (N × N) ℂ := fun g ↦
+    A g ⊗ₖ (1 : Matrix N N ℂ) +
+      t • ((1 : Matrix N N ℂ) ⊗ₖ (B g)ᵀ)
+  let Sbar : Matrix (N × N) (N × N) ℂ :=
+    Abar ⊗ₖ (1 : Matrix N N ℂ) +
+      t • ((1 : Matrix N N ℂ) ⊗ₖ Bbarᵀ)
+  let a : G → N × N → ℂ := fun g ↦ Matrix.vec (A g)ᵀ
+  let abar : N × N → ℂ := Matrix.vec Abarᵀ
+  let x : N × N → ℂ := Sbar⁻¹ *ᵥ abar
+  have hdCpos : (0 : ℝ) < dC := by
+    exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne dC)
+  have hqpos : 0 < q := by
+    simp only [q]
+    positivity
+  have hU (g : G) : U g ∈ unitary (Matrix N N ℂ) := by
+    exact Matrix.kronecker_mem_unitary (Submonoid.one_mem _)
+      (weyl_mem_unitary hζ g.1 g.2)
+  have hA (g : G) : (A g).PosDef := by
+    have hc := posDef_conj_unitary hρ ⟨U g, hU g⟩
+    simpa only [A, star_eq_conjTranspose] using hc.smul hqpos
+  have hB (g : G) : (B g).PosDef := by
+    have hc := posDef_conj_unitary hσ ⟨U g, hU g⟩
+    simpa only [B, star_eq_conjTranspose] using hc.smul hqpos
+  have hS (g : G) : (S g).PosDef :=
+    superop_leftRight_posDef ht (hA g) (hB g)
+  have hsumS : ∑ g, S g = Sbar := by
+    ext ⟨i, j⟩ ⟨k, l⟩
+    simp only [S, Sbar, Abar, Bbar, Matrix.sum_apply, Matrix.add_apply,
+      Matrix.smul_apply, Matrix.kroneckerMap_apply, Matrix.transpose_apply,
+      Finset.sum_add_distrib, Finset.sum_mul, Finset.mul_sum]
+    rw [Finset.smul_sum]
+  have hsuma : ∑ g, a g = abar := by
+    ext ⟨i, j⟩
+    simp only [a, abar, Abar, Matrix.vec, Matrix.transpose_apply,
+      Matrix.sum_apply, Finset.sum_apply]
+  have hdef := resolvent_sqrt_defect_identity S a hS
+  change (∑ g, ∑ p, ‖((CFC.sqrt (S g))⁻¹ *ᵥ a g -
+      CFC.sqrt (S g) *ᵥ x) p‖ ^ 2) =
+    ∑ g, (dotProduct (star (a g)) ((S g)⁻¹ *ᵥ a g)).re -
+      (dotProduct (star abar) (Sbar⁻¹ *ᵥ abar)).re
+  simpa only [hsumS, hsuma, x] using hdef
+
 /-- **Zero Weyl defect gives the common fixed-resolvent solution.**
 In the positive-definite finite Weyl family, if the difference of resolvent
 quadratic forms in `weyl_resolvent_defect_identity` vanishes at a fixed
@@ -652,8 +738,8 @@ Taking `g = (0, 0)` gives the identity-Weyl summand required in the
 partial-trace equality argument.
 
 This is the zero-defect conclusion of Jenčová--Ruskai,
-arXiv:0903.2895, §4 and Appendix, equations `Mj` and `basiceq` and Theorem
-`thm:eqJp`. It does not assert that equality of relative entropies makes the
+arXiv:0903.2895, §4 and Appendix. It does not assert that equality of
+relative entropies makes the
 displayed defect vanish.
 
 **Scope restriction (positive definite, fixed `t`):** The implication from

--- a/TNLean/Channel/Schwarz/WeylRelativeEntropyIntegral.lean
+++ b/TNLean/Channel/Schwarz/WeylRelativeEntropyIntegral.lean
@@ -1,0 +1,620 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Analysis.RelativeEntropyResolventIntegral
+import TNLean.Channel.Schwarz.PetzEqualityPrerequisites
+import Mathlib.MeasureTheory.Measure.OpenPos
+
+/-!
+# The positive-definite finite-Weyl relative-entropy gap
+
+This file specializes the positive-definite resolvent representation of
+relative entropy to the finite uniform Weyl family used in the partial-trace
+data-processing argument.
+
+## Main results
+
+* `Matrix.weyl_relativeEntropy_gap_integral` proves the exact formula
+  `Gap = ∫ (DefA(t) + t DefB(t)) / (1 + t)`.
+* `Matrix.weyl_sourceB_defect_eq_zero_of_gap_eq_zero` proves that equality of
+  the scalar relative entropies forces the source-`B` defect to vanish for
+  every `t > 0`.
+* `Matrix.weyl_resolvent_eq_of_relativeEntropy_gap_eq_zero` combines this with
+  the fixed-resolvent result to obtain the common source-`B` solution.
+
+## References
+
+* A. Jenčová and M. B. Ruskai, *A Unified Treatment of Convexity of Relative
+  Entropy and Related Trace Functions, with Conditions for Equality*,
+  arXiv:0903.2895v4, §4 and Appendix.
+-/
+
+open Filter MeasureTheory Set Topology
+open scoped Matrix ComplexOrder MatrixOrder Kronecker
+open Matrix
+
+namespace Matrix
+
+/-- A uniformly weighted conjugate in the finite Weyl family. -/
+noncomputable def weightedWeylConjugate
+    {dS dC : ℕ} [NeZero dC] (ζ : ℂ)
+    (M : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ)
+    (g : ZMod dC × ZMod dC) :
+    Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ :=
+  let U := (1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ g.1 g.2
+  (((dC : ℝ) ^ 2)⁻¹) • (U * M * Uᴴ)
+
+/-- The sum of the uniformly weighted finite Weyl conjugates. -/
+noncomputable def weightedWeylAverage
+    {dS dC : ℕ} [NeZero dC] (ζ : ℂ)
+    (M : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ) :
+    Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ :=
+  ∑ g, weightedWeylConjugate ζ M g
+
+/-- The source-`A` quadratic-resolvent defect of the finite Weyl family. -/
+noncomputable def weylSourceAResolventDefect
+    {dS dC : ℕ} [NeZero dC] (ζ : ℂ)
+    (ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ)
+    (t : ℝ) : ℝ :=
+  ∑ g, sourceAResolventQuadratic
+      (weightedWeylConjugate ζ ρ g) (weightedWeylConjugate ζ σ g) t -
+    sourceAResolventQuadratic
+      (weightedWeylAverage ζ ρ) (weightedWeylAverage ζ σ) t
+
+/-- The source-`B` quadratic-resolvent defect of the finite Weyl family. -/
+noncomputable def weylSourceBResolventDefect
+    {dS dC : ℕ} [NeZero dC] (ζ : ℂ)
+    (ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ)
+    (t : ℝ) : ℝ :=
+  ∑ g, sourceBResolventQuadratic
+      (weightedWeylConjugate ζ ρ g) (weightedWeylConjugate ζ σ g) t -
+    sourceBResolventQuadratic
+      (weightedWeylAverage ζ ρ) (weightedWeylAverage ζ σ) t
+
+/-- The finite-Weyl Jensen gap of quantum relative entropy. -/
+noncomputable def weylRelativeEntropyGap
+    {dS dC : ℕ} [NeZero dC] (ζ : ℂ)
+    (ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ) : ℝ :=
+  ∑ g, quantumRelativeEntropy
+      (weightedWeylConjugate ζ ρ g) (weightedWeylConjugate ζ σ g) -
+    quantumRelativeEntropy
+      (weightedWeylAverage ζ ρ) (weightedWeylAverage ζ σ)
+
+private lemma weightedWeylConjugate_posDef
+    {dS dC : ℕ} [NeZero dC]
+    {M : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
+    (hM : M.PosDef) {ζ : ℂ} (hζ : IsPrimitiveRoot ζ dC)
+    (g : ZMod dC × ZMod dC) :
+    (weightedWeylConjugate ζ M g).PosDef := by
+  let U : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ :=
+    (1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ g.1 g.2
+  have hU : U ∈ unitary
+      (Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ) := by
+    exact Matrix.kronecker_mem_unitary (Submonoid.one_mem _)
+      (weyl_mem_unitary hζ g.1 g.2)
+  have hq : 0 < ((dC : ℝ) ^ 2)⁻¹ := by
+    have hdC : (0 : ℝ) < dC := by
+      exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne dC)
+    positivity
+  have hc := posDef_conj_unitary hM ⟨U, hU⟩
+  simpa only [weightedWeylConjugate, U, star_eq_conjTranspose] using
+    hc.smul hq
+
+private lemma weightedWeylAverage_posDef
+    {dS dC : ℕ} [NeZero dC]
+    {M : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
+    (hM : M.PosDef) {ζ : ℂ} (hζ : IsPrimitiveRoot ζ dC) :
+    (weightedWeylAverage ζ M).PosDef := by
+  rw [weightedWeylAverage]
+  exact Matrix.posDef_sum Finset.univ_nonempty fun g _ =>
+    weightedWeylConjugate_posDef hM hζ g
+
+private lemma sum_sum_smul
+    {ι κ M R : Type*} [Fintype ι] [Fintype κ] [AddCommMonoid M]
+    [Monoid R] [DistribMulAction R M] (r : R) (f : ι → κ → M) :
+    (∑ i, ∑ j, r • f i j) = r • ∑ i, ∑ j, f i j := by
+  rw [Finset.smul_sum (r := r) (s := Finset.univ)]
+  simp_rw [Finset.smul_sum (r := r) (s := Finset.univ)]
+
+private lemma trace_sum_re_eq
+    {dS dC : ℕ} [NeZero dC]
+    (B : ZMod dC × ZMod dC →
+      Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ) :
+    ∑ g, (Matrix.trace (B g)).re = (Matrix.trace (∑ g, B g)).re := by
+  rw [← Complex.re_sum, ← Matrix.trace_sum]
+
+/-- Saturation under the right partial trace makes the coefficient-correct
+positive-definite finite-Weyl relative-entropy gap vanish.
+
+The finite Jensen saturation theorem places the uniform coefficient outside
+each relative entropy. The positive-scalar homogeneity of relative entropy
+identifies that expression with the sum of the relative entropies of the
+uniformly weighted Weyl conjugates used in `weylRelativeEntropyGap`.
+
+This is the normalization identity in the finite-Weyl proof of partial-trace
+data processing associated with Hayden--Jozsa--Petz--Winter,
+arXiv:quant-ph/0304007v2, Theorem 3 and equation (8).
+
+**Scope restriction (positive definite):** The singular-support extension is
+not asserted here. Documented in
+`docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex`. -/
+theorem weylRelativeEntropyGap_eq_zero_of_partialTraceRight_eq
+    {dS dC : ℕ} [NeZero dC]
+    {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
+    (hρ : ρ.PosDef) (hσ : σ.PosDef)
+    (heq : quantumRelativeEntropy ρ σ =
+      quantumRelativeEntropy (partialTraceRight ρ) (partialTraceRight σ))
+    {ζ : ℂ} (hζ : IsPrimitiveRoot ζ dC) :
+    weylRelativeEntropyGap ζ ρ σ = 0 := by
+  classical
+  have hsupp : ∀ v : Fin dS × ZMod dC → ℂ, σ.mulVec v = 0 → ρ.mulVec v = 0 := by
+    intro v hv
+    have hv0 : v = 0 := by
+      apply Matrix.mulVec_injective_of_isUnit hσ.isUnit
+      simpa using hv
+    simp [hv0]
+  have hsat := quantumRelativeEntropy_weyl_jensen_eq_of_partialTraceRight_eq
+    hρ.posSemidef hσ.posSemidef hsupp heq hζ
+  let q : ℝ := ((dC : ℝ) ^ 2)⁻¹
+  let U := fun g : ZMod dC × ZMod dC =>
+    (1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ g.1 g.2
+  have hq : 0 < q := by
+    have hdC : (0 : ℝ) < dC := by
+      exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne dC)
+    dsimp [q]
+    positivity
+  have hU (g : ZMod dC × ZMod dC) : U g ∈ unitary
+      (Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ) := by
+    exact Matrix.kronecker_mem_unitary (Submonoid.one_mem _)
+      (weyl_mem_unitary hζ g.1 g.2)
+  have hρg (g : ZMod dC × ZMod dC) : (U g * ρ * (U g)ᴴ).PosDef :=
+    posDef_conj_unitary hρ ⟨U g, hU g⟩
+  have hσg (g : ZMod dC × ZMod dC) : (U g * σ * (U g)ᴴ).PosDef :=
+    posDef_conj_unitary hσ ⟨U g, hU g⟩
+  rw [weylRelativeEntropyGap]
+  have hterm (g : ZMod dC × ZMod dC) :
+      quantumRelativeEntropy (weightedWeylConjugate ζ ρ g)
+          (weightedWeylConjugate ζ σ g) =
+        q * quantumRelativeEntropy (U g * ρ * (U g)ᴴ)
+          (U g * σ * (U g)ᴴ) := by
+    simpa only [weightedWeylConjugate, q, U] using
+      quantumRelativeEntropy_smul_posDef (hA := hρg g) (hB := hσg g) hq
+  rw [Finset.sum_congr rfl (fun g _ => hterm g)]
+  rw [← Finset.mul_sum]
+  have haverageρ : weightedWeylAverage ζ ρ =
+      (((dC : ℂ) ^ 2)⁻¹ • ∑ c : ZMod dC, ∑ e : ZMod dC,
+        ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ c e) * ρ *
+          ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ c e)ᴴ) := by
+    rw [weightedWeylAverage, Fintype.sum_prod_type]
+    simp only [weightedWeylConjugate]
+    rw [sum_sum_smul]
+    ext i j
+    norm_num
+  have haverageσ : weightedWeylAverage ζ σ =
+      (((dC : ℂ) ^ 2)⁻¹ • ∑ c : ZMod dC, ∑ e : ZMod dC,
+        ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ c e) * σ *
+          ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ c e)ᴴ) := by
+    rw [weightedWeylAverage, Fintype.sum_prod_type]
+    simp only [weightedWeylConjugate]
+    rw [sum_sum_smul]
+    ext i j
+    norm_num
+  rw [sub_eq_zero, haverageρ, haverageσ, hsat]
+  simp only [q, U, smul_eq_mul, Fintype.sum_prod_type]
+  simp_rw [Finset.mul_sum]
+
+/-- **The coefficient-correct finite-Weyl relative-entropy gap formula.**
+For positive-definite `ρ` and `σ`, the finite-Weyl Jensen gap is
+\[
+ \int_0^\infty
+ \frac{\operatorname{Def}_A(t)+t\operatorname{Def}_B(t)}{1+t}\,dt.
+\]
+In particular, neither source family is omitted and the source-`B` defect has
+the coefficient `t` dictated by the scalar logarithmic representation.
+
+This is the finite-Weyl specialization of Jenčová--Ruskai,
+arXiv:0903.2895v4, §4, at `p=1`.
+
+**Scope restriction (positive definite):** Singular supports and the later
+Petz sandwich are not asserted here. Documented in
+`docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex`. -/
+theorem weyl_relativeEntropy_gap_integral
+    {dS dC : ℕ} [NeZero dC]
+    {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
+    (hρ : ρ.PosDef) (hσ : σ.PosDef)
+    {ζ : ℂ} (hζ : IsPrimitiveRoot ζ dC) :
+    weylRelativeEntropyGap ζ ρ σ =
+      ∫ t : ℝ in Ioi 0,
+        (weylSourceAResolventDefect ζ ρ σ t +
+          t * weylSourceBResolventDefect ζ ρ σ t) / (1 + t) := by
+  classical
+  let A := fun g : ZMod dC × ZMod dC => weightedWeylConjugate ζ ρ g
+  let B := fun g : ZMod dC × ZMod dC => weightedWeylConjugate ζ σ g
+  let Abar := weightedWeylAverage ζ ρ
+  let Bbar := weightedWeylAverage ζ σ
+  have hA (g : ZMod dC × ZMod dC) : (A g).PosDef :=
+    weightedWeylConjugate_posDef hρ hζ g
+  have hB (g : ZMod dC × ZMod dC) : (B g).PosDef :=
+    weightedWeylConjugate_posDef hσ hζ g
+  have hAbar : Abar.PosDef := weightedWeylAverage_posDef hρ hζ
+  have hBbar : Bbar.PosDef := weightedWeylAverage_posDef hσ hζ
+  have hInt (g : ZMod dC × ZMod dC) :
+      IntegrableOn (relativeEntropyResolventIntegrand (A g) (B g)) (Ioi 0) :=
+    relativeEntropyResolventIntegrand_integrableOn (hA g) (hB g)
+  have hIntBar :
+      IntegrableOn (relativeEntropyResolventIntegrand Abar Bbar) (Ioi 0) :=
+    relativeEntropyResolventIntegrand_integrableOn hAbar hBbar
+  rw [weylRelativeEntropyGap]
+  change (∑ g, quantumRelativeEntropy (A g) (B g)) -
+    quantumRelativeEntropy Abar Bbar = _
+  simp_rw [quantumRelativeEntropy_resolvent_integral (hA _) (hB _)]
+  rw [quantumRelativeEntropy_resolvent_integral hAbar hBbar]
+  rw [← integral_finsetSum Finset.univ (fun g _ => hInt g),
+    ← integral_sub (integrable_finsetSum Finset.univ (fun g _ => hInt g)) hIntBar]
+  apply integral_congr_ae
+  filter_upwards [ae_restrict_mem measurableSet_Ioi] with t ht
+  simp only [relativeEntropyResolventIntegrand, weylSourceAResolventDefect,
+    weylSourceBResolventDefect, A, B, Abar, Bbar]
+  rw [← Finset.sum_div]
+  rw [Finset.sum_add_distrib, Finset.sum_sub_distrib, ← Finset.mul_sum]
+  have htrace : ∑ g, (Matrix.trace (B g)).re = (Matrix.trace Bbar).re := by
+    exact trace_sum_re_eq B
+  rw [htrace]
+  ring
+
+/-- The source-`A` finite-Weyl defect is continuous for positive resolvent
+parameter. -/
+theorem weylSourceAResolventDefect_continuousOn
+    {dS dC : ℕ} [NeZero dC]
+    {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
+    (hρ : ρ.PosDef) (hσ : σ.PosDef)
+    {ζ : ℂ} (hζ : IsPrimitiveRoot ζ dC) :
+    ContinuousOn (weylSourceAResolventDefect ζ ρ σ) (Ioi 0) := by
+  classical
+  let A := fun g : ZMod dC × ZMod dC => weightedWeylConjugate ζ ρ g
+  let B := fun g : ZMod dC × ZMod dC => weightedWeylConjugate ζ σ g
+  let Abar := weightedWeylAverage ζ ρ
+  let Bbar := weightedWeylAverage ζ σ
+  have hA (g : ZMod dC × ZMod dC) : (A g).PosDef :=
+    weightedWeylConjugate_posDef hρ hζ g
+  have hB (g : ZMod dC × ZMod dC) : (B g).PosDef :=
+    weightedWeylConjugate_posDef hσ hζ g
+  have hAbar : Abar.PosDef := weightedWeylAverage_posDef hρ hζ
+  have hBbar : Bbar.PosDef := weightedWeylAverage_posDef hσ hζ
+  have hsum : ContinuousOn
+      (fun t => ∑ g, sourceAResolventQuadratic (A g) (B g) t) (Ioi 0) :=
+    continuousOn_finsetSum Finset.univ fun g _ =>
+      sourceAResolventQuadratic_continuousOn (hA g) (hB g)
+  have hbar : ContinuousOn
+      (sourceAResolventQuadratic Abar Bbar) (Ioi 0) :=
+    sourceAResolventQuadratic_continuousOn hAbar hBbar
+  change ContinuousOn (fun t =>
+    (∑ g, sourceAResolventQuadratic (A g) (B g) t) -
+      sourceAResolventQuadratic Abar Bbar t) (Ioi 0)
+  exact hsum.sub hbar
+
+/-- The source-`B` finite-Weyl defect is continuous for positive resolvent
+parameter. -/
+theorem weylSourceBResolventDefect_continuousOn
+    {dS dC : ℕ} [NeZero dC]
+    {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
+    (hρ : ρ.PosDef) (hσ : σ.PosDef)
+    {ζ : ℂ} (hζ : IsPrimitiveRoot ζ dC) :
+    ContinuousOn (weylSourceBResolventDefect ζ ρ σ) (Ioi 0) := by
+  classical
+  let A := fun g : ZMod dC × ZMod dC => weightedWeylConjugate ζ ρ g
+  let B := fun g : ZMod dC × ZMod dC => weightedWeylConjugate ζ σ g
+  let Abar := weightedWeylAverage ζ ρ
+  let Bbar := weightedWeylAverage ζ σ
+  have hA (g : ZMod dC × ZMod dC) : (A g).PosDef :=
+    weightedWeylConjugate_posDef hρ hζ g
+  have hB (g : ZMod dC × ZMod dC) : (B g).PosDef :=
+    weightedWeylConjugate_posDef hσ hζ g
+  have hAbar : Abar.PosDef := weightedWeylAverage_posDef hρ hζ
+  have hBbar : Bbar.PosDef := weightedWeylAverage_posDef hσ hζ
+  have hsum : ContinuousOn
+      (fun t => ∑ g, sourceBResolventQuadratic (A g) (B g) t) (Ioi 0) :=
+    continuousOn_finsetSum Finset.univ fun g _ =>
+      sourceBResolventQuadratic_continuousOn (hA g) (hB g)
+  have hbar : ContinuousOn
+      (sourceBResolventQuadratic Abar Bbar) (Ioi 0) :=
+    sourceBResolventQuadratic_continuousOn hAbar hBbar
+  change ContinuousOn (fun t =>
+    (∑ g, sourceBResolventQuadratic (A g) (B g) t) -
+      sourceBResolventQuadratic Abar Bbar t) (Ioi 0)
+  exact hsum.sub hbar
+
+/-- The source-`A` finite-Weyl resolvent defect is nonnegative at every
+positive resolvent parameter. -/
+theorem weylSourceAResolventDefect_nonneg
+    {dS dC : ℕ} [NeZero dC]
+    {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
+    (hρ : ρ.PosDef) (hσ : σ.PosDef)
+    {ζ : ℂ} (hζ : IsPrimitiveRoot ζ dC) {t : ℝ} (ht : 0 < t) :
+    0 ≤ weylSourceAResolventDefect ζ ρ σ t := by
+  classical
+  let N := Fin dS × ZMod dC
+  let G := ZMod dC × ZMod dC
+  let U : G → Matrix N N ℂ := fun g =>
+    (1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ g.1 g.2
+  let q : ℝ := ((dC : ℝ) ^ 2)⁻¹
+  let A : G → Matrix N N ℂ := fun g => q • (U g * ρ * (U g)ᴴ)
+  let B : G → Matrix N N ℂ := fun g => q • (U g * σ * (U g)ᴴ)
+  let Abar : Matrix N N ℂ := ∑ g, A g
+  let Bbar : Matrix N N ℂ := ∑ g, B g
+  let S : G → Matrix (N × N) (N × N) ℂ := fun g =>
+    A g ⊗ₖ (1 : Matrix N N ℂ) +
+      t • ((1 : Matrix N N ℂ) ⊗ₖ (B g)ᵀ)
+  let Sbar : Matrix (N × N) (N × N) ℂ :=
+    Abar ⊗ₖ (1 : Matrix N N ℂ) +
+      t • ((1 : Matrix N N ℂ) ⊗ₖ Bbarᵀ)
+  let a : G → N × N → ℂ := fun g => Matrix.vec (A g)ᵀ
+  let abar : N × N → ℂ := Matrix.vec Abarᵀ
+  let x : N × N → ℂ := Sbar⁻¹ *ᵥ abar
+  have hid :
+      ∑ g, ∑ p, ‖((CFC.sqrt (S g))⁻¹ *ᵥ a g -
+        CFC.sqrt (S g) *ᵥ x) p‖ ^ 2 =
+        ∑ g, sourceAResolventQuadratic (A g) (B g) t -
+          sourceAResolventQuadratic Abar Bbar t := by
+    have h := weyl_sourceA_resolvent_defect_identity hρ hσ hζ ht
+    simpa only [U, q, A, B, Abar, Bbar, S, Sbar, a, abar, x,
+      sourceAResolventQuadratic] using h
+  have hnonneg :
+      0 ≤ ∑ g, sourceAResolventQuadratic (A g) (B g) t -
+        sourceAResolventQuadratic Abar Bbar t := by
+    rw [← hid]
+    positivity
+  simpa only [weylSourceAResolventDefect, weightedWeylConjugate,
+    weightedWeylAverage, U, q, A, B, Abar, Bbar] using hnonneg
+
+/-- The source-`B` finite-Weyl resolvent defect is nonnegative at every
+positive resolvent parameter. -/
+theorem weylSourceBResolventDefect_nonneg
+    {dS dC : ℕ} [NeZero dC]
+    {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
+    (hρ : ρ.PosDef) (hσ : σ.PosDef)
+    {ζ : ℂ} (hζ : IsPrimitiveRoot ζ dC) {t : ℝ} (ht : 0 < t) :
+    0 ≤ weylSourceBResolventDefect ζ ρ σ t := by
+  classical
+  let N := Fin dS × ZMod dC
+  let G := ZMod dC × ZMod dC
+  let U : G → Matrix N N ℂ := fun g =>
+    (1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ g.1 g.2
+  let q : ℝ := ((dC : ℝ) ^ 2)⁻¹
+  let A : G → Matrix N N ℂ := fun g => q • (U g * ρ * (U g)ᴴ)
+  let B : G → Matrix N N ℂ := fun g => q • (U g * σ * (U g)ᴴ)
+  let Abar : Matrix N N ℂ := ∑ g, A g
+  let Bbar : Matrix N N ℂ := ∑ g, B g
+  let S : G → Matrix (N × N) (N × N) ℂ := fun g =>
+    A g ⊗ₖ (1 : Matrix N N ℂ) +
+      t • ((1 : Matrix N N ℂ) ⊗ₖ (B g)ᵀ)
+  let Sbar : Matrix (N × N) (N × N) ℂ :=
+    Abar ⊗ₖ (1 : Matrix N N ℂ) +
+      t • ((1 : Matrix N N ℂ) ⊗ₖ Bbarᵀ)
+  let b : G → N × N → ℂ := fun g => Matrix.vec (B g)ᵀ
+  let bbar : N × N → ℂ := Matrix.vec Bbarᵀ
+  let x : N × N → ℂ := Sbar⁻¹ *ᵥ bbar
+  have hid :
+      ∑ g, ∑ p, ‖((CFC.sqrt (S g))⁻¹ *ᵥ b g -
+        CFC.sqrt (S g) *ᵥ x) p‖ ^ 2 =
+        ∑ g, sourceBResolventQuadratic (A g) (B g) t -
+          sourceBResolventQuadratic Abar Bbar t := by
+    have h := weyl_resolvent_defect_identity hρ hσ hζ ht
+    simpa only [U, q, A, B, Abar, Bbar, S, Sbar, b, bbar, x,
+      sourceBResolventQuadratic] using h
+  have hnonneg :
+      0 ≤ ∑ g, sourceBResolventQuadratic (A g) (B g) t -
+        sourceBResolventQuadratic Abar Bbar t := by
+    rw [← hid]
+    positivity
+  simpa only [weylSourceBResolventDefect, weightedWeylConjugate,
+    weightedWeylAverage, U, q, A, B, Abar, Bbar] using hnonneg
+
+/-- The coefficient-correct finite-Weyl gap integrand is integrable on the
+positive half-line. This assertion is separate from the value of its integral,
+so it can be used in the equality case. -/
+theorem weylRelativeEntropyGapIntegrand_integrableOn
+    {dS dC : ℕ} [NeZero dC]
+    {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
+    (hρ : ρ.PosDef) (hσ : σ.PosDef)
+    {ζ : ℂ} (hζ : IsPrimitiveRoot ζ dC) :
+    IntegrableOn (fun t : ℝ =>
+      (weylSourceAResolventDefect ζ ρ σ t +
+        t * weylSourceBResolventDefect ζ ρ σ t) / (1 + t)) (Ioi 0) := by
+  classical
+  let A := fun g : ZMod dC × ZMod dC => weightedWeylConjugate ζ ρ g
+  let B := fun g : ZMod dC × ZMod dC => weightedWeylConjugate ζ σ g
+  let Abar := weightedWeylAverage ζ ρ
+  let Bbar := weightedWeylAverage ζ σ
+  have hA (g : ZMod dC × ZMod dC) : (A g).PosDef :=
+    weightedWeylConjugate_posDef hρ hζ g
+  have hB (g : ZMod dC × ZMod dC) : (B g).PosDef :=
+    weightedWeylConjugate_posDef hσ hζ g
+  have hAbar : Abar.PosDef := weightedWeylAverage_posDef hρ hζ
+  have hBbar : Bbar.PosDef := weightedWeylAverage_posDef hσ hζ
+  have hInt (g : ZMod dC × ZMod dC) :
+      IntegrableOn (relativeEntropyResolventIntegrand (A g) (B g)) (Ioi 0) :=
+    relativeEntropyResolventIntegrand_integrableOn (hA g) (hB g)
+  have hIntBar :
+      IntegrableOn (relativeEntropyResolventIntegrand Abar Bbar) (Ioi 0) :=
+    relativeEntropyResolventIntegrand_integrableOn hAbar hBbar
+  have hbase : IntegrableOn (fun t =>
+      (∑ g, relativeEntropyResolventIntegrand (A g) (B g) t) -
+        relativeEntropyResolventIntegrand Abar Bbar t) (Ioi 0) :=
+    (integrable_finsetSum Finset.univ fun g _ => hInt g).sub hIntBar
+  refine hbase.congr_fun ?_ measurableSet_Ioi
+  intro t ht
+  simp only [relativeEntropyResolventIntegrand, weylSourceAResolventDefect,
+    weylSourceBResolventDefect, A, B, Abar, Bbar]
+  rw [← Finset.sum_div]
+  rw [Finset.sum_add_distrib, Finset.sum_sub_distrib, ← Finset.mul_sum]
+  have htrace : ∑ g, (Matrix.trace (B g)).re = (Matrix.trace Bbar).re := by
+    exact trace_sum_re_eq B
+  rw [htrace]
+  ring
+
+/-- The coefficient-correct finite-Weyl gap integrand is continuous on the
+positive half-line. -/
+theorem weylRelativeEntropyGapIntegrand_continuousOn
+    {dS dC : ℕ} [NeZero dC]
+    {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
+    (hρ : ρ.PosDef) (hσ : σ.PosDef)
+    {ζ : ℂ} (hζ : IsPrimitiveRoot ζ dC) :
+    ContinuousOn (fun t : ℝ =>
+      (weylSourceAResolventDefect ζ ρ σ t +
+        t * weylSourceBResolventDefect ζ ρ σ t) / (1 + t)) (Ioi 0) := by
+  have hA := weylSourceAResolventDefect_continuousOn hρ hσ hζ
+  have hB := weylSourceBResolventDefect_continuousOn hρ hσ hζ
+  have hnum := hA.add (continuousOn_id.mul hB)
+  have hden : ContinuousOn (fun t : ℝ => 1 + t) (Ioi 0) :=
+    continuousOn_const.add continuousOn_id
+  exact hnum.div hden fun t ht hzero => by
+    have ht0 : 0 < t := ht
+    have : 0 < 1 + t := by linarith
+    exact (ne_of_gt this) hzero
+
+/-- The coefficient-correct finite-Weyl gap integrand is nonnegative on the
+positive half-line. -/
+theorem weylRelativeEntropyGapIntegrand_nonneg
+    {dS dC : ℕ} [NeZero dC]
+    {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
+    (hρ : ρ.PosDef) (hσ : σ.PosDef)
+    {ζ : ℂ} (hζ : IsPrimitiveRoot ζ dC)
+    {t : ℝ} (ht : 0 < t) :
+    0 ≤ (weylSourceAResolventDefect ζ ρ σ t +
+      t * weylSourceBResolventDefect ζ ρ σ t) / (1 + t) := by
+  have hA := weylSourceAResolventDefect_nonneg hρ hσ hζ ht
+  have hB := weylSourceBResolventDefect_nonneg hρ hσ hζ ht
+  exact div_nonneg (add_nonneg hA (mul_nonneg (le_of_lt ht) hB)) (by linarith)
+
+/-- If the positive-definite finite-Weyl relative-entropy gap vanishes, then
+the source-`B` resolvent defect vanishes at every `t > 0`.
+
+The passage from almost-everywhere vanishing to pointwise vanishing uses the
+continuity of both defect families. The domain is explicitly `t > 0`; no
+claim is made at the endpoint `t = 0`.
+
+This is the equality argument of Jenčová--Ruskai,
+arXiv:0903.2895v4, §4, lines 652--674.
+
+**Scope restriction (positive definite):** Singular supports and the Petz
+sandwich remain outside this theorem. Documented in
+`docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex`. -/
+theorem weyl_sourceB_defect_eq_zero_of_gap_eq_zero
+    {dS dC : ℕ} [NeZero dC]
+    {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
+    (hρ : ρ.PosDef) (hσ : σ.PosDef)
+    {ζ : ℂ} (hζ : IsPrimitiveRoot ζ dC)
+    (hgap : weylRelativeEntropyGap ζ ρ σ = 0) :
+    ∀ {t : ℝ}, 0 < t → weylSourceBResolventDefect ζ ρ σ t = 0 := by
+  let f : ℝ → ℝ := fun t =>
+    (weylSourceAResolventDefect ζ ρ σ t +
+      t * weylSourceBResolventDefect ζ ρ σ t) / (1 + t)
+  have hfInt : IntegrableOn f (Ioi 0) :=
+    weylRelativeEntropyGapIntegrand_integrableOn hρ hσ hζ
+  have hfCont : ContinuousOn f (Ioi 0) :=
+    weylRelativeEntropyGapIntegrand_continuousOn hρ hσ hζ
+  have hfNonneg : ∀ t ∈ Ioi (0 : ℝ), 0 ≤ f t := by
+    intro t ht
+    exact weylRelativeEntropyGapIntegrand_nonneg hρ hσ hζ ht
+  have hIntZero : ∫ t in Ioi (0 : ℝ), f t = 0 := by
+    rw [← weyl_relativeEntropy_gap_integral hρ hσ hζ]
+    exact hgap
+  have haeNonneg : 0 ≤ᵐ[volume.restrict (Ioi (0 : ℝ))] f := by
+    filter_upwards [ae_restrict_mem measurableSet_Ioi] with t ht
+    exact hfNonneg t ht
+  have haeZero : f =ᵐ[volume.restrict (Ioi (0 : ℝ))] 0 :=
+    (integral_eq_zero_iff_of_nonneg_ae haeNonneg hfInt).mp hIntZero
+  have hpointZero : EqOn f 0 (Ioi (0 : ℝ)) :=
+    Measure.eqOn_open_of_ae_eq haeZero isOpen_Ioi hfCont continuousOn_const
+  intro t ht
+  have hfZero : f t = 0 := hpointZero ht
+  have hden : (1 + t : ℝ) ≠ 0 := by linarith
+  have hsum : weylSourceAResolventDefect ζ ρ σ t +
+      t * weylSourceBResolventDefect ζ ρ σ t = 0 := by
+    rcases (div_eq_zero_iff.mp hfZero) with h | h
+    · exact h
+    · exact (hden h).elim
+  have hA := weylSourceAResolventDefect_nonneg hρ hσ hζ ht
+  have hB := weylSourceBResolventDefect_nonneg hρ hσ hζ ht
+  nlinarith
+
+/-- Equality in the positive-definite finite-Weyl relative-entropy inequality
+gives the common source-`B` fixed-resolvent solution for every `t > 0`.
+
+This combines the coefficient-correct integral equality argument with
+`weyl_resolvent_eq_of_defect_eq_zero`; it corresponds to the equality
+analysis of Jenčová--Ruskai, arXiv:0903.2895v4, §4 and Appendix.
+
+**Scope restriction (positive definite):** The inverse-square-root integral
+and singular-support extension are not asserted here. Documented in
+`docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex`. -/
+theorem weyl_resolvent_eq_of_relativeEntropy_gap_eq_zero
+    {dS dC : ℕ} [NeZero dC]
+    {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
+    (hρ : ρ.PosDef) (hσ : σ.PosDef)
+    {ζ : ℂ} (hζ : IsPrimitiveRoot ζ dC)
+    (hgap : weylRelativeEntropyGap ζ ρ σ = 0)
+    {t : ℝ} (ht : 0 < t) :
+    let U := fun g : ZMod dC × ZMod dC =>
+      (1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ g.1 g.2
+    let q : ℝ := ((dC : ℝ) ^ 2)⁻¹
+    let A := fun g => q • (U g * ρ * (U g)ᴴ)
+    let B := fun g => q • (U g * σ * (U g)ᴴ)
+    let Abar := ∑ g, A g
+    let Bbar := ∑ g, B g
+    let S := fun g => A g ⊗ₖ (1 : Matrix (Fin dS × ZMod dC)
+        (Fin dS × ZMod dC) ℂ) +
+      t • ((1 : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ) ⊗ₖ (B g)ᵀ)
+    let Sbar := Abar ⊗ₖ (1 : Matrix (Fin dS × ZMod dC)
+        (Fin dS × ZMod dC) ℂ) +
+      t • ((1 : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ) ⊗ₖ Bbarᵀ)
+    let b := fun g => Matrix.vec (B g)ᵀ
+    let bbar := Matrix.vec Bbarᵀ
+    ∀ g, (S g)⁻¹ *ᵥ b g = Sbar⁻¹ *ᵥ bbar := by
+  apply weyl_resolvent_eq_of_defect_eq_zero hρ hσ hζ ht
+  simpa only [weylSourceBResolventDefect, sourceBResolventQuadratic,
+    weightedWeylConjugate, weightedWeylAverage] using
+    weyl_sourceB_defect_eq_zero_of_gap_eq_zero hρ hσ hζ hgap ht
+
+/-- Saturation of relative entropy under the right partial trace gives the
+common source-`B` fixed-resolvent solution for every positive parameter.
+
+This combines the finite-Weyl Jensen saturation theorem, positive-scalar
+homogeneity, and the coefficient-correct gap integral. It is the
+positive-definite resolvent conclusion corresponding to Jenčová--Ruskai,
+arXiv:0903.2895v4, §4 and Appendix.
+
+**Scope restriction (positive definite):** The inverse-square-root limit and
+singular-support extension are not asserted here. Documented in
+`docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex`. -/
+theorem weyl_resolvent_eq_of_partialTraceRight_eq
+    {dS dC : ℕ} [NeZero dC]
+    {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
+    (hρ : ρ.PosDef) (hσ : σ.PosDef)
+    (heq : quantumRelativeEntropy ρ σ =
+      quantumRelativeEntropy (partialTraceRight ρ) (partialTraceRight σ))
+    {ζ : ℂ} (hζ : IsPrimitiveRoot ζ dC)
+    {t : ℝ} (ht : 0 < t) :
+    let U := fun g : ZMod dC × ZMod dC =>
+      (1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ g.1 g.2
+    let q : ℝ := ((dC : ℝ) ^ 2)⁻¹
+    let A := fun g => q • (U g * ρ * (U g)ᴴ)
+    let B := fun g => q • (U g * σ * (U g)ᴴ)
+    let Abar := ∑ g, A g
+    let Bbar := ∑ g, B g
+    let S := fun g => A g ⊗ₖ (1 : Matrix (Fin dS × ZMod dC)
+        (Fin dS × ZMod dC) ℂ) +
+      t • ((1 : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ) ⊗ₖ (B g)ᵀ)
+    let Sbar := Abar ⊗ₖ (1 : Matrix (Fin dS × ZMod dC)
+        (Fin dS × ZMod dC) ℂ) +
+      t • ((1 : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ) ⊗ₖ Bbarᵀ)
+    let b := fun g => Matrix.vec (B g)ᵀ
+    let bbar := Matrix.vec Bbarᵀ
+    ∀ g, (S g)⁻¹ *ᵥ b g = Sbar⁻¹ *ᵥ bbar := by
+  exact weyl_resolvent_eq_of_relativeEntropy_gap_eq_zero hρ hσ hζ
+    (weylRelativeEntropyGap_eq_zero_of_partialTraceRight_eq hρ hσ heq hζ) ht
+
+end Matrix

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -2410,6 +2410,137 @@ Theorem~\ref{thm:trace_norm_abs}.
     \]
 \end{proof}
 
+\begin{lemma}[Positive homogeneity of relative entropy]
+    \label{lem:relative_entropy_positive_homogeneity}
+    \lean{Matrix.quantumRelativeEntropy_smul_posDef}
+    \leanok
+    \uses{def:quantum_relative_entropy}
+    If $A$ and $B$ are positive definite and $c>0$, then
+    \[
+        D(cA\Vert cB)=cD(A\Vert B).
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    The functional-calculus identity
+    $\log(cA)=(\log c)\mathbf 1+\log A$, and its analogue for $B$,
+    show that the scalar logarithmic terms cancel in
+    $\log(cA)-\log(cB)$.  Linearity of the trace then gives the result.
+\end{proof}
+
+\begin{theorem}[Partial-trace saturation gives zero weighted Weyl gap]
+    \label{thm:partial_trace_saturation_weyl_gap_zero}
+    \lean{Matrix.weylRelativeEntropyGap_eq_zero_of_partialTraceRight_eq}
+    \leanok
+    \uses{thm:relative_entropy_weyl_jensen_eq,
+        lem:relative_entropy_positive_homogeneity}
+    Let $\rho$ and $\sigma$ be positive definite, and suppose that
+    \[
+        D(\rho\Vert\sigma)
+          =D(\tr_C\rho\Vert\tr_C\sigma).
+    \]
+    For the uniformly weighted Weyl conjugates
+    $A_g=d_C^{-2}U_g\rho U_g^\dagger$ and
+    $B_g=d_C^{-2}U_g\sigma U_g^\dagger$, put
+    $A=\sum_gA_g$ and $B=\sum_gB_g$.  Then
+    \[
+        \sum_gD(A_g\Vert B_g)-D(A\Vert B)=0.
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    Positive definiteness of $\sigma$ makes the support condition in
+    Theorem~\ref{thm:relative_entropy_weyl_jensen_eq} automatic.  That theorem
+    gives the equality with $d_C^{-2}$ multiplying each scalar relative
+    entropy.  Lemma~\ref{lem:relative_entropy_positive_homogeneity} moves this
+    coefficient inside both matrix arguments, which is precisely the stated
+    weighted gap.
+\end{proof}
+
+\begin{lemma}[Scalar logarithmic resolvent integral]
+    \label{lem:relative_entropy_scalar_resolvent_integral}
+    \lean{Matrix.relativeEntropyScalar}
+    \lean{Matrix.relativeEntropyScalar_integrableOn}
+    \lean{Matrix.integral_relativeEntropyScalar}
+    \leanok
+    Let $a,b>0$.  Then the function
+    \[
+      t\longmapsto
+      \frac{a^2/(a+tb)-b+t b^2/(a+tb)}{1+t}
+    \]
+    is integrable on $(0,\infty)$, and
+    \[
+      \int_0^\infty
+      \frac{a^2/(a+tb)-b+t b^2/(a+tb)}{1+t}\,dt
+      =a(\log a-\log b).
+    \]
+    This is the scalar identity underlying the spectral representation in
+    Jen\v{c}ov\'a--Ruskai, arXiv:0903.2895v4, \S4.
+\end{lemma}
+
+\begin{proof}\leanok
+    The integrand is the derivative of
+    \[
+      a\bigl(\log(1+t)-\log(a+tb)\bigr).
+    \]
+    Its value at $t=0$ is $-a\log a$, whereas its limit as
+    $t\to\infty$ is $-a\log b$.  The derivative has constant sign, according
+    as $a-b$ is positive or negative, and is therefore integrable.  The
+    fundamental theorem of calculus gives the stated value.
+\end{proof}
+
+\begin{theorem}[Spectral resolvent representation of relative entropy]
+    \label{thm:relative_entropy_resolvent_integral}
+    \lean{Matrix.sourceAResolventQuadratic}
+    \lean{Matrix.sourceBResolventQuadratic}
+    \lean{Matrix.leftRight_mulVec_vec_transpose}
+    \lean{Matrix.sourceA_resolvent_quadratic_spectral}
+    \lean{Matrix.sourceB_resolvent_quadratic_spectral}
+    \lean{Matrix.sourceAResolventQuadratic_continuousOn}
+    \lean{Matrix.sourceBResolventQuadratic_continuousOn}
+    \lean{Matrix.quantumRelativeEntropy_posDef_spectral}
+    \lean{Matrix.relativeEntropyResolventIntegrand}
+    \lean{Matrix.relativeEntropyResolventIntegrand_integrableOn}
+    \lean{Matrix.relativeEntropyResolventIntegrand_continuousOn}
+    \lean{Matrix.quantumRelativeEntropy_resolvent_integral}
+    \leanok
+    \uses{def:quantum_relative_entropy,
+        lem:relative_entropy_scalar_resolvent_integral}
+    Let $A$ and $B$ be positive definite, with spectral resolutions
+    $A=\sum_i\alpha_i|u_i\rangle\langle u_i|$ and
+    $B=\sum_j\beta_j|v_j\rangle\langle v_j|$.  Put
+    $w_{ij}=\langle u_i,v_j\rangle$.  Let $L_A$ and $R_B$ denote left and
+    right multiplication, $L_A(X)=AX$ and $R_B(X)=XB$.  Then, for $t>0$,
+    \begin{align*}
+      \operatorname{Re}\langle A,(L_A+tR_B)^{-1}A\rangle_{\rm HS}
+        &=\sum_{i,j}\frac{\alpha_i^2}{\alpha_i+t\beta_j}|w_{ij}|^2,\\
+      \operatorname{Re}\langle B,(L_A+tR_B)^{-1}B\rangle_{\rm HS}
+        &=\sum_{i,j}\frac{\beta_j^2}{\alpha_i+t\beta_j}|w_{ij}|^2.
+    \end{align*}
+    Both quadratic forms are continuous on $(0,\infty)$.  Moreover,
+    \[
+      D(A\Vert B)=\int_0^\infty
+      \frac{
+        \operatorname{Re}\langle A,(L_A+tR_B)^{-1}A\rangle_{\rm HS}
+        -\operatorname{Re}\operatorname{Tr}B
+        +t\operatorname{Re}\langle B,(L_A+tR_B)^{-1}B\rangle_{\rm HS}}
+      {1+t}\,dt,
+    \]
+    and the displayed integrand is continuous and integrable on the positive
+    half-line.  This is the positive-definite spectral route of
+    Jen\v{c}ov\'a--Ruskai, arXiv:0903.2895v4, \S4.
+\end{theorem}
+
+\begin{proof}\leanok
+    Vectorization sends $L_A+tR_B$ to
+    $A\otimes\mathbf 1+t\mathbf 1\otimes B^{\mathsf T}$.  The vectors
+    $u_i\otimes\overline{v_j}$ diagonalize this matrix with eigenvalues
+    $\alpha_i+t\beta_j$, which proves the two quadratic-form identities.
+    Insert them into the integrand, use
+    $\sum_i|w_{ij}|^2=1$, and apply the preceding scalar integral term by
+    term.  The same finite spectral sum proves continuity and integrability.
+\end{proof}
+
 \begin{theorem}[Fixed-resolvent defect identity for the Weyl family]
     \label{thm:weyl_resolvent_defect_identity}
     \lean{Matrix.weyl_resolvent_defect_identity}
@@ -2439,8 +2570,7 @@ Theorem~\ref{thm:trace_norm_abs}.
           \langle B,T^{-1}(B)\rangle_{\mathrm{HS}}.
     \]
     This is the positive-definite, fixed-$t$ identity in
-    Jen\v{c}ov\'a--Ruskai, arXiv:0903.2895, \S4 and Appendix, equations
-    \texttt{Mj} and \texttt{basiceq}.  It does not infer zero defect from
+    Jen\v{c}ov\'a--Ruskai, arXiv:0903.2895, \S4 and Appendix.  It does not infer zero defect from
     equality of relative entropies and makes no assertion about singular
     supports.
 \end{theorem}
@@ -2464,6 +2594,86 @@ Theorem~\ref{thm:trace_norm_abs}.
         =\operatorname{Re}\langle r_g,S_g^{-1}r_g\rangle.
     \]
     Summing proves the identity.
+\end{proof}
+
+\begin{theorem}[Source-$A$ fixed-resolvent defect identity]
+    \label{thm:weyl_sourceA_resolvent_defect_identity}
+    \lean{Matrix.weyl_sourceA_resolvent_defect_identity}
+    \leanok
+    \uses{thm:weyl_operator_unitary}
+    Under the notation of Theorem~\ref{thm:weyl_resolvent_defect_identity},
+    set $\Gamma_t=T^{-1}(A)$.  Then, for every $t>0$,
+    \[
+      \sum_g\left\|
+        T_g^{-1/2}(A_g)-T_g^{1/2}(\Gamma_t)
+      \right\|_{\rm HS}^2
+      =\sum_g\operatorname{Re}
+        \langle A_g,T_g^{-1}(A_g)\rangle_{\rm HS}
+       -\operatorname{Re}\langle A,T^{-1}(A)\rangle_{\rm HS}.
+    \]
+    This is the second defect family in Jen\v{c}ov\'a--Ruskai,
+    arXiv:0903.2895v4, \S4 and Appendix.
+\end{theorem}
+
+\begin{proof}\leanok
+    Apply the residual identity of
+    Theorem~\ref{thm:weyl_resolvent_defect_identity} with
+    $a_g=\operatorname{vec}(A_g^{\mathsf T})$ and
+    $\bar a=\operatorname{vec}(A^{\mathsf T})$.  Thus
+    \[
+      \sum_g\langle a_g,S_g^{-1}a_g\rangle
+        -\langle\bar a,S^{-1}\bar a\rangle
+      =\sum_g\|S_g^{-1/2}a_g-S_g^{1/2}S^{-1}\bar a\|^2,
+    \]
+    which is the asserted source-$A$ identity.
+\end{proof}
+
+\begin{theorem}[Finite-Weyl relative-entropy gap integral]
+    \label{thm:weyl_relative_entropy_gap_integral}
+    \lean{Matrix.weightedWeylConjugate}
+    \lean{Matrix.weightedWeylAverage}
+    \lean{Matrix.weylSourceAResolventDefect}
+    \lean{Matrix.weylSourceBResolventDefect}
+    \lean{Matrix.weylRelativeEntropyGap}
+    \lean{Matrix.weyl_relativeEntropy_gap_integral}
+    \lean{Matrix.weylSourceAResolventDefect_continuousOn}
+    \lean{Matrix.weylSourceBResolventDefect_continuousOn}
+    \lean{Matrix.weylSourceAResolventDefect_nonneg}
+    \lean{Matrix.weylSourceBResolventDefect_nonneg}
+    \lean{Matrix.weylRelativeEntropyGapIntegrand_integrableOn}
+    \lean{Matrix.weylRelativeEntropyGapIntegrand_continuousOn}
+    \lean{Matrix.weylRelativeEntropyGapIntegrand_nonneg}
+    \leanok
+    \uses{thm:relative_entropy_resolvent_integral,
+        thm:weyl_resolvent_defect_identity,
+        thm:weyl_sourceA_resolvent_defect_identity}
+    For the positive definite finite-Weyl family, let
+    \[
+      \operatorname{Def}_A(t)=
+        \sum_g\operatorname{Re}\langle A_g,T_g^{-1}(A_g)\rangle_{\rm HS}
+        -\operatorname{Re}\langle A,T^{-1}(A)\rangle_{\rm HS}
+    \]
+    and define $\operatorname{Def}_B(t)$ analogously, with the real parts of
+    the corresponding source-$B$ pairings.  Then both defects are
+    nonnegative and continuous for $t>0$, and
+    \[
+      \sum_gD(A_g\Vert B_g)-D(A\Vert B)
+      =\int_0^\infty
+        \frac{\operatorname{Def}_A(t)+t\operatorname{Def}_B(t)}{1+t}\,dt.
+    \]
+    The integrand is continuous, nonnegative, and integrable on
+    $(0,\infty)$.  The coefficient of the source-$B$ defect is exactly $t$,
+    as prescribed by the integral formula and equality analysis of
+    Jen\v{c}ov\'a--Ruskai, arXiv:0903.2895v4, \S4.
+\end{theorem}
+
+\begin{proof}\leanok
+    Apply Theorem~\ref{thm:relative_entropy_resolvent_integral} to each pair
+    $(A_g,B_g)$ and to $(A,B)$, and interchange the finite sum with the
+    integral.  The trace terms cancel because $B=\sum_gB_g$.  The two
+    fixed-resolvent identities write the defects as sums of squared norms,
+    proving nonnegativity.  Continuity and integrability follow from the
+    corresponding spectral assertions before taking the finite difference.
 \end{proof}
 
 \begin{theorem}[Zero Weyl defect gives the common resolvent solution]
@@ -2493,6 +2703,42 @@ Theorem~\ref{thm:trace_norm_abs}.
     $S_g^{-1/2}(b_g-S_gx)=0$ for every $g$.  Invertibility of
     $S_g^{-1/2}$ gives $b_g=S_gx$, and hence
     $S_g^{-1}b_g=x=S^{-1}\sum_hb_h$.
+\end{proof}
+
+\begin{theorem}[Zero finite-Weyl gap gives the common resolvent solution]
+    \label{thm:weyl_relative_entropy_zero_gap_resolvent}
+    \lean{Matrix.weyl_sourceB_defect_eq_zero_of_gap_eq_zero}
+    \lean{Matrix.weyl_resolvent_eq_of_relativeEntropy_gap_eq_zero}
+    \lean{Matrix.weyl_resolvent_eq_of_partialTraceRight_eq}
+    \leanok
+    \uses{thm:partial_trace_saturation_weyl_gap_zero,
+        thm:weyl_relative_entropy_gap_integral,
+        thm:weyl_resolvent_zero_defect}
+    Under the positive-definite finite-Weyl hypotheses, suppose that
+    \[
+      \sum_gD(A_g\Vert B_g)-D(A\Vert B)=0.
+    \]
+    Then $\operatorname{Def}_B(t)=0$ for every $t>0$, and consequently
+    \[
+      T_g^{-1}(B_g)=T^{-1}(B)
+    \]
+    for every $t>0$ and every Weyl index $g$.
+    In particular, equality of relative entropy under the right partial trace
+    implies this conclusion by
+    Theorem~\ref{thm:partial_trace_saturation_weyl_gap_zero}.
+    This is the positive-definite conclusion of the equality argument in
+    Jen\v{c}ov\'a--Ruskai, arXiv:0903.2895v4, \S4 and Appendix.  It makes no
+    assertion at $t=0$ or for singular inputs.
+\end{theorem}
+
+\begin{proof}\leanok
+    The integrand in
+    Theorem~\ref{thm:weyl_relative_entropy_gap_integral} is nonnegative and
+    has integral zero, hence it vanishes almost everywhere.  Its continuity
+    improves this to vanishing at every $t>0$.  Since
+    $\operatorname{Def}_A(t)\geq0$, $\operatorname{Def}_B(t)\geq0$, and
+    $t/(1+t)>0$, it follows that $\operatorname{Def}_B(t)=0$.  Theorem
+    \ref{thm:weyl_resolvent_zero_defect} now gives the common solution.
 \end{proof}
 
 \begin{lemma}[Maximally mixed support-sandwich normalization]

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -299,19 +299,46 @@ the residuals $R_g=B_g-T_g(\Lambda_t)$ gives the exact identity
 Consequently, if the right-hand side vanishes, then
 $T_g^{-1}(B_g)=\Lambda_t$ for every $g$, in particular for the identity Weyl
 element.  This is the fixed-$t$ calculation of Jen\v{c}ov\'a--Ruskai,
-arXiv:0903.2895, \S4 and Appendix, equations \texttt{Mj} and
-\texttt{basiceq}.
+arXiv:0903.2895v4, \S4 and Appendix.
 \footnote{Formal declarations:
 \leanid{Matrix.weyl_resolvent_defect_identity} and
 \leanid{Matrix.weyl_resolvent_eq_of_defect_eq_zero} in
 \path{TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean}.}
-This result is deliberately restricted to positive definite inputs and one
-fixed value of $t$.  The missing analytic bridge is to rewrite the scalar
-equality in the preceding finite Weyl Jensen step as the integral of a
-nonnegative sum whose summands include a positive multiple of this defect,
-deduce its vanishing for every $t>0$, and then pass to singular supports.
-Thus the new identity advances the saturation analysis but does not by itself
-imply the Petz sandwich below.
+The positive-definite analytic connection is now available.  The scalar spectral
+identity is integrated exactly, and the finite Weyl gap is written as
+\[
+  \sum_gD(A_g\Vert B_g)-D(A\Vert B)
+  =\int_0^\infty
+    \frac{\operatorname{Def}_A(t)+t\operatorname{Def}_B(t)}{1+t}\,dt.
+\]
+There is an essential normalization point.  Saturation of the finite Weyl
+Jensen inequality gives $d_R^{-2}$ times each relative entropy, whereas the
+displayed gap uses the weighted matrices
+$A_g=d_R^{-2}U_g\rho U_g^\dagger$ and
+$B_g=d_R^{-2}U_g\sigma U_g^\dagger$.  Positive homogeneity,
+$D(cA\Vert cB)=cD(A\Vert B)$ for $c>0$, identifies these two expressions.
+Consequently equality under the partial trace makes this precise weighted gap
+vanish; no separate gap hypothesis is needed.
+Both defects are nonnegative and continuous on $(0,\infty)$, while the full
+integrand is integrable there.  Hence a zero gap first gives almost-everywhere
+vanishing and then, by continuity, pointwise vanishing for every $t>0$.
+Since $t/(1+t)>0$ on this domain, the source-$B$ defect vanishes, and the
+fixed-resolvent theorem gives $T_g^{-1}(B_g)=T^{-1}(B)$ for every Weyl index.
+\footnote{Formal declarations:
+\leanid{Matrix.quantumRelativeEntropy_smul_posDef},
+\leanid{Matrix.weylRelativeEntropyGap_eq_zero_of_partialTraceRight_eq},
+\leanid{Matrix.quantumRelativeEntropy_resolvent_integral},
+\leanid{Matrix.weyl_relativeEntropy_gap_integral},
+\leanid{Matrix.weyl_sourceB_defect_eq_zero_of_gap_eq_zero},
+\leanid{Matrix.weyl_resolvent_eq_of_relativeEntropy_gap_eq_zero}, and
+\leanid{Matrix.weyl_resolvent_eq_of_partialTraceRight_eq} in
+\path{TNLean/Analysis/RelativeEntropyResolventIntegral.lean} and
+\path{TNLean/Channel/Schwarz/WeylRelativeEntropyIntegral.lean}.}
+This completes the positive-definite finite-Weyl integral step of
+Jen\v{c}ov\'a--Ruskai, arXiv:0903.2895v4, \S4 and Appendix.  The remaining
+analytic
+work is the inverse-square-root passage from the common resolvent solution to
+the identity-Weyl sandwich, followed by extension to singular supports.
 
 There is nevertheless a useful algebraic reduction for the identity summand.
 Write
@@ -360,7 +387,9 @@ processing on this support domain:
 This is the forward implication of
 \cite[Theorem~3]{HaydenJozsaPetzWinter2004}.  The present proof of data
 processing establishes the inequality by regularization, unitary averaging,
-and joint convexity, but it does not yet analyze equality in those steps.
+and joint convexity.  In the positive-definite case its equality analysis now
+reaches the common Weyl resolvent solution, but not yet the limiting
+inverse-square-root sandwich required for recovery.
 After this analytic implication, the proof of the block decomposition still
 requires the invariant-state decomposition used in
 \cite[Theorem~6]{HaydenJozsaPetzWinter2004}; that is the

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -152,6 +152,27 @@ current counts and full location lists).
   cover (membership in red/blue/crossing regions) stated once in the
   RegionBlock development.
 
+### spectral_double_sum_continuity — candidate
+- **Pattern:**
+  ```
+  apply continuousOn_finsetSum Finset.univ
+  intro i _
+  apply continuousOn_finsetSum Finset.univ
+  intro j _ t ht
+  have ht0 : 0 < t := ht
+  have hα : 0 < α i := hA.eigenvalues_pos i
+  have hβ : 0 < β j := hB.eigenvalues_pos j
+  have hden : α i + t * β j ≠ 0 := by positivity
+  ```
+- **Seen:** 3 occurrences in
+  `TNLean/Analysis/RelativeEntropyResolventIntegral.lean` (lines 608, 637,
+  and 846 in the initial scan).
+- **Abstraction (proposed):** a local lemma reducing continuity of a finite
+  spectral double sum on `(0, ∞)` to continuity of one summand, while supplying
+  positivity of the two eigenvalues and nonvanishing of
+  `α i + t * β j`.  The repetition is presently confined to one file, so
+  retain it as a candidate rather than adding a general tactic.
+
 ---
 
 ## Rejected


### PR DESCRIPTION
## Summary

This pull request proves the coefficient-correct positive-definite finite-Weyl relative-entropy gap formula
\[
\operatorname{Gap}=\int_0^\infty
\frac{\operatorname{Def}_A(t)+t\operatorname{Def}_B(t)}{1+t}\,dt.
\]

It follows the finite-dimensional spectral route of Jenčová--Ruskai (arXiv:0903.2895v4):

- proves the scalar improper logarithmic integral;
- diagonalizes both source quadratic resolvents and proves their spectral formulas;
- derives the positive-definite resolvent integral representation of quantum relative entropy;
- adds the source-`A` Weyl squared-residual identity alongside the source-`B` identity;
- proves continuity, integrability, and nonnegativity of both defect families and of the combined integrand;
- upgrades zero integral from almost-everywhere vanishing to pointwise vanishing on `t > 0`;
- concludes that the source-`B` defect vanishes for every `t > 0`, hence obtains the common fixed-resolvent solution.

The blueprint and the SSA equality paper-gap note are updated with source citations and the exact remaining boundary: the inverse-square-root passage and singular-support extension.

## Scope

All new endpoint theorems assume positive-definite inputs. No assertion is made at `t = 0`, no extra invertibility hypothesis is introduced, and no singular-support or arbitrary-ensemble conclusion is claimed.

## Verification

- `lake build TNLean.Analysis.RelativeEntropyResolventIntegral`: passes under the repository strict implicit-argument setting.
- `lake build TNLean.Channel.Schwarz.WeylRelativeEntropyIntegral`: passes.
- Combined focused build of both targets: passes (3178 jobs).
- Source-level blueprint tag synchronization (`python3 scripts/blueprint_lean_sync.py --root . --ci`): passes; repository CI remains authoritative for `leanblueprint checkdecls`.
- Changed-declaration blueprint coverage: passes.
- Proof-integrity scan: no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast` in the changed Lean files.
- `TNLean.lean` remains at exactly 1000 lines.

The failed initial head was repaired from the first scalar elaboration error downward before this focused verification. Repository CI remains authoritative for the full root build and `leanblueprint checkdecls`.

Closes LionSR/TNLean#4376.
Advances LionSR/QICLean#233.
Advances LionSR/TNLean#4228.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new formal proofs in quantum relative entropy and Petz/SSA equality infrastructure; scope stays positive-definite with explicit gaps documented, but mistakes here would affect downstream equality-characterization claims.
> 
> **Overview**
> Adds **positive-definite** Lean proofs for the Jenčová–Ruskai resolvent route to equality in partial-trace data processing, and wires them into the library, blueprint, and paper-gap notes.
> 
> **`RelativeEntropyResolventIntegral.lean`** (new): scalar improper integral for the logarithmic resolvent integrand; spectral expansions for source-`A` and source-`B` quadratic forms; `quantumRelativeEntropy_resolvent_integral` with the **coefficient `t`** on the source-`B` term; homogeneity `D(cA‖cB)=cD(A‖B)`; continuity and integrability of the matrix integrand.
> 
> **`WeylRelativeEntropyIntegral.lean`** (new): finite uniform Weyl gap as `∫₀^∞ (Def_A(t)+t·Def_B(t))/(1+t)`; partial-trace saturation forces the weighted gap to zero (via homogeneity vs. Jensen saturation); zero gap ⇒ source-`B` defect vanishes for every `t>0` (nonnegative integrand + continuity); combines with existing zero-defect machinery for a **common source-`B` resolvent** at each `t>0`, including from `D(ρ‖σ)=D(tr_R ρ‖tr_R σ)`.
> 
> **`PetzEqualityPrerequisites.lean`**: parallel **source-`A`** Weyl squared-residual identity (`weyl_sourceA_resolvent_defect_identity`).
> 
> **Docs**: blueprint Ch.19 entropy lemmas/theorems aligned to new declarations; SSA equality gap note reframed—the positive-definite integral bridge is **done**; remaining work is inverse-square-root limit and singular supports (still positive-definite only at `t>0`, not `t=0`).
> 
> **`TNLean.lean`**: imports the two new modules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7128931c532a3a874b6f8552875b89244087ddf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


