### PR TITLE
feat(MPS/RFP): prove Beigi sector graph formula

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -21,7 +21,6 @@ The following archival modules are intentionally excluded
 * the archival alternate proof `TNLean.Archive.BlockingPeriodicityCFII2`;
 * the documentary counterexample `TNLean.Archive.BlockSepCounterexample`.
 -/
-
 -- Layer 0: General algebra
 import TNLean.Algebra.FinTupleEquiv
 import TNLean.Algebra.TracePairing
@@ -32,6 +31,7 @@ import TNLean.Algebra.HermitianHelpers
 import TNLean.Algebra.MatrixSpectralDecomp
 import TNLean.Algebra.MatrixAux
 import TNLean.Algebra.OrthogonalProjection
+import TNLean.Algebra.CommutingProjectionProduct
 import TNLean.Algebra.PosSemidefSupport
 import TNLean.Algebra.KroneckerFactorPositivity
 import TNLean.Algebra.ComplexPhasePositivity
@@ -628,9 +628,9 @@ import TNLean.MPS.RFP.ResidualWordSpan
 import TNLean.MPS.RFP.NNCPHMultiSector
 import TNLean.MPS.RFP.BeigiGroundSpaceDimension
 import TNLean.MPS.RFP.BeigiSpatialDecomposition
+import TNLean.MPS.RFP.BeigiSectorGraph
 import TNLean.MPS.RFP.PhaseMultiplicityCounterexample
 import TNLean.MPS.RFP.BNTWeightCounterexample
-
 -- Layer 6a: Quantum Wielandt span-growth infrastructure
 import TNLean.Wielandt.SpanGrowth.CumulativeSpan
 import TNLean.Wielandt.SpanGrowth.NonzeroTraceProduct

--- a/TNLean/Algebra/CommutingProjectionProduct.lean
+++ b/TNLean/Algebra/CommutingProjectionProduct.lean
@@ -1,0 +1,147 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Analysis.ProjectionGeometry
+
+/-!
+# Products of complementary commuting projections
+
+For a finite commuting family of orthogonal projections, the ordered product
+of the complementary projections has range equal to the kernel of their sum.
+The order of the product is retained in the statement, so the result applies
+directly to cyclic chains of local operators.
+-/
+
+open scoped BigOperators
+
+namespace Matrix
+
+variable {R ι : Type*} [CommSemiring R] [Fintype ι] [DecidableEq ι]
+  {α : ι → Type*} [∀ i, Fintype (α i)]
+
+/-- The trace of a matrix whose entries are dependent products of matrix
+entries is the product of the traces of its factors. -/
+theorem trace_piProduct (P : (i : ι) → Matrix (α i) (α i) R) :
+    trace (fun (x y : ∀ i, α i) ↦ ∏ i, P i (x i) (y i)) =
+      ∏ i, trace (P i) := by
+  simp only [trace, diag]
+  rw [← Fintype.piFinset_univ]
+  rw [← Finset.prod_univ_sum (fun _ ↦ Finset.univ) fun i x ↦ P i x x]
+
+end Matrix
+
+namespace LinearMap
+
+variable {𝕜 E : Type*} [RCLike 𝕜] [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
+
+private theorem apply_list_prod_one_sub_eq_self
+    (P : List (E →ₗ[𝕜] E)) (v : E) (hP : ∀ p ∈ P, p v = 0) :
+    (P.map fun p ↦ (1 : E →ₗ[𝕜] E) - p).prod v = v := by
+  induction P with
+  | nil => simp
+  | cons p P ih =>
+      simp only [List.map_cons, List.prod_cons]
+      change (1 - p) ((P.map fun q ↦ (1 : E →ₗ[𝕜] E) - q).prod v) = v
+      rw [ih (fun q hq ↦ hP q (List.mem_cons_of_mem p hq))]
+      simp [hP p (List.mem_cons_self)]
+
+private theorem mul_list_prod_one_sub_eq_zero
+    (P : List (E →ₗ[𝕜] E)) (hcomm : P.Pairwise fun p q ↦ Commute p q)
+    (hidem : ∀ p ∈ P, IsIdempotentElem p) {p : E →ₗ[𝕜] E} (hp : p ∈ P) :
+    p * (P.map fun q ↦ (1 : E →ₗ[𝕜] E) - q).prod = 0 := by
+  induction P with
+  | nil => simp at hp
+  | cons q P ih =>
+      rw [List.pairwise_cons] at hcomm
+      simp only [List.map_cons, List.prod_cons]
+      rcases List.mem_cons.mp hp with hp | hp
+      · subst p
+        rw [← mul_assoc, (hidem q (List.mem_cons_self)).mul_one_sub_self, zero_mul]
+      · have hpq : Commute p q :=
+          (hcomm.1 p hp).symm
+        rw [← mul_assoc, ((Commute.one_right p).sub_right hpq).eq, mul_assoc,
+          ih hcomm.2 (fun r hr ↦ hidem r (List.mem_cons_of_mem q hr)) hp, mul_zero]
+
+private theorem list_prod_one_sub_isIdempotentElem
+    (P : List (E →ₗ[𝕜] E)) (hcomm : P.Pairwise fun p q ↦ Commute p q)
+    (hidem : ∀ p ∈ P, IsIdempotentElem p) :
+    IsIdempotentElem (P.map fun p ↦ (1 : E →ₗ[𝕜] E) - p).prod := by
+  induction P with
+  | nil => exact IsIdempotentElem.one
+  | cons p P ih =>
+      rw [List.pairwise_cons] at hcomm
+      simp only [List.map_cons, List.prod_cons]
+      have hhead : IsIdempotentElem ((1 : E →ₗ[𝕜] E) - p) :=
+        (hidem p List.mem_cons_self).one_sub
+      have htail := ih hcomm.2 (fun q hq ↦ hidem q (List.mem_cons_of_mem p hq))
+      apply hhead.mul_of_commute _ htail
+      apply Commute.list_prod_right
+      intro q hq
+      rw [List.mem_map] at hq
+      obtain ⟨r, hr, rfl⟩ := hq
+      exact (Commute.one_left ((1 : E →ₗ[𝕜] E) - r)).sub_left
+        ((Commute.one_right p).sub_right (hcomm.1 r hr))
+
+/-- For a finite commuting family of symmetric projections, the ordered
+product of their complements has range equal to the kernel of their sum. -/
+theorem range_listProd_one_sub_eq_ker_sum
+    {N : ℕ} (P : Fin N → E →ₗ[𝕜] E)
+    (hP : ∀ i, (P i).IsSymmetricProjection)
+    (hcomm : ∀ i j, Commute (P i) (P j)) :
+    range ((List.ofFn fun i ↦ 1 - P i).prod) = ker (∑ i, P i) := by
+  classical
+  let Ps : List (E →ₗ[𝕜] E) := List.ofFn P
+  have hpair : Ps.Pairwise fun p q ↦ Commute p q := by
+    simp only [Ps, List.pairwise_ofFn]
+    intro i j _
+    exact hcomm i j
+  have hidem : ∀ p ∈ Ps, IsIdempotentElem p := by
+    intro p hp
+    simp only [Ps, List.mem_ofFn] at hp
+    obtain ⟨i, rfl⟩ := hp
+    exact (hP i).isIdempotentElem
+  apply le_antisymm
+  · rintro v ⟨x, rfl⟩
+    rw [mem_ker]
+    simp only [sum_apply]
+    apply Finset.sum_eq_zero
+    intro i _
+    have hkill := mul_list_prod_one_sub_eq_zero Ps hpair hidem
+      (List.mem_ofFn.mpr ⟨i, rfl⟩)
+    change P i ((List.ofFn ((fun q ↦ (1 : E →ₗ[𝕜] E) - q) ∘ P)).prod x) = 0
+    simpa [Ps] using LinearMap.congr_fun hkill x
+  · intro v hv
+    rw [mem_ker] at hv
+    have heach : ∀ i, P i v = 0 := fun i ↦
+      ProjectionGeometry.apply_eq_zero_of_sum_apply_eq_zero P hP hv i
+    refine ⟨v, ?_⟩
+    change (List.ofFn ((fun p ↦ (1 : E →ₗ[𝕜] E) - p) ∘ P)).prod v = v
+    simpa [Ps] using apply_list_prod_one_sub_eq_self Ps v (by
+      intro p hp
+      simp only [Ps, List.mem_ofFn] at hp
+      obtain ⟨i, rfl⟩ := hp
+      exact heach i)
+
+/-- The ordered product of the complementary members of a finite commuting
+family of symmetric projections is the projection onto the kernel of their
+sum. -/
+theorem isProj_ker_sum_listProd_one_sub
+    {N : ℕ} (P : Fin N → E →ₗ[𝕜] E)
+    (hP : ∀ i, (P i).IsSymmetricProjection)
+    (hcomm : ∀ i j, Commute (P i) (P j)) :
+    IsProj (ker (∑ i, P i)) ((List.ofFn fun i ↦ 1 - P i).prod) := by
+  classical
+  rw [← range_listProd_one_sub_eq_ker_sum P hP hcomm,
+    isProj_range_iff_isIdempotentElem]
+  simpa only [List.map_ofFn, Function.comp_def] using
+    list_prod_one_sub_isIdempotentElem (List.ofFn P) (by
+      rw [List.pairwise_ofFn]
+      exact fun _ _ _ ↦ hcomm _ _) (by
+      intro p hp
+      rw [List.mem_ofFn] at hp
+      obtain ⟨i, rfl⟩ := hp
+      exact (hP i).isIdempotentElem)
+
+end LinearMap

--- a/TNLean/MPS/MPDO/CommutingBondEtaCyclicTransport.lean
+++ b/TNLean/MPS/MPDO/CommutingBondEtaCyclicTransport.lean
@@ -116,7 +116,7 @@ variable {d : ℕ}
 /-- In pair coordinates, conjugating a two-site operator by the tensor square
 of a conjugate-transposed one-site matrix is the corresponding Kronecker
 conjugation. -/
-private theorem singleKrausMap_sitewise_conjTranspose_two_eq
+theorem singleKrausMap_sitewise_conjTranspose_two_eq
     (U : Matrix (Fin d) (Fin d) ℂ)
     (B : Matrix (Fin 2 → Fin d) (Fin 2 → Fin d) ℂ) :
     singleKrausMap (sitewisePhysicalMatrix Uᴴ 2) B =
@@ -246,6 +246,33 @@ private theorem prod_etaEdgePartialProduct_singletons_univ {K N : ℕ} [NeZero N
     exact List.mem_ofFn.mpr ⟨i, rfl⟩
   rw [hfin]
   exact etaEdgePartialProduct_univ dl dr η k
+
+private theorem etaEdgePartialProduct_singletons_comm {K N : ℕ} [NeZero N]
+    (dl dr : Fin K → ℕ)
+    (η : (q h : Fin K) →
+      Matrix (Matrix.EtaEdgeIndex dl dr q h) (Matrix.EtaEdgeIndex dl dr q h) ℂ)
+    (k : Fin N → Fin K) (i j : Fin N) :
+    etaEdgePartialProduct dl dr η k {i} * etaEdgePartialProduct dl dr η k {j} =
+      etaEdgePartialProduct dl dr η k {j} * etaEdgePartialProduct dl dr η k {i} := by
+  by_cases hij : i = j
+  · subst j
+    rfl
+  · calc
+      etaEdgePartialProduct dl dr η k {i} * etaEdgePartialProduct dl dr η k {j} =
+          etaEdgePartialProduct dl dr η k (insert i {j}) :=
+        etaEdgePartialProduct_singleton_mul dl dr η k {j} i (by simp [hij])
+      _ = etaEdgePartialProduct dl dr η k (insert j {i}) := by
+        congr 1
+        apply Finset.ext
+        intro q
+        simp only [Finset.mem_insert, Finset.mem_singleton]
+        exact or_comm
+      _ = etaEdgePartialProduct dl dr η k {j} *
+          etaEdgePartialProduct dl dr η k {i} :=
+        (etaEdgePartialProduct_singleton_mul dl dr η k {i} j
+          (by
+            simp only [Finset.mem_singleton]
+            exact fun hji ↦ hij hji.symm)).symm
 
 private theorem add_one_ne_self_of_two_le {N : ℕ} [NeZero N]
     (hN : 2 ≤ N) (i : Fin N) :
@@ -525,6 +552,68 @@ private theorem reindex_embedLocalOperator_etaPairBond {K N : ℕ} [NeZero N]
       simpa [Matrix.reindex_apply, Matrix.etaPairSpatialBlockEquiv,
         Matrix.blockDiagonal'_apply_ne _ _ _ hpairs] using hentry
     · rw [if_neg ha]
+
+/-- Two translated bonds commute whenever their common two-site matrix has a
+neighboring-operator decomposition.  This is the local-to-global commutation
+consequence of the same cyclic edge coordinates used in Beigi's finite-chain
+decomposition.
+
+Source: Beigi, arXiv:1105.1019v2, Section III, equations (2)--(3), pages 3--4. -/
+theorem embedLocalOperator_commute_of_etaPair_decomposition
+    {K N : ℕ} [NeZero N] (hN : 2 ≤ N) (dl dr : Fin K → ℕ)
+    (e : Matrix.EtaSiteIndex K dl dr ≃ Fin d)
+    (η : (q h : Fin K) →
+      Matrix (Matrix.EtaEdgeIndex dl dr q h) (Matrix.EtaEdgeIndex dl dr q h) ℂ)
+    (B : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
+    (hB : Matrix.reindex (Matrix.etaPairSpatialBlockEquiv e).symm
+        (Matrix.etaPairSpatialBlockEquiv e).symm B =
+      Matrix.blockDiagonal' fun qh : Fin K × Fin K ↦
+        ((1 : Matrix (Fin (dl qh.1)) (Fin (dl qh.1)) ℂ) ⊗ₖ
+          η qh.1 qh.2) ⊗ₖ
+            (1 : Matrix (Fin (dr qh.2)) (Fin (dr qh.2)) ℂ))
+    (i j : Fin N) :
+    embedLocalOperator (d := d) 2 N hN i
+          (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+            (finTwoArrowEquiv (Fin d)).symm B) *
+        embedLocalOperator (d := d) 2 N hN j
+          (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+            (finTwoArrowEquiv (Fin d)).symm B) =
+      embedLocalOperator (d := d) 2 N hN j
+          (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+            (finTwoArrowEquiv (Fin d)).symm B) *
+        embedLocalOperator (d := d) 2 N hN i
+          (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+            (finTwoArrowEquiv (Fin d)).symm B) := by
+  classical
+  apply (Matrix.reindex (Matrix.etaCyclicEdgeEquiv dl dr e)
+    (Matrix.etaCyclicEdgeEquiv dl dr e)).injective
+  change (Matrix.reindexLinearEquiv ℂ ℂ (Matrix.etaCyclicEdgeEquiv dl dr e)
+      (Matrix.etaCyclicEdgeEquiv dl dr e))
+        (embedLocalOperator (d := d) 2 N hN i
+            (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+              (finTwoArrowEquiv (Fin d)).symm B) *
+          embedLocalOperator (d := d) 2 N hN j
+            (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+              (finTwoArrowEquiv (Fin d)).symm B)) =
+    (Matrix.reindexLinearEquiv ℂ ℂ (Matrix.etaCyclicEdgeEquiv dl dr e)
+      (Matrix.etaCyclicEdgeEquiv dl dr e))
+        (embedLocalOperator (d := d) 2 N hN j
+            (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+              (finTwoArrowEquiv (Fin d)).symm B) *
+          embedLocalOperator (d := d) 2 N hN i
+            (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+              (finTwoArrowEquiv (Fin d)).symm B))
+  rw [← Matrix.reindexLinearEquiv_mul ℂ ℂ (Matrix.etaCyclicEdgeEquiv dl dr e)
+      (Matrix.etaCyclicEdgeEquiv dl dr e) (Matrix.etaCyclicEdgeEquiv dl dr e),
+    ← Matrix.reindexLinearEquiv_mul ℂ ℂ (Matrix.etaCyclicEdgeEquiv dl dr e)
+      (Matrix.etaCyclicEdgeEquiv dl dr e) (Matrix.etaCyclicEdgeEquiv dl dr e),
+    Matrix.coe_reindexLinearEquiv,
+    reindex_embedLocalOperator_etaPairBond hN dl dr e η B hB i,
+    reindex_embedLocalOperator_etaPairBond hN dl dr e η B hB j,
+    ← Matrix.blockDiagonal'_mul, ← Matrix.blockDiagonal'_mul]
+  congr 1
+  funext k
+  exact etaEdgePartialProduct_singletons_comm dl dr η k i j
 
 private theorem reindex_list_prod {α β : Type*} [Fintype α] [DecidableEq α]
     [Fintype β] [DecidableEq β] (e : α ≃ β) (l : List (Matrix α α ℂ)) :

--- a/TNLean/MPS/MPDO/CommutingForm.lean
+++ b/TNLean/MPS/MPDO/CommutingForm.lean
@@ -254,7 +254,7 @@ theorem embedLocalOperator_mul (L N : ℕ) (hLN : L ≤ N) (i : Fin N)
 
 /-- The action of a cyclically embedded local operator is the sum over
 replacements of the configuration inside its window. -/
-private theorem embedLocalOperator_mulVec_apply (L N : ℕ) (hLN : L ≤ N) (i : Fin N)
+theorem embedLocalOperator_mulVec_apply (L N : ℕ) (hLN : L ≤ N) (i : Fin N)
     (B : Matrix (Fin L → Fin d) (Fin L → Fin d) ℂ)
     (v : (Fin N → Fin d) → ℂ) (σ : Fin N → Fin d) :
     (embedLocalOperator (d := d) L N hLN i B).mulVec v σ =

--- a/TNLean/MPS/RFP/BeigiSectorGraph.lean
+++ b/TNLean/MPS/RFP/BeigiSectorGraph.lean
@@ -1,0 +1,565 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.CommutingBondEtaCyclicTransport
+import TNLean.MPS.ParentHamiltonian.KernelChainGroundSpace
+import TNLean.MPS.RFP.BeigiSpatialDecomposition
+import TNLean.Algebra.CommutingProjectionProduct
+
+/-!
+# The finite sector graph of a commuting parent Hamiltonian
+
+Beigi's spatial decomposition writes the one-site space as a finite direct sum
+of left--right tensor factors.  In these coordinates, the complementary
+two-site parent interaction is a direct sum of operators
+`1 ⊗ P_{a,b} ⊗ 1`, where `P_{a,b}` is the orthogonal projector onto the
+ground space carried by the directed edge from `a` to `b`.
+
+The product of all translated complementary interactions is therefore block
+diagonal over ordered cyclic sector sequences.  Its trace is the sum, over
+those sequences, of the products of the edge-ground-space dimensions.  Since
+this product is the ground-space projector of the commuting parent
+Hamiltonian, its trace gives Beigi's ordered-cycle formula.
+
+## Main declarations
+
+* `BeigiSectorGraphData`: the finite local sector data and its two-site
+  coordinate identity;
+* `BeigiSectorGraphData.OrderedCycle`: ordered cyclic sector sequences whose
+  adjacent edge ground spaces are nonzero;
+* `BeigiSectorGraphData.parentHamiltonianGroundSpaceES_finrank_eq`: Beigi's
+  finite-chain dimension formula.
+
+## References
+
+* S. Beigi, *Classification of the phases of 1D spin chains with commuting
+  Hamiltonians*, arXiv:1105.1019v2, Section III, equations (2)--(4), pages
+  3--4.
+-/
+
+open scoped BigOperators ComplexOrder Kronecker Matrix
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- The two-site projector onto the canonical parent ground space, in ordered
+pair coordinates.  It is the complement of the canonical parent interaction.
+
+Source: Beigi, arXiv:1105.1019v2, Section III, equation (2), page 3. -/
+noncomputable def twoSiteParentGroundProjectorMatrix (A : MPSTensor d D) :
+    Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ :=
+  1 - twoSiteParentInteractionMatrix A
+
+/-- The finite sector graph associated with a spatial decomposition of the
+canonical two-site parent interaction.
+
+The edge projector `edgeProjector a b` has range `ker Q_{a,b}` in Beigi's
+notation.  The only compatibility field is the local coordinate identity for
+the complementary bond `1 - h`; no finite-chain ground-space statement or
+scale-invariance hypothesis is part of the data.
+
+Source: Beigi, arXiv:1105.1019v2, Section III, equations (2)--(3), pages 3--4. -/
+structure BeigiSectorGraphData (A : MPSTensor d D) where
+  /-- The number of sectors in the one-site spatial decomposition.
+
+  Source: Beigi, arXiv:1105.1019v2, Section III, equation (2), page 3. -/
+  sectorCount : ℕ
+  /-- The dimension of the left factor in each sector.
+
+  Source: Beigi, arXiv:1105.1019v2, Section III, equation (2), page 3. -/
+  leftDim : Fin sectorCount → ℕ
+  /-- The dimension of the right factor in each sector.
+
+  Source: Beigi, arXiv:1105.1019v2, Section III, equation (2), page 3. -/
+  rightDim : Fin sectorCount → ℕ
+  /-- Identification of one physical site with its finite sum of right--left
+  sector factors.
+
+  Source: Beigi, arXiv:1105.1019v2, Section III, equation (2), page 3. -/
+  sectorEquiv : Matrix.EtaSiteIndex sectorCount leftDim rightDim ≃ Fin d
+  /-- The one-site unitary implementing the spatial coordinates.
+
+  Source: Beigi, arXiv:1105.1019v2, Section III, equation (2), page 3. -/
+  unitary : Matrix (Fin d) (Fin d) ℂ
+  /-- The spatial coordinate change is unitary.
+
+  Source: Beigi, arXiv:1105.1019v2, Section III, equation (2), page 3. -/
+  unitary_mem : unitary ∈ Matrix.unitaryGroup (Fin d) ℂ
+  /-- The projector onto the ground space carried by the directed edge
+  `a ⟶ b`.
+
+  Source: Beigi, arXiv:1105.1019v2, Section III, equations (2)--(3), pages 3--4. -/
+  edgeProjector : (a b : Fin sectorCount) →
+    Matrix (Matrix.EtaEdgeIndex leftDim rightDim a b)
+      (Matrix.EtaEdgeIndex leftDim rightDim a b) ℂ
+  /-- Every edge ground-space operator is an orthogonal projector.
+
+  Source: Beigi, arXiv:1105.1019v2, Section III, equations (2)--(3), pages 3--4. -/
+  edgeProjector_isOrthogonal : ∀ a b,
+    (edgeProjector a b).IsHermitian ∧ IsIdempotentElem (edgeProjector a b)
+  /-- In spatial coordinates, the complementary parent interaction is the
+  direct sum of the edge ground-space projectors, with identities on the two
+  boundary factors.
+
+  Source: Beigi, arXiv:1105.1019v2, Section III, equation (2), page 3. -/
+  groundProjector_block :
+    Matrix.reindex (Matrix.etaPairSpatialBlockEquiv sectorEquiv).symm
+        (Matrix.etaPairSpatialBlockEquiv sectorEquiv).symm
+        (star (unitary ⊗ₖ unitary) * twoSiteParentGroundProjectorMatrix A *
+          (unitary ⊗ₖ unitary)) =
+      Matrix.blockDiagonal' fun ab : Fin sectorCount × Fin sectorCount ↦
+        ((1 : Matrix (Fin (leftDim ab.1)) (Fin (leftDim ab.1)) ℂ) ⊗ₖ
+          edgeProjector ab.1 ab.2) ⊗ₖ
+            (1 : Matrix (Fin (rightDim ab.2)) (Fin (rightDim ab.2)) ℂ)
+
+namespace BeigiSectorGraphData
+
+variable {A : MPSTensor d D}
+
+/-- The edge ground space from sector `a` to sector `b`.
+
+This is `ker Q_{a,b}` in Beigi's notation, represented as the range of its
+orthogonal projector `P_{a,b}`.
+
+Source: Beigi, arXiv:1105.1019v2, Section III, equation (3), page 4. -/
+noncomputable def edgeGroundSpace (F : BeigiSectorGraphData A)
+    (a b : Fin F.sectorCount) :
+    Submodule ℂ (Matrix.EtaEdgeIndex F.leftDim F.rightDim a b → ℂ) :=
+  LinearMap.range (Matrix.toLin' (F.edgeProjector a b))
+
+/-- A directed edge is present exactly when its edge ground space is nonzero.
+
+Source: Beigi, arXiv:1105.1019v2, Section III, graph definition immediately
+after equation (2), page 3. -/
+def IsEdge (F : BeigiSectorGraphData A) (a b : Fin F.sectorCount) : Prop :=
+  F.edgeGroundSpace a b ≠ ⊥
+
+/-- An ordered cyclic sector sequence all of whose adjacent edge ground spaces
+are nonzero.  Cyclic rotation is not quotiented out: the source sum is over
+ordered cycles.
+
+Source: Beigi, arXiv:1105.1019v2, Section III, equations (3)--(4), page 4. -/
+def OrderedCycle (F : BeigiSectorGraphData A) (N : ℕ) [NeZero N] :=
+  {k : Fin N → Fin F.sectorCount // ∀ n : Fin N, F.IsEdge (k n) (k (n + 1))}
+
+noncomputable instance (F : BeigiSectorGraphData A) (N : ℕ) [NeZero N] :
+    Fintype (F.OrderedCycle N) := by
+  classical
+  unfold OrderedCycle
+  infer_instance
+
+noncomputable instance (F : BeigiSectorGraphData A) (N : ℕ) [NeZero N] :
+    DecidableEq (F.OrderedCycle N) :=
+  Classical.decEq _
+
+/-- The complementary two-site bond in configuration coordinates. -/
+private noncomputable def groundBond (A : MPSTensor d D) :
+    Matrix (Fin 2 → Fin d) (Fin 2 → Fin d) ℂ :=
+  Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+    (finTwoArrowEquiv (Fin d)).symm (twoSiteParentGroundProjectorMatrix A)
+
+/-- The coordinate-transformed complementary two-site bond. -/
+private noncomputable def transformedGroundBond (F : BeigiSectorGraphData A) :
+    Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ :=
+  star (F.unitary ⊗ₖ F.unitary) * twoSiteParentGroundProjectorMatrix A *
+    (F.unitary ⊗ₖ F.unitary)
+
+private theorem transformedGroundBond_block (F : BeigiSectorGraphData A) :
+    Matrix.reindex (Matrix.etaPairSpatialBlockEquiv F.sectorEquiv).symm
+        (Matrix.etaPairSpatialBlockEquiv F.sectorEquiv).symm
+        F.transformedGroundBond =
+      Matrix.blockDiagonal' fun ab : Fin F.sectorCount × Fin F.sectorCount ↦
+        ((1 : Matrix (Fin (F.leftDim ab.1)) (Fin (F.leftDim ab.1)) ℂ) ⊗ₖ
+          F.edgeProjector ab.1 ab.2) ⊗ₖ
+            (1 : Matrix (Fin (F.rightDim ab.2)) (Fin (F.rightDim ab.2)) ℂ) :=
+  F.groundProjector_block
+
+private theorem localTerm_eq_toLin'_embedLocalOperator {N : ℕ} (hN : 2 ≤ N)
+    (i : Fin N) :
+    localTerm A 2 N i = Matrix.toLin'
+      (MPOTensor.embedLocalOperator (d := d) 2 N hN i
+        (LinearMap.toMatrix' (parentInteraction A 2))) := by
+  classical
+  apply LinearMap.ext
+  intro v
+  funext σ
+  rw [localTerm_apply_of_le A 2 N hN i, Matrix.toLin'_apply,
+    MPOTensor.embedLocalOperator_mulVec_apply]
+  symm
+  exact congrFun (LinearMap.congr_fun
+    (Matrix.toLin'_toMatrix' (parentInteraction A 2))
+    (fun τ ↦ v (replaceWindow 2 hN i σ τ))) (extractWindow 2 i σ)
+
+private theorem groundBond_eq_one_sub_toMatrix' :
+    groundBond A = 1 - LinearMap.toMatrix' (parentInteraction A 2) := by
+  classical
+  ext x y
+  simp [groundBond, twoSiteParentGroundProjectorMatrix,
+    twoSiteParentInteractionMatrix, Matrix.reindex_apply,
+    Matrix.submatrix_apply, Matrix.one_apply]
+  · have hx : ![x 0, x 1] = x := by
+      funext j
+      fin_cases j <;> rfl
+    have hy : ![y 0, y 1] = y := by
+      funext j
+      fin_cases j <;> rfl
+    rw [hx, hy]
+    have hxy : (x 0 = y 0 ∧ x 1 = y 1) ↔ x = y := by
+      constructor
+      · rintro ⟨h0, h1⟩
+        funext j
+        fin_cases j
+        · exact h0
+        · exact h1
+      · rintro rfl
+        exact ⟨rfl, rfl⟩
+    simp only [hxy]
+
+private theorem embedLocalOperator_groundBond_eq_one_sub {N : ℕ} (hN : 2 ≤ N)
+    (i : Fin N) :
+    MPOTensor.embedLocalOperator (d := d) 2 N hN i (groundBond A) =
+      1 - MPOTensor.embedLocalOperator (d := d) 2 N hN i
+        (LinearMap.toMatrix' (parentInteraction A 2)) := by
+  classical
+  rw [groundBond_eq_one_sub_toMatrix']
+  ext σ τ
+  by_cases hστ : MPOTensor.AgreesOutsideWindow (d := d) 2 hN i σ τ
+  · simp only [MPOTensor.embedLocalOperator_apply, hστ, if_true,
+      Matrix.sub_apply, Matrix.one_apply]
+    by_cases hEq : σ = τ
+    · subst τ
+      simp
+    · have hExtract : extractWindow 2 i σ ≠ extractWindow 2 i τ := by
+        intro h
+        apply hEq
+        rw [← replaceWindow_extractWindow 2 hN i τ]
+        rw [← h, hστ]
+      simp [hEq, hExtract]
+  · simp [MPOTensor.embedLocalOperator_apply, hστ, Matrix.one_apply]
+    intro hEq
+    subst τ
+    exact hστ (by simp [MPOTensor.AgreesOutsideWindow])
+
+private theorem singleKrausMap_groundBond_eq_transformedGroundBond
+    (F : BeigiSectorGraphData A) :
+    singleKrausMap (MPOTensor.sitewisePhysicalMatrix F.unitaryᴴ 2) (groundBond A) =
+      Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+        (finTwoArrowEquiv (Fin d)).symm F.transformedGroundBond := by
+  rw [MPOTensor.singleKrausMap_sitewise_conjTranspose_two_eq]
+  congr 1
+
+private theorem groundBondEmbeddings_commute (F : BeigiSectorGraphData A)
+    {N : ℕ} [NeZero N] (hN : 2 ≤ N) (i j : Fin N) :
+    Commute
+      (MPOTensor.embedLocalOperator (d := d) 2 N hN i (groundBond A))
+      (MPOTensor.embedLocalOperator (d := d) 2 N hN j (groundBond A)) := by
+  classical
+  let W := MPOTensor.sitewisePhysicalMatrix F.unitaryᴴ N
+  let G : Fin N → Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ := fun n ↦
+    MPOTensor.embedLocalOperator (d := d) 2 N hN n (groundBond A)
+  let T : Fin N → Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ := fun n ↦
+    MPOTensor.embedLocalOperator (d := d) 2 N hN n
+      (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+        (finTwoArrowEquiv (Fin d)).symm F.transformedGroundBond)
+  have hUstarU : star F.unitary * F.unitary = 1 :=
+    Unitary.star_mul_self_of_mem F.unitary_mem
+  have hUUstar : F.unitary * star F.unitary = 1 :=
+    Unitary.mul_star_self_of_mem F.unitary_mem
+  have hUstarU' : F.unitaryᴴ * F.unitary = 1 := by
+    simpa only [Matrix.star_eq_conjTranspose] using hUstarU
+  have hUUstar' : F.unitary * F.unitaryᴴ = 1 := by
+    simpa only [Matrix.star_eq_conjTranspose] using hUUstar
+  have hWstarW : Wᴴ * W = 1 := by
+    simp only [W, MPOTensor.sitewisePhysicalMatrix_conjTranspose,
+      Matrix.conjTranspose_conjTranspose]
+    rw [← MPOTensor.sitewisePhysicalMatrix_conjTranspose,
+      MPOTensor.sitewisePhysicalMatrix_mul_conjTranspose, hUUstar',
+      MPOTensor.sitewisePhysicalMatrix_one]
+  have hWWstar : W * Wᴴ = 1 := by
+    simp only [W]
+    rw [MPOTensor.sitewisePhysicalMatrix_mul_conjTranspose]
+    simp only [Matrix.conjTranspose_conjTranspose]
+    rw [hUstarU', MPOTensor.sitewisePhysicalMatrix_one]
+  have hWone : singleKrausMap W 1 = 1 := by
+    simp only [singleKrausMap_apply, Matrix.mul_one]
+    exact hWWstar
+  have hconj (n : Fin N) : singleKrausMap W (G n) = T n := by
+    simp only [G, T]
+    rw [MPOTensor.singleKrausMap_embedLocalOperator_eq_range_mul_lift
+      F.unitaryᴴ (by simpa using hUUstar') hN n,
+      singleKrausMap_groundBond_eq_transformedGroundBond]
+    rw [show singleKrausMap
+      (MPOTensor.sitewisePhysicalMatrix F.unitaryᴴ N) 1 = 1 by exact hWone]
+    exact Matrix.one_mul _
+  have hT : Commute (T i) (T j) := by
+    exact MPOTensor.embedLocalOperator_commute_of_etaPair_decomposition hN
+      F.leftDim F.rightDim F.sectorEquiv F.edgeProjector F.transformedGroundBond
+      F.transformedGroundBond_block i j
+  rw [← hconj i, ← hconj j] at hT
+  have hback := congrArg (singleKrausMap Wᴴ) hT.eq
+  simp only [singleKrausMap_apply, Matrix.conjTranspose_conjTranspose] at hback
+  simp only [← Matrix.mul_assoc, hWstarW, Matrix.one_mul] at hback
+  simp only [Matrix.mul_assoc, hWstarW, Matrix.mul_one] at hback
+  simp only [G] at hback
+  exact hback
+
+private theorem localTerm_commute (F : BeigiSectorGraphData A)
+    {N : ℕ} [NeZero N] (hN : 2 ≤ N) (i j : Fin N) :
+    Commute (localTerm A 2 N i) (localTerm A 2 N j) := by
+  classical
+  let G : Fin N → Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ := fun n ↦
+    MPOTensor.embedLocalOperator (d := d) 2 N hN n (groundBond A)
+  have hG : Commute (G i) (G j) := F.groundBondEmbeddings_commute hN i j
+  have htoLin (n : Fin N) :
+      Matrix.toLin' (G n) = 1 - localTerm A 2 N n := by
+    simp only [G]
+    rw [embedLocalOperator_groundBond_eq_one_sub]
+    change (Matrix.toLinAlgEquiv' :
+      Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ ≃ₐ[ℂ]
+        Module.End ℂ (NSiteSpace d N))
+        (1 - MPOTensor.embedLocalOperator (d := d) 2 N hN n
+          (LinearMap.toMatrix' (parentInteraction A 2))) = _
+    rw [map_sub, map_one]
+    change 1 - Matrix.toLin'
+      (MPOTensor.embedLocalOperator (d := d) 2 N hN n
+        (LinearMap.toMatrix' (parentInteraction A 2))) = _
+    rw [localTerm_eq_toLin'_embedLocalOperator (A := A) hN n]
+  have hcomp : Commute
+      (1 - localTerm A 2 N i) (1 - localTerm A 2 N j) := by
+    rw [← htoLin i, ← htoLin j]
+    exact hG.map Matrix.toLinAlgEquiv'
+  change localTerm A 2 N i * localTerm A 2 N j =
+    localTerm A 2 N j * localTerm A 2 N i
+  change (1 - localTerm A 2 N i) * (1 - localTerm A 2 N j) =
+    (1 - localTerm A 2 N j) * (1 - localTerm A 2 N i) at hcomp
+  simp only [sub_mul, mul_sub, one_mul, mul_one] at hcomp
+  abel_nf at hcomp
+  exact add_left_cancel (add_left_cancel (add_left_cancel hcomp))
+
+private theorem localTermES_commute (F : BeigiSectorGraphData A)
+    {N : ℕ} [NeZero N] (hN : 2 ≤ N) (i j : Fin N) :
+    Commute (localTermES A 2 i) (localTermES A 2 j) := by
+  let e := WithLp.linearEquiv 2 ℂ (NSiteSpace d N)
+  have hraw := F.localTerm_commute hN i j
+  have hmap := hraw.map (LinearEquiv.conjAlgEquiv ℂ e.symm)
+  simpa only [localTermES, e, LinearEquiv.conjAlgEquiv_apply,
+    LinearEquiv.symm_symm] using hmap
+
+private theorem edgeProjector_trace (F : BeigiSectorGraphData A)
+    (a b : Fin F.sectorCount) :
+    Matrix.trace (F.edgeProjector a b) =
+      (Module.finrank ℂ (F.edgeGroundSpace a b) : ℂ) := by
+  classical
+  have hproj : LinearMap.IsProj (F.edgeGroundSpace a b)
+      (Matrix.toLin' (F.edgeProjector a b)) := by
+    rw [edgeGroundSpace, LinearMap.isProj_range_iff_isIdempotentElem]
+    change Matrix.toLin' (F.edgeProjector a b) *
+      Matrix.toLin' (F.edgeProjector a b) = Matrix.toLin' (F.edgeProjector a b)
+    rw [Module.End.mul_eq_comp, ← Matrix.toLin'_mul,
+      (F.edgeProjector_isOrthogonal a b).2.eq]
+  rw [← Matrix.trace_toLin'_eq]
+  exact hproj.trace
+
+private theorem transformedGroundBondProduct_trace (F : BeigiSectorGraphData A)
+    {N : ℕ} [NeZero N] (hN : 2 ≤ N) :
+    Matrix.trace
+        (List.ofFn fun i : Fin N ↦
+          MPOTensor.embedLocalOperator (d := d) 2 N hN i
+            (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+              (finTwoArrowEquiv (Fin d)).symm F.transformedGroundBond)).prod =
+      ∑ k : Fin N → Fin F.sectorCount,
+        (↑(∏ n : Fin N,
+          Module.finrank ℂ (F.edgeGroundSpace (k n) (k (n + 1)))) : ℂ) := by
+  classical
+  let e := Matrix.etaCyclicEdgeEquiv (N := N) F.leftDim F.rightDim F.sectorEquiv
+  let edgeBlock (k : Fin N → Fin F.sectorCount) :
+      Matrix ((n : Fin N) → Matrix.EtaEdgeIndex F.leftDim F.rightDim (k n) (k (n + 1)))
+        ((n : Fin N) → Matrix.EtaEdgeIndex F.leftDim F.rightDim (k n) (k (n + 1))) ℂ :=
+    fun x y ↦ ∏ n : Fin N,
+      F.edgeProjector (k n) (k (n + 1)) (x n) (y n)
+  have hblocks : Matrix.reindex e e
+      (List.ofFn fun i : Fin N ↦
+        MPOTensor.embedLocalOperator (d := d) 2 N hN i
+          (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+            (finTwoArrowEquiv (Fin d)).symm F.transformedGroundBond)).prod =
+      Matrix.blockDiagonal' edgeBlock :=
+    MPOTensor.reindex_product_embedLocalOperator_of_etaPair_decomposition
+      hN F.leftDim F.rightDim F.sectorEquiv F.edgeProjector F.transformedGroundBond
+      F.transformedGroundBond_block
+  calc
+    Matrix.trace
+        (List.ofFn fun i : Fin N ↦
+          MPOTensor.embedLocalOperator (d := d) 2 N hN i
+            (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+              (finTwoArrowEquiv (Fin d)).symm F.transformedGroundBond)).prod =
+        Matrix.trace (Matrix.reindex e e
+          (List.ofFn fun i : Fin N ↦
+            MPOTensor.embedLocalOperator (d := d) 2 N hN i
+              (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+                (finTwoArrowEquiv (Fin d)).symm F.transformedGroundBond)).prod) := by
+          exact (Matrix.trace_reindex e _).symm
+    _ = Matrix.trace (Matrix.blockDiagonal' edgeBlock) := by
+          rw [hblocks]
+    _ = _ := by
+      rw [Matrix.trace_blockDiagonal']
+      apply Finset.sum_congr rfl
+      intro k _
+      simp only [edgeBlock]
+      rw [Matrix.trace_piProduct]
+      simp_rw [F.edgeProjector_trace]
+      norm_cast
+
+private theorem groundBondProduct_trace (F : BeigiSectorGraphData A)
+    {N : ℕ} [NeZero N] (hN : 2 ≤ N) :
+    Matrix.trace
+        (List.ofFn fun i : Fin N ↦
+          MPOTensor.embedLocalOperator (d := d) 2 N hN i (groundBond A)).prod =
+      ∑ k : Fin N → Fin F.sectorCount,
+        (↑(∏ n : Fin N,
+          Module.finrank ℂ (F.edgeGroundSpace (k n) (k (n + 1)))) : ℂ) := by
+  classical
+  let W := MPOTensor.sitewisePhysicalMatrix F.unitaryᴴ N
+  let Q := (List.ofFn fun i : Fin N ↦
+    MPOTensor.embedLocalOperator (d := d) 2 N hN i (groundBond A)).prod
+  have hUstarU : F.unitaryᴴ * F.unitary = 1 := by
+    simpa only [Matrix.star_eq_conjTranspose] using
+      Unitary.star_mul_self_of_mem F.unitary_mem
+  have hUUstar : F.unitary * F.unitaryᴴ = 1 := by
+    simpa only [Matrix.star_eq_conjTranspose] using
+      Unitary.mul_star_self_of_mem F.unitary_mem
+  have hWstarW : Wᴴ * W = 1 := by
+    simp only [W, MPOTensor.sitewisePhysicalMatrix_conjTranspose,
+      Matrix.conjTranspose_conjTranspose]
+    rw [← MPOTensor.sitewisePhysicalMatrix_conjTranspose,
+      MPOTensor.sitewisePhysicalMatrix_mul_conjTranspose, hUUstar,
+      MPOTensor.sitewisePhysicalMatrix_one]
+  have hprod := MPOTensor.singleKrausMap_bondProduct_of_unitary F.unitaryᴴ
+    (by simpa using hUUstar) (by simpa using hUstarU) hN (groundBond A)
+  simp_rw [singleKrausMap_groundBond_eq_transformedGroundBond] at hprod
+  have htrace := F.transformedGroundBondProduct_trace hN
+  rw [← hprod] at htrace
+  calc
+    Matrix.trace Q = Matrix.trace (singleKrausMap W Q) := by
+      simp only [singleKrausMap_apply]
+      symm
+      rw [Matrix.trace_mul_comm (W * Q) Wᴴ, ← Matrix.mul_assoc, hWstarW,
+        Matrix.one_mul]
+    _ = _ := by simpa only [Q, W] using htrace
+
+private theorem localComplementProductES_trace (F : BeigiSectorGraphData A)
+    {N : ℕ} [NeZero N] (hN : 2 ≤ N) :
+    LinearMap.trace ℂ (EuclideanSpace ℂ (Cfg d N))
+        (List.ofFn fun i : Fin N ↦ 1 - localTermES A 2 i).prod =
+      ∑ k : Fin N → Fin F.sectorCount,
+        (↑(∏ n : Fin N,
+          Module.finrank ℂ (F.edgeGroundSpace (k n) (k (n + 1)))) : ℂ) := by
+  classical
+  let qMatrix := (List.ofFn fun i : Fin N ↦
+    MPOTensor.embedLocalOperator (d := d) 2 N hN i (groundBond A)).prod
+  let qRaw := (List.ofFn fun i : Fin N ↦ 1 - localTerm A 2 N i).prod
+  let qES := (List.ofFn fun i : Fin N ↦ 1 - localTermES A 2 i).prod
+  let e := WithLp.linearEquiv 2 ℂ (NSiteSpace d N)
+  have hfactor (i : Fin N) : Matrix.toLin'
+      (MPOTensor.embedLocalOperator (d := d) 2 N hN i (groundBond A)) =
+      1 - localTerm A 2 N i := by
+    rw [embedLocalOperator_groundBond_eq_one_sub]
+    change (Matrix.toLinAlgEquiv' :
+      Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ ≃ₐ[ℂ]
+        Module.End ℂ (NSiteSpace d N))
+        (1 - MPOTensor.embedLocalOperator (d := d) 2 N hN i
+          (LinearMap.toMatrix' (parentInteraction A 2))) = _
+    rw [map_sub, map_one]
+    change 1 - Matrix.toLin'
+      (MPOTensor.embedLocalOperator (d := d) 2 N hN i
+        (LinearMap.toMatrix' (parentInteraction A 2))) = _
+    rw [localTerm_eq_toLin'_embedLocalOperator (A := A) hN i]
+  have hMatrix : Matrix.toLin' qMatrix = qRaw := by
+    change (Matrix.toLinAlgEquiv' :
+      Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ ≃ₐ[ℂ]
+        Module.End ℂ (NSiteSpace d N)) qMatrix = qRaw
+    simp only [qMatrix, qRaw]
+    rw [map_list_prod, List.map_ofFn]
+    apply congrArg List.prod
+    apply congrArg List.ofFn
+    funext i
+    exact hfactor i
+  have hES : (LinearEquiv.conjAlgEquiv ℂ e.symm) qRaw = qES := by
+    simp only [qRaw, qES]
+    rw [map_list_prod, List.map_ofFn]
+    apply congrArg List.prod
+    apply congrArg List.ofFn
+    funext i
+    simp only [Function.comp_apply, map_sub, map_one, localTermES, e,
+      LinearEquiv.conjAlgEquiv_apply, LinearEquiv.symm_symm]
+  calc
+    LinearMap.trace ℂ (EuclideanSpace ℂ (Cfg d N)) qES =
+        LinearMap.trace ℂ (NSiteSpace d N) qRaw := by
+          rw [← hES]
+          exact LinearMap.trace_conj' qRaw e.symm
+    _ = Matrix.trace qMatrix := by
+      rw [← hMatrix, Matrix.trace_toLin'_eq]
+    _ = _ := F.groundBondProduct_trace hN
+
+private theorem parentHamiltonianGroundSpaceES_finrank_eq_all_sequences
+    (F : BeigiSectorGraphData A) {N : ℕ} [NeZero N] (hN : 2 ≤ N) :
+    Module.finrank ℂ (parentHamiltonianGroundSpaceES A 2 N) =
+      ∑ k : Fin N → Fin F.sectorCount,
+        ∏ n : Fin N, Module.finrank ℂ (F.edgeGroundSpace (k n) (k (n + 1))) := by
+  classical
+  have hproj := LinearMap.isProj_ker_sum_listProd_one_sub
+    (fun i : Fin N ↦ localTermES A 2 i)
+    (fun i ↦ localTermES_isSymmetricProjection A 2 i)
+    (fun i j ↦ F.localTermES_commute hN i j)
+  rw [← parentHamiltonianES_eq_sum_localTermES] at hproj
+  have htrace := hproj.trace
+  rw [F.localComplementProductES_trace hN] at htrace
+  norm_cast at htrace
+  rw [parentHamiltonianGroundSpaceES_eq_ker_parentHamiltonianES]
+  exact htrace.symm
+
+/-- Beigi's finite-chain ground-space dimension formula: for a periodic chain
+of length greater than two, the dimension is the sum over ordered cyclic
+sector sequences of the products of the adjacent edge-ground-space
+dimensions.
+
+Source: Beigi, arXiv:1105.1019v2, Section III, equations (3)--(4), page 4. -/
+theorem parentHamiltonianGroundSpaceES_finrank_eq
+    (F : BeigiSectorGraphData A) {N : ℕ} (hN : 2 < N) :
+    letI : NeZero N := ⟨by omega⟩
+    Module.finrank ℂ (parentHamiltonianGroundSpaceES A 2 N) =
+      ∑ c : F.OrderedCycle N,
+        ∏ n : Fin N,
+          Module.finrank ℂ (F.edgeGroundSpace (c.1 n) (c.1 (n + 1))) := by
+  classical
+  letI : NeZero N := ⟨by omega⟩
+  let weight : (Fin N → Fin F.sectorCount) → ℕ := fun k ↦
+    ∏ n : Fin N, Module.finrank ℂ (F.edgeGroundSpace (k n) (k (n + 1)))
+  let cycle : (Fin N → Fin F.sectorCount) → Prop := fun k ↦
+    ∀ n : Fin N, F.IsEdge (k n) (k (n + 1))
+  rw [F.parentHamiltonianGroundSpaceES_finrank_eq_all_sequences (by omega)]
+  change ∑ k : Fin N → Fin F.sectorCount, weight k =
+    ∑ c : {k // cycle k}, weight c.1
+  calc
+    ∑ k : Fin N → Fin F.sectorCount, weight k =
+        ∑ k ∈ Finset.univ.filter cycle, weight k := by
+      symm
+      apply Finset.sum_subset (Finset.filter_subset cycle Finset.univ)
+      intro k _ hk
+      have hncycle : ¬cycle k := by simpa using hk
+      simp only [cycle, not_forall] at hncycle
+      obtain ⟨n, hn⟩ := hncycle
+      have hbot : F.edgeGroundSpace (k n) (k (n + 1)) = ⊥ :=
+        not_ne_iff.mp hn
+      change (∏ m : Fin N,
+        Module.finrank ℂ (F.edgeGroundSpace (k m) (k (m + 1)))) = 0
+      rw [Finset.prod_eq_zero (Finset.mem_univ n)]
+      exact Submodule.finrank_eq_zero.mpr hbot
+    _ = ∑ c : {k // cycle k}, weight c.1 := by
+      exact Finset.sum_subtype (Finset.univ.filter cycle) (by simp) weight
+
+end BeigiSectorGraphData
+
+end MPSTensor

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -2358,6 +2358,59 @@ specialization of that Appendix~D definition.
     Theorem~\ref{thm:two_site_parent_interaction_commuting_overlaps}.
 \end{proof}
 
+\begin{definition}[Finite sector graph]\label{def:beigi_sector_graph}
+    \lean{MPSTensor.BeigiSectorGraphData}
+    \lean{MPSTensor.BeigiSectorGraphData.edgeGroundSpace}
+    \lean{MPSTensor.BeigiSectorGraphData.IsEdge}
+    \lean{MPSTensor.BeigiSectorGraphData.OrderedCycle}
+    \leanok
+    Suppose that a one-site unitary identifies the physical Hilbert space with
+    a finite direct sum
+    \[
+        \mathcal H\cong\bigoplus_a
+        \mathcal H_{a,l}\otimes\mathcal H_{a,r},
+    \]
+    and that in these coordinates the complementary two-site interaction is
+    \[
+        \bigoplus_{a,b}
+        \mathbf 1_{a,l}\otimes P_{a,b}\otimes\mathbf 1_{b,r},
+    \]
+    where each $P_{a,b}$ is an orthogonal projector.  The directed edge
+    $a\to b$ is present precisely when $\operatorname{ran}P_{a,b}$ is nonzero.
+    An ordered cycle of length $N$ is a sequence $(a_0,\ldots,a_{N-1})$ for
+    which every cyclically adjacent edge $a_n\to a_{n+1}$ is present.  Cyclic
+    rotations are not identified.  This is the graph following equation~(2)
+    of \cite[Section~III]{Beigi2012Classification}.
+\end{definition}
+
+\begin{theorem}[Ordered-cycle ground-space dimension formula]
+    \label{thm:beigi_ordered_cycle_ground_space_dimension}
+    \lean{MPSTensor.BeigiSectorGraphData.parentHamiltonianGroundSpaceES_finrank_eq}
+    \leanok
+    \uses{def:beigi_sector_graph}
+    For every $N>2$, the periodic ground-space dimension is
+    \[
+        \dim\ker H_N
+        =
+        \sum_{(a_0,\ldots,a_{N-1})}
+        \prod_{n=0}^{N-1}
+        \dim\operatorname{ran}P_{a_n,a_{n+1}},
+    \]
+    where the sum is over ordered cycles and the indices are read modulo $N$.
+    This is equations~(3)--(4) of
+    \cite[Section~III]{Beigi2012Classification}.
+\end{theorem}
+
+\begin{proof}\leanok
+    The translated parent interactions commute.  Hence the ordered product of
+    their complementary orthogonal projectors is the projector onto
+    $\ker H_N$.  In the cyclic sector coordinates this product is block
+    diagonal, with the block indexed by $(a_0,\ldots,a_{N-1})$ equal to the
+    tensor product of the adjacent projectors $P_{a_n,a_{n+1}}$.  Taking the
+    trace gives the product of their ranks.  A sequence containing a missing
+    edge contributes zero, leaving exactly the displayed ordered-cycle sum.
+\end{proof}
+
 \begin{theorem}[All-chain nearest-neighbor commuting parent-Hamiltonian ground spaces imply a renormalization fixed point]\label{thm:nncph_implies_rfp}
     \lean{MPSTensor.nncph_implies_rfp}
     \lean{Axioms.beigi_nncph_to_rfp}

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -164,8 +164,10 @@ non-periodic FT cleanup loop unless explicitly brought back into scope.
   tracked by issue #952.
 - `cpsv16_nncph_ground_state_scope.tex` records the separation between the
   zero-energy ground-vector predicate and the source ground-space spanning
-  predicates for CPSV16 Theorem 3.10(iii). The all-chain condition is now
-  named, but the spanning equation has not been proved for concrete tensors.
+  predicates for CPSV16 Theorem 3.10(iii). The finite Beigi sector graph and
+  its ordered-cycle ground-space dimension formula are formalized; reducing
+  the graph by eventual constancy and identifying its states with the chosen
+  normal-tensor basis remain open.
 - `cpsv16_parent_commuting_hamiltonian_scope.tex` records that the current
   parent commuting Hamiltonian predicate keeps only the idempotent-product
   consequence of CPSV16 Definition D.2, while the source definition also has

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -267,8 +267,13 @@ canonical-form or ground-space-spanning assumption.  Its direct consequence
 \hspace{0pt}\leanid{exists_unitary_blockActions_of_twoSiteParentInteractionMatrix}
 decomposes the middle physical space into a finite direct sum of left and
 right tensor factors on which the two adjacent interactions act separately.
-This completes the local Bravyi--Vyalyi step.  It does not yet construct the
-finite sector graph or analyze its cyclic ground spaces.
+The subsequent sector datum is now formalized in
+\leanid{MPSTensor.BeigiSectorGraphData}.  From its source equation~(2) alone,
+\leanid{MPSTensor.BeigiSectorGraphData.parentHamiltonianGroundSpaceES_finrank_eq}
+constructs the finite directed graph and proves Beigi's ordered-cycle
+ground-space dimension formula for every $N>2$.  No chain-level ground-space
+equation, eventual degeneracy, or canonical-form datum is assumed in this
+sector-graph theorem.
 
 \section{Elimination plan}
 
@@ -287,9 +292,10 @@ including the spanning condition in the parent-Hamiltonian ground-space clause:
 The forward commutation implication uses the basic-vector form in
 Theorem~3.11 and the corresponding local projectors.  The reverse implication
 must internalize the remaining part of Beigi's one-dimensional
-nearest-neighbor commuting-Hamiltonian ground-space classification: construct
-the finite sector graph, use eventual degeneracy constancy to reduce its cycles
-to loops with one-dimensional cyclic edge kernels, and identify the resulting
+nearest-neighbor commuting-Hamiltonian ground-space classification: use
+eventual degeneracy constancy together with the proved finite-sector-graph
+dimension formula to reduce its cycles to loops with one-dimensional cyclic
+edge kernels, and identify the resulting
 locally orthogonal product-of-pairs states with the basis of normal tensors of
 $A$.\footnote{Tracked by \ghissue{2633}.}
 
@@ -312,9 +318,9 @@ canonical form is subject to the source obstruction recorded in
 ground-space spanning clause and the multiplicity-one distinct-sector
 extension are proved. The repeated-copy and arbitrary-raw-weight extension
 remains open.  In the reverse direction, eventual ground-space dimension
-stability and the local spatial decomposition are proved; the sector-graph
-classification and its identification with the basis of normal tensors remain
-open.
+stability, the local spatial decomposition, and the ordered-cycle sector-graph
+dimension formula are proved.  The reduction of this graph under eventual
+constancy and its identification with the basis of normal tensors remain open.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

- define the finite sector graph from Beigi equation (2), using only the one-site spatial coordinates and the edge ground projectors
- prove that the ordered product of complementary commuting projections is the projector onto the kernel of their sum
- prove Beigi equations (3)--(4): for every periodic length N > 2, the parent-Hamiltonian ground-space dimension is the ordered-cycle sum of products of adjacent edge-ground-space dimensions
- record the theorem in the blueprint and narrow the remaining CPSV16 reverse-implication gap

## Source alignment

The theorem follows Beigi, arXiv:1105.1019v2, Section III, equations (2)--(4). The sector datum contains no finite-chain ground-space equation, eventual-degeneracy assumption, scale-invariance assumption, or canonical-form assumption.

## Verification

- lake env lean TNLean/Algebra/CommutingProjectionProduct.lean
- lake env lean TNLean/MPS/MPDO/CommutingForm.lean
- lake env lean TNLean/MPS/MPDO/CommutingBondEtaCyclicTransport.lean
- lake env lean TNLean/MPS/RFP/BeigiSectorGraph.lean
- proof-integrity scan: no sorry, admit, axiom, native_decide, or unsafeCast in changed Lean files
- TNLean.lean remains exactly 1000 lines

Closes #4375.
Advances #2633.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new formal proofs in parent-Hamiltonian / RFP ground-space theory with many dependencies; incorrect projection or trace identities would skew dimension formulas, but changes are additive with no auth or runtime surface.
> 
> **Overview**
> Adds a **Lean proof of Beigi’s ordered-cycle ground-space dimension formula** (Section III, eqs. (3)–(4)) for periodic chains with \(N>2\), from local spatial data only—no chain-level ground-space axiom, eventual degeneracy, or canonical form.
> 
> **New algebra:** `CommutingProjectionProduct` shows that for commuting symmetric projections, the ordered product \(\prod_i (1-P_i)\) is the projector onto \(\ker(\sum_i P_i)\), plus `Matrix.trace_piProduct` for dependent-product traces.
> 
> **New RFP module `BeigiSectorGraph`:** `BeigiSectorGraphData` packages the one-site unitary, sector factors, and edge ground projectors; defines directed edges and `OrderedCycle` sequences; proves `parentHamiltonianGroundSpaceES_finrank_eq` by commuting local terms, block-diagonalizing the complementary bond product in cyclic \(\eta\) coordinates, and matching traces to products of edge ground-space dimensions (zeroing sequences with a missing edge).
> 
> **MPDO support:** public `embedLocalOperator_mulVec_apply` and `singleKrausMap_sitewise_conjTranspose_two_eq`; new `embedLocalOperator_commute_of_etaPair_decomposition` and singleton edge-partial-product commutation in `CommutingBondEtaCyclicTransport`.
> 
> **Docs:** blueprint definition/theorem for the finite sector graph; CPSV16 gap notes updated to mark the sector-graph dimension step proved and graph reduction / BNT identification still open. Root imports wired in `TNLean.lean`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c8c7978d20004809c5b0cedfc674c744946ca83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->