### PR TITLE
feat(MPS/MPDO): prove vertical-sector trace preservation

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -479,6 +479,7 @@ import TNLean.MPS.MPDO.VerticalSectorFixedGenerators
 import TNLean.MPS.MPDO.VerticalSectorTraceLoss
 import TNLean.MPS.MPDO.VerticalSectorImagePreservation
 import TNLean.MPS.MPDO.VerticalSectorGeneration
+import TNLean.MPS.MPDO.VerticalSectorTracePreservation
 import TNLean.MPS.MPDO.PRFP
 import TNLean.MPS.MPDO.LocalPurificationRFP
 import TNLean.MPS.MPDO.SimpleLocalStructure
@@ -594,7 +595,6 @@ import TNLean.MPS.MPDO.GSNNCHSectorSum
 import TNLean.MPS.MPDO.GSNNCHOrthogonalSectors
 import TNLean.MPS.MPDO.BNTSectorCommutingFamily
 import TNLean.MPS.MPDO.BlockedRFPConstruction
-
 -- MPS examples
 import TNLean.MPS.Examples.AKLT
 import TNLean.MPS.Examples.AKLTCorrelation

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -90,12 +90,10 @@ import TNLean.Analysis.LiebScalarIntegral
 import TNLean.Analysis.LiebOperatorIntegral
 import TNLean.Analysis.LiebIntegrandConcave
 import TNLean.Analysis.LiebOperatorConcave
-
 -- Layer 1: Generic convex/topological infrastructure
 import TNLean.Topology.ConvexProjection
 import TNLean.Topology.BrouwerProduct
 import TNLean.Topology.CompactRetractFixedPoint
-
 -- Layer 2: Quantum channels (general theory)
 import TNLean.Channel.Basic
 import TNLean.Channel.PositiveExamples
@@ -209,6 +207,8 @@ import TNLean.Channel.FixedPoint.DirectSumExtension
 import TNLean.Channel.FixedPoint.FullSupportBlockRetraction
 import TNLean.Channel.FixedPoint.TraceAdjointDensityBlocks
 import TNLean.Channel.FixedPoint.DirectSumBlockRetraction
+import TNLean.Channel.FixedPoint.TraceNonincreasingProductSpan
+import TNLean.Channel.FixedPoint.TraceNonincreasingDirectSum
 import TNLean.Channel.FixedPoint.CornerAlgebra
 import TNLean.Channel.FixedPoint.CornerBlockForm
 import TNLean.Channel.FixedPoint.StationaryProjection

--- a/TNLean/Algebra/PosSemidefSupport.lean
+++ b/TNLean/Algebra/PosSemidefSupport.lean
@@ -176,4 +176,18 @@ theorem supportProj_mulVec_eq_zero_of_mulVec_eq_zero
     simp [w, U, Matrix.mulVec_mulVec, Matrix.mul_assoc]
   simp [hPdef, hPeval, hSw]
 
+/-- A positive semidefinite matrix whose support projection is the identity
+is positive definite. -/
+theorem posDef_of_supportProj_eq_one
+    (hSupport : hρ.supportProj = 1) : ρ.PosDef := by
+  apply hρ.posDef_iff_isUnit.mpr
+  rw [← Matrix.mulVec_injective_iff_isUnit]
+  intro v w hvw
+  apply sub_eq_zero.mp
+  have hzero : ρ *ᵥ (v - w) = 0 := by
+    rw [Matrix.mulVec_sub, hvw, sub_self]
+  have hsuppzero := hρ.supportProj_mulVec_eq_zero_of_mulVec_eq_zero (v - w) hzero
+  rw [hSupport, Matrix.one_mulVec] at hsuppzero
+  exact hsuppzero
+
 end Matrix.PosSemidef

--- a/TNLean/Algebra/TraceReindex.lean
+++ b/TNLean/Algebra/TraceReindex.lean
@@ -1,0 +1,27 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.LinearAlgebra.Matrix.Reindex
+import Mathlib.LinearAlgebra.Matrix.Trace
+import Mathlib.Data.Complex.Basic
+
+/-!
+# Trace under matrix reindexing
+
+This file records the invariance of the trace under a simultaneous change of
+the row and column index sets.
+-/
+
+namespace Matrix
+
+/-- Trace is invariant under simultaneous reindexing of the rows and columns. -/
+theorem trace_reindex {m n : Type*} [Fintype m] [Fintype n]
+    (e : m ≃ n) (M : Matrix m m ℂ) :
+    Matrix.trace (Matrix.reindex e e M) = Matrix.trace M := by
+  classical
+  simpa [trace, reindex_apply] using
+    Fintype.sum_equiv e.symm _ _ (by intro; simp)
+
+end Matrix

--- a/TNLean/Channel/Basic.lean
+++ b/TNLean/Channel/Basic.lean
@@ -27,6 +27,8 @@ Chapters 3 and 6 of Wolf's lecture notes.
 ## Main results
 
 * `IsPositiveMap`: a linear map that preserves the PSD cone
+* `IsTraceNonincreasingMap`: a linear endomorphism that does not increase the
+  trace of positive semidefinite inputs
 * `IsCPMap`: a linear map that admits a Kraus representation
 * `IsCompletelyCopositiveMap`: a map whose composition with transposition is CP
 * `IsDecomposablePositiveMap`: a sum of a CP map and a completely copositive map
@@ -64,6 +66,19 @@ def IsPositiveMap (E : Matrix n n ℂ →ₗ[ℂ] Matrix m m ℂ) : Prop :=
 /-- A linear map is **trace-preserving** if `Tr(E(X)) = Tr(X)` for all `X`. -/
 def IsTracePreservingMap (E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ) : Prop :=
   ∀ X : Matrix n n ℂ, trace (E X) = trace X
+
+/-- A matrix endomorphism is **trace-nonincreasing** if it does not increase
+the trace of any positive semidefinite input. -/
+def IsTraceNonincreasingMap (E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ) : Prop :=
+  ∀ X : Matrix n n ℂ, X.PosSemidef → trace (E X) ≤ trace X
+
+omit [DecidableEq n] in
+/-- Every trace-preserving matrix endomorphism is trace-nonincreasing. -/
+theorem IsTracePreservingMap.isTraceNonincreasingMap
+    {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
+    (hE : IsTracePreservingMap E) : IsTraceNonincreasingMap E := by
+  intro X _
+  exact (hE X).le
 
 /-- A linear map is **completely positive** if it admits a Kraus representation:
 `E(X) = ∑ᵢ Kᵢ X Kᵢ†` for some family of operators `{Kᵢ}`.

--- a/TNLean/Channel/FixedPoint/DirectSumBlockRetraction.lean
+++ b/TNLean/Channel/FixedPoint/DirectSumBlockRetraction.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.TraceReindex
 import TNLean.Channel.FixedPoint.DirectSumExtension
 import TNLean.Channel.FixedPoint.TraceAdjointDensityBlocks
 
@@ -44,11 +45,6 @@ theorem reindexEndomorphism_apply (e : α ≃ β)
   rfl
 
 omit [DecidableEq α] [DecidableEq β] in
-private theorem trace_reindex (e : α ≃ β) (A : Matrix α α ℂ) :
-    (Matrix.reindex e e A).trace = A.trace := by
-  simpa only [Matrix.reindex_apply] using Matrix.trace_submatrix_equiv e.symm A
-
-omit [DecidableEq α] [DecidableEq β] in
 private theorem trace_reindex_mul (e : α ≃ β) (A : Matrix α α ℂ)
     (B : Matrix β β ℂ) :
     (Matrix.reindex e e A * B).trace =
@@ -68,7 +64,7 @@ private theorem trace_reindex_mul (e : α ≃ β) (A : Matrix α α ℂ)
       exact congrArg Matrix.trace (congrArg (Matrix.reindex e e A * ·) hB)
     _ = (Matrix.reindex e e
           (A * Matrix.reindex e.symm e.symm B)).trace := by rw [hmul]
-    _ = (A * Matrix.reindex e.symm e.symm B).trace := trace_reindex e _
+    _ = (A * Matrix.reindex e.symm e.symm B).trace := Matrix.trace_reindex e _
 
 omit [DecidableEq α] [DecidableEq β] in
 private theorem reindex_conjugation (e : α ≃ β)
@@ -121,7 +117,7 @@ theorem IsTracePreservingMap.reindexEndomorphism
     (hT : IsTracePreservingMap T) (e : α ≃ β) :
     IsTracePreservingMap (reindexEndomorphism e T) := by
   intro A
-  rw [reindexEndomorphism_apply, trace_reindex, hT, trace_reindex]
+  rw [reindexEndomorphism_apply, Matrix.trace_reindex, hT, Matrix.trace_reindex]
 
 omit [DecidableEq α] [DecidableEq β] in
 /-- The trace adjoint commutes with simultaneous reindexing of matrix

--- a/TNLean/Channel/FixedPoint/DirectSumBlockRetraction.lean
+++ b/TNLean/Channel/FixedPoint/DirectSumBlockRetraction.lean
@@ -120,6 +120,21 @@ theorem IsTracePreservingMap.reindexEndomorphism
   rw [reindexEndomorphism_apply, Matrix.trace_reindex, hT, Matrix.trace_reindex]
 
 omit [DecidableEq α] [DecidableEq β] in
+/-- Trace nonincrease is invariant under a simultaneous change of matrix
+coordinates. -/
+theorem IsTraceNonincreasingMap.reindexEndomorphism
+    {T : Matrix α α ℂ →ₗ[ℂ] Matrix α α ℂ}
+    (hT : IsTraceNonincreasingMap T) (e : α ≃ β) :
+    IsTraceNonincreasingMap (reindexEndomorphism e T) := by
+  classical
+  intro A hA
+  rw [reindexEndomorphism_apply, Matrix.trace_reindex]
+  have htrace : Matrix.trace (A.submatrix e e) = Matrix.trace A := by
+    simpa only [Matrix.reindex_apply, Equiv.symm_symm] using
+      Matrix.trace_reindex e.symm A
+  exact (hT _ (hA.submatrix e)).trans_eq htrace
+
+omit [DecidableEq α] [DecidableEq β] in
 /-- The trace adjoint commutes with simultaneous reindexing of matrix
 coordinates. -/
 theorem traceAdjointMap_reindexEndomorphism (e : α ≃ β)

--- a/TNLean/Channel/FixedPoint/MaximalSupportBasic.lean
+++ b/TNLean/Channel/FixedPoint/MaximalSupportBasic.lean
@@ -13,17 +13,20 @@ import TNLean.Channel.Schwarz.PositiveMapProperties
 /-!
 # Maximal support for fixed points of positive maps
 
-For a positive trace-preserving endomorphism, the mean-ergodic image of the
+For a positive endomorphism with bounded orbits, the mean-ergodic image of the
 identity is a positive semidefinite fixed point whose support contains every
 fixed point.  The argument uses only positive-map and finite-dimensional
-support-projection facts.
+support-projection facts.  Trace preservation supplies bounded orbits as a
+special case.
 
 ## Main declarations
 
 * `Kraus.stationaryProj_absorb_of_le_smul` -- scalar domination transfers support.
 * `Kraus.stationaryProj_absorb_of_le` -- Loewner domination transfers support.
-* `IsPositiveMap.exists_maximalSupport_fixedPoint` -- the mean-ergodic image of
-  the identity has support carrying every fixed point.
+* `IsPositiveMap.exists_maximalSupport_fixedPoint_of_hasBoundedOrbits` -- the
+  bounded-orbit form of maximal support.
+* `IsPositiveMap.exists_maximalSupport_fixedPoint` -- the trace-preserving
+  specialization.
 
 ## References
 
@@ -125,6 +128,82 @@ variable {D : ℕ}
 
 local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
 
+/-- The mean-ergodic image of the identity has maximal support among the fixed
+points of a positive endomorphism with bounded orbits.
+
+Unlike the trace-preserving form of Wolf, Proposition 6.9, the support
+argument needs only positivity and bounded orbits. -/
+theorem exists_maximalSupport_fixedPoint_of_hasBoundedOrbits
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT : IsPositiveMap T) (hbounded : T.HasBoundedOrbits) :
+    let ρ₀ := LinearMap.meanErgodicProjection (𝕜 := ℂ)
+      (E := Matrix (Fin D) (Fin D) ℂ) T hbounded 1
+    ∃ hρ₀ : ρ₀.PosSemidef, T ρ₀ = ρ₀ ∧
+      ∀ X, T X = X → stationaryProj hρ₀ * X * stationaryProj hρ₀ = X := by
+  classical
+  dsimp only
+  let P := LinearMap.meanErgodicProjection (𝕜 := ℂ)
+    (E := Matrix (Fin D) (Fin D) ℂ) T hbounded
+  let ρ₀ : Matrix (Fin D) (Fin D) ℂ := P 1
+  have hPpos : IsPositiveMap P := hT.meanErgodicProjection_isPositiveMap hbounded
+  have hρ₀psd : ρ₀.PosSemidef := hPpos 1 Matrix.PosSemidef.one
+  have hPfixed (A : Matrix (Fin D) (Fin D) ℂ) (hA : T A = A) : P A = A :=
+    hbounded.meanErgodicProjection_apply_eq_self_iff A |>.2 hA
+  have hρ₀fix : T ρ₀ = ρ₀ := by
+    apply (hbounded.meanErgodicProjection_apply_eq_self_iff ρ₀).1
+    exact hbounded.meanErgodicProjection_apply_meanErgodicProjection 1
+  refine ⟨hρ₀psd, hρ₀fix, ?_⟩
+  intro X hXfix
+  cases isEmpty_or_nonempty (Fin D) with
+  | inl hD =>
+      letI := hD
+      have hXzero : X = 0 := Subsingleton.elim _ _
+      rw [hXzero, Matrix.mul_zero, Matrix.zero_mul]
+  | inr hD =>
+      letI := hD
+      have hbound (A : Matrix (Fin D) (Fin D) ℂ) (hA : A.PosSemidef) :
+          P A ≤ A.trace • ρ₀ := by
+        have hshift : (A.trace • (1 : Matrix (Fin D) (Fin D) ℂ) - A).PosSemidef :=
+          hA.trace_smul_one_sub_self_posSemidef
+        have himage := hPpos _ hshift
+        change (P (A.trace • (1 : Matrix (Fin D) (Fin D) ℂ) - A)).PosSemidef at himage
+        rw [P.map_sub, P.map_smul] at himage
+        change (A.trace • ρ₀ - P A).PosSemidef at himage
+        exact sub_nonneg.mp himage.nonneg
+      have hsupported (A : Matrix (Fin D) (Fin D) ℂ) (hA : A.PosSemidef) :
+          stationaryProj hρ₀psd * P A * stationaryProj hρ₀psd = P A := by
+        have hPA : (P A).PosSemidef := hPpos A hA
+        obtain ⟨hQA, hAQ⟩ := stationaryProj_absorb_of_le_smul
+          hρ₀psd hPA A.trace (hbound A hA)
+        rw [Matrix.mul_assoc, hAQ, hQA]
+      have hHermitianSupport (H : Matrix (Fin D) (Fin D) ℂ)
+          (hH : H.IsHermitian) (hHfix : T H = H) :
+          stationaryProj hρ₀psd * H * stationaryProj hρ₀psd = H := by
+        let A : Matrix (Fin D) (Fin D) ℂ := H⁺
+        let B : Matrix (Fin D) (Fin D) ℂ := H⁻
+        have hA : A.PosSemidef :=
+          Matrix.nonneg_iff_posSemidef.mp (CFC.posPart_nonneg H)
+        have hB : B.PosSemidef :=
+          Matrix.nonneg_iff_posSemidef.mp (CFC.negPart_nonneg H)
+        have hdecomp : H = A - B := by
+          simpa only [A, B] using
+            (CFC.posPart_sub_negPart H (isSelfAdjoint_iff.mpr hH)).symm
+        rw [← hPfixed H hHfix, hdecomp, P.map_sub, Matrix.mul_sub,
+          Matrix.sub_mul, hsupported A hA, hsupported B hB]
+      obtain ⟨H₁, H₂, hH₁def, hH₂def, hH₁herm, hH₂herm, hXeq⟩ :=
+        Matrix.exists_isHermitian_decomposition X
+      have hXstar : T Xᴴ = Xᴴ := by
+        rw [hT.map_conjTranspose, hXfix]
+      have hH₁fix : T H₁ = H₁ := by
+        rw [hH₁def, T.map_add, hXfix, hXstar]
+      have hH₂fix : T H₂ = H₂ := by
+        rw [hH₂def, T.map_smul, T.map_sub, hXfix, hXstar]
+      have hH₁support := hHermitianSupport H₁ hH₁herm hH₁fix
+      have hH₂support := hHermitianSupport H₂ hH₂herm hH₂fix
+      conv_lhs => rw [hXeq]
+      rw [Matrix.mul_sub, Matrix.sub_mul, Matrix.mul_smul, Matrix.smul_mul,
+        Matrix.mul_smul, Matrix.smul_mul, hH₁support, hH₂support, ← hXeq]
+
 /-- **Maximal support of fixed points.** Let $T$ be a positive trace-preserving
 endomorphism and $T_\infty$ its mean-ergodic projection. Then
 $\rho_0=T_\infty(\mathbf 1)$ is positive semidefinite and fixed by $T$, and its
@@ -139,66 +218,7 @@ theorem exists_maximalSupport_fixedPoint
       (E := Matrix (Fin D) (Fin D) ℂ) T hbounded 1
     ∃ hρ₀ : ρ₀.PosSemidef, T ρ₀ = ρ₀ ∧
       ∀ X : Mat, T X = X → stationaryProj hρ₀ * X * stationaryProj hρ₀ = X := by
-  classical
   dsimp only
-  let hbounded := hT.hasBoundedOrbits_of_tracePreserving hTP
-  let P := LinearMap.meanErgodicProjection (𝕜 := ℂ)
-    (E := Matrix (Fin D) (Fin D) ℂ) T hbounded
-  let ρ₀ : Mat := P 1
-  have hPpos : IsPositiveMap P := hT.meanErgodicProjection_isPositiveMap hbounded
-  have hρ₀psd : ρ₀.PosSemidef := hPpos 1 Matrix.PosSemidef.one
-  have hPfixed (A : Mat) (hA : T A = A) : P A = A :=
-    (hT.meanErgodicProjection_apply_eq_self_iff_of_tracePreserving hTP A).2 hA
-  have hρ₀fix : T ρ₀ = ρ₀ := by
-    apply (hT.meanErgodicProjection_apply_eq_self_iff_of_tracePreserving hTP ρ₀).1
-    exact hbounded.meanErgodicProjection_apply_meanErgodicProjection 1
-  refine ⟨hρ₀psd, hρ₀fix, ?_⟩
-  intro X hXfix
-  cases isEmpty_or_nonempty (Fin D) with
-  | inl hD =>
-      letI := hD
-      have hXzero : X = 0 := Subsingleton.elim _ _
-      rw [hXzero, Matrix.mul_zero, Matrix.zero_mul]
-  | inr hD =>
-      letI := hD
-      obtain ⟨H₁, H₂, hH₁def, hH₂def, hH₁herm, hH₂herm, hXeq⟩ :=
-        Matrix.exists_isHermitian_decomposition X
-      have hXstar : T Xᴴ = Xᴴ := by
-        rw [hT.map_conjTranspose, hXfix]
-      have hH₁fix : T H₁ = H₁ := by
-        rw [hH₁def, T.map_add, hXfix, hXstar]
-      have hH₂fix : T H₂ = H₂ := by
-        rw [hH₂def, T.map_smul, T.map_sub, hXfix, hXstar]
-      obtain ⟨P₁p, P₁m, hP₁p, hP₁m, hH₁parts, hf₁p, hf₁m⟩ :=
-        IsPositiveMap.posSemidef_parts_of_hermitian_fixedPoint
-          T hT hTP hH₁herm hH₁fix
-      obtain ⟨P₂p, P₂m, hP₂p, hP₂m, hH₂parts, hf₂p, hf₂m⟩ :=
-        IsPositiveMap.posSemidef_parts_of_hermitian_fixedPoint
-          T hT hTP hH₂herm hH₂fix
-      have hbound (A : Mat) (hA : A.PosSemidef) (hAfix : T A = A) :
-          A ≤ A.trace • ρ₀ := by
-        have hshift : (A.trace • (1 : Mat) - A).PosSemidef :=
-          hA.trace_smul_one_sub_self_posSemidef
-        have himage := hPpos _ hshift
-        change (P (A.trace • (1 : Mat) - A)).PosSemidef at himage
-        rw [P.map_sub, P.map_smul, hPfixed A hAfix] at himage
-        change (A.trace • ρ₀ - A).PosSemidef at himage
-        exact sub_nonneg.mp himage.nonneg
-      have hsupported (A : Mat) (hA : A.PosSemidef) (hAfix : T A = A) :
-          stationaryProj hρ₀psd * A * stationaryProj hρ₀psd = A := by
-        obtain ⟨hQA, hAQ⟩ := stationaryProj_absorb_of_le_smul
-          hρ₀psd hA A.trace (hbound A hA hAfix)
-        rw [Matrix.mul_assoc, hAQ, hQA]
-      have hH₁support :
-          stationaryProj hρ₀psd * H₁ * stationaryProj hρ₀psd = H₁ := by
-        rw [hH₁parts, Matrix.mul_sub, Matrix.sub_mul,
-          hsupported P₁p hP₁p hf₁p, hsupported P₁m hP₁m hf₁m]
-      have hH₂support :
-          stationaryProj hρ₀psd * H₂ * stationaryProj hρ₀psd = H₂ := by
-        rw [hH₂parts, Matrix.mul_sub, Matrix.sub_mul,
-          hsupported P₂p hP₂p hf₂p, hsupported P₂m hP₂m hf₂m]
-      conv_lhs => rw [hXeq]
-      rw [Matrix.mul_sub, Matrix.sub_mul, Matrix.mul_smul, Matrix.smul_mul,
-        Matrix.mul_smul, Matrix.smul_mul, hH₁support, hH₂support, ← hXeq]
-
+  exact hT.exists_maximalSupport_fixedPoint_of_hasBoundedOrbits
+    (hT.hasBoundedOrbits_of_tracePreserving hTP)
 end IsPositiveMap

--- a/TNLean/Channel/FixedPoint/MeanErgodicProjection.lean
+++ b/TNLean/Channel/FixedPoint/MeanErgodicProjection.lean
@@ -7,12 +7,13 @@ import TNLean.Analysis.MeanErgodic
 import TNLean.Channel.Basic
 
 /-!
-# Positive trace-preserving mean-ergodic projections
+# Positive trace-nonincreasing mean-ergodic projections
 
-A positive trace-preserving endomorphism of a finite-dimensional complex matrix
-algebra has bounded forward orbits.  Its finite-dimensional mean-ergodic
-projection is therefore defined, is positive and trace-preserving, and fixes the
-identity whenever the original map fixes the identity.
+A positive trace-nonincreasing endomorphism of a finite-dimensional complex
+matrix algebra has bounded forward orbits.  Its finite-dimensional
+mean-ergodic projection is therefore defined and positive.  For a
+trace-preserving map, the projection is trace-preserving and fixes the identity
+whenever the original map fixes the identity.
 
 The bounded-orbit estimate is proved directly.  A positive semidefinite orbit
 remains in a bounded trace section of the positive cone.  Hermitian matrices are
@@ -21,8 +22,10 @@ complex linear combinations of two Hermitian matrices.
 
 ## Main statements
 
-* `IsPositiveMap.hasBoundedOrbits_of_tracePreserving`: positivity and trace
-  preservation imply bounded forward orbits on every matrix.
+* `IsPositiveMap.hasBoundedOrbits_of_traceNonincreasing`: positivity and trace
+  nonincrease imply bounded forward orbits on every matrix.
+* `IsPositiveMap.hasBoundedOrbits_of_tracePreserving`: the trace-preserving
+  specialization.
 * `IsPositiveMap.meanErgodicProjection_isPositiveMap`: the mean-ergodic
   projection of a positive map is positive.
 * `IsTracePreservingMap.meanErgodicProjection_isTracePreservingMap`: the
@@ -45,16 +48,16 @@ open scoped Matrix ComplexOrder MatrixOrder Matrix.Norms.Frobenius Topology
 variable {D : ℕ}
 
 /-- The forward orbit of a positive semidefinite matrix under a positive
-trace-preserving endomorphism is bounded.
+trace-nonincreasing endomorphism is bounded.
 
-Indeed, every iterate remains positive semidefinite and has the same trace, so
-the orbit lies in a bounded trace section of the positive cone.
+Indeed, every iterate remains positive semidefinite and its trace does not
+increase, so the orbit lies in a bounded trace section of the positive cone.
 
 Source: Wolf, Proposition 6.3 and Equation (6.14), local source
 `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 226--256. -/
-private theorem IsPositiveMap.isBounded_orbit_of_posSemidef_of_tracePreserving
+private theorem IsPositiveMap.isBounded_orbit_of_posSemidef_of_traceNonincreasing
     {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
-    (hT : IsPositiveMap T) (hTP : IsTracePreservingMap T)
+    (hT : IsPositiveMap T) (hTNI : IsTraceNonincreasingMap T)
     {X : Matrix (Fin D) (Fin D) ℂ} (hX : X.PosSemidef) :
     Bornology.IsBounded (Set.range fun n : ℕ ↦ T^[n] X) := by
   have hiter_pos : ∀ n : ℕ, (T^[n] X).PosSemidef := by
@@ -64,19 +67,30 @@ private theorem IsPositiveMap.isBounded_orbit_of_posSemidef_of_tracePreserving
     | succ n ih =>
         rw [Function.iterate_succ_apply']
         exact hT _ ih
-  have hiter_trace : ∀ n : ℕ, Matrix.trace (T^[n] X) = Matrix.trace X := by
+  have hiter_trace : ∀ n : ℕ, Matrix.trace (T^[n] X) ≤ Matrix.trace X := by
     intro n
     induction n with
     | zero => rfl
     | succ n ih =>
-        rw [Function.iterate_succ_apply', hTP, ih]
+        rw [Function.iterate_succ_apply']
+        exact (hTNI _ (hiter_pos n)).trans ih
+  have hiter_trace_norm : ∀ n : ℕ,
+      ‖Matrix.trace (T^[n] X)‖ ≤ ‖Matrix.trace X‖ := by
+    intro n
+    rw [show ‖Matrix.trace (T^[n] X)‖ = (Matrix.trace (T^[n] X)).re from by
+        simpa using congrArg Complex.re
+          (Complex.norm_of_nonneg' (hiter_pos n).trace_nonneg),
+      show ‖Matrix.trace X‖ = (Matrix.trace X).re from by
+        simpa using congrArg Complex.re (Complex.norm_of_nonneg' hX.trace_nonneg)]
+    rw [← sub_nonneg]
+    simpa using (RCLike.nonneg_iff.mp (sub_nonneg.mpr (hiter_trace n))).1
   apply (posSemidef_trace_bounded_isBounded ‖Matrix.trace X‖).subset
   intro Y hY
   obtain ⟨n, rfl⟩ := hY
-  exact ⟨hiter_pos n, by rw [hiter_trace n]⟩
+  exact ⟨hiter_pos n, hiter_trace_norm n⟩
 
 /-- The forward orbit of a Hermitian matrix under a positive
-trace-preserving endomorphism is bounded.
+trace-nonincreasing endomorphism is bounded.
 
 The matrix is the difference of its positive and negative parts.  Each part
 has a bounded positive semidefinite orbit, and linearity gives the stated
@@ -84,9 +98,9 @@ bound.
 
 Source: Wolf, Proposition 6.3 and Equation (6.14), local source
 `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 226--256. -/
-private theorem IsPositiveMap.isBounded_orbit_of_isHermitian_of_tracePreserving
+private theorem IsPositiveMap.isBounded_orbit_of_isHermitian_of_traceNonincreasing
     {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
-    (hT : IsPositiveMap T) (hTP : IsTracePreservingMap T)
+    (hT : IsPositiveMap T) (hTNI : IsTraceNonincreasingMap T)
     {X : Matrix (Fin D) (Fin D) ℂ} (hX : X.IsHermitian) :
     Bornology.IsBounded (Set.range fun n : ℕ ↦ T^[n] X) := by
   let Q₁ : Matrix (Fin D) (Fin D) ℂ := X⁺
@@ -98,8 +112,8 @@ private theorem IsPositiveMap.isBounded_orbit_of_isHermitian_of_tracePreserving
   have hdecomp : X = Q₁ - Q₂ := by
     simpa only [Q₁, Q₂] using
       (CFC.posPart_sub_negPart X (isSelfAdjoint_iff.mpr hX)).symm
-  have hb₁ := hT.isBounded_orbit_of_posSemidef_of_tracePreserving hTP hQ₁
-  have hb₂ := hT.isBounded_orbit_of_posSemidef_of_tracePreserving hTP hQ₂
+  have hb₁ := hT.isBounded_orbit_of_posSemidef_of_traceNonincreasing hTNI hQ₁
+  have hb₂ := hT.isBounded_orbit_of_posSemidef_of_traceNonincreasing hTNI hQ₂
   rw [isBounded_iff_forall_norm_le] at hb₁ hb₂ ⊢
   obtain ⟨C₁, hC₁⟩ := hb₁
   obtain ⟨C₂, hC₂⟩ := hb₂
@@ -110,6 +124,51 @@ private theorem IsPositiveMap.isBounded_orbit_of_isHermitian_of_tracePreserving
   rw [hdecomp, iterate_map_sub]
   calc
     ‖T^[n] Q₁ - T^[n] Q₂‖ ≤ ‖T^[n] Q₁‖ + ‖T^[n] Q₂‖ := norm_sub_le _ _
+    _ ≤ C₁ + C₂ := add_le_add (hC₁ _ ⟨n, rfl⟩) (hC₂ _ ⟨n, rfl⟩)
+
+/-- A positive trace-nonincreasing matrix endomorphism has bounded forward
+orbits. Positive orbits remain in the bounded trace section determined by
+their initial trace; Hermitian decomposition gives the general case.
+
+This is the trace-nonincreasing form of Wolf, Proposition 6.3. -/
+theorem IsPositiveMap.hasBoundedOrbits_of_traceNonincreasing
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT : IsPositiveMap T) (hTNI : IsTraceNonincreasingMap T) :
+    T.HasBoundedOrbits := by
+  intro X
+  let H₁ : Matrix (Fin D) (Fin D) ℂ := X + Xᴴ
+  let H₂ : Matrix (Fin D) (Fin D) ℂ := Complex.I • (X - Xᴴ)
+  have hH₁ : H₁.IsHermitian := by
+    ext i j
+    simp [H₁, add_comm]
+  have hH₂ : H₂.IsHermitian := by
+    ext i j
+    simp [H₂, sub_eq_add_neg, add_comm]
+  have hdecomp : X = (2 : ℂ)⁻¹ • (H₁ - Complex.I • H₂) := by
+    ext i j
+    simp only [H₁, H₂, Matrix.add_apply, Matrix.sub_apply, Matrix.smul_apply,
+      smul_eq_mul]
+    ring_nf
+    rw [Complex.I_sq]
+    ring
+  have hb₁ := hT.isBounded_orbit_of_isHermitian_of_traceNonincreasing hTNI hH₁
+  have hb₂ := hT.isBounded_orbit_of_isHermitian_of_traceNonincreasing hTNI hH₂
+  rw [isBounded_iff_forall_norm_le] at hb₁ hb₂ ⊢
+  obtain ⟨C₁, hC₁⟩ := hb₁
+  obtain ⟨C₂, hC₂⟩ := hb₂
+  refine ⟨‖(2 : ℂ)⁻¹‖ * (C₁ + C₂), ?_⟩
+  intro Y hY
+  obtain ⟨n, rfl⟩ := hY
+  change ‖T^[n] X‖ ≤ ‖(2 : ℂ)⁻¹‖ * (C₁ + C₂)
+  rw [hdecomp, ← Module.End.coe_pow]
+  simp only [map_smul, map_sub]
+  rw [norm_smul]
+  apply mul_le_mul_of_nonneg_left _ (norm_nonneg _)
+  calc
+    ‖(T ^ n) H₁ - Complex.I • (T ^ n) H₂‖ ≤
+        ‖(T ^ n) H₁‖ + ‖Complex.I • (T ^ n) H₂‖ := norm_sub_le _ _
+    _ = ‖T^[n] H₁‖ + ‖T^[n] H₂‖ := by
+      simp only [norm_smul, Complex.norm_I, one_mul, Module.End.coe_pow]
     _ ≤ C₁ + C₂ := add_le_add (hC₁ _ ⟨n, rfl⟩) (hC₂ _ ⟨n, rfl⟩)
 
 /-- A positive trace-preserving endomorphism of a finite-dimensional complex
@@ -128,42 +187,8 @@ Source: Wolf, Proposition 6.3 and Equation (6.14), local source
 theorem IsPositiveMap.hasBoundedOrbits_of_tracePreserving
     {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
     (hT : IsPositiveMap T) (hTP : IsTracePreservingMap T) :
-    T.HasBoundedOrbits := by
-  intro X
-  let H₁ : Matrix (Fin D) (Fin D) ℂ := X + Xᴴ
-  let H₂ : Matrix (Fin D) (Fin D) ℂ := Complex.I • (X - Xᴴ)
-  have hH₁ : H₁.IsHermitian := by
-    ext i j
-    simp [H₁, add_comm]
-  have hH₂ : H₂.IsHermitian := by
-    ext i j
-    simp [H₂, sub_eq_add_neg, add_comm]
-  have hdecomp : X = (2 : ℂ)⁻¹ • (H₁ - Complex.I • H₂) := by
-    ext i j
-    simp only [H₁, H₂, Matrix.add_apply, Matrix.sub_apply, Matrix.smul_apply,
-      smul_eq_mul]
-    ring_nf
-    rw [Complex.I_sq]
-    ring
-  have hb₁ := hT.isBounded_orbit_of_isHermitian_of_tracePreserving hTP hH₁
-  have hb₂ := hT.isBounded_orbit_of_isHermitian_of_tracePreserving hTP hH₂
-  rw [isBounded_iff_forall_norm_le] at hb₁ hb₂ ⊢
-  obtain ⟨C₁, hC₁⟩ := hb₁
-  obtain ⟨C₂, hC₂⟩ := hb₂
-  refine ⟨‖(2 : ℂ)⁻¹‖ * (C₁ + C₂), ?_⟩
-  intro Y hY
-  obtain ⟨n, rfl⟩ := hY
-  change ‖T^[n] X‖ ≤ ‖(2 : ℂ)⁻¹‖ * (C₁ + C₂)
-  rw [hdecomp, ← Module.End.coe_pow]
-  simp only [map_smul, map_sub]
-  rw [norm_smul]
-  apply mul_le_mul_of_nonneg_left _ (norm_nonneg _)
-  calc
-    ‖(T ^ n) H₁ - Complex.I • (T ^ n) H₂‖ ≤
-        ‖(T ^ n) H₁‖ + ‖Complex.I • (T ^ n) H₂‖ := norm_sub_le _ _
-    _ = ‖T^[n] H₁‖ + ‖T^[n] H₂‖ := by
-      simp only [norm_smul, Complex.norm_I, one_mul, Module.End.coe_pow]
-    _ ≤ C₁ + C₂ := add_le_add (hC₁ _ ⟨n, rfl⟩) (hC₂ _ ⟨n, rfl⟩)
+    T.HasBoundedOrbits :=
+  hT.hasBoundedOrbits_of_traceNonincreasing hTP.isTraceNonincreasingMap
 
 /-- The finite-dimensional mean-ergodic projection of a positive matrix
 endomorphism is positive.

--- a/TNLean/Channel/FixedPoint/TraceNonincreasingDirectSum.lean
+++ b/TNLean/Channel/FixedPoint/TraceNonincreasingDirectSum.lean
@@ -44,6 +44,15 @@ def IsTracePreservingBetweenDirectSums
       (∀ l, Matrix (m l) (m l) ℂ)) : Prop :=
   ∀ A, ∑ l, (T A l).trace = ∑ k, (A k).trace
 
+omit [DecidableEq ι] [(k : ι) → DecidableEq (n k)] in
+/-- For an endomorphism of one finite direct sum, the rectangular and
+endomorphism formulations of total-trace preservation agree. -/
+theorem isTracePreservingBetweenDirectSums_iff_isTracePreservingDirectSumMap
+    {T : (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ]
+      (∀ k, Matrix (n k) (n k) ℂ)} :
+    IsTracePreservingBetweenDirectSums T ↔ IsTracePreservingDirectSumMap T :=
+  Iff.rfl
+
 /-- A map between two finite direct sums does not increase the total trace of
 a positive family. -/
 def IsTraceNonincreasingBetweenDirectSums
@@ -128,7 +137,7 @@ theorem isTracePreservingBetweenDirectSums_of_comp_of_traceNonincreasing
       ∀ l, (T A l).PosSemidef)
     (hTNI : IsTraceNonincreasingBetweenDirectSums T)
     (hSNI : IsTraceNonincreasingBetweenDirectSums S)
-    (hComp : IsTracePreservingDirectSumMap (S.comp T)) :
+    (hComp : IsTracePreservingBetweenDirectSums (S.comp T)) :
     IsTracePreservingBetweenDirectSums T := by
   apply isTracePreservingBetweenDirectSums_of_posSemidef
   intro A hA

--- a/TNLean/Channel/FixedPoint/TraceNonincreasingDirectSum.lean
+++ b/TNLean/Channel/FixedPoint/TraceNonincreasingDirectSum.lean
@@ -46,7 +46,7 @@ def IsTracePreservingBetweenDirectSums
 
 /-- A map between two finite direct sums does not increase the total trace of
 a positive family. -/
-def IsDirectSumTraceNonincreasing
+def IsTraceNonincreasingBetweenDirectSums
     {κ : Type*} {m : κ → Type*} [Fintype κ] [(l : κ) → Fintype (m l)]
     (T : (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ]
       (∀ l, Matrix (m l) (m l) ℂ)) : Prop :=
@@ -126,8 +126,8 @@ theorem isTracePreservingBetweenDirectSums_of_comp_of_traceNonincreasing
       (∀ k, Matrix (n k) (n k) ℂ)}
     (hTpos : ∀ A, (∀ k, (A k).PosSemidef) →
       ∀ l, (T A l).PosSemidef)
-    (hTNI : IsDirectSumTraceNonincreasing T)
-    (hSNI : IsDirectSumTraceNonincreasing S)
+    (hTNI : IsTraceNonincreasingBetweenDirectSums T)
+    (hSNI : IsTraceNonincreasingBetweenDirectSums S)
     (hComp : IsTracePreservingDirectSumMap (S.comp T)) :
     IsTracePreservingBetweenDirectSums T := by
   apply isTracePreservingBetweenDirectSums_of_posSemidef
@@ -138,10 +138,10 @@ theorem isTracePreservingBetweenDirectSums_of_comp_of_traceNonincreasing
 
 omit [(k : ι) → DecidableEq (n k)] in
 /-- Trace nonincrease passes to the canonical full-matrix extension. -/
-theorem IsDirectSumTraceNonincreasing.directSumExtension
+theorem IsTraceNonincreasingBetweenDirectSums.directSumExtension
     {T : (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ]
       (∀ k, Matrix (n k) (n k) ℂ)}
-    (hT : IsDirectSumTraceNonincreasing T) :
+    (hT : IsTraceNonincreasingBetweenDirectSums T) :
     IsTraceNonincreasingMap (directSumExtension T) := by
   intro A hA
   rw [directSumExtension_apply, trace_directSumDiagonalEmbedding]
@@ -177,7 +177,7 @@ theorem IsPositiveDirectSumMap.tracePreserving_of_traceNonincreasing_of_fixed_pr
     {T : (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ]
       (∀ k, Matrix (n k) (n k) ℂ)}
     (hT : IsPositiveDirectSumMap T)
-    (hTNI : IsDirectSumTraceNonincreasing T)
+    (hTNI : IsTraceNonincreasingBetweenDirectSums T)
     (V : J → (∀ k, Matrix (n k) (n k) ℂ))
     (L : ℕ) (hL : 0 < L)
     (hFixed : ∀ j, T (V j) = V j)

--- a/TNLean/Channel/FixedPoint/TraceNonincreasingDirectSum.lean
+++ b/TNLean/Channel/FixedPoint/TraceNonincreasingDirectSum.lean
@@ -1,0 +1,240 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.FixedPoint.DirectSumExtension
+import TNLean.Channel.FixedPoint.TraceNonincreasingProductSpan
+
+/-!
+# Trace-nonincreasing maps on finite sums of matrix algebras
+
+The canonical block-diagonal extension transfers trace nonincrease and fixed
+product generators from a finite direct sum to a full matrix algebra.  The
+full-matrix product-span theorem then gives trace preservation on the original
+direct sum.
+
+This is the finite-direct-sum form needed for arXiv:1606.00608, Appendix C.4.
+Lines 1974--1980 identify the fixed contraction families, and lines
+1980--1995 place them in the spanning argument.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder
+
+namespace Matrix
+
+variable {ι : Type*} {n : ι → Type*}
+variable [Fintype ι] [DecidableEq ι]
+variable [(k : ι) → Fintype (n k)] [(k : ι) → DecidableEq (n k)]
+
+/-- The total trace on a finite direct sum of matrix algebras, as a complex
+linear functional. -/
+noncomputable def directSumTraceLinearMap :
+    (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ] ℂ where
+  toFun A := ∑ k, (A k).trace
+  map_add' A B := by simp only [Pi.add_apply, trace_add, Finset.sum_add_distrib]
+  map_smul' c A := by
+    simp only [Pi.smul_apply, trace_smul, RingHom.id_apply, Finset.smul_sum]
+
+/-- A map between two finite direct sums of matrix algebras preserves their
+respective total traces. -/
+def IsTracePreservingBetweenDirectSums
+    {κ : Type*} {m : κ → Type*} [Fintype κ] [(l : κ) → Fintype (m l)]
+    (T : (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ]
+      (∀ l, Matrix (m l) (m l) ℂ)) : Prop :=
+  ∀ A, ∑ l, (T A l).trace = ∑ k, (A k).trace
+
+/-- A map between two finite direct sums does not increase the total trace of
+a positive family. -/
+def IsDirectSumTraceNonincreasing
+    {κ : Type*} {m : κ → Type*} [Fintype κ] [(l : κ) → Fintype (m l)]
+    (T : (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ]
+      (∀ l, Matrix (m l) (m l) ℂ)) : Prop :=
+  ∀ A, (∀ k, (A k).PosSemidef) →
+    (∑ l, (T A l).trace) ≤ ∑ k, (A k).trace
+
+omit [DecidableEq ι] [(k : ι) → DecidableEq (n k)] in
+/-- Equality of total traces on positive families extends to every family. -/
+theorem isTracePreservingBetweenDirectSums_of_posSemidef
+    {κ : Type*} {m : κ → Type*}
+    [Fintype κ] [(l : κ) → Fintype (m l)]
+    {T : (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ]
+      (∀ l, Matrix (m l) (m l) ℂ)}
+    (hT : ∀ A, (∀ k, (A k).PosSemidef) →
+      (∑ l, (T A l).trace) = ∑ k, (A k).trace) :
+    IsTracePreservingBetweenDirectSums T := by
+  classical
+  let τin : (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ] ℂ := directSumTraceLinearMap
+  let τout : (∀ l, Matrix (m l) (m l) ℂ) →ₗ[ℂ] ℂ := directSumTraceLinearMap
+  have hHermitian (H : ∀ k, Matrix (n k) (n k) ℂ)
+      (hH : ∀ k, (H k).IsHermitian) : τout (T H) = τin H := by
+    let P : ∀ k, Matrix (n k) (n k) ℂ := fun k ↦ (H k)⁺
+    let N : ∀ k, Matrix (n k) (n k) ℂ := fun k ↦ (H k)⁻
+    have hP : ∀ k, (P k).PosSemidef := fun k ↦
+      nonneg_iff_posSemidef.mp (CFC.posPart_nonneg (H k))
+    have hN : ∀ k, (N k).PosSemidef := fun k ↦
+      nonneg_iff_posSemidef.mp (CFC.negPart_nonneg (H k))
+    have hdecomp : P - N = H := by
+      funext k
+      exact CFC.posPart_sub_negPart (H k) (isSelfAdjoint_iff.mpr (hH k))
+    have hPtrace : τout (T P) = τin P := hT P hP
+    have hNtrace : τout (T N) = τin N := hT N hN
+    calc
+      τout (T H) = τout (T (P - N)) := by rw [hdecomp]
+      _ = τout (T P) - τout (T N) := by rw [map_sub, map_sub]
+      _ = τin P - τin N := by rw [hPtrace, hNtrace]
+      _ = τin (P - N) := by rw [map_sub]
+      _ = τin H := by rw [hdecomp]
+  intro X
+  let H₁ : ∀ k, Matrix (n k) (n k) ℂ := fun k ↦ X k + (X k)ᴴ
+  let H₂ : ∀ k, Matrix (n k) (n k) ℂ := fun k ↦
+    Complex.I • (X k - (X k)ᴴ)
+  have hH₁ : ∀ k, (H₁ k).IsHermitian := by
+    intro k
+    ext i j
+    simp [H₁, add_comm]
+  have hH₂ : ∀ k, (H₂ k).IsHermitian := by
+    intro k
+    ext i j
+    simp [H₂, sub_eq_add_neg, add_comm]
+  have hdecomp : X = (2 : ℂ)⁻¹ • (H₁ - Complex.I • H₂) := by
+    funext k i j
+    simp only [H₁, H₂, Pi.smul_apply, Pi.sub_apply, Matrix.add_apply,
+      Matrix.sub_apply, Matrix.smul_apply, smul_eq_mul]
+    ring_nf
+    rw [Complex.I_sq]
+    ring
+  have hH₁trace := hHermitian H₁ hH₁
+  have hH₂trace := hHermitian H₂ hH₂
+  change τout (T X) = τin X
+  rw [hdecomp]
+  simp only [map_smul, map_sub, hH₁trace, hH₂trace]
+
+omit [DecidableEq ι] [(k : ι) → DecidableEq (n k)] in
+/-- If two positive trace-nonincreasing maps have a trace-preserving square
+composite, then the first map preserves the total trace.
+
+For a positive input, trace nonincrease gives
+`tr(S(T(X))) ≤ tr(T(X)) ≤ tr(X)`, while preservation by the composite makes
+the endpoints equal. -/
+theorem isTracePreservingBetweenDirectSums_of_comp_of_traceNonincreasing
+    {κ : Type*} {m : κ → Type*}
+    [Fintype κ] [(l : κ) → Fintype (m l)]
+    {T : (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ]
+      (∀ l, Matrix (m l) (m l) ℂ)}
+    {S : (∀ l, Matrix (m l) (m l) ℂ) →ₗ[ℂ]
+      (∀ k, Matrix (n k) (n k) ℂ)}
+    (hTpos : ∀ A, (∀ k, (A k).PosSemidef) →
+      ∀ l, (T A l).PosSemidef)
+    (hTNI : IsDirectSumTraceNonincreasing T)
+    (hSNI : IsDirectSumTraceNonincreasing S)
+    (hComp : IsTracePreservingDirectSumMap (S.comp T)) :
+    IsTracePreservingBetweenDirectSums T := by
+  apply isTracePreservingBetweenDirectSums_of_posSemidef
+  intro A hA
+  apply le_antisymm (hTNI A hA)
+  rw [← hComp A]
+  exact hSNI (T A) (hTpos A hA)
+
+omit [(k : ι) → DecidableEq (n k)] in
+/-- Trace nonincrease passes to the canonical full-matrix extension. -/
+theorem IsDirectSumTraceNonincreasing.directSumExtension
+    {T : (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ]
+      (∀ k, Matrix (n k) (n k) ℂ)}
+    (hT : IsDirectSumTraceNonincreasing T) :
+    IsTraceNonincreasingMap (directSumExtension T) := by
+  intro A hA
+  rw [directSumExtension_apply, trace_directSumDiagonalEmbedding]
+  exact (hT (directSumDiagonalCompression A) fun k =>
+    directSumDiagonalCompression_posSemidef hA k).trans_eq
+      (sum_trace_directSumDiagonalCompression A)
+
+omit [(k : ι) → DecidableEq (n k)] in
+/-- Trace preservation of the full-matrix extension restricts to preservation
+of the total trace on the direct sum. -/
+theorem IsTracePreservingMap.isTracePreservingDirectSumMap_of_extension
+    {T : (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ]
+      (∀ k, Matrix (n k) (n k) ℂ)}
+    (hT : IsTracePreservingMap (directSumExtension T)) :
+    IsTracePreservingDirectSumMap T := by
+  intro A
+  have h := hT (directSumDiagonalEmbedding A)
+  simpa only [directSumExtension_apply, directSumDiagonalCompression_embedding,
+    trace_directSumDiagonalEmbedding] using h
+
+omit [DecidableEq ι] in
+/-- A positive trace-nonincreasing endomorphism of a finite sum of matrix
+algebras preserves the total trace when the identity family lies in the span
+of positive-length products of fixed families.
+
+The block-diagonal embedding preserves products and the identity, so the
+full-matrix fixed-product criterion applies to the canonical extension.  This
+is the finite-sector form of the channel-hypothesis step in
+arXiv:1606.00608, Appendix C.4.  Lines 1974--1980 supply the fixed
+contraction families; lines 1980--1995 supply their spanning context. -/
+theorem IsPositiveDirectSumMap.tracePreserving_of_traceNonincreasing_of_fixed_product_span
+    {J : Type*}
+    {T : (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ]
+      (∀ k, Matrix (n k) (n k) ℂ)}
+    (hT : IsPositiveDirectSumMap T)
+    (hTNI : IsDirectSumTraceNonincreasing T)
+    (V : J → (∀ k, Matrix (n k) (n k) ℂ))
+    (L : ℕ) (hL : 0 < L)
+    (hFixed : ∀ j, T (V j) = V j)
+    (hOne : (1 : ∀ k, Matrix (n k) (n k) ℂ) ∈
+      Submodule.span ℂ (Set.range fun x : Fin L → J ↦
+        (List.ofFn fun t ↦ V (x t)).prod)) :
+    IsTracePreservingDirectSumMap T := by
+  classical
+  let E := directSumExtension T
+  let W : J → Matrix ((k : ι) × n k) ((k : ι) × n k) ℂ :=
+    fun j ↦ directSumDiagonalEmbedding (V j)
+  have hEpos : IsPositiveMap E := hT.directSumExtension_isPositiveMap
+  have hETNI : IsTraceNonincreasingMap E := hTNI.directSumExtension
+  have hWFixed (j : J) : E (W j) = W j := by
+    exact (directSumExtension_embedding_eq_self_iff T (V j)).2 (hFixed j)
+  have hEmbeddingProd (l : List J) :
+      directSumDiagonalEmbedding (l.map V).prod = (l.map W).prod := by
+    induction l with
+    | nil =>
+        simp only [List.map_nil, List.prod_nil]
+        change Matrix.blockDiagonal' (1 : ∀ k, Matrix (n k) (n k) ℂ) = 1
+        exact Matrix.blockDiagonal'_one
+    | cons a l ih =>
+        simp only [List.map_cons, List.prod_cons]
+        rw [directSumDiagonalEmbedding_mul, ih]
+  let productSpan := Submodule.span ℂ
+    (Set.range fun x : Fin L → J ↦ (List.ofFn fun t ↦ W (x t)).prod)
+  have hOneEmbedded :
+      directSumDiagonalEmbedding (1 : ∀ k, Matrix (n k) (n k) ℂ) = 1 := by
+    exact Matrix.blockDiagonal'_one
+  have hOneFull :
+      (1 : Matrix ((k : ι) × n k) ((k : ι) × n k) ℂ) ∈ productSpan := by
+    rw [← hOneEmbedded]
+    exact Submodule.span_induction (p := fun X _ ↦
+        directSumDiagonalEmbedding X ∈ productSpan)
+      (fun X hX ↦ by
+        obtain ⟨x, rfl⟩ := hX
+        apply Submodule.subset_span
+        refine ⟨x, ?_⟩
+        have hprod := hEmbeddingProd (List.ofFn x)
+        rw [List.map_ofFn, List.map_ofFn] at hprod
+        have hfun : V ∘ x = fun t ↦ V (x t) := rfl
+        have hfunW : W ∘ x = fun t ↦ W (x t) := rfl
+        simpa only [hfun, hfunW] using hprod.symm)
+      (by
+        rw [map_zero]
+        exact Submodule.zero_mem productSpan)
+      (fun X Y _ _ hX hY ↦ by
+        rw [map_add]
+        exact Submodule.add_mem productSpan hX hY)
+      (fun c X _ hX ↦ by
+        rw [_root_.map_smul]
+        exact Submodule.smul_mem productSpan c hX)
+      hOne
+  have hETrace : IsTracePreservingMap E :=
+    hEpos.tracePreserving_of_traceNonincreasing_of_fixed_product_span
+      hETNI W L hL hWFixed hOneFull
+  exact Matrix.IsTracePreservingMap.isTracePreservingDirectSumMap_of_extension hETrace
+
+end Matrix

--- a/TNLean/Channel/FixedPoint/TraceNonincreasingProductSpan.lean
+++ b/TNLean/Channel/FixedPoint/TraceNonincreasingProductSpan.lean
@@ -1,0 +1,269 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.TraceReindex
+import TNLean.Channel.FixedPoint.MaximalSupportBasic
+import TNLean.Channel.FixedPoint.MeanErgodicAdjoint
+import TNLean.Channel.FixedPoint.DirectSumBlockRetraction
+
+/-!
+# Trace preservation from fixed product generators
+
+A positive trace-nonincreasing endomorphism is trace preserving when a
+positive-length product family of its fixed points spans the identity.  The
+mean-ergodic image of the identity has maximal support among fixed points.
+Every product of fixed generators remains on that support; spanning the
+identity therefore makes the mean-ergodic fixed point faithful.  The positive
+trace-loss functional must then vanish.
+
+This supplies the channel hypothesis used silently for the transported
+vertical-sector composites in arXiv:1606.00608, Appendix C.4.  Lines
+1974--1980 identify the fixed contraction generators, and lines 1980--1995
+place them in the spanning argument.
+
+## Main results
+
+* `IsPositiveMap.tracePreserving_of_traceNonincreasing_of_fixed_product_span`
+
+## References
+
+* M. Wolf, *Quantum Channels & Operations: Guided Tour*, Proposition 6.3 and
+  Proposition 6.9.
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608, Appendix C.4,
+  lines 1974--1980 and 1980--1995.
+-/
+
+open Filter Function Set
+open scoped Matrix ComplexOrder MatrixOrder Matrix.Norms.Frobenius Topology
+
+variable {D : ℕ}
+
+/-- Trace nonincrease is invariant under a simultaneous change of matrix
+coordinates. -/
+theorem IsTraceNonincreasingMap.reindexEndomorphism
+    {α β : Type*} [Fintype α] [Fintype β]
+    {T : Matrix α α ℂ →ₗ[ℂ] Matrix α α ℂ}
+    (hT : IsTraceNonincreasingMap T) (e : α ≃ β) :
+    IsTraceNonincreasingMap (Matrix.reindexEndomorphism e T) := by
+  classical
+  intro A hA
+  rw [Matrix.reindexEndomorphism_apply, Matrix.trace_reindex]
+  have htrace : Matrix.trace (A.submatrix e e) = Matrix.trace A := by
+    simpa only [Matrix.reindex_apply, Equiv.symm_symm] using
+      Matrix.trace_reindex e.symm A
+  exact (hT _ (hA.submatrix e)).trans_eq htrace
+
+open Kraus
+
+/-- A positive trace-nonincreasing endomorphism is trace preserving when the
+identity lies in the span of positive-length products of a fixed family.
+
+No product is assumed to be fixed.  The fixed factors lie on the support of
+the mean-ergodic image of the identity, so their products do as well.  The
+product-span hypothesis forces this support to be the identity.  Faithfulness
+then makes the positive trace-loss functional vanish.
+
+This is the channel-hypothesis step used at arXiv:1606.00608, Appendix C.4.
+Lines 1974--1980 supply the fixed contraction factors; lines 1980--1995
+supply their spanning context. -/
+private theorem IsPositiveMap.tracePreserving_of_traceNonincreasing_of_fixed_product_span_fin
+    {J : Type*}
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT : IsPositiveMap T) (hTNI : IsTraceNonincreasingMap T)
+    (V : J → Matrix (Fin D) (Fin D) ℂ) (L : ℕ) (hL : 0 < L)
+    (hFixed : ∀ j, T (V j) = V j)
+    (hOne : (1 : Matrix (Fin D) (Fin D) ℂ) ∈
+      Submodule.span ℂ (Set.range fun x : Fin L → J =>
+        (List.ofFn fun t => V (x t)).prod)) :
+    IsTracePreservingMap T := by
+  classical
+  let hbounded := hT.hasBoundedOrbits_of_traceNonincreasing hTNI
+  let ρ := LinearMap.meanErgodicProjection (𝕜 := ℂ)
+    (E := Matrix (Fin D) (Fin D) ℂ) T hbounded 1
+  obtain ⟨hρ, hρfixed, hMaxSupport⟩ :=
+    hT.exists_maximalSupport_fixedPoint_of_hasBoundedOrbits hbounded
+  let Q := stationaryProj hρ
+  have hQidem : Q * Q = Q := (isOrthogonalProjection_stationaryProj hρ).2
+  have hVsupport (j : J) : Q * V j * Q = V j := hMaxSupport _ (hFixed j)
+  have hVleft (j : J) : Q * V j = V j := by
+    calc
+      Q * V j = Q * (Q * V j * Q) := by rw [hVsupport j]
+      _ = (Q * Q) * V j * Q := by simp [Matrix.mul_assoc]
+      _ = Q * V j * Q := by rw [hQidem]
+      _ = V j := hVsupport j
+  have hVright (j : J) : V j * Q = V j := by
+    calc
+      V j * Q = (Q * V j * Q) * Q := by rw [hVsupport j]
+      _ = Q * V j * (Q * Q) := by simp [Matrix.mul_assoc]
+      _ = Q * V j * Q := by rw [hQidem]
+      _ = V j := hVsupport j
+  have hProdAbsorb (l : List J) (hl : l ≠ []) :
+      Q * (l.map V).prod = (l.map V).prod ∧
+        (l.map V).prod * Q = (l.map V).prod := by
+    induction l with
+    | nil => exact (hl rfl).elim
+    | cons a l ih =>
+        constructor
+        · simp only [List.map_cons, List.prod_cons]
+          rw [← Matrix.mul_assoc, hVleft a]
+        · cases l with
+          | nil => simpa using hVright a
+          | cons b l =>
+              have ihtail := (ih (by simp)).2
+              simp only [List.map_cons, List.prod_cons] at ihtail ⊢
+              calc
+                (V a * (V b * (List.map V l).prod)) * Q =
+                    V a * ((V b * (List.map V l).prod) * Q) :=
+                  Matrix.mul_assoc _ _ _
+                _ = V a * (V b * (List.map V l).prod) := by rw [ihtail]
+  have hProductSupport (x : Fin L → J) :
+      Q * (List.ofFn fun t => V (x t)).prod * Q =
+        (List.ofFn fun t => V (x t)).prod := by
+    have hne : List.ofFn x ≠ [] := by
+      intro hempty
+      have hlen := congrArg List.length hempty
+      simp only [List.length_ofFn, List.length_nil] at hlen
+      omega
+    have habsorb := hProdAbsorb (List.ofFn x) hne
+    rw [List.map_ofFn] at habsorb
+    have hfun : V ∘ x = fun t => V (x t) := rfl
+    rw [hfun] at habsorb
+    calc
+      Q * (List.ofFn fun t => V (x t)).prod * Q =
+          (List.ofFn fun t => V (x t)).prod * Q := by rw [habsorb.1]
+      _ = (List.ofFn fun t => V (x t)).prod := habsorb.2
+  have hOneSupport : Q * (1 : Matrix (Fin D) (Fin D) ℂ) * Q = 1 := by
+    exact Submodule.span_induction (p := fun X _ => Q * X * Q = X)
+      (fun Y hY => by
+        obtain ⟨x, rfl⟩ := hY
+        exact hProductSupport x)
+      (by simp)
+      (fun X Y _ _ hX hY => by
+        rw [Matrix.mul_add, Matrix.add_mul, hX, hY])
+      (fun c X _ hX => by
+        rw [Matrix.mul_smul, Matrix.smul_mul, hX])
+      hOne
+  have hQone : Q = 1 := by
+    simpa [hQidem] using hOneSupport
+  have hρposDef : ρ.PosDef := hρ.posDef_of_supportProj_eq_one hQone
+  let gap : Matrix (Fin D) (Fin D) ℂ :=
+    1 - Matrix.traceAdjointMap T 1
+  have hAdjointOne : (Matrix.traceAdjointMap T 1).PosSemidef :=
+    IsPositiveMap.traceAdjointMap hT 1 Matrix.PosSemidef.one
+  have hGapHermitian : gap.IsHermitian := by
+    exact Matrix.IsHermitian.sub Matrix.isHermitian_one hAdjointOne.isHermitian
+  have hGap : gap.PosSemidef := by
+    apply Matrix.PosSemidef.of_forall_trace_mul_nonneg hGapHermitian
+    intro X hX
+    have hloss : 0 ≤ Matrix.trace X - Matrix.trace (T X) :=
+      sub_nonneg.mpr (hTNI X hX)
+    simpa only [gap, Matrix.sub_mul, Matrix.trace_sub, Matrix.one_mul,
+      Matrix.trace_traceAdjointMap_mul] using hloss
+  have hGapTrace : Matrix.trace (ρ * gap) = 0 := by
+    calc
+      Matrix.trace (ρ * gap) = Matrix.trace (gap * ρ) := Matrix.trace_mul_comm _ _
+      _ = Matrix.trace ρ - Matrix.trace (T ρ) := by
+        simp only [gap, Matrix.sub_mul, Matrix.trace_sub, Matrix.one_mul,
+          Matrix.trace_traceAdjointMap_mul]
+      _ = 0 := by rw [hρfixed, sub_self]
+  have hGapZero : gap = 0 :=
+    Matrix.posSemidef_eq_zero_of_posDef_trace_mul_eq_zero hGap hρposDef hGapTrace
+  apply isTracePreservingMap_iff_traceAdjointMap_one.mpr
+  change 1 - Matrix.traceAdjointMap T 1 = 0 at hGapZero
+  exact (sub_eq_zero.mp hGapZero).symm
+
+/-- A positive trace-nonincreasing endomorphism of a finite matrix algebra is
+trace preserving when the identity lies in the span of positive-length
+products of a fixed family.
+
+This coordinate-free finite-index form is obtained from the preceding
+`Fin`-indexed argument by simultaneous matrix reindexing.  In
+arXiv:1606.00608, Appendix C.4, lines 1974--1980 supply the fixed factors to
+which this criterion is applied. -/
+theorem IsPositiveMap.tracePreserving_of_traceNonincreasing_of_fixed_product_span
+    {n J : Type*} [Fintype n] [DecidableEq n]
+    {T : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
+    (hT : IsPositiveMap T) (hTNI : IsTraceNonincreasingMap T)
+    (V : J → Matrix n n ℂ) (L : ℕ) (hL : 0 < L)
+    (hFixed : ∀ j, T (V j) = V j)
+    (hOne : (1 : Matrix n n ℂ) ∈
+      Submodule.span ℂ (Set.range fun x : Fin L → J =>
+        (List.ofFn fun t => V (x t)).prod)) :
+    IsTracePreservingMap T := by
+  classical
+  let e : n ≃ Fin (Fintype.card n) := Fintype.equivFin n
+  let Φ := Matrix.reindexLinearEquiv ℂ ℂ e e
+  let TFin := Matrix.reindexEndomorphism e T
+  let VFin : J → Matrix (Fin (Fintype.card n)) (Fin (Fintype.card n)) ℂ :=
+    fun j => Matrix.reindex e e (V j)
+  have hTFin : IsPositiveMap TFin :=
+    Matrix.IsPositiveMap.reindexEndomorphism hT e
+  have hTNIFin : IsTraceNonincreasingMap TFin := hTNI.reindexEndomorphism e
+  have hreindex_symm (A : Matrix n n ℂ) :
+      Matrix.reindex e.symm e.symm (Matrix.reindex e e A) = A := by
+    simpa only [Matrix.coe_reindexLinearEquiv,
+      Matrix.symm_reindexLinearEquiv] using
+      (Matrix.reindexLinearEquiv ℂ ℂ e e).symm_apply_apply A
+  have hFixedFin (j : J) : TFin (VFin j) = VFin j := by
+    change Matrix.reindex e e
+        (T (Matrix.reindex e.symm e.symm (Matrix.reindex e e (V j)))) =
+      Matrix.reindex e e (V j)
+    rw [hreindex_symm, hFixed]
+  have hreindexProd (l : List J) :
+      Matrix.reindex e e (l.map V).prod = (l.map VFin).prod := by
+    induction l with
+    | nil =>
+        ext i j
+        simp [Matrix.reindex_apply, Matrix.one_apply]
+    | cons a l ih =>
+        simp only [List.map_cons, List.prod_cons]
+        calc
+          Matrix.reindex e e (V a * (l.map V).prod) =
+              Matrix.reindex e e (V a) * Matrix.reindex e e (l.map V).prod :=
+            (Matrix.reindexLinearEquiv_mul ℂ ℂ e e e _ _).symm
+          _ = VFin a * (l.map VFin).prod := by rw [ih]
+  let productSpanFin := Submodule.span ℂ
+    (Set.range fun x : Fin L → J => (List.ofFn fun t => VFin (x t)).prod)
+  have hOneFin :
+      (1 : Matrix (Fin (Fintype.card n)) (Fin (Fintype.card n)) ℂ) ∈
+        productSpanFin := by
+    have hReindexOne : Matrix.reindex e e (1 : Matrix n n ℂ) = 1 := by
+      simpa only [List.map_nil, List.prod_nil] using hreindexProd ([] : List J)
+    rw [← hReindexOne]
+    exact Submodule.span_induction (p := fun X _ =>
+        Matrix.reindex e e X ∈ productSpanFin)
+      (fun X hX => by
+        obtain ⟨x, rfl⟩ := hX
+        apply Submodule.subset_span
+        refine ⟨x, ?_⟩
+        have hprod := hreindexProd (List.ofFn x)
+        rw [List.map_ofFn, List.map_ofFn] at hprod
+        have hfun : V ∘ x = fun t => V (x t) := rfl
+        have hfunFin : VFin ∘ x = fun t => VFin (x t) := rfl
+        simpa only [hfun, hfunFin] using hprod.symm)
+      (by
+        change Φ 0 ∈ productSpanFin
+        rw [map_zero]
+        exact Submodule.zero_mem productSpanFin)
+      (fun X Y _ _ hX hY => by
+        change Φ (X + Y) ∈ productSpanFin
+        rw [map_add]
+        exact Submodule.add_mem productSpanFin hX hY)
+      (fun c X _ hX => by
+        change Φ (c • X) ∈ productSpanFin
+        rw [_root_.map_smul]
+        exact Submodule.smul_mem productSpanFin c hX)
+      hOne
+  have hTPFin : IsTracePreservingMap TFin :=
+    hTFin.tracePreserving_of_traceNonincreasing_of_fixed_product_span_fin
+      hTNIFin VFin L hL hFixedFin hOneFin
+  intro A
+  have h := hTPFin (Matrix.reindex e e A)
+  change Matrix.trace
+      (Matrix.reindex e e
+        (T (Matrix.reindex e.symm e.symm (Matrix.reindex e e A)))) =
+      Matrix.trace (Matrix.reindex e e A) at h
+  rw [hreindex_symm] at h
+  simpa only [Matrix.trace_reindex] using h

--- a/TNLean/Channel/FixedPoint/TraceNonincreasingProductSpan.lean
+++ b/TNLean/Channel/FixedPoint/TraceNonincreasingProductSpan.lean
@@ -3,7 +3,6 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.Algebra.TraceReindex
 import TNLean.Channel.FixedPoint.MaximalSupportBasic
 import TNLean.Channel.FixedPoint.MeanErgodicAdjoint
 import TNLean.Channel.FixedPoint.DirectSumBlockRetraction
@@ -39,21 +38,6 @@ open Filter Function Set
 open scoped Matrix ComplexOrder MatrixOrder Matrix.Norms.Frobenius Topology
 
 variable {D : ℕ}
-
-/-- Trace nonincrease is invariant under a simultaneous change of matrix
-coordinates. -/
-theorem IsTraceNonincreasingMap.reindexEndomorphism
-    {α β : Type*} [Fintype α] [Fintype β]
-    {T : Matrix α α ℂ →ₗ[ℂ] Matrix α α ℂ}
-    (hT : IsTraceNonincreasingMap T) (e : α ≃ β) :
-    IsTraceNonincreasingMap (Matrix.reindexEndomorphism e T) := by
-  classical
-  intro A hA
-  rw [Matrix.reindexEndomorphism_apply, Matrix.trace_reindex]
-  have htrace : Matrix.trace (A.submatrix e e) = Matrix.trace A := by
-    simpa only [Matrix.reindex_apply, Equiv.symm_symm] using
-      Matrix.trace_reindex e.symm A
-  exact (hT _ (hA.submatrix e)).trans_eq htrace
 
 open Kraus
 
@@ -200,7 +184,8 @@ theorem IsPositiveMap.tracePreserving_of_traceNonincreasing_of_fixed_product_spa
     fun j => Matrix.reindex e e (V j)
   have hTFin : IsPositiveMap TFin :=
     Matrix.IsPositiveMap.reindexEndomorphism hT e
-  have hTNIFin : IsTraceNonincreasingMap TFin := hTNI.reindexEndomorphism e
+  have hTNIFin : IsTraceNonincreasingMap TFin :=
+    Matrix.IsTraceNonincreasingMap.reindexEndomorphism hTNI e
   have hreindex_symm (A : Matrix n n ℂ) :
       Matrix.reindex e.symm e.symm (Matrix.reindex e e A) = A := by
     simpa only [Matrix.coe_reindexLinearEquiv,

--- a/TNLean/MPS/Core/MultiBlock.lean
+++ b/TNLean/MPS/Core/MultiBlock.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.TraceReindex
 import TNLean.MPS.Defs
 
 import Mathlib.Algebra.BigOperators.Fin
@@ -73,18 +74,6 @@ def evalWord {d : ℕ} {n : Type*} [Fintype n] [DecidableEq n]
     (A : Fin d → Matrix n n ℂ) : List (Fin d) → Matrix n n ℂ
   | [] => 1
   | i :: w => A i * evalWord A w
-
-namespace Matrix
-
-/-- Trace is invariant under reindexing of the basis. -/
-lemma trace_reindex {m n : Type*} [Fintype m] [Fintype n]
-    (e : m ≃ n) (M : Matrix m m ℂ) :
-    Matrix.trace ((Matrix.reindex e e) M) = Matrix.trace M := by
-  classical
-  simpa [trace, reindex_apply] using
-    Fintype.sum_equiv e.symm _ _ (by intro; simp)
-
-end Matrix
 
 section BlockDiagonal
 

--- a/TNLean/MPS/MPDO/VerticalSectorTracePreservation.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorTracePreservation.lean
@@ -171,16 +171,16 @@ theorem transportedVerticalSector_composites_tracePreserving
     transportedVerticalSectorS_trace_le
       dim₁ mult₁ dim₂ mult₂ weight₂ hMult₂ hWeight₂
       U₁ hU₁ U₂ hU₂ S hSCPTP X hX
-  have hTbarTNI : Matrix.IsDirectSumTraceNonincreasing Tbar := by
+  have hTbarTNI : Matrix.IsTraceNonincreasingBetweenDirectSums Tbar := by
     intro X hX
     exact hTbarle X hX
-  have hSbarTNI : Matrix.IsDirectSumTraceNonincreasing Sbar := by
+  have hSbarTNI : Matrix.IsTraceNonincreasingBetweenDirectSums Sbar := by
     intro X hX
     exact hSbarle X hX
-  have hF₁TNI : Matrix.IsDirectSumTraceNonincreasing F₁ := by
+  have hF₁TNI : Matrix.IsTraceNonincreasingBetweenDirectSums F₁ := by
     intro X hX
     exact (hSbarle (Tbar X) (hTbarpos X hX)).trans (hTbarle X hX)
-  have hF₂TNI : Matrix.IsDirectSumTraceNonincreasing F₂ := by
+  have hF₂TNI : Matrix.IsTraceNonincreasingBetweenDirectSums F₂ := by
     intro X hX
     exact (hTbarle (Sbar X) (hSbarpos X hX)).trans (hSbarle X hX)
   obtain ⟨L₁, hL₁, hSpan₁⟩ :=

--- a/TNLean/MPS/MPDO/VerticalSectorTracePreservation.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorTracePreservation.lean
@@ -233,10 +233,14 @@ theorem transportedVerticalSector_composites_tracePreserving
       hF₂TNI V₂ L₂ hL₂ hV₂fixed hOne₂
   have hTbarTrace : Matrix.IsTracePreservingBetweenDirectSums Tbar :=
     Matrix.isTracePreservingBetweenDirectSums_of_comp_of_traceNonincreasing
-      hTbarpos hTbarTNI hSbarTNI hF₁trace
+      hTbarpos hTbarTNI hSbarTNI
+        (Matrix.isTracePreservingBetweenDirectSums_iff_isTracePreservingDirectSumMap.mpr
+          hF₁trace)
   have hSbarTrace : Matrix.IsTracePreservingBetweenDirectSums Sbar :=
     Matrix.isTracePreservingBetweenDirectSums_of_comp_of_traceNonincreasing
-      hSbarpos hSbarTNI hTbarTNI hF₂trace
+      hSbarpos hSbarTNI hTbarTNI
+        (Matrix.isTracePreservingBetweenDirectSums_iff_isTracePreservingDirectSumMap.mpr
+          hF₂trace)
   exact ⟨hF₁trace, hF₂trace, hTbarTrace, hSbarTrace⟩
 
 end MPOTensor

--- a/TNLean/MPS/MPDO/VerticalSectorTracePreservation.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorTracePreservation.lean
@@ -1,0 +1,242 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.FixedPoint.TraceNonincreasingDirectSum
+import TNLean.MPS.MPDO.VerticalSectorFixedGenerators
+import TNLean.MPS.MPDO.VerticalSectorGeneration
+import TNLean.MPS.MPDO.VerticalSectorTraceLoss
+
+/-!
+# Trace preservation of the transported vertical-sector maps
+
+The two square composites of the transported vertical-sector maps preserve
+the total sector trace.  Consequently, the trace-nonincreasing inequalities
+for the two individual maps become equalities.  Positivity and trace
+nonincrease give bounded
+orbits.  The mean-ergodic image of the identity has maximal support among
+fixed points, while the fixed vertical bond contractions have
+positive-length products spanning the sector algebra.  Their common support
+must therefore be the identity, and the trace-loss functional vanishes.
+
+No product of fixed contractions is assumed to be fixed, and neither
+multiplicativity nor invertibility enters the argument.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608, Appendix C.4,
+  lines 1974--1980 and 1980--1995.
+* M. Wolf, *Quantum Channels & Operations: Guided Tour*, Propositions 6.3
+  and 6.9.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+noncomputable section
+
+namespace MPOTensor
+
+/-- The BNT product-span formulation agrees with the pointwise product family
+used by the direct-sum trace criterion. -/
+private theorem one_mem_product_span_of_weightedVerticalBondContractions
+    {g D L : ℕ} {dim : Fin g → ℕ}
+    (m : Fin g → ℂ)
+    (A : (α : Fin g) → MPSTensor (D * D) (dim α))
+    (hSpan : WeightedVerticalBondContractionProductSpanTop m A L) :
+    (1 : VerticalSectorAlgebra dim) ∈
+      Submodule.span ℂ (Set.range fun x : Fin L → Matrix (Fin D) (Fin D) ℂ ↦
+        (List.ofFn fun t ↦ weightedVerticalBondContraction m A (x t)).prod) := by
+  have hOneRaw : (1 : VerticalSectorAlgebra dim) ∈
+      Submodule.span ℂ (Set.range
+        (weightedVerticalBondContractionProduct (L := L) m A)) := by
+    rw [hSpan]
+    exact Submodule.mem_top
+  have hRange : Set.range (weightedVerticalBondContractionProduct
+      (L := L) m A) =
+      Set.range (fun x : Fin L → Matrix (Fin D) (Fin D) ℂ ↦
+        (List.ofFn fun t ↦ weightedVerticalBondContraction m A (x t)).prod) := by
+    ext Y
+    constructor
+    · rintro ⟨x, rfl⟩
+      refine ⟨x, ?_⟩
+      funext α
+      change ((List.ofFn fun t ↦
+          weightedVerticalBondContraction m A (x t)).prod) α =
+        (List.ofFn fun t ↦ weightedVerticalBondContraction m A (x t) α).prod
+      rw [Pi.list_prod_apply, List.map_ofFn]
+      rfl
+    · rintro ⟨x, rfl⟩
+      refine ⟨x, ?_⟩
+      funext α
+      change (List.ofFn fun t ↦
+          weightedVerticalBondContraction m A (x t) α).prod =
+        ((List.ofFn fun t ↦ weightedVerticalBondContraction m A (x t)).prod) α
+      rw [Pi.list_prod_apply, List.map_ofFn]
+      rfl
+  rw [← hRange]
+  exact hOneRaw
+
+/-- The transported coarse-graining and refinement maps, as well as their two
+square composites, preserve the appropriate total sector traces.
+
+The proof uses the source hypotheses from arXiv:1606.00608, Appendix C.4.
+Lines 1974--1980 supply the fixed vertical contractions; lines 1980--1995
+supply the BNT spanning context.  The product span is used only to force full
+support of a positive mean-ergodic fixed point; it is not used to claim that
+products of fixed points are fixed. -/
+theorem transportedVerticalSector_composites_tracePreserving
+    {g₁ g₂ d D : ℕ}
+    (dim₁ mult₁ : Fin g₁ → ℕ)
+    (weight₁ : (α : Fin g₁) → Fin (mult₁ α) → ℂ)
+    (dim₂ mult₂ : Fin g₂ → ℕ)
+    (weight₂ : (β : Fin g₂) → Fin (mult₂ β) → ℂ)
+    (hMult₁ : ∀ α, 0 < mult₁ α)
+    (hWeight₁ : ∀ α q, (0 : ℂ) < weight₁ α q)
+    (hMult₂ : ∀ β, 0 < mult₂ β)
+    (hWeight₂ : ∀ β q, (0 : ℂ) < weight₂ β q)
+    (M : MPOTensor d D)
+    (A₁ : (α : Fin g₁) → MPSTensor (D * D) (dim₁ α))
+    (A₂ : (β : Fin g₂) → MPSTensor (D * D) (dim₂ β))
+    (hBNT₁ : MPSTensor.IsCPSVBasisOfNormalTensors (verticalTensor M)
+      (fun α ↦ ⟨dim₁ α, A₁ α⟩))
+    (hBNT₂ : MPSTensor.IsCPSVBasisOfNormalTensors (verticalTensor (blockTwo M))
+      (fun β ↦ ⟨dim₂ β, A₂ β⟩))
+    (U₁ : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g₁, mult₁ α), verticalCopyDim dim₁ mult₁ q))
+      (Fin d) ℂ)
+    (U₂ : Matrix
+      (Fin (∑ q : Fin (∑ β : Fin g₂, mult₂ β), verticalCopyDim dim₂ mult₂ q))
+      (Fin (d * d)) ℂ)
+    (hU₁ : U₁ * U₁ᴴ = 1)
+    (hU₂ : U₂ * U₂ᴴ = 1)
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
+    (S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d) (Fin d) ℂ)
+    (hTCPTP : IsKrausCPTP T)
+    (hSCPTP : IsKrausCPTP S)
+    (hForward₁ : ∀ ab, U₁ * verticalTensor M ab * U₁ᴴ =
+      verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab)
+    (hReconstruct₁ : ∀ ab, verticalTensor M ab =
+      U₁ᴴ * verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab * U₁)
+    (hForward₂ : ∀ ab, U₂ * verticalTensor (blockTwo M) ab * U₂ᴴ =
+      verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab)
+    (hReconstruct₂ : ∀ ab, verticalTensor (blockTwo M) ab =
+      U₂ᴴ * verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab * U₂)
+    (hTphys : ∀ X, T (physClose1 M X) = physClose2 M X)
+    (hSphys : ∀ X, S (physClose2 M X) = physClose1 M X) :
+    Matrix.IsTracePreservingDirectSumMap
+        ((transportedVerticalSectorS dim₁ mult₁ dim₂ mult₂ weight₂ U₁ U₂ S).comp
+          (transportedVerticalSectorT dim₁ mult₁ weight₁ dim₂ mult₂ U₁ U₂ T)) ∧
+      Matrix.IsTracePreservingDirectSumMap
+        ((transportedVerticalSectorT dim₁ mult₁ weight₁ dim₂ mult₂ U₁ U₂ T).comp
+          (transportedVerticalSectorS dim₁ mult₁ dim₂ mult₂ weight₂ U₁ U₂ S)) ∧
+      Matrix.IsTracePreservingBetweenDirectSums
+        (transportedVerticalSectorT dim₁ mult₁ weight₁ dim₂ mult₂ U₁ U₂ T) ∧
+      Matrix.IsTracePreservingBetweenDirectSums
+        (transportedVerticalSectorS dim₁ mult₁ dim₂ mult₂ weight₂ U₁ U₂ S) := by
+  classical
+  let Tbar := transportedVerticalSectorT
+    dim₁ mult₁ weight₁ dim₂ mult₂ U₁ U₂ T
+  let Sbar := transportedVerticalSectorS
+    dim₁ mult₁ dim₂ mult₂ weight₂ U₁ U₂ S
+  let F₁ := Sbar.comp Tbar
+  let F₂ := Tbar.comp Sbar
+  have hTbarpos (X : VerticalSectorAlgebra dim₁)
+      (hX : IsVerticalSectorPosSemidef X) :
+      IsVerticalSectorPosSemidef (Tbar X) := by
+    exact transportedVerticalSectorT_posSemidef
+      dim₁ mult₁ weight₁ dim₂ mult₂ hMult₁ hWeight₁ U₁ U₂ T hTCPTP X hX
+  have hSbarpos (X : VerticalSectorAlgebra dim₂)
+      (hX : IsVerticalSectorPosSemidef X) :
+      IsVerticalSectorPosSemidef (Sbar X) := by
+    exact transportedVerticalSectorS_posSemidef
+      dim₁ mult₁ dim₂ mult₂ weight₂ hMult₂ hWeight₂ U₁ U₂ S hSCPTP X hX
+  have hF₁pos : Matrix.IsPositiveDirectSumMap F₁ := by
+    intro X hX
+    exact hSbarpos (Tbar X) (hTbarpos X hX)
+  have hF₂pos : Matrix.IsPositiveDirectSumMap F₂ := by
+    intro X hX
+    exact hTbarpos (Sbar X) (hSbarpos X hX)
+  have hTbarle (X : VerticalSectorAlgebra dim₁)
+      (hX : IsVerticalSectorPosSemidef X) :
+      verticalSectorTrace (Tbar X) ≤ verticalSectorTrace X :=
+    transportedVerticalSectorT_trace_le
+      dim₁ mult₁ weight₁ dim₂ mult₂ hMult₁ hWeight₁
+      U₁ hU₁ U₂ hU₂ T hTCPTP X hX
+  have hSbarle (X : VerticalSectorAlgebra dim₂)
+      (hX : IsVerticalSectorPosSemidef X) :
+      verticalSectorTrace (Sbar X) ≤ verticalSectorTrace X :=
+    transportedVerticalSectorS_trace_le
+      dim₁ mult₁ dim₂ mult₂ weight₂ hMult₂ hWeight₂
+      U₁ hU₁ U₂ hU₂ S hSCPTP X hX
+  have hTbarTNI : Matrix.IsDirectSumTraceNonincreasing Tbar := by
+    intro X hX
+    exact hTbarle X hX
+  have hSbarTNI : Matrix.IsDirectSumTraceNonincreasing Sbar := by
+    intro X hX
+    exact hSbarle X hX
+  have hF₁TNI : Matrix.IsDirectSumTraceNonincreasing F₁ := by
+    intro X hX
+    exact (hSbarle (Tbar X) (hTbarpos X hX)).trans (hTbarle X hX)
+  have hF₂TNI : Matrix.IsDirectSumTraceNonincreasing F₂ := by
+    intro X hX
+    exact (hTbarle (Sbar X) (hSbarpos X hX)).trans (hSbarle X hX)
+  obtain ⟨L₁, hL₁, hSpan₁⟩ :=
+    exists_positive_verticalMultiplicityTraceBondContractionProductSpanTop_of_bnt
+      hBNT₁ weight₁ hMult₁ hWeight₁
+  obtain ⟨L₂, hL₂, hSpan₂⟩ :=
+    exists_positive_verticalMultiplicityTraceBondContractionProductSpanTop_of_bnt
+      hBNT₂ weight₂ hMult₂ hWeight₂
+  let V₁ := weightedVerticalBondContraction
+    (verticalMultiplicityTrace weight₁) A₁
+  let V₂ := weightedVerticalBondContraction
+    (verticalMultiplicityTrace weight₂) A₂
+  have hV₁fixed (X : Matrix (Fin D) (Fin D) ℂ) : F₁ (V₁ X) = V₁ X := by
+    change F₁ (fun α ↦ verticalMultiplicityTrace weight₁ α •
+      MPSTensor.contractBondMatrix (A₁ α) X) =
+        fun α ↦ verticalMultiplicityTrace weight₁ α •
+          MPSTensor.contractBondMatrix (A₁ α) X
+    simpa only [F₁, Tbar, Sbar] using
+      transportedVerticalSectorS_comp_T_fixed_contractBondMatrix_trace_smul
+        dim₁ mult₁ weight₁ dim₂ mult₂ weight₂ hMult₁ hWeight₁ hMult₂ hWeight₂
+        M A₁ A₂ U₁ U₂ T S hForward₁ hReconstruct₁ hForward₂ hReconstruct₂ X
+        (hTphys X) (hSphys X)
+  have hV₂fixed (X : Matrix (Fin D) (Fin D) ℂ) : F₂ (V₂ X) = V₂ X := by
+    change F₂ (fun β ↦ verticalMultiplicityTrace weight₂ β •
+      MPSTensor.contractBondMatrix (A₂ β) X) =
+        fun β ↦ verticalMultiplicityTrace weight₂ β •
+          MPSTensor.contractBondMatrix (A₂ β) X
+    simpa only [F₂, Tbar, Sbar] using
+      transportedVerticalSectorT_comp_S_fixed_contractBondMatrix_trace_smul
+        dim₁ mult₁ weight₁ dim₂ mult₂ weight₂ hMult₁ hWeight₁ hMult₂ hWeight₂
+        M A₁ A₂ U₁ U₂ T S hForward₁ hReconstruct₁ hForward₂ hReconstruct₂ X
+        (hTphys X) (hSphys X)
+  have hOne₁ : (1 : VerticalSectorAlgebra dim₁) ∈
+      Submodule.span ℂ (Set.range fun x : Fin L₁ → Matrix (Fin D) (Fin D) ℂ ↦
+        (List.ofFn fun t ↦ V₁ (x t)).prod) := by
+    simpa only [V₁] using
+      one_mem_product_span_of_weightedVerticalBondContractions
+        (verticalMultiplicityTrace weight₁) A₁ hSpan₁
+  have hOne₂ : (1 : VerticalSectorAlgebra dim₂) ∈
+      Submodule.span ℂ (Set.range fun x : Fin L₂ → Matrix (Fin D) (Fin D) ℂ ↦
+        (List.ofFn fun t ↦ V₂ (x t)).prod) := by
+    simpa only [V₂] using
+      one_mem_product_span_of_weightedVerticalBondContractions
+        (verticalMultiplicityTrace weight₂) A₂ hSpan₂
+  have hF₁trace :=
+    hF₁pos.tracePreserving_of_traceNonincreasing_of_fixed_product_span
+      hF₁TNI V₁ L₁ hL₁ hV₁fixed hOne₁
+  have hF₂trace :=
+    hF₂pos.tracePreserving_of_traceNonincreasing_of_fixed_product_span
+      hF₂TNI V₂ L₂ hL₂ hV₂fixed hOne₂
+  have hTbarTrace : Matrix.IsTracePreservingBetweenDirectSums Tbar :=
+    Matrix.isTracePreservingBetweenDirectSums_of_comp_of_traceNonincreasing
+      hTbarpos hTbarTNI hSbarTNI hF₁trace
+  have hSbarTrace : Matrix.IsTracePreservingBetweenDirectSums Sbar :=
+    Matrix.isTracePreservingBetweenDirectSums_of_comp_of_traceNonincreasing
+      hSbarpos hSbarTNI hTbarTNI hF₂trace
+  exact ⟨hF₁trace, hF₂trace, hTbarTrace, hSbarTrace⟩
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -1554,7 +1554,8 @@ physical indices, as in
       MPOTensor.transportedVerticalSector_composites_tracePreserving}
     \leanok
     \uses{lem:mpdo_transported_vertical_sector_fixed_generators,
-      thm:mpdo_vertical_bond_contractions_generate_sector_algebra}
+      thm:mpdo_vertical_bond_contractions_generate_sector_algebra,
+      thm:mpdo_transported_vertical_sector_trace_loss}
     Suppose that every one-site and two-site multiplicity space is nonzero
     and every corresponding diagonal weight is positive.  Let
     $\widetilde M^{(1)}$ and $\widetilde M^{(2)}$ be the vertical tensors of

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -1543,6 +1543,124 @@ physical indices, as in
     \]
 \end{proof}
 
+\begin{theorem}[Trace preservation of the transported vertical-sector maps]
+    \label{thm:mpdo_transported_vertical_sector_composites_trace_preserving}
+    \lean{IsPositiveMap.hasBoundedOrbits_of_traceNonincreasing,
+      IsPositiveMap.exists_maximalSupport_fixedPoint_of_hasBoundedOrbits,
+      IsPositiveMap.tracePreserving_of_traceNonincreasing_of_fixed_product_span,
+      Matrix.IsPositiveDirectSumMap.%
+        tracePreserving_of_traceNonincreasing_of_fixed_product_span,
+      Matrix.isTracePreservingBetweenDirectSums_of_comp_of_traceNonincreasing,
+      MPOTensor.transportedVerticalSector_composites_tracePreserving}
+    \leanok
+    \uses{lem:mpdo_transported_vertical_sector_fixed_generators,
+      thm:mpdo_vertical_bond_contractions_generate_sector_algebra}
+    Suppose that every one-site and two-site multiplicity space is nonzero
+    and every corresponding diagonal weight is positive.  Let
+    $\widetilde M^{(1)}$ and $\widetilde M^{(2)}$ be the vertical tensors of
+    $M$ and its two-site blocking, and let $B_1$ and $B_2$ be their assembled
+    one-site and two-site canonical forms.  Assume that both canonical forms
+    are bases of normal tensors and that, for every vertical letter $\ell$,
+    \[
+      U_i\widetilde M^{(i)}_\ell U_i^\dagger=(B_i)_\ell,
+      \qquad
+      \widetilde M^{(i)}_\ell
+        =U_i^\dagger(B_i)_\ell U_i,
+      \qquad
+      U_iU_i^\dagger=\mathbf 1
+      \quad (i=1,2).
+    \]
+    Assume in addition that the physical maps $T$ and $S$ are completely
+    positive and trace preserving and that, for every horizontal bond matrix
+    $Z$, the two physical-coordinate identities hold:
+    \[
+      T(\mathcal M^{(1)}(Z))=\mathcal M^{(2)}(Z),
+      \qquad
+      S(\mathcal M^{(2)}(Z))=\mathcal M^{(1)}(Z).
+    \]
+    Then each transported map and both square composites preserve the
+    appropriate total sector trace.
+    For the individual maps,
+    \[
+      \sum_\beta\operatorname{tr}(\widetilde T(X)_\beta)
+        =\sum_\alpha\operatorname{tr}(X_\alpha),
+      \qquad
+      \sum_\alpha\operatorname{tr}(\widetilde S(Y)_\alpha)
+        =\sum_\beta\operatorname{tr}(Y_\beta).
+    \]
+    For the square composites,
+    \[
+      \sum_\alpha\operatorname{tr}
+        \bigl((\widetilde S\widetilde T)(X)_\alpha\bigr)
+        =\sum_\alpha\operatorname{tr}(X_\alpha),
+      \qquad
+      \sum_\beta\operatorname{tr}
+        \bigl((\widetilde T\widetilde S)(Y)_\beta\bigr)
+        =\sum_\beta\operatorname{tr}(Y_\beta).
+    \]
+    Neither of the stronger range inclusions
+    \[
+      T(R_1(\mathcal A_1))\subseteq R_2(\mathcal A_2),
+      \qquad
+      S(R_2(\mathcal A_2))\subseteq R_1(\mathcal A_1)
+    \]
+    is assumed.
+\end{theorem}
+
+\begin{proof}\leanok
+    Each transported map is positive and trace nonincreasing.  Hence the same
+    is true of either square composite $F$.  For $X\geq0$ and $n\geq0$,
+    \[
+      0\leq\operatorname{tr}(F^n(X))
+        \leq\operatorname{tr}(X).
+    \]
+    Thus positive orbits remain in a bounded trace section; decomposition
+    into Hermitian parts gives bounded orbits for every input.  Let $P$ be the
+    mean-ergodic projection of $F$, set $\rho=P(\mathbf 1)$, and let $Q$ be
+    the support projection of $\rho$.  Positivity of $P$ implies that every
+    fixed operator is supported on $Q$.
+
+    The preceding fixed-generator lemma places every weighted vertical bond
+    contraction $V_j$ in the fixed-point space.  The support absorption
+    identities give
+    \[
+      QV_jQ=V_j,
+      \qquad QV_j=V_j=V_jQ,
+    \]
+    and hence, for every positive-length product,
+    \[
+      Q(V_{j_1}\cdots V_{j_L})
+        =V_{j_1}\cdots V_{j_L}
+        =(V_{j_1}\cdots V_{j_L})Q.
+    \]
+    These products span the sector algebra, so their common support contains
+    the identity.  Therefore $Q=\mathbf 1$ and $\rho$ is positive definite.
+
+    Let $F^*$ be the trace adjoint and set
+    \[
+      \Delta=\mathbf 1-F^*(\mathbf 1).
+    \]
+    Trace nonincrease gives
+    $\operatorname{tr}(\Delta X)=\operatorname{tr}(X)-
+    \operatorname{tr}(F(X))\geq0$ for every positive $X$, and positivity of
+    $F$ implies that $\Delta$ is Hermitian.  Hence $\Delta\geq0$.  Since
+    $F(\rho)=\rho$, one has $\operatorname{tr}(\rho\Delta)=0$.
+    Positive definiteness of $\rho$ therefore forces $\Delta=0$, which is
+    equivalent to trace preservation.  This argument uses fixedness only of
+    the contraction factors, not of their products.
+
+    Finally, for positive $X$ the two trace-nonincreasing inequalities give
+    \[
+      \operatorname{tr}((\widetilde S\widetilde T)(X))
+        \leq\operatorname{tr}(\widetilde T(X))
+        \leq\operatorname{tr}(X).
+    \]
+    The equality of the endpoints forces trace preservation by
+    $\widetilde T$ on the positive cone and hence on the whole algebra.
+    Interchanging the two maps proves the corresponding assertion for
+    $\widetilde S$.
+\end{proof}
+
 \begin{theorem}[Two-site closure of the two-site blocking]
     \label{thm:mpdo_two_site_closure_two_site_blocking}
     \lean{MPOTensor.physClose2_blockTwo_eq_physClose4}

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -49,11 +49,12 @@ For MPDO renormalization fixed points:
   density-weighted fixed-point argument in Appendix C.4. Wolf's full
   fixed-point theorem, including maximal-support reduction and the
   complementary zero summand, and its full-support direct-sum consequence are
-  now formalized. For the transported sector maps it remains to prove the
-  channel hypotheses on the full sector algebras. The note also records that
-  sector relabelling
-  follows from mutually inverse positive trace-preserving maps, not from a
-  bare linear equivalence.
+  now formalized.  The two transported square composites are proved trace
+  preserving on the full sector algebras by a maximal-support argument, and a
+  trace sandwich gives the same conclusion for each transported map; the
+  complete-positivity and adjoint Schwarz hypotheses remain.  The note also
+  records that sector relabelling follows from mutually inverse positive
+  trace-preserving maps, not from a bare linear equivalence.
 - `cpsv16_simple_tensor_nilpotency.tex` identifies the source's nilpotent BNT
   elements with nilpotent physical-trace transfer matrices and records the
   positive physical blocking and chosen-BNT interpretation of the

--- a/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
+++ b/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
@@ -136,16 +136,71 @@ the Schwarz inequality pass to this extension, its trace adjoint is the
 extension of the direct-sum trace adjoint, and its fixed points are exactly the
 block-diagonal images of the direct-sum fixed points.  Reindexing the extension
 by a finite equivalence and applying the full-support theorem now gives the
-density-block form of the fixed families on the original direct sum.  What
-remains is to verify the required channel hypotheses for the transported
-sector maps on the whole direct sums and to supply a blockwise
-positive-definite fixed family.  Alternatively, the maximal-support witness
+density-block form of the fixed families on the original direct sum.  The
+trace-preservation part of the required channel hypotheses for the two square
+composites is resolved below.  Complete positivity and the adjoint Schwarz
+inequality still have to be transferred to the full direct sums.
+Alternatively, the maximal-support witness
 $T_\infty(\mathbf 1)$ is now available for an arbitrary positive
 trace-preserving map.  The construction of the supported endomorphism and its
 complementary zero summand is now completed in the full-matrix theorem recorded
 in \path{docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex}; it
 removes the need to assume a positive-definite fixed point before applying the
 full-matrix classification.
+
+\section{Resolution of the composite trace hypothesis}
+
+The range inclusions
+\[
+  T(R_1(\mathcal A_1))\subseteq R_2(\mathcal A_2),
+  \qquad
+  S(R_2(\mathcal A_2))\subseteq R_1(\mathcal A_1)
+\]
+are not consequences presently extracted from lines 1974--1980.  They are
+not needed for trace preservation: first the two square composites preserve
+trace on their full algebras, and then a trace sandwich gives the same
+conclusion for each individual transported map.
+
+Let $F$ be either square composite.  It is positive and trace nonincreasing.
+Consequently all forward orbits are bounded: a positive orbit stays positive
+with decreasing trace, and Hermitian decomposition gives the general case.
+The mean-ergodic image $\rho=P(\mathbf 1)$ is then a positive fixed point whose
+support contains every fixed point of $F$.  In particular it contains every
+distinguished vertical bond contraction.  Since positive-length products of
+these contractions span the whole sector algebra, their common support must
+contain the identity.  Hence $\rho$ is positive definite.
+
+Let $F^*$ be the trace adjoint and define the trace-loss operator
+\[
+  \Delta=\mathbf 1-F^*(\mathbf 1).
+\]
+Trace nonincrease gives
+$\operatorname{tr}(\Delta X)=\operatorname{tr}(X)-
+\operatorname{tr}(F(X))\geq0$ for every positive $X$, and positivity of $F$
+makes $\Delta$ Hermitian.  Thus $\Delta\geq0$.  Since $\rho$ is fixed,
+$\operatorname{tr}(\rho\Delta)=0$; positive definiteness of $\rho$ forces
+$\Delta=0$, which is equivalent to trace preservation on the full algebra.
+
+Now let $X\geq0$ belong to the one-site sector algebra.  Positivity and trace
+nonincrease give
+\[
+  \operatorname{tr}((\widetilde S\widetilde T)(X))
+    \leq \operatorname{tr}(\widetilde T(X))
+    \leq \operatorname{tr}(X).
+\]
+The first and last terms are equal by the composite result, hence both
+inequalities are equalities.  Thus $\widetilde T$ preserves trace on the
+positive cone, and therefore on the full algebra by linearity.  The other
+square composite gives the same conclusion for $\widetilde S$.
+
+This argument is formalized first for full matrix algebras, then for finite
+direct sums by block-diagonal extension, and finally for the two transported
+vertical-sector composites.  It assumes neither multiplicativity nor
+fixedness of products.  The only product statement used is the
+basis-of-normal-tensors conclusion that products of the fixed contraction
+\emph{factors} span the ambient sector algebra.  Thus the trace-preservation
+subproblem is closed for the individual maps and their square composites even
+though the active-image inclusions remain unproved.
 
 \section{Sector relabelling uses positivity, not linear isomorphism}
 
@@ -185,9 +240,10 @@ one of the following source-faithful routes:
 The unrestricted CPSV16 conclusion should be completed in the following
 order:
 \begin{enumerate}
-    \item prove complete positivity and trace preservation of the transported
-          maps on the full sector algebras, including the required active-image
-          statement for every input;
+    \item prove complete positivity and the adjoint Schwarz inequality for the
+          two transported square composites on the full sector algebras;
+          trace preservation of the individual maps and composites is now
+          established without an all-input active-image statement;
     \item complete the density-weighted fixed-point theorem and transfer it to
           the sector direct sums, either through a block-diagonal full-matrix
           extension or through a direct-sum theorem, to prove
@@ -204,9 +260,12 @@ order:
 
 \section{Classification}
 
-\textbf{Verdict: open gap.}  Until these steps are proved, neither
-transported-map invertibility nor sector relabelling should carry a completion
-marker in the blueprint.
+\textbf{Verdict: trace subproblem closed; invertibility gap open.}  The two
+transported maps and their square composites are trace preserving under the
+source tensor hypotheses.  The stronger active-image inclusions remain
+unproved.  Until the remaining channel-structure and fixed-point steps are
+proved, neither transported-map invertibility nor sector relabelling should
+carry a completion marker in the blueprint.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -51,6 +51,23 @@ abstracted — record why, so it is not re-proposed).
 Seeded from `scripts/tactic_pattern_scan.py` (2026-07-18 scan; re-run for
 current counts and full location lists).
 
+### product_span_transport — candidate
+- **Pattern:** transport membership in the span of fixed-length products through
+  a linear map that preserves the identity and the relevant products, using
+  `Submodule.span_induction` with separate generator, zero, addition, and scalar
+  cases.
+- **Seen:** 2 occurrences, at
+  `TNLean/Channel/FixedPoint/TraceNonincreasingProductSpan.lean:234` and
+  `TNLean/Channel/FixedPoint/TraceNonincreasingDirectSum.lean:221`
+  (2026-07-19). This is below the rule-of-three promotion threshold.
+- **Abstraction (proposed):** a lemma transporting a product-span membership
+  statement through a linear map, parameterized by the product-compatibility
+  equation. Scout Mathlib's `Submodule.map_span` and `Submodule.map_mono` API
+  before introducing a project lemma.
+- **Notes:** The two current instances use matrix reindexing and block-diagonal
+  embedding. Record before a third coordinate-transport proof appears; confirm
+  that their product-family goal shapes agree before promotion.
+
 ### matrix_entry_cases — candidate
 - **Pattern:**
   ```

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -56,9 +56,10 @@ current counts and full location lists).
   a linear map that preserves the identity and the relevant products, using
   `Submodule.span_induction` with separate generator, zero, addition, and scalar
   cases.
-- **Seen:** 2 occurrences, at
-  `TNLean/Channel/FixedPoint/TraceNonincreasingProductSpan.lean:234` and
-  `TNLean/Channel/FixedPoint/TraceNonincreasingDirectSum.lean:221`
+- **Seen:** 2 occurrences: the reindexing step in
+  `IsPositiveMap.tracePreserving_of_traceNonincreasing_of_fixed_product_span`
+  and the block-diagonal step in
+  `IsPositiveDirectSumMap.tracePreserving_of_traceNonincreasing_of_fixed_product_span`
   (2026-07-19). This is below the rule-of-three promotion threshold.
 - **Abstraction (proposed):** a lemma transporting a product-span membership
   statement through a linear map, parameterized by the product-compatibility


### PR DESCRIPTION
## Mathematical result

This proves trace preservation for each transported vertical-sector map and for both square composites on the full direct-sum sector algebras under the CPSV16 Appendix C.4 hypotheses:

- the rectangular map `T̃` from the one-site sectors to the two-site sectors;
- the rectangular map `S̃` from the two-site sectors to the one-site sectors;
- the one-site composite `S̃ ∘ T̃`;
- the two-site composite `T̃ ∘ S̃`.

The BNT hypotheses are attached to the actual tensors `verticalTensor M` and `verticalTensor (blockTwo M)`. The theorem also assumes the source-faithful physical-coordinate identities for `T` and `S` on every horizontal bond matrix.

## Argument

For a positive trace-nonincreasing endomorphism `F`, positive orbits remain in a bounded trace section. The positive mean-ergodic projection therefore gives a positive fixed point `ρ = P(1)` whose support contains every fixed operator. The distinguished vertical bond contractions are fixed, and their positive-length products span the sector algebra. Their common support consequently contains the identity, so `ρ` is positive definite.

The trace-adjoint defect `1 - F*(1)` is positive by trace nonincrease. Its pairing with the faithful fixed point `ρ` vanishes, hence faithfulness forces the defect to vanish and `F` preserves trace. This proves trace preservation of both square composites without assuming that products of fixed contractions are themselves fixed.

For positive `X`, the trace sandwich

`tr((S̃ ∘ T̃)(X)) ≤ tr(T̃(X)) ≤ tr(X)`

has equal endpoints because the composite preserves trace. Thus `T̃` preserves trace on the positive cone and therefore on the whole direct sum. Interchanging the two maps proves the corresponding statement for `S̃`.

The proof does not assume either all-input active-image inclusion.

## Structure

- places trace nonincrease and its trace-preserving specialization in the common channel infrastructure;
- derives bounded orbits and maximal-support fixed points under trace nonincrease;
- proves the fixed-product trace criterion on full matrix algebras;
- transfers the criterion to finite direct sums and adds the rectangular trace-sandwich lemma;
- applies these results to both transported maps and both square composites;
- updates the blueprint and paper-gap note so that only the trace subproblem is marked closed.

Complete positivity or adjoint Schwarz structure for the transported maps, the active-image inclusions, and the resulting invertibility statement remain open.

No `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast` is introduced.

## Verification

- focused build passed: 8980 jobs;
- complete root build passed: 9614 jobs;
- `TNLean.lean` passed and remains exactly 1000 lines;
- blueprint/Lean synchronization and reader-facing prose checks passed;
- `checkdecls` passed against the exact declaration list;
- `git diff --check` and the proof-integrity scan passed.

Closes #4370.
Advances #4120 and #232.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib formalization extending channel fixed-point theory and MPDO lemmas; no runtime, auth, or data-path changes. Residual risk is mathematical correctness of the new proofs, not production system impact.
> 
> **Overview**
> Formalizes **trace preservation** for the transported vertical-sector maps `T̃`, `S̃` and both square composites on full direct-sum sector algebras under CPSV16 Appendix C.4 hypotheses, without assuming all-input active-image inclusions.
> 
> **Infrastructure:** Adds `IsTraceNonincreasingMap` (trace-preserving maps specialize to it), generalizes bounded orbits and maximal-support fixed points from trace preservation to trace nonincrease, and proves that a positive trace-nonincreasing map with fixed generators whose positive-length products span the identity is trace preserving (full matrix algebras, then finite direct sums via block-diagonal extension). Shared `Matrix.trace_reindex` and `posDef_of_supportProj_eq_one` support the faithfulness step.
> 
> **Application:** `transportedVerticalSector_composites_tracePreserving` applies the product-span criterion to weighted vertical bond contractions fixed by the composites; a trace sandwich then yields trace preservation for `T̃` and `S̃` individually. Blueprint chapter 21 and the vertical-sector invertibility gap note mark the **trace subproblem closed**; CP/Schwarz transfer and invertibility remain open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fbf26f5ca7189f19bda352e523ad9efffaf3970. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->